### PR TITLE
Add instance ID to metric labels

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/golangci/golangci-lint v1.21.0
 	github.com/google/addlicense v0.0.0-20200301095109-7c013a14f2e2
 	github.com/google/go-cmp v0.3.1
+	github.com/google/uuid v1.1.1
 	github.com/gorilla/handlers v1.4.2 // indirect
 	github.com/gorilla/mux v1.7.3
 	github.com/grpc-ecosystem/grpc-gateway v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -306,6 +306,7 @@ github.com/google/pprof v0.0.0-20190723021845-34ac40c74b70/go.mod h1:zfwlbNMJ+OI
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5 h1:sjZBwGj9Jlw33ImPtvFviGYvseOtDM7hkSKB7+Tv3SM=

--- a/obsreport/obsreport_exporter.go
+++ b/obsreport/obsreport_exporter.go
@@ -152,8 +152,10 @@ func ExporterContext(
 	}
 
 	if useNew {
-		ctx, _ = tag.New(ctx, tag.Upsert(
-			tagKeyExporter, exporter, tag.WithTTL(tag.TTLNoPropagation)))
+		ctx, _ = tag.New(ctx,
+			tag.Upsert(tagKeyExporter, exporter, tag.WithTTL(tag.TTLNoPropagation)),
+			tag.Upsert(tagKeyInstanceID, instanceID, tag.WithTTL(tag.TTLNoPropagation)),
+		)
 	}
 
 	return ctx

--- a/obsreport/obsreport_processor.go
+++ b/obsreport/obsreport_processor.go
@@ -112,7 +112,10 @@ func ProcessorContext(
 ) context.Context {
 	if useNew {
 		ctx, _ = tag.New(
-			ctx, tag.Upsert(tagKeyProcessor, processor, tag.WithTTL(tag.TTLNoPropagation)))
+			ctx,
+			tag.Upsert(tagKeyProcessor, processor, tag.WithTTL(tag.TTLNoPropagation)),
+			tag.Upsert(tagKeyInstanceID, instanceID, tag.WithTTL(tag.TTLNoPropagation)),
+		)
 	}
 
 	return ctx

--- a/obsreport/obsreport_receiver.go
+++ b/obsreport/obsreport_receiver.go
@@ -240,6 +240,7 @@ func ReceiverContext(
 		mutators := []tag.Mutator{
 			tag.Upsert(tagKeyReceiver, receiver, tag.WithTTL(tag.TTLNoPropagation)),
 			tag.Upsert(tagKeyTransport, transport, tag.WithTTL(tag.TTLNoPropagation)),
+			tag.Upsert(tagKeyInstanceID, instanceID, tag.WithTTL(tag.TTLNoPropagation)),
 		}
 		ctx, _ = tag.New(ctx, mutators...)
 	}
@@ -281,6 +282,30 @@ func traceReceiveOp(
 	span.AddAttributes(trace.StringAttribute(
 		TransportKey, transport))
 	return ctx
+}
+
+// setParentLink tries to retrieve a span from parentCtx and if one exists
+// sets its SpanID, TraceID as a link to the given child Span.
+// It returns true only if it retrieved a parent span from the context.
+//
+// This is typically used when the parentCtx may already have a trace and is
+// long lived (eg.: an gRPC stream, or TCP connection) and one desires distinct
+// traces for individual operations under the long lived trace associated to
+// the parentCtx. This function is a helper that encapsulates the work of
+// linking the short lived trace/span to the longer one.
+func setParentLink(parentCtx context.Context, childSpan *trace.Span) bool {
+	parentSpanFromRPC := trace.FromContext(parentCtx)
+	if parentSpanFromRPC == nil {
+		return false
+	}
+
+	psc := parentSpanFromRPC.SpanContext()
+	childSpan.AddLink(trace.Link{
+		SpanID:  psc.SpanID,
+		TraceID: psc.TraceID,
+		Type:    trace.LinkTypeParent,
+	})
+	return true
 }
 
 // endReceiveOp records the observability signals at the end of an operation.

--- a/obsreport/obsreport_test.go
+++ b/obsreport/obsreport_test.go
@@ -584,18 +584,21 @@ func receiverViewTags(receiver, transport string) []tag.Tag {
 	return []tag.Tag{
 		{Key: tagKeyReceiver, Value: receiver},
 		{Key: tagKeyTransport, Value: transport},
+		{Key: tagKeyInstanceID, Value: InstanceID()},
 	}
 }
 
 func exporterViewTags(exporter string) []tag.Tag {
 	return []tag.Tag{
 		{Key: tagKeyExporter, Value: exporter},
+		{Key: tagKeyInstanceID, Value: InstanceID()},
 	}
 }
 
 func processorViewTags(processor string) []tag.Tag {
 	return []tag.Tag{
 		{Key: tagKeyProcessor, Value: processor},
+		{Key: tagKeyInstanceID, Value: InstanceID()},
 	}
 }
 

--- a/service/service.go
+++ b/service/service.go
@@ -35,6 +35,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector/config/configcheck"
 	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
 	"github.com/open-telemetry/opentelemetry-collector/extension"
+	"github.com/open-telemetry/opentelemetry-collector/obsreport"
 	"github.com/open-telemetry/opentelemetry-collector/oterr"
 	"github.com/open-telemetry/opentelemetry-collector/service/builder"
 )
@@ -422,6 +423,7 @@ func (app *Application) execute(factory ConfigFactory) error {
 		zap.String("Version", app.info.Version),
 		zap.String("GitHash", app.info.GitHash),
 		zap.Int("NumCPU", runtime.NumCPU()),
+		zap.String(obsreport.InstanceIDKey, obsreport.InstanceID()),
 	)
 
 	// Set memory ballast


### PR DESCRIPTION
**Description:** This allows identifying different Collector instances independently of how the Collector is being deployed.
