### PR TITLE
Rename componenterr to componenterror

### DIFF
--- a/component/componenterror/errors.go
+++ b/component/componenterror/errors.go
@@ -14,7 +14,7 @@
 
 // Package oterr provides helper functions to create and process
 // OpenTelemetry specific errors
-package componenterr
+package componenterror
 
 import (
 	"errors"

--- a/component/componenterror/errors_test.go
+++ b/component/componenterror/errors_test.go
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package componenterr_test
+package componenterror_test
 
 import (
 	"fmt"
 	"testing"
 
-	"github.com/open-telemetry/opentelemetry-collector/component/componenterr"
+	"github.com/open-telemetry/opentelemetry-collector/component/componenterror"
 )
 
 func TestCombineErrors(t *testing.T) {
@@ -43,7 +43,7 @@ func TestCombineErrors(t *testing.T) {
 	}}
 
 	for _, tc := range testCases {
-		got := componenterr.CombineErrors(tc.errors)
+		got := componenterror.CombineErrors(tc.errors)
 		if (got == nil) != tc.expectNil {
 			t.Errorf("CombineErrors(%v) == nil? Got: %t. Want: %t", tc.errors, got == nil, tc.expectNil)
 		}

--- a/config/configcheck/configcheck.go
+++ b/config/configcheck/configcheck.go
@@ -24,7 +24,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/open-telemetry/opentelemetry-collector/component/componenterr"
+	"github.com/open-telemetry/opentelemetry-collector/component/componenterror"
 	"github.com/open-telemetry/opentelemetry-collector/config"
 )
 
@@ -56,7 +56,7 @@ func ValidateConfigFromFactories(factories config.Factories) error {
 		}
 	}
 
-	return componenterr.CombineErrors(errs)
+	return componenterror.CombineErrors(errs)
 }
 
 // ValidateConfig enforces that given configuration object is following the patterns
@@ -109,7 +109,7 @@ func validateConfigDataType(t reflect.Type) error {
 		// reflect.UnsafePointer.
 	}
 
