### PR TITLE
Add the Observability Report Package

### DIFF
--- a/obsreport/doc.go
+++ b/obsreport/doc.go
@@ -38,7 +38,10 @@
 //
 // The package is capable of generating legacy metrics by using the
 // observability package allowing a controlled transition from legacy to the
-// new metrics. The main differences regarding the legacy metrics are:
+// new metrics. The goal is to eventually remove the legacy metrics and use only
+// the new metrics.
+//
+// The main differences regarding the legacy metrics are:
 //
 // 1. "Amount of metric data" is measured as metric points (ie.: a single value
 // in time), contrast it with number of time series used legacy. Number of
@@ -47,11 +50,34 @@
 //
 // 2. Exporters measure the number of items, ie.: number of spans or metric
 // points, that were sent and the ones for which the attempt to send failed.
-// Legacy treated the latter as "dropped" data but depending on configuration
-// it is not certain that the data was actually dropped, ie.: there may be a
-// processor, like the "queued_retry", taking care of a retry.
+// For more information about this see Notes below about reporting data loss.
 //
-// 3. All measurements of "amount of data" used in the new metrics should
-// reflect their native formats, not internal formats of the Collector. This is
-// to facilitate reconciliation between the Collector, client and backend.
+// 3. All measurements of "amount of data" used in the new metrics for receivers
+// and exporters should reflect their native formats, not the internal format
+// used in the Collector. This is to facilitate reconciliation between Collector,
+// client and backend. For instance: certain metric formats do not provide
+// direct support for histograms and have predefined conventions to represent
+// those, this conversion may end with a different number of time series and
+// data points than the internal Collector format.
+//
+// Notes:
+//
+// * Data loss should be recorded only when the component itself remove the data
+// from the pipeline. Legacy metrics for receivers used "dropped" in their names
+// but these could be non-zero under normal operations and reflected no actual
+// data loss when components like the "queued_retry" are used. New metrics
+// were renamed to avoid this misunderstanding. Here are the general
+// recommendations to report data loss:
+//
+// 		* Receivers reporting errors to clients typically result in the client
+//		  re-sending the same data so it is more correct to report "receive errors",
+//		  not actual data loss.
+//
+//		* Exporters need to report individual failures to send data, but on
+//		  typical production pipelines processors usually take care of retries,
+//		  so these should be reported as "send errors".
+//
+//		* Data "filtered out" should have its own metrics and not be confused
+//		  with dropped data.
+//
 package obsreport

--- a/obsreport/doc.go
+++ b/obsreport/doc.go
@@ -1,0 +1,57 @@
+// Copyright 2020 OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package obsreport provides unified and consistent observability signals (
+// metrics, tracing, etc) for components of the OpenTelemetry collector.
+//
+// The function Configure is used to control which signals are going to be
+// generated. It provides functions for the typical operations of receivers,
+// processors, and exporters.
+//
+// Receivers should use the respective start and end according to the data type
+// being received, ie.:
+//
+// 	* TraceData receive operations should use the pair:
+// 		StartTraceDataReceiveOp/EndTraceDataReceiveOp
+//
+// 	* Metrics receive operations should use the pair:
+// 		StartMetricsReceiveOp/EndMetricsReceiveOp
+//
+// Similar for exporters:
+//
+// 	* TraceData export operations should use the pair:
+// 		StartTraceDataExportOp/EndTraceDataExportOp
+//
+// 	* Metrics export operations should use the pair:
+// 		StartMetricsExportOp/EndMetricsExportOp
+//
+// The package is capable of generating legacy metrics by using the
+// observability package allowing a controlled transition from legacy to the
+// new metrics. The main differences regarding the legacy metrics are:
+//
+// 1. "Amount of metric data" is measured as metric points (ie.: a single value
+// in time), contrast it with number of time series used legacy. Number of
+// metric data points is a more general concept regarding various metric
+// formats.
+//
+// 2. Exporters measure the number of items, ie.: number of spans or metric
+// points, that were sent and the ones for which the attempt to send failed.
+// Legacy treated the latter as "dropped" data but depending on configuration
+// it is not certain that the data was actually dropped, ie.: there may be a
+// processor, like the "queued_retry", taking care of a retry.
+//
+// 3. All measurements of "amount of data" used in the new metrics should
+// reflect their native formats, not internal formats of the Collector. This is
+// to facilitate reconciliation between the Collector, client and backend.
+package obsreport

