### PR TITLE
Fix usage string of logger level flag

### DIFF
--- a/service/logger.go
+++ b/service/logger.go
@@ -31,7 +31,7 @@ var (
 )
 
 func loggerFlags(flags *flag.FlagSet) {
-	loggerLevelPtr = flags.String(logLevelCfg, "INFO", "Output level of logs (TRACE, DEBUG, INFO, WARN, ERROR, FATAL)")
+	loggerLevelPtr = flags.String(logLevelCfg, "INFO", "Output level of logs (DEBUG, INFO, WARN, ERROR, DPANIC, PANIC, FATAL)")
 }
 
 func newLogger() (*zap.Logger, error) {


### PR DESCRIPTION
**Description:**
Remove invalid `TRACE` level & add missing `DPANIC`, `PANIC` levels to logger level flag's (`--log-level`) usage string.

**Link to tracking Issue:**
Fixes #531 

**Testing:**
N/A

**Documentation:**
N/A