### PR TITLE
Add Append to Generated pdata Structs

### DIFF
--- a/cmd/pdatagen/internal/base_structs.go
+++ b/cmd/pdatagen/internal/base_structs.go
@@ -132,6 +132,14 @@ func (es ${structName}) Resize(newLen int) {
 		oldOrig = append(oldOrig, &extraOrigs[i])
 	}
 	(*es.orig) = oldOrig
+}
+
+// Append will increase the length of the ${structName} by one and set the
+// given ${elementName} at that new position.  The original ${elementName}
+// could still be referenced so do not reuse it after passing it to this
+// method.
+func (es ${structName}) Append(e *${elementName}) {
+	(*es.orig) = append((*es.orig), *e.orig)
 }`
 
 const sliceTestTemplate = `func Test${structName}(t *testing.T) {
@@ -233,6 +241,23 @@ func Test${structName}_Resize(t *testing.T) {
 	// Test Resize 0 elements.
 	es.Resize(0)
 	assert.EqualValues(t, New${structName}(), es)
+}
+
+func Test${structName}_Append(t *testing.T) {
+	es := generateTest${structName}()
+	emptyVal := New${elementName}()
+	emptyVal.InitEmpty()
+
+	es.Append(&emptyVal)
+	assert.EqualValues(t, *(es.At(7)).orig, *emptyVal.orig)
+
+	emptyVal2:= New${elementName}()
+	emptyVal2.InitEmpty()
+
+	es.Append(&emptyVal2)
+	assert.EqualValues(t, *(es.At(8)).orig, *emptyVal2.orig)
+
+	assert.Equal(t, 9, es.Len())
 }`
 
 const sliceGenerateTest = `func generateTest${structName}() ${structName} {

--- a/consumer/pdata/generated_log.go
+++ b/consumer/pdata/generated_log.go
@@ -136,6 +136,14 @@ func (es ResourceLogsSlice) Resize(newLen int) {
 	(*es.orig) = oldOrig
 }
 
+// Append will increase the length of the ResourceLogsSlice by one and set the
+// given ResourceLogs at that new position.  The original ResourceLogs
+// could still be referenced so do not reuse it after passing it to this
+// method.
+func (es ResourceLogsSlice) Append(e *ResourceLogs) {
+	(*es.orig) = append((*es.orig), *e.orig)
+}
+
 // ResourceLogs is a collection of logs from a Resource.
 //
 // This is a reference type, if passed by value and callee modifies it the
@@ -317,6 +325,14 @@ func (es LogSlice) Resize(newLen int) {
 		oldOrig = append(oldOrig, &extraOrigs[i])
 	}
 	(*es.orig) = oldOrig
+}
+
+// Append will increase the length of the LogSlice by one and set the
+// given LogRecord at that new position.  The original LogRecord
+// could still be referenced so do not reuse it after passing it to this
+// method.
+func (es LogSlice) Append(e *LogRecord) {
+	(*es.orig) = append((*es.orig), *e.orig)
 }
 
 // LogRecord are experimental implementation of OpenTelemetry Log Data Model.

--- a/consumer/pdata/generated_log_test.go
+++ b/consumer/pdata/generated_log_test.go
@@ -126,6 +126,23 @@ func TestResourceLogsSlice_Resize(t *testing.T) {
 	assert.EqualValues(t, NewResourceLogsSlice(), es)
 }
 
+func TestResourceLogsSlice_Append(t *testing.T) {
+	es := generateTestResourceLogsSlice()
+	emptyVal := NewResourceLogs()
+	emptyVal.InitEmpty()
+
+	es.Append(&emptyVal)
+	assert.EqualValues(t, *(es.At(7)).orig, *emptyVal.orig)
+
+	emptyVal2:= NewResourceLogs()
+	emptyVal2.InitEmpty()
+
+	es.Append(&emptyVal2)
+	assert.EqualValues(t, *(es.At(8)).orig, *emptyVal2.orig)
+
+	assert.Equal(t, 9, es.Len())
+}
+
 func TestResourceLogs_InitEmpty(t *testing.T) {
 	ms := NewResourceLogs()
 	assert.True(t, ms.IsNil())
@@ -259,6 +276,23 @@ func TestLogSlice_Resize(t *testing.T) {
 	// Test Resize 0 elements.
 	es.Resize(0)
 	assert.EqualValues(t, NewLogSlice(), es)
+}
+
+func TestLogSlice_Append(t *testing.T) {
+	es := generateTestLogSlice()
+	emptyVal := NewLogRecord()
+	emptyVal.InitEmpty()
+
+	es.Append(&emptyVal)
+	assert.EqualValues(t, *(es.At(7)).orig, *emptyVal.orig)
+
+	emptyVal2:= NewLogRecord()
+	emptyVal2.InitEmpty()
+
+	es.Append(&emptyVal2)
+	assert.EqualValues(t, *(es.At(8)).orig, *emptyVal2.orig)
+
+	assert.Equal(t, 9, es.Len())
 }
 
 func TestLogRecord_InitEmpty(t *testing.T) {

--- a/consumer/pdata/generated_metrics.go
+++ b/consumer/pdata/generated_metrics.go
@@ -136,6 +136,14 @@ func (es ResourceMetricsSlice) Resize(newLen int) {
 	(*es.orig) = oldOrig
 }
 
+// Append will increase the length of the ResourceMetricsSlice by one and set the
+// given ResourceMetrics at that new position.  The original ResourceMetrics
+// could still be referenced so do not reuse it after passing it to this
+// method.
+func (es ResourceMetricsSlice) Append(e *ResourceMetrics) {
+	(*es.orig) = append((*es.orig), *e.orig)
+}
+
 // InstrumentationLibraryMetrics is a collection of metrics from a LibraryInstrumentation.
 //
 // This is a reference type, if passed by value and callee modifies it the
@@ -319,6 +327,14 @@ func (es InstrumentationLibraryMetricsSlice) Resize(newLen int) {
 	(*es.orig) = oldOrig
 }
 
+// Append will increase the length of the InstrumentationLibraryMetricsSlice by one and set the
+// given InstrumentationLibraryMetrics at that new position.  The original InstrumentationLibraryMetrics
+// could still be referenced so do not reuse it after passing it to this
+// method.
+func (es InstrumentationLibraryMetricsSlice) Append(e *InstrumentationLibraryMetrics) {
+	(*es.orig) = append((*es.orig), *e.orig)
+}
+
 // InstrumentationLibraryMetrics is a collection of metrics from a LibraryInstrumentation.
 //
 // This is a reference type, if passed by value and callee modifies it the
@@ -500,6 +516,14 @@ func (es MetricSlice) Resize(newLen int) {
 		oldOrig = append(oldOrig, &extraOrigs[i])
 	}
 	(*es.orig) = oldOrig
+}
+
+// Append will increase the length of the MetricSlice by one and set the
+// given Metric at that new position.  The original Metric
+// could still be referenced so do not reuse it after passing it to this
+// method.
+func (es MetricSlice) Append(e *Metric) {
+	(*es.orig) = append((*es.orig), *e.orig)
 }
 
 // Metric represents one metric as a collection of datapoints.
@@ -819,6 +843,14 @@ func (es Int64DataPointSlice) Resize(newLen int) {
 	(*es.orig) = oldOrig
 }
 
+// Append will increase the length of the Int64DataPointSlice by one and set the
+// given Int64DataPoint at that new position.  The original Int64DataPoint
+// could still be referenced so do not reuse it after passing it to this
+// method.
+func (es Int64DataPointSlice) Append(e *Int64DataPoint) {
+	(*es.orig) = append((*es.orig), *e.orig)
+}
+
 // Int64DataPoint is a single data point in a timeseries that describes the time-varying values of a int64 metric.
 //
 // This is a reference type, if passed by value and callee modifies it the
@@ -1036,6 +1068,14 @@ func (es DoubleDataPointSlice) Resize(newLen int) {
 	(*es.orig) = oldOrig
 }
 
+// Append will increase the length of the DoubleDataPointSlice by one and set the
+// given DoubleDataPoint at that new position.  The original DoubleDataPoint
+// could still be referenced so do not reuse it after passing it to this
+// method.
+func (es DoubleDataPointSlice) Append(e *DoubleDataPoint) {
+	(*es.orig) = append((*es.orig), *e.orig)
+}
+
 // DoubleDataPoint is a single data point in a timeseries that describes the time-varying value of a double metric.
 //
 // This is a reference type, if passed by value and callee modifies it the
@@ -1251,6 +1291,14 @@ func (es HistogramDataPointSlice) Resize(newLen int) {
 		oldOrig = append(oldOrig, &extraOrigs[i])
 	}
 	(*es.orig) = oldOrig
+}
+
+// Append will increase the length of the HistogramDataPointSlice by one and set the
+// given HistogramDataPoint at that new position.  The original HistogramDataPoint
+// could still be referenced so do not reuse it after passing it to this
+// method.
+func (es HistogramDataPointSlice) Append(e *HistogramDataPoint) {
+	(*es.orig) = append((*es.orig), *e.orig)
 }
 
 // HistogramDataPoint is a single data point in a timeseries that describes the time-varying values of a Histogram.
@@ -1506,6 +1554,14 @@ func (es HistogramBucketSlice) Resize(newLen int) {
 		oldOrig = append(oldOrig, &extraOrigs[i])
 	}
 	(*es.orig) = oldOrig
+}
+
+// Append will increase the length of the HistogramBucketSlice by one and set the
+// given HistogramBucket at that new position.  The original HistogramBucket
+// could still be referenced so do not reuse it after passing it to this
+// method.
+func (es HistogramBucketSlice) Append(e *HistogramBucket) {
+	(*es.orig) = append((*es.orig), *e.orig)
 }
 
 // HistogramBucket contains values for a histogram bucket.
