### PR TITLE
Replace log.Fatal with returning errors to be handled by caller

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -146,6 +146,14 @@ explain the problem and exit with a non-zero code. It is acceptable to crash the
 during startup if there is no good way to exit cleanly but do your best to log and
 exit cleanly with a process exit code.
 
+### Propagate Errors to the Caller
+
+Do not crash or exit outside the `main()` function, e.g. via `log.Fatal` or `os.Exit`,
+even during startup. Instead, return detailed errors to be handled appropriately 
+by the caller. The code in packages other than `main` may be imported and used by
+third-party applications, and they should have full control over error handling 
+and process termination.
+
 ### Do not Crash after Startup
 
 Do not crash or exit the Collector process after the startup sequence is finished.

--- a/cmd/otelcol/main.go
+++ b/cmd/otelcol/main.go
@@ -25,14 +25,14 @@ import (
 )
 
 func main() {
-	handleErr := func(err error) {
+	handleErr := func(message string, err error) {
 		if err != nil {
-			log.Fatalf("Failed to run the service: %v", err)
+			log.Fatalf("%s: %v", message, err)
 		}
 	}
 
 	factories, err := defaults.Components()
-	handleErr(err)
+	handleErr("Failed to build default components", err)
 
 	info := service.ApplicationStartInfo{
 		ExeName:  "otelcol",
@@ -42,8 +42,8 @@ func main() {
 	}
 
 	svc, err := service.New(factories, info)
-	handleErr(err)
+	handleErr("Failed to construct the application", err)
 
 	err = svc.Start()
-	handleErr(err)
+	handleErr("Application run finished with error", err)
 }

--- a/service/builder/exporters_builder.go
+++ b/service/builder/exporters_builder.go
@@ -88,10 +88,19 @@ func (exps Exporters) StartAll(logger *zap.Logger, host component.Host) error {
 }
 
 // ShutdownAll stops all exporters.
-func (exps Exporters) ShutdownAll() {
+func (exps Exporters) ShutdownAll() error {
+	var errs []error
 	for _, exp := range exps {
-		exp.Shutdown()
+		err := exp.Shutdown()
+		if err != nil {
+			errs = append(errs, err)
+		}
 	}
+
+	if len(errs) != 0 {
+		return oterr.CombineErrors(errs)
+	}
+	return nil
 }
 
 type dataTypeRequirement struct {

--- a/service/builder/receivers_builder.go
+++ b/service/builder/receivers_builder.go
@@ -25,6 +25,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector/config/configerror"
 	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
 	"github.com/open-telemetry/opentelemetry-collector/consumer"
+	"github.com/open-telemetry/opentelemetry-collector/oterr"
 	"github.com/open-telemetry/opentelemetry-collector/processor"
 	"github.com/open-telemetry/opentelemetry-collector/receiver"
 )
@@ -51,10 +52,19 @@ func (rcv *builtReceiver) Start(host component.Host) error {
 type Receivers map[configmodels.Receiver]*builtReceiver
 
 // StopAll stops all receivers.
-func (rcvs Receivers) StopAll() {
+func (rcvs Receivers) StopAll() error {
+	var errs []error
 	for _, rcv := range rcvs {
-		rcv.Stop()
+		err := rcv.Stop()
+		if err != nil {
+			errs = append(errs, err)
+		}
 	}
+
+	if len(errs) != 0 {
+		return oterr.CombineErrors(errs)
+	}
+	return nil
 }
 
 // StartAll starts all receivers.

--- a/service/service.go
+++ b/service/service.go
@@ -18,9 +18,9 @@ package service
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
-	"log"
 	"os"
 	"os/signal"
 	"runtime"
@@ -112,9 +112,18 @@ func New(
 	rootCmd := &cobra.Command{
 		Use:  appInfo.ExeName,
 		Long: appInfo.LongName,
-		Run: func(cmd *cobra.Command, args []string) {
-			app.init()
-			app.execute()
+		RunE: func(cmd *cobra.Command, args []string) error {
+			err := app.init()
+			if err != nil {
+				return err
+			}
+
+			err = app.execute()
+			if err != nil {
+				return err
+			}
+
+			return nil
 		},
 	}
 
@@ -142,29 +151,35 @@ func (app *Application) ReportFatalError(err error) {
 	app.asyncErrorChannel <- err
 }
 
-func (app *Application) init() {
+func (app *Application) init() error {
 	file := builder.GetConfigFile()
 	if file == "" {
-		log.Fatalf("Config file not specified")
+		return errors.New("config file not specified")
 	}
 	app.v.SetConfigFile(file)
+
 	err := app.v.ReadInConfig()
 	if err != nil {
-		log.Fatalf("Error loading config file %q: %v", file, err)
+		return fmt.Errorf("error loading config file %q: %v", file, err)
 	}
+
 	app.logger, err = newLogger()
 	if err != nil {
-		log.Fatalf("Failed to get logger: %v", err)
+		return fmt.Errorf("failed to get logger: %v", err)
 	}
+
+	return nil
 }
 
-func (app *Application) setupTelemetry(ballastSizeBytes uint64) {
+func (app *Application) setupTelemetry(ballastSizeBytes uint64) error {
 	app.logger.Info("Setting up own telemetry...")
+
 	err := AppTelemetry.init(app.asyncErrorChannel, ballastSizeBytes, app.logger)
 	if err != nil {
-		app.logger.Error("Failed to initialize telemetry", zap.Error(err))
-		os.Exit(1)
+		return fmt.Errorf("failed to initialize telemetry: %v", err)
 	}
+
+	return nil
 }
 
 // runAndWaitForShutdownEvent waits for one of the shutdown events that can happen.
@@ -190,23 +205,29 @@ func (app *Application) runAndWaitForShutdownEvent() {
 	}
 }
 
-func (app *Application) setupConfigurationComponents() {
+func (app *Application) setupConfigurationComponents() error {
 	// Load configuration.
 	app.logger.Info("Loading configuration...")
 	cfg, err := config.Load(app.v, app.factories, app.logger)
 	if err != nil {
-		log.Fatalf("Cannot load configuration: %v", err)
+		return fmt.Errorf("cannot load configuration: %v", err)
 	}
 
 	app.config = cfg
 
 	app.logger.Info("Applying configuration...")
 
-	if err := app.setupExtensions(); err != nil {
-		log.Fatalf("Cannot setup extensions: %v", err)
+	err = app.setupExtensions()
+	if err != nil {
+		return fmt.Errorf("cannot setup extensions: %v", err)
 	}
 
-	app.setupPipelines()
+	err = app.setupPipelines()
+	if err != nil {
+		return fmt.Errorf("cannot setup pipelines: %v", err)
+	}
+
+	return nil
 }
 
 func (app *Application) setupExtensions() error {
@@ -241,7 +262,7 @@ func (app *Application) setupExtensions() error {
 	return nil
 }
 
-func (app *Application) setupPipelines() {
+func (app *Application) setupPipelines() error {
 	// Pipeline is built backwards, starting from exporters, so that we create objects
 	// which are referenced before objects which reference them.
 
@@ -249,52 +270,56 @@ func (app *Application) setupPipelines() {
 	var err error
 	app.exporters, err = builder.NewExportersBuilder(app.logger, app.config, app.factories.Exporters).Build()
 	if err != nil {
-		log.Fatalf("Cannot build exporters: %v", err)
+		return fmt.Errorf("cannot build exporters: %v", err)
 	}
 	app.logger.Info("Starting exporters...")
 	err = app.exporters.StartAll(app.logger, app)
 	if err != nil {
-		log.Fatalf("Cannot start exporters: %v", err)
+		return fmt.Errorf("cannot start exporters: %v", err)
 	}
 
 	// Create pipelines and their processors and plug exporters to the
 	// end of the pipelines.
 	app.builtPipelines, err = builder.NewPipelinesBuilder(app.logger, app.config, app.exporters, app.factories.Processors).Build()
 	if err != nil {
-		log.Fatalf("Cannot build pipelines: %v", err)
+		return fmt.Errorf("cannot build pipelines: %v", err)
 	}
 
 	app.logger.Info("Starting processors...")
 	err = app.builtPipelines.StartProcessors(app.logger, app)
 	if err != nil {
-		log.Fatalf("Cannot start processors: %v", err)
+		return fmt.Errorf("cannot start processors: %v", err)
 	}
 
 	// Create receivers and plug them into the start of the pipelines.
 	app.builtReceivers, err = builder.NewReceiversBuilder(app.logger, app.config, app.builtPipelines, app.factories.Receivers).Build()
 	if err != nil {
-		log.Fatalf("Cannot build receivers: %v", err)
+		return fmt.Errorf("annot build receivers: %v", err)
 	}
 
 	app.logger.Info("Starting receivers...")
 	err = app.builtReceivers.StartAll(app.logger, app)
 	if err != nil {
-		log.Fatalf("Cannot start receivers: %v", err)
+		return fmt.Errorf("cannot start receivers: %v", err)
 	}
+
+	return nil
 }
 
-func (app *Application) notifyPipelineReady() {
+func (app *Application) notifyPipelineReady() error {
 	for i, ext := range app.extensions {
 		if pw, ok := ext.(extension.PipelineWatcher); ok {
 			if err := pw.Ready(); err != nil {
-				log.Fatalf(
-					"Error notifying extension %q that the pipeline was started: %v",
+				return fmt.Errorf(
+					"error notifying extension %q that the pipeline was started: %v",
 					app.config.Service.Extensions[i],
 					err,
 				)
 			}
 		}
 	}
+
+	return nil
 }
 
 func (app *Application) notifyPipelineNotReady() {
@@ -313,7 +338,7 @@ func (app *Application) notifyPipelineNotReady() {
 	}
 }
 
-func (app *Application) shutdownPipelines() {
+func (app *Application) shutdownPipelines() error {
 	// Shutdown order is the reverse of building: first receivers, then flushing pipelines
 	// giving senders a chance to send all their data. This may take time, the allowed
 	// time should be part of configuration.
@@ -322,10 +347,15 @@ func (app *Application) shutdownPipelines() {
 	app.builtReceivers.StopAll()
 
 	app.logger.Info("Stopping processors...")
-	app.builtPipelines.ShutdownProcessors(app.logger)
+	err := app.builtPipelines.ShutdownProcessors(app.logger)
+	if err != nil {
+		return fmt.Errorf("failed to shutdown processors: %v", err)
+	}
 
 	app.logger.Info("Shutting down exporters...")
 	app.exporters.ShutdownAll()
+
+	return nil
 }
 
 func (app *Application) shutdownExtensions() {
@@ -342,7 +372,7 @@ func (app *Application) shutdownExtensions() {
 	}
 }
 
-func (app *Application) execute() {
+func (app *Application) execute() error {
 	app.logger.Info("Starting "+app.info.LongName+"...",
 		zap.String("Version", app.info.Version),
 		zap.String("GitHash", app.info.GitHash),
@@ -355,9 +385,20 @@ func (app *Application) execute() {
 	app.asyncErrorChannel = make(chan error)
 
 	// Setup everything.
-	app.setupTelemetry(ballastSizeBytes)
-	app.setupConfigurationComponents()
-	app.notifyPipelineReady()
+	err := app.setupTelemetry(ballastSizeBytes)
+	if err != nil {
+		return err
+	}
+
+	err = app.setupConfigurationComponents()
+	if err != nil {
+		return err
+	}
+
+	err = app.notifyPipelineReady()
+	if err != nil {
+		return err
+	}
 
 	// Everything is ready, now run until an event requiring shutdown happens.
 	app.runAndWaitForShutdownEvent()
@@ -367,12 +408,18 @@ func (app *Application) execute() {
 	app.logger.Info("Starting shutdown...")
 
 	app.notifyPipelineNotReady()
-	app.shutdownPipelines()
+
+	err = app.shutdownPipelines()
+	if err != nil {
+		return err
+	}
+
 	app.shutdownExtensions()
 
 	AppTelemetry.shutdown()
 
 	app.logger.Info("Shutdown complete.")
+	return nil
 }
 
 // Start starts the collector according to the command and configuration

--- a/service/telemetry.go
+++ b/service/telemetry.go
@@ -16,11 +16,11 @@ package service
 
 import (
 	"flag"
-	"fmt"
 	"net/http"
 	"strconv"
 
 	"contrib.go.opencensus.io/exporter/prometheus"
+	"github.com/pkg/errors"
 	"go.opencensus.io/stats/view"
 	"go.uber.org/zap"
 
@@ -89,7 +89,7 @@ func telemetryFlags(flags *flag.FlagSet) {
 func (tel *appTelemetry) init(asyncErrorChannel chan<- error, ballastSizeBytes uint64, logger *zap.Logger) error {
 	level, err := telemetry.ParseLevel(*metricsLevelPtr)
 	if err != nil {
-		return fmt.Errorf("failed to parse metrics level: %v", err)
+		return errors.Wrap(err, "failed to parse metrics level")
 	}
 
 	if level == telemetry.None {

--- a/service/telemetry.go
+++ b/service/telemetry.go
@@ -16,7 +16,7 @@ package service
 
 import (
 	"flag"
-	"log"
+	"fmt"
 	"net/http"
 	"strconv"
 
@@ -89,7 +89,7 @@ func telemetryFlags(flags *flag.FlagSet) {
 func (tel *appTelemetry) init(asyncErrorChannel chan<- error, ballastSizeBytes uint64, logger *zap.Logger) error {
 	level, err := telemetry.ParseLevel(*metricsLevelPtr)
 	if err != nil {
-		log.Fatalf("Failed to parse metrics level: %v", err)
+		return fmt.Errorf("failed to parse metrics level: %v", err)
 	}
 
 	if level == telemetry.None {


### PR DESCRIPTION
**Description:** 
Fixes #619 - Replacing usages of `log.Fatal` with returning errors in `Application`, to be handled by the caller of `Application.Start()`.

**Link to tracking Issue:** #619

**Testing:** No tests failing

**Documentation:** Updated `CONTRIBUTING.md` to document the rules for process termination.