### PR TITLE
Use empty struct in string-attribute-filter

### DIFF
--- a/processor/samplingprocessor/tailsamplingprocessor/sampling/string_tag_filter.go
+++ b/processor/samplingprocessor/tailsamplingprocessor/sampling/string_tag_filter.go
@@ -18,7 +18,7 @@ import tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/
 
 type stringAttributeFilter struct {
 	key    string
-	values map[string]bool
+	values map[string]struct{}
 }
 
 var _ PolicyEvaluator = (*stringAttributeFilter)(nil)
@@ -26,10 +26,10 @@ var _ PolicyEvaluator = (*stringAttributeFilter)(nil)
 // NewStringAttributeFilter creates a policy evaluator that samples all traces with
 // the given attribute in the given numeric range.
 func NewStringAttributeFilter(key string, values []string) PolicyEvaluator {
-	valuesMap := make(map[string]bool)
+	valuesMap := make(map[string]struct{})
 	for _, value := range values {
 		if value != "" {
-			valuesMap[value] = true
+			valuesMap[value] = struct{}{}
 		}
 	}
 	return &stringAttributeFilter{


### PR DESCRIPTION
Replaced bool with empty struct since bool wasn't leveraged:

```go
if _, ok := saf.values[truncableStr.Value]; ok {
  // 
}
```

instead of 

```go
if saf.values[truncableStr.Value] {
  //
}
```

Also, empty struct occupies less memory.