### PR TITLE
Change all metric data points to be automatically generated

### DIFF
--- a/internal/data/generated_metrics.go
+++ b/internal/data/generated_metrics.go
@@ -21,41 +21,254 @@ import (
 	otlpmetrics "github.com/open-telemetry/opentelemetry-proto/gen/go/metrics/v1"
 )
 
-// SummaryDataPointGeneratedSlice logically represents a slice of SummaryDataPoint.
+// Int64DataPoint is a single data point in a timeseries that describes the time-varying values of a int64 metric.
 //
 // This is a reference type, if passsed by value and callee modifies it the
 // caller will see the modification.
 //
-// Must use NewSummaryDataPointGeneratedSlice function to create new instances.
+// Must use NewInt64DataPoint function to create new instances.
 // Important: zero-initialized instance is not valid for use.
-type SummaryDataPointGeneratedSlice struct {
-	orig *[]*otlpmetrics.SummaryDataPoint
+type Int64DataPoint struct {
+	// Wrap OTLP otlpmetrics.Int64DataPoint.
+	orig *otlpmetrics.Int64DataPoint
 }
 
-// NewSummaryDataPointGeneratedSlice creates a SummaryDataPointGeneratedSlice with "len" empty elements.
+// NewInt64DataPoint creates a new Int64DataPoint.
+func NewInt64DataPoint() Int64DataPoint {
+	return Int64DataPoint{&otlpmetrics.Int64DataPoint{}}
+}
+
+func newInt64DataPoint(orig *otlpmetrics.Int64DataPoint) Int64DataPoint {
+	return Int64DataPoint{orig}
+}
+
+// LabelsMap returns the Labels associated with this Int64DataPoint.
+func (ms Int64DataPoint) LabelsMap() StringMap {
+	return newStringMap(&ms.orig.Labels)
+}
+
+// SetLabelsMap replaces the Labels associated with this Int64DataPoint.
+func (ms Int64DataPoint) SetLabelsMap(v StringMap) {
+	ms.orig.Labels = *v.orig
+}
+
+// StartTime returns the starttime associated with this Int64DataPoint.
+func (ms Int64DataPoint) StartTime() TimestampUnixNano {
+	return TimestampUnixNano(ms.orig.GetStartTimeUnixnano())
+}
+
+// SetStartTime replaces the starttime associated with this Int64DataPoint.
+func (ms Int64DataPoint) SetStartTime(v TimestampUnixNano) {
+	ms.orig.StartTimeUnixnano = uint64(v)
+}
+
+// Timestamp returns the timestamp associated with this Int64DataPoint.
+func (ms Int64DataPoint) Timestamp() TimestampUnixNano {
+	return TimestampUnixNano(ms.orig.GetTimestampUnixnano())
+}
+
+// SetTimestamp replaces the timestamp associated with this Int64DataPoint.
+func (ms Int64DataPoint) SetTimestamp(v TimestampUnixNano) {
+	ms.orig.TimestampUnixnano = uint64(v)
+}
+
+// Value returns the value associated with this Int64DataPoint.
+func (ms Int64DataPoint) Value() int64 {
+	return ms.orig.GetValue()
+}
+
+// SetValue replaces the value associated with this Int64DataPoint.
+func (ms Int64DataPoint) SetValue(v int64) {
+	ms.orig.Value = v
+}
+
+// DoubleDataPoint is a single data point in a timeseries that describes the time-varying value of a double metric.
 //
-// es := NewSummaryDataPointGeneratedSlice(4)
+// This is a reference type, if passsed by value and callee modifies it the
+// caller will see the modification.
+//
+// Must use NewDoubleDataPoint function to create new instances.
+// Important: zero-initialized instance is not valid for use.
+type DoubleDataPoint struct {
+	// Wrap OTLP otlpmetrics.DoubleDataPoint.
+	orig *otlpmetrics.DoubleDataPoint
+}
+
+// NewDoubleDataPoint creates a new DoubleDataPoint.
+func NewDoubleDataPoint() DoubleDataPoint {
+	return DoubleDataPoint{&otlpmetrics.DoubleDataPoint{}}
+}
+
+func newDoubleDataPoint(orig *otlpmetrics.DoubleDataPoint) DoubleDataPoint {
+	return DoubleDataPoint{orig}
+}
+
+// LabelsMap returns the Labels associated with this DoubleDataPoint.
+func (ms DoubleDataPoint) LabelsMap() StringMap {
+	return newStringMap(&ms.orig.Labels)
+}
+
+// SetLabelsMap replaces the Labels associated with this DoubleDataPoint.
+func (ms DoubleDataPoint) SetLabelsMap(v StringMap) {
+	ms.orig.Labels = *v.orig
+}
+
+// StartTime returns the starttime associated with this DoubleDataPoint.
+func (ms DoubleDataPoint) StartTime() TimestampUnixNano {
+	return TimestampUnixNano(ms.orig.GetStartTimeUnixnano())
+}
+
+// SetStartTime replaces the starttime associated with this DoubleDataPoint.
+func (ms DoubleDataPoint) SetStartTime(v TimestampUnixNano) {
+	ms.orig.StartTimeUnixnano = uint64(v)
+}
+
+// Timestamp returns the timestamp associated with this DoubleDataPoint.
+func (ms DoubleDataPoint) Timestamp() TimestampUnixNano {
+	return TimestampUnixNano(ms.orig.GetTimestampUnixnano())
+}
+
+// SetTimestamp replaces the timestamp associated with this DoubleDataPoint.
+func (ms DoubleDataPoint) SetTimestamp(v TimestampUnixNano) {
+	ms.orig.TimestampUnixnano = uint64(v)
+}
+
+// Value returns the value associated with this DoubleDataPoint.
+func (ms DoubleDataPoint) Value() float64 {
+	return ms.orig.GetValue()
+}
+
+// SetValue replaces the value associated with this DoubleDataPoint.
+func (ms DoubleDataPoint) SetValue(v float64) {
+	ms.orig.Value = v
+}
+
+// HistogramDataPoint is a single data point in a timeseries that describes the time-varying values of a Histogram.
+//
+// This is a reference type, if passsed by value and callee modifies it the
+// caller will see the modification.
+//
+// Must use NewHistogramDataPoint function to create new instances.
+// Important: zero-initialized instance is not valid for use.
+type HistogramDataPoint struct {
+	// Wrap OTLP otlpmetrics.HistogramDataPoint.
+	orig *otlpmetrics.HistogramDataPoint
+}
+
+// NewHistogramDataPoint creates a new HistogramDataPoint.
+func NewHistogramDataPoint() HistogramDataPoint {
+	return HistogramDataPoint{&otlpmetrics.HistogramDataPoint{}}
+}
+
+func newHistogramDataPoint(orig *otlpmetrics.HistogramDataPoint) HistogramDataPoint {
+	return HistogramDataPoint{orig}
+}
+
+// LabelsMap returns the Labels associated with this HistogramDataPoint.
+func (ms HistogramDataPoint) LabelsMap() StringMap {
+	return newStringMap(&ms.orig.Labels)
+}
+
+// SetLabelsMap replaces the Labels associated with this HistogramDataPoint.
+func (ms HistogramDataPoint) SetLabelsMap(v StringMap) {
+	ms.orig.Labels = *v.orig
+}
+
+// StartTime returns the starttime associated with this HistogramDataPoint.
+func (ms HistogramDataPoint) StartTime() TimestampUnixNano {
+	return TimestampUnixNano(ms.orig.GetStartTimeUnixnano())
+}
+
+// SetStartTime replaces the starttime associated with this HistogramDataPoint.
+func (ms HistogramDataPoint) SetStartTime(v TimestampUnixNano) {
+	ms.orig.StartTimeUnixnano = uint64(v)
+}
+
+// Timestamp returns the timestamp associated with this HistogramDataPoint.
+func (ms HistogramDataPoint) Timestamp() TimestampUnixNano {
+	return TimestampUnixNano(ms.orig.GetTimestampUnixnano())
+}
+
+// SetTimestamp replaces the timestamp associated with this HistogramDataPoint.
+func (ms HistogramDataPoint) SetTimestamp(v TimestampUnixNano) {
+	ms.orig.TimestampUnixnano = uint64(v)
+}
+
+// Count returns the count associated with this HistogramDataPoint.
+func (ms HistogramDataPoint) Count() uint64 {
+	return ms.orig.GetCount()
+}
+
+// SetCount replaces the count associated with this HistogramDataPoint.
+func (ms HistogramDataPoint) SetCount(v uint64) {
+	ms.orig.Count = v
+}
+
+// Sum returns the sum associated with this HistogramDataPoint.
+func (ms HistogramDataPoint) Sum() float64 {
+	return ms.orig.GetSum()
+}
+
+// SetSum replaces the sum associated with this HistogramDataPoint.
+func (ms HistogramDataPoint) SetSum(v float64) {
+	ms.orig.Sum = v
+}
+
+// Buckets returns the Buckets associated with this HistogramDataPoint.
+func (ms HistogramDataPoint) Buckets() HistogramBucketSlice {
+	return newHistogramBucketSlice(&ms.orig.Buckets)
+}
+
+// SetBuckets replaces the Buckets associated with this HistogramDataPoint.
+func (ms HistogramDataPoint) SetBuckets(v HistogramBucketSlice) {
+	ms.orig.Buckets = *v.orig
+}
+
+// ExplicitBounds returns the explicitbounds associated with this HistogramDataPoint.
+func (ms HistogramDataPoint) ExplicitBounds() []float64 {
+	return ms.orig.GetExplicitBounds()
+}
+
+// SetExplicitBounds replaces the explicitbounds associated with this HistogramDataPoint.
+func (ms HistogramDataPoint) SetExplicitBounds(v []float64) {
+	ms.orig.ExplicitBounds = v
+}
+
+// HistogramBucketSlice logically represents a slice of HistogramBucket.
+//
+// This is a reference type, if passsed by value and callee modifies it the
+// caller will see the modification.
+//
+// Must use NewHistogramBucketSlice function to create new instances.
+// Important: zero-initialized instance is not valid for use.
+type HistogramBucketSlice struct {
+	orig *[]*otlpmetrics.HistogramDataPoint_Bucket
+}
+
+// NewHistogramBucketSlice creates a HistogramBucketSlice with "len" empty elements.
+//
+// es := NewHistogramBucketSlice(4)
 // for i := 0; i < es.Len(); i++ {
 //     e := es.Get(i)
 //     // Here should set all the values for e.
 // }
-func NewSummaryDataPointGeneratedSlice(len int) SummaryDataPointGeneratedSlice {
+func NewHistogramBucketSlice(len int) HistogramBucketSlice {
 	// Slice for underlying orig.
-	origs := make([]otlpmetrics.SummaryDataPoint, len)
+	origs := make([]otlpmetrics.HistogramDataPoint_Bucket, len)
 	// Slice for wrappers.
-	wrappers := make([]*otlpmetrics.SummaryDataPoint, len)
+	wrappers := make([]*otlpmetrics.HistogramDataPoint_Bucket, len)
 	for i := range origs {
 		wrappers[i] = &origs[i]
 	}
-	return SummaryDataPointGeneratedSlice{&wrappers}
+	return HistogramBucketSlice{&wrappers}
 }
 
-func newSummaryDataPointGeneratedSlice(orig *[]*otlpmetrics.SummaryDataPoint) SummaryDataPointGeneratedSlice {
-	return SummaryDataPointGeneratedSlice{orig}
+func newHistogramBucketSlice(orig *[]*otlpmetrics.HistogramDataPoint_Bucket) HistogramBucketSlice {
+	return HistogramBucketSlice{orig}
 }
 
 // Len returns the number of elements in the slice.
-func (es SummaryDataPointGeneratedSlice) Len() int {
+func (es HistogramBucketSlice) Len() int {
 	return len(*es.orig)
 }
 
@@ -66,19 +279,116 @@ func (es SummaryDataPointGeneratedSlice) Len() int {
 //     e := es.Get(i)
 //     ... // Do something with the element
 // }
-func (es SummaryDataPointGeneratedSlice) Get(ix int) SummaryDataPoint {
-	return newSummaryDataPoint((*es.orig)[ix])
+func (es HistogramBucketSlice) Get(ix int) HistogramBucket {
+	return newHistogramBucket((*es.orig)[ix])
 }
 
 // Remove removes the element from the given index from the slice.
-func (es SummaryDataPointGeneratedSlice) Remove(ix int) {
+func (es HistogramBucketSlice) Remove(ix int) {
 	(*es.orig)[ix] = (*es.orig)[len(*es.orig)-1]
 	*es.orig = (*es.orig)[:len(*es.orig)-1]
 }
 
 // Resize resizes the slice. This operation is equivalent with slice[to:from].
-func (es SummaryDataPointGeneratedSlice) Resize(from, to int) {
+func (es HistogramBucketSlice) Resize(from, to int) {
 	*es.orig = (*es.orig)[from:to]
+}
+
+// HistogramBucket contains values for a histogram bucket.
+//
+// This is a reference type, if passsed by value and callee modifies it the
+// caller will see the modification.
+//
+// Must use NewHistogramBucket function to create new instances.
+// Important: zero-initialized instance is not valid for use.
+type HistogramBucket struct {
+	// Wrap OTLP otlpmetrics.HistogramDataPoint_Bucket.
+	orig *otlpmetrics.HistogramDataPoint_Bucket
+}
+
+// NewHistogramBucket creates a new HistogramBucket.
+func NewHistogramBucket() HistogramBucket {
+	return HistogramBucket{&otlpmetrics.HistogramDataPoint_Bucket{}}
+}
+
+func newHistogramBucket(orig *otlpmetrics.HistogramDataPoint_Bucket) HistogramBucket {
+	return HistogramBucket{orig}
+}
+
+// Count returns the count associated with this HistogramBucket.
+func (ms HistogramBucket) Count() uint64 {
+	return ms.orig.GetCount()
+}
+
+// SetCount replaces the count associated with this HistogramBucket.
+func (ms HistogramBucket) SetCount(v uint64) {
+	ms.orig.Count = v
+}
+
+// Exemplar returns the exemplar associated with this HistogramBucket.
+func (ms HistogramBucket) Exemplar() HistogramBucketExemplar {
+	if ms.orig.Exemplar == nil {
+		// No Exemplar available, initialize one to make all operations on HistogramBucketExemplar available.
+		ms.orig.Exemplar = &otlpmetrics.HistogramDataPoint_Bucket_Exemplar{}
+	}
+	return newHistogramBucketExemplar(ms.orig.Exemplar)
+}
+
+// SetExemplar replaces the exemplar associated with this HistogramBucket.
+func (ms HistogramBucket) SetExemplar(v HistogramBucketExemplar) {
+	ms.orig.Exemplar = v.orig
+}
+
+// HistogramBucketExemplar are example points that may be used to annotate aggregated Histogram values.
+// They are metadata that gives information about a particular value added to a Histogram bucket.
+//
+// This is a reference type, if passsed by value and callee modifies it the
+// caller will see the modification.
+//
+// Must use NewHistogramBucketExemplar function to create new instances.
+// Important: zero-initialized instance is not valid for use.
+type HistogramBucketExemplar struct {
+	// Wrap OTLP otlpmetrics.HistogramDataPoint_Bucket_Exemplar.
+	orig *otlpmetrics.HistogramDataPoint_Bucket_Exemplar
+}
+
+// NewHistogramBucketExemplar creates a new HistogramBucketExemplar.
+func NewHistogramBucketExemplar() HistogramBucketExemplar {
+	return HistogramBucketExemplar{&otlpmetrics.HistogramDataPoint_Bucket_Exemplar{}}
+}
+
+func newHistogramBucketExemplar(orig *otlpmetrics.HistogramDataPoint_Bucket_Exemplar) HistogramBucketExemplar {
+	return HistogramBucketExemplar{orig}
+}
+
+// Timestamp returns the timestamp associated with this HistogramBucketExemplar.
+func (ms HistogramBucketExemplar) Timestamp() TimestampUnixNano {
+	return TimestampUnixNano(ms.orig.GetTimestampUnixnano())
+}
+
+// SetTimestamp replaces the timestamp associated with this HistogramBucketExemplar.
+func (ms HistogramBucketExemplar) SetTimestamp(v TimestampUnixNano) {
+	ms.orig.TimestampUnixnano = uint64(v)
+}
+
+// Value returns the value associated with this HistogramBucketExemplar.
+func (ms HistogramBucketExemplar) Value() float64 {
+	return ms.orig.GetValue()
+}
+
+// SetValue replaces the value associated with this HistogramBucketExemplar.
+func (ms HistogramBucketExemplar) SetValue(v float64) {
+	ms.orig.Value = v
+}
+
+// Attachments returns the Attachments associated with this HistogramBucketExemplar.
+func (ms HistogramBucketExemplar) Attachments() StringMap {
+	return newStringMap(&ms.orig.Attachments)
+}
+
+// SetAttachments replaces the Attachments associated with this HistogramBucketExemplar.
+func (ms HistogramBucketExemplar) SetAttachments(v StringMap) {
+	ms.orig.Attachments = *v.orig
 }
 
 // SummaryDataPoint is a single data point in a timeseries that describes the time-varying values of a Summary metric.
@@ -100,6 +410,16 @@ func NewSummaryDataPoint() SummaryDataPoint {
 
 func newSummaryDataPoint(orig *otlpmetrics.SummaryDataPoint) SummaryDataPoint {
 	return SummaryDataPoint{orig}
+}
+
+// LabelsMap returns the Labels associated with this SummaryDataPoint.
+func (ms SummaryDataPoint) LabelsMap() StringMap {
+	return newStringMap(&ms.orig.Labels)
+}
+
+// SetLabelsMap replaces the Labels associated with this SummaryDataPoint.
+func (ms SummaryDataPoint) SetLabelsMap(v StringMap) {
+	ms.orig.Labels = *v.orig
 }
 
 // StartTime returns the starttime associated with this SummaryDataPoint.
@@ -150,16 +470,6 @@ func (ms SummaryDataPoint) ValueAtPercentiles() SummaryValueAtPercentileSlice {
 // SetValueAtPercentiles replaces the PercentileValues associated with this SummaryDataPoint.
 func (ms SummaryDataPoint) SetValueAtPercentiles(v SummaryValueAtPercentileSlice) {
 	ms.orig.PercentileValues = *v.orig
-}
-
-// LabelsMap returns the Labels associated with this SummaryDataPoint.
-func (ms SummaryDataPoint) LabelsMap() StringMap {
-	return newStringMap(&ms.orig.Labels)
-}
-
-// SetLabelsMap replaces the Labels associated with this SummaryDataPoint.
-func (ms SummaryDataPoint) SetLabelsMap(v StringMap) {
-	ms.orig.Labels = *v.orig
 }
 
 // SummaryValueAtPercentileSlice logically represents a slice of SummaryValueAtPercentile.
@@ -222,7 +532,7 @@ func (es SummaryValueAtPercentileSlice) Resize(from, to int) {
 	*es.orig = (*es.orig)[from:to]
 }
 
-// SummaryValueAtPercentile represents the value at a given percentile of a distribution..
+// SummaryValueAtPercentile represents the value at a given percentile of a distribution.
 //
 // This is a reference type, if passsed by value and callee modifies it the
 // caller will see the modification.

--- a/internal/data/metric.go
+++ b/internal/data/metric.go
@@ -518,21 +518,6 @@ const (
 	MetricTypeSummary             MetricType = MetricType(otlpmetrics.MetricDescriptor_SUMMARY)
 )
 
-// Int64DataPoint is a single data point in a timeseries that describes the time-varying
-// values of a int64 metric.
-//
-// Must use NewInt64DataPoint* functions to create new instances.
-// Important: zero-initialized instance is not valid for use.
-type Int64DataPoint struct {
-	// Wrap OTLP Int64DataPoint.
-	orig *otlpmetrics.Int64DataPoint
-}
-
-// NewInt64DataPoint creates a new Int64DataPoint
-func NewInt64DataPoint() Int64DataPoint {
-	return Int64DataPoint{&otlpmetrics.Int64DataPoint{}}
-}
-
 // NewInt64DataPointSlice creates a slice of Int64DataPoint that are correctly initialized.
 func NewInt64DataPointSlice(len int) []Int64DataPoint {
 	// Slice for underlying orig.
@@ -552,53 +537,6 @@ func newInt64DataPointSliceFromOrig(origs []*otlpmetrics.Int64DataPoint) []Int64
 		wrappers[i].orig = origs[i]
 	}
 	return wrappers
-}
-
-func (dp Int64DataPoint) LabelsMap() StringMap {
-	return newStringMap(&dp.orig.Labels)
-}
-
-func (dp Int64DataPoint) SetLabelsMap(sm StringMap) {
-	dp.orig.Labels = *sm.orig
-}
-
-func (dp Int64DataPoint) StartTime() TimestampUnixNano {
-	return TimestampUnixNano(dp.orig.StartTimeUnixnano)
-}
-
-func (dp Int64DataPoint) SetStartTime(v TimestampUnixNano) {
-	dp.orig.StartTimeUnixnano = uint64(v)
-}
-
-func (dp Int64DataPoint) Timestamp() TimestampUnixNano {
-	return TimestampUnixNano(dp.orig.TimestampUnixnano)
-}
-
-func (dp Int64DataPoint) SetTimestamp(v TimestampUnixNano) {
-	dp.orig.TimestampUnixnano = uint64(v)
-}
-
-func (dp Int64DataPoint) Value() int64 {
-	return dp.orig.Value
-}
-
-func (dp Int64DataPoint) SetValue(v int64) {
-	dp.orig.Value = v
-}
-
-// DoubleDataPoint is a single data point in a timeseries that describes the time-varying
-// value of a double metric.
-//
-// Must use NewDoubleDataPoint* functions to create new instances.
-// Important: zero-initialized instance is not valid for use.
-type DoubleDataPoint struct {
-	// Wrap OTLP DoubleDataPoint.
-	orig *otlpmetrics.DoubleDataPoint
-}
-
-// NewDoubleDataPoint creates a new DoubleDataPoint.
-func NewDoubleDataPoint() *DoubleDataPoint {
-	return &DoubleDataPoint{&otlpmetrics.DoubleDataPoint{}}
 }
 
 // NewDoubleDataPointSlice creates a slice of DoubleDataPoint that are correctly initialized.
@@ -622,258 +560,25 @@ func newDoubleDataPointSliceFormOrgig(origs []*otlpmetrics.DoubleDataPoint) []Do
 	return wrappers
 }
 
-func (dp DoubleDataPoint) LabelsMap() StringMap {
-	return newStringMap(&dp.orig.Labels)
-}
-
-func (dp DoubleDataPoint) SetLabelsMap(sm StringMap) {
-	dp.orig.Labels = *sm.orig
-}
-
-func (dp DoubleDataPoint) StartTime() TimestampUnixNano {
-	return TimestampUnixNano(dp.orig.StartTimeUnixnano)
-}
-
-func (dp DoubleDataPoint) SetStartTime(v TimestampUnixNano) {
-	dp.orig.StartTimeUnixnano = uint64(v)
-}
-
-func (dp DoubleDataPoint) Timestamp() TimestampUnixNano {
-	return TimestampUnixNano(dp.orig.TimestampUnixnano)
-}
-
-func (dp DoubleDataPoint) SetTimestamp(v TimestampUnixNano) {
-	dp.orig.TimestampUnixnano = uint64(v)
-}
-
-func (dp DoubleDataPoint) Value() float64 {
-	return dp.orig.Value
-}
-
-func (dp DoubleDataPoint) SetValue(v float64) {
-	dp.orig.Value = v
-}
-
-// HistogramDataPoint is a single data point in a timeseries that describes the time-varying
-// values of a Histogram.
-//
-// Must use NewHistogramDataPoint* functions to create new instances.
-// Important: zero-initialized instance is not valid for use.
-type HistogramDataPoint struct {
-	// Wrap OTLP HistogramDataPoint.
-	orig *otlpmetrics.HistogramDataPoint
-
-	// Override a few fields. These fields are the source of truth. Their counterparts
-	// stored in corresponding fields of "orig" are ignored.
-	pimpl *internalHistogramDataPoint
-}
-
-type internalHistogramDataPoint struct {
-	buckets []HistogramBucket
-	// True if the buckets slice was initialized.
-	initializedSlice bool
-}
-
-// NewHistogramDataPoint creates a new HistogramDataPoint.
-func NewHistogramDataPoint() HistogramDataPoint {
-	return HistogramDataPoint{&otlpmetrics.HistogramDataPoint{}, &internalHistogramDataPoint{}}
-}
-
 // NewHistogramDataPointSlice creates a slice of HistogramDataPoint that are correctly initialized.
 func NewHistogramDataPointSlice(len int) []HistogramDataPoint {
 	// Slice for underlying orig.
 	origs := make([]otlpmetrics.HistogramDataPoint, len)
-	// Slice for underlying pimpl.
-	internals := make([]internalHistogramDataPoint, len)
 	// Slice for wrappers.
 	wrappers := make([]HistogramDataPoint, len)
 	for i := range origs {
 		wrappers[i].orig = &origs[i]
-		wrappers[i].pimpl = &internals[i]
 	}
 	return wrappers
 }
 
 func newHistogramDataPointSliceFromOrig(origs []*otlpmetrics.HistogramDataPoint) []HistogramDataPoint {
-	// Slice for underlying pimpl.
-	pimpls := make([]internalHistogramDataPoint, len(origs))
 	// Slice for wrappers.
 	wrappers := make([]HistogramDataPoint, len(origs))
 	for i := range origs {
 		wrappers[i].orig = origs[i]
-		wrappers[i].pimpl = &pimpls[i]
 	}
 	return wrappers
-}
-
-func (dp HistogramDataPoint) LabelsMap() StringMap {
-	return newStringMap(&dp.orig.Labels)
-}
-
-func (dp HistogramDataPoint) SetLabelsMap(sm StringMap) {
-	dp.orig.Labels = *sm.orig
-}
-
-func (dp HistogramDataPoint) StartTime() TimestampUnixNano {
-	return TimestampUnixNano(dp.orig.StartTimeUnixnano)
-}
-
-func (dp HistogramDataPoint) SetStartTime(v TimestampUnixNano) {
-	dp.orig.StartTimeUnixnano = uint64(v)
-}
-
-func (dp HistogramDataPoint) Timestamp() TimestampUnixNano {
-	return TimestampUnixNano(dp.orig.TimestampUnixnano)
-}
-
-func (dp HistogramDataPoint) SetTimestamp(v TimestampUnixNano) {
-	dp.orig.TimestampUnixnano = uint64(v)
-}
-
-func (dp HistogramDataPoint) Count() uint64 {
-	return dp.orig.Count
-}
-
-func (dp HistogramDataPoint) SetCount(v uint64) {
-	dp.orig.Count = v
-}
-
-func (dp HistogramDataPoint) Sum() float64 {
-	return dp.orig.Sum
-}
-
-func (dp HistogramDataPoint) SetSum(v float64) {
-	dp.orig.Sum = v
-}
-
-func (dp HistogramDataPoint) Buckets() []HistogramBucket {
-	if !dp.pimpl.initializedSlice {
-		dp.pimpl.buckets = newHistogramBucketSliceFromOrig(dp.orig.Buckets)
-		dp.pimpl.initializedSlice = true
-	}
-	return dp.pimpl.buckets
-}
-
-func (dp HistogramDataPoint) SetBuckets(v []HistogramBucket) {
-	dp.pimpl.buckets = v
-	dp.pimpl.initializedSlice = true
-	if len(dp.pimpl.buckets) == 0 {
-		dp.orig.Buckets = nil
-		return
-	}
-
-	// TODO: reuse orig slice if capacity is enough.
-	// Reconstruct the slice because we don't know what elements were removed/added.
-	dp.orig.Buckets = make([]*otlpmetrics.HistogramDataPoint_Bucket, len(dp.pimpl.buckets))
-	for i := range dp.pimpl.buckets {
-		dp.orig.Buckets[i] = dp.pimpl.buckets[i].orig
-	}
-}
-
-func (dp HistogramDataPoint) ExplicitBounds() []float64 {
-	return dp.orig.ExplicitBounds
-}
-
-func (dp HistogramDataPoint) SetExplicitBounds(v []float64) {
-	dp.orig.ExplicitBounds = v
-}
-
-// HistogramBucket contains values for a histogram bucket.
-//
-// Must use NewHistogramBucket* functions to create new instances.
-// Important: zero-initialized instance is not valid for use.
-type HistogramBucket struct {
-	// Wrap OTLP HistogramDataPoint_Bucket.
-	orig *otlpmetrics.HistogramDataPoint_Bucket
-}
-
-// NewHistogramBucket creates a new HistogramBucket.
-func NewHistogramBucket() HistogramBucket {
-	return HistogramBucket{&otlpmetrics.HistogramDataPoint_Bucket{}}
-}
-
-// NewHistogramBucketSlice creates a slice of HistogramBucket that are correctly initialized.
-func NewHistogramBucketSlice(len int) []HistogramBucket {
-	// Slice for underlying orig.
-	origs := make([]otlpmetrics.HistogramDataPoint_Bucket, len)
-	// Slice for wrappers.
-	wrappers := make([]HistogramBucket, len)
-	for i := range origs {
-		wrappers[i].orig = &origs[i]
-	}
-	return wrappers
-}
-
-func newHistogramBucketSliceFromOrig(origs []*otlpmetrics.HistogramDataPoint_Bucket) []HistogramBucket {
-	// Slice for wrappers.
-	wrappers := make([]HistogramBucket, len(origs))
-	for i := range origs {
-		wrappers[i].orig = origs[i]
-	}
-	return wrappers
-}
-
-func (hb HistogramBucket) Count() uint64 {
-	return hb.orig.Count
-}
-
-func (hb HistogramBucket) SetCount(v uint64) {
-	hb.orig.Count = v
-}
-
-func (hb HistogramBucket) Exemplar() HistogramBucketExemplar {
-	if hb.orig.Exemplar == nil {
-		// No Exemplar available, initialize one to make all operations available.
-		hb.orig.Exemplar = &otlpmetrics.HistogramDataPoint_Bucket_Exemplar{}
-	}
-	return newHistogramBucketExemplar(hb.orig.Exemplar)
-}
-
-func (hb HistogramBucket) SetExemplar(v HistogramBucketExemplar) {
-	hb.orig.Exemplar = v.orig
-}
-
-// HistogramBucketExemplar are example points that may be used to annotate aggregated Histogram values.
-// They are metadata that gives information about a particular value added to a Histogram bucket.
-//
-// Must use NewHistogramBucketExemplar* functions to create new instances.
-// Important: zero-initialized instance is not valid for use.
-type HistogramBucketExemplar struct {
-	// Wrap OTLP HistogramDataPoint_Bucket_Exemplar.
-	orig *otlpmetrics.HistogramDataPoint_Bucket_Exemplar
-}
-
-// NewHistogramBucketExemplar creates a new HistogramBucketExemplar.
-func NewHistogramBucketExemplar() HistogramBucketExemplar {
-	return HistogramBucketExemplar{&otlpmetrics.HistogramDataPoint_Bucket_Exemplar{}}
-}
-
-func newHistogramBucketExemplar(orig *otlpmetrics.HistogramDataPoint_Bucket_Exemplar) HistogramBucketExemplar {
-	return HistogramBucketExemplar{orig}
-}
-
-func (hbe HistogramBucketExemplar) Value() float64 {
-	return hbe.orig.Value
-}
-
-func (hbe HistogramBucketExemplar) SetValue(v float64) {
-	hbe.orig.Value = v
-}
-
-func (hbe HistogramBucketExemplar) Timestamp() TimestampUnixNano {
-	return TimestampUnixNano(hbe.orig.TimestampUnixnano)
-}
-
-func (hbe HistogramBucketExemplar) SetTimestamp(v TimestampUnixNano) {
-	hbe.orig.TimestampUnixnano = uint64(v)
-}
-
-func (hbe HistogramBucketExemplar) Attachments() StringMap {
-	return newStringMap(&hbe.orig.Attachments)
-}
-
-func (hbe HistogramBucketExemplar) SetAttachments(sm StringMap) {
-	hbe.orig.Attachments = *sm.orig
 }
 
 // NewSummaryDataPointSlice creates a slice of SummaryDataPoint that are correctly initialized.

--- a/internal/data_generator/internal/base_fields.go
+++ b/internal/data_generator/internal/base_fields.go
@@ -31,16 +31,16 @@ func (ms ${structName}) Set${fieldName}(v ${returnType}) {
 
 const accessorMessageTemplate = `// ${fieldName} returns the ${lowerFieldName} associated with this ${structName}.
 func (ms ${structName}) ${fieldName}() ${returnType} {
-	if rm.orig.${originFieldName} == nil {
+	if ms.orig.${originFieldName} == nil {
 		// No ${originFieldName} available, initialize one to make all operations on ${returnType} available.
-		rm.orig.${originFieldName} = &${structOriginFullName}{}
+		ms.orig.${originFieldName} = &${structOriginFullName}{}
 	}
-	return new${returnType}(&ms.orig.${originFieldName})
+	return new${returnType}(ms.orig.${originFieldName})
 }
 
 // Set${fieldName} replaces the ${lowerFieldName} associated with this ${structName}.
 func (ms ${structName}) Set${fieldName}(v ${returnType}) {
-	ms.orig.${originFieldName} = *v.orig
+	ms.orig.${originFieldName} = v.orig
 }`
 
 const accessorPrimitiveTemplate = `// ${fieldName} returns the ${lowerFieldName} associated with this ${structName}.

--- a/internal/data_generator/internal/base_structs.go
+++ b/internal/data_generator/internal/base_structs.go
@@ -79,7 +79,7 @@ func (es ${structName}) Resize(from, to int) {
 	*es.orig = (*es.orig)[from:to]
 }`
 
-const messageTemplate = `// ${structName} ${description}.
+const messageTemplate = `${description}
 //
 // This is a reference type, if passsed by value and callee modifies it the
 // caller will see the modification.

--- a/internal/data_generator/internal/metrics_structs.go
+++ b/internal/data_generator/internal/metrics_structs.go
@@ -20,44 +20,142 @@ var metricsFile = &File{
 		`otlpmetrics "github.com/open-telemetry/opentelemetry-proto/gen/go/metrics/v1"`,
 	},
 	structs: []baseStruct{
-		summaryDataPointSlice,
+		int64DataPoint,
+		doubleDataPoint,
+		histogramDataPoint,
+		histogramBucketSlice,
+		histogramBucket,
+		histogramBucketExemplar,
 		summaryDataPoint,
 		summaryValueAtPercentileSlice,
 		summaryValueAtPercentile,
 	},
 }
 
-var summaryDataPointSlice = &sliceStruct{
-	structName: "SummaryDataPointGeneratedSlice",
-	element:    summaryDataPoint,
-}
-
-var summaryDataPoint = &messageStruct{
-	structName:     "SummaryDataPoint",
-	description:    "is a single data point in a timeseries that describes the time-varying values of a Summary metric",
-	originFullName: "otlpmetrics.SummaryDataPoint",
+var int64DataPoint = &messageStruct{
+	structName:     "Int64DataPoint",
+	description:    "// Int64DataPoint is a single data point in a timeseries that describes the time-varying values of a int64 metric.",
+	originFullName: "otlpmetrics.Int64DataPoint",
 	fields: []baseField{
-		startTimeFiled,
-		timestampFiled,
-		&primitiveField{
-			fieldMame:       "Count",
-			originFieldName: "Count",
-			returnType:      "uint64",
-		},
-		&primitiveField{
-			fieldMame:       "Sum",
-			originFieldName: "Sum",
-			returnType:      "float64",
-		},
-		&sliceField{
-			fieldMame:       "ValueAtPercentiles",
-			originFieldName: "PercentileValues",
-			returnSlice:     summaryValueAtPercentileSlice,
-		},
 		&sliceField{
 			fieldMame:       "LabelsMap",
 			originFieldName: "Labels",
 			returnSlice:     stringMap,
+		},
+		startTimeFiled,
+		timestampFiled,
+		&primitiveField{
+			fieldMame:       "Value",
+			originFieldName: "Value",
+			returnType:      "int64",
+		},
+	},
+}
+
+var doubleDataPoint = &messageStruct{
+	structName:     "DoubleDataPoint",
+	description:    "// DoubleDataPoint is a single data point in a timeseries that describes the time-varying value of a double metric.",
+	originFullName: "otlpmetrics.DoubleDataPoint",
+	fields: []baseField{
+		&sliceField{
+			fieldMame:       "LabelsMap",
+			originFieldName: "Labels",
+			returnSlice:     stringMap,
+		},
+		startTimeFiled,
+		timestampFiled,
+		&primitiveField{
+			fieldMame:       "Value",
+			originFieldName: "Value",
+			returnType:      "float64",
+		},
+	},
+}
+
+var histogramDataPoint = &messageStruct{
+	structName:     "HistogramDataPoint",
+	description:    "// HistogramDataPoint is a single data point in a timeseries that describes the time-varying values of a Histogram.",
+	originFullName: "otlpmetrics.HistogramDataPoint",
+	fields: []baseField{
+		&sliceField{
+			fieldMame:       "LabelsMap",
+			originFieldName: "Labels",
+			returnSlice:     stringMap,
+		},
+		startTimeFiled,
+		timestampFiled,
+		countField,
+		sumField,
+		&sliceField{
+			fieldMame:       "Buckets",
+			originFieldName: "Buckets",
+			returnSlice:     histogramBucketSlice,
+		},
+		&primitiveField{
+			fieldMame:       "ExplicitBounds",
+			originFieldName: "ExplicitBounds",
+			returnType:      "[]float64",
+		},
+	},
+}
+
+var histogramBucketSlice = &sliceStruct{
+	structName: "HistogramBucketSlice",
+	element:    histogramBucket,
+}
+
+var histogramBucket = &messageStruct{
+	structName:     "HistogramBucket",
+	description:    "// HistogramBucket contains values for a histogram bucket.",
+	originFullName: "otlpmetrics.HistogramDataPoint_Bucket",
+	fields: []baseField{
+		countField,
+		&messageField{
+			fieldMame:       "Exemplar",
+			originFieldName: "Exemplar",
+			returnMessage:   histogramBucketExemplar,
+		},
+	},
+}
+
+var histogramBucketExemplar = &messageStruct{
+	structName: "HistogramBucketExemplar",
+	description: "// HistogramBucketExemplar are example points that may be used to annotate aggregated Histogram values.\n" +
+		"// They are metadata that gives information about a particular value added to a Histogram bucket.",
+	originFullName: "otlpmetrics.HistogramDataPoint_Bucket_Exemplar",
+	fields: []baseField{
+		timestampFiled,
+		&primitiveField{
+			fieldMame:       "Value",
+			originFieldName: "Value",
+			returnType:      "float64",
+		},
+		&sliceField{
+			fieldMame:       "Attachments",
+			originFieldName: "Attachments",
+			returnSlice:     stringMap,
+		},
+	},
+}
+
+var summaryDataPoint = &messageStruct{
+	structName:     "SummaryDataPoint",
+	description:    "// SummaryDataPoint is a single data point in a timeseries that describes the time-varying values of a Summary metric.",
+	originFullName: "otlpmetrics.SummaryDataPoint",
+	fields: []baseField{
+		&sliceField{
+			fieldMame:       "LabelsMap",
+			originFieldName: "Labels",
+			returnSlice:     stringMap,
+		},
+		startTimeFiled,
+		timestampFiled,
+		countField,
+		sumField,
+		&sliceField{
+			fieldMame:       "ValueAtPercentiles",
+			originFieldName: "PercentileValues",
+			returnSlice:     summaryValueAtPercentileSlice,
 		},
 	},
 }
@@ -69,7 +167,7 @@ var summaryValueAtPercentileSlice = &sliceStruct{
 
 var summaryValueAtPercentile = &messageStruct{
 	structName:     "SummaryValueAtPercentile",
-	description:    "represents the value at a given percentile of a distribution.",
+	description:    "// SummaryValueAtPercentile represents the value at a given percentile of a distribution.",
 	originFullName: "otlpmetrics.SummaryDataPoint_ValueAtPercentile",
 	fields: []baseField{
 		&primitiveField{
@@ -83,6 +181,18 @@ var summaryValueAtPercentile = &messageStruct{
 			returnType:      "float64",
 		},
 	},
+}
+
+var countField = &primitiveField{
+	fieldMame:       "Count",
+	originFieldName: "Count",
+	returnType:      "uint64",
+}
+
+var sumField = &primitiveField{
+	fieldMame:       "Sum",
+	originFieldName: "Sum",
+	returnType:      "float64",
 }
 
 var startTimeFiled = &primitiveTypedField{

--- a/translator/internaldata/metrics_to_oc.go
+++ b/translator/internaldata/metrics_to_oc.go
@@ -259,13 +259,14 @@ func histogramExplicitBoundsToOC(bounds []float64) *ocmetrics.DistributionValue_
 	}
 }
 
-func histogramBucketsToOC(buckets []data.HistogramBucket) []*ocmetrics.DistributionValue_Bucket {
-	if len(buckets) == 0 {
+func histogramBucketsToOC(buckets data.HistogramBucketSlice) []*ocmetrics.DistributionValue_Bucket {
+	if buckets.Len() == 0 {
 		return nil
 	}
 
-	ocBuckets := make([]*ocmetrics.DistributionValue_Bucket, 0, len(buckets))
-	for _, bucket := range buckets {
+	ocBuckets := make([]*ocmetrics.DistributionValue_Bucket, 0, buckets.Len())
+	for i := 0; i < buckets.Len(); i++ {
+		bucket := buckets.Get(i)
 		ocBuckets = append(ocBuckets, &ocmetrics.DistributionValue_Bucket{
 			Count:    int64(bucket.Count()),
 			Exemplar: exemplarToOC(bucket.Exemplar()),


### PR DESCRIPTION
Before (#660):
```
go test -benchmem -bench=. -run=notests ./internal/data/...
goos: darwin
goarch: amd64
pkg: github.com/open-telemetry/opentelemetry-collector/internal/data
BenchmarkOtlpToFromInternal_PassThrough-16                              1000000000               0.256 ns/op           0 B/op          0 allocs/op
BenchmarkOtlpToFromInternal_Int64Points_MutateOneLabel-16                4681989               252 ns/op             240 B/op          7 allocs/op
BenchmarkOtlpToFromInternal_DoublePoints_MutateOneLabel-16               4736796               249 ns/op             240 B/op          7 allocs/op
BenchmarkOtlpToFromInternal_HistogramPoints_MutateOneLabel-16            3651998               331 ns/op             320 B/op          8 allocs/op
BenchmarkOtlpToFromInternal_SummaryPoints_MutateOneLabel-16              3555200               336 ns/op             320 B/op          8 allocs/op
PASS
ok      github.com/open-telemetry/opentelemetry-collector/internal/data 7.523s
```

After:
```
go test -benchmem -bench=. -run=notests ./internal/data/...                                                           
goos: darwin
goarch: amd64
pkg: github.com/open-telemetry/opentelemetry-collector/internal/data
BenchmarkOtlpToFromInternal_PassThrough-16                              1000000000               0.262 ns/op           0 B/op          0 allocs/op
BenchmarkOtlpToFromInternal_Int64Points_MutateOneLabel-16                4814449               249 ns/op             240 B/op          7 allocs/op
BenchmarkOtlpToFromInternal_DoublePoints_MutateOneLabel-16               4815667               253 ns/op             240 B/op          7 allocs/op
BenchmarkOtlpToFromInternal_HistogramPoints_MutateOneLabel-16            4795528               251 ns/op             240 B/op          7 allocs/op
BenchmarkOtlpToFromInternal_SummaryPoints_MutateOneLabel-16              4808486               249 ns/op             240 B/op          7 allocs/op
PASS
ok      github.com/open-telemetry/opentelemetry-collector/internal/data 6.415s
```