### PR TITLE
Remove Context() from component.Host interface

### DIFF
--- a/component/component.go
+++ b/component/component.go
@@ -14,8 +14,6 @@
 
 package component
 
-import "context"
-
 // Component is either a receiver, exporter, processor or extension.
 type Component interface {
 	// Start tells the component to start. Host parameter can be used for communicating
@@ -47,10 +45,6 @@ type Host interface {
 	// encountered a fatal error (i.e.: an error that the instance can't recover
 	// from) after its start function had already returned.
 	ReportFatalError(err error)
-
-	// Context returns a context provided by the host to be used on the component
-	// operations.
-	Context() context.Context
 
 	// GetFactory of the specified kind. Returns the factory for a component type.
 	// This allows components to create other components. For example:

--- a/component/mock_host.go
+++ b/component/mock_host.go
@@ -16,21 +16,11 @@
 // implementing the receiver package interfaces.
 package component
 
-import (
-	"context"
-)
-
 // MockHost mocks a receiver.ReceiverHost for test purposes.
 type MockHost struct {
 }
 
 var _ Host = (*MockHost)(nil)
-
-// Context returns a context provided by the host to be used on the receiver
-// operations.
-func (mh *MockHost) Context() context.Context {
-	return context.Background()
-}
 
 // ReportFatalError is used to report to the host that the receiver encountered
 // a fatal error (i.e.: an error that the instance can't recover from) after

--- a/component/mock_host_test.go
+++ b/component/mock_host_test.go
@@ -26,9 +26,6 @@ func TestNewMockHost(t *testing.T) {
 	if got == nil {
 		t.Fatal("NewMockHost() = nil, want non-nil", got)
 	}
-	if ctx := got.Context(); ctx == nil {
-		t.Fatalf("Context() = nil, want non-nil")
-	}
 	_, ok := got.(*MockHost)
 	if !ok {
 		t.Fatal("got.(*MockHost) failed")

--- a/extension/extensiontest/mock_host.go
+++ b/extension/extensiontest/mock_host.go
@@ -15,7 +15,6 @@
 package extensiontest
 
 import (
-	"context"
 	"time"
 
 	"github.com/open-telemetry/opentelemetry-collector/component"
@@ -39,12 +38,6 @@ func NewMockHost() *MockHost {
 // its start function has already returned.
 func (mh *MockHost) ReportFatalError(err error) {
 	mh.errorChan <- err
-}
-
-// Context returns a context provided by the host to be used on the component
-// operations.
-func (mh *MockHost) Context() context.Context {
-	return context.Background()
 }
 
 // WaitForFatalError waits the given amount of time until an error is reported via

--- a/processor/queuedprocessor/queued_processor.go
+++ b/processor/queuedprocessor/queued_processor.go
@@ -71,7 +71,7 @@ func newQueuedSpanProcessor(logger *zap.Logger, sender consumer.TraceConsumerOld
 // Start is invoked during service startup.
 func (sp *queuedSpanProcessor) Start(host component.Host) error {
 	// emit 0's so that the metric is present and reported, rather than absent
-	ctx := obsreport.ProcessorContext(host.Context(), sp.name)
+	ctx := obsreport.ProcessorContext(context.Background(), sp.name)
 	stats.Record(
 		ctx,
 		processor.StatTraceBatchesDroppedCount.M(int64(0)),

--- a/receiver/prometheusreceiver/metrics_receiver.go
+++ b/receiver/prometheusreceiver/metrics_receiver.go
@@ -54,7 +54,7 @@ func newPrometheusReceiver(logger *zap.Logger, cfg *Config, next consumer.Metric
 // is controlled by having previously defined a Configuration using perhaps New.
 func (pr *Preceiver) Start(host component.Host) error {
 	pr.startOnce.Do(func() {
-		ctx := host.Context()
+		ctx := context.Background()
 		c, cancel := context.WithCancel(ctx)
 		pr.cancel = cancel
 		c = obsreport.ReceiverContext(c, pr.cfg.Name(), "http", pr.cfg.Name())

--- a/service/service.go
+++ b/service/service.go
@@ -17,7 +17,6 @@
 package service
 
 import (
-	"context"
 	"flag"
 	"fmt"
 	"os"
@@ -81,13 +80,6 @@ type ApplicationStartInfo struct {
 
 	// Git hash of the source code.
 	GitHash string
-}
-
-// Context returns a context provided by the host to be used on the receiver
-// operations.
-func (app *Application) Context() context.Context {
-	// For now simply the background context.
-	return context.Background()
 }
 
 // Parameters holds configuration for creating a new Application.

--- a/testbed/testbed/mock_backend.go
+++ b/testbed/testbed/mock_backend.go
@@ -64,10 +64,6 @@ func NewMockBackend(logFilePath string, receiver DataReceiver) *MockBackend {
 	return mb
 }
 
-func (mb *MockBackend) Context() context.Context {
-	return context.Background()
-}
-
 func (mb *MockBackend) ReportFatalError(err error) {
 	log.Printf("Fatal error reported: %v", err)
 }

--- a/testbed/testbed/receivers.go
+++ b/testbed/testbed/receivers.go
@@ -15,7 +15,6 @@
 package testbed
 
 import (
-	"context"
 	"fmt"
 	"log"
 
@@ -48,10 +47,6 @@ type DataReceiver interface {
 type DataReceiverBase struct {
 	// Port on which to listen.
 	Port int
-}
-
-func (mb *DataReceiverBase) Context() context.Context {
-	return context.Background()
 }
 
 func (mb *DataReceiverBase) ReportFatalError(err error) {


### PR DESCRIPTION
It doesn't make sense to have this method on `component.Host`. Currently, the only usages are in `Start` methods, later we can add it to `Start` if we want to support timeout or cancellation. See https://github.com/open-telemetry/opentelemetry-collector/pull/748#discussion_r402690039