### PR TITLE
Use development logging when running a local build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,8 @@ LINT=golangci-lint
 IMPI=impi
 GOSEC=gosec
 STATIC_CHECK=staticcheck
+# BUILD_TYPE should be one of (dev, release).
+BUILD_TYPE?=release
 
 GIT_SHA=$(shell git rev-parse --short HEAD)
 BUILD_INFO_IMPORT_PATH=github.com/open-telemetry/opentelemetry-collector/internal/version
@@ -36,7 +38,8 @@ BUILD_X1=-X $(BUILD_INFO_IMPORT_PATH).GitHash=$(GIT_SHA)
 ifdef VERSION
 BUILD_X2=-X $(BUILD_INFO_IMPORT_PATH).Version=$(VERSION)
 endif
-BUILD_INFO=-ldflags "${BUILD_X1} ${BUILD_X2}"
+BUILD_X3=-X $(BUILD_INFO_IMPORT_PATH).BuildType=$(BUILD_TYPE)
+BUILD_INFO=-ldflags "${BUILD_X1} ${BUILD_X2} ${BUILD_X3}"
 
 all-srcs:
 	@echo $(ALL_SRC) | tr ' ' '\n' | sort

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -20,11 +20,20 @@ import (
 	"runtime"
 )
 
+const (
+	defaultVersion = "latest"
+)
+
 // Version variable will be replaced at link time after `make` has been run.
-var Version = "latest"
+var Version = defaultVersion
 
 // GitHash variable will be replaced at link time after `make` has been run.
 var GitHash = "<NOT PROPERLY GENERATED>"
+
+// IsDevBuild returns true if this is a development (local) build.
+func IsDevBuild() bool {
+	return Version == defaultVersion
+}
 
 // Info returns a formatted string, with linebreaks, intended to be displayed
 // on stdout.

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -21,18 +21,27 @@ import (
 )
 
 const (
-	defaultVersion = "latest"
+	buildDev     = "dev"
+	buildRelease = "release"
 )
 
 // Version variable will be replaced at link time after `make` has been run.
-var Version = defaultVersion
+var Version = "latest"
 
 // GitHash variable will be replaced at link time after `make` has been run.
 var GitHash = "<NOT PROPERLY GENERATED>"
 
+// BuildType should be one of (dev, release).
+var BuildType = buildDev
+
 // IsDevBuild returns true if this is a development (local) build.
 func IsDevBuild() bool {
-	return Version == defaultVersion
+	return BuildType == buildDev
+}
+
+// IsReleaseBuild returns true if this is a release build.
+func IsReleaseBuild() bool {
+	return BuildType == buildRelease
 }
 
 // Info returns a formatted string, with linebreaks, intended to be displayed

--- a/service/logger.go
+++ b/service/logger.go
@@ -24,13 +24,13 @@ import (
 )
 
 const (
-	logLevelCfg = "log-level"
+	logLevelCfg   = "log-level"
 	logProfileCfg = "log-profile"
 )
 
 var (
 	// Command line pointer to logger level flag configuration.
-	loggerLevelPtr *string
+	loggerLevelPtr   *string
 	loggerProfilePtr *string
 )
 

--- a/service/logger.go
+++ b/service/logger.go
@@ -19,6 +19,8 @@ import (
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+
+	"github.com/open-telemetry/opentelemetry-collector/internal/version"
 )
 
 const (
@@ -41,6 +43,9 @@ func newLogger() (*zap.Logger, error) {
 		return nil, err
 	}
 	conf := zap.NewProductionConfig()
+	if version.IsDevBuild() {
+		conf = zap.NewDevelopmentConfig()
+	}
 	conf.Level.SetLevel(level)
 	return conf.Build()
 }


