### PR TITLE
Eliminate unnecessary V2 suffixes from function names

### DIFF
--- a/config/configmodels/configmodels.go
+++ b/config/configmodels/configmodels.go
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 // Package configmodels defines the data models for entities. This file defines the
-// models for V2 configuration format. The defined entities are:
+// models for configuration format. The defined entities are:
 // Config (the top-level structure), Receivers, Exporters, Processors, Pipelines.
 package configmodels
 

--- a/consumer/consumer.go
+++ b/consumer/consumer.go
@@ -33,7 +33,7 @@ type MetricsConsumer interface {
 // MetricsConsumerV2 is the new metrics consumer interface that receives data.MetricData, processes it
 // as needed, and sends it to the next processing node if any or to the destination.
 type MetricsConsumerV2 interface {
-	ConsumeMetricsV2(ctx context.Context, md data.MetricData) error
+	ConsumeMetrics(ctx context.Context, md data.MetricData) error
 }
 
 // BaseTraceConsumer defines a common interface for TraceConsumer and TraceConsumerV2.
@@ -52,6 +52,6 @@ type TraceConsumer interface {
 // as needed, and sends it to the next processing node if any or to the destination.
 type TraceConsumerV2 interface {
 	BaseTraceConsumer
-	// ConsumeTraceV2 receives data.TraceData for processing.
-	ConsumeTraceV2(ctx context.Context, td data.TraceData) error
+	// ConsumeTrace receives data.TraceData for processing.
+	ConsumeTrace(ctx context.Context, td data.TraceData) error
 }

--- a/consumer/converter.go
+++ b/consumer/converter.go
@@ -23,20 +23,20 @@ import (
 )
 
 // NewInternalToOCTraceConverter creates new internalToOCTraceConverter that takes TraceConsumer and
-// implements ConsumeTraceV2 interface.
+// implements ConsumeTrace interface.
 func NewInternalToOCTraceConverter(tc TraceConsumer) TraceConsumerV2 {
 	return &internalToOCTraceConverter{tc}
 }
 
 // internalToOCTraceConverter is a internal to oc translation shim that takes TraceConsumer and
-// implements ConsumeTraceV2 interface.
+// implements ConsumeTrace interface.
 type internalToOCTraceConverter struct {
 	traceConsumer TraceConsumer
 }
 
-// ConsumeTraceV2 takes new-style data.TraceData method, converts it to OC and uses old-style ConsumeTraceData method
+// ConsumeTrace takes new-style data.TraceData method, converts it to OC and uses old-style ConsumeTraceData method
 // to process the trace data.
-func (tc *internalToOCTraceConverter) ConsumeTraceV2(ctx context.Context, td data.TraceData) error {
+func (tc *internalToOCTraceConverter) ConsumeTrace(ctx context.Context, td data.TraceData) error {
 	ocTraces := internaldata.InternalToOC(td)
 	for i := range ocTraces {
 		err := tc.traceConsumer.ConsumeTraceData(ctx, ocTraces[i])

--- a/exporter/exporterhelper/tracehelper.go
+++ b/exporter/exporterhelper/tracehelper.go
@@ -121,7 +121,7 @@ func (te *traceExporterV2) Start(host component.Host) error {
 	return nil
 }
 
-func (te *traceExporterV2) ConsumeTraceV2(
+func (te *traceExporterV2) ConsumeTrace(
 	ctx context.Context,
 	td data.TraceData,
 ) error {

--- a/exporter/exporterhelper/tracehelper_test.go
+++ b/exporter/exporterhelper/tracehelper_test.go
@@ -255,7 +255,7 @@ func TestTraceV2Exporter_Default(t *testing.T) {
 	assert.NotNil(t, te)
 	assert.Nil(t, err)
 
-	assert.Nil(t, te.ConsumeTraceV2(context.Background(), td))
+	assert.Nil(t, te.ConsumeTrace(context.Background(), td))
 	assert.Nil(t, te.Shutdown())
 }
 
@@ -266,7 +266,7 @@ func TestTraceV2Exporter_Default_ReturnError(t *testing.T) {
 	require.Nil(t, err)
 	require.NotNil(t, te)
 
-	err = te.ConsumeTraceV2(context.Background(), td)
+	err = te.ConsumeTrace(context.Background(), td)
 	require.Equalf(t, want, err, "ConsumeTraceData returns: Want %v Got %v", want, err)
 }
 
@@ -361,7 +361,7 @@ func checkRecordedMetricsForTraceExporterV2(t *testing.T, te exporter.TraceExpor
 	ctx := observability.ContextWithReceiverName(context.Background(), fakeTraceReceiverName)
 	const numBatches = 7
 	for i := 0; i < numBatches; i++ {
-		require.Equal(t, wantError, te.ConsumeTraceV2(ctx, td))
+		require.Equal(t, wantError, te.ConsumeTrace(ctx, td))
 	}
 
 	err := observabilitytest.CheckValueViewExporterReceivedSpans(fakeTraceReceiverName, fakeTraceExporterName, numBatches*len(spans))
@@ -380,7 +380,7 @@ func generateTraceV2Traffic(t *testing.T, te exporter.TraceExporterV2, numReques
 	ctx, span := trace.StartSpan(context.Background(), fakeTraceParentSpanName, trace.WithSampler(trace.AlwaysSample()))
 	defer span.End()
 	for i := 0; i < numRequests; i++ {
-		require.Equal(t, wantError, te.ConsumeTraceV2(ctx, td))
+		require.Equal(t, wantError, te.ConsumeTrace(ctx, td))
 	}
 }
 

--- a/exporter/factory.go
+++ b/exporter/factory.go
@@ -61,15 +61,15 @@ type CreationParams struct {
 type FactoryV2 interface {
 	BaseFactory
 
-	// CreateTraceReceiverV2 creates a trace receiver based on this config.
-	// If the receiver type does not support tracing or if the config is not valid
+	// CreateTraceExporter creates a trace exporter based on this config.
+	// If the exporter type does not support tracing or if the config is not valid
 	// error will be returned instead.
-	CreateTraceExporterV2(ctx context.Context, params CreationParams, cfg configmodels.Exporter) (TraceExporterV2, error)
+	CreateTraceExporter(ctx context.Context, params CreationParams, cfg configmodels.Exporter) (TraceExporterV2, error)
 
-	// CreateMetricsExporterV2 creates a metrics receiver based on this config.
-	// If the receiver type does not support metrics or if the config is not valid
+	// CreateMetricsExporter creates a metrics exporter based on this config.
+	// If the exporter type does not support metrics or if the config is not valid
 	// error will be returned instead.
-	CreateMetricsExporterV2(ctx context.Context, params CreationParams, cfg configmodels.Exporter) (MetricsExporterV2, error)
+	CreateMetricsExporter(ctx context.Context, params CreationParams, cfg configmodels.Exporter) (MetricsExporterV2, error)
 }
 
 // Build takes a list of exporter factories and returns a map of type map[string]Factory

--- a/processor/factory.go
+++ b/processor/factory.go
@@ -68,16 +68,16 @@ type CreationParams struct {
 type FactoryV2 interface {
 	BaseFactory
 
-	// CreateTraceProcessorV2 creates a trace processor based on this config.
+	// CreateTraceProcessor creates a trace processor based on this config.
 	// If the processor type does not support tracing or if the config is not valid
 	// error will be returned instead.
-	CreateTraceProcessorV2(ctx context.Context, params CreationParams,
+	CreateTraceProcessor(ctx context.Context, params CreationParams,
 		nextConsumer consumer.TraceConsumerV2, cfg configmodels.Processor) (TraceProcessorV2, error)
 
-	// CreateMetricsProcessorV2 creates a metrics processor based on this config.
+	// CreateMetricsProcessor creates a metrics processor based on this config.
 	// If the processor type does not support metrics or if the config is not valid
 	// error will be returned instead.
-	CreateMetricsProcessorV2(ctx context.Context, params CreationParams,
+	CreateMetricsProcessor(ctx context.Context, params CreationParams,
 		nextConsumer consumer.MetricsConsumerV2, cfg configmodels.Processor) (MetricsProcessorV2, error)
 }
 

--- a/receiver/factory.go
+++ b/receiver/factory.go
@@ -88,16 +88,16 @@ type CreationParams struct {
 type FactoryV2 interface {
 	BaseFactory
 
-	// CreateTraceReceiverV2 creates a trace receiver based on this config.
+	// CreateTraceReceiver creates a trace receiver based on this config.
 	// If the receiver type does not support tracing or if the config is not valid
 	// error will be returned instead.
-	CreateTraceReceiverV2(ctx context.Context, params CreationParams, cfg configmodels.Receiver,
+	CreateTraceReceiver(ctx context.Context, params CreationParams, cfg configmodels.Receiver,
 		nextConsumer consumer.TraceConsumerV2) (TraceReceiver, error)
 
-	// CreateMetricsReceiverV2 creates a metrics receiver based on this config.
+	// CreateMetricsReceiver creates a metrics receiver based on this config.
 	// If the receiver type does not support metrics or if the config is not valid
 	// error will be returned instead.
-	CreateMetricsReceiverV2(ctx context.Context, params CreationParams, cfg configmodels.Receiver,
+	CreateMetricsReceiver(ctx context.Context, params CreationParams, cfg configmodels.Receiver,
 		nextConsumer consumer.MetricsConsumerV2) (MetricsReceiver, error)
 }
 

--- a/receiver/prometheusreceiver/factory.go
+++ b/receiver/prometheusreceiver/factory.go
@@ -31,7 +31,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector/receiver"
 )
 
-// This file implements config V2 for Prometheus receiver.
+// This file implements config for Prometheus receiver.
 
 var _ (receiver.Factory) = (*Factory)(nil)
 

--- a/service/builder/receivers_builder.go
+++ b/service/builder/receivers_builder.go
@@ -323,15 +323,15 @@ func createTraceReceiver(
 		creationParams := receiver.CreationParams{Logger: logger}
 
 		// If both receiver and consumer are of the new type (can manipulate on internal data structure),
-		// use FactoryV2.CreateTraceReceiverV2.
+		// use FactoryV2.CreateTraceReceiver.
 		if nextConsumerV2, ok := nextConsumer.(consumer.TraceConsumerV2); ok {
-			return factoryV2.CreateTraceReceiverV2(ctx, creationParams, cfg, nextConsumerV2)
+			return factoryV2.CreateTraceReceiver(ctx, creationParams, cfg, nextConsumerV2)
 		}
 
 		// If receiver is of the new type, but downstream consumer is of the old type,
 		// use internalToOCTraceConverter compatibility shim.
 		traceConverter := consumer.NewInternalToOCTraceConverter(nextConsumer.(consumer.TraceConsumer))
-		return factoryV2.CreateTraceReceiverV2(ctx, creationParams, cfg, traceConverter)
+		return factoryV2.CreateTraceReceiver(ctx, creationParams, cfg, traceConverter)
 	}
 
 	// If both receiver and consumer are of the old type (can manipulate on OC traces only),

--- a/service/builder/receivers_builder_test.go
+++ b/service/builder/receivers_builder_test.go
@@ -398,7 +398,7 @@ func (b *newStyleReceiverFactory) CustomUnmarshaler() receiver.CustomUnmarshaler
 	return nil
 }
 
-func (b *newStyleReceiverFactory) CreateTraceReceiverV2(
+func (b *newStyleReceiverFactory) CreateTraceReceiver(
 	ctx context.Context,
 	params receiver.CreationParams,
 	cfg configmodels.Receiver,
@@ -407,7 +407,7 @@ func (b *newStyleReceiverFactory) CreateTraceReceiverV2(
 	return &config.ExampleReceiverProducer{}, nil
 }
 
-func (b *newStyleReceiverFactory) CreateMetricsReceiverV2(
+func (b *newStyleReceiverFactory) CreateMetricsReceiver(
 	ctx context.Context,
 	params receiver.CreationParams,
 	cfg configmodels.Receiver,


### PR DESCRIPTION
Certain functions had V2 suffixes where it was necessary to have one.
Even without a sufix they have different signature than equally-named
old functions and thus the compiler can clearly distinguish between
structs which implement the old of V2 interfaces.

Removing the suffixes results in cleaner and more readable code.
Some type names still have to use V2 suffix for now otherwise the
names would conflict with existing old type names.

Thanks, Jay for the hint.
