### PR TITLE
Rename testutils to testutil

### DIFF
--- a/exporter/opencensusexporter/factory_test.go
+++ b/exporter/opencensusexporter/factory_test.go
@@ -29,7 +29,7 @@ import (
 	"go.opentelemetry.io/collector/config/configtls"
 	"go.opentelemetry.io/collector/exporter/exportertest"
 	"go.opentelemetry.io/collector/receiver/opencensusreceiver"
-	"go.opentelemetry.io/collector/testutils"
+	"go.opentelemetry.io/collector/testutil"
 )
 
 func TestCreateDefaultConfig(t *testing.T) {
@@ -42,7 +42,7 @@ func TestCreateDefaultConfig(t *testing.T) {
 func TestCreateMetricsExporter(t *testing.T) {
 	factory := Factory{}
 	cfg := factory.CreateDefaultConfig().(*Config)
-	cfg.GRPCClientSettings.Endpoint = testutils.GetAvailableLocalAddress(t)
+	cfg.GRPCClientSettings.Endpoint = testutil.GetAvailableLocalAddress(t)
 
 	oexp, err := factory.CreateMetricsExporter(zap.NewNop(), cfg)
 	require.Nil(t, err)
@@ -57,7 +57,7 @@ func TestCreateTraceExporter(t *testing.T) {
 	rcvFactory := &opencensusreceiver.Factory{}
 	require.NotNil(t, rcvFactory)
 	rcvCfg := rcvFactory.CreateDefaultConfig().(*opencensusreceiver.Config)
-	rcvCfg.Endpoint = testutils.GetAvailableLocalAddress(t)
+	rcvCfg.Endpoint = testutil.GetAvailableLocalAddress(t)
 
 	rcv, err := rcvFactory.CreateTraceReceiver(
 		context.Background(),

--- a/exporter/otlpexporter/factory_test.go
+++ b/exporter/otlpexporter/factory_test.go
@@ -27,7 +27,7 @@ import (
 	"go.opentelemetry.io/collector/config/configcheck"
 	"go.opentelemetry.io/collector/config/configgrpc"
 	"go.opentelemetry.io/collector/config/configtls"
-	"go.opentelemetry.io/collector/testutils"
+	"go.opentelemetry.io/collector/testutil"
 )
 
 func TestCreateDefaultConfig(t *testing.T) {
@@ -40,7 +40,7 @@ func TestCreateDefaultConfig(t *testing.T) {
 func TestCreateMetricsExporter(t *testing.T) {
 	factory := Factory{}
 	cfg := factory.CreateDefaultConfig().(*Config)
-	cfg.GRPCClientSettings.Endpoint = testutils.GetAvailableLocalAddress(t)
+	cfg.GRPCClientSettings.Endpoint = testutil.GetAvailableLocalAddress(t)
 
 	creationParams := component.ExporterCreateParams{Logger: zap.NewNop()}
 	oexp, err := factory.CreateMetricsExporter(context.Background(), creationParams, cfg)
@@ -49,7 +49,7 @@ func TestCreateMetricsExporter(t *testing.T) {
 }
 
 func TestCreateTraceExporter(t *testing.T) {
-	endpoint := testutils.GetAvailableLocalAddress(t)
+	endpoint := testutil.GetAvailableLocalAddress(t)
 
 	tests := []struct {
 		name     string
@@ -184,7 +184,7 @@ func TestCreateTraceExporter(t *testing.T) {
 func TestCreateLogsExporter(t *testing.T) {
 	factory := Factory{}
 	cfg := factory.CreateDefaultConfig().(*Config)
-	cfg.GRPCClientSettings.Endpoint = testutils.GetAvailableLocalAddress(t)
+	cfg.GRPCClientSettings.Endpoint = testutil.GetAvailableLocalAddress(t)
 
 	creationParams := component.ExporterCreateParams{Logger: zap.NewNop()}
 	oexp, err := factory.CreateLogExporter(context.Background(), creationParams, cfg)

--- a/exporter/otlpexporter/otlp_test.go
+++ b/exporter/otlpexporter/otlp_test.go
@@ -36,7 +36,7 @@ import (
 	otlplogs "go.opentelemetry.io/collector/internal/data/opentelemetry-proto-gen/logs/v1"
 	"go.opentelemetry.io/collector/internal/data/testdata"
 	"go.opentelemetry.io/collector/observability"
-	"go.opentelemetry.io/collector/testutils"
+	"go.opentelemetry.io/collector/testutil"
 )
 
 type mockTraceReceiver struct {
@@ -150,7 +150,7 @@ func TestSendTraceData(t *testing.T) {
 	assert.NoError(t, exp.ConsumeTraces(context.Background(), td))
 
 	// Wait until it is received.
-	testutils.WaitFor(t, func() bool {
+	testutil.WaitFor(t, func() bool {
 		return atomic.LoadInt32(&rcv.requestCount) > 0
 	}, "receive a request")
 
@@ -168,7 +168,7 @@ func TestSendTraceData(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Wait until it is received.
-	testutils.WaitFor(t, func() bool {
+	testutil.WaitFor(t, func() bool {
 		return atomic.LoadInt32(&rcv.requestCount) > 1
 	}, "receive a request")
 
@@ -303,7 +303,7 @@ func startServerAndMakeRequest(t *testing.T, exp component.TraceExporter, td pda
 	cancel()
 
 	// Wait until it is received.
-	testutils.WaitFor(t, func() bool {
+	testutil.WaitFor(t, func() bool {
 		return atomic.LoadInt32(&rcv.requestCount) > 0
 	}, "receive a request")
 
@@ -355,7 +355,7 @@ func TestSendLogData(t *testing.T) {
 	assert.NoError(t, exp.ConsumeLogs(context.Background(), td))
 
 	// Wait until it is received.
-	testutils.WaitFor(t, func() bool {
+	testutil.WaitFor(t, func() bool {
 		return atomic.LoadInt32(&rcv.requestCount) > 0
 	}, "receive a request")
 
@@ -373,7 +373,7 @@ func TestSendLogData(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Wait until it is received.
-	testutils.WaitFor(t, func() bool {
+	testutil.WaitFor(t, func() bool {
 		return atomic.LoadInt32(&rcv.requestCount) > 1
 	}, "receive a request")
 

--- a/exporter/zipkinexporter/zipkin_test.go
+++ b/exporter/zipkinexporter/zipkin_test.go
@@ -38,7 +38,7 @@ import (
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/processor"
 	"go.opentelemetry.io/collector/receiver/zipkinreceiver"
-	"go.opentelemetry.io/collector/testutils"
+	"go.opentelemetry.io/collector/testutil"
 )
 
 // This function tests that Zipkin spans that are received then processed roundtrip
@@ -76,7 +76,7 @@ func TestZipkinExporter_roundtripJSON(t *testing.T) {
 
 	// Run the Zipkin receiver to "receive spans upload from a client application"
 	zexp := processor.NewTraceFanOutConnectorOld([]consumer.TraceConsumerOld{tes})
-	addr := testutils.GetAvailableLocalAddress(t)
+	addr := testutil.GetAvailableLocalAddress(t)
 	cfg := &zipkinreceiver.Config{
 		ReceiverSettings: configmodels.ReceiverSettings{
 			NameVal: "zipkin_receiver",
@@ -139,9 +139,9 @@ func TestZipkinExporter_roundtripJSON(t *testing.T) {
 		}]
 		`}
 	for i, s := range wants {
-		want := testutils.GenerateNormalizedJSON(t, s)
+		want := testutil.GenerateNormalizedJSON(t, s)
 		gotBytes := buf.Next(int(sizes[i]))
-		got := testutils.GenerateNormalizedJSON(t, string(gotBytes))
+		got := testutil.GenerateNormalizedJSON(t, string(gotBytes))
 		assert.Equal(t, want, got)
 	}
 }
@@ -317,7 +317,7 @@ func TestZipkinExporter_roundtripProto(t *testing.T) {
 
 	// Run the Zipkin receiver to "receive spans upload from a client application"
 	zexp := processor.NewTraceFanOutConnectorOld([]consumer.TraceConsumerOld{tes})
-	port := testutils.GetAvailablePort(t)
+	port := testutil.GetAvailablePort(t)
 	cfg := &zipkinreceiver.Config{
 		ReceiverSettings: configmodels.ReceiverSettings{
 			NameVal: "zipkin_receiver",

--- a/extension/healthcheckextension/factory_test.go
+++ b/extension/healthcheckextension/factory_test.go
@@ -26,7 +26,7 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configcheck"
 	"go.opentelemetry.io/collector/config/configmodels"
-	"go.opentelemetry.io/collector/testutils"
+	"go.opentelemetry.io/collector/testutil"
 )
 
 func TestFactory_Type(t *testing.T) {
@@ -58,7 +58,7 @@ func TestFactory_CreateDefaultConfig(t *testing.T) {
 func TestFactory_CreateExtension(t *testing.T) {
 	factory := Factory{}
 	cfg := factory.CreateDefaultConfig().(*Config)
-	cfg.Port = testutils.GetAvailablePort(t)
+	cfg.Port = testutil.GetAvailablePort(t)
 
 	ext, err := factory.CreateExtension(context.Background(), component.ExtensionCreateParams{Logger: zap.NewNop()}, cfg)
 	require.NoError(t, err)
@@ -71,7 +71,7 @@ func TestFactory_CreateExtension(t *testing.T) {
 func TestFactory_CreateExtensionOnlyOnce(t *testing.T) {
 	factory := Factory{}
 	cfg := factory.CreateDefaultConfig().(*Config)
-	cfg.Port = testutils.GetAvailablePort(t)
+	cfg.Port = testutil.GetAvailablePort(t)
 
 	ext, err := factory.CreateExtension(context.Background(), component.ExtensionCreateParams{Logger: zap.NewNop()}, cfg)
 	require.NoError(t, err)

--- a/extension/healthcheckextension/healthcheckextension_test.go
+++ b/extension/healthcheckextension/healthcheckextension_test.go
@@ -27,12 +27,12 @@ import (
 	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/component/componenttest"
-	"go.opentelemetry.io/collector/testutils"
+	"go.opentelemetry.io/collector/testutil"
 )
 
 func TestHealthCheckExtensionUsage(t *testing.T) {
 	config := Config{
-		Port: testutils.GetAvailablePort(t),
+		Port: testutil.GetAvailablePort(t),
 	}
 
 	hcExt, err := newServer(config, zap.NewNop())
@@ -67,7 +67,7 @@ func TestHealthCheckExtensionUsage(t *testing.T) {
 }
 
 func TestHealthCheckExtensionPortAlreadyInUse(t *testing.T) {
-	endpoint := testutils.GetAvailableLocalAddress(t)
+	endpoint := testutil.GetAvailableLocalAddress(t)
 	_, portStr, err := net.SplitHostPort(endpoint)
 	require.NoError(t, err)
 
@@ -100,7 +100,7 @@ func TestHealthCheckExtensionPortAlreadyInUse(t *testing.T) {
 
 func TestHealthCheckMultipleStarts(t *testing.T) {
 	config := Config{
-		Port: testutils.GetAvailablePort(t),
+		Port: testutil.GetAvailablePort(t),
 	}
 
 	hcExt, err := newServer(config, zap.NewNop())
@@ -122,7 +122,7 @@ func TestHealthCheckMultipleStarts(t *testing.T) {
 
 func TestHealthCheckMultipleShutdowns(t *testing.T) {
 	config := Config{
-		Port: testutils.GetAvailablePort(t),
+		Port: testutil.GetAvailablePort(t),
 	}
 
 	hcExt, err := newServer(config, zap.NewNop())
@@ -136,7 +136,7 @@ func TestHealthCheckMultipleShutdowns(t *testing.T) {
 
 func TestHealthCheckShutdownWithoutStart(t *testing.T) {
 	config := Config{
-		Port: testutils.GetAvailablePort(t),
+		Port: testutil.GetAvailablePort(t),
 	}
 
 	hcExt, err := newServer(config, zap.NewNop())

--- a/extension/pprofextension/factory_test.go
+++ b/extension/pprofextension/factory_test.go
@@ -26,7 +26,7 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configcheck"
 	"go.opentelemetry.io/collector/config/configmodels"
-	"go.opentelemetry.io/collector/testutils"
+	"go.opentelemetry.io/collector/testutil"
 )
 
 func TestFactory_Type(t *testing.T) {
@@ -58,7 +58,7 @@ func TestFactory_CreateDefaultConfig(t *testing.T) {
 func TestFactory_CreateExtension(t *testing.T) {
 	factory := Factory{}
 	cfg := factory.CreateDefaultConfig().(*Config)
-	cfg.Endpoint = testutils.GetAvailableLocalAddress(t)
+	cfg.Endpoint = testutil.GetAvailableLocalAddress(t)
 
 	ext, err := factory.CreateExtension(context.Background(), component.ExtensionCreateParams{Logger: zap.NewNop()}, cfg)
 	require.NoError(t, err)
@@ -71,7 +71,7 @@ func TestFactory_CreateExtension(t *testing.T) {
 func TestFactory_CreateExtensionOnlyOnce(t *testing.T) {
 	factory := Factory{}
 	cfg := factory.CreateDefaultConfig().(*Config)
-	cfg.Endpoint = testutils.GetAvailableLocalAddress(t)
+	cfg.Endpoint = testutil.GetAvailableLocalAddress(t)
 
 	ext, err := factory.CreateExtension(context.Background(), component.ExtensionCreateParams{Logger: zap.NewNop()}, cfg)
 	require.NoError(t, err)

--- a/extension/pprofextension/pprofextension_test.go
+++ b/extension/pprofextension/pprofextension_test.go
@@ -25,12 +25,12 @@ import (
 	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/component/componenttest"
-	"go.opentelemetry.io/collector/testutils"
+	"go.opentelemetry.io/collector/testutil"
 )
 
 func TestPerformanceProfilerExtensionUsage(t *testing.T) {
 	config := Config{
-		Endpoint:             testutils.GetAvailableLocalAddress(t),
+		Endpoint:             testutil.GetAvailableLocalAddress(t),
 		BlockProfileFraction: 3,
 		MutexProfileFraction: 5,
 	}
@@ -57,7 +57,7 @@ func TestPerformanceProfilerExtensionUsage(t *testing.T) {
 }
 
 func TestPerformanceProfilerExtensionPortAlreadyInUse(t *testing.T) {
-	endpoint := testutils.GetAvailableLocalAddress(t)
+	endpoint := testutil.GetAvailableLocalAddress(t)
 	ln, err := net.Listen("tcp", endpoint)
 	require.NoError(t, err)
 	defer ln.Close()
@@ -74,7 +74,7 @@ func TestPerformanceProfilerExtensionPortAlreadyInUse(t *testing.T) {
 
 func TestPerformanceProfilerMultipleStarts(t *testing.T) {
 	config := Config{
-		Endpoint: testutils.GetAvailableLocalAddress(t),
+		Endpoint: testutil.GetAvailableLocalAddress(t),
 	}
 
 	pprofExt, err := newServer(config, zap.NewNop())
@@ -90,7 +90,7 @@ func TestPerformanceProfilerMultipleStarts(t *testing.T) {
 
 func TestPerformanceProfilerMultipleShutdowns(t *testing.T) {
 	config := Config{
-		Endpoint: testutils.GetAvailableLocalAddress(t),
+		Endpoint: testutil.GetAvailableLocalAddress(t),
 	}
 
 	pprofExt, err := newServer(config, zap.NewNop())
@@ -104,7 +104,7 @@ func TestPerformanceProfilerMultipleShutdowns(t *testing.T) {
 
 func TestPerformanceProfilerShutdownWithoutStart(t *testing.T) {
 	config := Config{
-		Endpoint: testutils.GetAvailableLocalAddress(t),
+		Endpoint: testutil.GetAvailableLocalAddress(t),
 	}
 
 	pprofExt, err := newServer(config, zap.NewNop())

--- a/extension/zpagesextension/factory_test.go
+++ b/extension/zpagesextension/factory_test.go
@@ -26,7 +26,7 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configcheck"
 	"go.opentelemetry.io/collector/config/configmodels"
-	"go.opentelemetry.io/collector/testutils"
+	"go.opentelemetry.io/collector/testutil"
 )
 
 func TestFactory_Type(t *testing.T) {
@@ -58,7 +58,7 @@ func TestFactory_CreateDefaultConfig(t *testing.T) {
 func TestFactory_CreateExtension(t *testing.T) {
 	factory := Factory{}
 	cfg := factory.CreateDefaultConfig().(*Config)
-	cfg.Endpoint = testutils.GetAvailableLocalAddress(t)
+	cfg.Endpoint = testutil.GetAvailableLocalAddress(t)
 
 	ext, err := factory.CreateExtension(context.Background(), component.ExtensionCreateParams{Logger: zap.NewNop()}, cfg)
 	require.NoError(t, err)
@@ -71,7 +71,7 @@ func TestFactory_CreateExtension(t *testing.T) {
 func TestFactory_CreateExtensionOnlyOnce(t *testing.T) {
 	factory := Factory{}
 	cfg := factory.CreateDefaultConfig().(*Config)
-	cfg.Endpoint = testutils.GetAvailableLocalAddress(t)
+	cfg.Endpoint = testutil.GetAvailableLocalAddress(t)
 
 	ext, err := factory.CreateExtension(context.Background(), component.ExtensionCreateParams{Logger: zap.NewNop()}, cfg)
 	require.NoError(t, err)

--- a/extension/zpagesextension/zpagesextension_test.go
+++ b/extension/zpagesextension/zpagesextension_test.go
@@ -25,12 +25,12 @@ import (
 	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/component/componenttest"
-	"go.opentelemetry.io/collector/testutils"
+	"go.opentelemetry.io/collector/testutil"
 )
 
 func TestZPagesExtensionUsage(t *testing.T) {
 	config := Config{
-		Endpoint: testutils.GetAvailableLocalAddress(t),
+		Endpoint: testutil.GetAvailableLocalAddress(t),
 	}
 
 	zpagesExt, err := newServer(config, zap.NewNop())
@@ -55,7 +55,7 @@ func TestZPagesExtensionUsage(t *testing.T) {
 }
 
 func TestZPagesExtensionPortAlreadyInUse(t *testing.T) {
-	endpoint := testutils.GetAvailableLocalAddress(t)
+	endpoint := testutil.GetAvailableLocalAddress(t)
 	ln, err := net.Listen("tcp", endpoint)
 	require.NoError(t, err)
 	defer ln.Close()
@@ -72,7 +72,7 @@ func TestZPagesExtensionPortAlreadyInUse(t *testing.T) {
 
 func TestZPagesMultipleStarts(t *testing.T) {
 	config := Config{
-		Endpoint: testutils.GetAvailableLocalAddress(t),
+		Endpoint: testutil.GetAvailableLocalAddress(t),
 	}
 
 	zpagesExt, err := newServer(config, zap.NewNop())
@@ -88,7 +88,7 @@ func TestZPagesMultipleStarts(t *testing.T) {
 
 func TestZPagesMultipleShutdowns(t *testing.T) {
 	config := Config{
-		Endpoint: testutils.GetAvailableLocalAddress(t),
+		Endpoint: testutil.GetAvailableLocalAddress(t),
 	}
 
 	zpagesExt, err := newServer(config, zap.NewNop())
@@ -102,7 +102,7 @@ func TestZPagesMultipleShutdowns(t *testing.T) {
 
 func TestZPagesShutdownWithoutStart(t *testing.T) {
 	config := Config{
-		Endpoint: testutils.GetAvailableLocalAddress(t),
+		Endpoint: testutil.GetAvailableLocalAddress(t),
 	}
 
 	zpagesExt, err := newServer(config, zap.NewNop())

--- a/receiver/jaegerreceiver/jaeger_agent_test.go
+++ b/receiver/jaegerreceiver/jaeger_agent_test.go
@@ -34,7 +34,7 @@ import (
 	"go.opentelemetry.io/collector/config/configgrpc"
 	"go.opentelemetry.io/collector/config/configtls"
 	"go.opentelemetry.io/collector/exporter/exportertest"
-	"go.opentelemetry.io/collector/testutils"
+	"go.opentelemetry.io/collector/testutil"
 )
 
 const jaegerAgent = "jaeger_agent_test"
@@ -75,7 +75,7 @@ func TestJaegerAgentUDP_ThriftBinary_6832(t *testing.T) {
 
 func TestJaegerAgentUDP_ThriftBinary_PortInUse(t *testing.T) {
 	// This test confirms that the thrift binary port is opened correctly.  This is all we can test at the moment.  See above.
-	port := testutils.GetAvailablePort(t)
+	port := testutil.GetAvailablePort(t)
 
 	config := &Configuration{
 		AgentBinaryThriftPort: int(port),
@@ -137,7 +137,7 @@ func TestJaegerHTTP(t *testing.T) {
 	})
 	defer s.GracefulStop()
 
-	port := testutils.GetAvailablePort(t)
+	port := testutil.GetAvailablePort(t)
 	config := &Configuration{
 		AgentHTTPPort: int(port),
 		RemoteSamplingClientSettings: configgrpc.GRPCClientSettings{
@@ -156,7 +156,7 @@ func TestJaegerHTTP(t *testing.T) {
 	assert.NoError(t, err, "Start failed")
 
 	// allow http server to start
-	err = testutils.WaitForPort(t, port)
+	err = testutil.WaitForPort(t, port)
 	assert.NoError(t, err, "WaitForPort failed")
 
 	testURL := fmt.Sprintf("http://localhost:%d/sampling?service=test", port)

--- a/receiver/jaegerreceiver/trace_receiver_test.go
+++ b/receiver/jaegerreceiver/trace_receiver_test.go
@@ -50,7 +50,7 @@ import (
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/exporter/exportertest"
 	otlptrace "go.opentelemetry.io/collector/internal/data/opentelemetry-proto-gen/trace/v1"
-	"go.opentelemetry.io/collector/testutils"
+	"go.opentelemetry.io/collector/testutil"
 	"go.opentelemetry.io/collector/translator/conventions"
 	tracetranslator "go.opentelemetry.io/collector/translator/trace"
 )
@@ -264,7 +264,7 @@ func TestGRPCReceptionWithTLS(t *testing.T) {
 	assert.NoError(t, err)
 	grpcServerOptions = append(grpcServerOptions, grpc.Creds(credentials.NewTLS(tlsCfg)))
 
-	port := testutils.GetAvailablePort(t)
+	port := testutil.GetAvailablePort(t)
 	config := &Configuration{
 		CollectorGRPCPort:    int(port),
 		CollectorGRPCOptions: grpcServerOptions,
@@ -447,7 +447,7 @@ func grpcFixture(t1 time.Time, d1, d2 time.Duration) *api_v2.PostSpansRequest {
 }
 
 func TestSampling(t *testing.T) {
-	port := testutils.GetAvailablePort(t)
+	port := testutil.GetAvailablePort(t)
 	config := &Configuration{
 		CollectorGRPCPort:          int(port),
 		RemoteSamplingStrategyFile: "testdata/strategies.json",
@@ -500,7 +500,7 @@ func TestSampling(t *testing.T) {
 }
 
 func TestSamplingFailsOnNotConfigured(t *testing.T) {
-	port := testutils.GetAvailablePort(t)
+	port := testutil.GetAvailablePort(t)
 	// prepare
 	config := &Configuration{
 		CollectorGRPCPort: int(port),
@@ -529,7 +529,7 @@ func TestSamplingFailsOnNotConfigured(t *testing.T) {
 }
 
 func TestSamplingFailsOnBadFile(t *testing.T) {
-	port := testutils.GetAvailablePort(t)
+	port := testutil.GetAvailablePort(t)
 	// prepare
 	config := &Configuration{
 		CollectorGRPCPort:          int(port),

--- a/receiver/opencensusreceiver/factory_test.go
+++ b/receiver/opencensusreceiver/factory_test.go
@@ -29,7 +29,7 @@ import (
 	"go.opentelemetry.io/collector/config/configmodels"
 	"go.opentelemetry.io/collector/config/configprotocol"
 	"go.opentelemetry.io/collector/exporter/exportertest"
-	"go.opentelemetry.io/collector/testutils"
+	"go.opentelemetry.io/collector/testutil"
 )
 
 func TestCreateDefaultConfig(t *testing.T) {
@@ -44,7 +44,7 @@ func TestCreateReceiver(t *testing.T) {
 	cfg := factory.CreateDefaultConfig()
 
 	config := cfg.(*Config)
-	config.Endpoint = testutils.GetAvailableLocalAddress(t)
+	config.Endpoint = testutil.GetAvailableLocalAddress(t)
 
 	tReceiver, err := factory.CreateTraceReceiver(context.Background(), zap.NewNop(), cfg, nil)
 	assert.NotNil(t, tReceiver)
@@ -57,7 +57,7 @@ func TestCreateReceiver(t *testing.T) {
 
 func TestCreateTraceReceiver(t *testing.T) {
 	factory := Factory{}
-	endpoint := testutils.GetAvailableLocalAddress(t)
+	endpoint := testutil.GetAvailableLocalAddress(t)
 	defaultReceiverSettings := configmodels.ReceiverSettings{
 		TypeVal: typeStr,
 		NameVal: typeStr,
@@ -132,7 +132,7 @@ func TestCreateTraceReceiver(t *testing.T) {
 
 func TestCreateMetricReceiver(t *testing.T) {
 	factory := Factory{}
-	endpoint := testutils.GetAvailableLocalAddress(t)
+	endpoint := testutil.GetAvailableLocalAddress(t)
 	defaultReceiverSettings := configmodels.ReceiverSettings{
 		TypeVal: typeStr,
 		NameVal: typeStr,

--- a/receiver/opencensusreceiver/ocmetrics/opencensus_test.go
+++ b/receiver/opencensusreceiver/ocmetrics/opencensus_test.go
@@ -37,7 +37,7 @@ import (
 	"go.opentelemetry.io/collector/consumer/consumerdata"
 	"go.opentelemetry.io/collector/internal"
 	"go.opentelemetry.io/collector/observability"
-	"go.opentelemetry.io/collector/testutils"
+	"go.opentelemetry.io/collector/testutil"
 )
 
 // TODO: add E2E tests once ocagent implements metric service client.
@@ -342,7 +342,7 @@ func ocReceiverOnGRPCServer(t *testing.T, sr consumer.MetricsConsumerOld) (oci *
 		}
 	}
 
-	_, port, err = testutils.HostPortFromAddr(ln.Addr())
+	_, port, err = testutil.HostPortFromAddr(ln.Addr())
 	if err != nil {
 		done()
 		t.Fatalf("Failed to parse host:port from listener address: %s error: %v", ln.Addr(), err)

--- a/receiver/opencensusreceiver/octrace/opencensus_test.go
+++ b/receiver/opencensusreceiver/octrace/opencensus_test.go
@@ -41,7 +41,7 @@ import (
 	"go.opentelemetry.io/collector/consumer/consumerdata"
 	"go.opentelemetry.io/collector/internal"
 	"go.opentelemetry.io/collector/observability"
-	"go.opentelemetry.io/collector/testutils"
+	"go.opentelemetry.io/collector/testutil"
 )
 
 func TestReceiver_endToEnd(t *testing.T) {
@@ -471,7 +471,7 @@ func ocReceiverOnGRPCServer(t *testing.T, sr consumer.TraceConsumerOld, opts ...
 		}
 	}
 
-	_, port, err = testutils.HostPortFromAddr(ln.Addr())
+	_, port, err = testutil.HostPortFromAddr(ln.Addr())
 	if err != nil {
 		done()
 		t.Fatalf("Failed to parse host:port from listener address: %s error: %v", ln.Addr(), err)

--- a/receiver/opencensusreceiver/opencensus_test.go
+++ b/receiver/opencensusreceiver/opencensus_test.go
@@ -47,14 +47,14 @@ import (
 	"go.opentelemetry.io/collector/exporter/exportertest"
 	"go.opentelemetry.io/collector/internal"
 	"go.opentelemetry.io/collector/observability/observabilitytest"
-	"go.opentelemetry.io/collector/testutils"
+	"go.opentelemetry.io/collector/testutil"
 )
 
 const ocReceiver = "oc_receiver_test"
 
 // TODO(ccaraman): Migrate tests to use assert for validating functionality.
 func TestGrpcGateway_endToEnd(t *testing.T) {
-	addr := testutils.GetAvailableLocalAddress(t)
+	addr := testutil.GetAvailableLocalAddress(t)
 
 	// Set the buffer count to 1 to make it flush the test span immediately.
 	sink := new(exportertest.SinkTraceExporterOld)
@@ -152,7 +152,7 @@ func TestGrpcGateway_endToEnd(t *testing.T) {
 }
 
 func TestTraceGrpcGatewayCors_endToEnd(t *testing.T) {
-	addr := testutils.GetAvailableLocalAddress(t)
+	addr := testutil.GetAvailableLocalAddress(t)
 	corsOrigins := []string{"allowed-*.com"}
 
 	sink := new(exportertest.SinkTraceExporterOld)
@@ -177,7 +177,7 @@ func TestTraceGrpcGatewayCors_endToEnd(t *testing.T) {
 }
 
 func TestMetricsGrpcGatewayCors_endToEnd(t *testing.T) {
-	addr := testutils.GetAvailableLocalAddress(t)
+	addr := testutil.GetAvailableLocalAddress(t)
 	corsOrigins := []string{"allowed-*.com"}
 
 	sink := new(exportertest.SinkMetricsExporterOld)
@@ -207,7 +207,7 @@ func TestMetricsGrpcGatewayCors_endToEnd(t *testing.T) {
 func TestAcceptAllGRPCProtoAffiliatedContentTypes(t *testing.T) {
 	t.Skip("Currently a flaky test as we need a way to flush all written traces")
 
-	addr := testutils.GetAvailableLocalAddress(t)
+	addr := testutil.GetAvailableLocalAddress(t)
 	cbts := new(exportertest.SinkTraceExporterOld)
 	ocr, err := New(ocReceiver, "tcp", addr, cbts, nil)
 	require.NoError(t, err, "Failed to create trace receiver: %v", err)
@@ -331,7 +331,7 @@ func verifyCorsResp(t *testing.T, url string, origin string, wantStatus int, wan
 }
 
 func TestStopWithoutStartNeverCrashes(t *testing.T) {
-	addr := testutils.GetAvailableLocalAddress(t)
+	addr := testutil.GetAvailableLocalAddress(t)
 	ocr, err := New(ocReceiver, "tcp", addr, nil, nil)
 	require.NoError(t, err, "Failed to create an OpenCensus receiver: %v", err)
 	// Stop it before ever invoking Start*.
@@ -339,7 +339,7 @@ func TestStopWithoutStartNeverCrashes(t *testing.T) {
 }
 
 func TestNewPortAlreadyUsed(t *testing.T) {
-	addr := testutils.GetAvailableLocalAddress(t)
+	addr := testutil.GetAvailableLocalAddress(t)
 	ln, err := net.Listen("tcp", addr)
 	require.NoError(t, err, "failed to listen on %q: %v", addr, err)
 	defer ln.Close()
@@ -350,7 +350,7 @@ func TestNewPortAlreadyUsed(t *testing.T) {
 }
 
 func TestMultipleStopReceptionShouldNotError(t *testing.T) {
-	addr := testutils.GetAvailableLocalAddress(t)
+	addr := testutil.GetAvailableLocalAddress(t)
 	r, err := New(ocReceiver, "tcp", addr, new(exportertest.SinkTraceExporterOld), new(exportertest.SinkMetricsExporterOld))
 	require.NoError(t, err)
 	require.NotNil(t, r)
@@ -360,7 +360,7 @@ func TestMultipleStopReceptionShouldNotError(t *testing.T) {
 }
 
 func TestStartWithoutConsumersShouldFail(t *testing.T) {
-	addr := testutils.GetAvailableLocalAddress(t)
+	addr := testutil.GetAvailableLocalAddress(t)
 	r, err := New(ocReceiver, "tcp", addr, nil, nil)
 	require.NoError(t, err)
 	require.NotNil(t, r)
@@ -461,7 +461,7 @@ func TestOCReceiverTrace_HandleNextConsumerResponse(t *testing.T) {
 		},
 	}
 
-	addr := testutils.GetAvailableLocalAddress(t)
+	addr := testutil.GetAvailableLocalAddress(t)
 	msg := &agenttracepb.ExportTraceServiceRequest{
 		Node: &commonpb.Node{
 			ServiceInfo: &commonpb.ServiceInfo{Name: "test-svc"},
@@ -621,7 +621,7 @@ func TestOCReceiverMetrics_HandleNextConsumerResponse(t *testing.T) {
 		Timeseries:       []*metricspb.TimeSeries{ts},
 	}
 
-	addr := testutils.GetAvailableLocalAddress(t)
+	addr := testutil.GetAvailableLocalAddress(t)
 	msg := &agentmetricspb.ExportMetricsServiceRequest{
 		Node: &commonpb.Node{
 			ServiceInfo: &commonpb.ServiceInfo{Name: "test-svc"},

--- a/receiver/otlpreceiver/factory_test.go
+++ b/receiver/otlpreceiver/factory_test.go
@@ -30,7 +30,7 @@ import (
 	"go.opentelemetry.io/collector/config/configmodels"
 	"go.opentelemetry.io/collector/config/configprotocol"
 	"go.opentelemetry.io/collector/exporter/exportertest"
-	"go.opentelemetry.io/collector/testutils"
+	"go.opentelemetry.io/collector/testutil"
 )
 
 func TestCreateDefaultConfig(t *testing.T) {
@@ -45,7 +45,7 @@ func TestCreateReceiver(t *testing.T) {
 	cfg := factory.CreateDefaultConfig()
 
 	config := cfg.(*Config)
-	config.Endpoint = testutils.GetAvailableLocalAddress(t)
+	config.Endpoint = testutil.GetAvailableLocalAddress(t)
 
 	creationParams := component.ReceiverCreateParams{Logger: zap.NewNop()}
 	tReceiver, err := factory.CreateTraceReceiver(context.Background(), creationParams, cfg, nil)
@@ -59,7 +59,7 @@ func TestCreateReceiver(t *testing.T) {
 
 func TestCreateTraceReceiver(t *testing.T) {
 	factory := Factory{}
-	endpoint := testutils.GetAvailableLocalAddress(t)
+	endpoint := testutil.GetAvailableLocalAddress(t)
 	defaultReceiverSettings := configmodels.ReceiverSettings{
 		TypeVal: typeStr,
 		NameVal: typeStr,
@@ -134,7 +134,7 @@ func TestCreateTraceReceiver(t *testing.T) {
 
 func TestCreateMetricReceiver(t *testing.T) {
 	factory := Factory{}
-	endpoint := testutils.GetAvailableLocalAddress(t)
+	endpoint := testutil.GetAvailableLocalAddress(t)
 	defaultReceiverSettings := configmodels.ReceiverSettings{
 		TypeVal: typeStr,
 		NameVal: typeStr,

--- a/receiver/otlpreceiver/metrics/otlp_test.go
+++ b/receiver/otlpreceiver/metrics/otlp_test.go
@@ -33,7 +33,7 @@ import (
 	otlpmetrics "go.opentelemetry.io/collector/internal/data/opentelemetry-proto-gen/metrics/v1"
 	otlpresource "go.opentelemetry.io/collector/internal/data/opentelemetry-proto-gen/resource/v1"
 	"go.opentelemetry.io/collector/observability"
-	"go.opentelemetry.io/collector/testutils"
+	"go.opentelemetry.io/collector/testutil"
 )
 
 var _ collectormetrics.MetricsServiceServer = (*Receiver)(nil)
@@ -154,7 +154,7 @@ func otlpReceiverOnGRPCServer(t *testing.T, mc consumer.MetricsConsumer) (r *Rec
 		}
 	}
 
-	_, port, err = testutils.HostPortFromAddr(ln.Addr())
+	_, port, err = testutil.HostPortFromAddr(ln.Addr())
 	if err != nil {
 		done()
 		t.Fatalf("Failed to parse host:port from listener address: %s error: %v", ln.Addr(), err)

--- a/receiver/otlpreceiver/otlp_test.go
+++ b/receiver/otlpreceiver/otlp_test.go
@@ -45,14 +45,14 @@ import (
 	otlptrace "go.opentelemetry.io/collector/internal/data/opentelemetry-proto-gen/trace/v1"
 	"go.opentelemetry.io/collector/internal/data/testdata"
 	"go.opentelemetry.io/collector/observability/observabilitytest"
-	"go.opentelemetry.io/collector/testutils"
+	"go.opentelemetry.io/collector/testutil"
 	"go.opentelemetry.io/collector/translator/conventions"
 )
 
 const otlpReceiver = "otlp_receiver_test"
 
 func TestGrpcGateway_endToEnd(t *testing.T) {
-	addr := testutils.GetAvailableLocalAddress(t)
+	addr := testutil.GetAvailableLocalAddress(t)
 
 	// Set the buffer count to 1 to make it flush the test span immediately.
 	sink := new(exportertest.SinkTraceExporter)
@@ -171,7 +171,7 @@ func TestGrpcGateway_endToEnd(t *testing.T) {
 }
 
 func TestProtoHttp(t *testing.T) {
-	addr := testutils.GetAvailableLocalAddress(t)
+	addr := testutil.GetAvailableLocalAddress(t)
 
 	// Set the buffer count to 1 to make it flush the test span immediately.
 	sink := new(exportertest.SinkTraceExporter)
@@ -245,7 +245,7 @@ func TestProtoHttp(t *testing.T) {
 }
 
 func TestTraceGrpcGatewayCors_endToEnd(t *testing.T) {
-	addr := testutils.GetAvailableLocalAddress(t)
+	addr := testutil.GetAvailableLocalAddress(t)
 	corsOrigins := []string{"allowed-*.com"}
 
 	sink := new(exportertest.SinkTraceExporter)
@@ -269,7 +269,7 @@ func TestTraceGrpcGatewayCors_endToEnd(t *testing.T) {
 }
 
 func TestMetricsGrpcGatewayCors_endToEnd(t *testing.T) {
-	addr := testutils.GetAvailableLocalAddress(t)
+	addr := testutil.GetAvailableLocalAddress(t)
 	corsOrigins := []string{"allowed-*.com"}
 
 	sink := new(exportertest.SinkMetricsExporter)
@@ -298,7 +298,7 @@ func TestMetricsGrpcGatewayCors_endToEnd(t *testing.T) {
 func TestAcceptAllGRPCProtoAffiliatedContentTypes(t *testing.T) {
 	t.Skip("Currently a flaky test as we need a way to flush all written traces")
 
-	addr := testutils.GetAvailableLocalAddress(t)
+	addr := testutil.GetAvailableLocalAddress(t)
 	cbts := new(exportertest.SinkTraceExporter)
 	ocr, err := New(otlpReceiver, "tcp", addr, cbts, nil)
 	require.NoError(t, err, "Failed to create trace receiver: %v", err)
@@ -428,7 +428,7 @@ func verifyCorsResp(t *testing.T, url string, origin string, wantStatus int, wan
 }
 
 func TestStopWithoutStartNeverCrashes(t *testing.T) {
-	addr := testutils.GetAvailableLocalAddress(t)
+	addr := testutil.GetAvailableLocalAddress(t)
 	ocr, err := New(otlpReceiver, "tcp", addr, nil, nil)
 	require.NoError(t, err, "Failed to create an OpenCensus receiver: %v", err)
 	// Stop it before ever invoking Start*.
@@ -436,7 +436,7 @@ func TestStopWithoutStartNeverCrashes(t *testing.T) {
 }
 
 func TestNewPortAlreadyUsed(t *testing.T) {
-	addr := testutils.GetAvailableLocalAddress(t)
+	addr := testutil.GetAvailableLocalAddress(t)
 	ln, err := net.Listen("tcp", addr)
 	require.NoError(t, err, "failed to listen on %q: %v", addr, err)
 	defer ln.Close()
@@ -447,7 +447,7 @@ func TestNewPortAlreadyUsed(t *testing.T) {
 }
 
 func TestMultipleStopReceptionShouldNotError(t *testing.T) {
-	addr := testutils.GetAvailableLocalAddress(t)
+	addr := testutil.GetAvailableLocalAddress(t)
 	r, err := New(otlpReceiver, "tcp", addr, new(exportertest.SinkTraceExporter), new(exportertest.SinkMetricsExporter))
 	require.NoError(t, err)
 	require.NotNil(t, r)
@@ -457,7 +457,7 @@ func TestMultipleStopReceptionShouldNotError(t *testing.T) {
 }
 
 func TestStartWithoutConsumersShouldFail(t *testing.T) {
-	addr := testutils.GetAvailableLocalAddress(t)
+	addr := testutil.GetAvailableLocalAddress(t)
 	r, err := New(otlpReceiver, "tcp", addr, nil, nil)
 	require.NoError(t, err)
 	require.NotNil(t, r)
@@ -565,7 +565,7 @@ func TestOTLPReceiverTrace_HandleNextConsumerResponse(t *testing.T) {
 		},
 	}
 
-	addr := testutils.GetAvailableLocalAddress(t)
+	addr := testutil.GetAvailableLocalAddress(t)
 	req := &collectortrace.ExportTraceServiceRequest{
 		ResourceSpans: []*otlptrace.ResourceSpans{
 			{

--- a/receiver/otlpreceiver/trace/otlp_test.go
+++ b/receiver/otlpreceiver/trace/otlp_test.go
@@ -33,7 +33,7 @@ import (
 	otlpresource "go.opentelemetry.io/collector/internal/data/opentelemetry-proto-gen/resource/v1"
 	otlptrace "go.opentelemetry.io/collector/internal/data/opentelemetry-proto-gen/trace/v1"
 	"go.opentelemetry.io/collector/observability"
-	"go.opentelemetry.io/collector/testutils"
+	"go.opentelemetry.io/collector/testutil"
 )
 
 var _ collectortrace.TraceServiceServer = (*Receiver)(nil)
@@ -157,7 +157,7 @@ func otlpReceiverOnGRPCServer(t *testing.T, tc consumer.TraceConsumer) (r *Recei
 		}
 	}
 
-	_, port, err = testutils.HostPortFromAddr(ln.Addr())
+	_, port, err = testutil.HostPortFromAddr(ln.Addr())
 	if err != nil {
 		done()
 		t.Fatalf("Failed to parse host:port from listener address: %s error: %v", ln.Addr(), err)

--- a/receiver/prometheusreceiver/internal/metrics_adjuster_test.go
+++ b/receiver/prometheusreceiver/internal/metrics_adjuster_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 
-	mtu "go.opentelemetry.io/collector/testutils/metricstestutils"
+	mtu "go.opentelemetry.io/collector/testutil/metricstestutil"
 )
 
 func Test_gauge(t *testing.T) {

--- a/receiver/zipkinreceiver/trace_receiver_test.go
+++ b/receiver/zipkinreceiver/trace_receiver_test.go
@@ -48,7 +48,7 @@ import (
 	"go.opentelemetry.io/collector/exporter/exportertest"
 	"go.opentelemetry.io/collector/exporter/zipkinexporter"
 	"go.opentelemetry.io/collector/internal"
-	"go.opentelemetry.io/collector/testutils"
+	"go.opentelemetry.io/collector/testutil"
 	"go.opentelemetry.io/collector/translator/trace/zipkin"
 )
 
@@ -342,8 +342,8 @@ func TestConversionRoundtrip(t *testing.T) {
 	// fail with error. Use a small hack to transform the multiple arrays into a
 	// single one.
 	accumulatedJSONMsgs := strings.Replace(buf.String(), "][", ",", -1)
-	gj := testutils.GenerateNormalizedJSON(t, accumulatedJSONMsgs)
-	wj := testutils.GenerateNormalizedJSON(t, string(receiverInputJSON))
+	gj := testutil.GenerateNormalizedJSON(t, accumulatedJSONMsgs)
+	wj := testutil.GenerateNormalizedJSON(t, string(receiverInputJSON))
 	assert.Equal(t, wj, gj)
 }
 

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -39,7 +39,7 @@ import (
 	"go.opentelemetry.io/collector/config/configmodels"
 	"go.opentelemetry.io/collector/internal/version"
 	"go.opentelemetry.io/collector/service/defaultcomponents"
-	"go.opentelemetry.io/collector/testutils"
+	"go.opentelemetry.io/collector/testutil"
 )
 
 func TestApplication_Start(t *testing.T) {
@@ -57,7 +57,7 @@ func TestApplication_Start(t *testing.T) {
 	assert.Equal(t, app.rootCmd, app.Command())
 
 	const testPrefix = "a_test"
-	metricsPort := testutils.GetAvailablePort(t)
+	metricsPort := testutil.GetAvailablePort(t)
 	app.rootCmd.SetArgs([]string{
 		"--config=testdata/otelcol-config.yaml",
 		"--metrics-addr=localhost:" + strconv.FormatUint(uint64(metricsPort), 10),

--- a/testbed/testbed/utils.go
+++ b/testbed/testbed/utils.go
@@ -17,9 +17,9 @@ package testbed
 import (
 	"testing"
 
-	"go.opentelemetry.io/collector/testutils"
+	"go.opentelemetry.io/collector/testutil"
 )
 
 func GetAvailablePort(t *testing.T) int {
-	return int(testutils.GetAvailablePort(t))
+	return int(testutil.GetAvailablePort(t))
 }

--- a/testutil/metricstestutil/metricsutil.go
+++ b/testutil/metricstestutil/metricsutil.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package metricstestutils
+package metricstestutil
 
 import (
 	"time"

--- a/testutil/metricstestutil/metricsutil_test.go
+++ b/testutil/metricstestutil/metricsutil_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package metricstestutils
+package metricstestutil
 
 import (
 	"testing"

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package testutils
+package testutil
 
 import (
 	"encoding/json"

--- a/testutil/testutil_test.go
+++ b/testutil/testutil_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package testutils
+package testutil
 
 import (
 	"fmt"

--- a/translator/trace/jaeger/jaegerthrift_to_protospan_test.go
+++ b/translator/trace/jaeger/jaegerthrift_to_protospan_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/collector/consumer/consumerdata"
-	"go.opentelemetry.io/collector/testutils"
+	"go.opentelemetry.io/collector/testutil"
 	tracetranslator "go.opentelemetry.io/collector/translator/trace"
 )
 
@@ -65,7 +65,7 @@ func TestThriftBatchToOCProto(t *testing.T) {
 			continue
 		}
 
-		gj, wj := testutils.GenerateNormalizedJSON(t, string(gb)), testutils.GenerateNormalizedJSON(t, string(wb))
+		gj, wj := testutil.GenerateNormalizedJSON(t, string(gb)), testutil.GenerateNormalizedJSON(t, string(wb))
 		if gj != wj {
 			t.Errorf("The roundtrip JSON doesn't match the JSON that we want\nGot:\n%s\nWant:\n%s", gj, wj)
 		}


### PR DESCRIPTION
To keep the consistency with *util naming in the repo and in the larger Go ecosystem.

Similarly moved metricsutils to metricutil.

Also shorten some of the very long file names in the testutil packages.
