### PR TITLE
Remove 499 from mapping of OTel status code and HTTP

### DIFF
--- a/translator/trace/grpc_http_mapper.go
+++ b/translator/trace/grpc_http_mapper.go
@@ -44,7 +44,6 @@ var httpToOCCodeMap = map[int32]int32{
 	403: OCPermissionDenied,
 	404: OCNotFound,
 	429: OCResourceExhausted,
-	499: OCCancelled,
 	501: OCUnimplemented,
 	503: OCUnavailable,
 	504: OCDeadlineExceeded,
@@ -70,7 +69,6 @@ func OCStatusCodeFromHTTP(code int32) int32 {
 
 var ocToHTTPCodeMap = map[int32]int32{
 	OCOK:                 http.StatusOK,
-	OCCancelled:          499,
 	OCUnknown:            http.StatusInternalServerError,
 	OCInvalidArgument:    http.StatusBadRequest,
 	OCDeadlineExceeded:   http.StatusGatewayTimeout,


### PR DESCRIPTION
**Description:** <Describe what has changed. 

Currently, status codes and HTTP are not mapped in a way that matches the spec. There is no mention of 499 or cancelled

https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/semantic_conventions/http.md#status

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** < Describe what testing was performed and which tests were added.>

**Documentation:** < Describe the documentation added.>