### PR TITLE
Remove unnecessary log tags from processors

### DIFF
--- a/processor/memorylimiter/memorylimiter.go
+++ b/processor/memorylimiter/memorylimiter.go
@@ -195,9 +195,8 @@ func (ml *memoryLimiter) readMemStats(ms *runtime.MemStats) {
 		// This indicates misconfiguration. Log it once.
 		if !ml.configMismatchedLogged {
 			ml.configMismatchedLogged = true
-			ml.logger.Warn(typeStr+" is likely incorrectly configured. "+ballastSizeMibKey+
-				" must be set equal to --mem-ballast-size-mib command line option.",
-				zap.String("processor", ml.procName))
+			ml.logger.Warn(typeStr + " is likely incorrectly configured. " + ballastSizeMibKey +
+				" must be set equal to --mem-ballast-size-mib command line option.")
 		}
 	}
 }


### PR DESCRIPTION
The service builder adds by default log tags for:
* kind (receiver, exporter, processor)
* type
* name

See https://github.com/open-telemetry/opentelemetry-collector/blob/master/service/builder/pipelines_builder.go#L155