### PR TITLE
Expose service command

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -62,6 +62,11 @@ type Application struct {
 	asyncErrorChannel chan error
 }
 
+// Command returns Application's root command.
+func (app *Application) Command() *cobra.Command {
+	return app.rootCmd
+}
+
 // ApplicationStartInfo is the information that is logged at the application start.
 // This information can be overridden in custom builds.
 type ApplicationStartInfo struct {

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -41,6 +41,7 @@ func TestApplication_Start(t *testing.T) {
 
 	app, err := New(factories, ApplicationStartInfo{})
 	require.NoError(t, err)
+	assert.Equal(t, app.rootCmd, app.Command())
 
 	const testPrefix = "a_test"
 	metricsPort := testutils.GetAvailablePort(t)


### PR DESCRIPTION
Signed-off-by: Pavol Loffay <ploffay@redhat.com>

**Description:** <Describe what has changed. 
This patch exposes service's `cobra.Command`. This is useful when service is embedded in other application which is adding other configuration properties.

I would like to use this feature in https://github.com/jaegertracing/jaeger-opentelemetry-collector to add Jaeger storage flags. The storage flags will be taken into account when creating a default exporter configuration. Storage flags will enable us a smoother migration from Jaeger collector to jaeger-otel-collector in jaeger-operator.

**Link to tracking Issue:** <Issue number if applicable>


**Testing:** < Describe what testing was performed and which tests were added.>

**Documentation:** < Describe the documentation added.>