### PR TITLE
Add AppDirect to adopters page

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -5,3 +5,4 @@ environments** to receive and export trace and metric telemetry data. Please sen
 to add or remove organizations.
 
 * [AppDirect](https://www.appdirect.com/)
+* [Splunk](https://www.splunk.com/)

--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,7 +1,7 @@
 # OpenTelemetry Collector Adopters
 
 This is the list of organizations that are using the OpenTelemetry Collector in **production
-environments** to receive and export their trace and metrics telemetry. Please send PRs
+environments** to receive and export trace and metric telemetry data. Please send PRs
 to add or remove organizations.
 
 * [AppDirect](https://www.appdirect.com/)

--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,0 +1,7 @@
+# OpenTelemetry Collector Adopters
+
+This is the list of organizations that are using the OpenTelemetry Collector in **production
+environments** to receive and export their trace and metrics telemetry. Please send PRs
+to add or remove organizations.
+
+* [AppDirect](https://www.appdirect.com/)


### PR DESCRIPTION
**Description:** The goal is to understand who is using the OpenTelemetry Collector in
production. Other CNCF projects have taken a similar approach to
highlight adoption.

**Link to tracking Issue:**

**Testing:** N/A

**Documentation:** Create page and adding AppDirect pending their approval.