### PR TITLE
Fix several example typos in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ exporters:
     loglevel: debug
 
   jaeger_grpc:
-    endpoint: "http://localhost:14250"
+    endpoint: "localhost:14250"
 
   jaeger_thrift_http:
     headers: {"X-test-header": "test-header"}

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ receivers:
     address: "localhost:55678"
 
   zipkin:
-    address: "localhost:9411"
+    endpoint: "0.0.0.0:9411"
 
   jaeger:
     protocols:
@@ -304,7 +304,7 @@ service:
 
 ### <a name="troubleshooting"></a>Troubleshooting
 By default, the OpenTelemetry Collector exposes Prometheus metrics and logs for
-monitoring and troubleshooting. When troubleshooting live issues it is 
+monitoring and troubleshooting. When troubleshooting live issues it is
 recommended to use `zpages` [extension](#config-extensions).
 
 The `zpages` extension provides live information about receivers and exporters.
@@ -313,7 +313,7 @@ at `http://localhost:55679/debug/tracez`. Click on the links of the displayed
 operations to see information about each individual operation. Operations that
 encountered errors are reported on the right most column.
 
-![zpages-example](docs/images/zpages-example.png) 
+![zpages-example](docs/images/zpages-example.png)
 
 ## <a name="other-information"></a>Other Information
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ README.md](receiver/README.md).
 ```yaml
 receivers:
   opencensus:
-    address: "localhost:55678"
+    endpoint: "0.0.0.0:55678"
 
   zipkin:
     endpoint: "0.0.0.0:9411"


### PR DESCRIPTION
**Description:** 
I found several of the examples in the README were incorrect:
* the opencensus and zipkin receivers take an `endpoint` key, not `address`
  * Most users will want these to listen on `0.0.0.0` or a specific IP, not localhost 
* the jaeger_grpc exporter endpoint can't start with `http://`, it is simply `hostname:port`
* my editor auto-trimmed a few trailing whitespaces

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** 
These issues were discovered while attempting to integrate the otel collector into the [Google/OpenCensus microservices-demo project](https://github.com/irvingpop/microservices-demo/tree/full_jaeger)

**Documentation:** < Describe the documentation added.>