### PR TITLE
Validate configuration object tags

### DIFF
--- a/cmd/otelcol/main.go
+++ b/cmd/otelcol/main.go
@@ -33,7 +33,9 @@ func main() {
 	factories, err := defaults.Components()
 	handleErr(err)
 
-	svc := service.New(factories)
+	svc, err := service.New(factories)
+	handleErr(err)
+
 	err = svc.Start()
 	handleErr(err)
 }

--- a/config/configcheck/configcheck.go
+++ b/config/configcheck/configcheck.go
@@ -1,0 +1,194 @@
+// Copyright 2019, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package configcheck has checks to be applied to configuration
+// objects implemented by factories of components used in the OpenTelemetry
+// collector. It is recommended for implementers of components to run the
+// validations available on this package.
+package configcheck
+
+import (
+	"fmt"
+	"reflect"
+	"regexp"
+	"strings"
+
+	"github.com/open-telemetry/opentelemetry-collector/config"
+	"github.com/open-telemetry/opentelemetry-collector/oterr"
+)
+
+// The regular expression for valid config field tag.
+var configFieldTagRegExp = regexp.MustCompile("^[a-z0-9][a-z0-9_]*$")
+
+// ValidateConfigFromFactories checks if all configurations for the given factories
+// are satisfying the patterns used by the collector.
+func ValidateConfigFromFactories(factories config.Factories) error {
+	var errs []error
+	var configs []interface{}
+
+	for _, factory := range factories.Receivers {
+		configs = append(configs, factory.CreateDefaultConfig())
+	}
+	for _, factory := range factories.Processors {
+		configs = append(configs, factory.CreateDefaultConfig())
+	}
+	for _, factory := range factories.Exporters {
+		configs = append(configs, factory.CreateDefaultConfig())
+	}
+	for _, factory := range factories.Extensions {
+		configs = append(configs, factory.CreateDefaultConfig())
+	}
+
+	for _, config := range configs {
+		if err := ValidateConfig(config); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	return oterr.CombineErrors(errs)
+}
+
+// ValidateConfig enforces that given configuration object is following the patterns
+// used by the collector. This ensures consistency between different implementations
+// of components and extensions. It is recommended for implementers of components
+// to call this function on their tests passing the default configurtation of the
+// component factory.
+func ValidateConfig(config interface{}) error {
+	t := reflect.TypeOf(config)
+
+	tk := t.Kind()
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+		tk = t.Kind()
+	}
+
+	if tk != reflect.Struct {
+		return fmt.Errorf(
+			"config must be a struct or a pointer to one, the passed object is a %s",
+			tk)
+	}
+
+	return validateConfigDataType(t)
+}
+
+// validateConfigDataType performs a descending validation of the given type.
+// If the type is a struct it goes to each of its fields to check for the proper
+// tags.
+func validateConfigDataType(t reflect.Type) error {
+	var errs []error
+
+	switch t.Kind() {
+	case reflect.Ptr:
+		if err := validateConfigDataType(t.Elem()); err != nil {
+			errs = append(errs, err)
+		}
+	case reflect.Struct:
+		// Reflect on the pointed data and check each of its fields.
+		// vt := reflect.ValueOf(config).Elem().Type()
+		nf := t.NumField()
+		for i := 0; i < nf; i++ {
+			f := t.Field(i)
+			if err := checkStructFieldTags(f); err != nil {
+				errs = append(errs, err)
+			}
+		}
+	default:
+		// The config object can carry other types but they are not used when
+		// reading the configuration via viper so ignore them. Basically ignore:
+		// reflect.Uintptr, reflect.Chan, reflect.Func, reflect.Interface, and
+		// reflect.UnsafePointer.
+	}
+
+	if err := oterr.CombineErrors(errs); err != nil {
+		return fmt.Errorf(
+			"type %q from package %q has invalid config settings: %v",
+			t.Name(),
+			t.PkgPath(),
+			err)
+	}
+
+	return nil
+}
+
+// checkStructFieldTags inspects the tags of a struct field.
+func checkStructFieldTags(f reflect.StructField) error {
+
+	tagValue := f.Tag.Get("mapstructure")
+	if tagValue == "" {
+
+		// Ignore special types.
+		switch f.Type.Kind() {
+		case reflect.Interface, reflect.Chan, reflect.Func, reflect.Uintptr, reflect.UnsafePointer:
+			// Allow the config to carry the types above, but since they are not read
+			// when loading configuration, just ignore them.
+			return nil
+		}
+
+		// Public fields of other types should be tagged.
+		chars := []byte(f.Name)
+		if len(chars) > 0 && chars[0] >= 'A' && chars[0] <= 'Z' {
+			return fmt.Errorf("mapstructure tag not present on field %q", f.Name)
+		}
+
+		// Not public field, no need to have a tag.
+		return nil
+	}
+
+	tagParts := strings.Split(tagValue, ",")
+	if tagParts[0] != "" {
+		if tagParts[0] == "-" {
+			// Nothing to do, as mapstructure decode skips this field.
+			return nil
+		}
+	}
+
+	// Check if squash is specified.
+	squash := false
+	for _, tag := range tagParts[1:] {
+		if tag == "squash" {
+			squash = true
+			break
+		}
+	}
+
+	if squash {
+		// Field was squashed.
+		if f.Type.Kind() != reflect.Struct {
+			return fmt.Errorf(
+				"attempt to squash non-struct type on field %q", f.Name)
+		}
+	}
+
+	switch f.Type.Kind() {
+	case reflect.Struct:
+		// It is another struct, continue down-level
+		return validateConfigDataType(f.Type)
+
+	case reflect.Map, reflect.Slice, reflect.Array:
+		// The element of map, array, or slice can be itself a configuration object.
+		return validateConfigDataType(f.Type.Elem())
+
+	default:
+		fieldTag := tagParts[0]
+		if !configFieldTagRegExp.MatchString(fieldTag) {
+			return fmt.Errorf(
+				"field %q has config tag %q which doesn't satisfy %q",
+				f.Name,
+				fieldTag,
+				configFieldTagRegExp.String())
+		}
+	}
+
+	return nil
+}

