### PR TITLE
fixing policy names in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,16 +332,16 @@ sampling:
       # exporters the policy applies to
       exporters:
         - jaeger
-      policy: string_attribute_filter
+      policy: string_attribute
       configuration:
         key: key1
         values:
           - value1
           - value2
-    my-numeric_attribute-filter:
+    my_numeric_attribute_filter:
       exporters:
         - zipkin
-      policy: numeric_attribute-filter
+      policy: numeric_attribute
       configuration:
         key: key1
         min_value: 0


### PR DESCRIPTION
This relates to issue #226 since I couldn't find the mentioned policy.