### PR TITLE
Add StringMap and use it instead of LablesMap

### DIFF
--- a/internal/data/common_test.go
+++ b/internal/data/common_test.go
@@ -16,6 +16,7 @@ package data
 
 import (
 	"math/rand"
+	"strconv"
 	"testing"
 
 	otlp "github.com/open-telemetry/opentelemetry-proto/gen/go/common/v1"
@@ -65,5 +66,95 @@ func TestNewAttributeValueSlice(t *testing.T) {
 	assert.EqualValues(t, n, len(events))
 	for event := range events {
 		assert.NotNil(t, event)
+	}
+}
+
+func TestNilStringMap(t *testing.T) {
+	val, exist := NewStringMap(nil).Get("test_key")
+	assert.EqualValues(t, false, exist)
+	assert.EqualValues(t, StringKeyValue{nil}, val)
+	insertMap := NewStringMap(nil)
+	insertMap.Insert("key", "value")
+	assert.EqualValues(t, NewStringMap(map[string]string{"key": "value"}), insertMap)
+	updateMap := NewStringMap(nil)
+	updateMap.Update("key", "value")
+	assert.EqualValues(t, NewStringMap(nil), updateMap)
+	upsertMap := NewStringMap(nil)
+	upsertMap.Upsert("key", "value")
+	assert.EqualValues(t, NewStringMap(map[string]string{"key": "value"}), upsertMap)
+	deleteMap := NewStringMap(nil)
+	assert.EqualValues(t, false, deleteMap.Delete("key"))
+	assert.EqualValues(t, NewStringMap(nil), deleteMap)
+	assert.EqualValues(t, 0, NewStringMap(nil).Len())
+	assert.EqualValues(t, NewStringMap(nil), NewStringMap(nil).Sort())
+}
+
+func TestStringMap(t *testing.T) {
+	origMap := map[string]string{"k0": "v0", "k1": "v1", "k2": "v2"}
+	sm := NewStringMap(origMap)
+	assert.EqualValues(t, 3, sm.Len())
+
+	val, exist := sm.Get("k2")
+	assert.EqualValues(t, true, exist)
+	assert.EqualValues(t, NewStringKeyValue("k2", "v2"), val)
+
+	val, exist = sm.Get("k3")
+	assert.EqualValues(t, false, exist)
+	assert.EqualValues(t, StringKeyValue{nil}, val)
+
+	sm.Insert("k1", "v1")
+	assert.EqualValues(t, NewStringMap(origMap).Sort(), sm.Sort())
+	sm.Insert("k3", "v3")
+	assert.EqualValues(t, 4, sm.Len())
+	assert.EqualValues(t, NewStringMap(map[string]string{"k0": "v0", "k1": "v1", "k2": "v2", "k3": "v3"}).Sort(), sm.Sort())
+	assert.EqualValues(t, true, sm.Delete("k3"))
+	assert.EqualValues(t, 3, sm.Len())
+	assert.EqualValues(t, NewStringMap(origMap).Sort(), sm.Sort())
+
+	sm.Update("k3", "v3")
+	assert.EqualValues(t, 3, sm.Len())
+	assert.EqualValues(t, NewStringMap(origMap).Sort(), sm.Sort())
+	sm.Update("k2", "v3")
+	assert.EqualValues(t, 3, sm.Len())
+	assert.EqualValues(t, NewStringMap(map[string]string{"k0": "v0", "k1": "v1", "k2": "v3"}).Sort(), sm.Sort())
+	sm.Update("k2", "v2")
+	assert.EqualValues(t, 3, sm.Len())
+	assert.EqualValues(t, NewStringMap(origMap).Sort(), sm.Sort())
+
+	sm.Upsert("k3", "v3")
+	assert.EqualValues(t, 4, sm.Len())
+	assert.EqualValues(t, NewStringMap(map[string]string{"k0": "v0", "k1": "v1", "k2": "v2", "k3": "v3"}).Sort(), sm.Sort())
+	sm.Upsert("k1", "v5")
+	assert.EqualValues(t, 4, sm.Len())
+	assert.EqualValues(t, NewStringMap(map[string]string{"k0": "v0", "k1": "v5", "k2": "v2", "k3": "v3"}).Sort(), sm.Sort())
+	sm.Upsert("k1", "v1")
+	assert.EqualValues(t, 4, sm.Len())
+	assert.EqualValues(t, NewStringMap(map[string]string{"k0": "v0", "k1": "v1", "k2": "v2", "k3": "v3"}).Sort(), sm.Sort())
+	assert.EqualValues(t, true, sm.Delete("k3"))
+	assert.EqualValues(t, 3, sm.Len())
+	assert.EqualValues(t, NewStringMap(origMap).Sort(), sm.Sort())
+
+	assert.EqualValues(t, false, sm.Delete("k3"))
+	assert.EqualValues(t, 3, sm.Len())
+	assert.EqualValues(t, NewStringMap(origMap).Sort(), sm.Sort())
+
+	assert.EqualValues(t, true, sm.Delete("k0"))
+	assert.EqualValues(t, 2, sm.Len())
+	assert.EqualValues(t, NewStringMap(map[string]string{"k1": "v1", "k2": "v2"}).Sort(), sm.Sort())
+	assert.EqualValues(t, true, sm.Delete("k2"))
+	assert.EqualValues(t, 1, sm.Len())
+	assert.EqualValues(t, NewStringMap(map[string]string{"k1": "v1"}).Sort(), sm.Sort())
+	assert.EqualValues(t, true, sm.Delete("k1"))
+	assert.EqualValues(t, 0, sm.Len())
+}
+
+func TestStringMapIteration(t *testing.T) {
+	sm := NewStringMap(map[string]string{"k0": "v0", "k1": "v1", "k2": "v2"})
+	assert.EqualValues(t, 3, sm.Len())
+	sm.Sort()
+	for i := 0; i < sm.Len(); i++ {
+		skv := sm.GetStringKeyValue(i)
+		assert.EqualValues(t, "k"+strconv.Itoa(i), skv.Key())
+		assert.EqualValues(t, "v"+strconv.Itoa(i), skv.Value())
 	}
 }

--- a/internal/data/metric_test.go
+++ b/internal/data/metric_test.go
@@ -159,24 +159,26 @@ func TestOtlpToInternalReadOnly(t *testing.T) {
 	assert.EqualValues(t, newResource(generateTestResource()), resourceMetric.Resource())
 	metrics := resourceMetric.InstrumentationLibraryMetrics()[0].Metrics()
 	assert.EqualValues(t, 4, len(metrics))
+	// Check int64 metric
 	metricInt := metrics[0]
 	assert.EqualValues(t, "my_metric_int", metricInt.MetricDescriptor().Name())
 	assert.EqualValues(t, "My metric", metricInt.MetricDescriptor().Description())
 	assert.EqualValues(t, "ms", metricInt.MetricDescriptor().Unit())
 	assert.EqualValues(t, MetricTypeCounterInt64, metricInt.MetricDescriptor().Type())
-	assert.EqualValues(t, LabelsMap{}, metricInt.MetricDescriptor().LabelsMap())
-	// Check int64 points
+	assert.EqualValues(t, NewStringMap(map[string]string{}), metricInt.MetricDescriptor().LabelsMap())
 	int64DataPoints := metricInt.Int64DataPoints()
 	assert.EqualValues(t, 2, len(int64DataPoints))
+	// First point
 	assert.EqualValues(t, startTime, int64DataPoints[0].StartTime())
 	assert.EqualValues(t, endTime, int64DataPoints[0].Timestamp())
 	assert.EqualValues(t, 123, int64DataPoints[0].Value())
-	assert.EqualValues(t, LabelsMap{"key0": "value0"}, int64DataPoints[0].LabelsMap())
+	assert.EqualValues(t, NewStringMap(map[string]string{"key0": "value0"}), int64DataPoints[0].LabelsMap())
+	// Second point
 	assert.EqualValues(t, startTime, int64DataPoints[1].StartTime())
 	assert.EqualValues(t, endTime, int64DataPoints[1].Timestamp())
 	assert.EqualValues(t, 456, int64DataPoints[1].Value())
-	assert.EqualValues(t, LabelsMap{"key1": "value1"}, int64DataPoints[1].LabelsMap())
-	// Check double points
+	assert.EqualValues(t, NewStringMap(map[string]string{"key1": "value1"}), int64DataPoints[1].LabelsMap())
+	// Check double metric
 	metricDouble := metrics[1]
 	assert.EqualValues(t, "my_metric_double", metricDouble.MetricDescriptor().Name())
 	assert.EqualValues(t, "My metric", metricDouble.MetricDescriptor().Description())
@@ -184,14 +186,16 @@ func TestOtlpToInternalReadOnly(t *testing.T) {
 	assert.EqualValues(t, MetricTypeCounterDouble, metricDouble.MetricDescriptor().Type())
 	doubleDataPoints := metricDouble.DoubleDataPoints()
 	assert.EqualValues(t, 2, len(doubleDataPoints))
+	// First point
 	assert.EqualValues(t, startTime, doubleDataPoints[0].StartTime())
 	assert.EqualValues(t, endTime, doubleDataPoints[0].Timestamp())
 	assert.EqualValues(t, 123.1, doubleDataPoints[0].Value())
-	assert.EqualValues(t, LabelsMap{"key0": "value0"}, doubleDataPoints[0].LabelsMap())
+	assert.EqualValues(t, NewStringMap(map[string]string{"key0": "value0"}), doubleDataPoints[0].LabelsMap())
+	// Second point
 	assert.EqualValues(t, startTime, doubleDataPoints[1].StartTime())
 	assert.EqualValues(t, endTime, doubleDataPoints[1].Timestamp())
 	assert.EqualValues(t, 456.1, doubleDataPoints[1].Value())
-	assert.EqualValues(t, LabelsMap{"key1": "value1"}, doubleDataPoints[1].LabelsMap())
+	assert.EqualValues(t, NewStringMap(map[string]string{"key1": "value1"}), doubleDataPoints[1].LabelsMap())
 	// Check histogram metric
 	metricHistogram := metrics[2]
 	assert.EqualValues(t, "my_metric_histogram", metricHistogram.MetricDescriptor().Name())
@@ -200,21 +204,23 @@ func TestOtlpToInternalReadOnly(t *testing.T) {
 	assert.EqualValues(t, MetricTypeCumulativeHistogram, metricHistogram.MetricDescriptor().Type())
 	histogramDataPoints := metricHistogram.HistogramDataPoints()
 	assert.EqualValues(t, 2, len(histogramDataPoints))
+	// First point
 	assert.EqualValues(t, startTime, histogramDataPoints[0].StartTime())
 	assert.EqualValues(t, endTime, histogramDataPoints[0].Timestamp())
 	assert.EqualValues(t, []float64{1, 2}, histogramDataPoints[0].ExplicitBounds())
-	assert.EqualValues(t, LabelsMap{"key0": "value0"}, histogramDataPoints[0].LabelsMap())
+	assert.EqualValues(t, NewStringMap(map[string]string{"key0": "value0"}), histogramDataPoints[0].LabelsMap())
 	assert.EqualValues(t, 3, len(histogramDataPoints[0].Buckets()))
 	assert.EqualValues(t, 10, histogramDataPoints[0].Buckets()[0].Count())
 	assert.EqualValues(t, 15, histogramDataPoints[0].Buckets()[1].Count())
 	assert.EqualValues(t, 1.5, histogramDataPoints[0].Buckets()[1].Exemplar().Value())
 	assert.EqualValues(t, startTime, histogramDataPoints[0].Buckets()[1].Exemplar().Timestamp())
-	assert.EqualValues(t, LabelsMap{"key_a1": "value_a1"}, histogramDataPoints[0].Buckets()[1].Exemplar().Attachments())
+	assert.EqualValues(t, NewStringMap(map[string]string{"key_a1": "value_a1"}), histogramDataPoints[0].Buckets()[1].Exemplar().Attachments())
 	assert.EqualValues(t, 1, histogramDataPoints[0].Buckets()[2].Count())
+	// Second point
 	assert.EqualValues(t, startTime, histogramDataPoints[1].StartTime())
 	assert.EqualValues(t, endTime, histogramDataPoints[1].Timestamp())
 	assert.EqualValues(t, []float64{1}, histogramDataPoints[1].ExplicitBounds())
-	assert.EqualValues(t, LabelsMap{"key1": "value1"}, histogramDataPoints[1].LabelsMap())
+	assert.EqualValues(t, NewStringMap(map[string]string{"key1": "value1"}), histogramDataPoints[1].LabelsMap())
 	assert.EqualValues(t, 2, len(histogramDataPoints[1].Buckets()))
 	assert.EqualValues(t, 10, histogramDataPoints[1].Buckets()[0].Count())
 	assert.EqualValues(t, 1, histogramDataPoints[1].Buckets()[1].Count())
@@ -229,7 +235,7 @@ func TestOtlpToInternalReadOnly(t *testing.T) {
 	// First point
 	assert.EqualValues(t, startTime, summaryDataPoints[0].StartTime())
 	assert.EqualValues(t, endTime, summaryDataPoints[0].Timestamp())
-	assert.EqualValues(t, LabelsMap{"key0": "value0"}, summaryDataPoints[0].LabelsMap())
+	assert.EqualValues(t, NewStringMap(map[string]string{"key0": "value0"}), summaryDataPoints[0].LabelsMap())
 	assert.EqualValues(t, 2, len(summaryDataPoints[0].ValueAtPercentiles()))
 	assert.EqualValues(t, 0.0, summaryDataPoints[0].ValueAtPercentiles()[0].Percentile())
 	assert.EqualValues(t, 1.23, summaryDataPoints[0].ValueAtPercentiles()[0].Value())
@@ -238,7 +244,7 @@ func TestOtlpToInternalReadOnly(t *testing.T) {
 	// Second point
 	assert.EqualValues(t, startTime, summaryDataPoints[1].StartTime())
 	assert.EqualValues(t, endTime, summaryDataPoints[1].Timestamp())
-	assert.EqualValues(t, LabelsMap{"key1": "value1"}, summaryDataPoints[1].LabelsMap())
+	assert.EqualValues(t, NewStringMap(map[string]string{"key1": "value1"}), summaryDataPoints[1].LabelsMap())
 	assert.EqualValues(t, 2, len(summaryDataPoints[1].ValueAtPercentiles()))
 	assert.EqualValues(t, 0.5, summaryDataPoints[1].ValueAtPercentiles()[0].Percentile())
 	assert.EqualValues(t, 4.56, summaryDataPoints[1].ValueAtPercentiles()[0].Value())
@@ -273,7 +279,7 @@ func TestOtlpToFromInternalReadOnly(t *testing.T) {
 }
 
 func TestOtlpToFromInternalIntPointsMutating(t *testing.T) {
-	newLabels := LabelsMap{"k": "v"}
+	newLabels := NewStringMap(map[string]string{"k": "v"})
 
 	metricData := MetricDataFromOtlp([]*otlpmetrics.ResourceMetrics{
 		{
@@ -357,7 +363,7 @@ func TestOtlpToFromInternalIntPointsMutating(t *testing.T) {
 }
 
 func TestOtlpToFromInternalDoublePointsMutating(t *testing.T) {
-	newLabels := LabelsMap{"k": "v"}
+	newLabels := NewStringMap(map[string]string{"k": "v"})
 
 	metricData := MetricDataFromOtlp([]*otlpmetrics.ResourceMetrics{
 		{
@@ -441,7 +447,7 @@ func TestOtlpToFromInternalDoublePointsMutating(t *testing.T) {
 }
 
 func TestOtlpToFromInternalHistogramPointsMutating(t *testing.T) {
-	newLabels := LabelsMap{"k": "v"}
+	newLabels := NewStringMap(map[string]string{"k": "v"})
 
 	metricData := MetricDataFromOtlp([]*otlpmetrics.ResourceMetrics{
 		{
@@ -557,7 +563,7 @@ func TestOtlpToFromInternalHistogramPointsMutating(t *testing.T) {
 }
 
 func TestOtlpToFromInternalSummaryPointsMutating(t *testing.T) {
-	newLabels := LabelsMap{"k": "v"}
+	newLabels := NewStringMap(map[string]string{"k": "v"})
 	metricData := MetricDataFromOtlp([]*otlpmetrics.ResourceMetrics{
 		{
 			Resource: generateTestResource(),
@@ -685,7 +691,7 @@ func BenchmarkOtlpToFromInternal_Int64Points_MutateOneLabel(b *testing.B) {
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		md := MetricDataFromOtlp(resourceMetricsList)
-		md.ResourceMetrics()[0].InstrumentationLibraryMetrics()[0].Metrics()[0].Int64DataPoints()[0].LabelsMap()["key0"] = "value0"
+		md.ResourceMetrics()[0].InstrumentationLibraryMetrics()[0].Metrics()[0].Int64DataPoints()[0].LabelsMap().Upsert("key0", "value0")
 		MetricDataToOtlp(md)
 	}
 }
@@ -706,7 +712,7 @@ func BenchmarkOtlpToFromInternal_DoublePoints_MutateOneLabel(b *testing.B) {
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		md := MetricDataFromOtlp(resourceMetricsList)
-		md.ResourceMetrics()[0].InstrumentationLibraryMetrics()[0].Metrics()[0].DoubleDataPoints()[0].LabelsMap()["key0"] = "value0"
+		md.ResourceMetrics()[0].InstrumentationLibraryMetrics()[0].Metrics()[0].DoubleDataPoints()[0].LabelsMap().Upsert("key0", "value0")
 		MetricDataToOtlp(md)
 	}
 }
@@ -727,7 +733,7 @@ func BenchmarkOtlpToFromInternal_HistogramPoints_MutateOneLabel(b *testing.B) {
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		md := MetricDataFromOtlp(resourceMetricsList)
-		md.ResourceMetrics()[0].InstrumentationLibraryMetrics()[0].Metrics()[0].HistogramDataPoints()[0].LabelsMap()["key0"] = "value0"
+		md.ResourceMetrics()[0].InstrumentationLibraryMetrics()[0].Metrics()[0].HistogramDataPoints()[0].LabelsMap().Upsert("key0", "value0")
 		MetricDataToOtlp(md)
 	}
 }
@@ -748,7 +754,7 @@ func BenchmarkOtlpToFromInternal_SummaryPoints_MutateOneLabel(b *testing.B) {
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		md := MetricDataFromOtlp(resourceMetricsList)
-		md.ResourceMetrics()[0].InstrumentationLibraryMetrics()[0].Metrics()[0].SummaryDataPoints()[0].LabelsMap()["key0"] = "value0"
+		md.ResourceMetrics()[0].InstrumentationLibraryMetrics()[0].Metrics()[0].SummaryDataPoints()[0].LabelsMap().Upsert("key0", "value0")
 		MetricDataToOtlp(md)
 	}
 }

--- a/translator/internaldata/metrics_to_oc_test.go
+++ b/translator/internaldata/metrics_to_oc_test.go
@@ -46,21 +46,21 @@ func TestResourceMetricsToMetricsData(t *testing.T) {
 	metrics[0].SetMetricDescriptor(metricDescriptor)
 
 	int64DataPoints := data.NewInt64DataPointSlice(2)
-	int64DataPoints[0].SetLabelsMap(data.LabelsMap{"key1": "value1"})
+	int64DataPoints[0].SetLabelsMap(data.NewStringMap(map[string]string{"key1": "value1"}))
 	int64DataPoints[0].SetStartTime(ts1)
 	int64DataPoints[0].SetTimestamp(ts2)
 	int64DataPoints[0].SetValue(123)
-	int64DataPoints[1].SetLabelsMap(data.LabelsMap{"key2": "value2"})
+	int64DataPoints[1].SetLabelsMap(data.NewStringMap(map[string]string{"key2": "value2"}))
 	int64DataPoints[1].SetStartTime(ts1)
 	int64DataPoints[1].SetTimestamp(ts2)
 	int64DataPoints[1].SetValue(456)
 	metrics[0].SetInt64DataPoints(int64DataPoints)
 
 	doubleDataPoints := data.NewDoubleDataPointSlice(1)
-	doubleDataPoints[0].SetLabelsMap(data.LabelsMap{
+	doubleDataPoints[0].SetLabelsMap(data.NewStringMap(map[string]string{
 		"key1": "double-value1",
 		"key3": "double-value3",
-	})
+	}))
 	doubleDataPoints[0].SetStartTime(ts1)
 	doubleDataPoints[0].SetTimestamp(ts2)
 	doubleDataPoints[0].SetValue(1.23)


### PR DESCRIPTION
This PR plugs the new StringMap that is used in the Metrics, and we can see a very nice benefit from this in the metrics benchmarks:

Before:
```
go test -benchmem -bench=. -run=notests ./internal/data/...
goos: darwin
goarch: amd64
pkg: github.com/open-telemetry/opentelemetry-collector/internal/data
BenchmarkOtlpToFromInternal_PassThrough-16                              317034267                3.64 ns/op            0 B/op          0 allocs/op
BenchmarkOtlpToFromInternal_Int64Points_MutateOneLabel-16                1399080               849 ns/op            1088 B/op         16 allocs/op
BenchmarkOtlpToFromInternal_DoublePoints_MutateOneLabel-16               1414124               846 ns/op            1088 B/op         16 allocs/op
BenchmarkOtlpToFromInternal_HistogramPoints_MutateOneLabel-16            1383159               862 ns/op            1152 B/op         16 allocs/op
BenchmarkOtlpToFromInternal_SummaryPoints_MutateOneLabel-16              1377898               935 ns/op            1152 B/op         16 allocs/op
PASS
ok      github.com/open-telemetry/opentelemetry-collector/internal/data 10.045s
```

After:
```
go test -benchmem -bench=. -run=notests ./internal/data/...
goos: darwin
goarch: amd64
pkg: github.com/open-telemetry/opentelemetry-collector/internal/data
BenchmarkOtlpToFromInternal_PassThrough-16                              318627304                3.66 ns/op            0 B/op          0 allocs/op
BenchmarkOtlpToFromInternal_Int64Points_MutateOneLabel-16                2147724               551 ns/op             688 B/op         13 allocs/op
BenchmarkOtlpToFromInternal_DoublePoints_MutateOneLabel-16               2170123               554 ns/op             688 B/op         13 allocs/op
BenchmarkOtlpToFromInternal_HistogramPoints_MutateOneLabel-16            1902834               638 ns/op             768 B/op         14 allocs/op
BenchmarkOtlpToFromInternal_SummaryPoints_MutateOneLabel-16              1880725               639 ns/op             768 B/op         14 allocs/op
PASS
ok      github.com/open-telemetry/opentelemetry-collector/internal/data 11.143s
```