### PR TITLE
Prevent chance of panic on shutdown of load scraper

### DIFF
--- a/receiver/hostmetricsreceiver/internal/scraper/loadscraper/load_scraper_windows.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/loadscraper/load_scraper_windows.go
@@ -65,7 +65,7 @@ func startSampling(_ context.Context, logger *zap.Logger) error {
 	// startSampling may be called multiple times if multiple scrapers are
 	// initialized - but we only want to initialize a single load sampler
 	scraperCount++
-	if samplerInstance != nil {
+	if scraperCount > 1 {
 		return nil
 	}
 
@@ -137,10 +137,7 @@ func stopSampling(_ context.Context) error {
 	}
 
 	close(samplerInstance.done)
-
-	err := samplerInstance.processorQueueLengthCounter.Close()
-	samplerInstance = nil
-	return err
+	return samplerInstance.processorQueueLengthCounter.Close()
 }
 
 func getSampledLoadAverages() (*load.AvgStat, error) {

--- a/receiver/hostmetricsreceiver/internal/scraper/loadscraper/load_scraper_windows_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/loadscraper/load_scraper_windows_test.go
@@ -63,7 +63,7 @@ func TestStartSampling(t *testing.T) {
 	// second call to stopSampling should close perf counter, stop
 	// sampling, and clean up the sampler
 	stopSampling(context.Background())
-	assert.Nil(t, samplerInstance)
+	assertSamplingStopped(t)
 }
 
 func assertSamplingUnderway(t *testing.T) {
@@ -74,6 +74,18 @@ func assertSamplingUnderway(t *testing.T) {
 	case <-samplerInstance.done:
 		assert.Fail(t, "Load scraper sampling done channel unexpectedly closed")
 	default:
+	}
+}
+
+func assertSamplingStopped(t *testing.T) {
+	// validate perf counter was closed by trying to close again
+	err := samplerInstance.processorQueueLengthCounter.Close()
+	assert.EqualError(t, err, "attempted to call close more than once")
+
+	select {
+	case <-samplerInstance.done:
+	default:
+		assert.Fail(t, "Load scraper sampling done channel not closed")
 	}
 }
 

--- a/receiver/hostmetricsreceiver/internal/windows/pdh/performance_counter_mock.go
+++ b/receiver/hostmetricsreceiver/internal/windows/pdh/performance_counter_mock.go
@@ -17,6 +17,7 @@
 package pdh
 
 import (
+	"errors"
 	"fmt"
 
 	"go.opentelemetry.io/collector/receiver/hostmetricsreceiver/internal/third_party/telegraf/win_perf_counters"
@@ -26,6 +27,7 @@ type MockPerfCounter struct {
 	returnValues []interface{}
 
 	timesCalled int
+	closed      bool
 }
 
 // NewMockPerfCounter creates a MockPerfCounter that returns the supplied
@@ -40,6 +42,11 @@ func NewMockPerfCounter(valuesToBeReturned ...interface{}) *MockPerfCounter {
 
 // Close
 func (pc *MockPerfCounter) Close() error {
+	if pc.closed {
+		return errors.New("attempted to call close more than once")
+	}
+
+	pc.closed = true
 	return nil
 }
 


### PR DESCRIPTION
There is a chance that the hostmetrics scrape ticker may run one last time after the receiver has been shutdown. On shutdown, don't set the load scraper instance to `nil`. This means stale values will be read on the last tick instead of raising an error. This also allows the tests to be improved somewhat.