--- a/config/configcheck/configcheck.go
+++ b/config/configcheck/configcheck.go
@@ -62,7 +62,7 @@ func ValidateConfigFromFactories(factories config.Factories) error {
 // ValidateConfig enforces that given configuration object is following the patterns
 // used by the collector. This ensures consistency between different implementations
 // of components and extensions. It is recommended for implementers of components
-// to call this function on their tests passing the default configurtation of the
+// to call this function on their tests passing the default configuration of the
 // component factory.
 func ValidateConfig(config interface{}) error {
 	t := reflect.TypeOf(config)

--- a/config/configcheck/configcheck.go
+++ b/config/configcheck/configcheck.go
@@ -95,7 +95,6 @@ func validateConfigDataType(t reflect.Type) error {
 		}
 	case reflect.Struct:
 		// Reflect on the pointed data and check each of its fields.
-		// vt := reflect.ValueOf(config).Elem().Type()
 		nf := t.NumField()
 		for i := 0; i < nf; i++ {
 			f := t.Field(i)

--- a/config/configcheck/configcheck_test.go
+++ b/config/configcheck/configcheck_test.go
@@ -1,0 +1,208 @@
+// Copyright 2019, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package configcheck
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
+	"github.com/open-telemetry/opentelemetry-collector/defaults"
+	"github.com/open-telemetry/opentelemetry-collector/extension"
+)
+
+func TestValidateConfigFromFactories_Success(t *testing.T) {
+	factories, err := defaults.Components()
+	require.NoError(t, err)
+
+	err = ValidateConfigFromFactories(factories)
+	require.NoError(t, err)
+}
+
+func TestValidateConfigFromFactories_Failure(t *testing.T) {
+	factories, err := defaults.Components()
+	require.NoError(t, err)
+
+	// Add a factory returning config not following pattern to force error.
+	f := &badConfigExtensionFactory{}
+	factories.Extensions[f.Type()] = f
+
+	err = ValidateConfigFromFactories(factories)
+	require.Error(t, err)
+}
+
+func TestValidateConfigPointerAndValue(t *testing.T) {
+	config := struct {
+		SomeFiled string `mapstructure:"test"`
+	}{}
+	assert.NoError(t, ValidateConfig(config))
+	assert.NoError(t, ValidateConfig(&config))
+}
+
+func TestValidateConfig(t *testing.T) {
+	type BadConfigTag struct {
+		BadTagField int `mapstructure:"test-dash"`
+	}
+
+	tests := []struct {
+		name             string
+		config           interface{}
+		wantErrMsgSubStr string
+	}{
+		{
+			name: "typical_config",
+			config: struct {
+				MyPublicString string `mapstructure:"string"`
+			}{},
+		},
+		{
+			name: "private_fields_ignored",
+			config: struct {
+				// A public type with proper tag.
+				MyPublicString string `mapstructure:"string"`
+				// A public type with proper tag.
+				MyPublicInt string `mapstructure:"int"`
+				// A public type that should be ignored.
+				MyFunc func() error
+				// A public type that should be ignored.
+				Reader io.Reader
+				// private type not tagged.
+				myPrivateString string
+				_someInt        int
+			}{},
+		},
+		{
+			name: "not_struct_nor_pointer",
+			config: func(x int) int {
+				return x * x
+			},
+			wantErrMsgSubStr: "config must be a struct or a pointer to one, the passed object is a func",
+		},
+		{
+			name: "squash_on_non_struct",
+			config: struct {
+				MyInt int `mapstructure:",squash"`
+			}{},
+			wantErrMsgSubStr: "attempt to squash non-struct type on field \"MyInt\"",
+		},
+		{
+			name:             "invalid_tag_detected",
+			config:           BadConfigTag{},
+			wantErrMsgSubStr: "field \"BadTagField\" has config tag \"test-dash\" which doesn't satisfy",
+		},
+		{
+			name: "public_field_must_have_tag",
+			config: struct {
+				PublicFieldWithoutMapstructureTag string
+			}{},
+			wantErrMsgSubStr: "mapstructure tag not present on field \"PublicFieldWithoutMapstructureTag\"",
+		},
+		{
+			name: "invalid_map_item",
+			config: struct {
+				Map map[string]BadConfigTag `mapstructure:"test_map"`
+			}{},
+			wantErrMsgSubStr: "field \"BadTagField\" has config tag \"test-dash\" which doesn't satisfy",
+		},
+		{
+			name: "invalid_slice_item",
+			config: struct {
+				Slice []BadConfigTag `mapstructure:"test_slice"`
+			}{},
+			wantErrMsgSubStr: "field \"BadTagField\" has config tag \"test-dash\" which doesn't satisfy",
+		},
+		{
+			name: "invalid_array_item",
+			config: struct {
+				Array [2]BadConfigTag `mapstructure:"test_array"`
+			}{},
+			wantErrMsgSubStr: "field \"BadTagField\" has config tag \"test-dash\" which doesn't satisfy",
+		},
+		{
+			name: "invalid_map_item_ptr",
+			config: struct {
+				Map map[string]*BadConfigTag `mapstructure:"test_map"`
+			}{},
+			wantErrMsgSubStr: "field \"BadTagField\" has config tag \"test-dash\" which doesn't satisfy",
+		},
+		{
+			name: "invalid_slice_item_ptr",
+			config: struct {
+				Slice []*BadConfigTag `mapstructure:"test_slice"`
+			}{},
+			wantErrMsgSubStr: "field \"BadTagField\" has config tag \"test-dash\" which doesn't satisfy",
+		},
+		{
+			name: "invalid_array_item_ptr",
+			config: struct {
+				Array [2]*BadConfigTag `mapstructure:"test_array"`
+			}{},
+			wantErrMsgSubStr: "field \"BadTagField\" has config tag \"test-dash\" which doesn't satisfy",
+		},
+		{
+			name: "valid_map_item",
+			config: struct {
+				Map map[string]int `mapstructure:"test_map"`
+			}{},
+		},
+		{
+			name: "valid_slice_item",
+			config: struct {
+				Slice []string `mapstructure:"test_slice"`
+			}{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateConfig(tt.config)
+			if tt.wantErrMsgSubStr == "" {
+				assert.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assert.True(t, strings.Contains(err.Error(), tt.wantErrMsgSubStr))
+			}
+		})
+	}
+}
+
+// badConfigExtensionFactory was created to force error path from factory returning
+// a config not satisfying the validation.
+type badConfigExtensionFactory struct{}
+
+var _ extension.Factory = (*badConfigExtensionFactory)(nil)
+
+func (b badConfigExtensionFactory) Type() string {
+	return "bad_config"
+}
+
+func (b badConfigExtensionFactory) CreateDefaultConfig() configmodels.Extension {
+	return &struct {
+		configmodels.ExtensionSettings
+		BadTagField int `mapstructure:"tag-with-dashes"`
+	}{}
+}
+
+func (b badConfigExtensionFactory) CreateExtension(
+	logger *zap.Logger,
+	cfg configmodels.Extension,
+) (extension.ServiceExtension, error) {
+	return nil, nil
+}

--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -44,7 +44,7 @@ import (
 )
 
 // Components returns the default set of components used by the
-// opentelemetry service
+// OpenTelemetry collector.
 func Components() (
 	config.Factories,
 	error,

--- a/exporter/factory.go
+++ b/exporter/factory.go
@@ -28,6 +28,12 @@ type Factory interface {
 	Type() string
 
 	// CreateDefaultConfig creates the default configuration for the Exporter.
+	// This method can be called multiple times depending on the pipeline
+	// configuration and should not cause side-effects that prevent the creation
+	// of multiple instances of the Exporter.
+	// The object returned by this method needs to pass the checks implemented by
+	// 'conifgcheck.ValidateConfig'. It is recommended to have such check in the
+	// tests of any implementation of the Factory interface.
 	CreateDefaultConfig() configmodels.Exporter
 
 	// CreateTraceExporter creates a trace exporter based on this config.

--- a/exporter/jaeger/jaegergrpcexporter/factory_test.go
+++ b/exporter/jaeger/jaegergrpcexporter/factory_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 
+	"github.com/open-telemetry/opentelemetry-collector/config/configcheck"
 	"github.com/open-telemetry/opentelemetry-collector/config/configerror"
 )
 
@@ -27,6 +28,7 @@ func TestCreateDefaultConfig(t *testing.T) {
 	factory := Factory{}
 	cfg := factory.CreateDefaultConfig()
 	assert.NotNil(t, cfg, "failed to create default config")
+	assert.NoError(t, configcheck.ValidateConfig(cfg))
 }
 
 func TestCreateMetricsExporter(t *testing.T) {

--- a/exporter/loggingexporter/factory_test.go
+++ b/exporter/loggingexporter/factory_test.go
@@ -19,12 +19,15 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector/config/configcheck"
 )
 
 func TestCreateDefaultConfig(t *testing.T) {
-	factory := &Factory{}
+	factory := Factory{}
 	cfg := factory.CreateDefaultConfig()
 	assert.NotNil(t, cfg, "failed to create default config")
+	assert.NoError(t, configcheck.ValidateConfig(cfg))
 }
 
 func TestCreateMetricsExporter(t *testing.T) {

--- a/exporter/opencensusexporter/factory_test.go
+++ b/exporter/opencensusexporter/factory_test.go
@@ -24,6 +24,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector/compression"
+	"github.com/open-telemetry/opentelemetry-collector/config/configcheck"
 	"github.com/open-telemetry/opentelemetry-collector/config/configgrpc"
 	"github.com/open-telemetry/opentelemetry-collector/exporter/exportertest"
 	"github.com/open-telemetry/opentelemetry-collector/internal/testutils"
@@ -35,6 +36,7 @@ func TestCreateDefaultConfig(t *testing.T) {
 	factory := Factory{}
 	cfg := factory.CreateDefaultConfig()
 	assert.NotNil(t, cfg, "failed to create default config")
+	assert.NoError(t, configcheck.ValidateConfig(cfg))
 }
 
 func TestCreateMetricsExporter(t *testing.T) {

--- a/exporter/prometheusexporter/factory_test.go
+++ b/exporter/prometheusexporter/factory_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
+	"github.com/open-telemetry/opentelemetry-collector/config/configcheck"
 	"github.com/open-telemetry/opentelemetry-collector/config/configerror"
 )
 
@@ -30,6 +31,7 @@ func TestCreateDefaultConfig(t *testing.T) {
 
 	cfg := factory.CreateDefaultConfig()
 	assert.NotNil(t, cfg, "failed to create default config")
+	assert.NoError(t, configcheck.ValidateConfig(cfg))
 }
 
 func TestCreateTraceExporter(t *testing.T) {

--- a/exporter/zipkinexporter/factory_test.go
+++ b/exporter/zipkinexporter/factory_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 
+	"github.com/open-telemetry/opentelemetry-collector/config/configcheck"
 	"github.com/open-telemetry/opentelemetry-collector/config/configerror"
 )
 
@@ -27,6 +28,7 @@ func TestCreateDefaultConfig(t *testing.T) {
 	factory := Factory{}
 	cfg := factory.CreateDefaultConfig()
 	assert.NotNil(t, cfg, "failed to create default config")
+	assert.NoError(t, configcheck.ValidateConfig(cfg))
 }
 
 func TestCreateMetricsExporter(t *testing.T) {

--- a/extension/factory.go
+++ b/extension/factory.go
@@ -27,7 +27,13 @@ type Factory interface {
 	// Type gets the type of the extension created by this factory.
 	Type() string
 
-	// CreateDefaultConfig creates the default configuration for the extension.
+	// CreateDefaultConfig creates the default configuration for the Extension.
+	// This method can be called multiple times depending on the pipeline
+	// configuration and should not cause side-effects that prevent the creation
+	// of multiple instances of the Extension.
+	// The object returned by this method needs to pass the checks implemented by
+	// 'conifgcheck.ValidateConfig'. It is recommended to have such check in the
+	// tests of any implementation of the Factory interface.
 	CreateDefaultConfig() configmodels.Extension
 
 	// CreateExtension creates a service extension based on the given config.

--- a/extension/healthcheckextension/factory_test.go
+++ b/extension/healthcheckextension/factory_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
+	"github.com/open-telemetry/opentelemetry-collector/config/configcheck"
 	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
 	"github.com/open-telemetry/opentelemetry-collector/internal/testutils"
 )
@@ -43,6 +44,7 @@ func TestFactory_CreateDefaultConfig(t *testing.T) {
 	},
 		cfg)
 
+	assert.NoError(t, configcheck.ValidateConfig(cfg))
 	ext, err := factory.CreateExtension(zap.NewNop(), cfg)
 	require.NoError(t, err)
 	require.NotNil(t, ext)

--- a/extension/pprofextension/factory_test.go
+++ b/extension/pprofextension/factory_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
+	"github.com/open-telemetry/opentelemetry-collector/config/configcheck"
 	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
 	"github.com/open-telemetry/opentelemetry-collector/internal/testutils"
 )
@@ -43,6 +44,7 @@ func TestFactory_CreateDefaultConfig(t *testing.T) {
 	},
 		cfg)
 
+	assert.NoError(t, configcheck.ValidateConfig(cfg))
 	ext, err := factory.CreateExtension(zap.NewNop(), cfg)
 	require.NoError(t, err)
 	require.NotNil(t, ext)

--- a/extension/zpagesextension/factory_test.go
+++ b/extension/zpagesextension/factory_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
+	"github.com/open-telemetry/opentelemetry-collector/config/configcheck"
 	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
 	"github.com/open-telemetry/opentelemetry-collector/internal/testutils"
 )
@@ -43,6 +44,7 @@ func TestFactory_CreateDefaultConfig(t *testing.T) {
 	},
 		cfg)
 
