### PR TITLE
Make MatchSpan implementation use FilterSet package

### DIFF
--- a/internal/processor/filterset/config.go
+++ b/internal/processor/filterset/config.go
@@ -31,6 +31,10 @@ const (
 	Strict MatchType = "strict"
 )
 
+var (
+	validMatchTypes = []MatchType{Regexp, Strict}
+)
+
 // Config configures the matching behavior of a FilterSet.
 type Config struct {
 	MatchType    MatchType      `mapstructure:"match_type"`
@@ -46,6 +50,6 @@ func CreateFilterSet(filters []string, cfg *Config) (FilterSet, error) {
 		// Strict FilterSets do not have any extra configuration options, so call the constructor directly.
 		return strict.NewStrictFilterSet(filters)
 	default:
-		return nil, fmt.Errorf("unrecognized filter type: %v", cfg.MatchType)
+		return nil, fmt.Errorf("unrecognized match_type: '%v', valid types are: %v", cfg.MatchType, validMatchTypes)
 	}
 }

--- a/internal/processor/filterspan/config.go
+++ b/internal/processor/filterspan/config.go
@@ -14,6 +14,10 @@
 
 package filterspan
 
+import (
+	"go.opentelemetry.io/collector/internal/processor/filterset"
+)
+
 // MatchConfig has two optional MatchProperties one to define what is processed
 // by the processor, captured under the 'include' and the second, exclude, to
 // define what is excluded from the processor.
