### PR TITLE
Add support to extract attributes and rename span

### DIFF
--- a/processor/spanprocessor/config.go
+++ b/processor/spanprocessor/config.go
@@ -32,10 +32,10 @@ type Config struct {
 
 // Name specifies the attributes to use to re-name a span.
 type Name struct {
-	// Separator is the string used to separate attributes values in the new
-	// span name. If no value is set, no separator is used between attribute
-	// values.
-	Separator string `mapstructure:"separator"`
+	// Specifies transformations of span name to and from attributes.
+	// First FromAttributes rules are applied, then ToAttributes are applied.
+	// At least one of these 2 fields must be set.
+
 	// FromAttributes represents the attribute keys to pull the values from to
 	// generate the new span name. All attribute keys are required in the span
 	// to re-name a span. If any attribute is missing from the span, no re-name
@@ -43,4 +43,31 @@ type Name struct {
 	// Note: The new span name is constructed in order of the `from_attributes`
 	// specified in the configuration. This field is required and cannot be empty.
 	FromAttributes []string `mapstructure:"from_attributes"`
+
+	// Separator is the string used to separate attributes values in the new
+	// span name. If no value is set, no separator is used between attribute
+	// values. Used with FromAttributes only.
+	Separator string `mapstructure:"separator"`
+
+	// ToAttributes specifies a configuration to extract attributes from span name.
+	ToAttributes *ToAttributes `mapstructure:"to_attributes"`
+}
+
+type ToAttributes struct {
+	// Rules is a list of rules to extract attribute values from span name. The values
+	// in the span name are replaced by extracted attribute names. Each rule in the list
+	// is a regex pattern string. Span name is checked against the regex. If it matches
+	// then all named subexpressions of the regex are extracted as attributes
+	// and are added to the span. Each subexpression name becomes an attribute name and
+	// subexpression matched portion becomes the attribute value. The matched portion
+	// in the span name is replaced by extracted attribute name. If the attributes
+	// already exist in the span then they will be overwritten. The process is repeated
+	// for all rules in the order they are specified. Each subsequent rule works on the
+	// span name that is the output after processing the previous rule.
+	Rules []string `mapstructure:"rules"`
+
+	// BreakAfterMatch specifies if processing of rules should stop after the first
+	// match. If it is false rule processing will continue to be performed over the
+	// modified span name.
+	BreakAfterMatch bool `mapstructure:"break_after_match"`
 }

--- a/processor/spanprocessor/config_test.go
+++ b/processor/spanprocessor/config_test.go
@@ -59,4 +59,17 @@ func TestLoadConfig(t *testing.T) {
 			Separator:      "",
 		},
 	})
+
+	p2 := config.Processors["span/to_attributes"]
+	assert.Equal(t, p2, &Config{
+		ProcessorSettings: configmodels.ProcessorSettings{
+			TypeVal: typeStr,
+			NameVal: "span/to_attributes",
+		},
+		Rename: Name{
+			ToAttributes: &ToAttributes{
+				Rules: []string{`^\/api\/v1\/document\/(?P<documentId>.*)\/update$`},
+			},
+		},
+	})
 }

