### PR TITLE
Improve OC metrics observability and return errors to clients

### DIFF
--- a/receiver/opencensusreceiver/ocmetrics/opencensus.go
+++ b/receiver/opencensusreceiver/ocmetrics/opencensus.go
@@ -21,7 +21,6 @@ import (
 
 	commonpb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
 	agentmetricspb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/metrics/v1"
-	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
 	resourcepb "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
 
 	"github.com/open-telemetry/opentelemetry-collector/consumer"
@@ -53,14 +52,15 @@ var _ agentmetricspb.MetricsServiceServer = (*Receiver)(nil)
 var errMetricsExportProtocolViolation = errors.New("protocol violation: Export's first message must have a Node")
 
 const (
-	receiverTagValue  = "oc_metrics"
-	receiverTransport = "grpc" // TODO: transport is being hard coded for now, investigate if info is available on context.
+	receiverTagValue   = "oc_metrics"
+	receiverTransport  = "grpc" // TODO: transport is being hard coded for now, investigate if info is available on context.
+	receiverDataFormat = "protobuf"
 )
 
 // Export is the gRPC method that receives streamed metrics from
 // OpenCensus-metricproto compatible libraries/applications.
 func (ocr *Receiver) Export(mes agentmetricspb.MetricsService_ExportServer) error {
-	receiverCtx := obsreport.ReceiverContext(
+	longLivedRPCCtx := obsreport.ReceiverContext(
 		mes.Context(), ocr.instanceName, receiverTransport, receiverTagValue)
 
 	// Retrieve the first message. It MUST have a non-nil Node.
@@ -78,18 +78,14 @@ func (ocr *Receiver) Export(mes agentmetricspb.MetricsService_ExportServer) erro
 	var resource *resourcepb.Resource
 	// Now that we've got the first message with a Node, we can start to receive streamed up metrics.
 	for {
-		// If a Node has been sent from downstream, save and use it.
-		if recv.Node != nil {
-			lastNonNilNode = recv.Node
+		lastNonNilNode, resource, err = ocr.processReceivedMsg(
+			longLivedRPCCtx,
+			lastNonNilNode,
+			resource,
+			recv)
+		if err != nil {
+			return nil
 		}
-
-		// TODO(songya): differentiate between unset and nil resource. See
-		// https://github.com/census-instrumentation/opencensus-proto/issues/146.
-		if recv.Resource != nil {
-			resource = recv.Resource
-		}
-
-		ocr.processReceivedMetrics(receiverCtx, lastNonNilNode, resource, recv.Metrics)
 
 		recv, err = mes.Recv()
 		if err != nil {
@@ -103,14 +99,34 @@ func (ocr *Receiver) Export(mes agentmetricspb.MetricsService_ExportServer) erro
 	}
 }
 
-func (ocr *Receiver) processReceivedMetrics(longLivedRPCCtx context.Context, ni *commonpb.Node, resource *resourcepb.Resource, metrics []*metricspb.Metric) {
-	if len(metrics) > 0 {
-		md := consumerdata.MetricsData{Node: ni, Metrics: metrics, Resource: resource}
-		ocr.sendToNextConsumer(longLivedRPCCtx, md)
+func (ocr *Receiver) processReceivedMsg(
+	longLivedRPCCtx context.Context,
+	lastNonNilNode *commonpb.Node,
+	resource *resourcepb.Resource,
+	recv *agentmetricspb.ExportMetricsServiceRequest,
+) (*commonpb.Node, *resourcepb.Resource, error) {
+	// If a Node has been sent from downstream, save and use it.
+	if recv.Node != nil {
+		lastNonNilNode = recv.Node
 	}
+
+	// TODO(songya): differentiate between unset and nil resource. See
+	// https://github.com/census-instrumentation/opencensus-proto/issues/146.
+	if recv.Resource != nil {
+		resource = recv.Resource
+	}
+
+	md := consumerdata.MetricsData{
+		Node:     lastNonNilNode,
+		Resource: resource,
+		Metrics:  recv.Metrics,
+	}
+
+	err := ocr.sendToNextConsumer(longLivedRPCCtx, md)
+	return lastNonNilNode, resource, err
 }
 
-func (ocr *Receiver) sendToNextConsumer(longLivedRPCCtx context.Context, md consumerdata.MetricsData) {
+func (ocr *Receiver) sendToNextConsumer(longLivedRPCCtx context.Context, md consumerdata.MetricsData) error {
 	ctx := obsreport.StartMetricsReceiveOp(
 		longLivedRPCCtx,
 		ocr.instanceName,
@@ -127,12 +143,17 @@ func (ocr *Receiver) sendToNextConsumer(longLivedRPCCtx context.Context, md cons
 		}
 	}
 
-	consumerErr := ocr.nextConsumer.ConsumeMetricsData(ctx, md)
+	var consumerErr error
+	if len(md.Metrics) > 0 {
+		consumerErr = ocr.nextConsumer.ConsumeMetricsData(ctx, md)
+	}
 
 	obsreport.EndMetricsReceiveOp(
 		ctx,
-		"protobuf",
+		receiverDataFormat,
 		numPoints,
 		numTimeSeries,
 		consumerErr)
+
+	return consumerErr
 }

--- a/receiver/opencensusreceiver/ocmetrics/opencensus.go
+++ b/receiver/opencensusreceiver/ocmetrics/opencensus.go
@@ -84,7 +84,7 @@ func (ocr *Receiver) Export(mes agentmetricspb.MetricsService_ExportServer) erro
 			resource,
 			recv)
 		if err != nil {
-			return nil
+			return err
 		}
 
 		recv, err = mes.Recv()

--- a/receiver/opencensusreceiver/octrace/opencensus.go
+++ b/receiver/opencensusreceiver/octrace/opencensus.go
@@ -136,7 +136,7 @@ func (ocr *Receiver) processReceivedMsg(
 		resource = recv.Resource
 	}
 
-	td := &consumerdata.TraceData{
+	td := consumerdata.TraceData{
 		Node:         lastNonNilNode,
 		Resource:     resource,
 		Spans:        recv.Spans,
@@ -147,7 +147,7 @@ func (ocr *Receiver) processReceivedMsg(
 	return lastNonNilNode, resource, err
 }
 
-func (ocr *Receiver) sendToNextConsumer(longLivedRPCCtx context.Context, tracedata *consumerdata.TraceData) error {
+func (ocr *Receiver) sendToNextConsumer(longLivedRPCCtx context.Context, tracedata consumerdata.TraceData) error {
 	ctx := obsreport.StartTraceDataReceiveOp(
 		longLivedRPCCtx,
 		ocr.instanceName,
@@ -156,9 +156,8 @@ func (ocr *Receiver) sendToNextConsumer(longLivedRPCCtx context.Context, traceda
 
 	var err error
 	numSpans := len(tracedata.Spans)
-	if tracedata != nil && len(tracedata.Spans) != 0 {
-		numSpans = len(tracedata.Spans)
-		err = ocr.nextConsumer.ConsumeTraceData(ctx, *tracedata)
+	if numSpans != 0 {
+		err = ocr.nextConsumer.ConsumeTraceData(ctx, tracedata)
 	}
 
 	obsreport.EndTraceDataReceiveOp(ctx, receiverDataFormat, numSpans, err)

--- a/receiver/opencensusreceiver/octrace/opencensus.go
+++ b/receiver/opencensusreceiver/octrace/opencensus.go
@@ -102,9 +102,7 @@ func (ocr *Receiver) Export(tes agenttracepb.TraceService_ExportServer) error {
 			resource,
 			recv)
 		if err != nil {
-			// Metrics and z-pages record data loss but there is no back pressure.
-			// However, cause the stream to be closed.
-			return nil
+			return err
 		}
 
 		recv, err = tes.Recv()


### PR DESCRIPTION
**Description:** 
- Per review [comment](https://github.com/open-telemetry/opentelemetry-collector/pull/577/files#r393999653) ensuring that observability is recorded if OC metrics receives empty data;
- Noticed that OC metrics were not returning errors to clients, changed it to be in line with OC trace and return an error (terminating the stream);
- Changed OC trace to capture client info from the context when the stream is started instead for each received message.
