### PR TITLE
[WIP] Add span_names glob-based filtering to attributes processor

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/client9/misspell v0.3.4
 	github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd // indirect
 	github.com/go-kit/kit v0.9.0
+	github.com/gobwas/glob v0.2.3
 	github.com/gogo/googleapis v1.3.0 // indirect
 	github.com/golang/protobuf v1.3.2
 	github.com/golangci/golangci-lint v1.21.0

--- a/processor/README.md
+++ b/processor/README.md
@@ -132,24 +132,29 @@ if the span should be included or excluded from the processor. By default, all
 spans are processed by the processor.
 
 To configure this option, under `include` and/or `exclude`:
-- at least one of or both `services` and `attributes` is required.
+- at least one of `services`, `span_names` or `attributes` is required.
 
 Note: If both `include` and `exclude` are specified, the `include` properties
 are checked before the `exclude` properties.
+
+Items in `span_names` array are glob patterns, with wildcard characters * and ?
+allowed (for more details on glob pattern see https://godoc.org/github.com/gobwas/glob#Compile).
 
 ```yaml
 attributes:
     # include and/or exclude can be specified. However, the include properties
     # are always checked before the exclude properties.
     {include, exclude}:
-      # At least one of services or attributes must be specified. It is supported
-      # to have both specified, but both `services` and `attributes` must evaluate
+      # At least one of services, span_names or attributes must be specified. It is supported
+      # to have more than one specified, but all of the specified conditions must evaluate
       # to true for a match to occur.
 
       # Services specify the list of service name to match against.
       # A match occurs if the span service name is in this list.
       # Note: This is an optional field.
       services: [<key1>, ..., <keyN>]
+      # The span name must match "login*" or "auth*" glob.
+      span_names: ["login*", "auth*"]
       # Attributes specifies the list of attributes to match against.
       # All of these attributes must match exactly for a match to occur.
       # Note: This is an optional field.

--- a/processor/attributesprocessor/config.go
+++ b/processor/attributesprocessor/config.go
@@ -132,18 +132,24 @@ const (
 // Please refer to testdata/config.yaml for valid configurations.
 type MatchProperties struct {
 
+	// Note: either Services, SpanNames or Attributes must be specified with a non
+	// empty value for a valid configuration.
+
 	// Services specify the list of service name to match against.
 	// A match occurs if the span service name is in this list.
-	// Note: This is an optional field. However, one of services or
-	// attributes must be specified with a non empty value for a valid
-	// configuration.
+	// This is an optional field.
 	Services []string `mapstructure:"services"`
+
+	// SpanNames specify the list of span name to match against.
+	// A match occurs if the span name matches at least one item in this list.
+	// If the item in the list has globing characters (* or ?) the match will be
+	// performed by pattern matching the glob.
+	// This is an optional field.
+	SpanNames []string `mapstructure:"span_names"`
 
 	// Attributes specifies the list of attributes to match against.
 	// All of these attributes must match exactly for a match to occur.
-	// Note: This is an optional field. However, one of services or
-	// attributes must be specified with a non empty value for a valid
-	// configuration.
+	// Note: This is an optional field.
 	Attributes []Attribute `mapstructure:"attributes"`
 }
 

--- a/processor/attributesprocessor/config_test.go
+++ b/processor/attributesprocessor/config_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/open-telemetry/opentelemetry-collector/config"
 	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
@@ -33,7 +34,7 @@ func TestLoadingConifg(t *testing.T) {
 	config, err := config.LoadConfigFile(t, path.Join(".", "testdata", "config.yaml"), factories)
 
 	assert.Nil(t, err)
-	assert.NotNil(t, config)
+	require.NotNil(t, config)
 
 	p0 := config.Processors["attributes/insert"]
 	assert.Equal(t, p0, &Config{
@@ -165,4 +166,21 @@ func TestLoadingConifg(t *testing.T) {
 		},
 	})
 
+	p9 := config.Processors["attributes/glob"]
+	assert.Equal(t, p9, &Config{
+		ProcessorSettings: configmodels.ProcessorSettings{
+			NameVal: "attributes/glob",
+			TypeVal: typeStr,
+		},
+		Include: &MatchProperties{
+			Services: []string{"auth"},
+		},
+		Exclude: &MatchProperties{
+			SpanNames: []string{"login*"},
+		},
+		Actions: []ActionKeyValue{
+			{Key: "password", Action: UPDATE, Value: "obfuscated"},
+			{Key: "token", Action: DELETE},
+		},
+	})
 }

--- a/processor/attributesprocessor/testdata/config.yaml
+++ b/processor/attributesprocessor/testdata/config.yaml
@@ -192,6 +192,25 @@ processors:
       - key: account_password
         action: delete
 
+  # The following demonstrates how to process spans that have a specified service name and
+  # span name that matches the glob pattern. This processor will remove "token" attribute
+  # and will obfuscate "password" attribute in spans where service name is "auth"
+  # and where span name does not begin with "login".
+  attributes/glob:
+    # Specifies the span properties that must exist for the processor to be applied.
+    include:
+      # The span service name must be "auth".
+      services: ["auth"]
+    exclude:
+      # The span name must not match "login*" glob.
+      span_names: ["login*"]
+    actions:
+      - key: password
+        action: update
+        value: "obfuscated"
+      - key: token
+        action: delete
+
 receivers:
   examplereceiver:
 

--- a/testbed/testbed/load_generator.go
+++ b/testbed/testbed/load_generator.go
@@ -117,6 +117,10 @@ func (lg *LoadGenerator) DataItemsSent() uint64 {
 	return atomic.LoadUint64(&lg.dataItemsSent)
 }
 
+func (lg *LoadGenerator) IncDataItemsSent() {
+	atomic.AddUint64(&lg.dataItemsSent, 1)
+}
+
 func (lg *LoadGenerator) generate() {
 	// Indicate that generation is done at the end
 	defer lg.stopWait.Done()
@@ -166,8 +170,8 @@ func (lg *LoadGenerator) generateTrace() {
 
 		// Create a span.
 		span := &tracepb.Span{
-			TraceId: generateTraceID(traceID),
-			SpanId:  generateSpanID(spanID),
+			TraceId: GenerateTraceID(traceID),
+			SpanId:  GenerateSpanID(spanID),
 			Name:    &tracepb.TruncatableString{Value: "load-generator-span"},
 			Kind:    tracepb.Span_CLIENT,
 			Attributes: &tracepb.Span_Attributes{
@@ -204,13 +208,13 @@ func (lg *LoadGenerator) generateTrace() {
 	}
 }
 
-func generateTraceID(id uint64) []byte {
+func GenerateTraceID(id uint64) []byte {
 	var traceID [16]byte
 	binary.PutUvarint(traceID[:], id)
 	return traceID[:]
 }
 
-func generateSpanID(id uint64) []byte {
+func GenerateSpanID(id uint64) []byte {
 	var spanID [8]byte
 	binary.PutUvarint(spanID[:], id)
 	return spanID[:]

--- a/testbed/testbed/mock_backend.go
+++ b/testbed/testbed/mock_backend.go
@@ -41,6 +41,12 @@ type MockBackend struct {
 	// Start/stop flags
 	isStarted bool
 	stopOnce  sync.Once
+
+	// Recording fields.
+	isRecording     bool
+	recordMutex     sync.Mutex
+	ReceivedTraces  []consumerdata.TraceData
+	ReceivedMetrics []consumerdata.MetricsData
 }
 
 // NewMockBackend creates a new mock backend that receives data using specified receiver.
@@ -51,6 +57,8 @@ func NewMockBackend(logFilePath string, receiver DataReceiver) *MockBackend {
 		tc:          &MockTraceConsumer{},
 		mc:          &MockMetricConsumer{},
 	}
+	mb.tc.backend = mb
+	mb.mc.backend = mb
 	return mb
 }
 
@@ -102,6 +110,13 @@ func (mb *MockBackend) Stop() {
 	})
 }
 
+// RecordReceived enables recording of all data received by MockBackend.
+func (mb *MockBackend) RecordReceived() {
+	mb.recordMutex.Lock()
+	defer mb.recordMutex.Unlock()
+	mb.isRecording = true
+}
+
 func (mb *MockBackend) GetStats() string {
 	return fmt.Sprintf("Received:%5d items", mb.DataItemsReceived())
 }
@@ -110,8 +125,32 @@ func (mb *MockBackend) DataItemsReceived() uint64 {
 	return atomic.LoadUint64(&mb.tc.spansReceived) + atomic.LoadUint64(&mb.mc.metricsReceived)
 }
 
+func (mb *MockBackend) ClearReceived() {
+	mb.recordMutex.Lock()
+	defer mb.recordMutex.Unlock()
+	mb.ReceivedTraces = nil
+	mb.ReceivedMetrics = nil
+}
+
+func (mb *MockBackend) ConsumeTrace(td consumerdata.TraceData) {
+	mb.recordMutex.Lock()
+	defer mb.recordMutex.Unlock()
+	if mb.isRecording {
+		mb.ReceivedTraces = append(mb.ReceivedTraces, td)
+	}
+}
+
+func (mb *MockBackend) ConsumeMetric(md consumerdata.MetricsData) {
+	mb.recordMutex.Lock()
+	defer mb.recordMutex.Unlock()
+	if mb.isRecording {
+		mb.ReceivedMetrics = append(mb.ReceivedMetrics, md)
+	}
+}
+
 type MockTraceConsumer struct {
 	spansReceived uint64
+	backend       *MockBackend
 }
 
 func (tc *MockTraceConsumer) ConsumeTraceData(ctx context.Context, td consumerdata.TraceData) error {
@@ -121,19 +160,23 @@ func (tc *MockTraceConsumer) ConsumeTraceData(ctx context.Context, td consumerda
 		var spanSeqnum int64
 		var traceSeqnum int64
 
-		seqnumAttr, ok := span.Attributes.AttributeMap["load_generator.span_seq_num"]
-		if ok {
-			spanSeqnum = seqnumAttr.GetIntValue()
+		if span.Attributes != nil {
+			seqnumAttr, ok := span.Attributes.AttributeMap["load_generator.span_seq_num"]
+			if ok {
+				spanSeqnum = seqnumAttr.GetIntValue()
+			}
+
+			seqnumAttr, ok = span.Attributes.AttributeMap["load_generator.trace_seq_num"]
+			if ok {
+				traceSeqnum = seqnumAttr.GetIntValue()
+			}
+
+			// Ignore the seqnums for now. We will use them later.
+			_ = spanSeqnum
+			_ = traceSeqnum
 		}
 
-		seqnumAttr, ok = span.Attributes.AttributeMap["load_generator.trace_seq_num"]
-		if ok {
-			traceSeqnum = seqnumAttr.GetIntValue()
-		}
-
-		// Ignore the seqnums for now. We will use them later.
-		_ = spanSeqnum
-		_ = traceSeqnum
+		tc.backend.ConsumeTrace(td)
 	}
 
 	return nil
@@ -141,6 +184,7 @@ func (tc *MockTraceConsumer) ConsumeTraceData(ctx context.Context, td consumerda
 
 type MockMetricConsumer struct {
 	metricsReceived uint64
+	backend         *MockBackend
 }
 
 func (mc *MockMetricConsumer) ConsumeMetricsData(ctx context.Context, md consumerdata.MetricsData) error {
@@ -152,5 +196,8 @@ func (mc *MockMetricConsumer) ConsumeMetricsData(ctx context.Context, md consume
 	}
 
 	atomic.AddUint64(&mc.metricsReceived, uint64(dataPoints))
+
+	mc.backend.ConsumeMetric(md)
+
 	return nil
 }

--- a/testbed/testbed/test_case.go
+++ b/testbed/testbed/test_case.go
@@ -49,6 +49,9 @@ type TestCase struct {
 	// Agent process.
 	agentProc childProcess
 
+	Sender   DataSender
+	Receiver DataReceiver
+
 	LoadGenerator *LoadGenerator
 	MockBackend   *MockBackend
 
@@ -84,6 +87,8 @@ func NewTestCase(
 	tc.ErrorSignal = make(chan struct{})
 	tc.doneSignal = make(chan struct{})
 	tc.startTime = time.Now()
+	tc.Sender = sender
+	tc.Receiver = receiver
 
 	// Get requested test case duration from env variable.
 	duration := os.Getenv(TESTCASE_DURATION_VAR)
@@ -229,6 +234,11 @@ func (tc *TestCase) StartBackend() {
 // StopBackend stops the backend.
 func (tc *TestCase) StopBackend() {
 	tc.MockBackend.Stop()
+}
+
+// RecordReceived enables recording of all data received by MockBackend.
+func (tc *TestCase) RecordReceived() {
+	tc.MockBackend.RecordReceived()
 }
 
 // AgentMemoryInfo returns raw memory info struct about the agent

--- a/testbed/tests/trace_test.go
+++ b/testbed/tests/trace_test.go
@@ -21,11 +21,15 @@ package tests
 // coded in this file or use scenarios from perf_scenarios.go.
 
 import (
+	"os"
 	"path"
+	"path/filepath"
 	"testing"
 
+	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-collector/testbed/testbed"
 )
 
@@ -81,7 +85,7 @@ func TestTraceNoBackend10kSPSJaeger(t *testing.T) {
 		expectedMaxRAM      uint32
 		expectedMinFinalRAM uint32
 	}{
-		{name: "NoMemoryLimiter", configFileName: "agent-config.yaml", expectedMaxRAM: 200, expectedMinFinalRAM: 100},
+		{name: "NoMemoryLimit", configFileName: "agent-config.yaml", expectedMaxRAM: 200, expectedMinFinalRAM: 100},
 
 		// Memory limiter in memory-limiter.yaml is configured to allow max 10MiB of heap size.
 		// However, heap is not the only memory user, so the total limit we set for this
@@ -222,4 +226,126 @@ func TestTraceBallast1kSPSAddAttrs(t *testing.T) {
 		},
 		testbed.WithConfigFile(path.Join("testdata", "add-attributes-config.yaml")),
 	)
+}
+
+func verifySingleSpan(
+	t *testing.T,
+	tc *testbed.TestCase,
+	span *tracepb.Span,
+	verifyReceived func(span *tracepb.Span),
+) {
+
+	// Clear previously received traces.
+	tc.MockBackend.ClearReceived()
+	startCounter := tc.MockBackend.DataItemsReceived()
+
+	// Add dummy IDs
+	span.TraceId = testbed.GenerateTraceID(1)
+	span.SpanId = testbed.GenerateSpanID(1)
+	td := consumerdata.TraceData{Spans: []*tracepb.Span{span}}
+
+	sender := tc.Sender.(testbed.TraceDataSender)
+
+	// Send the span.
+	sender.SendSpans(td)
+
+	// We bypass the load generator in this test, but make sure to increment the counter
+	// since it is used in final reports.
+	tc.LoadGenerator.IncDataItemsSent()
+
+	// Wait until span is received.
+	tc.WaitFor(func() bool { return tc.MockBackend.DataItemsReceived() == startCounter+1 },
+		"span received")
+
+	// Verify received span.
+	count := 0
+	for _, td := range tc.MockBackend.ReceivedTraces {
+		for _, span := range td.Spans {
+			verifyReceived(span)
+			count++
+		}
+	}
+	assert.EqualValues(t, 1, count, "must receive one span")
+}
+
+func TestTraceAttributesProcessor(t *testing.T) {
+	tests := []struct {
+		name     string
+		sender   testbed.DataSender
+		receiver testbed.DataReceiver
+	}{
+		{
+			"JaegerThrift",
+			testbed.NewJaegerThriftDataSender(testbed.GetAvailablePort(t)),
+			testbed.NewJaegerDataReceiver(testbed.GetAvailablePort(t)),
+		},
+		{
+			"OpenCensus",
+			testbed.NewOCTraceDataSender(testbed.GetAvailablePort(t)),
+			testbed.NewOCDataReceiver(testbed.GetAvailablePort(t)),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			resultDir, err := filepath.Abs(path.Join("results", t.Name()))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Use processor to add attributes to certain spans.
+			processors := map[string]string{
+				"attributes": `
+  attributes:
+    include:
+      span_names: ["span-to-add-*"]
+    actions:
+      - action: insert
+        key: "new_attr"
+        value: "string value"
+`,
+			}
+
+			configFile := createConfigFile(test.sender, test.receiver, resultDir, processors)
+			defer os.Remove(configFile)
+
+			if configFile == "" {
+				t.Fatal("Cannot create config file")
+			}
+
+			tc := testbed.NewTestCase(t, test.sender, test.receiver, testbed.WithConfigFile(configFile))
+			defer tc.Stop()
+
+			tc.StartBackend()
+			tc.StartAgent()
+			defer tc.StopAgent()
+
+			tc.RecordReceived()
+
+			sender := test.sender.(testbed.TraceDataSender)
+			sender.Start()
+
+			// Create a span that matches "include" filter.
+			span := &tracepb.Span{
+				Name: &tracepb.TruncatableString{Value: "span-to-add-attr"},
+			}
+
+			verifySingleSpan(t, tc, span, func(span *tracepb.Span) {
+				// Verify attributes was added.
+				attrVal, ok := span.Attributes.AttributeMap["new_attr"]
+				assert.True(t, ok)
+				assert.NotNil(t, attrVal)
+				assert.EqualValues(t, "string value", attrVal.GetStringValue().Value)
+			})
+
+			// Create another span that does not match "include" filter.
+			span = &tracepb.Span{
+				Name: &tracepb.TruncatableString{Value: "span-not-to-add-attr"},
+			}
+			verifySingleSpan(t, tc, span, func(span *tracepb.Span) {
+				// Verify attributes was not added.
+				assert.Nil(t, span.Attributes)
+			})
+		})
+	}
 }


### PR DESCRIPTION
- Added span_names filter condition.
- Implemented support for glob patterns in span_names array.
- Added E2E test for attributes processor.
- Added ability to record and verify received data in E2E tests.

**Testing:** make e2e-test
**Documentation:** processors README and config examples altered to show the new capability.