### PR TITLE
[WIP] Add custom data type support

### DIFF
--- a/component/exporter.go
+++ b/component/exporter.go
@@ -62,6 +62,12 @@ type MetricsExporter interface {
 	MetricsExporterBase
 }
 
+// DataExporter is an DataConsumer that is also an Exporter.
+type DataExporter interface {
+	Exporter
+	consumer.DataConsumer
+}
+
 // ExporterFactoryBase defines the common functions for all exporter factories.
 type ExporterFactoryBase interface {
 	Factory
@@ -110,4 +116,19 @@ type ExporterFactory interface {
 	// error will be returned instead.
 	CreateMetricsExporter(ctx context.Context, params ExporterCreateParams,
 		cfg configmodels.Exporter) (MetricsExporter, error)
+}
+
+// DataExporterFactory can create Exporter.
+type DataExporterFactory interface {
+	ExporterFactoryBase
+
+	// CreateExporter creates an exporter based on this config.
+	// If the exporter type does not support the data type or if the config is not valid
+	// error will be returned instead.
+	CreateExporter(
+		ctx context.Context,
+		params ExporterCreateParams,
+		dataType configmodels.DataType,
+		cfg configmodels.Exporter,
+	) (DataExporter, error)
 }

--- a/component/processor.go
+++ b/component/processor.go
@@ -66,6 +66,12 @@ type MetricsProcessor interface {
 	MetricsProcessorBase
 }
 
+// DataProcessor composes DataConsumer with some additional processor-specific functions.
+type DataProcessor interface {
+	Processor
+	consumer.DataConsumer
+}
+
 // ProcessorCapabilities describes the capabilities of a Processor.
 type ProcessorCapabilities struct {
 	// MutatesConsumedData is set to true if Consume* function of the
@@ -130,4 +136,21 @@ type ProcessorFactory interface {
 	// error will be returned instead.
 	CreateMetricsProcessor(ctx context.Context, params ProcessorCreateParams,
 		nextConsumer consumer.MetricsConsumer, cfg configmodels.Processor) (MetricsProcessor, error)
+}
+
+// DataProcessorFactory is factory interface for processors. This is the
+// new factory type that can create new style processors.
+type DataProcessorFactory interface {
+	ProcessorFactoryBase
+
+	// CreateProcessor creates a processor based on this config.
+	// If the processor type does not support the dataType or if the config is not valid
+	// error will be returned instead.
+	CreateProcessor(
+		ctx context.Context,
+		params ProcessorCreateParams,
+		dataType configmodels.DataType,
+		cfg configmodels.Processor,
+		nextConsumer consumer.DataConsumer,
+	) (DataProcessor, error)
 }

--- a/component/receiver.go
+++ b/component/receiver.go
@@ -49,6 +49,16 @@ type MetricsReceiver interface {
 	Receiver
 }
 
+// A DataReceiver is an "arbitrary data"-to-"internal format" converter.
+// Its purpose is to translate data from the wild into internal data format.
+// DataReceiver feeds a consumer.DataConsumer with data.
+//
+// For example it could be Zipkin data source which translates
+// Zipkin spans into consumerdata.DataData.
+type DataReceiver interface {
+	Receiver
+}
+
 // ReceiverFactoryBase defines the common functions for all receiver factories.
 type ReceiverFactoryBase interface {
 	Factory
@@ -116,4 +126,20 @@ type ReceiverFactory interface {
 	// error will be returned instead.
 	CreateMetricsReceiver(ctx context.Context, params ReceiverCreateParams,
 		cfg configmodels.Receiver, nextConsumer consumer.MetricsConsumer) (MetricsReceiver, error)
+}
+
+// DataReceiverFactory can create Receiver and MetricsReceiver.
+type DataReceiverFactory interface {
+	ReceiverFactoryBase
+
+	// CreateReceiver creates a  receiver based on this config.
+	// If the receiver type does not support the dataType or if the config is not valid
+	// error will be returned instead.
+	CreateReceiver(
+		ctx context.Context,
+		params ReceiverCreateParams,
+		dataType configmodels.DataType,
+		cfg configmodels.Receiver,
+		nextConsumer consumer.DataConsumer,
+	) (DataReceiver, error)
 }

--- a/config/config.go
+++ b/config/config.go
@@ -539,17 +539,7 @@ func loadPipelines(v *viper.Viper) (configmodels.Pipelines, error) {
 		var pipelineCfg configmodels.Pipeline
 
 		// Set the type.
-		switch typeStr {
-		case configmodels.TracesDataTypeStr:
-			pipelineCfg.InputType = configmodels.TracesDataType
-		case configmodels.MetricsDataTypeStr:
-			pipelineCfg.InputType = configmodels.MetricsDataType
-		default:
-			return nil, &configError{
-				code: errInvalidPipelineType,
-				msg:  fmt.Sprintf("invalid pipeline type %q (must be metrics or traces)", typeStr),
-			}
-		}
+		pipelineCfg.InputType = configmodels.DataType(typeStr)
 
 		pipelineConfig := ViperSub(pipelinesConfig, key)
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -100,7 +100,7 @@ func TestDecodeConfig(t *testing.T) {
 	assert.Equal(t, 1, len(config.Processors), "Incorrect processors count")
 
 	assert.Equal(t,
-		&ExampleProcessor{
+		&ExampleProcessorCfg{
 			ProcessorSettings: configmodels.ProcessorSettings{
 				TypeVal: "exampleprocessor",
 				NameVal: "exampleprocessor",
@@ -258,7 +258,7 @@ func TestSimpleConfig(t *testing.T) {
 		assert.Equalf(t, 1, len(config.Processors), "TEST[%s]", test.name)
 
 		assert.Equalf(t,
-			&ExampleProcessor{
+			&ExampleProcessorCfg{
 				ProcessorSettings: configmodels.ProcessorSettings{
 					TypeVal: "exampleprocessor",
 					NameVal: "exampleprocessor",
@@ -367,7 +367,6 @@ func TestDecodeConfig_Invalid(t *testing.T) {
 		{name: "unknown-processor-type", expected: errUnknownProcessorType},
 		{name: "invalid-service-extensions-value", expected: errUnmarshalErrorOnService},
 		{name: "invalid-sequence-value", expected: errUnmarshalErrorOnPipeline},
-		{name: "invalid-pipeline-type", expected: errInvalidPipelineType},
 		{name: "invalid-pipeline-type-and-name", expected: errInvalidTypeAndNameKey},
 		{name: "duplicate-extension", expected: errDuplicateExtensionName},
 		{name: "duplicate-receiver", expected: errDuplicateReceiverName},

--- a/config/configmodels/configmodels.go
+++ b/config/configmodels/configmodels.go
@@ -79,36 +79,17 @@ type Processors map[string]Processor
 
 // DataType is the data type that is supported for collection. We currently support
 // collecting metrics and traces, this can expand in the future (e.g. logs, events, etc).
-type DataType int
+
+type DataType string
 
 // Currently supported data types. Add new data types here when new types are supported in the future.
 const (
-	_ DataType = iota // skip 0, start types from 1.
-
 	// TracesDataType is the data type tag for traces.
-	TracesDataType
+	TracesDataType DataType = "traces"
 
 	// MetricsDataType is the data type tag for metrics.
-	MetricsDataType
+	MetricsDataType DataType = "metrics"
 )
-
-// Data type strings.
-const (
-	TracesDataTypeStr  = "traces"
-	MetricsDataTypeStr = "metrics"
-)
-
-// GetString converts data type to string.
-func (dataType DataType) GetString() string {
-	switch dataType {
-	case TracesDataType:
-		return TracesDataTypeStr
-	case MetricsDataType:
-		return MetricsDataTypeStr
-	default:
-		panic("unknown data type")
-	}
-}
 
 // Pipeline defines a single pipeline.
 type Pipeline struct {

--- a/config/example_factories.go
+++ b/config/example_factories.go
@@ -25,6 +25,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
 	"github.com/open-telemetry/opentelemetry-collector/consumer"
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
+	"github.com/open-telemetry/opentelemetry-collector/internal/data"
 )
 
 // ExampleReceiver is for testing purposes. We are defining an example config and factory
@@ -60,7 +61,8 @@ func (f *ExampleReceiverFactory) CustomUnmarshaler() component.CustomUnmarshaler
 func (f *ExampleReceiverFactory) CreateDefaultConfig() configmodels.Receiver {
 	return &ExampleReceiver{
 		ReceiverSettings: configmodels.ReceiverSettings{
-			TypeVal:  "examplereceiver",
+			TypeVal:  f.Type(),
+			NameVal:  string(f.Type()),
 			Endpoint: "localhost:1000",
 		},
 		ExtraSetting:     "some string",
@@ -120,12 +122,36 @@ func (f *ExampleReceiverFactory) CreateMetricsReceiver(
 	return receiver, nil
 }
 
+func (f *ExampleReceiverFactory) CreateReceiver(
+	ctx context.Context,
+	params component.ReceiverCreateParams,
+	dataType configmodels.DataType,
+	cfg configmodels.Receiver,
+	nextConsumer consumer.DataConsumer,
+) (component.DataReceiver, error) {
+	// There must be one receiver for both metrics and traces. We maintain a map of
+	// receivers per config.
+
+	// Check to see if there is already a receiver for this config.
+	receiver, ok := exampleReceivers[cfg]
+	if !ok {
+		receiver = &ExampleReceiverProducer{}
+		// Remember the receiver in the map
+		exampleReceivers[cfg] = receiver
+	}
+	receiver.DataConsumer = nextConsumer
+
+	return receiver, nil
+
+}
+
 // ExampleReceiverProducer allows producing traces and metrics for testing purposes.
 type ExampleReceiverProducer struct {
-	TraceConsumer   consumer.TraceConsumerOld
 	Started         bool
 	Stopped         bool
+	TraceConsumer   consumer.TraceConsumerOld
 	MetricsConsumer consumer.MetricsConsumerOld
+	DataConsumer    consumer.DataConsumer
 }
 
 // Start tells the receiver to start its processing.
@@ -199,7 +225,8 @@ func (f *MultiProtoReceiverFactory) CustomUnmarshaler() component.CustomUnmarsha
 // CreateDefaultConfig creates the default configuration for the Receiver.
 func (f *MultiProtoReceiverFactory) CreateDefaultConfig() configmodels.Receiver {
 	return &MultiProtoReceiver{
-		TypeVal: "multireceiver",
+		TypeVal: f.Type(),
+		NameVal: string(f.Type()),
 		Protocols: map[string]MultiProtoReceiverOneCfg{
 			"http": {
 				Endpoint:     "example.com:8888",
@@ -256,7 +283,10 @@ func (f *ExampleExporterFactory) Type() configmodels.Type {
 // CreateDefaultConfig creates the default configuration for the Exporter.
 func (f *ExampleExporterFactory) CreateDefaultConfig() configmodels.Exporter {
 	return &ExampleExporter{
-		ExporterSettings: configmodels.ExporterSettings{TypeVal: f.Type()},
+		ExporterSettings: configmodels.ExporterSettings{
+			TypeVal: f.Type(),
+			NameVal: string(f.Type()),
+		},
 		ExtraSetting:     "some export string",
 		ExtraMapSetting:  nil,
 		ExtraListSetting: nil,
@@ -273,10 +303,23 @@ func (f *ExampleExporterFactory) CreateMetricsExporter(logger *zap.Logger, cfg c
 	return &ExampleExporterConsumer{}, nil
 }
 
+func (f *ExampleExporterFactory) CreateExporter(
+	ctx context.Context,
+	params component.ExporterCreateParams,
+	dataType configmodels.DataType,
+	cfg configmodels.Exporter,
+) (component.DataExporter, error) {
+	if dataType == "exampledata" {
+		return &ExampleExporterConsumer{}, nil
+	}
+	return nil, configerror.ErrDataTypeIsNotSupported
+}
+
 // ExampleExporterConsumer stores consumed traces and metrics for testing purposes.
 type ExampleExporterConsumer struct {
 	Traces           []consumerdata.TraceData
 	Metrics          []consumerdata.MetricsData
+	Data             []data.Custom
 	ExporterStarted  bool
 	ExporterShutdown bool
 }
@@ -301,6 +344,19 @@ func (exp *ExampleExporterConsumer) ConsumeMetricsData(ctx context.Context, md c
 	return nil
 }
 
+func (exp *ExampleExporterConsumer) ConsumeData(ctx context.Context, td data.Custom) error {
+	exp.Data = append(exp.Data, td)
+	return nil
+}
+
+type ExampleCustomData struct {
+	Data string
+}
+
+func (ecd *ExampleCustomData) Clone() data.Custom {
+	return &ExampleCustomData{ecd.Data}
+}
+
 // Name returns the name of the exporter.
 func (exp *ExampleExporterConsumer) Name() string {
 	return "exampleexporter"
@@ -312,9 +368,9 @@ func (exp *ExampleExporterConsumer) Shutdown(context.Context) error {
 	return nil
 }
 
-// ExampleProcessor is for testing purposes. We are defining an example config and factory
+// ExampleProcessorCfg is for testing purposes. We are defining an example config and factory
 // for "exampleprocessor" processor type.
-type ExampleProcessor struct {
+type ExampleProcessorCfg struct {
 	configmodels.ProcessorSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
 	ExtraSetting                   string                   `mapstructure:"extra"`
 	ExtraMapSetting                map[string]string        `mapstructure:"extra_map"`
@@ -332,11 +388,14 @@ func (f *ExampleProcessorFactory) Type() configmodels.Type {
 
 // CreateDefaultConfig creates the default configuration for the Processor.
 func (f *ExampleProcessorFactory) CreateDefaultConfig() configmodels.Processor {
-	return &ExampleProcessor{
-		ProcessorSettings: configmodels.ProcessorSettings{},
-		ExtraSetting:      "some export string",
-		ExtraMapSetting:   nil,
-		ExtraListSetting:  nil,
+	return &ExampleProcessorCfg{
+		ProcessorSettings: configmodels.ProcessorSettings{
+			TypeVal: f.Type(),
+			NameVal: string(f.Type()),
+		},
+		ExtraSetting:     "some export string",
+		ExtraMapSetting:  nil,
+		ExtraListSetting: nil,
 	}
 }
 
@@ -356,6 +415,39 @@ func (f *ExampleProcessorFactory) CreateMetricsProcessor(
 	cfg configmodels.Processor,
 ) (component.MetricsProcessorOld, error) {
 	return nil, configerror.ErrDataTypeIsNotSupported
+}
+
+func (f *ExampleProcessorFactory) CreateProcessor(
+	ctx context.Context,
+	params component.ProcessorCreateParams,
+	dataType configmodels.DataType,
+	cfg configmodels.Processor,
+	nextConsumer consumer.DataConsumer,
+) (component.DataProcessor, error) {
+	if dataType == "exampledata" {
+		return &ExampleProcessor{nextConsumer}, nil
+	}
+	return nil, configerror.ErrDataTypeIsNotSupported
+}
+
+type ExampleProcessor struct {
+	nextConsumer consumer.DataConsumer
+}
+
+func (ep *ExampleProcessor) Start(ctx context.Context, host component.Host) error {
+	return nil
+}
+
+func (ep *ExampleProcessor) Shutdown(ctx context.Context) error {
+	return nil
+}
+
+func (ep *ExampleProcessor) GetCapabilities() component.ProcessorCapabilities {
+	return component.ProcessorCapabilities{MutatesConsumedData: false}
+}
+
+func (ep *ExampleProcessor) ConsumeData(ctx context.Context, td data.Custom) error {
+	return ep.nextConsumer.ConsumeData(ctx, td)
 }
 
 // ExampleExtensionCfg is for testing purposes. We are defining an example config and factory
@@ -387,10 +479,13 @@ func (f *ExampleExtensionFactory) Type() configmodels.Type {
 // CreateDefaultConfig creates the default configuration for the Extension.
 func (f *ExampleExtensionFactory) CreateDefaultConfig() configmodels.Extension {
 	return &ExampleExtensionCfg{
-		ExtensionSettings: configmodels.ExtensionSettings{TypeVal: f.Type()},
-		ExtraSetting:      "extra string setting",
-		ExtraMapSetting:   nil,
-		ExtraListSetting:  nil,
+		ExtensionSettings: configmodels.ExtensionSettings{
+			TypeVal: f.Type(),
+			NameVal: string(f.Type()),
+		},
+		ExtraSetting:     "extra string setting",
+		ExtraMapSetting:  nil,
+		ExtraListSetting: nil,
 	}
 }
 

--- a/consumer/consumer.go
+++ b/consumer/consumer.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-collector/consumer/pdata"
+	"github.com/open-telemetry/opentelemetry-collector/internal/data"
 )
 
 // MetricsConsumerBase defines a common interface for MetricsConsumerOld and MetricsConsumer.
@@ -59,4 +60,11 @@ type TraceConsumer interface {
 	TraceConsumerBase
 	// ConsumeTraces receives pdata.Traces for processing.
 	ConsumeTraces(ctx context.Context, td pdata.Traces) error
+}
+
+// DataConsumer is an interface that receives data.Custom, processes it
+// as needed, and sends it to the next processing node if any or to the destination.
+type DataConsumer interface {
+	// ConsumeData receives data.Custom for processing.
+	ConsumeData(ctx context.Context, td data.Custom) error
 }

--- a/internal/data/custom.go
+++ b/internal/data/custom.go
@@ -1,0 +1,18 @@
+// Copyright OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package data
+
+type Custom interface {
+	Clone() Custom
+}

--- a/processor/fanoutconnector.go
+++ b/processor/fanoutconnector.go
@@ -22,6 +22,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-collector/consumer/converter"
 	"github.com/open-telemetry/opentelemetry-collector/consumer/pdata"
+	"github.com/open-telemetry/opentelemetry-collector/internal/data"
 )
 
 // This file contains implementations of Trace/Metrics connectors
@@ -149,6 +150,26 @@ func (tfc traceFanOutConnector) ConsumeTraces(ctx context.Context, td pdata.Trac
 	var errs []error
 	for _, tc := range tfc {
 		if err := tc.ConsumeTraces(ctx, td); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return componenterror.CombineErrors(errs)
+}
+
+// NewFanOutConnector wraps multiple new type  consumers in a single one.
+func NewFanOutConnector(tcs []consumer.DataConsumer) consumer.DataConsumer {
+	return FanOutConnector(tcs)
+}
+
+type FanOutConnector []consumer.DataConsumer
+
+var _ consumer.DataConsumer = (*FanOutConnector)(nil)
+
+// Consume exports the span data to all  consumers wrapped by the current one.
+func (tfc FanOutConnector) ConsumeData(ctx context.Context, td data.Custom) error {
+	var errs []error
+	for _, tc := range tfc {
+		if err := tc.ConsumeData(ctx, td); err != nil {
 			errs = append(errs, err)
 		}
 	}

--- a/service/builder/exporters_builder_test.go
+++ b/service/builder/exporters_builder_test.go
@@ -103,6 +103,70 @@ func TestExportersBuilder_Build(t *testing.T) {
 	// TODO: once we have an exporter that supports metrics data type test it too.
 }
 
+func TestExportersBuilder_BuildCustom(t *testing.T) {
+	factories, err := config.ExampleComponents()
+	assert.Nil(t, err)
+
+	cfg := &configmodels.Config{
+		Exporters: map[string]configmodels.Exporter{
+			"exampleexporter": &config.ExampleExporter{
+				ExporterSettings: configmodels.ExporterSettings{
+					NameVal: "exampleexporter",
+					TypeVal: "exampleexporter",
+				},
+			},
+		},
+
+		Service: configmodels.Service{
+			Pipelines: map[string]*configmodels.Pipeline{
+				"exampledata": {
+					Name:      "exampledata",
+					InputType: "exampledata",
+					Exporters: []string{"exampleexporter"},
+				},
+			},
+		},
+	}
+
+	exporters, err := NewExportersBuilder(zap.NewNop(), cfg, factories.Exporters).Build()
+
+	assert.NoError(t, err)
+	require.NotNil(t, exporters)
+
+	e1 := exporters[cfg.Exporters["exampleexporter"]]
+
+	// Ensure exporter has its fields correctly populated.
+	require.NotNil(t, e1)
+	assert.Equal(t, 1, len(e1.de))
+	assert.Nil(t, e1.te)
+	assert.Nil(t, e1.me)
+
+	// Ensure it can be started.
+	err = exporters.StartAll(context.Background(), componenttest.NewNopHost())
+	assert.NoError(t, err)
+
+	// Ensure it can be stopped.
+	err = e1.Shutdown(context.Background())
+	assert.NoError(t, err)
+
+	// Remove the pipeline so that the exporter is not attached to any pipeline.
+	// This should result in creating an exporter that has none of consumption
+	// functions set.
+	delete(cfg.Service.Pipelines, "exampledata")
+	exporters, err = NewExportersBuilder(zap.NewNop(), cfg, factories.Exporters).Build()
+	assert.NotNil(t, exporters)
+	assert.Nil(t, err)
+
+	e1 = exporters[cfg.Exporters["exampleexporter"]]
+
+	// Ensure exporter has its fields correctly populated, ie Trace Exporter and
+	// Metrics Exporter are nil.
+	require.NotNil(t, e1)
+	assert.Nil(t, e1.te)
+	assert.Nil(t, e1.me)
+	assert.Equal(t, 0, len(e1.de))
+}
+
 func TestExportersBuilder_StartAll(t *testing.T) {
 	exporters := make(Exporters)
 	expCfg := &configmodels.ExporterSettings{}

--- a/service/builder/testdata/pipelines_builder.yaml
+++ b/service/builder/testdata/pipelines_builder.yaml
@@ -38,3 +38,7 @@ service:
     metrics/3:
       receivers: [examplereceiver/3]
       exporters: [exampleexporter/2]
+
+    exampledata:
+      receivers: [examplereceiver/3]
+      exporters: [exampleexporter/2]

--- a/service/service.go
+++ b/service/service.go
@@ -520,7 +520,7 @@ func (app *Application) getPipelinesSummaryTableData() internal.SummaryPipelines
 	for c, p := range app.builtPipelines {
 		row := internal.SummaryPipelinesTableRowData{
 			FullName:            c.Name,
-			InputType:           c.InputType.GetString(),
+			InputType:           string(c.InputType),
 			MutatesConsumedData: p.MutatesConsumedData,
 			Receivers:           c.Receivers,
 			Processors:          c.Processors,


### PR DESCRIPTION
This will allow to have pipelines of data types that are not one of the
builtin type: traces and metrics.

See design.md for detailed description of how custom data types work.