### PR DESCRIPTION
The [zap development logger](https://godoc.org/go.uber.org/zap#NewDevelopmentConfig) provides nicer console output as well as a few other different defaults for development.

To decide whether to use production or development it's checking if `Version`
has been set at build time. If not it assumes it's development. It may be
better not to conflate version number with build type in which case we could
add a separate build type. But first I wanted to see if the general idea
desirable.

---

Before

```
{"level":"info","ts":1588175559.4787421,"caller":"service/service.go:360","msg":"Starting OpenTelemetry Contrib Collector...","Version":"latest","GitHash":"<NOT PROPERLY GENERATED>","NumCPU":12}
{"level":"info","ts":1588175559.478791,"caller":"service/service.go:199","msg":"Setting up own telemetry..."}
{"level":"info","ts":1588175559.4789288,"caller":"service/telemetry.go:94","msg":"Serving Prometheus metrics","address":"localhost:8888","legacy_metrics":true,"new_metrics":false,"level":3,"service.instance.id":""}
{"level":"info","ts":1588175559.479254,"caller":"service/service.go:237","msg":"Loading configuration..."}
{"level":"info","ts":1588175559.480563,"caller":"service/service.go:248","msg":"Applying configuration..."}
{"level":"info","ts":1588175559.489289,"caller":"service/service.go:269","msg":"Starting extensions..."}
{"level":"info","ts":1588175559.489312,"caller":"builder/extensions_builder.go:53","msg":"Extension is starting...","component_kind":"extension","component_type":"k8s_observer","component_name":"k8s_observer"}
{"level":"info","ts":1588175559.4897852,"caller":"builder/extensions_builder.go:59","msg":"Extension started.","component_kind":"extension","component_type":"k8s_observer","component_name":"k8s_observer"}
{"level":"info","ts":1588175559.489795,"caller":"builder/extensions_builder.go:53","msg":"Extension is starting...","component_kind":"extension","component_type":"zpages","component_name":"zpages"}
{"level":"info","ts":1588175559.490153,"caller":"zpagesextension/zpagesextension.go:45","msg":"Starting zPages extension","component_kind":"extension","config":{"TypeVal":"zpages","NameVal":"zpages","Disabled":false,"Endpoint":"localhost:55679"}}
{"level":"info","ts":1588175559.490222,"caller":"builder/extensions_builder.go:59","msg":"Extension started.","component_kind":"extension","component_type":"zpages","component_name":"zpages"}
{"level":"warn","ts":1588175559.490238,"caller":"builder/exporters_builder.go:209","msg":"Exportee is not associated with any pipeline and will not export data.","component_kind":"exporter","component_type":"logging","component_name":"logging"}
{"level":"info","ts":1588175559.490324,"caller":"builder/exporters_builder.go:252","msg":"Exporter is enabled.","component_kind":"exporter","exporter":"file"}
{"level":"info","ts":1588175559.490348,"caller":"builder/exporters_builder.go:252","msg":"Exporter is enabled.","component_kind":"exporter","exporter":"signalfx"}
```

After

```
2020-04-29T12:01:20.926-0400	INFO	service/service.go:360	Starting OpenTelemetry Contrib Collector...	{"Version": "latest", "GitHash": "<NOT PROPERLY GENERATED>", "NumCPU": 12}
2020-04-29T12:01:20.926-0400	INFO	service/service.go:199	Setting up own telemetry...
2020-04-29T12:01:20.926-0400	INFO	service/telemetry.go:95	Serving Prometheus metrics	{"port": 8888, "legacy_metrics": true, "new_metrics": false, "level": 3, "service.instance.id": ""}
2020-04-29T12:01:20.927-0400	INFO	service/service.go:237	Loading configuration...
2020-04-29T12:01:20.928-0400	INFO	service/service.go:248	Applying configuration...
2020-04-29T12:01:20.937-0400	INFO	service/service.go:269	Starting extensions...
2020-04-29T12:01:20.937-0400	INFO	builder/extensions_builder.go:53	Extension is starting...	{"component_kind": "extension", "component_type": "zpages", "component_name": "zpages"}
2020-04-29T12:01:20.938-0400	INFO	zpagesextension/zpagesextension.go:45	Starting zPages extension	{"component_kind": "extension", "config": {"TypeVal":"zpages","NameVal":"zpages","Disabled":false,"Endpoint":"localhost:55679"}}
2020-04-29T12:01:20.938-0400	INFO	builder/extensions_builder.go:59	Extension started.	{"component_kind": "extension", "component_type": "zpages", "component_name": "zpages"}
2020-04-29T12:01:20.938-0400	INFO	builder/extensions_builder.go:53	Extension is starting...	{"component_kind": "extension", "component_type": "k8s_observer", "component_name": "k8s_observer"}
2020-04-29T12:01:20.938-0400	INFO	builder/extensions_builder.go:59	Extension started.	{"component_kind": "extension", "component_type": "k8s_observer", "component_name": "k8s_observer"}
2020-04-29T12:01:20.938-0400	INFO	builder/exporters_builder.go:252	Exporter is enabled.	{"component_kind": "exporter", "exporter": "signalfx"}
2020-04-29T12:01:20.938-0400	INFO	builder/exporters_builder.go:252	Exporter is enabled.	{"component_kind": "exporter", "exporter": "file"}
```