### PR TITLE
Add HasX for all the cases where message can miss

### DIFF
--- a/internal/data/common.go
+++ b/internal/data/common.go
@@ -436,7 +436,7 @@ type InstrumentationLibrary struct {
 
 // NewInstrumentationLibrary creates a new InstrumentationLibrary.
 func NewInstrumentationLibrary() InstrumentationLibrary {
-	return InstrumentationLibrary{}
+	return InstrumentationLibrary{&otlpcommon.InstrumentationLibrary{}}
 }
 
 func newInstrumentationLibrary(orig *otlpcommon.InstrumentationLibrary) InstrumentationLibrary {

--- a/internal/data/metric.go
+++ b/internal/data/metric.go
@@ -15,6 +15,7 @@
 package data
 
 import (
+	otlpcommon "github.com/open-telemetry/opentelemetry-proto/gen/go/common/v1"
 	otlpmetrics "github.com/open-telemetry/opentelemetry-proto/gen/go/metrics/v1"
 	otlpresource "github.com/open-telemetry/opentelemetry-proto/gen/go/resource/v1"
 )
@@ -144,9 +145,14 @@ func newResourceMetricsSliceFromOrig(origs []*otlpmetrics.ResourceMetrics) []Res
 
 func (rm ResourceMetrics) Resource() Resource {
 	if rm.orig.Resource == nil {
+		// No Resource available, initialize one to make all operations available.
 		rm.orig.Resource = &otlpresource.Resource{}
 	}
 	return newResource(rm.orig.Resource)
+}
+
+func (rm ResourceMetrics) HasResource() bool {
+	return rm.orig.Resource != nil
 }
 
 func (rm ResourceMetrics) SetResource(r Resource) {
@@ -238,7 +244,15 @@ func newInstrumentationLibraryMetricsSliceFromOrig(origs []*otlpmetrics.Instrume
 }
 
 func (ilm InstrumentationLibraryMetrics) InstrumentationLibrary() InstrumentationLibrary {
+	if ilm.orig.InstrumentationLibrary == nil {
+		// No InstrumentationLibrary available, initialize one to make all operations available.
+		ilm.orig.InstrumentationLibrary = &otlpcommon.InstrumentationLibrary{}
+	}
 	return newInstrumentationLibrary(ilm.orig.InstrumentationLibrary)
+}
+
+func (ilm InstrumentationLibraryMetrics) HasInstrumentationLibrary() bool {
+	return ilm.orig.InstrumentationLibrary != nil
 }
 
 func (ilm InstrumentationLibraryMetrics) SetInstrumentationLibrary(il InstrumentationLibrary) {
@@ -330,6 +344,10 @@ func (m Metric) MetricDescriptor() MetricDescriptor {
 		m.orig.MetricDescriptor = &otlpmetrics.MetricDescriptor{}
 	}
 	return newMetricDescriptor(m.orig.MetricDescriptor)
+}
+
+func (m Metric) HasMetricDescriptor() bool {
+	return m.orig.MetricDescriptor != nil
 }
 
 func (m Metric) SetMetricDescriptor(md MetricDescriptor) {
@@ -823,6 +841,10 @@ func (hb HistogramBucket) Exemplar() HistogramBucketExemplar {
 		hb.orig.Exemplar = &otlpmetrics.HistogramDataPoint_Bucket_Exemplar{}
 	}
 	return newHistogramBucketExemplar(hb.orig.Exemplar)
+}
+
+func (hb HistogramBucket) HasExemplar() bool {
+	return hb.orig.Exemplar != nil
 }
 
 func (hb HistogramBucket) SetExemplar(v HistogramBucketExemplar) {

--- a/internal/data/metric_test.go
+++ b/internal/data/metric_test.go
@@ -250,8 +250,48 @@ func TestOtlpToInternalReadOnly(t *testing.T) {
 	assert.EqualValues(t, 4.56, summaryDataPoints[1].ValueAtPercentiles()[0].Value())
 	assert.EqualValues(t, 0.9, summaryDataPoints[1].ValueAtPercentiles()[1].Percentile())
 	assert.EqualValues(t, 7.89, summaryDataPoints[1].ValueAtPercentiles()[1].Value())
-
 }
+
+func TestHasMessages(t *testing.T) {
+	metricData := MetricDataFromOtlp([]*otlpmetrics.ResourceMetrics{
+		{
+			InstrumentationLibraryMetrics: []*otlpmetrics.InstrumentationLibraryMetrics{
+				{
+					Metrics: []*otlpmetrics.Metric{
+						{
+							HistogramDataPoints: []*otlpmetrics.HistogramDataPoint{
+								{
+									Buckets: []*otlpmetrics.HistogramDataPoint_Bucket{{}},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	rm := metricData.ResourceMetrics()[0]
+	assert.EqualValues(t, false, rm.HasResource())
+	assert.EqualValues(t, NewResource(), rm.Resource())
+	assert.EqualValues(t, true, rm.HasResource())
+
+	ilms := rm.InstrumentationLibraryMetrics()[0]
+	assert.EqualValues(t, false, ilms.HasInstrumentationLibrary())
+	assert.EqualValues(t, NewInstrumentationLibrary(), ilms.InstrumentationLibrary())
+	assert.EqualValues(t, true, ilms.HasInstrumentationLibrary())
+
+	m := ilms.Metrics()[0]
+	assert.EqualValues(t, false, m.HasMetricDescriptor())
+	assert.EqualValues(t, NewMetricDescriptor(), m.MetricDescriptor())
+	assert.EqualValues(t, true, m.HasMetricDescriptor())
+
+	hb := m.HistogramDataPoints()[0].Buckets()[0]
+	assert.EqualValues(t, false, hb.HasExemplar())
+	assert.EqualValues(t, NewHistogramBucketExemplar(), hb.Exemplar())
+	assert.EqualValues(t, true, hb.HasExemplar())
+}
+
 func TestOtlpToFromInternalReadOnly(t *testing.T) {
 	metricData := MetricDataFromOtlp([]*otlpmetrics.ResourceMetrics{
 		{


### PR DESCRIPTION
Open question: Should we not initialize the underlying orig when returning the object - see in tests that `HasMessage` will return true after `Message()` was called.