### PR TITLE
Improve obsreport receiver operations under long lived contexts

### DIFF
--- a/obsreport/obsreport.go
+++ b/obsreport/obsreport.go
@@ -38,8 +38,8 @@ var (
 	okStatus = trace.Status{Code: trace.StatusCodeOK}
 )
 
-// SetParentLink tries to retrieve a span from parentCtx and if one exists
-// sets its SpanID, TraceID as a link to the Span from the provided context.
+// setParentLink tries to retrieve a span from parentCtx and if one exists
+// sets its SpanID, TraceID as a link to the given Span.
 // It returns true only if it retrieved a parent span from the context.
 //
 // This is typically used when the parentCtx may already have a trace and is
@@ -47,14 +47,13 @@ var (
 // traces for individual operations under the long lived trace associated to
 // the parentCtx. This function is a helper that encapsulates the work of
 // linking the short lived trace/span to the longer one.
-func SetParentLink(ctx, parentCtx context.Context) bool {
+func setParentLink(parentCtx context.Context, span *trace.Span) bool {
 	parentSpanFromRPC := trace.FromContext(parentCtx)
 	if parentSpanFromRPC == nil {
 		return false
 	}
 
 	psc := parentSpanFromRPC.SpanContext()
-	span := trace.FromContext(ctx)
 	span.AddLink(trace.Link{
 		SpanID:  psc.SpanID,
 		TraceID: psc.TraceID,

--- a/obsreport/obsreport.go
+++ b/obsreport/obsreport.go
@@ -36,9 +36,6 @@ var (
 	useNew    = true
 
 	okStatus = trace.Status{Code: trace.StatusCodeOK}
-
-	// useAlwaysSample is used in tests to force spans to be sampled.
-	useAlwaysSample bool
 )
 
 // setParentLink tries to retrieve a span from parentCtx and if one exists

--- a/obsreport/obsreport.go
+++ b/obsreport/obsreport.go
@@ -36,6 +36,9 @@ var (
 	useNew    = true
 
 	okStatus = trace.Status{Code: trace.StatusCodeOK}
+
+	// useAlwaysSample is used in tests to force spans to be sampled.
+	useAlwaysSample bool
 )
 
 // setParentLink tries to retrieve a span from parentCtx and if one exists

--- a/obsreport/obsreport.go
+++ b/obsreport/obsreport.go
@@ -39,7 +39,7 @@ var (
 )
 
 // setParentLink tries to retrieve a span from parentCtx and if one exists
-// sets its SpanID, TraceID as a link to the given Span.
+// sets its SpanID, TraceID as a link to the given child Span.
 // It returns true only if it retrieved a parent span from the context.
 //
 // This is typically used when the parentCtx may already have a trace and is
@@ -47,14 +47,14 @@ var (
 // traces for individual operations under the long lived trace associated to
 // the parentCtx. This function is a helper that encapsulates the work of
 // linking the short lived trace/span to the longer one.
-func setParentLink(parentCtx context.Context, span *trace.Span) bool {
+func setParentLink(parentCtx context.Context, childSpan *trace.Span) bool {
 	parentSpanFromRPC := trace.FromContext(parentCtx)
 	if parentSpanFromRPC == nil {
 		return false
 	}
 
 	psc := parentSpanFromRPC.SpanContext()
-	span.AddLink(trace.Link{
+	childSpan.AddLink(trace.Link{
 		SpanID:  psc.SpanID,
 		TraceID: psc.TraceID,
 		Type:    trace.LinkTypeParent,

--- a/obsreport/obsreport_receiver.go
+++ b/obsreport/obsreport_receiver.go
@@ -88,7 +88,7 @@ type StartReceiveOption func(*StartReceiveOptions)
 // Example:
 //
 //    func (r *receiver) ClientConnect(ctx context.Context, rcvChan <-chan consumerdata.TraceData) {
-//        longLivedCtx := ctx
+//        longLivedCtx := obsreport.ReceiverContext(ctx, r.config.Name(), r.transport, "")
 //        for {
 //            // Since the context outlives the individual receive operations call obsreport using
 //            // WithLongLivedCtx().

--- a/obsreport/obsreport_receiver.go
+++ b/obsreport/obsreport_receiver.go
@@ -219,23 +219,16 @@ func traceReceiveOp(
 		o(&opts)
 	}
 
-	var sampleOption []trace.StartOption
-	if useAlwaysSample {
-		sampleOption = []trace.StartOption{
-			trace.WithSampler(trace.AlwaysSample()),
-		}
-	}
-
 	var ctx context.Context
 	var span *trace.Span
 	spanName := receiverPrefix + receiverName + operationSuffix
 	if !opts.LongLivedCtx {
-		ctx, span = trace.StartSpan(receiverCtx, spanName, sampleOption...)
+		ctx, span = trace.StartSpan(receiverCtx, spanName)
 	} else {
 		// Since the receiverCtx is long lived do not use it to start the span.
 		// This way this trace ends when the EndTraceDataReceiveOp is called.
 		// Here is safe to ignore the returned context since it is not used below.
-		_, span = trace.StartSpan(context.Background(), spanName, sampleOption...)
+		_, span = trace.StartSpan(context.Background(), spanName)
 
 		// If the long lived context has a parent span, then add it as a parent link.
 		setParentLink(receiverCtx, span)

--- a/obsreport/obsreport_test.go
+++ b/obsreport/obsreport_test.go
@@ -353,13 +353,16 @@ func Test_obsreport_ReceiveWithLongLivedCtx(t *testing.T) {
 	trace.RegisterExporter(ss)
 	defer trace.UnregisterExporter(ss)
 
-	useAlwaysSample = true
+	trace.ApplyConfig(trace.Config{
+		DefaultSampler: trace.AlwaysSample(),
+	})
 	defer func() {
-		useAlwaysSample = false
+		trace.ApplyConfig(trace.Config{
+			DefaultSampler: trace.ProbabilitySampler(1e-4),
+		})
 	}()
 
-	parentCtx, parentSpan := trace.StartSpan(context.Background(),
-		t.Name(), trace.WithSampler(trace.AlwaysSample()))
+	parentCtx, parentSpan := trace.StartSpan(context.Background(), t.Name())
 	defer parentSpan.End()
 
 	longLivedCtx := ReceiverContext(parentCtx, receiver, transport, legacyName)

--- a/receiver/opencensusreceiver/ocmetrics/opencensus.go
+++ b/receiver/opencensusreceiver/ocmetrics/opencensus.go
@@ -111,14 +111,11 @@ func (ocr *Receiver) processReceivedMetrics(longLivedRPCCtx context.Context, ni 
 }
 
 func (ocr *Receiver) sendToNextConsumer(longLivedRPCCtx context.Context, md consumerdata.MetricsData) {
-	// Pass longLivedRPCCtx as an option and use a new context to start the
-	// observability of the operation so any tracing end right at this function,
-	// and the span is not a child of any span from the stream context.
 	ctx := obsreport.StartMetricsReceiveOp(
-		context.Background(),
+		longLivedRPCCtx,
 		ocr.instanceName,
 		receiverTransport,
-		obsreport.WithLongLivedCtx(longLivedRPCCtx))
+		obsreport.WithLongLivedCtx())
 
 	numTimeSeries := 0
 	numPoints := 0

--- a/receiver/opencensusreceiver/ocmetrics/opencensus.go
+++ b/receiver/opencensusreceiver/ocmetrics/opencensus.go
@@ -23,7 +23,6 @@ import (
 	agentmetricspb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/metrics/v1"
 	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
 	resourcepb "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
-	"go.opencensus.io/trace"
 
 	"github.com/open-telemetry/opentelemetry-collector/consumer"
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
@@ -112,19 +111,14 @@ func (ocr *Receiver) processReceivedMetrics(longLivedRPCCtx context.Context, ni 
 }
 
 func (ocr *Receiver) sendToNextConsumer(longLivedRPCCtx context.Context, md consumerdata.MetricsData) {
-	// Do not use longLivedRPCCtx to start the span so this trace ends right at this
-	// function, and the span is not a child of any span from the stream context.
-	tmpCtx := obsreport.StartMetricsReceiveOp(
+	// Pass longLivedRPCCtx as an option and use a new context to start the
+	// observability of the operation so any tracing end right at this function,
+	// and the span is not a child of any span from the stream context.
+	ctx := obsreport.StartMetricsReceiveOp(
 		context.Background(),
 		ocr.instanceName,
-		receiverTransport)
-
-	// If the starting RPC has a parent span, then add it as a parent link.
-	obsreport.SetParentLink(tmpCtx, longLivedRPCCtx)
-
-	// TODO: We should offer a version of StartTraceDataReceiveOp that starts the Span
-	// with as root, and links to the longLived context.
-	ctx := trace.NewContext(longLivedRPCCtx, trace.FromContext(tmpCtx))
+		receiverTransport,
+		obsreport.WithLongLivedCtx(longLivedRPCCtx))
 
 	numTimeSeries := 0
 	numPoints := 0

--- a/receiver/opencensusreceiver/octrace/opencensus.go
+++ b/receiver/opencensusreceiver/octrace/opencensus.go
@@ -22,7 +22,6 @@ import (
 	commonpb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
 	agenttracepb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/trace/v1"
 	resourcepb "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
-	"go.opencensus.io/trace"
 
 	"github.com/open-telemetry/opentelemetry-collector/client"
 	"github.com/open-telemetry/opentelemetry-collector/consumer"
@@ -140,19 +139,14 @@ func (ocr *Receiver) processReceivedMsg(
 }
 
 func (ocr *Receiver) sendToNextConsumer(longLivedRPCCtx context.Context, tracedata *consumerdata.TraceData) error {
-	// Do not use longLivedRPCCtx to start the span so this trace ends right at this
-	// function, and the span is not a child of any span from the stream context.
-	tmpCtx := obsreport.StartTraceDataReceiveOp(
+	// Pass longLivedRPCCtx as an option and use a new context to start the
+	// observability of the operation so any tracing end right at this function,
+	// and the span is not a child of any span from the stream context.
+	ctx := obsreport.StartTraceDataReceiveOp(
 		context.Background(),
 		ocr.instanceName,
-		receiverTransport)
-
-	// If the starting RPC has a parent span, then add it as a parent link.
-	obsreport.SetParentLink(tmpCtx, longLivedRPCCtx)
-
-	// TODO: We should offer a version of StartTraceDataReceiveOp that starts the Span
-	// with as root, and links to the longLived context.
-	ctx := trace.NewContext(longLivedRPCCtx, trace.FromContext(tmpCtx))
+		receiverTransport,
+		obsreport.WithLongLivedCtx(longLivedRPCCtx))
 
 	if c, ok := client.FromGRPC(ctx); ok {
 		ctx = client.NewContext(ctx, c)

--- a/receiver/opencensusreceiver/octrace/opencensus.go
+++ b/receiver/opencensusreceiver/octrace/opencensus.go
@@ -139,14 +139,11 @@ func (ocr *Receiver) processReceivedMsg(
 }
 
 func (ocr *Receiver) sendToNextConsumer(longLivedRPCCtx context.Context, tracedata *consumerdata.TraceData) error {
-	// Pass longLivedRPCCtx as an option and use a new context to start the
-	// observability of the operation so any tracing end right at this function,
-	// and the span is not a child of any span from the stream context.
 	ctx := obsreport.StartTraceDataReceiveOp(
-		context.Background(),
+		longLivedRPCCtx,
 		ocr.instanceName,
 		receiverTransport,
-		obsreport.WithLongLivedCtx(longLivedRPCCtx))
+		obsreport.WithLongLivedCtx())
 
 	if c, ok := client.FromGRPC(ctx); ok {
 		ctx = client.NewContext(ctx, c)


### PR DESCRIPTION
**Description:** Makes the handling of receive operations under long-lived contexts more straightforward for obsreport package users. See https://github.com/open-telemetry/opentelemetry-collector/pull/625/files/eab570775ccc5de671c7b60946a12541c4d72b27#r391766521

**Link to tracking Issue:** Related to #141 

**Testing:** Added a new test to exercise the new code.

**Documentation:** Added to public members of the package.