### PR TITLE
Make component interfaces uniform

### DIFF
--- a/component/component.go
+++ b/component/component.go
@@ -1,0 +1,43 @@
+// Copyright 2019 OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package component
+
+import "context"
+
+// Component is either a receiver, exporter, processor or extension.
+type Component interface {
+	// Start tells the component to start. Host parameter can be used for communicating
+	// with the host after Start() has already returned. If error is returned by
+	// Start() then the collector startup will be aborted.
+	// If this is an exporter component it may prepare for exporting
+	// by connecting to the endpoint.
+	Start(host Host) error
+
+	// Shutdown is invoked during service shutdown.
+	Shutdown() error
+}
+
+// Host represents the entity that is hosting a Component. It is used to allow communication
+// between the Component and its host (normally the service.Application is the host).
+type Host interface {
+	// ReportFatalError is used to report to the host that the extension
+	// encountered a fatal error (i.e.: an error that the instance can't recover
+	// from) after its start function had already returned.
+	ReportFatalError(err error)
+
+	// Context returns a context provided by the host to be used on the component
+	// operations.
+	Context() context.Context
+}

--- a/component/component_test.go
+++ b/component/component_test.go
@@ -1,0 +1,15 @@
+// Copyright 2019 OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package component

--- a/component/mock_host.go
+++ b/component/mock_host.go
@@ -14,19 +14,17 @@
 
 // Package receivertest define types and functions used to help test packages
 // implementing the receiver package interfaces.
-package receivertest
+package component
 
 import (
 	"context"
-
-	"github.com/open-telemetry/opentelemetry-collector/receiver"
 )
 
 // MockHost mocks a receiver.ReceiverHost for test purposes.
 type MockHost struct {
 }
 
-var _ receiver.Host = (*MockHost)(nil)
+var _ Host = (*MockHost)(nil)
 
 // Context returns a context provided by the host to be used on the receiver
 // operations.
@@ -43,6 +41,6 @@ func (mh *MockHost) ReportFatalError(err error) {
 
 // NewMockHost returns a new instance of MockHost with proper defaults for most
 // tests.
-func NewMockHost() receiver.Host {
+func NewMockHost() Host {
 	return &MockHost{}
 }

--- a/component/mock_host_test.go
+++ b/component/mock_host_test.go
@@ -14,7 +14,7 @@
 
 // Package receivertest define types and functions used to help test packages
 // implementing the receiver package interfaces.
-package receivertest
+package component
 
 import (
 	"errors"

--- a/config/example_factories_test.go
+++ b/config/example_factories_test.go
@@ -1,0 +1,62 @@
+// Copyright 2019 OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/open-telemetry/opentelemetry-collector/component"
+	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
+)
+
+func TestExampleExporterConsumer(t *testing.T) {
+	exp := &ExampleExporterConsumer{}
+	host := component.NewMockHost()
+	assert.Equal(t, false, exp.ExporterStarted)
+	err := exp.Start(host)
+	assert.NoError(t, err)
+	assert.Equal(t, true, exp.ExporterStarted)
+
+	assert.Equal(t, 0, len(exp.Traces))
+	err = exp.ConsumeTraceData(context.Background(), consumerdata.TraceData{})
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(exp.Traces))
+
+	assert.Equal(t, 0, len(exp.Metrics))
+	err = exp.ConsumeMetricsData(context.Background(), consumerdata.MetricsData{})
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(exp.Metrics))
+
+	assert.Equal(t, false, exp.ExporterShutdown)
+	err = exp.Shutdown()
+	assert.NoError(t, err)
+	assert.Equal(t, true, exp.ExporterShutdown)
+}
+
+func TestExampleReceiverProducer(t *testing.T) {
+	rcv := &ExampleReceiverProducer{}
+	host := component.NewMockHost()
+	assert.Equal(t, false, rcv.Started)
+	err := rcv.Start(host)
+	assert.NoError(t, err)
+	assert.Equal(t, true, rcv.Started)
+
+	err = rcv.Shutdown()
+	assert.NoError(t, err)
+	assert.Equal(t, true, rcv.Started)
+}

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -16,28 +16,13 @@
 package exporter
 
 import (
+	"github.com/open-telemetry/opentelemetry-collector/component"
 	"github.com/open-telemetry/opentelemetry-collector/consumer"
 )
 
-// Host represents the entity where the exporter is being hosted. It is used to
-// allow communication between the exporter and its host.
-type Host interface {
-	// ReportFatalError is used to report to the host that the exporter encountered
-	// a fatal error (i.e.: an error that the instance can't recover from) after
-	// its start function has already returned.
-	ReportFatalError(err error)
-}
-
 // Exporter defines functions that trace and metric exporters must implement.
 type Exporter interface {
-	// Start tells the exporter to start. The exporter may prepare for exporting
-	// by connecting to the endpoint. Host parameter can be used for communicating
-	// with the host after Start() has already returned. If error is returned by
-	// Start() then the collector startup will be aborted.
-	Start(host Host) error
-
-	// Shutdown is invoked during service shutdown.
-	Shutdown() error
+	component.Component
 }
 
 // TraceExporter composes TraceConsumer with some additional exporter-specific functions.

