### PR TITLE
Unify log message when exporter or receiver is not registered

### DIFF
--- a/service/builder/exporters_builder.go
+++ b/service/builder/exporters_builder.go
@@ -232,11 +232,7 @@ func (eb *ExportersBuilder) buildExporter(
 
 	inputDataTypes := exportersInputDataTypes[config]
 	if inputDataTypes == nil {
-		// TODO  https://go.opentelemetry.io/collector/issues/294
-		// Move this validation to config/config.go:validateConfig
-		// No data types where requested for this exporter. This can only happen
-		// if there are no pipelines associated with the exporter.
-		logger.Warn("Exporter is not associated with any pipeline and will not export data.")
+		logger.Info("Ignoring exporter as it is not used by any pipeline")
 		return exporter, nil
 	}
 

--- a/service/builder/receivers_builder.go
+++ b/service/builder/receivers_builder.go
@@ -109,7 +109,7 @@ func (rb *ReceiversBuilder) Build() (Receivers, error) {
 		rcv, err := rb.buildReceiver(logger, cfg)
 		if err != nil {
 			if err == errUnusedReceiver {
-				rb.logger.Info("Ignoring receiver as it is not used by any pipeline", zap.String("receiver", cfg.Name()))
+				logger.Info("Ignoring receiver as it is not used by any pipeline", zap.String("receiver", cfg.Name()))
 				continue
 			}
 			return nil, err


### PR DESCRIPTION
Resolves: https://github.com/jaegertracing/jaeger/issues/2252
Related to https://github.com/open-telemetry/opentelemetry-collector/issues/294

**Description:** <Describe what has changed>

Just fixing the log message. The warn level was printing stacktrace what was confusing for users.

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** < Describe what testing was performed and which tests were added.>

**Documentation:** < Describe the documentation added.>