### PR TITLE
Add protocol server settings and remove endpoint from ReceiverSettings

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/collector/config/configmodels"
+	"go.opentelemetry.io/collector/config/configprotocol"
 )
 
 func TestDecodeConfig(t *testing.T) {
@@ -50,8 +51,10 @@ func TestDecodeConfig(t *testing.T) {
 	assert.Equal(t,
 		&ExampleReceiver{
 			ReceiverSettings: configmodels.ReceiverSettings{
-				TypeVal:  "examplereceiver",
-				NameVal:  "examplereceiver",
+				TypeVal: "examplereceiver",
+				NameVal: "examplereceiver",
+			},
+			ProtocolServerSettings: configprotocol.ProtocolServerSettings{
 				Endpoint: "localhost:1000",
 			},
 			ExtraSetting: "some string",
@@ -62,8 +65,10 @@ func TestDecodeConfig(t *testing.T) {
 	assert.Equal(t,
 		&ExampleReceiver{
 			ReceiverSettings: configmodels.ReceiverSettings{
-				TypeVal:  "examplereceiver",
-				NameVal:  "examplereceiver/myreceiver",
+				TypeVal: "examplereceiver",
+				NameVal: "examplereceiver/myreceiver",
+			},
+			ProtocolServerSettings: configprotocol.ProtocolServerSettings{
 				Endpoint: "localhost:12345",
 			},
 			ExtraSetting: "some string",
@@ -226,8 +231,10 @@ func TestSimpleConfig(t *testing.T) {
 		assert.Equalf(t,
 			&ExampleReceiver{
 				ReceiverSettings: configmodels.ReceiverSettings{
-					TypeVal:  "examplereceiver",
-					NameVal:  "examplereceiver",
+					TypeVal: "examplereceiver",
+					NameVal: "examplereceiver",
+				},
+				ProtocolServerSettings: configprotocol.ProtocolServerSettings{
 					Endpoint: "localhost:1234",
 				},
 				ExtraSetting:     receiverExtra,
@@ -327,8 +334,10 @@ func TestEscapedEnvVars(t *testing.T) {
 	assert.Equal(t,
 		&ExampleReceiver{
 			ReceiverSettings: configmodels.ReceiverSettings{
-				TypeVal:  "examplereceiver",
-				NameVal:  "examplereceiver",
+				TypeVal: "examplereceiver",
+				NameVal: "examplereceiver",
+			},
+			ProtocolServerSettings: configprotocol.ProtocolServerSettings{
 				Endpoint: "localhost:1234",
 			},
 			ExtraSetting: "$RECEIVERS_EXAMPLERECEIVER_EXTRA",

--- a/config/configmodels/configmodels.go
+++ b/config/configmodels/configmodels.go
@@ -129,14 +129,11 @@ type Service struct {
 // These are helper structs which you can embed when implementing your specific
 // receiver/exporter/processor config storage.
 
-// ReceiverSettings defines common settings for a single-protocol receiver configuration.
+// ReceiverSettings defines common settings for a receiver configuration.
 // Specific receivers can embed this struct and extend it with more fields if needed.
 type ReceiverSettings struct {
 	TypeVal Type   `mapstructure:"-"`
 	NameVal string `mapstructure:"-"`
-	// Endpoint configures the endpoint in the format 'address:port' for the receiver.
-	// The default value is set by the receiver populating the struct.
-	Endpoint string `mapstructure:"endpoint"`
 }
 
 // Name gets the receiver name.

--- a/config/configprotocol/configprotocol.go
+++ b/config/configprotocol/configprotocol.go
@@ -1,0 +1,31 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package configprotocol
+
+import (
+	"go.opentelemetry.io/collector/config/configtls"
+)
+
+// ProtocolServerSettings defines common settings for a single-protocol server configuration.
+// Specific receivers or exporters can embed this struct and extend it with more fields if needed.
+type ProtocolServerSettings struct {
+	// Endpoint configures the endpoint in the format 'address:port' for the receiver.
+	// The default value is set by the receiver populating the struct.
+	Endpoint string `mapstructure:"endpoint"`
+
+	// Configures the protocol to use TLS.
+	// The default value is nil, which will cause the protocol to not use TLS.
+	TLSCredentials *configtls.TLSServerSetting `mapstructure:"tls_credentials, omitempty"`
+}

--- a/config/configprotocol/empty_test.go
+++ b/config/configprotocol/empty_test.go
@@ -12,17 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package zipkinreceiver
+package configprotocol
 
-import (
-	"go.opentelemetry.io/collector/config/configmodels"
-	"go.opentelemetry.io/collector/config/configprotocol"
-)
-
-// Config defines configuration for Zipkin receiver.
-type Config struct {
-	configmodels.ReceiverSettings `mapstructure:",squash"`
-
-	// Configures the receiver server protocol.
-	configprotocol.ProtocolServerSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
-}
+// Package with interfaces and structs only.

--- a/config/configtls/configtls.go
+++ b/config/configtls/configtls.go
@@ -63,6 +63,15 @@ type TLSClientSetting struct {
 	ServerName string `mapstructure:"server_name_override"`
 }
 
+// TLSServerSetting contains TLS configurations that are specific to server
+// connections in addition to the common configurations. This should be used by
+// components configuring TLS server connections.
+type TLSServerSetting struct {
+	TLSSetting `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
+
+	// These are config options specific to server connections.
+}
+
 // LoadTLSConfig loads TLS certificates and returns a tls.Config.
 // This will set the RootCAs and Certificates of a tls.Config.
 func (c TLSSetting) LoadTLSConfig() (*tls.Config, error) {
@@ -124,7 +133,7 @@ func (c TLSClientSetting) LoadgRPCTLSClientCredentials() (grpc.DialOption, error
 	return grpc.WithTransportCredentials(creds), nil
 }
 
-func (c TLSSetting) LoadgRPCTLSServerCredentials() (grpc.ServerOption, error) {
+func (c TLSServerSetting) LoadgRPCTLSServerCredentials() (grpc.ServerOption, error) {
 	tlsConf, err := c.LoadTLSConfig()
 	if err != nil {
 		return nil, fmt.Errorf("failed to load TLS config: %w", err)

--- a/config/configtls/configtls_test.go
+++ b/config/configtls/configtls_test.go
@@ -124,9 +124,11 @@ func TestOptionsToConfig(t *testing.T) {
 }
 
 func TestTLSSetting_LoadgRPCTLSServerCredentialsError(t *testing.T) {
-	tlsSetting := TLSSetting{
-		CertFile: "doesnt/exist",
-		KeyFile:  "doesnt/exist",
+	tlsSetting := TLSServerSetting{
+		TLSSetting: TLSSetting{
+			CertFile: "doesnt/exist",
+			KeyFile:  "doesnt/exist",
+		},
 	}
 	_, err := tlsSetting.LoadgRPCTLSServerCredentials()
 	assert.Error(t, err)

--- a/config/example_factories.go
+++ b/config/example_factories.go
@@ -23,6 +23,7 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configerror"
 	"go.opentelemetry.io/collector/config/configmodels"
+	"go.opentelemetry.io/collector/config/configprotocol"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumerdata"
 	"go.opentelemetry.io/collector/internal/data"
@@ -32,9 +33,12 @@ import (
 // for "examplereceiver" receiver type.
 type ExampleReceiver struct {
 	configmodels.ReceiverSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
-	ExtraSetting                  string                   `mapstructure:"extra"`
-	ExtraMapSetting               map[string]string        `mapstructure:"extra_map"`
-	ExtraListSetting              []string                 `mapstructure:"extra_list"`
+	// Configures the receiver server protocol.
+	configprotocol.ProtocolServerSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
+
+	ExtraSetting     string            `mapstructure:"extra"`
+	ExtraMapSetting  map[string]string `mapstructure:"extra_map"`
+	ExtraListSetting []string          `mapstructure:"extra_list"`
 
 	// FailTraceCreation causes CreateTraceReceiver to fail. Useful for testing.
 	FailTraceCreation bool `mapstructure:"-"`
@@ -61,8 +65,10 @@ func (f *ExampleReceiverFactory) CustomUnmarshaler() component.CustomUnmarshaler
 func (f *ExampleReceiverFactory) CreateDefaultConfig() configmodels.Receiver {
 	return &ExampleReceiver{
 		ReceiverSettings: configmodels.ReceiverSettings{
-			TypeVal:  f.Type(),
-			NameVal:  string(f.Type()),
+			TypeVal: f.Type(),
+			NameVal: string(f.Type()),
+		},
+		ProtocolServerSettings: configprotocol.ProtocolServerSettings{
 			Endpoint: "localhost:1000",
 		},
 		ExtraSetting:     "some string",

--- a/receiver/jaegerreceiver/config.go
+++ b/receiver/jaegerreceiver/config.go
@@ -17,7 +17,7 @@ package jaegerreceiver
 import (
 	"go.opentelemetry.io/collector/config/configgrpc"
 	"go.opentelemetry.io/collector/config/configmodels"
-	"go.opentelemetry.io/collector/config/configtls"
+	"go.opentelemetry.io/collector/config/configprotocol"
 )
 
 // The config field name to load the protocol map from
@@ -30,19 +30,12 @@ type RemoteSamplingConfig struct {
 	configgrpc.GRPCClientSettings `mapstructure:",squash"`
 }
 
-type SecureSetting struct {
-	configmodels.ReceiverSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
-	// Configures the receiver to use TLS.
-	// The default value is nil, which will cause the receiver to not use TLS.
-	TLSCredentials *configtls.TLSSetting `mapstructure:"tls_credentials, omitempty"`
-}
-
 // Config defines configuration for Jaeger receiver.
 type Config struct {
-	TypeVal        configmodels.Type         `mapstructure:"-"`
-	NameVal        string                    `mapstructure:"-"`
-	Protocols      map[string]*SecureSetting `mapstructure:"protocols"`
-	RemoteSampling *RemoteSamplingConfig     `mapstructure:"remote_sampling"`
+	TypeVal        configmodels.Type                                 `mapstructure:"-"`
+	NameVal        string                                            `mapstructure:"-"`
+	Protocols      map[string]*configprotocol.ProtocolServerSettings `mapstructure:"protocols"`
+	RemoteSampling *RemoteSamplingConfig                             `mapstructure:"remote_sampling"`
 }
 
 // Name gets the receiver name.

--- a/receiver/jaegerreceiver/config_test.go
+++ b/receiver/jaegerreceiver/config_test.go
@@ -23,7 +23,7 @@ import (
 
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/configgrpc"
-	"go.opentelemetry.io/collector/config/configmodels"
+	"go.opentelemetry.io/collector/config/configprotocol"
 	"go.opentelemetry.io/collector/config/configtls"
 )
 
@@ -45,26 +45,18 @@ func TestLoadConfig(t *testing.T) {
 		&Config{
 			TypeVal: typeStr,
 			NameVal: "jaeger/customname",
-			Protocols: map[string]*SecureSetting{
+			Protocols: map[string]*configprotocol.ProtocolServerSettings{
 				"grpc": {
-					ReceiverSettings: configmodels.ReceiverSettings{
-						Endpoint: "localhost:9876",
-					},
+					Endpoint: "localhost:9876",
 				},
 				"thrift_http": {
-					ReceiverSettings: configmodels.ReceiverSettings{
-						Endpoint: ":3456",
-					},
+					Endpoint: ":3456",
 				},
 				"thrift_compact": {
-					ReceiverSettings: configmodels.ReceiverSettings{
-						Endpoint: "0.0.0.0:456",
-					},
+					Endpoint: "0.0.0.0:456",
 				},
 				"thrift_binary": {
-					ReceiverSettings: configmodels.ReceiverSettings{
-						Endpoint: "0.0.0.0:789",
-					},
+					Endpoint: "0.0.0.0:789",
 				},
 			},
 			RemoteSampling: &RemoteSamplingConfig{
@@ -81,26 +73,18 @@ func TestLoadConfig(t *testing.T) {
 		&Config{
 			TypeVal: typeStr,
 			NameVal: "jaeger/defaults",
-			Protocols: map[string]*SecureSetting{
+			Protocols: map[string]*configprotocol.ProtocolServerSettings{
 				"grpc": {
-					ReceiverSettings: configmodels.ReceiverSettings{
-						Endpoint: defaultGRPCBindEndpoint,
-					},
+					Endpoint: defaultGRPCBindEndpoint,
 				},
 				"thrift_http": {
-					ReceiverSettings: configmodels.ReceiverSettings{
-						Endpoint: defaultHTTPBindEndpoint,
-					},
+					Endpoint: defaultHTTPBindEndpoint,
 				},
 				"thrift_compact": {
-					ReceiverSettings: configmodels.ReceiverSettings{
-						Endpoint: defaultThriftCompactBindEndpoint,
-					},
+					Endpoint: defaultThriftCompactBindEndpoint,
 				},
 				"thrift_binary": {
-					ReceiverSettings: configmodels.ReceiverSettings{
-						Endpoint: defaultThriftBinaryBindEndpoint,
-					},
+					Endpoint: defaultThriftBinaryBindEndpoint,
 				},
 			},
 		})
@@ -110,16 +94,12 @@ func TestLoadConfig(t *testing.T) {
 		&Config{
 			TypeVal: typeStr,
 			NameVal: "jaeger/mixed",
-			Protocols: map[string]*SecureSetting{
+			Protocols: map[string]*configprotocol.ProtocolServerSettings{
 				"grpc": {
-					ReceiverSettings: configmodels.ReceiverSettings{
-						Endpoint: "localhost:9876",
-					},
+					Endpoint: "localhost:9876",
 				},
 				"thrift_compact": {
-					ReceiverSettings: configmodels.ReceiverSettings{
-						Endpoint: defaultThriftCompactBindEndpoint,
-					},
+					Endpoint: defaultThriftCompactBindEndpoint,
 				},
 			},
 		})
@@ -130,20 +110,18 @@ func TestLoadConfig(t *testing.T) {
 		&Config{
 			TypeVal: typeStr,
 			NameVal: "jaeger/tls",
-			Protocols: map[string]*SecureSetting{
+			Protocols: map[string]*configprotocol.ProtocolServerSettings{
 				"grpc": {
-					ReceiverSettings: configmodels.ReceiverSettings{
-						Endpoint: "localhost:9876",
-					},
-					TLSCredentials: &configtls.TLSSetting{
-						CertFile: "/test.crt",
-						KeyFile:  "/test.key",
+					Endpoint: "localhost:9876",
+					TLSCredentials: &configtls.TLSServerSetting{
+						TLSSetting: configtls.TLSSetting{
+							CertFile: "/test.crt",
+							KeyFile:  "/test.key",
+						},
 					},
 				},
 				"thrift_http": {
-					ReceiverSettings: configmodels.ReceiverSettings{
-						Endpoint: ":3456",
-					},
+					Endpoint: ":3456",
 				},
 			},
 		})

--- a/receiver/jaegerreceiver/factory.go
+++ b/receiver/jaegerreceiver/factory.go
@@ -29,6 +29,7 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configerror"
 	"go.opentelemetry.io/collector/config/configmodels"
+	"go.opentelemetry.io/collector/config/configprotocol"
 	"go.opentelemetry.io/collector/consumer"
 )
 
@@ -103,7 +104,7 @@ func (f *Factory) CreateDefaultConfig() configmodels.Receiver {
 	return &Config{
 		TypeVal:   typeStr,
 		NameVal:   typeStr,
-		Protocols: map[string]*SecureSetting{},
+		Protocols: map[string]*configprotocol.ProtocolServerSettings{},
 	}
 }
 
@@ -247,7 +248,7 @@ func extractPortFromEndpoint(endpoint string) (int, error) {
 }
 
 // returns a default value for a protocol name.  this really just boils down to the endpoint
-func defaultsForProtocol(proto string) (*SecureSetting, error) {
+func defaultsForProtocol(proto string) (*configprotocol.ProtocolServerSettings, error) {
 	var defaultEndpoint string
 
 	switch proto {
@@ -263,9 +264,7 @@ func defaultsForProtocol(proto string) (*SecureSetting, error) {
 		return nil, fmt.Errorf("unknown Jaeger protocol %s", proto)
 	}
 
-	return &SecureSetting{
-		ReceiverSettings: configmodels.ReceiverSettings{
-			Endpoint: defaultEndpoint,
-		},
+	return &configprotocol.ProtocolServerSettings{
+		Endpoint: defaultEndpoint,
 	}, nil
 }

--- a/receiver/jaegerreceiver/factory_test.go
+++ b/receiver/jaegerreceiver/factory_test.go
@@ -27,7 +27,7 @@ import (
 	"go.opentelemetry.io/collector/config/configcheck"
 	"go.opentelemetry.io/collector/config/configerror"
 	"go.opentelemetry.io/collector/config/configgrpc"
-	"go.opentelemetry.io/collector/config/configmodels"
+	"go.opentelemetry.io/collector/config/configprotocol"
 	"go.opentelemetry.io/collector/config/configtls"
 )
 
@@ -80,9 +80,11 @@ func TestCreateTLSGPRCEndpoint(t *testing.T) {
 	rCfg := cfg.(*Config)
 
 	rCfg.Protocols[protoGRPC], _ = defaultsForProtocol(protoGRPC)
-	rCfg.Protocols[protoGRPC].TLSCredentials = &configtls.TLSSetting{
-		CertFile: "./testdata/certificate.pem",
-		KeyFile:  "./testdata/key.pem",
+	rCfg.Protocols[protoGRPC].TLSCredentials = &configtls.TLSServerSetting{
+		TLSSetting: configtls.TLSSetting{
+			CertFile: "./testdata/certificate.pem",
+			KeyFile:  "./testdata/key.pem",
+		},
 	}
 	params := component.ReceiverCreateParams{Logger: zap.NewNop()}
 
@@ -169,10 +171,8 @@ func TestCreateNoPort(t *testing.T) {
 	cfg := factory.CreateDefaultConfig()
 	rCfg := cfg.(*Config)
 
-	rCfg.Protocols[protoThriftHTTP] = &SecureSetting{
-		ReceiverSettings: configmodels.ReceiverSettings{
-			Endpoint: "localhost:",
-		},
+	rCfg.Protocols[protoThriftHTTP] = &configprotocol.ProtocolServerSettings{
+		Endpoint: "localhost:",
 	}
 	params := component.ReceiverCreateParams{Logger: zap.NewNop()}
 	_, err := factory.CreateTraceReceiver(context.Background(), params, cfg, nil)
@@ -184,10 +184,8 @@ func TestCreateLargePort(t *testing.T) {
 	cfg := factory.CreateDefaultConfig()
 	rCfg := cfg.(*Config)
 
-	rCfg.Protocols[protoThriftHTTP] = &SecureSetting{
-		ReceiverSettings: configmodels.ReceiverSettings{
-			Endpoint: "localhost:65536",
-		},
+	rCfg.Protocols[protoThriftHTTP] = &configprotocol.ProtocolServerSettings{
+		Endpoint: "localhost:65536",
 	}
 	params := component.ReceiverCreateParams{Logger: zap.NewNop()}
 	_, err := factory.CreateTraceReceiver(context.Background(), params, cfg, nil)
@@ -199,10 +197,8 @@ func TestCreateInvalidHost(t *testing.T) {
 	cfg := factory.CreateDefaultConfig()
 	rCfg := cfg.(*Config)
 
-	rCfg.Protocols[protoGRPC] = &SecureSetting{
-		ReceiverSettings: configmodels.ReceiverSettings{
-			Endpoint: "1234",
-		},
+	rCfg.Protocols[protoGRPC] = &configprotocol.ProtocolServerSettings{
+		Endpoint: "1234",
 	}
 	params := component.ReceiverCreateParams{Logger: zap.NewNop()}
 	_, err := factory.CreateTraceReceiver(context.Background(), params, cfg, nil)
@@ -214,7 +210,7 @@ func TestCreateNoProtocols(t *testing.T) {
 	cfg := factory.CreateDefaultConfig()
 	rCfg := cfg.(*Config)
 
-	rCfg.Protocols = make(map[string]*SecureSetting)
+	rCfg.Protocols = make(map[string]*configprotocol.ProtocolServerSettings)
 
 	params := component.ReceiverCreateParams{Logger: zap.NewNop()}
 	_, err := factory.CreateTraceReceiver(context.Background(), params, cfg, nil)
@@ -226,10 +222,8 @@ func TestThriftBinaryBadPort(t *testing.T) {
 	cfg := factory.CreateDefaultConfig()
 	rCfg := cfg.(*Config)
 
-	rCfg.Protocols[protoThriftBinary] = &SecureSetting{
-		ReceiverSettings: configmodels.ReceiverSettings{
-			Endpoint: "localhost:65536",
-		},
+	rCfg.Protocols[protoThriftBinary] = &configprotocol.ProtocolServerSettings{
+		Endpoint: "localhost:65536",
 	}
 
 	params := component.ReceiverCreateParams{Logger: zap.NewNop()}
@@ -242,10 +236,8 @@ func TestThriftCompactBadPort(t *testing.T) {
 	cfg := factory.CreateDefaultConfig()
 	rCfg := cfg.(*Config)
 
-	rCfg.Protocols[protoThriftCompact] = &SecureSetting{
-		ReceiverSettings: configmodels.ReceiverSettings{
-			Endpoint: "localhost:65536",
-		},
+	rCfg.Protocols[protoThriftCompact] = &configprotocol.ProtocolServerSettings{
+		Endpoint: "localhost:65536",
 	}
 
 	params := component.ReceiverCreateParams{Logger: zap.NewNop()}

--- a/receiver/jaegerreceiver/trace_receiver_test.go
+++ b/receiver/jaegerreceiver/trace_receiver_test.go
@@ -45,7 +45,7 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/configgrpc"
-	"go.opentelemetry.io/collector/config/configmodels"
+	"go.opentelemetry.io/collector/config/configprotocol"
 	"go.opentelemetry.io/collector/config/configtls"
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/exporter/exportertest"
@@ -253,9 +253,11 @@ func TestGRPCReception(t *testing.T) {
 func TestGRPCReceptionWithTLS(t *testing.T) {
 	// prepare
 	grpcServerOptions := []grpc.ServerOption{}
-	tlsCreds := configtls.TLSSetting{
-		CertFile: path.Join(".", "testdata", "certificate.pem"),
-		KeyFile:  path.Join(".", "testdata", "key.pem"),
+	tlsCreds := configtls.TLSServerSetting{
+		TLSSetting: configtls.TLSSetting{
+			CertFile: path.Join(".", "testdata", "certificate.pem"),
+			KeyFile:  path.Join(".", "testdata", "key.pem"),
+		},
 	}
 
 	tlsOption, _ := tlsCreds.LoadgRPCTLSServerCredentials()
@@ -590,10 +592,10 @@ func TestSamplingStrategiesMutualTLS(t *testing.T) {
 	// at least one protocol has to be enabled
 	thriftHTTPPort, err := randomAvailablePort()
 	require.NoError(t, err)
-	cfg.Protocols = map[string]*SecureSetting{
-		"thrift_http": {ReceiverSettings: configmodels.ReceiverSettings{
+	cfg.Protocols = map[string]*configprotocol.ProtocolServerSettings{
+		"thrift_http": {
 			Endpoint: fmt.Sprintf("localhost:%d", thriftHTTPPort),
-		}},
+		},
 	}
 	exp, err := factory.CreateTraceReceiver(context.Background(), component.ReceiverCreateParams{Logger: zap.NewNop()}, cfg, exportertest.NewNopTraceExporter())
 	require.NoError(t, err)

--- a/receiver/opencensusreceiver/config.go
+++ b/receiver/opencensusreceiver/config.go
@@ -22,16 +22,15 @@ import (
 	"google.golang.org/grpc/keepalive"
 
 	"go.opentelemetry.io/collector/config/configmodels"
-	"go.opentelemetry.io/collector/config/configtls"
+	"go.opentelemetry.io/collector/config/configprotocol"
 )
 
 // Config defines configuration for OpenCensus receiver.
 type Config struct {
 	configmodels.ReceiverSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
 
-	// Configures the receiver to use TLS.
-	// The default value is nil, which will cause the receiver to not use TLS.
-	TLSCredentials *configtls.TLSSetting `mapstructure:"tls_credentials, omitempty"`
+	// Configures the receiver server protocol.
+	configprotocol.ProtocolServerSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
 
 	// Transport to use: one of tcp or unix, defaults to tcp
 	Transport string `mapstructure:"transport"`

--- a/receiver/opencensusreceiver/config_test.go
+++ b/receiver/opencensusreceiver/config_test.go
@@ -24,6 +24,7 @@ import (
 
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/configmodels"
+	"go.opentelemetry.io/collector/config/configprotocol"
 	"go.opentelemetry.io/collector/config/configtls"
 )
 
@@ -47,9 +48,12 @@ func TestLoadConfig(t *testing.T) {
 	assert.Equal(t, r1,
 		&Config{
 			ReceiverSettings: configmodels.ReceiverSettings{
-				TypeVal:  typeStr,
-				NameVal:  "opencensus/customname",
-				Endpoint: "0.0.0.0:9090",
+				TypeVal: typeStr,
+				NameVal: "opencensus/customname",
+			},
+			ProtocolServerSettings: configprotocol.ProtocolServerSettings{
+				Endpoint:       "0.0.0.0:9090",
+				TLSCredentials: nil,
 			},
 			Transport: "tcp",
 		})
@@ -58,12 +62,14 @@ func TestLoadConfig(t *testing.T) {
 	assert.Equal(t, r2,
 		&Config{
 			ReceiverSettings: configmodels.ReceiverSettings{
-				TypeVal:  typeStr,
-				NameVal:  "opencensus/keepalive",
-				Endpoint: "0.0.0.0:55678",
+				TypeVal: typeStr,
+				NameVal: "opencensus/keepalive",
 			},
-			TLSCredentials: nil,
-			Transport:      "tcp",
+			ProtocolServerSettings: configprotocol.ProtocolServerSettings{
+				TLSCredentials: nil,
+				Endpoint:       "0.0.0.0:55678",
+			},
+			Transport: "tcp",
 			Keepalive: &serverParametersAndEnforcementPolicy{
 				ServerParameters: &keepaliveServerParameters{
 					MaxConnectionIdle:     11 * time.Second,
@@ -83,11 +89,13 @@ func TestLoadConfig(t *testing.T) {
 	assert.Equal(t, r3,
 		&Config{
 			ReceiverSettings: configmodels.ReceiverSettings{
-				TypeVal:  typeStr,
-				NameVal:  "opencensus/msg-size-conc-connect-max-idle",
-				Endpoint: "0.0.0.0:55678",
+				TypeVal: typeStr,
+				NameVal: "opencensus/msg-size-conc-connect-max-idle",
 			},
-
+			ProtocolServerSettings: configprotocol.ProtocolServerSettings{
+				Endpoint:       "0.0.0.0:55678",
+				TLSCredentials: nil,
+			},
 			Transport:            "tcp",
 			MaxRecvMsgSizeMiB:    32,
 			MaxConcurrentStreams: 16,
@@ -104,13 +112,17 @@ func TestLoadConfig(t *testing.T) {
 	assert.Equal(t, r4,
 		&Config{
 			ReceiverSettings: configmodels.ReceiverSettings{
-				TypeVal:  typeStr,
-				NameVal:  "opencensus/tlscredentials",
-				Endpoint: "0.0.0.0:55678",
+				TypeVal: typeStr,
+				NameVal: "opencensus/tlscredentials",
 			},
-			TLSCredentials: &configtls.TLSSetting{
-				CertFile: "test.crt",
-				KeyFile:  "test.key",
+			ProtocolServerSettings: configprotocol.ProtocolServerSettings{
+				Endpoint: "0.0.0.0:55678",
+				TLSCredentials: &configtls.TLSServerSetting{
+					TLSSetting: configtls.TLSSetting{
+						CertFile: "test.crt",
+						KeyFile:  "test.key",
+					},
+				},
 			},
 			Transport: "tcp",
 		})
@@ -119,8 +131,10 @@ func TestLoadConfig(t *testing.T) {
 	assert.Equal(t, r5,
 		&Config{
 			ReceiverSettings: configmodels.ReceiverSettings{
-				TypeVal:  typeStr,
-				NameVal:  "opencensus/cors",
+				TypeVal: typeStr,
+				NameVal: "opencensus/cors",
+			},
+			ProtocolServerSettings: configprotocol.ProtocolServerSettings{
 				Endpoint: "0.0.0.0:55678",
 			},
 			Transport:   "tcp",
@@ -131,8 +145,10 @@ func TestLoadConfig(t *testing.T) {
 	assert.Equal(t, r6,
 		&Config{
 			ReceiverSettings: configmodels.ReceiverSettings{
-				TypeVal:  typeStr,
-				NameVal:  "opencensus/uds",
+				TypeVal: typeStr,
+				NameVal: "opencensus/uds",
+			},
+			ProtocolServerSettings: configprotocol.ProtocolServerSettings{
 				Endpoint: "/tmp/opencensus.sock",
 			},
 			Transport: "unix",
@@ -144,14 +160,18 @@ func TestBuildOptions_TLSCredentials(t *testing.T) {
 		ReceiverSettings: configmodels.ReceiverSettings{
 			NameVal: "IncorrectTLS",
 		},
-		TLSCredentials: &configtls.TLSSetting{
-			CertFile: "willfail",
+		ProtocolServerSettings: configprotocol.ProtocolServerSettings{
+			TLSCredentials: &configtls.TLSServerSetting{
+				TLSSetting: configtls.TLSSetting{
+					CertFile: "willfail",
+				},
+			},
 		},
 	}
 	_, err := cfg.buildOptions()
 	assert.EqualError(t, err, `error initializing OpenCensus receiver "IncorrectTLS" TLS Credentials: failed to load TLS config: for auth via TLS, either both certificate and key must be supplied, or neither`)
 
-	cfg.TLSCredentials = &configtls.TLSSetting{}
+	cfg.TLSCredentials = &configtls.TLSServerSetting{}
 	opt, err := cfg.buildOptions()
 	assert.NoError(t, err)
 	assert.NotNil(t, opt)

--- a/receiver/opencensusreceiver/factory.go
+++ b/receiver/opencensusreceiver/factory.go
@@ -21,6 +21,7 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configmodels"
+	"go.opentelemetry.io/collector/config/configprotocol"
 	"go.opentelemetry.io/collector/consumer"
 )
 
@@ -47,8 +48,10 @@ func (f *Factory) CustomUnmarshaler() component.CustomUnmarshaler {
 func (f *Factory) CreateDefaultConfig() configmodels.Receiver {
 	return &Config{
 		ReceiverSettings: configmodels.ReceiverSettings{
-			TypeVal:  typeStr,
-			NameVal:  typeStr,
+			TypeVal: typeStr,
+			NameVal: typeStr,
+		},
+		ProtocolServerSettings: configprotocol.ProtocolServerSettings{
 			Endpoint: "0.0.0.0:55678",
 		},
 		Transport: "tcp",

--- a/receiver/opencensusreceiver/factory_test.go
+++ b/receiver/opencensusreceiver/factory_test.go
@@ -26,6 +26,7 @@ import (
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/configcheck"
 	"go.opentelemetry.io/collector/config/configmodels"
+	"go.opentelemetry.io/collector/config/configprotocol"
 	"go.opentelemetry.io/collector/exporter/exportertest"
 	"go.opentelemetry.io/collector/testutils"
 )
@@ -57,8 +58,10 @@ func TestCreateTraceReceiver(t *testing.T) {
 	factory := Factory{}
 	endpoint := testutils.GetAvailableLocalAddress(t)
 	defaultReceiverSettings := configmodels.ReceiverSettings{
-		TypeVal:  typeStr,
-		NameVal:  typeStr,
+		TypeVal: typeStr,
+		NameVal: typeStr,
+	}
+	defaultProtocolSettings := configprotocol.ProtocolServerSettings{
 		Endpoint: endpoint,
 	}
 	tests := []struct {
@@ -69,17 +72,19 @@ func TestCreateTraceReceiver(t *testing.T) {
 		{
 			name: "default",
 			cfg: &Config{
-				ReceiverSettings: defaultReceiverSettings,
-				TLSCredentials:   nil,
-				Transport:        "tcp",
+				ReceiverSettings:       defaultReceiverSettings,
+				ProtocolServerSettings: defaultProtocolSettings,
+				Transport:              "tcp",
 			},
 		},
 		{
 			name: "invalid_port",
 			cfg: &Config{
 				ReceiverSettings: configmodels.ReceiverSettings{
-					TypeVal:  typeStr,
-					NameVal:  typeStr,
+					TypeVal: typeStr,
+					NameVal: typeStr,
+				},
+				ProtocolServerSettings: configprotocol.ProtocolServerSettings{
 					Endpoint: "localhost:112233",
 				},
 				Transport: "tcp",
@@ -119,10 +124,13 @@ func TestCreateMetricReceiver(t *testing.T) {
 	factory := Factory{}
 	endpoint := testutils.GetAvailableLocalAddress(t)
 	defaultReceiverSettings := configmodels.ReceiverSettings{
-		TypeVal:  typeStr,
-		NameVal:  typeStr,
+		TypeVal: typeStr,
+		NameVal: typeStr,
+	}
+	defaultProtocolSettings := configprotocol.ProtocolServerSettings{
 		Endpoint: endpoint,
 	}
+
 	tests := []struct {
 		name    string
 		cfg     *Config
@@ -131,16 +139,19 @@ func TestCreateMetricReceiver(t *testing.T) {
 		{
 			name: "default",
 			cfg: &Config{
-				ReceiverSettings: defaultReceiverSettings,
-				Transport:        "tcp",
+				ReceiverSettings:       defaultReceiverSettings,
+				ProtocolServerSettings: defaultProtocolSettings,
+				Transport:              "tcp",
 			},
 		},
 		{
 			name: "invalid_address",
 			cfg: &Config{
 				ReceiverSettings: configmodels.ReceiverSettings{
-					TypeVal:  typeStr,
-					NameVal:  typeStr,
+					TypeVal: typeStr,
+					NameVal: typeStr,
+				},
+				ProtocolServerSettings: configprotocol.ProtocolServerSettings{
 					Endpoint: "327.0.0.1:1122",
 				},
 				Transport: "tcp",

--- a/receiver/otlpreceiver/config.go
+++ b/receiver/otlpreceiver/config.go
@@ -22,16 +22,15 @@ import (
 	"google.golang.org/grpc/keepalive"
 
 	"go.opentelemetry.io/collector/config/configmodels"
-	"go.opentelemetry.io/collector/config/configtls"
+	"go.opentelemetry.io/collector/config/configprotocol"
 )
 
 // Config defines configuration for OTLP receiver.
 type Config struct {
 	configmodels.ReceiverSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
 
-	// Configures the receiver to use TLS.
-	// The default value is nil, which will cause the receiver to not use TLS.
-	TLSCredentials *configtls.TLSSetting `mapstructure:"tls_credentials, omitempty"`
+	// Configures the receiver server protocol.
+	configprotocol.ProtocolServerSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
 
 	// Transport to use: one of tcp or unix, defaults to tcp
 	Transport string `mapstructure:"transport"`

--- a/receiver/otlpreceiver/factory.go
+++ b/receiver/otlpreceiver/factory.go
@@ -19,6 +19,7 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configmodels"
+	"go.opentelemetry.io/collector/config/configprotocol"
 	"go.opentelemetry.io/collector/consumer"
 )
 
@@ -45,8 +46,10 @@ func (f *Factory) CustomUnmarshaler() component.CustomUnmarshaler {
 func (f *Factory) CreateDefaultConfig() configmodels.Receiver {
 	return &Config{
 		ReceiverSettings: configmodels.ReceiverSettings{
-			TypeVal:  typeStr,
-			NameVal:  typeStr,
+			TypeVal: typeStr,
+			NameVal: typeStr,
+		},
+		ProtocolServerSettings: configprotocol.ProtocolServerSettings{
 			Endpoint: "0.0.0.0:55680",
 		},
 		Transport: "tcp",

--- a/receiver/otlpreceiver/factory_test.go
+++ b/receiver/otlpreceiver/factory_test.go
@@ -27,6 +27,7 @@ import (
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/configcheck"
 	"go.opentelemetry.io/collector/config/configmodels"
+	"go.opentelemetry.io/collector/config/configprotocol"
 	"go.opentelemetry.io/collector/exporter/exportertest"
 	"go.opentelemetry.io/collector/testutils"
 )
@@ -59,10 +60,13 @@ func TestCreateTraceReceiver(t *testing.T) {
 	factory := Factory{}
 	endpoint := testutils.GetAvailableLocalAddress(t)
 	defaultReceiverSettings := configmodels.ReceiverSettings{
-		TypeVal:  typeStr,
-		NameVal:  typeStr,
+		TypeVal: typeStr,
+		NameVal: typeStr,
+	}
+	defaultProtocolSettings := configprotocol.ProtocolServerSettings{
 		Endpoint: endpoint,
 	}
+
 	tests := []struct {
 		name    string
 		cfg     *Config
@@ -71,17 +75,19 @@ func TestCreateTraceReceiver(t *testing.T) {
 		{
 			name: "default",
 			cfg: &Config{
-				ReceiverSettings: defaultReceiverSettings,
-				TLSCredentials:   nil,
-				Transport:        "tcp",
+				ReceiverSettings:       defaultReceiverSettings,
+				ProtocolServerSettings: defaultProtocolSettings,
+				Transport:              "tcp",
 			},
 		},
 		{
 			name: "invalid_port",
 			cfg: &Config{
 				ReceiverSettings: configmodels.ReceiverSettings{
-					TypeVal:  typeStr,
-					NameVal:  typeStr,
+					TypeVal: typeStr,
+					NameVal: typeStr,
+				},
+				ProtocolServerSettings: configprotocol.ProtocolServerSettings{
 					Endpoint: "localhost:112233",
 				},
 				Transport: "tcp",
@@ -120,8 +126,10 @@ func TestCreateMetricReceiver(t *testing.T) {
 	factory := Factory{}
 	endpoint := testutils.GetAvailableLocalAddress(t)
 	defaultReceiverSettings := configmodels.ReceiverSettings{
-		TypeVal:  typeStr,
-		NameVal:  typeStr,
+		TypeVal: typeStr,
+		NameVal: typeStr,
+	}
+	defaultProtocolSettings := configprotocol.ProtocolServerSettings{
 		Endpoint: endpoint,
 	}
 	tests := []struct {
@@ -132,16 +140,19 @@ func TestCreateMetricReceiver(t *testing.T) {
 		{
 			name: "default",
 			cfg: &Config{
-				ReceiverSettings: defaultReceiverSettings,
-				Transport:        "tcp",
+				ReceiverSettings:       defaultReceiverSettings,
+				ProtocolServerSettings: defaultProtocolSettings,
+				Transport:              "tcp",
 			},
 		},
 		{
 			name: "invalid_address",
 			cfg: &Config{
 				ReceiverSettings: configmodels.ReceiverSettings{
-					TypeVal:  typeStr,
-					NameVal:  typeStr,
+					TypeVal: typeStr,
+					NameVal: typeStr,
+				},
+				ProtocolServerSettings: configprotocol.ProtocolServerSettings{
 					Endpoint: "327.0.0.1:1122",
 				},
 				Transport: "tcp",

--- a/receiver/prometheusreceiver/config_test.go
+++ b/receiver/prometheusreceiver/config_test.go
@@ -46,9 +46,8 @@ func TestLoadConfig(t *testing.T) {
 	r1 := cfg.Receivers["prometheus/customname"].(*Config)
 	assert.Equal(t, r1.ReceiverSettings,
 		configmodels.ReceiverSettings{
-			TypeVal:  typeStr,
-			NameVal:  "prometheus/customname",
-			Endpoint: "1.2.3.4:456",
+			TypeVal: typeStr,
+			NameVal: "prometheus/customname",
 		})
 	assert.Equal(t, r1.PrometheusConfig.ScrapeConfigs[0].JobName, "demo")
 	assert.Equal(t, time.Duration(r1.PrometheusConfig.ScrapeConfigs[0].ScrapeInterval), 5*time.Second)
@@ -72,9 +71,8 @@ func TestLoadConfigWithEnvVar(t *testing.T) {
 	r := cfg.Receivers["prometheus"].(*Config)
 	assert.Equal(t, r.ReceiverSettings,
 		configmodels.ReceiverSettings{
-			TypeVal:  typeStr,
-			NameVal:  "prometheus",
-			Endpoint: "1.2.3.4:456",
+			TypeVal: typeStr,
+			NameVal: "prometheus",
 		})
 	assert.Equal(t, r.PrometheusConfig.ScrapeConfigs[0].JobName, jobname)
 	os.Unsetenv(jobnamevar)

--- a/receiver/prometheusreceiver/factory.go
+++ b/receiver/prometheusreceiver/factory.go
@@ -95,9 +95,8 @@ func CustomUnmarshalerFunc(componentViperSection *viper.Viper, intoCfg interface
 func (f *Factory) CreateDefaultConfig() configmodels.Receiver {
 	return &Config{
 		ReceiverSettings: configmodels.ReceiverSettings{
-			TypeVal:  typeStr,
-			NameVal:  typeStr,
-			Endpoint: "0.0.0.0:9090",
+			TypeVal: typeStr,
+			NameVal: typeStr,
 		},
 	}
 }

--- a/receiver/prometheusreceiver/testdata/config.yaml
+++ b/receiver/prometheusreceiver/testdata/config.yaml
@@ -1,7 +1,6 @@
 receivers:
   prometheus:
   prometheus/customname:
-    endpoint: "1.2.3.4:456"
     buffer_period: 234
     buffer_count: 45
     use_start_time_metric: true

--- a/receiver/prometheusreceiver/testdata/config_env.yaml
+++ b/receiver/prometheusreceiver/testdata/config_env.yaml
@@ -1,6 +1,5 @@
 receivers:
   prometheus:
-    endpoint: "1.2.3.4:456"
     config:
       scrape_configs:
         - job_name: ${JOBNAME}

--- a/receiver/zipkinreceiver/config_test.go
+++ b/receiver/zipkinreceiver/config_test.go
@@ -23,6 +23,7 @@ import (
 
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/configmodels"
+	"go.opentelemetry.io/collector/config/configprotocol"
 )
 
 func TestLoadConfig(t *testing.T) {
@@ -45,8 +46,10 @@ func TestLoadConfig(t *testing.T) {
 	assert.Equal(t, r1,
 		&Config{
 			ReceiverSettings: configmodels.ReceiverSettings{
-				TypeVal:  typeStr,
-				NameVal:  "zipkin/customname",
+				TypeVal: typeStr,
+				NameVal: "zipkin/customname",
+			},
+			ProtocolServerSettings: configprotocol.ProtocolServerSettings{
 				Endpoint: "localhost:8765",
 			},
 		})

--- a/receiver/zipkinreceiver/factory.go
+++ b/receiver/zipkinreceiver/factory.go
@@ -22,6 +22,7 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configerror"
 	"go.opentelemetry.io/collector/config/configmodels"
+	"go.opentelemetry.io/collector/config/configprotocol"
 	"go.opentelemetry.io/collector/consumer"
 )
 
@@ -52,8 +53,10 @@ func (f *Factory) CustomUnmarshaler() component.CustomUnmarshaler {
 func (f *Factory) CreateDefaultConfig() configmodels.Receiver {
 	return &Config{
 		ReceiverSettings: configmodels.ReceiverSettings{
-			TypeVal:  typeStr,
-			NameVal:  typeStr,
+			TypeVal: typeStr,
+			NameVal: typeStr,
+		},
+		ProtocolServerSettings: configprotocol.ProtocolServerSettings{
 			Endpoint: defaultBindEndpoint,
 		},
 	}


### PR DESCRIPTION
The configuration is backwards compatible except `Prometheus` receiver which defined an `Endpoint` but never used that.

TLSServerSetting was added in preparation to support proper mtls, and since this PR touches all the structs that use TLSSetting it was a good opportunity to avoid touching same files twice.