### PR TITLE
Add benchmarks for resource translation

### DIFF
--- a/translator/internaldata/oc_testdata.go
+++ b/translator/internaldata/oc_testdata.go
@@ -16,6 +16,8 @@
 package internaldata
 
 import (
+	"time"
+
 	occommon "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
 	ocmetrics "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
 	ocresource "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
@@ -23,7 +25,9 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-collector/internal"
+	"github.com/open-telemetry/opentelemetry-collector/internal/data"
 	"github.com/open-telemetry/opentelemetry-collector/internal/data/testdata"
+	"github.com/open-telemetry/opentelemetry-collector/translator/conventions"
 )
 
 func generateOCTestDataNoMetrics() consumerdata.MetricsData {
@@ -444,6 +448,54 @@ func generateOCTestMetricSummary() *ocmetrics.Metric {
 					},
 				},
 			},
+		},
+	}
+}
+
+func generateResourceWithOcNodeAndResource() data.Resource {
+	resource := data.NewResource()
+	resource.InitEmpty()
+	resource.Attributes().InitFromMap(map[string]data.AttributeValue{
+		conventions.OCAttributeProcessStartTime: data.NewAttributeValueString("2020-02-11T20:26:00Z"),
+		conventions.AttributeHostHostname:       data.NewAttributeValueString("host1"),
+		conventions.OCAttributeProcessID:        data.NewAttributeValueInt(123),
+		conventions.AttributeLibraryVersion:     data.NewAttributeValueString("v2.0.1"),
+		conventions.OCAttributeExporterVersion:  data.NewAttributeValueString("v1.2.0"),
+		conventions.AttributeLibraryLanguage:    data.NewAttributeValueString("CPP"),
+		conventions.OCAttributeResourceType:     data.NewAttributeValueString("good-resource"),
+		"node-str-attr":                         data.NewAttributeValueString("node-str-attr-val"),
+		"resource-str-attr":                     data.NewAttributeValueString("resource-str-attr-val"),
+		"resource-int-attr":                     data.NewAttributeValueInt(123),
+	})
+	return resource
+}
+
+func generateOcNode() *occommon.Node {
+	ts := internal.TimeToTimestamp(time.Date(2020, 2, 11, 20, 26, 0, 0, time.UTC))
+
+	return &occommon.Node{
+		Identifier: &occommon.ProcessIdentifier{
+			HostName:       "host1",
+			Pid:            123,
+			StartTimestamp: ts,
+		},
+		LibraryInfo: &occommon.LibraryInfo{
+			Language:           occommon.LibraryInfo_CPP,
+			ExporterVersion:    "v1.2.0",
+			CoreLibraryVersion: "v2.0.1",
+		},
+		Attributes: map[string]string{
+			"node-str-attr": "node-str-attr-val",
+		},
+	}
+}
+
+func generateOcResource() *ocresource.Resource {
+	return &ocresource.Resource{
+		Type: "good-resource",
+		Labels: map[string]string{
+			"resource-str-attr": "resource-str-attr-val",
+			"resource-int-attr": "123",
 		},
 	}
 }

