### PR TITLE
change k8s.io/client-go version to sha1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -63,5 +63,7 @@ require (
 	google.golang.org/grpc v1.29.1
 	gopkg.in/yaml.v2 v2.2.8
 	honnef.co/go/tools v0.0.1-2020.1.3
-	k8s.io/client-go v12.0.0+incompatible // indirect
+	// Keep pinned to this version instead of v12.0.0+incompatible unless dependency changes
+	// because it breaks `go list` and tooling that uses it.
+	k8s.io/client-go v0.0.0-20190620085101-78d2af792bab // indirect
 )


### PR DESCRIPTION
This was removed before but found its way back in. I'm hoping keeping it
included with // indirect but changing it to pin to sha1 will prevent it from
getting clobbered again. Added note explaining why it's pinned the way it is.