### PR TITLE
Add pdata.Metrics with an opaque internal data.

### DIFF
--- a/consumer/consumer.go
+++ b/consumer/consumer.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-collector/consumer/pdata"
-	"github.com/open-telemetry/opentelemetry-collector/internal/data"
 )
 
 // MetricsConsumerBase defines a common interface for MetricsConsumerOld and MetricsConsumer.
@@ -39,7 +38,7 @@ type MetricsConsumerOld interface {
 // as needed, and sends it to the next processing node if any or to the destination.
 type MetricsConsumer interface {
 	MetricsConsumerBase
-	ConsumeMetrics(ctx context.Context, md data.MetricData) error
+	ConsumeMetrics(ctx context.Context, md pdata.Metrics) error
 }
 
 // TraceConsumerBase defines a common interface for TraceConsumerOld and TraceConsumer.

--- a/consumer/converter/converter_test.go
+++ b/consumer/converter/converter_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/open-telemetry/opentelemetry-collector/consumer/pdatautil"
 	"github.com/open-telemetry/opentelemetry-collector/exporter/exportertest"
 	"github.com/open-telemetry/opentelemetry-collector/internal/data/testdata"
 	"github.com/open-telemetry/opentelemetry-collector/translator/internaldata"
@@ -47,7 +48,7 @@ func TestNewInternalToOCMetricsConverter(t *testing.T) {
 	metricsExporterOld := new(exportertest.SinkMetricsExporterOld)
 	converter := NewInternalToOCMetricsConverter(metricsExporterOld)
 
-	err := converter.ConsumeMetrics(context.Background(), md)
+	err := converter.ConsumeMetrics(context.Background(), pdatautil.MetricsFromInternalMetrics(md))
 	assert.Nil(t, err)
 
 	ocMetrics := metricsExporterOld.AllMetrics()
@@ -55,7 +56,7 @@ func TestNewInternalToOCMetricsConverter(t *testing.T) {
 	assert.EqualValues(t, ocMetrics, internaldata.MetricDataToOC(md))
 
 	metricsExporterOld.SetConsumeMetricsError(fmt.Errorf("consumer error"))
-	err = converter.ConsumeMetrics(context.Background(), md)
+	err = converter.ConsumeMetrics(context.Background(), pdatautil.MetricsFromInternalMetrics(md))
 	assert.NotNil(t, err)
 }
 
@@ -92,7 +93,8 @@ func TestNewOCToInternalMetricsConverter(t *testing.T) {
 
 	ocMetrics := metricsExporter.AllMetrics()
 	assert.Equal(t, len(ocMetrics), 2)
-	assert.EqualValues(t, ocMetrics[0], md)
+	assert.EqualValues(t, pdatautil.MetricsToInternalMetrics(ocMetrics[0]), md)
+	assert.EqualValues(t, pdatautil.MetricsToInternalMetrics(ocMetrics[1]), md)
 
 	metricsExporter.SetConsumeMetricsError(fmt.Errorf("consumer error"))
 	err = converter.ConsumeMetricsData(context.Background(), ocMetricData)

--- a/consumer/pdata/metric.go
+++ b/consumer/pdata/metric.go
@@ -31,6 +31,18 @@ const (
 	MetricTypeSummary             = MetricType(otlpmetrics.MetricDescriptor_SUMMARY)
 )
 
+// InternalNewMetricsResourceSlice is a helper
 func InternalNewMetricsResourceSlice(orig *[]*otlpmetrics.ResourceMetrics) ResourceMetricsSlice {
 	return newResourceMetricsSlice(orig)
+}
+
+// Metrics is an opaque interface that allows transition to the new internal Metrics data, but also facilitate the
+// transition to the new components especially for traces.
+//
+// Outside of the core repository the metrics pipeline cannot be converted to the new model since data.MetricData is
+// part of the internal package.
+//
+// IMPORTANT: Do not try to convert to/from this manually, use the helper functions in the pdatautil instead.
+type Metrics struct {
+	InternalOpaque interface{}
 }

--- a/consumer/pdatautil/empty_test.go
+++ b/consumer/pdatautil/empty_test.go
@@ -1,0 +1,17 @@
+// Copyright 2019, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pdatautil
+
+// Temporary package.

--- a/consumer/pdatautil/pdatautil.go
+++ b/consumer/pdatautil/pdatautil.go
@@ -1,0 +1,148 @@
+// Copyright 2020 OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package pdatautil is a temporary package to allow components to transition to the new API.
+// It will be removed when pdata.Metrics will be finalized.
+package pdatautil
+
+import (
+	commonpb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
+	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
+	resourcepb "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
+	"github.com/golang/protobuf/proto"
+
+	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
+	"github.com/open-telemetry/opentelemetry-collector/consumer/pdata"
+	"github.com/open-telemetry/opentelemetry-collector/internal/data"
+	"github.com/open-telemetry/opentelemetry-collector/translator/internaldata"
+)
+
+// MetricsToMetricsData returns the `[]consumerdata.MetricsData` representation of the `pdata.Metrics`.
+//
+// This is a temporary function that will be removed when the new internal pdata.Metrics will be finalized.
+func MetricsToMetricsData(md pdata.Metrics) []consumerdata.MetricsData {
+	if cmd, ok := md.InternalOpaque.([]consumerdata.MetricsData); ok {
+		return cmd
+	}
+	if ims, ok := md.InternalOpaque.(data.MetricData); ok {
+		return internaldata.MetricDataToOC(ims)
+	}
+	panic("Unsupported metrics type.")
+}
+
+// MetricsFromMetricsData returns the `pdata.Metrics` representation of the `[]consumerdata.MetricsData`.
+//
+// This is a temporary function that will be removed when the new internal pdata.Metrics will be finalized.
+func MetricsFromMetricsData(ocmds []consumerdata.MetricsData) pdata.Metrics {
+	return pdata.Metrics{InternalOpaque: ocmds}
+}
+
+// MetricsToInternalMetrics returns the `data.MetricData` representation of the `pdata.Metrics`.
+//
+// This is a temporary function that will be removed when the new internal pdata.Metrics will be finalized.
+func MetricsToInternalMetrics(md pdata.Metrics) data.MetricData {
+	if ims, ok := md.InternalOpaque.(data.MetricData); ok {
+		return ims
+	}
+	if cmd, ok := md.InternalOpaque.([]consumerdata.MetricsData); ok {
+		return internaldata.OCSliceToMetricData(cmd)
+	}
+	panic("Unsupported metrics type.")
+}
+
+// MetricsFromMetricsData returns the `pdata.Metrics` representation of the `data.MetricData`.
+//
+// This is a temporary function that will be removed when the new internal pdata.Metrics will be finalized.
+func MetricsFromInternalMetrics(md data.MetricData) pdata.Metrics {
+	return pdata.Metrics{InternalOpaque: md}
+}
+
+// CloneMetrics returns a clone of the given `pdata.Metrics`.
+//
+// This is a temporary function that will be removed when the new internal pdata.Metrics will be finalized.
+func CloneMetrics(md pdata.Metrics) pdata.Metrics {
+	if ims, ok := md.InternalOpaque.(data.MetricData); ok {
+		return pdata.Metrics{InternalOpaque: ims.Clone()}
+	}
+	if ocmds, ok := md.InternalOpaque.([]consumerdata.MetricsData); ok {
+		clone := make([]consumerdata.MetricsData, 0, len(ocmds))
+		for _, ocmd := range ocmds {
+			clone = append(clone, CloneMetricsDataOld(ocmd))
+		}
+		return pdata.Metrics{InternalOpaque: clone}
+	}
+	panic("Unsupported metrics type.")
+}
+
+func MetricCount(md pdata.Metrics) int {
+	if ims, ok := md.InternalOpaque.(data.MetricData); ok {
+		return ims.MetricCount()
+	}
+	if ocmds, ok := md.InternalOpaque.([]consumerdata.MetricsData); ok {
+		metricCount := 0
+		for _, ocmd := range ocmds {
+			metricCount += len(ocmd.Metrics)
+		}
+	}
+	panic("Unsupported metrics type.")
+}
+
+func MetricAndDataPointCount(md pdata.Metrics) (int, int) {
+	if ims, ok := md.InternalOpaque.(data.MetricData); ok {
+		return ims.MetricAndDataPointCount()
+	}
+	if ocmds, ok := md.InternalOpaque.([]consumerdata.MetricsData); ok {
+		metricCount := 0
+		dataPointCount := 0
+		for _, ocmd := range ocmds {
+			mc, dpc := TimeseriesAndPointCount(ocmd)
+			metricCount += mc
+			dataPointCount += dpc
+		}
+	}
+	panic("Unsupported metrics type.")
+}
+
+// CloneMetricsDataOld copied from processors.cloneMetricsDataOld
+func CloneMetricsDataOld(md consumerdata.MetricsData) consumerdata.MetricsData {
+	clone := consumerdata.MetricsData{
+		Node:     proto.Clone(md.Node).(*commonpb.Node),
+		Resource: proto.Clone(md.Resource).(*resourcepb.Resource),
+	}
+
+	if md.Metrics != nil {
+		clone.Metrics = make([]*metricspb.Metric, 0, len(md.Metrics))
+
+		for _, metric := range md.Metrics {
+			metricClone := proto.Clone(metric).(*metricspb.Metric)
+			clone.Metrics = append(clone.Metrics, metricClone)
+		}
+	}
+
+	return clone
+}
+
+// TimeseriesAndPointCount copied from exporterhelper.measureMetricsExport
+func TimeseriesAndPointCount(md consumerdata.MetricsData) (int, int) {
+	numTimeSeries := 0
+	numPoints := 0
+	for _, metric := range md.Metrics {
+		tss := metric.GetTimeseries()
+		numTimeSeries += len(metric.GetTimeseries())
+		for _, ts := range tss {
+			numPoints += len(ts.GetPoints())
+		}
+	}
+	return numTimeSeries, numPoints
+}

--- a/exporter/exportertest/nop_exporter.go
+++ b/exporter/exportertest/nop_exporter.go
@@ -20,7 +20,6 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector/component"
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-collector/consumer/pdata"
-	"github.com/open-telemetry/opentelemetry-collector/internal/data"
 )
 
 type nopExporterOld struct {
@@ -79,7 +78,7 @@ func (ne *nopExporter) ConsumeTraces(_ context.Context, _ pdata.Traces) error {
 	return ne.retError
 }
 
-func (ne *nopExporter) ConsumeMetrics(_ context.Context, _ data.MetricData) error {
+func (ne *nopExporter) ConsumeMetrics(ctx context.Context, md pdata.Metrics) error {
 	return ne.retError
 }
 

--- a/exporter/exportertest/nop_exporter_test.go
+++ b/exporter/exportertest/nop_exporter_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-collector/consumer/pdata"
+	"github.com/open-telemetry/opentelemetry-collector/consumer/pdatautil"
 	"github.com/open-telemetry/opentelemetry-collector/internal/data"
 )
 
@@ -56,6 +57,6 @@ func TestNopTraceExporter(t *testing.T) {
 func TestNopMetricsExporter(t *testing.T) {
 	nme := NewNopMetricsExporter()
 	require.NoError(t, nme.Start(context.Background(), nil))
-	require.NoError(t, nme.ConsumeMetrics(context.Background(), data.NewMetricData()))
+	require.NoError(t, nme.ConsumeMetrics(context.Background(), pdatautil.MetricsFromInternalMetrics(data.NewMetricData())))
 	require.NoError(t, nme.Shutdown(context.Background()))
 }

--- a/exporter/exportertest/sink_exporter.go
+++ b/exporter/exportertest/sink_exporter.go
@@ -21,7 +21,6 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector/component"
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-collector/consumer/pdata"
-	"github.com/open-telemetry/opentelemetry-collector/internal/data"
 )
 
 // SinkTraceExporterOld acts as a trace receiver for use in tests.
@@ -166,7 +165,7 @@ func (sme *SinkMetricsExporterOld) Shutdown(context.Context) error {
 type SinkMetricsExporter struct {
 	consumeMetricsError error // to be returned by ConsumeMetrics, if set
 	mu                  sync.Mutex
-	metrics             []data.MetricData
+	metrics             []pdata.Metrics
 }
 
 // SetConsumeMetricsError sets an error that will be returned by ConsumeMetrics
@@ -182,7 +181,7 @@ func (sme *SinkMetricsExporter) Start(ctx context.Context, host component.Host) 
 }
 
 // ConsumeMetricsData stores traces for tests.
-func (sme *SinkMetricsExporter) ConsumeMetrics(ctx context.Context, md data.MetricData) error {
+func (sme *SinkMetricsExporter) ConsumeMetrics(_ context.Context, md pdata.Metrics) error {
 	if sme.consumeMetricsError != nil {
 		return sme.consumeMetricsError
 	}
@@ -196,7 +195,7 @@ func (sme *SinkMetricsExporter) ConsumeMetrics(ctx context.Context, md data.Metr
 }
 
 // AllMetrics returns the metrics sent to the test sink.
-func (sme *SinkMetricsExporter) AllMetrics() []data.MetricData {
+func (sme *SinkMetricsExporter) AllMetrics() []pdata.Metrics {
 	sme.mu.Lock()
 	defer sme.mu.Unlock()
 

--- a/exporter/exportertest/sink_exporter_test.go
+++ b/exporter/exportertest/sink_exporter_test.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-collector/consumer/pdata"
-	"github.com/open-telemetry/opentelemetry-collector/internal/data"
+	"github.com/open-telemetry/opentelemetry-collector/consumer/pdatautil"
 	"github.com/open-telemetry/opentelemetry-collector/internal/data/testdata"
 )
 
@@ -74,11 +74,11 @@ func TestSinkMetricsExporterOld(t *testing.T) {
 func TestSinkMetricsExporter(t *testing.T) {
 	sink := new(SinkMetricsExporter)
 	md := testdata.GenerateMetricDataOneMetric()
-	want := make([]data.MetricData, 0, 7)
+	want := make([]pdata.Metrics, 0, 7)
 	for i := 0; i < 7; i++ {
-		err := sink.ConsumeMetrics(context.Background(), md)
+		err := sink.ConsumeMetrics(context.Background(), pdatautil.MetricsFromInternalMetrics(md))
 		require.Nil(t, err)
-		want = append(want, md)
+		want = append(want, pdatautil.MetricsFromInternalMetrics(md))
 	}
 	got := sink.AllMetrics()
 	assert.Equal(t, want, got)

--- a/exporter/loggingexporter/logging_exporter.go
+++ b/exporter/loggingexporter/logging_exporter.go
@@ -27,8 +27,8 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector/component"
 	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
 	"github.com/open-telemetry/opentelemetry-collector/consumer/pdata"
+	"github.com/open-telemetry/opentelemetry-collector/consumer/pdatautil"
 	"github.com/open-telemetry/opentelemetry-collector/exporter/exporterhelper"
-	"github.com/open-telemetry/opentelemetry-collector/internal/data"
 )
 
 type logDataBuffer struct {
@@ -151,16 +151,17 @@ func (s *loggingExporter) pushTraceData(
 
 func (s *loggingExporter) pushMetricsData(
 	_ context.Context,
-	md data.MetricData,
+	md pdata.Metrics,
 ) (int, error) {
-	s.logger.Info("MetricsExporter", zap.Int("#metrics", md.MetricCount()))
+	imd := pdatautil.MetricsToInternalMetrics(md)
+	s.logger.Info("MetricsExporter", zap.Int("#metrics", imd.MetricCount()))
 
 	if !s.debug {
 		return 0, nil
 	}
 
 	buf := logDataBuffer{}
-	rms := md.ResourceMetrics()
+	rms := imd.ResourceMetrics()
 	for i := 0; i < rms.Len(); i++ {
 		buf.logEntry("ResourceMetrics #%d", i)
 		rm := rms.At(i)

--- a/exporter/loggingexporter/logging_exporter_test.go
+++ b/exporter/loggingexporter/logging_exporter_test.go
@@ -22,6 +22,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
+	"github.com/open-telemetry/opentelemetry-collector/consumer/pdatautil"
 	"github.com/open-telemetry/opentelemetry-collector/internal/data/testdata"
 )
 
@@ -44,11 +45,11 @@ func TestLoggingMetricsExporterNoErrors(t *testing.T) {
 	require.NotNil(t, lme)
 	assert.NoError(t, err)
 
-	assert.NoError(t, lme.ConsumeMetrics(context.Background(), testdata.GenerateMetricDataEmpty()))
-	assert.NoError(t, lme.ConsumeMetrics(context.Background(), testdata.GenerateMetricDataOneEmptyOneNilResourceMetrics()))
-	assert.NoError(t, lme.ConsumeMetrics(context.Background(), testdata.GenerateMetricDataOneEmptyOneNilInstrumentationLibrary()))
-	assert.NoError(t, lme.ConsumeMetrics(context.Background(), testdata.GenerateMetricDataOneMetricOneNil()))
-	assert.NoError(t, lme.ConsumeMetrics(context.Background(), testdata.GenerateMetricDataWithCountersHistogramAndSummary()))
+	assert.NoError(t, lme.ConsumeMetrics(context.Background(), pdatautil.MetricsFromInternalMetrics(testdata.GenerateMetricDataEmpty())))
+	assert.NoError(t, lme.ConsumeMetrics(context.Background(), pdatautil.MetricsFromInternalMetrics(testdata.GenerateMetricDataOneEmptyOneNilResourceMetrics())))
+	assert.NoError(t, lme.ConsumeMetrics(context.Background(), pdatautil.MetricsFromInternalMetrics(testdata.GenerateMetricDataOneEmptyOneNilInstrumentationLibrary())))
+	assert.NoError(t, lme.ConsumeMetrics(context.Background(), pdatautil.MetricsFromInternalMetrics(testdata.GenerateMetricDataOneMetricOneNil())))
+	assert.NoError(t, lme.ConsumeMetrics(context.Background(), pdatautil.MetricsFromInternalMetrics(testdata.GenerateMetricDataWithCountersHistogramAndSummary())))
 
 	assert.NoError(t, lme.Shutdown(context.Background()))
 }

--- a/processor/fanoutconnector.go
+++ b/processor/fanoutconnector.go
@@ -22,7 +22,6 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-collector/consumer/converter"
 	"github.com/open-telemetry/opentelemetry-collector/consumer/pdata"
-	"github.com/open-telemetry/opentelemetry-collector/internal/data"
 )
 
 // This file contains implementations of Trace/Metrics connectors
@@ -82,7 +81,7 @@ type metricsFanOutConnector []consumer.MetricsConsumer
 var _ consumer.MetricsConsumer = (*metricsFanOutConnector)(nil)
 
 // ConsumeMetricsData exports the MetricsData to all consumers wrapped by the current one.
-func (mfc metricsFanOutConnector) ConsumeMetrics(ctx context.Context, md data.MetricData) error {
+func (mfc metricsFanOutConnector) ConsumeMetrics(ctx context.Context, md pdata.Metrics) error {
 	var errs []error
 	for _, mc := range mfc {
 		if err := mc.ConsumeMetrics(ctx, md); err != nil {

--- a/processor/memorylimiter/memorylimiter.go
+++ b/processor/memorylimiter/memorylimiter.go
@@ -27,7 +27,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector/component"
 	"github.com/open-telemetry/opentelemetry-collector/consumer"
 	"github.com/open-telemetry/opentelemetry-collector/consumer/pdata"
-	"github.com/open-telemetry/opentelemetry-collector/internal/data"
+	"github.com/open-telemetry/opentelemetry-collector/consumer/pdatautil"
 	"github.com/open-telemetry/opentelemetry-collector/obsreport"
 	"github.com/open-telemetry/opentelemetry-collector/processor"
 )
@@ -146,13 +146,10 @@ func (ml *memoryLimiter) ConsumeTraces(
 	return ml.traceConsumer.ConsumeTraces(ctx, td)
 }
 
-func (ml *memoryLimiter) ConsumeMetrics(
-	ctx context.Context,
-	md data.MetricData,
-) error {
+func (ml *memoryLimiter) ConsumeMetrics(ctx context.Context, md pdata.Metrics) error {
 
 	ctx = obsreport.ProcessorContext(ctx, ml.procName)
-	_, numDataPoints := md.MetricAndDataPointCount()
+	_, numDataPoints := pdatautil.MetricAndDataPointCount(md)
 	if ml.forcingDrop() {
 		stats.Record(
 			ctx,

--- a/processor/memorylimiter/memorylimiter_test.go
+++ b/processor/memorylimiter/memorylimiter_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-collector/consumer"
 	"github.com/open-telemetry/opentelemetry-collector/consumer/pdata"
+	"github.com/open-telemetry/opentelemetry-collector/consumer/pdatautil"
 	"github.com/open-telemetry/opentelemetry-collector/exporter/exportertest"
 	"github.com/open-telemetry/opentelemetry-collector/internal/data"
 )
@@ -112,17 +113,17 @@ func TestMetricsMemoryPressureResponse(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	td := data.NewMetricData()
+	md := data.NewMetricData()
 
 	// Below memAllocLimit.
 	currentMemAlloc = 800
 	ml.memCheck()
-	assert.NoError(t, ml.ConsumeMetrics(ctx, td))
+	assert.NoError(t, ml.ConsumeMetrics(ctx, pdatautil.MetricsFromInternalMetrics(md)))
 
 	// Above memAllocLimit.
 	currentMemAlloc = 1800
 	ml.memCheck()
-	assert.Equal(t, errForcedDrop, ml.ConsumeMetrics(ctx, td))
+	assert.Equal(t, errForcedDrop, ml.ConsumeMetrics(ctx, pdatautil.MetricsFromInternalMetrics(md)))
 
 	// Check ballast effect
 	ml.ballastSize = 1000
@@ -130,12 +131,12 @@ func TestMetricsMemoryPressureResponse(t *testing.T) {
 	// Below memAllocLimit accounting for ballast.
 	currentMemAlloc = 800 + ml.ballastSize
 	ml.memCheck()
-	assert.NoError(t, ml.ConsumeMetrics(ctx, td))
+	assert.NoError(t, ml.ConsumeMetrics(ctx, pdatautil.MetricsFromInternalMetrics(md)))
 
 	// Above memAllocLimit even accountiing for ballast.
 	currentMemAlloc = 1800 + ml.ballastSize
 	ml.memCheck()
-	assert.Equal(t, errForcedDrop, ml.ConsumeMetrics(ctx, td))
+	assert.Equal(t, errForcedDrop, ml.ConsumeMetrics(ctx, pdatautil.MetricsFromInternalMetrics(md)))
 
 	// Restore ballast to default.
 	ml.ballastSize = 0
@@ -146,12 +147,12 @@ func TestMetricsMemoryPressureResponse(t *testing.T) {
 	// Below memSpikeLimit.
 	currentMemAlloc = 500
 	ml.memCheck()
-	assert.NoError(t, ml.ConsumeMetrics(ctx, td))
+	assert.NoError(t, ml.ConsumeMetrics(ctx, pdatautil.MetricsFromInternalMetrics(md)))
 
 	// Above memSpikeLimit.
 	currentMemAlloc = 550
 	ml.memCheck()
-	assert.Equal(t, errForcedDrop, ml.ConsumeMetrics(ctx, td))
+	assert.Equal(t, errForcedDrop, ml.ConsumeMetrics(ctx, pdatautil.MetricsFromInternalMetrics(md)))
 
 }
 

--- a/receiver/otlpreceiver/metrics/otlp.go
+++ b/receiver/otlpreceiver/metrics/otlp.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-collector/component/componenterror"
 	"github.com/open-telemetry/opentelemetry-collector/consumer"
+	"github.com/open-telemetry/opentelemetry-collector/consumer/pdatautil"
 	"github.com/open-telemetry/opentelemetry-collector/internal/data"
 	"github.com/open-telemetry/opentelemetry-collector/obsreport"
 )
@@ -72,7 +73,7 @@ func (r *Receiver) sendToNextConsumer(ctx context.Context, md data.MetricData) e
 	}
 
 	ctx = obsreport.StartMetricsReceiveOp(ctx, r.instanceName, receiverTransport)
-	err := r.nextConsumer.ConsumeMetrics(ctx, md)
+	err := r.nextConsumer.ConsumeMetrics(ctx, pdatautil.MetricsFromInternalMetrics(md))
 	obsreport.EndMetricsReceiveOp(ctx, dataFormatProtobuf, dataPointCount, metricCount, err)
 
 	return err

--- a/receiver/otlpreceiver/metrics/otlp_test.go
+++ b/receiver/otlpreceiver/metrics/otlp_test.go
@@ -29,6 +29,7 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/open-telemetry/opentelemetry-collector/consumer"
+	"github.com/open-telemetry/opentelemetry-collector/consumer/pdatautil"
 	"github.com/open-telemetry/opentelemetry-collector/exporter/exportertest"
 	"github.com/open-telemetry/opentelemetry-collector/internal/data"
 	"github.com/open-telemetry/opentelemetry-collector/observability"
@@ -126,7 +127,7 @@ func TestExport(t *testing.T) {
 	require.Equal(t, 1, len(metricSink.AllMetrics()),
 		"unexpected length: %v", len(metricSink.AllMetrics()))
 
-	assert.EqualValues(t, metricData, metricSink.AllMetrics()[0])
+	assert.EqualValues(t, metricData, pdatautil.MetricsToInternalMetrics(metricSink.AllMetrics()[0]))
 }
 
 func makeMetricsServiceClient(port int) (collectormetrics.MetricsServiceClient, func(), error) {

--- a/testbed/testbed/mock_backend.go
+++ b/testbed/testbed/mock_backend.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-collector/consumer/pdata"
-	"github.com/open-telemetry/opentelemetry-collector/internal/data"
+	"github.com/open-telemetry/opentelemetry-collector/consumer/pdatautil"
 )
 
 // MockBackend is a backend that allows receiving the data locally.
@@ -47,7 +47,7 @@ type MockBackend struct {
 	isRecording        bool
 	recordMutex        sync.Mutex
 	ReceivedTraces     []pdata.Traces
-	ReceivedMetrics    []data.MetricData
+	ReceivedMetrics    []pdata.Metrics
 	ReceivedTracesOld  []consumerdata.TraceData
 	ReceivedMetricsOld []consumerdata.MetricsData
 }
@@ -151,7 +151,7 @@ func (mb *MockBackend) ConsumeTraceOld(td consumerdata.TraceData) {
 	}
 }
 
-func (mb *MockBackend) ConsumeMetric(md data.MetricData) {
+func (mb *MockBackend) ConsumeMetric(md pdata.Metrics) {
 	mb.recordMutex.Lock()
 	defer mb.recordMutex.Unlock()
 	if mb.isRecording {
@@ -244,8 +244,8 @@ type MockMetricConsumer struct {
 	backend         *MockBackend
 }
 
-func (mc *MockMetricConsumer) ConsumeMetrics(ctx context.Context, md data.MetricData) error {
-	_, dataPoints := md.MetricAndDataPointCount()
+func (mc *MockMetricConsumer) ConsumeMetrics(_ context.Context, md pdata.Metrics) error {
+	_, dataPoints := pdatautil.MetricAndDataPointCount(md)
 	atomic.AddUint64(&mc.metricsReceived, uint64(dataPoints))
 	mc.backend.ConsumeMetric(md)
 	return nil

--- a/testbed/testbed/senders.go
+++ b/testbed/testbed/senders.go
@@ -24,6 +24,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector/config/configgrpc"
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-collector/consumer/pdata"
+	"github.com/open-telemetry/opentelemetry-collector/consumer/pdatautil"
 	"github.com/open-telemetry/opentelemetry-collector/exporter/jaegerexporter"
 	"github.com/open-telemetry/opentelemetry-collector/exporter/opencensusexporter"
 	"github.com/open-telemetry/opentelemetry-collector/exporter/otlpexporter"
@@ -369,7 +370,7 @@ func (ome *OTLPMetricsDataSender) Start() error {
 }
 
 func (ome *OTLPMetricsDataSender) SendMetrics(metrics data.MetricData) error {
-	return ome.exporter.ConsumeMetrics(context.Background(), metrics)
+	return ome.exporter.ConsumeMetrics(context.Background(), pdatautil.MetricsFromInternalMetrics(metrics))
 }
 
 func (ome *OTLPMetricsDataSender) Flush() {

--- a/translator/internaldata/oc_to_metrics_test.go
+++ b/translator/internaldata/oc_to_metrics_test.go
@@ -109,6 +109,19 @@ func TestOCToMetricData(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			got := OCToMetricData(test.oc)
 			assert.EqualValues(t, test.internal, got)
+
+			ocslice := []consumerdata.MetricsData{
+				test.oc,
+				test.oc,
+			}
+			wantSlice := data.NewMetricData()
+			// Double the ResourceMetrics only if not empty.
+			if test.internal.ResourceMetrics().Len() != 0 {
+				test.internal.Clone().ResourceMetrics().MoveTo(wantSlice.ResourceMetrics())
+				test.internal.Clone().ResourceMetrics().MoveTo(wantSlice.ResourceMetrics())
+			}
+			gotSlice := OCSliceToMetricData(ocslice)
+			assert.EqualValues(t, wantSlice, gotSlice)
 		})
 	}
 }


### PR DESCRIPTION
The main idea is that currently even if the pdata.Traces is public still contrib cannot be changed to the new Components because there is no way in implementing the `ConsumeMetrics`.

To solve this problem we add a `pdata.Traces` with an opaque field that can carry `[]consumedata.MetricsData` or `data.MetricData` and make all the common consumers/components avoid conversion between the types if not necessary by proving util functions that work on both accepted formts.

With this change all contrib components can be easily change, it adds a very small overhead when carrying the old data because it forces to add an extra slice. 