### PR TITLE
 Add config settings for Http Client, change Zipkin to use it.

### DIFF
--- a/config/confighttp/confighttp.go
+++ b/config/confighttp/confighttp.go
@@ -1,0 +1,48 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package confighttp
+
+import (
+	"net/http"
+	"time"
+
+	"go.opentelemetry.io/collector/config/configtls"
+)
+
+type HTTPClientSettings struct {
+	// The target URL to send data to (e.g.: http://some.url:9411/v1/trace).
+	Endpoint string `mapstructure:"endpoint"`
+
+	// TLSSetting struct exposes TLS client configuration.
+	TLSSetting configtls.TLSClientSetting `mapstructure:",squash"`
+
+	// Timeout parameter configures `http.Client.Timeout`.
+	Timeout time.Duration `mapstructure:"timeout,omitempty"`
+}
+
+func (hcs *HTTPClientSettings) ToClient() (*http.Client, error) {
+	tlsCfg, err := hcs.TLSSetting.LoadTLSConfig()
+	if err != nil {
+		return nil, err
+	}
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	if tlsCfg != nil {
+		transport.TLSClientConfig = tlsCfg
+	}
+	return &http.Client{
+		Transport: transport,
+		Timeout:   hcs.Timeout,
+	}, nil
+}

--- a/config/confighttp/confighttp_test.go
+++ b/config/confighttp/confighttp_test.go
@@ -1,0 +1,63 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package confighttp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"go.opentelemetry.io/collector/config/configtls"
+)
+
+func TestInvalidPemFile(t *testing.T) {
+	tests := []struct {
+		settings HTTPClientSettings
+		err      string
+	}{
+		{
+			err: "^failed to load TLS config: failed to load CA CertPool: failed to load CA /doesnt/exist:",
+			settings: HTTPClientSettings{
+				Endpoint: "",
+				TLSSetting: configtls.TLSClientSetting{
+					TLSSetting: configtls.TLSSetting{
+						CAFile: "/doesnt/exist",
+					},
+					Insecure:   false,
+					ServerName: "",
+				},
+			},
+		},
+		{
+			err: "^failed to load TLS config: for auth via TLS, either both certificate and key must be supplied, or neither",
+			settings: HTTPClientSettings{
+				Endpoint: "",
+				TLSSetting: configtls.TLSClientSetting{
+					TLSSetting: configtls.TLSSetting{
+						CertFile: "/doesnt/exist",
+					},
+					Insecure:   false,
+					ServerName: "",
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.err, func(t *testing.T) {
+			_, err := test.settings.ToClient()
+			assert.Regexp(t, test.err, err)
+		})
+	}
+}

--- a/exporter/zipkinexporter/config.go
+++ b/exporter/zipkinexporter/config.go
@@ -15,6 +15,7 @@
 package zipkinexporter
 
 import (
+	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/config/configmodels"
 )
 
@@ -22,9 +23,10 @@ import (
 type Config struct {
 	configmodels.ExporterSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct.
 
-	// The URL to send the Zipkin trace data to (e.g.:
-	// http://some.url:9411/api/v2/spans).
-	URL    string `mapstructure:"url"`
+	// Configures the exporter client.
+	// The Endpoint to send the Zipkin trace data to (e.g.: http://some.url:9411/api/v2/spans).
+	confighttp.HTTPClientSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct.
+
 	Format string `mapstructure:"format"`
 
 	DefaultServiceName string `mapstructure:"default_service_name"`

--- a/exporter/zipkinexporter/config_test.go
+++ b/exporter/zipkinexporter/config_test.go
@@ -40,13 +40,13 @@ func TestLoadConfig(t *testing.T) {
 
 	// URL doesn't have a default value so set it directly.
 	defaultCfg := factory.CreateDefaultConfig().(*Config)
-	defaultCfg.URL = "http://some.location.org:9411/api/v2/spans"
+	defaultCfg.Endpoint = "http://some.location.org:9411/api/v2/spans"
 	assert.Equal(t, defaultCfg, e0)
 	assert.Equal(t, "json", e0.(*Config).Format)
 
 	e1 := cfg.Exporters["zipkin/2"]
 	assert.Equal(t, "zipkin/2", e1.(*Config).Name())
-	assert.Equal(t, "https://somedest:1234/api/v2/spans", e1.(*Config).URL)
+	assert.Equal(t, "https://somedest:1234/api/v2/spans", e1.(*Config).Endpoint)
 	assert.Equal(t, "proto", e1.(*Config).Format)
 	_, err = factory.CreateTraceExporter(zap.NewNop(), e1)
 	require.NoError(t, err)

--- a/exporter/zipkinexporter/factory_test.go
+++ b/exporter/zipkinexporter/factory_test.go
@@ -46,18 +46,14 @@ func TestCreateInstanceViaFactory(t *testing.T) {
 
 	// Default config doesn't have default endpoint so creating from it should
 	// fail.
-	ze, err := factory.CreateTraceExporter(
-		zap.NewNop(),
-		cfg)
+	ze, err := factory.CreateTraceExporter(zap.NewNop(), cfg)
 	assert.Error(t, err)
 	assert.Nil(t, ze)
 
 	// URL doesn't have a default value so set it directly.
 	zeCfg := cfg.(*Config)
-	zeCfg.URL = "http://some.location.org:9411/api/v2/spans"
-	ze, err = factory.CreateTraceExporter(
-		zap.NewNop(),
-		cfg)
+	zeCfg.Endpoint = "http://some.location.org:9411/api/v2/spans"
+	ze, err = factory.CreateTraceExporter(zap.NewNop(), cfg)
 	assert.NoError(t, err)
 	assert.NotNil(t, ze)
 }

--- a/exporter/zipkinexporter/testdata/config.yaml
+++ b/exporter/zipkinexporter/testdata/config.yaml
@@ -6,9 +6,9 @@ processors:
 
 exporters:
   zipkin:
-    url: "http://some.location.org:9411/api/v2/spans"
+    endpoint: "http://some.location.org:9411/api/v2/spans"
   zipkin/2:
-    url: "https://somedest:1234/api/v2/spans"
+    endpoint: "https://somedest:1234/api/v2/spans"
     format: proto
     default_service_name: test_name
 

--- a/exporter/zipkinexporter/zipkin_test.go
+++ b/exporter/zipkinexporter/zipkin_test.go
@@ -33,6 +33,7 @@ import (
 	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/processor"
 	"go.opentelemetry.io/collector/receiver/zipkinreceiver"
@@ -59,10 +60,12 @@ func TestZipkinExporter_roundtripJSON(t *testing.T) {
 	defer cst.Close()
 
 	config := &Config{
-		URL:    cst.URL,
+		HTTPClientSettings: confighttp.HTTPClientSettings{
+			Endpoint: cst.URL,
+		},
 		Format: "json",
 	}
-	tes, err := NewTraceExporter(config)
+	tes, err := newTraceExporter(config)
 	assert.NoError(t, err)
 	require.NotNil(t, tes)
 
@@ -267,7 +270,9 @@ const zipkinSpansJSONJavaLibrary = `
 
 func TestZipkinExporter_invalidFormat(t *testing.T) {
 	config := &Config{
-		URL:    "1.2.3.4",
+		HTTPClientSettings: confighttp.HTTPClientSettings{
+			Endpoint: "1.2.3.4",
+		},
 		Format: "foobar",
 	}
 	f := &Factory{}
@@ -287,10 +292,12 @@ func TestZipkinExporter_roundtripProto(t *testing.T) {
 	defer cst.Close()
 
 	config := &Config{
-		URL:    cst.URL,
+		HTTPClientSettings: confighttp.HTTPClientSettings{
+			Endpoint: cst.URL,
+		},
 		Format: "proto",
 	}
-	tes, err := NewTraceExporter(config)
+	tes, err := newTraceExporter(config)
 	require.NoError(t, err)
 
 	// The test requires the spans from zipkinSpansJSONJavaLibrary to be sent in a single batch, use

--- a/receiver/zipkinreceiver/trace_receiver_test.go
+++ b/receiver/zipkinreceiver/trace_receiver_test.go
@@ -41,7 +41,6 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenterror"
 	"go.opentelemetry.io/collector/component/componenttest"
-	"go.opentelemetry.io/collector/config/configmodels"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumerdata"
 	"go.opentelemetry.io/collector/exporter/exportertest"
@@ -318,11 +317,8 @@ func TestConversionRoundtrip(t *testing.T) {
 	defer backend.Close()
 
 	factory := &zipkinexporter.Factory{}
-	config := &zipkinexporter.Config{
-		ExporterSettings: configmodels.ExporterSettings{},
-		URL:              backend.URL,
-		Format:           "json",
-	}
+	config := factory.CreateDefaultConfig().(*zipkinexporter.Config)
+	config.Endpoint = backend.URL
 	ze, err := factory.CreateTraceExporter(zap.NewNop(), config)
 	require.NoError(t, err)
 	require.NotNil(t, ze)

--- a/testbed/testbed/receivers.go
+++ b/testbed/testbed/receivers.go
@@ -242,7 +242,7 @@ func (zr *ZipkinDataReceiver) GenConfigYAMLStr() string {
 	// Note that this generates an exporter config for agent.
 	return fmt.Sprintf(`
   zipkin:
-    url: http://localhost:%d/api/v2/spans
+    endpoint: http://localhost:%d/api/v2/spans
     format: json`, zr.Port)
 }
 

--- a/testbed/testbed/senders.go
+++ b/testbed/testbed/senders.go
@@ -452,14 +452,9 @@ func NewZipkinDataSender(host string, port int) *ZipkinDataSender {
 }
 
 func (zs *ZipkinDataSender) Start() error {
-	spansURL := fmt.Sprintf("http://localhost:%d/api/v2/spans", zs.Port)
-
-	cfg := &zipkinexporter.Config{
-		URL:    spansURL,
-		Format: "json",
-	}
-
 	factory := zipkinexporter.Factory{}
+	cfg := factory.CreateDefaultConfig().(*zipkinexporter.Config)
+	cfg.Endpoint = fmt.Sprintf("http://localhost:%d/api/v2/spans", zs.Port)
 	exporter, err := factory.CreateTraceExporter(zap.L(), cfg)
 
 	if err != nil {


### PR DESCRIPTION
Breaking change for Zipkin config "url" -> "endpoint", this makes it consistent with others.

Depends on #1184

Side effects:
* Zipkin exporter supports tls and mtls now.
* Allow to configure Client Timeout.