### PR TITLE
Introduce internal TraceData and other data structures

### DIFF
--- a/consumer/consumer.go
+++ b/consumer/consumer.go
@@ -19,6 +19,7 @@ import (
 	"context"
 
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
+	"github.com/open-telemetry/opentelemetry-collector/internal/data"
 )
 
 // MetricsConsumer is an interface that receives consumerdata.MetricsData, process it as needed, and
@@ -37,9 +38,9 @@ type TraceConsumer interface {
 	ConsumeTraceData(ctx context.Context, td consumerdata.TraceData) error
 }
 
-// OTLPTraceConsumer is an interface that receives consumerdata.OTLPTraceData, processes it
+// TraceConsumerV2 is an interface that receives data.TraceData, processes it
 // as needed, and sends it to the next processing node if any or to the destination.
-type OTLPTraceConsumer interface {
-	// ConsumeOTLPTrace receives consumerdata.OTLPTraceData for processing.
-	ConsumeOTLPTrace(ctx context.Context, td consumerdata.OTLPTraceData) error
+type TraceConsumerV2 interface {
+	// ConsumeTraceV2 receives data.TraceData for processing.
+	ConsumeTraceV2(ctx context.Context, td data.TraceData) error
 }

--- a/consumer/consumerdata/consumerdata.go
+++ b/consumer/consumerdata/consumerdata.go
@@ -20,7 +20,6 @@ import (
 	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
 	resourcepb "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
 	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
-	otlptrace "github.com/open-telemetry/opentelemetry-proto/gen/go/trace/v1"
 )
 
 // MetricsData is a struct that groups proto metrics with a unique node and a resource.
@@ -36,23 +35,4 @@ type TraceData struct {
 	Resource     *resourcepb.Resource
 	Spans        []*tracepb.Span
 	SourceFormat string
-}
-
-// OTLPTraceData is a struct that groups proto spans with a resource. This is the
-// newer version of TraceData, using OTLP-based representation.
-type OTLPTraceData struct {
-	resourceSpanList []*otlptrace.ResourceSpans
-}
-
-func NewOTLPTraceData(resourceSpanList []*otlptrace.ResourceSpans) OTLPTraceData {
-	return OTLPTraceData{resourceSpanList}
-}
-
-// SpanCount calculates the total number of spans.
-func (td OTLPTraceData) SpanCount() int {
-	spanCount := 0
-	for _, rsl := range td.resourceSpanList {
-		spanCount += len(rsl.Spans)
-	}
-	return spanCount
 }

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -31,9 +31,9 @@ type TraceExporter interface {
 	Exporter
 }
 
-// OTLPTraceExporter is an OTLPTraceConsumer that is also an Exporter.
-type OTLPTraceExporter interface {
-	consumer.OTLPTraceConsumer
+// TraceExporterV2 is an TraceConsumerV2 that is also an Exporter.
+type TraceExporterV2 interface {
+	consumer.TraceConsumerV2
 	Exporter
 }
 

--- a/exporter/exporterhelper/tracehelper.go
+++ b/exporter/exporterhelper/tracehelper.go
@@ -21,6 +21,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-collector/exporter"
+	"github.com/open-telemetry/opentelemetry-collector/internal/data"
 	"github.com/open-telemetry/opentelemetry-collector/obsreport"
 )
 
@@ -28,9 +29,9 @@ import (
 // returns the number of dropped spans.
 type traceDataPusher func(ctx context.Context, td consumerdata.TraceData) (droppedSpans int, err error)
 
-// otlpTraceDataPusher is a helper function that is similar to ConsumeTraceData but also
+// traceV2DataPusher is a helper function that is similar to ConsumeTraceData but also
 // returns the number of dropped spans.
-type otlpTraceDataPusher func(ctx context.Context, td consumerdata.OTLPTraceData) (droppedSpans int, err error)
+type traceV2DataPusher func(ctx context.Context, td data.TraceData) (droppedSpans int, err error)
 
 // traceExporter implements the exporter with additional helper options.
 type traceExporter struct {
@@ -108,21 +109,21 @@ func (p traceDataPusher) withObservability(exporterName string) traceDataPusher 
 	}
 }
 
-type otlpTraceExporter struct {
+type traceExporterV2 struct {
 	exporterFullName string
-	dataPusher       otlpTraceDataPusher
+	dataPusher       traceV2DataPusher
 	shutdown         Shutdown
 }
 
-var _ exporter.OTLPTraceExporter = (*otlpTraceExporter)(nil)
+var _ exporter.TraceExporterV2 = (*traceExporterV2)(nil)
 
-func (te *otlpTraceExporter) Start(host component.Host) error {
+func (te *traceExporterV2) Start(host component.Host) error {
 	return nil
 }
 
-func (te *otlpTraceExporter) ConsumeOTLPTrace(
+func (te *traceExporterV2) ConsumeTraceV2(
 	ctx context.Context,
-	td consumerdata.OTLPTraceData,
+	td data.TraceData,
 ) error {
 	exporterCtx := obsreport.ExporterContext(ctx, te.exporterFullName)
 	_, err := te.dataPusher(exporterCtx, td)
@@ -130,17 +131,17 @@ func (te *otlpTraceExporter) ConsumeOTLPTrace(
 }
 
 // Shutdown stops the exporter and is invoked during shutdown.
-func (te *otlpTraceExporter) Shutdown() error {
+func (te *traceExporterV2) Shutdown() error {
 	return te.shutdown()
 }
 
-// NewOTLPTraceExporter creates an OTLPTraceExporter that can record metrics and can wrap
+// NewTraceExporterV2 creates a TraceExporterV2 that can record metrics and can wrap
 // every request with a Span.
-func NewOTLPTraceExporter(
+func NewTraceExporterV2(
 	config configmodels.Exporter,
-	dataPusher otlpTraceDataPusher,
+	dataPusher traceV2DataPusher,
 	options ...ExporterOption,
-) (exporter.OTLPTraceExporter, error) {
+) (exporter.TraceExporterV2, error) {
 
 	if config == nil {
 		return nil, errNilConfig
@@ -161,7 +162,7 @@ func NewOTLPTraceExporter(
 		}
 	}
 
-	return &otlpTraceExporter{
+	return &traceExporterV2{
 		exporterFullName: config.Name(),
 		dataPusher:       dataPusher,
 		shutdown:         opts.shutdown,
@@ -170,8 +171,8 @@ func NewOTLPTraceExporter(
 
 // withObservability wraps the current pusher into a function that records
 // the observability signals during the pusher execution.
-func (p otlpTraceDataPusher) withObservability(exporterName string) otlpTraceDataPusher {
-	return func(ctx context.Context, td consumerdata.OTLPTraceData) (int, error) {
+func (p traceV2DataPusher) withObservability(exporterName string) traceV2DataPusher {
+	return func(ctx context.Context, td data.TraceData) (int, error) {
 		exporterCtx, span := obsreport.StartTraceDataExportOp(ctx, exporterName)
 		// Forward the data to the next consumer (this pusher is the next).
 		droppedSpans, err := p(exporterCtx, td)

--- a/exporter/exporterhelper/tracehelper_test.go
+++ b/exporter/exporterhelper/tracehelper_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
-	otlptrace "github.com/open-telemetry/opentelemetry-proto/gen/go/trace/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opencensus.io/trace"
@@ -28,6 +27,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-collector/exporter"
+	"github.com/open-telemetry/opentelemetry-collector/internal/data"
 	"github.com/open-telemetry/opentelemetry-collector/observability"
 	"github.com/open-telemetry/opentelemetry-collector/observability/observabilitytest"
 	"github.com/open-telemetry/opentelemetry-collector/obsreport"
@@ -237,94 +237,94 @@ func (tote *testOCTraceExporter) ExportSpan(sd *trace.SpanData) {
 	tote.spanData = append(tote.spanData, sd)
 }
 
-func TestOTLPTraceExporter_InvalidName(t *testing.T) {
-	te, err := NewOTLPTraceExporter(nil, newPushOTLPTrace(0, nil))
+func TestTraceV2Exporter_InvalidName(t *testing.T) {
+	te, err := NewTraceExporterV2(nil, newPushTraceV2(0, nil))
 	require.Nil(t, te)
 	require.Equal(t, errNilConfig, err)
 }
 
-func TestOTLPTraceExporter_NilPushTraceData(t *testing.T) {
-	te, err := NewOTLPTraceExporter(fakeTraceExporterConfig, nil)
+func TestTraceV2Exporter_NilPushTraceData(t *testing.T) {
+	te, err := NewTraceExporterV2(fakeTraceExporterConfig, nil)
 	require.Nil(t, te)
 	require.Equal(t, errNilPushTraceData, err)
 }
 
-func TestOTLPTraceExporter_Default(t *testing.T) {
-	td := consumerdata.OTLPTraceData{}
-	te, err := NewOTLPTraceExporter(fakeTraceExporterConfig, newPushOTLPTrace(0, nil))
+func TestTraceV2Exporter_Default(t *testing.T) {
+	td := data.TraceData{}
+	te, err := NewTraceExporterV2(fakeTraceExporterConfig, newPushTraceV2(0, nil))
 	assert.NotNil(t, te)
 	assert.Nil(t, err)
 
-	assert.Nil(t, te.ConsumeOTLPTrace(context.Background(), td))
+	assert.Nil(t, te.ConsumeTraceV2(context.Background(), td))
 	assert.Nil(t, te.Shutdown())
 }
 
-func TestOTLPTraceExporter_Default_ReturnError(t *testing.T) {
-	td := consumerdata.OTLPTraceData{}
+func TestTraceV2Exporter_Default_ReturnError(t *testing.T) {
+	td := data.TraceData{}
 	want := errors.New("my_error")
-	te, err := NewOTLPTraceExporter(fakeTraceExporterConfig, newPushOTLPTrace(0, want))
+	te, err := NewTraceExporterV2(fakeTraceExporterConfig, newPushTraceV2(0, want))
 	require.Nil(t, err)
 	require.NotNil(t, te)
 
-	err = te.ConsumeOTLPTrace(context.Background(), td)
+	err = te.ConsumeTraceV2(context.Background(), td)
 	require.Equalf(t, want, err, "ConsumeTraceData returns: Want %v Got %v", want, err)
 }
 
-func TestOTLPTraceExporter_WithRecordMetrics(t *testing.T) {
-	te, err := NewOTLPTraceExporter(fakeTraceExporterConfig, newPushOTLPTrace(0, nil))
+func TestTraceV2Exporter_WithRecordMetrics(t *testing.T) {
+	te, err := NewTraceExporterV2(fakeTraceExporterConfig, newPushTraceV2(0, nil))
 	require.Nil(t, err)
 	require.NotNil(t, te)
 
-	checkRecordedMetricsForOTLPTraceExporter(t, te, nil, 0)
+	checkRecordedMetricsForTraceExporterV2(t, te, nil, 0)
 }
 
-func TestOTLPTraceExporter_WithRecordMetrics_NonZeroDropped(t *testing.T) {
-	te, err := NewOTLPTraceExporter(fakeTraceExporterConfig, newPushOTLPTrace(1, nil))
+func TestTraceV2Exporter_WithRecordMetrics_NonZeroDropped(t *testing.T) {
+	te, err := NewTraceExporterV2(fakeTraceExporterConfig, newPushTraceV2(1, nil))
 	require.Nil(t, err)
 	require.NotNil(t, te)
 
-	checkRecordedMetricsForOTLPTraceExporter(t, te, nil, 1)
+	checkRecordedMetricsForTraceExporterV2(t, te, nil, 1)
 }
 
-func TestOTLPTraceExporter_WithRecordMetrics_ReturnError(t *testing.T) {
+func TestTraceV2Exporter_WithRecordMetrics_ReturnError(t *testing.T) {
 	want := errors.New("my_error")
-	te, err := NewOTLPTraceExporter(fakeTraceExporterConfig, newPushOTLPTrace(0, want))
+	te, err := NewTraceExporterV2(fakeTraceExporterConfig, newPushTraceV2(0, want))
 	require.Nil(t, err)
 	require.NotNil(t, te)
 
-	checkRecordedMetricsForOTLPTraceExporter(t, te, want, 0)
+	checkRecordedMetricsForTraceExporterV2(t, te, want, 0)
 }
 
-func TestOTLPTraceExporter_WithSpan(t *testing.T) {
-	te, err := NewOTLPTraceExporter(fakeTraceExporterConfig, newPushOTLPTrace(0, nil))
+func TestTraceV2Exporter_WithSpan(t *testing.T) {
+	te, err := NewTraceExporterV2(fakeTraceExporterConfig, newPushTraceV2(0, nil))
 	require.Nil(t, err)
 	require.NotNil(t, te)
 
-	checkWrapSpanForOTLPTraceExporter(t, te, nil, 1)
+	checkWrapSpanForTraceExporterV2(t, te, nil, 1)
 }
 
-func TestOTLPTraceExporter_WithSpan_NonZeroDropped(t *testing.T) {
-	te, err := NewOTLPTraceExporter(fakeTraceExporterConfig, newPushOTLPTrace(1, nil))
+func TestTraceV2Exporter_WithSpan_NonZeroDropped(t *testing.T) {
+	te, err := NewTraceExporterV2(fakeTraceExporterConfig, newPushTraceV2(1, nil))
 	require.Nil(t, err)
 	require.NotNil(t, te)
 
-	checkWrapSpanForOTLPTraceExporter(t, te, nil, 1)
+	checkWrapSpanForTraceExporterV2(t, te, nil, 1)
 }
 
-func TestOTLPTraceExporter_WithSpan_ReturnError(t *testing.T) {
+func TestTraceV2Exporter_WithSpan_ReturnError(t *testing.T) {
 	want := errors.New("my_error")
-	te, err := NewOTLPTraceExporter(fakeTraceExporterConfig, newPushOTLPTrace(0, want))
+	te, err := NewTraceExporterV2(fakeTraceExporterConfig, newPushTraceV2(0, want))
 	require.Nil(t, err)
 	require.NotNil(t, te)
 
-	checkWrapSpanForOTLPTraceExporter(t, te, want, 1)
+	checkWrapSpanForTraceExporterV2(t, te, want, 1)
 }
 
-func TestOTLPTraceExporter_WithShutdown(t *testing.T) {
+func TestTraceV2Exporter_WithShutdown(t *testing.T) {
 	shutdownCalled := false
 	shutdown := func() error { shutdownCalled = true; return nil }
 
-	te, err := NewOTLPTraceExporter(fakeTraceExporterConfig, newPushOTLPTrace(0, nil), WithShutdown(shutdown))
+	te, err := NewTraceExporterV2(fakeTraceExporterConfig, newPushTraceV2(0, nil), WithShutdown(shutdown))
 	assert.NotNil(t, te)
 	assert.Nil(t, err)
 
@@ -332,33 +332,35 @@ func TestOTLPTraceExporter_WithShutdown(t *testing.T) {
 	assert.True(t, shutdownCalled)
 }
 
-func TestOTLPTraceExporter_WithShutdown_ReturnError(t *testing.T) {
+func TestTraceV2Exporter_WithShutdown_ReturnError(t *testing.T) {
 	want := errors.New("my_error")
 	shutdownErr := func() error { return want }
 
-	te, err := NewOTLPTraceExporter(fakeTraceExporterConfig, newPushOTLPTrace(0, nil), WithShutdown(shutdownErr))
+	te, err := NewTraceExporterV2(fakeTraceExporterConfig, newPushTraceV2(0, nil), WithShutdown(shutdownErr))
 	assert.NotNil(t, te)
 	assert.Nil(t, err)
 
 	assert.Equal(t, te.Shutdown(), want)
 }
 
-func newPushOTLPTrace(droppedSpans int, retError error) otlpTraceDataPusher {
-	return func(ctx context.Context, td consumerdata.OTLPTraceData) (int, error) {
+func newPushTraceV2(droppedSpans int, retError error) traceV2DataPusher {
+	return func(ctx context.Context, td data.TraceData) (int, error) {
 		return droppedSpans, retError
 	}
 }
 
-func checkRecordedMetricsForOTLPTraceExporter(t *testing.T, te exporter.OTLPTraceExporter, wantError error, droppedSpans int) {
+func checkRecordedMetricsForTraceExporterV2(t *testing.T, te exporter.TraceExporterV2, wantError error, droppedSpans int) {
 	doneFn := observabilitytest.SetupRecordedMetricsTest()
 	defer doneFn()
 
-	spans := make([]*otlptrace.Span, 2)
-	td := consumerdata.NewOTLPTraceData([]*otlptrace.ResourceSpans{{Spans: spans}})
+	spans := make([]*data.Span, 2)
+	rs := data.NewResourceSpans(nil, nil)
+	rs.SetSpans(spans)
+	td := data.NewTraceData([]*data.ResourceSpans{rs})
 	ctx := observability.ContextWithReceiverName(context.Background(), fakeTraceReceiverName)
 	const numBatches = 7
 	for i := 0; i < numBatches; i++ {
-		require.Equal(t, wantError, te.ConsumeOTLPTrace(ctx, td))
+		require.Equal(t, wantError, te.ConsumeTraceV2(ctx, td))
 	}
 
 	err := observabilitytest.CheckValueViewExporterReceivedSpans(fakeTraceReceiverName, fakeTraceExporterName, numBatches*len(spans))
@@ -368,22 +370,25 @@ func checkRecordedMetricsForOTLPTraceExporter(t *testing.T, te exporter.OTLPTrac
 	require.Nilf(t, err, "CheckValueViewExporterDroppedSpans: Want nil Got %v", err)
 }
 
-func generateOTLPTraceTraffic(t *testing.T, te exporter.OTLPTraceExporter, numRequests int, wantError error) {
-	td := consumerdata.NewOTLPTraceData([]*otlptrace.ResourceSpans{{Spans: []*otlptrace.Span{{}}}})
+func generateTraceV2Traffic(t *testing.T, te exporter.TraceExporterV2, numRequests int, wantError error) {
+	spans := make([]*data.Span, 1)
+	rs := data.NewResourceSpans(nil, nil)
+	rs.SetSpans(spans)
+	td := data.NewTraceData([]*data.ResourceSpans{rs})
 	ctx, span := trace.StartSpan(context.Background(), fakeTraceParentSpanName, trace.WithSampler(trace.AlwaysSample()))
 	defer span.End()
 	for i := 0; i < numRequests; i++ {
-		require.Equal(t, wantError, te.ConsumeOTLPTrace(ctx, td))
+		require.Equal(t, wantError, te.ConsumeTraceV2(ctx, td))
 	}
 }
 
-func checkWrapSpanForOTLPTraceExporter(t *testing.T, te exporter.OTLPTraceExporter, wantError error, numSpans int64) {
+func checkWrapSpanForTraceExporterV2(t *testing.T, te exporter.TraceExporterV2, wantError error, numSpans int64) {
 	ocSpansSaver := new(testOCTraceExporter)
 	trace.RegisterExporter(ocSpansSaver)
 	defer trace.UnregisterExporter(ocSpansSaver)
 
 	const numRequests = 5
-	generateOTLPTraceTraffic(t, te, numRequests, wantError)
+	generateTraceV2Traffic(t, te, numRequests, wantError)
 
 	// Inspection time!
 	ocSpansSaver.mu.Lock()

--- a/exporter/factory.go
+++ b/exporter/factory.go
@@ -48,17 +48,17 @@ type Factory interface {
 	CreateMetricsExporter(logger *zap.Logger, cfg configmodels.Exporter) (MetricsExporter, error)
 }
 
-// OTLPFactory can create OTLPTraceExporter and OTLPMetricsExporter. This is the
-// new factory type that can create OTLP-based exporters.
-type OTLPFactory interface {
+// FactoryV2 can create TraceExporterV2 and MetricsExporterV2. This is the
+// new factory type that can create new style exporters.
+type FactoryV2 interface {
 	BaseFactory
 
-	// CreateOTLPTraceReceiver creates a trace receiver based on this config.
+	// CreateTraceReceiverV2 creates a trace receiver based on this config.
 	// If the receiver type does not support tracing or if the config is not valid
 	// error will be returned instead.
-	CreateOTLPTraceExporter(logger *zap.Logger, cfg configmodels.Exporter) (OTLPTraceExporter, error)
+	CreateTraceExporterV2(logger *zap.Logger, cfg configmodels.Exporter) (TraceExporterV2, error)
 
-	// TODO: Add CreateOTLPMetricsExporter.
+	// TODO: Add CreateMetricsExporterV2.
 }
 
 // Build takes a list of exporter factories and returns a map of type map[string]Factory

--- a/internal/data/common.go
+++ b/internal/data/common.go
@@ -1,0 +1,141 @@
+// Copyright 2019 OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package data
+
+// This file contains data structures that are common for all telemetry types,
+// such as timestamps, attributes, etc.
+
+import (
+	otlp "github.com/open-telemetry/opentelemetry-proto/gen/go/common/v1"
+)
+
+// TimestampUnixNano is a time specified as UNIX Epoch time in nanoseconds since
+// 00:00:00 UTC on 1 January 1970.
+type TimestampUnixNano uint64
+
+// AttributeValueType specifies the type of value. Numerically is equal to
+// otlp.AttributeKeyValue_ValueType.
+type AttributeValueType int32
+
+const (
+	AttributeValueSTRING AttributeValueType = AttributeValueType(otlp.AttributeKeyValue_STRING)
+	AttributeValueINT    AttributeValueType = AttributeValueType(otlp.AttributeKeyValue_INT)
+	AttributeValueDOUBLE AttributeValueType = AttributeValueType(otlp.AttributeKeyValue_DOUBLE)
+	AttributeValueBOOL   AttributeValueType = AttributeValueType(otlp.AttributeKeyValue_BOOL)
+)
+
+// AttributeValue represents a value of an attribute. Typically used in an Attributes map.
+// Must use one of NewAttributeValue* functions below to create new instances.
+// Important: zero-initialized instance is not valid for use.
+//
+// Intended to be passed by value since internally it is just a pointer to actual
+// value representation. For the same reason passing by value and calling setters
+// will modify the original, e.g.:
+//
+//   function f1(val AttributeValue) { val.SetInt(234) }
+//   function f2() {
+//   	v := NewAttributeValueString("a string")
+//      f1(v)
+//      _ := v.GetType() // this will return AttributeValueINT
+//   }
+type AttributeValue struct {
+	orig *otlp.AttributeKeyValue
+}
+
+func NewAttributeValueString(v string) AttributeValue {
+	return AttributeValue{orig: &otlp.AttributeKeyValue{Type: otlp.AttributeKeyValue_STRING, StringValue: v}}
+}
+
+func NewAttributeValueInt(v int64) AttributeValue {
+	return AttributeValue{orig: &otlp.AttributeKeyValue{Type: otlp.AttributeKeyValue_INT, IntValue: v}}
+}
+
+func NewAttributeValueDouble(v float64) AttributeValue {
+	return AttributeValue{orig: &otlp.AttributeKeyValue{Type: otlp.AttributeKeyValue_DOUBLE, DoubleValue: v}}
+}
+
+func NewAttributeValueBool(v bool) AttributeValue {
+	return AttributeValue{orig: &otlp.AttributeKeyValue{Type: otlp.AttributeKeyValue_BOOL, BoolValue: v}}
+}
+
+// NewAttributeValueSlice creates a slice of attributes values that are correctly initialized.
+func NewAttributeValueSlice(len int) []AttributeValue {
+	// Allocate 2 slices, one for AttributeValues, another for underlying OTLP structs.
+	// TODO: make one allocation for both slices.
+	origs := make([]otlp.AttributeKeyValue, len)
+	wrappers := make([]AttributeValue, len)
+	for i := range origs {
+		wrappers[i].orig = &origs[i]
+	}
+	return wrappers
+}
+
+// All AttributeValue functions bellow must be called only on instances that are created
+// via NewAttributeValue* functions. Calling these functions on zero-initialized
+// AttributeValue struct will cause a panic.
+
+func (a AttributeValue) Type() AttributeValueType {
+	return AttributeValueType(a.orig.Type)
+}
+
+func (a AttributeValue) StringVal() string {
+	return a.orig.StringValue
+}
+
+func (a AttributeValue) IntVal() int64 {
+	return a.orig.IntValue
+}
+
+func (a AttributeValue) DoubleVal() float64 {
+	return a.orig.DoubleValue
+}
+
+func (a AttributeValue) BoolVal() bool {
+	return a.orig.BoolValue
+}
+
+func (a AttributeValue) SetString(v string) {
+	a.orig.Type = otlp.AttributeKeyValue_STRING
+	a.orig.StringValue = v
+}
+
+func (a AttributeValue) SetInt(v int64) {
+	a.orig.Type = otlp.AttributeKeyValue_INT
+	a.orig.IntValue = v
+}
+
+func (a AttributeValue) SetDouble(v float64) {
+	a.orig.Type = otlp.AttributeKeyValue_DOUBLE
+	a.orig.DoubleValue = v
+}
+
+func (a AttributeValue) SetBool(v bool) {
+	a.orig.Type = otlp.AttributeKeyValue_BOOL
+	a.orig.BoolValue = v
+}
+
+// AttributesMap stores a map of attribute keys to values.
+type AttributesMap map[string]AttributeValue
+
+// Attributes stores the map of attributes and a number of dropped attributes.
+// Typically used by translator functions to easily pass the pair.
+type Attributes struct {
+	attrs        AttributesMap
+	droppedCount uint32
+}
+
+func NewAttributes(m AttributesMap, droppedCount uint32) Attributes {
+	return Attributes{m, droppedCount}
+}

--- a/internal/data/common_test.go
+++ b/internal/data/common_test.go
@@ -1,0 +1,69 @@
+// Copyright 2019 OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package data
+
+import (
+	"math/rand"
+	"testing"
+
+	otlp "github.com/open-telemetry/opentelemetry-proto/gen/go/common/v1"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAttributeValue(t *testing.T) {
+	v := NewAttributeValueString("abc")
+	assert.EqualValues(t, otlp.AttributeKeyValue_STRING, v.Type())
+	assert.EqualValues(t, "abc", v.StringVal())
+
+	v = NewAttributeValueInt(123)
+	assert.EqualValues(t, otlp.AttributeKeyValue_INT, v.Type())
+	assert.EqualValues(t, 123, v.IntVal())
+
+	v = NewAttributeValueDouble(3.4)
+	assert.EqualValues(t, otlp.AttributeKeyValue_DOUBLE, v.Type())
+	assert.EqualValues(t, 3.4, v.DoubleVal())
+
+	v = NewAttributeValueBool(true)
+	assert.EqualValues(t, otlp.AttributeKeyValue_BOOL, v.Type())
+	assert.EqualValues(t, true, v.BoolVal())
+
+	v.SetString("abc")
+	assert.EqualValues(t, otlp.AttributeKeyValue_STRING, v.Type())
+	assert.EqualValues(t, "abc", v.StringVal())
+
+	v.SetInt(123)
+	assert.EqualValues(t, otlp.AttributeKeyValue_INT, v.Type())
+	assert.EqualValues(t, 123, v.IntVal())
+
+	v.SetDouble(3.4)
+	assert.EqualValues(t, otlp.AttributeKeyValue_DOUBLE, v.Type())
+	assert.EqualValues(t, 3.4, v.DoubleVal())
+
+	v.SetBool(true)
+	assert.EqualValues(t, otlp.AttributeKeyValue_BOOL, v.Type())
+	assert.EqualValues(t, true, v.BoolVal())
+}
+
+func TestNewAttributeValueSlice(t *testing.T) {
+	events := NewAttributeValueSlice(0)
+	assert.EqualValues(t, 0, len(events))
+
+	n := rand.Intn(10)
+	events = NewAttributeValueSlice(n)
+	assert.EqualValues(t, n, len(events))
+	for event := range events {
+		assert.NotNil(t, event)
+	}
+}

--- a/internal/data/doc.go
+++ b/internal/data/doc.go
@@ -1,0 +1,35 @@
+// Copyright 2019 OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package data implements data structures that represent telemetry data in-memory.
+// All data received is converted into this format and travels through the pipeline
+// in this format and that is converted from this format by exporters when sending.
+// The package is placed in "internal" for now since it is incubating and may undergoe
+// changes as we iterate and improve it. Once it is stable we will move it to an
+// exported location so that other components outside this module can use it.
+//
+// Current implementation primarily uses OTLP ProtoBuf structs as the underlying data
+// structures for many of of the declared structs. We keep a pointer to OTLP protobuf
+// in the "orig" member field. This allows efficient translation to/from OTLP wire
+// protocol. Note that the underlying data structure is kept private so that in the
+// future we are free to make changes to it to make more optimal.
+//
+// Most of internal data structures must be created via New* functions. Zero-initialized
+// structures in most cases are not valid (read comments for each struct to know if it
+// is the case). This is a slight deviation from idiomatic Go to avoid unnecessary
+// pointer checks in dozens of functions which assume the invariant that "orig" member
+// is non-nil. Several structures also provide New*Slice functions that allows to create
+// more than one instance of the struct more efficiently instead of calling New*
+// repeatedly. Use it where appropriate.
+package data

--- a/internal/data/resource.go
+++ b/internal/data/resource.go
@@ -1,0 +1,36 @@
+// Copyright 2019 OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package data
+
+// Resource information.
+//
+// Must use NewResource functions to create new instances.
+// Important: zero-initialized instance is not valid for use.
+type Resource struct {
+	// Set of attributes that describe the resource.
+	attributes AttributesMap
+}
+
+func NewResource() *Resource {
+	return &Resource{}
+}
+
+func (m *Resource) Attributes() AttributesMap {
+	return m.attributes
+}
+
+func (m *Resource) SetAttributes(v AttributesMap) {
+	m.attributes = v
+}

--- a/internal/data/trace.go
+++ b/internal/data/trace.go
@@ -1,0 +1,394 @@
+// Copyright 2019 OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package data
+
+import (
+	otlptrace "github.com/open-telemetry/opentelemetry-proto/gen/go/trace/v1"
+)
+
+// This file defines in-memory data structures to represent traces (spans).
+
+// TraceData is the top-level struct that is propagated through the traces pipeline.
+// This is the newer version of consumerdata.TraceData, but uses more efficient
+// in-memory representation.
+type TraceData struct {
+	resourceSpans []*ResourceSpans
+}
+
+func NewTraceData(resourceSpans []*ResourceSpans) TraceData {
+	return TraceData{resourceSpans}
+}
+
+// SpanCount calculates the total number of spans.
+func (td TraceData) SpanCount() int {
+	spanCount := 0
+	for _, rsl := range td.resourceSpans {
+		spanCount += len(rsl.spans)
+	}
+	return spanCount
+}
+
+// A collection of spans from a Resource.
+//
+// Must use NewResourceSpans functions to create new instances.
+// Important: zero-initialized instance is not valid for use.
+type ResourceSpans struct {
+	// The resource for the spans in this message.
+	// If this field is not set then no resource info is known.
+	resource *Resource
+
+	// A list of Spans that originate from a resource.
+	spans []*Span
+}
+
+func NewResourceSpans(resource *Resource, spans []*Span) *ResourceSpans {
+	return &ResourceSpans{resource, spans}
+}
+
+func (m *ResourceSpans) Resource() *Resource {
+	return m.resource
+}
+
+func (m *ResourceSpans) SetResource(r *Resource) {
+	m.resource = r
+}
+
+func (m *ResourceSpans) Spans() []*Span {
+	return m.spans
+}
+
+func (m *ResourceSpans) SetSpans(s []*Span) {
+	m.spans = s
+}
+
+type TraceID struct {
+	bytes []byte
+}
+
+func TraceIDFromBytes(bytes []byte) TraceID { return TraceID{bytes} }
+
+type SpanID struct {
+	bytes []byte
+}
+
+func SpanIDFromBytes(bytes []byte) SpanID { return SpanID{bytes} }
+
+// TraceState in w3c-trace-context format: https://www.w3.org/TR/trace-context/#tracestate-header
+type TraceState string
+
+type SpanKind otlptrace.Span_SpanKind
+
+func (sk SpanKind) String() string { return otlptrace.Span_SpanKind(sk).String() }
+
+const (
+	SpanKindUNSPECIFIED SpanKind = 0
+	SpanKindINTERNAL    SpanKind = SpanKind(otlptrace.Span_INTERNAL)
+	SpanKindSERVER      SpanKind = SpanKind(otlptrace.Span_SERVER)
+	SpanKindCLIENT      SpanKind = SpanKind(otlptrace.Span_CLIENT)
+	SpanKindPRODUCER    SpanKind = SpanKind(otlptrace.Span_PRODUCER)
+	SpanKindCONSUMER    SpanKind = SpanKind(otlptrace.Span_CONSUMER)
+)
+
+// Span represents a single operation within a trace.
+// See Span definition in OTLP: https://github.com/open-telemetry/opentelemetry-proto/blob/master/opentelemetry/proto/trace/v1/trace.proto#L37
+//
+// Must use NewSpan* functions to create new instances.
+// Important: zero-initialized instance is not valid for use.
+type Span struct {
+	// Wrap OTLP Span.
+	orig *otlptrace.Span
+
+	// Override a few fields. These fields are the source of truth. Their counterparts
+	// stored in corresponding fields of "orig" are ignored.
+	attributes AttributesMap
+	events     []*SpanEvent
+	links      []*SpanLink
+}
+
+func NewSpan() *Span {
+	return &Span{orig: &otlptrace.Span{}}
+}
+
+// NewSpanSlice creates a slice of Spans that are correctly initialized.
+func NewSpanSlice(len int) []Span {
+	origs := make([]otlptrace.Span, len)
+	wrappers := make([]Span, len)
+	for i := range origs {
+		wrappers[i].orig = &origs[i]
+	}
+	return wrappers
+}
+
+func (m *Span) TraceID() TraceID {
+	return TraceIDFromBytes(m.orig.TraceId)
+}
+
+func (m *Span) SpanID() SpanID {
+	return SpanIDFromBytes(m.orig.SpanId)
+}
+
+func (m *Span) TraceState() TraceState {
+	return TraceState(m.orig.Tracestate)
+}
+
+func (m *Span) ParentSpanID() SpanID {
+	return SpanIDFromBytes(m.orig.ParentSpanId)
+}
+
+func (m *Span) Name() string {
+	return m.orig.Name
+}
+
+func (m *Span) Kind() SpanKind {
+	return SpanKind(m.orig.Kind)
+}
+
+func (m *Span) StartTime() TimestampUnixNano {
+	return TimestampUnixNano(m.orig.StartTimeUnixnano)
+}
+
+func (m *Span) EndTime() TimestampUnixNano {
+	return TimestampUnixNano(m.orig.EndTimeUnixnano)
+}
+
+func (m *Span) Attributes() AttributesMap {
+	return m.attributes
+}
+
+func (m *Span) DroppedAttributesCount() uint32 {
+	return m.orig.DroppedAttributesCount
+}
+
+func (m *Span) Events() []*SpanEvent {
+	return m.events
+}
+
+func (m *Span) DroppedEventsCount() uint32 {
+	return m.orig.DroppedEventsCount
+}
+
+func (m *Span) Links() []*SpanLink {
+	return m.links
+}
+
+func (m *Span) DroppedLinksCount() uint32 {
+	return m.orig.DroppedLinksCount
+}
+
+func (m *Span) Status() SpanStatus {
+	return SpanStatus{orig: m.orig.Status}
+}
+
+func (m *Span) SetTraceID(v TraceID) {
+	m.orig.TraceId = v.bytes
+}
+
+func (m *Span) SetSpanID(v SpanID) {
+	m.orig.SpanId = v.bytes
+}
+
+func (m *Span) SetTraceState(v TraceState) {
+	m.orig.Tracestate = string(v)
+}
+
+func (m *Span) SetParentSpanID(v SpanID) {
+	m.orig.ParentSpanId = v.bytes
+}
+
+func (m *Span) SetName(v string) {
+	m.orig.Name = v
+}
+
+func (m *Span) SetKind(v SpanKind) {
+	m.orig.Kind = otlptrace.Span_SpanKind(v)
+}
+
+func (m *Span) SetStartTime(v TimestampUnixNano) {
+	m.orig.StartTimeUnixnano = uint64(v)
+}
+
+func (m *Span) SetEndTime(v TimestampUnixNano) {
+	m.orig.EndTimeUnixnano = uint64(v)
+}
+
+func (m *Span) SetAttributes(v Attributes) {
+	m.attributes = v.attrs
+	m.orig.DroppedAttributesCount = v.droppedCount
+}
+
+func (m *Span) SetEvents(v []*SpanEvent) {
+	m.events = v
+}
+
+func (m *Span) SetDroppedEventsCount(v uint32) {
+	m.orig.DroppedEventsCount = v
+}
+
+func (m *Span) SetLinks(v []*SpanLink) {
+	m.links = v
+}
+
+func (m *Span) SetDroppedLinksCount(v uint32) {
+	m.orig.DroppedLinksCount = v
+}
+
+func (m *Span) SetStatus(v SpanStatus) {
+	m.orig.Status = v.orig
+}
+
+type SpanStatus struct {
+	orig *otlptrace.Status
+}
+
+// StatusCode mirrors the codes defined at
+// https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/api-tracing.md#statuscanonicalcode
+// and is numerically equal to Standard GRPC codes https://github.com/grpc/grpc/blob/master/doc/statuscodes.md
+type StatusCode otlptrace.Status_StatusCode
+
+func NewSpanStatus(code StatusCode, message string) SpanStatus {
+	return SpanStatus{orig: &otlptrace.Status{
+		Code:    otlptrace.Status_StatusCode(code),
+		Message: message,
+	}}
+}
+
+// SpanEvent is a time-stamped annotation of the span, consisting of user-supplied
+// text description and key-value pairs. See OTLP for event definition.
+//
+// Must use NewSpanEvent* function to create new instances.
+// Important: zero-initialized instance is not valid for use.
+type SpanEvent struct {
+	// Wrap OTLP Event.
+	orig *otlptrace.Span_Event
+
+	// Override attributes. This field is the source of truth for attributes.
+	// The counterpart stored in corresponding field of "orig" is ignored.
+	attributes AttributesMap
+}
+
+func NewSpanEvent(timestamp TimestampUnixNano, name string, attributes Attributes) *SpanEvent {
+	return &SpanEvent{
+		orig: &otlptrace.Span_Event{
+			TimeUnixnano:           uint64(timestamp),
+			Name:                   name,
+			DroppedAttributesCount: attributes.droppedCount,
+		},
+		attributes: attributes.attrs,
+	}
+}
+
+// NewSpanEventSlice creates a slice of SpanEvents that are correctly initialized.
+func NewSpanEventSlice(len int) []SpanEvent {
+	origs := make([]otlptrace.Span_Event, len)
+	wrappers := make([]SpanEvent, len)
+	for i := range origs {
+		wrappers[i].orig = &origs[i]
+	}
+	return wrappers
+}
+
+func (m *SpanEvent) Timestamp() TimestampUnixNano {
+	return TimestampUnixNano(m.orig.TimeUnixnano)
+}
+
+func (m *SpanEvent) Name() string {
+	return m.orig.Name
+}
+
+func (m *SpanEvent) Attributes() AttributesMap {
+	return m.attributes
+}
+func (m *SpanEvent) DroppedAttributesCount() uint32 {
+	return m.orig.DroppedAttributesCount
+}
+
+func (m *SpanEvent) SetTimestamp(v TimestampUnixNano) {
+	m.orig.TimeUnixnano = uint64(v)
+}
+
+func (m *SpanEvent) SetName(v string) {
+	m.orig.Name = v
+}
+
+func (m *SpanEvent) SetAttributes(v Attributes) {
+	m.attributes = v.attrs
+	m.orig.DroppedAttributesCount = v.droppedCount
+}
+
+// SpanLink is a pointer from the current span to another span in the same trace or in a
+// different trace. See OTLP for link definition.
+//
+// Must use NewSpanLink* function to create new instances.
+// Important: zero-initialized instance is not valid for use.
+type SpanLink struct {
+	// Wrap OTLP Link.
+	orig *otlptrace.Span_Link
+
+	// Override attributes. This field is the source of truth for attributes.
+	// The counterpart stored in corresponding field of "orig" is ignored.
+	attributes AttributesMap
+}
+
+// NewSpanLink creates a SpanLink that is correctly initialized.
+func NewSpanLink() *SpanLink {
+	return &SpanLink{orig: &otlptrace.Span_Link{}}
+}
+
+// NewSpanLinkSlice creates a slice of SpanLinks that are correctly initialized.
+func NewSpanLinkSlice(len int) []SpanLink {
+	origs := make([]otlptrace.Span_Link, len)
+	wrappers := make([]SpanLink, len)
+	for i := range origs {
+		wrappers[i].orig = &origs[i]
+	}
+	return wrappers
+}
+
+func (m *SpanLink) TraceID() TraceID {
+	return TraceIDFromBytes(m.orig.TraceId)
+}
+
+func (m *SpanLink) SpanID() SpanID {
+	return SpanIDFromBytes(m.orig.SpanId)
+}
+
+func (m *SpanLink) Attributes() AttributesMap {
+	return m.attributes
+}
+
+func (m *SpanLink) DroppedAttributesCount() uint32 {
+	return m.orig.DroppedAttributesCount
+}
+
+func (m *SpanLink) TraceState() TraceState {
+	return TraceState(m.orig.Tracestate)
+}
+
+func (m *SpanLink) SetTraceID(v TraceID) {
+	m.orig.TraceId = v.bytes
+}
+
+func (m *SpanLink) SetSpanID(v SpanID) {
+	m.orig.SpanId = v.bytes
+}
+
+func (m *SpanLink) SetTraceState(v TraceState) {
+	m.orig.Tracestate = string(v)
+}
+
+func (m *SpanLink) SetAttributes(v Attributes) {
+	m.attributes = v.attrs
+	m.orig.DroppedAttributesCount = v.droppedCount
+}

--- a/internal/data/trace_test.go
+++ b/internal/data/trace_test.go
@@ -1,0 +1,106 @@
+// Copyright 2019 OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package data
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSpanCount(t *testing.T) {
+	td := TraceData{}
+	assert.EqualValues(t, 0, td.SpanCount())
+
+	td = TraceData{
+		resourceSpans: []*ResourceSpans{
+			NewResourceSpans(nil, []*Span{}),
+		},
+	}
+	assert.EqualValues(t, 0, td.SpanCount())
+
+	td = TraceData{
+		resourceSpans: []*ResourceSpans{
+			NewResourceSpans(nil, []*Span{nil}),
+		},
+	}
+	assert.EqualValues(t, 1, td.SpanCount())
+
+	td = TraceData{
+		resourceSpans: []*ResourceSpans{
+			NewResourceSpans(nil, []*Span{nil}),
+			NewResourceSpans(nil, []*Span{}),
+			NewResourceSpans(nil, []*Span{nil, nil, nil, nil, nil}),
+		},
+	}
+	assert.EqualValues(t, 6, td.SpanCount())
+}
+
+func TestNewSpanSlice(t *testing.T) {
+	spans := NewSpanSlice(0)
+	assert.EqualValues(t, 0, len(spans))
+
+	n := rand.Intn(10)
+	spans = NewSpanSlice(n)
+	assert.EqualValues(t, n, len(spans))
+	for span := range spans {
+		assert.NotNil(t, span)
+	}
+}
+
+func TestNewSpanEventSlice(t *testing.T) {
+	events := NewSpanEventSlice(0)
+	assert.EqualValues(t, 0, len(events))
+
+	n := rand.Intn(10)
+	events = NewSpanEventSlice(n)
+	assert.EqualValues(t, n, len(events))
+	for event := range events {
+		assert.NotNil(t, event)
+	}
+}
+
+func TestNewSpanLinkSlice(t *testing.T) {
+	links := NewSpanLinkSlice(0)
+	assert.EqualValues(t, 0, len(links))
+
+	n := rand.Intn(10)
+	links = NewSpanLinkSlice(n)
+	assert.EqualValues(t, n, len(links))
+	for link := range links {
+		assert.NotNil(t, link)
+	}
+}
+
+func TestAttrs(t *testing.T) {
+	attrs := AttributesMap{"attr1": NewAttributeValueString("abc")}
+
+	span := NewSpan()
+	assert.EqualValues(t, 0, span.DroppedAttributesCount())
+	span.SetAttributes(NewAttributes(attrs, 123))
+	assert.EqualValues(t, 123, span.DroppedAttributesCount())
+	assert.EqualValues(t, attrs, span.Attributes())
+
+	event := NewSpanEvent(0, "", NewAttributes(attrs, 234))
+	assert.EqualValues(t, 234, event.DroppedAttributesCount())
+	assert.EqualValues(t, attrs, event.Attributes())
+
+	link := NewSpanLink()
+	assert.EqualValues(t, 0, link.DroppedAttributesCount())
+	link.SetAttributes(NewAttributes(attrs, 456))
+	assert.EqualValues(t, 456, link.DroppedAttributesCount())
+	assert.EqualValues(t, attrs, link.Attributes())
+}

--- a/receiver/factory.go
+++ b/receiver/factory.go
@@ -76,18 +76,18 @@ type Factory interface {
 		consumer consumer.MetricsConsumer) (MetricsReceiver, error)
 }
 
-// OTLPFactory can create OTLPTraceReceiver and OTLPMetricsReceiver. This is the
-// new factory type that can create OTLP-based receivers.
-type OTLPFactory interface {
+// FactoryV2 can create TraceReceiverV2 and MetricsReceiverV2. This is the
+// new factory type that can create new style receivers.
+type FactoryV2 interface {
 	BaseFactory
 
-	// CreateOTLPTraceReceiver creates a trace receiver based on this config.
+	// CreateTraceReceiverV2 creates a trace receiver based on this config.
 	// If the receiver type does not support tracing or if the config is not valid
 	// error will be returned instead.
-	CreateOTLPTraceReceiver(ctx context.Context, logger *zap.Logger, cfg configmodels.Receiver,
-		nextConsumer consumer.OTLPTraceConsumer) (TraceReceiver, error)
+	CreateTraceReceiverV2(ctx context.Context, logger *zap.Logger, cfg configmodels.Receiver,
+		nextConsumer consumer.TraceConsumerV2) (TraceReceiver, error)
 
-	// TODO: add CreateOTLPMetricsReceiver.
+	// TODO: add CreateMetricsReceiverV2.
 }
 
 // Build takes a list of receiver factories and returns a map of type map[string]Factory

--- a/translator/trace/oc_to_otlp.go
+++ b/translator/trace/oc_to_otlp.go
@@ -46,10 +46,10 @@ const (
 	ocTimeEventMessageEventCSize = "opencensus.timeevent.messageevent.csize"
 )
 
-func ocToOtlp(td consumerdata.TraceData) consumerdata.OTLPTraceData {
+func ocToOtlp(td consumerdata.TraceData) []*otlptrace.ResourceSpans {
 
 	if td.Node == nil && td.Resource == nil && len(td.Spans) == 0 {
-		return consumerdata.OTLPTraceData{}
+		return nil
 	}
 
 	resource := ocNodeResourceToOtlp(td.Node, td.Resource)
@@ -85,7 +85,7 @@ func ocToOtlp(td consumerdata.TraceData) consumerdata.OTLPTraceData {
 		}
 	}
 
-	return consumerdata.NewOTLPTraceData(resourceSpanList)
+	return resourceSpanList
 }
 
 func timestampToUnixnano(ts *timestamp.Timestamp) uint64 {

--- a/translator/trace/oc_to_otlp_test.go
+++ b/translator/trace/oc_to_otlp_test.go
@@ -411,36 +411,36 @@ func TestOcToOtlp(t *testing.T) {
 	tests := []struct {
 		name string
 		oc   consumerdata.TraceData
-		otlp consumerdata.OTLPTraceData
+		otlp []*otlptrace.ResourceSpans
 	}{
 		{
 			name: "empty",
 			oc:   consumerdata.TraceData{},
-			otlp: consumerdata.OTLPTraceData{},
+			otlp: nil,
 		},
 
 		{
 			name: "nil-resource",
 			oc:   consumerdata.TraceData{Node: ocNode},
-			otlp: consumerdata.NewOTLPTraceData([]*otlptrace.ResourceSpans{
+			otlp: []*otlptrace.ResourceSpans{
 				{Resource: &otlpresource.Resource{}},
-			}),
+			},
 		},
 
 		{
 			name: "nil-node",
 			oc:   consumerdata.TraceData{Resource: ocResource},
-			otlp: consumerdata.NewOTLPTraceData([]*otlptrace.ResourceSpans{
+			otlp: []*otlptrace.ResourceSpans{
 				{Resource: &otlpresource.Resource{}},
-			}),
+			},
 		},
 
 		{
 			name: "no-spans",
 			oc:   consumerdata.TraceData{Node: ocNode, Resource: ocResource},
-			otlp: consumerdata.NewOTLPTraceData([]*otlptrace.ResourceSpans{
+			otlp: []*otlptrace.ResourceSpans{
 				{Resource: &otlpresource.Resource{}},
-			}),
+			},
 		},
 
 		{
@@ -450,12 +450,12 @@ func TestOcToOtlp(t *testing.T) {
 				Resource: ocResource,
 				Spans:    []*octrace.Span{ocSpan1},
 			},
-			otlp: consumerdata.NewOTLPTraceData([]*otlptrace.ResourceSpans{
+			otlp: []*otlptrace.ResourceSpans{
 				{
 					Resource: &otlpresource.Resource{},
 					Spans:    []*otlptrace.Span{otlpSpan1},
 				},
-			}),
+			},
 		},
 
 		{
@@ -465,12 +465,12 @@ func TestOcToOtlp(t *testing.T) {
 				Resource: ocResource,
 				Spans:    []*octrace.Span{ocSpan1, nil, ocSpan2},
 			},
-			otlp: consumerdata.NewOTLPTraceData([]*otlptrace.ResourceSpans{
+			otlp: []*otlptrace.ResourceSpans{
 				{
 					Resource: &otlpresource.Resource{},
 					Spans:    []*otlptrace.Span{otlpSpan1, otlpSpan2},
 				},
-			}),
+			},
 		},
 
 		{
@@ -480,7 +480,7 @@ func TestOcToOtlp(t *testing.T) {
 				Resource: ocResource,
 				Spans:    []*octrace.Span{ocSpan1, ocSpan2, ocSpan3},
 			},
-			otlp: consumerdata.NewOTLPTraceData([]*otlptrace.ResourceSpans{
+			otlp: []*otlptrace.ResourceSpans{
 				{
 					Resource: &otlpresource.Resource{},
 					Spans:    []*otlptrace.Span{otlpSpan1, otlpSpan2},
@@ -489,7 +489,7 @@ func TestOcToOtlp(t *testing.T) {
 					Resource: &otlpresource.Resource{},
 					Spans:    []*otlptrace.Span{otlpSpan3},
 				},
-			}),
+			},
 		},
 
 		{
@@ -499,7 +499,7 @@ func TestOcToOtlp(t *testing.T) {
 				Resource: ocResource,
 				Spans:    []*octrace.Span{ocSpan1, ocSpan3, ocSpan2},
 			},
-			otlp: consumerdata.NewOTLPTraceData([]*otlptrace.ResourceSpans{
+			otlp: []*otlptrace.ResourceSpans{
 				{
 					Resource: &otlpresource.Resource{},
 					Spans:    []*otlptrace.Span{otlpSpan1, otlpSpan2},
@@ -508,7 +508,7 @@ func TestOcToOtlp(t *testing.T) {
 					Resource: &otlpresource.Resource{},
 					Spans:    []*otlptrace.Span{otlpSpan3},
 				},
-			}),
+			},
 		},
 	}
 


### PR DESCRIPTION
1. Introduced data structures that represent telemetry data in-memory.

2. Renamed OTLP* interfaces and types to *V2 types to denote that they are
   Internal and not OTLP and are the new version of internal data.
   Internal representation is somewhat different from OTLP.

Testing done: unit tests that cover non-trivial functions. Single-line
getters and setters are typically not covered.

Documentation: added doc.go to describe the implementation and usage.

Design doc and benchmarks: https://docs.google.com/document/d/1MSKjMVXQsP51lA6OwpfyLfZhWK-MkGo5vff43LhrqZU/edit#