--- a/obsreport/obsreport.go
+++ b/obsreport/obsreport.go
@@ -1,0 +1,114 @@
+// Copyright 2020 OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package obsreport
+
+import (
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
+	"go.opencensus.io/trace"
+
+	"github.com/open-telemetry/opentelemetry-collector/observability"
+)
+
+// Identifies the type of the observability data being received or exported.
+type dataType int
+
+const (
+	noDataType dataType = iota
+	traceData
+	metricsData
+
+	nameSep = "/"
+)
+
+var (
+	// Variables to control the usage of legacy and new metrics.
+	useLegacy = true
+	useNew    = true
+
+	okStatus = trace.Status{Code: trace.StatusCodeOK}
+)
+
+// Configure is used to control the settings that will be used by the obsreport
+// package.
+func Configure(
+	generateLegacy, generateNew bool,
+) (views []*view.View) {
+
+	// TODO: expose some level control, similar to telemetry.Level
+
+	useLegacy = generateLegacy
+	useNew = generateNew
+
+	if useLegacy {
+		views = append(views, observability.AllViews...)
+	}
+
+	if useNew {
+		views = append(views, genAllViews()...)
+	}
+
+	return views
+}
+
+func genAllViews() (views []*view.View) {
+	// Receiver views.
+	measures := []*stats.Int64Measure{
+		mReceiverAcceptedSpans, mReceiverRefusedSpans,
+		mReceiverAcceptedMetricPoints, mReceiverRefusedMetricPoints,
+	}
+	tagKeys := []tag.Key{
+		tagKeyReceiver, tagKeyTransport,
+	}
+	views = append(views, genViews(
+		measures, tagKeys, view.Sum())...)
+
+	// Exporter views.
+	measures = []*stats.Int64Measure{
+		mExporterSentSpans, mExporterFailedToSendSpans,
+		mExporterSentMetricPoints, mExporterFailedToSendMetricPoints,
+	}
+	tagKeys = []tag.Key{tagKeyExporter}
+	views = append(views, genViews(
+		measures, tagKeys, view.Sum())...)
+
+	return views
+}
+
+func genViews(
+	measures []*stats.Int64Measure,
+	tagKeys []tag.Key,
+	aggregation *view.Aggregation,
+) []*view.View {
+	views := make([]*view.View, 0, len(measures))
+	for _, measure := range measures {
+		views = append(views, &view.View{
+			Name:        measure.Name(),
+			Description: measure.Description(),
+			TagKeys:     tagKeys,
+			Measure:     measure,
+			Aggregation: aggregation,
+		})
+	}
+	return views
+}
+
+func errToStatus(err error) trace.Status {
+	if err != nil {
+		return trace.Status{Code: trace.StatusCodeUnknown, Message: err.Error()}
+	}
+	return okStatus
+}

--- a/obsreport/obsreport.go
+++ b/obsreport/obsreport.go
@@ -23,14 +23,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector/observability"
 )
 
-// Identifies the type of the observability data being received or exported.
-type dataType int
-
 const (
-	noDataType dataType = iota
-	traceData
-	metricsData
-
 	nameSep = "/"
 )
 

