### PR TITLE
Support any OS in host metrics receiver

### DIFF
--- a/receiver/hostmetricsreceiver/factory.go
+++ b/receiver/hostmetricsreceiver/factory.go
@@ -16,9 +16,7 @@ package hostmetricsreceiver
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"runtime"
 	"time"
 
 	"github.com/spf13/viper"
@@ -143,11 +141,6 @@ func (f *Factory) CreateMetricsReceiver(
 	cfg configmodels.Receiver,
 	consumer consumer.MetricsConsumer,
 ) (component.MetricsReceiver, error) {
-
-	if runtime.GOOS != "windows" {
-		return nil, errors.New("hostmetrics receiver is currently only supported on windows")
-	}
-
 	config := cfg.(*Config)
 
 	hmr, err := NewHostMetricsReceiver(ctx, params.Logger, config, f.scraperFactories, consumer)

--- a/receiver/hostmetricsreceiver/factory_test.go
+++ b/receiver/hostmetricsreceiver/factory_test.go
@@ -16,7 +16,6 @@ package hostmetricsreceiver
 
 import (
 	"context"
-	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -47,11 +46,6 @@ func TestCreateReceiver(t *testing.T) {
 
 	mReceiver, err := factory.CreateMetricsReceiver(context.Background(), creationParams, cfg, nil)
 
-	if runtime.GOOS != "windows" {
-		assert.NotNil(t, err)
-		assert.Nil(t, tReceiver)
-	} else {
-		assert.Nil(t, err)
-		assert.NotNil(t, mReceiver)
-	}
+	assert.Nil(t, err)
+	assert.NotNil(t, mReceiver)
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_constants.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_constants.go
@@ -30,6 +30,10 @@ var (
 	SystemStateLabelValue    = "system"
 	IdleStateLabelValue      = "idle"
 	InterruptStateLabelValue = "interrupt"
+	NiceStateLabelValue      = "nice"
+	SoftIRQStateLabelValue   = "softirq"
+	StealStateLabelValue     = "steal"
+	WaitStateLabelValue      = "wait"
 )
 
 var MetricCPUSecondsDescriptor = metricCPUSecondsDescriptor()

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper.go
@@ -114,12 +114,9 @@ func initializeCPUSecondsMetric(metric pdata.Metric, startTime pdata.TimestampUn
 	MetricCPUSecondsDescriptor.CopyTo(metric.MetricDescriptor())
 
 	idps := metric.Int64DataPoints()
-	idps.Resize(4 * len(cpuTimes))
+	idps.Resize(len(cpuTimes) * cpuStatesLen)
 	for i, cpuTime := range cpuTimes {
-		initializeCPUSecondsDataPoint(idps.At(4*i+0), startTime, cpuTime.CPU, UserStateLabelValue, int64(cpuTime.User))
-		initializeCPUSecondsDataPoint(idps.At(4*i+1), startTime, cpuTime.CPU, SystemStateLabelValue, int64(cpuTime.System))
-		initializeCPUSecondsDataPoint(idps.At(4*i+2), startTime, cpuTime.CPU, IdleStateLabelValue, int64(cpuTime.Idle))
-		initializeCPUSecondsDataPoint(idps.At(4*i+3), startTime, cpuTime.CPU, InterruptStateLabelValue, int64(cpuTime.Irq))
+		appendCPUStateTimes(idps, i*cpuStatesLen, startTime, cpuTime)
 	}
 }
 

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_linux.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_linux.go
@@ -1,0 +1,36 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build linux
+
+package cpuscraper
+
+import (
+	"github.com/shirou/gopsutil/cpu"
+
+	"github.com/open-telemetry/opentelemetry-collector/consumer/pdata"
+)
+
+const cpuStatesLen = 8
+
+func appendCPUStateTimes(idps pdata.Int64DataPointSlice, startIdx int, startTime pdata.TimestampUnixNano, cpuTime cpu.TimesStat) {
+	initializeCPUSecondsDataPoint(idps.At(startIdx+0), startTime, cpuTime.CPU, UserStateLabelValue, int64(cpuTime.User))
+	initializeCPUSecondsDataPoint(idps.At(startIdx+1), startTime, cpuTime.CPU, SystemStateLabelValue, int64(cpuTime.System))
+	initializeCPUSecondsDataPoint(idps.At(startIdx+2), startTime, cpuTime.CPU, IdleStateLabelValue, int64(cpuTime.Idle))
+	initializeCPUSecondsDataPoint(idps.At(startIdx+3), startTime, cpuTime.CPU, InterruptStateLabelValue, int64(cpuTime.Irq))
+	initializeCPUSecondsDataPoint(idps.At(startIdx+4), startTime, cpuTime.CPU, NiceStateLabelValue, int64(cpuTime.Nice))
+	initializeCPUSecondsDataPoint(idps.At(startIdx+5), startTime, cpuTime.CPU, SoftIRQStateLabelValue, int64(cpuTime.Softirq))
+	initializeCPUSecondsDataPoint(idps.At(startIdx+6), startTime, cpuTime.CPU, StealStateLabelValue, int64(cpuTime.Steal))
+	initializeCPUSecondsDataPoint(idps.At(startIdx+7), startTime, cpuTime.CPU, WaitStateLabelValue, int64(cpuTime.Iowait))
+}

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_others.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_others.go
@@ -1,0 +1,32 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !linux
+
+package cpuscraper
+
+import (
+	"github.com/shirou/gopsutil/cpu"
+
+	"github.com/open-telemetry/opentelemetry-collector/consumer/pdata"
+)
+
+const cpuStatesLen = 4
+
+func appendCPUStateTimes(idps pdata.Int64DataPointSlice, startIdx int, startTime pdata.TimestampUnixNano, cpuTime cpu.TimesStat) {
+	initializeCPUSecondsDataPoint(idps.At(startIdx+0), startTime, cpuTime.CPU, UserStateLabelValue, int64(cpuTime.User))
+	initializeCPUSecondsDataPoint(idps.At(startIdx+1), startTime, cpuTime.CPU, SystemStateLabelValue, int64(cpuTime.System))
+	initializeCPUSecondsDataPoint(idps.At(startIdx+2), startTime, cpuTime.CPU, IdleStateLabelValue, int64(cpuTime.Idle))
+	initializeCPUSecondsDataPoint(idps.At(startIdx+3), startTime, cpuTime.CPU, InterruptStateLabelValue, int64(cpuTime.Irq))
+}

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/factory.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/factory.go
@@ -16,8 +16,6 @@ package cpuscraper
 
 import (
 	"context"
-	"errors"
-	"runtime"
 
 	"go.uber.org/zap"
 
@@ -55,11 +53,6 @@ func (f *Factory) CreateMetricsScraper(
 	config internal.Config,
 	consumer consumer.MetricsConsumer,
 ) (internal.Scraper, error) {
-	if runtime.GOOS != "windows" {
-		return nil, errors.New("cpu scraper is currently only supported on windows")
-	}
-
 	cfg := config.(*Config)
-
 	return NewCPUScraper(ctx, cfg, consumer)
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/factory_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/factory_test.go
@@ -16,7 +16,6 @@ package cpuscraper
 
 import (
 	"context"
-	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -29,12 +28,6 @@ func TestCreateMetricsScraper(t *testing.T) {
 
 	scraper, err := factory.CreateMetricsScraper(context.Background(), zap.NewNop(), cfg, nil)
 
-	switch os := runtime.GOOS; os {
-	case "windows":
-		assert.Nil(t, err)
-		assert.NotNil(t, scraper)
-	default:
-		assert.NotNil(t, err)
-		assert.Nil(t, scraper)
-	}
+	assert.Nil(t, err)
+	assert.NotNil(t, scraper)
 }


### PR DESCRIPTION
- Include all relevant cpu states for Linux when collecting cpu times data
- Remove windows only restriction from host metrics receiver