### PR TITLE
Add support for Prometheus' start time metric

### DIFF
--- a/receiver/prometheusreceiver/config.go
+++ b/receiver/prometheusreceiver/config.go
@@ -28,6 +28,7 @@ type Config struct {
 	PrometheusConfig              *config.Config      `mapstructure:"-"`
 	BufferPeriod                  time.Duration       `mapstructure:"buffer_period"`
 	BufferCount                   int                 `mapstructure:"buffer_count"`
+	UseStartTimeMetric            bool                `mapstructure:"use_start_time_metric"`
 	IncludeFilter                 map[string][]string `mapstructure:"include_filter"`
 
 	// ConfigPlaceholder is just an entry to make the configuration pass a check

--- a/receiver/prometheusreceiver/config_test.go
+++ b/receiver/prometheusreceiver/config_test.go
@@ -51,6 +51,7 @@ func TestLoadConfig(t *testing.T) {
 		})
 	assert.Equal(t, r1.PrometheusConfig.ScrapeConfigs[0].JobName, "demo")
 	assert.Equal(t, time.Duration(r1.PrometheusConfig.ScrapeConfigs[0].ScrapeInterval), 5*time.Second)
+	assert.Equal(t, r1.UseStartTimeMetric, true)
 	wantFilter := map[string][]string{
 		"localhost:9777": {"http/server/server_latency", "custom_metric1"},
 		"localhost:9778": {"http/client/roundtrip_latency"},

--- a/receiver/prometheusreceiver/internal/metricsbuilder.go
+++ b/receiver/prometheusreceiver/internal/metricsbuilder.go
@@ -32,6 +32,7 @@ import (
 const metricsSuffixCount = "_count"
 const metricsSuffixBucket = "_bucket"
 const metricsSuffixSum = "_sum"
+const startTimeMetricName = "process_start_time_seconds"
 
 var trimmableSuffixes = []string{metricsSuffixBucket, metricsSuffixCount, metricsSuffixSum}
 var errNoDataToBuild = errors.New("there's no data to build")
@@ -81,7 +82,7 @@ func (b *metricBuilder) AddDataPoint(ls labels.Labels, t int64, v float64) error
 		delete(lm, model.MetricNameLabel)
 		b.logger.Debugw("skip internal metric", "name", metricName, "ts", t, "value", v, "labels", lm)
 		return nil
-	} else if b.useStartTimeMetric && metricName == "process_start_time_seconds" {
+	} else if b.useStartTimeMetric && metricName == startTimeMetricName {
 		b.startTime = v
 		return nil
 	}

--- a/receiver/prometheusreceiver/internal/metricsbuilder_test.go
+++ b/receiver/prometheusreceiver/internal/metricsbuilder_test.go
@@ -95,7 +95,7 @@ func runBuilderTests(t *testing.T, tests []buildTestData) {
 			mc := newMockMetadataCache(testMetadata)
 			st := startTs
 			for i, page := range tt.inputs {
-				b := newMetricBuilder(mc, testLogger)
+				b := newMetricBuilder(mc, false, testLogger)
 				for _, pt := range page.pts {
 					// set ts for testing
 					pt.t = st
@@ -1068,7 +1068,7 @@ func Test_metricBuilder_skipped(t *testing.T) {
 func Test_metricBuilder_baddata(t *testing.T) {
 	t.Run("empty-metric-name", func(t *testing.T) {
 		mc := newMockMetadataCache(testMetadata)
-		b := newMetricBuilder(mc, testLogger)
+		b := newMetricBuilder(mc, false, testLogger)
 		if err := b.AddDataPoint(labels.FromStrings("a", "b"), startTs, 123); err != errMetricNameNotFound {
 			t.Error("expecting errMetricNameNotFound error, but get nil")
 			return
@@ -1081,7 +1081,7 @@ func Test_metricBuilder_baddata(t *testing.T) {
 
 	t.Run("histogram-datapoint-no-bucket-label", func(t *testing.T) {
 		mc := newMockMetadataCache(testMetadata)
-		b := newMetricBuilder(mc, testLogger)
+		b := newMetricBuilder(mc, false, testLogger)
 		if err := b.AddDataPoint(createLabels("hist_test", "k", "v"), startTs, 123); err != errEmptyBoundaryLabel {
 			t.Error("expecting errEmptyBoundaryLabel error, but get nil")
 		}
@@ -1089,7 +1089,7 @@ func Test_metricBuilder_baddata(t *testing.T) {
 
 	t.Run("summary-datapoint-no-quantile-label", func(t *testing.T) {
 		mc := newMockMetadataCache(testMetadata)
-		b := newMetricBuilder(mc, testLogger)
+		b := newMetricBuilder(mc, false, testLogger)
 		if err := b.AddDataPoint(createLabels("summary_test", "k", "v"), startTs, 123); err != errEmptyBoundaryLabel {
 			t.Error("expecting errEmptyBoundaryLabel error, but get nil")
 		}

--- a/receiver/prometheusreceiver/internal/metricsbuilder_test.go
+++ b/receiver/prometheusreceiver/internal/metricsbuilder_test.go
@@ -95,7 +95,8 @@ func runBuilderTests(t *testing.T, tests []buildTestData) {
 			mc := newMockMetadataCache(testMetadata)
 			st := startTs
 			for i, page := range tt.inputs {
-				b := newMetricBuilder(mc, false, testLogger)
+				b := newMetricBuilder(mc, true, testLogger)
+				b.startTime = 1.0 // set to a non-zero value
 				for _, pt := range page.pts {
 					// set ts for testing
 					pt.t = st
@@ -1068,7 +1069,8 @@ func Test_metricBuilder_skipped(t *testing.T) {
 func Test_metricBuilder_baddata(t *testing.T) {
 	t.Run("empty-metric-name", func(t *testing.T) {
 		mc := newMockMetadataCache(testMetadata)
-		b := newMetricBuilder(mc, false, testLogger)
+		b := newMetricBuilder(mc, true, testLogger)
+		b.startTime = 1.0 // set to a non-zero value
 		if err := b.AddDataPoint(labels.FromStrings("a", "b"), startTs, 123); err != errMetricNameNotFound {
 			t.Error("expecting errMetricNameNotFound error, but get nil")
 			return
@@ -1081,7 +1083,8 @@ func Test_metricBuilder_baddata(t *testing.T) {
 
 	t.Run("histogram-datapoint-no-bucket-label", func(t *testing.T) {
 		mc := newMockMetadataCache(testMetadata)
-		b := newMetricBuilder(mc, false, testLogger)
+		b := newMetricBuilder(mc, true, testLogger)
+		b.startTime = 1.0 // set to a non-zero value
 		if err := b.AddDataPoint(createLabels("hist_test", "k", "v"), startTs, 123); err != errEmptyBoundaryLabel {
 			t.Error("expecting errEmptyBoundaryLabel error, but get nil")
 		}
@@ -1089,7 +1092,8 @@ func Test_metricBuilder_baddata(t *testing.T) {
 
 	t.Run("summary-datapoint-no-quantile-label", func(t *testing.T) {
 		mc := newMockMetadataCache(testMetadata)
-		b := newMetricBuilder(mc, false, testLogger)
+		b := newMetricBuilder(mc, true, testLogger)
+		b.startTime = 1.0 // set to a non-zero value
 		if err := b.AddDataPoint(createLabels("summary_test", "k", "v"), startTs, 123); err != errEmptyBoundaryLabel {
 			t.Error("expecting errEmptyBoundaryLabel error, but get nil")
 		}

--- a/receiver/prometheusreceiver/internal/ocastore_test.go
+++ b/receiver/prometheusreceiver/internal/ocastore_test.go
@@ -24,7 +24,7 @@ import (
 
 func TestOcaStore(t *testing.T) {
 
-	o := NewOcaStore(context.Background(), nil, nil, nil)
+	o := NewOcaStore(context.Background(), nil, nil, nil, false)
 
 	_, err := o.Appender()
 	if err == nil {

--- a/receiver/prometheusreceiver/internal/transaction.go
+++ b/receiver/prometheusreceiver/internal/transaction.go
@@ -175,7 +175,6 @@ func (tr *transaction) Rollback() error {
 func adjustStartTime(startTime float64, metrics []*metricspb.Metric) {
 	startTimeTs := timestampFromFloat64(startTime)
 	for _, metric := range metrics {
-		// should we skip the check and just update gauges too?
 		switch metric.GetMetricDescriptor().GetType() {
 		case metricspb.MetricDescriptor_GAUGE_DOUBLE, metricspb.MetricDescriptor_GAUGE_DISTRIBUTION:
 			continue

--- a/receiver/prometheusreceiver/internal/transaction.go
+++ b/receiver/prometheusreceiver/internal/transaction.go
@@ -22,6 +22,8 @@ import (
 	"sync/atomic"
 
 	commonpb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
+	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
+	"github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/storage"
@@ -48,28 +50,30 @@ var errNoJobInstance = errors.New("job or instance cannot be found from labels")
 // will be flush to the downstream consumer, or Rollback, which means discard all the data, is called and all data
 // points are discarded.
 type transaction struct {
-	id            int64
-	ctx           context.Context
-	isNew         bool
-	sink          consumer.MetricsConsumer
-	job           string
-	instance      string
-	jobsMap       *JobsMap
-	ms            MetadataService
-	node          *commonpb.Node
-	metricBuilder *metricBuilder
-	logger        *zap.SugaredLogger
+	id                 int64
+	ctx                context.Context
+	isNew              bool
+	sink               consumer.MetricsConsumer
+	job                string
+	instance           string
+	jobsMap            *JobsMap
+	useStartTimeMetric bool
+	ms                 MetadataService
+	node               *commonpb.Node
+	metricBuilder      *metricBuilder
+	logger             *zap.SugaredLogger
 }
 
-func newTransaction(ctx context.Context, jobsMap *JobsMap, ms MetadataService, sink consumer.MetricsConsumer, logger *zap.SugaredLogger) *transaction {
+func newTransaction(ctx context.Context, jobsMap *JobsMap, useStartTimeMetric bool, ms MetadataService, sink consumer.MetricsConsumer, logger *zap.SugaredLogger) *transaction {
 	return &transaction{
-		id:      atomic.AddInt64(&idSeq, 1),
-		ctx:     ctx,
-		isNew:   true,
-		sink:    sink,
-		jobsMap: jobsMap,
-		ms:      ms,
-		logger:  logger,
+		id:                 atomic.AddInt64(&idSeq, 1),
+		ctx:                ctx,
+		isNew:              true,
+		sink:               sink,
+		jobsMap:            jobsMap,
+		useStartTimeMetric: useStartTimeMetric,
+		ms:                 ms,
+		logger:             logger,
 	}
 }
 
@@ -122,7 +126,7 @@ func (tr *transaction) initTransaction(ls labels.Labels) error {
 		tr.instance = instance
 	}
 	tr.node = createNode(job, instance, mc.SharedLabels().Get(model.SchemeLabel))
-	tr.metricBuilder = newMetricBuilder(mc, tr.logger)
+	tr.metricBuilder = newMetricBuilder(mc, tr.useStartTimeMetric, tr.logger)
 	tr.isNew = false
 	return nil
 }
@@ -145,6 +149,13 @@ func (tr *transaction) Commit() error {
 		dropped := 0
 		metrics, dropped = NewMetricsAdjuster(tr.jobsMap.get(tr.job, tr.instance), tr.logger).AdjustMetrics(metrics)
 		droppedTimeseries += dropped
+	} else if tr.useStartTimeMetric {
+		if tr.metricBuilder.startTime == 0.0 {
+			metrics = []*metricspb.Metric{}
+			droppedTimeseries = numTimeseries
+		} else {
+			adjustStartTime(tr.metricBuilder.startTime, metrics)
+		}
 	}
 	observability.RecordMetricsForMetricsReceiver(tr.ctx, numTimeseries, droppedTimeseries)
 	if len(metrics) > 0 {
@@ -159,6 +170,30 @@ func (tr *transaction) Commit() error {
 
 func (tr *transaction) Rollback() error {
 	return nil
+}
+
+func adjustStartTime(startTime float64, metrics []*metricspb.Metric) {
+	startTimeTs := timestampFromFloat64(startTime)
+	for _, metric := range metrics {
+		// should we skip the check and just update gauges too?
+		switch metric.GetMetricDescriptor().GetType() {
+		case metricspb.MetricDescriptor_GAUGE_DOUBLE, metricspb.MetricDescriptor_GAUGE_DISTRIBUTION:
+			continue
+		default:
+			for _, ts := range metric.GetTimeseries() {
+				ts.StartTimestamp = startTimeTs
+			}
+		}
+	}
+}
+
+func timestampFromFloat64(ts float64) *timestamp.Timestamp {
+	secs := int64(ts)
+	nanos := int64((ts - float64(secs)) * 1e9)
+	return &timestamp.Timestamp{
+		Seconds: secs,
+		Nanos:   int32(nanos),
+	}
 }
 
 func createNode(job, instance, scheme string) *commonpb.Node {

--- a/receiver/prometheusreceiver/internal/transaction_test.go
+++ b/receiver/prometheusreceiver/internal/transaction_test.go
@@ -34,7 +34,7 @@ func Test_transaction(t *testing.T) {
 
 	t.Run("Commit Without Adding", func(t *testing.T) {
 		mcon := newMockConsumer()
-		tr := newTransaction(context.Background(), nil, ms, mcon, testLogger)
+		tr := newTransaction(context.Background(), nil, false, ms, mcon, testLogger)
 		if got := tr.Commit(); got != nil {
 			t.Errorf("expecting nil from Commit() but got err %v", got)
 		}
@@ -42,7 +42,7 @@ func Test_transaction(t *testing.T) {
 
 	t.Run("Rollback dose nothing", func(t *testing.T) {
 		mcon := newMockConsumer()
-		tr := newTransaction(context.Background(), nil, ms, mcon, testLogger)
+		tr := newTransaction(context.Background(), nil, false, ms, mcon, testLogger)
 		if got := tr.Rollback(); got != nil {
 			t.Errorf("expecting nil from Rollback() but got err %v", got)
 		}
@@ -51,7 +51,7 @@ func Test_transaction(t *testing.T) {
 	badLabels := labels.Labels([]labels.Label{{Name: "foo", Value: "bar"}})
 	t.Run("Add One No Target", func(t *testing.T) {
 		mcon := newMockConsumer()
-		tr := newTransaction(context.Background(), nil, ms, mcon, testLogger)
+		tr := newTransaction(context.Background(), nil, false, ms, mcon, testLogger)
 		if _, got := tr.Add(badLabels, time.Now().Unix()*1000, 1.0); got == nil {
 			t.Errorf("expecting error from Add() but got nil")
 		}
@@ -63,7 +63,7 @@ func Test_transaction(t *testing.T) {
 		{Name: "foo", Value: "bar"}})
 	t.Run("Add One Job not found", func(t *testing.T) {
 		mcon := newMockConsumer()
-		tr := newTransaction(context.Background(), nil, ms, mcon, testLogger)
+		tr := newTransaction(context.Background(), nil, false, ms, mcon, testLogger)
 		if _, got := tr.Add(jobNotFoundLb, time.Now().Unix()*1000, 1.0); got == nil {
 			t.Errorf("expecting error from Add() but got nil")
 		}
@@ -74,7 +74,7 @@ func Test_transaction(t *testing.T) {
 		{Name: "__name__", Value: "foo"}})
 	t.Run("Add One Good", func(t *testing.T) {
 		mcon := newMockConsumer()
-		tr := newTransaction(context.Background(), nil, ms, mcon, testLogger)
+		tr := newTransaction(context.Background(), nil, false, ms, mcon, testLogger)
 		if _, got := tr.Add(goodLabels, time.Now().Unix()*1000, 1.0); got != nil {
 			t.Errorf("expecting error == nil from Add() but got: %v\n", got)
 		}
@@ -95,7 +95,7 @@ func Test_transaction(t *testing.T) {
 
 	t.Run("Drop NaN value", func(t *testing.T) {
 		mcon := newMockConsumer()
-		tr := newTransaction(context.Background(), nil, ms, mcon, testLogger)
+		tr := newTransaction(context.Background(), nil, false, ms, mcon, testLogger)
 		if _, got := tr.Add(goodLabels, time.Now().Unix()*1000, math.NaN()); got != nil {
 			t.Errorf("expecting error == nil from Add() but got: %v\n", got)
 		}

--- a/receiver/prometheusreceiver/internal/transaction_test.go
+++ b/receiver/prometheusreceiver/internal/transaction_test.go
@@ -34,7 +34,7 @@ func Test_transaction(t *testing.T) {
 
 	t.Run("Commit Without Adding", func(t *testing.T) {
 		mcon := newMockConsumer()
-		tr := newTransaction(context.Background(), nil, false, ms, mcon, testLogger)
+		tr := newTransaction(context.Background(), nil, true, ms, mcon, testLogger)
 		if got := tr.Commit(); got != nil {
 			t.Errorf("expecting nil from Commit() but got err %v", got)
 		}
@@ -42,7 +42,7 @@ func Test_transaction(t *testing.T) {
 
 	t.Run("Rollback dose nothing", func(t *testing.T) {
 		mcon := newMockConsumer()
-		tr := newTransaction(context.Background(), nil, false, ms, mcon, testLogger)
+		tr := newTransaction(context.Background(), nil, true, ms, mcon, testLogger)
 		if got := tr.Rollback(); got != nil {
 			t.Errorf("expecting nil from Rollback() but got err %v", got)
 		}
@@ -51,7 +51,7 @@ func Test_transaction(t *testing.T) {
 	badLabels := labels.Labels([]labels.Label{{Name: "foo", Value: "bar"}})
 	t.Run("Add One No Target", func(t *testing.T) {
 		mcon := newMockConsumer()
-		tr := newTransaction(context.Background(), nil, false, ms, mcon, testLogger)
+		tr := newTransaction(context.Background(), nil, true, ms, mcon, testLogger)
 		if _, got := tr.Add(badLabels, time.Now().Unix()*1000, 1.0); got == nil {
 			t.Errorf("expecting error from Add() but got nil")
 		}
@@ -63,7 +63,7 @@ func Test_transaction(t *testing.T) {
 		{Name: "foo", Value: "bar"}})
 	t.Run("Add One Job not found", func(t *testing.T) {
 		mcon := newMockConsumer()
-		tr := newTransaction(context.Background(), nil, false, ms, mcon, testLogger)
+		tr := newTransaction(context.Background(), nil, true, ms, mcon, testLogger)
 		if _, got := tr.Add(jobNotFoundLb, time.Now().Unix()*1000, 1.0); got == nil {
 			t.Errorf("expecting error from Add() but got nil")
 		}
@@ -74,14 +74,14 @@ func Test_transaction(t *testing.T) {
 		{Name: "__name__", Value: "foo"}})
 	t.Run("Add One Good", func(t *testing.T) {
 		mcon := newMockConsumer()
-		tr := newTransaction(context.Background(), nil, false, ms, mcon, testLogger)
+		tr := newTransaction(context.Background(), nil, true, ms, mcon, testLogger)
 		if _, got := tr.Add(goodLabels, time.Now().Unix()*1000, 1.0); got != nil {
 			t.Errorf("expecting error == nil from Add() but got: %v\n", got)
 		}
+		tr.metricBuilder.startTime = 1.0 // set to a non-zero value
 		if got := tr.Commit(); got != nil {
 			t.Errorf("expecting nil from Commit() but got err %v", got)
 		}
-
 		expected := createNode("test", "localhost:8080", "http")
 		md := mcon.md
 		if !reflect.DeepEqual(md.Node, expected) {
@@ -95,7 +95,7 @@ func Test_transaction(t *testing.T) {
 
 	t.Run("Drop NaN value", func(t *testing.T) {
 		mcon := newMockConsumer()
-		tr := newTransaction(context.Background(), nil, false, ms, mcon, testLogger)
+		tr := newTransaction(context.Background(), nil, true, ms, mcon, testLogger)
 		if _, got := tr.Add(goodLabels, time.Now().Unix()*1000, math.NaN()); got != nil {
 			t.Errorf("expecting error == nil from Add() but got: %v\n", got)
 		}

--- a/receiver/prometheusreceiver/metrics_receiver.go
+++ b/receiver/prometheusreceiver/metrics_receiver.go
@@ -87,8 +87,11 @@ func (pr *Preceiver) StartMetricsReception(host receiver.Host) error {
 		pr.cancel = cancel
 		// TODO: Use the name from the ReceiverSettings
 		c = observability.ContextWithReceiverName(c, pr.receiverFullName)
-		jobsMap := internal.NewJobsMap(time.Duration(2 * time.Minute))
-		app := internal.NewOcaStore(c, pr.consumer, pr.logger.Sugar(), jobsMap)
+		var jobsMap *internal.JobsMap
+		if !pr.cfg.UseStartTimeMetric {
+			jobsMap = internal.NewJobsMap(time.Duration(2 * time.Minute))
+		}
+		app := internal.NewOcaStore(c, pr.consumer, pr.logger.Sugar(), jobsMap, pr.cfg.UseStartTimeMetric)
 		// need to use a logger with the gokitLog interface
 		l := internal.NewZapToGokitLogAdapter(pr.logger)
 		scrapeManager := scrape.NewManager(l, app)

--- a/receiver/prometheusreceiver/metrics_receiver_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_test.go
@@ -967,7 +967,7 @@ func TestEndToEnd(t *testing.T) {
 		},
 	}
 
-        testEndToEnd(t, targets, false)
+	testEndToEnd(t, targets, false)
 }
 
 var startTimeMetricPage = `

--- a/receiver/prometheusreceiver/metrics_receiver_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_test.go
@@ -29,9 +29,12 @@ import (
 
 	commonpb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
 	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
+	timestamppb "github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/google/go-cmp/cmp"
 	promcfg "github.com/prometheus/prometheus/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	"gopkg.in/yaml.v2"
 
@@ -40,7 +43,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector/receiver/receivertest"
 )
 
-var logger, _ = zap.NewDevelopment()
+var logger = zap.NewNop()
 
 type mockPrometheusResponse struct {
 	code int
@@ -930,7 +933,7 @@ func verifyTarget3(t *testing.T, td *testData, mds []consumerdata.MetricsData) {
 
 // TestEndToEnd  end to end test executor
 func TestEndToEnd(t *testing.T) {
-	// 1. setup input data and mock server
+	// 1. setup input data
 	targets := []*testData{
 		{
 			name: "target1",
@@ -964,20 +967,86 @@ func TestEndToEnd(t *testing.T) {
 		},
 	}
 
-	mp, cfg, err := setupMockPrometheus(targets...)
-	if err != nil {
-		t.Fatalf("Failed to create Promtheus config: %v", err)
+        testEndToEnd(t, targets, false)
+}
+
+var startTimeMetricPage = `
+# HELP go_threads Number of OS threads created
+# TYPE go_threads gauge
+go_threads 19
+# HELP http_requests_total The total number of HTTP requests.
+# TYPE http_requests_total counter
+http_requests_total{method="post",code="200"} 100
+http_requests_total{method="post",code="400"} 5
+# HELP http_request_duration_seconds A histogram of the request duration.
+# TYPE http_request_duration_seconds histogram
+http_request_duration_seconds_bucket{le="0.05"} 1000
+http_request_duration_seconds_bucket{le="0.5"} 1500
+http_request_duration_seconds_bucket{le="1"} 2000
+http_request_duration_seconds_bucket{le="+Inf"} 2500
+http_request_duration_seconds_sum 5000
+http_request_duration_seconds_count 2500
+# HELP rpc_duration_seconds A summary of the RPC duration in seconds.
+# TYPE rpc_duration_seconds summary
+rpc_duration_seconds{quantile="0.01"} 1
+rpc_duration_seconds{quantile="0.9"} 5
+rpc_duration_seconds{quantile="0.99"} 8
+rpc_duration_seconds_sum 5000
+rpc_duration_seconds_count 1000
+# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
+# TYPE process_start_time_seconds gauge
+process_start_time_seconds 400.8
+`
+
+var startTimeMetricPageStartTimestamp = &timestamppb.Timestamp{Seconds: 400, Nanos: 800000000}
+
+const numStartTimeMetricPageTimeseries = 5
+
+func verifyStartTimeMetricPage(t *testing.T, td *testData, mds []consumerdata.MetricsData) {
+	numTimeseries := 0
+	for _, cmd := range mds {
+		for _, metric := range cmd.Metrics {
+			timestamp := startTimeMetricPageStartTimestamp
+			switch metric.GetMetricDescriptor().GetType() {
+			case metricspb.MetricDescriptor_GAUGE_DOUBLE, metricspb.MetricDescriptor_GAUGE_DISTRIBUTION:
+				timestamp = nil
+			}
+			for _, ts := range metric.GetTimeseries() {
+				assert.Equal(t, timestamp, ts.GetStartTimestamp())
+				numTimeseries++
+			}
+		}
 	}
+	assert.Equal(t, numStartTimeMetricPageTimeseries, numTimeseries)
+}
+
+// TestStartTimeMetric validates that timeseries have start time set to 'process_start_time_seconds'
+func TestStartTimeMetric(t *testing.T) {
+	targets := []*testData{
+		{
+			name: "target1",
+			pages: []mockPrometheusResponse{
+				{code: 200, data: startTimeMetricPage},
+			},
+			validateFunc: verifyStartTimeMetricPage,
+		},
+	}
+	testEndToEnd(t, targets, true)
+}
+
+func testEndToEnd(t *testing.T, targets []*testData, useStartTimeMetric bool) {
+	// 1. setup mock server
+	mp, cfg, err := setupMockPrometheus(targets...)
+	require.Nilf(t, err, "Failed to create Promtheus config: %v", err)
 	defer mp.Close()
 
 	cms := new(exportertest.SinkMetricsExporter)
-	precv := newPrometheusReceiver(logger, &Config{PrometheusConfig: cfg}, cms)
+	rcvr := newPrometheusReceiver(logger, &Config{PrometheusConfig: cfg, UseStartTimeMetric: useStartTimeMetric}, cms)
 
 	mh := receivertest.NewMockHost()
-	if err := precv.StartMetricsReception(mh); err != nil {
-		t.Fatalf("Failed to invoke StartMetricsReception: %v", err)
-	}
-	defer precv.StopMetricsReception()
+	err = rcvr.StartMetricsReception(mh)
+	require.Nilf(t, err, "Failed to invoke StartMetricsReception: %v", err)
+	defer rcvr.StopMetricsReception()
 
 	// wait for all provided data to be scraped
 	mp.wg.Wait()
@@ -993,18 +1062,11 @@ func TestEndToEnd(t *testing.T) {
 		results[m.Node.ServiceInfo.Name] = append(result, m)
 	}
 
-	t.Run("results-num-shall-match-targets", func(t *testing.T) {
-		if l := len(results); l != len(mp.endpoints) {
-			t.Errorf("want %d targets, but got %v\n", len(mp.endpoints), l)
-		}
-	})
+	lres, lep := len(results), len(mp.endpoints)
+	assert.Equalf(t, lep, lres, "want %d targets, but got %v\n", lep, lres)
 
 	// loop to validate outputs for each targets
-	for _, tt := range targets {
-		result := results[tt.name]
-		t.Run(fmt.Sprintf("verify-%s-results", tt.name), func(t *testing.T) {
-			tt.validateFunc(t, tt, result)
-		})
-		tt.validateFunc(t, tt, result)
+	for _, target := range targets {
+		target.validateFunc(t, target, results[target.name])
 	}
 }

--- a/receiver/prometheusreceiver/testdata/config.yaml
+++ b/receiver/prometheusreceiver/testdata/config.yaml
@@ -4,6 +4,7 @@ receivers:
     endpoint: "1.2.3.4:456"
     buffer_period: 234
     buffer_count: 45
+    use_start_time_metric: true
     include_filter: {
       "localhost:9777" : [http/server/server_latency, custom_metric1],
       "localhost:9778" : [http/client/roundtrip_latency],


### PR DESCRIPTION
Prometheus clients can optionally export a standard start-time gauge metric, process_start_time_seconds, that greatly simplifies the logic necessary for setting the start timestamp for exported timeseries, which removes the overhead of the metrics adjuster.

This change adds a configuration option to use the start-time metric. If the start-time metric is not found in a scrape, the timeseries for that scrape are dropped.

Note that the start-time timeseries is not exported by the prometheus receiver as a metric (i.e. not passed to ConsumeMetricsData).