### PR TITLE
Fix processor metric tag key and add queued retry name

### DIFF
--- a/processor/batchprocessor/metrics.go
+++ b/processor/batchprocessor/metrics.go
@@ -44,7 +44,7 @@ func MetricViews(level telemetry.Level) []*view.View {
 		return nil
 	}
 
-	exporterTagKeys := []tag.Key{processor.TagExporterNameKey}
+	processorTagKeys := []tag.Key{processor.TagProcessorNameKey}
 
 	batchSizeAggregation := view.Distribution(10, 25, 50, 75, 100, 250, 500, 750, 1000, 2000, 3000, 4000, 5000, 10000, 20000, 30000, 50000, 100000)
 
@@ -52,7 +52,7 @@ func MetricViews(level telemetry.Level) []*view.View {
 		Name:        statBatchSize.Name(),
 		Measure:     statBatchSize,
 		Description: statBatchSize.Description(),
-		TagKeys:     exporterTagKeys,
+		TagKeys:     processorTagKeys,
 		Aggregation: batchSizeAggregation,
 	}
 
@@ -60,7 +60,7 @@ func MetricViews(level telemetry.Level) []*view.View {
 		Name:        statNodesAddedToBatches.Name(),
 		Measure:     statNodesAddedToBatches,
 		Description: statNodesAddedToBatches.Description(),
-		TagKeys:     exporterTagKeys,
+		TagKeys:     processorTagKeys,
 		Aggregation: view.Sum(),
 	}
 
@@ -68,7 +68,7 @@ func MetricViews(level telemetry.Level) []*view.View {
 		Name:        statNodesRemovedFromBatches.Name(),
 		Measure:     statNodesRemovedFromBatches,
 		Description: statNodesRemovedFromBatches.Description(),
-		TagKeys:     exporterTagKeys,
+		TagKeys:     processorTagKeys,
 		Aggregation: view.Sum(),
 	}
 

--- a/processor/metrics.go
+++ b/processor/metrics.go
@@ -25,9 +25,9 @@ import (
 
 // Keys and stats for telemetry.
 var (
-	TagSourceFormatKey, _ = tag.NewKey("format")
-	TagServiceNameKey, _  = tag.NewKey("service")
-	TagExporterNameKey, _ = tag.NewKey("exporter")
+	TagSourceFormatKey, _  = tag.NewKey("source_format")
+	TagServiceNameKey, _   = tag.NewKey("service")
+	TagProcessorNameKey, _ = tag.NewKey("processor")
 
 	StatReceivedSpanCount = stats.Int64(
 		"spans_received",
@@ -54,7 +54,7 @@ func MetricTagKeys(level telemetry.Level) []tag.Key {
 		tagKeys = append(tagKeys, TagSourceFormatKey)
 		fallthrough
 	case telemetry.Basic:
-		tagKeys = append(tagKeys, TagExporterNameKey)
+		tagKeys = append(tagKeys, TagProcessorNameKey)
 	default:
 		return nil
 	}
@@ -143,7 +143,7 @@ func StatsTagsForBatch(processorName, serviceName, spanFormat string) []tag.Muta
 	statsTags := []tag.Mutator{
 		tag.Upsert(TagSourceFormatKey, spanFormat),
 		tag.Upsert(TagServiceNameKey, serviceName),
-		tag.Upsert(TagExporterNameKey, processorName),
+		tag.Upsert(TagProcessorNameKey, processorName),
 	}
 
 	return statsTags

--- a/processor/queuedprocessor/factory.go
+++ b/processor/queuedprocessor/factory.go
@@ -61,6 +61,7 @@ func (f *Factory) CreateTraceProcessor(
 ) (processor.TraceProcessor, error) {
 	oCfg := cfg.(*Config)
 	return NewQueuedSpanProcessor(nextConsumer,
+		Options.WithName(oCfg.Name()),
 		Options.WithNumWorkers(oCfg.NumWorkers),
 		Options.WithQueueSize(oCfg.QueueSize),
 		Options.WithRetryOnProcessingFailures(oCfg.RetryOnFailure),

--- a/processor/queuedprocessor/queued_processor.go
+++ b/processor/queuedprocessor/queued_processor.go
@@ -66,7 +66,7 @@ func NewQueuedSpanProcessor(sender consumer.TraceConsumer, opts ...Option) proce
 	})
 
 	// Start a timer to report the queue length.
-	ctx, _ := tag.New(context.Background(), tag.Upsert(processor.TagExporterNameKey, sp.name))
+	ctx, _ := tag.New(context.Background(), tag.Upsert(processor.TagProcessorNameKey, sp.name))
 	ticker := time.NewTicker(1 * time.Second)
 	go func(ctx context.Context) {
 		defer ticker.Stop()
@@ -246,13 +246,13 @@ func MetricViews(level telemetry.Level) []*view.View {
 		return nil
 	}
 
-	exporterTagKeys := []tag.Key{processor.TagExporterNameKey}
+	processorTagKeys := []tag.Key{processor.TagProcessorNameKey}
 
 	queueLengthView := &view.View{
 		Name:        statQueueLength.Name(),
 		Measure:     statQueueLength,
 		Description: "Current number of batches in the queued exporter",
-		TagKeys:     exporterTagKeys,
+		TagKeys:     processorTagKeys,
 		Aggregation: view.LastValue(),
 	}
 	countSuccessSendView := &view.View{
@@ -276,14 +276,14 @@ func MetricViews(level telemetry.Level) []*view.View {
 		Name:        statSendLatencyMs.Name(),
 		Measure:     statSendLatencyMs,
 		Description: "The latency of the successful send operations.",
-		TagKeys:     exporterTagKeys,
+		TagKeys:     processorTagKeys,
 		Aggregation: latencyDistributionAggregation,
 	}
 	inQueueLatencyView := &view.View{
 		Name:        statInQueueLatencyMs.Name(),
 		Measure:     statInQueueLatencyMs,
 		Description: "The \"in queue\" latency of the successful send operations.",
-		TagKeys:     exporterTagKeys,
+		TagKeys:     processorTagKeys,
 		Aggregation: latencyDistributionAggregation,
 	}
 


### PR DESCRIPTION
For historical reasons the tag associated to the name of a processor was still named "exporter", changed that to "processor". Added also the name of the queued retry instance to be used as the name of the processor.