### PR TITLE
Support programmatic API for passing config to the service

### DIFF
--- a/cmd/otelcol/main.go
+++ b/cmd/otelcol/main.go
@@ -41,7 +41,7 @@ func main() {
 		GitHash:  version.GitHash,
 	}
 
-	svc, err := service.New(factories, info)
+	svc, err := service.New(service.Parameters{ApplicationStartInfo: info, Factories: factories})
 	handleErr("Failed to construct the application", err)
 
 	err = svc.Start()

--- a/config/config.go
+++ b/config/config.go
@@ -123,7 +123,6 @@ type Factories struct {
 func Load(
 	v *viper.Viper,
 	factories Factories,
-	logger *zap.Logger,
 ) (*configmodels.Config, error) {
 
 	var config configmodels.Config
@@ -180,12 +179,6 @@ func Load(
 		return nil, err
 	}
 	config.Service = service
-
-	// Config is loaded. Now validate it.
-
-	if err := validateConfig(&config, logger); err != nil {
-		return nil, err
-	}
 
 	return &config, nil
 }
@@ -579,7 +572,8 @@ func loadPipelines(v *viper.Viper) (configmodels.Pipelines, error) {
 	return pipelines, nil
 }
 
-func validateConfig(cfg *configmodels.Config, logger *zap.Logger) error {
+// ValidateConfig validates config.
+func ValidateConfig(cfg *configmodels.Config, logger *zap.Logger) error {
 	// This function performs basic validation of configuration. There may be more subtle
 	// invalid cases that we currently don't check for but which we may want to add in
 	// the future (e.g. disallowing receiving and exporting on the same endpoint).

--- a/config/test_helpers.go
+++ b/config/test_helpers.go
@@ -43,5 +43,13 @@ func LoadConfigFile(t *testing.T, fileName string, factories Factories) (*config
 	}
 
 	// Load the config from viper using the given factories.
-	return Load(v, factories, zap.NewNop())
+	cfg, err := Load(v, factories)
+	if err != nil {
+		return nil, err
+	}
+	err = ValidateConfig(cfg, zap.NewNop())
+	if err != nil {
+		return nil, err
+	}
+	return cfg, nil
 }

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -39,7 +39,7 @@ func TestApplication_Start(t *testing.T) {
 	factories, err := defaults.Components()
 	require.NoError(t, err)
 
-	app, err := New(factories, ApplicationStartInfo{})
+	app, err := New(Parameters{Factories: factories, ApplicationStartInfo: ApplicationStartInfo{}})
 	require.NoError(t, err)
 	assert.Equal(t, app.rootCmd, app.Command())
 


### PR DESCRIPTION

**Description:** <Describe what has changed. 

Support programmatic API for passing config to the service.

This is needed for Jaeger-opentelemetry collector:
* it starts the service with Jaeger components when the configuration file is missing
* it configures components based on the additional flags added to the service

Not polished example of this PR used in Jaeger https://github.com/jaegertracing/jaeger-opentelemetry-collector/pull/32

Jaeger adds additional flags to the service's command. These flags are used to create default configuration objects, therefore the `ConfigFactory` has to be executed after `cmd.Execute` to populate flag values to viper.

**Link to tracking Issue:** <Issue number if applicable>
Resolves #601

**Testing:** < Describe what testing was performed and which tests were added.>

**Documentation:** < Describe the documentation added.>