### PR TITLE
Added resource detection interface

### DIFF
--- a/cmd/otelcol/main.go
+++ b/cmd/otelcol/main.go
@@ -22,6 +22,7 @@ import (
 	"go.opentelemetry.io/collector/internal/version"
 	"go.opentelemetry.io/collector/service"
 	"go.opentelemetry.io/collector/service/defaultcomponents"
+	"go.opentelemetry.io/collector/service/resourcedetection"
 )
 
 func main() {
@@ -41,7 +42,9 @@ func main() {
 		GitHash:  version.GitHash,
 	}
 
-	svc, err := service.New(service.Parameters{ApplicationStartInfo: info, Factories: factories})
+	rp := resourcedetection.NewResourceProvider()
+
+	svc, err := service.New(service.Parameters{ApplicationStartInfo: info, Factories: factories, ResourceProvider: rp})
 	handleErr("Failed to construct the application", err)
 
 	err = svc.Start()

--- a/component/component.go
+++ b/component/component.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"go.opentelemetry.io/collector/config/configmodels"
+	"go.opentelemetry.io/collector/consumer/pdata"
 )
 
 // Component is either a receiver, exporter, processor or extension.
@@ -79,6 +80,10 @@ type Host interface {
 	// thus we may have an instance of the exporter for multiple data types.
 	// This is an experimental function that may change or even be removed completely.
 	GetExporters() map[configmodels.DataType]map[configmodels.Exporter]Exporter
+
+	// Return the resource information that was automatically detected as being associated
+	// with this host based on the configured resource detectors.
+	GetResource() pdata.Resource
 }
 
 // Factory interface must be implemented by all component factories.

--- a/component/componenttest/error_waiting_host.go
+++ b/component/componenttest/error_waiting_host.go
@@ -19,6 +19,7 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configmodels"
+	"go.opentelemetry.io/collector/consumer/pdata"
 )
 
 // ErrorWaitingHost mocks an component.Host for test purposes.
@@ -67,4 +68,8 @@ func (ews *ErrorWaitingHost) GetExtensions() map[configmodels.Extension]componen
 
 func (ews *ErrorWaitingHost) GetExporters() map[configmodels.DataType]map[configmodels.Exporter]component.Exporter {
 	return nil
+}
+
+func (ews *ErrorWaitingHost) GetResource() pdata.Resource {
+	return pdata.NewResource()
 }

--- a/component/componenttest/nop_host.go
+++ b/component/componenttest/nop_host.go
@@ -17,6 +17,7 @@ package componenttest
 import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configmodels"
+	"go.opentelemetry.io/collector/consumer/pdata"
 )
 
 // NopHost mocks a receiver.ReceiverHost for test purposes.
@@ -49,4 +50,8 @@ func (nh *NopHost) GetExtensions() map[configmodels.Extension]component.ServiceE
 
 func (nh *NopHost) GetExporters() map[configmodels.DataType]map[configmodels.Exporter]component.Exporter {
 	return nil
+}
+
+func (nh *NopHost) GetResource() pdata.Resource {
+	return pdata.NewResource()
 }

--- a/consumer/pdatautil/pdatautil.go
+++ b/consumer/pdatautil/pdatautil.go
@@ -21,6 +21,7 @@ import (
 	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
 	resourcepb "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
 	"github.com/golang/protobuf/proto"
+	"go.opentelemetry.io/otel/sdk/resource"
 
 	"go.opentelemetry.io/collector/consumer/consumerdata"
 	"go.opentelemetry.io/collector/consumer/pdata"
@@ -147,4 +148,21 @@ func TimeseriesAndPointCount(md consumerdata.MetricsData) (int, int) {
 		}
 	}
 	return numTimeSeries, numPoints
+}
+
+// SdkResourceToInternalResource returns the `pdata.Resource` representation of the Otel SDK `resource.Resource`.
+func SdkResourceToInternalResource(sdkRes *resource.Resource) pdata.Resource {
+	res := pdata.NewResource()
+	res.InitEmpty()
+	attr := res.Attributes()
+	attr.InitEmptyWithCapacity(sdkRes.Len())
+
+	// TODO implement more thoughtfully & test
+	sdkAttrIter := sdkRes.Iter()
+	for sdkAttrIter.Next() {
+		sdkAttr := sdkAttrIter.Attribute()
+		attr.Insert(string(sdkAttr.Key), pdata.NewAttributeValueString(sdkAttr.Value.AsString()))
+	}
+
+	return res
 }

