### PR TITLE
Add initial set of benchmarks for MetricData v2 internal

### DIFF
--- a/internal/data/metric_test.go
+++ b/internal/data/metric_test.go
@@ -653,6 +653,110 @@ func TestOtlpToFromInternalSummaryPointsMutating(t *testing.T) {
 	}, MetricDataToOtlp(metricData))
 }
 
+func BenchmarkOtlpToFromInternal_PassThrough(b *testing.B) {
+	resourceMetricsList := []*otlpmetrics.ResourceMetrics{
+		{
+			Resource: generateTestResource(),
+			InstrumentationLibraryMetrics: []*otlpmetrics.InstrumentationLibraryMetrics{
+				{
+					InstrumentationLibrary: generateTestInstrumentationLibrary(),
+					Metrics:                []*otlpmetrics.Metric{generateTestIntMetric(), generateTestDoubleMetric(), generateTestHistogramMetric(), generateTestSummaryMetric()},
+				},
+			},
+		},
+	}
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		md := MetricDataFromOtlp(resourceMetricsList)
+		MetricDataToOtlp(md)
+	}
+}
+
+func BenchmarkOtlpToFromInternal_Int64Points_MutateOneLabel(b *testing.B) {
+	resourceMetricsList := []*otlpmetrics.ResourceMetrics{
+		{
+			Resource: generateTestResource(),
+			InstrumentationLibraryMetrics: []*otlpmetrics.InstrumentationLibraryMetrics{
+				{
+					InstrumentationLibrary: generateTestInstrumentationLibrary(),
+					Metrics:                []*otlpmetrics.Metric{generateTestIntMetric()},
+				},
+			},
+		},
+	}
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		md := MetricDataFromOtlp(resourceMetricsList)
+		md.ResourceMetrics()[0].InstrumentationLibraryMetrics()[0].Metrics()[0].Int64DataPoints()[0].Labels().LabelsMap()["key0"] = "value0"
+		MetricDataToOtlp(md)
+	}
+}
+
+func BenchmarkOtlpToFromInternal_DoublePoints_MutateOneLabel(b *testing.B) {
+	resourceMetricsList := []*otlpmetrics.ResourceMetrics{
+		{
+			Resource: generateTestResource(),
+			InstrumentationLibraryMetrics: []*otlpmetrics.InstrumentationLibraryMetrics{
+				{
+					InstrumentationLibrary: generateTestInstrumentationLibrary(),
+					Metrics:                []*otlpmetrics.Metric{generateTestDoubleMetric()},
+				},
+			},
+		},
+	}
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		md := MetricDataFromOtlp(resourceMetricsList)
+		md.ResourceMetrics()[0].InstrumentationLibraryMetrics()[0].Metrics()[0].DoubleDataPoints()[0].Labels().LabelsMap()["key0"] = "value0"
+		MetricDataToOtlp(md)
+	}
+}
+
+func BenchmarkOtlpToFromInternal_HistogramPoints_MutateOneLabel(b *testing.B) {
+	resourceMetricsList := []*otlpmetrics.ResourceMetrics{
+		{
+			Resource: generateTestResource(),
+			InstrumentationLibraryMetrics: []*otlpmetrics.InstrumentationLibraryMetrics{
+				{
+					InstrumentationLibrary: generateTestInstrumentationLibrary(),
+					Metrics:                []*otlpmetrics.Metric{generateTestHistogramMetric()},
+				},
+			},
+		},
+	}
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		md := MetricDataFromOtlp(resourceMetricsList)
+		md.ResourceMetrics()[0].InstrumentationLibraryMetrics()[0].Metrics()[0].HistogramDataPoints()[0].Labels().LabelsMap()["key0"] = "value0"
+		MetricDataToOtlp(md)
+	}
+}
+
+func BenchmarkOtlpToFromInternal_SummaryPoints_MutateOneLabel(b *testing.B) {
+	resourceMetricsList := []*otlpmetrics.ResourceMetrics{
+		{
+			Resource: generateTestResource(),
+			InstrumentationLibraryMetrics: []*otlpmetrics.InstrumentationLibraryMetrics{
+				{
+					InstrumentationLibrary: generateTestInstrumentationLibrary(),
+					Metrics:                []*otlpmetrics.Metric{generateTestSummaryMetric()},
+				},
+			},
+		},
+	}
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		md := MetricDataFromOtlp(resourceMetricsList)
+		md.ResourceMetrics()[0].InstrumentationLibraryMetrics()[0].Metrics()[0].SummaryDataPoints()[0].Labels().LabelsMap()["key0"] = "value0"
+		MetricDataToOtlp(md)
+	}
+}
+
 func generateTestResource() *otlpresource.Resource {
 	return &otlpresource.Resource{
 		Attributes: []*otlpcommon.AttributeKeyValue{


### PR DESCRIPTION
```
$go test -benchmem -bench=. -run=notests ./internal/data/...
goos: darwin
goarch: amd64
pkg: github.com/open-telemetry/opentelemetry-collector/internal/data
BenchmarkOtlpToFromInternal_PassThrough-16                              290311723                4.03 ns/op            0 B/op          0 allocs/op
BenchmarkOtlpToFromInternal_Int64Points_MutateOneLabel-16                1199534               970 ns/op            1216 B/op         18 allocs/op
BenchmarkOtlpToFromInternal_DoublePoints_MutateOneLabel-16               1233117               967 ns/op            1216 B/op         18 allocs/op
BenchmarkOtlpToFromInternal_HistogramPoints_MutateOneLabel-16            1000000              1223 ns/op            1392 B/op         20 allocs/op
BenchmarkOtlpToFromInternal_SummaryPoints_MutateOneLabel-16              1000000              1011 ns/op            1280 B/op         19 allocs/op
PASS
ok      github.com/open-telemetry/opentelemetry-collector/internal/data 10.458s
```