### PR TITLE
Switch Jaeger receiver to internal data model

### DIFF
--- a/receiver/jaegerreceiver/factory.go
+++ b/receiver/jaegerreceiver/factory.go
@@ -111,9 +111,9 @@ func (f *Factory) CreateDefaultConfig() configmodels.Receiver {
 // CreateTraceReceiver creates a trace receiver based on provided config.
 func (f *Factory) CreateTraceReceiver(
 	ctx context.Context,
-	logger *zap.Logger,
+	params component.ReceiverCreateParams,
 	cfg configmodels.Receiver,
-	nextConsumer consumer.TraceConsumerOld,
+	nextConsumer consumer.TraceConsumer,
 ) (component.TraceReceiver, error) {
 
 	// Convert settings in the source config to Configuration struct
@@ -130,6 +130,7 @@ func (f *Factory) CreateTraceReceiver(
 
 	config := Configuration{}
 	var grpcServerOptions []grpc.ServerOption
+	logger := params.Logger
 
 	// Set ports
 	if protoGRPC != nil && protoGRPC.IsEnabled() {
@@ -217,14 +218,15 @@ func (f *Factory) CreateTraceReceiver(
 	}
 
 	// Create the receiver.
-	return New(rCfg.Name(), &config, nextConsumer, logger)
+	return New(rCfg.Name(), &config, nextConsumer, params)
 }
 
 // CreateMetricsReceiver creates a metrics receiver based on provided config.
 func (f *Factory) CreateMetricsReceiver(
-	logger *zap.Logger,
-	cfg configmodels.Receiver,
-	consumer consumer.MetricsConsumerOld,
+	_ context.Context,
+	_ component.ReceiverCreateParams,
+	_ configmodels.Receiver,
+	_ consumer.MetricsConsumer,
 ) (component.MetricsReceiver, error) {
 	return nil, configerror.ErrDataTypeIsNotSupported
 }

--- a/testbed/testbed/receivers.go
+++ b/testbed/testbed/receivers.go
@@ -126,7 +126,8 @@ func (jr *JaegerDataReceiver) Start(tc *MockTraceConsumer, mc *MockMetricConsume
 		CollectorGRPCPort: jr.Port,
 	}
 	var err error
-	jr.receiver, err = jaegerreceiver.New("jaeger", &jaegerCfg, tc, zap.NewNop())
+	params := component.ReceiverCreateParams{Logger: zap.NewNop()}
+	jr.receiver, err = jaegerreceiver.New("jaeger", &jaegerCfg, tc, params)
 	if err != nil {
 		return err
 	}

--- a/translator/trace/jaeger/jaegerproto_to_traces.go
+++ b/translator/trace/jaeger/jaegerproto_to_traces.go
@@ -1,0 +1,313 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package jaeger
+
+import (
+	"encoding/base64"
+	"fmt"
+	"math"
+	"reflect"
+	"strconv"
+
+	"github.com/jaegertracing/jaeger/model"
+	otlptrace "github.com/open-telemetry/opentelemetry-proto/gen/go/trace/v1"
+
+	"github.com/open-telemetry/opentelemetry-collector/consumer/pdata"
+	"github.com/open-telemetry/opentelemetry-collector/translator/conventions"
+	tracetranslator "github.com/open-telemetry/opentelemetry-collector/translator/trace"
+)
+
+func ProtoBatchToInternalTraces(batch model.Batch) pdata.Traces {
+	traceData := pdata.NewTraces()
+	jProcess := batch.GetProcess()
+	jSpans := batch.GetSpans()
+
+	if jProcess == nil && len(jSpans) == 0 {
+		return traceData
+	}
+
+	rss := traceData.ResourceSpans()
+	rss.Resize(1)
+	rs := rss.At(0)
+	jProcessToInternalResource(jProcess, rs.Resource())
+
+	if len(jSpans) == 0 {
+		return traceData
+	}
+
+	ilss := rs.InstrumentationLibrarySpans()
+	ilss.Resize(1)
+	jSpansToInternal(jSpans, ilss.At(0).Spans())
+
+	return traceData
+}
+
+func jProcessToInternalResource(process *model.Process, dest pdata.Resource) {
+	if process == nil {
+		return
+	}
+
+	dest.InitEmpty()
+
+	serviceName := process.GetServiceName()
+	tags := process.GetTags()
+	if serviceName == "" && tags == nil {
+		return
+	}
+
+	attrs := dest.Attributes()
+
+	if serviceName != "" {
+		attrs.UpsertString(conventions.AttributeServiceName, serviceName)
+	}
+
+	for _, tag := range tags {
+		switch tag.GetVType() {
+		case model.ValueType_STRING:
+			attrs.UpsertString(tag.Key, tag.GetVStr())
+		case model.ValueType_BOOL:
+			attrs.UpsertBool(tag.Key, tag.GetVBool())
+		case model.ValueType_INT64:
+			attrs.UpsertInt(tag.Key, tag.GetVInt64())
+		case model.ValueType_FLOAT64:
+			attrs.UpsertDouble(tag.Key, tag.GetVFloat64())
+		case model.ValueType_BINARY:
+			attrs.UpsertString(tag.Key, base64.StdEncoding.EncodeToString(tag.GetVBinary()))
+		default:
+			attrs.UpsertString(tag.Key, fmt.Sprintf("<Unknown Jaeger TagType %q>", tag.GetVType()))
+		}
+	}
+
+	// Handle special keys translations.
+	translateHostnameAttr(attrs)
+	translateJaegerVersionAttr(attrs)
+}
+
+// translateHostnameAttr translates "hostname" atttribute
+func translateHostnameAttr(attrs pdata.AttributeMap) {
+	hostname, hostnameFound := attrs.Get("hostname")
+	_, convHostnameFound := attrs.Get(conventions.AttributeHostHostname)
+	if hostnameFound && !convHostnameFound {
+		attrs.Insert(conventions.AttributeHostHostname, hostname)
+		attrs.Delete("hostname")
+	}
+}
+
+// translateHostnameAttr translates "jaeger.version" atttribute
+func translateJaegerVersionAttr(attrs pdata.AttributeMap) {
+	jaegerVersion, jaegerVersionFound := attrs.Get("jaeger.version")
+	_, exporterVersionFound := attrs.Get(conventions.OCAttributeExporterVersion)
+	if jaegerVersionFound && !exporterVersionFound {
+		attrs.InsertString(conventions.OCAttributeExporterVersion, "Jaeger-"+jaegerVersion.StringVal())
+		attrs.Delete("jaeger.version")
+	}
+}
+
+func jSpansToInternal(spans []*model.Span, dest pdata.SpanSlice) {
+	if len(spans) == 0 {
+		return
+	}
+
+	dest.Resize(len(spans))
+	i := 0
+	for _, span := range spans {
+		if span == nil || reflect.DeepEqual(span, blankJaegerProtoSpan) {
+			continue
+		}
+		jSpanToInternal(span, dest.At(i))
+		i++
+	}
+
+	if i < len(spans) {
+		dest.Resize(i)
+	}
+}
+
+func jSpanToInternal(span *model.Span, dest pdata.Span) {
+	dest.SetTraceID(pdata.TraceID(tracetranslator.UInt64ToByteTraceID(span.TraceID.High, span.TraceID.Low)))
+	dest.SetSpanID(pdata.SpanID(tracetranslator.UInt64ToByteSpanID(uint64(span.SpanID))))
+	dest.SetName(span.OperationName)
+	dest.SetStartTime(pdata.TimestampUnixNano(uint64(span.StartTime.UnixNano())))
+	dest.SetEndTime(pdata.TimestampUnixNano(uint64(span.StartTime.Add(span.Duration).UnixNano())))
+
+	parentSpanID := span.ParentSpanID()
+	if parentSpanID != model.SpanID(0) {
+		dest.SetParentSpanID(pdata.SpanID(tracetranslator.UInt64ToByteSpanID(uint64(parentSpanID))))
+	}
+
+	attrs := jTagsToInternalAttributes(span.Tags)
+	setInternalSpanStatus(attrs, dest.Status())
+	if spanKindAttr, ok := attrs[tracetranslator.TagSpanKind]; ok {
+		dest.SetKind(jSpanKindToInternal(spanKindAttr.StringVal()))
+	}
+	dest.Attributes().InitFromMap(attrs)
+
+	jLogsToSpanEvents(span.Logs, dest.Events())
+	jReferencesToSpanLinks(span.References, parentSpanID, dest.Links())
+}
+
+func jTagsToInternalAttributes(tags []model.KeyValue) map[string]pdata.AttributeValue {
+	attrs := make(map[string]pdata.AttributeValue)
+
+	for _, tag := range tags {
+		switch tag.GetVType() {
+		case model.ValueType_STRING:
+			attrs[tag.Key] = pdata.NewAttributeValueString(tag.GetVStr())
+		case model.ValueType_BOOL:
+			attrs[tag.Key] = pdata.NewAttributeValueBool(tag.GetVBool())
+		case model.ValueType_INT64:
+			attrs[tag.Key] = pdata.NewAttributeValueInt(tag.GetVInt64())
+		case model.ValueType_FLOAT64:
+			attrs[tag.Key] = pdata.NewAttributeValueDouble(tag.GetVFloat64())
+		case model.ValueType_BINARY:
+			attrs[tag.Key] = pdata.NewAttributeValueString(base64.StdEncoding.EncodeToString(tag.GetVBinary()))
+		default:
+			attrs[tag.Key] = pdata.NewAttributeValueString(fmt.Sprintf("<Unknown Jaeger TagType %q>", tag.GetVType()))
+		}
+	}
+
+	return attrs
+}
+
+func setInternalSpanStatus(attrs map[string]pdata.AttributeValue, dest pdata.SpanStatus) {
+	dest.InitEmpty()
+
+	var codeSet bool
+	if codeAttr, ok := attrs[tracetranslator.TagStatusCode]; ok {
+		code, err := getStatusCodeFromAttr(codeAttr)
+		if err == nil {
+			codeSet = true
+			dest.SetCode(code)
+			delete(attrs, tracetranslator.TagStatusCode)
+		}
+	} else if errorVal, ok := attrs[tracetranslator.TagError]; ok {
+		if errorVal.BoolVal() {
+			dest.SetCode(pdata.StatusCode(otlptrace.Status_UnknownError))
+			codeSet = true
+		}
+	}
+
+	if codeSet {
+		if msgAttr, ok := attrs[tracetranslator.TagStatusMsg]; ok {
+			dest.SetMessage(msgAttr.StringVal())
+			delete(attrs, tracetranslator.TagStatusMsg)
+		}
+	} else {
+		httpCodeAttr, ok := attrs[tracetranslator.TagHTTPStatusCode]
+		if ok {
+			code, err := getStatusCodeFromHTTPStatusAttr(httpCodeAttr)
+			if err == nil {
+				dest.SetCode(code)
+			}
+		} else {
+			dest.SetCode(pdata.StatusCode(otlptrace.Status_Ok))
+		}
+		if msgAttr, ok := attrs[tracetranslator.TagHTTPStatusMsg]; ok {
+			dest.SetMessage(msgAttr.StringVal())
+		}
+	}
+
+}
+
+func getStatusCodeFromAttr(attrVal pdata.AttributeValue) (pdata.StatusCode, error) {
+	var codeVal int64
+	switch attrVal.Type() {
+	case pdata.AttributeValueINT:
+		codeVal = attrVal.IntVal()
+	case pdata.AttributeValueSTRING:
+		i, err := strconv.Atoi(attrVal.StringVal())
+		if err != nil {
+			return pdata.StatusCode(0), err
+		}
+		codeVal = int64(i)
+	default:
+		return pdata.StatusCode(0), fmt.Errorf("invalid status code attribute type: %s", attrVal.Type().String())
+	}
+	if codeVal > math.MaxInt32 || codeVal < math.MinInt32 {
+		return pdata.StatusCode(0), fmt.Errorf("invalid status code value: %d", codeVal)
+	}
+	return pdata.StatusCode(codeVal), nil
+}
+
+func getStatusCodeFromHTTPStatusAttr(attrVal pdata.AttributeValue) (pdata.StatusCode, error) {
+	statusCode, err := getStatusCodeFromAttr(attrVal)
+	if err != nil {
+		return pdata.StatusCode(0), err
+	}
+
+	// TODO: Introduce and use new HTTP -> OTLP code translator instead
+	return pdata.StatusCode(tracetranslator.OCStatusCodeFromHTTP(int32(statusCode))), nil
+}
+
+func jSpanKindToInternal(spanKind string) pdata.SpanKind {
+	switch spanKind {
+	case "client":
+		return pdata.SpanKindCLIENT
+	case "server":
+		return pdata.SpanKindSERVER
+	case "producer":
+		return pdata.SpanKindPRODUCER
+	case "consumer":
+		return pdata.SpanKindCONSUMER
+	}
+	return pdata.SpanKindUNSPECIFIED
+}
+
+func jLogsToSpanEvents(logs []model.Log, dest pdata.SpanEventSlice) {
+	if len(logs) == 0 {
+		return
+	}
+
+	dest.Resize(len(logs))
+
+	for i, log := range logs {
+		event := dest.At(i)
+
+		event.SetTimestamp(pdata.TimestampUnixNano(uint64(log.Timestamp.UnixNano())))
+
+		attrs := jTagsToInternalAttributes(log.Fields)
+		if name, ok := attrs["message"]; ok {
+			event.SetName(name.StringVal())
+		}
+		if len(attrs) > 0 {
+			event.Attributes().InitFromMap(attrs)
+		}
+	}
+}
+
+// jReferencesToSpanLinks sets internal span links based on jaeger span references skipping excludeParentID
+func jReferencesToSpanLinks(refs []model.SpanRef, excludeParentID model.SpanID, dest pdata.SpanLinkSlice) {
+	if len(refs) == 0 || len(refs) == 1 && refs[0].SpanID == excludeParentID && refs[0].RefType == model.ChildOf {
+		return
+	}
+
+	dest.Resize(len(refs))
+	i := 0
+	for _, ref := range refs {
+		link := dest.At(i)
+		if ref.SpanID == excludeParentID && ref.RefType == model.ChildOf {
+			continue
+		}
+
+		link.SetTraceID(pdata.NewTraceID(tracetranslator.UInt64ToByteTraceID(ref.TraceID.High, ref.TraceID.Low)))
+		link.SetSpanID(pdata.NewSpanID(tracetranslator.UInt64ToByteSpanID(uint64(ref.SpanID))))
+		i++
+	}
+
+	// Reduce slice size in case if excludeParentID was skipped
+	if i < len(refs) {
+		dest.Resize(i)
+	}
+}

--- a/translator/trace/jaeger/jaegerproto_to_traces_test.go
+++ b/translator/trace/jaeger/jaegerproto_to_traces_test.go
@@ -1,0 +1,427 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package jaeger
+
+import (
+	"encoding/binary"
+	"fmt"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/jaegertracing/jaeger/model"
+	otlptrace "github.com/open-telemetry/opentelemetry-proto/gen/go/trace/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-telemetry/opentelemetry-collector/consumer/pdata"
+	"github.com/open-telemetry/opentelemetry-collector/internal/data/testdata"
+	tracetranslator "github.com/open-telemetry/opentelemetry-collector/translator/trace"
+)
+
+// Use timespamp with microsecond granularity to work well with jaeger thrift translation
+var (
+	testSpanStartTime      = time.Date(2020, 2, 11, 20, 26, 12, 321000, time.UTC)
+	testSpanStartTimestamp = pdata.TimestampUnixNano(testSpanStartTime.UnixNano())
+	testSpanEventTime      = time.Date(2020, 2, 11, 20, 26, 13, 123000, time.UTC)
+	testSpanEventTimestamp = pdata.TimestampUnixNano(testSpanEventTime.UnixNano())
+	testSpanEndTime        = time.Date(2020, 2, 11, 20, 26, 13, 789000, time.UTC)
+	testSpanEndTimestamp   = pdata.TimestampUnixNano(testSpanEndTime.UnixNano())
+)
+
+func TestGetStatusCodeFromAttr(t *testing.T) {
+	_, invalidNumErr := strconv.Atoi("inf")
+
+	tests := []struct {
+		name string
+		attr pdata.AttributeValue
+		code pdata.StatusCode
+		err  error
+	}{
+		{
+			name: "ok-string",
+			attr: pdata.NewAttributeValueString("0"),
+			code: pdata.StatusCode(0),
+			err:  nil,
+		},
+
+		{
+			name: "ok-int",
+			attr: pdata.NewAttributeValueInt(1),
+			code: pdata.StatusCode(1),
+			err:  nil,
+		},
+
+		{
+			name: "wrong-type",
+			attr: pdata.NewAttributeValueBool(true),
+			code: pdata.StatusCode(0),
+			err:  fmt.Errorf("invalid status code attribute type: BOOL"),
+		},
+
+		{
+			name: "invalid-string",
+			attr: pdata.NewAttributeValueString("inf"),
+			code: pdata.StatusCode(0),
+			err:  invalidNumErr,
+		},
+
+		{
+			name: "invalid-int",
+			attr: pdata.NewAttributeValueInt(1844674407370955),
+			code: pdata.StatusCode(0),
+			err:  fmt.Errorf("invalid status code value: 1844674407370955"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			code, err := getStatusCodeFromAttr(test.attr)
+			assert.EqualValues(t, test.err, err)
+			assert.Equal(t, test.code, code)
+		})
+	}
+}
+
+func TestGetStatusCodeFromHTTPStatusAttr(t *testing.T) {
+	tests := []struct {
+		name string
+		attr pdata.AttributeValue
+		code pdata.StatusCode
+	}{
+		{
+			name: "string-unknown",
+			attr: pdata.NewAttributeValueString("10"),
+			code: pdata.StatusCode(otlptrace.Status_UnknownError),
+		},
+
+		{
+			name: "string-ok",
+			attr: pdata.NewAttributeValueString("101"),
+			code: pdata.StatusCode(otlptrace.Status_Ok),
+		},
+
+		{
+			name: "int-not-found",
+			attr: pdata.NewAttributeValueInt(404),
+			code: pdata.StatusCode(otlptrace.Status_NotFound),
+		},
+		{
+			name: "int-invalid-arg",
+			attr: pdata.NewAttributeValueInt(408),
+			code: pdata.StatusCode(otlptrace.Status_InvalidArgument),
+		},
+
+		{
+			name: "int-internal",
+			attr: pdata.NewAttributeValueInt(500),
+			code: pdata.StatusCode(otlptrace.Status_InternalError),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			code, err := getStatusCodeFromHTTPStatusAttr(test.attr)
+			assert.Nil(t, err)
+			assert.Equal(t, test.code, code)
+		})
+	}
+}
+
+func TestJTagsToInternalAttributes(t *testing.T) {
+	tags := []model.KeyValue{
+		{
+			Key:   "bool-val",
+			VType: model.ValueType_BOOL,
+			VBool: true,
+		},
+		{
+			Key:    "int-val",
+			VType:  model.ValueType_INT64,
+			VInt64: 123,
+		},
+		{
+			Key:   "string-val",
+			VType: model.ValueType_STRING,
+			VStr:  "abc",
+		},
+		{
+			Key:      "double-val",
+			VType:    model.ValueType_FLOAT64,
+			VFloat64: 1.23,
+		},
+		{
+			Key:     "binary-val",
+			VType:   model.ValueType_BINARY,
+			VBinary: []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x64, 0x7D, 0x98},
+		},
+	}
+
+	expected := map[string]pdata.AttributeValue{
+		"bool-val":   pdata.NewAttributeValueBool(true),
+		"int-val":    pdata.NewAttributeValueInt(123),
+		"string-val": pdata.NewAttributeValueString("abc"),
+		"double-val": pdata.NewAttributeValueDouble(1.23),
+		"binary-val": pdata.NewAttributeValueString("AAAAAABkfZg="),
+	}
+
+	got := jTagsToInternalAttributes(tags)
+
+	require.EqualValues(t, expected, got)
+}
+
+func TestProtoBatchToInternalTraces(t *testing.T) {
+
+	tests := []struct {
+		name string
+		jb   model.Batch
+		td   pdata.Traces
+	}{
+		{
+			name: "empty",
+			jb:   model.Batch{},
+			td:   testdata.GenerateTraceDataEmpty(),
+		},
+
+		{
+			name: "no-spans",
+			jb: model.Batch{
+				Process: generateProtoProcess(),
+			},
+			td: testdata.GenerateTraceDataNoLibraries(),
+		},
+
+		{
+			name: "one-span-no-resources",
+			jb: model.Batch{
+				Spans: []*model.Span{
+					generateProtoSpan(),
+				},
+			},
+			td: generateTraceDataOneSpanNoResource(),
+		},
+		{
+			name: "two-spans-child-parent",
+			jb: model.Batch{
+				Spans: []*model.Span{
+					generateProtoSpan(),
+					generateProtoChildSpan(),
+				},
+			},
+			td: generateTraceDataTwoSpansChildParent(),
+		},
+
+		{
+			name: "two-spans-with-follower",
+			jb: model.Batch{
+				Spans: []*model.Span{
+					generateProtoSpan(),
+					generateProtoFollowerSpan(),
+				},
+			},
+			td: generateTraceDataTwoSpansWithFollower(),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			td := ProtoBatchToInternalTraces(test.jb)
+			assert.EqualValues(t, test.td, td)
+		})
+	}
+}
+
+func generateProtoProcess() *model.Process {
+	return &model.Process{
+		Tags: []model.KeyValue{
+			{
+				Key:   "resource-attr",
+				VType: model.ValueType_STRING,
+				VStr:  "resource-attr-val-1",
+			},
+		},
+	}
+}
+
+func generateTraceDataOneSpanNoResource() pdata.Traces {
+	td := testdata.GenerateTraceDataOneSpanNoResource()
+	span := td.ResourceSpans().At(0).InstrumentationLibrarySpans().At(0).Spans().At(0)
+	span.SetSpanID(pdata.NewSpanID([]byte{0xAF, 0xAE, 0xAD, 0xAC, 0xAB, 0xAA, 0xA9, 0xA8}))
+	span.SetTraceID(pdata.NewTraceID(
+		[]byte{0xF1, 0xF2, 0xF3, 0xF4, 0xF5, 0xF6, 0xF7, 0xF8, 0xF9, 0xFA, 0xFB, 0xFC, 0xFD, 0xFE, 0xFF, 0x80}))
+	span.SetDroppedAttributesCount(0)
+	span.SetDroppedEventsCount(0)
+	span.SetStartTime(testSpanStartTimestamp)
+	span.SetEndTime(testSpanEndTimestamp)
+	span.Events().At(0).SetTimestamp(testSpanEventTimestamp)
+	span.Events().At(0).SetDroppedAttributesCount(0)
+	span.Events().At(0).Attributes().InitFromMap(map[string]pdata.AttributeValue{
+		"message": pdata.NewAttributeValueString("event-with-attr"),
+	})
+	span.Events().At(1).SetTimestamp(testSpanEventTimestamp)
+	span.Events().At(1).SetDroppedAttributesCount(0)
+	span.Events().At(1).SetName("")
+	span.Events().At(1).Attributes().InsertInt("attr-int", 123)
+	return td
+}
+
+func generateProtoSpan() *model.Span {
+	return &model.Span{
+		TraceID: model.NewTraceID(
+			binary.BigEndian.Uint64([]byte{0xF1, 0xF2, 0xF3, 0xF4, 0xF5, 0xF6, 0xF7, 0xF8}),
+			binary.BigEndian.Uint64([]byte{0xF9, 0xFA, 0xFB, 0xFC, 0xFD, 0xFE, 0xFF, 0x80}),
+		),
+		SpanID:        model.NewSpanID(binary.BigEndian.Uint64([]byte{0xAF, 0xAE, 0xAD, 0xAC, 0xAB, 0xAA, 0xA9, 0xA8})),
+		OperationName: "operationA",
+		StartTime:     testSpanStartTime,
+		Duration:      testSpanEndTime.Sub(testSpanStartTime),
+		Logs: []model.Log{
+			{
+				Timestamp: testSpanEventTime,
+				Fields: []model.KeyValue{
+					{
+						Key:   "message",
+						VType: model.ValueType_STRING,
+						VStr:  "event-with-attr",
+					},
+				},
+			},
+			{
+				Timestamp: testSpanEventTime,
+				Fields: []model.KeyValue{
+					{
+						Key:    "attr-int",
+						VType:  model.ValueType_INT64,
+						VInt64: 123,
+					},
+				},
+			},
+		},
+		Tags: []model.KeyValue{
+			{
+				Key:    tracetranslator.TagStatusCode,
+				VType:  model.ValueType_INT64,
+				VInt64: tracetranslator.OCCancelled,
+			},
+			{
+				Key:   tracetranslator.TagStatusMsg,
+				VType: model.ValueType_STRING,
+				VStr:  "status-cancelled",
+			},
+		},
+	}
+}
+
+func generateTraceDataTwoSpansChildParent() pdata.Traces {
+	td := generateTraceDataOneSpanNoResource()
+	spans := td.ResourceSpans().At(0).InstrumentationLibrarySpans().At(0).Spans()
+	spans.Resize(2)
+
+	span := spans.At(1)
+	span.SetName("operationB")
+	span.SetSpanID([]byte{0x1F, 0x1E, 0x1D, 0x1C, 0x1B, 0x1A, 0x19, 0x18})
+	span.SetParentSpanID(spans.At(0).SpanID())
+	span.SetTraceID(spans.At(0).TraceID())
+	span.SetStartTime(spans.At(0).StartTime())
+	span.SetEndTime(spans.At(0).EndTime())
+	span.Status().InitEmpty()
+	span.Status().SetCode(pdata.StatusCode(otlptrace.Status_NotFound))
+	span.Attributes().InitFromMap(map[string]pdata.AttributeValue{
+		tracetranslator.TagHTTPStatusCode: pdata.NewAttributeValueInt(404),
+	})
+
+	return td
+}
+
+func generateProtoChildSpan() *model.Span {
+	traceID := model.NewTraceID(
+		binary.BigEndian.Uint64([]byte{0xF1, 0xF2, 0xF3, 0xF4, 0xF5, 0xF6, 0xF7, 0xF8}),
+		binary.BigEndian.Uint64([]byte{0xF9, 0xFA, 0xFB, 0xFC, 0xFD, 0xFE, 0xFF, 0x80}),
+	)
+	return &model.Span{
+		TraceID:       traceID,
+		SpanID:        model.NewSpanID(binary.BigEndian.Uint64([]byte{0x1F, 0x1E, 0x1D, 0x1C, 0x1B, 0x1A, 0x19, 0x18})),
+		OperationName: "operationB",
+		StartTime:     testSpanStartTime,
+		Duration:      testSpanEndTime.Sub(testSpanStartTime),
+		Tags: []model.KeyValue{
+			{
+				Key:    tracetranslator.TagHTTPStatusCode,
+				VType:  model.ValueType_INT64,
+				VInt64: 404,
+			},
+		},
+		References: []model.SpanRef{
+			{
+				TraceID: traceID,
+				SpanID:  model.NewSpanID(binary.BigEndian.Uint64([]byte{0xAF, 0xAE, 0xAD, 0xAC, 0xAB, 0xAA, 0xA9, 0xA8})),
+				RefType: model.SpanRefType_CHILD_OF,
+			},
+		},
+	}
+}
+
+func generateTraceDataTwoSpansWithFollower() pdata.Traces {
+	td := generateTraceDataOneSpanNoResource()
+	spans := td.ResourceSpans().At(0).InstrumentationLibrarySpans().At(0).Spans()
+	spans.Resize(2)
+
+	span := spans.At(1)
+	span.SetName("operationC")
+	span.SetSpanID([]byte{0x1F, 0x1E, 0x1D, 0x1C, 0x1B, 0x1A, 0x19, 0x18})
+	span.SetTraceID(spans.At(0).TraceID())
+	span.SetStartTime(spans.At(0).EndTime())
+	span.SetEndTime(spans.At(0).EndTime() + 1000000)
+	span.Status().InitEmpty()
+	span.Status().SetCode(pdata.StatusCode(otlptrace.Status_Ok))
+	span.Status().SetMessage("status-ok")
+	span.Links().Resize(1)
+	span.Links().At(0).SetTraceID(span.TraceID())
+	span.Links().At(0).SetSpanID(spans.At(0).SpanID())
+	return td
+}
+
+func generateProtoFollowerSpan() *model.Span {
+	traceID := model.NewTraceID(
+		binary.BigEndian.Uint64([]byte{0xF1, 0xF2, 0xF3, 0xF4, 0xF5, 0xF6, 0xF7, 0xF8}),
+		binary.BigEndian.Uint64([]byte{0xF9, 0xFA, 0xFB, 0xFC, 0xFD, 0xFE, 0xFF, 0x80}),
+	)
+	return &model.Span{
+		TraceID:       traceID,
+		SpanID:        model.NewSpanID(binary.BigEndian.Uint64([]byte{0x1F, 0x1E, 0x1D, 0x1C, 0x1B, 0x1A, 0x19, 0x18})),
+		OperationName: "operationC",
+		StartTime:     testSpanEndTime,
+		Duration:      time.Duration(time.Millisecond),
+		Tags: []model.KeyValue{
+			{
+				Key:    tracetranslator.TagStatusCode,
+				VType:  model.ValueType_INT64,
+				VInt64: tracetranslator.OCOK,
+			},
+			{
+				Key:   tracetranslator.TagStatusMsg,
+				VType: model.ValueType_STRING,
+				VStr:  "status-ok",
+			},
+		},
+		References: []model.SpanRef{
+			{
+				TraceID: traceID,
+				SpanID:  model.NewSpanID(binary.BigEndian.Uint64([]byte{0xAF, 0xAE, 0xAD, 0xAC, 0xAB, 0xAA, 0xA9, 0xA8})),
+				RefType: model.SpanRefType_FOLLOWS_FROM,
+			},
+		},
+	}
+}

