### PR TITLE
Add maps iterators similar Java's "ForEach"

### DIFF
--- a/internal/data/common.go
+++ b/internal/data/common.go
@@ -446,73 +446,20 @@ func (am AttributeMap) Cap() int {
 	return len(*am.orig)
 }
 
-// Iter returns an iterator for ranging over a map.
-// Similar with Reflect.MapRange.
-//
-// Call Next to advance the iterator, and Key/Value to access each entry. Next returns false when the iterator is
-// exhausted. StringMapIter follows the same iteration semantics as a range statement.
+// ForEach iterates over the every elements in the map by calling the provided func.
 //
 // Example:
 //
-// it := sm.Range()
-// for iter.Next() {
-//	 k := iter.Key()
-//	 v := iter.Value()
-//	 ...
-// }
-func (am AttributeMap) Range() *AttributeMapIter {
-	return newAttributeMapIter(am)
-}
-
-// AttributeMapIter is an iterator for ranging over a map.
-// Similar with Reflect.MapIter.
-type AttributeMapIter struct {
-	orig []*otlpcommon.AttributeKeyValue
-	pos  int
-}
-
-func newAttributeMapIter(sm AttributeMap) *AttributeMapIter {
-	return &AttributeMapIter{orig: *sm.orig, pos: -1}
-}
-
-// Key returns the key of the iterator's current map entry.
-func (it *AttributeMapIter) Key() string {
-	if it.pos == -1 {
-		panic("MapIter.Key called before Next")
+// it := sm.ForEach(func(k string, v StringValue) {
+//   ...
+// })
+func (am AttributeMap) ForEach(f func(k string, v AttributeValue)) {
+	for _, kv := range *am.orig {
+		if kv == nil {
+			continue
+		}
+		f(kv.Key, AttributeValue{kv})
 	}
-	if it.pos >= len(it.orig) {
-		panic("MapIter.Key called on exhausted iterator")
-	}
-
-	return it.orig[it.pos].Key
-}
-
-// Value returns the value of the iterator's current map entry.
-func (it *AttributeMapIter) Value() AttributeValue {
-	if it.pos == -1 {
-		panic("MapIter.Value called before Next")
-	}
-	if it.pos >= len(it.orig) {
-		panic("MapIter.Value called on exhausted iterator")
-	}
-
-	return AttributeValue{it.orig[it.pos]}
-}
-
-// Next advances the map iterator and reports whether there is another
-// entry. It returns false when the iterator is exhausted; subsequent
-// calls to Key, Value, or Next will panic.
-func (it *AttributeMapIter) Next() bool {
-	if it.pos >= len(it.orig) {
-		panic("MapIter.Next called on exhausted iterator")
-	}
-	it.pos++
-	// Iterate until the end of the slice or first non nil element.
-	for it.pos < len(it.orig) && it.orig[it.pos] == nil {
-		it.pos++
-	}
-
-	return it.pos < len(it.orig)
 }
 
 // StringValue stores a string value.
@@ -643,73 +590,20 @@ func (sm StringMap) Cap() int {
 	return len(*sm.orig)
 }
 
-// Iter returns an iterator for ranging over a map.
-// Similar with Reflect.MapRange.
-//
-// Call Next to advance the iterator, and Key/Value to access each entry. Next returns false when the iterator is
-// exhausted. StringMapIter follows the same iteration semantics as a range statement.
+// ForEach iterates over the every elements in the map by calling the provided func.
 //
 // Example:
 //
-// it := sm.Range()
-// for iter.Next() {
-//	 k := iter.Key()
-//	 v := iter.Value()
-//	 ...
-// }
-func (sm StringMap) Range() *StringMapIter {
-	return newStringMapIter(sm)
-}
-
-// StringMapIter is an iterator for ranging over a map.
-// Similar with Reflect.MapIter.
-type StringMapIter struct {
-	orig []*otlpcommon.StringKeyValue
-	pos  int
-}
-
-func newStringMapIter(sm StringMap) *StringMapIter {
-	return &StringMapIter{orig: *sm.orig, pos: -1}
-}
-
-// Key returns the key of the iterator's current map entry.
-func (it *StringMapIter) Key() string {
-	if it.pos == -1 {
-		panic("MapIter.Key called before Next")
+// it := sm.ForEach(func(k string, v StringValue) {
+//   ...
+// })
+func (sm StringMap) ForEach(f func(k string, v StringValue)) {
+	for _, kv := range *sm.orig {
+		if kv == nil {
+			continue
+		}
+		f(kv.Key, StringValue{kv})
 	}
-	if it.pos >= len(it.orig) {
-		panic("MapIter.Key called on exhausted iterator")
-	}
-
-	return it.orig[it.pos].Key
-}
-
-// Value returns the value of the iterator's current map entry.
-func (it *StringMapIter) Value() StringValue {
-	if it.pos == -1 {
-		panic("MapIter.Key called before Next")
-	}
-	if it.pos >= len(it.orig) {
-		panic("MapIter.Key called on exhausted iterator")
-	}
-
-	return StringValue{it.orig[it.pos]}
-}
-
-// Next advances the map iterator and reports whether there is another
-// entry. It returns false when the iterator is exhausted; subsequent
-// calls to Key, Value, or Next will panic.
-func (it *StringMapIter) Next() bool {
-	if it.pos >= len(it.orig) {
-		panic("MapIter.Next called on exhausted iterator")
-	}
-	it.pos++
-	// Iterate until the end of the slice or first non nil element.
-	for it.pos < len(it.orig) && it.orig[it.pos] == nil {
-		it.pos++
-	}
-
-	return it.pos < len(it.orig)
 }
 
 // Sort sorts the entries in the StringMap so two instances can be compared.

--- a/internal/data/common_test.go
+++ b/internal/data/common_test.go
@@ -70,6 +70,8 @@ func TestNewAttributeValueSlice(t *testing.T) {
 }
 
 func TestNilAttributeMap(t *testing.T) {
+	assert.EqualValues(t, 0, NewAttributeMap().Cap())
+
 	val, exist := NewAttributeMap().Get("test_key")
 	assert.False(t, exist)
 	assert.EqualValues(t, AttributeValue{nil}, val)
@@ -137,7 +139,6 @@ func TestNilAttributeMap(t *testing.T) {
 	deleteMap := NewAttributeMap()
 	assert.False(t, deleteMap.Delete("k"))
 	assert.EqualValues(t, NewAttributeMap(), deleteMap)
-	assert.EqualValues(t, 0, NewAttributeMap().Len())
 
 	// Test Sort
 	assert.EqualValues(t, NewAttributeMap(), NewAttributeMap().Sort())
@@ -282,7 +283,67 @@ func TestAttributeMapWithNilValues(t *testing.T) {
 	assert.EqualValues(t, AttributeMap{orig: &origWithNil}, sm.Sort())
 }
 
+func TestAttributeMapIterationNil(t *testing.T) {
+	assert.False(t, NewAttributeMap().Range().Next())
+}
+
+func TestAttributeMapIteration(t *testing.T) {
+	rawMap := map[string]AttributeValue{
+		"k_string": NewAttributeValueString("123"),
+		"k_int":    NewAttributeValueInt(123),
+		"k_double": NewAttributeValueDouble(1.23),
+		"k_bool":   NewAttributeValueBool(true),
+	}
+	sm := NewAttributeMap().InitFromMap(rawMap)
+	assert.EqualValues(t, 4, sm.Cap())
+
+	it := sm.Range()
+	for it.Next() {
+		assert.True(t, it.Value().Equal(rawMap[it.Key()]))
+		delete(rawMap, it.Key())
+	}
+	assert.EqualValues(t, 0, len(rawMap))
+}
+
+func TestAttributeMapIterationWithNils(t *testing.T) {
+	rawMap := map[string]AttributeValue{
+		"k_string": NewAttributeValueString("123"),
+		"k_int":    NewAttributeValueInt(123),
+		"k_double": NewAttributeValueDouble(1.23),
+		"k_bool":   NewAttributeValueBool(true),
+	}
+	rawOrigWithNil := []*otlpcommon.AttributeKeyValue{
+		nil,
+		newAttributeKeyValueString("k_string", "123"),
+		nil,
+		newAttributeKeyValueInt("k_int", 123),
+		nil,
+		newAttributeKeyValueDouble("k_double", 1.23),
+		nil,
+		newAttributeKeyValueBool("k_bool", true),
+		nil,
+	}
+	sm := AttributeMap{
+		orig: &rawOrigWithNil,
+	}
+	assert.EqualValues(t, 9, sm.Cap())
+
+	it := sm.Range()
+	assert.Panics(t, func() { it.Key() })
+	assert.Panics(t, func() { it.Value() })
+	for it.Next() {
+		assert.True(t, it.Value().Equal(rawMap[it.Key()]))
+		delete(rawMap, it.Key())
+	}
+	assert.Panics(t, func() { it.Key() })
+	assert.Panics(t, func() { it.Value() })
+	assert.Panics(t, func() { it.Next() })
+	assert.EqualValues(t, 0, len(rawMap))
+}
+
 func TestNilStringMap(t *testing.T) {
+	assert.EqualValues(t, 0, NewStringMap().Cap())
+
 	val, exist := NewStringMap().Get("test_key")
 	assert.False(t, exist)
 	assert.EqualValues(t, StringValue{nil}, val)
@@ -302,7 +363,6 @@ func TestNilStringMap(t *testing.T) {
 	deleteMap := NewStringMap()
 	assert.False(t, deleteMap.Delete("k"))
 	assert.EqualValues(t, NewStringMap(), deleteMap)
-	assert.EqualValues(t, 0, NewStringMap().Len())
 
 	// Test Sort
 	assert.EqualValues(t, NewStringMap(), NewStringMap().Sort())
@@ -362,7 +422,7 @@ func TestStringMap(t *testing.T) {
 	origRawMap := map[string]string{"k0": "v0", "k1": "v1", "k2": "v2"}
 	origMap := NewStringMap().InitFromMap(origRawMap)
 	sm := NewStringMap().InitFromMap(origRawMap)
-	assert.EqualValues(t, 3, sm.Len())
+	assert.EqualValues(t, 3, sm.Cap())
 
 	val, exist := sm.Get("k2")
 	assert.True(t, exist)
@@ -375,61 +435,105 @@ func TestStringMap(t *testing.T) {
 	sm.Insert("k1", "v1")
 	assert.EqualValues(t, origMap.Sort(), sm.Sort())
 	sm.Insert("k3", "v3")
-	assert.EqualValues(t, 4, sm.Len())
+	assert.EqualValues(t, 4, sm.Cap())
 	assert.EqualValues(t, NewStringMap().InitFromMap(map[string]string{"k0": "v0", "k1": "v1", "k2": "v2", "k3": "v3"}).Sort(), sm.Sort())
 	assert.True(t, sm.Delete("k3"))
-	assert.EqualValues(t, 3, sm.Len())
+	assert.EqualValues(t, 3, sm.Cap())
 	assert.EqualValues(t, origMap.Sort(), sm.Sort())
 
 	sm.Update("k3", "v3")
-	assert.EqualValues(t, 3, sm.Len())
+	assert.EqualValues(t, 3, sm.Cap())
 	assert.EqualValues(t, origMap.Sort(), sm.Sort())
 	sm.Update("k2", "v3")
-	assert.EqualValues(t, 3, sm.Len())
+	assert.EqualValues(t, 3, sm.Cap())
 	assert.EqualValues(t, NewStringMap().InitFromMap(map[string]string{"k0": "v0", "k1": "v1", "k2": "v3"}).Sort(), sm.Sort())
 	sm.Update("k2", "v2")
-	assert.EqualValues(t, 3, sm.Len())
+	assert.EqualValues(t, 3, sm.Cap())
 	assert.EqualValues(t, origMap.Sort(), sm.Sort())
 
 	sm.Upsert("k3", "v3")
-	assert.EqualValues(t, 4, sm.Len())
+	assert.EqualValues(t, 4, sm.Cap())
 	assert.EqualValues(t, NewStringMap().InitFromMap(map[string]string{"k0": "v0", "k1": "v1", "k2": "v2", "k3": "v3"}).Sort(), sm.Sort())
 	sm.Upsert("k1", "v5")
-	assert.EqualValues(t, 4, sm.Len())
+	assert.EqualValues(t, 4, sm.Cap())
 	assert.EqualValues(t, NewStringMap().InitFromMap(map[string]string{"k0": "v0", "k1": "v5", "k2": "v2", "k3": "v3"}).Sort(), sm.Sort())
 	sm.Upsert("k1", "v1")
-	assert.EqualValues(t, 4, sm.Len())
+	assert.EqualValues(t, 4, sm.Cap())
 	assert.EqualValues(t, NewStringMap().InitFromMap(map[string]string{"k0": "v0", "k1": "v1", "k2": "v2", "k3": "v3"}).Sort(), sm.Sort())
 	assert.True(t, sm.Delete("k3"))
-	assert.EqualValues(t, 3, sm.Len())
+	assert.EqualValues(t, 3, sm.Cap())
 	assert.EqualValues(t, origMap.Sort(), sm.Sort())
 
-	assert.False(t, sm.Delete("k3"))
-	assert.EqualValues(t, 3, sm.Len())
+	assert.EqualValues(t, false, sm.Delete("k3"))
+	assert.EqualValues(t, 3, sm.Cap())
 	assert.EqualValues(t, origMap.Sort(), sm.Sort())
 
 	assert.True(t, sm.Delete("k0"))
-	assert.EqualValues(t, 2, sm.Len())
+	assert.EqualValues(t, 2, sm.Cap())
 	assert.EqualValues(t, NewStringMap().InitFromMap(map[string]string{"k1": "v1", "k2": "v2"}).Sort(), sm.Sort())
 	assert.True(t, sm.Delete("k2"))
-	assert.EqualValues(t, 1, sm.Len())
+	assert.EqualValues(t, 1, sm.Cap())
 	assert.EqualValues(t, NewStringMap().InitFromMap(map[string]string{"k1": "v1"}).Sort(), sm.Sort())
 	assert.True(t, sm.Delete("k1"))
-	assert.EqualValues(t, 0, sm.Len())
+	assert.EqualValues(t, 0, sm.Cap())
+}
+
+func TestStringMapIterationNil(t *testing.T) {
+	assert.False(t, NewStringMap().Range().Next())
 }
 
 func TestStringMapIteration(t *testing.T) {
-	sm := NewStringMap().InitFromMap(map[string]string{"k0": "v0", "k1": "v1", "k2": "v2"})
-	assert.EqualValues(t, 3, sm.Len())
-	sm.Sort()
-	for i := 0; i < sm.Len(); i++ {
-		k, v := sm.GetStringKeyValue(i)
-		assert.EqualValues(t, "k"+strconv.Itoa(i), k)
-		assert.EqualValues(t, "v"+strconv.Itoa(i), v.Value())
+	rawMap := map[string]string{"k0": "v0", "k1": "v1", "k2": "v2"}
+	sm := NewStringMap().InitFromMap(rawMap)
+	assert.EqualValues(t, 3, sm.Cap())
+
+	it := sm.Range()
+	for it.Next() {
+		assert.EqualValues(t, rawMap[it.Key()], it.Value().Value())
+		delete(rawMap, it.Key())
 	}
+	assert.EqualValues(t, 0, len(rawMap))
 }
 
-func BenchmarkSetValue(b *testing.B) {
+func TestStringMapIterationWithNils(t *testing.T) {
+	rawMap := map[string]string{"k0": "v0", "k1": "v1", "k2": "v2"}
+	rawOrigWithNil := []*otlpcommon.StringKeyValue{
+		nil,
+		{
+			Key:   "k0",
+			Value: "v0",
+		},
+		nil,
+		{
+			Key:   "k1",
+			Value: "v1",
+		},
+		nil,
+		{
+			Key:   "k2",
+			Value: "v2",
+		},
+		nil,
+	}
+	sm := StringMap{
+		orig: &rawOrigWithNil,
+	}
+	assert.EqualValues(t, 7, sm.Cap())
+
+	it := sm.Range()
+	assert.Panics(t, func() { it.Key() })
+	assert.Panics(t, func() { it.Value() })
+	for it.Next() {
+		assert.EqualValues(t, rawMap[it.Key()], it.Value().Value())
+		delete(rawMap, it.Key())
+	}
+	assert.Panics(t, func() { it.Key() })
+	assert.Panics(t, func() { it.Value() })
+	assert.Panics(t, func() { it.Next() })
+	assert.EqualValues(t, 0, len(rawMap))
+}
+
+func BenchmarkAttributeValue_CopyFrom(b *testing.B) {
 	av := NewAttributeValueString("k")
 	c := NewAttributeValueInt(123)
 
@@ -442,7 +546,7 @@ func BenchmarkSetValue(b *testing.B) {
 	}
 }
 
-func BenchmarkSetIntVal(b *testing.B) {
+func BenchmarkAttributeValue_SetIntVal(b *testing.B) {
 	av := NewAttributeValueString("k")
 
 	b.ResetTimer()
@@ -451,6 +555,101 @@ func BenchmarkSetIntVal(b *testing.B) {
 	}
 	if av.IntVal() != int64(b.N-1) {
 		b.Fail()
+	}
+}
+
+func BenchmarkAttributeMap_Range(b *testing.B) {
+	const numElements = 50
+	rawOrigWithNil := make([]*otlpcommon.AttributeKeyValue, 2*numElements)
+	for i := 0; i < numElements; i++ {
+		rawOrigWithNil[i*2] = &otlpcommon.AttributeKeyValue{
+			Key:         "k" + strconv.Itoa(i),
+			StringValue: "v" + strconv.Itoa(i),
+		}
+	}
+	sm := AttributeMap{
+		orig: &rawOrigWithNil,
+	}
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		numEls := 0
+		it := sm.Range()
+		for it.Next() {
+			numEls++
+		}
+		if numEls != numElements {
+			b.Fail()
+		}
+	}
+}
+
+func BenchmarkAttributeMap_Range_WithMap(b *testing.B) {
+	const numElements = 50
+	rawOrig := make(map[string]AttributeValue, numElements)
+	for i := 0; i < numElements; i++ {
+		key := "k" + strconv.Itoa(i)
+		rawOrig[key] = NewAttributeValueString("v" + strconv.Itoa(i))
+	}
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		numEls := 0
+		for _, v := range rawOrig {
+			if v.orig == nil {
+				continue
+			}
+			numEls++
+		}
+		if numEls != numElements {
+			b.Fail()
+		}
+	}
+}
+
+func BenchmarkStringMap_Range(b *testing.B) {
+	const numElements = 50
+	rawOrigWithNil := make([]*otlpcommon.StringKeyValue, 2*numElements)
+	for i := 0; i < numElements; i++ {
+		rawOrigWithNil[i*2] = &otlpcommon.StringKeyValue{
+			Key:   "k" + strconv.Itoa(i),
+			Value: "v" + strconv.Itoa(i),
+		}
+	}
+	sm := StringMap{
+		orig: &rawOrigWithNil,
+	}
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		numEls := 0
+		it := sm.Range()
+		for it.Next() {
+			numEls++
+		}
+		if numEls != numElements {
+			b.Fail()
+		}
+	}
+}
+
+func BenchmarkStringMap_Range_WithMap(b *testing.B) {
+	const numElements = 50
+	rawOrig := make(map[string]StringValue, numElements)
+	for i := 0; i < numElements; i++ {
+		key := "k" + strconv.Itoa(i)
+		rawOrig[key] = StringValue{newStringKeyValue(key, "v"+strconv.Itoa(i))}
+	}
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		numEls := 0
+		for _, v := range rawOrig {
+			if v.orig == nil {
+				continue
+			}
+			numEls++
+		}
+		if numEls != numElements {
+			b.Fail()
+		}
 	}
 }
 

--- a/internal/processor/filterspan/filterspan.go
+++ b/internal/processor/filterspan/filterspan.go
@@ -276,7 +276,7 @@ func (ma attributesMatcher) match(span data.Span) bool {
 	attrs := span.Attributes()
 	// At this point, it is expected of the span to have attributes because of
 	// len(ma) != 0. This means for spans with no attributes, it does not match.
-	if attrs.Len() == 0 {
+	if attrs.Cap() == 0 {
 		return false
 	}
 

--- a/processor/spanprocessor/span.go
+++ b/processor/spanprocessor/span.go
@@ -144,7 +144,7 @@ func (sp *spanProcessor) processFromAttributes(span data.Span) {
 	}
 
 	attrs := span.Attributes()
-	if attrs.Len() == 0 {
+	if attrs.Cap() == 0 {
 		// There are no attributes to create span name from.
 		return
 	}

--- a/testbed/tests/trace_test.go
+++ b/testbed/tests/trace_test.go
@@ -385,7 +385,7 @@ func TestTraceAttributesProcessor(t *testing.T) {
 			// verifySpan verifies that attributes was added to the internal data span.
 			verifySpan := func(span data.Span) {
 				require.NotNil(t, span)
-				require.Equal(t, span.Attributes().Len(), 1)
+				require.Equal(t, span.Attributes().Cap(), 1)
 				attrVal, ok := span.Attributes().Get("new_attr")
 				assert.True(t, ok)
 				assert.EqualValues(t, "string value", attrVal.StringVal())
@@ -409,7 +409,7 @@ func TestTraceAttributesProcessor(t *testing.T) {
 
 			verifySingleSpan(t, tc, nodeToExclude, spanToInclude, func(span data.Span) {
 				// Verify attributes was not added to the new internal data span.
-				assert.Equal(t, span.Attributes().Len(), 0)
+				assert.Equal(t, span.Attributes().Cap(), 0)
 			}, func(span *tracepb.Span) {
 				// Verify attributes was not added to the OC span.
 				assert.Nil(t, span.Attributes)
@@ -419,7 +419,7 @@ func TestTraceAttributesProcessor(t *testing.T) {
 			spanToExclude := "span-not-to-add-attr"
 			verifySingleSpan(t, tc, nodeToInclude, spanToExclude, func(span data.Span) {
 				// Verify attributes was not added to the new internal data span.
-				assert.Equal(t, span.Attributes().Len(), 0)
+				assert.Equal(t, span.Attributes().Cap(), 0)
 			}, func(span *tracepb.Span) {
 				// Verify attributes was not added to the OC span.
 				assert.Nil(t, span.Attributes)

--- a/translator/internaldata/oc_to_resource_test.go
+++ b/translator/internaldata/oc_to_resource_test.go
@@ -48,14 +48,12 @@ func TestOcNodeResourceToInternal(t *testing.T) {
 
 	// Make sure hard-coded fields override same-name values in Attributes.
 	// To do that add Attributes with same-name.
-	it := expectedAttrs.Range()
-	for it.Next() {
+	expectedAttrs.ForEach(func(k string, v data.AttributeValue) {
 		// Set all except "attr1" which is not a hard-coded field to some bogus values.
-
-		if !strings.Contains(it.Key(), "-attr") {
-			ocNode.Attributes[it.Key()] = "this will be overridden 1"
+		if !strings.Contains(k, "-attr") {
+			ocNode.Attributes[k] = "this will be overridden 1"
 		}
-	}
+	})
 	ocResource.Labels[conventions.OCAttributeResourceType] = "this will be overridden 2"
 
 	// Convert again.

--- a/translator/internaldata/oc_to_resource_test.go
+++ b/translator/internaldata/oc_to_resource_test.go
@@ -48,12 +48,12 @@ func TestOcNodeResourceToInternal(t *testing.T) {
 
 	// Make sure hard-coded fields override same-name values in Attributes.
 	// To do that add Attributes with same-name.
-	for i := 0; i < expectedAttrs.Len(); i++ {
+	it := expectedAttrs.Range()
+	for it.Next() {
 		// Set all except "attr1" which is not a hard-coded field to some bogus values.
 
-		k, _ := expectedAttrs.GetAttribute(i)
-		if !strings.Contains(k, "-attr") {
-			ocNode.Attributes[k] = "this will be overridden 1"
+		if !strings.Contains(it.Key(), "-attr") {
+			ocNode.Attributes[it.Key()] = "this will be overridden 1"
 		}
 	}
 	ocResource.Labels[conventions.OCAttributeResourceType] = "this will be overridden 2"

--- a/translator/internaldata/resource_to_oc.go
+++ b/translator/internaldata/resource_to_oc.go
@@ -36,16 +36,16 @@ func internalResourceToOC(resource data.Resource) (*occommon.Node, *ocresource.R
 	ocNode := occommon.Node{}
 	ocResource := ocresource.Resource{}
 
-	if attrs.Len() == 0 {
+	if attrs.Cap() == 0 {
 		return &ocNode, &ocResource
 	}
 
-	labels := make(map[string]string, attrs.Len())
-	for i := 0; i < attrs.Len(); i++ {
-		k, av := attrs.GetAttribute(i)
-		val := attributeValueToString(av)
+	labels := make(map[string]string, attrs.Cap())
+	it := attrs.Range()
+	for it.Next() {
+		val := attributeValueToString(it.Value())
 
-		switch k {
+		switch it.Key() {
 		case conventions.OCAttributeResourceType:
 			ocResource.Type = val
 		case conventions.AttributeServiceName:
@@ -99,7 +99,7 @@ func internalResourceToOC(resource data.Resource) (*occommon.Node, *ocresource.R
 			}
 		default:
 			// Not a special attribute, put it into resource labels
-			labels[k] = val
+			labels[it.Key()] = val
 		}
 	}
 	ocResource.Labels = labels

--- a/translator/internaldata/resource_to_oc.go
+++ b/translator/internaldata/resource_to_oc.go
@@ -41,11 +41,10 @@ func internalResourceToOC(resource data.Resource) (*occommon.Node, *ocresource.R
 	}
 
 	labels := make(map[string]string, attrs.Cap())
-	it := attrs.Range()
-	for it.Next() {
-		val := attributeValueToString(it.Value())
+	attrs.ForEach(func(k string, v data.AttributeValue) {
+		val := attributeValueToString(v)
 
-		switch it.Key() {
+		switch k {
 		case conventions.OCAttributeResourceType:
 			ocResource.Type = val
 		case conventions.AttributeServiceName:
@@ -56,11 +55,11 @@ func internalResourceToOC(resource data.Resource) (*occommon.Node, *ocresource.R
 		case conventions.OCAttributeProcessStartTime:
 			t, err := time.Parse(time.RFC3339Nano, val)
 			if err != nil {
-				continue
+				return
 			}
 			ts, err := ptypes.TimestampProto(t)
 			if err != nil {
-				continue
+				return
 			}
 			if ocNode.Identifier == nil {
 				ocNode.Identifier = &occommon.ProcessIdentifier{}
@@ -99,9 +98,9 @@ func internalResourceToOC(resource data.Resource) (*occommon.Node, *ocresource.R
 			}
 		default:
 			// Not a special attribute, put it into resource labels
-			labels[it.Key()] = val
+			labels[k] = val
 		}
-	}
+	})
 	ocResource.Labels = labels
 
 	return &ocNode, &ocResource

--- a/translator/internaldata/traces_to_oc.go
+++ b/translator/internaldata/traces_to_oc.go
@@ -116,7 +116,7 @@ func spanToOC(span data.Span) *octrace.Span {
 }
 
 func attributesMapToOCSpanAttributes(attributes data.AttributeMap, droppedCount uint32) *octrace.Span_Attributes {
-	if attributes.Len() == 0 && droppedCount == 0 {
+	if attributes.Cap() == 0 && droppedCount == 0 {
 		return nil
 	}
 
@@ -127,14 +127,14 @@ func attributesMapToOCSpanAttributes(attributes data.AttributeMap, droppedCount 
 }
 
 func attributesMapToOCAttributeMap(attributes data.AttributeMap) map[string]*octrace.AttributeValue {
-	if attributes.Len() == 0 {
+	if attributes.Cap() == 0 {
 		return nil
 	}
 
-	ocAttributes := make(map[string]*octrace.AttributeValue, attributes.Len())
-	for i := 0; i < attributes.Len(); i++ {
-		k, av := attributes.GetAttribute(i)
-		ocAttributes[k] = attributeValueToOC(av)
+	ocAttributes := make(map[string]*octrace.AttributeValue, attributes.Cap())
+	it := attributes.Range()
+	for it.Next() {
+		ocAttributes[it.Key()] = attributeValueToOC(it.Value())
 	}
 	return ocAttributes
 }
@@ -287,7 +287,8 @@ func eventToOC(event data.SpanEvent) *octrace.Span_TimeEvent {
 		conventions.OCTimeEventMessageEventUSize,
 		conventions.OCTimeEventMessageEventCSize,
 	}
-	if attrs.Len() == len(ocMessageEventAttrs) {
+	// TODO: Find a better way to check for message_event. Maybe use the event.Name.
+	if attrs.Cap() == len(ocMessageEventAttrs) {
 		ocMessageEventAttrValues := map[string]data.AttributeValue{}
 		var ocMessageEventAttrFound bool
 		for _, attr := range ocMessageEventAttrs {

--- a/translator/internaldata/traces_to_oc.go
+++ b/translator/internaldata/traces_to_oc.go
@@ -132,10 +132,9 @@ func attributesMapToOCAttributeMap(attributes data.AttributeMap) map[string]*oct
 	}
 
 	ocAttributes := make(map[string]*octrace.AttributeValue, attributes.Cap())
-	it := attributes.Range()
-	for it.Next() {
-		ocAttributes[it.Key()] = attributeValueToOC(it.Value())
-	}
+	attributes.ForEach(func(k string, v data.AttributeValue) {
+		ocAttributes[k] = attributeValueToOC(v)
+	})
 	return ocAttributes
 }
 


### PR DESCRIPTION
**Open Questions**
1. Kind of don't like on the StringMap that I have to call `v.Value()`. Should we return just `string` from iterator? This makes things inconsistent with `AttributeMap`. 

**Benchmark results**
```
BenchmarkAttributeMap_ForEach-16                                 	26334198	        45.4 ns/op	       0 B/op	       0 allocs/op
BenchmarkAttributeMap_RangeOverMap-16                            	 5635006	       214 ns/op	       0 B/op	       0 allocs/op
BenchmarkStringMap_ForEach-16                                    	26362994	        45.0 ns/op	       0 B/op	       0 allocs/op
BenchmarkStringMap_RangeOverMap-16                               	 5518018	       220 ns/op	       0 B/op	       0 allocs/op
```

This was a huge surprise to me that range over maps is very inefficient. In the benchmark I have half elements in the map.