### PR TITLE
Add OC -> OTLP metrics translation

### DIFF
--- a/exporter/otlpexporter/factory_test.go
+++ b/exporter/otlpexporter/factory_test.go
@@ -41,8 +41,8 @@ func TestCreateMetricsExporter(t *testing.T) {
 	cfg.GRPCSettings.Endpoint = testutils.GetAvailableLocalAddress(t)
 
 	oexp, err := factory.CreateMetricsExporter(zap.NewNop(), cfg)
-	require.Error(t, err)
-	require.Nil(t, oexp)
+	require.Nil(t, err)
+	require.NotNil(t, oexp)
 }
 
 func TestCreateTraceExporter(t *testing.T) {

--- a/translator/common/oc_to_otlp.go
+++ b/translator/common/oc_to_otlp.go
@@ -1,0 +1,128 @@
+// Copyright 2020 OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"strconv"
+
+	occommon "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
+	ocresource "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
+	"github.com/golang/protobuf/ptypes"
+	otlpcommon "github.com/open-telemetry/opentelemetry-proto/gen/go/common/v1"
+	otlpresource "github.com/open-telemetry/opentelemetry-proto/gen/go/resource/v1"
+
+	"github.com/open-telemetry/opentelemetry-collector/translator/conventions"
+)
+
+func OCNodeResourceToOtlp(node *occommon.Node, resource *ocresource.Resource) *otlpresource.Resource {
+	otlpResource := &otlpresource.Resource{}
+
+	// Move all special fields in Node and in Resource to a temporary attributes map.
+	// After that we will build the attributes slice in OTLP format from this map.
+	// This ensures there are no attributes with duplicate keys.
+
+	// Number of special fields in the Node. See the code below that deals with special fields.
+	const specialNodeAttrCount = 7
+
+	// Number of special fields in the Resource.
+	const specialResourceAttrCount = 1
+
+	// Calculate maximum total number of attributes. It is OK if we are a bit higher than
+	// the exact number since this is only needed for capacity reservation.
+	totalAttrCount := 0
+	if node != nil {
+		totalAttrCount += len(node.Attributes) + specialNodeAttrCount
+	}
+	if resource != nil {
+		totalAttrCount += len(resource.Labels) + specialResourceAttrCount
+	}
+
+	// Create a temporary map where we will place all attributes from the Node and Resource.
+	attrs := make(map[string]string, totalAttrCount)
+
+	if node != nil {
+		// Copy all Attributes.
+		for k, v := range node.Attributes {
+			attrs[k] = v
+		}
+
+		// Add all special fields.
+		if node.ServiceInfo != nil {
+			if node.ServiceInfo.Name != "" {
+				attrs[conventions.AttributeServiceName] = node.ServiceInfo.Name
+			}
+		}
+		if node.Identifier != nil {
+			if node.Identifier.StartTimestamp != nil {
+				attrs[conventions.OCAttributeProcessStartTime] = ptypes.TimestampString(node.Identifier.StartTimestamp)
+			}
+			if node.Identifier.HostName != "" {
+				attrs[conventions.AttributeHostHostname] = node.Identifier.HostName
+			}
+			if node.Identifier.Pid != 0 {
+				attrs[conventions.OCAttributeProcessID] = strconv.Itoa(int(node.Identifier.Pid))
+			}
+		}
+		if node.LibraryInfo != nil {
+			if node.LibraryInfo.CoreLibraryVersion != "" {
+				attrs[conventions.AttributeLibraryVersion] = node.LibraryInfo.CoreLibraryVersion
+			}
+			if node.LibraryInfo.ExporterVersion != "" {
+				attrs[conventions.OCAttributeExporterVersion] = node.LibraryInfo.ExporterVersion
+			}
+			if node.LibraryInfo.Language != occommon.LibraryInfo_LANGUAGE_UNSPECIFIED {
+				attrs[conventions.AttributeLibraryLanguage] = node.LibraryInfo.Language.String()
+			}
+		}
+	}
+
+	if resource != nil {
+		// Copy resource Labels.
+		for k, v := range resource.Labels {
+			attrs[k] = v
+		}
+		// Add special fields.
+		if resource.Type != "" {
+			attrs[conventions.OCAttributeResourceType] = resource.Type
+		}
+	}
+
+	// Convert everything from the temporary matp to OTLP format.
+	otlpResource.Attributes = attrMapToOtlp(attrs)
+
+	return otlpResource
+}
+
+func attrMapToOtlp(ocAttrs map[string]string) []*otlpcommon.AttributeKeyValue {
+	if len(ocAttrs) == 0 {
+		return nil
+	}
+
+	otlpAttrs := make([]*otlpcommon.AttributeKeyValue, len(ocAttrs))
+	i := 0
+	for k, v := range ocAttrs {
+		otlpAttrs[i] = otlpStringAttr(k, v)
+		i++
+	}
+	return otlpAttrs
+}
+
+func otlpStringAttr(key string, val string) *otlpcommon.AttributeKeyValue {
+	return &otlpcommon.AttributeKeyValue{
+		Key:         key,
+		Type:        otlpcommon.AttributeKeyValue_STRING,
+		StringValue: val,
+	}
+}