--- a/obsreport/obsreport_exporter.go
+++ b/obsreport/obsreport_exporter.go
@@ -1,0 +1,216 @@
+// Copyright 2020 OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package obsreport
+
+import (
+	"context"
+
+	"go.opencensus.io/stats"
+	"go.opencensus.io/tag"
+	"go.opencensus.io/trace"
+
+	"github.com/open-telemetry/opentelemetry-collector/observability"
+)
+
+const (
+	ExporterKey = "exporter"
+
+	SentSpansKey         = "sent_spans"
+	FailedToSendSpansKey = "send_failed_spans"
+
+	SentMetricPointsKey         = "sent_metric_points"
+	FailedToSendMetricPointsKey = "send_failed_metric_points"
+)
+
+var (
+	tagKeyExporter, _ = tag.NewKey(ExporterKey)
+
+	exporterPrefix                 = ExporterKey + nameSep
+	exportTraceDataOperationSuffix = nameSep + "TraceDataExported"
+	exportMetricsOperationSuffix   = nameSep + "MetricsExported"
+
+	// Exporter metrics. Any count of data items below is in the final format
+	// that they were sent, reasoning: reconciliation is easier if measurements
+	// on backend and exporter are expected to be the same. Translation issues
+	// that result in a different number of elements should be reported in a
+	// separate way.
+	mExporterSentSpans = stats.Int64(
+		exporterPrefix+SentSpansKey,
+		"Number of spans successfully sent to destination.",
+		stats.UnitDimensionless)
+	mExporterFailedToSendSpans = stats.Int64(
+		exporterPrefix+FailedToSendSpansKey,
+		"Number of spans in failed attempts to send to destination.",
+		stats.UnitDimensionless)
+	mExporterSentMetricPoints = stats.Int64(
+		exporterPrefix+SentMetricPointsKey,
+		"Number of metric points successfully sent to destination.",
+		stats.UnitDimensionless)
+	mExporterFailedToSendMetricPoints = stats.Int64(
+		exporterPrefix+RefusedMetricPointsKey,
+		"Number of metric points in failed attempts to send to destination.",
+		stats.UnitDimensionless)
+)
+
+// StartTraceDataExportOp is called at the start of an Export operation.
+// The returned context should be used in other calls to the obsreport functions
+// dealing with the same export operation.
+func StartTraceDataExportOp(ctx context.Context, exporter string) (context.Context, *trace.Span) {
+	return traceExportDataOp(
+		exporterContext(ctx, exporter),
+		exporter,
+		exportTraceDataOperationSuffix)
+}
+
+// EndTraceDataExportOp completes the export operation that was started with
+// StartTraceDataExportOp.
+func EndTraceDataExportOp(
+	ctx context.Context,
+	span *trace.Span,
+	numExportedSpans int,
+	numDroppedSpans int, // TODO: For legacy measurements, to be removed in the future.
+	err error,
+) {
+	if useLegacy {
+		observability.RecordMetricsForTraceExporter(
+			ctx, numExportedSpans, numDroppedSpans)
+	}
+
+	endExportOp(
+		ctx,
+		span,
+		numExportedSpans,
+		err,
+		traceData,
+	)
+}
+
+// StartMetricsExportOp is called at the start of an Export operation.
+// The returned context should be used in other calls to the obsreport functions
+// dealing with the same export operation.
+func StartMetricsExportOp(
+	ctx context.Context,
+	exporter string,
+) (context.Context, *trace.Span) {
+	return traceExportDataOp(
+		exporterContext(ctx, exporter),
+		exporter,
+		exportMetricsOperationSuffix)
+}
+
+// EndMetricsExportOp completes the export operation that was started with
+// StartMetricsExportOp.
+func EndMetricsExportOp(
+	ctx context.Context,
+	span *trace.Span,
+	numExportedPoints int,
+	numExportedTimeSeries int, // TODO: For legacy measurements, to be removed in the future.
+	numDroppedTimeSeries int, // TODO: For legacy measurements, to be removed in the future.
+	err error,
+) {
+	if useLegacy {
+		observability.RecordMetricsForMetricsExporter(
+			ctx, numExportedTimeSeries, numDroppedTimeSeries)
+	}
+
+	endExportOp(
+		ctx,
+		span,
+		numExportedPoints,
+		err,
+		metricsData,
+	)
+}
+
+// exporterContext adds the keys used when recording observability metrics to
+// the given context returning the newly created context. This context should
+// be used in related calls to the obsreport functions so metrics are properly
+// recorded.
+func exporterContext(
+	ctx context.Context,
+	exporter string,
+) context.Context {
+	if useLegacy {
+		ctx = observability.ContextWithExporterName(ctx, exporter)
+	}
+
+	if useNew {
+		ctx, _ = tag.New(ctx, tag.Upsert(
+			tagKeyExporter, exporter, tag.WithTTL(tag.TTLNoPropagation)))
+	}
+
+	return ctx
+}
+
+// traceExportDataOp creates the span used to trace the operation. Returning
+// the updated context and the created span.
+func traceExportDataOp(
+	exporterCtx context.Context,
+	exporterName string,
+	operationSuffix string,
+) (context.Context, *trace.Span) {
+	spanName := exporterPrefix + exporterName + operationSuffix
+	return trace.StartSpan(exporterCtx, spanName)
+}
+
+// endExportOp records the observability signals at the end of an operation.
+func endExportOp(
+	exporterCtx context.Context,
+	span *trace.Span,
+	numExportedItems int,
+	err error,
+	dataType dataType,
+) {
+	numSent := numExportedItems
+	numFailedToSend := 0
+	if err != nil {
+		numSent = 0
+		numFailedToSend = numExportedItems
+	}
+
+	var sentMeasure, failedToSendMeasure *stats.Int64Measure
+	var sentItemsKey, failedToSendItemsKey string
+	switch dataType {
+	case traceData:
+		sentMeasure = mExporterSentSpans
+		failedToSendMeasure = mExporterFailedToSendSpans
+		sentItemsKey = SentSpansKey
+		failedToSendItemsKey = FailedToSendSpansKey
+	case metricsData:
+		sentMeasure = mExporterSentMetricPoints
+		failedToSendMeasure = mExporterFailedToSendMetricPoints
+		sentItemsKey = SentMetricPointsKey
+		failedToSendItemsKey = FailedToSendMetricPointsKey
+	}
+
+	if useNew {
+		stats.Record(
+			exporterCtx,
+			sentMeasure.M(int64(numSent)),
+			failedToSendMeasure.M(int64(numFailedToSend)))
+	}
+
+	// End span according to errors.
+	if span.IsRecordingEvents() {
+		span.AddAttributes(
+			trace.Int64Attribute(
+				sentItemsKey, int64(numSent)),
+			trace.Int64Attribute(
+				failedToSendItemsKey, int64(numFailedToSend)),
+		)
+		span.SetStatus(errToStatus(err))
+	}
+	span.End()
+}

--- a/obsreport/obsreport_exporter.go
+++ b/obsreport/obsreport_exporter.go
@@ -21,6 +21,7 @@ import (
 	"go.opencensus.io/tag"
 	"go.opencensus.io/trace"
 
+	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
 	"github.com/open-telemetry/opentelemetry-collector/observability"
 )
 
@@ -93,7 +94,7 @@ func EndTraceDataExportOp(
 		span,
 		numExportedSpans,
 		err,
-		traceData,
+		configmodels.TracesDataType,
 	)
 }
 
@@ -130,7 +131,7 @@ func EndMetricsExportOp(
 		span,
 		numExportedPoints,
 		err,
-		metricsData,
+		configmodels.MetricsDataType,
 	)
 }
 
