### PR TITLE
Add span_names regexp-based filtering to attributes processor

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	contrib.go.opencensus.io/exporter/ocagent v0.6.0
 	contrib.go.opencensus.io/exporter/prometheus v0.1.0
 	contrib.go.opencensus.io/resource v0.1.2
-	github.com/VividCortex/gohistogram v1.0.0 // indirect
 	github.com/apache/thrift v0.0.0-20161221203622-b2a4d4ae21c7
 	github.com/bmizerany/perks v0.0.0-20141205001514-d9a9656a3a4b // indirect
 	github.com/census-instrumentation/opencensus-proto v0.2.1

--- a/go.sum
+++ b/go.sum
@@ -40,8 +40,6 @@ github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWX
 github.com/Shopify/toxiproxy v2.1.4+incompatible h1:TKdv8HiTLgE5wdJuEML90aBgNWsokNbMijUGhmcoBJc=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
-github.com/VividCortex/gohistogram v1.0.0 h1:6+hBz+qvs0JOrrNhhmR7lFxo5sINxBCGXrdtl/UvroE=
-github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf h1:qet1QNfXsQxTZqLG4oE62mJzwPIB8+Tee4RNCL9ulrY=
@@ -51,7 +49,6 @@ github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRF
 github.com/apache/thrift v0.0.0-20161221203622-b2a4d4ae21c7 h1:Fv9bK1Q+ly/ROk4aJsVMeuIwPel4bEnD8EPiI91nZMg=
 github.com/apache/thrift v0.0.0-20161221203622-b2a4d4ae21c7/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.0.0-20161221203622-b2a4d4ae21c7/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
-github.com/apache/thrift v0.13.0 h1:5hryIiq9gtn+MiLVn0wP37kb/uTeRZgN08WoCsAhIhI=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da h1:8GUt8eRujhVEGZFFEjBj46YV4rDjvGrNxb0KMWYkL2I=
@@ -214,7 +211,6 @@ github.com/go-toolsmith/strparse v1.0.0 h1:Vcw78DnpCAKlM20kSbAyO4mPfJn/lyYA4BJUD
 github.com/go-toolsmith/strparse v1.0.0/go.mod h1:YI2nUKP9YGZnL/L1/DLFBfixrcjslWct4wyljWhSRy8=
 github.com/go-toolsmith/typep v1.0.0 h1:zKymWyA1TRYvqYrYDrfEMZULyrhcnGY3x7LDKU2XQaA=
 github.com/go-toolsmith/typep v1.0.0/go.mod h1:JSQCQMUPdRlMZFswiq3TGpNp1GMktqkR2Ns5AIQkATU=
-github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/gofrs/flock v0.0.0-20190320160742-5135e617513b h1:ekuhfTjngPhisSjOJ0QWKpPQE8/rbknHaes6WVJj5Hw=
 github.com/gofrs/flock v0.0.0-20190320160742-5135e617513b/go.mod h1:F1TvTiK9OcQqauNUHlbJvyl9Qa1QvF/gOUDKA14jxHU=
@@ -506,7 +502,6 @@ github.com/onsi/gomega v1.5.0 h1:izbySO9zDPmjJ8rDjLvkA2zJHIo+HkYXHnf7eN7SSyo=
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.7.0 h1:XPnZz8VVBHjVsy1vzJmRwIcSwiUO+JFfrv/xGiigmME=
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
-github.com/open-telemetry/opentelemetry-service v0.2.0 h1:sesxaZ+IuDVCOOORGykV+xkzZwkoluJxXSqdxvo252E=
 github.com/opentracing-contrib/go-stdlib v0.0.0-20190519235532-cf7a6c988dc9/go.mod h1:PLldrQSroqzH70Xl+1DQcGnefIbqsKR7UDaiux3zV+w=
 github.com/opentracing/opentracing-go v1.1.0 h1:pWlfV3Bxv7k65HYwkikxat0+s3pV4bsqf19k25Ur8rU=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
@@ -662,8 +657,6 @@ github.com/uber/jaeger-client-go v2.15.0+incompatible h1:NP3qsSqNxh8VYr956ur1N/1
 github.com/uber/jaeger-client-go v2.15.0+incompatible/go.mod h1:WVhlPFC8FDjOFMMWRy2pZqQJSXxYSwNYOkTr/Z6d3Kk=
 github.com/uber/jaeger-client-go v2.16.0+incompatible h1:Q2Pp6v3QYiocMxomCaJuwQGFt7E53bPYqEgug/AoBtY=
 github.com/uber/jaeger-client-go v2.16.0+incompatible/go.mod h1:WVhlPFC8FDjOFMMWRy2pZqQJSXxYSwNYOkTr/Z6d3Kk=
