### PR TITLE
Add a generic grpc server settings config, cleanup client config

### DIFF
--- a/config/configgrpc/configgrpc.go
+++ b/config/configgrpc/configgrpc.go
@@ -20,11 +20,13 @@ import (
 	"strings"
 	"time"
 
+	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/encoding/gzip"
 	"google.golang.org/grpc/keepalive"
 
+	"go.opentelemetry.io/collector/config/configprotocol"
 	"go.opentelemetry.io/collector/config/configtls"
 )
 
@@ -33,6 +35,22 @@ const (
 	CompressionUnsupported = ""
 	CompressionGzip        = "gzip"
 )
+
+var (
+	// Map of opentelemetry compression types to grpc registered compression types
+	grpcCompressionKeyMap = map[string]string{
+		CompressionGzip: gzip.Name,
+	}
+)
+
+// KeepaliveClientConfig exposes the keepalive.ClientParameters to be used by the exporter.
+// Refer to the original data-structure for the meaning of each parameter:
+// https://godoc.org/google.golang.org/grpc/keepalive#ClientParameters
+type KeepaliveClientConfig struct {
+	Time                time.Duration `mapstructure:"time,omitempty"`
+	Timeout             time.Duration `mapstructure:"timeout,omitempty"`
+	PermitWithoutStream bool          `mapstructure:"permit_without_stream,omitempty"`
+}
 
 // GRPCClientSettings defines common settings for a gRPC client configuration.
 type GRPCClientSettings struct {
@@ -53,23 +71,54 @@ type GRPCClientSettings struct {
 
 	// The keepalive parameters for client gRPC. See grpc.WithKeepaliveParams
 	// (https://godoc.org/google.golang.org/grpc#WithKeepaliveParams).
-	KeepaliveParameters *KeepaliveConfig `mapstructure:"keepalive"`
+	Keepalive *KeepaliveClientConfig `mapstructure:"keepalive"`
 
 	// WaitForReady parameter configures client to wait for ready state before sending data.
 	// (https://github.com/grpc/grpc/blob/master/doc/wait-for-ready.md)
 	WaitForReady bool `mapstructure:"wait_for_ready"`
 }
 
-// KeepaliveConfig exposes the keepalive.ClientParameters to be used by the exporter.
-// Refer to the original data-structure for the meaning of each parameter.
-type KeepaliveConfig struct {
-	Time                time.Duration `mapstructure:"time,omitempty"`
-	Timeout             time.Duration `mapstructure:"timeout,omitempty"`
+type KeepaliveServerConfig struct {
+	ServerParameters  *KeepaliveServerParameters  `mapstructure:"server_parameters,omitempty"`
+	EnforcementPolicy *KeepaliveEnforcementPolicy `mapstructure:"enforcement_policy,omitempty"`
+}
+
+// KeepaliveServerParameters allow configuration of the keepalive.ServerParameters.
+// The same default values as keepalive.ServerParameters are applicable and get applied by the server.
+// See https://godoc.org/google.golang.org/grpc/keepalive#ServerParameters for details.
+type KeepaliveServerParameters struct {
+	MaxConnectionIdle     time.Duration `mapstructure:"max_connection_idle,omitempty"`
+	MaxConnectionAge      time.Duration `mapstructure:"max_connection_age,omitempty"`
+	MaxConnectionAgeGrace time.Duration `mapstructure:"max_connection_age_grace,omitempty"`
+	Time                  time.Duration `mapstructure:"time,omitempty"`
+	Timeout               time.Duration `mapstructure:"timeout,omitempty"`
+}
+
+// KeepaliveEnforcementPolicy allow configuration of the keepalive.EnforcementPolicy.
+// The same default values as keepalive.EnforcementPolicy are applicable and get applied by the server.
+// See https://godoc.org/google.golang.org/grpc/keepalive#EnforcementPolicy for details.
+type KeepaliveEnforcementPolicy struct {
+	MinTime             time.Duration `mapstructure:"min_time,omitempty"`
 	PermitWithoutStream bool          `mapstructure:"permit_without_stream,omitempty"`
 }
 
-// GrpcSettingsToDialOptions maps configgrpc.GRPCClientSettings to a slice of dial options for gRPC
-func GrpcSettingsToDialOptions(settings GRPCClientSettings) ([]grpc.DialOption, error) {
+type GRPCServerSettings struct {
+	// Configures the generic server protocol.
+	configprotocol.ProtocolServerSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
+
+	// MaxRecvMsgSizeMiB sets the maximum size (in MiB) of messages accepted by the server.
+	MaxRecvMsgSizeMiB uint64 `mapstructure:"max_recv_msg_size_mib,omitempty"`
+
+	// MaxConcurrentStreams sets the limit on the number of concurrent streams to each ServerTransport.
+	// It has effect only for streaming RPCs.
+	MaxConcurrentStreams uint32 `mapstructure:"max_concurrent_streams,omitempty"`
+
+	// Keepalive anchor for all the settings related to keepalive.
+	Keepalive *KeepaliveServerConfig `mapstructure:"keepalive,omitempty"`
+}
+
+// ToServerOption maps configgrpc.GRPCClientSettings to a slice of dial options for gRPC
+func (settings *GRPCClientSettings) ToDialOptions() ([]grpc.DialOption, error) {
 	opts := []grpc.DialOption{}
 
 	if settings.Compression != "" {
@@ -90,11 +139,11 @@ func GrpcSettingsToDialOptions(settings GRPCClientSettings) ([]grpc.DialOption, 
 	}
 	opts = append(opts, tlsDialOption)
 
-	if settings.KeepaliveParameters != nil {
+	if settings.Keepalive != nil {
 		keepAliveOption := grpc.WithKeepaliveParams(keepalive.ClientParameters{
-			Time:                settings.KeepaliveParameters.Time,
-			Timeout:             settings.KeepaliveParameters.Timeout,
-			PermitWithoutStream: settings.KeepaliveParameters.PermitWithoutStream,
+			Time:                settings.Keepalive.Time,
+			Timeout:             settings.Keepalive.Timeout,
+			PermitWithoutStream: settings.Keepalive.PermitWithoutStream,
 		})
 		opts = append(opts, keepAliveOption)
 	}
@@ -102,12 +151,56 @@ func GrpcSettingsToDialOptions(settings GRPCClientSettings) ([]grpc.DialOption, 
 	return opts, nil
 }
 
-var (
-	// Map of opentelemetry compression types to grpc registered compression types
-	grpcCompressionKeyMap = map[string]string{
-		CompressionGzip: gzip.Name,
+// ToServerOption maps configgrpc.GRPCServerSettings to a slice of server options for gRPC
+func (gss *GRPCServerSettings) ToServerOption() ([]grpc.ServerOption, error) {
+	var opts []grpc.ServerOption
+
+	if gss.TLSCredentials != nil {
+		tlsCfg, err := gss.TLSCredentials.LoadTLSConfig()
+		if err != nil {
+			return nil, errors.Wrap(err, "error initializing TLS Credentials")
+		}
+		opts = append(opts, grpc.Creds(credentials.NewTLS(tlsCfg)))
 	}
-)
+
+	if gss.MaxRecvMsgSizeMiB > 0 {
+		opts = append(opts, grpc.MaxRecvMsgSize(int(gss.MaxRecvMsgSizeMiB*1024*1024)))
+	}
+
+	if gss.MaxConcurrentStreams > 0 {
+		opts = append(opts, grpc.MaxConcurrentStreams(gss.MaxConcurrentStreams))
+	}
+
+	// The default values referenced in the GRPC docs are set within the server, so this code doesn't need
+	// to apply them over zero/nil values before passing these as grpc.ServerOptions.
+	// The following shows the server code for applying default grpc.ServerOptions.
+	// https://github.com/grpc/grpc-go/blob/120728e1f775e40a2a764341939b78d666b08260/internal/transport/http2_server.go#L184-L200
+	if gss.Keepalive != nil {
+		if gss.Keepalive.ServerParameters != nil {
+			svrParams := gss.Keepalive.ServerParameters
+			opts = append(opts, grpc.KeepaliveParams(keepalive.ServerParameters{
+				MaxConnectionIdle:     svrParams.MaxConnectionIdle,
+				MaxConnectionAge:      svrParams.MaxConnectionAge,
+				MaxConnectionAgeGrace: svrParams.MaxConnectionAgeGrace,
+				Time:                  svrParams.Time,
+				Timeout:               svrParams.Timeout,
+			}))
+		}
+		// The default values referenced in the GRPC are set within the server, so this code doesn't need
+		// to apply them over zero/nil values before passing these as grpc.ServerOptions.
+		// The following shows the server code for applying default grpc.ServerOptions.
+		// https://github.com/grpc/grpc-go/blob/120728e1f775e40a2a764341939b78d666b08260/internal/transport/http2_server.go#L202-L205
+		if gss.Keepalive.EnforcementPolicy != nil {
+			enfPol := gss.Keepalive.EnforcementPolicy
+			opts = append(opts, grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
+				MinTime:             enfPol.MinTime,
+				PermitWithoutStream: enfPol.PermitWithoutStream,
+			}))
+		}
+	}
+
+	return opts, nil
+}
 
 // GetGRPCCompressionKey returns the grpc registered compression key if the
 // passed in compression key is supported, and CompressionUnsupported otherwise

--- a/config/configgrpc/configgrpc_test.go
+++ b/config/configgrpc/configgrpc_test.go
@@ -23,13 +23,13 @@ import (
 )
 
 func TestBasicGrpcSettings(t *testing.T) {
-
-	_, err := GrpcSettingsToDialOptions(GRPCClientSettings{
-		Headers:             nil,
-		Endpoint:            "",
-		Compression:         "",
-		KeepaliveParameters: nil,
-	})
+	gcs := &GRPCClientSettings{
+		Headers:     nil,
+		Endpoint:    "",
+		Compression: "",
+		Keepalive:   nil,
+	}
+	_, err := gcs.ToDialOptions()
 
 	assert.NoError(t, err)
 }
@@ -52,7 +52,7 @@ func TestInvalidPemFile(t *testing.T) {
 					Insecure:   false,
 					ServerName: "",
 				},
-				KeepaliveParameters: nil,
+				Keepalive: nil,
 			},
 		},
 		{
@@ -68,27 +68,27 @@ func TestInvalidPemFile(t *testing.T) {
 					Insecure:   false,
 					ServerName: "",
 				},
-				KeepaliveParameters: nil,
+				Keepalive: nil,
 			},
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.err, func(t *testing.T) {
-			_, err := GrpcSettingsToDialOptions(test.settings)
+			_, err := test.settings.ToDialOptions()
 			assert.Regexp(t, test.err, err)
 		})
 	}
 }
 
 func TestUseSecure(t *testing.T) {
-	dialOpts, err := GrpcSettingsToDialOptions(GRPCClientSettings{
-		Headers:             nil,
-		Endpoint:            "",
-		Compression:         "",
-		TLSSetting:          configtls.TLSClientSetting{},
-		KeepaliveParameters: nil,
-	})
-
+	gcs := &GRPCClientSettings{
+		Headers:     nil,
+		Endpoint:    "",
+		Compression: "",
+		TLSSetting:  configtls.TLSClientSetting{},
+		Keepalive:   nil,
+	}
+	dialOpts, err := gcs.ToDialOptions()
 	assert.NoError(t, err)
 	assert.Equal(t, len(dialOpts), 1)
 }

