### PR TITLE
Add batch processor to E2E tests

### DIFF
--- a/testbed/tests/results/BASELINE.md
+++ b/testbed/tests/results/BASELINE.md
@@ -1,23 +1,25 @@
 # Test Results
-Started: Tue, 10 Dec 2019 12:36:08 -0500
+Started: Fri, 13 Dec 2019 09:20:14 -0500
 
 Test                                    |Result|Duration|CPU Avg%|CPU Max%|RAM Avg MiB|RAM Max MiB|Sent Items|Received Items|
 ----------------------------------------|------|-------:|-------:|-------:|----------:|----------:|---------:|-------------:|
-IdleMode                                |PASS  |     16s|     1.0|     3.3|         16|         20|         0|             0|
-MetricNoBackend10kDPSOpenCensus         |PASS  |     15s|    18.7|    19.7|         21|         26|    149960|             0|
-Metric10kDPS/OpenCensus                 |PASS  |     18s|    11.5|    14.3|         27|         33|    149900|        149900|
-Trace10kSPS/JaegerReceiver              |PASS  |     15s|    48.9|    52.4|         20|         25|    149990|        149990|
-Trace10kSPS/OpenCensusReceiver          |PASS  |     15s|    42.8|    47.4|         21|         26|    149950|        149950|
-TraceNoBackend10kSPSJaeger              |PASS  |     15s|    24.4|    27.1|         95|        131|    149310|             0|
-Trace1kSPSWithAttrs/0*0bytes            |PASS  |     15s|    18.2|    18.5|         22|         27|     15000|         15000|
-Trace1kSPSWithAttrs/100*50bytes         |PASS  |     15s|    64.9|    73.0|         24|         30|     15000|         15000|
-Trace1kSPSWithAttrs/10*1000bytes        |PASS  |     15s|    56.3|    61.0|         24|         29|     15000|         15000|
-Trace1kSPSWithAttrs/20*5000bytes        |PASS  |     20s|    84.4|   112.1|         66|         77|     14990|         14990|
-TraceBallast1kSPSWithAttrs/0*0bytes     |PASS  |     15s|    17.2|    17.9|         84|        134|     15000|         15000|
-TraceBallast1kSPSWithAttrs/100*50bytes  |PASS  |     15s|    40.7|    44.0|        655|        976|     15000|         15000|
-TraceBallast1kSPSWithAttrs/10*1000bytes |PASS  |     15s|    34.6|    38.1|        449|        762|     15000|         15000|
-TraceBallast1kSPSWithAttrs/20*5000bytes |PASS  |     45s|    27.4|    36.1|        969|       1067|     15000|         15000|
-TraceBallast1kSPSAddAttrs/0*0bytes      |PASS  |     15s|    17.5|    19.0|         89|        145|     15000|         15000|
-TraceBallast1kSPSAddAttrs/100*50bytes   |PASS  |     15s|    43.8|    51.4|        676|        979|     15000|         15000|
-TraceBallast1kSPSAddAttrs/10*1000bytes  |PASS  |     15s|    39.2|    43.9|        515|        837|     15000|         15000|
-TraceBallast1kSPSAddAttrs/20*5000bytes  |PASS  |     15s|    69.0|    76.9|        848|       1071|     15000|         15000|
+IdleMode                                |PASS  |     15s|     1.3|     4.6|         17|         21|         0|             0|
+MetricNoBackend10kDPSOpenCensus         |PASS  |     15s|    19.9|    22.2|         23|         28|    149940|             0|
+Metric10kDPS/OpenCensus                 |PASS  |     18s|     9.6|    11.3|         26|         33|    149900|        149900|
+Trace10kSPS/JaegerReceiver              |PASS  |     16s|    28.9|    31.5|         46|         56|    148830|        148830|
+Trace10kSPS/OpenCensusReceiver          |PASS  |     16s|    27.8|    30.1|         38|         46|    149340|        149340|
+TraceNoBackend10kSPSJaeger              |PASS  |     15s|    25.7|    28.1|         99|        138|    148690|             0|
+Trace1kSPSWithAttrs/0*0bytes            |PASS  |     15s|    16.8|    19.3|         22|         27|     15000|         15000|
+Trace1kSPSWithAttrs/100*50bytes         |PASS  |     15s|    59.9|    65.0|         24|         30|     13920|         13920|
+Trace1kSPSWithAttrs/10*1000bytes        |PASS  |     15s|    49.0|    59.4|         24|         30|     14370|         14370|
+Trace1kSPSWithAttrs/20*5000bytes        |PASS  |     15s|   108.2|   114.1|         38|         53|     14730|         14730|
+TraceBallast1kSPSWithAttrs/0*0bytes     |PASS  |     15s|    16.7|    18.4|         85|        136|     15000|         15000|
+TraceBallast1kSPSWithAttrs/100*50bytes  |PASS  |     15s|    41.0|    47.6|        628|        975|     13900|         13900|
+TraceBallast1kSPSWithAttrs/10*1000bytes |PASS  |     15s|    36.3|    40.3|        448|        757|     14910|         14910|
+TraceBallast1kSPSWithAttrs/20*5000bytes |PASS  |     15s|    77.2|    84.5|        879|       1077|     14070|         14070|
+TraceBallast1kSPSAddAttrs/0*0bytes      |PASS  |     15s|    17.1|    18.2|         90|        147|     15000|         15000|
+TraceBallast1kSPSAddAttrs/100*50bytes   |PASS  |     15s|    47.1|    49.3|        676|        979|     14820|         14820|
+TraceBallast1kSPSAddAttrs/10*1000bytes  |PASS  |     15s|    37.6|    40.0|        516|        838|     15000|         15000|
+TraceBallast1kSPSAddAttrs/20*5000bytes  |PASS  |     15s|    53.8|    69.0|        823|       1049|     11740|         11740|
+
+Total duration: 278s

--- a/testbed/tests/scenarios.go
+++ b/testbed/tests/scenarios.go
@@ -42,13 +42,14 @@ func createConfigFile(sender testbed.DataSender, receiver testbed.DataReceiver) 
 receivers:%v
 exporters:%v
 processors:
+  batch:
   queued_retry:
 
 service:
   pipelines:
     traces:
       receivers: [%v]
-      processors: [queued_retry]
+      processors: [batch,queued_retry]
       exporters: [%v]
 `
 	} else {
@@ -59,7 +60,7 @@ exporters:%v
 
 service:
   pipelines:
-    METRICS:
+    metrics:
       receivers: [%v]
       exporters: [%v]
 `
@@ -110,7 +111,7 @@ func Scenario10kItemsPerSecond(
 	defer tc.Stop()
 
 	tc.SetExpectedMaxCPU(150)
-	tc.SetExpectedMaxRAM(70)
+	tc.SetExpectedMaxRAM(90)
 
 	tc.StartBackend()
 	tc.StartAgent()


### PR DESCRIPTION
Batch processor is typical part of any reasonable configuration.
Added it to the configuration of E2E tests so they better reflect
real world usage.