### PR TITLE
Disable usage msg after Start and suppress errors from loggingexporter

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -460,6 +460,9 @@ func (app *Application) execute() error {
 // Start starts the collector according to the command and configuration
 // given by the user.
 func (app *Application) Start() error {
+	// From this point on do not show usage in case of error.
+	app.rootCmd.SilenceUsage = true
+
 	return app.rootCmd.Execute()
 }
 


### PR DESCRIPTION

**Description:** Two fit and finish issues on this change:
- With the improved shutdown merged recently the Collector started to show error messages on shutdown.
- Call to Sync on loggingexporter generates non-actionable error messages.

**Link to tracking Issue:** N/A

**Testing:** Manual validation

**Documentation:** N/A