### PR TITLE
Make config.LoadReceiver take Factory instance

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -317,12 +317,17 @@ func loadService(v *viper.Viper) (configmodels.Service, error) {
 	return service, nil
 }
 
-// LoadReceiver loads a receiver config from v under the subkey receiverKey using the provided factories.
+// LoadReceiver loads a receiver config from v under the subkey receiverKey using the factory corresponding
+// to the receiver type from receiverKey.
 func LoadReceiver(receiverKey string, v *viper.Viper, factory component.ReceiverFactoryBase) (configmodels.Receiver, error) {
 	// Decode the key into type and fullName components.
 	typeStr, fullName, err := DecodeTypeAndName(receiverKey)
 	if err != nil {
 		return nil, err
+	}
+
+	if typeStr != factory.Type() {
+		return nil, fmt.Errorf("receiverKey had type %q but factory had type %q", typeStr, factory.Type())
 	}
 
 	// Create the default config for this receiver.


### PR DESCRIPTION
LoadReceiver now takes a factory instance instead of a factories map since the
specific factory to load is already known and does not need to come indirectly
through a map.

Also make DecodeTypeAndName wrap errors itself since it's called many times.