### PR TITLE
Add a NetAddr that can be used for HTTP or other protocols

### DIFF
--- a/config/confignet/confignet.go
+++ b/config/confignet/confignet.go
@@ -1,0 +1,41 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package confignet
+
+import (
+	"net"
+)
+
+// NetAddr represents a network endpoint address.
+type NetAddr struct {
+	// Endpoint configures the address for this network connection.
+	// For TCP and UDP networks, the address has the form "host:port". The host must be a literal IP address,
+	// or a host name that can be resolved to IP addresses. The port must be a literal port number or a service name.
+	// If the host is a literal IPv6 address it must be enclosed in square brackets, as in "[2001:db8::1]:80" or
+	// "[fe80::1%zone]:80". The zone specifies the scope of the literal IPv6 address as defined in RFC 4007.
+	Endpoint string `mapstructure:"endpoint"`
+
+	// Transport to use. Known protocols are "tcp", "tcp4" (IPv4-only), "tcp6" (IPv6-only), "udp", "udp4" (IPv4-only),
+	// "udp6" (IPv6-only), "ip", "ip4" (IPv4-only), "ip6" (IPv6-only), "unix", "unixgram" and "unixpacket".
+	Transport string `mapstructure:"transport"`
+}
+
+func (na *NetAddr) Dial() (net.Conn, error) {
+	return net.Dial(na.Transport, na.Endpoint)
+}
+
+func (na *NetAddr) Listen() (net.Listener, error) {
+	return net.Listen(na.Transport, na.Endpoint)
+}

--- a/config/confignet/confignet_test.go
+++ b/config/confignet/confignet_test.go
@@ -1,0 +1,57 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package confignet
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNetAddr(t *testing.T) {
+	nas := &NetAddr{
+		Endpoint:  "localhost:0",
+		Transport: "tcp",
+	}
+	ln, err := nas.Listen()
+	assert.NoError(t, err)
+	done := make(chan bool, 1)
+
+	go func() {
+		conn, errGo := ln.Accept()
+		assert.NoError(t, errGo)
+		buf := make([]byte, 10)
+		var numChr int
+		numChr, errGo = conn.Read(buf)
+		assert.NoError(t, errGo)
+		assert.Equal(t, "test", string(buf[:numChr]))
+		assert.NoError(t, conn.Close())
+		done <- true
+	}()
+
+	nac := &NetAddr{
+		Endpoint:  ln.Addr().String(),
+		Transport: "tcp",
+	}
+	var conn net.Conn
+	conn, err = nac.Dial()
+	assert.NoError(t, err)
+	_, err = conn.Write([]byte("test"))
+	assert.NoError(t, err)
+	assert.NoError(t, conn.Close())
+	<-done
+	assert.NoError(t, ln.Close())
+}


### PR DESCRIPTION
This target definition will be used for all the protocols except gRPC which has its own definition for target https://github.com/grpc/grpc/blob/master/doc/naming.md

Will change HttpClientSettings to use this definition after it gets merged.