### PR TITLE
Add regexp support to service name include/exclude filters

### DIFF
--- a/processor/README.md
+++ b/processor/README.md
@@ -148,15 +148,24 @@ attributes:
       # It is supported to have more than one specified, but all of the specified
       # conditions must evaluate to true for a match to occur.
 
-      # Services specify the list of service name to match against.
-      # A match occurs if the span service name is in this list.
-      # Note: This is an optional field.
-      services: [<key1>, ..., <keyN>]
-      # The span name must match "login.*" or "auth.*" pattern.
-      span_names: ["login.*", "auth.*"]
+      # match_type controls how items in "services" and "span_names" arrays are
+      # interpreted. Possible values are "regexp" or "strict".
+      # This is a required field.
+      match_type: {strict, regexp}
+
+      # services specify an array of items to match the service name against.
+      # A match occurs if the span service name matches at least of the items.
+      # This is an optional field.
+      services: [<item1>, ..., <itemN>]
+
+      # The span name must match at least one of the items.
+      # This is an optional field.
+      span_names: [<item1>, ..., <itemN>]
+
       # Attributes specifies the list of attributes to match against.
       # All of these attributes must match exactly for a match to occur.
-      # Note: This is an optional field.
+      # Only match_type=strict is allowed if "attributes" are specified.
+      # This is an optional field.
       attributes:
           # Key specifies the attribute to match against.
         - key: <key>