@@ -1786,6 +1842,14 @@ func (es SummaryDataPointSlice) Resize(newLen int) {
 	(*es.orig) = oldOrig
 }
 
+// Append will increase the length of the SummaryDataPointSlice by one and set the
+// given SummaryDataPoint at that new position.  The original SummaryDataPoint
+// could still be referenced so do not reuse it after passing it to this
+// method.
+func (es SummaryDataPointSlice) Append(e *SummaryDataPoint) {
+	(*es.orig) = append((*es.orig), *e.orig)
+}
+
 // SummaryDataPoint is a single data point in a timeseries that describes the time-varying values of a Summary metric.
 //
 // This is a reference type, if passed by value and callee modifies it the
@@ -2024,6 +2088,14 @@ func (es SummaryValueAtPercentileSlice) Resize(newLen int) {
 		oldOrig = append(oldOrig, &extraOrigs[i])
 	}
 	(*es.orig) = oldOrig
+}
+
+// Append will increase the length of the SummaryValueAtPercentileSlice by one and set the
+// given SummaryValueAtPercentile at that new position.  The original SummaryValueAtPercentile
+// could still be referenced so do not reuse it after passing it to this
+// method.
+func (es SummaryValueAtPercentileSlice) Append(e *SummaryValueAtPercentile) {
+	(*es.orig) = append((*es.orig), *e.orig)
 }
 
 // SummaryValueAtPercentile represents the value at a given percentile of a distribution.

