### PR TITLE
Jaeger receiver: Remote sampling support

### DIFF
--- a/receiver/README.md
+++ b/receiver/README.md
@@ -148,7 +148,7 @@ receivers:
 
 ### Remote Sampling
 The Jaeger receiver also supports fetching sampling configuration from a remote collector.
-It works proxying client requests for remote sampling configuration to the configured collector.
+It works by proxying client requests for remote sampling configuration to the configured collector.
 
 +---------------+                   +--------------+              +-----------------+
 |               |       get         |              |    proxy     |                 |

--- a/receiver/README.md
+++ b/receiver/README.md
@@ -165,7 +165,7 @@ receivers:
       grpc:
       .
       .
-    remotesampling:
+    remote_sampling:
       fetch_endpoint: "jaeger-collector:1234"
 ``` 
 

--- a/receiver/README.md
+++ b/receiver/README.md
@@ -145,6 +145,31 @@ receivers:
           cert_file: /cert.pem # path to certificate
         endpoint: "localhost:9876"
 ``` 
+
+### Remote Sampling
+The Jaeger receiver also supports fetching sampling configuration from a remote collector.
+It works proxying client requests for remote sampling configuration to the configured collector.
+
++---------------+                   +--------------+              +-----------------+
+|               |       get         |              |    proxy     |                 |
+|    client     +---  sampling ---->+    agent     +------------->+    collector    |
+|               |     strategy      |              |              |                 |
++---------------+                   +--------------+              +-----------------+
+
+Remote sampling can be enabled by specifying the following lines in the jaeger receiver config:
+
+```yaml
+receivers:
+  jaeger:
+    protocols:
+      grpc:
+      .
+      .
+    remotesampling:
+      fetch_endpoint: "jaeger-collector:1234"
+``` 
+
+
 ## <a name="prometheus"></a>Prometheus Receiver
 **Only metrics are supported.**
 

--- a/receiver/jaegerreceiver/config.go
+++ b/receiver/jaegerreceiver/config.go
@@ -23,7 +23,7 @@ type Config struct {
 	TypeVal        string                                      `mapstructure:"-"`
 	NameVal        string                                      `mapstructure:"-"`
 	Protocols      map[string]*receiver.SecureReceiverSettings `mapstructure:"protocols"`
-	RemoteSampling map[string]*receiver.SecureReceiverSettings `mapstructure:"remotesampling"`
+	RemoteSampling map[string]string                           `mapstructure:"remotesampling"`
 }
 
 // Name gets the receiver name.

--- a/receiver/jaegerreceiver/config.go
+++ b/receiver/jaegerreceiver/config.go
@@ -20,9 +20,10 @@ import (
 
 // Config defines configuration for Jaeger receiver.
 type Config struct {
-	TypeVal   string                                      `mapstructure:"-"`
-	NameVal   string                                      `mapstructure:"-"`
-	Protocols map[string]*receiver.SecureReceiverSettings `mapstructure:"protocols"`
+	TypeVal        string                                      `mapstructure:"-"`
+	NameVal        string                                      `mapstructure:"-"`
+	Protocols      map[string]*receiver.SecureReceiverSettings `mapstructure:"protocols"`
+	RemoteSampling map[string]*receiver.SecureReceiverSettings `mapstructure:"remotesampling"`
 }
 
 // Name gets the receiver name.

--- a/receiver/jaegerreceiver/config.go
+++ b/receiver/jaegerreceiver/config.go
@@ -28,7 +28,7 @@ type Config struct {
 	TypeVal        string                                      `mapstructure:"-"`
 	NameVal        string                                      `mapstructure:"-"`
 	Protocols      map[string]*receiver.SecureReceiverSettings `mapstructure:"protocols"`
-	RemoteSampling *RemoteSamplingConfig                       `mapstructure:"remotesampling"`
+	RemoteSampling *RemoteSamplingConfig                       `mapstructure:"remote_sampling"`
 }
 
 // Name gets the receiver name.

--- a/receiver/jaegerreceiver/config.go
+++ b/receiver/jaegerreceiver/config.go
@@ -18,12 +18,17 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector/receiver"
 )
 
