### PR TITLE
Reduce parallelism for loadtest job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,7 +166,7 @@ jobs:
 
   loadtest:
     executor: golang
-    parallelism: 10
+    parallelism: 1
     steps:
       - attach_to_workspace
       - run:


### PR DESCRIPTION
Otherwise CPU usage is not measured adequately and tests are randomly failing

First, trying to see how long tests will take with this change