### PR TITLE
Fix some metric names in obsreport

### DIFF
--- a/obsreport/obsreport_exporter.go
+++ b/obsreport/obsreport_exporter.go
@@ -65,7 +65,7 @@ var (
 		"Number of metric points successfully sent to destination.",
 		stats.UnitDimensionless)
 	mExporterFailedToSendMetricPoints = stats.Int64(
-		exporterPrefix+RefusedMetricPointsKey,
+		exporterPrefix+FailedToSendMetricPointsKey,
 		"Number of metric points in failed attempts to send to destination.",
 		stats.UnitDimensionless)
 )

--- a/obsreport/obsreport_processor.go
+++ b/obsreport/obsreport_processor.go
@@ -83,8 +83,18 @@ func ProcessorMetricViews(configType string, legacyViews []*view.View) []*view.V
 	}
 	if useNew {
 		for _, legacyView := range legacyViews {
+			// Ignore any nil entry and views without measure or aggregation.
+			// These can't be registered but some code registering legacy views may
+			// ignore the errors.
+			if legacyView == nil || legacyView.Measure == nil || legacyView.Aggregation == nil {
+				continue
+			}
 			newView := *legacyView
-			newView.Name = BuildProcessorCustomMetricName(configType, legacyView.Name)
+			viewName := legacyView.Name
+			if viewName == "" {
+				viewName = legacyView.Measure.Name()
+			}
+			newView.Name = BuildProcessorCustomMetricName(configType, viewName)
 			allViews = append(allViews, &newView)
 		}
 	}


### PR DESCRIPTION
**Description:** 
- Fix export failed for metrics (changed the test to not use the metric itself, so the intended name is captured on the test).
- Fix creation of new processor metrics from legacy views.

**Testing:** 
- Hardcoded the desired metric names on the tests to avoid the tests ignoring mistakes on the metric definition. 
- Added a test to ensure that new metric views are handling views without explicit names.

**Documentation:** < Describe the documentation added.>