### PR TITLE
Export start time metric, consistent with other metrics.

### DIFF
--- a/receiver/prometheusreceiver/internal/metricsbuilder.go
+++ b/receiver/prometheusreceiver/internal/metricsbuilder.go
@@ -105,7 +105,6 @@ func (b *metricBuilder) AddDataPoint(ls labels.Labels, t int64, v float64) error
 		return nil
 	} else if b.useStartTimeMetric && metricName == startTimeMetricName {
 		b.startTime = v
-		return nil
 	}
 
 	b.hasData = true

--- a/receiver/prometheusreceiver/metrics_receiver_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_test.go
@@ -1000,7 +1000,7 @@ process_start_time_seconds 400.8
 
 var startTimeMetricPageStartTimestamp = &timestamppb.Timestamp{Seconds: 400, Nanos: 800000000}
 
-const numStartTimeMetricPageTimeseries = 5
+const numStartTimeMetricPageTimeseries = 6
 
 func verifyStartTimeMetricPage(t *testing.T, td *testData, mds []consumerdata.MetricsData) {
 	numTimeseries := 0


### PR DESCRIPTION
**Description:** The Prometheus receiver currently drops the process start time metric when it is used to set the start time for scraped metrics but this is inconsistent with how other metrics are handled and prevents users from accessing the metric.

**Testing:** The associated metrics receiver unit test to verify that the metric is no longer dropped.