### PR TITLE
Use ResourceCheckPeriod as logging intervals in test bed

### DIFF
--- a/testbed/testbed/test_case.go
+++ b/testbed/testbed/test_case.go
@@ -359,7 +359,7 @@ func (tc *TestCase) indicateError(err error) {
 }
 
 func (tc *TestCase) logStats() {
-	t := time.NewTicker(1 * time.Second)
+	t := time.NewTicker(tc.resourceSpec.ResourceCheckPeriod)
 	defer t.Stop()
 
 	for {


### PR DESCRIPTION
**Description:** 
If ResourceCheckPeriod is more than 1 second, reported resource values are not being changed during each ResourceCheckPeriod, so logging every second doens't provide much value, but makes it hard to read logs in long run running tests