### PR TITLE
Record dropped spans when zero

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -211,6 +211,7 @@ github.com/go-toolsmith/strparse v1.0.0 h1:Vcw78DnpCAKlM20kSbAyO4mPfJn/lyYA4BJUD
 github.com/go-toolsmith/strparse v1.0.0/go.mod h1:YI2nUKP9YGZnL/L1/DLFBfixrcjslWct4wyljWhSRy8=
 github.com/go-toolsmith/typep v1.0.0 h1:zKymWyA1TRYvqYrYDrfEMZULyrhcnGY3x7LDKU2XQaA=
 github.com/go-toolsmith/typep v1.0.0/go.mod h1:JSQCQMUPdRlMZFswiq3TGpNp1GMktqkR2Ns5AIQkATU=
+github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/gofrs/flock v0.0.0-20190320160742-5135e617513b h1:ekuhfTjngPhisSjOJ0QWKpPQE8/rbknHaes6WVJj5Hw=
 github.com/gofrs/flock v0.0.0-20190320160742-5135e617513b/go.mod h1:F1TvTiK9OcQqauNUHlbJvyl9Qa1QvF/gOUDKA14jxHU=

--- a/processor/metrics.go
+++ b/processor/metrics.go
@@ -41,6 +41,11 @@ var (
 		"bad_batch_spans_dropped",
 		"counts the number of spans dropped due to being in bad batches",
 		stats.UnitDimensionless)
+
+	StatBatchesDroppedCount = stats.Int64(
+		"batches_dropped",
+		"counts the number of batches dropped",
+		stats.UnitDimensionless)
 )
 
 // MetricTagKeys returns the metric tag keys according to the given telemetry level.
