### PR TITLE
Allow OpenCensus receiver to listen on Unix Domain Socket (#400)

### DIFF
--- a/receiver/end_to_end_test.go
+++ b/receiver/end_to_end_test.go
@@ -38,7 +38,7 @@ func Example_endToEnd() {
 		log.Fatalf("Failed to create logging exporter: %v", err)
 	}
 
-	tr, err := opencensusreceiver.New("localhost:55678", lte, nil)
+	tr, err := opencensusreceiver.New("tcp", "localhost:55678", lte, nil)
 	if err != nil {
 		log.Fatalf("Failed to create trace receiver: %v", err)
 	}

--- a/receiver/opencensusreceiver/config.go
+++ b/receiver/opencensusreceiver/config.go
@@ -27,6 +27,10 @@ import (
 // Config defines configuration for OpenCensus receiver.
 type Config struct {
 	receiver.SecureReceiverSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
+
+	// Transport to use: one of tcp or unix, defaults to tcp
+	Transport string `mapstructure:"transport,omit_empty"`
+
 	// CorsOrigins are the allowed CORS origins for HTTP/JSON requests to grpc-gateway adapter
 	// for the OpenCensus receiver. See github.com/rs/cors
 	// An empty list means that CORS is not enabled at all. A wildcard (*) can be

--- a/receiver/opencensusreceiver/config_test.go
+++ b/receiver/opencensusreceiver/config_test.go
@@ -40,17 +40,22 @@ func TestLoadConfig(t *testing.T) {
 
 	// Currently disabled receivers are removed from the total list of receivers so 'opencensus/disabled' doesn't
 	// contribute to the count.
-	assert.Equal(t, len(cfg.Receivers), 6)
+	assert.Equal(t, len(cfg.Receivers), 7)
 
 	r0 := cfg.Receivers["opencensus"]
 	assert.Equal(t, r0, factory.CreateDefaultConfig())
 
 	r1 := cfg.Receivers["opencensus/customname"].(*Config)
-	assert.Equal(t, r1.ReceiverSettings,
-		configmodels.ReceiverSettings{
-			TypeVal:  typeStr,
-			NameVal:  "opencensus/customname",
-			Endpoint: "0.0.0.0:9090",
+	assert.Equal(t, r1,
+		&Config{
+			SecureReceiverSettings: receiver.SecureReceiverSettings{
+				ReceiverSettings: configmodels.ReceiverSettings{
+					TypeVal:  typeStr,
+					NameVal:  "opencensus/customname",
+					Endpoint: "0.0.0.0:9090",
+				},
+			},
+			Transport: "tcp",
 		})
 
 	r2 := cfg.Receivers["opencensus/keepalive"].(*Config)
@@ -64,6 +69,7 @@ func TestLoadConfig(t *testing.T) {
 				},
 				TLSCredentials: nil,
 			},
+			Transport: "tcp",
 			Keepalive: &serverParametersAndEnforcementPolicy{
 				ServerParameters: &keepaliveServerParameters{
 					MaxConnectionIdle:     11 * time.Second,
@@ -89,6 +95,7 @@ func TestLoadConfig(t *testing.T) {
 					Endpoint: "localhost:55678",
 				},
 			},
+			Transport:            "tcp",
 			MaxRecvMsgSizeMiB:    32,
 			MaxConcurrentStreams: 16,
 			Keepalive: &serverParametersAndEnforcementPolicy{
@@ -114,6 +121,7 @@ func TestLoadConfig(t *testing.T) {
 					KeyFile:  "test.key",
 				},
 			},
+			Transport: "tcp",
 		})
 
 	r5 := cfg.Receivers["opencensus/cors"].(*Config)
@@ -126,6 +134,20 @@ func TestLoadConfig(t *testing.T) {
 					Endpoint: "localhost:55678",
 				},
 			},
+			Transport:   "tcp",
 			CorsOrigins: []string{"https://*.test.com", "https://test.com"},
+		})
+
+	r6 := cfg.Receivers["opencensus/uds"].(*Config)
+	assert.Equal(t, r6,
+		&Config{
+			SecureReceiverSettings: receiver.SecureReceiverSettings{
+				ReceiverSettings: configmodels.ReceiverSettings{
+					TypeVal:  typeStr,
+					NameVal:  "opencensus/uds",
+					Endpoint: "/tmp/opencensus.sock",
+				},
+			},
+			Transport: "unix",
 		})
 }

--- a/receiver/opencensusreceiver/factory.go
+++ b/receiver/opencensusreceiver/factory.go
@@ -54,6 +54,7 @@ func (f *Factory) CreateDefaultConfig() configmodels.Receiver {
 				// Disable: false - This receiver is enabled by default.
 			},
 		},
+		Transport: "tcp",
 	}
 }
 
@@ -107,7 +108,7 @@ func (f *Factory) createReceiver(cfg configmodels.Receiver) (*Receiver, error) {
 		}
 
 		// We don't have a receiver, so create one.
-		receiver, err = New(rCfg.Endpoint, nil, nil, opts...)
+		receiver, err = New(rCfg.Transport, rCfg.Endpoint, nil, nil, opts...)
 		if err != nil {
 			return nil, err
 		}

