### PR TITLE
Refactor jaeger receiver config to allow different configs for different protocols

### DIFF
--- a/receiver/jaegerreceiver/config.go
+++ b/receiver/jaegerreceiver/config.go
@@ -16,6 +16,7 @@ package jaegerreceiver
 
 import (
 	"go.opentelemetry.io/collector/config/configgrpc"
+	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/config/configmodels"
 	"go.opentelemetry.io/collector/config/configprotocol"
 )
@@ -30,9 +31,16 @@ type RemoteSamplingConfig struct {
 	configgrpc.GRPCClientSettings `mapstructure:",squash"`
 }
 
+type Protocols struct {
+	GRPC          *configgrpc.GRPCServerSettings         `mapstructure:"grpc"`
+	ThriftHTTP    *confighttp.HTTPServerSettings         `mapstructure:"thrift_http"`
+	ThriftBinary  *configprotocol.ProtocolServerSettings `mapstructure:"thrift_binary"`
+	ThriftCompact *configprotocol.ProtocolServerSettings `mapstructure:"thrift_compact"`
+}
+
 // Config defines configuration for Jaeger receiver.
 type Config struct {
-	configmodels.ReceiverSettings `mapstructure:",squash"`                          // squash ensures fields are correctly decoded in embedded struct
-	Protocols                     map[string]*configprotocol.ProtocolServerSettings `mapstructure:"protocols"`
-	RemoteSampling                *RemoteSamplingConfig                             `mapstructure:"remote_sampling"`
+	configmodels.ReceiverSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
+	Protocols                     `mapstructure:"protocols"`
+	RemoteSampling                *RemoteSamplingConfig `mapstructure:"remote_sampling"`
 }

--- a/receiver/jaegerreceiver/testdata/bad_typo_default_proto_config.yaml
+++ b/receiver/jaegerreceiver/testdata/bad_typo_default_proto_config.yaml
@@ -2,8 +2,9 @@ receivers:
   # The following demonstrates how to enable protocols with defaults
   jaeger:
     protocols:
-      thrift_htttp:
+      grpc:
         endpoint: "127.0.0.1:123"
+      thrift_htttp:
 
 processors:
   exampleprocessor:
@@ -14,6 +15,6 @@ exporters:
 service:
   pipelines:
     traces:
-     receivers: [jaeger]
-     processors: [exampleprocessor]
-     exporters: [exampleexporter]
+      receivers: [jaeger]
+      processors: [exampleprocessor]
+      exporters: [exampleexporter]

--- a/receiver/jaegerreceiver/trace_receiver_test.go
+++ b/receiver/jaegerreceiver/trace_receiver_test.go
@@ -45,7 +45,7 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/configgrpc"
-	"go.opentelemetry.io/collector/config/configprotocol"
+	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/config/configtls"
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/exporter/exportertest"
@@ -594,10 +594,8 @@ func TestSamplingStrategiesMutualTLS(t *testing.T) {
 	// at least one protocol has to be enabled
 	thriftHTTPPort, err := randomAvailablePort()
 	require.NoError(t, err)
-	cfg.Protocols = map[string]*configprotocol.ProtocolServerSettings{
-		"thrift_http": {
-			Endpoint: fmt.Sprintf("localhost:%d", thriftHTTPPort),
-		},
+	cfg.Protocols.ThriftHTTP = &confighttp.HTTPServerSettings{
+		Endpoint: fmt.Sprintf("localhost:%d", thriftHTTPPort),
 	}
 	exp, err := factory.CreateTraceReceiver(context.Background(), component.ReceiverCreateParams{Logger: zap.NewNop()}, cfg, exportertest.NewNopTraceExporter())
 	require.NoError(t, err)

--- a/testbed/testbed/receivers.go
+++ b/testbed/testbed/receivers.go
@@ -22,8 +22,8 @@ import (
 	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config/configgrpc"
 	"go.opentelemetry.io/collector/config/configmodels"
-	"go.opentelemetry.io/collector/config/configprotocol"
 	"go.opentelemetry.io/collector/receiver/jaegerreceiver"
 	"go.opentelemetry.io/collector/receiver/opencensusreceiver"
 	"go.opentelemetry.io/collector/receiver/otlpreceiver"
@@ -147,7 +147,7 @@ func (jr *JaegerDataReceiver) Start(tc *MockTraceConsumer, _ *MockMetricConsumer
 	factory := jaegerreceiver.Factory{}
 	cfg := factory.CreateDefaultConfig().(*jaegerreceiver.Config)
 	cfg.SetName(jr.ProtocolName())
-	cfg.Protocols["grpc"] = &configprotocol.ProtocolServerSettings{
+	cfg.Protocols.GRPC = &configgrpc.GRPCServerSettings{
 		Endpoint: fmt.Sprintf("localhost:%d", jr.Port),
 	}
 	var err error

--- a/testbed/testbed/senders.go
+++ b/testbed/testbed/senders.go
@@ -157,28 +157,11 @@ func (je *JaegerGRPCDataSender) Start() error {
 }
 
 func (je *JaegerGRPCDataSender) GenConfigYAMLStr() string {
-	// Note that this generates a receiver config for agent.
-	// We only need to enable gRPC protocol because that's what we use in tests.
-	// Due to bug in Jaeger receiver (https://go.opentelemetry.io/collector/issues/445)
-	// which makes it impossible to disable protocols that we don't need to receive on we
-	// have to use fake ports for all endpoints except gRPC, otherwise it is
-	// impossible to start the Collector because the standard ports for those protocols
-	// are already listened by mock Jaeger backend that is part of the tests.
-	// As soon as the bug is fixed remove the endpoints and use "disabled: true" setting
-	// instead.
 	return fmt.Sprintf(`
   jaeger:
     protocols:
       grpc:
-        endpoint: "%s:%d"
-      thrift_tchannel:
-        endpoint: "localhost:8372"
-      thrift_compact:
-        endpoint: "localhost:8373"
-      thrift_binary:
-        endpoint: "localhost:8374"
-      thrift_http:
-        endpoint: "localhost:8375"`, je.Host, je.Port)
+        endpoint: "%s:%d"`, je.Host, je.Port)
 }
 
 func (je *JaegerGRPCDataSender) ProtocolName() string {


### PR DESCRIPTION
This change is backwards compatible for configuration.

Allows more configs for HTTP and gRPC protocols and ensure consistency with OTLP and OpenCensus.