### PR TITLE
Fix metric/spans count, add tests for nil entries in the slices

### DIFF
--- a/internal/data/metric.go
+++ b/internal/data/metric.go
@@ -74,9 +74,17 @@ func (md MetricData) MetricCount() int {
 	metricCount := 0
 	rms := md.ResourceMetrics()
 	for i := 0; i < rms.Len(); i++ {
-		ils := rms.At(i).InstrumentationLibraryMetrics()
-		for j := 0; j < ils.Len(); j++ {
-			metricCount += ils.At(j).Metrics().Len()
+		rm := rms.At(i)
+		if rm.IsNil() {
+			continue
+		}
+		ilms := rm.InstrumentationLibraryMetrics()
+		for j := 0; j < ilms.Len(); j++ {
+			ilm := ilms.At(j)
+			if ilm.IsNil() {
+				continue
+			}
+			metricCount += ilm.Metrics().Len()
 		}
 	}
 	return metricCount
@@ -104,12 +112,12 @@ func (md MetricData) MetricAndDataPointCount() (metricCount int, dataPointCount 
 type MetricType otlpmetrics.MetricDescriptor_Type
 
 const (
-	MetricTypeUnspecified         MetricType = MetricType(otlpmetrics.MetricDescriptor_UNSPECIFIED)
-	MetricTypeGaugeInt64          MetricType = MetricType(otlpmetrics.MetricDescriptor_GAUGE_INT64)
-	MetricTypeGaugeDouble         MetricType = MetricType(otlpmetrics.MetricDescriptor_GAUGE_DOUBLE)
-	MetricTypeGaugeHistogram      MetricType = MetricType(otlpmetrics.MetricDescriptor_GAUGE_HISTOGRAM)
-	MetricTypeCounterInt64        MetricType = MetricType(otlpmetrics.MetricDescriptor_COUNTER_INT64)
-	MetricTypeCounterDouble       MetricType = MetricType(otlpmetrics.MetricDescriptor_COUNTER_DOUBLE)
-	MetricTypeCumulativeHistogram MetricType = MetricType(otlpmetrics.MetricDescriptor_CUMULATIVE_HISTOGRAM)
-	MetricTypeSummary             MetricType = MetricType(otlpmetrics.MetricDescriptor_SUMMARY)
+	MetricTypeUnspecified         = MetricType(otlpmetrics.MetricDescriptor_UNSPECIFIED)
+	MetricTypeGaugeInt64          = MetricType(otlpmetrics.MetricDescriptor_GAUGE_INT64)
+	MetricTypeGaugeDouble         = MetricType(otlpmetrics.MetricDescriptor_GAUGE_DOUBLE)
+	MetricTypeGaugeHistogram      = MetricType(otlpmetrics.MetricDescriptor_GAUGE_HISTOGRAM)
+	MetricTypeCounterInt64        = MetricType(otlpmetrics.MetricDescriptor_COUNTER_INT64)
+	MetricTypeCounterDouble       = MetricType(otlpmetrics.MetricDescriptor_COUNTER_DOUBLE)
+	MetricTypeCumulativeHistogram = MetricType(otlpmetrics.MetricDescriptor_CUMULATIVE_HISTOGRAM)
+	MetricTypeSummary             = MetricType(otlpmetrics.MetricDescriptor_SUMMARY)
 )

--- a/internal/data/metric_test.go
+++ b/internal/data/metric_test.go
@@ -51,6 +51,24 @@ func TestMetricCount(t *testing.T) {
 	assert.EqualValues(t, 6, md.MetricCount())
 }
 
+func TestMetricCountWithNils(t *testing.T) {
+	assert.EqualValues(t, 0, MetricDataFromOtlp([]*otlpmetrics.ResourceMetrics{nil, {}}).MetricCount())
+	assert.EqualValues(t, 0, MetricDataFromOtlp([]*otlpmetrics.ResourceMetrics{
+		{
+			InstrumentationLibraryMetrics: []*otlpmetrics.InstrumentationLibraryMetrics{nil, {}},
+		},
+	}).MetricCount())
+	assert.EqualValues(t, 2, MetricDataFromOtlp([]*otlpmetrics.ResourceMetrics{
+		{
+			InstrumentationLibraryMetrics: []*otlpmetrics.InstrumentationLibraryMetrics{
+				{
+					Metrics: []*otlpmetrics.Metric{nil, {}},
+				},
+			},
+		},
+	}).MetricCount())
+}
+
 func TestMetricAndDataPointCount(t *testing.T) {
 	md := NewMetricData()
 	ms, dps := md.MetricAndDataPointCount()

--- a/internal/data/testdata/common.go
+++ b/internal/data/testdata/common.go
@@ -28,6 +28,18 @@ var (
 	spanAttributes      = map[string]data.AttributeValue{"span-attr": data.NewAttributeValueString("span-attr-val")}
 )
 
+const (
+	TestLabelKey        = "label"
+	TestLabelKey1       = "label-1"
+	TestLabelValue1     = "label-value-1"
+	TestLabelKey2       = "label-2"
+	TestLabelValue2     = "label-value-2"
+	TestLabelKey3       = "label-3"
+	TestLabelValue3     = "label-value-3"
+	TestAttachmentKey   = "exemplar-attachment"
+	TestAttachmentValue = "exemplar-attachment-value"
+)
+
 func initResourceAttributes1(dest data.AttributeMap) {
 	dest.InitFromMap(resourceAttributes1)
 }
@@ -89,6 +101,118 @@ func generateOtlpSpanLinkAttributes() []*otlpcommon.AttributeKeyValue {
 		{
 			Key:         "span-link-attr",
 			StringValue: "span-link-attr-val",
+		},
+	}
+}
+
+func initMetricLabels1(dest data.StringMap) {
+	dest.InitFromMap(map[string]string{TestLabelKey1: TestLabelValue1})
+}
+
+func generateOtlpMetricLabels1() []*otlpcommon.StringKeyValue {
+	return []*otlpcommon.StringKeyValue{
+		{
+			Key:   TestLabelKey1,
+			Value: TestLabelValue1,
+		},
+	}
+}
+
+func initMetricLabelValue1(dest data.StringMap) {
+	dest.InitFromMap(map[string]string{TestLabelKey: TestLabelValue1})
+}
+
+func generateOtlpMetricLabelValue1() []*otlpcommon.StringKeyValue {
+	return []*otlpcommon.StringKeyValue{
+		{
+			Key:   TestLabelKey,
+			Value: TestLabelValue1,
+		},
+	}
+}
+
+func initMetricLabels12(dest data.StringMap) {
+	dest.InitFromMap(map[string]string{TestLabelKey1: TestLabelValue1, TestLabelKey2: TestLabelValue2}).Sort()
+}
+
+func generateOtlpMetricLabels12() []*otlpcommon.StringKeyValue {
+	return []*otlpcommon.StringKeyValue{
+		{
+			Key:   TestLabelKey1,
+			Value: TestLabelValue1,
+		},
+		{
+			Key:   TestLabelKey2,
+			Value: TestLabelValue2,
+		},
+	}
+}
+
+func initMetricLabels13(dest data.StringMap) {
+	dest.InitFromMap(map[string]string{TestLabelKey1: TestLabelValue1, TestLabelKey3: TestLabelValue3}).Sort()
+}
+
+func generateOtlpMetricLabels13() []*otlpcommon.StringKeyValue {
+	return []*otlpcommon.StringKeyValue{
+		{
+			Key:   TestLabelKey1,
+			Value: TestLabelValue1,
+		},
+		{
+			Key:   TestLabelKey3,
+			Value: TestLabelValue3,
+		},
+	}
+}
+
+func initMetricLabels2(dest data.StringMap) {
+	dest.InitFromMap(map[string]string{TestLabelKey2: TestLabelValue2})
+}
+
+func generateOtlpMetricLabels2() []*otlpcommon.StringKeyValue {
+	return []*otlpcommon.StringKeyValue{
+		{
+			Key:   TestLabelKey2,
+			Value: TestLabelValue2,
+		},
+	}
+}
+
+func initMetricLabelValue2(dest data.StringMap) {
+	dest.InitFromMap(map[string]string{TestLabelKey: TestLabelValue2})
+}
+
+func generateOtlpMetricLabelValue2() []*otlpcommon.StringKeyValue {
+	return []*otlpcommon.StringKeyValue{
+		{
+			Key:   TestLabelKey,
+			Value: TestLabelValue2,
+		},
+	}
+}
+
+func initMetricLabels3(dest data.StringMap) {
+	dest.InitFromMap(map[string]string{TestLabelKey3: TestLabelValue3})
+}
+
+func generateOtlpMetricLabels3() []*otlpcommon.StringKeyValue {
+	return []*otlpcommon.StringKeyValue{
+		{
+			Key:   TestLabelKey3,
+			Value: TestLabelValue3,
+		},
+	}
+}
+
+func initMetricAttachment(dest data.StringMap) {
+	dest.InitFromMap(map[string]string{TestAttachmentKey: TestAttachmentValue})
+}
+
+func generateOtlpMetricAttachment() []*otlpcommon.StringKeyValue {
+	return []*otlpcommon.StringKeyValue{
+		{
+			Key:   TestAttachmentKey,
+			Value: TestAttachmentValue,
 		},
 	}
 }

--- a/internal/data/testdata/metric.go
+++ b/internal/data/testdata/metric.go
@@ -17,6 +17,8 @@ package testdata
 import (
 	"time"
 
+	otlpmetrics "github.com/open-telemetry/opentelemetry-proto/gen/go/metrics/v1"
+
 	"github.com/open-telemetry/opentelemetry-collector/internal/data"
 )
 
@@ -39,12 +41,39 @@ const (
 	TestGaugeHistogramMetricName      = "gauge-histogram"
 	TestCumulativeHistogramMetricName = "cumulative-histogram"
 	TestSummaryMetricName             = "summary"
+	NumMetricTests                    = 14
 )
 
-func GenerateMetricDataOneEmptyResourceMetrics() data.MetricData {
+func GenerateMetricDataEmpty() data.MetricData {
 	md := data.NewMetricData()
+	return md
+}
+
+func generateMetricOtlpEmpty() []*otlpmetrics.ResourceMetrics {
+	return []*otlpmetrics.ResourceMetrics(nil)
+}
+
+func GenerateMetricDataOneEmptyResourceMetrics() data.MetricData {
+	md := GenerateMetricDataEmpty()
 	md.ResourceMetrics().Resize(1)
 	return md
+}
+
+func generateMetricOtlpOneEmptyResourceMetrics() []*otlpmetrics.ResourceMetrics {
+	return []*otlpmetrics.ResourceMetrics{
+		{},
+	}
+}
+
+func GenerateMetricDataOneEmptyOneNilResourceMetrics() data.MetricData {
+	return data.MetricDataFromOtlp(generateMetricOtlpOneEmptyOneNilResourceMetrics())
+}
+
+func generateMetricOtlpOneEmptyOneNilResourceMetrics() []*otlpmetrics.ResourceMetrics {
+	return []*otlpmetrics.ResourceMetrics{
+		{},
+		nil,
+	}
 }
 
 func GenerateMetricDataNoLibraries() data.MetricData {
@@ -54,14 +83,157 @@ func GenerateMetricDataNoLibraries() data.MetricData {
 	return md
 }
 
-func GenerateMetricDataNoMetrics() data.MetricData {
+func generateMetricOtlpNoLibraries() []*otlpmetrics.ResourceMetrics {
+	return []*otlpmetrics.ResourceMetrics{
+		{
+			Resource: generateOtlpResource1(),
+		},
+	}
+}
+
+func GenerateMetricDataOneEmptyInstrumentationLibrary() data.MetricData {
 	md := GenerateMetricDataNoLibraries()
 	md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().Resize(1)
 	return md
 }
 
+// generateMetricOtlpOneEmptyInstrumentationLibrary returns the OTLP representation of the GenerateMetricDataOneEmptyInstrumentationLibrary.
+func generateMetricOtlpOneEmptyInstrumentationLibrary() []*otlpmetrics.ResourceMetrics {
+	return []*otlpmetrics.ResourceMetrics{
+		{
+			Resource: generateOtlpResource1(),
+			InstrumentationLibraryMetrics: []*otlpmetrics.InstrumentationLibraryMetrics{
+				{},
+			},
+		},
+	}
+}
+
+func GenerateMetricDataOneEmptyOneNilInstrumentationLibrary() data.MetricData {
+	return data.MetricDataFromOtlp(generateMetricOtlpOneEmptyOneNilInstrumentationLibrary())
+}
+
+func generateMetricOtlpOneEmptyOneNilInstrumentationLibrary() []*otlpmetrics.ResourceMetrics {
+	return []*otlpmetrics.ResourceMetrics{
+		{
+			Resource: generateOtlpResource1(),
+			InstrumentationLibraryMetrics: []*otlpmetrics.InstrumentationLibraryMetrics{
+				{},
+				nil,
+			},
+		},
+	}
+}
+
+func GenerateMetricDataOneMetricNoResource() data.MetricData {
+	md := GenerateMetricDataOneEmptyResourceMetrics()
+	rm0 := md.ResourceMetrics().At(0)
+	rm0.InstrumentationLibraryMetrics().Resize(1)
+	rm0ils0 := rm0.InstrumentationLibraryMetrics().At(0)
+	rm0ils0.Metrics().Resize(1)
+	initCounterIntMetric(rm0ils0.Metrics().At(0))
+	return md
+}
+
+func generateMetricOtlpOneMetricNoResource() []*otlpmetrics.ResourceMetrics {
+	return []*otlpmetrics.ResourceMetrics{
+		{
+			InstrumentationLibraryMetrics: []*otlpmetrics.InstrumentationLibraryMetrics{
+				{
+					Metrics: []*otlpmetrics.Metric{
+						generateOtlpCounterIntMetric(),
+					},
+				},
+			},
+		},
+	}
+}
+
+func GenerateMetricDataOneMetric() data.MetricData {
+	md := GenerateMetricDataOneEmptyInstrumentationLibrary()
+	rm0ils0 := md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0)
+	rm0ils0.Metrics().Resize(1)
+	initCounterIntMetric(rm0ils0.Metrics().At(0))
+	return md
+}
+
+func generateMetricOtlpOneMetric() []*otlpmetrics.ResourceMetrics {
+	return []*otlpmetrics.ResourceMetrics{
+		{
+			Resource: generateOtlpResource1(),
+			InstrumentationLibraryMetrics: []*otlpmetrics.InstrumentationLibraryMetrics{
+				{
+					Metrics: []*otlpmetrics.Metric{
+						generateOtlpCounterIntMetric(),
+					},
+				},
+			},
+		},
+	}
+}
+
+func GenerateMetricDataOneMetricOneNil() data.MetricData {
+	return data.MetricDataFromOtlp(generateMetricOtlpOneMetricOneNil())
+}
+
+func generateMetricOtlpOneMetricOneNil() []*otlpmetrics.ResourceMetrics {
+	return []*otlpmetrics.ResourceMetrics{
+		{
+			Resource: generateOtlpResource1(),
+			InstrumentationLibraryMetrics: []*otlpmetrics.InstrumentationLibraryMetrics{
+				{
+					Metrics: []*otlpmetrics.Metric{
+						generateOtlpCounterIntMetric(),
+						nil,
+					},
+				},
+			},
+		},
+	}
+}
+
+func GenerateMetricDataOneMetricNoLabels() data.MetricData {
+	md := GenerateMetricDataOneMetric()
+	dps := md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(0).Int64DataPoints()
+	dps.At(0).LabelsMap().InitFromMap(map[string]string{})
+	dps.At(1).LabelsMap().InitFromMap(map[string]string{})
+	return md
+}
+
+func generateMetricOtlpOneMetricNoLabels() []*otlpmetrics.ResourceMetrics {
+	md := generateMetricOtlpOneMetric()
+	m := md[0].InstrumentationLibraryMetrics[0].Metrics[0]
+	m.Int64DataPoints[0].Labels = nil
+	m.Int64DataPoints[1].Labels = nil
+	return md
+}
+
+func GenerateMetricDataOneMetricLabelsInDescriptor() data.MetricData {
+	md := GenerateMetricDataOneMetric()
+	m := md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(0)
+	initMetricLabels3(m.MetricDescriptor().LabelsMap())
+	return md
+}
+
+func generateMetricOtlpOneMetricLabelsInDescriptor() []*otlpmetrics.ResourceMetrics {
+	md := generateMetricOtlpOneMetric()
+	md[0].InstrumentationLibraryMetrics[0].Metrics[0].MetricDescriptor.Labels = generateOtlpMetricLabels3()
+	return md
+}
+
+func GenerateMetricDataOneMetricOneNilPoint() data.MetricData {
+	return data.MetricDataFromOtlp(generateMetricOtlpOneMetricOneNilPoint())
+}
+
+func generateMetricOtlpOneMetricOneNilPoint() []*otlpmetrics.ResourceMetrics {
+	md := generateMetricOtlpOneMetric()
+	md[0].InstrumentationLibraryMetrics[0].Metrics[0].Int64DataPoints =
+		append(md[0].InstrumentationLibraryMetrics[0].Metrics[0].Int64DataPoints, nil)
+	return md
+}
+
 func GenerateMetricDataAllTypesNoDataPoints() data.MetricData {
-	md := GenerateMetricDataNoMetrics()
+	md := GenerateMetricDataOneEmptyInstrumentationLibrary()
 	ilm0 := md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0)
 	ms := ilm0.Metrics()
 	ms.Resize(7)
@@ -80,6 +252,41 @@ func GenerateMetricDataAllTypesNoDataPoints() data.MetricData {
 	initMetricDescriptor(
 		ms.At(6).MetricDescriptor(), TestSummaryMetricName, data.MetricTypeSummary)
 	return md
+}
+
+func generateMetricOtlpAllTypesNoDataPoints() []*otlpmetrics.ResourceMetrics {
+	return []*otlpmetrics.ResourceMetrics{
+		{
+			Resource: generateOtlpResource1(),
+			InstrumentationLibraryMetrics: []*otlpmetrics.InstrumentationLibraryMetrics{
+				{
+					Metrics: []*otlpmetrics.Metric{
+						{
+							MetricDescriptor: generateOtlpMetricDescriptor(TestGaugeDoubleMetricName, data.MetricTypeGaugeDouble),
+						},
+						{
+							MetricDescriptor: generateOtlpMetricDescriptor(TestGaugeIntMetricName, data.MetricTypeGaugeInt64),
+						},
+						{
+							MetricDescriptor: generateOtlpMetricDescriptor(TestCounterDoubleMetricName, data.MetricTypeCounterDouble),
+						},
+						{
+							MetricDescriptor: generateOtlpMetricDescriptor(TestCounterIntMetricName, data.MetricTypeCounterInt64),
+						},
+						{
+							MetricDescriptor: generateOtlpMetricDescriptor(TestGaugeHistogramMetricName, data.MetricTypeGaugeHistogram),
+						},
+						{
+							MetricDescriptor: generateOtlpMetricDescriptor(TestCumulativeHistogramMetricName, data.MetricTypeCumulativeHistogram),
+						},
+						{
+							MetricDescriptor: generateOtlpMetricDescriptor(TestSummaryMetricName, data.MetricTypeSummary),
+						},
+					},
+				},
+			},
+		},
+	}
 }
 
 func GenerateMetricDataWithCountersHistogramAndSummary() data.MetricData {
@@ -102,39 +309,22 @@ func GenerateMetricDataWithCountersHistogramAndSummary() data.MetricData {
 	return metricData
 }
 
-func GenerateMetricDataOneMetricNoResource() data.MetricData {
-	md := GenerateMetricDataOneEmptyResourceMetrics()
-	rm0 := md.ResourceMetrics().At(0)
-	rm0.InstrumentationLibraryMetrics().Resize(1)
-	rm0ils0 := rm0.InstrumentationLibraryMetrics().At(0)
-	rm0ils0.Metrics().Resize(1)
-	initCounterIntMetric(rm0ils0.Metrics().At(0))
-	return md
-}
-
-func GenerateMetricDataOneMetric() data.MetricData {
-	md := GenerateMetricDataNoMetrics()
-	rm0ils0 := md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0)
-	rm0ils0.Metrics().Resize(1)
-	initCounterIntMetric(rm0ils0.Metrics().At(0))
-	return md
-}
-
-func GenerateMetricDataOneMetricNoLabels() data.MetricData {
-	md := GenerateMetricDataOneMetric()
-	dps := md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(0).Int64DataPoints()
-	dps.At(0).LabelsMap().InitFromMap(map[string]string{})
-	dps.At(1).LabelsMap().InitFromMap(map[string]string{})
-	return md
-}
-
-func GenerateMetricDataTwoMetrics() data.MetricData {
-	md := GenerateMetricDataNoMetrics()
-	rm0ils0 := md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0)
-	rm0ils0.Metrics().Resize(2)
-	initCounterIntMetric(rm0ils0.Metrics().At(0))
-	initCounterDoubleMetric(rm0ils0.Metrics().At(1))
-	return md
+func generateMetricOtlpWithCountersHistogramAndSummary() []*otlpmetrics.ResourceMetrics {
+	return []*otlpmetrics.ResourceMetrics{
+		{
+			Resource: generateOtlpResource1(),
+			InstrumentationLibraryMetrics: []*otlpmetrics.InstrumentationLibraryMetrics{
+				{
+					Metrics: []*otlpmetrics.Metric{
+						generateOtlpCounterIntMetric(),
+						generateOtlpCounterDoubleMetric(),
+						generateOtlpCumulativeHistogramMetric(),
+						generateOtlpSummaryMetric(),
+					},
+				},
+			},
+		},
+	}
 }
 
 func initCounterIntMetric(im data.Metric) {
@@ -143,15 +333,35 @@ func initCounterIntMetric(im data.Metric) {
 	idps := im.Int64DataPoints()
 	idps.Resize(2)
 	idp0 := idps.At(0)
-	idp0.LabelsMap().InitFromMap(map[string]string{"int-label-1": "int-label-value-1"})
+	initMetricLabels1(idp0.LabelsMap())
 	idp0.SetStartTime(TestMetricStartTimestamp)
 	idp0.SetTimestamp(TestMetricTimestamp)
 	idp0.SetValue(123)
 	idp1 := idps.At(1)
-	idp1.LabelsMap().InitFromMap(map[string]string{"int-label-2": "int-label-value-2"})
+	initMetricLabels2(idp1.LabelsMap())
 	idp1.SetStartTime(TestMetricStartTimestamp)
 	idp1.SetTimestamp(TestMetricTimestamp)
 	idp1.SetValue(456)
+}
+
+func generateOtlpCounterIntMetric() *otlpmetrics.Metric {
+	return &otlpmetrics.Metric{
+		MetricDescriptor: generateOtlpMetricDescriptor(TestCounterIntMetricName, data.MetricTypeCounterInt64),
+		Int64DataPoints: []*otlpmetrics.Int64DataPoint{
+			{
+				Labels:            generateOtlpMetricLabels1(),
+				StartTimeUnixNano: uint64(TestMetricStartTimestamp),
+				TimeUnixNano:      uint64(TestMetricTimestamp),
+				Value:             123,
+			},
+			{
+				Labels:            generateOtlpMetricLabels2(),
+				StartTimeUnixNano: uint64(TestMetricStartTimestamp),
+				TimeUnixNano:      uint64(TestMetricTimestamp),
+				Value:             456,
+			},
+		},
+	}
 }
 
 func initCounterDoubleMetric(dm data.Metric) {
@@ -161,18 +371,36 @@ func initCounterDoubleMetric(dm data.Metric) {
 	ddps.Resize(2)
 
 	ddp0 := ddps.At(0)
-	ddp0.LabelsMap().Insert("double-label-1", "double-label-value-1")
-	ddp0.LabelsMap().Insert("double-label-2", "double-label-value-2")
+	initMetricLabels12(ddp0.LabelsMap())
 	ddp0.SetStartTime(TestMetricStartTimestamp)
 	ddp0.SetTimestamp(TestMetricTimestamp)
 	ddp0.SetValue(1.23)
 
 	ddp1 := ddps.At(1)
-	ddp1.LabelsMap().Insert("double-label-1", "double-label-different-value-1")
-	ddp1.LabelsMap().Insert("double-label-3", "double-label-value-3")
+	initMetricLabels13(ddp1.LabelsMap())
 	ddp1.SetStartTime(TestMetricStartTimestamp)
 	ddp1.SetTimestamp(TestMetricTimestamp)
 	ddp1.SetValue(4.56)
+}
+
+func generateOtlpCounterDoubleMetric() *otlpmetrics.Metric {
+	return &otlpmetrics.Metric{
+		MetricDescriptor: generateOtlpMetricDescriptor(TestCounterDoubleMetricName, data.MetricTypeCounterDouble),
+		DoubleDataPoints: []*otlpmetrics.DoubleDataPoint{
+			{
+				Labels:            generateOtlpMetricLabels12(),
+				StartTimeUnixNano: uint64(TestMetricStartTimestamp),
+				TimeUnixNano:      uint64(TestMetricTimestamp),
+				Value:             1.23,
+			},
+			{
+				Labels:            generateOtlpMetricLabels13(),
+				StartTimeUnixNano: uint64(TestMetricStartTimestamp),
+				TimeUnixNano:      uint64(TestMetricTimestamp),
+				Value:             4.56,
+			},
+		},
+	}
 }
 
 func initCumulativeHistogramMetric(hm data.Metric) {
@@ -181,16 +409,13 @@ func initCumulativeHistogramMetric(hm data.Metric) {
 	hdps := hm.HistogramDataPoints()
 	hdps.Resize(2)
 	hdp0 := hdps.At(0)
-	hdp0.LabelsMap().Insert("histogram-label-1", "histogram-label-value-1")
-	hdp0.LabelsMap().Insert("histogram-label-3", "histogram-label-value-3")
+	initMetricLabels13(hdp0.LabelsMap())
 	hdp0.SetStartTime(TestMetricStartTimestamp)
 	hdp0.SetTimestamp(TestMetricTimestamp)
 	hdp0.SetCount(1)
 	hdp0.SetSum(15)
 	hdp1 := hdps.At(1)
-	hdp1.LabelsMap().InitFromMap(map[string]string{
-		"histogram-label-2": "histogram-label-value-2",
-	})
+	initMetricLabels2(hdp1.LabelsMap())
 	hdp1.SetStartTime(TestMetricStartTimestamp)
 	hdp1.SetTimestamp(TestMetricTimestamp)
 	hdp1.SetCount(1)
@@ -198,13 +423,48 @@ func initCumulativeHistogramMetric(hm data.Metric) {
 	hdp1.Buckets().Resize(2)
 	hdp1.Buckets().At(0).SetCount(0)
 	hdp1.Buckets().At(1).SetCount(1)
-	hdp1.Buckets().At(1).Exemplar().InitEmpty()
-	hdp1.Buckets().At(1).Exemplar().SetTimestamp(TestMetricExemplarTimestamp)
-	hdp1.Buckets().At(1).Exemplar().SetValue(15)
-	hdp1.Buckets().At(1).Exemplar().Attachments().InitFromMap(map[string]string{
-		"exemplar-attachment": "exemplar-attachment-value",
-	})
+	exemplar := hdp1.Buckets().At(1).Exemplar()
+	exemplar.InitEmpty()
+	exemplar.SetTimestamp(TestMetricExemplarTimestamp)
+	exemplar.SetValue(15)
+	initMetricAttachment(exemplar.Attachments())
 	hdp1.SetExplicitBounds([]float64{1})
+}
+
+func generateOtlpCumulativeHistogramMetric() *otlpmetrics.Metric {
+	return &otlpmetrics.Metric{
+		MetricDescriptor: generateOtlpMetricDescriptor(TestCumulativeHistogramMetricName, data.MetricTypeCumulativeHistogram),
+		HistogramDataPoints: []*otlpmetrics.HistogramDataPoint{
+			{
+				Labels:            generateOtlpMetricLabels13(),
+				StartTimeUnixNano: uint64(TestMetricStartTimestamp),
+				TimeUnixNano:      uint64(TestMetricTimestamp),
+				Count:             1,
+				Sum:               15,
+			},
+			{
+				Labels:            generateOtlpMetricLabels2(),
+				StartTimeUnixNano: uint64(TestMetricStartTimestamp),
+				TimeUnixNano:      uint64(TestMetricTimestamp),
+				Count:             1,
+				Sum:               15,
+				Buckets: []*otlpmetrics.HistogramDataPoint_Bucket{
+					{
+						Count: 0,
+					},
+					{
+						Count: 1,
+						Exemplar: &otlpmetrics.HistogramDataPoint_Bucket_Exemplar{
+							TimeUnixNano: uint64(TestMetricExemplarTimestamp),
+							Value:        15,
+							Attachments:  generateOtlpMetricAttachment(),
+						},
+					},
+				},
+				ExplicitBounds: []float64{1},
+			},
+		},
+	}
 }
 
 func initSummaryMetric(sm data.Metric) {
@@ -213,17 +473,13 @@ func initSummaryMetric(sm data.Metric) {
 	sdps := sm.SummaryDataPoints()
 	sdps.Resize(2)
 	sdp0 := sdps.At(0)
-	sdp0.LabelsMap().InitFromMap(map[string]string{
-		"summary-label": "summary-label-value-1",
-	})
+	initMetricLabelValue1(sdp0.LabelsMap())
 	sdp0.SetStartTime(TestMetricStartTimestamp)
 	sdp0.SetTimestamp(TestMetricTimestamp)
 	sdp0.SetCount(1)
 	sdp0.SetSum(15)
 	sdp1 := sdps.At(1)
-	sdp1.LabelsMap().InitFromMap(map[string]string{
-		"summary-label": "summary-label-value-2",
-	})
+	initMetricLabelValue2(sdp1.LabelsMap())
 	sdp1.SetStartTime(TestMetricStartTimestamp)
 	sdp1.SetTimestamp(TestMetricTimestamp)
 	sdp1.SetCount(1)
@@ -233,10 +489,48 @@ func initSummaryMetric(sm data.Metric) {
 	sdp1.ValueAtPercentiles().At(0).SetValue(15)
 }
 
+func generateOtlpSummaryMetric() *otlpmetrics.Metric {
+	return &otlpmetrics.Metric{
+		MetricDescriptor: generateOtlpMetricDescriptor(TestSummaryMetricName, data.MetricTypeSummary),
+		SummaryDataPoints: []*otlpmetrics.SummaryDataPoint{
+			{
+				Labels:            generateOtlpMetricLabelValue1(),
+				StartTimeUnixNano: uint64(TestMetricStartTimestamp),
+				TimeUnixNano:      uint64(TestMetricTimestamp),
+				Count:             1,
+				Sum:               15,
+			},
+			{
+				Labels:            generateOtlpMetricLabelValue2(),
+				StartTimeUnixNano: uint64(TestMetricStartTimestamp),
+				TimeUnixNano:      uint64(TestMetricTimestamp),
+				Count:             1,
+				Sum:               15,
+				PercentileValues: []*otlpmetrics.SummaryDataPoint_ValueAtPercentile{
+					{
+						Percentile: 1,
+						Value:      15,
+					},
+				},
+			},
+		},
+	}
+}
+
 func initMetricDescriptor(md data.MetricDescriptor, name string, ty data.MetricType) {
 	md.InitEmpty()
 	md.SetName(name)
 	md.SetDescription("")
 	md.SetUnit("1")
 	md.SetType(ty)
+}
+
+func generateOtlpMetricDescriptor(name string, ty data.MetricType) *otlpmetrics.MetricDescriptor {
+	return &otlpmetrics.MetricDescriptor{
+		Name:        name,
+		Description: "",
+		Unit:        "1",
+		Type:        otlpmetrics.MetricDescriptor_Type(ty),
+		Labels:      nil,
+	}
 }

--- a/internal/data/testdata/metric_test.go
+++ b/internal/data/testdata/metric_test.go
@@ -17,13 +17,123 @@ package testdata
 import (
 	"testing"
 
+	otlpmetrics "github.com/open-telemetry/opentelemetry-proto/gen/go/metrics/v1"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/open-telemetry/opentelemetry-collector/internal/data"
 )
 
-func TestGenerateMetricData(t *testing.T) {
-	assert.EqualValues(t, GenerateMetricDataNoLibraries(), GenerateMetricDataNoLibraries())
-	assert.EqualValues(t, GenerateMetricDataNoMetrics(), GenerateMetricDataNoMetrics())
-	assert.EqualValues(t, GenerateMetricDataOneMetricNoResource(), GenerateMetricDataOneMetricNoResource())
-	assert.EqualValues(t, GenerateMetricDataOneMetric(), GenerateMetricDataOneMetric())
-	assert.EqualValues(t, GenerateMetricDataTwoMetrics(), GenerateMetricDataTwoMetrics())
+type traceMetricsCase struct {
+	name string
+	td   data.MetricData
+	otlp []*otlpmetrics.ResourceMetrics
+}
+
+func generateAllMetricsTestCases() []traceMetricsCase {
+	return []traceMetricsCase{
+		{
+			name: "empty",
+			td:   GenerateMetricDataEmpty(),
+			otlp: generateMetricOtlpEmpty(),
+		},
+		{
+			name: "one-empty-resource-metrics",
+			td:   GenerateMetricDataOneEmptyResourceMetrics(),
+			otlp: generateMetricOtlpOneEmptyResourceMetrics(),
+		},
+		{
+			name: "one-empty-one-nil-resource-metrics",
+			td:   GenerateMetricDataOneEmptyOneNilResourceMetrics(),
+			otlp: generateMetricOtlpOneEmptyOneNilResourceMetrics(),
+		},
+		{
+			name: "no-libraries",
+			td:   GenerateMetricDataNoLibraries(),
+			otlp: generateMetricOtlpNoLibraries(),
+		},
+		{
+			name: "one-empty-instrumentation-library",
+			td:   GenerateMetricDataOneEmptyInstrumentationLibrary(),
+			otlp: generateMetricOtlpOneEmptyInstrumentationLibrary(),
+		},
+		{
+			name: "one-empty-one-nil-instrumentation-library",
+			td:   GenerateMetricDataOneEmptyOneNilInstrumentationLibrary(),
+			otlp: generateMetricOtlpOneEmptyOneNilInstrumentationLibrary(),
+		},
+		{
+			name: "one-metric-no-resource",
+			td:   GenerateMetricDataOneMetricNoResource(),
+			otlp: generateMetricOtlpOneMetricNoResource(),
+		},
+		{
+			name: "one-metric",
+			td:   GenerateMetricDataOneMetric(),
+			otlp: generateMetricOtlpOneMetric(),
+		},
+		{
+			name: "one-metric-one-nil",
+			td:   GenerateMetricDataOneMetricOneNil(),
+			otlp: generateMetricOtlpOneMetricOneNil(),
+		},
+		{
+			name: "one-metric-no-labels",
+			td:   GenerateMetricDataOneMetricNoLabels(),
+			otlp: generateMetricOtlpOneMetricNoLabels(),
+		},
+		{
+			name: "one-metric-labels-in-descriptor",
+			td:   GenerateMetricDataOneMetricLabelsInDescriptor(),
+			otlp: generateMetricOtlpOneMetricLabelsInDescriptor(),
+		},
+		{
+			name: "one-metric-one-nil-point",
+			td:   GenerateMetricDataOneMetricOneNilPoint(),
+			otlp: generateMetricOtlpOneMetricOneNilPoint(),
+		},
+		{
+			name: "all-types-no-data-points",
+			td:   GenerateMetricDataAllTypesNoDataPoints(),
+			otlp: generateMetricOtlpAllTypesNoDataPoints(),
+		},
+		{
+			name: "counters-histogram-summary",
+			td:   GenerateMetricDataWithCountersHistogramAndSummary(),
+			otlp: generateMetricOtlpWithCountersHistogramAndSummary(),
+		},
+	}
+}
+
+func TestToFromOtlpMetrics(t *testing.T) {
+	allTestCases := generateAllMetricsTestCases()
+	// Ensure NumMetricTests gets updated.
+	assert.EqualValues(t, NumMetricTests, len(allTestCases))
+	for i := range allTestCases {
+		test := allTestCases[i]
+		t.Run(test.name, func(t *testing.T) {
+			td := data.MetricDataFromOtlp(test.otlp)
+			assert.EqualValues(t, test.td, td)
+			otlp := data.MetricDataToOtlp(td)
+			assert.EqualValues(t, test.otlp, otlp)
+		})
+	}
+}
+
+func TestToFromOtlpMetricsWithNils(t *testing.T) {
+	md := GenerateMetricDataOneEmptyOneNilResourceMetrics()
+	assert.EqualValues(t, 2, md.ResourceMetrics().Len())
+	assert.False(t, md.ResourceMetrics().At(0).IsNil())
+	assert.True(t, md.ResourceMetrics().At(1).IsNil())
+
+	md = GenerateMetricDataOneEmptyOneNilInstrumentationLibrary()
+	rs := md.ResourceMetrics().At(0)
+	assert.EqualValues(t, 2, rs.InstrumentationLibraryMetrics().Len())
+	assert.False(t, rs.InstrumentationLibraryMetrics().At(0).IsNil())
+	assert.True(t, rs.InstrumentationLibraryMetrics().At(1).IsNil())
+
+	md = GenerateMetricDataOneMetricOneNil()
+	ilss := md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0)
+	assert.EqualValues(t, 2, ilss.Metrics().Len())
+	assert.False(t, ilss.Metrics().At(0).IsNil())
+	assert.True(t, ilss.Metrics().At(1).IsNil())
 }

--- a/internal/data/testdata/trace.go
+++ b/internal/data/testdata/trace.go
@@ -34,7 +34,7 @@ var (
 )
 
 const (
-	NumTraceTests = 8
+	NumTraceTests = 11
 )
 
 func GenerateTraceDataEmpty() data.TraceData {
@@ -52,10 +52,21 @@ func GenerateTraceDataOneEmptyResourceSpans() data.TraceData {
 	return td
 }
 
-// generateTraceOtlpOneEmptyResourceSpans returns the OTLP representation of the GenerateTraceDataOneEmptyResourceSpans
 func generateTraceOtlpOneEmptyResourceSpans() []*otlptrace.ResourceSpans {
 	return []*otlptrace.ResourceSpans{
 		{},
+	}
+}
+
+func GenerateTraceDataOneEmptyOneNilResourceSpans() data.TraceData {
+	return data.TraceDataFromOtlp(generateTraceOtlpOneEmptyOneNilResourceSpans())
+
+}
+
+func generateTraceOtlpOneEmptyOneNilResourceSpans() []*otlptrace.ResourceSpans {
+	return []*otlptrace.ResourceSpans{
+		{},
+		nil,
 	}
 }
 
@@ -66,7 +77,6 @@ func GenerateTraceDataNoLibraries() data.TraceData {
 	return td
 }
 
-// generateTraceOtlpDataNoLibraries returns the OTLP representation of the GenerateTraceDataNoLibraries.
 func generateTraceOtlpNoLibraries() []*otlptrace.ResourceSpans {
 	return []*otlptrace.ResourceSpans{
 		{
@@ -75,20 +85,35 @@ func generateTraceOtlpNoLibraries() []*otlptrace.ResourceSpans {
 	}
 }
 
-func GenerateTraceDataNoSpans() data.TraceData {
+func GenerateTraceDataOneEmptyInstrumentationLibrary() data.TraceData {
 	td := GenerateTraceDataNoLibraries()
 	rs0 := td.ResourceSpans().At(0)
 	rs0.InstrumentationLibrarySpans().Resize(1)
 	return td
 }
 
-// generateTraceOtlpNoSpans returns the OTLP representation of the GenerateTraceDataNoSpans.
-func generateTraceOtlpNoSpans() []*otlptrace.ResourceSpans {
+func generateTraceOtlpOneEmptyInstrumentationLibrary() []*otlptrace.ResourceSpans {
 	return []*otlptrace.ResourceSpans{
 		{
 			Resource: generateOtlpResource1(),
 			InstrumentationLibrarySpans: []*otlptrace.InstrumentationLibrarySpans{
 				{},
+			},
+		},
+	}
+}
+
+func GenerateTraceDataOneEmptyOneNilInstrumentationLibrary() data.TraceData {
+	return data.TraceDataFromOtlp(generateTraceOtlpOneEmptyOneNilInstrumentationLibrary())
+}
+
+func generateTraceOtlpOneEmptyOneNilInstrumentationLibrary() []*otlptrace.ResourceSpans {
+	return []*otlptrace.ResourceSpans{
+		{
+			Resource: generateOtlpResource1(),
+			InstrumentationLibrarySpans: []*otlptrace.InstrumentationLibrarySpans{
+				{},
+				nil,
 			},
 		},
 	}
@@ -104,7 +129,6 @@ func GenerateTraceDataOneSpanNoResource() data.TraceData {
 	return td
 }
 
-// generateTraceOtlpOneSpanNoResource returns the OTLP representation of the GenerateTraceDataOneSpanNoResource.
 func generateTraceOtlpOneSpanNoResource() []*otlptrace.ResourceSpans {
 	return []*otlptrace.ResourceSpans{
 		{
@@ -120,14 +144,13 @@ func generateTraceOtlpOneSpanNoResource() []*otlptrace.ResourceSpans {
 }
 
 func GenerateTraceDataOneSpan() data.TraceData {
-	td := GenerateTraceDataNoSpans()
+	td := GenerateTraceDataOneEmptyInstrumentationLibrary()
 	rs0ils0 := td.ResourceSpans().At(0).InstrumentationLibrarySpans().At(0)
 	rs0ils0.Spans().Resize(1)
 	fillSpanOne(rs0ils0.Spans().At(0))
 	return td
 }
 
-// generateTraceOtlpOneSpan returns the OTLP representation of the GenerateTraceDataOneSpan.
 func generateTraceOtlpOneSpan() []*otlptrace.ResourceSpans {
 	return []*otlptrace.ResourceSpans{
 		{
@@ -143,8 +166,28 @@ func generateTraceOtlpOneSpan() []*otlptrace.ResourceSpans {
 	}
 }
 
+func GenerateTraceDataOneSpanOneNil() data.TraceData {
+	return data.TraceDataFromOtlp(generateTraceOtlpOneSpanOneNil())
+}
+
+func generateTraceOtlpOneSpanOneNil() []*otlptrace.ResourceSpans {
+	return []*otlptrace.ResourceSpans{
+		{
+			Resource: generateOtlpResource1(),
+			InstrumentationLibrarySpans: []*otlptrace.InstrumentationLibrarySpans{
+				{
+					Spans: []*otlptrace.Span{
+						generateOtlpSpanOne(),
+						nil,
+					},
+				},
+			},
+		},
+	}
+}
+
 func GenerateTraceDataTwoSpansSameResource() data.TraceData {
-	td := GenerateTraceDataNoSpans()
+	td := GenerateTraceDataOneEmptyInstrumentationLibrary()
 	rs0ils0 := td.ResourceSpans().At(0).InstrumentationLibrarySpans().At(0)
 	rs0ils0.Spans().Resize(2)
 	fillSpanOne(rs0ils0.Spans().At(0))
@@ -152,7 +195,6 @@ func GenerateTraceDataTwoSpansSameResource() data.TraceData {
 	return td
 }
 
-// generateTraceOtlpSameResourcewoSpans returns the OTLP representation of the generateTraceDataSameResourcewoSpans.
 func generateTraceOtlpSameResourceTwoSpans() []*otlptrace.ResourceSpans {
 	return []*otlptrace.ResourceSpans{
 		{
@@ -188,7 +230,6 @@ func GenerateTraceDataTwoSpansSameResourceOneDifferent() data.TraceData {
 	return td
 }
 
-// generateTraceOtlpTwoSpansSameResourceOneDifferent returns the OTLP representation of the GenerateTraceDataTwoSpansSameResourceOneDifferent.
 func generateTraceOtlpTwoSpansSameResourceOneDifferent() []*otlptrace.ResourceSpans {
 	return []*otlptrace.ResourceSpans{
 		{

--- a/internal/data/testdata/trace_test.go
+++ b/internal/data/testdata/trace_test.go
@@ -42,14 +42,24 @@ func generateAllTraceTestCases() []traceTestCase {
 			otlp: generateTraceOtlpOneEmptyResourceSpans(),
 		},
 		{
+			name: "one-empty-one-nil-resource-spans",
+			td:   GenerateTraceDataOneEmptyOneNilResourceSpans(),
+			otlp: generateTraceOtlpOneEmptyOneNilResourceSpans(),
+		},
+		{
 			name: "no-libraries",
 			td:   GenerateTraceDataNoLibraries(),
 			otlp: generateTraceOtlpNoLibraries(),
 		},
 		{
-			name: "no-spans",
-			td:   GenerateTraceDataNoSpans(),
-			otlp: generateTraceOtlpNoSpans(),
+			name: "one-empty-instrumentation-library",
+			td:   GenerateTraceDataOneEmptyInstrumentationLibrary(),
+			otlp: generateTraceOtlpOneEmptyInstrumentationLibrary(),
+		},
+		{
+			name: "one-empty-one-nil-instrumentation-library",
+			td:   GenerateTraceDataOneEmptyOneNilInstrumentationLibrary(),
+			otlp: generateTraceOtlpOneEmptyOneNilInstrumentationLibrary(),
 		},
 		{
 			name: "one-span-no-resource",
@@ -60,6 +70,11 @@ func generateAllTraceTestCases() []traceTestCase {
 			name: "one-span",
 			td:   GenerateTraceDataOneSpan(),
 			otlp: generateTraceOtlpOneSpan(),
+		},
+		{
+			name: "one-span-one-nil",
+			td:   GenerateTraceDataOneSpanOneNil(),
+			otlp: generateTraceOtlpOneSpanOneNil(),
 		},
 		{
 			name: "two-spans-same-resource",
@@ -74,26 +89,7 @@ func generateAllTraceTestCases() []traceTestCase {
 	}
 }
 
-func TestGenerateTraceData(t *testing.T) {
-	assert.EqualValues(t, GenerateTraceDataOneEmptyResourceSpans(), GenerateTraceDataOneEmptyResourceSpans())
-	assert.EqualValues(t, GenerateTraceDataNoLibraries(), GenerateTraceDataNoLibraries())
-	assert.EqualValues(t, GenerateTraceDataNoSpans(), GenerateTraceDataNoSpans())
-	assert.EqualValues(t, GenerateTraceDataOneSpanNoResource(), GenerateTraceDataOneSpanNoResource())
-	assert.EqualValues(t, GenerateTraceDataOneSpan(), GenerateTraceDataOneSpan())
-	assert.EqualValues(t, GenerateTraceDataTwoSpansSameResource(), GenerateTraceDataTwoSpansSameResource())
-	assert.EqualValues(t, GenerateTraceDataTwoSpansSameResourceOneDifferent(), GenerateTraceDataTwoSpansSameResourceOneDifferent())
-}
-
-func TestGeneratedTraceOtlp(t *testing.T) {
-	assert.EqualValues(t, generateTraceOtlpNoLibraries(), generateTraceOtlpNoLibraries())
-	assert.EqualValues(t, generateTraceOtlpNoSpans(), generateTraceOtlpNoSpans())
-	assert.EqualValues(t, generateTraceOtlpOneSpanNoResource(), generateTraceOtlpOneSpanNoResource())
-	assert.EqualValues(t, generateTraceOtlpOneSpan(), generateTraceOtlpOneSpan())
-	assert.EqualValues(t, generateTraceOtlpSameResourceTwoSpans(), generateTraceOtlpSameResourceTwoSpans())
-	assert.EqualValues(t, generateTraceOtlpTwoSpansSameResourceOneDifferent(), generateTraceOtlpTwoSpansSameResourceOneDifferent())
-}
-
-func TestToFromOtlp(t *testing.T) {
+func TestToFromOtlpTrace(t *testing.T) {
 	allTestCases := generateAllTraceTestCases()
 	// Ensure NumTraceTests gets updated.
 	assert.EqualValues(t, NumTraceTests, len(allTestCases))
@@ -106,4 +102,23 @@ func TestToFromOtlp(t *testing.T) {
 			assert.EqualValues(t, test.otlp, otlp)
 		})
 	}
+}
+
+func TestToFromOtlpTraceWithNils(t *testing.T) {
+	md := GenerateTraceDataOneEmptyOneNilResourceSpans()
+	assert.EqualValues(t, 2, md.ResourceSpans().Len())
+	assert.False(t, md.ResourceSpans().At(0).IsNil())
+	assert.True(t, md.ResourceSpans().At(1).IsNil())
+
+	md = GenerateTraceDataOneEmptyOneNilInstrumentationLibrary()
+	rs := md.ResourceSpans().At(0)
+	assert.EqualValues(t, 2, rs.InstrumentationLibrarySpans().Len())
+	assert.False(t, rs.InstrumentationLibrarySpans().At(0).IsNil())
+	assert.True(t, rs.InstrumentationLibrarySpans().At(1).IsNil())
+
+	md = GenerateTraceDataOneSpanOneNil()
+	ilss := md.ResourceSpans().At(0).InstrumentationLibrarySpans().At(0)
+	assert.EqualValues(t, 2, ilss.Spans().Len())
+	assert.False(t, ilss.Spans().At(0).IsNil())
+	assert.True(t, ilss.Spans().At(1).IsNil())
 }

--- a/internal/data/trace.go
+++ b/internal/data/trace.go
@@ -60,9 +60,17 @@ func (td TraceData) SpanCount() int {
 	spanCount := 0
 	rss := td.ResourceSpans()
 	for i := 0; i < rss.Len(); i++ {
-		ils := rss.At(i).InstrumentationLibrarySpans()
-		for j := 0; j < ils.Len(); j++ {
-			spanCount += ils.At(j).Spans().Len()
+		rs := rss.At(i)
+		if rs.IsNil() {
+			continue
+		}
+		ilss := rs.InstrumentationLibrarySpans()
+		for j := 0; j < ilss.Len(); j++ {
+			ils := ilss.At(j)
+			if ils.IsNil() {
+				continue
+			}
+			spanCount += ilss.At(j).Spans().Len()
 		}
 	}
 	return spanCount

--- a/internal/data/trace_test.go
+++ b/internal/data/trace_test.go
@@ -44,6 +44,24 @@ func TestSpanCount(t *testing.T) {
 	assert.EqualValues(t, 6, md.SpanCount())
 }
 
+func TestSpanCountWithNils(t *testing.T) {
+	assert.EqualValues(t, 0, TraceDataFromOtlp([]*otlptrace.ResourceSpans{nil, {}}).SpanCount())
+	assert.EqualValues(t, 0, TraceDataFromOtlp([]*otlptrace.ResourceSpans{
+		{
+			InstrumentationLibrarySpans: []*otlptrace.InstrumentationLibrarySpans{nil, {}},
+		},
+	}).SpanCount())
+	assert.EqualValues(t, 2, TraceDataFromOtlp([]*otlptrace.ResourceSpans{
+		{
+			InstrumentationLibrarySpans: []*otlptrace.InstrumentationLibrarySpans{
+				{
+					Spans: []*otlptrace.Span{nil, {}},
+				},
+			},
+		},
+	}).SpanCount())
+}
+
 func TestTraceID(t *testing.T) {
 	tid := NewTraceID(nil)
 	assert.EqualValues(t, []byte(nil), tid.Bytes())

--- a/processor/cloningfanoutconnector_test.go
+++ b/processor/cloningfanoutconnector_test.go
@@ -195,7 +195,7 @@ func TestMetricsProcessorCloningMultiplexing(t *testing.T) {
 	}
 
 	mfc := NewMetricsCloningFanOutConnector(processors)
-	md := testdata.GenerateMetricDataTwoMetrics()
+	md := testdata.GenerateMetricDataWithCountersHistogramAndSummary()
 
 	var wantMetricsCount = 0
 	for i := 0; i < 2; i++ {
@@ -311,7 +311,7 @@ func TestCreateMetricsCloningFanOutConnectorWithConvertion(t *testing.T) {
 
 	resourceTypeName := "good-resource"
 
-	md := testdata.GenerateMetricDataTwoMetrics()
+	md := testdata.GenerateMetricDataWithCountersHistogramAndSummary()
 	resource := md.ResourceMetrics().At(0).Resource()
 	resource.Attributes().Upsert(data.NewAttributeKeyValueString(conventions.OCAttributeResourceType, resourceTypeName))
 

--- a/translator/internaldata/metrics_to_oc_test.go
+++ b/translator/internaldata/metrics_to_oc_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector/translator/conventions"
 )
 
-func TestResourceMetricsToMetricsData(t *testing.T) {
+func TestMetricsDataToOC(t *testing.T) {
 
 	sampleMetricData := testdata.GenerateMetricDataWithCountersHistogramAndSummary()
 	attrs := sampleMetricData.ResourceMetrics().At(0).Resource().Attributes()
@@ -47,9 +47,25 @@ func TestResourceMetricsToMetricsData(t *testing.T) {
 		oc       []consumerdata.MetricsData
 	}{
 		{
-			name:     "none",
-			internal: data.NewMetricData(),
+			name:     "empty",
+			internal: testdata.GenerateMetricDataEmpty(),
 			oc:       []consumerdata.MetricsData(nil),
+		},
+
+		{
+			name:     "one-empty-resource-metrics",
+			internal: testdata.GenerateMetricDataOneEmptyResourceMetrics(),
+			oc: []consumerdata.MetricsData{
+				{},
+			},
+		},
+
+		{
+			name:     "one-empty-one-nil-resource-metrics",
+			internal: testdata.GenerateMetricDataOneEmptyOneNilResourceMetrics(),
+			oc: []consumerdata.MetricsData{
+				{},
+			},
 		},
 
 		{
@@ -61,26 +77,78 @@ func TestResourceMetricsToMetricsData(t *testing.T) {
 		},
 
 		{
-			name:     "no-metrics",
-			internal: testdata.GenerateMetricDataNoMetrics(),
+			name:     "one-empty-instrumentation-library",
+			internal: testdata.GenerateMetricDataOneEmptyInstrumentationLibrary(),
 			oc: []consumerdata.MetricsData{
 				generateOCTestDataNoMetrics(),
 			},
 		},
 
 		{
-			name:     "no-points",
-			internal: testdata.GenerateMetricDataAllTypesNoDataPoints(),
+			name:     "one-empty-one-nil-instrumentation-library",
+			internal: testdata.GenerateMetricDataOneEmptyOneNilInstrumentationLibrary(),
 			oc: []consumerdata.MetricsData{
-				generateOCTestDataNoPoints(),
+				generateOCTestDataNoMetrics(),
 			},
 		},
 
 		{
-			name:     "no-labels-metric",
+			name:     "one-metric-no-resource",
+			internal: testdata.GenerateMetricDataOneMetricNoResource(),
+			oc: []consumerdata.MetricsData{
+				{
+					Metrics: []*ocmetrics.Metric{
+						generateOCTestMetricInt(),
+					},
+				},
+			},
+		},
+
+		{
+			name:     "one-metric",
+			internal: testdata.GenerateMetricDataOneMetric(),
+			oc: []consumerdata.MetricsData{
+				generateOCTestDataMetricsOneMetric(),
+			},
+		},
+
+		{
+			name:     "one-metric-one-nil",
+			internal: testdata.GenerateMetricDataOneMetricOneNil(),
+			oc: []consumerdata.MetricsData{
+				generateOCTestDataMetricsOneMetric(),
+			},
+		},
+
+		{
+			name:     "one-metric-one-nil-point",
+			internal: testdata.GenerateMetricDataOneMetricOneNilPoint(),
+			oc: []consumerdata.MetricsData{
+				generateOCTestDataMetricsOneMetric(),
+			},
+		},
+
+		{
+			name:     "one-metric-no-labels",
 			internal: testdata.GenerateMetricDataOneMetricNoLabels(),
 			oc: []consumerdata.MetricsData{
 				generateOCTestDataNoLabels(),
+			},
+		},
+
+		{
+			name:     "one-metric-labels-in-descriptor",
+			internal: testdata.GenerateMetricDataOneMetricLabelsInDescriptor(),
+			oc: []consumerdata.MetricsData{
+				generateOCTestDataMetricsInDescriptor(),
+			},
+		},
+
+		{
+			name:     "all-types-no-data-points",
+			internal: testdata.GenerateMetricDataAllTypesNoDataPoints(),
+			oc: []consumerdata.MetricsData{
+				generateOCTestDataNoPoints(),
 			},
 		},
 

--- a/translator/internaldata/oc_testdata_test.go
+++ b/translator/internaldata/oc_testdata_test.go
@@ -36,7 +36,6 @@ func generateOCTestDataNoMetrics() consumerdata.MetricsData {
 		Resource: &ocresource.Resource{
 			Labels: map[string]string{"resource-attr": "resource-attr-val-1"},
 		},
-		Metrics: []*ocmetrics.Metric(nil),
 	}
 }
 
@@ -108,44 +107,81 @@ func generateOCTestDataNoPoints() consumerdata.MetricsData {
 }
 
 func generateOCTestDataNoLabels() consumerdata.MetricsData {
+	m := generateOCTestMetricInt()
+	m.MetricDescriptor.LabelKeys = nil
+	m.Timeseries[0].LabelValues = nil
+	m.Timeseries[1].LabelValues = nil
 	return consumerdata.MetricsData{
 		Node: &occommon.Node{},
 		Resource: &ocresource.Resource{
 			Labels: map[string]string{"resource-attr": "resource-attr-val-1"},
 		},
-		Metrics: []*ocmetrics.Metric{
-			{
-				MetricDescriptor: &ocmetrics.MetricDescriptor{
-					Name: "counter-int",
-					Unit: "1",
-					Type: ocmetrics.MetricDescriptor_CUMULATIVE_INT64,
-				},
-				Timeseries: []*ocmetrics.TimeSeries{
-					{
-						StartTimestamp: internal.TimeToTimestamp(testdata.TestMetricStartTime),
-						Points: []*ocmetrics.Point{
-							{
-								Timestamp: internal.TimeToTimestamp(testdata.TestMetricTime),
-								Value: &ocmetrics.Point_Int64Value{
-									Int64Value: 123,
-								},
-							},
-						},
-					},
-					{
-						StartTimestamp: internal.TimeToTimestamp(testdata.TestMetricStartTime),
-						Points: []*ocmetrics.Point{
-							{
-								Timestamp: internal.TimeToTimestamp(testdata.TestMetricTime),
-								Value: &ocmetrics.Point_Int64Value{
-									Int64Value: 456,
-								},
-							},
-						},
-					},
-				},
-			},
+		Metrics: []*ocmetrics.Metric{m},
+	}
+}
+
+func generateOCTestDataMetricsInDescriptor() consumerdata.MetricsData {
+	m := generateOCTestMetricInt()
+	m.MetricDescriptor.LabelKeys = append(m.MetricDescriptor.LabelKeys, &ocmetrics.LabelKey{Key: testdata.TestLabelKey3})
+	m.Timeseries[0].LabelValues = append(m.Timeseries[0].LabelValues, &ocmetrics.LabelValue{
+		Value:    testdata.TestLabelValue3,
+		HasValue: true,
+	})
+	m.Timeseries[1].LabelValues = append(m.Timeseries[1].LabelValues, &ocmetrics.LabelValue{
+		Value:    testdata.TestLabelValue3,
+		HasValue: true,
+	})
+
+	return consumerdata.MetricsData{
+		Node: &occommon.Node{},
+		Resource: &ocresource.Resource{
+			Labels: map[string]string{"resource-attr": "resource-attr-val-1"},
 		},
+		Metrics: []*ocmetrics.Metric{m},
+	}
+}
+
+func generateOCTestDataMetricsOneMetric() consumerdata.MetricsData {
+	return consumerdata.MetricsData{
+		Node: &occommon.Node{},
+		Resource: &ocresource.Resource{
+			Labels: map[string]string{"resource-attr": "resource-attr-val-1"},
+		},
+		Metrics: []*ocmetrics.Metric{generateOCTestMetricInt()},
+	}
+}
+
+func generateOCTestDataMetricsOneMetricOneNil() consumerdata.MetricsData {
+	return consumerdata.MetricsData{
+		Node: &occommon.Node{},
+		Resource: &ocresource.Resource{
+			Labels: map[string]string{"resource-attr": "resource-attr-val-1"},
+		},
+		Metrics: []*ocmetrics.Metric{generateOCTestMetricInt(), nil},
+	}
+}
+
+func generateOCTestDataMetricsOneMetricOneNilTimeseries() consumerdata.MetricsData {
+	m := generateOCTestMetricInt()
+	m.Timeseries = append(m.Timeseries, nil)
+	return consumerdata.MetricsData{
+		Node: &occommon.Node{},
+		Resource: &ocresource.Resource{
+			Labels: map[string]string{"resource-attr": "resource-attr-val-1"},
+		},
+		Metrics: []*ocmetrics.Metric{m},
+	}
+}
+
+func generateOCTestDataMetricsOneMetricOneNilPoint() consumerdata.MetricsData {
+	m := generateOCTestMetricInt()
+	m.Timeseries[0].Points = append(m.Timeseries[0].Points, nil)
+	return consumerdata.MetricsData{
+		Node: &occommon.Node{},
+		Resource: &ocresource.Resource{
+			Labels: map[string]string{"resource-attr": "resource-attr-val-1"},
+		},
+		Metrics: []*ocmetrics.Metric{m},
 	}
 }
 
@@ -157,8 +193,8 @@ func generateOCTestMetricInt() *ocmetrics.Metric {
 			Unit:        "1",
 			Type:        ocmetrics.MetricDescriptor_CUMULATIVE_INT64,
 			LabelKeys: []*ocmetrics.LabelKey{
-				{Key: "int-label-1"},
-				{Key: "int-label-2"},
+				{Key: testdata.TestLabelKey1},
+				{Key: testdata.TestLabelKey2},
 			},
 		},
 		Timeseries: []*ocmetrics.TimeSeries{
@@ -167,7 +203,7 @@ func generateOCTestMetricInt() *ocmetrics.Metric {
 				LabelValues: []*ocmetrics.LabelValue{
 					{
 						// key1
-						Value:    "int-label-value-1",
+						Value:    testdata.TestLabelValue1,
 						HasValue: true,
 					},
 					{
@@ -193,7 +229,7 @@ func generateOCTestMetricInt() *ocmetrics.Metric {
 					},
 					{
 						// key2
-						Value:    "int-label-value-2",
+						Value:    testdata.TestLabelValue2,
 						HasValue: true,
 					},
 				},
@@ -217,9 +253,9 @@ func generateOCTestMetricDouble() *ocmetrics.Metric {
 			Unit: "1",
 			Type: ocmetrics.MetricDescriptor_CUMULATIVE_DOUBLE,
 			LabelKeys: []*ocmetrics.LabelKey{
-				{Key: "double-label-1"},
-				{Key: "double-label-2"},
-				{Key: "double-label-3"},
+				{Key: testdata.TestLabelKey1},
+				{Key: testdata.TestLabelKey2},
+				{Key: testdata.TestLabelKey3},
 			},
 		},
 		Timeseries: []*ocmetrics.TimeSeries{
@@ -228,12 +264,12 @@ func generateOCTestMetricDouble() *ocmetrics.Metric {
 				LabelValues: []*ocmetrics.LabelValue{
 					{
 						// key1
-						Value:    "double-label-value-1",
+						Value:    testdata.TestLabelValue1,
 						HasValue: true,
 					},
 					{
 						// key2
-						Value:    "double-label-value-2",
+						Value:    testdata.TestLabelValue2,
 						HasValue: true,
 					},
 					{
@@ -255,7 +291,7 @@ func generateOCTestMetricDouble() *ocmetrics.Metric {
 				LabelValues: []*ocmetrics.LabelValue{
 					{
 						// key1
-						Value:    "double-label-different-value-1",
+						Value:    testdata.TestLabelValue1,
 						HasValue: true,
 					},
 					{
@@ -264,7 +300,7 @@ func generateOCTestMetricDouble() *ocmetrics.Metric {
 					},
 					{
 						// key3
-						Value:    "double-label-value-3",
+						Value:    testdata.TestLabelValue3,
 						HasValue: true,
 					},
 				},
@@ -289,9 +325,9 @@ func generateOCTestMetricHistogram() *ocmetrics.Metric {
 			Unit:        "1",
 			Type:        ocmetrics.MetricDescriptor_CUMULATIVE_DISTRIBUTION,
 			LabelKeys: []*ocmetrics.LabelKey{
-				{Key: "histogram-label-1"},
-				{Key: "histogram-label-2"},
-				{Key: "histogram-label-3"},
+				{Key: testdata.TestLabelKey1},
+				{Key: testdata.TestLabelKey2},
+				{Key: testdata.TestLabelKey3},
 			},
 		},
 		Timeseries: []*ocmetrics.TimeSeries{
@@ -300,7 +336,7 @@ func generateOCTestMetricHistogram() *ocmetrics.Metric {
 				LabelValues: []*ocmetrics.LabelValue{
 					{
 						// key1
-						Value:    "histogram-label-value-1",
+						Value:    testdata.TestLabelValue1,
 						HasValue: true,
 					},
 					{
@@ -309,7 +345,7 @@ func generateOCTestMetricHistogram() *ocmetrics.Metric {
 					},
 					{
 						// key3
-						Value:    "histogram-label-value-3",
+						Value:    testdata.TestLabelValue3,
 						HasValue: true,
 					},
 				},
@@ -334,7 +370,7 @@ func generateOCTestMetricHistogram() *ocmetrics.Metric {
 					},
 					{
 						// key2
-						Value:    "histogram-label-value-2",
+						Value:    testdata.TestLabelValue2,
 						HasValue: true,
 					},
 					{
@@ -365,7 +401,7 @@ func generateOCTestMetricHistogram() *ocmetrics.Metric {
 										Exemplar: &ocmetrics.DistributionValue_Exemplar{
 											Timestamp:   internal.TimeToTimestamp(testdata.TestMetricExemplarTime),
 											Value:       15,
-											Attachments: map[string]string{"exemplar-attachment": "exemplar-attachment-value"},
+											Attachments: map[string]string{testdata.TestAttachmentKey: testdata.TestAttachmentValue},
 										},
 									},
 								},
@@ -386,7 +422,7 @@ func generateOCTestMetricSummary() *ocmetrics.Metric {
 			Unit:        "1",
 			Type:        ocmetrics.MetricDescriptor_SUMMARY,
 			LabelKeys: []*ocmetrics.LabelKey{
-				{Key: "summary-label"},
+				{Key: testdata.TestLabelKey},
 			},
 		},
 		Timeseries: []*ocmetrics.TimeSeries{
@@ -395,7 +431,7 @@ func generateOCTestMetricSummary() *ocmetrics.Metric {
 				LabelValues: []*ocmetrics.LabelValue{
 					{
 						// key1
-						Value:    "summary-label-value-1",
+						Value:    testdata.TestLabelValue1,
 						HasValue: true,
 					},
 				},
@@ -420,7 +456,7 @@ func generateOCTestMetricSummary() *ocmetrics.Metric {
 				LabelValues: []*ocmetrics.LabelValue{
 					{
 						// key1
-						Value:    "summary-label-value-2",
+						Value:    testdata.TestLabelValue2,
 						HasValue: true,
 					},
 				},

--- a/translator/internaldata/oc_to_metrics_test.go
+++ b/translator/internaldata/oc_to_metrics_test.go
@@ -36,11 +36,11 @@ func TestOCToMetricData(t *testing.T) {
 		{
 			name:     "empty",
 			oc:       consumerdata.MetricsData{},
-			internal: data.NewMetricData(),
+			internal: testdata.GenerateMetricDataEmpty(),
 		},
 
 		{
-			name: "empty-metrics",
+			name: "one-empty-resource-metrics",
 			oc: consumerdata.MetricsData{
 				Node:     &occommon.Node{},
 				Resource: &ocresource.Resource{},
@@ -55,33 +55,39 @@ func TestOCToMetricData(t *testing.T) {
 		},
 
 		{
-			name:     "no-points",
+			name:     "all-types-no-points",
 			oc:       generateOCTestDataNoPoints(),
 			internal: testdata.GenerateMetricDataAllTypesNoDataPoints(),
 		},
 
 		{
-			name:     "no-labels-metric",
+			name:     "one-metric-no-labels",
 			oc:       generateOCTestDataNoLabels(),
 			internal: testdata.GenerateMetricDataOneMetricNoLabels(),
 		},
 
 		{
-			name: "int64-metric",
-			oc: consumerdata.MetricsData{
-				Resource: generateOCTestResource(),
-				Metrics:  []*ocmetrics.Metric{generateOCTestMetricInt()},
-			},
+			name:     "one-metric",
+			oc:       generateOCTestDataMetricsOneMetric(),
 			internal: testdata.GenerateMetricDataOneMetric(),
 		},
 
 		{
-			name: "int64-and-double-metrics",
-			oc: consumerdata.MetricsData{
-				Resource: generateOCTestResource(),
-				Metrics:  []*ocmetrics.Metric{generateOCTestMetricInt(), generateOCTestMetricDouble()},
-			},
-			internal: testdata.GenerateMetricDataTwoMetrics(),
+			name:     "one-metric-one-nil",
+			oc:       generateOCTestDataMetricsOneMetricOneNil(),
+			internal: testdata.GenerateMetricDataOneMetric(),
+		},
+
+		{
+			name:     "one-metric-one-nil-timeseries",
+			oc:       generateOCTestDataMetricsOneMetricOneNilTimeseries(),
+			internal: testdata.GenerateMetricDataOneMetric(),
+		},
+
+		{
+			name:     "one-metric-one-nil-point",
+			oc:       generateOCTestDataMetricsOneMetricOneNilPoint(),
+			internal: testdata.GenerateMetricDataOneMetric(),
 		},
 
 		{

--- a/translator/internaldata/oc_to_traces_test.go
+++ b/translator/internaldata/oc_to_traces_test.go
@@ -322,13 +322,22 @@ func TestOcToInternal(t *testing.T) {
 		},
 
 		{
-
 			name: "one-span",
 			td:   testdata.GenerateTraceDataOneSpan(),
 			oc: consumerdata.TraceData{
 				Node:     ocNode,
 				Resource: ocResource1,
 				Spans:    []*octrace.Span{ocSpan1},
+			},
+		},
+
+		{
+			name: "one-span-one-nil",
+			td:   testdata.GenerateTraceDataOneSpan(),
+			oc: consumerdata.TraceData{
+				Node:     ocNode,
+				Resource: ocResource1,
+				Spans:    []*octrace.Span{ocSpan1, nil},
 			},
 		},
 
@@ -363,9 +372,13 @@ func TestOcToInternal(t *testing.T) {
 		},
 	}
 
-	// Equal number of tests even though there is an extra test "two-spans-and-separate-in-the-middle"
-	// but the test case GenerateTraceDataNoSpans it is impossible to get from OC data.
-	assert.EqualValues(t, testdata.NumTraceTests, len(tests))
+	// Extra test:
+	//	* "two-spans-and-separate-in-the-middle"
+	// Missing tests (impossible to generate):
+	//  * GenerateTraceDataOneEmptyOneNilResourceSpans
+	//	* GenerateTraceDataOneEmptyInstrumentationLibrary
+	//	* GenerateTraceDataOneEmptyOneNilInstrumentationLibrary
+	assert.EqualValues(t, testdata.NumTraceTests-2, len(tests))
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/translator/internaldata/traces_to_oc.go
+++ b/translator/internaldata/traces_to_oc.go
@@ -43,7 +43,11 @@ func TraceDataToOC(td data.TraceData) []consumerdata.TraceData {
 	ocResourceSpansList := make([]consumerdata.TraceData, 0, resourceSpans.Len())
 
 	for i := 0; i < resourceSpans.Len(); i++ {
-		ocResourceSpansList = append(ocResourceSpansList, ResourceSpansToOC(resourceSpans.At(i)))
+		rs := resourceSpans.At(i)
+		if rs.IsNil() {
+			continue
+		}
+		ocResourceSpansList = append(ocResourceSpansList, ResourceSpansToOC(rs))
 	}
 
 	return ocResourceSpansList
@@ -58,14 +62,22 @@ func ResourceSpansToOC(rs data.ResourceSpans) consumerdata.TraceData {
 	if ilss.Len() == 0 {
 		return ocTraceData
 	}
-	// Approximate the number of the metrics as the number of the metrics in the first
+	// Approximate the number of the spans as the number of the spans in the first
 	// instrumentation library info.
 	ocSpans := make([]*octrace.Span, 0, ilss.At(0).Spans().Len())
 	for i := 0; i < ilss.Len(); i++ {
+		ils := ilss.At(i)
+		if ils.IsNil() {
+			continue
+		}
 		// TODO: Handle instrumentation library name and version.
-		spans := ilss.At(i).Spans()
+		spans := ils.Spans()
 		for j := 0; j < spans.Len(); j++ {
-			ocSpans = append(ocSpans, spanToOC(spans.At(j)))
+			span := spans.At(j)
+			if span.IsNil() {
+				continue
+			}
+			ocSpans = append(ocSpans, spanToOC(span))
 		}
 	}
 	ocTraceData.Spans = ocSpans

--- a/translator/internaldata/traces_to_oc_test.go
+++ b/translator/internaldata/traces_to_oc_test.go
@@ -301,6 +301,19 @@ func TestInternalToOC(t *testing.T) {
 		},
 
 		{
+			name: "one-empty-one-nil-resource-spans",
+			td:   testdata.GenerateTraceDataOneEmptyOneNilResourceSpans(),
+			oc: []consumerdata.TraceData{
+				{
+					Node:         nil,
+					Resource:     nil,
+					Spans:        []*octrace.Span(nil),
+					SourceFormat: sourceFormat,
+				},
+			},
+		},
+
+		{
 			name: "no-libraries",
 			td:   testdata.GenerateTraceDataNoLibraries(),
 			oc: []consumerdata.TraceData{
@@ -314,8 +327,21 @@ func TestInternalToOC(t *testing.T) {
 		},
 
 		{
-			name: "no-spans",
-			td:   testdata.GenerateTraceDataNoSpans(),
+			name: "one-empty-instrumentation-library",
+			td:   testdata.GenerateTraceDataOneEmptyInstrumentationLibrary(),
+			oc: []consumerdata.TraceData{
+				{
+					Node:         ocNode,
+					Resource:     ocResource1,
+					Spans:        []*octrace.Span{},
+					SourceFormat: sourceFormat,
+				},
+			},
+		},
+
+		{
+			name: "one-empty-one-nil-instrumentation-library",
+			td:   testdata.GenerateTraceDataOneEmptyOneNilInstrumentationLibrary(),
 			oc: []consumerdata.TraceData{
 				{
 					Node:         ocNode,
@@ -342,6 +368,19 @@ func TestInternalToOC(t *testing.T) {
 		{
 			name: "one-span",
 			td:   testdata.GenerateTraceDataOneSpan(),
+			oc: []consumerdata.TraceData{
+				{
+					Node:         ocNode,
+					Resource:     ocResource1,
+					Spans:        []*octrace.Span{ocSpan1},
+					SourceFormat: sourceFormat,
+				},
+			},
+		},
+
+		{
+			name: "one-span-one-nil",
+			td:   testdata.GenerateTraceDataOneSpanOneNil(),
 			oc: []consumerdata.TraceData{
 				{
 					Node:         ocNode,


### PR DESCRIPTION
Fixes in this PR:
* Handle correctly nil Resource[Spans|Metrics], InstrumentationLibrary[Spans|Metrics], Span|Metric, MetricDataPoints.
* Found a bug that the OTLP MetricDescriptor.Labels were ignored in Internal->OC
* Rename translator/internaldata/{oc_testdata.go => oc_testdata_test.go} to not count these lines in coverage.

Work left for slices:
* Tests and fixes for nil Events, Links, Buckets, ValueAtPercentile

Work left for maps:
* Define what should be the behavior if a nil entry in the "slice map representation".
* Add tests for these cases.