### PR TITLE
Rename import package in data/common.go

### DIFF
--- a/internal/data/common.go
+++ b/internal/data/common.go
@@ -18,7 +18,7 @@ package data
 // such as timestamps, attributes, etc.
 
 import (
-	otlp "github.com/open-telemetry/opentelemetry-proto/gen/go/common/v1"
+	otlpcommon "github.com/open-telemetry/opentelemetry-proto/gen/go/common/v1"
 )
 
 // TimestampUnixNano is a time specified as UNIX Epoch time in nanoseconds since
@@ -30,10 +30,10 @@ type TimestampUnixNano uint64
 type AttributeValueType int32
 
 const (
-	AttributeValueSTRING AttributeValueType = AttributeValueType(otlp.AttributeKeyValue_STRING)
-	AttributeValueINT    AttributeValueType = AttributeValueType(otlp.AttributeKeyValue_INT)
-	AttributeValueDOUBLE AttributeValueType = AttributeValueType(otlp.AttributeKeyValue_DOUBLE)
-	AttributeValueBOOL   AttributeValueType = AttributeValueType(otlp.AttributeKeyValue_BOOL)
+	AttributeValueSTRING AttributeValueType = AttributeValueType(otlpcommon.AttributeKeyValue_STRING)
+	AttributeValueINT    AttributeValueType = AttributeValueType(otlpcommon.AttributeKeyValue_INT)
+	AttributeValueDOUBLE AttributeValueType = AttributeValueType(otlpcommon.AttributeKeyValue_DOUBLE)
+	AttributeValueBOOL   AttributeValueType = AttributeValueType(otlpcommon.AttributeKeyValue_BOOL)
 )
 
 // AttributeValue represents a value of an attribute. Typically used in an Attributes map.
@@ -51,30 +51,30 @@ const (
 //      _ := v.GetType() // this will return AttributeValueINT
 //   }
 type AttributeValue struct {
-	orig *otlp.AttributeKeyValue
+	orig *otlpcommon.AttributeKeyValue
 }
 
 func NewAttributeValueString(v string) AttributeValue {
-	return AttributeValue{orig: &otlp.AttributeKeyValue{Type: otlp.AttributeKeyValue_STRING, StringValue: v}}
+	return AttributeValue{orig: &otlpcommon.AttributeKeyValue{Type: otlpcommon.AttributeKeyValue_STRING, StringValue: v}}
 }
 
 func NewAttributeValueInt(v int64) AttributeValue {
-	return AttributeValue{orig: &otlp.AttributeKeyValue{Type: otlp.AttributeKeyValue_INT, IntValue: v}}
+	return AttributeValue{orig: &otlpcommon.AttributeKeyValue{Type: otlpcommon.AttributeKeyValue_INT, IntValue: v}}
 }
 
 func NewAttributeValueDouble(v float64) AttributeValue {
-	return AttributeValue{orig: &otlp.AttributeKeyValue{Type: otlp.AttributeKeyValue_DOUBLE, DoubleValue: v}}
+	return AttributeValue{orig: &otlpcommon.AttributeKeyValue{Type: otlpcommon.AttributeKeyValue_DOUBLE, DoubleValue: v}}
 }
 
 func NewAttributeValueBool(v bool) AttributeValue {
-	return AttributeValue{orig: &otlp.AttributeKeyValue{Type: otlp.AttributeKeyValue_BOOL, BoolValue: v}}
+	return AttributeValue{orig: &otlpcommon.AttributeKeyValue{Type: otlpcommon.AttributeKeyValue_BOOL, BoolValue: v}}
 }
 
 // NewAttributeValueSlice creates a slice of attributes values that are correctly initialized.
 func NewAttributeValueSlice(len int) []AttributeValue {
 	// Allocate 2 slices, one for AttributeValues, another for underlying OTLP structs.
 	// TODO: make one allocation for both slices.
-	origs := make([]otlp.AttributeKeyValue, len)
+	origs := make([]otlpcommon.AttributeKeyValue, len)
 	wrappers := make([]AttributeValue, len)
 	for i := range origs {
 		wrappers[i].orig = &origs[i]
@@ -107,22 +107,22 @@ func (a AttributeValue) BoolVal() bool {
 }
 
 func (a AttributeValue) SetString(v string) {
-	a.orig.Type = otlp.AttributeKeyValue_STRING
+	a.orig.Type = otlpcommon.AttributeKeyValue_STRING
 	a.orig.StringValue = v
 }
 
 func (a AttributeValue) SetInt(v int64) {
-	a.orig.Type = otlp.AttributeKeyValue_INT
+	a.orig.Type = otlpcommon.AttributeKeyValue_INT
 	a.orig.IntValue = v
 }
 
 func (a AttributeValue) SetDouble(v float64) {
-	a.orig.Type = otlp.AttributeKeyValue_DOUBLE
+	a.orig.Type = otlpcommon.AttributeKeyValue_DOUBLE
 	a.orig.DoubleValue = v
 }
 
 func (a AttributeValue) SetBool(v bool) {
-	a.orig.Type = otlp.AttributeKeyValue_BOOL
+	a.orig.Type = otlpcommon.AttributeKeyValue_BOOL
 	a.orig.BoolValue = v
 }
 


### PR DESCRIPTION
This is to be consistent with other package names we use in data.

Split from https://github.com/open-telemetry/opentelemetry-collector/pull/630 to reduce size of that PR with unrelated changes.