### PR TITLE
Ensure file exporter truncates output file when starting

### DIFF
--- a/exporter/fileexporter/factory.go
+++ b/exporter/fileexporter/factory.go
@@ -67,7 +67,7 @@ func (f *Factory) createExporter(config configmodels.Exporter) (*Exporter, error
 	exporter, ok := exporters[cfg]
 
 	if !ok {
-		file, err := os.OpenFile(cfg.Path, os.O_RDWR|os.O_CREATE, 0755)
+		file, err := os.OpenFile(cfg.Path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0755)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Previously file exporter could write to existing file without truncating it.
Truncating is the desired behavior so that the file contains the new data only.
