### PR TITLE
Unslice to simplify

### DIFF
--- a/exporter/exporterhelper/metricshelper_test.go
+++ b/exporter/exporterhelper/metricshelper_test.go
@@ -204,7 +204,7 @@ func checkWrapSpanForMetricsExporter(t *testing.T, me exporter.MetricsExporter, 
 
 	require.NotEqual(t, 0, len(ocSpansSaver.spanData), "No exported span data")
 
-	gotSpanData := ocSpansSaver.spanData[:]
+	gotSpanData := ocSpansSaver.spanData
 	require.Equal(t, numRequests+1, len(gotSpanData))
 
 	parentSpan := gotSpanData[numRequests]

--- a/exporter/exporterhelper/tracehelper_test.go
+++ b/exporter/exporterhelper/tracehelper_test.go
@@ -202,7 +202,7 @@ func checkWrapSpanForTraceExporter(t *testing.T, te exporter.TraceExporter, want
 
 	require.NotEqual(t, 0, len(ocSpansSaver.spanData), "No exported span data.")
 
-	gotSpanData := ocSpansSaver.spanData[:]
+	gotSpanData := ocSpansSaver.spanData
 	require.Equal(t, numRequests+1, len(gotSpanData))
 
 	parentSpan := gotSpanData[numRequests]

--- a/exporter/exportertest/sink_exporter.go
+++ b/exporter/exportertest/sink_exporter.go
@@ -62,7 +62,7 @@ func (ste *SinkTraceExporter) AllTraces() []consumerdata.TraceData {
 	ste.mu.Lock()
 	defer ste.mu.Unlock()
 
-	return ste.traces[:]
+	return ste.traces
 }
 
 // Shutdown stops the exporter and is invoked during shutdown.
@@ -105,7 +105,7 @@ func (sme *SinkMetricsExporter) AllMetrics() []consumerdata.MetricsData {
 	sme.mu.Lock()
 	defer sme.mu.Unlock()
 
-	return sme.metrics[:]
+	return sme.metrics
 }
 
 // Shutdown stops the exporter and is invoked during shutdown.

--- a/receiver/opencensusreceiver/octrace/observability_test.go
+++ b/receiver/opencensusreceiver/octrace/observability_test.go
@@ -126,7 +126,7 @@ func TestExportSpanLinkingMaintainsParentLink(t *testing.T) {
 		"Unfortunately did not receive an exported span data. Please check this library's implementation or go.opencensus.io/trace",
 	)
 
-	gotSpanData := ocSpansSaver.spanData[:]
+	gotSpanData := ocSpansSaver.spanData
 	if g, w := len(gotSpanData), n+1; g != w {
 		blob, _ := json.MarshalIndent(gotSpanData, "  ", " ")
 		t.Fatalf("Spandata count: Got %d Want %d\n\nData: %s", g, w, blob)


### PR DESCRIPTION
Slicing is unnecessary, because slice expressions are equal to itself when evaluated. That's why removed to simplify.