### PR TITLE
Handle factories returning nil objects without error

### DIFF
--- a/service/builder/exporters_builder.go
+++ b/service/builder/exporters_builder.go
@@ -207,8 +207,7 @@ func (eb *ExportersBuilder) buildExporter(
 			return nil, fmt.Errorf("error creating %s exporter: %v", config.Name(), err)
 		}
 
-		// The factories can be implemented by third parties, check if they really
-		// created the exporter.
+		// Check if the factory really created the exporter.
 		if te == nil {
 			return nil, fmt.Errorf("factory for %q produced a nil exporter", config.Name())
 		}

--- a/service/builder/exporters_builder.go
+++ b/service/builder/exporters_builder.go
@@ -134,6 +134,7 @@ func (eb *ExportersBuilder) Build() (Exporters, error) {
 		if err != nil {
 			return nil, err
 		}
+
 		exporters[cfg] = exp
 	}
 
@@ -206,6 +207,12 @@ func (eb *ExportersBuilder) buildExporter(
 			return nil, fmt.Errorf("error creating %s exporter: %v", config.Name(), err)
 		}
 
+		// The factories can be implemented by third parties, check if they really
+		// created the exporter.
+		if te == nil {
+			return nil, fmt.Errorf("factory for %q produced a nil exporter", config.Name())
+		}
+
 		exporter.te = te
 	}
 
@@ -218,6 +225,12 @@ func (eb *ExportersBuilder) buildExporter(
 				return nil, typeMismatchErr(config, requirement.requiredBy, configmodels.MetricsDataType)
 			}
 			return nil, fmt.Errorf("error creating %s exporter: %v", config.Name(), err)
+		}
+
+		// The factories can be implemented by third parties, check if they really
+		// created the exporter.
+		if me == nil {
+			return nil, fmt.Errorf("factory for %q produced a nil exporter", config.Name())
 		}
 
 		exporter.me = me

--- a/service/builder/pipelines_builder.go
+++ b/service/builder/pipelines_builder.go
@@ -131,8 +131,7 @@ func (pb *PipelinesBuilder) buildPipeline(
 				procName, pipelineCfg.Name, err)
 		}
 
-		// The factories can be implemented by third parties, check if they really
-		// created the exporter.
+		// Check if the factory really created the processor.
 		if tc == nil && mc == nil {
 			return nil, fmt.Errorf("factory for %q produced a nil processor", procCfg.Name())
 		}

--- a/service/builder/pipelines_builder.go
+++ b/service/builder/pipelines_builder.go
@@ -130,6 +130,12 @@ func (pb *PipelinesBuilder) buildPipeline(
 			return nil, fmt.Errorf("error creating processor %q in pipeline %q: %v",
 				procName, pipelineCfg.Name, err)
 		}
+
+		// The factories can be implemented by third parties, check if they really
+		// created the exporter.
+		if tc == nil && mc == nil {
+			return nil, fmt.Errorf("factory for %q produced a nil processor", procCfg.Name())
+		}
 	}
 
 	pb.logger.Info("Pipeline is enabled.", zap.String("pipelines", pipelineCfg.Name))

