### PR TITLE
Add batch size metric 

### DIFF
--- a/processor/batchprocessor/batch_processor.go
+++ b/processor/batchprocessor/batch_processor.go
@@ -171,7 +171,8 @@ func (bp *batchTraceProcessor) resetTimer() {
 func (bp *batchTraceProcessor) sendItems(measure *stats.Int64Measure) {
 	// Add that it came form the trace pipeline?
 	statsTags := []tag.Mutator{tag.Insert(processor.TagProcessorNameKey, bp.name)}
-	stats.RecordWithTags(context.Background(), statsTags, measure.M(1))
+	_ = stats.RecordWithTags(context.Background(), statsTags, measure.M(1))
+	_ = stats.RecordWithTags(context.Background(), statsTags, statBatchSendSize.M(int64(bp.batchTraces.getSpanCount())))
 
 	if err := bp.traceConsumer.ConsumeTraces(context.Background(), bp.batchTraces.getTraceData()); err != nil {
 		bp.logger.Warn("Sender failed", zap.Error(err))
@@ -232,6 +233,7 @@ func (bp *batchMetricProcessor) sendItems(measure *stats.Int64Measure) {
 	// Add that it came from the metrics pipeline
 	statsTags := []tag.Mutator{tag.Insert(processor.TagProcessorNameKey, bp.name)}
 	_ = stats.RecordWithTags(context.Background(), statsTags, measure.M(1))
+	_ = stats.RecordWithTags(context.Background(), statsTags, statBatchSendSize.M(int64(bp.batchMetrics.metricData.MetricCount())))
 
 	_ = bp.metricsConsumer.ConsumeMetrics(context.Background(), bp.batchMetrics.getData())
 	bp.batchMetrics.reset()

--- a/processor/batchprocessor/metrics.go
+++ b/processor/batchprocessor/metrics.go
@@ -49,7 +49,7 @@ func MetricViews() []*view.View {
 		Aggregation: view.Sum(),
 	}
 
-	countBatchSendSizeView := &view.View{
+	distributionBatchSendSizeView := &view.View{
 		Name:        statBatchSendSize.Name(),
 		Measure:     statBatchSendSize,
 		Description: statBatchSendSize.Description(),
@@ -60,7 +60,7 @@ func MetricViews() []*view.View {
 	legacyViews := []*view.View{
 		countBatchSizeTriggerSendView,
 		countTimeoutTriggerSendView,
-		countBatchSendSizeView,
+		distributionBatchSendSizeView,
 	}
 
 	return obsreport.ProcessorMetricViews(typeStr, legacyViews)

--- a/processor/batchprocessor/metrics.go
+++ b/processor/batchprocessor/metrics.go
@@ -26,6 +26,7 @@ import (
 var (
 	statBatchSizeTriggerSend = stats.Int64("batch_size_trigger_send", "Number of times the batch was sent due to a size trigger", stats.UnitDimensionless)
 	statTimeoutTriggerSend   = stats.Int64("timeout_trigger_send", "Number of times the batch was sent due to a timeout trigger", stats.UnitDimensionless)
+	statBatchSendSize        = stats.Int64("batch_send_size", "Number of units in the batch", stats.UnitDimensionless)
 )
 
 // MetricViews returns the metrics views related to batching
@@ -48,9 +49,18 @@ func MetricViews() []*view.View {
 		Aggregation: view.Sum(),
 	}
 
+	countBatchSendSizeView := &view.View{
+		Name:        statBatchSendSize.Name(),
+		Measure:     statBatchSendSize,
+		Description: statBatchSendSize.Description(),
+		TagKeys:     processorTagKeys,
+		Aggregation: view.Distribution(10, 25, 50, 75, 100, 250, 500, 750, 1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000, 9000, 10000, 20000, 30000, 50000, 100000),
+	}
+
 	legacyViews := []*view.View{
 		countBatchSizeTriggerSendView,
 		countTimeoutTriggerSendView,
+		countBatchSendSizeView,
 	}
 
 	return obsreport.ProcessorMetricViews(typeStr, legacyViews)


### PR DESCRIPTION
**Description:** <Describe what has changed. 

Add batch size metric (units send in a batch). This metric helps us to tune batch processor size. 

**Link to tracking Issue:** <Issue number if applicable>

Related to https://github.com/jaegertracing/jaeger/issues/2165#issuecomment-651179655
Related to https://github.com/open-telemetry/opentelemetry-collector/issues/662
Related to https://github.com/open-telemetry/opentelemetry-collector/issues/1139

**Testing:** < Describe what testing was performed and which tests were added.>

**Documentation:** < Describe the documentation added.>