### PR TITLE
Improve OcNodeResourceToInternal and add benchmarks for mashal/unmarshal

### DIFF
--- a/translator/internaldata/oc_to_metrics_test.go
+++ b/translator/internaldata/oc_to_metrics_test.go
@@ -45,7 +45,7 @@ func TestOCToMetricData(t *testing.T) {
 				Node:     &occommon.Node{},
 				Resource: &ocresource.Resource{},
 			},
-			internal: testdata.GenerateMetricDataOneEmptyResourceMetrics(),
+			internal: wrapMetricsWithEmptyResource(testdata.GenerateMetricDataOneEmptyResourceMetrics()),
 		},
 
 		{
@@ -105,6 +105,12 @@ func TestOCToMetricData(t *testing.T) {
 			assert.EqualValues(t, test.internal, got)
 		})
 	}
+}
+
+// TODO: Try to avoid unnecessary Resource object allocation.
+func wrapMetricsWithEmptyResource(md data.MetricData) data.MetricData {
+	md.ResourceMetrics().At(0).Resource().InitEmpty()
+	return md
 }
 
 func BenchmarkMetricIntOCToInternal(b *testing.B) {

--- a/translator/internaldata/oc_to_traces_test.go
+++ b/translator/internaldata/oc_to_traces_test.go
@@ -301,7 +301,7 @@ func TestOcToInternal(t *testing.T) {
 
 		{
 			name: "one-empty-resource-spans",
-			td:   testdata.GenerateTraceDataOneEmptyResourceSpans(),
+			td:   wrapTraceWithEmptyResource(testdata.GenerateTraceDataOneEmptyResourceSpans()),
 			oc:   consumerdata.TraceData{Node: ocNode},
 		},
 
@@ -313,7 +313,7 @@ func TestOcToInternal(t *testing.T) {
 
 		{
 			name: "one-span-no-resource",
-			td:   testdata.GenerateTraceDataOneSpanNoResource(),
+			td:   wrapTraceWithEmptyResource(testdata.GenerateTraceDataOneSpanNoResource()),
 			oc: consumerdata.TraceData{
 				Node:     ocNode,
 				Resource: &ocresource.Resource{},
@@ -372,4 +372,10 @@ func TestOcToInternal(t *testing.T) {
 			assert.EqualValues(t, test.td, OCToTraceData(test.oc))
 		})
 	}
+}
+
+// TODO: Try to avoid unnecessary Resource object allocation.
+func wrapTraceWithEmptyResource(td data.TraceData) data.TraceData {
+	td.ResourceSpans().At(0).Resource().InitEmpty()
+	return td
 }

--- a/translator/internaldata/resource_to_oc_test.go
+++ b/translator/internaldata/resource_to_oc_test.go
@@ -18,7 +18,9 @@ import (
 	"testing"
 
 	occommon "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
+	agenttracepb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/trace/v1"
 	ocresource "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
+	"github.com/golang/protobuf/proto"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/open-telemetry/opentelemetry-collector/internal/data"
@@ -79,6 +81,22 @@ func BenchmarkInternalResourceToOC(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		ocNode, _ := internalResourceToOC(resource)
 		if ocNode.Identifier.Pid != 123 {
+			b.Fail()
+		}
+	}
+}
+
+func BenchmarkOcResourceNodeMarshal(b *testing.B) {
+	oc := &agenttracepb.ExportTraceServiceRequest{
+		Node:     generateOcNode(),
+		Spans:    nil,
+		Resource: generateOcResource(),
+	}
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		buf := proto.Buffer{}
+		if err := buf.Marshal(oc); err != nil {
 			b.Fail()
 		}
 	}


### PR DESCRIPTION
Before:
```
go test -benchmem -run=^$ github.com/open-telemetry/opentelemetry-collector/translator/internaldata -bench=.
goos: darwin
goarch: amd64
pkg: github.com/open-telemetry/opentelemetry-collector/translator/internaldata
BenchmarkMetricIntOCToInternal-16          	  521413	      1947 ns/op	    2232 B/op	      37 allocs/op
BenchmarkMetricDoubleOCToInternal-16       	  475279	      2430 ns/op	    2712 B/op	      49 allocs/op
BenchmarkMetricHistogramOCToInternal-16    	  344828	      3263 ns/op	    3672 B/op	      61 allocs/op
BenchmarkMetricSummaryOCToInternal-16      	  519634	      2270 ns/op	    2592 B/op	      43 allocs/op
BenchmarkOcNodeResourceToInternal-16       	  656428	      1823 ns/op	    2580 B/op	      15 allocs/op
BenchmarkInternalResourceToOC-16           	 1365171	       892 ns/op	     950 B/op	       9 allocs/op
```

After:
```
go test -benchmem -run=^$ github.com/open-telemetry/opentelemetry-collector/translator/internaldata -bench=.
goos: darwin
goarch: amd64
pkg: github.com/open-telemetry/opentelemetry-collector/translator/internaldata
BenchmarkMetricIntOCToInternal-16          	  563001	      1858 ns/op	    2136 B/op	      36 allocs/op
BenchmarkMetricDoubleOCToInternal-16       	  497038	      2407 ns/op	    2616 B/op	      48 allocs/op
BenchmarkMetricHistogramOCToInternal-16    	  346826	      3295 ns/op	    3576 B/op	      60 allocs/op
BenchmarkMetricSummaryOCToInternal-16      	  536635	      2228 ns/op	    2496 B/op	      42 allocs/op
BenchmarkOcNodeResourceToInternal-16       	  920998	      1293 ns/op	    1304 B/op	      17 allocs/op
BenchmarkOcResourceNodeUnmarshal-16        	  603808	      1874 ns/op	    1352 B/op	      26 allocs/op
BenchmarkInternalResourceToOC-16           	 1325178	       897 ns/op	     950 B/op	       9 allocs/op
BenchmarkOcResourceNodeMarshal-16          	  497047	      2308 ns/op	    1104 B/op	      33 allocs/op
PASS
ok  	github.com/open-telemetry/opentelemetry-collector/translator/internaldata	11.740s
```

Improvement from `1823 ns/op | 2580 B/op` to `1293 ns/op | 1304 B/op`