### PR TITLE
Fix handling of SpanKind INTERNAL in OTLP OC translation

### DIFF
--- a/translator/internaldata/oc_to_traces.go
+++ b/translator/internaldata/oc_to_traces.go
@@ -251,6 +251,8 @@ func ocSpanKindToInternal(ocKind octrace.Span_SpanKind, ocAttrs *octrace.Span_At
 						otlpKind = pdata.SpanKindCONSUMER
 					case tracetranslator.OpenTracingSpanKindProducer:
 						otlpKind = pdata.SpanKindPRODUCER
+					case tracetranslator.OpenTracingSpanKindInternal:
+						otlpKind = pdata.SpanKindINTERNAL
 					default:
 						return pdata.SpanKindUNSPECIFIED
 					}

--- a/translator/internaldata/oc_to_traces_test.go
+++ b/translator/internaldata/oc_to_traces_test.go
@@ -180,6 +180,16 @@ func TestOcSpanKindToInternal(t *testing.T) {
 			},
 			otlpKind: otlptrace.Span_CLIENT,
 		},
+		{
+			ocKind: octrace.Span_SPAN_KIND_UNSPECIFIED,
+			ocAttrs: &octrace.Span_Attributes{
+				AttributeMap: map[string]*octrace.AttributeValue{
+					"span.kind": {Value: &octrace.AttributeValue_StringValue{
+						StringValue: &octrace.TruncatableString{Value: "internal"}}},
+				},
+			},
+			otlpKind: otlptrace.Span_INTERNAL,
+		},
 	}
 
 	for _, test := range tests {

--- a/translator/internaldata/traces_to_oc.go
+++ b/translator/internaldata/traces_to_oc.go
@@ -178,8 +178,9 @@ func spanKindToOCAttribute(kind pdata.SpanKind) *octrace.AttributeValue {
 		ocKind = tracetranslator.OpenTracingSpanKindConsumer
 	case pdata.SpanKindPRODUCER:
 		ocKind = tracetranslator.OpenTracingSpanKindProducer
-	case pdata.SpanKindUNSPECIFIED:
 	case pdata.SpanKindINTERNAL:
+		ocKind = tracetranslator.OpenTracingSpanKindInternal
+	case pdata.SpanKindUNSPECIFIED:
 	case pdata.SpanKindSERVER: // explicitly handled as SpanKind
 	case pdata.SpanKindCLIENT: // explicitly handled as SpanKind
 	default:

--- a/translator/internaldata/traces_to_oc_test.go
+++ b/translator/internaldata/traces_to_oc_test.go
@@ -118,6 +118,10 @@ func TestSpanKindToOC(t *testing.T) {
 			kind:   pdata.SpanKindUNSPECIFIED,
 			ocKind: octrace.Span_SPAN_KIND_UNSPECIFIED,
 		},
+		{
+			kind:   pdata.SpanKindINTERNAL,
+			ocKind: octrace.Span_SPAN_KIND_UNSPECIFIED,
+		},
 	}
 
 	for _, test := range tests {
@@ -149,6 +153,16 @@ func TestSpanKindToOCAttribute(t *testing.T) {
 				Value: &octrace.AttributeValue_StringValue{
 					StringValue: &octrace.TruncatableString{
 						Value: string(tracetranslator.OpenTracingSpanKindProducer),
+					},
+				},
+			},
+		},
+		{
+			kind: pdata.SpanKindINTERNAL,
+			ocAttribute: &octrace.AttributeValue{
+				Value: &octrace.AttributeValue_StringValue{
+					StringValue: &octrace.TruncatableString{
+						Value: string(tracetranslator.OpenTracingSpanKindInternal),
 					},
 				},
 			},

--- a/translator/trace/protospan_translation.go
+++ b/translator/trace/protospan_translation.go
@@ -48,4 +48,5 @@ const (
 	OpenTracingSpanKindServer      OpenTracingSpanKind = "server"
 	OpenTracingSpanKindConsumer    OpenTracingSpanKind = "consumer"
 	OpenTracingSpanKindProducer    OpenTracingSpanKind = "producer"
+	OpenTracingSpanKindInternal    OpenTracingSpanKind = "internal"
 )


### PR DESCRIPTION
**Description:** <Describe what has changed. 
Added setting of span attribute "span.kind" to "internal" when translating from OTLP to OC and translate back to SpanKindINTERNAL when translating from OC to OTLP.

**Link to tracking Issue:** #1136 #754

**Testing:** All tracing correctness tests involving only otlp and opencensus receivers and exporters now report a zero failure count.

**Documentation:** N/A