### PR TITLE
Extend attributeprocessor to enable extracting multiple attributes from other attribute values using regex (979)

### DIFF
--- a/processor/attributesprocessor/attributes_test.go
+++ b/processor/attributesprocessor/attributes_test.go
@@ -417,6 +417,81 @@ func TestAttributes_UpsertValue(t *testing.T) {
 	}
 }
 
+func TestAttributes_UpsertFromRegex(t *testing.T) {
+	testCases := []testCase{
+		// Ensure `new_user_key` is not set for spans with no attributes.
+		{
+			name:               "UpsertEmptyAttributes",
+			inputAttributes:    map[string]pdata.AttributeValue{},
+			expectedAttributes: map[string]pdata.AttributeValue{},
+		},
+		// Ensure `new_user_key` is not inserted for spans with missing attribute `user_key`.
+		{
+			name: "UpsertFromRegexNoExist",
+			inputAttributes: map[string]pdata.AttributeValue{
+				"boo": pdata.NewAttributeValueString("ghosts are scary"),
+			},
+			expectedAttributes: map[string]pdata.AttributeValue{
+				"boo": pdata.NewAttributeValueString("ghosts are scary"),
+			},
+		},
+		// Ensure `new_user_key` is not updated for spans with attribute `user_key` that does not match regex.
+		{
+			name: "UpsertFromRegexNotMatch",
+			inputAttributes: map[string]pdata.AttributeValue{
+				"user_key": pdata.NewAttributeValueString("does not match"),
+				"boo":      pdata.NewAttributeValueString("ghosts are scary"),
+			},
+			expectedAttributes: map[string]pdata.AttributeValue{
+				"user_key": pdata.NewAttributeValueString("does not match"),
+				"boo":      pdata.NewAttributeValueString("ghosts are scary"),
+			},
+		},
+		// Ensure `new_user_key` is inserted for spans with attribute `user_key`.
+		{
+			name: "UpsertFromRegexExistsInsert",
+			inputAttributes: map[string]pdata.AttributeValue{
+				"user_key": pdata.NewAttributeValueString("/api/v1/document/12345678/update"),
+				"foo":      pdata.NewAttributeValueString("casper the friendly ghost"),
+			},
+			expectedAttributes: map[string]pdata.AttributeValue{
+				"user_key":     pdata.NewAttributeValueString("/api/v1/document/12345678/update"),
+				"new_user_key": pdata.NewAttributeValueString("12345678"),
+				"foo":          pdata.NewAttributeValueString("casper the friendly ghost"),
+			},
+		},
+		// Ensure `new_user_key` is updated for spans with attribute `user_key`.
+		{
+			name: "UpsertFromRegexExistsUpdate",
+			inputAttributes: map[string]pdata.AttributeValue{
+				"user_key":     pdata.NewAttributeValueString("/api/v1/document/12345678/update"),
+				"new_user_key": pdata.NewAttributeValueString("2321"),
+				"foo":          pdata.NewAttributeValueString("casper the friendly ghost"),
+			},
+			expectedAttributes: map[string]pdata.AttributeValue{
+				"user_key":     pdata.NewAttributeValueString("/api/v1/document/12345678/update"),
+				"new_user_key": pdata.NewAttributeValueString("12345678"),
+				"foo":          pdata.NewAttributeValueString("casper the friendly ghost"),
+			},
+		},
+	}
+
+	factory := Factory{}
+	cfg := factory.CreateDefaultConfig()
+	oCfg := cfg.(*Config)
+	oCfg.Actions = []ActionKeyValue{
+		{Regex: "^\\/api\\/v1\\/document\\/(?P<new_user_key>.*)\\/update$", Action: UPSERT, FromAttribute: "user_key"},
+	}
+
+	tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{}, exportertest.NewNopTraceExporter(), cfg)
+	require.Nil(t, err)
+	require.NotNil(t, tp)
+
+	for _, tt := range testCases {
+		runIndividualTestCase(t, tt, tp)
+	}
+}
+
 func TestAttributes_UpsertFromAttribute(t *testing.T) {
 
 	testCases := []testCase{

--- a/processor/attributesprocessor/config.go
+++ b/processor/attributesprocessor/config.go
@@ -47,6 +47,11 @@ type ActionKeyValue struct {
 	// The type of the value is inferred from the configuration.
 	Value interface{} `mapstructure:"value"`
 
+	// A regex may be specified in place of a value for INSERT, UPDATE or UPSERT
+	// The keys will be inferred based on the names of the matcher groups provided
+	// And the names will be inferred based on the values of the matcher group
+	Regex string `mapstructure:"regex"`
+
 	// FromAttribute specifies the attribute from the span to use to populate
 	// the value. If the attribute doesn't exist, no action is performed.
 	FromAttribute string `mapstructure:"from_attribute"`

--- a/processor/attributesprocessor/factory_test.go
+++ b/processor/attributesprocessor/factory_test.go
@@ -173,7 +173,7 @@ func TestFactory_validateActionsConfiguration_InvalidConfig(t *testing.T) {
 			actionLists: []ActionKeyValue{
 				{Value: "value", Regex: "(?P<operation_website>.*?)$", FromAttribute: "aa", Action: UPSERT},
 			},
-			errorString: "error creating \"attributes\" processor. Only of field \"value\" or \"regex\" setting must be specified for 0-th action of processor \"attributes/error\"",
+			errorString: "error creating \"attributes\" processor due to both fields \"value\" and \"regex\" being set at the 0-th actions of processor \"attributes/error\"",
 		},
 		{
 			name: "regex and not from attribute",
@@ -195,6 +195,20 @@ func TestFactory_validateActionsConfiguration_InvalidConfig(t *testing.T) {
 				{Regex: "(?P<operation_website>.*?)$", Key: "", Value: 123, Action: DELETE},
 			},
 			errorString: "error creating \"attributes\" processor. Action \"DELETE\" does not use \"value\", \"regex\" or \"from_attribute\" field. These must not be specified for 0-th action of processor \"attributes/error\"",
+		},
+		{
+			name: "regex with unnamed capture group",
+			actionLists: []ActionKeyValue{
+				{Regex: "(.*)$", FromAttribute: "aa", Action: UPSERT},
+			},
+			errorString: "error creating \"attributes\" processor. Field \"regex\" contains an unnamed matcher group at the 0-th actions of processor \"attributes/error\"",
+		},
+		{
+			name: "regex with no named capture groups",
+			actionLists: []ActionKeyValue{
+				{Regex: ".*", FromAttribute: "aa", Action: UPSERT},
+			},
+			errorString: "error creating \"attributes\" processor. Field \"regex\" contains no named matcher groups at the 0-th actions of processor \"attributes/error\"",
 		},
 	}
 	factory := Factory{}

--- a/processor/attributesprocessor/testdata/config.yaml
+++ b/processor/attributesprocessor/testdata/config.yaml
@@ -19,6 +19,19 @@ processors:
         from_attribute: "anotherkey"
         action: insert
 
+  # The following example demonstrates using regex to create new attributes based on the value of another attribute.
+  attributes/regex_insert:
+    actions:
+      # The following uses the value from attribute "http.url" to insert new attributes
+      # Given http.url = http://example.com/path?queryParam1=value1,queryParam2=value2 then the following attributes will be inserted:
+      # http_protocol: http
+      # http_domain: example.com
+      # http_path: path
+      # http_query_params=queryParam1=value1,queryParam2=value2
+      - regex: ^(?P<http_protocol>.*):\/\/(?P<http_domain>.*)\/(?P<http_path>.*)(\?|\&)(?P<http_query_params>.*)
+        from_attribute: "http.url"
+        action: insert
+
   # The following demonstrates configuring the processor to only update existing
   # keys in an attribute.
   # Note: `action: update` must be set.


### PR DESCRIPTION
**Description:** 
Added the option to create one or more attributes using regex matcher groups against another attribute value.

**Link to tracking Issue:**
https://github.com/open-telemetry/opentelemetry-collector/issues/979

**Testing:** 
I have added unit tests to validate that the configuration is validated as expected and that the regex matching works correctly.

**Documentation:**
I updated the example configuration file with a detailed example of how to use this.