### PR TITLE
Add missing logging for metrics at 'debug' level

### DIFF
--- a/exporter/loggingexporter/logging_exporter.go
+++ b/exporter/loggingexporter/logging_exporter.go
@@ -210,6 +210,8 @@ func (s *loggingExporter) pushMetricsData(
 			}
 		}
 	}
+	s.logger.Debug(buf.str.String())
+
 	return 0, nil
 }
 


### PR DESCRIPTION
**Description:** 
Fixing a bug - enable metrics' debug logging in Logging Exporter

**Link to tracking Issue:** Fixes #1107

**Testing:**
Manual testing: simply run a collector with `--log-level=DEBUG` and the following config:
```yaml
receivers:
  prometheus:
    config:
      scrape_configs:
      - job_name: "test"
        scrape_interval: 60s
        static_configs:
        - targets: ["localhost:8888"]
exporters:
  logging:
    loglevel: debug
service:
  pipelines:
    metrics:
      receivers: [prometheus]
      exporters: [logging]
```

The log now includes detailed information at the `DEBUG` level:
```
2020-06-11T14:13:08.697+1000	INFO	loggingexporter/logging_exporter.go:169	MetricsExporter	{"#metrics": 4}
2020-06-11T14:13:08.697+1000	DEBUG	loggingexporter/logging_exporter.go:213	ResourceMetrics #0
Resource labels:
     -> port: STRING(8888)
     -> scheme: STRING(http)
     -> service.name: STRING(test)
     -> host.hostname: STRING(localhost)
InstrumentationLibraryMetrics #0
Metric #0
Descriptor:
     -> Name: otelcol_process_cpu_seconds
     -> Description: Total CPU user and system time in seconds
     -> Unit: s
     -> Type: GAUGE_DOUBLE
Metric #1
Descriptor:
     -> Name: otelcol_process_runtime_heap_alloc_bytes
     -> Description: Bytes of allocated heap objects (see 'go doc runtime.MemStats.HeapAlloc')
     -> Unit: By
     -> Type: GAUGE_DOUBLE
Metric #2
Descriptor:
     -> Name: otelcol_process_runtime_total_alloc_bytes
     -> Description: Cumulative bytes allocated for heap objects (see 'go doc runtime.MemStats.TotalAlloc')
     -> Unit: By
     -> Type: GAUGE_DOUBLE
Metric #3
Descriptor:
     -> Name: otelcol_process_runtime_total_sys_memory_bytes
     -> Description: Total bytes of memory obtained from the OS (see 'go doc runtime.MemStats.Sys')
     -> Unit: By
     -> Type: GAUGE_DOUBLE
```

**Documentation:** N/A