### PR TITLE
resourceprocessor: Don't panic when consumed resource has nil labels

### DIFF
--- a/processor/resourceprocessor/resource_processor.go
+++ b/processor/resourceprocessor/resource_processor.go
@@ -131,7 +131,7 @@ func mergeResource(to, from *resourcepb.Resource) *resourcepb.Resource {
 	}
 	if from.Labels != nil {
 		if to.Labels == nil {
-			to.Labels = map[string]string{}
+			to.Labels = make(map[string]string, len(from.Labels))
 		}
 
 		for k, v := range from.Labels {

--- a/processor/resourceprocessor/resource_processor.go
+++ b/processor/resourceprocessor/resource_processor.go
@@ -130,6 +130,10 @@ func mergeResource(to, from *resourcepb.Resource) *resourcepb.Resource {
 		to.Type = from.Type
 	}
 	if from.Labels != nil {
+		if to.Labels == nil {
+			to.Labels = map[string]string{}
+		}
+
 		for k, v := range from.Labels {
 			to.Labels[k] = v
 		}

--- a/processor/resourceprocessor/resource_processor_test.go
+++ b/processor/resourceprocessor/resource_processor_test.go
@@ -129,6 +129,22 @@ func TestResourceProcessor(t *testing.T) {
 			sourceResource:      nil,
 			wantResource:        nil,
 		},
+		{
+			name:                "Consumed resource with nil labels",
+			config:              cfgWithEmptyResourceType,
+			mutatesConsumedData: true,
+			sourceResource: &resourcepb.Resource{
+				Type: "original-type",
+			},
+			wantResource: &resourcepb.Resource{
+				Type: "original-type",
+				Labels: map[string]string{
+					"cloud.zone":       "zone-1",
+					"k8s.cluster.name": "k8s-cluster",
+					"host.name":        "k8s-node",
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
**Description:** The `resource` processor panics if the `Labels` field on a consumed resource is `nil`. Handled this gracefully by initializing the field if it is `nil`.

**Testing:** Added unit test.

