### PR TITLE
Enable "new-metrics" by default

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -2,8 +2,8 @@
 
 Many metrics are provided by the Collector for its monitoring. Below some
 key recommendations for alerting and monitoring are listed. All metrics
-referenced below are using the `--new-metrics` option, eventually the Collector
-will transition to these metrics as default and disable the old ones.
+referenced below are using the `--new-metrics` option that is enabled by
+default.
 
 ## Critical Monitoring
 

--- a/internal/collector/telemetry/telemetry.go
+++ b/internal/collector/telemetry/telemetry.go
@@ -71,19 +71,19 @@ func Flags(flags *flag.FlagSet) {
 
 	useLegacyMetricsPtr = flags.Bool(
 		"legacy-metrics",
-		true,
+		false,
 		"Flag to control usage of legacy metrics",
 	)
 
 	useNewMetricsPtr = flags.Bool(
 		"new-metrics",
-		false,
+		true,
 		"Flag to control usage of new metrics",
 	)
 
 	addInstanceIDPtr = flags.Bool(
 		"add-instance-id",
-		false,
+		true,
 		"Flag to control the addition of 'service.instance.id' to the collector metrics.")
 }
 


### PR DESCRIPTION
**Description:**
This change switches the defaults between "new-metrics" and "legacy-metrics".

Now the defaults are:
- "new-metrics" ON by default
- "legacy-metrics" OFF by default
- "add-instance-id" ON by default
 
**Link to tracking Issue:** Third item on https://github.com/open-telemetry/opentelemetry-collector/issues/1082

**Testing:** Added test to enforce the "service_instance_id" label ON by default.

**Documentation:** Updated `monitoring.md` to reflect that the "new-metrics" are on by default.