### PR TITLE
Add Capabilities to Processor and use for Fanout cloning decision

### DIFF
--- a/consumer/consumer.go
+++ b/consumer/consumer.go
@@ -36,9 +36,3 @@ type MetricsConsumer interface {
 type TraceConsumer interface {
 	ConsumeTraceData(ctx context.Context, td consumerdata.TraceData) error
 }
-
-// DataConsumer is a union type that can accept traces and/or metrics.
-type DataConsumer interface {
-	TraceConsumer
-	MetricsConsumer
-}

--- a/processor/attributesprocessor/attributes.go
+++ b/processor/attributesprocessor/attributes.go
@@ -122,6 +122,10 @@ func (a *attributesProcessor) ConsumeTraceData(ctx context.Context, td consumerd
 	return a.nextConsumer.ConsumeTraceData(ctx, td)
 }
 
+func (a *attributesProcessor) GetCapabilities() processor.Capabilities {
+	return processor.Capabilities{MutatesConsumedData: true}
+}
+
 func insertAttribute(action attributeAction, attributesMap map[string]*tracepb.AttributeValue) {
 	// Insert is only performed when the target key does not already exist
 	// in the attribute map.

--- a/processor/cloningfanoutconnector.go
+++ b/processor/cloningfanoutconnector.go
@@ -1,0 +1,137 @@
+// Copyright 2019, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package processor
+
+import (
+	"context"
+
+	commonpb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
+	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
+	resourcepb "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
+	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
+	"github.com/golang/protobuf/proto"
+
+	"github.com/open-telemetry/opentelemetry-collector/consumer"
+	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
+	"github.com/open-telemetry/opentelemetry-collector/oterr"
+)
+
+// This file contains implementations of cloning Trace/Metrics connectors
+// that fan out the data to multiple other consumers. Cloning connectors create
+// clones of data before fanning out, which ensures each consumer gets their
+// own copy of data and is free to modify it.
+
+// NewMetricsCloningFanOutConnector wraps multiple metrics consumers in a single one.
+func NewMetricsCloningFanOutConnector(mcs []consumer.MetricsConsumer) consumer.MetricsConsumer {
+	return metricsCloningFanOutConnector(mcs)
+}
+
+type metricsCloningFanOutConnector []consumer.MetricsConsumer
+
+var _ consumer.MetricsConsumer = (*metricsCloningFanOutConnector)(nil)
+
+// ConsumeMetricsData exports the MetricsData to all consumers wrapped by the current one.
+func (mfc metricsCloningFanOutConnector) ConsumeMetricsData(ctx context.Context, md consumerdata.MetricsData) error {
+	var errs []error
+
+	// Fan out to first len-1 consumers.
+	for i := 0; i < len(mfc)-1; i++ {
+		// Create a clone of data. We need to clone because consumers may modify the data.
+		clone := cloneMetricsData(&md)
+		if err := mfc[i].ConsumeMetricsData(ctx, *clone); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	if len(mfc) > 0 {
+		// Give the original data to the last consumer.
+		lastTc := mfc[len(mfc)-1]
+		if err := lastTc.ConsumeMetricsData(ctx, md); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	return oterr.CombineErrors(errs)
+}
+
+// NewTraceCloningFanOutConnector wraps multiple trace consumers in a single one.
+func NewTraceCloningFanOutConnector(tcs []consumer.TraceConsumer) consumer.TraceConsumer {
+	return traceCloningFanOutConnector(tcs)
+}
+
+type traceCloningFanOutConnector []consumer.TraceConsumer
+
+var _ consumer.TraceConsumer = (*traceCloningFanOutConnector)(nil)
+
+// ConsumeTraceData exports the span data to all trace consumers wrapped by the current one.
+func (tfc traceCloningFanOutConnector) ConsumeTraceData(ctx context.Context, td consumerdata.TraceData) error {
+	var errs []error
+
+	// Fan out to first len-1 consumers.
+	for i := 0; i < len(tfc)-1; i++ {
+		// Create a clone of data. We need to clone because consumers may modify the data.
+		clone := cloneTraceData(&td)
+		if err := tfc[i].ConsumeTraceData(ctx, *clone); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	if len(tfc) > 0 {
+		// Give the original data to the last consumer.
+		lastTc := tfc[len(tfc)-1]
+		if err := lastTc.ConsumeTraceData(ctx, td); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	return oterr.CombineErrors(errs)
+}
+
+func cloneTraceData(td *consumerdata.TraceData) *consumerdata.TraceData {
+	clone := &consumerdata.TraceData{
+		SourceFormat: td.SourceFormat,
+		Node:         proto.Clone(td.Node).(*commonpb.Node),
+		Resource:     proto.Clone(td.Resource).(*resourcepb.Resource),
+	}
+
+	if td.Spans != nil {
+		clone.Spans = make([]*tracepb.Span, 0, len(td.Spans))
+
+		for _, span := range td.Spans {
+			spanClone := proto.Clone(span).(*tracepb.Span)
+			clone.Spans = append(clone.Spans, spanClone)
+		}
+	}
+
+	return clone
+}
+
+func cloneMetricsData(md *consumerdata.MetricsData) *consumerdata.MetricsData {
+	clone := &consumerdata.MetricsData{
+		Node:     proto.Clone(md.Node).(*commonpb.Node),
+		Resource: proto.Clone(md.Resource).(*resourcepb.Resource),
+	}
+
+	if md.Metrics != nil {
+		clone.Metrics = make([]*metricspb.Metric, 0, len(md.Metrics))
+
+		for _, metric := range md.Metrics {
+			metricClone := proto.Clone(metric).(*metricspb.Metric)
+			clone.Metrics = append(clone.Metrics, metricClone)
+		}
+	}
+
+	return clone
+}

--- a/processor/cloningfanoutconnector_test.go
+++ b/processor/cloningfanoutconnector_test.go
@@ -1,0 +1,158 @@
+// Copyright 2019, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package processor
+
+import (
+	"context"
+	"math/rand"
+	"strconv"
+	"testing"
+
+	commonpb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
+	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
+	resourcepb "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
+	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/open-telemetry/opentelemetry-collector/consumer"
+	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
+)
+
+func TestTraceProcessorCloningMultiplexing(t *testing.T) {
+	processors := make([]consumer.TraceConsumer, 3)
+	for i := range processors {
+		processors[i] = &mockTraceConsumer{}
+	}
+
+	tfc := NewTraceCloningFanOutConnector(processors)
+	td := consumerdata.TraceData{
+		Spans: make([]*tracepb.Span, 7),
+		Resource: &resourcepb.Resource{
+			Type: "testtype",
+		},
+	}
+
+	var wantSpansCount = 0
+	for i := 0; i < 2; i++ {
+		wantSpansCount += len(td.Spans)
+		err := tfc.ConsumeTraceData(context.Background(), td)
+		if err != nil {
+			t.Errorf("Wanted nil got error")
+			return
+		}
+	}
+
+	for i, p := range processors {
+		m := p.(*mockTraceConsumer)
+		assert.Equal(t, wantSpansCount, m.TotalSpans)
+		if i < len(processors)-1 {
+			assert.True(t, td.Resource != m.Traces[0].Resource)
+		} else {
+			assert.True(t, td.Resource == m.Traces[0].Resource)
+		}
+		assert.EqualValues(t, td.Resource, m.Traces[0].Resource)
+	}
+}
+
+func TestMetricsProcessorCloningMultiplexing(t *testing.T) {
+	processors := make([]consumer.MetricsConsumer, 3)
+	for i := range processors {
+		processors[i] = &mockMetricsConsumer{}
+	}
+
+	mfc := NewMetricsCloningFanOutConnector(processors)
+	md := consumerdata.MetricsData{
+		Metrics: make([]*metricspb.Metric, 7),
+		Resource: &resourcepb.Resource{
+			Type: "testtype",
+		},
+	}
+
+	var wantMetricsCount = 0
+	for i := 0; i < 2; i++ {
+		wantMetricsCount += len(md.Metrics)
+		err := mfc.ConsumeMetricsData(context.Background(), md)
+		if err != nil {
+			t.Errorf("Wanted nil got error")
+			return
+		}
+	}
+
+	for i, p := range processors {
+		m := p.(*mockMetricsConsumer)
+		assert.Equal(t, wantMetricsCount, m.TotalMetrics)
+		if i < len(processors)-1 {
+			assert.True(t, md.Resource != m.Metrics[0].Resource)
+		} else {
+			assert.True(t, md.Resource == m.Metrics[0].Resource)
+		}
+		assert.EqualValues(t, md.Resource, m.Metrics[0].Resource)
+	}
+}
+
+func Benchmark100SpanClone(b *testing.B) {
+
+	b.StopTimer()
+
+	name := tracepb.TruncatableString{Value: "testspanname"}
+	traceData := &consumerdata.TraceData{
+		SourceFormat: "test-source-format",
+		Node: &commonpb.Node{
+			ServiceInfo: &commonpb.ServiceInfo{
+				Name: "servicename",
+			},
+		},
+		Resource: &resourcepb.Resource{
+			Type: "resourcetype",
+		},
+	}
+	for i := 0; i < 100; i++ {
+		span := &tracepb.Span{
+			TraceId: genRandBytes(16),
+			SpanId:  genRandBytes(8),
+			Name:    &name,
+			Attributes: &tracepb.Span_Attributes{
+				AttributeMap: map[string]*tracepb.AttributeValue{},
+			},
+		}
+
+		for j := 0; j < 5; j++ {
+			span.Attributes.AttributeMap["intattr"+strconv.Itoa(j)] = &tracepb.AttributeValue{
+				Value: &tracepb.AttributeValue_IntValue{IntValue: int64(i)},
+			}
+			span.Attributes.AttributeMap["strattr"+strconv.Itoa(j)] = &tracepb.AttributeValue{
+				Value: &tracepb.AttributeValue_StringValue{
+					StringValue: &tracepb.TruncatableString{Value: string(genRandBytes(20))},
+				},
+			}
+		}
+
+		traceData.Spans = append(traceData.Spans, span)
+	}
+
+	b.StartTimer()
+
+	for i := 0; i < b.N; i++ {
+		cloneTraceData(traceData)
+	}
+}
+
+func genRandBytes(len int) []byte {
+	b := make([]byte, len)
+	for i := range b {
+		b[i] = byte(rand.Intn(256))
+	}
+	return b
+}

--- a/processor/fanoutconnector.go
+++ b/processor/fanoutconnector.go
@@ -17,12 +17,6 @@ package processor
 import (
 	"context"
 
-	commonpb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
-	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
-	resourcepb "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
-	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
-	"github.com/golang/protobuf/proto"
-
 	"github.com/open-telemetry/opentelemetry-collector/consumer"
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-collector/oterr"
@@ -32,104 +26,41 @@ import (
 // that fan out the data to multiple other consumers.
 
 // NewMetricsFanOutConnector wraps multiple metrics consumers in a single one.
-func NewMetricsFanOutConnector(mcs []consumer.MetricsConsumer) MetricsProcessor {
+func NewMetricsFanOutConnector(mcs []consumer.MetricsConsumer) consumer.MetricsConsumer {
 	return metricsFanOutConnector(mcs)
 }
 
 type metricsFanOutConnector []consumer.MetricsConsumer
 
-var _ MetricsProcessor = (*metricsFanOutConnector)(nil)
+var _ consumer.MetricsConsumer = (*metricsFanOutConnector)(nil)
 
 // ConsumeMetricsData exports the MetricsData to all consumers wrapped by the current one.
 func (mfc metricsFanOutConnector) ConsumeMetricsData(ctx context.Context, md consumerdata.MetricsData) error {
 	var errs []error
-
-	// Fan out to first len-1 consumers.
-	for i := 0; i < len(mfc)-1; i++ {
-		// Create a clone of data. We need to clone because consumers may modify the data.
-		clone := cloneMetricsData(&md)
-		if err := mfc[i].ConsumeMetricsData(ctx, *clone); err != nil {
+	for _, mc := range mfc {
+		if err := mc.ConsumeMetricsData(ctx, md); err != nil {
 			errs = append(errs, err)
 		}
 	}
-
-	if len(mfc) > 0 {
-		// Give the original data to the last consumer.
-		lastTc := mfc[len(mfc)-1]
-		if err := lastTc.ConsumeMetricsData(ctx, md); err != nil {
-			errs = append(errs, err)
-		}
-	}
-
 	return oterr.CombineErrors(errs)
 }
 
 // NewTraceFanOutConnector wraps multiple trace consumers in a single one.
-func NewTraceFanOutConnector(tcs []consumer.TraceConsumer) TraceProcessor {
+func NewTraceFanOutConnector(tcs []consumer.TraceConsumer) consumer.TraceConsumer {
 	return traceFanOutConnector(tcs)
 }
 
 type traceFanOutConnector []consumer.TraceConsumer
 
-var _ TraceProcessor = (*traceFanOutConnector)(nil)
+var _ consumer.TraceConsumer = (*traceFanOutConnector)(nil)
 
 // ConsumeTraceData exports the span data to all trace consumers wrapped by the current one.
 func (tfc traceFanOutConnector) ConsumeTraceData(ctx context.Context, td consumerdata.TraceData) error {
 	var errs []error
-
-	// Fan out to first len-1 consumers.
-	for i := 0; i < len(tfc)-1; i++ {
-		// Create a clone of data. We need to clone because consumers may modify the data.
-		clone := cloneTraceData(&td)
-		if err := tfc[i].ConsumeTraceData(ctx, *clone); err != nil {
+	for _, tc := range tfc {
+		if err := tc.ConsumeTraceData(ctx, td); err != nil {
 			errs = append(errs, err)
 		}
 	}
-
-	if len(tfc) > 0 {
-		// Give the original data to the last consumer.
-		lastTc := tfc[len(tfc)-1]
-		if err := lastTc.ConsumeTraceData(ctx, td); err != nil {
-			errs = append(errs, err)
-		}
-	}
-
 	return oterr.CombineErrors(errs)
-}
-
-func cloneTraceData(td *consumerdata.TraceData) *consumerdata.TraceData {
-	clone := &consumerdata.TraceData{
-		SourceFormat: td.SourceFormat,
-		Node:         proto.Clone(td.Node).(*commonpb.Node),
-		Resource:     proto.Clone(td.Resource).(*resourcepb.Resource),
-	}
-
-	if td.Spans != nil {
-		clone.Spans = make([]*tracepb.Span, 0, len(td.Spans))
-
-		for _, span := range td.Spans {
-			spanClone := proto.Clone(span).(*tracepb.Span)
-			clone.Spans = append(clone.Spans, spanClone)
-		}
-	}
-
-	return clone
-}
-
-func cloneMetricsData(md *consumerdata.MetricsData) *consumerdata.MetricsData {
-	clone := &consumerdata.MetricsData{
-		Node:     proto.Clone(md.Node).(*commonpb.Node),
-		Resource: proto.Clone(md.Resource).(*resourcepb.Resource),
-	}
-
-	if md.Metrics != nil {
-		clone.Metrics = make([]*metricspb.Metric, 0, len(md.Metrics))
-
-		for _, metric := range md.Metrics {
-			metricClone := proto.Clone(metric).(*metricspb.Metric)
-			clone.Metrics = append(clone.Metrics, metricClone)
-		}
-	}
-
-	return clone
 }

--- a/processor/nodebatcherprocessor/node_batcher.go
+++ b/processor/nodebatcherprocessor/node_batcher.go
@@ -76,7 +76,7 @@ type batcher struct {
 var _ consumer.TraceConsumer = (*batcher)(nil)
 
 // NewBatcher creates a new batcher that batches spans by node and resource
-func NewBatcher(name string, logger *zap.Logger, sender consumer.TraceConsumer, opts ...Option) consumer.TraceConsumer {
+func NewBatcher(name string, logger *zap.Logger, sender consumer.TraceConsumer, opts ...Option) processor.TraceProcessor {
 	// Init with defaults
 	b := &batcher{
 		name:   name,
@@ -107,6 +107,10 @@ func (b *batcher) ConsumeTraceData(ctx context.Context, td consumerdata.TraceDat
 	bucket := b.getOrAddBucket(bucketID, td.Node, td.Resource, td.SourceFormat)
 	bucket.add(td.Spans)
 	return nil
+}
+
+func (b *batcher) GetCapabilities() processor.Capabilities {
+	return processor.Capabilities{MutatesConsumedData: false}
 }
 
 func (b *batcher) genBucketID(node *commonpb.Node, resource *resourcepb.Resource, spanFormat string) string {

--- a/processor/probabilisticsamplerprocessor/probabilisticsampler.go
+++ b/processor/probabilisticsamplerprocessor/probabilisticsampler.go
@@ -82,6 +82,10 @@ func (tsp *tracesamplerprocessor) ConsumeTraceData(ctx context.Context, td consu
 	return tsp.nextConsumer.ConsumeTraceData(ctx, sampledTraceData)
 }
 
+func (tsp *tracesamplerprocessor) GetCapabilities() processor.Capabilities {
+	return processor.Capabilities{MutatesConsumedData: false}
+}
+
 // hash is a murmur3 hash function, see http://en.wikipedia.org/wiki/MurmurHash.
 func hash(key []byte, seed uint32) (hash uint32) {
 	const (

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -22,18 +22,21 @@ import (
 // TraceProcessor composes TraceConsumer with some additional processor-specific functions.
 type TraceProcessor interface {
 	consumer.TraceConsumer
-
-	// TODO: Add processor specific functions.
+	GetCapabilities() Capabilities
 }
 
 // MetricsProcessor composes MetricsConsumer with some additional processor-specific functions.
 type MetricsProcessor interface {
 	consumer.MetricsConsumer
-
-	// TODO: Add processor specific functions.
+	GetCapabilities() Capabilities
 }
 
-// Processor is a data consumer.
-type Processor interface {
-	consumer.DataConsumer
+// Capabilities describes the capabilities of TraceProcessor or MetricsProcessor.
+type Capabilities struct {
+	// MutatesConsumedData is set to true if ConsumeTraceData or ConsumeMetricsData
+	// function of the processor modifies the input TraceData or MetricsData argument.
+	// Processors which modify the input data MUST set this flag to true. If the processor
+	// does not modify the data it MUST set this flag to false. If the processor creates
+	// a copy of the data before modifying then this flag can be safely set to false.
+	MutatesConsumedData bool
 }

--- a/processor/processortest/nop_processor.go
+++ b/processor/processortest/nop_processor.go
@@ -38,6 +38,10 @@ func (np *nopProcessor) ConsumeMetricsData(ctx context.Context, md consumerdata.
 	return np.nextMetricsProcessor.ConsumeMetricsData(ctx, md)
 }
 
+func (np *nopProcessor) GetCapabilities() processor.Capabilities {
+	return processor.Capabilities{MutatesConsumedData: false}
+}
+
 // NewNopTraceProcessor creates an TraceProcessor that just pass the received data to the nextTraceProcessor.
 func NewNopTraceProcessor(nextTraceProcessor consumer.TraceConsumer) consumer.TraceConsumer {
 	return &nopProcessor{nextTraceProcessor: nextTraceProcessor}

--- a/processor/queuedprocessor/queued_processor.go
+++ b/processor/queuedprocessor/queued_processor.go
@@ -56,7 +56,7 @@ type queueItem struct {
 // NewQueuedSpanProcessor returns a span processor that maintains a bounded
 // in-memory queue of span batches, and sends out span batches using the
 // provided sender
-func NewQueuedSpanProcessor(sender consumer.TraceConsumer, opts ...Option) consumer.TraceConsumer {
+func NewQueuedSpanProcessor(sender consumer.TraceConsumer, opts ...Option) processor.TraceProcessor {
 	options := Options.apply(opts...)
 	sp := newQueuedSpanProcessor(sender, options)
 
@@ -129,6 +129,10 @@ func (sp *queuedSpanProcessor) ConsumeTraceData(ctx context.Context, td consumer
 		sp.onItemDropped(item, statsTags)
 	}
 	return nil
+}
+
+func (sp *queuedSpanProcessor) GetCapabilities() processor.Capabilities {
+	return processor.Capabilities{MutatesConsumedData: false}
 }
 
 func (sp *queuedSpanProcessor) processItemFromQueue(item *queueItem) {

--- a/processor/queuedprocessor/queued_processor_test.go
+++ b/processor/queuedprocessor/queued_processor_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector/consumer"
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumererror"
+	"github.com/open-telemetry/opentelemetry-collector/processor"
 )
 
 func TestQueuedProcessor_noEnqueueOnPermanentError(t *testing.T) {
@@ -77,6 +78,10 @@ func (c *waitGroupTraceConsumer) ConsumeTraceData(ctx context.Context, td consum
 	return c.consumeTraceDataError
 }
 
+func (c *waitGroupTraceConsumer) GetCapabilities() processor.Capabilities {
+	return processor.Capabilities{MutatesConsumedData: false}
+}
+
 func TestQueueProcessorHappyPath(t *testing.T) {
 	mockProc := newMockConcurrentSpanProcessor()
 	qp := NewQueuedSpanProcessor(mockProc)
@@ -122,6 +127,10 @@ func (p *mockConcurrentSpanProcessor) ConsumeTraceData(ctx context.Context, td c
 	atomic.AddInt32(&p.spanCount, int32(len(td.Spans)))
 	p.waitGroup.Done()
 	return nil
+}
+
+func (p *mockConcurrentSpanProcessor) GetCapabilities() processor.Capabilities {
+	return processor.Capabilities{MutatesConsumedData: false}
 }
 
 func newMockConcurrentSpanProcessor() *mockConcurrentSpanProcessor {

--- a/processor/spanprocessor/span.go
+++ b/processor/spanprocessor/span.go
@@ -57,6 +57,10 @@ func (sp *spanProcessor) ConsumeTraceData(ctx context.Context, td consumerdata.T
 	return sp.nextConsumer.ConsumeTraceData(ctx, td)
 }
 
+func (sp *spanProcessor) GetCapabilities() processor.Capabilities {
+	return processor.Capabilities{MutatesConsumedData: true}
+}
+
 func (sp *spanProcessor) nameSpan(span *tracepb.Span) {
 	// Note: There was a separate proposal for creating the string.
 	// With benchmarking, strings.Builder is faster than the proposal.

--- a/processor/tailsamplingprocessor/processor.go
+++ b/processor/tailsamplingprocessor/processor.go
@@ -311,6 +311,10 @@ func (tsp *tailSamplingSpanProcessor) ConsumeTraceData(ctx context.Context, td c
 	return nil
 }
 
+func (tsp *tailSamplingSpanProcessor) GetCapabilities() processor.Capabilities {
+	return processor.Capabilities{MutatesConsumedData: false}
+}
+
 func (tsp *tailSamplingSpanProcessor) dropTrace(traceID traceKey, deletionTime time.Time) {
 	var trace *sampling.TraceData
 	if d, ok := tsp.idToTrace.Load(traceID); ok {

--- a/processor/tailsamplingprocessor/processor_test.go
+++ b/processor/tailsamplingprocessor/processor_test.go
@@ -327,3 +327,7 @@ func (p *mockSpanProcessor) ConsumeTraceData(ctx context.Context, td consumerdat
 	p.TotalSpans += batchSize
 	return nil
 }
+
+func (p *mockSpanProcessor) GetCapabilities() processor.Capabilities {
+	return processor.Capabilities{MutatesConsumedData: false}
+}

--- a/service/builder/pipelines_builder_test.go
+++ b/service/builder/pipelines_builder_test.go
@@ -98,8 +98,8 @@ func testPipeline(t *testing.T, pipelineName string, exporterNames []string) {
 
 	// Ensure pipeline has its fields correctly populated.
 	require.NotNil(t, processor)
-	assert.NotNil(t, processor.tc)
-	assert.Nil(t, processor.mc)
+	assert.NotNil(t, processor.firstTC)
+	assert.Nil(t, processor.firstMC)
 
 	// Compose the list of created exporters.
 	var exporters []*builtExporter
@@ -136,7 +136,7 @@ func testPipeline(t *testing.T, pipelineName string, exporterNames []string) {
 			Type: "resourcetype",
 		},
 	}
-	processor.tc.ConsumeTraceData(context.Background(), traceData)
+	processor.firstTC.ConsumeTraceData(context.Background(), traceData)
 
 	// Now verify received data.
 	for _, consumer := range exporterConsumers {


### PR DESCRIPTION
This is part 1 of the task to introduce capabilities and declare
processor's intent to mutate or not mutate consumed data for the
purpose of optimizing pipeline data ownership.

If a processor declares that they mutate data the pipeline
that the processor is in will use cloning fan out connector.
This is done only if the pipeline shares a receiver with another
pipeline.

This ensures that it is safe for processor modify the data (because
pipelines work concurrently) and avoids cloning for pipelines that
consume data from the same receiver but do not modify it.

For more details see:
https://github.com/open-telemetry/opentelemetry-collector/issues/372