### PR TITLE
Upgrade the project to use go 1.14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache:
 go_import_path: github.com/open-telemetry/opentelemetry-collector
 
 go:
-  - 1.13.x
+  - 1.14.x
 
 env:
   global:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,7 +73,7 @@ section of general project contributing guide.
 Working with the project sources requires the following tools:
 
 1. [git](https://git-scm.com/)
-2. [go](https://golang.org/) (version 1.12.5 and up)
+2. [go](https://golang.org/) (version 1.14 and up)
 3. [make](https://www.gnu.org/software/make/)
 4. [docker](https://www.docker.com/)
 
@@ -116,7 +116,7 @@ $ git push fork feature
 
 ## General Notes
 
-This project uses Go 1.12.5 and Travis for CI.
+This project uses Go 1.14.* and Travis for CI.
 
 Travis CI uses the Makefile with the default target, it is recommended to
 run it before submitting your PR. It runs `gofmt -s` (simplify) and `golint`.

--- a/exporter/jaeger/jaegerthrifthttpexporter/factory_test.go
+++ b/exporter/jaeger/jaegerthrifthttpexporter/factory_test.go
@@ -98,7 +98,7 @@ func TestFactory_CreateTraceExporterFails(t *testing.T) {
 					NameVal: typeStr,
 				},
 			},
-			errorMessage: "\"jaeger_thrift_http\" config requires a valid \"url\": parse : empty url",
+			errorMessage: "\"jaeger_thrift_http\" config requires a valid \"url\": parse \"\": empty url",
 		},
 		{
 			name: "invalid_url",
@@ -109,7 +109,7 @@ func TestFactory_CreateTraceExporterFails(t *testing.T) {
 				},
 				URL: ".localhost:123",
 			},
-			errorMessage: "\"jaeger_thrift_http\" config requires a valid \"url\": parse .localhost:123: invalid URI for request",
+			errorMessage: "\"jaeger_thrift_http\" config requires a valid \"url\": parse \".localhost:123\": invalid URI for request",
 		},
 		{
 			name: "negative_duration",

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector
 
-go 1.13
+go 1.14
 
 require (
 	contrib.go.opencensus.io/exporter/jaeger v0.1.1-0.20190430175949-e8b55949d948


### PR DESCRIPTION
There are some runtime improvements like defer functions that we would like to benefit from. See  https://golang.org/doc/go1.14#runtime for more details.

There are some small code changes caused by a change in how go formats errors.