--- a/consumer/pdata/generated_metrics_test.go
+++ b/consumer/pdata/generated_metrics_test.go
@@ -126,6 +126,23 @@ func TestResourceMetricsSlice_Resize(t *testing.T) {
 	assert.EqualValues(t, NewResourceMetricsSlice(), es)
 }
 
+func TestResourceMetricsSlice_Append(t *testing.T) {
+	es := generateTestResourceMetricsSlice()
+	emptyVal := NewResourceMetrics()
+	emptyVal.InitEmpty()
+
+	es.Append(&emptyVal)
+	assert.EqualValues(t, *(es.At(7)).orig, *emptyVal.orig)
+
+	emptyVal2:= NewResourceMetrics()
+	emptyVal2.InitEmpty()
+
+	es.Append(&emptyVal2)
+	assert.EqualValues(t, *(es.At(8)).orig, *emptyVal2.orig)
+
+	assert.Equal(t, 9, es.Len())
+}
+
 func TestResourceMetrics_InitEmpty(t *testing.T) {
 	ms := NewResourceMetrics()
 	assert.True(t, ms.IsNil())
@@ -261,6 +278,23 @@ func TestInstrumentationLibraryMetricsSlice_Resize(t *testing.T) {
 	assert.EqualValues(t, NewInstrumentationLibraryMetricsSlice(), es)
 }
 
+func TestInstrumentationLibraryMetricsSlice_Append(t *testing.T) {
+	es := generateTestInstrumentationLibraryMetricsSlice()
+	emptyVal := NewInstrumentationLibraryMetrics()
+	emptyVal.InitEmpty()
+
+	es.Append(&emptyVal)
+	assert.EqualValues(t, *(es.At(7)).orig, *emptyVal.orig)
+
+	emptyVal2:= NewInstrumentationLibraryMetrics()
+	emptyVal2.InitEmpty()
+
+	es.Append(&emptyVal2)
+	assert.EqualValues(t, *(es.At(8)).orig, *emptyVal2.orig)
+
+	assert.Equal(t, 9, es.Len())
+}
+
 func TestInstrumentationLibraryMetrics_InitEmpty(t *testing.T) {
 	ms := NewInstrumentationLibraryMetrics()
 	assert.True(t, ms.IsNil())
@@ -394,6 +428,23 @@ func TestMetricSlice_Resize(t *testing.T) {
 	// Test Resize 0 elements.
 	es.Resize(0)
 	assert.EqualValues(t, NewMetricSlice(), es)
+}
+
+func TestMetricSlice_Append(t *testing.T) {
+	es := generateTestMetricSlice()
+	emptyVal := NewMetric()
+	emptyVal.InitEmpty()
+
+	es.Append(&emptyVal)
+	assert.EqualValues(t, *(es.At(7)).orig, *emptyVal.orig)
+
+	emptyVal2:= NewMetric()
+	emptyVal2.InitEmpty()
+
+	es.Append(&emptyVal2)
+	assert.EqualValues(t, *(es.At(8)).orig, *emptyVal2.orig)
+
+	assert.Equal(t, 9, es.Len())
 }
 
 func TestMetric_InitEmpty(t *testing.T) {
@@ -609,6 +660,23 @@ func TestInt64DataPointSlice_Resize(t *testing.T) {
 	assert.EqualValues(t, NewInt64DataPointSlice(), es)
 }
 
+func TestInt64DataPointSlice_Append(t *testing.T) {
+	es := generateTestInt64DataPointSlice()
+	emptyVal := NewInt64DataPoint()
+	emptyVal.InitEmpty()
+
+	es.Append(&emptyVal)
+	assert.EqualValues(t, *(es.At(7)).orig, *emptyVal.orig)
+
+	emptyVal2:= NewInt64DataPoint()
+	emptyVal2.InitEmpty()
+
+	es.Append(&emptyVal2)
+	assert.EqualValues(t, *(es.At(8)).orig, *emptyVal2.orig)
+
+	assert.Equal(t, 9, es.Len())
+}
+
 func TestInt64DataPoint_InitEmpty(t *testing.T) {
 	ms := NewInt64DataPoint()
 	assert.True(t, ms.IsNil())
@@ -761,6 +829,23 @@ func TestDoubleDataPointSlice_Resize(t *testing.T) {
 	assert.EqualValues(t, NewDoubleDataPointSlice(), es)
 }
 
+func TestDoubleDataPointSlice_Append(t *testing.T) {
+	es := generateTestDoubleDataPointSlice()
+	emptyVal := NewDoubleDataPoint()
+	emptyVal.InitEmpty()
+
+	es.Append(&emptyVal)
+	assert.EqualValues(t, *(es.At(7)).orig, *emptyVal.orig)
+
+	emptyVal2:= NewDoubleDataPoint()
+	emptyVal2.InitEmpty()
+
+	es.Append(&emptyVal2)
+	assert.EqualValues(t, *(es.At(8)).orig, *emptyVal2.orig)
+
+	assert.Equal(t, 9, es.Len())
+}
+
 func TestDoubleDataPoint_InitEmpty(t *testing.T) {
 	ms := NewDoubleDataPoint()
 	assert.True(t, ms.IsNil())
@@ -911,6 +996,23 @@ func TestHistogramDataPointSlice_Resize(t *testing.T) {
 	// Test Resize 0 elements.
 	es.Resize(0)
 	assert.EqualValues(t, NewHistogramDataPointSlice(), es)
+}
+
+func TestHistogramDataPointSlice_Append(t *testing.T) {
+	es := generateTestHistogramDataPointSlice()
+	emptyVal := NewHistogramDataPoint()
+	emptyVal.InitEmpty()
+
+	es.Append(&emptyVal)
+	assert.EqualValues(t, *(es.At(7)).orig, *emptyVal.orig)
+
+	emptyVal2:= NewHistogramDataPoint()
+	emptyVal2.InitEmpty()
+
+	es.Append(&emptyVal2)
+	assert.EqualValues(t, *(es.At(8)).orig, *emptyVal2.orig)
+
+	assert.Equal(t, 9, es.Len())
 }
 
 func TestHistogramDataPoint_InitEmpty(t *testing.T) {
@@ -1092,6 +1194,23 @@ func TestHistogramBucketSlice_Resize(t *testing.T) {
 	assert.EqualValues(t, NewHistogramBucketSlice(), es)
 }
 
+func TestHistogramBucketSlice_Append(t *testing.T) {
+	es := generateTestHistogramBucketSlice()
+	emptyVal := NewHistogramBucket()
+	emptyVal.InitEmpty()
+
+	es.Append(&emptyVal)
+	assert.EqualValues(t, *(es.At(7)).orig, *emptyVal.orig)
+
+	emptyVal2:= NewHistogramBucket()
+	emptyVal2.InitEmpty()
+
+	es.Append(&emptyVal2)
+	assert.EqualValues(t, *(es.At(8)).orig, *emptyVal2.orig)
+
+	assert.Equal(t, 9, es.Len())
+}
+
 func TestHistogramBucket_InitEmpty(t *testing.T) {
 	ms := NewHistogramBucket()
 	assert.True(t, ms.IsNil())
@@ -1269,6 +1388,23 @@ func TestSummaryDataPointSlice_Resize(t *testing.T) {
 	assert.EqualValues(t, NewSummaryDataPointSlice(), es)
 }
 
+func TestSummaryDataPointSlice_Append(t *testing.T) {
+	es := generateTestSummaryDataPointSlice()
+	emptyVal := NewSummaryDataPoint()
+	emptyVal.InitEmpty()
+
+	es.Append(&emptyVal)
+	assert.EqualValues(t, *(es.At(7)).orig, *emptyVal.orig)
+
+	emptyVal2:= NewSummaryDataPoint()
+	emptyVal2.InitEmpty()
+
+	es.Append(&emptyVal2)
+	assert.EqualValues(t, *(es.At(8)).orig, *emptyVal2.orig)
+
+	assert.Equal(t, 9, es.Len())
+}
+
 func TestSummaryDataPoint_InitEmpty(t *testing.T) {
 	ms := NewSummaryDataPoint()
 	assert.True(t, ms.IsNil())
@@ -1437,6 +1573,23 @@ func TestSummaryValueAtPercentileSlice_Resize(t *testing.T) {
 	// Test Resize 0 elements.
 	es.Resize(0)
 	assert.EqualValues(t, NewSummaryValueAtPercentileSlice(), es)
+}
+
+func TestSummaryValueAtPercentileSlice_Append(t *testing.T) {
+	es := generateTestSummaryValueAtPercentileSlice()
+	emptyVal := NewSummaryValueAtPercentile()
+	emptyVal.InitEmpty()
+
+	es.Append(&emptyVal)
+	assert.EqualValues(t, *(es.At(7)).orig, *emptyVal.orig)
+
+	emptyVal2:= NewSummaryValueAtPercentile()
+	emptyVal2.InitEmpty()
+
+	es.Append(&emptyVal2)
+	assert.EqualValues(t, *(es.At(8)).orig, *emptyVal2.orig)
+
+	assert.Equal(t, 9, es.Len())
 }
 
 func TestSummaryValueAtPercentile_InitEmpty(t *testing.T) {

--- a/consumer/pdata/generated_trace.go
+++ b/consumer/pdata/generated_trace.go
@@ -136,6 +136,14 @@ func (es ResourceSpansSlice) Resize(newLen int) {
 	(*es.orig) = oldOrig
 }
 
+// Append will increase the length of the ResourceSpansSlice by one and set the
+// given ResourceSpans at that new position.  The original ResourceSpans
+// could still be referenced so do not reuse it after passing it to this
+// method.
+func (es ResourceSpansSlice) Append(e *ResourceSpans) {
+	(*es.orig) = append((*es.orig), *e.orig)
+}
+
 // InstrumentationLibrarySpans is a collection of spans from a LibraryInstrumentation.
 //
 // This is a reference type, if passed by value and callee modifies it the
@@ -319,6 +327,14 @@ func (es InstrumentationLibrarySpansSlice) Resize(newLen int) {
 	(*es.orig) = oldOrig
 }
 
+// Append will increase the length of the InstrumentationLibrarySpansSlice by one and set the
+// given InstrumentationLibrarySpans at that new position.  The original InstrumentationLibrarySpans
+// could still be referenced so do not reuse it after passing it to this
+// method.
+func (es InstrumentationLibrarySpansSlice) Append(e *InstrumentationLibrarySpans) {
+	(*es.orig) = append((*es.orig), *e.orig)
+}
+
 // InstrumentationLibrarySpans is a collection of spans from a LibraryInstrumentation.
 //
 // This is a reference type, if passed by value and callee modifies it the
@@ -500,6 +516,14 @@ func (es SpanSlice) Resize(newLen int) {
 		oldOrig = append(oldOrig, &extraOrigs[i])
 	}
 	(*es.orig) = oldOrig
+}
+
+// Append will increase the length of the SpanSlice by one and set the
+// given Span at that new position.  The original Span
+// could still be referenced so do not reuse it after passing it to this
+// method.
+func (es SpanSlice) Append(e *Span) {
+	(*es.orig) = append((*es.orig), *e.orig)
 }
 
 // Span represents a single operation within a trace.
@@ -867,6 +891,14 @@ func (es SpanEventSlice) Resize(newLen int) {
 	(*es.orig) = oldOrig
 }
 
+// Append will increase the length of the SpanEventSlice by one and set the
+// given SpanEvent at that new position.  The original SpanEvent
+// could still be referenced so do not reuse it after passing it to this
+// method.
+func (es SpanEventSlice) Append(e *SpanEvent) {
+	(*es.orig) = append((*es.orig), *e.orig)
+}
+
 // SpanEvent is a time-stamped annotation of the span, consisting of user-supplied
 // text description and key-value pairs. See OTLP for event definition.
 //
@@ -1083,6 +1115,14 @@ func (es SpanLinkSlice) Resize(newLen int) {
 		oldOrig = append(oldOrig, &extraOrigs[i])
 	}
 	(*es.orig) = oldOrig
+}
+
+// Append will increase the length of the SpanLinkSlice by one and set the
+// given SpanLink at that new position.  The original SpanLink
+// could still be referenced so do not reuse it after passing it to this
+// method.
+func (es SpanLinkSlice) Append(e *SpanLink) {
+	(*es.orig) = append((*es.orig), *e.orig)
 }
 
 // SpanLink is a pointer from the current span to another span in the same trace or in a

--- a/consumer/pdata/generated_trace_test.go
+++ b/consumer/pdata/generated_trace_test.go
@@ -126,6 +126,23 @@ func TestResourceSpansSlice_Resize(t *testing.T) {
 	assert.EqualValues(t, NewResourceSpansSlice(), es)
 }
 
+func TestResourceSpansSlice_Append(t *testing.T) {
+	es := generateTestResourceSpansSlice()
+	emptyVal := NewResourceSpans()
+	emptyVal.InitEmpty()
+
+	es.Append(&emptyVal)
+	assert.EqualValues(t, *(es.At(7)).orig, *emptyVal.orig)
+
+	emptyVal2:= NewResourceSpans()
+	emptyVal2.InitEmpty()
+
+	es.Append(&emptyVal2)
+	assert.EqualValues(t, *(es.At(8)).orig, *emptyVal2.orig)
+
+	assert.Equal(t, 9, es.Len())
+}
+
 func TestResourceSpans_InitEmpty(t *testing.T) {
 	ms := NewResourceSpans()
 	assert.True(t, ms.IsNil())
@@ -261,6 +278,23 @@ func TestInstrumentationLibrarySpansSlice_Resize(t *testing.T) {
 	assert.EqualValues(t, NewInstrumentationLibrarySpansSlice(), es)
 }
 
+func TestInstrumentationLibrarySpansSlice_Append(t *testing.T) {
+	es := generateTestInstrumentationLibrarySpansSlice()
+	emptyVal := NewInstrumentationLibrarySpans()
+	emptyVal.InitEmpty()
+
+	es.Append(&emptyVal)
+	assert.EqualValues(t, *(es.At(7)).orig, *emptyVal.orig)
+
+	emptyVal2:= NewInstrumentationLibrarySpans()
+	emptyVal2.InitEmpty()
+
+	es.Append(&emptyVal2)
+	assert.EqualValues(t, *(es.At(8)).orig, *emptyVal2.orig)
+
+	assert.Equal(t, 9, es.Len())
+}
+
 func TestInstrumentationLibrarySpans_InitEmpty(t *testing.T) {
 	ms := NewInstrumentationLibrarySpans()
 	assert.True(t, ms.IsNil())
@@ -394,6 +428,23 @@ func TestSpanSlice_Resize(t *testing.T) {
 	// Test Resize 0 elements.
 	es.Resize(0)
 	assert.EqualValues(t, NewSpanSlice(), es)
+}
+
+func TestSpanSlice_Append(t *testing.T) {
+	es := generateTestSpanSlice()
+	emptyVal := NewSpan()
+	emptyVal.InitEmpty()
+
+	es.Append(&emptyVal)
+	assert.EqualValues(t, *(es.At(7)).orig, *emptyVal.orig)
+
+	emptyVal2:= NewSpan()
+	emptyVal2.InitEmpty()
+
+	es.Append(&emptyVal2)
+	assert.EqualValues(t, *(es.At(8)).orig, *emptyVal2.orig)
+
+	assert.Equal(t, 9, es.Len())
 }
 
 func TestSpan_InitEmpty(t *testing.T) {
@@ -648,6 +699,23 @@ func TestSpanEventSlice_Resize(t *testing.T) {
 	assert.EqualValues(t, NewSpanEventSlice(), es)
 }
 
+func TestSpanEventSlice_Append(t *testing.T) {
+	es := generateTestSpanEventSlice()
+	emptyVal := NewSpanEvent()
+	emptyVal.InitEmpty()
+
+	es.Append(&emptyVal)
+	assert.EqualValues(t, *(es.At(7)).orig, *emptyVal.orig)
+
+	emptyVal2:= NewSpanEvent()
+	emptyVal2.InitEmpty()
+
+	es.Append(&emptyVal2)
+	assert.EqualValues(t, *(es.At(8)).orig, *emptyVal2.orig)
+
+	assert.Equal(t, 9, es.Len())
+}
+
 func TestSpanEvent_InitEmpty(t *testing.T) {
 	ms := NewSpanEvent()
 	assert.True(t, ms.IsNil())
@@ -798,6 +866,23 @@ func TestSpanLinkSlice_Resize(t *testing.T) {
 	// Test Resize 0 elements.
 	es.Resize(0)
 	assert.EqualValues(t, NewSpanLinkSlice(), es)
+}
+
+func TestSpanLinkSlice_Append(t *testing.T) {
+	es := generateTestSpanLinkSlice()
+	emptyVal := NewSpanLink()
+	emptyVal.InitEmpty()
+
+	es.Append(&emptyVal)
+	assert.EqualValues(t, *(es.At(7)).orig, *emptyVal.orig)
+
+	emptyVal2:= NewSpanLink()
+	emptyVal2.InitEmpty()
+
+	es.Append(&emptyVal2)
+	assert.EqualValues(t, *(es.At(8)).orig, *emptyVal2.orig)
+
+	assert.Equal(t, 9, es.Len())
 }
 
 func TestSpanLink_InitEmpty(t *testing.T) {


### PR DESCRIPTION
This makes it a bit more convenient to assemble data structures.

It is also congruent with the existing Go slice functionality with
the same name.