### PR TITLE
Allow getting factories from component Host

### DIFF
--- a/component/mock_host.go
+++ b/component/mock_host.go
@@ -39,6 +39,11 @@ func (mh *MockHost) ReportFatalError(err error) {
 	// Do nothing for now.
 }
 
+// GetFactory of the specified kind. Returns the factory for a component type.
+func (mh *MockHost) GetFactory(kind Kind, componentType string) Factory {
+	return nil
+}
+
 // NewMockHost returns a new instance of MockHost with proper defaults for most
 // tests.
 func NewMockHost() Host {

--- a/config/example_factories.go
+++ b/config/example_factories.go
@@ -255,7 +255,6 @@ type ExampleExporter struct {
 	ExtraSetting                  string                   `mapstructure:"extra"`
 	ExtraMapSetting               map[string]string        `mapstructure:"extra_map"`
 	ExtraListSetting              []string                 `mapstructure:"extra_list"`
-	ExporterShutdown              bool
 }
 
 // ExampleExporterFactory is factory for ExampleExporter.

--- a/extension/extensiontest/mock_host.go
+++ b/extension/extensiontest/mock_host.go
@@ -17,6 +17,8 @@ package extensiontest
 import (
 	"context"
 	"time"
+
+	"github.com/open-telemetry/opentelemetry-collector/component"
 )
 
 // MockHost mocks an component.Host for test purposes.
@@ -56,4 +58,9 @@ func (mh *MockHost) WaitForFatalError(timeout time.Duration) (receivedError bool
 	}
 
 	return
+}
+
+// GetFactory of the specified kind. Returns the factory for a component type.
+func (mh *MockHost) GetFactory(kind component.Kind, componentType string) component.Factory {
+	return nil
 }

--- a/service/service.go
+++ b/service/service.go
@@ -180,6 +180,20 @@ func (app *Application) ReportFatalError(err error) {
 	app.asyncErrorChannel <- err
 }
 
+func (app *Application) GetFactory(kind component.Kind, componentType string) component.Factory {
+	switch kind {
+	case component.KindReceiver:
+		return app.factories.Receivers[componentType]
+	case component.KindProcessor:
+		return app.factories.Processors[componentType]
+	case component.KindExporter:
+		return app.factories.Exporters[componentType]
+	case component.KindExtension:
+		return app.factories.Extensions[componentType]
+	}
+	return nil
+}
+
 func (app *Application) init() error {
 	l, err := newLogger()
 	if err != nil {

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -236,3 +236,52 @@ func (b badExtensionFactory) CreateExtension(
 ) (component.ServiceExtension, error) {
 	return nil, nil
 }
+
+func TestApplication_GetFactory(t *testing.T) {
+	// Create some factories.
+	exampleReceiverFactory := &config.ExampleReceiverFactory{}
+	exampleProcessorFactory := &config.ExampleProcessorFactory{}
+	exampleExporterFactory := &config.ExampleExporterFactory{}
+	exampleExtensionFactory := &config.ExampleExtensionFactory{}
+
+	factories := config.Factories{
+		Receivers: map[string]component.ReceiverFactoryBase{
+			exampleReceiverFactory.Type(): exampleReceiverFactory,
+		},
+		Processors: map[string]component.ProcessorFactoryBase{
+			exampleProcessorFactory.Type(): exampleProcessorFactory,
+		},
+		Exporters: map[string]component.ExporterFactoryBase{
+			exampleExporterFactory.Type(): exampleExporterFactory,
+		},
+		Extensions: map[string]component.ExtensionFactory{
+			exampleExtensionFactory.Type(): exampleExtensionFactory,
+		},
+	}
+
+	// Create an App with factories.
+	app, err := New(Parameters{Factories: factories})
+	require.NoError(t, err)
+
+	// Verify GetFactory call for all component kinds.
+
+	factory := app.GetFactory(component.KindReceiver, exampleReceiverFactory.Type())
+	assert.EqualValues(t, exampleReceiverFactory, factory)
+	factory = app.GetFactory(component.KindReceiver, "wrongtype")
+	assert.EqualValues(t, nil, factory)
+
+	factory = app.GetFactory(component.KindProcessor, exampleProcessorFactory.Type())
+	assert.EqualValues(t, exampleProcessorFactory, factory)
+	factory = app.GetFactory(component.KindProcessor, "wrongtype")
+	assert.EqualValues(t, nil, factory)
+
+	factory = app.GetFactory(component.KindExporter, exampleExporterFactory.Type())
+	assert.EqualValues(t, exampleExporterFactory, factory)
+	factory = app.GetFactory(component.KindExporter, "wrongtype")
+	assert.EqualValues(t, nil, factory)
+
+	factory = app.GetFactory(component.KindExtension, exampleExtensionFactory.Type())
+	assert.EqualValues(t, exampleExtensionFactory, factory)
+	factory = app.GetFactory(component.KindExtension, "wrongtype")
+	assert.EqualValues(t, nil, factory)
+}

--- a/testbed/testbed/load_generator.go
+++ b/testbed/testbed/load_generator.go
@@ -134,7 +134,7 @@ func (lg *LoadGenerator) generate() {
 	// Indicate that generation is done at the end
 	defer lg.stopWait.Done()
 
-	if lg.options.DataItemsPerSecond <= 0 {
+	if lg.options.DataItemsPerSecond == 0 {
 		return
 	}
 

--- a/testbed/testbed/receivers.go
+++ b/testbed/testbed/receivers.go
@@ -58,6 +58,11 @@ func (mb *DataReceiverBase) ReportFatalError(err error) {
 	log.Printf("Fatal error reported: %v", err)
 }
 
+// GetFactory of the specified kind. Returns the factory for a component type.
+func (mb *DataReceiverBase) GetFactory(kind component.Kind, componentType string) component.Factory {
+	return nil
+}
+
 // OCDataReceiver implements OpenCensus format receiver.
 type OCDataReceiver struct {
 	DataReceiverBase

--- a/testbed/tests/trace_test.go
+++ b/testbed/tests/trace_test.go
@@ -52,7 +52,7 @@ func TestTrace10kSPS(t *testing.T) {
 			testbed.NewJaegerGRPCDataSender(testbed.GetAvailablePort(t)),
 			testbed.NewJaegerDataReceiver(testbed.GetAvailablePort(t)),
 			testbed.ResourceSpec{
-				ExpectedMaxCPU: 53,
+				ExpectedMaxCPU: 69,
 				ExpectedMaxRAM: 89,
 			},
 		},


### PR DESCRIPTION
Added GetFactory function to Host interface. This allows components
to fetch factories and create components dynamically. The functionality
will be used by receiver creator that creates and destroys other receivers
as it discovers relevant external endpoints from which these receivers
can get data.
