### PR TITLE
Minor cleanup to Host Metrics receiver

### DIFF
--- a/receiver/hostmetricsreceiver/internal/scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper.go
@@ -38,9 +38,6 @@ type Scraper interface {
 
 // Factory can create a Scraper.
 type Factory interface {
-	// Type gets the type of the scraper created by this factory.
-	Type() string
-
 	// CreateDefaultConfig creates the default configuration for the Scraper.
 	CreateDefaultConfig() Config
 

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_constants.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_constants.go
@@ -20,25 +20,25 @@ import (
 
 // cpu metric constants
 
-var (
-	StateLabel = "state"
-	CPULabel   = "cpu"
+const (
+	stateLabelName = "state"
+	cpuLabelName   = "cpu"
 )
 
-var (
-	UserStateLabelValue      = "user"
-	SystemStateLabelValue    = "system"
-	IdleStateLabelValue      = "idle"
-	InterruptStateLabelValue = "interrupt"
-	NiceStateLabelValue      = "nice"
-	SoftIRQStateLabelValue   = "softirq"
-	StealStateLabelValue     = "steal"
-	WaitStateLabelValue      = "wait"
+const (
+	userStateLabelValue      = "user"
+	systemStateLabelValue    = "system"
+	idleStateLabelValue      = "idle"
+	interruptStateLabelValue = "interrupt"
+	niceStateLabelValue      = "nice"
+	softIRQStateLabelValue   = "softirq"
+	stealStateLabelValue     = "steal"
+	waitStateLabelValue      = "wait"
 )
 
-var MetricCPUSecondsDescriptor = metricCPUSecondsDescriptor()
+var metricCPUSecondsDescriptor = createMetricCPUSecondsDescriptor()
 
-func metricCPUSecondsDescriptor() pdata.MetricDescriptor {
+func createMetricCPUSecondsDescriptor() pdata.MetricDescriptor {
 	descriptor := pdata.NewMetricDescriptor()
 	descriptor.InitEmpty()
 	descriptor.SetName("host/cpu/time")

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper.go
@@ -111,7 +111,7 @@ func (c *Scraper) scrapeAndAppendMetrics(metrics pdata.MetricSlice) error {
 }
 
 func initializeCPUSecondsMetric(metric pdata.Metric, startTime pdata.TimestampUnixNano, cpuTimes []cpu.TimesStat) {
-	MetricCPUSecondsDescriptor.CopyTo(metric.MetricDescriptor())
+	metricCPUSecondsDescriptor.CopyTo(metric.MetricDescriptor())
 
 	idps := metric.Int64DataPoints()
 	idps.Resize(len(cpuTimes) * cpuStatesLen)
@@ -126,9 +126,9 @@ func initializeCPUSecondsDataPoint(dataPoint pdata.Int64DataPoint, startTime pda
 	labelsMap := dataPoint.LabelsMap()
 	// ignore cpu label if reporting "total" cpu usage
 	if cpuLabel != gopsCPUTotal {
-		labelsMap.Insert(CPULabel, cpuLabel)
+		labelsMap.Insert(cpuLabelName, cpuLabel)
 	}
-	labelsMap.Insert(StateLabel, stateLabel)
+	labelsMap.Insert(stateLabelName, stateLabel)
 
 	dataPoint.SetStartTime(startTime)
 	dataPoint.SetTimestamp(pdata.TimestampUnixNano(uint64(time.Now().UnixNano())))

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_linux.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_linux.go
@@ -25,12 +25,12 @@ import (
 const cpuStatesLen = 8
 
 func appendCPUStateTimes(idps pdata.Int64DataPointSlice, startIdx int, startTime pdata.TimestampUnixNano, cpuTime cpu.TimesStat) {
-	initializeCPUSecondsDataPoint(idps.At(startIdx+0), startTime, cpuTime.CPU, UserStateLabelValue, int64(cpuTime.User))
-	initializeCPUSecondsDataPoint(idps.At(startIdx+1), startTime, cpuTime.CPU, SystemStateLabelValue, int64(cpuTime.System))
-	initializeCPUSecondsDataPoint(idps.At(startIdx+2), startTime, cpuTime.CPU, IdleStateLabelValue, int64(cpuTime.Idle))
-	initializeCPUSecondsDataPoint(idps.At(startIdx+3), startTime, cpuTime.CPU, InterruptStateLabelValue, int64(cpuTime.Irq))
-	initializeCPUSecondsDataPoint(idps.At(startIdx+4), startTime, cpuTime.CPU, NiceStateLabelValue, int64(cpuTime.Nice))
-	initializeCPUSecondsDataPoint(idps.At(startIdx+5), startTime, cpuTime.CPU, SoftIRQStateLabelValue, int64(cpuTime.Softirq))
-	initializeCPUSecondsDataPoint(idps.At(startIdx+6), startTime, cpuTime.CPU, StealStateLabelValue, int64(cpuTime.Steal))
-	initializeCPUSecondsDataPoint(idps.At(startIdx+7), startTime, cpuTime.CPU, WaitStateLabelValue, int64(cpuTime.Iowait))
+	initializeCPUSecondsDataPoint(idps.At(startIdx+0), startTime, cpuTime.CPU, userStateLabelValue, int64(cpuTime.User))
+	initializeCPUSecondsDataPoint(idps.At(startIdx+1), startTime, cpuTime.CPU, systemStateLabelValue, int64(cpuTime.System))
+	initializeCPUSecondsDataPoint(idps.At(startIdx+2), startTime, cpuTime.CPU, idleStateLabelValue, int64(cpuTime.Idle))
+	initializeCPUSecondsDataPoint(idps.At(startIdx+3), startTime, cpuTime.CPU, interruptStateLabelValue, int64(cpuTime.Irq))
+	initializeCPUSecondsDataPoint(idps.At(startIdx+4), startTime, cpuTime.CPU, niceStateLabelValue, int64(cpuTime.Nice))
+	initializeCPUSecondsDataPoint(idps.At(startIdx+5), startTime, cpuTime.CPU, softIRQStateLabelValue, int64(cpuTime.Softirq))
+	initializeCPUSecondsDataPoint(idps.At(startIdx+6), startTime, cpuTime.CPU, stealStateLabelValue, int64(cpuTime.Steal))
+	initializeCPUSecondsDataPoint(idps.At(startIdx+7), startTime, cpuTime.CPU, waitStateLabelValue, int64(cpuTime.Iowait))
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_others.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_others.go
@@ -25,8 +25,8 @@ import (
 const cpuStatesLen = 4
 
 func appendCPUStateTimes(idps pdata.Int64DataPointSlice, startIdx int, startTime pdata.TimestampUnixNano, cpuTime cpu.TimesStat) {
-	initializeCPUSecondsDataPoint(idps.At(startIdx+0), startTime, cpuTime.CPU, UserStateLabelValue, int64(cpuTime.User))
-	initializeCPUSecondsDataPoint(idps.At(startIdx+1), startTime, cpuTime.CPU, SystemStateLabelValue, int64(cpuTime.System))
-	initializeCPUSecondsDataPoint(idps.At(startIdx+2), startTime, cpuTime.CPU, IdleStateLabelValue, int64(cpuTime.Idle))
-	initializeCPUSecondsDataPoint(idps.At(startIdx+3), startTime, cpuTime.CPU, InterruptStateLabelValue, int64(cpuTime.Irq))
+	initializeCPUSecondsDataPoint(idps.At(startIdx+0), startTime, cpuTime.CPU, userStateLabelValue, int64(cpuTime.User))
+	initializeCPUSecondsDataPoint(idps.At(startIdx+1), startTime, cpuTime.CPU, systemStateLabelValue, int64(cpuTime.System))
+	initializeCPUSecondsDataPoint(idps.At(startIdx+2), startTime, cpuTime.CPU, idleStateLabelValue, int64(cpuTime.Idle))
+	initializeCPUSecondsDataPoint(idps.At(startIdx+3), startTime, cpuTime.CPU, interruptStateLabelValue, int64(cpuTime.Irq))
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_test.go
@@ -39,13 +39,13 @@ func TestScrapeMetrics_MinimalData(t *testing.T) {
 
 		// for cpu seconds metric, expect a datapoint for each state label, including at least 4 standard states
 		hostCPUTimeMetric := metrics.At(0)
-		internal.AssertDescriptorEqual(t, MetricCPUSecondsDescriptor, hostCPUTimeMetric.MetricDescriptor())
+		internal.AssertDescriptorEqual(t, metricCPUSecondsDescriptor, hostCPUTimeMetric.MetricDescriptor())
 		assert.GreaterOrEqual(t, hostCPUTimeMetric.Int64DataPoints().Len(), 4)
-		internal.AssertInt64MetricLabelDoesNotExist(t, hostCPUTimeMetric, 0, CPULabel)
-		internal.AssertInt64MetricLabelHasValue(t, hostCPUTimeMetric, 0, StateLabel, UserStateLabelValue)
-		internal.AssertInt64MetricLabelHasValue(t, hostCPUTimeMetric, 1, StateLabel, SystemStateLabelValue)
-		internal.AssertInt64MetricLabelHasValue(t, hostCPUTimeMetric, 2, StateLabel, IdleStateLabelValue)
-		internal.AssertInt64MetricLabelHasValue(t, hostCPUTimeMetric, 3, StateLabel, InterruptStateLabelValue)
+		internal.AssertInt64MetricLabelDoesNotExist(t, hostCPUTimeMetric, 0, cpuLabelName)
+		internal.AssertInt64MetricLabelHasValue(t, hostCPUTimeMetric, 0, stateLabelName, userStateLabelValue)
+		internal.AssertInt64MetricLabelHasValue(t, hostCPUTimeMetric, 1, stateLabelName, systemStateLabelValue)
+		internal.AssertInt64MetricLabelHasValue(t, hostCPUTimeMetric, 2, stateLabelName, idleStateLabelValue)
+		internal.AssertInt64MetricLabelHasValue(t, hostCPUTimeMetric, 3, stateLabelName, interruptStateLabelValue)
 	})
 }
 
@@ -62,13 +62,13 @@ func TestScrapeMetrics_AllData(t *testing.T) {
 
 		// for cpu seconds metric, expect a datapoint for each state label & core combination with at least 4 standard states
 		hostCPUTimeMetric := metrics.At(0)
-		internal.AssertDescriptorEqual(t, MetricCPUSecondsDescriptor, hostCPUTimeMetric.MetricDescriptor())
+		internal.AssertDescriptorEqual(t, metricCPUSecondsDescriptor, hostCPUTimeMetric.MetricDescriptor())
 		assert.GreaterOrEqual(t, hostCPUTimeMetric.Int64DataPoints().Len(), runtime.NumCPU()*4)
-		internal.AssertInt64MetricLabelExists(t, hostCPUTimeMetric, 0, CPULabel)
-		internal.AssertInt64MetricLabelHasValue(t, hostCPUTimeMetric, 0, StateLabel, UserStateLabelValue)
-		internal.AssertInt64MetricLabelHasValue(t, hostCPUTimeMetric, 1, StateLabel, SystemStateLabelValue)
-		internal.AssertInt64MetricLabelHasValue(t, hostCPUTimeMetric, 2, StateLabel, IdleStateLabelValue)
-		internal.AssertInt64MetricLabelHasValue(t, hostCPUTimeMetric, 3, StateLabel, InterruptStateLabelValue)
+		internal.AssertInt64MetricLabelExists(t, hostCPUTimeMetric, 0, cpuLabelName)
+		internal.AssertInt64MetricLabelHasValue(t, hostCPUTimeMetric, 0, stateLabelName, userStateLabelValue)
+		internal.AssertInt64MetricLabelHasValue(t, hostCPUTimeMetric, 1, stateLabelName, systemStateLabelValue)
+		internal.AssertInt64MetricLabelHasValue(t, hostCPUTimeMetric, 2, stateLabelName, idleStateLabelValue)
+		internal.AssertInt64MetricLabelHasValue(t, hostCPUTimeMetric, 3, stateLabelName, interruptStateLabelValue)
 	})
 }
 
@@ -82,17 +82,17 @@ func TestScrapeMetrics_Linux(t *testing.T) {
 
 		// for cpu seconds metric, expect a datapoint for all 8 state labels
 		hostCPUTimeMetric := metrics.At(0)
-		internal.AssertDescriptorEqual(t, MetricCPUSecondsDescriptor, hostCPUTimeMetric.MetricDescriptor())
+		internal.AssertDescriptorEqual(t, metricCPUSecondsDescriptor, hostCPUTimeMetric.MetricDescriptor())
 		assert.Equal(t, 8, hostCPUTimeMetric.Int64DataPoints().Len())
-		internal.AssertInt64MetricLabelDoesNotExist(t, hostCPUTimeMetric, 0, CPULabel)
-		internal.AssertInt64MetricLabelHasValue(t, hostCPUTimeMetric, 0, StateLabel, UserStateLabelValue)
-		internal.AssertInt64MetricLabelHasValue(t, hostCPUTimeMetric, 1, StateLabel, SystemStateLabelValue)
-		internal.AssertInt64MetricLabelHasValue(t, hostCPUTimeMetric, 2, StateLabel, IdleStateLabelValue)
-		internal.AssertInt64MetricLabelHasValue(t, hostCPUTimeMetric, 3, StateLabel, InterruptStateLabelValue)
-		internal.AssertInt64MetricLabelHasValue(t, hostCPUTimeMetric, 4, StateLabel, NiceStateLabelValue)
-		internal.AssertInt64MetricLabelHasValue(t, hostCPUTimeMetric, 5, StateLabel, SoftIRQStateLabelValue)
-		internal.AssertInt64MetricLabelHasValue(t, hostCPUTimeMetric, 6, StateLabel, StealStateLabelValue)
-		internal.AssertInt64MetricLabelHasValue(t, hostCPUTimeMetric, 7, StateLabel, WaitStateLabelValue)
+		internal.AssertInt64MetricLabelDoesNotExist(t, hostCPUTimeMetric, 0, cpuLabelName)
+		internal.AssertInt64MetricLabelHasValue(t, hostCPUTimeMetric, 0, stateLabelName, userStateLabelValue)
+		internal.AssertInt64MetricLabelHasValue(t, hostCPUTimeMetric, 1, stateLabelName, systemStateLabelValue)
+		internal.AssertInt64MetricLabelHasValue(t, hostCPUTimeMetric, 2, stateLabelName, idleStateLabelValue)
+		internal.AssertInt64MetricLabelHasValue(t, hostCPUTimeMetric, 3, stateLabelName, interruptStateLabelValue)
+		internal.AssertInt64MetricLabelHasValue(t, hostCPUTimeMetric, 4, stateLabelName, niceStateLabelValue)
+		internal.AssertInt64MetricLabelHasValue(t, hostCPUTimeMetric, 5, stateLabelName, softIRQStateLabelValue)
+		internal.AssertInt64MetricLabelHasValue(t, hostCPUTimeMetric, 6, stateLabelName, stealStateLabelValue)
+		internal.AssertInt64MetricLabelHasValue(t, hostCPUTimeMetric, 7, stateLabelName, waitStateLabelValue)
 	})
 }
 

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/factory.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/factory.go
@@ -34,11 +34,6 @@ const (
 type Factory struct {
 }
 
-// Type gets the type of the scraper config created by this Factory.
-func (f *Factory) Type() string {
-	return TypeStr
-}
-
 // CreateDefaultConfig creates the default configuration for the Scraper.
 func (f *Factory) CreateDefaultConfig() internal.Config {
 	return &Config{

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/factory.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/factory.go
@@ -34,11 +34,6 @@ const (
 type Factory struct {
 }
 
-// Type gets the type of the scraper config created by this Factory.
-func (f *Factory) Type() string {
-	return TypeStr
-}
-
 // CreateDefaultConfig creates the default configuration for the Scraper.
 func (f *Factory) CreateDefaultConfig() internal.Config {
 	return &Config{}


### PR DESCRIPTION
Minor cleanup:

- Removed unused `Type()` function
- Const label values don't need to be exported anymore