### PR TITLE
Account for dropped timeseries in the Prometheus metrics adjuster

### DIFF
--- a/receiver/prometheusreceiver/internal/metrics_adjuster_test.go
+++ b/receiver/prometheusreceiver/internal/metrics_adjuster_test.go
@@ -15,13 +15,13 @@
 package internal
 
 import (
-	"reflect"
 	"testing"
 	"time"
 
 	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
 	"github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/golang/protobuf/ptypes/wrappers"
+	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 )
 
@@ -242,7 +242,7 @@ func Test_tsGC(t *testing.T) {
 	}}
 
 	script2 := []*metricsAdjusterTest{{
-		"TsGC: round 2 -  metrics first timeseries adjusted based on round 2, second timeseries not updated",
+		"TsGC: round 2 - metrics first timeseries adjusted based on round 2, second timeseries not updated",
 		[]*metricspb.Metric{
 			cumulative(k1k2, timeseries(2, v1v2, double(2, 88))),
 			cumulativeDist(k1k2, timeseries(2, v1v2, dist(2, bounds0, []int64{8, 7, 9, 14}))),
@@ -296,7 +296,7 @@ func Test_jobGC(t *testing.T) {
 	}}
 
 	job1Script2 := []*metricsAdjusterTest{{
-		"JobGC: job 1, round 2- metrics timeseries empty due to job-level gc",
+		"JobGC: job 1, round 2 - metrics timeseries empty due to job-level gc",
 		[]*metricspb.Metric{
 			cumulative(k1k2, timeseries(4, v1v2, double(4, 99)), timeseries(4, v10v20, double(4, 80))),
 			cumulativeDist(k1k2, timeseries(4, v1v2, dist(4, bounds0, []int64{9, 8, 10, 15})), timeseries(4, v10v20, dist(4, bounds0, []int64{55, 66, 33, 77}))),
@@ -357,16 +357,10 @@ func runScript(t *testing.T, tsm *timeseriesMap, script []*metricsAdjusterTest) 
 	ma := NewMetricsAdjuster(tsm, l.Sugar())
 
 	for _, test := range script {
-		wantDropped := test.dropped()
+		expectedDropped := test.dropped()
 		adjusted, dropped := ma.AdjustMetrics(test.metrics)
-		if !reflect.DeepEqual(test.adjusted, adjusted) {
-			t.Errorf("Error: %v - Adjusted: want: %v, got %v", test.description, test.adjusted, adjusted)
-			break
-		}
-		if wantDropped != dropped {
-			t.Errorf("Error: %v - Dropped: want: %v, got: %v", test.description, wantDropped, dropped)
-			break
-		}
+		assert.EqualValuesf(t, test.adjusted, adjusted, "Test: %v - expected: %v, actual: %v", test.description, test.adjusted, adjusted)
+		assert.Equalf(t, expectedDropped, dropped, "Test: %v", test.description)
 	}
 }
 

--- a/receiver/prometheusreceiver/internal/transaction.go
+++ b/receiver/prometheusreceiver/internal/transaction.go
@@ -142,8 +142,11 @@ func (tr *transaction) Commit() error {
 	}
 	// Note: metrics could be empty after adjustment, which needs to be checked before passing it on to ConsumeMetricsData()
 	if tr.jobsMap != nil {
-		metrics = NewMetricsAdjuster(tr.jobsMap.get(tr.job, tr.instance), tr.logger).AdjustMetrics(metrics)
+		dropped := 0
+		metrics, dropped = NewMetricsAdjuster(tr.jobsMap.get(tr.job, tr.instance), tr.logger).AdjustMetrics(metrics)
+		droppedTimeseries += dropped
 	}
+	observability.RecordMetricsForMetricsReceiver(tr.ctx, numTimeseries, droppedTimeseries)
 	if len(metrics) > 0 {
 		md := consumerdata.MetricsData{
 			Node:    tr.node,


### PR DESCRIPTION
The Prometheus receiver does not currently account for timeseries dropped by the metrics adjuster, this code change adds support for doing so.

One question is whether timeseries dropped by the metrics adjuster should contribute to overall dropped timeseries or should be removed from received timeseries. I went with the former because, if there were an issue with the metrics adjuster, it would be useful to see the actual number of timeseries received.