### PR TITLE
Fix unit tests on Windows

### DIFF
--- a/config/configgrpc/configgrpc.go
+++ b/config/configgrpc/configgrpc.go
@@ -133,9 +133,14 @@ func GrpcSettingsToDialOptions(settings GRPCSettings) ([]grpc.DialOption, error)
 
 // LoadTLSConfig loads TLS certificates and returns a tls.Config.
 func (c TLSConfig) LoadTLSConfig() (*tls.Config, error) {
-	certPool, err := c.loadCertPool()
-	if err != nil {
-		return nil, fmt.Errorf("failed to load CA CertPool: %w", err)
+	var err error
+	var certPool *x509.CertPool
+	if len(c.CaCert) != 0 {
+		// setup user specified truststore
+		certPool, err = c.loadCert(c.CaCert)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load CA CertPool: %w", err)
+		}
 	}
 	// #nosec G402
 	tlsCfg := &tls.Config{
@@ -155,20 +160,6 @@ func (c TLSConfig) LoadTLSConfig() (*tls.Config, error) {
 	}
 
 	return tlsCfg, nil
-}
-
-var systemCertPool = x509.SystemCertPool // to allow overriding in unit test
-
-func (c TLSConfig) loadCertPool() (*x509.CertPool, error) {
-	if len(c.CaCert) == 0 { // no truststore given, use SystemCertPool
-		certPool, err := systemCertPool()
-		if err != nil {
-			return nil, fmt.Errorf("failed to load SystemCertPool: %w", err)
-		}
-		return certPool, nil
-	}
-	// setup user specified truststore
-	return c.loadCert(c.CaCert)
 }
 
 func (c TLSConfig) loadCert(caPath string) (*x509.CertPool, error) {

--- a/receiver/opencensusreceiver/opencensus_test.go
+++ b/receiver/opencensusreceiver/opencensus_test.go
@@ -371,10 +371,9 @@ func TestStartWithoutConsumersShouldFail(t *testing.T) {
 func tempSocketName(t *testing.T) string {
 	tmpfile, err := ioutil.TempFile("", "sock")
 	require.NoError(t, err)
+	require.NoError(t, tmpfile.Close())
 	socket := tmpfile.Name()
-	err = os.Remove(socket)
-	require.NoError(t, err)
-
+	require.NoError(t, os.Remove(socket))
 	return socket
 }
 

--- a/receiver/otlpreceiver/otlp_test.go
+++ b/receiver/otlpreceiver/otlp_test.go
@@ -395,10 +395,9 @@ func TestStartWithoutConsumersShouldFail(t *testing.T) {
 func tempSocketName(t *testing.T) string {
 	tmpfile, err := ioutil.TempFile("", "sock")
 	require.NoError(t, err)
+	require.NoError(t, tmpfile.Close())
 	socket := tmpfile.Name()
-	err = os.Remove(socket)
-	require.NoError(t, err)
-
+	require.NoError(t, os.Remove(socket))
 	return socket
 }
 


### PR DESCRIPTION
**Description:**
Fixes several unit tests that were failling on Windows:

1. `configgrpc`, `configgrpc_test` & `opencensusexporter.factory`: On Windows, calling `x509.SystemCertPool()` directly returns an error (see the discussion here https://github.com/golang/go/issues/16736), but as per the documentation, leaving `TLSConfig.RootCAs` as `nil` will still correctly validate certificates against the system cert pool. Fixing the failing tests on Windows required some minor code changes so that we never load the system cert pool, and just rely on `RootCAs` being `nil` instead. This made an existing test that checked if the call to `x509.SystemCertPool()` failed redundant.

2. `configgrpc_test`: Generalised a couple of checks against expected errors so they will pass on Windows (due to slightly different error responses).

3. `opencensus_test` & `otlp_test`: A tmp file was opened and then deleted before being closed, which raises a file-in-use error on Windows ==> Close the file before deleting it.

**Link to tracking Issue:**
https://github.com/open-telemetry/opentelemetry-collector/issues/854

**See also:**
https://github.com/open-telemetry/opentelemetry-collector/pull/976