### PR TITLE
Fix G302 errors in gosec evaluation

### DIFF
--- a/exporter/fileexporter/factory.go
+++ b/exporter/fileexporter/factory.go
@@ -67,7 +67,7 @@ func (f *Factory) createExporter(config configmodels.Exporter) (*Exporter, error
 	exporter, ok := exporters[cfg]
 
 	if !ok {
-		file, err := os.OpenFile(cfg.Path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0755)
+		file, err := os.OpenFile(cfg.Path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Fix this issue:
```
[/Users/lazy/github/opentelemetry-collector/exporter/fileexporter/factory.go:70] - G302 (CWE-276): Expect file permissions to be 0600 or less (Confidence: HIGH, Severity: MEDIUM)
  > os.OpenFile(cfg.Path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0755)
```

Updates https://github.com/open-telemetry/opentelemetry-collector/issues/672