### PR TITLE
Add MoveTo function to the Slice to allow optimal batching.

### DIFF
--- a/internal/data/generated_metrics.go
+++ b/internal/data/generated_metrics.go
@@ -63,6 +63,23 @@ func (es ResourceMetricsSlice) At(ix int) ResourceMetrics {
 	return newResourceMetrics(&(*es.orig)[ix])
 }
 
+// MoveTo moves all elements from the current slice to the dest. The current slice will be cleared.
+func (es ResourceMetricsSlice) MoveTo(dest ResourceMetricsSlice) {
+	if es.Len() == 0 {
+		// Just to ensure that we always return a Slice with nil elements.
+		*es.orig = nil
+		return
+	}
+	if dest.Len() == 0 {
+		*dest.orig = *es.orig
+		*es.orig = nil
+		return
+	}
+	*dest.orig = append(*dest.orig, *es.orig...)
+	*es.orig = nil
+	return
+}
+
 // Resize is an operation that resizes the slice:
 // 1. If newLen is 0 then the slice is replaced with a nil slice.
 // 2. If the newLen < len then equivalent with slice[0:newLen].
@@ -189,6 +206,23 @@ func (es InstrumentationLibraryMetricsSlice) Len() int {
 // }
 func (es InstrumentationLibraryMetricsSlice) At(ix int) InstrumentationLibraryMetrics {
 	return newInstrumentationLibraryMetrics(&(*es.orig)[ix])
+}
+
+// MoveTo moves all elements from the current slice to the dest. The current slice will be cleared.
+func (es InstrumentationLibraryMetricsSlice) MoveTo(dest InstrumentationLibraryMetricsSlice) {
+	if es.Len() == 0 {
+		// Just to ensure that we always return a Slice with nil elements.
+		*es.orig = nil
+		return
+	}
+	if dest.Len() == 0 {
+		*dest.orig = *es.orig
+		*es.orig = nil
+		return
+	}
+	*dest.orig = append(*dest.orig, *es.orig...)
+	*es.orig = nil
+	return
 }
 
 // Resize is an operation that resizes the slice:
@@ -319,6 +353,23 @@ func (es MetricSlice) At(ix int) Metric {
 	return newMetric(&(*es.orig)[ix])
 }
 
+// MoveTo moves all elements from the current slice to the dest. The current slice will be cleared.
+func (es MetricSlice) MoveTo(dest MetricSlice) {
+	if es.Len() == 0 {
+		// Just to ensure that we always return a Slice with nil elements.
+		*es.orig = nil
+		return
+	}
+	if dest.Len() == 0 {
+		*dest.orig = *es.orig
+		*es.orig = nil
+		return
+	}
+	*dest.orig = append(*dest.orig, *es.orig...)
+	*es.orig = nil
+	return
+}
+
 // Resize is an operation that resizes the slice:
 // 1. If newLen is 0 then the slice is replaced with a nil slice.
 // 2. If the newLen < len then equivalent with slice[0:newLen].
@@ -351,7 +402,7 @@ func (es MetricSlice) Resize(newLen int) {
 }
 
 // Metric represents one metric as a collection of datapoints.
-// See Metric definition in OTLP: https://github.com/open-telemetry/opentelemetry-proto/blob/master/opentelemetry/proto/metrics/v1/metrics.proto
+// See Metric definition in OTLP: https://github.com/open-telemetry/opentelemetry-proto/blob/master/opentelemetry/proto/metrics/v1/metrics.proto#L96
 //
 // This is a reference type, if passsed by value and callee modifies it the
 // caller will see the modification.
@@ -570,6 +621,23 @@ func (es Int64DataPointSlice) At(ix int) Int64DataPoint {
 	return newInt64DataPoint(&(*es.orig)[ix])
 }
 
+// MoveTo moves all elements from the current slice to the dest. The current slice will be cleared.
+func (es Int64DataPointSlice) MoveTo(dest Int64DataPointSlice) {
+	if es.Len() == 0 {
+		// Just to ensure that we always return a Slice with nil elements.
+		*es.orig = nil
+		return
+	}
+	if dest.Len() == 0 {
+		*dest.orig = *es.orig
+		*es.orig = nil
+		return
+	}
+	*dest.orig = append(*dest.orig, *es.orig...)
+	*es.orig = nil
+	return
+}
+
 // Resize is an operation that resizes the slice:
 // 1. If newLen is 0 then the slice is replaced with a nil slice.
 // 2. If the newLen < len then equivalent with slice[0:newLen].
@@ -730,6 +798,23 @@ func (es DoubleDataPointSlice) At(ix int) DoubleDataPoint {
 	return newDoubleDataPoint(&(*es.orig)[ix])
 }
 
+// MoveTo moves all elements from the current slice to the dest. The current slice will be cleared.
+func (es DoubleDataPointSlice) MoveTo(dest DoubleDataPointSlice) {
+	if es.Len() == 0 {
+		// Just to ensure that we always return a Slice with nil elements.
+		*es.orig = nil
+		return
+	}
+	if dest.Len() == 0 {
+		*dest.orig = *es.orig
+		*es.orig = nil
+		return
+	}
+	*dest.orig = append(*dest.orig, *es.orig...)
+	*es.orig = nil
+	return
+}
+
 // Resize is an operation that resizes the slice:
 // 1. If newLen is 0 then the slice is replaced with a nil slice.
 // 2. If the newLen < len then equivalent with slice[0:newLen].
@@ -888,6 +973,23 @@ func (es HistogramDataPointSlice) Len() int {
 // }
 func (es HistogramDataPointSlice) At(ix int) HistogramDataPoint {
 	return newHistogramDataPoint(&(*es.orig)[ix])
+}
+
+// MoveTo moves all elements from the current slice to the dest. The current slice will be cleared.
+func (es HistogramDataPointSlice) MoveTo(dest HistogramDataPointSlice) {
+	if es.Len() == 0 {
+		// Just to ensure that we always return a Slice with nil elements.
+		*es.orig = nil
+		return
+	}
+	if dest.Len() == 0 {
+		*dest.orig = *es.orig
+		*es.orig = nil
+		return
+	}
+	*dest.orig = append(*dest.orig, *es.orig...)
+	*es.orig = nil
+	return
 }
 
 // Resize is an operation that resizes the slice:
@@ -1083,6 +1185,23 @@ func (es HistogramBucketSlice) Len() int {
 // }
 func (es HistogramBucketSlice) At(ix int) HistogramBucket {
 	return newHistogramBucket(&(*es.orig)[ix])
+}
+
+// MoveTo moves all elements from the current slice to the dest. The current slice will be cleared.
+func (es HistogramBucketSlice) MoveTo(dest HistogramBucketSlice) {
+	if es.Len() == 0 {
+		// Just to ensure that we always return a Slice with nil elements.
+		*es.orig = nil
+		return
+	}
+	if dest.Len() == 0 {
+		*dest.orig = *es.orig
+		*es.orig = nil
+		return
+	}
+	*dest.orig = append(*dest.orig, *es.orig...)
+	*es.orig = nil
+	return
 }
 
 // Resize is an operation that resizes the slice:
@@ -1294,6 +1413,23 @@ func (es SummaryDataPointSlice) At(ix int) SummaryDataPoint {
 	return newSummaryDataPoint(&(*es.orig)[ix])
 }
 
+// MoveTo moves all elements from the current slice to the dest. The current slice will be cleared.
+func (es SummaryDataPointSlice) MoveTo(dest SummaryDataPointSlice) {
+	if es.Len() == 0 {
+		// Just to ensure that we always return a Slice with nil elements.
+		*es.orig = nil
+		return
+	}
+	if dest.Len() == 0 {
+		*dest.orig = *es.orig
+		*es.orig = nil
+		return
+	}
+	*dest.orig = append(*dest.orig, *es.orig...)
+	*es.orig = nil
+	return
+}
+
 // Resize is an operation that resizes the slice:
 // 1. If newLen is 0 then the slice is replaced with a nil slice.
 // 2. If the newLen < len then equivalent with slice[0:newLen].
@@ -1473,6 +1609,23 @@ func (es SummaryValueAtPercentileSlice) Len() int {
 // }
 func (es SummaryValueAtPercentileSlice) At(ix int) SummaryValueAtPercentile {
 	return newSummaryValueAtPercentile(&(*es.orig)[ix])
+}
+
+// MoveTo moves all elements from the current slice to the dest. The current slice will be cleared.
+func (es SummaryValueAtPercentileSlice) MoveTo(dest SummaryValueAtPercentileSlice) {
+	if es.Len() == 0 {
+		// Just to ensure that we always return a Slice with nil elements.
+		*es.orig = nil
+		return
+	}
+	if dest.Len() == 0 {
+		*dest.orig = *es.orig
+		*es.orig = nil
+		return
+	}
+	*dest.orig = append(*dest.orig, *es.orig...)
+	*es.orig = nil
+	return
 }
 
 // Resize is an operation that resizes the slice:

--- a/internal/data/generated_metrics_test.go
+++ b/internal/data/generated_metrics_test.go
@@ -30,19 +30,49 @@ func TestResourceMetricsSlice(t *testing.T) {
 	es = newResourceMetricsSlice(&[]*otlpmetrics.ResourceMetrics{})
 	assert.EqualValues(t, 0, es.Len())
 
-	es.Resize(13)
+	es.Resize(7)
 	emptyVal := NewResourceMetrics()
 	emptyVal.InitEmpty()
 	testVal := generateTestResourceMetrics()
-	assert.EqualValues(t, 13, es.Len())
+	assert.EqualValues(t, 7, es.Len())
 	for i := 0; i < es.Len(); i++ {
 		assert.EqualValues(t, emptyVal, es.At(i))
 		fillTestResourceMetrics(es.At(i))
 		assert.EqualValues(t, testVal, es.At(i))
 	}
+}
 
+func TestResourceMetricsSliceMoveTo(t *testing.T) {
+	// Test MoveTo to empty
+	expectedSlice := generateTestResourceMetricsSlice()
+	dest := NewResourceMetricsSlice()
+	src := generateTestResourceMetricsSlice()
+	src.MoveTo(dest)
+	assert.EqualValues(t, generateTestResourceMetricsSlice(), dest)
+	assert.EqualValues(t, 0, src.Len())
+	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
+
+	// Test MoveTo empty slice
+	src.MoveTo(dest)
+	assert.EqualValues(t, generateTestResourceMetricsSlice(), dest)
+	assert.EqualValues(t, 0, src.Len())
+	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
+
+	// Test MoveTo not empty slice
+	generateTestResourceMetricsSlice().MoveTo(dest)
+	assert.EqualValues(t, 2*expectedSlice.Len(), dest.Len())
+	for i := 0; i < expectedSlice.Len(); i++ {
+		assert.EqualValues(t, expectedSlice.At(i), dest.At(i))
+		assert.EqualValues(t, expectedSlice.At(i), dest.At(i+expectedSlice.Len()))
+	}
+}
+
+func TestResourceMetricsSliceResize(t *testing.T) {
+	es := generateTestResourceMetricsSlice()
+	emptyVal := NewResourceMetrics()
+	emptyVal.InitEmpty()
 	// Test Resize less elements.
-	const resizeSmallLen = 10
+	const resizeSmallLen = 4
 	expectedEs := make(map[*otlpmetrics.ResourceMetrics]bool, resizeSmallLen)
 	for i := 0; i < resizeSmallLen; i++ {
 		expectedEs[*(es.At(i).orig)] = true
@@ -57,7 +87,7 @@ func TestResourceMetricsSlice(t *testing.T) {
 	assert.EqualValues(t, expectedEs, foundEs)
 
 	// Test Resize more elements.
-	const resizeLargeLen = 13
+	const resizeLargeLen = 7
 	oldLen := es.Len()
 	expectedEs = make(map[*otlpmetrics.ResourceMetrics]bool, oldLen)
 	for i := 0; i < oldLen; i++ {
@@ -106,19 +136,49 @@ func TestInstrumentationLibraryMetricsSlice(t *testing.T) {
 	es = newInstrumentationLibraryMetricsSlice(&[]*otlpmetrics.InstrumentationLibraryMetrics{})
 	assert.EqualValues(t, 0, es.Len())
 
-	es.Resize(13)
+	es.Resize(7)
 	emptyVal := NewInstrumentationLibraryMetrics()
 	emptyVal.InitEmpty()
 	testVal := generateTestInstrumentationLibraryMetrics()
-	assert.EqualValues(t, 13, es.Len())
+	assert.EqualValues(t, 7, es.Len())
 	for i := 0; i < es.Len(); i++ {
 		assert.EqualValues(t, emptyVal, es.At(i))
 		fillTestInstrumentationLibraryMetrics(es.At(i))
 		assert.EqualValues(t, testVal, es.At(i))
 	}
+}
 
+func TestInstrumentationLibraryMetricsSliceMoveTo(t *testing.T) {
+	// Test MoveTo to empty
+	expectedSlice := generateTestInstrumentationLibraryMetricsSlice()
+	dest := NewInstrumentationLibraryMetricsSlice()
+	src := generateTestInstrumentationLibraryMetricsSlice()
+	src.MoveTo(dest)
+	assert.EqualValues(t, generateTestInstrumentationLibraryMetricsSlice(), dest)
+	assert.EqualValues(t, 0, src.Len())
+	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
+
+	// Test MoveTo empty slice
+	src.MoveTo(dest)
+	assert.EqualValues(t, generateTestInstrumentationLibraryMetricsSlice(), dest)
+	assert.EqualValues(t, 0, src.Len())
+	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
+
+	// Test MoveTo not empty slice
+	generateTestInstrumentationLibraryMetricsSlice().MoveTo(dest)
+	assert.EqualValues(t, 2*expectedSlice.Len(), dest.Len())
+	for i := 0; i < expectedSlice.Len(); i++ {
+		assert.EqualValues(t, expectedSlice.At(i), dest.At(i))
+		assert.EqualValues(t, expectedSlice.At(i), dest.At(i+expectedSlice.Len()))
+	}
+}
+
+func TestInstrumentationLibraryMetricsSliceResize(t *testing.T) {
+	es := generateTestInstrumentationLibraryMetricsSlice()
+	emptyVal := NewInstrumentationLibraryMetrics()
+	emptyVal.InitEmpty()
 	// Test Resize less elements.
-	const resizeSmallLen = 10
+	const resizeSmallLen = 4
 	expectedEs := make(map[*otlpmetrics.InstrumentationLibraryMetrics]bool, resizeSmallLen)
 	for i := 0; i < resizeSmallLen; i++ {
 		expectedEs[*(es.At(i).orig)] = true
@@ -133,7 +193,7 @@ func TestInstrumentationLibraryMetricsSlice(t *testing.T) {
 	assert.EqualValues(t, expectedEs, foundEs)
 
 	// Test Resize more elements.
-	const resizeLargeLen = 13
+	const resizeLargeLen = 7
 	oldLen := es.Len()
 	expectedEs = make(map[*otlpmetrics.InstrumentationLibraryMetrics]bool, oldLen)
 	for i := 0; i < oldLen; i++ {
@@ -182,19 +242,49 @@ func TestMetricSlice(t *testing.T) {
 	es = newMetricSlice(&[]*otlpmetrics.Metric{})
 	assert.EqualValues(t, 0, es.Len())
 
-	es.Resize(13)
+	es.Resize(7)
 	emptyVal := NewMetric()
 	emptyVal.InitEmpty()
 	testVal := generateTestMetric()
-	assert.EqualValues(t, 13, es.Len())
+	assert.EqualValues(t, 7, es.Len())
 	for i := 0; i < es.Len(); i++ {
 		assert.EqualValues(t, emptyVal, es.At(i))
 		fillTestMetric(es.At(i))
 		assert.EqualValues(t, testVal, es.At(i))
 	}
+}
 
+func TestMetricSliceMoveTo(t *testing.T) {
+	// Test MoveTo to empty
+	expectedSlice := generateTestMetricSlice()
+	dest := NewMetricSlice()
+	src := generateTestMetricSlice()
+	src.MoveTo(dest)
+	assert.EqualValues(t, generateTestMetricSlice(), dest)
+	assert.EqualValues(t, 0, src.Len())
+	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
+
+	// Test MoveTo empty slice
+	src.MoveTo(dest)
+	assert.EqualValues(t, generateTestMetricSlice(), dest)
+	assert.EqualValues(t, 0, src.Len())
+	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
+
+	// Test MoveTo not empty slice
+	generateTestMetricSlice().MoveTo(dest)
+	assert.EqualValues(t, 2*expectedSlice.Len(), dest.Len())
+	for i := 0; i < expectedSlice.Len(); i++ {
+		assert.EqualValues(t, expectedSlice.At(i), dest.At(i))
+		assert.EqualValues(t, expectedSlice.At(i), dest.At(i+expectedSlice.Len()))
+	}
+}
+
+func TestMetricSliceResize(t *testing.T) {
+	es := generateTestMetricSlice()
+	emptyVal := NewMetric()
+	emptyVal.InitEmpty()
 	// Test Resize less elements.
-	const resizeSmallLen = 10
+	const resizeSmallLen = 4
 	expectedEs := make(map[*otlpmetrics.Metric]bool, resizeSmallLen)
 	for i := 0; i < resizeSmallLen; i++ {
 		expectedEs[*(es.At(i).orig)] = true
@@ -209,7 +299,7 @@ func TestMetricSlice(t *testing.T) {
 	assert.EqualValues(t, expectedEs, foundEs)
 
 	// Test Resize more elements.
-	const resizeLargeLen = 13
+	const resizeLargeLen = 7
 	oldLen := es.Len()
 	expectedEs = make(map[*otlpmetrics.Metric]bool, oldLen)
 	for i := 0; i < oldLen; i++ {
@@ -307,19 +397,49 @@ func TestInt64DataPointSlice(t *testing.T) {
 	es = newInt64DataPointSlice(&[]*otlpmetrics.Int64DataPoint{})
 	assert.EqualValues(t, 0, es.Len())
 
-	es.Resize(13)
+	es.Resize(7)
 	emptyVal := NewInt64DataPoint()
 	emptyVal.InitEmpty()
 	testVal := generateTestInt64DataPoint()
-	assert.EqualValues(t, 13, es.Len())
+	assert.EqualValues(t, 7, es.Len())
 	for i := 0; i < es.Len(); i++ {
 		assert.EqualValues(t, emptyVal, es.At(i))
 		fillTestInt64DataPoint(es.At(i))
 		assert.EqualValues(t, testVal, es.At(i))
 	}
+}
 
+func TestInt64DataPointSliceMoveTo(t *testing.T) {
+	// Test MoveTo to empty
+	expectedSlice := generateTestInt64DataPointSlice()
+	dest := NewInt64DataPointSlice()
+	src := generateTestInt64DataPointSlice()
+	src.MoveTo(dest)
+	assert.EqualValues(t, generateTestInt64DataPointSlice(), dest)
+	assert.EqualValues(t, 0, src.Len())
+	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
+
+	// Test MoveTo empty slice
+	src.MoveTo(dest)
+	assert.EqualValues(t, generateTestInt64DataPointSlice(), dest)
+	assert.EqualValues(t, 0, src.Len())
+	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
+
+	// Test MoveTo not empty slice
+	generateTestInt64DataPointSlice().MoveTo(dest)
+	assert.EqualValues(t, 2*expectedSlice.Len(), dest.Len())
+	for i := 0; i < expectedSlice.Len(); i++ {
+		assert.EqualValues(t, expectedSlice.At(i), dest.At(i))
+		assert.EqualValues(t, expectedSlice.At(i), dest.At(i+expectedSlice.Len()))
+	}
+}
+
+func TestInt64DataPointSliceResize(t *testing.T) {
+	es := generateTestInt64DataPointSlice()
+	emptyVal := NewInt64DataPoint()
+	emptyVal.InitEmpty()
 	// Test Resize less elements.
-	const resizeSmallLen = 10
+	const resizeSmallLen = 4
 	expectedEs := make(map[*otlpmetrics.Int64DataPoint]bool, resizeSmallLen)
 	for i := 0; i < resizeSmallLen; i++ {
 		expectedEs[*(es.At(i).orig)] = true
@@ -334,7 +454,7 @@ func TestInt64DataPointSlice(t *testing.T) {
 	assert.EqualValues(t, expectedEs, foundEs)
 
 	// Test Resize more elements.
-	const resizeLargeLen = 13
+	const resizeLargeLen = 7
 	oldLen := es.Len()
 	expectedEs = make(map[*otlpmetrics.Int64DataPoint]bool, oldLen)
 	for i := 0; i < oldLen; i++ {
@@ -392,19 +512,49 @@ func TestDoubleDataPointSlice(t *testing.T) {
 	es = newDoubleDataPointSlice(&[]*otlpmetrics.DoubleDataPoint{})
 	assert.EqualValues(t, 0, es.Len())
 
-	es.Resize(13)
+	es.Resize(7)
 	emptyVal := NewDoubleDataPoint()
 	emptyVal.InitEmpty()
 	testVal := generateTestDoubleDataPoint()
-	assert.EqualValues(t, 13, es.Len())
+	assert.EqualValues(t, 7, es.Len())
 	for i := 0; i < es.Len(); i++ {
 		assert.EqualValues(t, emptyVal, es.At(i))
 		fillTestDoubleDataPoint(es.At(i))
 		assert.EqualValues(t, testVal, es.At(i))
 	}
+}
 
+func TestDoubleDataPointSliceMoveTo(t *testing.T) {
+	// Test MoveTo to empty
+	expectedSlice := generateTestDoubleDataPointSlice()
+	dest := NewDoubleDataPointSlice()
+	src := generateTestDoubleDataPointSlice()
+	src.MoveTo(dest)
+	assert.EqualValues(t, generateTestDoubleDataPointSlice(), dest)
+	assert.EqualValues(t, 0, src.Len())
+	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
+
+	// Test MoveTo empty slice
+	src.MoveTo(dest)
+	assert.EqualValues(t, generateTestDoubleDataPointSlice(), dest)
+	assert.EqualValues(t, 0, src.Len())
+	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
+
+	// Test MoveTo not empty slice
+	generateTestDoubleDataPointSlice().MoveTo(dest)
+	assert.EqualValues(t, 2*expectedSlice.Len(), dest.Len())
+	for i := 0; i < expectedSlice.Len(); i++ {
+		assert.EqualValues(t, expectedSlice.At(i), dest.At(i))
+		assert.EqualValues(t, expectedSlice.At(i), dest.At(i+expectedSlice.Len()))
+	}
+}
+
+func TestDoubleDataPointSliceResize(t *testing.T) {
+	es := generateTestDoubleDataPointSlice()
+	emptyVal := NewDoubleDataPoint()
+	emptyVal.InitEmpty()
 	// Test Resize less elements.
-	const resizeSmallLen = 10
+	const resizeSmallLen = 4
 	expectedEs := make(map[*otlpmetrics.DoubleDataPoint]bool, resizeSmallLen)
 	for i := 0; i < resizeSmallLen; i++ {
 		expectedEs[*(es.At(i).orig)] = true
@@ -419,7 +569,7 @@ func TestDoubleDataPointSlice(t *testing.T) {
 	assert.EqualValues(t, expectedEs, foundEs)
 
 	// Test Resize more elements.
-	const resizeLargeLen = 13
+	const resizeLargeLen = 7
 	oldLen := es.Len()
 	expectedEs = make(map[*otlpmetrics.DoubleDataPoint]bool, oldLen)
 	for i := 0; i < oldLen; i++ {
@@ -477,19 +627,49 @@ func TestHistogramDataPointSlice(t *testing.T) {
 	es = newHistogramDataPointSlice(&[]*otlpmetrics.HistogramDataPoint{})
 	assert.EqualValues(t, 0, es.Len())
 
-	es.Resize(13)
+	es.Resize(7)
 	emptyVal := NewHistogramDataPoint()
 	emptyVal.InitEmpty()
 	testVal := generateTestHistogramDataPoint()
-	assert.EqualValues(t, 13, es.Len())
+	assert.EqualValues(t, 7, es.Len())
 	for i := 0; i < es.Len(); i++ {
 		assert.EqualValues(t, emptyVal, es.At(i))
 		fillTestHistogramDataPoint(es.At(i))
 		assert.EqualValues(t, testVal, es.At(i))
 	}
+}
 
+func TestHistogramDataPointSliceMoveTo(t *testing.T) {
+	// Test MoveTo to empty
+	expectedSlice := generateTestHistogramDataPointSlice()
+	dest := NewHistogramDataPointSlice()
+	src := generateTestHistogramDataPointSlice()
+	src.MoveTo(dest)
+	assert.EqualValues(t, generateTestHistogramDataPointSlice(), dest)
+	assert.EqualValues(t, 0, src.Len())
+	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
+
+	// Test MoveTo empty slice
+	src.MoveTo(dest)
+	assert.EqualValues(t, generateTestHistogramDataPointSlice(), dest)
+	assert.EqualValues(t, 0, src.Len())
+	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
+
+	// Test MoveTo not empty slice
+	generateTestHistogramDataPointSlice().MoveTo(dest)
+	assert.EqualValues(t, 2*expectedSlice.Len(), dest.Len())
+	for i := 0; i < expectedSlice.Len(); i++ {
+		assert.EqualValues(t, expectedSlice.At(i), dest.At(i))
+		assert.EqualValues(t, expectedSlice.At(i), dest.At(i+expectedSlice.Len()))
+	}
+}
+
+func TestHistogramDataPointSliceResize(t *testing.T) {
+	es := generateTestHistogramDataPointSlice()
+	emptyVal := NewHistogramDataPoint()
+	emptyVal.InitEmpty()
 	// Test Resize less elements.
-	const resizeSmallLen = 10
+	const resizeSmallLen = 4
 	expectedEs := make(map[*otlpmetrics.HistogramDataPoint]bool, resizeSmallLen)
 	for i := 0; i < resizeSmallLen; i++ {
 		expectedEs[*(es.At(i).orig)] = true
@@ -504,7 +684,7 @@ func TestHistogramDataPointSlice(t *testing.T) {
 	assert.EqualValues(t, expectedEs, foundEs)
 
 	// Test Resize more elements.
-	const resizeLargeLen = 13
+	const resizeLargeLen = 7
 	oldLen := es.Len()
 	expectedEs = make(map[*otlpmetrics.HistogramDataPoint]bool, oldLen)
 	for i := 0; i < oldLen; i++ {
@@ -577,19 +757,49 @@ func TestHistogramBucketSlice(t *testing.T) {
 	es = newHistogramBucketSlice(&[]*otlpmetrics.HistogramDataPoint_Bucket{})
 	assert.EqualValues(t, 0, es.Len())
 
-	es.Resize(13)
+	es.Resize(7)
 	emptyVal := NewHistogramBucket()
 	emptyVal.InitEmpty()
 	testVal := generateTestHistogramBucket()
-	assert.EqualValues(t, 13, es.Len())
+	assert.EqualValues(t, 7, es.Len())
 	for i := 0; i < es.Len(); i++ {
 		assert.EqualValues(t, emptyVal, es.At(i))
 		fillTestHistogramBucket(es.At(i))
 		assert.EqualValues(t, testVal, es.At(i))
 	}
+}
 
+func TestHistogramBucketSliceMoveTo(t *testing.T) {
+	// Test MoveTo to empty
+	expectedSlice := generateTestHistogramBucketSlice()
+	dest := NewHistogramBucketSlice()
+	src := generateTestHistogramBucketSlice()
+	src.MoveTo(dest)
+	assert.EqualValues(t, generateTestHistogramBucketSlice(), dest)
+	assert.EqualValues(t, 0, src.Len())
+	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
+
+	// Test MoveTo empty slice
+	src.MoveTo(dest)
+	assert.EqualValues(t, generateTestHistogramBucketSlice(), dest)
+	assert.EqualValues(t, 0, src.Len())
+	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
+
+	// Test MoveTo not empty slice
+	generateTestHistogramBucketSlice().MoveTo(dest)
+	assert.EqualValues(t, 2*expectedSlice.Len(), dest.Len())
+	for i := 0; i < expectedSlice.Len(); i++ {
+		assert.EqualValues(t, expectedSlice.At(i), dest.At(i))
+		assert.EqualValues(t, expectedSlice.At(i), dest.At(i+expectedSlice.Len()))
+	}
+}
+
+func TestHistogramBucketSliceResize(t *testing.T) {
+	es := generateTestHistogramBucketSlice()
+	emptyVal := NewHistogramBucket()
+	emptyVal.InitEmpty()
 	// Test Resize less elements.
-	const resizeSmallLen = 10
+	const resizeSmallLen = 4
 	expectedEs := make(map[*otlpmetrics.HistogramDataPoint_Bucket]bool, resizeSmallLen)
 	for i := 0; i < resizeSmallLen; i++ {
 		expectedEs[*(es.At(i).orig)] = true
@@ -604,7 +814,7 @@ func TestHistogramBucketSlice(t *testing.T) {
 	assert.EqualValues(t, expectedEs, foundEs)
 
 	// Test Resize more elements.
-	const resizeLargeLen = 13
+	const resizeLargeLen = 7
 	oldLen := es.Len()
 	expectedEs = make(map[*otlpmetrics.HistogramDataPoint_Bucket]bool, oldLen)
 	for i := 0; i < oldLen; i++ {
@@ -677,19 +887,49 @@ func TestSummaryDataPointSlice(t *testing.T) {
 	es = newSummaryDataPointSlice(&[]*otlpmetrics.SummaryDataPoint{})
 	assert.EqualValues(t, 0, es.Len())
 
-	es.Resize(13)
+	es.Resize(7)
 	emptyVal := NewSummaryDataPoint()
 	emptyVal.InitEmpty()
 	testVal := generateTestSummaryDataPoint()
-	assert.EqualValues(t, 13, es.Len())
+	assert.EqualValues(t, 7, es.Len())
 	for i := 0; i < es.Len(); i++ {
 		assert.EqualValues(t, emptyVal, es.At(i))
 		fillTestSummaryDataPoint(es.At(i))
 		assert.EqualValues(t, testVal, es.At(i))
 	}
+}
 
+func TestSummaryDataPointSliceMoveTo(t *testing.T) {
+	// Test MoveTo to empty
+	expectedSlice := generateTestSummaryDataPointSlice()
+	dest := NewSummaryDataPointSlice()
+	src := generateTestSummaryDataPointSlice()
+	src.MoveTo(dest)
+	assert.EqualValues(t, generateTestSummaryDataPointSlice(), dest)
+	assert.EqualValues(t, 0, src.Len())
+	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
+
+	// Test MoveTo empty slice
+	src.MoveTo(dest)
+	assert.EqualValues(t, generateTestSummaryDataPointSlice(), dest)
+	assert.EqualValues(t, 0, src.Len())
+	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
+
+	// Test MoveTo not empty slice
+	generateTestSummaryDataPointSlice().MoveTo(dest)
+	assert.EqualValues(t, 2*expectedSlice.Len(), dest.Len())
+	for i := 0; i < expectedSlice.Len(); i++ {
+		assert.EqualValues(t, expectedSlice.At(i), dest.At(i))
+		assert.EqualValues(t, expectedSlice.At(i), dest.At(i+expectedSlice.Len()))
+	}
+}
+
+func TestSummaryDataPointSliceResize(t *testing.T) {
+	es := generateTestSummaryDataPointSlice()
+	emptyVal := NewSummaryDataPoint()
+	emptyVal.InitEmpty()
 	// Test Resize less elements.
-	const resizeSmallLen = 10
+	const resizeSmallLen = 4
 	expectedEs := make(map[*otlpmetrics.SummaryDataPoint]bool, resizeSmallLen)
 	for i := 0; i < resizeSmallLen; i++ {
 		expectedEs[*(es.At(i).orig)] = true
@@ -704,7 +944,7 @@ func TestSummaryDataPointSlice(t *testing.T) {
 	assert.EqualValues(t, expectedEs, foundEs)
 
 	// Test Resize more elements.
-	const resizeLargeLen = 13
+	const resizeLargeLen = 7
 	oldLen := es.Len()
 	expectedEs = make(map[*otlpmetrics.SummaryDataPoint]bool, oldLen)
 	for i := 0; i < oldLen; i++ {
@@ -772,19 +1012,49 @@ func TestSummaryValueAtPercentileSlice(t *testing.T) {
 	es = newSummaryValueAtPercentileSlice(&[]*otlpmetrics.SummaryDataPoint_ValueAtPercentile{})
 	assert.EqualValues(t, 0, es.Len())
 
-	es.Resize(13)
+	es.Resize(7)
 	emptyVal := NewSummaryValueAtPercentile()
 	emptyVal.InitEmpty()
 	testVal := generateTestSummaryValueAtPercentile()
-	assert.EqualValues(t, 13, es.Len())
+	assert.EqualValues(t, 7, es.Len())
 	for i := 0; i < es.Len(); i++ {
 		assert.EqualValues(t, emptyVal, es.At(i))
 		fillTestSummaryValueAtPercentile(es.At(i))
 		assert.EqualValues(t, testVal, es.At(i))
 	}
+}
 
+func TestSummaryValueAtPercentileSliceMoveTo(t *testing.T) {
+	// Test MoveTo to empty
+	expectedSlice := generateTestSummaryValueAtPercentileSlice()
+	dest := NewSummaryValueAtPercentileSlice()
+	src := generateTestSummaryValueAtPercentileSlice()
+	src.MoveTo(dest)
+	assert.EqualValues(t, generateTestSummaryValueAtPercentileSlice(), dest)
+	assert.EqualValues(t, 0, src.Len())
+	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
+
+	// Test MoveTo empty slice
+	src.MoveTo(dest)
+	assert.EqualValues(t, generateTestSummaryValueAtPercentileSlice(), dest)
+	assert.EqualValues(t, 0, src.Len())
+	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
+
+	// Test MoveTo not empty slice
+	generateTestSummaryValueAtPercentileSlice().MoveTo(dest)
+	assert.EqualValues(t, 2*expectedSlice.Len(), dest.Len())
+	for i := 0; i < expectedSlice.Len(); i++ {
+		assert.EqualValues(t, expectedSlice.At(i), dest.At(i))
+		assert.EqualValues(t, expectedSlice.At(i), dest.At(i+expectedSlice.Len()))
+	}
+}
+
+func TestSummaryValueAtPercentileSliceResize(t *testing.T) {
+	es := generateTestSummaryValueAtPercentileSlice()
+	emptyVal := NewSummaryValueAtPercentile()
+	emptyVal.InitEmpty()
 	// Test Resize less elements.
-	const resizeSmallLen = 10
+	const resizeSmallLen = 4
 	expectedEs := make(map[*otlpmetrics.SummaryDataPoint_ValueAtPercentile]bool, resizeSmallLen)
 	for i := 0; i < resizeSmallLen; i++ {
 		expectedEs[*(es.At(i).orig)] = true
@@ -799,7 +1069,7 @@ func TestSummaryValueAtPercentileSlice(t *testing.T) {
 	assert.EqualValues(t, expectedEs, foundEs)
 
 	// Test Resize more elements.
-	const resizeLargeLen = 13
+	const resizeLargeLen = 7
 	oldLen := es.Len()
 	expectedEs = make(map[*otlpmetrics.SummaryDataPoint_ValueAtPercentile]bool, oldLen)
 	for i := 0; i < oldLen; i++ {
@@ -848,7 +1118,7 @@ func generateTestResourceMetricsSlice() ResourceMetricsSlice {
 }
 
 func fillTestResourceMetricsSlice(tv ResourceMetricsSlice) {
-	tv.Resize(13)
+	tv.Resize(7)
 	for i := 0; i < tv.Len(); i++ {
 		fillTestResourceMetrics(tv.At(i))
 	}
@@ -874,7 +1144,7 @@ func generateTestInstrumentationLibraryMetricsSlice() InstrumentationLibraryMetr
 }
 
 func fillTestInstrumentationLibraryMetricsSlice(tv InstrumentationLibraryMetricsSlice) {
-	tv.Resize(13)
+	tv.Resize(7)
 	for i := 0; i < tv.Len(); i++ {
 		fillTestInstrumentationLibraryMetrics(tv.At(i))
 	}
@@ -900,7 +1170,7 @@ func generateTestMetricSlice() MetricSlice {
 }
 
 func fillTestMetricSlice(tv MetricSlice) {
-	tv.Resize(13)
+	tv.Resize(7)
 	for i := 0; i < tv.Len(); i++ {
 		fillTestMetric(tv.At(i))
 	}
@@ -944,7 +1214,7 @@ func generateTestInt64DataPointSlice() Int64DataPointSlice {
 }
 
 func fillTestInt64DataPointSlice(tv Int64DataPointSlice) {
-	tv.Resize(13)
+	tv.Resize(7)
 	for i := 0; i < tv.Len(); i++ {
 		fillTestInt64DataPoint(tv.At(i))
 	}
@@ -971,7 +1241,7 @@ func generateTestDoubleDataPointSlice() DoubleDataPointSlice {
 }
 
 func fillTestDoubleDataPointSlice(tv DoubleDataPointSlice) {
-	tv.Resize(13)
+	tv.Resize(7)
 	for i := 0; i < tv.Len(); i++ {
 		fillTestDoubleDataPoint(tv.At(i))
 	}
@@ -998,7 +1268,7 @@ func generateTestHistogramDataPointSlice() HistogramDataPointSlice {
 }
 
 func fillTestHistogramDataPointSlice(tv HistogramDataPointSlice) {
-	tv.Resize(13)
+	tv.Resize(7)
 	for i := 0; i < tv.Len(); i++ {
 		fillTestHistogramDataPoint(tv.At(i))
 	}
@@ -1028,7 +1298,7 @@ func generateTestHistogramBucketSlice() HistogramBucketSlice {
 }
 
 func fillTestHistogramBucketSlice(tv HistogramBucketSlice) {
-	tv.Resize(13)
+	tv.Resize(7)
 	for i := 0; i < tv.Len(); i++ {
 		fillTestHistogramBucket(tv.At(i))
 	}
@@ -1067,7 +1337,7 @@ func generateTestSummaryDataPointSlice() SummaryDataPointSlice {
 }
 
 func fillTestSummaryDataPointSlice(tv SummaryDataPointSlice) {
-	tv.Resize(13)
+	tv.Resize(7)
 	for i := 0; i < tv.Len(); i++ {
 		fillTestSummaryDataPoint(tv.At(i))
 	}
@@ -1096,7 +1366,7 @@ func generateTestSummaryValueAtPercentileSlice() SummaryValueAtPercentileSlice {
 }
 
 func fillTestSummaryValueAtPercentileSlice(tv SummaryValueAtPercentileSlice) {
-	tv.Resize(13)
+	tv.Resize(7)
 	for i := 0; i < tv.Len(); i++ {
 		fillTestSummaryValueAtPercentile(tv.At(i))
 	}

--- a/internal/data/generated_trace.go
+++ b/internal/data/generated_trace.go
@@ -63,6 +63,23 @@ func (es ResourceSpansSlice) At(ix int) ResourceSpans {
 	return newResourceSpans(&(*es.orig)[ix])
 }
 
+// MoveTo moves all elements from the current slice to the dest. The current slice will be cleared.
+func (es ResourceSpansSlice) MoveTo(dest ResourceSpansSlice) {
+	if es.Len() == 0 {
+		// Just to ensure that we always return a Slice with nil elements.
+		*es.orig = nil
+		return
+	}
+	if dest.Len() == 0 {
+		*dest.orig = *es.orig
+		*es.orig = nil
+		return
+	}
+	*dest.orig = append(*dest.orig, *es.orig...)
+	*es.orig = nil
+	return
+}
+
 // Resize is an operation that resizes the slice:
 // 1. If newLen is 0 then the slice is replaced with a nil slice.
 // 2. If the newLen < len then equivalent with slice[0:newLen].
@@ -191,6 +208,23 @@ func (es InstrumentationLibrarySpansSlice) At(ix int) InstrumentationLibrarySpan
 	return newInstrumentationLibrarySpans(&(*es.orig)[ix])
 }
 
+// MoveTo moves all elements from the current slice to the dest. The current slice will be cleared.
+func (es InstrumentationLibrarySpansSlice) MoveTo(dest InstrumentationLibrarySpansSlice) {
+	if es.Len() == 0 {
+		// Just to ensure that we always return a Slice with nil elements.
+		*es.orig = nil
+		return
+	}
+	if dest.Len() == 0 {
+		*dest.orig = *es.orig
+		*es.orig = nil
+		return
+	}
+	*dest.orig = append(*dest.orig, *es.orig...)
+	*es.orig = nil
+	return
+}
+
 // Resize is an operation that resizes the slice:
 // 1. If newLen is 0 then the slice is replaced with a nil slice.
 // 2. If the newLen < len then equivalent with slice[0:newLen].
@@ -317,6 +351,23 @@ func (es SpanSlice) Len() int {
 // }
 func (es SpanSlice) At(ix int) Span {
 	return newSpan(&(*es.orig)[ix])
+}
+
+// MoveTo moves all elements from the current slice to the dest. The current slice will be cleared.
+func (es SpanSlice) MoveTo(dest SpanSlice) {
+	if es.Len() == 0 {
+		// Just to ensure that we always return a Slice with nil elements.
+		*es.orig = nil
+		return
+	}
+	if dest.Len() == 0 {
+		*dest.orig = *es.orig
+		*es.orig = nil
+		return
+	}
+	*dest.orig = append(*dest.orig, *es.orig...)
+	*es.orig = nil
+	return
 }
 
 // Resize is an operation that resizes the slice:
@@ -616,6 +667,23 @@ func (es SpanEventSlice) At(ix int) SpanEvent {
 	return newSpanEvent(&(*es.orig)[ix])
 }
 
+// MoveTo moves all elements from the current slice to the dest. The current slice will be cleared.
+func (es SpanEventSlice) MoveTo(dest SpanEventSlice) {
+	if es.Len() == 0 {
+		// Just to ensure that we always return a Slice with nil elements.
+		*es.orig = nil
+		return
+	}
+	if dest.Len() == 0 {
+		*dest.orig = *es.orig
+		*es.orig = nil
+		return
+	}
+	*dest.orig = append(*dest.orig, *es.orig...)
+	*es.orig = nil
+	return
+}
+
 // Resize is an operation that resizes the slice:
 // 1. If newLen is 0 then the slice is replaced with a nil slice.
 // 2. If the newLen < len then equivalent with slice[0:newLen].
@@ -775,6 +843,23 @@ func (es SpanLinkSlice) Len() int {
 // }
 func (es SpanLinkSlice) At(ix int) SpanLink {
 	return newSpanLink(&(*es.orig)[ix])
+}
+
+// MoveTo moves all elements from the current slice to the dest. The current slice will be cleared.
+func (es SpanLinkSlice) MoveTo(dest SpanLinkSlice) {
+	if es.Len() == 0 {
+		// Just to ensure that we always return a Slice with nil elements.
+		*es.orig = nil
+		return
+	}
+	if dest.Len() == 0 {
+		*dest.orig = *es.orig
+		*es.orig = nil
+		return
+	}
+	*dest.orig = append(*dest.orig, *es.orig...)
+	*es.orig = nil
+	return
 }
 
 // Resize is an operation that resizes the slice:

--- a/internal/data/generated_trace_test.go
+++ b/internal/data/generated_trace_test.go
@@ -30,19 +30,49 @@ func TestResourceSpansSlice(t *testing.T) {
 	es = newResourceSpansSlice(&[]*otlptrace.ResourceSpans{})
 	assert.EqualValues(t, 0, es.Len())
 
-	es.Resize(13)
+	es.Resize(7)
 	emptyVal := NewResourceSpans()
 	emptyVal.InitEmpty()
 	testVal := generateTestResourceSpans()
-	assert.EqualValues(t, 13, es.Len())
+	assert.EqualValues(t, 7, es.Len())
 	for i := 0; i < es.Len(); i++ {
 		assert.EqualValues(t, emptyVal, es.At(i))
 		fillTestResourceSpans(es.At(i))
 		assert.EqualValues(t, testVal, es.At(i))
 	}
+}
 
+func TestResourceSpansSliceMoveTo(t *testing.T) {
+	// Test MoveTo to empty
+	expectedSlice := generateTestResourceSpansSlice()
+	dest := NewResourceSpansSlice()
+	src := generateTestResourceSpansSlice()
+	src.MoveTo(dest)
+	assert.EqualValues(t, generateTestResourceSpansSlice(), dest)
+	assert.EqualValues(t, 0, src.Len())
+	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
+
+	// Test MoveTo empty slice
+	src.MoveTo(dest)
+	assert.EqualValues(t, generateTestResourceSpansSlice(), dest)
+	assert.EqualValues(t, 0, src.Len())
+	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
+
+	// Test MoveTo not empty slice
+	generateTestResourceSpansSlice().MoveTo(dest)
+	assert.EqualValues(t, 2*expectedSlice.Len(), dest.Len())
+	for i := 0; i < expectedSlice.Len(); i++ {
+		assert.EqualValues(t, expectedSlice.At(i), dest.At(i))
+		assert.EqualValues(t, expectedSlice.At(i), dest.At(i+expectedSlice.Len()))
+	}
+}
+
+func TestResourceSpansSliceResize(t *testing.T) {
+	es := generateTestResourceSpansSlice()
+	emptyVal := NewResourceSpans()
+	emptyVal.InitEmpty()
 	// Test Resize less elements.
-	const resizeSmallLen = 10
+	const resizeSmallLen = 4
 	expectedEs := make(map[*otlptrace.ResourceSpans]bool, resizeSmallLen)
 	for i := 0; i < resizeSmallLen; i++ {
 		expectedEs[*(es.At(i).orig)] = true
@@ -57,7 +87,7 @@ func TestResourceSpansSlice(t *testing.T) {
 	assert.EqualValues(t, expectedEs, foundEs)
 
 	// Test Resize more elements.
-	const resizeLargeLen = 13
+	const resizeLargeLen = 7
 	oldLen := es.Len()
 	expectedEs = make(map[*otlptrace.ResourceSpans]bool, oldLen)
 	for i := 0; i < oldLen; i++ {
@@ -106,19 +136,49 @@ func TestInstrumentationLibrarySpansSlice(t *testing.T) {
 	es = newInstrumentationLibrarySpansSlice(&[]*otlptrace.InstrumentationLibrarySpans{})
 	assert.EqualValues(t, 0, es.Len())
 
-	es.Resize(13)
+	es.Resize(7)
 	emptyVal := NewInstrumentationLibrarySpans()
 	emptyVal.InitEmpty()
 	testVal := generateTestInstrumentationLibrarySpans()
-	assert.EqualValues(t, 13, es.Len())
+	assert.EqualValues(t, 7, es.Len())
 	for i := 0; i < es.Len(); i++ {
 		assert.EqualValues(t, emptyVal, es.At(i))
 		fillTestInstrumentationLibrarySpans(es.At(i))
 		assert.EqualValues(t, testVal, es.At(i))
 	}
+}
 
+func TestInstrumentationLibrarySpansSliceMoveTo(t *testing.T) {
+	// Test MoveTo to empty
+	expectedSlice := generateTestInstrumentationLibrarySpansSlice()
+	dest := NewInstrumentationLibrarySpansSlice()
+	src := generateTestInstrumentationLibrarySpansSlice()
+	src.MoveTo(dest)
+	assert.EqualValues(t, generateTestInstrumentationLibrarySpansSlice(), dest)
+	assert.EqualValues(t, 0, src.Len())
+	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
+
+	// Test MoveTo empty slice
+	src.MoveTo(dest)
+	assert.EqualValues(t, generateTestInstrumentationLibrarySpansSlice(), dest)
+	assert.EqualValues(t, 0, src.Len())
+	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
+
+	// Test MoveTo not empty slice
+	generateTestInstrumentationLibrarySpansSlice().MoveTo(dest)
+	assert.EqualValues(t, 2*expectedSlice.Len(), dest.Len())
+	for i := 0; i < expectedSlice.Len(); i++ {
+		assert.EqualValues(t, expectedSlice.At(i), dest.At(i))
+		assert.EqualValues(t, expectedSlice.At(i), dest.At(i+expectedSlice.Len()))
+	}
+}
+
+func TestInstrumentationLibrarySpansSliceResize(t *testing.T) {
+	es := generateTestInstrumentationLibrarySpansSlice()
+	emptyVal := NewInstrumentationLibrarySpans()
+	emptyVal.InitEmpty()
 	// Test Resize less elements.
-	const resizeSmallLen = 10
+	const resizeSmallLen = 4
 	expectedEs := make(map[*otlptrace.InstrumentationLibrarySpans]bool, resizeSmallLen)
 	for i := 0; i < resizeSmallLen; i++ {
 		expectedEs[*(es.At(i).orig)] = true
@@ -133,7 +193,7 @@ func TestInstrumentationLibrarySpansSlice(t *testing.T) {
 	assert.EqualValues(t, expectedEs, foundEs)
 
 	// Test Resize more elements.
-	const resizeLargeLen = 13
+	const resizeLargeLen = 7
 	oldLen := es.Len()
 	expectedEs = make(map[*otlptrace.InstrumentationLibrarySpans]bool, oldLen)
 	for i := 0; i < oldLen; i++ {
@@ -182,19 +242,49 @@ func TestSpanSlice(t *testing.T) {
 	es = newSpanSlice(&[]*otlptrace.Span{})
 	assert.EqualValues(t, 0, es.Len())
 
-	es.Resize(13)
+	es.Resize(7)
 	emptyVal := NewSpan()
 	emptyVal.InitEmpty()
 	testVal := generateTestSpan()
-	assert.EqualValues(t, 13, es.Len())
+	assert.EqualValues(t, 7, es.Len())
 	for i := 0; i < es.Len(); i++ {
 		assert.EqualValues(t, emptyVal, es.At(i))
 		fillTestSpan(es.At(i))
 		assert.EqualValues(t, testVal, es.At(i))
 	}
+}
 
+func TestSpanSliceMoveTo(t *testing.T) {
+	// Test MoveTo to empty
+	expectedSlice := generateTestSpanSlice()
+	dest := NewSpanSlice()
+	src := generateTestSpanSlice()
+	src.MoveTo(dest)
+	assert.EqualValues(t, generateTestSpanSlice(), dest)
+	assert.EqualValues(t, 0, src.Len())
+	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
+
+	// Test MoveTo empty slice
+	src.MoveTo(dest)
+	assert.EqualValues(t, generateTestSpanSlice(), dest)
+	assert.EqualValues(t, 0, src.Len())
+	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
+
+	// Test MoveTo not empty slice
+	generateTestSpanSlice().MoveTo(dest)
+	assert.EqualValues(t, 2*expectedSlice.Len(), dest.Len())
+	for i := 0; i < expectedSlice.Len(); i++ {
+		assert.EqualValues(t, expectedSlice.At(i), dest.At(i))
+		assert.EqualValues(t, expectedSlice.At(i), dest.At(i+expectedSlice.Len()))
+	}
+}
+
+func TestSpanSliceResize(t *testing.T) {
+	es := generateTestSpanSlice()
+	emptyVal := NewSpan()
+	emptyVal.InitEmpty()
 	// Test Resize less elements.
-	const resizeSmallLen = 10
+	const resizeSmallLen = 4
 	expectedEs := make(map[*otlptrace.Span]bool, resizeSmallLen)
 	for i := 0; i < resizeSmallLen; i++ {
 		expectedEs[*(es.At(i).orig)] = true
@@ -209,7 +299,7 @@ func TestSpanSlice(t *testing.T) {
 	assert.EqualValues(t, expectedEs, foundEs)
 
 	// Test Resize more elements.
-	const resizeLargeLen = 13
+	const resizeLargeLen = 7
 	oldLen := es.Len()
 	expectedEs = make(map[*otlptrace.Span]bool, oldLen)
 	for i := 0; i < oldLen; i++ {
@@ -323,19 +413,49 @@ func TestSpanEventSlice(t *testing.T) {
 	es = newSpanEventSlice(&[]*otlptrace.Span_Event{})
 	assert.EqualValues(t, 0, es.Len())
 
-	es.Resize(13)
+	es.Resize(7)
 	emptyVal := NewSpanEvent()
 	emptyVal.InitEmpty()
 	testVal := generateTestSpanEvent()
-	assert.EqualValues(t, 13, es.Len())
+	assert.EqualValues(t, 7, es.Len())
 	for i := 0; i < es.Len(); i++ {
 		assert.EqualValues(t, emptyVal, es.At(i))
 		fillTestSpanEvent(es.At(i))
 		assert.EqualValues(t, testVal, es.At(i))
 	}
+}
 
+func TestSpanEventSliceMoveTo(t *testing.T) {
+	// Test MoveTo to empty
+	expectedSlice := generateTestSpanEventSlice()
+	dest := NewSpanEventSlice()
+	src := generateTestSpanEventSlice()
+	src.MoveTo(dest)
+	assert.EqualValues(t, generateTestSpanEventSlice(), dest)
+	assert.EqualValues(t, 0, src.Len())
+	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
+
+	// Test MoveTo empty slice
+	src.MoveTo(dest)
+	assert.EqualValues(t, generateTestSpanEventSlice(), dest)
+	assert.EqualValues(t, 0, src.Len())
+	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
+
+	// Test MoveTo not empty slice
+	generateTestSpanEventSlice().MoveTo(dest)
+	assert.EqualValues(t, 2*expectedSlice.Len(), dest.Len())
+	for i := 0; i < expectedSlice.Len(); i++ {
+		assert.EqualValues(t, expectedSlice.At(i), dest.At(i))
+		assert.EqualValues(t, expectedSlice.At(i), dest.At(i+expectedSlice.Len()))
+	}
+}
+
+func TestSpanEventSliceResize(t *testing.T) {
+	es := generateTestSpanEventSlice()
+	emptyVal := NewSpanEvent()
+	emptyVal.InitEmpty()
 	// Test Resize less elements.
-	const resizeSmallLen = 10
+	const resizeSmallLen = 4
 	expectedEs := make(map[*otlptrace.Span_Event]bool, resizeSmallLen)
 	for i := 0; i < resizeSmallLen; i++ {
 		expectedEs[*(es.At(i).orig)] = true
@@ -350,7 +470,7 @@ func TestSpanEventSlice(t *testing.T) {
 	assert.EqualValues(t, expectedEs, foundEs)
 
 	// Test Resize more elements.
-	const resizeLargeLen = 13
+	const resizeLargeLen = 7
 	oldLen := es.Len()
 	expectedEs = make(map[*otlptrace.Span_Event]bool, oldLen)
 	for i := 0; i < oldLen; i++ {
@@ -408,19 +528,49 @@ func TestSpanLinkSlice(t *testing.T) {
 	es = newSpanLinkSlice(&[]*otlptrace.Span_Link{})
 	assert.EqualValues(t, 0, es.Len())
 
-	es.Resize(13)
+	es.Resize(7)
 	emptyVal := NewSpanLink()
 	emptyVal.InitEmpty()
 	testVal := generateTestSpanLink()
-	assert.EqualValues(t, 13, es.Len())
+	assert.EqualValues(t, 7, es.Len())
 	for i := 0; i < es.Len(); i++ {
 		assert.EqualValues(t, emptyVal, es.At(i))
 		fillTestSpanLink(es.At(i))
 		assert.EqualValues(t, testVal, es.At(i))
 	}
+}
 
+func TestSpanLinkSliceMoveTo(t *testing.T) {
+	// Test MoveTo to empty
+	expectedSlice := generateTestSpanLinkSlice()
+	dest := NewSpanLinkSlice()
+	src := generateTestSpanLinkSlice()
+	src.MoveTo(dest)
+	assert.EqualValues(t, generateTestSpanLinkSlice(), dest)
+	assert.EqualValues(t, 0, src.Len())
+	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
+
+	// Test MoveTo empty slice
+	src.MoveTo(dest)
+	assert.EqualValues(t, generateTestSpanLinkSlice(), dest)
+	assert.EqualValues(t, 0, src.Len())
+	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
+
+	// Test MoveTo not empty slice
+	generateTestSpanLinkSlice().MoveTo(dest)
+	assert.EqualValues(t, 2*expectedSlice.Len(), dest.Len())
+	for i := 0; i < expectedSlice.Len(); i++ {
+		assert.EqualValues(t, expectedSlice.At(i), dest.At(i))
+		assert.EqualValues(t, expectedSlice.At(i), dest.At(i+expectedSlice.Len()))
+	}
+}
+
+func TestSpanLinkSliceResize(t *testing.T) {
+	es := generateTestSpanLinkSlice()
+	emptyVal := NewSpanLink()
+	emptyVal.InitEmpty()
 	// Test Resize less elements.
-	const resizeSmallLen = 10
+	const resizeSmallLen = 4
 	expectedEs := make(map[*otlptrace.Span_Link]bool, resizeSmallLen)
 	for i := 0; i < resizeSmallLen; i++ {
 		expectedEs[*(es.At(i).orig)] = true
@@ -435,7 +585,7 @@ func TestSpanLinkSlice(t *testing.T) {
 	assert.EqualValues(t, expectedEs, foundEs)
 
 	// Test Resize more elements.
-	const resizeLargeLen = 13
+	const resizeLargeLen = 7
 	oldLen := es.Len()
 	expectedEs = make(map[*otlptrace.Span_Link]bool, oldLen)
 	for i := 0; i < oldLen; i++ {
@@ -518,7 +668,7 @@ func generateTestResourceSpansSlice() ResourceSpansSlice {
 }
 
 func fillTestResourceSpansSlice(tv ResourceSpansSlice) {
-	tv.Resize(13)
+	tv.Resize(7)
 	for i := 0; i < tv.Len(); i++ {
 		fillTestResourceSpans(tv.At(i))
 	}
@@ -544,7 +694,7 @@ func generateTestInstrumentationLibrarySpansSlice() InstrumentationLibrarySpansS
 }
 
 func fillTestInstrumentationLibrarySpansSlice(tv InstrumentationLibrarySpansSlice) {
-	tv.Resize(13)
+	tv.Resize(7)
 	for i := 0; i < tv.Len(); i++ {
 		fillTestInstrumentationLibrarySpans(tv.At(i))
 	}
@@ -570,7 +720,7 @@ func generateTestSpanSlice() SpanSlice {
 }
 
 func fillTestSpanSlice(tv SpanSlice) {
-	tv.Resize(13)
+	tv.Resize(7)
 	for i := 0; i < tv.Len(); i++ {
 		fillTestSpan(tv.At(i))
 	}
@@ -609,7 +759,7 @@ func generateTestSpanEventSlice() SpanEventSlice {
 }
 
 func fillTestSpanEventSlice(tv SpanEventSlice) {
-	tv.Resize(13)
+	tv.Resize(7)
 	for i := 0; i < tv.Len(); i++ {
 		fillTestSpanEvent(tv.At(i))
 	}
@@ -636,7 +786,7 @@ func generateTestSpanLinkSlice() SpanLinkSlice {
 }
 
 func fillTestSpanLinkSlice(tv SpanLinkSlice) {
-	tv.Resize(13)
+	tv.Resize(7)
 	for i := 0; i < tv.Len(); i++ {
 		fillTestSpanLink(tv.At(i))
 	}


### PR DESCRIPTION
Split Slice tests to allow parallelism and reduce the number of elements in the generated data for slices.