### PR TITLE
Add Dockerfile for building binaries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,12 +9,17 @@ COPY go.mod .
 COPY go.sum .
 RUN go mod download
 
-ADD . .
+COPY Makefile .
 RUN make install-tools
-RUN make otelcol
 
-FROM alpine:3.10
-COPY --from=build /src/bin/linux/otelcol /otelcol
+ADD . .
+ARG target=otelcol
+RUN make ${target}
+
+
+FROM scratch
+COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=build /src/bin/linux/${target} /otel
 
 EXPOSE 55678 55679
-ENTRYPOINT ["/otelcol"]
+ENTRYPOINT ["/otel"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.13 as build
+WORKDIR /src
+
+ADD . .
+RUN go mod download
+RUN make install-tools
+RUN make otelcol
+
+FROM alpine:3.10
+COPY --from=build /src/bin/linux/otelcol /otelcol
+
+EXPOSE 55678 55679
+ENTRYPOINT ["/otelcol"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,7 @@
+FROM alpine:3.10 as certs
+RUN apk --update add ca-certificates
+
+
 FROM golang:1.13 as build
 WORKDIR /src
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,11 @@
 FROM golang:1.13 as build
 WORKDIR /src
 
-ADD . .
+COPY go.mod .
+COPY go.sum .
 RUN go mod download
+
+ADD . .
 RUN make install-tools
 RUN make otelcol
 


### PR DESCRIPTION
**Description:** This commit adds a Dockerfile that will build the OTEL binary.

**Link to tracking Issue:** _none_

**Testing:** Built successfully locally

**Documentation:** None, as it is a straightforward `docker build` and its behaviour is in-line with the convention of how a `Dockerfile` in a repo root is expected to work.