### PR TITLE
Enable filter processor as a default processor

### DIFF
--- a/processor/filterprocessor/factory.go
+++ b/processor/filterprocessor/factory.go
@@ -15,8 +15,6 @@
 package filterprocessor
 
 import (
-	"context"
-
 	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/component"
@@ -50,12 +48,11 @@ func (f Factory) CreateDefaultConfig() configmodels.Processor {
 }
 
 // CreateTraceProcessor creates a trace processor based on this config.
-func (f *Factory) CreateTraceProcessor(
-	ctx context.Context,
-	params component.ProcessorCreateParams,
-	nextConsumer consumer.TraceConsumer,
-	cfg configmodels.Processor,
-) (component.TraceProcessor, error) {
+func (f Factory) CreateTraceProcessor(
+	logger *zap.Logger,
+	nextConsumer consumer.TraceConsumerOld,
+	c configmodels.Processor,
+) (component.TraceProcessorOld, error) {
 	return nil, configerror.ErrDataTypeIsNotSupported
 }
 

--- a/processor/filterprocessor/factory_test.go
+++ b/processor/filterprocessor/factory_test.go
@@ -15,7 +15,6 @@
 package filterprocessor
 
 import (
-	"context"
 	"fmt"
 	"path"
 	"testing"
@@ -23,7 +22,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 
-	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/configcheck"
 	"go.opentelemetry.io/collector/config/configmodels"
@@ -77,9 +75,8 @@ func TestCreateProcessors(t *testing.T) {
 		for name, cfg := range config.Processors {
 			t.Run(fmt.Sprintf("%s/%s", test.configName, name), func(t *testing.T) {
 				factory := &Factory{}
-				creationParams := component.ProcessorCreateParams{Logger: zap.NewNop()}
 
-				tp, tErr := factory.CreateTraceProcessor(context.Background(), creationParams, nil, cfg)
+				tp, tErr := factory.CreateTraceProcessor(zap.NewNop(), nil, cfg)
 				// Not implemented error
 				assert.NotNil(t, tErr)
 				assert.Nil(t, tp)

--- a/service/defaultcomponents/defaults.go
+++ b/service/defaultcomponents/defaults.go
@@ -31,6 +31,7 @@ import (
 	"go.opentelemetry.io/collector/extension/zpagesextension"
 	"go.opentelemetry.io/collector/processor/attributesprocessor"
 	"go.opentelemetry.io/collector/processor/batchprocessor"
+	"go.opentelemetry.io/collector/processor/filterprocessor"
 	"go.opentelemetry.io/collector/processor/memorylimiter"
 	"go.opentelemetry.io/collector/processor/queuedprocessor"
 	"go.opentelemetry.io/collector/processor/resourceprocessor"
@@ -98,6 +99,7 @@ func Components() (
 		&tailsamplingprocessor.Factory{},
 		&probabilisticsamplerprocessor.Factory{},
 		&spanprocessor.Factory{},
+		&filterprocessor.Factory{},
 	)
 	if err != nil {
 		errs = append(errs, err)

--- a/service/defaultcomponents/defaults_test.go
+++ b/service/defaultcomponents/defaults_test.go
@@ -35,6 +35,7 @@ import (
 	"go.opentelemetry.io/collector/extension/zpagesextension"
 	"go.opentelemetry.io/collector/processor/attributesprocessor"
 	"go.opentelemetry.io/collector/processor/batchprocessor"
+	"go.opentelemetry.io/collector/processor/filterprocessor"
 	"go.opentelemetry.io/collector/processor/memorylimiter"
 	"go.opentelemetry.io/collector/processor/queuedprocessor"
 	"go.opentelemetry.io/collector/processor/resourceprocessor"
@@ -74,6 +75,7 @@ func TestDefaultComponents(t *testing.T) {
 		"tail_sampling":         &tailsamplingprocessor.Factory{},
 		"probabilistic_sampler": &probabilisticsamplerprocessor.Factory{},
 		"span":                  &spanprocessor.Factory{},
+		"filter":                &filterprocessor.Factory{},
 	}
 	expectedExporters := map[configmodels.Type]component.ExporterFactoryBase{
 		"opencensus": &opencensusexporter.Factory{},


### PR DESCRIPTION
**Description:**
Add filter processor as a default processor.

Change trace processor to be old format so the filterprocessor correctly implements the old processor factory interface, otherwise there will be runtime errors.

**Link to tracking Issue:** part of #560

**Testing:** N/A

**Documentation:** N/A