### PR TITLE
testbed improvements

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,9 +48,11 @@ require (
 	github.com/tcnksm/ghr v0.13.0
 	github.com/uber/jaeger-lib v2.2.0+incompatible
 	go.opencensus.io v0.22.3
+	go.uber.org/atomic v1.5.1
 	go.uber.org/zap v1.13.0
 	golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e
 	golang.org/x/sys v0.0.0-20200408040146-ea54a3c99b9b
+	golang.org/x/text v0.3.2
 	golang.org/x/tools v0.0.0-20200428211428-0c9eba77bc32 // indirect
 	google.golang.org/api v0.10.0 // indirect
 	google.golang.org/genproto v0.0.0-20200408120641-fbb3ad325eb7

--- a/testbed/testbed/mock_backend.go
+++ b/testbed/testbed/mock_backend.go
@@ -119,7 +119,7 @@ func (mb *MockBackend) EnableRecording() {
 
 func (mb *MockBackend) GetStats() string {
 	received := mb.DataItemsReceived()
-	return printer.Sprintf("Received:%10d items (%d/sec)", received, int(float64(received) / time.Since(mb.startedAt).Seconds()))
+	return printer.Sprintf("Received:%10d items (%d/sec)", received, int(float64(received)/time.Since(mb.startedAt).Seconds()))
 }
 
 // DataItemsReceived returns total number of received spans and metrics.

--- a/testbed/testbed/mock_backend.go
+++ b/testbed/testbed/mock_backend.go
@@ -16,11 +16,12 @@ package testbed
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"os"
 	"sync"
-	"sync/atomic"
+	"time"
+
+	"go.uber.org/atomic"
 
 	"go.opentelemetry.io/collector/consumer/consumerdata"
 	"go.opentelemetry.io/collector/consumer/pdata"
@@ -42,6 +43,7 @@ type MockBackend struct {
 	// Start/stop flags
 	isStarted bool
 	stopOnce  sync.Once
+	startedAt time.Time
 
 	// Recording fields.
 	isRecording        bool
@@ -87,6 +89,7 @@ func (mb *MockBackend) Start() error {
 	}
 
 	mb.isStarted = true
+	mb.startedAt = time.Now()
 	return nil
 }
 
@@ -115,12 +118,13 @@ func (mb *MockBackend) EnableRecording() {
 }
 
 func (mb *MockBackend) GetStats() string {
-	return fmt.Sprintf("Received:%5d items", mb.DataItemsReceived())
+	received := mb.DataItemsReceived()
+	return printer.Sprintf("Received:%10d items (%d/sec)", received, int(float64(received) / time.Since(mb.startedAt).Seconds()))
 }
 
 // DataItemsReceived returns total number of received spans and metrics.
 func (mb *MockBackend) DataItemsReceived() uint64 {
-	return atomic.LoadUint64(&mb.tc.spansReceived) + atomic.LoadUint64(&mb.mc.metricsReceived)
+	return mb.tc.spansReceived.Load() + mb.mc.metricsReceived.Load()
 }
 
 // ClearReceivedItems clears the list of received traces and metrics. Note: counters
@@ -169,12 +173,12 @@ func (mb *MockBackend) ConsumeMetricOld(md consumerdata.MetricsData) {
 }
 
 type MockTraceConsumer struct {
-	spansReceived uint64
+	spansReceived atomic.Uint64
 	backend       *MockBackend
 }
 
 func (tc *MockTraceConsumer) ConsumeTraces(ctx context.Context, td pdata.Traces) error {
-	atomic.AddUint64(&tc.spansReceived, uint64(td.SpanCount()))
+	tc.spansReceived.Add(uint64(td.SpanCount()))
 
 	rs := td.ResourceSpans()
 	for i := 0; i < rs.Len(); i++ {
@@ -210,7 +214,7 @@ func (tc *MockTraceConsumer) ConsumeTraces(ctx context.Context, td pdata.Traces)
 }
 
 func (tc *MockTraceConsumer) ConsumeTraceData(ctx context.Context, td consumerdata.TraceData) error {
-	atomic.AddUint64(&tc.spansReceived, uint64(len(td.Spans)))
+	tc.spansReceived.Add(uint64(len(td.Spans)))
 
 	for _, span := range td.Spans {
 		var spanSeqnum int64
@@ -240,13 +244,13 @@ func (tc *MockTraceConsumer) ConsumeTraceData(ctx context.Context, td consumerda
 }
 
 type MockMetricConsumer struct {
-	metricsReceived uint64
+	metricsReceived atomic.Uint64
 	backend         *MockBackend
 }
 
 func (mc *MockMetricConsumer) ConsumeMetrics(_ context.Context, md pdata.Metrics) error {
 	_, dataPoints := pdatautil.MetricAndDataPointCount(md)
-	atomic.AddUint64(&mc.metricsReceived, uint64(dataPoints))
+	mc.metricsReceived.Add(uint64(dataPoints))
 	mc.backend.ConsumeMetric(md)
 	return nil
 }
@@ -259,7 +263,7 @@ func (mc *MockMetricConsumer) ConsumeMetricsData(ctx context.Context, md consume
 		}
 	}
 
-	atomic.AddUint64(&mc.metricsReceived, uint64(dataPoints))
+	mc.metricsReceived.Add(uint64(dataPoints))
 
 	mc.backend.ConsumeMetricOld(md)
 

--- a/testbed/testbed/mock_backend_test.go
+++ b/testbed/testbed/mock_backend_test.go
@@ -3,7 +3,7 @@
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-////     http://www.apache.org/licenses/LICENSE-2.0
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -57,7 +57,7 @@ func TestGeneratorAndBackend(t *testing.T) {
 			lg, err := NewLoadGenerator(dataProvider, test.sender)
 			require.NoError(t, err, "Cannot start load generator")
 
-			assert.EqualValues(t, 0, lg.dataItemsSent)
+			assert.EqualValues(t, 0, lg.dataItemsSent.Load())
 
 			// Generate at 1000 SPS
 			lg.Start(LoadOptions{DataItemsPerSecond: 1000})

--- a/testbed/testbed/mock_backend_test.go
+++ b/testbed/testbed/mock_backend_test.go
@@ -52,7 +52,7 @@ func TestGeneratorAndBackend(t *testing.T) {
 
 			defer mb.Stop()
 
-			options := LoadOptions{DataItemsPerSecond: 10000, ItemsPerBatch: 10}
+			options := LoadOptions{DataItemsPerSecond: 10_000, ItemsPerBatch: 10}
 			dataProvider := NewPerfTestDataProvider(options)
 			lg, err := NewLoadGenerator(dataProvider, test.sender)
 			require.NoError(t, err, "Cannot start load generator")

--- a/testbed/testbed/test_case.go
+++ b/testbed/testbed/test_case.go
@@ -347,7 +347,7 @@ func (tc *TestCase) logStats() {
 }
 
 func (tc *TestCase) logStatsOnce() {
-	log.Printf("%s, %s, %s",
+	log.Printf("%s | %s | %s",
 		tc.agentProc.GetResourceConsumption(),
 		tc.LoadGenerator.GetStats(),
 		tc.MockBackend.GetStats())

--- a/testbed/tests/e2e_test.go
+++ b/testbed/tests/e2e_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 func TestIdleMode(t *testing.T) {
-	options := testbed.LoadOptions{DataItemsPerSecond: 10000, ItemsPerBatch: 10}
+	options := testbed.LoadOptions{DataItemsPerSecond: 10_000, ItemsPerBatch: 10}
 	dataProvider := testbed.NewPerfTestDataProvider(options)
 	tc := testbed.NewTestCase(
 		t,
@@ -58,7 +58,7 @@ func TestBallastMemory(t *testing.T) {
 		{1000, 100},
 	}
 
-	options := testbed.LoadOptions{DataItemsPerSecond: 10000, ItemsPerBatch: 10}
+	options := testbed.LoadOptions{DataItemsPerSecond: 10_000, ItemsPerBatch: 10}
 	dataProvider := testbed.NewPerfTestDataProvider(options)
 	for _, test := range tests {
 		tc := testbed.NewTestCase(

--- a/testbed/tests/metric_test.go
+++ b/testbed/tests/metric_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestMetricNoBackend10kDPSOpenCensus(t *testing.T) {
-	options := testbed.LoadOptions{DataItemsPerSecond: 10000, ItemsPerBatch: 10}
+	options := testbed.LoadOptions{DataItemsPerSecond: 10_000, ItemsPerBatch: 10}
 	dataProvider := testbed.NewPerfTestDataProvider(options)
 	tc := testbed.NewTestCase(
 		t,
@@ -40,7 +40,7 @@ func TestMetricNoBackend10kDPSOpenCensus(t *testing.T) {
 	tc.SetResourceLimits(testbed.ResourceSpec{ExpectedMaxCPU: 200, ExpectedMaxRAM: 200})
 	tc.StartAgent()
 
-	tc.StartLoad(testbed.LoadOptions{DataItemsPerSecond: 10000})
+	tc.StartLoad(testbed.LoadOptions{DataItemsPerSecond: 10_000})
 
 	tc.Sleep(tc.Duration)
 }

--- a/testbed/tests/scenarios.go
+++ b/testbed/tests/scenarios.go
@@ -26,11 +26,15 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/text/message"
 
 	"go.opentelemetry.io/collector/testbed/testbed"
 )
 
-var performanceResultsSummary testbed.TestResultsSummary = &testbed.PerformanceResults{}
+var (
+	performanceResultsSummary testbed.TestResultsSummary = &testbed.PerformanceResults{}
+	printer = message.NewPrinter(message.MatchLanguage("en"))
+)
 
 // createConfigYaml creates a collector config file that corresponds to the
 // sender and receiver used in the test and returns the config file name.
@@ -123,7 +127,7 @@ func Scenario10kItemsPerSecond(
 	require.NoError(t, err)
 
 	options := testbed.LoadOptions{
-		DataItemsPerSecond: 10000,
+		DataItemsPerSecond: 10_000,
 		ItemsPerBatch:      100,
 	}
 	agentProc := &testbed.ChildProcess{}

--- a/testbed/tests/scenarios.go
+++ b/testbed/tests/scenarios.go
@@ -33,7 +33,7 @@ import (
 
 var (
 	performanceResultsSummary testbed.TestResultsSummary = &testbed.PerformanceResults{}
-	printer = message.NewPrinter(message.MatchLanguage("en"))
+	printer                                              = message.NewPrinter(message.MatchLanguage("en"))
 )
 
 // createConfigYaml creates a collector config file that corresponds to the


### PR DESCRIPTION
* Use atomic wrappers for readability and for preventing accidentally accessing atomic variables
  non-atomically.
* Enhance readability of large numbers in testbed by formatting with thousands separator.
* Include rate per second in testbed output.

---
New output looks like:

```
2020/06/22 14:03:09 Starting load generator at 10000 items/sec.
2020/06/22 14:03:12 Agent RAM (RES):   1 MiB, CPU: 0.0% | Sent:   186,200 items | Received:   186,200 items (62,078/sec)
2020/06/22 14:03:15 Agent RAM (RES):  36 MiB, CPU:24.9% | Sent:   396,200 items | Received:   396,200 items (66,040/sec)
2020/06/22 14:03:18 Agent RAM (RES):  36 MiB, CPU:24.7% | Sent:   606,200 items | Received:   606,200 items (67,359/sec)
2020/06/22 14:03:21 Agent RAM (RES):  36 MiB, CPU:25.3% | Sent:   816,200 items | Received:   816,200 items (68,020/sec)
2020/06/22 14:03:24 Agent RAM (RES):  36 MiB, CPU:23.7% | Sent: 1,026,200 items | Received: 1,026,200 items (68,415/sec)
```