### PR TITLE
Make prometheus reciever config loading strict (fixes #583)

### DIFF
--- a/receiver/prometheusreceiver/config_test.go
+++ b/receiver/prometheusreceiver/config_test.go
@@ -93,3 +93,20 @@ func TestLoadConfigFailsOnUnknownSection(t *testing.T) {
 	require.Error(t, err)
 	require.Nil(t, cfg)
 }
+
+// As one of the config parameters is consuming prometheus
+// configuration as a subkey, ensure that invalid configuration
+// within the subkey will also raise an error.
+func TestLoadConfigFailsOnUnknownPrometheusSection(t *testing.T) {
+	factories, err := config.ExampleComponents()
+	assert.Nil(t, err)
+
+	factory := &Factory{}
+	factories.Receivers[typeStr] = factory
+	cfg, err := config.LoadConfigFile(
+		t,
+		path.Join(".", "testdata", "invalid-config-prometheus-section.yaml"), factories)
+
+	require.Error(t, err)
+	require.Nil(t, cfg)
+}

--- a/receiver/prometheusreceiver/factory.go
+++ b/receiver/prometheusreceiver/factory.go
@@ -91,7 +91,7 @@ func CustomUnmarshalerFunc(v *viper.Viper, viperKey string, sourceViperSection *
 	out = []byte(os.ExpandEnv(string(out)))
 	config := intoCfg.(*Config)
 
-	err = yaml.Unmarshal(out, &config.PrometheusConfig)
+	err = yaml.UnmarshalStrict(out, &config.PrometheusConfig)
 	if err != nil {
 		return fmt.Errorf("prometheus receiver failed to unmarshal yaml to prometheus config: %s", err)
 	}

--- a/receiver/prometheusreceiver/testdata/invalid-config-prometheus-section.yaml
+++ b/receiver/prometheusreceiver/testdata/invalid-config-prometheus-section.yaml
@@ -1,0 +1,20 @@
+receivers:
+  prometheus:
+    config:
+      use_start_time_metric: true
+      scrape_configs:
+        - job_name: 'demo'
+          scrape_interval: 5s
+
+processors:
+  exampleprocessor:
+
+exporters:
+  exampleexporter:
+
+service:
+  pipelines:
+    traces:
+      receivers: [prometheus]
+      processors: [exampleprocessor]
+      exporters: [exampleexporter]


### PR DESCRIPTION
**Description:** 

Using strict umarshalling ensures eliminates common mistakes
such as adding a key intended for the prometheus reciever itself
into the prometheus subconfiguration.

It's worth noting that this is a backwards-incompatible change, as anyone currently using the prometheus receiver with a configuration including unused keys will now fail to start. 

I believe this is ok, as the guideline is to fail fast: https://github.com/open-telemetry/opentelemetry-collector/blob/master/CONTRIBUTING.md#startup-error-handling

**Link to tracking Issue:** 

Fixes #583

**Testing:**

reciever/prometheusreciever/TestLoadConfigFailsOnUnknownPrometheusSection