### PR TITLE
Fix race in TestExportProtocolViolations_nodelessFirstMessage

### DIFF
--- a/receiver/opencensusreceiver/octrace/opencensus_test.go
+++ b/receiver/opencensusreceiver/octrace/opencensus_test.go
@@ -309,7 +309,8 @@ func TestExportProtocolViolations_nodelessFirstMessage(t *testing.T) {
 	require.NoError(t, err, "Unexpectedly failed to send the first message: %v", err)
 
 	longDuration := 2 * time.Second
-	testDone := make(chan bool, 1)
+	testDone := make(chan struct{})
+	goroutineDone := make(chan struct{})
 	go func() {
 		// Our insurance policy to ensure that this test doesn't hang
 		// forever and should quickly report if/when we regress.
@@ -320,6 +321,7 @@ func TestExportProtocolViolations_nodelessFirstMessage(t *testing.T) {
 			traceClientDoneFn()
 			t.Errorf("Test took too long (%s) and is likely still hanging so this is a regression", longDuration)
 		}
+		close(goroutineDone)
 	}()
 
 	// Now the response should return an error and should have been torn down
@@ -354,6 +356,7 @@ func TestExportProtocolViolations_nodelessFirstMessage(t *testing.T) {
 	}
 
 	close(testDone)
+	<-goroutineDone
 }
 
 // If the first message is valid (has a non-nil Node) and has spans, those


### PR DESCRIPTION
**Description:** Fix race in TestExportProtocolViolations_nodelessFirstMessage. The race is on the `t *testing.T` having one of its fields being read and write concurrently. I didn't investigate why this test needs this special timeout handling, just took the obvious fix to protect against the data race - will look at this again later.

**Link to tracking Issue:** Fixes #41
