### PR TITLE
Merge componentdocs into componenttest

### DIFF
--- a/component/componenttest/docs.go
+++ b/component/componenttest/docs.go
@@ -12,9 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package componenttest define types and functions used to help test packages
-// implementing the component package interfaces.
-package componentdocs
+package componenttest
 
 import (
 	"fmt"
@@ -29,7 +27,7 @@ const (
 	readMeFileName = "README.md"
 )
 
-// VerifyComponentDocumentation returns an error if README.md for at least one
+// CheckDocs returns an error if README.md for at least one
 // enabled component is missing. "projectPath" is the absolute path to the root
 // of the project to which the components belong. "defaultComponentsFilePath" is
 // the path to the file that contains imports to all required components,
@@ -37,20 +35,21 @@ const (
 // to be used only to verify documentation in Opentelemetry core and contrib
 // repositories. Examples,
 // 1) Usage in the core repo:
-// componenttest.VerifyComponentDocumentation(
+//
+// componenttest.CheckDocs(
 //		"path/to/project",
 //		"service/defaultcomponents/defaults.go",
 //      "go.opentelemetry.io/collector",
 //	)
 //
 // 2) Usage in the contrib repo:
-// componenttest.VerifyComponentDocumentation(
+// componenttest.CheckDocs(
 //		"path/to/project",
 //		"cmd/otelcontrib/components.go",
 //      "github.com/open-telemetry/opentelemetry-collector-contrib",
 //	).
-func VerifyComponentDocumentation(projectPath string, relativeDefaultComponentsPath string, projectGoModule string) error {
-	defaultComponentsFilePath := filepath.Join(projectPath, relativeDefaultComponentsPath)
+func CheckDocs(projectPath string, relativeComponentsPath string, projectGoModule string) error {
+	defaultComponentsFilePath := filepath.Join(projectPath, relativeComponentsPath)
 	_, err := os.Stat(defaultComponentsFilePath)
 	if err != nil {
 		return fmt.Errorf("failed to load file %s: %v", defaultComponentsFilePath, err)

--- a/component/componenttest/docs_test.go
+++ b/component/componenttest/docs_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package componentdocs
+package componenttest
 
 import (
 	"os"
@@ -100,7 +100,7 @@ func TestGetImportPrefixesToCheck(t *testing.T) {
 	}
 }
 
-func TestVerifyComponentDocumentation(t *testing.T) {
+func TestCheckDocs(t *testing.T) {
 	type args struct {
 		projectPath                   string
 		relativeDefaultComponentsPath string
@@ -159,8 +159,8 @@ func TestVerifyComponentDocumentation(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := VerifyComponentDocumentation(tt.args.projectPath, tt.args.relativeDefaultComponentsPath, tt.args.projectGoModule); (err != nil) != tt.wantErr {
-				t.Errorf("VerifyComponentDocumentation() error = %v, wantErr %v", err, tt.wantErr)
+			if err := CheckDocs(tt.args.projectPath, tt.args.relativeDefaultComponentsPath, tt.args.projectGoModule); (err != nil) != tt.wantErr {
+				t.Errorf("CheckDocs() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}

--- a/service/defaultcomponents/docs_test.go
+++ b/service/defaultcomponents/docs_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
 	"go.opentelemetry.io/collector/component/componenttest"
 )
 

--- a/service/defaultcomponents/docs_test.go
+++ b/service/defaultcomponents/docs_test.go
@@ -20,8 +20,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
-	"go.opentelemetry.io/collector/component/componentdocs"
+	"go.opentelemetry.io/collector/component/componenttest"
 )
 
 const (
@@ -42,7 +41,7 @@ func TestComponentDocs(t *testing.T) {
 	// Absolute path to the project root directory
 	projectPath := filepath.Join(wd, "../../")
 
-	err = componentdocs.VerifyComponentDocumentation(
+	err = componenttest.CheckDocs(
 		projectPath,
 		relativeDefaultComponentsPath,
 		projectGoModule,


### PR DESCRIPTION
componentdocs is used for testing reasons, merging the docs validation code into the test package helps other developers to discover the existence of it.

Rename VerifyComponentDocumentation for CheckDocs to help verbosity and have consistency with the other checker functions in the module.