-github.com/uber/jaeger-lib v2.0.0+incompatible h1:iMSCV0rmXEogjNWPh2D0xk9YVKvrtGoHJNe9ebLu/pw=
-github.com/uber/jaeger-lib v2.0.0+incompatible/go.mod h1:ComeNDZlWwrWnDv8aPp0Ba6+uUTzImX/AauajbLI56U=
 github.com/uber/jaeger-lib v2.2.0+incompatible h1:MxZXOiR2JuoANZ3J6DE/U0kSFv/eJ/GfSYVCjK7dyaw=
 github.com/uber/jaeger-lib v2.2.0+incompatible/go.mod h1:ComeNDZlWwrWnDv8aPp0Ba6+uUTzImX/AauajbLI56U=
 github.com/uber/tchannel-go v1.10.0 h1:YOihLHuvkwT3nzvpgqFtexFW+pb5vD1Tz7h/bIWApgE=
@@ -930,6 +923,7 @@ k8s.io/api v0.0.0-20190813020757-36bff7324fb7/go.mod h1:3Iy+myeAORNCLgjd/Xu9ebwN
 k8s.io/apimachinery v0.0.0-20190612205821-1799e75a0719/go.mod h1:I4A+glKBHiTgiEjQiCCQfCAIcIMFGt291SmsvcrFzJA=
 k8s.io/apimachinery v0.0.0-20190809020650-423f5d784010 h1:pyoq062NftC1y/OcnbSvgolyZDJ8y4fmUPWMkdA6gfU=
 k8s.io/apimachinery v0.0.0-20190809020650-423f5d784010/go.mod h1:Waf/xTS2FGRrgXCkO5FP3XxTOWh0qLf2QhL1qFZZ/R8=
+k8s.io/client-go v0.0.0-20190620085101-78d2af792bab h1:E8Fecph0qbNsAbijJJQryKu4Oi9QTp5cVpjTE+nqg6g=
 k8s.io/client-go v0.0.0-20190620085101-78d2af792bab/go.mod h1:E95RaSlHr79aHaX0aGSwcPNfygDiPKOVXdmivCIZT0k=
 k8s.io/client-go v12.0.0+incompatible h1:YlJxncpeVUC98/WMZKC3JZGk/OXQWCZjAB4Xr3B17RY=
 k8s.io/client-go v12.0.0+incompatible/go.mod h1:E95RaSlHr79aHaX0aGSwcPNfygDiPKOVXdmivCIZT0k=

--- a/processor/README.md
+++ b/processor/README.md
@@ -132,24 +132,28 @@ if the span should be included or excluded from the processor. By default, all
 spans are processed by the processor.
 
 To configure this option, under `include` and/or `exclude`:
-- at least one of or both `services` and `attributes` is required.
+- at least one of `services`, `span_names` or `attributes` is required.
 
 Note: If both `include` and `exclude` are specified, the `include` properties
 are checked before the `exclude` properties.
