### PR TITLE
Rename host metrics disk scraper receive/transmit labels to read/write

### DIFF
--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_constants.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_constants.go
@@ -26,8 +26,8 @@ const (
 )
 
 const (
-	receiveDirectionLabelValue  = "receive"
-	transmitDirectionLabelValue = "transmit"
+	readDirectionLabelValue  = "read"
+	writeDirectionLabelValue = "write"
 )
 
 var metricDiskBytesDescriptor = createMetricDiskBytesDescriptor()

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper.go
@@ -120,8 +120,8 @@ func initializeMetricDiskBytes(metric pdata.Metric, ioCounters map[string]disk.I
 
 	idx := 0
 	for device, ioCounter := range ioCounters {
-		initializeDataPoint(idps.At(idx+0), startTime, device, receiveDirectionLabelValue, int64(ioCounter.ReadBytes))
-		initializeDataPoint(idps.At(idx+1), startTime, device, transmitDirectionLabelValue, int64(ioCounter.WriteBytes))
+		initializeDataPoint(idps.At(idx+0), startTime, device, readDirectionLabelValue, int64(ioCounter.ReadBytes))
+		initializeDataPoint(idps.At(idx+1), startTime, device, writeDirectionLabelValue, int64(ioCounter.WriteBytes))
 		idx += 2
 	}
 }
@@ -134,8 +134,8 @@ func initializeMetricDiskOps(metric pdata.Metric, ioCounters map[string]disk.IOC
 
 	idx := 0
 	for device, ioCounter := range ioCounters {
-		initializeDataPoint(idps.At(idx+0), startTime, device, receiveDirectionLabelValue, int64(ioCounter.ReadCount))
-		initializeDataPoint(idps.At(idx+1), startTime, device, transmitDirectionLabelValue, int64(ioCounter.WriteCount))
+		initializeDataPoint(idps.At(idx+0), startTime, device, readDirectionLabelValue, int64(ioCounter.ReadCount))
+		initializeDataPoint(idps.At(idx+1), startTime, device, writeDirectionLabelValue, int64(ioCounter.WriteCount))
 		idx += 2
 	}
 }
@@ -148,8 +148,8 @@ func initializeMetricDiskTime(metric pdata.Metric, ioCounters map[string]disk.IO
 
 	idx := 0
 	for device, ioCounter := range ioCounters {
-		initializeDataPoint(idps.At(idx+0), startTime, device, receiveDirectionLabelValue, int64(ioCounter.ReadTime))
-		initializeDataPoint(idps.At(idx+1), startTime, device, transmitDirectionLabelValue, int64(ioCounter.WriteTime))
+		initializeDataPoint(idps.At(idx+0), startTime, device, readDirectionLabelValue, int64(ioCounter.ReadTime))
+		initializeDataPoint(idps.At(idx+1), startTime, device, writeDirectionLabelValue, int64(ioCounter.WriteTime))
 		idx += 2
 	}
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_test.go
@@ -36,27 +36,18 @@ func TestScrapeMetrics(t *testing.T) {
 		// expect 3 metrics
 		assert.Equal(t, 3, metrics.Len())
 
-		// for disk byts metric, expect a receive & transmit datapoint for at least one drive
-		hostDiskBytesMetric := metrics.At(0)
-		internal.AssertDescriptorEqual(t, metricDiskBytesDescriptor, hostDiskBytesMetric.MetricDescriptor())
-		assert.GreaterOrEqual(t, hostDiskBytesMetric.Int64DataPoints().Len(), 2)
-		internal.AssertInt64MetricLabelHasValue(t, hostDiskBytesMetric, 0, directionLabelName, receiveDirectionLabelValue)
-		internal.AssertInt64MetricLabelHasValue(t, hostDiskBytesMetric, 1, directionLabelName, transmitDirectionLabelValue)
-
-		// for disk operations metric, expect a receive & transmit datapoint for at least one drive
-		hostDiskOpsMetric := metrics.At(1)
-		internal.AssertDescriptorEqual(t, metricDiskOpsDescriptor, hostDiskOpsMetric.MetricDescriptor())
-		assert.GreaterOrEqual(t, hostDiskOpsMetric.Int64DataPoints().Len(), 2)
-		internal.AssertInt64MetricLabelHasValue(t, hostDiskOpsMetric, 0, directionLabelName, receiveDirectionLabelValue)
-		internal.AssertInt64MetricLabelHasValue(t, hostDiskOpsMetric, 1, directionLabelName, transmitDirectionLabelValue)
-
-		// for disk time metric, expect a receive & transmit datapoint for at least one drive
-		hostDiskTimeMetric := metrics.At(2)
-		internal.AssertDescriptorEqual(t, metricDiskTimeDescriptor, hostDiskTimeMetric.MetricDescriptor())
-		assert.GreaterOrEqual(t, hostDiskTimeMetric.Int64DataPoints().Len(), 2)
-		internal.AssertInt64MetricLabelHasValue(t, hostDiskTimeMetric, 0, directionLabelName, receiveDirectionLabelValue)
-		internal.AssertInt64MetricLabelHasValue(t, hostDiskTimeMetric, 1, directionLabelName, transmitDirectionLabelValue)
+		// for disk byts metric, expect a read & write datapoint for at least one drive
+		assertDiskMetricMatchesDescriptorAndHasReadAndWriteDataPoints(t, metrics.At(0), metricDiskBytesDescriptor)
+		assertDiskMetricMatchesDescriptorAndHasReadAndWriteDataPoints(t, metrics.At(1), metricDiskOpsDescriptor)
+		assertDiskMetricMatchesDescriptorAndHasReadAndWriteDataPoints(t, metrics.At(2), metricDiskTimeDescriptor)
 	})
+}
+
+func assertDiskMetricMatchesDescriptorAndHasReadAndWriteDataPoints(t *testing.T, metric pdata.Metric, expectedDescriptor pdata.MetricDescriptor) {
+	internal.AssertDescriptorEqual(t, expectedDescriptor, metric.MetricDescriptor())
+	assert.GreaterOrEqual(t, metric.Int64DataPoints().Len(), 2)
+	internal.AssertInt64MetricLabelHasValue(t, metric, 0, directionLabelName, readDirectionLabelValue)
+	internal.AssertInt64MetricLabelHasValue(t, metric, 1, directionLabelName, writeDirectionLabelValue)
 }
 
 func createScraperAndValidateScrapedMetrics(t *testing.T, config *Config, assertFn validationFn) {


### PR DESCRIPTION
**Link to tracking Issue:**
https://github.com/open-telemetry/opentelemetry-collector/issues/847

**Description:**
Renamed disk scraper receive/transmit labels to read/write (this was just a typo before - receive/transmit was meant to be for network metrics rather than disk)