### PR TITLE
Add Jaeger Agent Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,10 @@ receivers:
         endpoint: "localhost:14268"
       thrift-tchannel:
         endpoint: "localhost:14267"
+      thrift-compact:
+        endpoint: "localhost:6831"
+      thrift-binary:
+        endpoint: "localhost:6832"
 
   prometheus:
     config:

--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/stretchr/testify v1.4.0
 	github.com/uber-go/atomic v1.4.0 // indirect
 	github.com/uber/jaeger-client-go v2.16.0+incompatible // indirect
-	github.com/uber/jaeger-lib v2.0.0+incompatible
+	github.com/uber/jaeger-lib v2.2.0+incompatible
 	github.com/uber/tchannel-go v1.10.0
 	go.opencensus.io v0.22.1
 	go.uber.org/zap v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -554,6 +554,8 @@ github.com/uber/jaeger-client-go v2.16.0+incompatible h1:Q2Pp6v3QYiocMxomCaJuwQG
 github.com/uber/jaeger-client-go v2.16.0+incompatible/go.mod h1:WVhlPFC8FDjOFMMWRy2pZqQJSXxYSwNYOkTr/Z6d3Kk=
 github.com/uber/jaeger-lib v2.0.0+incompatible h1:iMSCV0rmXEogjNWPh2D0xk9YVKvrtGoHJNe9ebLu/pw=
 github.com/uber/jaeger-lib v2.0.0+incompatible/go.mod h1:ComeNDZlWwrWnDv8aPp0Ba6+uUTzImX/AauajbLI56U=
+github.com/uber/jaeger-lib v2.2.0+incompatible h1:MxZXOiR2JuoANZ3J6DE/U0kSFv/eJ/GfSYVCjK7dyaw=
+github.com/uber/jaeger-lib v2.2.0+incompatible/go.mod h1:ComeNDZlWwrWnDv8aPp0Ba6+uUTzImX/AauajbLI56U=
 github.com/uber/tchannel-go v1.10.0 h1:YOihLHuvkwT3nzvpgqFtexFW+pb5vD1Tz7h/bIWApgE=
 github.com/uber/tchannel-go v1.10.0/go.mod h1:Rrgz1eL8kMjW/nEzZos0t+Heq0O4LhnUJVA32OvWKHo=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=

--- a/go.sum
+++ b/go.sum
@@ -48,6 +48,7 @@ github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRF
 github.com/apache/thrift v0.0.0-20161221203622-b2a4d4ae21c7 h1:Fv9bK1Q+ly/ROk4aJsVMeuIwPel4bEnD8EPiI91nZMg=
 github.com/apache/thrift v0.0.0-20161221203622-b2a4d4ae21c7/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.0.0-20161221203622-b2a4d4ae21c7/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
+github.com/apache/thrift v0.13.0 h1:5hryIiq9gtn+MiLVn0wP37kb/uTeRZgN08WoCsAhIhI=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da h1:8GUt8eRujhVEGZFFEjBj46YV4rDjvGrNxb0KMWYkL2I=