--- a/service/builder/receivers_builder.go
+++ b/service/builder/receivers_builder.go
@@ -192,8 +192,7 @@ func (rb *ReceiversBuilder) attachReceiverToPipelines(
 		// Now create the receiver and tell it to send to the junction point.
 		rcv.trace, err = factory.CreateTraceReceiver(context.Background(), rb.logger, config, junction)
 
-		// The factories can be implemented by third parties, check if they really
-		// created the exporter.
+		// Check if the factory really created the receiver.
 		if rcv.trace == nil {
 			return fmt.Errorf("factory for %q produced a nil receiver", config.Name())
 		}

--- a/service/builder/receivers_builder.go
+++ b/service/builder/receivers_builder.go
@@ -192,9 +192,21 @@ func (rb *ReceiversBuilder) attachReceiverToPipelines(
 		// Now create the receiver and tell it to send to the junction point.
 		rcv.trace, err = factory.CreateTraceReceiver(context.Background(), rb.logger, config, junction)
 
+		// The factories can be implemented by third parties, check if they really
+		// created the exporter.
+		if rcv.trace == nil {
+			return fmt.Errorf("factory for %q produced a nil receiver", config.Name())
+		}
+
 	case configmodels.MetricsDataType:
 		junction := buildFanoutMetricConsumer(builtPipelines)
 		rcv.metrics, err = factory.CreateMetricsReceiver(rb.logger, config, junction)
+
+		// The factories can be implemented by third parties, check if they really
+		// created the exporter.
+		if rcv.metrics == nil {
+			return fmt.Errorf("factory for %q produced a nil receiver", config.Name())
+		}
 	}
 
 	if err != nil {

--- a/service/builder/testdata/bad_processor_factory.yaml
+++ b/service/builder/testdata/bad_processor_factory.yaml
@@ -1,0 +1,18 @@
+receivers:
+  examplereceiver:
+processors:
+  bf/traces: # this is the bad processor factory
+  bf/metrics:
+exporters:
+  exampleexporter:
+
+service:
+  pipelines:
+    traces:
+      receivers: [examplereceiver]
+      processors: [bf/traces]
+      exporters: [exampleexporter]
+    metrics:
+      receivers: [examplereceiver]
+      processors: [bf/metrics]
+      exporters: [exampleexporter]

--- a/service/builder/testdata/bad_receiver_factory.yaml
+++ b/service/builder/testdata/bad_receiver_factory.yaml
@@ -1,0 +1,16 @@
+receivers:
+  bf: # this is the bad receiver factory
+processors:
+  nop:
+exporters:
+  exampleexporter:
+
+service:
+  pipelines:
+    traces:
+      receivers: [bf]
+      processors: [nop] # trace pipeline requires a processor
+      exporters: [exampleexporter]
+    metrics:
+      receivers: [bf]
+      exporters: [exampleexporter]

--- a/service/service.go
+++ b/service/service.go
@@ -195,8 +195,7 @@ func (app *Application) setupExtensions() error {
 			return fmt.Errorf("failed to create extension %q: %v", extName, err)
 		}
 
-		// The factories can be implemented by third parties, check if they really
-		// created the extension.
+		// Check if the factory really created the extension.
 		if ext == nil {
 			return fmt.Errorf("factory for %q produced a nil extension", extName)
 		}

--- a/service/service.go
+++ b/service/service.go
@@ -19,6 +19,7 @@ package service
 import (
 	"context"
 	"flag"
+	"fmt"
 	"log"
 	"os"
 	"os/signal"
@@ -170,32 +171,44 @@ func (app *Application) setupConfigurationComponents() {
 
 	app.logger.Info("Applying configuration...")
 
-	app.setupExtensions()
+	if err := app.setupExtensions(); err != nil {
+		log.Fatalf("Cannot setup extensions: %v", err)
+	}
+
 	app.setupPipelines()
 }
 
-func (app *Application) setupExtensions() {
+func (app *Application) setupExtensions() error {
 	for _, extName := range app.config.Service.Extensions {
 		extCfg, exists := app.config.Extensions[extName]
 		if !exists {
-			log.Fatalf("Cannot load configuration: extension %q is not configured", extName)
+			return fmt.Errorf("extension %q is not configured", extName)
 		}
 
 		factory, exists := app.factories.Extensions[extCfg.Type()]
 		if !exists {
-			log.Fatalf("Cannot load configuration: extension factory for type %q is not configured", extCfg.Type())
+			return fmt.Errorf("extension factory for type %q is not configured", extCfg.Type())
 		}
 
 		ext, err := factory.CreateExtension(app.logger, extCfg)
 		if err != nil {
-			log.Fatalf("Cannot load configuration: failed to create extension %q: %v", extName, err)
+			return fmt.Errorf("failed to create extension %q: %v", extName, err)
+		}
+
+		// The factories can be implemented by third parties, check if they really
+		// created the extension.
+		if ext == nil {
+			return fmt.Errorf("factory for %q produced a nil extension", extName)
 		}
 
 		if err := ext.Start(app); err != nil {
-			log.Fatalf("Cannot start extension %q: %v", extName, err)
+			return fmt.Errorf("error starting extension %q: %v", extName, err)
 		}
+
 		app.extensions = append(app.extensions, ext)
 	}
+
+	return nil
 }
 
 func (app *Application) setupPipelines() {

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -184,7 +184,7 @@ func TestApplication_setupExtensions(t *testing.T) {
 	}
 }
 
-// badProcessorFactory is a factory that returns no error but returns a nil object.
+// badExtensionFactory is a factory that returns no error but returns a nil object.
 type badExtensionFactory struct{}
 
 var _ extension.Factory = (*badExtensionFactory)(nil)

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -21,8 +21,12 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
 
+	"github.com/open-telemetry/opentelemetry-collector/config"
+	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
 	"github.com/open-telemetry/opentelemetry-collector/defaults"
+	"github.com/open-telemetry/opentelemetry-collector/extension"
 	"github.com/open-telemetry/opentelemetry-collector/internal/testutils"
 )
 
@@ -68,4 +72,134 @@ func isAppAvailable(t *testing.T, healthCheckEndPoint string) bool {
 	}
 	defer resp.Body.Close()
 	return resp.StatusCode == http.StatusOK
+}
+
+func TestApplication_setupExtensions(t *testing.T) {
+	exampleExtensionFactory := &config.ExampleExtensionFactory{}
+	exampleExtensionConfig := &config.ExampleExtension{
+		ExtensionSettings: configmodels.ExtensionSettings{
+			TypeVal: exampleExtensionFactory.Type(),
+			NameVal: exampleExtensionFactory.Type(),
+		},
+	}
+
+	badExtensionFactory := &badExtensionFactory{}
+	badExtensionFactoryConfig := &configmodels.ExtensionSettings{
+		TypeVal: "bf",
+		NameVal: "bf",
+	}
+
+	tests := []struct {
+		name       string
+		factories  config.Factories
+		config     *configmodels.Config
+		wantErrMsg string
+	}{
+		{
+			name: "extension_not_configured",
+			config: &configmodels.Config{
+				Service: configmodels.Service{
+					Extensions: []string{
+						"myextension",
+					},
+				},
+			},
+			wantErrMsg: "extension \"myextension\" is not configured",
+		},
+		{
+			name: "missing_extension_factory",
+			config: &configmodels.Config{
+				Extensions: map[string]configmodels.Extension{
+					exampleExtensionFactory.Type(): exampleExtensionConfig,
+				},
+				Service: configmodels.Service{
+					Extensions: []string{
+						exampleExtensionFactory.Type(),
+					},
+				},
+			},
+			wantErrMsg: "extension factory for type \"exampleextension\" is not configured",
+		},
+		{
+			name: "error_on_create_extension",
+			factories: config.Factories{
+				Extensions: map[string]extension.Factory{
+					exampleExtensionFactory.Type(): exampleExtensionFactory,
+				},
+			},
+			config: &configmodels.Config{
+				Extensions: map[string]configmodels.Extension{
+					exampleExtensionFactory.Type(): exampleExtensionConfig,
+				},
+				Service: configmodels.Service{
+					Extensions: []string{
+						exampleExtensionFactory.Type(),
+					},
+				},
+			},
+			wantErrMsg: "failed to create extension \"exampleextension\": cannot create \"exampleextension\" extension type",
+		},
+		{
+			name: "bad_factory",
+			factories: config.Factories{
+				Extensions: map[string]extension.Factory{
+					badExtensionFactory.Type(): badExtensionFactory,
+				},
+			},
+			config: &configmodels.Config{
+				Extensions: map[string]configmodels.Extension{
+					badExtensionFactory.Type(): badExtensionFactoryConfig,
+				},
+				Service: configmodels.Service{
+					Extensions: []string{
+						badExtensionFactory.Type(),
+					},
+				},
+			},
+			wantErrMsg: "factory for \"bf\" produced a nil extension",
+		},
+	}
+
+	nopLogger := zap.NewNop()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			app := &Application{
+				logger:    nopLogger,
+				factories: tt.factories,
+				config:    tt.config,
+			}
+
+			err := app.setupExtensions()
+
+			if tt.wantErrMsg == "" {
+				assert.NoError(t, err)
+				assert.Equal(t, 1, len(app.extensions))
+				assert.NotNil(t, app.extensions[0])
+			} else {
+				assert.Error(t, err)
+				assert.Equal(t, tt.wantErrMsg, err.Error())
+				assert.Equal(t, 0, len(app.extensions))
+			}
+		})
+	}
+}
+
+// badProcessorFactory is a factory that returns no error but returns a nil object.
+type badExtensionFactory struct{}
+
+var _ extension.Factory = (*badExtensionFactory)(nil)
+
+func (b badExtensionFactory) Type() string {
+	return "bf"
+}
+
+func (b badExtensionFactory) CreateDefaultConfig() configmodels.Extension {
+	return &configmodels.ExtensionSettings{}
+}
+
+func (b badExtensionFactory) CreateExtension(
+	logger *zap.Logger,
+	cfg configmodels.Extension,
+) (extension.ServiceExtension, error) {
+	return nil, nil
 }


### PR DESCRIPTION
The factories can be implemented by 3rd party and this gives a better error message instead of a crash.

Fixes #358 