### PR TITLE
Migrate to Go1.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache:
 go_import_path: github.com/open-telemetry/opentelemetry-collector
 
 go:
-  - 1.12.x
+  - 1.13.x
 
 env:
   global:
@@ -17,7 +17,7 @@ install:
   - make install-tools
 
 script:
-  - make travis-ci
+  - make ci
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/Makefile
+++ b/Makefile
@@ -51,8 +51,8 @@ test:
 benchmark:
 	$(GOTEST) -bench=. -run=notests $(ALL_PKGS)
 
-.PHONY: travis-ci
-travis-ci: all test-with-cover
+.PHONY: ci
+ci: all test-with-cover
 	$(MAKE) -C testbed install-tools
 	$(MAKE) -C testbed runtests
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector
 
-go 1.12
+go 1.13
 
 require (
 	contrib.go.opencensus.io/exporter/jaeger v0.1.1-0.20190430175949-e8b55949d948
@@ -53,3 +53,5 @@ require (
 	gopkg.in/yaml.v2 v2.2.4
 	k8s.io/client-go v12.0.0+incompatible // indirect
 )
+
+replace k8s.io/client-go => k8s.io/client-go v0.0.0-20190620085101-78d2af792bab


### PR DESCRIPTION
Go 1.13 has been out for quite a while now and 1.14 beta is out as well.
We've been building core, contrib and some internal collectors with 1.13
for quite some time now and have resolved all issues that came with the
upgrade already. This should be a very safe change.

This will allow us to use leverage new features and fixes shipped by
1.13 such as updates to Go modules, error wrapping, etc.

