### PR TITLE
Remove set for maps data

### DIFF
--- a/internal/data/common.go
+++ b/internal/data/common.go
@@ -133,11 +133,6 @@ type AttributeKeyValue struct {
 	orig *otlpcommon.AttributeKeyValue
 }
 
-// NewAttributeKeyValue creates a new AttributeKeyValue with the given key.
-func NewAttributeKeyValue(k string) AttributeKeyValue {
-	return AttributeKeyValue{&otlpcommon.AttributeKeyValue{Key: k}}
-}
-
 // NewAttributeKeyValueString creates a new AttributeKeyValue with the given key and string value.
 func NewAttributeKeyValueString(k string, v string) AttributeKeyValue {
 	akv := AttributeKeyValue{&otlpcommon.AttributeKeyValue{Key: k}}
@@ -232,11 +227,25 @@ type AttributeMap struct {
 	orig *[]*otlpcommon.AttributeKeyValue
 }
 
-// NewAttributeMap creates a new AttributeMap from the given map[string]AttributeValue.
-func NewAttributeMap(attrMap map[string]AttributeValue) AttributeMap {
+// NewAttributeMap creates a AttributeMap with 0 elements.
+func NewAttributeMap() AttributeMap {
+	orig := []*otlpcommon.AttributeKeyValue(nil)
+	return AttributeMap{&orig}
+}
+
+func newAttributeMap(orig *[]*otlpcommon.AttributeKeyValue) AttributeMap {
+	return AttributeMap{orig}
+}
+
+// InitFromMap overwrites the entire AttributeMap and reconstructs the AttributeMap
+// with values from the given map[string]string.
+//
+// Returns the same instance to allow nicer code like:
+// assert.EqualValues(t, NewAttributeMap().InitFromMap(map[string]AttributeValue{...}), actual)
+func (am AttributeMap) InitFromMap(attrMap map[string]AttributeValue) AttributeMap {
 	if len(attrMap) == 0 {
-		orig := []*otlpcommon.AttributeKeyValue(nil)
-		return AttributeMap{&orig}
+		*am.orig = []*otlpcommon.AttributeKeyValue(nil)
+		return am
 	}
 	origs := make([]otlpcommon.AttributeKeyValue, len(attrMap))
 	wrappers := make([]*otlpcommon.AttributeKeyValue, len(attrMap))
@@ -249,11 +258,9 @@ func NewAttributeMap(attrMap map[string]AttributeValue) AttributeMap {
 		ix++
 	}
 
-	return AttributeMap{&wrappers}
-}
+	*am.orig = wrappers
 
-func newAttributeMap(orig *[]*otlpcommon.AttributeKeyValue) AttributeMap {
-	return AttributeMap{orig}
+	return am
 }
 
 // Get returns the AttributeKeyValue associated with the key and true,
@@ -361,15 +368,25 @@ type StringMap struct {
 	orig *[]*otlpcommon.StringKeyValue
 }
 
+// NewStringMap creates a StringMap with 0 elements.
+func NewStringMap() StringMap {
+	orig := []*otlpcommon.StringKeyValue(nil)
+	return StringMap{&orig}
+}
+
 func newStringMap(orig *[]*otlpcommon.StringKeyValue) StringMap {
 	return StringMap{orig}
 }
 
-// NewStringMap creates a new StringMap from the given map[string]string.
-func NewStringMap(attrMap map[string]string) StringMap {
+// InitFromMap overwrites the entire StringMap and reconstructs the StringMap
+// with values from the given map[string]string.
+//
+// Returns the same instance to allow nicer code like:
+// assert.EqualValues(t, NewStringMap().InitFromMap(map[string]string{...}), actual)
+func (sm StringMap) InitFromMap(attrMap map[string]string) StringMap {
 	if len(attrMap) == 0 {
-		orig := []*otlpcommon.StringKeyValue(nil)
-		return StringMap{&orig}
+		*sm.orig = []*otlpcommon.StringKeyValue(nil)
+		return sm
 	}
 	origs := make([]otlpcommon.StringKeyValue, len(attrMap))
 	wrappers := make([]*otlpcommon.StringKeyValue, len(attrMap))
@@ -381,8 +398,8 @@ func NewStringMap(attrMap map[string]string) StringMap {
 		wrappers[ix].Value = v
 		ix++
 	}
-
-	return StringMap{&wrappers}
+	*sm.orig = wrappers
+	return sm
 }
 
 // Get returns the StringKeyValue associated with the key and true,

--- a/internal/data/common_test.go
+++ b/internal/data/common_test.go
@@ -112,28 +112,29 @@ func TestAttributeKeyValue(t *testing.T) {
 }
 
 func TestNilStringMap(t *testing.T) {
-	val, exist := NewStringMap(nil).Get("test_key")
+	val, exist := NewStringMap().Get("test_key")
 	assert.EqualValues(t, false, exist)
 	assert.EqualValues(t, StringKeyValue{nil}, val)
-	insertMap := NewStringMap(nil)
-	insertMap.Insert("key", "value")
-	assert.EqualValues(t, NewStringMap(map[string]string{"key": "value"}), insertMap)
-	updateMap := NewStringMap(nil)
-	updateMap.Update("key", "value")
-	assert.EqualValues(t, NewStringMap(nil), updateMap)
-	upsertMap := NewStringMap(nil)
-	upsertMap.Upsert("key", "value")
-	assert.EqualValues(t, NewStringMap(map[string]string{"key": "value"}), upsertMap)
-	deleteMap := NewStringMap(nil)
-	assert.EqualValues(t, false, deleteMap.Delete("key"))
-	assert.EqualValues(t, NewStringMap(nil), deleteMap)
-	assert.EqualValues(t, 0, NewStringMap(nil).Len())
-	assert.EqualValues(t, NewStringMap(nil), NewStringMap(nil).Sort())
+	insertMap := NewStringMap()
+	insertMap.Insert("k", "v")
+	assert.EqualValues(t, generateTestStringMap(), insertMap)
+	updateMap := NewStringMap()
+	updateMap.Update("k", "v")
+	assert.EqualValues(t, NewStringMap(), updateMap)
+	upsertMap := NewStringMap()
+	upsertMap.Upsert("k", "v")
+	assert.EqualValues(t, generateTestStringMap(), upsertMap)
+	deleteMap := NewStringMap()
+	assert.EqualValues(t, false, deleteMap.Delete("k"))
+	assert.EqualValues(t, NewStringMap(), deleteMap)
+	assert.EqualValues(t, 0, NewStringMap().Len())
+	assert.EqualValues(t, NewStringMap(), NewStringMap().Sort())
 }
 
 func TestStringMap(t *testing.T) {
-	origMap := map[string]string{"k0": "v0", "k1": "v1", "k2": "v2"}
-	sm := NewStringMap(origMap)
+	origRawMap := map[string]string{"k0": "v0", "k1": "v1", "k2": "v2"}
+	origMap := NewStringMap().InitFromMap(origRawMap)
+	sm := NewStringMap().InitFromMap(origRawMap)
 	assert.EqualValues(t, 3, sm.Len())
 
 	val, exist := sm.Get("k2")
@@ -145,53 +146,53 @@ func TestStringMap(t *testing.T) {
 	assert.EqualValues(t, StringKeyValue{nil}, val)
 
 	sm.Insert("k1", "v1")
-	assert.EqualValues(t, NewStringMap(origMap).Sort(), sm.Sort())
+	assert.EqualValues(t, origMap.Sort(), sm.Sort())
 	sm.Insert("k3", "v3")
 	assert.EqualValues(t, 4, sm.Len())
-	assert.EqualValues(t, NewStringMap(map[string]string{"k0": "v0", "k1": "v1", "k2": "v2", "k3": "v3"}).Sort(), sm.Sort())
+	assert.EqualValues(t, NewStringMap().InitFromMap(map[string]string{"k0": "v0", "k1": "v1", "k2": "v2", "k3": "v3"}).Sort(), sm.Sort())
 	assert.EqualValues(t, true, sm.Delete("k3"))
 	assert.EqualValues(t, 3, sm.Len())
-	assert.EqualValues(t, NewStringMap(origMap).Sort(), sm.Sort())
+	assert.EqualValues(t, origMap.Sort(), sm.Sort())
 
 	sm.Update("k3", "v3")
 	assert.EqualValues(t, 3, sm.Len())
-	assert.EqualValues(t, NewStringMap(origMap).Sort(), sm.Sort())
+	assert.EqualValues(t, origMap.Sort(), sm.Sort())
 	sm.Update("k2", "v3")
 	assert.EqualValues(t, 3, sm.Len())
-	assert.EqualValues(t, NewStringMap(map[string]string{"k0": "v0", "k1": "v1", "k2": "v3"}).Sort(), sm.Sort())
+	assert.EqualValues(t, NewStringMap().InitFromMap(map[string]string{"k0": "v0", "k1": "v1", "k2": "v3"}).Sort(), sm.Sort())
 	sm.Update("k2", "v2")
 	assert.EqualValues(t, 3, sm.Len())
-	assert.EqualValues(t, NewStringMap(origMap).Sort(), sm.Sort())
+	assert.EqualValues(t, origMap.Sort(), sm.Sort())
 
 	sm.Upsert("k3", "v3")
 	assert.EqualValues(t, 4, sm.Len())
-	assert.EqualValues(t, NewStringMap(map[string]string{"k0": "v0", "k1": "v1", "k2": "v2", "k3": "v3"}).Sort(), sm.Sort())
+	assert.EqualValues(t, NewStringMap().InitFromMap(map[string]string{"k0": "v0", "k1": "v1", "k2": "v2", "k3": "v3"}).Sort(), sm.Sort())
 	sm.Upsert("k1", "v5")
 	assert.EqualValues(t, 4, sm.Len())
-	assert.EqualValues(t, NewStringMap(map[string]string{"k0": "v0", "k1": "v5", "k2": "v2", "k3": "v3"}).Sort(), sm.Sort())
+	assert.EqualValues(t, NewStringMap().InitFromMap(map[string]string{"k0": "v0", "k1": "v5", "k2": "v2", "k3": "v3"}).Sort(), sm.Sort())
 	sm.Upsert("k1", "v1")
 	assert.EqualValues(t, 4, sm.Len())
-	assert.EqualValues(t, NewStringMap(map[string]string{"k0": "v0", "k1": "v1", "k2": "v2", "k3": "v3"}).Sort(), sm.Sort())
+	assert.EqualValues(t, NewStringMap().InitFromMap(map[string]string{"k0": "v0", "k1": "v1", "k2": "v2", "k3": "v3"}).Sort(), sm.Sort())
 	assert.EqualValues(t, true, sm.Delete("k3"))
 	assert.EqualValues(t, 3, sm.Len())
-	assert.EqualValues(t, NewStringMap(origMap).Sort(), sm.Sort())
+	assert.EqualValues(t, origMap.Sort(), sm.Sort())
 
 	assert.EqualValues(t, false, sm.Delete("k3"))
 	assert.EqualValues(t, 3, sm.Len())
-	assert.EqualValues(t, NewStringMap(origMap).Sort(), sm.Sort())
+	assert.EqualValues(t, origMap.Sort(), sm.Sort())
 
 	assert.EqualValues(t, true, sm.Delete("k0"))
 	assert.EqualValues(t, 2, sm.Len())
-	assert.EqualValues(t, NewStringMap(map[string]string{"k1": "v1", "k2": "v2"}).Sort(), sm.Sort())
+	assert.EqualValues(t, NewStringMap().InitFromMap(map[string]string{"k1": "v1", "k2": "v2"}).Sort(), sm.Sort())
 	assert.EqualValues(t, true, sm.Delete("k2"))
 	assert.EqualValues(t, 1, sm.Len())
-	assert.EqualValues(t, NewStringMap(map[string]string{"k1": "v1"}).Sort(), sm.Sort())
+	assert.EqualValues(t, NewStringMap().InitFromMap(map[string]string{"k1": "v1"}).Sort(), sm.Sort())
 	assert.EqualValues(t, true, sm.Delete("k1"))
 	assert.EqualValues(t, 0, sm.Len())
 }
 
 func TestStringMapIteration(t *testing.T) {
-	sm := NewStringMap(map[string]string{"k0": "v0", "k1": "v1", "k2": "v2"})
+	sm := NewStringMap().InitFromMap(map[string]string{"k0": "v0", "k1": "v1", "k2": "v2"})
 	assert.EqualValues(t, 3, sm.Len())
 	sm.Sort()
 	for i := 0; i < sm.Len(); i++ {
@@ -202,13 +203,25 @@ func TestStringMapIteration(t *testing.T) {
 }
 
 func generateTestStringMap() StringMap {
-	return NewStringMap(map[string]string{
+	sm := NewStringMap()
+	fillTestStringMap(sm)
+	return sm
+}
+
+func fillTestStringMap(dest StringMap) {
+	dest.InitFromMap(map[string]string{
 		"k": "v",
 	})
 }
 
 func generateTestAttributeMap() AttributeMap {
-	return NewAttributeMap(map[string]AttributeValue{
+	am := NewAttributeMap()
+	fillTestAttributeMap(am)
+	return am
+}
+
+func fillTestAttributeMap(dest AttributeMap) {
+	dest.InitFromMap(map[string]AttributeValue{
 		"k": NewAttributeValueString("v"),
 	})
 }

--- a/internal/data/generated_metrics.go
+++ b/internal/data/generated_metrics.go
@@ -527,13 +527,6 @@ func (ms MetricDescriptor) LabelsMap() StringMap {
 	return newStringMap(&(*ms.orig).Labels)
 }
 
-// SetLabelsMap replaces the Labels associated with this MetricDescriptor.
-//
-// Important: This causes a runtime error if IsNil() returns "true".
-func (ms MetricDescriptor) SetLabelsMap(v StringMap) {
-	(*ms.orig).Labels = *v.orig
-}
-
 // Int64DataPointSlice logically represents a slice of Int64DataPoint.
 //
 // This is a reference type, if passsed by value and callee modifies it the
@@ -650,13 +643,6 @@ func (ms Int64DataPoint) IsNil() bool {
 // Important: This causes a runtime error if IsNil() returns "true".
 func (ms Int64DataPoint) LabelsMap() StringMap {
 	return newStringMap(&(*ms.orig).Labels)
-}
-
-// SetLabelsMap replaces the Labels associated with this Int64DataPoint.
-//
-// Important: This causes a runtime error if IsNil() returns "true".
-func (ms Int64DataPoint) SetLabelsMap(v StringMap) {
-	(*ms.orig).Labels = *v.orig
 }
 
 // StartTime returns the starttime associated with this Int64DataPoint.
@@ -819,13 +805,6 @@ func (ms DoubleDataPoint) LabelsMap() StringMap {
 	return newStringMap(&(*ms.orig).Labels)
 }
 
-// SetLabelsMap replaces the Labels associated with this DoubleDataPoint.
-//
-// Important: This causes a runtime error if IsNil() returns "true".
-func (ms DoubleDataPoint) SetLabelsMap(v StringMap) {
-	(*ms.orig).Labels = *v.orig
-}
-
 // StartTime returns the starttime associated with this DoubleDataPoint.
 //
 // Important: This causes a runtime error if IsNil() returns "true".
@@ -984,13 +963,6 @@ func (ms HistogramDataPoint) IsNil() bool {
 // Important: This causes a runtime error if IsNil() returns "true".
 func (ms HistogramDataPoint) LabelsMap() StringMap {
 	return newStringMap(&(*ms.orig).Labels)
-}
-
-// SetLabelsMap replaces the Labels associated with this HistogramDataPoint.
-//
-// Important: This causes a runtime error if IsNil() returns "true".
-func (ms HistogramDataPoint) SetLabelsMap(v StringMap) {
-	(*ms.orig).Labels = *v.orig
 }
 
 // StartTime returns the starttime associated with this HistogramDataPoint.
@@ -1279,13 +1251,6 @@ func (ms HistogramBucketExemplar) Attachments() StringMap {
 	return newStringMap(&(*ms.orig).Attachments)
 }
 
-// SetAttachments replaces the Attachments associated with this HistogramBucketExemplar.
-//
-// Important: This causes a runtime error if IsNil() returns "true".
-func (ms HistogramBucketExemplar) SetAttachments(v StringMap) {
-	(*ms.orig).Attachments = *v.orig
-}
-
 // SummaryDataPointSlice logically represents a slice of SummaryDataPoint.
 //
 // This is a reference type, if passsed by value and callee modifies it the
@@ -1402,13 +1367,6 @@ func (ms SummaryDataPoint) IsNil() bool {
 // Important: This causes a runtime error if IsNil() returns "true".
 func (ms SummaryDataPoint) LabelsMap() StringMap {
 	return newStringMap(&(*ms.orig).Labels)
-}
-
-// SetLabelsMap replaces the Labels associated with this SummaryDataPoint.
-//
-// Important: This causes a runtime error if IsNil() returns "true".
-func (ms SummaryDataPoint) SetLabelsMap(v StringMap) {
-	(*ms.orig).Labels = *v.orig
 }
 
 // StartTime returns the starttime associated with this SummaryDataPoint.

--- a/internal/data/generated_metrics_test.go
+++ b/internal/data/generated_metrics_test.go
@@ -293,9 +293,9 @@ func TestMetricDescriptor(t *testing.T) {
 	ms.SetType(testValType)
 	assert.EqualValues(t, testValType, ms.Type())
 
-	assert.EqualValues(t, NewStringMap(nil), ms.LabelsMap())
+	assert.EqualValues(t, NewStringMap(), ms.LabelsMap())
+	fillTestStringMap(ms.LabelsMap())
 	testValLabelsMap := generateTestStringMap()
-	ms.SetLabelsMap(testValLabelsMap)
 	assert.EqualValues(t, testValLabelsMap, ms.LabelsMap())
 
 	assert.EqualValues(t, generateTestMetricDescriptor(), ms)
@@ -363,9 +363,9 @@ func TestInt64DataPoint(t *testing.T) {
 	ms.InitEmpty()
 	assert.EqualValues(t, false, ms.IsNil())
 
-	assert.EqualValues(t, NewStringMap(nil), ms.LabelsMap())
+	assert.EqualValues(t, NewStringMap(), ms.LabelsMap())
+	fillTestStringMap(ms.LabelsMap())
 	testValLabelsMap := generateTestStringMap()
-	ms.SetLabelsMap(testValLabelsMap)
 	assert.EqualValues(t, testValLabelsMap, ms.LabelsMap())
 
 	assert.EqualValues(t, TimestampUnixNano(0), ms.StartTime())
@@ -448,9 +448,9 @@ func TestDoubleDataPoint(t *testing.T) {
 	ms.InitEmpty()
 	assert.EqualValues(t, false, ms.IsNil())
 
-	assert.EqualValues(t, NewStringMap(nil), ms.LabelsMap())
+	assert.EqualValues(t, NewStringMap(), ms.LabelsMap())
+	fillTestStringMap(ms.LabelsMap())
 	testValLabelsMap := generateTestStringMap()
-	ms.SetLabelsMap(testValLabelsMap)
 	assert.EqualValues(t, testValLabelsMap, ms.LabelsMap())
 
 	assert.EqualValues(t, TimestampUnixNano(0), ms.StartTime())
@@ -533,9 +533,9 @@ func TestHistogramDataPoint(t *testing.T) {
 	ms.InitEmpty()
 	assert.EqualValues(t, false, ms.IsNil())
 
-	assert.EqualValues(t, NewStringMap(nil), ms.LabelsMap())
+	assert.EqualValues(t, NewStringMap(), ms.LabelsMap())
+	fillTestStringMap(ms.LabelsMap())
 	testValLabelsMap := generateTestStringMap()
-	ms.SetLabelsMap(testValLabelsMap)
 	assert.EqualValues(t, testValLabelsMap, ms.LabelsMap())
 
 	assert.EqualValues(t, TimestampUnixNano(0), ms.StartTime())
@@ -663,9 +663,9 @@ func TestHistogramBucketExemplar(t *testing.T) {
 	ms.SetValue(testValValue)
 	assert.EqualValues(t, testValValue, ms.Value())
 
-	assert.EqualValues(t, NewStringMap(nil), ms.Attachments())
+	assert.EqualValues(t, NewStringMap(), ms.Attachments())
+	fillTestStringMap(ms.Attachments())
 	testValAttachments := generateTestStringMap()
-	ms.SetAttachments(testValAttachments)
 	assert.EqualValues(t, testValAttachments, ms.Attachments())
 
 	assert.EqualValues(t, generateTestHistogramBucketExemplar(), ms)
@@ -733,9 +733,9 @@ func TestSummaryDataPoint(t *testing.T) {
 	ms.InitEmpty()
 	assert.EqualValues(t, false, ms.IsNil())
 
-	assert.EqualValues(t, NewStringMap(nil), ms.LabelsMap())
+	assert.EqualValues(t, NewStringMap(), ms.LabelsMap())
+	fillTestStringMap(ms.LabelsMap())
 	testValLabelsMap := generateTestStringMap()
-	ms.SetLabelsMap(testValLabelsMap)
 	assert.EqualValues(t, testValLabelsMap, ms.LabelsMap())
 
 	assert.EqualValues(t, TimestampUnixNano(0), ms.StartTime())
@@ -934,7 +934,7 @@ func fillTestMetricDescriptor(tv MetricDescriptor) {
 	tv.SetDescription("test_description")
 	tv.SetUnit("1")
 	tv.SetType(MetricTypeGaugeInt64)
-	tv.SetLabelsMap(generateTestStringMap())
+	fillTestStringMap(tv.LabelsMap())
 }
 
 func generateTestInt64DataPointSlice() Int64DataPointSlice {
@@ -958,7 +958,7 @@ func generateTestInt64DataPoint() Int64DataPoint {
 }
 
 func fillTestInt64DataPoint(tv Int64DataPoint) {
-	tv.SetLabelsMap(generateTestStringMap())
+	fillTestStringMap(tv.LabelsMap())
 	tv.SetStartTime(TimestampUnixNano(1234567890))
 	tv.SetTimestamp(TimestampUnixNano(1234567890))
 	tv.SetValue(int64(-17))
@@ -985,7 +985,7 @@ func generateTestDoubleDataPoint() DoubleDataPoint {
 }
 
 func fillTestDoubleDataPoint(tv DoubleDataPoint) {
-	tv.SetLabelsMap(generateTestStringMap())
+	fillTestStringMap(tv.LabelsMap())
 	tv.SetStartTime(TimestampUnixNano(1234567890))
 	tv.SetTimestamp(TimestampUnixNano(1234567890))
 	tv.SetValue(float64(17.13))
@@ -1012,7 +1012,7 @@ func generateTestHistogramDataPoint() HistogramDataPoint {
 }
 
 func fillTestHistogramDataPoint(tv HistogramDataPoint) {
-	tv.SetLabelsMap(generateTestStringMap())
+	fillTestStringMap(tv.LabelsMap())
 	tv.SetStartTime(TimestampUnixNano(1234567890))
 	tv.SetTimestamp(TimestampUnixNano(1234567890))
 	tv.SetCount(uint64(17))
@@ -1057,7 +1057,7 @@ func generateTestHistogramBucketExemplar() HistogramBucketExemplar {
 func fillTestHistogramBucketExemplar(tv HistogramBucketExemplar) {
 	tv.SetTimestamp(TimestampUnixNano(1234567890))
 	tv.SetValue(float64(17.13))
-	tv.SetAttachments(generateTestStringMap())
+	fillTestStringMap(tv.Attachments())
 }
 
 func generateTestSummaryDataPointSlice() SummaryDataPointSlice {
@@ -1081,7 +1081,7 @@ func generateTestSummaryDataPoint() SummaryDataPoint {
 }
 
 func fillTestSummaryDataPoint(tv SummaryDataPoint) {
-	tv.SetLabelsMap(generateTestStringMap())
+	fillTestStringMap(tv.LabelsMap())
 	tv.SetStartTime(TimestampUnixNano(1234567890))
 	tv.SetTimestamp(TimestampUnixNano(1234567890))
 	tv.SetCount(uint64(17))

--- a/internal/data/generated_resource.go
+++ b/internal/data/generated_resource.go
@@ -65,10 +65,3 @@ func (ms Resource) IsNil() bool {
 func (ms Resource) Attributes() AttributeMap {
 	return newAttributeMap(&(*ms.orig).Attributes)
 }
-
-// SetAttributes replaces the Attributes associated with this Resource.
-//
-// Important: This causes a runtime error if IsNil() returns "true".
-func (ms Resource) SetAttributes(v AttributeMap) {
-	(*ms.orig).Attributes = *v.orig
-}

--- a/internal/data/generated_resource_test.go
+++ b/internal/data/generated_resource_test.go
@@ -29,9 +29,9 @@ func TestResource(t *testing.T) {
 	ms.InitEmpty()
 	assert.EqualValues(t, false, ms.IsNil())
 
-	assert.EqualValues(t, NewAttributeMap(nil), ms.Attributes())
+	assert.EqualValues(t, NewAttributeMap(), ms.Attributes())
+	fillTestAttributeMap(ms.Attributes())
 	testValAttributes := generateTestAttributeMap()
-	ms.SetAttributes(testValAttributes)
 	assert.EqualValues(t, testValAttributes, ms.Attributes())
 
 	assert.EqualValues(t, generateTestResource(), ms)
@@ -45,5 +45,5 @@ func generateTestResource() Resource {
 }
 
 func fillTestResource(tv Resource) {
-	tv.SetAttributes(generateTestAttributeMap())
+	fillTestAttributeMap(tv.Attributes())
 }

--- a/internal/data/generated_trace.go
+++ b/internal/data/generated_trace.go
@@ -508,13 +508,6 @@ func (ms Span) Attributes() AttributeMap {
 	return newAttributeMap(&(*ms.orig).Attributes)
 }
 
-// SetAttributes replaces the Attributes associated with this Span.
-//
-// Important: This causes a runtime error if IsNil() returns "true".
-func (ms Span) SetAttributes(v AttributeMap) {
-	(*ms.orig).Attributes = *v.orig
-}
-
 // DroppedAttributesCount returns the droppedattributescount associated with this Span.
 //
 // Important: This causes a runtime error if IsNil() returns "true".
@@ -728,13 +721,6 @@ func (ms SpanEvent) Attributes() AttributeMap {
 	return newAttributeMap(&(*ms.orig).Attributes)
 }
 
-// SetAttributes replaces the Attributes associated with this SpanEvent.
-//
-// Important: This causes a runtime error if IsNil() returns "true".
-func (ms SpanEvent) SetAttributes(v AttributeMap) {
-	(*ms.orig).Attributes = *v.orig
-}
-
 // DroppedAttributesCount returns the droppedattributescount associated with this SpanEvent.
 //
 // Important: This causes a runtime error if IsNil() returns "true".
@@ -908,13 +894,6 @@ func (ms SpanLink) SetTraceState(v TraceState) {
 // Important: This causes a runtime error if IsNil() returns "true".
 func (ms SpanLink) Attributes() AttributeMap {
 	return newAttributeMap(&(*ms.orig).Attributes)
-}
-
-// SetAttributes replaces the Attributes associated with this SpanLink.
-//
-// Important: This causes a runtime error if IsNil() returns "true".
-func (ms SpanLink) SetAttributes(v AttributeMap) {
-	(*ms.orig).Attributes = *v.orig
 }
 
 // DroppedAttributesCount returns the droppedattributescount associated with this SpanLink.

--- a/internal/data/generated_trace_test.go
+++ b/internal/data/generated_trace_test.go
@@ -278,9 +278,9 @@ func TestSpan(t *testing.T) {
 	ms.SetEndTime(testValEndTime)
 	assert.EqualValues(t, testValEndTime, ms.EndTime())
 
-	assert.EqualValues(t, NewAttributeMap(nil), ms.Attributes())
+	assert.EqualValues(t, NewAttributeMap(), ms.Attributes())
+	fillTestAttributeMap(ms.Attributes())
 	testValAttributes := generateTestAttributeMap()
-	ms.SetAttributes(testValAttributes)
 	assert.EqualValues(t, testValAttributes, ms.Attributes())
 
 	assert.EqualValues(t, uint32(0), ms.DroppedAttributesCount())
@@ -389,9 +389,9 @@ func TestSpanEvent(t *testing.T) {
 	ms.SetName(testValName)
 	assert.EqualValues(t, testValName, ms.Name())
 
-	assert.EqualValues(t, NewAttributeMap(nil), ms.Attributes())
+	assert.EqualValues(t, NewAttributeMap(), ms.Attributes())
+	fillTestAttributeMap(ms.Attributes())
 	testValAttributes := generateTestAttributeMap()
-	ms.SetAttributes(testValAttributes)
 	assert.EqualValues(t, testValAttributes, ms.Attributes())
 
 	assert.EqualValues(t, uint32(0), ms.DroppedAttributesCount())
@@ -479,9 +479,9 @@ func TestSpanLink(t *testing.T) {
 	ms.SetTraceState(testValTraceState)
 	assert.EqualValues(t, testValTraceState, ms.TraceState())
 
-	assert.EqualValues(t, NewAttributeMap(nil), ms.Attributes())
+	assert.EqualValues(t, NewAttributeMap(), ms.Attributes())
+	fillTestAttributeMap(ms.Attributes())
 	testValAttributes := generateTestAttributeMap()
-	ms.SetAttributes(testValAttributes)
 	assert.EqualValues(t, testValAttributes, ms.Attributes())
 
 	assert.EqualValues(t, uint32(0), ms.DroppedAttributesCount())
@@ -592,7 +592,7 @@ func fillTestSpan(tv Span) {
 	tv.SetKind(SpanKindSERVER)
 	tv.SetStartTime(TimestampUnixNano(1234567890))
 	tv.SetEndTime(TimestampUnixNano(1234567890))
-	tv.SetAttributes(generateTestAttributeMap())
+	fillTestAttributeMap(tv.Attributes())
 	tv.SetDroppedAttributesCount(uint32(17))
 	fillTestSpanEventSlice(tv.Events())
 	tv.SetDroppedEventsCount(uint32(17))
@@ -625,7 +625,7 @@ func generateTestSpanEvent() SpanEvent {
 func fillTestSpanEvent(tv SpanEvent) {
 	tv.SetTimestamp(TimestampUnixNano(1234567890))
 	tv.SetName("test_name")
-	tv.SetAttributes(generateTestAttributeMap())
+	fillTestAttributeMap(tv.Attributes())
 	tv.SetDroppedAttributesCount(uint32(17))
 }
 
@@ -653,7 +653,7 @@ func fillTestSpanLink(tv SpanLink) {
 	tv.SetTraceID(NewTraceID([]byte{1, 2, 3, 4, 5, 6, 7, 8, 8, 7, 6, 5, 4, 3, 2, 1}))
 	tv.SetSpanID(NewSpanID([]byte{1, 2, 3, 4, 5, 6, 7, 8}))
 	tv.SetTraceState(TraceState("congo=congos"))
-	tv.SetAttributes(generateTestAttributeMap())
+	fillTestAttributeMap(tv.Attributes())
 	tv.SetDroppedAttributesCount(uint32(17))
 }
 

--- a/internal/data/metric_test.go
+++ b/internal/data/metric_test.go
@@ -70,25 +70,27 @@ func TestOtlpToInternalReadOnly(t *testing.T) {
 	assert.EqualValues(t, generateTestProtoResource(), *resourceMetric.Resource().orig)
 	metrics := resourceMetric.InstrumentationLibraryMetrics().At(0).Metrics()
 	assert.EqualValues(t, 4, metrics.Len())
+
 	// Check int64 metric
 	metricInt := metrics.At(0)
 	assert.EqualValues(t, "my_metric_int", metricInt.MetricDescriptor().Name())
 	assert.EqualValues(t, "My metric", metricInt.MetricDescriptor().Description())
 	assert.EqualValues(t, "ms", metricInt.MetricDescriptor().Unit())
 	assert.EqualValues(t, MetricTypeCounterInt64, metricInt.MetricDescriptor().Type())
-	assert.EqualValues(t, NewStringMap(map[string]string{}), metricInt.MetricDescriptor().LabelsMap())
+	assert.EqualValues(t, NewStringMap(), metricInt.MetricDescriptor().LabelsMap())
 	int64DataPoints := metricInt.Int64DataPoints()
 	assert.EqualValues(t, 2, int64DataPoints.Len())
 	// First point
 	assert.EqualValues(t, startTime, int64DataPoints.At(0).StartTime())
 	assert.EqualValues(t, endTime, int64DataPoints.At(0).Timestamp())
 	assert.EqualValues(t, 123, int64DataPoints.At(0).Value())
-	assert.EqualValues(t, NewStringMap(map[string]string{"key0": "value0"}), int64DataPoints.At(0).LabelsMap())
+	assert.EqualValues(t, NewStringMap().InitFromMap(map[string]string{"key0": "value0"}), int64DataPoints.At(0).LabelsMap())
 	// Second point
 	assert.EqualValues(t, startTime, int64DataPoints.At(1).StartTime())
 	assert.EqualValues(t, endTime, int64DataPoints.At(1).Timestamp())
 	assert.EqualValues(t, 456, int64DataPoints.At(1).Value())
-	assert.EqualValues(t, NewStringMap(map[string]string{"key1": "value1"}), int64DataPoints.At(1).LabelsMap())
+	assert.EqualValues(t, NewStringMap().InitFromMap(map[string]string{"key1": "value1"}), int64DataPoints.At(1).LabelsMap())
+
 	// Check double metric
 	metricDouble := metrics.At(1)
 	assert.EqualValues(t, "my_metric_double", metricDouble.MetricDescriptor().Name())
@@ -101,12 +103,13 @@ func TestOtlpToInternalReadOnly(t *testing.T) {
 	assert.EqualValues(t, startTime, doubleDataPoints.At(0).StartTime())
 	assert.EqualValues(t, endTime, doubleDataPoints.At(0).Timestamp())
 	assert.EqualValues(t, 123.1, doubleDataPoints.At(0).Value())
-	assert.EqualValues(t, NewStringMap(map[string]string{"key0": "value0"}), doubleDataPoints.At(0).LabelsMap())
+	assert.EqualValues(t, NewStringMap().InitFromMap(map[string]string{"key0": "value0"}), doubleDataPoints.At(0).LabelsMap())
 	// Second point
 	assert.EqualValues(t, startTime, doubleDataPoints.At(1).StartTime())
 	assert.EqualValues(t, endTime, doubleDataPoints.At(1).Timestamp())
 	assert.EqualValues(t, 456.1, doubleDataPoints.At(1).Value())
-	assert.EqualValues(t, NewStringMap(map[string]string{"key1": "value1"}), doubleDataPoints.At(1).LabelsMap())
+	assert.EqualValues(t, NewStringMap().InitFromMap(map[string]string{"key1": "value1"}), doubleDataPoints.At(1).LabelsMap())
+
 	// Check histogram metric
 	metricHistogram := metrics.At(2)
 	assert.EqualValues(t, "my_metric_histogram", metricHistogram.MetricDescriptor().Name())
@@ -119,22 +122,23 @@ func TestOtlpToInternalReadOnly(t *testing.T) {
 	assert.EqualValues(t, startTime, histogramDataPoints.At(0).StartTime())
 	assert.EqualValues(t, endTime, histogramDataPoints.At(0).Timestamp())
 	assert.EqualValues(t, []float64{1, 2}, histogramDataPoints.At(0).ExplicitBounds())
-	assert.EqualValues(t, NewStringMap(map[string]string{"key0": "value0"}), histogramDataPoints.At(0).LabelsMap())
+	assert.EqualValues(t, NewStringMap().InitFromMap(map[string]string{"key0": "value0"}), histogramDataPoints.At(0).LabelsMap())
 	assert.EqualValues(t, 3, histogramDataPoints.At(0).Buckets().Len())
 	assert.EqualValues(t, 10, histogramDataPoints.At(0).Buckets().At(0).Count())
 	assert.EqualValues(t, 15, histogramDataPoints.At(0).Buckets().At(1).Count())
 	assert.EqualValues(t, 1.5, histogramDataPoints.At(0).Buckets().At(1).Exemplar().Value())
 	assert.EqualValues(t, startTime, histogramDataPoints.At(0).Buckets().At(1).Exemplar().Timestamp())
-	assert.EqualValues(t, NewStringMap(map[string]string{"key_a1": "value_a1"}), histogramDataPoints.At(0).Buckets().At(1).Exemplar().Attachments())
+	assert.EqualValues(t, NewStringMap().InitFromMap(map[string]string{"key_a1": "value_a1"}), histogramDataPoints.At(0).Buckets().At(1).Exemplar().Attachments())
 	assert.EqualValues(t, 1, histogramDataPoints.At(0).Buckets().At(2).Count())
 	// Second point
 	assert.EqualValues(t, startTime, histogramDataPoints.At(1).StartTime())
 	assert.EqualValues(t, endTime, histogramDataPoints.At(1).Timestamp())
 	assert.EqualValues(t, []float64{1}, histogramDataPoints.At(1).ExplicitBounds())
-	assert.EqualValues(t, NewStringMap(map[string]string{"key1": "value1"}), histogramDataPoints.At(1).LabelsMap())
+	assert.EqualValues(t, NewStringMap().InitFromMap(map[string]string{"key1": "value1"}), histogramDataPoints.At(1).LabelsMap())
 	assert.EqualValues(t, 2, histogramDataPoints.At(1).Buckets().Len())
 	assert.EqualValues(t, 10, histogramDataPoints.At(1).Buckets().At(0).Count())
 	assert.EqualValues(t, 1, histogramDataPoints.At(1).Buckets().At(1).Count())
+
 	// Check summary metric
 	metricSummary := metrics.At(3)
 	assert.EqualValues(t, "my_metric_summary", metricSummary.MetricDescriptor().Name())
@@ -146,7 +150,7 @@ func TestOtlpToInternalReadOnly(t *testing.T) {
 	// First point
 	assert.EqualValues(t, startTime, summaryDataPoints.At(0).StartTime())
 	assert.EqualValues(t, endTime, summaryDataPoints.At(0).Timestamp())
-	assert.EqualValues(t, NewStringMap(map[string]string{"key0": "value0"}), summaryDataPoints.At(0).LabelsMap())
+	assert.EqualValues(t, NewStringMap().InitFromMap(map[string]string{"key0": "value0"}), summaryDataPoints.At(0).LabelsMap())
 	assert.EqualValues(t, 2, summaryDataPoints.At(0).ValueAtPercentiles().Len())
 	assert.EqualValues(t, 0.0, summaryDataPoints.At(0).ValueAtPercentiles().At(0).Percentile())
 	assert.EqualValues(t, 1.23, summaryDataPoints.At(0).ValueAtPercentiles().At(0).Value())
@@ -155,7 +159,7 @@ func TestOtlpToInternalReadOnly(t *testing.T) {
 	// Second point
 	assert.EqualValues(t, startTime, summaryDataPoints.At(1).StartTime())
 	assert.EqualValues(t, endTime, summaryDataPoints.At(1).Timestamp())
-	assert.EqualValues(t, NewStringMap(map[string]string{"key1": "value1"}), summaryDataPoints.At(1).LabelsMap())
+	assert.EqualValues(t, NewStringMap().InitFromMap(map[string]string{"key1": "value1"}), summaryDataPoints.At(1).LabelsMap())
 	assert.EqualValues(t, 2, summaryDataPoints.At(1).ValueAtPercentiles().Len())
 	assert.EqualValues(t, 0.5, summaryDataPoints.At(1).ValueAtPercentiles().At(0).Percentile())
 	assert.EqualValues(t, 4.56, summaryDataPoints.At(1).ValueAtPercentiles().At(0).Value())
@@ -189,7 +193,7 @@ func TestOtlpToFromInternalReadOnly(t *testing.T) {
 }
 
 func TestOtlpToFromInternalIntPointsMutating(t *testing.T) {
-	newLabels := NewStringMap(map[string]string{"k": "v"})
+	newLabels := NewStringMap().InitFromMap(map[string]string{"k": "v"})
 
 	metricData := MetricDataFromOtlp([]*otlpmetrics.ResourceMetrics{
 		{
@@ -213,7 +217,7 @@ func TestOtlpToFromInternalIntPointsMutating(t *testing.T) {
 	assert.EqualValues(t, "1", metric.MetricDescriptor().Unit())
 	metric.MetricDescriptor().SetType(MetricTypeGaugeInt64)
 	assert.EqualValues(t, MetricTypeGaugeInt64, metric.MetricDescriptor().Type())
-	metric.MetricDescriptor().SetLabelsMap(newLabels)
+	metric.MetricDescriptor().LabelsMap().Insert("k", "v")
 	assert.EqualValues(t, newLabels, metric.MetricDescriptor().LabelsMap())
 	// Mutate DataPoints
 	assert.EqualValues(t, 2, metric.Int64DataPoints().Len())
@@ -226,7 +230,8 @@ func TestOtlpToFromInternalIntPointsMutating(t *testing.T) {
 	assert.EqualValues(t, endTime+1, int64DataPoints.At(0).Timestamp())
 	int64DataPoints.At(0).SetValue(124)
 	assert.EqualValues(t, 124, int64DataPoints.At(0).Value())
-	int64DataPoints.At(0).SetLabelsMap(newLabels)
+	int64DataPoints.At(0).LabelsMap().Delete("key0")
+	int64DataPoints.At(0).LabelsMap().Upsert("k", "v")
 	assert.EqualValues(t, newLabels, int64DataPoints.At(0).LabelsMap())
 
 	// Test that everything is updated.
@@ -272,7 +277,7 @@ func TestOtlpToFromInternalIntPointsMutating(t *testing.T) {
 }
 
 func TestOtlpToFromInternalDoublePointsMutating(t *testing.T) {
-	newLabels := NewStringMap(map[string]string{"k": "v"})
+	newLabels := NewStringMap().InitFromMap(map[string]string{"k": "v"})
 
 	metricData := MetricDataFromOtlp([]*otlpmetrics.ResourceMetrics{
 		{
@@ -296,7 +301,7 @@ func TestOtlpToFromInternalDoublePointsMutating(t *testing.T) {
 	assert.EqualValues(t, "1", metric.MetricDescriptor().Unit())
 	metric.MetricDescriptor().SetType(MetricTypeGaugeDouble)
 	assert.EqualValues(t, MetricTypeGaugeDouble, metric.MetricDescriptor().Type())
-	metric.MetricDescriptor().SetLabelsMap(newLabels)
+	metric.MetricDescriptor().LabelsMap().Insert("k", "v")
 	assert.EqualValues(t, newLabels, metric.MetricDescriptor().LabelsMap())
 	// Mutate DataPoints
 	assert.EqualValues(t, 2, metric.DoubleDataPoints().Len())
@@ -309,7 +314,8 @@ func TestOtlpToFromInternalDoublePointsMutating(t *testing.T) {
 	assert.EqualValues(t, endTime+1, doubleDataPoints.At(0).Timestamp())
 	doubleDataPoints.At(0).SetValue(124.1)
 	assert.EqualValues(t, 124.1, doubleDataPoints.At(0).Value())
-	doubleDataPoints.At(0).SetLabelsMap(newLabels)
+	doubleDataPoints.At(0).LabelsMap().Delete("key0")
+	doubleDataPoints.At(0).LabelsMap().Upsert("k", "v")
 	assert.EqualValues(t, newLabels, doubleDataPoints.At(0).LabelsMap())
 
 	// Test that everything is updated.
@@ -355,7 +361,7 @@ func TestOtlpToFromInternalDoublePointsMutating(t *testing.T) {
 }
 
 func TestOtlpToFromInternalHistogramPointsMutating(t *testing.T) {
-	newLabels := NewStringMap(map[string]string{"k": "v"})
+	newLabels := NewStringMap().InitFromMap(map[string]string{"k": "v"})
 
 	metricData := MetricDataFromOtlp([]*otlpmetrics.ResourceMetrics{
 		{
@@ -379,7 +385,7 @@ func TestOtlpToFromInternalHistogramPointsMutating(t *testing.T) {
 	assert.EqualValues(t, "1", metric.MetricDescriptor().Unit())
 	metric.MetricDescriptor().SetType(MetricTypeGaugeHistogram)
 	assert.EqualValues(t, MetricTypeGaugeHistogram, metric.MetricDescriptor().Type())
-	metric.MetricDescriptor().SetLabelsMap(newLabels)
+	metric.MetricDescriptor().LabelsMap().Insert("k", "v")
 	assert.EqualValues(t, newLabels, metric.MetricDescriptor().LabelsMap())
 	// Mutate DataPoints
 	assert.EqualValues(t, 2, metric.HistogramDataPoints().Len())
@@ -390,7 +396,8 @@ func TestOtlpToFromInternalHistogramPointsMutating(t *testing.T) {
 	assert.EqualValues(t, startTime+1, histogramDataPoints.At(0).StartTime())
 	histogramDataPoints.At(0).SetTimestamp(TimestampUnixNano(endTime + 1))
 	assert.EqualValues(t, endTime+1, histogramDataPoints.At(0).Timestamp())
-	histogramDataPoints.At(0).SetLabelsMap(newLabels)
+	histogramDataPoints.At(0).LabelsMap().Delete("key0")
+	histogramDataPoints.At(0).LabelsMap().Upsert("k", "v")
 	assert.EqualValues(t, newLabels, histogramDataPoints.At(0).LabelsMap())
 	histogramDataPoints.At(0).SetExplicitBounds([]float64{1})
 	assert.EqualValues(t, []float64{1}, histogramDataPoints.At(0).ExplicitBounds())
@@ -406,7 +413,8 @@ func TestOtlpToFromInternalHistogramPointsMutating(t *testing.T) {
 	assert.EqualValues(t, startTime+1, buckets.At(1).Exemplar().Timestamp())
 	buckets.At(1).Exemplar().SetValue(10.5)
 	assert.EqualValues(t, 10.5, buckets.At(1).Exemplar().Value())
-	buckets.At(1).Exemplar().SetAttachments(newLabels)
+	buckets.At(1).Exemplar().Attachments().Delete("key_a1")
+	buckets.At(1).Exemplar().Attachments().Upsert("k", "v")
 	assert.EqualValues(t, newLabels, buckets.At(1).Exemplar().Attachments())
 
 	// Test that everything is updated.
@@ -470,7 +478,7 @@ func TestOtlpToFromInternalHistogramPointsMutating(t *testing.T) {
 }
 
 func TestOtlpToFromInternalSummaryPointsMutating(t *testing.T) {
-	newLabels := NewStringMap(map[string]string{"k": "v"})
+	newLabels := NewStringMap().InitFromMap(map[string]string{"k": "v"})
 	metricData := MetricDataFromOtlp([]*otlpmetrics.ResourceMetrics{
 		{
 			Resource: generateTestProtoResource(),
@@ -491,7 +499,7 @@ func TestOtlpToFromInternalSummaryPointsMutating(t *testing.T) {
 	assert.EqualValues(t, "My new metric", metric.MetricDescriptor().Description())
 	metric.MetricDescriptor().SetUnit("1")
 	assert.EqualValues(t, "1", metric.MetricDescriptor().Unit())
-	metric.MetricDescriptor().SetLabelsMap(newLabels)
+	metric.MetricDescriptor().LabelsMap().Insert("k", "v")
 	assert.EqualValues(t, newLabels, metric.MetricDescriptor().LabelsMap())
 	// Mutate DataPoints
 	assert.EqualValues(t, 2, metric.SummaryDataPoints().Len())
@@ -502,7 +510,8 @@ func TestOtlpToFromInternalSummaryPointsMutating(t *testing.T) {
 	assert.EqualValues(t, startTime+1, summaryDataPoints.At(0).StartTime())
 	summaryDataPoints.At(0).SetTimestamp(TimestampUnixNano(endTime + 1))
 	assert.EqualValues(t, endTime+1, summaryDataPoints.At(0).Timestamp())
-	summaryDataPoints.At(0).SetLabelsMap(newLabels)
+	summaryDataPoints.At(0).LabelsMap().Delete("key0")
+	summaryDataPoints.At(0).LabelsMap().Upsert("k", "v")
 	assert.EqualValues(t, newLabels, summaryDataPoints.At(0).LabelsMap())
 	// Mutate ValueAtPercentiles
 	assert.EqualValues(t, 2, summaryDataPoints.At(0).ValueAtPercentiles().Len())

--- a/internal/data/testdata/common.go
+++ b/internal/data/testdata/common.go
@@ -28,8 +28,8 @@ var (
 	spanAttributes      = map[string]data.AttributeValue{"span-attr": data.NewAttributeValueString("span-attr-val")}
 )
 
-func generateResourceAttributes1() data.AttributeMap {
-	return data.NewAttributeMap(resourceAttributes1)
+func initResourceAttributes1(dest data.AttributeMap) {
+	dest.InitFromMap(resourceAttributes1)
 }
 
 func generateOtlpResourceAttributes1() []*otlpcommon.AttributeKeyValue {
@@ -41,8 +41,8 @@ func generateOtlpResourceAttributes1() []*otlpcommon.AttributeKeyValue {
 	}
 }
 
-func generateResourceAttributes2() data.AttributeMap {
-	return data.NewAttributeMap(resourceAttributes2)
+func initResourceAttributes2(dest data.AttributeMap) {
+	dest.InitFromMap(resourceAttributes2)
 }
 
 func generateOtlpResourceAttributes2() []*otlpcommon.AttributeKeyValue {
@@ -54,8 +54,8 @@ func generateOtlpResourceAttributes2() []*otlpcommon.AttributeKeyValue {
 	}
 }
 
-func generateSpanAttributes() data.AttributeMap {
-	return data.NewAttributeMap(spanAttributes)
+func initSpanAttributes(dest data.AttributeMap) {
+	dest.InitFromMap(spanAttributes)
 }
 
 func generateOtlpSpanAttributes() []*otlpcommon.AttributeKeyValue {
@@ -67,8 +67,8 @@ func generateOtlpSpanAttributes() []*otlpcommon.AttributeKeyValue {
 	}
 }
 
-func generateSpanEventAttributes() data.AttributeMap {
-	return data.NewAttributeMap(spanEventAttributes)
+func initSpanEventAttributes(dest data.AttributeMap) {
+	dest.InitFromMap(spanEventAttributes)
 }
 
 func generateOtlpSpanEventAttributes() []*otlpcommon.AttributeKeyValue {
@@ -80,8 +80,8 @@ func generateOtlpSpanEventAttributes() []*otlpcommon.AttributeKeyValue {
 	}
 }
 
-func generateSpanLinkAttributes() data.AttributeMap {
-	return data.NewAttributeMap(spanLinkAttributes)
+func initSpanLinkAttributes(dest data.AttributeMap) {
+	dest.InitFromMap(spanLinkAttributes)
 }
 
 func generateOtlpSpanLinkAttributes() []*otlpcommon.AttributeKeyValue {

--- a/internal/data/testdata/metric.go
+++ b/internal/data/testdata/metric.go
@@ -135,12 +135,12 @@ func initCounterIntMetric(im data.Metric) {
 	idps := im.Int64DataPoints()
 	idps.Resize(2)
 	idp0 := idps.At(0)
-	idp0.SetLabelsMap(data.NewStringMap(map[string]string{"int-label-1": "int-label-value-1"}))
+	idp0.LabelsMap().InitFromMap(map[string]string{"int-label-1": "int-label-value-1"})
 	idp0.SetStartTime(TestMetricStartTimestamp)
 	idp0.SetTimestamp(TestMetricTimestamp)
 	idp0.SetValue(123)
 	idp1 := idps.At(1)
-	idp1.SetLabelsMap(data.NewStringMap(map[string]string{"int-label-2": "int-label-value-2"}))
+	idp1.LabelsMap().InitFromMap(map[string]string{"int-label-2": "int-label-value-2"})
 	idp1.SetStartTime(TestMetricStartTimestamp)
 	idp1.SetTimestamp(TestMetricTimestamp)
 	idp1.SetValue(456)
@@ -163,18 +163,18 @@ func initCumulativeHistogramMetric(hm data.Metric) {
 	hdps := hm.HistogramDataPoints()
 	hdps.Resize(2)
 	hdp0 := hdps.At(0)
-	hdp0.SetLabelsMap(data.NewStringMap(map[string]string{
+	hdp0.LabelsMap().InitFromMap(map[string]string{
 		"histogram-label-1": "histogram-label-value-1",
 		"histogram-label-3": "histogram-label-value-3",
-	}))
+	})
 	hdp0.SetStartTime(TestMetricStartTimestamp)
 	hdp0.SetTimestamp(TestMetricTimestamp)
 	hdp0.SetCount(1)
 	hdp0.SetSum(15)
 	hdp1 := hdps.At(1)
-	hdp1.SetLabelsMap(data.NewStringMap(map[string]string{
+	hdp1.LabelsMap().InitFromMap(map[string]string{
 		"histogram-label-2": "histogram-label-value-2",
-	}))
+	})
 	hdp1.SetStartTime(TestMetricStartTimestamp)
 	hdp1.SetTimestamp(TestMetricTimestamp)
 	hdp1.SetCount(1)
@@ -185,9 +185,9 @@ func initCumulativeHistogramMetric(hm data.Metric) {
 	hdp1.Buckets().At(1).Exemplar().InitEmpty()
 	hdp1.Buckets().At(1).Exemplar().SetTimestamp(TestMetricExemplarTimestamp)
 	hdp1.Buckets().At(1).Exemplar().SetValue(15)
-	hdp1.Buckets().At(1).Exemplar().SetAttachments(data.NewStringMap(map[string]string{
+	hdp1.Buckets().At(1).Exemplar().Attachments().InitFromMap(map[string]string{
 		"exemplar-attachment": "exemplar-attachment-value",
-	}))
+	})
 	hdp1.SetExplicitBounds([]float64{1})
 }
 
@@ -197,17 +197,17 @@ func initSummaryMetric(sm data.Metric) {
 	sdps := sm.SummaryDataPoints()
 	sdps.Resize(2)
 	sdp0 := sdps.At(0)
-	sdp0.SetLabelsMap(data.NewStringMap(map[string]string{
+	sdp0.LabelsMap().InitFromMap(map[string]string{
 		"summary-label": "summary-label-value-1",
-	}))
+	})
 	sdp0.SetStartTime(TestMetricStartTimestamp)
 	sdp0.SetTimestamp(TestMetricTimestamp)
 	sdp0.SetCount(1)
 	sdp0.SetSum(15)
 	sdp1 := sdps.At(1)
-	sdp1.SetLabelsMap(data.NewStringMap(map[string]string{
+	sdp1.LabelsMap().InitFromMap(map[string]string{
 		"summary-label": "summary-label-value-2",
-	}))
+	})
 	sdp1.SetStartTime(TestMetricStartTimestamp)
 	sdp1.SetTimestamp(TestMetricTimestamp)
 	sdp1.SetCount(1)

--- a/internal/data/testdata/resource.go
+++ b/internal/data/testdata/resource.go
@@ -22,7 +22,7 @@ import (
 
 func initResource1(r data.Resource) {
 	r.InitEmpty()
-	r.SetAttributes(generateResourceAttributes1())
+	initResourceAttributes1(r.Attributes())
 }
 
 func generateOtlpResource1() *otlpresource.Resource {
@@ -33,7 +33,7 @@ func generateOtlpResource1() *otlpresource.Resource {
 
 func initResource2(r data.Resource) {
 	r.InitEmpty()
-	r.SetAttributes(generateResourceAttributes2())
+	initResourceAttributes2(r.Attributes())
 }
 
 func generateOtlpResource2() *otlpresource.Resource {

--- a/internal/data/testdata/trace.go
+++ b/internal/data/testdata/trace.go
@@ -225,7 +225,7 @@ func fillSpanOne(span data.Span) {
 	ev0 := evs.At(0)
 	ev0.SetTimestamp(TestSpanEventTimestamp)
 	ev0.SetName("event-with-attr")
-	ev0.SetAttributes(generateSpanEventAttributes())
+	initSpanEventAttributes(ev0.Attributes())
 	ev0.SetDroppedAttributesCount(2)
 	ev1 := evs.At(1)
 	ev1.SetTimestamp(TestSpanEventTimestamp)
@@ -270,7 +270,7 @@ func fillSpanTwo(span data.Span) {
 	span.SetStartTime(TestSpanStartTimestamp)
 	span.SetEndTime(TestSpanEndTimestamp)
 	span.Links().Resize(2)
-	span.Links().At(0).SetAttributes(generateSpanLinkAttributes())
+	initSpanLinkAttributes(span.Links().At(0).Attributes())
 	span.Links().At(0).SetDroppedAttributesCount(4)
 	span.Links().At(1).SetDroppedAttributesCount(4)
 	span.SetDroppedLinksCount(3)
@@ -298,7 +298,7 @@ func fillSpanThree(span data.Span) {
 	span.SetName("operationC")
 	span.SetStartTime(TestSpanStartTimestamp)
 	span.SetEndTime(TestSpanEndTimestamp)
-	span.SetAttributes(generateSpanAttributes())
+	initSpanAttributes(span.Attributes())
 	span.SetDroppedAttributesCount(5)
 }
 

--- a/internal/data_generator/internal/base_fields.go
+++ b/internal/data_generator/internal/base_fields.go
@@ -31,25 +31,6 @@ const accessorsSliceTestTemplate = `	assert.EqualValues(t, New${returnType}(), m
 	testVal${fieldName} := generateTest${returnType}()
 	assert.EqualValues(t, testVal${fieldName}, ms.${fieldName}())`
 
-const accessorMapTemplate = `// ${fieldName} returns the ${originFieldName} associated with this ${structName}.
-//
-// Important: This causes a runtime error if IsNil() returns "true".
-func (ms ${structName}) ${fieldName}() ${returnType} {
-	return new${returnType}(&(*ms.orig).${originFieldName})
-}
-
-// Set${fieldName} replaces the ${originFieldName} associated with this ${structName}.
-//
-// Important: This causes a runtime error if IsNil() returns "true".
-func (ms ${structName}) Set${fieldName}(v ${returnType}) {
-	(*ms.orig).${originFieldName} = *v.orig
-}`
-
-const accessorsMapTestTemplate = `	assert.EqualValues(t, New${returnType}(${constructorDefaultValue}), ms.${fieldName}())
-	testVal${fieldName} := generateTest${returnType}()
-	ms.Set${fieldName}(testVal${fieldName})
-	assert.EqualValues(t, testVal${fieldName}, ms.${fieldName}())`
-
 const accessorsMessageTemplate = `// ${fieldName} returns the ${lowerFieldName} associated with this ${structName}.
 // If no ${lowerFieldName} available, it creates an empty message and associates it with this ${structName}.
 //
@@ -105,49 +86,6 @@ type baseField interface {
 	generateAccessorsTests(ms *messageStruct, sb *strings.Builder)
 
 	generateSetWithTestValue(sb *strings.Builder)
-}
-
-type mapField struct {
-	fieldMame               string
-	originFieldName         string
-	returnSlice             *sliceStruct
-	constructorDefaultValue string
-}
-
-func (mf *mapField) generateAccessors(ms *messageStruct, sb *strings.Builder) {
-	sb.WriteString(os.Expand(accessorMapTemplate, func(name string) string {
-		switch name {
-		case "structName":
-			return ms.structName
-		case "fieldName":
-			return mf.fieldMame
-		case "returnType":
-			return mf.returnSlice.structName
-		case "originFieldName":
-			return mf.originFieldName
-		default:
-			panic(name)
-		}
-	}))
-}
-
-func (mf *mapField) generateAccessorsTests(ms *messageStruct, sb *strings.Builder) {
-	sb.WriteString(os.Expand(accessorsMapTestTemplate, func(name string) string {
-		switch name {
-		case "fieldName":
-			return mf.fieldMame
-		case "returnType":
-			return mf.returnSlice.structName
-		case "constructorDefaultValue":
-			return mf.constructorDefaultValue
-		default:
-			panic(name)
-		}
-	}))
-}
-
-func (mf *mapField) generateSetWithTestValue(sb *strings.Builder) {
-	sb.WriteString("\ttv.Set" + mf.fieldMame + "(generateTest" + mf.returnSlice.structName + "())")
 }
 
 type sliceField struct {

--- a/internal/data_generator/internal/common_structs.go
+++ b/internal/data_generator/internal/common_structs.go
@@ -96,11 +96,10 @@ var endTimeField = &primitiveTypedField{
 	testVal:         "TimestampUnixNano(1234567890)",
 }
 
-var attributes = &mapField{
-	fieldMame:               "Attributes",
-	originFieldName:         "Attributes",
-	returnSlice:             attributeMap,
-	constructorDefaultValue: "nil",
+var attributes = &sliceField{
+	fieldMame:       "Attributes",
+	originFieldName: "Attributes",
+	returnSlice:     attributeMap,
 }
 
 var nameField = &primitiveField{

--- a/internal/data_generator/internal/metrics_structs.go
+++ b/internal/data_generator/internal/metrics_structs.go
@@ -242,11 +242,10 @@ var histogramBucketExemplar = &messageStruct{
 	fields: []baseField{
 		timeField,
 		valueFloat64Field,
-		&mapField{
-			fieldMame:               "Attachments",
-			originFieldName:         "Attachments",
-			returnSlice:             stringMap,
-			constructorDefaultValue: "nil",
+		&sliceField{
+			fieldMame:       "Attachments",
+			originFieldName: "Attachments",
+			returnSlice:     stringMap,
 		},
 	},
 }
@@ -289,11 +288,10 @@ var summaryValueAtPercentile = &messageStruct{
 	},
 }
 
-var labelsField = &mapField{
-	fieldMame:               "LabelsMap",
-	originFieldName:         "Labels",
-	returnSlice:             stringMap,
-	constructorDefaultValue: "nil",
+var labelsField = &sliceField{
+	fieldMame:       "LabelsMap",
+	originFieldName: "Labels",
+	returnSlice:     stringMap,
 }
 
 var countField = &primitiveField{

--- a/processor/fanoutconnector_test.go
+++ b/processor/fanoutconnector_test.go
@@ -171,9 +171,9 @@ func TestCreateTraceFanOutConnectorWithConvertion(t *testing.T) {
 	rs0 := rss.At(0)
 	res := rs0.Resource()
 	res.InitEmpty()
-	res.SetAttributes(data.NewAttributeMap(map[string]data.AttributeValue{
+	res.Attributes().InitFromMap(map[string]data.AttributeValue{
 		conventions.OCAttributeResourceType: data.NewAttributeValueString(resourceTypeName),
-	}))
+	})
 	rs0.InstrumentationLibrarySpans().Resize(1)
 	rs0.InstrumentationLibrarySpans().At(0).Spans().Resize(3)
 
@@ -190,7 +190,7 @@ func TestCreateTraceFanOutConnectorWithConvertion(t *testing.T) {
 	assert.Equal(t, resourceTypeName, traceConsumerOld.Traces[0].Resource.Type)
 
 	assert.Equal(t, wantSpansCount, traceConsumer.TotalSpans)
-	assert.Equal(t, data.NewAttributeMap(map[string]data.AttributeValue{
+	assert.Equal(t, data.NewAttributeMap().InitFromMap(map[string]data.AttributeValue{
 		conventions.OCAttributeResourceType: data.NewAttributeValueString(resourceTypeName),
 	}), traceConsumer.Traces[0].ResourceSpans().At(0).Resource().Attributes())
 }
@@ -211,9 +211,9 @@ func TestCreateMetricsFanOutConnectorWithConvertion(t *testing.T) {
 	rm0 := rms.At(0)
 	res := rm0.Resource()
 	res.InitEmpty()
-	res.SetAttributes(data.NewAttributeMap(map[string]data.AttributeValue{
+	res.Attributes().InitFromMap(map[string]data.AttributeValue{
 		conventions.OCAttributeResourceType: data.NewAttributeValueString(resourceTypeName),
-	}))
+	})
 	rm0.InstrumentationLibraryMetrics().Resize(1)
 	rm0.InstrumentationLibraryMetrics().At(0).Metrics().Resize(4)
 
@@ -230,7 +230,7 @@ func TestCreateMetricsFanOutConnectorWithConvertion(t *testing.T) {
 	assert.Equal(t, resourceTypeName, metricsConsumerOld.Metrics[0].Resource.Type)
 
 	assert.Equal(t, wantSpansCount, metricsConsumer.TotalMetrics)
-	assert.Equal(t, data.NewAttributeMap(map[string]data.AttributeValue{
+	assert.Equal(t, data.NewAttributeMap().InitFromMap(map[string]data.AttributeValue{
 		conventions.OCAttributeResourceType: data.NewAttributeValueString(resourceTypeName),
 	}), metricsConsumer.Metrics[0].ResourceMetrics().At(0).Resource().Attributes())
 }

--- a/translator/internaldata/resource_to_oc_test.go
+++ b/translator/internaldata/resource_to_oc_test.go
@@ -49,7 +49,7 @@ func TestResourceToOC(t *testing.T) {
 	}
 	resource := data.NewResource()
 	resource.InitEmpty()
-	resource.SetAttributes(data.NewAttributeMap(attrs))
+	resource.Attributes().InitFromMap(attrs)
 
 	emptyResource := data.NewResource()
 	emptyResource.InitEmpty()

--- a/translator/internaldata/traces_to_oc_test.go
+++ b/translator/internaldata/traces_to_oc_test.go
@@ -51,12 +51,12 @@ func TestInternalTraceStateToOC(t *testing.T) {
 }
 
 func TestAttributesMapToOC(t *testing.T) {
-	assert.EqualValues(t, (*octrace.Span_Attributes)(nil), attributesMapToOCSpanAttributes(data.NewAttributeMap(nil), 0))
+	assert.EqualValues(t, (*octrace.Span_Attributes)(nil), attributesMapToOCSpanAttributes(data.NewAttributeMap(), 0))
 
 	ocAttrs := &octrace.Span_Attributes{
 		DroppedAttributesCount: 123,
 	}
-	assert.EqualValues(t, ocAttrs, attributesMapToOCSpanAttributes(data.NewAttributeMap(nil), 123))
+	assert.EqualValues(t, ocAttrs, attributesMapToOCSpanAttributes(data.NewAttributeMap(), 123))
 
 	ocAttrs = &octrace.Span_Attributes{
 		AttributeMap: map[string]*octrace.AttributeValue{
@@ -68,7 +68,7 @@ func TestAttributesMapToOC(t *testing.T) {
 	}
 	assert.EqualValues(t, ocAttrs,
 		attributesMapToOCSpanAttributes(
-			data.NewAttributeMap(map[string]data.AttributeValue{
+			data.NewAttributeMap().InitFromMap(map[string]data.AttributeValue{
 				"abc": data.NewAttributeValueString("def"),
 			}),
 			234))
@@ -83,7 +83,7 @@ func TestAttributesMapToOC(t *testing.T) {
 		Value: &octrace.AttributeValue_DoubleValue{DoubleValue: 4.5},
 	}
 	assert.EqualValues(t, ocAttrs,
-		attributesMapToOCSpanAttributes(data.NewAttributeMap(
+		attributesMapToOCSpanAttributes(data.NewAttributeMap().InitFromMap(
 			map[string]data.AttributeValue{
 				"abc":       data.NewAttributeValueString("def"),
 				"intval":    data.NewAttributeValueInt(345),


### PR DESCRIPTION
The main focus for this PR is to remove all "Set" methods for maps. The current `InitFromMap` is not final but it was the easiest path forward at this moment. A bigger cleanup for maps will be done next, for the moment this allows to finalize all generated data except maps.