### PR TITLE
Add environment variable substitution to the Prometheus Receiver config

### DIFF
--- a/receiver/prometheusreceiver/config_test.go
+++ b/receiver/prometheusreceiver/config_test.go
@@ -59,7 +59,7 @@ func TestLoadConfigWithEnvVar(t *testing.T) {
 	const jobname = "JobName"
 	const jobnamevar = "JOBNAME"
 	os.Setenv(jobnamevar, jobname)
-	
+
 	factories, err := config.ExampleComponents()
 	assert.Nil(t, err)
 

--- a/receiver/prometheusreceiver/config_test.go
+++ b/receiver/prometheusreceiver/config_test.go
@@ -15,6 +15,7 @@
 package prometheusreceiver
 
 import (
+	"os"
 	"path"
 	"testing"
 	"time"
@@ -52,6 +53,31 @@ func TestLoadConfig(t *testing.T) {
 	assert.Equal(t, r1.PrometheusConfig.ScrapeConfigs[0].JobName, "demo")
 	assert.Equal(t, time.Duration(r1.PrometheusConfig.ScrapeConfigs[0].ScrapeInterval), 5*time.Second)
 	assert.Equal(t, r1.UseStartTimeMetric, true)
+}
+
+func TestLoadConfigWithEnvVar(t *testing.T) {
+	const jobname = "JobName"
+	const jobnamevar = "JOBNAME"
+	os.Setenv(jobnamevar, jobname)
+	
+	factories, err := config.ExampleComponents()
+	assert.Nil(t, err)
+
+	factory := &Factory{}
+	factories.Receivers[typeStr] = factory
+	cfg, err := config.LoadConfigFile(t, path.Join(".", "testdata", "config_env.yaml"), factories)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+
+	r := cfg.Receivers["prometheus"].(*Config)
+	assert.Equal(t, r.ReceiverSettings,
+		configmodels.ReceiverSettings{
+			TypeVal:  typeStr,
+			NameVal:  "prometheus",
+			Endpoint: "1.2.3.4:456",
+		})
+	assert.Equal(t, r.PrometheusConfig.ScrapeConfigs[0].JobName, jobname)
+	os.Unsetenv(jobnamevar)
 }
 
 func TestLoadConfigFailsOnUnknownSection(t *testing.T) {

--- a/receiver/prometheusreceiver/factory.go
+++ b/receiver/prometheusreceiver/factory.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 
 	"github.com/mitchellh/mapstructure"
 	"github.com/spf13/viper"
@@ -87,7 +88,7 @@ func CustomUnmarshalerFunc(v *viper.Viper, viperKey string, intoCfg interface{})
 	if err != nil {
 		return fmt.Errorf("prometheus receiver failed to marshal config to yaml: %s", err)
 	}
-
+	out = []byte(os.ExpandEnv(string(out)))
 	config := intoCfg.(*Config)
 
 	err = yaml.Unmarshal(out, &config.PrometheusConfig)

--- a/receiver/prometheusreceiver/testdata/config_env.yaml
+++ b/receiver/prometheusreceiver/testdata/config_env.yaml
@@ -1,0 +1,20 @@
+receivers:
+  prometheus:
+    endpoint: "1.2.3.4:456"
+    config:
+      scrape_configs:
+        - job_name: ${JOBNAME}
+          scrape_interval: 5s
+
+processors:
+  exampleprocessor:
+
+exporters:
+  exampleexporter:
+
+service:
+  pipelines:
+    traces:
+      receivers: [prometheus]
+      processors: [exampleprocessor]
+      exporters: [exampleexporter]


### PR DESCRIPTION
The OpenTelemetery Collector currently provides environment variable substitution for config files but this doesn't work for the 'config' portion of the Prometheus receiver where a custom unmarshaler used.

To support our current use-case, we need this feature available for the 'config' portion so we extend the custom unmarshaler to provide it.