--- a/receiver/opencensusreceiver/factory_test.go
+++ b/receiver/opencensusreceiver/factory_test.go
@@ -74,6 +74,7 @@ func TestCreateTraceReceiver(t *testing.T) {
 					ReceiverSettings: defaultReceiverSettings,
 					TLSCredentials:   nil,
 				},
+				Transport: "tcp",
 			},
 		},
 		{
@@ -86,6 +87,7 @@ func TestCreateTraceReceiver(t *testing.T) {
 						Endpoint: "localhost:112233",
 					},
 				},
+				Transport: "tcp",
 			},
 			wantErr: true,
 		},
@@ -95,6 +97,7 @@ func TestCreateTraceReceiver(t *testing.T) {
 				SecureReceiverSettings: receiver.SecureReceiverSettings{
 					ReceiverSettings: defaultReceiverSettings,
 				},
+				Transport:            "tcp",
 				MaxRecvMsgSizeMiB:    32,
 				MaxConcurrentStreams: 16,
 			},
@@ -139,6 +142,7 @@ func TestCreateMetricReceiver(t *testing.T) {
 				SecureReceiverSettings: receiver.SecureReceiverSettings{
 					ReceiverSettings: defaultReceiverSettings,
 				},
+				Transport: "tcp",
 			},
 		},
 		{
@@ -151,6 +155,7 @@ func TestCreateMetricReceiver(t *testing.T) {
 						Endpoint: "327.0.0.1:1122",
 					},
 				},
+				Transport: "tcp",
 			},
 			wantErr: true,
 		},
@@ -160,6 +165,7 @@ func TestCreateMetricReceiver(t *testing.T) {
 				SecureReceiverSettings: receiver.SecureReceiverSettings{
 					ReceiverSettings: defaultReceiverSettings,
 				},
+				Transport: "tcp",
 				Keepalive: &serverParametersAndEnforcementPolicy{
 					ServerParameters: &keepaliveServerParameters{
 						MaxConnectionAge: 60 * time.Second,

--- a/receiver/opencensusreceiver/opencensus.go
+++ b/receiver/opencensusreceiver/opencensus.go
@@ -71,9 +71,9 @@ const source string = "OpenCensus"
 // New just creates the OpenCensus receiver services. It is the caller's
 // responsibility to invoke the respective Start*Reception methods as well
 // as the various Stop*Reception methods to end it.
-func New(addr string, tc consumer.TraceConsumer, mc consumer.MetricsConsumer, opts ...Option) (*Receiver, error) {
+func New(transport string, addr string, tc consumer.TraceConsumer, mc consumer.MetricsConsumer, opts ...Option) (*Receiver, error) {
 	// TODO: (@odeke-em) use options to enable address binding changes.
-	ln, err := net.Listen("tcp", addr)
+	ln, err := net.Listen(transport, addr)
 	if err != nil {
 		return nil, fmt.Errorf("failed to bind to address %q: %v", addr, err)
 	}
@@ -237,6 +237,11 @@ func (ocr *Receiver) startServer(host component.Host) error {
 		c := context.Background()
 		opts := []grpc.DialOption{grpc.WithInsecure()}
 		endpoint := ocr.ln.Addr().String()
+
+		_, ok := ocr.ln.(*net.UnixListener)
+		if ok {
+			endpoint = "unix:" + endpoint
+		}
 
 		err = agenttracepb.RegisterTraceServiceHandlerFromEndpoint(c, ocr.gatewayMux, endpoint, opts)
 		if err != nil {

--- a/receiver/opencensusreceiver/testdata/config.yaml
+++ b/receiver/opencensusreceiver/testdata/config.yaml
@@ -40,6 +40,10 @@ receivers:
     tls_credentials:
       cert_file: test.crt
       key_file: test.key
+  # The following entry demonstrates how to specify a Unix Domain Socket for the server.
+  opencensus/uds:
+    transport: unix
+    endpoint: /tmp/opencensus.sock
   # The following entry demonstrates how to disable a receiver using the disabled flag from the common receiver settings.
   # Note: The current implementation removes disabled receivers from the global list of receivers so the total count
   # of receivers in the test will not include this one.

--- a/testbed/testbed/receivers.go
+++ b/testbed/testbed/receivers.go
@@ -77,7 +77,7 @@ func NewOCDataReceiver(port int) *OCDataReceiver {
 func (or *OCDataReceiver) Start(tc *MockTraceConsumer, mc *MockMetricConsumer) error {
 	addr := fmt.Sprintf("localhost:%d", or.Port)
 	var err error
-	or.receiver, err = opencensusreceiver.New(addr, tc, mc)
+	or.receiver, err = opencensusreceiver.New("tcp", addr, tc, mc)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Allows the OpenCensus receiver to listen on a Unix Domain Socket by prefixing the endpoint address with `unix:`.

This provides improved performance for applications that can't maintain a persistent collection (e.g. PHP applications) without requiring use of a custom receiver and protocol as provided by https://github.com/open-telemetry/opentelemetry-collector/issues/396