--- a/go.mod
+++ b/go.mod
@@ -55,6 +55,7 @@ require (
 	github.com/uber/jaeger-lib v2.2.0+incompatible
 	github.com/uber/tchannel-go v1.10.0 // indirect
 	go.opencensus.io v0.22.3
+	go.opentelemetry.io/otel v0.6.0
 	go.uber.org/zap v1.10.0
 	golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e
 	golang.org/x/sys v0.0.0-20200408040146-ea54a3c99b9b

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/DataDog/datadog-go v2.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
+github.com/DataDog/sketches-go v0.0.0-20190923095040-43f19ad77ff7 h1:qELHH0AWCvf98Yf+CNIJx9vOZOfHFDDzgDRYsnNk/vs=
+github.com/DataDog/sketches-go v0.0.0-20190923095040-43f19ad77ff7/go.mod h1:Q5DbzQ+3AkgGwymQO7aZFNP7ns2lZKGtvRBzRXfdi60=
 github.com/Masterminds/semver v1.4.2/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Microsoft/go-winio v0.4.11/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyvVC4A4RozmA=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
@@ -85,6 +87,8 @@ github.com/aws/aws-sdk-go v1.23.12/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpi
 github.com/aws/aws-sdk-go v1.23.19 h1:QiEkjRHkDXAThgnHKSEC63JwsSjL/jfYUOA2QYFmbSw=
 github.com/aws/aws-sdk-go v1.23.19/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-xray-sdk-go v0.9.4/go.mod h1:XtMKdBQfpVut+tJEwI7+dJFRxxRdxHDyVNp2tHXRq04=
+github.com/benbjohnson/clock v1.0.0 h1:78Jk/r6m4wCi6sndMpty7A//t4dw/RW5fV4ZgDVfX1w=
+github.com/benbjohnson/clock v1.0.0/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLMYoU8P317H5OQ+Via4RmuPwCS0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0 h1:HWo1m869IqiPhD389kmkxeTalrjNbbJTC8LXupb+sl0=
@@ -887,6 +891,8 @@ github.com/opentracing-contrib/go-stdlib v0.0.0-20190519235532-cf7a6c988dc9/go.m
 github.com/opentracing/opentracing-go v1.0.2/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/opentracing/opentracing-go v1.1.0 h1:pWlfV3Bxv7k65HYwkikxat0+s3pV4bsqf19k25Ur8rU=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
+github.com/opentracing/opentracing-go v1.1.1-0.20190913142402-a7454ce5950e h1:fI6mGTyggeIYVmGhf80XFHxTupjOexbCppgTNDkv9AA=
+github.com/opentracing/opentracing-go v1.1.1-0.20190913142402-a7454ce5950e/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/openzipkin/zipkin-go v0.2.1 h1:noL5/5Uf1HpVl3wNsfkZhIKbSWCVi5jgqkONNx8PXcA=
 github.com/openzipkin/zipkin-go v0.2.1/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/orijtech/prometheus-go-metrics-exporter v0.0.5 h1:76JFgRIgNDA3pW1fUhmqinU2u5ndHv1gvapDfGG+7/c=
@@ -1170,7 +1176,8 @@ go.opencensus.io v0.22.1 h1:8dP3SGL7MPB94crU3bEPplMPe83FI4EouesJUeFHv50=
 go.opencensus.io v0.22.1/go.mod h1:Ap50jQcDJrx6rB6VgeeFPtuPIf3wMRvRfrfYDO6+BmA=
 go.opencensus.io v0.22.3 h1:8sGtKOrtQqkN1bp2AtX+misvLIlOmsEsNd+9NIcPEm8=
 go.opencensus.io v0.22.3/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
-go.opentelemetry.io v0.1.0 h1:EANZoRCOP+A3faIlw/iN6YEWoYb1vleZRKm1EvH8T48=
+go.opentelemetry.io/otel v0.6.0 h1:+vkHm/XwJ7ekpISV2Ixew93gCrxTbuwTF5rSewnLLgw=
+go.opentelemetry.io/otel v0.6.0/go.mod h1:jzBIgIzK43Iu1BpDAXwqOd6UPsSAk+ewVZ5ofSXw4Ek=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.4.0 h1:cxzIVoETapQEqDhQu3QfnvXAV4AlzcvUCxkVUFw3+EU=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
@@ -1462,6 +1469,7 @@ google.golang.org/genproto v0.0.0-20190801165951-fa694d86fc64/go.mod h1:DMBHOl98
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55 h1:gSJIx1SDwno+2ElGhA4+qG2zF97qiUzTM+rQ0klBOcE=
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
 google.golang.org/genproto v0.0.0-20190927181202-20e1ac93f88c/go.mod h1:IbNlFCBrqXvoKpeg0TB2l7cyZUmoaFKYIwrEpbDKLA8=
+google.golang.org/genproto v0.0.0-20191009194640-548a555dbc03/go.mod h1:n3cpQtvxv34hfy77yVDNjmbRyujviMdxYliBSkLhpCc=
 google.golang.org/genproto v0.0.0-20200408120641-fbb3ad325eb7 h1:AMRSRXQjlgdwNhezZB0hscb7mJ4AK/UCM6uNIlEknCc=
 google.golang.org/genproto v0.0.0-20200408120641-fbb3ad325eb7/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
@@ -1476,6 +1484,7 @@ google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyac
 google.golang.org/grpc v1.24.0/go.mod h1:XDChyiUovWa60DnaeDeZmSW86xtLtjtZbwvSiRnRtcA=
 google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=
 google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
+google.golang.org/grpc v1.27.1/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/grpc v1.29.1 h1:EC2SB8S04d2r73uptxphDSUG+kTKVgjRPF+N3xpxRB4=
 google.golang.org/grpc v1.29.1/go.mod h1:itym6AZVZYACWQqET3MqgPpjcuV5QH3BxFS3IjizoKk=
 gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4K+aSYdM/U=

--- a/service/resourcedetection/fromenv.go
+++ b/service/resourcedetection/fromenv.go
@@ -1,0 +1,77 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resourcedetection
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"go.opentelemetry.io/otel/api/kv"
+	"go.opentelemetry.io/otel/sdk/resource"
+)
+
+// Environment variable used by FromEnv to decode a resource.
+const envVar = "OT_RESOURCE"
+
+type FromEnv struct{}
+
+// FromEnv is a detector that loads resource information from the OT_RESOURCE environment
+// variable. A list of labels of the form `<key1>="<value1>",<key2>="<value2>",...` is
+// accepted. Domain names and paths are accepted as label keys.
+func (d *FromEnv) Detect(context.Context) (*resource.Resource, error) {
+	labels := strings.TrimSpace(os.Getenv(envVar))
+	if labels == "" {
+		return resource.New(), nil
+	}
+
+	resLabels, err := decodeLabels(labels)
+	if err != nil {
+		return nil, err
+	}
+
+	return resource.New(resLabels...), nil
+}
+
+var labelRegex = regexp.MustCompile(`^\s*([[:ascii:]]{1,256}?)=("[[:ascii:]]{0,256}?")\s*,`)
+
+func decodeLabels(s string) ([]kv.KeyValue, error) {
+	kvs := []kv.KeyValue{}
+	// Ensure a trailing comma, which allows us to keep the regex simpler
+	s = strings.TrimRight(strings.TrimSpace(s), ",") + ","
+
+	for len(s) > 0 {
+		match := labelRegex.FindStringSubmatch(s)
+		if len(match) == 0 {
+			return nil, fmt.Errorf("invalid label formatting, remainder: %s", s)
+		}
+		v := match[2]
+		if v == "" {
+			v = match[3]
+		} else {
+			var err error
+			if v, err = strconv.Unquote(v); err != nil {
+				return nil, fmt.Errorf("invalid label formatting, remainder: %s, err: %s", s, err)
+			}
+		}
+		kvs = append(kvs, kv.String(match[1], v))
+
+		s = s[len(match[0]):]
+	}
+	return kvs, nil
+}

