### PR TITLE
Add Support for Sampling JSON

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -392,6 +392,7 @@ github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANyt
 github.com/influxdata/influxdb v1.7.7/go.mod h1:qZna6X/4elxqT3yI9iZYdZrWWdeFOOprn86kgg4+IzY=
 github.com/jaegertracing/jaeger v1.14.0 h1:C0En+gfcxf3NsAriMAvQ6LcSFrQ5VQGXddqfty1EpTI=
 github.com/jaegertracing/jaeger v1.14.0/go.mod h1:LUWPSnzNPGRubM8pk0inANGitpiMOOxihXx0+53llXI=
+github.com/jaegertracing/jaeger v1.16.0 h1:WPpd4nmpau+nuAE0gBHbigdzOUfQXvIm9pGMnbWHO5A=
 github.com/jessevdk/go-flags v0.0.0-20180331124232-1c38ed7ad0cc/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/go.sum
+++ b/go.sum
@@ -392,7 +392,6 @@ github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANyt
 github.com/influxdata/influxdb v1.7.7/go.mod h1:qZna6X/4elxqT3yI9iZYdZrWWdeFOOprn86kgg4+IzY=
 github.com/jaegertracing/jaeger v1.14.0 h1:C0En+gfcxf3NsAriMAvQ6LcSFrQ5VQGXddqfty1EpTI=
 github.com/jaegertracing/jaeger v1.14.0/go.mod h1:LUWPSnzNPGRubM8pk0inANGitpiMOOxihXx0+53llXI=
-github.com/jaegertracing/jaeger v1.16.0 h1:WPpd4nmpau+nuAE0gBHbigdzOUfQXvIm9pGMnbWHO5A=
 github.com/jessevdk/go-flags v0.0.0-20180331124232-1c38ed7ad0cc/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/receiver/README.md
+++ b/receiver/README.md
@@ -151,7 +151,7 @@ It works by proxying client requests for remote sampling configuration to the co
 |               |     strategy      |              |              |                 |
 +---------------+                   +--------------+              +-----------------+
 
-Remote sampling can be enabled by specifying the following lines in the jaeger receiver config:
+Remote sample proxying can be enabled by specifying the following lines in the jaeger receiver config:
 
 ```yaml
 receivers:
@@ -164,6 +164,18 @@ receivers:
       fetch_endpoint: "jaeger-collector:1234"
 ``` 
 
+Remote sampling can also be directly served by the collector by providing a sampling json file.
+
+```yaml
+receivers:
+  jaeger:
+    protocols:
+      grpc:
+    remote_sampling:
+      strategy_file: "/etc/strategy.json"
+``` 
+
+Note that GRPC must be enabled for this to work as Jaeger serves its remote sampling strategies over GRPC.
 
 ## <a name="prometheus"></a>Prometheus Receiver
 **Only metrics are supported.**

--- a/receiver/jaegerreceiver/config.go
+++ b/receiver/jaegerreceiver/config.go
@@ -25,6 +25,7 @@ const protocolsFieldName = "protocols"
 type RemoteSamplingConfig struct {
 	HostEndpoint  string `mapstructure:"host_endpoint"`
 	FetchEndpoint string `mapstructure:"fetch_endpoint"`
+	StrategyFile  string `mapstructure:"strategy_file"`
 }
 
 // Config defines configuration for Jaeger receiver.

--- a/receiver/jaegerreceiver/config_test.go
+++ b/receiver/jaegerreceiver/config_test.go
@@ -76,6 +76,7 @@ func TestLoadConfig(t *testing.T) {
 			RemoteSampling: &RemoteSamplingConfig{
 				HostEndpoint:  "0.0.0.0:5778",
 				FetchEndpoint: "jaeger-collector:1234",
+				StrategyFile:  "/etc/strategies.json",
 			},
 		})
 

--- a/receiver/jaegerreceiver/factory.go
+++ b/receiver/jaegerreceiver/factory.go
@@ -194,6 +194,15 @@ func (f *Factory) CreateTraceReceiver(
 				return nil, err
 			}
 		}
+
+		// strategies are served over grpc so if grpc is not enabled and strategies are present return an error
+		if len(remoteSamplingConfig.StrategyFile) != 0 {
+			if config.CollectorGRPCPort == 0 {
+				return nil, fmt.Errorf("strategy file requires the GRPC protocol to be enabled")
+			}
+
+			config.RemoteSamplingStrategyFile = remoteSamplingConfig.StrategyFile
+		}
 	}
 
 	if (protoGRPC == nil && protoHTTP == nil && protoTChannel == nil && protoThriftBinary == nil && protoThriftCompact == nil) ||

--- a/receiver/jaegerreceiver/testdata/config.yaml
+++ b/receiver/jaegerreceiver/testdata/config.yaml
@@ -18,6 +18,7 @@ receivers:
     remote_sampling:
       host_endpoint: "0.0.0.0:5778"
       fetch_endpoint: "jaeger-collector:1234"
+      strategy_file: "/etc/strategies.json"
   # The following demonstrates how to enable protocols with defaults.
   jaeger/defaults:
     protocols:

--- a/receiver/jaegerreceiver/testdata/strategies.json
+++ b/receiver/jaegerreceiver/testdata/strategies.json
@@ -1,0 +1,30 @@
+{
+    "service_strategies": [
+      {
+        "service": "foo",
+        "type": "probabilistic",
+        "param": 0.8,
+        "operation_strategies": [
+          {
+            "operation": "op1",
+            "type": "probabilistic",
+            "param": 0.2
+          },
+          {
+            "operation": "op2",
+            "type": "probabilistic",
+            "param": 0.4
+          }
+        ]
+      },
+      {
+        "service": "bar",
+        "type": "ratelimiting",
+        "param": 5
+      }
+    ],
+    "default_strategy": {
+      "type": "probabilistic",
+      "param": 0.5
+    }
+  }

--- a/receiver/jaegerreceiver/trace_receiver.go
+++ b/receiver/jaegerreceiver/trace_receiver.go
@@ -64,10 +64,11 @@ type Configuration struct {
 	CollectorGRPCPort    int
 	CollectorGRPCOptions []grpc.ServerOption
 
-	AgentCompactThriftPort int
-	AgentBinaryThriftPort  int
-	AgentHTTPPort          int
-	RemoteSamplingEndpoint string
+	AgentCompactThriftPort     int
+	AgentBinaryThriftPort      int
+	AgentHTTPPort              int
+	RemoteSamplingEndpoint     string
+	RemoteSamplingStrategyFile string
 }
 
 // Receiver type is used to receive spans that were originally intended to be sent to Jaeger.

--- a/receiver/jaegerreceiver/trace_receiver.go
+++ b/receiver/jaegerreceiver/trace_receiver.go
@@ -495,7 +495,7 @@ func (jr *jReceiver) startCollector(host component.Host) error {
 				StrategiesFile: jr.config.RemoteSamplingStrategyFile,
 			}, jr.logger)
 			if gerr != nil {
-				return fmt.Errorf("failed to create collectory strategy store: %v", gerr)
+				return fmt.Errorf("failed to create collector strategy store: %v", gerr)
 			}
 			api_v2.RegisterSamplingManagerServer(jr.grpc, collectorSampling.NewGRPCHandler(ss))
 		}

