### PR TITLE
Fix example otel local config

### DIFF
--- a/examples/otel-local-config.yaml
+++ b/examples/otel-local-config.yaml
@@ -1,6 +1,5 @@
    extensions:
      health_check:
-       endpoint: 0.0.0.0:13133
      pprof:
        endpoint: 0.0.0.0:1777
      zpages:


### PR DESCRIPTION
The `health_check` extension does not have an endpoint property, it has a `port` property instead.