### PR TITLE
Continue attribute regex support from PR 981

### DIFF
--- a/processor/attributesprocessor/README.md
+++ b/processor/attributesprocessor/README.md
@@ -16,6 +16,9 @@ The supported actions are:
   does exist.
 - `delete`: Deletes an attribute from a span.
 - `hash`: Hashes (SHA1) an existing attribute value.
+- `extract`: Extracts values using a regular expression rule from the input key
+  to target keys specified in the rule. If a target key already exists, it will
+  be overridden.
 
 For the actions `insert`, `update` and `upsert`,
  - `key`  is required
@@ -55,6 +58,22 @@ For the `hash` action,
 - key: <key>
   action: hash
 ```
+
+
+For the `extract` action,
+ - `key` is required and will
+ ```yaml
+ # Key specifies the attribute to extract values from.
+ # The value of `key` is NOT altered.
+- key: <key>
+  # Rule specifies the regex pattern used to extract attributes from the value
+  # of `key`.
+  # The submatchers must be named.
+  # If attributes already exist, they will be overwritten.
+  pattern: <regular pattern with named matchers>
+  action: extract
+
+ ```
 
 The list of actions can be composed to create rich scenarios, such as
 back filling attribute, copying values to a new key, redacting sensitive information.

--- a/processor/attributesprocessor/README.md
+++ b/processor/attributesprocessor/README.md
@@ -18,7 +18,8 @@ The supported actions are:
 - `hash`: Hashes (SHA1) an existing attribute value.
 - `extract`: Extracts values using a regular expression rule from the input key
   to target keys specified in the rule. If a target key already exists, it will
-  be overridden.
+  be overridden. Note: It behaves similar to the Span Processor `to_attributes`
+  setting with the existing attribute as the source.
 
 For the actions `insert`, `update` and `upsert`,
  - `key`  is required
@@ -61,7 +62,8 @@ For the `hash` action,
 
 
 For the `extract` action,
- - `key` is required and will
+ - `key` is required
+ - `pattern` is required.
  ```yaml
  # Key specifies the attribute to extract values from.
  # The value of `key` is NOT altered.

--- a/processor/attributesprocessor/attributes_test.go
+++ b/processor/attributesprocessor/attributes_test.go
@@ -418,7 +418,7 @@ func TestAttributes_UpsertValue(t *testing.T) {
 	}
 }
 
