### PR TITLE
Use specific commit hash in dependency

### DIFF
--- a/testbed/go.mod
+++ b/testbed/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/census-instrumentation/opencensus-proto v0.2.1
 	github.com/go-ole/go-ole v1.2.4 // indirect
 	github.com/golang/protobuf v1.3.2
-	github.com/open-telemetry/opentelemetry-collector v0.2.0
+	github.com/open-telemetry/opentelemetry-collector v0.2.0-0.20200110151913-9777072f35b3
 	github.com/shirou/gopsutil v2.18.12+incompatible
 	github.com/spf13/viper v1.4.1-0.20190911140308-99520c81d86e
 	github.com/stretchr/testify v1.4.0


### PR DESCRIPTION
We previously had a broken dependency that was referring
to non-existing version 0.2.0. This is now causing problems
whenever go attempts to resolve latest version.

Pinning to specific commit should hopefully fix the problem.