--- a/service/resourcedetection/fromenv_test.go
+++ b/service/resourcedetection/fromenv_test.go
@@ -1,0 +1,58 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resourcedetection
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/otel/api/kv"
+)
+
+func TestDecodeLabels(t *testing.T) {
+	cases := []struct {
+		encoded    string
+		wantLabels []kv.KeyValue
+		wantFail   bool
+	}{
+		{
+			encoded:    `example.org/test-1="test $ \"" ,  Abc="Def"`,
+			wantLabels: []kv.KeyValue{kv.String("example.org/test-1", "test $ \""), kv.String("Abc", "Def")},
+		}, {
+			encoded:    `single="key"`,
+			wantLabels: []kv.KeyValue{kv.String("single", "key")},
+		},
+		{encoded: `invalid-char-ü="test"`, wantFail: true},
+		{encoded: `invalid-char="ü-test"`, wantFail: true},
+		{encoded: `missing="trailing-quote`, wantFail: true},
+		{encoded: `missing=leading-quote"`, wantFail: true},
+		{encoded: `extra="chars", a`, wantFail: true},
+	}
+
+	for i, c := range cases {
+		t.Run(fmt.Sprintf("case-%d", i), func(t *testing.T) {
+			res, err := decodeLabels(c.encoded)
+
+			if c.wantFail {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			assert.Equal(t, c.wantLabels, res)
+		})
+	}
+}

--- a/service/resourcedetection/resourcedetection.go
+++ b/service/resourcedetection/resourcedetection.go
@@ -1,0 +1,58 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package resourcedetection contains an interface for detecting resource
+// information, and a mechanism to add custom detectors.
+//
+// It also includes a default implementation to detect resource information
+// from the OT_RESOURCE environment variable.
+package resourcedetection
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/sdk/resource"
+)
+
+type ResourceDetector interface {
+	Detect(ctx context.Context) (*resource.Resource, error)
+}
+
+type ResourceProvider struct {
+	detectors []ResourceDetector
+}
+
+func NewResourceProvider() *ResourceProvider {
+	return &ResourceProvider{detectors: []ResourceDetector{&FromEnv{}}}
+}
+
+func (rp *ResourceProvider) AddDetectors(detectors ...ResourceDetector) {
+	rp.detectors = append(rp.detectors, detectors...)
+}
+
+func (rp *ResourceProvider) DetectResource(ctx context.Context) (*resource.Resource, error) {
+	var res *resource.Resource
+	if rp == nil {
+		return res, nil
+	}
+
+	for _, detector := range rp.detectors {
+		r, err := detector.Detect(ctx)
+		if err != nil {
+			return nil, err
+		}
+		res = resource.Merge(res, r)
+	}
+	return res, nil
+}

