### PR TITLE
Validate factories on service run

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -120,11 +120,6 @@ func fileLoaderConfigFactory(v *viper.Viper, factories config.Factories) (*confi
 
 // New creates and returns a new instance of Application.
 func New(params Parameters) (*Application, error) {
-
-	if err := configcheck.ValidateConfigFromFactories(params.Factories); err != nil {
-		return nil, err
-	}
-
 	app := &Application{
 		info:      params.ApplicationStartInfo,
 		v:         config.NewViper(),
@@ -238,6 +233,10 @@ func (app *Application) runAndWaitForShutdownEvent() {
 }
 
 func (app *Application) setupConfigurationComponents(factory ConfigFactory) error {
+	if err := configcheck.ValidateConfigFromFactories(app.factories); err != nil {
+		return err
+	}
+
 	app.logger.Info("Loading configuration...")
 	cfg, err := factory(app.v, app.factories)
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Pavol Loffay <ploffay@redhat.com>

**Description:** 
Validate factories on `service.Run`. `factory.CreateDefaultConfig` can use (default) values from viper, however viper can be initialized with flags from cobra only in `command.Run`.

We would like to use this in jaeger.

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** < Describe what testing was performed and which tests were added.>

**Documentation:** < Describe the documentation added.>