### PR TITLE
Add ability to specify resource limits in scenarios

### DIFF
--- a/testbed/testbed/test_case.go
+++ b/testbed/testbed/test_case.go
@@ -44,7 +44,7 @@ type TestCase struct {
 	// loadSpecFile string
 
 	// Resource spec for agent.
-	resourceSpec resourceSpec
+	resourceSpec ResourceSpec
 
 	// Agent process.
 	agentProc childProcess
@@ -112,10 +112,10 @@ func NewTestCase(
 	}
 
 	// Set default resource check period.
-	tc.resourceSpec.resourceCheckPeriod = 3 * time.Second
-	if tc.Duration < tc.resourceSpec.resourceCheckPeriod {
+	tc.resourceSpec.ResourceCheckPeriod = 3 * time.Second
+	if tc.Duration < tc.resourceSpec.ResourceCheckPeriod {
 		// Resource check period should not be longer than entire test duration.
-		tc.resourceSpec.resourceCheckPeriod = tc.Duration
+		tc.resourceSpec.ResourceCheckPeriod = tc.Duration
 	}
 
 	configFile := tc.agentConfigFile
@@ -150,18 +150,20 @@ func (tc *TestCase) composeTestResultFileName(fileName string) string {
 	return fileName
 }
 
-// SetExpectedMaxCPU sets the percentage of one core agent is expected to consume at most.
-// Error is signalled if consumption during resourceCheckPeriod exceeds this number.
-// If this function is not called the CPU consumption does not affect the test result.
-func (tc *TestCase) SetExpectedMaxCPU(cpuPercentage uint32) {
-	tc.resourceSpec.expectedMaxCPU = cpuPercentage
-}
-
-// SetExpectedMaxRAM sets the maximum RAM in MiB the agent is expected to consume.
-// Error is signalled if consumption during resourceCheckPeriod exceeds this number.
-// If this function is not called the RAM consumption does not affect the test result.
-func (tc *TestCase) SetExpectedMaxRAM(ramMiB uint32) {
-	tc.resourceSpec.expectedMaxRAM = ramMiB
+// SetResourceLimits sets expected limits for resource consmption.
+// Error is signalled if consumption during ResourceCheckPeriod exceeds the limits.
+// Limits are modified only for non-zero fields of resourceSpec, all zero-value fields
+// fo resourceSpec are ignored and their previous values remain in effect.
+func (tc *TestCase) SetResourceLimits(resourceSpec ResourceSpec) {
+	if resourceSpec.ExpectedMaxCPU > 0 {
+		tc.resourceSpec.ExpectedMaxCPU = resourceSpec.ExpectedMaxCPU
+	}
+	if resourceSpec.ExpectedMaxRAM > 0 {
+		tc.resourceSpec.ExpectedMaxRAM = resourceSpec.ExpectedMaxRAM
+	}
+	if resourceSpec.ResourceCheckPeriod > 0 {
+		tc.resourceSpec.ResourceCheckPeriod = resourceSpec.ResourceCheckPeriod
+	}
 }
 
 // StartAgent starts the agent and redirects its standard output and standard error

--- a/testbed/tests/e2e_test.go
+++ b/testbed/tests/e2e_test.go
@@ -36,9 +36,7 @@ func TestIdleMode(t *testing.T) {
 	)
 	defer tc.Stop()
 
-	tc.SetExpectedMaxCPU(4)
-	tc.SetExpectedMaxRAM(50)
-
+	tc.SetResourceLimits(testbed.ResourceSpec{ExpectedMaxCPU: 4, ExpectedMaxRAM: 50})
 	tc.StartAgent()
 
 	tc.Sleep(tc.Duration)
@@ -61,7 +59,7 @@ func TestBallastMemory(t *testing.T) {
 			testbed.NewOCDataReceiver(testbed.DefaultOCPort),
 			testbed.WithSkipResults(),
 		)
-		tc.SetExpectedMaxRAM(test.maxRSS)
+		tc.SetResourceLimits(testbed.ResourceSpec{ExpectedMaxRAM: test.maxRSS})
 
 		tc.StartAgent("--mem-ballast-size-mib", strconv.Itoa(int(test.ballastSize)))
 

--- a/testbed/tests/metric_test.go
+++ b/testbed/tests/metric_test.go
@@ -31,9 +31,7 @@ func TestMetricNoBackend10kDPSOpenCensus(t *testing.T) {
 	)
 	defer tc.Stop()
 
-	tc.SetExpectedMaxCPU(200)
-	tc.SetExpectedMaxRAM(200)
-
+	tc.SetResourceLimits(testbed.ResourceSpec{ExpectedMaxCPU: 200, ExpectedMaxRAM: 200})
 	tc.StartAgent()
 
 	tc.StartLoad(testbed.LoadOptions{DataItemsPerSecond: 10000})
@@ -43,14 +41,19 @@ func TestMetricNoBackend10kDPSOpenCensus(t *testing.T) {
 
 func TestMetric10kDPS(t *testing.T) {
 	tests := []struct {
-		name     string
-		sender   testbed.DataSender
-		receiver testbed.DataReceiver
+		name         string
+		sender       testbed.DataSender
+		receiver     testbed.DataReceiver
+		resourceSpec testbed.ResourceSpec
 	}{
 		{
 			"OpenCensus",
 			testbed.NewOCMetricDataSender(testbed.GetAvailablePort(t)),
 			testbed.NewOCDataReceiver(testbed.GetAvailablePort(t)),
+			testbed.ResourceSpec{
+				ExpectedMaxCPU: 8,
+				ExpectedMaxRAM: 60,
+			},
 		},
 	}
 
@@ -61,6 +64,7 @@ func TestMetric10kDPS(t *testing.T) {
 				test.sender,
 				test.receiver,
 				testbed.LoadOptions{ItemsPerBatch: 100},
+				test.resourceSpec,
 			)
 		})
 	}

--- a/testbed/tests/scenarios.go
+++ b/testbed/tests/scenarios.go
@@ -99,6 +99,7 @@ func Scenario10kItemsPerSecond(
 	sender testbed.DataSender,
 	receiver testbed.DataReceiver,
 	loadOptions testbed.LoadOptions,
+	resourceSpec testbed.ResourceSpec,
 ) {
 	configFile := createConfigFile(sender, receiver)
 	defer os.Remove(configFile)
@@ -110,9 +111,7 @@ func Scenario10kItemsPerSecond(
 	tc := testbed.NewTestCase(t, sender, receiver, testbed.WithConfigFile(configFile))
 	defer tc.Stop()
 
-	tc.SetExpectedMaxCPU(150)
-	tc.SetExpectedMaxRAM(90)
-
+	tc.SetResourceLimits(resourceSpec)
 	tc.StartBackend()
 	tc.StartAgent()
 
@@ -164,8 +163,10 @@ func Scenario1kSPSWithAttrs(t *testing.T, args []string, tests []TestCase, opts 
 			)
 			defer tc.Stop()
 
-			tc.SetExpectedMaxCPU(test.expectedMaxCPU)
-			tc.SetExpectedMaxRAM(test.expectedMaxRAM)
+			tc.SetResourceLimits(testbed.ResourceSpec{
+				ExpectedMaxCPU: test.expectedMaxCPU,
+				ExpectedMaxRAM: test.expectedMaxRAM,
+			})
 
 			tc.StartBackend()
 			tc.StartAgent(args...)

--- a/testbed/tests/trace_test.go
+++ b/testbed/tests/trace_test.go
@@ -34,19 +34,28 @@ func TestMain(m *testing.M) {
 
 func TestTrace10kSPS(t *testing.T) {
 	tests := []struct {
-		name     string
-		sender   testbed.DataSender
-		receiver testbed.DataReceiver
+		name         string
+		sender       testbed.DataSender
+		receiver     testbed.DataReceiver
+		resourceSpec testbed.ResourceSpec
 	}{
 		{
 			"JaegerThrift",
 			testbed.NewJaegerThriftDataSender(testbed.GetAvailablePort(t)),
 			testbed.NewJaegerDataReceiver(testbed.GetAvailablePort(t)),
+			testbed.ResourceSpec{
+				ExpectedMaxCPU: 44,
+				ExpectedMaxRAM: 84,
+			},
 		},
 		{
 			"OpenCensus",
 			testbed.NewOCTraceDataSender(testbed.GetAvailablePort(t)),
 			testbed.NewOCDataReceiver(testbed.GetAvailablePort(t)),
+			testbed.ResourceSpec{
+				ExpectedMaxCPU: 32,
+				ExpectedMaxRAM: 84,
+			},
 		},
 	}
 
@@ -57,6 +66,7 @@ func TestTrace10kSPS(t *testing.T) {
 				test.sender,
 				test.receiver,
 				testbed.LoadOptions{},
+				test.resourceSpec,
 			)
 		})
 	}
@@ -70,8 +80,10 @@ func TestTraceNoBackend10kSPSJaeger(t *testing.T) {
 	)
 	defer tc.Stop()
 
-	tc.SetExpectedMaxCPU(200)
-	tc.SetExpectedMaxRAM(200)
+	tc.SetResourceLimits(testbed.ResourceSpec{
+		ExpectedMaxCPU: 45,
+		ExpectedMaxRAM: 198,
+	})
 
 	tc.StartAgent()
 	tc.StartLoad(testbed.LoadOptions{DataItemsPerSecond: 10000})


### PR DESCRIPTION
- Changed TestCase to use ResourceSpec to specify resource limits.
- Changed Scenario10kItemsPerSecond to accept and use ResourceSpec.
- Removed SetExpectedMaxCPU and SetExpectedMaxRAM functions, using
  SetResourceLimits instead. This makes the resource limit specifications
  more uniform across the testbed.
- Adjusted resource limits of existing tests to be 1.2x of what they
  consume in Travis CI. This gives enough room for measurement instability
  in CI and still allows catching big regressions.