### PR TITLE
Increase limits for TestTrace10kSPS/OpenCensus

### DIFF
--- a/testbed/tests/trace_test.go
+++ b/testbed/tests/trace_test.go
@@ -63,7 +63,7 @@ func TestTrace10kSPS(t *testing.T) {
 			testbed.NewOCTraceDataSender(testbed.GetAvailablePort(t)),
 			testbed.NewOCDataReceiver(testbed.GetAvailablePort(t)),
 			testbed.ResourceSpec{
-				ExpectedMaxCPU: 30,
+				ExpectedMaxCPU: 39,
 				ExpectedMaxRAM: 60,
 			},
 		},


### PR DESCRIPTION
The limits are set too low and sporadically fail when CI runs a bit slower
than usual. We normally set limits to 1.3x of observed maximum.
