### PR TITLE
OpenCensus to internal data structure translation

### DIFF
--- a/internal/data/trace.go
+++ b/internal/data/trace.go
@@ -289,6 +289,10 @@ func NewSpanEvent(timestamp TimestampUnixNano, name string, attributes Attribute
 	}
 }
 
+// TODO: see if we need a SpanEvents type that contains the slice of events and
+// the dropped counter (similar to how Attributes type is done).
+// The same applies to SpanLinks.
+
 // NewSpanEventSlice creates a slice of SpanEvents that are correctly initialized.
 func NewSpanEventSlice(len int) []SpanEvent {
 	origs := make([]otlptrace.Span_Event, len)

--- a/internal/data/trace.go
+++ b/internal/data/trace.go
@@ -121,14 +121,24 @@ func NewSpan() *Span {
 	return &Span{orig: &otlptrace.Span{}}
 }
 
-// NewSpanSlice creates a slice of Spans that are correctly initialized.
-func NewSpanSlice(len int) []Span {
+// NewSpanSlice creates a slice of pointers to Spans that are correctly initialized.
+func NewSpanSlice(len int) []*Span {
+	// Slice for underlying data.
 	origs := make([]otlptrace.Span, len)
+
+	// Slice for wrappers.
 	wrappers := make([]Span, len)
+
+	// Slice for pointers to wrappers.
+	ptrs := make([]*Span, len)
+
+	// TODO: see if we can make one allocation instead of 3 allocations above.
+
 	for i := range origs {
 		wrappers[i].orig = &origs[i]
+		ptrs[i] = &wrappers[i]
 	}
-	return wrappers
+	return ptrs
 }
 
 func (m *Span) TraceID() TraceID {
@@ -293,14 +303,24 @@ func NewSpanEvent(timestamp TimestampUnixNano, name string, attributes Attribute
 // the dropped counter (similar to how Attributes type is done).
 // The same applies to SpanLinks.
 
-// NewSpanEventSlice creates a slice of SpanEvents that are correctly initialized.
-func NewSpanEventSlice(len int) []SpanEvent {
+// NewSpanEventSlice creates a slice of pointers to SpanEvent that are correctly initialized.
+func NewSpanEventSlice(len int) []*SpanEvent {
+	// Slice for underlying data.
 	origs := make([]otlptrace.Span_Event, len)
+
+	// Slice for wrappers.
 	wrappers := make([]SpanEvent, len)
+
+	// Slice for pointers to wrappers.
+	ptrs := make([]*SpanEvent, len)
+
+	// TODO: see if we can make one allocation instead of 3 allocations above.
+
 	for i := range origs {
 		wrappers[i].orig = &origs[i]
+		ptrs[i] = &wrappers[i]
 	}
-	return wrappers
+	return ptrs
 }
 
 func (m *SpanEvent) Timestamp() TimestampUnixNano {
@@ -350,14 +370,24 @@ func NewSpanLink() *SpanLink {
 	return &SpanLink{orig: &otlptrace.Span_Link{}}
 }
 
-// NewSpanLinkSlice creates a slice of SpanLinks that are correctly initialized.
-func NewSpanLinkSlice(len int) []SpanLink {
+// NewSpanLinkSlice creates a slice of pointers to SpanLinks that are correctly initialized.
+func NewSpanLinkSlice(len int) []*SpanLink {
+	// Slice for underlying data.
 	origs := make([]otlptrace.Span_Link, len)
+
+	// Slice for wrappers.
 	wrappers := make([]SpanLink, len)
+
+	// Slice for pointers to wrappers.
+	ptrs := make([]*SpanLink, len)
+
+	// TODO: see if we can make one allocation instead of 3 allocations above.
+
 	for i := range origs {
 		wrappers[i].orig = &origs[i]
+		ptrs[i] = &wrappers[i]
 	}
-	return wrappers
+	return ptrs
 }
 
 func (m *SpanLink) TraceID() TraceID {

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -18,6 +18,8 @@ import (
 	"time"
 
 	"github.com/golang/protobuf/ptypes/timestamp"
+
+	"github.com/open-telemetry/opentelemetry-collector/internal/data"
 )
 
 // TimeToTimestamp converts a time.Time to a timestamp.Timestamp pointer.
@@ -37,4 +39,8 @@ func TimestampToTime(ts *timestamp.Timestamp) (t time.Time) {
 		return
 	}
 	return time.Unix(ts.Seconds, int64(ts.Nanos))
+}
+
+func TimestampToUnixnano(ts *timestamp.Timestamp) data.TimestampUnixNano {
+	return data.TimestampUnixNano(uint64(TimestampToTime(ts).UnixNano()))
 }

--- a/testbed/go.sum
+++ b/testbed/go.sum
@@ -484,6 +484,7 @@ github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1Cpa
 github.com/open-telemetry/opentelemetry-proto v0.0.0-20200211051721-ff5f19c6217d h1:hZcHR0at6tb3jBjaPHlfLr6yK7rTrA8xGCS6jlUSLcU=
 github.com/open-telemetry/opentelemetry-proto v0.0.0-20200211051721-ff5f19c6217d/go.mod h1:PMR5GI0F7BSpio+rBGFxNm6SLzg3FypDTcFuQZnO+F8=
 github.com/open-telemetry/opentelemetry-proto v0.0.0-20200227223449-a65b867510c0/go.mod h1:PMR5GI0F7BSpio+rBGFxNm6SLzg3FypDTcFuQZnO+F8=
+github.com/open-telemetry/opentelemetry-proto v0.0.0-20200308012146-674ae1c8703f/go.mod h1:PMR5GI0F7BSpio+rBGFxNm6SLzg3FypDTcFuQZnO+F8=
 github.com/opentracing-contrib/go-stdlib v0.0.0-20190519235532-cf7a6c988dc9/go.mod h1:PLldrQSroqzH70Xl+1DQcGnefIbqsKR7UDaiux3zV+w=
 github.com/opentracing/opentracing-go v1.1.0 h1:pWlfV3Bxv7k65HYwkikxat0+s3pV4bsqf19k25Ur8rU=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=

--- a/translator/conventions/opencensus.go
+++ b/translator/conventions/opencensus.go
@@ -12,18 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package tracetranslator
+package conventions
 
 // OTLP attributes to map certain OpenCensus proto fields. These fields don't have
 // corresponding fields in OTLP, nor are defined in OTLP semantic conventions.
 // TODO: decide if any of these must be in OTLP semantic conventions.
 const (
-	ocAttributeProcessStartTime  = "opencensus.starttime"
-	ocAttributeProcessID         = "opencensus.pid"
-	ocAttributeExporterVersion   = "opencensus.exporterversion"
-	ocAttributeResourceType      = "opencensus.resourcetype"
-	ocTimeEventMessageEventType  = "opencensus.timeevent.messageevent.type"
-	ocTimeEventMessageEventID    = "opencensus.timeevent.messageevent.id"
-	ocTimeEventMessageEventUSize = "opencensus.timeevent.messageevent.usize"
-	ocTimeEventMessageEventCSize = "opencensus.timeevent.messageevent.csize"
+	OCAttributeProcessStartTime  = "opencensus.starttime"
+	OCAttributeProcessID         = "opencensus.pid"
+	OCAttributeExporterVersion   = "opencensus.exporterversion"
+	OCAttributeResourceType      = "opencensus.resourcetype"
+	OCTimeEventMessageEventType  = "opencensus.timeevent.messageevent.type"
+	OCTimeEventMessageEventID    = "opencensus.timeevent.messageevent.id"
+	OCTimeEventMessageEventUSize = "opencensus.timeevent.messageevent.usize"
+	OCTimeEventMessageEventCSize = "opencensus.timeevent.messageevent.csize"
 )

--- a/translator/opencensus/oc_to_internal.go
+++ b/translator/opencensus/oc_to_internal.go
@@ -1,0 +1,383 @@
+// Copyright 2020 OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package opencensus
+
+import (
+	"strings"
+
+	occommon "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
+	ocresource "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
+	octrace "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
+	"github.com/golang/protobuf/ptypes"
+
+	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
+	"github.com/open-telemetry/opentelemetry-collector/internal"
+	"github.com/open-telemetry/opentelemetry-collector/internal/data"
+	"github.com/open-telemetry/opentelemetry-collector/translator/conventions"
+	tracetranslator "github.com/open-telemetry/opentelemetry-collector/translator/trace"
+)
+
+func ocToInternal(td consumerdata.TraceData) data.TraceData {
+
+	if td.Node == nil && td.Resource == nil && len(td.Spans) == 0 {
+		return data.TraceData{}
+	}
+
+	resource := ocNodeResourceToInternal(td.Node, td.Resource)
+
+	resourceSpans := data.NewResourceSpans(resource, nil)
+	resourceSpanList := []*data.ResourceSpans{resourceSpans}
+
+	spanCount := len(td.Spans)
+	if spanCount == 0 {
+		return data.NewTraceData(resourceSpanList)
+	}
+
+	// Create slice that holds pointers and another slice that holds structs at once
+	// to avoid individual allocations of structs.
+	spans := data.NewSpanSlice(spanCount)
+	spanPtrs := make([]*data.Span, 0, spanCount)
+
+	for i, ocSpan := range td.Spans {
+		if ocSpan == nil {
+			// Skip nil spans.
+			continue
+		}
+
+		// Point one element in slice of pointers to an element in slice of structs.
+		destSpan := &spans[i]
+
+		ocSpanToInternal(destSpan, ocSpan)
+
+		if ocSpan.Resource != nil {
+			// Add a separate ResourceSpans item just for this span since it
+			// has a different Resource.
+			separateRS := data.NewResourceSpans(
+				ocNodeResourceToInternal(td.Node, ocSpan.Resource),
+				[]*data.Span{destSpan},
+			)
+			resourceSpanList = append(resourceSpanList, separateRS)
+		} else {
+			// Otherwise add the span to the first ResourceSpans item.
+			spanPtrs = append(spanPtrs, destSpan)
+		}
+	}
+
+	resourceSpans.SetSpans(spanPtrs)
+
+	return data.NewTraceData(resourceSpanList)
+}
+
+func ocSpanToInternal(dest *data.Span, src *octrace.Span) {
+	events, droppedEventCount := ocEventsToInternal(src.TimeEvents)
+	links, droppedLinkCount := ocLinksToInternal(src.Links)
+
+	dest.SetTraceID(data.TraceIDFromBytes(src.TraceId))
+	dest.SetSpanID(data.SpanIDFromBytes(src.SpanId))
+	dest.SetTraceState(ocTraceStateToInternal(src.Tracestate))
+	dest.SetParentSpanID(data.SpanIDFromBytes(src.ParentSpanId))
+	dest.SetName(src.Name.GetValue())
+	dest.SetKind(ocSpanKindToInternal(src.Kind, src.Attributes))
+	dest.SetStartTime(internal.TimestampToUnixnano(src.StartTime))
+	dest.SetEndTime(internal.TimestampToUnixnano(src.EndTime))
+	dest.SetAttributes(ocAttrsToInternal(src.Attributes))
+	dest.SetEvents(events)
+	dest.SetDroppedEventsCount(droppedEventCount)
+	dest.SetLinks(links)
+	dest.SetDroppedLinksCount(droppedLinkCount)
+	dest.SetStatus(ocStatusToInternal(src.Status))
+}
+
+func ocStatusToInternal(ocStatus *octrace.Status) data.SpanStatus {
+	if ocStatus == nil {
+		return data.SpanStatus{}
+	}
+	return data.NewSpanStatus(data.StatusCode(ocStatus.Code), ocStatus.Message)
+}
+
+// Convert tracestate to W3C format. See the https://w3c.github.io/trace-context/
+func ocTraceStateToInternal(ocTracestate *octrace.Span_Tracestate) data.TraceState {
+	if ocTracestate == nil {
+		return ""
+	}
+	var sb strings.Builder
+	for i, entry := range ocTracestate.Entries {
+		sb.Grow(1 + len(entry.Key) + 1 + len(entry.Value))
+		if i > 0 {
+			sb.WriteString(",")
+		}
+		sb.WriteString(entry.Key)
+		sb.WriteString("=")
+		sb.WriteString(entry.Value)
+	}
+	return data.TraceState(sb.String())
+}
+
+func ocAttrsToInternal(ocAttrs *octrace.Span_Attributes) data.Attributes {
+	if ocAttrs == nil {
+		return data.Attributes{}
+	}
+
+	attrCount := len(ocAttrs.AttributeMap)
+	attrMap := make(data.AttributesMap, attrCount)
+	if attrCount > 0 {
+		values := data.NewAttributeValueSlice(attrCount)
+		i := 0
+		for key, ocAttr := range ocAttrs.AttributeMap {
+			switch attribValue := ocAttr.Value.(type) {
+			case *octrace.AttributeValue_StringValue:
+				values[i].SetString(attribValue.StringValue.GetValue())
+
+			case *octrace.AttributeValue_IntValue:
+				values[i].SetInt(attribValue.IntValue)
+
+			case *octrace.AttributeValue_BoolValue:
+				values[i].SetBool(attribValue.BoolValue)
+
+			case *octrace.AttributeValue_DoubleValue:
+				values[i].SetDouble(attribValue.DoubleValue)
+
+			default:
+				str := "<Unknown OpenCensus attribute value type>"
+				values[i].SetString(str)
+			}
+			attrMap[key] = values[i]
+			i++
+		}
+	}
+	droppedCount := uint32(ocAttrs.DroppedAttributesCount)
+	return data.NewAttributes(attrMap, droppedCount)
+}
+
+func ocSpanKindToInternal(ocKind octrace.Span_SpanKind, ocAttrs *octrace.Span_Attributes) data.SpanKind {
+	switch ocKind {
+	case octrace.Span_SERVER:
+		return data.SpanKindSERVER
+
+	case octrace.Span_CLIENT:
+		return data.SpanKindCLIENT
+
+	case octrace.Span_SPAN_KIND_UNSPECIFIED:
+		// Span kind field is unspecified, check if TagSpanKind attribute is set.
+		// This can happen if span kind had no equivalent in OC, so we could represent it in
+		// the SpanKind. In that case the span kind may be a special attribute TagSpanKind.
+		if ocAttrs != nil {
+			kindAttr := ocAttrs.AttributeMap[tracetranslator.TagSpanKind]
+			if kindAttr != nil {
+				strVal, ok := kindAttr.Value.(*octrace.AttributeValue_StringValue)
+				if ok && strVal != nil {
+					var otlpKind data.SpanKind
+					switch tracetranslator.OpenTracingSpanKind(strVal.StringValue.GetValue()) {
+					case tracetranslator.OpenTracingSpanKindConsumer:
+						otlpKind = data.SpanKindCONSUMER
+					case tracetranslator.OpenTracingSpanKindProducer:
+						otlpKind = data.SpanKindPRODUCER
+					default:
+						return data.SpanKindUNSPECIFIED
+					}
+					delete(ocAttrs.AttributeMap, tracetranslator.TagSpanKind)
+					return otlpKind
+				}
+			}
+		}
+		return data.SpanKindUNSPECIFIED
+
+	default:
+		return data.SpanKindUNSPECIFIED
+	}
+}
+
+func ocEventsToInternal(ocEvents *octrace.Span_TimeEvents) (ptrs []*data.SpanEvent, droppedCount uint32) {
+	if ocEvents == nil {
+		return
+	}
+
+	droppedCount = uint32(ocEvents.DroppedMessageEventsCount + ocEvents.DroppedAnnotationsCount)
+
+	eventCount := len(ocEvents.TimeEvent)
+	if eventCount == 0 {
+		return
+	}
+
+	// Create slice that holds pointers and another slice that holds structs at once
+	// to avoid individual allocations of structs.
+	ptrs = make([]*data.SpanEvent, 0, eventCount)
+	content := data.NewSpanEventSlice(eventCount)
+
+	for i, ocEvent := range ocEvents.TimeEvent {
+		if ocEvent == nil {
+			continue
+		}
+
+		// Point one element in slice of pointers to an element in slice of structs.
+		event := &content[i]
+		ptrs = append(ptrs, event)
+
+		event.SetTimestamp(internal.TimestampToUnixnano(ocEvent.Time))
+
+		switch teValue := ocEvent.Value.(type) {
+		case *octrace.Span_TimeEvent_Annotation_:
+			if teValue.Annotation != nil {
+				event.SetName(teValue.Annotation.Description.GetValue())
+				attrs := ocAttrsToInternal(teValue.Annotation.Attributes)
+				event.SetAttributes(attrs)
+			}
+
+		case *octrace.Span_TimeEvent_MessageEvent_:
+			event.SetAttributes(ocMessageEventToInternalAttrs(teValue.MessageEvent))
+
+		default:
+			event.SetName("An unknown OpenCensus TimeEvent type was detected when translating")
+		}
+	}
+	return
+}
+
+func ocLinksToInternal(ocLinks *octrace.Span_Links) (ptrs []*data.SpanLink, droppedCount uint32) {
+	if ocLinks == nil {
+		return
+	}
+
+	droppedCount = uint32(ocLinks.DroppedLinksCount)
+
+	linkCount := len(ocLinks.Link)
+	if linkCount == 0 {
+		return
+	}
+
+	// Create slice that holds pointers and another slice that holds structs at once
+	// to avoid individual allocations of structs.
+	ptrs = make([]*data.SpanLink, 0, linkCount)
+	content := data.NewSpanLinkSlice(linkCount)
+
+	for i, ocLink := range ocLinks.Link {
+		if ocLink == nil {
+			continue
+		}
+
+		// Point one element in slice of pointers to an element in slice of structs.
+		link := &content[i]
+		ptrs = append(ptrs, link)
+
+		link.SetTraceID(data.TraceIDFromBytes(ocLink.TraceId))
+		link.SetSpanID(data.SpanIDFromBytes(ocLink.SpanId))
+		link.SetTraceState(ocTraceStateToInternal(ocLink.Tracestate))
+		link.SetAttributes(ocAttrsToInternal(ocLink.Attributes))
+	}
+	return
+}
+
+func ocMessageEventToInternalAttrs(msgEvent *octrace.Span_TimeEvent_MessageEvent) data.Attributes {
+	if msgEvent == nil {
+		return data.Attributes{}
+	}
+
+	attrs := data.NewAttributeValueSlice(4)
+	attrs[0].SetString(msgEvent.Type.String())
+	attrs[1].SetInt(int64(msgEvent.Id))
+	attrs[2].SetInt(int64(msgEvent.UncompressedSize))
+	attrs[3].SetInt(int64(msgEvent.CompressedSize))
+
+	return data.NewAttributes(
+		map[string]data.AttributeValue{
+			conventions.OCTimeEventMessageEventType:  attrs[0],
+			conventions.OCTimeEventMessageEventID:    attrs[1],
+			conventions.OCTimeEventMessageEventUSize: attrs[2],
+			conventions.OCTimeEventMessageEventCSize: attrs[3],
+		},
+		0)
+}
+
+func ocNodeResourceToInternal(ocNode *occommon.Node, ocResource *ocresource.Resource) *data.Resource {
+	resource := &data.Resource{}
+
+	// Number of special fields in the Node. See the code below that deals with special fields.
+	const specialNodeAttrCount = 7
+
+	// Number of special fields in the Resource.
+	const specialResourceAttrCount = 1
+
+	// Calculate maximum total number of attributes. It is OK if we are a bit higher than
+	// the exact number since this is only needed for capacity reservation.
+	maxTotalAttrCount := 0
+	if ocNode != nil {
+		maxTotalAttrCount += len(ocNode.Attributes) + specialNodeAttrCount
+	}
+	if ocResource != nil {
+		maxTotalAttrCount += len(ocResource.Labels) + specialResourceAttrCount
+	}
+
+	// Create a map where we will place all attributes from the Node and Resource.
+	attrs := make(data.AttributesMap, maxTotalAttrCount)
+
+	if ocNode != nil {
+		// Copy all Attributes.
+		for k, v := range ocNode.Attributes {
+			attrs[k] = data.NewAttributeValueString(v)
+		}
+
+		// Add all special fields.
+		if ocNode.ServiceInfo != nil {
+			if ocNode.ServiceInfo.Name != "" {
+				attrs[conventions.AttributeServiceName] = data.NewAttributeValueString(
+					ocNode.ServiceInfo.Name)
+			}
+		}
+		if ocNode.Identifier != nil {
+			if ocNode.Identifier.StartTimestamp != nil {
+				attrs[conventions.OCAttributeProcessStartTime] = data.NewAttributeValueString(
+					ptypes.TimestampString(ocNode.Identifier.StartTimestamp))
+			}
+			if ocNode.Identifier.HostName != "" {
+				attrs[conventions.AttributeHostHostname] = data.NewAttributeValueString(
+					ocNode.Identifier.HostName)
+			}
+			if ocNode.Identifier.Pid != 0 {
+				attrs[conventions.OCAttributeProcessID] = data.NewAttributeValueInt(int64(ocNode.Identifier.Pid))
+			}
+		}
+		if ocNode.LibraryInfo != nil {
+			if ocNode.LibraryInfo.CoreLibraryVersion != "" {
+				attrs[conventions.AttributeLibraryVersion] = data.NewAttributeValueString(
+					ocNode.LibraryInfo.CoreLibraryVersion)
+			}
+			if ocNode.LibraryInfo.ExporterVersion != "" {
+				attrs[conventions.OCAttributeExporterVersion] = data.NewAttributeValueString(
+					ocNode.LibraryInfo.ExporterVersion)
+			}
+			if ocNode.LibraryInfo.Language != occommon.LibraryInfo_LANGUAGE_UNSPECIFIED {
+				attrs[conventions.AttributeLibraryLanguage] = data.NewAttributeValueString(
+					ocNode.LibraryInfo.Language.String())
+			}
+		}
+	}
+
+	if ocResource != nil {
+		// Copy resource Labels.
+		for k, v := range ocResource.Labels {
+			attrs[k] = data.NewAttributeValueString(v)
+		}
+		// Add special fields.
+		if ocResource.Type != "" {
+			attrs[conventions.OCAttributeResourceType] = data.NewAttributeValueString(ocResource.Type)
+		}
+	}
+
+	if len(attrs) != 0 {
+		resource.SetAttributes(attrs)
+	}
+
+	return resource
+}

--- a/translator/opencensus/oc_to_internal_test.go
+++ b/translator/opencensus/oc_to_internal_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 OpenTelemetry Authors
+// Copyright 2020 OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package tracetranslator
+package opencensus
 
 import (
 	"strings"
@@ -23,49 +23,28 @@ import (
 	ocresource "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
 	octrace "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
 	"github.com/golang/protobuf/ptypes"
-	otlpcommon "github.com/open-telemetry/opentelemetry-proto/gen/go/common/v1"
-	otlpresource "github.com/open-telemetry/opentelemetry-proto/gen/go/resource/v1"
 	otlptrace "github.com/open-telemetry/opentelemetry-proto/gen/go/trace/v1"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
+	"github.com/open-telemetry/opentelemetry-collector/internal"
+	"github.com/open-telemetry/opentelemetry-collector/internal/data"
 	"github.com/open-telemetry/opentelemetry-collector/translator/conventions"
 )
 
-func TestAttrMapToOtlp(t *testing.T) {
-	ocAttrs := map[string]string{}
+func TestOcNodeResourceToInternal(t *testing.T) {
+	resource := ocNodeResourceToInternal(nil, nil)
+	assert.EqualValues(t, &data.Resource{}, resource)
 
-	otlpAttrs := attrMapToOtlp(ocAttrs)
-	assert.True(t, otlpAttrs == nil)
-
-	ocAttrs = map[string]string{"abc": "def"}
-	otlpAttrs = attrMapToOtlp(ocAttrs)
-	assert.EqualValues(t, []*otlpcommon.AttributeKeyValue{
-		{
-			Key:         "abc",
-			Type:        otlpcommon.AttributeKeyValue_STRING,
-			StringValue: "def",
-		},
-	}, otlpAttrs)
-}
-
-func TestOcNodeResourceToOtlp(t *testing.T) {
-	otlpResource := ocNodeResourceToOtlp(nil, nil)
-	assert.EqualValues(t, &otlpresource.Resource{
-		Attributes: nil,
-	}, otlpResource)
-
-	node := &occommon.Node{}
-	resource := &ocresource.Resource{}
-	otlpResource = ocNodeResourceToOtlp(node, resource)
-	assert.EqualValues(t, &otlpresource.Resource{
-		Attributes: nil,
-	}, otlpResource)
+	ocNode := &occommon.Node{}
+	ocResource := &ocresource.Resource{}
+	resource = ocNodeResourceToInternal(ocNode, ocResource)
+	assert.EqualValues(t, &data.Resource{}, resource)
 
 	ts, err := ptypes.TimestampProto(time.Date(2020, 2, 11, 20, 26, 0, 0, time.UTC))
 	assert.NoError(t, err)
 
-	node = &occommon.Node{
+	ocNode = &occommon.Node{
 		Identifier: &occommon.ProcessIdentifier{
 			HostName:       "host1",
 			Pid:            123,
@@ -83,31 +62,28 @@ func TestOcNodeResourceToOtlp(t *testing.T) {
 			"node-attr": "val1",
 		},
 	}
-	resource = &ocresource.Resource{
+	ocResource = &ocresource.Resource{
 		Type: "good-resource",
 		Labels: map[string]string{
 			"resource-attr": "val2",
 		},
 	}
-	otlpResource = ocNodeResourceToOtlp(node, resource)
+	resource = ocNodeResourceToInternal(ocNode, ocResource)
 
-	expectedAttrs := map[string]string{
-		conventions.AttributeHostHostname:       "host1",
-		conventions.OCAttributeProcessID:        "123",
-		conventions.OCAttributeProcessStartTime: "2020-02-11T20:26:00Z",
-		conventions.AttributeLibraryLanguage:    "CPP",
-		conventions.OCAttributeExporterVersion:  "v1.2.0",
-		conventions.AttributeLibraryVersion:     "v2.0.1",
-		conventions.AttributeServiceName:        "svcA",
-		"node-attr":                             "val1",
-		conventions.OCAttributeResourceType:     "good-resource",
-		"resource-attr":                         "val2",
+	expectedAttrs := data.AttributesMap{
+		conventions.AttributeHostHostname:       data.NewAttributeValueString("host1"),
+		conventions.OCAttributeProcessID:        data.NewAttributeValueInt(123),
+		conventions.OCAttributeProcessStartTime: data.NewAttributeValueString("2020-02-11T20:26:00Z"),
+		conventions.AttributeLibraryLanguage:    data.NewAttributeValueString("CPP"),
+		conventions.OCAttributeExporterVersion:  data.NewAttributeValueString("v1.2.0"),
+		conventions.AttributeLibraryVersion:     data.NewAttributeValueString("v2.0.1"),
+		conventions.AttributeServiceName:        data.NewAttributeValueString("svcA"),
+		"node-attr":                             data.NewAttributeValueString("val1"),
+		conventions.OCAttributeResourceType:     data.NewAttributeValueString("good-resource"),
+		"resource-attr":                         data.NewAttributeValueString("val2"),
 	}
 
-	assert.EqualValues(t, len(expectedAttrs), len(otlpResource.Attributes))
-	for k, v := range expectedAttrs {
-		assertHasAttrStr(t, otlpResource.Attributes, k, v)
-	}
+	assert.EqualValues(t, expectedAttrs, resource.Attributes())
 
 	// Make sure hard-coded fields override same-name values in Attributes.
 	// To do that add Attributes with same-name.
@@ -115,43 +91,20 @@ func TestOcNodeResourceToOtlp(t *testing.T) {
 		// Set all except "attr1" which is not a hard-coded field to some bogus values.
 
 		if strings.Index(k, "-attr") < 0 {
-			node.Attributes[k] = "this will be overridden 1"
+			ocNode.Attributes[k] = "this will be overridden 1"
 		}
 	}
-	resource.Labels[conventions.OCAttributeResourceType] = "this will be overridden 2"
+	ocResource.Labels[conventions.OCAttributeResourceType] = "this will be overridden 2"
 
 	// Convert again.
-	otlpResource = ocNodeResourceToOtlp(node, resource)
+	resource = ocNodeResourceToInternal(ocNode, ocResource)
 
 	// And verify that same-name attributes were ignored.
-	assert.EqualValues(t, len(expectedAttrs), len(otlpResource.Attributes))
-	for k, v := range expectedAttrs {
-		assertHasAttrStr(t, otlpResource.Attributes, k, v)
-	}
+	assert.EqualValues(t, expectedAttrs, resource.Attributes())
 }
 
-func assertHasAttrStr(t *testing.T, attrs []*otlpcommon.AttributeKeyValue, key string, val string) {
-	assertHasAttrVal(t, attrs, key, &otlpcommon.AttributeKeyValue{
-		Key:         key,
-		Type:        otlpcommon.AttributeKeyValue_STRING,
-		StringValue: val,
-	})
-}
-
-func assertHasAttrVal(t *testing.T, attrs []*otlpcommon.AttributeKeyValue, key string, val *otlpcommon.AttributeKeyValue) {
-	found := false
-	for _, attr := range attrs {
-		if attr != nil && attr.Key == key {
-			assert.EqualValues(t, false, found, "Duplicate key "+key)
-			assert.EqualValues(t, val, attr)
-			found = true
-		}
-	}
-	assert.EqualValues(t, true, found, "Cannot find key "+key)
-}
-
-func TestOcTraceStateToOtlp(t *testing.T) {
-	assert.EqualValues(t, "", ocTraceStateToOtlp(nil))
+func TestOcTraceStateToInternal(t *testing.T) {
+	assert.EqualValues(t, "", ocTraceStateToInternal(nil))
 
 	tracestate := &octrace.Span_Tracestate{
 		Entries: []*octrace.Span_Tracestate_Entry{
@@ -161,40 +114,36 @@ func TestOcTraceStateToOtlp(t *testing.T) {
 			},
 		},
 	}
-	assert.EqualValues(t, "abc=def", ocTraceStateToOtlp(tracestate))
+	assert.EqualValues(t, "abc=def", ocTraceStateToInternal(tracestate))
 
 	tracestate.Entries = append(tracestate.Entries,
 		&octrace.Span_Tracestate_Entry{
 			Key:   "123",
 			Value: "4567",
 		})
-	assert.EqualValues(t, "abc=def,123=4567", ocTraceStateToOtlp(tracestate))
+	assert.EqualValues(t, "abc=def,123=4567", ocTraceStateToInternal(tracestate))
 }
 
-func TestOcAttrsToOtlp(t *testing.T) {
-	otlpAttrs, droppedCount := ocAttrsToOtlp(nil)
-	assert.True(t, otlpAttrs == nil)
-	assert.EqualValues(t, 0, droppedCount)
+func TestOcAttrsToInternal(t *testing.T) {
+	attrs := ocAttrsToInternal(nil)
+	assert.EqualValues(t, data.NewAttributes(nil, 0), attrs)
 
 	ocAttrs := &octrace.Span_Attributes{}
-	otlpAttrs, droppedCount = ocAttrsToOtlp(ocAttrs)
-	assert.EqualValues(t, []*otlpcommon.AttributeKeyValue{}, otlpAttrs)
-	assert.EqualValues(t, 0, droppedCount)
+	attrs = ocAttrsToInternal(ocAttrs)
+	assert.EqualValues(t, data.NewAttributes(data.AttributesMap{}, 0), attrs)
 
 	ocAttrs = &octrace.Span_Attributes{
 		DroppedAttributesCount: 123,
 	}
-	otlpAttrs, droppedCount = ocAttrsToOtlp(ocAttrs)
-	assert.EqualValues(t, []*otlpcommon.AttributeKeyValue{}, otlpAttrs)
-	assert.EqualValues(t, 123, droppedCount)
+	attrs = ocAttrsToInternal(ocAttrs)
+	assert.EqualValues(t, data.NewAttributes(data.AttributesMap{}, 123), attrs)
 
 	ocAttrs = &octrace.Span_Attributes{
 		AttributeMap:           map[string]*octrace.AttributeValue{},
 		DroppedAttributesCount: 234,
 	}
-	otlpAttrs, droppedCount = ocAttrsToOtlp(ocAttrs)
-	assert.EqualValues(t, []*otlpcommon.AttributeKeyValue{}, otlpAttrs)
-	assert.EqualValues(t, 234, droppedCount)
+	attrs = ocAttrsToInternal(ocAttrs)
+	assert.EqualValues(t, data.NewAttributes(data.AttributesMap{}, 234), attrs)
 
 	ocAttrs = &octrace.Span_Attributes{
 		AttributeMap: map[string]*octrace.AttributeValue{
@@ -204,15 +153,14 @@ func TestOcAttrsToOtlp(t *testing.T) {
 		},
 		DroppedAttributesCount: 234,
 	}
-	otlpAttrs, droppedCount = ocAttrsToOtlp(ocAttrs)
-	assert.EqualValues(t, []*otlpcommon.AttributeKeyValue{
-		{
-			Key:         "abc",
-			Type:        otlpcommon.AttributeKeyValue_STRING,
-			StringValue: "def",
-		},
-	}, otlpAttrs)
-	assert.EqualValues(t, 234, droppedCount)
+	attrs = ocAttrsToInternal(ocAttrs)
+	assert.EqualValues(t,
+		data.NewAttributes(
+			data.AttributesMap{
+				"abc": data.NewAttributeValueString("def"),
+			},
+			234),
+		attrs)
 
 	ocAttrs.AttributeMap["intval"] = &octrace.AttributeValue{
 		Value: &octrace.AttributeValue_IntValue{IntValue: 345},
@@ -223,32 +171,18 @@ func TestOcAttrsToOtlp(t *testing.T) {
 	ocAttrs.AttributeMap["doubleval"] = &octrace.AttributeValue{
 		Value: &octrace.AttributeValue_DoubleValue{DoubleValue: 4.5},
 	}
-	otlpAttrs, droppedCount = ocAttrsToOtlp(ocAttrs)
-	assert.EqualValues(t, 234, droppedCount)
-	assert.EqualValues(t, 4, len(otlpAttrs))
-	assertHasAttrVal(t, otlpAttrs, "abc", &otlpcommon.AttributeKeyValue{
-		Key:         "abc",
-		Type:        otlpcommon.AttributeKeyValue_STRING,
-		StringValue: "def",
-	})
-	assertHasAttrVal(t, otlpAttrs, "intval", &otlpcommon.AttributeKeyValue{
-		Key:      "intval",
-		Type:     otlpcommon.AttributeKeyValue_INT,
-		IntValue: 345,
-	})
-	assertHasAttrVal(t, otlpAttrs, "boolval", &otlpcommon.AttributeKeyValue{
-		Key:       "boolval",
-		Type:      otlpcommon.AttributeKeyValue_BOOL,
-		BoolValue: true,
-	})
-	assertHasAttrVal(t, otlpAttrs, "doubleval", &otlpcommon.AttributeKeyValue{
-		Key:         "doubleval",
-		Type:        otlpcommon.AttributeKeyValue_DOUBLE,
-		DoubleValue: 4.5,
-	})
+	attrs = ocAttrsToInternal(ocAttrs)
+
+	expected := data.NewAttributes(data.AttributesMap{
+		"abc":       data.NewAttributeValueString("def"),
+		"intval":    data.NewAttributeValueInt(345),
+		"boolval":   data.NewAttributeValueBool(true),
+		"doubleval": data.NewAttributeValueDouble(4.5),
+	}, 234)
+	assert.EqualValues(t, expected, attrs)
 }
 
-func TestOcSpanKindToOtlp(t *testing.T) {
+func TestOcSpanKindToInternal(t *testing.T) {
 	tests := []struct {
 		ocAttrs  *octrace.Span_Attributes
 		ocKind   octrace.Span_SpanKind
@@ -310,14 +244,14 @@ func TestOcSpanKindToOtlp(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.otlpKind.String(), func(t *testing.T) {
-			got := ocSpanKindToOtlp(test.ocKind, test.ocAttrs)
+			got := ocSpanKindToInternal(test.ocKind, test.ocAttrs)
 			assert.EqualValues(t, test.otlpKind, got, "Expected "+test.otlpKind.String()+", got "+got.String())
 		})
 	}
 }
 
-func TestOcToOtlp(t *testing.T) {
-	ocNode := &occommon.Node{}
+func TestOcToInternal(t *testing.T) {
+	ocNode := &occommon.Node{Attributes: map[string]string{"nodeattr": "attrval123"}}
 	ocResource := &ocresource.Resource{}
 
 	timestampP, err := ptypes.TimestampProto(time.Date(2020, 2, 11, 20, 26, 0, 0, time.UTC))
@@ -372,75 +306,75 @@ func TestOcToOtlp(t *testing.T) {
 		Resource:  ocResource,
 	}
 
-	otlpSpan1 := &otlptrace.Span{
-		Name:              "operationB",
-		StartTimeUnixnano: timestampToUnixnano(timestampP),
-		EndTimeUnixnano:   timestampToUnixnano(timestampP),
-		Events: []*otlptrace.Span_Event{
-			{
-				TimeUnixnano: timestampToUnixnano(timestampP),
-				Name:         "event1",
-				Attributes: []*otlpcommon.AttributeKeyValue{
-					{
-						Key:         "eventattr1",
-						Type:        otlpcommon.AttributeKeyValue_STRING,
-						StringValue: "eventattrval1",
-					},
+	span1 := data.NewSpan()
+	span1.SetName("operationB")
+	span1.SetStartTime(internal.TimestampToUnixnano(timestampP))
+	span1.SetEndTime(internal.TimestampToUnixnano(timestampP))
+	span1.SetEvents([]*data.SpanEvent{
+		data.NewSpanEvent(
+			internal.TimestampToUnixnano(timestampP),
+			"event1",
+			data.NewAttributes(
+				data.AttributesMap{
+					"eventattr1": data.NewAttributeValueString("eventattrval1"),
 				},
-				DroppedAttributesCount: 4,
-			},
-		},
-		DroppedEventsCount: 3,
-		Status:             &otlptrace.Status{Message: "status-cancelled", Code: otlptrace.Status_Cancelled},
-	}
+				4,
+			),
+		),
+	})
+	span1.SetDroppedEventsCount(3)
+	span1.SetStatus(data.NewSpanStatus(data.StatusCode(1), "status-cancelled"))
 
-	otlpSpan2 := &otlptrace.Span{
-		Name:              "operationC",
-		StartTimeUnixnano: timestampToUnixnano(timestampP),
-		EndTimeUnixnano:   timestampToUnixnano(timestampP),
-		Links:             []*otlptrace.Span_Link{{}},
-		DroppedLinksCount: 1,
-	}
+	span2 := data.NewSpan()
+	span2.SetName("operationC")
+	span2.SetStartTime(internal.TimestampToUnixnano(timestampP))
+	span2.SetEndTime(internal.TimestampToUnixnano(timestampP))
+	span2.SetLinks([]*data.SpanLink{data.NewSpanLink()})
+	span2.SetDroppedLinksCount(1)
 
-	otlpSpan3 := &otlptrace.Span{
-		Name:              "operationD",
-		StartTimeUnixnano: timestampToUnixnano(timestampP),
-		EndTimeUnixnano:   timestampToUnixnano(timestampP),
-	}
+	span3 := data.NewSpan()
+	span3.SetName("operationD")
+	span3.SetStartTime(internal.TimestampToUnixnano(timestampP))
+	span3.SetEndTime(internal.TimestampToUnixnano(timestampP))
+
+	internalResource := data.NewResource()
+	internalResource.SetAttributes(
+		map[string]data.AttributeValue{"nodeattr": data.NewAttributeValueString("attrval123")},
+	)
 
 	tests := []struct {
 		name string
 		oc   consumerdata.TraceData
-		otlp []*otlptrace.ResourceSpans
+		itd  data.TraceData
 	}{
 		{
 			name: "empty",
 			oc:   consumerdata.TraceData{},
-			otlp: nil,
+			itd:  data.TraceData{},
 		},
 
 		{
 			name: "nil-resource",
 			oc:   consumerdata.TraceData{Node: ocNode},
-			otlp: []*otlptrace.ResourceSpans{
-				{Resource: &otlpresource.Resource{}},
-			},
+			itd: data.NewTraceData([]*data.ResourceSpans{
+				data.NewResourceSpans(internalResource, nil),
+			}),
 		},
 
 		{
 			name: "nil-node",
 			oc:   consumerdata.TraceData{Resource: ocResource},
-			otlp: []*otlptrace.ResourceSpans{
-				{Resource: &otlpresource.Resource{}},
-			},
+			itd: data.NewTraceData([]*data.ResourceSpans{
+				data.NewResourceSpans(data.NewResource(), nil),
+			}),
 		},
 
 		{
 			name: "no-spans",
 			oc:   consumerdata.TraceData{Node: ocNode, Resource: ocResource},
-			otlp: []*otlptrace.ResourceSpans{
-				{Resource: &otlpresource.Resource{}},
-			},
+			itd: data.NewTraceData([]*data.ResourceSpans{
+				data.NewResourceSpans(internalResource, nil),
+			}),
 		},
 
 		{
@@ -450,12 +384,9 @@ func TestOcToOtlp(t *testing.T) {
 				Resource: ocResource,
 				Spans:    []*octrace.Span{ocSpan1},
 			},
-			otlp: []*otlptrace.ResourceSpans{
-				{
-					Resource: &otlpresource.Resource{},
-					Spans:    []*otlptrace.Span{otlpSpan1},
-				},
-			},
+			itd: data.NewTraceData([]*data.ResourceSpans{
+				data.NewResourceSpans(internalResource, []*data.Span{span1}),
+			}),
 		},
 
 		{
@@ -465,12 +396,9 @@ func TestOcToOtlp(t *testing.T) {
 				Resource: ocResource,
 				Spans:    []*octrace.Span{ocSpan1, nil, ocSpan2},
 			},
-			otlp: []*otlptrace.ResourceSpans{
-				{
-					Resource: &otlpresource.Resource{},
-					Spans:    []*otlptrace.Span{otlpSpan1, otlpSpan2},
-				},
-			},
+			itd: data.NewTraceData([]*data.ResourceSpans{
+				data.NewResourceSpans(internalResource, []*data.Span{span1, span2}),
+			}),
 		},
 
 		{
@@ -480,16 +408,10 @@ func TestOcToOtlp(t *testing.T) {
 				Resource: ocResource,
 				Spans:    []*octrace.Span{ocSpan1, ocSpan2, ocSpan3},
 			},
-			otlp: []*otlptrace.ResourceSpans{
-				{
-					Resource: &otlpresource.Resource{},
-					Spans:    []*otlptrace.Span{otlpSpan1, otlpSpan2},
-				},
-				{
-					Resource: &otlpresource.Resource{},
-					Spans:    []*otlptrace.Span{otlpSpan3},
-				},
-			},
+			itd: data.NewTraceData([]*data.ResourceSpans{
+				data.NewResourceSpans(internalResource, []*data.Span{span1, span2}),
+				data.NewResourceSpans(internalResource, []*data.Span{span3}),
+			}),
 		},
 
 		{
@@ -499,23 +421,17 @@ func TestOcToOtlp(t *testing.T) {
 				Resource: ocResource,
 				Spans:    []*octrace.Span{ocSpan1, ocSpan3, ocSpan2},
 			},
-			otlp: []*otlptrace.ResourceSpans{
-				{
-					Resource: &otlpresource.Resource{},
-					Spans:    []*otlptrace.Span{otlpSpan1, otlpSpan2},
-				},
-				{
-					Resource: &otlpresource.Resource{},
-					Spans:    []*otlptrace.Span{otlpSpan3},
-				},
-			},
+			itd: data.NewTraceData([]*data.ResourceSpans{
+				data.NewResourceSpans(internalResource, []*data.Span{span1, span2}),
+				data.NewResourceSpans(internalResource, []*data.Span{span3}),
+			}),
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got := ocToOtlp(test.oc)
-			assert.EqualValues(t, test.otlp, got)
+			got := ocToInternal(test.oc)
+			assert.EqualValues(t, test.itd, got)
 		})
 	}
 }

--- a/translator/trace/oc_to_otlp.go
+++ b/translator/trace/oc_to_otlp.go
@@ -75,7 +75,7 @@ func ocToOtlp(td consumerdata.TraceData) []*otlptrace.ResourceSpans {
 }
 
 func timestampToUnixnano(ts *timestamp.Timestamp) uint64 {
-	return uint64(internal.TimestampToTime(ts).UnixNano())
+	return uint64(internal.TimestampToUnixnano(ts))
 }
 
 func ocSpanToOtlp(ocSpan *octrace.Span) *otlptrace.Span {
@@ -291,22 +291,22 @@ func ocMessageEventToOtlpAttrs(msgEvent *octrace.Span_TimeEvent_MessageEvent) []
 
 	return []*otlpcommon.AttributeKeyValue{
 		{
-			Key:         ocTimeEventMessageEventType,
+			Key:         conventions.OCTimeEventMessageEventType,
 			StringValue: msgEvent.Type.String(),
 			Type:        otlpcommon.AttributeKeyValue_STRING,
 		},
 		{
-			Key:      ocTimeEventMessageEventID,
+			Key:      conventions.OCTimeEventMessageEventID,
 			IntValue: int64(msgEvent.Id),
 			Type:     otlpcommon.AttributeKeyValue_INT,
 		},
 		{
-			Key:      ocTimeEventMessageEventUSize,
+			Key:      conventions.OCTimeEventMessageEventUSize,
 			IntValue: int64(msgEvent.UncompressedSize),
 			Type:     otlpcommon.AttributeKeyValue_INT,
 		},
 		{
-			Key:      ocTimeEventMessageEventCSize,
+			Key:      conventions.OCTimeEventMessageEventCSize,
 			IntValue: int64(msgEvent.CompressedSize),
 			Type:     otlpcommon.AttributeKeyValue_INT,
 		},
@@ -360,13 +360,13 @@ func ocNodeResourceToOtlp(node *occommon.Node, resource *ocresource.Resource) *o
 		}
 		if node.Identifier != nil {
 			if node.Identifier.StartTimestamp != nil {
-				attrs[ocAttributeProcessStartTime] = ptypes.TimestampString(node.Identifier.StartTimestamp)
+				attrs[conventions.OCAttributeProcessStartTime] = ptypes.TimestampString(node.Identifier.StartTimestamp)
 			}
 			if node.Identifier.HostName != "" {
 				attrs[conventions.AttributeHostHostname] = node.Identifier.HostName
 			}
 			if node.Identifier.Pid != 0 {
-				attrs[ocAttributeProcessID] = strconv.Itoa(int(node.Identifier.Pid))
+				attrs[conventions.OCAttributeProcessID] = strconv.Itoa(int(node.Identifier.Pid))
 			}
 		}
 		if node.LibraryInfo != nil {
@@ -374,7 +374,7 @@ func ocNodeResourceToOtlp(node *occommon.Node, resource *ocresource.Resource) *o
 				attrs[conventions.AttributeLibraryVersion] = node.LibraryInfo.CoreLibraryVersion
 			}
 			if node.LibraryInfo.ExporterVersion != "" {
-				attrs[ocAttributeExporterVersion] = node.LibraryInfo.ExporterVersion
+				attrs[conventions.OCAttributeExporterVersion] = node.LibraryInfo.ExporterVersion
 			}
 			if node.LibraryInfo.Language != occommon.LibraryInfo_LANGUAGE_UNSPECIFIED {
 				attrs[conventions.AttributeLibraryLanguage] = node.LibraryInfo.Language.String()
@@ -389,7 +389,7 @@ func ocNodeResourceToOtlp(node *occommon.Node, resource *ocresource.Resource) *o
 		}
 		// Add special fields.
 		if resource.Type != "" {
-			attrs[ocAttributeResourceType] = resource.Type
+			attrs[conventions.OCAttributeResourceType] = resource.Type
 		}
 	}
 

--- a/translator/trace/otlp_to_oc.go
+++ b/translator/trace/otlp_to_oc.go
@@ -188,14 +188,14 @@ func resourceToOC(resource *otlpresource.Resource) (*occommon.Node, *ocresource.
 		val := attributeValueToString(attr)
 
 		switch key {
-		case ocAttributeResourceType:
+		case conventions.OCAttributeResourceType:
 			ocResource.Type = val
 		case conventions.AttributeServiceName:
 			if ocNode.ServiceInfo == nil {
 				ocNode.ServiceInfo = &occommon.ServiceInfo{}
 			}
 			ocNode.ServiceInfo.Name = val
-		case ocAttributeProcessStartTime:
+		case conventions.OCAttributeProcessStartTime:
 			t, err := time.Parse(time.RFC3339Nano, val)
 			if err != nil {
 				t = defaultTime
@@ -213,7 +213,7 @@ func resourceToOC(resource *otlpresource.Resource) (*occommon.Node, *ocresource.
 				ocNode.Identifier = &occommon.ProcessIdentifier{}
 			}
 			ocNode.Identifier.HostName = val
-		case ocAttributeProcessID:
+		case conventions.OCAttributeProcessID:
 			pid, err := strconv.Atoi(val)
 			if err != nil {
 				pid = defaultProcessID
@@ -227,7 +227,7 @@ func resourceToOC(resource *otlpresource.Resource) (*occommon.Node, *ocresource.
 				ocNode.LibraryInfo = &occommon.LibraryInfo{}
 			}
 			ocNode.LibraryInfo.CoreLibraryVersion = val
-		case ocAttributeExporterVersion:
+		case conventions.OCAttributeExporterVersion:
 			if ocNode.LibraryInfo == nil {
 				ocNode.LibraryInfo = &occommon.LibraryInfo{}
 			}

--- a/translator/trace/otlp_to_oc_test.go
+++ b/translator/trace/otlp_to_oc_test.go
@@ -88,12 +88,12 @@ func TestResourceSpansToTraceData(t *testing.T) {
 
 	otlpAttributes := []*otlpcommon.AttributeKeyValue{
 		{
-			Key:         ocAttributeResourceType,
+			Key:         conventions.OCAttributeResourceType,
 			Type:        otlpcommon.AttributeKeyValue_STRING,
 			StringValue: "good-resource",
 		},
 		{
-			Key:         ocAttributeProcessStartTime,
+			Key:         conventions.OCAttributeProcessStartTime,
 			Type:        otlpcommon.AttributeKeyValue_STRING,
 			StringValue: "2020-02-11T20:26:00Z",
 		},
@@ -103,7 +103,7 @@ func TestResourceSpansToTraceData(t *testing.T) {
 			StringValue: "host1",
 		},
 		{
-			Key:         ocAttributeProcessID,
+			Key:         conventions.OCAttributeProcessID,
 			Type:        otlpcommon.AttributeKeyValue_STRING,
 			StringValue: "123",
 		},
@@ -113,7 +113,7 @@ func TestResourceSpansToTraceData(t *testing.T) {
 			StringValue: "v2.0.1",
 		},
 		{
-			Key:         ocAttributeExporterVersion,
+			Key:         conventions.OCAttributeExporterVersion,
 			Type:        otlpcommon.AttributeKeyValue_STRING,
 			StringValue: "v1.2.0",
 		},


### PR DESCRIPTION
This implements translation from OpenCensus to internal representation.
This will be needed by OpenCensus receiver and can be also used
by compatibility shims.

Moved oc_const.go to conventions/opencensus.go and made the constants
exported so that we can reuse in the codebase.