### PR TITLE
Initial commit of host metrics network scraper

### DIFF
--- a/receiver/hostmetricsreceiver/example_config.yaml
+++ b/receiver/hostmetricsreceiver/example_config.yaml
@@ -11,6 +11,7 @@ receivers:
       memory:
       disk:
       filesystem:
+      network:
 
 exporters:
   logging:

--- a/receiver/hostmetricsreceiver/factory.go
+++ b/receiver/hostmetricsreceiver/factory.go
@@ -31,6 +31,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector/receiver/hostmetricsreceiver/internal/scraper/diskscraper"
 	"github.com/open-telemetry/opentelemetry-collector/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper"
 	"github.com/open-telemetry/opentelemetry-collector/receiver/hostmetricsreceiver/internal/scraper/memoryscraper"
+	"github.com/open-telemetry/opentelemetry-collector/receiver/hostmetricsreceiver/internal/scraper/networkscraper"
 )
 
 // This file implements Factory for HostMetrics receiver.
@@ -54,6 +55,7 @@ func NewFactory() *Factory {
 			diskscraper.TypeStr:       &diskscraper.Factory{},
 			filesystemscraper.TypeStr: &filesystemscraper.Factory{},
 			memoryscraper.TypeStr:     &memoryscraper.Factory{},
+			networkscraper.TypeStr:    &networkscraper.Factory{},
 		},
 	}
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/config.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/config.go
@@ -1,0 +1,22 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package networkscraper
+
+import "github.com/open-telemetry/opentelemetry-collector/receiver/hostmetricsreceiver/internal"
+
+// Config relating to Network Metric Scraper.
+type Config struct {
+	internal.ConfigSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
+}

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/factory.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/factory.go
@@ -1,0 +1,51 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package networkscraper
+
+import (
+	"context"
+
+	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector/consumer"
+	"github.com/open-telemetry/opentelemetry-collector/receiver/hostmetricsreceiver/internal"
+)
+
+// This file implements Factory for Network scraper.
+
+const (
+	// The value of "type" key in configuration.
+	TypeStr = "network"
+)
+
+// Factory is the Factory for scraper.
+type Factory struct {
+}
+
+// CreateDefaultConfig creates the default configuration for the Scraper.
+func (f *Factory) CreateDefaultConfig() internal.Config {
+	return &Config{}
+}
+
+// CreateMetricsScraper creates a scraper based on provided config.
+func (f *Factory) CreateMetricsScraper(
+	ctx context.Context,
+	logger *zap.Logger,
+	config internal.Config,
+	consumer consumer.MetricsConsumer,
+) (internal.Scraper, error) {
+	cfg := config.(*Config)
+	return NewNetworkScraper(ctx, cfg, consumer)
+}

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/factory_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/factory_test.go
@@ -1,0 +1,33 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package networkscraper
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+)
+
+func TestCreateMetricsScraper(t *testing.T) {
+	factory := &Factory{}
+	cfg := &Config{}
+
+	scraper, err := factory.CreateMetricsScraper(context.Background(), zap.NewNop(), cfg, nil)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, scraper)
+}

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/network_constants.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/network_constants.go
@@ -1,0 +1,91 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package networkscraper
+
+import (
+	"github.com/open-telemetry/opentelemetry-collector/consumer/pdata"
+)
+
+// network metric constants
+
+const (
+	directionLabelName = "direction"
+	stateLabelName     = "state"
+)
+
+const (
+	receiveDirectionLabelValue  = "receive"
+	transmitDirectionLabelValue = "transmit"
+)
+
+var metricNetworkPacketsDescriptor = createMetricNetworkPacketsDescriptor()
+
+func createMetricNetworkPacketsDescriptor() pdata.MetricDescriptor {
+	descriptor := pdata.NewMetricDescriptor()
+	descriptor.InitEmpty()
+	descriptor.SetName("host/network/packets")
+	descriptor.SetDescription("The number of packets transferred.")
+	descriptor.SetUnit("1")
+	descriptor.SetType(pdata.MetricTypeCounterInt64)
+	return descriptor
+}
+
+var metricNetworkDroppedPacketsDescriptor = createMetricNetworkDroppedPacketsDescriptor()
+
+func createMetricNetworkDroppedPacketsDescriptor() pdata.MetricDescriptor {
+	descriptor := pdata.NewMetricDescriptor()
+	descriptor.InitEmpty()
+	descriptor.SetName("host/network/dropped_packets")
+	descriptor.SetDescription("The number of packets dropped.")
+	descriptor.SetUnit("1")
+	descriptor.SetType(pdata.MetricTypeCounterInt64)
+	return descriptor
+}
+
+var metricNetworkErrorsDescriptor = createMetricNetworkErrorsDescriptor()
+
+func createMetricNetworkErrorsDescriptor() pdata.MetricDescriptor {
+	descriptor := pdata.NewMetricDescriptor()
+	descriptor.InitEmpty()
+	descriptor.SetName("host/network/errors")
+	descriptor.SetDescription("The number of errors encountered")
+	descriptor.SetUnit("1")
+	descriptor.SetType(pdata.MetricTypeCounterInt64)
+	return descriptor
+}
+
+var metricNetworkBytesDescriptor = createMetricNetworkBytesDescriptor()
+
+func createMetricNetworkBytesDescriptor() pdata.MetricDescriptor {
+	descriptor := pdata.NewMetricDescriptor()
+	descriptor.InitEmpty()
+	descriptor.SetName("host/network/bytes")
+	descriptor.SetDescription("The number of bytes transmitted and received")
+	descriptor.SetUnit("bytes")
+	descriptor.SetType(pdata.MetricTypeCounterInt64)
+	return descriptor
+}
+
+var metricNetworkTCPConnectionDescriptor = createMetricNetworkTCPConnectionDescriptor()
+
+func createMetricNetworkTCPConnectionDescriptor() pdata.MetricDescriptor {
+	descriptor := pdata.NewMetricDescriptor()
+	descriptor.InitEmpty()
+	descriptor.SetName("host/network/tcp_connections")
+	descriptor.SetDescription("The number of tcp connections")
+	descriptor.SetUnit("bytes")
+	descriptor.SetType(pdata.MetricTypeGaugeInt64)
+	return descriptor
+}

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/network_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/network_scraper.go
@@ -1,0 +1,203 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package networkscraper
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/shirou/gopsutil/host"
+	"github.com/shirou/gopsutil/net"
+	"go.opencensus.io/trace"
+
+	"github.com/open-telemetry/opentelemetry-collector/component/componenterror"
+	"github.com/open-telemetry/opentelemetry-collector/consumer"
+	"github.com/open-telemetry/opentelemetry-collector/consumer/pdata"
+	"github.com/open-telemetry/opentelemetry-collector/consumer/pdatautil"
+	"github.com/open-telemetry/opentelemetry-collector/internal/data"
+	"github.com/open-telemetry/opentelemetry-collector/receiver/hostmetricsreceiver/internal"
+)
+
+// Scraper for Network Metrics
+type Scraper struct {
+	config    *Config
+	consumer  consumer.MetricsConsumer
+	startTime pdata.TimestampUnixNano
+	cancel    context.CancelFunc
+}
+
+// NewNetworkScraper creates a set of Network related metrics
+func NewNetworkScraper(ctx context.Context, cfg *Config, consumer consumer.MetricsConsumer) (*Scraper, error) {
+	return &Scraper{config: cfg, consumer: consumer}, nil
+}
+
+// Start
+func (c *Scraper) Start(ctx context.Context) error {
+	ctx, c.cancel = context.WithCancel(ctx)
+
+	bootTime, err := host.BootTime()
+	if err != nil {
+		return err
+	}
+
+	c.startTime = pdata.TimestampUnixNano(bootTime)
+
+	go func() {
+		ticker := time.NewTicker(c.config.CollectionInterval())
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ticker.C:
+				c.scrapeMetrics(ctx)
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	return nil
+}
+
+// Shutdown
+func (c *Scraper) Shutdown(ctx context.Context) error {
+	c.cancel()
+	return nil
+}
+
+func (c *Scraper) scrapeMetrics(ctx context.Context) {
+	ctx, span := trace.StartSpan(ctx, "networkscraper.scrapeMetrics")
+	defer span.End()
+
+	metricData := data.NewMetricData()
+	metrics := internal.InitializeMetricSlice(metricData)
+
+	err := c.scrapeAndAppendMetrics(metrics)
+	if err != nil {
+		span.SetStatus(trace.Status{Code: trace.StatusCodeDataLoss, Message: fmt.Sprintf("Error(s) when scraping network metrics: %v", err)})
+		return
+	}
+
+	if metrics.Len() > 0 {
+		err := c.consumer.ConsumeMetrics(ctx, pdatautil.MetricsFromInternalMetrics(metricData))
+		if err != nil {
+			span.SetStatus(trace.Status{Code: trace.StatusCodeDataLoss, Message: fmt.Sprintf("Unable to process metrics: %v", err)})
+			return
+		}
+	}
+}
+
+// scrapeAndAppendMetrics appends scraped metrics to the provided metric slice.
+// If errors occur scraping some metrics, an error will be returned, but the
+// successfully scraped metrics will still be appended to the provided slice
+func (c *Scraper) scrapeAndAppendMetrics(metrics pdata.MetricSlice) error {
+	var errors []error
+
+	err := scrapeAndAppendNetworkCounterMetrics(metrics, c.startTime)
+	if err != nil {
+		errors = append(errors, err)
+	}
+
+	err = scrapeAndAppendNetworkTCPConnectionsMetric(metrics)
+	if err != nil {
+		errors = append(errors, err)
+	}
+
+	if len(errors) > 0 {
+		return componenterror.CombineErrors(errors)
+	}
+
+	return nil
+}
+
+func scrapeAndAppendNetworkCounterMetrics(metrics pdata.MetricSlice, startTime pdata.TimestampUnixNano) error {
+	// get total stats only
+	perNetworkInterfaceController := false
+
+	networkStatsSlice, err := net.IOCounters(perNetworkInterfaceController)
+	if err != nil {
+		return err
+	}
+
+	networkStats := networkStatsSlice[0]
+
+	startIdx := metrics.Len()
+	metrics.Resize(startIdx + 4)
+	initializeNetworkMetric(metrics.At(startIdx+0), metricNetworkPacketsDescriptor, startTime, networkStats.PacketsSent, networkStats.PacketsRecv)
+	initializeNetworkMetric(metrics.At(startIdx+1), metricNetworkDroppedPacketsDescriptor, startTime, networkStats.Dropout, networkStats.Dropin)
+	initializeNetworkMetric(metrics.At(startIdx+2), metricNetworkErrorsDescriptor, startTime, networkStats.Errout, networkStats.Errin)
+	initializeNetworkMetric(metrics.At(startIdx+3), metricNetworkBytesDescriptor, startTime, networkStats.BytesSent, networkStats.BytesRecv)
+	return nil
+}
+
+func initializeNetworkMetric(metric pdata.Metric, metricDescriptor pdata.MetricDescriptor, startTime pdata.TimestampUnixNano, transmitValue, receiveValue uint64) {
+	metricDescriptor.CopyTo(metric.MetricDescriptor())
+
+	idps := metric.Int64DataPoints()
+	idps.Resize(2)
+	initializeNetworkDataPoint(idps.At(0), startTime, transmitDirectionLabelValue, int64(transmitValue))
+	initializeNetworkDataPoint(idps.At(1), startTime, receiveDirectionLabelValue, int64(receiveValue))
+}
+
+func initializeNetworkDataPoint(dataPoint pdata.Int64DataPoint, startTime pdata.TimestampUnixNano, directionLabel string, value int64) {
+	labelsMap := dataPoint.LabelsMap()
+	labelsMap.Insert(directionLabelName, directionLabel)
+	dataPoint.SetStartTime(startTime)
+	dataPoint.SetTimestamp(pdata.TimestampUnixNano(uint64(time.Now().UnixNano())))
+	dataPoint.SetValue(value)
+}
+
+func scrapeAndAppendNetworkTCPConnectionsMetric(metrics pdata.MetricSlice) error {
+	connections, err := net.Connections("tcp")
+	if err != nil {
+		return err
+	}
+
+	connectionStatusCounts := getConnectionStatusCounts(connections)
+
+	metric := internal.AddNewMetric(metrics)
+	initializeNetworkTCPConnectionsMetric(metric, connectionStatusCounts)
+	return nil
+}
+
+func getConnectionStatusCounts(connections []net.ConnectionStat) map[string]int64 {
+	connectionStatuses := make(map[string]int64, len(connections))
+	for _, connection := range connections {
+		connectionStatuses[strings.ToLower(connection.Status)]++
+	}
+	return connectionStatuses
+}
+
+func initializeNetworkTCPConnectionsMetric(metric pdata.Metric, connectionStateCounts map[string]int64) {
+	metricNetworkTCPConnectionDescriptor.CopyTo(metric.MetricDescriptor())
+
+	idps := metric.Int64DataPoints()
+	idps.Resize(len(connectionStateCounts))
+
+	i := 0
+	for connectionState, count := range connectionStateCounts {
+		initializeTCPConnectionsDataPoint(idps.At(i), connectionState, count)
+		i++
+	}
+}
+
+func initializeTCPConnectionsDataPoint(dataPoint pdata.Int64DataPoint, stateLabel string, value int64) {
+	labelsMap := dataPoint.LabelsMap()
+	labelsMap.Insert(stateLabelName, stateLabel)
+	dataPoint.SetTimestamp(pdata.TimestampUnixNano(uint64(time.Now().UnixNano())))
+	dataPoint.SetValue(value)
+}

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/network_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/network_scraper_test.go
@@ -1,0 +1,81 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package networkscraper
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-telemetry/opentelemetry-collector/consumer/pdata"
+	"github.com/open-telemetry/opentelemetry-collector/exporter/exportertest"
+	"github.com/open-telemetry/opentelemetry-collector/receiver/hostmetricsreceiver/internal"
+)
+
+type validationFn func(*testing.T, []pdata.Metrics)
+
+func TestScrapeMetrics(t *testing.T) {
+	createScraperAndValidateScrapedMetrics(t, &Config{}, func(t *testing.T, got []pdata.Metrics) {
+		metrics := internal.AssertSingleMetricDataAndGetMetricsSlice(t, got)
+
+		// expect 5 metrics
+		assert.Equal(t, 5, metrics.Len())
+
+		// for network packets, dropped packets, errors, & bytes metrics, expect a transmit & receive datapoint
+		assertNetworkMetricMatchesDescriptorAndHasTransmitAndReceiveDataPoints(t, metrics.At(0), metricNetworkPacketsDescriptor)
+		assertNetworkMetricMatchesDescriptorAndHasTransmitAndReceiveDataPoints(t, metrics.At(1), metricNetworkDroppedPacketsDescriptor)
+		assertNetworkMetricMatchesDescriptorAndHasTransmitAndReceiveDataPoints(t, metrics.At(2), metricNetworkErrorsDescriptor)
+		assertNetworkMetricMatchesDescriptorAndHasTransmitAndReceiveDataPoints(t, metrics.At(3), metricNetworkBytesDescriptor)
+
+		// for tcp connections metric, expect at least one datapoint with a state label
+		hostNetworkTCPConnectionsMetric := metrics.At(4)
+		internal.AssertDescriptorEqual(t, metricNetworkTCPConnectionDescriptor, hostNetworkTCPConnectionsMetric.MetricDescriptor())
+		internal.AssertInt64MetricLabelExists(t, hostNetworkTCPConnectionsMetric, 0, stateLabelName)
+		assert.GreaterOrEqual(t, hostNetworkTCPConnectionsMetric.Int64DataPoints().Len(), 1)
+	})
+}
+
+func assertNetworkMetricMatchesDescriptorAndHasTransmitAndReceiveDataPoints(t *testing.T, metric pdata.Metric, expectedDescriptor pdata.MetricDescriptor) {
+	internal.AssertDescriptorEqual(t, expectedDescriptor, metric.MetricDescriptor())
+	assert.Equal(t, 2, metric.Int64DataPoints().Len())
+	internal.AssertInt64MetricLabelHasValue(t, metric, 0, directionLabelName, transmitDirectionLabelValue)
+	internal.AssertInt64MetricLabelHasValue(t, metric, 1, directionLabelName, receiveDirectionLabelValue)
+}
+
+func createScraperAndValidateScrapedMetrics(t *testing.T, config *Config, assertFn validationFn) {
+	config.SetCollectionInterval(5 * time.Millisecond)
+
+	sink := &exportertest.SinkMetricsExporter{}
+
+	scraper, err := NewNetworkScraper(context.Background(), config, sink)
+	require.NoError(t, err, "Failed to create network scraper: %v", err)
+
+	err = scraper.Start(context.Background())
+	require.NoError(t, err, "Failed to start network scraper: %v", err)
+	defer func() { assert.NoError(t, scraper.Shutdown(context.Background())) }()
+
+	require.Eventually(t, func() bool {
+		got := sink.AllMetrics()
+		if len(got) == 0 {
+			return false
+		}
+
+		assertFn(t, got)
+		return true
+	}, time.Second, 2*time.Millisecond, "No metrics were collected")
+}


### PR DESCRIPTION
**Link to tracking Issue:**
https://github.com/open-telemetry/opentelemetry-collector/issues/847

**Description:**
Added network scraper to the hostmetricsreceiver which uses gopsutil to collect metrics related to network usage & the number of active tcp connections

**Exported Metrics:**

![image](https://user-images.githubusercontent.com/568630/81364371-d1a21080-9128-11ea-8c6b-1f3861afc261.png)