--- a/translator/trace/jaeger/jaegerthrift_to_traces.go
+++ b/translator/trace/jaeger/jaegerthrift_to_traces.go
@@ -1,0 +1,210 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package jaeger
+
+import (
+	"encoding/base64"
+	"fmt"
+	"reflect"
+
+	"github.com/jaegertracing/jaeger/thrift-gen/jaeger"
+
+	"github.com/open-telemetry/opentelemetry-collector/consumer/pdata"
+	"github.com/open-telemetry/opentelemetry-collector/translator/conventions"
+	tracetranslator "github.com/open-telemetry/opentelemetry-collector/translator/trace"
+)
+
+func ThriftBatchToInternalTraces(batch *jaeger.Batch) pdata.Traces {
+	traceData := pdata.NewTraces()
+	jProcess := batch.GetProcess()
+	jSpans := batch.GetSpans()
+
+	if jProcess == nil && len(jSpans) == 0 {
+		return traceData
+	}
+
+	rss := traceData.ResourceSpans()
+	rss.Resize(1)
+	rs := rss.At(0)
+	jThriftProcessToInternalResource(jProcess, rs.Resource())
+
+	if len(jSpans) == 0 {
+		return traceData
+	}
+
+	ilss := rs.InstrumentationLibrarySpans()
+	ilss.Resize(1)
+	jThriftSpansToInternal(jSpans, ilss.At(0).Spans())
+
+	return traceData
+}
+
+func jThriftProcessToInternalResource(process *jaeger.Process, dest pdata.Resource) {
+	if process == nil {
+		return
+	}
+
+	dest.InitEmpty()
+
+	serviceName := process.GetServiceName()
+	tags := process.GetTags()
+	if serviceName == "" && tags == nil {
+		return
+	}
+
+	attrs := dest.Attributes()
+
+	if serviceName != "" {
+		attrs.UpsertString(conventions.AttributeServiceName, serviceName)
+	}
+
+	for _, tag := range tags {
+		switch tag.GetVType() {
+		case jaeger.TagType_STRING:
+			attrs.UpsertString(tag.Key, tag.GetVStr())
+		case jaeger.TagType_BOOL:
+			attrs.UpsertBool(tag.Key, tag.GetVBool())
+		case jaeger.TagType_LONG:
+			attrs.UpsertInt(tag.Key, tag.GetVLong())
+		case jaeger.TagType_DOUBLE:
+			attrs.UpsertDouble(tag.Key, tag.GetVDouble())
+		case jaeger.TagType_BINARY:
+			attrs.UpsertString(tag.Key, base64.StdEncoding.EncodeToString(tag.GetVBinary()))
+		default:
+			attrs.UpsertString(tag.Key, fmt.Sprintf("<Unknown Jaeger TagType %q>", tag.GetVType()))
+		}
+	}
+
+	// Handle special keys translations.
+	translateHostnameAttr(attrs)
+	translateJaegerVersionAttr(attrs)
+}
+
+func jThriftSpansToInternal(spans []*jaeger.Span, dest pdata.SpanSlice) {
+	if len(spans) == 0 {
+		return
+	}
+
+	dest.Resize(len(spans))
+	i := 0
+	for _, span := range spans {
+		if span == nil || reflect.DeepEqual(span, blankJaegerProtoSpan) {
+			continue
+		}
+		jThriftSpanToInternal(span, dest.At(i))
+		i++
+	}
+
+	if i < len(spans) {
+		dest.Resize(i)
+	}
+}
+
+func jThriftSpanToInternal(span *jaeger.Span, dest pdata.Span) {
+	dest.SetTraceID(pdata.TraceID(tracetranslator.Int64ToByteTraceID(span.TraceIdHigh, span.TraceIdLow)))
+	dest.SetSpanID(pdata.SpanID(tracetranslator.Int64ToByteSpanID(span.SpanId)))
+	dest.SetName(span.OperationName)
+	dest.SetStartTime(microsecondsToUnixNano(span.StartTime))
+	dest.SetEndTime(microsecondsToUnixNano(span.StartTime + span.Duration))
+
+	parentSpanID := span.ParentSpanId
+	if parentSpanID != 0 {
+		dest.SetParentSpanID(pdata.SpanID(tracetranslator.Int64ToByteSpanID(parentSpanID)))
+	}
+
+	attrs := jThriftTagsToInternalAttributes(span.Tags)
+	setInternalSpanStatus(attrs, dest.Status())
+	if spanKindAttr, ok := attrs[tracetranslator.TagSpanKind]; ok {
+		dest.SetKind(jSpanKindToInternal(spanKindAttr.StringVal()))
+	}
+	dest.Attributes().InitFromMap(attrs)
+
+	jThriftLogsToSpanEvents(span.Logs, dest.Events())
+	jThriftReferencesToSpanLinks(span.References, parentSpanID, dest.Links())
+}
+
+// jThriftTagsToInternalAttributes sets internal span links based on jaeger span references skipping excludeParentID
+func jThriftTagsToInternalAttributes(tags []*jaeger.Tag) map[string]pdata.AttributeValue {
+	attrs := make(map[string]pdata.AttributeValue)
+
+	for _, tag := range tags {
+		switch tag.GetVType() {
+		case jaeger.TagType_STRING:
+			attrs[tag.Key] = pdata.NewAttributeValueString(tag.GetVStr())
+		case jaeger.TagType_BOOL:
+			attrs[tag.Key] = pdata.NewAttributeValueBool(tag.GetVBool())
+		case jaeger.TagType_LONG:
+			attrs[tag.Key] = pdata.NewAttributeValueInt(tag.GetVLong())
+		case jaeger.TagType_DOUBLE:
+			attrs[tag.Key] = pdata.NewAttributeValueDouble(tag.GetVDouble())
+		case jaeger.TagType_BINARY:
+			attrs[tag.Key] = pdata.NewAttributeValueString(base64.StdEncoding.EncodeToString(tag.GetVBinary()))
+		default:
+			attrs[tag.Key] = pdata.NewAttributeValueString(fmt.Sprintf("<Unknown Jaeger TagType %q>", tag.GetVType()))
+		}
+	}
+
+	return attrs
+}
+
+func jThriftLogsToSpanEvents(logs []*jaeger.Log, dest pdata.SpanEventSlice) {
+	if len(logs) == 0 {
+		return
+	}
+
+	dest.Resize(len(logs))
+
+	for i, log := range logs {
+		event := dest.At(i)
+
+		event.SetTimestamp(microsecondsToUnixNano(log.Timestamp))
+		attrs := jThriftTagsToInternalAttributes(log.Fields)
+		if name, ok := attrs["message"]; ok {
+			event.SetName(name.StringVal())
+		}
+		if len(attrs) > 0 {
+			event.Attributes().InitFromMap(attrs)
+		}
+	}
+}
+
+func jThriftReferencesToSpanLinks(refs []*jaeger.SpanRef, excludeParentID int64, dest pdata.SpanLinkSlice) {
+	if len(refs) == 0 || len(refs) == 1 && refs[0].SpanId == excludeParentID && refs[0].RefType == jaeger.SpanRefType_CHILD_OF {
+		return
+	}
+
+	dest.Resize(len(refs))
+	i := 0
+	for _, ref := range refs {
+		link := dest.At(i)
+		if ref.SpanId == excludeParentID && ref.RefType == jaeger.SpanRefType_CHILD_OF {
+			continue
+		}
+
+		link.SetTraceID(pdata.NewTraceID(tracetranslator.Int64ToByteTraceID(ref.TraceIdHigh, ref.TraceIdLow)))
+		link.SetSpanID(pdata.NewSpanID(tracetranslator.Int64ToByteSpanID(ref.SpanId)))
+		i++
+	}
+
+	// Reduce slice size in case if excludeParentID was skipped
+	if i < len(refs) {
+		dest.Resize(i)
+	}
+}
+
+// microsecondsToUnixNano converts epoch microseconds to pdata.TimestampUnixNano
+func microsecondsToUnixNano(ms int64) pdata.TimestampUnixNano {
+	return pdata.TimestampUnixNano(uint64(ms) * 1000)
+}

