### PR TITLE
Add support for client IP detection to Jaeger Thrift HTTP receiver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,8 @@ BUILD_X2=-X $(BUILD_INFO_IMPORT_PATH).Version=$(VERSION)
 endif
 BUILD_INFO=-ldflags "${BUILD_X1} ${BUILD_X2}"
 
+RUN_CONFIG=local/config.yaml
+
 all-srcs:
 	@echo $(ALL_SRC) | tr ' ' '\n' | sort
 
@@ -137,6 +139,10 @@ install-tools:
 .PHONY: otelcol
 otelcol:
 	GO111MODULE=on CGO_ENABLED=0 go build -o ./bin/otelcol_$(GOOS)_$(GOARCH) $(BUILD_INFO) ./cmd/otelcol
+
+.PHONY: run
+run:
+	GO111MODULE=on go run --race ./cmd/otelcol/... --config ${RUN_CONFIG}
 
 .PHONY: docker-component # Not intended to be used directly
 docker-component: check-component

--- a/receiver/jaegerreceiver/errors.go
+++ b/receiver/jaegerreceiver/errors.go
@@ -1,0 +1,24 @@
+// Copyright 2019, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package jaegerreceiver
+
+type httpError struct {
+	msg        string
+	statusCode int
+}
+
+func (h httpError) Error() string {
+	return h.msg
+}

--- a/receiver/jaegerreceiver/trace_receiver.go
+++ b/receiver/jaegerreceiver/trace_receiver.go
@@ -19,6 +19,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/ioutil"
+	"mime"
 	"net"
 	"net/http"
 	"sync"
@@ -111,6 +113,13 @@ const (
 
 	thriftFormat   = "thrift"
 	protobufFormat = "protobuf"
+)
+
+var (
+	acceptedThriftFormats = map[string]struct{}{
+		"application/x-thrift":                 {},
+		"application/vnd.apache.thrift.binary": {},
+	}
 )
 
 // New creates a TraceReceiver that receives traffic as a Jaeger collector, and
@@ -287,18 +296,6 @@ func consumeTraces(
 	return jbsr, numSpans, consumerError
 }
 
-func (jr *jReceiver) SubmitBatches(batches []*jaeger.Batch, options handler.SubmitBatchOptions) ([]*jaeger.BatchSubmitResponse, error) {
-	ctx := obsreport.ReceiverContext(
-		context.Background(), jr.instanceName, collectorHTTPTransport, collectorReceiverTagValue)
-	ctx = obsreport.StartTraceDataReceiveOp(
-		ctx, jr.instanceName, collectorHTTPTransport)
-
-	jbsr, numSpans, err := consumeTraces(ctx, batches, jr.nextConsumer)
-	obsreport.EndTraceDataReceiveOp(ctx, thriftFormat, numSpans, err)
-
-	return jbsr, err
-}
-
 var _ jaeger.Agent = (*agentHandler)(nil)
 var _ api_v2.CollectorServiceServer = (*jReceiver)(nil)
 var _ configmanager.ClientConfigManager = (*jReceiver)(nil)
@@ -437,6 +434,69 @@ func (jr *jReceiver) buildProcessor(address string, factory apacheThrift.TProtoc
 	return processor, nil
 }
 
+func (jr *jReceiver) decodeThriftHTTPBody(r *http.Request) (*jaeger.Batch, *httpError) {
+	bodyBytes, err := ioutil.ReadAll(r.Body)
+	r.Body.Close()
+	if err != nil {
+		return nil, &httpError{
+			handler.UnableToReadBodyErrFormat,
+			http.StatusInternalServerError,
+		}
+	}
+
+	contentType, _, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+	if err != nil {
+		return nil, &httpError{
+			fmt.Sprintf("Cannot parse content type: %v", err),
+			http.StatusBadRequest,
+		}
+	}
+	if _, ok := acceptedThriftFormats[contentType]; !ok {
+		return nil, &httpError{
+			fmt.Sprintf("Unsupported content type: %v", contentType),
+			http.StatusBadRequest,
+		}
+	}
+
+	tdes := apacheThrift.NewTDeserializer()
+	batch := &jaeger.Batch{}
+	if err = tdes.Read(batch, bodyBytes); err != nil {
+		return nil, &httpError{
+			fmt.Sprintf(handler.UnableToReadBodyErrFormat, err),
+			http.StatusBadRequest,
+		}
+	}
+	return batch, nil
+}
+
+// HandleThriftHTTPBatch implements Jaeger HTTP Thrift handler.
+func (jr *jReceiver) HandleThriftHTTPBatch(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	if c, ok := client.FromHTTP(r); ok {
+		ctx = client.NewContext(ctx, c)
+	}
+
+	ctx = obsreport.ReceiverContext(
+		ctx, jr.instanceName, collectorHTTPTransport, collectorReceiverTagValue)
+	ctx = obsreport.StartTraceDataReceiveOp(
+		ctx, jr.instanceName, collectorHTTPTransport)
+
+	batch, hErr := jr.decodeThriftHTTPBody(r)
+	if hErr != nil {
+		http.Error(w, hErr.msg, hErr.statusCode)
+		obsreport.EndTraceDataReceiveOp(ctx, thriftFormat, 0, hErr)
+		return
+	}
+
+	_, numSpans, err := consumeTraces(ctx, []*jaeger.Batch{batch}, jr.nextConsumer)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Cannot submit Jaeger batch: %v", err), http.StatusInternalServerError)
+	} else {
+		w.WriteHeader(http.StatusAccepted)
+	}
+	obsreport.EndTraceDataReceiveOp(ctx, thriftFormat, numSpans, err)
+}
+
 func (jr *jReceiver) startCollector(host component.Host) error {
 	if !jr.collectorGRPCEnabled() && !jr.collectorHTTPEnabled() {
 		return nil
@@ -451,8 +511,7 @@ func (jr *jReceiver) startCollector(host component.Host) error {
 		}
 
 		nr := mux.NewRouter()
-		apiHandler := handler.NewAPIHandler(jr)
-		apiHandler.RegisterRoutes(nr)
+		nr.HandleFunc("/api/traces", jr.HandleThriftHTTPBatch).Methods(http.MethodPost)
 		jr.collectorServer = &http.Server{Handler: nr}
 		go func() {
 			_ = jr.collectorServer.Serve(cln)


### PR DESCRIPTION
**Description:** This pulls in one more function from Jaeger collector that deals more
directly with the HTTP request object. We need reference to HTTP request
object and we need a way to pass the request context on to the next
consumer.

**Testing:** Tested manually and added a test case