### PR TITLE
Update tests to use stretchr/testify/require

### DIFF
--- a/testbed/testbed/test_case.go
+++ b/testbed/testbed/test_case.go
@@ -110,9 +110,7 @@ func NewTestCase(
 	// Prepare directory for results.
 	tc.resultDir, err = filepath.Abs(path.Join("results", t.Name()))
 	require.NoErrorf(t, err, "Cannot resolve %s", t.Name())
-
-	err = os.MkdirAll(tc.resultDir, os.ModePerm)
-	require.NoErrorf(t, err, "Cannot create directory %s", tc.resultDir)
+	require.NoErrorf(t, os.MkdirAll(tc.resultDir, os.ModePerm), "Cannot create directory %s", tc.resultDir)
 
 	// Set default resource check period.
 	tc.resourceSpec.ResourceCheckPeriod = 3 * time.Second
@@ -219,8 +217,7 @@ func (tc *TestCase) StopLoad() {
 
 // StartBackend starts the specified backend type.
 func (tc *TestCase) StartBackend() {
-	err := tc.MockBackend.Start()
-	require.NoError(tc.t, err, "Cannot start backend")
+	require.NoError(tc.t, tc.MockBackend.Start(), "Cannot start backend")
 }
 
 // StopBackend stops the backend.

--- a/testbed/testbed/test_case.go
+++ b/testbed/testbed/test_case.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestCase defines a running test case.
@@ -108,13 +109,10 @@ func NewTestCase(
 
 	// Prepare directory for results.
 	tc.resultDir, err = filepath.Abs(path.Join("results", t.Name()))
-	if err != nil {
-		t.Fatalf("Cannot resolve %s: %v", t.Name(), err)
-	}
+	require.NoErrorf(t, err, "Cannot resolve %s", t.Name())
+
 	err = os.MkdirAll(tc.resultDir, os.ModePerm)
-	if err != nil {
-		t.Fatalf("Cannot create directory %s: %v", tc.resultDir, err)
-	}
+	require.NoErrorf(t, err, "Cannot create directory %s", tc.resultDir)
 
 	// Set default resource check period.
 	tc.resourceSpec.ResourceCheckPeriod = 3 * time.Second
@@ -131,14 +129,10 @@ func NewTestCase(
 
 	// Ensure that the config file is an absolute path.
 	tc.agentConfigFile, err = filepath.Abs(configFile)
-	if err != nil {
-		tc.t.Fatalf("Cannot resolve filename: %s", err.Error())
-	}
+	require.NoError(t, err, "Cannot resolve filename")
 
 	tc.LoadGenerator, err = NewLoadGenerator(sender)
-	if err != nil {
-		t.Fatalf("Cannot create generator: %s", err.Error())
-	}
+	require.NoError(t, err, "Cannot create generator")
 
 	tc.MockBackend = NewMockBackend(tc.composeTestResultFileName("backend.log"), receiver)
 
@@ -149,9 +143,8 @@ func NewTestCase(
 
 func (tc *TestCase) composeTestResultFileName(fileName string) string {
 	fileName, err := filepath.Abs(path.Join(tc.resultDir, fileName))
-	if err != nil {
-		tc.t.Fatalf("Cannot resolve %s: %s", fileName, err.Error())
-	}
+	require.NoError(tc.t, err, "Cannot resolve %s", fileName)
+
 	return fileName
 }
 
@@ -226,9 +219,8 @@ func (tc *TestCase) StopLoad() {
 
 // StartBackend starts the specified backend type.
 func (tc *TestCase) StartBackend() {
-	if err := tc.MockBackend.Start(); err != nil {
-		tc.t.Fatalf("Cannot start backend: %s", err.Error())
-	}
+	err := tc.MockBackend.Start()
+	require.NoError(tc.t, err, "Cannot start backend")
 }
 
 // StopBackend stops the backend.

--- a/testbed/tests/scenarios.go
+++ b/testbed/tests/scenarios.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/open-telemetry/opentelemetry-collector/testbed/testbed"
 )
@@ -141,16 +142,11 @@ func Scenario10kItemsPerSecond(
 	processors map[string]string,
 ) {
 	resultDir, err := filepath.Abs(path.Join("results", t.Name()))
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	configFile := createConfigFile(t, sender, receiver, resultDir, processors)
 	defer os.Remove(configFile)
-
-	if configFile == "" {
-		t.Fatal("Cannot create config file")
-	}
+	require.NotEmpty(t, configFile, "Cannot create config file")
 
 	tc := testbed.NewTestCase(t, sender, receiver, testbed.WithConfigFile(configFile))
 	defer tc.Stop()
@@ -252,16 +248,11 @@ func ScenarioTestTraceNoBackend10kSPS(t *testing.T, sender testbed.DataSender, r
 	resourceSpec testbed.ResourceSpec, configuration processorConfig) {
 
 	resultDir, err := filepath.Abs(path.Join("results", t.Name()))
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	configFile := createConfigFile(t, sender, receiver, resultDir, configuration.Processor)
 	defer os.Remove(configFile)
-
-	if configFile == "" {
-		t.Fatal("Cannot create config file")
-	}
+	require.NotEmpty(t, configFile, "Cannot create config file")
 
 	tc := testbed.NewTestCase(
 		t,

--- a/testbed/tests/trace_test.go
+++ b/testbed/tests/trace_test.go
@@ -381,9 +381,7 @@ func TestTraceAttributesProcessor(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			resultDir, err := filepath.Abs(path.Join("results", t.Name()))
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
 			// Use processor to add attributes to certain spans.
 			processors := map[string]string{
@@ -409,9 +407,7 @@ func TestTraceAttributesProcessor(t *testing.T) {
 			configFile := createConfigFile(t, test.sender, test.receiver, resultDir, processors)
 			defer os.Remove(configFile)
 
-			if configFile == "" {
-				t.Fatal("Cannot create config file")
-			}
+			require.NotEmpty(t, configFile, "Cannot create config file")
 
 			tc := testbed.NewTestCase(t, test.sender, test.receiver, testbed.WithConfigFile(configFile))
 			defer tc.Stop()


### PR DESCRIPTION
Signed-off-by: Kevin Earls <kearls@redhat.com>

**Description:** This is part of the fix for issue #266.  It updates tests in testbed to use stretchr/testify/require rather then checking err and calling t.Fatal

**Link to tracking Issue:** #266 

**Testing:** There are no new tests

**Documentation:** 