### PR TITLE
Add compatibility shim between internal and OC traces

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -107,7 +107,7 @@ const typeAndNameSeparator = "/"
 // can be handled by the Config.
 type Factories struct {
 	// Receivers maps receiver type names in the config to the respective factory.
-	Receivers map[string]receiver.Factory
+	Receivers map[string]receiver.BaseFactory
 
 	// Processors maps processor type names in the config to the respective factory.
 	Processors map[string]processor.Factory
@@ -314,7 +314,7 @@ func loadService(v *viper.Viper) (configmodels.Service, error) {
 	return service, nil
 }
 
-func loadReceivers(v *viper.Viper, factories map[string]receiver.Factory) (configmodels.Receivers, error) {
+func loadReceivers(v *viper.Viper, factories map[string]receiver.BaseFactory) (configmodels.Receivers, error) {
 	// Get the list of all "receivers" sub vipers from config source.
 	subViper := v.Sub(receiversKeyName)
 

--- a/consumer/consumer.go
+++ b/consumer/consumer.go
@@ -30,17 +30,28 @@ type MetricsConsumer interface {
 	ConsumeMetricsData(ctx context.Context, md consumerdata.MetricsData) error
 }
 
+// MetricsConsumerV2 is the new metrics consumer interface that receives data.MetricData, processes it
+// as needed, and sends it to the next processing node if any or to the destination.
+type MetricsConsumerV2 interface {
+	ConsumeMetricsData(ctx context.Context, md data.MetricData) error
+}
+
+// BaseTraceConsumer defines a common interface for TraceConsumer and TraceConsumerV2.
+type BaseTraceConsumer interface{}
+
 // TraceConsumer is an interface that receives consumerdata.TraceData, process it as needed, and
 // sends it to the next processing node if any or to the destination.
 //
 // ConsumeTraceData receives consumerdata.TraceData for processing by the TraceConsumer.
 type TraceConsumer interface {
+	BaseTraceConsumer
 	ConsumeTraceData(ctx context.Context, td consumerdata.TraceData) error
 }
 
 // TraceConsumerV2 is an interface that receives data.TraceData, processes it
 // as needed, and sends it to the next processing node if any or to the destination.
 type TraceConsumerV2 interface {
+	BaseTraceConsumer
 	// ConsumeTraceV2 receives data.TraceData for processing.
 	ConsumeTraceV2(ctx context.Context, td data.TraceData) error
 }

--- a/consumer/converter.go
+++ b/consumer/converter.go
@@ -1,0 +1,50 @@
+// Copyright 2019, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package consumer contains interfaces that receive and process consumerdata.
+package consumer
+
+import (
+	"context"
+
+	"github.com/open-telemetry/opentelemetry-collector/internal/data"
+	"github.com/open-telemetry/opentelemetry-collector/translator/internaldata"
+)
+
+// NewInternalToOCTraceConverter creates new internalToOCTraceConverter that takes TraceConsumer and
+// implements ConsumeTraceV2 interface.
+func NewInternalToOCTraceConverter(tc TraceConsumer) TraceConsumerV2 {
+	return &internalToOCTraceConverter{tc}
+}
+
+// internalToOCTraceConverter is a internal to oc translation shim that takes TraceConsumer and
+// implements ConsumeTraceV2 interface.
+type internalToOCTraceConverter struct {
+	traceConsumer TraceConsumer
+}
+
+// ConsumeTraceV2 takes new-style data.TraceData method, converts it to OC and uses old-style ConsumeTraceData method
+// to process the trace data.
+func (tc *internalToOCTraceConverter) ConsumeTraceV2(ctx context.Context, td data.TraceData) error {
+	ocTraces := internaldata.InternalToOC(td)
+	for i := range ocTraces {
+		err := tc.traceConsumer.ConsumeTraceData(ctx, ocTraces[i])
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+var _ TraceConsumerV2 = (*internalToOCTraceConverter)(nil)

--- a/defaults/defaults_test.go
+++ b/defaults/defaults_test.go
@@ -56,7 +56,7 @@ func TestDefaultComponents(t *testing.T) {
 		"pprof":        &pprofextension.Factory{},
 		"zpages":       &zpagesextension.Factory{},
 	}
-	expectedReceivers := map[string]receiver.Factory{
+	expectedReceivers := map[string]receiver.BaseFactory{
 		"jaeger":     &jaegerreceiver.Factory{},
 		"zipkin":     &zipkinreceiver.Factory{},
 		"prometheus": &prometheusreceiver.Factory{},

--- a/receiver/factory.go
+++ b/receiver/factory.go
@@ -93,8 +93,8 @@ type FactoryV2 interface {
 // Build takes a list of receiver factories and returns a map of type map[string]Factory
 // with factory type as keys. It returns a non-nil error when more than one factories
 // have the same type.
-func Build(factories ...Factory) (map[string]Factory, error) {
-	fMap := map[string]Factory{}
+func Build(factories ...BaseFactory) (map[string]BaseFactory, error) {
+	fMap := map[string]BaseFactory{}
 	for _, f := range factories {
 		if _, ok := fMap[f.Type()]; ok {
 			return fMap, fmt.Errorf("duplicate receiver factory %q", f.Type())

--- a/receiver/factory_test.go
+++ b/receiver/factory_test.go
@@ -67,25 +67,25 @@ func (f *TestFactory) CreateMetricsReceiver(
 
 func TestFactoriesBuilder(t *testing.T) {
 	type testCase struct {
-		in  []Factory
-		out map[string]Factory
+		in  []BaseFactory
+		out map[string]BaseFactory
 		err bool
 	}
 
 	testCases := []testCase{
 		{
-			in: []Factory{
+			in: []BaseFactory{
 				&TestFactory{"e1"},
 				&TestFactory{"e2"},
 			},
-			out: map[string]Factory{
+			out: map[string]BaseFactory{
 				"e1": &TestFactory{"e1"},
 				"e2": &TestFactory{"e2"},
 			},
 			err: false,
 		},
 		{
-			in: []Factory{
+			in: []BaseFactory{
 				&TestFactory{"e1"},
 				&TestFactory{"e1"},
 			},

--- a/service/builder/testdata/new_style_receiver_factory.yaml
+++ b/service/builder/testdata/new_style_receiver_factory.yaml
@@ -1,0 +1,13 @@
+receivers:
+  newstylereceiver:
+processors:
+  nop:
+exporters:
+  exampleexporter:
+
+service:
+  pipelines:
+    traces:
+      receivers: [newstylereceiver]
+      processors: [nop] # trace pipeline requires a processor
+      exporters: [exampleexporter]

--- a/translator/internaldata/internal_to_oc.go
+++ b/translator/internaldata/internal_to_oc.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package internal
+package internaldata
 
 import (
 	"fmt"
@@ -39,7 +39,7 @@ var (
 	emptyStatus      = data.SpanStatus{}
 )
 
-func internalToOC(td data.TraceData) []consumerdata.TraceData {
+func InternalToOC(td data.TraceData) []consumerdata.TraceData {
 	ocTraceData := consumerdata.TraceData{
 		SourceFormat: sourceFormat,
 	}

--- a/translator/internaldata/internal_to_oc_test.go
+++ b/translator/internaldata/internal_to_oc_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package internal
+package internaldata
 
 import (
 	"testing"
@@ -390,7 +390,7 @@ func TestInternalToOC(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got := internalToOC(test.internal)
+			got := InternalToOC(test.internal)
 			assert.EqualValues(t, test.oc, got)
 		})
 	}


### PR DESCRIPTION
**Description:**
Once new receiver that uses internal data structure added into the pipeline it must be able to work with downstream components that still use old OC traces internally. This change makes it possible by using a compatibility shim. 

**Testing:** Unit test