### PR TITLE
Fixed a nil pointer deference error with unused receivers

### DIFF
--- a/service/builder/testdata/unused_receiver.yaml
+++ b/service/builder/testdata/unused_receiver.yaml
@@ -1,0 +1,20 @@
+receivers:
+  examplereceiver:
+  zipkin:
+
+processors:
+  attributes:
+    actions:
+      - key: attr1
+        value: 12345
+        action: insert
+
+exporters:
+  exampleexporter:
+
+service:
+  pipelines:
+    traces:
+      receivers: [examplereceiver]
+      processors: [attributes]
+      exporters: [exampleexporter]


### PR DESCRIPTION
If a receiver is defined but not used in any pipelines, collector
crashes with nil pointer deference error. This patch fixes the issue.

**Description:** 

If a receiver is defined but not added to any pipelines, the collector segfaults with the following error:

```
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x16d1c29]

goroutine 21 [running]:
testing.tRunner.func1(0xc00018c700)
	/usr/local/go/src/testing/testing.go:874 +0x3a3
panic(0x17af7c0, 0x1efc7a0)
	/usr/local/go/src/runtime/panic.go:679 +0x1b2
github.com/open-telemetry/opentelemetry-collector/service/builder.(*builtReceiver).Start(...)
	/Users/olone/Projects/opentelemetry/opentelemetry-collector/service/builder/receivers_builder.go:47
github.com/open-telemetry/opentelemetry-collector/service/builder.Receivers.StartAll(0xc0003027e0, 0xc000155f08, 0x19bbaa0, 0x1f30220, 0x0, 0x0)
	/Users/olone/Projects/opentelemetry/opentelemetry-collector/service/builder/receivers_builder.go:65 +0x249
github.com/open-telemetry/opentelemetry-collector/service/builder.TestReceiversBuilder_Unused(0xc00018c700)
	/Users/olone/Projects/opentelemetry/opentelemetry-collector/service/builder/receivers_builder_test.go:326 +0x853
testing.tRunner(0xc00018c700, 0x18e3da8)
	/usr/local/go/src/testing/testing.go:909 +0xc9
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:960 +0x350
```


Exporters and processors are not affected.

**Testing:** Added test case that segfaults without the patch