### PR TITLE
Add Resource Processor

### DIFF
--- a/processor/resourceprocessor/config.go
+++ b/processor/resourceprocessor/config.go
@@ -1,0 +1,27 @@
+// Copyright 2019 OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resourceprocessor
+
+import (
+	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
+)
+
+// Config defines configuration for Resource processor.
+type Config struct {
+	configmodels.ProcessorSettings `mapstructure:",squash"`
+	// Resource specifies the labels to be added to exported metrics.
+	ResourceType string            `mapstructure:"type"`
+	Labels       map[string]string `mapstructure:"labels"`
+}

--- a/processor/resourceprocessor/config.go
+++ b/processor/resourceprocessor/config.go
@@ -21,7 +21,7 @@ import (
 // Config defines configuration for Resource processor.
 type Config struct {
 	configmodels.ProcessorSettings `mapstructure:",squash"`
-	// Resource specifies the labels to be added to exported metrics.
+	// Resource specifies the labels to be added to exported metrics and traces.
 	ResourceType string            `mapstructure:"type"`
 	Labels       map[string]string `mapstructure:"labels"`
 }

--- a/processor/resourceprocessor/config_test.go
+++ b/processor/resourceprocessor/config_test.go
@@ -1,0 +1,55 @@
+// Copyright 2019 OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resourceprocessor
+
+import (
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/open-telemetry/opentelemetry-collector/config"
+	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
+)
+
+func TestLoadConfig(t *testing.T) {
+	factories, err := config.ExampleComponents()
+	assert.NoError(t, err)
+
+	factory := &Factory{}
+	factories.Processors[typeStr] = &Factory{}
+
+	cfg, err := config.LoadConfigFile(t, path.Join(".", "testdata", "config.yaml"), factories)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, cfg)
+
+	p1 := cfg.Processors["resource"]
+	assert.Equal(t, p1, factory.CreateDefaultConfig())
+
+	p2 := cfg.Processors["resource/2"]
+	assert.Equal(t, p2, &Config{
+		ProcessorSettings: configmodels.ProcessorSettings{
+			TypeVal: "resource",
+			NameVal: "resource/2",
+		},
+		ResourceType: "host",
+		Labels: map[string]string{
+			"cloud.zone":       "zone-1",
+			"k8s.cluster.name": "k8s-cluster",
+			"host.name":        "k8s-node",
+		},
+	})
+}

--- a/processor/resourceprocessor/config_test.go
+++ b/processor/resourceprocessor/config_test.go
@@ -32,8 +32,7 @@ func TestLoadConfig(t *testing.T) {
 	factories.Processors[typeStr] = &Factory{}
 
 	cfg, err := config.LoadConfigFile(t, path.Join(".", "testdata", "config.yaml"), factories)
-
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, cfg)
 
 	p1 := cfg.Processors["resource"]

--- a/processor/resourceprocessor/doc.go
+++ b/processor/resourceprocessor/doc.go
@@ -1,0 +1,17 @@
+// Copyright 2019 OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package resourceprocessor implements a processor for specifying resource
+// labels to be added to OpenCensus trace data and metrics data.
+package resourceprocessor

--- a/processor/resourceprocessor/factory.go
+++ b/processor/resourceprocessor/factory.go
@@ -1,0 +1,63 @@
+// Copyright 2019 OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resourceprocessor
+
+import (
+	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
+	"github.com/open-telemetry/opentelemetry-collector/consumer"
+	"github.com/open-telemetry/opentelemetry-collector/processor"
+
+	"go.uber.org/zap"
+)
+
+const (
+	// The value of "type" key in configuration.
+	typeStr = "resource"
+)
+
+// Factory is the factory for OpenCensus exporter.
+type Factory struct {
+}
+
+var _ processor.Factory = Factory{}
+
+// Type gets the type of the Option config created by this factory.
+func (Factory) Type() string {
+	return typeStr
+}
+
+// CreateDefaultConfig creates the default configuration for processor.
+func (Factory) CreateDefaultConfig() configmodels.Processor {
+	return &Config{
+		ProcessorSettings: configmodels.ProcessorSettings{
+			TypeVal: typeStr,
+			NameVal: typeStr,
+		},
+		ResourceType: "",
+		Labels:       map[string]string{},
+	}
+}
+
+// CreateTraceProcessor creates a trace processor based on this config.
+func (Factory) CreateTraceProcessor(logger *zap.Logger, nextConsumer consumer.TraceConsumer, cfg configmodels.Processor) (processor.TraceProcessor, error) {
+	oCfg := cfg.(*Config)
+	return newResourceTraceProcessor(nextConsumer, oCfg), nil
+}
+
+// CreateMetricsProcessor creates a metrics processor based on this config.
+func (Factory) CreateMetricsProcessor(logger *zap.Logger, nextConsumer consumer.MetricsConsumer, cfg configmodels.Processor) (processor.MetricsProcessor, error) {
+	oCfg := cfg.(*Config)
+	return newResourceMetricProcessor(nextConsumer, oCfg), nil
+}