+// RemoteSamplingConfig defines config key for remote sampling fetch endpoint
+type RemoteSamplingConfig struct {
+	FetchEndpoint string `mapstructure:"fetch_endpoint"`
+}
+
 // Config defines configuration for Jaeger receiver.
 type Config struct {
 	TypeVal        string                                      `mapstructure:"-"`
 	NameVal        string                                      `mapstructure:"-"`
 	Protocols      map[string]*receiver.SecureReceiverSettings `mapstructure:"protocols"`
-	RemoteSampling map[string]string                           `mapstructure:"remotesampling"`
+	RemoteSampling *RemoteSamplingConfig                       `mapstructure:"remotesampling"`
 }
 
 // Name gets the receiver name.

--- a/receiver/jaegerreceiver/config_test.go
+++ b/receiver/jaegerreceiver/config_test.go
@@ -76,6 +76,9 @@ func TestLoadConfig(t *testing.T) {
 					},
 				},
 			},
+			RemoteSampling: map[string]string{
+				"fetch_endpoint": "jaeger-collector:1234",
+			},
 		})
 
 	tlsConfig := cfg.Receivers["jaeger/tls"].(*Config)

--- a/receiver/jaegerreceiver/config_test.go
+++ b/receiver/jaegerreceiver/config_test.go
@@ -76,8 +76,8 @@ func TestLoadConfig(t *testing.T) {
 					},
 				},
 			},
-			RemoteSampling: map[string]string{
-				"fetch_endpoint": "jaeger-collector:1234",
+			RemoteSampling: &RemoteSamplingConfig{
+				FetchEndpoint: "jaeger-collector:1234",
 			},
 		})
 

--- a/receiver/jaegerreceiver/factory.go
+++ b/receiver/jaegerreceiver/factory.go
@@ -165,8 +165,8 @@ func (f *Factory) CreateTraceReceiver(
 		}
 	}
 
