### PR TITLE
Add Log Support to OTLP Exporter

### DIFF
--- a/exporter/exporterhelper/constants.go
+++ b/exporter/exporterhelper/constants.go
@@ -25,4 +25,6 @@ var (
 	errNilPushTraceData = errors.New("nil traceDataPusher")
 	// errNilPushMetricsData is returned when a nil pushMetricsData is given.
 	errNilPushMetricsData = errors.New("nil pushMetricsData")
+	// errNilPushLogsData is returned when a nil pushLogsData is given.
+	errNilPushLogsData = errors.New("nil pushLogsData")
 )

--- a/exporter/exporterhelper/logshelper.go
+++ b/exporter/exporterhelper/logshelper.go
@@ -1,0 +1,89 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exporterhelper
+
+import (
+	"context"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config/configmodels"
+	"go.opentelemetry.io/collector/internal/data"
+	"go.opentelemetry.io/collector/obsreport"
+)
+
+// PushLogsData is a helper function that is similar to ConsumeLogsData but also returns
+// the number of dropped logs.
+type PushLogsData func(ctx context.Context, md data.Logs) (droppedTimeSeries int, err error)
+
+type logsExporter struct {
+	exporterFullName string
+	pushLogsData     PushLogsData
+	shutdown         Shutdown
+}
+
+func (me *logsExporter) Start(ctx context.Context, host component.Host) error {
+	return nil
+}
+
+func (me *logsExporter) ConsumeLogs(ctx context.Context, md data.Logs) error {
+	exporterCtx := obsreport.ExporterContext(ctx, me.exporterFullName)
+	_, err := me.pushLogsData(exporterCtx, md)
+	return err
+}
+
+// Shutdown stops the exporter and is invoked during shutdown.
+func (me *logsExporter) Shutdown(ctx context.Context) error {
+	return me.shutdown(ctx)
+}
+
+// NewLogsExporter creates an LogsExporter that can record logs and can wrap every request with a Span.
+// If no options are passed it just adds the exporter format as a tag in the Context.
+// TODO: Add support for retries.
+func NewLogsExporter(config configmodels.Exporter, pushLogsData PushLogsData, options ...ExporterOption) (component.LogExporter, error) {
+	if config == nil {
+		return nil, errNilConfig
+	}
+
+	if pushLogsData == nil {
+		return nil, errNilPushLogsData
+	}
+
+	opts := newExporterOptions(options...)
+
+	pushLogsData = pushLogsWithObservability(pushLogsData, config.Name())
+
+	// The default shutdown method always returns nil.
+	if opts.shutdown == nil {
+		opts.shutdown = func(context.Context) error { return nil }
+	}
+
+	return &logsExporter{
+		exporterFullName: config.Name(),
+		pushLogsData:     pushLogsData,
+		shutdown:         opts.shutdown,
+	}, nil
+}
+
+func pushLogsWithObservability(next PushLogsData, exporterName string) PushLogsData {
+	return func(ctx context.Context, ld data.Logs) (int, error) {
+		ctx = obsreport.StartLogsExportOp(ctx, exporterName)
+		numDroppedLogs, err := next(ctx, ld)
+
+		numLogs := ld.LogRecordCount()
+
+		obsreport.EndLogsExportOp(ctx, numLogs, numDroppedLogs, err)
+		return numLogs, err
+	}
+}

--- a/exporter/exporterhelper/logshelper.go
+++ b/exporter/exporterhelper/logshelper.go
@@ -49,7 +49,6 @@ func (me *logsExporter) Shutdown(ctx context.Context) error {
 }
 
 // NewLogsExporter creates an LogsExporter that can record logs and can wrap every request with a Span.