--- a/exporter/jaegerexporter/exporter.go
+++ b/exporter/jaegerexporter/exporter.go
@@ -22,7 +22,6 @@ import (
 	"google.golang.org/grpc/metadata"
 
 	"go.opentelemetry.io/collector/component"
-	"go.opentelemetry.io/collector/config/configgrpc"
 	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
@@ -34,7 +33,7 @@ import (
 // The collectorEndpoint should be of the form "hostname:14250" (a gRPC target).
 func New(config *Config) (component.TraceExporter, error) {
 
-	opts, err := configgrpc.GrpcSettingsToDialOptions(config.GRPCClientSettings)
+	opts, err := config.GRPCClientSettings.ToDialOptions()
 	if err != nil {
 		return nil, err
 	}

--- a/exporter/jaegerexporter/exporter_test.go
+++ b/exporter/jaegerexporter/exporter_test.go
@@ -56,7 +56,7 @@ func TestNew(t *testing.T) {
 						TLSSetting: configtls.TLSClientSetting{
 							Insecure: true,
 						},
-						KeepaliveParameters: nil,
+						Keepalive: nil,
 					},
 				},
 			},
@@ -66,10 +66,10 @@ func TestNew(t *testing.T) {
 			args: args{
 				config: Config{
 					GRPCClientSettings: configgrpc.GRPCClientSettings{
-						Headers:             map[string]string{"extra-header": "header-value"},
-						Endpoint:            "foo.bar",
-						Compression:         "",
-						KeepaliveParameters: nil,
+						Headers:     map[string]string{"extra-header": "header-value"},
+						Endpoint:    "foo.bar",
+						Compression: "",
+						Keepalive:   nil,
 					},
 				},
 			},
@@ -79,10 +79,10 @@ func TestNew(t *testing.T) {
 			args: args{
 				config: Config{
 					GRPCClientSettings: configgrpc.GRPCClientSettings{
-						Headers:             nil,
-						Endpoint:            "foo.bar",
-						Compression:         "",
-						KeepaliveParameters: nil,
+						Headers:     nil,
+						Endpoint:    "foo.bar",
+						Compression: "",
+						Keepalive:   nil,
 					},
 				},
 			},
@@ -101,7 +101,7 @@ func TestNew(t *testing.T) {
 							},
 							Insecure: false,
 						},
-						KeepaliveParameters: nil,
+						Keepalive: nil,
 					},
 				},
 			},
