### PR TITLE
Remove default processors from e2e tests

### DIFF
--- a/testbed/tests/scenarios.go
+++ b/testbed/tests/scenarios.go
@@ -37,10 +37,10 @@ func createConfigFile(
 	receiver testbed.DataReceiver, // Receiver to receive test data.
 	resultDir string, // Directory to write config file to.
 
-	// Map of extra processor names to their configs. Config is in YAML and must be
+	// Map of processor names to their configs. Config is in YAML and must be
 	// indented by 2 spaces. Processors will be placed between batch and queue for traces
 	// pipeline. For metrics pipeline these will be sole processors.
-	extraProcessors map[string]string,
+	processors map[string]string,
 ) string {
 
 	// Create a config. Note that our DataSender is used to generate a config for Collector's
@@ -50,16 +50,16 @@ func createConfigFile(
 
 	// Prepare extra processor config section and comma-separated list of extra processor
 	// names to use in corresponding "processors" settings.
-	extraProcessorsSections := ""
-	extraProcessorsList := ""
-	if len(extraProcessors) > 0 {
+	processorsSections := ""
+	processorsList := ""
+	if len(processors) > 0 {
 		first := true
-		for name, cfg := range extraProcessors {
-			extraProcessorsSections += cfg + "\n"
+		for name, cfg := range processors {
+			processorsSections += cfg + "\n"
 			if !first {
-				extraProcessorsList += ","
+				processorsList += ","
 			}
-			extraProcessorsList += name
+			processorsList += name
 			first = false
 		}
 	}
@@ -71,8 +71,6 @@ func createConfigFile(
 receivers:%v
 exporters:%v
 processors:
-  batch:
-  queued_retry:
   %s
 
 extensions:
@@ -84,14 +82,9 @@ service:
   pipelines:
     traces:
       receivers: [%v]
-      processors: [batch%s,queued_retry]
+      processors: [%s]
       exporters: [%v]
 `
-
-		if extraProcessorsList != "" {
-			// Trace test has some processors by default. Add the rest after a comma.
-			extraProcessorsList = "," + extraProcessorsList
-		}
 	} else {
 		// This is a metric test. Create appropriate config template.
 		format = `
@@ -119,10 +112,10 @@ service:
 		format,
 		sender.GenConfigYAMLStr(),
 		receiver.GenConfigYAMLStr(),
-		extraProcessorsSections,
+		processorsSections,
 		resultDir,
 		sender.ProtocolName(),
-		extraProcessorsList,
+		processorsList,
 		receiver.ProtocolName(),
 	)
 

--- a/testbed/tests/trace_test.go
+++ b/testbed/tests/trace_test.go
@@ -53,8 +53,8 @@ func TestTrace10kSPS(t *testing.T) {
 			testbed.NewJaegerGRPCDataSender(testbed.GetAvailablePort(t)),
 			testbed.NewJaegerDataReceiver(testbed.GetAvailablePort(t)),
 			testbed.ResourceSpec{
-				ExpectedMaxCPU: 69,
-				ExpectedMaxRAM: 89,
+				ExpectedMaxCPU: 85,
+				ExpectedMaxRAM: 50,
 			},
 		},
 		{
@@ -62,8 +62,8 @@ func TestTrace10kSPS(t *testing.T) {
 			testbed.NewOCTraceDataSender(testbed.GetAvailablePort(t)),
 			testbed.NewOCDataReceiver(testbed.GetAvailablePort(t)),
 			testbed.ResourceSpec{
-				ExpectedMaxCPU: 42,
-				ExpectedMaxRAM: 84,
+				ExpectedMaxCPU: 52,
+				ExpectedMaxRAM: 46,
 			},
 		},
 		{
@@ -71,8 +71,8 @@ func TestTrace10kSPS(t *testing.T) {
 			testbed.NewOTLPTraceDataSender(testbed.GetAvailablePort(t)),
 			testbed.NewOTLPDataReceiver(testbed.GetAvailablePort(t)),
 			testbed.ResourceSpec{
-				ExpectedMaxCPU: 60,
-				ExpectedMaxRAM: 84,
+				ExpectedMaxCPU: 85,
+				ExpectedMaxRAM: 50,
 			},
 		},
 	}
@@ -327,6 +327,9 @@ func TestTraceAttributesProcessor(t *testing.T) {
 
 			// Use processor to add attributes to certain spans.
 			processors := map[string]string{
+				"batch": `
+  batch:
+`,
 				"attributes": `
   attributes:
     include:
@@ -337,6 +340,9 @@ func TestTraceAttributesProcessor(t *testing.T) {
       - action: insert
         key: "new_attr"
         value: "string value"
+`,
+				"queued_retry": `
+  queued_retry:
 `,
 			}
 


### PR DESCRIPTION
Right before switching OTLP exporter to internal data we want to capture the current OTLP pipeline performance with translation to OC. Once OTLP exporter switched to internal data we can measure improvement of using OTLP internally through the whole pipeline against the OC based pipeline.

This PR removes processors added by default to e2e  tests so we don't need to wait for processors to be switched to internal data in order to measure the performance improvement