+
+Items in `span_names` array are regular expression patterns.
 
 ```yaml
 attributes:
     # include and/or exclude can be specified. However, the include properties
     # are always checked before the exclude properties.
     {include, exclude}:
-      # At least one of services or attributes must be specified. It is supported
-      # to have both specified, but both `services` and `attributes` must evaluate
-      # to true for a match to occur.
+      # At least one of services, span_names or attributes must be specified.
+      # It is supported to have more than one specified, but all of the specified
+      # conditions must evaluate to true for a match to occur.
 
       # Services specify the list of service name to match against.
       # A match occurs if the span service name is in this list.
       # Note: This is an optional field.
       services: [<key1>, ..., <keyN>]
+      # The span name must match "login.*" or "auth.*" pattern.
+      span_names: ["login.*", "auth.*"]
       # Attributes specifies the list of attributes to match against.
       # All of these attributes must match exactly for a match to occur.
       # Note: This is an optional field.

--- a/processor/attributesprocessor/attributes_test.go
+++ b/processor/attributesprocessor/attributes_test.go
@@ -16,6 +16,7 @@ package attributesprocessor
 
 import (
 	"context"
+	"regexp"
 	"testing"
 
 	commonpb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
@@ -859,7 +860,7 @@ func TestAttributes_Matching_False(t *testing.T) {
 		properties matchingProperties
 	}{
 		{
-			name: "service name doesn't match",
+			name: "service_name_doesnt_match",
 			properties: matchingProperties{
 				Services: map[string]bool{
 					"svcA": true,
@@ -867,8 +868,29 @@ func TestAttributes_Matching_False(t *testing.T) {
 				Attributes: []matchAttribute{},
 			},
 		},
+
 		{
-			name: "wrong property value",
+			name: "span_name_doesnt_match",
+			properties: matchingProperties{
+				SpanNames:  []*regexp.Regexp{regexp.MustCompile("spanNo.*Name")},
+				Attributes: []matchAttribute{},
+			},
+		},
+
+		{
+			name: "span_name_doesnt_match_any",
+			properties: matchingProperties{
+				SpanNames: []*regexp.Regexp{
+					regexp.MustCompile("spanNo.*Name"),
+					regexp.MustCompile("non-matching?pattern"),
+					regexp.MustCompile("regular string"),
+				},
+				Attributes: []matchAttribute{},
+			},
+		},
+
+		{
+			name: "wrong_property_value",
 			properties: matchingProperties{
 				Services: map[string]bool{},
 				Attributes: []matchAttribute{
@@ -884,7 +906,7 @@ func TestAttributes_Matching_False(t *testing.T) {
 			},
 		},
 		{
-			name: "incompatible property value",
+			name: "incompatible_property_value",
 			properties: matchingProperties{
 				Services: map[string]bool{},
 				Attributes: []matchAttribute{
@@ -900,7 +922,7 @@ func TestAttributes_Matching_False(t *testing.T) {
 			},
 		},
 		{
-			name: "property key does not exist",
+			name: "property_key_does_not_exist",
 			properties: matchingProperties{
 				Services: map[string]bool{},
 				Attributes: []matchAttribute{
@@ -914,6 +936,7 @@ func TestAttributes_Matching_False(t *testing.T) {
 	}
 
 	span := &tracepb.Span{
+		Name: &tracepb.TruncatableString{Value: "spanName"},
 		Attributes: &tracepb.Span_Attributes{
 			AttributeMap: map[string]*tracepb.AttributeValue{
 				"keyInt": {
@@ -948,19 +971,19 @@ func TestAttributes_MatchingCornerCases(t *testing.T) {
 		span *tracepb.Span
 	}{
 		{
-			name: "nil attributes",
+			name: "nil_attributes",
 			span: &tracepb.Span{
 				Attributes: nil,
 			},
 		},
 		{
-			name: "default attributes",
+			name: "default_attributes",
 			span: &tracepb.Span{
 				Attributes: &tracepb.Span_Attributes{},
 			},
 		},
 		{
-			name: "empty map",
+			name: "empty_map",
 			span: &tracepb.Span{
 				Attributes: &tracepb.Span_Attributes{
 					AttributeMap: map[string]*tracepb.AttributeValue{},
@@ -988,19 +1011,19 @@ func TestAttributes_MissingServiceName(t *testing.T) {
 		span *tracepb.Span
 	}{
 		{
-			name: "nil attributes",
+			name: "nil_attributes",
 			span: &tracepb.Span{
 				Attributes: nil,
 			},
 		},
 		{
-			name: "default attributes",
+			name: "default_attributes",
 			span: &tracepb.Span{
 				Attributes: &tracepb.Span_Attributes{},
 			},
 		},
 		{
-			name: "empty map",
+			name: "empty_map",
 			span: &tracepb.Span{
 				Attributes: &tracepb.Span_Attributes{
 					AttributeMap: map[string]*tracepb.AttributeValue{},
@@ -1023,14 +1046,14 @@ func TestAttributes_Matching_True(t *testing.T) {
 		properties matchingProperties
 	}{
 		{
-			name: "empty match properties",
+			name: "empty_match_properties",
 			properties: matchingProperties{
 				Services:   map[string]bool{},
 				Attributes: []matchAttribute{},
 			},
 		},
 		{
-			name: "service name match",
+			name: "service_name_match",
 			properties: matchingProperties{
 				Services: map[string]bool{
 					"svcA": true,
@@ -1039,7 +1062,26 @@ func TestAttributes_Matching_True(t *testing.T) {
 			},
 		},
 		{
-			name: "property exact value match",
+			name: "span_name_match",
+			properties: matchingProperties{
+				SpanNames:  []*regexp.Regexp{regexp.MustCompile("span.*")},
+				Attributes: []matchAttribute{},
+			},
+		},
+		{
+			name: "span_name_second_match",
+			properties: matchingProperties{
+				SpanNames: []*regexp.Regexp{
+					regexp.MustCompile("wrong.*pattern"),
+					regexp.MustCompile("span.*"),
+					regexp.MustCompile("yet another?pattern"),
+					regexp.MustCompile("regularstring"),
+				},
+				Attributes: []matchAttribute{},
+			},
+		},
+		{
+			name: "property_exact_value_match",
 			properties: matchingProperties{
 				Services: map[string]bool{},
 				Attributes: []matchAttribute{
@@ -1077,7 +1119,7 @@ func TestAttributes_Matching_True(t *testing.T) {
 			},
 		},
 		{
-			name: "property exists",
+			name: "property_exists",
 			properties: matchingProperties{
 				Services: map[string]bool{
 					"svcA": true,
@@ -1091,7 +1133,7 @@ func TestAttributes_Matching_True(t *testing.T) {
 			},
 		},
 		{
-			name: "match all settings exists",
+			name: "match_all_settings_exists",
 			properties: matchingProperties{
 				Services: map[string]bool{
 					"svcA": true,
@@ -1115,6 +1157,7 @@ func TestAttributes_Matching_True(t *testing.T) {
 	}
 
 	span := &tracepb.Span{
+		Name: &tracepb.TruncatableString{Value: "spanName"},
 		Attributes: &tracepb.Span_Attributes{
 			AttributeMap: map[string]*tracepb.AttributeValue{
 				"keyString": {
@@ -1217,5 +1260,171 @@ func TestAttributes_FilterSpans(t *testing.T) {
 
 	for _, tt := range testCases {
 		runIndividualTestCase(t, tt, tp)
+	}
+}
+
+func TestAttributes_FilterSpansByName(t *testing.T) {
+	testCases := []testCase{
+		{
+			name:            "apply_to_span_with_no_attrs",
+			nodeName:        "svcB",
+			inputAttributes: map[string]*tracepb.AttributeValue{},
+			expectedAttributes: map[string]*tracepb.AttributeValue{
+				"attribute1": {
+					Value: &tracepb.AttributeValue_IntValue{IntValue: 123},
+				},
+			},
+		},
+		{
+			name:     "apply_to_span_with_attr",
+			nodeName: "svcB",
+			inputAttributes: map[string]*tracepb.AttributeValue{
+				"NoModification": {
+					Value: &tracepb.AttributeValue_BoolValue{BoolValue: false},
+				},
+			},
+			expectedAttributes: map[string]*tracepb.AttributeValue{
+				"attribute1": {
+					Value: &tracepb.AttributeValue_IntValue{IntValue: 123},
+				},
+				"NoModification": {
+					Value: &tracepb.AttributeValue_BoolValue{BoolValue: false},
+				},
+			},
+		},
+		{
+			name:               "incorrect_span_name",
+			nodeName:           "svcB",
+			inputAttributes:    map[string]*tracepb.AttributeValue{},
+			expectedAttributes: map[string]*tracepb.AttributeValue{},
+		},
+		{
+			name:               "apply_dont_apply",
+			nodeName:           "svcB",
+			inputAttributes:    map[string]*tracepb.AttributeValue{},
+			expectedAttributes: map[string]*tracepb.AttributeValue{},
+		},
+		{
+			name:     "incorrect_span_name_with_attr",
+			nodeName: "svcB",
+			inputAttributes: map[string]*tracepb.AttributeValue{
+				"NoModification": {
+					Value: &tracepb.AttributeValue_BoolValue{BoolValue: true},
+				},
+			},
+			expectedAttributes: map[string]*tracepb.AttributeValue{
+				"NoModification": {
+					Value: &tracepb.AttributeValue_BoolValue{BoolValue: true},
+				},
+			},
+		},
+	}
+
+	factory := Factory{}
+	cfg := factory.CreateDefaultConfig()
+	oCfg := cfg.(*Config)
+	oCfg.Actions = []ActionKeyValue{
+		{Key: "attribute1", Action: INSERT, Value: 123},
+	}
+	oCfg.Include = &MatchProperties{
+		SpanNames: []string{"^apply.*"},
+	}
+	oCfg.Exclude = &MatchProperties{
+		SpanNames: []string{".*dont_apply$"},
+	}
+	tp, err := factory.CreateTraceProcessor(zap.NewNop(), exportertest.NewNopTraceExporter(), cfg)
+	require.Nil(t, err)
+	require.NotNil(t, tp)
+
+	for _, tt := range testCases {
+		runIndividualTestCase(t, tt, tp)
+	}
+}
+
+func BenchmarkAttributes_FilterSpansByName(b *testing.B) {
+	testCases := []testCase{
+		{
+			name:            "apply_to_span_with_no_attrs",
+			inputAttributes: map[string]*tracepb.AttributeValue{},
+			expectedAttributes: map[string]*tracepb.AttributeValue{
+				"attribute1": {
+					Value: &tracepb.AttributeValue_IntValue{IntValue: 123},
+				},
+			},
+		},
+		{
+			name: "apply_to_span_with_attr",
+			inputAttributes: map[string]*tracepb.AttributeValue{
+				"NoModification": {
+					Value: &tracepb.AttributeValue_BoolValue{BoolValue: false},
+				},
+			},
+			expectedAttributes: map[string]*tracepb.AttributeValue{
+				"attribute1": {
+					Value: &tracepb.AttributeValue_IntValue{IntValue: 123},
+				},
+				"NoModification": {
+					Value: &tracepb.AttributeValue_BoolValue{BoolValue: false},
+				},
+			},
+		},
+		{
+			name:               "dont_apply",
+			inputAttributes:    map[string]*tracepb.AttributeValue{},
+			expectedAttributes: map[string]*tracepb.AttributeValue{},
+		},
+	}
+
+	factory := Factory{}
+	cfg := factory.CreateDefaultConfig()
+	oCfg := cfg.(*Config)
+	oCfg.Actions = []ActionKeyValue{
+		{Key: "attribute1", Action: INSERT, Value: 123},
+	}
+	oCfg.Include = &MatchProperties{
+		SpanNames: []string{"^apply.*"},
+	}
+	tp, err := factory.CreateTraceProcessor(zap.NewNop(), exportertest.NewNopTraceExporter(), cfg)
+	require.Nil(b, err)
+	require.NotNil(b, tp)
+
+	for _, tt := range testCases {
+		traceData := consumerdata.TraceData{
+			Node: &commonpb.Node{
+				ServiceInfo: &commonpb.ServiceInfo{
+					Name: tt.nodeName,
+				},
+			},
+			Spans: []*tracepb.Span{
+				{
+					Name: &tracepb.TruncatableString{Value: tt.name},
+					Attributes: &tracepb.Span_Attributes{
+						AttributeMap: tt.inputAttributes,
+					},
+				},
+			},
+		}
+
+		b.Run(tt.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				assert.NoError(b, tp.ConsumeTraceData(context.Background(), traceData))
+			}
+		})
+
+		assert.Equal(b, consumerdata.TraceData{
+			Node: &commonpb.Node{
+				ServiceInfo: &commonpb.ServiceInfo{
+					Name: tt.nodeName,
+				},
+			},
+			Spans: []*tracepb.Span{
+				{
+					Name: &tracepb.TruncatableString{Value: tt.name},
+					Attributes: &tracepb.Span_Attributes{
+						AttributeMap: tt.expectedAttributes,
+					},
+				},
+			},
+		}, traceData)
 	}
 }

--- a/processor/attributesprocessor/config.go
+++ b/processor/attributesprocessor/config.go
@@ -132,18 +132,22 @@ const (
 // Please refer to testdata/config.yaml for valid configurations.
 type MatchProperties struct {
 
+	// Note: one of Services, SpanNames or Attributes must be specified with a
+	// non-empty value for a valid configuration.
+
 	// Services specify the list of service name to match against.
-	// A match occurs if the span service name is in this list.
-	// Note: This is an optional field. However, one of services or
-	// attributes must be specified with a non empty value for a valid
-	// configuration.
+	// A match occurs if the span's service name is in this list.
+	// This is an optional field.
 	Services []string `mapstructure:"services"`
+
+	// SpanNames specify the list of regexps to match span name against.
+	// A match occurs if the span name matches at least one regexp item in this list.
+	// This is an optional field.
+	SpanNames []string `mapstructure:"span_names"`
 
 	// Attributes specifies the list of attributes to match against.
 	// All of these attributes must match exactly for a match to occur.
-	// Note: This is an optional field. However, one of services or
-	// attributes must be specified with a non empty value for a valid
-	// configuration.
+	// This is an optional field.
 	Attributes []Attribute `mapstructure:"attributes"`
 }
 

--- a/processor/attributesprocessor/config_test.go
+++ b/processor/attributesprocessor/config_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/open-telemetry/opentelemetry-collector/config"
 	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
@@ -33,7 +34,7 @@ func TestLoadingConifg(t *testing.T) {
 	config, err := config.LoadConfigFile(t, path.Join(".", "testdata", "config.yaml"), factories)
 
 	assert.Nil(t, err)
-	assert.NotNil(t, config)
+	require.NotNil(t, config)
 
 	p0 := config.Processors["attributes/insert"]
 	assert.Equal(t, p0, &Config{
@@ -165,4 +166,21 @@ func TestLoadingConifg(t *testing.T) {
 		},
 	})
 
+	p9 := config.Processors["attributes/regexp"]
+	assert.Equal(t, p9, &Config{
+		ProcessorSettings: configmodels.ProcessorSettings{
+			NameVal: "attributes/regexp",
+			TypeVal: typeStr,
+		},
+		Include: &MatchProperties{
+			Services: []string{"auth"},
+		},
+		Exclude: &MatchProperties{
+			SpanNames: []string{"login.*"},
+		},
+		Actions: []ActionKeyValue{
+			{Key: "password", Action: UPDATE, Value: "obfuscated"},
+			{Key: "token", Action: DELETE},
+		},
+	})
 }

--- a/processor/attributesprocessor/testdata/config.yaml
+++ b/processor/attributesprocessor/testdata/config.yaml
@@ -192,6 +192,25 @@ processors:
       - key: account_password
         action: delete
 
+  # The following demonstrates how to process spans that have a specified service name and
+  # span name that matches the regexp pattern. This processor will remove "token" attribute
+  # and will obfuscate "password" attribute in spans where service name is "auth"
+  # and where span name does not match "login.*".
+  attributes/regexp:
+    # Specifies the span properties that must exist for the processor to be applied.
+    include:
+      # The span service name must be "auth".
+      services: ["auth"]
+    exclude:
+      # The span name must not match "login.*" pattern.
+      span_names: ["login.*"]
+    actions:
+      - key: password
+        action: update
+        value: "obfuscated"
+      - key: token
+        action: delete
+
 receivers:
   examplereceiver:
 

--- a/testbed/go.sum
+++ b/testbed/go.sum
@@ -35,8 +35,6 @@ github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMx
 github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d h1:G0m3OIz70MZUWq3EgK3CesDbo8upS2Vm9/P3FtgI+Jk=
 github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
-github.com/VividCortex/gohistogram v1.0.0 h1:6+hBz+qvs0JOrrNhhmR7lFxo5sINxBCGXrdtl/UvroE=
-github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=

--- a/testbed/testbed/test_case.go
+++ b/testbed/testbed/test_case.go
@@ -49,6 +49,9 @@ type TestCase struct {
 	// Agent process.
 	agentProc childProcess
 
+	Sender   DataSender
+	Receiver DataReceiver
+
 	LoadGenerator *LoadGenerator
 	MockBackend   *MockBackend
 
@@ -84,6 +87,8 @@ func NewTestCase(
 	tc.ErrorSignal = make(chan struct{})
 	tc.doneSignal = make(chan struct{})
 	tc.startTime = time.Now()
+	tc.Sender = sender
+	tc.Receiver = receiver
 
 	// Get requested test case duration from env variable.
 	duration := os.Getenv(TESTCASE_DURATION_VAR)
@@ -229,6 +234,11 @@ func (tc *TestCase) StartBackend() {
 // StopBackend stops the backend.
 func (tc *TestCase) StopBackend() {
 	tc.MockBackend.Stop()
+}
+
+// EnableRecording enables recording of all data received by MockBackend.
+func (tc *TestCase) EnableRecording() {
+	tc.MockBackend.EnableRecording()
 }
 
 // AgentMemoryInfo returns raw memory info struct about the agent


### PR DESCRIPTION
- Added span_names filter condition.
- Implemented support for regexp patterns in span_names array.
- Added E2E test for attributes processor.
- Added ability to record and verify received data in E2E tests.

**Testing:** 
1. make e2e-test
2. Benchmarked `include` filter using regexp. It takes about 1 microsecond per span for simple regexes, which is virtually the same performance when strict equality is used instead of regex.

**Documentation:** processors README and config examples altered to show the new capability.