### PR TITLE
k8s example: Correct keepalive parameter naming

### DIFF
--- a/examples/k8s.yaml
+++ b/examples/k8s.yaml
@@ -82,11 +82,11 @@ data:
   otel-collector-config: |
     receivers:
       opencensus:
-# keepalive settings can help load balancing, see receiver/README.md for more info.
+        # keepalive settings can help load balancing, see receiver/README.md for more info.
         keepalive:
           server_parameters:
             max_connection_age: 120s
-            max_connection_age-grace: 30s
+            max_connection_age_grace: 30s
       jaeger:
         protocols:
           grpc:


### PR DESCRIPTION
**Description:** Instructions at https://opentelemetry.io/docs/collector/about/ were causing a formatting error, and correcting the formatting resulted in an error starting otel-collector related to naming in the opencensus configuration.

**Testing:** Verified that this change resulted in a successful deployment with `kubectl apply`.