### PR TITLE
match spans on resource attributes

### DIFF
--- a/internal/processor/filterset/strict/strictfilterset.go
+++ b/internal/processor/filterset/strict/strictfilterset.go
@@ -33,7 +33,7 @@ func NewFilterSet(filters []string) (*FilterSet, error) {
 	return fs, nil
 }
 
-// Matches returns true if the given string matches any of the FitlerSet's filters.
+// Matches returns true if the given string matches any of the FilterSet's filters.
 func (sfs *FilterSet) Matches(toMatch string) bool {
 	_, ok := sfs.filters[toMatch]
 	return ok

--- a/internal/processor/filterspan/config.go
+++ b/internal/processor/filterspan/config.go
@@ -76,6 +76,11 @@ type MatchProperties struct {
 	// This is an optional field.
 	Services []string `mapstructure:"services"`
 
+	// Resources specify the list of items to match the resources against.
+	// A match occurs if the span's service name matches at least one item in this list.
+	// This is an optional field.
+	Resources []Attribute `mapstructure:"resource"`
+
 	// SpanNames specify the list of items to match span name against.
 	// A match occurs if the span name matches at least one item in this list.
 	// This is an optional field.
@@ -87,9 +92,6 @@ type MatchProperties struct {
 	// This is an optional field.
 	Attributes []Attribute `mapstructure:"attributes"`
 }
-
-// MatchTypeFieldName is the mapstructure field name for MatchProperties.Attributes field.
-const AttributesFieldName = "attributes"
 
 // Attribute specifies the attribute key and optional value to match against.
 type Attribute struct {

--- a/processor/metrics.go
+++ b/processor/metrics.go
@@ -147,21 +147,6 @@ func ServiceNameForNode(node *commonpb.Node) string {
 	}
 }
 
-// ServiceNameForResource gets the service name for a specified Resource.
-// TODO: Find a better package for this function.
-func ServiceNameForResource(resource pdata.Resource) string {
-	if resource.IsNil() {
-		return "<nil-resource>"
-	}
-
-	service, found := resource.Attributes().Get(conventions.AttributeServiceName)
-	if !found {
-		return "<nil-service-name>"
-	}
-
-	return service.StringVal()
-}
-
 // RecordsSpanCountMetrics reports span count metrics for specified measure.
 func RecordsSpanCountMetrics(ctx context.Context, scm *SpanCountStats, measure *stats.Int64Measure) {
 	if scm.isDetailed {

--- a/processor/metrics_test.go
+++ b/processor/metrics_test.go
@@ -20,20 +20,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/collector/internal/data/testdata"
-	"go.opentelemetry.io/collector/translator/conventions"
 )
-
-func TestServiceNameForResource(t *testing.T) {
-	td := testdata.GenerateTraceDataOneSpanNoResource()
-	require.Equal(t, ServiceNameForResource(td.ResourceSpans().At(0).Resource()), "<nil-resource>")
-
-	td = testdata.GenerateTraceDataOneSpan()
-	resource := td.ResourceSpans().At(0).Resource()
-	require.Equal(t, ServiceNameForResource(resource), "<nil-service-name>")
-
-	resource.Attributes().InsertString(conventions.AttributeServiceName, "test-service")
-	require.Equal(t, ServiceNameForResource(resource), "test-service")
-}
 
 func TestSpanCountByResourceStringAttribute(t *testing.T) {
 	td := testdata.GenerateTraceDataEmpty()

--- a/processor/spanprocessor/span.go
+++ b/processor/spanprocessor/span.go
@@ -23,7 +23,6 @@ import (
 
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/internal/processor/filterspan"
-	"go.opentelemetry.io/collector/processor"
 )
 
 type spanProcessor struct {
@@ -87,7 +86,6 @@ func (sp *spanProcessor) ProcessTraces(_ context.Context, td pdata.Traces) (pdat
 		if rs.IsNil() {
 			continue
 		}
-		serviceName := processor.ServiceNameForResource(rs.Resource())
 		ilss := rss.At(i).InstrumentationLibrarySpans()
 		for j := 0; j < ilss.Len(); j++ {
 			ils := ilss.At(j)
@@ -101,7 +99,7 @@ func (sp *spanProcessor) ProcessTraces(_ context.Context, td pdata.Traces) (pdat
 					continue
 				}
 
-				if sp.skipSpan(s, serviceName) {
+				if filterspan.SkipSpan(sp.include, sp.exclude, s, rs.Resource()) {
 					continue
 				}
 				sp.processFromAttributes(s)
@@ -228,28 +226,4 @@ func (sp *spanProcessor) processToAttributes(span pdata.Span) {
 			break
 		}
 	}
-}
-
-// skipSpan determines if a span should be processed.
-// True is returned when a span should be skipped.
-// False is returned when a span should not be skipped.
-// The logic determining if a span should be processed is set
-// in the attribute configuration with the include and exclude settings.
-// Include properties are checked before exclude settings are checked.
-func (sp *spanProcessor) skipSpan(span pdata.Span, serviceName string) bool {
-	if sp.include != nil {
-		// A false returned in this case means the span should not be processed.
-		if include := sp.include.MatchSpan(span, serviceName); !include {
-			return true
-		}
-	}
-
-	if sp.exclude != nil {
-		// A true returned in this case means the span should not be processed.
-		if exclude := sp.exclude.MatchSpan(span, serviceName); exclude {
-			return true
-		}
-	}
-
-	return false
 }


### PR DESCRIPTION
### match spans on resource attributes

Use case: drop attribute values (e.g. a password) for a certain version (`host.image.version`)

### allow regexp when matching attribute value if it is a string

Regular expressions should only be prohibited if the expected value is not a string (because an implicit conversion to string would be unexpected).
If the expected value is a string, then a regular expression should be allowed.

Note:

This is a prototype to discuss the feature.

More tests, example config, and documentation will be added later.