### PR TITLE
Do not pass zeroed parent span id from OC receiver

### DIFF
--- a/translator/internaldata/oc_to_traces_test.go
+++ b/translator/internaldata/oc_to_traces_test.go
@@ -246,6 +246,10 @@ func TestOcToInternal(t *testing.T) {
 		Status: &octrace.Status{Message: "status-cancelled", Code: 1},
 	}
 
+	// TODO: Create another unit test fully covering ocSpanToInternal
+	ocSpanZeroedParentID := proto.Clone(ocSpan1).(*octrace.Span)
+	ocSpanZeroedParentID.ParentSpanId = []byte{0, 0, 0, 0, 0, 0, 0, 0}
+
 	ocSpan2 := &octrace.Span{
 		Name:      &octrace.TruncatableString{Value: "operationB"},
 		StartTime: startTime,
@@ -335,6 +339,16 @@ func TestOcToInternal(t *testing.T) {
 		},
 
 		{
+			name: "one-span-zeroed-parent-id",
+			td:   testdata.GenerateTraceDataOneSpan(),
+			oc: consumerdata.TraceData{
+				Node:     ocNode,
+				Resource: ocResource1,
+				Spans:    []*octrace.Span{ocSpanZeroedParentID},
+			},
+		},
+
+		{
 			name: "one-span-one-nil",
 			td:   testdata.GenerateTraceDataOneSpan(),
 			oc: consumerdata.TraceData{
@@ -375,13 +389,14 @@ func TestOcToInternal(t *testing.T) {
 		},
 	}
 
-	// Extra test:
+	// Extra tests:
 	//	* "two-spans-and-separate-in-the-middle"
+	//	* "one-span-zeroed-parent-id"
 	// Missing tests (impossible to generate):
 	//  * GenerateTraceDataOneEmptyOneNilResourceSpans
 	//	* GenerateTraceDataOneEmptyInstrumentationLibrary
 	//	* GenerateTraceDataOneEmptyOneNilInstrumentationLibrary
-	assert.EqualValues(t, testdata.NumTraceTests-2, len(tests))
+	assert.EqualValues(t, testdata.NumTraceTests-1, len(tests))
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
OpenCensus go instrumentation uses 8-bytes array internally https://github.com/census-instrumentation/opencensus-go/blob/master/trace/export.go#L76, and before exporting it in OC format the array is converted to slice https://github.com/census-ecosystem/opencensus-go-exporter-ocagent/blob/master/transform_spans.go#L44. As a result root spans are exported with ParentSpanID set to 8 byte slices with all zero values. 

This commit makes the OC->Internal trace convertor skip those values and align such spans with internal representation of a root span which supposed to have ParentSpanID set to nil instead.