### PR TITLE
Metrics translation from internal data structure to OC format

### DIFF
--- a/consumer/converter.go
+++ b/consumer/converter.go
@@ -37,7 +37,7 @@ type internalToOCTraceConverter struct {
 // ConsumeTrace takes new-style data.TraceData method, converts it to OC and uses old-style ConsumeTraceData method
 // to process the trace data.
 func (tc *internalToOCTraceConverter) ConsumeTrace(ctx context.Context, td data.TraceData) error {
-	ocTraces := internaldata.InternalToOC(td)
+	ocTraces := internaldata.TraceDataToOC(td)
 	for i := range ocTraces {
 		err := tc.traceConsumer.ConsumeTraceData(ctx, ocTraces[i])
 		if err != nil {

--- a/internal/data/metric.go
+++ b/internal/data/metric.go
@@ -87,11 +87,8 @@ func (md MetricData) SetResourceMetrics(r []ResourceMetrics) {
 // MetricCount calculates the total number of metrics.
 func (md MetricData) MetricCount() int {
 	metricCount := 0
-	// TODO: Do not access internal members, add a metricCount to ResourceMetrics.
-	for _, rm := range md.pimpl.resourceMetrics {
-		for _, ilm := range rm.pimpl.instrumentationLibraryMetrics {
-			metricCount += len(ilm.pimpl.metrics)
-		}
+	for _, rm := range md.ResourceMetrics() {
+		metricCount += rm.MetricCount()
 	}
 	return metricCount
 }
@@ -191,6 +188,15 @@ func (rm ResourceMetrics) SetInstrumentationLibraryMetrics(s []InstrumentationLi
 	for i := range rm.pimpl.instrumentationLibraryMetrics {
 		rm.orig.InstrumentationLibraryMetrics[i] = rm.pimpl.instrumentationLibraryMetrics[i].orig
 	}
+}
+
+// MetricCount calculates the total number of metrics.
+func (rm ResourceMetrics) MetricCount() int {
+	metricCount := 0
+	for _, ilm := range rm.InstrumentationLibraryMetrics() {
+		metricCount += len(ilm.pimpl.metrics)
+	}
+	return metricCount
 }
 
 func (rm ResourceMetrics) flushInternal() {

--- a/translator/internaldata/metrics_to_oc.go
+++ b/translator/internaldata/metrics_to_oc.go
@@ -1,0 +1,362 @@
+// Copyright 2019 OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internaldata
+
+import (
+	"sort"
+
+	ocmetrics "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
+	"github.com/golang/protobuf/ptypes/wrappers"
+
+	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
+	"github.com/open-telemetry/opentelemetry-collector/internal"
+	"github.com/open-telemetry/opentelemetry-collector/internal/data"
+)
+
+const (
+	invalidMetricDescriptorType = ocmetrics.MetricDescriptor_Type(-1)
+)
+
+type labelKeys struct {
+	// ordered OC label keys
+	keys []*ocmetrics.LabelKey
+	// map from a label key literal
+	// to its index in the slice above
+	keyIndices map[string]int
+}
+
+func MetricDataToOC(td data.MetricData) []consumerdata.MetricsData {
+	ocMetricsData := consumerdata.MetricsData{}
+
+	resourceMetricsList := td.ResourceMetrics()
+
+	ocResourceMetricsList := make([]consumerdata.MetricsData, 0, len(resourceMetricsList))
+
+	for _, resourceMetrics := range resourceMetricsList {
+		ocMetricsData.Node, ocMetricsData.Resource = internalResourceToOC(resourceMetrics.Resource())
+		ocMetrics := make([]*ocmetrics.Metric, 0, resourceMetrics.MetricCount())
+		for _, instrumentationLibraryMetrics := range resourceMetrics.InstrumentationLibraryMetrics() {
+			// TODO: Handle instrumentation library name and version.
+			metrics := instrumentationLibraryMetrics.Metrics()
+			for _, metric := range metrics {
+				ocMetrics = append(ocMetrics, metricToOC(metric))
+			}
+		}
+		ocMetricsData.Metrics = ocMetrics
+		ocResourceMetricsList = append(ocResourceMetricsList, ocMetricsData)
+	}
+
+	return ocResourceMetricsList
+}
+
+func metricToOC(metric data.Metric) *ocmetrics.Metric {
+	labelKeys := collectLabelKeys(metric)
+	return &ocmetrics.Metric{
+		MetricDescriptor: descriptorToOC(metric.MetricDescriptor(), labelKeys),
+		Timeseries:       dataPointsToTimeseries(metric, labelKeys),
+		Resource:         nil,
+	}
+}
+
+func collectLabelKeys(metric data.Metric) *labelKeys {
+	// NOTE: Intrenal data structure and OpenCensus have different representations of labels:
+	// - OC has a single "global" ordered list of label keys per metric in the MetricDescriptor;
+	// then, every data point has an ordered list of label values matching the key index.
+	// - Internally labels are stored independently as key-value storage for each point.
+	//
+	// So what we do in this translator:
+	// - Scan all points and their labels to find all label keys used across the metric,
+	// sort them and set in the MetricDescriptor.
+	// - For each point we generate an ordered list of label values,
+	// matching the order of label keys returned here (see `labelValuesToOC` function).
+	// - If the value for particular label key is missing in the point, we set it to default
+	// to preserve 1:1 matching between label keys and values.
+
+	// First, collect a set of all labels present in the metric
+	keySet := make(map[string]struct{})
+	for _, point := range metric.Int64DataPoints() {
+		addLabelKeys(keySet, point.LabelsMap())
+	}
+	for _, point := range metric.DoubleDataPoints() {
+		addLabelKeys(keySet, point.LabelsMap())
+	}
+	for _, point := range metric.HistogramDataPoints() {
+		addLabelKeys(keySet, point.LabelsMap())
+	}
+	for _, point := range metric.SummaryDataPoints() {
+		addLabelKeys(keySet, point.LabelsMap())
+	}
+
+	// Sort keys: while not mandatory, this helps to make the
+	// output OC metric deterministic and easy to test, i.e.
+	// the same set of labels will always produce
+	// OC labels in the alphabetically sorted order.
+	sortedKeys := make([]string, 0, len(keySet))
+	for key := range keySet {
+		sortedKeys = append(sortedKeys, key)
+	}
+	sort.Strings(sortedKeys)
+
+	// Construct a resulting list of label keys
+	keys := make([]*ocmetrics.LabelKey, 0, len(sortedKeys))
+	// Label values will have to match keys by index
+	// so this map will help with fast lookups.
+	indices := make(map[string]int, len(sortedKeys))
+	for i, key := range sortedKeys {
+		keys = append(keys, &ocmetrics.LabelKey{
+			Key: key,
+		})
+		indices[key] = i
+	}
+
+	return &labelKeys{
+		keys:       keys,
+		keyIndices: indices,
+	}
+}
+
+func addLabelKeys(keySet map[string]struct{}, labels data.LabelsMap) {
+	for label := range labels {
+		keySet[label] = struct{}{}
+	}
+}
+
+func descriptorToOC(descriptor data.MetricDescriptor, labelKeys *labelKeys) *ocmetrics.MetricDescriptor {
+	return &ocmetrics.MetricDescriptor{
+		Name:        descriptor.Name(),
+		Description: descriptor.Description(),
+		Unit:        descriptor.Unit(),
+		Type:        descriptorTypeToOC(descriptor.Type()),
+		LabelKeys:   labelKeys.keys,
+	}
+}
+
+func descriptorTypeToOC(t data.MetricType) ocmetrics.MetricDescriptor_Type {
+	switch t {
+	case data.MetricTypeUnspecified:
+		return ocmetrics.MetricDescriptor_UNSPECIFIED
+	case data.MetricTypeGaugeInt64:
+		return ocmetrics.MetricDescriptor_GAUGE_INT64
+	case data.MetricTypeGaugeDouble:
+		return ocmetrics.MetricDescriptor_GAUGE_DOUBLE
+	case data.MetricTypeGaugeHistogram:
+		return ocmetrics.MetricDescriptor_GAUGE_DISTRIBUTION
+	case data.MetricTypeCounterInt64:
+		return ocmetrics.MetricDescriptor_CUMULATIVE_INT64
+	case data.MetricTypeCounterDouble:
+		return ocmetrics.MetricDescriptor_CUMULATIVE_DOUBLE
+	case data.MetricTypeCumulativeHistogram:
+		return ocmetrics.MetricDescriptor_CUMULATIVE_DISTRIBUTION
+	case data.MetricTypeSummary:
+		return ocmetrics.MetricDescriptor_SUMMARY
+	default:
+		return invalidMetricDescriptorType
+	}
+}
+
+func dataPointsToTimeseries(metric data.Metric, labelKeys *labelKeys) []*ocmetrics.TimeSeries {
+	length := len(metric.Int64DataPoints()) + len(metric.DoubleDataPoints()) + len(metric.HistogramDataPoints()) +
+		len(metric.SummaryDataPoints())
+	if length == 0 {
+		return nil
+	}
+
+	timeseries := make([]*ocmetrics.TimeSeries, 0, length)
+	for _, point := range metric.Int64DataPoints() {
+		ts := int64PointToOC(point, labelKeys)
+		timeseries = append(timeseries, ts)
+	}
+	for _, point := range metric.DoubleDataPoints() {
+		ts := doublePointToOC(point, labelKeys)
+		timeseries = append(timeseries, ts)
+	}
+	for _, point := range metric.HistogramDataPoints() {
+		ts := histogramPointToOC(point, labelKeys)
+		timeseries = append(timeseries, ts)
+	}
+	for _, point := range metric.SummaryDataPoints() {
+		ts := summaryPointToOC(point, labelKeys)
+		timeseries = append(timeseries, ts)
+	}
+
+	return timeseries
+}
+
+func int64PointToOC(point data.Int64DataPoint, labelKeys *labelKeys) *ocmetrics.TimeSeries {
+	return &ocmetrics.TimeSeries{
+		StartTimestamp: internal.UnixnanoToTimestamp(point.StartTime()),
+		LabelValues:    labelValuesToOC(point.LabelsMap(), labelKeys),
+		Points: []*ocmetrics.Point{
+			{
+				Timestamp: internal.UnixnanoToTimestamp(point.Timestamp()),
+				Value: &ocmetrics.Point_Int64Value{
+					Int64Value: point.Value(),
+				},
+			},
+		},
+	}
+}
+
+func doublePointToOC(point data.DoubleDataPoint, labelKeys *labelKeys) *ocmetrics.TimeSeries {
+	return &ocmetrics.TimeSeries{
+		StartTimestamp: internal.UnixnanoToTimestamp(point.StartTime()),
+		LabelValues:    labelValuesToOC(point.LabelsMap(), labelKeys),
+		Points: []*ocmetrics.Point{
+			{
+				Timestamp: internal.UnixnanoToTimestamp(point.Timestamp()),
+				Value: &ocmetrics.Point_DoubleValue{
+					DoubleValue: point.Value(),
+				},
+			},
+		},
+	}
+}
+
+func histogramPointToOC(point data.HistogramDataPoint, labelKeys *labelKeys) *ocmetrics.TimeSeries {
+	return &ocmetrics.TimeSeries{
+		StartTimestamp: internal.UnixnanoToTimestamp(point.StartTime()),
+		LabelValues:    labelValuesToOC(point.LabelsMap(), labelKeys),
+		Points: []*ocmetrics.Point{
+			{
+				Timestamp: internal.UnixnanoToTimestamp(point.Timestamp()),
+				Value: &ocmetrics.Point_DistributionValue{
+					DistributionValue: &ocmetrics.DistributionValue{
+						Count:                 int64(point.Count()),
+						Sum:                   point.Sum(),
+						SumOfSquaredDeviation: 0,
+						BucketOptions:         histogramExplicitBoundsToOC(point.ExplicitBounds()),
+						Buckets:               histogramBucketsToOC(point.Buckets()),
+					},
+				},
+			},
+		},
+	}
+}
+
+func histogramExplicitBoundsToOC(bounds []float64) *ocmetrics.DistributionValue_BucketOptions {
+	if len(bounds) == 0 {
+		return nil
+	}
+
+	return &ocmetrics.DistributionValue_BucketOptions{
+		Type: &ocmetrics.DistributionValue_BucketOptions_Explicit_{
+			Explicit: &ocmetrics.DistributionValue_BucketOptions_Explicit{
+				Bounds: bounds,
+			},
+		},
+	}
+}
+
+func histogramBucketsToOC(buckets []data.HistogramBucket) []*ocmetrics.DistributionValue_Bucket {
+	if len(buckets) == 0 {
+		return nil
+	}
+
+	ocBuckets := make([]*ocmetrics.DistributionValue_Bucket, 0, len(buckets))
+	for _, bucket := range buckets {
+		ocBuckets = append(ocBuckets, &ocmetrics.DistributionValue_Bucket{
+			Count:    int64(bucket.Count()),
+			Exemplar: exemplarToOC(bucket.Exemplar()),
+		})
+	}
+	return ocBuckets
+}
+
+func exemplarToOC(exemplar data.HistogramBucketExemplar) *ocmetrics.DistributionValue_Exemplar {
+	return &ocmetrics.DistributionValue_Exemplar{
+		Value:       exemplar.Value(),
+		Timestamp:   internal.UnixnanoToTimestamp(exemplar.Timestamp()),
+		Attachments: exemplar.Attachments(),
+	}
+}
+
+func summaryPointToOC(point data.SummaryDataPoint, labelKeys *labelKeys) *ocmetrics.TimeSeries {
+	return &ocmetrics.TimeSeries{
+		StartTimestamp: internal.UnixnanoToTimestamp(point.StartTime()),
+		LabelValues:    labelValuesToOC(point.LabelsMap(), labelKeys),
+		Points: []*ocmetrics.Point{
+			{
+				Timestamp: internal.UnixnanoToTimestamp(point.Timestamp()),
+				Value: &ocmetrics.Point_SummaryValue{
+					SummaryValue: &ocmetrics.SummaryValue{
+						Count: int64Value(point.Count()),
+						Sum:   doubleValue(point.Sum()),
+						Snapshot: &ocmetrics.SummaryValue_Snapshot{
+							Count:            nil,
+							Sum:              nil,
+							PercentileValues: percentileToOC(point.ValueAtPercentiles()),
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func percentileToOC(percentiles []data.SummaryValueAtPercentile) []*ocmetrics.SummaryValue_Snapshot_ValueAtPercentile {
+	if len(percentiles) == 0 {
+		return nil
+	}
+
+	ocPercentiles := make([]*ocmetrics.SummaryValue_Snapshot_ValueAtPercentile, 0, len(percentiles))
+	for _, p := range percentiles {
+		ocPercentiles = append(ocPercentiles, &ocmetrics.SummaryValue_Snapshot_ValueAtPercentile{
+			Percentile: p.Percentile(),
+			Value:      p.Value(),
+		})
+	}
+	return ocPercentiles
+}
+
+func labelValuesToOC(labelsMap data.LabelsMap, labelKeys *labelKeys) []*ocmetrics.LabelValue {
+	if len(labelsMap) == 0 {
+		return nil
+	}
+
+	// Initialize label values with defaults
+	// (The order matches key indices)
+	labelValues := make([]*ocmetrics.LabelValue, len(labelKeys.keyIndices))
+	for i := 0; i < len(labelKeys.keys); i++ {
+		labelValues[i] = &ocmetrics.LabelValue{
+			HasValue: false,
+		}
+	}
+
+	// Visit all defined label values and
+	// override defaults with actual values
+	for key, val := range labelsMap {
+		// Find the appropriate label value that we need to update
+		keyIndex := labelKeys.keyIndices[key]
+		labelValue := labelValues[keyIndex]
+
+		// Update label value
+		labelValue.Value = val
+		labelValue.HasValue = true
+	}
+
+	return labelValues
+}
+
+func int64Value(val uint64) *wrappers.Int64Value {
+	return &wrappers.Int64Value{
+		Value: int64(val),
+	}
+}
+
+func doubleValue(val float64) *wrappers.DoubleValue {
+	return &wrappers.DoubleValue{
+		Value: val,
+	}
+}

--- a/translator/internaldata/metrics_to_oc_test.go
+++ b/translator/internaldata/metrics_to_oc_test.go
@@ -1,0 +1,251 @@
+// Copyright 2020 OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internaldata
+
+import (
+	"testing"
+	"time"
+
+	occommon "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
+	ocmetrics "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
+	ocresource "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
+	"github.com/golang/protobuf/ptypes"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
+	"github.com/open-telemetry/opentelemetry-collector/internal"
+	"github.com/open-telemetry/opentelemetry-collector/internal/data"
+	"github.com/open-telemetry/opentelemetry-collector/translator/conventions"
+)
+
+func TestResourceMetricsToMetricsData(t *testing.T) {
+	ts, err := ptypes.TimestampProto(time.Date(2020, 2, 11, 20, 26, 0, 0, time.UTC))
+	assert.NoError(t, err)
+
+	ts1 := data.TimestampUnixNano(12578940000000012345)
+	ts2 := data.TimestampUnixNano(12578940000000054321)
+
+	metrics := data.NewMetricSlice(1)
+	metricDescriptor := data.NewMetricDescriptor()
+	metricDescriptor.SetName("mymetric")
+	metricDescriptor.SetDescription("My metric")
+	metricDescriptor.SetUnit("ms")
+	metricDescriptor.SetMetricType(data.MetricTypeCounterInt64)
+	metrics[0].SetMetricDescriptor(metricDescriptor)
+
+	int64DataPoints := data.NewInt64DataPointSlice(2)
+	int64DataPoints[0].SetLabelsMap(data.LabelsMap{"key1": "value1"})
+	int64DataPoints[0].SetStartTime(ts1)
+	int64DataPoints[0].SetTimestamp(ts2)
+	int64DataPoints[0].SetValue(123)
+	int64DataPoints[1].SetLabelsMap(data.LabelsMap{"key2": "value2"})
+	int64DataPoints[1].SetStartTime(ts1)
+	int64DataPoints[1].SetTimestamp(ts2)
+	int64DataPoints[1].SetValue(456)
+	metrics[0].SetInt64DataPoints(int64DataPoints)
+
+	doubleDataPoints := data.NewDoubleDataPointSlice(1)
+	doubleDataPoints[0].SetLabelsMap(data.LabelsMap{
+		"key1": "double-value1",
+		"key3": "double-value3",
+	})
+	doubleDataPoints[0].SetStartTime(ts1)
+	doubleDataPoints[0].SetTimestamp(ts2)
+	doubleDataPoints[0].SetValue(1.23)
+	metrics[0].SetDoubleDataPoints(doubleDataPoints)
+
+	resource := data.NewResource()
+	attrs := data.AttributesMap{
+		conventions.OCAttributeProcessStartTime: data.NewAttributeValueString("2020-02-11T20:26:00Z"),
+		conventions.AttributeHostHostname:       data.NewAttributeValueString("host1"),
+		conventions.OCAttributeProcessID:        data.NewAttributeValueString("123"),
+		conventions.AttributeLibraryVersion:     data.NewAttributeValueString("v2.0.1"),
+		conventions.OCAttributeExporterVersion:  data.NewAttributeValueString("v1.2.0"),
+		conventions.AttributeLibraryLanguage:    data.NewAttributeValueString("CPP"),
+		conventions.OCAttributeResourceType:     data.NewAttributeValueString("good-resource"),
+		"str1":                                  data.NewAttributeValueString("text"),
+		"int2":                                  data.NewAttributeValueInt(123),
+	}
+	resource.SetAttributes(attrs)
+
+	ilm := data.NewInstrumentationLibraryMetricsSlice(1)
+	ilm[0].SetMetrics(metrics)
+	resourceMetricsSlice := data.NewResourceMetricsSlice(1)
+	resourceMetricsSlice[0].SetInstrumentationLibraryMetrics(ilm)
+	resourceMetricsSlice[0].SetResource(resource)
+
+	metricData := data.NewMetricData()
+	metricData.SetResourceMetrics(resourceMetricsSlice)
+
+	emptyMetricData := data.NewMetricData()
+	emptyMetricData.SetResourceMetrics([]data.ResourceMetrics{data.NewResourceMetrics()})
+
+	ocMetric := &ocmetrics.Metric{
+		MetricDescriptor: &ocmetrics.MetricDescriptor{
+			Name:        "mymetric",
+			Description: "My metric",
+			Unit:        "ms",
+			Type:        ocmetrics.MetricDescriptor_CUMULATIVE_INT64,
+			LabelKeys: []*ocmetrics.LabelKey{
+				{Key: "key1"},
+				{Key: "key2"},
+				{Key: "key3"},
+			},
+		},
+		Timeseries: []*ocmetrics.TimeSeries{
+			{
+				StartTimestamp: internal.UnixnanoToTimestamp(ts1),
+				LabelValues: []*ocmetrics.LabelValue{
+					{
+						// key1
+						Value:    "value1",
+						HasValue: true,
+					},
+					{
+						// key2
+						HasValue: false,
+					},
+					{
+						// key3
+						HasValue: false,
+					},
+				},
+				Points: []*ocmetrics.Point{
+					{
+						Timestamp: internal.UnixnanoToTimestamp(ts2),
+						Value: &ocmetrics.Point_Int64Value{
+							Int64Value: 123,
+						},
+					},
+				},
+			},
+			{
+				StartTimestamp: internal.UnixnanoToTimestamp(ts1),
+				LabelValues: []*ocmetrics.LabelValue{
+					{
+						// key1
+						HasValue: false,
+					},
+					{
+						// key2
+						Value:    "value2",
+						HasValue: true,
+					},
+					{
+						// key3
+						HasValue: false,
+					},
+				},
+				Points: []*ocmetrics.Point{
+					{
+						Timestamp: internal.UnixnanoToTimestamp(ts2),
+						Value: &ocmetrics.Point_Int64Value{
+							Int64Value: 456,
+						},
+					},
+				},
+			},
+			{
+				StartTimestamp: internal.UnixnanoToTimestamp(ts1),
+				LabelValues: []*ocmetrics.LabelValue{
+					{
+						// key1
+						Value:    "double-value1",
+						HasValue: true,
+					},
+					{
+						// key2
+						HasValue: false,
+					},
+					{
+						// key3
+						Value:    "double-value3",
+						HasValue: true,
+					},
+				},
+				Points: []*ocmetrics.Point{
+					{
+						Timestamp: internal.UnixnanoToTimestamp(ts2),
+						Value: &ocmetrics.Point_DoubleValue{
+							DoubleValue: 1.23,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	ocAttributes := map[string]string{
+		"str1": "text",
+		"int2": "123",
+	}
+
+	tests := []struct {
+		name     string
+		internal data.MetricData
+		oc       []consumerdata.MetricsData
+	}{
+		{
+			name:     "none",
+			internal: data.NewMetricData(),
+			oc:       []consumerdata.MetricsData{},
+		},
+
+		{
+			name:     "empty",
+			internal: emptyMetricData,
+			oc: []consumerdata.MetricsData{
+				{
+					Node:     &occommon.Node{},
+					Resource: &ocresource.Resource{},
+					Metrics:  []*ocmetrics.Metric{},
+				},
+			},
+		},
+
+		{
+			name:     "sample-metric",
+			internal: metricData,
+			oc: []consumerdata.MetricsData{
+				{
+					Node: &occommon.Node{
+						Identifier: &occommon.ProcessIdentifier{
+							HostName:       "host1",
+							Pid:            123,
+							StartTimestamp: ts,
+						},
+						LibraryInfo: &occommon.LibraryInfo{
+							Language:           occommon.LibraryInfo_CPP,
+							ExporterVersion:    "v1.2.0",
+							CoreLibraryVersion: "v2.0.1",
+						},
+					},
+					Resource: &ocresource.Resource{
+						Type:   "good-resource",
+						Labels: ocAttributes,
+					},
+					Metrics: []*ocmetrics.Metric{ocMetric},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := MetricDataToOC(test.internal)
+			assert.EqualValues(t, test.oc, got)
+		})
+	}
+}

--- a/translator/internaldata/resource_to_oc.go
+++ b/translator/internaldata/resource_to_oc.go
@@ -1,0 +1,119 @@
+// Copyright 2019 OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internaldata
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	occommon "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
+	ocresource "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
+	"github.com/golang/protobuf/ptypes"
+
+	"github.com/open-telemetry/opentelemetry-collector/internal/data"
+	"github.com/open-telemetry/opentelemetry-collector/translator/conventions"
+)
+
+func internalResourceToOC(resource *data.Resource) (*occommon.Node, *ocresource.Resource) {
+	attrs := resource.Attributes()
+
+	ocNode := occommon.Node{}
+	ocResource := ocresource.Resource{}
+
+	if len(attrs) == 0 {
+		return &ocNode, &ocResource
+	}
+
+	labels := make(map[string]string, len(attrs))
+	for key, attributeValue := range attrs {
+		val := attributeValueToString(attributeValue)
+
+		switch key {
+		case conventions.OCAttributeResourceType:
+			ocResource.Type = val
+		case conventions.AttributeServiceName:
+			if ocNode.ServiceInfo == nil {
+				ocNode.ServiceInfo = &occommon.ServiceInfo{}
+			}
+			ocNode.ServiceInfo.Name = val
+		case conventions.OCAttributeProcessStartTime:
+			t, err := time.Parse(time.RFC3339Nano, val)
+			if err != nil {
+				continue
+			}
+			ts, err := ptypes.TimestampProto(t)
+			if err != nil {
+				continue
+			}
+			if ocNode.Identifier == nil {
+				ocNode.Identifier = &occommon.ProcessIdentifier{}
+			}
+			ocNode.Identifier.StartTimestamp = ts
+		case conventions.AttributeHostHostname:
+			if ocNode.Identifier == nil {
+				ocNode.Identifier = &occommon.ProcessIdentifier{}
+			}
+			ocNode.Identifier.HostName = val
+		case conventions.OCAttributeProcessID:
+			pid, err := strconv.Atoi(val)
+			if err != nil {
+				pid = defaultProcessID
+			}
+			if ocNode.Identifier == nil {
+				ocNode.Identifier = &occommon.ProcessIdentifier{}
+			}
+			ocNode.Identifier.Pid = uint32(pid)
+		case conventions.AttributeLibraryVersion:
+			if ocNode.LibraryInfo == nil {
+				ocNode.LibraryInfo = &occommon.LibraryInfo{}
+			}
+			ocNode.LibraryInfo.CoreLibraryVersion = val
+		case conventions.OCAttributeExporterVersion:
+			if ocNode.LibraryInfo == nil {
+				ocNode.LibraryInfo = &occommon.LibraryInfo{}
+			}
+			ocNode.LibraryInfo.ExporterVersion = val
+		case conventions.AttributeLibraryLanguage:
+			if code, ok := occommon.LibraryInfo_Language_value[val]; ok {
+				if ocNode.LibraryInfo == nil {
+					ocNode.LibraryInfo = &occommon.LibraryInfo{}
+				}
+				ocNode.LibraryInfo.Language = occommon.LibraryInfo_Language(code)
+			}
+		default:
+			// Not a special attribute, put it into resource labels
+			labels[key] = val
+		}
+	}
+	ocResource.Labels = labels
+
+	return &ocNode, &ocResource
+}
+
+func attributeValueToString(attr data.AttributeValue) string {
+	switch attr.Type() {
+	case data.AttributeValueSTRING:
+		return attr.StringVal()
+	case data.AttributeValueBOOL:
+		return strconv.FormatBool(attr.BoolVal())
+	case data.AttributeValueDOUBLE:
+		return strconv.FormatFloat(attr.DoubleVal(), 'f', -1, 64)
+	case data.AttributeValueINT:
+		return strconv.FormatInt(attr.IntVal(), 10)
+	default:
+		return fmt.Sprintf("<Unknown OpenTelemetry attribute value type %q>", attr.Type())
+	}
+}

--- a/translator/internaldata/resource_to_oc_test.go
+++ b/translator/internaldata/resource_to_oc_test.go
@@ -1,0 +1,95 @@
+// Copyright 2020 OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internaldata
+
+import (
+	"testing"
+	"time"
+
+	occommon "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
+	ocresource "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
+	"github.com/golang/protobuf/ptypes"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/open-telemetry/opentelemetry-collector/internal/data"
+	"github.com/open-telemetry/opentelemetry-collector/translator/conventions"
+)
+
+func TestResourceToOC(t *testing.T) {
+	ts, err := ptypes.TimestampProto(time.Date(2020, 2, 11, 20, 26, 0, 0, time.UTC))
+	assert.NoError(t, err)
+
+	ocAttributes := map[string]string{
+		"str1": "text",
+		"int2": "123",
+	}
+
+	resource := data.NewResource()
+	attrs := data.AttributesMap{
+		conventions.OCAttributeProcessStartTime: data.NewAttributeValueString("2020-02-11T20:26:00Z"),
+		conventions.AttributeHostHostname:       data.NewAttributeValueString("host1"),
+		conventions.OCAttributeProcessID:        data.NewAttributeValueString("123"),
+		conventions.AttributeLibraryVersion:     data.NewAttributeValueString("v2.0.1"),
+		conventions.OCAttributeExporterVersion:  data.NewAttributeValueString("v1.2.0"),
+		conventions.AttributeLibraryLanguage:    data.NewAttributeValueString("CPP"),
+		conventions.OCAttributeResourceType:     data.NewAttributeValueString("good-resource"),
+		"str1":                                  data.NewAttributeValueString("text"),
+		"int2":                                  data.NewAttributeValueInt(123),
+	}
+	resource.SetAttributes(attrs)
+
+	tests := []struct {
+		name       string
+		resource   *data.Resource
+		ocNode     *occommon.Node
+		ocResource *ocresource.Resource
+	}{
+		{
+			name:       "empty",
+			resource:   data.NewResource(),
+			ocNode:     &occommon.Node{},
+			ocResource: &ocresource.Resource{},
+		},
+
+		{
+			name:     "with-attributes",
+			resource: resource,
+			ocNode: &occommon.Node{
+				Identifier: &occommon.ProcessIdentifier{
+					HostName:       "host1",
+					Pid:            123,
+					StartTimestamp: ts,
+				},
+				LibraryInfo: &occommon.LibraryInfo{
+					Language:           occommon.LibraryInfo_CPP,
+					ExporterVersion:    "v1.2.0",
+					CoreLibraryVersion: "v2.0.1",
+				},
+			},
+			ocResource: &ocresource.Resource{
+				Type:   "good-resource",
+				Labels: ocAttributes,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ocNode, ocResource := internalResourceToOC(test.resource)
+			assert.EqualValues(t, test.ocNode, ocNode)
+			assert.EqualValues(t, test.ocResource, ocResource)
+		})
+	}
+}

--- a/translator/internaldata/traces_to_oc.go
+++ b/translator/internaldata/traces_to_oc.go
@@ -16,14 +16,9 @@ package internaldata
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
-	"time"
 
-	occommon "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
-	ocresource "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
 	octrace "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
-	"github.com/golang/protobuf/ptypes"
 
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-collector/internal"
@@ -39,7 +34,7 @@ var (
 	emptyStatus      = data.SpanStatus{}
 )
 
-func InternalToOC(td data.TraceData) []consumerdata.TraceData {
+func TraceDataToOC(td data.TraceData) []consumerdata.TraceData {
 	ocTraceData := consumerdata.TraceData{
 		SourceFormat: sourceFormat,
 	}
@@ -61,101 +56,6 @@ func InternalToOC(td data.TraceData) []consumerdata.TraceData {
 	}
 
 	return ocResourceSpansList
-}
-
-func internalResourceToOC(resource *data.Resource) (*occommon.Node, *ocresource.Resource) {
-	if resource == nil {
-		return nil, nil
-	}
-
-	attrs := resource.Attributes()
-
-	ocNode := occommon.Node{}
-	ocResource := ocresource.Resource{}
-
-	if len(attrs) == 0 {
-		return &ocNode, &ocResource
-	}
-
-	labels := make(map[string]string, len(attrs))
-	for key, attributeValue := range attrs {
-		val := attributeValueToString(attributeValue)
-
-		switch key {
-		case conventions.OCAttributeResourceType:
-			ocResource.Type = val
-		case conventions.AttributeServiceName:
-			if ocNode.ServiceInfo == nil {
-				ocNode.ServiceInfo = &occommon.ServiceInfo{}
-			}
-			ocNode.ServiceInfo.Name = val
-		case conventions.OCAttributeProcessStartTime:
-			t, err := time.Parse(time.RFC3339Nano, val)
-			if err != nil {
-				continue
-			}
-			ts, err := ptypes.TimestampProto(t)
-			if err != nil {
-				continue
-			}
-			if ocNode.Identifier == nil {
-				ocNode.Identifier = &occommon.ProcessIdentifier{}
-			}
-			ocNode.Identifier.StartTimestamp = ts
-		case conventions.AttributeHostHostname:
-			if ocNode.Identifier == nil {
-				ocNode.Identifier = &occommon.ProcessIdentifier{}
-			}
-			ocNode.Identifier.HostName = val
-		case conventions.OCAttributeProcessID:
-			pid, err := strconv.Atoi(val)
-			if err != nil {
-				pid = defaultProcessID
-			}
-			if ocNode.Identifier == nil {
-				ocNode.Identifier = &occommon.ProcessIdentifier{}
-			}
-			ocNode.Identifier.Pid = uint32(pid)
-		case conventions.AttributeLibraryVersion:
-			if ocNode.LibraryInfo == nil {
-				ocNode.LibraryInfo = &occommon.LibraryInfo{}
-			}
-			ocNode.LibraryInfo.CoreLibraryVersion = val
-		case conventions.OCAttributeExporterVersion:
-			if ocNode.LibraryInfo == nil {
-				ocNode.LibraryInfo = &occommon.LibraryInfo{}
-			}
-			ocNode.LibraryInfo.ExporterVersion = val
-		case conventions.AttributeLibraryLanguage:
-			if code, ok := occommon.LibraryInfo_Language_value[val]; ok {
-				if ocNode.LibraryInfo == nil {
-					ocNode.LibraryInfo = &occommon.LibraryInfo{}
-				}
-				ocNode.LibraryInfo.Language = occommon.LibraryInfo_Language(code)
-			}
-		default:
-			// Not a special attribute, put it into resource labels
-			labels[key] = val
-		}
-	}
-	ocResource.Labels = labels
-
-	return &ocNode, &ocResource
-}
-
-func attributeValueToString(attr data.AttributeValue) string {
-	switch attr.Type() {
-	case data.AttributeValueSTRING:
-		return attr.StringVal()
-	case data.AttributeValueBOOL:
-		return strconv.FormatBool(attr.BoolVal())
-	case data.AttributeValueDOUBLE:
-		return strconv.FormatFloat(attr.DoubleVal(), 'f', -1, 64)
-	case data.AttributeValueINT:
-		return strconv.FormatInt(attr.IntVal(), 10)
-	default:
-		return fmt.Sprintf("<Unknown OpenTelemetry attribute value type %q>", attr.Type())
-	}
 }
 
 func spanToOC(span *data.Span) *octrace.Span {

--- a/translator/internaldata/traces_to_oc_test.go
+++ b/translator/internaldata/traces_to_oc_test.go
@@ -395,7 +395,7 @@ func TestInternalToOC(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got := InternalToOC(test.internal)
+			got := TraceDataToOC(test.internal)
 			assert.EqualValues(t, test.oc, got)
 		})
 	}


### PR DESCRIPTION
**Description:**
This will allow the new-styles metric receivers to send data to old-style processors during the period of transition to internal data structure, also will be reused by OC exporter
Translation is mostly based on OTLP to OC translation defined in translator/metrics/otlp_to_oc.go

**Testing:** Unit tests