### PR TITLE
Do not require a local build to run the demo

### DIFF
--- a/examples/demo/.env
+++ b/examples/demo/.env
@@ -1,0 +1,1 @@
+OTELCOL_IMG=omnition/opentelemetry-collector-contrib:latest

--- a/examples/demo/README.md
+++ b/examples/demo/README.md
@@ -2,25 +2,48 @@
 
 *IMPORTANT:* This is a pre-released version of the OpenTelemetry Collector.
 
-Typical flow of tracing and metrics data with OpenTelemetry Collector: tracing and metrics data initially received by OpenTelemetry Agent
-and then sent to OpenTelemetry Collector using OC data format. The OpenTelemetry Collector then sends the data to the
-backend, in this demo Jaeger, Zipkin, and Prometheus.
+This demo presents the typical flow of observability data with multiple
+OpenTelemetry Collectors deployed:
 
-This demo uses `docker-compose` and runs against locally built docker images of OpenTelemetry Collector. In
-order to build the docker images use the commands below from the root of the repo:
+- Applications send data directly to a Collector configured to use fewer
+ resources, aka the _agent_;
+- The agent then forwards the data to Collector(s) that receive data from
+ multiple agents. Collectors on this layer typically are allowed to use more
+ resources and queue more data;
+- The Collector then sends the data to the appropriate backend, in this demo
+ Jaeger, Zipkin, and Prometheus;
+
+This demo uses `docker-compose` and by default runs against the 
+`omnition/opentelemetry-collector-contrib:latest` image. To run the demo, switch
+to the `examples/demo` folder and run:
+
+```shell
+docker-compose up -d
+```
+
+The demo exposes the following backends:
+
+- Jaeger at http://localhost:16686
+- Zipkin at http://localhost:9411
+- Prometheus at http://localhost:9090 
+
+Notes:
+
+- It may take some time for the application metrics to appear on the Prometheus
+ dashboard;
+
+To clean up any docker container from the demo run `docker-compose down` from 
+the `examples/demo` folder.
+
+### Using a Locally Built Image
+Developers interested in running a local build of the Collector need to build a
+docker image using the command below:
 
 ```shell
 make docker-otelcol
 ```
 
-To run the demo, switch to the `examples/demo` folder and run:
+And set an environment variable `OTELCOL_IMG` to `otelcol:latest` before 
+launching the command `docker-compose up -d`.
 
-```shell
-docker-compose up
-```
 
-Open `http://localhost:16686` to see the data on the Jaeger backend, `http://localhost:9411` to see
-the data on the Zipkin backend, or `http://localhost:9090` to see data on the Prometheus backend (Note that
-it may take some time for the application metrics to appear on the Prometheus dashboard).
-
-To clean up any docker container from the demo run `docker-compose down` from the `examples/demo` folder.

--- a/examples/demo/docker-compose.yaml
+++ b/examples/demo/docker-compose.yaml
@@ -17,7 +17,7 @@ services:
 
   # Collector
   otel-collector:
-    image: otelcol:latest
+    image: ${OTELCOL_IMG}
     command: ["--config=/etc/otel-collector-config.yaml"]
     volumes:
       - ./otel-collector-config.yaml:/etc/otel-collector-config.yaml
@@ -34,7 +34,7 @@ services:
 
   # Agent
   otel-agent:
-    image: otelcol:latest
+    image: ${OTELCOL_IMG}
     command: ["--config=/etc/otel-agent-config.yaml"]
     volumes:
       - ./otel-agent-config.yaml:/etc/otel-agent-config.yaml


### PR DESCRIPTION
**Description:** Point the demo, by default, to a pre-built image. Devs can still run local builds by settings the env var OTELCOL_IMG.

**Link to tracking Issue:** Fix #536.

**Testing:** Manually launched the demo with new image and locally built.

**Documentation:** Updated demo doc.