### PR TITLE
Fixed untyped Prometheus receiver bug, updated tests and updated Design.md

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1065,6 +1065,8 @@ github.com/prometheus/procfs v0.0.11/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4
 github.com/prometheus/prometheus v0.0.0-20180315085919-58e2a31db8de/go.mod h1:oAIUtOny2rjMX0OWN5vPR5/q/twIROJvdqnQKDdil/s=
 github.com/prometheus/prometheus v1.8.2-0.20190924101040-52e0504f83ea h1:DkijwrDmxCei6erPY2JZPJMOr8srbkbOJVkWbhSYWH4=
 github.com/prometheus/prometheus v1.8.2-0.20190924101040-52e0504f83ea/go.mod h1:elNqjVbwD3sCZJqKzyN7uEuwGcCpeJvv67D6BrHsDbw=
+github.com/prometheus/prometheus v1.8.2 h1:PAL466mnJw1VolZPm1OarpdUpqukUy/eX4tagia17DM=
+github.com/prometheus/prometheus v2.5.0+incompatible h1:7QPitgO2kOFG8ecuRn9O/4L9+10He72rVRJvMXrE9Hg=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/quasilyte/go-consistent v0.0.0-20190521200055-c6f3937de18c/go.mod h1:5STLWrekHfjyYwxBRVRXNOSewLJ3PWfDJd1VyTS21fI=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=

--- a/receiver/prometheusreceiver/DESIGN.md
+++ b/receiver/prometheusreceiver/DESIGN.md
@@ -48,7 +48,7 @@ Based on this document, Prometheus supports the following 5 types of metrics:
 * Gauge
 * Histogram
 * Summary
-* Untyped
+* Untyped (untyped metrics are converted to `gauge` by default)
 
 However, this is not the whole story, from the implementation details of
 Prometheus scraper, which the receiver based on, it supports a couple more

--- a/receiver/prometheusreceiver/internal/metricsbuilder.go
+++ b/receiver/prometheusreceiver/internal/metricsbuilder.go
@@ -214,7 +214,8 @@ func convToOCAMetricType(metricType textparse.MetricType) metricspb.MetricDescri
 	case textparse.MetricTypeCounter:
 		// always use float64, as it's the internal data type used in prometheus
 		return metricspb.MetricDescriptor_CUMULATIVE_DOUBLE
-	case textparse.MetricTypeGauge:
+	// textparse.MetricTypeUnknown is converted to gauge by default to fix Prometheus untyped metrics from being dropped
+	case textparse.MetricTypeGauge, textparse.MetricTypeUnknown:
 		return metricspb.MetricDescriptor_GAUGE_DOUBLE
 	case textparse.MetricTypeHistogram:
 		return metricspb.MetricDescriptor_CUMULATIVE_DISTRIBUTION

--- a/receiver/prometheusreceiver/internal/metricsbuilder.go
+++ b/receiver/prometheusreceiver/internal/metricsbuilder.go
@@ -226,7 +226,7 @@ func convToOCAMetricType(metricType textparse.MetricType) metricspb.MetricDescri
 	case textparse.MetricTypeSummary:
 		return metricspb.MetricDescriptor_SUMMARY
 	default:
-		// including: textparse.MetricTypeUnknown, textparse.MetricTypeInfo, textparse.MetricTypeStateset
+		// including: textparse.MetricTypeInfo, textparse.MetricTypeStateset
 		return metricspb.MetricDescriptor_UNSPECIFIED
 	}
 }

--- a/receiver/prometheusreceiver/internal/metricsbuilder_test.go
+++ b/receiver/prometheusreceiver/internal/metricsbuilder_test.go
@@ -426,7 +426,7 @@ func Test_metricBuilder_untype(t *testing.T) {
 					{
 						MetricDescriptor: &metricspb.MetricDescriptor{
 							Name:      "unknown_test",
-							Type:      metricspb.MetricDescriptor_UNSPECIFIED,
+							Type:      metricspb.MetricDescriptor_GAUGE_DOUBLE,
 							LabelKeys: []*metricspb.LabelKey{{Key: "foo"}}},
 						Timeseries: []*metricspb.TimeSeries{
 							{
@@ -504,7 +504,7 @@ func Test_metricBuilder_untype(t *testing.T) {
 					{
 						MetricDescriptor: &metricspb.MetricDescriptor{
 							Name:      "some_count",
-							Type:      metricspb.MetricDescriptor_UNSPECIFIED,
+							Type:      metricspb.MetricDescriptor_GAUGE_DOUBLE,
 							LabelKeys: []*metricspb.LabelKey{{Key: "foo"}}},
 						Timeseries: []*metricspb.TimeSeries{
 							{
@@ -1223,7 +1223,7 @@ func Test_convToOCAMetricType(t *testing.T) {
 		{"summary", textparse.MetricTypeSummary, metricspb.MetricDescriptor_SUMMARY},
 		{"info", textparse.MetricTypeInfo, metricspb.MetricDescriptor_UNSPECIFIED},
 		{"stateset", textparse.MetricTypeStateset, metricspb.MetricDescriptor_UNSPECIFIED},
-		{"unknown", textparse.MetricTypeUnknown, metricspb.MetricDescriptor_UNSPECIFIED},
+		{"unknown", textparse.MetricTypeUnknown, metricspb.MetricDescriptor_GAUGE_DOUBLE},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
**Description:**
Made `textparse.MetricTypeUnknown` metrics convert to `gauge` by default to fix a Prometheus Receiver bug where `untyped` metrics were being dropped.

**Link to tracking Issue:**
Issue link with much more details: https://github.com/open-telemetry/opentelemetry-collector/issues/1103

**Testing:**
Modified the tests for the new type the metrics are being converted to.

**Documentation:**
Added a small line in the design documentation stating that we default `untyped` metrics to `gauge`

Thanks @asuresh4 and @bogdandrutu 