### PR TITLE
Initial commit of host metrics memory scraper

### DIFF
--- a/receiver/hostmetricsreceiver/example_config.yaml
+++ b/receiver/hostmetricsreceiver/example_config.yaml
@@ -8,6 +8,7 @@ receivers:
     scrapers:
       cpu:
         report_per_cpu: true
+      memory:
 
 exporters:
   logging:

--- a/receiver/hostmetricsreceiver/factory.go
+++ b/receiver/hostmetricsreceiver/factory.go
@@ -28,6 +28,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector/consumer"
 	"github.com/open-telemetry/opentelemetry-collector/receiver/hostmetricsreceiver/internal"
 	"github.com/open-telemetry/opentelemetry-collector/receiver/hostmetricsreceiver/internal/scraper/cpuscraper"
+	"github.com/open-telemetry/opentelemetry-collector/receiver/hostmetricsreceiver/internal/scraper/memoryscraper"
 )
 
 // This file implements Factory for HostMetrics receiver.
@@ -47,7 +48,8 @@ type Factory struct {
 func NewFactory() *Factory {
 	return &Factory{
 		scraperFactories: map[string]internal.Factory{
-			cpuscraper.TypeStr: &cpuscraper.Factory{},
+			cpuscraper.TypeStr:    &cpuscraper.Factory{},
+			memoryscraper.TypeStr: &memoryscraper.Factory{},
 		},
 	}
 }

--- a/receiver/hostmetricsreceiver/hostmetrics_receiver.go
+++ b/receiver/hostmetricsreceiver/hostmetrics_receiver.go
@@ -43,7 +43,12 @@ func NewHostMetricsReceiver(
 
 	scrapers := make([]internal.Scraper, 0)
 	for key, cfg := range config.Scrapers {
-		scraper, err := factories[key].CreateMetricsScraper(ctx, logger, cfg, consumer)
+		factory := factories[key]
+		if factory == nil {
+			return nil, fmt.Errorf("host metrics scraper factory not found for key: %s", key)
+		}
+
+		scraper, err := factory.CreateMetricsScraper(ctx, logger, cfg, consumer)
 		if err != nil {
 			return nil, fmt.Errorf("cannot create scraper: %s", err.Error())
 		}

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/config.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/config.go
@@ -1,0 +1,22 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package memoryscraper
+
+import "github.com/open-telemetry/opentelemetry-collector/receiver/hostmetricsreceiver/internal"
+
+// Config relating to Memory Metric Scraper.
+type Config struct {
+	internal.ConfigSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
+}

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/factory.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/factory.go
@@ -1,0 +1,56 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package memoryscraper
+
+import (
+	"context"
+
+	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector/consumer"
+	"github.com/open-telemetry/opentelemetry-collector/receiver/hostmetricsreceiver/internal"
+)
+
+// This file implements Factory for Memory scraper.
+
+const (
+	// The value of "type" key in configuration.
+	TypeStr = "memory"
+)
+
+// Factory is the Factory for scraper.
+type Factory struct {
+}
+
+// Type gets the type of the scraper config created by this Factory.
+func (f *Factory) Type() string {
+	return TypeStr
+}
+
+// CreateDefaultConfig creates the default configuration for the Scraper.
+func (f *Factory) CreateDefaultConfig() internal.Config {
+	return &Config{}
+}
+
+// CreateMetricsScraper creates a scraper based on provided config.
+func (f *Factory) CreateMetricsScraper(
+	ctx context.Context,
+	logger *zap.Logger,
+	config internal.Config,
+	consumer consumer.MetricsConsumer,
+) (internal.Scraper, error) {
+	cfg := config.(*Config)
+	return NewMemoryScraper(ctx, cfg, consumer)
+}

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/factory_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/factory_test.go
@@ -1,0 +1,33 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package memoryscraper
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+)
+
+func TestCreateMetricsScraper(t *testing.T) {
+	factory := &Factory{}
+	cfg := &Config{}
+
+	scraper, err := factory.CreateMetricsScraper(context.Background(), zap.NewNop(), cfg, nil)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, scraper)
+}

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/memory_constants.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/memory_constants.go
@@ -1,0 +1,44 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package memoryscraper
+
+import (
+	"github.com/open-telemetry/opentelemetry-collector/consumer/pdata"
+)
+
+// memory metric constants
+
+const stateLabelName = "state"
+
+const (
+	usedStateLabelValue              = "used"
+	bufferedStateLabelValue          = "buffered"
+	cachedStateLabelValue            = "cached"
+	freeStateLabelValue              = "free"
+	slabReclaimableStateLabelValue   = "slab_reclaimable"
+	slabUnreclaimableStateLabelValue = "slab_unreclaimable"
+)
+
+var metricMemoryUsedDescriptor = createMetricMemoryUsedDescriptor()
+
+func createMetricMemoryUsedDescriptor() pdata.MetricDescriptor {
+	descriptor := pdata.NewMetricDescriptor()
+	descriptor.InitEmpty()
+	descriptor.SetName("host/memory/used")
+	descriptor.SetDescription("Bytes of memory in use.")
+	descriptor.SetUnit("bytes")
+	descriptor.SetType(pdata.MetricTypeGaugeInt64)
+	return descriptor
+}

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/memory_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/memory_scraper.go
@@ -1,0 +1,117 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package memoryscraper
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/shirou/gopsutil/mem"
+	"go.opencensus.io/trace"
+
+	"github.com/open-telemetry/opentelemetry-collector/consumer"
+	"github.com/open-telemetry/opentelemetry-collector/consumer/pdata"
+	"github.com/open-telemetry/opentelemetry-collector/consumer/pdatautil"
+	"github.com/open-telemetry/opentelemetry-collector/internal/data"
+	"github.com/open-telemetry/opentelemetry-collector/receiver/hostmetricsreceiver/internal"
+)
+
+// Scraper for Memory Metrics
+type Scraper struct {
+	config   *Config
+	consumer consumer.MetricsConsumer
+	cancel   context.CancelFunc
+}
+
+// NewMemoryScraper creates a set of Memory related metrics
+func NewMemoryScraper(ctx context.Context, cfg *Config, consumer consumer.MetricsConsumer) (*Scraper, error) {
+	return &Scraper{config: cfg, consumer: consumer}, nil
+}
+
+// Start
+func (c *Scraper) Start(ctx context.Context) error {
+	ctx, c.cancel = context.WithCancel(ctx)
+
+	go func() {
+		ticker := time.NewTicker(c.config.CollectionInterval())
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ticker.C:
+				c.scrapeMetrics(ctx)
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	return nil
+}
+
+// Close
+func (c *Scraper) Close(ctx context.Context) error {
+	c.cancel()
+	return nil
+}
+
+func (c *Scraper) scrapeMetrics(ctx context.Context) {
+	ctx, span := trace.StartSpan(ctx, "memoryscraper.scrapeMetrics")
+	defer span.End()
+
+	metricData := data.NewMetricData()
+	metrics := internal.InitializeMetricSlice(metricData)
+
+	err := c.scrapeAndAppendMetrics(metrics)
+	if err != nil {
+		span.SetStatus(trace.Status{Code: trace.StatusCodeDataLoss, Message: fmt.Sprintf("Error(s) when scraping memory metrics: %v", err)})
+		return
+	}
+
+	if metrics.Len() > 0 {
+		err := c.consumer.ConsumeMetrics(ctx, pdatautil.MetricsFromInternalMetrics(metricData))
+		if err != nil {
+			span.SetStatus(trace.Status{Code: trace.StatusCodeDataLoss, Message: fmt.Sprintf("Unable to process metrics: %v", err)})
+			return
+		}
+	}
+}
+
+func (c *Scraper) scrapeAndAppendMetrics(metrics pdata.MetricSlice) error {
+	memInfo, err := mem.VirtualMemory()
+	if err != nil {
+		return err
+	}
+
+	metric := internal.AddNewMetric(metrics)
+	initializeMetricUsedMemoryFrom(memInfo, metric)
+	return nil
+}
+
+func initializeMetricUsedMemoryFrom(memInfo *mem.VirtualMemoryStat, metric pdata.Metric) {
+	metricMemoryUsedDescriptor.CopyTo(metric.MetricDescriptor())
+
+	idps := metric.Int64DataPoints()
+	idps.Resize(memStatesLen)
+	appendMemoryUsedStates(idps, memInfo)
+}
+
+func initializeMemoryUsedDataPoint(dataPoint pdata.Int64DataPoint, stateLabel string, value int64) {
+	labelsMap := dataPoint.LabelsMap()
+	labelsMap.Insert(stateLabelName, stateLabel)
+	dataPoint.SetTimestamp(pdata.TimestampUnixNano(uint64(time.Now().UnixNano())))
+	dataPoint.SetValue(value)
+}

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/memory_scraper_linux.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/memory_scraper_linux.go
@@ -1,0 +1,34 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build linux
+
+package memoryscraper
+
+import (
+	"github.com/shirou/gopsutil/mem"
+
+	"github.com/open-telemetry/opentelemetry-collector/consumer/pdata"
+)
+
+const memStatesLen = 6
+
+func appendMemoryUsedStates(idps pdata.Int64DataPointSlice, memInfo *mem.VirtualMemoryStat) {
+	initializeMemoryUsedDataPoint(idps.At(0), usedStateLabelValue, int64(memInfo.Used))
+	initializeMemoryUsedDataPoint(idps.At(1), freeStateLabelValue, int64(memInfo.Free))
+	initializeMemoryUsedDataPoint(idps.At(2), bufferedStateLabelValue, int64(memInfo.Buffers))
+	initializeMemoryUsedDataPoint(idps.At(3), cachedStateLabelValue, int64(memInfo.Cached))
+	initializeMemoryUsedDataPoint(idps.At(4), slabReclaimableStateLabelValue, int64(memInfo.SReclaimable))
+	initializeMemoryUsedDataPoint(idps.At(5), slabUnreclaimableStateLabelValue, int64(memInfo.SUnreclaim))
+}

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/memory_scraper_others.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/memory_scraper_others.go
@@ -1,0 +1,32 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !linux
+
+package memoryscraper
+
+import (
+	"github.com/shirou/gopsutil/mem"
+
+	"github.com/open-telemetry/opentelemetry-collector/consumer/pdata"
+)
+
+const availableStateLabelValue = "available"
+
+const memStatesLen = 2
+
+func appendMemoryUsedStates(idps pdata.Int64DataPointSlice, memInfo *mem.VirtualMemoryStat) {
+	initializeMemoryUsedDataPoint(idps.At(0), usedStateLabelValue, int64(memInfo.Used))
+	initializeMemoryUsedDataPoint(idps.At(1), availableStateLabelValue, int64(memInfo.Available))
+}

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/memory_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/memory_scraper_test.go
@@ -1,0 +1,90 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package memoryscraper
+
+import (
+	"context"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-telemetry/opentelemetry-collector/consumer/pdata"
+	"github.com/open-telemetry/opentelemetry-collector/exporter/exportertest"
+	"github.com/open-telemetry/opentelemetry-collector/receiver/hostmetricsreceiver/internal"
+)
+
+type validationFn func(*testing.T, []pdata.Metrics)
+
+func TestScrapeMetrics(t *testing.T) {
+	createScraperAndValidateScrapedMetrics(t, &Config{}, func(t *testing.T, got []pdata.Metrics) {
+		metrics := internal.AssertSingleMetricDataAndGetMetricsSlice(t, got)
+
+		// expect 1 metric
+		assert.Equal(t, 1, metrics.Len())
+
+		// for memory used metric, expect a datapoint for each state label, including at least 2 states, one of which is 'Used'
+		hostMemoryUsedMetric := metrics.At(0)
+		internal.AssertDescriptorEqual(t, metricMemoryUsedDescriptor, hostMemoryUsedMetric.MetricDescriptor())
+		assert.GreaterOrEqual(t, hostMemoryUsedMetric.Int64DataPoints().Len(), 2)
+		internal.AssertInt64MetricLabelHasValue(t, hostMemoryUsedMetric, 0, stateLabelName, usedStateLabelValue)
+	})
+}
+
+func TestScrapeMetrics_Linux(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		return
+	}
+
+	createScraperAndValidateScrapedMetrics(t, &Config{}, func(t *testing.T, got []pdata.Metrics) {
+		metrics := internal.AssertSingleMetricDataAndGetMetricsSlice(t, got)
+
+		// for memory used metric, expect a datapoint for all 6 state labels
+		hostMemoryUsedMetric := metrics.At(0)
+		internal.AssertDescriptorEqual(t, metricMemoryUsedDescriptor, hostMemoryUsedMetric.MetricDescriptor())
+		assert.Equal(t, 6, hostMemoryUsedMetric.Int64DataPoints().Len())
+		internal.AssertInt64MetricLabelHasValue(t, hostMemoryUsedMetric, 0, stateLabelName, usedStateLabelValue)
+		internal.AssertInt64MetricLabelHasValue(t, hostMemoryUsedMetric, 1, stateLabelName, freeStateLabelValue)
+		internal.AssertInt64MetricLabelHasValue(t, hostMemoryUsedMetric, 2, stateLabelName, bufferedStateLabelValue)
+		internal.AssertInt64MetricLabelHasValue(t, hostMemoryUsedMetric, 3, stateLabelName, cachedStateLabelValue)
+		internal.AssertInt64MetricLabelHasValue(t, hostMemoryUsedMetric, 4, stateLabelName, slabReclaimableStateLabelValue)
+		internal.AssertInt64MetricLabelHasValue(t, hostMemoryUsedMetric, 5, stateLabelName, slabUnreclaimableStateLabelValue)
+	})
+}
+
+func createScraperAndValidateScrapedMetrics(t *testing.T, config *Config, assertFn validationFn) {
+	config.SetCollectionInterval(5 * time.Millisecond)
+
+	sink := &exportertest.SinkMetricsExporter{}
+
+	scraper, err := NewMemoryScraper(context.Background(), config, sink)
+	require.NoError(t, err, "Failed to create memory scraper: %v", err)
+
+	err = scraper.Start(context.Background())
+	require.NoError(t, err, "Failed to start memory scraper: %v", err)
+	defer func() { assert.NoError(t, scraper.Close(context.Background())) }()
+
+	require.Eventually(t, func() bool {
+		got := sink.AllMetrics()
+		if len(got) == 0 {
+			return false
+		}
+
+		assertFn(t, got)
+		return true
+	}, time.Second, 2*time.Millisecond, "No metrics were collected")
+}

