### PR TITLE
Add Host Metrics receiver scaffolding

### DIFF
--- a/receiver/README.md
+++ b/receiver/README.md
@@ -12,6 +12,7 @@ Supported trace receivers (sorted alphabetically):
 - [Zipkin Receiver](#zipkin)
 
 Supported metric receivers (sorted alphabetically):
+- [Host Metrics Receiver](#hostmetrics)
 - [OpenCensus Receiver](#opencensus)
 - [Prometheus Receiver](#prometheus)
 - [VM Metrics Receiver](#vmmetrics)

--- a/receiver/hostmetricsreceiver/README.md
+++ b/receiver/hostmetricsreceiver/README.md
@@ -1,0 +1,22 @@
+# Host Metrics Receiver
+
+The Host Metrics receiver generates metrics about the host system. This is intended to be used when the collector is
+deployed as an agent.
+
+The categories of metrics scraped can be configured under the `scrapers` key, e.g. to scrape cpu, memory and disk metrics
+(note not all of these are implemented yet):
+
+```
+hostmetrics:
+  default_collection_interval: 10s
+  scrapers:
+    cpu:
+      report_per_process: true
+    memory:
+    disk:
+```
+
+## OS Support
+
+The initial implementation of the Host Metrics receiver supports Windows only. It's intended that future iterations
+of this receiver will support the collection of identical metrics (where possible) on other operating systems.

--- a/receiver/hostmetricsreceiver/config.go
+++ b/receiver/hostmetricsreceiver/config.go
@@ -1,0 +1,30 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hostmetricsreceiver
+
+import (
+	"time"
+
+	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
+	"github.com/open-telemetry/opentelemetry-collector/receiver/hostmetricsreceiver/internal"
+)
+
+// Config defines configuration for HostMetrics receiver.
+type Config struct {
+	configmodels.ReceiverSettings `mapstructure:",squash"`
+
+	DefaultCollectionInterval time.Duration              `mapstructure:"default_collection_interval"`
+	Scrapers                  map[string]internal.Config `mapstructure:"-"`
+}

--- a/receiver/hostmetricsreceiver/config_test.go
+++ b/receiver/hostmetricsreceiver/config_test.go
@@ -1,0 +1,35 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hostmetricsreceiver
+
+import (
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-telemetry/opentelemetry-collector/config"
+)
+
+func TestLoadConfig(t *testing.T) {
+	factories, err := config.ExampleComponents()
+	require.NoError(t, err)
+
+	factory := NewFactory()
+	factories.Receivers[typeStr] = factory
+	_, err = config.LoadConfigFile(t, path.Join(".", "testdata", "config.yaml"), factories)
+
+	require.Error(t, err)
+}

--- a/receiver/hostmetricsreceiver/example_config.yaml
+++ b/receiver/hostmetricsreceiver/example_config.yaml
@@ -1,0 +1,21 @@
+extensions:
+  zpages:
+    endpoint: 0.0.0.0:55679
+
+receivers:
+  hostmetrics:
+    default_collection_interval: 10s
+    scrapers:
+
+exporters:
+  logging:
+  prometheus:
+    endpoint: 0.0.0.0:8889
+
+service:
+  pipelines:
+    metrics:
+      receivers: [hostmetrics]
+      exporters: [prometheus, logging]
+
+  extensions: [zpages]

--- a/receiver/hostmetricsreceiver/factory.go
+++ b/receiver/hostmetricsreceiver/factory.go
@@ -1,0 +1,147 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hostmetricsreceiver
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"runtime"
+	"time"
+
+	"github.com/spf13/viper"
+
+	"github.com/open-telemetry/opentelemetry-collector/component"
+	"github.com/open-telemetry/opentelemetry-collector/config/configerror"
+	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
+	"github.com/open-telemetry/opentelemetry-collector/consumer"
+	"github.com/open-telemetry/opentelemetry-collector/receiver/hostmetricsreceiver/internal"
+)
+
+// This file implements Factory for HostMetrics receiver.
+
+const (
+	// The value of "type" key in configuration.
+	typeStr     = "hostmetrics"
+	scrapersKey = "scrapers"
+)
+
+// Factory is the Factory for receiver.
+type Factory struct {
+	ScraperFactories map[string]internal.Factory
+}
+
+// NewFactory creates a new factory
+func NewFactory() *Factory {
+	return &Factory{
+		ScraperFactories: map[string]internal.Factory{},
+	}
+}
+
+// Type gets the type of the Receiver config created by this Factory.
+func (f *Factory) Type() string {
+	return typeStr
+}
+
+// CustomUnmarshaler returns custom unmarshaler for this config.
+func (f *Factory) CustomUnmarshaler() component.CustomUnmarshaler {
+	return func(componentViperSection *viper.Viper, intoCfg interface{}) error {
+
+		// load the non-dynamic config normally
+
+		err := componentViperSection.Unmarshal(intoCfg)
+		if err != nil {
+			return err
+		}
+
+		cfg, ok := intoCfg.(*Config)
+		if !ok {
+			return fmt.Errorf("config type not hostmetrics.Config")
+		}
+
+		// dynamically load the individual collector configs based on the key name
+
+		cfg.Scrapers = map[string]internal.Config{}
+
+		scrapersViperSection := componentViperSection.Sub(scrapersKey)
+		if scrapersViperSection == nil || len(scrapersViperSection.AllKeys()) == 0 {
+			return fmt.Errorf("must specify at least one scraper when using hostmetrics receiver")
+		}
+
+		for key := range componentViperSection.GetStringMap(scrapersKey) {
+			factory, ok := f.ScraperFactories[key]
+			if !ok {
+				return fmt.Errorf("invalid hostmetrics scraper key: %s", key)
+			}
+
+			collectorCfg := factory.CreateDefaultConfig()
+			collectorViperSection := scrapersViperSection.Sub(key)
+			if collectorViperSection != nil {
+				err := collectorViperSection.UnmarshalExact(collectorCfg)
+				if err != nil {
+					return fmt.Errorf("error reading settings for hostmetric scraper type %q: %v", key, err)
+				}
+			}
+
+			cfg.Scrapers[key] = collectorCfg
+		}
+
+		return nil
+	}
+}
+
+// CreateDefaultConfig creates the default configuration for receiver.
+func (f *Factory) CreateDefaultConfig() configmodels.Receiver {
+	return &Config{
+		ReceiverSettings: configmodels.ReceiverSettings{
+			TypeVal: typeStr,
+			NameVal: typeStr,
+		},
+		DefaultCollectionInterval: 10 * time.Second,
+	}
+}
+
+// CreateTraceReceiver creates a trace receiver based on provided config.
+func (f *Factory) CreateTraceReceiver(
+	ctx context.Context,
+	params component.ReceiverCreateParams,
+	cfg configmodels.Receiver,
+	consumer consumer.TraceConsumer,
+) (component.TraceReceiver, error) {
+	// Host Metrics does not support traces
+	return nil, configerror.ErrDataTypeIsNotSupported
+}
+
+// CreateMetricsReceiver creates a metrics receiver based on provided config.
+func (f *Factory) CreateMetricsReceiver(
+	ctx context.Context,
+	params component.ReceiverCreateParams,
+	cfg configmodels.Receiver,
+	consumer consumer.MetricsConsumer,
+) (component.MetricsReceiver, error) {
+
+	if runtime.GOOS != "windows" {
+		return nil, errors.New("hostmetrics receiver is currently only supported on windows")
+	}
+
+	config := cfg.(*Config)
+
+	hmr, err := NewHostMetricsReceiver(ctx, params.Logger, config, f.ScraperFactories, consumer)
+	if err != nil {
+		return nil, err
+	}
+
+	return hmr, nil
+}

--- a/receiver/hostmetricsreceiver/factory_test.go
+++ b/receiver/hostmetricsreceiver/factory_test.go
@@ -1,0 +1,57 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hostmetricsreceiver
+
+import (
+	"context"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector/component"
+	"github.com/open-telemetry/opentelemetry-collector/config/configcheck"
+	"github.com/open-telemetry/opentelemetry-collector/config/configerror"
+)
+
+var creationParams = component.ReceiverCreateParams{Logger: zap.NewNop()}
+
+func TestCreateDefaultConfig(t *testing.T) {
+	factory := &Factory{}
+	cfg := factory.CreateDefaultConfig()
+	assert.NotNil(t, cfg, "failed to create default config")
+	assert.NoError(t, configcheck.ValidateConfig(cfg))
+}
+
+func TestCreateReceiver(t *testing.T) {
+	factory := &Factory{}
+	cfg := factory.CreateDefaultConfig()
+
+	tReceiver, err := factory.CreateTraceReceiver(context.Background(), creationParams, cfg, nil)
+
+	assert.Equal(t, err, configerror.ErrDataTypeIsNotSupported)
+	assert.Nil(t, tReceiver)
+
+	mReceiver, err := factory.CreateMetricsReceiver(context.Background(), creationParams, cfg, nil)
+
+	if runtime.GOOS != "windows" {
+		assert.NotNil(t, err)
+		assert.Nil(t, tReceiver)
+	} else {
+		assert.Nil(t, err)
+		assert.NotNil(t, mReceiver)
+	}
+}

--- a/receiver/hostmetricsreceiver/hostmetrics_receiver.go
+++ b/receiver/hostmetricsreceiver/hostmetrics_receiver.go
@@ -1,0 +1,99 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hostmetricsreceiver
+
+import (
+	"context"
+	"fmt"
+
+	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector/component"
+	"github.com/open-telemetry/opentelemetry-collector/component/componenterror"
+	"github.com/open-telemetry/opentelemetry-collector/consumer"
+	"github.com/open-telemetry/opentelemetry-collector/receiver/hostmetricsreceiver/internal"
+)
+
+// Receiver is the type used to handle metrics from VM metrics.
+type Receiver struct {
+	consumer consumer.MetricsConsumer
+	config   *Config
+	scrapers []internal.Scraper
+	cancel   context.CancelFunc
+}
+
+// NewHostMetricsReceiver creates a new set of VM and Process Metrics
+func NewHostMetricsReceiver(
+	ctx context.Context,
+	logger *zap.Logger,
+	config *Config,
+	factories map[string]internal.Factory,
+	consumer consumer.MetricsConsumer,
+) (*Receiver, error) {
+
+	scrapers := make([]internal.Scraper, 0)
+	for key, cfg := range config.Scrapers {
+		scraper, err := factories[key].CreateMetricsScraper(ctx, logger, cfg)
+		if err != nil {
+			return nil, fmt.Errorf("cannot create scraper: %s", err.Error())
+		}
+		scrapers = append(scrapers, scraper)
+	}
+
+	hmr := &Receiver{
+		consumer: consumer,
+		config:   config,
+		scrapers: scrapers,
+	}
+
+	return hmr, nil
+}
+
+// Start begins scraping host metrics based on the OS platform.
+func (hmr *Receiver) Start(ctx context.Context, host component.Host) error {
+	ctx, hmr.cancel = context.WithCancel(ctx)
+
+	go func() {
+		for _, scraper := range hmr.scrapers {
+			err := scraper.Start(ctx)
+			if err != nil {
+				host.ReportFatalError(err)
+				return
+			}
+		}
+	}()
+
+	return nil
+}
+
+// Shutdown stops the underlying host metrics scrapers.
+func (hmr *Receiver) Shutdown(ctx context.Context) error {
+	hmr.cancel()
+
+	var errs []error
+
+	for _, scraper := range hmr.scrapers {
+		err := scraper.Close(ctx)
+		if err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	if len(errs) > 0 {
+		return componenterror.CombineErrors(errs)
+	}
+
+	return nil
+}

--- a/receiver/hostmetricsreceiver/hostmetrics_receiver_test.go
+++ b/receiver/hostmetricsreceiver/hostmetrics_receiver_test.go
@@ -1,0 +1,51 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hostmetricsreceiver
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector/component/componenttest"
+	"github.com/open-telemetry/opentelemetry-collector/exporter/exportertest"
+	"github.com/open-telemetry/opentelemetry-collector/receiver/hostmetricsreceiver/internal"
+)
+
+func TestGatherMetrics_EndToEnd(t *testing.T) {
+	sink := &exportertest.SinkMetricsExporter{}
+
+	config := &Config{
+		DefaultCollectionInterval: 0,
+		Scrapers:                  map[string]internal.Config{},
+	}
+
+	factories := map[string]internal.Factory{}
+
+	receiver, err := NewHostMetricsReceiver(context.Background(), zap.NewNop(), config, factories, sink)
+	require.NoError(t, err, "Failed to create metrics receiver: %v", err)
+
+	err = receiver.Start(context.Background(), componenttest.NewNopHost())
+	require.NoError(t, err, "Failed to start metrics receiver: %v", err)
+	defer func() { assert.NoError(t, receiver.Shutdown(context.Background())) }()
+
+	got := sink.AllMetrics()
+
+	// expect 0 MetricData objects
+	assert.Equal(t, 0, len(got))
+}

--- a/receiver/hostmetricsreceiver/internal/empty_test.go
+++ b/receiver/hostmetricsreceiver/internal/empty_test.go
@@ -1,0 +1,15 @@
+// Copyright  OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal

--- a/receiver/hostmetricsreceiver/internal/scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper.go
@@ -1,0 +1,52 @@
+// Copyright  OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"context"
+
+	"go.uber.org/zap"
+)
+
+// Scraper gathers metrics from the host machine and converts
+// these into internal metrics format.
+type Scraper interface {
+	// Start performs any timely initialization tasks such as
+	// setting up performance counters for initial collection,
+	// and then begins scraping metrics at the configured
+	// collection interval.
+	Start(ctx context.Context) error
+	// Close should clean up any unmanaged resources such as
+	// performance counter handles.
+	Close(ctx context.Context) error
+}
+
+// Factory can create a Scraper.
+type Factory interface {
+	// Type gets the type of the scraper created by this factory.
+	Type() string
+
+	// CreateDefaultConfig creates the default configuration for the Scraper.
+	CreateDefaultConfig() Config
+
+	// CreateMetricsScraper creates a scraper based on this config.
+	// If the config is not valid, error will be returned instead.
+	CreateMetricsScraper(ctx context.Context,
+		logger *zap.Logger, cfg Config) (Scraper, error)
+}
+
+// Config is the configuration of a scraper.
+type Config interface {
+}

--- a/receiver/hostmetricsreceiver/testdata/config.yaml
+++ b/receiver/hostmetricsreceiver/testdata/config.yaml
@@ -1,0 +1,17 @@
+receivers:
+  hostmetrics:
+    scrape_interval: 10s
+    scrapers:
+
+processors:
+  exampleprocessor:
+
+exporters:
+  exampleexporter:
+
+service:
+  pipelines:
+    traces:
+      receivers: [hostmetrics]
+      processors: [exampleprocessor]
+      exporters: [exampleexporter]

--- a/service/defaultcomponents/defaults.go
+++ b/service/defaultcomponents/defaults.go
@@ -36,6 +36,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector/processor/samplingprocessor/probabilisticsamplerprocessor"
 	"github.com/open-telemetry/opentelemetry-collector/processor/samplingprocessor/tailsamplingprocessor"
 	"github.com/open-telemetry/opentelemetry-collector/processor/spanprocessor"
+	"github.com/open-telemetry/opentelemetry-collector/receiver/hostmetricsreceiver"
 	"github.com/open-telemetry/opentelemetry-collector/receiver/jaegerreceiver"
 	"github.com/open-telemetry/opentelemetry-collector/receiver/opencensusreceiver"
 	"github.com/open-telemetry/opentelemetry-collector/receiver/otlpreceiver"
@@ -68,6 +69,7 @@ func Components() (
 		&opencensusreceiver.Factory{},
 		&otlpreceiver.Factory{},
 		&vmmetricsreceiver.Factory{},
+		hostmetricsreceiver.NewFactory(),
 	)
 	if err != nil {
 		errs = append(errs, err)

--- a/service/defaultcomponents/defaults_test.go
+++ b/service/defaultcomponents/defaults_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector/processor/samplingprocessor/probabilisticsamplerprocessor"
 	"github.com/open-telemetry/opentelemetry-collector/processor/samplingprocessor/tailsamplingprocessor"
 	"github.com/open-telemetry/opentelemetry-collector/processor/spanprocessor"
+	"github.com/open-telemetry/opentelemetry-collector/receiver/hostmetricsreceiver"
 	"github.com/open-telemetry/opentelemetry-collector/receiver/jaegerreceiver"
 	"github.com/open-telemetry/opentelemetry-collector/receiver/opencensusreceiver"
 	"github.com/open-telemetry/opentelemetry-collector/receiver/otlpreceiver"
@@ -55,12 +56,13 @@ func TestDefaultComponents(t *testing.T) {
 		"zpages":       &zpagesextension.Factory{},
 	}
 	expectedReceivers := map[string]component.ReceiverFactoryBase{
-		"jaeger":     &jaegerreceiver.Factory{},
-		"zipkin":     &zipkinreceiver.Factory{},
-		"prometheus": &prometheusreceiver.Factory{},
-		"opencensus": &opencensusreceiver.Factory{},
-		"otlp":       &otlpreceiver.Factory{},
-		"vmmetrics":  &vmmetricsreceiver.Factory{},
+		"jaeger":      &jaegerreceiver.Factory{},
+		"zipkin":      &zipkinreceiver.Factory{},
+		"prometheus":  &prometheusreceiver.Factory{},
+		"opencensus":  &opencensusreceiver.Factory{},
+		"otlp":        &otlpreceiver.Factory{},
+		"vmmetrics":   &vmmetricsreceiver.Factory{},
+		"hostmetrics": hostmetricsreceiver.NewFactory(),
 	}
 	expectedProcessors := map[string]component.ProcessorFactoryBase{
 		"attributes":            &attributesprocessor.Factory{},


### PR DESCRIPTION
**Link to tracking Issue:**
[Issue 847](https://github.com/open-telemetry/opentelemetry-collector/issues/847)

**Description:**
Added initial scaffolding code for a new hostmetricsreceiver which will scrape Host Metrics (CPU, Memory, Disk, etc) based on the operating system.

This receiver supports configuration per metric type (or "Scraper"), e.g. to collect cpu, memory and disk metrics, config would look something like:
```
hostmetrics:
  scrape_interval: 1s
  scrapers:
    cpu:
      report_per_cpu: true
    memory:
    disk:
```

**Not included in this PR:**

- Scraping implementation: Will be added in follow-up PR
- End to end tests: Will be added in follow-up PR
- Windows build step: A lot of this code only runs against windows (see the `+build windows` flag). At some stage, we'll presumably need to add a build step that ensures this code is built and tested as part of CI (running integration & e2e tests would require a windows agent, which circleci does appear to support). Likewise, may need to look at how to measure code coverage of the windows specific code.