### PR TITLE
Jaeger Receiver Config Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,15 +162,10 @@ receivers:
   jaeger:
     protocols:
       grpc:
-        endpoint: "localhost:9876"
       thrift-http:
-        endpoint: "localhost:14268"
       thrift-tchannel:
-        endpoint: "localhost:14267"
       thrift-compact:
-        endpoint: "localhost:6831"
       thrift-binary:
-        endpoint: "localhost:6832"
 
   prometheus:
     config:

--- a/config/config.go
+++ b/config/config.go
@@ -366,7 +366,7 @@ func loadReceivers(v *viper.Viper, factories map[string]receiver.Factory) (confi
 		customUnmarshaler := factory.CustomUnmarshaler()
 		if customUnmarshaler != nil {
 			// This configuration requires a custom unmarshaler, use it.
-			err = customUnmarshaler(subViper, key, receiverCfg, sv)
+			err = customUnmarshaler(subViper, key, sv, receiverCfg)
 		} else {
 			err = sv.UnmarshalExact(receiverCfg)
 		}

--- a/receiver/README.md
+++ b/receiver/README.md
@@ -124,15 +124,20 @@ It also supports the Jaeger Agent protocols:
 - Thrift Compact
 - Thrift Binary
 
-By default, these services are not started unless an endpoint is explicitly defined.
+By default, these services are not started unless they are explicitly referenced in
+the configuration.  Referencing any protocol with an absent endpoint will choose the
+default ports.
+
+```yaml
+receivers:
+  jaeger:
+    thrift-compact:
+```
 
 It is possible to configure the protocols on different ports, refer to
 [config.yaml](jaegerreceiver/testdata/config.yaml) for detailed config
 examples.
 
-// TODO Issue https://github.com/open-telemetry/opentelemetry-collector/issues/158
-// The Jaeger receiver enables all protocols even when one is specified or a
-// subset is enabled. The documentation should be updated when that fix occurs.
 ### Communicating over TLS
 This receiver supports communication using Transport Layer Security (TLS), but only using the gRPC protocol. It can be configured by specifying a `tls-crendentials` object in the gRPC receiver configuration.   
 ```yaml

--- a/receiver/README.md
+++ b/receiver/README.md
@@ -120,7 +120,8 @@ receiver with only gRPC enabled on the default port.
 ```yaml
 receivers:
   jaeger:
-    grpc:
+    protocols:
+      grpc:
 ```
 
 It is possible to configure the protocols on different ports, refer to

--- a/receiver/README.md
+++ b/receiver/README.md
@@ -107,31 +107,20 @@ This receiver receives traces in the [Jaeger](https://www.jaegertracing.io)
 format. It translates them into the internal format and sends
 it to processors and exporters.
 
-It supports the Jaeger Collector protocols:
+It supports the Jaeger Collector and Agent protocols:
+- gRPC
 - Thrift HTTP
 - Thrift TChannel
-- gRPC
-
-By default, the Jaeger receiver supports all three protocols on the default ports
-specified in [factory.go](jaegerreceiver/factory.go). The following demonstrates
-how to specify the default Jaeger receiver.
-```yaml
-receivers:
-  jaeger:
-```
-
-It also supports the Jaeger Agent protocols:
 - Thrift Compact
 - Thrift Binary
 
-By default, these services are not started unless they are explicitly referenced in
-the configuration.  Referencing any protocol with an absent endpoint will choose the
-default ports.
-
+By default, the Jaeger receiver will not serve any protocol. A protocol must be named
+for the jaeger receiver to start.  The following demonstrates how to start the Jaeger
+receiver with only gRPC enabled on the default port.
 ```yaml
 receivers:
   jaeger:
-    thrift-compact:
+    grpc:
 ```
 
 It is possible to configure the protocols on different ports, refer to

--- a/receiver/factory.go
+++ b/receiver/factory.go
@@ -59,7 +59,7 @@ type Factory interface {
 
 // CustomUnmarshaler is a function that un-marshals a viper data into a config struct
 // in a custom way.
-type CustomUnmarshaler func(v *viper.Viper, viperKey string, intoCfg interface{}) error
+type CustomUnmarshaler func(v *viper.Viper, viperKey string, intoCfg interface{}, sourceViperSection *viper.Viper) error
 
 // Build takes a list of receiver factories and returns a map of type map[string]Factory
 // with factory type as keys. It returns a non-nil error when more than one factories

--- a/receiver/factory.go
+++ b/receiver/factory.go
@@ -59,7 +59,17 @@ type Factory interface {
 
 // CustomUnmarshaler is a function that un-marshals a viper data into a config struct
 // in a custom way.
-type CustomUnmarshaler func(v *viper.Viper, viperKey string, intoCfg interface{}, sourceViperSection *viper.Viper) error
+// v *viper.Viper
+//   A viper instance at the "receivers" node in the config yaml.  v.Sub(viperKey) is
+//   the raw config this function should load.
+// viperKey string
+//   The name of this config.  i.e. "jaeger/custom".  v.Sub(viperKey) is the raw config
+//   this function should load.
+// sourceViperSection *viper.Viper
+//   The value of v.Sub(viperKey) with all environment substitution complete.
+// intoCfg interface{}
+//   An empty interface wrapping a pointer to the config struct to unmarshal into.
+type CustomUnmarshaler func(v *viper.Viper, viperKey string, sourceViperSection *viper.Viper, intoCfg interface{}) error
 
 // Build takes a list of receiver factories and returns a map of type map[string]Factory
 // with factory type as keys. It returns a non-nil error when more than one factories

--- a/receiver/jaegerreceiver/config.go
+++ b/receiver/jaegerreceiver/config.go
@@ -18,6 +18,9 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector/receiver"
 )
 
+// The config field name to load the protocol map from
+const protocolsFieldName = "protocols"
+
 // RemoteSamplingConfig defines config key for remote sampling fetch endpoint
 type RemoteSamplingConfig struct {
 	FetchEndpoint string `mapstructure:"fetch_endpoint"`

--- a/receiver/jaegerreceiver/config_test.go
+++ b/receiver/jaegerreceiver/config_test.go
@@ -41,9 +41,6 @@ func TestLoadConfig(t *testing.T) {
 	// are excluded from the final list.
 	assert.Equal(t, len(cfg.Receivers), 4)
 
-	r0 := cfg.Receivers["jaeger"]
-	assert.Nil(t, r0)
-
 	r1 := cfg.Receivers["jaeger/customname"].(*Config)
 	assert.Equal(t, r1,
 		&Config{
@@ -81,11 +78,11 @@ func TestLoadConfig(t *testing.T) {
 			},
 		})
 
-	rDefaults := cfg.Receivers["jaeger/defaults"].(*Config)
+	rDefaults := cfg.Receivers["jaeger"].(*Config)
 	assert.Equal(t, rDefaults,
 		&Config{
 			TypeVal: typeStr,
-			NameVal: "jaeger/defaults",
+			NameVal: "jaeger",
 			Protocols: map[string]*receiver.SecureReceiverSettings{
 				"grpc": {
 					ReceiverSettings: configmodels.ReceiverSettings{
@@ -162,4 +159,17 @@ func TestLoadConfig(t *testing.T) {
 				},
 			},
 		})
+}
+
+func TestFailedLoadConfig(t *testing.T) {
+	factories, err := config.ExampleComponents()
+	assert.Nil(t, err)
+
+	factory := &Factory{}
+	factories.Receivers[typeStr] = factory
+	_, err = config.LoadConfigFile(t, path.Join(".", "testdata", "bad_proto_config.yaml"), factories)
+	assert.NotNil(t, err)
+
+	_, err = config.LoadConfigFile(t, path.Join(".", "testdata", "no_proto_config.yaml"), factories)
+	assert.NotNil(t, err)
 }

--- a/receiver/jaegerreceiver/config_test.go
+++ b/receiver/jaegerreceiver/config_test.go
@@ -168,8 +168,8 @@ func TestFailedLoadConfig(t *testing.T) {
 	factory := &Factory{}
 	factories.Receivers[typeStr] = factory
 	_, err = config.LoadConfigFile(t, path.Join(".", "testdata", "bad_proto_config.yaml"), factories)
-	assert.NotNil(t, err)
+	assert.EqualError(t, err, `error reading settings for receiver type "jaeger": unknown Jaeger protocol badproto`)
 
 	_, err = config.LoadConfigFile(t, path.Join(".", "testdata", "no_proto_config.yaml"), factories)
-	assert.NotNil(t, err)
+	assert.EqualError(t, err, `error reading settings for receiver type "jaeger": must specify at least one protocol when using the Jaeger receiver`)
 }

--- a/receiver/jaegerreceiver/config_test.go
+++ b/receiver/jaegerreceiver/config_test.go
@@ -78,11 +78,11 @@ func TestLoadConfig(t *testing.T) {
 			},
 		})
 
-	rDefaults := cfg.Receivers["jaeger"].(*Config)
+	rDefaults := cfg.Receivers["jaeger/defaults"].(*Config)
 	assert.Equal(t, rDefaults,
 		&Config{
 			TypeVal: typeStr,
-			NameVal: "jaeger",
+			NameVal: "jaeger/defaults",
 			Protocols: map[string]*receiver.SecureReceiverSettings{
 				"grpc": {
 					ReceiverSettings: configmodels.ReceiverSettings{
@@ -170,6 +170,9 @@ func TestFailedLoadConfig(t *testing.T) {
 	_, err = config.LoadConfigFile(t, path.Join(".", "testdata", "bad_proto_config.yaml"), factories)
 	assert.EqualError(t, err, `error reading settings for receiver type "jaeger": unknown Jaeger protocol badproto`)
 
-	_, err = config.LoadConfigFile(t, path.Join(".", "testdata", "no_proto_config.yaml"), factories)
+	_, err = config.LoadConfigFile(t, path.Join(".", "testdata", "bad_no_proto_config.yaml"), factories)
 	assert.EqualError(t, err, `error reading settings for receiver type "jaeger": must specify at least one protocol when using the Jaeger receiver`)
+
+	_, err = config.LoadConfigFile(t, path.Join(".", "testdata", "bad_empty_config.yaml"), factories)
+	assert.EqualError(t, err, `error reading settings for receiver type "jaeger": Jaeger receiver config is empty`)
 }

--- a/receiver/jaegerreceiver/config_test.go
+++ b/receiver/jaegerreceiver/config_test.go
@@ -37,12 +37,12 @@ func TestLoadConfig(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, cfg)
 
-	// The receiver `jaeger/disabled` doesn't count because disabled receivers
+	// The receiver `jaeger/disabled` and `jaeger` don't count because disabled receivers
 	// are excluded from the final list.
-	assert.Equal(t, len(cfg.Receivers), 3)
+	assert.Equal(t, len(cfg.Receivers), 4)
 
 	r0 := cfg.Receivers["jaeger"]
-	assert.Equal(t, r0, factory.CreateDefaultConfig())
+	assert.Nil(t, r0)
 
 	r1 := cfg.Receivers["jaeger/customname"].(*Config)
 	assert.Equal(t, r1,
@@ -78,6 +78,59 @@ func TestLoadConfig(t *testing.T) {
 			},
 			RemoteSampling: &RemoteSamplingConfig{
 				FetchEndpoint: "jaeger-collector:1234",
+			},
+		})
+
+	rDefaults := cfg.Receivers["jaeger/defaults"].(*Config)
+	assert.Equal(t, rDefaults,
+		&Config{
+			TypeVal: typeStr,
+			NameVal: "jaeger/defaults",
+			Protocols: map[string]*receiver.SecureReceiverSettings{
+				"grpc": {
+					ReceiverSettings: configmodels.ReceiverSettings{
+						Endpoint: defaultGRPCBindEndpoint,
+					},
+				},
+				"thrift-http": {
+					ReceiverSettings: configmodels.ReceiverSettings{
+						Endpoint: defaultHTTPBindEndpoint,
+					},
+				},
+				"thrift-tchannel": {
+					ReceiverSettings: configmodels.ReceiverSettings{
+						Endpoint: defaultTChannelBindEndpoint,
+					},
+				},
+				"thrift-compact": {
+					ReceiverSettings: configmodels.ReceiverSettings{
+						Endpoint: defaultThriftCompactBindEndpoint,
+					},
+				},
+				"thrift-binary": {
+					ReceiverSettings: configmodels.ReceiverSettings{
+						Endpoint: defaultThriftBinaryBindEndpoint,
+					},
+				},
+			},
+		})
+
+	rMixed := cfg.Receivers["jaeger/mixed"].(*Config)
+	assert.Equal(t, rMixed,
+		&Config{
+			TypeVal: typeStr,
+			NameVal: "jaeger/mixed",
+			Protocols: map[string]*receiver.SecureReceiverSettings{
+				"grpc": {
+					ReceiverSettings: configmodels.ReceiverSettings{
+						Endpoint: "localhost:9876",
+					},
+				},
+				"thrift-compact": {
+					ReceiverSettings: configmodels.ReceiverSettings{
+						Endpoint: defaultThriftCompactBindEndpoint,
+					},
+				},
 			},
 		})
 

--- a/receiver/jaegerreceiver/factory.go
+++ b/receiver/jaegerreceiver/factory.go
@@ -26,7 +26,6 @@ import (
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 
-	"github.com/open-telemetry/opentelemetry-collector/config"
 	"github.com/open-telemetry/opentelemetry-collector/config/configerror"
 	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
 	"github.com/open-telemetry/opentelemetry-collector/consumer"
@@ -66,10 +65,9 @@ func (f *Factory) Type() string {
 
 // CustomUnmarshaler is used to add defaults for named but empty protocols
 func (f *Factory) CustomUnmarshaler() receiver.CustomUnmarshaler {
-	return func(v *viper.Viper, viperKey string, intoCfg interface{}) error {
+	return func(v *viper.Viper, viperKey string, intoCfg interface{}, sourceViperSection *viper.Viper) error {
 		// first load the config normally
-		vReceiverCfg := config.GetConfigSection(v, viperKey)
-		err := vReceiverCfg.UnmarshalExact(intoCfg)
+		err := sourceViperSection.UnmarshalExact(intoCfg)
 		if err != nil {
 			return err
 		}

--- a/receiver/jaegerreceiver/factory.go
+++ b/receiver/jaegerreceiver/factory.go
@@ -48,6 +48,9 @@ const (
 	defaultGRPCBindEndpoint     = "localhost:14250"
 	defaultHTTPBindEndpoint     = "localhost:14268"
 	defaultTChannelBindEndpoint = "localhost:14267"
+
+	defaultThriftCompactBindEndpoint = "localhost:6831"
+	defaultThriftBinaryBindEndpoint  = "localhost:6832"
 )
 
 // Factory is the factory for Jaeger receiver.
@@ -115,7 +118,11 @@ func (f *Factory) CreateTraceReceiver(
 	// Set ports
 	if protoGRPC != nil && protoGRPC.IsEnabled() {
 		var err error
-		config.CollectorGRPCPort, err = extractPortFromEndpoint(protoGRPC.Endpoint)
+		endpoint := protoGRPC.Endpoint
+		if endpoint == "" {
+			endpoint = defaultGRPCBindEndpoint
+		}
+		config.CollectorGRPCPort, err = extractPortFromEndpoint(endpoint)
 		if err != nil {
 			return nil, err
 		}
@@ -132,7 +139,11 @@ func (f *Factory) CreateTraceReceiver(
 
 	if protoHTTP != nil && protoHTTP.IsEnabled() {
 		var err error
-		config.CollectorHTTPPort, err = extractPortFromEndpoint(protoHTTP.Endpoint)
+		endpoint := protoHTTP.Endpoint
+		if endpoint == "" {
+			endpoint = defaultHTTPBindEndpoint
+		}
+		config.CollectorHTTPPort, err = extractPortFromEndpoint(endpoint)
 		if err != nil {
 			return nil, err
 		}
@@ -140,7 +151,11 @@ func (f *Factory) CreateTraceReceiver(
 
 	if protoTChannel != nil && protoTChannel.IsEnabled() {
 		var err error
-		config.CollectorThriftPort, err = extractPortFromEndpoint(protoTChannel.Endpoint)
+		endpoint := protoTChannel.Endpoint
+		if endpoint == "" {
+			endpoint = defaultTChannelBindEndpoint
+		}
+		config.CollectorThriftPort, err = extractPortFromEndpoint(endpoint)
 		if err != nil {
 			return nil, err
 		}
@@ -148,7 +163,11 @@ func (f *Factory) CreateTraceReceiver(
 
 	if protoThriftBinary != nil && protoThriftBinary.IsEnabled() {
 		var err error
-		config.AgentBinaryThriftPort, err = extractPortFromEndpoint(protoThriftBinary.Endpoint)
+		endpoint := protoThriftBinary.Endpoint
+		if endpoint == "" {
+			endpoint = defaultThriftBinaryBindEndpoint
+		}
+		config.AgentBinaryThriftPort, err = extractPortFromEndpoint(endpoint)
 		if err != nil {
 			return nil, err
 		}
@@ -156,7 +175,11 @@ func (f *Factory) CreateTraceReceiver(
 
 	if protoThriftCompact != nil && protoThriftCompact.IsEnabled() {
 		var err error
-		config.AgentCompactThriftPort, err = extractPortFromEndpoint(protoThriftCompact.Endpoint)
+		endpoint := protoThriftCompact.Endpoint
+		if endpoint == "" {
+			endpoint = defaultThriftCompactBindEndpoint
+		}
+		config.AgentCompactThriftPort, err = extractPortFromEndpoint(endpoint)
 		if err != nil {
 			return nil, err
 		}

--- a/receiver/jaegerreceiver/factory.go
+++ b/receiver/jaegerreceiver/factory.go
@@ -77,6 +77,10 @@ func (f *Factory) CustomUnmarshaler() receiver.CustomUnmarshaler {
 			return fmt.Errorf("config type not *jaegerreceiver.Config")
 		}
 
+		if len(receiverCfg.Protocols) == 0 {
+			return fmt.Errorf("must specify at least one protocol when using the Jaeger receiver")
+		}
+
 		// any protocol for which k exists, but v is nil needs to have defaults injected
 		for k, v := range receiverCfg.Protocols {
 			if v == nil {
@@ -235,7 +239,7 @@ func defaultsForProtocol(proto string) (*receiver.SecureReceiverSettings, error)
 	case protoThriftCompact:
 		defaultEndpoint = defaultThriftCompactBindEndpoint
 	default:
-		return nil, fmt.Errorf("unknown jaeger protocol %s", proto)
+		return nil, fmt.Errorf("unknown Jaeger protocol %s", proto)
 	}
 
 	return &receiver.SecureReceiverSettings{

--- a/receiver/jaegerreceiver/factory.go
+++ b/receiver/jaegerreceiver/factory.go
@@ -65,7 +65,7 @@ func (f *Factory) Type() string {
 
 // CustomUnmarshaler is used to add defaults for named but empty protocols
 func (f *Factory) CustomUnmarshaler() receiver.CustomUnmarshaler {
-	return func(v *viper.Viper, viperKey string, intoCfg interface{}, sourceViperSection *viper.Viper) error {
+	return func(v *viper.Viper, viperKey string, sourceViperSection *viper.Viper, intoCfg interface{}) error {
 		// first load the config normally
 		err := sourceViperSection.UnmarshalExact(intoCfg)
 		if err != nil {
@@ -83,7 +83,7 @@ func (f *Factory) CustomUnmarshaler() receiver.CustomUnmarshaler {
 		if vSub == nil {
 			return fmt.Errorf("Jaeger receiver config is empty")
 		}
-		protocols := vSub.GetStringMap("protocols")
+		protocols := vSub.GetStringMap(protocolsFieldName)
 		if len(protocols) == 0 {
 			return fmt.Errorf("must specify at least one protocol when using the Jaeger receiver")
 		}

--- a/receiver/jaegerreceiver/factory_test.go
+++ b/receiver/jaegerreceiver/factory_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 
@@ -26,6 +27,12 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
 	"github.com/open-telemetry/opentelemetry-collector/receiver"
 )
+
+func TestTypeStr(t *testing.T) {
+	factory := Factory{}
+
+	assert.Equal(t, "jaeger", factory.Type())
+}
 
 func TestCreateDefaultConfig(t *testing.T) {
 	factory := Factory{}
@@ -207,4 +214,18 @@ func TestRemoteSamplingConfigPropagation(t *testing.T) {
 
 	assert.NoError(t, err, "create trace receiver should not error")
 	assert.Equal(t, endpoint, r.(*jReceiver).config.RemoteSamplingEndpoint)
+}
+
+func TestCustomUnmarshalErrors(t *testing.T) {
+	factory := Factory{}
+	v := viper.New()
+
+	f := factory.CustomUnmarshaler()
+	assert.NotNil(t, f, "custom unmarshal function should not be nil")
+
+	err := f(v, "", nil)
+	assert.Error(t, err, "should not have been able to marshal to a nil config")
+
+	err = f(v, "", &RemoteSamplingConfig{})
+	assert.Error(t, err, "should not have been able to marshal to a non-jaegerreceiver config")
 }

--- a/receiver/jaegerreceiver/factory_test.go
+++ b/receiver/jaegerreceiver/factory_test.go
@@ -45,7 +45,7 @@ func TestCreateReceiver(t *testing.T) {
 	factory := Factory{}
 	cfg := factory.CreateDefaultConfig()
 	// have to enable at least one protocol for the jaeger receiver to be created
-	cfg.(*Config).Protocols[protoGRPC] = defaultsForProtocol(protoGRPC)
+	cfg.(*Config).Protocols[protoGRPC], _ = defaultsForProtocol(protoGRPC)
 
 	tReceiver, err := factory.CreateTraceReceiver(context.Background(), zap.NewNop(), cfg, nil)
 	assert.NoError(t, err, "receiver creation failed")
@@ -62,7 +62,7 @@ func TestCreateDefaultGRPCEndpoint(t *testing.T) {
 	cfg := factory.CreateDefaultConfig()
 	rCfg := cfg.(*Config)
 
-	rCfg.Protocols[protoGRPC] = defaultsForProtocol(protoGRPC)
+	rCfg.Protocols[protoGRPC], _ = defaultsForProtocol(protoGRPC)
 	r, err := factory.CreateTraceReceiver(context.Background(), zap.NewNop(), cfg, nil)
 
 	assert.NoError(t, err, "unexpected error creating receiver")
@@ -74,7 +74,7 @@ func TestCreateInvalidHTTPEndpoint(t *testing.T) {
 	cfg := factory.CreateDefaultConfig()
 	rCfg := cfg.(*Config)
 
-	rCfg.Protocols[protoThriftHTTP] = defaultsForProtocol(protoThriftHTTP)
+	rCfg.Protocols[protoThriftHTTP], _ = defaultsForProtocol(protoThriftHTTP)
 	r, err := factory.CreateTraceReceiver(context.Background(), zap.NewNop(), cfg, nil)
 
 	assert.NoError(t, err, "unexpected error creating receiver")
@@ -86,7 +86,7 @@ func TestCreateInvalidTChannelEndpoint(t *testing.T) {
 	cfg := factory.CreateDefaultConfig()
 	rCfg := cfg.(*Config)
 
-	rCfg.Protocols[protoThriftTChannel] = defaultsForProtocol(protoThriftTChannel)
+	rCfg.Protocols[protoThriftTChannel], _ = defaultsForProtocol(protoThriftTChannel)
 	r, err := factory.CreateTraceReceiver(context.Background(), zap.NewNop(), cfg, nil)
 
 	assert.NoError(t, err, "unexpected error creating receiver")
@@ -98,7 +98,7 @@ func TestCreateInvalidThriftBinaryEndpoint(t *testing.T) {
 	cfg := factory.CreateDefaultConfig()
 	rCfg := cfg.(*Config)
 
-	rCfg.Protocols[protoThriftBinary] = defaultsForProtocol(protoThriftBinary)
+	rCfg.Protocols[protoThriftBinary], _ = defaultsForProtocol(protoThriftBinary)
 	r, err := factory.CreateTraceReceiver(context.Background(), zap.NewNop(), cfg, nil)
 
 	assert.NoError(t, err, "unexpected error creating receiver")
@@ -110,7 +110,7 @@ func TestCreateInvalidThriftCompactEndpoint(t *testing.T) {
 	cfg := factory.CreateDefaultConfig()
 	rCfg := cfg.(*Config)
 
-	rCfg.Protocols[protoThriftCompact] = defaultsForProtocol(protoThriftCompact)
+	rCfg.Protocols[protoThriftCompact], _ = defaultsForProtocol(protoThriftCompact)
 	r, err := factory.CreateTraceReceiver(context.Background(), zap.NewNop(), cfg, nil)
 
 	assert.NoError(t, err, "unexpected error creating receiver")
@@ -206,7 +206,7 @@ func TestRemoteSamplingConfigPropagation(t *testing.T) {
 	rCfg := cfg.(*Config)
 
 	endpoint := "localhost:1234"
-	rCfg.Protocols[protoThriftCompact] = defaultsForProtocol(protoThriftCompact)
+	rCfg.Protocols[protoThriftCompact], _ = defaultsForProtocol(protoThriftCompact)
 	rCfg.RemoteSampling = &RemoteSamplingConfig{
 		FetchEndpoint: endpoint,
 	}
@@ -228,4 +228,11 @@ func TestCustomUnmarshalErrors(t *testing.T) {
 
 	err = f(v, "", &RemoteSamplingConfig{})
 	assert.Error(t, err, "should not have been able to marshal to a non-jaegerreceiver config")
+}
+
+func TestDefaultsForProtocolError(t *testing.T) {
+	d, err := defaultsForProtocol("badproto")
+
+	assert.Nil(t, d, "defaultsForProtocol should have returned nil")
+	assert.Error(t, err, "defaultsForProtocol should have errored")
 }

--- a/receiver/jaegerreceiver/factory_test.go
+++ b/receiver/jaegerreceiver/factory_test.go
@@ -223,10 +223,10 @@ func TestCustomUnmarshalErrors(t *testing.T) {
 	f := factory.CustomUnmarshaler()
 	assert.NotNil(t, f, "custom unmarshal function should not be nil")
 
-	err := f(v, "", nil)
+	err := f(v, "", nil, viper.New())
 	assert.Error(t, err, "should not have been able to marshal to a nil config")
 
-	err = f(v, "", &RemoteSamplingConfig{})
+	err = f(v, "", &RemoteSamplingConfig{}, viper.New())
 	assert.Error(t, err, "should not have been able to marshal to a non-jaegerreceiver config")
 }
 

--- a/receiver/jaegerreceiver/factory_test.go
+++ b/receiver/jaegerreceiver/factory_test.go
@@ -223,10 +223,10 @@ func TestCustomUnmarshalErrors(t *testing.T) {
 	f := factory.CustomUnmarshaler()
 	assert.NotNil(t, f, "custom unmarshal function should not be nil")
 
-	err := f(v, "", nil, viper.New())
+	err := f(v, "", viper.New(), nil)
 	assert.Error(t, err, "should not have been able to marshal to a nil config")
 
-	err = f(v, "", &RemoteSamplingConfig{}, viper.New())
+	err = f(v, "", viper.New(), &RemoteSamplingConfig{})
 	assert.Error(t, err, "should not have been able to marshal to a non-jaegerreceiver config")
 }
 

--- a/receiver/jaegerreceiver/factory_test.go
+++ b/receiver/jaegerreceiver/factory_test.go
@@ -47,14 +47,17 @@ func TestCreateReceiver(t *testing.T) {
 	assert.Nil(t, mReceiver)
 }
 
-func TestCreateInvalidGRPCEndpoint(t *testing.T) {
+// default ports retrieved from https://www.jaegertracing.io/docs/1.16/deployment/
+func TestCreateDefaultGRPCEndpoint(t *testing.T) {
 	factory := Factory{}
 	cfg := factory.CreateDefaultConfig()
 	rCfg := cfg.(*Config)
 
 	rCfg.Protocols[protoGRPC].Endpoint = ""
-	_, err := factory.CreateTraceReceiver(context.Background(), zap.NewNop(), cfg, nil)
-	assert.Error(t, err, "receiver creation with no endpoints must fail")
+	r, err := factory.CreateTraceReceiver(context.Background(), zap.NewNop(), cfg, nil)
+
+	assert.NoError(t, err, "unexpected error creating receiver")
+	assert.Equal(t, 14250, r.(*jReceiver).config.CollectorGRPCPort, "grpc port should be default")
 }
 
 func TestCreateInvalidHTTPEndpoint(t *testing.T) {
@@ -63,8 +66,10 @@ func TestCreateInvalidHTTPEndpoint(t *testing.T) {
 	rCfg := cfg.(*Config)
 
 	rCfg.Protocols[protoThriftHTTP].Endpoint = ""
-	_, err := factory.CreateTraceReceiver(context.Background(), zap.NewNop(), cfg, nil)
-	assert.Error(t, err, "receiver creation with no endpoints must fail")
+	r, err := factory.CreateTraceReceiver(context.Background(), zap.NewNop(), cfg, nil)
+
+	assert.NoError(t, err, "unexpected error creating receiver")
+	assert.Equal(t, 14268, r.(*jReceiver).config.CollectorHTTPPort, "http port should be default")
 }
 
 func TestCreateInvalidTChannelEndpoint(t *testing.T) {
@@ -73,8 +78,10 @@ func TestCreateInvalidTChannelEndpoint(t *testing.T) {
 	rCfg := cfg.(*Config)
 
 	rCfg.Protocols[protoThriftTChannel].Endpoint = ""
-	_, err := factory.CreateTraceReceiver(context.Background(), zap.NewNop(), cfg, nil)
-	assert.Error(t, err, "receiver creation with invalid tchannel endpoint must fail")
+	r, err := factory.CreateTraceReceiver(context.Background(), zap.NewNop(), cfg, nil)
+
+	assert.NoError(t, err, "unexpected error creating receiver")
+	assert.Equal(t, 14267, r.(*jReceiver).config.CollectorThriftPort, "thrift port should be default")
 }
 
 func TestCreateInvalidThriftBinaryEndpoint(t *testing.T) {
@@ -87,8 +94,10 @@ func TestCreateInvalidThriftBinaryEndpoint(t *testing.T) {
 			Endpoint: "",
 		},
 	}
-	_, err := factory.CreateTraceReceiver(context.Background(), zap.NewNop(), cfg, nil)
-	assert.Error(t, err, "receiver creation with no endpoints must fail")
+	r, err := factory.CreateTraceReceiver(context.Background(), zap.NewNop(), cfg, nil)
+
+	assert.NoError(t, err, "unexpected error creating receiver")
+	assert.Equal(t, 6832, r.(*jReceiver).config.AgentBinaryThriftPort, "thrift port should be default")
 }
 
 func TestCreateInvalidThriftCompactEndpoint(t *testing.T) {
@@ -101,8 +110,10 @@ func TestCreateInvalidThriftCompactEndpoint(t *testing.T) {
 			Endpoint: "",
 		},
 	}
-	_, err := factory.CreateTraceReceiver(context.Background(), zap.NewNop(), cfg, nil)
-	assert.Error(t, err, "receiver creation with no endpoints must fail")
+	r, err := factory.CreateTraceReceiver(context.Background(), zap.NewNop(), cfg, nil)
+
+	assert.NoError(t, err, "unexpected error creating receiver")
+	assert.Equal(t, 6831, r.(*jReceiver).config.AgentCompactThriftPort, "thrift port should be default")
 }
 
 func TestCreateNoPort(t *testing.T) {

--- a/receiver/jaegerreceiver/testdata/bad_empty_config.yaml
+++ b/receiver/jaegerreceiver/testdata/bad_empty_config.yaml
@@ -1,5 +1,4 @@
 receivers:
-  # The following demonstrates how to enable protocols with defaults
   jaeger:
 
 processors:

--- a/receiver/jaegerreceiver/testdata/bad_no_proto_config.yaml
+++ b/receiver/jaegerreceiver/testdata/bad_no_proto_config.yaml
@@ -1,0 +1,16 @@
+receivers:
+  jaeger:
+    protocols:
+
+processors:
+  exampleprocessor:
+
+exporters:
+  exampleexporter:
+
+service:
+  pipelines:
+    traces:
+     receivers: [jaeger]
+     processors: [exampleprocessor]
+     exporters: [exampleexporter]

--- a/receiver/jaegerreceiver/testdata/bad_proto_config.yaml
+++ b/receiver/jaegerreceiver/testdata/bad_proto_config.yaml
@@ -1,0 +1,18 @@
+receivers:
+  # The following demonstrates how to enable protocols with defaults
+  jaeger:
+    protocols:
+      badproto:
+
+processors:
+  exampleprocessor:
+
+exporters:
+  exampleexporter:
+
+service:
+  pipelines:
+    traces:
+     receivers: [jaeger]
+     processors: [exampleprocessor]
+     exporters: [exampleexporter]

--- a/receiver/jaegerreceiver/testdata/config.yaml
+++ b/receiver/jaegerreceiver/testdata/config.yaml
@@ -1,11 +1,11 @@
 receivers:
   # The following demonstrates initializing the default jaeger receiver.
-  # By default this configuration enables nothing and will serve no jaeger protocols
+  # By default this configuration enables nothing and will serve no jaeger protocols.
   jaeger:
   # The following demonstrates specifying different endpoints.
   # The Jaeger receiver connects to ports on all available network interfaces.
   # Ex: `endpoint: "9876"` is incorrect.
-  # Ex: `endpoint: "1.2.3.4:9876"`  and ":9876" is correct
+  # Ex: `endpoint: "1.2.3.4:9876"`  and ":9876" is correct.
   jaeger/customname:
     protocols:
       grpc:
@@ -20,7 +20,7 @@ receivers:
         endpoint: "0.0.0.0:789"
     remote_sampling:
       fetch_endpoint: "jaeger-collector:1234"
-  # The following demonstrates how to enable protocols with defaults
+  # The following demonstrates how to enable protocols with defaults.
   jaeger:
     protocols:
       grpc:
@@ -28,14 +28,14 @@ receivers:
       thrift-tchannel:
       thrift-compact:
       thrift-binary:
-  # The following demonstrates only enabling certain protocols with defaults/overrides
+  # The following demonstrates only enabling certain protocols with defaults/overrides.
   jaeger/mixed:
     protocols:
       grpc:
         endpoint: "localhost:9876"
       thrift-compact:
   # The following demonstrates how to disable a protocol.  This particular config
-  # will not start any jaeger protocols
+  # will not start any jaeger protocols.
   jaeger/disabled:
     protocols:
       grpc:
@@ -51,7 +51,7 @@ receivers:
   # The following demonstrates specifying different endpoints.
   # The Jaeger receiver connects to ports on all available network interfaces.
   # Ex: `endpoint: "9876"` is incorrect.
-  # Ex: `endpoint: "1.2.3.4:9876"`  and ":9876" is correct
+  # Ex: `endpoint: "1.2.3.4:9876"`  and ":9876" is correct.
   jaeger/tls:
     protocols:
       grpc:

--- a/receiver/jaegerreceiver/testdata/config.yaml
+++ b/receiver/jaegerreceiver/testdata/config.yaml
@@ -1,7 +1,6 @@
 receivers:
   # The following demonstrates initializing the default jaeger receiver.
-  # By default all three protocols (grpc, thrift-http, thrift-tchannel)
-  # are enabled and the default endpoints are specified in factory.go
+  # By default this configuration enables nothing and will not server no jaeger protocols
   jaeger:
   # The following demonstrates specifying different endpoints.
   # The Jaeger receiver connects to ports on all available network interfaces.
@@ -21,13 +20,22 @@ receivers:
         endpoint: "0.0.0.0:789"
     remote_sampling:
       fetch_endpoint: "jaeger-collector:1234"
-
-  # The following demonstrates disabling the receiver.
-  # All of the protocols need to be disabled for the receiver to be disabled.
-  # If a subset of the protocols are disabled, the disabled flags are ignored
-  # and all protocols are enabled.
-  # This is to be fixed with issue
-  # https://github.com/open-telemetry/opentelemetry-collector/issues/158
+  # The following demonstrates how to enable protocols with defaults
+  jaeger/defaults:
+    protocols:
+      grpc:
+      thrift-http:
+      thrift-tchannel:
+      thrift-compact:
+      thrift-binary:
+  # The following demonstrates only enabling certain protocols with defaults/overrides
+  jaeger/mixed:
+    protocols:
+      grpc:
+        endpoint: "localhost:9876"
+      thrift-compact:
+  # The following demonstrates how to disable a protocol.  This particular config
+  # will not start any jaeger protocols
   jaeger/disabled:
     protocols:
       grpc:
@@ -40,7 +48,6 @@ receivers:
         disabled: true
       thrift-binary:
         disabled: true
-
   # The following demonstrates specifying different endpoints.
   # The Jaeger receiver connects to ports on all available network interfaces.
   # Ex: `endpoint: "9876"` is incorrect.

--- a/receiver/jaegerreceiver/testdata/config.yaml
+++ b/receiver/jaegerreceiver/testdata/config.yaml
@@ -1,7 +1,4 @@
 receivers:
-  # The following demonstrates initializing the default jaeger receiver.
-  # By default this configuration enables nothing and will serve no jaeger protocols.
-  jaeger:
   # The following demonstrates specifying different endpoints.
   # The Jaeger receiver connects to ports on all available network interfaces.
   # Ex: `endpoint: "9876"` is incorrect.
@@ -21,7 +18,7 @@ receivers:
     remote_sampling:
       fetch_endpoint: "jaeger-collector:1234"
   # The following demonstrates how to enable protocols with defaults.
-  jaeger:
+  jaeger/defaults:
     protocols:
       grpc:
       thrift-http:
@@ -73,6 +70,6 @@ exporters:
 service:
   pipelines:
     traces:
-     receivers: [jaeger]
+     receivers: [jaeger/defaults]
      processors: [exampleprocessor]
      exporters: [exampleexporter]

--- a/receiver/jaegerreceiver/testdata/config.yaml
+++ b/receiver/jaegerreceiver/testdata/config.yaml
@@ -21,7 +21,7 @@ receivers:
     remote_sampling:
       fetch_endpoint: "jaeger-collector:1234"
   # The following demonstrates how to enable protocols with defaults
-  jaeger/defaults:
+  jaeger:
     protocols:
       grpc:
       thrift-http:

--- a/receiver/jaegerreceiver/testdata/config.yaml
+++ b/receiver/jaegerreceiver/testdata/config.yaml
@@ -1,6 +1,6 @@
 receivers:
   # The following demonstrates initializing the default jaeger receiver.
-  # By default this configuration enables nothing and will not server no jaeger protocols
+  # By default this configuration enables nothing and will serve no jaeger protocols
   jaeger:
   # The following demonstrates specifying different endpoints.
   # The Jaeger receiver connects to ports on all available network interfaces.

--- a/receiver/jaegerreceiver/testdata/no_proto_config.yaml
+++ b/receiver/jaegerreceiver/testdata/no_proto_config.yaml
@@ -1,0 +1,16 @@
+receivers:
+  # The following demonstrates how to enable protocols with defaults
+  jaeger:
+
+processors:
+  exampleprocessor:
+
+exporters:
+  exampleexporter:
+
+service:
+  pipelines:
+    traces:
+     receivers: [jaeger]
+     processors: [exampleprocessor]
+     exporters: [exampleexporter]

--- a/receiver/jaegerreceiver/trace_receiver.go
+++ b/receiver/jaegerreceiver/trace_receiver.go
@@ -102,14 +102,6 @@ const (
 	defaultAgentMaxPacketSize = 65000
 	defaultAgentServerWorkers = 10
 
-	// As per https://www.jaegertracing.io/docs/1.13/deployment/
-	// By default, the port used by jaeger-agent to send spans in model.proto format
-	defaultGRPCPort = 14250
-	// By default, the port used by jaeger-agent to send spans in jaeger.thrift format
-	defaultTChannelPort = 14267
-	// By default, can accept spans directly from clients in jaeger.thrift format over binary thrift protocol
-	defaultCollectorHTTPPort = 14268
-
 	traceSource string = "Jaeger"
 )
 

--- a/receiver/jaegerreceiver/trace_receiver.go
+++ b/receiver/jaegerreceiver/trace_receiver.go
@@ -128,41 +128,6 @@ func New(ctx context.Context, config *Configuration, nextConsumer consumer.Trace
 
 var _ receiver.TraceReceiver = (*jReceiver)(nil)
 
-func (jr *jReceiver) collectorAddr() string {
-	var port int
-	if jr.config != nil {
-		port = jr.config.CollectorHTTPPort
-	}
-	if port <= 0 {
-		port = defaultCollectorHTTPPort
-	}
-	return fmt.Sprintf(":%d", port)
-}
-
-// TODO https://github.com/open-telemetry/opentelemetry-collector/issues/267
-//	Remove ThriftTChannel support.
-func (jr *jReceiver) tchannelAddr() string {
-	var port int
-	if jr.config != nil {
-		port = jr.config.CollectorThriftPort
-	}
-	if port <= 0 {
-		port = defaultTChannelPort
-	}
-	return fmt.Sprintf(":%d", port)
-}
-
-func (jr *jReceiver) grpcAddr() string {
-	var port int
-	if jr.config != nil {
-		port = jr.config.CollectorGRPCPort
-	}
-	if port <= 0 {
-		port = defaultGRPCPort
-	}
-	return fmt.Sprintf(":%d", port)
-}
-
 func (jr *jReceiver) agentCompactThriftAddr() string {
 	var port int
 	if jr.config != nil {
@@ -187,7 +152,7 @@ func (jr *jReceiver) agentBinaryThriftEnabled() bool {
 	return jr.config != nil && jr.config.AgentBinaryThriftPort > 0
 }
 
-func (jr *jReceiver) agentHTTPPortAddr() string {
+func (jr *jReceiver) agentHTTPAddr() string {
 	var port int
 	if jr.config != nil {
 		port = jr.config.AgentHTTPPort
@@ -197,6 +162,44 @@ func (jr *jReceiver) agentHTTPPortAddr() string {
 
 func (jr *jReceiver) agentHTTPEnabled() bool {
 	return jr.config != nil && jr.config.AgentHTTPPort > 0
+}
+
+func (jr *jReceiver) collectorGRPCAddr() string {
+	var port int
+	if jr.config != nil {
+		port = jr.config.CollectorGRPCPort
+	}
+	return fmt.Sprintf(":%d", port)
+}
+
+func (jr *jReceiver) collectorGRPCEnabled() bool {
+	return jr.config != nil && jr.config.CollectorGRPCPort > 0
+}
+
+func (jr *jReceiver) collectorHTTPAddr() string {
+	var port int
+	if jr.config != nil {
+		port = jr.config.CollectorHTTPPort
+	}
+	return fmt.Sprintf(":%d", port)
+}
+
+func (jr *jReceiver) collectorHTTPEnabled() bool {
+	return jr.config != nil && jr.config.CollectorHTTPPort > 0
+}
+
+// TODO https://github.com/open-telemetry/opentelemetry-collector/issues/267
+//	Remove ThriftTChannel support.
+func (jr *jReceiver) collectorThriftAddr() string {
+	var port int
+	if jr.config != nil {
+		port = jr.config.CollectorThriftPort
+	}
+	return fmt.Sprintf(":%d", port)
+}
+
+func (jr *jReceiver) collectorThriftEnabled() bool {
+	return jr.config != nil && jr.config.CollectorThriftPort > 0
 }
 
 func (jr *jReceiver) TraceSource() string {
@@ -412,7 +415,7 @@ func (jr *jReceiver) startAgent(_ receiver.Host) error {
 	}
 
 	if jr.agentHTTPEnabled() {
-		jr.agentServer = httpserver.NewHTTPServer(jr.agentHTTPPortAddr(), jr, metrics.NullFactory)
+		jr.agentServer = httpserver.NewHTTPServer(jr.agentHTTPAddr(), jr, metrics.NullFactory)
 
 		go func() {
 			if err := jr.agentServer.ListenAndServe(); err != nil {
@@ -442,6 +445,10 @@ func (jr *jReceiver) buildProcessor(address string, factory apacheThrift.TProtoc
 }
 
 func (jr *jReceiver) startCollector(host receiver.Host) error {
+	if !jr.collectorGRPCEnabled() && !jr.collectorHTTPEnabled() && !jr.collectorThriftEnabled() {
+		return nil
+	}
+
 	tch, terr := tchannel.NewChannel("jaeger-collector", new(tchannel.ChannelOptions))
 	if terr != nil {
 		return fmt.Errorf("failed to create NewTChannel: %v", terr)
@@ -450,7 +457,7 @@ func (jr *jReceiver) startCollector(host receiver.Host) error {
 	server := thrift.NewServer(tch)
 	server.Register(jaeger.NewTChanCollectorServer(jr.tchanServer))
 
-	taddr := jr.tchannelAddr()
+	taddr := jr.collectorThriftAddr()
 	tln, terr := net.Listen("tcp", taddr)
 	if terr != nil {
 		return fmt.Errorf("failed to bind to TChannel address %q: %v", taddr, terr)
@@ -459,7 +466,7 @@ func (jr *jReceiver) startCollector(host receiver.Host) error {
 	jr.tchanServer.tchannel = tch
 
 	// Now the collector that runs over HTTP
-	caddr := jr.collectorAddr()
+	caddr := jr.collectorHTTPAddr()
 	cln, cerr := net.Listen("tcp", caddr)
 	if cerr != nil {
 		// Abort and close tch
@@ -475,23 +482,25 @@ func (jr *jReceiver) startCollector(host receiver.Host) error {
 		_ = jr.collectorServer.Serve(cln)
 	}()
 
-	jr.grpc = grpc.NewServer(jr.config.CollectorGRPCOptions...)
-	gaddr := jr.grpcAddr()
-	gln, gerr := net.Listen("tcp", gaddr)
-	if gerr != nil {
-		// Abort and close tch, cln
-		tch.Close()
-		cln.Close()
-		return fmt.Errorf("failed to bind to gRPC address %q: %v", gaddr, gerr)
-	}
-
-	api_v2.RegisterCollectorServiceServer(jr.grpc, jr)
-
-	go func() {
-		if err := jr.grpc.Serve(gln); err != nil {
-			host.ReportFatalError(err)
+	if jr.collectorGRPCEnabled() {
+		jr.grpc = grpc.NewServer(jr.config.CollectorGRPCOptions...)
+		gaddr := jr.collectorGRPCAddr()
+		gln, gerr := net.Listen("tcp", gaddr)
+		if gerr != nil {
+			// Abort and close tch, cln
+			tch.Close()
+			cln.Close()
+			return fmt.Errorf("failed to bind to gRPC address %q: %v", gaddr, gerr)
 		}
-	}()
+
+		api_v2.RegisterCollectorServiceServer(jr.grpc, jr)
+
+		go func() {
+			if err := jr.grpc.Serve(gln); err != nil {
+				host.ReportFatalError(err)
+			}
+		}()
+	}
 
 	return nil
 }

--- a/receiver/jaegerreceiver/trace_receiver.go
+++ b/receiver/jaegerreceiver/trace_receiver.go
@@ -464,7 +464,6 @@ func (jr *jReceiver) startCollector(host receiver.Host) error {
 		caddr := jr.collectorHTTPAddr()
 		cln, cerr := net.Listen("tcp", caddr)
 		if cerr != nil {
-			// Abort and close tch
 			return fmt.Errorf("failed to bind to Collector address %q: %v", caddr, cerr)
 		}
 
@@ -482,7 +481,6 @@ func (jr *jReceiver) startCollector(host receiver.Host) error {
 		gaddr := jr.collectorGRPCAddr()
 		gln, gerr := net.Listen("tcp", gaddr)
 		if gerr != nil {
-			// Abort and close tch, cln
 			return fmt.Errorf("failed to bind to gRPC address %q: %v", gaddr, gerr)
 		}
 

--- a/receiver/jaegerreceiver/trace_receiver_test.go
+++ b/receiver/jaegerreceiver/trace_receiver_test.go
@@ -121,7 +121,8 @@ func TestPortsNotOpen(t *testing.T) {
 	assert.NoError(t, err, "should not have failed to start trace reception")
 
 	// there is a race condition here that we're ignoring.
-	//   this test may occasionally pass incorrectly, but it will not fail incorrectly
+	//  this test may occasionally pass incorrectly, but it will not fail incorrectly
+	//  TODO: consider adding a way for a receiver to asynchronously signal that is ready to receive spans to eliminate races/arbitrary waits
 	l, err := net.Listen("tcp", "localhost:14250")
 	assert.NoError(t, err, "should have been able to listen on 14250.  jaeger receiver incorrectly started grpc")
 	if l != nil {

--- a/receiver/jaegerreceiver/trace_receiver_test.go
+++ b/receiver/jaegerreceiver/trace_receiver_test.go
@@ -115,6 +115,7 @@ func TestPortsNotOpen(t *testing.T) {
 
 	mh := receivertest.NewMockHost()
 	err = jr.StartTraceReception(mh)
+	assert.NoError(t, err, "should not have failed to start trace reception")
 
 	// there is a race condition here that we're ignoring.
 	//   this test may occasionally pass incorrectly, but it will not fail incorrectly

--- a/receiver/jaegerreceiver/trace_receiver_test.go
+++ b/receiver/jaegerreceiver/trace_receiver_test.go
@@ -27,10 +27,12 @@ import (
 	commonpb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
 	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
 	"github.com/google/go-cmp/cmp"
+	"github.com/jaegertracing/jaeger/cmd/agent/app/reporter/tchannel"
 	"github.com/jaegertracing/jaeger/model"
 	"github.com/jaegertracing/jaeger/proto-gen/api_v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/uber/jaeger-lib/metrics"
 	"go.opencensus.io/trace"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
@@ -43,6 +45,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector/receiver/receivertest"
 	"github.com/open-telemetry/opentelemetry-collector/testutils"
 	tracetranslator "github.com/open-telemetry/opentelemetry-collector/translator/trace"
+	jaegertranslator "github.com/open-telemetry/opentelemetry-collector/translator/trace/jaeger"
 )
 
 func TestTraceSource(t *testing.T) {
@@ -240,6 +243,53 @@ func TestGRPCReceptionWithTLS(t *testing.T) {
 
 	assert.Len(t, req.Batch.Spans, len(want[0].Spans), "got a conflicting amount of spans")
 	assert.Equal(t, "", cmp.Diff(got, want))
+}
+
+func TestThriftTChannelReception(t *testing.T) {
+	port := testutils.GetAvailablePort(t)
+	config := &Configuration{
+		CollectorThriftPort: int(port),
+	}
+	sink := new(exportertest.SinkTraceExporter)
+
+	jr, err := New(context.Background(), config, sink, zap.NewNop())
+	assert.NoError(t, err, "should not have failed to create a new receiver")
+	defer jr.StopTraceReception()
+
+	mh := receivertest.NewMockHost()
+	err = jr.StartTraceReception(mh)
+	assert.NoError(t, err, "should not have failed to start trace reception")
+	t.Log("StartTraceReception")
+
+	b := tchannel.NewBuilder()
+	b.CollectorHostPorts = []string{fmt.Sprintf("localhost:%d", port)}
+
+	p, err := tchannel.NewCollectorProxy(b, metrics.NullFactory, zap.NewNop())
+	assert.NoError(t, err, "should not have failed to create collector proxy")
+
+	now := time.Unix(1542158650, 536343000).UTC()
+	d10min := 10 * time.Minute
+	d2sec := 2 * time.Second
+	nowPlus10min := now.Add(d10min)
+	nowPlus10min2sec := now.Add(d10min).Add(d2sec)
+
+	want := expectedTraceData(now, nowPlus10min, nowPlus10min2sec)
+	batch, err := jaegertranslator.OCProtoToJaegerThrift(want[0])
+	assert.NoError(t, err, "should not have failed proto/thrift translation")
+
+	//confirm port is open before attempting
+	err = testutils.WaitForPort(t, port)
+	assert.NoError(t, err, "WaitForPort failed")
+
+	err = p.GetReporter().EmitBatch(batch)
+	assert.NoError(t, err, "should not have failed to emit batch")
+
+	got := sink.AllTraces()
+	assert.Len(t, batch.Spans, len(want[0].Spans), "got a conflicting amount of spans")
+
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("Mismatched responses\n-Got +Want:\n\t%s", diff)
+	}
 }
 
 func expectedTraceData(t1, t2, t3 time.Time) []consumerdata.TraceData {

--- a/receiver/prometheusreceiver/factory.go
+++ b/receiver/prometheusreceiver/factory.go
@@ -62,7 +62,7 @@ func (f *Factory) CustomUnmarshaler() receiver.CustomUnmarshaler {
 }
 
 // CustomUnmarshalerFunc performs custom unmarshaling of config.
-func CustomUnmarshalerFunc(v *viper.Viper, viperKey string, intoCfg interface{}) error {
+func CustomUnmarshalerFunc(v *viper.Viper, viperKey string, intoCfg interface{}, sourceViperSection *viper.Viper) error {
 	// We need custom unmarshaling because prometheus "config" subkey defines its own
 	// YAML unmarshaling routines so we need to do it explicitly.
 

--- a/receiver/prometheusreceiver/factory.go
+++ b/receiver/prometheusreceiver/factory.go
@@ -62,7 +62,7 @@ func (f *Factory) CustomUnmarshaler() receiver.CustomUnmarshaler {
 }
 
 // CustomUnmarshalerFunc performs custom unmarshaling of config.
-func CustomUnmarshalerFunc(v *viper.Viper, viperKey string, intoCfg interface{}, sourceViperSection *viper.Viper) error {
+func CustomUnmarshalerFunc(v *viper.Viper, viperKey string, sourceViperSection *viper.Viper, intoCfg interface{}) error {
 	// We need custom unmarshaling because prometheus "config" subkey defines its own
 	// YAML unmarshaling routines so we need to do it explicitly.
 

--- a/service/testdata/otelcol-config.yaml
+++ b/service/testdata/otelcol-config.yaml
@@ -1,5 +1,7 @@
 receivers:
   jaeger:
+    protocols:
+      grpc:
 
 exporters:
   opencensus:


### PR DESCRIPTION
Fixes #445, #158 

This PR addresses some Jaeger receiver config cleanup as well as makes some breaking changes to the way the config is handled.   See below for details.

**Fixes/Updates**
- Disabled flag is respected per protocol
- Unspecified protocols will no longer be started
- Empty protocol configs can now be specified to start the protocol with defaults. e.g.
  ```
  jaeger:
    protocols:
      grpc:
  ```
- Updated readmes
- Naming and behavior of per protocol Addr/Enabled functions in `trace_reciever.go` has been standardized.
- Added thrift tchannel test to meet code coverage

**Breaking Change**
Changed the way an empty `jaeger:` config is handled.  An empty/default config does not start any jaeger protocols.  Previously it started all three collector protocols.  This is a consequence of not starting unspecified protocols.
