### PR TITLE
Simplify the host metrics ticker logic

### DIFF
--- a/receiver/hostmetricsreceiver/README.md
+++ b/receiver/hostmetricsreceiver/README.md
@@ -3,17 +3,38 @@
 The Host Metrics receiver generates metrics about the host system. This is intended to be used when the collector is
 deployed as an agent.
 
-The categories of metrics scraped can be configured under the `scrapers` key, e.g. to scrape cpu, memory and disk metrics
-(note not all of these are implemented yet):
+The categories of metrics scraped can be configured under the `scrapers` key, e.g. to scrape cpu, memory and disk metrics:
 
-```
+```yaml
 hostmetrics:
-  default_collection_interval: 10s
+  collection_interval: 1m
   scrapers:
     cpu:
-      report_per_cpu: true
     memory:
     disk:
+```
+
+If you would like to scrape some metrics at a different frequency than others, you can configure multiple hostmetrics
+receivers with different collection_interval values, e.g.
+
+```yaml
+receivers:
+  hostmetrics:
+    collection_interval: 30s
+    scrapers:
+      cpu:
+      memory:
+
+  hostmetrics/disk:
+    collection_interval: 1m
+    scrapers:
+      disk:
+      filesystem:
+
+service:
+  pipelines:
+    metrics:
+      receivers: [hostmetrics, hostmetrics/disk]
 ```
 
 ## OS Support

--- a/receiver/hostmetricsreceiver/config.go
+++ b/receiver/hostmetricsreceiver/config.go
@@ -25,6 +25,6 @@ import (
 type Config struct {
 	configmodels.ReceiverSettings `mapstructure:",squash"`
 
-	DefaultCollectionInterval time.Duration              `mapstructure:"default_collection_interval"`
-	Scrapers                  map[string]internal.Config `mapstructure:"-"`
+	CollectionInterval time.Duration              `mapstructure:"collection_interval"`
+	Scrapers           map[string]internal.Config `mapstructure:"-"`
 }

--- a/receiver/hostmetricsreceiver/config_test.go
+++ b/receiver/hostmetricsreceiver/config_test.go
@@ -48,7 +48,7 @@ func TestLoadConfig(t *testing.T) {
 	r0 := cfg.Receivers["hostmetrics"]
 	defaultConfigAllScrapers := factory.CreateDefaultConfig()
 	defaultConfigAllScrapers.(*Config).Scrapers = map[string]internal.Config{
-		cpuscraper.TypeStr: getDefaultConfigWithDefaultCollectionInterval(&cpuscraper.Factory{}),
+		cpuscraper.TypeStr: (&cpuscraper.Factory{}).CreateDefaultConfig(),
 	}
 	assert.Equal(t, r0, defaultConfigAllScrapers)
 
@@ -59,30 +59,13 @@ func TestLoadConfig(t *testing.T) {
 				TypeVal: typeStr,
 				NameVal: "hostmetrics/customname",
 			},
-			DefaultCollectionInterval: 1 * time.Minute,
+			CollectionInterval: 30 * time.Second,
 			Scrapers: map[string]internal.Config{
-				cpuscraper.TypeStr: &cpuscraper.Config{
-					ConfigSettings: internal.ConfigSettings{CollectionIntervalValue: 1 * time.Minute},
-					ReportPerCPU:   true,
-				},
-				diskscraper.TypeStr: &diskscraper.Config{
-					ConfigSettings: internal.ConfigSettings{CollectionIntervalValue: 5 * time.Minute},
-				},
-				filesystemscraper.TypeStr: &filesystemscraper.Config{
-					ConfigSettings: internal.ConfigSettings{CollectionIntervalValue: 5 * time.Minute},
-				},
-				memoryscraper.TypeStr: &memoryscraper.Config{
-					ConfigSettings: internal.ConfigSettings{CollectionIntervalValue: 30 * time.Second},
-				},
-				networkscraper.TypeStr: &networkscraper.Config{
-					ConfigSettings: internal.ConfigSettings{CollectionIntervalValue: 45 * time.Second},
-				},
+				cpuscraper.TypeStr:        &cpuscraper.Config{ReportPerCPU: true},
+				diskscraper.TypeStr:       &diskscraper.Config{},
+				filesystemscraper.TypeStr: &filesystemscraper.Config{},
+				memoryscraper.TypeStr:     &memoryscraper.Config{},
+				networkscraper.TypeStr:    &networkscraper.Config{},
 			},
 		})
-}
-
-func getDefaultConfigWithDefaultCollectionInterval(factory internal.Factory) internal.Config {
-	cfg := factory.CreateDefaultConfig()
-	cfg.SetCollectionInterval(10 * time.Second)
-	return cfg
 }

--- a/receiver/hostmetricsreceiver/config_test.go
+++ b/receiver/hostmetricsreceiver/config_test.go
@@ -26,6 +26,10 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
 	"github.com/open-telemetry/opentelemetry-collector/receiver/hostmetricsreceiver/internal"
 	"github.com/open-telemetry/opentelemetry-collector/receiver/hostmetricsreceiver/internal/scraper/cpuscraper"
+	"github.com/open-telemetry/opentelemetry-collector/receiver/hostmetricsreceiver/internal/scraper/diskscraper"
+	"github.com/open-telemetry/opentelemetry-collector/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper"
+	"github.com/open-telemetry/opentelemetry-collector/receiver/hostmetricsreceiver/internal/scraper/memoryscraper"
+	"github.com/open-telemetry/opentelemetry-collector/receiver/hostmetricsreceiver/internal/scraper/networkscraper"
 )
 
 func TestLoadConfig(t *testing.T) {
@@ -55,11 +59,23 @@ func TestLoadConfig(t *testing.T) {
 				TypeVal: typeStr,
 				NameVal: "hostmetrics/customname",
 			},
-			DefaultCollectionInterval: 10 * time.Second,
+			DefaultCollectionInterval: 1 * time.Minute,
 			Scrapers: map[string]internal.Config{
 				cpuscraper.TypeStr: &cpuscraper.Config{
-					ConfigSettings: internal.ConfigSettings{CollectionIntervalValue: 5 * time.Second},
+					ConfigSettings: internal.ConfigSettings{CollectionIntervalValue: 1 * time.Minute},
 					ReportPerCPU:   true,
+				},
+				diskscraper.TypeStr: &diskscraper.Config{
+					ConfigSettings: internal.ConfigSettings{CollectionIntervalValue: 5 * time.Minute},
+				},
+				filesystemscraper.TypeStr: &filesystemscraper.Config{
+					ConfigSettings: internal.ConfigSettings{CollectionIntervalValue: 5 * time.Minute},
+				},
+				memoryscraper.TypeStr: &memoryscraper.Config{
+					ConfigSettings: internal.ConfigSettings{CollectionIntervalValue: 30 * time.Second},
+				},
+				networkscraper.TypeStr: &networkscraper.Config{
+					ConfigSettings: internal.ConfigSettings{CollectionIntervalValue: 45 * time.Second},
 				},
 			},
 		})

--- a/receiver/hostmetricsreceiver/example_config.yaml
+++ b/receiver/hostmetricsreceiver/example_config.yaml
@@ -4,10 +4,10 @@ extensions:
 
 receivers:
   hostmetrics:
-    default_collection_interval: 60s
+    collection_interval: 1m
     scrapers:
       cpu:
-        report_per_cpu: true
+        report_per_cpu: false
       memory:
       disk:
       filesystem:

--- a/receiver/hostmetricsreceiver/hostmetrics_receiver.go
+++ b/receiver/hostmetricsreceiver/hostmetrics_receiver.go
@@ -19,37 +19,35 @@ import (
 	"fmt"
 	"time"
 
-	gopshost "github.com/shirou/gopsutil/host"
 	"go.opencensus.io/trace"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector/component"
 	"github.com/open-telemetry/opentelemetry-collector/component/componenterror"
 	"github.com/open-telemetry/opentelemetry-collector/consumer"
-	"github.com/open-telemetry/opentelemetry-collector/consumer/pdata"
 	"github.com/open-telemetry/opentelemetry-collector/consumer/pdatautil"
 	"github.com/open-telemetry/opentelemetry-collector/internal/data"
 	"github.com/open-telemetry/opentelemetry-collector/receiver/hostmetricsreceiver/internal"
 )
 
-// Receiver is the type that scrapes various host metrics.
-type Receiver struct {
-	config          *Config
-	groupedScrapers map[time.Duration][]internal.Scraper
-	consumer        consumer.MetricsConsumer
-	cancel          context.CancelFunc
+// receiver is the type that scrapes various host metrics.
+type receiver struct {
+	config   *Config
+	scrapers []internal.Scraper
+	consumer consumer.MetricsConsumer
+	cancel   context.CancelFunc
 }
 
-// NewHostMetricsReceiver creates a host metrics scraper.
-func NewHostMetricsReceiver(
+// newHostMetricsReceiver creates a host metrics scraper.
+func newHostMetricsReceiver(
 	ctx context.Context,
 	logger *zap.Logger,
 	config *Config,
 	factories map[string]internal.Factory,
 	consumer consumer.MetricsConsumer,
-) (*Receiver, error) {
+) (*receiver, error) {
 
-	groupedScrapers := make(map[time.Duration][]internal.Scraper, len(config.Scrapers))
+	scrapers := make([]internal.Scraper, 0)
 	for key, cfg := range config.Scrapers {
 		factory := factories[key]
 		if factory == nil {
@@ -60,16 +58,13 @@ func NewHostMetricsReceiver(
 		if err != nil {
 			return nil, fmt.Errorf("cannot create scraper: %s", err.Error())
 		}
-
-		// minimize the number of tickers needed by grouping scrapers that have the same collection interval
-		collectionInterval := cfg.CollectionInterval()
-		groupedScrapers[collectionInterval] = append(groupedScrapers[collectionInterval], scraper)
+		scrapers = append(scrapers, scraper)
 	}
 
-	hmr := &Receiver{
-		config:          config,
-		groupedScrapers: groupedScrapers,
-		consumer:        consumer,
+	hmr := &receiver{
+		config:   config,
+		scrapers: scrapers,
+		consumer: consumer,
 	}
 
 	return hmr, nil
@@ -77,54 +72,42 @@ func NewHostMetricsReceiver(
 
 // Start initializes the underlying scrapers and begins scraping
 // host metrics based on the OS platform.
-func (hmr *Receiver) Start(ctx context.Context, host component.Host) error {
+func (hmr *receiver) Start(ctx context.Context, host component.Host) error {
 	ctx, hmr.cancel = context.WithCancel(ctx)
 
 	go func() {
 		hmr.initializeScrapers(ctx, host)
-		for collectionInterval, scrapers := range hmr.groupedScrapers {
-			hmr.startScrapers(ctx, collectionInterval, scrapers)
-		}
+		hmr.startScrapers(ctx)
 	}()
 
 	return nil
 }
 
 // Shutdown terminates all tickers and stops the underlying scrapers.
-func (hmr *Receiver) Shutdown(ctx context.Context) error {
+func (hmr *receiver) Shutdown(ctx context.Context) error {
 	hmr.cancel()
 	return hmr.closeScrapers(ctx)
 }
 
-func (hmr *Receiver) initializeScrapers(ctx context.Context, host component.Host) {
-	bootTime, err := gopshost.BootTime()
-	if err != nil {
-		host.ReportFatalError(err)
-		return
-	}
-
-	startTime := pdata.TimestampUnixNano(bootTime)
-
-	for _, scrapers := range hmr.groupedScrapers {
-		for _, scraper := range scrapers {
-			err := scraper.Initialize(ctx, startTime)
-			if err != nil {
-				host.ReportFatalError(err)
-				return
-			}
+func (hmr *receiver) initializeScrapers(ctx context.Context, host component.Host) {
+	for _, scraper := range hmr.scrapers {
+		err := scraper.Initialize(ctx)
+		if err != nil {
+			host.ReportFatalError(err)
+			return
 		}
 	}
 }
 
-func (hmr *Receiver) startScrapers(ctx context.Context, collectionInterval time.Duration, scrapers []internal.Scraper) {
+func (hmr *receiver) startScrapers(ctx context.Context) {
 	go func() {
-		ticker := time.NewTicker(collectionInterval)
+		ticker := time.NewTicker(hmr.config.CollectionInterval)
 		defer ticker.Stop()
 
 		for {
 			select {
 			case <-ticker.C:
-				hmr.scrapeAndAppendMetrics(context.Background(), scrapers)
+				hmr.scrapeAndAppendMetrics(context.Background(), hmr.scrapers)
 			case <-ctx.Done():
 				return
 			}
@@ -132,7 +115,7 @@ func (hmr *Receiver) startScrapers(ctx context.Context, collectionInterval time.
 	}()
 }
 
-func (hmr *Receiver) scrapeAndAppendMetrics(ctx context.Context, scrapers []internal.Scraper) {
+func (hmr *receiver) scrapeAndAppendMetrics(ctx context.Context, scrapers []internal.Scraper) {
 	ctx, span := trace.StartSpan(ctx, "hostmetricsreceiver.scrapeAndAppendMetrics")
 	defer span.End()
 
@@ -160,14 +143,12 @@ func (hmr *Receiver) scrapeAndAppendMetrics(ctx context.Context, scrapers []inte
 	}
 }
 
-func (hmr *Receiver) closeScrapers(ctx context.Context) error {
+func (hmr *receiver) closeScrapers(ctx context.Context) error {
 	var errs []error
-	for _, scrapers := range hmr.groupedScrapers {
-		for _, scraper := range scrapers {
-			err := scraper.Close(ctx)
-			if err != nil {
-				errs = append(errs, err)
-			}
+	for _, scraper := range hmr.scrapers {
+		err := scraper.Close(ctx)
+		if err != nil {
+			errs = append(errs, err)
 		}
 	}
 

--- a/receiver/hostmetricsreceiver/hostmetrics_receiver.go
+++ b/receiver/hostmetricsreceiver/hostmetrics_receiver.go
@@ -17,19 +17,27 @@ package hostmetricsreceiver
 import (
 	"context"
 	"fmt"
+	"time"
 
+	gopshost "github.com/shirou/gopsutil/host"
+	"go.opencensus.io/trace"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector/component"
 	"github.com/open-telemetry/opentelemetry-collector/component/componenterror"
 	"github.com/open-telemetry/opentelemetry-collector/consumer"
+	"github.com/open-telemetry/opentelemetry-collector/consumer/pdata"
+	"github.com/open-telemetry/opentelemetry-collector/consumer/pdatautil"
+	"github.com/open-telemetry/opentelemetry-collector/internal/data"
 	"github.com/open-telemetry/opentelemetry-collector/receiver/hostmetricsreceiver/internal"
 )
 
 // Receiver is the type that scrapes various host metrics.
 type Receiver struct {
-	config   *Config
-	scrapers []internal.Scraper
+	config          *Config
+	groupedScrapers map[time.Duration][]internal.Scraper
+	consumer        consumer.MetricsConsumer
+	cancel          context.CancelFunc
 }
 
 // NewHostMetricsReceiver creates a host metrics scraper.
@@ -41,51 +49,125 @@ func NewHostMetricsReceiver(
 	consumer consumer.MetricsConsumer,
 ) (*Receiver, error) {
 
-	scrapers := make([]internal.Scraper, 0)
+	groupedScrapers := make(map[time.Duration][]internal.Scraper, len(config.Scrapers))
 	for key, cfg := range config.Scrapers {
 		factory := factories[key]
 		if factory == nil {
 			return nil, fmt.Errorf("host metrics scraper factory not found for key: %s", key)
 		}
 
-		scraper, err := factory.CreateMetricsScraper(ctx, logger, cfg, consumer)
+		scraper, err := factory.CreateMetricsScraper(ctx, logger, cfg)
 		if err != nil {
 			return nil, fmt.Errorf("cannot create scraper: %s", err.Error())
 		}
-		scrapers = append(scrapers, scraper)
+
+		// minimize the number of tickers needed by grouping scrapers that have the same collection interval
+		collectionInterval := cfg.CollectionInterval()
+		groupedScrapers[collectionInterval] = append(groupedScrapers[collectionInterval], scraper)
 	}
 
 	hmr := &Receiver{
-		config:   config,
-		scrapers: scrapers,
+		config:          config,
+		groupedScrapers: groupedScrapers,
+		consumer:        consumer,
 	}
 
 	return hmr, nil
 }
 
-// Start begins scraping host metrics based on the OS platform.
+// Start initializes the underlying scrapers and begins scraping
+// host metrics based on the OS platform.
 func (hmr *Receiver) Start(ctx context.Context, host component.Host) error {
+	ctx, hmr.cancel = context.WithCancel(ctx)
+
 	go func() {
-		for _, scraper := range hmr.scrapers {
-			err := scraper.Start(ctx)
-			if err != nil {
-				host.ReportFatalError(err)
-				return
-			}
+		hmr.initializeScrapers(ctx, host)
+		for collectionInterval, scrapers := range hmr.groupedScrapers {
+			hmr.startScrapers(ctx, collectionInterval, scrapers)
 		}
 	}()
 
 	return nil
 }
 
-// Shutdown stops the underlying host metrics scrapers.
+// Shutdown terminates all tickers and stops the underlying scrapers.
 func (hmr *Receiver) Shutdown(ctx context.Context) error {
-	var errs []error
+	hmr.cancel()
+	return hmr.closeScrapers(ctx)
+}
 
-	for _, scraper := range hmr.scrapers {
-		err := scraper.Shutdown(ctx)
+func (hmr *Receiver) initializeScrapers(ctx context.Context, host component.Host) {
+	bootTime, err := gopshost.BootTime()
+	if err != nil {
+		host.ReportFatalError(err)
+		return
+	}
+
+	startTime := pdata.TimestampUnixNano(bootTime)
+
+	for _, scrapers := range hmr.groupedScrapers {
+		for _, scraper := range scrapers {
+			err := scraper.Initialize(ctx, startTime)
+			if err != nil {
+				host.ReportFatalError(err)
+				return
+			}
+		}
+	}
+}
+
+func (hmr *Receiver) startScrapers(ctx context.Context, collectionInterval time.Duration, scrapers []internal.Scraper) {
+	go func() {
+		ticker := time.NewTicker(collectionInterval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ticker.C:
+				hmr.scrapeAndAppendMetrics(context.Background(), scrapers)
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+}
+
+func (hmr *Receiver) scrapeAndAppendMetrics(ctx context.Context, scrapers []internal.Scraper) {
+	ctx, span := trace.StartSpan(ctx, "hostmetricsreceiver.scrapeAndAppendMetrics")
+	defer span.End()
+
+	metricData := data.NewMetricData()
+	metrics := internal.InitializeMetricSlice(metricData)
+
+	var errors []error
+	for _, scraper := range scrapers {
+		err := scraper.ScrapeAndAppendMetrics(ctx, metrics)
 		if err != nil {
-			errs = append(errs, err)
+			errors = append(errors, err)
+		}
+	}
+
+	if len(errors) > 0 {
+		span.SetStatus(trace.Status{Code: trace.StatusCodeDataLoss, Message: fmt.Sprintf("Error(s) when scraping metrics: %v", componenterror.CombineErrors(errors))})
+	}
+
+	if metrics.Len() > 0 {
+		err := hmr.consumer.ConsumeMetrics(ctx, pdatautil.MetricsFromInternalMetrics(metricData))
+		if err != nil {
+			span.SetStatus(trace.Status{Code: trace.StatusCodeDataLoss, Message: fmt.Sprintf("Unable to process metrics: %v", err)})
+			return
+		}
+	}
+}
+
+func (hmr *Receiver) closeScrapers(ctx context.Context) error {
+	var errs []error
+	for _, scrapers := range hmr.groupedScrapers {
+		for _, scraper := range scrapers {
+			err := scraper.Close(ctx)
+			if err != nil {
+				errs = append(errs, err)
+			}
 		}
 	}
 

--- a/receiver/hostmetricsreceiver/internal/metricutils.go
+++ b/receiver/hostmetricsreceiver/internal/metricutils.go
@@ -29,11 +29,3 @@ func InitializeMetricSlice(metricData data.MetricData) pdata.MetricSlice {
 	ilm := ilms.At(0)
 	return ilm.Metrics()
 }
-
-// AddNewMetric appends an empty metric to the metric slice, resizing
-// the slice by 1, and returns the new metric.
-func AddNewMetric(metrics pdata.MetricSlice) pdata.Metric {
-	len := metrics.Len()
-	metrics.Resize(len + 1)
-	return metrics.At(len)
-}

--- a/receiver/hostmetricsreceiver/internal/scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper.go
@@ -31,11 +31,10 @@ type Scraper interface {
 	// Close should clean up any unmanaged resources such as
 	// performance counter handles.
 	Close(ctx context.Context) error
-	// ScrapeAndAppendMetrics scrapes relevant metrics and appends them to
-	// the provided metric slice. If errors occur scraping some metrics,
-	// an error should be returned, but successfully scraped metrics should
-	// still be appended to the provided slice.
-	ScrapeAndAppendMetrics(ctx context.Context, metrics pdata.MetricSlice) error
+	// ScrapeMetrics returns relevant scraped metrics. If errors occur
+	// scraping some metrics, an error should be returned, but any
+	// metrics that were successfully scraped should still be returned.
+	ScrapeMetrics(ctx context.Context) (pdata.MetricSlice, error)
 }
 
 // Factory can create a Scraper.

--- a/receiver/hostmetricsreceiver/internal/scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper.go
@@ -16,7 +16,6 @@ package internal
 
 import (
 	"context"
-	"time"
 
 	"go.uber.org/zap"
 
@@ -28,7 +27,7 @@ import (
 type Scraper interface {
 	// Initialize performs any timely initialization tasks such as
 	// setting up performance counters for initial collection.
-	Initialize(ctx context.Context, startTime pdata.TimestampUnixNano) error
+	Initialize(ctx context.Context) error
 	// Close should clean up any unmanaged resources such as
 	// performance counter handles.
 	Close(ctx context.Context) error
@@ -54,23 +53,8 @@ type Factory interface {
 
 // Config is the configuration of a scraper.
 type Config interface {
-	// CollectionInterval returns the interval at which the scraper collects metrics
-	CollectionInterval() time.Duration
-	// SetCollectionInterval sets the interval at which the scraper collects metrics
-	SetCollectionInterval(time.Duration)
 }
 
 // ConfigSettings provides common settings for scraper configuration.
 type ConfigSettings struct {
-	CollectionIntervalValue time.Duration `mapstructure:"collection_interval"`
-}
-
-// CollectionInterval returns the interval at which the scraper collects metrics
-func (c *ConfigSettings) CollectionInterval() time.Duration {
-	return c.CollectionIntervalValue
-}
-
-// SetCollectionInterval sets the interval at which the scraper collects metrics
-func (c *ConfigSettings) SetCollectionInterval(interval time.Duration) {
-	c.CollectionIntervalValue = interval
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper.go
@@ -19,35 +19,41 @@ import (
 	"time"
 
 	"github.com/shirou/gopsutil/cpu"
+	"github.com/shirou/gopsutil/host"
 	"go.opencensus.io/trace"
 
 	"github.com/open-telemetry/opentelemetry-collector/consumer/pdata"
 )
 
-// Scraper for CPU Metrics
-type Scraper struct {
+// scraper for CPU Metrics
+type scraper struct {
 	config    *Config
 	startTime pdata.TimestampUnixNano
 }
 
-// NewCPUScraper creates a set of CPU related metrics
-func NewCPUScraper(_ context.Context, cfg *Config) *Scraper {
-	return &Scraper{config: cfg}
+// newCPUScraper creates a set of CPU related metrics
+func newCPUScraper(_ context.Context, cfg *Config) *scraper {
+	return &scraper{config: cfg}
 }
 
 // Initialize
-func (s *Scraper) Initialize(_ context.Context, startTime pdata.TimestampUnixNano) error {
-	s.startTime = startTime
+func (s *scraper) Initialize(_ context.Context) error {
+	bootTime, err := host.BootTime()
+	if err != nil {
+		return err
+	}
+
+	s.startTime = pdata.TimestampUnixNano(bootTime)
 	return nil
 }
 
 // Close
-func (s *Scraper) Close(_ context.Context) error {
+func (s *scraper) Close(_ context.Context) error {
 	return nil
 }
 
 // ScrapeAndAppendMetrics
-func (s *Scraper) ScrapeAndAppendMetrics(ctx context.Context, metrics pdata.MetricSlice) error {
+func (s *scraper) ScrapeAndAppendMetrics(ctx context.Context, metrics pdata.MetricSlice) error {
 	_, span := trace.StartSpan(ctx, "cpuscraper.ScrapeAndAppendMetrics")
 	defer span.End()
 

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper.go
@@ -16,97 +16,49 @@ package cpuscraper
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/shirou/gopsutil/cpu"
-	"github.com/shirou/gopsutil/host"
 	"go.opencensus.io/trace"
 
-	"github.com/open-telemetry/opentelemetry-collector/consumer"
 	"github.com/open-telemetry/opentelemetry-collector/consumer/pdata"
-	"github.com/open-telemetry/opentelemetry-collector/consumer/pdatautil"
-	"github.com/open-telemetry/opentelemetry-collector/internal/data"
-	"github.com/open-telemetry/opentelemetry-collector/receiver/hostmetricsreceiver/internal"
 )
 
 // Scraper for CPU Metrics
 type Scraper struct {
 	config    *Config
-	consumer  consumer.MetricsConsumer
 	startTime pdata.TimestampUnixNano
-	cancel    context.CancelFunc
 }
 
 // NewCPUScraper creates a set of CPU related metrics
-func NewCPUScraper(ctx context.Context, cfg *Config, consumer consumer.MetricsConsumer) (*Scraper, error) {
-	return &Scraper{config: cfg, consumer: consumer}, nil
+func NewCPUScraper(_ context.Context, cfg *Config) *Scraper {
+	return &Scraper{config: cfg}
 }
 
-// Start
-func (c *Scraper) Start(ctx context.Context) error {
-	ctx, c.cancel = context.WithCancel(ctx)
-
-	bootTime, err := host.BootTime()
-	if err != nil {
-		return err
-	}
-
-	c.startTime = pdata.TimestampUnixNano(bootTime)
-
-	go func() {
-		ticker := time.NewTicker(c.config.CollectionInterval())
-		defer ticker.Stop()
-
-		for {
-			select {
-			case <-ticker.C:
-				c.scrapeMetrics(ctx)
-			case <-ctx.Done():
-				return
-			}
-		}
-	}()
-
+// Initialize
+func (s *Scraper) Initialize(_ context.Context, startTime pdata.TimestampUnixNano) error {
+	s.startTime = startTime
 	return nil
 }
 
-// Shutdown
-func (c *Scraper) Shutdown(ctx context.Context) error {
-	c.cancel()
+// Close
+func (s *Scraper) Close(_ context.Context) error {
 	return nil
 }
 
-func (c *Scraper) scrapeMetrics(ctx context.Context) {
-	ctx, span := trace.StartSpan(ctx, "cpuscraper.scrapeMetrics")
+// ScrapeAndAppendMetrics
+func (s *Scraper) ScrapeAndAppendMetrics(ctx context.Context, metrics pdata.MetricSlice) error {
+	_, span := trace.StartSpan(ctx, "cpuscraper.ScrapeAndAppendMetrics")
 	defer span.End()
 
-	metricData := data.NewMetricData()
-	metrics := internal.InitializeMetricSlice(metricData)
-
-	err := c.scrapeAndAppendMetrics(metrics)
-	if err != nil {
-		span.SetStatus(trace.Status{Code: trace.StatusCodeDataLoss, Message: fmt.Sprintf("Error(s) when scraping cpu metrics: %v", err)})
-		return
-	}
-
-	if metrics.Len() > 0 {
-		err := c.consumer.ConsumeMetrics(ctx, pdatautil.MetricsFromInternalMetrics(metricData))
-		if err != nil {
-			span.SetStatus(trace.Status{Code: trace.StatusCodeDataLoss, Message: fmt.Sprintf("Unable to process metrics: %v", err)})
-			return
-		}
-	}
-}
-
-func (c *Scraper) scrapeAndAppendMetrics(metrics pdata.MetricSlice) error {
-	cpuTimes, err := cpu.Times(c.config.ReportPerCPU)
+	cpuTimes, err := cpu.Times(s.config.ReportPerCPU)
 	if err != nil {
 		return err
 	}
 
-	metric := internal.AddNewMetric(metrics)
-	initializeCPUSecondsMetric(metric, c.startTime, cpuTimes)
+	startIdx := metrics.Len()
+	metrics.Resize(startIdx + 1)
+	initializeCPUSecondsMetric(metrics.At(startIdx), s.startTime, cpuTimes)
 	return nil
 }
 

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper.go
@@ -52,20 +52,21 @@ func (s *scraper) Close(_ context.Context) error {
 	return nil
 }
 
-// ScrapeAndAppendMetrics
-func (s *scraper) ScrapeAndAppendMetrics(ctx context.Context, metrics pdata.MetricSlice) error {
-	_, span := trace.StartSpan(ctx, "cpuscraper.ScrapeAndAppendMetrics")
+// ScrapeMetrics
+func (s *scraper) ScrapeMetrics(ctx context.Context) (pdata.MetricSlice, error) {
+	_, span := trace.StartSpan(ctx, "cpuscraper.ScrapeMetrics")
 	defer span.End()
+
+	metrics := pdata.NewMetricSlice()
 
 	cpuTimes, err := cpu.Times(s.config.ReportPerCPU)
 	if err != nil {
-		return err
+		return metrics, err
 	}
 
-	startIdx := metrics.Len()
-	metrics.Resize(startIdx + 1)
-	initializeCPUSecondsMetric(metrics.At(startIdx), s.startTime, cpuTimes)
-	return nil
+	metrics.Resize(1)
+	initializeCPUSecondsMetric(metrics.At(0), s.startTime, cpuTimes)
+	return metrics, nil
 }
 
 func initializeCPUSecondsMetric(metric pdata.Metric, startTime pdata.TimestampUnixNano, cpuTimes []cpu.TimesStat) {

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_test.go
@@ -89,8 +89,8 @@ func TestScrapeMetrics_Linux(t *testing.T) {
 }
 
 func createScraperAndValidateScrapedMetrics(t *testing.T, config *Config, assertFn validationFn) {
-	scraper := NewCPUScraper(context.Background(), config)
-	err := scraper.Initialize(context.Background(), pdata.TimestampUnixNano(0))
+	scraper := newCPUScraper(context.Background(), config)
+	err := scraper.Initialize(context.Background())
 	require.NoError(t, err, "Failed to initialize cpu scraper: %v", err)
 	defer func() { assert.NoError(t, scraper.Close(context.Background())) }()
 

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_test.go
@@ -94,8 +94,7 @@ func createScraperAndValidateScrapedMetrics(t *testing.T, config *Config, assert
 	require.NoError(t, err, "Failed to initialize cpu scraper: %v", err)
 	defer func() { assert.NoError(t, scraper.Close(context.Background())) }()
 
-	metrics := pdata.NewMetricSlice()
-	err = scraper.ScrapeAndAppendMetrics(context.Background(), metrics)
+	metrics, err := scraper.ScrapeMetrics(context.Background())
 	require.NoError(t, err, "Failed to scrape metrics: %v", err)
 
 	assertFn(t, metrics)

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_test.go
@@ -18,22 +18,18 @@ import (
 	"context"
 	"runtime"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/open-telemetry/opentelemetry-collector/consumer/pdata"
-	"github.com/open-telemetry/opentelemetry-collector/exporter/exportertest"
 	"github.com/open-telemetry/opentelemetry-collector/receiver/hostmetricsreceiver/internal"
 )
 
-type validationFn func(*testing.T, []pdata.Metrics)
+type validationFn func(*testing.T, pdata.MetricSlice)
 
 func TestScrapeMetrics_MinimalData(t *testing.T) {
-	createScraperAndValidateScrapedMetrics(t, &Config{}, func(t *testing.T, got []pdata.Metrics) {
-		metrics := internal.AssertSingleMetricDataAndGetMetricsSlice(t, got)
-
+	createScraperAndValidateScrapedMetrics(t, &Config{}, func(t *testing.T, metrics pdata.MetricSlice) {
 		// expect 1 metric
 		assert.Equal(t, 1, metrics.Len())
 
@@ -54,9 +50,7 @@ func TestScrapeMetrics_AllData(t *testing.T) {
 		ReportPerCPU: true,
 	}
 
-	createScraperAndValidateScrapedMetrics(t, config, func(t *testing.T, got []pdata.Metrics) {
-		metrics := internal.AssertSingleMetricDataAndGetMetricsSlice(t, got)
-
+	createScraperAndValidateScrapedMetrics(t, config, func(t *testing.T, metrics pdata.MetricSlice) {
 		// expect 1 metric
 		assert.Equal(t, 1, metrics.Len())
 
@@ -77,9 +71,7 @@ func TestScrapeMetrics_Linux(t *testing.T) {
 		return
 	}
 
-	createScraperAndValidateScrapedMetrics(t, &Config{}, func(t *testing.T, got []pdata.Metrics) {
-		metrics := internal.AssertSingleMetricDataAndGetMetricsSlice(t, got)
-
+	createScraperAndValidateScrapedMetrics(t, &Config{}, func(t *testing.T, metrics pdata.MetricSlice) {
 		// for cpu seconds metric, expect a datapoint for all 8 state labels
 		hostCPUTimeMetric := metrics.At(0)
 		internal.AssertDescriptorEqual(t, metricCPUSecondsDescriptor, hostCPUTimeMetric.MetricDescriptor())
@@ -97,24 +89,14 @@ func TestScrapeMetrics_Linux(t *testing.T) {
 }
 
 func createScraperAndValidateScrapedMetrics(t *testing.T, config *Config, assertFn validationFn) {
-	config.SetCollectionInterval(100 * time.Millisecond)
+	scraper := NewCPUScraper(context.Background(), config)
+	err := scraper.Initialize(context.Background(), pdata.TimestampUnixNano(0))
+	require.NoError(t, err, "Failed to initialize cpu scraper: %v", err)
+	defer func() { assert.NoError(t, scraper.Close(context.Background())) }()
 
-	sink := &exportertest.SinkMetricsExporter{}
+	metrics := pdata.NewMetricSlice()
+	err = scraper.ScrapeAndAppendMetrics(context.Background(), metrics)
+	require.NoError(t, err, "Failed to scrape metrics: %v", err)
 
-	scraper, err := NewCPUScraper(context.Background(), config, sink)
-	require.NoError(t, err, "Failed to create cpu scraper: %v", err)
-
-	err = scraper.Start(context.Background())
-	require.NoError(t, err, "Failed to start cpu scraper: %v", err)
-	defer func() { assert.NoError(t, scraper.Shutdown(context.Background())) }()
-
-	require.Eventually(t, func() bool {
-		got := sink.AllMetrics()
-		if len(got) == 0 {
-			return false
-		}
-
-		assertFn(t, got)
-		return true
-	}, time.Second, 10*time.Millisecond, "No metrics were collected")
+	assertFn(t, metrics)
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/factory.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/factory.go
@@ -19,7 +19,6 @@ import (
 
 	"go.uber.org/zap"
 
-	"github.com/open-telemetry/opentelemetry-collector/consumer"
 	"github.com/open-telemetry/opentelemetry-collector/receiver/hostmetricsreceiver/internal"
 )
 
@@ -44,10 +43,9 @@ func (f *Factory) CreateDefaultConfig() internal.Config {
 // CreateMetricsScraper creates a scraper based on provided config.
 func (f *Factory) CreateMetricsScraper(
 	ctx context.Context,
-	logger *zap.Logger,
+	_ *zap.Logger,
 	config internal.Config,
-	consumer consumer.MetricsConsumer,
 ) (internal.Scraper, error) {
 	cfg := config.(*Config)
-	return NewCPUScraper(ctx, cfg, consumer)
+	return NewCPUScraper(ctx, cfg), nil
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/factory.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/factory.go
@@ -35,9 +35,7 @@ type Factory struct {
 
 // CreateDefaultConfig creates the default configuration for the Scraper.
 func (f *Factory) CreateDefaultConfig() internal.Config {
-	return &Config{
-		ReportPerCPU: true,
-	}
+	return &Config{}
 }
 
 // CreateMetricsScraper creates a scraper based on provided config.
@@ -47,5 +45,5 @@ func (f *Factory) CreateMetricsScraper(
 	config internal.Config,
 ) (internal.Scraper, error) {
 	cfg := config.(*Config)
-	return NewCPUScraper(ctx, cfg), nil
+	return newCPUScraper(ctx, cfg), nil
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/factory_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/factory_test.go
@@ -26,7 +26,7 @@ func TestCreateDefaultConfig(t *testing.T) {
 	factory := &Factory{}
 	cfg := factory.CreateDefaultConfig()
 	assert.IsType(t, &Config{}, cfg)
-	assert.Equal(t, true, cfg.(*Config).ReportPerCPU)
+	assert.Equal(t, false, cfg.(*Config).ReportPerCPU)
 }
 
 func TestCreateMetricsScraper(t *testing.T) {

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/factory_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/factory_test.go
@@ -22,11 +22,18 @@ import (
 	"go.uber.org/zap"
 )
 
+func TestCreateDefaultConfig(t *testing.T) {
+	factory := &Factory{}
+	cfg := factory.CreateDefaultConfig()
+	assert.IsType(t, &Config{}, cfg)
+	assert.Equal(t, true, cfg.(*Config).ReportPerCPU)
+}
+
 func TestCreateMetricsScraper(t *testing.T) {
 	factory := &Factory{}
 	cfg := &Config{}
 
-	scraper, err := factory.CreateMetricsScraper(context.Background(), zap.NewNop(), cfg, nil)
+	scraper, err := factory.CreateMetricsScraper(context.Background(), zap.NewNop(), cfg)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, scraper)

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper.go
@@ -52,22 +52,23 @@ func (s *scraper) Close(_ context.Context) error {
 	return nil
 }
 
-// ScrapeAndAppendMetrics
-func (s *scraper) ScrapeAndAppendMetrics(ctx context.Context, metrics pdata.MetricSlice) error {
-	_, span := trace.StartSpan(ctx, "diskscraper.ScrapeAndAppendMetrics")
+// ScrapeMetrics
+func (s *scraper) ScrapeMetrics(ctx context.Context) (pdata.MetricSlice, error) {
+	_, span := trace.StartSpan(ctx, "diskscraper.ScrapeMetrics")
 	defer span.End()
+
+	metrics := pdata.NewMetricSlice()
 
 	ioCounters, err := disk.IOCounters()
 	if err != nil {
-		return err
+		return metrics, err
 	}
 
-	startIdx := metrics.Len()
-	metrics.Resize(startIdx + 3)
-	initializeMetricDiskBytes(metrics.At(startIdx+0), ioCounters, s.startTime)
-	initializeMetricDiskOps(metrics.At(startIdx+1), ioCounters, s.startTime)
-	initializeMetricDiskTime(metrics.At(startIdx+2), ioCounters, s.startTime)
-	return nil
+	metrics.Resize(3)
+	initializeMetricDiskBytes(metrics.At(0), ioCounters, s.startTime)
+	initializeMetricDiskOps(metrics.At(1), ioCounters, s.startTime)
+	initializeMetricDiskTime(metrics.At(2), ioCounters, s.startTime)
+	return metrics, nil
 }
 
 func initializeMetricDiskBytes(metric pdata.Metric, ioCounters map[string]disk.IOCountersStat, startTime pdata.TimestampUnixNano) {

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper.go
@@ -19,35 +19,41 @@ import (
 	"time"
 
 	"github.com/shirou/gopsutil/disk"
+	"github.com/shirou/gopsutil/host"
 	"go.opencensus.io/trace"
 
 	"github.com/open-telemetry/opentelemetry-collector/consumer/pdata"
 )
 
-// Scraper for Disk Metrics
-type Scraper struct {
+// scraper for Disk Metrics
+type scraper struct {
 	config    *Config
 	startTime pdata.TimestampUnixNano
 }
 
-// NewDiskScraper creates a Disk Scraper
-func NewDiskScraper(_ context.Context, cfg *Config) *Scraper {
-	return &Scraper{config: cfg}
+// newDiskScraper creates a Disk Scraper
+func newDiskScraper(_ context.Context, cfg *Config) *scraper {
+	return &scraper{config: cfg}
 }
 
 // Initialize
-func (s *Scraper) Initialize(_ context.Context, startTime pdata.TimestampUnixNano) error {
-	s.startTime = startTime
+func (s *scraper) Initialize(_ context.Context) error {
+	bootTime, err := host.BootTime()
+	if err != nil {
+		return err
+	}
+
+	s.startTime = pdata.TimestampUnixNano(bootTime)
 	return nil
 }
 
 // Close
-func (s *Scraper) Close(_ context.Context) error {
+func (s *scraper) Close(_ context.Context) error {
 	return nil
 }
 
 // ScrapeAndAppendMetrics
-func (s *Scraper) ScrapeAndAppendMetrics(ctx context.Context, metrics pdata.MetricSlice) error {
+func (s *scraper) ScrapeAndAppendMetrics(ctx context.Context, metrics pdata.MetricSlice) error {
 	_, span := trace.StartSpan(ctx, "diskscraper.ScrapeAndAppendMetrics")
 	defer span.End()
 

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_test.go
@@ -47,8 +47,8 @@ func assertDiskMetricMatchesDescriptorAndHasReadAndWriteDataPoints(t *testing.T,
 }
 
 func createScraperAndValidateScrapedMetrics(t *testing.T, config *Config, assertFn validationFn) {
-	scraper := NewDiskScraper(context.Background(), config)
-	err := scraper.Initialize(context.Background(), pdata.TimestampUnixNano(0))
+	scraper := newDiskScraper(context.Background(), config)
+	err := scraper.Initialize(context.Background())
 	require.NoError(t, err, "Failed to initialize disk scraper: %v", err)
 	defer func() { assert.NoError(t, scraper.Close(context.Background())) }()
 

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_test.go
@@ -52,8 +52,7 @@ func createScraperAndValidateScrapedMetrics(t *testing.T, config *Config, assert
 	require.NoError(t, err, "Failed to initialize disk scraper: %v", err)
 	defer func() { assert.NoError(t, scraper.Close(context.Background())) }()
 
-	metrics := pdata.NewMetricSlice()
-	err = scraper.ScrapeAndAppendMetrics(context.Background(), metrics)
+	metrics, err := scraper.ScrapeMetrics(context.Background())
 	require.NoError(t, err, "Failed to scrape metrics: %v", err)
 
 	assertFn(t, metrics)

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_test.go
@@ -17,26 +17,22 @@ package diskscraper
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/open-telemetry/opentelemetry-collector/consumer/pdata"
-	"github.com/open-telemetry/opentelemetry-collector/exporter/exportertest"
 	"github.com/open-telemetry/opentelemetry-collector/receiver/hostmetricsreceiver/internal"
 )
 
-type validationFn func(*testing.T, []pdata.Metrics)
+type validationFn func(*testing.T, pdata.MetricSlice)
 
 func TestScrapeMetrics(t *testing.T) {
-	createScraperAndValidateScrapedMetrics(t, &Config{}, func(t *testing.T, got []pdata.Metrics) {
-		metrics := internal.AssertSingleMetricDataAndGetMetricsSlice(t, got)
-
+	createScraperAndValidateScrapedMetrics(t, &Config{}, func(t *testing.T, metrics pdata.MetricSlice) {
 		// expect 3 metrics
 		assert.Equal(t, 3, metrics.Len())
 
-		// for disk byts metric, expect a read & write datapoint for at least one drive
+		// for each disk metric, expect a read & write datapoint for at least one drive
 		assertDiskMetricMatchesDescriptorAndHasReadAndWriteDataPoints(t, metrics.At(0), metricDiskBytesDescriptor)
 		assertDiskMetricMatchesDescriptorAndHasReadAndWriteDataPoints(t, metrics.At(1), metricDiskOpsDescriptor)
 		assertDiskMetricMatchesDescriptorAndHasReadAndWriteDataPoints(t, metrics.At(2), metricDiskTimeDescriptor)
@@ -51,24 +47,14 @@ func assertDiskMetricMatchesDescriptorAndHasReadAndWriteDataPoints(t *testing.T,
 }
 
 func createScraperAndValidateScrapedMetrics(t *testing.T, config *Config, assertFn validationFn) {
-	config.SetCollectionInterval(5 * time.Millisecond)
+	scraper := NewDiskScraper(context.Background(), config)
+	err := scraper.Initialize(context.Background(), pdata.TimestampUnixNano(0))
+	require.NoError(t, err, "Failed to initialize disk scraper: %v", err)
+	defer func() { assert.NoError(t, scraper.Close(context.Background())) }()
 
-	sink := &exportertest.SinkMetricsExporter{}
+	metrics := pdata.NewMetricSlice()
+	err = scraper.ScrapeAndAppendMetrics(context.Background(), metrics)
+	require.NoError(t, err, "Failed to scrape metrics: %v", err)
 
-	scraper, err := NewDiskScraper(context.Background(), config, sink)
-	require.NoError(t, err, "Failed to create disk scraper: %v", err)
-
-	err = scraper.Start(context.Background())
-	require.NoError(t, err, "Failed to start disk scraper: %v", err)
-	defer func() { assert.NoError(t, scraper.Shutdown(context.Background())) }()
-
-	require.Eventually(t, func() bool {
-		got := sink.AllMetrics()
-		if len(got) == 0 {
-			return false
-		}
-
-		assertFn(t, got)
-		return true
-	}, time.Second, 2*time.Millisecond, "No metrics were collected")
+	assertFn(t, metrics)
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/factory.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/factory.go
@@ -45,5 +45,5 @@ func (f *Factory) CreateMetricsScraper(
 	config internal.Config,
 ) (internal.Scraper, error) {
 	cfg := config.(*Config)
-	return NewDiskScraper(ctx, cfg), nil
+	return newDiskScraper(ctx, cfg), nil
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/factory.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/factory.go
@@ -19,7 +19,6 @@ import (
 
 	"go.uber.org/zap"
 
-	"github.com/open-telemetry/opentelemetry-collector/consumer"
 	"github.com/open-telemetry/opentelemetry-collector/receiver/hostmetricsreceiver/internal"
 )
 
@@ -42,10 +41,9 @@ func (f *Factory) CreateDefaultConfig() internal.Config {
 // CreateMetricsScraper creates a scraper based on provided config.
 func (f *Factory) CreateMetricsScraper(
 	ctx context.Context,
-	logger *zap.Logger,
+	_ *zap.Logger,
 	config internal.Config,
-	consumer consumer.MetricsConsumer,
 ) (internal.Scraper, error) {
 	cfg := config.(*Config)
-	return NewDiskScraper(ctx, cfg, consumer)
+	return NewDiskScraper(ctx, cfg), nil
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/factory_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/factory_test.go
@@ -22,11 +22,17 @@ import (
 	"go.uber.org/zap"
 )
 
+func TestCreateDefaultConfig(t *testing.T) {
+	factory := &Factory{}
+	cfg := factory.CreateDefaultConfig()
+	assert.IsType(t, &Config{}, cfg)
+}
+
 func TestCreateMetricsScraper(t *testing.T) {
 	factory := &Factory{}
 	cfg := &Config{}
 
-	scraper, err := factory.CreateMetricsScraper(context.Background(), zap.NewNop(), cfg, nil)
+	scraper, err := factory.CreateMetricsScraper(context.Background(), zap.NewNop(), cfg)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, scraper)

--- a/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/factory.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/factory.go
@@ -19,7 +19,6 @@ import (
 
 	"go.uber.org/zap"
 
-	"github.com/open-telemetry/opentelemetry-collector/consumer"
 	"github.com/open-telemetry/opentelemetry-collector/receiver/hostmetricsreceiver/internal"
 )
 
@@ -47,10 +46,9 @@ func (f *Factory) CreateDefaultConfig() internal.Config {
 // CreateMetricsScraper creates a scraper based on provided config.
 func (f *Factory) CreateMetricsScraper(
 	ctx context.Context,
-	logger *zap.Logger,
+	_ *zap.Logger,
 	config internal.Config,
-	consumer consumer.MetricsConsumer,
 ) (internal.Scraper, error) {
 	cfg := config.(*Config)
-	return NewFileSystemScraper(ctx, cfg, consumer)
+	return NewFileSystemScraper(ctx, cfg), nil
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/factory.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/factory.go
@@ -50,5 +50,5 @@ func (f *Factory) CreateMetricsScraper(
 	config internal.Config,
 ) (internal.Scraper, error) {
 	cfg := config.(*Config)
-	return NewFileSystemScraper(ctx, cfg), nil
+	return newFileSystemScraper(ctx, cfg), nil
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/factory_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/factory_test.go
@@ -22,11 +22,17 @@ import (
 	"go.uber.org/zap"
 )
 
+func TestCreateDefaultConfig(t *testing.T) {
+	factory := &Factory{}
+	cfg := factory.CreateDefaultConfig()
+	assert.IsType(t, &Config{}, cfg)
+}
+
 func TestCreateMetricsScraper(t *testing.T) {
 	factory := &Factory{}
 	cfg := &Config{}
 
-	scraper, err := factory.CreateMetricsScraper(context.Background(), zap.NewNop(), cfg, nil)
+	scraper, err := factory.CreateMetricsScraper(context.Background(), zap.NewNop(), cfg)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, scraper)

--- a/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/filesystem_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/filesystem_scraper.go
@@ -25,8 +25,8 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector/consumer/pdata"
 )
 
-// Scraper for FileSystem Metrics
-type Scraper struct {
+// scraper for FileSystem Metrics
+type scraper struct {
 	config *Config
 }
 
@@ -35,23 +35,23 @@ type deviceUsage struct {
 	usage      *disk.UsageStat
 }
 
-// NewFileSystemScraper creates a FileSystem Scraper
-func NewFileSystemScraper(_ context.Context, cfg *Config) *Scraper {
-	return &Scraper{config: cfg}
+// newFileSystemScraper creates a FileSystem Scraper
+func newFileSystemScraper(_ context.Context, cfg *Config) *scraper {
+	return &scraper{config: cfg}
 }
 
 // Initialize
-func (s *Scraper) Initialize(_ context.Context, startTime pdata.TimestampUnixNano) error {
+func (s *scraper) Initialize(_ context.Context) error {
 	return nil
 }
 
 // Close
-func (s *Scraper) Close(_ context.Context) error {
+func (s *scraper) Close(_ context.Context) error {
 	return nil
 }
 
 // ScrapeAndAppendMetrics
-func (s *Scraper) ScrapeAndAppendMetrics(ctx context.Context, metrics pdata.MetricSlice) error {
+func (s *scraper) ScrapeAndAppendMetrics(ctx context.Context, metrics pdata.MetricSlice) error {
 	_, span := trace.StartSpan(ctx, "filesystemscraper.ScrapeAndAppendMetrics")
 	defer span.End()
 

--- a/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/filesystem_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/filesystem_scraper_test.go
@@ -69,8 +69,8 @@ func TestScrapeMetrics_Unux(t *testing.T) {
 }
 
 func createScraperAndValidateScrapedMetrics(t *testing.T, config *Config, assertFn validationFn) {
-	scraper := NewFileSystemScraper(context.Background(), config)
-	err := scraper.Initialize(context.Background(), pdata.TimestampUnixNano(0))
+	scraper := newFileSystemScraper(context.Background(), config)
+	err := scraper.Initialize(context.Background())
 	require.NoError(t, err, "Failed to initialize file system scraper: %v", err)
 	defer func() { assert.NoError(t, scraper.Close(context.Background())) }()
 

--- a/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/filesystem_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/filesystem_scraper_test.go
@@ -74,8 +74,7 @@ func createScraperAndValidateScrapedMetrics(t *testing.T, config *Config, assert
 	require.NoError(t, err, "Failed to initialize file system scraper: %v", err)
 	defer func() { assert.NoError(t, scraper.Close(context.Background())) }()
 
-	metrics := pdata.NewMetricSlice()
-	err = scraper.ScrapeAndAppendMetrics(context.Background(), metrics)
+	metrics, err := scraper.ScrapeMetrics(context.Background())
 	require.NoError(t, err, "Failed to scrape metrics: %v", err)
 
 	assertFn(t, metrics)

--- a/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/filesystem_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/filesystem_scraper_test.go
@@ -18,22 +18,18 @@ import (
 	"context"
 	"runtime"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/open-telemetry/opentelemetry-collector/consumer/pdata"
-	"github.com/open-telemetry/opentelemetry-collector/exporter/exportertest"
 	"github.com/open-telemetry/opentelemetry-collector/receiver/hostmetricsreceiver/internal"
 )
 
-type validationFn func(*testing.T, []pdata.Metrics)
+type validationFn func(*testing.T, pdata.MetricSlice)
 
 func TestScrapeMetrics(t *testing.T) {
-	createScraperAndValidateScrapedMetrics(t, &Config{}, func(t *testing.T, got []pdata.Metrics) {
-		metrics := internal.AssertSingleMetricDataAndGetMetricsSlice(t, got)
-
+	createScraperAndValidateScrapedMetrics(t, &Config{}, func(t *testing.T, metrics pdata.MetricSlice) {
 		// expect at least 1 metric
 		assert.GreaterOrEqual(t, metrics.Len(), 1)
 
@@ -51,9 +47,7 @@ func TestScrapeMetrics_Unux(t *testing.T) {
 		return
 	}
 
-	createScraperAndValidateScrapedMetrics(t, &Config{}, func(t *testing.T, got []pdata.Metrics) {
-		metrics := internal.AssertSingleMetricDataAndGetMetricsSlice(t, got)
-
+	createScraperAndValidateScrapedMetrics(t, &Config{}, func(t *testing.T, metrics pdata.MetricSlice) {
 		// expect 2 metrics
 		assert.Equal(t, 2, metrics.Len())
 
@@ -75,26 +69,16 @@ func TestScrapeMetrics_Unux(t *testing.T) {
 }
 
 func createScraperAndValidateScrapedMetrics(t *testing.T, config *Config, assertFn validationFn) {
-	config.SetCollectionInterval(5 * time.Millisecond)
+	scraper := NewFileSystemScraper(context.Background(), config)
+	err := scraper.Initialize(context.Background(), pdata.TimestampUnixNano(0))
+	require.NoError(t, err, "Failed to initialize file system scraper: %v", err)
+	defer func() { assert.NoError(t, scraper.Close(context.Background())) }()
 
-	sink := &exportertest.SinkMetricsExporter{}
+	metrics := pdata.NewMetricSlice()
+	err = scraper.ScrapeAndAppendMetrics(context.Background(), metrics)
+	require.NoError(t, err, "Failed to scrape metrics: %v", err)
 
-	scraper, err := NewFileSystemScraper(context.Background(), config, sink)
-	require.NoError(t, err, "Failed to create filesystem scraper: %v", err)
-
-	err = scraper.Start(context.Background())
-	require.NoError(t, err, "Failed to start filesystem scraper: %v", err)
-	defer func() { assert.NoError(t, scraper.Shutdown(context.Background())) }()
-
-	require.Eventually(t, func() bool {
-		got := sink.AllMetrics()
-		if len(got) == 0 {
-			return false
-		}
-
-		assertFn(t, got)
-		return true
-	}, time.Second, 2*time.Millisecond, "No metrics were collected")
+	assertFn(t, metrics)
 }
 
 func isUnix() bool {

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/factory.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/factory.go
@@ -45,5 +45,5 @@ func (f *Factory) CreateMetricsScraper(
 	config internal.Config,
 ) (internal.Scraper, error) {
 	cfg := config.(*Config)
-	return NewMemoryScraper(ctx, cfg), nil
+	return newMemoryScraper(ctx, cfg), nil
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/factory.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/factory.go
@@ -19,7 +19,6 @@ import (
 
 	"go.uber.org/zap"
 
-	"github.com/open-telemetry/opentelemetry-collector/consumer"
 	"github.com/open-telemetry/opentelemetry-collector/receiver/hostmetricsreceiver/internal"
 )
 
@@ -42,10 +41,9 @@ func (f *Factory) CreateDefaultConfig() internal.Config {
 // CreateMetricsScraper creates a scraper based on provided config.
 func (f *Factory) CreateMetricsScraper(
 	ctx context.Context,
-	logger *zap.Logger,
+	_ *zap.Logger,
 	config internal.Config,
-	consumer consumer.MetricsConsumer,
 ) (internal.Scraper, error) {
 	cfg := config.(*Config)
-	return NewMemoryScraper(ctx, cfg, consumer)
+	return NewMemoryScraper(ctx, cfg), nil
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/factory_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/factory_test.go
@@ -22,11 +22,17 @@ import (
 	"go.uber.org/zap"
 )
 
+func TestCreateDefaultConfig(t *testing.T) {
+	factory := &Factory{}
+	cfg := factory.CreateDefaultConfig()
+	assert.IsType(t, &Config{}, cfg)
+}
+
 func TestCreateMetricsScraper(t *testing.T) {
 	factory := &Factory{}
 	cfg := &Config{}
 
-	scraper, err := factory.CreateMetricsScraper(context.Background(), zap.NewNop(), cfg, nil)
+	scraper, err := factory.CreateMetricsScraper(context.Background(), zap.NewNop(), cfg)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, scraper)

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/memory_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/memory_scraper.go
@@ -44,20 +44,21 @@ func (s *scraper) Close(_ context.Context) error {
 	return nil
 }
 
-// ScrapeAndAppendMetrics
-func (s *scraper) ScrapeAndAppendMetrics(ctx context.Context, metrics pdata.MetricSlice) error {
-	_, span := trace.StartSpan(ctx, "memoryscraper.ScrapeAndAppendMetrics")
+// ScrapeMetrics
+func (s *scraper) ScrapeMetrics(ctx context.Context) (pdata.MetricSlice, error) {
+	_, span := trace.StartSpan(ctx, "memoryscraper.ScrapeMetrics")
 	defer span.End()
+
+	metrics := pdata.NewMetricSlice()
 
 	memInfo, err := mem.VirtualMemory()
 	if err != nil {
-		return err
+		return metrics, err
 	}
 
-	startIdx := metrics.Len()
-	metrics.Resize(startIdx + 1)
-	initializeMetricMemoryUsed(metrics.At(startIdx), memInfo)
-	return nil
+	metrics.Resize(1)
+	initializeMetricMemoryUsed(metrics.At(0), memInfo)
+	return metrics, nil
 }
 
 func initializeMetricMemoryUsed(metric pdata.Metric, memInfo *mem.VirtualMemoryStat) {

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/memory_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/memory_scraper.go
@@ -24,28 +24,28 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector/consumer/pdata"
 )
 
-// Scraper for Memory Metrics
-type Scraper struct {
+// scraper for Memory Metrics
+type scraper struct {
 	config *Config
 }
 
-// NewMemoryScraper creates a Memory Scraper
-func NewMemoryScraper(_ context.Context, cfg *Config) *Scraper {
-	return &Scraper{config: cfg}
+// newMemoryScraper creates a Memory Scraper
+func newMemoryScraper(_ context.Context, cfg *Config) *scraper {
+	return &scraper{config: cfg}
 }
 
 // Initialize
-func (s *Scraper) Initialize(_ context.Context, startTime pdata.TimestampUnixNano) error {
+func (s *scraper) Initialize(_ context.Context) error {
 	return nil
 }
 
 // Close
-func (s *Scraper) Close(_ context.Context) error {
+func (s *scraper) Close(_ context.Context) error {
 	return nil
 }
 
 // ScrapeAndAppendMetrics
-func (s *Scraper) ScrapeAndAppendMetrics(ctx context.Context, metrics pdata.MetricSlice) error {
+func (s *scraper) ScrapeAndAppendMetrics(ctx context.Context, metrics pdata.MetricSlice) error {
 	_, span := trace.StartSpan(ctx, "memoryscraper.ScrapeAndAppendMetrics")
 	defer span.End()
 

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/memory_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/memory_scraper_test.go
@@ -18,22 +18,18 @@ import (
 	"context"
 	"runtime"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/open-telemetry/opentelemetry-collector/consumer/pdata"
-	"github.com/open-telemetry/opentelemetry-collector/exporter/exportertest"
 	"github.com/open-telemetry/opentelemetry-collector/receiver/hostmetricsreceiver/internal"
 )
 
-type validationFn func(*testing.T, []pdata.Metrics)
+type validationFn func(*testing.T, pdata.MetricSlice)
 
 func TestScrapeMetrics(t *testing.T) {
-	createScraperAndValidateScrapedMetrics(t, &Config{}, func(t *testing.T, got []pdata.Metrics) {
-		metrics := internal.AssertSingleMetricDataAndGetMetricsSlice(t, got)
-
+	createScraperAndValidateScrapedMetrics(t, &Config{}, func(t *testing.T, metrics pdata.MetricSlice) {
 		// expect 1 metric
 		assert.Equal(t, 1, metrics.Len())
 
@@ -50,8 +46,9 @@ func TestScrapeMetrics_Linux(t *testing.T) {
 		return
 	}
 
-	createScraperAndValidateScrapedMetrics(t, &Config{}, func(t *testing.T, got []pdata.Metrics) {
-		metrics := internal.AssertSingleMetricDataAndGetMetricsSlice(t, got)
+	createScraperAndValidateScrapedMetrics(t, &Config{}, func(t *testing.T, metrics pdata.MetricSlice) {
+		// expect 1 metric
+		assert.Equal(t, 1, metrics.Len())
 
 		// for memory used metric, expect a datapoint for all 6 state labels
 		hostMemoryUsedMetric := metrics.At(0)
@@ -67,24 +64,14 @@ func TestScrapeMetrics_Linux(t *testing.T) {
 }
 
 func createScraperAndValidateScrapedMetrics(t *testing.T, config *Config, assertFn validationFn) {
-	config.SetCollectionInterval(5 * time.Millisecond)
+	scraper := NewMemoryScraper(context.Background(), config)
+	err := scraper.Initialize(context.Background(), pdata.TimestampUnixNano(0))
+	require.NoError(t, err, "Failed to initialize memory scraper: %v", err)
+	defer func() { assert.NoError(t, scraper.Close(context.Background())) }()
 
-	sink := &exportertest.SinkMetricsExporter{}
+	metrics := pdata.NewMetricSlice()
+	err = scraper.ScrapeAndAppendMetrics(context.Background(), metrics)
+	require.NoError(t, err, "Failed to scrape metrics: %v", err)
 
-	scraper, err := NewMemoryScraper(context.Background(), config, sink)
-	require.NoError(t, err, "Failed to create memory scraper: %v", err)
-
-	err = scraper.Start(context.Background())
-	require.NoError(t, err, "Failed to start memory scraper: %v", err)
-	defer func() { assert.NoError(t, scraper.Shutdown(context.Background())) }()
-
-	require.Eventually(t, func() bool {
-		got := sink.AllMetrics()
-		if len(got) == 0 {
-			return false
-		}
-
-		assertFn(t, got)
-		return true
-	}, time.Second, 2*time.Millisecond, "No metrics were collected")
+	assertFn(t, metrics)
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/memory_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/memory_scraper_test.go
@@ -69,8 +69,7 @@ func createScraperAndValidateScrapedMetrics(t *testing.T, config *Config, assert
 	require.NoError(t, err, "Failed to initialize memory scraper: %v", err)
 	defer func() { assert.NoError(t, scraper.Close(context.Background())) }()
 
-	metrics := pdata.NewMetricSlice()
-	err = scraper.ScrapeAndAppendMetrics(context.Background(), metrics)
+	metrics, err := scraper.ScrapeMetrics(context.Background())
 	require.NoError(t, err, "Failed to scrape metrics: %v", err)
 
 	assertFn(t, metrics)

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/memory_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/memory_scraper_test.go
@@ -64,8 +64,8 @@ func TestScrapeMetrics_Linux(t *testing.T) {
 }
 
 func createScraperAndValidateScrapedMetrics(t *testing.T, config *Config, assertFn validationFn) {
-	scraper := NewMemoryScraper(context.Background(), config)
-	err := scraper.Initialize(context.Background(), pdata.TimestampUnixNano(0))
+	scraper := newMemoryScraper(context.Background(), config)
+	err := scraper.Initialize(context.Background())
 	require.NoError(t, err, "Failed to initialize memory scraper: %v", err)
 	defer func() { assert.NoError(t, scraper.Close(context.Background())) }()
 

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/factory.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/factory.go
@@ -45,5 +45,5 @@ func (f *Factory) CreateMetricsScraper(
 	config internal.Config,
 ) (internal.Scraper, error) {
 	cfg := config.(*Config)
-	return NewNetworkScraper(ctx, cfg), nil
+	return newNetworkScraper(ctx, cfg), nil
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/factory.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/factory.go
@@ -19,7 +19,6 @@ import (
 
 	"go.uber.org/zap"
 
-	"github.com/open-telemetry/opentelemetry-collector/consumer"
 	"github.com/open-telemetry/opentelemetry-collector/receiver/hostmetricsreceiver/internal"
 )
 
@@ -44,8 +43,7 @@ func (f *Factory) CreateMetricsScraper(
 	ctx context.Context,
 	logger *zap.Logger,
 	config internal.Config,
-	consumer consumer.MetricsConsumer,
 ) (internal.Scraper, error) {
 	cfg := config.(*Config)
-	return NewNetworkScraper(ctx, cfg, consumer)
+	return NewNetworkScraper(ctx, cfg), nil
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/factory_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/factory_test.go
@@ -22,11 +22,17 @@ import (
 	"go.uber.org/zap"
 )
 
+func TestCreateDefaultConfig(t *testing.T) {
+	factory := &Factory{}
+	cfg := factory.CreateDefaultConfig()
+	assert.IsType(t, &Config{}, cfg)
+}
+
 func TestCreateMetricsScraper(t *testing.T) {
 	factory := &Factory{}
 	cfg := &Config{}
 
-	scraper, err := factory.CreateMetricsScraper(context.Background(), zap.NewNop(), cfg, nil)
+	scraper, err := factory.CreateMetricsScraper(context.Background(), zap.NewNop(), cfg)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, scraper)

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/network_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/network_scraper.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/shirou/gopsutil/host"
 	"github.com/shirou/gopsutil/net"
 	"go.opencensus.io/trace"
 
@@ -26,30 +27,35 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector/consumer/pdata"
 )
 
-// Scraper for Network Metrics
-type Scraper struct {
+// scraper for Network Metrics
+type scraper struct {
 	config    *Config
 	startTime pdata.TimestampUnixNano
 }
 
-// NewNetworkScraper creates a set of Network related metrics
-func NewNetworkScraper(_ context.Context, cfg *Config) *Scraper {
-	return &Scraper{config: cfg}
+// newNetworkScraper creates a set of Network related metrics
+func newNetworkScraper(_ context.Context, cfg *Config) *scraper {
+	return &scraper{config: cfg}
 }
 
 // Initialize
-func (s *Scraper) Initialize(_ context.Context, startTime pdata.TimestampUnixNano) error {
-	s.startTime = startTime
+func (s *scraper) Initialize(_ context.Context) error {
+	bootTime, err := host.BootTime()
+	if err != nil {
+		return err
+	}
+
+	s.startTime = pdata.TimestampUnixNano(bootTime)
 	return nil
 }
 
 // Close
-func (s *Scraper) Close(_ context.Context) error {
+func (s *scraper) Close(_ context.Context) error {
 	return nil
 }
 
 // ScrapeAndAppendMetrics
-func (s *Scraper) ScrapeAndAppendMetrics(ctx context.Context, metrics pdata.MetricSlice) error {
+func (s *scraper) ScrapeAndAppendMetrics(ctx context.Context, metrics pdata.MetricSlice) error {
 	_, span := trace.StartSpan(ctx, "networkscraper.ScrapeAndAppendMetrics")
 	defer span.End()
 

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/network_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/network_scraper.go
@@ -54,10 +54,12 @@ func (s *scraper) Close(_ context.Context) error {
 	return nil
 }
 
-// ScrapeAndAppendMetrics
-func (s *scraper) ScrapeAndAppendMetrics(ctx context.Context, metrics pdata.MetricSlice) error {
-	_, span := trace.StartSpan(ctx, "networkscraper.ScrapeAndAppendMetrics")
+// ScrapeMetrics
+func (s *scraper) ScrapeMetrics(ctx context.Context) (pdata.MetricSlice, error) {
+	_, span := trace.StartSpan(ctx, "networkscraper.ScrapeMetrics")
 	defer span.End()
+
+	metrics := pdata.NewMetricSlice()
 
 	var errors []error
 
@@ -72,10 +74,10 @@ func (s *scraper) ScrapeAndAppendMetrics(ctx context.Context, metrics pdata.Metr
 	}
 
 	if len(errors) > 0 {
-		return componenterror.CombineErrors(errors)
+		return metrics, componenterror.CombineErrors(errors)
 	}
 
-	return nil
+	return metrics, nil
 }
 
 func scrapeAndAppendNetworkCounterMetrics(metrics pdata.MetricSlice, startTime pdata.TimestampUnixNano) error {

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/network_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/network_scraper_test.go
@@ -17,22 +17,18 @@ package networkscraper
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/open-telemetry/opentelemetry-collector/consumer/pdata"
-	"github.com/open-telemetry/opentelemetry-collector/exporter/exportertest"
 	"github.com/open-telemetry/opentelemetry-collector/receiver/hostmetricsreceiver/internal"
 )
 
-type validationFn func(*testing.T, []pdata.Metrics)
+type validationFn func(*testing.T, pdata.MetricSlice)
 
 func TestScrapeMetrics(t *testing.T) {
-	createScraperAndValidateScrapedMetrics(t, &Config{}, func(t *testing.T, got []pdata.Metrics) {
-		metrics := internal.AssertSingleMetricDataAndGetMetricsSlice(t, got)
-
+	createScraperAndValidateScrapedMetrics(t, &Config{}, func(t *testing.T, metrics pdata.MetricSlice) {
 		// expect 5 metrics
 		assert.Equal(t, 5, metrics.Len())
 
@@ -58,24 +54,14 @@ func assertNetworkMetricMatchesDescriptorAndHasTransmitAndReceiveDataPoints(t *t
 }
 
 func createScraperAndValidateScrapedMetrics(t *testing.T, config *Config, assertFn validationFn) {
-	config.SetCollectionInterval(5 * time.Millisecond)
+	scraper := NewNetworkScraper(context.Background(), config)
+	err := scraper.Initialize(context.Background(), pdata.TimestampUnixNano(0))
+	require.NoError(t, err, "Failed to initialize network scraper: %v", err)
+	defer func() { assert.NoError(t, scraper.Close(context.Background())) }()
 
-	sink := &exportertest.SinkMetricsExporter{}
+	metrics := pdata.NewMetricSlice()
+	err = scraper.ScrapeAndAppendMetrics(context.Background(), metrics)
+	require.NoError(t, err, "Failed to scrape metrics: %v", err)
 
-	scraper, err := NewNetworkScraper(context.Background(), config, sink)
-	require.NoError(t, err, "Failed to create network scraper: %v", err)
-
-	err = scraper.Start(context.Background())
-	require.NoError(t, err, "Failed to start network scraper: %v", err)
-	defer func() { assert.NoError(t, scraper.Shutdown(context.Background())) }()
-
-	require.Eventually(t, func() bool {
-		got := sink.AllMetrics()
-		if len(got) == 0 {
-			return false
-		}
-
-		assertFn(t, got)
-		return true
-	}, time.Second, 2*time.Millisecond, "No metrics were collected")
+	assertFn(t, metrics)
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/network_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/network_scraper_test.go
@@ -59,8 +59,7 @@ func createScraperAndValidateScrapedMetrics(t *testing.T, config *Config, assert
 	require.NoError(t, err, "Failed to initialize network scraper: %v", err)
 	defer func() { assert.NoError(t, scraper.Close(context.Background())) }()
 
-	metrics := pdata.NewMetricSlice()
-	err = scraper.ScrapeAndAppendMetrics(context.Background(), metrics)
+	metrics, err := scraper.ScrapeMetrics(context.Background())
 	require.NoError(t, err, "Failed to scrape metrics: %v", err)
 
 	assertFn(t, metrics)

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/network_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/network_scraper_test.go
@@ -54,8 +54,8 @@ func assertNetworkMetricMatchesDescriptorAndHasTransmitAndReceiveDataPoints(t *t
 }
 
 func createScraperAndValidateScrapedMetrics(t *testing.T, config *Config, assertFn validationFn) {
-	scraper := NewNetworkScraper(context.Background(), config)
-	err := scraper.Initialize(context.Background(), pdata.TimestampUnixNano(0))
+	scraper := newNetworkScraper(context.Background(), config)
+	err := scraper.Initialize(context.Background())
 	require.NoError(t, err, "Failed to initialize network scraper: %v", err)
 	defer func() { assert.NoError(t, scraper.Close(context.Background())) }()
 

--- a/receiver/hostmetricsreceiver/internal/testutils.go
+++ b/receiver/hostmetricsreceiver/internal/testutils.go
@@ -20,28 +20,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/open-telemetry/opentelemetry-collector/consumer/pdata"
-	"github.com/open-telemetry/opentelemetry-collector/consumer/pdatautil"
 )
-
-func AssertSingleMetricDataAndGetMetricsSlice(t *testing.T, metrics []pdata.Metrics) pdata.MetricSlice {
-	// expect 1 MetricData object
-	assert.Equal(t, 1, len(metrics))
-	return AssertMetricDataAndGetMetricsSlice(t, metrics[0])
-}
-
-func AssertMetricDataAndGetMetricsSlice(t *testing.T, metrics pdata.Metrics) pdata.MetricSlice {
-	md := pdatautil.MetricsToInternalMetrics(metrics)
-
-	// expect 1 ResourceMetrics object
-	rms := md.ResourceMetrics()
-	assert.Equal(t, 1, rms.Len())
-	rm := rms.At(0)
-
-	// expect 1 InstrumentationLibraryMetrics object
-	ilms := rm.InstrumentationLibraryMetrics()
-	assert.Equal(t, 1, ilms.Len())
-	return ilms.At(0).Metrics()
-}
 
 func AssertDescriptorEqual(t *testing.T, expected pdata.MetricDescriptor, actual pdata.MetricDescriptor) {
 	assert.Equal(t, expected.Name(), actual.Name())

--- a/receiver/hostmetricsreceiver/testdata/config.yaml
+++ b/receiver/hostmetricsreceiver/testdata/config.yaml
@@ -3,11 +3,18 @@ receivers:
     scrapers:
       cpu:
   hostmetrics/customname:
-    default_collection_interval: 10s
+    default_collection_interval: 1m
     scrapers:
       cpu:
-        collection_interval: 5s
         report_per_cpu: true
+      disk:
+        collection_interval: 5m
+      filesystem:
+        collection_interval: 5m
+      memory:
+        collection_interval: 30s
+      network:
+        collection_interval: 45s
 
 processors:
   exampleprocessor:

--- a/receiver/hostmetricsreceiver/testdata/config.yaml
+++ b/receiver/hostmetricsreceiver/testdata/config.yaml
@@ -3,18 +3,14 @@ receivers:
     scrapers:
       cpu:
   hostmetrics/customname:
-    default_collection_interval: 1m
+    collection_interval: 30s
     scrapers:
       cpu:
         report_per_cpu: true
       disk:
-        collection_interval: 5m
       filesystem:
-        collection_interval: 5m
       memory:
-        collection_interval: 30s
       network:
-        collection_interval: 45s
 
 processors:
   exampleprocessor:


### PR DESCRIPTION
**Link to tracking Issue:**
https://github.com/open-telemetry/opentelemetry-collector/issues/847

**Description:** (edited)
Currently, each Scraper can be configured with a `collection_interval`. Scrapers have a `Start` and `End` function and manage a ticker internally to determine when to scrape metrics and pass these to the next consumer in the pipeline.

This PR simplifies the Host Metrics receiver so that only a single `collection_interval` can be defined for all Scrapers, and refactors the Scrapers so they only have a `ScrapeMetrics` function. A single ticker is managed by the Host Metrics receiver directly.

In order to achieve the same functionality as before, users can configure multiple receivers. Updated some documentation to point this out.

This PR touches quite a few files, but the changes are essentially:
- Refactor Scraper config & interface as described above (also includes `Initialize` & `Close` functions for setting up/cleaning up resources)
- Refactor Scrapers/Scraper Factories:
  - Remove ticker logic & references to next consumer
  - Refactor (simplify) tests accordingly
- Add ticker & append metrics logic to the Host Metrics receiver

---

Note this PR was simplified as per suggestion from @bogdandrutu (originally the host metrics receiver was maintaining multiple tickers).