### PR TITLE
Set logger for queued_retry

### DIFF
--- a/processor/queuedprocessor/factory.go
+++ b/processor/queuedprocessor/factory.go
@@ -66,6 +66,7 @@ func (f *Factory) CreateTraceProcessor(
 		Options.WithQueueSize(oCfg.QueueSize),
 		Options.WithRetryOnProcessingFailures(oCfg.RetryOnFailure),
 		Options.WithBackoffDelay(oCfg.BackoffDelay),
+		Options.WithLogger(logger),
 	), nil
 }
 


### PR DESCRIPTION
The logger for the queued retry is not being set making hard to debug issues.