### PR TITLE
Use one golangci and same config for testbed linting

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -113,3 +113,6 @@ issues:
     - path: _test\.go
       linters:
         - scopelint
+    - path: perf_scenarios\.go
+      linters:
+        - scopelint

--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,7 @@ misspell-correction:
 .PHONY: lint
 lint:
 	$(LINT) run
+	$(MAKE) -C testbed lint
 
 .PHONY: impi
 impi:

--- a/testbed/Makefile
+++ b/testbed/Makefile
@@ -1,51 +1,26 @@
 GOTEST_OPT?=-v -race -timeout 30s
 GOTEST_OPT_WITH_COVERAGE = $(GOTEST_OPT) -coverprofile=coverage.txt -covermode=atomic
 GOTEST=go test
-GOFMT=gofmt
-GOLINT=golint
-GOVET=go vet
+LINT=golangci-lint
 GOOS=$(shell go env GOOS)
 
-.DEFAULT_GOAL := fmt-vet-lint-test
+.DEFAULT_GOAL := lint-test
 
-.PHONY: fmt-vet-lint-test
-fmt-vet-lint-test: fmt vet lint test
+.PHONY: lint-test
+fmt-vet-lint-test: lint test
 
 .PHONY: test
 test:
 	$(GOTEST) $(GOTEST_OPT) ./...
 
+.PHONY: lint
+lint:
+	$(LINT) run -c ../.golangci.yml
+
 .PHONY: runtests
 runtests: test
 	./runtests.sh
 
-.PHONY: fmt
-fmt:
-	@FMTOUT=`$(GOFMT) -s -l ./.. 2>&1`; \
-	if [ "$$FMTOUT" ]; then \
-		echo "$(GOFMT) FAILED => gofmt the following files:\n"; \
-		echo "$$FMTOUT\n"; \
-		exit 1; \
-	else \
-	    echo "Fmt finished successfully"; \
-	fi
-
-.PHONY: lint
-lint:
-	@LINTOUT=`$(GOLINT) $(ALL_PKGS) 2>&1`; \
-	if [ "$$LINTOUT" ]; then \
-		echo "$(GOLINT) FAILED => clean the following lint errors:\n"; \
-		echo "$$LINTOUT\n"; \
-		exit 1; \
-	else \
-	    echo "Lint finished successfully"; \
-	fi
-
-.PHONY: vet
-vet:
-	$(GOVET) ./...
-
 .PHONY: install-tools
 install-tools:
-	go install golang.org/x/lint/golint
 	go install github.com/jstemmer/go-junit-report


### PR DESCRIPTION
Since testbed has its own go module and golangci uses go/analysis,
testbed folder will be excluded from linting.

testbed makefile has its own fmt/lint/fmt targets but actually they 
weren't part of CI.

Here, golangci is used to lint this folder and same config is leveraged.