### PR TITLE
Update Collector approvers from Google

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,4 +12,4 @@
 #  https://help.github.com/en/articles/about-code-owners
 #
 
-* @bogdandrutu @pjanotti @flands @songy23 @tigrannajaryan @owais @rghetia @dmitryax
+* @bogdandrutu @pjanotti @flands @tigrannajaryan @owais @dmitryax @nilebox @james-bebbington

--- a/README.md
+++ b/README.md
@@ -62,10 +62,10 @@ Objectives:
 Approvers ([@open-telemetry/collector-approvers](https://github.com/orgs/open-telemetry/teams/collector-approvers)):
 
 - [Owais Lone](https://github.com/owais), Splunk
-- [Rahul Patel](https://github.com/rghetia), Google
 - [Steve Flanders](https://github.com/flands), Splunk
-- [Yang Song](https://github.com/songy23), Google
 - [Dmitrii Anoshin](https://github.com/dmitryax), Splunk
+- [Nail Islamov](https://github.com/nilebox), Google
+- [James Bebbington](https://github.com/james-bebbington), Google
 
 Maintainers ([@open-telemetry/collector-maintainers](https://github.com/orgs/open-telemetry/teams/collector-maintainers)):
 


### PR DESCRIPTION
**Description:**
As discussed at the Collector SIG meeting, updating the list of approvers representing Google:
- Remove [Rahul Patel](https://github.com/rghetia) and [Yang Song](https://github.com/songy23) from approvers
- Add [Nail Islamov](https://github.com/nilebox) and [James Bebbington](https://github.com/james-bebbington) to approvers

**We also need to update membership in ([@open-telemetry/collector-approvers](https://github.com/orgs/open-telemetry/teams/collector-approvers)).**

/cc @tigrannajaryan @james-bebbington @rghetia @songy23 