### PR TITLE
Add missed semantic convention attribute

### DIFF
--- a/translator/conventions/opentelemetry.go
+++ b/translator/conventions/opentelemetry.go
@@ -93,6 +93,7 @@ const (
 	AttributeDBInstance  = "db.instance"
 	AttributeDBStatement = "db.statement"
 	AttributeDBUser      = "db.user"
+	AttributeDBURL       = "db.url"
 )
 
 // OpenTelemetry Semantic Convention attribute names for gRPC related attributes


### PR DESCRIPTION
I missed on attribute `db.url` in my pull request yesterday.