### PR TITLE
Apply headers configuration to Jaeger gRPC exporter

### DIFF
--- a/exporter/jaeger/jaegergrpcexporter/exporter.go
+++ b/exporter/jaeger/jaegergrpcexporter/exporter.go
@@ -76,8 +76,12 @@ func (s *protoGRPCSender) pushTraceData(
 		return len(td.Spans), consumererror.Permanent(err)
 	}
 
+	if s.metadata.Len() > 0 {
+		ctx = metadata.NewOutgoingContext(ctx, s.metadata)
+	}
+
 	_, err = s.client.PostSpans(
-		metadata.NewOutgoingContext(ctx, s.metadata),
+		ctx,
 		&jaegerproto.PostSpansRequest{Batch: *protoBatch})
 
 	if err != nil {

--- a/exporter/jaeger/jaegergrpcexporter/exporter.go
+++ b/exporter/jaeger/jaegergrpcexporter/exporter.go
@@ -16,6 +16,7 @@ package jaegergrpcexporter
 
 import (
 	"context"
+
 	jaegerproto "github.com/jaegertracing/jaeger/proto-gen/api_v2"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
@@ -45,7 +46,7 @@ func New(config *Config) (exporter.TraceExporter, error) {
 
 	collectorServiceClient := jaegerproto.NewCollectorServiceClient(client)
 	s := &protoGRPCSender{
-		client: collectorServiceClient,
+		client:  collectorServiceClient,
 		headers: config.GRPCSettings.Headers,
 	}
 
@@ -61,7 +62,7 @@ func New(config *Config) (exporter.TraceExporter, error) {
 // protoGRPCSender forwards spans encoded in the jaeger proto
 // format, to a grpc server.
 type protoGRPCSender struct {
-	client jaegerproto.CollectorServiceClient
+	client  jaegerproto.CollectorServiceClient
 	headers map[string]string
 }
 

--- a/exporter/jaeger/jaegergrpcexporter/exporter_test.go
+++ b/exporter/jaeger/jaegergrpcexporter/exporter_test.go
@@ -50,6 +50,22 @@ func TestNew(t *testing.T) {
 			},
 		},
 		{
+			name: "createExporterWithHeaders",
+			args: args{
+				config: Config{
+					GRPCSettings: configgrpc.GRPCSettings{
+						Headers:             map[string]string{"extra-header": "header-value"},
+						Endpoint:            "foo.bar",
+						Compression:         "",
+						CertPemFile:         "",
+						UseSecure:           true,
+						ServerNameOverride:  "",
+						KeepaliveParameters: nil,
+					},
+				},
+			},
+		},
+		{
 			name: "createBasicSecureExporter",
 			args: args{
 				config: Config{


### PR DESCRIPTION
**Description:**

This change fixes an issue where the Jaeger gRPC exporter doesn't behave as expected. The Jaeger gRPC exporter accepts a `headers` configuration value (part of `configgrpc.GRPCSettings`) but doesn't add these headers to the gRPC request that is issued.
