### PR TITLE
Add OpenCensus data sender and E2E test

### DIFF
--- a/testbed/testbed/mock_backend_test.go
+++ b/testbed/testbed/mock_backend_test.go
@@ -3,8 +3,7 @@
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
+////     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -33,7 +32,7 @@ func TestGeneratorAndBackend(t *testing.T) {
 
 	defer mb.Stop()
 
-	lg, err := NewLoadGenerator(NewJaegerDataSender(port))
+	lg, err := NewLoadGenerator(NewJaegerThriftDataSender(port))
 	require.NoError(t, err, "Cannot start load generator")
 
 	assert.EqualValues(t, 0, lg.dataItemsSent)

--- a/testbed/tests/e2e_test.go
+++ b/testbed/tests/e2e_test.go
@@ -31,7 +31,7 @@ import (
 func TestIdleMode(t *testing.T) {
 	tc := testbed.NewTestCase(
 		t,
-		testbed.NewJaegerDataSender(testbed.DefaultJaegerPort),
+		testbed.NewJaegerThriftDataSender(testbed.DefaultJaegerPort),
 		testbed.NewOCDataReceiver(testbed.DefaultOCPort),
 	)
 	defer tc.Stop()
@@ -57,7 +57,7 @@ func TestBallastMemory(t *testing.T) {
 	for _, test := range tests {
 		tc := testbed.NewTestCase(
 			t,
-			testbed.NewJaegerDataSender(testbed.DefaultJaegerPort),
+			testbed.NewJaegerThriftDataSender(testbed.DefaultJaegerPort),
 			testbed.NewOCDataReceiver(testbed.DefaultOCPort),
 			testbed.WithSkipResults(),
 		)

--- a/testbed/tests/scenarios.go
+++ b/testbed/tests/scenarios.go
@@ -158,7 +158,7 @@ func Scenario1kSPSWithAttrs(t *testing.T, args []string, tests []TestCase, opts 
 
 			tc := testbed.NewTestCase(
 				t,
-				testbed.NewJaegerDataSender(testbed.DefaultJaegerPort),
+				testbed.NewJaegerThriftDataSender(testbed.DefaultJaegerPort),
 				testbed.NewOCDataReceiver(testbed.DefaultOCPort),
 				opts...,
 			)

--- a/testbed/tests/trace_test.go
+++ b/testbed/tests/trace_test.go
@@ -35,17 +35,26 @@ func TestMain(m *testing.M) {
 func TestTrace10kSPS(t *testing.T) {
 	tests := []struct {
 		name     string
+		sender   testbed.DataSender
 		receiver testbed.DataReceiver
 	}{
-		{"JaegerReceiver", testbed.NewJaegerDataReceiver(testbed.GetAvailablePort(t))},
-		{"OpenCensusReceiver", testbed.NewOCDataReceiver(testbed.DefaultOCPort)},
+		{
+			"JaegerThrift",
+			testbed.NewJaegerThriftDataSender(testbed.GetAvailablePort(t)),
+			testbed.NewJaegerDataReceiver(testbed.GetAvailablePort(t)),
+		},
+		{
+			"OpenCensus",
+			testbed.NewOCTraceDataSender(testbed.GetAvailablePort(t)),
+			testbed.NewOCDataReceiver(testbed.GetAvailablePort(t)),
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			Scenario10kItemsPerSecond(
 				t,
-				testbed.NewJaegerDataSender(testbed.GetAvailablePort(t)),
+				test.sender,
 				test.receiver,
 				testbed.LoadOptions{},
 			)
@@ -56,7 +65,7 @@ func TestTrace10kSPS(t *testing.T) {
 func TestTraceNoBackend10kSPSJaeger(t *testing.T) {
 	tc := testbed.NewTestCase(
 		t,
-		testbed.NewJaegerDataSender(testbed.DefaultJaegerPort),
+		testbed.NewJaegerThriftDataSender(testbed.DefaultJaegerPort),
 		testbed.NewOCDataReceiver(testbed.DefaultOCPort),
 	)
 	defer tc.Stop()


### PR DESCRIPTION
OpenCensus E2E test was previously using JaegerThrift sender.
Now it uses OpenCensus protocol on both ends.