### PR TITLE
Use instance label instead of address label when fetching instance me…

### DIFF
--- a/receiver/prometheusreceiver/internal/metadata.go
+++ b/receiver/prometheusreceiver/internal/metadata.go
@@ -45,7 +45,7 @@ func (t *mService) Get(job, instance string) (MetadataCache, error) {
 
 	// from the same targetGroup, instance is not going to be duplicated
 	for _, target := range targetGroup {
-		if target.DiscoveredLabels().Get(model.AddressLabel) == instance {
+		if target.Labels().Get(model.InstanceLabel) == instance {
 			return &mCache{target}, nil
 		}
 	}


### PR DESCRIPTION
Use instance label instead of address label when fetching instance metadata

**Description:**
Use instance label instead of address label when fetching instance metadata to allow using service discovery in prometheusreceiver

**Link to tracking Issue:** 

https://github.com/open-telemetry/opentelemetry-collector/issues/709

**Testing:**

**Documentation:** 