### PR TITLE
Make fullname its own type

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -199,7 +199,7 @@ func loadExtensions(v *viper.Viper, factories map[configmodels.Type]component.Ex
 	// Iterate over extensions and create a config for each.
 	for key := range keyMap {
 		// Decode the key into type and fullName components.
-		entity, err := configmodels.NewEntityName(key)
+		entity, err := configmodels.ParseEntityName(key)
 		if err != nil {
 			return nil, &configError{
 				code: errInvalidTypeAndNameKey,
@@ -315,7 +315,7 @@ func loadReceivers(v *viper.Viper, factories map[configmodels.Type]component.Rec
 	// Iterate over input map and create a config for each.
 	for key := range keyMap {
 		// Decode the key into type and fullName components.
-		entity, err := configmodels.NewEntityName(key)
+		entity, err := configmodels.ParseEntityName(key)
 		if err != nil {
 			return nil, &configError{
 				code: errInvalidTypeAndNameKey,
@@ -365,7 +365,7 @@ func loadExporters(v *viper.Viper, factories map[configmodels.Type]component.Exp
 	// Iterate over exporters and create a config for each.
 	for key := range keyMap {
 		// Decode the key into type and fullName components.
-		entity, err := configmodels.NewEntityName(key)
+		entity, err := configmodels.ParseEntityName(key)
 		if err != nil {
 			return nil, &configError{
 				code: errInvalidTypeAndNameKey,
@@ -426,7 +426,7 @@ func loadProcessors(v *viper.Viper, factories map[configmodels.Type]component.Pr
 	// Iterate over processors and create a config for each.
 	for key := range keyMap {
 		// Decode the key into type and fullName components.
-		entity, err := configmodels.NewEntityName(key)
+		entity, err := configmodels.ParseEntityName(key)
 		if err != nil {
 			return nil, &configError{
 				code: errInvalidTypeAndNameKey,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -37,7 +37,7 @@ func TestDecodeConfig(t *testing.T) {
 
 	// Verify extensions.
 	assert.Equal(t, 3, len(config.Extensions))
-	assert.Equal(t, "some string", config.Extensions["exampleextension/1"].(*ExampleExtensionCfg).ExtraSetting)
+	assert.Equal(t, "some string", config.Extensions[configmodels.MustParseEntityName("exampleextension/1")].(*ExampleExtensionCfg).ExtraSetting)
 
 	// Verify service.
 	assert.Equal(t, 2, len(config.Service.Extensions))
@@ -56,7 +56,7 @@ func TestDecodeConfig(t *testing.T) {
 			},
 			ExtraSetting: "some string",
 		},
-		config.Receivers["examplereceiver"],
+		config.Receivers[configmodels.MustParseEntityName("examplereceiver")],
 		"Did not load receiver config correctly")
 
 	assert.Equal(t,
@@ -68,7 +68,7 @@ func TestDecodeConfig(t *testing.T) {
 			},
 			ExtraSetting: "some string",
 		},
-		config.Receivers["examplereceiver/myreceiver"],
+		config.Receivers[configmodels.MustParseEntityName("examplereceiver/myreceiver")],
 		"Did not load receiver config correctly")
 
 	// Verify exporters
@@ -82,7 +82,7 @@ func TestDecodeConfig(t *testing.T) {
 			},
 			ExtraSetting: "some export string",
 		},
-		config.Exporters["exampleexporter"],
+		config.Exporters[configmodels.MustParseEntityName("exampleexporter")],
 		"Did not load exporter config correctly")
 
 	assert.Equal(t,
@@ -93,7 +93,7 @@ func TestDecodeConfig(t *testing.T) {
 			},
 			ExtraSetting: "some export string 2",
 		},
-		config.Exporters["exampleexporter/myexporter"],
+		config.Exporters[configmodels.MustParseEntityName("exampleexporter/myexporter")],
 		"Did not load exporter config correctly")
 
 	// Verify Processors
@@ -107,7 +107,7 @@ func TestDecodeConfig(t *testing.T) {
 			},
 			ExtraSetting: "some export string",
 		},
-		config.Processors["exampleprocessor"],
+		config.Processors[configmodels.MustParseEntityName("exampleprocessor")],
 		"Did not load processor config correctly")
 
 	// Verify Pipelines
@@ -115,11 +115,11 @@ func TestDecodeConfig(t *testing.T) {
 
 	assert.Equal(t,
 		&configmodels.Pipeline{
-			Name:       "traces",
+			Name:       configmodels.MustParseEntityName("traces"),
 			InputType:  configmodels.TracesDataType,
-			Receivers:  []string{"examplereceiver"},
-			Processors: []string{"exampleprocessor"},
-			Exporters:  []string{"exampleexporter"},
+			Receivers:  []configmodels.EntityName{configmodels.MustParseEntityName("examplereceiver")},
+			Processors: []configmodels.EntityName{configmodels.MustParseEntityName("exampleprocessor")},
+			Exporters:  []configmodels.EntityName{configmodels.MustParseEntityName("exampleexporter")},
 		},
 		config.Service.Pipelines["traces"],
 		"Did not load pipeline config correctly")
@@ -213,7 +213,7 @@ func TestSimpleConfig(t *testing.T) {
 				ExtraMapSetting:  map[string]string{"ext-1": extensionExtraMapValue + "_1", "ext-2": extensionExtraMapValue + "_2"},
 				ExtraListSetting: []string{extensionExtraListElement + "_1", extensionExtraListElement + "_2"},
 			},
-			config.Extensions["exampleextension"],
+			config.Extensions[configmodels.MustParseEntityName("exampleextension")],
 			"TEST[%s] Did not load extension config correctly", test.name)
 
 		// Verify service.
@@ -234,7 +234,7 @@ func TestSimpleConfig(t *testing.T) {
 				ExtraMapSetting:  map[string]string{"recv.1": receiverExtraMapValue + "_1", "recv.2": receiverExtraMapValue + "_2"},
 				ExtraListSetting: []string{receiverExtraListElement + "_1", receiverExtraListElement + "_2"},
 			},
-			config.Receivers["examplereceiver"],
+			config.Receivers[configmodels.MustParseEntityName("examplereceiver")],
 			"TEST[%s] Did not load receiver config correctly", test.name)
 
 		// Verify exporters
@@ -251,7 +251,7 @@ func TestSimpleConfig(t *testing.T) {
 				ExtraMapSetting:  map[string]string{"exp_1": exporterExtraMapValue + "_1", "exp_2": exporterExtraMapValue + "_2"},
 				ExtraListSetting: []string{exporterExtraListElement + "_1", exporterExtraListElement + "_2"},
 			},
-			config.Exporters["exampleexporter"],
+			config.Exporters[configmodels.MustParseEntityName("exampleexporter")],
 			"TEST[%s] Did not load exporter config correctly", test.name)
 
 		// Verify Processors
@@ -267,7 +267,7 @@ func TestSimpleConfig(t *testing.T) {
 				ExtraMapSetting:  map[string]string{"proc_1": processorExtraMapValue + "_1", "proc_2": processorExtraMapValue + "_2"},
 				ExtraListSetting: []string{processorExtraListElement + "_1", processorExtraListElement + "_2"},
 			},
-			config.Processors["exampleprocessor"],
+			config.Processors[configmodels.MustParseEntityName("exampleprocessor")],
 			"TEST[%s] Did not load processor config correctly", test.name)
 
 		// Verify Pipelines
@@ -275,13 +275,13 @@ func TestSimpleConfig(t *testing.T) {
 
 		assert.Equalf(t,
 			&configmodels.Pipeline{
-				Name:       "traces",
+				Name:       configmodels.MustParseEntityName("traces"),
 				InputType:  configmodels.TracesDataType,
-				Receivers:  []string{"examplereceiver"},
-				Processors: []string{"exampleprocessor"},
-				Exporters:  []string{"exampleexporter"},
+				Receivers:  []configmodels.EntityName{configmodels.MustParseEntityName("examplereceiver")},
+				Processors: []configmodels.EntityName{configmodels.MustParseEntityName("exampleprocessor")},
+				Exporters:  []configmodels.EntityName{configmodels.MustParseEntityName("exampleexporter")},
 			},
-			config.Service.Pipelines["traces"],
+			config.Service.Pipelines[configmodels.MustParseEntityName("traces")],
 			"TEST[%s] Did not load pipeline config correctly", test.name)
 	}
 }
@@ -314,7 +314,7 @@ func TestDecodeConfig_MultiProto(t *testing.T) {
 				},
 			},
 		},
-		config.Receivers["multireceiver"],
+		config.Receivers[configmodels.MustParseEntityName("multireceiver")],
 		"Did not load receiver config correctly")
 
 	assert.Equal(t,
@@ -332,7 +332,7 @@ func TestDecodeConfig_MultiProto(t *testing.T) {
 				},
 			},
 		},
-		config.Receivers["multireceiver/myreceiver"],
+		config.Receivers[configmodels.MustParseEntityName("multireceiver/myreceiver")],
 		"Did not load receiver config correctly")
 }
 

