### PR TITLE
Fix zipkin receiver status code conversion

### DIFF
--- a/translator/trace/zipkin/status_code_test.go
+++ b/translator/trace/zipkin/status_code_test.go
@@ -1,0 +1,95 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package zipkin
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAttribToStatusCode(t *testing.T) {
+	_, atoiError := strconv.Atoi("nan")
+
+	tests := []struct {
+		name string
+		attr *tracepb.AttributeValue
+		code int32
+		err  error
+	}{
+		{
+			name: "nil",
+			attr: nil,
+			code: 0,
+			err:  fmt.Errorf("nil attribute"),
+		},
+
+		{
+			name: "valid-int-code",
+			attr: &tracepb.AttributeValue{
+				Value: &tracepb.AttributeValue_IntValue{IntValue: int64(0)},
+			},
+			code: 0,
+			err:  nil,
+		},
+
+		{
+			name: "invalid-int-code",
+			attr: &tracepb.AttributeValue{
+				Value: &tracepb.AttributeValue_IntValue{IntValue: int64(1 << 32)},
+			},
+			code: 0,
+			err:  fmt.Errorf("outside of the int32 range"),
+		},
+
+		{
+			name: "valid-string-code",
+			attr: &tracepb.AttributeValue{
+				Value: &tracepb.AttributeValue_StringValue{StringValue: &tracepb.TruncatableString{Value: "200"}},
+			},
+			code: 200,
+			err:  nil,
+		},
+
+		{
+			name: "invalid-string-code",
+			attr: &tracepb.AttributeValue{
+				Value: &tracepb.AttributeValue_StringValue{StringValue: &tracepb.TruncatableString{Value: "nan"}},
+			},
+			code: 0,
+			err:  atoiError,
+		},
+
+		{
+			name: "bool-code",
+			attr: &tracepb.AttributeValue{
+				Value: &tracepb.AttributeValue_BoolValue{BoolValue: true},
+			},
+			code: 0,
+			err:  fmt.Errorf("invalid attribute type"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := attribToStatusCode(test.attr)
+			assert.Equal(t, test.code, got)
+			assert.Equal(t, test.err, err)
+		})
+	}
+}


### PR DESCRIPTION
Problem: 
If any zipkin span attribute that is used as source for setting OC status code (like `status.code`, `http.status_code` or `census.status_code`) received with a type other than int64, the underlying value will be taken as an integer. For example if http.status_code sent as "200" string attribute it's got converted to status code = 2. 
The problem wasn't that critical until we started setting error tag based on status code https://github.com/open-telemetry/opentelemetry-collector/commit/75ae9198a89eb9df1d14308c89c2a4c93b6ba9e1 

This commit adds support of string values in status.code, http.status_code or census.status_code attributes and reject values of other types.