### PR TITLE
Add CPU profile saving to E2E tests

### DIFF
--- a/extension/pprofextension/config.go
+++ b/extension/pprofextension/config.go
@@ -36,4 +36,8 @@ type Config struct {
 	// disables profiling. See https://golang.org/pkg/runtime/#SetMutexProfileFraction
 	// for details.
 	MutexProfileFraction int `mapstructure:"mutex_profile_fraction"`
+
+	// Optional file name to save the CPU profile to. The profiling starts when the
+	// Collector starts and is saved to the file when the Collector is terminated.
+	SaveToFile string `mapstructure:"save_to_file"`
 }

--- a/extension/pprofextension/pprofextension.go
+++ b/extension/pprofextension/pprofextension.go
@@ -18,7 +18,9 @@ import (
 	"net"
 	"net/http"
 	_ "net/http/pprof" // Needed to enable the performance profiler
+	"os"
 	"runtime"
+	"runtime/pprof"
 
 	"go.uber.org/zap"
 
@@ -52,10 +54,21 @@ func (p *pprofExtension) Start(host extension.Host) error {
 		}
 	}()
 
+	if p.config.SaveToFile != "" {
+		f, err := os.Create(p.config.SaveToFile)
+		if err != nil {
+			return err
+		}
+		pprof.StartCPUProfile(f)
+	}
+
 	return nil
 }
 
 func (p *pprofExtension) Shutdown() error {
+	if p.config.SaveToFile != "" {
+		pprof.StopCPUProfile()
+	}
 	return p.server.Close()
 }
 

--- a/testbed/tests/scenarios.go
+++ b/testbed/tests/scenarios.go
@@ -22,6 +22,8 @@ import (
 	"io/ioutil"
 	"math/rand"
 	"os"
+	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/open-telemetry/opentelemetry-collector/testbed/testbed"
@@ -29,7 +31,7 @@ import (
 
 // createConfigFile creates a collector config file that corresponds to the
 // sender and receiver used in the test and returns the config file name.
-func createConfigFile(sender testbed.DataSender, receiver testbed.DataReceiver) string {
+func createConfigFile(sender testbed.DataSender, receiver testbed.DataReceiver, resultDir string) string {
 	// Create a config. Note that our DataSender is used to generate a config for Collector's
 	// receiver and our DataReceiver is used to generate a config for Collector's exporter.
 	// This is because our DataSender sends to Collector's receiver and our DataReceiver
@@ -45,7 +47,12 @@ processors:
   batch:
   queued_retry:
 
+extensions:
+  pprof:
+    save_to_file: %v/cpu.prof
+
 service:
+  extensions: [pprof]
   pipelines:
     traces:
       receivers: [%v]
@@ -58,7 +65,12 @@ service:
 receivers:%v
 exporters:%v
 
+extensions:
+  pprof:
+    save_to_file: %v/cpu.prof
+
 service:
+  extensions: [pprof]
   pipelines:
     metrics:
       receivers: [%v]
@@ -71,6 +83,7 @@ service:
 		format,
 		sender.GenConfigYAMLStr(),
 		receiver.GenConfigYAMLStr(),
+		resultDir,
 		sender.ProtocolName(),
 		receiver.ProtocolName(),
 	)
@@ -101,7 +114,12 @@ func Scenario10kItemsPerSecond(
 	loadOptions testbed.LoadOptions,
 	resourceSpec testbed.ResourceSpec,
 ) {
-	configFile := createConfigFile(sender, receiver)
+	resultDir, err := filepath.Abs(path.Join("results", t.Name()))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	configFile := createConfigFile(sender, receiver, resultDir)
 	defer os.Remove(configFile)
 
 	if configFile == "" {


### PR DESCRIPTION
Collector was already able to collect own CPU profiles.
This change enables saving CPU profile to a file after each E2E test.
This helps to analyze performance of the Collector in E2E tests.

Resolves https://github.com/open-telemetry/opentelemetry-collector/issues/481