### PR TITLE
Add missing checkInterval to k8s deployment config

### DIFF
--- a/examples/k8s.yaml
+++ b/examples/k8s.yaml
@@ -135,7 +135,7 @@ data:
         traces/1:
           receivers: [otlp, zipkin]
           processors: [memory_limiter, batch, queued_retry]
-          exporters: [otlp, zipkin]
+          exporters: [zipkin]
         traces/2:
           receivers: [otlp, jaeger]
           processors: [memory_limiter, batch, queued_retry]

--- a/examples/k8s.yaml
+++ b/examples/k8s.yaml
@@ -22,6 +22,7 @@ data:
         limit_mib: 400
         # 25% of limit up to 2G
         spike_limit_mib: 100
+        check_interval: 5s
       queued_retry:
         num_workers: 4
         queue_size: 100
@@ -118,6 +119,7 @@ data:
         limit_mib: 400
         # 25% of limit up to 2G
         spike_limit_mib: 100
+        check_interval: 5s
       queued_retry:
     extensions:
       health_check: {}


### PR DESCRIPTION
**Description:** 

As is, the example k8s agent fails to deploy, going into a CrashLoopBackoff:

```
{"level":"info","ts":1589972770.1904275,"caller":"builder/exporters_builder.go:95","msg":"Exporter started.","component_kind":"exporter","component_type":"otlp","component_name":"otlp"}
Error: cannot setup pipelines: cannot build pipelines: error creating processor "memory_limiter" in pipeline "traces": checkInterval must be greater than zero
2020/05/20 11:06:10 Application run finished with error: cannot setup pipelines: cannot build pipelines: error creating processor "memory_limiter" in pipeline "traces": checkInterval must be greater than zero
```

**Testing:** 
I created a completely empty minikube and tried to apply k8s.yml from master. With this change, the agent becomes ready.

**Documentation**
None  - caveat: as I couldn't find existing documentation for checkInterval and am just playing around right now, I don' really know if 5s is a sensible value for this.