### PR TITLE
Use DataSender and DataReceiver names in TestBed

### DIFF
--- a/testbed/testbed/mock_backend.go
+++ b/testbed/testbed/mock_backend.go
@@ -32,7 +32,7 @@ type MockBackend struct {
 	tc *mockTraceConsumer
 	mc *mockMetricConsumer
 
-	receiver Receiver
+	receiver DataReceiver
 
 	// Log file
 	logFilePath string
@@ -44,7 +44,7 @@ type MockBackend struct {
 }
 
 // NewMockBackend creates a new mock backend that receives data using specified receiver.
-func NewMockBackend(logFilePath string, receiver Receiver) *MockBackend {
+func NewMockBackend(logFilePath string, receiver DataReceiver) *MockBackend {
 	mb := &MockBackend{
 		logFilePath: logFilePath,
 		receiver:    receiver,

--- a/testbed/testbed/mock_backend_test.go
+++ b/testbed/testbed/mock_backend_test.go
@@ -24,7 +24,7 @@ import (
 
 func TestGeneratorAndBackend(t *testing.T) {
 	port := GetAvailablePort(t)
-	mb := NewMockBackend("mockbackend.log", NewJaegerReceiver(port))
+	mb := NewMockBackend("mockbackend.log", NewJaegerDataReceiver(port))
 
 	assert.EqualValues(t, 0, mb.DataItemsReceived())
 
@@ -33,7 +33,7 @@ func TestGeneratorAndBackend(t *testing.T) {
 
 	defer mb.Stop()
 
-	lg, err := NewLoadGenerator(NewJaegerExporter(port))
+	lg, err := NewLoadGenerator(NewJaegerDataSender(port))
 	require.NoError(t, err, "Cannot start load generator")
 
 	assert.EqualValues(t, 0, lg.dataItemsSent)

--- a/testbed/testbed/test_case.go
+++ b/testbed/testbed/test_case.go
@@ -74,8 +74,8 @@ const TESTCASE_DURATION_VAR = "TESTCASE_DURATION"
 // NewTestCase creates a new TestCase. It expects agent-config.yaml in the specified directory.
 func NewTestCase(
 	t *testing.T,
-	exporter Exporter,
-	receiver Receiver,
+	sender DataSender,
+	receiver DataReceiver,
 	opts ...TestCaseOption,
 ) *TestCase {
 	tc := TestCase{}
@@ -130,7 +130,7 @@ func NewTestCase(
 		tc.t.Fatalf("Cannot resolve filename: %s", err.Error())
 	}
 
-	tc.LoadGenerator, err = NewLoadGenerator(exporter)
+	tc.LoadGenerator, err = NewLoadGenerator(sender)
 	if err != nil {
 		t.Fatalf("Cannot create generator: %s", err.Error())
 	}
@@ -196,7 +196,7 @@ func (tc *TestCase) StartAgent(args ...string) {
 	// connect to the port to which we intend to send load.
 	tc.WaitFor(func() bool {
 		_, err := net.Dial("tcp",
-			fmt.Sprintf("localhost:%d", tc.LoadGenerator.exporter.GetCollectorPort()))
+			fmt.Sprintf("localhost:%d", tc.LoadGenerator.sender.GetCollectorPort()))
 		return err == nil
 	})
 }

--- a/testbed/tests/e2e_test.go
+++ b/testbed/tests/e2e_test.go
@@ -31,8 +31,8 @@ import (
 func TestIdleMode(t *testing.T) {
 	tc := testbed.NewTestCase(
 		t,
-		testbed.NewJaegerExporter(testbed.DefaultJaegerPort),
-		testbed.NewOCReceiver(testbed.DefaultOCPort),
+		testbed.NewJaegerDataSender(testbed.DefaultJaegerPort),
+		testbed.NewOCDataReceiver(testbed.DefaultOCPort),
 	)
 	defer tc.Stop()
 
@@ -57,8 +57,8 @@ func TestBallastMemory(t *testing.T) {
 	for _, test := range tests {
 		tc := testbed.NewTestCase(
 			t,
-			testbed.NewJaegerExporter(testbed.DefaultJaegerPort),
-			testbed.NewOCReceiver(testbed.DefaultOCPort),
+			testbed.NewJaegerDataSender(testbed.DefaultJaegerPort),
+			testbed.NewOCDataReceiver(testbed.DefaultOCPort),
 			testbed.WithSkipResults(),
 		)
 		tc.SetExpectedMaxRAM(test.maxRSS)

--- a/testbed/tests/metric_test.go
+++ b/testbed/tests/metric_test.go
@@ -26,8 +26,8 @@ import (
 func TestMetricNoBackend10kDPSOpenCensus(t *testing.T) {
 	tc := testbed.NewTestCase(
 		t,
-		testbed.NewOcMetricExporter(55678),
-		testbed.NewOCReceiver(testbed.DefaultOCPort),
+		testbed.NewOCMetricDataSender(55678),
+		testbed.NewOCDataReceiver(testbed.DefaultOCPort),
 	)
 	defer tc.Stop()
 
@@ -44,13 +44,13 @@ func TestMetricNoBackend10kDPSOpenCensus(t *testing.T) {
 func TestMetric10kDPS(t *testing.T) {
 	tests := []struct {
 		name     string
-		exporter testbed.Exporter
-		receiver testbed.Receiver
+		sender   testbed.DataSender
+		receiver testbed.DataReceiver
 	}{
 		{
 			"OpenCensus",
-			testbed.NewOcMetricExporter(testbed.GetAvailablePort(t)),
-			testbed.NewOCReceiver(testbed.GetAvailablePort(t)),
+			testbed.NewOCMetricDataSender(testbed.GetAvailablePort(t)),
+			testbed.NewOCDataReceiver(testbed.GetAvailablePort(t)),
 		},
 	}
 
@@ -58,7 +58,7 @@ func TestMetric10kDPS(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			Scenario10kItemsPerSecond(
 				t,
-				test.exporter,
+				test.sender,
 				test.receiver,
 				testbed.LoadOptions{ItemsPerBatch: 100},
 			)

--- a/testbed/tests/trace_test.go
+++ b/testbed/tests/trace_test.go
@@ -35,17 +35,17 @@ func TestMain(m *testing.M) {
 func TestTrace10kSPS(t *testing.T) {
 	tests := []struct {
 		name     string
-		receiver testbed.Receiver
+		receiver testbed.DataReceiver
 	}{
-		{"JaegerReceiver", testbed.NewJaegerReceiver(testbed.GetAvailablePort(t))},
-		{"OpenCensusReceiver", testbed.NewOCReceiver(testbed.DefaultOCPort)},
+		{"JaegerReceiver", testbed.NewJaegerDataReceiver(testbed.GetAvailablePort(t))},
+		{"OpenCensusReceiver", testbed.NewOCDataReceiver(testbed.DefaultOCPort)},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			Scenario10kItemsPerSecond(
 				t,
-				testbed.NewJaegerExporter(testbed.GetAvailablePort(t)),
+				testbed.NewJaegerDataSender(testbed.GetAvailablePort(t)),
 				test.receiver,
 				testbed.LoadOptions{},
 			)
@@ -56,8 +56,8 @@ func TestTrace10kSPS(t *testing.T) {
 func TestTraceNoBackend10kSPSJaeger(t *testing.T) {
 	tc := testbed.NewTestCase(
 		t,
-		testbed.NewJaegerExporter(testbed.DefaultJaegerPort),
-		testbed.NewOCReceiver(testbed.DefaultOCPort),
+		testbed.NewJaegerDataSender(testbed.DefaultJaegerPort),
+		testbed.NewOCDataReceiver(testbed.DefaultOCPort),
 	)
 	defer tc.Stop()
 


### PR DESCRIPTION
Exporter and Receiver names were easy to confuse with exporters
and receivers in the actual Collector. This changes helps to make
them distinct.