--- a/processor/resourceprocessor/factory.go
+++ b/processor/resourceprocessor/factory.go
@@ -15,11 +15,11 @@
 package resourceprocessor
 
 import (
+	"go.uber.org/zap"
+
 	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
 	"github.com/open-telemetry/opentelemetry-collector/consumer"
 	"github.com/open-telemetry/opentelemetry-collector/processor"
-
-	"go.uber.org/zap"
 )
 
 const (

--- a/processor/resourceprocessor/factory_test.go
+++ b/processor/resourceprocessor/factory_test.go
@@ -18,10 +18,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector/config/configcheck"
-
-	"go.uber.org/zap"
 )
 
 func TestCreateDefaultConfig(t *testing.T) {

--- a/processor/resourceprocessor/factory_test.go
+++ b/processor/resourceprocessor/factory_test.go
@@ -19,12 +19,15 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/open-telemetry/opentelemetry-collector/config/configcheck"
+
 	"go.uber.org/zap"
 )
 
 func TestCreateDefaultConfig(t *testing.T) {
 	var factory Factory
 	cfg := factory.CreateDefaultConfig()
+	assert.NoError(t, configcheck.ValidateConfig(cfg))
 	assert.NotNil(t, cfg)
 }
 
@@ -33,10 +36,10 @@ func TestCreateProcessor(t *testing.T) {
 	cfg := factory.CreateDefaultConfig()
 
 	tp, err := factory.CreateTraceProcessor(zap.NewNop(), nil, cfg)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, tp)
 
 	mp, err := factory.CreateMetricsProcessor(zap.NewNop(), nil, cfg)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, mp)
 }

--- a/processor/resourceprocessor/factory_test.go
+++ b/processor/resourceprocessor/factory_test.go
@@ -1,0 +1,42 @@
+// Copyright 2019 OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resourceprocessor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"go.uber.org/zap"
+)
+
+func TestCreateDefaultConfig(t *testing.T) {
+	var factory Factory
+	cfg := factory.CreateDefaultConfig()
+	assert.NotNil(t, cfg)
+}
+
+func TestCreateProcessor(t *testing.T) {
+	var factory Factory
+	cfg := factory.CreateDefaultConfig()
+
+	tp, err := factory.CreateTraceProcessor(zap.NewNop(), nil, cfg)
+	assert.Nil(t, err)
+	assert.NotNil(t, tp)
+
+	mp, err := factory.CreateMetricsProcessor(zap.NewNop(), nil, cfg)
+	assert.Nil(t, err)
+	assert.NotNil(t, mp)
+}

--- a/processor/resourceprocessor/resource_processor.go
+++ b/processor/resourceprocessor/resource_processor.go
@@ -113,8 +113,10 @@ func mergeResource(to, from *resourcepb.Resource) *resourcepb.Resource {
 		to = &resourcepb.Resource{Labels: map[string]string{}}
 	}
 	to.Type = from.Type
-	for k, v := range from.Labels {
-		to.Labels[k] = v
+	if from.Labels != nil {
+		for k, v := range from.Labels {
+			to.Labels[k] = v
+		}
 	}
 	return to
 }

