### PR TITLE
Add the rest of V2 factories and interfaces

### DIFF
--- a/consumer/consumer.go
+++ b/consumer/consumer.go
@@ -33,7 +33,7 @@ type MetricsConsumer interface {
 // MetricsConsumerV2 is the new metrics consumer interface that receives data.MetricData, processes it
 // as needed, and sends it to the next processing node if any or to the destination.
 type MetricsConsumerV2 interface {
-	ConsumeMetricsData(ctx context.Context, md data.MetricData) error
+	ConsumeMetricsV2(ctx context.Context, md data.MetricData) error
 }
 
 // BaseTraceConsumer defines a common interface for TraceConsumer and TraceConsumerV2.

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -42,3 +42,9 @@ type MetricsExporter interface {
 	consumer.MetricsConsumer
 	Exporter
 }
+
+// MetricsExporterV2 is a MetricsConsumerV2 that is also an Exporter.
+type MetricsExporterV2 interface {
+	consumer.MetricsConsumerV2
+	Exporter
+}

--- a/exporter/factory.go
+++ b/exporter/factory.go
@@ -15,6 +15,7 @@
 package exporter
 
 import (
+	"context"
 	"fmt"
 
 	"go.uber.org/zap"
@@ -32,7 +33,7 @@ type BaseFactory interface {
 	// configuration and should not cause side-effects that prevent the creation
 	// of multiple instances of the Exporter.
 	// The object returned by this method needs to pass the checks implemented by
-	// 'conifgcheck.ValidateConfig'. It is recommended to have such check in the
+	// 'configcheck.ValidateConfig'. It is recommended to have such check in the
 	// tests of any implementation of the Factory interface.
 	CreateDefaultConfig() configmodels.Exporter
 }
@@ -48,6 +49,13 @@ type Factory interface {
 	CreateMetricsExporter(logger *zap.Logger, cfg configmodels.Exporter) (MetricsExporter, error)
 }
 
+// CreationParams is passed to Create* functions in FactoryV2.
+type CreationParams struct {
+	// Logger that the factory can use during creation and can pass to the created
+	// component to be used later as well.
+	Logger *zap.Logger
+}
+
 // FactoryV2 can create TraceExporterV2 and MetricsExporterV2. This is the
 // new factory type that can create new style exporters.
 type FactoryV2 interface {
@@ -56,9 +64,12 @@ type FactoryV2 interface {
 	// CreateTraceReceiverV2 creates a trace receiver based on this config.
 	// If the receiver type does not support tracing or if the config is not valid
 	// error will be returned instead.
-	CreateTraceExporterV2(logger *zap.Logger, cfg configmodels.Exporter) (TraceExporterV2, error)
+	CreateTraceExporterV2(ctx context.Context, params CreationParams, cfg configmodels.Exporter) (TraceExporterV2, error)
 
-	// TODO: Add CreateMetricsExporterV2.
+	// CreateMetricsExporterV2 creates a metrics receiver based on this config.
+	// If the receiver type does not support metrics or if the config is not valid
+	// error will be returned instead.
+	CreateMetricsExporterV2(ctx context.Context, params CreationParams, cfg configmodels.Exporter) (MetricsExporterV2, error)
 }
 
 // Build takes a list of exporter factories and returns a map of type map[string]Factory

--- a/extension/factory.go
+++ b/extension/factory.go
@@ -32,7 +32,7 @@ type Factory interface {
 	// configuration and should not cause side-effects that prevent the creation
 	// of multiple instances of the Extension.
 	// The object returned by this method needs to pass the checks implemented by
-	// 'conifgcheck.ValidateConfig'. It is recommended to have such check in the
+	// 'configcheck.ValidateConfig'. It is recommended to have such check in the
 	// tests of any implementation of the Factory interface.
 	CreateDefaultConfig() configmodels.Extension
 

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -41,6 +41,18 @@ type MetricsProcessor interface {
 	Processor
 }
 
+// TraceProcessorV2 composes TraceConsumerV2 with some additional processor-specific functions.
+type TraceProcessorV2 interface {
+	consumer.TraceConsumerV2
+	Processor
+}
+
+// MetricsProcessorV2 composes MetricsConsumerV2 with some additional processor-specific functions.
+type MetricsProcessorV2 interface {
+	consumer.MetricsConsumerV2
+	Processor
+}
+
 type DualTypeProcessor interface {
 	consumer.TraceConsumer
 	consumer.MetricsConsumer

--- a/receiver/factory.go
+++ b/receiver/factory.go
@@ -76,6 +76,13 @@ type Factory interface {
 		consumer consumer.MetricsConsumer) (MetricsReceiver, error)
 }
 
+// CreationParams is passed to Create* functions in FactoryV2.
+type CreationParams struct {
+	// Logger that the factory can use during creation and can pass to the created
+	// component to be used later as well.
+	Logger *zap.Logger
+}
+
 // FactoryV2 can create TraceReceiverV2 and MetricsReceiverV2. This is the
 // new factory type that can create new style receivers.
 type FactoryV2 interface {
@@ -84,10 +91,14 @@ type FactoryV2 interface {
 	// CreateTraceReceiverV2 creates a trace receiver based on this config.
 	// If the receiver type does not support tracing or if the config is not valid
 	// error will be returned instead.
-	CreateTraceReceiverV2(ctx context.Context, logger *zap.Logger, cfg configmodels.Receiver,
+	CreateTraceReceiverV2(ctx context.Context, params CreationParams, cfg configmodels.Receiver,
 		nextConsumer consumer.TraceConsumerV2) (TraceReceiver, error)
 
-	// TODO: add CreateMetricsReceiverV2.
+	// CreateMetricsReceiverV2 creates a metrics receiver based on this config.
+	// If the receiver type does not support metrics or if the config is not valid
+	// error will be returned instead.
+	CreateMetricsReceiverV2(ctx context.Context, params CreationParams, cfg configmodels.Receiver,
+		nextConsumer consumer.MetricsConsumerV2) (MetricsReceiver, error)
 }
 
 // Build takes a list of receiver factories and returns a map of type map[string]Factory

--- a/service/builder/receivers_builder.go
+++ b/service/builder/receivers_builder.go
@@ -320,17 +320,18 @@ func createTraceReceiver(
 	nextConsumer consumer.BaseTraceConsumer,
 ) (receiver.TraceReceiver, error) {
 	if factoryV2, ok := factory.(receiver.FactoryV2); ok {
+		creationParams := receiver.CreationParams{Logger: logger}
 
 		// If both receiver and consumer are of the new type (can manipulate on internal data structure),
 		// use FactoryV2.CreateTraceReceiverV2.
 		if nextConsumerV2, ok := nextConsumer.(consumer.TraceConsumerV2); ok {
-			return factoryV2.CreateTraceReceiverV2(ctx, logger, cfg, nextConsumerV2)
+			return factoryV2.CreateTraceReceiverV2(ctx, creationParams, cfg, nextConsumerV2)
 		}
 
 		// If receiver is of the new type, but downstream consumer is of the old type,
 		// use internalToOCTraceConverter compatibility shim.
 		traceConverter := consumer.NewInternalToOCTraceConverter(nextConsumer.(consumer.TraceConsumer))
-		return factoryV2.CreateTraceReceiverV2(ctx, logger, cfg, traceConverter)
+		return factoryV2.CreateTraceReceiverV2(ctx, creationParams, cfg, traceConverter)
 	}
 
 	// If both receiver and consumer are of the old type (can manipulate on OC traces only),

--- a/service/builder/receivers_builder_test.go
+++ b/service/builder/receivers_builder_test.go
@@ -400,7 +400,7 @@ func (b *newStyleReceiverFactory) CustomUnmarshaler() receiver.CustomUnmarshaler
 
 func (b *newStyleReceiverFactory) CreateTraceReceiverV2(
 	ctx context.Context,
-	logger *zap.Logger,
+	params receiver.CreationParams,
 	cfg configmodels.Receiver,
 	nextConsumer consumer.TraceConsumerV2,
 ) (receiver.TraceReceiver, error) {
@@ -408,7 +408,8 @@ func (b *newStyleReceiverFactory) CreateTraceReceiverV2(
 }
 
 func (b *newStyleReceiverFactory) CreateMetricsReceiverV2(
-	logger *zap.Logger,
+	ctx context.Context,
+	params receiver.CreationParams,
 	cfg configmodels.Receiver,
 	consumer consumer.MetricsConsumerV2,
 ) (receiver.MetricsReceiver, error) {


### PR DESCRIPTION
- Added V2 metric factories and interfaces for receivers and exporters.
- Added V2 factories and interfaces for processors.

All changes are uniform with previously introduced initial batch of
V2 factories and interfaces.

Issue: https://github.com/open-telemetry/opentelemetry-collector/issues/478