### PR TITLE
Introduce TESTBED_DURATION to control duration of E2E tests

### DIFF
--- a/testbed/tests/perf_scenarios.go
+++ b/testbed/tests/perf_scenarios.go
@@ -23,7 +23,6 @@ import (
 	"math/rand"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/open-telemetry/opentelemetry-collector/testbed/testbed"
 )
@@ -84,7 +83,7 @@ func Scenario10kSPS(t *testing.T, exporter testbed.TraceExporter, receiver testb
 	tc.StartAgent()
 	tc.StartLoad(testbed.LoadOptions{SpansPerSecond: 10000})
 
-	tc.Sleep(15 * time.Second)
+	tc.Sleep(tc.Duration)
 
 	tc.StopLoad()
 
@@ -137,7 +136,7 @@ func Scenario1kSPSWithAttrs(t *testing.T, args []string, tests []TestCase, opts 
 			}
 
 			tc.StartLoad(options)
-			tc.Sleep(10 * time.Second)
+			tc.Sleep(tc.Duration)
 			tc.StopLoad()
 
 			tc.WaitFor(func() bool { return tc.LoadGenerator.SpansSent() == tc.MockBackend.SpansReceived() },

--- a/testbed/tests/perf_test.go
+++ b/testbed/tests/perf_test.go
@@ -23,7 +23,6 @@ package tests
 import (
 	"path"
 	"testing"
-	"time"
 
 	"github.com/open-telemetry/opentelemetry-collector/testbed/testbed"
 	"github.com/open-telemetry/opentelemetry-collector/testutils"
@@ -43,7 +42,7 @@ func TestIdleMode(t *testing.T) {
 
 	tc.StartAgent()
 
-	tc.Sleep(10 * time.Second)
+	tc.Sleep(tc.Duration)
 }
 
 func Test10kSPS(t *testing.T) {
@@ -72,7 +71,7 @@ func TestNoBackend10kSPS(t *testing.T) {
 	tc.StartAgent()
 	tc.StartLoad(testbed.LoadOptions{SpansPerSecond: 10000})
 
-	tc.Sleep(10 * time.Second)
+	tc.Sleep(tc.Duration)
 }
 
 func Test1kSPSWithAttrs(t *testing.T) {


### PR DESCRIPTION
When running locally on dev machine it is often useful to have short E2E tests.
This is now possible using TESTBED_DURATION env variable. For example to run E2E
tests so that each takes approximately 1 second do this:

TESTBED_DURATION=1s make run tests

If TESTBED_DURATION is unspecified it defaults to 15 seconds which was the most
common duration in the past.