### PR TITLE
Rename Start() to Run() since it's a blocking call

### DIFF
--- a/cmd/otelcol/main.go
+++ b/cmd/otelcol/main.go
@@ -44,6 +44,6 @@ func main() {
 	svc, err := service.New(factories, info)
 	handleErr(err)
 
-	err = svc.Start()
+	err = svc.Run()
 	handleErr(err)
 }

--- a/service/service.go
+++ b/service/service.go
@@ -381,6 +381,14 @@ func (app *Application) Run() error {
 	return app.rootCmd.Execute()
 }
 
+// Start starts the collector according to the command and configuration
+// given by the user, and waits for it to complete.
+//
+// Deprecated: use Run instead.
+func (app *Application) Start() error {
+	return app.Run()
+}
+
 func (app *Application) createMemoryBallast() ([]byte, uint64) {
 	ballastSizeMiB := builder.MemBallastSize()
 	if ballastSizeMiB > 0 {

--- a/service/service.go
+++ b/service/service.go
@@ -375,9 +375,9 @@ func (app *Application) execute() {
 	app.logger.Info("Shutdown complete.")
 }
 
-// Start starts the collector according to the command and configuration
-// given by the user.
-func (app *Application) Start() error {
+// Run starts the collector according to the command and configuration
+// given by the user, and waits for it to complete.
+func (app *Application) Run() error {
 	return app.rootCmd.Execute()
 }
 

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -54,7 +54,7 @@ func TestApplication_Start(t *testing.T) {
 	appDone := make(chan struct{})
 	go func() {
 		defer close(appDone)
-		assert.NoError(t, app.Start())
+		assert.NoError(t, app.Run())
 	}()
 
 	<-app.readyChan


### PR DESCRIPTION
Rename **Start()** to **Run()** to follow the naming pattern used in Go, e.g. see blocking [Cmd.Run](https://golang.org/pkg/os/exec/#Cmd.Run) vs non-blocking [Cmd.Start](https://golang.org/pkg/os/exec/#Cmd.Start).

Same as #607 but keeping original method for backward compatibility. We can keep it for a few releases before deleting.