### PR TITLE
Add AttributeMap and use it in the Resource

### DIFF
--- a/exporter/exporterhelper/tracehelper_test.go
+++ b/exporter/exporterhelper/tracehelper_test.go
@@ -354,7 +354,7 @@ func checkRecordedMetricsForTraceExporterV2(t *testing.T, te exporter.TraceExpor
 	defer doneFn()
 
 	spans := make([]*data.Span, 2)
-	rs := data.NewResourceSpans(nil, nil)
+	rs := data.NewResourceSpans(data.NewResource(), nil)
 	ils := data.NewInstrumentationLibrarySpans(data.NewInstrumentationLibrary(), spans)
 	rs.SetInstrumentationLibrarySpans([]*data.InstrumentationLibrarySpans{ils})
 	td := data.NewTraceData([]*data.ResourceSpans{rs})
@@ -373,7 +373,7 @@ func checkRecordedMetricsForTraceExporterV2(t *testing.T, te exporter.TraceExpor
 
 func generateTraceV2Traffic(t *testing.T, te exporter.TraceExporterV2, numRequests int, wantError error) {
 	spans := make([]*data.Span, 1)
-	rs := data.NewResourceSpans(nil, nil)
+	rs := data.NewResourceSpans(data.NewResource(), nil)
 	ils := data.NewInstrumentationLibrarySpans(data.NewInstrumentationLibrary(), spans)
 	rs.SetInstrumentationLibrarySpans([]*data.InstrumentationLibrarySpans{ils})
 	td := data.NewTraceData([]*data.ResourceSpans{rs})

--- a/internal/data/resource.go
+++ b/internal/data/resource.go
@@ -15,7 +15,6 @@
 package data
 
 import (
-	otlpcommon "github.com/open-telemetry/opentelemetry-proto/gen/go/common/v1"
 	otlpresource "github.com/open-telemetry/opentelemetry-proto/gen/go/resource/v1"
 )
 
@@ -24,46 +23,24 @@ import (
 // Must use NewResource functions to create new instances.
 // Important: zero-initialized instance is not valid for use.
 type Resource struct {
-	// Set of attributes that describe the resource.
-	attributes AttributesMap
+	orig *otlpresource.Resource
 }
 
-func NewResource() *Resource {
-	return &Resource{}
+// NewResource creates a new empty Resource.
+func NewResource() Resource {
+	return Resource{&otlpresource.Resource{}}
 }
 
-func newResource(orig *otlpresource.Resource) *Resource {
-	if orig == nil {
-		return &Resource{}
-	}
-	origAttr := orig.Attributes
-	attr := make(AttributesMap, len(origAttr))
-	for i := range origAttr {
-		attr[origAttr[i].GetKey()] = AttributeValue{origAttr[i]}
-	}
-	return &Resource{attr}
+func newResource(orig *otlpresource.Resource) Resource {
+	return Resource{orig}
 }
 
-func (r *Resource) Attributes() AttributesMap {
-	return r.attributes
+// Attributes returns the AttributesMap associated with this Resource.
+func (r Resource) Attributes() AttributeMap {
+	return AttributeMap{&r.orig.Attributes}
 }
 
-func (r *Resource) SetAttributes(v AttributesMap) {
-	r.attributes = v
-}
-
-func (r *Resource) toOrig() *otlpresource.Resource {
-	if r.attributes == nil {
-		return nil
-	}
-	attrs := make([]otlpcommon.AttributeKeyValue, len(r.attributes))
-	wrappers := make([]*otlpcommon.AttributeKeyValue, len(r.attributes))
-	i := 0
-	for k, v := range r.attributes {
-		attrs[i] = *v.orig
-		attrs[i].Key = k
-		wrappers[i] = &attrs[i]
-		i++
-	}
-	return &otlpresource.Resource{Attributes: wrappers}
+// SetAttributes repaces the AttributesMap associated with this Resource.
+func (r Resource) SetAttributes(v AttributeMap) {
+	r.orig.Attributes = *v.orig
 }

--- a/internal/data/trace.go
+++ b/internal/data/trace.go
@@ -53,21 +53,21 @@ func (td TraceData) ResourceSpans() []*ResourceSpans {
 type ResourceSpans struct {
 	// The resource for the spans in this message.
 	// If this field is not set then no resource info is known.
-	resource *Resource
+	resource Resource
 
 	// A list of Spans that originate from a resource.
 	ils []*InstrumentationLibrarySpans
 }
 
-func NewResourceSpans(resource *Resource, ils []*InstrumentationLibrarySpans) *ResourceSpans {
+func NewResourceSpans(resource Resource, ils []*InstrumentationLibrarySpans) *ResourceSpans {
 	return &ResourceSpans{resource, ils}
 }
 
-func (m *ResourceSpans) Resource() *Resource {
+func (m *ResourceSpans) Resource() Resource {
 	return m.resource
 }
 
-func (m *ResourceSpans) SetResource(r *Resource) {
+func (m *ResourceSpans) SetResource(r Resource) {
 	m.resource = r
 }
 

--- a/internal/data/trace_test.go
+++ b/internal/data/trace_test.go
@@ -27,14 +27,14 @@ func TestSpanCount(t *testing.T) {
 
 	td = TraceData{
 		resourceSpans: []*ResourceSpans{
-			NewResourceSpans(nil, []*InstrumentationLibrarySpans{}),
+			NewResourceSpans(NewResource(), []*InstrumentationLibrarySpans{}),
 		},
 	}
 	assert.EqualValues(t, 0, td.SpanCount())
 
 	td = TraceData{
 		resourceSpans: []*ResourceSpans{
-			NewResourceSpans(nil, []*InstrumentationLibrarySpans{
+			NewResourceSpans(NewResource(), []*InstrumentationLibrarySpans{
 				NewInstrumentationLibrarySpans(NewInstrumentationLibrary(), []*Span{})}),
 		},
 	}
@@ -42,7 +42,7 @@ func TestSpanCount(t *testing.T) {
 
 	td = TraceData{
 		resourceSpans: []*ResourceSpans{
-			NewResourceSpans(nil, []*InstrumentationLibrarySpans{
+			NewResourceSpans(NewResource(), []*InstrumentationLibrarySpans{
 				NewInstrumentationLibrarySpans(NewInstrumentationLibrary(), []*Span{nil})}),
 		},
 	}
@@ -50,11 +50,11 @@ func TestSpanCount(t *testing.T) {
 
 	td = TraceData{
 		resourceSpans: []*ResourceSpans{
-			NewResourceSpans(nil, []*InstrumentationLibrarySpans{
+			NewResourceSpans(NewResource(), []*InstrumentationLibrarySpans{
 				NewInstrumentationLibrarySpans(NewInstrumentationLibrary(), []*Span{nil})}),
-			NewResourceSpans(nil, []*InstrumentationLibrarySpans{
+			NewResourceSpans(NewResource(), []*InstrumentationLibrarySpans{
 				NewInstrumentationLibrarySpans(NewInstrumentationLibrary(), []*Span{})}),
-			NewResourceSpans(nil, []*InstrumentationLibrarySpans{
+			NewResourceSpans(NewResource(), []*InstrumentationLibrarySpans{
 				NewInstrumentationLibrarySpans(NewInstrumentationLibrary(), []*Span{nil, nil, nil, nil, nil})}),
 		},
 	}

--- a/translator/internaldata/metrics_to_oc_test.go
+++ b/translator/internaldata/metrics_to_oc_test.go
@@ -78,7 +78,7 @@ func TestResourceMetricsToMetricsData(t *testing.T) {
 		"str1":                                  data.NewAttributeValueString("text"),
 		"int2":                                  data.NewAttributeValueInt(123),
 	}
-	resource.SetAttributes(attrs)
+	resource.SetAttributes(data.NewAttributeMap(attrs))
 
 	ilm := data.NewInstrumentationLibraryMetricsSlice(1)
 	ilm[0].SetMetrics(metrics)

--- a/translator/internaldata/resource_to_oc.go
+++ b/translator/internaldata/resource_to_oc.go
@@ -27,21 +27,22 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector/translator/conventions"
 )
 
-func internalResourceToOC(resource *data.Resource) (*occommon.Node, *ocresource.Resource) {
+func internalResourceToOC(resource data.Resource) (*occommon.Node, *ocresource.Resource) {
 	attrs := resource.Attributes()
 
 	ocNode := occommon.Node{}
 	ocResource := ocresource.Resource{}
 
-	if len(attrs) == 0 {
+	if attrs.Len() == 0 {
 		return &ocNode, &ocResource
 	}
 
-	labels := make(map[string]string, len(attrs))
-	for key, attributeValue := range attrs {
-		val := attributeValueToString(attributeValue)
+	labels := make(map[string]string, attrs.Len())
+	for i := 0; i < attrs.Len(); i++ {
+		akv := attrs.GetAttribute(i)
+		val := attributeValueToString(akv.Value())
 
-		switch key {
+		switch akv.Key() {
 		case conventions.OCAttributeResourceType:
 			ocResource.Type = val
 		case conventions.AttributeServiceName:
@@ -95,7 +96,7 @@ func internalResourceToOC(resource *data.Resource) (*occommon.Node, *ocresource.
 			}
 		default:
 			// Not a special attribute, put it into resource labels
-			labels[key] = val
+			labels[akv.Key()] = val
 		}
 	}
 	ocResource.Labels = labels

--- a/translator/internaldata/resource_to_oc_test.go
+++ b/translator/internaldata/resource_to_oc_test.go
@@ -48,11 +48,11 @@ func TestResourceToOC(t *testing.T) {
 		"str1":                                  data.NewAttributeValueString("text"),
 		"int2":                                  data.NewAttributeValueInt(123),
 	}
-	resource.SetAttributes(attrs)
+	resource.SetAttributes(data.NewAttributeMap(attrs))
 
 	tests := []struct {
 		name       string
-		resource   *data.Resource
+		resource   data.Resource
 		ocNode     *occommon.Node
 		ocResource *ocresource.Resource
 	}{

--- a/translator/internaldata/traces_to_oc_test.go
+++ b/translator/internaldata/traces_to_oc_test.go
@@ -183,11 +183,7 @@ func TestInternalToOC(t *testing.T) {
 	assert.NoError(t, err)
 
 	resource := data.NewResource()
-	resource.SetAttributes(
-		data.AttributesMap{
-			"label1": data.NewAttributeValueString("value1"),
-		},
-	)
+	resource.SetAttributes(data.NewAttributeMap(map[string]data.AttributeValue{"label1": data.NewAttributeValueString("value1")}))
 
 	span1 := data.NewSpan()
 	span1.SetName("operationB")
@@ -233,9 +229,8 @@ func TestInternalToOC(t *testing.T) {
 	span3.SetEndTime(internal.TimestampToUnixnano(timestampP))
 	span3ResourceType := "resource2"
 	span3Resource := data.NewResource()
-	span3Resource.SetAttributes(data.AttributesMap{
-		conventions.OCAttributeResourceType: data.NewAttributeValueString(span3ResourceType),
-	})
+	span3Resource.SetAttributes(data.NewAttributeMap(map[string]data.AttributeValue{
+		conventions.OCAttributeResourceType: data.NewAttributeValueString(span3ResourceType)}))
 	resourceSpans3 := data.NewResourceSpans(span3Resource, []*data.InstrumentationLibrarySpans{
 		data.NewInstrumentationLibrarySpans(data.NewInstrumentationLibrary(), []*data.Span{span3})})
 

--- a/translator/opencensus/oc_to_internal.go
+++ b/translator/opencensus/oc_to_internal.go
@@ -354,7 +354,7 @@ func ocMessageEventToInternalAttrs(msgEvent *octrace.Span_TimeEvent_MessageEvent
 		0)
 }
 
-func ocNodeResourceToInternal(ocNode *occommon.Node, ocResource *ocresource.Resource) *data.Resource {
+func ocNodeResourceToInternal(ocNode *occommon.Node, ocResource *ocresource.Resource) data.Resource {
 	resource := data.NewResource()
 
 	// Number of special fields in the Node. See the code below that deals with special fields.
@@ -430,7 +430,9 @@ func ocNodeResourceToInternal(ocNode *occommon.Node, ocResource *ocresource.Reso
 	}
 
 	if len(attrs) != 0 {
-		resource.SetAttributes(attrs)
+		// TODO: Re-evaluate if we want to construct a map first, or we can construct directly
+		// a slice of AttributeKeyValue.
+		resource.SetAttributes(data.NewAttributeMap(attrs))
 	}
 
 	return resource

--- a/translator/opencensus/oc_to_internal_test.go
+++ b/translator/opencensus/oc_to_internal_test.go
@@ -70,7 +70,7 @@ func TestOcNodeResourceToInternal(t *testing.T) {
 	}
 	resource = ocNodeResourceToInternal(ocNode, ocResource)
 
-	expectedAttrs := data.AttributesMap{
+	expectedAttrs := data.NewAttributeMap(map[string]data.AttributeValue{
 		conventions.AttributeHostHostname:       data.NewAttributeValueString("host1"),
 		conventions.OCAttributeProcessID:        data.NewAttributeValueInt(123),
 		conventions.OCAttributeProcessStartTime: data.NewAttributeValueString("2020-02-11T20:26:00Z"),
@@ -81,17 +81,17 @@ func TestOcNodeResourceToInternal(t *testing.T) {
 		"node-attr":                             data.NewAttributeValueString("val1"),
 		conventions.OCAttributeResourceType:     data.NewAttributeValueString("good-resource"),
 		"resource-attr":                         data.NewAttributeValueString("val2"),
-	}
+	})
 
-	assert.EqualValues(t, expectedAttrs, resource.Attributes())
+	assert.EqualValues(t, expectedAttrs.Sort(), resource.Attributes().Sort())
 
 	// Make sure hard-coded fields override same-name values in Attributes.
 	// To do that add Attributes with same-name.
-	for k := range expectedAttrs {
+	for i := 0; i < expectedAttrs.Len(); i++ {
 		// Set all except "attr1" which is not a hard-coded field to some bogus values.
 
-		if strings.Index(k, "-attr") < 0 {
-			ocNode.Attributes[k] = "this will be overridden 1"
+		if strings.Index(expectedAttrs.GetAttribute(i).Key(), "-attr") < 0 {
+			ocNode.Attributes[expectedAttrs.GetAttribute(i).Key()] = "this will be overridden 1"
 		}
 	}
 	ocResource.Labels[conventions.OCAttributeResourceType] = "this will be overridden 2"
@@ -100,7 +100,7 @@ func TestOcNodeResourceToInternal(t *testing.T) {
 	resource = ocNodeResourceToInternal(ocNode, ocResource)
 
 	// And verify that same-name attributes were ignored.
-	assert.EqualValues(t, expectedAttrs, resource.Attributes())
+	assert.EqualValues(t, expectedAttrs.Sort(), resource.Attributes().Sort())
 }
 
 func TestOcTraceStateToInternal(t *testing.T) {
@@ -339,8 +339,7 @@ func TestOcToInternal(t *testing.T) {
 
 	internalResource := data.NewResource()
 	internalResource.SetAttributes(
-		map[string]data.AttributeValue{"nodeattr": data.NewAttributeValueString("attrval123")},
-	)
+		data.NewAttributeMap(map[string]data.AttributeValue{"nodeattr": data.NewAttributeValueString("attrval123")}))
 
 	tests := []struct {
 		name string


### PR DESCRIPTION
This PR plugs the new AttributeMap only into the Resource, but we can see a very nice benefit from this in the metrics benchmarks:

Before:
```
go test -benchmem -bench=. -run=notests ./internal/data/...
goos: darwin
goarch: amd64
pkg: github.com/open-telemetry/opentelemetry-collector/internal/data
BenchmarkOtlpToFromInternal_PassThrough-16                              318627304                3.66 ns/op            0 B/op          0 allocs/op
BenchmarkOtlpToFromInternal_Int64Points_MutateOneLabel-16                2147724               551 ns/op             688 B/op         13 allocs/op
BenchmarkOtlpToFromInternal_DoublePoints_MutateOneLabel-16               2170123               554 ns/op             688 B/op         13 allocs/op
BenchmarkOtlpToFromInternal_HistogramPoints_MutateOneLabel-16            1902834               638 ns/op             768 B/op         14 allocs/op
BenchmarkOtlpToFromInternal_SummaryPoints_MutateOneLabel-16              1880725               639 ns/op             768 B/op         14 allocs/op
PASS
ok      github.com/open-telemetry/opentelemetry-collector/internal/data 11.143s
```

After:
```
go test -benchmem -bench=. -run=notests ./internal/data/...
goos: darwin
goarch: amd64
pkg: github.com/open-telemetry/opentelemetry-collector/internal/data
BenchmarkOtlpToFromInternal_PassThrough-16                              1000000000               0.256 ns/op           0 B/op          0 allocs/op
BenchmarkOtlpToFromInternal_Int64Points_MutateOneLabel-16                4681989               252 ns/op             240 B/op          7 allocs/op
BenchmarkOtlpToFromInternal_DoublePoints_MutateOneLabel-16               4736796               249 ns/op             240 B/op          7 allocs/op
BenchmarkOtlpToFromInternal_HistogramPoints_MutateOneLabel-16            3651998               331 ns/op             320 B/op          8 allocs/op
BenchmarkOtlpToFromInternal_SummaryPoints_MutateOneLabel-16              3555200               336 ns/op             320 B/op          8 allocs/op
PASS
ok      github.com/open-telemetry/opentelemetry-collector/internal/data 7.523s
```