### PR TITLE
Declare component Type as a type alias

### DIFF
--- a/component/component.go
+++ b/component/component.go
@@ -62,7 +62,7 @@ type Host interface {
 	// GetFactory can be called by the component anytime after Start() begins and
 	// until Shutdown() is called. Note that the component is responsible for destroying
 	// other components that it creates.
-	GetFactory(kind Kind, componentType string) Factory
+	GetFactory(kind Kind, componentType configmodels.Type) Factory
 
 	// Return map of extensions. Only enabled and created extensions will be returned.
 	// Typically is used to find an extension by type or by full config name. Both cases
@@ -74,5 +74,5 @@ type Host interface {
 // Factory interface must be implemented by all component factories.
 type Factory interface {
 	// Type gets the type of the component created by this factory.
-	Type() string
+	Type() configmodels.Type
 }

--- a/component/componenttest/error_waiting_host.go
+++ b/component/componenttest/error_waiting_host.go
@@ -57,7 +57,7 @@ func (ews *ErrorWaitingHost) WaitForFatalError(timeout time.Duration) (receivedE
 }
 
 // GetFactory of the specified kind. Returns the factory for a component type.
-func (ews *ErrorWaitingHost) GetFactory(_ component.Kind, _ string) component.Factory {
+func (ews *ErrorWaitingHost) GetFactory(_ component.Kind, _ configmodels.Type) component.Factory {
 	return nil
 }
 

--- a/component/componenttest/nop_host.go
+++ b/component/componenttest/nop_host.go
@@ -39,7 +39,7 @@ func (nh *NopHost) ReportFatalError(_ error) {
 }
 
 // GetFactory of the specified kind. Returns the factory for a component type.
-func (nh *NopHost) GetFactory(_ component.Kind, _ string) component.Factory {
+func (nh *NopHost) GetFactory(_ component.Kind, _ configmodels.Type) component.Factory {
 	return nil
 }
 

--- a/component/exporter_test.go
+++ b/component/exporter_test.go
@@ -28,8 +28,8 @@ type TestExporterFactory struct {
 }
 
 // Type gets the type of the Exporter config created by this factory.
-func (f *TestExporterFactory) Type() string {
-	return f.name
+func (f *TestExporterFactory) Type() configmodels.Type {
+	return configmodels.Type(f.name)
 }
 
 // CreateDefaultConfig creates the default configuration for the Exporter.
@@ -50,7 +50,7 @@ func (f *TestExporterFactory) CreateMetricsExporter(logger *zap.Logger, cfg conf
 func TestBuildExporters(t *testing.T) {
 	type testCase struct {
 		in  []ExporterFactoryBase
-		out map[string]ExporterFactoryBase
+		out map[configmodels.Type]ExporterFactoryBase
 		err bool
 	}
 
@@ -60,7 +60,7 @@ func TestBuildExporters(t *testing.T) {
 				&TestExporterFactory{"exp1"},
 				&TestExporterFactory{"exp2"},
 			},
-			out: map[string]ExporterFactoryBase{
+			out: map[configmodels.Type]ExporterFactoryBase{
 				"exp1": &TestExporterFactory{"exp1"},
 				"exp2": &TestExporterFactory{"exp2"},
 			},

--- a/component/factory_helpers.go
+++ b/component/factory_helpers.go
@@ -14,13 +14,17 @@
 
 package component
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
+)
 
 // MakeReceiverFactoryMap takes a list of receiver factories and returns a map
 // with factory type as keys. It returns a non-nil error when more than one factories
 // have the same type.
-func MakeReceiverFactoryMap(factories ...ReceiverFactoryBase) (map[string]ReceiverFactoryBase, error) {
-	fMap := map[string]ReceiverFactoryBase{}
+func MakeReceiverFactoryMap(factories ...ReceiverFactoryBase) (map[configmodels.Type]ReceiverFactoryBase, error) {
+	fMap := map[configmodels.Type]ReceiverFactoryBase{}
 	for _, f := range factories {
 		if _, ok := fMap[f.Type()]; ok {
 			return fMap, fmt.Errorf("duplicate receiver factory %q", f.Type())
@@ -33,8 +37,8 @@ func MakeReceiverFactoryMap(factories ...ReceiverFactoryBase) (map[string]Receiv
 // MakeProcessorFactoryMap takes a list of processor factories and returns a map
 // with factory type as keys. It returns a non-nil error when more than one factories
 // have the same type.
-func MakeProcessorFactoryMap(factories ...ProcessorFactoryBase) (map[string]ProcessorFactoryBase, error) {
-	fMap := map[string]ProcessorFactoryBase{}
+func MakeProcessorFactoryMap(factories ...ProcessorFactoryBase) (map[configmodels.Type]ProcessorFactoryBase, error) {
+	fMap := map[configmodels.Type]ProcessorFactoryBase{}
 	for _, f := range factories {
 		if _, ok := fMap[f.Type()]; ok {
 			return fMap, fmt.Errorf("duplicate processor factory %q", f.Type())
@@ -47,8 +51,8 @@ func MakeProcessorFactoryMap(factories ...ProcessorFactoryBase) (map[string]Proc
 // MakeExporterFactoryMap takes a list of exporter factories and returns a map
 // with factory type as keys. It returns a non-nil error when more than one factories
 // have the same type.
-func MakeExporterFactoryMap(factories ...ExporterFactoryBase) (map[string]ExporterFactoryBase, error) {
-	fMap := map[string]ExporterFactoryBase{}
+func MakeExporterFactoryMap(factories ...ExporterFactoryBase) (map[configmodels.Type]ExporterFactoryBase, error) {
+	fMap := map[configmodels.Type]ExporterFactoryBase{}
 	for _, f := range factories {
 		if _, ok := fMap[f.Type()]; ok {
 			return fMap, fmt.Errorf("duplicate exporter factory %q", f.Type())
@@ -61,8 +65,8 @@ func MakeExporterFactoryMap(factories ...ExporterFactoryBase) (map[string]Export
 // MakeExtensionFactoryMap takes a list of extension factories and returns a map
 // with factory type as keys. It returns a non-nil error when more than one factories
 // have the same type.
-func MakeExtensionFactoryMap(factories ...ExtensionFactory) (map[string]ExtensionFactory, error) {
-	fMap := map[string]ExtensionFactory{}
+func MakeExtensionFactoryMap(factories ...ExtensionFactory) (map[configmodels.Type]ExtensionFactory, error) {
+	fMap := map[configmodels.Type]ExtensionFactory{}
 	for _, f := range factories {
 		if _, ok := fMap[f.Type()]; ok {
 			return fMap, fmt.Errorf("duplicate extension factory %q", f.Type())

--- a/component/processor_test.go
+++ b/component/processor_test.go
@@ -30,8 +30,8 @@ type TestProcessorFactory struct {
 }
 
 // Type gets the type of the Processor config created by this factory.
-func (f *TestProcessorFactory) Type() string {
-	return f.name
+func (f *TestProcessorFactory) Type() configmodels.Type {
+	return configmodels.Type(f.name)
 }
 
 // CreateDefaultConfig creates the default configuration for the Processor.
@@ -60,7 +60,7 @@ func (f *TestProcessorFactory) CreateMetricsProcessor(
 func TestFactoriesBuilder(t *testing.T) {
 	type testCase struct {
 		in  []ProcessorFactoryBase
-		out map[string]ProcessorFactoryBase
+		out map[configmodels.Type]ProcessorFactoryBase
 		err bool
 	}
 
@@ -70,7 +70,7 @@ func TestFactoriesBuilder(t *testing.T) {
 				&TestProcessorFactory{"p1"},
 				&TestProcessorFactory{"p2"},
 			},
-			out: map[string]ProcessorFactoryBase{
+			out: map[configmodels.Type]ProcessorFactoryBase{
 				"p1": &TestProcessorFactory{"p1"},
 				"p2": &TestProcessorFactory{"p2"},
 			},

--- a/component/receiver_test.go
+++ b/component/receiver_test.go
@@ -26,11 +26,11 @@ import (
 )
 
 type TestReceiverFactory struct {
-	name string
+	name configmodels.Type
 }
 
 // Type gets the type of the Receiver config created by this factory.
-func (f *TestReceiverFactory) Type() string {
+func (f *TestReceiverFactory) Type() configmodels.Type {
 	return f.name
 }
 
@@ -68,7 +68,7 @@ func (f *TestReceiverFactory) CreateMetricsReceiver(
 func TestBuildReceivers(t *testing.T) {
 	type testCase struct {
 		in  []ReceiverFactoryBase
-		out map[string]ReceiverFactoryBase
+		out map[configmodels.Type]ReceiverFactoryBase
 		err bool
 	}
 
@@ -78,7 +78,7 @@ func TestBuildReceivers(t *testing.T) {
 				&TestReceiverFactory{"e1"},
 				&TestReceiverFactory{"e2"},
 			},
-			out: map[string]ReceiverFactoryBase{
+			out: map[configmodels.Type]ReceiverFactoryBase{
 				"e1": &TestReceiverFactory{"e1"},
 				"e2": &TestReceiverFactory{"e2"},
 			},

--- a/config/config.go
+++ b/config/config.go
@@ -104,16 +104,16 @@ const typeAndNameSeparator = "/"
 // can be handled by the Config.
 type Factories struct {
 	// Receivers maps receiver type names in the config to the respective factory.
-	Receivers map[string]component.ReceiverFactoryBase
+	Receivers map[configmodels.Type]component.ReceiverFactoryBase
 
 	// Processors maps processor type names in the config to the respective factory.
-	Processors map[string]component.ProcessorFactoryBase
+	Processors map[configmodels.Type]component.ProcessorFactoryBase
 
 	// Exporters maps exporter type names in the config to the respective factory.
-	Exporters map[string]component.ExporterFactoryBase
+	Exporters map[configmodels.Type]component.ExporterFactoryBase
 
 	// Extensions maps extension type names in the config to the respective factory.
-	Extensions map[string]component.ExtensionFactory
+	Extensions map[configmodels.Type]component.ExtensionFactory
 }
 
 // Creates a new Viper instance with a different key-delimitor "::" instead of the
@@ -190,11 +190,11 @@ func Load(
 // fullName is the key normalized such that type and name components have spaces trimmed.
 // The "type" part must be present, the forward slash and "name" are optional. typeStr
 // will be non-empty if err is nil.
-func DecodeTypeAndName(key string) (typeStr, fullName string, err error) {
+func DecodeTypeAndName(key string) (typeStr configmodels.Type, fullName string, err error) {
 	items := strings.SplitN(key, typeAndNameSeparator, 2)
 
 	if len(items) >= 1 {
-		typeStr = strings.TrimSpace(items[0])
+		typeStr = configmodels.Type(strings.TrimSpace(items[0]))
 	}
 
 	if len(items) < 1 || typeStr == "" {
@@ -216,16 +216,16 @@ func DecodeTypeAndName(key string) (typeStr, fullName string, err error) {
 
 	// Create normalized fullName.
 	if nameSuffix == "" {
-		fullName = typeStr
+		fullName = string(typeStr)
 	} else {
-		fullName = typeStr + typeAndNameSeparator + nameSuffix
+		fullName = string(typeStr) + typeAndNameSeparator + nameSuffix
 	}
 
 	err = nil
 	return
 }
 
-func loadExtensions(v *viper.Viper, factories map[string]component.ExtensionFactory) (configmodels.Extensions, error) {
+func loadExtensions(v *viper.Viper, factories map[configmodels.Type]component.ExtensionFactory) (configmodels.Extensions, error) {
 	// Get the list of all "extensions" sub vipers from config source.
 	extensionsConfig := viperSub(v, extensionsKeyName)
 	expandEnvConfig(extensionsConfig)
@@ -314,7 +314,7 @@ func loadService(v *viper.Viper) (configmodels.Service, error) {
 }
 
 // LoadReceiver loads a receiver config from componentConfig using the provided factories.
-func LoadReceiver(componentConfig *viper.Viper, typeStr string, fullName string, factory component.ReceiverFactoryBase) (configmodels.Receiver, error) {
+func LoadReceiver(componentConfig *viper.Viper, typeStr configmodels.Type, fullName string, factory component.ReceiverFactoryBase) (configmodels.Receiver, error) {
 	// Create the default config for this receiver.
 	receiverCfg := factory.CreateDefaultConfig()
 	receiverCfg.SetType(typeStr)
@@ -341,7 +341,7 @@ func LoadReceiver(componentConfig *viper.Viper, typeStr string, fullName string,
 	return receiverCfg, nil
 }
 
-func loadReceivers(v *viper.Viper, factories map[string]component.ReceiverFactoryBase) (configmodels.Receivers, error) {
+func loadReceivers(v *viper.Viper, factories map[configmodels.Type]component.ReceiverFactoryBase) (configmodels.Receivers, error) {
 	// Get the list of all "receivers" sub vipers from config source.
 	receiversConfig := viperSub(v, receiversKeyName)
 	expandEnvConfig(receiversConfig)
@@ -400,7 +400,7 @@ func loadReceivers(v *viper.Viper, factories map[string]component.ReceiverFactor
 	return receivers, nil
 }
 
-func loadExporters(v *viper.Viper, factories map[string]component.ExporterFactoryBase) (configmodels.Exporters, error) {
+func loadExporters(v *viper.Viper, factories map[configmodels.Type]component.ExporterFactoryBase) (configmodels.Exporters, error) {
 	// Get the list of all "exporters" sub vipers from config source.
 	exportersConfig := viperSub(v, exportersKeyName)
 	expandEnvConfig(exportersConfig)
@@ -469,7 +469,7 @@ func loadExporters(v *viper.Viper, factories map[string]component.ExporterFactor
 	return exporters, nil
 }
 
-func loadProcessors(v *viper.Viper, factories map[string]component.ProcessorFactoryBase) (configmodels.Processors, error) {
+func loadProcessors(v *viper.Viper, factories map[configmodels.Type]component.ProcessorFactoryBase) (configmodels.Processors, error) {
 	// Get the list of all "processors" sub vipers from config source.
 	processorsConfig := viperSub(v, processorsKeyName)
 	expandEnvConfig(processorsConfig)

--- a/config/configcheck/configcheck_test.go
+++ b/config/configcheck/configcheck_test.go
@@ -187,7 +187,7 @@ func TestValidateConfig(t *testing.T) {
 // a config not satisfying the validation.
 type badConfigExtensionFactory struct{}
 
-func (b badConfigExtensionFactory) Type() string {
+func (b badConfigExtensionFactory) Type() configmodels.Type {
 	return "bad_config"
 }
 

--- a/config/configmodels/configmodels.go
+++ b/config/configmodels/configmodels.go
@@ -46,13 +46,16 @@ type NamedEntity interface {
 	SetName(name string)
 }
 
+// Component type as it is used in the config.
+type Type string
+
 // Receiver is the configuration of a receiver. Specific receivers must implement this
 // interface and will typically embed ReceiverSettings struct or a struct that extends it.
 type Receiver interface {
 	NamedEntity
 	IsEnabled() bool
-	Type() string
-	SetType(typeStr string)
+	Type() Type
+	SetType(typeStr Type)
 }
 
 // Receivers is a map of names to Receivers.
@@ -62,8 +65,8 @@ type Receivers map[string]Receiver
 type Exporter interface {
 	NamedEntity
 	IsEnabled() bool
-	Type() string
-	SetType(typeStr string)
+	Type() Type
+	SetType(typeStr Type)
 }
 
 // Exporters is a map of names to Exporters.
@@ -74,8 +77,8 @@ type Exporters map[string]Exporter
 type Processor interface {
 	NamedEntity
 	IsEnabled() bool
-	Type() string
-	SetType(typeStr string)
+	Type() Type
+	SetType(typeStr Type)
 }
 
 // Processors is a map of names to Processors.
@@ -132,8 +135,8 @@ type Pipelines map[string]*Pipeline
 type Extension interface {
 	NamedEntity
 	IsEnabled() bool
-	Type() string
-	SetType(typeStr string)
+	Type() Type
+	SetType(typeStr Type)
 }
 
 // Extensions is a map of names to extensions.
@@ -155,7 +158,7 @@ type Service struct {
 // ReceiverSettings defines common settings for a single-protocol receiver configuration.
 // Specific receivers can embed this struct and extend it with more fields if needed.
 type ReceiverSettings struct {
-	TypeVal string `mapstructure:"-"`
+	TypeVal Type   `mapstructure:"-"`
 	NameVal string `mapstructure:"-"`
 	// Configures if the receiver is disabled and doesn't receive any data.
 	// The default value is false(meaning the receiver is enabled by default), and it is expected that receivers
@@ -177,12 +180,12 @@ func (rs *ReceiverSettings) SetName(name string) {
 }
 
 // Type sets the receiver type.
-func (rs *ReceiverSettings) Type() string {
+func (rs *ReceiverSettings) Type() Type {
 	return rs.TypeVal
 }
 
 // SetType sets the receiver type.
-func (rs *ReceiverSettings) SetType(typeStr string) {
+func (rs *ReceiverSettings) SetType(typeStr Type) {
 	rs.TypeVal = typeStr
 }
 
@@ -196,7 +199,7 @@ func (rs *ReceiverSettings) IsEnabled() bool {
 // ExporterSettings defines common settings for an exporter configuration.
 // Specific exporters can embed this struct and extend it with more fields if needed.
 type ExporterSettings struct {
-	TypeVal  string `mapstructure:"-"`
+	TypeVal  Type   `mapstructure:"-"`
 	NameVal  string `mapstructure:"-"`
 	Disabled bool   `mapstructure:"disabled"`
 }
@@ -214,12 +217,12 @@ func (es *ExporterSettings) SetName(name string) {
 }
 
 // Type sets the exporter type.
-func (es *ExporterSettings) Type() string {
+func (es *ExporterSettings) Type() Type {
 	return es.TypeVal
 }
 
 // SetType sets the exporter type.
-func (es *ExporterSettings) SetType(typeStr string) {
+func (es *ExporterSettings) SetType(typeStr Type) {
 	es.TypeVal = typeStr
 }
 
@@ -231,7 +234,7 @@ func (es *ExporterSettings) IsEnabled() bool {
 // ProcessorSettings defines common settings for a processor configuration.
 // Specific processors can embed this struct and extend it with more fields if needed.
 type ProcessorSettings struct {
-	TypeVal  string `mapstructure:"-"`
+	TypeVal  Type   `mapstructure:"-"`
 	NameVal  string `mapstructure:"-"`
 	Disabled bool   `mapstructure:"disabled"`
 }
@@ -247,12 +250,12 @@ func (proc *ProcessorSettings) SetName(name string) {
 }
 
 // Type sets the processor type.
-func (proc *ProcessorSettings) Type() string {
+func (proc *ProcessorSettings) Type() Type {
 	return proc.TypeVal
 }
 
 // SetType sets the processor type.
-func (proc *ProcessorSettings) SetType(typeStr string) {
+func (proc *ProcessorSettings) SetType(typeStr Type) {
 	proc.TypeVal = typeStr
 }
 
@@ -266,7 +269,7 @@ var _ Processor = (*ProcessorSettings)(nil)
 // ExtensionSettings defines common settings for a service extension configuration.
 // Specific extensions can embed this struct and extend it with more fields if needed.
 type ExtensionSettings struct {
-	TypeVal  string `mapstructure:"-"`
+	TypeVal  Type   `mapstructure:"-"`
 	NameVal  string `mapstructure:"-"`
 	Disabled bool   `mapstructure:"disabled"`
 }
@@ -282,12 +285,12 @@ func (ext *ExtensionSettings) SetName(name string) {
 }
 
 // Type sets the extension type.
-func (ext *ExtensionSettings) Type() string {
+func (ext *ExtensionSettings) Type() Type {
 	return ext.TypeVal
 }
 
 // SetType sets the extension type.
-func (ext *ExtensionSettings) SetType(typeStr string) {
+func (ext *ExtensionSettings) SetType(typeStr Type) {
 	ext.TypeVal = typeStr
 }
 

--- a/config/example_factories.go
+++ b/config/example_factories.go
@@ -47,7 +47,7 @@ type ExampleReceiverFactory struct {
 }
 
 // Type gets the type of the Receiver config created by this factory.
-func (f *ExampleReceiverFactory) Type() string {
+func (f *ExampleReceiverFactory) Type() configmodels.Type {
 	return "examplereceiver"
 }
 
@@ -149,7 +149,7 @@ var exampleReceivers = map[configmodels.Receiver]*ExampleReceiverProducer{}
 // MultiProtoReceiver is for testing purposes. We are defining an example multi protocol
 // config and factory for "multireceiver" receiver type.
 type MultiProtoReceiver struct {
-	TypeVal   string                              `mapstructure:"-"`
+	TypeVal   configmodels.Type                   `mapstructure:"-"`
 	NameVal   string                              `mapstructure:"-"`
 	Protocols map[string]MultiProtoReceiverOneCfg `mapstructure:"protocols"`
 }
@@ -167,12 +167,12 @@ func (rs *MultiProtoReceiver) SetName(name string) {
 }
 
 // Type sets the receiver type.
-func (rs *MultiProtoReceiver) Type() string {
+func (rs *MultiProtoReceiver) Type() configmodels.Type {
 	return rs.TypeVal
 }
 
 // SetType sets the receiver type.
-func (rs *MultiProtoReceiver) SetType(typeStr string) {
+func (rs *MultiProtoReceiver) SetType(typeStr configmodels.Type) {
 	rs.TypeVal = typeStr
 }
 
@@ -200,7 +200,7 @@ type MultiProtoReceiverFactory struct {
 }
 
 // Type gets the type of the Receiver config created by this factory.
-func (f *MultiProtoReceiverFactory) Type() string {
+func (f *MultiProtoReceiverFactory) Type() configmodels.Type {
 	return "multireceiver"
 }
 
@@ -262,7 +262,7 @@ type ExampleExporterFactory struct {
 }
 
 // Type gets the type of the Exporter config created by this factory.
-func (f *ExampleExporterFactory) Type() string {
+func (f *ExampleExporterFactory) Type() configmodels.Type {
 	return "exampleexporter"
 }
 
@@ -339,7 +339,7 @@ type ExampleProcessorFactory struct {
 }
 
 // Type gets the type of the Processor config created by this factory.
-func (f *ExampleProcessorFactory) Type() string {
+func (f *ExampleProcessorFactory) Type() configmodels.Type {
 	return "exampleprocessor"
 }
 
@@ -393,7 +393,7 @@ type ExampleExtensionFactory struct {
 }
 
 // Type gets the type of the Extension config created by this factory.
-func (f *ExampleExtensionFactory) Type() string {
+func (f *ExampleExtensionFactory) Type() configmodels.Type {
 	return "exampleextension"
 }
 

--- a/exporter/fileexporter/factory.go
+++ b/exporter/fileexporter/factory.go
@@ -33,7 +33,7 @@ type Factory struct {
 }
 
 // Type gets the type of the Exporter config created by this factory.
-func (f *Factory) Type() string {
+func (f *Factory) Type() configmodels.Type {
 	return typeStr
 }
 

--- a/exporter/jaegerexporter/factory.go
+++ b/exporter/jaegerexporter/factory.go
@@ -34,7 +34,7 @@ type Factory struct {
 }
 
 // Type gets the type of the Exporter config created by this factory.
-func (f *Factory) Type() string {
+func (f *Factory) Type() configmodels.Type {
 	return typeStr
 }
 

--- a/exporter/loggingexporter/factory.go
+++ b/exporter/loggingexporter/factory.go
@@ -36,7 +36,7 @@ type Factory struct {
 }
 
 // Type gets the type of the Exporter config created by this factory.
-func (f *Factory) Type() string {
+func (f *Factory) Type() configmodels.Type {
 	return typeStr
 }
 

--- a/exporter/opencensusexporter/factory.go
+++ b/exporter/opencensusexporter/factory.go
@@ -41,7 +41,7 @@ type Factory struct {
 }
 
 // Type gets the type of the Exporter config created by this factory.
-func (f *Factory) Type() string {
+func (f *Factory) Type() configmodels.Type {
 	return typeStr
 }
 

--- a/exporter/otlpexporter/factory.go
+++ b/exporter/otlpexporter/factory.go
@@ -32,7 +32,7 @@ type Factory struct {
 }
 
 // Type gets the type of the Exporter config created by this factory.
-func (f *Factory) Type() string {
+func (f *Factory) Type() configmodels.Type {
 	return typeStr
 }
 

--- a/exporter/prometheusexporter/factory.go
+++ b/exporter/prometheusexporter/factory.go
@@ -37,7 +37,7 @@ type Factory struct {
 }
 
 // Type gets the type of the Exporter config created by this factory.
-func (f *Factory) Type() string {
+func (f *Factory) Type() configmodels.Type {
 	return typeStr
 }
 

--- a/exporter/zipkinexporter/factory.go
+++ b/exporter/zipkinexporter/factory.go
@@ -34,7 +34,7 @@ type Factory struct {
 }
 
 // Type gets the type of the Exporter config created by this factory.
-func (f *Factory) Type() string {
+func (f *Factory) Type() configmodels.Type {
 	return typeStr
 }
 

--- a/extension/healthcheckextension/factory.go
+++ b/extension/healthcheckextension/factory.go
@@ -33,7 +33,7 @@ type Factory struct {
 }
 
 // Type gets the type of the config created by this factory.
-func (f *Factory) Type() string {
+func (f *Factory) Type() configmodels.Type {
 	return typeStr
 }
 

--- a/extension/healthcheckextension/factory_test.go
+++ b/extension/healthcheckextension/factory_test.go
@@ -31,7 +31,7 @@ import (
 
 func TestFactory_Type(t *testing.T) {
 	factory := Factory{}
-	require.Equal(t, typeStr, factory.Type())
+	require.Equal(t, configmodels.Type(typeStr), factory.Type())
 }
 
 func TestFactory_CreateDefaultConfig(t *testing.T) {

--- a/extension/pprofextension/factory.go
+++ b/extension/pprofextension/factory.go
@@ -33,7 +33,7 @@ type Factory struct {
 }
 
 // Type gets the type of the config created by this factory.
-func (f *Factory) Type() string {
+func (f *Factory) Type() configmodels.Type {
 	return typeStr
 }
 

--- a/extension/pprofextension/factory_test.go
+++ b/extension/pprofextension/factory_test.go
@@ -31,7 +31,7 @@ import (
 
 func TestFactory_Type(t *testing.T) {
 	factory := Factory{}
-	require.Equal(t, typeStr, factory.Type())
+	require.Equal(t, configmodels.Type(typeStr), factory.Type())
 }
 
 func TestFactory_CreateDefaultConfig(t *testing.T) {

--- a/extension/zpagesextension/factory.go
+++ b/extension/zpagesextension/factory.go
@@ -33,7 +33,7 @@ type Factory struct {
 }
 
 // Type gets the type of the config created by this factory.
-func (f *Factory) Type() string {
+func (f *Factory) Type() configmodels.Type {
 	return typeStr
 }
 

--- a/extension/zpagesextension/factory_test.go
+++ b/extension/zpagesextension/factory_test.go
@@ -31,7 +31,7 @@ import (
 
 func TestFactory_Type(t *testing.T) {
 	factory := Factory{}
-	require.Equal(t, typeStr, factory.Type())
+	require.Equal(t, configmodels.Type(typeStr), factory.Type())
 }
 
 func TestFactory_CreateDefaultConfig(t *testing.T) {

--- a/processor/attributesprocessor/factory.go
+++ b/processor/attributesprocessor/factory.go
@@ -37,7 +37,7 @@ type Factory struct {
 }
 
 // Type gets the type of the config created by this factory.
-func (f *Factory) Type() string {
+func (f *Factory) Type() configmodels.Type {
 	return typeStr
 }
 

--- a/processor/attributesprocessor/factory_test.go
+++ b/processor/attributesprocessor/factory_test.go
@@ -31,7 +31,7 @@ import (
 
 func TestFactory_Type(t *testing.T) {
 	factory := Factory{}
-	assert.Equal(t, factory.Type(), typeStr)
+	assert.Equal(t, factory.Type(), configmodels.Type(typeStr))
 }
 
 func TestFactory_CreateDefaultConfig(t *testing.T) {

--- a/processor/batchprocessor/factory.go
+++ b/processor/batchprocessor/factory.go
@@ -37,7 +37,7 @@ type Factory struct {
 }
 
 // Type gets the type of the config created by this factory.
-func (f *Factory) Type() string {
+func (f *Factory) Type() configmodels.Type {
 	return typeStr
 }
 

--- a/processor/memorylimiter/factory.go
+++ b/processor/memorylimiter/factory.go
@@ -34,7 +34,7 @@ type Factory struct {
 }
 
 // Type gets the type of the config created by this factory.
-func (f *Factory) Type() string {
+func (f *Factory) Type() configmodels.Type {
 	return typeStr
 }
 

--- a/processor/processortest/nop_processor.go
+++ b/processor/processortest/nop_processor.go
@@ -67,7 +67,7 @@ func NewNopMetricsProcessor(nextMetricsProcessor consumer.MetricsConsumerOld) co
 type NopProcessorFactory struct{}
 
 // Type gets the type of the Processor created by this factory.
-func (npf *NopProcessorFactory) Type() string {
+func (npf *NopProcessorFactory) Type() configmodels.Type {
 	return "nop"
 }
 
@@ -75,7 +75,7 @@ func (npf *NopProcessorFactory) Type() string {
 func (npf *NopProcessorFactory) CreateDefaultConfig() configmodels.Processor {
 	return &configmodels.ProcessorSettings{
 		TypeVal: npf.Type(),
-		NameVal: npf.Type(),
+		NameVal: string(npf.Type()),
 	}
 }
 

--- a/processor/queuedprocessor/factory.go
+++ b/processor/queuedprocessor/factory.go
@@ -34,7 +34,7 @@ type Factory struct {
 }
 
 // Type gets the type of the Option config created by this factory.
-func (f *Factory) Type() string {
+func (f *Factory) Type() configmodels.Type {
 	return typeStr
 }
 

--- a/processor/resourceprocessor/factory.go
+++ b/processor/resourceprocessor/factory.go
@@ -32,7 +32,7 @@ type Factory struct {
 }
 
 // Type gets the type of the Option config created by this factory.
-func (Factory) Type() string {
+func (Factory) Type() configmodels.Type {
 	return typeStr
 }
 

--- a/processor/samplingprocessor/probabilisticsamplerprocessor/factory.go
+++ b/processor/samplingprocessor/probabilisticsamplerprocessor/factory.go
@@ -33,7 +33,7 @@ type Factory struct {
 }
 
 // Type gets the type of the config created by this factory.
-func (f *Factory) Type() string {
+func (f *Factory) Type() configmodels.Type {
 	return typeStr
 }
 

--- a/processor/samplingprocessor/tailsamplingprocessor/factory.go
+++ b/processor/samplingprocessor/tailsamplingprocessor/factory.go
@@ -35,7 +35,7 @@ type Factory struct {
 }
 
 // Type gets the type of the config created by this factory.
-func (f *Factory) Type() string {
+func (f *Factory) Type() configmodels.Type {
 	return typeStr
 }
 

--- a/processor/spanprocessor/factory.go
+++ b/processor/spanprocessor/factory.go
@@ -42,7 +42,7 @@ type Factory struct {
 var _ component.ProcessorFactory = (*Factory)(nil)
 
 // Type gets the type of the config created by this factory.
-func (f *Factory) Type() string {
+func (f *Factory) Type() configmodels.Type {
 	return typeStr
 }
 

--- a/processor/spanprocessor/factory_test.go
+++ b/processor/spanprocessor/factory_test.go
@@ -26,12 +26,13 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector/component"
 	"github.com/open-telemetry/opentelemetry-collector/config/configcheck"
 	"github.com/open-telemetry/opentelemetry-collector/config/configerror"
+	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
 	"github.com/open-telemetry/opentelemetry-collector/exporter/exportertest"
 )
 
 func TestFactory_Type(t *testing.T) {
 	factory := &Factory{}
-	assert.Equal(t, factory.Type(), typeStr)
+	assert.Equal(t, factory.Type(), configmodels.Type(typeStr))
 }
 
 func TestFactory_CreateDefaultConfig(t *testing.T) {
@@ -41,7 +42,7 @@ func TestFactory_CreateDefaultConfig(t *testing.T) {
 
 	// Check the values of the default configuration.
 	assert.NotNil(t, cfg)
-	assert.Equal(t, typeStr, cfg.Type())
+	assert.Equal(t, configmodels.Type(typeStr), cfg.Type())
 	assert.Equal(t, typeStr, cfg.Name())
 }
 

--- a/receiver/hostmetricsreceiver/factory.go
+++ b/receiver/hostmetricsreceiver/factory.go
@@ -51,7 +51,7 @@ func NewFactory() *Factory {
 }
 
 // Type gets the type of the Receiver config created by this Factory.
-func (f *Factory) Type() string {
+func (f *Factory) Type() configmodels.Type {
 	return typeStr
 }
 

--- a/receiver/jaegerreceiver/config.go
+++ b/receiver/jaegerreceiver/config.go
@@ -15,6 +15,7 @@
 package jaegerreceiver
 
 import (
+	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
 	"github.com/open-telemetry/opentelemetry-collector/receiver"
 )
 
@@ -30,7 +31,7 @@ type RemoteSamplingConfig struct {
 
 // Config defines configuration for Jaeger receiver.
 type Config struct {
-	TypeVal        string                                      `mapstructure:"-"`
+	TypeVal        configmodels.Type                           `mapstructure:"-"`
 	NameVal        string                                      `mapstructure:"-"`
 	Protocols      map[string]*receiver.SecureReceiverSettings `mapstructure:"protocols"`
 	RemoteSampling *RemoteSamplingConfig                       `mapstructure:"remote_sampling"`
@@ -47,12 +48,12 @@ func (rs *Config) SetName(name string) {
 }
 
 // Type sets the receiver type.
-func (rs *Config) Type() string {
+func (rs *Config) Type() configmodels.Type {
 	return rs.TypeVal
 }
 
 // SetType sets the receiver type.
-func (rs *Config) SetType(typeStr string) {
+func (rs *Config) SetType(typeStr configmodels.Type) {
 	rs.TypeVal = typeStr
 }
 

--- a/receiver/jaegerreceiver/factory.go
+++ b/receiver/jaegerreceiver/factory.go
@@ -59,7 +59,7 @@ type Factory struct {
 }
 
 // Type gets the type of the Receiver config created by this factory.
-func (f *Factory) Type() string {
+func (f *Factory) Type() configmodels.Type {
 	return typeStr
 }
 

--- a/receiver/jaegerreceiver/factory_test.go
+++ b/receiver/jaegerreceiver/factory_test.go
@@ -33,7 +33,7 @@ import (
 func TestTypeStr(t *testing.T) {
 	factory := Factory{}
 
-	assert.Equal(t, "jaeger", factory.Type())
+	assert.Equal(t, "jaeger", string(factory.Type()))
 }
 
 func TestCreateDefaultConfig(t *testing.T) {

--- a/receiver/opencensusreceiver/factory.go
+++ b/receiver/opencensusreceiver/factory.go
@@ -35,7 +35,7 @@ type Factory struct {
 }
 
 // Type gets the type of the Receiver config created by this Factory.
-func (f *Factory) Type() string {
+func (f *Factory) Type() configmodels.Type {
 	return typeStr
 }
 

--- a/receiver/otlpreceiver/factory.go
+++ b/receiver/otlpreceiver/factory.go
@@ -33,7 +33,7 @@ type Factory struct {
 }
 
 // Type gets the type of the Receiver config created by this Factory.
-func (f *Factory) Type() string {
+func (f *Factory) Type() configmodels.Type {
 	return typeStr
 }
 

--- a/receiver/prometheusreceiver/factory.go
+++ b/receiver/prometheusreceiver/factory.go
@@ -48,7 +48,7 @@ type Factory struct {
 }
 
 // Type gets the type of the Receiver config created by this factory.
-func (f *Factory) Type() string {
+func (f *Factory) Type() configmodels.Type {
 	return typeStr
 }
 

--- a/receiver/vmmetricsreceiver/factory.go
+++ b/receiver/vmmetricsreceiver/factory.go
@@ -39,7 +39,7 @@ type Factory struct {
 }
 
 // Type gets the type of the Receiver config created by this Factory.
-func (f *Factory) Type() string {
+func (f *Factory) Type() configmodels.Type {
 	return typeStr
 }
 

--- a/receiver/zipkinreceiver/factory.go
+++ b/receiver/zipkinreceiver/factory.go
@@ -39,7 +39,7 @@ type Factory struct {
 }
 
 // Type gets the type of the Receiver config created by this factory.
-func (f *Factory) Type() string {
+func (f *Factory) Type() configmodels.Type {
 	return typeStr
 }
 

--- a/service/builder/exporters_builder.go
+++ b/service/builder/exporters_builder.go
@@ -119,14 +119,14 @@ type exportersRequiredDataTypes map[configmodels.Exporter]dataTypeRequirements
 type ExportersBuilder struct {
 	logger    *zap.Logger
 	config    *configmodels.Config
-	factories map[string]component.ExporterFactoryBase
+	factories map[configmodels.Type]component.ExporterFactoryBase
 }
 
 // NewExportersBuilder creates a new ExportersBuilder. Call BuildExporters() on the returned value.
 func NewExportersBuilder(
 	logger *zap.Logger,
 	config *configmodels.Config,
-	factories map[string]component.ExporterFactoryBase,
+	factories map[configmodels.Type]component.ExporterFactoryBase,
 ) *ExportersBuilder {
 	return &ExportersBuilder{logger.With(zap.String(kindLogKey, kindLogExporter)), config, factories}
 }
@@ -141,7 +141,7 @@ func (eb *ExportersBuilder) Build() (Exporters, error) {
 
 	// BuildExporters exporters based on configuration and required input data types.
 	for _, cfg := range eb.config.Exporters {
-		componentLogger := eb.logger.With(zap.String(typeLogKey, cfg.Type()), zap.String(nameLogKey, cfg.Name()))
+		componentLogger := eb.logger.With(zap.String(typeLogKey, string(cfg.Type())), zap.String(nameLogKey, cfg.Name()))
 		exp, err := eb.buildExporter(componentLogger, cfg, exporterInputDataTypes)
 		if err != nil {
 			return nil, err

--- a/service/builder/exporters_builder_test.go
+++ b/service/builder/exporters_builder_test.go
@@ -142,7 +142,7 @@ func TestExportersBuilder_StopAll(t *testing.T) {
 
 func TestExportersBuilder_ErrorOnNilExporter(t *testing.T) {
 	bf := &badExporterFactory{}
-	fm := map[string]component.ExporterFactoryBase{
+	fm := map[configmodels.Type]component.ExporterFactoryBase{
 		bf.Type(): bf,
 	}
 
@@ -150,12 +150,12 @@ func TestExportersBuilder_ErrorOnNilExporter(t *testing.T) {
 		{
 			Name:      "trace",
 			InputType: configmodels.TracesDataType,
-			Exporters: []string{bf.Type()},
+			Exporters: []string{string(bf.Type())},
 		},
 		{
 			Name:      "metrics",
 			InputType: configmodels.MetricsDataType,
-			Exporters: []string{bf.Type()},
+			Exporters: []string{string(bf.Type())},
 		},
 	}
 
@@ -164,7 +164,7 @@ func TestExportersBuilder_ErrorOnNilExporter(t *testing.T) {
 
 			cfg := &configmodels.Config{
 				Exporters: map[string]configmodels.Exporter{
-					bf.Type(): &configmodels.ExporterSettings{
+					string(bf.Type()): &configmodels.ExporterSettings{
 						TypeVal: bf.Type(),
 					},
 				},
@@ -186,7 +186,7 @@ func TestExportersBuilder_ErrorOnNilExporter(t *testing.T) {
 // badExporterFactory is a factory that returns no error but returns a nil object.
 type badExporterFactory struct{}
 
-func (b *badExporterFactory) Type() string {
+func (b *badExporterFactory) Type() configmodels.Type {
 	return "bf"
 }
 

--- a/service/builder/extensions_builder.go
+++ b/service/builder/extensions_builder.go
@@ -121,14 +121,14 @@ func (exts Extensions) GetServiceExtensions() map[configmodels.Extension]compone
 type ExtensionsBuilder struct {
 	logger    *zap.Logger
 	config    *configmodels.Config
-	factories map[string]component.ExtensionFactory
+	factories map[configmodels.Type]component.ExtensionFactory
 }
 
 // NewExportersBuilder creates a new ExportersBuilder. Call BuildExporters() on the returned value.
 func NewExtensionsBuilder(
 	logger *zap.Logger,
 	config *configmodels.Config,
-	factories map[string]component.ExtensionFactory,
+	factories map[configmodels.Type]component.ExtensionFactory,
 ) *ExtensionsBuilder {
 	return &ExtensionsBuilder{logger.With(zap.String(kindLogKey, kindLogExtension)), config, factories}
 }
@@ -143,7 +143,7 @@ func (eb *ExtensionsBuilder) Build() (Extensions, error) {
 			return nil, errors.Errorf("extension %q is not configured", extName)
 		}
 
-		componentLogger := eb.logger.With(zap.String(typeLogKey, extCfg.Type()), zap.String(nameLogKey, extCfg.Name()))
+		componentLogger := eb.logger.With(zap.String(typeLogKey, string(extCfg.Type())), zap.String(nameLogKey, extCfg.Name()))
 		ext, err := eb.buildExtension(componentLogger, extCfg)
 		if err != nil {
 			return nil, err

--- a/service/builder/pipelines_builder.go
+++ b/service/builder/pipelines_builder.go
@@ -86,7 +86,7 @@ type PipelinesBuilder struct {
 	logger    *zap.Logger
 	config    *configmodels.Config
 	exporters Exporters
-	factories map[string]component.ProcessorFactoryBase
+	factories map[configmodels.Type]component.ProcessorFactoryBase
 }
 
 // NewPipelinesBuilder creates a new PipelinesBuilder. Requires exporters to be already
@@ -95,7 +95,7 @@ func NewPipelinesBuilder(
 	logger *zap.Logger,
 	config *configmodels.Config,
 	exporters Exporters,
-	factories map[string]component.ProcessorFactoryBase,
+	factories map[configmodels.Type]component.ProcessorFactoryBase,
 ) *PipelinesBuilder {
 	return &PipelinesBuilder{logger, config, exporters, factories}
 }
@@ -152,7 +152,7 @@ func (pb *PipelinesBuilder) buildPipeline(pipelineCfg *configmodels.Pipeline,
 		// it becomes the next for the previous one (previous in the pipeline,
 		// which we will build in the next loop iteration).
 		var err error
-		componentLogger := pb.logger.With(zap.String(kindLogKey, kindLogProcessor), zap.String(typeLogKey, procCfg.Type()), zap.String(nameLogKey, procCfg.Name()))
+		componentLogger := pb.logger.With(zap.String(kindLogKey, kindLogProcessor), zap.String(typeLogKey, string(procCfg.Type())), zap.String(nameLogKey, procCfg.Name()))
 		switch pipelineCfg.InputType {
 		case configmodels.TracesDataType:
 			var proc component.TraceProcessorBase

--- a/service/builder/pipelines_builder_test.go
+++ b/service/builder/pipelines_builder_test.go
@@ -263,7 +263,7 @@ func TestProcessorsBuilder_ErrorOnNilProcessor(t *testing.T) {
 // badProcessorFactory is a factory that returns no error but returns a nil object.
 type badProcessorFactory struct{}
 
-func (b *badProcessorFactory) Type() string {
+func (b *badProcessorFactory) Type() configmodels.Type {
 	return "bf"
 }
 

--- a/service/builder/receivers_builder.go
+++ b/service/builder/receivers_builder.go
@@ -86,7 +86,7 @@ type ReceiversBuilder struct {
 	logger         *zap.Logger
 	config         *configmodels.Config
 	builtPipelines BuiltPipelines
-	factories      map[string]component.ReceiverFactoryBase
+	factories      map[configmodels.Type]component.ReceiverFactoryBase
 }
 
 // NewReceiversBuilder creates a new ReceiversBuilder. Call BuildProcessors() on the returned value.
@@ -94,7 +94,7 @@ func NewReceiversBuilder(
 	logger *zap.Logger,
 	config *configmodels.Config,
 	builtPipelines BuiltPipelines,
-	factories map[string]component.ReceiverFactoryBase,
+	factories map[configmodels.Type]component.ReceiverFactoryBase,
 ) *ReceiversBuilder {
 	return &ReceiversBuilder{logger.With(zap.String(kindLogKey, kindLogReceiver)), config, builtPipelines, factories}
 }
@@ -105,7 +105,7 @@ func (rb *ReceiversBuilder) Build() (Receivers, error) {
 
 	// BuildProcessors receivers based on configuration.
 	for _, cfg := range rb.config.Receivers {
-		logger := rb.logger.With(zap.String(typeLogKey, cfg.Type()), zap.String(nameLogKey, cfg.Name()))
+		logger := rb.logger.With(zap.String(typeLogKey, string(cfg.Type())), zap.String(nameLogKey, cfg.Name()))
 		rcv, err := rb.buildReceiver(logger, cfg)
 		if err != nil {
 			if err == errUnusedReceiver {

--- a/service/builder/receivers_builder_test.go
+++ b/service/builder/receivers_builder_test.go
@@ -336,7 +336,7 @@ func TestReceiversBuilder_InternalToOcTraceConverter(t *testing.T) {
 // badReceiverFactory is a factory that returns no error but returns a nil object.
 type badReceiverFactory struct{}
 
-func (b *badReceiverFactory) Type() string {
+func (b *badReceiverFactory) Type() configmodels.Type {
 	return "bf"
 }
 
@@ -368,7 +368,7 @@ func (b *badReceiverFactory) CreateMetricsReceiver(
 // newStyleReceiverFactory defines FactoryV2 interface
 type newStyleReceiverFactory struct{}
 
-func (b *newStyleReceiverFactory) Type() string {
+func (b *newStyleReceiverFactory) Type() configmodels.Type {
 	return "newstylereceiver"
 }
 

--- a/service/defaultcomponents/defaults_test.go
+++ b/service/defaultcomponents/defaults_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/open-telemetry/opentelemetry-collector/component"
+	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
 	"github.com/open-telemetry/opentelemetry-collector/exporter/fileexporter"
 	"github.com/open-telemetry/opentelemetry-collector/exporter/jaegerexporter"
 	"github.com/open-telemetry/opentelemetry-collector/exporter/loggingexporter"
@@ -50,12 +51,12 @@ import (
 )
 
 func TestDefaultComponents(t *testing.T) {
-	expectedExtensions := map[string]component.ExtensionFactory{
+	expectedExtensions := map[configmodels.Type]component.ExtensionFactory{
 		"health_check": &healthcheckextension.Factory{},
 		"pprof":        &pprofextension.Factory{},
 		"zpages":       &zpagesextension.Factory{},
 	}
-	expectedReceivers := map[string]component.ReceiverFactoryBase{
+	expectedReceivers := map[configmodels.Type]component.ReceiverFactoryBase{
 		"jaeger":      &jaegerreceiver.Factory{},
 		"zipkin":      &zipkinreceiver.Factory{},
 		"prometheus":  &prometheusreceiver.Factory{},
@@ -64,7 +65,7 @@ func TestDefaultComponents(t *testing.T) {
 		"vmmetrics":   &vmmetricsreceiver.Factory{},
 		"hostmetrics": hostmetricsreceiver.NewFactory(),
 	}
-	expectedProcessors := map[string]component.ProcessorFactoryBase{
+	expectedProcessors := map[configmodels.Type]component.ProcessorFactoryBase{
 		"attributes":            &attributesprocessor.Factory{},
 		"queued_retry":          &queuedprocessor.Factory{},
 		"batch":                 &batchprocessor.Factory{},
@@ -73,7 +74,7 @@ func TestDefaultComponents(t *testing.T) {
 		"probabilistic_sampler": &probabilisticsamplerprocessor.Factory{},
 		"span":                  &spanprocessor.Factory{},
 	}
-	expectedExporters := map[string]component.ExporterFactoryBase{
+	expectedExporters := map[configmodels.Type]component.ExporterFactoryBase{
 		"opencensus": &opencensusexporter.Factory{},
 		"prometheus": &prometheusexporter.Factory{},
 		"logging":    &loggingexporter.Factory{},

--- a/service/service.go
+++ b/service/service.go
@@ -168,7 +168,7 @@ func (app *Application) ReportFatalError(err error) {
 	app.asyncErrorChannel <- err
 }
 
-func (app *Application) GetFactory(kind component.Kind, componentType string) component.Factory {
+func (app *Application) GetFactory(kind component.Kind, componentType configmodels.Type) component.Factory {
 	switch kind {
 	case component.KindReceiver:
 		return app.factories.Receivers[componentType]

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -117,7 +117,7 @@ func TestApplication_setupExtensions(t *testing.T) {
 	exampleExtensionConfig := &config.ExampleExtensionCfg{
 		ExtensionSettings: configmodels.ExtensionSettings{
 			TypeVal: exampleExtensionFactory.Type(),
-			NameVal: exampleExtensionFactory.Type(),
+			NameVal: string(exampleExtensionFactory.Type()),
 		},
 	}
 
@@ -148,11 +148,11 @@ func TestApplication_setupExtensions(t *testing.T) {
 			name: "missing_extension_factory",
 			config: &configmodels.Config{
 				Extensions: map[string]configmodels.Extension{
-					exampleExtensionFactory.Type(): exampleExtensionConfig,
+					string(exampleExtensionFactory.Type()): exampleExtensionConfig,
 				},
 				Service: configmodels.Service{
 					Extensions: []string{
-						exampleExtensionFactory.Type(),
+						string(exampleExtensionFactory.Type()),
 					},
 				},
 			},
@@ -161,17 +161,17 @@ func TestApplication_setupExtensions(t *testing.T) {
 		{
 			name: "error_on_create_extension",
 			factories: config.Factories{
-				Extensions: map[string]component.ExtensionFactory{
+				Extensions: map[configmodels.Type]component.ExtensionFactory{
 					exampleExtensionFactory.Type(): exampleExtensionFactory,
 				},
 			},
 			config: &configmodels.Config{
 				Extensions: map[string]configmodels.Extension{
-					exampleExtensionFactory.Type(): exampleExtensionConfig,
+					string(exampleExtensionFactory.Type()): exampleExtensionConfig,
 				},
 				Service: configmodels.Service{
 					Extensions: []string{
-						exampleExtensionFactory.Type(),
+						string(exampleExtensionFactory.Type()),
 					},
 				},
 			},
@@ -180,17 +180,17 @@ func TestApplication_setupExtensions(t *testing.T) {
 		{
 			name: "bad_factory",
 			factories: config.Factories{
-				Extensions: map[string]component.ExtensionFactory{
+				Extensions: map[configmodels.Type]component.ExtensionFactory{
 					badExtensionFactory.Type(): badExtensionFactory,
 				},
 			},
 			config: &configmodels.Config{
 				Extensions: map[string]configmodels.Extension{
-					badExtensionFactory.Type(): badExtensionFactoryConfig,
+					string(badExtensionFactory.Type()): badExtensionFactoryConfig,
 				},
 				Service: configmodels.Service{
 					Extensions: []string{
-						badExtensionFactory.Type(),
+						string(badExtensionFactory.Type()),
 					},
 				},
 			},
@@ -227,7 +227,7 @@ func TestApplication_setupExtensions(t *testing.T) {
 // badExtensionFactory is a factory that returns no error but returns a nil object.
 type badExtensionFactory struct{}
 
-func (b badExtensionFactory) Type() string {
+func (b badExtensionFactory) Type() configmodels.Type {
 	return "bf"
 }
 
@@ -247,16 +247,16 @@ func TestApplication_GetFactory(t *testing.T) {
 	exampleExtensionFactory := &config.ExampleExtensionFactory{}
 
 	factories := config.Factories{
-		Receivers: map[string]component.ReceiverFactoryBase{
+		Receivers: map[configmodels.Type]component.ReceiverFactoryBase{
 			exampleReceiverFactory.Type(): exampleReceiverFactory,
 		},
-		Processors: map[string]component.ProcessorFactoryBase{
+		Processors: map[configmodels.Type]component.ProcessorFactoryBase{
 			exampleProcessorFactory.Type(): exampleProcessorFactory,
 		},
-		Exporters: map[string]component.ExporterFactoryBase{
+		Exporters: map[configmodels.Type]component.ExporterFactoryBase{
 			exampleExporterFactory.Type(): exampleExporterFactory,
 		},
-		Extensions: map[string]component.ExtensionFactory{
+		Extensions: map[configmodels.Type]component.ExtensionFactory{
 			exampleExtensionFactory.Type(): exampleExtensionFactory,
 		},
 	}
@@ -295,16 +295,16 @@ func createExampleApplication(t *testing.T) *Application {
 	exampleExporterFactory := &config.ExampleExporterFactory{}
 	exampleExtensionFactory := &config.ExampleExtensionFactory{}
 	factories := config.Factories{
-		Receivers: map[string]component.ReceiverFactoryBase{
+		Receivers: map[configmodels.Type]component.ReceiverFactoryBase{
 			exampleReceiverFactory.Type(): exampleReceiverFactory,
 		},
-		Processors: map[string]component.ProcessorFactoryBase{
+		Processors: map[configmodels.Type]component.ProcessorFactoryBase{
 			exampleProcessorFactory.Type(): exampleProcessorFactory,
 		},
-		Exporters: map[string]component.ExporterFactoryBase{
+		Exporters: map[configmodels.Type]component.ExporterFactoryBase{
 			exampleExporterFactory.Type(): exampleExporterFactory,
 		},
-		Extensions: map[string]component.ExtensionFactory{
+		Extensions: map[configmodels.Type]component.ExtensionFactory{
 			exampleExtensionFactory.Type(): exampleExtensionFactory,
 		},
 	}
@@ -314,23 +314,23 @@ func createExampleApplication(t *testing.T) *Application {
 		ConfigFactory: func(v *viper.Viper, factories config.Factories) (c *configmodels.Config, err error) {
 			config := &configmodels.Config{
 				Receivers: map[string]configmodels.Receiver{
-					exampleReceiverFactory.Type(): exampleReceiverFactory.CreateDefaultConfig(),
+					string(exampleReceiverFactory.Type()): exampleReceiverFactory.CreateDefaultConfig(),
 				},
 				Exporters: map[string]configmodels.Exporter{
-					exampleExporterFactory.Type(): exampleExporterFactory.CreateDefaultConfig(),
+					string(exampleExporterFactory.Type()): exampleExporterFactory.CreateDefaultConfig(),
 				},
 				Extensions: map[string]configmodels.Extension{
-					exampleExtensionFactory.Type(): exampleExtensionFactory.CreateDefaultConfig(),
+					string(exampleExtensionFactory.Type()): exampleExtensionFactory.CreateDefaultConfig(),
 				},
 				Service: configmodels.Service{
-					Extensions: []string{exampleExtensionFactory.Type()},
+					Extensions: []string{string(exampleExtensionFactory.Type())},
 					Pipelines: map[string]*configmodels.Pipeline{
 						"trace": {
 							Name:       "traces",
 							InputType:  configmodels.TracesDataType,
-							Receivers:  []string{exampleReceiverFactory.Type()},
+							Receivers:  []string{string(exampleReceiverFactory.Type())},
 							Processors: []string{},
-							Exporters:  []string{exampleExporterFactory.Type()},
+							Exporters:  []string{string(exampleExporterFactory.Type())},
 						},
 					},
 				},
@@ -359,7 +359,7 @@ func TestApplication_GetExtensions(t *testing.T) {
 	var extTypes []string
 	for cfg, ext := range extMap {
 		assert.NotNil(t, ext)
-		extTypes = append(extTypes, cfg.Type())
+		extTypes = append(extTypes, string(cfg.Type()))
 	}
 	sort.Strings(extTypes)
 

--- a/testbed/testbed/receivers.go
+++ b/testbed/testbed/receivers.go
@@ -57,7 +57,7 @@ func (mb *DataReceiverBase) ReportFatalError(err error) {
 }
 
 // GetFactory of the specified kind. Returns the factory for a component type.
-func (mb *DataReceiverBase) GetFactory(kind component.Kind, componentType string) component.Factory {
+func (mb *DataReceiverBase) GetFactory(kind component.Kind, componentType configmodels.Type) component.Factory {
 	return nil
 }
 


### PR DESCRIPTION
We previously used string in the codebase to represent component type
(as it is known to factories and referred to in the config).

Now we have configmodels.Type alias that provides stronger compile-time
type checks.

This is a breaking change for components but fixing the components is easy.

Resolves: https://github.com/open-telemetry/opentelemetry-collector/issues/762