--- a/service/resourcedetection/resourcedetection_test.go
+++ b/service/resourcedetection/resourcedetection_test.go
@@ -1,0 +1,67 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resourcedetection
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/api/kv"
+	"go.opentelemetry.io/otel/sdk/resource"
+)
+
+type MockDetector struct {
+	mock.Mock
+}
+
+func (p *MockDetector) Detect(ctx context.Context) (*resource.Resource, error) {
+	args := p.Called()
+	return args.Get(0).(*resource.Resource), args.Error(1)
+}
+
+func TestDetectResource(t *testing.T) {
+	md1 := &MockDetector{}
+	md1.On("Detect").Return(resource.New(kv.String("a", "1"), kv.String("b", "2")), nil)
+
+	md2 := &MockDetector{}
+	md2.On("Detect").Return(resource.New(kv.String("a", "11"), kv.String("c", "3")), nil)
+
+	rp := NewResourceProvider()
+	rp.AddDetectors(md1, md2)
+
+	got, err := rp.DetectResource(context.Background())
+	require.NoError(t, err)
+
+	want := resource.New(kv.String("a", "1"), kv.String("b", "2"), kv.String("c", "3"))
+	assert.Equal(t, got, want)
+}
+
+func TestDetectResource_Error(t *testing.T) {
+	md1 := &MockDetector{}
+	md1.On("Detect").Return(resource.New(kv.String("a", "1"), kv.String("b", "2")), nil)
+
+	md2 := &MockDetector{}
+	md2.On("Detect").Return(resource.New(), errors.New("err1"))
+
+	rp := NewResourceProvider()
+	rp.AddDetectors(md1, md2)
+
+	_, err := rp.DetectResource(context.Background())
+	require.EqualError(t, err, "err1")
+}

--- a/testbed/testbed/receivers.go
+++ b/testbed/testbed/receivers.go
@@ -23,6 +23,7 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configmodels"
+	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/receiver/jaegerreceiver"
 	"go.opentelemetry.io/collector/receiver/opencensusreceiver"
 	"go.opentelemetry.io/collector/receiver/otlpreceiver"
@@ -68,6 +69,10 @@ func (mb *DataReceiverBase) GetExtensions() map[configmodels.Extension]component
 
 func (mb *DataReceiverBase) GetExporters() map[configmodels.DataType]map[configmodels.Exporter]component.Exporter {
 	return nil
+}
+
+func (mb *DataReceiverBase) GetResource() pdata.Resource {
+	return pdata.NewResource()
 }
 
 // OCDataReceiver implements OpenCensus format receiver.


### PR DESCRIPTION
_DRAFT PR ready for conceptual review to see if this approach is valid. Not ready to be merged yet_

**Description:**
Added interface to auto-detect resource information, & support for attaching the detected resource information to the host app (where it can be accessed by components). Also includes a default "FromEnv" implementation that detects resource information from a custom environment variable (largely ported from OpenCensus).

**See tracking issue for more details:**
https://github.com/open-telemetry/opentelemetry-collector/issues/871

**Key Questions / Thoughts:**

- Does this approach seem generally valid?
- I've written the interface to use the Otel SDK Resource, with the expectation that this (and importantly any custom detectors) could be re-used by the SDK. In fact, I would imagine everything in the `resourcedetection` package should ideally be moved to the SDK at some point. But I'm not sure about adding a dependency on the SDK (which adds a bunch of transitive dependencies as well)? Note the Collector currently has an indirect dependency on the OpenCensus SDK, but that will presumably eventually go away
- Does it make sense to store the auto-detected resource against the Host service, or would it be simpler to just make this available via a global function?