### PR TITLE
Add "sampling.priority" support to probabilistic sampler

### DIFF
--- a/processor/samplingprocessor/probabilisticsamplerprocessor/probabilisticsampler.go
+++ b/processor/samplingprocessor/probabilisticsamplerprocessor/probabilisticsampler.go
@@ -132,15 +132,6 @@ func parseSpanSamplingPriority(span *tracepb.Span) samplingPriority {
 		return deferDecision
 	}
 
-	decideForDoubleFn := func(value float64) samplingPriority {
-		if value == 0.0 {
-			return doNotSampleSpan
-		} else if value > 0.0 {
-			return mustSampleSpan
-		}
-		return deferDecision
-	}
-
 	// By default defer the decision.
 	decision := deferDecision
 
@@ -158,11 +149,18 @@ func parseSpanSamplingPriority(span *tracepb.Span) samplingPriority {
 		}
 	case *tracepb.AttributeValue_DoubleValue:
 		value := samplingPriorityAttrib.GetDoubleValue()
-		decision = decideForDoubleFn(value)
+		if value == 0.0 {
+			decision = doNotSampleSpan
+		} else if value > 0.0 {
+			decision = mustSampleSpan
+		}
 	case *tracepb.AttributeValue_StringValue:
-		if attribVal := samplingPriorityAttrib.GetStringValue().GetValue(); attribVal != "" {
-			if value, err := strconv.ParseFloat(attribVal, 64); err == nil {
-				decision = decideForDoubleFn(value)
+		attribVal := samplingPriorityAttrib.GetStringValue().GetValue()
+		if value, err := strconv.ParseFloat(attribVal, 64); err == nil {
+			if value == 0.0 {
+				decision = doNotSampleSpan
+			} else if value > 0.0 {
+				decision = mustSampleSpan
 			}
 		}
 	}

--- a/processor/samplingprocessor/probabilisticsamplerprocessor/probabilisticsampler.go
+++ b/processor/samplingprocessor/probabilisticsamplerprocessor/probabilisticsampler.go
@@ -121,7 +121,7 @@ func parseSpanSamplingPriority(span *tracepb.Span) samplingPriority {
 		return deferDecision
 	}
 
-	decideForDoubleFn := func (value float64) samplingPriority {
+	decideForDoubleFn := func(value float64) samplingPriority {
 		if value == 0.0 {
 			return doNotSampleSpan
 		} else if value > 0.0 {

--- a/processor/samplingprocessor/probabilisticsamplerprocessor/probabilisticsampler_test.go
+++ b/processor/samplingprocessor/probabilisticsamplerprocessor/probabilisticsampler_test.go
@@ -23,13 +23,13 @@ import (
 
 	commonpb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
 	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/open-telemetry/opentelemetry-collector/consumer"
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-collector/exporter/exportertest"
 	"github.com/open-telemetry/opentelemetry-collector/processor"
-	processormetrics "github.com/open-telemetry/opentelemetry-collector/processor"
 	tracetranslator "github.com/open-telemetry/opentelemetry-collector/translator/trace"
 )
 
@@ -173,6 +173,168 @@ func Test_tracesamplerprocessor_SamplingPercentageRange(t *testing.T) {
 	}
 }
 
+// Test_tracesamplerprocessor_SpanSamplingPriority checks if handling of "sampling.priority" is correct.
+func Test_tracesamplerprocessor_SpanSamplingPriority(t *testing.T) {
+	singleSpanWithAttrib := func(key string, attribValue *tracepb.AttributeValue) consumerdata.TraceData {
+		return consumerdata.TraceData{
+			Spans: []*tracepb.Span{
+				{
+					Attributes: &tracepb.Span_Attributes{
+						AttributeMap: map[string]*tracepb.AttributeValue{
+							key: {Value: attribValue.Value},
+						},
+					},
+				},
+			},
+		}
+	}
+	tests := []struct {
+		name    string
+		cfg     Config
+		td      consumerdata.TraceData
+		sampled bool
+	}{
+		{
+			name: "must_sample",
+			cfg: Config{
+				SamplingPercentage: 0.0,
+			},
+			td: singleSpanWithAttrib(
+				"sampling.priority",
+				&tracepb.AttributeValue{Value: &tracepb.AttributeValue_IntValue{IntValue: 2}}),
+			sampled: true,
+		},
+		{
+			name: "must_not_sample",
+			cfg: Config{
+				SamplingPercentage: 100.0,
+			},
+			td: singleSpanWithAttrib(
+				"sampling.priority",
+				&tracepb.AttributeValue{Value: &tracepb.AttributeValue_IntValue{IntValue: 0}}),
+		},
+		{
+			name: "defer_sample_expect_not_sampled",
+			cfg: Config{
+				SamplingPercentage: 0.0,
+			},
+			td: singleSpanWithAttrib(
+				"no.sampling.priority",
+				&tracepb.AttributeValue{Value: &tracepb.AttributeValue_IntValue{IntValue: 2}}),
+		},
+		{
+			name: "defer_sample_expect_sampled",
+			cfg: Config{
+				SamplingPercentage: 100.0,
+			},
+			td: singleSpanWithAttrib(
+				"no.sampling.priority",
+				&tracepb.AttributeValue{Value: &tracepb.AttributeValue_IntValue{IntValue: 2}}),
+			sampled: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sink := &exportertest.SinkTraceExporter{}
+			tsp, err := NewTraceProcessor(sink, tt.cfg)
+			require.NoError(t, err)
+
+			err = tsp.ConsumeTraceData(context.Background(), tt.td)
+			require.NoError(t, err)
+
+			sampledData := sink.AllTraces()
+			require.Equal(t, 1, len(sampledData))
+			assert.Equal(t, tt.sampled, len(sampledData[0].Spans) == 1)
+		})
+	}
+}
+
+// Test_parseSpanSamplingPriority ensures that the function parsing the attributes is taking "sampling.priority"
+// attribute correctly.
+func Test_parseSpanSamplingPriority(t *testing.T) {
+	tests := []struct {
+		name string
+		span *tracepb.Span
+		want samplingPriority
+	}{
+		{
+			name: "nil_span",
+			span: &tracepb.Span{},
+			want: deferDecision,
+		},
+		{
+			name: "nil_attributes",
+			span: &tracepb.Span{},
+			want: deferDecision,
+		},
+		{
+			name: "nil_attribute_map",
+			span: &tracepb.Span{
+				Attributes: &tracepb.Span_Attributes{},
+			},
+			want: deferDecision,
+		},
+		{
+			name: "empty_attribute_map",
+			span: &tracepb.Span{
+				Attributes: &tracepb.Span_Attributes{
+					AttributeMap: map[string]*tracepb.AttributeValue{},
+				},
+			},
+			want: deferDecision,
+		},
+		{
+			name: "no_sampling_priority",
+			span: &tracepb.Span{
+				Attributes: &tracepb.Span_Attributes{
+					AttributeMap: map[string]*tracepb.AttributeValue{
+						"key": {Value: &tracepb.AttributeValue_BoolValue{BoolValue: true}},
+					},
+				},
+			},
+			want: deferDecision,
+		},
+		{
+			name: "sampling_priority_zero",
+			span: &tracepb.Span{
+				Attributes: &tracepb.Span_Attributes{
+					AttributeMap: map[string]*tracepb.AttributeValue{
+						"sampling.priority": {Value: &tracepb.AttributeValue_IntValue{IntValue: 0}},
+					},
+				},
+			},
+			want: doNotSampleSpan,
+		},
+		{
+			name: "sampling_priority_int_non_zero",
+			span: &tracepb.Span{
+				Attributes: &tracepb.Span_Attributes{
+					AttributeMap: map[string]*tracepb.AttributeValue{
+						"sampling.priority": {Value: &tracepb.AttributeValue_IntValue{IntValue: 1}},
+					},
+				},
+			},
+			want: mustSampleSpan,
+		},
+		{
+			name: "sampling_priority_double_non_zero",
+			span: &tracepb.Span{
+				Attributes: &tracepb.Span_Attributes{
+					AttributeMap: map[string]*tracepb.AttributeValue{
+						"sampling.priority": {Value: &tracepb.AttributeValue_DoubleValue{DoubleValue: 1}},
+					},
+				},
+			},
+			want: doNotSampleSpan,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, parseSpanSamplingPriority(tt.span))
+		})
+	}
+}
+
 // Test_hash ensures that the hash function supports different key lengths even if in
 // practice it is only expected to receive keys with length 16 (trace id length in OC proto).
 func Test_hash(t *testing.T) {
@@ -201,6 +363,20 @@ func genRandomTestData(numBatches, numTracesPerBatch int, serviceName string) (t
 		for j := 0; j < numTracesPerBatch; j++ {
 			span := &tracepb.Span{
 				TraceId: tracetranslator.UInt64ToByteTraceID(r.Uint64(), r.Uint64()),
+				Attributes: &tracepb.Span_Attributes{
+					AttributeMap: map[string]*tracepb.AttributeValue{
+						tracetranslator.TagHTTPStatusCode: {
+							Value: &tracepb.AttributeValue_IntValue{
+								IntValue: 404,
+							},
+						},
+						tracetranslator.TagHTTPStatusMsg: {
+							Value: &tracepb.AttributeValue_StringValue{
+								StringValue: &tracepb.TruncatableString{Value: "NotFound"},
+							},
+						},
+					},
+				},
 			}
 			spans = append(spans, span)
 		}
@@ -221,7 +397,7 @@ func genRandomTestData(numBatches, numTracesPerBatch int, serviceName string) (t
 func assertSampledData(t *testing.T, sampled []consumerdata.TraceData, serviceName string) (traceIDs map[string]bool, spanCount int) {
 	traceIDs = make(map[string]bool)
 	for _, td := range sampled {
-		if processormetrics.ServiceNameForNode(td.Node) != serviceName {
+		if processor.ServiceNameForNode(td.Node) != serviceName {
 			continue
 		}
 		for _, span := range td.Spans {

--- a/processor/samplingprocessor/probabilisticsamplerprocessor/testdata/config.yaml
+++ b/processor/samplingprocessor/probabilisticsamplerprocessor/testdata/config.yaml
@@ -4,9 +4,11 @@ receivers:
 processors:
   # The probabilistic_sampler sets trace sampling by hashing the trace id of
   # each span and making the sampling decision based on the hashed value. It
-  # also obeys the "sampling.priority" semantic convention as defined by
+  # also implements the "sampling.priority" semantic convention as defined by
   # OpenTracing. See
   # https://github.com/opentracing/specification/blob/master/semantic_conventions.md#span-tags-table
+  # The "sampling.priority" semantics have priority over trace id hashing and
+  # can be used to control if given spans are sampled, ie.: forwarded, or not.
   probabilistic_sampler:
     # the percentage rate at which traces are going to be sampled. Defaults to
     # zero, i.e.: no sample. Values greater or equal 100 are treated as

--- a/processor/samplingprocessor/probabilisticsamplerprocessor/testdata/config.yaml
+++ b/processor/samplingprocessor/probabilisticsamplerprocessor/testdata/config.yaml
@@ -15,10 +15,13 @@ processors:
     # "sample all traces".
     sampling_percentage: 15.3
     # hash_seed allows one to configure the hashing seed. This is important in
-    # scenarios where multiple layers of collectors have different sampling
-    # rates: if all layers use the same seed, all data passing one layer may
-    # pass the next even if they have different sampling rates. Having different
-    # seeds at different layers avoid that problem.
+    # scenarios where multiple layers of collectors are used to achieve the
+    # desired sampling rate, eg.: 10% on first layer and 10% on the
+    # second, resulting in an overall sampling rate of 1% (10% x 10%).
+    # If all layers use the same seed, all data passing one layer will also pass
+    # the next one, independent of the configured sampling rate. Having different
+    # seeds at different layers ensures that sampling rate in each layer work as
+    # intended.
     hash_seed: 22
 
 exporters:

--- a/processor/samplingprocessor/probabilisticsamplerprocessor/testdata/config.yaml
+++ b/processor/samplingprocessor/probabilisticsamplerprocessor/testdata/config.yaml
@@ -2,8 +2,21 @@ receivers:
   examplereceiver:
 
 processors:
+  # The probabilistic_sampler sets trace sampling by hashing the trace id of
+  # each span and making the sampling decision based on the hashed value. It
+  # also obeys the "sampling.priority" semantic convention as defined by
+  # OpenTracing. See
+  # https://github.com/opentracing/specification/blob/master/semantic_conventions.md#span-tags-table
   probabilistic_sampler:
+    # the percentage rate at which traces are going to be sampled. Defaults to
+    # zero, i.e.: no sample. Values greater or equal 100 are treated as
+    # "sample all traces".
     sampling_percentage: 15.3
+    # hash_seed allows one to configure the hashing seed. This is important in
+    # scenarios where multiple layers of collectors have different sampling
+    # rates: if all layers use the same seed, all data passing one layer may
+    # pass the next even if they have different sampling rates. Having different
+    # seeds at different layers avoid that problem.
     hash_seed: 22
 
 exporters:


### PR DESCRIPTION
Adds support to OpenTracing "sampling.priority" per semantic conventions at https://github.com/opentracing/specification/blob/master/semantic_conventions.md#span-tags-table