--- a/translator/common/oc_to_otlp_test.go
+++ b/translator/common/oc_to_otlp_test.go
@@ -1,0 +1,148 @@
+// Copyright 2020 OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	occommon "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
+	ocresource "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
+	"github.com/golang/protobuf/ptypes"
+	otlpcommon "github.com/open-telemetry/opentelemetry-proto/gen/go/common/v1"
+	otlpresource "github.com/open-telemetry/opentelemetry-proto/gen/go/resource/v1"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/open-telemetry/opentelemetry-collector/translator/conventions"
+)
+
+func TestOcNodeResourceToOtlp(t *testing.T) {
+	otlpResource := OCNodeResourceToOtlp(nil, nil)
+	assert.EqualValues(t, &otlpresource.Resource{
+		Attributes: nil,
+	}, otlpResource)
+
+	node := &occommon.Node{}
+	resource := &ocresource.Resource{}
+	otlpResource = OCNodeResourceToOtlp(node, resource)
+	assert.EqualValues(t, &otlpresource.Resource{
+		Attributes: nil,
+	}, otlpResource)
+
+	ts, err := ptypes.TimestampProto(time.Date(2020, 2, 11, 20, 26, 0, 0, time.UTC))
+	assert.NoError(t, err)
+
+	node = &occommon.Node{
+		Identifier: &occommon.ProcessIdentifier{
+			HostName:       "host1",
+			Pid:            123,
+			StartTimestamp: ts,
+		},
+		LibraryInfo: &occommon.LibraryInfo{
+			Language:           occommon.LibraryInfo_CPP,
+			ExporterVersion:    "v1.2.0",
+			CoreLibraryVersion: "v2.0.1",
+		},
+		ServiceInfo: &occommon.ServiceInfo{
+			Name: "svcA",
+		},
+		Attributes: map[string]string{
+			"node-attr": "val1",
+		},
+	}
+	resource = &ocresource.Resource{
+		Type: "good-resource",
+		Labels: map[string]string{
+			"resource-attr": "val2",
+		},
+	}
+	otlpResource = OCNodeResourceToOtlp(node, resource)
+
+	expectedAttrs := map[string]string{
+		conventions.AttributeHostHostname:       "host1",
+		conventions.OCAttributeProcessID:        "123",
+		conventions.OCAttributeProcessStartTime: "2020-02-11T20:26:00Z",
+		conventions.AttributeLibraryLanguage:    "CPP",
+		conventions.OCAttributeExporterVersion:  "v1.2.0",
+		conventions.AttributeLibraryVersion:     "v2.0.1",
+		conventions.AttributeServiceName:        "svcA",
+		"node-attr":                             "val1",
+		conventions.OCAttributeResourceType:     "good-resource",
+		"resource-attr":                         "val2",
+	}
+
+	assert.EqualValues(t, len(expectedAttrs), len(otlpResource.Attributes))
+	for k, v := range expectedAttrs {
+		assertHasAttrStr(t, otlpResource.Attributes, k, v)
+	}
+
+	// Make sure hard-coded fields override same-name values in Attributes.
+	// To do that add Attributes with same-name.
+	for k := range expectedAttrs {
+		// Set all except "attr1" which is not a hard-coded field to some bogus values.
+
+		if strings.Index(k, "-attr") < 0 {
+			node.Attributes[k] = "this will be overridden 1"
+		}
+	}
+	resource.Labels[conventions.OCAttributeResourceType] = "this will be overridden 2"
+
+	// Convert again.
+	otlpResource = OCNodeResourceToOtlp(node, resource)
+
+	// And verify that same-name attributes were ignored.
+	assert.EqualValues(t, len(expectedAttrs), len(otlpResource.Attributes))
+	for k, v := range expectedAttrs {
+		assertHasAttrStr(t, otlpResource.Attributes, k, v)
+	}
+}
+
+func assertHasAttrStr(t *testing.T, attrs []*otlpcommon.AttributeKeyValue, key string, val string) {
+	assertHasAttrVal(t, attrs, key, &otlpcommon.AttributeKeyValue{
+		Key:         key,
+		Type:        otlpcommon.AttributeKeyValue_STRING,
+		StringValue: val,
+	})
+}
+
+func assertHasAttrVal(t *testing.T, attrs []*otlpcommon.AttributeKeyValue, key string, val *otlpcommon.AttributeKeyValue) {
+	found := false
+	for _, attr := range attrs {
+		if attr != nil && attr.Key == key {
+			assert.EqualValues(t, false, found, "Duplicate key "+key)
+			assert.EqualValues(t, val, attr)
+			found = true
+		}
+	}
+	assert.EqualValues(t, true, found, "Cannot find key "+key)
+}
+
+func TestAttrMapToOtlp(t *testing.T) {
+	ocAttrs := map[string]string{}
+
+	otlpAttrs := attrMapToOtlp(ocAttrs)
+	assert.True(t, otlpAttrs == nil)
+
+	ocAttrs = map[string]string{"abc": "def"}
+	otlpAttrs = attrMapToOtlp(ocAttrs)
+	assert.EqualValues(t, []*otlpcommon.AttributeKeyValue{
+		{
+			Key:         "abc",
+			Type:        otlpcommon.AttributeKeyValue_STRING,
+			StringValue: "def",
+		},
+	}, otlpAttrs)
+}

