### PR TITLE
Rename Cap to Len for maps

### DIFF
--- a/consumer/pdata/common.go
+++ b/consumer/pdata/common.go
@@ -454,8 +454,11 @@ func (am AttributeMap) Sort() AttributeMap {
 	return am
 }
 
-// Cap returns the capacity of this map.
-func (am AttributeMap) Cap() int {
+// Len returns the length of this map.
+//
+// Because the AttributeMap is represented internally by a slice of pointers, and the data are comping from the wire,
+// it is possible that when iterating using "ForEach" to get access to fewer elements because nil elements are skipped.
+func (am AttributeMap) Len() int {
 	return len(*am.orig)
 }
 
@@ -631,8 +634,11 @@ func (sm StringMap) Upsert(k, v string) {
 	}
 }
 
-// Cap returns the capacity of this map.
-func (sm StringMap) Cap() int {
+// Len returns the length of this map.
+//
+// Because the AttributeMap is represented internally by a slice of pointers, and the data are comping from the wire,
+// it is possible that when iterating using "ForEach" to get access to fewer elements because nil elements are skipped.
+func (sm StringMap) Len() int {
 	return len(*sm.orig)
 }
 

--- a/consumer/pdata/common_test.go
+++ b/consumer/pdata/common_test.go
@@ -70,7 +70,7 @@ func TestNewAttributeValueSlice(t *testing.T) {
 }
 
 func TestNilAttributeMap(t *testing.T) {
-	assert.EqualValues(t, 0, NewAttributeMap().Cap())
+	assert.EqualValues(t, 0, NewAttributeMap().Len())
 
 	val, exist := NewAttributeMap().Get("test_key")
 	assert.False(t, exist)
@@ -298,7 +298,7 @@ func TestAttributeMap_ForEach(t *testing.T) {
 		"k_bool":   NewAttributeValueBool(true),
 	}
 	am := NewAttributeMap().InitFromMap(rawMap)
-	assert.EqualValues(t, 4, am.Cap())
+	assert.EqualValues(t, 4, am.Len())
 
 	am.ForEach(func(k string, v AttributeValue) {
 		assert.True(t, v.Equal(rawMap[k]))
@@ -328,7 +328,7 @@ func TestAttributeMap_ForEach_WithNils(t *testing.T) {
 	am := AttributeMap{
 		orig: &rawOrigWithNil,
 	}
-	assert.EqualValues(t, 9, am.Cap())
+	assert.EqualValues(t, 9, am.Len())
 
 	am.ForEach(func(k string, v AttributeValue) {
 		assert.True(t, v.Equal(rawMap[k]))
@@ -361,7 +361,7 @@ func TestAttributeMap_CopyTo(t *testing.T) {
 	dest := NewAttributeMap()
 	// Test CopyTo to empty
 	NewAttributeMap().CopyTo(dest)
-	assert.EqualValues(t, 0, dest.Cap())
+	assert.EqualValues(t, 0, dest.Len())
 
 	// Test CopyTo larger slice
 	generateTestAttributeMap().CopyTo(dest)
@@ -373,7 +373,7 @@ func TestAttributeMap_CopyTo(t *testing.T) {
 }
 
 func TestNilStringMap(t *testing.T) {
-	assert.EqualValues(t, 0, NewStringMap().Cap())
+	assert.EqualValues(t, 0, NewStringMap().Len())
 
 	val, exist := NewStringMap().Get("test_key")
 	assert.False(t, exist)
@@ -453,7 +453,7 @@ func TestStringMap(t *testing.T) {
 	origRawMap := map[string]string{"k0": "v0", "k1": "v1", "k2": "v2"}
 	origMap := NewStringMap().InitFromMap(origRawMap)
 	sm := NewStringMap().InitFromMap(origRawMap)
-	assert.EqualValues(t, 3, sm.Cap())
+	assert.EqualValues(t, 3, sm.Len())
 
 	val, exist := sm.Get("k2")
 	assert.True(t, exist)
@@ -466,47 +466,47 @@ func TestStringMap(t *testing.T) {
 	sm.Insert("k1", "v1")
 	assert.EqualValues(t, origMap.Sort(), sm.Sort())
 	sm.Insert("k3", "v3")
-	assert.EqualValues(t, 4, sm.Cap())
+	assert.EqualValues(t, 4, sm.Len())
 	assert.EqualValues(t, NewStringMap().InitFromMap(map[string]string{"k0": "v0", "k1": "v1", "k2": "v2", "k3": "v3"}).Sort(), sm.Sort())
 	assert.True(t, sm.Delete("k3"))
-	assert.EqualValues(t, 3, sm.Cap())
+	assert.EqualValues(t, 3, sm.Len())
 	assert.EqualValues(t, origMap.Sort(), sm.Sort())
 
 	sm.Update("k3", "v3")
-	assert.EqualValues(t, 3, sm.Cap())
+	assert.EqualValues(t, 3, sm.Len())
 	assert.EqualValues(t, origMap.Sort(), sm.Sort())
 	sm.Update("k2", "v3")
-	assert.EqualValues(t, 3, sm.Cap())
+	assert.EqualValues(t, 3, sm.Len())
 	assert.EqualValues(t, NewStringMap().InitFromMap(map[string]string{"k0": "v0", "k1": "v1", "k2": "v3"}).Sort(), sm.Sort())
 	sm.Update("k2", "v2")
-	assert.EqualValues(t, 3, sm.Cap())
+	assert.EqualValues(t, 3, sm.Len())
 	assert.EqualValues(t, origMap.Sort(), sm.Sort())
 
 	sm.Upsert("k3", "v3")
-	assert.EqualValues(t, 4, sm.Cap())
+	assert.EqualValues(t, 4, sm.Len())
 	assert.EqualValues(t, NewStringMap().InitFromMap(map[string]string{"k0": "v0", "k1": "v1", "k2": "v2", "k3": "v3"}).Sort(), sm.Sort())
 	sm.Upsert("k1", "v5")
-	assert.EqualValues(t, 4, sm.Cap())
+	assert.EqualValues(t, 4, sm.Len())
 	assert.EqualValues(t, NewStringMap().InitFromMap(map[string]string{"k0": "v0", "k1": "v5", "k2": "v2", "k3": "v3"}).Sort(), sm.Sort())
 	sm.Upsert("k1", "v1")
-	assert.EqualValues(t, 4, sm.Cap())
+	assert.EqualValues(t, 4, sm.Len())
 	assert.EqualValues(t, NewStringMap().InitFromMap(map[string]string{"k0": "v0", "k1": "v1", "k2": "v2", "k3": "v3"}).Sort(), sm.Sort())
 	assert.True(t, sm.Delete("k3"))
-	assert.EqualValues(t, 3, sm.Cap())
+	assert.EqualValues(t, 3, sm.Len())
 	assert.EqualValues(t, origMap.Sort(), sm.Sort())
 
 	assert.EqualValues(t, false, sm.Delete("k3"))
-	assert.EqualValues(t, 3, sm.Cap())
+	assert.EqualValues(t, 3, sm.Len())
 	assert.EqualValues(t, origMap.Sort(), sm.Sort())
 
 	assert.True(t, sm.Delete("k0"))
-	assert.EqualValues(t, 2, sm.Cap())
+	assert.EqualValues(t, 2, sm.Len())
 	assert.EqualValues(t, NewStringMap().InitFromMap(map[string]string{"k1": "v1", "k2": "v2"}).Sort(), sm.Sort())
 	assert.True(t, sm.Delete("k2"))
-	assert.EqualValues(t, 1, sm.Cap())
+	assert.EqualValues(t, 1, sm.Len())
 	assert.EqualValues(t, NewStringMap().InitFromMap(map[string]string{"k1": "v1"}).Sort(), sm.Sort())
 	assert.True(t, sm.Delete("k1"))
-	assert.EqualValues(t, 0, sm.Cap())
+	assert.EqualValues(t, 0, sm.Len())
 }
 
 func TestStringMapIterationNil(t *testing.T) {
@@ -519,7 +519,7 @@ func TestStringMapIterationNil(t *testing.T) {
 func TestStringMap_ForEach(t *testing.T) {
 	rawMap := map[string]string{"k0": "v0", "k1": "v1", "k2": "v2"}
 	sm := NewStringMap().InitFromMap(rawMap)
-	assert.EqualValues(t, 3, sm.Cap())
+	assert.EqualValues(t, 3, sm.Len())
 
 	sm.ForEach(func(k string, v StringValue) {
 		assert.EqualValues(t, rawMap[k], v.Value())
@@ -551,7 +551,7 @@ func TestStringMap_ForEach_WithNils(t *testing.T) {
 	sm := StringMap{
 		orig: &rawOrigWithNil,
 	}
-	assert.EqualValues(t, 7, sm.Cap())
+	assert.EqualValues(t, 7, sm.Len())
 
 	sm.ForEach(func(k string, v StringValue) {
 		assert.EqualValues(t, rawMap[k], v.Value())
@@ -564,7 +564,7 @@ func TestStringMap_CopyTo(t *testing.T) {
 	dest := NewStringMap()
 	// Test CopyTo to empty
 	NewStringMap().CopyTo(dest)
-	assert.EqualValues(t, 0, dest.Cap())
+	assert.EqualValues(t, 0, dest.Len())
 
 	// Test CopyTo larger slice
 	generateTestStringMap().CopyTo(dest)

--- a/exporter/loggingexporter/logging_exporter.go
+++ b/exporter/loggingexporter/logging_exporter.go
@@ -45,7 +45,7 @@ func (b *logDataBuffer) logAttr(label string, value string) {
 }
 
 func (b *logDataBuffer) logAttributeMap(label string, am pdata.AttributeMap) {
-	if am.Cap() == 0 {
+	if am.Len() == 0 {
 		return
 	}
 

--- a/internal/processor/filterspan/filterspan.go
+++ b/internal/processor/filterspan/filterspan.go
@@ -276,7 +276,7 @@ func (ma attributesMatcher) match(span pdata.Span) bool {
 	attrs := span.Attributes()
 	// At this point, it is expected of the span to have attributes because of
 	// len(ma) != 0. This means for spans with no attributes, it does not match.
-	if attrs.Cap() == 0 {
+	if attrs.Len() == 0 {
 		return false
 	}
 

--- a/processor/spanprocessor/span.go
+++ b/processor/spanprocessor/span.go
@@ -144,7 +144,7 @@ func (sp *spanProcessor) processFromAttributes(span pdata.Span) {
 	}
 
 	attrs := span.Attributes()
-	if attrs.Cap() == 0 {
+	if attrs.Len() == 0 {
 		// There are no attributes to create span name from.
 		return
 	}

--- a/testbed/tests/trace_test.go
+++ b/testbed/tests/trace_test.go
@@ -432,7 +432,7 @@ func TestTraceAttributesProcessor(t *testing.T) {
 			// verifySpan verifies that attributes was added to the internal data span.
 			verifySpan := func(span pdata.Span) {
 				require.NotNil(t, span)
-				require.Equal(t, span.Attributes().Cap(), 1)
+				require.Equal(t, span.Attributes().Len(), 1)
 				attrVal, ok := span.Attributes().Get("new_attr")
 				assert.True(t, ok)
 				assert.EqualValues(t, "string value", attrVal.StringVal())
@@ -456,7 +456,7 @@ func TestTraceAttributesProcessor(t *testing.T) {
 
 			verifySingleSpan(t, tc, nodeToExclude, spanToInclude, func(span pdata.Span) {
 				// Verify attributes was not added to the new internal data span.
-				assert.Equal(t, span.Attributes().Cap(), 0)
+				assert.Equal(t, span.Attributes().Len(), 0)
 			}, func(span *tracepb.Span) {
 				// Verify attributes was not added to the OC span.
 				assert.Nil(t, span.Attributes)
@@ -466,7 +466,7 @@ func TestTraceAttributesProcessor(t *testing.T) {
 			spanToExclude := "span-not-to-add-attr"
 			verifySingleSpan(t, tc, nodeToInclude, spanToExclude, func(span pdata.Span) {
 				// Verify attributes was not added to the new internal data span.
-				assert.Equal(t, span.Attributes().Cap(), 0)
+				assert.Equal(t, span.Attributes().Len(), 0)
 			}, func(span *tracepb.Span) {
 				// Verify attributes was not added to the OC span.
 				assert.Nil(t, span.Attributes)

--- a/translator/internaldata/metrics_to_oc.go
+++ b/translator/internaldata/metrics_to_oc.go
@@ -361,7 +361,7 @@ func exemplarToOC(exemplar pdata.HistogramBucketExemplar) *ocmetrics.Distributio
 		return nil
 	}
 	attachments := exemplar.Attachments()
-	if attachments.Cap() == 0 {
+	if attachments.Len() == 0 {
 		return &ocmetrics.DistributionValue_Exemplar{
 			Value:       exemplar.Value(),
 			Timestamp:   internal.UnixNanoToTimestamp(exemplar.Timestamp()),
@@ -369,7 +369,7 @@ func exemplarToOC(exemplar pdata.HistogramBucketExemplar) *ocmetrics.Distributio
 		}
 	}
 
-	labels := make(map[string]string, attachments.Cap())
+	labels := make(map[string]string, attachments.Len())
 	attachments.ForEach(func(k string, v pdata.StringValue) {
 		labels[k] = v.Value()
 	})

--- a/translator/internaldata/resource_to_oc.go
+++ b/translator/internaldata/resource_to_oc.go
@@ -36,11 +36,11 @@ func internalResourceToOC(resource pdata.Resource) (*occommon.Node, *ocresource.
 	ocNode := occommon.Node{}
 	ocResource := ocresource.Resource{}
 
-	if attrs.Cap() == 0 {
+	if attrs.Len() == 0 {
 		return &ocNode, &ocResource
 	}
 
-	labels := make(map[string]string, attrs.Cap())
+	labels := make(map[string]string, attrs.Len())
 	attrs.ForEach(func(k string, v pdata.AttributeValue) {
 		val := attributeValueToString(v)
 

--- a/translator/internaldata/traces_to_oc.go
+++ b/translator/internaldata/traces_to_oc.go
@@ -116,7 +116,7 @@ func spanToOC(span pdata.Span) *octrace.Span {
 }
 
 func attributesMapToOCSpanAttributes(attributes pdata.AttributeMap, droppedCount uint32) *octrace.Span_Attributes {
-	if attributes.Cap() == 0 && droppedCount == 0 {
+	if attributes.Len() == 0 && droppedCount == 0 {
 		return nil
 	}
 
@@ -127,11 +127,11 @@ func attributesMapToOCSpanAttributes(attributes pdata.AttributeMap, droppedCount
 }
 
 func attributesMapToOCAttributeMap(attributes pdata.AttributeMap) map[string]*octrace.AttributeValue {
-	if attributes.Cap() == 0 {
+	if attributes.Len() == 0 {
 		return nil
 	}
 
-	ocAttributes := make(map[string]*octrace.AttributeValue, attributes.Cap())
+	ocAttributes := make(map[string]*octrace.AttributeValue, attributes.Len())
 	attributes.ForEach(func(k string, v pdata.AttributeValue) {
 		ocAttributes[k] = attributeValueToOC(v)
 	})
@@ -287,7 +287,7 @@ func eventToOC(event pdata.SpanEvent) *octrace.Span_TimeEvent {
 		conventions.OCTimeEventMessageEventCSize,
 	}
 	// TODO: Find a better way to check for message_event. Maybe use the event.Name.
-	if attrs.Cap() == len(ocMessageEventAttrs) {
+	if attrs.Len() == len(ocMessageEventAttrs) {
 		ocMessageEventAttrValues := map[string]pdata.AttributeValue{}
 		var ocMessageEventAttrFound bool
 		for _, attr := range ocMessageEventAttrs {

--- a/translator/trace/jaeger/jaegerproto_to_traces.go
+++ b/translator/trace/jaeger/jaegerproto_to_traces.go
@@ -174,7 +174,7 @@ func jSpanToInternal(span *model.Span, dest pdata.Span) {
 	}
 
 	// drop the attributes slice if all of them were replaced during translation
-	if attrs.Cap() == 0 {
+	if attrs.Len() == 0 {
 		attrs.InitFromMap(nil)
 	}
 

--- a/translator/trace/jaeger/jaegerthrift_to_traces.go
+++ b/translator/trace/jaeger/jaegerthrift_to_traces.go
@@ -119,7 +119,7 @@ func jThriftSpanToInternal(span *jaeger.Span, dest pdata.Span) {
 	}
 
 	// drop the attributes slice if all of them were replaced during translation
-	if attrs.Cap() == 0 {
+	if attrs.Len() == 0 {
 		attrs.InitFromMap(nil)
 	}
 

--- a/translator/trace/jaeger/traces_to_jaegerproto.go
+++ b/translator/trace/jaeger/traces_to_jaegerproto.go
@@ -110,7 +110,7 @@ func resourceToJaegerProtoProcess(resource pdata.Resource) *model.Process {
 	}
 
 	attrs := resource.Attributes()
-	if attrs.Cap() == 0 {
+	if attrs.Len() == 0 {
 		return nil
 	}
 
@@ -124,11 +124,11 @@ func resourceToJaegerProtoProcess(resource pdata.Resource) *model.Process {
 }
 
 func resourceAttributesToJaegerProtoTags(attrs pdata.AttributeMap) []model.KeyValue {
-	if attrs.Cap() == 0 {
+	if attrs.Len() == 0 {
 		return nil
 	}
 
-	tags := make([]model.KeyValue, 0, attrs.Cap())
+	tags := make([]model.KeyValue, 0, attrs.Len())
 	attrs.ForEach(func(key string, attr pdata.AttributeValue) {
 		if key == conventions.AttributeServiceName {
 			return
@@ -139,11 +139,11 @@ func resourceAttributesToJaegerProtoTags(attrs pdata.AttributeMap) []model.KeyVa
 }
 
 func attributesToJaegerProtoTags(attrs pdata.AttributeMap) []model.KeyValue {
-	if attrs.Cap() == 0 {
+	if attrs.Len() == 0 {
 		return nil
 	}
 
-	tags := make([]model.KeyValue, 0, attrs.Cap())
+	tags := make([]model.KeyValue, 0, attrs.Len())
 	attrs.ForEach(func(key string, attr pdata.AttributeValue) {
 		tags = append(tags, attributeToJaegerProtoTag(key, attr))
 	})


### PR DESCRIPTION
I found that `Cap` is very strange when used in practice, for example #906. I would propose to use `Len` and comment the caveat that when iterating fewer elements may be available.