### PR TITLE
Implement OTLP/HTTP X-Protobuf Receiver

### DIFF
--- a/receiver/otlpreceiver/otlp.go
+++ b/receiver/otlpreceiver/otlp.go
@@ -80,7 +80,9 @@ func New(
 	r := &Receiver{
 		ln:          ln,
 		corsOrigins: []string{}, // Disable CORS by default.
-		gatewayMux:  gatewayruntime.NewServeMux(),
+		gatewayMux: gatewayruntime.NewServeMux(
+			gatewayruntime.WithMarshalerOption("application/x-protobuf", &xProtobufMarshaler{}),
+		),
 	}
 
 	for _, opt := range opts {

--- a/receiver/otlpreceiver/otlp_test.go
+++ b/receiver/otlpreceiver/otlp_test.go
@@ -43,6 +43,7 @@ import (
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/exporter/exportertest"
+	"go.opentelemetry.io/collector/internal/data/testdata"
 	"go.opentelemetry.io/collector/observability/observabilitytest"
 	"go.opentelemetry.io/collector/testutils"
 	"go.opentelemetry.io/collector/translator/conventions"
@@ -189,39 +190,7 @@ func TestProtoHttp(t *testing.T) {
 
 	url := fmt.Sprintf("http://%s/v1/trace", addr)
 
-	wantOtlp := []*otlptrace.ResourceSpans{
-		{
-			Resource: &otlpresource.Resource{
-				Attributes: []*otlpcommon.AttributeKeyValue{
-					{
-						Key:         conventions.AttributeHostHostname,
-						StringValue: "testHost",
-						Type:        otlpcommon.AttributeKeyValue_STRING,
-					},
-				},
-			},
-			InstrumentationLibrarySpans: []*otlptrace.InstrumentationLibrarySpans{
-				{
-					Spans: []*otlptrace.Span{
-						{
-							TraceId:           []byte{0x5B, 0x8E, 0xFF, 0xF7, 0x98, 0x3, 0x81, 0x3, 0xD2, 0x69, 0xB6, 0x33, 0x81, 0x3F, 0xC6, 0xC},
-							SpanId:            []byte{0xEE, 0xE1, 0x9B, 0x7E, 0xC3, 0xC1, 0xB1, 0x73},
-							Name:              "testSpan",
-							StartTimeUnixNano: 1544712660000000000,
-							EndTimeUnixNano:   1544712661000000000,
-							Attributes: []*otlpcommon.AttributeKeyValue{
-								{
-									Key:      "attr1",
-									Type:     otlpcommon.AttributeKeyValue_INT,
-									IntValue: 55,
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
+	wantOtlp := pdata.TracesToOtlp(testdata.GenerateTraceDataOneSpan())
 
 	traceProto := collectortrace.ExportTraceServiceRequest{
 		ResourceSpans: wantOtlp,

--- a/receiver/otlpreceiver/otlphttp.go
+++ b/receiver/otlpreceiver/otlphttp.go
@@ -15,38 +15,16 @@
 package otlpreceiver
 
 import (
-	"io"
-
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 )
 
 // xProtobufMarshaler is a Marshaler which wraps runtime.ProtoMarshaller
 // and sets ContentType to application/x-protobuf
 type xProtobufMarshaler struct {
-	marshaler runtime.ProtoMarshaller
+	*runtime.ProtoMarshaller
 }
 
 // ContentType always returns "application/x-protobuf".
 func (*xProtobufMarshaler) ContentType() string {
 	return "application/x-protobuf"
-}
-
-// Marshal marshals "value" into Proto
-func (m *xProtobufMarshaler) Marshal(value interface{}) ([]byte, error) {
-	return m.marshaler.Marshal(value)
-}
-
-// Unmarshal unmarshals proto "data" into "value"
-func (m *xProtobufMarshaler) Unmarshal(data []byte, value interface{}) error {
-	return m.marshaler.Unmarshal(data, value)
-}
-
-// NewDecoder returns a Decoder which reads proto stream from "reader".
-func (m *xProtobufMarshaler) NewDecoder(reader io.Reader) runtime.Decoder {
-	return m.marshaler.NewDecoder(reader)
-}
-
-// NewEncoder returns an Encoder which writes proto stream into "writer".
-func (m *xProtobufMarshaler) NewEncoder(writer io.Writer) runtime.Encoder {
-	return m.marshaler.NewEncoder(writer)
 }

--- a/receiver/otlpreceiver/otlphttp.go
+++ b/receiver/otlpreceiver/otlphttp.go
@@ -1,0 +1,52 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package otlpreceiver
+
+import (
+	"io"
+
+	"github.com/grpc-ecosystem/grpc-gateway/runtime"
+)
+
+// xProtobufMarshaler is a Marshaler which wraps runtime.ProtoMarshaller
+// and sets ContentType to application/x-protobuf
+type xProtobufMarshaler struct {
+	marshaler runtime.ProtoMarshaller
+}
+
+// ContentType always returns "application/x-protobuf".
+func (*xProtobufMarshaler) ContentType() string {
+	return "application/x-protobuf"
+}
+
+// Marshal marshals "value" into Proto
+func (m *xProtobufMarshaler) Marshal(value interface{}) ([]byte, error) {
+	return m.marshaler.Marshal(value)
+}
+
+// Unmarshal unmarshals proto "data" into "value"
+func (m *xProtobufMarshaler) Unmarshal(data []byte, value interface{}) error {
+	return m.marshaler.Unmarshal(data, value)
+}
+
+// NewDecoder returns a Decoder which reads proto stream from "reader".
+func (m *xProtobufMarshaler) NewDecoder(reader io.Reader) runtime.Decoder {
+	return m.marshaler.NewDecoder(reader)
+}
+
+// NewEncoder returns an Encoder which writes proto stream into "writer".
+func (m *xProtobufMarshaler) NewEncoder(writer io.Writer) runtime.Encoder {
+	return m.marshaler.NewEncoder(writer)
+}


### PR DESCRIPTION
**Description:** This change adds application/x-protobuf support to the existing
grpc-gateway mux in the OTLP receiver.

(This change is a duplicate of #982 because CircleCI wasn't working.)

Protocol spec: https://github.com/open-telemetry/oteps/blob/master/text/0099-otlp-http.md

What currently works:
* The receiver will correctly process HTTP requests with the
  Content-Type application/x-protobuf.
* The receiver will respond with Content-Type application/x-protobuf.
* The receiver will respond with status code HTTP 200 OK on success.
* The receiver can handle gzip-encoded requests (Content-Encoding
  gzip) (http.Server natively supports gzip decoding).

What doesn't work yet:

* The receiver will not gzip-encode responses to requests with
  Accept-Encoding: gzip.

**Link to tracking Issue:** #881

**Testing:** A test was added to verify that the receiver accepts application/x-protobuf requests.

**Documentation:**