### PR TITLE
Rename MoveTo to MoveAndAppendTo.

### DIFF
--- a/consumer/pdata/generated_metrics.go
+++ b/consumer/pdata/generated_metrics.go
@@ -63,8 +63,9 @@ func (es ResourceMetricsSlice) At(ix int) ResourceMetrics {
 	return newResourceMetrics(&(*es.orig)[ix])
 }
 
-// MoveTo moves all elements from the current slice to the dest. The current slice will be cleared.
-func (es ResourceMetricsSlice) MoveTo(dest ResourceMetricsSlice) {
+// MoveAndAppendTo moves all elements from the current slice and appends them to the dest.
+// The current slice will be cleared.
+func (es ResourceMetricsSlice) MoveAndAppendTo(dest ResourceMetricsSlice) {
 	if es.Len() == 0 {
 		// Just to ensure that we always return a Slice with nil elements.
 		*es.orig = nil
@@ -101,7 +102,7 @@ func (es ResourceMetricsSlice) CopyTo(dest ResourceMetricsSlice) {
 		wrappers[i] = &origs[i]
 		newResourceMetrics(&el).CopyTo(newResourceMetrics(&wrappers[i]))
 	}
-    *dest.orig = wrappers
+	*dest.orig = wrappers
 }
 
 // Resize is an operation that resizes the slice:
@@ -245,8 +246,9 @@ func (es InstrumentationLibraryMetricsSlice) At(ix int) InstrumentationLibraryMe
 	return newInstrumentationLibraryMetrics(&(*es.orig)[ix])
 }
 
-// MoveTo moves all elements from the current slice to the dest. The current slice will be cleared.
-func (es InstrumentationLibraryMetricsSlice) MoveTo(dest InstrumentationLibraryMetricsSlice) {
+// MoveAndAppendTo moves all elements from the current slice and appends them to the dest.
+// The current slice will be cleared.
+func (es InstrumentationLibraryMetricsSlice) MoveAndAppendTo(dest InstrumentationLibraryMetricsSlice) {
 	if es.Len() == 0 {
 		// Just to ensure that we always return a Slice with nil elements.
 		*es.orig = nil
@@ -283,7 +285,7 @@ func (es InstrumentationLibraryMetricsSlice) CopyTo(dest InstrumentationLibraryM
 		wrappers[i] = &origs[i]
 		newInstrumentationLibraryMetrics(&el).CopyTo(newInstrumentationLibraryMetrics(&wrappers[i]))
 	}
-    *dest.orig = wrappers
+	*dest.orig = wrappers
 }
 
 // Resize is an operation that resizes the slice:
@@ -427,8 +429,9 @@ func (es MetricSlice) At(ix int) Metric {
 	return newMetric(&(*es.orig)[ix])
 }
 
-// MoveTo moves all elements from the current slice to the dest. The current slice will be cleared.
-func (es MetricSlice) MoveTo(dest MetricSlice) {
+// MoveAndAppendTo moves all elements from the current slice and appends them to the dest.
+// The current slice will be cleared.
+func (es MetricSlice) MoveAndAppendTo(dest MetricSlice) {
 	if es.Len() == 0 {
 		// Just to ensure that we always return a Slice with nil elements.
 		*es.orig = nil
@@ -465,7 +468,7 @@ func (es MetricSlice) CopyTo(dest MetricSlice) {
 		wrappers[i] = &origs[i]
 		newMetric(&el).CopyTo(newMetric(&wrappers[i]))
 	}
-    *dest.orig = wrappers
+	*dest.orig = wrappers
 }
 
 // Resize is an operation that resizes the slice:
@@ -751,8 +754,9 @@ func (es Int64DataPointSlice) At(ix int) Int64DataPoint {
 	return newInt64DataPoint(&(*es.orig)[ix])
 }
 
-// MoveTo moves all elements from the current slice to the dest. The current slice will be cleared.
-func (es Int64DataPointSlice) MoveTo(dest Int64DataPointSlice) {
+// MoveAndAppendTo moves all elements from the current slice and appends them to the dest.
+// The current slice will be cleared.
+func (es Int64DataPointSlice) MoveAndAppendTo(dest Int64DataPointSlice) {
 	if es.Len() == 0 {
 		// Just to ensure that we always return a Slice with nil elements.
 		*es.orig = nil
@@ -789,7 +793,7 @@ func (es Int64DataPointSlice) CopyTo(dest Int64DataPointSlice) {
 		wrappers[i] = &origs[i]
 		newInt64DataPoint(&el).CopyTo(newInt64DataPoint(&wrappers[i]))
 	}
-    *dest.orig = wrappers
+	*dest.orig = wrappers
 }
 
 // Resize is an operation that resizes the slice:
@@ -967,8 +971,9 @@ func (es DoubleDataPointSlice) At(ix int) DoubleDataPoint {
 	return newDoubleDataPoint(&(*es.orig)[ix])
 }
 
-// MoveTo moves all elements from the current slice to the dest. The current slice will be cleared.
-func (es DoubleDataPointSlice) MoveTo(dest DoubleDataPointSlice) {
+// MoveAndAppendTo moves all elements from the current slice and appends them to the dest.
+// The current slice will be cleared.
+func (es DoubleDataPointSlice) MoveAndAppendTo(dest DoubleDataPointSlice) {
 	if es.Len() == 0 {
 		// Just to ensure that we always return a Slice with nil elements.
 		*es.orig = nil
@@ -1005,7 +1010,7 @@ func (es DoubleDataPointSlice) CopyTo(dest DoubleDataPointSlice) {
 		wrappers[i] = &origs[i]
 		newDoubleDataPoint(&el).CopyTo(newDoubleDataPoint(&wrappers[i]))
 	}
-    *dest.orig = wrappers
+	*dest.orig = wrappers
 }
 
 // Resize is an operation that resizes the slice:
@@ -1183,8 +1188,9 @@ func (es HistogramDataPointSlice) At(ix int) HistogramDataPoint {
 	return newHistogramDataPoint(&(*es.orig)[ix])
 }
 
-// MoveTo moves all elements from the current slice to the dest. The current slice will be cleared.
-func (es HistogramDataPointSlice) MoveTo(dest HistogramDataPointSlice) {
+// MoveAndAppendTo moves all elements from the current slice and appends them to the dest.
+// The current slice will be cleared.
+func (es HistogramDataPointSlice) MoveAndAppendTo(dest HistogramDataPointSlice) {
 	if es.Len() == 0 {
 		// Just to ensure that we always return a Slice with nil elements.
 		*es.orig = nil
@@ -1221,7 +1227,7 @@ func (es HistogramDataPointSlice) CopyTo(dest HistogramDataPointSlice) {
 		wrappers[i] = &origs[i]
 		newHistogramDataPoint(&el).CopyTo(newHistogramDataPoint(&wrappers[i]))
 	}
-    *dest.orig = wrappers
+	*dest.orig = wrappers
 }
 
 // Resize is an operation that resizes the slice:
@@ -1437,8 +1443,9 @@ func (es HistogramBucketSlice) At(ix int) HistogramBucket {
 	return newHistogramBucket(&(*es.orig)[ix])
 }
 
-// MoveTo moves all elements from the current slice to the dest. The current slice will be cleared.
-func (es HistogramBucketSlice) MoveTo(dest HistogramBucketSlice) {
+// MoveAndAppendTo moves all elements from the current slice and appends them to the dest.
+// The current slice will be cleared.
+func (es HistogramBucketSlice) MoveAndAppendTo(dest HistogramBucketSlice) {
 	if es.Len() == 0 {
 		// Just to ensure that we always return a Slice with nil elements.
 		*es.orig = nil
@@ -1475,7 +1482,7 @@ func (es HistogramBucketSlice) CopyTo(dest HistogramBucketSlice) {
 		wrappers[i] = &origs[i]
 		newHistogramBucket(&el).CopyTo(newHistogramBucket(&wrappers[i]))
 	}
-    *dest.orig = wrappers
+	*dest.orig = wrappers
 }
 
 // Resize is an operation that resizes the slice:
@@ -1714,8 +1721,9 @@ func (es SummaryDataPointSlice) At(ix int) SummaryDataPoint {
 	return newSummaryDataPoint(&(*es.orig)[ix])
 }
 
-// MoveTo moves all elements from the current slice to the dest. The current slice will be cleared.
-func (es SummaryDataPointSlice) MoveTo(dest SummaryDataPointSlice) {
+// MoveAndAppendTo moves all elements from the current slice and appends them to the dest.
+// The current slice will be cleared.
+func (es SummaryDataPointSlice) MoveAndAppendTo(dest SummaryDataPointSlice) {
 	if es.Len() == 0 {
 		// Just to ensure that we always return a Slice with nil elements.
 		*es.orig = nil
@@ -1752,7 +1760,7 @@ func (es SummaryDataPointSlice) CopyTo(dest SummaryDataPointSlice) {
 		wrappers[i] = &origs[i]
 		newSummaryDataPoint(&el).CopyTo(newSummaryDataPoint(&wrappers[i]))
 	}
-    *dest.orig = wrappers
+	*dest.orig = wrappers
 }
 
 // Resize is an operation that resizes the slice:
@@ -1953,8 +1961,9 @@ func (es SummaryValueAtPercentileSlice) At(ix int) SummaryValueAtPercentile {
 	return newSummaryValueAtPercentile(&(*es.orig)[ix])
 }
 
-// MoveTo moves all elements from the current slice to the dest. The current slice will be cleared.
-func (es SummaryValueAtPercentileSlice) MoveTo(dest SummaryValueAtPercentileSlice) {
+// MoveAndAppendTo moves all elements from the current slice and appends them to the dest.
+// The current slice will be cleared.
+func (es SummaryValueAtPercentileSlice) MoveAndAppendTo(dest SummaryValueAtPercentileSlice) {
 	if es.Len() == 0 {
 		// Just to ensure that we always return a Slice with nil elements.
 		*es.orig = nil
@@ -1991,7 +2000,7 @@ func (es SummaryValueAtPercentileSlice) CopyTo(dest SummaryValueAtPercentileSlic
 		wrappers[i] = &origs[i]
 		newSummaryValueAtPercentile(&el).CopyTo(newSummaryValueAtPercentile(&wrappers[i]))
 	}
-    *dest.orig = wrappers
+	*dest.orig = wrappers
 }
 
 // Resize is an operation that resizes the slice:

--- a/consumer/pdata/generated_metrics_test.go
+++ b/consumer/pdata/generated_metrics_test.go
@@ -42,24 +42,24 @@ func TestResourceMetricsSlice(t *testing.T) {
 	}
 }
 
-func TestResourceMetricsSlice_MoveTo(t *testing.T) {
-	// Test MoveTo to empty
+func TestResourceMetricsSlice_MoveAndAppendTo(t *testing.T) {
+	// Test MoveAndAppendTo to empty
 	expectedSlice := generateTestResourceMetricsSlice()
 	dest := NewResourceMetricsSlice()
 	src := generateTestResourceMetricsSlice()
-	src.MoveTo(dest)
+	src.MoveAndAppendTo(dest)
 	assert.EqualValues(t, generateTestResourceMetricsSlice(), dest)
 	assert.EqualValues(t, 0, src.Len())
 	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
 
-	// Test MoveTo empty slice
-	src.MoveTo(dest)
+	// Test MoveAndAppendTo empty slice
+	src.MoveAndAppendTo(dest)
 	assert.EqualValues(t, generateTestResourceMetricsSlice(), dest)
 	assert.EqualValues(t, 0, src.Len())
 	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
 
-	// Test MoveTo not empty slice
-	generateTestResourceMetricsSlice().MoveTo(dest)
+	// Test MoveAndAppendTo not empty slice
+	generateTestResourceMetricsSlice().MoveAndAppendTo(dest)
 	assert.EqualValues(t, 2*expectedSlice.Len(), dest.Len())
 	for i := 0; i < expectedSlice.Len(); i++ {
 		assert.EqualValues(t, expectedSlice.At(i), dest.At(i))
@@ -177,24 +177,24 @@ func TestInstrumentationLibraryMetricsSlice(t *testing.T) {
 	}
 }
 
-func TestInstrumentationLibraryMetricsSlice_MoveTo(t *testing.T) {
-	// Test MoveTo to empty
+func TestInstrumentationLibraryMetricsSlice_MoveAndAppendTo(t *testing.T) {
+	// Test MoveAndAppendTo to empty
 	expectedSlice := generateTestInstrumentationLibraryMetricsSlice()
 	dest := NewInstrumentationLibraryMetricsSlice()
 	src := generateTestInstrumentationLibraryMetricsSlice()
-	src.MoveTo(dest)
+	src.MoveAndAppendTo(dest)
 	assert.EqualValues(t, generateTestInstrumentationLibraryMetricsSlice(), dest)
 	assert.EqualValues(t, 0, src.Len())
 	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
 
-	// Test MoveTo empty slice
-	src.MoveTo(dest)
+	// Test MoveAndAppendTo empty slice
+	src.MoveAndAppendTo(dest)
 	assert.EqualValues(t, generateTestInstrumentationLibraryMetricsSlice(), dest)
 	assert.EqualValues(t, 0, src.Len())
 	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
 
-	// Test MoveTo not empty slice
-	generateTestInstrumentationLibraryMetricsSlice().MoveTo(dest)
+	// Test MoveAndAppendTo not empty slice
+	generateTestInstrumentationLibraryMetricsSlice().MoveAndAppendTo(dest)
 	assert.EqualValues(t, 2*expectedSlice.Len(), dest.Len())
 	for i := 0; i < expectedSlice.Len(); i++ {
 		assert.EqualValues(t, expectedSlice.At(i), dest.At(i))
@@ -312,24 +312,24 @@ func TestMetricSlice(t *testing.T) {
 	}
 }
 
-func TestMetricSlice_MoveTo(t *testing.T) {
-	// Test MoveTo to empty
+func TestMetricSlice_MoveAndAppendTo(t *testing.T) {
+	// Test MoveAndAppendTo to empty
 	expectedSlice := generateTestMetricSlice()
 	dest := NewMetricSlice()
 	src := generateTestMetricSlice()
-	src.MoveTo(dest)
+	src.MoveAndAppendTo(dest)
 	assert.EqualValues(t, generateTestMetricSlice(), dest)
 	assert.EqualValues(t, 0, src.Len())
 	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
 
-	// Test MoveTo empty slice
-	src.MoveTo(dest)
+	// Test MoveAndAppendTo empty slice
+	src.MoveAndAppendTo(dest)
 	assert.EqualValues(t, generateTestMetricSlice(), dest)
 	assert.EqualValues(t, 0, src.Len())
 	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
 
-	// Test MoveTo not empty slice
-	generateTestMetricSlice().MoveTo(dest)
+	// Test MoveAndAppendTo not empty slice
+	generateTestMetricSlice().MoveAndAppendTo(dest)
 	assert.EqualValues(t, 2*expectedSlice.Len(), dest.Len())
 	for i := 0; i < expectedSlice.Len(); i++ {
 		assert.EqualValues(t, expectedSlice.At(i), dest.At(i))
@@ -534,24 +534,24 @@ func TestInt64DataPointSlice(t *testing.T) {
 	}
 }
 
-func TestInt64DataPointSlice_MoveTo(t *testing.T) {
-	// Test MoveTo to empty
+func TestInt64DataPointSlice_MoveAndAppendTo(t *testing.T) {
+	// Test MoveAndAppendTo to empty
 	expectedSlice := generateTestInt64DataPointSlice()
 	dest := NewInt64DataPointSlice()
 	src := generateTestInt64DataPointSlice()
-	src.MoveTo(dest)
+	src.MoveAndAppendTo(dest)
 	assert.EqualValues(t, generateTestInt64DataPointSlice(), dest)
 	assert.EqualValues(t, 0, src.Len())
 	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
 
-	// Test MoveTo empty slice
-	src.MoveTo(dest)
+	// Test MoveAndAppendTo empty slice
+	src.MoveAndAppendTo(dest)
 	assert.EqualValues(t, generateTestInt64DataPointSlice(), dest)
 	assert.EqualValues(t, 0, src.Len())
 	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
 
-	// Test MoveTo not empty slice
-	generateTestInt64DataPointSlice().MoveTo(dest)
+	// Test MoveAndAppendTo not empty slice
+	generateTestInt64DataPointSlice().MoveAndAppendTo(dest)
 	assert.EqualValues(t, 2*expectedSlice.Len(), dest.Len())
 	for i := 0; i < expectedSlice.Len(); i++ {
 		assert.EqualValues(t, expectedSlice.At(i), dest.At(i))
@@ -686,24 +686,24 @@ func TestDoubleDataPointSlice(t *testing.T) {
 	}
 }
 
-func TestDoubleDataPointSlice_MoveTo(t *testing.T) {
-	// Test MoveTo to empty
+func TestDoubleDataPointSlice_MoveAndAppendTo(t *testing.T) {
+	// Test MoveAndAppendTo to empty
 	expectedSlice := generateTestDoubleDataPointSlice()
 	dest := NewDoubleDataPointSlice()
 	src := generateTestDoubleDataPointSlice()
-	src.MoveTo(dest)
+	src.MoveAndAppendTo(dest)
 	assert.EqualValues(t, generateTestDoubleDataPointSlice(), dest)
 	assert.EqualValues(t, 0, src.Len())
 	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
 
-	// Test MoveTo empty slice
-	src.MoveTo(dest)
+	// Test MoveAndAppendTo empty slice
+	src.MoveAndAppendTo(dest)
 	assert.EqualValues(t, generateTestDoubleDataPointSlice(), dest)
 	assert.EqualValues(t, 0, src.Len())
 	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
 
-	// Test MoveTo not empty slice
-	generateTestDoubleDataPointSlice().MoveTo(dest)
+	// Test MoveAndAppendTo not empty slice
+	generateTestDoubleDataPointSlice().MoveAndAppendTo(dest)
 	assert.EqualValues(t, 2*expectedSlice.Len(), dest.Len())
 	for i := 0; i < expectedSlice.Len(); i++ {
 		assert.EqualValues(t, expectedSlice.At(i), dest.At(i))
@@ -838,24 +838,24 @@ func TestHistogramDataPointSlice(t *testing.T) {
 	}
 }
 
-func TestHistogramDataPointSlice_MoveTo(t *testing.T) {
-	// Test MoveTo to empty
+func TestHistogramDataPointSlice_MoveAndAppendTo(t *testing.T) {
+	// Test MoveAndAppendTo to empty
 	expectedSlice := generateTestHistogramDataPointSlice()
 	dest := NewHistogramDataPointSlice()
 	src := generateTestHistogramDataPointSlice()
-	src.MoveTo(dest)
+	src.MoveAndAppendTo(dest)
 	assert.EqualValues(t, generateTestHistogramDataPointSlice(), dest)
 	assert.EqualValues(t, 0, src.Len())
 	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
 
-	// Test MoveTo empty slice
-	src.MoveTo(dest)
+	// Test MoveAndAppendTo empty slice
+	src.MoveAndAppendTo(dest)
 	assert.EqualValues(t, generateTestHistogramDataPointSlice(), dest)
 	assert.EqualValues(t, 0, src.Len())
 	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
 
-	// Test MoveTo not empty slice
-	generateTestHistogramDataPointSlice().MoveTo(dest)
+	// Test MoveAndAppendTo not empty slice
+	generateTestHistogramDataPointSlice().MoveAndAppendTo(dest)
 	assert.EqualValues(t, 2*expectedSlice.Len(), dest.Len())
 	for i := 0; i < expectedSlice.Len(); i++ {
 		assert.EqualValues(t, expectedSlice.At(i), dest.At(i))
@@ -1017,24 +1017,24 @@ func TestHistogramBucketSlice(t *testing.T) {
 	}
 }
 
-func TestHistogramBucketSlice_MoveTo(t *testing.T) {
-	// Test MoveTo to empty
+func TestHistogramBucketSlice_MoveAndAppendTo(t *testing.T) {
+	// Test MoveAndAppendTo to empty
 	expectedSlice := generateTestHistogramBucketSlice()
 	dest := NewHistogramBucketSlice()
 	src := generateTestHistogramBucketSlice()
-	src.MoveTo(dest)
+	src.MoveAndAppendTo(dest)
 	assert.EqualValues(t, generateTestHistogramBucketSlice(), dest)
 	assert.EqualValues(t, 0, src.Len())
 	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
 
-	// Test MoveTo empty slice
-	src.MoveTo(dest)
+	// Test MoveAndAppendTo empty slice
+	src.MoveAndAppendTo(dest)
 	assert.EqualValues(t, generateTestHistogramBucketSlice(), dest)
 	assert.EqualValues(t, 0, src.Len())
 	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
 
-	// Test MoveTo not empty slice
-	generateTestHistogramBucketSlice().MoveTo(dest)
+	// Test MoveAndAppendTo not empty slice
+	generateTestHistogramBucketSlice().MoveAndAppendTo(dest)
 	assert.EqualValues(t, 2*expectedSlice.Len(), dest.Len())
 	for i := 0; i < expectedSlice.Len(); i++ {
 		assert.EqualValues(t, expectedSlice.At(i), dest.At(i))
@@ -1194,24 +1194,24 @@ func TestSummaryDataPointSlice(t *testing.T) {
 	}
 }
 
-func TestSummaryDataPointSlice_MoveTo(t *testing.T) {
-	// Test MoveTo to empty
+func TestSummaryDataPointSlice_MoveAndAppendTo(t *testing.T) {
+	// Test MoveAndAppendTo to empty
 	expectedSlice := generateTestSummaryDataPointSlice()
 	dest := NewSummaryDataPointSlice()
 	src := generateTestSummaryDataPointSlice()
-	src.MoveTo(dest)
+	src.MoveAndAppendTo(dest)
 	assert.EqualValues(t, generateTestSummaryDataPointSlice(), dest)
 	assert.EqualValues(t, 0, src.Len())
 	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
 
-	// Test MoveTo empty slice
-	src.MoveTo(dest)
+	// Test MoveAndAppendTo empty slice
+	src.MoveAndAppendTo(dest)
 	assert.EqualValues(t, generateTestSummaryDataPointSlice(), dest)
 	assert.EqualValues(t, 0, src.Len())
 	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
 
-	// Test MoveTo not empty slice
-	generateTestSummaryDataPointSlice().MoveTo(dest)
+	// Test MoveAndAppendTo not empty slice
+	generateTestSummaryDataPointSlice().MoveAndAppendTo(dest)
 	assert.EqualValues(t, 2*expectedSlice.Len(), dest.Len())
 	for i := 0; i < expectedSlice.Len(); i++ {
 		assert.EqualValues(t, expectedSlice.At(i), dest.At(i))
@@ -1364,24 +1364,24 @@ func TestSummaryValueAtPercentileSlice(t *testing.T) {
 	}
 }
 
-func TestSummaryValueAtPercentileSlice_MoveTo(t *testing.T) {
-	// Test MoveTo to empty
+func TestSummaryValueAtPercentileSlice_MoveAndAppendTo(t *testing.T) {
+	// Test MoveAndAppendTo to empty
 	expectedSlice := generateTestSummaryValueAtPercentileSlice()
 	dest := NewSummaryValueAtPercentileSlice()
 	src := generateTestSummaryValueAtPercentileSlice()
-	src.MoveTo(dest)
+	src.MoveAndAppendTo(dest)
 	assert.EqualValues(t, generateTestSummaryValueAtPercentileSlice(), dest)
 	assert.EqualValues(t, 0, src.Len())
 	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
 
-	// Test MoveTo empty slice
-	src.MoveTo(dest)
+	// Test MoveAndAppendTo empty slice
+	src.MoveAndAppendTo(dest)
 	assert.EqualValues(t, generateTestSummaryValueAtPercentileSlice(), dest)
 	assert.EqualValues(t, 0, src.Len())
 	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
 
-	// Test MoveTo not empty slice
-	generateTestSummaryValueAtPercentileSlice().MoveTo(dest)
+	// Test MoveAndAppendTo not empty slice
+	generateTestSummaryValueAtPercentileSlice().MoveAndAppendTo(dest)
 	assert.EqualValues(t, 2*expectedSlice.Len(), dest.Len())
 	for i := 0; i < expectedSlice.Len(); i++ {
 		assert.EqualValues(t, expectedSlice.At(i), dest.At(i))

--- a/consumer/pdata/generated_trace.go
+++ b/consumer/pdata/generated_trace.go
@@ -63,8 +63,9 @@ func (es ResourceSpansSlice) At(ix int) ResourceSpans {
 	return newResourceSpans(&(*es.orig)[ix])
 }
 
-// MoveTo moves all elements from the current slice to the dest. The current slice will be cleared.
-func (es ResourceSpansSlice) MoveTo(dest ResourceSpansSlice) {
+// MoveAndAppendTo moves all elements from the current slice and appends them to the dest.
+// The current slice will be cleared.
+func (es ResourceSpansSlice) MoveAndAppendTo(dest ResourceSpansSlice) {
 	if es.Len() == 0 {
 		// Just to ensure that we always return a Slice with nil elements.
 		*es.orig = nil
@@ -101,7 +102,7 @@ func (es ResourceSpansSlice) CopyTo(dest ResourceSpansSlice) {
 		wrappers[i] = &origs[i]
 		newResourceSpans(&el).CopyTo(newResourceSpans(&wrappers[i]))
 	}
-    *dest.orig = wrappers
+	*dest.orig = wrappers
 }
 
 // Resize is an operation that resizes the slice:
@@ -245,8 +246,9 @@ func (es InstrumentationLibrarySpansSlice) At(ix int) InstrumentationLibrarySpan
 	return newInstrumentationLibrarySpans(&(*es.orig)[ix])
 }
 
-// MoveTo moves all elements from the current slice to the dest. The current slice will be cleared.
-func (es InstrumentationLibrarySpansSlice) MoveTo(dest InstrumentationLibrarySpansSlice) {
+// MoveAndAppendTo moves all elements from the current slice and appends them to the dest.
+// The current slice will be cleared.
+func (es InstrumentationLibrarySpansSlice) MoveAndAppendTo(dest InstrumentationLibrarySpansSlice) {
 	if es.Len() == 0 {
 		// Just to ensure that we always return a Slice with nil elements.
 		*es.orig = nil
@@ -283,7 +285,7 @@ func (es InstrumentationLibrarySpansSlice) CopyTo(dest InstrumentationLibrarySpa
 		wrappers[i] = &origs[i]
 		newInstrumentationLibrarySpans(&el).CopyTo(newInstrumentationLibrarySpans(&wrappers[i]))
 	}
-    *dest.orig = wrappers
+	*dest.orig = wrappers
 }
 
 // Resize is an operation that resizes the slice:
@@ -427,8 +429,9 @@ func (es SpanSlice) At(ix int) Span {
 	return newSpan(&(*es.orig)[ix])
 }
 
-// MoveTo moves all elements from the current slice to the dest. The current slice will be cleared.
-func (es SpanSlice) MoveTo(dest SpanSlice) {
+// MoveAndAppendTo moves all elements from the current slice and appends them to the dest.
+// The current slice will be cleared.
+func (es SpanSlice) MoveAndAppendTo(dest SpanSlice) {
 	if es.Len() == 0 {
 		// Just to ensure that we always return a Slice with nil elements.
 		*es.orig = nil
@@ -465,7 +468,7 @@ func (es SpanSlice) CopyTo(dest SpanSlice) {
 		wrappers[i] = &origs[i]
 		newSpan(&el).CopyTo(newSpan(&wrappers[i]))
 	}
-    *dest.orig = wrappers
+	*dest.orig = wrappers
 }
 
 // Resize is an operation that resizes the slice:
@@ -791,8 +794,9 @@ func (es SpanEventSlice) At(ix int) SpanEvent {
 	return newSpanEvent(&(*es.orig)[ix])
 }
 
-// MoveTo moves all elements from the current slice to the dest. The current slice will be cleared.
-func (es SpanEventSlice) MoveTo(dest SpanEventSlice) {
+// MoveAndAppendTo moves all elements from the current slice and appends them to the dest.
+// The current slice will be cleared.
+func (es SpanEventSlice) MoveAndAppendTo(dest SpanEventSlice) {
 	if es.Len() == 0 {
 		// Just to ensure that we always return a Slice with nil elements.
 		*es.orig = nil
@@ -829,7 +833,7 @@ func (es SpanEventSlice) CopyTo(dest SpanEventSlice) {
 		wrappers[i] = &origs[i]
 		newSpanEvent(&el).CopyTo(newSpanEvent(&wrappers[i]))
 	}
-    *dest.orig = wrappers
+	*dest.orig = wrappers
 }
 
 // Resize is an operation that resizes the slice:
@@ -1008,8 +1012,9 @@ func (es SpanLinkSlice) At(ix int) SpanLink {
 	return newSpanLink(&(*es.orig)[ix])
 }
 
-// MoveTo moves all elements from the current slice to the dest. The current slice will be cleared.
-func (es SpanLinkSlice) MoveTo(dest SpanLinkSlice) {
+// MoveAndAppendTo moves all elements from the current slice and appends them to the dest.
+// The current slice will be cleared.
+func (es SpanLinkSlice) MoveAndAppendTo(dest SpanLinkSlice) {
 	if es.Len() == 0 {
 		// Just to ensure that we always return a Slice with nil elements.
 		*es.orig = nil
@@ -1046,7 +1051,7 @@ func (es SpanLinkSlice) CopyTo(dest SpanLinkSlice) {
 		wrappers[i] = &origs[i]
 		newSpanLink(&el).CopyTo(newSpanLink(&wrappers[i]))
 	}
-    *dest.orig = wrappers
+	*dest.orig = wrappers
 }
 
 // Resize is an operation that resizes the slice:

--- a/consumer/pdata/generated_trace_test.go
+++ b/consumer/pdata/generated_trace_test.go
@@ -42,24 +42,24 @@ func TestResourceSpansSlice(t *testing.T) {
 	}
 }
 
-func TestResourceSpansSlice_MoveTo(t *testing.T) {
-	// Test MoveTo to empty
+func TestResourceSpansSlice_MoveAndAppendTo(t *testing.T) {
+	// Test MoveAndAppendTo to empty
 	expectedSlice := generateTestResourceSpansSlice()
 	dest := NewResourceSpansSlice()
 	src := generateTestResourceSpansSlice()
-	src.MoveTo(dest)
+	src.MoveAndAppendTo(dest)
 	assert.EqualValues(t, generateTestResourceSpansSlice(), dest)
 	assert.EqualValues(t, 0, src.Len())
 	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
 
-	// Test MoveTo empty slice
-	src.MoveTo(dest)
+	// Test MoveAndAppendTo empty slice
+	src.MoveAndAppendTo(dest)
 	assert.EqualValues(t, generateTestResourceSpansSlice(), dest)
 	assert.EqualValues(t, 0, src.Len())
 	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
 
-	// Test MoveTo not empty slice
-	generateTestResourceSpansSlice().MoveTo(dest)
+	// Test MoveAndAppendTo not empty slice
+	generateTestResourceSpansSlice().MoveAndAppendTo(dest)
 	assert.EqualValues(t, 2*expectedSlice.Len(), dest.Len())
 	for i := 0; i < expectedSlice.Len(); i++ {
 		assert.EqualValues(t, expectedSlice.At(i), dest.At(i))
@@ -177,24 +177,24 @@ func TestInstrumentationLibrarySpansSlice(t *testing.T) {
 	}
 }
 
-func TestInstrumentationLibrarySpansSlice_MoveTo(t *testing.T) {
-	// Test MoveTo to empty
+func TestInstrumentationLibrarySpansSlice_MoveAndAppendTo(t *testing.T) {
+	// Test MoveAndAppendTo to empty
 	expectedSlice := generateTestInstrumentationLibrarySpansSlice()
 	dest := NewInstrumentationLibrarySpansSlice()
 	src := generateTestInstrumentationLibrarySpansSlice()
-	src.MoveTo(dest)
+	src.MoveAndAppendTo(dest)
 	assert.EqualValues(t, generateTestInstrumentationLibrarySpansSlice(), dest)
 	assert.EqualValues(t, 0, src.Len())
 	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
 
-	// Test MoveTo empty slice
-	src.MoveTo(dest)
+	// Test MoveAndAppendTo empty slice
+	src.MoveAndAppendTo(dest)
 	assert.EqualValues(t, generateTestInstrumentationLibrarySpansSlice(), dest)
 	assert.EqualValues(t, 0, src.Len())
 	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
 
-	// Test MoveTo not empty slice
-	generateTestInstrumentationLibrarySpansSlice().MoveTo(dest)
+	// Test MoveAndAppendTo not empty slice
+	generateTestInstrumentationLibrarySpansSlice().MoveAndAppendTo(dest)
 	assert.EqualValues(t, 2*expectedSlice.Len(), dest.Len())
 	for i := 0; i < expectedSlice.Len(); i++ {
 		assert.EqualValues(t, expectedSlice.At(i), dest.At(i))
@@ -312,24 +312,24 @@ func TestSpanSlice(t *testing.T) {
 	}
 }
 
-func TestSpanSlice_MoveTo(t *testing.T) {
-	// Test MoveTo to empty
+func TestSpanSlice_MoveAndAppendTo(t *testing.T) {
+	// Test MoveAndAppendTo to empty
 	expectedSlice := generateTestSpanSlice()
 	dest := NewSpanSlice()
 	src := generateTestSpanSlice()
-	src.MoveTo(dest)
+	src.MoveAndAppendTo(dest)
 	assert.EqualValues(t, generateTestSpanSlice(), dest)
 	assert.EqualValues(t, 0, src.Len())
 	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
 
-	// Test MoveTo empty slice
-	src.MoveTo(dest)
+	// Test MoveAndAppendTo empty slice
+	src.MoveAndAppendTo(dest)
 	assert.EqualValues(t, generateTestSpanSlice(), dest)
 	assert.EqualValues(t, 0, src.Len())
 	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
 
-	// Test MoveTo not empty slice
-	generateTestSpanSlice().MoveTo(dest)
+	// Test MoveAndAppendTo not empty slice
+	generateTestSpanSlice().MoveAndAppendTo(dest)
 	assert.EqualValues(t, 2*expectedSlice.Len(), dest.Len())
 	for i := 0; i < expectedSlice.Len(); i++ {
 		assert.EqualValues(t, expectedSlice.At(i), dest.At(i))
@@ -564,24 +564,24 @@ func TestSpanEventSlice(t *testing.T) {
 	}
 }
 
-func TestSpanEventSlice_MoveTo(t *testing.T) {
-	// Test MoveTo to empty
+func TestSpanEventSlice_MoveAndAppendTo(t *testing.T) {
+	// Test MoveAndAppendTo to empty
 	expectedSlice := generateTestSpanEventSlice()
 	dest := NewSpanEventSlice()
 	src := generateTestSpanEventSlice()
-	src.MoveTo(dest)
+	src.MoveAndAppendTo(dest)
 	assert.EqualValues(t, generateTestSpanEventSlice(), dest)
 	assert.EqualValues(t, 0, src.Len())
 	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
 
-	// Test MoveTo empty slice
-	src.MoveTo(dest)
+	// Test MoveAndAppendTo empty slice
+	src.MoveAndAppendTo(dest)
 	assert.EqualValues(t, generateTestSpanEventSlice(), dest)
 	assert.EqualValues(t, 0, src.Len())
 	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
 
-	// Test MoveTo not empty slice
-	generateTestSpanEventSlice().MoveTo(dest)
+	// Test MoveAndAppendTo not empty slice
+	generateTestSpanEventSlice().MoveAndAppendTo(dest)
 	assert.EqualValues(t, 2*expectedSlice.Len(), dest.Len())
 	for i := 0; i < expectedSlice.Len(); i++ {
 		assert.EqualValues(t, expectedSlice.At(i), dest.At(i))
@@ -716,24 +716,24 @@ func TestSpanLinkSlice(t *testing.T) {
 	}
 }
 
-func TestSpanLinkSlice_MoveTo(t *testing.T) {
-	// Test MoveTo to empty
+func TestSpanLinkSlice_MoveAndAppendTo(t *testing.T) {
+	// Test MoveAndAppendTo to empty
 	expectedSlice := generateTestSpanLinkSlice()
 	dest := NewSpanLinkSlice()
 	src := generateTestSpanLinkSlice()
-	src.MoveTo(dest)
+	src.MoveAndAppendTo(dest)
 	assert.EqualValues(t, generateTestSpanLinkSlice(), dest)
 	assert.EqualValues(t, 0, src.Len())
 	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
 
-	// Test MoveTo empty slice
-	src.MoveTo(dest)
+	// Test MoveAndAppendTo empty slice
+	src.MoveAndAppendTo(dest)
 	assert.EqualValues(t, generateTestSpanLinkSlice(), dest)
 	assert.EqualValues(t, 0, src.Len())
 	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
 
-	// Test MoveTo not empty slice
-	generateTestSpanLinkSlice().MoveTo(dest)
+	// Test MoveAndAppendTo not empty slice
+	generateTestSpanLinkSlice().MoveAndAppendTo(dest)
 	assert.EqualValues(t, 2*expectedSlice.Len(), dest.Len())
 	for i := 0; i < expectedSlice.Len(); i++ {
 		assert.EqualValues(t, expectedSlice.At(i), dest.At(i))

--- a/internal/data_generator/internal/base_structs.go
+++ b/internal/data_generator/internal/base_structs.go
@@ -61,8 +61,9 @@ func (es ${structName}) At(ix int) ${elementName} {
 	return new${elementName}(&(*es.orig)[ix])
 }
 
-// MoveTo moves all elements from the current slice to the dest. The current slice will be cleared.
-func (es ${structName}) MoveTo(dest ${structName}) {
+// MoveAndAppendTo moves all elements from the current slice and appends them to the dest.
+// The current slice will be cleared.
+func (es ${structName}) MoveAndAppendTo(dest ${structName}) {
 	if es.Len() == 0 {
 		// Just to ensure that we always return a Slice with nil elements.
 		*es.orig = nil
@@ -99,7 +100,7 @@ func (es ${structName}) CopyTo(dest ${structName}) {
 		wrappers[i] = &origs[i]
 		new${elementName}(&el).CopyTo(new${elementName}(&wrappers[i]))
 	}
-    *dest.orig = wrappers
+	*dest.orig = wrappers
 }
 
 // Resize is an operation that resizes the slice:
@@ -151,24 +152,24 @@ const sliceTestTemplate = `func Test${structName}(t *testing.T) {
 	}
 }
 
-func Test${structName}_MoveTo(t *testing.T) {
-	// Test MoveTo to empty
+func Test${structName}_MoveAndAppendTo(t *testing.T) {
+	// Test MoveAndAppendTo to empty
 	expectedSlice := generateTest${structName}()
 	dest := New${structName}()
 	src := generateTest${structName}()
-	src.MoveTo(dest)
+	src.MoveAndAppendTo(dest)
 	assert.EqualValues(t, generateTest${structName}(), dest)
 	assert.EqualValues(t, 0, src.Len())
 	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
 
-	// Test MoveTo empty slice
-	src.MoveTo(dest)
+	// Test MoveAndAppendTo empty slice
+	src.MoveAndAppendTo(dest)
 	assert.EqualValues(t, generateTest${structName}(), dest)
 	assert.EqualValues(t, 0, src.Len())
 	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
 
-	// Test MoveTo not empty slice
-	generateTest${structName}().MoveTo(dest)
+	// Test MoveAndAppendTo not empty slice
+	generateTest${structName}().MoveAndAppendTo(dest)
 	assert.EqualValues(t, 2*expectedSlice.Len(), dest.Len())
 	for i := 0; i < expectedSlice.Len(); i++ {
 		assert.EqualValues(t, expectedSlice.At(i), dest.At(i))

--- a/processor/batchprocessor/batch_processor.go
+++ b/processor/batchprocessor/batch_processor.go
@@ -154,7 +154,7 @@ func (b *batch) add(td pdata.Traces) {
 
 	b.resourceSpansCount = b.resourceSpansCount + uint32(newResourceSpansCount)
 	b.spanCount = b.spanCount + uint32(td.SpanCount())
-	td.ResourceSpans().MoveTo(b.traceData.ResourceSpans())
+	td.ResourceSpans().MoveAndAppendTo(b.traceData.ResourceSpans())
 }
 
 func (b *batch) getTraceData() pdata.Traces {

--- a/translator/internaldata/oc_to_metrics_test.go
+++ b/translator/internaldata/oc_to_metrics_test.go
@@ -117,8 +117,8 @@ func TestOCToMetricData(t *testing.T) {
 			wantSlice := data.NewMetricData()
 			// Double the ResourceMetrics only if not empty.
 			if test.internal.ResourceMetrics().Len() != 0 {
-				test.internal.Clone().ResourceMetrics().MoveTo(wantSlice.ResourceMetrics())
-				test.internal.Clone().ResourceMetrics().MoveTo(wantSlice.ResourceMetrics())
+				test.internal.Clone().ResourceMetrics().MoveAndAppendTo(wantSlice.ResourceMetrics())
+				test.internal.Clone().ResourceMetrics().MoveAndAppendTo(wantSlice.ResourceMetrics())
 			}
 			gotSlice := OCSliceToMetricData(ocslice)
 			assert.EqualValues(t, wantSlice, gotSlice)


### PR DESCRIPTION
The current `MoveTo` function does move and appends the data to the destination slice. A clear `MoveTo` should replace the data in the destination slice.