--- a/translator/metrics/oc_to_otlp.go
+++ b/translator/metrics/oc_to_otlp.go
@@ -1,0 +1,390 @@
+// Copyright 2020 OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	ocmetrics "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
+	"github.com/golang/protobuf/ptypes/timestamp"
+	otlpcommon "github.com/open-telemetry/opentelemetry-proto/gen/go/common/v1"
+	otlpmetrics "github.com/open-telemetry/opentelemetry-proto/gen/go/metrics/v1"
+
+	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
+	"github.com/open-telemetry/opentelemetry-collector/internal"
+	translatorcommon "github.com/open-telemetry/opentelemetry-collector/translator/common"
+)
+
+const (
+	invalidOtlpMetricDescriptorType = otlpmetrics.MetricDescriptor_Type(-1)
+)
+
+// OCToOTLP converts metrics from OpenCensus to OTLP format
+func OCToOTLP(md consumerdata.MetricsData) []*otlpmetrics.ResourceMetrics {
+	if md.Node == nil && md.Resource == nil && len(md.Metrics) == 0 {
+		return nil
+	}
+
+	resource := translatorcommon.OCNodeResourceToOtlp(md.Node, md.Resource)
+
+	resourceMetrics := &otlpmetrics.ResourceMetrics{
+		Resource: resource,
+	}
+	resourceMetricsList := []*otlpmetrics.ResourceMetrics{resourceMetrics}
+	if len(md.Metrics) == 0 {
+		return resourceMetricsList
+	}
+
+	// TODO: Add InstrumentationLibrary field support
+	ilm := &otlpmetrics.InstrumentationLibraryMetrics{}
+	resourceMetrics.InstrumentationLibraryMetrics = []*otlpmetrics.InstrumentationLibraryMetrics{ilm}
+
+	ilm.Metrics = make([]*otlpmetrics.Metric, 0, len(md.Metrics))
+
+	for _, ocMetric := range md.Metrics {
+		if ocMetric == nil {
+			// Skip nil metrics.
+			continue
+		}
+
+		otlpMetric := metricToOtlp(ocMetric)
+
+		if ocMetric.Resource != nil {
+			// Add a separate ResourceMetrics item just for this metric since it
+			// has a different Resource.
+			separateRM := &otlpmetrics.ResourceMetrics{
+				Resource: translatorcommon.OCNodeResourceToOtlp(md.Node, ocMetric.Resource),
+				InstrumentationLibraryMetrics: []*otlpmetrics.InstrumentationLibraryMetrics{
+					{
+						Metrics: []*otlpmetrics.Metric{otlpMetric},
+					},
+				},
+			}
+			resourceMetricsList = append(resourceMetricsList, separateRM)
+		} else {
+			// Otherwise add the metrics to the first ResourceMetrics item.
+			ilm.Metrics = append(ilm.Metrics, otlpMetric)
+		}
+	}
+	return resourceMetricsList
+}
+
+func metricToOtlp(ocMetric *ocmetrics.Metric) *otlpmetrics.Metric {
+	metricDescriptor := descriptorToOtlp(ocMetric.GetMetricDescriptor())
+	otlpMetric := &otlpmetrics.Metric{
+		MetricDescriptor: metricDescriptor,
+	}
+	if metricDescriptor == nil {
+		return otlpMetric
+	}
+	commonLabels, labels := getOtlpLabels(ocMetric)
+	if commonLabels != nil {
+		otlpMetric.MetricDescriptor.Labels = commonLabels
+	}
+	setDataPoints(otlpMetric, ocMetric, labels)
+	return otlpMetric
+}
+
+// setDataPoints sets one of oltp metric datapoint slices based on metric type
+func setDataPoints(
+	otlpMetric *otlpmetrics.Metric,
+	ocMetric *ocmetrics.Metric,
+	labels [][]*otlpcommon.StringKeyValue,
+) {
+	switch ocMetric.MetricDescriptor.GetType() {
+	case ocmetrics.MetricDescriptor_GAUGE_INT64, ocmetrics.MetricDescriptor_CUMULATIVE_INT64:
+		otlpMetric.Int64DataPoints = getInt64DataPoints(ocMetric, labels)
+	case ocmetrics.MetricDescriptor_GAUGE_DOUBLE, ocmetrics.MetricDescriptor_CUMULATIVE_DOUBLE:
+		otlpMetric.DoubleDataPoints = getDoubleDataPoints(ocMetric, labels)
+	case ocmetrics.MetricDescriptor_GAUGE_DISTRIBUTION, ocmetrics.MetricDescriptor_CUMULATIVE_DISTRIBUTION:
+		otlpMetric.HistogramDataPoints = getHistogramDataPoints(ocMetric, labels)
+	case ocmetrics.MetricDescriptor_SUMMARY:
+		otlpMetric.SummaryDataPoints = getSummaryDataPoints(ocMetric, labels)
+	default:
+	}
+}
+
+// getOtlpLabels scans OC metric labels and returns labels in OTLP format as two collections of StringKeyValue.
+// The first collection is a slice of labels that were found in all of OC metric timeseries.
+// The second collection is map of OTLP labels by OC timeseries indexes.
+func getOtlpLabels(ocMetric *ocmetrics.Metric) ([]*otlpcommon.StringKeyValue, [][]*otlpcommon.StringKeyValue) {
+	ocLabelsKeys := ocMetric.GetMetricDescriptor().GetLabelKeys()
+	labelsCount := len(ocLabelsKeys)
+	timeseriesCount := len(ocMetric.GetTimeseries())
+	if labelsCount == 0 || timeseriesCount == 0 {
+		return nil, nil
+	}
+
+	labelsByTimeseriesIdx := make([][]*otlpcommon.StringKeyValue, timeseriesCount)
+
+	// Scan the first OC timeseries and prepare slice of common and its own OTLP labels
+	commonLabelsByIdx := make([]*otlpcommon.StringKeyValue, labelsCount)
+	labelsByTimeseriesIdx[0] = make([]*otlpcommon.StringKeyValue, labelsCount)
+	for i := 0; i < labelsCount; i++ {
+		otlpLabel := ocLabelToOtlp(ocLabelsKeys[i], ocMetric.GetTimeseries()[0].GetLabelValues()[i])
+		commonLabelsByIdx[i] = otlpLabel
+		labelsByTimeseriesIdx[0][i] = otlpLabel
+	}
+
+	// Scan other timeseries and drop common labels that are not repeated
+	for i := 1; i < timeseriesCount; i++ {
+		ts := ocMetric.GetTimeseries()[i]
+		labelsByTimeseriesIdx[i] = make([]*otlpcommon.StringKeyValue, labelsCount)
+		for l := 0; l < labelsCount; l++ {
+			otlpLabel := ocLabelToOtlp(ocLabelsKeys[l], ts.GetLabelValues()[l])
+			labelsByTimeseriesIdx[i][l] = otlpLabel
+			if otlpLabel == nil || otlpLabel.GetValue() != commonLabelsByIdx[l].GetValue() {
+				commonLabelsByIdx[l] = nil
+			}
+		}
+	}
+
+	// Clean the common labels collection from nil values
+	commonLabels := make([]*otlpcommon.StringKeyValue, 0, labelsCount)
+	for l := 0; l < labelsCount; l++ {
+		if commonLabelsByIdx[l] != nil {
+			commonLabels = append(commonLabels, commonLabelsByIdx[l])
+
+			// Make sure labels are not duplicated at per timeseries level if they are set as common
+			for i := 1; i < timeseriesCount; i++ {
+				labelsByTimeseriesIdx[i][l] = nil
+			}
+		}
+	}
+	if len(commonLabels) == 0 {
+		commonLabels = nil
+	}
+
+	// Clean the timeseriesIdx->OtlpLabels collection from nil values
+	timeseriesLabels := make([][]*otlpcommon.StringKeyValue, timeseriesCount)
+	for i := 0; i < timeseriesCount; i++ {
+		timeseriesLabels[i] = make([]*otlpcommon.StringKeyValue, 0, labelsCount)
+		for l := 0; l < labelsCount; l++ {
+			if labelsByTimeseriesIdx[i][l] != nil && commonLabelsByIdx[l] == nil {
+				timeseriesLabels[i] = append(timeseriesLabels[i], labelsByTimeseriesIdx[i][l])
+			}
+		}
+		if len(timeseriesLabels[i]) == 0 {
+			timeseriesLabels[i] = nil
+		}
+	}
+
+	return commonLabels, timeseriesLabels
+}
+
+func ocLabelToOtlp(ocLabelKey *ocmetrics.LabelKey, ocLabelValue *ocmetrics.LabelValue) *otlpcommon.StringKeyValue {
+	if !ocLabelValue.GetHasValue() {
+		return nil
+	}
+	return &otlpcommon.StringKeyValue{
+		Key:   ocLabelKey.Key,
+		Value: ocLabelValue.Value,
+	}
+}
+
+func getInt64DataPoints(
+	ocMetric *ocmetrics.Metric,
+	labels [][]*otlpcommon.StringKeyValue,
+) []*otlpmetrics.Int64DataPoint {
+	int64DataPoints := make([]*otlpmetrics.Int64DataPoint, 0, getPointsCount(ocMetric))
+	for i, timeseries := range ocMetric.GetTimeseries() {
+		startTimestamp := timeseries.GetStartTimestamp()
+		for _, point := range timeseries.GetPoints() {
+			int64DataPoints = append(int64DataPoints, &otlpmetrics.Int64DataPoint{
+				StartTimeUnixnano: ocTimestampToNanos(startTimestamp),
+				TimestampUnixnano: ocTimestampToNanos(point.GetTimestamp()),
+				Value:             point.GetInt64Value(),
+				Labels:            labels[i],
+			})
+		}
+	}
+	return int64DataPoints
+}
+
+func getDoubleDataPoints(
+	ocMetric *ocmetrics.Metric,
+	labels [][]*otlpcommon.StringKeyValue,
+) []*otlpmetrics.DoubleDataPoint {
+	int64DataPoints := make([]*otlpmetrics.DoubleDataPoint, 0, getPointsCount(ocMetric))
+	for i, timeseries := range ocMetric.GetTimeseries() {
+		startTimestamp := timeseries.GetStartTimestamp()
+		for _, point := range timeseries.GetPoints() {
+			int64DataPoints = append(int64DataPoints, &otlpmetrics.DoubleDataPoint{
+				StartTimeUnixnano: ocTimestampToNanos(startTimestamp),
+				TimestampUnixnano: ocTimestampToNanos(point.GetTimestamp()),
+				Value:             point.GetDoubleValue(),
+				Labels:            labels[i],
+			})
+		}
+	}
+	return int64DataPoints
+}
+
+func getHistogramDataPoints(
+	ocMetric *ocmetrics.Metric,
+	labels [][]*otlpcommon.StringKeyValue,
+) []*otlpmetrics.HistogramDataPoint {
+	histogramDataPoints := make([]*otlpmetrics.HistogramDataPoint, 0, getPointsCount(ocMetric))
+	for i, timeseries := range ocMetric.GetTimeseries() {
+		startTimestamp := timeseries.GetStartTimestamp()
+		for _, point := range timeseries.GetPoints() {
+			distributionValue := point.GetDistributionValue()
+			if distributionValue == nil {
+				continue
+			}
+			histogramDataPoints = append(histogramDataPoints, &otlpmetrics.HistogramDataPoint{
+				StartTimeUnixnano: ocTimestampToNanos(startTimestamp),
+				TimestampUnixnano: ocTimestampToNanos(point.GetTimestamp()),
+				Count:             uint64(distributionValue.GetCount()),
+				Sum:               distributionValue.GetSum(),
+				Buckets:           histogramBucketsToOtlp(distributionValue.Buckets),
+				ExplicitBounds:    distributionValue.GetBucketOptions().GetExplicit().GetBounds(),
+				Labels:            labels[i],
+			})
+		}
+	}
+	return histogramDataPoints
+}
+
+func getSummaryDataPoints(
+	ocMetric *ocmetrics.Metric,
+	labels [][]*otlpcommon.StringKeyValue,
+) []*otlpmetrics.SummaryDataPoint {
+	summaryDataPoints := make([]*otlpmetrics.SummaryDataPoint, 0, getPointsCount(ocMetric))
+	for i, timeseries := range ocMetric.GetTimeseries() {
+		startTimestamp := timeseries.GetStartTimestamp()
+		for _, point := range timeseries.GetPoints() {
+			ocSummaryValue := point.GetSummaryValue()
+			if ocSummaryValue == nil {
+				continue
+			}
+			summaryDataPoints = append(summaryDataPoints, &otlpmetrics.SummaryDataPoint{
+				StartTimeUnixnano: ocTimestampToNanos(startTimestamp),
+				TimestampUnixnano: ocTimestampToNanos(point.GetTimestamp()),
+				Count:             uint64(ocSummaryValue.GetCount().GetValue()),
+				Sum:               ocSummaryValue.GetSum().GetValue(),
+				PercentileValues:  percentileToOtlp(ocSummaryValue.GetSnapshot().GetPercentileValues()),
+				Labels:            labels[i],
+			})
+		}
+	}
+	return summaryDataPoints
+}
+
+func percentileToOtlp(
+	ocPercentiles []*ocmetrics.SummaryValue_Snapshot_ValueAtPercentile,
+) []*otlpmetrics.SummaryDataPoint_ValueAtPercentile {
+	if ocPercentiles == nil {
+		return nil
+	}
+	otlpPercentiles := make([]*otlpmetrics.SummaryDataPoint_ValueAtPercentile, 0, len(ocPercentiles))
+	for _, p := range ocPercentiles {
+		otlpPercentiles = append(otlpPercentiles, &otlpmetrics.SummaryDataPoint_ValueAtPercentile{
+			Percentile: p.Percentile,
+			Value:      p.Value,
+		})
+	}
+	return otlpPercentiles
+}
+
+func histogramBucketsToOtlp(ocBuckets []*ocmetrics.DistributionValue_Bucket) []*otlpmetrics.HistogramDataPoint_Bucket {
+	if ocBuckets == nil {
+		return nil
+	}
+	otlpBuckets := make([]*otlpmetrics.HistogramDataPoint_Bucket, 0, len(ocBuckets))
+	for _, bucket := range ocBuckets {
+		otlpBuckets = append(otlpBuckets, &otlpmetrics.HistogramDataPoint_Bucket{
+			Count:    uint64(bucket.Count),
+			Exemplar: exemplarToOtlp(bucket.Exemplar),
+		})
+	}
+	return otlpBuckets
+}
+
+func exemplarToOtlp(ocExemplar *ocmetrics.DistributionValue_Exemplar) *otlpmetrics.HistogramDataPoint_Bucket_Exemplar {
+	if ocExemplar == nil {
+		return nil
+	}
+
+	return &otlpmetrics.HistogramDataPoint_Bucket_Exemplar{
+		Value:             ocExemplar.Value,
+		TimestampUnixnano: ocTimestampToNanos(ocExemplar.Timestamp),
+		Attachments:       exemplarAttachmentsToOtlp(ocExemplar.Attachments),
+	}
+}
+
+func exemplarAttachmentsToOtlp(ocAttachments map[string]string) []*otlpcommon.StringKeyValue {
+	if len(ocAttachments) == 0 {
+		return nil
+	}
+
+	otlpAttachments := make([]*otlpcommon.StringKeyValue, 0, len(ocAttachments))
+	for key, value := range ocAttachments {
+		otlpAttachments = append(otlpAttachments, &otlpcommon.StringKeyValue{
+			Key:   key,
+			Value: value,
+		})
+	}
+	return otlpAttachments
+}
+
+func ocTimestampToNanos(ts *timestamp.Timestamp) uint64 {
+	return uint64(internal.TimestampToUnixnano(ts))
+}
+
+func getPointsCount(ocMetric *ocmetrics.Metric) int {
+	timeseriesSlice := ocMetric.GetTimeseries()
+	var count int
+	for _, timeseries := range timeseriesSlice {
+		points := timeseries.GetPoints()
+		count += len(points)
+	}
+	return count
+}
+
+func descriptorToOtlp(descriptor *ocmetrics.MetricDescriptor) *otlpmetrics.MetricDescriptor {
+	descriptorType := descriptorTypeToOtlp(descriptor.Type)
+	if descriptor == nil || descriptorType == invalidOtlpMetricDescriptorType {
+		return nil
+	}
+
+	return &otlpmetrics.MetricDescriptor{
+		Name:        descriptor.Name,
+		Description: descriptor.Description,
+		Unit:        descriptor.Unit,
+		Type:        descriptorType,
+	}
+}
+
+func descriptorTypeToOtlp(t ocmetrics.MetricDescriptor_Type) otlpmetrics.MetricDescriptor_Type {
+	switch t {
+	case ocmetrics.MetricDescriptor_UNSPECIFIED:
+		return otlpmetrics.MetricDescriptor_UNSPECIFIED
+	case ocmetrics.MetricDescriptor_GAUGE_INT64:
+		return otlpmetrics.MetricDescriptor_GAUGE_INT64
+	case ocmetrics.MetricDescriptor_GAUGE_DOUBLE:
+		return otlpmetrics.MetricDescriptor_GAUGE_DOUBLE
+	case ocmetrics.MetricDescriptor_GAUGE_DISTRIBUTION:
+		return otlpmetrics.MetricDescriptor_GAUGE_HISTOGRAM
+	case ocmetrics.MetricDescriptor_CUMULATIVE_INT64:
+		return otlpmetrics.MetricDescriptor_COUNTER_INT64
+	case ocmetrics.MetricDescriptor_CUMULATIVE_DOUBLE:
+		return otlpmetrics.MetricDescriptor_COUNTER_DOUBLE
+	case ocmetrics.MetricDescriptor_CUMULATIVE_DISTRIBUTION:
+		return otlpmetrics.MetricDescriptor_CUMULATIVE_HISTOGRAM
+	case ocmetrics.MetricDescriptor_SUMMARY:
+		return otlpmetrics.MetricDescriptor_SUMMARY
+	default:
+		return invalidOtlpMetricDescriptorType
+	}
+}

