### PR TITLE
Allow components to discover Extensions

### DIFF
--- a/component/component.go
+++ b/component/component.go
@@ -16,6 +16,8 @@ package component
 
 import (
 	"context"
+
+	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
 )
 
 // Component is either a receiver, exporter, processor or extension.
@@ -61,6 +63,12 @@ type Host interface {
 	// until Shutdown() is called. Note that the component is responsible for destroying
 	// other components that it creates.
 	GetFactory(kind Kind, componentType string) Factory
+
+	// Return map of extensions. Only enabled and created extensions will be returned.
+	// Typically is used to find an extension by type or by full config name. Both cases
+	// can be done by iterating the returned map. There are typically very few extensions
+	// so there there is no performance implications due to iteration.
+	GetExtensions() map[configmodels.Extension]ServiceExtension
 }
 
 // Factory interface must be implemented by all component factories.

--- a/component/componenttest/error_waiting_host.go
+++ b/component/componenttest/error_waiting_host.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/open-telemetry/opentelemetry-collector/component"
+	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
 )
 
 // ErrorWaitingHost mocks an component.Host for test purposes.
@@ -57,5 +58,9 @@ func (ews *ErrorWaitingHost) WaitForFatalError(timeout time.Duration) (receivedE
 
 // GetFactory of the specified kind. Returns the factory for a component type.
 func (ews *ErrorWaitingHost) GetFactory(_ component.Kind, _ string) component.Factory {
+	return nil
+}
+
+func (ews *ErrorWaitingHost) GetExtensions() map[configmodels.Extension]component.ServiceExtension {
 	return nil
 }

--- a/component/componenttest/nop_host.go
+++ b/component/componenttest/nop_host.go
@@ -16,6 +16,7 @@ package componenttest
 
 import (
 	"github.com/open-telemetry/opentelemetry-collector/component"
+	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
 )
 
 // NopHost mocks a receiver.ReceiverHost for test purposes.
@@ -39,5 +40,9 @@ func (nh *NopHost) ReportFatalError(_ error) {
 
 // GetFactory of the specified kind. Returns the factory for a component type.
 func (nh *NopHost) GetFactory(_ component.Kind, _ string) component.Factory {
+	return nil
+}
+
+func (nh *NopHost) GetExtensions() map[configmodels.Extension]component.ServiceExtension {
 	return nil
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -37,7 +37,7 @@ func TestDecodeConfig(t *testing.T) {
 	// Verify extensions.
 	assert.Equal(t, 3, len(config.Extensions))
 	assert.False(t, config.Extensions["exampleextension/disabled"].IsEnabled())
-	assert.Equal(t, "some string", config.Extensions["exampleextension/1"].(*ExampleExtension).ExtraSetting)
+	assert.Equal(t, "some string", config.Extensions["exampleextension/1"].(*ExampleExtensionCfg).ExtraSetting)
 
 	// Verify service.
 	assert.Equal(t, 2, len(config.Service.Extensions))
@@ -205,7 +205,7 @@ func TestSimpleConfig(t *testing.T) {
 		assert.Equalf(t, 1, len(config.Extensions), "TEST[%s]", test.name)
 		assert.Truef(t, config.Extensions["exampleextension"].IsEnabled(), "TEST[%s]", test.name)
 		assert.Equalf(t,
-			&ExampleExtension{
+			&ExampleExtensionCfg{
 				ExtensionSettings: configmodels.ExtensionSettings{
 					TypeVal: "exampleextension",
 					NameVal: "exampleextension",

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -21,10 +21,12 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
 	"testing"
 
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -111,8 +113,8 @@ func assertMetricsPrefix(t *testing.T, prefix string, metricsPort uint16) {
 }
 
 func TestApplication_setupExtensions(t *testing.T) {
-	exampleExtensionFactory := &config.ExampleExtensionFactory{}
-	exampleExtensionConfig := &config.ExampleExtension{
+	exampleExtensionFactory := &config.ExampleExtensionFactory{FailCreation: true}
+	exampleExtensionConfig := &config.ExampleExtensionCfg{
 		ExtensionSettings: configmodels.ExtensionSettings{
 			TypeVal: exampleExtensionFactory.Type(),
 			NameVal: exampleExtensionFactory.Type(),
@@ -209,12 +211,16 @@ func TestApplication_setupExtensions(t *testing.T) {
 
 			if tt.wantErrMsg == "" {
 				assert.NoError(t, err)
-				assert.Equal(t, 1, len(app.extensions))
-				assert.NotNil(t, app.extensions[0])
+				assert.Equal(t, 1, len(app.extensionsList))
+				assert.Equal(t, 1, len(app.extensionsMap))
+				for _, ext := range app.extensionsList {
+					assert.NotNil(t, ext)
+				}
 			} else {
 				assert.Error(t, err)
 				assert.Equal(t, tt.wantErrMsg, err.Error())
-				assert.Equal(t, 0, len(app.extensions))
+				assert.Equal(t, 0, len(app.extensionsList))
+				assert.Equal(t, 0, len(app.extensionsMap))
 			}
 		})
 	}
@@ -282,4 +288,86 @@ func TestApplication_GetFactory(t *testing.T) {
 	assert.EqualValues(t, exampleExtensionFactory, factory)
 	factory = app.GetFactory(component.KindExtension, "wrongtype")
 	assert.EqualValues(t, nil, factory)
+}
+
+func createExampleApplication(t *testing.T) *Application {
+	// Create some factories.
+	exampleReceiverFactory := &config.ExampleReceiverFactory{}
+	exampleProcessorFactory := &config.ExampleProcessorFactory{}
+	exampleExporterFactory := &config.ExampleExporterFactory{}
+	exampleExtensionFactory := &config.ExampleExtensionFactory{}
+	factories := config.Factories{
+		Receivers: map[string]component.ReceiverFactoryBase{
+			exampleReceiverFactory.Type(): exampleReceiverFactory,
+		},
+		Processors: map[string]component.ProcessorFactoryBase{
+			exampleProcessorFactory.Type(): exampleProcessorFactory,
+		},
+		Exporters: map[string]component.ExporterFactoryBase{
+			exampleExporterFactory.Type(): exampleExporterFactory,
+		},
+		Extensions: map[string]component.ExtensionFactory{
+			exampleExtensionFactory.Type(): exampleExtensionFactory,
+		},
+	}
+
+	app, err := New(Parameters{
+		Factories: factories,
+		ConfigFactory: func(v *viper.Viper, factories config.Factories) (c *configmodels.Config, err error) {
+			config := &configmodels.Config{
+				Receivers: map[string]configmodels.Receiver{
+					exampleReceiverFactory.Type(): exampleReceiverFactory.CreateDefaultConfig(),
+				},
+				Exporters: map[string]configmodels.Exporter{
+					exampleExporterFactory.Type(): exampleExporterFactory.CreateDefaultConfig(),
+				},
+				Extensions: map[string]configmodels.Extension{
+					exampleExtensionFactory.Type(): exampleExtensionFactory.CreateDefaultConfig(),
+				},
+				Service: configmodels.Service{
+					Extensions: []string{exampleExtensionFactory.Type()},
+					Pipelines: map[string]*configmodels.Pipeline{
+						"trace": {
+							Name:       "traces",
+							InputType:  configmodels.TracesDataType,
+							Receivers:  []string{exampleReceiverFactory.Type()},
+							Processors: []string{},
+							Exporters:  []string{exampleExporterFactory.Type()},
+						},
+					},
+				},
+			}
+			return config, nil
+		},
+	})
+	require.NoError(t, err)
+	return app
+}
+
+func TestApplication_GetExtensions(t *testing.T) {
+	app := createExampleApplication(t)
+
+	appDone := make(chan struct{})
+	go func() {
+		defer close(appDone)
+		assert.NoError(t, app.Start())
+	}()
+
+	<-app.readyChan
+
+	// Verify GetExensions(). The results must match what we have in testdata/otelcol-config.yaml.
+
+	extMap := app.GetExtensions()
+	var extTypes []string
+	for cfg, ext := range extMap {
+		assert.NotNil(t, ext)
+		extTypes = append(extTypes, cfg.Type())
+	}
+	sort.Strings(extTypes)
+
+	assert.Equal(t, []string{"exampleextension"}, extTypes)
+
+	// Stop the Application.
+	close(app.stopTestChan)
+	<-appDone
 }

--- a/testbed/testbed/receivers.go
+++ b/testbed/testbed/receivers.go
@@ -22,6 +22,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector/component"
+	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
 	"github.com/open-telemetry/opentelemetry-collector/receiver/jaegerreceiver"
 	"github.com/open-telemetry/opentelemetry-collector/receiver/opencensusreceiver"
 	"github.com/open-telemetry/opentelemetry-collector/receiver/otlpreceiver"
@@ -56,6 +57,11 @@ func (mb *DataReceiverBase) ReportFatalError(err error) {
 
 // GetFactory of the specified kind. Returns the factory for a component type.
 func (mb *DataReceiverBase) GetFactory(kind component.Kind, componentType string) component.Factory {
+	return nil
+}
+
+// Return map of extensions. Only enabled and created extensions will be returned.
+func (mb *DataReceiverBase) GetExtensions() map[configmodels.Extension]component.ServiceExtension {
 	return nil
 }
 


### PR DESCRIPTION
Host.GetExtensions now allows components to discover extensions.
This will be used by upcoming receivers that need to cooperate
with extensions.