@@ -121,7 +121,7 @@ func TestNew(t *testing.T) {
 							Insecure:   false,
 							ServerName: "",
 						},
-						KeepaliveParameters: &configgrpc.KeepaliveConfig{
+						Keepalive: &configgrpc.KeepaliveClientConfig{
 							Time:                0,
 							Timeout:             0,
 							PermitWithoutStream: false,
@@ -144,7 +144,7 @@ func TestNew(t *testing.T) {
 							},
 							Insecure: false,
 						},
-						KeepaliveParameters: nil,
+						Keepalive: nil,
 					},
 				},
 			},

--- a/exporter/opencensusexporter/config_test.go
+++ b/exporter/opencensusexporter/config_test.go
@@ -62,7 +62,7 @@ func TestLoadConfig(t *testing.T) {
 					},
 					Insecure: false,
 				},
-				KeepaliveParameters: &configgrpc.KeepaliveConfig{
+				Keepalive: &configgrpc.KeepaliveClientConfig{
 					Time:                20,
 					PermitWithoutStream: true,
 					Timeout:             30,

--- a/exporter/opencensusexporter/factory.go
+++ b/exporter/opencensusexporter/factory.go
@@ -110,11 +110,11 @@ func (f *Factory) OCAgentOptions(logger *zap.Logger, ocac *Config) ([]ocagent.Ex
 	if ocac.ReconnectionDelay > 0 {
 		opts = append(opts, ocagent.WithReconnectionPeriod(ocac.ReconnectionDelay))
 	}
-	if ocac.KeepaliveParameters != nil {
+	if ocac.Keepalive != nil {
 		opts = append(opts, ocagent.WithGRPCDialOption(grpc.WithKeepaliveParams(keepalive.ClientParameters{
-			Time:                ocac.KeepaliveParameters.Time,
-			Timeout:             ocac.KeepaliveParameters.Timeout,
-			PermitWithoutStream: ocac.KeepaliveParameters.PermitWithoutStream,
+			Time:                ocac.Keepalive.Time,
+			Timeout:             ocac.Keepalive.Timeout,
+			PermitWithoutStream: ocac.Keepalive.PermitWithoutStream,
 		})))
 	}
 	return opts, nil

--- a/exporter/opencensusexporter/factory_test.go
+++ b/exporter/opencensusexporter/factory_test.go
@@ -104,11 +104,11 @@ func TestCreateTraceExporter(t *testing.T) {
 			},
 		},
 		{
-			name: "KeepaliveParameters",
+			name: "Keepalive",
 			config: Config{
 				GRPCClientSettings: configgrpc.GRPCClientSettings{
 					Endpoint: rcvCfg.Endpoint,
-					KeepaliveParameters: &configgrpc.KeepaliveConfig{
+					Keepalive: &configgrpc.KeepaliveClientConfig{
 						Time:                30 * time.Second,
 						Timeout:             25 * time.Second,
 						PermitWithoutStream: true,

--- a/exporter/otlpexporter/config_test.go
+++ b/exporter/otlpexporter/config_test.go
@@ -63,7 +63,7 @@ func TestLoadConfig(t *testing.T) {
 					},
 					Insecure: false,
 				},
-				KeepaliveParameters: &configgrpc.KeepaliveConfig{
+				Keepalive: &configgrpc.KeepaliveClientConfig{
 					Time:                20 * time.Second,
 					PermitWithoutStream: true,
 					Timeout:             30 * time.Second,

--- a/exporter/otlpexporter/exporter.go
+++ b/exporter/otlpexporter/exporter.go
@@ -27,7 +27,6 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 
-	"go.opentelemetry.io/collector/config/configgrpc"
 	otlpmetriccol "go.opentelemetry.io/collector/internal/data/opentelemetry-proto-gen/collector/metrics/v1"
 	otlptracecol "go.opentelemetry.io/collector/internal/data/opentelemetry-proto-gen/collector/trace/v1"
 	otlplogcol "go.opentelemetry.io/collector/internal/data/opentelemetry-proto-gen/logs/v1"
@@ -62,7 +61,7 @@ func newExporter(config *Config) (*exporterImp, error) {
 	e.config = config
 
 	var err error
-	e.dialOpts, err = configgrpc.GrpcSettingsToDialOptions(e.config.GRPCClientSettings)
+	e.dialOpts, err = e.config.GRPCClientSettings.ToDialOptions()
 	if err != nil {
 		return nil, err
 	}

--- a/exporter/otlpexporter/factory_test.go
+++ b/exporter/otlpexporter/factory_test.go
@@ -77,11 +77,11 @@ func TestCreateTraceExporter(t *testing.T) {
 			},
 		},
 		{
-			name: "KeepaliveParameters",
+			name: "Keepalive",
 			config: Config{
 				GRPCClientSettings: configgrpc.GRPCClientSettings{
 					Endpoint: endpoint,
-					KeepaliveParameters: &configgrpc.KeepaliveConfig{
+					Keepalive: &configgrpc.KeepaliveClientConfig{
 						Time:                30 * time.Second,
 						Timeout:             25 * time.Second,
 						PermitWithoutStream: true,

--- a/receiver/jaegerreceiver/trace_receiver.go
+++ b/receiver/jaegerreceiver/trace_receiver.go
@@ -395,7 +395,7 @@ func (jr *jReceiver) startAgent(_ component.Host) error {
 
 	// Start upstream grpc client before serving sampling endpoints over HTTP
 	if jr.config.RemoteSamplingClientSettings.Endpoint != "" {
-		grpcOpts, err := configgrpc.GrpcSettingsToDialOptions(jr.config.RemoteSamplingClientSettings)
+		grpcOpts, err := jr.config.RemoteSamplingClientSettings.ToDialOptions()
 		if err != nil {
 			jr.logger.Error("Error creating grpc dial options for remote sampling endpoint", zap.Error(err))
 			return err

--- a/receiver/opencensusreceiver/config.go
+++ b/receiver/opencensusreceiver/config.go
@@ -15,15 +15,8 @@
 package opencensusreceiver
 
 import (
-	"fmt"
-	"time"
-
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
-	"google.golang.org/grpc/keepalive"
-
+	"go.opentelemetry.io/collector/config/configgrpc"
 	"go.opentelemetry.io/collector/config/configmodels"
-	"go.opentelemetry.io/collector/config/configprotocol"
 )
 
 // Config defines configuration for OpenCensus receiver.
@@ -31,7 +24,7 @@ type Config struct {
 	configmodels.ReceiverSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
 
 	// Configures the receiver server protocol.
-	configprotocol.ProtocolServerSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
+	configgrpc.GRPCServerSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
 
 	// Transport to use: one of tcp or unix, defaults to tcp
 	Transport string `mapstructure:"transport"`
@@ -41,98 +34,21 @@ type Config struct {
 	// An empty list means that CORS is not enabled at all. A wildcard (*) can be
 	// used to match any origin or one or more characters of an origin.
 	CorsOrigins []string `mapstructure:"cors_allowed_origins"`
-
-	// Keepalive anchor for all the settings related to keepalive.
-	Keepalive *serverParametersAndEnforcementPolicy `mapstructure:"keepalive,omitempty"`
-
-	// MaxRecvMsgSizeMiB sets the maximum size (in MiB) of messages accepted by the server.
-	MaxRecvMsgSizeMiB uint64 `mapstructure:"max_recv_msg_size_mib,omitempty"`
-
-	// MaxConcurrentStreams sets the limit on the number of concurrent streams to each ServerTransport.
-	MaxConcurrentStreams uint32 `mapstructure:"max_concurrent_streams,omitempty"`
-}
-
-type serverParametersAndEnforcementPolicy struct {
-	ServerParameters  *keepaliveServerParameters  `mapstructure:"server_parameters,omitempty"`
-	EnforcementPolicy *keepaliveEnforcementPolicy `mapstructure:"enforcement_policy,omitempty"`
-}
-
-// keepaliveServerParameters allow configuration of the keepalive.ServerParameters.
-// The same default values as keepalive.ServerParameters are applicable and get applied by the server.
-// See https://godoc.org/google.golang.org/grpc/keepalive#ServerParameters for details.
-type keepaliveServerParameters struct {
-	MaxConnectionIdle     time.Duration `mapstructure:"max_connection_idle,omitempty"`
-	MaxConnectionAge      time.Duration `mapstructure:"max_connection_age,omitempty"`
-	MaxConnectionAgeGrace time.Duration `mapstructure:"max_connection_age_grace,omitempty"`
-	Time                  time.Duration `mapstructure:"time,omitempty"`
-	Timeout               time.Duration `mapstructure:"timeout,omitempty"`
-}
-
-// keepaliveEnforcementPolicy allow configuration of the keepalive.EnforcementPolicy.
-// The same default values as keepalive.EnforcementPolicy are applicable and get applied by the server.
-// See https://godoc.org/google.golang.org/grpc/keepalive#EnforcementPolicy for details.
-type keepaliveEnforcementPolicy struct {
-	MinTime             time.Duration `mapstructure:"min_time,omitempty"`
-	PermitWithoutStream bool          `mapstructure:"permit_without_stream,omitempty"`
 }
 
 func (rOpts *Config) buildOptions() ([]Option, error) {
 	var opts []Option
-	if rOpts.TLSCredentials != nil {
-		tlsCfg, err := rOpts.TLSCredentials.LoadTLSConfig()
-		if err != nil {
-			return nil, fmt.Errorf("error initializing OpenCensus receiver %q TLS Credentials: %v", rOpts.NameVal, err)
-		}
-		opts = append(opts, WithGRPCServerOptions(grpc.Creds(credentials.NewTLS(tlsCfg))))
-	}
-
 	if len(rOpts.CorsOrigins) > 0 {
 		opts = append(opts, WithCorsOrigins(rOpts.CorsOrigins))
 	}
 
-	grpcServerOptions := rOpts.grpcServerOptions()
+	grpcServerOptions, err := rOpts.GRPCServerSettings.ToServerOption()
+	if err != nil {
+		return nil, err
+	}
 	if len(grpcServerOptions) > 0 {
 		opts = append(opts, WithGRPCServerOptions(grpcServerOptions...))
 	}
 
 	return opts, nil
-}
-
-func (rOpts *Config) grpcServerOptions() []grpc.ServerOption {
-	var grpcServerOptions []grpc.ServerOption
-	if rOpts.MaxRecvMsgSizeMiB > 0 {
-		grpcServerOptions = append(grpcServerOptions, grpc.MaxRecvMsgSize(int(rOpts.MaxRecvMsgSizeMiB*1024*1024)))
-	}
-	if rOpts.MaxConcurrentStreams > 0 {
-		grpcServerOptions = append(grpcServerOptions, grpc.MaxConcurrentStreams(rOpts.MaxConcurrentStreams))
-	}
-	// The default values referenced in the GRPC docs are set within the server, so this code doesn't need
-	// to apply them over zero/nil values before passing these as grpc.ServerOptions.
-	// The following shows the server code for applying default grpc.ServerOptions.
-	// https://sourcegraph.com/github.com/grpc/grpc-go@120728e1f775e40a2a764341939b78d666b08260/-/blob/internal/transport/http2_server.go#L184-200
-	if rOpts.Keepalive != nil {
-		if rOpts.Keepalive.ServerParameters != nil {
-			svrParams := rOpts.Keepalive.ServerParameters
-			grpcServerOptions = append(grpcServerOptions, grpc.KeepaliveParams(keepalive.ServerParameters{
-				MaxConnectionIdle:     svrParams.MaxConnectionIdle,
-				MaxConnectionAge:      svrParams.MaxConnectionAge,
-				MaxConnectionAgeGrace: svrParams.MaxConnectionAgeGrace,
-				Time:                  svrParams.Time,
-				Timeout:               svrParams.Timeout,
-			}))
-		}
-		// The default values referenced in the GRPC are set within the server, so this code doesn't need
-		// to apply them over zero/nil values before passing these as grpc.ServerOptions.
-		// The following shows the server code for applying default grpc.ServerOptions.
-		// https://sourcegraph.com/github.com/grpc/grpc-go@120728e1f775e40a2a764341939b78d666b08260/-/blob/internal/transport/http2_server.go#L202-205
-		if rOpts.Keepalive.EnforcementPolicy != nil {
-			enfPol := rOpts.Keepalive.EnforcementPolicy
-			grpcServerOptions = append(grpcServerOptions, grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
-				MinTime:             enfPol.MinTime,
-				PermitWithoutStream: enfPol.PermitWithoutStream,
-			}))
-		}
-	}
-
-	return grpcServerOptions
 }

--- a/receiver/opencensusreceiver/factory.go
+++ b/receiver/opencensusreceiver/factory.go
@@ -20,6 +20,7 @@ import (
 	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config/configgrpc"
 	"go.opentelemetry.io/collector/config/configmodels"
 	"go.opentelemetry.io/collector/config/configprotocol"
 	"go.opentelemetry.io/collector/consumer"
@@ -51,8 +52,10 @@ func (f *Factory) CreateDefaultConfig() configmodels.Receiver {
 			TypeVal: typeStr,
 			NameVal: typeStr,
 		},
-		ProtocolServerSettings: configprotocol.ProtocolServerSettings{
-			Endpoint: "0.0.0.0:55678",
+		GRPCServerSettings: configgrpc.GRPCServerSettings{
+			ProtocolServerSettings: configprotocol.ProtocolServerSettings{
+				Endpoint: "0.0.0.0:55678",
+			},
 		},
 		Transport: "tcp",
 	}

--- a/receiver/opencensusreceiver/factory_test.go
+++ b/receiver/opencensusreceiver/factory_test.go
@@ -25,6 +25,7 @@ import (
 
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/configcheck"
+	"go.opentelemetry.io/collector/config/configgrpc"
 	"go.opentelemetry.io/collector/config/configmodels"
 	"go.opentelemetry.io/collector/config/configprotocol"
 	"go.opentelemetry.io/collector/exporter/exportertest"
@@ -61,8 +62,10 @@ func TestCreateTraceReceiver(t *testing.T) {
 		TypeVal: typeStr,
 		NameVal: typeStr,
 	}
-	defaultProtocolSettings := configprotocol.ProtocolServerSettings{
-		Endpoint: endpoint,
+	defaultGRPCSettings := configgrpc.GRPCServerSettings{
+		ProtocolServerSettings: configprotocol.ProtocolServerSettings{
+			Endpoint: endpoint,
+		},
 	}
 	tests := []struct {
 		name    string
@@ -72,9 +75,9 @@ func TestCreateTraceReceiver(t *testing.T) {
 		{
 			name: "default",
 			cfg: &Config{
-				ReceiverSettings:       defaultReceiverSettings,
-				ProtocolServerSettings: defaultProtocolSettings,
-				Transport:              "tcp",
+				ReceiverSettings:   defaultReceiverSettings,
+				GRPCServerSettings: defaultGRPCSettings,
+				Transport:          "tcp",
 			},
 		},
 		{
@@ -84,8 +87,10 @@ func TestCreateTraceReceiver(t *testing.T) {
 					TypeVal: typeStr,
 					NameVal: typeStr,
 				},
-				ProtocolServerSettings: configprotocol.ProtocolServerSettings{
-					Endpoint: "localhost:112233",
+				GRPCServerSettings: configgrpc.GRPCServerSettings{
+					ProtocolServerSettings: configprotocol.ProtocolServerSettings{
+						Endpoint: "localhost:112233",
+					},
 				},
 				Transport: "tcp",
 			},
@@ -94,10 +99,15 @@ func TestCreateTraceReceiver(t *testing.T) {
 		{
 			name: "max-msg-size-and-concurrent-connections",
 			cfg: &Config{
-				ReceiverSettings:     defaultReceiverSettings,
-				Transport:            "tcp",
-				MaxRecvMsgSizeMiB:    32,
-				MaxConcurrentStreams: 16,
+				ReceiverSettings: defaultReceiverSettings,
+				GRPCServerSettings: configgrpc.GRPCServerSettings{
+					ProtocolServerSettings: configprotocol.ProtocolServerSettings{
+						Endpoint: endpoint,
+					},
+					MaxRecvMsgSizeMiB:    32,
+					MaxConcurrentStreams: 16,
+				},
+				Transport: "tcp",
 			},
 		},
 	}
@@ -127,8 +137,10 @@ func TestCreateMetricReceiver(t *testing.T) {
 		TypeVal: typeStr,
 		NameVal: typeStr,
 	}
-	defaultProtocolSettings := configprotocol.ProtocolServerSettings{
-		Endpoint: endpoint,
+	defaultGRPCSettings := configgrpc.GRPCServerSettings{
+		ProtocolServerSettings: configprotocol.ProtocolServerSettings{
+			Endpoint: endpoint,
+		},
 	}
 
 	tests := []struct {
@@ -139,9 +151,9 @@ func TestCreateMetricReceiver(t *testing.T) {
 		{
 			name: "default",
 			cfg: &Config{
-				ReceiverSettings:       defaultReceiverSettings,
-				ProtocolServerSettings: defaultProtocolSettings,
-				Transport:              "tcp",
+				ReceiverSettings:   defaultReceiverSettings,
+				GRPCServerSettings: defaultGRPCSettings,
+				Transport:          "tcp",
 			},
 		},
 		{
@@ -151,8 +163,10 @@ func TestCreateMetricReceiver(t *testing.T) {
 					TypeVal: typeStr,
 					NameVal: typeStr,
 				},
-				ProtocolServerSettings: configprotocol.ProtocolServerSettings{
-					Endpoint: "327.0.0.1:1122",
+				GRPCServerSettings: configgrpc.GRPCServerSettings{
+					ProtocolServerSettings: configprotocol.ProtocolServerSettings{
+						Endpoint: "327.0.0.1:1122",
+					},
 				},
 				Transport: "tcp",
 			},
@@ -162,16 +176,21 @@ func TestCreateMetricReceiver(t *testing.T) {
 			name: "keepalive",
 			cfg: &Config{
 				ReceiverSettings: defaultReceiverSettings,
-				Transport:        "tcp",
-				Keepalive: &serverParametersAndEnforcementPolicy{
-					ServerParameters: &keepaliveServerParameters{
-						MaxConnectionAge: 60 * time.Second,
+				GRPCServerSettings: configgrpc.GRPCServerSettings{
+					ProtocolServerSettings: configprotocol.ProtocolServerSettings{
+						Endpoint: endpoint,
 					},
-					EnforcementPolicy: &keepaliveEnforcementPolicy{
-						MinTime:             30 * time.Second,
-						PermitWithoutStream: true,
+					Keepalive: &configgrpc.KeepaliveServerConfig{
+						ServerParameters: &configgrpc.KeepaliveServerParameters{
+							MaxConnectionAge: 60 * time.Second,
+						},
+						EnforcementPolicy: &configgrpc.KeepaliveEnforcementPolicy{
+							MinTime:             30 * time.Second,
+							PermitWithoutStream: true,
+						},
 					},
 				},
+				Transport: "tcp",
 			},
 		},
 	}

--- a/receiver/otlpreceiver/config.go
+++ b/receiver/otlpreceiver/config.go
@@ -15,15 +15,8 @@
 package otlpreceiver
 
 import (
-	"fmt"
-	"time"
-
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
-	"google.golang.org/grpc/keepalive"
-
+	"go.opentelemetry.io/collector/config/configgrpc"
 	"go.opentelemetry.io/collector/config/configmodels"
-	"go.opentelemetry.io/collector/config/configprotocol"
 )
 
 // Config defines configuration for OTLP receiver.
@@ -31,7 +24,7 @@ type Config struct {
 	configmodels.ReceiverSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
 
 	// Configures the receiver server protocol.
-	configprotocol.ProtocolServerSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
+	configgrpc.GRPCServerSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
 
 	// Transport to use: one of tcp or unix, defaults to tcp
 	Transport string `mapstructure:"transport"`
@@ -41,98 +34,21 @@ type Config struct {
 	// An empty list means that CORS is not enabled at all. A wildcard (*) can be
 	// used to match any origin or one or more characters of an origin.
 	CorsOrigins []string `mapstructure:"cors_allowed_origins"`
-
-	// Keepalive anchor for all the settings related to keepalive.
-	Keepalive *serverParametersAndEnforcementPolicy `mapstructure:"keepalive,omitempty"`
-
-	// MaxRecvMsgSizeMiB sets the maximum size (in MiB) of messages accepted by the server.
-	MaxRecvMsgSizeMiB uint64 `mapstructure:"max_recv_msg_size_mib,omitempty"`
-
-	// MaxConcurrentStreams sets the limit on the number of concurrent streams to each ServerTransport.
-	// TODO(nilebox): This setting affecting HTTP/2 streams need to be tested
-	MaxConcurrentStreams uint32 `mapstructure:"max_concurrent_streams,omitempty"`
-}
-
-type serverParametersAndEnforcementPolicy struct {
-	ServerParameters  *keepaliveServerParameters  `mapstructure:"server_parameters,omitempty"`
-	EnforcementPolicy *keepaliveEnforcementPolicy `mapstructure:"enforcement_policy,omitempty"`
-}
-
-// keepaliveServerParameters allow configuration of the keepalive.ServerParameters.
-// The same default values as keepalive.ServerParameters are applicable and get applied by the server.
-// See https://godoc.org/google.golang.org/grpc/keepalive#ServerParameters for details.
-type keepaliveServerParameters struct {
-	MaxConnectionIdle     time.Duration `mapstructure:"max_connection_idle,omitempty"`
-	MaxConnectionAge      time.Duration `mapstructure:"max_connection_age,omitempty"`
-	MaxConnectionAgeGrace time.Duration `mapstructure:"max_connection_age_grace,omitempty"`
-	Time                  time.Duration `mapstructure:"time,omitempty"`
-	Timeout               time.Duration `mapstructure:"timeout,omitempty"`
-}
-
-// keepaliveEnforcementPolicy allow configuration of the keepalive.EnforcementPolicy.
-// The same default values as keepalive.EnforcementPolicy are applicable and get applied by the server.
-// See https://godoc.org/google.golang.org/grpc/keepalive#EnforcementPolicy for details.
-type keepaliveEnforcementPolicy struct {
-	MinTime             time.Duration `mapstructure:"min_time,omitempty"`
-	PermitWithoutStream bool          `mapstructure:"permit_without_stream,omitempty"`
 }
 
 func (rOpts *Config) buildOptions() ([]Option, error) {
 	var opts []Option
-	if rOpts.TLSCredentials != nil {
-		tlsCfg, err := rOpts.TLSCredentials.LoadTLSConfig()
-		if err != nil {
-			return nil, fmt.Errorf("error initializing OTLP receiver %q TLS Credentials: %v", rOpts.NameVal, err)
-		}
-		opts = append(opts, WithGRPCServerOptions(grpc.Creds(credentials.NewTLS(tlsCfg))))
-	}
 	if len(rOpts.CorsOrigins) > 0 {
 		opts = append(opts, WithCorsOrigins(rOpts.CorsOrigins))
 	}
 
-	grpcServerOptions := rOpts.grpcServerOptions()
+	grpcServerOptions, err := rOpts.GRPCServerSettings.ToServerOption()
+	if err != nil {
+		return nil, err
+	}
 	if len(grpcServerOptions) > 0 {
 		opts = append(opts, WithGRPCServerOptions(grpcServerOptions...))
 	}
 
 	return opts, nil
-}
-
-func (rOpts *Config) grpcServerOptions() []grpc.ServerOption {
-	var grpcServerOptions []grpc.ServerOption
-	if rOpts.MaxRecvMsgSizeMiB > 0 {
-		grpcServerOptions = append(grpcServerOptions, grpc.MaxRecvMsgSize(int(rOpts.MaxRecvMsgSizeMiB*1024*1024)))
-	}
-	if rOpts.MaxConcurrentStreams > 0 {
-		grpcServerOptions = append(grpcServerOptions, grpc.MaxConcurrentStreams(rOpts.MaxConcurrentStreams))
-	}
-	// The default values referenced in the GRPC docs are set within the server, so this code doesn't need
-	// to apply them over zero/nil values before passing these as grpc.ServerOptions.
-	// The following shows the server code for applying default grpc.ServerOptions.
-	// https://sourcegraph.com/github.com/grpc/grpc-go@120728e1f775e40a2a764341939b78d666b08260/-/blob/internal/transport/http2_server.go#L184-200
-	if rOpts.Keepalive != nil {
-		if rOpts.Keepalive.ServerParameters != nil {
-			svrParams := rOpts.Keepalive.ServerParameters
-			grpcServerOptions = append(grpcServerOptions, grpc.KeepaliveParams(keepalive.ServerParameters{
-				MaxConnectionIdle:     svrParams.MaxConnectionIdle,
-				MaxConnectionAge:      svrParams.MaxConnectionAge,
-				MaxConnectionAgeGrace: svrParams.MaxConnectionAgeGrace,
-				Time:                  svrParams.Time,
-				Timeout:               svrParams.Timeout,
-			}))
-		}
-		// The default values referenced in the GRPC are set within the server, so this code doesn't need
-		// to apply them over zero/nil values before passing these as grpc.ServerOptions.
-		// The following shows the server code for applying default grpc.ServerOptions.
-		// https://sourcegraph.com/github.com/grpc/grpc-go@120728e1f775e40a2a764341939b78d666b08260/-/blob/internal/transport/http2_server.go#L202-205
-		if rOpts.Keepalive.EnforcementPolicy != nil {
-			enfPol := rOpts.Keepalive.EnforcementPolicy
-			grpcServerOptions = append(grpcServerOptions, grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
-				MinTime:             enfPol.MinTime,
-				PermitWithoutStream: enfPol.PermitWithoutStream,
-			}))
-		}
-	}
-
-	return grpcServerOptions
 }

--- a/receiver/otlpreceiver/factory.go
+++ b/receiver/otlpreceiver/factory.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config/configgrpc"
 	"go.opentelemetry.io/collector/config/configmodels"
 	"go.opentelemetry.io/collector/config/configprotocol"
 	"go.opentelemetry.io/collector/consumer"
@@ -49,8 +50,10 @@ func (f *Factory) CreateDefaultConfig() configmodels.Receiver {
 			TypeVal: typeStr,
 			NameVal: typeStr,
 		},
-		ProtocolServerSettings: configprotocol.ProtocolServerSettings{
-			Endpoint: "0.0.0.0:55680",
+		GRPCServerSettings: configgrpc.GRPCServerSettings{
+			ProtocolServerSettings: configprotocol.ProtocolServerSettings{
+				Endpoint: "0.0.0.0:55680",
+			},
 		},
 		Transport: "tcp",
 	}

--- a/receiver/otlpreceiver/factory_test.go
+++ b/receiver/otlpreceiver/factory_test.go
@@ -26,6 +26,7 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/configcheck"
+	"go.opentelemetry.io/collector/config/configgrpc"
 	"go.opentelemetry.io/collector/config/configmodels"
 	"go.opentelemetry.io/collector/config/configprotocol"
 	"go.opentelemetry.io/collector/exporter/exportertest"
@@ -63,8 +64,10 @@ func TestCreateTraceReceiver(t *testing.T) {
 		TypeVal: typeStr,
 		NameVal: typeStr,
 	}
-	defaultProtocolSettings := configprotocol.ProtocolServerSettings{
-		Endpoint: endpoint,
+	defaultGRPCSettings := configgrpc.GRPCServerSettings{
+		ProtocolServerSettings: configprotocol.ProtocolServerSettings{
+			Endpoint: endpoint,
+		},
 	}
 
 	tests := []struct {
@@ -75,9 +78,9 @@ func TestCreateTraceReceiver(t *testing.T) {
 		{
 			name: "default",
 			cfg: &Config{
-				ReceiverSettings:       defaultReceiverSettings,
-				ProtocolServerSettings: defaultProtocolSettings,
-				Transport:              "tcp",
+				ReceiverSettings:   defaultReceiverSettings,
+				GRPCServerSettings: defaultGRPCSettings,
+				Transport:          "tcp",
 			},
 		},
 		{
@@ -87,8 +90,10 @@ func TestCreateTraceReceiver(t *testing.T) {
 					TypeVal: typeStr,
 					NameVal: typeStr,
 				},
-				ProtocolServerSettings: configprotocol.ProtocolServerSettings{
-					Endpoint: "localhost:112233",
+				GRPCServerSettings: configgrpc.GRPCServerSettings{
+					ProtocolServerSettings: configprotocol.ProtocolServerSettings{
+						Endpoint: "localhost:112233",
+					},
 				},
 				Transport: "tcp",
 			},
@@ -97,10 +102,15 @@ func TestCreateTraceReceiver(t *testing.T) {
 		{
 			name: "max-msg-size-and-concurrent-connections",
 			cfg: &Config{
-				ReceiverSettings:     defaultReceiverSettings,
-				Transport:            "tcp",
-				MaxRecvMsgSizeMiB:    32,
-				MaxConcurrentStreams: 16,
+				ReceiverSettings: defaultReceiverSettings,
+				GRPCServerSettings: configgrpc.GRPCServerSettings{
+					ProtocolServerSettings: configprotocol.ProtocolServerSettings{
+						Endpoint: endpoint,
+					},
+					MaxRecvMsgSizeMiB:    32,
+					MaxConcurrentStreams: 16,
+				},
+				Transport: "tcp",
 			},
 		},
 	}
@@ -129,9 +139,12 @@ func TestCreateMetricReceiver(t *testing.T) {
 		TypeVal: typeStr,
 		NameVal: typeStr,
 	}
-	defaultProtocolSettings := configprotocol.ProtocolServerSettings{
-		Endpoint: endpoint,
+	defaultGRPCSettings := configgrpc.GRPCServerSettings{
+		ProtocolServerSettings: configprotocol.ProtocolServerSettings{
+			Endpoint: endpoint,
+		},
 	}
+
 	tests := []struct {
 		name    string
 		cfg     *Config
@@ -140,9 +153,9 @@ func TestCreateMetricReceiver(t *testing.T) {
 		{
 			name: "default",
 			cfg: &Config{
-				ReceiverSettings:       defaultReceiverSettings,
-				ProtocolServerSettings: defaultProtocolSettings,
-				Transport:              "tcp",
+				ReceiverSettings:   defaultReceiverSettings,
+				GRPCServerSettings: defaultGRPCSettings,
+				Transport:          "tcp",
 			},
 		},
 		{
@@ -152,8 +165,10 @@ func TestCreateMetricReceiver(t *testing.T) {
 					TypeVal: typeStr,
 					NameVal: typeStr,
 				},
-				ProtocolServerSettings: configprotocol.ProtocolServerSettings{
-					Endpoint: "327.0.0.1:1122",
+				GRPCServerSettings: configgrpc.GRPCServerSettings{
+					ProtocolServerSettings: configprotocol.ProtocolServerSettings{
+						Endpoint: "327.0.0.1:1122",
+					},
 				},
 				Transport: "tcp",
 			},
@@ -163,16 +178,21 @@ func TestCreateMetricReceiver(t *testing.T) {
 			name: "keepalive",
 			cfg: &Config{
 				ReceiverSettings: defaultReceiverSettings,
-				Transport:        "tcp",
-				Keepalive: &serverParametersAndEnforcementPolicy{
-					ServerParameters: &keepaliveServerParameters{
-						MaxConnectionAge: 60 * time.Second,
+				GRPCServerSettings: configgrpc.GRPCServerSettings{
+					ProtocolServerSettings: configprotocol.ProtocolServerSettings{
+						Endpoint: endpoint,
 					},
-					EnforcementPolicy: &keepaliveEnforcementPolicy{
-						MinTime:             30 * time.Second,
-						PermitWithoutStream: true,
+					Keepalive: &configgrpc.KeepaliveServerConfig{
+						ServerParameters: &configgrpc.KeepaliveServerParameters{
+							MaxConnectionAge: 60 * time.Second,
+						},
+						EnforcementPolicy: &configgrpc.KeepaliveEnforcementPolicy{
+							MinTime:             30 * time.Second,
+							PermitWithoutStream: true,
+						},
 					},
 				},
+				Transport: "tcp",
 			},
 		},
 	}


### PR DESCRIPTION
Backwards compatible change for the configuration.

Depends on https://github.com/open-telemetry/opentelemetry-collector/pull/1172

Fixes https://github.com/open-telemetry/opentelemetry-collector/issues/1014