### PR TITLE
Add a new `HASH` action to attribute processor

### DIFF
--- a/processor/README.md
+++ b/processor/README.md
@@ -142,6 +142,7 @@ The supported actions are:
   key does not already exist and updates an attribute in spans where the key
   does exist.
 - delete: Deletes an attribute from a span.
+- hash: Hashes (SHA1) an existing attribute value.
 
 For the actions `insert`, `update` and `upsert`,
  - `key`  is required
@@ -172,6 +173,15 @@ For the `delete` action,
   action: delete
 ```
 
+For the `hash` action,
+ - `key` is required
+ - `action: hash` is required.
+```yaml
+# Key specifies the attribute to act upon.
+- key: <key>
+  action: hash 
+```
+
 Please refer to [config.go](attributesprocessor/config.go) for the config spec.
 
 ### Example
@@ -195,6 +205,8 @@ processors:
         value: 2245
       - key: account_password
         action: delete
+      - key: account_email 
+        action: hash
 
 ```
 Refer to [config.yaml](attributesprocessor/testdata/config.yaml) for detailed

--- a/processor/attributesprocessor/attribute_hasher.go
+++ b/processor/attributesprocessor/attribute_hasher.go
@@ -1,0 +1,74 @@
+// Copyright 2019, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package attributesprocessor
+
+import (
+	"crypto/sha1"
+	"encoding/binary"
+	"encoding/hex"
+	"math"
+
+	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
+)
+
+const (
+	int64ByteSize   = 8
+	float64ByteSize = 8
+)
+
+var (
+	byteTrue  = [1]byte{1}
+	byteFalse = [1]byte{0}
+)
+
+// SHA1AttributeHahser hashes an AttributeValue using SHA1 and returns a
+// hashed version of the attribute. In practice, this would mostly be used
+// for string attributes but we support all types for completeness/correctness
+// and eliminate any surprises.
+func SHA1AttributeHahser(attr *tracepb.AttributeValue) *tracepb.AttributeValue {
+	var val []byte
+	switch attr.Value.(type) {
+	case *tracepb.AttributeValue_StringValue:
+		val = []byte(attr.GetStringValue().Value)
+	case *tracepb.AttributeValue_BoolValue:
+		if attr.GetBoolValue() {
+			val = byteTrue[:]
+		} else {
+			val = byteFalse[:]
+		}
+	case *tracepb.AttributeValue_IntValue:
+		val = make([]byte, int64ByteSize)
+		binary.LittleEndian.PutUint64(val, uint64(attr.GetIntValue()))
+	case *tracepb.AttributeValue_DoubleValue:
+		val = make([]byte, float64ByteSize)
+		binary.LittleEndian.PutUint64(val, math.Float64bits(attr.GetDoubleValue()))
+	}
+
+	var hashed string
+	if len(val) > 0 {
+		h := sha1.New()
+		h.Write(val)
+		val = h.Sum(nil)
+		hashedBytes := make([]byte, hex.EncodedLen(len(val)))
+		hex.Encode(hashedBytes, val)
+		hashed = string(hashedBytes)
+	}
+
+	return &tracepb.AttributeValue{
+		Value: &tracepb.AttributeValue_StringValue{
+			StringValue: &tracepb.TruncatableString{Value: string(hashed)},
+		},
+	}
+}

--- a/processor/attributesprocessor/attributes.go
+++ b/processor/attributesprocessor/attributes.go
@@ -104,6 +104,8 @@ func (a *attributesProcessor) ConsumeTraceData(ctx context.Context, td consumerd
 				// There is no need to check if the target key exists in the attribute map
 				// because the value is to be set regardless.
 				setAttribute(action, span.Attributes.AttributeMap)
+			case HASH:
+				hashAttribute(action, span.Attributes.AttributeMap)
 			}
 		}
 	}
@@ -151,6 +153,12 @@ func setAttribute(action attributeAction, attributesMap map[string]*tracepb.Attr
 	} else if value, fromAttributeExists := attributesMap[action.FromAttribute]; fromAttributeExists {
 		// Set the key with a value from another attribute, if it exists.
 		attributesMap[action.Key] = value
+	}
+}
+
+func hashAttribute(action attributeAction, attributesMap map[string]*tracepb.AttributeValue) {
+	if value, exists := attributesMap[action.Key]; exists {
+		attributesMap[action.Key] = SHA1AttributeHahser(value)
 	}
 }
 

--- a/processor/attributesprocessor/config.go
+++ b/processor/attributesprocessor/config.go
@@ -52,7 +52,7 @@ type ActionKeyValue struct {
 	FromAttribute string `mapstructure:"from_attribute"`
 
 	// Action specifies the type of action to perform.
-	// The set of values are {INSERT, UPDATE, UPSERT, DELETE}.
+	// The set of values are {INSERT, UPDATE, UPSERT, DELETE, HASH}.
 	// Both lower case and upper case are supported.
 	// INSERT - Inserts the key/value to spans when the key does not exist.
 	//          No action is applied to spans where the key already exists.
@@ -92,4 +92,8 @@ const (
 	// DELETE deletes the attribute from the span. If the key doesn't exist,
 	//no action is performed.
 	DELETE Action = "delete"
+
+	// HASH calculates the SHA-1 hash of an existing value and overwrites the value
+	// with it's SHA-1 hash result.
+	HASH Action = "hash"
 )

--- a/processor/attributesprocessor/config_test.go
+++ b/processor/attributesprocessor/config_test.go
@@ -85,8 +85,19 @@ func TestLoadingConifg(t *testing.T) {
 		},
 	})
 
