### PR TITLE
Include resource labels in Zipkin export

### DIFF
--- a/exporter/README.md
+++ b/exporter/README.md
@@ -164,7 +164,9 @@ The following settings are required:
 
 The following settings can be optionally configured:
 
-- `export_resource_labels` (default = true): Whether Resource labels are going to be merged with span attributes
+- (temporary flag) `export_resource_labels` (default = true): Whether Resource labels are going to be merged with span attributes
+Note: this flag was added to aid the migration to new (fixed and symmetric) behavior and is going to be 
+removed soon. See https://github.com/open-telemetry/opentelemetry-collector/issues/595 for more details
 - `defaultservicename` (no default): What to name services missing this information
 
 Example:

--- a/exporter/README.md
+++ b/exporter/README.md
@@ -164,7 +164,7 @@ The following settings are required:
 
 The following settings can be optionally configured:
 
-- `export_resource_labels` (default = false): Whether Resource labels are going to be merged with span attributes
+- `export_resource_labels` (default = true): Whether Resource labels are going to be merged with span attributes
 - `defaultservicename` (no default): What to name services missing this information
 
 Example:

--- a/exporter/README.md
+++ b/exporter/README.md
@@ -164,6 +164,7 @@ The following settings are required:
 
 The following settings can be optionally configured:
 
+- `export_resource_labels` (default = false): Whether Resource labels are going to be merged with span attributes
 - `defaultservicename` (no default): What to name services missing this information
 
 Example:

--- a/exporter/zipkinexporter/config.go
+++ b/exporter/zipkinexporter/config.go
@@ -27,5 +27,8 @@ type Config struct {
 	URL    string `mapstructure:"url"`
 	Format string `mapstructure:"format"`
 
+	// Whether resource labels from TraceData are to be included in Span
+	ExportResourceLabels string `mapstructure:"export_resource_labels"`
+
 	DefaultServiceName string `mapstructure:"default_service_name"`
 }

--- a/exporter/zipkinexporter/config.go
+++ b/exporter/zipkinexporter/config.go
@@ -27,8 +27,8 @@ type Config struct {
 	URL    string `mapstructure:"url"`
 	Format string `mapstructure:"format"`
 
-	// Whether resource labels from TraceData are to be included in Span
-	ExportResourceLabels string `mapstructure:"export_resource_labels"`
+	// Whether resource labels from TraceData are to be included in Span. True by default
+	ExportResourceLabels *bool `mapstructure:"export_resource_labels"`
 
 	DefaultServiceName string `mapstructure:"default_service_name"`
 }