-// If no options are passed it just adds the exporter format as a tag in the Context.
 // TODO: Add support for retries.
 func NewLogsExporter(config configmodels.Exporter, pushLogsData PushLogsData, options ...ExporterOption) (component.LogExporter, error) {
 	if config == nil {

--- a/exporter/exporterhelper/logshelper_test.go
+++ b/exporter/exporterhelper/logshelper_test.go
@@ -1,0 +1,214 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package exporterhelper
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opencensus.io/trace"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config/configmodels"
+	"go.opentelemetry.io/collector/internal/data"
+	"go.opentelemetry.io/collector/internal/data/testdata"
+	"go.opentelemetry.io/collector/observability"
+	"go.opentelemetry.io/collector/observability/observabilitytest"
+	"go.opentelemetry.io/collector/obsreport"
+)
+
+const (
+	fakeLogsReceiverName   = "fake_receiver"
+	fakeLogsExporterType   = "fake_logs_exporter"
+	fakeLogsExporterName   = "fake_logs_exporter/with_name"
+	fakeLogsParentSpanName = "fake_logs_parent_span_name"
+)
+
+var (
+	fakeLogsExporterConfig = &configmodels.ExporterSettings{
+		TypeVal: fakeLogsExporterType,
+		NameVal: fakeLogsExporterName,
+	}
+)
+
+func TestLogsExporter_InvalidName(t *testing.T) {
+	me, err := NewLogsExporter(nil, newPushLogsData(0, nil))
+	require.Nil(t, me)
+	require.Equal(t, errNilConfig, err)
+}
+
+func TestLogsExporter_NilPushLogsData(t *testing.T) {
+	me, err := NewLogsExporter(fakeLogsExporterConfig, nil)
+	require.Nil(t, me)
+	require.Equal(t, errNilPushLogsData, err)
+}
+
+func TestLogsExporter_Default(t *testing.T) {
+	ld := testdata.GenerateLogDataEmpty()
+	me, err := NewLogsExporter(fakeLogsExporterConfig, newPushLogsData(0, nil))
+	assert.NotNil(t, me)
+	assert.NoError(t, err)
+
+	assert.Nil(t, me.ConsumeLogs(context.Background(), ld))
+	assert.Nil(t, me.Shutdown(context.Background()))
+}
+
+func TestLogsExporter_Default_ReturnError(t *testing.T) {
+	ld := testdata.GenerateLogDataEmpty()
+	want := errors.New("my_error")
+	me, err := NewLogsExporter(fakeLogsExporterConfig, newPushLogsData(0, want))
+	require.Nil(t, err)
+	require.NotNil(t, me)
+	require.Equal(t, want, me.ConsumeLogs(context.Background(), ld))
+}
+
+func TestLogsExporter_WithRecordLogs(t *testing.T) {
+	me, err := NewLogsExporter(fakeLogsExporterConfig, newPushLogsData(0, nil))
+	require.Nil(t, err)
+	require.NotNil(t, me)
+
+	checkRecordedMetricsForLogsExporter(t, me, nil, 0)
+}
+
+func TestLogsExporter_WithRecordLogs_NonZeroDropped(t *testing.T) {
+	me, err := NewLogsExporter(fakeLogsExporterConfig, newPushLogsData(1, nil))
+	require.Nil(t, err)
+	require.NotNil(t, me)
+
+	checkRecordedMetricsForLogsExporter(t, me, nil, 1)
+}
+
+func TestLogsExporter_WithRecordLogs_ReturnError(t *testing.T) {
+	want := errors.New("my_error")
+	me, err := NewLogsExporter(fakeLogsExporterConfig, newPushLogsData(0, want))
+	require.Nil(t, err)
+	require.NotNil(t, me)
+
+	checkRecordedMetricsForLogsExporter(t, me, want, 0)
+}
+
+func TestLogsExporter_WithSpan(t *testing.T) {
+	me, err := NewLogsExporter(fakeLogsExporterConfig, newPushLogsData(0, nil))
+	require.Nil(t, err)
+	require.NotNil(t, me)
+	checkWrapSpanForLogsExporter(t, me, nil, 1)
+}
+
+func TestLogsExporter_WithSpan_NonZeroDropped(t *testing.T) {
+	me, err := NewLogsExporter(fakeLogsExporterConfig, newPushLogsData(1, nil))
+	require.Nil(t, err)
+	require.NotNil(t, me)
+	checkWrapSpanForLogsExporter(t, me, nil, 1)
+}
+
+func TestLogsExporter_WithSpan_ReturnError(t *testing.T) {
+	want := errors.New("my_error")
+	me, err := NewLogsExporter(fakeLogsExporterConfig, newPushLogsData(0, want))
+	require.Nil(t, err)
+	require.NotNil(t, me)
+	checkWrapSpanForLogsExporter(t, me, want, 1)
+}
+
+func TestLogsExporter_WithShutdown(t *testing.T) {
+	shutdownCalled := false
+	shutdown := func(context.Context) error { shutdownCalled = true; return nil }
+
+	me, err := NewLogsExporter(fakeLogsExporterConfig, newPushLogsData(0, nil), WithShutdown(shutdown))
+	assert.NotNil(t, me)
+	assert.NoError(t, err)
+
+	assert.Nil(t, me.Shutdown(context.Background()))
+	assert.True(t, shutdownCalled)
+}
+
+func TestLogsExporter_WithShutdown_ReturnError(t *testing.T) {
+	want := errors.New("my_error")
+	shutdownErr := func(context.Context) error { return want }
+
+	me, err := NewLogsExporter(fakeLogsExporterConfig, newPushLogsData(0, nil), WithShutdown(shutdownErr))
+	assert.NotNil(t, me)
+	assert.NoError(t, err)
+
+	assert.Equal(t, me.Shutdown(context.Background()), want)
+}
+
+func newPushLogsData(droppedTimeSeries int, retError error) PushLogsData {
+	return func(ctx context.Context, td data.Logs) (int, error) {
+		return droppedTimeSeries, retError
+	}
+}
+
+func checkRecordedMetricsForLogsExporter(t *testing.T, me component.LogExporter, wantError error, droppedTimeSeries int) {
+	doneFn := observabilitytest.SetupRecordedMetricsTest()
+	defer doneFn()
+
+	ld := testdata.GenerateLogDataTwoLogsSameResource()
+	ctx := observability.ContextWithReceiverName(context.Background(), fakeLogsReceiverName)
+	const numBatches = 7
+	for i := 0; i < numBatches; i++ {
+		require.Equal(t, wantError, me.ConsumeLogs(ctx, ld))
+	}
+
+	err := observabilitytest.CheckValueViewExporterReceivedLogRecords(fakeLogsReceiverName, fakeLogsExporterName, numBatches*ld.LogRecordCount())
+	require.Nilf(t, err, "CheckValueViewExporterTimeSeries: Want nil Got %v", err)
+
+	err = observabilitytest.CheckValueViewExporterDroppedLogRecords(fakeLogsReceiverName, fakeLogsExporterName, numBatches*droppedTimeSeries)
+	require.Nilf(t, err, "CheckValueViewExporterTimeSeries: Want nil Got %v", err)
+}
+
+func generateLogsTraffic(t *testing.T, me component.LogExporter, numRequests int, wantError error) {
+	ld := testdata.GenerateLogDataOneLog()
+	ctx, span := trace.StartSpan(context.Background(), fakeLogsParentSpanName, trace.WithSampler(trace.AlwaysSample()))
+	defer span.End()
+	for i := 0; i < numRequests; i++ {
+		require.Equal(t, wantError, me.ConsumeLogs(ctx, ld))
+	}
+}
+
+func checkWrapSpanForLogsExporter(t *testing.T, me component.LogExporter, wantError error, numMetricPoints int64) {
+	ocSpansSaver := new(testOCTraceExporter)
+	trace.RegisterExporter(ocSpansSaver)
+	defer trace.UnregisterExporter(ocSpansSaver)
+
+	const numRequests = 5
+	generateLogsTraffic(t, me, numRequests, wantError)
+
+	// Inspection time!
+	ocSpansSaver.mu.Lock()
+	defer ocSpansSaver.mu.Unlock()
+
+	require.NotEqual(t, 0, len(ocSpansSaver.spanData), "No exported span data")
+
+	gotSpanData := ocSpansSaver.spanData
+	require.Equal(t, numRequests+1, len(gotSpanData))
+
+	parentSpan := gotSpanData[numRequests]
+	require.Equalf(t, fakeLogsParentSpanName, parentSpan.Name, "SpanData %v", parentSpan)
+	for _, sd := range gotSpanData[:numRequests] {
+		require.Equalf(t, parentSpan.SpanContext.SpanID, sd.ParentSpanID, "Exporter span not a child\nSpanData %v", sd)
+		require.Equalf(t, errToStatus(wantError), sd.Status, "SpanData %v", sd)
+
+		sentMetricPoints := numMetricPoints
+		var failedToSendMetricPoints int64
+		if wantError != nil {
+			sentMetricPoints = 0
+			failedToSendMetricPoints = numMetricPoints
+		}
+		require.Equalf(t, sentMetricPoints, sd.Attributes[obsreport.SentLogRecordsKey], "SpanData %v", sd)
+		require.Equalf(t, failedToSendMetricPoints, sd.Attributes[obsreport.FailedToSendLogRecordsKey], "SpanData %v", sd)
+	}
+}

--- a/exporter/otlpexporter/README.md
+++ b/exporter/otlpexporter/README.md
@@ -1,12 +1,12 @@
 # OTLP Exporter
 
-Exports traces, metrics and/or logs to another Collector via gRPC using OTLP format.
+Exports traces and/or metrics to another Collector via gRPC using OTLP format.
 
 The following settings are required:
 
-- `endpoint`: target to which the exporter is going to send traces, metrics, or
-  logs, using the gRPC protocol. The valid syntax is described at
-  https://github.com/grpc/grpc/blob/master/doc/naming.md.
+- `endpoint`: target to which the exporter is going to send traces or metrics,
+using the gRPC protocol. The valid syntax is described at
+https://github.com/grpc/grpc/blob/master/doc/naming.md.
 
 The following settings can be optionally configured:
 

--- a/exporter/otlpexporter/README.md
+++ b/exporter/otlpexporter/README.md
@@ -1,12 +1,12 @@
 # OTLP Exporter
 
-Exports traces and/or metrics to another Collector via gRPC using OTLP format.
+Exports traces, metrics and/or logs to another Collector via gRPC using OTLP format.
 
 The following settings are required:
 
-- `endpoint`: target to which the exporter is going to send traces or metrics,
-using the gRPC protocol. The valid syntax is described at
-https://github.com/grpc/grpc/blob/master/doc/naming.md.
+- `endpoint`: target to which the exporter is going to send traces, metrics, or
+  logs, using the gRPC protocol. The valid syntax is described at
+  https://github.com/grpc/grpc/blob/master/doc/naming.md.
 
 The following settings can be optionally configured:
 

--- a/exporter/otlpexporter/factory.go
+++ b/exporter/otlpexporter/factory.go
@@ -66,3 +66,12 @@ func (f *Factory) CreateMetricsExporter(
 ) (component.MetricsExporter, error) {
 	return NewMetricsExporter(ctx, params, cfg)
 }
+
+// CreateLogExporter creates a log exporter based on this config.
+func (f *Factory) CreateLogExporter(
+	ctx context.Context,
+	params component.ExporterCreateParams,
+	cfg configmodels.Exporter,
+) (component.LogExporter, error) {
+	return NewLogExporter(ctx, params, cfg)
+}

--- a/exporter/otlpexporter/factory_test.go
+++ b/exporter/otlpexporter/factory_test.go
@@ -180,3 +180,14 @@ func TestCreateTraceExporter(t *testing.T) {
 		})
 	}
 }
