### PR TITLE
Use stretchr/testify/require instead of t.Fatal (#266)

### DIFF
--- a/component/componenttest/nop_host_test.go
+++ b/component/componenttest/nop_host_test.go
@@ -17,16 +17,13 @@ package componenttest
 import (
 	"errors"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewNopHost(t *testing.T) {
 	got := NewNopHost()
-	if got == nil {
-		t.Fatal("NewNopHost() = nil, want non-nil", got)
-	}
-	_, ok := got.(*NopHost)
-	if !ok {
-		t.Fatal("got.(*NopHost) failed")
-	}
+	require.IsType(t, &NopHost{}, got)
+
 	got.ReportFatalError(errors.New("TestError"))
 }

--- a/exporter/prometheusexporter/prometheus_test.go
+++ b/exporter/prometheusexporter/prometheus_test.go
@@ -93,9 +93,8 @@ func TestPrometheusExporter_endToEnd(t *testing.T) {
 		consumer.ConsumeMetricsData(context.Background(), consumerdata.MetricsData{Metrics: metricBuilder(int64(delta))})
 
 		res, err := http.Get("http://localhost:7777/metrics")
-		if err != nil {
-			t.Fatalf("Failed to perform a scrape: %v", err)
-		}
+		require.NoError(t, err, "Failed to perform a scrape")
+
 		if g, w := res.StatusCode, 200; g != w {
 			t.Errorf("Mismatched HTTP response status code: Got: %d Want: %d", g, w)
 		}

--- a/receiver/otlpreceiver/otlp_test.go
+++ b/receiver/otlpreceiver/otlp_test.go
@@ -211,14 +211,10 @@ func TestProtoHttp(t *testing.T) {
 	require.NoError(t, err, "Error posting trace to grpc-gateway server: %v", err)
 
 	respBytes, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		t.Fatalf("Error reading response from trace grpc-gateway, %v", err)
-	}
+	require.NoError(t, err, "Error reading response from trace grpc-gateway")
 
 	err = resp.Body.Close()
-	if err != nil {
-		t.Fatalf("Error closing response body, %v", err)
-	}
+	require.NoError(t, err, "Error closing response body")
 
 	if resp.StatusCode != 200 {
 		t.Errorf("Unexpected status from trace grpc-gateway: %v", resp.StatusCode)
@@ -230,9 +226,7 @@ func TestProtoHttp(t *testing.T) {
 
 	tmp := collectortrace.ExportTraceServiceResponse{}
 	err = proto.Unmarshal(respBytes, &tmp)
-	if err != nil {
-		t.Errorf("Unable to unmarshal response to ExportTraceServiceResponse proto: %v", err)
-	}
+	require.NoError(t, err, "Unable to unmarshal response to ExportTraceServiceResponse proto")
 
 	gotOtlp := pdata.TracesToOtlp(sink.AllTraces()[0])
 

--- a/receiver/prometheusreceiver/internal/ocastore_test.go
+++ b/receiver/prometheusreceiver/internal/ocastore_test.go
@@ -20,6 +20,8 @@ import (
 
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/scrape"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestOcaStore(t *testing.T) {
@@ -27,29 +29,22 @@ func TestOcaStore(t *testing.T) {
 	o := NewOcaStore(context.Background(), nil, nil, nil, false, "prometheus")
 
 	_, err := o.Appender()
-	if err == nil {
-		t.Fatal("expecting error, but get nil")
-	}
+	require.Error(t, err)
 
 	o.SetScrapeManager(nil)
 	_, err = o.Appender()
-	if err == nil {
-		t.Fatal("expecting error when ScrapeManager is not set, but get nil")
-	}
+	require.Error(t, err, "Expecting error when ScrapeManager is not set")
 
 	o.SetScrapeManager(&scrape.Manager{})
 
 	app, err := o.Appender()
-	if app == nil {
-		t.Fatalf("expecting app, but got error %v\n", err)
-	}
+	require.NotNil(t, app, "Expecting app, but got error %v\n", err)
 
 	_ = o.Close()
 
 	app, err = o.Appender()
-	if app != noop || err != nil {
-		t.Fatalf("expect app!=nil and err==nil, got app=%v and err=%v", app, err)
-	}
+	assert.Equal(t, noop, app)
+	assert.NoError(t, err)
 }
 
 func TestNoopAppender(t *testing.T) {

--- a/testutils/testutils.go
+++ b/testutils/testutils.go
@@ -49,9 +49,7 @@ func GenerateNormalizedJSON(t *testing.T, jsonStr string) string {
 // immediately.
 func GetAvailableLocalAddress(t *testing.T) string {
 	ln, err := net.Listen("tcp", "localhost:0")
-	if err != nil {
-		t.Fatalf("failed to get a free local port: %v", err)
-	}
+	require.NoError(t, err, "Failed to get a free local port")
 	// There is a possible race if something else takes this same port before
 	// the test uses it, however, that is unlikely in practice.
 	defer ln.Close()

--- a/translator/trace/jaeger/jaegerthrift_to_protospan_test.go
+++ b/translator/trace/jaeger/jaegerthrift_to_protospan_test.go
@@ -18,12 +18,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"reflect"
 	"testing"
 
 	commonpb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
 	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
 	"github.com/jaegertracing/jaeger/thrift-gen/jaeger"
+	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/collector/consumer/consumerdata"
 	"go.opentelemetry.io/collector/testutils"
@@ -265,9 +265,7 @@ func TestConservativeConversions(t *testing.T) {
 		},
 	}
 
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("Unsuccessful conversion\nGot:\n\t%v\nWant:\n\t%v", got, want)
-	}
+	require.Equal(t, want, got, "Unsuccessful conversion")
 }
 
 func TestJaegerStatusTagsToOCStatus(t *testing.T) {
@@ -494,12 +492,8 @@ func TestJaegerStatusTagsToOCStatus(t *testing.T) {
 			continue
 		}
 		gs := gb.Spans[0]
-		if !reflect.DeepEqual(gs.Attributes, c.wantAttributes) {
-			t.Fatalf("Unsuccessful conversion: %d\nGot:\n\t%v\nWant:\n\t%v", i, gs.Attributes, c.wantAttributes)
-		}
-		if !reflect.DeepEqual(gs.Status, c.wantStatus) {
-			t.Fatalf("Unsuccessful conversion: %d\nGot:\n\t%v\nWant:\n\t%v", i, gs.Status, c.wantStatus)
-		}
+		require.Equal(t, c.wantAttributes, gs.Attributes, "Unsuccessful conversion %d", i)
+		require.Equal(t, c.wantStatus, gs.Status, "Unsuccessful conversion %d", i)
 	}
 }
 
@@ -524,8 +518,6 @@ func TestHTTPToGRPCStatusCode(t *testing.T) {
 			continue
 		}
 		gs := gb.Spans[0]
-		if !reflect.DeepEqual(gs.Status.Code, wantStatus) {
-			t.Fatalf("Unsuccessful conversion: %d\nGot:\n\t%v\nWant:\n\t%v", i, gs.Status, wantStatus)
-		}
+		require.Equal(t, wantStatus, gs.Status.Code, "Unsuccessful conversion %d", i)
 	}
 }

--- a/translator/trace/zipkin/protospan_to_zipkinv1_test.go
+++ b/translator/trace/zipkin/protospan_to_zipkinv1_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/golang/protobuf/ptypes/wrappers"
 	zipkinmodel "github.com/openzipkin/zipkin-go/model"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opencensus.io/trace/tracestate"
 
 	"go.opentelemetry.io/collector/internal"
@@ -224,15 +225,12 @@ func TestOCSpanProtoToZipkin_endToEnd(t *testing.T) {
 	}
 
 	gotOCSpanData, err := OCSpanProtoToZipkin(nil, resource, protoSpan, "default_service")
-	if err != nil {
-		t.Fatalf("Failed to convert from ProtoSpan to OCSpanData: %v", err)
-	}
+	require.NoError(t, err, "Failed to convert from ProtoSpan to OCSpanData")
 
 	ocTracestate, err := tracestate.New(new(tracestate.Tracestate), tracestate.Entry{Key: "foo", Value: "bar"},
 		tracestate.Entry{Key: "a", Value: "b"})
-	if err != nil || ocTracestate == nil {
-		t.Fatalf("Failed to create ocTracestate: %v", err)
-	}
+	require.NotNil(t, ocTracestate)
+	require.NoError(t, err)
 
 	sampled := true
 	parentID := zipkinmodel.ID(uint64(0xEFEEEDECEBEAE9E8))


### PR DESCRIPTION
**Description:** 
* Removes most of `t.Fatal` usages in tests in favor of `stretchr/testify/require`
* Additionally adds a `t.Run` for table tests in `config/config_test.go` for cleaner test output
 
**Link to tracking Issue:** #266 

**Testing:** N/A

**Documentation:** N/A