### PR TITLE
Delete observability.SetParentLink

### DIFF
--- a/observability/observability.go
+++ b/observability/observability.go
@@ -25,7 +25,6 @@ import (
 	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
-	"go.opencensus.io/trace"
 	"google.golang.org/grpc"
 )
 
@@ -177,22 +176,4 @@ func RecordMetricsForMetricsExporter(ctx context.Context, receivedTimeSeries int
 func GRPCServerWithObservabilityEnabled(extraOpts ...grpc.ServerOption) *grpc.Server {
 	opts := append(extraOpts, grpc.StatsHandler(&ocgrpc.ServerHandler{}))
 	return grpc.NewServer(opts...)
-}
-
-// SetParentLink tries to retrieve a span from sideCtx and if one exists
-// sets its SpanID, TraceID as a link in the span provided. It returns
-// true only if it retrieved a parent span from the context.
-func SetParentLink(sideCtx context.Context, span *trace.Span) bool {
-	parentSpanFromRPC := trace.FromContext(sideCtx)
-	if parentSpanFromRPC == nil {
-		return false
-	}
-
-	psc := parentSpanFromRPC.SpanContext()
-	span.AddLink(trace.Link{
-		SpanID:  psc.SpanID,
-		TraceID: psc.TraceID,
-		Type:    trace.LinkTypeParent,
-	})
-	return true
 }

--- a/receiver/opencensusreceiver/octrace/opencensus.go
+++ b/receiver/opencensusreceiver/octrace/opencensus.go
@@ -26,7 +26,6 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector/client"
 	"github.com/open-telemetry/opentelemetry-collector/consumer"
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
-	"github.com/open-telemetry/opentelemetry-collector/observability"
 	"github.com/open-telemetry/opentelemetry-collector/obsreport"
 	"github.com/open-telemetry/opentelemetry-collector/oterr"
 )
@@ -148,7 +147,7 @@ func (ocr *Receiver) sendToNextConsumer(longLivedRPCCtx context.Context, traceda
 		receiverTransport)
 
 	// If the starting RPC has a parent span, then add it as a parent link.
-	observability.SetParentLink(longLivedRPCCtx, span)
+	obsreport.SetParentLink(longLivedRPCCtx, span)
 
 	if c, ok := client.FromGRPC(longLivedRPCCtx); ok {
 		ctx = client.NewContext(ctx, c)


### PR DESCRIPTION
Follow-up to #578, cleaning up one missed change, and deleting unused method.

/cc @pjanotti