--- a/exporter/zipkinexporter/config.go
+++ b/exporter/zipkinexporter/config.go
@@ -28,6 +28,8 @@ type Config struct {
 	Format string `mapstructure:"format"`
 
 	// Whether resource labels from TraceData are to be included in Span. True by default
+	// This is a temporary flag and will be removed soon,
+	// see https://github.com/open-telemetry/opentelemetry-collector/issues/595
 	ExportResourceLabels *bool `mapstructure:"export_resource_labels"`
 
 	DefaultServiceName string `mapstructure:"default_service_name"`

--- a/exporter/zipkinexporter/config_test.go
+++ b/exporter/zipkinexporter/config_test.go
@@ -48,6 +48,7 @@ func TestLoadConfig(t *testing.T) {
 	assert.Equal(t, "zipkin/2", e1.(*Config).Name())
 	assert.Equal(t, "https://somedest:1234/api/v2/spans", e1.(*Config).URL)
 	assert.Equal(t, "proto", e1.(*Config).Format)
+	assert.Equal(t, false, *e1.(*Config).ExportResourceLabels)
 	_, err = factory.CreateTraceExporter(zap.NewNop(), e1)
 	require.NoError(t, err)
 }

--- a/exporter/zipkinexporter/testdata/config.yaml
+++ b/exporter/zipkinexporter/testdata/config.yaml
@@ -9,7 +9,7 @@ exporters:
     url: "http://some.location.org:9411/api/v2/spans"
   zipkin/2:
     url: "https://somedest:1234/api/v2/spans"
-    export_resource_labels: true
+    export_resource_labels: false
     format: proto
     default_service_name: test_name
 

--- a/exporter/zipkinexporter/testdata/config.yaml
+++ b/exporter/zipkinexporter/testdata/config.yaml
@@ -9,6 +9,7 @@ exporters:
     url: "http://some.location.org:9411/api/v2/spans"
   zipkin/2:
     url: "https://somedest:1234/api/v2/spans"
+    export_resource_labels: true
     format: proto
     default_service_name: test_name
 

--- a/exporter/zipkinexporter/zipkin.go
+++ b/exporter/zipkinexporter/zipkin.go
@@ -18,11 +18,11 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	resourcepb "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
 	"net/http"
 	"time"
 
 	commonpb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
+	resourcepb "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
 	zipkinmodel "github.com/openzipkin/zipkin-go/model"
 	zipkinproto "github.com/openzipkin/zipkin-go/proto/v2"
 	zipkinreporter "github.com/openzipkin/zipkin-go/reporter"

--- a/exporter/zipkinexporter/zipkin.go
+++ b/exporter/zipkinexporter/zipkin.go
@@ -47,9 +47,9 @@ type zipkinExporter struct {
 	defaultServiceName string
 
 	exportResourceLabels bool
-	url        			 string
-	client     			 *http.Client
-	serializer 			 zipkinreporter.SpanSerializer
+	url                  string
+	client               *http.Client
+	serializer           zipkinreporter.SpanSerializer
 }
 
 // Default values for Zipkin endpoint.
@@ -58,7 +58,7 @@ const (
 
 	defaultServiceName string = "<missing service name>"
 
-	DefaultExportResourceLabels   = false
+	DefaultExportResourceLabels   = true
 	DefaultZipkinEndpointHostPort = "localhost:9411"
 	DefaultZipkinEndpointURL      = "http://" + DefaultZipkinEndpointHostPort + "/api/v2/spans"
 )
@@ -88,8 +88,8 @@ func createZipkinExporter(logger *zap.Logger, config configmodels.Exporter) (*zi
 	}
 
 	exportResourceLabels := DefaultExportResourceLabels
-	if zCfg.ExportResourceLabels != "" {
-		exportResourceLabels = zCfg.ExportResourceLabels == "true"
+	if zCfg.ExportResourceLabels != nil {
+		exportResourceLabels = *zCfg.ExportResourceLabels
 	}
 
 	ze := &zipkinExporter{

--- a/exporter/zipkinexporter/zipkin.go
+++ b/exporter/zipkinexporter/zipkin.go
@@ -114,7 +114,7 @@ func createZipkinExporter(logger *zap.Logger, config configmodels.Exporter) (*zi
 func (ze *zipkinExporter) PushTraceData(ctx context.Context, td consumerdata.TraceData) (droppedSpans int, err error) {
 	tbatch := []*zipkinmodel.SpanModel{}
 
-	var resource *resourcepb.Resource = nil
+	var resource *resourcepb.Resource
 	if ze.exportResourceLabels {
 		resource = td.Resource
 	}

--- a/translator/trace/spandata/protospan_to_spandata.go
+++ b/translator/trace/spandata/protospan_to_spandata.go
@@ -17,8 +17,8 @@ package spandata
 
 import (
 	"errors"
-	resourcepb "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
 
+	resourcepb "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
 	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
 	"github.com/golang/protobuf/ptypes/wrappers"
 	"go.opencensus.io/trace"
@@ -132,7 +132,7 @@ func protoLinkTypeToOCLinkType(lt tracepb.Span_Link_Type) trace.LinkType {
 }
 
 func protoAttributesToOCAttributes(attrs *tracepb.Span_Attributes, resource *resourcepb.Resource) map[string]interface{} {
-	if attrs == nil {
+	if attrs == nil && resource == nil {
 		return nil
 	}
 
@@ -144,7 +144,7 @@ func protoAttributesToOCAttributes(attrs *tracepb.Span_Attributes, resource *res
 		}
 	}
 
-	if len(attrs.AttributeMap) == 0 {
+	if attrs == nil || len(attrs.AttributeMap) == 0 {
 		return ocAttrsMap
 	}
 	for key, attr := range attrs.AttributeMap {

--- a/translator/trace/spandata/protospan_to_spandata.go
+++ b/translator/trace/spandata/protospan_to_spandata.go
@@ -17,6 +17,7 @@ package spandata
 
 import (
 	"errors"
+	resourcepb "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
 
 	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
 	"github.com/golang/protobuf/ptypes/wrappers"
@@ -29,7 +30,8 @@ import (
 var errNilSpan = errors.New("expected a non-nil span")
 
 // ProtoSpanToOCSpanData transforms a protobuf span into the equivalent trace.SpanData one.
-func ProtoSpanToOCSpanData(span *tracepb.Span) (*trace.SpanData, error) {
+// When resource is not nil, then its labels are attached to span attributes
+func ProtoSpanToOCSpanData(span *tracepb.Span, resource *resourcepb.Resource) (*trace.SpanData, error) {
 	if span == nil {
 		return nil, errNilSpan
 	}
@@ -50,7 +52,7 @@ func ProtoSpanToOCSpanData(span *tracepb.Span) (*trace.SpanData, error) {
 		StartTime:       internal.TimestampToTime(span.StartTime),
 		EndTime:         internal.TimestampToTime(span.EndTime),
 		Name:            derefTruncatableString(span.Name),
-		Attributes:      protoAttributesToOCAttributes(span.Attributes),
+		Attributes:      protoAttributesToOCAttributes(span.Attributes, resource),
 		Links:           protoLinksToOCLinks(span.Links),
 		Status:          protoStatusToOCStatus(span.Status),
 		SpanKind:        protoSpanKindToOCSpanKind(span.Kind),
@@ -129,12 +131,19 @@ func protoLinkTypeToOCLinkType(lt tracepb.Span_Link_Type) trace.LinkType {
 	}
 }
 
-func protoAttributesToOCAttributes(attrs *tracepb.Span_Attributes) map[string]interface{} {
+func protoAttributesToOCAttributes(attrs *tracepb.Span_Attributes, resource *resourcepb.Resource) map[string]interface{} {
 	if attrs == nil {
 		return nil
 	}
 
 	ocAttrsMap := make(map[string]interface{})
+
+	if resource != nil {
+		for key, value := range resource.Labels {
+			ocAttrsMap[key] = value
+		}
+	}
+
 	if len(attrs.AttributeMap) == 0 {
 		return ocAttrsMap
 	}
@@ -153,6 +162,7 @@ func protoAttributesToOCAttributes(attrs *tracepb.Span_Attributes) map[string]in
 			ocAttrsMap[key] = derefTruncatableString(value.StringValue)
 		}
 	}
+
 	return ocAttrsMap
 }
 

--- a/translator/trace/spandata/protospan_to_spandata_test.go
+++ b/translator/trace/spandata/protospan_to_spandata_test.go
@@ -17,6 +17,7 @@ package spandata
 import (
 	"bytes"
 	"encoding/json"
+	resourcepb "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
 	"reflect"
 	"testing"
 	"time"
@@ -101,7 +102,14 @@ func TestProtoSpanToOCSpanData_endToEnd(t *testing.T) {
 		},
 	}
 
-	gotOCSpanData, err := ProtoSpanToOCSpanData(protoSpan)
+	resource := &resourcepb.Resource{
+		Type: "k8s",
+		Labels: map[string]string{
+			"namespace": "kube-system",
+		},
+	}
+
+	gotOCSpanData, err := ProtoSpanToOCSpanData(protoSpan, resource)
 	if err != nil {
 		t.Fatalf("Failed to convert from ProtoSpan to OCSpanData: %v", err)
 	}
@@ -145,6 +153,7 @@ func TestProtoSpanToOCSpanData_endToEnd(t *testing.T) {
 		},
 		HasRemoteParent: true,
 		Attributes: map[string]interface{}{
+			"namespace": "kube-system",
 			"timeout_ns": int64(12e9),
 			"agent":      "ocagent",
 			"cache_hit":  true,

--- a/translator/trace/spandata/protospan_to_spandata_test.go
+++ b/translator/trace/spandata/protospan_to_spandata_test.go
@@ -17,11 +17,11 @@ package spandata
 import (
 	"bytes"
 	"encoding/json"
-	resourcepb "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
 	"reflect"
 	"testing"
 	"time"
 
+	resourcepb "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
 	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
 	"github.com/golang/protobuf/ptypes/wrappers"
 	"go.opencensus.io/trace"
@@ -153,7 +153,7 @@ func TestProtoSpanToOCSpanData_endToEnd(t *testing.T) {
 		},
 		HasRemoteParent: true,
 		Attributes: map[string]interface{}{
-			"namespace": "kube-system",
+			"namespace":  "kube-system",
 			"timeout_ns": int64(12e9),
 			"agent":      "ocagent",
 			"cache_hit":  true,

--- a/translator/trace/zipkin/zipkinv1_to_protospan_test.go
+++ b/translator/trace/zipkin/zipkinv1_to_protospan_test.go
@@ -863,7 +863,7 @@ func TestSpanKindTranslation(t *testing.T) {
 			}
 
 			// Translate to OCSpanData.
-			sd, err := spandata.ProtoSpanToOCSpanData(ocSpan)
+			sd, err := spandata.ProtoSpanToOCSpanData(ocSpan, nil)
 			assert.NoError(t, err)
 			assert.EqualValues(t, test.ocKind, sd.SpanKind)
 


### PR DESCRIPTION
**Description:** 

Resource data might include various labels that are currently missed when doing conversion. It seems to be a current limitation of the design: https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/exporter-zipkin.md

This change adds this capability, simple merging resource labels with span attributes

**Link to tracking Issue:** N/A

**Testing:** Unit Tests + Manual tests on interoperability with K8S metadata tagging

**Documentation:** Relevant project documentation updated