### PR TITLE
mTLS: Add support to configure client CA and enforce ClientAuth

### DIFF
--- a/config/configgrpc/configgrpc.go
+++ b/config/configgrpc/configgrpc.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/encoding/gzip"
 	"google.golang.org/grpc/keepalive"
 
@@ -79,9 +80,13 @@ func GrpcSettingsToDialOptions(settings GRPCClientSettings) ([]grpc.DialOption, 
 		}
 	}
 
-	tlsDialOption, err := settings.TLSSetting.LoadgRPCTLSClientCredentials()
+	tlsCfg, err := settings.TLSSetting.LoadTLSConfig()
 	if err != nil {
 		return nil, err
+	}
+	tlsDialOption := grpc.WithInsecure()
+	if tlsCfg != nil {
+		tlsDialOption = grpc.WithTransportCredentials(credentials.NewTLS(tlsCfg))
 	}
 	opts = append(opts, tlsDialOption)
 

--- a/config/configtls/configtls.go
+++ b/config/configtls/configtls.go
@@ -20,9 +20,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
-
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
 )
 
 // TLSSetting exposes the common client and server TLS configurations.
@@ -74,7 +71,7 @@ type TLSServerSetting struct {
 
 // LoadTLSConfig loads TLS certificates and returns a tls.Config.
 // This will set the RootCAs and Certificates of a tls.Config.
-func (c TLSSetting) LoadTLSConfig() (*tls.Config, error) {
+func (c TLSSetting) loadTLSConfig() (*tls.Config, error) {
 	// There is no need to load the System Certs for RootCAs because
 	// if the value is nil, it will default to checking against th System Certs.
 	var err error
@@ -119,25 +116,23 @@ func (c TLSSetting) loadCert(caPath string) (*x509.CertPool, error) {
 	return certPool, nil
 }
 
-func (c TLSClientSetting) LoadgRPCTLSClientCredentials() (grpc.DialOption, error) {
+func (c TLSClientSetting) LoadTLSConfig() (*tls.Config, error) {
 	if c.Insecure && c.CAFile == "" {
-		return grpc.WithInsecure(), nil
+		return nil, nil
 	}
 
-	tlsConf, err := c.TLSSetting.LoadTLSConfig()
+	tlsCfg, err := c.TLSSetting.loadTLSConfig()
 	if err != nil {
 		return nil, fmt.Errorf("failed to load TLS config: %w", err)
 	}
-	tlsConf.ServerName = c.ServerName
-	creds := credentials.NewTLS(tlsConf)
-	return grpc.WithTransportCredentials(creds), nil
+	tlsCfg.ServerName = c.ServerName
+	return tlsCfg, nil
 }
 
-func (c TLSServerSetting) LoadgRPCTLSServerCredentials() (grpc.ServerOption, error) {
-	tlsConf, err := c.LoadTLSConfig()
+func (c TLSServerSetting) LoadTLSConfig() (*tls.Config, error) {
+	tlsCfg, err := c.loadTLSConfig()
 	if err != nil {
 		return nil, fmt.Errorf("failed to load TLS config: %w", err)
 	}
-	creds := credentials.NewTLS(tlsConf)
-	return grpc.Creds(creds), nil
+	return tlsCfg, nil
 }

--- a/config/configtls/configtls_test.go
+++ b/config/configtls/configtls_test.go
@@ -123,7 +123,7 @@ func TestOptionsToConfig(t *testing.T) {
 	}
 }
 
-func TestTLSSetting_LoadTLSClientConfigError(t *testing.T) {
+func TestLoadTLSClientConfigError(t *testing.T) {
 	tlsSetting := TLSClientSetting{
 		TLSSetting: TLSSetting{
 			CertFile: "doesnt/exist",
@@ -134,7 +134,21 @@ func TestTLSSetting_LoadTLSClientConfigError(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestTLSSetting_LoadTLSServerConfigError(t *testing.T) {
+func TestLoadTLSClientConfig(t *testing.T) {
+	tlsSetting := TLSClientSetting{
+		Insecure: true,
+	}
+	tlsCfg, err := tlsSetting.LoadTLSConfig()
+	assert.NoError(t, err)
+	assert.Nil(t, tlsCfg)
+
+	tlsSetting = TLSClientSetting{}
+	tlsCfg, err = tlsSetting.LoadTLSConfig()
+	assert.NoError(t, err)
+	assert.NotNil(t, tlsCfg)
+}
+
+func TestLoadTLSServerConfigError(t *testing.T) {
 	tlsSetting := TLSServerSetting{
 		TLSSetting: TLSSetting{
 			CertFile: "doesnt/exist",
@@ -143,4 +157,17 @@ func TestTLSSetting_LoadTLSServerConfigError(t *testing.T) {
 	}
 	_, err := tlsSetting.LoadTLSConfig()
 	assert.Error(t, err)
+
+	tlsSetting = TLSServerSetting{
+		ClientCAFile: "doesnt/exist",
+	}
+	_, err = tlsSetting.LoadTLSConfig()
+	assert.Error(t, err)
+}
+
+func TestLoadTLSServerConfig(t *testing.T) {
+	tlsSetting := TLSServerSetting{}
+	tlsCfg, err := tlsSetting.LoadTLSConfig()
+	assert.NoError(t, err)
+	assert.NotNil(t, tlsCfg)
 }

--- a/config/configtls/configtls_test.go
+++ b/config/configtls/configtls_test.go
@@ -111,7 +111,7 @@ func TestOptionsToConfig(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			cfg, err := test.options.LoadTLSConfig()
+			cfg, err := test.options.loadTLSConfig()
 			if test.expectError != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), test.expectError)
@@ -123,13 +123,24 @@ func TestOptionsToConfig(t *testing.T) {
 	}
 }
 
-func TestTLSSetting_LoadgRPCTLSServerCredentialsError(t *testing.T) {
+func TestTLSSetting_LoadTLSClientConfigError(t *testing.T) {
+	tlsSetting := TLSClientSetting{
+		TLSSetting: TLSSetting{
+			CertFile: "doesnt/exist",
+			KeyFile:  "doesnt/exist",
+		},
+	}
+	_, err := tlsSetting.LoadTLSConfig()
+	assert.Error(t, err)
+}
+
+func TestTLSSetting_LoadTLSServerConfigError(t *testing.T) {
 	tlsSetting := TLSServerSetting{
 		TLSSetting: TLSSetting{
 			CertFile: "doesnt/exist",
 			KeyFile:  "doesnt/exist",
 		},
 	}
-	_, err := tlsSetting.LoadgRPCTLSServerCredentials()
+	_, err := tlsSetting.LoadTLSConfig()
 	assert.Error(t, err)
 }

--- a/exporter/jaegerexporter/exporter_test.go
+++ b/exporter/jaegerexporter/exporter_test.go
@@ -190,10 +190,12 @@ func TestMutualTLS(t *testing.T) {
 	clientKeyPath := path.Join(".", "testdata", "client.key")
 
 	// start gRPC Jaeger server
-	tlsCfgOpts := configtls.TLSSetting{
-		CAFile:   caPath,
-		CertFile: serverCertPath,
-		KeyFile:  serverKeyPath,
+	tlsCfgOpts := configtls.TLSServerSetting{
+		TLSSetting: configtls.TLSSetting{
+			CAFile:   caPath,
+			CertFile: serverCertPath,
+			KeyFile:  serverKeyPath,
+		},
 	}
 	tlsCfg, err := tlsCfgOpts.LoadTLSConfig()
 	require.NoError(t, err)

--- a/receiver/jaegerreceiver/factory.go
+++ b/receiver/jaegerreceiver/factory.go
@@ -25,6 +25,7 @@ import (
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configerror"
@@ -141,11 +142,11 @@ func (f *Factory) CreateTraceReceiver(
 		}
 
 		if protoGRPC.TLSCredentials != nil {
-			option, err := protoGRPC.TLSCredentials.LoadgRPCTLSServerCredentials()
+			tlsCfg, err := protoGRPC.TLSCredentials.LoadTLSConfig()
 			if err != nil {
 				return nil, fmt.Errorf("failed to configure TLS: %v", err)
 			}
-			grpcServerOptions = append(grpcServerOptions, option)
+			grpcServerOptions = append(grpcServerOptions, grpc.Creds(credentials.NewTLS(tlsCfg)))
 		}
 		config.CollectorGRPCOptions = grpcServerOptions
 	}

--- a/receiver/jaegerreceiver/trace_receiver_test.go
+++ b/receiver/jaegerreceiver/trace_receiver_test.go
@@ -260,9 +260,9 @@ func TestGRPCReceptionWithTLS(t *testing.T) {
 		},
 	}
 
-	tlsOption, _ := tlsCreds.LoadgRPCTLSServerCredentials()
-
-	grpcServerOptions = append(grpcServerOptions, tlsOption)
+	tlsCfg, err := tlsCreds.LoadTLSConfig()
+	assert.NoError(t, err)
+	grpcServerOptions = append(grpcServerOptions, grpc.Creds(credentials.NewTLS(tlsCfg)))
 
 	port := testutils.GetAvailablePort(t)
 	config := &Configuration{
@@ -552,10 +552,12 @@ func TestSamplingStrategiesMutualTLS(t *testing.T) {
 	clientKeyPath := path.Join(".", "testdata", "client.key")
 
 	// start gRPC server that serves sampling strategies
-	tlsCfgOpts := configtls.TLSSetting{
-		CAFile:   caPath,
-		CertFile: serverCertPath,
-		KeyFile:  serverKeyPath,
+	tlsCfgOpts := configtls.TLSServerSetting{
+		TLSSetting: configtls.TLSSetting{
+			CAFile:   caPath,
+			CertFile: serverCertPath,
+			KeyFile:  serverKeyPath,
+		},
 	}
 	tlsCfg, err := tlsCfgOpts.LoadTLSConfig()
 	require.NoError(t, err)

--- a/receiver/opencensusreceiver/config.go
+++ b/receiver/opencensusreceiver/config.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/keepalive"
 
 	"go.opentelemetry.io/collector/config/configmodels"
@@ -78,11 +79,11 @@ type keepaliveEnforcementPolicy struct {
 func (rOpts *Config) buildOptions() ([]Option, error) {
 	var opts []Option
 	if rOpts.TLSCredentials != nil {
-		tlsCredsOptions, err := rOpts.TLSCredentials.LoadgRPCTLSServerCredentials()
+		tlsCfg, err := rOpts.TLSCredentials.LoadTLSConfig()
 		if err != nil {
 			return nil, fmt.Errorf("error initializing OpenCensus receiver %q TLS Credentials: %v", rOpts.NameVal, err)
 		}
-		opts = append(opts, WithGRPCServerOptions(tlsCredsOptions))
+		opts = append(opts, WithGRPCServerOptions(grpc.Creds(credentials.NewTLS(tlsCfg))))
 	}
 
 	if len(rOpts.CorsOrigins) > 0 {

--- a/receiver/otlpreceiver/config.go
+++ b/receiver/otlpreceiver/config.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/keepalive"
 
 	"go.opentelemetry.io/collector/config/configmodels"
@@ -79,11 +80,11 @@ type keepaliveEnforcementPolicy struct {
 func (rOpts *Config) buildOptions() ([]Option, error) {
 	var opts []Option
 	if rOpts.TLSCredentials != nil {
-		tlsCredsOptions, err := rOpts.TLSCredentials.LoadgRPCTLSServerCredentials()
+		tlsCfg, err := rOpts.TLSCredentials.LoadTLSConfig()
 		if err != nil {
 			return nil, fmt.Errorf("error initializing OTLP receiver %q TLS Credentials: %v", rOpts.NameVal, err)
 		}
-		opts = append(opts, WithGRPCServerOptions(tlsCredsOptions))
+		opts = append(opts, WithGRPCServerOptions(grpc.Creds(credentials.NewTLS(tlsCfg))))
 	}
 	if len(rOpts.CorsOrigins) > 0 {
 		opts = append(opts, WithCorsOrigins(rOpts.CorsOrigins))


### PR DESCRIPTION
Depends on https://github.com/open-telemetry/opentelemetry-collector/pull/1184

Fixes https://github.com/open-telemetry/opentelemetry-collector/issues/963