### PR TITLE
Add http latency metrics to Prometheus receiver

### DIFF
--- a/receiver/prometheusreceiver/internal/metricsbuilder.go
+++ b/receiver/prometheusreceiver/internal/metricsbuilder.go
@@ -98,7 +98,7 @@ func (b *metricBuilder) AddDataPoint(ls labels.Labels, t int64, v float64) error
 				b.scrapeStatus = scrapeStatusOk
 			} else {
 				b.scrapeStatus = scrapeStatusErr
-				b.logger.Infow("http client error:", "ts", t, "value", v, "labels", lm)
+				b.logger.Warnw("http client error:", "ts", t, "value", v, "labels", lm)
 			}
 		case scrapeLatencyMetricName:
 			b.scrapeLatencyMs = v * 1000

--- a/receiver/prometheusreceiver/internal/metricsbuilder.go
+++ b/receiver/prometheusreceiver/internal/metricsbuilder.go
@@ -39,7 +39,7 @@ const (
 	scrapeStatusOk          = "200"
 	// The 'up' metric only reports whether or not the scrape succeeded - in the case that
 	// it fails, we set the status to '404', which is the most generic failure status.
-	scrapeStatusErr         = "404"
+	scrapeStatusErr = "404"
 )
 
 var (

--- a/receiver/prometheusreceiver/internal/metricsbuilder.go
+++ b/receiver/prometheusreceiver/internal/metricsbuilder.go
@@ -37,6 +37,8 @@ const (
 	scrapeLatencyMetricName = "scrape_duration_seconds"
 	scrapeStatusMetricName  = "up"
 	scrapeStatusOk          = "200"
+	// The 'up' metric only reports whether or not the scrape succeeded - in the case that
+	// it fails, we set the status to '404', which is the most generic failure status.
 	scrapeStatusErr         = "404"
 )
 
@@ -90,7 +92,6 @@ func (b *metricBuilder) AddDataPoint(ls labels.Labels, t int64, v float64) error
 		b.hasInternalMetric = true
 		lm := ls.Map()
 		delete(lm, model.MetricNameLabel)
-		b.logger.Debugw("skip internal metric", "name", metricName, "ts", t, "value", v, "labels", lm)
 		switch metricName {
 		case scrapeStatusMetricName:
 			if v == 1.0 {

--- a/receiver/prometheusreceiver/internal/ocastore.go
+++ b/receiver/prometheusreceiver/internal/ocastore.go
@@ -56,10 +56,11 @@ type ocaStore struct {
 	ctx                context.Context
 	jobsMap            *JobsMap
 	useStartTimeMetric bool
+	receiverName       string
 }
 
 // NewOcaStore returns an ocaStore instance, which can be acted as prometheus' scrape.Appendable
-func NewOcaStore(ctx context.Context, sink consumer.MetricsConsumer, logger *zap.SugaredLogger, jobsMap *JobsMap, useStartTimeMetric bool) OcaStore {
+func NewOcaStore(ctx context.Context, sink consumer.MetricsConsumer, logger *zap.SugaredLogger, jobsMap *JobsMap, useStartTimeMetric bool, receiverName string) OcaStore {
 	return &ocaStore{
 		running:            runningStateInit,
 		ctx:                ctx,
@@ -68,6 +69,7 @@ func NewOcaStore(ctx context.Context, sink consumer.MetricsConsumer, logger *zap
 		once:               &sync.Once{},
 		jobsMap:            jobsMap,
 		useStartTimeMetric: useStartTimeMetric,
+		receiverName:       receiverName,
 	}
 }
 
@@ -82,7 +84,7 @@ func (o *ocaStore) SetScrapeManager(scrapeManager *scrape.Manager) {
 func (o *ocaStore) Appender() (storage.Appender, error) {
 	state := atomic.LoadInt32(&o.running)
 	if state == runningStateReady {
-		return newTransaction(o.ctx, o.jobsMap, o.useStartTimeMetric, o.mc, o.sink, o.logger), nil
+		return newTransaction(o.ctx, o.jobsMap, o.useStartTimeMetric, o.receiverName, o.mc, o.sink, o.logger), nil
 	} else if state == runningStateInit {
 		return nil, errors.New("ScrapeManager is not set")
 	}

--- a/receiver/prometheusreceiver/internal/ocastore_test.go
+++ b/receiver/prometheusreceiver/internal/ocastore_test.go
@@ -24,7 +24,7 @@ import (
 
 func TestOcaStore(t *testing.T) {
 
-	o := NewOcaStore(context.Background(), nil, nil, nil, false)
+	o := NewOcaStore(context.Background(), nil, nil, nil, false, "prometheus")
 
 	_, err := o.Appender()
 	if err == nil {

--- a/receiver/prometheusreceiver/internal/transaction_test.go
+++ b/receiver/prometheusreceiver/internal/transaction_test.go
@@ -32,9 +32,11 @@ func Test_transaction(t *testing.T) {
 		},
 	}
 
+	rn := "prometheus"
+
 	t.Run("Commit Without Adding", func(t *testing.T) {
 		mcon := newMockConsumer()
-		tr := newTransaction(context.Background(), nil, true, ms, mcon, testLogger)
+		tr := newTransaction(context.Background(), nil, true, rn, ms, mcon, testLogger)
 		if got := tr.Commit(); got != nil {
 			t.Errorf("expecting nil from Commit() but got err %v", got)
 		}
@@ -42,7 +44,7 @@ func Test_transaction(t *testing.T) {
 
 	t.Run("Rollback dose nothing", func(t *testing.T) {
 		mcon := newMockConsumer()
-		tr := newTransaction(context.Background(), nil, true, ms, mcon, testLogger)
+		tr := newTransaction(context.Background(), nil, true, rn, ms, mcon, testLogger)
 		if got := tr.Rollback(); got != nil {
 			t.Errorf("expecting nil from Rollback() but got err %v", got)
 		}
@@ -51,7 +53,7 @@ func Test_transaction(t *testing.T) {
 	badLabels := labels.Labels([]labels.Label{{Name: "foo", Value: "bar"}})
 	t.Run("Add One No Target", func(t *testing.T) {
 		mcon := newMockConsumer()
-		tr := newTransaction(context.Background(), nil, true, ms, mcon, testLogger)
+		tr := newTransaction(context.Background(), nil, true, rn, ms, mcon, testLogger)
 		if _, got := tr.Add(badLabels, time.Now().Unix()*1000, 1.0); got == nil {
 			t.Errorf("expecting error from Add() but got nil")
 		}
@@ -63,7 +65,7 @@ func Test_transaction(t *testing.T) {
 		{Name: "foo", Value: "bar"}})
 	t.Run("Add One Job not found", func(t *testing.T) {
 		mcon := newMockConsumer()
-		tr := newTransaction(context.Background(), nil, true, ms, mcon, testLogger)
+		tr := newTransaction(context.Background(), nil, true, rn, ms, mcon, testLogger)
 		if _, got := tr.Add(jobNotFoundLb, time.Now().Unix()*1000, 1.0); got == nil {
 			t.Errorf("expecting error from Add() but got nil")
 		}
@@ -74,7 +76,7 @@ func Test_transaction(t *testing.T) {
 		{Name: "__name__", Value: "foo"}})
 	t.Run("Add One Good", func(t *testing.T) {
 		mcon := newMockConsumer()
-		tr := newTransaction(context.Background(), nil, true, ms, mcon, testLogger)
+		tr := newTransaction(context.Background(), nil, true, rn, ms, mcon, testLogger)
 		if _, got := tr.Add(goodLabels, time.Now().Unix()*1000, 1.0); got != nil {
 			t.Errorf("expecting error == nil from Add() but got: %v\n", got)
 		}
@@ -95,7 +97,7 @@ func Test_transaction(t *testing.T) {
 
 	t.Run("Drop NaN value", func(t *testing.T) {
 		mcon := newMockConsumer()
-		tr := newTransaction(context.Background(), nil, true, ms, mcon, testLogger)
+		tr := newTransaction(context.Background(), nil, true, rn, ms, mcon, testLogger)
 		if _, got := tr.Add(goodLabels, time.Now().Unix()*1000, math.NaN()); got != nil {
 			t.Errorf("expecting error == nil from Add() but got: %v\n", got)
 		}


### PR DESCRIPTION
The metrics are recorded based on the Prometheus-define sample timeseries (https://prometheus.io/docs/concepts/jobs_instances/). 