-func TestAttributes_UpsertFromRegex(t *testing.T) {
+func TestAttributes_Extract(t *testing.T) {
 	testCases := []testCase{
 		// Ensure `new_user_key` is not set for spans with no attributes.
 		{
@@ -428,7 +428,7 @@ func TestAttributes_UpsertFromRegex(t *testing.T) {
 		},
 		// Ensure `new_user_key` is not inserted for spans with missing attribute `user_key`.
 		{
-			name: "UpsertFromRegexNoExist",
+			name: "No extract with no target key",
 			inputAttributes: map[string]pdata.AttributeValue{
 				"boo": pdata.NewAttributeValueString("ghosts are scary"),
 			},
@@ -436,9 +436,22 @@ func TestAttributes_UpsertFromRegex(t *testing.T) {
 				"boo": pdata.NewAttributeValueString("ghosts are scary"),
 			},
 		},
-		// Ensure `new_user_key` is not updated for spans with attribute `user_key` that does not match regex.
+		// Ensure `new_user_key` is not inserted for spans with missing attribute `user_key`.
 		{
-			name: "UpsertFromRegexNotMatch",
+			name: "No extract with non string target key",
+			inputAttributes: map[string]pdata.AttributeValue{
+				"boo":      pdata.NewAttributeValueString("ghosts are scary"),
+				"user_key": pdata.NewAttributeValueInt(1234),
+			},
+			expectedAttributes: map[string]pdata.AttributeValue{
+				"boo":      pdata.NewAttributeValueString("ghosts are scary"),
+				"user_key": pdata.NewAttributeValueInt(1234),
+			},
+		},
+		// Ensure `new_user_key` is not updated for spans with attribute
+		// `user_key` because `user_key` does not match the regular expression.
+		{
+			name: "No extract with no pattern matching",
 			inputAttributes: map[string]pdata.AttributeValue{
 				"user_key": pdata.NewAttributeValueString("does not match"),
 				"boo":      pdata.NewAttributeValueString("ghosts are scary"),
@@ -448,30 +461,62 @@ func TestAttributes_UpsertFromRegex(t *testing.T) {
 				"boo":      pdata.NewAttributeValueString("ghosts are scary"),
 			},
 		},
-		// Ensure `new_user_key` is inserted for spans with attribute `user_key`.
+		// Ensure `new_user_key` is not updated for spans with attribute
+		// `user_key` because `user_key` does not match all of the regular
+		// expression.
 		{
-			name: "UpsertFromRegexExistsInsert",
+			name: "No extract with no pattern matching",
 			inputAttributes: map[string]pdata.AttributeValue{
 				"user_key": pdata.NewAttributeValueString("/api/v1/document/12345678/update"),
+				"boo":      pdata.NewAttributeValueString("ghosts are scary"),
+			},
+			expectedAttributes: map[string]pdata.AttributeValue{
+				"user_key": pdata.NewAttributeValueString("/api/v1/document/12345678/update"),
+				"boo":      pdata.NewAttributeValueString("ghosts are scary"),
+			},
+		},
+		// Ensure `new_user_key` and `version` is inserted for spans with attribute `user_key`.
+		{
+			name: "Extract insert new values.",
+			inputAttributes: map[string]pdata.AttributeValue{
+				"user_key": pdata.NewAttributeValueString("/api/v1/document/12345678/update/v1"),
 				"foo":      pdata.NewAttributeValueString("casper the friendly ghost"),
 			},
 			expectedAttributes: map[string]pdata.AttributeValue{
-				"user_key":     pdata.NewAttributeValueString("/api/v1/document/12345678/update"),
+				"user_key":     pdata.NewAttributeValueString("/api/v1/document/12345678/update/v1"),
 				"new_user_key": pdata.NewAttributeValueString("12345678"),
+				"version":      pdata.NewAttributeValueString("v1"),
 				"foo":          pdata.NewAttributeValueString("casper the friendly ghost"),
 			},
 		},
-		// Ensure `new_user_key` is updated for spans with attribute `user_key`.
+		// Ensure `new_user_key` and `version` is updated for spans with attribute `user_key`.
 		{
-			name: "UpsertFromRegexExistsUpdate",
+			name: "Extract updates existing values ",
 			inputAttributes: map[string]pdata.AttributeValue{
-				"user_key":     pdata.NewAttributeValueString("/api/v1/document/12345678/update"),
+				"user_key":     pdata.NewAttributeValueString("/api/v1/document/12345678/update/v1"),
+				"new_user_key": pdata.NewAttributeValueString("2321"),
+				"version":      pdata.NewAttributeValueString("na"),
+				"foo":          pdata.NewAttributeValueString("casper the friendly ghost"),
+			},
+			expectedAttributes: map[string]pdata.AttributeValue{
+				"user_key":     pdata.NewAttributeValueString("/api/v1/document/12345678/update/v1"),
+				"new_user_key": pdata.NewAttributeValueString("12345678"),
+				"version":      pdata.NewAttributeValueString("v1"),
+				"foo":          pdata.NewAttributeValueString("casper the friendly ghost"),
+			},
+		},
+		// Ensure `new_user_key` is updated and `version` is inserted for spans with attribute `user_key`.
+		{
+			name: "Extract upserts values",
+			inputAttributes: map[string]pdata.AttributeValue{
+				"user_key":     pdata.NewAttributeValueString("/api/v1/document/12345678/update/v1"),
 				"new_user_key": pdata.NewAttributeValueString("2321"),
 				"foo":          pdata.NewAttributeValueString("casper the friendly ghost"),
 			},
 			expectedAttributes: map[string]pdata.AttributeValue{
-				"user_key":     pdata.NewAttributeValueString("/api/v1/document/12345678/update"),
+				"user_key":     pdata.NewAttributeValueString("/api/v1/document/12345678/update/v1"),
 				"new_user_key": pdata.NewAttributeValueString("12345678"),
+				"version":      pdata.NewAttributeValueString("v1"),
 				"foo":          pdata.NewAttributeValueString("casper the friendly ghost"),
 			},
 		},
@@ -481,7 +526,7 @@ func TestAttributes_UpsertFromRegex(t *testing.T) {
 	cfg := factory.CreateDefaultConfig()
 	oCfg := cfg.(*Config)
 	oCfg.Actions = []ActionKeyValue{
-		{Regex: "^\\/api\\/v1\\/document\\/(?P<new_user_key>.*)\\/update$", Action: UPSERT, FromAttribute: "user_key"},
+		{Key: "user_key", RegexPattern: "^\\/api\\/v1\\/document\\/(?P<new_user_key>.*)\\/update\\/(?P<version>.*)$", Action: EXTRACT},
 	}
 
 	tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{}, exportertest.NewNopTraceExporter(), cfg)

--- a/processor/attributesprocessor/config.go
+++ b/processor/attributesprocessor/config.go
@@ -47,6 +47,11 @@ type ActionKeyValue struct {
 	// The type of the value is inferred from the configuration.
 	Value interface{} `mapstructure:"value"`
 
+	// A regex may be specified in place of a value for INSERT, UPDATE or UPSERT
+	// The keys will be inferred based on the names of the matcher groups provided
+	// And the names will be inferred based on the values of the matcher group
+	Regex string `mapstructure:"regex"`
+
 	// FromAttribute specifies the attribute from the span to use to populate
 	// the value. If the attribute doesn't exist, no action is performed.
 	FromAttribute string `mapstructure:"from_attribute"`

--- a/processor/attributesprocessor/config.go
+++ b/processor/attributesprocessor/config.go
@@ -47,10 +47,15 @@ type ActionKeyValue struct {
 	// The type of the value is inferred from the configuration.
 	Value interface{} `mapstructure:"value"`
 
-	// A regex may be specified in place of a value for INSERT, UPDATE or UPSERT
-	// The keys will be inferred based on the names of the matcher groups provided
-	// And the names will be inferred based on the values of the matcher group
-	Regex string `mapstructure:"regex"`
+	// A regex pattern  must be specified for the action EXTRACT.
+	// It uses the attribute specified by `key' to extract values from
+	// The target keys are inferred based on the names of the matcher groups
+	// provided and the names will be inferred based on the values of the
+	// matcher group.
+	// Note: All subexpressions must have a name.
+	// Note: The value type of the source key must be a string. If it isn't,
+	// no extraction will occur.
+	RegexPattern string `mapstructure:"pattern"`
 
 	// FromAttribute specifies the attribute from the span to use to populate
 	// the value. If the attribute doesn't exist, no action is performed.
@@ -59,19 +64,24 @@ type ActionKeyValue struct {
 	// Action specifies the type of action to perform.
 	// The set of values are {INSERT, UPDATE, UPSERT, DELETE, HASH}.
 	// Both lower case and upper case are supported.
-	// INSERT - Inserts the key/value to spans when the key does not exist.
-	//          No action is applied to spans where the key already exists.
-	//          Either Value or FromAttribute must be set.
-	// UPDATE - Updates an existing key with a value. No action is applied
-	//          to spans where the key does not exist.
-	//          Either Value or FromAttribute must be set.
-	// UPSERT - Performs insert or update action depending on the span
-	//          containing the key. The key/value is insert to spans
-	//          that did not originally have the key. The key/value is updated
-	//          for spans where the key already existed.
-	//          Either Value or FromAttribute must be set.
-	// DELETE - Deletes the attribute from the span. If the key doesn't exist,
-	//          no action is performed.
+	// INSERT -  Inserts the key/value to spans when the key does not exist.
+	//           No action is applied to spans where the key already exists.
+	//           Either Value or FromAttribute must be set.
+	// UPDATE -  Updates an existing key with a value. No action is applied
+	//           to spans where the key does not exist.
+	//           Either Value or FromAttribute must be set.
+	// UPSERT -  Performs insert or update action depending on the span
+	//           containing the key. The key/value is insert to spans
+	//           that did not originally have the key. The key/value is updated
+	//           for spans where the key already existed.
+	//           Either Value or FromAttribute must be set.
+	// DELETE  - Deletes the attribute from the span. If the key doesn't exist,
+	//           no action is performed.
+	// HASH    - Calculates the SHA-1 hash of an existing value and overwrites the
+	//           value with it's SHA-1 hash result.
+	// EXTRACT - Extracts values using a regular expression rule from the input
+	//           'key' to target keys specified in the 'rule'. If a target key
+	//           already exists, it will be overridden.
 	// This is a required field.
 	Action Action `mapstructure:"action"`
 }
@@ -95,10 +105,15 @@ const (
 	UPSERT Action = "upsert"
 
 	// DELETE deletes the attribute from the span. If the key doesn't exist,
-	//no action is performed.
+	// no action is performed.
 	DELETE Action = "delete"
 
-	// HASH calculates the SHA-1 hash of an existing value and overwrites the value
-	// with it's SHA-1 hash result.
+	// HASH calculates the SHA-1 hash of an existing value and overwrites the
+	// value with it's SHA-1 hash result.
 	HASH Action = "hash"
+
+	// EXTRACT extracts values using a regular expression rule from the input
+	// 'key' to target keys specified in the 'rule'. If a target key already
+	// exists, it will be overridden.
+	EXTRACT Action = "extract"
 )

--- a/processor/attributesprocessor/factory_test.go
+++ b/processor/attributesprocessor/factory_test.go
@@ -166,7 +166,7 @@ func TestFactory_validateActionsConfiguration_InvalidConfig(t *testing.T) {
 			actionLists: []ActionKeyValue{
 				{Key: "key", RegexPattern: "(?P<operation_website>.*?)$", FromAttribute: "aa", Action: INSERT},
 			},
-			errorString:"error creating \"attributes\" processor. Action \"insert\" does not use the \"pattern\" field. This must not be specified for 0-th action of processor \"attributes/error\"",
+			errorString: "error creating \"attributes\" processor. Action \"insert\" does not use the \"pattern\" field. This must not be specified for 0-th action of processor \"attributes/error\"",
 		},
 		{
 			name: "missing rule for extract",

--- a/processor/attributesprocessor/factory_test.go
+++ b/processor/attributesprocessor/factory_test.go
@@ -173,7 +173,7 @@ func TestFactory_validateActionsConfiguration_InvalidConfig(t *testing.T) {
 			actionLists: []ActionKeyValue{
 				{Value: "value", Regex: "(?P<operation_website>.*?)$", FromAttribute: "aa", Action: UPSERT},
 			},
-			errorString: "error creating \"attributes\" processor. Only of field \"value\" or \"regex\" setting must be specified for 0-th action of processor \"attributes/error\"",
+			errorString: "error creating \"attributes\" processor due to both fields \"value\" and \"regex\" being set at the 0-th actions of processor \"attributes/error\"",
 		},
 		{
 			name: "regex and not from attribute",
@@ -195,6 +195,20 @@ func TestFactory_validateActionsConfiguration_InvalidConfig(t *testing.T) {
 				{Regex: "(?P<operation_website>.*?)$", Key: "", Value: 123, Action: DELETE},
 			},
 			errorString: "error creating \"attributes\" processor. Action \"DELETE\" does not use \"value\", \"regex\" or \"from_attribute\" field. These must not be specified for 0-th action of processor \"attributes/error\"",
+		},
+		{
+			name: "regex with unnamed capture group",
+			actionLists: []ActionKeyValue{
+				{Regex: "(.*)$", FromAttribute: "aa", Action: UPSERT},
+			},
+			errorString: "error creating \"attributes\" processor. Field \"regex\" contains an unnamed matcher group at the 0-th actions of processor \"attributes/error\"",
+		},
+		{
+			name: "regex with no named capture groups",
+			actionLists: []ActionKeyValue{
+				{Regex: ".*", FromAttribute: "aa", Action: UPSERT},
+			},
+			errorString: "error creating \"attributes\" processor. Field \"regex\" contains no named matcher groups at the 0-th actions of processor \"attributes/error\"",
 		},
 	}
 	factory := Factory{}

--- a/processor/attributesprocessor/testdata/config.yaml
+++ b/processor/attributesprocessor/testdata/config.yaml
@@ -19,6 +19,19 @@ processors:
         from_attribute: "anotherkey"
         action: insert
 
+  # The following example demonstrates using regex to create new attributes based on the value of another attribute.
+  attributes/regex_insert:
+    actions:
+      # The following uses the value from attribute "http.url" to insert new attributes
+      # Given http.url = http://example.com/path?queryParam1=value1,queryParam2=value2 then the following attributes will be inserted:
+      # http_protocol: http
+      # http_domain: example.com
+      # http_path: path
+      # http_query_params=queryParam1=value1,queryParam2=value2
+      - regex: ^(?P<http_protocol>.*):\/\/(?P<http_domain>.*)\/(?P<http_path>.*)(\?|\&)(?P<http_query_params>.*)
+        from_attribute: "http.url"
+        action: insert
+
   # The following demonstrates configuring the processor to only update existing
   # keys in an attribute.
   # Note: `action: update` must be set.

--- a/processor/attributesprocessor/testdata/config.yaml
+++ b/processor/attributesprocessor/testdata/config.yaml
@@ -19,18 +19,26 @@ processors:
         from_attribute: "anotherkey"
         action: insert
 
-  # The following example demonstrates using regex to create new attributes based on the value of another attribute.
+  # The following example demonstrates using regex to create new attributes
+  # based on the value of another attribute.
   attributes/regex_insert:
     actions:
-      # The following uses the value from attribute "http.url" to insert new attributes
-      # Given http.url = http://example.com/path?queryParam1=value1,queryParam2=value2 then the following attributes will be inserted:
+      # The following uses the value from `key:http.url` to upsert attributes
+      # to the target keys specified in the `rule`.
+      # (Insert attributes for target keys that do not exist and update keys
+      # that exist.)
+      # Given http.url = http://example.com/path?queryParam1=value1,queryParam2=value2
+      # then the following attributes will be inserted:
       # http_protocol: http
       # http_domain: example.com
       # http_path: path
       # http_query_params=queryParam1=value1,queryParam2=value2
-      - regex: ^(?P<http_protocol>.*):\/\/(?P<http_domain>.*)\/(?P<http_path>.*)(\?|\&)(?P<http_query_params>.*)
-        from_attribute: "http.url"
-        action: insert
+      # http.url value does NOT change.
+      # Note: Similar to the Span Procesor, if a target key already exists,
+      # it will be updated.
+      - key: "http.url"
+        pattern: ^(?P<http_protocol>.*):\/\/(?P<http_domain>.*)\/(?P<http_path>.*)(\?|\&)(?P<http_query_params>.*)
+        action: extract
 
   # The following demonstrates configuring the processor to only update existing
   # keys in an attribute.


### PR DESCRIPTION
**Description:** Note: All of the cudos go to @dneray for the logic/testing/effort in https://github.com/open-telemetry/opentelemetry-collector/pull/981

This pr is based off of it with the following modifications

- The config looks like
```
- key : <key to use for applying the rule too>
  pattern: <the regex pattern with named submatchers>
  action: extract
```
I think that the original PR is going in the right way for what we can the internal logic to be but as the issue #979 and #1170 indicate we need to take a step back and redesign the attributes processor (or make it clear of its limitations).  This pr unblocks the required functionality. 

**Link to tracking Issue:** #979 

**Link to follow up issue:** #1170 

**Testing:** Added tests for extracting.

**Documentation:** Updated processor readme.