### PR TITLE
Match spans against the instrumentation library and resource attributes

### DIFF
--- a/internal/processor/filterconfig/config.go
+++ b/internal/processor/filterconfig/config.go
@@ -74,7 +74,7 @@ type MatchProperties struct {
 	// Note: For spans, one of Services, SpanNames, Attributes, Resources or Libraries must be specified with a
 	// non-empty value for a valid configuration.
 
-	// For logs, one of LogNames or Attributes must be specified with a
+	// For logs, one of LogNames, Attributes, Resources or Libraries must be specified with a
 	// non-empty value for a valid configuration.
 
 	// Services specify the list of of items to match service name against.
@@ -122,12 +122,12 @@ func (mp *MatchProperties) ValidateForSpans() error {
 }
 
 func (mp *MatchProperties) ValidateForLogs() error {
-	if len(mp.SpanNames) > 0 || len(mp.Services) > 0 || len(mp.Resources) > 0 || len(mp.Libraries) > 0 {
-		return errors.New("neither services nor span_names nor resources nor libraries should be specified for log records")
+	if len(mp.SpanNames) > 0 || len(mp.Services) > 0 {
+		return errors.New("neither services nor span_names should be specified for log records")
 	}
 
-	if len(mp.LogNames) == 0 && len(mp.Attributes) == 0 {
-		return errors.New(`at least one of "log_names" or "attributes" field must be specified`)
+	if len(mp.LogNames) == 0 && len(mp.Attributes) == 0 && len(mp.Libraries) == 0 && len(mp.Resources) == 0 {
+		return errors.New(`at least one of "log_names", "attributes", "libraries" or "resources" field must be specified`)
 	}
 
 	return nil

--- a/internal/processor/filterconfig/config.go
+++ b/internal/processor/filterconfig/config.go
@@ -100,7 +100,7 @@ type MatchProperties struct {
 	// Resources specify the list of items to match the resources against.
 	// A match occurs if the span's resources matches at least one item in this list.
 	// This is an optional field.
-	Resources []Attribute `mapstructure:"resource"`
+	Resources []Attribute `mapstructure:"resources"`
 
 	// Libraries specify the list of items to match the implementation library against.
 	// A match occurs if the span's implementation library matches at least one item in this list.

--- a/internal/processor/filterhelper/attributematcher.go
+++ b/internal/processor/filterhelper/attributematcher.go
@@ -1,0 +1,128 @@
+// Copyright  The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filterhelper
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+
+	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.opentelemetry.io/collector/internal/processor/filterconfig"
+	"go.opentelemetry.io/collector/internal/processor/filterset"
+)
+
+type AttributesMatcher []AttributeMatcher
+
+// AttributeMatcher is a attribute key/value pair to match to.
+type AttributeMatcher struct {
+	Key string
+	// If both AttributeValue and StringFilter are nil only check for key existence.
+	AttributeValue *pdata.AttributeValue
+	// StringFilter is needed to match against a regular expression
+	StringFilter filterset.FilterSet
+}
+
+var errUnexpectedAttributeType = errors.New("unexpected attribute type")
+
+func NewAttributesMatcher(config filterset.Config, attributes []filterconfig.Attribute) (AttributesMatcher, error) {
+	// Convert attribute values from mp representation to in-memory representation.
+	var rawAttributes []AttributeMatcher
+	for _, attribute := range attributes {
+
+		if attribute.Key == "" {
+			return nil, errors.New("error creating processor. Can't have empty key in the list of attributes")
+		}
+
+		entry := AttributeMatcher{
+			Key: attribute.Key,
+		}
+		if attribute.Value != nil {
+			val, err := NewAttributeValueRaw(attribute.Value)
+			if err != nil {
+				return nil, err
+			}
+
+			if config.MatchType == filterset.Regexp {
+				if val.Type() != pdata.AttributeValueSTRING {
+					return nil, fmt.Errorf(
+						"%s=%s for %q only supports STRING, but found %s",
+						filterset.MatchTypeFieldName, filterset.Regexp, attribute.Key, val.Type(),
+					)
+				}
+
+				filter, err := filterset.CreateFilterSet([]string{val.StringVal()}, &config)
+				if err != nil {
+					return nil, err
+				}
+				entry.StringFilter = filter
+			} else {
+				entry.AttributeValue = &val
+			}
+		}
+
+		rawAttributes = append(rawAttributes, entry)
+	}
+	return rawAttributes, nil
+}
+
+// match attributes specification against a span/log.
+func (ma AttributesMatcher) Match(attrs pdata.AttributeMap) bool {
+	// If there are no attributes to match against, the span/log matches.
+	if len(ma) == 0 {
+		return true
+	}
+
+	// At this point, it is expected of the span/log to have attributes because of
+	// len(ma) != 0. This means for spans/logs with no attributes, it does not match.
+	if attrs.Len() == 0 {
+		return false
+	}
+
+	// Check that all expected properties are set.
+	for _, property := range ma {
+		attr, exist := attrs.Get(property.Key)
+		if !exist {
+			return false
+		}
+
+		if property.StringFilter != nil {
+			value, err := attributeStringValue(attr)
+			if err != nil || !property.StringFilter.Matches(value) {
+				return false
+			}
+		} else if property.AttributeValue != nil {
+			if !attr.Equal(*property.AttributeValue) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func attributeStringValue(attr pdata.AttributeValue) (string, error) {
+	switch attr.Type() {
+	case pdata.AttributeValueSTRING:
+		return attr.StringVal(), nil
+	case pdata.AttributeValueBOOL:
+		return strconv.FormatBool(attr.BoolVal()), nil
+	case pdata.AttributeValueDOUBLE:
+		return strconv.FormatFloat(attr.DoubleVal(), 'f', -1, 64), nil
+	case pdata.AttributeValueINT:
+		return strconv.FormatInt(attr.IntVal(), 10), nil
+	default:
+		return "", errUnexpectedAttributeType
+	}
+}

--- a/internal/processor/filterlog/filterlog_test.go
+++ b/internal/processor/filterlog/filterlog_test.go
@@ -22,6 +22,7 @@ import (
 
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/internal/processor/filterconfig"
+	"go.opentelemetry.io/collector/internal/processor/filterhelper"
 	"go.opentelemetry.io/collector/internal/processor/filterset"
 )
 
@@ -54,7 +55,7 @@ func TestLogRecord_validateMatchesConfiguration_InvalidConfig(t *testing.T) {
 			property: filterconfig.MatchProperties{
 				SpanNames: []string{"span"},
 			},
-			errorString: "neither services nor span_names should be specified for log records",
+			errorString: "neither services nor span_names nor resources nor libraries should be specified for log records",
 		},
 		{
 			name: "invalid_match_type",
@@ -70,16 +71,6 @@ func TestLogRecord_validateMatchesConfiguration_InvalidConfig(t *testing.T) {
 				LogNames: []string{"abc"},
 			},
 			errorString: "error creating log record name filters: unrecognized match_type: '', valid types are: [regexp strict]",
-		},
-		{
-			name: "regexp_match_type_for_attributes",
-			property: filterconfig.MatchProperties{
-				Config: *createConfig(filterset.Regexp),
-				Attributes: []filterconfig.Attribute{
-					{Key: "key", Value: "value"},
-				},
-			},
-			errorString: `match_type=regexp is not supported for "attributes"`,
 		},
 		{
 			name: "invalid_regexp_pattern",
@@ -349,7 +340,7 @@ func TestLogRecord_validateMatchesConfigurationForAttributes(t *testing.T) {
 				},
 			},
 			output: &propertiesMatcher{
-				Attributes: []attributeMatcher{
+				Attributes: []filterhelper.AttributeMatcher{
 					{
 						Key: "key1",
 					},
@@ -376,7 +367,7 @@ func TestLogRecord_validateMatchesConfigurationForAttributes(t *testing.T) {
 				},
 			},
 			output: &propertiesMatcher{
-				Attributes: []attributeMatcher{
+				Attributes: []filterhelper.AttributeMatcher{
 					{
 						Key: "key1",
 					},

--- a/internal/processor/filtermatcher/.nocover
+++ b/internal/processor/filtermatcher/.nocover
@@ -1,0 +1,1 @@
+Tested in filterspan package

--- a/internal/processor/filtermatcher/attributematcher.go
+++ b/internal/processor/filtermatcher/attributematcher.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package filterhelper
+package filtermatcher
 
 import (
 	"errors"
@@ -21,13 +21,14 @@ import (
 
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/internal/processor/filterconfig"
+	"go.opentelemetry.io/collector/internal/processor/filterhelper"
 	"go.opentelemetry.io/collector/internal/processor/filterset"
 )
 
-type AttributesMatcher []AttributeMatcher
+type attributesMatcher []attributeMatcher
 
-// AttributeMatcher is a attribute key/value pair to match to.
-type AttributeMatcher struct {
+// attributeMatcher is a attribute key/value pair to match to.
+type attributeMatcher struct {
 	Key string
 	// If both AttributeValue and StringFilter are nil only check for key existence.
 	AttributeValue *pdata.AttributeValue
@@ -37,20 +38,20 @@ type AttributeMatcher struct {
 
 var errUnexpectedAttributeType = errors.New("unexpected attribute type")
 
-func NewAttributesMatcher(config filterset.Config, attributes []filterconfig.Attribute) (AttributesMatcher, error) {
+func newAttributesMatcher(config filterset.Config, attributes []filterconfig.Attribute) (attributesMatcher, error) {
 	// Convert attribute values from mp representation to in-memory representation.
-	var rawAttributes []AttributeMatcher
+	var rawAttributes []attributeMatcher
 	for _, attribute := range attributes {
 
 		if attribute.Key == "" {
-			return nil, errors.New("error creating processor. Can't have empty key in the list of attributes")
+			return nil, errors.New("can't have empty key in the list of attributes")
 		}
 
-		entry := AttributeMatcher{
+		entry := attributeMatcher{
 			Key: attribute.Key,
 		}
 		if attribute.Value != nil {
-			val, err := NewAttributeValueRaw(attribute.Value)
+			val, err := filterhelper.NewAttributeValueRaw(attribute.Value)
 			if err != nil {
 				return nil, err
 			}
@@ -79,7 +80,7 @@ func NewAttributesMatcher(config filterset.Config, attributes []filterconfig.Att
 }
 
 // match attributes specification against a span/log.
-func (ma AttributesMatcher) Match(attrs pdata.AttributeMap) bool {
+func (ma attributesMatcher) Match(attrs pdata.AttributeMap) bool {
 	// If there are no attributes to match against, the span/log matches.
 	if len(ma) == 0 {
 		return true

--- a/internal/processor/filtermatcher/filtermatcher.go
+++ b/internal/processor/filtermatcher/filtermatcher.go
@@ -1,0 +1,89 @@
+package filtermatcher
+
+import (
+	"fmt"
+
+	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.opentelemetry.io/collector/internal/processor/filterconfig"
+	"go.opentelemetry.io/collector/internal/processor/filterset"
+)
+
+type instrumentationLibraryMatcher struct {
+	Name    filterset.FilterSet
+	Version filterset.FilterSet
+}
+
+// propertiesMatcher allows matching a span against various span properties.
+type PropertiesMatcher struct {
+	// Instrumentation libraries to compare against
+	libraries []instrumentationLibraryMatcher
+
+	// The attribute values are stored in the internal format.
+	attributes attributesMatcher
+
+	// The attribute values are stored in the internal format.
+	resources attributesMatcher
+}
+
+// NewMatcher creates a span Matcher that matches based on the given MatchProperties.
+func NewMatcher(mp *filterconfig.MatchProperties) (PropertiesMatcher, error) {
+	var lm []instrumentationLibraryMatcher
+	for _, library := range mp.Libraries {
+		name, err := filterset.CreateFilterSet([]string{library.Name}, &mp.Config)
+		if err != nil {
+			return PropertiesMatcher{}, fmt.Errorf("error creating library name filters: %v", err)
+		}
+
+		var version filterset.FilterSet
+		if library.Version != nil {
+			filter, err := filterset.CreateFilterSet([]string{*library.Version}, &mp.Config)
+			if err != nil {
+				return PropertiesMatcher{}, fmt.Errorf("error creating library version filters: %v", err)
+			}
+			version = filter
+		}
+
+		lm = append(lm, instrumentationLibraryMatcher{Name: name, Version: version})
+	}
+
+	var err error
+	var am attributesMatcher
+	if len(mp.Attributes) > 0 {
+		am, err = newAttributesMatcher(mp.Config, mp.Attributes)
+		if err != nil {
+			return PropertiesMatcher{}, fmt.Errorf("error creating attribute filters: %v", err)
+		}
+	}
+
+	var rm attributesMatcher
+	if len(mp.Resources) > 0 {
+		rm, err = newAttributesMatcher(mp.Config, mp.Resources)
+		if err != nil {
+			return PropertiesMatcher{}, fmt.Errorf("error creating resource filters: %v", err)
+		}
+	}
+
+	return PropertiesMatcher{
+		libraries:  lm,
+		attributes: am,
+		resources:  rm,
+	}, nil
+}
+
+// Match matches a span or log to a set of properties.
+func (mp *PropertiesMatcher) Match(attributes pdata.AttributeMap, resource pdata.Resource, library pdata.InstrumentationLibrary) bool {
+	for _, matcher := range mp.libraries {
+		if !matcher.Name.Matches(library.Name()) {
+			return false
+		}
+		if matcher.Version != nil && !matcher.Version.Matches(library.Version()) {
+			return false
+		}
+	}
+
+	if mp.resources != nil && !mp.resources.Match(resource.Attributes()) {
+		return false
+	}
+
+	return mp.attributes.Match(attributes)
+}

--- a/internal/processor/filtermatcher/filtermatcher.go
+++ b/internal/processor/filtermatcher/filtermatcher.go
@@ -1,3 +1,17 @@
+// Copyright  The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package filtermatcher
 
 import (

--- a/internal/processor/filterset/strict/strictfilterset.go
+++ b/internal/processor/filterset/strict/strictfilterset.go
@@ -33,7 +33,7 @@ func NewFilterSet(filters []string) (*FilterSet, error) {
 	return fs, nil
 }
 
-// Matches returns true if the given string matches any of the FitlerSet's filters.
+// Matches returns true if the given string matches any of the FilterSet's filters.
 func (sfs *FilterSet) Matches(toMatch string) bool {
 	_, ok := sfs.filters[toMatch]
 	return ok

--- a/internal/processor/filterspan/filterspan.go
+++ b/internal/processor/filterspan/filterspan.go
@@ -19,7 +19,7 @@ import (
 
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/internal/processor/filterconfig"
-	"go.opentelemetry.io/collector/internal/processor/filterhelper"
+	"go.opentelemetry.io/collector/internal/processor/filtermatcher"
 	"go.opentelemetry.io/collector/internal/processor/filterset"
 	"go.opentelemetry.io/collector/translator/conventions"
 )
@@ -34,24 +34,13 @@ type Matcher interface {
 
 // propertiesMatcher allows matching a span against various span properties.
 type propertiesMatcher struct {
+	filtermatcher.PropertiesMatcher
+
 	// Service names to compare to.
 	serviceFilters filterset.FilterSet
 
 	// Span names to compare to.
 	nameFilters filterset.FilterSet
-
-	// Instrumentation libraries to compare against
-	Libraries []instrumentationLibraryMatcher
-
-	// The attribute values are stored in the internal format.
-	Attributes filterhelper.AttributesMatcher
-
-	Resources filterhelper.AttributesMatcher
-}
-
-type instrumentationLibraryMatcher struct {
-	Name    filterset.FilterSet
-	Version filterset.FilterSet
 }
 
 // NewMatcher creates a span Matcher that matches based on the given MatchProperties.
@@ -64,40 +53,9 @@ func NewMatcher(mp *filterconfig.MatchProperties) (Matcher, error) {
 		return nil, err
 	}
 
-	var lm []instrumentationLibraryMatcher
-	for _, library := range mp.Libraries {
-		name, err := filterset.CreateFilterSet([]string{library.Name}, &mp.Config)
-		if err != nil {
-			return nil, fmt.Errorf("error creating library name filters: %v", err)
-		}
-
-		var version filterset.FilterSet
-		if library.Version != nil {
-			filter, err := filterset.CreateFilterSet([]string{*library.Version}, &mp.Config)
-			if err != nil {
-				return nil, fmt.Errorf("error creating library version filters: %v", err)
-			}
-			version = filter
-		}
-
-		lm = append(lm, instrumentationLibraryMatcher{Name: name, Version: version})
-	}
-
-	var err error
-	var am filterhelper.AttributesMatcher
-	if len(mp.Attributes) > 0 {
-		am, err = filterhelper.NewAttributesMatcher(mp.Config, mp.Attributes)
-		if err != nil {
-			return nil, fmt.Errorf("error creating attribute filters: %v", err)
-		}
-	}
-
-	var rm filterhelper.AttributesMatcher
-	if len(mp.Resources) > 0 {
-		rm, err = filterhelper.NewAttributesMatcher(mp.Config, mp.Resources)
-		if err != nil {
-			return nil, fmt.Errorf("error creating resource filters: %v", err)
-		}
+	rm, err := filtermatcher.NewMatcher(mp)
+	if err != nil {
+		return nil, err
 	}
 
 	var serviceFS filterset.FilterSet = nil
@@ -117,11 +75,9 @@ func NewMatcher(mp *filterconfig.MatchProperties) (Matcher, error) {
 	}
 
 	return &propertiesMatcher{
-		serviceFilters: serviceFS,
-		nameFilters:    nameFS,
-		Libraries:      lm,
-		Attributes:     am,
-		Resources:      rm,
+		PropertiesMatcher: rm,
+		serviceFilters:    serviceFS,
+		nameFilters:       nameFS,
 	}, nil
 }
 
@@ -150,12 +106,7 @@ func SkipSpan(include Matcher, exclude Matcher, span pdata.Span, resource pdata.
 }
 
 // MatchSpan matches a span and service to a set of properties.
-// There are 3 sets of properties to match against.
-// The service name is checked first, if specified. Then span names are matched, if specified.
-// The attributes are checked last, if specified.
-// At least one of services, span names or attributes must be specified. It is supported
-// to have more than one of these specified, and all specified must evaluate
-// to true for a match to occur.
+// see filterconfig.MatchProperties for more details
 func (mp *propertiesMatcher) MatchSpan(span pdata.Span, resource pdata.Resource, library pdata.InstrumentationLibrary) bool {
 	// If a set of properties was not in the mp, all spans are considered to match on that property
 	if mp.serviceFilters != nil {
@@ -169,21 +120,7 @@ func (mp *propertiesMatcher) MatchSpan(span pdata.Span, resource pdata.Resource,
 		return false
 	}
 
-	for _, matcher := range mp.Libraries {
-		if !matcher.Name.Matches(library.Name()) {
-			return false
-		}
-		if matcher.Version != nil && !matcher.Version.Matches(library.Version()) {
-			return false
-		}
-	}
-
-	attributes := span.Attributes()
-	if mp.Resources != nil && !mp.Resources.Match(attributes) {
-		return false
-	}
-
-	return mp.Attributes.Match(attributes)
+	return mp.PropertiesMatcher.Match(span.Attributes(), resource, library)
 }
 
 // serviceNameForResource gets the service name for a specified Resource.

--- a/internal/processor/filterspan/filterspan_test.go
+++ b/internal/processor/filterspan/filterspan_test.go
@@ -21,8 +21,11 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.opentelemetry.io/collector/internal/data/testdata"
 	"go.opentelemetry.io/collector/internal/processor/filterconfig"
+	"go.opentelemetry.io/collector/internal/processor/filterhelper"
 	"go.opentelemetry.io/collector/internal/processor/filterset"
+	"go.opentelemetry.io/collector/translator/conventions"
 )
 
 func createConfig(matchType filterset.MatchType) *filterset.Config {
@@ -32,6 +35,7 @@ func createConfig(matchType filterset.MatchType) *filterset.Config {
 }
 
 func TestSpan_validateMatchesConfiguration_InvalidConfig(t *testing.T) {
+	version := "["
 	testcases := []struct {
 		name        string
 		property    filterconfig.MatchProperties
@@ -40,14 +44,14 @@ func TestSpan_validateMatchesConfiguration_InvalidConfig(t *testing.T) {
 		{
 			name:        "empty_property",
 			property:    filterconfig.MatchProperties{},
-			errorString: "at least one of \"services\", \"span_names\" or \"attributes\" field must be specified",
+			errorString: "at least one of \"services\", \"span_names\", \"attributes\", \"libraries\" or \"resources\" field must be specified",
 		},
 		{
 			name: "empty_service_span_names_and_attributes",
 			property: filterconfig.MatchProperties{
 				Services: []string{},
 			},
-			errorString: "at least one of \"services\", \"span_names\" or \"attributes\" field must be specified",
+			errorString: "at least one of \"services\", \"span_names\", \"attributes\", \"libraries\" or \"resources\" field must be specified",
 		},
 		{
 			name: "log_properties",
@@ -72,17 +76,27 @@ func TestSpan_validateMatchesConfiguration_InvalidConfig(t *testing.T) {
 			errorString: "error creating service name filters: unrecognized match_type: '', valid types are: [regexp strict]",
 		},
 		{
-			name: "regexp_match_type_for_attributes",
+			name: "regexp_match_type_for_int_attribute",
 			property: filterconfig.MatchProperties{
 				Config: *createConfig(filterset.Regexp),
 				Attributes: []filterconfig.Attribute{
-					{Key: "key", Value: "value"},
+					{Key: "key", Value: 1},
 				},
 			},
-			errorString: `match_type=regexp is not supported for "attributes"`,
+			errorString: `error creating attribute filters: match_type=regexp for "key" only supports STRING, but found INT`,
 		},
 		{
-			name: "invalid_regexp_pattern",
+			name: "unknown_attribute_value",
+			property: filterconfig.MatchProperties{
+				Config: *createConfig(filterset.Strict),
+				Attributes: []filterconfig.Attribute{
+					{Key: "key", Value: []string{}},
+				},
+			},
+			errorString: `error creating attribute filters: error unsupported value type "[]string"`,
+		},
+		{
+			name: "invalid_regexp_pattern_service",
 			property: filterconfig.MatchProperties{
 				Config:   *createConfig(filterset.Regexp),
 				Services: []string{"["},
@@ -90,12 +104,45 @@ func TestSpan_validateMatchesConfiguration_InvalidConfig(t *testing.T) {
 			errorString: "error creating service name filters: error parsing regexp: missing closing ]: `[`",
 		},
 		{
-			name: "invalid_regexp_pattern2",
+			name: "invalid_regexp_pattern_span",
 			property: filterconfig.MatchProperties{
 				Config:    *createConfig(filterset.Regexp),
 				SpanNames: []string{"["},
 			},
 			errorString: "error creating span name filters: error parsing regexp: missing closing ]: `[`",
+		},
+		{
+			name: "invalid_regexp_pattern_attribute",
+			property: filterconfig.MatchProperties{
+				Config:     *createConfig(filterset.Regexp),
+				SpanNames:  []string{"["},
+				Attributes: []filterconfig.Attribute{{Key: "key", Value: "["}},
+			},
+			errorString: "error creating attribute filters: error parsing regexp: missing closing ]: `[`",
+		},
+		{
+			name: "invalid_regexp_pattern_resource",
+			property: filterconfig.MatchProperties{
+				Config:    *createConfig(filterset.Regexp),
+				Resources: []filterconfig.Attribute{{Key: "key", Value: "["}},
+			},
+			errorString: "error creating resource filters: error parsing regexp: missing closing ]: `[`",
+		},
+		{
+			name: "invalid_regexp_pattern_library_name",
+			property: filterconfig.MatchProperties{
+				Config:    *createConfig(filterset.Regexp),
+				Libraries: []filterconfig.InstrumentationLibrary{{Name: "["}},
+			},
+			errorString: "error creating library name filters: error parsing regexp: missing closing ]: `[`",
+		},
+		{
+			name: "invalid_regexp_pattern_library_version",
+			property: filterconfig.MatchProperties{
+				Config:    *createConfig(filterset.Regexp),
+				Libraries: []filterconfig.InstrumentationLibrary{{Name: "lib", Version: &version}},
+			},
+			errorString: "error creating library version filters: error parsing regexp: missing closing ]: `[`",
 		},
 		{
 			name: "empty_key_name_in_attributes_list",
@@ -108,20 +155,20 @@ func TestSpan_validateMatchesConfiguration_InvalidConfig(t *testing.T) {
 					},
 				},
 			},
-			errorString: "error creating processor. Can't have empty key in the list of attributes",
+			errorString: "error creating attribute filters: error creating processor. Can't have empty key in the list of attributes",
 		},
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			output, err := NewMatcher(&tc.property)
 			assert.Nil(t, output)
-			require.NotNil(t, err)
-			assert.Equal(t, tc.errorString, err.Error())
+			assert.EqualError(t, err, tc.errorString)
 		})
 	}
 }
 
 func TestSpan_Matching_False(t *testing.T) {
+	version := "wrong"
 	testcases := []struct {
 		name       string
 		properties *filterconfig.MatchProperties
@@ -167,7 +214,24 @@ func TestSpan_Matching_False(t *testing.T) {
 		},
 
 		{
-			name: "wrong_property_value",
+			name: "wrong_library_name",
+			properties: &filterconfig.MatchProperties{
+				Config:    *createConfig(filterset.Strict),
+				Services:  []string{},
+				Libraries: []filterconfig.InstrumentationLibrary{{Name: "wrong"}},
+			},
+		},
+		{
+			name: "wrong_library_version",
+			properties: &filterconfig.MatchProperties{
+				Config:    *createConfig(filterset.Strict),
+				Services:  []string{},
+				Libraries: []filterconfig.InstrumentationLibrary{{Name: "lib", Version: &version}},
+			},
+		},
+
+		{
+			name: "wrong_attribute_value",
 			properties: &filterconfig.MatchProperties{
 				Config:   *createConfig(filterset.Strict),
 				Services: []string{},
@@ -180,13 +244,39 @@ func TestSpan_Matching_False(t *testing.T) {
 			},
 		},
 		{
-			name: "incompatible_property_value",
+			name: "wrong_resource_value",
+			properties: &filterconfig.MatchProperties{
+				Config:   *createConfig(filterset.Strict),
+				Services: []string{},
+				Resources: []filterconfig.Attribute{
+					{
+						Key:   "keyInt",
+						Value: 1234,
+					},
+				},
+			},
+		},
+		{
+			name: "incompatible_attribute_value",
 			properties: &filterconfig.MatchProperties{
 				Config:   *createConfig(filterset.Strict),
 				Services: []string{},
 				Attributes: []filterconfig.Attribute{
 					{
 						Key:   "keyInt",
+						Value: "123",
+					},
+				},
+			},
+		},
+		{
+			name: "unsupported_attribute_value",
+			properties: &filterconfig.MatchProperties{
+				Config:   *createConfig(filterset.Regexp),
+				Services: []string{},
+				Attributes: []filterconfig.Attribute{
+					{
+						Key:   "keyMap",
 						Value: "123",
 					},
 				},
@@ -210,16 +300,32 @@ func TestSpan_Matching_False(t *testing.T) {
 	span := pdata.NewSpan()
 	span.InitEmpty()
 	span.SetName("spanName")
-	span.Attributes().InitFromMap(map[string]pdata.AttributeValue{"keyInt": pdata.NewAttributeValueInt(123)})
+	span.Attributes().InitFromMap(map[string]pdata.AttributeValue{
+		"keyInt": pdata.NewAttributeValueInt(123),
+		"keyMap": pdata.NewAttributeValueMap(),
+	})
+
+	library := pdata.NewInstrumentationLibrary()
+	library.InitEmpty()
+	library.SetName("lib")
+	library.SetVersion("ver")
+
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			matcher, err := NewMatcher(tc.properties)
-			assert.Nil(t, err)
+			require.NoError(t, err)
 			assert.NotNil(t, matcher)
 
-			assert.False(t, matcher.MatchSpan(span, "wrongSvc"))
+			assert.False(t, matcher.MatchSpan(span, resource("wrongSvc"), library))
 		})
 	}
+}
+
+func resource(service string) pdata.Resource {
+	r := pdata.NewResource()
+	r.InitEmpty()
+	r.Attributes().InitFromMap(map[string]pdata.AttributeValue{conventions.AttributeServiceName: pdata.NewAttributeValueString(service)})
+	return r
 }
 
 func TestSpan_MatchingCornerCases(t *testing.T) {
@@ -240,7 +346,7 @@ func TestSpan_MatchingCornerCases(t *testing.T) {
 
 	emptySpan := pdata.NewSpan()
 	emptySpan.InitEmpty()
-	assert.False(t, mp.MatchSpan(emptySpan, "svcA"))
+	assert.False(t, mp.MatchSpan(emptySpan, resource("svcA"), pdata.NewInstrumentationLibrary()))
 }
 
 func TestSpan_MissingServiceName(t *testing.T) {
@@ -255,10 +361,12 @@ func TestSpan_MissingServiceName(t *testing.T) {
 
 	emptySpan := pdata.NewSpan()
 	emptySpan.InitEmpty()
-	assert.False(t, mp.MatchSpan(emptySpan, ""))
+	assert.False(t, mp.MatchSpan(emptySpan, resource(""), pdata.NewInstrumentationLibrary()))
 }
 
 func TestSpan_Matching_True(t *testing.T) {
+	ver := "v.*"
+
 	testcases := []struct {
 		name       string
 		properties *filterconfig.MatchProperties
@@ -276,6 +384,22 @@ func TestSpan_Matching_True(t *testing.T) {
 			properties: &filterconfig.MatchProperties{
 				Config:     *createConfig(filterset.Strict),
 				Services:   []string{"svcA"},
+				Attributes: []filterconfig.Attribute{},
+			},
+		},
+		{
+			name: "library_match",
+			properties: &filterconfig.MatchProperties{
+				Config:     *createConfig(filterset.Regexp),
+				Libraries:  []filterconfig.InstrumentationLibrary{{Name: "li.*"}},
+				Attributes: []filterconfig.Attribute{},
+			},
+		},
+		{
+			name: "library_match_with_version",
+			properties: &filterconfig.MatchProperties{
+				Config:     *createConfig(filterset.Regexp),
+				Libraries:  []filterconfig.InstrumentationLibrary{{Name: "li.*", Version: &ver}},
 				Attributes: []filterconfig.Attribute{},
 			},
 		},
@@ -301,7 +425,7 @@ func TestSpan_Matching_True(t *testing.T) {
 			},
 		},
 		{
-			name: "property_exact_value_match",
+			name: "attribute_exact_value_match",
 			properties: &filterconfig.MatchProperties{
 				Config:   *createConfig(filterset.Strict),
 				Services: []string{},
@@ -321,6 +445,42 @@ func TestSpan_Matching_True(t *testing.T) {
 					{
 						Key:   "keyBool",
 						Value: true,
+					},
+				},
+			},
+		},
+		{
+			name: "attribute_regex_value_match",
+			properties: &filterconfig.MatchProperties{
+				Config: *createConfig(filterset.Regexp),
+				Attributes: []filterconfig.Attribute{
+					{
+						Key:   "keyString",
+						Value: "arith.*",
+					},
+					{
+						Key:   "keyInt",
+						Value: "12.*",
+					},
+					{
+						Key:   "keyDouble",
+						Value: "324.*",
+					},
+					{
+						Key:   "keyBool",
+						Value: "tr.*",
+					},
+				},
+			},
+		},
+		{
+			name: "resource_exact_value_match",
+			properties: &filterconfig.MatchProperties{
+				Config: *createConfig(filterset.Strict),
+				Resources: []filterconfig.Attribute{
+					{
+						Key:   "keyString",
+						Value: "arithmetic",
 					},
 				},
 			},
@@ -367,15 +527,27 @@ func TestSpan_Matching_True(t *testing.T) {
 		"keyBool":   pdata.NewAttributeValueBool(true),
 		"keyExists": pdata.NewAttributeValueString("present"),
 	})
+	assert.NotNil(t, span)
+
+	resource := pdata.NewResource()
+	resource.InitEmpty()
+	resource.Attributes().InitFromMap(map[string]pdata.AttributeValue{
+		conventions.AttributeServiceName: pdata.NewAttributeValueString("svcA"),
+		"keyString":                      pdata.NewAttributeValueString("arithmetic"),
+	})
+
+	library := pdata.NewInstrumentationLibrary()
+	library.InitEmpty()
+	library.SetName("lib")
+	library.SetVersion("ver")
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			mp, err := NewMatcher(tc.properties)
-			assert.Nil(t, err)
+			require.NoError(t, err)
 			assert.NotNil(t, mp)
 
-			assert.NotNil(t, span)
-			assert.True(t, mp.MatchSpan(span, "svcA"))
+			assert.True(t, mp.MatchSpan(span, resource, library))
 		})
 	}
 }
@@ -401,7 +573,7 @@ func TestSpan_validateMatchesConfigurationForAttributes(t *testing.T) {
 				},
 			},
 			output: &propertiesMatcher{
-				Attributes: []attributeMatcher{
+				Attributes: []filterhelper.AttributeMatcher{
 					{
 						Key: "key1",
 					},
@@ -428,7 +600,7 @@ func TestSpan_validateMatchesConfigurationForAttributes(t *testing.T) {
 				},
 			},
 			output: &propertiesMatcher{
-				Attributes: []attributeMatcher{
+				Attributes: []filterhelper.AttributeMatcher{
 					{
 						Key: "key1",
 					},
@@ -452,4 +624,16 @@ func TestSpan_validateMatchesConfigurationForAttributes(t *testing.T) {
 func newAttributeValueInt(v int64) *pdata.AttributeValue {
 	attr := pdata.NewAttributeValueInt(v)
 	return &attr
+}
+
+func TestServiceNameForResource(t *testing.T) {
+	td := testdata.GenerateTraceDataOneSpanNoResource()
+	require.Equal(t, serviceNameForResource(td.ResourceSpans().At(0).Resource()), "<nil-resource>")
+
+	td = testdata.GenerateTraceDataOneSpan()
+	resource := td.ResourceSpans().At(0).Resource()
+	require.Equal(t, serviceNameForResource(resource), "<nil-service-name>")
+
+	resource.Attributes().InsertString(conventions.AttributeServiceName, "test-service")
+	require.Equal(t, serviceNameForResource(resource), "test-service")
 }

--- a/processor/attributesprocessor/attributes.go
+++ b/processor/attributesprocessor/attributes.go
@@ -19,7 +19,6 @@ import (
 
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/internal/processor/filterspan"
-	"go.opentelemetry.io/collector/processor"
 	"go.opentelemetry.io/collector/processor/processorhelper"
 )
 
@@ -48,7 +47,7 @@ func (a *attributesProcessor) ProcessTraces(_ context.Context, td pdata.Traces) 
 		if rs.IsNil() {
 			continue
 		}
-		serviceName := processor.ServiceNameForResource(rs.Resource())
+		resource := rs.Resource()
 		ilss := rss.At(i).InstrumentationLibrarySpans()
 		for j := 0; j < ilss.Len(); j++ {
 			ils := ilss.At(j)
@@ -56,6 +55,7 @@ func (a *attributesProcessor) ProcessTraces(_ context.Context, td pdata.Traces) 
 				continue
 			}
 			spans := ils.Spans()
+			library := ils.InstrumentationLibrary()
 			for k := 0; k < spans.Len(); k++ {
 				span := spans.At(k)
 				if span.IsNil() {
@@ -63,7 +63,7 @@ func (a *attributesProcessor) ProcessTraces(_ context.Context, td pdata.Traces) 
 					continue
 				}
 
-				if a.skipSpan(span, serviceName) {
+				if filterspan.SkipSpan(a.include, a.exclude, span, resource, library) {
 					continue
 				}
 
@@ -72,28 +72,4 @@ func (a *attributesProcessor) ProcessTraces(_ context.Context, td pdata.Traces) 
 		}
 	}
 	return td, nil
-}
-
-// skipSpan determines if a span should be processed.
-// True is returned when a span should be skipped.
-// False is returned when a span should not be skipped.
-// The logic determining if a span should be processed is set
-// in the attribute configuration with the include and exclude settings.
-// Include properties are checked before exclude settings are checked.
-func (a *attributesProcessor) skipSpan(span pdata.Span, serviceName string) bool {
-	if a.include != nil {
-		// A false returned in this case means the span should not be processed.
-		if include := a.include.MatchSpan(span, serviceName); !include {
-			return true
-		}
-	}
-
-	if a.exclude != nil {
-		// A true returned in this case means the span should not be processed.
-		if exclude := a.exclude.MatchSpan(span, serviceName); exclude {
-			return true
-		}
-	}
-
-	return false
 }

--- a/processor/attributesprocessor/config_test.go
+++ b/processor/attributesprocessor/config_test.go
@@ -29,7 +29,7 @@ import (
 	"go.opentelemetry.io/collector/processor/processorhelper"
 )
 
-func TestLoadingConifg(t *testing.T) {
+func TestLoadingConfig(t *testing.T) {
 	factories, err := componenttest.ExampleComponents()
 	assert.NoError(t, err)
 

--- a/processor/attributesprocessor/testdata/config.yaml
+++ b/processor/attributesprocessor/testdata/config.yaml
@@ -119,6 +119,38 @@ processors:
       - key: duplicate_key
         action: delete
 
+  # The following demonstrates excluding spans from this attributes processor based on a resource.
+  attributes/excluderesources:
+    # Specifies the spans properties that exclude a span from being processed.
+    exclude:
+      # match_type defines that "resources" is an map where values must match strictly.
+      match_type: strict
+      resources:
+        # This exact resource ('host.type', 'n1-standard-1') must exist in the span for a match.
+        - {key: host.type, value: "n1-standard-1"}
+    actions:
+      - key: credit_card
+        action: delete
+      - key: duplicate_key
+        action: delete
+
+  # The following demonstrates excluding spans from this attributes processor based on an instrumenting library.
+  # If no version is provided, any version will match, even no version.
+  # If a blank version provided, only no version will match.
+  attributes/excludelibrary:
+    # Specifies the spans properties that exclude a span from being processed.
+    exclude:
+      # match_type defines that "libraries" is an map where values must match strictly.
+      match_type: strict
+      libraries:
+        # This exact library ('mongo-java-driver', version '3.8.0') must exist in the span for a match.
+        - {name: "mongo-java-driver", version: "3.8.0"}
+    actions:
+      - key: credit_card
+        action: delete
+      - key: duplicate_key
+        action: delete
+
   # The following demonstrates including spans for this attributes processor.
   # All other spans that do no match the properties are not processed
   # by this processor.
@@ -163,8 +195,7 @@ processors:
       # The Span service name must be equal to "svcA" or "svcB".
       services: ["svcA", "svcB"]
     exclude:
-      # match_type defines that "attributes" values must match strictly. It is the
-      # only supported match_type for "attributes" setting.
+      # match_type defines that "attributes" values must match strictly.
       match_type: strict
       attributes:
         - { key: redact_trace, value: false}
@@ -242,7 +273,7 @@ processors:
       # The span service name must match "auth.*" pattern.
       services: ["auth.*"]
     exclude:
-      # match_type defines that "services" is an array of regexp-es.
+      # match_type defines that "span_names" is an array of regexp-es.
       match_type: regexp
       # The span name must not match "login.*" pattern.
       span_names: ["login.*"]
@@ -252,6 +283,22 @@ processors:
         value: "obfuscated"
       - key: token
         action: delete
+
+  # The following demonstrates how to process spans that have an attribute that matches a regexp patterns.
+  # This processor will obfuscate "db.statement" attribute in spans where "db.statement attribute
+  # matches a regex pattern.
+  attributes/regexp2:
+    # Specifies the span properties that must exist for the processor to be applied.
+    include:
+      # match_type defines that "attributes" is a map where values are regexp-es.
+      match_type: regexp
+      attributes:
+        # This attribute ('db.statement') must exist in the span and match the regex ('SELECT \* FROM USERS.*') for a match.
+        - {key: env, value: "'SELECT * FROM USERS WHERE ID=1'"}
+    actions:
+      - key: db.statement
+        action: update
+        value: "SELECT * FROM USERS [obfuscated]"
 
 receivers:
   examplereceiver:

--- a/processor/metrics.go
+++ b/processor/metrics.go
@@ -148,21 +148,6 @@ func ServiceNameForNode(node *commonpb.Node) string {
 	}
 }
 
-// ServiceNameForResource gets the service name for a specified Resource.
-// TODO: Find a better package for this function.
-func ServiceNameForResource(resource pdata.Resource) string {
-	if resource.IsNil() {
-		return "<nil-resource>"
-	}
-
-	service, found := resource.Attributes().Get(conventions.AttributeServiceName)
-	if !found {
-		return "<nil-service-name>"
-	}
-
-	return service.StringVal()
-}
-
 // RecordsSpanCountMetrics reports span count metrics for specified measure.
 func RecordsSpanCountMetrics(ctx context.Context, scm *SpanCountStats, measure *stats.Int64Measure) {
 	if scm.isDetailed {

--- a/processor/metrics_test.go
+++ b/processor/metrics_test.go
@@ -20,20 +20,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/collector/internal/data/testdata"
-	"go.opentelemetry.io/collector/translator/conventions"
 )
-
-func TestServiceNameForResource(t *testing.T) {
-	td := testdata.GenerateTraceDataOneSpanNoResource()
-	require.Equal(t, ServiceNameForResource(td.ResourceSpans().At(0).Resource()), "<nil-resource>")
-
-	td = testdata.GenerateTraceDataOneSpan()
-	resource := td.ResourceSpans().At(0).Resource()
-	require.Equal(t, ServiceNameForResource(resource), "<nil-service-name>")
-
-	resource.Attributes().InsertString(conventions.AttributeServiceName, "test-service")
-	require.Equal(t, ServiceNameForResource(resource), "test-service")
-}
 
 func TestSpanCountByResourceStringAttribute(t *testing.T) {
 	td := testdata.GenerateTraceDataEmpty()


### PR DESCRIPTION
### Add the possibility to match spans against the instrumentation library.

This is how it works:

```
// version match
//  expected actual  match
//  nil      <blank> yes
//  nil      1       yes
//  <blank>  <blank> yes
//  <blank>  1       no
//  1        <blank> no
//  1        1       yes
```

You can decide to match against all versions (expected = `nil`), a specific version (e.g. expected = `1`), or against "version not provided" (expected = `<blank>`). 

### match spans on resource attributes

Use case: drop attribute values (e.g. a password) for a certain version (`host.image.version`)

### allow regexp when matching attribute value if it is a string

Regular expressions should only be prohibited if the expected value is not a string (because an implicit conversion to string would be unexpected).
If the expected value is a string, then a regular expression should be allowed.