### PR TITLE
Enable OTLP exporter and add OTLP E2E tests

### DIFF
--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -23,6 +23,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector/exporter/jaeger/jaegerthrifthttpexporter"
 	"github.com/open-telemetry/opentelemetry-collector/exporter/loggingexporter"
 	"github.com/open-telemetry/opentelemetry-collector/exporter/opencensusexporter"
+	"github.com/open-telemetry/opentelemetry-collector/exporter/otlpexporter"
 	"github.com/open-telemetry/opentelemetry-collector/exporter/prometheusexporter"
 	"github.com/open-telemetry/opentelemetry-collector/exporter/zipkinexporter"
 	"github.com/open-telemetry/opentelemetry-collector/extension"
@@ -84,6 +85,7 @@ func Components() (
 		&jaegergrpcexporter.Factory{},
 		&jaegerthrifthttpexporter.Factory{},
 		&fileexporter.Factory{},
+		&otlpexporter.Factory{},
 	)
 	if err != nil {
 		errs = append(errs, err)

--- a/defaults/defaults_test.go
+++ b/defaults/defaults_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector/exporter/jaeger/jaegerthrifthttpexporter"
 	"github.com/open-telemetry/opentelemetry-collector/exporter/loggingexporter"
 	"github.com/open-telemetry/opentelemetry-collector/exporter/opencensusexporter"
+	"github.com/open-telemetry/opentelemetry-collector/exporter/otlpexporter"
 	"github.com/open-telemetry/opentelemetry-collector/exporter/prometheusexporter"
 	"github.com/open-telemetry/opentelemetry-collector/exporter/zipkinexporter"
 	"github.com/open-telemetry/opentelemetry-collector/extension"
@@ -82,6 +83,7 @@ func TestDefaultComponents(t *testing.T) {
 		"jaeger_grpc":        &jaegergrpcexporter.Factory{},
 		"jaeger_thrift_http": &jaegerthrifthttpexporter.Factory{},
 		"file":               &fileexporter.Factory{},
+		"otlp":               &otlpexporter.Factory{},
 	}
 
 	factories, err := Components()

--- a/testbed/go.sum
+++ b/testbed/go.sum
@@ -64,6 +64,7 @@ github.com/bmizerany/perks v0.0.0-20141205001514-d9a9656a3a4b h1:AP/Y7sqYicnjGDf
 github.com/bmizerany/perks v0.0.0-20141205001514-d9a9656a3a4b/go.mod h1:ac9efd0D1fsDb3EJvhqgXRbFx7bs2wqZ10HQPeU8U/Q=
 github.com/bombsimon/wsl v1.2.5 h1:9gTOkIwVtoDZywvX802SDHokeX4kW1cKnV8ZTVAPkRs=
 github.com/bombsimon/wsl v1.2.5/go.mod h1:43lEF/i0kpXbLCeDXL9LMT8c92HyBywXb0AsgMHYngM=
+github.com/cenkalti/backoff v0.0.0-20181003080854-62661b46c409 h1:Da6uN+CAo1Wf09Rz1U4i9QN8f0REjyNJ73BEwAq/paU=
 github.com/cenkalti/backoff v0.0.0-20181003080854-62661b46c409/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/census-instrumentation/opencensus-proto v0.2.1 h1:glEXhBS5PSLLv4IXzLA5yPRVX4bilULVyxxbrfOtDAk=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
@@ -265,8 +266,8 @@ github.com/golangci/revgrep v0.0.0-20180526074752-d9c87f5ffaf0 h1:HVfrLniijszjS1
 github.com/golangci/revgrep v0.0.0-20180526074752-d9c87f5ffaf0/go.mod h1:qOQCunEYvmd/TLamH+7LlVccLvUH5kZNhbCgTHoBbp4=
 github.com/golangci/unconvert v0.0.0-20180507085042-28b1c447d1f4 h1:zwtduBRr5SSWhqsYNgcuWO2kFlpdOZbP0+yRjmvPGys=
 github.com/golangci/unconvert v0.0.0-20180507085042-28b1c447d1f4/go.mod h1:Izgrg8RkN3rCIMLGE9CyYmU9pY2Jer6DgANEnZ/L/cQ=
-github.com/google/addlicense v0.0.0-20190510175307-22550fa7c1b0 h1:ydbHzabf84uucKri5fcfiqYxGg+rYgP/zQfLLN8lyP0=
-github.com/google/addlicense v0.0.0-20190510175307-22550fa7c1b0/go.mod h1:QtPG26W17m+OIQgE6gQ24gC1M6pUaMBAbFrTIDtwG/E=
+github.com/google/addlicense v0.0.0-20200301095109-7c013a14f2e2 h1:N/H6+jLLYNoskSbyRaph9ttbcaGEw4AWpAZw+1VqIGs=
+github.com/google/addlicense v0.0.0-20200301095109-7c013a14f2e2/go.mod h1:EMjYTRimagHs1FwlIqKyX3wAM0u3rA+McvlIIWmSamA=
 github.com/google/btree v0.0.0-20160524151835-7d79101e329e/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0 h1:0udJVsspx3VBr5FwtLhQQtuAsVc79tTq0ocGIPAU6qo=
@@ -481,8 +482,7 @@ github.com/onsi/gomega v1.5.0 h1:izbySO9zDPmjJ8rDjLvkA2zJHIo+HkYXHnf7eN7SSyo=
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.7.0 h1:XPnZz8VVBHjVsy1vzJmRwIcSwiUO+JFfrv/xGiigmME=
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
-github.com/open-telemetry/opentelemetry-proto v0.0.0-20200308012146-674ae1c8703f h1:o21WlujGsrjoN3+n99AflASF/K0S6+SOLOj2O9nNplc=
-github.com/open-telemetry/opentelemetry-proto v0.0.0-20200308012146-674ae1c8703f/go.mod h1:PMR5GI0F7BSpio+rBGFxNm6SLzg3FypDTcFuQZnO+F8=
+github.com/open-telemetry/opentelemetry-proto v0.0.0-20200316171511-e76584d22418 h1:R4Mjk1d++Hke9e4W33O6CMUS85hALRP5wKjhaeCYuSk=
 github.com/open-telemetry/opentelemetry-proto v0.0.0-20200316171511-e76584d22418/go.mod h1:PMR5GI0F7BSpio+rBGFxNm6SLzg3FypDTcFuQZnO+F8=
 github.com/opentracing-contrib/go-stdlib v0.0.0-20190519235532-cf7a6c988dc9/go.mod h1:PLldrQSroqzH70Xl+1DQcGnefIbqsKR7UDaiux3zV+w=
 github.com/opentracing/opentracing-go v1.1.0 h1:pWlfV3Bxv7k65HYwkikxat0+s3pV4bsqf19k25Ur8rU=
@@ -731,6 +731,8 @@ golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6 h1:bjcUS9ztw9kFmmIxJInhon/0
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58 h1:8gQV6CLnAEikrhgkHFbMAEhagSSnXWGV915qUMm9mrU=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e h1:vcxGaoTs7kV8m5Np9uUNQin4BrLOthgV7252N8V+FwY=
+golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20170830134202-bb24a47a89ea/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/testbed/testbed/senders.go
+++ b/testbed/testbed/senders.go
@@ -26,6 +26,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector/exporter"
 	"github.com/open-telemetry/opentelemetry-collector/exporter/jaeger/jaegerthrifthttpexporter"
 	"github.com/open-telemetry/opentelemetry-collector/exporter/opencensusexporter"
+	"github.com/open-telemetry/opentelemetry-collector/exporter/otlpexporter"
 )
 
 // DataSender defines the interface that allows sending data. This is an interface