--- a/receiver/jaegerreceiver/trace_receiver.go
+++ b/receiver/jaegerreceiver/trace_receiver.go
@@ -490,13 +490,15 @@ func (jr *jReceiver) startCollector(host component.Host) error {
 		api_v2.RegisterCollectorServiceServer(jr.grpc, jr)
 
 		// init and register sampling strategy store
-		ss, gerr := staticStrategyStore.NewStrategyStore(staticStrategyStore.Options{
-			StrategiesFile: "",
-		}, jr.logger)
-		if gerr != nil {
-			return fmt.Errorf("failed to create collectory strategy store: %v", gerr)
+		if len(jr.config.RemoteSamplingStrategyFile) != 0 {
+			ss, gerr := staticStrategyStore.NewStrategyStore(staticStrategyStore.Options{
+				StrategiesFile: jr.config.RemoteSamplingStrategyFile,
+			}, jr.logger)
+			if gerr != nil {
+				return fmt.Errorf("failed to create collectory strategy store: %v", gerr)
+			}
+			api_v2.RegisterSamplingManagerServer(jr.grpc, collectorSampling.NewGRPCHandler(ss))
 		}
-		api_v2.RegisterSamplingManagerServer(jr.grpc, collectorSampling.NewGRPCHandler(ss))
 
 		go func() {
 			if err := jr.grpc.Serve(gln); err != nil {

--- a/receiver/jaegerreceiver/trace_receiver_test.go
+++ b/receiver/jaegerreceiver/trace_receiver_test.go
@@ -475,7 +475,7 @@ func TestSampling(t *testing.T) {
 	assert.NoError(t, err, "should not have failed to start trace reception")
 	t.Log("Start")
 
-	conn, err := grpc.Dial(fmt.Sprintf("0.0.0.0:%d", config.CollectorGRPCPort), grpc.WithInsecure())
+	conn, err := grpc.Dial(fmt.Sprintf("localhost:%d", config.CollectorGRPCPort), grpc.WithInsecure())
 	assert.NoError(t, err)
 	defer conn.Close()
 

--- a/receiver/jaegerreceiver/trace_receiver_test.go
+++ b/receiver/jaegerreceiver/trace_receiver_test.go
@@ -489,13 +489,13 @@ func TestSampling(t *testing.T) {
 		OperationSampling: &api_v2.PerOperationSamplingStrategies{
 			DefaultSamplingProbability: 0.8,
 			PerOperationStrategies: []*api_v2.OperationSamplingStrategy{
-				&api_v2.OperationSamplingStrategy{
+				{
 					Operation: "op1",
 					ProbabilisticSampling: &api_v2.ProbabilisticSamplingStrategy{
 						SamplingRate: 0.2,
 					},
 				},
-				&api_v2.OperationSamplingStrategy{
+				{
 					Operation: "op2",
 					ProbabilisticSampling: &api_v2.ProbabilisticSamplingStrategy{
 						SamplingRate: 0.4,

--- a/receiver/jaegerreceiver/trace_receiver_test.go
+++ b/receiver/jaegerreceiver/trace_receiver_test.go
@@ -460,6 +460,60 @@ func grpcFixture(t1 time.Time, d1, d2 time.Duration) *api_v2.PostSpansRequest {
 
 func TestSampling(t *testing.T) {
 	port := testutils.GetAvailablePort(t)
+	config := &Configuration{
+		CollectorGRPCPort:          int(port),
+		RemoteSamplingStrategyFile: "testdata/strategies.json",
+	}
+	sink := new(exportertest.SinkTraceExporter)
+
+	jr, err := New(context.Background(), config, sink, zap.NewNop())
+	assert.NoError(t, err, "should not have failed to create a new receiver")
+	defer jr.Shutdown()
+
+	mh := component.NewMockHost()
+	err = jr.Start(mh)
+	assert.NoError(t, err, "should not have failed to start trace reception")
+	t.Log("Start")
+
+	conn, err := grpc.Dial(fmt.Sprintf("0.0.0.0:%d", config.CollectorGRPCPort), grpc.WithInsecure())
+	assert.NoError(t, err)
+	defer conn.Close()
+
+	cl := api_v2.NewSamplingManagerClient(conn)
+
+	expected := &api_v2.SamplingStrategyResponse{
+		StrategyType: api_v2.SamplingStrategyType_PROBABILISTIC,
+		ProbabilisticSampling: &api_v2.ProbabilisticSamplingStrategy{
+			SamplingRate: 0.8,
+		},
+		OperationSampling: &api_v2.PerOperationSamplingStrategies{
+			DefaultSamplingProbability: 0.8,
+			PerOperationStrategies: []*api_v2.OperationSamplingStrategy{
+				&api_v2.OperationSamplingStrategy{
+					Operation: "op1",
+					ProbabilisticSampling: &api_v2.ProbabilisticSamplingStrategy{
+						SamplingRate: 0.2,
+					},
+				},
+				&api_v2.OperationSamplingStrategy{
+					Operation: "op2",
+					ProbabilisticSampling: &api_v2.ProbabilisticSamplingStrategy{
+						SamplingRate: 0.4,
+					},
+				},
+			},
+		},
+	}
+
+	resp, err := cl.GetSamplingStrategy(context.Background(), &api_v2.SamplingStrategyParameters{
+		ServiceName: "foo",
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, expected, resp)
+}
+
+func TestSamplingFailsOnNotConfigured(t *testing.T) {
+	port := testutils.GetAvailablePort(t)
 	// prepare
 	config := &Configuration{
 		CollectorGRPCPort: int(port),
@@ -481,9 +535,26 @@ func TestSampling(t *testing.T) {
 
 	cl := api_v2.NewSamplingManagerClient(conn)
 
-	resp, err := cl.GetSamplingStrategy(context.Background(), &api_v2.SamplingStrategyParameters{
+	_, err = cl.GetSamplingStrategy(context.Background(), &api_v2.SamplingStrategyParameters{
 		ServiceName: "nothing",
 	})
-	assert.NoError(t, err)
-	assert.NotNil(t, resp)
+	assert.Error(t, err)
+}
+
+func TestSamplingFailsOnBadFile(t *testing.T) {
+	port := testutils.GetAvailablePort(t)
+	// prepare
+	config := &Configuration{
+		CollectorGRPCPort:          int(port),
+		RemoteSamplingStrategyFile: "does-not-exist",
+	}
+	sink := new(exportertest.SinkTraceExporter)
+
+	jr, err := New(context.Background(), config, sink, zap.NewNop())
+	assert.NoError(t, err, "should not have failed to create a new receiver")
+	defer jr.Shutdown()
+
+	mh := component.NewMockHost()
+	err = jr.Start(mh)
+	assert.Error(t, err)
 }

--- a/receiver/jaegerreceiver/trace_receiver_test.go
+++ b/receiver/jaegerreceiver/trace_receiver_test.go
@@ -529,7 +529,7 @@ func TestSamplingFailsOnNotConfigured(t *testing.T) {
 	assert.NoError(t, err, "should not have failed to start trace reception")
 	t.Log("Start")
 
-	conn, err := grpc.Dial(fmt.Sprintf("0.0.0.0:%d", config.CollectorGRPCPort), grpc.WithInsecure())
+	conn, err := grpc.Dial(fmt.Sprintf("localhost:%d", config.CollectorGRPCPort), grpc.WithInsecure())
 	assert.NoError(t, err)
 	defer conn.Close()
 


### PR DESCRIPTION
**Description:** 
Added support for hosting a jaeger remote sampling file as requested in #500.  This was added to the core repo per discussion there.  

**Link to tracking Issue:** 
Fixes #500 

**Testing:**
Tests were added covering config, receiver creation and receiver functionality.

**Documentation:**
Added documentation on the new `strategy_file` config option.