+
+func TestCreateLogsExporter(t *testing.T) {
+	factory := Factory{}
+	cfg := factory.CreateDefaultConfig().(*Config)
+	cfg.GRPCClientSettings.Endpoint = testutils.GetAvailableLocalAddress(t)
+
+	creationParams := component.ExporterCreateParams{Logger: zap.NewNop()}
+	oexp, err := factory.CreateLogExporter(context.Background(), creationParams, cfg)
+	require.Nil(t, err)
+	require.NotNil(t, oexp)
+}

--- a/exporter/otlpexporter/otlp_test.go
+++ b/exporter/otlpexporter/otlp_test.go
@@ -340,7 +340,7 @@ func TestSendLogData(t *testing.T) {
 	// Ensure that initially there is no data in the receiver.
 	assert.EqualValues(t, 0, rcv.requestCount)
 
-	// Send empty trace.
+	// Send empty request.
 	td := testdata.GenerateLogDataEmpty()
 	assert.NoError(t, exp.ConsumeLogs(context.Background(), td))
 
@@ -352,7 +352,7 @@ func TestSendLogData(t *testing.T) {
 	// Ensure it was received empty.
 	assert.EqualValues(t, 0, rcv.totalLogRecordCount)
 
-	// A trace with 2 spans.
+	// A request with 2 log entries.
 	td = testdata.GenerateLogDataTwoLogsSameResource()
 
 	expectedOTLPReq := &otlplogs.ExportLogServiceRequest{

--- a/exporter/otlpexporter/otlp_test.go
+++ b/exporter/otlpexporter/otlp_test.go
@@ -32,19 +32,20 @@ import (
 	"go.opentelemetry.io/collector/config/configtls"
 	"go.opentelemetry.io/collector/consumer/pdata"
 	otlptracecol "go.opentelemetry.io/collector/internal/data/opentelemetry-proto-gen/collector/trace/v1"
+	otlplogs "go.opentelemetry.io/collector/internal/data/opentelemetry-proto-gen/logs/v1"
 	"go.opentelemetry.io/collector/internal/data/testdata"
 	"go.opentelemetry.io/collector/observability"
 	"go.opentelemetry.io/collector/testutils"
 )
 
-type mockReceiver struct {
+type mockTraceReceiver struct {
 	srv            *grpc.Server
 	requestCount   int32
 	totalSpanCount int32
 	lastRequest    *otlptracecol.ExportTraceServiceRequest
 }
 
-func (r *mockReceiver) Export(
+func (r *mockTraceReceiver) Export(
 	ctx context.Context,
 	req *otlptracecol.ExportTraceServiceRequest,
 ) (*otlptracecol.ExportTraceServiceResponse, error) {
@@ -60,8 +61,8 @@ func (r *mockReceiver) Export(
 	return &otlptracecol.ExportTraceServiceResponse{}, nil
 }
 
-func otlpReceiverOnGRPCServer(ln net.Listener) *mockReceiver {
-	rcv := &mockReceiver{}
+func otlpTraceReceiverOnGRPCServer(ln net.Listener) *mockTraceReceiver {
+	rcv := &mockTraceReceiver{}
 
 	// Now run it as a gRPC server
 	rcv.srv = observability.GRPCServerWithObservabilityEnabled()
@@ -73,11 +74,42 @@ func otlpReceiverOnGRPCServer(ln net.Listener) *mockReceiver {
 	return rcv
 }
 
+type mockLogsReceiver struct {
+	srv                 *grpc.Server
+	requestCount        int32
+	totalLogRecordCount int32
+	lastRequest         *otlplogs.ExportLogServiceRequest
+}
+
+func (r *mockLogsReceiver) Export(ctx context.Context, req *otlplogs.ExportLogServiceRequest) (*otlplogs.ExportLogServiceResponse, error) {
+	atomic.AddInt32(&r.requestCount, 1)
+	recordCount := 0
+	for _, rs := range req.ResourceLogs {
+		recordCount += len(rs.Logs)
+	}
+	atomic.AddInt32(&r.totalLogRecordCount, int32(recordCount))
+	r.lastRequest = req
+	return &otlplogs.ExportLogServiceResponse{}, nil
+}
+
+func otlpLogsReceiverOnGRPCServer(ln net.Listener) *mockLogsReceiver {
+	rcv := &mockLogsReceiver{}
+
+	// Now run it as a gRPC server
+	rcv.srv = observability.GRPCServerWithObservabilityEnabled()
+	otlplogs.RegisterLogServiceServer(rcv.srv, rcv)
+	go func() {
+		_ = rcv.srv.Serve(ln)
+	}()
+
+	return rcv
+}
+
 func TestSendTraceData(t *testing.T) {
 	// Start an OTLP-compatible receiver.
 	ln, err := net.Listen("tcp", "localhost:")
 	require.NoError(t, err, "Failed to find an available address to run the gRPC server: %v", err)
-	rcv := otlpReceiverOnGRPCServer(ln)
+	rcv := otlpTraceReceiverOnGRPCServer(ln)
 	// Also closes the connection.
 	defer rcv.srv.GracefulStop()
 
@@ -237,7 +269,7 @@ func TestSendTraceDataServerStartWhileRequest(t *testing.T) {
 	}()
 
 	time.Sleep(2 * time.Second)
-	rcv := otlpReceiverOnGRPCServer(ln)
+	rcv := otlpTraceReceiverOnGRPCServer(ln)
 	defer rcv.srv.GracefulStop()
 	// Wait until one of the conditions below triggers.
 	select {
@@ -250,7 +282,7 @@ func TestSendTraceDataServerStartWhileRequest(t *testing.T) {
 }
 
 func startServerAndMakeRequest(t *testing.T, exp component.TraceExporter, td pdata.Traces, ln net.Listener) {
-	rcv := otlpReceiverOnGRPCServer(ln)
+	rcv := otlpTraceReceiverOnGRPCServer(ln)
 	defer rcv.srv.GracefulStop()
 	// Ensure that initially there is no data in the receiver.
 	assert.EqualValues(t, 0, rcv.requestCount)
@@ -271,5 +303,71 @@ func startServerAndMakeRequest(t *testing.T, exp component.TraceExporter, td pda
 
 	// Verify received span.
 	assert.EqualValues(t, 2, rcv.totalSpanCount)
+	assert.EqualValues(t, expectedOTLPReq, rcv.lastRequest)
+}
+
+func TestSendLogData(t *testing.T) {
+	// Start an OTLP-compatible receiver.
+	ln, err := net.Listen("tcp", "localhost:")
+	require.NoError(t, err, "Failed to find an available address to run the gRPC server: %v", err)
+	rcv := otlpLogsReceiverOnGRPCServer(ln)
+	// Also closes the connection.
+	defer rcv.srv.GracefulStop()
+
+	// Start an OTLP exporter and point to the receiver.
+	config := Config{
+		GRPCClientSettings: configgrpc.GRPCClientSettings{
+			Endpoint: ln.Addr().String(),
+			TLSSetting: configtls.TLSClientSetting{
+				Insecure: true,
+			},
+		},
+	}
+
+	factory := &Factory{}
+	creationParams := component.ExporterCreateParams{Logger: zap.NewNop()}
+	exp, err := factory.CreateLogExporter(context.Background(), creationParams, &config)
+	require.NoError(t, err)
+	require.NotNil(t, exp)
+	defer func() {
+		assert.NoError(t, exp.Shutdown(context.Background()))
+	}()
+
+	host := componenttest.NewNopHost()
+
+	assert.NoError(t, exp.Start(context.Background(), host))
+
+	// Ensure that initially there is no data in the receiver.
+	assert.EqualValues(t, 0, rcv.requestCount)
+
+	// Send empty trace.
+	td := testdata.GenerateLogDataEmpty()
+	assert.NoError(t, exp.ConsumeLogs(context.Background(), td))
+
+	// Wait until it is received.
+	testutils.WaitFor(t, func() bool {
+		return atomic.LoadInt32(&rcv.requestCount) > 0
+	}, "receive a request")
+
+	// Ensure it was received empty.
+	assert.EqualValues(t, 0, rcv.totalLogRecordCount)
+
+	// A trace with 2 spans.
+	td = testdata.GenerateLogDataTwoLogsSameResource()
+
+	expectedOTLPReq := &otlplogs.ExportLogServiceRequest{
+		ResourceLogs: testdata.GenerateLogOtlpSameResourceTwoLogs(),
+	}
+
+	err = exp.ConsumeLogs(context.Background(), td)
+	assert.NoError(t, err)
+
+	// Wait until it is received.
+	testutils.WaitFor(t, func() bool {
+		return atomic.LoadInt32(&rcv.requestCount) > 1
+	}, "receive a request")
+
+	// Verify received span.
+	assert.EqualValues(t, 2, rcv.totalLogRecordCount)
 	assert.EqualValues(t, expectedOTLPReq, rcv.lastRequest)
 }

--- a/go.sum
+++ b/go.sum
@@ -1170,7 +1170,6 @@ go.opencensus.io v0.22.1 h1:8dP3SGL7MPB94crU3bEPplMPe83FI4EouesJUeFHv50=
 go.opencensus.io v0.22.1/go.mod h1:Ap50jQcDJrx6rB6VgeeFPtuPIf3wMRvRfrfYDO6+BmA=
 go.opencensus.io v0.22.3 h1:8sGtKOrtQqkN1bp2AtX+misvLIlOmsEsNd+9NIcPEm8=
 go.opencensus.io v0.22.3/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
-go.opentelemetry.io v0.1.0 h1:EANZoRCOP+A3faIlw/iN6YEWoYb1vleZRKm1EvH8T48=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.4.0 h1:cxzIVoETapQEqDhQu3QfnvXAV4AlzcvUCxkVUFw3+EU=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=

--- a/internal/data/testdata/log.go
+++ b/internal/data/testdata/log.go
@@ -1,0 +1,326 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testdata
+
+import (
+	"time"
+
+	"go.opentelemetry.io/collector/internal/data"
+	otlplogs "go.opentelemetry.io/collector/internal/data/opentelemetry-proto-gen/logs/v1"
+
+	"go.opentelemetry.io/collector/consumer/pdata"
+	opentelemetry_proto_common_v1 "go.opentelemetry.io/collector/internal/data/opentelemetry-proto-gen/common/v1"
+)
+
+var (
+	TestLogTime      = time.Date(2020, 2, 11, 20, 26, 13, 789, time.UTC)
+	TestLogTimestamp = pdata.TimestampUnixNano(TestLogTime.UnixNano())
+)
+
+const (
+	NumLogTests = 11
+)
+
+func GenerateLogDataEmpty() data.Logs {
+	ld := data.NewLogs()
+	return ld
+}
+
+func generateLogOtlpEmpty() []*otlplogs.ResourceLogs {
+	return []*otlplogs.ResourceLogs(nil)
+}
+
+func GenerateLogDataOneEmptyResourceLogs() data.Logs {
+	ld := GenerateLogDataEmpty()
+	ld.ResourceLogs().Resize(1)
+	return ld
+}
+
+func generateLogOtlpOneEmptyResourceLogs() []*otlplogs.ResourceLogs {
+	return []*otlplogs.ResourceLogs{
+		{},
+	}
+}
+
+func GenerateLogDataOneEmptyOneNilResourceLogs() data.Logs {
+	return data.LogsFromProto(generateLogOtlpOneEmptyOneNilResourceLogs())
+
+}
+
+func generateLogOtlpOneEmptyOneNilResourceLogs() []*otlplogs.ResourceLogs {
+	return []*otlplogs.ResourceLogs{
+		{},
+		nil,
+	}
+}
+
+func GenerateLogDataNoLogRecords() data.Logs {
+	ld := GenerateLogDataOneEmptyResourceLogs()
+	rs0 := ld.ResourceLogs().At(0)
+	initResource1(rs0.Resource())
+	return ld
+}
+
+func generateLogOtlpNoLogRecords() []*otlplogs.ResourceLogs {
+	return []*otlplogs.ResourceLogs{
+		{
+			Resource: generateOtlpResource1(),
+		},
+	}
+}
+
+func GenerateLogDataOneEmptyLogs() data.Logs {
+	ld := GenerateLogDataNoLogRecords()
+	rs0 := ld.ResourceLogs().At(0)
+	rs0.Logs().Resize(1)
+	return ld
+}
+
+func generateLogOtlpOneEmptyLogs() []*otlplogs.ResourceLogs {
+	return []*otlplogs.ResourceLogs{
+		{
+			Resource: generateOtlpResource1(),
+			Logs: []*otlplogs.LogRecord{
+				{},
+			},
+		},
+	}
+}
+
+func GenerateLogDataOneEmptyOneNilLogRecord() data.Logs {
+	return data.LogsFromProto(generateLogOtlpOneEmptyOneNilLogRecord())
+}
+
+func generateLogOtlpOneEmptyOneNilLogRecord() []*otlplogs.ResourceLogs {
+	return []*otlplogs.ResourceLogs{
+		{
+			Resource: generateOtlpResource1(),
+			Logs: []*otlplogs.LogRecord{
+				{},
+				nil,
+			},
+		},
+	}
+}
+
+func GenerateLogDataOneLogNoResource() data.Logs {
+	ld := GenerateLogDataOneEmptyResourceLogs()
+	rs0 := ld.ResourceLogs().At(0)
+	rs0.Logs().Resize(1)
+	rs0lr0 := rs0.Logs().At(0)
+	fillLogOne(rs0lr0)
+	return ld
+}
+
+func generateLogOtlpOneLogNoResource() []*otlplogs.ResourceLogs {
+	return []*otlplogs.ResourceLogs{
+		{
+			Logs: []*otlplogs.LogRecord{
+				generateOtlpLogOne(),
+			},
+		},
+	}
+}
+
+func GenerateLogDataOneLog() data.Logs {
+	ld := GenerateLogDataOneEmptyLogs()
+	rs0lr0 := ld.ResourceLogs().At(0)
+	rs0lr0.Logs().Resize(1)
+	fillLogOne(rs0lr0.Logs().At(0))
+	return ld
+}
+
+func generateLogOtlpOneLog() []*otlplogs.ResourceLogs {
+	return []*otlplogs.ResourceLogs{
+		{
+			Resource: generateOtlpResource1(),
+			Logs: []*otlplogs.LogRecord{
+				generateOtlpLogOne(),
+			},
+		},
+	}
+}
+
+func GenerateLogDataOneLogOneNil() data.Logs {
+	return data.LogsFromProto(generateLogOtlpOneLogOneNil())
+}
+
+func generateLogOtlpOneLogOneNil() []*otlplogs.ResourceLogs {
+	return []*otlplogs.ResourceLogs{
+		{
+			Resource: generateOtlpResource1(),
+			Logs: []*otlplogs.LogRecord{
+				generateOtlpLogOne(),
+				nil,
+			},
+		},
+	}
+}
+
+func GenerateLogDataTwoLogsSameResource() data.Logs {
+	ld := GenerateLogDataOneEmptyLogs()
+	rs0 := ld.ResourceLogs().At(0)
+	rs0.Logs().Resize(2)
+	fillLogOne(rs0.Logs().At(0))
+	fillLogTwo(rs0.Logs().At(1))
+	return ld
+}
+
+// GenerateLogOtlpSameResourceTwologs returns the OTLP representation of the GenerateLogOtlpSameResourceTwologs.
+func GenerateLogOtlpSameResourceTwoLogs() []*otlplogs.ResourceLogs {
+	return []*otlplogs.ResourceLogs{
+		{
+			Resource: generateOtlpResource1(),
+			Logs: []*otlplogs.LogRecord{
+				generateOtlpLogOne(),
+				generateOtlpLogTwo(),
+			},
+		},
+	}
+}
+
+func GenerateLogDataTwoLogsSameResourceOneDifferent() data.Logs {
+	ld := data.NewLogs()
+	ld.ResourceLogs().Resize(2)
+	rl0 := ld.ResourceLogs().At(0)
+	initResource1(rl0.Resource())
+	rl0.Logs().Resize(2)
+	fillLogOne(rl0.Logs().At(0))
+	fillLogTwo(rl0.Logs().At(1))
+	rl1 := ld.ResourceLogs().At(1)
+	initResource2(rl1.Resource())
+	rl1.Logs().Resize(1)
+	fillLogThree(rl1.Logs().At(0))
+	return ld
+}
+
+func GenerateLogDataManyLogsSameResource(logsCount int) data.Logs {
+	ld := GenerateLogDataOneEmptyLogs()
+	rs0 := ld.ResourceLogs().At(0)
+	rs0.Logs().Resize(logsCount)
+	for i := 0; i < logsCount; i++ {
+		fillLogOne(rs0.Logs().At(i))
+	}
+	return ld
+}
+
+func generateLogOtlpTwoLogsSameResourceOneDifferent() []*otlplogs.ResourceLogs {
+	return []*otlplogs.ResourceLogs{
+		{
+			Resource: generateOtlpResource1(),
+			Logs: []*otlplogs.LogRecord{
+				generateOtlpLogOne(),
+				generateOtlpLogTwo(),
+			},
+		},
+		{
+			Resource: generateOtlpResource2(),
+			Logs: []*otlplogs.LogRecord{
+				generateOtlpLogThree(),
+			},
+		},
+	}
+}
+
+func fillLogOne(log pdata.LogRecord) {
+	log.SetShortName("logA")
+	log.SetTimestamp(TestLogTimestamp)
+	log.SetDroppedAttributesCount(1)
+	log.SetSeverityNumber(otlplogs.SeverityNumber_INFO)
+	log.SetSeverityText("Info")
+
+	attrs := log.Attributes()
+	attrs.InsertString("app", "server")
+	attrs.InsertString("env", "prod")
+
+	log.SetBody("This is a log message")
+}
+
+func generateOtlpLogOne() *otlplogs.LogRecord {
+	return &otlplogs.LogRecord{
+		ShortName:              "logA",
+		TimestampUnixNano:      uint64(TestLogTimestamp),
+		DroppedAttributesCount: 1,
+		SeverityNumber:         otlplogs.SeverityNumber_INFO,
+		SeverityText:           "Info",
+		Body:                   "This is a log message",
+		Attributes: []*opentelemetry_proto_common_v1.AttributeKeyValue{
+			{
+				Key:         "app",
+				StringValue: "server",
+			},
+			{
+				Key:         "env",
+				StringValue: "prod",
+			},
+		},
+	}
+}
+
+func fillLogTwo(log pdata.LogRecord) {
+	log.SetShortName("logB")
+	log.SetTimestamp(TestLogTimestamp)
+	log.SetDroppedAttributesCount(1)
+	log.SetSeverityNumber(otlplogs.SeverityNumber_INFO)
+	log.SetSeverityText("Info")
+
+	attrs := log.Attributes()
+	attrs.InsertString("customer", "acme")
+	attrs.InsertString("env", "dev")
+
+	log.SetBody("something happened")
+}
+
+func generateOtlpLogTwo() *otlplogs.LogRecord {
+	return &otlplogs.LogRecord{
+		ShortName:              "logB",
+		TimestampUnixNano:      uint64(TestLogTimestamp),
+		DroppedAttributesCount: 1,
+		SeverityNumber:         otlplogs.SeverityNumber_INFO,
+		SeverityText:           "Info",
+		Body:                   "something happened",
+		Attributes: []*opentelemetry_proto_common_v1.AttributeKeyValue{
+			{
+				Key:         "customer",
+				StringValue: "acme",
+			},
+			{
+				Key:         "env",
+				StringValue: "dev",
+			},
+		},
+	}
+}
+
+func fillLogThree(log pdata.LogRecord) {
+	log.SetShortName("logC")
+	log.SetTimestamp(TestLogTimestamp)
+	log.SetDroppedAttributesCount(1)
+	log.SetSeverityNumber(otlplogs.SeverityNumber_WARN)
+	log.SetSeverityText("Warning")
+
+	log.SetBody("something else happened")
+}
+
+func generateOtlpLogThree() *otlplogs.LogRecord {
+	return &otlplogs.LogRecord{
+		ShortName:              "logC",
+		TimestampUnixNano:      uint64(TestLogTimestamp),
+		DroppedAttributesCount: 1,
+		SeverityNumber:         otlplogs.SeverityNumber_WARN,
+		SeverityText:           "Warning",
+		Body:                   "something else happened",
+	}
+}

--- a/internal/data/testdata/log.go
+++ b/internal/data/testdata/log.go
@@ -206,16 +206,6 @@ func GenerateLogDataTwoLogsSameResourceOneDifferent() data.Logs {
 	return ld
 }
 
-func GenerateLogDataManyLogsSameResource(logsCount int) data.Logs {
-	ld := GenerateLogDataOneEmptyLogs()
-	rs0 := ld.ResourceLogs().At(0)
-	rs0.Logs().Resize(logsCount)
-	for i := 0; i < logsCount; i++ {
-		fillLogOne(rs0.Logs().At(i))
-	}
-	return ld
-}
-
 func generateLogOtlpTwoLogsSameResourceOneDifferent() []*otlplogs.ResourceLogs {
 	return []*otlplogs.ResourceLogs{
 		{
@@ -240,10 +230,12 @@ func fillLogOne(log pdata.LogRecord) {
 	log.SetDroppedAttributesCount(1)
 	log.SetSeverityNumber(otlplogs.SeverityNumber_INFO)
 	log.SetSeverityText("Info")
+	log.SetSpanID([]byte{0x01, 0x02, 0x04, 0x08})
+	log.SetTraceID([]byte{0x08, 0x04, 0x02, 0x01})
 
 	attrs := log.Attributes()
 	attrs.InsertString("app", "server")
-	attrs.InsertString("env", "prod")
+	attrs.InsertInt("instance_num", 1)
 
 	log.SetBody("This is a log message")
 }
@@ -256,14 +248,18 @@ func generateOtlpLogOne() *otlplogs.LogRecord {
 		SeverityNumber:         otlplogs.SeverityNumber_INFO,
 		SeverityText:           "Info",
 		Body:                   "This is a log message",
+		SpanId:                 []byte{0x01, 0x02, 0x04, 0x08},
+		TraceId:                []byte{0x08, 0x04, 0x02, 0x01},
 		Attributes: []*opentelemetry_proto_common_v1.AttributeKeyValue{
 			{
 				Key:         "app",
+				Type:        opentelemetry_proto_common_v1.AttributeKeyValue_STRING,
 				StringValue: "server",
 			},
 			{
-				Key:         "env",
-				StringValue: "prod",
+				Key:      "instance_num",
+				Type:     opentelemetry_proto_common_v1.AttributeKeyValue_INT,
+				IntValue: 1,
 			},
 		},
 	}

--- a/internal/data/testdata/log_test.go
+++ b/internal/data/testdata/log_test.go
@@ -1,0 +1,124 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testdata
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"go.opentelemetry.io/collector/internal/data"
+	otlplogs "go.opentelemetry.io/collector/internal/data/opentelemetry-proto-gen/logs/v1"
+)
+
+type logTestCase struct {
+	name string
+	ld   data.Logs
+	otlp []*otlplogs.ResourceLogs
+}
+
+func generateAllLogTestCases() []logTestCase {
+	return []logTestCase{
+		{
+			name: "empty",
+			ld:   GenerateLogDataEmpty(),
+			otlp: generateLogOtlpEmpty(),
+		},
+		{
+			name: "one-empty-resource-logs",
+			ld:   GenerateLogDataOneEmptyResourceLogs(),
+			otlp: generateLogOtlpOneEmptyResourceLogs(),
+		},
+		{
+			name: "one-empty-one-nil-resource-logs",
+			ld:   GenerateLogDataOneEmptyOneNilResourceLogs(),
+			otlp: generateLogOtlpOneEmptyOneNilResourceLogs(),
+		},
+		{
+			name: "no-log-records",
+			ld:   GenerateLogDataNoLogRecords(),
+			otlp: generateLogOtlpNoLogRecords(),
+		},
+		{
+			name: "one-empty-log-record",
+			ld:   GenerateLogDataOneEmptyLogs(),
+			otlp: generateLogOtlpOneEmptyLogs(),
+		},
+		{
+			name: "one-empty-one-nil-log-record",
+			ld:   GenerateLogDataOneEmptyOneNilLogRecord(),
+			otlp: generateLogOtlpOneEmptyOneNilLogRecord(),
+		},
+		{
+			name: "one-log-record-no-resource",
+			ld:   GenerateLogDataOneLogNoResource(),
+			otlp: generateLogOtlpOneLogNoResource(),
+		},
+		{
+			name: "one-log-record",
+			ld:   GenerateLogDataOneLog(),
+			otlp: generateLogOtlpOneLog(),
+		},
+		{
+			name: "one-log-record-one-nil",
+			ld:   GenerateLogDataOneLogOneNil(),
+			otlp: generateLogOtlpOneLogOneNil(),
+		},
+		{
+			name: "two-records-same-resource",
+			ld:   GenerateLogDataTwoLogsSameResource(),
+			otlp: GenerateLogOtlpSameResourceTwoLogs(),
+		},
+		{
+			name: "two-records-same-resource-one-different",
+			ld:   GenerateLogDataTwoLogsSameResourceOneDifferent(),
+			otlp: generateLogOtlpTwoLogsSameResourceOneDifferent(),
+		},
+	}
+}
+
+func TestToFromOtlpLog(t *testing.T) {
+	allTestCases := generateAllLogTestCases()
+	// Ensure NumLogTests gets updated.
+	assert.EqualValues(t, NumLogTests, len(allTestCases))
+	for i := range allTestCases {
+		test := allTestCases[i]
+		t.Run(test.name, func(t *testing.T) {
+			ld := data.LogsFromProto(test.otlp)
+			assert.EqualValues(t, test.ld, ld)
+			otlp := data.LogsToProto(ld)
+			assert.EqualValues(t, test.otlp, otlp)
+		})
+	}
+}
+
+func TestToFromOtlpLogWithNils(t *testing.T) {
+	md := GenerateLogDataOneEmptyOneNilResourceLogs()
+	assert.EqualValues(t, 2, md.ResourceLogs().Len())
+	assert.False(t, md.ResourceLogs().At(0).IsNil())
+	assert.True(t, md.ResourceLogs().At(1).IsNil())
+
+	md = GenerateLogDataOneEmptyOneNilLogRecord()
+	rs := md.ResourceLogs().At(0)
+	assert.EqualValues(t, 2, rs.Logs().Len())
+	assert.False(t, rs.Logs().At(0).IsNil())
+	assert.True(t, rs.Logs().At(1).IsNil())
+
+	md = GenerateLogDataOneLogOneNil()
+	rl0 := md.ResourceLogs().At(0)
+	assert.EqualValues(t, 2, rl0.Logs().Len())
+	assert.False(t, rl0.Logs().At(0).IsNil())
+	assert.True(t, rl0.Logs().At(1).IsNil())
+}

--- a/observability/observability.go
+++ b/observability/observability.go
@@ -38,6 +38,8 @@ var (
 	mExporterDroppedSpans       = stats.Int64("otelcol/exporter/dropped_spans", "Counts the number of spans dropped by the exporter", "1")
 	mExporterReceivedTimeSeries = stats.Int64("otelcol/exporter/received_timeseries", "Counts the number of timeseries received by the exporter", "1")
 	mExporterDroppedTimeSeries  = stats.Int64("otelcol/exporter/dropped_timeseries", "Counts the number of timeseries received by the exporter", "1")
+	mExporterReceivedLogRecords = stats.Int64("otelcol/exporter/received_logs", "Counts the number of log records received by the exporter", "1")
+	mExporterDroppedLogRecords  = stats.Int64("otelcol/exporter/dropped_logs", "Counts the number of log records dropped by the exporter", "1")
 )
 
 // TagKeyReceiver defines tag key for Receiver.
@@ -118,6 +120,24 @@ var ViewExporterDroppedTimeSeries = &view.View{
 	TagKeys:     []tag.Key{TagKeyReceiver, TagKeyExporter},
 }
 
+// ViewExporterReceivedLogRecords defines the view for the exporter received logs metric.
+var ViewExporterReceivedLogRecords = &view.View{
+	Name:        mExporterReceivedLogRecords.Name(),
+	Description: mExporterReceivedLogRecords.Description(),
+	Measure:     mExporterReceivedLogRecords,
+	Aggregation: view.Sum(),
+	TagKeys:     []tag.Key{TagKeyReceiver, TagKeyExporter},
+}
+
+// ViewExporterDroppedLogRecords defines the view for the exporter dropped logs metric.
+var ViewExporterDroppedLogRecords = &view.View{
+	Name:        mExporterDroppedLogRecords.Name(),
+	Description: mExporterDroppedLogRecords.Description(),
+	Measure:     mExporterDroppedLogRecords,
+	Aggregation: view.Sum(),
+	TagKeys:     []tag.Key{TagKeyReceiver, TagKeyExporter},
+}
+
 // AllViews has the views for the metrics provided by the agent.
 var AllViews = []*view.View{
 	ViewReceiverReceivedSpans,
@@ -126,6 +146,8 @@ var AllViews = []*view.View{
 	ViewReceiverDroppedTimeSeries,
 	ViewExporterReceivedSpans,
 	ViewExporterDroppedSpans,
+	ViewExporterReceivedLogRecords,
+	ViewExporterDroppedLogRecords,
 	ViewExporterReceivedTimeSeries,
 	ViewExporterDroppedTimeSeries,
 }
@@ -168,6 +190,12 @@ func RecordMetricsForTraceExporter(ctx context.Context, receivedSpans int, dropp
 // Use it with a context.Context generated using ContextWithExporterName().
 func RecordMetricsForMetricsExporter(ctx context.Context, receivedTimeSeries int, droppedTimeSeries int) {
 	stats.Record(ctx, mExporterReceivedTimeSeries.M(int64(receivedTimeSeries)), mExporterDroppedTimeSeries.M(int64(droppedTimeSeries)))
+}
+
+// RecordMetricsForLogsExporter records the number of timeseries received and dropped by the exporter.
+// Use it with a context.Context generated using ContextWithExporterName().
+func RecordMetricsForLogsExporter(ctx context.Context, receivedLogs int, droppedLogs int) {
+	stats.Record(ctx, mExporterReceivedLogRecords.M(int64(receivedLogs)), mExporterDroppedLogRecords.M(int64(droppedLogs)))
 }
 
 // GRPCServerWithObservabilityEnabled creates a gRPC server that at a bare minimum has

--- a/observability/observabilitytest/observabilitytest.go
+++ b/observability/observabilitytest/observabilitytest.go
@@ -68,6 +68,22 @@ func CheckValueViewExporterDroppedTimeSeries(receiverName string, exporterTagNam
 		wantsTagsForExporterView(receiverName, exporterTagName), int64(value))
 }
 
+// CheckValueViewExporterReceivedLogRecords checks that for the current exported value in the ViewExporterReceivedLogRecords
+// for {TagKeyReceiver: receiverName, TagKeyExporter: exporterTagName} is equal to "value".
+// When this function is called it is required to also call SetupRecordedMetricsTest as first thing.
+func CheckValueViewExporterReceivedLogRecords(receiverName string, exporterTagName string, value int) error {
+	return checkValueForView(observability.ViewExporterReceivedLogRecords.Name,
+		wantsTagsForExporterView(receiverName, exporterTagName), int64(value))
+}
+
+// CheckValueViewExporterDroppedLogRecords checks that for the current exported value in the ViewExporterDroppedLogRecords
+// for {TagKeyReceiver: receiverName} is equal to "value".
+// In tests that this function is called it is required to also call SetupRecordedMetricsTest as first thing.
+func CheckValueViewExporterDroppedLogRecords(receiverName string, exporterTagName string, value int) error {
+	return checkValueForView(observability.ViewExporterDroppedLogRecords.Name,
+		wantsTagsForExporterView(receiverName, exporterTagName), int64(value))
+}
+
 // CheckValueViewReceiverReceivedSpans checks that for the current exported value in the ViewReceiverReceivedSpans
 // for {TagKeyReceiver: receiverName, TagKeyExporter: exporterTagName} is equal to "value".
 // In tests that this function is called it is required to also call SetupRecordedMetricsTest as first thing.


### PR DESCRIPTION
The GRPC service was already defined in a previous PR.

This is still experimental.