### PR TITLE
Use instance label for matching instance metadata

### DIFF
--- a/receiver/prometheusreceiver/internal/internal_test.go
+++ b/receiver/prometheusreceiver/internal/internal_test.go
@@ -16,7 +16,6 @@ package internal
 
 import (
 	"context"
-	"errors"
 
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/scrape"
@@ -64,14 +63,10 @@ func (m *mockConsumer) ConsumeMetricsData(ctx context.Context, md consumerdata.M
 	return nil
 }
 
-type mockMetadataSvc struct {
-	caches map[string]*mockMetadataCache
+type mockScrapeManager struct {
+	targets map[string][]*scrape.Target
 }
 
-func (mm *mockMetadataSvc) Get(job, instance string) (MetadataCache, error) {
-	if mc, ok := mm.caches[job+"_"+instance]; ok {
-		return mc, nil
-	}
-
-	return nil, errors.New("cache not found")
+func (sm *mockScrapeManager) TargetsAll() map[string][]*scrape.Target {
+	return sm.targets
 }

--- a/receiver/prometheusreceiver/internal/metadata.go
+++ b/receiver/prometheusreceiver/internal/metadata.go
@@ -22,7 +22,7 @@ import (
 	"github.com/prometheus/prometheus/scrape"
 )
 
-// MetadataService is an adapter to scrapeManager and provide only the functionality which is needed
+// MetadataService is an adapter to ScrapeManager and provide only the functionality which is needed
 type MetadataService interface {
 	Get(job, instance string) (MetadataCache, error)
 }
@@ -33,8 +33,12 @@ type MetadataCache interface {
 	SharedLabels() labels.Labels
 }
 
+type ScrapeManager interface {
+	TargetsAll() map[string][]*scrape.Target
+}
+
 type mService struct {
-	sm *scrape.Manager
+	sm ScrapeManager
 }
 
 func (t *mService) Get(job, instance string) (MetadataCache, error) {
@@ -45,7 +49,7 @@ func (t *mService) Get(job, instance string) (MetadataCache, error) {
 
 	// from the same targetGroup, instance is not going to be duplicated
 	for _, target := range targetGroup {
-		if target.DiscoveredLabels().Get(model.AddressLabel) == instance {
+		if target.Labels().Get(model.InstanceLabel) == instance {
 			return &mCache{target}, nil
 		}
 	}

--- a/receiver/prometheusreceiver/internal/transaction_test.go
+++ b/receiver/prometheusreceiver/internal/transaction_test.go
@@ -21,15 +21,40 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/scrape"
 )
 
 func Test_transaction(t *testing.T) {
-	ms := &mockMetadataSvc{
-		caches: map[string]*mockMetadataCache{
-			"test_localhost:8080": {data: map[string]scrape.MetricMetadata{}},
+	// discoveredLabels contain labels prior to any processing
+	discoveredLabels := labels.New(
+		labels.Label{
+			Name:  model.AddressLabel,
+			Value: "address:8080",
 		},
+		labels.Label{
+			Name:  model.MetricNameLabel,
+			Value: "foo",
+		},
+		labels.Label{
+			Name:  model.SchemeLabel,
+			Value: "http",
+		},
+	)
+	// processedLabels contain label values after processing (e.g. relabeling)
+	processedLabels := labels.New(
+		labels.Label{
+			Name:  model.InstanceLabel,
+			Value: "localhost:8080",
+		},
+	)
+	ms := &mService{
+		sm: &mockScrapeManager{targets: map[string][]*scrape.Target{
+			"test": {
+				scrape.NewTarget(processedLabels, discoveredLabels, nil),
+			},
+		}},
 	}
 
 	rn := "prometheus"


### PR DESCRIPTION
**Description:**
Fixing a bug - Match instance metadata via `instance` label (currently, `__address__` label is used, which may differ due to relabeling or explicit overridden value).

**Link to tracking Issue:** #709

**Testing:** Replaced mock with the actual implementation of the `MetadataService` interface to reproduce the issue and the fix in the unit test.

**Documentation:** -