--- a/internal/testutils/testutils.go
+++ b/internal/testutils/testutils.go
@@ -16,9 +16,11 @@ package testutils
 
 import (
 	"encoding/json"
+	"fmt"
 	"net"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -66,4 +68,23 @@ func GetAvailablePort(t *testing.T) uint16 {
 	require.NoError(t, err)
 
 	return uint16(portInt)
+}
+
+// WaitForPort repeatedly attempts to open a local port until it either succeeds or 5 seconds pass
+// It is useful if you need to asynchronously start a service and wait for it to start
+func WaitForPort(t *testing.T, port uint16) error {
+	t.Helper()
+
+	duration := 100 * time.Millisecond
+	iterations := 50 // 50 * 100ms = 5 seconds
+	address := fmt.Sprintf("localhost:%d", port)
+	for i := 0; i < iterations; i++ {
+		_, err := net.Dial("tcp", address)
+
+		if err == nil {
+			return nil
+		}
+		time.Sleep(duration)
+	}
+	return fmt.Errorf("failed to wait for port %d", port)
 }

--- a/internal/testutils/testutils.go
+++ b/internal/testutils/testutils.go
@@ -79,9 +79,10 @@ func WaitForPort(t *testing.T, port uint16) error {
 	wait := 100 * time.Millisecond
 	address := fmt.Sprintf("localhost:%d", port)
 	for i := totalDuration; i > 0; i -= wait {
-		_, err := net.Dial("tcp", address)
+		conn, err := net.Dial("tcp", address)
 
-		if err == nil {
+		if err == nil && conn != nil {
+			conn.Close()
 			return nil
 		}
 		time.Sleep(wait)

--- a/internal/testutils/testutils.go
+++ b/internal/testutils/testutils.go
@@ -75,16 +75,16 @@ func GetAvailablePort(t *testing.T) uint16 {
 func WaitForPort(t *testing.T, port uint16) error {
 	t.Helper()
 
-	duration := 100 * time.Millisecond
-	iterations := 50 // 50 * 100ms = 5 seconds
+	totalDuration := 5 * time.Second
+	wait := 100 * time.Millisecond
 	address := fmt.Sprintf("localhost:%d", port)
-	for i := 0; i < iterations; i++ {
+	for i := totalDuration; i > 0; i -= wait {
 		_, err := net.Dial("tcp", address)
 
 		if err == nil {
 			return nil
 		}
-		time.Sleep(duration)
+		time.Sleep(wait)
 	}
 	return fmt.Errorf("failed to wait for port %d", port)
 }

--- a/internal/testutils/testutils_test.go
+++ b/internal/testutils/testutils_test.go
@@ -15,6 +15,7 @@
 package testutils
 
 import (
+	"fmt"
 	"net"
 	"strconv"
 	"testing"
@@ -31,6 +32,20 @@ func TestGetAvailablePort(t *testing.T) {
 	require.NotEqual(t, "", portStr)
 
 	testEndpointAvailable(t, "localhost:"+portStr)
+}
+
+func TestWaitForPort(t *testing.T) {
+	port := GetAvailablePort(t)
+	err := WaitForPort(t, port)
+	require.Error(t, err)
+
+	port = GetAvailablePort(t)
+	l, err := net.Listen("tcp", fmt.Sprintf("localhost:%d", port))
+	err = WaitForPort(t, port)
+	require.NoError(t, err)
+
+	err = l.Close()
+	require.NoError(t, err)
 }
 
 func testEndpointAvailable(t *testing.T, endpoint string) {

--- a/internal/testutils/testutils_test.go
+++ b/internal/testutils/testutils_test.go
@@ -41,6 +41,8 @@ func TestWaitForPort(t *testing.T) {
 
 	port = GetAvailablePort(t)
 	l, err := net.Listen("tcp", fmt.Sprintf("localhost:%d", port))
+	require.NoError(t, err)
+
 	err = WaitForPort(t, port)
 	require.NoError(t, err)
 

--- a/receiver/README.md
+++ b/receiver/README.md
@@ -120,15 +120,15 @@ receivers:
   jaeger:
 ```
 
-It is possible to configure the protocols on different ports, refer to
-[config.yaml](jaegerreceiver/testdata/config.yaml) for detailed config
-examples.
-
 It also supports the Jaeger Agent protocols:
 - Thrift Compact
 - Thrift Binary
 
 By default, these services are not started unless an endpoint is explicitly defined.
+
+It is possible to configure the protocols on different ports, refer to
+[config.yaml](jaegerreceiver/testdata/config.yaml) for detailed config
+examples.
 
 // TODO Issue https://github.com/open-telemetry/opentelemetry-collector/issues/158
 // The Jaeger receiver enables all protocols even when one is specified or a

--- a/receiver/README.md
+++ b/receiver/README.md
@@ -107,7 +107,7 @@ This receiver receives traces in the [Jaeger](https://www.jaegertracing.io)
 format. It translates them into the internal format and sends
 it to processors and exporters.
 
-It supports multiple protocols:
+It supports the Jaeger Collector protocols:
 - Thrift HTTP
 - Thrift TChannel
 - gRPC
@@ -123,6 +123,12 @@ receivers:
 It is possible to configure the protocols on different ports, refer to
 [config.yaml](jaegerreceiver/testdata/config.yaml) for detailed config
 examples.
+
+It also supports the Jaeger Agent protocols:
+- Thrift Compact
+- Thrift Binary
+
+By default, these services are not started unless an endpoint is explicitly defined.
 
 // TODO Issue https://github.com/open-telemetry/opentelemetry-collector/issues/158
 // The Jaeger receiver enables all protocols even when one is specified or a

--- a/receiver/jaegerreceiver/config_test.go
+++ b/receiver/jaegerreceiver/config_test.go
@@ -65,6 +65,16 @@ func TestLoadConfig(t *testing.T) {
 						Endpoint: "0.0.0.0:123",
 					},
 				},
+				"thrift-compact": {
+					ReceiverSettings: configmodels.ReceiverSettings{
+						Endpoint: "0.0.0.0:456",
+					},
+				},
+				"thrift-binary": {
+					ReceiverSettings: configmodels.ReceiverSettings{
+						Endpoint: "0.0.0.0:789",
+					},
+				},
 			},
 		})
 

--- a/receiver/jaegerreceiver/factory.go
+++ b/receiver/jaegerreceiver/factory.go
@@ -41,6 +41,8 @@ const (
 	// TODO https://github.com/open-telemetry/opentelemetry-collector/issues/267
 	//	Remove ThriftTChannel support.
 	protoThriftTChannel = "thrift-tchannel"
+	protoThriftBinary   = "thrift-binary"
+	protoThriftCompact  = "thrift-compact"
 
 	// Default endpoints to bind to.
 	defaultGRPCBindEndpoint     = "localhost:14250"
@@ -103,6 +105,8 @@ func (f *Factory) CreateTraceReceiver(
 	protoGRPC := rCfg.Protocols[protoGRPC]
 	protoHTTP := rCfg.Protocols[protoThriftHTTP]
 	protoTChannel := rCfg.Protocols[protoThriftTChannel]
+	protoThriftCompact := rCfg.Protocols[protoThriftCompact]
+	protoThriftBinary := rCfg.Protocols[protoThriftBinary]
 
 	config := Configuration{}
 	var grpcServerOptions []grpc.ServerOption
@@ -141,12 +145,30 @@ func (f *Factory) CreateTraceReceiver(
 		}
 	}
 
-	if (protoGRPC == nil && protoHTTP == nil && protoTChannel == nil) ||
-		(config.CollectorGRPCPort == 0 && config.CollectorHTTPPort == 0 && config.CollectorThriftPort == 0) {
-		err := fmt.Errorf("either %v, %v, or %v protocol endpoint with non-zero port must be enabled for %s receiver",
+	if protoThriftBinary != nil && protoThriftBinary.IsEnabled() {
+		var err error
+		config.AgentBinaryThriftPort, err = extractPortFromEndpoint(protoThriftBinary.Endpoint)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if protoThriftCompact != nil && protoThriftCompact.IsEnabled() {
+		var err error
+		config.AgentCompactThriftPort, err = extractPortFromEndpoint(protoThriftCompact.Endpoint)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if (protoGRPC == nil && protoHTTP == nil && protoTChannel == nil && protoThriftBinary == nil && protoThriftCompact == nil) ||
+		(config.CollectorGRPCPort == 0 && config.CollectorHTTPPort == 0 && config.CollectorThriftPort == 0 && config.AgentBinaryThriftPort == 0 && config.AgentCompactThriftPort == 0) {
+		err := fmt.Errorf("either %v, %v, %v, %v, or %v protocol endpoint with non-zero port must be enabled for %s receiver",
 			protoGRPC,
 			protoThriftHTTP,
 			protoThriftTChannel,
+			protoThriftCompact,
+			protoThriftBinary,
 			typeStr,
 		)
 		return nil, err

--- a/receiver/jaegerreceiver/factory.go
+++ b/receiver/jaegerreceiver/factory.go
@@ -175,7 +175,7 @@ func (f *Factory) CreateTraceReceiver(
 	}
 
 	// Create the receiver.
-	return New(ctx, &config, nextConsumer)
+	return New(ctx, &config, nextConsumer, logger)
 }
 
 // CreateMetricsReceiver creates a metrics receiver based on provided config.

--- a/receiver/jaegerreceiver/factory_test.go
+++ b/receiver/jaegerreceiver/factory_test.go
@@ -23,6 +23,8 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-collector/config/configcheck"
 	"github.com/open-telemetry/opentelemetry-collector/config/configerror"
+	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
+	"github.com/open-telemetry/opentelemetry-collector/receiver"
 )
 
 func TestCreateDefaultConfig(t *testing.T) {
@@ -73,6 +75,34 @@ func TestCreateInvalidTChannelEndpoint(t *testing.T) {
 	rCfg.Protocols[protoThriftTChannel].Endpoint = ""
 	_, err := factory.CreateTraceReceiver(context.Background(), zap.NewNop(), cfg, nil)
 	assert.Error(t, err, "receiver creation with invalid tchannel endpoint must fail")
+}
+
+func TestCreateInvalidThriftBinaryEndpoint(t *testing.T) {
+	factory := Factory{}
+	cfg := factory.CreateDefaultConfig()
+	rCfg := cfg.(*Config)
+
+	rCfg.Protocols[protoThriftBinary] = &receiver.SecureReceiverSettings{
+		ReceiverSettings: configmodels.ReceiverSettings{
+			Endpoint: "",
+		},
+	}
+	_, err := factory.CreateTraceReceiver(context.Background(), zap.NewNop(), cfg, nil)
+	assert.Error(t, err, "receiver creation with no endpoints must fail")
+}
+
+func TestCreateInvalidThriftCompactEndpoint(t *testing.T) {
+	factory := Factory{}
+	cfg := factory.CreateDefaultConfig()
+	rCfg := cfg.(*Config)
+
+	rCfg.Protocols[protoThriftCompact] = &receiver.SecureReceiverSettings{
+		ReceiverSettings: configmodels.ReceiverSettings{
+			Endpoint: "",
+		},
+	}
+	_, err := factory.CreateTraceReceiver(context.Background(), zap.NewNop(), cfg, nil)
+	assert.Error(t, err, "receiver creation with no endpoints must fail")
 }
 
 func TestCreateNoPort(t *testing.T) {

--- a/receiver/jaegerreceiver/jaeger_agent_test.go
+++ b/receiver/jaegerreceiver/jaeger_agent_test.go
@@ -52,9 +52,7 @@ func TestJaegerAgentUDP_ThriftCompact_InvalidPort(t *testing.T) {
 		AgentCompactThriftPort: int(port),
 	}
 	jr, err := New(context.Background(), config, nil, zap.NewNop())
-	if err != nil {
-		t.Fatalf("Failed to create new Jaeger Receiver: %v", err)
-	}
+	assert.NoError(t, err, "Failed to create new Jaeger Receiver")
 
 	mh := receivertest.NewMockHost()
 	err = jr.StartTraceReception(mh)
@@ -81,14 +79,11 @@ func TestJaegerAgentUDP_ThriftBinary_PortInUse(t *testing.T) {
 		AgentBinaryThriftPort: int(port),
 	}
 	jr, err := New(context.Background(), config, nil, zap.NewNop())
-	if err != nil {
-		t.Fatalf("Failed to create new Jaeger Receiver: %v", err)
-	}
+	assert.NoError(t, err, "Failed to create new Jaeger Receiver")
 
 	mh := receivertest.NewMockHost()
-	if err := jr.(*jReceiver).startAgent(mh); err != nil {
-		t.Fatalf("StartTraceReception failed: %v", err)
-	}
+	err = jr.(*jReceiver).startAgent(mh)
+	assert.NoError(t, err, "StartTraceReception failed")
 	defer jr.StopTraceReception()
 
 	l, err := net.Listen("udp", fmt.Sprintf("localhost:%d", port))
@@ -106,9 +101,7 @@ func TestJaegerAgentUDP_ThriftBinary_InvalidPort(t *testing.T) {
 		AgentBinaryThriftPort: int(port),
 	}
 	jr, err := New(context.Background(), config, nil, zap.NewNop())
-	if err != nil {
-		t.Fatalf("Failed to create new Jaeger Receiver: %v", err)
-	}
+	assert.NoError(t, err, "Failed to create new Jaeger Receiver")
 
 	mh := receivertest.NewMockHost()
 	err = jr.StartTraceReception(mh)
@@ -123,20 +116,16 @@ func TestJaegerHTTP(t *testing.T) {
 		AgentHTTPPort: int(port),
 	}
 	jr, err := New(context.Background(), config, nil, zap.NewNop())
-	if err != nil {
-		t.Fatalf("Failed to create new Jaeger Receiver: %v", err)
-	}
+	assert.NoError(t, err, "Failed to create new Jaeger Receiver")
 	defer jr.StopTraceReception()
 
 	mh := receivertest.NewMockHost()
-	if err := jr.StartTraceReception(mh); err != nil {
-		t.Fatalf("StartTraceReception failed: %v", err)
-	}
+	err = jr.StartTraceReception(mh)
+	assert.NoError(t, err, "StartTraceReception failed")
 
 	// allow http server to start
-	if err := testutils.WaitForPort(t, port); err != nil {
-		t.Fatalf("WaitForPort failed: %v", err)
-	}
+	err = testutils.WaitForPort(t, port)
+	assert.NoError(t, err, "WaitForPort failed")
 
 	// this functionality is just stubbed out at the moment.  just confirm they 200.
 	testURL := fmt.Sprintf("http://localhost:%d/sampling?service=test", port)
@@ -165,15 +154,12 @@ func testJaegerAgent(t *testing.T, agentEndpoint string, receiverConfig *Configu
 	// 1. Create the Jaeger receiver aka "server"
 	sink := new(exportertest.SinkTraceExporter)
 	jr, err := New(context.Background(), receiverConfig, sink, zap.NewNop())
-	if err != nil {
-		t.Fatalf("Failed to create new Jaeger Receiver: %v", err)
-	}
+	assert.NoError(t, err, "Failed to create new Jaeger Receiver")
 	defer jr.StopTraceReception()
 
 	mh := receivertest.NewMockHost()
-	if err := jr.StartTraceReception(mh); err != nil {
-		t.Fatalf("StartTraceReception failed: %v", err)
-	}
+	err = jr.StartTraceReception(mh)
+	assert.NoError(t, err, "StartTraceReception failed")
 
 	now := time.Unix(1542158650, 536343000).UTC()
 	nowPlus10min := now.Add(10 * time.Minute)
@@ -192,9 +178,7 @@ func testJaegerAgent(t *testing.T, agentEndpoint string, receiverConfig *Configu
 			},
 		},
 	})
-	if err != nil {
-		t.Fatalf("Failed to create the Jaeger OpenCensus exporter for the live application: %v", err)
-	}
+	assert.NoError(t, err, "Failed to create the Jaeger OpenCensus exporter for the live application")
 
 	// 3. Now finally send some spans
 	spandata := []*trace.SpanData{

--- a/receiver/jaegerreceiver/jaeger_agent_test.go
+++ b/receiver/jaegerreceiver/jaeger_agent_test.go
@@ -89,6 +89,13 @@ func TestJaegerHTTP(t *testing.T) {
 	if resp != nil {
 		assert.Equal(t, 200, resp.StatusCode, "should have returned 200")
 	}
+
+	testURL = fmt.Sprintf("http://localhost:%d/baggageRestrictions?service=test", port)
+	resp, err = http.Get(testURL)
+	assert.NoError(t, err, "should not have failed to make request")
+	if resp != nil {
+		assert.Equal(t, 200, resp.StatusCode, "should have returned 200")
+	}
 }
 
 func testJaegerAgent(t *testing.T, agentEndpoint string, receiverConfig *Configuration) {

--- a/receiver/jaegerreceiver/jaeger_agent_test.go
+++ b/receiver/jaegerreceiver/jaeger_agent_test.go
@@ -86,7 +86,7 @@ func TestJaegerAgentUDP_ThriftBinary_PortInUse(t *testing.T) {
 	}
 
 	mh := receivertest.NewMockHost()
-	if err := jr.StartTraceReception(mh); err != nil {
+	if err := jr.(*jReceiver).startAgent(mh); err != nil {
 		t.Fatalf("StartTraceReception failed: %v", err)
 	}
 	defer jr.StopTraceReception()

--- a/receiver/jaegerreceiver/jaeger_agent_test.go
+++ b/receiver/jaegerreceiver/jaeger_agent_test.go
@@ -55,9 +55,9 @@ func TestJaegerAgentUDP_ThriftBinary_6832(t *testing.T) {
 }
 
 func TestJaegerHTTP(t *testing.T) {
-	port := int(testutils.GetAvailablePort(t))
+	port := testutils.GetAvailablePort(t)
 	config := &Configuration{
-		AgentHTTPPort: port,
+		AgentHTTPPort: int(port),
 	}
 	jr, err := New(context.Background(), config, nil, zap.NewNop())
 	if err != nil {
@@ -71,7 +71,9 @@ func TestJaegerHTTP(t *testing.T) {
 	}
 
 	// allow http server to start
-	<-time.After(100 * time.Millisecond)
+	if err := testutils.WaitForPort(t, port); err != nil {
+		t.Fatalf("WaitForPort failed: %v", err)
+	}
 
 	// this functionality is just stubbed out at the moment.  just confirm they 200.
 	testURL := fmt.Sprintf("http://localhost:%d/sampling?service=test", port)

--- a/receiver/jaegerreceiver/jaeger_agent_test.go
+++ b/receiver/jaegerreceiver/jaeger_agent_test.go
@@ -25,6 +25,7 @@ import (
 	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
 	"github.com/google/go-cmp/cmp"
 	"go.opencensus.io/trace"
+	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-collector/exporter/exportertest"
@@ -53,7 +54,7 @@ func TestJaegerAgentUDP_ThriftBinary_6832(t *testing.T) {
 func testJaegerAgent(t *testing.T, agentEndpoint string, receiverConfig *Configuration) {
 	// 1. Create the Jaeger receiver aka "server"
 	sink := new(exportertest.SinkTraceExporter)
-	jr, err := New(context.Background(), receiverConfig, sink)
+	jr, err := New(context.Background(), receiverConfig, sink, zap.NewNop())
 	if err != nil {
 		t.Fatalf("Failed to create new Jaeger Receiver: %v", err)
 	}

--- a/receiver/jaegerreceiver/jaeger_agent_test.go
+++ b/receiver/jaegerreceiver/jaeger_agent_test.go
@@ -220,6 +220,7 @@ func testJaegerAgent(t *testing.T, agentEndpoint string, receiverConfig *Configu
 					},
 				},
 			},
+			SourceFormat: "jaeger",
 		},
 	}
 

--- a/receiver/jaegerreceiver/jaeger_agent_test.go
+++ b/receiver/jaegerreceiver/jaeger_agent_test.go
@@ -45,6 +45,24 @@ func TestJaegerAgentUDP_ThriftCompact_6831(t *testing.T) {
 	})
 }
 
+func TestJaegerAgentUDP_ThriftCompact_InvalidPort(t *testing.T) {
+	port := 999999
+
+	config := &Configuration{
+		AgentCompactThriftPort: int(port),
+	}
+	jr, err := New(context.Background(), config, nil, zap.NewNop())
+	if err != nil {
+		t.Fatalf("Failed to create new Jaeger Receiver: %v", err)
+	}
+
+	mh := receivertest.NewMockHost()
+	err = jr.StartTraceReception(mh)
+	assert.Error(t, err, "should not have been able to startTraceReception")
+
+	jr.StopTraceReception()
+}
+
 func TestJaegerAgentUDP_ThriftBinary_6832(t *testing.T) {
 	t.Skipf("Unfortunately due to Jaeger internal versioning, OpenCensus-Go's Thrift seems to conflict with ours")
 
@@ -79,6 +97,24 @@ func TestJaegerAgentUDP_ThriftBinary_PortInUse(t *testing.T) {
 	if l != nil {
 		l.Close()
 	}
+}
+
+func TestJaegerAgentUDP_ThriftBinary_InvalidPort(t *testing.T) {
+	port := 999999
+
+	config := &Configuration{
+		AgentBinaryThriftPort: int(port),
+	}
+	jr, err := New(context.Background(), config, nil, zap.NewNop())
+	if err != nil {
+		t.Fatalf("Failed to create new Jaeger Receiver: %v", err)
+	}
+
+	mh := receivertest.NewMockHost()
+	err = jr.StartTraceReception(mh)
+	assert.Error(t, err, "should not have been able to startTraceReception")
+
+	jr.StopTraceReception()
 }
 
 func TestJaegerHTTP(t *testing.T) {

--- a/receiver/jaegerreceiver/jaeger_agent_test.go
+++ b/receiver/jaegerreceiver/jaeger_agent_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-collector/exporter/exportertest"
 	"github.com/open-telemetry/opentelemetry-collector/internal"
+	"github.com/open-telemetry/opentelemetry-collector/internal/testutils"
 	"github.com/open-telemetry/opentelemetry-collector/receiver/receivertest"
 )
 
@@ -54,8 +55,9 @@ func TestJaegerAgentUDP_ThriftBinary_6832(t *testing.T) {
 }
 
 func TestJaegerHTTP(t *testing.T) {
+	port := int(testutils.GetAvailablePort(t))
 	config := &Configuration{
-		AgentHTTPPort: 5778,
+		AgentHTTPPort: port,
 	}
 	jr, err := New(context.Background(), config, nil, zap.NewNop())
 	if err != nil {
@@ -72,13 +74,15 @@ func TestJaegerHTTP(t *testing.T) {
 	<-time.After(100 * time.Millisecond)
 
 	// this functionality is just stubbed out at the moment.  just confirm they 200.
-	resp, err := http.Get("http://localhost:5778/sampling?service=test")
+	testURL := fmt.Sprintf("http://localhost:%d/sampling?service=test", port)
+	resp, err := http.Get(testURL)
 	assert.NoError(t, err, "should not have failed to make request")
 	if resp != nil {
 		assert.Equal(t, 200, resp.StatusCode, "should have returned 200")
 	}
 
-	resp, err = http.Get("http://localhost:5778/baggageRestrictions?service=test")
+	testURL = fmt.Sprintf("http://localhost:%d/sampling?service=test", port)
+	resp, err = http.Get(testURL)
 	assert.NoError(t, err, "should not have failed to make request")
 	if resp != nil {
 		assert.Equal(t, 200, resp.StatusCode, "should have returned 200")

--- a/receiver/jaegerreceiver/testdata/config.yaml
+++ b/receiver/jaegerreceiver/testdata/config.yaml
@@ -15,6 +15,10 @@ receivers:
         endpoint: ":3456"
       thrift-tchannel:
         endpoint: "0.0.0.0:123"
+      thrift-compact:
+        endpoint: "0.0.0.0:456"
+      thrift-binary:
+        endpoint: "0.0.0.0:789"
 
   # The following demonstrates disabling the receiver.
   # All of the protocols need to be disabled for the receiver to be disabled.
@@ -29,6 +33,10 @@ receivers:
       thrift-http:
         disabled: true
       thrift-tchannel:
+        disabled: true
+      thrift-compact:
+        disabled: true
+      thrift-binary:
         disabled: true
 
   # The following demonstrates specifying different endpoints.

--- a/receiver/jaegerreceiver/trace_receiver.go
+++ b/receiver/jaegerreceiver/trace_receiver.go
@@ -192,7 +192,7 @@ func (jr *jReceiver) agentHTTPPortAddr() string {
 	return fmt.Sprintf(":%d", port)
 }
 
-func (jr *jReceiver) agentHTTPPortEnabled() bool {
+func (jr *jReceiver) agentHTTPEnabled() bool {
 	return jr.config != nil && jr.config.AgentHTTPPort > 0
 }
 
@@ -366,7 +366,7 @@ func (jr *jReceiver) PostSpans(ctx context.Context, r *api_v2.PostSpansRequest) 
 }
 
 func (jr *jReceiver) startAgent(_ receiver.Host) error {
-	if !jr.agentBinaryThriftEnabled() && !jr.agentCompactThriftEnabled() {
+	if !jr.agentBinaryThriftEnabled() && !jr.agentCompactThriftEnabled() && !jr.agentHTTPEnabled() {
 		return nil
 	}
 
@@ -408,7 +408,7 @@ func (jr *jReceiver) startAgent(_ receiver.Host) error {
 		go processor.Serve()
 	}
 
-	if jr.agentHTTPPortEnabled() {
+	if jr.agentHTTPEnabled() {
 		jr.agentServer = httpserver.NewHTTPServer(jr.agentHTTPPortAddr(), jr, metrics.NullFactory)
 
 		go func() {

--- a/receiver/jaegerreceiver/trace_receiver.go
+++ b/receiver/jaegerreceiver/trace_receiver.go
@@ -381,7 +381,7 @@ func (jr *jReceiver) startAgent(_ receiver.Host) error {
 		if err != nil {
 			return err
 		}
-		processor, err := processors.NewThriftProcessor(server, defaultAgentServerWorkers, metrics.NullFactory, apacheThrift.NewTBinaryProtocolFactoryDefault(), handler, zap.NewNop())
+		processor, err := processors.NewThriftProcessor(server, defaultAgentServerWorkers, metrics.NullFactory, apacheThrift.NewTBinaryProtocolFactoryDefault(), handler, jr.logger)
 		if err != nil {
 			return err
 		}
@@ -397,7 +397,7 @@ func (jr *jReceiver) startAgent(_ receiver.Host) error {
 		if err != nil {
 			return err
 		}
-		processor, err := processors.NewThriftProcessor(server, defaultAgentServerWorkers, metrics.NullFactory, apacheThrift.NewTCompactProtocolFactory(), handler, zap.NewNop())
+		processor, err := processors.NewThriftProcessor(server, defaultAgentServerWorkers, metrics.NullFactory, apacheThrift.NewTCompactProtocolFactory(), handler, jr.logger)
 		if err != nil {
 			return err
 		}

--- a/receiver/jaegerreceiver/trace_receiver.go
+++ b/receiver/jaegerreceiver/trace_receiver.go
@@ -296,6 +296,7 @@ func (jr *jReceiver) EmitZipkinBatch(spans []*zipkincore.Span) error {
 // Jaeger spans received by the Jaeger agent processor.
 func (jr *jReceiver) EmitBatch(batch *jaeger.Batch) error {
 	td, err := jaegertranslator.ThriftBatchToOCProto(batch)
+	td.SourceFormat = "jaeger"
 	if err != nil {
 		observability.RecordMetricsForTraceReceiver(jr.defaultAgentCtx, len(batch.Spans), len(batch.Spans))
 		return err

--- a/receiver/jaegerreceiver/trace_receiver.go
+++ b/receiver/jaegerreceiver/trace_receiver.go
@@ -381,7 +381,7 @@ func (jr *jReceiver) startAgent(_ receiver.Host) error {
 		if err != nil {
 			return err
 		}
-		processor, err := processors.NewThriftProcessor(server, defaultAgentServerWorkers, metrics.NullFactory, apacheThrift.NewTCompactProtocolFactory(), handler, zap.NewNop())
+		processor, err := processors.NewThriftProcessor(server, defaultAgentServerWorkers, metrics.NullFactory, apacheThrift.NewTBinaryProtocolFactoryDefault(), handler, zap.NewNop())
 		if err != nil {
 			return err
 		}

--- a/receiver/jaegerreceiver/trace_receiver.go
+++ b/receiver/jaegerreceiver/trace_receiver.go
@@ -54,7 +54,6 @@ type Configuration struct {
 	CollectorGRPCPort    int
 	CollectorGRPCOptions []grpc.ServerOption
 
-	AgentPort              int
 	AgentCompactThriftPort int
 	AgentBinaryThriftPort  int
 }
@@ -127,19 +126,6 @@ func (jr *jReceiver) collectorAddr() string {
 	}
 	if port <= 0 {
 		port = defaultCollectorHTTPPort
-	}
-	return fmt.Sprintf(":%d", port)
-}
-
-const defaultAgentPort = 5778
-
-func (jr *jReceiver) agentAddress() string {
-	var port int
-	if jr.config != nil {
-		port = jr.config.AgentPort
-	}
-	if port <= 0 {
-		port = defaultAgentPort
 	}
 	return fmt.Sprintf(":%d", port)
 }
@@ -383,9 +369,6 @@ func (jr *jReceiver) startAgent(_ receiver.Host) error {
 
 	builder := agentapp.Builder{
 		Processors: processorConfigs,
-		HTTPServer: agentapp.HTTPServerConfiguration{
-			HostPort: jr.agentAddress(),
-		},
 	}
 
 	agent, err := builder.CreateAgent(jr, zap.NewNop(), metrics.NullFactory)

--- a/receiver/jaegerreceiver/trace_receiver.go
+++ b/receiver/jaegerreceiver/trace_receiver.go
@@ -343,6 +343,10 @@ func (jr *jReceiver) PostSpans(ctx context.Context, r *api_v2.PostSpansRequest) 
 }
 
 func (jr *jReceiver) startAgent(_ receiver.Host) error {
+	if !jr.agentBinaryThriftEnabled() && !jr.agentCompactThriftEnabled() {
+		return nil
+	}
+
 	processorConfigs := []agentapp.ProcessorConfiguration{}
 
 	if jr.agentBinaryThriftEnabled() {

--- a/receiver/jaegerreceiver/trace_receiver.go
+++ b/receiver/jaegerreceiver/trace_receiver.go
@@ -240,7 +240,7 @@ func (jr *jReceiver) stopTraceReceptionLocked() error {
 			jr.agentServer = nil
 		}
 		for _, processor := range jr.agentProcessors {
-			go processor.Stop()
+			processor.Stop()
 		}
 
 		if jr.collectorServer != nil {

--- a/receiver/jaegerreceiver/trace_receiver_test.go
+++ b/receiver/jaegerreceiver/trace_receiver_test.go
@@ -196,6 +196,114 @@ func TestGRPCReceptionWithTLS(t *testing.T) {
 	assert.Equal(t, "", cmp.Diff(got, want))
 }
 
+func TestThriftCompactReception(t *testing.T) {
+	// 1. Create the Jaeger receiver aka "server"
+	config := &Configuration{
+		AgentCompactThriftPort: 6831, // that's the only one used by this test
+	}
+	sink := new(exportertest.SinkTraceExporter)
+
+	jr, err := New(context.Background(), config, sink)
+	defer jr.StopTraceReception()
+	assert.NoError(t, err, "should not have failed to create the Jaeger received")
+
+	t.Log("Starting")
+
+	mh := receivertest.NewMockHost()
+	err = jr.StartTraceReception(mh)
+	assert.NoError(t, err, "should not have failed to start trace reception")
+
+	t.Log("StartTraceReception")
+
+	now := time.Unix(1542158650, 536343000).UTC()
+	nowPlus10min := now.Add(10 * time.Minute)
+	nowPlus10min2sec := now.Add(10 * time.Minute).Add(2 * time.Second)
+
+	// 2. Then with a "live application", send spans to the Jaeger exporter.
+	jexp, err := jaeger.NewExporter(jaeger.Options{
+		Process: jaeger.Process{
+			ServiceName: "issaTest",
+			Tags: []jaeger.Tag{
+				jaeger.BoolTag("bool", true),
+				jaeger.StringTag("string", "yes"),
+				jaeger.Int64Tag("int64", 1e7),
+			},
+		},
+		AgentEndpoint: fmt.Sprintf("localhost:%d", config.AgentCompactThriftPort),
+	})
+	assert.NoError(t, err, "should not have failed to create the Jaeger OpenCensus exporter")
+
+	// 3. Now finally send some spans
+	for _, sd := range traceFixture(now, nowPlus10min, nowPlus10min2sec) {
+		jexp.ExportSpan(sd)
+	}
+	jexp.Flush()
+
+	// sleep for one second to allow UDP to send.
+	time.Sleep(1 * time.Second)
+
+	got := sink.AllTraces()
+	want := expectedTraceData(now, nowPlus10min, nowPlus10min2sec)
+
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("Mismatched responses\n-Got +Want:\n\t%s", diff)
+	}
+}
+
+func TestThriftBinaryReception(t *testing.T) {
+	// 1. Create the Jaeger receiver aka "server"
+	config := &Configuration{
+		AgentBinaryThriftPort: 6832, // that's the only one used by this test
+	}
+	sink := new(exportertest.SinkTraceExporter)
+
+	jr, err := New(context.Background(), config, sink)
+	defer jr.StopTraceReception()
+	assert.NoError(t, err, "should not have failed to create the Jaeger received")
+
+	t.Log("Starting")
+
+	mh := receivertest.NewMockHost()
+	err = jr.StartTraceReception(mh)
+	assert.NoError(t, err, "should not have failed to start trace reception")
+
+	t.Log("StartTraceReception")
+
+	now := time.Unix(1542158650, 536343000).UTC()
+	nowPlus10min := now.Add(10 * time.Minute)
+	nowPlus10min2sec := now.Add(10 * time.Minute).Add(2 * time.Second)
+
+	// 2. Then with a "live application", send spans to the Jaeger exporter.
+	jexp, err := jaeger.NewExporter(jaeger.Options{
+		Process: jaeger.Process{
+			ServiceName: "issaTest",
+			Tags: []jaeger.Tag{
+				jaeger.BoolTag("bool", true),
+				jaeger.StringTag("string", "yes"),
+				jaeger.Int64Tag("int64", 1e7),
+			},
+		},
+		AgentEndpoint: fmt.Sprintf("localhost:%d", config.AgentBinaryThriftPort),
+	})
+	assert.NoError(t, err, "should not have failed to create the Jaeger OpenCensus exporter")
+
+	// 3. Now finally send some spans
+	for _, sd := range traceFixture(now, nowPlus10min, nowPlus10min2sec) {
+		jexp.ExportSpan(sd)
+	}
+	jexp.Flush()
+
+	// sleep for one second to allow UDP to send.
+	time.Sleep(1 * time.Second)
+
+	got := sink.AllTraces()
+	want := expectedTraceData(now, nowPlus10min, nowPlus10min2sec)
+
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("Mismatched responses\n-Got +Want:\n\t%s", diff)
+	}
+}
+
 func expectedTraceData(t1, t2, t3 time.Time) []consumerdata.TraceData {
 	traceID := []byte{0xF1, 0xF2, 0xF3, 0xF4, 0xF5, 0xF6, 0xF7, 0xF8, 0xF9, 0xFA, 0xFB, 0xFC, 0xFD, 0xFE, 0xFF, 0x80}
 	parentSpanID := []byte{0x1F, 0x1E, 0x1D, 0x1C, 0x1B, 0x1A, 0x19, 0x18}

--- a/receiver/jaegerreceiver/trace_receiver_test.go
+++ b/receiver/jaegerreceiver/trace_receiver_test.go
@@ -196,60 +196,6 @@ func TestGRPCReceptionWithTLS(t *testing.T) {
 	assert.Equal(t, "", cmp.Diff(got, want))
 }
 
-func TestThriftCompactReception(t *testing.T) {
-	// 1. Create the Jaeger receiver aka "server"
-	config := &Configuration{
-		AgentCompactThriftPort: 6831, // that's the only one used by this test
-	}
-	sink := new(exportertest.SinkTraceExporter)
-
-	jr, err := New(context.Background(), config, sink)
-	defer jr.StopTraceReception()
-	assert.NoError(t, err, "should not have failed to create the Jaeger received")
-
-	t.Log("Starting")
-
-	mh := receivertest.NewMockHost()
-	err = jr.StartTraceReception(mh)
-	assert.NoError(t, err, "should not have failed to start trace reception")
-
-	t.Log("StartTraceReception")
-
-	now := time.Unix(1542158650, 536343000).UTC()
-	nowPlus10min := now.Add(10 * time.Minute)
-	nowPlus10min2sec := now.Add(10 * time.Minute).Add(2 * time.Second)
-
-	// 2. Then with a "live application", send spans to the Jaeger exporter.
-	jexp, err := jaeger.NewExporter(jaeger.Options{
-		Process: jaeger.Process{
-			ServiceName: "issaTest",
-			Tags: []jaeger.Tag{
-				jaeger.BoolTag("bool", true),
-				jaeger.StringTag("string", "yes"),
-				jaeger.Int64Tag("int64", 1e7),
-			},
-		},
-		AgentEndpoint: fmt.Sprintf("localhost:%d", config.AgentCompactThriftPort),
-	})
-	assert.NoError(t, err, "should not have failed to create the Jaeger OpenCensus exporter")
-
-	// 3. Now finally send some spans
-	for _, sd := range traceFixture(now, nowPlus10min, nowPlus10min2sec) {
-		jexp.ExportSpan(sd)
-	}
-	jexp.Flush()
-
-	// sleep for one second to allow UDP to send.
-	time.Sleep(1 * time.Second)
-
-	got := sink.AllTraces()
-	want := expectedTraceData(now, nowPlus10min, nowPlus10min2sec)
-
-	if diff := cmp.Diff(got, want); diff != "" {
-		t.Errorf("Mismatched responses\n-Got +Want:\n\t%s", diff)
-	}
-}
-
 func expectedTraceData(t1, t2, t3 time.Time) []consumerdata.TraceData {
 	traceID := []byte{0xF1, 0xF2, 0xF3, 0xF4, 0xF5, 0xF6, 0xF7, 0xF8, 0xF9, 0xFA, 0xFB, 0xFC, 0xFD, 0xFE, 0xFF, 0x80}
 	parentSpanID := []byte{0x1F, 0x1E, 0x1D, 0x1C, 0x1B, 0x1A, 0x19, 0x18}

--- a/receiver/jaegerreceiver/trace_receiver_test.go
+++ b/receiver/jaegerreceiver/trace_receiver_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
-	"net"
 	"path"
 	"testing"
 	"time"
@@ -39,7 +38,6 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-collector/exporter/exportertest"
 	"github.com/open-telemetry/opentelemetry-collector/internal"
-	"github.com/open-telemetry/opentelemetry-collector/internal/testutils"
 	"github.com/open-telemetry/opentelemetry-collector/receiver"
 	"github.com/open-telemetry/opentelemetry-collector/receiver/receivertest"
 	tracetranslator "github.com/open-telemetry/opentelemetry-collector/translator/trace"
@@ -103,27 +101,6 @@ func TestReception(t *testing.T) {
 	}
 }
 
-func TestHTTPCollectorPortInUse(t *testing.T) {
-	port := testutils.GetAvailablePort(t)
-
-	config := &Configuration{
-		CollectorHTTPPort: int(port),
-	}
-	sink := new(exportertest.SinkTraceExporter)
-
-	l, err := net.Listen("tcp", fmt.Sprintf("localhost:%d", port))
-	defer l.Close()
-	assert.NoErrorf(t, err, "should have been able to open port %d", port)
-
-	jr, err := New(context.Background(), config, sink, zap.NewNop())
-	defer jr.StopTraceReception()
-	assert.NoError(t, err, "should have been to create the receiver")
-
-	mh := receivertest.NewMockHost()
-	err = jr.StartTraceReception(mh)
-	assert.Error(t, err, "should not have been able to start the collector")
-}
-
 func TestGRPCReception(t *testing.T) {
 	// prepare
 	config := &Configuration{
@@ -169,27 +146,6 @@ func TestGRPCReception(t *testing.T) {
 		t.Errorf("Mismatched responses\n-Got +Want:\n\t%s", diff)
 	}
 
-}
-
-func TestGRPCCollectorPortInUse(t *testing.T) {
-	port := testutils.GetAvailablePort(t)
-
-	config := &Configuration{
-		CollectorGRPCPort: int(port),
-	}
-	sink := new(exportertest.SinkTraceExporter)
-
-	l, err := net.Listen("tcp", fmt.Sprintf("localhost:%d", port))
-	defer l.Close()
-	assert.NoErrorf(t, err, "should have been able to open port %d", port)
-
-	jr, err := New(context.Background(), config, sink, zap.NewNop())
-	defer jr.StopTraceReception()
-	assert.NoError(t, err, "should have been to create the receiver")
-
-	mh := receivertest.NewMockHost()
-	err = jr.StartTraceReception(mh)
-	assert.Error(t, err, "should not have been able to start the collector")
 }
 
 func TestGRPCReceptionWithTLS(t *testing.T) {

--- a/receiver/jaegerreceiver/trace_receiver_test.go
+++ b/receiver/jaegerreceiver/trace_receiver_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opencensus.io/trace"
+	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 
@@ -49,7 +50,7 @@ func TestReception(t *testing.T) {
 	}
 	sink := new(exportertest.SinkTraceExporter)
 
-	jr, err := New(context.Background(), config, sink)
+	jr, err := New(context.Background(), config, sink, zap.NewNop())
 	defer jr.StopTraceReception()
 	assert.NoError(t, err, "should not have failed to create the Jaeger received")
 
@@ -100,7 +101,7 @@ func TestGRPCReception(t *testing.T) {
 	}
 	sink := new(exportertest.SinkTraceExporter)
 
-	jr, err := New(context.Background(), config, sink)
+	jr, err := New(context.Background(), config, sink, zap.NewNop())
 	assert.NoError(t, err, "should not have failed to create a new receiver")
 	defer jr.StopTraceReception()
 
@@ -158,7 +159,7 @@ func TestGRPCReceptionWithTLS(t *testing.T) {
 	}
 	sink := new(exportertest.SinkTraceExporter)
 
-	jr, err := New(context.Background(), config, sink)
+	jr, err := New(context.Background(), config, sink, zap.NewNop())
 	assert.NoError(t, err, "should not have failed to create a new receiver")
 	defer jr.StopTraceReception()
 

--- a/testbed/go.mod
+++ b/testbed/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/spf13/viper v1.4.1-0.20190911140308-99520c81d86e
 	github.com/stretchr/testify v1.4.0
 	go.opencensus.io v0.22.1
+	go.uber.org/zap v1.10.0
 )
 
 replace github.com/open-telemetry/opentelemetry-collector => ../

--- a/testbed/testbed/mock_backend.go
+++ b/testbed/testbed/mock_backend.go
@@ -22,11 +22,12 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"go.uber.org/zap"
+
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-collector/receiver"
 	"github.com/open-telemetry/opentelemetry-collector/receiver/jaegerreceiver"
 	"github.com/open-telemetry/opentelemetry-collector/receiver/opencensusreceiver"
-	"go.uber.org/zap"
 )
 
 // MockBackend is a backend that allows receiving the data locally.

--- a/testbed/testbed/mock_backend.go
+++ b/testbed/testbed/mock_backend.go
@@ -26,6 +26,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector/receiver"
 	"github.com/open-telemetry/opentelemetry-collector/receiver/jaegerreceiver"
 	"github.com/open-telemetry/opentelemetry-collector/receiver/opencensusreceiver"
+	"go.uber.org/zap"
 )
 
 // MockBackend is a backend that allows receiving the data locally.
@@ -109,7 +110,7 @@ func (mb *MockBackend) Start(backendType BackendType) error {
 		jaegerCfg := jaegerreceiver.Configuration{
 			CollectorHTTPPort: 14268,
 		}
-		mb.jaegerReceiver, err = jaegerreceiver.New(context.Background(), &jaegerCfg, mb.tc)
+		mb.jaegerReceiver, err = jaegerreceiver.New(context.Background(), &jaegerCfg, mb.tc, zap.NewNop())
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Adds the ability to configure the Jaeger Agent protocols independently.  Resolves #157.

Changes: 
- Added documentation about new configuration options
- Added new options to config tests
- Removed `agent *agentapp.Agent` because the agent did not support independently configuring the http server and agent protocols.  
- Added agentProcessors/agentServer to allow for independent configuration of remote sampling proxy as well as agent protocols.
- Added structure to support future addition of jaeger http proxy for remote sampling/baggage.
- Correctly set the `SourceFormat` to jaeger for spans ingested through the agent services.

Tests pass and this has been manually tested in our internal environment.

cc @annanay25 