### PR TITLE
Remove workers from OpenCensus receiver implementation

### DIFF
--- a/receiver/opencensusreceiver/octrace/options.go
+++ b/receiver/opencensusreceiver/octrace/options.go
@@ -18,11 +18,3 @@ package octrace
 //
 // WithReceiver applies the configuration to the given receiver.
 type Option func(*Receiver)
-
-// WithWorkerCount sets the number of worker goroutines that will be started
-// for the receiver
-func WithWorkerCount(workerCount int) Option {
-	return func(r *Receiver) {
-		r.numWorkers = workerCount
-	}
-}

--- a/receiver/opencensusreceiver/opencensus.go
+++ b/receiver/opencensusreceiver/opencensus.go
@@ -195,12 +195,6 @@ func (ocr *Receiver) stop() error {
 	ocr.stopOnce.Do(func() {
 		err = nil
 
-		if ocr.traceReceiver != nil {
-			ocr.traceReceiver.Stop()
-		}
-
-		// Currently there is no symmetric stop for metrics receiver.
-
 		if ocr.serverHTTP != nil {
 			_ = ocr.serverHTTP.Close()
 		}


### PR DESCRIPTION
Workers were unnecessary complication and did not provide any measurable
performance gains.

In addition they were decoupling receiver from subsequent processors which
makes difficult upcoming implementation of backpressure in the pipeline
(from processors to receivers).

Test results that shows that worker give no performance benefits (any
differences are within the measurement error margin):

Without workers (this commit):

Test                                    |Result|Duration|CPU Avg%|CPU Max%|RAM Avg MiB|RAM Max MiB|Sent Items|Received Items|
----------------------------------------|------|-------:|-------:|-------:|----------:|----------:|---------:|-------------:|
Trace10kSPS/OpenCensus                  |PASS  |     16s|    22.7|    25.9|         37|         45|    149880|        149880|

With workers (latest `master` branch):

Test                                    |Result|Duration|CPU Avg%|CPU Max%|RAM Avg MiB|RAM Max MiB|Sent Items|Received Items|
----------------------------------------|------|-------:|-------:|-------:|----------:|----------:|---------:|-------------:|
Trace10kSPS/OpenCensus                  |PASS  |     16s|    23.3|    24.9|         37|         46|    149920|        149920|
