### PR TITLE
Remove year from copyright header

### DIFF
--- a/processor/filterprocessor/config.go
+++ b/processor/filterprocessor/config.go
@@ -1,4 +1,4 @@
-// Copyright 2020 OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/filterprocessor/filter_processor.go
+++ b/processor/filterprocessor/filter_processor.go
@@ -1,4 +1,4 @@
-// Copyright 2020 OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/filterprocessor/filter_processor_test.go
+++ b/processor/filterprocessor/filter_processor_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
It's mostly to see if CIrcleCI hooks will be triggered. It doesn't work for me in another PR: https://github.com/open-telemetry/opentelemetry-collector/pull/1105