@@ -61,9 +65,8 @@ type MatchConfig struct {
 // Please refer to processor/attributesprocessor/testdata/config.yaml and
 // processor/spanprocessor/testdata/config.yaml for valid configurations.
 type MatchProperties struct {
-	// MatchType controls how items in "services" and "span_names" arrays are
-	// interpreted. Possible values are "regexp" or "strict".
-	MatchType MatchType `mapstructure:"match_type"`
+	// Config configures the matching patterns used when matching span properties.
+	filterset.Config `mapstructure:",squash"`
 
 	// Note: one of Services, SpanNames or Attributes must be specified with a
 	// non-empty value for a valid configuration.
@@ -84,14 +87,6 @@ type MatchProperties struct {
 	// This is an optional field.
 	Attributes []Attribute `mapstructure:"attributes"`
 }
-
-// MatchType defines possible match types.
-type MatchType string
-
-const (
-	MatchTypeRegexp MatchType = "regexp"
-	MatchTypeStrict MatchType = "strict"
-)
 
 // MatchTypeFieldName is the mapstructure field name for MatchProperties.MatchType field.
 const MatchTypeFieldName = "match_type"

--- a/processor/README.md
+++ b/processor/README.md
@@ -126,6 +126,10 @@ are checked before the `exclude` properties.
       # This is a required field.
       match_type: {strict, regexp}
 
+      # regexp is an optional configuration section for match_type regexp.
+      {regexp}: 
+        # < see "Match Configuration" below >
+
       # services specify an array of items to match the service name against.
       # A match occurs if the span service name matches at least of the items.
       # This is an optional field.
@@ -145,6 +149,20 @@ are checked before the `exclude` properties.
           # Value specifies the exact value to match against.
           # If not specified, a match occurs if the key is present in the attributes.
           value: {value}
+```
+
+#### Match Configuration
+
+Some `match_type` values have additional configuration options that can be specified. The `match_type` value is the name of the configuration section. These sections are optional.
+
+```yaml
+# regexp is an optional configuration section for match_type regexp.
+{regexp}: 
+  # cacheenabled determines whether match results are LRU cached to make subsequent matches faster.
+  # Cache size is unlimited unless cachemaxnumentries is also specified.
+  cacheenabled: <bool>
+  # cachemaxnumentries is the max number of entries of the LRU cache; ignored if cacheenabled is false.
+  cachemaxnumentries: <int>
 ```
 
 ## <a name="recommended-processors"></a>Recommended Processors

--- a/processor/README.md
+++ b/processor/README.md
@@ -127,7 +127,7 @@ are checked before the `exclude` properties.
       match_type: {strict, regexp}
 
       # regexp is an optional configuration section for match_type regexp.
-      {regexp}: 
+      regexp: 
         # < see "Match Configuration" below >
 
       # services specify an array of items to match the service name against.
@@ -157,7 +157,7 @@ Some `match_type` values have additional configuration options that can be speci
 
 ```yaml
 # regexp is an optional configuration section for match_type regexp.
-{regexp}: 
+regexp: 
   # cacheenabled determines whether match results are LRU cached to make subsequent matches faster.
   # Cache size is unlimited unless cachemaxnumentries is also specified.
   cacheenabled: <bool>

--- a/processor/attributesprocessor/config_test.go
+++ b/processor/attributesprocessor/config_test.go
@@ -23,6 +23,7 @@ import (
 
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/configmodels"
+	"go.opentelemetry.io/collector/internal/processor/filterset"
 	"go.opentelemetry.io/collector/internal/processor/filterspan"
 )
 
@@ -104,8 +105,8 @@ func TestLoadingConifg(t *testing.T) {
 		},
 		MatchConfig: filterspan.MatchConfig{
 			Exclude: &filterspan.MatchProperties{
-				MatchType: filterspan.MatchTypeStrict,
-				Services:  []string{"svcA", "svcB"},
+				Config:   *createConfig(filterset.Strict),
+				Services: []string{"svcA", "svcB"},
 				Attributes: []filterspan.Attribute{
 					{Key: "env", Value: "dev"},
 					{Key: "test_request"},
@@ -126,8 +127,8 @@ func TestLoadingConifg(t *testing.T) {
 		},
 		MatchConfig: filterspan.MatchConfig{
 			Include: &filterspan.MatchProperties{
-				MatchType: filterspan.MatchTypeRegexp,
-				Services:  []string{"auth.*", "login.*"},
+				Config:   *createConfig(filterset.Regexp),
+				Services: []string{"auth.*", "login.*"},
 			},
 		},
 		Actions: []ActionKeyValue{
@@ -144,11 +145,11 @@ func TestLoadingConifg(t *testing.T) {
 		},
 		MatchConfig: filterspan.MatchConfig{
 			Include: &filterspan.MatchProperties{
-				MatchType: filterspan.MatchTypeStrict,
-				Services:  []string{"svcA", "svcB"},
+				Config:   *createConfig(filterset.Strict),
+				Services: []string{"svcA", "svcB"},
 			},
 			Exclude: &filterspan.MatchProperties{
-				MatchType: filterspan.MatchTypeStrict,
+				Config: *createConfig(filterset.Strict),
 				Attributes: []filterspan.Attribute{
 					{Key: "redact_trace", Value: false},
 				},
@@ -196,11 +197,11 @@ func TestLoadingConifg(t *testing.T) {
 		},
 		MatchConfig: filterspan.MatchConfig{
 			Include: &filterspan.MatchProperties{
-				MatchType: filterspan.MatchTypeRegexp,
-				Services:  []string{"auth.*"},
+				Config:   *createConfig(filterset.Regexp),
+				Services: []string{"auth.*"},
 			},
 			Exclude: &filterspan.MatchProperties{
-				MatchType: filterspan.MatchTypeRegexp,
+				Config:    *createConfig(filterset.Regexp),
 				SpanNames: []string{"login.*"},
 			},
 		},

--- a/processor/spanprocessor/config_test.go
+++ b/processor/spanprocessor/config_test.go
@@ -22,6 +22,7 @@ import (
 
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/configmodels"
+	"go.opentelemetry.io/collector/internal/processor/filterset"
 	"go.opentelemetry.io/collector/internal/processor/filterspan"
 )
 
@@ -82,12 +83,12 @@ func TestLoadConfig(t *testing.T) {
 		},
 		MatchConfig: filterspan.MatchConfig{
 			Include: &filterspan.MatchProperties{
-				MatchType: filterspan.MatchTypeRegexp,
+				Config:    *createMatchConfig(filterset.Regexp),
 				Services:  []string{`banks`},
 				SpanNames: []string{"^(.*?)/(.*?)$"},
 			},
 			Exclude: &filterspan.MatchProperties{
-				MatchType: filterspan.MatchTypeStrict,
+				Config:    *createMatchConfig(filterset.Strict),
 				SpanNames: []string{`donot/change`},
 			},
 		},
@@ -97,4 +98,10 @@ func TestLoadConfig(t *testing.T) {
 			},
 		},
 	})
+}
+
+func createMatchConfig(matchType filterset.MatchType) *filterset.Config {
+	return &filterset.Config{
+		MatchType: matchType,
+	}
 }

--- a/processor/spanprocessor/span_test.go
+++ b/processor/spanprocessor/span_test.go
@@ -27,6 +27,7 @@ import (
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/exporter/exportertest"
 	"go.opentelemetry.io/collector/internal/data/testdata"
+	"go.opentelemetry.io/collector/internal/processor/filterset"
 	"go.opentelemetry.io/collector/internal/processor/filterspan"
 	"go.opentelemetry.io/collector/translator/conventions"
 )
@@ -149,8 +150,8 @@ func TestSpanProcessor_NilEmptyData(t *testing.T) {
 	cfg := factory.CreateDefaultConfig()
 	oCfg := cfg.(*Config)
 	oCfg.Include = &filterspan.MatchProperties{
-		MatchType: "strict",
-		Services:  []string{"service"},
+		Config:   *createMatchConfig(filterset.Strict),
+		Services: []string{"service"},
 	}
 	oCfg.Rename.FromAttributes = []string{"key"}
 
@@ -607,12 +608,12 @@ func TestSpanProcessor_skipSpan(t *testing.T) {
 	cfg := factory.CreateDefaultConfig()
 	oCfg := cfg.(*Config)
 	oCfg.Include = &filterspan.MatchProperties{
-		MatchType: filterspan.MatchTypeRegexp,
+		Config:    *createMatchConfig(filterset.Regexp),
 		Services:  []string{`^banks$`},
 		SpanNames: []string{"/"},
 	}
 	oCfg.Exclude = &filterspan.MatchProperties{
-		MatchType: filterspan.MatchTypeStrict,
+		Config:    *createMatchConfig(filterset.Strict),
 		SpanNames: []string{`donot/change`},
 	}
 	oCfg.Rename.ToAttributes = &ToAttributes{


### PR DESCRIPTION
**Description:**
The MatchSpan interface is used by the attributes/span processor,
however this change does not change the yaml configuration or behavior,
just implementation.

FilterSet has the same filtering logic as MatchSpan previously had, but operates more
generically on just strings instead of spans and adds some additional
options, such as caching.

**Link to tracking Issue:** Side effect of #560 to help keep metrics and trace processors using matching configs the same.

**Testing:** unit tests updated, no new behavior, just implementation swapout
**Documentation:** N/A