### PR TITLE
Don't modify process attributes in jaeger translator

### DIFF
--- a/translator/trace/jaeger/traces_to_jaegerproto.go
+++ b/translator/trace/jaeger/traces_to_jaegerproto.go
@@ -117,7 +117,6 @@ func resourceToJaegerProtoProcess(resource pdata.Resource) *model.Process {
 	process := model.Process{}
 	if serviceName, ok := attrs.Get(conventions.AttributeServiceName); ok {
 		process.ServiceName = serviceName.StringVal()
-		attrs.Delete(conventions.AttributeServiceName)
 	}
 	process.Tags = attributesToJaegerProtoTags(attrs)
 	return &process
@@ -131,6 +130,10 @@ func attributesToJaegerProtoTags(attrs pdata.AttributeMap) []model.KeyValue {
 
 	tags := make([]model.KeyValue, 0, attrs.Cap())
 	attrs.ForEach(func(key string, attr pdata.AttributeValue) {
+		if key == conventions.AttributeServiceName {
+			return
+		}
+
 		tag := model.KeyValue{Key: key}
 		switch attr.Type() {
 		case pdata.AttributeValueSTRING:

--- a/translator/trace/jaeger/traces_to_jaegerproto_test.go
+++ b/translator/trace/jaeger/traces_to_jaegerproto_test.go
@@ -188,6 +188,7 @@ func TestAttributesToJaegerProtoTags(t *testing.T) {
 	attributes.InsertInt("int-val", 123)
 	attributes.InsertString("string-val", "abc")
 	attributes.InsertDouble("double-val", 1.23)
+	attributes.InsertString("skip", "must be skipped")
 
 	expected := []model.KeyValue{
 		{
@@ -212,7 +213,10 @@ func TestAttributesToJaegerProtoTags(t *testing.T) {
 		},
 	}
 
-	require.EqualValues(t, expected, attributesToJaegerProtoTags(attributes))
+	skipKeys := map[string]struct{}{
+		"skip": {},
+	}
+	require.EqualValues(t, expected, attributesToJaegerProtoTags(attributes, skipKeys))
 }
 
 func TestInternalTracesToJaegerProto(t *testing.T) {


### PR DESCRIPTION
**Description:** currently `InternalTracesToJaegerProto` deletes `service.name` attribute during conversion to jaeger proto. It causes problems if you want to export trace data via several exporters.