--- a/translator/internaldata/resource_to_oc_test.go
+++ b/translator/internaldata/resource_to_oc_test.go
@@ -16,43 +16,24 @@ package internaldata
 
 import (
 	"testing"
-	"time"
 
 	occommon "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
 	ocresource "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
-	"github.com/golang/protobuf/ptypes"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/open-telemetry/opentelemetry-collector/internal/data"
-	"github.com/open-telemetry/opentelemetry-collector/translator/conventions"
 )
 
 func TestResourceToOC(t *testing.T) {
-	ts, err := ptypes.TimestampProto(time.Date(2020, 2, 11, 20, 26, 0, 0, time.UTC))
-	assert.NoError(t, err)
-
-	ocAttributes := map[string]string{
-		"str1": "text",
-		"int2": "123",
-	}
-
-	attrs := map[string]data.AttributeValue{
-		conventions.OCAttributeProcessStartTime: data.NewAttributeValueString("2020-02-11T20:26:00Z"),
-		conventions.AttributeHostHostname:       data.NewAttributeValueString("host1"),
-		conventions.OCAttributeProcessID:        data.NewAttributeValueString("123"),
-		conventions.AttributeLibraryVersion:     data.NewAttributeValueString("v2.0.1"),
-		conventions.OCAttributeExporterVersion:  data.NewAttributeValueString("v1.2.0"),
-		conventions.AttributeLibraryLanguage:    data.NewAttributeValueString("CPP"),
-		conventions.OCAttributeResourceType:     data.NewAttributeValueString("good-resource"),
-		"str1":                                  data.NewAttributeValueString("text"),
-		"int2":                                  data.NewAttributeValueInt(123),
-	}
-	resource := data.NewResource()
-	resource.InitEmpty()
-	resource.Attributes().InitFromMap(attrs)
-
 	emptyResource := data.NewResource()
 	emptyResource.InitEmpty()
+
+	ocNode := generateOcNode()
+	ocResource := generateOcResource()
+	// We don't differentiate between Node.Attributes and Resource when converting,
+	// and put everything in Resource.
+	ocResource.Labels["node-str-attr"] = "node-str-attr-val"
+	ocNode.Attributes = nil
 
 	tests := []struct {
 		name       string
@@ -75,24 +56,10 @@ func TestResourceToOC(t *testing.T) {
 		},
 
 		{
-			name:     "with-attributes",
-			resource: resource,
-			ocNode: &occommon.Node{
-				Identifier: &occommon.ProcessIdentifier{
-					HostName:       "host1",
-					Pid:            123,
-					StartTimestamp: ts,
-				},
-				LibraryInfo: &occommon.LibraryInfo{
-					Language:           occommon.LibraryInfo_CPP,
-					ExporterVersion:    "v1.2.0",
-					CoreLibraryVersion: "v2.0.1",
-				},
-			},
-			ocResource: &ocresource.Resource{
-				Type:   "good-resource",
-				Labels: ocAttributes,
-			},
+			name:       "with-attributes",
+			resource:   generateResourceWithOcNodeAndResource(),
+			ocNode:     ocNode,
+			ocResource: ocResource,
 		},
 	}
 
@@ -102,5 +69,17 @@ func TestResourceToOC(t *testing.T) {
 			assert.EqualValues(t, test.ocNode, ocNode)
 			assert.EqualValues(t, test.ocResource, ocResource)
 		})
+	}
+}
+
+func BenchmarkInternalResourceToOC(b *testing.B) {
+	resource := generateResourceWithOcNodeAndResource()
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		ocNode, _ := internalResourceToOC(resource)
+		if ocNode.Identifier.Pid != 123 {
+			b.Fail()
+		}
 	}
 }


### PR DESCRIPTION
```
go test -benchmem -run=^$ github.com/open-telemetry/opentelemetry-collector/translator/internaldata -bench=.
goos: darwin
goarch: amd64
pkg: github.com/open-telemetry/opentelemetry-collector/translator/internaldata
BenchmarkMetricIntOCToInternal-16          	  529880	      1930 ns/op	    2232 B/op	      37 allocs/op
BenchmarkMetricDoubleOCToInternal-16       	  466656	      2466 ns/op	    2712 B/op	      49 allocs/op
BenchmarkMetricHistogramOCToInternal-16    	  343155	      3389 ns/op	    3672 B/op	      61 allocs/op
BenchmarkMetricSummaryOCToInternal-16      	  476601	      2307 ns/op	    2592 B/op	      43 allocs/op
BenchmarkOcNodeResourceToInternal-16       	  659343	      1837 ns/op	    2580 B/op	      15 allocs/op
BenchmarkInternalResourceToOC-16           	 1361719	       892 ns/op	     950 B/op	       9 allocs/op
PASS
ok  	github.com/open-telemetry/opentelemetry-collector/translator/internaldata	9.213s
```