### PR TITLE
Initial commit of host metrics disk scraper

### DIFF
--- a/receiver/hostmetricsreceiver/example_config.yaml
+++ b/receiver/hostmetricsreceiver/example_config.yaml
@@ -9,6 +9,7 @@ receivers:
       cpu:
         report_per_cpu: true
       memory:
+      disk:
 
 exporters:
   logging:

--- a/receiver/hostmetricsreceiver/factory.go
+++ b/receiver/hostmetricsreceiver/factory.go
@@ -28,6 +28,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector/consumer"
 	"github.com/open-telemetry/opentelemetry-collector/receiver/hostmetricsreceiver/internal"
 	"github.com/open-telemetry/opentelemetry-collector/receiver/hostmetricsreceiver/internal/scraper/cpuscraper"
+	"github.com/open-telemetry/opentelemetry-collector/receiver/hostmetricsreceiver/internal/scraper/diskscraper"
 	"github.com/open-telemetry/opentelemetry-collector/receiver/hostmetricsreceiver/internal/scraper/memoryscraper"
 )
 
@@ -49,6 +50,7 @@ func NewFactory() *Factory {
 	return &Factory{
 		scraperFactories: map[string]internal.Factory{
 			cpuscraper.TypeStr:    &cpuscraper.Factory{},
+			diskscraper.TypeStr:   &diskscraper.Factory{},
 			memoryscraper.TypeStr: &memoryscraper.Factory{},
 		},
 	}

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/config.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/config.go
@@ -1,0 +1,22 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package diskscraper
+
+import "github.com/open-telemetry/opentelemetry-collector/receiver/hostmetricsreceiver/internal"
+
+// Config relating to Disk Metric Scraper.
+type Config struct {
+	internal.ConfigSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
+}

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_constants.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_constants.go
@@ -1,0 +1,67 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package diskscraper
+
+import (
+	"github.com/open-telemetry/opentelemetry-collector/consumer/pdata"
+)
+
+// disk metric constants
+
+const (
+	deviceLabelName    = "device"
+	directionLabelName = "direction"
+)
+
+const (
+	receiveDirectionLabelValue  = "receive"
+	transmitDirectionLabelValue = "transmit"
+)
+
+var metricDiskBytesDescriptor = createMetricDiskBytesDescriptor()
+
+func createMetricDiskBytesDescriptor() pdata.MetricDescriptor {
+	descriptor := pdata.NewMetricDescriptor()
+	descriptor.InitEmpty()
+	descriptor.SetName("host/disk/bytes")
+	descriptor.SetDescription("Disk bytes transferred.")
+	descriptor.SetUnit("bytes")
+	descriptor.SetType(pdata.MetricTypeCounterInt64)
+	return descriptor
+}
+
+var metricDiskOpsDescriptor = createMetricDiskOpsDescriptor()
+
+func createMetricDiskOpsDescriptor() pdata.MetricDescriptor {
+	descriptor := pdata.NewMetricDescriptor()
+	descriptor.InitEmpty()
+	descriptor.SetName("host/disk/ops")
+	descriptor.SetDescription("Disk operations count.")
+	descriptor.SetUnit("1")
+	descriptor.SetType(pdata.MetricTypeCounterInt64)
+	return descriptor
+}
+
+var metricDiskTimeDescriptor = createMetricDiskTimeDescriptor()
+
+func createMetricDiskTimeDescriptor() pdata.MetricDescriptor {
+	descriptor := pdata.NewMetricDescriptor()
+	descriptor.InitEmpty()
+	descriptor.SetName("host/disk/time")
+	descriptor.SetDescription("Time spent in disk operations.")
+	descriptor.SetUnit("ms")
+	descriptor.SetType(pdata.MetricTypeGaugeInt64)
+	return descriptor
+}

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper.go
@@ -1,0 +1,164 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package diskscraper
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/shirou/gopsutil/disk"
+	"github.com/shirou/gopsutil/host"
+	"go.opencensus.io/trace"
+
+	"github.com/open-telemetry/opentelemetry-collector/consumer"
+	"github.com/open-telemetry/opentelemetry-collector/consumer/pdata"
+	"github.com/open-telemetry/opentelemetry-collector/consumer/pdatautil"
+	"github.com/open-telemetry/opentelemetry-collector/internal/data"
+	"github.com/open-telemetry/opentelemetry-collector/receiver/hostmetricsreceiver/internal"
+)
+
+// Scraper for Disk Metrics
+type Scraper struct {
+	config    *Config
+	consumer  consumer.MetricsConsumer
+	startTime pdata.TimestampUnixNano
+	cancel    context.CancelFunc
+}
+
+// NewDiskScraper creates a set of Disk related metrics
+func NewDiskScraper(ctx context.Context, cfg *Config, consumer consumer.MetricsConsumer) (*Scraper, error) {
+	return &Scraper{config: cfg, consumer: consumer}, nil
+}
+
+// Start
+func (s *Scraper) Start(ctx context.Context) error {
+	ctx, s.cancel = context.WithCancel(ctx)
+
+	bootTime, err := host.BootTime()
+	if err != nil {
+		return err
+	}
+
+	s.startTime = pdata.TimestampUnixNano(bootTime)
+
+	go func() {
+		ticker := time.NewTicker(s.config.CollectionInterval())
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ticker.C:
+				s.scrapeMetrics(ctx)
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	return nil
+}
+
+// Close
+func (s *Scraper) Close(ctx context.Context) error {
+	s.cancel()
+	return nil
+}
+
+func (s *Scraper) scrapeMetrics(ctx context.Context) {
+	ctx, span := trace.StartSpan(ctx, "diskscraper.scrapeMetrics")
+	defer span.End()
+
+	metricData := data.NewMetricData()
+	metrics := internal.InitializeMetricSlice(metricData)
+
+	err := s.scrapeAndAppendMetrics(metrics)
+	if err != nil {
+		span.SetStatus(trace.Status{Code: trace.StatusCodeDataLoss, Message: fmt.Sprintf("Error(s) when scraping disk metrics: %v", err)})
+		return
+	}
+
+	if metrics.Len() > 0 {
+		err := s.consumer.ConsumeMetrics(ctx, pdatautil.MetricsFromInternalMetrics(metricData))
+		if err != nil {
+			span.SetStatus(trace.Status{Code: trace.StatusCodeDataLoss, Message: fmt.Sprintf("Unable to process metrics: %v", err)})
+			return
+		}
+	}
+}
+
+func (s *Scraper) scrapeAndAppendMetrics(metrics pdata.MetricSlice) error {
+	ioCounters, err := disk.IOCounters()
+	if err != nil {
+		return err
+	}
+
+	metrics.Resize(3)
+	initializeMetricDiskBytes(metrics.At(0), ioCounters, s.startTime)
+	initializeMetricDiskOps(metrics.At(1), ioCounters, s.startTime)
+	initializeMetricDiskTime(metrics.At(2), ioCounters, s.startTime)
+	return nil
+}
+
+func initializeMetricDiskBytes(metric pdata.Metric, ioCounters map[string]disk.IOCountersStat, startTime pdata.TimestampUnixNano) {
+	metricDiskBytesDescriptor.CopyTo(metric.MetricDescriptor())
+
+	idps := metric.Int64DataPoints()
+	idps.Resize(2 * len(ioCounters))
+
+	idx := 0
+	for device, ioCounter := range ioCounters {
+		initializeDataPoint(idps.At(idx+0), startTime, device, receiveDirectionLabelValue, int64(ioCounter.ReadBytes))
+		initializeDataPoint(idps.At(idx+1), startTime, device, transmitDirectionLabelValue, int64(ioCounter.WriteBytes))
+		idx += 2
+	}
+}
+
+func initializeMetricDiskOps(metric pdata.Metric, ioCounters map[string]disk.IOCountersStat, startTime pdata.TimestampUnixNano) {
+	metricDiskOpsDescriptor.CopyTo(metric.MetricDescriptor())
+
+	idps := metric.Int64DataPoints()
+	idps.Resize(2 * len(ioCounters))
+
+	idx := 0
+	for device, ioCounter := range ioCounters {
+		initializeDataPoint(idps.At(idx+0), startTime, device, receiveDirectionLabelValue, int64(ioCounter.ReadCount))
+		initializeDataPoint(idps.At(idx+1), startTime, device, transmitDirectionLabelValue, int64(ioCounter.WriteCount))
+		idx += 2
+	}
+}
+
+func initializeMetricDiskTime(metric pdata.Metric, ioCounters map[string]disk.IOCountersStat, startTime pdata.TimestampUnixNano) {
+	metricDiskTimeDescriptor.CopyTo(metric.MetricDescriptor())
+
+	idps := metric.Int64DataPoints()
+	idps.Resize(2 * len(ioCounters))
+
+	idx := 0
+	for device, ioCounter := range ioCounters {
+		initializeDataPoint(idps.At(idx+0), startTime, device, receiveDirectionLabelValue, int64(ioCounter.ReadTime))
+		initializeDataPoint(idps.At(idx+1), startTime, device, transmitDirectionLabelValue, int64(ioCounter.WriteTime))
+		idx += 2
+	}
+}
+
+func initializeDataPoint(dataPoint pdata.Int64DataPoint, startTime pdata.TimestampUnixNano, deviceLabel string, directionLabel string, value int64) {
+	labelsMap := dataPoint.LabelsMap()
+	labelsMap.Insert(deviceLabelName, deviceLabel)
+	labelsMap.Insert(directionLabelName, directionLabel)
+	dataPoint.SetStartTime(startTime)
+	dataPoint.SetTimestamp(pdata.TimestampUnixNano(uint64(time.Now().UnixNano())))
+	dataPoint.SetValue(value)
+}

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_test.go
@@ -1,0 +1,83 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package diskscraper
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-telemetry/opentelemetry-collector/consumer/pdata"
+	"github.com/open-telemetry/opentelemetry-collector/exporter/exportertest"
+	"github.com/open-telemetry/opentelemetry-collector/receiver/hostmetricsreceiver/internal"
+)
+
+type validationFn func(*testing.T, []pdata.Metrics)
+
+func TestScrapeMetrics(t *testing.T) {
+	createScraperAndValidateScrapedMetrics(t, &Config{}, func(t *testing.T, got []pdata.Metrics) {
+		metrics := internal.AssertSingleMetricDataAndGetMetricsSlice(t, got)
+
+		// expect 3 metrics
+		assert.Equal(t, 3, metrics.Len())
+
+		// for disk byts metric, expect a receive & transmit datapoint for at least one drive
+		hostDiskBytesMetric := metrics.At(0)
+		internal.AssertDescriptorEqual(t, metricDiskBytesDescriptor, hostDiskBytesMetric.MetricDescriptor())
+		assert.GreaterOrEqual(t, hostDiskBytesMetric.Int64DataPoints().Len(), 2)
+		internal.AssertInt64MetricLabelHasValue(t, hostDiskBytesMetric, 0, directionLabelName, receiveDirectionLabelValue)
+		internal.AssertInt64MetricLabelHasValue(t, hostDiskBytesMetric, 1, directionLabelName, transmitDirectionLabelValue)
+
+		// for disk operations metric, expect a receive & transmit datapoint for at least one drive
+		hostDiskOpsMetric := metrics.At(1)
+		internal.AssertDescriptorEqual(t, metricDiskOpsDescriptor, hostDiskOpsMetric.MetricDescriptor())
+		assert.GreaterOrEqual(t, hostDiskOpsMetric.Int64DataPoints().Len(), 2)
+		internal.AssertInt64MetricLabelHasValue(t, hostDiskOpsMetric, 0, directionLabelName, receiveDirectionLabelValue)
+		internal.AssertInt64MetricLabelHasValue(t, hostDiskOpsMetric, 1, directionLabelName, transmitDirectionLabelValue)
+
+		// for disk time metric, expect a receive & transmit datapoint for at least one drive
+		hostDiskTimeMetric := metrics.At(2)
+		internal.AssertDescriptorEqual(t, metricDiskTimeDescriptor, hostDiskTimeMetric.MetricDescriptor())
+		assert.GreaterOrEqual(t, hostDiskTimeMetric.Int64DataPoints().Len(), 2)
+		internal.AssertInt64MetricLabelHasValue(t, hostDiskTimeMetric, 0, directionLabelName, receiveDirectionLabelValue)
+		internal.AssertInt64MetricLabelHasValue(t, hostDiskTimeMetric, 1, directionLabelName, transmitDirectionLabelValue)
+	})
+}
+
+func createScraperAndValidateScrapedMetrics(t *testing.T, config *Config, assertFn validationFn) {
+	config.SetCollectionInterval(5 * time.Millisecond)
+
+	sink := &exportertest.SinkMetricsExporter{}
+
+	scraper, err := NewDiskScraper(context.Background(), config, sink)
+	require.NoError(t, err, "Failed to create disk scraper: %v", err)
+
+	err = scraper.Start(context.Background())
+	require.NoError(t, err, "Failed to start disk scraper: %v", err)
+	defer func() { assert.NoError(t, scraper.Close(context.Background())) }()
+
+	require.Eventually(t, func() bool {
+		got := sink.AllMetrics()
+		if len(got) == 0 {
+			return false
+		}
+
+		assertFn(t, got)
+		return true
+	}, time.Second, 2*time.Millisecond, "No metrics were collected")
+}

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/factory.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/factory.go
@@ -1,0 +1,51 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package diskscraper
+
+import (
+	"context"
+
+	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector/consumer"
+	"github.com/open-telemetry/opentelemetry-collector/receiver/hostmetricsreceiver/internal"
+)
+
+// This file implements Factory for Disk scraper.
+
+const (
+	// The value of "type" key in configuration.
+	TypeStr = "disk"
+)
+
+// Factory is the Factory for scraper.
+type Factory struct {
+}
+
+// CreateDefaultConfig creates the default configuration for the Scraper.
+func (f *Factory) CreateDefaultConfig() internal.Config {
+	return &Config{}
+}
+
+// CreateMetricsScraper creates a scraper based on provided config.
+func (f *Factory) CreateMetricsScraper(
+	ctx context.Context,
+	logger *zap.Logger,
+	config internal.Config,
+	consumer consumer.MetricsConsumer,
+) (internal.Scraper, error) {
+	cfg := config.(*Config)
+	return NewDiskScraper(ctx, cfg, consumer)
+}

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/factory_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/factory_test.go
@@ -1,0 +1,33 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package diskscraper
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+)
+
+func TestCreateMetricsScraper(t *testing.T) {
+	factory := &Factory{}
+	cfg := &Config{}
+
+	scraper, err := factory.CreateMetricsScraper(context.Background(), zap.NewNop(), cfg, nil)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, scraper)
+}


### PR DESCRIPTION
**Link to tracking Issue:**
https://github.com/open-telemetry/opentelemetry-collector/issues/847

**Description:**
Added disk scraper to the hostmetricsreceiver which uses gopsutil to collect disk related metrics

![image](https://user-images.githubusercontent.com/568630/81164799-49125b80-8fd4-11ea-8a94-db817757e7f6.png)
