### PR TITLE
Fix collector config to use insecure option in docker example

### DIFF
--- a/examples/demo/otel-collector-config.yaml
+++ b/examples/demo/otel-collector-config.yaml
@@ -16,6 +16,7 @@ exporters:
 
   jaeger:
     endpoint: jaeger-all-in-one:14250
+    insecure: true
 
 # Alternatively, use jaeger_thrift_http with the settings below. In this case
 # update the list of exporters on the traces pipeline.


### PR DESCRIPTION
**Description:** From the TLS refactor, connections are by default secure so they will fail in local scenarios. The docker compose example wasn't updated apart of the refactor. 

The k8s example is up to date and accurate.

**Link to tracking Issue:** Address issue seen in #1075 

**Testing:** Ran the docker compose environment locally and checked for metrics at localhost:8889/metrics

**Documentation:** N/aA