### PR TITLE
[WIP] Allow getting factories from component Host

### DIFF
--- a/component/mock_host.go
+++ b/component/mock_host.go
@@ -39,6 +39,11 @@ func (mh *MockHost) ReportFatalError(err error) {
 	// Do nothing for now.
 }
 
+// GetFactories of the specified kind. Returns a map of component types to factories.
+func (mh *MockHost) GetFactories(kind Kind) map[string]Factory {
+	return nil
+}
+
 // NewMockHost returns a new instance of MockHost with proper defaults for most
 // tests.
 func NewMockHost() Host {

--- a/extension/extensiontest/mock_host.go
+++ b/extension/extensiontest/mock_host.go
@@ -61,3 +61,8 @@ func (mh *MockHost) WaitForFatalError(timeout time.Duration) (receivedError bool
 
 	return
 }
+
+// GetFactories of the specified kind. Returns a map of component types to factories.
+func (mh *MockHost) GetFactories(kind component.Kind) map[string]component.Factory {
+	return nil
+}

--- a/receiver/factory.go
+++ b/receiver/factory.go
@@ -21,14 +21,14 @@ import (
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
 
+	"github.com/open-telemetry/opentelemetry-collector/component"
 	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
 	"github.com/open-telemetry/opentelemetry-collector/consumer"
 )
 
 // BaseFactory defines the common functions for all receiver factories.
 type BaseFactory interface {
-	// Type gets the type of the Receiver created by this factory.
-	Type() string
+	component.Factory
 
 	// CreateDefaultConfig creates the default configuration for the Receiver.
 	// This method can be called multiple times depending on the pipeline

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
+	"github.com/open-telemetry/opentelemetry-collector/component"
 	"github.com/open-telemetry/opentelemetry-collector/config"
 	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
 	"github.com/open-telemetry/opentelemetry-collector/defaults"
@@ -236,4 +237,21 @@ func (b badExtensionFactory) CreateExtension(
 	cfg configmodels.Extension,
 ) (extension.ServiceExtension, error) {
 	return nil, nil
+}
+
+func TestApplication_GetFactories(t *testing.T) {
+	exampleExtensionFactory := &config.ExampleExtensionFactory{}
+	factories := config.Factories{
+		Extensions: map[string]extension.Factory{
+			exampleExtensionFactory.Type(): exampleExtensionFactory,
+		},
+	}
+
+	app, err := New(factories, ApplicationStartInfo{})
+	require.NoError(t, err)
+
+	fMap := app.GetFactories(component.KindExtension)
+	assert.EqualValues(t, exampleExtensionFactory, fMap[exampleExtensionFactory.Type()])
+
+	// TODO: test the rest of factory maps.
 }


### PR DESCRIPTION
Added GetFactories function to Host interface. This allows components
to fetch factories and create components dynamically. The functionality
will be used by receiver creator that creates and destroys other receivers
as it discovers relevant external endpoints from which these receivers
can get data.