-	if err := componenterr.CombineErrors(errs); err != nil {
+	if err := componenterror.CombineErrors(errs); err != nil {
 		return fmt.Errorf(
 			"type %q from package %q has invalid config settings: %v",
 			t.Name(),

--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -17,7 +17,7 @@ package defaults
 
 import (
 	"github.com/open-telemetry/opentelemetry-collector/component"
-	"github.com/open-telemetry/opentelemetry-collector/component/componenterr"
+	"github.com/open-telemetry/opentelemetry-collector/component/componenterror"
 	"github.com/open-telemetry/opentelemetry-collector/config"
 	"github.com/open-telemetry/opentelemetry-collector/exporter/fileexporter"
 	"github.com/open-telemetry/opentelemetry-collector/exporter/jaegerexporter"
@@ -106,5 +106,5 @@ func Components() (
 		Exporters:  exporters,
 	}
 
-	return factories, componenterr.CombineErrors(errs)
+	return factories, componenterror.CombineErrors(errs)
 }

--- a/exporter/opencensusexporter/opencensus.go
+++ b/exporter/opencensusexporter/opencensus.go
@@ -25,7 +25,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector/component"
-	"github.com/open-telemetry/opentelemetry-collector/component/componenterr"
+	"github.com/open-telemetry/opentelemetry-collector/component/componenterror"
 	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-collector/exporter/exporterhelper"
@@ -145,7 +145,7 @@ func (oce *ocAgentExporter) Shutdown() error {
 	wg.Wait()
 	close(oce.exporters)
 
-	return componenterr.CombineErrors(errors)
+	return componenterror.CombineErrors(errors)
 }
 
 func (oce *ocAgentExporter) PushTraceData(ctx context.Context, td consumerdata.TraceData) (int, error) {

--- a/exporter/otlpexporter/otlp.go
+++ b/exporter/otlpexporter/otlp.go
@@ -24,7 +24,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector/component"
-	"github.com/open-telemetry/opentelemetry-collector/component/componenterr"
+	"github.com/open-telemetry/opentelemetry-collector/component/componenterror"
 	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-collector/exporter/exporterhelper"
@@ -153,7 +153,7 @@ func (oce *otlpExporter) Shutdown() error {
 	wg.Wait()
 	close(oce.exporters)
 
-	return componenterr.CombineErrors(errors)
+	return componenterror.CombineErrors(errors)
 }
 
 func (oce *otlpExporter) pushTraceData(ctx context.Context, td consumerdata.TraceData) (int, error) {

--- a/processor/attributesprocessor/attributes.go
+++ b/processor/attributesprocessor/attributes.go
@@ -20,7 +20,7 @@ import (
 	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
 
 	"github.com/open-telemetry/opentelemetry-collector/component"
-	"github.com/open-telemetry/opentelemetry-collector/component/componenterr"
+	"github.com/open-telemetry/opentelemetry-collector/component/componenterror"
 	"github.com/open-telemetry/opentelemetry-collector/consumer"
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-collector/internal/processor/span"
@@ -57,7 +57,7 @@ type attributeAction struct {
 // in order to validate the inputs.
 func newTraceProcessor(nextConsumer consumer.TraceConsumerOld, config attributesConfig) (component.TraceProcessorOld, error) {
 	if nextConsumer == nil {
-		return nil, componenterr.ErrNilNextConsumer
+		return nil, componenterror.ErrNilNextConsumer
 	}
 	ap := &attributesProcessor{
 		nextConsumer: nextConsumer,

--- a/processor/cloningfanoutconnector.go
+++ b/processor/cloningfanoutconnector.go
@@ -23,7 +23,7 @@ import (
 	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
 	"github.com/golang/protobuf/proto"
 
-	"github.com/open-telemetry/opentelemetry-collector/component/componenterr"
+	"github.com/open-telemetry/opentelemetry-collector/component/componenterror"
 	"github.com/open-telemetry/opentelemetry-collector/consumer"
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-collector/internal/data"
@@ -87,7 +87,7 @@ func (mfc metricsCloningFanOutConnectorOld) ConsumeMetricsData(ctx context.Conte
 		}
 	}
 
-	return componenterr.CombineErrors(errs)
+	return componenterror.CombineErrors(errs)
 }
 
 // NewMetricsCloningFanOutConnector wraps multiple metrics consumers in a single one.
@@ -120,7 +120,7 @@ func (mfc metricsCloningFanOutConnector) ConsumeMetrics(ctx context.Context, md 
 		}
 	}
 
-	return componenterr.CombineErrors(errs)
+	return componenterror.CombineErrors(errs)
 }
 
 // CreateTraceCloningFanOutConnector is a placeholder function for now.
@@ -176,7 +176,7 @@ func (tfc traceCloningFanOutConnectorOld) ConsumeTraceData(ctx context.Context, 
 		}
 	}
 
-	return componenterr.CombineErrors(errs)
+	return componenterror.CombineErrors(errs)
 }
 
 // NewTraceCloningFanOutConnector wraps multiple trace consumers in a single one.
@@ -209,7 +209,7 @@ func (tfc traceCloningFanOutConnector) ConsumeTrace(ctx context.Context, td data
 		}
 	}
 
-	return componenterr.CombineErrors(errs)
+	return componenterror.CombineErrors(errs)
 }
 
 func cloneTraceDataOld(td *consumerdata.TraceData) *consumerdata.TraceData {

--- a/processor/fanoutconnector.go
+++ b/processor/fanoutconnector.go
@@ -17,7 +17,7 @@ package processor
 import (
 	"context"
 
-	"github.com/open-telemetry/opentelemetry-collector/component/componenterr"
+	"github.com/open-telemetry/opentelemetry-collector/component/componenterror"
 	"github.com/open-telemetry/opentelemetry-collector/consumer"
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-collector/internal/data"
@@ -67,7 +67,7 @@ func (mfc metricsFanOutConnectorOld) ConsumeMetricsData(ctx context.Context, md 
 			errs = append(errs, err)
 		}
 	}
-	return componenterr.CombineErrors(errs)
+	return componenterror.CombineErrors(errs)
 }
 
 // NewMetricsFanOutConnector wraps multiple new type metrics consumers in a single one.
@@ -87,7 +87,7 @@ func (mfc metricsFanOutConnector) ConsumeMetrics(ctx context.Context, md data.Me
 			errs = append(errs, err)
 		}
 	}
-	return componenterr.CombineErrors(errs)
+	return componenterror.CombineErrors(errs)
 }
 
 // CreateTraceFanOutConnector wraps multiple trace consumers in a single one.
@@ -131,7 +131,7 @@ func (tfc traceFanOutConnectorOld) ConsumeTraceData(ctx context.Context, td cons
 			errs = append(errs, err)
 		}
 	}
-	return componenterr.CombineErrors(errs)
+	return componenterror.CombineErrors(errs)
 }
 
 // NewTraceFanOutConnector wraps multiple new type trace consumers in a single one.
@@ -151,5 +151,5 @@ func (tfc traceFanOutConnector) ConsumeTrace(ctx context.Context, td data.TraceD
 			errs = append(errs, err)
 		}
 	}
-	return componenterr.CombineErrors(errs)
+	return componenterror.CombineErrors(errs)
 }