@@ -171,7 +172,7 @@ func endExportOp(
 	span *trace.Span,
 	numExportedItems int,
 	err error,
-	dataType dataType,
+	dataType configmodels.DataType,
 ) {
 	numSent := numExportedItems
 	numFailedToSend := 0
@@ -183,12 +184,12 @@ func endExportOp(
 	var sentMeasure, failedToSendMeasure *stats.Int64Measure
 	var sentItemsKey, failedToSendItemsKey string
 	switch dataType {
-	case traceData:
+	case configmodels.TracesDataType:
 		sentMeasure = mExporterSentSpans
 		failedToSendMeasure = mExporterFailedToSendSpans
 		sentItemsKey = SentSpansKey
 		failedToSendItemsKey = FailedToSendSpansKey
-	case metricsData:
+	case configmodels.MetricsDataType:
 		sentMeasure = mExporterSentMetricPoints
 		failedToSendMeasure = mExporterFailedToSendMetricPoints
 		sentItemsKey = SentMetricPointsKey

--- a/obsreport/obsreport_receiver.go
+++ b/obsreport/obsreport_receiver.go
@@ -1,0 +1,257 @@
+// Copyright 2020 OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package obsreport
+
+import (
+	"context"
+
+	"go.opencensus.io/stats"
+	"go.opencensus.io/tag"
+	"go.opencensus.io/trace"
+
+	"github.com/open-telemetry/opentelemetry-collector/observability"
+)
+
+const (
+	ReceiverKey  = "receiver"
+	TransportKey = "transport"
+	FormatKey    = "format"
+
+	AcceptedSpansKey = "accepted_spans"
+	RefusedSpansKey  = "refused_spans"
+
+	AcceptedMetricPointsKey = "accepted_metric_points"
+	RefusedMetricPointsKey  = "refused_metric_points"
+)
+
+var (
+	tagKeyReceiver, _  = tag.NewKey(ReceiverKey)
+	tagKeyTransport, _ = tag.NewKey(TransportKey)
+
+	receiverPrefix                  = ReceiverKey + nameSep
+	receiveTraceDataOperationSuffix = nameSep + "TraceDataReceived"
+	receiverMetricsOperationSuffix  = nameSep + "MetricsReceived"
+
+	// Receiver metrics. Any count of data items below is in the original format
+	// that they were received, reasoning: reconciliation is easier if measurements
+	// on clients and receiver are expected to be the same. Translation issues
+	// that result in a different number of elements should be reported in a
+	// separate way.
+	mReceiverAcceptedSpans = stats.Int64(
+		receiverPrefix+AcceptedSpansKey,
+		"Number of spans successfully pushed into the pipeline.",
+		stats.UnitDimensionless)
+	mReceiverRefusedSpans = stats.Int64(
+		receiverPrefix+RefusedSpansKey,
+		"Number of spans that could not be pushed into the pipeline.",
+		stats.UnitDimensionless)
+	mReceiverAcceptedMetricPoints = stats.Int64(
+		receiverPrefix+AcceptedMetricPointsKey,
+		"Number of metric points successfully pushed into the pipeline.",
+		stats.UnitDimensionless)
+	mReceiverRefusedMetricPoints = stats.Int64(
+		receiverPrefix+RefusedMetricPointsKey,
+		"Number of metric points that could not be pushed into the pipeline.",
+		stats.UnitDimensionless)
+)
+
+// StartTraceDataReceiveOp is called when a \request is received from a client.
+// The returned context should be used in other calls to the obsreport functions
+// dealing with the same receive operation.
+func StartTraceDataReceiveOp(
+	ctx context.Context,
+	receiver string,
+	transport string,
+	legacyName string,
+) (context.Context, *trace.Span) {
+	return traceReceiveTraceDataOp(
+		receiverContext(ctx, receiver, transport, legacyName),
+		receiver,
+		transport,
+		receiveTraceDataOperationSuffix)
+}
+
+// EndTraceDataReceiveOp completes the receive operation that was started with
+// StartTraceDataReceiveOp.
+func EndTraceDataReceiveOp(
+	ctx context.Context,
+	span *trace.Span,
+	format string,
+	numReceivedSpans int,
+	err error,
+) {
+	if useLegacy {
+		numReceivedLegacy := numReceivedSpans
+		numDroppedSpans := 0
+		if err != nil {
+			numDroppedSpans = numReceivedSpans
+			numReceivedLegacy = 0
+		}
+		observability.RecordMetricsForTraceReceiver(
+			ctx, numReceivedLegacy, numDroppedSpans)
+	}
+
+	endReceiveOp(
+		ctx,
+		span,
+		format,
+		numReceivedSpans,
+		err,
+		traceData,
+	)
+}
+
+// StartMetricsReceiveOp is called when a \request is received from a client.
+// The returned context should be used in other calls to the obsreport functions
+// dealing with the same receive operation.
+func StartMetricsReceiveOp(
+	ctx context.Context,
+	receiver string,
+	transport string,
+	legacyName string,
+) (context.Context, *trace.Span) {
+	return traceReceiveTraceDataOp(
+		receiverContext(ctx, receiver, transport, legacyName),
+		receiver,
+		transport,
+		receiverMetricsOperationSuffix)
+}
+
+// EndMetricsReceiveOp completes the receive operation that was started with
+// StartMetricsReceiveOp.
+func EndMetricsReceiveOp(
+	ctx context.Context,
+	span *trace.Span,
+	format string,
+	numReceivedPoints int,
+	numReceivedTimeSeries int, // For legacy measurements.
+	err error,
+) {
+	if useLegacy {
+		numDroppedTimeSeries := 0
+		if err != nil {
+			numDroppedTimeSeries = numReceivedTimeSeries
+			numReceivedTimeSeries = 0
+		}
+		observability.RecordMetricsForMetricsReceiver(
+			ctx, numReceivedTimeSeries, numDroppedTimeSeries)
+	}
+
+	endReceiveOp(
+		ctx,
+		span,
+		format,
+		numReceivedPoints,
+		err,
+		metricsData,
+	)
+}
+
+// receiverContext adds the keys used when recording observability metrics to
+// the given context returning the newly created context. This context should
+// be used in related calls to the obsreport functions so metrics are properly
+// recorded.
+func receiverContext(
+	ctx context.Context,
+	receiver string,
+	transport string,
+	legacyName string,
+) context.Context {
+	if useLegacy {
+		name := receiver
+		if legacyName != "" {
+			name = legacyName
+		}
+		ctx = observability.ContextWithReceiverName(ctx, name)
+	}
+
+	if useNew {
+		mutators := []tag.Mutator{
+			tag.Upsert(tagKeyReceiver, receiver, tag.WithTTL(tag.TTLNoPropagation)),
+			tag.Upsert(tagKeyTransport, transport, tag.WithTTL(tag.TTLNoPropagation)),
+		}
+		ctx, _ = tag.New(ctx, mutators...)
+	}
+
+	return ctx
+}
+
+// traceReceiveTraceDataOp creates the span used to trace the operation. Returning
+// the updated context and the created span.
+func traceReceiveTraceDataOp(
+	receiverCtx context.Context,
+	receiverName string,
+	transport string,
+	operationSuffix string,
+) (context.Context, *trace.Span) {
+	spanName := receiverPrefix + receiverName + operationSuffix
+	ctx, span := trace.StartSpan(receiverCtx, spanName)
+	span.AddAttributes(trace.StringAttribute(
+		TransportKey, transport))
+	return ctx, span
+}
+
+// endReceiveOp records the observability signals at the end of an operation.
+func endReceiveOp(
+	receiverCtx context.Context,
+	span *trace.Span,
+	format string,
+	numReceivedItems int,
+	err error,
+	dataType dataType,
+) {
+	numAccepted := numReceivedItems
+	numRefused := 0
+	if err != nil {
+		numAccepted = 0
+		numRefused = numReceivedItems
+	}
+
+	var acceptedMeasure, refusedMeasure *stats.Int64Measure
+	var acceptedItemsKey, refusedItemsKey string
+	switch dataType {
+	case traceData:
+		acceptedMeasure = mReceiverAcceptedSpans
+		refusedMeasure = mReceiverRefusedSpans
+		acceptedItemsKey = AcceptedSpansKey
+		refusedItemsKey = RefusedSpansKey
+	case metricsData:
+		acceptedMeasure = mReceiverAcceptedMetricPoints
+		refusedMeasure = mReceiverRefusedMetricPoints
+		acceptedItemsKey = AcceptedMetricPointsKey
+		refusedItemsKey = RefusedMetricPointsKey
+	}
+
+	if useNew {
+		stats.Record(
+			receiverCtx,
+			acceptedMeasure.M(int64(numAccepted)),
+			refusedMeasure.M(int64(numRefused)))
+	}
+
+	// end span according to errors
+	if span.IsRecordingEvents() {
+		span.AddAttributes(
+			trace.StringAttribute(
+				FormatKey, format),
+			trace.Int64Attribute(
+				acceptedItemsKey, int64(numAccepted)),
+			trace.Int64Attribute(
+				refusedItemsKey, int64(numRefused)),
+		)
+		span.SetStatus(errToStatus(err))
+	}
+	span.End()
+}

--- a/obsreport/obsreport_receiver.go
+++ b/obsreport/obsreport_receiver.go
@@ -21,6 +21,7 @@ import (
 	"go.opencensus.io/tag"
 	"go.opencensus.io/trace"
 
+	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
 	"github.com/open-telemetry/opentelemetry-collector/observability"
 )
 
@@ -109,7 +110,7 @@ func EndTraceDataReceiveOp(
 		format,
 		numReceivedSpans,
 		err,
-		traceData,
+		configmodels.TracesDataType,
 	)
 }
 
@@ -155,7 +156,7 @@ func EndMetricsReceiveOp(
 		format,
 		numReceivedPoints,
 		err,
-		metricsData,
+		configmodels.MetricsDataType,
 	)
 }
 
@@ -210,7 +211,7 @@ func endReceiveOp(
 	format string,
 	numReceivedItems int,
 	err error,
-	dataType dataType,
+	dataType configmodels.DataType,
 ) {
 	numAccepted := numReceivedItems
 	numRefused := 0
@@ -222,12 +223,12 @@ func endReceiveOp(
 	var acceptedMeasure, refusedMeasure *stats.Int64Measure
 	var acceptedItemsKey, refusedItemsKey string
 	switch dataType {
-	case traceData:
+	case configmodels.TracesDataType:
 		acceptedMeasure = mReceiverAcceptedSpans
 		refusedMeasure = mReceiverRefusedSpans
 		acceptedItemsKey = AcceptedSpansKey
 		refusedItemsKey = RefusedSpansKey
-	case metricsData:
+	case configmodels.MetricsDataType:
 		acceptedMeasure = mReceiverAcceptedMetricPoints
 		refusedMeasure = mReceiverRefusedMetricPoints
 		acceptedItemsKey = AcceptedMetricPointsKey

--- a/obsreport/obsreport_test.go
+++ b/obsreport/obsreport_test.go
@@ -1,0 +1,430 @@
+// Copyright 2020 OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package obsreport
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"sort"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
+	"go.opencensus.io/trace"
+
+	"github.com/open-telemetry/opentelemetry-collector/observability"
+	"github.com/open-telemetry/opentelemetry-collector/observability/observabilitytest"
+)
+
+const (
+	exporter   = "fakeExporter"
+	receiver   = "fakeReicever"
+	transport  = "fakeTransport"
+	format     = "fakeFormat"
+	legacyName = "fakeLegacyName"
+)
+
+var (
+	errFake = errors.New("errFake")
+)
+
+func TestConfigure(t *testing.T) {
+	type args struct {
+		generateLegacy bool
+		generateNew    bool
+	}
+	tests := []struct {
+		name      string
+		args      args
+		wantViews []*view.View
+	}{
+		{
+			name: "none",
+		},
+		{
+			name: "legacy_only",
+			args: args{
+				generateLegacy: true,
+			},
+			wantViews: observability.AllViews,
+		},
+		{
+			name: "new_only",
+			args: args{
+				generateNew: true,
+			},
+			wantViews: genAllViews(),
+		},
+		{
+			name: "new_only",
+			args: args{
+				generateNew:    true,
+				generateLegacy: true,
+			},
+			wantViews: append(
+				observability.AllViews,
+				genAllViews()...),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotViews := Configure(tt.args.generateLegacy, tt.args.generateNew)
+			assert.Equal(t, tt.wantViews, gotViews)
+		})
+	}
+}
+
+func Test_obsreport_ReceiveTraceDataOp(t *testing.T) {
+	doneFn, err := setupViews()
+	defer doneFn()
+	require.NoError(t, err)
+
+	ss := &spanStore{}
+	trace.RegisterExporter(ss)
+	defer trace.UnregisterExporter(ss)
+
+	parentCtx, parentSpan := trace.StartSpan(context.Background(),
+		t.Name(), trace.WithSampler(trace.AlwaysSample()))
+	defer parentSpan.End()
+
+	errs := []error{nil, errFake}
+	rcvdSpans := []int{13, 42}
+	for i, err := range errs {
+		ctx, span := StartTraceDataReceiveOp(
+			parentCtx,
+			receiver,
+			transport,
+			legacyName)
+		assert.NotNil(t, ctx)
+		assert.NotNil(t, span)
+
+		EndTraceDataReceiveOp(
+			ctx,
+			span,
+			format,
+			rcvdSpans[i],
+			err)
+	}
+
+	spans := ss.PullAllSpans()
+	require.Equal(t, len(errs), len(spans))
+
+	var acceptedSpans, refusedSpans int
+	for i, span := range spans {
+		assert.Equal(t, receiverPrefix+receiver+receiveTraceDataOperationSuffix, span.Name)
+		assert.Equal(t, transport, span.Attributes[TransportKey])
+		switch errs[i] {
+		case nil:
+			acceptedSpans += rcvdSpans[i]
+			assert.Equal(t, int64(rcvdSpans[i]), span.Attributes[AcceptedSpansKey])
+			assert.Equal(t, int64(0), span.Attributes[RefusedSpansKey])
+			assert.Equal(t, okStatus, span.Status)
+		case errFake:
+			refusedSpans += rcvdSpans[i]
+			assert.Equal(t, int64(0), span.Attributes[AcceptedSpansKey])
+			assert.Equal(t, int64(rcvdSpans[i]), span.Attributes[RefusedSpansKey])
+			assert.Equal(t, errs[i].Error(), span.Status.Message)
+		default:
+			t.Fatalf("unexpected error: %v", errs[i])
+		}
+	}
+
+	// Check legacy metrics.
+	assert.NoError(t, observabilitytest.CheckValueViewReceiverReceivedSpans(legacyName, acceptedSpans))
+	assert.NoError(t, observabilitytest.CheckValueViewReceiverDroppedSpans(legacyName, refusedSpans))
+	// Check new metrics.
+	receiverTags := receiverViewTags(receiver, transport)
+	checkValueForSumView(t, mReceiverAcceptedSpans.Name(), receiverTags, acceptedSpans)
+	checkValueForSumView(t, mReceiverRefusedSpans.Name(), receiverTags, refusedSpans)
+}
+
+func Test_obsreport_ReceiveMetricsOp(t *testing.T) {
+	doneFn, err := setupViews()
+	defer doneFn()
+	require.NoError(t, err)
+
+	ss := &spanStore{}
+	trace.RegisterExporter(ss)
+	defer trace.UnregisterExporter(ss)
+
+	parentCtx, parentSpan := trace.StartSpan(context.Background(),
+		t.Name(), trace.WithSampler(trace.AlwaysSample()))
+	defer parentSpan.End()
+
+	errs := []error{errFake, nil}
+	rcvdMetricPts := []int{23, 29}
+	rcvdTimeSeries := []int{2, 3}
+	for i, err := range errs {
+		ctx, span := StartMetricsReceiveOp(
+			parentCtx,
+			receiver,
+			transport,
+			legacyName)
+		assert.NotNil(t, ctx)
+		assert.NotNil(t, span)
+
+		EndMetricsReceiveOp(
+			ctx,
+			span,
+			format,
+			rcvdMetricPts[i],
+			rcvdTimeSeries[i],
+			err)
+	}
+
+	spans := ss.PullAllSpans()
+	require.Equal(t, len(errs), len(spans))
+
+	var receivedTimeSeries, droppedTimeSeries int
+	var acceptedMetricPoints, refusedMetricPoints int
+	for i, span := range spans {
+		assert.Equal(t, receiverPrefix+receiver+receiverMetricsOperationSuffix, span.Name)
+		assert.Equal(t, transport, span.Attributes[TransportKey])
+		switch errs[i] {
+		case nil:
+			receivedTimeSeries += rcvdTimeSeries[i]
+			acceptedMetricPoints += rcvdMetricPts[i]
+			assert.Equal(t, int64(rcvdMetricPts[i]), span.Attributes[AcceptedMetricPointsKey])
+			assert.Equal(t, int64(0), span.Attributes[RefusedMetricPointsKey])
+			assert.Equal(t, okStatus, span.Status)
+		case errFake:
+			droppedTimeSeries += rcvdTimeSeries[i]
+			refusedMetricPoints += rcvdMetricPts[i]
+			assert.Equal(t, int64(0), span.Attributes[AcceptedMetricPointsKey])
+			assert.Equal(t, int64(rcvdMetricPts[i]), span.Attributes[RefusedMetricPointsKey])
+			assert.Equal(t, errs[i].Error(), span.Status.Message)
+		default:
+			t.Fatalf("unexpected error: %v", errs[i])
+		}
+	}
+
+	// Check legacy metrics.
+	assert.NoError(t, observabilitytest.CheckValueViewReceiverReceivedTimeSeries(legacyName, receivedTimeSeries))
+	assert.NoError(t, observabilitytest.CheckValueViewReceiverDroppedTimeSeries(legacyName, droppedTimeSeries))
+	// Check new metrics.
+	receiverTags := receiverViewTags(receiver, transport)
+	checkValueForSumView(t, mReceiverAcceptedMetricPoints.Name(), receiverTags, acceptedMetricPoints)
+	checkValueForSumView(t, mReceiverRefusedMetricPoints.Name(), receiverTags, refusedMetricPoints)
+}
+
+func Test_obsreport_ExportTraceDataOp(t *testing.T) {
+	doneFn, err := setupViews()
+	defer doneFn()
+	require.NoError(t, err)
+
+	ss := &spanStore{}
+	trace.RegisterExporter(ss)
+	defer trace.UnregisterExporter(ss)
+
+	parentCtx, parentSpan := trace.StartSpan(context.Background(),
+		t.Name(), trace.WithSampler(trace.AlwaysSample()))
+	defer parentSpan.End()
+
+	// observabilitytest for exporters expects the context to flow the original
+	// receiver tags, adding that to parent span.
+	parentCtx = observability.ContextWithReceiverName(parentCtx, receiver)
+
+	errs := []error{nil, errFake}
+	numExportedSpans := []int{22, 14}
+	for i, err := range errs {
+		ctx, span := StartTraceDataExportOp(parentCtx, exporter)
+		assert.NotNil(t, ctx)
+		assert.NotNil(t, span)
+
+		var numDroppedSpans int
+		if err != nil {
+			numDroppedSpans = numExportedSpans[i]
+		}
+
+		EndTraceDataExportOp(
+			ctx, span, numExportedSpans[i], numDroppedSpans, err)
+	}
+
+	spans := ss.PullAllSpans()
+	require.Equal(t, len(errs), len(spans))
+
+	var sentSpans, failedToSendSpans int
+	for i, span := range spans {
+		assert.Equal(t, exporterPrefix+exporter+exportTraceDataOperationSuffix, span.Name)
+		switch errs[i] {
+		case nil:
+			sentSpans += numExportedSpans[i]
+			assert.Equal(t, int64(numExportedSpans[i]), span.Attributes[SentSpansKey])
+			assert.Equal(t, int64(0), span.Attributes[FailedToSendSpansKey])
+			assert.Equal(t, okStatus, span.Status)
+		case errFake:
+			failedToSendSpans += numExportedSpans[i]
+			assert.Equal(t, int64(0), span.Attributes[SentSpansKey])
+			assert.Equal(t, int64(numExportedSpans[i]), span.Attributes[FailedToSendSpansKey])
+			assert.Equal(t, errs[i].Error(), span.Status.Message)
+		default:
+			t.Fatalf("unexpected error: %v", errs[i])
+		}
+	}
+
+	// Check legacy metrics.
+	assert.NoError(t, observabilitytest.CheckValueViewExporterReceivedSpans(receiver, exporter, sentSpans+failedToSendSpans))
+	assert.NoError(t, observabilitytest.CheckValueViewExporterDroppedSpans(receiver, exporter, failedToSendSpans))
+	// Check new metrics.
+	exporterTags := exporterViewTags(exporter)
+	checkValueForSumView(t, mExporterSentSpans.Name(), exporterTags, sentSpans)
+	checkValueForSumView(t, mExporterFailedToSendSpans.Name(), exporterTags, failedToSendSpans)
+}
+
+func Test_obsreport_ExportMetricsOp(t *testing.T) {
+	doneFn, err := setupViews()
+	defer doneFn()
+	require.NoError(t, err)
+
+	ss := &spanStore{}
+	trace.RegisterExporter(ss)
+	defer trace.UnregisterExporter(ss)
+
+	parentCtx, parentSpan := trace.StartSpan(context.Background(),
+		t.Name(), trace.WithSampler(trace.AlwaysSample()))
+	defer parentSpan.End()
+
+	// observabilitytest for exporters expects the context to flow the original
+	// receiver tags, adding that to parent span.
+	parentCtx = observability.ContextWithReceiverName(parentCtx, receiver)
+
+	errs := []error{nil, errFake}
+	toSendMetricPts := []int{17, 23}
+	toSendTimeSeries := []int{3, 5}
+	for i, err := range errs {
+		ctx, span := StartMetricsExportOp(parentCtx, exporter)
+		assert.NotNil(t, ctx)
+		assert.NotNil(t, span)
+
+		var numDroppedTimeSeires int
+		if err != nil {
+			numDroppedTimeSeires = toSendTimeSeries[i]
+		}
+
+		EndMetricsExportOp(
+			ctx,
+			span,
+			toSendMetricPts[i],
+			toSendTimeSeries[i],
+			numDroppedTimeSeires,
+			err)
+	}
+
+	spans := ss.PullAllSpans()
+	require.Equal(t, len(errs), len(spans))
+
+	var receivedTimeSeries, droppedTimeSeries int
+	var sentPoints, failedToSendPoints int
+	for i, span := range spans {
+		assert.Equal(t, exporterPrefix+exporter+exportMetricsOperationSuffix, span.Name)
+		receivedTimeSeries += toSendTimeSeries[i]
+		switch errs[i] {
+		case nil:
+			sentPoints += toSendMetricPts[i]
+			assert.Equal(t, int64(toSendMetricPts[i]), span.Attributes[SentMetricPointsKey])
+			assert.Equal(t, int64(0), span.Attributes[FailedToSendMetricPointsKey])
+			assert.Equal(t, okStatus, span.Status)
+		case errFake:
+			failedToSendPoints += toSendMetricPts[i]
+			droppedTimeSeries += toSendTimeSeries[i]
+			assert.Equal(t, int64(0), span.Attributes[SentMetricPointsKey])
+			assert.Equal(t, int64(toSendMetricPts[i]), span.Attributes[FailedToSendMetricPointsKey])
+			assert.Equal(t, errs[i].Error(), span.Status.Message)
+		default:
+			t.Fatalf("unexpected error: %v", errs[i])
+		}
+	}
+
+	// Check legacy metrics.
+	assert.NoError(t, observabilitytest.CheckValueViewExporterReceivedTimeSeries(receiver, exporter, receivedTimeSeries))
+	assert.NoError(t, observabilitytest.CheckValueViewExporterDroppedTimeSeries(receiver, exporter, droppedTimeSeries))
+	// Check new metrics.
+	exporterTags := exporterViewTags(exporter)
+	checkValueForSumView(t, mExporterSentMetricPoints.Name(), exporterTags, sentPoints)
+	checkValueForSumView(t, mExporterFailedToSendMetricPoints.Name(), exporterTags, failedToSendPoints)
+}
+
+func setupViews() (doneFn func(), err error) {
+	genLegacy := true
+	genNew := true
+	views := Configure(genLegacy, genNew)
+	err = view.Register(views...)
+
+	return func() {
+		view.Unregister(views...)
+	}, err
+}
+
+func checkValueForSumView(t *testing.T, vName string, wantTags []tag.Tag, value int) {
+	// Make sure the tags slice is sorted by tag keys.
+	sortTags(wantTags)
+
+	rows, err := view.RetrieveData(vName)
+	require.NoError(t, err, "error retrieving view data for view %s", vName)
+
+	for _, row := range rows {
+		// Make sure the tags slice is sorted by tag keys.
+		sortTags(row.Tags)
+		if reflect.DeepEqual(wantTags, row.Tags) {
+			sum := row.Data.(*view.SumData)
+			assert.Equal(t, float64(value), sum.Value)
+			return
+		}
+	}
+
+	assert.Fail(t, "row not found", "no row matches %v in rows %v", wantTags, rows)
+}
+
+func receiverViewTags(receiver, transport string) []tag.Tag {
+	return []tag.Tag{
+		{Key: tagKeyReceiver, Value: receiver},
+		{Key: tagKeyTransport, Value: transport},
+	}
+}
+
+func exporterViewTags(exporter string) []tag.Tag {
+	return []tag.Tag{
+		{Key: tagKeyExporter, Value: exporter},
+	}
+}
+
+func sortTags(tags []tag.Tag) {
+	sort.SliceStable(tags, func(i, j int) bool {
+		return tags[i].Key.Name() < tags[j].Key.Name()
+	})
+}
+
+type spanStore struct {
+	sync.Mutex
+	spans []*trace.SpanData
+}
+
+func (ss *spanStore) ExportSpan(sd *trace.SpanData) {
+	ss.Lock()
+	ss.spans = append(ss.spans, sd)
+	ss.Unlock()
+}
+
+func (ss *spanStore) PullAllSpans() []*trace.SpanData {
+	ss.Lock()
+	capturedSpans := ss.spans
+	ss.spans = nil
+	ss.Unlock()
+	return capturedSpans
+}


### PR DESCRIPTION
This package is going to allow controlled transition/rename of metrics.
The initial implementation just prepares the way to remove the calls to
the observability package.

**Description:** In order to be able to rename and change the metrics generated by the Collector without breaking current usage the `obsreport` package is being introduced. After this is merged a command-line flag can be added to control the generation of the different sets of metrics - initially with the default as legacy only.

**Link to tracking Issue:** Needed for #141, see also the comments of PR #530

**Testing:** Besides the added tests I have a series of follow up PRs ready, I used these other PRs to manually validate the changes.

**Documentation:** Please refer to `doc.go` in the new package.