+	assert.NoError(t, configcheck.ValidateConfig(cfg))
 	ext, err := factory.CreateExtension(zap.NewNop(), cfg)
 	require.NoError(t, err)
 	require.NotNil(t, ext)

--- a/processor/attributesprocessor/factory_test.go
+++ b/processor/attributesprocessor/factory_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
+	"github.com/open-telemetry/opentelemetry-collector/config/configcheck"
 	"github.com/open-telemetry/opentelemetry-collector/config/configerror"
 	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
 	"github.com/open-telemetry/opentelemetry-collector/exporter/exportertest"
@@ -42,6 +43,7 @@ func TestFactory_CreateDefaultConfig(t *testing.T) {
 			TypeVal: typeStr,
 		},
 	})
+	assert.NoError(t, configcheck.ValidateConfig(cfg))
 }
 
 func TestFactory_CreateTraceProcessor(t *testing.T) {

--- a/processor/factory.go
+++ b/processor/factory.go
@@ -29,6 +29,12 @@ type Factory interface {
 	Type() string
 
 	// CreateDefaultConfig creates the default configuration for the Processor.
+	// This method can be called multiple times depending on the pipeline
+	// configuration and should not cause side-effects that prevent the creation
+	// of multiple instances of the Processor.
+	// The object returned by this method needs to pass the checks implemented by
+	// 'conifgcheck.ValidateConfig'. It is recommended to have such check in the
+	// tests of any implementation of the Factory interface.
 	CreateDefaultConfig() configmodels.Processor
 
 	// CreateTraceProcessor creates a trace processor based on this config.

--- a/processor/nodebatcherprocessor/factory_test.go
+++ b/processor/nodebatcherprocessor/factory_test.go
@@ -17,9 +17,10 @@ package nodebatcherprocessor
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/open-telemetry/opentelemetry-collector/config/configcheck"
 )
 
 func TestCreateDefaultConfig(t *testing.T) {
@@ -27,6 +28,7 @@ func TestCreateDefaultConfig(t *testing.T) {
 
 	cfg := factory.CreateDefaultConfig()
 	assert.NotNil(t, cfg, "failed to create default config")
+	assert.NoError(t, configcheck.ValidateConfig(cfg))
 }
 
 func TestCreateProcessor(t *testing.T) {

--- a/processor/probabilisticsamplerprocessor/factory_test.go
+++ b/processor/probabilisticsamplerprocessor/factory_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 
+	"github.com/open-telemetry/opentelemetry-collector/config/configcheck"
 	"github.com/open-telemetry/opentelemetry-collector/exporter/exportertest"
 )
 
@@ -28,6 +29,7 @@ func TestCreateDefaultConfig(t *testing.T) {
 
 	cfg := factory.CreateDefaultConfig()
 	assert.NotNil(t, cfg, "failed to create default config")
+	assert.NoError(t, configcheck.ValidateConfig(cfg))
 }
 
 func TestCreateProcessor(t *testing.T) {

--- a/processor/queuedprocessor/factory_test.go
+++ b/processor/queuedprocessor/factory_test.go
@@ -17,15 +17,17 @@ package queuedprocessor
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/open-telemetry/opentelemetry-collector/config/configcheck"
 )
 
 func TestCreateDefaultConfig(t *testing.T) {
 	factory := &Factory{}
 	cfg := factory.CreateDefaultConfig()
 	assert.NotNil(t, cfg, "failed to create default config")
+	assert.NoError(t, configcheck.ValidateConfig(cfg))
 }
 
 func TestCreateProcessor(t *testing.T) {

--- a/processor/spanprocessor/factory_test.go
+++ b/processor/spanprocessor/factory_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
+	"github.com/open-telemetry/opentelemetry-collector/config/configcheck"
 	"github.com/open-telemetry/opentelemetry-collector/config/configerror"
 	"github.com/open-telemetry/opentelemetry-collector/exporter/exportertest"
 )
@@ -33,6 +34,7 @@ func TestFactory_Type(t *testing.T) {
 func TestFactory_CreateDefaultConfig(t *testing.T) {
 	factory := &Factory{}
 	cfg := factory.CreateDefaultConfig()
+	assert.NoError(t, configcheck.ValidateConfig(cfg))
 
 	// Check the values of the default configuration.
 	assert.NotNil(t, cfg)

--- a/processor/tailsamplingprocessor/factory_test.go
+++ b/processor/tailsamplingprocessor/factory_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 
+	"github.com/open-telemetry/opentelemetry-collector/config/configcheck"
 	"github.com/open-telemetry/opentelemetry-collector/exporter/exportertest"
 )
 
@@ -28,6 +29,7 @@ func TestCreateDefaultConfig(t *testing.T) {
 
 	cfg := factory.CreateDefaultConfig()
 	assert.NotNil(t, cfg, "failed to create default config")
+	assert.NoError(t, configcheck.ValidateConfig(cfg))
 }
 
 func TestCreateProcessor(t *testing.T) {

--- a/receiver/factory.go
+++ b/receiver/factory.go
@@ -31,6 +31,12 @@ type Factory interface {
 	Type() string
 
 	// CreateDefaultConfig creates the default configuration for the Receiver.
+	// This method can be called multiple times depending on the pipeline
+	// configuration and should not cause side-effects that prevent the creation
+	// of multiple instances of the Receiver.
+	// The object returned by this method needs to pass the checks implemented by
+	// 'conifgcheck.ValidateConfig'. It is recommended to have such check in the
+	// tests of any implementation of the Factory interface.
 	CreateDefaultConfig() configmodels.Receiver
 
 	// CustomUnmarshaler returns a custom unmarshaler for the configuration or nil if

--- a/receiver/jaegerreceiver/factory_test.go
+++ b/receiver/jaegerreceiver/factory_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 
+	"github.com/open-telemetry/opentelemetry-collector/config/configcheck"
 	"github.com/open-telemetry/opentelemetry-collector/config/configerror"
 )
 
@@ -28,6 +29,7 @@ func TestCreateDefaultConfig(t *testing.T) {
 	factory := Factory{}
 	cfg := factory.CreateDefaultConfig()
 	assert.NotNil(t, cfg, "failed to create default config")
+	assert.NoError(t, configcheck.ValidateConfig(cfg))
 }
 
 func TestCreateReceiver(t *testing.T) {

--- a/receiver/opencensusreceiver/factory_test.go
+++ b/receiver/opencensusreceiver/factory_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 
+	"github.com/open-telemetry/opentelemetry-collector/config/configcheck"
 	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
 	"github.com/open-telemetry/opentelemetry-collector/exporter/exportertest"
 	"github.com/open-telemetry/opentelemetry-collector/internal/testutils"
@@ -33,6 +34,7 @@ func TestCreateDefaultConfig(t *testing.T) {
 	factory := Factory{}
 	cfg := factory.CreateDefaultConfig()
 	assert.NotNil(t, cfg, "failed to create default config")
+	assert.NoError(t, configcheck.ValidateConfig(cfg))
 }
 
 func TestCreateReceiver(t *testing.T) {

--- a/receiver/prometheusreceiver/factory_test.go
+++ b/receiver/prometheusreceiver/factory_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 
+	"github.com/open-telemetry/opentelemetry-collector/config/configcheck"
 	"github.com/open-telemetry/opentelemetry-collector/config/configerror"
 )
 
@@ -28,6 +29,7 @@ func TestCreateDefaultConfig(t *testing.T) {
 	factory := &Factory{}
 	cfg := factory.CreateDefaultConfig()
 	assert.NotNil(t, cfg, "failed to create default config")
+	assert.NoError(t, configcheck.ValidateConfig(cfg))
 }
 
 func TestCreateReceiver(t *testing.T) {

--- a/receiver/vmmetricsreceiver/factory_test.go
+++ b/receiver/vmmetricsreceiver/factory_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
+	"github.com/open-telemetry/opentelemetry-collector/config/configcheck"
 	"github.com/open-telemetry/opentelemetry-collector/config/configerror"
 )
 
@@ -30,6 +31,7 @@ func TestCreateDefaultConfig(t *testing.T) {
 	factory := &Factory{}
 	cfg := factory.CreateDefaultConfig()
 	assert.NotNil(t, cfg, "failed to create default config")
+	assert.NoError(t, configcheck.ValidateConfig(cfg))
 }
 
 func TestCreateReceiver(t *testing.T) {

--- a/receiver/zipkinreceiver/factory_test.go
+++ b/receiver/zipkinreceiver/factory_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/open-telemetry/opentelemetry-collector/config/configcheck"
 	"github.com/open-telemetry/opentelemetry-collector/config/configerror"
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
 )
@@ -30,6 +31,7 @@ func TestCreateDefaultConfig(t *testing.T) {
 	factory := &Factory{}
 	cfg := factory.CreateDefaultConfig()
 	assert.NotNil(t, cfg, "failed to create default config")
+	assert.NoError(t, configcheck.ValidateConfig(cfg))
 }
 
 type mockTraceConsumer struct {

--- a/service/service.go
+++ b/service/service.go
@@ -31,6 +31,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector/config"
+	"github.com/open-telemetry/opentelemetry-collector/config/configcheck"
 	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
 	"github.com/open-telemetry/opentelemetry-collector/extension"
 	"github.com/open-telemetry/opentelemetry-collector/receiver"
@@ -68,17 +69,15 @@ func (app *Application) Context() context.Context {
 	return context.Background()
 }
 
-// ReportFatalError is used to report to the host that the receiver encountered
-// a fatal error (i.e.: an error that the instance can't recover from) after
-// its start function has already returned.
-func (app *Application) ReportFatalError(err error) {
-	app.asyncErrorChannel <- err
-}
-
 // New creates and returns a new instance of Application.
 func New(
 	factories config.Factories,
-) *Application {
+) (*Application, error) {
+
+	if err := configcheck.ValidateConfigFromFactories(factories); err != nil {
+		return nil, err
+	}
+
 	app := &Application{
 		v:         viper.New(),
 		readyChan: make(chan struct{}),
@@ -108,7 +107,14 @@ func New(
 
 	app.rootCmd = rootCmd
 
-	return app
+	return app, nil
+}
+
+// ReportFatalError is used to report to the host that the receiver encountered
+// a fatal error (i.e.: an error that the instance can't recover from) after
+// its start function has already returned.
+func (app *Application) ReportFatalError(err error) {
+	app.asyncErrorChannel <- err
 }
 
 func (app *Application) init() {

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector/config"
@@ -32,9 +33,10 @@ import (
 
 func TestApplication_Start(t *testing.T) {
 	factories, err := defaults.Components()
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
-	app := New(factories)
+	app, err := New(factories)
+	require.NoError(t, err)
 
 	metricsPort := testutils.GetAvailablePort(t)
 	app.rootCmd.SetArgs([]string{


### PR DESCRIPTION
Adds a validation via reflection that checks if the 'mapstructure' tags are following the desired naming conventions desired for the config file. This becomes a runtime validation so even if not properly tested by some component the inconsistency is captured.

Fixes #359