### PR TITLE
Publish to otel dockerhub account

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ workflows:
       - coverage:
           requires:
             - setup-and-lint
-      - publish:
+      - publish-stable:
           requires:
             - cross-compile
             - loadtest
@@ -61,6 +61,17 @@ workflows:
               ignore: /.*/
             tags:
               only: /^v[0-9].[0-9].[0-9]+.*/
+      - publish-dev:
+          requires:
+            - cross-compile
+            - loadtest
+            - test
+            - coverage
+          filters:
+            branches:
+              only: master
+            tags:
+              ignore: /.*/
 
 jobs:
   setup-and-lint:
@@ -146,7 +157,7 @@ jobs:
           name: Code coverage
           command: bash <(curl -s https://codecov.io/bash)
 
-  publish:
+  publish-stable:
     docker:
       - image: cimg/go:1.14
     steps:
@@ -157,13 +168,36 @@ jobs:
           name: Build image
           command: |
             make docker-otelcol
-            docker tag otelcol:latest omnition/opentelemetry-collector:${CIRCLE_TAG:1}
-            docker tag otelcol:latest omnition/opentelemetry-collector:latest
+            docker tag otelcol:latest otel/opentelemetry-collector:${CIRCLE_TAG:1}
+            docker tag otelcol:latest otel/opentelemetry-collector:latest
       - run:
           name: Login to Docker Hub
           command: docker login -u $DOCKER_HUB_USERNAME -p $DOCKER_HUB_PASSWORD
       - run:
           name: Push image
           command: |
-            docker push omnition/opentelemetry-collector:${CIRCLE_TAG:1}
-            docker push omnition/opentelemetry-collector:latest
+            docker push otel/opentelemetry-collector:${CIRCLE_TAG:1}
+            docker push otel/opentelemetry-collector:latest
+
+  publish-dev:
+    docker:
+      - image: circleci/golang:1.14
+    steps:
+      - attach_workspace:
+          at: .
+      - setup_remote_docker
+      - run:
+          name: Build image
+          command: |
+            make docker-otelcol
+            docker tag otelcol:latest otel/opentelemetry-collector-dev:${CIRCLE_SHA1:1}
+            docker tag otelcol:latest otel/opentelemetry-collector-dev:latest
+      - run:
+          name: Login to Docker Hub
+          command: docker login -u $DOCKER_HUB_USERNAME -p $DOCKER_HUB_PASSWORD
+      - run:
+          name: Push image
+          command: |
+            docker push otel/opentelemetry-collector-dev:${CIRCLE_SHA1:1}
+            docker push otel/opentelemetry-collector-dev:latest
+


### PR DESCRIPTION
**Description:** 
Publish to the newly created `otel` Docker Hub org instead of `omnition`. 

In addition to publishing released, we'll also be publishing a dev image on every commit to master.

**Testing:** 
Tested manually on CirceCI
