### PR TITLE
Remove unused MetricsSource() and TraceSource() methods

### DIFF
--- a/config/example_factories.go
+++ b/config/example_factories.go
@@ -132,11 +132,6 @@ type ExampleReceiverProducer struct {
 	MetricsConsumer consumer.MetricsConsumer
 }
 
-// TraceSource returns the name of the trace data source.
-func (erp *ExampleReceiverProducer) TraceSource() string {
-	return ""
-}
-
 // Start tells the receiver to start its processing.
 func (erp *ExampleReceiverProducer) Start(host component.Host) error {
 	erp.Started = true
@@ -147,11 +142,6 @@ func (erp *ExampleReceiverProducer) Start(host component.Host) error {
 func (erp *ExampleReceiverProducer) Shutdown() error {
 	erp.Stopped = true
 	return nil
-}
-
-// MetricsSource returns the name of the metrics data source.
-func (erp *ExampleReceiverProducer) MetricsSource() string {
-	return ""
 }
 
 // This is the map of already created example receivers for particular configurations.

--- a/receiver/jaegerreceiver/trace_receiver.go
+++ b/receiver/jaegerreceiver/trace_receiver.go
@@ -103,8 +103,6 @@ const (
 	defaultAgentQueueSize     = 1000
 	defaultAgentMaxPacketSize = 65000
 	defaultAgentServerWorkers = 10
-
-	traceSource string = "Jaeger"
 )
 
 // New creates a TraceReceiver that receives traffic as a collector with both Thrift and HTTP transports.
@@ -194,10 +192,6 @@ func (jr *jReceiver) collectorThriftAddr() string {
 
 func (jr *jReceiver) collectorThriftEnabled() bool {
 	return jr.config != nil && jr.config.CollectorThriftPort > 0
-}
-
-func (jr *jReceiver) TraceSource() string {
-	return traceSource
 }
 
 func (jr *jReceiver) Start(host component.Host) error {

--- a/receiver/jaegerreceiver/trace_receiver_test.go
+++ b/receiver/jaegerreceiver/trace_receiver_test.go
@@ -51,8 +51,7 @@ import (
 func TestTraceSource(t *testing.T) {
 	jr, err := New(context.Background(), &Configuration{}, nil, zap.NewNop())
 	assert.NoError(t, err, "should not have failed to create the Jaeger receiver")
-
-	assert.Equal(t, traceSource, jr.TraceSource())
+	require.NotNil(t, jr)
 }
 
 func TestReception(t *testing.T) {

--- a/receiver/opencensusreceiver/opencensus.go
+++ b/receiver/opencensusreceiver/opencensus.go
@@ -66,8 +66,6 @@ type Receiver struct {
 var _ receiver.MetricsReceiver = (*Receiver)(nil)
 var _ receiver.TraceReceiver = (*Receiver)(nil)
 
-const source string = "OpenCensus"
-
 // New just creates the OpenCensus receiver services. It is the caller's
 // responsibility to invoke the respective Start*Reception methods as well
 // as the various Stop*Reception methods to end it.
@@ -94,11 +92,6 @@ func New(addr string, tc consumer.TraceConsumer, mc consumer.MetricsConsumer, op
 	return ocr, nil
 }
 
-// TraceSource returns the name of the trace data source.
-func (ocr *Receiver) TraceSource() string {
-	return source
-}
-
 // Start runs the trace receiver on the gRPC server. Currently
 // it also enables the metrics receiver too.
 func (ocr *Receiver) Start(host component.Host) error {
@@ -117,11 +110,6 @@ func (ocr *Receiver) registerTraceConsumer() error {
 	})
 
 	return err
-}
-
-// MetricsSource returns the name of the metrics data source.
-func (ocr *Receiver) MetricsSource() string {
-	return source
 }
 
 func (ocr *Receiver) registerMetricsConsumer() error {

--- a/receiver/prometheusreceiver/metrics_receiver.go
+++ b/receiver/prometheusreceiver/metrics_receiver.go
@@ -53,13 +53,6 @@ func newPrometheusReceiver(logger *zap.Logger, cfg *Config, next consumer.Metric
 	return pr
 }
 
-const metricsSource string = "Prometheus"
-
-// MetricsSource returns the name of the metrics data source.
-func (pr *Preceiver) MetricsSource() string {
-	return metricsSource
-}
-
 // Start is the method that starts Prometheus scraping and it
 // is controlled by having previously defined a Configuration using perhaps New.
 func (pr *Preceiver) Start(host component.Host) error {

--- a/receiver/receiver.go
+++ b/receiver/receiver.go
@@ -16,7 +16,6 @@ package receiver
 
 import (
 	"github.com/open-telemetry/opentelemetry-collector/component"
-	_ "github.com/open-telemetry/opentelemetry-collector/compression/grpc" // load in supported grpc compression encodings
 )
 
 // Receiver defines functions that trace and metric receivers must implement.
@@ -33,9 +32,6 @@ type Receiver interface {
 // Zipkin spans into *tracepb.Span-s.
 type TraceReceiver interface {
 	Receiver
-
-	// TraceSource returns the name of the trace data source.
-	TraceSource() string
 }
 
 // A MetricsReceiver is an "arbitrary data"-to-"metric proto" converter.
@@ -47,7 +43,4 @@ type TraceReceiver interface {
 // Prometheus metrics into *metricpb.Metric-s.
 type MetricsReceiver interface {
 	Receiver
-
-	// MetricsSource returns the name of the metrics data source.
-	MetricsSource() string
 }

--- a/receiver/vmmetricsreceiver/metrics_receiver.go
+++ b/receiver/vmmetricsreceiver/metrics_receiver.go
@@ -34,13 +34,6 @@ type Receiver struct {
 	startOnce sync.Once
 }
 
-const metricsSource string = "VMMetrics"
-
-// MetricsSource returns the name of the metrics data source.
-func (vmr *Receiver) MetricsSource() string {
-	return metricsSource
-}
-
 // Start scrapes VM metrics based on the OS platform.
 func (vmr *Receiver) Start(host component.Host) error {
 	vmr.mu.Lock()

--- a/receiver/zipkinreceiver/trace_receiver.go
+++ b/receiver/zipkinreceiver/trace_receiver.go
@@ -89,19 +89,12 @@ func (zr *ZipkinReceiver) address() string {
 	return addr
 }
 
-const traceSource string = "Zipkin"
-
 func (zr *ZipkinReceiver) WithHTTPServer(s *http.Server) *ZipkinReceiver {
 	if s.Handler == nil {
 		s.Handler = zr
 	}
 	zr.server = s
 	return zr
-}
-
-// TraceSource returns the name of the trace data source.
-func (zr *ZipkinReceiver) TraceSource() string {
-	return traceSource
 }
 
 // Start spins up the receiver's HTTP server and makes the receiver start its processing.

--- a/receiver/zipkinreceiver/trace_receiver_test.go
+++ b/receiver/zipkinreceiver/trace_receiver_test.go
@@ -128,7 +128,11 @@ func TestNew(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := New(tt.args.address, tt.args.nextConsumer)
 			require.Equal(t, tt.wantErr, err)
-			assert.Equal(t, traceSource, got.TraceSource())
+			if tt.wantErr == nil {
+				require.NotNil(t, got)
+			} else {
+				require.Nil(t, got)
+			}
 		})
 	}
 }


### PR DESCRIPTION
These methods are not being used, removing them to reduce a bit
boiler-plate code of components.

**Description:** Removing unused method to reduce a little bit boiler-plate code of components.
**Link to tracking Issue:** N/A
**Testing:** `make test`
**Documentation:** N/A

I was tempted to look into removing `TraceReceiver` and `MetricsReceiver` interfaces since they are now just embedding `Receiver` but that will be a larger changing touching many modules. I will look at it separately, this one already reduces a tiny bit the boiler plate code as intended.