--- a/processor/attributesprocessor/config.go
+++ b/processor/attributesprocessor/config.go
@@ -132,24 +132,43 @@ const (
 // Please refer to testdata/config.yaml for valid configurations.
 type MatchProperties struct {
 
+	// MatchType controls how items in "services" and "span_names" arrays are
+	// interpreted. Possible values are "regexp" or "strict".
+	MatchType MatchType `mapstructure:"match_type"`
+
 	// Note: one of Services, SpanNames or Attributes must be specified with a
 	// non-empty value for a valid configuration.
 
-	// Services specify the list of service name to match against.
-	// A match occurs if the span's service name is in this list.
+	// Services specify the list of of items to match service name against.
+	// A match occurs if the span's service name matches at least one item in this list.
 	// This is an optional field.
 	Services []string `mapstructure:"services"`
 
-	// SpanNames specify the list of regexps to match span name against.
-	// A match occurs if the span name matches at least one regexp item in this list.
+	// SpanNames specify the list of items to match span name against.
+	// A match occurs if the span name matches at least one item in this list.
 	// This is an optional field.
 	SpanNames []string `mapstructure:"span_names"`
 
 	// Attributes specifies the list of attributes to match against.
 	// All of these attributes must match exactly for a match to occur.
+	// Only match_type=strict is allowed if "attributes" are specified.
 	// This is an optional field.
 	Attributes []Attribute `mapstructure:"attributes"`
 }
+
+// MatchType defines possible match types.
+type MatchType string
+
+const (
+	MatchTypeRegexp MatchType = "regexp"
+	MatchTypeStrict MatchType = "strict"
+)
+
+// MatchTypeFieldName is the mapstructure field name for MatchProperties.MatchType field.
+const MatchTypeFieldName = "match_type"
+
+// MatchTypeFieldName is the mapstructure field name for MatchProperties.Attributes field.
+const AttributesFieldName = "attributes"
 
 // Attribute specifies the attribute key and optional value to match against.
 type Attribute struct {

--- a/processor/attributesprocessor/config_test.go
+++ b/processor/attributesprocessor/config_test.go
@@ -91,7 +91,8 @@ func TestLoadingConifg(t *testing.T) {
 			TypeVal: typeStr,
 		},
 		Exclude: &MatchProperties{
-			Services: []string{"svcA", "svcB"},
+			MatchType: MatchTypeStrict,
+			Services:  []string{"svcA", "svcB"},
 			Attributes: []Attribute{
 				{Key: "env", Value: "dev"},
 				{Key: "test_request"},
@@ -110,7 +111,8 @@ func TestLoadingConifg(t *testing.T) {
 			TypeVal: typeStr,
 		},
 		Include: &MatchProperties{
-			Services: []string{"svcA", "svcB"},
+			MatchType: MatchTypeRegexp,
+			Services:  []string{"auth.*", "login.*"},
 		},
 		Actions: []ActionKeyValue{
 			{Key: "credit_card", Action: DELETE},
@@ -125,9 +127,11 @@ func TestLoadingConifg(t *testing.T) {
 			TypeVal: typeStr,
 		},
 		Include: &MatchProperties{
-			Services: []string{"svcA", "svcB"},
+			MatchType: MatchTypeStrict,
+			Services:  []string{"svcA", "svcB"},
 		},
 		Exclude: &MatchProperties{
+			MatchType: MatchTypeStrict,
 			Attributes: []Attribute{
 				{Key: "redact_trace", Value: false},
 			},
@@ -173,9 +177,11 @@ func TestLoadingConifg(t *testing.T) {
 			TypeVal: typeStr,
 		},
 		Include: &MatchProperties{
-			Services: []string{"auth"},
+			MatchType: MatchTypeRegexp,
+			Services:  []string{"auth.*"},
 		},
 		Exclude: &MatchProperties{
+			MatchType: MatchTypeRegexp,
 			SpanNames: []string{"login.*"},
 		},
 		Actions: []ActionKeyValue{

--- a/processor/attributesprocessor/testdata/config.yaml
+++ b/processor/attributesprocessor/testdata/config.yaml
@@ -75,7 +75,10 @@ processors:
   attributes/excludemulti:
     # Specifies the spans properties that exclude a span from being processed.
     exclude:
-      # The Span service name must either be "svcA" or "svcB" to match.
+      # match_type defines that "services" is an array of strings that must
+      # match service name strictly.
+      match_type: strict
+      # The Span service name must be equal to "svcA" or "svcB".
       services: ["svcA", "svcB"]
       attributes:
         # This exact attribute ('env', 'dev') must exist in the span for a match.
@@ -102,8 +105,10 @@ processors:
   attributes/includeservices:
     # Specifies the span properties that must exist for the processor to be applied.
     include:
-      # The Span service name must either be "svcA" or "svcB" to match.
-      services: ["svcA", "svcB"]
+      # match_type defines that "services" is an array of regexp-es.
+      match_type: regexp
+      # The Span service name must match "auth.*" or "login.*" regexp.
+      services: ["auth.*", "login.*"]
     actions:
       - key: credit_card
         action: delete
@@ -125,9 +130,15 @@ processors:
   attributes/selectiveprocessing:
     # Specifies the span properties that must exist for the processor to be applied.
     include:
-      # The Span service name must either be "svcA" or "svcB" to match.
+      # match_type defines that "services" is an array of strings that must
+      # match service name strictly.
+      match_type: strict
+      # The Span service name must be equal to "svcA" or "svcB".
       services: ["svcA", "svcB"]
     exclude:
+      # match_type defines that "attributes" values must match strictly. It is the
+      # only supported match_type for "attributes" setting.
+      match_type: strict
       attributes:
         - { key: redact_trace, value: false}
     actions:
@@ -192,16 +203,20 @@ processors:
       - key: account_password
         action: delete
 
-  # The following demonstrates how to process spans that have a specified service name and
-  # span name that matches the regexp pattern. This processor will remove "token" attribute
-  # and will obfuscate "password" attribute in spans where service name is "auth"
+  # The following demonstrates how to process spans that have a service name and span
+  # name that match regexp patterns. This processor will remove "token" attribute
+  # and will obfuscate "password" attribute in spans where service name matches "auth.*"
   # and where span name does not match "login.*".
   attributes/regexp:
     # Specifies the span properties that must exist for the processor to be applied.
     include:
-      # The span service name must be "auth".
-      services: ["auth"]
+      # match_type defines that "services" is an array of regexp-es.
+      match_type: regexp
+      # The span service name must match "auth.*" pattern.
+      services: ["auth.*"]
     exclude:
+      # match_type defines that "services" is an array of regexp-es.
+      match_type: regexp
       # The span name must not match "login.*" pattern.
       span_names: ["login.*"]
     actions:


### PR DESCRIPTION
- Added regexp support to service name field in include/exclude
  filters of attributes processor. This makes it consistent with
  span name fields which already use regexp patterns.

- Added match_type to make service name and span name matching explicit.

Testing: added unit and E2E tests.
Documentation: README modified as appropriate.