### PR TITLE
Preset capacity for ApptibuteMap and StringMap to improve performance

### DIFF
--- a/consumer/pdata/common.go
+++ b/consumer/pdata/common.go
@@ -260,6 +260,14 @@ func (am AttributeMap) InitFromMap(attrMap map[string]AttributeValue) AttributeM
 	return am
 }
 
+// InitEmptyWithCapacity constructs an empty AttributeMap with predefined slice capacity.
+func (am AttributeMap) InitEmptyWithCapacity(cap int) {
+	if cap == 0 {
+		*am.orig = []*otlpcommon.AttributeKeyValue(nil)
+	}
+	*am.orig = make([]*otlpcommon.AttributeKeyValue, 0, cap)
+}
+
 // Get returns the AttributeKeyValue associated with the key and true,
 // otherwise an invalid instance of the AttributeKeyValue and false.
 // Calling any functions on the returned invalid instance will cause a panic.
@@ -561,6 +569,14 @@ func (sm StringMap) InitFromMap(attrMap map[string]string) StringMap {
 	}
 	*sm.orig = wrappers
 	return sm
+}
+
+// InitEmptyWithCapacity constructs an empty StringMap with predefined slice capacity.
+func (sm StringMap) InitEmptyWithCapacity(cap int) {
+	if cap == 0 {
+		*sm.orig = []*otlpcommon.StringKeyValue(nil)
+	}
+	*sm.orig = make([]*otlpcommon.StringKeyValue, 0, cap)
 }
 
 // Get returns the StringValue associated with the key and true,