--- a/translator/metrics/oc_to_otlp_test.go
+++ b/translator/metrics/oc_to_otlp_test.go
@@ -322,24 +322,24 @@ func TestOCToOTLP(t *testing.T) {
 			Description: "My metric",
 			Unit:        "ms",
 			Type:        otlpmetrics.MetricDescriptor_GAUGE_HISTOGRAM,
-			Labels: []*otlpcommon.StringKeyValue{
-				{
-					Key:   "key1",
-					Value: "value1",
-				},
-				{
-					Key:   "key2",
-					Value: "value2",
-				},
-			},
 		},
 		HistogramDataPoints: []*otlpmetrics.HistogramDataPoint{
 			{
 				StartTimeUnixnano: unixnanos1,
 				TimestampUnixnano: unixnanos2,
-				Count:             48,
-				Sum:               123.45,
-				ExplicitBounds:    []float64{1.2, 4.5},
+				Labels: []*otlpcommon.StringKeyValue{
+					{
+						Key:   "key1",
+						Value: "value1",
+					},
+					{
+						Key:   "key2",
+						Value: "value2",
+					},
+				},
+				Count:          48,
+				Sum:            123.45,
+				ExplicitBounds: []float64{1.2, 4.5},
 				Buckets: []*otlpmetrics.HistogramDataPoint_Bucket{
 					{
 						Count: 12,

--- a/translator/metrics/oc_to_otlp_test.go
+++ b/translator/metrics/oc_to_otlp_test.go
@@ -1,0 +1,510 @@
+// Copyright 2020 OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"testing"
+
+	occommon "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
+	ocmetrics "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
+	ocresource "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
+	otlpcommon "github.com/open-telemetry/opentelemetry-proto/gen/go/common/v1"
+	otlpmetrics "github.com/open-telemetry/opentelemetry-proto/gen/go/metrics/v1"
+	otlpresource "github.com/open-telemetry/opentelemetry-proto/gen/go/resource/v1"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
+	"github.com/open-telemetry/opentelemetry-collector/translator/conventions"
+)
+
+func TestOCToOTLP(t *testing.T) {
+	unixnanos1 := uint64(12578940000000012345)
+	unixnanos2 := uint64(12578940000000054321)
+
+	int64OCMetric := &ocmetrics.Metric{
+		MetricDescriptor: &ocmetrics.MetricDescriptor{
+			Name:        "mymetric",
+			Description: "My metric",
+			Unit:        "ms",
+			Type:        ocmetrics.MetricDescriptor_CUMULATIVE_INT64,
+			LabelKeys: []*ocmetrics.LabelKey{
+				{Key: "key1"},
+				{Key: "key2"},
+			},
+		},
+		Timeseries: []*ocmetrics.TimeSeries{
+			{
+				StartTimestamp: unixnanoToTimestamp(unixnanos1),
+				LabelValues: []*ocmetrics.LabelValue{
+					{
+						// key1
+						Value:    "value1",
+						HasValue: true,
+					},
+					{
+						// key2
+						HasValue: false,
+					},
+				},
+				Points: []*ocmetrics.Point{
+					{
+						Timestamp: unixnanoToTimestamp(unixnanos2),
+						Value: &ocmetrics.Point_Int64Value{
+							Int64Value: 123,
+						},
+					},
+				},
+			},
+			{
+				StartTimestamp: unixnanoToTimestamp(unixnanos1),
+				LabelValues: []*ocmetrics.LabelValue{
+					{
+						// key1
+						HasValue: false,
+					},
+					{
+						// key2
+						Value:    "value2",
+						HasValue: true,
+					},
+				},
+				Points: []*ocmetrics.Point{
+					{
+						Timestamp: unixnanoToTimestamp(unixnanos2),
+						Value: &ocmetrics.Point_Int64Value{
+							Int64Value: 456,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	doubleOCMetric := &ocmetrics.Metric{
+		MetricDescriptor: &ocmetrics.MetricDescriptor{
+			Name:        "mymetric",
+			Description: "My metric",
+			Unit:        "ms",
+			Type:        ocmetrics.MetricDescriptor_GAUGE_DOUBLE,
+			LabelKeys: []*ocmetrics.LabelKey{
+				{Key: "key1"},
+				{Key: "key2"},
+				{Key: "key3"},
+			},
+		},
+		Timeseries: []*ocmetrics.TimeSeries{
+			{
+				StartTimestamp: unixnanoToTimestamp(unixnanos1),
+				LabelValues: []*ocmetrics.LabelValue{
+					{
+						// key1
+						Value:    "value1",
+						HasValue: true,
+					},
+					{
+						// key2
+						Value:    "value2",
+						HasValue: true,
+					},
+					{
+						// key3
+						HasValue: false,
+					},
+				},
+				Points: []*ocmetrics.Point{
+					{
+						Timestamp: unixnanoToTimestamp(unixnanos2),
+						Value: &ocmetrics.Point_DoubleValue{
+							DoubleValue: 1.23,
+						},
+					},
+				},
+			},
+			{
+				StartTimestamp: unixnanoToTimestamp(unixnanos1),
+				LabelValues: []*ocmetrics.LabelValue{
+					{
+						// key1
+						Value:    "another-value1",
+						HasValue: true,
+					},
+					{
+						// key2
+						HasValue: false,
+					},
+					{
+						// key3
+						Value:    "value3",
+						HasValue: true,
+					},
+				},
+				Points: []*ocmetrics.Point{
+					{
+						Timestamp: unixnanoToTimestamp(unixnanos2),
+						Value: &ocmetrics.Point_DoubleValue{
+							DoubleValue: 3.45,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	histogramOCMetric := &ocmetrics.Metric{
+		MetricDescriptor: &ocmetrics.MetricDescriptor{
+			Name:        "mymetric",
+			Description: "My metric",
+			Unit:        "ms",
+			Type:        ocmetrics.MetricDescriptor_GAUGE_DISTRIBUTION,
+			LabelKeys: []*ocmetrics.LabelKey{
+				{Key: "key1"},
+				{Key: "key2"},
+			},
+		},
+		Timeseries: []*ocmetrics.TimeSeries{
+			{
+				StartTimestamp: unixnanoToTimestamp(unixnanos1),
+				LabelValues: []*ocmetrics.LabelValue{
+					{
+						// key1
+						Value:    "value1",
+						HasValue: true,
+					},
+					{
+						// key2
+						Value:    "value2",
+						HasValue: true,
+					},
+				},
+				Points: []*ocmetrics.Point{
+					{
+						Timestamp: unixnanoToTimestamp(unixnanos2),
+						Value: &ocmetrics.Point_DistributionValue{
+							DistributionValue: &ocmetrics.DistributionValue{
+								Count: 48,
+								Sum:   123.45,
+								BucketOptions: &ocmetrics.DistributionValue_BucketOptions{
+									Type: &ocmetrics.DistributionValue_BucketOptions_Explicit_{
+										Explicit: &ocmetrics.DistributionValue_BucketOptions_Explicit{
+											Bounds: []float64{1.2, 4.5},
+										},
+									},
+								},
+								Buckets: []*ocmetrics.DistributionValue_Bucket{
+									{
+										Count: 12,
+										Exemplar: &ocmetrics.DistributionValue_Exemplar{
+											Value:     1.1,
+											Timestamp: unixnanoToTimestamp(unixnanos2),
+											Attachments: map[string]string{
+												"key1": "value1",
+											},
+										},
+									},
+									{
+										Count: 24,
+										Exemplar: &ocmetrics.DistributionValue_Exemplar{
+											Value:     2.2,
+											Timestamp: unixnanoToTimestamp(unixnanos2),
+											Attachments: map[string]string{
+												"key2": "value2",
+											},
+										},
+									},
+									{
+										Count: 12,
+										Exemplar: &ocmetrics.DistributionValue_Exemplar{
+											Value:     7.1,
+											Timestamp: unixnanoToTimestamp(unixnanos2),
+											Attachments: map[string]string{
+												"key3": "value3",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	int64Metric := &otlpmetrics.Metric{
+		MetricDescriptor: &otlpmetrics.MetricDescriptor{
+			Name:        "mymetric",
+			Description: "My metric",
+			Unit:        "ms",
+			Type:        otlpmetrics.MetricDescriptor_COUNTER_INT64,
+		},
+		Int64DataPoints: []*otlpmetrics.Int64DataPoint{
+			{
+				Labels: []*otlpcommon.StringKeyValue{
+					{
+						Key:   "key1",
+						Value: "value1",
+					},
+				},
+				StartTimeUnixnano: unixnanos1,
+				TimestampUnixnano: unixnanos2,
+				Value:             123,
+			},
+			{
+				Labels: []*otlpcommon.StringKeyValue{
+					{
+						Key:   "key2",
+						Value: "value2",
+					},
+				},
+				StartTimeUnixnano: unixnanos1,
+				TimestampUnixnano: unixnanos2,
+				Value:             456,
+			},
+		},
+	}
+
+	doubleMetric := &otlpmetrics.Metric{
+		MetricDescriptor: &otlpmetrics.MetricDescriptor{
+			Name:        "mymetric",
+			Description: "My metric",
+			Unit:        "ms",
+			Type:        otlpmetrics.MetricDescriptor_GAUGE_DOUBLE,
+		},
+		DoubleDataPoints: []*otlpmetrics.DoubleDataPoint{
+			{
+				Labels: []*otlpcommon.StringKeyValue{
+					{
+						Key:   "key1",
+						Value: "value1",
+					},
+					{
+						Key:   "key2",
+						Value: "value2",
+					},
+				},
+				StartTimeUnixnano: unixnanos1,
+				TimestampUnixnano: unixnanos2,
+				Value:             1.23,
+			},
+			{
+				Labels: []*otlpcommon.StringKeyValue{
+					{
+						Key:   "key1",
+						Value: "another-value1",
+					},
+					{
+						Key:   "key3",
+						Value: "value3",
+					},
+				},
+				StartTimeUnixnano: unixnanos1,
+				TimestampUnixnano: unixnanos2,
+				Value:             3.45,
+			},
+		},
+	}
+
+	histogramMetric := &otlpmetrics.Metric{
+		MetricDescriptor: &otlpmetrics.MetricDescriptor{
+			Name:        "mymetric",
+			Description: "My metric",
+			Unit:        "ms",
+			Type:        otlpmetrics.MetricDescriptor_GAUGE_HISTOGRAM,
+			Labels: []*otlpcommon.StringKeyValue{
+				{
+					Key:   "key1",
+					Value: "value1",
+				},
+				{
+					Key:   "key2",
+					Value: "value2",
+				},
+			},
+		},
+		HistogramDataPoints: []*otlpmetrics.HistogramDataPoint{
+			{
+				StartTimeUnixnano: unixnanos1,
+				TimestampUnixnano: unixnanos2,
+				Count:             48,
+				Sum:               123.45,
+				ExplicitBounds:    []float64{1.2, 4.5},
+				Buckets: []*otlpmetrics.HistogramDataPoint_Bucket{
+					{
+						Count: 12,
+						Exemplar: &otlpmetrics.HistogramDataPoint_Bucket_Exemplar{
+							Value:             1.1,
+							TimestampUnixnano: unixnanos2,
+							Attachments: []*otlpcommon.StringKeyValue{
+								{
+									Key:   "key1",
+									Value: "value1",
+								},
+							},
+						},
+					},
+					{
+						Count: 24,
+						Exemplar: &otlpmetrics.HistogramDataPoint_Bucket_Exemplar{
+							Value:             2.2,
+							TimestampUnixnano: unixnanos2,
+							Attachments: []*otlpcommon.StringKeyValue{
+								{
+									Key:   "key2",
+									Value: "value2",
+								},
+							},
+						},
+					},
+					{
+						Count: 12,
+						Exemplar: &otlpmetrics.HistogramDataPoint_Bucket_Exemplar{
+							Value:             7.1,
+							TimestampUnixnano: unixnanos2,
+							Attachments: []*otlpcommon.StringKeyValue{
+								{
+									Key:   "key3",
+									Value: "value3",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	otlpAttributes := []*otlpcommon.AttributeKeyValue{
+		{
+			Key:         conventions.OCAttributeResourceType,
+			Type:        otlpcommon.AttributeKeyValue_STRING,
+			StringValue: "good-resource",
+		},
+	}
+
+	tests := []struct {
+		name string
+		oc   consumerdata.MetricsData
+		otlp []*otlpmetrics.ResourceMetrics
+	}{
+		{
+			name: "empty",
+			oc:   consumerdata.MetricsData{},
+			otlp: nil,
+		},
+
+		{
+			name: "empty-metrics",
+			oc: consumerdata.MetricsData{
+				Node:     &occommon.Node{},
+				Resource: &ocresource.Resource{},
+			},
+			otlp: []*otlpmetrics.ResourceMetrics{
+				{
+					Resource: &otlpresource.Resource{},
+				},
+			},
+		},
+
+		{
+			name: "no-metrics",
+			oc: consumerdata.MetricsData{
+				Resource: &ocresource.Resource{
+					Type: "good-resource",
+				},
+				Metrics: []*ocmetrics.Metric{},
+			},
+			otlp: []*otlpmetrics.ResourceMetrics{
+				{
+					Resource: &otlpresource.Resource{
+						Attributes: otlpAttributes,
+					},
+				},
+			},
+		},
+
+		{
+			name: "int64-metric",
+			oc: consumerdata.MetricsData{
+				Resource: &ocresource.Resource{
+					Type: "good-resource",
+				},
+				Metrics: []*ocmetrics.Metric{int64OCMetric},
+			},
+			otlp: []*otlpmetrics.ResourceMetrics{
+				{
+					Resource: &otlpresource.Resource{
+						Attributes: otlpAttributes,
+					},
+					InstrumentationLibraryMetrics: []*otlpmetrics.InstrumentationLibraryMetrics{
+						{
+							Metrics: []*otlpmetrics.Metric{int64Metric},
+						},
+					},
+				},
+			},
+		},
+
+		{
+			name: "double-metric",
+			oc: consumerdata.MetricsData{
+				Resource: &ocresource.Resource{
+					Type: "good-resource",
+				},
+				Metrics: []*ocmetrics.Metric{doubleOCMetric},
+			},
+			otlp: []*otlpmetrics.ResourceMetrics{
+				{
+					Resource: &otlpresource.Resource{
+						Attributes: otlpAttributes,
+					},
+					InstrumentationLibraryMetrics: []*otlpmetrics.InstrumentationLibraryMetrics{
+						{
+							Metrics: []*otlpmetrics.Metric{doubleMetric},
+						},
+					},
+				},
+			},
+		},
+
+		{
+			name: "histogram-metric",
+			oc: consumerdata.MetricsData{
+				Resource: &ocresource.Resource{
+					Type: "good-resource",
+				},
+				Metrics: []*ocmetrics.Metric{histogramOCMetric},
+			},
+			otlp: []*otlpmetrics.ResourceMetrics{
+				{
+					Resource: &otlpresource.Resource{
+						Attributes: otlpAttributes,
+					},
+					InstrumentationLibraryMetrics: []*otlpmetrics.InstrumentationLibraryMetrics{
+						{
+							Metrics: []*otlpmetrics.Metric{histogramMetric},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := OCToOTLP(test.oc)
+			assert.EqualValues(t, test.otlp, got)
+		})
+	}
+}

--- a/translator/metrics/otlp_to_oc.go
+++ b/translator/metrics/otlp_to_oc.go
@@ -105,6 +105,8 @@ func labelKeysToOC(metric *otlpmetrics.Metric) *labelKeys {
 	// - If the value for particular label key is missing in the point, we set it to default
 	// to preserve 1:1 matching between label keys and values.
 
+	// TODO: Support common labels from otlpmetrics.MetricDescriptor.Labels
+
 	// First, collect a set of all labels present in the metric
 	keySet := make(map[string]struct{}, 0)
 	for _, point := range metric.Int64DataPoints {

--- a/translator/trace/oc_to_otlp_test.go
+++ b/translator/trace/oc_to_otlp_test.go
@@ -15,7 +15,6 @@
 package tracetranslator
 
 import (
-	"strings"
 	"testing"
 	"time"
 
@@ -29,126 +28,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
-	"github.com/open-telemetry/opentelemetry-collector/translator/conventions"
 )
-
-func TestAttrMapToOtlp(t *testing.T) {
-	ocAttrs := map[string]string{}
-
-	otlpAttrs := attrMapToOtlp(ocAttrs)
-	assert.True(t, otlpAttrs == nil)
-
-	ocAttrs = map[string]string{"abc": "def"}
-	otlpAttrs = attrMapToOtlp(ocAttrs)
-	assert.EqualValues(t, []*otlpcommon.AttributeKeyValue{
-		{
-			Key:         "abc",
-			Type:        otlpcommon.AttributeKeyValue_STRING,
-			StringValue: "def",
-		},
-	}, otlpAttrs)
-}
-
-func TestOcNodeResourceToOtlp(t *testing.T) {
-	otlpResource := ocNodeResourceToOtlp(nil, nil)
-	assert.EqualValues(t, &otlpresource.Resource{
-		Attributes: nil,
-	}, otlpResource)
-
-	node := &occommon.Node{}
-	resource := &ocresource.Resource{}
-	otlpResource = ocNodeResourceToOtlp(node, resource)
-	assert.EqualValues(t, &otlpresource.Resource{
-		Attributes: nil,
-	}, otlpResource)
-
-	ts, err := ptypes.TimestampProto(time.Date(2020, 2, 11, 20, 26, 0, 0, time.UTC))
-	assert.NoError(t, err)
-
-	node = &occommon.Node{
-		Identifier: &occommon.ProcessIdentifier{
-			HostName:       "host1",
-			Pid:            123,
-			StartTimestamp: ts,
-		},
-		LibraryInfo: &occommon.LibraryInfo{
-			Language:           occommon.LibraryInfo_CPP,
-			ExporterVersion:    "v1.2.0",
-			CoreLibraryVersion: "v2.0.1",
-		},
-		ServiceInfo: &occommon.ServiceInfo{
-			Name: "svcA",
-		},
-		Attributes: map[string]string{
-			"node-attr": "val1",
-		},
-	}
-	resource = &ocresource.Resource{
-		Type: "good-resource",
-		Labels: map[string]string{
-			"resource-attr": "val2",
-		},
-	}
-	otlpResource = ocNodeResourceToOtlp(node, resource)
-
-	expectedAttrs := map[string]string{
-		conventions.AttributeHostHostname:       "host1",
-		conventions.OCAttributeProcessID:        "123",
-		conventions.OCAttributeProcessStartTime: "2020-02-11T20:26:00Z",
-		conventions.AttributeLibraryLanguage:    "CPP",
-		conventions.OCAttributeExporterVersion:  "v1.2.0",
-		conventions.AttributeLibraryVersion:     "v2.0.1",
-		conventions.AttributeServiceName:        "svcA",
-		"node-attr":                             "val1",
-		conventions.OCAttributeResourceType:     "good-resource",
-		"resource-attr":                         "val2",
-	}
-
-	assert.EqualValues(t, len(expectedAttrs), len(otlpResource.Attributes))
-	for k, v := range expectedAttrs {
-		assertHasAttrStr(t, otlpResource.Attributes, k, v)
-	}
-
-	// Make sure hard-coded fields override same-name values in Attributes.
-	// To do that add Attributes with same-name.
-	for k := range expectedAttrs {
-		// Set all except "attr1" which is not a hard-coded field to some bogus values.
-
-		if strings.Index(k, "-attr") < 0 {
-			node.Attributes[k] = "this will be overridden 1"
-		}
-	}
-	resource.Labels[conventions.OCAttributeResourceType] = "this will be overridden 2"
-
-	// Convert again.
-	otlpResource = ocNodeResourceToOtlp(node, resource)
-
-	// And verify that same-name attributes were ignored.
-	assert.EqualValues(t, len(expectedAttrs), len(otlpResource.Attributes))
-	for k, v := range expectedAttrs {
-		assertHasAttrStr(t, otlpResource.Attributes, k, v)
-	}
-}
-
-func assertHasAttrStr(t *testing.T, attrs []*otlpcommon.AttributeKeyValue, key string, val string) {
-	assertHasAttrVal(t, attrs, key, &otlpcommon.AttributeKeyValue{
-		Key:         key,
-		Type:        otlpcommon.AttributeKeyValue_STRING,
-		StringValue: val,
-	})
-}
-
-func assertHasAttrVal(t *testing.T, attrs []*otlpcommon.AttributeKeyValue, key string, val *otlpcommon.AttributeKeyValue) {
-	found := false
-	for _, attr := range attrs {
-		if attr != nil && attr.Key == key {
-			assert.EqualValues(t, false, found, "Duplicate key "+key)
-			assert.EqualValues(t, val, attr)
-			found = true
-		}
-	}
-	assert.EqualValues(t, true, found, "Cannot find key "+key)
-}
 
 func TestOcTraceStateToOtlp(t *testing.T) {
 	assert.EqualValues(t, "", ocTraceStateToOtlp(nil))
@@ -542,4 +422,16 @@ func TestOcToOtlp(t *testing.T) {
 			assert.EqualValues(t, test.otlp, got)
 		})
 	}
+}
+
+func assertHasAttrVal(t *testing.T, attrs []*otlpcommon.AttributeKeyValue, key string, val *otlpcommon.AttributeKeyValue) {
+	found := false
+	for _, attr := range attrs {
+		if attr != nil && attr.Key == key {
+			assert.EqualValues(t, false, found, "Duplicate key "+key)
+			assert.EqualValues(t, val, attr)
+			found = true
+		}
+	}
+	assert.EqualValues(t, true, found, "Cannot find key "+key)
 }


### PR DESCRIPTION
**Description:** Used in OTLP Exporter to translate internal OC format to OTLP

`translator/common/oc_to_otlp.go` code was moved as is from `trace/oc_to_otlp.go` 

**Testing:** Unit tests
