### PR TITLE
Support secure connections in Jaeger remote sampling gRPC receiver

### DIFF
--- a/receiver/jaegerreceiver/config.go
+++ b/receiver/jaegerreceiver/config.go
@@ -15,6 +15,7 @@
 package jaegerreceiver
 
 import (
+	"github.com/open-telemetry/opentelemetry-collector/config/configgrpc"
 	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
 	"github.com/open-telemetry/opentelemetry-collector/receiver"
 )
@@ -24,9 +25,9 @@ const protocolsFieldName = "protocols"
 
 // RemoteSamplingConfig defines config key for remote sampling fetch endpoint
 type RemoteSamplingConfig struct {
-	HostEndpoint  string `mapstructure:"host_endpoint"`
-	FetchEndpoint string `mapstructure:"fetch_endpoint"`
-	StrategyFile  string `mapstructure:"strategy_file"`
+	HostEndpoint            string `mapstructure:"host_endpoint"`
+	StrategyFile            string `mapstructure:"strategy_file"`
+	configgrpc.GRPCSettings `mapstructure:",squash"`
 }
 
 // Config defines configuration for Jaeger receiver.

--- a/receiver/jaegerreceiver/config_test.go
+++ b/receiver/jaegerreceiver/config_test.go
@@ -18,6 +18,8 @@ import (
 	"path"
 	"testing"
 
+	"github.com/open-telemetry/opentelemetry-collector/config/configgrpc"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -67,9 +69,11 @@ func TestLoadConfig(t *testing.T) {
 				},
 			},
 			RemoteSampling: &RemoteSamplingConfig{
-				HostEndpoint:  "0.0.0.0:5778",
-				FetchEndpoint: "jaeger-collector:1234",
-				StrategyFile:  "/etc/strategies.json",
+				HostEndpoint: "0.0.0.0:5778",
+				GRPCSettings: configgrpc.GRPCSettings{
+					Endpoint: "jaeger-collector:1234",
+				},
+				StrategyFile: "/etc/strategies.json",
 			},
 		})
 

--- a/receiver/jaegerreceiver/config_test.go
+++ b/receiver/jaegerreceiver/config_test.go
@@ -18,12 +18,11 @@ import (
 	"path"
 	"testing"
 
-	"github.com/open-telemetry/opentelemetry-collector/config/configgrpc"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/open-telemetry/opentelemetry-collector/config"
+	"github.com/open-telemetry/opentelemetry-collector/config/configgrpc"
 	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
 	"github.com/open-telemetry/opentelemetry-collector/receiver"
 )

