### PR TITLE
Minor changes to Obsreport

### DIFF
--- a/obsreport/obsreport.go
+++ b/obsreport/obsreport.go
@@ -85,7 +85,8 @@ func Configure(
 	return views
 }
 
-// CountMetricPoints is a helper to count the "amount" of metrics data.
+// CountMetricPoints is a helper to count the "amount" of metrics data. For code using the
+// internal data structure, pdatautil.MetricAndDataPointCount should be used instead
 func CountMetricPoints(md consumerdata.MetricsData) (numTimeSeries int, numPoints int) {
 	for _, metric := range md.Metrics {
 		tss := metric.GetTimeseries()

--- a/obsreport/obsreport_receiver.go
+++ b/obsreport/obsreport_receiver.go
@@ -237,10 +237,12 @@ func ReceiverContext(
 	}
 
 	if useNew {
-		mutators := []tag.Mutator{
-			tag.Upsert(tagKeyReceiver, receiver, tag.WithTTL(tag.TTLNoPropagation)),
-			tag.Upsert(tagKeyTransport, transport, tag.WithTTL(tag.TTLNoPropagation)),
+		mutators := make([]tag.Mutator, 0, 2)
+		mutators = append(mutators, tag.Upsert(tagKeyReceiver, receiver, tag.WithTTL(tag.TTLNoPropagation)))
+		if transport != "" {
+			mutators = append(mutators, tag.Upsert(tagKeyTransport, transport, tag.WithTTL(tag.TTLNoPropagation)))
 		}
+
 		ctx, _ = tag.New(ctx, mutators...)
 	}
 
@@ -278,8 +280,9 @@ func traceReceiveOp(
 		ctx = trace.NewContext(receiverCtx, span)
 	}
 
-	span.AddAttributes(trace.StringAttribute(
-		TransportKey, transport))
+	if transport != "" {
+		span.AddAttributes(trace.StringAttribute(TransportKey, transport))
+	}
 	return ctx
 }
 


### PR DESCRIPTION
**Link to tracking Issue:**
https://github.com/open-telemetry/opentelemetry-collector/issues/918

**Description:**
Made the "transport" parameter that's used to set a corresponding attribute value optional for obsreport receiver functions. This parameter doesn't make sense for all receivers.

Also added a comment regarding using the internal data structure with the CountMetricPoints function.