--- a/config/configmodels/configmodels.go
+++ b/config/configmodels/configmodels.go
@@ -53,15 +53,30 @@ type Type string
 
 // EntityName is a component type and an optional name.
 type EntityName struct {
-	Type Type
-	Name string
+	Type     Type
+	Name     string
+	fullName string
 }
 
-// NewEntityName decodes a key in type[/name] format into Type and Name.
+func NewEntityName(typeStr Type, name string) EntityName {
+	var fullName string
+	if name == "" {
+		fullName = string(typeStr)
+	} else {
+		fullName = string(typeStr) + typeAndNameSeparator + name
+	}
+	return EntityName{
+		Type:     typeStr,
+		Name:     name,
+		fullName: fullName,
+	}
+}
+
+// ParseEntityName decodes a key in type[/name] format into Type and Name.
 // Type and Name components have spaces trimmed.
 // The "type" part must be present, the forward slash and "name" are optional. typeStr
 // will be non-empty if err is nil.
-func NewEntityName(key string) (entity EntityName, err error) {
+func ParseEntityName(key string) (entity EntityName, err error) {
 	items := strings.SplitN(key, typeAndNameSeparator, 2)
 	var typeStr Type
 
@@ -86,18 +101,14 @@ func NewEntityName(key string) (entity EntityName, err error) {
 		nameSuffix = ""
 	}
 
-	return EntityName{
-		Type: typeStr,
-		Name: nameSuffix,
-	}, nil
+	return NewEntityName(
+		typeStr,
+		nameSuffix,
+	), nil
 }
 
 func (e EntityName) String() string {
-	if e.Name == "" {
-		return string(e.Type)
-	} else {
-		return string(e.Type) + typeAndNameSeparator + e.Name
-	}
+	return e.fullName
 }
 
 // NamedEntity is a configuration entity that has a type and a name.

--- a/config/example_factories.go
+++ b/config/example_factories.go
@@ -168,24 +168,15 @@ type MultiProtoReceiver struct {
 
 var _ configmodels.Receiver = (*MultiProtoReceiver)(nil)
 
-// Name gets the exporter name.
-func (rs *MultiProtoReceiver) Name() string {
-	return rs.NameVal
-}
-
 // SetName sets the receiver name.
-func (rs *MultiProtoReceiver) SetName(name string) {
-	rs.NameVal = name
+func (rs *MultiProtoReceiver) SetName(name configmodels.EntityName) {
+	rs.TypeVal = name.Type()
+	rs.NameVal = name.Name()
 }
 
-// Type sets the receiver type.
-func (rs *MultiProtoReceiver) Type() configmodels.Type {
-	return rs.TypeVal
-}
-
-// SetType sets the receiver type.
-func (rs *MultiProtoReceiver) SetType(typeStr configmodels.Type) {
-	rs.TypeVal = typeStr
+// Return receiver name.
+func (rs *MultiProtoReceiver) Name() configmodels.EntityName {
+	return configmodels.NewEntityName(rs.TypeVal, rs.NameVal)
 }
 
 // MultiProtoReceiverOneCfg is multi proto receiver config.

--- a/exporter/exporterhelper/metricshelper.go
+++ b/exporter/exporterhelper/metricshelper.go
@@ -30,7 +30,7 @@ import (
 type PushMetricsDataOld func(ctx context.Context, td consumerdata.MetricsData) (droppedTimeSeries int, err error)
 
 type metricsExporterOld struct {
-	exporterFullName string
+	exporterFullName configmodels.EntityName
 	pushMetricsData  PushMetricsDataOld
 	shutdown         Shutdown
 }
@@ -40,7 +40,7 @@ func (me *metricsExporterOld) Start(ctx context.Context, host component.Host) er
 }
 
 func (me *metricsExporterOld) ConsumeMetricsData(ctx context.Context, md consumerdata.MetricsData) error {
-	exporterCtx := obsreport.ExporterContext(ctx, me.exporterFullName)
+	exporterCtx := obsreport.ExporterContext(ctx, me.exporterFullName.String())
 	_, err := me.pushMetricsData(exporterCtx, md)
 	return err
 }
@@ -78,9 +78,9 @@ func NewMetricsExporterOld(config configmodels.Exporter, pushMetricsData PushMet
 	}, nil
 }
 
-func pushMetricsWithObservabilityOld(next PushMetricsDataOld, exporterName string) PushMetricsDataOld {
+func pushMetricsWithObservabilityOld(next PushMetricsDataOld, exporterName configmodels.EntityName) PushMetricsDataOld {
 	return func(ctx context.Context, md consumerdata.MetricsData) (int, error) {
-		ctx = obsreport.StartMetricsExportOp(ctx, exporterName)
+		ctx = obsreport.StartMetricsExportOp(ctx, exporterName.String())
 		numDroppedTimeSeries, err := next(ctx, md)
 
 		// TODO: this is not ideal: it should come from the next function itself.
@@ -107,7 +107,7 @@ func NumTimeSeries(md consumerdata.MetricsData) int {
 type PushMetricsData func(ctx context.Context, md pdata.Metrics) (droppedTimeSeries int, err error)
 
 type metricsExporter struct {
-	exporterFullName string
+	exporterFullName configmodels.EntityName
 	pushMetricsData  PushMetricsData
 	shutdown         Shutdown
 }
@@ -117,7 +117,7 @@ func (me *metricsExporter) Start(ctx context.Context, host component.Host) error
 }
 
 func (me *metricsExporter) ConsumeMetrics(ctx context.Context, md pdata.Metrics) error {
-	exporterCtx := obsreport.ExporterContext(ctx, me.exporterFullName)
+	exporterCtx := obsreport.ExporterContext(ctx, me.exporterFullName.String())
 	_, err := me.pushMetricsData(exporterCtx, md)
 	return err
 }
@@ -155,9 +155,9 @@ func NewMetricsExporter(config configmodels.Exporter, pushMetricsData PushMetric
 	}, nil
 }
 
-func pushMetricsWithObservability(next PushMetricsData, exporterName string) PushMetricsData {
+func pushMetricsWithObservability(next PushMetricsData, exporterName configmodels.EntityName) PushMetricsData {
 	return func(ctx context.Context, md pdata.Metrics) (int, error) {
-		ctx = obsreport.StartMetricsExportOp(ctx, exporterName)
+		ctx = obsreport.StartMetricsExportOp(ctx, exporterName.String())
 		numDroppedMetrics, err := next(ctx, md)
 
 		// TODO: this is not ideal: it should come from the next function itself.

--- a/exporter/exporterhelper/tracehelper.go
+++ b/exporter/exporterhelper/tracehelper.go
@@ -34,7 +34,7 @@ type traceDataPusher func(ctx context.Context, td pdata.Traces) (droppedSpans in
 
 // traceExporterOld implements the exporter with additional helper options.
 type traceExporterOld struct {
-	exporterFullName string
+	exporterFullName configmodels.EntityName
 	dataPusher       traceDataPusherOld
 	shutdown         Shutdown
 }
@@ -44,7 +44,7 @@ func (te *traceExporterOld) Start(_ context.Context, _ component.Host) error {
 }
 
 func (te *traceExporterOld) ConsumeTraceData(ctx context.Context, td consumerdata.TraceData) error {
-	exporterCtx := obsreport.ExporterContext(ctx, te.exporterFullName)
+	exporterCtx := obsreport.ExporterContext(ctx, te.exporterFullName.String())
 	_, err := te.dataPusher(exporterCtx, td)
 	return err
 }
@@ -89,9 +89,9 @@ func NewTraceExporterOld(
 
 // withObservability wraps the current pusher into a function that records
 // the observability signals during the pusher execution.
-func (p traceDataPusherOld) withObservability(exporterName string) traceDataPusherOld {
+func (p traceDataPusherOld) withObservability(exporterName configmodels.EntityName) traceDataPusherOld {
 	return func(ctx context.Context, td consumerdata.TraceData) (int, error) {
-		ctx = obsreport.StartTraceDataExportOp(ctx, exporterName)
+		ctx = obsreport.StartTraceDataExportOp(ctx, exporterName.String())
 		// Forward the data to the next consumer (this pusher is the next).
 		droppedSpans, err := p(ctx, td)
 
@@ -105,7 +105,7 @@ func (p traceDataPusherOld) withObservability(exporterName string) traceDataPush
 }
 
 type traceExporter struct {
-	exporterFullName string
+	exporterFullName configmodels.EntityName
 	dataPusher       traceDataPusher
 	shutdown         Shutdown
 }
@@ -118,7 +118,7 @@ func (te *traceExporter) ConsumeTraces(
 	ctx context.Context,
 	td pdata.Traces,
 ) error {
-	exporterCtx := obsreport.ExporterContext(ctx, te.exporterFullName)
+	exporterCtx := obsreport.ExporterContext(ctx, te.exporterFullName.String())
 	_, err := te.dataPusher(exporterCtx, td)
 	return err
 }
@@ -162,9 +162,9 @@ func NewTraceExporter(
 
 // withObservability wraps the current pusher into a function that records
 // the observability signals during the pusher execution.
-func (p traceDataPusher) withObservability(exporterName string) traceDataPusher {
+func (p traceDataPusher) withObservability(exporterName configmodels.EntityName) traceDataPusher {
 	return func(ctx context.Context, td pdata.Traces) (int, error) {
-		ctx = obsreport.StartTraceDataExportOp(ctx, exporterName)
+		ctx = obsreport.StartTraceDataExportOp(ctx, exporterName.String())
 		// Forward the data to the next consumer (this pusher is the next).
 		droppedSpans, err := p(ctx, td)
 

--- a/exporter/prometheusexporter/factory.go
+++ b/exporter/prometheusexporter/factory.go
@@ -91,7 +91,7 @@ func (f *Factory) CreateMetricsExporter(logger *zap.Logger, cfg configmodels.Exp
 	}()
 
 	pexp := &prometheusExporter{
-		name:         cfg.Name(),
+		name:         cfg.Name().String(),
 		exporter:     pe,
 		shutdownFunc: ln.Close,
 	}

--- a/processor/attributesprocessor/config_test.go
+++ b/processor/attributesprocessor/config_test.go
@@ -38,7 +38,7 @@ func TestLoadingConifg(t *testing.T) {
 	assert.NoError(t, err)
 	require.NotNil(t, config)
 
-	p0 := config.Processors["attributes/insert"]
+	p0 := config.Processors[configmodels.MustParseEntityName("attributes/insert")]
 	assert.Equal(t, p0, &Config{
 		ProcessorSettings: configmodels.ProcessorSettings{
 			NameVal: "attributes/insert",
@@ -50,7 +50,7 @@ func TestLoadingConifg(t *testing.T) {
 		},
 	})
 
-	p1 := config.Processors["attributes/update"]
+	p1 := config.Processors[configmodels.MustParseEntityName("attributes/update")]
 	assert.Equal(t, p1, &Config{
 		ProcessorSettings: configmodels.ProcessorSettings{
 			NameVal: "attributes/update",
@@ -62,7 +62,7 @@ func TestLoadingConifg(t *testing.T) {
 		},
 	})
 
-	p2 := config.Processors["attributes/upsert"]
+	p2 := config.Processors[configmodels.MustParseEntityName("attributes/upsert")]
 	assert.Equal(t, p2, &Config{
 		ProcessorSettings: configmodels.ProcessorSettings{
 			NameVal: "attributes/upsert",
@@ -74,7 +74,7 @@ func TestLoadingConifg(t *testing.T) {
 		},
 	})
 
-	p3 := config.Processors["attributes/delete"]
+	p3 := config.Processors[configmodels.MustParseEntityName("attributes/delete")]
 	assert.Equal(t, p3, &Config{
 		ProcessorSettings: configmodels.ProcessorSettings{
 			NameVal: "attributes/delete",
@@ -86,7 +86,7 @@ func TestLoadingConifg(t *testing.T) {
 		},
 	})
 
-	p4 := config.Processors["attributes/hash"]
+	p4 := config.Processors[configmodels.MustParseEntityName("attributes/hash")]
 	assert.Equal(t, p4, &Config{
 		ProcessorSettings: configmodels.ProcessorSettings{
 			NameVal: "attributes/hash",
@@ -97,7 +97,7 @@ func TestLoadingConifg(t *testing.T) {
 		},
 	})
 
-	p5 := config.Processors["attributes/excludemulti"]
+	p5 := config.Processors[configmodels.MustParseEntityName("attributes/excludemulti")]
 	assert.Equal(t, p5, &Config{
 		ProcessorSettings: configmodels.ProcessorSettings{
 			NameVal: "attributes/excludemulti",
@@ -119,7 +119,7 @@ func TestLoadingConifg(t *testing.T) {
 		},
 	})
 
-	p6 := config.Processors["attributes/includeservices"]
+	p6 := config.Processors[configmodels.MustParseEntityName("attributes/includeservices")]
 	assert.Equal(t, p6, &Config{
 		ProcessorSettings: configmodels.ProcessorSettings{
 			NameVal: "attributes/includeservices",
@@ -137,7 +137,7 @@ func TestLoadingConifg(t *testing.T) {
 		},
 	})
 
-	p7 := config.Processors["attributes/selectiveprocessing"]
+	p7 := config.Processors[configmodels.MustParseEntityName("attributes/selectiveprocessing")]
 	assert.Equal(t, p7, &Config{
 		ProcessorSettings: configmodels.ProcessorSettings{
 			NameVal: "attributes/selectiveprocessing",
@@ -161,7 +161,7 @@ func TestLoadingConifg(t *testing.T) {
 		},
 	})
 
-	p8 := config.Processors["attributes/complex"]
+	p8 := config.Processors[configmodels.MustParseEntityName("attributes/complex")]
 	assert.Equal(t, p8, &Config{
 		ProcessorSettings: configmodels.ProcessorSettings{
 			NameVal: "attributes/complex",
@@ -174,7 +174,7 @@ func TestLoadingConifg(t *testing.T) {
 		},
 	})
 
-	p9 := config.Processors["attributes/example"]
+	p9 := config.Processors[configmodels.MustParseEntityName("attributes/example")]
 	assert.Equal(t, p9, &Config{
 		ProcessorSettings: configmodels.ProcessorSettings{
 			NameVal: "attributes/example",
@@ -189,7 +189,7 @@ func TestLoadingConifg(t *testing.T) {
 		},
 	})
 
-	p10 := config.Processors["attributes/regexp"]
+	p10 := config.Processors[configmodels.MustParseEntityName("attributes/regexp")]
 	assert.Equal(t, p10, &Config{
 		ProcessorSettings: configmodels.ProcessorSettings{
 			NameVal: "attributes/regexp",

--- a/processor/batchprocessor/batch_processor.go
+++ b/processor/batchprocessor/batch_processor.go
@@ -74,7 +74,7 @@ var _ consumer.MetricsConsumer = (*batchMetricProcessor)(nil)
 func newBatchTracesProcessor(params component.ProcessorCreateParams, trace consumer.TraceConsumer, cfg *Config) *batchTraceProcessor {
 	p := &batchTraceProcessor{
 		batchProcessor: batchProcessor{
-			name:   cfg.Name(),
+			name:   cfg.Name().String(),
 			logger: params.Logger,
 
 			sendBatchSize: cfg.SendBatchSize,
@@ -96,7 +96,7 @@ func newBatchTracesProcessor(params component.ProcessorCreateParams, trace consu
 func newBatchMetricsProcessor(params component.ProcessorCreateParams, metrics consumer.MetricsConsumer, cfg *Config) *batchMetricProcessor {
 	p := &batchMetricProcessor{
 		batchProcessor: batchProcessor{
-			name:   cfg.Name(),
+			name:   cfg.Name().String(),
 			logger: params.Logger,
 
 			sendBatchSize: cfg.SendBatchSize,

--- a/processor/memorylimiter/memorylimiter.go
+++ b/processor/memorylimiter/memorylimiter.go
@@ -108,7 +108,7 @@ func newMemoryLimiter(
 		ballastSize:     ballastSize,
 		ticker:          time.NewTicker(cfg.CheckInterval),
 		readMemStatsFn:  runtime.ReadMemStats,
-		procName:        cfg.Name(),
+		procName:        cfg.Name().String(),
 		logger:          logger,
 	}
 

--- a/processor/processortest/nop_processor.go
+++ b/processor/processortest/nop_processor.go
@@ -74,9 +74,7 @@ func (npf *NopProcessorFactory) Type() configmodels.Type {
 // CreateDefaultConfig creates the default configuration for the Processor.
 func (npf *NopProcessorFactory) CreateDefaultConfig() configmodels.Processor {
 	return &configmodels.ProcessorSettings{
-		EntityName: configmodels.EntityName{
-			Type: npf.Type(),
-		},
+		EntityName: configmodels.NewEntityName(npf.Type(), ""),
 	}
 }
 

--- a/processor/processortest/nop_processor.go
+++ b/processor/processortest/nop_processor.go
@@ -74,8 +74,9 @@ func (npf *NopProcessorFactory) Type() configmodels.Type {
 // CreateDefaultConfig creates the default configuration for the Processor.
 func (npf *NopProcessorFactory) CreateDefaultConfig() configmodels.Processor {
 	return &configmodels.ProcessorSettings{
-		TypeVal: npf.Type(),
-		NameVal: string(npf.Type()),
+		EntityName: configmodels.EntityName{
+			Type: npf.Type(),
+		},
 	}
 }
 

--- a/processor/queuedprocessor/queued_processor.go
+++ b/processor/queuedprocessor/queued_processor.go
@@ -61,7 +61,7 @@ func newQueuedSpanProcessor(
 ) *queuedSpanProcessor {
 	boundedQueue := queue.NewBoundedQueue(cfg.QueueSize, func(item interface{}) {})
 	return &queuedSpanProcessor{
-		name:                     cfg.Name(),
+		name:                     cfg.Name().String(),
 		queue:                    boundedQueue,
 		logger:                   params.Logger,
 		numWorkers:               cfg.NumWorkers,

--- a/processor/spanprocessor/config_test.go
+++ b/processor/spanprocessor/config_test.go
@@ -38,7 +38,7 @@ func TestLoadConfig(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, config)
 
-	p0 := config.Processors["span/custom"]
+	p0 := config.Processors[configmodels.MustParseEntityName("span/custom")]
 	assert.Equal(t, p0, &Config{
 		ProcessorSettings: configmodels.ProcessorSettings{
 			TypeVal: typeStr,
@@ -50,7 +50,7 @@ func TestLoadConfig(t *testing.T) {
 		},
 	})
 
-	p1 := config.Processors["span/no-separator"]
+	p1 := config.Processors[configmodels.MustParseEntityName("span/no-separator")]
 	assert.Equal(t, p1, &Config{
 		ProcessorSettings: configmodels.ProcessorSettings{
 			TypeVal: typeStr,
@@ -62,7 +62,7 @@ func TestLoadConfig(t *testing.T) {
 		},
 	})
 
-	p2 := config.Processors["span/to_attributes"]
+	p2 := config.Processors[configmodels.MustParseEntityName("span/to_attributes")]
 	assert.Equal(t, p2, &Config{
 		ProcessorSettings: configmodels.ProcessorSettings{
 			TypeVal: typeStr,
@@ -75,7 +75,7 @@ func TestLoadConfig(t *testing.T) {
 		},
 	})
 
-	p3 := config.Processors["span/includeexclude"]
+	p3 := config.Processors[configmodels.MustParseEntityName("span/includeexclude")]
 	assert.Equal(t, p3, &Config{
 		ProcessorSettings: configmodels.ProcessorSettings{
 			TypeVal: typeStr,

--- a/receiver/jaegerreceiver/config.go
+++ b/receiver/jaegerreceiver/config.go
@@ -46,13 +46,8 @@ type Config struct {
 }
 
 // Name gets the receiver name.
-func (rs *Config) Name() string {
-	return rs.NameVal
-}
-
-// SetName sets the receiver name.
-func (rs *Config) SetName(name string) {
-	rs.NameVal = name
+func (rs *Config) Name() configmodels.EntityName {
+	return configmodels.NewEntityName(rs.TypeVal, rs.NameVal)
 }
 
 // Type sets the receiver type.
@@ -60,7 +55,8 @@ func (rs *Config) Type() configmodels.Type {
 	return rs.TypeVal
 }
 
-// SetType sets the receiver type.
-func (rs *Config) SetType(typeStr configmodels.Type) {
-	rs.TypeVal = typeStr
+// SetEntityName sets the processor name and type.
+func (rs *Config) SetName(name configmodels.EntityName) {
+	rs.TypeVal = name.Type()
+	rs.NameVal = name.Name()
 }

--- a/receiver/jaegerreceiver/factory.go
+++ b/receiver/jaegerreceiver/factory.go
@@ -216,7 +216,7 @@ func (f *Factory) CreateTraceReceiver(
 	}
 
 	// Create the receiver.
-	return New(rCfg.Name(), &config, nextConsumer, params)
+	return New(rCfg.Name().String(), &config, nextConsumer, params)
 }
 
 // CreateMetricsReceiver creates a metrics receiver based on provided config.

--- a/receiver/opencensusreceiver/factory.go
+++ b/receiver/opencensusreceiver/factory.go
@@ -106,7 +106,7 @@ func (f *Factory) createReceiver(cfg configmodels.Receiver) (*Receiver, error) {
 
 		// We don't have a receiver, so create one.
 		receiver, err = New(
-			rCfg.Name(), rCfg.Transport, rCfg.Endpoint, nil, nil, opts...)
+			rCfg.Name().String(), rCfg.Transport, rCfg.Endpoint, nil, nil, opts...)
 		if err != nil {
 			return nil, err
 		}

--- a/receiver/otlpreceiver/factory.go
+++ b/receiver/otlpreceiver/factory.go
@@ -105,7 +105,7 @@ func (f *Factory) createReceiver(cfg configmodels.Receiver) (*Receiver, error) {
 
 		// We don't have a receiver, so create one.
 		receiver, err = New(
-			rCfg.Name(), rCfg.Transport, rCfg.Endpoint, nil, nil, opts...)
+			rCfg.Name().String(), rCfg.Transport, rCfg.Endpoint, nil, nil, opts...)
 		if err != nil {
 			return nil, err
 		}

--- a/receiver/prometheusreceiver/metrics_receiver.go
+++ b/receiver/prometheusreceiver/metrics_receiver.go
@@ -57,12 +57,12 @@ func (pr *Preceiver) Start(ctx context.Context, host component.Host) error {
 		ctx := context.Background()
 		c, cancel := context.WithCancel(ctx)
 		pr.cancel = cancel
-		c = obsreport.ReceiverContext(c, pr.cfg.Name(), "http", pr.cfg.Name())
+		c = obsreport.ReceiverContext(c, pr.cfg.Name().String(), "http", pr.cfg.Name().String())
 		var jobsMap *internal.JobsMap
 		if !pr.cfg.UseStartTimeMetric {
 			jobsMap = internal.NewJobsMap(time.Duration(2 * time.Minute))
 		}
-		app := internal.NewOcaStore(c, pr.consumer, pr.logger, jobsMap, pr.cfg.UseStartTimeMetric, pr.cfg.Name())
+		app := internal.NewOcaStore(c, pr.consumer, pr.logger, jobsMap, pr.cfg.UseStartTimeMetric, pr.cfg.Name().String())
 		// need to use a logger with the gokitLog interface
 		l := internal.NewZapToGokitLogAdapter(pr.logger)
 		scrapeManager := scrape.NewManager(l, app)

--- a/receiver/zipkinreceiver/factory.go
+++ b/receiver/zipkinreceiver/factory.go
@@ -68,7 +68,7 @@ func (f *Factory) CreateTraceReceiver(
 ) (component.TraceReceiver, error) {
 
 	rCfg := cfg.(*Config)
-	return New(rCfg.Name(), rCfg.Endpoint, nextConsumer)
+	return New(rCfg.Name().String(), rCfg.Endpoint, nextConsumer)
 }
 
 // CreateMetricsReceiver creates a metrics receiver based on provided config.

--- a/service/builder/exporters_builder.go
+++ b/service/builder/exporters_builder.go
@@ -171,7 +171,7 @@ func (eb *ExportersBuilder) Build() (Exporters, error) {
 
 	// BuildExporters exporters based on configuration and required input data types.
 	for _, cfg := range eb.config.Exporters {
-		componentLogger := eb.logger.With(zap.String(typeLogKey, string(cfg.Type())), zap.String(nameLogKey, cfg.Name()))
+		componentLogger := eb.logger.With(zap.Stringer(typeLogKey, cfg.Name().Type()), zap.Stringer(nameLogKey, cfg.Name()))
 		exp, err := eb.buildExporter(componentLogger, cfg, exporterInputDataTypes)
 		if err != nil {
 			return nil, err
@@ -221,9 +221,9 @@ func (eb *ExportersBuilder) buildExporter(
 	config configmodels.Exporter,
 	exportersInputDataTypes exportersRequiredDataTypes,
 ) (*builtExporter, error) {
-	factory := eb.factories[config.Type()]
+	factory := eb.factories[config.Name().Type()]
 	if factory == nil {
-		return nil, fmt.Errorf("exporter factory not found for type: %s", config.Type())
+		return nil, fmt.Errorf("exporter factory not found for type: %s", config.Name().Type())
 	}
 
 	exporter := &builtExporter{
@@ -299,7 +299,7 @@ func (eb *ExportersBuilder) buildExporter(
 		}
 	}
 
-	eb.logger.Info("Exporter is enabled.", zap.String("exporter", config.Name()))
+	eb.logger.Info("Exporter is enabled.", zap.Stringer("exporter", config.Name()))
 
 	return exporter, nil
 }

--- a/service/builder/extensions_builder.go
+++ b/service/builder/extensions_builder.go
@@ -143,7 +143,7 @@ func (eb *ExtensionsBuilder) Build() (Extensions, error) {
 			return nil, errors.Errorf("extension %q is not configured", extName)
 		}
 
-		componentLogger := eb.logger.With(zap.String(typeLogKey, string(extCfg.Type())), zap.String(nameLogKey, extCfg.Name()))
+		componentLogger := eb.logger.With(zap.Stringer(typeLogKey, extCfg.Name().Type()), zap.Stringer(nameLogKey, extCfg.Name()))
 		ext, err := eb.buildExtension(componentLogger, extCfg)
 		if err != nil {
 			return nil, err
@@ -156,9 +156,9 @@ func (eb *ExtensionsBuilder) Build() (Extensions, error) {
 }
 
 func (eb *ExtensionsBuilder) buildExtension(logger *zap.Logger, cfg configmodels.Extension) (*builtExtension, error) {
-	factory := eb.factories[cfg.Type()]
+	factory := eb.factories[cfg.Name().Type()]
 	if factory == nil {
-		return nil, errors.Errorf("extension factory for type %q is not configured", cfg.Type())
+		return nil, errors.Errorf("extension factory for type %q is not configured", cfg.Name().Type())
 	}
 
 	ext := &builtExtension{

--- a/service/builder/receivers_builder.go
+++ b/service/builder/receivers_builder.go
@@ -105,11 +105,11 @@ func (rb *ReceiversBuilder) Build() (Receivers, error) {
 
 	// BuildProcessors receivers based on configuration.
 	for _, cfg := range rb.config.Receivers {
-		logger := rb.logger.With(zap.String(typeLogKey, string(cfg.Type())), zap.String(nameLogKey, cfg.Name()))
+		logger := rb.logger.With(zap.Stringer(typeLogKey, cfg.Name().Type()), zap.Stringer(nameLogKey, cfg.Name()))
 		rcv, err := rb.buildReceiver(logger, cfg)
 		if err != nil {
 			if err == errUnusedReceiver {
-				logger.Info("Ignoring receiver as it is not used by any pipeline", zap.String("receiver", cfg.Name()))
+				logger.Info("Ignoring receiver as it is not used by any pipeline", zap.Stringer("receiver", cfg.Name()))
 				continue
 			}
 			return nil, err
@@ -121,7 +121,7 @@ func (rb *ReceiversBuilder) Build() (Receivers, error) {
 }
 
 // hasReceiver returns true if the pipeline is attached to specified receiver.
-func hasReceiver(pipeline *configmodels.Pipeline, receiverName string) bool {
+func hasReceiver(pipeline *configmodels.Pipeline, receiverName configmodels.EntityName) bool {
 	for _, name := range pipeline.Receivers {
 		if name == receiverName {
 			return true
@@ -245,9 +245,9 @@ func (rb *ReceiversBuilder) buildReceiver(logger *zap.Logger, config configmodel
 	}
 
 	// Prepare to build the receiver.
-	factory := rb.factories[config.Type()]
+	factory := rb.factories[config.Name().Type()]
 	if factory == nil {
-		return nil, fmt.Errorf("receiver factory not found for type: %s", config.Type())
+		return nil, fmt.Errorf("receiver factory not found for type: %s", config.Name().Type())
 	}
 	rcv := &builtReceiver{
 		logger: logger,

--- a/service/internal/templates.go
+++ b/service/internal/templates.go
@@ -19,6 +19,8 @@ import (
 	"io"
 	"io/ioutil"
 	"log"
+
+	"go.opentelemetry.io/collector/config/configmodels"
 )
 
 var (
@@ -69,7 +71,7 @@ type SummaryExtensionsTableData struct {
 
 // SummaryExtensionsTableData contains data for one row in extensions summary table template.
 type SummaryExtensionsTableRowData struct {
-	FullName string
+	FullName configmodels.EntityName
 	Enabled  bool
 }
 
@@ -89,12 +91,12 @@ type SummaryPipelinesTableData struct {
 
 // SummaryPipelinesTableRowData contains data for one row in pipelines summary table template.
 type SummaryPipelinesTableRowData struct {
-	FullName            string
+	FullName            configmodels.EntityName
 	InputType           string
 	MutatesConsumedData bool
-	Receivers           []string
-	Processors          []string
-	Exporters           []string
+	Receivers           []configmodels.EntityName
+	Processors          []configmodels.EntityName
+	Exporters           []configmodels.EntityName
 }
 
 // WriteHTMLSummaryTable writes the summary table for one component type (receivers, processors, exporters).

--- a/service/service.go
+++ b/service/service.go
@@ -554,7 +554,7 @@ func (app *Application) getPipelinesSummaryTableData() internal.SummaryPipelines
 	}
 
 	sort.Slice(data.Rows, func(i, j int) bool {
-		return data.Rows[i].FullName < data.Rows[j].FullName
+		return data.Rows[i].FullName.String() < data.Rows[j].FullName.String()
 	})
 	return data
 }
@@ -571,7 +571,7 @@ func (app *Application) getExtensionsSummaryTableData() internal.SummaryExtensio
 	}
 
 	sort.Slice(data.Rows, func(i, j int) bool {
-		return data.Rows[i].FullName < data.Rows[j].FullName
+		return data.Rows[i].FullName.String() < data.Rows[j].FullName.String()
 	})
 	return data
 }


### PR DESCRIPTION
Full name (ie type[/id]) is used extensively throughout the code but it's
passed around as a string. It's known as many things depending on the context
(fullName, instanceName, receiverName, etc.). By having its own type you don't
have to rely on inferring the contents of the string based on how the variable
is named.

This obviously causes a lot of churn in the code but I think it makes code that
uses the full name easier to follow.