--- a/processor/resourceprocessor/resource_processor.go
+++ b/processor/resourceprocessor/resource_processor.go
@@ -1,0 +1,101 @@
+// Copyright 2019 OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resourceprocessor
+
+import (
+	"context"
+
+	resourcepb "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
+
+	"github.com/open-telemetry/opentelemetry-collector/consumer"
+	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
+	"github.com/open-telemetry/opentelemetry-collector/processor"
+)
+
+type resourceTraceProcessor struct {
+	resource *resourcepb.Resource
+	next     consumer.TraceConsumer
+}
+
+func newResourceTraceProcessor(next consumer.TraceConsumer, cfg *Config) *resourceTraceProcessor {
+	resource := createResource(cfg)
+	return &resourceTraceProcessor{
+		next:     next,
+		resource: resource,
+	}
+}
+
+// ConsumeTraceData implements the TraceProcessor interface
+func (rtp *resourceTraceProcessor) ConsumeTraceData(ctx context.Context, td consumerdata.TraceData) error {
+	return rtp.next.ConsumeTraceData(ctx, consumerdata.TraceData{
+		Node:         td.Node,
+		Resource:     rtp.resource,
+		Spans:        td.Spans,
+		SourceFormat: td.SourceFormat,
+	})
+}
+
+// GetCapabilities returns the Capabilities assocciated with the resource processor.
+func (rtp *resourceTraceProcessor) GetCapabilities() processor.Capabilities {
+	return processor.Capabilities{MutatesConsumedData: true}
+}
+
+// Shutdown is invoked during service shutdown.
+func (*resourceTraceProcessor) Shutdown() error {
+	return nil
+}
+
+type resourceMetricProcessor struct {
+	resource *resourcepb.Resource
+	next     consumer.MetricsConsumer
+}
+
+func newResourceMetricProcessor(next consumer.MetricsConsumer, cfg *Config) *resourceMetricProcessor {
+	resource := createResource(cfg)
+	return &resourceMetricProcessor{
+		next:     next,
+		resource: resource,
+	}
+}
+
+// GetCapabilities returns the Capabilities assocciated with the resource processor.
+func (rmp *resourceMetricProcessor) GetCapabilities() processor.Capabilities {
+	return processor.Capabilities{MutatesConsumedData: true}
+}
+
+// Shutdown is invoked during service shutdown.
+func (*resourceMetricProcessor) Shutdown() error {
+	return nil
+}
+
+// ConsumeMetricsData implements the MetricsProcessor interface
+func (rmp *resourceMetricProcessor) ConsumeMetricsData(ctx context.Context, md consumerdata.MetricsData) error {
+	return rmp.next.ConsumeMetricsData(ctx, consumerdata.MetricsData{
+		Node:     md.Node,
+		Resource: rmp.resource,
+		Metrics:  md.Metrics,
+	})
+}
+
+func createResource(cfg *Config) *resourcepb.Resource {
+	rpb := &resourcepb.Resource{
+		Type:   cfg.ResourceType,
+		Labels: map[string]string{},
+	}
+	for k, v := range cfg.Labels {
+		rpb.Labels[k] = v
+	}
+	return rpb
+}

