### PR TITLE
Improve performance of jaeger to internal traces translation

### DIFF
--- a/translator/trace/jaeger/jaegerproto_to_traces_test.go
+++ b/translator/trace/jaeger/jaegerproto_to_traces_test.go
@@ -170,15 +170,15 @@ func TestJTagsToInternalAttributes(t *testing.T) {
 		},
 	}
 
-	expected := map[string]pdata.AttributeValue{
-		"bool-val":   pdata.NewAttributeValueBool(true),
-		"int-val":    pdata.NewAttributeValueInt(123),
-		"string-val": pdata.NewAttributeValueString("abc"),
-		"double-val": pdata.NewAttributeValueDouble(1.23),
-		"binary-val": pdata.NewAttributeValueString("AAAAAABkfZg="),
-	}
+	expected := pdata.NewAttributeMap()
+	expected.InsertBool("bool-val", true)
+	expected.InsertInt("int-val", 123)
+	expected.InsertString("string-val", "abc")
+	expected.InsertDouble("double-val", 1.23)
+	expected.InsertString("binary-val", "AAAAAABkfZg=")
 
-	got := jTagsToInternalAttributes(tags)
+	got := pdata.NewAttributeMap()
+	jTagsToInternalAttributes(tags, got)
 
 	require.EqualValues(t, expected, got)
 }
@@ -470,5 +470,20 @@ func generateProtoFollowerSpan() *model.Span {
 				RefType: model.SpanRefType_FOLLOWS_FROM,
 			},
 		},
+	}
+}
+
+func BenchmarkProtoBatchToInternalTraces(b *testing.B) {
+	jb := model.Batch{
+		Process: generateProtoProcess(),
+		Spans: []*model.Span{
+			generateProtoSpan(),
+			generateProtoChildSpan(),
+		},
+	}
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		ProtoBatchToInternalTraces(jb)
 	}
 }

--- a/translator/trace/jaeger/jaegerthrift_to_traces_test.go
+++ b/translator/trace/jaeger/jaegerthrift_to_traces_test.go
@@ -60,15 +60,15 @@ func TestJThriftTagsToInternalAttributes(t *testing.T) {
 		},
 	}
 
-	expected := map[string]pdata.AttributeValue{
-		"bool-val":   pdata.NewAttributeValueBool(true),
-		"int-val":    pdata.NewAttributeValueInt(123),
-		"string-val": pdata.NewAttributeValueString("abc"),
-		"double-val": pdata.NewAttributeValueDouble(1.23),
-		"binary-val": pdata.NewAttributeValueString("AAAAAABkfZg="),
-	}
+	expected := pdata.NewAttributeMap()
+	expected.InsertBool("bool-val", true)
+	expected.InsertInt("int-val", 123)
+	expected.InsertString("string-val", "abc")
+	expected.InsertDouble("double-val", 1.23)
+	expected.InsertString("binary-val", "AAAAAABkfZg=")
 
-	got := jThriftTagsToInternalAttributes(tags)
+	got := pdata.NewAttributeMap()
+	jThriftTagsToInternalAttributes(tags, got)
 
 	require.EqualValues(t, expected, got)
 }
@@ -258,4 +258,19 @@ func generateThriftFollowerSpan() *jaeger.Span {
 
 func unixNanoToMicroseconds(ns pdata.TimestampUnixNano) int64 {
 	return int64(ns / 1000)
+}
+
+func BenchmarkThriftBatchToInternalTraces(b *testing.B) {
+	jb := &jaeger.Batch{
+		Process: generateThriftProcess(),
+		Spans: []*jaeger.Span{
+			generateThriftSpan(),
+			generateThriftChildSpan(),
+		},
+	}
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		ThriftBatchToInternalTraces(jb)
+	}
 }


### PR DESCRIPTION
Results of BenchmarkProtoBatchToInternalTraces:

Before:
```
BenchmarkProtoBatchToInternalTraces-12        329313          3346 ns/op        3352 B/op         43 allocs/op
```

After:
```
BenchmarkProtoBatchToInternalTraces-12        646017          1737 ns/op        2064 B/op         32 allocs/op
```

Roughly 80% of improvement was gained just by avoiding using intermediate map structure before creation of AttributeMap.