### PR TITLE
Adjusted test signatures to support tests in contrib project

### DIFF
--- a/testbed/tests/metric_test.go
+++ b/testbed/tests/metric_test.go
@@ -79,6 +79,7 @@ func TestMetric10kDPS(t *testing.T) {
 				test.sender,
 				test.receiver,
 				test.resourceSpec,
+				performanceResultsSummary,
 				nil,
 			)
 		})

--- a/testbed/tests/scenarios.go
+++ b/testbed/tests/scenarios.go
@@ -34,15 +34,14 @@ var performanceResultsSummary testbed.TestResultsSummary = &testbed.PerformanceR
 
 // createConfigYaml creates a collector config file that corresponds to the
 // sender and receiver used in the test and returns the config file name.
+// Map of processor names to their configs. Config is in YAML and must be
+// indented by 2 spaces. Processors will be placed between batch and queue for traces
+// pipeline. For metrics pipeline these will be sole processors.
 func createConfigYaml(
 	t *testing.T,
-	sender testbed.DataSender, // Sender to send test data.
-	receiver testbed.DataReceiver, // Receiver to receive test data.
-	resultDir string, // Directory to write config file to.
-
-	// Map of processor names to their configs. Config is in YAML and must be
-	// indented by 2 spaces. Processors will be placed between batch and queue for traces
-	// pipeline. For metrics pipeline these will be sole processors.
+	sender testbed.DataSender,
+	receiver testbed.DataReceiver,
+	resultDir string,
 	processors map[string]string,
 ) string {
 
@@ -117,6 +116,7 @@ func Scenario10kItemsPerSecond(
 	sender testbed.DataSender,
 	receiver testbed.DataReceiver,
 	resourceSpec testbed.ResourceSpec,
+	resultsSummary testbed.TestResultsSummary,
 	processors map[string]string,
 ) {
 	resultDir, err := filepath.Abs(path.Join("results", t.Name()))
@@ -140,7 +140,7 @@ func Scenario10kItemsPerSecond(
 		receiver,
 		agentProc,
 		&testbed.PerfTestValidator{},
-		performanceResultsSummary,
+		resultsSummary,
 	)
 	defer tc.Stop()
 
@@ -168,6 +168,7 @@ type TestCase struct {
 	attrSizeByte   int
 	expectedMaxCPU uint32
 	expectedMaxRAM uint32
+	resultsSummary testbed.TestResultsSummary
 }
 
 func genRandByteString(len int) string {
@@ -194,7 +195,7 @@ func Scenario1kSPSWithAttrs(t *testing.T, args []string, tests []TestCase, opts 
 				testbed.NewOCDataReceiver(testbed.DefaultOCPort),
 				&testbed.ChildProcess{},
 				&testbed.PerfTestValidator{},
-				performanceResultsSummary,
+				test.resultsSummary,
 				opts...,
 			)
 			defer tc.Stop()
@@ -231,8 +232,14 @@ type processorConfig struct {
 	ExpectedMinFinalRAM uint32
 }
 
-func ScenarioTestTraceNoBackend10kSPS(t *testing.T, sender testbed.DataSender, receiver testbed.DataReceiver,
-	resourceSpec testbed.ResourceSpec, configuration processorConfig) {
+func ScenarioTestTraceNoBackend10kSPS(
+	t *testing.T,
+	sender testbed.DataSender,
+	receiver testbed.DataReceiver,
+	resourceSpec testbed.ResourceSpec,
+	resultsSummary testbed.TestResultsSummary,
+	configuration processorConfig,
+) {
 
 	resultDir, err := filepath.Abs(path.Join("results", t.Name()))
 	require.NoError(t, err)
@@ -252,7 +259,7 @@ func ScenarioTestTraceNoBackend10kSPS(t *testing.T, sender testbed.DataSender, r
 		receiver,
 		agentProc,
 		&testbed.PerfTestValidator{},
-		performanceResultsSummary,
+		resultsSummary,
 	)
 
 	defer tc.Stop()

--- a/testbed/tests/trace_test.go
+++ b/testbed/tests/trace_test.go
@@ -99,6 +99,7 @@ func TestTrace10kSPS(t *testing.T) {
 				test.sender,
 				test.receiver,
 				test.resourceSpec,
+				performanceResultsSummary,
 				processors,
 			)
 		})
@@ -177,6 +178,7 @@ func TestTraceNoBackend10kSPS(t *testing.T) {
 					test.sender,
 					test.receiver,
 					test.resourceSpec,
+					performanceResultsSummary,
 					testConf,
 				)
 			})
@@ -192,6 +194,7 @@ func TestTrace1kSPSWithAttrs(t *testing.T) {
 			attrSizeByte:   0,
 			expectedMaxCPU: 30,
 			expectedMaxRAM: 100,
+			resultsSummary: performanceResultsSummary,
 		},
 
 		// We generate 10 attributes each with average key length of 100 bytes and
@@ -202,6 +205,7 @@ func TestTrace1kSPSWithAttrs(t *testing.T) {
 			attrSizeByte:   50,
 			expectedMaxCPU: 120,
 			expectedMaxRAM: 100,
+			resultsSummary: performanceResultsSummary,
 		},
 
 		// Approx 10 KiB attributes.
@@ -210,6 +214,7 @@ func TestTrace1kSPSWithAttrs(t *testing.T) {
 			attrSizeByte:   1000,
 			expectedMaxCPU: 100,
 			expectedMaxRAM: 100,
+			resultsSummary: performanceResultsSummary,
 		},
 
 		// Approx 100 KiB attributes.
@@ -218,6 +223,7 @@ func TestTrace1kSPSWithAttrs(t *testing.T) {
 			attrSizeByte:   5000,
 			expectedMaxCPU: 250,
 			expectedMaxRAM: 100,
+			resultsSummary: performanceResultsSummary,
 		},
 	})
 }