--- a/translator/trace/jaeger/jaegerthrift_to_traces_test.go
+++ b/translator/trace/jaeger/jaegerthrift_to_traces_test.go
@@ -1,0 +1,261 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package jaeger
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/jaegertracing/jaeger/thrift-gen/jaeger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-telemetry/opentelemetry-collector/consumer/pdata"
+	"github.com/open-telemetry/opentelemetry-collector/internal/data/testdata"
+	tracetranslator "github.com/open-telemetry/opentelemetry-collector/translator/trace"
+)
+
+func TestJThriftTagsToInternalAttributes(t *testing.T) {
+	var intVal int64 = 123
+	boolVal := true
+	stringVal := "abc"
+	doubleVal := 1.23
+	tags := []*jaeger.Tag{
+		{
+			Key:   "bool-val",
+			VType: jaeger.TagType_BOOL,
+			VBool: &boolVal,
+		},
+		{
+			Key:   "int-val",
+			VType: jaeger.TagType_LONG,
+			VLong: &intVal,
+		},
+		{
+			Key:   "string-val",
+			VType: jaeger.TagType_STRING,
+			VStr:  &stringVal,
+		},
+		{
+			Key:     "double-val",
+			VType:   jaeger.TagType_DOUBLE,
+			VDouble: &doubleVal,
+		},
+		{
+			Key:     "binary-val",
+			VType:   jaeger.TagType_BINARY,
+			VBinary: []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x64, 0x7D, 0x98},
+		},
+	}
+
+	expected := map[string]pdata.AttributeValue{
+		"bool-val":   pdata.NewAttributeValueBool(true),
+		"int-val":    pdata.NewAttributeValueInt(123),
+		"string-val": pdata.NewAttributeValueString("abc"),
+		"double-val": pdata.NewAttributeValueDouble(1.23),
+		"binary-val": pdata.NewAttributeValueString("AAAAAABkfZg="),
+	}
+
+	got := jThriftTagsToInternalAttributes(tags)
+
+	require.EqualValues(t, expected, got)
+}
+
+func TestThriftBatchToInternalTraces(t *testing.T) {
+
+	tests := []struct {
+		name string
+		jb   *jaeger.Batch
+		td   pdata.Traces
+	}{
+		{
+			name: "empty",
+			jb:   &jaeger.Batch{},
+			td:   testdata.GenerateTraceDataEmpty(),
+		},
+
+		{
+			name: "no-spans",
+			jb: &jaeger.Batch{
+				Process: generateThriftProcess(),
+			},
+			td: testdata.GenerateTraceDataNoLibraries(),
+		},
+
+		{
+			name: "one-span-no-resources",
+			jb: &jaeger.Batch{
+				Spans: []*jaeger.Span{
+					generateThriftSpan(),
+				},
+			},
+			td: generateTraceDataOneSpanNoResource(),
+		},
+		{
+			name: "two-spans-child-parent",
+			jb: &jaeger.Batch{
+				Spans: []*jaeger.Span{
+					generateThriftSpan(),
+					generateThriftChildSpan(),
+				},
+			},
+			td: generateTraceDataTwoSpansChildParent(),
+		},
+
+		{
+			name: "two-spans-with-follower",
+			jb: &jaeger.Batch{
+				Spans: []*jaeger.Span{
+					generateThriftSpan(),
+					generateThriftFollowerSpan(),
+				},
+			},
+			td: generateTraceDataTwoSpansWithFollower(),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			td := ThriftBatchToInternalTraces(test.jb)
+			assert.EqualValues(t, test.td, td)
+		})
+	}
+}
+
+func generateThriftProcess() *jaeger.Process {
+	attrVal := "resource-attr-val-1"
+	return &jaeger.Process{
+		Tags: []*jaeger.Tag{
+			{
+				Key:   "resource-attr",
+				VType: jaeger.TagType_STRING,
+				VStr:  &attrVal,
+			},
+		},
+	}
+}
+
+func generateThriftSpan() *jaeger.Span {
+	spanStartTs := unixNanoToMicroseconds(testSpanStartTimestamp)
+	spanEndTs := unixNanoToMicroseconds(testSpanEndTimestamp)
+	eventTs := unixNanoToMicroseconds(testSpanEventTimestamp)
+	intAttrVal := int64(123)
+	eventAttrVal := "event-with-attr"
+	statusCode := int64(tracetranslator.OCCancelled)
+	statusMsg := "status-cancelled"
+
+	return &jaeger.Span{
+		TraceIdHigh:   int64(binary.BigEndian.Uint64([]byte{0xF1, 0xF2, 0xF3, 0xF4, 0xF5, 0xF6, 0xF7, 0xF8})),
+		TraceIdLow:    int64(binary.BigEndian.Uint64([]byte{0xF9, 0xFA, 0xFB, 0xFC, 0xFD, 0xFE, 0xFF, 0x80})),
+		SpanId:        int64(binary.BigEndian.Uint64([]byte{0xAF, 0xAE, 0xAD, 0xAC, 0xAB, 0xAA, 0xA9, 0xA8})),
+		OperationName: "operationA",
+		StartTime:     spanStartTs,
+		Duration:      spanEndTs - spanStartTs,
+		Logs: []*jaeger.Log{
+			{
+				Timestamp: eventTs,
+				Fields: []*jaeger.Tag{
+					{
+						Key:   "message",
+						VType: jaeger.TagType_STRING,
+						VStr:  &eventAttrVal,
+					},
+				},
+			},
+			{
+				Timestamp: eventTs,
+				Fields: []*jaeger.Tag{
+					{
+						Key:   "attr-int",
+						VType: jaeger.TagType_LONG,
+						VLong: &intAttrVal,
+					},
+				},
+			},
+		},
+		Tags: []*jaeger.Tag{
+			{
+				Key:   tracetranslator.TagStatusCode,
+				VType: jaeger.TagType_LONG,
+				VLong: &statusCode,
+			},
+			{
+				Key:   tracetranslator.TagStatusMsg,
+				VType: jaeger.TagType_STRING,
+				VStr:  &statusMsg,
+			},
+		},
+	}
+}
+
+func generateThriftChildSpan() *jaeger.Span {
+	spanStartTs := unixNanoToMicroseconds(testSpanStartTimestamp)
+	spanEndTs := unixNanoToMicroseconds(testSpanEndTimestamp)
+	notFoundAttrVal := int64(404)
+
+	return &jaeger.Span{
+		TraceIdHigh:   int64(binary.BigEndian.Uint64([]byte{0xF1, 0xF2, 0xF3, 0xF4, 0xF5, 0xF6, 0xF7, 0xF8})),
+		TraceIdLow:    int64(binary.BigEndian.Uint64([]byte{0xF9, 0xFA, 0xFB, 0xFC, 0xFD, 0xFE, 0xFF, 0x80})),
+		SpanId:        int64(binary.BigEndian.Uint64([]byte{0x1F, 0x1E, 0x1D, 0x1C, 0x1B, 0x1A, 0x19, 0x18})),
+		ParentSpanId:  int64(binary.BigEndian.Uint64([]byte{0xAF, 0xAE, 0xAD, 0xAC, 0xAB, 0xAA, 0xA9, 0xA8})),
+		OperationName: "operationB",
+		StartTime:     spanStartTs,
+		Duration:      spanEndTs - spanStartTs,
+		Tags: []*jaeger.Tag{
+			{
+				Key:   tracetranslator.TagHTTPStatusCode,
+				VType: jaeger.TagType_LONG,
+				VLong: &notFoundAttrVal,
+			},
+		},
+	}
+}
+
+func generateThriftFollowerSpan() *jaeger.Span {
+	statusCode := int64(tracetranslator.OCOK)
+	statusMsg := "status-ok"
+	return &jaeger.Span{
+		TraceIdHigh:   int64(binary.BigEndian.Uint64([]byte{0xF1, 0xF2, 0xF3, 0xF4, 0xF5, 0xF6, 0xF7, 0xF8})),
+		TraceIdLow:    int64(binary.BigEndian.Uint64([]byte{0xF9, 0xFA, 0xFB, 0xFC, 0xFD, 0xFE, 0xFF, 0x80})),
+		SpanId:        int64(binary.BigEndian.Uint64([]byte{0x1F, 0x1E, 0x1D, 0x1C, 0x1B, 0x1A, 0x19, 0x18})),
+		OperationName: "operationC",
+		StartTime:     unixNanoToMicroseconds(testSpanEndTimestamp),
+		Duration:      1000,
+		Tags: []*jaeger.Tag{
+			{
+				Key:   tracetranslator.TagStatusCode,
+				VType: jaeger.TagType_LONG,
+				VLong: &statusCode,
+			},
+			{
+				Key:   tracetranslator.TagStatusMsg,
+				VType: jaeger.TagType_STRING,
+				VStr:  &statusMsg,
+			},
+		},
+		References: []*jaeger.SpanRef{
+			{
+				TraceIdHigh: int64(binary.BigEndian.Uint64([]byte{0xF1, 0xF2, 0xF3, 0xF4, 0xF5, 0xF6, 0xF7, 0xF8})),
+				TraceIdLow:  int64(binary.BigEndian.Uint64([]byte{0xF9, 0xFA, 0xFB, 0xFC, 0xFD, 0xFE, 0xFF, 0x80})),
+				SpanId:      int64(binary.BigEndian.Uint64([]byte{0xAF, 0xAE, 0xAD, 0xAC, 0xAB, 0xAA, 0xA9, 0xA8})),
+				RefType:     jaeger.SpanRefType_FOLLOWS_FROM,
+			},
+		},
+	}
+}
+
+func unixNanoToMicroseconds(ns pdata.TimestampUnixNano) int64 {
+	return int64(ns / 1000)
+}


### PR DESCRIPTION
Conversion were replicated from existing jaeger -> OC -> internal.

One concern:
We are getting ParentSpanID from Jaeger span links and writing the link to internal Span.Links slice as well. I'm not sure if it's desired behavior. I'd remove parent span link from the translated internal span and keep that information only ParentSpanID field. Keeping the link copy in Span.Links makes it even more confusing because, with the links conversion, we lose RefType information (like Span_Link_PARENT_LINKED_SPAN or Span_Link_TYPE_UNSPECIFIED), OTLP doesn't have that field.
@tigrannajaryan @pjanotti what do you think about it ^