### PR TITLE
Add translator from internal data structure to Opencensus format

### DIFF
--- a/internal/data/trace.go
+++ b/internal/data/trace.go
@@ -40,6 +40,10 @@ func (td TraceData) SpanCount() int {
 	return spanCount
 }
 
+func (td TraceData) ResourceSpans() []*ResourceSpans {
+	return td.resourceSpans
+}
+
 // A collection of spans from a Resource.
 //
 // Must use NewResourceSpans functions to create new instances.
@@ -135,8 +139,16 @@ func (m *Span) TraceID() TraceID {
 	return TraceIDFromBytes(m.orig.TraceId)
 }
 
+func (m *Span) TraceIDBytes() []byte {
+	return m.orig.TraceId
+}
+
 func (m *Span) SpanID() SpanID {
 	return SpanIDFromBytes(m.orig.SpanId)
+}
+
+func (m *Span) SpanIDBytes() []byte {
+	return m.orig.SpanId
 }
 
 func (m *Span) TraceState() TraceState {
@@ -145,6 +157,10 @@ func (m *Span) TraceState() TraceState {
 
 func (m *Span) ParentSpanID() SpanID {
 	return SpanIDFromBytes(m.orig.ParentSpanId)
+}
+
+func (m *Span) ParentSpanIDBytes() []byte {
+	return m.orig.ParentSpanId
 }
 
 func (m *Span) Name() string {
@@ -250,6 +266,14 @@ func (m *Span) SetStatus(v SpanStatus) {
 
 type SpanStatus struct {
 	orig *otlptrace.Status
+}
+
+func (s *SpanStatus) Code() StatusCode {
+	return StatusCode(s.orig.Code)
+}
+
+func (s *SpanStatus) Message() string {
+	return s.orig.Message
 }
 
 // StatusCode mirrors the codes defined at
@@ -360,8 +384,16 @@ func (m *SpanLink) TraceID() TraceID {
 	return TraceIDFromBytes(m.orig.TraceId)
 }
 
+func (m *SpanLink) TraceIDBytes() []byte {
+	return m.orig.TraceId
+}
+
 func (m *SpanLink) SpanID() SpanID {
 	return SpanIDFromBytes(m.orig.SpanId)
+}
+
+func (m *SpanLink) SpanIDBytes() []byte {
+	return m.orig.SpanId
 }
 
 func (m *SpanLink) Attributes() AttributesMap {

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -18,6 +18,8 @@ import (
 	"time"
 
 	"github.com/golang/protobuf/ptypes/timestamp"
+
+	"github.com/open-telemetry/opentelemetry-collector/internal/data"
 )
 
 // TimeToTimestamp converts a time.Time to a timestamp.Timestamp pointer.
@@ -37,4 +39,12 @@ func TimestampToTime(ts *timestamp.Timestamp) (t time.Time) {
 		return
 	}
 	return time.Unix(ts.Seconds, int64(ts.Nanos))
+}
+
+func TimestampToUnixnano(ts *timestamp.Timestamp) data.TimestampUnixNano {
+	return data.TimestampUnixNano(uint64(TimestampToTime(ts).UnixNano()))
+}
+
+func UnixnanoToTimestamp(u uint64) *timestamp.Timestamp {
+	return TimeToTimestamp(time.Unix(0, int64(u)))
 }

--- a/translator/conventions/opencensus.go
+++ b/translator/conventions/opencensus.go
@@ -1,0 +1,29 @@
+// Copyright 2019 OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conventions
+
+// OTLP attributes to map certain OpenCensus proto fields. These fields don't have
+// corresponding fields in OTLP, nor are defined in OTLP semantic conventions.
+// TODO: decide if any of these must be in OTLP semantic conventions.
+const (
+	OCAttributeProcessStartTime  = "opencensus.starttime"
+	OCAttributeProcessID         = "opencensus.pid"
+	OCAttributeExporterVersion   = "opencensus.exporterversion"
+	OCAttributeResourceType      = "opencensus.resourcetype"
+	OCTimeEventMessageEventType  = "opencensus.timeevent.messageevent.type"
+	OCTimeEventMessageEventID    = "opencensus.timeevent.messageevent.id"
+	OCTimeEventMessageEventUSize = "opencensus.timeevent.messageevent.usize"
+	OCTimeEventMessageEventCSize = "opencensus.timeevent.messageevent.csize"
+)

--- a/translator/internal/internal_to_oc.go
+++ b/translator/internal/internal_to_oc.go
@@ -1,0 +1,436 @@
+// Copyright 2019 OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	occommon "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
+	ocresource "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
+	octrace "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
+	"github.com/golang/protobuf/ptypes"
+	"github.com/golang/protobuf/ptypes/timestamp"
+
+	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
+	"github.com/open-telemetry/opentelemetry-collector/internal"
+	"github.com/open-telemetry/opentelemetry-collector/internal/data"
+	"github.com/open-telemetry/opentelemetry-collector/translator/conventions"
+	tracetranslator "github.com/open-telemetry/opentelemetry-collector/translator/trace"
+)
+
+const sourceFormat = "ot_internal_trace"
+
+var (
+	defaultTime      = time.Time{} // zero
+	defaultTimestamp = timestamp.Timestamp{}
+	defaultProcessID = 0
+)
+
+func internalToOC(td data.TraceData) consumerdata.TraceData {
+	ocTraceData := consumerdata.TraceData{
+		SourceFormat: sourceFormat,
+	}
+
+	resourceSpansList := td.ResourceSpans()
+
+	if len(resourceSpansList) == 0 {
+		return ocTraceData
+	}
+
+	// Original resource with its spans stored in the first object of resourceSpansList
+	// Additional spans originated from different resources stored in the following objects of resourceSpansList
+	originalResourceSpans := resourceSpansList[0]
+	additionalResourceSpansList := resourceSpansList[1:]
+
+	ocTraceData.Node, ocTraceData.Resource = internalResourceToOC(originalResourceSpans.Resource())
+	ocSpans := make([]*octrace.Span, 0, td.SpanCount())
+
+	for _, span := range originalResourceSpans.Spans() {
+		ocSpans = append(ocSpans, spanToOC(span))
+	}
+	for _, resourceSpans := range additionalResourceSpansList {
+		_, resource := internalResourceToOC(resourceSpans.Resource())
+		for _, span := range resourceSpans.Spans() {
+			ocSpan := spanToOC(span)
+			ocSpan.Resource = resource
+			ocSpans = append(ocSpans, ocSpan)
+		}
+	}
+	ocTraceData.Spans = ocSpans
+
+	return ocTraceData
+}
+
+func internalResourceToOC(resource *data.Resource) (*occommon.Node, *ocresource.Resource) {
+	if resource == nil {
+		return nil, nil
+	}
+
+	attrs := resource.Attributes()
+
+	ocNode := occommon.Node{}
+	ocResource := ocresource.Resource{}
+
+	if len(attrs) == 0 {
+		return &ocNode, &ocResource
+	}
+
+	labels := make(map[string]string, len(attrs))
+	for key, attributeValue := range attrs {
+		val := attributeValueToString(attributeValue)
+
+		switch key {
+		case conventions.OCAttributeResourceType:
+			ocResource.Type = val
+		case conventions.AttributeServiceName:
+			if ocNode.ServiceInfo == nil {
+				ocNode.ServiceInfo = &occommon.ServiceInfo{}
+			}
+			ocNode.ServiceInfo.Name = val
+		case conventions.OCAttributeProcessStartTime:
+			t, err := time.Parse(time.RFC3339Nano, val)
+			if err != nil {
+				t = defaultTime
+			}
+			ts, err := ptypes.TimestampProto(t)
+			if err != nil {
+				ts = &defaultTimestamp
+			}
+			if ocNode.Identifier == nil {
+				ocNode.Identifier = &occommon.ProcessIdentifier{}
+			}
+			ocNode.Identifier.StartTimestamp = ts
+		case conventions.AttributeHostHostname:
+			if ocNode.Identifier == nil {
+				ocNode.Identifier = &occommon.ProcessIdentifier{}
+			}
+			ocNode.Identifier.HostName = val
+		case conventions.OCAttributeProcessID:
+			pid, err := strconv.Atoi(val)
+			if err != nil {
+				pid = defaultProcessID
+			}
+			if ocNode.Identifier == nil {
+				ocNode.Identifier = &occommon.ProcessIdentifier{}
+			}
+			ocNode.Identifier.Pid = uint32(pid)
+		case conventions.AttributeLibraryVersion:
+			if ocNode.LibraryInfo == nil {
+				ocNode.LibraryInfo = &occommon.LibraryInfo{}
+			}
+			ocNode.LibraryInfo.CoreLibraryVersion = val
+		case conventions.OCAttributeExporterVersion:
+			if ocNode.LibraryInfo == nil {
+				ocNode.LibraryInfo = &occommon.LibraryInfo{}
+			}
+			ocNode.LibraryInfo.ExporterVersion = val
+		case conventions.AttributeLibraryLanguage:
+			if code, ok := occommon.LibraryInfo_Language_value[val]; ok {
+				if ocNode.LibraryInfo == nil {
+					ocNode.LibraryInfo = &occommon.LibraryInfo{}
+				}
+				ocNode.LibraryInfo.Language = occommon.LibraryInfo_Language(code)
+			}
+		default:
+			// Not a special attribute, put it into resource labels
+			labels[key] = val
+		}
+	}
+	ocResource.Labels = labels
+
+	return &ocNode, &ocResource
+}
+
+func attributeValueToString(attr data.AttributeValue) string {
+	switch attr.Type() {
+	case data.AttributeValueSTRING:
+		return attr.StringVal()
+	case data.AttributeValueBOOL:
+		return strconv.FormatBool(attr.BoolVal())
+	case data.AttributeValueDOUBLE:
+		return strconv.FormatFloat(attr.DoubleVal(), 'f', -1, 64)
+	case data.AttributeValueINT:
+		return strconv.FormatInt(attr.IntVal(), 10)
+	default:
+		return fmt.Sprintf("<Unknown OpenTelemetry attribute value type %q>", attr.Type())
+	}
+}
+
+func spanToOC(span *data.Span) *octrace.Span {
+	attributes := attributesMapToOCSpanAttributes(span.Attributes(), span.DroppedAttributesCount())
+	if kindAttr := spanKindToOCAttribute(span.Kind()); kindAttr != nil {
+		if attributes == nil {
+			attributes = &octrace.Span_Attributes{
+				AttributeMap:           make(map[string]*octrace.AttributeValue, 1),
+				DroppedAttributesCount: 0,
+			}
+		}
+		attributes.AttributeMap[tracetranslator.TagSpanKind] = kindAttr
+	}
+
+	return &octrace.Span{
+		TraceId:      span.TraceIDBytes(),
+		SpanId:       span.SpanIDBytes(),
+		Tracestate:   traceStateToOC(span.TraceState()),
+		ParentSpanId: span.ParentSpanIDBytes(),
+		Name: &octrace.TruncatableString{
+			Value: span.Name(),
+		},
+		Kind:           spanKindToOC(span.Kind()),
+		StartTime:      internal.UnixnanoToTimestamp(uint64(span.StartTime())),
+		EndTime:        internal.UnixnanoToTimestamp(uint64(span.EndTime())),
+		Attributes:     attributes,
+		TimeEvents:     eventsToOC(span.Events(), span.DroppedEventsCount()),
+		Links:          linksToOC(span.Links(), span.DroppedLinksCount()),
+		Status:         statusToOC(span.Status()),
+		ChildSpanCount: nil, // TODO(dmitryax): Handle once OTLP supports it
+	}
+}
+
+func attributesMapToOCSpanAttributes(attributes data.AttributesMap, droppedCount uint32) *octrace.Span_Attributes {
+	if len(attributes) == 0 && droppedCount == 0 {
+		return nil
+	}
+
+	return &octrace.Span_Attributes{
+		AttributeMap:           attributesMapToOCAttributeMap(attributes),
+		DroppedAttributesCount: int32(droppedCount),
+	}
+}
+
+func attributesMapToOCAttributeMap(attributes data.AttributesMap) map[string]*octrace.AttributeValue {
+	if len(attributes) == 0 {
+		return nil
+	}
+
+	ocAttributes := make(map[string]*octrace.AttributeValue, len(attributes))
+	for key, attr := range attributes {
+		ocAttributes[key] = attributeValueToOC(attr)
+	}
+	return ocAttributes
+}
+
+func attributeValueToOC(attr data.AttributeValue) *octrace.AttributeValue {
+	a := &octrace.AttributeValue{}
+
+	switch attr.Type() {
+	case data.AttributeValueSTRING:
+		a.Value = &octrace.AttributeValue_StringValue{
+			StringValue: &octrace.TruncatableString{
+				Value: attr.StringVal(),
+			},
+		}
+	case data.AttributeValueBOOL:
+		a.Value = &octrace.AttributeValue_BoolValue{
+			BoolValue: attr.BoolVal(),
+		}
+	case data.AttributeValueDOUBLE:
+		a.Value = &octrace.AttributeValue_DoubleValue{
+			DoubleValue: attr.DoubleVal(),
+		}
+	case data.AttributeValueINT:
+		a.Value = &octrace.AttributeValue_IntValue{
+			IntValue: attr.IntVal(),
+		}
+	default:
+		a.Value = &octrace.AttributeValue_StringValue{
+			StringValue: &octrace.TruncatableString{
+				Value: fmt.Sprintf("<Unknown OpenTelemetry attribute value type %q>", attr.Type()),
+			},
+		}
+	}
+
+	return a
+}
+
+func spanKindToOCAttribute(kind data.SpanKind) *octrace.AttributeValue {
+	var ocKind tracetranslator.OpenTracingSpanKind
+	switch kind {
+	case data.SpanKindCONSUMER:
+		ocKind = tracetranslator.OpenTracingSpanKindConsumer
+	case data.SpanKindPRODUCER:
+		ocKind = tracetranslator.OpenTracingSpanKindProducer
+	case data.SpanKindUNSPECIFIED:
+	case data.SpanKindINTERNAL:
+	case data.SpanKindSERVER: // explicitly handled as SpanKind
+	case data.SpanKindCLIENT: // explicitly handled as SpanKind
+	default:
+
+	}
+
+	if string(ocKind) == "" {
+		// No matching kind attribute value
+		return nil
+	}
+
+	return stringAttributeValue(string(ocKind))
+}
+
+func stringAttributeValue(val string) *octrace.AttributeValue {
+	return &octrace.AttributeValue{
+		Value: &octrace.AttributeValue_StringValue{
+			StringValue: &octrace.TruncatableString{
+				Value: val,
+			},
+		},
+	}
+}
+
+// OTLP follows the W3C format, e.g. "vendorname1=opaqueValue1,vendorname2=opaqueValue2"
+func traceStateToOC(traceState data.TraceState) *octrace.Span_Tracestate {
+	if traceState == "" {
+		return nil
+	}
+
+	// key-value pairs in the "key1=value1" format
+	pairs := strings.Split(string(traceState), ",")
+
+	entries := make([]*octrace.Span_Tracestate_Entry, 0, len(pairs))
+	for _, pair := range pairs {
+		kv := strings.SplitN(pair, "=", 2)
+		if len(kv) == 0 {
+			continue
+		}
+
+		key := kv[0]
+		val := ""
+		if len(kv) >= 2 {
+			val = kv[1]
+		}
+
+		entries = append(entries, &octrace.Span_Tracestate_Entry{
+			Key:   key,
+			Value: val,
+		})
+	}
+
+	return &octrace.Span_Tracestate{
+		Entries: entries,
+	}
+}
+
+func spanKindToOC(kind data.SpanKind) octrace.Span_SpanKind {
+	switch kind {
+	case data.SpanKindSERVER:
+		return octrace.Span_SERVER
+	case data.SpanKindCLIENT:
+		return octrace.Span_CLIENT
+	// NOTE: see `spanKindToOCAttribute` function for custom kinds
+	case data.SpanKindUNSPECIFIED:
+	case data.SpanKindINTERNAL:
+	case data.SpanKindPRODUCER:
+	case data.SpanKindCONSUMER:
+	default:
+	}
+
+	return octrace.Span_SPAN_KIND_UNSPECIFIED
+}
+
+func eventsToOC(events []*data.SpanEvent, droppedCount uint32) *octrace.Span_TimeEvents {
+	if len(events) == 0 && droppedCount == 0 {
+		return nil
+	}
+
+	ocEvents := make([]*octrace.Span_TimeEvent, 0, len(events))
+	for _, event := range events {
+		ocEvents = append(ocEvents, eventToOC(event))
+	}
+
+	return &octrace.Span_TimeEvents{
+		TimeEvent:                 ocEvents,
+		DroppedMessageEventsCount: int32(droppedCount),
+	}
+}
+
+func eventToOC(event *data.SpanEvent) *octrace.Span_TimeEvent {
+	attrs := event.Attributes()
+
+	ocMessageEventType, ocMessageEventTypeAttrFound := attrs[conventions.OCTimeEventMessageEventType]
+	ocMessageEventID, ocMessageEventIDAttrFound := attrs[conventions.OCTimeEventMessageEventID]
+	ocMessageEventUSize, ocMessageEventUSizeAttrFound := attrs[conventions.OCTimeEventMessageEventUSize]
+	ocMessageEventCSize, ocMessageEventCSizeAttrFound := attrs[conventions.OCTimeEventMessageEventCSize]
+
+	// Consider TimeEvent to be of MessageEvent type if all relevant attributes are set
+	if ocMessageEventTypeAttrFound && ocMessageEventIDAttrFound && ocMessageEventUSizeAttrFound && ocMessageEventCSizeAttrFound {
+		ocMessageEventTypeVal, _ := octrace.Span_TimeEvent_MessageEvent_Type_value[ocMessageEventType.StringVal()]
+		return &octrace.Span_TimeEvent{
+			Time: internal.UnixnanoToTimestamp(uint64(event.Timestamp())),
+			Value: &octrace.Span_TimeEvent_MessageEvent_{
+				MessageEvent: &octrace.Span_TimeEvent_MessageEvent{
+					Type:             octrace.Span_TimeEvent_MessageEvent_Type(ocMessageEventTypeVal),
+					Id:               uint64(ocMessageEventID.IntVal()),
+					UncompressedSize: uint64(ocMessageEventUSize.IntVal()),
+					CompressedSize:   uint64(ocMessageEventCSize.IntVal()),
+				},
+			},
+		}
+	}
+
+	ocAttributes := attributesMapToOCSpanAttributes(attrs, event.DroppedAttributesCount())
+	return &octrace.Span_TimeEvent{
+		Time: internal.UnixnanoToTimestamp(uint64(event.Timestamp())),
+		Value: &octrace.Span_TimeEvent_Annotation_{
+			Annotation: &octrace.Span_TimeEvent_Annotation{
+				Description: &octrace.TruncatableString{
+					Value: event.Name(),
+				},
+				Attributes: ocAttributes,
+			},
+		},
+	}
+}
+
+func linksToOC(links []*data.SpanLink, droppedCount uint32) *octrace.Span_Links {
+	if len(links) == 0 && droppedCount == 0 {
+		return nil
+	}
+
+	return &octrace.Span_Links{
+		Link:              linksToOCLinks(links),
+		DroppedLinksCount: int32(droppedCount),
+	}
+}
+
+func linksToOCLinks(links []*data.SpanLink) []*octrace.Span_Link {
+	if len(links) == 0 {
+		return nil
+	}
+
+	ocLinks := make([]*octrace.Span_Link, 0, len(links))
+	for _, link := range links {
+		ocLink := &octrace.Span_Link{
+			TraceId:    link.TraceIDBytes(),
+			SpanId:     link.SpanIDBytes(),
+			Tracestate: traceStateToOC(link.TraceState()),
+			Attributes: attributesMapToOCSpanAttributes(link.Attributes(), link.DroppedAttributesCount()),
+		}
+		ocLinks = append(ocLinks, ocLink)
+	}
+	return ocLinks
+}
+
+func statusToOC(status data.SpanStatus) *octrace.Status {
+	emptyStatus := data.SpanStatus{}
+	if status == emptyStatus {
+		return nil
+	}
+	return &octrace.Status{
+		Code:    int32(status.Code()),
+		Message: status.Message(),
+	}
+}

--- a/translator/internal/internal_to_oc_test.go
+++ b/translator/internal/internal_to_oc_test.go
@@ -1,0 +1,383 @@
+// Copyright 2019 OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"testing"
+	"time"
+
+	occommon "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
+	ocresource "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
+	octrace "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
+	v1 "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
+	"github.com/golang/protobuf/ptypes"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
+	"github.com/open-telemetry/opentelemetry-collector/internal"
+	"github.com/open-telemetry/opentelemetry-collector/internal/data"
+	"github.com/open-telemetry/opentelemetry-collector/translator/conventions"
+	tracetranslator "github.com/open-telemetry/opentelemetry-collector/translator/trace"
+)
+
+func TestInternalTraceStateToOC(t *testing.T) {
+	assert.Equal(t, (*v1.Span_Tracestate)(nil), traceStateToOC(data.TraceState("")))
+
+	ocTracestate := &octrace.Span_Tracestate{
+		Entries: []*octrace.Span_Tracestate_Entry{
+			{
+				Key:   "abc",
+				Value: "def",
+			},
+		},
+	}
+	assert.EqualValues(t, ocTracestate, traceStateToOC(data.TraceState("abc=def")))
+
+	ocTracestate.Entries = append(ocTracestate.Entries,
+		&octrace.Span_Tracestate_Entry{
+			Key:   "123",
+			Value: "4567",
+		})
+	assert.EqualValues(t, ocTracestate, traceStateToOC(data.TraceState("abc=def,123=4567")))
+}
+
+func TestAttributesMapToOC(t *testing.T) {
+	assert.EqualValues(t, (*v1.Span_Attributes)(nil), attributesMapToOCSpanAttributes(data.AttributesMap{}, 0))
+
+	ocAttrs := &octrace.Span_Attributes{
+		DroppedAttributesCount: 123,
+	}
+	assert.EqualValues(t, ocAttrs, attributesMapToOCSpanAttributes(data.AttributesMap{}, 123))
+
+	ocAttrs = &octrace.Span_Attributes{
+		AttributeMap: map[string]*octrace.AttributeValue{
+			"abc": {
+				Value: &octrace.AttributeValue_StringValue{StringValue: &octrace.TruncatableString{Value: "def"}},
+			},
+		},
+		DroppedAttributesCount: 234,
+	}
+	assert.EqualValues(t, ocAttrs,
+		attributesMapToOCSpanAttributes(
+			data.AttributesMap{
+				"abc": data.NewAttributeValueString("def"),
+			},
+			234))
+
+	ocAttrs.AttributeMap["intval"] = &octrace.AttributeValue{
+		Value: &octrace.AttributeValue_IntValue{IntValue: 345},
+	}
+	ocAttrs.AttributeMap["boolval"] = &octrace.AttributeValue{
+		Value: &octrace.AttributeValue_BoolValue{BoolValue: true},
+	}
+	ocAttrs.AttributeMap["doubleval"] = &octrace.AttributeValue{
+		Value: &octrace.AttributeValue_DoubleValue{DoubleValue: 4.5},
+	}
+	assert.EqualValues(t, ocAttrs,
+		attributesMapToOCSpanAttributes(
+			data.AttributesMap{
+				"abc":       data.NewAttributeValueString("def"),
+				"intval":    data.NewAttributeValueInt(345),
+				"boolval":   data.NewAttributeValueBool(true),
+				"doubleval": data.NewAttributeValueDouble(4.5),
+			},
+			234))
+}
+
+func TestSpanKindToOC(t *testing.T) {
+	tests := []struct {
+		kind   data.SpanKind
+		ocKind octrace.Span_SpanKind
+	}{
+		{
+			kind:   data.SpanKindCLIENT,
+			ocKind: octrace.Span_CLIENT,
+		},
+		{
+			kind:   data.SpanKindSERVER,
+			ocKind: octrace.Span_SERVER,
+		},
+		{
+			kind:   data.SpanKindCONSUMER,
+			ocKind: octrace.Span_SPAN_KIND_UNSPECIFIED,
+		},
+		{
+			kind:   data.SpanKindPRODUCER,
+			ocKind: octrace.Span_SPAN_KIND_UNSPECIFIED,
+		},
+		{
+			kind:   data.SpanKindUNSPECIFIED,
+			ocKind: octrace.Span_SPAN_KIND_UNSPECIFIED,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.kind.String(), func(t *testing.T) {
+			got := spanKindToOC(test.kind)
+			assert.EqualValues(t, test.ocKind, got, "Expected "+test.ocKind.String()+", got "+got.String())
+		})
+	}
+}
+
+func TestSpanKindToOCAttribute(t *testing.T) {
+	tests := []struct {
+		kind        data.SpanKind
+		ocAttribute *octrace.AttributeValue
+	}{
+		{
+			kind: data.SpanKindCONSUMER,
+			ocAttribute: &octrace.AttributeValue{
+				Value: &octrace.AttributeValue_StringValue{
+					StringValue: &octrace.TruncatableString{
+						Value: string(tracetranslator.OpenTracingSpanKindConsumer),
+					},
+				},
+			},
+		},
+		{
+			kind: data.SpanKindPRODUCER,
+			ocAttribute: &octrace.AttributeValue{
+				Value: &octrace.AttributeValue_StringValue{
+					StringValue: &octrace.TruncatableString{
+						Value: string(tracetranslator.OpenTracingSpanKindProducer),
+					},
+				},
+			},
+		},
+		{
+			kind:        data.SpanKindUNSPECIFIED,
+			ocAttribute: nil,
+		},
+		{
+			kind:        data.SpanKindSERVER,
+			ocAttribute: nil,
+		},
+		{
+			kind:        data.SpanKindCLIENT,
+			ocAttribute: nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.kind.String(), func(t *testing.T) {
+			got := spanKindToOCAttribute(test.kind)
+			assert.EqualValues(t, test.ocAttribute, got, "Expected "+test.ocAttribute.String()+", got "+got.String())
+		})
+	}
+}
+
+func TestInternalToOC(t *testing.T) {
+	timestampP, err := ptypes.TimestampProto(time.Date(2020, 3, 9, 20, 26, 0, 0, time.UTC))
+	assert.NoError(t, err)
+
+	resource := &data.Resource{}
+	resource.SetAttributes(
+		data.AttributesMap{
+			"label1": data.NewAttributeValueString("value1"),
+		},
+	)
+
+	span1 := data.NewSpan()
+	span1.SetName("operationB")
+	span1.SetStartTime(internal.TimestampToUnixnano(timestampP))
+	span1.SetEndTime(internal.TimestampToUnixnano(timestampP))
+	span1.SetEvents([]*data.SpanEvent{
+		data.NewSpanEvent(
+			internal.TimestampToUnixnano(timestampP),
+			"event1",
+			data.NewAttributes(
+				data.AttributesMap{
+					"eventattr1": data.NewAttributeValueString("eventattrval1"),
+				},
+				4),
+		),
+	})
+	span1.SetDroppedEventsCount(3)
+	span1.SetStatus(data.NewSpanStatus(data.StatusCode(1), "status-cancelled"))
+
+	span2 := data.NewSpan()
+	span2.SetName("operationC")
+	span2.SetStartTime(internal.TimestampToUnixnano(timestampP))
+	span2.SetEndTime(internal.TimestampToUnixnano(timestampP))
+	span2.SetLinks([]*data.SpanLink{data.NewSpanLink()})
+	span2.SetDroppedLinksCount(1)
+	span2event := data.NewSpanEvent(
+		internal.TimestampToUnixnano(timestampP),
+		"",
+		data.NewAttributes(
+			data.AttributesMap{
+				conventions.OCTimeEventMessageEventType:  data.NewAttributeValueString(octrace.Span_TimeEvent_MessageEvent_SENT.String()),
+				conventions.OCTimeEventMessageEventID:    data.NewAttributeValueInt(123),
+				conventions.OCTimeEventMessageEventUSize: data.NewAttributeValueInt(345),
+				conventions.OCTimeEventMessageEventCSize: data.NewAttributeValueInt(234),
+			},
+			0),
+	)
+	span2.SetEvents([]*data.SpanEvent{span2event})
+
+	span3 := data.NewSpan()
+	span3.SetName("operationD")
+	span3.SetStartTime(internal.TimestampToUnixnano(timestampP))
+	span3.SetEndTime(internal.TimestampToUnixnano(timestampP))
+	span3ResourceType := "resource2"
+	span3Resource := &data.Resource{}
+	span3Resource.SetAttributes(data.AttributesMap{
+		conventions.OCAttributeResourceType: data.NewAttributeValueString(span3ResourceType),
+	})
+	resourceSpans3 := data.NewResourceSpans(span3Resource, []*data.Span{span3})
+
+	ocNode := &occommon.Node{}
+	ocResource := &ocresource.Resource{
+		Labels: map[string]string{
+			"label1": "value1",
+		},
+	}
+
+	ocSpan1 := &octrace.Span{
+		Name:      &octrace.TruncatableString{Value: "operationB"},
+		StartTime: timestampP,
+		EndTime:   timestampP,
+		TimeEvents: &octrace.Span_TimeEvents{
+			TimeEvent: []*octrace.Span_TimeEvent{
+				{
+					Time: timestampP,
+					Value: &octrace.Span_TimeEvent_Annotation_{
+						Annotation: &octrace.Span_TimeEvent_Annotation{
+							Description: &octrace.TruncatableString{Value: "event1"},
+							Attributes: &octrace.Span_Attributes{
+								AttributeMap: map[string]*octrace.AttributeValue{
+									"eventattr1": {
+										Value: &octrace.AttributeValue_StringValue{
+											StringValue: &octrace.TruncatableString{Value: "eventattrval1"},
+										},
+									},
+								},
+								DroppedAttributesCount: 4,
+							},
+						},
+					},
+				},
+			},
+			DroppedMessageEventsCount: 3,
+		},
+		Status: &octrace.Status{Message: "status-cancelled", Code: 1},
+	}
+
+	ocSpan2 := &octrace.Span{
+		Name:      &octrace.TruncatableString{Value: "operationC"},
+		StartTime: timestampP,
+		EndTime:   timestampP,
+		Links: &octrace.Span_Links{
+			Link:              []*octrace.Span_Link{{}},
+			DroppedLinksCount: 1,
+		},
+		TimeEvents: &octrace.Span_TimeEvents{
+			TimeEvent: []*octrace.Span_TimeEvent{
+				{
+					Time: timestampP,
+					Value: &octrace.Span_TimeEvent_MessageEvent_{
+						MessageEvent: &octrace.Span_TimeEvent_MessageEvent{
+							Type:             octrace.Span_TimeEvent_MessageEvent_SENT,
+							Id:               123,
+							UncompressedSize: 345,
+							CompressedSize:   234,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	ocSpan3 := &octrace.Span{
+		Name:      &octrace.TruncatableString{Value: "operationD"},
+		StartTime: timestampP,
+		EndTime:   timestampP,
+		Resource: &ocresource.Resource{
+			Type:   span3ResourceType,
+			Labels: map[string]string{},
+		},
+	}
+
+	tests := []struct {
+		name     string
+		internal data.TraceData
+		oc       consumerdata.TraceData
+	}{
+		{
+			name:     "empty",
+			internal: data.TraceData{},
+			oc:       consumerdata.TraceData{SourceFormat: sourceFormat},
+		},
+
+		{
+			name: "no-spans",
+			internal: data.NewTraceData([]*data.ResourceSpans{
+				data.NewResourceSpans(&data.Resource{}, []*data.Span{}),
+			}),
+			oc: consumerdata.TraceData{
+				Node:         ocNode,
+				Resource:     &ocresource.Resource{},
+				Spans:        []*octrace.Span{},
+				SourceFormat: sourceFormat},
+		},
+
+		{
+			name: "one-spans",
+			internal: data.NewTraceData([]*data.ResourceSpans{
+				data.NewResourceSpans(resource, []*data.Span{span1}),
+			}),
+			oc: consumerdata.TraceData{
+				Node:         ocNode,
+				Resource:     ocResource,
+				Spans:        []*octrace.Span{ocSpan1},
+				SourceFormat: sourceFormat,
+			},
+		},
+
+		{
+			name: "two-spans",
+			internal: data.NewTraceData([]*data.ResourceSpans{
+				data.NewResourceSpans(&data.Resource{}, []*data.Span{span1, span2}),
+			}),
+			oc: consumerdata.TraceData{
+				Node:         ocNode,
+				Resource:     &ocresource.Resource{},
+				Spans:        []*octrace.Span{ocSpan1, ocSpan2},
+				SourceFormat: sourceFormat,
+			},
+		},
+
+		{
+			name: "two-spans-plus-one-separate",
+			internal: data.NewTraceData([]*data.ResourceSpans{
+				data.NewResourceSpans(resource, []*data.Span{span1, span2}),
+				resourceSpans3,
+			}),
+			oc: consumerdata.TraceData{
+				Node:         ocNode,
+				Resource:     ocResource,
+				Spans:        []*octrace.Span{ocSpan1, ocSpan2, ocSpan3},
+				SourceFormat: sourceFormat,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := internalToOC(test.internal)
+			assert.EqualValues(t, test.oc, got)
+		})
+	}
+}

--- a/translator/trace/otlp_to_oc.go
+++ b/translator/trace/otlp_to_oc.go
@@ -85,8 +85,8 @@ func spanToOC(span *otlptrace.Span) *octrace.Span {
 			Value: span.Name,
 		},
 		Kind:           kindToOC(span.Kind),
-		StartTime:      unixnanoToTimestamp(span.StartTimeUnixnano),
-		EndTime:        unixnanoToTimestamp(span.EndTimeUnixnano),
+		StartTime:      internal.UnixnanoToTimestamp(span.StartTimeUnixnano),
+		EndTime:        internal.UnixnanoToTimestamp(span.EndTimeUnixnano),
 		Attributes:     attributes,
 		TimeEvents:     eventsToOC(span.Events, span.DroppedEventsCount),
 		Links:          linksToOC(span.Links, span.DroppedLinksCount),
@@ -144,7 +144,7 @@ func eventsToOCEvents(events []*otlptrace.Span_Event) []*octrace.Span_TimeEvent 
 	for _, event := range events {
 		ocAttributes := attributesToOCSpanAttributes(event.Attributes, event.DroppedAttributesCount)
 		ocEvent := &octrace.Span_TimeEvent{
-			Time: unixnanoToTimestamp(event.TimeUnixnano),
+			Time: internal.UnixnanoToTimestamp(event.TimeUnixnano),
 			Value: &octrace.Span_TimeEvent_Annotation_{
 				Annotation: &octrace.Span_TimeEvent_Annotation{
 					Description: &octrace.TruncatableString{
@@ -401,8 +401,4 @@ func stringAttributeValue(val string) *octrace.AttributeValue {
 			},
 		},
 	}
-}
-
-func unixnanoToTimestamp(u uint64) *timestamp.Timestamp {
-	return internal.TimeToTimestamp(time.Unix(0, int64(u)))
 }

--- a/translator/trace/otlp_to_oc_test.go
+++ b/translator/trace/otlp_to_oc_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
+	"github.com/open-telemetry/opentelemetry-collector/internal"
 	"github.com/open-telemetry/opentelemetry-collector/translator/conventions"
 )
 
@@ -139,12 +140,12 @@ func TestResourceSpansToTraceData(t *testing.T) {
 		SpanId:    spanID,
 		Name:      &octrace.TruncatableString{Value: "operationB"},
 		Kind:      octrace.Span_SERVER,
-		StartTime: unixnanoToTimestamp(unixnanos),
-		EndTime:   unixnanoToTimestamp(unixnanos),
+		StartTime: internal.UnixnanoToTimestamp(unixnanos),
+		EndTime:   internal.UnixnanoToTimestamp(unixnanos),
 		TimeEvents: &octrace.Span_TimeEvents{
 			TimeEvent: []*octrace.Span_TimeEvent{
 				{
-					Time: unixnanoToTimestamp(unixnanos),
+					Time: internal.UnixnanoToTimestamp(unixnanos),
 					Value: &octrace.Span_TimeEvent_Annotation_{
 						Annotation: &octrace.Span_TimeEvent_Annotation{
 							Description: &octrace.TruncatableString{Value: "event1"},
@@ -193,8 +194,8 @@ func TestResourceSpansToTraceData(t *testing.T) {
 	ocSpan2 := &octrace.Span{
 		Name:      &octrace.TruncatableString{Value: "operationC"},
 		Kind:      octrace.Span_SPAN_KIND_UNSPECIFIED,
-		StartTime: unixnanoToTimestamp(unixnanos),
-		EndTime:   unixnanoToTimestamp(unixnanos),
+		StartTime: internal.UnixnanoToTimestamp(unixnanos),
+		EndTime:   internal.UnixnanoToTimestamp(unixnanos),
 		Attributes: &octrace.Span_Attributes{
 			AttributeMap: map[string]*octrace.AttributeValue{
 				TagSpanKind: {


### PR DESCRIPTION
This implements translation from internal data representation to OpenCensus format.

Needed as a temporary solution that allows new-styles receivers to send data to old-style processors.

**Testing:** Unit tests