--- a/receiver/hostmetricsreceiver/internal/testutils.go
+++ b/receiver/hostmetricsreceiver/internal/testutils.go
@@ -26,7 +26,11 @@ import (
 func AssertSingleMetricDataAndGetMetricsSlice(t *testing.T, metrics []pdata.Metrics) pdata.MetricSlice {
 	// expect 1 MetricData object
 	assert.Equal(t, 1, len(metrics))
-	md := pdatautil.MetricsToInternalMetrics(metrics[0])
+	return AssertMetricDataAndGetMetricsSlice(t, metrics[0])
+}
+
+func AssertMetricDataAndGetMetricsSlice(t *testing.T, metrics pdata.Metrics) pdata.MetricSlice {
+	md := pdatautil.MetricsToInternalMetrics(metrics)
 
 	// expect 1 ResourceMetrics object
 	rms := md.ResourceMetrics()


### PR DESCRIPTION
**Link to tracking Issue:**
https://github.com/open-telemetry/opentelemetry-collector/issues/847

**Description:**
Added memory scraper to the hostmetricsreceiver which uses gopsutil to collect memory used metric.

**Exported Metric on Windows:**
![image](https://user-images.githubusercontent.com/568630/80930338-4d811d80-8df6-11ea-847e-32e1af359ef7.png)
