### PR TITLE
Fixed zipkin README  - setting "url" is now refered as "endpoint"

### DIFF
--- a/exporter/zipkinexporter/README.md
+++ b/exporter/zipkinexporter/README.md
@@ -5,7 +5,7 @@ Exports trace data to a [Zipkin](https://zipkin.io/) back-end.
 The following settings are required:
 
 - `format` (default = JSON): The format to sent events in. Can be set to JSON or proto.
-- `url` (no default): URL to which the exporter is going to send Zipkin trace data.
+- `endpoint` (no default): endpoint to which the exporter is going to send Zipkin trace data.
 
 The following settings can be optionally configured:
 
@@ -16,7 +16,7 @@ Example:
 ```yaml
 exporters:
 zipkin:
- url: "http://some.url:9411/api/v2/spans"
+ endpoint: "http://some.url:9411/api/v2/spans"
 ```
 
 The full list of settings exposed for this exporter are documented [here](./config.go)


### PR DESCRIPTION
**Description:** 
Updated README of zipkin exporter to refer "endpoint" instead of old "url"

**Testing:** 
Tested a sample deployment with OTLP receiver sending traces to zipkin, used "endpoint" as key in zipkin settings
```
receivers:
  otlp:

exporters:
  zipkin:
    endpoint: "http://zipkin:9411/api/v2/spans"
    format: proto

service:
  pipelines:
    traces:
      receivers: [otlp]
      exporters: [zipkin]
```

**Documentation:**  README.md 