### PR TITLE
Enable default govet checks, enable and fix shadows

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -54,7 +54,7 @@ output:
 linters-settings:
   govet:
     # report about shadowed variables
-    check-shadowing: false
+    check-shadowing: true
 
     # settings per analyzer
     settings:
@@ -65,13 +65,6 @@ linters-settings:
           - (github.com/golangci/golangci-lint/pkg/logutils.Log).Errorf
           - (github.com/golangci/golangci-lint/pkg/logutils.Log).Fatalf
 
-    # enable or disable analyzers by name
-    enable:
-      - atomicalign
-    enable-all: false
-    disable:
-      - shadow
-    disable-all: false
   golint:
     # minimal confidence for issues, default is 0.8
     min-confidence: 0.8

--- a/config/test_helpers.go
+++ b/config/test_helpers.go
@@ -34,9 +34,8 @@ func LoadConfigFile(t *testing.T, fileName string, factories Factories) (*config
 	}
 
 	defer func() {
-		err := file.Close()
-		if err != nil {
-			t.Error(err)
+		if errClose := file.Close(); errClose != nil {
+			t.Error(errClose)
 		}
 	}()
 

--- a/exporter/jaeger/jaegerthrifthttpexporter/exporter_test.go
+++ b/exporter/jaeger/jaegerthrifthttpexporter/exporter_test.go
@@ -36,14 +36,14 @@ type args struct {
 }
 
 func TestNew(t *testing.T) {
-	args := args{
+	arg := args{
 		config:      &configmodels.ExporterSettings{},
 		httpAddress: testHTTPAddress,
 		headers:     map[string]string{"test": "test"},
 		timeout:     10 * time.Nanosecond,
 	}
 
-	got, err := New(args.config, args.httpAddress, args.headers, args.timeout)
+	got, err := New(arg.config, arg.httpAddress, arg.headers, arg.timeout)
 	assert.NoError(t, err)
 	require.NotNil(t, got)
 
@@ -53,12 +53,12 @@ func TestNew(t *testing.T) {
 }
 
 func TestNewFailsWithEmptyExporterName(t *testing.T) {
-	args := args{
+	arg := args{
 		config:      nil,
 		httpAddress: testHTTPAddress,
 	}
 
-	got, err := New(args.config, args.httpAddress, args.headers, args.timeout)
+	got, err := New(arg.config, arg.httpAddress, arg.headers, arg.timeout)
 	assert.EqualError(t, err, "nil config")
 	assert.Nil(t, got)
 }

--- a/exporter/jaeger/jaegerthrifthttpexporter/factory.go
+++ b/exporter/jaeger/jaegerthrifthttpexporter/factory.go
@@ -68,7 +68,7 @@ func (f *Factory) CreateTraceExporter(
 	}
 
 	if expCfg.Timeout <= 0 {
-		err := fmt.Errorf(
+		err = fmt.Errorf(
 			"%q config requires a positive value for \"timeout\"",
 			expCfg.Name())
 		return nil, err

--- a/exporter/otlpexporter/exporter.go
+++ b/exporter/otlpexporter/exporter.go
@@ -109,7 +109,7 @@ func (e *exporterImp) start() error {
 		// An optimistic first connection attempt to ensure that
 		// applications under heavy load can immediately process
 		// data. See https://github.com/census-ecosystem/opencensus-go-exporter-ocagent/pull/63
-		if err := e.connect(); err == nil {
+		if err = e.connect(); err == nil {
 			e.setStateConnected()
 		} else {
 			e.setStateDisconnected(err)

--- a/exporter/zipkinexporter/zipkin.go
+++ b/exporter/zipkinexporter/zipkin.go
@@ -111,7 +111,7 @@ func createZipkinExporter(logger *zap.Logger, config configmodels.Exporter) (*zi
 	return ze, nil
 }
 
-func (ze *zipkinExporter) PushTraceData(ctx context.Context, td consumerdata.TraceData) (droppedSpans int, err error) {
+func (ze *zipkinExporter) PushTraceData(ctx context.Context, td consumerdata.TraceData) (int, error) {
 	tbatch := []*zipkinmodel.SpanModel{}
 
 	var resource *resourcepb.Resource

--- a/processor/queuedprocessor/queued_processor.go
+++ b/processor/queuedprocessor/queued_processor.go
@@ -58,8 +58,8 @@ type queueItem struct {
 // in-memory queue of span batches, and sends out span batches using the
 // provided sender
 func NewQueuedSpanProcessor(sender consumer.TraceConsumerOld, opts ...Option) component.TraceProcessorOld {
-	options := Options.apply(opts...)
-	sp := newQueuedSpanProcessor(sender, options)
+	opt := Options.apply(opts...)
+	sp := newQueuedSpanProcessor(sender, opt)
 
 	return sp
 }

--- a/processor/samplingprocessor/probabilisticsamplerprocessor/probabilisticsampler.go
+++ b/processor/samplingprocessor/probabilisticsamplerprocessor/probabilisticsampler.go
@@ -82,8 +82,8 @@ func (tsp *tracesamplerprocessor) ConsumeTraceData(ctx context.Context, td consu
 
 	sampledSpans := make([]*tracepb.Span, 0, len(td.Spans))
 	for _, span := range td.Spans {
-		samplingPriority := parseSpanSamplingPriority(span)
-		if samplingPriority == doNotSampleSpan {
+		sp := parseSpanSamplingPriority(span)
+		if sp == doNotSampleSpan {
 			// The OpenTelemetry mentions this as a "hint" we take a stronger
 			// approach and do not sample the span since some may use it to
 			// remove specific spans from traces.
@@ -93,7 +93,7 @@ func (tsp *tracesamplerprocessor) ConsumeTraceData(ctx context.Context, td consu
 		// If one assumes random trace ids hashing may seems avoidable, however, traces can be coming from sources
 		// with various different criteria to generate trace id and perhaps were already sampled without hashing.
 		// Hashing here prevents bias due to such systems.
-		sampled := samplingPriority == mustSampleSpan ||
+		sampled := sp == mustSampleSpan ||
 			hash(span.TraceId, tsp.hashSeed)&bitMaskHashBuckets < scaledSamplingRate
 
 		if sampled {

--- a/processor/samplingprocessor/tailsamplingprocessor/processor.go
+++ b/processor/samplingprocessor/tailsamplingprocessor/processor.go
@@ -226,8 +226,8 @@ func (tsp *tailSamplingSpanProcessor) ConsumeTraceData(ctx context.Context, td c
 			tsp.logger.Warn("Span without valid TraceId", zap.String("SourceFormat", td.SourceFormat))
 			continue
 		}
-		traceKey := traceKey(span.TraceId)
-		idToSpans[traceKey] = append(idToSpans[traceKey], span)
+		tk := traceKey(span.TraceId)
+		idToSpans[tk] = append(idToSpans[tk], span)
 	}
 
 	var newTraceIDs int64

--- a/receiver/end_to_end_test.go
+++ b/receiver/end_to_end_test.go
@@ -49,7 +49,7 @@ func Example_endToEnd() {
 	// Once we have the span receiver which will connect to the
 	// various exporter pipeline i.e. *tracepb.Span->OpenCensus.SpanData
 	for _, tr := range trl {
-		if err := tr.Start(nil); err != nil {
+		if err = tr.Start(nil); err != nil {
 			log.Fatalf("Failed to start trace receiver: %v", err)
 		}
 	}
@@ -79,13 +79,13 @@ func Example_endToEnd() {
 	log.Println("Starting loop")
 	ctx, span := trace.StartSpan(context.Background(), "ClientLibrarySpan")
 	for i := 0; i < 10; i++ {
-		_, span := trace.StartSpan(ctx, "ChildSpan")
-		span.Annotatef([]trace.Attribute{
+		_, childSpan := trace.StartSpan(ctx, "ChildSpan")
+		childSpan.Annotatef([]trace.Attribute{
 			trace.StringAttribute("type", "Child"),
 			trace.Int64Attribute("i", int64(i)),
 		}, "This is an annotation")
 		<-time.After(100 * time.Millisecond)
-		span.End()
+		childSpan.End()
 		oce.Flush()
 	}
 	span.End()

--- a/receiver/opencensusreceiver/opencensus.go
+++ b/receiver/opencensusreceiver/opencensus.go
@@ -186,7 +186,7 @@ func (ocr *Receiver) stop() error {
 	ocr.mu.Lock()
 	defer ocr.mu.Unlock()
 
-	var err = oterr.ErrAlreadyStopped
+	err := oterr.ErrAlreadyStopped
 	ocr.stopOnce.Do(func() {
 		err = nil
 
@@ -256,18 +256,18 @@ func (ocr *Receiver) startServer(host component.Host) error {
 
 		httpL := m.Match(cmux.Any())
 		go func() {
-			if err := ocr.serverGRPC.Serve(grpcL); err != nil {
-				host.ReportFatalError(err)
+			if errGrpc := ocr.serverGRPC.Serve(grpcL); errGrpc != nil {
+				host.ReportFatalError(errGrpc)
 			}
 		}()
 		go func() {
-			if err := ocr.httpServer().Serve(httpL); err != nil {
-				host.ReportFatalError(err)
+			if errHTTP := ocr.httpServer().Serve(httpL); errHTTP != nil {
+				host.ReportFatalError(errHTTP)
 			}
 		}()
 		go func() {
-			if err := m.Serve(); err != nil {
-				host.ReportFatalError(err)
+			if errServe := m.Serve(); errServe != nil {
+				host.ReportFatalError(errServe)
 			}
 		}()
 	})

--- a/receiver/otlpreceiver/otlp.go
+++ b/receiver/otlpreceiver/otlp.go
@@ -250,18 +250,18 @@ func (r *Receiver) startServer(host component.Host) error {
 
 		httpL := m.Match(cmux.Any())
 		go func() {
-			if err := r.serverGRPC.Serve(grpcL); err != nil {
-				host.ReportFatalError(err)
+			if errGrpc := r.serverGRPC.Serve(grpcL); errGrpc != nil {
+				host.ReportFatalError(errGrpc)
 			}
 		}()
 		go func() {
-			if err := r.httpServer().Serve(httpL); err != nil {
-				host.ReportFatalError(err)
+			if errHTTP := r.httpServer().Serve(httpL); errHTTP != nil {
+				host.ReportFatalError(errHTTP)
 			}
 		}()
 		go func() {
-			if err := m.Serve(); err != nil {
-				host.ReportFatalError(err)
+			if errServe := m.Serve(); errServe != nil {
+				host.ReportFatalError(errServe)
 			}
 		}()
 	})

--- a/receiver/vmmetricsreceiver/vm_metrics_collector.go
+++ b/receiver/vmmetricsreceiver/vm_metrics_collector.go
@@ -159,12 +159,8 @@ func (vmc *VMMetricsCollector) scrapeAndExport() {
 		},
 	)
 
-	var proc procfs.Proc
-	var err error
-	proc, err = vmc.processFs.Proc(vmc.pid)
-	if err == nil {
-		procStat, err := proc.Stat()
-		if err == nil {
+	if proc, err := vmc.processFs.Proc(vmc.pid); err == nil {
+		if procStat, errStat := proc.Stat(); errStat == nil {
 			metrics = append(
 				metrics,
 				&metricspb.Metric{
@@ -173,14 +169,14 @@ func (vmc *VMMetricsCollector) scrapeAndExport() {
 					Timeseries:       []*metricspb.TimeSeries{vmc.getDoubleTimeSeries(procStat.CPUTime(), nil)},
 				},
 			)
+		} else {
+			errs = append(errs, errStat)
 		}
-	}
-	if err != nil {
+	} else {
 		errs = append(errs, err)
 	}
 
-	stat, err := vmc.fs.Stat()
-	if err == nil {
+	if stat, err := vmc.fs.Stat(); err == nil {
 		cpuStat := stat.CPUTotal
 		metrics = append(
 			metrics,

--- a/service/telemetry.go
+++ b/service/telemetry.go
@@ -117,7 +117,7 @@ func (tel *appTelemetry) init(asyncErrorChannel chan<- error, ballastSizeBytes u
 	processMetricsViews := telemetry.NewProcessMetricsViews(ballastSizeBytes)
 	views = append(views, processMetricsViews.Views()...)
 	tel.views = views
-	if err := view.Register(views...); err != nil {
+	if err = view.Register(views...); err != nil {
 		return err
 	}
 

--- a/translator/trace/grpc_http_mapper.go
+++ b/translator/trace/grpc_http_mapper.go
@@ -56,8 +56,8 @@ func OCStatusCodeFromHTTP(code int32) int32 {
 	if code >= 100 && code < 400 {
 		return OCOK
 	}
-	if code, ok := httpToOCCodeMap[code]; ok {
-		return code
+	if c, ok := httpToOCCodeMap[code]; ok {
+		return c
 	}
 	if code >= 400 && code < 500 {
 		return OCInvalidArgument
@@ -91,8 +91,8 @@ var ocToHTTPCodeMap = map[int32]int32{
 // HTTPStatusCodeFromOCStatus takes an OpenTelemetry status code and return the appropriate HTTP status code
 // See: https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/data-http.md
 func HTTPStatusCodeFromOCStatus(code int32) int32 {
-	if code, ok := ocToHTTPCodeMap[code]; ok {
-		return code
+	if c, ok := ocToHTTPCodeMap[code]; ok {
+		return c
 	}
 	return http.StatusInternalServerError
 }


### PR DESCRIPTION
Shadows may be annoying but I think it can cover some very hidden bugs, and make code harder to understand.

Here a hidden bug/issue, err from `proc.Stat()` is never added to the errs:
https://github.com/open-telemetry/opentelemetry-collector/compare/master...bogdandrutu:govetbetter?expand=1#diff-7cf6f365929a0f9534bf47378832af52R173

Here this code worked because ":=" was used and the returned `code` did not actually overwrite the incoming `code` argument (very hard to guess and get it right):
https://github.com/open-telemetry/opentelemetry-collector/compare/master...bogdandrutu:govetbetter?expand=1#diff-ce6c181a493dd6999a951052d26248f5R59