### PR TITLE
Disallow nil values in the custom data maps.

### DIFF
--- a/internal/data/common.go
+++ b/internal/data/common.go
@@ -58,10 +58,6 @@ type AttributeValue struct {
 	orig *otlpcommon.AttributeKeyValue
 }
 
-func NilAttributeValue() AttributeValue {
-	return AttributeValue{orig: nil}
-}
-
 // NewAttributeValueString creates a new AttributeValue with the given string value.
 func NewAttributeValueString(v string) AttributeValue {
 	return AttributeValue{orig: &otlpcommon.AttributeKeyValue{Type: otlpcommon.AttributeKeyValue_STRING, StringValue: v}}
@@ -92,10 +88,6 @@ func NewAttributeValueSlice(len int) []AttributeValue {
 		wrappers[i].orig = &origs[i]
 	}
 	return wrappers
-}
-
-func (a AttributeValue) IsNil() bool {
-	return a.orig == nil
 }
 
 // Type returns the type of the value for this AttributeValue.
@@ -264,6 +256,7 @@ func (am AttributeMap) InitFromMap(attrMap map[string]AttributeValue) AttributeM
 
 // Get returns the AttributeKeyValue associated with the key and true,
 // otherwise an invalid instance of the AttributeKeyValue and false.
+// Calling any functions on the returned invalid instance will cause a panic.
 func (am AttributeMap) Get(key string) (AttributeValue, bool) {
 	for _, a := range *am.orig {
 		if a != nil && a.Key == key {
@@ -288,6 +281,8 @@ func (am AttributeMap) Delete(key string) bool {
 
 // Insert adds the AttributeValue to the map when the key does not exist.
 // No action is applied to the map where the key already exists.
+//
+// Calling this function with a zero-initialized AttributeValue struct will cause a panic.
 //
 // Important: this function should not be used if the caller has access to
 // the raw value to avoid an extra allocation.
@@ -332,6 +327,8 @@ func (am AttributeMap) InsertBool(k string, v bool) {
 // Update updates an existing AttributeValue with a value.
 // No action is applied to the map where the key does not exist.
 //
+// Calling this function with a zero-initialized AttributeValue struct will cause a panic.
+//
 // Important: this function should not be used if the caller has access to
 // the raw value to avoid an extra allocation.
 func (am AttributeMap) Update(k string, v AttributeValue) {
@@ -375,6 +372,8 @@ func (am AttributeMap) UpdateBool(k string, v bool) {
 // Upsert performs the Insert or Update action. The AttributeValue is
 // insert to the map that did not originally have the key. The key/value is
 // updated to the map where the key already existed.
+//
+// Calling this function with a zero-initialized AttributeValue struct will cause a panic.
 //
 // Important: this function should not be used if the caller has access to
 // the raw value to avoid an extra allocation.
@@ -537,6 +536,7 @@ func (sm StringMap) InitFromMap(attrMap map[string]string) StringMap {
 
 // Get returns the StringKeyValue associated with the key and true,
 // otherwise an invalid instance of the StringKeyValue and false.
+// Calling any functions on the returned invalid instance will cause a panic.
 func (sm StringMap) Get(k string) (StringKeyValue, bool) {
 	for _, a := range *sm.orig {
 		if a != nil && a.Key == k {

--- a/internal/processor/filterhelper/filterhelper.go
+++ b/internal/processor/filterhelper/filterhelper.go
@@ -22,20 +22,19 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector/internal/data"
 )
 
-// NilAttributeValue is used to convert the raw `value` from ActionKeyValue to the supported trace attribute values.
-func NewAttributeValue(value interface{}) (data.AttributeValue, error) {
-	attr := data.NilAttributeValue()
+// NewAttributeValueRaw is used to convert the raw `value` from ActionKeyValue to the supported trace attribute values.
+// If error different than nil the return value is invalid. Calling any functions on the invalid value will cause a panic.
+func NewAttributeValueRaw(value interface{}) (data.AttributeValue, error) {
 	switch val := value.(type) {
 	case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
-		attr = data.NewAttributeValueInt(cast.ToInt64(val))
+		return data.NewAttributeValueInt(cast.ToInt64(val)), nil
 	case float32, float64:
-		attr = data.NewAttributeValueDouble(cast.ToFloat64(val))
+		return data.NewAttributeValueDouble(cast.ToFloat64(val)), nil
 	case string:
-		attr = data.NewAttributeValueString(val)
+		return data.NewAttributeValueString(val), nil
 	case bool:
-		attr = data.NewAttributeValueBool(val)
+		return data.NewAttributeValueBool(val), nil
 	default:
-		return attr, fmt.Errorf("error unsupported value type \"%T\"", value)
+		return data.AttributeValue{}, fmt.Errorf("error unsupported value type \"%T\"", value)
 	}
-	return attr, nil
 }

--- a/internal/processor/filterhelper/filterhelper_test.go
+++ b/internal/processor/filterhelper/filterhelper_test.go
@@ -23,43 +23,41 @@ import (
 )
 
 func TestHelper_AttributeValue(t *testing.T) {
-	val, err := NewAttributeValue(uint8(123))
+	val, err := NewAttributeValueRaw(uint8(123))
 	assert.Equal(t, data.NewAttributeValueInt(123), val)
 	assert.NoError(t, err)
 
-	val, err = NewAttributeValue(uint16(123))
+	val, err = NewAttributeValueRaw(uint16(123))
 	assert.Equal(t, data.NewAttributeValueInt(123), val)
 	assert.NoError(t, err)
 
-	val, err = NewAttributeValue(int8(123))
+	val, err = NewAttributeValueRaw(int8(123))
 	assert.Equal(t, data.NewAttributeValueInt(123), val)
 	assert.NoError(t, err)
 
-	val, err = NewAttributeValue(int16(123))
+	val, err = NewAttributeValueRaw(int16(123))
 	assert.Equal(t, data.NewAttributeValueInt(123), val)
 	assert.NoError(t, err)
 
-	val, err = NewAttributeValue(float32(234.129312))
+	val, err = NewAttributeValueRaw(float32(234.129312))
 	assert.Equal(t, data.NewAttributeValueDouble(float64(float32(234.129312))), val)
 	assert.NoError(t, err)
 
-	val, err = NewAttributeValue(234.129312)
+	val, err = NewAttributeValueRaw(234.129312)
 	assert.Equal(t, data.NewAttributeValueDouble(234.129312), val)
 	assert.NoError(t, err)
 
-	val, err = NewAttributeValue(true)
+	val, err = NewAttributeValueRaw(true)
 	assert.Equal(t, data.NewAttributeValueBool(true), val)
 	assert.NoError(t, err)
 
-	val, err = NewAttributeValue("bob the builder")
+	val, err = NewAttributeValueRaw("bob the builder")
 	assert.Equal(t, data.NewAttributeValueString("bob the builder"), val)
 	assert.NoError(t, err)
 
-	val, err = NewAttributeValue(nil)
-	assert.True(t, val.IsNil())
+	val, err = NewAttributeValueRaw(nil)
 	assert.Error(t, err)
 
-	val, err = NewAttributeValue(t)
-	assert.True(t, val.IsNil())
+	val, err = NewAttributeValueRaw(t)
 	assert.Error(t, err)
 }

--- a/internal/processor/filterspan/filterspan.go
+++ b/internal/processor/filterspan/filterspan.go
@@ -71,8 +71,9 @@ type regexpPropertiesMatcher struct {
 
 // attributeMatcher is a attribute key/value pair to match to.
 type attributeMatcher struct {
-	Key            string
-	AttributeValue data.AttributeValue
+	Key string
+	// If nil only check for key existence.
+	AttributeValue *data.AttributeValue
 }
 
 func NewMatcher(config *MatchProperties) (Matcher, error) {
@@ -166,11 +167,11 @@ func newAttributesMatcher(config *MatchProperties) (attributesMatcher, error) {
 			Key: attribute.Key,
 		}
 		if attribute.Value != nil {
-			val, err := filterhelper.NewAttributeValue(attribute.Value)
+			val, err := filterhelper.NewAttributeValueRaw(attribute.Value)
 			if err != nil {
 				return nil, err
 			}
-			entry.AttributeValue = val
+			entry.AttributeValue = &val
 		}
 
 		rawAttributes = append(rawAttributes, entry)
@@ -287,11 +288,11 @@ func (ma attributesMatcher) match(span data.Span) bool {
 		}
 
 		// This is for the case of checking that the key existed.
-		if property.AttributeValue.IsNil() {
+		if property.AttributeValue == nil {
 			continue
 		}
 
-		if !attr.Equal(property.AttributeValue) {
+		if !attr.Equal(*property.AttributeValue) {
 			return false
 		}
 	}

--- a/internal/processor/filterspan/filterspan_test.go
+++ b/internal/processor/filterspan/filterspan_test.go
@@ -156,7 +156,7 @@ func TestSpan_Matching_False(t *testing.T) {
 				Attributes: []attributeMatcher{
 					{
 						Key:            "keyInt",
-						AttributeValue: data.NewAttributeValueInt(1234),
+						AttributeValue: newAttributeValueInt(1234),
 					},
 				},
 			},
@@ -168,7 +168,7 @@ func TestSpan_Matching_False(t *testing.T) {
 				Attributes: []attributeMatcher{
 					{
 						Key:            "keyInt",
-						AttributeValue: data.NewAttributeValueString("123"),
+						AttributeValue: newAttributeValueString("123"),
 					},
 				},
 			},
@@ -180,7 +180,7 @@ func TestSpan_Matching_False(t *testing.T) {
 				Attributes: []attributeMatcher{
 					{
 						Key:            "doesnotexist",
-						AttributeValue: data.NilAttributeValue(),
+						AttributeValue: nil,
 					},
 				},
 			},
@@ -204,7 +204,7 @@ func TestSpan_MatchingCornerCases(t *testing.T) {
 		Attributes: []attributeMatcher{
 			{
 				Key:            "keyOne",
-				AttributeValue: data.NilAttributeValue(),
+				AttributeValue: nil,
 			},
 		},
 	}
@@ -275,19 +275,19 @@ func TestSpan_Matching_True(t *testing.T) {
 				Attributes: []attributeMatcher{
 					{
 						Key:            "keyString",
-						AttributeValue: data.NewAttributeValueString("arithmetic"),
+						AttributeValue: newAttributeValueString("arithmetic"),
 					},
 					{
 						Key:            "keyInt",
-						AttributeValue: data.NewAttributeValueInt(123),
+						AttributeValue: newAttributeValueInt(123),
 					},
 					{
 						Key:            "keyDouble",
-						AttributeValue: data.NewAttributeValueDouble(3245.6),
+						AttributeValue: newAttributeValueDouble(3245.6),
 					},
 					{
 						Key:            "keyBool",
-						AttributeValue: data.NewAttributeValueBool(true),
+						AttributeValue: newAttributeValueBool(true),
 					},
 				},
 			},
@@ -299,7 +299,7 @@ func TestSpan_Matching_True(t *testing.T) {
 				Attributes: []attributeMatcher{
 					{
 						Key:            "keyExists",
-						AttributeValue: data.NilAttributeValue(),
+						AttributeValue: nil,
 					},
 				},
 			},
@@ -311,11 +311,11 @@ func TestSpan_Matching_True(t *testing.T) {
 				Attributes: []attributeMatcher{
 					{
 						Key:            "keyExists",
-						AttributeValue: data.NilAttributeValue(),
+						AttributeValue: nil,
 					},
 					{
 						Key:            "keyString",
-						AttributeValue: data.NewAttributeValueString("arithmetic"),
+						AttributeValue: newAttributeValueString("arithmetic"),
 					},
 				},
 			},
@@ -381,7 +381,7 @@ func TestSpan_validateMatchesConfiguration(t *testing.T) {
 					},
 					{
 						Key:            "key2",
-						AttributeValue: data.NewAttributeValueInt(1234),
+						AttributeValue: newAttributeValueInt(1234),
 					},
 				},
 			},
@@ -414,7 +414,7 @@ func TestSpan_validateMatchesConfiguration(t *testing.T) {
 					},
 					{
 						Key:            "key2",
-						AttributeValue: data.NewAttributeValueInt(1234),
+						AttributeValue: newAttributeValueInt(1234),
 					},
 				},
 			},
@@ -438,4 +438,24 @@ func TestSpan_validateMatchesConfiguration(t *testing.T) {
 			assert.Equal(t, tc.output, output)
 		})
 	}
+}
+
+func newAttributeValueString(v string) *data.AttributeValue {
+	attr := data.NewAttributeValueString(v)
+	return &attr
+}
+
+func newAttributeValueInt(v int64) *data.AttributeValue {
+	attr := data.NewAttributeValueInt(v)
+	return &attr
+}
+
+func newAttributeValueDouble(v float64) *data.AttributeValue {
+	attr := data.NewAttributeValueDouble(v)
+	return &attr
+}
+
+func newAttributeValueBool(v bool) *data.AttributeValue {
+	attr := data.NewAttributeValueBool(v)
+	return &attr
 }


### PR DESCRIPTION
The maps don't have an easy way to carry nil values, so if user needs a "nil" AttributeValue or StringValue they should use pointers to these data structures. See an example in filterspan where nil is used to signal that only key must exist.