@@ -78,11 +83,10 @@ func MetricViews(level telemetry.Level) []*view.View {
 		Aggregation: view.Count(),
 	}
 	droppedBatchesView := &view.View{
-		Name:        "batches_dropped",
-		Measure:     StatDroppedSpanCount,
+		Measure:     StatBatchesDroppedCount,
 		Description: "The number of span batches dropped.",
 		TagKeys:     tagKeys,
-		Aggregation: view.Count(),
+		Aggregation: view.Sum(),
 	}
 	droppedBadBatchesView := &view.View{
 		Name:        "bad_batches_dropped",

--- a/processor/queuedprocessor/queued_processor.go
+++ b/processor/queuedprocessor/queued_processor.go
@@ -224,8 +224,7 @@ func (sp *queuedSpanProcessor) processItemFromQueue(item *queueItem) {
 
 func (sp *queuedSpanProcessor) onItemDropped(item *queueItem, statsTags []tag.Mutator) {
 	numSpans := len(item.td.Spans)
-	stats.RecordWithTags(context.Background(), statsTags, processor.StatDroppedSpanCount.M(int64(numSpans)))
-	stats.RecordWithTags(context.Background(), statsTags, processor.StatBatchesDroppedCount.M(int64(1)))
+	stats.RecordWithTags(context.Background(), statsTags, processor.StatDroppedSpanCount.M(int64(numSpans)), processor.StatBatchesDroppedCount.M(int64(1)))
 
 	sp.logger.Warn("Span batch dropped",
 		zap.String("processor", sp.name),

--- a/processor/queuedprocessor/queued_processor.go
+++ b/processor/queuedprocessor/queued_processor.go
@@ -61,6 +61,9 @@ func NewQueuedSpanProcessor(sender consumer.TraceConsumer, opts ...Option) proce
 	options := Options.apply(opts...)
 	sp := newQueuedSpanProcessor(sender, options)
 
+	// emit 0's so that the metric is present and reported, rather than absent
+	stats.Record(context.Background(), processor.StatBatchesDroppedCount.M(int64(0)), processor.StatDroppedSpanCount.M(int64(0)))
+
 	sp.queue.StartConsumers(sp.numWorkers, func(item interface{}) {
 		value := item.(*queueItem)
 		sp.processItemFromQueue(value)
@@ -150,11 +153,11 @@ func (sp *queuedSpanProcessor) Shutdown() error {
 func (sp *queuedSpanProcessor) processItemFromQueue(item *queueItem) {
 	startTime := time.Now()
 	err := sp.sender.ConsumeTraceData(item.ctx, item.td)
+	statsTags := processor.StatsTagsForBatch(sp.name, processor.ServiceNameForNode(item.td.Node), item.td.SourceFormat)
 	if err == nil {
 		// Record latency metrics and return
 		sendLatencyMs := int64(time.Since(startTime) / time.Millisecond)
 		inQueueLatencyMs := int64(time.Since(item.queuedTime) / time.Millisecond)
-		statsTags := processor.StatsTagsForBatch(sp.name, processor.ServiceNameForNode(item.td.Node), item.td.SourceFormat)
 		stats.RecordWithTags(context.Background(),
 			statsTags,
 			statSuccessSendOps.M(1),
@@ -165,7 +168,6 @@ func (sp *queuedSpanProcessor) processItemFromQueue(item *queueItem) {
 	}
 
 	// There was an error
-	statsTags := processor.StatsTagsForBatch(sp.name, processor.ServiceNameForNode(item.td.Node), item.td.SourceFormat)
 
 	// Immediately drop data on permanent errors. In this context permanent
 	// errors indicate some kind of bad data.
@@ -223,6 +225,7 @@ func (sp *queuedSpanProcessor) processItemFromQueue(item *queueItem) {
 func (sp *queuedSpanProcessor) onItemDropped(item *queueItem, statsTags []tag.Mutator) {
 	numSpans := len(item.td.Spans)
 	stats.RecordWithTags(context.Background(), statsTags, processor.StatDroppedSpanCount.M(int64(numSpans)))
+	stats.RecordWithTags(context.Background(), statsTags, processor.StatBatchesDroppedCount.M(int64(1)))
 
 	sp.logger.Warn("Span batch dropped",
 		zap.String("processor", sp.name),

--- a/processor/queuedprocessor/queued_processor_test.go
+++ b/processor/queuedprocessor/queued_processor_test.go
@@ -17,17 +17,21 @@ package queuedprocessor
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opencensus.io/stats/view"
 
 	"github.com/open-telemetry/opentelemetry-collector/consumer"
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumererror"
+	"github.com/open-telemetry/opentelemetry-collector/internal/collector/telemetry"
 	"github.com/open-telemetry/opentelemetry-collector/processor"
 )
 
@@ -82,7 +86,20 @@ func (c *waitGroupTraceConsumer) GetCapabilities() processor.Capabilities {
 	return processor.Capabilities{MutatesConsumedData: false}
 }
 
+func findViewNamed(views []*view.View, name string) (*view.View, error) {
+	for _, v := range views {
+		if v.Name == name {
+			return v, nil
+		}
+	}
+	return nil, fmt.Errorf("view %s not found", name)
+}
+
 func TestQueueProcessorHappyPath(t *testing.T) {
+	views := processor.MetricViews(telemetry.Detailed)
+	view.Register(views...)
+	defer view.Unregister(views...)
+
 	mockProc := newMockConcurrentSpanProcessor()
 	qp := NewQueuedSpanProcessor(mockProc)
 	goFn := func(td consumerdata.TraceData) {
@@ -108,6 +125,18 @@ func TestQueueProcessorHappyPath(t *testing.T) {
 
 	require.Equal(t, wantBatches, int(mockProc.batchCount), "Incorrect batches count")
 	require.Equal(t, wantSpans, int(mockProc.spanCount), "Incorrect batches spans")
+
+	droppedView, err := findViewNamed(views, processor.StatDroppedSpanCount.Name())
+	require.NoError(t, err)
+
+	data, err := view.RetrieveData(droppedView.Name)
+	require.NoError(t, err)
+	require.Len(t, data, 1)
+	assert.Equal(t, 0.0, data[0].Data.(*view.SumData).Value)
+
+	data, err = view.RetrieveData("batches_dropped")
+	require.NoError(t, err)
+	assert.Equal(t, 0.0, data[0].Data.(*view.SumData).Value)
 }
 
 type mockConcurrentSpanProcessor struct {


### PR DESCRIPTION
Change "batches_dropped" to a .Sum(), and emit 0s for them on processor start.

Motivation:
   Currently with batches_dropped being a .Count() we end up with a missing metric for bad_batches until one occurs.  This makes discovering the "error" metrics I want to watch kind of annoying as I can't just look in the default prom metric list and choose what I want to dashboard / alert on.

   I also think that for things we KNOW are 0, we should be emitting a 0.  If we send 8000 batches, the bad_batches shouldn't be *absent* it should be 0.  I do think that view.Count()'s should be initialized to 0 as well ( but I may not know the whole story there. )

I can add these to the other processors if we think this is a good idea.  For now I just hoped the metric name is correct in my current production dashboards.

**Testing:** 
   I added some happy path metric tests to the processor.  I can figure out a way to add bad path tests, it will just require a bunch of plumbing I think.

**Documentation:** I think the metrics as a whole need better documentation, for example I "fail_sends" in the exporter wasn't actually an error.  Maybe a distinction between data loss events or not?  