### PR TITLE
Update docker image to latest contrib

### DIFF
--- a/examples/demo/README.md
+++ b/examples/demo/README.md
@@ -18,7 +18,7 @@ This demo uses `docker-compose` and by default runs against the
 to the `examples/demo` folder and run:
 
 ```shell
-docker-compose up -d
+docker-compose pull && docker-compose up -d
 ```
 
 The demo exposes the following backends:

--- a/examples/demo/otel-agent-config.yaml
+++ b/examples/demo/otel-agent-config.yaml
@@ -13,7 +13,6 @@ exporters:
   opencensus:
     endpoint: "otel-collector:55678"
   logging:
-    loglevel: debug
 
 processors:
   batch:

--- a/examples/k8s.yaml
+++ b/examples/k8s.yaml
@@ -48,7 +48,7 @@ spec:
       - command:
           - "/otelcol"
           - "--config=/conf/otel-agent-config.yaml"
-        image: omnition/opentelemetry-collector:v0.2.3
+        image: omnition/opentelemetry-collector-contrib:0.2.7
         name: otel-agent
         resources:
           limits:
@@ -179,7 +179,7 @@ spec:
         env:
         - name: GOGC
           value: "80"
-        image: omnition/opentelemetry-collector:v0.2.3
+        image: omnition/opentelemetry-collector-contrib:0.2.7
         name: otel-collector
         resources:
           limits:

--- a/testbed/go.sum
+++ b/testbed/go.sum
@@ -483,7 +483,6 @@ github.com/onsi/gomega v1.7.0 h1:XPnZz8VVBHjVsy1vzJmRwIcSwiUO+JFfrv/xGiigmME=
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/open-telemetry/opentelemetry-proto v0.0.0-20200308012146-674ae1c8703f h1:o21WlujGsrjoN3+n99AflASF/K0S6+SOLOj2O9nNplc=
 github.com/open-telemetry/opentelemetry-proto v0.0.0-20200308012146-674ae1c8703f/go.mod h1:PMR5GI0F7BSpio+rBGFxNm6SLzg3FypDTcFuQZnO+F8=
-github.com/open-telemetry/opentelemetry-proto v0.0.0-20200315170400-caed74b167ad/go.mod h1:PMR5GI0F7BSpio+rBGFxNm6SLzg3FypDTcFuQZnO+F8=
 github.com/opentracing-contrib/go-stdlib v0.0.0-20190519235532-cf7a6c988dc9/go.mod h1:PLldrQSroqzH70Xl+1DQcGnefIbqsKR7UDaiux3zV+w=
 github.com/opentracing/opentracing-go v1.1.0 h1:pWlfV3Bxv7k65HYwkikxat0+s3pV4bsqf19k25Ur8rU=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=

--- a/testbed/go.sum
+++ b/testbed/go.sum
@@ -483,6 +483,7 @@ github.com/onsi/gomega v1.7.0 h1:XPnZz8VVBHjVsy1vzJmRwIcSwiUO+JFfrv/xGiigmME=
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/open-telemetry/opentelemetry-proto v0.0.0-20200308012146-674ae1c8703f h1:o21WlujGsrjoN3+n99AflASF/K0S6+SOLOj2O9nNplc=
 github.com/open-telemetry/opentelemetry-proto v0.0.0-20200308012146-674ae1c8703f/go.mod h1:PMR5GI0F7BSpio+rBGFxNm6SLzg3FypDTcFuQZnO+F8=
+github.com/open-telemetry/opentelemetry-proto v0.0.0-20200315170400-caed74b167ad/go.mod h1:PMR5GI0F7BSpio+rBGFxNm6SLzg3FypDTcFuQZnO+F8=
 github.com/opentracing-contrib/go-stdlib v0.0.0-20190519235532-cf7a6c988dc9/go.mod h1:PLldrQSroqzH70Xl+1DQcGnefIbqsKR7UDaiux3zV+w=
 github.com/opentracing/opentracing-go v1.1.0 h1:pWlfV3Bxv7k65HYwkikxat0+s3pV4bsqf19k25Ur8rU=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=


### PR DESCRIPTION
**Description:** we have been updating the contrib image more frequently, updating the image usage to the contrib since it also includes all components from core.

**Link to tracking Issue:** N/A

**Testing:** Manual validation of docker-compose example.

**Documentation:** Update README.md to use `docker-compose pull` to ensure that the latest is pulled.