--- a/processor/spanprocessor/factory.go
+++ b/processor/spanprocessor/factory.go
@@ -34,7 +34,7 @@ const (
 // is not specified.
 // TODO https://github.com/open-telemetry/opentelemetry-collector/issues/215
 //	Move this to the error package that allows for span name and field to be specified.
-var errMissingRequiredField = errors.New("error creating \"span\" processor due to missing required field \"from_attributes\" in \"name:\"")
+var errMissingRequiredField = errors.New("error creating \"span\" processor: either \"from_attributes\" or \"to_attributes\" must be specified in \"name:\"")
 
 // Factory is the factory for the Span processor.
 type Factory struct {
@@ -61,10 +61,11 @@ func (f *Factory) CreateTraceProcessor(
 	nextConsumer consumer.TraceConsumer,
 	cfg configmodels.Processor) (processor.TraceProcessor, error) {
 
-	// 'from_attributes' under 'name' has to be set for the span processor to be valid.
-	// If not set and not enforced, the processor would do no work.
+	// 'from_attributes' or 'to_attributes' under 'name' has to be set for the span
+	// processor to be valid. If not set and not enforced, the processor would do no work.
 	oCfg := cfg.(*Config)
-	if len(oCfg.Rename.FromAttributes) == 0 {
+	if len(oCfg.Rename.FromAttributes) == 0 &&
+		(oCfg.Rename.ToAttributes == nil || len(oCfg.Rename.ToAttributes.Rules) == 0) {
 		return nil, errMissingRequiredField
 	}
 

--- a/processor/spanprocessor/span.go
+++ b/processor/spanprocessor/span.go
@@ -16,6 +16,8 @@ package spanprocessor
 
 import (
 	"context"
+	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -29,8 +31,18 @@ import (
 )
 
 type spanProcessor struct {
-	nextConsumer consumer.TraceConsumer
-	config       Config
+	nextConsumer     consumer.TraceConsumer
+	config           Config
+	toAttributeRules []toAttributeRule
+}
+
+// toAttributeRule is the compiled equivalent of config.ToAttributes field.
+type toAttributeRule struct {
+	// Compiled regexp.
+	re *regexp.Regexp
+
+	// Attribute names extracted from the regexp's subexpressions.
+	attrNames []string
 }
 
 // NewTraceProcessor returns the span processor.
@@ -44,16 +56,34 @@ func NewTraceProcessor(nextConsumer consumer.TraceConsumer, config Config) (proc
 		config:       config,
 	}
 
+	// Compile ToAttributes regexp and extract attributes names.
+	if config.Rename.ToAttributes != nil {
+		for _, pattern := range config.Rename.ToAttributes.Rules {
+			re, err := regexp.Compile(pattern)
+			if err != nil {
+				return nil, fmt.Errorf("invalid regexp pattern %s", pattern)
+			}
+
+			rule := toAttributeRule{
+				re: re,
+				// Subexpression names will become attribute names during extraction.
+				attrNames: re.SubexpNames(),
+			}
+
+			sp.toAttributeRules = append(sp.toAttributeRules, rule)
+		}
+	}
+
 	return sp, nil
 }
 
 func (sp *spanProcessor) ConsumeTraceData(ctx context.Context, td consumerdata.TraceData) error {
 	for _, span := range td.Spans {
-		if span == nil || span.Attributes == nil || len(span.Attributes.AttributeMap) == 0 {
+		if span == nil {
 			continue
 		}
-		// Name the span using attribute values.
-		sp.nameSpan(span)
+		sp.processFromAttributes(span)
+		sp.processToAttributes(span)
 	}
 	return sp.nextConsumer.ConsumeTraceData(ctx, td)
 }
@@ -72,7 +102,17 @@ func (sp *spanProcessor) Shutdown() error {
 	return nil
 }
 
-func (sp *spanProcessor) nameSpan(span *tracepb.Span) {
+func (sp *spanProcessor) processFromAttributes(span *tracepb.Span) {
+	if len(sp.config.Rename.FromAttributes) == 0 {
+		// There is FromAttributes rule.
+		return
+	}
+
+	if span.Attributes == nil || len(span.Attributes.AttributeMap) == 0 {
+		// There are no attributes to create span name from.
+		return
+	}
+
 	// Note: There was a separate proposal for creating the string.
 	// With benchmarking, strings.Builder is faster than the proposal.
 	// For full context, refer to this PR comment:
@@ -120,4 +160,81 @@ func (sp *spanProcessor) nameSpan(span *tracepb.Span) {
 		}
 	}
 	span.Name = &tracepb.TruncatableString{Value: sb.String()}
+}
+
+func (sp *spanProcessor) processToAttributes(span *tracepb.Span) {
+	if span.Name == nil || span.Name.Value == "" {
+		// There is no span name to work on.
+		return
+	}
+
+	if sp.config.Rename.ToAttributes == nil {
+		// No rules to apply.
+		return
+	}
+
+	// Process rules one by one. Store results of processing in the span
+	// so that each subsequent rule works on the span name that is the output
+	// after processing the previous rule.
+	for _, rule := range sp.toAttributeRules {
+		re := rule.re
+		oldName := span.Name.Value
+
+		// Match the regular expression and extract matched subexpressions.
+		submatches := re.FindStringSubmatch(oldName)
+		if submatches == nil {
+			continue
+		}
+		// There is a match. We will also need positions of subexpression matches.
+		submatchIdxPairs := re.FindStringSubmatchIndex(oldName)
+
+		// A place to accumulate new span name.
+		var sb strings.Builder
+
+		// Index in the oldName until which we traversed.
+		var oldNameIndex = 0
+
+		// Ensure we have a place to create attributes.
+		if span.Attributes == nil {
+			span.Attributes = &tracepb.Span_Attributes{}
+		}
+		attrs := span.Attributes
+
+		// Create a new map if one does not exist and size it to the number of
+		// attributes that we plan to extract.
+		if attrs.AttributeMap == nil {
+			attrs.AttributeMap = make(map[string]*tracepb.AttributeValue, len(rule.attrNames))
+		}
+
+		// Start from index 1, which is the first submatch (index 0 is the entire match).
+		// We will go over submatches and will simultaneously build a new span name,
+		// replacing matched subexpressions by attribute names.
+		for i := 1; i < len(submatches); i++ {
+			// Create a string attribute from extracted submatch.
+			attrValue := &tracepb.AttributeValue{Value: &tracepb.AttributeValue_StringValue{
+				StringValue: &tracepb.TruncatableString{Value: submatches[i]},
+			}}
+			attrs.AttributeMap[rule.attrNames[i]] = attrValue
+
+			// Add part of span name from end of previous match to start of this match
+			// and then add attribute name wrapped in curly brackets.
+			matchStartIndex := submatchIdxPairs[i*2] // start of i'th submatch.
+			sb.WriteString(oldName[oldNameIndex:matchStartIndex] + "{" + rule.attrNames[i] + "}")
+
+			// Advance the index to the end of current match.
+			oldNameIndex = submatchIdxPairs[i*2+1] // end of i'th submatch.
+		}
+		if oldNameIndex < len(oldName) {
+			// Append the remainder, from the end of last match until end of span name.
+			sb.WriteString(oldName[oldNameIndex:])
+		}
+
+		// Set new span name.
+		span.Name = &tracepb.TruncatableString{Value: sb.String()}
+
+		if sp.config.Rename.ToAttributes.BreakAfterMatch {
+			// Stop processing, break after first match is requested.
+			break
+		}
+	}
 }

--- a/processor/spanprocessor/testdata/config.yaml
+++ b/processor/spanprocessor/testdata/config.yaml
@@ -43,6 +43,28 @@ processors:
     name:
       from_attributes: [db.svc, operation, id]
 
+  # The following extracts attributes from span name and replaces extracted
+  # parts with attribute names.
+  # to_attributes is a list of rules that extract attribute values from span name and
+  # replace them by attributes names in the span name. Each rule in the list is
+  # regex pattern string. Span name is checked against the regex and if the regex matches
+  # all named subexpressions from the regex then the matches are extracted as attributes
+  # and added to the span. Subexpression name becomes the attribute name and
+  # subexpression matched portion becomes the attribute value. The matched portion
+  # in the span name is replaced by extracted attribute name. If the attributes exist
+  # they will be overwritten. Checks are performed for elements in this array in the
+  # order they are specified.
+  #
+  # Example:
+  # Let's assume input span name is /api/v1/document/12345678/update
+  # Applying the following results in output span name /api/v1/document/{documentId}/update
+  # and will add a new attribute "documentId"="12345678" to the span.
+  span/to_attributes:
+    name:
+      to_attributes:
+        rules:
+          - ^\/api\/v1\/document\/(?P<documentId>.*)\/update$
+
 exporters:
   exampleexporter:
 


### PR DESCRIPTION
This adds "to_attributes" functionality that complements already
existing "from_attributes" functionality. This is very useful for
extracting attributes from span names and reducing cardinality of
span names.

For usage and examples see rocessor/spanprocessor/config.go and
processor/spanprocessor/testdata/config.yaml.

Testing: unit tests added.
Documentation: see readme.md, config.go and config.yaml
