### PR TITLE
Remove indirect client-go dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -61,7 +61,4 @@ require (
 	google.golang.org/grpc v1.23.0
 	gopkg.in/yaml.v2 v2.2.8
 	honnef.co/go/tools v0.0.1-2020.1.3
-	k8s.io/client-go v12.0.0+incompatible // indirect
 )
-
-replace k8s.io/client-go => k8s.io/client-go v0.0.0-20190620085101-78d2af792bab


### PR DESCRIPTION
This is no longer needed as the prometheus version used has go.mod with the
required client-go version. Before we were requiring client-go v12 which makes
go unhappy because it thinks if the version vN where N is > 1 then it should
have vN in the import path. Instead Kubernetes now tags what would be v12 as
v0.12 to work around this issue. Although it looks like prometheus just uses
the commit hash in their go.mod.

contrib will also be cleaned up to get rid of the warnings.