### PR TITLE
Add support of new type consumers to cloning fanout connectors

### DIFF
--- a/internal/data/metric.go
+++ b/internal/data/metric.go
@@ -15,6 +15,7 @@
 package data
 
 import (
+	"github.com/golang/protobuf/proto"
 	otlpmetrics "github.com/open-telemetry/opentelemetry-proto/gen/go/metrics/v1"
 )
 
@@ -47,6 +48,17 @@ func MetricDataToOtlp(md MetricData) []*otlpmetrics.ResourceMetrics {
 func NewMetricData() MetricData {
 	orig := []*otlpmetrics.ResourceMetrics(nil)
 	return MetricData{&orig}
+}
+
+// Clone returns a copy of MetricData.
+func (md MetricData) Clone() MetricData {
+	otlp := MetricDataToOtlp(md)
+	resourceMetricsClones := make([]*otlpmetrics.ResourceMetrics, 0, len(otlp))
+	for _, resourceMetrics := range otlp {
+		resourceMetricsClones = append(resourceMetricsClones,
+			proto.Clone(resourceMetrics).(*otlpmetrics.ResourceMetrics))
+	}
+	return MetricDataFromOtlp(resourceMetricsClones)
 }
 
 func (md MetricData) ResourceMetrics() ResourceMetricsSlice {

--- a/internal/data/testdata/metric.go
+++ b/internal/data/testdata/metric.go
@@ -1,0 +1,217 @@
+// Copyright 2020 OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testdata
+
+import (
+	"time"
+
+	"github.com/open-telemetry/opentelemetry-collector/internal/data"
+)
+
+var (
+	TestMetricStartTime      = time.Date(2020, 2, 11, 20, 26, 12, 321, time.UTC)
+	TestMetricStartTimestamp = data.TimestampUnixNano(TestMetricStartTime.UnixNano())
+
+	TestMetricExemplarTime      = time.Date(2020, 2, 11, 20, 26, 13, 123, time.UTC)
+	TestMetricExemplarTimestamp = data.TimestampUnixNano(TestMetricExemplarTime.UnixNano())
+
+	TestMetricTime      = time.Date(2020, 2, 11, 20, 26, 13, 789, time.UTC)
+	TestMetricTimestamp = data.TimestampUnixNano(TestMetricTime.UnixNano())
+)
+
+const (
+	TestGaugeDoubleMetricName         = "gauge-double"
+	TestGaugeIntMetricName            = "gauge-int"
+	TestCounterDoubleMetricName       = "counter-double"
+	TestCounterIntMetricName          = "counter-int"
+	TestGaugeHistogramMetricName      = "gauge-histogram"
+	TestCumulativeHistogramMetricName = "cumulative-histogram"
+	TestSummaryMetricName             = "summary"
+)
+
+func GenerateMetricDataOneEmptyResourceMetrics() data.MetricData {
+	md := data.NewMetricData()
+	md.SetResourceMetrics(data.NewResourceMetricsSlice(1))
+	return md
+}
+
+func GenerateMetricDataNoLibraries() data.MetricData {
+	md := GenerateMetricDataOneEmptyResourceMetrics()
+	md.ResourceMetrics().Get(0).Resource().SetAttributes(generateResourceAttributes1())
+	return md
+}
+
+func GenerateMetricDataNoMetrics() data.MetricData {
+	md := GenerateMetricDataNoLibraries()
+	md.ResourceMetrics().Get(0).SetInstrumentationLibraryMetrics(data.NewInstrumentationLibraryMetricsSlice(1))
+	return md
+}
+
+func GenerateMetricDataAllTypesNoDataPoints() data.MetricData {
+	md := GenerateMetricDataNoMetrics()
+	ilm0 := md.ResourceMetrics().Get(0).InstrumentationLibraryMetrics().Get(0)
+	ilm0.SetMetrics(data.NewMetricSlice(7))
+	ms := ilm0.Metrics()
+	fillMetricDescriptor(
+		ms.Get(0).MetricDescriptor(), TestGaugeDoubleMetricName, data.MetricTypeGaugeDouble)
+	fillMetricDescriptor(
+		ms.Get(1).MetricDescriptor(), TestGaugeIntMetricName, data.MetricTypeGaugeInt64)
+	fillMetricDescriptor(
+		ms.Get(2).MetricDescriptor(), TestCounterDoubleMetricName, data.MetricTypeCounterDouble)
+	fillMetricDescriptor(
+		ms.Get(3).MetricDescriptor(), TestCounterIntMetricName, data.MetricTypeCounterInt64)
+	fillMetricDescriptor(
+		ms.Get(4).MetricDescriptor(), TestGaugeHistogramMetricName, data.MetricTypeGaugeHistogram)
+	fillMetricDescriptor(
+		ms.Get(5).MetricDescriptor(), TestCumulativeHistogramMetricName, data.MetricTypeCumulativeHistogram)
+	fillMetricDescriptor(
+		ms.Get(6).MetricDescriptor(), TestSummaryMetricName, data.MetricTypeSummary)
+	return md
+}
+
+func GenerateMetricDataWithCountersHistogramAndSummary() data.MetricData {
+	metricData := data.NewMetricData()
+	metricData.SetResourceMetrics(data.NewResourceMetricsSlice(1))
+
+	rms := metricData.ResourceMetrics()
+	rms.Get(0).SetInstrumentationLibraryMetrics(data.NewInstrumentationLibraryMetricsSlice(1))
+	rms.Get(0).Resource().SetAttributes(generateResourceAttributes1())
+
+	ilms := rms.Get(0).InstrumentationLibraryMetrics()
+	ilms.Get(0).SetMetrics(data.NewMetricSlice(4))
+	ms := ilms.Get(0).Metrics()
+	fillCounterIntMetric(ms.Get(0))
+	fillCounterDoubleMetric(ms.Get(1))
+	fillCumulativeHistogramMetric(ms.Get(2))
+	fillSummaryMetric(ms.Get(3))
+
+	return metricData
+}
+
+func GenerateMetricDataOneMetricNoResource() data.MetricData {
+	md := GenerateMetricDataOneEmptyResourceMetrics()
+	rm0 := md.ResourceMetrics().Get(0)
+	rm0.SetInstrumentationLibraryMetrics(data.NewInstrumentationLibraryMetricsSlice(1))
+	rm0ils0 := rm0.InstrumentationLibraryMetrics().Get(0)
+	rm0ils0.SetMetrics(data.NewMetricSlice(1))
+	fillCounterIntMetric(rm0ils0.Metrics().Get(0))
+	return md
+}
+
+func GenerateMetricDataOneMetric() data.MetricData {
+	md := GenerateMetricDataNoMetrics()
+	rm0ils0 := md.ResourceMetrics().Get(0).InstrumentationLibraryMetrics().Get(0)
+	rm0ils0.SetMetrics(data.NewMetricSlice(1))
+	fillCounterIntMetric(rm0ils0.Metrics().Get(0))
+	return md
+}
+
+func GenerateMetricDataTwoMetrics() data.MetricData {
+	md := GenerateMetricDataNoMetrics()
+	rm0ils0 := md.ResourceMetrics().Get(0).InstrumentationLibraryMetrics().Get(0)
+	rm0ils0.SetMetrics(data.NewMetricSlice(2))
+	fillCounterIntMetric(rm0ils0.Metrics().Get(0))
+	fillCounterDoubleMetric(rm0ils0.Metrics().Get(1))
+	return md
+}
+
+func fillCounterIntMetric(im data.Metric) {
+	fillMetricDescriptor(im.MetricDescriptor(), TestCounterIntMetricName, data.MetricTypeCounterInt64)
+	im.SetInt64DataPoints(data.NewInt64DataPointSlice(2))
+	idp0 := im.Int64DataPoints().Get(0)
+	idp0.SetLabelsMap(data.NewStringMap(map[string]string{"int-label-1": "int-label-value-1"}))
+	idp0.SetStartTime(TestMetricStartTimestamp)
+	idp0.SetTimestamp(TestMetricTimestamp)
+	idp0.SetValue(123)
+	idp1 := im.Int64DataPoints().Get(1)
+	idp1.SetLabelsMap(data.NewStringMap(map[string]string{"int-label-2": "int-label-value-2"}))
+	idp1.SetStartTime(TestMetricStartTimestamp)
+	idp1.SetTimestamp(TestMetricTimestamp)
+	idp1.SetValue(456)
+}
+
+func fillCounterDoubleMetric(dm data.Metric) {
+	dm.SetDoubleDataPoints(data.NewDoubleDataPointSlice(1))
+	fillMetricDescriptor(dm.MetricDescriptor(), TestCounterDoubleMetricName, data.MetricTypeCounterDouble)
+	ddp0 := dm.DoubleDataPoints().Get(0)
+	ddp0.SetStartTime(TestMetricStartTimestamp)
+	ddp0.SetTimestamp(TestMetricTimestamp)
+	ddp0.SetValue(1.23)
+}
+
+func fillCumulativeHistogramMetric(hm data.Metric) {
+	hm.SetHistogramDataPoints(data.NewHistogramDataPointSlice(2))
+	fillMetricDescriptor(hm.MetricDescriptor(), TestCumulativeHistogramMetricName, data.MetricTypeCumulativeHistogram)
+
+	hdp0 := hm.HistogramDataPoints().Get(0)
+	hdp0.SetLabelsMap(data.NewStringMap(map[string]string{
+		"histogram-label-1": "histogram-label-value-1",
+		"histogram-label-3": "histogram-label-value-3",
+	}))
+	hdp0.SetStartTime(TestMetricStartTimestamp)
+	hdp0.SetTimestamp(TestMetricTimestamp)
+	hdp0.SetCount(1)
+	hdp0.SetSum(15)
+	hdp1 := hm.HistogramDataPoints().Get(1)
+	hdp1.SetLabelsMap(data.NewStringMap(map[string]string{
+		"histogram-label-2": "histogram-label-value-2",
+	}))
+	hdp1.SetStartTime(TestMetricStartTimestamp)
+	hdp1.SetTimestamp(TestMetricTimestamp)
+	hdp1.SetCount(1)
+	hdp1.SetSum(15)
+	hdp1.SetBuckets(data.NewHistogramBucketSlice(2))
+	hdp1.Buckets().Get(0).SetCount(0)
+	hdp1.Buckets().Get(1).SetCount(1)
+	hdp1.Buckets().Get(1).Exemplar().SetTimestamp(TestMetricExemplarTimestamp)
+	hdp1.Buckets().Get(1).Exemplar().SetValue(15)
+	hdp1.Buckets().Get(1).Exemplar().SetAttachments(data.NewStringMap(map[string]string{
+		"exemplar-attachment": "exemplar-attachment-value",
+	}))
+	hdp1.SetExplicitBounds([]float64{1})
+}
+
+func fillSummaryMetric(sm data.Metric) {
+	sm.SetSummaryDataPoints(data.NewSummaryDataPointSlice(2))
+	fillMetricDescriptor(sm.MetricDescriptor(), TestSummaryMetricName, data.MetricTypeSummary)
+
+	sdps := sm.SummaryDataPoints()
+	sdp0 := sdps.Get(0)
+	sdp0.SetLabelsMap(data.NewStringMap(map[string]string{
+		"summary-label": "summary-label-value-1",
+	}))
+	sdp0.SetStartTime(TestMetricStartTimestamp)
+	sdp0.SetTimestamp(TestMetricTimestamp)
+	sdp0.SetCount(1)
+	sdp0.SetSum(15)
+	sdp1 := sdps.Get(1)
+	sdp1.SetLabelsMap(data.NewStringMap(map[string]string{
+		"summary-label": "summary-label-value-2",
+	}))
+	sdp1.SetStartTime(TestMetricStartTimestamp)
+	sdp1.SetTimestamp(TestMetricTimestamp)
+	sdp1.SetCount(1)
+	sdp1.SetSum(15)
+	sdp1.SetValueAtPercentiles(data.NewSummaryValueAtPercentileSlice(1))
+	sdp1.ValueAtPercentiles().Get(0).SetPercentile(1)
+	sdp1.ValueAtPercentiles().Get(0).SetValue(15)
+}
+
+func fillMetricDescriptor(md data.MetricDescriptor, name string, ty data.MetricType) {
+	md.SetName(name)
+	md.SetDescription("")
+	md.SetUnit("1")
+	md.SetType(ty)
+}

--- a/internal/data/testdata/metric_test.go
+++ b/internal/data/testdata/metric_test.go
@@ -1,0 +1,29 @@
+// Copyright 2020 OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testdata
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGenerateMetricData(t *testing.T) {
+	assert.EqualValues(t, GenerateMetricDataNoLibraries(), GenerateMetricDataNoLibraries())
+	assert.EqualValues(t, GenerateMetricDataNoMetrics(), GenerateMetricDataNoMetrics())
+	assert.EqualValues(t, GenerateMetricDataOneMetricNoResource(), GenerateMetricDataOneMetricNoResource())
+	assert.EqualValues(t, GenerateMetricDataOneMetric(), GenerateMetricDataOneMetric())
+	assert.EqualValues(t, GenerateMetricDataTwoMetrics(), GenerateMetricDataTwoMetrics())
+}

--- a/internal/data/testdata/trace.go
+++ b/internal/data/testdata/trace.go
@@ -22,14 +22,14 @@ import (
 )
 
 var (
-	TestStartTime      = time.Date(2020, 2, 11, 20, 26, 12, 321, time.UTC)
-	TestStartTimestamp = data.TimestampUnixNano(TestStartTime.UnixNano())
+	TestSpanStartTime      = time.Date(2020, 2, 11, 20, 26, 12, 321, time.UTC)
+	TestSpanStartTimestamp = data.TimestampUnixNano(TestSpanStartTime.UnixNano())
 
-	TestEventTime      = time.Date(2020, 2, 11, 20, 26, 13, 123, time.UTC)
-	TestEventTimestamp = data.TimestampUnixNano(TestEventTime.UnixNano())
+	TestSpanEventTime      = time.Date(2020, 2, 11, 20, 26, 13, 123, time.UTC)
+	TestSpanEventTimestamp = data.TimestampUnixNano(TestSpanEventTime.UnixNano())
 
-	TestEndTime      = time.Date(2020, 2, 11, 20, 26, 13, 789, time.UTC)
-	TestEndTimestamp = data.TimestampUnixNano(TestEndTime.UnixNano())
+	TestSpanEndTime      = time.Date(2020, 2, 11, 20, 26, 13, 789, time.UTC)
+	TestSpanEndTimestamp = data.TimestampUnixNano(TestSpanEndTime.UnixNano())
 )
 
 // TraceTestCase represents one test case with the coresponding TraceData and OTLP representation.
@@ -47,37 +47,37 @@ var (
 	}
 	OneEmptyResourceSpansTraceTestCase = TraceTestCase{
 		Name:      "one-empty-resource-spans",
-		TraceData: generateTraceDataOneEmptyResourceSpans(),
+		TraceData: GenerateTraceDataOneEmptyResourceSpans(),
 		OtlpData:  generateTraceOtlpOneEmptyResourceSpans(),
 	}
 	NoLibrariesTraceTestCase = TraceTestCase{
 		Name:      "no-libraries",
-		TraceData: generateTraceDataNoLibraries(),
+		TraceData: GenerateTraceDataNoLibraries(),
 		OtlpData:  generateTraceOtlpNoLibraries(),
 	}
 	NoSpansTraceTestCase = TraceTestCase{
 		Name:      "no-spans",
-		TraceData: generateTraceDataNoSpans(),
+		TraceData: GenerateTraceDataNoSpans(),
 		OtlpData:  generateTraceOtlpNoSpans(),
 	}
 	OneSpanNoResourceTraceTestCase = TraceTestCase{
 		Name:      "one-span-no-resource",
-		TraceData: generateTraceDataOneSpanNoResource(),
+		TraceData: GenerateTraceDataOneSpanNoResource(),
 		OtlpData:  generateTraceOtlpOneSpanNoResource(),
 	}
 	OneSpanTraceTestCase = TraceTestCase{
 		Name:      "one-span",
-		TraceData: generateTraceDataOneSpan(),
+		TraceData: GenerateTraceDataOneSpan(),
 		OtlpData:  generateTraceOtlpOneSpan(),
 	}
 	TwoSpansSameResourceTraceTestCase = TraceTestCase{
 		Name:      "two-spans-same-resource",
-		TraceData: generateTraceDataSameResourceTwoSpans(),
+		TraceData: GenerateTraceDataSameResourceTwoSpans(),
 		OtlpData:  generateTraceOtlpSameResourceTwoSpans(),
 	}
 	TwoSpansSameResourceOneDifferentTraceTestCase = TraceTestCase{
 		Name:      "two-spans-same-resource-one-different",
-		TraceData: generateTraceDataTwoSpansSameResourceOneDifferent(),
+		TraceData: GenerateTraceDataTwoSpansSameResourceOneDifferent(),
 		OtlpData:  generateTraceOtlpTwoSpansSameResourceOneDifferent(),
 	}
 
@@ -94,27 +94,27 @@ var (
 	}
 )
 
-func generateTraceDataOneEmptyResourceSpans() data.TraceData {
+func GenerateTraceDataOneEmptyResourceSpans() data.TraceData {
 	td := data.NewTraceData()
 	td.SetResourceSpans(data.NewResourceSpansSlice(1))
 	return td
 }
 
-// generateTraceOtlpOneEmptyResourceSpans returns the OTLP representation of the generateTraceDataOneEmptyResourceSpans
+// generateTraceOtlpOneEmptyResourceSpans returns the OTLP representation of the GenerateTraceDataOneEmptyResourceSpans
 func generateTraceOtlpOneEmptyResourceSpans() []*otlptrace.ResourceSpans {
 	return []*otlptrace.ResourceSpans{
 		{},
 	}
 }
 
-func generateTraceDataNoLibraries() data.TraceData {
-	td := generateTraceDataOneEmptyResourceSpans()
+func GenerateTraceDataNoLibraries() data.TraceData {
+	td := GenerateTraceDataOneEmptyResourceSpans()
 	rs0 := td.ResourceSpans().Get(0)
 	fillResource1(rs0.Resource())
 	return td
 }
 
-// generateTraceOtlpDataNoLibraries returns the OTLP representation of the generateTraceDataNoLibraries.
+// generateTraceOtlpDataNoLibraries returns the OTLP representation of the GenerateTraceDataNoLibraries.
 func generateTraceOtlpNoLibraries() []*otlptrace.ResourceSpans {
 	return []*otlptrace.ResourceSpans{
 		{
@@ -123,14 +123,14 @@ func generateTraceOtlpNoLibraries() []*otlptrace.ResourceSpans {
 	}
 }
 
-func generateTraceDataNoSpans() data.TraceData {
-	td := generateTraceDataNoLibraries()
+func GenerateTraceDataNoSpans() data.TraceData {
+	td := GenerateTraceDataNoLibraries()
 	rs0 := td.ResourceSpans().Get(0)
 	rs0.SetInstrumentationLibrarySpans(data.NewInstrumentationLibrarySpansSlice(1))
 	return td
 }
 
-// generateTraceOtlpNoSpans returns the OTLP representation of the generateTraceDataNoSpans.
+// generateTraceOtlpNoSpans returns the OTLP representation of the GenerateTraceDataNoSpans.
 func generateTraceOtlpNoSpans() []*otlptrace.ResourceSpans {
 	return []*otlptrace.ResourceSpans{
 		{
@@ -142,8 +142,8 @@ func generateTraceOtlpNoSpans() []*otlptrace.ResourceSpans {
 	}
 }
 
-func generateTraceDataOneSpanNoResource() data.TraceData {
-	td := generateTraceDataOneEmptyResourceSpans()
+func GenerateTraceDataOneSpanNoResource() data.TraceData {
+	td := GenerateTraceDataOneEmptyResourceSpans()
 	rs0 := td.ResourceSpans().Get(0)
 	rs0.SetInstrumentationLibrarySpans(data.NewInstrumentationLibrarySpansSlice(1))
 	rs0ils0 := rs0.InstrumentationLibrarySpans().Get(0)
@@ -152,7 +152,7 @@ func generateTraceDataOneSpanNoResource() data.TraceData {
 	return td
 }
 
-// generateTraceOtlpOneSpanNoResource returns the OTLP representation of the generateTraceDataOneSpanNoResource.
+// generateTraceOtlpOneSpanNoResource returns the OTLP representation of the GenerateTraceDataOneSpanNoResource.
 func generateTraceOtlpOneSpanNoResource() []*otlptrace.ResourceSpans {
 	return []*otlptrace.ResourceSpans{
 		{
@@ -167,15 +167,15 @@ func generateTraceOtlpOneSpanNoResource() []*otlptrace.ResourceSpans {
 	}
 }
 
-func generateTraceDataOneSpan() data.TraceData {
-	td := generateTraceDataNoSpans()
+func GenerateTraceDataOneSpan() data.TraceData {
+	td := GenerateTraceDataNoSpans()
 	rs0ils0 := td.ResourceSpans().Get(0).InstrumentationLibrarySpans().Get(0)
 	rs0ils0.SetSpans(data.NewSpanSlice(1))
 	fillSpanOne(rs0ils0.Spans().Get(0))
 	return td
 }
 
-// generateTraceOtlpOneSpan returns the OTLP representation of the generateTraceDataOneSpan.
+// generateTraceOtlpOneSpan returns the OTLP representation of the GenerateTraceDataOneSpan.
 func generateTraceOtlpOneSpan() []*otlptrace.ResourceSpans {
 	return []*otlptrace.ResourceSpans{
 		{
@@ -191,8 +191,8 @@ func generateTraceOtlpOneSpan() []*otlptrace.ResourceSpans {
 	}
 }
 
-func generateTraceDataSameResourceTwoSpans() data.TraceData {
-	td := generateTraceDataNoSpans()
+func GenerateTraceDataSameResourceTwoSpans() data.TraceData {
+	td := GenerateTraceDataNoSpans()
 	rs0ils0 := td.ResourceSpans().Get(0).InstrumentationLibrarySpans().Get(0)
 	rs0ils0.SetSpans(data.NewSpanSlice(2))
 	fillSpanOne(rs0ils0.Spans().Get(0))
@@ -217,11 +217,11 @@ func generateTraceOtlpSameResourceTwoSpans() []*otlptrace.ResourceSpans {
 	}
 }
 
-func generateTraceDataTwoSpansSameResourceOneDifferent() data.TraceData {
+func GenerateTraceDataTwoSpansSameResourceOneDifferent() data.TraceData {
 	td := data.NewTraceData()
 	td.SetResourceSpans(data.NewResourceSpansSlice(2))
 	rs0 := td.ResourceSpans().Get(0)
-	rs0.Resource().SetAttributes(generateResourceAttributes1())
+	fillResource1(rs0.Resource())
 	rs0.SetInstrumentationLibrarySpans(data.NewInstrumentationLibrarySpansSlice(1))
 	rs0ils0 := rs0.InstrumentationLibrarySpans().Get(0)
 	rs0ils0.SetSpans(data.NewSpanSlice(2))
@@ -236,7 +236,7 @@ func generateTraceDataTwoSpansSameResourceOneDifferent() data.TraceData {
 	return td
 }
 
-// generateTraceOtlpTwoSpansSameResourceOneDifferent returns the OTLP representation of the generateTraceDataTwoSpansSameResourceOneDifferent.
+// generateTraceOtlpTwoSpansSameResourceOneDifferent returns the OTLP representation of the GenerateTraceDataTwoSpansSameResourceOneDifferent.
 func generateTraceOtlpTwoSpansSameResourceOneDifferent() []*otlptrace.ResourceSpans {
 	return []*otlptrace.ResourceSpans{
 		{
@@ -265,17 +265,17 @@ func generateTraceOtlpTwoSpansSameResourceOneDifferent() []*otlptrace.ResourceSp
 
 func fillSpanOne(span data.Span) {
 	span.SetName("operationA")
-	span.SetStartTime(TestStartTimestamp)
-	span.SetEndTime(TestEndTimestamp)
+	span.SetStartTime(TestSpanStartTimestamp)
+	span.SetEndTime(TestSpanEndTimestamp)
 	span.SetDroppedAttributesCount(1)
 	span.SetEvents(data.NewSpanEventSlice(2))
 	ev0 := span.Events().Get(0)
-	ev0.SetTimestamp(TestEventTimestamp)
+	ev0.SetTimestamp(TestSpanEventTimestamp)
 	ev0.SetName("event-with-attr")
 	ev0.SetAttributes(generateSpanEventAttributes())
 	ev0.SetDroppedAttributesCount(2)
 	ev1 := span.Events().Get(1)
-	ev1.SetTimestamp(TestEventTimestamp)
+	ev1.SetTimestamp(TestSpanEventTimestamp)
 	ev1.SetName("event")
 	ev1.SetDroppedAttributesCount(2)
 	span.SetDroppedEventsCount(1)
@@ -286,19 +286,19 @@ func fillSpanOne(span data.Span) {
 func generateOtlpSpanOne() *otlptrace.Span {
 	return &otlptrace.Span{
 		Name:                   "operationA",
-		StartTimeUnixNano:      uint64(TestStartTimestamp),
-		EndTimeUnixNano:        uint64(TestEndTimestamp),
+		StartTimeUnixNano:      uint64(TestSpanStartTimestamp),
+		EndTimeUnixNano:        uint64(TestSpanEndTimestamp),
 		DroppedAttributesCount: 1,
 		Events: []*otlptrace.Span_Event{
 			{
 				Name:                   "event-with-attr",
-				TimeUnixNano:           uint64(TestEventTimestamp),
+				TimeUnixNano:           uint64(TestSpanEventTimestamp),
 				Attributes:             generateOtlpSpanEventAttributes(),
 				DroppedAttributesCount: 2,
 			},
 			{
 				Name:                   "event",
-				TimeUnixNano:           uint64(TestEventTimestamp),
+				TimeUnixNano:           uint64(TestSpanEventTimestamp),
 				DroppedAttributesCount: 2,
 			},
 		},
@@ -312,8 +312,8 @@ func generateOtlpSpanOne() *otlptrace.Span {
 
 func fillSpanTwo(span data.Span) {
 	span.SetName("operationB")
-	span.SetStartTime(TestStartTimestamp)
-	span.SetEndTime(TestEndTimestamp)
+	span.SetStartTime(TestSpanStartTimestamp)
+	span.SetEndTime(TestSpanEndTimestamp)
 	span.SetLinks(data.NewSpanLinkSlice(2))
 	span.Links().Get(0).SetAttributes(generateSpanLinkAttributes())
 	span.Links().Get(0).SetDroppedAttributesCount(4)
@@ -324,8 +324,8 @@ func fillSpanTwo(span data.Span) {
 func generateOtlpSpanTwo() *otlptrace.Span {
 	return &otlptrace.Span{
 		Name:              "operationB",
-		StartTimeUnixNano: uint64(TestStartTimestamp),
-		EndTimeUnixNano:   uint64(TestEndTimestamp),
+		StartTimeUnixNano: uint64(TestSpanStartTimestamp),
+		EndTimeUnixNano:   uint64(TestSpanEndTimestamp),
 		Links: []*otlptrace.Span_Link{
 			{
 				Attributes:             generateOtlpSpanLinkAttributes(),
@@ -341,17 +341,17 @@ func generateOtlpSpanTwo() *otlptrace.Span {
 
 func fillSpanThree(span data.Span) {
 	span.SetName("operationC")
-	span.SetStartTime(TestStartTimestamp)
-	span.SetEndTime(TestEndTimestamp)
-	span.SetAttributes(generateSpanAttributes())
+	span.SetStartTime(TestSpanStartTimestamp)
+	span.SetEndTime(TestSpanEndTimestamp)
+	span.SetAttributes(data.NewAttributeMap(spanAttributes))
 	span.SetDroppedAttributesCount(5)
 }
 
 func generateOtlpSpanThree() *otlptrace.Span {
 	return &otlptrace.Span{
 		Name:                   "operationC",
-		StartTimeUnixNano:      uint64(TestStartTimestamp),
-		EndTimeUnixNano:        uint64(TestEndTimestamp),
+		StartTimeUnixNano:      uint64(TestSpanStartTimestamp),
+		EndTimeUnixNano:        uint64(TestSpanEndTimestamp),
 		Attributes:             generateOtlpSpanAttributes(),
 		DroppedAttributesCount: 5,
 	}

--- a/internal/data/testdata/trace_test.go
+++ b/internal/data/testdata/trace_test.go
@@ -21,13 +21,14 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGeneratedTraceData(t *testing.T) {
-	assert.EqualValues(t, generateTraceDataNoLibraries(), generateTraceDataNoLibraries())
-	assert.EqualValues(t, generateTraceDataNoSpans(), generateTraceDataNoSpans())
-	assert.EqualValues(t, generateTraceDataOneSpanNoResource(), generateTraceDataOneSpanNoResource())
-	assert.EqualValues(t, generateTraceDataOneSpan(), generateTraceDataOneSpan())
-	assert.EqualValues(t, generateTraceDataSameResourceTwoSpans(), generateTraceDataSameResourceTwoSpans())
-	assert.EqualValues(t, generateTraceDataTwoSpansSameResourceOneDifferent(), generateTraceDataTwoSpansSameResourceOneDifferent())
+func TestGenerateTraceData(t *testing.T) {
+	assert.EqualValues(t, GenerateTraceDataOneEmptyResourceSpans(), GenerateTraceDataOneEmptyResourceSpans())
+	assert.EqualValues(t, GenerateTraceDataNoLibraries(), GenerateTraceDataNoLibraries())
+	assert.EqualValues(t, GenerateTraceDataNoSpans(), GenerateTraceDataNoSpans())
+	assert.EqualValues(t, GenerateTraceDataOneSpanNoResource(), GenerateTraceDataOneSpanNoResource())
+	assert.EqualValues(t, GenerateTraceDataOneSpan(), GenerateTraceDataOneSpan())
+	assert.EqualValues(t, GenerateTraceDataSameResourceTwoSpans(), GenerateTraceDataSameResourceTwoSpans())
+	assert.EqualValues(t, GenerateTraceDataTwoSpansSameResourceOneDifferent(), GenerateTraceDataTwoSpansSameResourceOneDifferent())
 }
 
 func TestGeneratedTraceOtlp(t *testing.T) {

--- a/internal/data/trace.go
+++ b/internal/data/trace.go
@@ -15,6 +15,7 @@
 package data
 
 import (
+	"github.com/golang/protobuf/proto"
 	otlptrace "github.com/open-telemetry/opentelemetry-proto/gen/go/trace/v1"
 )
 
@@ -33,14 +34,25 @@ func TraceDataFromOtlp(orig []*otlptrace.ResourceSpans) TraceData {
 }
 
 // TraceDataToOtlp converts the internal TraceData to the OTLP.
-func TraceDataToOtlp(md TraceData) []*otlptrace.ResourceSpans {
-	return *md.orig
+func TraceDataToOtlp(td TraceData) []*otlptrace.ResourceSpans {
+	return *td.orig
 }
 
 // NewTraceData creates a new TraceData.
 func NewTraceData() TraceData {
 	orig := []*otlptrace.ResourceSpans(nil)
 	return TraceData{&orig}
+}
+
+// Clone returns a copy of TraceData.
+func (td TraceData) Clone() TraceData {
+	otlp := TraceDataToOtlp(td)
+	resourceSpansClones := make([]*otlptrace.ResourceSpans, 0, len(otlp))
+	for _, resourceSpans := range otlp {
+		resourceSpansClones = append(resourceSpansClones,
+			proto.Clone(resourceSpans).(*otlptrace.ResourceSpans))
+	}
+	return TraceDataFromOtlp(resourceSpansClones)
 }
 
 // SpanCount calculates the total number of spans.

--- a/processor/cloningfanoutconnector_test.go
+++ b/processor/cloningfanoutconnector_test.go
@@ -28,15 +28,18 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-collector/consumer"
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
+	"github.com/open-telemetry/opentelemetry-collector/internal/data"
+	"github.com/open-telemetry/opentelemetry-collector/internal/data/testdata"
+	"github.com/open-telemetry/opentelemetry-collector/translator/conventions"
 )
 
-func TestTraceProcessorCloningMultiplexing(t *testing.T) {
+func TestTraceProcessorCloningMultiplexingOld(t *testing.T) {
 	processors := make([]consumer.TraceConsumerOld, 3)
 	for i := range processors {
 		processors[i] = &mockTraceConsumerOld{}
 	}
 
-	tfc := NewTraceCloningFanOutConnector(processors)
+	tfc := NewTraceCloningFanOutConnectorOld(processors)
 	td := consumerdata.TraceData{
 		Spans: make([]*tracepb.Span, 7),
 		Resource: &resourcepb.Resource{
@@ -66,13 +69,13 @@ func TestTraceProcessorCloningMultiplexing(t *testing.T) {
 	}
 }
 
-func TestMetricsProcessorCloningMultiplexing(t *testing.T) {
+func TestMetricsProcessorCloningMultiplexingOld(t *testing.T) {
 	processors := make([]consumer.MetricsConsumerOld, 3)
 	for i := range processors {
 		processors[i] = &mockMetricsConsumerOld{}
 	}
 
-	mfc := NewMetricsCloningFanOutConnector(processors)
+	mfc := NewMetricsCloningFanOutConnectorOld(processors)
 	md := consumerdata.MetricsData{
 		Metrics: make([]*metricspb.Metric, 7),
 		Resource: &resourcepb.Resource{
@@ -99,6 +102,125 @@ func TestMetricsProcessorCloningMultiplexing(t *testing.T) {
 			assert.True(t, md.Resource == m.Metrics[0].Resource)
 		}
 		assert.EqualValues(t, md.Resource, m.Metrics[0].Resource)
+	}
+}
+
+func Benchmark100SpanCloneOld(b *testing.B) {
+
+	b.StopTimer()
+
+	name := tracepb.TruncatableString{Value: "testspanname"}
+	traceData := &consumerdata.TraceData{
+		SourceFormat: "test-source-format",
+		Node: &commonpb.Node{
+			ServiceInfo: &commonpb.ServiceInfo{
+				Name: "servicename",
+			},
+		},
+		Resource: &resourcepb.Resource{
+			Type: "resourcetype",
+		},
+	}
+	for i := 0; i < 100; i++ {
+		span := &tracepb.Span{
+			TraceId: genRandBytes(16),
+			SpanId:  genRandBytes(8),
+			Name:    &name,
+			Attributes: &tracepb.Span_Attributes{
+				AttributeMap: map[string]*tracepb.AttributeValue{},
+			},
+		}
+
+		for j := 0; j < 5; j++ {
+			span.Attributes.AttributeMap["intattr"+strconv.Itoa(j)] = &tracepb.AttributeValue{
+				Value: &tracepb.AttributeValue_IntValue{IntValue: int64(i)},
+			}
+			span.Attributes.AttributeMap["strattr"+strconv.Itoa(j)] = &tracepb.AttributeValue{
+				Value: &tracepb.AttributeValue_StringValue{
+					StringValue: &tracepb.TruncatableString{Value: string(genRandBytes(20))},
+				},
+			}
+		}
+
+		traceData.Spans = append(traceData.Spans, span)
+	}
+
+	b.StartTimer()
+
+	for i := 0; i < b.N; i++ {
+		cloneTraceDataOld(traceData)
+	}
+}
+
+func TestTraceProcessorCloningMultiplexing(t *testing.T) {
+	processors := make([]consumer.TraceConsumer, 3)
+	for i := range processors {
+		processors[i] = &mockTraceConsumer{}
+	}
+
+	tfc := NewTraceCloningFanOutConnector(processors)
+	td := testdata.GenerateTraceDataSameResourceTwoSpans()
+
+	var wantSpansCount = 0
+	for i := 0; i < 2; i++ {
+		wantSpansCount += td.SpanCount()
+		err := tfc.ConsumeTrace(context.Background(), td)
+		if err != nil {
+			t.Errorf("Wanted nil got error")
+			return
+		}
+	}
+
+	for i, p := range processors {
+		m := p.(*mockTraceConsumer)
+		assert.Equal(t, wantSpansCount, m.TotalSpans)
+		spanOrig := td.ResourceSpans().Get(0).InstrumentationLibrarySpans().Get(0).Spans().Get(0)
+		spanClone := m.Traces[0].ResourceSpans().Get(0).InstrumentationLibrarySpans().Get(0).Spans().Get(0)
+		if i < len(processors)-1 {
+			assert.True(t, td.ResourceSpans().Get(0).Resource() != m.Traces[0].ResourceSpans().Get(0).Resource())
+			assert.True(t, spanOrig != spanClone)
+		} else {
+			assert.True(t, td.ResourceSpans().Get(0).Resource() == m.Traces[0].ResourceSpans().Get(0).Resource())
+			assert.True(t, spanOrig == spanClone)
+		}
+		assert.EqualValues(t, td.ResourceSpans().Get(0).Resource(), m.Traces[0].ResourceSpans().Get(0).Resource())
+		assert.EqualValues(t, spanOrig, spanClone)
+	}
+}
+
+func TestMetricsProcessorCloningMultiplexing(t *testing.T) {
+	processors := make([]consumer.MetricsConsumer, 3)
+	for i := range processors {
+		processors[i] = &mockMetricsConsumer{}
+	}
+
+	mfc := NewMetricsCloningFanOutConnector(processors)
+	md := testdata.GenerateMetricDataTwoMetrics()
+
+	var wantMetricsCount = 0
+	for i := 0; i < 2; i++ {
+		wantMetricsCount += md.MetricCount()
+		err := mfc.ConsumeMetrics(context.Background(), md)
+		if err != nil {
+			t.Errorf("Wanted nil got error")
+			return
+		}
+	}
+
+	for i, p := range processors {
+		m := p.(*mockMetricsConsumer)
+		assert.Equal(t, wantMetricsCount, m.TotalMetrics)
+		metricOrig := md.ResourceMetrics().Get(0).InstrumentationLibraryMetrics().Get(0).Metrics().Get(0)
+		metricClone := m.Metrics[0].ResourceMetrics().Get(0).InstrumentationLibraryMetrics().Get(0).Metrics().Get(0)
+		if i < len(processors)-1 {
+			assert.True(t, md.ResourceMetrics().Get(0).Resource() != m.Metrics[0].ResourceMetrics().Get(0).Resource())
+			assert.True(t, metricOrig != metricClone)
+		} else {
+			assert.True(t, md.ResourceMetrics().Get(0).Resource() == m.Metrics[0].ResourceMetrics().Get(0).Resource())
+			assert.True(t, metricOrig == metricClone)
+		}
+		assert.EqualValues(t, md.ResourceMetrics().Get(0).Resource(), m.Metrics[0].ResourceMetrics().Get(0).Resource())
+		assert.EqualValues(t, metricOrig, metricClone)
 	}
 }
 
@@ -145,8 +267,68 @@ func Benchmark100SpanClone(b *testing.B) {
 	b.StartTimer()
 
 	for i := 0; i < b.N; i++ {
-		cloneTraceData(traceData)
+		cloneTraceDataOld(traceData)
 	}
+}
+
+func TestCreateTraceCloningFanOutConnectorWithConvertion(t *testing.T) {
+	traceConsumerOld := &mockTraceConsumerOld{}
+	traceConsumer := &mockTraceConsumer{}
+	processors := []consumer.TraceConsumerBase{
+		traceConsumerOld,
+		traceConsumer,
+	}
+
+	resourceTypeName := "good-resource"
+
+	td := testdata.GenerateTraceDataSameResourceTwoSpans()
+	resource := td.ResourceSpans().Get(0).Resource()
+	resource.Attributes().Upsert(data.NewAttributeKeyValueString(conventions.OCAttributeResourceType, resourceTypeName))
+
+	tfc := CreateTraceCloningFanOutConnector(processors).(consumer.TraceConsumer)
+
+	var wantSpansCount = 0
+	for i := 0; i < 2; i++ {
+		wantSpansCount += td.SpanCount()
+		err := tfc.ConsumeTrace(context.Background(), td)
+		assert.NoError(t, err)
+	}
+
+	assert.Equal(t, wantSpansCount, traceConsumerOld.TotalSpans)
+	assert.Equal(t, resourceTypeName, traceConsumerOld.Traces[0].Resource.Type)
+
+	assert.Equal(t, wantSpansCount, traceConsumer.TotalSpans)
+	assert.Equal(t, resource, traceConsumer.Traces[0].ResourceSpans().Get(0).Resource())
+}
+
+func TestCreateMetricsCloningFanOutConnectorWithConvertion(t *testing.T) {
+	metricsConsumerOld := &mockMetricsConsumerOld{}
+	metricsConsumer := &mockMetricsConsumer{}
+	processors := []consumer.MetricsConsumerBase{
+		metricsConsumerOld,
+		metricsConsumer,
+	}
+
+	resourceTypeName := "good-resource"
+
+	md := testdata.GenerateMetricDataTwoMetrics()
+	resource := md.ResourceMetrics().Get(0).Resource()
+	resource.Attributes().Upsert(data.NewAttributeKeyValueString(conventions.OCAttributeResourceType, resourceTypeName))
+
+	mfc := CreateMetricsCloningFanOutConnector(processors).(consumer.MetricsConsumer)
+
+	var wantSpansCount = 0
+	for i := 0; i < 2; i++ {
+		wantSpansCount += md.MetricCount()
+		err := mfc.ConsumeMetrics(context.Background(), md)
+		assert.NoError(t, err)
+	}
+
+	assert.Equal(t, wantSpansCount, metricsConsumerOld.TotalMetrics)
+	assert.Equal(t, resourceTypeName, metricsConsumerOld.Metrics[0].Resource.Type)
+
+	assert.Equal(t, wantSpansCount, metricsConsumer.TotalMetrics)
+	assert.Equal(t, resource, metricsConsumer.Metrics[0].ResourceMetrics().Get(0).Resource())
 }
 
 func genRandBytes(len int) []byte {

--- a/translator/internaldata/metrics_to_oc_test.go
+++ b/translator/internaldata/metrics_to_oc_test.go
@@ -29,10 +29,20 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-collector/internal"
 	"github.com/open-telemetry/opentelemetry-collector/internal/data"
+	"github.com/open-telemetry/opentelemetry-collector/internal/data/testdata"
 	"github.com/open-telemetry/opentelemetry-collector/translator/conventions"
 )
 
 func TestResourceMetricsToMetricsData(t *testing.T) {
+
+	sampleMetricData := testdata.GenerateMetricDataWithCountersHistogramAndSummary()
+	attrs := sampleMetricData.ResourceMetrics().Get(0).Resource().Attributes()
+	attrs.Upsert(data.NewAttributeKeyValueString(conventions.AttributeHostHostname, "host1"))
+	attrs.Upsert(data.NewAttributeKeyValueString(conventions.OCAttributeProcessID, "123"))
+	attrs.Upsert(data.NewAttributeKeyValueString(conventions.OCAttributeProcessStartTime, "2020-02-11T20:26:00Z"))
+	attrs.Upsert(data.NewAttributeKeyValueString(conventions.AttributeLibraryLanguage, "CPP"))
+	attrs.Upsert(data.NewAttributeKeyValueString(conventions.AttributeLibraryVersion, "v2.0.1"))
+	attrs.Upsert(data.NewAttributeKeyValueString(conventions.OCAttributeExporterVersion, "v1.2.0"))
 
 	tests := []struct {
 		name     string
@@ -47,7 +57,7 @@ func TestResourceMetricsToMetricsData(t *testing.T) {
 
 		{
 			name:     "no-libraries",
-			internal: generateInternalTestDataNoLibraries(),
+			internal: testdata.GenerateMetricDataNoLibraries(),
 			oc: []consumerdata.MetricsData{
 				generateOcTestDataNoMetrics(),
 			},
@@ -55,7 +65,7 @@ func TestResourceMetricsToMetricsData(t *testing.T) {
 
 		{
 			name:     "no-metrics",
-			internal: generateInternalTestDataNoMetrics(),
+			internal: testdata.GenerateMetricDataNoMetrics(),
 			oc: []consumerdata.MetricsData{
 				generateOcTestDataNoMetrics(),
 			},
@@ -63,7 +73,7 @@ func TestResourceMetricsToMetricsData(t *testing.T) {
 
 		{
 			name:     "no-points",
-			internal: generateInternalTestDataNoPoints(),
+			internal: testdata.GenerateMetricDataAllTypesNoDataPoints(),
 			oc: []consumerdata.MetricsData{
 				generateOcTestDataNoPoints(),
 			},
@@ -71,7 +81,7 @@ func TestResourceMetricsToMetricsData(t *testing.T) {
 
 		{
 			name:     "sample-metric",
-			internal: generateInternalTestData(),
+			internal: sampleMetricData,
 			oc: []consumerdata.MetricsData{
 				generateOcTestData(t),
 			},
@@ -81,162 +91,82 @@ func TestResourceMetricsToMetricsData(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			got := MetricDataToOC(test.internal)
-			if test.name == "sample-metric" {
-				edv := test.oc[0].Metrics[2].Timeseries[1].Points[0].GetDistributionValue()
-				gdv := got[0].Metrics[2].Timeseries[1].Points[0].GetDistributionValue()
-				assert.EqualValues(t, edv, gdv)
-				assert.EqualValues(t, edv.Buckets[0].Exemplar, gdv.Buckets[0].Exemplar)
-			}
 			assert.EqualValues(t, test.oc, got)
 		})
 	}
 }
 
-const startTimeUnixNano = data.TimestampUnixNano(1585012403000000789)
-const timeUnixNano = data.TimestampUnixNano(1585012403000000789)
-
-func generateInternalTestDataNoLibraries() data.MetricData {
-	metricDataNoLibraries := data.NewMetricData()
-	metricDataNoLibraries.SetResourceMetrics(data.NewResourceMetricsSlice(1))
-	return metricDataNoLibraries
-}
-
-func generateInternalTestDataNoMetrics() data.MetricData {
-	metricDataNoMetrics := data.NewMetricData()
-	metricDataNoMetrics.SetResourceMetrics(data.NewResourceMetricsSlice(1))
-	metricDataNoMetrics.ResourceMetrics().Get(0).SetInstrumentationLibraryMetrics(data.NewInstrumentationLibraryMetricsSlice(1))
-	return metricDataNoMetrics
-}
-
-func generateInternalTestDataNoPoints() data.MetricData {
-	metricDataNoPoints := data.NewMetricData()
-	metricDataNoPoints.SetResourceMetrics(data.NewResourceMetricsSlice(1))
-	metricDataNoPoints.ResourceMetrics().Get(0).SetInstrumentationLibraryMetrics(data.NewInstrumentationLibraryMetricsSlice(1))
-	metricDataNoPoints.ResourceMetrics().Get(0).InstrumentationLibraryMetrics().Get(0).SetMetrics(data.NewMetricSlice(1))
-	fillMetricDescriptor(
-		metricDataNoPoints.ResourceMetrics().Get(0).InstrumentationLibraryMetrics().Get(0).Metrics().Get(0).MetricDescriptor(), "no-points", data.MetricTypeGaugeDouble)
-	return metricDataNoPoints
-}
-
-func generateInternalTestData() data.MetricData {
-	metricData := data.NewMetricData()
-	metricData.SetResourceMetrics(data.NewResourceMetricsSlice(1))
-
-	rms := metricData.ResourceMetrics()
-	rms.Get(0).SetInstrumentationLibraryMetrics(data.NewInstrumentationLibraryMetricsSlice(1))
-	rms.Get(0).Resource().SetAttributes(data.NewAttributeMap(data.AttributesMap{
-		conventions.OCAttributeProcessStartTime: data.NewAttributeValueString("2020-02-11T20:26:00Z"),
-		conventions.AttributeHostHostname:       data.NewAttributeValueString("host1"),
-		conventions.OCAttributeProcessID:        data.NewAttributeValueString("123"),
-		conventions.AttributeLibraryVersion:     data.NewAttributeValueString("v2.0.1"),
-		conventions.OCAttributeExporterVersion:  data.NewAttributeValueString("v1.2.0"),
-		conventions.AttributeLibraryLanguage:    data.NewAttributeValueString("CPP"),
-		conventions.OCAttributeResourceType:     data.NewAttributeValueString("good-resource"),
-		"str1":                                  data.NewAttributeValueString("text"),
-		"int2":                                  data.NewAttributeValueInt(123),
-	}))
-
-	ilms := rms.Get(0).InstrumentationLibraryMetrics()
-	ilms.Get(0).SetMetrics(data.NewMetricSlice(4))
-
-	metrics := ilms.Get(0).Metrics()
-
-	intMetric := metrics.Get(0)
-	fillMetricDescriptor(intMetric.MetricDescriptor(), "mymetric-int", data.MetricTypeCounterInt64)
-	intMetric.SetInt64DataPoints(data.NewInt64DataPointSlice(2))
-	int64DataPoints := intMetric.Int64DataPoints()
-	int64DataPoints.Get(0).SetLabelsMap(data.NewStringMap(map[string]string{"key1": "value1"}))
-	int64DataPoints.Get(0).SetStartTime(startTimeUnixNano)
-	int64DataPoints.Get(0).SetTimestamp(timeUnixNano)
-	int64DataPoints.Get(0).SetValue(123)
-	int64DataPoints.Get(1).SetLabelsMap(data.NewStringMap(map[string]string{"key2": "value2"}))
-	int64DataPoints.Get(1).SetStartTime(startTimeUnixNano)
-	int64DataPoints.Get(1).SetTimestamp(timeUnixNano)
-	int64DataPoints.Get(1).SetValue(456)
-
-	doubleMetric := metrics.Get(1)
-	doubleMetric.SetDoubleDataPoints(data.NewDoubleDataPointSlice(1))
-	fillMetricDescriptor(doubleMetric.MetricDescriptor(), "mymetric-double", data.MetricTypeCounterDouble)
-	doubleDataPoints := doubleMetric.DoubleDataPoints()
-	doubleDataPoints.Get(0).SetStartTime(startTimeUnixNano)
-	doubleDataPoints.Get(0).SetTimestamp(timeUnixNano)
-	doubleDataPoints.Get(0).SetValue(1.23)
-
-	histogramMetric := metrics.Get(2)
-	histogramMetric.SetHistogramDataPoints(data.NewHistogramDataPointSlice(2))
-	fillMetricDescriptor(histogramMetric.MetricDescriptor(), "mymetric-histogram", data.MetricTypeCumulativeHistogram)
-
-	histogramDataPoints := histogramMetric.HistogramDataPoints()
-	histogramDataPoints.Get(0).SetLabelsMap(data.NewStringMap(map[string]string{
-		"key1": "histogram-value1",
-		"key3": "histogram-value3",
-	}))
-	histogramDataPoints.Get(0).SetStartTime(startTimeUnixNano)
-	histogramDataPoints.Get(0).SetTimestamp(timeUnixNano)
-	histogramDataPoints.Get(0).SetCount(1)
-	histogramDataPoints.Get(0).SetSum(15)
-	histogramDataPoints.Get(1).SetLabelsMap(data.NewStringMap(map[string]string{
-		"key2": "histogram-value2",
-	}))
-	histogramDataPoints.Get(1).SetStartTime(startTimeUnixNano)
-	histogramDataPoints.Get(1).SetTimestamp(timeUnixNano)
-	histogramDataPoints.Get(1).SetCount(1)
-	histogramDataPoints.Get(1).SetSum(15)
-	histogramDataPoints.Get(1).SetBuckets(data.NewHistogramBucketSlice(2))
-	histogramDataPoints.Get(1).Buckets().Get(0).SetCount(0)
-	histogramDataPoints.Get(1).Buckets().Get(1).SetCount(1)
-	histogramDataPoints.Get(1).Buckets().Get(1).Exemplar().SetTimestamp(startTimeUnixNano)
-	histogramDataPoints.Get(1).Buckets().Get(1).Exemplar().SetValue(15)
-	histogramDataPoints.Get(1).Buckets().Get(1).Exemplar().SetAttachments(data.NewStringMap(map[string]string{
-		"key": "value",
-	}))
-	histogramDataPoints.Get(1).SetExplicitBounds([]float64{1})
-
-	summaryMetric := metrics.Get(3)
-	summaryMetric.SetSummaryDataPoints(data.NewSummaryDataPointSlice(2))
-	fillMetricDescriptor(summaryMetric.MetricDescriptor(), "mymetric-summary", data.MetricTypeSummary)
-
-	summaryDataPoints := summaryMetric.SummaryDataPoints()
-	summaryDataPoints.Get(0).SetLabelsMap(data.NewStringMap(map[string]string{
-		"key1": "summary-value1",
-	}))
-	summaryDataPoints.Get(0).SetStartTime(startTimeUnixNano)
-	summaryDataPoints.Get(0).SetTimestamp(timeUnixNano)
-	summaryDataPoints.Get(0).SetCount(1)
-	summaryDataPoints.Get(0).SetSum(15)
-	summaryDataPoints.Get(1).SetLabelsMap(data.NewStringMap(map[string]string{
-		"key1": "summary-value2",
-	}))
-	summaryDataPoints.Get(1).SetStartTime(startTimeUnixNano)
-	summaryDataPoints.Get(1).SetTimestamp(timeUnixNano)
-	summaryDataPoints.Get(1).SetCount(1)
-	summaryDataPoints.Get(1).SetSum(15)
-	summaryDataPoints.Get(1).SetValueAtPercentiles(data.NewSummaryValueAtPercentileSlice(1))
-	summaryDataPoints.Get(1).ValueAtPercentiles().Get(0).SetPercentile(1)
-	summaryDataPoints.Get(1).ValueAtPercentiles().Get(0).SetValue(15)
-
-	return metricData
-}
-
 func generateOcTestDataNoMetrics() consumerdata.MetricsData {
 	return consumerdata.MetricsData{
-		Node:     &occommon.Node{},
-		Resource: &ocresource.Resource{},
-		Metrics:  []*ocmetrics.Metric(nil),
+		Node: &occommon.Node{},
+		Resource: &ocresource.Resource{
+			Labels: map[string]string{"resource-attr": "resource-attr-val-1"},
+		},
+		Metrics: []*ocmetrics.Metric(nil),
 	}
 }
 
 func generateOcTestDataNoPoints() consumerdata.MetricsData {
 	return consumerdata.MetricsData{
-		Node:     &occommon.Node{},
-		Resource: &ocresource.Resource{},
+		Node: &occommon.Node{},
+		Resource: &ocresource.Resource{
+			Labels: map[string]string{"resource-attr": "resource-attr-val-1"},
+		},
 		Metrics: []*ocmetrics.Metric{
 			{
 				MetricDescriptor: &ocmetrics.MetricDescriptor{
-					Name:        "no-points",
-					Description: "My metric",
-					Unit:        "ms",
+					Name:        "gauge-double",
+					Description: "",
+					Unit:        "1",
 					Type:        ocmetrics.MetricDescriptor_GAUGE_DOUBLE,
+				},
+			},
+			{
+				MetricDescriptor: &ocmetrics.MetricDescriptor{
+					Name:        "gauge-int",
+					Description: "",
+					Unit:        "1",
+					Type:        ocmetrics.MetricDescriptor_GAUGE_INT64,
+				},
+			},
+			{
+				MetricDescriptor: &ocmetrics.MetricDescriptor{
+					Name:        "counter-double",
+					Description: "",
+					Unit:        "1",
+					Type:        ocmetrics.MetricDescriptor_CUMULATIVE_DOUBLE,
+				},
+			},
+			{
+				MetricDescriptor: &ocmetrics.MetricDescriptor{
+					Name:        "counter-int",
+					Description: "",
+					Unit:        "1",
+					Type:        ocmetrics.MetricDescriptor_CUMULATIVE_INT64,
+				},
+			},
+			{
+				MetricDescriptor: &ocmetrics.MetricDescriptor{
+					Name:        "gauge-histogram",
+					Description: "",
+					Unit:        "1",
+					Type:        ocmetrics.MetricDescriptor_GAUGE_DISTRIBUTION,
+				},
+			},
+			{
+				MetricDescriptor: &ocmetrics.MetricDescriptor{
+					Name:        "cumulative-histogram",
+					Description: "",
+					Unit:        "1",
+					Type:        ocmetrics.MetricDescriptor_CUMULATIVE_DISTRIBUTION,
+				},
+			},
+			{
+				MetricDescriptor: &ocmetrics.MetricDescriptor{
+					Name:        "summary",
+					Description: "",
+					Unit:        "1",
+					Type:        ocmetrics.MetricDescriptor_SUMMARY,
 				},
 			},
 		},
@@ -249,22 +179,22 @@ func generateOcTestData(t *testing.T) consumerdata.MetricsData {
 
 	ocMetricInt := &ocmetrics.Metric{
 		MetricDescriptor: &ocmetrics.MetricDescriptor{
-			Name:        "mymetric-int",
-			Description: "My metric",
-			Unit:        "ms",
+			Name:        testdata.TestCounterIntMetricName,
+			Description: "",
+			Unit:        "1",
 			Type:        ocmetrics.MetricDescriptor_CUMULATIVE_INT64,
 			LabelKeys: []*ocmetrics.LabelKey{
-				{Key: "key1"},
-				{Key: "key2"},
+				{Key: "int-label-1"},
+				{Key: "int-label-2"},
 			},
 		},
 		Timeseries: []*ocmetrics.TimeSeries{
 			{
-				StartTimestamp: internal.UnixNanoToTimestamp(startTimeUnixNano),
+				StartTimestamp: internal.TimeToTimestamp(testdata.TestMetricStartTime),
 				LabelValues: []*ocmetrics.LabelValue{
 					{
 						// key1
-						Value:    "value1",
+						Value:    "int-label-value-1",
 						HasValue: true,
 					},
 					{
@@ -274,7 +204,7 @@ func generateOcTestData(t *testing.T) consumerdata.MetricsData {
 				},
 				Points: []*ocmetrics.Point{
 					{
-						Timestamp: internal.UnixNanoToTimestamp(timeUnixNano),
+						Timestamp: internal.TimeToTimestamp(testdata.TestMetricTime),
 						Value: &ocmetrics.Point_Int64Value{
 							Int64Value: 123,
 						},
@@ -282,7 +212,7 @@ func generateOcTestData(t *testing.T) consumerdata.MetricsData {
 				},
 			},
 			{
-				StartTimestamp: internal.UnixNanoToTimestamp(startTimeUnixNano),
+				StartTimestamp: internal.TimeToTimestamp(testdata.TestMetricStartTime),
 				LabelValues: []*ocmetrics.LabelValue{
 					{
 						// key1
@@ -290,13 +220,13 @@ func generateOcTestData(t *testing.T) consumerdata.MetricsData {
 					},
 					{
 						// key2
-						Value:    "value2",
+						Value:    "int-label-value-2",
 						HasValue: true,
 					},
 				},
 				Points: []*ocmetrics.Point{
 					{
-						Timestamp: internal.UnixNanoToTimestamp(timeUnixNano),
+						Timestamp: internal.TimeToTimestamp(testdata.TestMetricTime),
 						Value: &ocmetrics.Point_Int64Value{
 							Int64Value: 456,
 						},
@@ -307,17 +237,17 @@ func generateOcTestData(t *testing.T) consumerdata.MetricsData {
 	}
 	ocMetricDouble := &ocmetrics.Metric{
 		MetricDescriptor: &ocmetrics.MetricDescriptor{
-			Name:        "mymetric-double",
-			Description: "My metric",
-			Unit:        "ms",
+			Name:        testdata.TestCounterDoubleMetricName,
+			Description: "",
+			Unit:        "1",
 			Type:        ocmetrics.MetricDescriptor_CUMULATIVE_DOUBLE,
 		},
 		Timeseries: []*ocmetrics.TimeSeries{
 			{
-				StartTimestamp: internal.UnixNanoToTimestamp(startTimeUnixNano),
+				StartTimestamp: internal.TimeToTimestamp(testdata.TestMetricStartTime),
 				Points: []*ocmetrics.Point{
 					{
-						Timestamp: internal.UnixNanoToTimestamp(timeUnixNano),
+						Timestamp: internal.TimeToTimestamp(testdata.TestMetricTime),
 						Value: &ocmetrics.Point_DoubleValue{
 							DoubleValue: 1.23,
 						},
@@ -328,23 +258,23 @@ func generateOcTestData(t *testing.T) consumerdata.MetricsData {
 	}
 	ocMetricHistogram := &ocmetrics.Metric{
 		MetricDescriptor: &ocmetrics.MetricDescriptor{
-			Name:        "mymetric-histogram",
-			Description: "My metric",
-			Unit:        "ms",
+			Name:        testdata.TestCumulativeHistogramMetricName,
+			Description: "",
+			Unit:        "1",
 			Type:        ocmetrics.MetricDescriptor_CUMULATIVE_DISTRIBUTION,
 			LabelKeys: []*ocmetrics.LabelKey{
-				{Key: "key1"},
-				{Key: "key2"},
-				{Key: "key3"},
+				{Key: "histogram-label-1"},
+				{Key: "histogram-label-2"},
+				{Key: "histogram-label-3"},
 			},
 		},
 		Timeseries: []*ocmetrics.TimeSeries{
 			{
-				StartTimestamp: internal.UnixNanoToTimestamp(startTimeUnixNano),
+				StartTimestamp: internal.TimeToTimestamp(testdata.TestMetricStartTime),
 				LabelValues: []*ocmetrics.LabelValue{
 					{
 						// key1
-						Value:    "histogram-value1",
+						Value:    "histogram-label-value-1",
 						HasValue: true,
 					},
 					{
@@ -353,13 +283,13 @@ func generateOcTestData(t *testing.T) consumerdata.MetricsData {
 					},
 					{
 						// key3
-						Value:    "histogram-value3",
+						Value:    "histogram-label-value-3",
 						HasValue: true,
 					},
 				},
 				Points: []*ocmetrics.Point{
 					{
-						Timestamp: internal.UnixNanoToTimestamp(timeUnixNano),
+						Timestamp: internal.TimeToTimestamp(testdata.TestMetricTime),
 						Value: &ocmetrics.Point_DistributionValue{
 							DistributionValue: &ocmetrics.DistributionValue{
 								Count: 1,
@@ -370,7 +300,7 @@ func generateOcTestData(t *testing.T) consumerdata.MetricsData {
 				},
 			},
 			{
-				StartTimestamp: internal.UnixNanoToTimestamp(startTimeUnixNano),
+				StartTimestamp: internal.TimeToTimestamp(testdata.TestMetricStartTime),
 				LabelValues: []*ocmetrics.LabelValue{
 					{
 						// key1
@@ -378,7 +308,7 @@ func generateOcTestData(t *testing.T) consumerdata.MetricsData {
 					},
 					{
 						// key2
-						Value:    "histogram-value2",
+						Value:    "histogram-label-value-2",
 						HasValue: true,
 					},
 					{
@@ -388,7 +318,7 @@ func generateOcTestData(t *testing.T) consumerdata.MetricsData {
 				},
 				Points: []*ocmetrics.Point{
 					{
-						Timestamp: internal.UnixNanoToTimestamp(timeUnixNano),
+						Timestamp: internal.TimeToTimestamp(testdata.TestMetricTime),
 						Value: &ocmetrics.Point_DistributionValue{
 							DistributionValue: &ocmetrics.DistributionValue{
 								Count: 1,
@@ -412,9 +342,9 @@ func generateOcTestData(t *testing.T) consumerdata.MetricsData {
 									{
 										Count: 1,
 										Exemplar: &ocmetrics.DistributionValue_Exemplar{
-											Timestamp:   internal.UnixNanoToTimestamp(timeUnixNano),
+											Timestamp:   internal.TimeToTimestamp(testdata.TestMetricExemplarTime),
 											Value:       15,
-											Attachments: map[string]string{"key": "value"},
+											Attachments: map[string]string{"exemplar-attachment": "exemplar-attachment-value"},
 										},
 									},
 								},
@@ -427,27 +357,27 @@ func generateOcTestData(t *testing.T) consumerdata.MetricsData {
 	}
 	ocMetricSummary := &ocmetrics.Metric{
 		MetricDescriptor: &ocmetrics.MetricDescriptor{
-			Name:        "mymetric-summary",
-			Description: "My metric",
-			Unit:        "ms",
+			Name:        testdata.TestSummaryMetricName,
+			Description: "",
+			Unit:        "1",
 			Type:        ocmetrics.MetricDescriptor_SUMMARY,
 			LabelKeys: []*ocmetrics.LabelKey{
-				{Key: "key1"},
+				{Key: "summary-label"},
 			},
 		},
 		Timeseries: []*ocmetrics.TimeSeries{
 			{
-				StartTimestamp: internal.UnixNanoToTimestamp(startTimeUnixNano),
+				StartTimestamp: internal.TimeToTimestamp(testdata.TestMetricStartTime),
 				LabelValues: []*ocmetrics.LabelValue{
 					{
 						// key1
-						Value:    "summary-value1",
+						Value:    "summary-label-value-1",
 						HasValue: true,
 					},
 				},
 				Points: []*ocmetrics.Point{
 					{
-						Timestamp: internal.UnixNanoToTimestamp(timeUnixNano),
+						Timestamp: internal.TimeToTimestamp(testdata.TestMetricTime),
 						Value: &ocmetrics.Point_SummaryValue{
 							SummaryValue: &ocmetrics.SummaryValue{
 								Count: &wrappers.Int64Value{
@@ -462,17 +392,17 @@ func generateOcTestData(t *testing.T) consumerdata.MetricsData {
 				},
 			},
 			{
-				StartTimestamp: internal.UnixNanoToTimestamp(startTimeUnixNano),
+				StartTimestamp: internal.TimeToTimestamp(testdata.TestMetricStartTime),
 				LabelValues: []*ocmetrics.LabelValue{
 					{
 						// key1
-						Value:    "summary-value2",
+						Value:    "summary-label-value-2",
 						HasValue: true,
 					},
 				},
 				Points: []*ocmetrics.Point{
 					{
-						Timestamp: internal.UnixNanoToTimestamp(timeUnixNano),
+						Timestamp: internal.TimeToTimestamp(testdata.TestMetricTime),
 						Value: &ocmetrics.Point_SummaryValue{
 							SummaryValue: &ocmetrics.SummaryValue{
 								Count: &wrappers.Int64Value{
@@ -511,19 +441,10 @@ func generateOcTestData(t *testing.T) consumerdata.MetricsData {
 			},
 		},
 		Resource: &ocresource.Resource{
-			Type: "good-resource",
 			Labels: map[string]string{
-				"str1": "text",
-				"int2": "123",
+				"resource-attr": "resource-attr-val-1",
 			},
 		},
 		Metrics: []*ocmetrics.Metric{ocMetricInt, ocMetricDouble, ocMetricHistogram, ocMetricSummary},
 	}
-}
-
-func fillMetricDescriptor(md data.MetricDescriptor, name string, ty data.MetricType) {
-	md.SetName(name)
-	md.SetDescription("My metric")
-	md.SetUnit("ms")
-	md.SetType(ty)
 }

--- a/translator/internaldata/oc_to_traces_test.go
+++ b/translator/internaldata/oc_to_traces_test.go
@@ -262,11 +262,11 @@ func TestOcToInternal(t *testing.T) {
 	ocResource1 := &ocresource.Resource{Labels: map[string]string{"resource-attr": "resource-attr-val-1"}}
 	ocResource2 := &ocresource.Resource{Labels: map[string]string{"resource-attr": "resource-attr-val-2"}}
 
-	startTime, err := ptypes.TimestampProto(testdata.TestStartTime)
+	startTime, err := ptypes.TimestampProto(testdata.TestSpanStartTime)
 	assert.NoError(t, err)
-	eventTime, err := ptypes.TimestampProto(testdata.TestEventTime)
+	eventTime, err := ptypes.TimestampProto(testdata.TestSpanEventTime)
 	assert.NoError(t, err)
-	endTime, err := ptypes.TimestampProto(testdata.TestEndTime)
+	endTime, err := ptypes.TimestampProto(testdata.TestSpanEndTime)
 	assert.NoError(t, err)
 
 	ocSpan1 := &octrace.Span{

--- a/translator/internaldata/traces_to_oc_test.go
+++ b/translator/internaldata/traces_to_oc_test.go
@@ -180,11 +180,11 @@ func TestInternalToOC(t *testing.T) {
 	ocResource1 := &ocresource.Resource{Labels: map[string]string{"resource-attr": "resource-attr-val-1"}}
 	ocResource2 := &ocresource.Resource{Labels: map[string]string{"resource-attr": "resource-attr-val-2"}}
 
-	startTime, err := ptypes.TimestampProto(testdata.TestStartTime)
+	startTime, err := ptypes.TimestampProto(testdata.TestSpanStartTime)
 	assert.NoError(t, err)
-	eventTime, err := ptypes.TimestampProto(testdata.TestEventTime)
+	eventTime, err := ptypes.TimestampProto(testdata.TestSpanEventTime)
 	assert.NoError(t, err)
-	endTime, err := ptypes.TimestampProto(testdata.TestEndTime)
+	endTime, err := ptypes.TimestampProto(testdata.TestSpanEndTime)
 	assert.NoError(t, err)
 
 	ocSpan1 := &octrace.Span{


### PR DESCRIPTION
**Description:** Cloning fanout connectors now able to work with new type of downstream consumers

**Testing:** Unit tests

Aslo added MetricData generators to `internal/data/testdata/metric.go` 
Code in `internal/data/testdata/common.go` moved from `internal/data/testdata/trace.go` as is