### PR TITLE
Fix concurrency handling when data is fanned out

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,10 @@ e2e-test: otelcol
 test:
 	$(GOTEST) $(GOTEST_OPT) $(ALL_PKGS)
 
+.PHONY: benchmark
+benchmark:
+	$(GOTEST) -bench=. -run=notests $(ALL_PKGS)
+
 .PHONY: travis-ci
 travis-ci: fmt vet lint goimports misspell staticcheck test-with-cover otelcol
 	$(MAKE) -C testbed install-tools

--- a/processor/README.md
+++ b/processor/README.md
@@ -11,9 +11,33 @@ Supported processors (sorted alphabetically):
 - [Span Processor](#span)
 - [Tail Sampling Processor](#tail_sampling)
 
+## Data Ownership
+
+The ownership of the `TraceData` and `MetricsData` in a pipeline is passed as the data travels
+through the pipeline. The data is created by the receiver and then the ownership is passed
+to the first processor when `ConsumeTraceData`/`ConsumeMetricsData` function is called.
+Each processor then subsequently calls `ConsumeTraceData`/`ConsumeMetricsData`
+function of the next processor and that in turn passes data ownership.
+The last processor calls `ConsumeTraceData`/`ConsumeMetricsData` of the exporter
+which then assumes the ownership of the data.
+
+Ownership of the data allows the owning component to freely modify the data.
+Data ownership is always exclusive, data is never shared between pipelines.
+This is achieved by cloning the data when the data needs to be processed concurrently.
+Cloning is done by `traceFanOutConnector`/`metricsFanOutConnector` and happens in 2 cases:
+- At the receiving fan out connector when the same receiver is attached to more than
+  one pipeline,
+- At the exporting fan out connector when the pipeline has more than one
+  exporter attached.
+  
+The exclusive ownership of data allows processors and exporters to freely modify the
+data while they own it (e.g. see `attributesprocessor`). Once the ownership is passed
+the processor must no longer read or write the data since it may be concurrently
+modified by the new owner.
+
 ## Ordering Processors
-The order processors are specified in a pipeline is important as this is the
-order in which each processor is applied to traces.
+The order processors specified in a pipeline is important as this is the
+order in which each processor is applied to traces and metrics.
 
 ## <a name="attributes"></a>Attributes Processor
 The attributes processor modifies attributes of a span.

--- a/processor/fanoutconnector.go
+++ b/processor/fanoutconnector.go
@@ -17,6 +17,12 @@ package processor
 import (
 	"context"
 
+	commonpb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
+	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
+	resourcepb "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
+	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
+	"github.com/golang/protobuf/proto"
+
 	"github.com/open-telemetry/opentelemetry-collector/consumer"
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-collector/oterr"
@@ -37,11 +43,29 @@ var _ MetricsProcessor = (*metricsFanOutConnector)(nil)
 // ConsumeMetricsData exports the MetricsData to all consumers wrapped by the current one.
 func (mfc metricsFanOutConnector) ConsumeMetricsData(ctx context.Context, md consumerdata.MetricsData) error {
 	var errs []error
-	for _, mc := range mfc {
-		if err := mc.ConsumeMetricsData(ctx, md); err != nil {
+
+	// Fan out to first len-1 consumers.
+	for i := 0; i < len(mfc)-1; i++ {
+		// Create a clone of data. We need to clone because consumers may modify the data.
+		clone, err := cloneMetricsData(&md)
+		if err != nil {
+			errs = append(errs, err)
+			break
+		} else {
+			if err := mfc[i].ConsumeMetricsData(ctx, *clone); err != nil {
+				errs = append(errs, err)
+			}
+		}
+	}
+
+	if len(mfc) > 0 {
+		// Give the original data to the last consumer.
+		lastTc := mfc[len(mfc)-1]
+		if err := lastTc.ConsumeMetricsData(ctx, md); err != nil {
 			errs = append(errs, err)
 		}
 	}
+
 	return oterr.CombineErrors(errs)
 }
 
@@ -57,10 +81,142 @@ var _ TraceProcessor = (*traceFanOutConnector)(nil)
 // ConsumeTraceData exports the span data to all trace consumers wrapped by the current one.
 func (tfc traceFanOutConnector) ConsumeTraceData(ctx context.Context, td consumerdata.TraceData) error {
 	var errs []error
-	for _, tc := range tfc {
-		if err := tc.ConsumeTraceData(ctx, td); err != nil {
+
+	// Fan out to first len-1 consumers.
+	for i := 0; i < len(tfc)-1; i++ {
+		// Create a clone of data. We need to clone because consumers may modify the data.
+		clone, err := cloneTraceData(&td)
+		if err != nil {
+			errs = append(errs, err)
+			break
+		} else {
+			if err := tfc[i].ConsumeTraceData(ctx, *clone); err != nil {
+				errs = append(errs, err)
+			}
+		}
+	}
+
+	if len(tfc) > 0 {
+		// Give the original data to the last consumer.
+		lastTc := tfc[len(tfc)-1]
+		if err := lastTc.ConsumeTraceData(ctx, td); err != nil {
 			errs = append(errs, err)
 		}
 	}
+
 	return oterr.CombineErrors(errs)
+}
+
+func cloneTraceData(td *consumerdata.TraceData) (*consumerdata.TraceData, error) {
+	clone := &consumerdata.TraceData{
+		SourceFormat: td.SourceFormat,
+	}
+
+	if td.Node != nil {
+		clone.Node = &commonpb.Node{}
+
+		bytes, err := proto.Marshal(td.Node)
+		if err != nil {
+			return nil, err
+		}
+
+		err = proto.Unmarshal(bytes, clone.Node)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if td.Resource != nil {
+		clone.Resource = &resourcepb.Resource{}
+
+		bytes, err := proto.Marshal(td.Resource)
+		if err != nil {
+			return nil, err
+		}
+
+		err = proto.Unmarshal(bytes, clone.Resource)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if td.Spans != nil {
+		clone.Spans = make([]*tracepb.Span, 0, len(td.Spans))
+
+		for _, span := range td.Spans {
+			if span != nil {
+				bytes, err := proto.Marshal(span)
+				if err != nil {
+					return nil, err
+				}
+
+				var spanClone tracepb.Span
+				err = proto.Unmarshal(bytes, &spanClone)
+				if err != nil {
+					return nil, err
+				}
+				clone.Spans = append(clone.Spans, &spanClone)
+			} else {
+				clone.Spans = append(clone.Spans, nil)
+			}
+		}
+	}
+
+	return clone, nil
+}
+
+func cloneMetricsData(md *consumerdata.MetricsData) (*consumerdata.MetricsData, error) {
+	clone := &consumerdata.MetricsData{}
+
+	if md.Node != nil {
+		clone.Node = &commonpb.Node{}
+
+		bytes, err := proto.Marshal(md.Node)
+		if err != nil {
+			return nil, err
+		}
+
+		err = proto.Unmarshal(bytes, clone.Node)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if md.Resource != nil {
+		clone.Resource = &resourcepb.Resource{}
+
+		bytes, err := proto.Marshal(md.Resource)
+		if err != nil {
+			return nil, err
+		}
+
+		err = proto.Unmarshal(bytes, clone.Resource)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if md.Metrics != nil {
+		clone.Metrics = make([]*metricspb.Metric, 0, len(md.Metrics))
+
+		for _, span := range md.Metrics {
+			if span != nil {
+				bytes, err := proto.Marshal(span)
+				if err != nil {
+					return nil, err
+				}
+
+				var metricClone metricspb.Metric
+				err = proto.Unmarshal(bytes, &metricClone)
+				if err != nil {
+					return nil, err
+				}
+				clone.Metrics = append(clone.Metrics, &metricClone)
+			} else {
+				clone.Metrics = append(clone.Metrics, nil)
+			}
+		}
+	}
+
+	return clone, nil
 }

--- a/service/builder/pipelines_builder_test.go
+++ b/service/builder/pipelines_builder_test.go
@@ -18,14 +18,13 @@ import (
 	"context"
 	"testing"
 
-	"go.uber.org/zap"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
 	commonpb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
 	resourcepb "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
 	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
+	"github.com/golang/protobuf/proto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector/config"
 	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
@@ -59,34 +58,23 @@ func TestPipelinesBuilder_Build(t *testing.T) {
 }
 
 func assertEqualTraceData(t *testing.T, expected consumerdata.TraceData, actual consumerdata.TraceData) {
-	if expected.Resource != nil {
-		assert.EqualValues(t, expected.Resource.Type, actual.Resource.Type)
-	}
-
-	if expected.Node != nil {
-		assert.EqualValues(t, expected.Node.ServiceInfo.Name, actual.Node.ServiceInfo.Name)
-	}
+	assert.True(t, proto.Equal(expected.Resource, actual.Resource))
+	assert.True(t, proto.Equal(expected.Node, actual.Node))
 
 	for i := range expected.Spans {
-		assert.EqualValues(t, expected.Spans[i].Name.Value, actual.Spans[i].Name.Value)
+		assert.True(t, proto.Equal(expected.Spans[i], actual.Spans[i]))
 	}
 
 	assert.EqualValues(t, expected.SourceFormat, actual.SourceFormat)
 }
 
 func assertEqualMetricsData(t *testing.T, expected consumerdata.MetricsData, actual consumerdata.MetricsData) {
-	if expected.Resource != nil {
-		assert.EqualValues(t, expected.Resource.Type, actual.Resource.Type)
-	}
-
-	if expected.Node != nil {
-		assert.EqualValues(t, expected.Node.ServiceInfo.Name, actual.Node.ServiceInfo.Name)
-	}
+	assert.True(t, proto.Equal(expected.Resource, actual.Resource))
+	assert.True(t, proto.Equal(expected.Node, actual.Node))
 
 	for i := range expected.Metrics {
-		assert.EqualValues(t, expected.Metrics[i].MetricDescriptor.Name, actual.Metrics[i].MetricDescriptor.Name)
+		assert.True(t, proto.Equal(expected.Metrics[i], actual.Metrics[i]))
 	}
-
 }
 
 func testPipeline(t *testing.T, pipelineName string, exporterNames []string) {

--- a/service/builder/receivers_builder_test.go
+++ b/service/builder/receivers_builder_test.go
@@ -185,7 +185,7 @@ func testReceivers(
 			require.Equal(t, spanDuplicationCount, len(traceConsumer.Traces))
 
 			for i := 0; i < spanDuplicationCount; i++ {
-				assert.Equal(t, traceData, traceConsumer.Traces[i])
+				assertEqualTraceData(t, traceData, traceConsumer.Traces[i])
 
 				// Check that the span was processed by "attributes" processor and an
 				// attribute was added.
@@ -198,7 +198,7 @@ func testReceivers(
 		if test.hasMetrics {
 			metricsConsumer := exporter.me.(*config.ExampleExporterConsumer)
 			require.Equal(t, 1, len(metricsConsumer.Metrics))
-			assert.Equal(t, metricsData, metricsConsumer.Metrics[0])
+			assertEqualMetricsData(t, metricsData, metricsConsumer.Metrics[0])
 		}
 	}
 }


### PR DESCRIPTION
`traceFanOutConnector` and `metricsFanOutConnector` previously simply
passed `TraceData` or `MetricsData` to consumers.

This could cause problems when the data is fed into multiple pipelines
and is concurrently processed and modified by processors.

Fan out connectors now create clones of data before and the clone to
each consumer that is connected (except one - which can use the original).

This is used both for fanout connectors used when the same receiver
feeds data to multiple pipelines (which is somewhat rare use case)
and also when we have multiple exporters connected to the same pipeline
(exporters may modify data).

Fixes issue: https://github.com/open-telemetry/opentelemetry-service/issues/353