--- a/receiver/jaegerreceiver/factory.go
+++ b/receiver/jaegerreceiver/factory.go
@@ -179,10 +179,9 @@ func (f *Factory) CreateTraceReceiver(
 	}
 
 	if remoteSamplingConfig != nil {
-		if len(remoteSamplingConfig.FetchEndpoint) == 0 {
-			config.RemoteSamplingEndpoint = defaultGRPCBindEndpoint
-		} else {
-			config.RemoteSamplingEndpoint = remoteSamplingConfig.FetchEndpoint
+		config.RemoteSamplingClientSettings = remoteSamplingConfig.GRPCSettings
+		if len(config.RemoteSamplingClientSettings.Endpoint) == 0 {
+			config.RemoteSamplingClientSettings.Endpoint = defaultGRPCBindEndpoint
 		}
 
 		if len(remoteSamplingConfig.HostEndpoint) == 0 {

--- a/receiver/jaegerreceiver/factory_test.go
+++ b/receiver/jaegerreceiver/factory_test.go
@@ -19,8 +19,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/open-telemetry/opentelemetry-collector/config/configgrpc"
-
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 
@@ -28,6 +26,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector/config"
 	"github.com/open-telemetry/opentelemetry-collector/config/configcheck"
 	"github.com/open-telemetry/opentelemetry-collector/config/configerror"
+	"github.com/open-telemetry/opentelemetry-collector/config/configgrpc"
 	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
 	"github.com/open-telemetry/opentelemetry-collector/receiver"
 )

--- a/receiver/jaegerreceiver/factory_test.go
+++ b/receiver/jaegerreceiver/factory_test.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/open-telemetry/opentelemetry-collector/config/configgrpc"
+
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 
@@ -142,7 +144,7 @@ func TestDefaultAgentRemoteSamplingEndpointAndPort(t *testing.T) {
 	r, err := factory.CreateTraceReceiver(context.Background(), params, cfg, nil)
 
 	assert.NoError(t, err, "create trace receiver should not error")
-	assert.Equal(t, defaultGRPCBindEndpoint, r.(*jReceiver).config.RemoteSamplingEndpoint)
+	assert.Equal(t, defaultGRPCBindEndpoint, r.(*jReceiver).config.RemoteSamplingClientSettings.Endpoint)
 	assert.Equal(t, defaultAgentRemoteSamplingHTTPPort, r.(*jReceiver).config.AgentHTTPPort, "agent http port should be default")
 }
 
@@ -154,13 +156,15 @@ func TestAgentRemoteSamplingEndpoint(t *testing.T) {
 	endpoint := "localhost:1234"
 	rCfg.Protocols[protoThriftCompact], _ = defaultsForProtocol(protoThriftCompact)
 	rCfg.RemoteSampling = &RemoteSamplingConfig{
-		FetchEndpoint: endpoint,
+		GRPCSettings: configgrpc.GRPCSettings{
+			Endpoint: endpoint,
+		},
 	}
 	params := component.ReceiverCreateParams{Logger: zap.NewNop()}
 	r, err := factory.CreateTraceReceiver(context.Background(), params, cfg, nil)
 
 	assert.NoError(t, err, "create trace receiver should not error")
-	assert.Equal(t, endpoint, r.(*jReceiver).config.RemoteSamplingEndpoint)
+	assert.Equal(t, endpoint, r.(*jReceiver).config.RemoteSamplingClientSettings.Endpoint)
 	assert.Equal(t, defaultAgentRemoteSamplingHTTPPort, r.(*jReceiver).config.AgentHTTPPort, "agent http port should be default")
 }
 
@@ -263,15 +267,17 @@ func TestRemoteSamplingConfigPropagation(t *testing.T) {
 	strategyFile := "strategies.json"
 	rCfg.Protocols[protoGRPC], _ = defaultsForProtocol(protoGRPC)
 	rCfg.RemoteSampling = &RemoteSamplingConfig{
-		FetchEndpoint: endpoint,
-		HostEndpoint:  fmt.Sprintf("localhost:%d", hostPort),
-		StrategyFile:  strategyFile,
+		GRPCSettings: configgrpc.GRPCSettings{
+			Endpoint: endpoint,
+		},
+		HostEndpoint: fmt.Sprintf("localhost:%d", hostPort),
+		StrategyFile: strategyFile,
 	}
 	params := component.ReceiverCreateParams{Logger: zap.NewNop()}
 	r, err := factory.CreateTraceReceiver(context.Background(), params, cfg, nil)
 
 	assert.NoError(t, err, "create trace receiver should not error")
-	assert.Equal(t, endpoint, r.(*jReceiver).config.RemoteSamplingEndpoint)
+	assert.Equal(t, endpoint, r.(*jReceiver).config.RemoteSamplingClientSettings.Endpoint)
 	assert.Equal(t, hostPort, r.(*jReceiver).config.AgentHTTPPort, "agent http port should be configured value")
 	assert.Equal(t, strategyFile, r.(*jReceiver).config.RemoteSamplingStrategyFile)
 }

--- a/receiver/jaegerreceiver/jaeger_agent_test.go
+++ b/receiver/jaegerreceiver/jaeger_agent_test.go
@@ -22,8 +22,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/open-telemetry/opentelemetry-collector/config/configgrpc"
-
 	"contrib.go.opencensus.io/exporter/jaeger"
 	"github.com/jaegertracing/jaeger/proto-gen/api_v2"
 	"github.com/stretchr/testify/assert"
@@ -33,6 +31,7 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-collector/component"
 	"github.com/open-telemetry/opentelemetry-collector/component/componenttest"
+	"github.com/open-telemetry/opentelemetry-collector/config/configgrpc"
 	"github.com/open-telemetry/opentelemetry-collector/exporter/exportertest"
 	"github.com/open-telemetry/opentelemetry-collector/testutils"
 )

--- a/receiver/jaegerreceiver/jaeger_agent_test.go
+++ b/receiver/jaegerreceiver/jaeger_agent_test.go
@@ -22,6 +22,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/open-telemetry/opentelemetry-collector/config/configgrpc"
+
 	"contrib.go.opencensus.io/exporter/jaeger"
 	"github.com/jaegertracing/jaeger/proto-gen/api_v2"
 	"github.com/stretchr/testify/assert"
@@ -137,8 +139,10 @@ func TestJaegerHTTP(t *testing.T) {
 
 	port := testutils.GetAvailablePort(t)
 	config := &Configuration{
-		AgentHTTPPort:          int(port),
-		RemoteSamplingEndpoint: addr.String(),
+		AgentHTTPPort: int(port),
+		RemoteSamplingClientSettings: configgrpc.GRPCSettings{
+			Endpoint: addr.String(),
+		},
 	}
 	params := component.ReceiverCreateParams{Logger: zap.NewNop()}
 	jr, err := New(jaegerAgent, config, nil, params)

--- a/receiver/jaegerreceiver/testdata/config.yaml
+++ b/receiver/jaegerreceiver/testdata/config.yaml
@@ -15,7 +15,7 @@ receivers:
         endpoint: "0.0.0.0:789"
     remote_sampling:
       host_endpoint: "0.0.0.0:5778"
-      fetch_endpoint: "jaeger-collector:1234"
+      endpoint: "jaeger-collector:1234"
       strategy_file: "/etc/strategies.json"
   # The following demonstrates how to enable protocols with defaults.
   jaeger/defaults:

--- a/receiver/jaegerreceiver/trace_receiver.go
+++ b/receiver/jaegerreceiver/trace_receiver.go
@@ -23,6 +23,8 @@ import (
 	"net/http"
 	"sync"
 
+	"github.com/open-telemetry/opentelemetry-collector/config/configgrpc"
+
 	apacheThrift "github.com/apache/thrift/lib/go/thrift"
 	"github.com/gorilla/mux"
 	"github.com/jaegertracing/jaeger/cmd/agent/app/configmanager"
@@ -63,11 +65,11 @@ type Configuration struct {
 	CollectorGRPCPort    int
 	CollectorGRPCOptions []grpc.ServerOption
 
-	AgentCompactThriftPort     int
-	AgentBinaryThriftPort      int
-	AgentHTTPPort              int
-	RemoteSamplingEndpoint     string
-	RemoteSamplingStrategyFile string
+	AgentCompactThriftPort       int
+	AgentBinaryThriftPort        int
+	AgentHTTPPort                int
+	RemoteSamplingClientSettings configgrpc.GRPCSettings
+	RemoteSamplingStrategyFile   string
 }
 
 // Receiver type is used to receive spans that were originally intended to be sent to Jaeger.
@@ -396,10 +398,15 @@ func (jr *jReceiver) startAgent(_ component.Host) error {
 	}
 
 	// Start upstream grpc client before serving sampling endpoints over HTTP
-	if jr.config.RemoteSamplingEndpoint != "" {
-		conn, err := grpc.Dial(jr.config.RemoteSamplingEndpoint, grpc.WithInsecure())
+	if jr.config.RemoteSamplingClientSettings.Endpoint != "" {
+		grpcOpts, err := configgrpc.GrpcSettingsToDialOptions(jr.config.RemoteSamplingClientSettings)
 		if err != nil {
-			jr.logger.Error("Error creating grpc connection to jaeger remote sampling endpoint", zap.String("endpoint", jr.config.RemoteSamplingEndpoint))
+			jr.logger.Error("Error creating grpc dial options for remote sampling endpoint", zap.Error(err))
+			return err
+		}
+		conn, err := grpc.Dial(jr.config.RemoteSamplingClientSettings.Endpoint, grpcOpts...)
+		if err != nil {
+			jr.logger.Error("Error creating grpc connection to jaeger remote sampling endpoint", zap.String("endpoint", jr.config.RemoteSamplingClientSettings.Endpoint))
 			return err
 		}
 

--- a/receiver/jaegerreceiver/trace_receiver.go
+++ b/receiver/jaegerreceiver/trace_receiver.go
@@ -23,8 +23,6 @@ import (
 	"net/http"
 	"sync"
 
-	"github.com/open-telemetry/opentelemetry-collector/config/configgrpc"
-
 	apacheThrift "github.com/apache/thrift/lib/go/thrift"
 	"github.com/gorilla/mux"
 	"github.com/jaegertracing/jaeger/cmd/agent/app/configmanager"
@@ -47,6 +45,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector/client"
 	"github.com/open-telemetry/opentelemetry-collector/component"
 	"github.com/open-telemetry/opentelemetry-collector/component/componenterror"
+	"github.com/open-telemetry/opentelemetry-collector/config/configgrpc"
 	"github.com/open-telemetry/opentelemetry-collector/consumer"
 	"github.com/open-telemetry/opentelemetry-collector/obsreport"
 	jaegertranslator "github.com/open-telemetry/opentelemetry-collector/translator/trace/jaeger"


### PR DESCRIPTION
Signed-off-by: Pavol Loffay <ploffay@redhat.com>

**Description:** <Describe what has changed>

This PR adds support for secure connections for gRPC remote sampling receiver used in Jaeger agent or delegated collector.

There is a breaking code change but also the configuration -
`receivers.jaeger.remote_sampling.fetch_endpoint` changes to `receivers.jaeger.remote_sampling.endpoint`.

**Link to tracking Issue:** <Issue number if applicable>

Resolves #461 

**Testing:** < Describe what testing was performed and which tests were added.>

**Documentation:** < Describe the documentation added.>