### PR TITLE
Remove sjkaris from README's Approvers list

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@ Approvers ([@open-telemetry/collector-approvers](https://github.com/orgs/open-te
 - [Owais Lone](https://github.com/owais), Splunk
 - [Rahul Patel](https://github.com/rghetia), Google
 - [Steve Flanders](https://github.com/flands), Splunk
-- [Steven Karis](https://github.com/sjkaris), Splunk
 - [Yang Song](https://github.com/songy23), Google
 - [Dmitrii Anoshin](https://github.com/dmitryax), Splunk
 


### PR DESCRIPTION
I chatted with sjkaris and he is currently not going to actively
contribute to the Collector so he will not need the "approver" role.
Removing for now and will add back when he decides to contribute
to the Collector again.

Thanks, sjkaris!