--- a/processor/samplingprocessor/probabilisticsamplerprocessor/probabilisticsampler.go
+++ b/processor/samplingprocessor/probabilisticsamplerprocessor/probabilisticsampler.go
@@ -21,7 +21,7 @@ import (
 	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
 
 	"github.com/open-telemetry/opentelemetry-collector/component"
-	"github.com/open-telemetry/opentelemetry-collector/component/componenterr"
+	"github.com/open-telemetry/opentelemetry-collector/component/componenterror"
 	"github.com/open-telemetry/opentelemetry-collector/consumer"
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
 )
@@ -60,7 +60,7 @@ type tracesamplerprocessor struct {
 // configuration.
 func newTraceProcessor(nextConsumer consumer.TraceConsumerOld, cfg Config) (component.TraceProcessorOld, error) {
 	if nextConsumer == nil {
-		return nil, componenterr.ErrNilNextConsumer
+		return nil, componenterror.ErrNilNextConsumer
 	}
 
 	return &tracesamplerprocessor{

--- a/processor/samplingprocessor/tailsamplingprocessor/processor.go
+++ b/processor/samplingprocessor/tailsamplingprocessor/processor.go
@@ -28,7 +28,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector/component"
-	"github.com/open-telemetry/opentelemetry-collector/component/componenterr"
+	"github.com/open-telemetry/opentelemetry-collector/component/componenterror"
 	"github.com/open-telemetry/opentelemetry-collector/consumer"
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-collector/processor/samplingprocessor/tailsamplingprocessor/idbatcher"
@@ -74,7 +74,7 @@ const (
 // configuration.
 func newTraceProcessor(logger *zap.Logger, nextConsumer consumer.TraceConsumerOld, cfg Config) (component.TraceProcessorOld, error) {
 	if nextConsumer == nil {
-		return nil, componenterr.ErrNilNextConsumer
+		return nil, componenterror.ErrNilNextConsumer
 	}
 
 	numDecisionBatches := uint64(cfg.DecisionWait.Seconds())

--- a/processor/spanprocessor/span.go
+++ b/processor/spanprocessor/span.go
@@ -24,7 +24,7 @@ import (
 	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
 
 	"github.com/open-telemetry/opentelemetry-collector/component"
-	"github.com/open-telemetry/opentelemetry-collector/component/componenterr"
+	"github.com/open-telemetry/opentelemetry-collector/component/componenterror"
 	"github.com/open-telemetry/opentelemetry-collector/consumer"
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-collector/internal/processor/span"
@@ -51,7 +51,7 @@ type toAttributeRule struct {
 // newSpanProcessor returns the span processor.
 func newSpanProcessor(nextConsumer consumer.TraceConsumerOld, config Config) (*spanProcessor, error) {
 	if nextConsumer == nil {
-		return nil, componenterr.ErrNilNextConsumer
+		return nil, componenterror.ErrNilNextConsumer
 	}
 
 	include, err := span.NewMatcher(config.Include)

--- a/processor/spanprocessor/span_test.go
+++ b/processor/spanprocessor/span_test.go
@@ -26,7 +26,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector/component"
-	"github.com/open-telemetry/opentelemetry-collector/component/componenterr"
+	"github.com/open-telemetry/opentelemetry-collector/component/componenterror"
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-collector/exporter/exportertest"
 	"github.com/open-telemetry/opentelemetry-collector/internal/processor/span"
@@ -37,7 +37,7 @@ func TestNewTraceProcessor(t *testing.T) {
 	cfg := factory.CreateDefaultConfig()
 	oCfg := cfg.(*Config)
 	tp, err := newSpanProcessor(nil, *oCfg)
-	require.Error(t, componenterr.ErrNilNextConsumer, err)
+	require.Error(t, componenterror.ErrNilNextConsumer, err)
 	require.Nil(t, tp)
 
 	tp, err = newSpanProcessor(exportertest.NewNopTraceExporterOld(), *oCfg)

--- a/receiver/jaegerreceiver/trace_receiver.go
+++ b/receiver/jaegerreceiver/trace_receiver.go
@@ -46,7 +46,7 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-collector/client"
 	"github.com/open-telemetry/opentelemetry-collector/component"
-	"github.com/open-telemetry/opentelemetry-collector/component/componenterr"
+	"github.com/open-telemetry/opentelemetry-collector/component/componenterror"
 	"github.com/open-telemetry/opentelemetry-collector/consumer"
 	"github.com/open-telemetry/opentelemetry-collector/obsreport"
 	jaegertranslator "github.com/open-telemetry/opentelemetry-collector/translator/trace/jaeger"
@@ -196,14 +196,14 @@ func (jr *jReceiver) Start(ctx context.Context, host component.Host) error {
 	jr.mu.Lock()
 	defer jr.mu.Unlock()
 
-	var err = componenterr.ErrAlreadyStarted
+	var err = componenterror.ErrAlreadyStarted
 	jr.startOnce.Do(func() {
-		if err = jr.startAgent(host); err != nil && err != componenterr.ErrAlreadyStarted {
+		if err = jr.startAgent(host); err != nil && err != componenterror.ErrAlreadyStarted {
 			jr.stopTraceReceptionLocked()
 			return
 		}
 
-		if err = jr.startCollector(host); err != nil && err != componenterr.ErrAlreadyStarted {
+		if err = jr.startCollector(host); err != nil && err != componenterror.ErrAlreadyStarted {
 			jr.stopTraceReceptionLocked()
 			return
 		}
@@ -221,7 +221,7 @@ func (jr *jReceiver) Shutdown(context.Context) error {
 }
 
 func (jr *jReceiver) stopTraceReceptionLocked() error {
-	var err = componenterr.ErrAlreadyStopped
+	var err = componenterror.ErrAlreadyStopped
 	jr.stopOnce.Do(func() {
 		var errs []error
 

--- a/receiver/opencensusreceiver/ocmetrics/opencensus.go
+++ b/receiver/opencensusreceiver/ocmetrics/opencensus.go
@@ -23,7 +23,7 @@ import (
 	agentmetricspb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/metrics/v1"
 	resourcepb "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
 
-	"github.com/open-telemetry/opentelemetry-collector/component/componenterr"
+	"github.com/open-telemetry/opentelemetry-collector/component/componenterror"
 	"github.com/open-telemetry/opentelemetry-collector/consumer"
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-collector/obsreport"
@@ -38,7 +38,7 @@ type Receiver struct {
 // New creates a new ocmetrics.Receiver reference.
 func New(instanceName string, nextConsumer consumer.MetricsConsumerOld) (*Receiver, error) {
 	if nextConsumer == nil {
-		return nil, componenterr.ErrNilNextConsumer
+		return nil, componenterror.ErrNilNextConsumer
 	}
 	ocr := &Receiver{
 		instanceName: instanceName,

--- a/receiver/opencensusreceiver/octrace/opencensus.go
+++ b/receiver/opencensusreceiver/octrace/opencensus.go
@@ -24,7 +24,7 @@ import (
 	resourcepb "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
 
 	"github.com/open-telemetry/opentelemetry-collector/client"
-	"github.com/open-telemetry/opentelemetry-collector/component/componenterr"
+	"github.com/open-telemetry/opentelemetry-collector/component/componenterror"
 	"github.com/open-telemetry/opentelemetry-collector/consumer"
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-collector/obsreport"
@@ -45,7 +45,7 @@ type Receiver struct {
 // New creates a new opencensus.Receiver reference.
 func New(instanceName string, nextConsumer consumer.TraceConsumerOld, opts ...Option) (*Receiver, error) {
 	if nextConsumer == nil {
-		return nil, componenterr.ErrNilNextConsumer
+		return nil, componenterror.ErrNilNextConsumer
 	}
 
 	ocr := &Receiver{

--- a/receiver/opencensusreceiver/opencensus.go
+++ b/receiver/opencensusreceiver/opencensus.go
@@ -30,7 +30,7 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/open-telemetry/opentelemetry-collector/component"
-	"github.com/open-telemetry/opentelemetry-collector/component/componenterr"
+	"github.com/open-telemetry/opentelemetry-collector/component/componenterror"
 	"github.com/open-telemetry/opentelemetry-collector/consumer"
 	"github.com/open-telemetry/opentelemetry-collector/observability"
 	"github.com/open-telemetry/opentelemetry-collector/receiver/opencensusreceiver/ocmetrics"
@@ -104,7 +104,7 @@ func (ocr *Receiver) Start(ctx context.Context, host component.Host) error {
 }
 
 func (ocr *Receiver) registerTraceConsumer() error {
-	var err = componenterr.ErrAlreadyStarted
+	var err = componenterror.ErrAlreadyStarted
 
 	ocr.startTraceReceiverOnce.Do(func() {
 		ocr.traceReceiver, err = octrace.New(
@@ -119,7 +119,7 @@ func (ocr *Receiver) registerTraceConsumer() error {
 }
 
 func (ocr *Receiver) registerMetricsConsumer() error {
-	var err = componenterr.ErrAlreadyStarted
+	var err = componenterror.ErrAlreadyStarted
 
 	ocr.startMetricsReceiverOnce.Do(func() {
 		ocr.metricsReceiver, err = ocmetrics.New(
@@ -145,7 +145,7 @@ func (ocr *Receiver) grpcServer() *grpc.Server {
 
 // Shutdown is a method to turn off receiving.
 func (ocr *Receiver) Shutdown(context.Context) error {
-	if err := ocr.stop(); err != componenterr.ErrAlreadyStopped {
+	if err := ocr.stop(); err != componenterror.ErrAlreadyStopped {
 		return err
 	}
 	return nil
@@ -156,14 +156,14 @@ func (ocr *Receiver) start(host component.Host) error {
 	hasConsumer := false
 	if ocr.traceConsumer != nil {
 		hasConsumer = true
-		if err := ocr.registerTraceConsumer(); err != nil && err != componenterr.ErrAlreadyStarted {
+		if err := ocr.registerTraceConsumer(); err != nil && err != componenterror.ErrAlreadyStarted {
 			return err
 		}
 	}
 
 	if ocr.metricsConsumer != nil {
 		hasConsumer = true
-		if err := ocr.registerMetricsConsumer(); err != nil && err != componenterr.ErrAlreadyStarted {
+		if err := ocr.registerMetricsConsumer(); err != nil && err != componenterror.ErrAlreadyStarted {
 			return err
 		}
 	}
@@ -172,7 +172,7 @@ func (ocr *Receiver) start(host component.Host) error {
 		return errors.New("cannot start receiver: no consumers were specified")
 	}
 
-	if err := ocr.startServer(host); err != nil && err != componenterr.ErrAlreadyStarted {
+	if err := ocr.startServer(host); err != nil && err != componenterror.ErrAlreadyStarted {
 		return err
 	}
 
@@ -186,7 +186,7 @@ func (ocr *Receiver) stop() error {
 	ocr.mu.Lock()
 	defer ocr.mu.Unlock()
 
-	err := componenterr.ErrAlreadyStopped
+	err := componenterror.ErrAlreadyStopped
 	ocr.stopOnce.Do(func() {
 		err = nil
 
@@ -225,7 +225,7 @@ func (ocr *Receiver) httpServer() *http.Server {
 }
 
 func (ocr *Receiver) startServer(host component.Host) error {
-	err := componenterr.ErrAlreadyStarted
+	err := componenterror.ErrAlreadyStarted
 	ocr.startServerOnce.Do(func() {
 		err = nil
 		// Register the grpc-gateway on the HTTP server mux

--- a/receiver/otlpreceiver/metrics/otlp.go
+++ b/receiver/otlpreceiver/metrics/otlp.go
@@ -19,7 +19,7 @@ import (
 
 	collectormetrics "github.com/open-telemetry/opentelemetry-proto/gen/go/collector/metrics/v1"
 
-	"github.com/open-telemetry/opentelemetry-collector/component/componenterr"
+	"github.com/open-telemetry/opentelemetry-collector/component/componenterror"
 	"github.com/open-telemetry/opentelemetry-collector/consumer"
 	"github.com/open-telemetry/opentelemetry-collector/internal/data"
 	"github.com/open-telemetry/opentelemetry-collector/obsreport"
@@ -38,7 +38,7 @@ type Receiver struct {
 // New creates a new Receiver reference.
 func New(instanceName string, nextConsumer consumer.MetricsConsumer) (*Receiver, error) {
 	if nextConsumer == nil {
-		return nil, componenterr.ErrNilNextConsumer
+		return nil, componenterror.ErrNilNextConsumer
 	}
 	r := &Receiver{
 		instanceName: instanceName,

--- a/receiver/otlpreceiver/otlp.go
+++ b/receiver/otlpreceiver/otlp.go
@@ -30,7 +30,7 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/open-telemetry/opentelemetry-collector/component"
-	"github.com/open-telemetry/opentelemetry-collector/component/componenterr"
+	"github.com/open-telemetry/opentelemetry-collector/component/componenterror"
 	"github.com/open-telemetry/opentelemetry-collector/consumer"
 	"github.com/open-telemetry/opentelemetry-collector/observability"
 	"github.com/open-telemetry/opentelemetry-collector/receiver/otlpreceiver/metrics"
@@ -101,7 +101,7 @@ func (r *Receiver) Start(ctx context.Context, host component.Host) error {
 }
 
 func (r *Receiver) registerTraceConsumer() error {
-	var err = componenterr.ErrAlreadyStarted
+	var err = componenterror.ErrAlreadyStarted
 
 	r.startTraceReceiverOnce.Do(func() {
 		r.traceReceiver, err = trace.New(r.instanceName, r.traceConsumer)
@@ -116,7 +116,7 @@ func (r *Receiver) registerTraceConsumer() error {
 }
 
 func (r *Receiver) registerMetricsConsumer() error {
-	var err = componenterr.ErrAlreadyStarted
+	var err = componenterror.ErrAlreadyStarted
 
 	r.startMetricsReceiverOnce.Do(func() {
 		r.metricsReceiver, err = metrics.New(r.instanceName, r.metricsConsumer)
@@ -143,7 +143,7 @@ func (r *Receiver) grpcServer() *grpc.Server {
 
 // Shutdown is a method to turn off receiving.
 func (r *Receiver) Shutdown(context.Context) error {
-	if err := r.stop(); err != componenterr.ErrAlreadyStopped {
+	if err := r.stop(); err != componenterror.ErrAlreadyStopped {
 		return err
 	}
 	return nil
@@ -154,14 +154,14 @@ func (r *Receiver) start(host component.Host) error {
 	hasConsumer := false
 	if r.traceConsumer != nil {
 		hasConsumer = true
-		if err := r.registerTraceConsumer(); err != nil && err != componenterr.ErrAlreadyStarted {
+		if err := r.registerTraceConsumer(); err != nil && err != componenterror.ErrAlreadyStarted {
 			return err
 		}
 	}
 
 	if r.metricsConsumer != nil {
 		hasConsumer = true
-		if err := r.registerMetricsConsumer(); err != nil && err != componenterr.ErrAlreadyStarted {
+		if err := r.registerMetricsConsumer(); err != nil && err != componenterror.ErrAlreadyStarted {
 			return err
 		}
 	}
@@ -170,7 +170,7 @@ func (r *Receiver) start(host component.Host) error {
 		return errors.New("cannot start receiver: no consumers were specified")
 	}
 
-	if err := r.startServer(host); err != nil && err != componenterr.ErrAlreadyStarted {
+	if err := r.startServer(host); err != nil && err != componenterror.ErrAlreadyStarted {
 		return err
 	}
 
@@ -184,7 +184,7 @@ func (r *Receiver) stop() error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	var err = componenterr.ErrAlreadyStopped
+	var err = componenterror.ErrAlreadyStopped
 	r.stopOnce.Do(func() {
 		err = nil
 
@@ -219,7 +219,7 @@ func (r *Receiver) httpServer() *http.Server {
 }
 
 func (r *Receiver) startServer(host component.Host) error {
-	err := componenterr.ErrAlreadyStarted
+	err := componenterror.ErrAlreadyStarted
 	r.startServerOnce.Do(func() {
 		err = nil
 		// Register the grpc-gateway on the HTTP server mux

--- a/receiver/otlpreceiver/trace/otlp.go
+++ b/receiver/otlpreceiver/trace/otlp.go
@@ -20,7 +20,7 @@ import (
 	collectortrace "github.com/open-telemetry/opentelemetry-proto/gen/go/collector/trace/v1"
 
 	"github.com/open-telemetry/opentelemetry-collector/client"
-	"github.com/open-telemetry/opentelemetry-collector/component/componenterr"
+	"github.com/open-telemetry/opentelemetry-collector/component/componenterror"
 	"github.com/open-telemetry/opentelemetry-collector/consumer"
 	"github.com/open-telemetry/opentelemetry-collector/internal/data"
 	"github.com/open-telemetry/opentelemetry-collector/obsreport"
@@ -39,7 +39,7 @@ type Receiver struct {
 // New creates a new Receiver reference.
 func New(instanceName string, nextConsumer consumer.TraceConsumer) (*Receiver, error) {
 	if nextConsumer == nil {
-		return nil, componenterr.ErrNilNextConsumer
+		return nil, componenterror.ErrNilNextConsumer
 	}
 
 	r := &Receiver{

--- a/receiver/prometheusreceiver/internal/ocastore.go
+++ b/receiver/prometheusreceiver/internal/ocastore.go
@@ -26,7 +26,7 @@ import (
 	"github.com/prometheus/prometheus/storage"
 	"go.uber.org/zap"
 
-	"github.com/open-telemetry/opentelemetry-collector/component/componenterr"
+	"github.com/open-telemetry/opentelemetry-collector/component/componenterror"
 	"github.com/open-telemetry/opentelemetry-collector/consumer"
 )
 
@@ -101,15 +101,15 @@ func (o *ocaStore) Close() error {
 type noopAppender struct{}
 
 func (*noopAppender) Add(l labels.Labels, t int64, v float64) (uint64, error) {
-	return 0, componenterr.ErrAlreadyStopped
+	return 0, componenterror.ErrAlreadyStopped
 }
 
 func (*noopAppender) AddFast(l labels.Labels, ref uint64, t int64, v float64) error {
-	return componenterr.ErrAlreadyStopped
+	return componenterror.ErrAlreadyStopped
 }
 
 func (*noopAppender) Commit() error {
-	return componenterr.ErrAlreadyStopped
+	return componenterror.ErrAlreadyStopped
 }
 
 func (*noopAppender) Rollback() error {

--- a/receiver/vmmetricsreceiver/metrics_receiver.go
+++ b/receiver/vmmetricsreceiver/metrics_receiver.go
@@ -19,7 +19,7 @@ import (
 	"sync"
 
 	"github.com/open-telemetry/opentelemetry-collector/component"
-	"github.com/open-telemetry/opentelemetry-collector/component/componenterr"
+	"github.com/open-telemetry/opentelemetry-collector/component/componenterror"
 )
 
 // Receiver is the type used to handle metrics from VM metrics.
@@ -37,7 +37,7 @@ func (vmr *Receiver) Start(ctx context.Context, host component.Host) error {
 	vmr.mu.Lock()
 	defer vmr.mu.Unlock()
 
-	var err = componenterr.ErrAlreadyStarted
+	var err = componenterror.ErrAlreadyStarted
 	vmr.startOnce.Do(func() {
 		vmr.vmc.StartCollection()
 		err = nil
@@ -50,7 +50,7 @@ func (vmr *Receiver) Shutdown(context.Context) error {
 	vmr.mu.Lock()
 	defer vmr.mu.Unlock()
 
-	var err = componenterr.ErrAlreadyStopped
+	var err = componenterror.ErrAlreadyStopped
 	vmr.stopOnce.Do(func() {
 		vmr.vmc.StopCollection()
 		err = nil

--- a/receiver/vmmetricsreceiver/vm_metrics_collector.go
+++ b/receiver/vmmetricsreceiver/vm_metrics_collector.go
@@ -28,7 +28,7 @@ import (
 	"github.com/prometheus/procfs"
 	"go.opencensus.io/trace"
 
-	"github.com/open-telemetry/opentelemetry-collector/component/componenterr"
+	"github.com/open-telemetry/opentelemetry-collector/component/componenterror"
 	"github.com/open-telemetry/opentelemetry-collector/consumer"
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-collector/internal"
@@ -212,7 +212,7 @@ func (vmc *VMMetricsCollector) scrapeAndExport() {
 	}
 
 	if len(errs) > 0 {
-		span.SetStatus(trace.Status{Code: trace.StatusCodeDataLoss, Message: fmt.Sprintf("Error(s) when scraping VM metrics: %v", componenterr.CombineErrors(errs))})
+		span.SetStatus(trace.Status{Code: trace.StatusCodeDataLoss, Message: fmt.Sprintf("Error(s) when scraping VM metrics: %v", componenterror.CombineErrors(errs))})
 	}
 
 	if len(metrics) > 0 {

--- a/receiver/zipkinreceiver/trace_receiver.go
+++ b/receiver/zipkinreceiver/trace_receiver.go
@@ -39,7 +39,7 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-collector/client"
 	"github.com/open-telemetry/opentelemetry-collector/component"
-	"github.com/open-telemetry/opentelemetry-collector/component/componenterr"
+	"github.com/open-telemetry/opentelemetry-collector/component/componenterror"
 	"github.com/open-telemetry/opentelemetry-collector/consumer"
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-collector/internal"
@@ -75,7 +75,7 @@ var _ http.Handler = (*ZipkinReceiver)(nil)
 // New creates a new zipkinreceiver.ZipkinReceiver reference.
 func New(instanceName, address string, nextConsumer consumer.TraceConsumerOld) (*ZipkinReceiver, error) {
 	if nextConsumer == nil {
-		return nil, componenterr.ErrNilNextConsumer
+		return nil, componenterror.ErrNilNextConsumer
 	}
 
 	zr := &ZipkinReceiver{
@@ -113,7 +113,7 @@ func (zr *ZipkinReceiver) Start(ctx context.Context, host component.Host) error 
 	zr.mu.Lock()
 	defer zr.mu.Unlock()
 
-	var err = componenterr.ErrAlreadyStarted
+	var err = componenterror.ErrAlreadyStarted
 
 	zr.startOnce.Do(func() {
 		ln, lerr := net.Listen("tcp", zr.address())
@@ -245,7 +245,7 @@ func (zr *ZipkinReceiver) deserializeFromJSON(jsonBlob []byte, debugWasSet bool)
 // giving it a chance to perform any necessary clean-up and shutting down
 // its HTTP server.
 func (zr *ZipkinReceiver) Shutdown(context.Context) error {
-	var err = componenterr.ErrAlreadyStopped
+	var err = componenterror.ErrAlreadyStopped
 	zr.stopOnce.Do(func() {
 		err = zr.server.Close()
 	})

--- a/receiver/zipkinreceiver/trace_receiver_test.go
+++ b/receiver/zipkinreceiver/trace_receiver_test.go
@@ -34,7 +34,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector/component"
-	"github.com/open-telemetry/opentelemetry-collector/component/componenterr"
+	"github.com/open-telemetry/opentelemetry-collector/component/componenterror"
 	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
 	"github.com/open-telemetry/opentelemetry-collector/consumer"
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
@@ -118,7 +118,7 @@ func TestNew(t *testing.T) {
 		{
 			name:    "nil nextConsumer",
 			args:    args{},
-			wantErr: componenterr.ErrNilNextConsumer,
+			wantErr: componenterror.ErrNilNextConsumer,
 		},
 		{
 			name: "happy path",

--- a/service/builder/exporters_builder.go
+++ b/service/builder/exporters_builder.go
@@ -21,7 +21,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector/component"
-	"github.com/open-telemetry/opentelemetry-collector/component/componenterr"
+	"github.com/open-telemetry/opentelemetry-collector/component/componenterror"
 	"github.com/open-telemetry/opentelemetry-collector/config/configerror"
 	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
 )
@@ -50,7 +50,7 @@ func (exp *builtExporter) Start(ctx context.Context, host component.Host) error 
 		}
 	}
 
-	return componenterr.CombineErrors(errors)
+	return componenterror.CombineErrors(errors)
 }
 
 // Shutdown the trace component and the metrics component of an exporter.
@@ -68,7 +68,7 @@ func (exp *builtExporter) Shutdown(context.Context) error {
 		}
 	}
 
-	return componenterr.CombineErrors(errors)
+	return componenterror.CombineErrors(errors)
 }
 
 // Exporters is a map of exporters created from exporter configs.
@@ -98,7 +98,7 @@ func (exps Exporters) ShutdownAll() error {
 	}
 
 	if len(errs) != 0 {
-		return componenterr.CombineErrors(errs)
+		return componenterror.CombineErrors(errs)
 	}
 	return nil
 }

--- a/service/builder/pipelines_builder.go
+++ b/service/builder/pipelines_builder.go
@@ -22,7 +22,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector/component"
-	"github.com/open-telemetry/opentelemetry-collector/component/componenterr"
+	"github.com/open-telemetry/opentelemetry-collector/component/componenterror"
 	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
 	"github.com/open-telemetry/opentelemetry-collector/consumer"
 	"github.com/open-telemetry/opentelemetry-collector/processor"
@@ -75,7 +75,7 @@ func (bps BuiltPipelines) ShutdownProcessors(logger *zap.Logger) error {
 	}
 
 	if len(errs) != 0 {
-		return componenterr.CombineErrors(errs)
+		return componenterror.CombineErrors(errs)
 	}
 	return nil
 }

--- a/service/builder/receivers_builder.go
+++ b/service/builder/receivers_builder.go
@@ -22,7 +22,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector/component"
-	"github.com/open-telemetry/opentelemetry-collector/component/componenterr"
+	"github.com/open-telemetry/opentelemetry-collector/component/componenterror"
 	"github.com/open-telemetry/opentelemetry-collector/config/configerror"
 	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
 	"github.com/open-telemetry/opentelemetry-collector/consumer"
@@ -61,7 +61,7 @@ func (rcvs Receivers) StopAll() error {
 	}
 
 	if len(errs) != 0 {
-		return componenterr.CombineErrors(errs)
+		return componenterror.CombineErrors(errs)
 	}
 	return nil
 }

--- a/service/service.go
+++ b/service/service.go
@@ -31,7 +31,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector/component"
-	"github.com/open-telemetry/opentelemetry-collector/component/componenterr"
+	"github.com/open-telemetry/opentelemetry-collector/component/componenterror"
 	"github.com/open-telemetry/opentelemetry-collector/config"
 	"github.com/open-telemetry/opentelemetry-collector/config/configcheck"
 	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
@@ -363,7 +363,7 @@ func (app *Application) notifyPipelineNotReady() error {
 	}
 
 	if len(errs) != 0 {
-		return componenterr.CombineErrors(errs)
+		return componenterror.CombineErrors(errs)
 	}
 
 	return nil
@@ -395,7 +395,7 @@ func (app *Application) shutdownPipelines() error {
 	}
 
 	if len(errs) != 0 {
-		return componenterr.CombineErrors(errs)
+		return componenterror.CombineErrors(errs)
 	}
 
 	return nil
@@ -414,7 +414,7 @@ func (app *Application) shutdownExtensions() error {
 	}
 
 	if len(errs) != 0 {
-		return componenterr.CombineErrors(errs)
+		return componenterror.CombineErrors(errs)
 	}
 
 	return nil
@@ -478,7 +478,7 @@ func (app *Application) execute(factory ConfigFactory) error {
 	app.logger.Info("Shutdown complete.")
 
 	if len(errs) != 0 {
-		return componenterr.CombineErrors(errs)
+		return componenterror.CombineErrors(errs)
 	}
 	return nil
 }


### PR DESCRIPTION
For consistency with `configerror` and `consumererror`

Question: Should `CombineErrors` be part of the `consumererror`?