### PR TITLE
Change host metrics shutdown to use done channel

### DIFF
--- a/receiver/hostmetricsreceiver/hostmetrics_receiver_test.go
+++ b/receiver/hostmetricsreceiver/hostmetrics_receiver_test.go
@@ -84,9 +84,13 @@ func TestGatherMetrics_EndToEnd(t *testing.T) {
 
 	require.NoError(t, err, "Failed to create metrics receiver: %v", err)
 
-	err = receiver.Start(context.Background(), componenttest.NewNopHost())
+	ctx, cancelFn := context.WithCancel(context.Background())
+	err = receiver.Start(ctx, componenttest.NewNopHost())
 	require.NoError(t, err, "Failed to start metrics receiver: %v", err)
 	defer func() { assert.NoError(t, receiver.Shutdown(context.Background())) }()
+
+	// canceling the context provided to Start should not cancel any async processes initiated by the receiver
+	cancelFn()
 
 	require.Eventually(t, func() bool {
 		got := sink.AllMetrics()


### PR DESCRIPTION
Minor change to the host metrics receiver to not rely on the context provided in the Start method to determine when the host metrics ticker function should be terminated.

Addresses https://github.com/open-telemetry/opentelemetry-collector/pull/974#discussion_r426889598