### PR TITLE
Make Testbed more protocol-independent

### DIFF
--- a/testbed/go.mod
+++ b/testbed/go.mod
@@ -6,7 +6,7 @@ require (
 	contrib.go.opencensus.io/exporter/jaeger v0.1.1-0.20190430175949-e8b55949d948
 	github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d // indirect
 	github.com/go-ole/go-ole v1.2.4 // indirect
-	github.com/open-telemetry/opentelemetry-collector v0.0.0-20190625135304-4bd705a25a35
+	github.com/open-telemetry/opentelemetry-collector v0.2.1-0.20191205212659-419ed61e5bac
 	github.com/shirou/gopsutil v2.18.12+incompatible
 	github.com/spf13/viper v1.4.1-0.20190911140308-99520c81d86e
 	github.com/stretchr/testify v1.4.0

--- a/testbed/go.sum
+++ b/testbed/go.sum
@@ -580,6 +580,8 @@ github.com/uber/jaeger-client-go v2.16.0+incompatible h1:Q2Pp6v3QYiocMxomCaJuwQG
 github.com/uber/jaeger-client-go v2.16.0+incompatible/go.mod h1:WVhlPFC8FDjOFMMWRy2pZqQJSXxYSwNYOkTr/Z6d3Kk=
 github.com/uber/jaeger-lib v2.0.0+incompatible h1:iMSCV0rmXEogjNWPh2D0xk9YVKvrtGoHJNe9ebLu/pw=
 github.com/uber/jaeger-lib v2.0.0+incompatible/go.mod h1:ComeNDZlWwrWnDv8aPp0Ba6+uUTzImX/AauajbLI56U=
+github.com/uber/jaeger-lib v2.2.0+incompatible h1:MxZXOiR2JuoANZ3J6DE/U0kSFv/eJ/GfSYVCjK7dyaw=
+github.com/uber/jaeger-lib v2.2.0+incompatible/go.mod h1:ComeNDZlWwrWnDv8aPp0Ba6+uUTzImX/AauajbLI56U=
 github.com/uber/tchannel-go v1.10.0 h1:YOihLHuvkwT3nzvpgqFtexFW+pb5vD1Tz7h/bIWApgE=
 github.com/uber/tchannel-go v1.10.0/go.mod h1:Rrgz1eL8kMjW/nEzZos0t+Heq0O4LhnUJVA32OvWKHo=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=

--- a/testbed/testbed/mock_backend.go
+++ b/testbed/testbed/mock_backend.go
@@ -43,13 +43,6 @@ type MockBackend struct {
 	stopOnce  sync.Once
 }
 
-type BackendType int
-
-const (
-	BackendJaeger BackendType = iota
-	BackendOC
-)
-
 // NewMockBackend creates a new mock backend that receives data using specified receiver.
 func NewMockBackend(logFilePath string, receiver Receiver) *MockBackend {
 	mb := &MockBackend{
@@ -71,8 +64,7 @@ func (mb *MockBackend) ReportFatalError(err error) {
 	log.Printf("Fatal error reported: %v", err)
 }
 
-// Start a backend of specified type. Only one backend type
-// can be started at a time.
+// Start a backend.
 func (mb *MockBackend) Start() error {
 	log.Printf("Starting mock backend...")
 

--- a/testbed/testbed/mock_backend.go
+++ b/testbed/testbed/mock_backend.go
@@ -22,12 +22,8 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"go.uber.org/zap"
-
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-collector/receiver"
-	"github.com/open-telemetry/opentelemetry-collector/receiver/jaegerreceiver"
-	"github.com/open-telemetry/opentelemetry-collector/receiver/opencensusreceiver"
 )
 
 // MockBackend is a backend that allows receiving the data locally.
@@ -36,19 +32,15 @@ type MockBackend struct {
 	tc *mockTraceConsumer
 	mc *mockMetricConsumer
 
-	// Receivers
-	ocReceiver     *opencensusreceiver.Receiver
-	jaegerReceiver receiver.TraceReceiver
-	jaegerErrChan  chan error
+	receiver Receiver
 
 	// Log file
 	logFilePath string
 	logFile     *os.File
 
 	// Start/stop flags
-	isStarted  bool
-	stopOnce   sync.Once
-	doneSignal chan struct{}
+	isStarted bool
+	stopOnce  sync.Once
 }
 
 type BackendType int
@@ -58,13 +50,14 @@ const (
 	BackendOC
 )
 
-// NewMockBackend creates a new mock backend.
-func NewMockBackend(logFilePath string) *MockBackend {
+// NewMockBackend creates a new mock backend that receives data using specified receiver.
+func NewMockBackend(logFilePath string, receiver Receiver) *MockBackend {
 	mb := &MockBackend{
 		logFilePath: logFilePath,
+		receiver:    receiver,
+		tc:          &mockTraceConsumer{},
+		mc:          &mockMetricConsumer{},
 	}
-	mb.tc = &mockTraceConsumer{}
-	mb.mc = &mockMetricConsumer{}
 	return mb
 }
 
@@ -80,7 +73,7 @@ func (mb *MockBackend) ReportFatalError(err error) {
 
 // Start a backend of specified type. Only one backend type
 // can be started at a time.
-func (mb *MockBackend) Start(backendType BackendType) error {
+func (mb *MockBackend) Start() error {
 	log.Printf("Starting mock backend...")
 
 	var err error
@@ -91,45 +84,12 @@ func (mb *MockBackend) Start(backendType BackendType) error {
 		return err
 	}
 
-	mb.doneSignal = make(chan struct{})
-	mb.jaegerErrChan = make(chan error)
-
-	switch backendType {
-	case BackendOC:
-		addr := "localhost:56565"
-		mb.ocReceiver, err = opencensusreceiver.New(addr, mb.tc, mb.mc)
-		if err != nil {
-			return err
-		}
-
-		err := mb.ocReceiver.StartTraceReception(mb)
-		if err != nil {
-			return err
-		}
-
-	case BackendJaeger:
-		jaegerCfg := jaegerreceiver.Configuration{
-			CollectorHTTPPort: 14268,
-		}
-		mb.jaegerReceiver, err = jaegerreceiver.New(context.Background(), &jaegerCfg, mb.tc, zap.NewNop())
-		if err != nil {
-			return err
-		}
-
-		go func() {
-			for err := range mb.jaegerErrChan {
-				log.Printf("Error from Jaeger receiver: %s", err.Error())
-			}
-		}()
-
-		err := mb.jaegerReceiver.StartTraceReception(mb)
-		if err != nil {
-			return err
-		}
+	err = mb.receiver.Start(mb.tc, mb.mc)
+	if err != nil {
+		return err
 	}
 
 	mb.isStarted = true
-
 	return nil
 }
 
@@ -142,20 +102,8 @@ func (mb *MockBackend) Stop() {
 
 		log.Printf("Stopping mock backend...")
 
-		close(mb.doneSignal)
-
 		mb.logFile.Close()
-
-		if mb.ocReceiver != nil {
-			_ = mb.ocReceiver.StopTraceReception()
-		}
-
-		if mb.jaegerReceiver != nil {
-			if err := mb.jaegerReceiver.StopTraceReception(); err != nil {
-				log.Printf("Cannot stop Jaeger receiver: %s", err.Error())
-			}
-		}
-		close(mb.jaegerErrChan)
+		mb.receiver.Stop()
 
 		// Print stats.
 		log.Printf("Stopped backend. %s", mb.GetStats())

--- a/testbed/testbed/mock_backend_test.go
+++ b/testbed/testbed/mock_backend_test.go
@@ -20,19 +20,22 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/open-telemetry/opentelemetry-collector/internal/testutils"
 )
 
 func TestGeneratorAndBackend(t *testing.T) {
-	mb := NewMockBackend("mockbackend.log")
+	port := int(testutils.GetAvailablePort(t))
+	mb := NewMockBackend("mockbackend.log", NewJaegerReceiver(port))
 
 	assert.EqualValues(t, 0, mb.SpansReceived())
 
-	err := mb.Start(BackendJaeger)
+	err := mb.Start()
 	require.NoError(t, err, "Cannot start backend")
 
 	defer mb.Stop()
 
-	lg, err := NewLoadGenerator()
+	lg, err := NewLoadGenerator(NewJaegerExporter(port))
 	require.NoError(t, err, "Cannot start load generator")
 
 	assert.EqualValues(t, 0, lg.spansSent)

--- a/testbed/testbed/receivers.go
+++ b/testbed/testbed/receivers.go
@@ -37,7 +37,7 @@ type Receiver interface {
 
 	// Generate a config string to place in exporter part of collector config
 	// so that it can send data to this receiver.
-	GenConfigStr() string
+	GenConfigYAMLStr() string
 
 	// Return protocol name to use in collector config pipeline.
 	ProtocolName() string
@@ -78,7 +78,7 @@ func (or *OCReceiver) Stop() {
 	or.receiver.StopTraceReception()
 }
 
-func (or *OCReceiver) GenConfigStr() string {
+func (or *OCReceiver) GenConfigYAMLStr() string {
 	// Note that this generates an exporter config for agent.
 	return `
   opencensus:
@@ -123,7 +123,7 @@ func (jr *jaegerReceiver) Stop() {
 	}
 }
 
-func (jr *jaegerReceiver) GenConfigStr() string {
+func (jr *jaegerReceiver) GenConfigYAMLStr() string {
 	// Note that this generates an exporter config for agent.
 	return fmt.Sprintf(`
   jaeger_thrift_http:

--- a/testbed/testbed/receivers.go
+++ b/testbed/testbed/receivers.go
@@ -1,0 +1,135 @@
+// Copyright 2019, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testbed
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector/receiver"
+	"github.com/open-telemetry/opentelemetry-collector/receiver/jaegerreceiver"
+	"github.com/open-telemetry/opentelemetry-collector/receiver/opencensusreceiver"
+)
+
+// Receiver allows to receive traces or metrics. This is an interface that must
+// be implemented by all protocols that want to be used in MockBackend.
+// Note the terminology: testbed.Receiver is something that can listen and receive data
+// from Collector and the corresponding entity in the Collector that sends this data is
+// an exporter.
+type Receiver interface {
+	Start(tc *mockTraceConsumer, mc *mockMetricConsumer) error
+	Stop()
+
+	// Generate a config string to place in exporter part of collector config
+	// so that it can send data to this receiver.
+	GenConfigStr() string
+
+	// Return protocol name to use in collector config pipeline.
+	ProtocolName() string
+}
+
+// ReceiverBase implement basic functions needed by all receivers.
+type ReceiverBase struct{}
+
+func (mb *ReceiverBase) Context() context.Context {
+	return context.Background()
+}
+
+func (mb *ReceiverBase) ReportFatalError(err error) {
+	log.Printf("Fatal error reported: %v", err)
+}
+
+// OCReceiver implements OpenCensus format receiver.
+type OCReceiver struct {
+	ReceiverBase
+	receiver *opencensusreceiver.Receiver
+}
+
+func (or *OCReceiver) Start(tc *mockTraceConsumer, mc *mockMetricConsumer) error {
+	// TODO: make the port dynamic.
+	addr := "localhost:56565"
+	var err error
+	or.receiver, err = opencensusreceiver.New(addr, tc, mc)
+	if err != nil {
+		return err
+	}
+
+	// TODO: add metric support.
+	return or.receiver.StartTraceReception(or)
+}
+
+func (or *OCReceiver) Stop() {
+	// TODO: add metric support.
+	or.receiver.StopTraceReception()
+}
+
+func (or *OCReceiver) GenConfigStr() string {
+	// Note that this generates an exporter config for agent.
+	return `
+  opencensus:
+    endpoint: "localhost:56565"`
+}
+
+func (or *OCReceiver) ProtocolName() string {
+	return "opencensus"
+}
+
+// jaegerReceiver implements Jaeger format receiver.
+type jaegerReceiver struct {
+	ReceiverBase
+	receiver receiver.TraceReceiver
+	port     int
+}
+
+const DefaultJaegerPort = 14268
+
+func NewJaegerReceiver(port int) *jaegerReceiver {
+	return &jaegerReceiver{port: port}
+}
+
+func (jr *jaegerReceiver) Start(tc *mockTraceConsumer, mc *mockMetricConsumer) error {
+	jaegerCfg := jaegerreceiver.Configuration{
+		CollectorHTTPPort: jr.port,
+	}
+	var err error
+	jr.receiver, err = jaegerreceiver.New(context.Background(), &jaegerCfg, tc, zap.NewNop())
+	if err != nil {
+		return err
+	}
+
+	return jr.receiver.StartTraceReception(jr)
+}
+
+func (jr *jaegerReceiver) Stop() {
+	if jr.receiver != nil {
+		if err := jr.receiver.StopTraceReception(); err != nil {
+			log.Printf("Cannot stop Jaeger receiver: %s", err.Error())
+		}
+	}
+}
+
+func (jr *jaegerReceiver) GenConfigStr() string {
+	// Note that this generates an exporter config for agent.
+	return fmt.Sprintf(`
+  jaeger_thrift_http:
+    url: "http://localhost:%d/api/traces"`, jr.port)
+}
+
+func (jr *jaegerReceiver) ProtocolName() string {
+	return "jaeger_thrift_http"
+}

--- a/testbed/testbed/test_case.go
+++ b/testbed/testbed/test_case.go
@@ -15,7 +15,9 @@
 package testbed
 
 import (
+	"fmt"
 	"log"
+	"net"
 	"os"
 	"path"
 	"path/filepath"
@@ -167,9 +169,13 @@ func (tc *TestCase) StartAgent(args ...string) {
 		}
 	}()
 
-	// Wait a bit for agent to start. This is a hack. We need to have a way to
-	// wait for agent to start properly.
-	time.Sleep(200 * time.Millisecond)
+	// Wait for agent to start. We consider the agent started when we can
+	// connect to the port to which we intend to send load.
+	tc.WaitFor(func() bool {
+		_, err := net.Dial("tcp",
+			fmt.Sprintf("localhost:%d", tc.LoadGenerator.exporter.GetCollectorPort()))
+		return err == nil
+	})
 }
 
 // StopAgent stops agent process.

--- a/testbed/testbed/test_case.go
+++ b/testbed/testbed/test_case.go
@@ -62,8 +62,13 @@ type TestCase struct {
 
 const mibibyte = 1024 * 1024
 
-// NewTestCase creates a new TestCase. It expected agent-config.yaml in the specified directory.
-func NewTestCase(t *testing.T, opts ...TestCaseOption) *TestCase {
+// NewTestCase creates a new TestCase. It expects agent-config.yaml in the specified directory.
+func NewTestCase(
+	t *testing.T,
+	exporter TraceExporter,
+	receiver Receiver,
+	opts ...TestCaseOption,
+) *TestCase {
 	tc := TestCase{}
 
 	tc.t = t
@@ -100,12 +105,12 @@ func NewTestCase(t *testing.T, opts ...TestCaseOption) *TestCase {
 		tc.t.Fatalf("Cannot resolve filename: %s", err.Error())
 	}
 
-	tc.LoadGenerator, err = NewLoadGenerator()
+	tc.LoadGenerator, err = NewLoadGenerator(exporter)
 	if err != nil {
 		t.Fatalf("Cannot create generator: %s", err.Error())
 	}
 
-	tc.MockBackend = NewMockBackend(tc.composeTestResultFileName("backend.log"))
+	tc.MockBackend = NewMockBackend(tc.composeTestResultFileName("backend.log"), receiver)
 
 	go tc.logStats()
 
@@ -184,8 +189,8 @@ func (tc *TestCase) StopLoad() {
 }
 
 // StartBackend starts the specified backend type.
-func (tc *TestCase) StartBackend(backendType BackendType) {
-	if err := tc.MockBackend.Start(backendType); err != nil {
+func (tc *TestCase) StartBackend() {
+	if err := tc.MockBackend.Start(); err != nil {
 		tc.t.Fatalf("Cannot start backend: %s", err.Error())
 	}
 }

--- a/testbed/testbed/trace_exporters.go
+++ b/testbed/testbed/trace_exporters.go
@@ -1,0 +1,100 @@
+// Copyright 2019, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testbed
+
+import (
+	"fmt"
+
+	"contrib.go.opencensus.io/exporter/jaeger"
+	"go.opencensus.io/trace"
+)
+
+// TraceExporter defines the interface that allows sending span data. This is an interface
+// that must be implemented by all protocols that want to be used in LoadGenerator.
+// Note the terminology: testbed.TraceExporter is something that sends data to Collector
+// and the corresponding entity in the Collector is a receiver.
+type TraceExporter interface {
+	ExportSpans(spans []*trace.SpanData)
+	Flush()
+
+	// Generate a config string to place in receiver part of collector config
+	// so that it can receive data from this exporter.
+	GenConfigStr() string
+
+	// Return protocol name to use in collector config pipeline.
+	ProtocolName() string
+}
+
+type jaegerExporter struct {
+	exporter *jaeger.Exporter
+	port     int
+}
+
+// Create a new Jaeger protocol exporter.
+func NewJaegerExporter(port int) *jaegerExporter {
+	opts := jaeger.Options{
+		// Use standard URL for Jaeger.
+		CollectorEndpoint: fmt.Sprintf("http://localhost:%d/api/traces", port),
+		Process: jaeger.Process{
+			ServiceName: "load-generator",
+		},
+	}
+
+	exporter, err := jaeger.NewExporter(opts)
+	if err != nil {
+		return nil
+	}
+
+	return &jaegerExporter{exporter: exporter, port: port}
+}
+
+func (je *jaegerExporter) ExportSpans(spans []*trace.SpanData) {
+	for _, span := range spans {
+		je.exporter.ExportSpan(span)
+	}
+}
+
+func (je *jaegerExporter) Flush() {
+	je.exporter.Flush()
+}
+
+func (je *jaegerExporter) GenConfigStr() string {
+	// Note that this generates a receiver config for agent.
+	// We only need to enable thrift-http protocol because that's what we use in tests.
+	// Due to bug in Jaeger receiver (https://github.com/open-telemetry/opentelemetry-collector/issues/445)
+	// which makes impossible to disable protocols that we don't need to receive on we
+	// have to use fake ports for all endpoints except thrift-http, otherwise it is
+	// impossible to start the Collector because the standard ports for those protocols
+	// are already listened by mock Jaeger backend that is part of the tests.
+	// As soon as the bug is fixed remove the endpoints and use "disabled: true" setting
+	// instead.
+	return fmt.Sprintf(`
+  jaeger:
+    protocols:
+      grpc:
+        endpoint: "localhost:8371"
+      thrift-tchannel:
+        endpoint: "localhost:8372"
+      thrift-compact:
+        endpoint: "localhost:8373"
+      thrift-binary:
+        endpoint: "localhost:8374"
+      thrift-http:
+        endpoint: "localhost:%d"`, je.port)
+}
+
+func (je *jaegerExporter) ProtocolName() string {
+	return "jaeger"
+}

--- a/testbed/testbed/trace_exporters.go
+++ b/testbed/testbed/trace_exporters.go
@@ -29,6 +29,9 @@ type TraceExporter interface {
 	ExportSpans(spans []*trace.SpanData)
 	Flush()
 
+	// Return the port to which this exporter will send data.
+	GetCollectorPort() int
+
 	// Generate a config string to place in receiver part of collector config
 	// so that it can receive data from this exporter.
 	GenConfigStr() string
@@ -93,6 +96,10 @@ func (je *jaegerExporter) GenConfigStr() string {
         endpoint: "localhost:8374"
       thrift-http:
         endpoint: "localhost:%d"`, je.port)
+}
+
+func (je *jaegerExporter) GetCollectorPort() int {
+	return je.port
 }
 
 func (je *jaegerExporter) ProtocolName() string {

--- a/testbed/testbed/trace_exporters.go
+++ b/testbed/testbed/trace_exporters.go
@@ -34,7 +34,7 @@ type TraceExporter interface {
 
 	// Generate a config string to place in receiver part of collector config
 	// so that it can receive data from this exporter.
-	GenConfigStr() string
+	GenConfigYAMLStr() string
 
 	// Return protocol name to use in collector config pipeline.
 	ProtocolName() string
@@ -73,11 +73,11 @@ func (je *jaegerExporter) Flush() {
 	je.exporter.Flush()
 }
 
-func (je *jaegerExporter) GenConfigStr() string {
+func (je *jaegerExporter) GenConfigYAMLStr() string {
 	// Note that this generates a receiver config for agent.
 	// We only need to enable thrift-http protocol because that's what we use in tests.
 	// Due to bug in Jaeger receiver (https://github.com/open-telemetry/opentelemetry-collector/issues/445)
-	// which makes impossible to disable protocols that we don't need to receive on we
+	// which makes it impossible to disable protocols that we don't need to receive on we
 	// have to use fake ports for all endpoints except thrift-http, otherwise it is
 	// impossible to start the Collector because the standard ports for those protocols
 	// are already listened by mock Jaeger backend that is part of the tests.

--- a/testbed/tests/e2e_test.go
+++ b/testbed/tests/e2e_test.go
@@ -39,7 +39,12 @@ func TestBallastMemory(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		tc := testbed.NewTestCase(t, testbed.WithSkipResults())
+		tc := testbed.NewTestCase(
+			t,
+			testbed.NewJaegerExporter(testbed.DefaultJaegerPort),
+			&testbed.OCReceiver{},
+			testbed.WithSkipResults(),
+		)
 		tc.SetExpectedMaxRAM(test.maxRSS)
 
 		tc.StartAgent("--mem-ballast-size-mib", strconv.Itoa(int(test.ballastSize)))

--- a/testbed/tests/perf_test.go
+++ b/testbed/tests/perf_test.go
@@ -71,6 +71,10 @@ func TestIdleMode(t *testing.T) {
 // createConfigFile creates a collector config file that corresponds to the
 // exporter and receiver used in the test and returns the config file name.
 func createConfigFile(exporter testbed.TraceExporter, receiver testbed.Receiver) string {
+	// Create a config. Note that our exporter is used to generate a config for Collector's
+	// receiver and our receiver is used to generate a config for Collector's exporter.
+	// This is because our exporter sends to Collector's receiver and our receiver
+	// receives from Collector's exporter.
 	config := fmt.Sprintf(`
 receivers:%v
 exporters:%v
@@ -83,7 +87,7 @@ service:
       receivers: [%v]
       processors: [queued_retry]
       exporters: [%v]
-`, exporter.GenConfigStr(), receiver.GenConfigStr(), exporter.ProtocolName(), receiver.ProtocolName())
+`, exporter.GenConfigYAMLStr(), receiver.GenConfigYAMLStr(), exporter.ProtocolName(), receiver.ProtocolName())
 
 	file, err := ioutil.TempFile("", "agent*.yaml")
 	if err != nil {

--- a/testbed/tests/perf_test.go
+++ b/testbed/tests/perf_test.go
@@ -19,12 +19,15 @@ package tests
 
 import (
 	"fmt"
+	"io/ioutil"
+	"log"
 	"math/rand"
 	"os"
 	"path"
 	"testing"
 	"time"
 
+	"github.com/open-telemetry/opentelemetry-collector/internal/testutils"
 	"github.com/open-telemetry/opentelemetry-collector/testbed/testbed"
 )
 
@@ -54,7 +57,7 @@ func genRandByteString(len int) string {
 }
 
 func TestIdleMode(t *testing.T) {
-	tc := testbed.NewTestCase(t)
+	tc := testbed.NewTestCase(t, testbed.NewJaegerExporter(testbed.DefaultJaegerPort), &testbed.OCReceiver{})
 	defer tc.Stop()
 
 	tc.SetExpectedMaxCPU(4)
@@ -65,14 +68,51 @@ func TestIdleMode(t *testing.T) {
 	tc.Sleep(10 * time.Second)
 }
 
-func Test10kSPS(t *testing.T) {
-	tc := testbed.NewTestCase(t)
+// createConfigFile creates a collector config file that corresponds to the
+// exporter and receiver used in the test and returns the config file name.
+func createConfigFile(exporter testbed.TraceExporter, receiver testbed.Receiver) string {
+	config := fmt.Sprintf(`
+receivers:%v
+exporters:%v
+processors:
+  queued_retry:
+
+service:
+  pipelines:
+    traces:
+      receivers: [%v]
+      processors: [queued_retry]
+      exporters: [%v]
+`, exporter.GenConfigStr(), receiver.GenConfigStr(), exporter.ProtocolName(), receiver.ProtocolName())
+
+	file, err := ioutil.TempFile("", "agent*.yaml")
+	if err != nil {
+		log.Fatal(err)
+		return ""
+	}
+
+	_, err = file.WriteString(config)
+	if err != nil {
+		fmt.Println(err)
+		file.Close()
+		return ""
+	}
+
+	return file.Name()
+}
+
+// Run 10k spans/sec test using specified exporter and receiver protocols.
+func RunTest10kSPS(t *testing.T, exporter testbed.TraceExporter, receiver testbed.Receiver) {
+	configFile := createConfigFile(exporter, receiver)
+	defer os.Remove(configFile)
+
+	tc := testbed.NewTestCase(t, exporter, receiver, testbed.WithConfigFile(configFile))
 	defer tc.Stop()
 
 	tc.SetExpectedMaxCPU(150)
 	tc.SetExpectedMaxRAM(70)
 
-	tc.StartBackend(testbed.BackendOC)
+	tc.StartBackend()
 	tc.StartAgent()
 	tc.StartLoad(testbed.LoadOptions{SpansPerSecond: 10000})
 
@@ -88,8 +128,24 @@ func Test10kSPS(t *testing.T) {
 	tc.ValidateData()
 }
 
+func Test10kSPS(t *testing.T) {
+	tests := []struct {
+		name     string
+		receiver testbed.Receiver
+	}{
+		{"JaegerRx", testbed.NewJaegerReceiver(int(testutils.GetAvailablePort(t)))},
+		{"OpenCensusRx", &testbed.OCReceiver{}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			RunTest10kSPS(t, testbed.NewJaegerExporter(int(testutils.GetAvailablePort(t))), test.receiver)
+		})
+	}
+}
+
 func TestNoBackend10kSPS(t *testing.T) {
-	tc := testbed.NewTestCase(t)
+	tc := testbed.NewTestCase(t, testbed.NewJaegerExporter(testbed.DefaultJaegerPort), &testbed.OCReceiver{})
 	defer tc.Stop()
 
 	tc.SetExpectedMaxCPU(200)
@@ -108,17 +164,17 @@ type testCase struct {
 	expectedMaxRAM uint32
 }
 
-func test1000SPSWithAttributes(t *testing.T, args []string, tests []testCase, opts ...testbed.TestCaseOption) {
+func test1kSPSWithAttrs(t *testing.T, args []string, tests []testCase, opts ...testbed.TestCaseOption) {
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("%d*%dbytes", test.attrCount, test.attrSizeByte), func(t *testing.T) {
 
-			tc := testbed.NewTestCase(t, opts...)
+			tc := testbed.NewTestCase(t, testbed.NewJaegerExporter(testbed.DefaultJaegerPort), &testbed.OCReceiver{}, opts...)
 			defer tc.Stop()
 
 			tc.SetExpectedMaxCPU(test.expectedMaxCPU)
 			tc.SetExpectedMaxRAM(test.expectedMaxRAM)
 
-			tc.StartBackend(testbed.BackendOC)
+			tc.StartBackend()
 			tc.StartAgent(args...)
 
 			options := testbed.LoadOptions{SpansPerSecond: 1000}
@@ -144,8 +200,8 @@ func test1000SPSWithAttributes(t *testing.T, args []string, tests []testCase, op
 	}
 }
 
-func Test1000SPSWithAttributes(t *testing.T) {
-	test1000SPSWithAttributes(t, []string{}, []testCase{
+func Test1kSPSWithAttrs(t *testing.T) {
+	test1kSPSWithAttrs(t, []string{}, []testCase{
 		// No attributes.
 		{
 			attrCount:      0,
@@ -182,9 +238,9 @@ func Test1000SPSWithAttributes(t *testing.T) {
 	})
 }
 
-func TestBallast1000SPSWithAttributes(t *testing.T) {
+func TestBallast1kSPSWithAttrs(t *testing.T) {
 	args := []string{"--mem-ballast-size-mib", "1000"}
-	test1000SPSWithAttributes(t, args, []testCase{
+	test1kSPSWithAttrs(t, args, []testCase{
 		// No attributes.
 		{
 			attrCount:      0,
@@ -213,9 +269,9 @@ func TestBallast1000SPSWithAttributes(t *testing.T) {
 	})
 }
 
-func TestBallast1000SPSWithAttributesAddAttributesProcessor(t *testing.T) {
+func TestBallast1kSPSWithAttrsAddAttributes(t *testing.T) {
 	args := []string{"--mem-ballast-size-mib", "1000"}
-	test1000SPSWithAttributes(
+	test1kSPSWithAttrs(
 		t,
 		args,
 		[]testCase{


### PR DESCRIPTION
1. Extracted TraceExporter and Receiver out of LoadGenerator and MockBackend.
This makes the testbed core protocol-independent and allows to generate
and receive loads using different protocols more easily. Previously it
was pretty much hard-coded to either Jaeger or OC. Now more protocols
can be tested.
For now we have TraceExporter implementation only for OC protocol. Once more
protocol exporters are added to the testbed we can implement matrix testing
of different input/output protocols if needed. Until then all tests use
Collector's OC receiver.

2. Test10kSPS scenario now tests 2 Collector exporters (using 2 Testbed Receivers);
both Jaeger and OC are tested. The test uses dynamic port and generates
config for each protocol sub-test. This is to demonstrate that we are able
to test more than one protocol for the same scenario.

TODO: implement metrics portion and extract testbed.MetricExporter or
combine MetricExporter and TraceExporter into one testbed.Exporter.