### PR TITLE
Add factories and component types to support logs data type

### DIFF
--- a/component/processor.go
+++ b/component/processor.go
@@ -37,13 +37,13 @@ type TraceProcessorBase interface {
 	Processor
 }
 
-// TraceProcessorOld composes TraceConsumer with some additional processor-specific functions.
+// TraceProcessorOld is a processor that can consume old-style traces.
 type TraceProcessorOld interface {
 	consumer.TraceConsumerOld
 	TraceProcessorBase
 }
 
-// TraceProcessor composes TraceConsumer with some additional processor-specific functions.
+// TraceProcessor is a processor that can consume traces.
 type TraceProcessor interface {
 	consumer.TraceConsumer
 	TraceProcessorBase
@@ -54,16 +54,22 @@ type MetricsProcessorBase interface {
 	Processor
 }
 
-// MetricsProcessor composes MetricsConsumer with some additional processor-specific functions.
+// MetricsProcessor is a processor that can consume old-style metrics.
 type MetricsProcessorOld interface {
 	consumer.MetricsConsumerOld
 	MetricsProcessorBase
 }
 
-// MetricsProcessor composes MetricsConsumer with some additional processor-specific functions.
+// MetricsProcessor is a processor that can consume metrics.
 type MetricsProcessor interface {
 	consumer.MetricsConsumer
 	MetricsProcessorBase
+}
+
+// LogProcessor is a processor that can consume logs.
+type LogProcessor interface {
+	Processor
+	consumer.LogConsumer
 }
 
 // ProcessorCapabilities describes the capabilities of a Processor.
@@ -130,4 +136,19 @@ type ProcessorFactory interface {
 	// error will be returned instead.
 	CreateMetricsProcessor(ctx context.Context, params ProcessorCreateParams,
 		nextConsumer consumer.MetricsConsumer, cfg configmodels.Processor) (MetricsProcessor, error)
+}
+
+// LogProcessorFactory can create LogProcessor.
+type LogProcessorFactory interface {
+	ProcessorFactoryBase
+
+	// CreateLogProcessor creates a processor based on the config.
+	// If the processor type does not support logs or if the config is not valid
+	// error will be returned instead.
+	CreateLogProcessor(
+		ctx context.Context,
+		params ProcessorCreateParams,
+		cfg configmodels.Processor,
+		nextConsumer consumer.LogConsumer,
+	) (LogProcessor, error)
 }

--- a/component/receiver.go
+++ b/component/receiver.go
@@ -49,6 +49,13 @@ type MetricsReceiver interface {
 	Receiver
 }
 
+// A LogReceiver is a "log data"-to-"internal format" converter.
+// Its purpose is to translate data from the wild into internal data format.
+// LogReceiver feeds a consumer.LogConsumer with data.
+type LogReceiver interface {
+	Receiver
+}
+
 // ReceiverFactoryBase defines the common functions for all receiver factories.
 type ReceiverFactoryBase interface {
 	Factory
@@ -116,4 +123,19 @@ type ReceiverFactory interface {
 	// error will be returned instead.
 	CreateMetricsReceiver(ctx context.Context, params ReceiverCreateParams,
 		cfg configmodels.Receiver, nextConsumer consumer.MetricsConsumer) (MetricsReceiver, error)
+}
+
+// LogReceiverFactory can create a LogReceiver.
+type LogReceiverFactory interface {
+	ReceiverFactoryBase
+
+	// CreateLogReceiver creates a log receiver based on this config.
+	// If the receiver type does not support the data type or if the config is not valid
+	// error will be returned instead.
+	CreateLogReceiver(
+		ctx context.Context,
+		params ReceiverCreateParams,
+		cfg configmodels.Receiver,
+		nextConsumer consumer.LogConsumer,
+	) (LogReceiver, error)
 }

--- a/config/config.go
+++ b/config/config.go
@@ -539,11 +539,11 @@ func loadPipelines(v *viper.Viper) (configmodels.Pipelines, error) {
 		var pipelineCfg configmodels.Pipeline
 
 		// Set the type.
-		switch typeStr {
-		case configmodels.TracesDataTypeStr:
-			pipelineCfg.InputType = configmodels.TracesDataType
-		case configmodels.MetricsDataTypeStr:
-			pipelineCfg.InputType = configmodels.MetricsDataType
+		pipelineCfg.InputType = configmodels.DataType(typeStr)
+		switch pipelineCfg.InputType {
+		case configmodels.TracesDataType:
+		case configmodels.MetricsDataType:
+		case configmodels.LogsDataType:
 		default:
 			return nil, &configError{
 				code: errInvalidPipelineType,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -100,7 +100,7 @@ func TestDecodeConfig(t *testing.T) {
 	assert.Equal(t, 1, len(config.Processors), "Incorrect processors count")
 
 	assert.Equal(t,
-		&ExampleProcessor{
+		&ExampleProcessorCfg{
 			ProcessorSettings: configmodels.ProcessorSettings{
 				TypeVal: "exampleprocessor",
 				NameVal: "exampleprocessor",
@@ -258,7 +258,7 @@ func TestSimpleConfig(t *testing.T) {
 		assert.Equalf(t, 1, len(config.Processors), "TEST[%s]", test.name)
 
 		assert.Equalf(t,
-			&ExampleProcessor{
+			&ExampleProcessorCfg{
 				ProcessorSettings: configmodels.ProcessorSettings{
 					TypeVal: "exampleprocessor",
 					NameVal: "exampleprocessor",

--- a/config/configmodels/configmodels.go
+++ b/config/configmodels/configmodels.go
@@ -78,37 +78,21 @@ type Processor interface {
 type Processors map[string]Processor
 
 // DataType is the data type that is supported for collection. We currently support
-// collecting metrics and traces, this can expand in the future (e.g. logs, events, etc).
-type DataType int
+// collecting metrics, traces and logs, this can expand in the future.
+
+type DataType string
 
 // Currently supported data types. Add new data types here when new types are supported in the future.
 const (
-	_ DataType = iota // skip 0, start types from 1.
-
 	// TracesDataType is the data type tag for traces.
-	TracesDataType
+	TracesDataType DataType = "traces"
 
 	// MetricsDataType is the data type tag for metrics.
-	MetricsDataType
-)
+	MetricsDataType DataType = "metrics"
 
-// Data type strings.
-const (
-	TracesDataTypeStr  = "traces"
-	MetricsDataTypeStr = "metrics"
+	// LogsDataType is the data type tag for logs.
+	LogsDataType DataType = "logs"
 )
-
-// GetString converts data type to string.
-func (dataType DataType) GetString() string {
-	switch dataType {
-	case TracesDataType:
-		return TracesDataTypeStr
-	case MetricsDataType:
-		return MetricsDataTypeStr
-	default:
-		panic("unknown data type")
-	}
-}
 
 // Pipeline defines a single pipeline.
 type Pipeline struct {

--- a/consumer/consumer.go
+++ b/consumer/consumer.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-collector/consumer/pdata"
+	"github.com/open-telemetry/opentelemetry-collector/internal/data"
 )
 
 // MetricsConsumerBase defines a common interface for MetricsConsumerOld and MetricsConsumer.
@@ -59,4 +60,11 @@ type TraceConsumer interface {
 	TraceConsumerBase
 	// ConsumeTraces receives pdata.Traces for processing.
 	ConsumeTraces(ctx context.Context, td pdata.Traces) error
+}
+
+// LogConsumer is an interface that receives data.Logs, processes it
+// as needed, and sends it to the next processing node if any or to the destination.
+type LogConsumer interface {
+	// ConsumeLogs receives data.Logs for processing.
+	ConsumeLogs(ctx context.Context, ld data.Logs) error
 }

--- a/internal/data/log.go
+++ b/internal/data/log.go
@@ -1,0 +1,25 @@
+// Copyright OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package data
+
+// This file defines in-memory data structures to represent logs.
+
+// Logs is the top-level struct that is propagated through the logs pipeline.
+type Logs struct {
+	// TODO: add data fields once OTLP protocol defines logs format.
+}
+
+func (l Logs) Clone() Logs {
+	return Logs{}
+}

--- a/service/builder/pipelines_builder_test.go
+++ b/service/builder/pipelines_builder_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
 	"github.com/open-telemetry/opentelemetry-collector/consumer"
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
+	idata "github.com/open-telemetry/opentelemetry-collector/internal/data"
 	"github.com/open-telemetry/opentelemetry-collector/processor/attributesprocessor"
 	"github.com/open-telemetry/opentelemetry-collector/translator/internaldata"
 )
@@ -58,6 +59,146 @@ func TestPipelinesBuilder_Build(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			testPipeline(t, test.pipelineName, test.exporterNames)
+		})
+	}
+}
+
+func createExampleFactories() config.Factories {
+	exampleReceiverFactory := &config.ExampleReceiverFactory{}
+	exampleProcessorFactory := &config.ExampleProcessorFactory{}
+	exampleExporterFactory := &config.ExampleExporterFactory{}
+
+	factories := config.Factories{
+		Receivers: map[configmodels.Type]component.ReceiverFactoryBase{
+			exampleReceiverFactory.Type(): exampleReceiverFactory,
+		},
+		Processors: map[configmodels.Type]component.ProcessorFactoryBase{
+			exampleProcessorFactory.Type(): exampleProcessorFactory,
+		},
+		Exporters: map[configmodels.Type]component.ExporterFactoryBase{
+			exampleExporterFactory.Type(): exampleExporterFactory,
+		},
+	}
+
+	return factories
+}
+
+func createExampleConfig(dataType string) *configmodels.Config {
+
+	exampleReceiverFactory := &config.ExampleReceiverFactory{}
+	exampleProcessorFactory := &config.ExampleProcessorFactory{}
+	exampleExporterFactory := &config.ExampleExporterFactory{}
+
+	cfg := &configmodels.Config{
+		Receivers: map[string]configmodels.Receiver{
+			string(exampleReceiverFactory.Type()): exampleReceiverFactory.CreateDefaultConfig(),
+		},
+		Processors: map[string]configmodels.Processor{
+			string(exampleProcessorFactory.Type()): exampleProcessorFactory.CreateDefaultConfig(),
+		},
+		Exporters: map[string]configmodels.Exporter{
+			string(exampleExporterFactory.Type()): exampleExporterFactory.CreateDefaultConfig(),
+		},
+		Service: configmodels.Service{
+			Pipelines: map[string]*configmodels.Pipeline{
+				dataType: {
+					Name:       dataType,
+					InputType:  configmodels.DataType(dataType),
+					Receivers:  []string{string(exampleReceiverFactory.Type())},
+					Processors: []string{string(exampleProcessorFactory.Type())},
+					Exporters:  []string{string(exampleExporterFactory.Type())},
+				},
+			},
+		},
+	}
+	return cfg
+}
+
+func TestPipelinesBuilder_BuildVarious(t *testing.T) {
+
+	factories := createExampleFactories()
+
+	tests := []struct {
+		dataType   string
+		shouldFail bool
+	}{
+		{
+			dataType:   "logs",
+			shouldFail: false,
+		},
+		{
+			dataType:   "nosuchdatatype",
+			shouldFail: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.dataType, func(t *testing.T) {
+			dataType := test.dataType
+
+			cfg := createExampleConfig(dataType)
+
+			// BuildProcessors the pipeline
+			allExporters, err := NewExportersBuilder(zap.NewNop(), cfg, factories.Exporters).Build()
+			if test.shouldFail {
+				assert.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.EqualValues(t, 1, len(allExporters))
+			pipelineProcessors, err := NewPipelinesBuilder(zap.NewNop(), cfg, allExporters, factories.Processors).Build()
+
+			assert.NoError(t, err)
+			require.NotNil(t, pipelineProcessors)
+
+			err = pipelineProcessors.StartProcessors(context.Background(), componenttest.NewNopHost())
+			assert.NoError(t, err)
+
+			pipelineName := dataType
+			processor := pipelineProcessors[cfg.Service.Pipelines[pipelineName]]
+
+			// Ensure pipeline has its fields correctly populated.
+			require.NotNil(t, processor)
+			assert.Nil(t, processor.firstTC)
+			assert.Nil(t, processor.firstMC)
+			assert.NotNil(t, processor.firstLC)
+
+			// Compose the list of created exporters.
+			exporterNames := []string{"exampleexporter"}
+			var exporters []*builtExporter
+			for _, name := range exporterNames {
+				// Ensure exporter is created.
+				exp := allExporters[cfg.Exporters[name]]
+				require.NotNil(t, exp)
+				exporters = append(exporters, exp)
+			}
+
+			// Send Logs via processor and verify that all exporters of the pipeline receive it.
+
+			// First check that there are no logs in the exporters yet.
+			var exporterConsumers []*config.ExampleExporterConsumer
+			for _, exporter := range exporters {
+				consumer := exporter.le.(*config.ExampleExporterConsumer)
+				exporterConsumers = append(exporterConsumers, consumer)
+				require.Equal(t, len(consumer.Logs), 0)
+			}
+
+			// Send one custom data.
+			log := idata.Logs{}
+			processor.firstLC.(consumer.LogConsumer).ConsumeLogs(context.Background(), log)
+
+			// Now verify received data.
+			for _, consumer := range exporterConsumers {
+				// Check that the trace is received by exporter.
+				require.Equal(t, 1, len(consumer.Logs))
+
+				// Verify that span is successfully delivered.
+				assert.EqualValues(t, log, consumer.Logs[0])
+			}
+
+			err = pipelineProcessors.ShutdownProcessors(context.Background())
+			assert.NoError(t, err)
 		})
 	}
 }

--- a/service/builder/receivers_builder_test.go
+++ b/service/builder/receivers_builder_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
 	"github.com/open-telemetry/opentelemetry-collector/consumer"
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
+	idata "github.com/open-telemetry/opentelemetry-collector/internal/data"
 	"github.com/open-telemetry/opentelemetry-collector/processor/attributesprocessor"
 	"github.com/open-telemetry/opentelemetry-collector/processor/processortest"
 	"github.com/open-telemetry/opentelemetry-collector/receiver/zipkinreceiver"
@@ -178,6 +179,88 @@ func testReceivers(
 			require.Equal(t, 1, len(metricsConsumer.Metrics))
 			assertEqualMetricsData(t, metricsData, metricsConsumer.Metrics[0])
 		}
+	}
+}
+
+func TestReceiversBuilder_BuildCustom(t *testing.T) {
+	factories := createExampleFactories()
+
+	tests := []struct {
+		dataType   string
+		shouldFail bool
+	}{
+		{
+			dataType:   "logs",
+			shouldFail: false,
+		},
+		{
+			dataType:   "nosuchdatatype",
+			shouldFail: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.dataType, func(t *testing.T) {
+			dataType := test.dataType
+
+			cfg := createExampleConfig(dataType)
+
+			// Build the pipeline
+			allExporters, err := NewExportersBuilder(zap.NewNop(), cfg, factories.Exporters).Build()
+			if test.shouldFail {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+			pipelineProcessors, err := NewPipelinesBuilder(zap.NewNop(), cfg, allExporters, factories.Processors).Build()
+			assert.NoError(t, err)
+			receivers, err := NewReceiversBuilder(zap.NewNop(), cfg, pipelineProcessors, factories.Receivers).Build()
+
+			assert.NoError(t, err)
+			require.NotNil(t, receivers)
+
+			receiver := receivers[cfg.Receivers["examplereceiver"]]
+
+			// Ensure receiver has its fields correctly populated.
+			require.NotNil(t, receiver)
+
+			assert.NotNil(t, receiver.receiver)
+
+			// Compose the list of created exporters.
+			exporterNames := []string{"exampleexporter"}
+			var exporters []*builtExporter
+			for _, name := range exporterNames {
+				// Ensure exporter is created.
+				exp := allExporters[cfg.Exporters[name]]
+				require.NotNil(t, exp)
+				exporters = append(exporters, exp)
+			}
+
+			// Send Data via receiver and verify that all exporters of the pipeline receive it.
+
+			// First check that there are no traces in the exporters yet.
+			for _, exporter := range exporters {
+				consumer := exporter.le.(*config.ExampleExporterConsumer)
+				require.Equal(t, len(consumer.Logs), 0)
+			}
+
+			// Send one data.
+			log := idata.Logs{}
+			producer := receiver.receiver.(*config.ExampleReceiverProducer)
+			producer.LogConsumer.ConsumeLogs(context.Background(), log)
+
+			// Now verify received data.
+			for _, name := range exporterNames {
+				// Check that the data is received by exporter.
+				exporter := allExporters[cfg.Exporters[name]]
+
+				// Validate exported data.
+				consumer := exporter.le.(*config.ExampleExporterConsumer)
+				require.Equal(t, 1, len(consumer.Logs))
+				assert.EqualValues(t, log, consumer.Logs[0])
+			}
+		})
 	}
 }
 

--- a/service/builder/testdata/pipelines_builder.yaml
+++ b/service/builder/testdata/pipelines_builder.yaml
@@ -38,3 +38,7 @@ service:
     metrics/3:
       receivers: [examplereceiver/3]
       exporters: [exampleexporter/2]
+
+    logs:
+      receivers: [examplereceiver/3]
+      exporters: [exampleexporter/2]

--- a/service/service.go
+++ b/service/service.go
@@ -520,7 +520,7 @@ func (app *Application) getPipelinesSummaryTableData() internal.SummaryPipelines
 	for c, p := range app.builtPipelines {
 		row := internal.SummaryPipelinesTableRowData{
 			FullName:            c.Name,
-			InputType:           c.InputType.GetString(),
+			InputType:           string(c.InputType),
 			MutatesConsumedData: p.MutatesConsumedData,
 			Receivers:           c.Receivers,
 			Processors:          c.Processors,


### PR DESCRIPTION
We are planning on experimenting with logs data type in the Collector.
This commit introduces factories and components types for logs and
implements pipeline building for logs.

The data.Log struct is for now empty. We need to wait for OTLP protocol
to define the log data format and we will use it in data.Log.

data.Log is in internal package since logs support is experimental
and is not intended for public usage.

Resolves https://github.com/open-telemetry/opentelemetry-collector/issues/957