### PR TITLE
Don't export application telemetry

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -255,7 +255,7 @@ func (app *Application) init(hooks ...func(zapcore.Entry) error) error {
 func (app *Application) setupTelemetry(ballastSizeBytes uint64) error {
 	app.logger.Info("Setting up own telemetry...")
 
-	err := AppTelemetry.init(app.asyncErrorChannel, ballastSizeBytes, app.logger)
+	err := applicationTelemetry.init(app.asyncErrorChannel, ballastSizeBytes, app.logger)
 	if err != nil {
 		return errors.Wrap(err, "failed to initialize telemetry")
 	}
@@ -466,7 +466,7 @@ func (app *Application) execute(ctx context.Context, factory ConfigFactory) erro
 		errs = append(errs, errors.Wrap(err, "failed to shutdown extensions"))
 	}
 
-	err = AppTelemetry.shutdown()
+	err = applicationTelemetry.shutdown()
 	if err != nil {
 		errs = append(errs, errors.Wrap(err, "failed to shutdown extensions"))
 	}

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -105,9 +105,9 @@ func (tel *mockAppTelemetry) shutdown() error {
 
 func TestApplication_ReportError(t *testing.T) {
 	// use a mock AppTelemetry struct to return an error on shutdown
-	preservedAppTelemetry := AppTelemetry
-	AppTelemetry = &mockAppTelemetry{}
-	defer func() { AppTelemetry = preservedAppTelemetry }()
+	preservedAppTelemetry := applicationTelemetry
+	applicationTelemetry = &mockAppTelemetry{}
+	defer func() { applicationTelemetry = preservedAppTelemetry }()
 
 	factories, err := defaultcomponents.Components()
 	require.NoError(t, err)

--- a/service/telemetry.go
+++ b/service/telemetry.go
@@ -34,7 +34,7 @@ import (
 	"go.opentelemetry.io/collector/translator/conventions"
 )
 
-// telemetry is application's own telemetry.
+// applicationTelemetry is application's own telemetry.
 var applicationTelemetry appTelemetryExporter = &appTelemetry{}
 
 type appTelemetryExporter interface {

--- a/service/telemetry.go
+++ b/service/telemetry.go
@@ -34,10 +34,8 @@ import (
 	"go.opentelemetry.io/collector/translator/conventions"
 )
 
-var (
-	// AppTelemetry is application's own telemetry.
-	AppTelemetry appTelemetryExporter = &appTelemetry{}
-)
+// telemetry is application's own telemetry.
+var applicationTelemetry appTelemetryExporter = &appTelemetry{}
 
 type appTelemetryExporter interface {
 	init(asyncErrorChannel chan<- error, ballastSizeBytes uint64, logger *zap.Logger) error


### PR DESCRIPTION
appTelemetryExporter is not an exported type and there is no way
override the default telemetry. Unexport this variable until
we decide to export the type or provide different implementations.
