### PR TITLE
Add CircleCI check for contrib repo breakage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -208,6 +208,18 @@ workflows:
           filters:
             tags:
               only: /^v([0-9])+.([0-9])+.([0-9])+.*/
+  contrib-test:
+    jobs:
+      - setup-environment:
+          filters:
+            tags:
+              only: /^v([0-9])+.([0-9])+.([0-9])+.*/
+      - contribtest:
+          requires:
+            - setup-environment
+          filters:
+            tags:
+              only: /^v([0-9])+.([0-9])+.([0-9])+.*/
 
 jobs:
   setup-environment:
@@ -283,6 +295,19 @@ jobs:
           path: unit-test-results/junit
       - save_module_cache
       - github_issue_generator
+
+  contribtest:
+    executor: golang
+    steps:
+      - attach_to_workspace
+      - run:
+          name: Contrib repo tests
+          command: |
+            contrib_path=/tmp/opentelemetry-collector-contrib
+            git clone https://github.com/open-telemetry/opentelemetry-collector-contrib.git $contrib_path
+            make CONTRIB_PATH=$contrib_path check-contrib
+
+      - save_module_cache
 
   gosec:
     executor: golang

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,8 @@ BUILD_INFO=-ldflags "${BUILD_X1} ${BUILD_X2} ${BUILD_X3}"
 
 RUN_CONFIG=local/config.yaml
 
+CONTRIB_PATH=$(CURDIR)/../opentelemetry-collector-contrib
+
 all-srcs:
 	@echo $(ALL_SRC) | tr ' ' '\n' | sort
 
@@ -275,3 +277,13 @@ genproto_sub:
 # to proto and after running `make genproto`
 genpdata:
 	go run cmd/pdatagen/main.go
+
+# Checks that the HEAD of the contrib repo checked out in CONTRIB_PATH compiles
+# against the current version of this repo.
+.PHONY: check-contrib
+check-contrib:
+	@echo Setting contrib at $(CONTRIB_PATH) to use this core checkout
+	make -C $(CONTRIB_PATH) for-all CMD="go mod edit -replace go.opentelemetry.io/collector=$(CURDIR)"
+	make -C $(CONTRIB_PATH) test
+	@echo Restoring contrib to no longer use this core checkout
+	make -C $(CONTRIB_PATH) for-all CMD="go mod edit -dropreplace go.opentelemetry.io/collector"


### PR DESCRIPTION
It just runs the latest master contrib tests against the HEAD of the given 
build to make sure none of the changes are incompatible.

It should not be a required check, but is meant to be a heads up to
contributors to fix the contrib repo after their PR is merged.