@@ -231,24 +237,28 @@ func TestTraceBallast1kSPSWithAttrs(t *testing.T) {
 			attrSizeByte:   0,
 			expectedMaxCPU: 30,
 			expectedMaxRAM: 2000,
+			resultsSummary: performanceResultsSummary,
 		},
 		{
 			attrCount:      100,
 			attrSizeByte:   50,
 			expectedMaxCPU: 80,
 			expectedMaxRAM: 2000,
+			resultsSummary: performanceResultsSummary,
 		},
 		{
 			attrCount:      10,
 			attrSizeByte:   1000,
 			expectedMaxCPU: 80,
 			expectedMaxRAM: 2000,
+			resultsSummary: performanceResultsSummary,
 		},
 		{
 			attrCount:      20,
 			attrSizeByte:   5000,
 			expectedMaxCPU: 120,
 			expectedMaxRAM: 2000,
+			resultsSummary: performanceResultsSummary,
 		},
 	})
 }
@@ -264,24 +274,28 @@ func TestTraceBallast1kSPSAddAttrs(t *testing.T) {
 				attrSizeByte:   0,
 				expectedMaxCPU: 30,
 				expectedMaxRAM: 2000,
+				resultsSummary: performanceResultsSummary,
 			},
 			{
 				attrCount:      100,
 				attrSizeByte:   50,
 				expectedMaxCPU: 80,
 				expectedMaxRAM: 2000,
+				resultsSummary: performanceResultsSummary,
 			},
 			{
 				attrCount:      10,
 				attrSizeByte:   1000,
 				expectedMaxCPU: 80,
 				expectedMaxRAM: 2000,
+				resultsSummary: performanceResultsSummary,
 			},
 			{
 				attrCount:      20,
 				attrSizeByte:   5000,
 				expectedMaxCPU: 120,
 				expectedMaxRAM: 2000,
+				resultsSummary: performanceResultsSummary,
 			},
 		},
 		testbed.WithConfigFile(path.Join("testdata", "add-attributes-config.yaml")),


### PR DESCRIPTION
**Description:** Adjusted scenario test function signatures so TestResultsSummary always gets passed in. This enables scenario functions currently reused in opentelemetry-collector-contrib to work correctly with TestResultsSummary instances created in that project.

**Link to tracking Issue:** N/A

**Testing:** All testbed tests are still passing.

**Documentation:** N/A