--- a/exporter/exporterhelper/metricshelper.go
+++ b/exporter/exporterhelper/metricshelper.go
@@ -19,6 +19,7 @@ import (
 
 	"go.opencensus.io/trace"
 
+	"github.com/open-telemetry/opentelemetry-collector/component"
 	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-collector/exporter"
@@ -37,7 +38,7 @@ type metricsExporter struct {
 
 var _ (exporter.MetricsExporter) = (*metricsExporter)(nil)
 
-func (me *metricsExporter) Start(host exporter.Host) error {
+func (me *metricsExporter) Start(host component.Host) error {
 	return nil
 }
 

--- a/exporter/exporterhelper/tracehelper.go
+++ b/exporter/exporterhelper/tracehelper.go
@@ -19,6 +19,7 @@ import (
 
 	"go.opencensus.io/trace"
 
+	"github.com/open-telemetry/opentelemetry-collector/component"
 	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-collector/exporter"
@@ -37,7 +38,7 @@ type traceExporter struct {
 
 var _ (exporter.TraceExporter) = (*traceExporter)(nil)
 
-func (te *traceExporter) Start(host exporter.Host) error {
+func (te *traceExporter) Start(host component.Host) error {
 	return nil
 }
 

--- a/exporter/exportertest/nop_exporter.go
+++ b/exporter/exportertest/nop_exporter.go
@@ -17,6 +17,7 @@ package exportertest
 import (
 	"context"
 
+	"github.com/open-telemetry/opentelemetry-collector/component"
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-collector/exporter"
 )
@@ -32,7 +33,7 @@ type nopExporter struct {
 var _ exporter.TraceExporter = (*nopExporter)(nil)
 var _ exporter.MetricsExporter = (*nopExporter)(nil)
 
-func (ne *nopExporter) Start(host exporter.Host) error {
+func (ne *nopExporter) Start(host component.Host) error {
 	return nil
 }
 

--- a/exporter/exportertest/sink_exporter.go
+++ b/exporter/exportertest/sink_exporter.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"sync"
 
+	"github.com/open-telemetry/opentelemetry-collector/component"
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-collector/exporter"
 )
@@ -33,7 +34,7 @@ var _ exporter.TraceExporter = (*SinkTraceExporter)(nil)
 // Start tells the exporter to start. The exporter may prepare for exporting
 // by connecting to the endpoint. Host parameter can be used for communicating
 // with the host after Start() has already returned.
-func (ste *SinkTraceExporter) Start(host exporter.Host) error {
+func (ste *SinkTraceExporter) Start(host component.Host) error {
 	return nil
 }
 
@@ -76,7 +77,7 @@ var _ exporter.MetricsExporter = (*SinkMetricsExporter)(nil)
 // Start tells the exporter to start. The exporter may prepare for exporting
 // by connecting to the endpoint. Host parameter can be used for communicating
 // with the host after Start() has already returned.
-func (sme *SinkMetricsExporter) Start(host exporter.Host) error {
+func (sme *SinkMetricsExporter) Start(host component.Host) error {
 	return nil
 }
 

--- a/exporter/opencensusexporter/factory_test.go
+++ b/exporter/opencensusexporter/factory_test.go
@@ -23,12 +23,12 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
+	"github.com/open-telemetry/opentelemetry-collector/component"
 	"github.com/open-telemetry/opentelemetry-collector/compression"
 	"github.com/open-telemetry/opentelemetry-collector/config/configcheck"
 	"github.com/open-telemetry/opentelemetry-collector/config/configgrpc"
 	"github.com/open-telemetry/opentelemetry-collector/exporter/exportertest"
 	"github.com/open-telemetry/opentelemetry-collector/receiver/opencensusreceiver"
-	"github.com/open-telemetry/opentelemetry-collector/receiver/receivertest"
 	"github.com/open-telemetry/opentelemetry-collector/testutils"
 )
 
@@ -66,8 +66,8 @@ func TestCreateTraceExporter(t *testing.T) {
 		new(exportertest.SinkTraceExporter))
 	require.NotNil(t, rcv)
 	require.Nil(t, err)
-	require.Nil(t, rcv.StartTraceReception(receivertest.NewMockHost()))
-	defer rcv.StopTraceReception()
+	require.Nil(t, rcv.Start(component.NewMockHost()))
+	defer rcv.Shutdown()
 
 	tests := []struct {
 		name     string

--- a/exporter/prometheusexporter/prometheus.go
+++ b/exporter/prometheusexporter/prometheus.go
@@ -22,9 +22,9 @@ import (
 	// official census-ecosystem location, update this import path.
 	"github.com/orijtech/prometheus-go-metrics-exporter"
 
+	"github.com/open-telemetry/opentelemetry-collector/component"
 	"github.com/open-telemetry/opentelemetry-collector/consumer"
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
-	"github.com/open-telemetry/opentelemetry-collector/exporter"
 	"github.com/open-telemetry/opentelemetry-collector/exporter/exporterhelper"
 )
 
@@ -38,7 +38,7 @@ type prometheusExporter struct {
 
 var _ consumer.MetricsConsumer = (*prometheusExporter)(nil)
 
-func (pe *prometheusExporter) Start(host exporter.Host) error {
+func (pe *prometheusExporter) Start(host component.Host) error {
 	return nil
 }
 

--- a/exporter/zipkinexporter/zipkin.go
+++ b/exporter/zipkinexporter/zipkin.go
@@ -29,9 +29,9 @@ import (
 	zipkinhttp "github.com/openzipkin/zipkin-go/reporter/http"
 	"go.opencensus.io/trace"
 
+	"github.com/open-telemetry/opentelemetry-collector/component"
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumererror"
-	"github.com/open-telemetry/opentelemetry-collector/exporter"
 	"github.com/open-telemetry/opentelemetry-collector/observability"
 	tracetranslator "github.com/open-telemetry/opentelemetry-collector/translator/trace"
 	spandatatranslator "github.com/open-telemetry/opentelemetry-collector/translator/trace/spandata"
@@ -160,7 +160,7 @@ func extractStringAttribute(
 	return value, ok
 }
 
-func (ze *zipkinExporter) Start(host exporter.Host) error {
+func (ze *zipkinExporter) Start(host component.Host) error {
 	return nil
 }
 

--- a/exporter/zipkinexporter/zipkin_test.go
+++ b/exporter/zipkinexporter/zipkin_test.go
@@ -32,9 +32,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/open-telemetry/opentelemetry-collector/component"
 	"github.com/open-telemetry/opentelemetry-collector/consumer"
 	"github.com/open-telemetry/opentelemetry-collector/processor"
-	"github.com/open-telemetry/opentelemetry-collector/receiver/receivertest"
 	"github.com/open-telemetry/opentelemetry-collector/receiver/zipkinreceiver"
 	"github.com/open-telemetry/opentelemetry-collector/testutils"
 	"github.com/open-telemetry/opentelemetry-collector/translator/trace/zipkin"
@@ -171,9 +171,9 @@ func TestZipkinExporter_roundtripJSON(t *testing.T) {
 	assert.NoError(t, err)
 	require.NotNil(t, zi)
 
-	mh := receivertest.NewMockHost()
-	require.NoError(t, zi.StartTraceReception(mh))
-	defer zi.StopTraceReception()
+	mh := component.NewMockHost()
+	require.NoError(t, zi.Start(mh))
+	defer zi.Shutdown()
 
 	// Let the receiver receive "uploaded Zipkin spans from a Java client application"
 	req, _ := http.NewRequest("POST", "https://tld.org/", strings.NewReader(zipkinSpansJSONJavaLibrary))
@@ -391,10 +391,10 @@ func TestZipkinExporter_roundtripProto(t *testing.T) {
 	zi, err := zipkinreceiver.New(fmt.Sprintf(":%d", port), zexp)
 	require.NoError(t, err)
 
-	mh := receivertest.NewMockHost()
-	err = zi.StartTraceReception(mh)
+	mh := component.NewMockHost()
+	err = zi.Start(mh)
 	require.NoError(t, err)
-	defer zi.StopTraceReception()
+	defer zi.Shutdown()
 
 	// Let the receiver receive "uploaded Zipkin spans from a Java client application"
 	req, _ := http.NewRequest("POST", "https://tld.org/", strings.NewReader(zipkinSpansJSONJavaLibrary))

--- a/extension/extension.go
+++ b/extension/extension.go
@@ -17,27 +17,13 @@
 // to the service, examples: health check endpoint, z-pages, etc.
 package extension
 
-// Host represents the entity where the extension is being hosted.
-// It is used to allow communication between the extension and its host.
-type Host interface {
-	// ReportFatalError is used to report to the host that the extension
-	// encountered a fatal error (i.e.: an error that the instance can't recover
-	// from) after its start function had already returned.
-	ReportFatalError(err error)
-}
+import "github.com/open-telemetry/opentelemetry-collector/component"
 
 // ServiceExtension is the interface for objects hosted by the OpenTelemetry Collector that
 // don't participate directly on data pipelines but provide some functionality
 // to the service, examples: health check endpoint, z-pages, etc.
 type ServiceExtension interface {
-	// Start the ServiceExtension object hosted by the given host. At this point in the
-	// process life-cycle the receivers are not started and the host did not
-	// receive any data yet.
-	Start(host Host) error
-
-	// Shutdown the ServiceExtension instance. This happens after the pipelines were
-	// shutdown.
-	Shutdown() error
+	component.Component
 }
 
 // PipelineWatcher is an extra interface for ServiceExtension hosted by the OpenTelemetry

--- a/extension/extensiontest/mock_host.go
+++ b/extension/extensiontest/mock_host.go
@@ -15,17 +15,18 @@
 package extensiontest
 
 import (
+	"context"
 	"time"
 
-	"github.com/open-telemetry/opentelemetry-collector/extension"
+	"github.com/open-telemetry/opentelemetry-collector/component"
 )
 
-// MockHost mocks an extension.Host for test purposes.
+// MockHost mocks an component.Host for test purposes.
 type MockHost struct {
 	errorChan chan error
 }
 
-var _ extension.Host = (*MockHost)(nil)
+var _ component.Host = (*MockHost)(nil)
 
 // NewMockHost returns a new instance of MockHost with proper defaults for most
 // tests.
@@ -40,6 +41,12 @@ func NewMockHost() *MockHost {
 // its start function has already returned.
 func (mh *MockHost) ReportFatalError(err error) {
 	mh.errorChan <- err
+}
+
+// Context returns a context provided by the host to be used on the component
+// operations.
+func (mh *MockHost) Context() context.Context {
+	return context.Background()
 }
 
 // WaitForFatalError waits the given amount of time until an error is reported via

--- a/extension/healthcheckextension/healthcheckextension.go
+++ b/extension/healthcheckextension/healthcheckextension.go
@@ -22,6 +22,7 @@ import (
 	"github.com/jaegertracing/jaeger/pkg/healthcheck"
 	"go.uber.org/zap"
 
+	"github.com/open-telemetry/opentelemetry-collector/component"
 	"github.com/open-telemetry/opentelemetry-collector/extension"
 )
 
@@ -35,7 +36,7 @@ type healthCheckExtension struct {
 var _ (extension.ServiceExtension) = (*healthCheckExtension)(nil)
 var _ (extension.PipelineWatcher) = (*healthCheckExtension)(nil)
 
-func (hc *healthCheckExtension) Start(host extension.Host) error {
+func (hc *healthCheckExtension) Start(host component.Host) error {
 
 	hc.logger.Info("Starting health_check extension", zap.Any("config", hc.config))
 

--- a/extension/pprofextension/pprofextension.go
+++ b/extension/pprofextension/pprofextension.go
@@ -24,6 +24,7 @@ import (
 
 	"go.uber.org/zap"
 
+	"github.com/open-telemetry/opentelemetry-collector/component"
 	"github.com/open-telemetry/opentelemetry-collector/extension"
 )
 
@@ -35,7 +36,7 @@ type pprofExtension struct {
 
 var _ (extension.ServiceExtension) = (*pprofExtension)(nil)
 
-func (p *pprofExtension) Start(host extension.Host) error {
+func (p *pprofExtension) Start(host component.Host) error {
 	// Start the listener here so we can have earlier failure if port is
 	// already in use.
 	ln, err := net.Listen("tcp", p.config.Endpoint)

--- a/extension/zpagesextension/zpagesextension.go
+++ b/extension/zpagesextension/zpagesextension.go
@@ -21,6 +21,7 @@ import (
 	"go.opencensus.io/zpages"
 	"go.uber.org/zap"
 
+	"github.com/open-telemetry/opentelemetry-collector/component"
 	"github.com/open-telemetry/opentelemetry-collector/extension"
 )
 
@@ -32,7 +33,7 @@ type zpagesExtension struct {
 
 var _ (extension.ServiceExtension) = (*zpagesExtension)(nil)
 
-func (zpe *zpagesExtension) Start(host extension.Host) error {
+func (zpe *zpagesExtension) Start(host component.Host) error {
 	zPagesMux := http.NewServeMux()
 	zpages.Handle(zPagesMux, "/debug")
 

--- a/processor/attributesprocessor/attributes.go
+++ b/processor/attributesprocessor/attributes.go
@@ -19,6 +19,7 @@ import (
 
 	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
 
+	"github.com/open-telemetry/opentelemetry-collector/component"
 	"github.com/open-telemetry/opentelemetry-collector/consumer"
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-collector/oterr"
@@ -124,6 +125,11 @@ func (a *attributesProcessor) ConsumeTraceData(ctx context.Context, td consumerd
 
 func (a *attributesProcessor) GetCapabilities() processor.Capabilities {
 	return processor.Capabilities{MutatesConsumedData: true}
+}
+
+// Start is invoked during service startup.
+func (a *attributesProcessor) Start(host component.Host) error {
+	return nil
 }
 
 // Shutdown is invoked during service shutdown.

--- a/processor/batchprocessor/node_batcher.go
+++ b/processor/batchprocessor/node_batcher.go
@@ -29,6 +29,7 @@ import (
 	"go.opencensus.io/stats"
 	"go.uber.org/zap"
 
+	"github.com/open-telemetry/opentelemetry-collector/component"
 	"github.com/open-telemetry/opentelemetry-collector/consumer"
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-collector/observability"
@@ -111,6 +112,11 @@ func (b *batcher) ConsumeTraceData(ctx context.Context, td consumerdata.TraceDat
 
 func (b *batcher) GetCapabilities() processor.Capabilities {
 	return processor.Capabilities{MutatesConsumedData: false}
+}
+
+// Start is invoked during service startup.
+func (b *batcher) Start(host component.Host) error {
+	return nil
 }
 
 // Shutdown is invoked during service shutdown.

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -16,18 +16,17 @@
 package processor
 
 import (
+	"github.com/open-telemetry/opentelemetry-collector/component"
 	"github.com/open-telemetry/opentelemetry-collector/consumer"
 )
 
 // Processor defines the common functions that must be implemented by TraceProcessor
 // and MetricsProcessor.
 type Processor interface {
+	component.Component
+
 	// GetCapabilities must return the capabilities of the processor.
 	GetCapabilities() Capabilities
-
-	// Shutdown is invoked during service shutdown. Typically used to flush the data
-	// that may be accumulated in the processor.
-	Shutdown() error
 }
 
 // TraceProcessor composes TraceConsumer with some additional processor-specific functions.

--- a/processor/processortest/nop_processor.go
+++ b/processor/processortest/nop_processor.go
@@ -19,6 +19,7 @@ import (
 
 	"go.uber.org/zap"
 
+	"github.com/open-telemetry/opentelemetry-collector/component"
 	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
 	"github.com/open-telemetry/opentelemetry-collector/consumer"
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
@@ -43,6 +44,11 @@ func (np *nopProcessor) ConsumeMetricsData(ctx context.Context, md consumerdata.
 
 func (np *nopProcessor) GetCapabilities() processor.Capabilities {
 	return processor.Capabilities{MutatesConsumedData: false}
+}
+
+// Start is invoked during service startup.
+func (np *nopProcessor) Start(host component.Host) error {
+	return nil
 }
 
 // Shutdown is invoked during service shutdown.

--- a/processor/queuedprocessor/queued_processor.go
+++ b/processor/queuedprocessor/queued_processor.go
@@ -25,6 +25,7 @@ import (
 	"go.opencensus.io/tag"
 	"go.uber.org/zap"
 
+	"github.com/open-telemetry/opentelemetry-collector/component"
 	"github.com/open-telemetry/opentelemetry-collector/consumer"
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumererror"
@@ -102,6 +103,11 @@ func newQueuedSpanProcessor(sender consumer.TraceConsumer, opts options) *queued
 		backoffDelay:             opts.backoffDelay,
 		stopCh:                   make(chan struct{}),
 	}
+}
+
+// Start is invoked during service startup.
+func (sp *queuedSpanProcessor) Start(host component.Host) error {
+	return nil
 }
 
 // Stop halts the span processor and all its goroutines.

--- a/processor/resourceprocessor/resource_processor.go
+++ b/processor/resourceprocessor/resource_processor.go
@@ -19,6 +19,7 @@ import (
 
 	resourcepb "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
 
+	"github.com/open-telemetry/opentelemetry-collector/component"
 	"github.com/open-telemetry/opentelemetry-collector/consumer"
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-collector/processor"
@@ -54,6 +55,11 @@ func (rtp *resourceTraceProcessor) GetCapabilities() processor.Capabilities {
 	return rtp.capabilities
 }
 
+// Start is invoked during service startup.
+func (*resourceTraceProcessor) Start(host component.Host) error {
+	return nil
+}
+
 // Shutdown is invoked during service shutdown.
 func (*resourceTraceProcessor) Shutdown() error {
 	return nil
@@ -77,6 +83,11 @@ func newResourceMetricProcessor(next consumer.MetricsConsumer, cfg *Config) *res
 // GetCapabilities returns the Capabilities assocciated with the resource processor.
 func (rmp *resourceMetricProcessor) GetCapabilities() processor.Capabilities {
 	return rmp.capabilities
+}
+
+// Start is invoked during service startup.
+func (*resourceMetricProcessor) Start(host component.Host) error {
+	return nil
 }
 
 // Shutdown is invoked during service shutdown.

--- a/processor/samplingprocessor/probabilisticsamplerprocessor/probabilisticsampler.go
+++ b/processor/samplingprocessor/probabilisticsamplerprocessor/probabilisticsampler.go
@@ -20,6 +20,7 @@ import (
 
 	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
 
+	"github.com/open-telemetry/opentelemetry-collector/component"
 	"github.com/open-telemetry/opentelemetry-collector/consumer"
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-collector/oterr"
@@ -110,6 +111,11 @@ func (tsp *tracesamplerprocessor) ConsumeTraceData(ctx context.Context, td consu
 
 func (tsp *tracesamplerprocessor) GetCapabilities() processor.Capabilities {
 	return processor.Capabilities{MutatesConsumedData: false}
+}
+
+// Start is invoked during service startup.
+func (tsp *tracesamplerprocessor) Start(host component.Host) error {
+	return nil
 }
 
 // Shutdown is invoked during service shutdown.

--- a/processor/samplingprocessor/tailsamplingprocessor/processor.go
+++ b/processor/samplingprocessor/tailsamplingprocessor/processor.go
@@ -27,6 +27,7 @@ import (
 	"go.opencensus.io/tag"
 	"go.uber.org/zap"
 
+	"github.com/open-telemetry/opentelemetry-collector/component"
 	"github.com/open-telemetry/opentelemetry-collector/consumer"
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-collector/observability"
@@ -314,6 +315,11 @@ func (tsp *tailSamplingSpanProcessor) ConsumeTraceData(ctx context.Context, td c
 
 func (tsp *tailSamplingSpanProcessor) GetCapabilities() processor.Capabilities {
 	return processor.Capabilities{MutatesConsumedData: false}
+}
+
+// Start is invoked during service startup.
+func (tsp *tailSamplingSpanProcessor) Start(host component.Host) error {
+	return nil
 }
 
 // Shutdown is invoked during service shutdown.

--- a/processor/samplingprocessor/tailsamplingprocessor/processor_test.go
+++ b/processor/samplingprocessor/tailsamplingprocessor/processor_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
+	"github.com/open-telemetry/opentelemetry-collector/component"
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-collector/exporter/exportertest"
 	"github.com/open-telemetry/opentelemetry-collector/processor"
@@ -320,6 +321,11 @@ func (p *mockSpanProcessor) ConsumeTraceData(ctx context.Context, td consumerdat
 
 func (p *mockSpanProcessor) GetCapabilities() processor.Capabilities {
 	return processor.Capabilities{MutatesConsumedData: false}
+}
+
+// Start is invoked during service startup.
+func (p *mockSpanProcessor) Start(host component.Host) error {
+	return nil
 }
 
 // Shutdown is invoked during service shutdown.

--- a/processor/spanprocessor/span.go
+++ b/processor/spanprocessor/span.go
@@ -21,6 +21,7 @@ import (
 
 	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
 
+	"github.com/open-telemetry/opentelemetry-collector/component"
 	"github.com/open-telemetry/opentelemetry-collector/consumer"
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-collector/oterr"
@@ -59,6 +60,11 @@ func (sp *spanProcessor) ConsumeTraceData(ctx context.Context, td consumerdata.T
 
 func (sp *spanProcessor) GetCapabilities() processor.Capabilities {
 	return processor.Capabilities{MutatesConsumedData: true}
+}
+
+// Start is invoked during service startup.
+func (sp *spanProcessor) Start(host component.Host) error {
+	return nil
 }
 
 // Shutdown is invoked during service shutdown.

--- a/receiver/end_to_end_test.go
+++ b/receiver/end_to_end_test.go
@@ -49,7 +49,7 @@ func Example_endToEnd() {
 	// Once we have the span receiver which will connect to the
 	// various exporter pipeline i.e. *tracepb.Span->OpenCensus.SpanData
 	for _, tr := range trl {
-		if err := tr.StartTraceReception(nil); err != nil {
+		if err := tr.Start(nil); err != nil {
 			log.Fatalf("Failed to start trace receiver: %v", err)
 		}
 	}
@@ -57,7 +57,7 @@ func Example_endToEnd() {
 	// Before exiting, stop all the trace receivers
 	defer func() {
 		for _, tr := range trl {
-			_ = tr.StopTraceReception()
+			_ = tr.Shutdown()
 		}
 	}()
 	log.Println("Done starting the trace receiver")

--- a/receiver/factory.go
+++ b/receiver/factory.go
@@ -35,7 +35,7 @@ type Factory interface {
 	// configuration and should not cause side-effects that prevent the creation
 	// of multiple instances of the Receiver.
 	// The object returned by this method needs to pass the checks implemented by
-	// 'conifgcheck.ValidateConfig'. It is recommended to have such check in the
+	// 'configcheck.ValidateConfig'. It is recommended to have such check in the
 	// tests of any implementation of the Factory interface.
 	CreateDefaultConfig() configmodels.Receiver
 

--- a/receiver/jaegerreceiver/trace_receiver.go
+++ b/receiver/jaegerreceiver/trace_receiver.go
@@ -45,6 +45,7 @@ import (
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 
+	"github.com/open-telemetry/opentelemetry-collector/component"
 	"github.com/open-telemetry/opentelemetry-collector/consumer"
 	"github.com/open-telemetry/opentelemetry-collector/observability"
 	"github.com/open-telemetry/opentelemetry-collector/oterr"
@@ -203,7 +204,7 @@ func (jr *jReceiver) TraceSource() string {
 	return traceSource
 }
 
-func (jr *jReceiver) StartTraceReception(host receiver.Host) error {
+func (jr *jReceiver) Start(host component.Host) error {
 	jr.mu.Lock()
 	defer jr.mu.Unlock()
 
@@ -224,7 +225,7 @@ func (jr *jReceiver) StartTraceReception(host receiver.Host) error {
 	return err
 }
 
-func (jr *jReceiver) StopTraceReception() error {
+func (jr *jReceiver) Shutdown() error {
 	jr.mu.Lock()
 	defer jr.mu.Unlock()
 
@@ -375,7 +376,7 @@ func (jr *jReceiver) PostSpans(ctx context.Context, r *api_v2.PostSpansRequest) 
 	return &api_v2.PostSpansResponse{}, err
 }
 
-func (jr *jReceiver) startAgent(_ receiver.Host) error {
+func (jr *jReceiver) startAgent(_ component.Host) error {
 	if !jr.agentBinaryThriftEnabled() && !jr.agentCompactThriftEnabled() && !jr.agentHTTPEnabled() {
 		return nil
 	}
@@ -441,7 +442,7 @@ func (jr *jReceiver) buildProcessor(address string, factory apacheThrift.TProtoc
 	return processor, nil
 }
 
-func (jr *jReceiver) startCollector(host receiver.Host) error {
+func (jr *jReceiver) startCollector(host component.Host) error {
 	tch, terr := tchannel.NewChannel("jaeger-collector", new(tchannel.ChannelOptions))
 	if terr != nil {
 		return fmt.Errorf("failed to create NewTChannel: %v", terr)

--- a/receiver/jaegerreceiver/trace_receiver_test.go
+++ b/receiver/jaegerreceiver/trace_receiver_test.go
@@ -35,11 +35,11 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 
+	"github.com/open-telemetry/opentelemetry-collector/component"
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-collector/exporter/exportertest"
 	"github.com/open-telemetry/opentelemetry-collector/internal"
 	"github.com/open-telemetry/opentelemetry-collector/receiver"
-	"github.com/open-telemetry/opentelemetry-collector/receiver/receivertest"
 	tracetranslator "github.com/open-telemetry/opentelemetry-collector/translator/trace"
 )
 
@@ -58,16 +58,16 @@ func TestReception(t *testing.T) {
 	sink := new(exportertest.SinkTraceExporter)
 
 	jr, err := New(context.Background(), config, sink, zap.NewNop())
-	defer jr.StopTraceReception()
+	defer jr.Shutdown()
 	assert.NoError(t, err, "should not have failed to create the Jaeger received")
 
 	t.Log("Starting")
 
-	mh := receivertest.NewMockHost()
-	err = jr.StartTraceReception(mh)
+	mh := component.NewMockHost()
+	err = jr.Start(mh)
 	assert.NoError(t, err, "should not have failed to start trace reception")
 
-	t.Log("StartTraceReception")
+	t.Log("Start")
 
 	now := time.Unix(1542158650, 536343000).UTC()
 	nowPlus10min := now.Add(10 * time.Minute)
@@ -110,12 +110,12 @@ func TestGRPCReception(t *testing.T) {
 
 	jr, err := New(context.Background(), config, sink, zap.NewNop())
 	assert.NoError(t, err, "should not have failed to create a new receiver")
-	defer jr.StopTraceReception()
+	defer jr.Shutdown()
 
-	mh := receivertest.NewMockHost()
-	err = jr.StartTraceReception(mh)
+	mh := component.NewMockHost()
+	err = jr.Start(mh)
 	assert.NoError(t, err, "should not have failed to start trace reception")
-	t.Log("StartTraceReception")
+	t.Log("Start")
 
 	conn, err := grpc.Dial(fmt.Sprintf("0.0.0.0:%d", config.CollectorGRPCPort), grpc.WithInsecure())
 	require.NoError(t, err)
@@ -168,12 +168,12 @@ func TestGRPCReceptionWithTLS(t *testing.T) {
 
 	jr, err := New(context.Background(), config, sink, zap.NewNop())
 	assert.NoError(t, err, "should not have failed to create a new receiver")
-	defer jr.StopTraceReception()
+	defer jr.Shutdown()
 
-	mh := receivertest.NewMockHost()
-	err = jr.StartTraceReception(mh)
+	mh := component.NewMockHost()
+	err = jr.Start(mh)
 	assert.NoError(t, err, "should not have failed to start trace reception")
-	t.Log("StartTraceReception")
+	t.Log("Start")
 
 	creds, err := credentials.NewClientTLSFromFile(path.Join(".", "testdata", "certificate.pem"), "opentelemetry.io")
 	require.NoError(t, err)

--- a/receiver/opencensusreceiver/factory_test.go
+++ b/receiver/opencensusreceiver/factory_test.go
@@ -23,11 +23,11 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
+	"github.com/open-telemetry/opentelemetry-collector/component"
 	"github.com/open-telemetry/opentelemetry-collector/config/configcheck"
 	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
 	"github.com/open-telemetry/opentelemetry-collector/exporter/exportertest"
 	"github.com/open-telemetry/opentelemetry-collector/receiver"
-	"github.com/open-telemetry/opentelemetry-collector/receiver/receivertest"
 	"github.com/open-telemetry/opentelemetry-collector/testutils"
 )
 
@@ -111,10 +111,10 @@ func TestCreateTraceReceiver(t *testing.T) {
 				return
 			}
 			if tr != nil {
-				mh := receivertest.NewMockHost()
-				err := tr.StartTraceReception(mh)
-				require.NoError(t, err, "StartTraceReception() error = %v", err)
-				tr.StopTraceReception()
+				mh := component.NewMockHost()
+				err := tr.Start(mh)
+				require.NoError(t, err, "Start() error = %v", err)
+				tr.Shutdown()
 			}
 		})
 	}
@@ -182,10 +182,10 @@ func TestCreateMetricReceiver(t *testing.T) {
 				return
 			}
 			if tc != nil {
-				mh := receivertest.NewMockHost()
-				err := tc.StartMetricsReception(mh)
-				require.NoError(t, err, "StartTraceReception() error = %v", err)
-				tc.StopMetricsReception()
+				mh := component.NewMockHost()
+				err := tc.Start(mh)
+				require.NoError(t, err, "Start() error = %v", err)
+				tc.Shutdown()
 			}
 		})
 	}

--- a/receiver/opencensusreceiver/opencensus.go
+++ b/receiver/opencensusreceiver/opencensus.go
@@ -29,6 +29,7 @@ import (
 	"github.com/soheilhy/cmux"
 	"google.golang.org/grpc"
 
+	"github.com/open-telemetry/opentelemetry-collector/component"
 	"github.com/open-telemetry/opentelemetry-collector/consumer"
 	"github.com/open-telemetry/opentelemetry-collector/observability"
 	"github.com/open-telemetry/opentelemetry-collector/oterr"
@@ -98,9 +99,9 @@ func (ocr *Receiver) TraceSource() string {
 	return source
 }
 
-// StartTraceReception runs the trace receiver on the gRPC server. Currently
+// Start runs the trace receiver on the gRPC server. Currently
 // it also enables the metrics receiver too.
-func (ocr *Receiver) StartTraceReception(host receiver.Host) error {
+func (ocr *Receiver) Start(host component.Host) error {
 	return ocr.start(host)
 }
 
@@ -121,12 +122,6 @@ func (ocr *Receiver) registerTraceConsumer() error {
 // MetricsSource returns the name of the metrics data source.
 func (ocr *Receiver) MetricsSource() string {
 	return source
-}
-
-// StartMetricsReception runs the metrics receiver on the gRPC server. Currently
-// it also enables the trace receiver too.
-func (ocr *Receiver) StartMetricsReception(host receiver.Host) error {
-	return ocr.start(host)
 }
 
 func (ocr *Receiver) registerMetricsConsumer() error {
@@ -153,18 +148,8 @@ func (ocr *Receiver) grpcServer() *grpc.Server {
 	return ocr.serverGRPC
 }
 
-// StopTraceReception is a method to turn off receiving traces. It stops
-// metrics reception too.
-func (ocr *Receiver) StopTraceReception() error {
-	if err := ocr.stop(); err != oterr.ErrAlreadyStopped {
-		return err
-	}
-	return nil
-}
-
-// StopMetricsReception is a method to turn off receiving metrics. It stops
-// trace reception too.
-func (ocr *Receiver) StopMetricsReception() error {
+// Shutdown is a method to turn off receiving.
+func (ocr *Receiver) Shutdown() error {
 	if err := ocr.stop(); err != oterr.ErrAlreadyStopped {
 		return err
 	}
@@ -172,7 +157,7 @@ func (ocr *Receiver) StopMetricsReception() error {
 }
 
 // start runs all the receivers/services namely, Trace and Metrics services.
-func (ocr *Receiver) start(host receiver.Host) error {
+func (ocr *Receiver) start(host component.Host) error {
 	hasConsumer := false
 	if ocr.traceConsumer != nil {
 		hasConsumer = true
@@ -250,7 +235,7 @@ func (ocr *Receiver) httpServer() *http.Server {
 	return ocr.serverHTTP
 }
 
-func (ocr *Receiver) startServer(host receiver.Host) error {
+func (ocr *Receiver) startServer(host component.Host) error {
 	err := oterr.ErrAlreadyStarted
 	ocr.startServerOnce.Do(func() {
 		err = nil

--- a/receiver/opencensusreceiver/opencensus_test.go
+++ b/receiver/opencensusreceiver/opencensus_test.go
@@ -32,10 +32,10 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 
+	"github.com/open-telemetry/opentelemetry-collector/component"
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-collector/exporter/exportertest"
 	"github.com/open-telemetry/opentelemetry-collector/internal"
-	"github.com/open-telemetry/opentelemetry-collector/receiver/receivertest"
 	"github.com/open-telemetry/opentelemetry-collector/testutils"
 )
 
@@ -48,10 +48,10 @@ func TestGrpcGateway_endToEnd(t *testing.T) {
 	ocr, err := New(addr, sink, nil)
 	require.NoError(t, err, "Failed to create trace receiver: %v", err)
 
-	mh := receivertest.NewMockHost()
-	err = ocr.StartTraceReception(mh)
+	mh := component.NewMockHost()
+	err = ocr.Start(mh)
 	require.NoError(t, err, "Failed to start trace receiver: %v", err)
-	defer ocr.StopTraceReception()
+	defer ocr.Shutdown()
 
 	// TODO(songy23): make starting server deterministic
 	// Wait for the servers to start
@@ -151,10 +151,10 @@ func TestTraceGrpcGatewayCors_endToEnd(t *testing.T) {
 	sink := new(exportertest.SinkTraceExporter)
 	ocr, err := New(addr, sink, nil, WithCorsOrigins(corsOrigins))
 	require.NoError(t, err, "Failed to create trace receiver: %v", err)
-	defer ocr.StopTraceReception()
+	defer ocr.Shutdown()
 
-	mh := receivertest.NewMockHost()
-	err = ocr.StartTraceReception(mh)
+	mh := component.NewMockHost()
+	err = ocr.Start(mh)
 	require.NoError(t, err, "Failed to start trace receiver: %v", err)
 
 	// TODO(songy23): make starting server deterministic
@@ -177,10 +177,10 @@ func TestMetricsGrpcGatewayCors_endToEnd(t *testing.T) {
 	sink := new(exportertest.SinkMetricsExporter)
 	ocr, err := New(addr, nil, sink, WithCorsOrigins(corsOrigins))
 	require.NoError(t, err, "Failed to create metrics receiver: %v", err)
-	defer ocr.StopMetricsReception()
+	defer ocr.Shutdown()
 
-	mh := receivertest.NewMockHost()
-	err = ocr.StartMetricsReception(mh)
+	mh := component.NewMockHost()
+	err = ocr.Start(mh)
 	require.NoError(t, err, "Failed to start metrics receiver: %v", err)
 
 	// TODO(songy23): make starting server deterministic
@@ -207,10 +207,10 @@ func TestAcceptAllGRPCProtoAffiliatedContentTypes(t *testing.T) {
 	ocr, err := New(addr, cbts, nil)
 	require.NoError(t, err, "Failed to create trace receiver: %v", err)
 
-	mh := receivertest.NewMockHost()
-	err = ocr.StartTraceReception(mh)
+	mh := component.NewMockHost()
+	err = ocr.Start(mh)
 	require.NoError(t, err, "Failed to start the trace receiver: %v", err)
-	defer ocr.StopTraceReception()
+	defer ocr.Shutdown()
 
 	// Now start the client with the various Proto affiliated gRPC Content-SubTypes as per:
 	//      https://godoc.org/google.golang.org/grpc#CallContentSubtype
@@ -351,12 +351,9 @@ func TestMultipleStopReceptionShouldNotError(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, r)
 
-	mh := receivertest.NewMockHost()
-	require.NoError(t, r.StartTraceReception(mh))
-	require.NoError(t, r.StartMetricsReception(mh))
-
-	require.NoError(t, r.StopMetricsReception())
-	require.NoError(t, r.StopTraceReception())
+	mh := component.NewMockHost()
+	require.NoError(t, r.Start(mh))
+	require.NoError(t, r.Shutdown())
 }
 
 func TestStartWithoutConsumersShouldFail(t *testing.T) {
@@ -365,8 +362,6 @@ func TestStartWithoutConsumersShouldFail(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, r)
 
-	mh := receivertest.NewMockHost()
-	require.Error(t, r.StartTraceReception(mh))
-	require.Error(t, r.StartMetricsReception(mh))
-
+	mh := component.NewMockHost()
+	require.Error(t, r.Start(mh))
 }

--- a/receiver/prometheusreceiver/internal/metrics_adjuster.go
+++ b/receiver/prometheusreceiver/internal/metrics_adjuster.go
@@ -53,7 +53,7 @@ import (
 // 1. If the job-level gc doesn't run often enough, or runs too often, a separate go routine can
 //    be spawned at JobMap creation time that gc's at periodic intervals. This approach potentially
 //    adds more contention and latency to each scrape so the current approach is used. Note that
-//    the go routine will need to be cancelled upon StopMetricsReception().
+//    the go routine will need to be cancelled upon Shutdown().
 // 2. If the gc of each timeseriesMap during the gc of the JobsMap causes too much contention,
 //    the gc of timeseriesMaps can be moved to the end of MetricsAdjuster().AdjustMetrics(). This
 //    approach requires adding 'lastGC' Time and (potentially) a gcInterval duration to

--- a/receiver/prometheusreceiver/metrics_receiver.go
+++ b/receiver/prometheusreceiver/metrics_receiver.go
@@ -24,6 +24,7 @@ import (
 	"github.com/prometheus/prometheus/scrape"
 	"go.uber.org/zap"
 
+	"github.com/open-telemetry/opentelemetry-collector/component"
 	"github.com/open-telemetry/opentelemetry-collector/consumer"
 	"github.com/open-telemetry/opentelemetry-collector/observability"
 	"github.com/open-telemetry/opentelemetry-collector/receiver"
@@ -59,9 +60,9 @@ func (pr *Preceiver) MetricsSource() string {
 	return metricsSource
 }
 
-// StartMetricsReception is the method that starts Prometheus scraping and it
+// Start is the method that starts Prometheus scraping and it
 // is controlled by having previously defined a Configuration using perhaps New.
-func (pr *Preceiver) StartMetricsReception(host receiver.Host) error {
+func (pr *Preceiver) Start(host component.Host) error {
 	pr.startOnce.Do(func() {
 		ctx := host.Context()
 		c, cancel := context.WithCancel(ctx)
@@ -123,8 +124,8 @@ func (pr *Preceiver) Flush() {
 
 }
 
-// StopMetricsReception stops and cancels the underlying Prometheus scrapers.
-func (pr *Preceiver) StopMetricsReception() error {
+// Shutdown stops and cancels the underlying Prometheus scrapers.
+func (pr *Preceiver) Shutdown() error {
 	pr.stopOnce.Do(pr.cancel)
 	return nil
 }

--- a/receiver/prometheusreceiver/metrics_receiver_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_test.go
@@ -38,9 +38,9 @@ import (
 	"go.uber.org/zap"
 	"gopkg.in/yaml.v2"
 
+	"github.com/open-telemetry/opentelemetry-collector/component"
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-collector/exporter/exportertest"
-	"github.com/open-telemetry/opentelemetry-collector/receiver/receivertest"
 )
 
 var logger = zap.NewNop()
@@ -1043,10 +1043,10 @@ func testEndToEnd(t *testing.T, targets []*testData, useStartTimeMetric bool) {
 	cms := new(exportertest.SinkMetricsExporter)
 	rcvr := newPrometheusReceiver(logger, &Config{PrometheusConfig: cfg, UseStartTimeMetric: useStartTimeMetric}, cms)
 
-	mh := receivertest.NewMockHost()
-	err = rcvr.StartMetricsReception(mh)
-	require.Nilf(t, err, "Failed to invoke StartMetricsReception: %v", err)
-	defer rcvr.StopMetricsReception()
+	mh := component.NewMockHost()
+	err = rcvr.Start(mh)
+	require.Nilf(t, err, "Failed to invoke Start: %v", err)
+	defer rcvr.Shutdown()
 
 	// wait for all provided data to be scraped
 	mp.wg.Wait()

--- a/receiver/receiver.go
+++ b/receiver/receiver.go
@@ -15,22 +15,13 @@
 package receiver
 
 import (
-	"context"
-
+	"github.com/open-telemetry/opentelemetry-collector/component"
 	_ "github.com/open-telemetry/opentelemetry-collector/compression/grpc" // load in supported grpc compression encodings
 )
 
-// Host represents the entity where the receiver is being hosted. It is used to
-// allow communication between the receiver and its host.
-type Host interface {
-	// Context returns a context provided by the host to be used on the receiver
-	// operations.
-	Context() context.Context
-
-	// ReportFatalError is used to report to the host that the receiver encountered
-	// a fatal error (i.e.: an error that the instance can't recover from) after
-	// its start function has already returned.
-	ReportFatalError(err error)
+// Receiver defines functions that trace and metric receivers must implement.
+type Receiver interface {
+	component.Component
 }
 
 // A TraceReceiver is an "arbitrary data"-to-"trace proto span" converter.
@@ -41,16 +32,10 @@ type Host interface {
 // For example it could be Zipkin data source which translates
 // Zipkin spans into *tracepb.Span-s.
 type TraceReceiver interface {
+	Receiver
+
 	// TraceSource returns the name of the trace data source.
 	TraceSource() string
-
-	// StartTraceReception tells the receiver to start its processing.
-	// By convention the consumer of the data received is set at creation time.
-	StartTraceReception(host Host) error
-
-	// StopTraceReception tells the receiver that should stop reception,
-	// giving it a chance to perform any necessary clean-up.
-	StopTraceReception() error
 }
 
 // A MetricsReceiver is an "arbitrary data"-to-"metric proto" converter.
@@ -61,14 +46,8 @@ type TraceReceiver interface {
 // For example it could be Prometheus data source which translates
 // Prometheus metrics into *metricpb.Metric-s.
 type MetricsReceiver interface {
+	Receiver
+
 	// MetricsSource returns the name of the metrics data source.
 	MetricsSource() string
-
-	// StartMetricsReception tells the receiver to start its processing.
-	// By convention the consumer of the data received is set at creation time.
-	StartMetricsReception(host Host) error
-
-	// StopMetricsReception tells the receiver that should stop reception,
-	// giving it a chance to perform any necessary clean-up.
-	StopMetricsReception() error
 }

--- a/receiver/vmmetricsreceiver/metrics_receiver.go
+++ b/receiver/vmmetricsreceiver/metrics_receiver.go
@@ -17,6 +17,7 @@ package vmmetricsreceiver
 import (
 	"sync"
 
+	"github.com/open-telemetry/opentelemetry-collector/component"
 	"github.com/open-telemetry/opentelemetry-collector/oterr"
 	"github.com/open-telemetry/opentelemetry-collector/receiver"
 )
@@ -40,8 +41,8 @@ func (vmr *Receiver) MetricsSource() string {
 	return metricsSource
 }
 
-// StartMetricsReception scrapes VM metrics based on the OS platform.
-func (vmr *Receiver) StartMetricsReception(host receiver.Host) error {
+// Start scrapes VM metrics based on the OS platform.
+func (vmr *Receiver) Start(host component.Host) error {
 	vmr.mu.Lock()
 	defer vmr.mu.Unlock()
 
@@ -53,8 +54,8 @@ func (vmr *Receiver) StartMetricsReception(host receiver.Host) error {
 	return err
 }
 
-// StopMetricsReception stops and cancels the underlying VM metrics scrapers.
-func (vmr *Receiver) StopMetricsReception() error {
+// Shutdown stops and cancels the underlying VM metrics scrapers.
+func (vmr *Receiver) Shutdown() error {
 	vmr.mu.Lock()
 	defer vmr.mu.Unlock()
 

--- a/receiver/zipkinreceiver/trace_receiver.go
+++ b/receiver/zipkinreceiver/trace_receiver.go
@@ -36,6 +36,7 @@ import (
 	zipkinproto "github.com/openzipkin/zipkin-go/proto/v2"
 	"go.opencensus.io/trace"
 
+	"github.com/open-telemetry/opentelemetry-collector/component"
 	"github.com/open-telemetry/opentelemetry-collector/consumer"
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-collector/internal"
@@ -53,7 +54,7 @@ type ZipkinReceiver struct {
 
 	// addr is the address onto which the HTTP server will be bound
 	addr         string
-	host         receiver.Host
+	host         component.Host
 	nextConsumer consumer.TraceConsumer
 
 	startOnce sync.Once
@@ -102,8 +103,8 @@ func (zr *ZipkinReceiver) TraceSource() string {
 	return traceSource
 }
 
-// StartTraceReception spins up the receiver's HTTP server and makes the receiver start its processing.
-func (zr *ZipkinReceiver) StartTraceReception(host receiver.Host) error {
+// Start spins up the receiver's HTTP server and makes the receiver start its processing.
+func (zr *ZipkinReceiver) Start(host component.Host) error {
 	if host == nil {
 		return errors.New("nil host")
 	}
@@ -239,10 +240,10 @@ func (zr *ZipkinReceiver) deserializeFromJSON(jsonBlob []byte, debugWasSet bool)
 	return zs, nil
 }
 
-// StopTraceReception tells the receiver that should stop reception,
+// Shutdown tells the receiver that should stop reception,
 // giving it a chance to perform any necessary clean-up and shutting down
 // its HTTP server.
-func (zr *ZipkinReceiver) StopTraceReception() error {
+func (zr *ZipkinReceiver) Shutdown() error {
 	var err = oterr.ErrAlreadyStopped
 	zr.stopOnce.Do(func() {
 		err = zr.server.Close()

--- a/receiver/zipkinreceiver/trace_receiver_test.go
+++ b/receiver/zipkinreceiver/trace_receiver_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
+	"github.com/open-telemetry/opentelemetry-collector/component"
 	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
 	"github.com/open-telemetry/opentelemetry-collector/consumer"
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
@@ -40,8 +41,6 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector/exporter/zipkinexporter"
 	"github.com/open-telemetry/opentelemetry-collector/internal"
 	"github.com/open-telemetry/opentelemetry-collector/oterr"
-	"github.com/open-telemetry/opentelemetry-collector/receiver"
-	"github.com/open-telemetry/opentelemetry-collector/receiver/receivertest"
 	"github.com/open-telemetry/opentelemetry-collector/testutils"
 	"github.com/open-telemetry/opentelemetry-collector/translator/trace/zipkin"
 )
@@ -142,10 +141,10 @@ func TestZipkinReceiverPortAlreadyInUse(t *testing.T) {
 	require.NoError(t, err, "failed to split listener address: %v", err)
 	traceReceiver, err := New("localhost:"+portStr, exportertest.NewNopTraceExporter())
 	require.NoError(t, err, "Failed to create receiver: %v", err)
-	mh := receivertest.NewMockHost()
-	err = traceReceiver.StartTraceReception(mh)
+	mh := component.NewMockHost()
+	err = traceReceiver.Start(mh)
 	if err == nil {
-		traceReceiver.StopTraceReception()
+		traceReceiver.Shutdown()
 		t.Fatal("conflict on port was expected")
 	}
 }
@@ -373,7 +372,7 @@ func TestConversionRoundtrip(t *testing.T) {
 	ze, err := factory.CreateTraceExporter(zap.NewNop(), config)
 	require.NoError(t, err)
 	require.NotNil(t, ze)
-	mh := receivertest.NewMockHost()
+	mh := component.NewMockHost()
 	require.NoError(t, ze.Start(mh))
 
 	for _, treq := range ereqs {
@@ -396,7 +395,7 @@ func TestConversionRoundtrip(t *testing.T) {
 func TestStartTraceReception(t *testing.T) {
 	tests := []struct {
 		name    string
-		host    receiver.Host
+		host    component.Host
 		wantErr bool
 	}{
 		{
@@ -405,7 +404,7 @@ func TestStartTraceReception(t *testing.T) {
 		},
 		{
 			name: "valid_host",
-			host: receivertest.NewMockHost(),
+			host: component.NewMockHost(),
 		},
 	}
 
@@ -416,10 +415,10 @@ func TestStartTraceReception(t *testing.T) {
 			require.Nil(t, err)
 			require.NotNil(t, zr)
 
-			err = zr.StartTraceReception(tt.host)
+			err = zr.Start(tt.host)
 			assert.Equal(t, tt.wantErr, err != nil)
 			if !tt.wantErr {
-				require.Nil(t, zr.StopTraceReception())
+				require.Nil(t, zr.Shutdown())
 			}
 		})
 	}

--- a/service/builder/exporters_builder.go
+++ b/service/builder/exporters_builder.go
@@ -19,6 +19,7 @@ import (
 
 	"go.uber.org/zap"
 
+	"github.com/open-telemetry/opentelemetry-collector/component"
 	"github.com/open-telemetry/opentelemetry-collector/config/configerror"
 	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
 	"github.com/open-telemetry/opentelemetry-collector/exporter"
@@ -33,7 +34,7 @@ type builtExporter struct {
 }
 
 // Start the exporter.
-func (exp *builtExporter) Start(host exporter.Host) error {
+func (exp *builtExporter) Start(host component.Host) error {
 	var errors []error
 	if exp.te != nil {
 		err := exp.te.Start(host)
@@ -74,7 +75,7 @@ func (exp *builtExporter) Shutdown() error {
 type Exporters map[configmodels.Exporter]*builtExporter
 
 // StartAll starts all exporters.
-func (exps Exporters) StartAll(logger *zap.Logger, host exporter.Host) error {
+func (exps Exporters) StartAll(logger *zap.Logger, host component.Host) error {
 	for cfg, exp := range exps {
 		logger.Info("Exporter is starting...", zap.String("exporter", cfg.Name()))
 

--- a/service/builder/exporters_builder_test.go
+++ b/service/builder/exporters_builder_test.go
@@ -21,12 +21,12 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
+	"github.com/open-telemetry/opentelemetry-collector/component"
 	"github.com/open-telemetry/opentelemetry-collector/config"
 	"github.com/open-telemetry/opentelemetry-collector/config/configgrpc"
 	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
 	"github.com/open-telemetry/opentelemetry-collector/exporter"
 	"github.com/open-telemetry/opentelemetry-collector/exporter/opencensusexporter"
-	"github.com/open-telemetry/opentelemetry-collector/receiver/receivertest"
 )
 
 func TestExportersBuilder_Build(t *testing.T) {
@@ -72,7 +72,7 @@ func TestExportersBuilder_Build(t *testing.T) {
 	assert.Nil(t, e1.me)
 
 	// Ensure it can be started.
-	mh := receivertest.NewMockHost()
+	mh := component.NewMockHost()
 	err = exporters.StartAll(zap.NewNop(), mh)
 	assert.NoError(t, err)
 
@@ -116,7 +116,7 @@ func TestExportersBuilder_StartAll(t *testing.T) {
 	assert.False(t, traceExporter.ExporterStarted)
 	assert.False(t, metricExporter.ExporterStarted)
 
-	mh := receivertest.NewMockHost()
+	mh := component.NewMockHost()
 	err := exporters.StartAll(zap.NewNop(), mh)
 	assert.NoError(t, err)
 

--- a/service/builder/pipelines_builder.go
+++ b/service/builder/pipelines_builder.go
@@ -19,6 +19,7 @@ import (
 
 	"go.uber.org/zap"
 
+	"github.com/open-telemetry/opentelemetry-collector/component"
 	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
 	"github.com/open-telemetry/opentelemetry-collector/consumer"
 	"github.com/open-telemetry/opentelemetry-collector/processor"
@@ -34,10 +35,42 @@ type builtPipeline struct {
 	// MutatesConsumedData is set to true if any processors in the pipeline
 	// can mutate the TraceData or MetricsData input argument.
 	MutatesConsumedData bool
+
+	processors []processor.Processor
 }
 
 // BuiltPipelines is a map of build pipelines created from pipeline configs.
 type BuiltPipelines map[*configmodels.Pipeline]*builtPipeline
+
+func (bps BuiltPipelines) StartProcessors(logger *zap.Logger, host component.Host) error {
+	for cfg, bp := range bps {
+		logger.Info("Pipeline is starting...", zap.String("pipeline", cfg.Name))
+		// Start in reverse order, starting from the back of processors pipeline.
+		// This is important so that processors that are earlier in the pipeline and
+		// reference processors that are later in the pipeline do not start sending
+		// data to later pipelines which are not yet started.
+		for i := len(bp.processors) - 1; i >= 0; i-- {
+			if err := bp.processors[i].Start(host); err != nil {
+				return err
+			}
+		}
+		logger.Info("Pipeline is started.", zap.String("pipeline", cfg.Name))
+	}
+	return nil
+}
+
+func (bps BuiltPipelines) ShutdownProcessors(logger *zap.Logger) error {
+	for cfg, bp := range bps {
+		logger.Info("Pipeline is shutting down...", zap.String("pipeline", cfg.Name))
+		for _, p := range bp.processors {
+			if err := p.Shutdown(); err != nil {
+				return err
+			}
+		}
+		logger.Info("Pipeline is shutdown.", zap.String("pipeline", cfg.Name))
+	}
+	return nil
+}
 
 // PipelinesBuilder builds pipelines from config.
 type PipelinesBuilder struct {
@@ -95,6 +128,8 @@ func (pb *PipelinesBuilder) buildPipeline(
 
 	mutatesConsumedData := false
 
+	processors := make([]processor.Processor, len(pipelineCfg.Processors))
+
 	// Now build the processors backwards, starting from the last one.
 	// The last processor points to consumer which fans out to exporters, then
 	// the processor itself becomes a consumer for the one that precedes it in
@@ -116,6 +151,7 @@ func (pb *PipelinesBuilder) buildPipeline(
 			if proc != nil {
 				mutatesConsumedData = mutatesConsumedData || proc.GetCapabilities().MutatesConsumedData
 			}
+			processors[i] = proc
 			tc = proc
 		case configmodels.MetricsDataType:
 			var proc processor.MetricsProcessor
@@ -123,6 +159,7 @@ func (pb *PipelinesBuilder) buildPipeline(
 			if proc != nil {
 				mutatesConsumedData = mutatesConsumedData || proc.GetCapabilities().MutatesConsumedData
 			}
+			processors[i] = proc
 			mc = proc
 		}
 
@@ -139,7 +176,14 @@ func (pb *PipelinesBuilder) buildPipeline(
 
 	pb.logger.Info("Pipeline is enabled.", zap.String("pipelines", pipelineCfg.Name))
 
-	return &builtPipeline{tc, mc, mutatesConsumedData}, nil
+	bp := &builtPipeline{
+		tc,
+		mc,
+		mutatesConsumedData,
+		processors,
+	}
+
+	return bp, nil
 }
 
 // Converts the list of exporter names to a list of corresponding builtExporters.

--- a/service/builder/pipelines_builder_test.go
+++ b/service/builder/pipelines_builder_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
+	"github.com/open-telemetry/opentelemetry-collector/component"
 	"github.com/open-telemetry/opentelemetry-collector/config"
 	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
 	"github.com/open-telemetry/opentelemetry-collector/consumer"
@@ -96,6 +97,10 @@ func testPipeline(t *testing.T, pipelineName string, exporterNames []string) {
 	assert.NoError(t, err)
 	require.NotNil(t, pipelineProcessors)
 
+	mh := component.NewMockHost()
+	err = pipelineProcessors.StartProcessors(zap.NewNop(), mh)
+	assert.NoError(t, err)
+
 	processor := pipelineProcessors[cfg.Service.Pipelines[pipelineName]]
 
 	// Ensure pipeline has its fields correctly populated.
@@ -153,6 +158,9 @@ func testPipeline(t *testing.T, pipelineName string, exporterNames []string) {
 		assert.Equal(t, int64(12345),
 			consumer.Traces[0].Spans[0].Attributes.AttributeMap["attr1"].GetIntValue())
 	}
+
+	err = pipelineProcessors.ShutdownProcessors(zap.NewNop())
+	assert.NoError(t, err)
 }
 
 func TestPipelinesBuilder_Error(t *testing.T) {

--- a/service/builder/receivers_builder.go
+++ b/service/builder/receivers_builder.go
@@ -20,10 +20,10 @@ import (
 
 	"go.uber.org/zap"
 
+	"github.com/open-telemetry/opentelemetry-collector/component"
 	"github.com/open-telemetry/opentelemetry-collector/config/configerror"
 	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
 	"github.com/open-telemetry/opentelemetry-collector/consumer"
-	"github.com/open-telemetry/opentelemetry-collector/oterr"
 	"github.com/open-telemetry/opentelemetry-collector/processor"
 	"github.com/open-telemetry/opentelemetry-collector/receiver"
 )
@@ -31,48 +31,17 @@ import (
 // builtReceiver is a receiver that is built based on a config. It can have
 // a trace and/or a metrics component.
 type builtReceiver struct {
-	trace   receiver.TraceReceiver
-	metrics receiver.MetricsReceiver
+	receiver receiver.Receiver
 }
 
 // Stop the receiver.
 func (rcv *builtReceiver) Stop() error {
-	var errors []error
-	if rcv.trace != nil {
-		err := rcv.trace.StopTraceReception()
-		if err != nil {
-			errors = append(errors, err)
-		}
-	}
-
-	if rcv.metrics != nil {
-		err := rcv.metrics.StopMetricsReception()
-		if err != nil {
-			errors = append(errors, err)
-		}
-	}
-
-	return oterr.CombineErrors(errors)
+	return rcv.receiver.Shutdown()
 }
 
 // Start the receiver.
-func (rcv *builtReceiver) Start(host receiver.Host) error {
-	var errors []error
-	if rcv.trace != nil {
-		err := rcv.trace.StartTraceReception(host)
-		if err != nil {
-			errors = append(errors, err)
-		}
-	}
-
-	if rcv.metrics != nil {
-		err := rcv.metrics.StartMetricsReception(host)
-		if err != nil {
-			errors = append(errors, err)
-		}
-	}
-
-	return oterr.CombineErrors(errors)
+func (rcv *builtReceiver) Start(host component.Host) error {
+	return rcv.receiver.Start(host)
 }
 
 // Receivers is a map of receivers created from receiver configs.
@@ -86,7 +55,7 @@ func (rcvs Receivers) StopAll() {
 }
 
 // StartAll starts all receivers.
-func (rcvs Receivers) StartAll(logger *zap.Logger, host receiver.Host) error {
+func (rcvs Receivers) StartAll(logger *zap.Logger, host component.Host) error {
 	for cfg, rcv := range rcvs {
 		logger.Info("Receiver is starting...", zap.String("receiver", cfg.Name()))
 
@@ -184,17 +153,19 @@ func (rb *ReceiversBuilder) attachReceiverToPipelines(
 	// the receiver. Create the receiver of corresponding data type and make
 	// sure its output is fanned out to all attached pipelines.
 	var err error
+	var createdReceiver receiver.Receiver
+
 	switch dataType {
 	case configmodels.TracesDataType:
 		// First, create the fan out junction point.
 		junction := buildFanoutTraceConsumer(builtPipelines)
 
 		// Now create the receiver and tell it to send to the junction point.
-		rcv.trace, err = factory.CreateTraceReceiver(context.Background(), rb.logger, config, junction)
+		createdReceiver, err = factory.CreateTraceReceiver(context.Background(), rb.logger, config, junction)
 
 	case configmodels.MetricsDataType:
 		junction := buildFanoutMetricConsumer(builtPipelines)
-		rcv.metrics, err = factory.CreateMetricsReceiver(rb.logger, config, junction)
+		createdReceiver, err = factory.CreateMetricsReceiver(rb.logger, config, junction)
 	}
 
 	if err != nil {
@@ -210,9 +181,24 @@ func (rb *ReceiversBuilder) attachReceiverToPipelines(
 	}
 
 	// Check if the factory really created the receiver.
-	if rcv.trace == nil && rcv.metrics == nil {
+	if createdReceiver == nil {
 		return fmt.Errorf("factory for %q produced a nil receiver", config.Name())
 	}
+
+	if rcv.receiver != nil {
+		// The receiver was previously created for this config. This can happen if the
+		// same receiver type supports more than one data type. In that case we expect
+		// that CreateTraceReceiver and CreateMetricsReceiver return the same value.
+		if rcv.receiver != createdReceiver {
+			return fmt.Errorf(
+				"factory for %q is implemented incorrectly: "+
+					"CreateTraceReceiver and CreateMetricsReceiver must return the same "+
+					"receiver pointer when creating receivers of different data types",
+				config.Name(),
+			)
+		}
+	}
+	rcv.receiver = createdReceiver
 
 	rb.logger.Info("Receiver is enabled.",
 		zap.String("receiver", config.Name()), zap.String("datatype", dataType.GetString()))

--- a/testbed/testbed/mock_backend.go
+++ b/testbed/testbed/mock_backend.go
@@ -22,8 +22,8 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/open-telemetry/opentelemetry-collector/component"
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
-	"github.com/open-telemetry/opentelemetry-collector/receiver"
 )
 
 // MockBackend is a backend that allows receiving the data locally.
@@ -54,7 +54,7 @@ func NewMockBackend(logFilePath string, receiver DataReceiver) *MockBackend {
 	return mb
 }
 
-var _ receiver.Host = (*MockBackend)(nil)
+var _ component.Host = (*MockBackend)(nil)
 
 func (mb *MockBackend) Context() context.Context {
 	return context.Background()

--- a/testbed/testbed/receivers.go
+++ b/testbed/testbed/receivers.go
@@ -82,16 +82,11 @@ func (or *OCDataReceiver) Start(tc *MockTraceConsumer, mc *MockMetricConsumer) e
 		return err
 	}
 
-	err = or.receiver.StartTraceReception(or)
-	if err != nil {
-		return err
-	}
-	return or.receiver.StartMetricsReception(or)
+	return or.receiver.Start(or)
 }
 
 func (or *OCDataReceiver) Stop() {
-	or.receiver.StopTraceReception()
-	or.receiver.StopMetricsReception()
+	or.receiver.Shutdown()
 }
 
 func (or *OCDataReceiver) GenConfigYAMLStr() string {
@@ -127,12 +122,12 @@ func (jr *JaegerDataReceiver) Start(tc *MockTraceConsumer, mc *MockMetricConsume
 		return err
 	}
 
-	return jr.receiver.StartTraceReception(jr)
+	return jr.receiver.Start(jr)
 }
 
 func (jr *JaegerDataReceiver) Stop() {
 	if jr.receiver != nil {
-		if err := jr.receiver.StopTraceReception(); err != nil {
+		if err := jr.receiver.Shutdown(); err != nil {
 			log.Printf("Cannot stop Jaeger receiver: %s", err.Error())
 		}
 	}


### PR DESCRIPTION
This change fixes inconsistencies in component interfaces. Motivation:
-  Uniformness results in reduction of code that currently has to deal with differences.
-  Processor.Start is missing and is important for allowing processors to communicate with the Host.

What's changed:

- Introduced Component interface.
- Unified Host interface.
- Added a Start function to processors (via Component interface).
- Receivers, Exporters, Processors, Extensions now embed Component interface.
- Replaced StartTraceReception/StartMetricsReception by single Start function for receivers.
- Replaced StopTraceReception/StopMetricsReception by single Shutdown function for receivers.

Note: before merging this we need to announce the change in Gitter since it breaks existing implementations in `contrib` (although the fix is easy).

Resolves https://github.com/open-telemetry/opentelemetry-collector/issues/477
Resolves https://github.com/open-telemetry/opentelemetry-collector/issues/262
