### PR TITLE
Fixed opentelemetry-collector dep version in testbed

### DIFF
--- a/testbed/go.mod
+++ b/testbed/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/census-instrumentation/opencensus-proto v0.2.1
 	github.com/go-ole/go-ole v1.2.4 // indirect
 	github.com/golang/protobuf v1.3.2
-	github.com/open-telemetry/opentelemetry-collector v0.2.0-0.20200110151913-9777072f35b3
+	github.com/open-telemetry/opentelemetry-collector v0.2.4-0.20200115225140-264426a9cae4
 	github.com/shirou/gopsutil v2.18.12+incompatible
 	github.com/spf13/viper v1.4.1-0.20190911140308-99520c81d86e
 	github.com/stretchr/testify v1.4.0


### PR DESCRIPTION
Previous version string was invalid and couldn't be used in contrib.

It resulted in the following error:

```
go: github.com/open-telemetry/opentelemetry-collector-contrib/testbed@v0.0.0-20200113165313-aaaf81577e1a requires
	github.com/open-telemetry/opentelemetry-collector/testbed@v0.0.0-20200110193345-9f801c5b8d9f requires
	github.com/open-telemetry/opentelemetry-collector@v0.2.0-0.20200110151913-9777072f35b3: invalid pseudo-version: version before v0.2.0 would have negative patch number
Add License finished successfully
Fmt finished successfully
go: github.com/open-telemetry/opentelemetry-collector-contrib/testbed@v0.0.0-20200113165313-aaaf81577e1a requires
	github.com/open-telemetry/opentelemetry-collector/testbed@v0.0.0-20200110193345-9f801c5b8d9f requires
	github.com/open-telemetry/opentelemetry-collector@v0.2.0-0.20200110151913-9777072f35b3: invalid pseudo-version: version before v0.2.0 would have negative patch number
make: *** [vet] Error 1
```