### PR TITLE
Fix broken links to configuration examples

### DIFF
--- a/extension/README.md
+++ b/extension/README.md
@@ -41,8 +41,8 @@ extensions:
   health_check:
 ```
 
-The full list of settings exposed for this exporter is documented [here](healthextension/config.go)
-with detailed sample configurations [here](healthextension/testdata/config.yaml).
+The full list of settings exposed for this exporter is documented [here](healthcheckextension/config.go)
+with detailed sample configurations [here](healthcheckextension/testdata/config.yaml).
 
 ## <a name="pprof"></a>Performance Profiler
 Performance Profiler extension enables the golang `net/http/pprof` endpoint.


### PR DESCRIPTION
Signed-off-by: Kevin Earls <kearls@redhat.com>

**Description:** This fixes 2 broken links in the extension/README.md

**Link to tracking Issue:** 

**Testing:** 

**Documentation:** 