### PR TITLE
Set wait for ready in Jaeger gRPC exporter 

### DIFF
--- a/config/configgrpc/configgrpc.go
+++ b/config/configgrpc/configgrpc.go
@@ -56,6 +56,10 @@ type GRPCSettings struct {
 	// The keepalive parameters for client gRPC. See grpc.WithKeepaliveParams
 	// (https://godoc.org/google.golang.org/grpc#WithKeepaliveParams).
 	KeepaliveParameters *KeepaliveConfig `mapstructure:"keepalive"`
+
+	// WaitForReady parameter configures client to wait for ready state before sending data.
+	// (https://github.com/grpc/grpc/blob/master/doc/wait-for-ready.md)
+	WaitForReady bool `mapstructure:"wait_for_ready"`
 }
 
 // KeepaliveConfig exposes the keepalive.ClientParameters to be used by the exporter.

--- a/exporter/jaegerexporter/exporter_test.go
+++ b/exporter/jaegerexporter/exporter_test.go
@@ -18,9 +18,10 @@ import (
 	"context"
 	"testing"
 
+	"github.com/open-telemetry/opentelemetry-collector/config/configgrpc"
+
 	"github.com/stretchr/testify/assert"
 
-	"github.com/open-telemetry/opentelemetry-collector/config/configgrpc"
 	"github.com/open-telemetry/opentelemetry-collector/internal/data/testdata"
 )
 

--- a/exporter/jaegerexporter/exporter_test.go
+++ b/exporter/jaegerexporter/exporter_test.go
@@ -18,10 +18,9 @@ import (
 	"context"
 	"testing"
 
-	"github.com/open-telemetry/opentelemetry-collector/config/configgrpc"
-
 	"github.com/stretchr/testify/assert"
 
+	"github.com/open-telemetry/opentelemetry-collector/config/configgrpc"
 	"github.com/open-telemetry/opentelemetry-collector/internal/data/testdata"
 )
 

--- a/exporter/otlpexporter/exporter.go
+++ b/exporter/otlpexporter/exporter.go
@@ -211,14 +211,14 @@ func (e *exporterImp) exportRequest(ctx context.Context, perform func(ctx contex
 
 func (e *exporterImp) exportTrace(ctx context.Context, request *otlptracecol.ExportTraceServiceRequest) error {
 	return e.exportRequest(ctx, func(ctx context.Context) error {
-		_, err := e.traceExporter.Export(ctx, request)
+		_, err := e.traceExporter.Export(ctx, request, grpc.WaitForReady(e.config.WaitForReady))
 		return err
 	})
 }
 
 func (e *exporterImp) exportMetrics(ctx context.Context, request *otlpmetriccol.ExportMetricsServiceRequest) error {
 	return e.exportRequest(ctx, func(ctx context.Context) error {
-		_, err := e.metricExporter.Export(ctx, request)
+		_, err := e.metricExporter.Export(ctx, request, grpc.WaitForReady(e.config.WaitForReady))
 		return err
 	})
 }


### PR DESCRIPTION
**Description:** <Describe what has changed>

gRPC can drop a couple of initial RPCs at the beginning of the connection. Wait for ready should prevent it.

Some resources:
* https://github.com/grpc/grpc/blob/master/doc/wait-for-ready.md
* https://github.com/grpc/grpc/tree/master/examples/python/wait_for_ready#use-cases-for-wait-for-ready


This feature is needed in Jaeger to make crossdock tests pass. Sometimes Jaeger exporter drops first batches that is causing test failures. I have tested this PR in https://github.com/jaegertracing/jaeger/pull/2211

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** < Describe what testing was performed and which tests were added.>

**Documentation:** < Describe the documentation added.>