### PR TITLE
Update CustomUnmarshaler to not require top level config and the key.

### DIFF
--- a/component/receiver.go
+++ b/component/receiver.go
@@ -70,17 +70,11 @@ type ReceiverFactoryBase interface {
 
 // CustomUnmarshaler is a function that un-marshals a viper data into a config struct
 // in a custom way.
-// v *viper.Viper
-//   A viper instance at the "receivers" node in the config yaml.  v.Sub(viperKey) is
-//   the raw config this function should load.
-// viperKey string
-//   The name of this config.  i.e. "jaeger/custom".  v.Sub(viperKey) is the raw config
-//   this function should load.
-// sourceViperSection *viper.Viper
-//   The value of v.Sub(viperKey) with all environment substitution complete.
+// componentViperSection *viper.Viper
+//   The config for this specific component. May be nil or empty if no config available.
 // intoCfg interface{}
 //   An empty interface wrapping a pointer to the config struct to unmarshal into.
-type CustomUnmarshaler func(v *viper.Viper, viperKey string, sourceViperSection *viper.Viper, intoCfg interface{}) error
+type CustomUnmarshaler func(componentViperSection *viper.Viper, intoCfg interface{}) error
 
 // ReceiverFactoryOld can create TraceReceiver and MetricsReceiver.
 type ReceiverFactoryOld interface {

--- a/config/config.go
+++ b/config/config.go
@@ -345,7 +345,7 @@ func LoadReceiver(receiverKey string, v *viper.Viper, factories map[string]compo
 	customUnmarshaler := factory.CustomUnmarshaler()
 	if customUnmarshaler != nil {
 		// This configuration requires a custom unmarshaler, use it.
-		err = customUnmarshaler(v, receiverKey, sv, receiverCfg)
+		err = customUnmarshaler(sv, receiverCfg)
 	} else {
 		err = sv.UnmarshalExact(receiverCfg)
 	}

--- a/receiver/jaegerreceiver/factory_test.go
+++ b/receiver/jaegerreceiver/factory_test.go
@@ -263,15 +263,14 @@ func TestRemoteSamplingFileRequiresGRPC(t *testing.T) {
 
 func TestCustomUnmarshalErrors(t *testing.T) {
 	factory := Factory{}
-	v := config.NewViper()
 
 	f := factory.CustomUnmarshaler()
 	assert.NotNil(t, f, "custom unmarshal function should not be nil")
 
-	err := f(v, "", config.NewViper(), nil)
+	err := f(config.NewViper(), nil)
 	assert.Error(t, err, "should not have been able to marshal to a nil config")
 
-	err = f(v, "", config.NewViper(), &RemoteSamplingConfig{})
+	err = f(config.NewViper(), &RemoteSamplingConfig{})
 	assert.Error(t, err, "should not have been able to marshal to a non-jaegerreceiver config")
 }
 


### PR DESCRIPTION
Split from https://github.com/open-telemetry/opentelemetry-collector/pull/799.