### PR TITLE
Remove cleverness that defined tests cases

### DIFF
--- a/internal/data/testdata/trace.go
+++ b/internal/data/testdata/trace.go
@@ -32,70 +32,21 @@ var (
 	TestSpanEndTimestamp = data.TimestampUnixNano(TestSpanEndTime.UnixNano())
 )
 
-// TraceTestCase represents one test case with the coresponding TraceData and OTLP representation.
-type TraceTestCase struct {
-	Name      string
-	TraceData data.TraceData
-	OtlpData  []*otlptrace.ResourceSpans
-}
-
-var (
-	NoResourceSpansTraceTestCase = TraceTestCase{
-		Name:      "no-resource-spans",
-		TraceData: data.NewTraceData(),
-		OtlpData:  []*otlptrace.ResourceSpans(nil),
-	}
-	OneEmptyResourceSpansTraceTestCase = TraceTestCase{
-		Name:      "one-empty-resource-spans",
-		TraceData: GenerateTraceDataOneEmptyResourceSpans(),
-		OtlpData:  generateTraceOtlpOneEmptyResourceSpans(),
-	}
-	NoLibrariesTraceTestCase = TraceTestCase{
-		Name:      "no-libraries",
-		TraceData: GenerateTraceDataNoLibraries(),
-		OtlpData:  generateTraceOtlpNoLibraries(),
-	}
-	NoSpansTraceTestCase = TraceTestCase{
-		Name:      "no-spans",
-		TraceData: GenerateTraceDataNoSpans(),
-		OtlpData:  generateTraceOtlpNoSpans(),
-	}
-	OneSpanNoResourceTraceTestCase = TraceTestCase{
-		Name:      "one-span-no-resource",
-		TraceData: GenerateTraceDataOneSpanNoResource(),
-		OtlpData:  generateTraceOtlpOneSpanNoResource(),
-	}
-	OneSpanTraceTestCase = TraceTestCase{
-		Name:      "one-span",
-		TraceData: GenerateTraceDataOneSpan(),
-		OtlpData:  generateTraceOtlpOneSpan(),
-	}
-	TwoSpansSameResourceTraceTestCase = TraceTestCase{
-		Name:      "two-spans-same-resource",
-		TraceData: GenerateTraceDataSameResourceTwoSpans(),
-		OtlpData:  generateTraceOtlpSameResourceTwoSpans(),
-	}
-	TwoSpansSameResourceOneDifferentTraceTestCase = TraceTestCase{
-		Name:      "two-spans-same-resource-one-different",
-		TraceData: GenerateTraceDataTwoSpansSameResourceOneDifferent(),
-		OtlpData:  generateTraceOtlpTwoSpansSameResourceOneDifferent(),
-	}
-
-	// AllTraceTestCases represents a set of test cases.
-	AllTraceTestCases = []TraceTestCase{
-		NoResourceSpansTraceTestCase,
-		OneEmptyResourceSpansTraceTestCase,
-		NoLibrariesTraceTestCase,
-		NoSpansTraceTestCase,
-		OneSpanNoResourceTraceTestCase,
-		OneSpanTraceTestCase,
-		TwoSpansSameResourceTraceTestCase,
-		TwoSpansSameResourceOneDifferentTraceTestCase,
-	}
+const (
+	NumTraceTests = 8
 )
 
-func GenerateTraceDataOneEmptyResourceSpans() data.TraceData {
+func GenerateTraceDataEmpty() data.TraceData {
 	td := data.NewTraceData()
+	return td
+}
+
+func generateTraceOtlpEmpty() []*otlptrace.ResourceSpans {
+	return []*otlptrace.ResourceSpans(nil)
+}
+
+func GenerateTraceDataOneEmptyResourceSpans() data.TraceData {
+	td := GenerateTraceDataEmpty()
 	td.SetResourceSpans(data.NewResourceSpansSlice(1))
 	return td
 }
@@ -191,7 +142,7 @@ func generateTraceOtlpOneSpan() []*otlptrace.ResourceSpans {
 	}
 }
 
-func GenerateTraceDataSameResourceTwoSpans() data.TraceData {
+func GenerateTraceDataTwoSpansSameResource() data.TraceData {
 	td := GenerateTraceDataNoSpans()
 	rs0ils0 := td.ResourceSpans().Get(0).InstrumentationLibrarySpans().Get(0)
 	rs0ils0.SetSpans(data.NewSpanSlice(2))

--- a/processor/cloningfanoutconnector_test.go
+++ b/processor/cloningfanoutconnector_test.go
@@ -159,7 +159,7 @@ func TestTraceProcessorCloningMultiplexing(t *testing.T) {
 	}
 
 	tfc := NewTraceCloningFanOutConnector(processors)
-	td := testdata.GenerateTraceDataSameResourceTwoSpans()
+	td := testdata.GenerateTraceDataTwoSpansSameResource()
 
 	var wantSpansCount = 0
 	for i := 0; i < 2; i++ {
@@ -281,7 +281,7 @@ func TestCreateTraceCloningFanOutConnectorWithConvertion(t *testing.T) {
 
 	resourceTypeName := "good-resource"
 
-	td := testdata.GenerateTraceDataSameResourceTwoSpans()
+	td := testdata.GenerateTraceDataTwoSpansSameResource()
 	resource := td.ResourceSpans().Get(0).Resource()
 	resource.Attributes().Upsert(data.NewAttributeKeyValueString(conventions.OCAttributeResourceType, resourceTypeName))
 

--- a/translator/internaldata/oc_to_traces_test.go
+++ b/translator/internaldata/oc_to_traces_test.go
@@ -359,27 +359,32 @@ func TestOcToInternal(t *testing.T) {
 	}
 
 	tests := []struct {
-		testdata.TraceTestCase
-		oc consumerdata.TraceData
+		name string
+		td   data.TraceData
+		oc   consumerdata.TraceData
 	}{
 		{
-			testdata.NoResourceSpansTraceTestCase,
-			consumerdata.TraceData{},
+			name: "empty",
+			td:   testdata.GenerateTraceDataEmpty(),
+			oc:   consumerdata.TraceData{},
 		},
 
 		{
-			testdata.OneEmptyResourceSpansTraceTestCase,
-			consumerdata.TraceData{Node: ocNode},
+			name: "one-empty-resource-spans",
+			td:   testdata.GenerateTraceDataOneEmptyResourceSpans(),
+			oc:   consumerdata.TraceData{Node: ocNode},
 		},
 
 		{
-			testdata.NoLibrariesTraceTestCase,
-			consumerdata.TraceData{Resource: ocResource1},
+			name: "no-libraries",
+			td:   testdata.GenerateTraceDataNoLibraries(),
+			oc:   consumerdata.TraceData{Resource: ocResource1},
 		},
 
 		{
-			testdata.OneSpanNoResourceTraceTestCase,
-			consumerdata.TraceData{
+			name: "one-span-no-resource",
+			td:   testdata.GenerateTraceDataOneSpanNoResource(),
+			oc: consumerdata.TraceData{
 				Node:     ocNode,
 				Resource: &ocresource.Resource{},
 				Spans:    []*octrace.Span{ocSpan1},
@@ -387,8 +392,10 @@ func TestOcToInternal(t *testing.T) {
 		},
 
 		{
-			testdata.OneSpanTraceTestCase,
-			consumerdata.TraceData{
+
+			name: "one-span",
+			td:   testdata.GenerateTraceDataOneSpan(),
+			oc: consumerdata.TraceData{
 				Node:     ocNode,
 				Resource: ocResource1,
 				Spans:    []*octrace.Span{ocSpan1},
@@ -396,8 +403,9 @@ func TestOcToInternal(t *testing.T) {
 		},
 
 		{
-			testdata.TwoSpansSameResourceTraceTestCase,
-			consumerdata.TraceData{
+			name: "two-spans-same-resource",
+			td:   testdata.GenerateTraceDataTwoSpansSameResource(),
+			oc: consumerdata.TraceData{
 				Node:     ocNode,
 				Resource: ocResource1,
 				Spans:    []*octrace.Span{ocSpan1, nil, ocSpan2},
@@ -405,8 +413,9 @@ func TestOcToInternal(t *testing.T) {
 		},
 
 		{
-			testdata.TwoSpansSameResourceOneDifferentTraceTestCase,
-			consumerdata.TraceData{
+			name: "two-spans-same-resource-one-different",
+			td:   testdata.GenerateTraceDataTwoSpansSameResourceOneDifferent(),
+			oc: consumerdata.TraceData{
 				Node:     ocNode,
 				Resource: ocResource1,
 				Spans:    []*octrace.Span{ocSpan1, ocSpan2, ocSpan3},
@@ -414,11 +423,9 @@ func TestOcToInternal(t *testing.T) {
 		},
 
 		{
-			testdata.TraceTestCase{
-				Name:      "two-spans-and-separate-in-the-middle",
-				TraceData: testdata.TwoSpansSameResourceOneDifferentTraceTestCase.TraceData,
-			},
-			consumerdata.TraceData{
+			name: "two-spans-and-separate-in-the-middle",
+			td:   testdata.GenerateTraceDataTwoSpansSameResourceOneDifferent(),
+			oc: consumerdata.TraceData{
 				Node:     ocNode,
 				Resource: ocResource1,
 				Spans:    []*octrace.Span{ocSpan1, ocSpan3, ocSpan2},
@@ -426,13 +433,13 @@ func TestOcToInternal(t *testing.T) {
 		},
 	}
 
-	// Result for NoSpansTraceTestCase is the same as for NoLibrariesTraceTestCase
-	assert.EqualValues(t, len(testdata.AllTraceTestCases), len(tests))
+	// Equal number of tests even though there is an extra test "two-spans-and-separate-in-the-middle"
+	// but the test case GenerateTraceDataNoSpans it is impossible to get from OC data.
+	assert.EqualValues(t, testdata.NumTraceTests, len(tests))
 
 	for _, test := range tests {
-		t.Run(test.Name, func(t *testing.T) {
-			got := OCToTraceData(test.oc)
-			assert.EqualValues(t, test.TraceData, got)
+		t.Run(test.name, func(t *testing.T) {
+			assert.EqualValues(t, test.td, OCToTraceData(test.oc))
 		})
 	}
 }

--- a/translator/internaldata/traces_to_oc_test.go
+++ b/translator/internaldata/traces_to_oc_test.go
@@ -283,17 +283,20 @@ func TestInternalToOC(t *testing.T) {
 	}
 
 	tests := []struct {
-		testdata.TraceTestCase
-		oc []consumerdata.TraceData
+		name string
+		td   data.TraceData
+		oc   []consumerdata.TraceData
 	}{
 		{
-			testdata.NoResourceSpansTraceTestCase,
-			[]consumerdata.TraceData(nil),
+			name: "empty",
+			td:   testdata.GenerateTraceDataEmpty(),
+			oc:   []consumerdata.TraceData(nil),
 		},
 
 		{
-			testdata.OneEmptyResourceSpansTraceTestCase,
-			[]consumerdata.TraceData{
+			name: "one-empty-resource-spans",
+			td:   testdata.GenerateTraceDataOneEmptyResourceSpans(),
+			oc: []consumerdata.TraceData{
 				{
 					Node:         ocNode,
 					Resource:     &ocresource.Resource{},
@@ -304,8 +307,9 @@ func TestInternalToOC(t *testing.T) {
 		},
 
 		{
-			testdata.NoLibrariesTraceTestCase,
-			[]consumerdata.TraceData{
+			name: "no-libraries",
+			td:   testdata.GenerateTraceDataNoLibraries(),
+			oc: []consumerdata.TraceData{
 				{
 					Node:         ocNode,
 					Resource:     ocResource1,
@@ -316,8 +320,9 @@ func TestInternalToOC(t *testing.T) {
 		},
 
 		{
-			testdata.NoSpansTraceTestCase,
-			[]consumerdata.TraceData{
+			name: "no-spans",
+			td:   testdata.GenerateTraceDataNoSpans(),
+			oc: []consumerdata.TraceData{
 				{
 					Node:         ocNode,
 					Resource:     ocResource1,
@@ -328,8 +333,9 @@ func TestInternalToOC(t *testing.T) {
 		},
 
 		{
-			testdata.OneSpanNoResourceTraceTestCase,
-			[]consumerdata.TraceData{
+			name: "one-span-no-resource",
+			td:   testdata.GenerateTraceDataOneSpanNoResource(),
+			oc: []consumerdata.TraceData{
 				{
 					Node:         ocNode,
 					Resource:     &ocresource.Resource{},
@@ -340,8 +346,9 @@ func TestInternalToOC(t *testing.T) {
 		},
 
 		{
-			testdata.OneSpanTraceTestCase,
-			[]consumerdata.TraceData{
+			name: "one-span",
+			td:   testdata.GenerateTraceDataOneSpan(),
+			oc: []consumerdata.TraceData{
 				{
 					Node:         ocNode,
 					Resource:     ocResource1,
@@ -352,8 +359,9 @@ func TestInternalToOC(t *testing.T) {
 		},
 
 		{
-			testdata.TwoSpansSameResourceTraceTestCase,
-			[]consumerdata.TraceData{
+			name: "two-spans-same-resource",
+			td:   testdata.GenerateTraceDataTwoSpansSameResource(),
+			oc: []consumerdata.TraceData{
 				{
 					Node:         ocNode,
 					Resource:     ocResource1,
@@ -364,8 +372,9 @@ func TestInternalToOC(t *testing.T) {
 		},
 
 		{
-			testdata.TwoSpansSameResourceOneDifferentTraceTestCase,
-			[]consumerdata.TraceData{
+			name: "two-spans-same-resource-one-different",
+			td:   testdata.GenerateTraceDataTwoSpansSameResourceOneDifferent(),
+			oc: []consumerdata.TraceData{
 				{
 					Node:         ocNode,
 					Resource:     ocResource1,
@@ -382,12 +391,11 @@ func TestInternalToOC(t *testing.T) {
 		},
 	}
 
-	assert.EqualValues(t, len(testdata.AllTraceTestCases), len(tests))
+	assert.EqualValues(t, testdata.NumTraceTests, len(tests))
 
 	for _, test := range tests {
-		t.Run(test.Name, func(t *testing.T) {
-			got := TraceDataToOC(test.TraceData)
-			assert.EqualValues(t, test.oc, got)
+		t.Run(test.name, func(t *testing.T) {
+			assert.EqualValues(t, test.oc, TraceDataToOC(test.td))
 		})
 	}
 }


### PR DESCRIPTION
The main problem is that I used global variables so tests were not deterministic if one of the test changes the input. Decided to revert back to just having functions to generate a new input.