### PR TITLE
Change testbed to send 100 spans/metrics per message for 10K tests.

### DIFF
--- a/testbed/tests/metric_test.go
+++ b/testbed/tests/metric_test.go
@@ -51,8 +51,8 @@ func TestMetric10kDPS(t *testing.T) {
 			testbed.NewOCMetricDataSender(testbed.GetAvailablePort(t)),
 			testbed.NewOCDataReceiver(testbed.GetAvailablePort(t)),
 			testbed.ResourceSpec{
-				ExpectedMaxCPU: 29,
-				ExpectedMaxRAM: 59,
+				ExpectedMaxCPU: 50,
+				ExpectedMaxRAM: 60,
 			},
 		},
 		{
@@ -60,8 +60,8 @@ func TestMetric10kDPS(t *testing.T) {
 			testbed.NewOTLPMetricDataSender(testbed.GetAvailablePort(t)),
 			testbed.NewOTLPDataReceiver(testbed.GetAvailablePort(t)),
 			testbed.ResourceSpec{
-				ExpectedMaxCPU: 69,
-				ExpectedMaxRAM: 59,
+				ExpectedMaxCPU: 50,
+				ExpectedMaxRAM: 60,
 			},
 		},
 	}
@@ -72,7 +72,6 @@ func TestMetric10kDPS(t *testing.T) {
 				t,
 				test.sender,
 				test.receiver,
-				testbed.LoadOptions{ItemsPerBatch: 100},
 				test.resourceSpec,
 			)
 		})

--- a/testbed/tests/scenarios.go
+++ b/testbed/tests/scenarios.go
@@ -135,7 +135,6 @@ func Scenario10kItemsPerSecond(
 	t *testing.T,
 	sender testbed.DataSender,
 	receiver testbed.DataReceiver,
-	loadOptions testbed.LoadOptions,
 	resourceSpec testbed.ResourceSpec,
 ) {
 	resultDir, err := filepath.Abs(path.Join("results", t.Name()))
@@ -157,11 +156,10 @@ func Scenario10kItemsPerSecond(
 	tc.StartBackend()
 	tc.StartAgent()
 
-	if loadOptions.DataItemsPerSecond == 0 {
-		// Use 10k spans or metric data points per second by default.
-		loadOptions.DataItemsPerSecond = 10000
-	}
-	tc.StartLoad(loadOptions)
+	tc.StartLoad(testbed.LoadOptions{
+		DataItemsPerSecond: 10000,
+		ItemsPerBatch:      100,
+	})
 
 	tc.Sleep(tc.Duration)
 

--- a/testbed/tests/trace_test.go
+++ b/testbed/tests/trace_test.go
@@ -53,8 +53,8 @@ func TestTrace10kSPS(t *testing.T) {
 			testbed.NewJaegerGRPCDataSender(testbed.GetAvailablePort(t)),
 			testbed.NewJaegerDataReceiver(testbed.GetAvailablePort(t)),
 			testbed.ResourceSpec{
-				ExpectedMaxCPU: 85,
-				ExpectedMaxRAM: 50,
+				ExpectedMaxCPU: 40,
+				ExpectedMaxRAM: 60,
 			},
 		},
 		{
@@ -62,8 +62,8 @@ func TestTrace10kSPS(t *testing.T) {
 			testbed.NewOCTraceDataSender(testbed.GetAvailablePort(t)),
 			testbed.NewOCDataReceiver(testbed.GetAvailablePort(t)),
 			testbed.ResourceSpec{
-				ExpectedMaxCPU: 52,
-				ExpectedMaxRAM: 50,
+				ExpectedMaxCPU: 40,
+				ExpectedMaxRAM: 60,
 			},
 		},
 		{
@@ -71,8 +71,8 @@ func TestTrace10kSPS(t *testing.T) {
 			testbed.NewOTLPTraceDataSender(testbed.GetAvailablePort(t)),
 			testbed.NewOTLPDataReceiver(testbed.GetAvailablePort(t)),
 			testbed.ResourceSpec{
-				ExpectedMaxCPU: 85,
-				ExpectedMaxRAM: 50,
+				ExpectedMaxCPU: 40,
+				ExpectedMaxRAM: 60,
 			},
 		},
 	}
@@ -83,7 +83,6 @@ func TestTrace10kSPS(t *testing.T) {
 				t,
 				test.sender,
 				test.receiver,
-				testbed.LoadOptions{},
 				test.resourceSpec,
 			)
 		})
@@ -126,7 +125,10 @@ func TestTraceNoBackend10kSPSJaeger(t *testing.T) {
 			})
 
 			tc.StartAgent()
-			tc.StartLoad(testbed.LoadOptions{DataItemsPerSecond: 10000})
+			tc.StartLoad(testbed.LoadOptions{
+				DataItemsPerSecond: 10000,
+				ItemsPerBatch:      10,
+			})
 
 			tc.Sleep(tc.Duration)
 


### PR DESCRIPTION
Before:
```
Test                                    |Result|Duration|CPU Avg%|CPU Max%|RAM Avg MiB|RAM Max MiB|Sent Items|Received Items|
----------------------------------------|------|-------:|-------:|-------:|----------:|----------:|---------:|-------------:|
Metric10kDPS/OpenCensus                 |PASS  |     15s|    16.4|    17.3|         24|         30|    149900|        149900|
Metric10kDPS/OTLP                       |PASS  |     15s|    20.4|    23.9|         26|         32|    150000|        150000|
Trace10kSPS/JaegerGRPC                  |PASS  |     16s|    62.2|    64.7|         24|         29|    149960|        149960|
Trace10kSPS/OpenCensus                  |PASS  |     15s|    36.8|    38.8|         25|         30|    149970|        149970|
Trace10kSPS/OTLP                        |PASS  |     15s|    58.5|    60.3|         26|         33|    149770|        149770|
```

After:
```
Test                                    |Result|Duration|CPU Avg%|CPU Max%|RAM Avg MiB|RAM Max MiB|Sent Items|Received Items|
----------------------------------------|------|-------:|-------:|-------:|----------:|----------:|---------:|-------------:|
Metric10kDPS/OpenCensus                 |PASS  |     16s|    32.1|    33.7|         26|         32|   1049300|       1049300|
Metric10kDPS/OTLP                       |PASS  |     15s|    32.3|    33.4|         28|         34|   1049300|       1049300|
Trace10kSPS/JaegerGRPC                  |PASS  |     15s|    31.0|    33.7|         24|         30|    149900|        149900|
Trace10kSPS/OpenCensus                  |PASS  |     15s|    22.6|    24.4|         25|         31|    149900|        149900|
Trace10kSPS/OTLP                        |PASS  |     15s|    22.7|    25.0|         28|         35|    149900|        149900|
```

The increase in metrics overall is expected because before we sent 10K data points equivalent of 1K metrics with 10 data points, the new logic is to send 10K metrics with 7 data points, so 7 times more data points.