### PR TITLE
Change Jaeger receiver config

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,10 +167,10 @@ receivers:
   jaeger:
     protocols:
       grpc:
-      thrift-http:
-      thrift-tchannel:
-      thrift-compact:
-      thrift-binary:
+      thrift_http:
+      thrift_tchannel:
+      thrift_compact:
+      thrift_binary:
 
   prometheus:
     config:

--- a/examples/demo/otel-agent-config.yaml
+++ b/examples/demo/otel-agent-config.yaml
@@ -3,7 +3,7 @@ receivers:
     endpoint: 0.0.0.0:55678
   jaeger:
     protocols:
-      thrift-http:
+      thrift_http:
         endpoint: "0.0.0.0:14268"
 
 

--- a/receiver/jaegerreceiver/config_test.go
+++ b/receiver/jaegerreceiver/config_test.go
@@ -52,22 +52,22 @@ func TestLoadConfig(t *testing.T) {
 						Endpoint: "localhost:9876",
 					},
 				},
-				"thrift-http": {
+				"thrift_http": {
 					ReceiverSettings: configmodels.ReceiverSettings{
 						Endpoint: ":3456",
 					},
 				},
-				"thrift-tchannel": {
+				"thrift_tchannel": {
 					ReceiverSettings: configmodels.ReceiverSettings{
 						Endpoint: "0.0.0.0:123",
 					},
 				},
-				"thrift-compact": {
+				"thrift_compact": {
 					ReceiverSettings: configmodels.ReceiverSettings{
 						Endpoint: "0.0.0.0:456",
 					},
 				},
-				"thrift-binary": {
+				"thrift_binary": {
 					ReceiverSettings: configmodels.ReceiverSettings{
 						Endpoint: "0.0.0.0:789",
 					},
@@ -90,22 +90,22 @@ func TestLoadConfig(t *testing.T) {
 						Endpoint: defaultGRPCBindEndpoint,
 					},
 				},
-				"thrift-http": {
+				"thrift_http": {
 					ReceiverSettings: configmodels.ReceiverSettings{
 						Endpoint: defaultHTTPBindEndpoint,
 					},
 				},
-				"thrift-tchannel": {
+				"thrift_tchannel": {
 					ReceiverSettings: configmodels.ReceiverSettings{
 						Endpoint: defaultTChannelBindEndpoint,
 					},
 				},
-				"thrift-compact": {
+				"thrift_compact": {
 					ReceiverSettings: configmodels.ReceiverSettings{
 						Endpoint: defaultThriftCompactBindEndpoint,
 					},
 				},
-				"thrift-binary": {
+				"thrift_binary": {
 					ReceiverSettings: configmodels.ReceiverSettings{
 						Endpoint: defaultThriftBinaryBindEndpoint,
 					},
@@ -124,7 +124,7 @@ func TestLoadConfig(t *testing.T) {
 						Endpoint: "localhost:9876",
 					},
 				},
-				"thrift-compact": {
+				"thrift_compact": {
 					ReceiverSettings: configmodels.ReceiverSettings{
 						Endpoint: defaultThriftCompactBindEndpoint,
 					},
@@ -148,12 +148,12 @@ func TestLoadConfig(t *testing.T) {
 						KeyFile:  "/test.key",
 					},
 				},
-				"thrift-http": {
+				"thrift_http": {
 					ReceiverSettings: configmodels.ReceiverSettings{
 						Endpoint: ":3456",
 					},
 				},
-				"thrift-tchannel": {
+				"thrift_tchannel": {
 					ReceiverSettings: configmodels.ReceiverSettings{
 						Endpoint: "0.0.0.0:123",
 					},

--- a/receiver/jaegerreceiver/factory.go
+++ b/receiver/jaegerreceiver/factory.go
@@ -38,12 +38,12 @@ const (
 
 	// Protocol values.
 	protoGRPC       = "grpc"
-	protoThriftHTTP = "thrift-http"
+	protoThriftHTTP = "thrift_http"
 	// TODO https://github.com/open-telemetry/opentelemetry-collector/issues/267
 	//	Remove ThriftTChannel support.
-	protoThriftTChannel = "thrift-tchannel"
-	protoThriftBinary   = "thrift-binary"
-	protoThriftCompact  = "thrift-compact"
+	protoThriftTChannel = "thrift_tchannel"
+	protoThriftBinary   = "thrift_binary"
+	protoThriftCompact  = "thrift_compact"
 
 	// Default endpoints to bind to.
 	defaultGRPCBindEndpoint     = "localhost:14250"

--- a/receiver/jaegerreceiver/testdata/config.yaml
+++ b/receiver/jaegerreceiver/testdata/config.yaml
@@ -7,13 +7,13 @@ receivers:
     protocols:
       grpc:
         endpoint: "localhost:9876"
-      thrift-http:
+      thrift_http:
         endpoint: ":3456"
-      thrift-tchannel:
+      thrift_tchannel:
         endpoint: "0.0.0.0:123"
-      thrift-compact:
+      thrift_compact:
         endpoint: "0.0.0.0:456"
-      thrift-binary:
+      thrift_binary:
         endpoint: "0.0.0.0:789"
     remote_sampling:
       host_endpoint: "0.0.0.0:5778"
@@ -22,29 +22,29 @@ receivers:
   jaeger/defaults:
     protocols:
       grpc:
-      thrift-http:
-      thrift-tchannel:
-      thrift-compact:
-      thrift-binary:
+      thrift_http:
+      thrift_tchannel:
+      thrift_compact:
+      thrift_binary:
   # The following demonstrates only enabling certain protocols with defaults/overrides.
   jaeger/mixed:
     protocols:
       grpc:
         endpoint: "localhost:9876"
-      thrift-compact:
+      thrift_compact:
   # The following demonstrates how to disable a protocol.  This particular config
   # will not start any jaeger protocols.
   jaeger/disabled:
     protocols:
       grpc:
         disabled: true
-      thrift-http:
+      thrift_http:
         disabled: true
-      thrift-tchannel:
+      thrift_tchannel:
         disabled: true
-      thrift-compact:
+      thrift_compact:
         disabled: true
-      thrift-binary:
+      thrift_binary:
         disabled: true
   # The following demonstrates specifying different endpoints.
   # The Jaeger receiver connects to ports on all available network interfaces.
@@ -57,9 +57,9 @@ receivers:
           cert_file: /test.crt
           key_file: /test.key
         endpoint: "localhost:9876"
-      thrift-http:
+      thrift_http:
         endpoint: ":3456"
-      thrift-tchannel:
+      thrift_tchannel:
         endpoint: "0.0.0.0:123"
 
 processors:

--- a/receiver/jaegerreceiver/trace_receiver_test.go
+++ b/receiver/jaegerreceiver/trace_receiver_test.go
@@ -130,12 +130,12 @@ func TestPortsNotOpen(t *testing.T) {
 	}
 
 	l, err = net.Listen("tcp", "localhost:14268")
-	assert.NoError(t, err, "should have been able to listen on 14268.  jaeger receiver incorrectly started thrift-http")
+	assert.NoError(t, err, "should have been able to listen on 14268.  jaeger receiver incorrectly started thrift_http")
 	if l != nil {
 		l.Close()
 	}
 	l, err = net.Listen("tcp", "localhost:14267")
-	assert.NoError(t, err, "should have been able to listen on 14267.  jaeger receiver incorrectly started thrift-tchannel")
+	assert.NoError(t, err, "should have been able to listen on 14267.  jaeger receiver incorrectly started thrift_tchannel")
 
 	if l != nil {
 		l.Close()

--- a/testbed/testbed/senders.go
+++ b/testbed/testbed/senders.go
@@ -89,7 +89,7 @@ func (ds *DataSenderOverTraceExporter) GetCollectorPort() int {
 	return ds.Port
 }
 
-// JaegerThriftDataSender implements TraceDataSender for Jaeger Thrift-HTTP protocol.
+// JaegerThriftDataSender implements TraceDataSender for Jaeger thrift_http protocol.
 type JaegerThriftDataSender struct {
 	DataSenderOverTraceExporter
 }
@@ -124,10 +124,10 @@ func (je *JaegerThriftDataSender) Start() error {
 
 func (je *JaegerThriftDataSender) GenConfigYAMLStr() string {
 	// Note that this generates a receiver config for agent.
-	// We only need to enable thrift-http protocol because that's what we use in tests.
+	// We only need to enable thrift_http protocol because that's what we use in tests.
 	// Due to bug in Jaeger receiver (https://github.com/open-telemetry/opentelemetry-collector/issues/445)
 	// which makes it impossible to disable protocols that we don't need to receive on we
-	// have to use fake ports for all endpoints except thrift-http, otherwise it is
+	// have to use fake ports for all endpoints except thrift_http, otherwise it is
 	// impossible to start the Collector because the standard ports for those protocols
 	// are already listened by mock Jaeger backend that is part of the tests.
 	// As soon as the bug is fixed remove the endpoints and use "disabled: true" setting
@@ -137,13 +137,13 @@ func (je *JaegerThriftDataSender) GenConfigYAMLStr() string {
     protocols:
       grpc:
         endpoint: "localhost:8371"
-      thrift-tchannel:
+      thrift_tchannel:
         endpoint: "localhost:8372"
-      thrift-compact:
+      thrift_compact:
         endpoint: "localhost:8373"
-      thrift-binary:
+      thrift_binary:
         endpoint: "localhost:8374"
-      thrift-http:
+      thrift_http:
         endpoint: "localhost:%d"`, je.Port)
 }
 

--- a/testbed/tests/testdata/add-attributes-config.yaml
+++ b/testbed/tests/testdata/add-attributes-config.yaml
@@ -1,7 +1,7 @@
 receivers:
   jaeger:
     protocols:
-      thrift-http:
+      thrift_http:
         endpoint: "localhost:14268"
 
 exporters:

--- a/testbed/tests/testdata/agent-config.yaml
+++ b/testbed/tests/testdata/agent-config.yaml
@@ -1,7 +1,7 @@
 receivers:
   jaeger:
     protocols:
-      thrift-http:
+      thrift_http:
         endpoint: "localhost:14268"
   opencensus:
     endpoint: "localhost:55678"

--- a/testbed/tests/testdata/memory-limiter.yaml
+++ b/testbed/tests/testdata/memory-limiter.yaml
@@ -1,7 +1,7 @@
 receivers:
   jaeger:
     protocols:
-      thrift-http:
+      thrift_http:
         endpoint: "localhost:14268"
   opencensus:
     endpoint: "localhost:55678"


### PR DESCRIPTION
We use underscores instead of dashes by convention in all component
configuration. Jaeger receiver used dashes. This commit brings jaeger
receiver in line with the rest of the components.