@@ -247,4 +248,102 @@ func (ome *OCMetricsDataSender) GetCollectorPort() int {
 
 func (ome *OCMetricsDataSender) ProtocolName() string {
 	return "opencensus"
+}
+
+// OTLPTraceDataSender implements TraceDataSender for OpenCensus trace protocol.
+type OTLPTraceDataSender struct {
+	DataSenderOverTraceExporter
+}
+
+// Ensure OTLPTraceDataSender implements TraceDataSender.
+var _ TraceDataSender = (*OTLPTraceDataSender)(nil)
+
+// NewOTLPTraceDataSender creates a new OTLPTraceDataSender that will send
+// to the specified port after Start is called.
+func NewOTLPTraceDataSender(port int) *OTLPTraceDataSender {
+	return &OTLPTraceDataSender{DataSenderOverTraceExporter{Port: port}}
+}
+
+func (ote *OTLPTraceDataSender) Start() error {
+	cfg := &otlpexporter.Config{
+		GRPCSettings: configgrpc.GRPCSettings{
+			Endpoint: fmt.Sprintf("localhost:%d", ote.Port),
+		},
+	}
+
+	factory := otlpexporter.Factory{}
+	exporter, err := factory.CreateTraceExporter(zap.L(), cfg)
+
+	if err != nil {
+		return err
+	}
+
+	ote.exporter = exporter
+	return err
+}
+
+func (ote *OTLPTraceDataSender) GenConfigYAMLStr() string {
+	// Note that this generates a receiver config for agent.
+	return fmt.Sprintf(`
+  otlp:
+    endpoint: "localhost:%d"`, ote.Port)
+}
+
+func (ote *OTLPTraceDataSender) ProtocolName() string {
+	return "otlp"
+}
+
+// OTLPMetricsDataSender implements MetricDataSender for OpenCensus metrics protocol.
+type OTLPMetricsDataSender struct {
+	exporter exporter.MetricsExporter
+	port     int
+}
+
+// Ensure OTLPMetricsDataSender implements MetricDataSender.
+var _ MetricDataSender = (*OTLPMetricsDataSender)(nil)
+
+// NewOTLPMetricDataSender creates a new OpenCensus metric protocol sender that will send
+// to the specified port after Start is called.
+func NewOTLPMetricDataSender(port int) *OTLPMetricsDataSender {
+	return &OTLPMetricsDataSender{port: port}
+}
+
+func (ome *OTLPMetricsDataSender) Start() error {
+	cfg := &otlpexporter.Config{
+		GRPCSettings: configgrpc.GRPCSettings{
+			Endpoint: fmt.Sprintf("localhost:%d", ome.port),
+		},
+	}
+
+	factory := otlpexporter.Factory{}
+	exporter, err := factory.CreateMetricsExporter(zap.L(), cfg)
+
+	if err != nil {
+		return err
+	}
+
+	ome.exporter = exporter
+	return nil
+}
+
+func (ome *OTLPMetricsDataSender) SendMetrics(metrics consumerdata.MetricsData) error {
+	return ome.exporter.ConsumeMetricsData(context.Background(), metrics)
+}
+
+func (ome *OTLPMetricsDataSender) Flush() {
+}
+
+func (ome *OTLPMetricsDataSender) GenConfigYAMLStr() string {
+	// Note that this generates a receiver config for agent.
+	return fmt.Sprintf(`
+  otlp:
+    endpoint: "localhost:%d"`, ome.port)
+}
+
+func (ome *OTLPMetricsDataSender) GetCollectorPort() int {
+	return ome.port
+}
+
+func (ome *OTLPMetricsDataSender) ProtocolName() string {
+	return "otlp"
 }

--- a/testbed/tests/trace_test.go
+++ b/testbed/tests/trace_test.go
@@ -65,6 +65,15 @@ func TestTrace10kSPS(t *testing.T) {
 				ExpectedMaxRAM: 84,
 			},
 		},
+		{
+			"OTLP",
+			testbed.NewOTLPTraceDataSender(testbed.GetAvailablePort(t)),
+			testbed.NewOTLPDataReceiver(testbed.GetAvailablePort(t)),
+			testbed.ResourceSpec{
+				ExpectedMaxCPU: 55,
+				ExpectedMaxRAM: 84,
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -284,6 +293,11 @@ func TestTraceAttributesProcessor(t *testing.T) {
 			"JaegerThrift",
 			testbed.NewJaegerThriftDataSender(testbed.GetAvailablePort(t)),
 			testbed.NewJaegerDataReceiver(testbed.GetAvailablePort(t)),
+		},
+		{
+			"OTLP",
+			testbed.NewOTLPTraceDataSender(testbed.GetAvailablePort(t)),
+			testbed.NewOTLPDataReceiver(testbed.GetAvailablePort(t)),
 		},
 	}
 


### PR DESCRIPTION
- OTLP exporter is now a component enabled in the default build.
- Added OTLP E2E tests for traces.

TODO: Add OTLP E2E tests for metrics once metrics are supported
in OTLP exporter.

Resolves: https://github.com/open-telemetry/opentelemetry-collector/issues/668