### PR TITLE
Do not embed ProtocolServerSettings in gRPC

### DIFF
--- a/receiver/opencensusreceiver/config_test.go
+++ b/receiver/opencensusreceiver/config_test.go
@@ -25,7 +25,6 @@ import (
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/configgrpc"
 	"go.opentelemetry.io/collector/config/configmodels"
-	"go.opentelemetry.io/collector/config/configprotocol"
 	"go.opentelemetry.io/collector/config/configtls"
 )
 
@@ -53,10 +52,7 @@ func TestLoadConfig(t *testing.T) {
 				NameVal: "opencensus/customname",
 			},
 			GRPCServerSettings: configgrpc.GRPCServerSettings{
-				ProtocolServerSettings: configprotocol.ProtocolServerSettings{
-					Endpoint:       "0.0.0.0:9090",
-					TLSCredentials: nil,
-				},
+				Endpoint: "0.0.0.0:9090",
 			},
 			Transport: "tcp",
 		})
@@ -69,10 +65,7 @@ func TestLoadConfig(t *testing.T) {
 				NameVal: "opencensus/keepalive",
 			},
 			GRPCServerSettings: configgrpc.GRPCServerSettings{
-				ProtocolServerSettings: configprotocol.ProtocolServerSettings{
-					TLSCredentials: nil,
-					Endpoint:       "0.0.0.0:55678",
-				},
+				Endpoint: "0.0.0.0:55678",
 				Keepalive: &configgrpc.KeepaliveServerConfig{
 					ServerParameters: &configgrpc.KeepaliveServerParameters{
 						MaxConnectionIdle:     11 * time.Second,
@@ -98,10 +91,7 @@ func TestLoadConfig(t *testing.T) {
 				NameVal: "opencensus/msg-size-conc-connect-max-idle",
 			},
 			GRPCServerSettings: configgrpc.GRPCServerSettings{
-				ProtocolServerSettings: configprotocol.ProtocolServerSettings{
-					Endpoint:       "0.0.0.0:55678",
-					TLSCredentials: nil,
-				},
+				Endpoint:             "0.0.0.0:55678",
 				MaxRecvMsgSizeMiB:    32,
 				MaxConcurrentStreams: 16,
 				Keepalive: &configgrpc.KeepaliveServerConfig{
@@ -123,13 +113,11 @@ func TestLoadConfig(t *testing.T) {
 				NameVal: "opencensus/tlscredentials",
 			},
 			GRPCServerSettings: configgrpc.GRPCServerSettings{
-				ProtocolServerSettings: configprotocol.ProtocolServerSettings{
-					Endpoint: "0.0.0.0:55678",
-					TLSCredentials: &configtls.TLSServerSetting{
-						TLSSetting: configtls.TLSSetting{
-							CertFile: "test.crt",
-							KeyFile:  "test.key",
-						},
+				Endpoint: "0.0.0.0:55678",
+				TLSCredentials: &configtls.TLSServerSetting{
+					TLSSetting: configtls.TLSSetting{
+						CertFile: "test.crt",
+						KeyFile:  "test.key",
 					},
 				},
 			},
@@ -144,9 +132,7 @@ func TestLoadConfig(t *testing.T) {
 				NameVal: "opencensus/cors",
 			},
 			GRPCServerSettings: configgrpc.GRPCServerSettings{
-				ProtocolServerSettings: configprotocol.ProtocolServerSettings{
-					Endpoint: "0.0.0.0:55678",
-				},
+				Endpoint: "0.0.0.0:55678",
 			},
 			Transport:   "tcp",
 			CorsOrigins: []string{"https://*.test.com", "https://test.com"},
@@ -160,9 +146,7 @@ func TestLoadConfig(t *testing.T) {
 				NameVal: "opencensus/uds",
 			},
 			GRPCServerSettings: configgrpc.GRPCServerSettings{
-				ProtocolServerSettings: configprotocol.ProtocolServerSettings{
-					Endpoint: "/tmp/opencensus.sock",
-				},
+				Endpoint: "/tmp/opencensus.sock",
 			},
 			Transport: "unix",
 		})
@@ -174,17 +158,15 @@ func TestBuildOptions_TLSCredentials(t *testing.T) {
 			NameVal: "IncorrectTLS",
 		},
 		GRPCServerSettings: configgrpc.GRPCServerSettings{
-			ProtocolServerSettings: configprotocol.ProtocolServerSettings{
-				TLSCredentials: &configtls.TLSServerSetting{
-					TLSSetting: configtls.TLSSetting{
-						CertFile: "willfail",
-					},
+			TLSCredentials: &configtls.TLSServerSetting{
+				TLSSetting: configtls.TLSSetting{
+					CertFile: "willfail",
 				},
 			},
 		},
 	}
 	_, err := cfg.buildOptions()
-	assert.EqualError(t, err, `error initializing TLS Credentials: failed to load TLS config: for auth via TLS, either both certificate and key must be supplied, or neither`)
+	assert.EqualError(t, err, `failed to load TLS config: for auth via TLS, either both certificate and key must be supplied, or neither`)
 
 	cfg.TLSCredentials = &configtls.TLSServerSetting{}
 	opt, err := cfg.buildOptions()

--- a/receiver/opencensusreceiver/factory.go
+++ b/receiver/opencensusreceiver/factory.go
@@ -22,7 +22,6 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configgrpc"
 	"go.opentelemetry.io/collector/config/configmodels"
-	"go.opentelemetry.io/collector/config/configprotocol"
 	"go.opentelemetry.io/collector/consumer"
 )
 
@@ -53,9 +52,7 @@ func (f *Factory) CreateDefaultConfig() configmodels.Receiver {
 			NameVal: typeStr,
 		},
 		GRPCServerSettings: configgrpc.GRPCServerSettings{
-			ProtocolServerSettings: configprotocol.ProtocolServerSettings{
-				Endpoint: "0.0.0.0:55678",
-			},
+			Endpoint: "0.0.0.0:55678",
 		},
 		Transport: "tcp",
 	}

--- a/receiver/opencensusreceiver/factory_test.go
+++ b/receiver/opencensusreceiver/factory_test.go
@@ -27,7 +27,6 @@ import (
 	"go.opentelemetry.io/collector/config/configcheck"
 	"go.opentelemetry.io/collector/config/configgrpc"
 	"go.opentelemetry.io/collector/config/configmodels"
-	"go.opentelemetry.io/collector/config/configprotocol"
 	"go.opentelemetry.io/collector/exporter/exportertest"
 	"go.opentelemetry.io/collector/testutil"
 )
@@ -63,9 +62,7 @@ func TestCreateTraceReceiver(t *testing.T) {
 		NameVal: typeStr,
 	}
 	defaultGRPCSettings := configgrpc.GRPCServerSettings{
-		ProtocolServerSettings: configprotocol.ProtocolServerSettings{
-			Endpoint: endpoint,
-		},
+		Endpoint: endpoint,
 	}
 	tests := []struct {
 		name    string
@@ -88,9 +85,7 @@ func TestCreateTraceReceiver(t *testing.T) {
 					NameVal: typeStr,
 				},
 				GRPCServerSettings: configgrpc.GRPCServerSettings{
-					ProtocolServerSettings: configprotocol.ProtocolServerSettings{
-						Endpoint: "localhost:112233",
-					},
+					Endpoint: "localhost:112233",
 				},
 				Transport: "tcp",
 			},
@@ -101,9 +96,7 @@ func TestCreateTraceReceiver(t *testing.T) {
 			cfg: &Config{
 				ReceiverSettings: defaultReceiverSettings,
 				GRPCServerSettings: configgrpc.GRPCServerSettings{
-					ProtocolServerSettings: configprotocol.ProtocolServerSettings{
-						Endpoint: endpoint,
-					},
+					Endpoint:             endpoint,
 					MaxRecvMsgSizeMiB:    32,
 					MaxConcurrentStreams: 16,
 				},
@@ -138,9 +131,7 @@ func TestCreateMetricReceiver(t *testing.T) {
 		NameVal: typeStr,
 	}
 	defaultGRPCSettings := configgrpc.GRPCServerSettings{
-		ProtocolServerSettings: configprotocol.ProtocolServerSettings{
-			Endpoint: endpoint,
-		},
+		Endpoint: endpoint,
 	}
 
 	tests := []struct {
@@ -164,9 +155,7 @@ func TestCreateMetricReceiver(t *testing.T) {
 					NameVal: typeStr,
 				},
 				GRPCServerSettings: configgrpc.GRPCServerSettings{
-					ProtocolServerSettings: configprotocol.ProtocolServerSettings{
-						Endpoint: "327.0.0.1:1122",
-					},
+					Endpoint: "327.0.0.1:1122",
 				},
 				Transport: "tcp",
 			},
@@ -177,9 +166,7 @@ func TestCreateMetricReceiver(t *testing.T) {
 			cfg: &Config{
 				ReceiverSettings: defaultReceiverSettings,
 				GRPCServerSettings: configgrpc.GRPCServerSettings{
-					ProtocolServerSettings: configprotocol.ProtocolServerSettings{
-						Endpoint: endpoint,
-					},
+					Endpoint: endpoint,
 					Keepalive: &configgrpc.KeepaliveServerConfig{
 						ServerParameters: &configgrpc.KeepaliveServerParameters{
 							MaxConnectionAge: 60 * time.Second,

--- a/receiver/otlpreceiver/config_test.go
+++ b/receiver/otlpreceiver/config_test.go
@@ -25,7 +25,6 @@ import (
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/configgrpc"
 	"go.opentelemetry.io/collector/config/configmodels"
-	"go.opentelemetry.io/collector/config/configprotocol"
 	"go.opentelemetry.io/collector/config/configtls"
 )
 
@@ -53,10 +52,7 @@ func TestLoadConfig(t *testing.T) {
 				NameVal: "otlp/customname",
 			},
 			GRPCServerSettings: configgrpc.GRPCServerSettings{
-				ProtocolServerSettings: configprotocol.ProtocolServerSettings{
-					Endpoint:       "localhost:9090",
-					TLSCredentials: nil,
-				},
+				Endpoint: "localhost:9090",
 			},
 			Transport: "tcp",
 		})
@@ -69,10 +65,7 @@ func TestLoadConfig(t *testing.T) {
 				NameVal: "otlp/keepalive",
 			},
 			GRPCServerSettings: configgrpc.GRPCServerSettings{
-				ProtocolServerSettings: configprotocol.ProtocolServerSettings{
-					Endpoint:       "0.0.0.0:55680",
-					TLSCredentials: nil,
-				},
+				Endpoint: "0.0.0.0:55680",
 				Keepalive: &configgrpc.KeepaliveServerConfig{
 					ServerParameters: &configgrpc.KeepaliveServerParameters{
 						MaxConnectionIdle:     11 * time.Second,
@@ -98,10 +91,7 @@ func TestLoadConfig(t *testing.T) {
 				NameVal: "otlp/msg-size-conc-connect-max-idle",
 			},
 			GRPCServerSettings: configgrpc.GRPCServerSettings{
-				ProtocolServerSettings: configprotocol.ProtocolServerSettings{
-					Endpoint:       "0.0.0.0:55680",
-					TLSCredentials: nil,
-				},
+				Endpoint:             "0.0.0.0:55680",
 				MaxRecvMsgSizeMiB:    32,
 				MaxConcurrentStreams: 16,
 				Keepalive: &configgrpc.KeepaliveServerConfig{
@@ -123,13 +113,11 @@ func TestLoadConfig(t *testing.T) {
 				NameVal: "otlp/tlscredentials",
 			},
 			GRPCServerSettings: configgrpc.GRPCServerSettings{
-				ProtocolServerSettings: configprotocol.ProtocolServerSettings{
-					Endpoint: "0.0.0.0:55680",
-					TLSCredentials: &configtls.TLSServerSetting{
-						TLSSetting: configtls.TLSSetting{
-							CertFile: "test.crt",
-							KeyFile:  "test.key",
-						},
+				Endpoint: "0.0.0.0:55680",
+				TLSCredentials: &configtls.TLSServerSetting{
+					TLSSetting: configtls.TLSSetting{
+						CertFile: "test.crt",
+						KeyFile:  "test.key",
 					},
 				},
 			},
@@ -144,10 +132,8 @@ func TestLoadConfig(t *testing.T) {
 				NameVal: "otlp/cors",
 			},
 			GRPCServerSettings: configgrpc.GRPCServerSettings{
-				ProtocolServerSettings: configprotocol.ProtocolServerSettings{
-					Endpoint:       "0.0.0.0:55680",
-					TLSCredentials: nil,
-				},
+				Endpoint:       "0.0.0.0:55680",
+				TLSCredentials: nil,
 			},
 			Transport:   "tcp",
 			CorsOrigins: []string{"https://*.test.com", "https://test.com"},
@@ -161,10 +147,8 @@ func TestLoadConfig(t *testing.T) {
 				NameVal: "otlp/uds",
 			},
 			GRPCServerSettings: configgrpc.GRPCServerSettings{
-				ProtocolServerSettings: configprotocol.ProtocolServerSettings{
-					Endpoint:       "/tmp/otlp.sock",
-					TLSCredentials: nil,
-				},
+				Endpoint:       "/tmp/otlp.sock",
+				TLSCredentials: nil,
 			},
 			Transport: "unix",
 		})
@@ -176,17 +160,15 @@ func TestBuildOptions_TLSCredentials(t *testing.T) {
 			NameVal: "IncorrectTLS",
 		},
 		GRPCServerSettings: configgrpc.GRPCServerSettings{
-			ProtocolServerSettings: configprotocol.ProtocolServerSettings{
-				TLSCredentials: &configtls.TLSServerSetting{
-					TLSSetting: configtls.TLSSetting{
-						CertFile: "willfail",
-					},
+			TLSCredentials: &configtls.TLSServerSetting{
+				TLSSetting: configtls.TLSSetting{
+					CertFile: "willfail",
 				},
 			},
 		},
 	}
 	_, err := cfg.buildOptions()
-	assert.EqualError(t, err, `error initializing TLS Credentials: failed to load TLS config: for auth via TLS, either both certificate and key must be supplied, or neither`)
+	assert.EqualError(t, err, `failed to load TLS config: for auth via TLS, either both certificate and key must be supplied, or neither`)
 
 	cfg.TLSCredentials = &configtls.TLSServerSetting{}
 	opt, err := cfg.buildOptions()

--- a/receiver/otlpreceiver/factory.go
+++ b/receiver/otlpreceiver/factory.go
@@ -20,7 +20,6 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configgrpc"
 	"go.opentelemetry.io/collector/config/configmodels"
-	"go.opentelemetry.io/collector/config/configprotocol"
 	"go.opentelemetry.io/collector/consumer"
 )
 
@@ -51,9 +50,7 @@ func (f *Factory) CreateDefaultConfig() configmodels.Receiver {
 			NameVal: typeStr,
 		},
 		GRPCServerSettings: configgrpc.GRPCServerSettings{
-			ProtocolServerSettings: configprotocol.ProtocolServerSettings{
-				Endpoint: "0.0.0.0:55680",
-			},
+			Endpoint: "0.0.0.0:55680",
 		},
 		Transport: "tcp",
 	}

--- a/receiver/otlpreceiver/factory_test.go
+++ b/receiver/otlpreceiver/factory_test.go
@@ -28,7 +28,6 @@ import (
 	"go.opentelemetry.io/collector/config/configcheck"
 	"go.opentelemetry.io/collector/config/configgrpc"
 	"go.opentelemetry.io/collector/config/configmodels"
-	"go.opentelemetry.io/collector/config/configprotocol"
 	"go.opentelemetry.io/collector/exporter/exportertest"
 	"go.opentelemetry.io/collector/testutil"
 )
@@ -65,9 +64,7 @@ func TestCreateTraceReceiver(t *testing.T) {
 		NameVal: typeStr,
 	}
 	defaultGRPCSettings := configgrpc.GRPCServerSettings{
-		ProtocolServerSettings: configprotocol.ProtocolServerSettings{
-			Endpoint: endpoint,
-		},
+		Endpoint: endpoint,
 	}
 
 	tests := []struct {
@@ -91,9 +88,7 @@ func TestCreateTraceReceiver(t *testing.T) {
 					NameVal: typeStr,
 				},
 				GRPCServerSettings: configgrpc.GRPCServerSettings{
-					ProtocolServerSettings: configprotocol.ProtocolServerSettings{
-						Endpoint: "localhost:112233",
-					},
+					Endpoint: "localhost:112233",
 				},
 				Transport: "tcp",
 			},
@@ -104,9 +99,7 @@ func TestCreateTraceReceiver(t *testing.T) {
 			cfg: &Config{
 				ReceiverSettings: defaultReceiverSettings,
 				GRPCServerSettings: configgrpc.GRPCServerSettings{
-					ProtocolServerSettings: configprotocol.ProtocolServerSettings{
-						Endpoint: endpoint,
-					},
+					Endpoint:             endpoint,
 					MaxRecvMsgSizeMiB:    32,
 					MaxConcurrentStreams: 16,
 				},
@@ -140,9 +133,7 @@ func TestCreateMetricReceiver(t *testing.T) {
 		NameVal: typeStr,
 	}
 	defaultGRPCSettings := configgrpc.GRPCServerSettings{
-		ProtocolServerSettings: configprotocol.ProtocolServerSettings{
-			Endpoint: endpoint,
-		},
+		Endpoint: endpoint,
 	}
 
 	tests := []struct {
@@ -166,9 +157,7 @@ func TestCreateMetricReceiver(t *testing.T) {
 					NameVal: typeStr,
 				},
 				GRPCServerSettings: configgrpc.GRPCServerSettings{
-					ProtocolServerSettings: configprotocol.ProtocolServerSettings{
-						Endpoint: "327.0.0.1:1122",
-					},
+					Endpoint: "327.0.0.1:1122",
 				},
 				Transport: "tcp",
 			},
@@ -179,9 +168,7 @@ func TestCreateMetricReceiver(t *testing.T) {
 			cfg: &Config{
 				ReceiverSettings: defaultReceiverSettings,
 				GRPCServerSettings: configgrpc.GRPCServerSettings{
-					ProtocolServerSettings: configprotocol.ProtocolServerSettings{
-						Endpoint: endpoint,
-					},
+					Endpoint: endpoint,
 					Keepalive: &configgrpc.KeepaliveServerConfig{
 						ServerParameters: &configgrpc.KeepaliveServerParameters{
 							MaxConnectionAge: 60 * time.Second,


### PR DESCRIPTION
Adding `ProtocolServerSettings` was a bit of a rush. We determined that `endpoint` has different meaning based on protocol, also not all the protocols support TLS.

In this PR we revert embedding `ProtocolServerSettings` in the GRPCServerSettings and make it consistent with HttpServerSettings.

Work left: Consistent config name for TLS settings `tls_settings` or `tls_credentials`.