### PR TITLE
Fix race on metrics adjuster

### DIFF
--- a/receiver/prometheusreceiver/internal/metrics_adjuster.go
+++ b/receiver/prometheusreceiver/internal/metrics_adjuster.go
@@ -80,9 +80,6 @@ func (tsm *timeseriesMap) get(
 	metric *metricspb.Metric, values []*metricspb.LabelValue) *timeseriesinfo {
 	name := metric.GetMetricDescriptor().GetName()
 	sig := getTimeseriesSignature(name, values)
-
-	tsm.Lock()
-	defer tsm.Unlock()
 	tsi, ok := tsm.tsiMap[sig]
 	if !ok {
 		tsi = &timeseriesinfo{}
@@ -211,6 +208,8 @@ func NewMetricsAdjuster(tsm *timeseriesMap, logger *zap.Logger) *MetricsAdjuster
 func (ma *MetricsAdjuster) AdjustMetrics(metrics []*metricspb.Metric) ([]*metricspb.Metric, int) {
 	var adjusted = make([]*metricspb.Metric, 0, len(metrics))
 	dropped := 0
+	ma.tsm.Lock()
+	defer ma.tsm.Unlock()
 	for _, metric := range metrics {
 		adj, d := ma.adjustMetric(metric)
 		dropped += d

--- a/receiver/prometheusreceiver/internal/metrics_adjuster.go
+++ b/receiver/prometheusreceiver/internal/metrics_adjuster.go
@@ -143,7 +143,7 @@ func NewJobsMap(gcInterval time.Duration) *JobsMap {
 func (jm *JobsMap) gc() {
 	jm.Lock()
 	defer jm.Unlock()
-	// once the structure is locked, confrim that gc() is still necessary
+	// once the structure is locked, confirm that gc() is still necessary
 	if time.Since(jm.lastGC) > jm.gcInterval {
 		for sig, tsm := range jm.jobsMap {
 			tsm.RLock()
@@ -161,6 +161,8 @@ func (jm *JobsMap) gc() {
 
 func (jm *JobsMap) maybeGC() {
 	// speculatively check if gc() is necessary, recheck once the structure is locked
+	jm.RLock()
+	defer jm.RUnlock()
 	if time.Since(jm.lastGC) > jm.gcInterval {
 		go jm.gc()
 	}

--- a/receiver/prometheusreceiver/internal/metrics_adjuster_test.go
+++ b/receiver/prometheusreceiver/internal/metrics_adjuster_test.go
@@ -317,6 +317,8 @@ func Test_jobGC(t *testing.T) {
 	time.Sleep(2 * gcInterval)
 	// re-run job 2, round1 - trigger job gc, removing unmarked entries
 	runScript(t, jobsMap.get("job", "1"), job2Script1)
+	// sleep longer than gcInterval to enable job gc in the next run
+	time.Sleep(2 * gcInterval)
 	// run job 1, round 2 - verify that all job 1 timeseries have been gc'd
 	runScript(t, jobsMap.get("job", "0"), job1Script2)
 }

--- a/receiver/prometheusreceiver/internal/metrics_adjuster_test.go
+++ b/receiver/prometheusreceiver/internal/metrics_adjuster_test.go
@@ -317,8 +317,8 @@ func Test_jobGC(t *testing.T) {
 	time.Sleep(2 * gcInterval)
 	// re-run job 2, round1 - trigger job gc, removing unmarked entries
 	runScript(t, jobsMap.get("job", "1"), job2Script1)
-	// sleep longer than gcInterval to enable job gc in the next run
-	time.Sleep(2 * gcInterval)
+	// ensure that at least one jobsMap.gc() completed
+	jobsMap.gc()
 	// run job 1, round 2 - verify that all job 1 timeseries have been gc'd
 	runScript(t, jobsMap.get("job", "0"), job1Script2)
 }


### PR DESCRIPTION
The field "mark" was not fully protected, added proper RLock/RUnlock to protect it. Opportunistically moved one lock from higher level to where it is actually used and also added a sleep looked like was missing from the test.

Fixes #391

/cc @dinooliva 