--- a/testbed/testbed/load_generator.go
+++ b/testbed/testbed/load_generator.go
@@ -366,6 +366,7 @@ func (lg *LoadGenerator) generateMetrics() {
 	metricData.ResourceMetrics().At(0).InstrumentationLibraryMetrics().Resize(1)
 	if lg.options.Attributes != nil {
 		attrs := metricData.ResourceMetrics().At(0).Resource().Attributes()
+		attrs.InitEmptyWithCapacity(len(lg.options.Attributes))
 		for k, v := range lg.options.Attributes {
 			attrs.UpsertString(k, v)
 		}

--- a/translator/internaldata/oc_to_metrics.go
+++ b/translator/internaldata/oc_to_metrics.go
@@ -289,6 +289,7 @@ func setLabelsMap(ocLabelsKeys []*ocmetrics.LabelKey, ocLabelValues []*ocmetrics
 		lablesCount = len(ocLabelValues)
 	}
 
+	labelsMap.InitEmptyWithCapacity(lablesCount)
 	for i := 0; i < lablesCount; i++ {
 		if !ocLabelValues[i].GetHasValue() {
 			continue
@@ -331,7 +332,9 @@ func exemplarToInternal(ocExemplar *ocmetrics.DistributionValue_Exemplar, exempl
 	}
 	exemplar.SetValue(ocExemplar.GetValue())
 	attachments := exemplar.Attachments()
-	for k, v := range ocExemplar.GetAttachments() {
+	ocAttachments := ocExemplar.GetAttachments()
+	attachments.InitEmptyWithCapacity(len(ocAttachments))
+	for k, v := range ocAttachments {
 		attachments.Upsert(k, v)
 	}
 }

--- a/translator/internaldata/oc_to_resource.go
+++ b/translator/internaldata/oc_to_resource.go
@@ -29,7 +29,41 @@ func ocNodeResourceToInternal(ocNode *occommon.Node, ocResource *ocresource.Reso
 	}
 
 	dest.InitEmpty()
+
+	// Number of special fields in OC that will be translated to Attributes
+	const serviceInfoAttrCount = 1     // Number of Node.ServiceInfo fields.
+	const nodeIdentifierAttrCount = 3  // Number of Node.Identifier fields.
+	const libraryInfoAttrCount = 3     // Number of Node.LibraryInfo fields.
+	const specialResourceAttrCount = 1 // Number of Resource fields.
+
+	// Calculate maximum total number of attributes for capacity reservation.
+	maxTotalAttrCount := 0
+	if ocNode != nil {
+		maxTotalAttrCount += len(ocNode.Attributes)
+		if ocNode.ServiceInfo != nil {
+			maxTotalAttrCount += serviceInfoAttrCount
+		}
+		if ocNode.Identifier != nil {
+			maxTotalAttrCount += nodeIdentifierAttrCount
+		}
+		if ocNode.LibraryInfo != nil {
+			maxTotalAttrCount += libraryInfoAttrCount
+		}
+	}
+	if ocResource != nil {
+		maxTotalAttrCount += len(ocResource.Labels)
+		if ocResource.Type != "" {
+			maxTotalAttrCount += specialResourceAttrCount
+		}
+	}
+
+	// There are no attributes to be set.
+	if maxTotalAttrCount == 0 {
+		return
+	}
+
 	attrs := dest.Attributes()
+	attrs.InitEmptyWithCapacity(maxTotalAttrCount)
 
 	if ocNode != nil {
 		// Copy all Attributes.

--- a/translator/internaldata/oc_to_traces_test.go
+++ b/translator/internaldata/oc_to_traces_test.go
@@ -53,15 +53,15 @@ func TestOcTraceStateToInternal(t *testing.T) {
 	assert.EqualValues(t, "abc=def,123=4567", ocTraceStateToInternal(tracestate))
 }
 
-func TestOcAttrsToInternal(t *testing.T) {
+func TestInitAttributeMapFromOC(t *testing.T) {
 	attrs := pdata.NewAttributeMap()
-	ocAttrsToInternal(nil, attrs)
+	initAttributeMapFromOC(nil, attrs)
 	assert.EqualValues(t, pdata.NewAttributeMap(), attrs)
 	assert.EqualValues(t, 0, ocAttrsToDroppedAttributes(nil))
 
 	ocAttrs := &octrace.Span_Attributes{}
 	attrs = pdata.NewAttributeMap()
-	ocAttrsToInternal(ocAttrs, attrs)
+	initAttributeMapFromOC(ocAttrs, attrs)
 	assert.EqualValues(t, pdata.NewAttributeMap(), attrs)
 	assert.EqualValues(t, 0, ocAttrsToDroppedAttributes(ocAttrs))
 
@@ -69,7 +69,7 @@ func TestOcAttrsToInternal(t *testing.T) {
 		DroppedAttributesCount: 123,
 	}
 	attrs = pdata.NewAttributeMap()
-	ocAttrsToInternal(ocAttrs, attrs)
+	initAttributeMapFromOC(ocAttrs, attrs)
 	assert.EqualValues(t, pdata.NewAttributeMap(), attrs)
 	assert.EqualValues(t, 123, ocAttrsToDroppedAttributes(ocAttrs))
 
@@ -78,7 +78,7 @@ func TestOcAttrsToInternal(t *testing.T) {
 		DroppedAttributesCount: 234,
 	}
 	attrs = pdata.NewAttributeMap()
-	ocAttrsToInternal(ocAttrs, attrs)
+	initAttributeMapFromOC(ocAttrs, attrs)
 	assert.EqualValues(t, pdata.NewAttributeMap(), attrs)
 	assert.EqualValues(t, 234, ocAttrsToDroppedAttributes(ocAttrs))
 
@@ -91,7 +91,7 @@ func TestOcAttrsToInternal(t *testing.T) {
 		DroppedAttributesCount: 234,
 	}
 	attrs = pdata.NewAttributeMap()
-	ocAttrsToInternal(ocAttrs, attrs)
+	initAttributeMapFromOC(ocAttrs, attrs)
 	assert.EqualValues(t,
 		pdata.NewAttributeMap().InitFromMap(
 			map[string]pdata.AttributeValue{
@@ -110,7 +110,7 @@ func TestOcAttrsToInternal(t *testing.T) {
 		Value: &octrace.AttributeValue_DoubleValue{DoubleValue: 4.5},
 	}
 	attrs = pdata.NewAttributeMap()
-	ocAttrsToInternal(ocAttrs, attrs)
+	initAttributeMapFromOC(ocAttrs, attrs)
 
 	expectedAttr := pdata.NewAttributeMap().InitFromMap(map[string]pdata.AttributeValue{
 		"abc":       pdata.NewAttributeValueString("def"),

--- a/translator/trace/jaeger/jaegerproto_to_traces.go
+++ b/translator/trace/jaeger/jaegerproto_to_traces.go
@@ -101,7 +101,10 @@ func jProcessToInternalResource(process *model.Process, dest pdata.Resource) {
 
 	attrs := dest.Attributes()
 	if serviceName != "" {
+		attrs.InitEmptyWithCapacity(len(tags) + 1)
 		attrs.UpsertString(conventions.AttributeServiceName, serviceName)
+	} else {
+		attrs.InitEmptyWithCapacity(len(tags))
 	}
 	jTagsToInternalAttributes(tags, attrs)
 
@@ -163,6 +166,7 @@ func jSpanToInternal(span *model.Span, dest pdata.Span) {
 	}
 
 	attrs := dest.Attributes()
+	attrs.InitEmptyWithCapacity(len(span.Tags))
 	jTagsToInternalAttributes(span.Tags, attrs)
 	setInternalSpanStatus(attrs, dest.Status())
 	if spanKindAttr, ok := attrs.Get(tracetranslator.TagSpanKind); ok {
@@ -298,6 +302,7 @@ func jLogsToSpanEvents(logs []model.Log, dest pdata.SpanEventSlice) {
 		}
 
 		attrs := event.Attributes()
+		attrs.InitEmptyWithCapacity(len(log.Fields))
 		jTagsToInternalAttributes(log.Fields, attrs)
 		if name, ok := attrs.Get("message"); ok {
 			event.SetName(name.StringVal())

--- a/translator/trace/jaeger/jaegerthrift_to_traces.go
+++ b/translator/trace/jaeger/jaegerthrift_to_traces.go
@@ -66,7 +66,10 @@ func jThriftProcessToInternalResource(process *jaeger.Process, dest pdata.Resour
 
 	attrs := dest.Attributes()
 	if serviceName != "" {
+		attrs.InitEmptyWithCapacity(len(tags) + 1)
 		attrs.UpsertString(conventions.AttributeServiceName, serviceName)
+	} else {
+		attrs.InitEmptyWithCapacity(len(tags))
 	}
 	jThriftTagsToInternalAttributes(tags, attrs)
 
@@ -108,6 +111,7 @@ func jThriftSpanToInternal(span *jaeger.Span, dest pdata.Span) {
 	}
 
 	attrs := dest.Attributes()
+	attrs.InitEmptyWithCapacity(len(span.Tags))
 	jThriftTagsToInternalAttributes(span.Tags, attrs)
 	setInternalSpanStatus(attrs, dest.Status())
 	if spanKindAttr, ok := attrs.Get(tracetranslator.TagSpanKind); ok {
@@ -159,6 +163,7 @@ func jThriftLogsToSpanEvents(logs []*jaeger.Log, dest pdata.SpanEventSlice) {
 		}
 
 		attrs := event.Attributes()
+		attrs.InitEmptyWithCapacity(len(log.Fields))
 		jThriftTagsToInternalAttributes(log.Fields, attrs)
 		if name, ok := attrs.Get("message"); ok {
 			event.SetName(name.StringVal())


### PR DESCRIPTION
Some benchmark runs *before*:
```
BenchmarkProtoBatchToInternalTraces-12        497078          2312 ns/op        2096 B/op         35 allocs/op
BenchmarkOcNodeResourceToInternal-12          698066          1889 ns/op        1304 B/op         17 allocs/op
BenchmarkSpansWithAttributesOCToInternal-12       282246          4596 ns/op        2328 B/op         30 allocs/op
BenchmarkMetricHistogramOCToInternal-12       363352          3540 ns/op        3544 B/op         59 allocs/op
```

Benchmark runs *after*:
```
BenchmarkProtoBatchToInternalTraces-12        646017          1737 ns/op        2064 B/op         32 allocs/op
BenchmarkOcNodeResourceToInternal-12         1075398          1126 ns/op        1152 B/op         13 allocs/op
BenchmarkSpansWithAttributesOCToInternal-12       305158          3897 ns/op        2216 B/op         26 allocs/op
BenchmarkMetricHistogramOCToInternal-12       320634          3382 ns/op        3648 B/op         56 allocs/op
```