--- a/processor/resourceprocessor/resource_processor.go
+++ b/processor/resourceprocessor/resource_processor.go
@@ -86,7 +86,6 @@ func (*resourceMetricProcessor) Shutdown() error {
 
 // ConsumeMetricsData implements the MetricsProcessor interface
 func (rmp *resourceMetricProcessor) ConsumeMetricsData(ctx context.Context, md consumerdata.MetricsData) error {
-	mergeResource(md.Resource, rmp.resource)
 	return rmp.next.ConsumeMetricsData(ctx, consumerdata.MetricsData{
 		Node:     md.Node,
 		Resource: mergeResource(md.Resource, rmp.resource),

--- a/processor/resourceprocessor/resource_processor_test.go
+++ b/processor/resourceprocessor/resource_processor_test.go
@@ -18,9 +18,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	resourcepb "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"

--- a/processor/resourceprocessor/resource_processor_test.go
+++ b/processor/resourceprocessor/resource_processor_test.go
@@ -167,6 +167,12 @@ func TestMetricResourceProcessorNonEmptyIncomingResource(t *testing.T) {
 	assert.Equal(t, tmn.md, want)
 }
 
+func TestMergeResourceWithNilLabels(t *testing.T) {
+	resourceNilLabels := &resourcepb.Resource{Type: "host"}
+	assert.Nil(t, resourceNilLabels.Labels)
+	assert.Equal(t, mergeResource(nil, resourceNilLabels), &resourcepb.Resource{Type: "host", Labels: map[string]string{}})
+}
+
 type testTraceConsumer struct {
 	td consumerdata.TraceData
 }

--- a/processor/resourceprocessor/resource_processor_test.go
+++ b/processor/resourceprocessor/resource_processor_test.go
@@ -1,0 +1,93 @@
+// Copyright 2019 OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resourceprocessor
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	resourcepb "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
+
+	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
+	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
+)
+
+var (
+	cfg = &Config{
+		ProcessorSettings: configmodels.ProcessorSettings{
+			TypeVal: "resource",
+			NameVal: "resource",
+		},
+		ResourceType: "host",
+		Labels: map[string]string{
+			"cloud.zone":       "zone-1",
+			"k8s.cluster.name": "k8s-cluster",
+			"host.name":        "k8s-node",
+		},
+	}
+
+	resource = &resourcepb.Resource{
+		Type: "host",
+		Labels: map[string]string{
+			"cloud.zone":       "zone-1",
+			"k8s.cluster.name": "k8s-cluster",
+			"host.name":        "k8s-node",
+		},
+	}
+)
+
+func TestTraceResourceProcessor(t *testing.T) {
+	want := consumerdata.TraceData{
+		Resource: resource,
+	}
+	test := consumerdata.TraceData{}
+
+	ttn := &testTraceConsumer{}
+	rtp := newResourceTraceProcessor(ttn, cfg)
+	rtp.ConsumeTraceData(context.Background(), test)
+	assert.Equal(t, ttn.td, want)
+}
+
+func TestMetricResourceProcessor(t *testing.T) {
+	want := consumerdata.MetricsData{
+		Resource: resource,
+	}
+	test := consumerdata.MetricsData{}
+
+	tmn := &testMetricsConsumer{}
+	rmp := newResourceMetricProcessor(tmn, cfg)
+	rmp.ConsumeMetricsData(context.Background(), test)
+	assert.Equal(t, tmn.md, want)
+}
+
+type testTraceConsumer struct {
+	td consumerdata.TraceData
+}
+
+func (ttn *testTraceConsumer) ConsumeTraceData(ctx context.Context, td consumerdata.TraceData) error {
+	ttn.td = td
+	return nil
+}
+
+type testMetricsConsumer struct {
+	md consumerdata.MetricsData
+}
+
+func (tmn *testMetricsConsumer) ConsumeMetricsData(ctx context.Context, md consumerdata.MetricsData) error {
+	tmn.md = md
+	return nil
+}

--- a/processor/resourceprocessor/testdata/config.yaml
+++ b/processor/resourceprocessor/testdata/config.yaml
@@ -2,7 +2,11 @@ receivers:
   examplereceiver:
 
 processors:
+  # The following specifies an empty resource - it will have no effect on trace or metrics data.
   resource:
+  # The following specifies a non-trivial resource. Type "host" is used for Kubernetes node resources
+  # that expect the labels "cloud.zone", "k8s.cluster.name", "host.name" to be defined (although this
+  # is not enforced by the configuration logic).
   resource/2:
     type: "host"
     labels: {

--- a/processor/resourceprocessor/testdata/config.yaml
+++ b/processor/resourceprocessor/testdata/config.yaml
@@ -1,0 +1,22 @@
+receivers:
+  examplereceiver:
+
+processors:
+  resource:
+  resource/2:
+    type: "host"
+    labels: {
+      "cloud.zone": "zone-1",
+      "k8s.cluster.name": "k8s-cluster",
+      "host.name": "k8s-node",
+    }
+
+exporters:
+  exampleexporter:
+
+service:
+  pipelines:
+    metrics:
+      receivers: [examplereceiver]
+      processors: [resource/2]
+      exporters: [exampleexporter]


### PR DESCRIPTION
Add a resource processor that provides config-based static specification of a resource label that will be added to metrics and trace data.