-	p4 := config.Processors["attributes/excludemulti"]
+	p4 := config.Processors["attributes/hash"]
 	assert.Equal(t, p4, &Config{
+		ProcessorSettings: configmodels.ProcessorSettings{
+			NameVal: "attributes/hash",
+			TypeVal: typeStr,
+		},
+		Actions: []ActionKeyValue{
+			{Key: "user.email", Action: HASH},
+		},
+	})
+
+	p5 := config.Processors["attributes/excludemulti"]
+	assert.Equal(t, p5, &Config{
 		ProcessorSettings: configmodels.ProcessorSettings{
 			NameVal: "attributes/excludemulti",
 			TypeVal: typeStr,
@@ -107,8 +118,8 @@ func TestLoadingConifg(t *testing.T) {
 		},
 	})
 
-	p5 := config.Processors["attributes/includeservices"]
-	assert.Equal(t, p5, &Config{
+	p6 := config.Processors["attributes/includeservices"]
+	assert.Equal(t, p6, &Config{
 		ProcessorSettings: configmodels.ProcessorSettings{
 			NameVal: "attributes/includeservices",
 			TypeVal: typeStr,
@@ -125,8 +136,8 @@ func TestLoadingConifg(t *testing.T) {
 		},
 	})
 
-	p6 := config.Processors["attributes/selectiveprocessing"]
-	assert.Equal(t, p6, &Config{
+	p7 := config.Processors["attributes/selectiveprocessing"]
+	assert.Equal(t, p7, &Config{
 		ProcessorSettings: configmodels.ProcessorSettings{
 			NameVal: "attributes/selectiveprocessing",
 			TypeVal: typeStr,
@@ -149,8 +160,8 @@ func TestLoadingConifg(t *testing.T) {
 		},
 	})
 
-	p7 := config.Processors["attributes/complex"]
-	assert.Equal(t, p7, &Config{
+	p8 := config.Processors["attributes/complex"]
+	assert.Equal(t, p8, &Config{
 		ProcessorSettings: configmodels.ProcessorSettings{
 			NameVal: "attributes/complex",
 			TypeVal: typeStr,
@@ -162,8 +173,8 @@ func TestLoadingConifg(t *testing.T) {
 		},
 	})
 
-	p8 := config.Processors["attributes/example"]
-	assert.Equal(t, p8, &Config{
+	p9 := config.Processors["attributes/example"]
+	assert.Equal(t, p9, &Config{
 		ProcessorSettings: configmodels.ProcessorSettings{
 			NameVal: "attributes/example",
 			TypeVal: typeStr,
@@ -177,8 +188,8 @@ func TestLoadingConifg(t *testing.T) {
 		},
 	})
 
-	p9 := config.Processors["attributes/regexp"]
-	assert.Equal(t, p9, &Config{
+	p10 := config.Processors["attributes/regexp"]
+	assert.Equal(t, p10, &Config{
 		ProcessorSettings: configmodels.ProcessorSettings{
 			NameVal: "attributes/regexp",
 			TypeVal: typeStr,

--- a/processor/attributesprocessor/factory.go
+++ b/processor/attributesprocessor/factory.go
@@ -111,6 +111,7 @@ func buildAttributesConfiguration(config Config) ([]attributeAction, error) {
 			Key:    a.Key,
 			Action: a.Action,
 		}
+
 		switch a.Action {
 		case INSERT, UPDATE, UPSERT:
 			if a.Value == nil && a.FromAttribute == "" {
@@ -129,9 +130,10 @@ func buildAttributesConfiguration(config Config) ([]attributeAction, error) {
 			} else {
 				action.FromAttribute = a.FromAttribute
 			}
-
-		case DELETE:
-			// Do nothing since `key` is the only required field for `delete` action.
+		case HASH, DELETE:
+			if a.Value != nil || a.FromAttribute != "" {
+				return nil, fmt.Errorf("error creating \"attributes\" processor. Action \"%s\" does not use \"value\" or \"from_attribute\" field. These must not be specified for %d-th action of processor %q", a.Action, i, config.Name())
+			}
 
 		default:
 			return nil, fmt.Errorf("error creating \"attributes\" processor due to unsupported action %q at the %d-th actions of processor %q", a.Action, i, config.Name())

--- a/processor/attributesprocessor/testdata/config.yaml
+++ b/processor/attributesprocessor/testdata/config.yaml
@@ -62,6 +62,12 @@ processors:
       - key: duplicate_key
         action: delete
 
+  # The following demonstrates hash existing attribute values.
+  attributes/hash:
+    actions:
+      - key: user.email
+        action: hash 
+
 
   # The following demonstrates excluding spans from this attributes processor.
   # Ex. The following spans match the properties and won't be processed by the


### PR DESCRIPTION
**Description:** 
The new HASH action hashes existing attribute values (using SHA-1) and
replaces the original value with the hashed ones. This is useful when
users want to obfuscate some sensitive values but still want to drive
metrics in the backend based on those values.


**Testing:**: 
- Added test cases for functionality and config.
- Tested manually.

**Documentation:** Updated documentation.