### PR TITLE
Allow components to discover Exporters

### DIFF
--- a/component/component.go
+++ b/component/component.go
@@ -69,6 +69,16 @@ type Host interface {
 	// can be done by iterating the returned map. There are typically very few extensions
 	// so there there is no performance implications due to iteration.
 	GetExtensions() map[configmodels.Extension]ServiceExtension
+
+	// Return map of exporters. Only enabled and created exporters will be returned.
+	// Typically is used to find exporters by type or by full config name. Both cases
+	// can be done by iterating the returned map. There are typically very few exporters
+	// so there there is no performance implications due to iteration.
+	// This returns a map by DataType of maps by exporter configs to the exporter instance.
+	// Note that an exporter with the same name may be attached to multiple pipelines and
+	// thus we may have an instance of the exporter for multiple data types.
+	// This is an experimental function that may change or even be removed completely.
+	GetExporters() map[configmodels.DataType]map[configmodels.Exporter]Exporter
 }
 
 // Factory interface must be implemented by all component factories.

--- a/component/componenttest/error_waiting_host.go
+++ b/component/componenttest/error_waiting_host.go
@@ -64,3 +64,7 @@ func (ews *ErrorWaitingHost) GetFactory(_ component.Kind, _ configmodels.Type) c
 func (ews *ErrorWaitingHost) GetExtensions() map[configmodels.Extension]component.ServiceExtension {
 	return nil
 }
+
+func (ews *ErrorWaitingHost) GetExporters() map[configmodels.DataType]map[configmodels.Exporter]component.Exporter {
+	return nil
+}

--- a/component/componenttest/nop_host.go
+++ b/component/componenttest/nop_host.go
@@ -46,3 +46,7 @@ func (nh *NopHost) GetFactory(_ component.Kind, _ configmodels.Type) component.F
 func (nh *NopHost) GetExtensions() map[configmodels.Extension]component.ServiceExtension {
 	return nil
 }
+
+func (nh *NopHost) GetExporters() map[configmodels.DataType]map[configmodels.Exporter]component.Exporter {
+	return nil
+}

--- a/service/builder/extensions_builder.go
+++ b/service/builder/extensions_builder.go
@@ -109,7 +109,7 @@ func (exts Extensions) NotifyPipelineNotReady() error {
 	return nil
 }
 
-func (exts Extensions) GetServiceExtensions() map[configmodels.Extension]component.ServiceExtension {
+func (exts Extensions) ToMap() map[configmodels.Extension]component.ServiceExtension {
 	result := make(map[configmodels.Extension]component.ServiceExtension, len(exts))
 	for k, v := range exts {
 		result[k] = v.extension

--- a/service/service.go
+++ b/service/service.go
@@ -183,7 +183,11 @@ func (app *Application) GetFactory(kind component.Kind, componentType configmode
 }
 
 func (app *Application) GetExtensions() map[configmodels.Extension]component.ServiceExtension {
-	return app.builtExtensions.GetServiceExtensions()
+	return app.builtExtensions.ToMap()
+}
+
+func (app *Application) GetExporters() map[configmodels.DataType]map[configmodels.Exporter]component.Exporter {
+	return app.builtExporters.ToMapByDataType()
 }
 
 func (app *Application) init() error {
@@ -280,8 +284,8 @@ func (app *Application) setupPipelines(ctx context.Context) error {
 	if err != nil {
 		return errors.Wrap(err, "cannot build builtExporters")
 	}
-	app.logger.Info("Starting exporters...")
 
+	app.logger.Info("Starting exporters...")
 	err = app.builtExporters.StartAll(ctx, app)
 	if err != nil {
 		return errors.Wrap(err, "cannot start builtExporters")

--- a/testbed/testbed/receivers.go
+++ b/testbed/testbed/receivers.go
@@ -66,6 +66,10 @@ func (mb *DataReceiverBase) GetExtensions() map[configmodels.Extension]component
 	return nil
 }
 
+func (mb *DataReceiverBase) GetExporters() map[configmodels.DataType]map[configmodels.Exporter]component.Exporter {
+	return nil
+}
+
 // OCDataReceiver implements OpenCensus format receiver.
 type OCDataReceiver struct {
 	DataReceiverBase


### PR DESCRIPTION
Host.GetExporters now allows components to discover exporters.
This will be used by upcoming receivers that need to cooperate
with exporters.
