### PR TITLE
Fix G307 errors in gosec evaluation

### DIFF
--- a/testbed/tests/scenarios.go
+++ b/testbed/tests/scenarios.go
@@ -32,6 +32,7 @@ import (
 // createConfigFile creates a collector config file that corresponds to the
 // sender and receiver used in the test and returns the config file name.
 func createConfigFile(
+	t *testing.T,
 	sender testbed.DataSender, // Sender to send test data.
 	receiver testbed.DataReceiver, // Receiver to receive test data.
 	resultDir string, // Directory to write config file to.
@@ -128,14 +129,20 @@ service:
 	// Write the config string to a temporary file.
 	file, err := ioutil.TempFile("", "agent*.yaml")
 	if err != nil {
-		fmt.Print(err)
+		t.Error(err)
 		return ""
 	}
-	defer file.Close()
+
+	defer func() {
+		err := file.Close()
+		if err != nil {
+			t.Error(err)
+		}
+	}()
 
 	_, err = file.WriteString(config)
 	if err != nil {
-		fmt.Print(err)
+		t.Error(err)
 		return ""
 	}
 
@@ -156,7 +163,7 @@ func Scenario10kItemsPerSecond(
 		t.Fatal(err)
 	}
 
-	configFile := createConfigFile(sender, receiver, resultDir, nil)
+	configFile := createConfigFile(t, sender, receiver, resultDir, nil)
 	defer os.Remove(configFile)
 
 	if configFile == "" {

--- a/testbed/tests/trace_test.go
+++ b/testbed/tests/trace_test.go
@@ -323,7 +323,7 @@ func TestTraceAttributesProcessor(t *testing.T) {
 `,
 			}
 
-			configFile := createConfigFile(test.sender, test.receiver, resultDir, processors)
+			configFile := createConfigFile(t, test.sender, test.receiver, resultDir, processors)
 			defer os.Remove(configFile)
 
 			if configFile == "" {


### PR DESCRIPTION
Fix this issue:
```
[/Users/lazy/github/opentelemetry-collector/testbed/tests/scenarios.go:134] - G307 (CWE-): Deferring unsafe method "*os.File" on type "Close" (Confidence: HIGH, Severity: MEDIUM)
  > defer file.Close()
```

Updates https://github.com/open-telemetry/opentelemetry-collector/issues/672