### PR TITLE
Remove code targeting Unix in tests

### DIFF
--- a/config/configgrpc/configgrpc_test.go
+++ b/config/configgrpc/configgrpc_test.go
@@ -19,7 +19,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/sys/unix"
 )
 
 func TestBasicGrpcSettings(t *testing.T) {
@@ -49,7 +48,11 @@ func TestInvalidPemFile(t *testing.T) {
 		KeepaliveParameters: nil,
 	})
 
-	assert.Equal(t, err, &os.PathError{Op: "open", Path: "/doesnt/exist", Err: unix.ENOENT})
+	// don't validate the specific error code as this differs on windows/unix
+	pathErr := err.(*os.PathError)
+	assert.Equal(t, pathErr.Op, "open")
+	assert.Equal(t, pathErr.Path, "/doesnt/exist")
+	assert.NotNil(t, pathErr.Err)
 }
 
 func TestUseSecure(t *testing.T) {

--- a/receiver/securereceiverconfig_test.go
+++ b/receiver/securereceiverconfig_test.go
@@ -17,10 +17,10 @@ package receiver
 import (
 	"os"
 	"path"
+	"syscall"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/sys/unix"
 )
 
 func TestToGrpcServerOption(t *testing.T) {
@@ -38,7 +38,7 @@ func TestToGrpcServerOption(t *testing.T) {
 			err: &os.PathError{
 				Op:   "open",
 				Path: "/badpath",
-				Err:  unix.ENOENT,
+				Err:  syscall.ENOENT,
 			},
 		},
 		{
@@ -49,7 +49,7 @@ func TestToGrpcServerOption(t *testing.T) {
 			err: &os.PathError{
 				Op:   "open",
 				Path: "/badpath",
-				Err:  unix.ENOENT,
+				Err:  syscall.ENOENT,
 			},
 		},
 		{


### PR DESCRIPTION
**Link to tracking Issue:**
https://github.com/open-telemetry/opentelemetry-collector/issues/854

**Description:**
Updated a couple of tests that targeted `unix` specific code to use the `syscall` package instead so they work regardless of the platform. Note there are still a number of tests that fail on windows, but these two were particularly frustrating as they caused build failures (of the test code) which affected some linting commands. See the linked issue for more details.