-	if remoteSamplingEndpoint != nil {
-		config.RemoteSamplingEndpoint = remoteSamplingEndpoint.Endpoint
+	if remoteSamplingEndpoint != "" {
+		config.RemoteSamplingEndpoint = remoteSamplingEndpoint
 	}
 
 	if (protoGRPC == nil && protoHTTP == nil && protoTChannel == nil && protoThriftBinary == nil && protoThriftCompact == nil) ||

--- a/receiver/jaegerreceiver/factory.go
+++ b/receiver/jaegerreceiver/factory.go
@@ -48,9 +48,6 @@ const (
 	defaultGRPCBindEndpoint     = "localhost:14250"
 	defaultHTTPBindEndpoint     = "localhost:14268"
 	defaultTChannelBindEndpoint = "localhost:14267"
-
-	// Endpoint to fetch remote sampling config
-	fetchEndpoint = "fetch_endpoint"
 )
 
 // Factory is the factory for Jaeger receiver.

--- a/receiver/jaegerreceiver/factory.go
+++ b/receiver/jaegerreceiver/factory.go
@@ -48,6 +48,9 @@ const (
 	defaultGRPCBindEndpoint     = "localhost:14250"
 	defaultHTTPBindEndpoint     = "localhost:14268"
 	defaultTChannelBindEndpoint = "localhost:14267"
+
+	// Endpoint to fetch remote sampling config
+	fetchEndpoint = "fetch_endpoint"
 )
 
 // Factory is the factory for Jaeger receiver.
@@ -107,6 +110,7 @@ func (f *Factory) CreateTraceReceiver(
 	protoTChannel := rCfg.Protocols[protoThriftTChannel]
 	protoThriftCompact := rCfg.Protocols[protoThriftCompact]
 	protoThriftBinary := rCfg.Protocols[protoThriftBinary]
+	remoteSamplingEndpoint := rCfg.RemoteSampling[fetchEndpoint]
 
 	config := Configuration{}
 	var grpcServerOptions []grpc.ServerOption
@@ -159,6 +163,10 @@ func (f *Factory) CreateTraceReceiver(
 		if err != nil {
 			return nil, err
 		}
+	}
+
+	if remoteSamplingEndpoint != nil {
+		config.RemoteSamplingEndpoint = remoteSamplingEndpoint.Endpoint
 	}
 
 	if (protoGRPC == nil && protoHTTP == nil && protoTChannel == nil && protoThriftBinary == nil && protoThriftCompact == nil) ||

--- a/receiver/jaegerreceiver/factory.go
+++ b/receiver/jaegerreceiver/factory.go
@@ -110,7 +110,7 @@ func (f *Factory) CreateTraceReceiver(
 	protoTChannel := rCfg.Protocols[protoThriftTChannel]
 	protoThriftCompact := rCfg.Protocols[protoThriftCompact]
 	protoThriftBinary := rCfg.Protocols[protoThriftBinary]
-	remoteSamplingEndpoint := rCfg.RemoteSampling[fetchEndpoint]
+	remoteSamplingConfig := rCfg.RemoteSampling
 
 	config := Configuration{}
 	var grpcServerOptions []grpc.ServerOption
@@ -165,8 +165,8 @@ func (f *Factory) CreateTraceReceiver(
 		}
 	}
 
-	if remoteSamplingEndpoint != "" {
-		config.RemoteSamplingEndpoint = remoteSamplingEndpoint
+	if remoteSamplingConfig.FetchEndpoint != "" {
+		config.RemoteSamplingEndpoint = remoteSamplingConfig.FetchEndpoint
 	}
 
 	if (protoGRPC == nil && protoHTTP == nil && protoTChannel == nil && protoThriftBinary == nil && protoThriftCompact == nil) ||

--- a/receiver/jaegerreceiver/factory.go
+++ b/receiver/jaegerreceiver/factory.go
@@ -165,7 +165,7 @@ func (f *Factory) CreateTraceReceiver(
 		}
 	}
 
-	if remoteSamplingConfig.FetchEndpoint != "" {
+	if remoteSamplingConfig != nil {
 		config.RemoteSamplingEndpoint = remoteSamplingConfig.FetchEndpoint
 	}
 

--- a/receiver/jaegerreceiver/jaeger_agent_test.go
+++ b/receiver/jaegerreceiver/jaeger_agent_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/jaegertracing/jaeger/proto-gen/api_v2"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opencensus.io/trace"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
@@ -115,11 +116,11 @@ func TestJaegerAgentUDP_ThriftBinary_InvalidPort(t *testing.T) {
 func initializeGRPCTestServer(t *testing.T, beforeServe func(server *grpc.Server)) (*grpc.Server, net.Addr) {
 	server := grpc.NewServer()
 	lis, err := net.Listen("tcp", "localhost:0")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	beforeServe(server)
 	go func() {
 		err := server.Serve(lis)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	}()
 	return server, lis.Addr()
 }

--- a/receiver/jaegerreceiver/jaeger_agent_test.go
+++ b/receiver/jaegerreceiver/jaeger_agent_test.go
@@ -26,9 +26,11 @@ import (
 	commonpb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
 	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
 	"github.com/google/go-cmp/cmp"
+	"github.com/jaegertracing/jaeger/proto-gen/api_v2"
 	"github.com/stretchr/testify/assert"
 	"go.opencensus.io/trace"
 	"go.uber.org/zap"
+	"google.golang.org/grpc"
 
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-collector/exporter/exportertest"
@@ -110,10 +112,35 @@ func TestJaegerAgentUDP_ThriftBinary_InvalidPort(t *testing.T) {
 	jr.StopTraceReception()
 }
 
+func initializeGRPCTestServer(t *testing.T, beforeServe func(server *grpc.Server)) (*grpc.Server, net.Addr) {
+	server := grpc.NewServer()
+	lis, err := net.Listen("tcp", "localhost:0")
+	assert.NoError(t, err)
+	beforeServe(server)
+	go func() {
+		err := server.Serve(lis)
+		assert.NoError(t, err)
+	}()
+	return server, lis.Addr()
+}
+
+type mockSamplingHandler struct {
+}
+
+func (*mockSamplingHandler) GetSamplingStrategy(context.Context, *api_v2.SamplingStrategyParameters) (*api_v2.SamplingStrategyResponse, error) {
+	return &api_v2.SamplingStrategyResponse{StrategyType: api_v2.SamplingStrategyType_PROBABILISTIC}, nil
+}
+
 func TestJaegerHTTP(t *testing.T) {
+	s, addr := initializeGRPCTestServer(t, func(s *grpc.Server) {
+		api_v2.RegisterSamplingManagerServer(s, &mockSamplingHandler{})
+	})
+	defer s.GracefulStop()
+
 	port := testutils.GetAvailablePort(t)
 	config := &Configuration{
-		AgentHTTPPort: int(port),
+		AgentHTTPPort:          int(port),
+		RemoteSamplingEndpoint: addr.String(),
 	}
 	jr, err := New(context.Background(), config, nil, zap.NewNop())
 	assert.NoError(t, err, "Failed to create new Jaeger Receiver")
@@ -127,7 +154,6 @@ func TestJaegerHTTP(t *testing.T) {
 	err = testutils.WaitForPort(t, port)
 	assert.NoError(t, err, "WaitForPort failed")
 
-	// this functionality is just stubbed out at the moment.  just confirm they 200.
 	testURL := fmt.Sprintf("http://localhost:%d/sampling?service=test", port)
 	resp, err := http.Get(testURL)
 	assert.NoError(t, err, "should not have failed to make request")

--- a/receiver/jaegerreceiver/testdata/config.yaml
+++ b/receiver/jaegerreceiver/testdata/config.yaml
@@ -20,7 +20,7 @@ receivers:
       thrift-binary:
         endpoint: "0.0.0.0:789"
     remotesampling:
-        fetch_endpoint: "jaeger-collector:1234"
+      fetch_endpoint: "jaeger-collector:1234"
 
   # The following demonstrates disabling the receiver.
   # All of the protocols need to be disabled for the receiver to be disabled.
@@ -69,4 +69,3 @@ service:
      receivers: [jaeger]
      processors: [exampleprocessor]
      exporters: [exampleexporter]
-

--- a/receiver/jaegerreceiver/testdata/config.yaml
+++ b/receiver/jaegerreceiver/testdata/config.yaml
@@ -19,6 +19,8 @@ receivers:
         endpoint: "0.0.0.0:456"
       thrift-binary:
         endpoint: "0.0.0.0:789"
+    remotesampling:
+        fetch_endpoint: "jaeger-collector:1234"
 
   # The following demonstrates disabling the receiver.
   # All of the protocols need to be disabled for the receiver to be disabled.

--- a/receiver/jaegerreceiver/testdata/config.yaml
+++ b/receiver/jaegerreceiver/testdata/config.yaml
@@ -19,7 +19,7 @@ receivers:
         endpoint: "0.0.0.0:456"
       thrift-binary:
         endpoint: "0.0.0.0:789"
-    remotesampling:
+    remote_sampling:
       fetch_endpoint: "jaeger-collector:1234"
 
   # The following demonstrates disabling the receiver.

--- a/receiver/jaegerreceiver/trace_receiver.go
+++ b/receiver/jaegerreceiver/trace_receiver.go
@@ -361,6 +361,9 @@ func (jr *jReceiver) GetSamplingStrategy(serviceName string) (*sampling.Sampling
 func (jr *jReceiver) GetBaggageRestrictions(serviceName string) ([]*baggage.BaggageRestriction, error) {
 	br, err := jr.agentSamplingManager.GetBaggageRestrictions(serviceName)
 	if err != nil {
+		// Baggage restrictions are not yet implemented - refer to - https://github.com/jaegertracing/jaeger/issues/373
+		// As of today, GetBaggageRestrictions() always returns an error.
+		// However, we `return nil, nil` here in order to serve a valid `200 OK` response.
 		return nil, nil
 	}
 	return br, nil

--- a/receiver/jaegerreceiver/trace_receiver.go
+++ b/receiver/jaegerreceiver/trace_receiver.go
@@ -359,7 +359,11 @@ func (jr *jReceiver) GetSamplingStrategy(serviceName string) (*sampling.Sampling
 }
 
 func (jr *jReceiver) GetBaggageRestrictions(serviceName string) ([]*baggage.BaggageRestriction, error) {
-	return jr.agentSamplingManager.GetBaggageRestrictions(serviceName)
+	br, err := jr.agentSamplingManager.GetBaggageRestrictions(serviceName)
+	if err != nil {
+		return nil, nil
+	}
+	return br, nil
 }
 
 func (jr *jReceiver) PostSpans(ctx context.Context, r *api_v2.PostSpansRequest) (*api_v2.PostSpansResponse, error) {


### PR DESCRIPTION
This PR takes over from #432 

- Added SamplingManager to the `jReceiver` struct
- Added new parameters to configure remote sampling endpoint (`remote_sampling:fetch_endpoint`)
- Added tests and updated README

/cc @joe-elliott @tigrannajaryan 