### PR TITLE
Enable tag publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,25 +34,46 @@ workflows:
   version: 2
   build-and-test:
     jobs:
-      - setup-and-lint
+      - setup-and-lint:
+          filters:
+            tags:
+              only: /^v([0-9])+.([0-9])+.([0-9])+.*/
       - build:
           requires:
             - setup-and-lint
+          filters:
+            tags:
+              only: /^v([0-9])+.([0-9])+.([0-9])+.*/
       - cross-compile:
           requires:
             - build
+          filters:
+            tags:
+              only: /^v([0-9])+.([0-9])+.([0-9])+.*/
       - loadtest:
           requires:
             - build
+          filters:
+            tags:
+              only: /^v([0-9])+.([0-9])+.([0-9])+.*/
       - test:
           requires:
             - setup-and-lint
+          filters:
+            tags:
+              only: /^v([0-9])+.([0-9])+.([0-9])+.*/
       - gosec:
           requires:
             - setup-and-lint
+          filters:
+            tags:
+              only: /^v([0-9])+.([0-9])+.([0-9])+.*/
       - coverage:
           requires:
             - setup-and-lint
+          filters:
+            tags:
+              only: /^v([0-9])+.([0-9])+.([0-9])+.*/
       - publish-stable:
           requires:
             - cross-compile
@@ -64,7 +85,7 @@ workflows:
             branches:
               ignore: /.*/
             tags:
-              only: /^v[0-9].[0-9].[0-9]+.*/
+              only: /^v([0-9])+.([0-9])+.([0-9])+.*/
 
 jobs:
   setup-and-lint:


### PR DESCRIPTION
**Description:** 
Circle was not running any builds for tags because the publish job had
other jobs as dependencies and they did not explicitly specify that they
should be run for tags. Looks like Circle will always run a job for any
branch unless the branch is ignored and never run a job for a tag unless
the tag is explicitly enabled.