### PR TITLE
Expose service's logger

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -180,6 +180,12 @@ func (app *Application) ReportFatalError(err error) {
 	app.asyncErrorChannel <- err
 }
 
+// GetLogger returns logger used by the Application.
+// The logger is initialized after application start.
+func (app *Application) GetLogger() *zap.Logger {
+	return app.logger
+}
+
 func (app *Application) GetFactory(kind component.Kind, componentType configmodels.Type) component.Factory {
 	switch kind {
 	case component.KindReceiver:

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -64,6 +64,7 @@ func TestApplication_Start(t *testing.T) {
 	<-app.readyChan
 
 	require.True(t, isAppAvailable(t, "http://localhost:13133"))
+	assert.Equal(t, app.logger, app.GetLogger())
 
 	assertMetricsPrefix(t, testPrefix, metricsPort)
 


### PR DESCRIPTION
Signed-off-by: Pavol Loffay <ploffay@redhat.com>

**Description:** <Describe what has changed>

The client code that extends service should have access to the service's logger instance. 

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** < Describe what testing was performed and which tests were added.>

**Documentation:** < Describe the documentation added.>