### PR TITLE
Don't mutate resource type if it wasn't specified in the Resource Processor config

### DIFF
--- a/processor/README.md
+++ b/processor/README.md
@@ -408,7 +408,8 @@ The resource processor can be used to override a resource.
 Please refer to [config.go](resourceprocessor/config.go) for the config spec.
 
 The following configuration options are required:
-- `type`: Resource type to be applied. This value overrides the original resource type.
+- `type`: Resource type to be applied. If specified, this value overrides the 
+original resource type. Otherwise, the original resource type is kept.
 - `labels`: Map of key/value pairs that should be added to the resource.
 
 Examples:

--- a/processor/resourceprocessor/resource_processor.go
+++ b/processor/resourceprocessor/resource_processor.go
@@ -119,9 +119,16 @@ func mergeResource(to, from *resourcepb.Resource) *resourcepb.Resource {
 		return to
 	}
 	if to == nil {
+		if from.Type == "" {
+			// Since resource without type would be invalid, we keep resource as nil
+			return nil
+		}
 		to = &resourcepb.Resource{Labels: map[string]string{}}
 	}
-	to.Type = from.Type
+	if from.Type != "" {
+		// Only change resource type if it was configured
+		to.Type = from.Type
+	}
 	if from.Labels != nil {
 		for k, v := range from.Labels {
 			to.Labels[k] = v


### PR DESCRIPTION
**Description:** 
A minor tweak for Resource Processor to be able to add static labels without modifying resource type.

**Link to tracking Issue:** #773

**Testing:** Unit test added.

**Documentation:** Documentation updated.