### PR TITLE
Add file exporter

### DIFF
--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -18,6 +18,7 @@ package defaults
 import (
 	"github.com/open-telemetry/opentelemetry-collector/config"
 	"github.com/open-telemetry/opentelemetry-collector/exporter"
+	"github.com/open-telemetry/opentelemetry-collector/exporter/fileexporter"
 	"github.com/open-telemetry/opentelemetry-collector/exporter/jaeger/jaegergrpcexporter"
 	"github.com/open-telemetry/opentelemetry-collector/exporter/jaeger/jaegerthrifthttpexporter"
 	"github.com/open-telemetry/opentelemetry-collector/exporter/loggingexporter"
@@ -79,6 +80,7 @@ func Components() (
 		&zipkinexporter.Factory{},
 		&jaegergrpcexporter.Factory{},
 		&jaegerthrifthttpexporter.Factory{},
+		&fileexporter.Factory{},
 	)
 	if err != nil {
 		errs = append(errs, err)

--- a/defaults/defaults_test.go
+++ b/defaults/defaults_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/open-telemetry/opentelemetry-collector/exporter"
+	"github.com/open-telemetry/opentelemetry-collector/exporter/fileexporter"
 	"github.com/open-telemetry/opentelemetry-collector/exporter/jaeger/jaegergrpcexporter"
 	"github.com/open-telemetry/opentelemetry-collector/exporter/jaeger/jaegerthrifthttpexporter"
 	"github.com/open-telemetry/opentelemetry-collector/exporter/loggingexporter"
@@ -76,6 +77,7 @@ func TestDefaultComponents(t *testing.T) {
 		"zipkin":             &zipkinexporter.Factory{},
 		"jaeger_grpc":        &jaegergrpcexporter.Factory{},
 		"jaeger_thrift_http": &jaegerthrifthttpexporter.Factory{},
+		"file":               &fileexporter.Factory{},
 	}
 
 	factories, err := Components()

--- a/exporter/fileexporter/config.go
+++ b/exporter/fileexporter/config.go
@@ -1,0 +1,27 @@
+// Copyright 2019, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fileexporter
+
+import (
+	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
+)
+
+// Config defines configuration for file exporter.
+type Config struct {
+	configmodels.ExporterSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct.
+
+	// Path of the file to write to. Path is relative to current directory.
+	Path string `mapstructure:"path"`
+}

--- a/exporter/fileexporter/config_test.go
+++ b/exporter/fileexporter/config_test.go
@@ -1,0 +1,51 @@
+// Copyright 2019, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fileexporter
+
+import (
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-telemetry/opentelemetry-collector/config"
+	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
+)
+
+func TestLoadConfig(t *testing.T) {
+	factories, err := config.ExampleComponents()
+	assert.Nil(t, err)
+
+	factory := &Factory{}
+	factories.Exporters[typeStr] = factory
+	cfg, err := config.LoadConfigFile(t, path.Join(".", "testdata", "config.yaml"), factories)
+
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+
+	e0 := cfg.Exporters["file"]
+	assert.Equal(t, e0, factory.CreateDefaultConfig())
+
+	e1 := cfg.Exporters["file/2"]
+	assert.Equal(t, e1,
+		&Config{
+			ExporterSettings: configmodels.ExporterSettings{
+				NameVal: "file/2",
+				TypeVal: "file",
+			},
+			Path: "./filename.json",
+		})
+}

--- a/exporter/fileexporter/factory.go
+++ b/exporter/fileexporter/factory.go
@@ -1,0 +1,86 @@
+// Copyright 2019, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fileexporter
+
+import (
+	"os"
+
+	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
+	"github.com/open-telemetry/opentelemetry-collector/exporter"
+)
+
+const (
+	// The value of "type" key in configuration.
+	typeStr = "file"
+)
+
+// Factory is the factory for logging exporter.
+type Factory struct {
+}
+
+// Type gets the type of the Exporter config created by this factory.
+func (f *Factory) Type() string {
+	return typeStr
+}
+
+// CreateDefaultConfig creates the default configuration for exporter.
+func (f *Factory) CreateDefaultConfig() configmodels.Exporter {
+	return &Config{
+		ExporterSettings: configmodels.ExporterSettings{
+			TypeVal: typeStr,
+			NameVal: typeStr,
+		},
+	}
+}
+
+// CreateTraceExporter creates a trace exporter based on this config.
+func (f *Factory) CreateTraceExporter(logger *zap.Logger, config configmodels.Exporter) (exporter.TraceExporter, error) {
+	return f.createExporter(config)
+}
+
+// CreateMetricsExporter creates a metrics exporter based on this config.
+func (f *Factory) CreateMetricsExporter(logger *zap.Logger, config configmodels.Exporter) (exporter.MetricsExporter, error) {
+	return f.createExporter(config)
+}
+
+func (f *Factory) createExporter(config configmodels.Exporter) (*Exporter, error) {
+	cfg := config.(*Config)
+
+	// There must be one exporter for both metrics and traces. We maintain a map of
+	// exporters per config.
+
+	// Check to see if there is already a exporter for this config.
+	exporter, ok := exporters[cfg]
+
+	if !ok {
+		file, err := os.OpenFile(cfg.Path, os.O_RDWR|os.O_CREATE, 0755)
+		if err != nil {
+			return nil, err
+		}
+		exporter = &Exporter{file: file}
+
+		// Remember the receiver in the map
+		exporters[cfg] = exporter
+	}
+	return exporter, nil
+}
+
+// This is the map of already created File exporters for particular configurations.
+// We maintain this map because the Factory is asked trace and metric receivers separately
+// when it gets CreateTraceReceiver() and CreateMetricsReceiver() but they must not
+// create separate objects, they must use one Receiver object per configuration.
+var exporters = map[*Config]*Exporter{}

--- a/exporter/fileexporter/factory_test.go
+++ b/exporter/fileexporter/factory_test.go
@@ -1,0 +1,47 @@
+// Copyright 2019, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fileexporter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector/config/configcheck"
+)
+
+func TestCreateDefaultConfig(t *testing.T) {
+	factory := Factory{}
+	cfg := factory.CreateDefaultConfig()
+	assert.NotNil(t, cfg, "failed to create default config")
+	assert.NoError(t, configcheck.ValidateConfig(cfg))
+}
+
+func TestCreateMetricsExporter(t *testing.T) {
+	factory := &Factory{}
+	cfg := factory.CreateDefaultConfig()
+
+	_, err := factory.CreateMetricsExporter(zap.NewNop(), cfg)
+	assert.Error(t, err)
+}
+
+func TestCreateTraceExporter(t *testing.T) {
+	factory := &Factory{}
+	cfg := factory.CreateDefaultConfig()
+
+	_, err := factory.CreateTraceExporter(zap.NewNop(), cfg)
+	assert.Error(t, err)
+}

--- a/exporter/fileexporter/file_exporter.go
+++ b/exporter/fileexporter/file_exporter.go
@@ -1,0 +1,207 @@
+// Copyright 2019, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fileexporter
+
+import (
+	"context"
+	"io"
+	"sync"
+
+	commonpb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
+	resourcepb "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
+	"github.com/golang/protobuf/jsonpb"
+	"github.com/golang/protobuf/proto"
+
+	"github.com/open-telemetry/opentelemetry-collector/component"
+	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
+)
+
+// Marshaler configuration used for marhsaling Protobuf to JSON. Use default config.
+var marshaler = &jsonpb.Marshaler{}
+
+// Helper struct to write JSON objects and arrays.
+type jsonWriter struct {
+	firstFieldDone     bool
+	firstArrayItemDone bool
+	writer             io.Writer
+}
+
+// Begin writing JSON. Call first.
+func (jw *jsonWriter) Begin() error {
+	_, err := io.WriteString(jw.writer, "{\n")
+	return err
+}
+
+// End writing JSON. Call last.
+func (jw *jsonWriter) End() error {
+	_, err := io.WriteString(jw.writer, "\n}\n")
+	return err
+}
+
+// MarshalObject marshals an object as a field of top-level object.
+func (jw *jsonWriter) MarshalObject(fieldName string, pb proto.Message) error {
+	if jw.firstFieldDone {
+		io.WriteString(jw.writer, ",\n")
+	} else {
+		jw.firstFieldDone = true
+	}
+	_, err := io.WriteString(jw.writer, `  "`+fieldName+`": `)
+	if err != nil {
+		return err
+	}
+
+	err = marshaler.Marshal(jw.writer, pb)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// BeginMarshalArray prepares to marshal array items under a field of top-level object.
+func (jw *jsonWriter) BeginMarshalArray(fieldName string) error {
+	if jw.firstFieldDone {
+		io.WriteString(jw.writer, ",\n")
+	} else {
+		jw.firstFieldDone = true
+	}
+	_, err := io.WriteString(jw.writer, `  "`+fieldName+"\": [")
+	jw.firstArrayItemDone = false
+	return err
+}
+
+// EndMarshalArray must be called after all array items are marshaled.
+func (jw *jsonWriter) EndMarshalArray() error {
+	var str string
+	if jw.firstArrayItemDone {
+		// Non-empty array. End on a new line.
+		str = "\n  ]"
+	} else {
+		// Empty array. End on the same line.
+		str = "]"
+	}
+	_, err := io.WriteString(jw.writer, str)
+	return err
+}
+
+// MarshalArrayItem marshals single array item. Call repeatedly after BeginMarshalArray.
+func (jw *jsonWriter) MarshalArrayItem(pb proto.Message) error {
+	var str string
+	if jw.firstArrayItemDone {
+		str = ",\n    "
+	} else {
+		str = "\n    "
+		jw.firstArrayItemDone = true
+	}
+	_, err := io.WriteString(jw.writer, str)
+	if err != nil {
+		return err
+	}
+	err = marshaler.Marshal(jw.writer, pb)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func exportResourceAndNode(writer *jsonWriter, node *commonpb.Node, resource *resourcepb.Resource) error {
+	if resource != nil {
+		err := writer.MarshalObject("resource", resource)
+		if err != nil {
+			return err
+		}
+	}
+	if node != nil {
+		return writer.MarshalObject("node", node)
+	}
+	return nil
+}
+
+// Exporter is the implementation of file exporter that writes telemetry data to a file
+// in Protobuf-JSON format.
+type Exporter struct {
+	file  io.WriteCloser
+	mutex sync.Mutex
+}
+
+func (e *Exporter) ConsumeTraceData(ctx context.Context, td consumerdata.TraceData) error {
+	// Ensure only one write operation happens at a time.
+	e.mutex.Lock()
+	defer e.mutex.Unlock()
+
+	// Prepare to write JSON object.
+	jw := &jsonWriter{writer: e.file}
+	if err := jw.Begin(); err != nil {
+		return err
+	}
+	defer jw.End()
+
+	if err := exportResourceAndNode(jw, td.Node, td.Resource); err != nil {
+		return err
+	}
+
+	if err := jw.BeginMarshalArray("spans"); err != nil {
+		return err
+	}
+	defer jw.EndMarshalArray()
+
+	for _, span := range td.Spans {
+		if span != nil {
+			if err := jw.MarshalArrayItem(span); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (e *Exporter) ConsumeMetricsData(ctx context.Context, md consumerdata.MetricsData) error {
+	// Ensure only one write operation happens at a time.
+	e.mutex.Lock()
+	defer e.mutex.Unlock()
+
+	// Prepare to write JSON object.
+	jw := &jsonWriter{writer: e.file}
+	if err := jw.Begin(); err != nil {
+		return err
+	}
+	defer jw.End()
+
+	if err := exportResourceAndNode(jw, md.Node, md.Resource); err != nil {
+		return err
+	}
+
+	if err := jw.BeginMarshalArray("metrics"); err != nil {
+		return err
+	}
+	defer jw.EndMarshalArray()
+
+	for _, metric := range md.Metrics {
+		if metric != nil {
+			if err := jw.MarshalArrayItem(metric); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (e *Exporter) Start(host component.Host) error {
+	return nil
+}
+
+// Shutdown stops the exporter and is invoked during shutdown.
+func (e *Exporter) Shutdown() error {
+	return e.file.Close()
+}

--- a/exporter/fileexporter/file_exporter_test.go
+++ b/exporter/fileexporter/file_exporter_test.go
@@ -1,0 +1,151 @@
+// Copyright 2019, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package fileexporter
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"testing"
+
+	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
+	resourcepb "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
+	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
+)
+
+type mockFile struct {
+	buf bytes.Buffer
+}
+
+func (mf *mockFile) Write(p []byte) (n int, err error) {
+	return mf.buf.Write(p)
+}
+
+func (mf *mockFile) Close() error {
+	return nil
+}
+
+func TestFileTraceExporterNoErrors(t *testing.T) {
+	mf := &mockFile{}
+	lte := &Exporter{file: mf}
+	require.NotNil(t, lte)
+
+	td := consumerdata.TraceData{
+		Resource: &resourcepb.Resource{
+			Type:   "ServiceA",
+			Labels: map[string]string{"attr1": "value1"},
+		},
+		Spans: []*tracepb.Span{
+			{
+				TraceId: []byte("123"),
+				SpanId:  []byte("456"),
+				Name:    &tracepb.TruncatableString{Value: "Checkout"},
+				Kind:    tracepb.Span_CLIENT,
+			},
+			{
+				Name: &tracepb.TruncatableString{Value: "Frontend"},
+				Kind: tracepb.Span_SERVER,
+			},
+		},
+	}
+	assert.NoError(t, lte.ConsumeTraceData(context.Background(), td))
+	assert.NoError(t, lte.Shutdown())
+
+	var j map[string]interface{}
+	assert.NoError(t, json.Unmarshal(mf.buf.Bytes(), &j))
+
+	assert.EqualValues(t, j,
+		map[string]interface{}{
+			"resource": map[string]interface{}{
+				"type":   "ServiceA",
+				"labels": map[string]interface{}{"attr1": "value1"},
+			},
+			"spans": []interface{}{
+				map[string]interface{}{
+					"traceId": "MTIz", // base64 encoding of "123"
+					"spanId":  "NDU2", // base64 encoding of "456"
+					"kind":    "CLIENT",
+					"name":    map[string]interface{}{"value": "Checkout"},
+				},
+				map[string]interface{}{
+					"kind": "SERVER",
+					"name": map[string]interface{}{"value": "Frontend"},
+				},
+			},
+		})
+}
+
+func TestFileMetricsExporterNoErrors(t *testing.T) {
+	mf := &mockFile{}
+	lme := &Exporter{file: mf}
+	require.NotNil(t, lme)
+
+	md := consumerdata.MetricsData{
+		Resource: &resourcepb.Resource{
+			Type:   "ServiceA",
+			Labels: map[string]string{"attr1": "value1"},
+		},
+		Metrics: []*metricspb.Metric{
+			{
+				MetricDescriptor: &metricspb.MetricDescriptor{
+					Name:        "my-metric",
+					Description: "My metric",
+					Type:        metricspb.MetricDescriptor_GAUGE_INT64,
+				},
+				Timeseries: []*metricspb.TimeSeries{
+					{
+						Points: []*metricspb.Point{
+							{Value: &metricspb.Point_Int64Value{Int64Value: 123}},
+						},
+					},
+				},
+			},
+		},
+	}
+	assert.NoError(t, lme.ConsumeMetricsData(context.Background(), md))
+	assert.NoError(t, lme.Shutdown())
+
+	var j map[string]interface{}
+	assert.NoError(t, json.Unmarshal(mf.buf.Bytes(), &j))
+
+	assert.EqualValues(t, j,
+		map[string]interface{}{
+			"resource": map[string]interface{}{
+				"type":   "ServiceA",
+				"labels": map[string]interface{}{"attr1": "value1"},
+			},
+			"metrics": []interface{}{
+				map[string]interface{}{
+					"metricDescriptor": map[string]interface{}{
+						"name":        "my-metric",
+						"description": "My metric",
+						"type":        "GAUGE_INT64",
+					},
+					"timeseries": []interface{}{
+						map[string]interface{}{
+							"points": []interface{}{
+								map[string]interface{}{
+									"int64Value": "123",
+								},
+							},
+						},
+					},
+				},
+			},
+		})
+}

--- a/exporter/fileexporter/testdata/config.yaml
+++ b/exporter/fileexporter/testdata/config.yaml
@@ -1,0 +1,26 @@
+receivers:
+  examplereceiver:
+
+processors:
+  exampleprocessor:
+
+exporters:
+  file:
+  file/2:
+    # This will write the pipeline data to a JSON file.
+    # The data is written in Protobuf JSON encoding
+    # (https://developers.google.com/protocol-buffers/docs/proto3#json).
+    # Note that there are no compatibility guarantees for this format, since it
+    # just a dump of internal structures which can be changed over time.
+    # This intended for primarily for debugging Collector without setting up backends.
+    path: ./filename.json
+
+service:
+  pipelines:
+    traces:
+      receivers: [examplereceiver]
+      processors: [exampleprocessor]
+      exporters: [file]
+    metrics:
+      receivers: [examplereceiver]
+      exporters: [file,file/2]


### PR DESCRIPTION
This exporter is very useful for debugging receivers and processors.
It allows to export the pipeline data to a JSON file and examine as needed.
The data is written in OpenCensus Protobuf JSON encoding
(https://developers.google.com/protocol-buffers/docs/proto3#json).

**Testing:** unit tests and tested manually.