### PR TITLE
Use defaults in Jaeger remote sampling.

### DIFF
--- a/receiver/jaegerreceiver/factory.go
+++ b/receiver/jaegerreceiver/factory.go
@@ -178,7 +178,11 @@ func (f *Factory) CreateTraceReceiver(
 	}
 
 	if remoteSamplingConfig != nil {
-		config.RemoteSamplingEndpoint = remoteSamplingConfig.FetchEndpoint
+		if len(remoteSamplingConfig.FetchEndpoint) == 0 {
+			config.RemoteSamplingEndpoint = defaultGRPCBindEndpoint
+		} else {
+			config.RemoteSamplingEndpoint = remoteSamplingConfig.FetchEndpoint
+		}
 
 		if len(remoteSamplingConfig.HostEndpoint) == 0 {
 			config.AgentHTTPPort = defaultAgentRemoteSamplingHTTPPort

--- a/receiver/jaegerreceiver/factory_test.go
+++ b/receiver/jaegerreceiver/factory_test.go
@@ -124,7 +124,21 @@ func TestCreateInvalidThriftCompactEndpoint(t *testing.T) {
 	assert.Equal(t, 6831, r.(*jReceiver).config.AgentCompactThriftPort, "thrift port should be default")
 }
 
-func TestDefaultAgentRemoteSamplingHTTPPort(t *testing.T) {
+func TestDefaultAgentRemoteSamplingEndpointAndPort(t *testing.T) {
+	factory := Factory{}
+	cfg := factory.CreateDefaultConfig()
+	rCfg := cfg.(*Config)
+
+	rCfg.Protocols[protoThriftCompact], _ = defaultsForProtocol(protoThriftCompact)
+	rCfg.RemoteSampling = &RemoteSamplingConfig{}
+	r, err := factory.CreateTraceReceiver(context.Background(), zap.NewNop(), cfg, nil)
+
+	assert.NoError(t, err, "create trace receiver should not error")
+	assert.Equal(t, defaultGRPCBindEndpoint, r.(*jReceiver).config.RemoteSamplingEndpoint)
+	assert.Equal(t, defaultAgentRemoteSamplingHTTPPort, r.(*jReceiver).config.AgentHTTPPort, "agent http port should be default")
+}
+
+func TestAgentRemoteSamplingEndpoint(t *testing.T) {
 	factory := Factory{}
 	cfg := factory.CreateDefaultConfig()
 	rCfg := cfg.(*Config)

--- a/receiver/jaegerreceiver/trace_receiver.go
+++ b/receiver/jaegerreceiver/trace_receiver.go
@@ -463,15 +463,13 @@ func (jr *jReceiver) startCollector(host component.Host) error {
 		api_v2.RegisterCollectorServiceServer(jr.grpc, jr)
 
 		// init and register sampling strategy store
-		if len(jr.config.RemoteSamplingStrategyFile) != 0 {
-			ss, gerr := staticStrategyStore.NewStrategyStore(staticStrategyStore.Options{
-				StrategiesFile: jr.config.RemoteSamplingStrategyFile,
-			}, jr.logger)
-			if gerr != nil {
-				return fmt.Errorf("failed to create collector strategy store: %v", gerr)
-			}
-			api_v2.RegisterSamplingManagerServer(jr.grpc, collectorSampling.NewGRPCHandler(ss))
+		ss, gerr := staticStrategyStore.NewStrategyStore(staticStrategyStore.Options{
+			StrategiesFile: jr.config.RemoteSamplingStrategyFile,
+		}, jr.logger)
+		if gerr != nil {
+			return fmt.Errorf("failed to create collector strategy store: %v", gerr)
 		}
+		api_v2.RegisterSamplingManagerServer(jr.grpc, collectorSampling.NewGRPCHandler(ss))
 
 		go func() {
 			if err := jr.grpc.Serve(gln); err != nil {

--- a/receiver/jaegerreceiver/trace_receiver_test.go
+++ b/receiver/jaegerreceiver/trace_receiver_test.go
@@ -463,10 +463,11 @@ func TestSamplingFailsOnNotConfigured(t *testing.T) {
 
 	cl := api_v2.NewSamplingManagerClient(conn)
 
-	_, err = cl.GetSamplingStrategy(context.Background(), &api_v2.SamplingStrategyParameters{
+	response, err := cl.GetSamplingStrategy(context.Background(), &api_v2.SamplingStrategyParameters{
 		ServiceName: "nothing",
 	})
-	assert.Error(t, err)
+	require.NoError(t, err)
+	assert.Equal(t, 0.001, response.GetProbabilisticSampling().GetSamplingRate())
 }
 
 func TestSamplingFailsOnBadFile(t *testing.T) {


### PR DESCRIPTION
* use default sampling strategy `{"strategyType":0,"probabilisticSampling":{"samplingRate":0.001}}` if no file is provided - this aligns with Jaeger behavior.
* use default values for fetch endpoint `fetch_endpoint`. If only `host_endpoint` is specified the collector will try to get the sampling strategies from grpc endpoint running on the localhost.

The following configuration would fail on `nil` pointer. The patch fixes it and uses the default value of `remote_endpoint` as `localhost:14250` so it would fail on `collector error: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing dial tcp [::1]:14250: connect: connection refused"` 
```
receivers:
  jaeger:
    remote_sampling:
      host_endpoint: localhost:5778
    protocols:
      thrift_compact:
      thrift_binary:
```
Once the `grpc` receiver is enabled it returns default sampling strategy as Jaeger does. Without the if fails on `nil` pointer. 
