### PR TITLE
Add support for CONSUMER and PRODUCER span kinds

### DIFF
--- a/exporter/zipkinexporter/zipkin.go
+++ b/exporter/zipkinexporter/zipkin.go
@@ -18,9 +18,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"net"
 	"net/http"
-	"strconv"
 	"time"
 
 	commonpb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
@@ -35,7 +33,6 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumererror"
 	"github.com/open-telemetry/opentelemetry-collector/exporter"
 	"github.com/open-telemetry/opentelemetry-collector/exporter/exporterhelper"
-	tracetranslator "github.com/open-telemetry/opentelemetry-collector/translator/trace"
 	spandatatranslator "github.com/open-telemetry/opentelemetry-collector/translator/trace/spandata"
 	"github.com/open-telemetry/opentelemetry-collector/translator/trace/zipkin"
 )
@@ -107,86 +104,6 @@ func createZipkinExporter(logger *zap.Logger, config configmodels.Exporter) (*zi
 	return ze, nil
 }
 
-// zipkinEndpointFromAttributes extracts zipkin endpoint information
-// from a set of attributes (in the format of OC SpanData). It returns the built
-// zipkin endpoint and insert the attribute keys that were made redundant
-// (because now they can be represented by the endpoint) into the redundantKeys
-// map (function assumes that this was created by the caller). Per call at most
-// 3 attribute keys can be made redundant.
-func zipkinEndpointFromAttributes(
-	attributes map[string]interface{},
-	serviceName string,
-	endpointType zipkinDirection,
-	redundantKeys map[string]bool,
-) (endpoint *zipkinmodel.Endpoint) {
-
-	if attributes == nil {
-		return nil
-	}
-
-	// The data in the Attributes map was saved in the format
-	// {
-	//      "ipv4": "192.168.99.101",
-	//      "port": "9000",
-	//      "serviceName": "backend",
-	// }
-
-	var ipv4Key, ipv6Key, portKey string
-	if endpointType == isLocalEndpoint {
-		ipv4Key, ipv6Key, portKey = zipkin.LocalEndpointIPv4, zipkin.LocalEndpointIPv6, zipkin.LocalEndpointPort
-	} else {
-		ipv4Key, ipv6Key, portKey = zipkin.RemoteEndpointIPv4, zipkin.RemoteEndpointIPv6, zipkin.RemoteEndpointPort
-	}
-
-	var ip net.IP
-	ipv6Selected := false
-
-	if ipv4Str, ok := extractStringAttribute(attributes, ipv4Key); ok {
-		ip = net.ParseIP(ipv4Str)
-		redundantKeys[ipv4Key] = true
-	} else if ipv6Str, ok := extractStringAttribute(attributes, ipv6Key); ok {
-		ip = net.ParseIP(ipv6Str)
-		ipv6Selected = true
-		redundantKeys[ipv6Key] = true
-	}
-
-	var port uint64
-	if portStr, ok := extractStringAttribute(attributes, portKey); ok {
-		port, _ = strconv.ParseUint(portStr, 10, 16)
-		redundantKeys[portKey] = true
-	}
-
-	if serviceName == "" && len(ip) == 0 && port == 0 {
-		// Nothing to put on the endpoint
-		return nil
-	}
-
-	zEndpoint := &zipkinmodel.Endpoint{
-		ServiceName: serviceName,
-		Port:        uint16(port),
-	}
-
-	if ipv6Selected {
-		zEndpoint.IPv6 = ip
-	} else {
-		zEndpoint.IPv4 = ip
-	}
-
-	return zEndpoint
-}
-
-func extractStringAttribute(
-	attributes map[string]interface{},
-	key string,
-) (value string, ok bool) {
-	var i interface{}
-	if i, ok = attributes[key]; ok {
-		value, ok = i.(string)
-	}
-
-	return value, ok
-}
-
 func (ze *zipkinExporter) PushTraceData(ctx context.Context, td consumerdata.TraceData) (droppedSpans int, err error) {
 	tbatch := []*zipkinmodel.SpanModel{}
 	for _, span := range td.Spans {
@@ -220,204 +137,9 @@ func (ze *zipkinExporter) PushTraceData(ctx context.Context, td consumerdata.Tra
 	return 0, nil
 }
 
-// This code from down below is mostly copied from
-// https://github.com/census-instrumentation/opencensus-go/blob/96e75b88df843315da521168a0e3b11792088728/exporter/zipkin/zipkin.go#L57-L194
-// but that is because the Zipkin Go exporter requires process to change
-// and was designed without taking into account that LocalEndpoint and RemoteEndpoint
-// are per-span-Node attributes instead of global/system variables.
-// The alternative is to create a single exporter for every single combination
-// but this wastes resources i.e. an HTTP client for every single combination
-// but also requires the exporter to be changed entirely as per
-// https://github.com/census-instrumentation/opencensus-go/issues/959
-//
-// TODO: (@odeke-em) whenever we come to consensus with the OpenCensus-Go repository
-// on the Zipkin exporter and they have the same logic, then delete all the code
-// below here to allow per-span configuration changes.
-
-const (
-	statusCodeTagKey        = "error"
-	statusDescriptionTagKey = "opencensus.status_description"
-)
-
-var (
-	sampledTrue    = true
-	canonicalCodes = [...]string{
-		"OK",
-		"CANCELLED",
-		"UNKNOWN",
-		"INVALID_ARGUMENT",
-		"DEADLINE_EXCEEDED",
-		"NOT_FOUND",
-		"ALREADY_EXISTS",
-		"PERMISSION_DENIED",
-		"RESOURCE_EXHAUSTED",
-		"FAILED_PRECONDITION",
-		"ABORTED",
-		"OUT_OF_RANGE",
-		"UNIMPLEMENTED",
-		"INTERNAL",
-		"UNAVAILABLE",
-		"DATA_LOSS",
-		"UNAUTHENTICATED",
-	}
-)
-
-func canonicalCodeString(code int32) string {
-	if code < 0 || int(code) >= len(canonicalCodes) {
-		return "error code " + strconv.FormatInt(int64(code), 10)
-	}
-	return canonicalCodes[code]
-}
-
-func convertTraceID(t trace.TraceID) zipkinmodel.TraceID {
-	h, l, _ := tracetranslator.BytesToUInt64TraceID(t[:])
-	return zipkinmodel.TraceID{High: h, Low: l}
-}
-
-func convertSpanID(s trace.SpanID) zipkinmodel.ID {
-	id, _ := tracetranslator.BytesToUInt64SpanID(s[:])
-	return zipkinmodel.ID(id)
-}
-
-func spanKind(s *trace.SpanData) zipkinmodel.Kind {
-	switch s.SpanKind {
-	case trace.SpanKindClient:
-		return zipkinmodel.Client
-	case trace.SpanKindServer:
-		return zipkinmodel.Server
-	}
-	return zipkinmodel.Undetermined
-}
-
-func (ze *zipkinExporter) serviceNameOrDefault(node *commonpb.Node) string {
-	// ze.defaultServiceName should never change
-	defaultServiceName := ze.defaultServiceName
-
-	if node == nil || node.ServiceInfo == nil {
-		return defaultServiceName
-	}
-
-	if node.ServiceInfo.Name == "" {
-		return defaultServiceName
-	}
-
-	return node.ServiceInfo.Name
-}
-
-type zipkinDirection bool
-
-const (
-	isLocalEndpoint  zipkinDirection = true
-	isRemoteEndpoint zipkinDirection = false
-)
-
 func (ze *zipkinExporter) zipkinSpan(
 	node *commonpb.Node,
 	s *trace.SpanData,
 ) (zc zipkinmodel.SpanModel) {
-
-	// Per call to zipkinEndpointFromAttributes at most 3 attribute keys can be
-	// made redundant, give a hint when calling make that we expect at most 6
-	// items on the map.
-	redundantKeys := make(map[string]bool, 6)
-	localEndpointServiceName := ze.serviceNameOrDefault(node)
-	localEndpoint := zipkinEndpointFromAttributes(
-		s.Attributes, localEndpointServiceName, isLocalEndpoint, redundantKeys)
-
-	remoteServiceName := ""
-	if remoteServiceEntry, ok := s.Attributes[zipkin.RemoteEndpointServiceName]; ok {
-		if remoteServiceName, ok = remoteServiceEntry.(string); ok {
-			redundantKeys[zipkin.RemoteEndpointServiceName] = true
-		}
-	}
-	remoteEndpoint := zipkinEndpointFromAttributes(
-		s.Attributes, remoteServiceName, isRemoteEndpoint, redundantKeys)
-
-	sc := s.SpanContext
-	z := zipkinmodel.SpanModel{
-		SpanContext: zipkinmodel.SpanContext{
-			TraceID: convertTraceID(sc.TraceID),
-			ID:      convertSpanID(sc.SpanID),
-			Sampled: &sampledTrue,
-		},
-		Kind:           spanKind(s),
-		Name:           s.Name,
-		Timestamp:      s.StartTime,
-		Shared:         false,
-		LocalEndpoint:  localEndpoint,
-		RemoteEndpoint: remoteEndpoint,
-	}
-
-	if s.ParentSpanID != (trace.SpanID{}) {
-		id := convertSpanID(s.ParentSpanID)
-		z.ParentID = &id
-	}
-
-	if s, e := s.StartTime, s.EndTime; !s.IsZero() && !e.IsZero() {
-		z.Duration = e.Sub(s)
-	}
-
-	// construct Tags from s.Attributes and s.Status.
-	if len(s.Attributes) != 0 {
-		m := make(map[string]string, len(s.Attributes)+2)
-		for key, value := range s.Attributes {
-			if redundantKeys[key] {
-				// Already represented by something other than an attribute,
-				// skip it.
-				continue
-			}
-
-			switch v := value.(type) {
-			case string:
-				m[key] = v
-			case bool:
-				if v {
-					m[key] = "true"
-				} else {
-					m[key] = "false"
-				}
-			case int64:
-				m[key] = strconv.FormatInt(v, 10)
-			}
-		}
-		z.Tags = m
-	}
-	if s.Status.Code != 0 || s.Status.Message != "" {
-		if z.Tags == nil {
-			z.Tags = make(map[string]string, 2)
-		}
-		if s.Status.Code != 0 {
-			z.Tags[statusCodeTagKey] = canonicalCodeString(s.Status.Code)
-		}
-		if s.Status.Message != "" {
-			z.Tags[statusDescriptionTagKey] = s.Status.Message
-		}
-	}
-
-	// construct Annotations from s.Annotations and s.MessageEvents.
-	if len(s.Annotations) != 0 || len(s.MessageEvents) != 0 {
-		z.Annotations = make([]zipkinmodel.Annotation, 0, len(s.Annotations)+len(s.MessageEvents))
-		for _, a := range s.Annotations {
-			z.Annotations = append(z.Annotations, zipkinmodel.Annotation{
-				Timestamp: a.Time,
-				Value:     a.Message,
-			})
-		}
-		for _, m := range s.MessageEvents {
-			a := zipkinmodel.Annotation{
-				Timestamp: m.Time,
-			}
-			switch m.EventType {
-			case trace.MessageEventTypeSent:
-				a.Value = "SENT"
-			case trace.MessageEventTypeRecv:
-				a.Value = "RECV"
-			default:
-				a.Value = "<?>"
-			}
-			z.Annotations = append(z.Annotations, a)
-		}
-	}
-
-	return z
+	return zipkin.OCSpanDataToZipkin(node, s, ze.defaultServiceName)
 }

--- a/exporter/zipkinexporter/zipkin_test.go
+++ b/exporter/zipkinexporter/zipkin_test.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -37,106 +36,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector/processor"
 	"github.com/open-telemetry/opentelemetry-collector/receiver/zipkinreceiver"
 	"github.com/open-telemetry/opentelemetry-collector/testutils"
-	"github.com/open-telemetry/opentelemetry-collector/translator/trace/zipkin"
 )
-
-func TestZipkinEndpointFromNode(t *testing.T) {
-	type args struct {
-		attributes   map[string]interface{}
-		serviceName  string
-		endpointType zipkinDirection
-	}
-	type want struct {
-		endpoint      *zipkinmodel.Endpoint
-		redundantKeys map[string]bool
-	}
-	tests := []struct {
-		name string
-		args args
-		want want
-	}{
-		{
-			name: "Nil attributes",
-			args: args{attributes: nil, serviceName: "", endpointType: isLocalEndpoint},
-			want: want{
-				redundantKeys: make(map[string]bool),
-			},
-		},
-		{
-			name: "Only svc name",
-			args: args{
-				attributes:   make(map[string]interface{}),
-				serviceName:  "test",
-				endpointType: isLocalEndpoint,
-			},
-			want: want{
-				endpoint:      &zipkinmodel.Endpoint{ServiceName: "test"},
-				redundantKeys: make(map[string]bool),
-			},
-		},
-		{
-			name: "Only ipv4",
-			args: args{
-				attributes:   map[string]interface{}{"ipv4": "1.2.3.4"},
-				serviceName:  "",
-				endpointType: isLocalEndpoint,
-			},
-			want: want{
-				endpoint:      &zipkinmodel.Endpoint{IPv4: net.ParseIP("1.2.3.4")},
-				redundantKeys: map[string]bool{"ipv4": true},
-			},
-		},
-		{
-			name: "Only ipv6 remote",
-			args: args{
-				attributes:   map[string]interface{}{zipkin.RemoteEndpointIPv6: "2001:0db8:85a3:0000:0000:8a2e:0370:7334"},
-				serviceName:  "",
-				endpointType: isRemoteEndpoint,
-			},
-			want: want{
-				endpoint:      &zipkinmodel.Endpoint{IPv6: net.ParseIP("2001:0db8:85a3:0000:0000:8a2e:0370:7334")},
-				redundantKeys: map[string]bool{zipkin.RemoteEndpointIPv6: true},
-			},
-		},
-		{
-			name: "Only port",
-			args: args{
-				attributes:   map[string]interface{}{"port": "42"},
-				serviceName:  "",
-				endpointType: isLocalEndpoint,
-			},
-			want: want{
-				endpoint:      &zipkinmodel.Endpoint{Port: 42},
-				redundantKeys: map[string]bool{"port": true},
-			},
-		},
-		{
-			name: "Service name, ipv4, and port",
-			args: args{
-				attributes:   map[string]interface{}{"ipv4": "4.3.2.1", "port": "2"},
-				serviceName:  "test-svc",
-				endpointType: isLocalEndpoint,
-			},
-			want: want{
-				endpoint:      &zipkinmodel.Endpoint{ServiceName: "test-svc", IPv4: net.ParseIP("4.3.2.1"), Port: 2},
-				redundantKeys: map[string]bool{"ipv4": true, "port": true},
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			redundantKeys := make(map[string]bool)
-			endpoint := zipkinEndpointFromAttributes(
-				tt.args.attributes,
-				tt.args.serviceName,
-				tt.args.endpointType,
-				redundantKeys)
-			assert.Equal(t, tt.want.endpoint, endpoint)
-			assert.Equal(t, tt.want.redundantKeys, redundantKeys)
-		})
-	}
-}
 
 // This function tests that Zipkin spans that are received then processed roundtrip
 // back to almost the same JSON with differences:

--- a/translator/trace/jaeger/protospan_to_jaegerproto.go
+++ b/translator/trace/jaeger/protospan_to_jaegerproto.go
@@ -362,13 +362,14 @@ func ocMessageEventToJaegerTagsProto(msgEvent *tracepb.Span_TimeEvent_MessageEve
 
 // Replica of protospan_to_jaegerthrift appendJaegerTagFromOCSpanKind
 func appendJaegerTagFromOCSpanKindProto(jTags []jaeger.KeyValue, ocSpanKind tracepb.Span_SpanKind) []jaeger.KeyValue {
-	// TODO: (@pjanotti): Replace any OpenTracing literals by importing github.com/opentracing/opentracing-go/ext?
+	// Follow OpenTracing conventions to set span kind value as a tag.
+
 	var tagValue string
 	switch ocSpanKind {
 	case tracepb.Span_CLIENT:
-		tagValue = "client"
+		tagValue = string(tracetranslator.OpenTracingSpanKindClient)
 	case tracepb.Span_SERVER:
-		tagValue = "server"
+		tagValue = string(tracetranslator.OpenTracingSpanKindServer)
 	}
 
 	if tagValue != "" {

--- a/translator/trace/jaeger/protospan_to_jaegerthrift.go
+++ b/translator/trace/jaeger/protospan_to_jaegerthrift.go
@@ -295,20 +295,21 @@ func appendJaegerThriftTagFromOCStatus(jTags []*jaeger.Tag, ocStatus *tracepb.St
 }
 
 func appendJaegerTagFromOCSpanKind(jTags []*jaeger.Tag, ocSpanKind tracepb.Span_SpanKind) []*jaeger.Tag {
+	// Follow OpenTracing conventions to set span kind value as a tag.
 
-	// TODO: (@pjanotti): Replace any OpenTracing literals by importing github.com/opentracing/opentracing-go/ext?
 	var tagValue string
 	switch ocSpanKind {
 	case tracepb.Span_CLIENT:
-		tagValue = "client"
+		tagValue = string(tracetranslator.OpenTracingSpanKindClient)
 	case tracepb.Span_SERVER:
-		tagValue = "server"
+		tagValue = string(tracetranslator.OpenTracingSpanKindServer)
 	}
 
 	if tagValue != "" {
 		jTag := &jaeger.Tag{
-			Key:  tracetranslator.TagSpanKind,
-			VStr: &tagValue,
+			Key:   tracetranslator.TagSpanKind,
+			VStr:  &tagValue,
+			VType: jaeger.TagType_STRING,
 		}
 		jTags = append(jTags, jTag)
 	}

--- a/translator/trace/protospan_translation.go
+++ b/translator/trace/protospan_translation.go
@@ -32,3 +32,19 @@ const (
 	TagZipkinCensusCode = "census.status_code"
 	TagZipkinCensusMsg  = "census.status_description"
 )
+
+// OpenTracingSpanKind are possible values for TagSpanKind and match the OpenTracing
+// conventions: https://github.com/opentracing/specification/blob/master/semantic_conventions.md
+// These values are also used for representing internally span kinds that have no
+// equivalents in OpenCensus format. They are stored as values of TagSpanKind
+// Note: this internal usage needs to be eliminated when we move to OTLP for internal
+// in-memory representation since OTLP has the equivalents.
+type OpenTracingSpanKind string
+
+const (
+	OpenTracingSpanKindUnspecified OpenTracingSpanKind = ""
+	OpenTracingSpanKindClient      OpenTracingSpanKind = "client"
+	OpenTracingSpanKindServer      OpenTracingSpanKind = "server"
+	OpenTracingSpanKindConsumer    OpenTracingSpanKind = "consumer"
+	OpenTracingSpanKindProducer    OpenTracingSpanKind = "producer"
+)

--- a/translator/trace/zipkin/protospan_to_zipkinv1.go
+++ b/translator/trace/zipkin/protospan_to_zipkinv1.go
@@ -1,0 +1,323 @@
+// Copyright 2019 OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package zipkin
+
+import (
+	"net"
+	"strconv"
+
+	commonpb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
+	zipkinmodel "github.com/openzipkin/zipkin-go/model"
+	"go.opencensus.io/trace"
+
+	tracetranslator "github.com/open-telemetry/opentelemetry-collector/translator/trace"
+)
+
+const (
+	statusCodeTagKey        = "error"
+	statusDescriptionTagKey = "opencensus.status_description"
+)
+
+var (
+	sampledTrue    = true
+	canonicalCodes = [...]string{
+		"OK",
+		"CANCELLED",
+		"UNKNOWN",
+		"INVALID_ARGUMENT",
+		"DEADLINE_EXCEEDED",
+		"NOT_FOUND",
+		"ALREADY_EXISTS",
+		"PERMISSION_DENIED",
+		"RESOURCE_EXHAUSTED",
+		"FAILED_PRECONDITION",
+		"ABORTED",
+		"OUT_OF_RANGE",
+		"UNIMPLEMENTED",
+		"INTERNAL",
+		"UNAVAILABLE",
+		"DATA_LOSS",
+		"UNAUTHENTICATED",
+	}
+)
+
+func canonicalCodeString(code int32) string {
+	if code < 0 || int(code) >= len(canonicalCodes) {
+		return "error code " + strconv.FormatInt(int64(code), 10)
+	}
+	return canonicalCodes[code]
+}
+
+// zipkinEndpointFromAttributes extracts zipkin endpoint information
+// from a set of attributes (in the format of OC SpanData). It returns the built
+// zipkin endpoint and insert the attribute keys that were made redundant
+// (because now they can be represented by the endpoint) into the redundantKeys
+// map (function assumes that this was created by the caller). Per call at most
+// 3 attribute keys can be made redundant.
+func zipkinEndpointFromAttributes(
+	attributes map[string]interface{},
+	serviceName string,
+	endpointType zipkinDirection,
+	redundantKeys map[string]bool,
+) (endpoint *zipkinmodel.Endpoint) {
+
+	if attributes == nil {
+		return nil
+	}
+
+	// The data in the Attributes map was saved in the format
+	// {
+	//      "ipv4": "192.168.99.101",
+	//      "port": "9000",
+	//      "serviceName": "backend",
+	// }
+
+	var ipv4Key, ipv6Key, portKey string
+	if endpointType == isLocalEndpoint {
+		ipv4Key, ipv6Key, portKey = LocalEndpointIPv4, LocalEndpointIPv6, LocalEndpointPort
+	} else {
+		ipv4Key, ipv6Key, portKey = RemoteEndpointIPv4, RemoteEndpointIPv6, RemoteEndpointPort
+	}
+
+	var ip net.IP
+	ipv6Selected := false
+
+	if ipv4Str, ok := extractStringAttribute(attributes, ipv4Key); ok {
+		ip = net.ParseIP(ipv4Str)
+		redundantKeys[ipv4Key] = true
+	} else if ipv6Str, ok := extractStringAttribute(attributes, ipv6Key); ok {
+		ip = net.ParseIP(ipv6Str)
+		ipv6Selected = true
+		redundantKeys[ipv6Key] = true
+	}
+
+	var port uint64
+	if portStr, ok := extractStringAttribute(attributes, portKey); ok {
+		port, _ = strconv.ParseUint(portStr, 10, 16)
+		redundantKeys[portKey] = true
+	}
+
+	if serviceName == "" && len(ip) == 0 && port == 0 {
+		// Nothing to put on the endpoint
+		return nil
+	}
+
+	zEndpoint := &zipkinmodel.Endpoint{
+		ServiceName: serviceName,
+		Port:        uint16(port),
+	}
+
+	if ipv6Selected {
+		zEndpoint.IPv6 = ip
+	} else {
+		zEndpoint.IPv4 = ip
+	}
+
+	return zEndpoint
+}
+
+func extractStringAttribute(
+	attributes map[string]interface{},
+	key string,
+) (value string, ok bool) {
+	var i interface{}
+	if i, ok = attributes[key]; ok {
+		value, ok = i.(string)
+	}
+
+	return value, ok
+}
+
+func convertTraceID(t trace.TraceID) zipkinmodel.TraceID {
+	h, l, _ := tracetranslator.BytesToUInt64TraceID(t[:])
+	return zipkinmodel.TraceID{High: h, Low: l}
+}
+
+func convertSpanID(s trace.SpanID) zipkinmodel.ID {
+	id, _ := tracetranslator.BytesToUInt64SpanID(s[:])
+	return zipkinmodel.ID(id)
+}
+
+func spanKind(s *trace.SpanData) zipkinmodel.Kind {
+	// First try span kinds that are set directly in SpanKind field.
+	switch s.SpanKind {
+	case trace.SpanKindClient:
+		return zipkinmodel.Client
+	case trace.SpanKindServer:
+		return zipkinmodel.Server
+	}
+
+	// SpanKind==SpanKindUnspecified, check if TagSpanKind attribute is set.
+	// This can happen if span kind had no equivalent in OC, so we could represent it in
+	// the SpanKind. In that case we had set a special attribute TagSpanKind in
+	// the span to preserve the span kind. Now we will do a reverse translation.
+	spanKind := s.Attributes[tracetranslator.TagSpanKind]
+	if spanKind != nil {
+		// Yes the attribute is present. Check that it is a string.
+		spanKindStr, ok := spanKind.(string)
+		kind := zipkinmodel.Undetermined
+		if ok {
+			// Check if it is one of the kinds that are defined by conventions.
+			switch tracetranslator.OpenTracingSpanKind(spanKindStr) {
+			case tracetranslator.OpenTracingSpanKindClient:
+				kind = zipkinmodel.Client
+			case tracetranslator.OpenTracingSpanKindServer:
+				kind = zipkinmodel.Server
+			case tracetranslator.OpenTracingSpanKindConsumer:
+				kind = zipkinmodel.Consumer
+			case tracetranslator.OpenTracingSpanKindProducer:
+				kind = zipkinmodel.Producer
+			default:
+				// Unknown kind. Keep the attribute, but return Undetermined to our caller.
+				return zipkinmodel.Undetermined
+			}
+			// The special attribute is no longer needed, delete it.
+			delete(s.Attributes, tracetranslator.TagSpanKind)
+		}
+		return kind
+	}
+	return zipkinmodel.Undetermined
+}
+
+type zipkinDirection bool
+
+const (
+	isLocalEndpoint  zipkinDirection = true
+	isRemoteEndpoint zipkinDirection = false
+)
+
+func serviceNameOrDefault(node *commonpb.Node, defaultServiceName string) string {
+	if node == nil || node.ServiceInfo == nil {
+		return defaultServiceName
+	}
+
+	if node.ServiceInfo.Name == "" {
+		return defaultServiceName
+	}
+
+	return node.ServiceInfo.Name
+}
+
+func OCSpanDataToZipkin(
+	node *commonpb.Node,
+	s *trace.SpanData,
+	defaultServiceName string,
+) (zc zipkinmodel.SpanModel) {
+
+	// Per call to zipkinEndpointFromAttributes at most 3 attribute keys can be
+	// made redundant, give a hint when calling make that we expect at most 6
+	// items on the map.
+	redundantKeys := make(map[string]bool, 6)
+	localEndpointServiceName := serviceNameOrDefault(node, defaultServiceName)
+	localEndpoint := zipkinEndpointFromAttributes(
+		s.Attributes, localEndpointServiceName, isLocalEndpoint, redundantKeys)
+
+	remoteServiceName := ""
+	if remoteServiceEntry, ok := s.Attributes[RemoteEndpointServiceName]; ok {
+		if remoteServiceName, ok = remoteServiceEntry.(string); ok {
+			redundantKeys[RemoteEndpointServiceName] = true
+		}
+	}
+	remoteEndpoint := zipkinEndpointFromAttributes(
+		s.Attributes, remoteServiceName, isRemoteEndpoint, redundantKeys)
+
+	sc := s.SpanContext
+	z := zipkinmodel.SpanModel{
+		SpanContext: zipkinmodel.SpanContext{
+			TraceID: convertTraceID(sc.TraceID),
+			ID:      convertSpanID(sc.SpanID),
+			Sampled: &sampledTrue,
+		},
+		Kind:           spanKind(s),
+		Name:           s.Name,
+		Timestamp:      s.StartTime,
+		Shared:         false,
+		LocalEndpoint:  localEndpoint,
+		RemoteEndpoint: remoteEndpoint,
+	}
+
+	if s.ParentSpanID != (trace.SpanID{}) {
+		id := convertSpanID(s.ParentSpanID)
+		z.ParentID = &id
+	}
+
+	if s, e := s.StartTime, s.EndTime; !s.IsZero() && !e.IsZero() {
+		z.Duration = e.Sub(s)
+	}
+
+	// construct Tags from s.Attributes and s.Status.
+	if len(s.Attributes) != 0 {
+		m := make(map[string]string, len(s.Attributes)+2)
+		for key, value := range s.Attributes {
+			if redundantKeys[key] {
+				// Already represented by something other than an attribute,
+				// skip it.
+				continue
+			}
+
+			switch v := value.(type) {
+			case string:
+				m[key] = v
+			case bool:
+				if v {
+					m[key] = "true"
+				} else {
+					m[key] = "false"
+				}
+			case int64:
+				m[key] = strconv.FormatInt(v, 10)
+			}
+		}
+		z.Tags = m
+	}
+	if s.Status.Code != 0 || s.Status.Message != "" {
+		if z.Tags == nil {
+			z.Tags = make(map[string]string, 2)
+		}
+		if s.Status.Code != 0 {
+			z.Tags[statusCodeTagKey] = canonicalCodeString(s.Status.Code)
+		}
+		if s.Status.Message != "" {
+			z.Tags[statusDescriptionTagKey] = s.Status.Message
+		}
+	}
+
+	// construct Annotations from s.Annotations and s.MessageEvents.
+	if len(s.Annotations) != 0 || len(s.MessageEvents) != 0 {
+		z.Annotations = make([]zipkinmodel.Annotation, 0, len(s.Annotations)+len(s.MessageEvents))
+		for _, a := range s.Annotations {
+			z.Annotations = append(z.Annotations, zipkinmodel.Annotation{
+				Timestamp: a.Time,
+				Value:     a.Message,
+			})
+		}
+		for _, m := range s.MessageEvents {
+			a := zipkinmodel.Annotation{
+				Timestamp: m.Time,
+			}
+			switch m.EventType {
+			case trace.MessageEventTypeSent:
+				a.Value = "SENT"
+			case trace.MessageEventTypeRecv:
+				a.Value = "RECV"
+			default:
+				a.Value = "<?>"
+			}
+			z.Annotations = append(z.Annotations, a)
+		}
+	}
+
+	return z
+}

--- a/translator/trace/zipkin/protospan_to_zipkinv1_test.go
+++ b/translator/trace/zipkin/protospan_to_zipkinv1_test.go
@@ -1,0 +1,121 @@
+// Copyright 2019 OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package zipkin
+
+import (
+	"net"
+	"testing"
+
+	zipkinmodel "github.com/openzipkin/zipkin-go/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestZipkinEndpointFromNode(t *testing.T) {
+	type args struct {
+		attributes   map[string]interface{}
+		serviceName  string
+		endpointType zipkinDirection
+	}
+	type want struct {
+		endpoint      *zipkinmodel.Endpoint
+		redundantKeys map[string]bool
+	}
+	tests := []struct {
+		name string
+		args args
+		want want
+	}{
+		{
+			name: "Nil attributes",
+			args: args{attributes: nil, serviceName: "", endpointType: isLocalEndpoint},
+			want: want{
+				redundantKeys: make(map[string]bool),
+			},
+		},
+		{
+			name: "Only svc name",
+			args: args{
+				attributes:   make(map[string]interface{}),
+				serviceName:  "test",
+				endpointType: isLocalEndpoint,
+			},
+			want: want{
+				endpoint:      &zipkinmodel.Endpoint{ServiceName: "test"},
+				redundantKeys: make(map[string]bool),
+			},
+		},
+		{
+			name: "Only ipv4",
+			args: args{
+				attributes:   map[string]interface{}{"ipv4": "1.2.3.4"},
+				serviceName:  "",
+				endpointType: isLocalEndpoint,
+			},
+			want: want{
+				endpoint:      &zipkinmodel.Endpoint{IPv4: net.ParseIP("1.2.3.4")},
+				redundantKeys: map[string]bool{"ipv4": true},
+			},
+		},
+		{
+			name: "Only ipv6 remote",
+			args: args{
+				attributes:   map[string]interface{}{RemoteEndpointIPv6: "2001:0db8:85a3:0000:0000:8a2e:0370:7334"},
+				serviceName:  "",
+				endpointType: isRemoteEndpoint,
+			},
+			want: want{
+				endpoint:      &zipkinmodel.Endpoint{IPv6: net.ParseIP("2001:0db8:85a3:0000:0000:8a2e:0370:7334")},
+				redundantKeys: map[string]bool{RemoteEndpointIPv6: true},
+			},
+		},
+		{
+			name: "Only port",
+			args: args{
+				attributes:   map[string]interface{}{"port": "42"},
+				serviceName:  "",
+				endpointType: isLocalEndpoint,
+			},
+			want: want{
+				endpoint:      &zipkinmodel.Endpoint{Port: 42},
+				redundantKeys: map[string]bool{"port": true},
+			},
+		},
+		{
+			name: "Service name, ipv4, and port",
+			args: args{
+				attributes:   map[string]interface{}{"ipv4": "4.3.2.1", "port": "2"},
+				serviceName:  "test-svc",
+				endpointType: isLocalEndpoint,
+			},
+			want: want{
+				endpoint:      &zipkinmodel.Endpoint{ServiceName: "test-svc", IPv4: net.ParseIP("4.3.2.1"), Port: 2},
+				redundantKeys: map[string]bool{"ipv4": true, "port": true},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			redundantKeys := make(map[string]bool)
+			endpoint := zipkinEndpointFromAttributes(
+				tt.args.attributes,
+				tt.args.serviceName,
+				tt.args.endpointType,
+				redundantKeys)
+			assert.Equal(t, tt.want.endpoint, endpoint)
+			assert.Equal(t, tt.want.redundantKeys, redundantKeys)
+		})
+	}
+}

--- a/translator/trace/zipkin/zipkinv1_thrift_to_protospan.go
+++ b/translator/trace/zipkin/zipkinv1_thrift_to_protospan.go
@@ -102,6 +102,8 @@ func zipkinV1ThriftToOCSpan(zSpan *zipkincore.Span) (*tracepb.Span, *annotationP
 		ocSpan.Name = &tracepb.TruncatableString{Value: zSpan.Name}
 	}
 
+	setSpanKind(ocSpan, parsedAnnotations.Kind, parsedAnnotations.ExtendedKind)
+
 	return ocSpan, parsedAnnotations, nil
 }
 


### PR DESCRIPTION
Previously these span kinds were not supported because OpenCensus
does not have equivalent span kinds and they were translated as
"Unspecified" span kind when received by Zipkin receiver.

Now these span kinds are internally stored in a span attribute
named "span.kind" when received by Zipkin receiver. When exporting,
this attribute is used to perform a reverse translation in Zipkin
exporter. "span.kind" also matches the OpenTracing semantic
conventions so it should be correctly interpreted by any backend
that follows this convention.

## To reviewers:
The code that does translation from OC to Zipkin is moved from
exporter/zipkinexporter/zipkin.go to translator/trace/zipkin/protospan_to_zipkinv1.go. protospan_to_zipkinv1.go is not all
new code, only the code that deals with span kind is to be reviewed.

Testing done:
- Added a unit test to verify translations between Zipkin,OC and Jaeger.
- TODO: Add E2E test to verify these translations on real pipelines.
