### PR TITLE
Added PerRPCCredentials for gRPC settings

### DIFF
--- a/config/configgrpc/bearer_token.go
+++ b/config/configgrpc/bearer_token.go
@@ -15,10 +15,8 @@
 package configgrpc
 
 import (
-	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 
 	"google.golang.org/grpc/credentials"
 )
@@ -28,22 +26,6 @@ var _ credentials.PerRPCCredentials = (*PerRPCAuth)(nil)
 // PerRPCAuth is a gRPC credentials.PerRPCCredentials implementation that returns an 'authorization' header.
 type PerRPCAuth struct {
 	metadata map[string]string
-}
-
-// BearerTokenFromFile builds a new PerRPCAuth with bearer token authentication, reading the token from the specified file.
-func BearerTokenFromFile(file string) (*PerRPCAuth, error) {
-	token, err := ioutil.ReadFile(file)
-	if err != nil {
-		return nil, fmt.Errorf("couldn't obtain token from file: %w", err)
-	}
-
-	// Replace all white space.
-	token = bytes.ReplaceAll(token, []byte(" "), []byte(""))
-	token = bytes.ReplaceAll(token, []byte("\n"), []byte(""))
-
-	return &PerRPCAuth{
-		metadata: map[string]string{"authorization": fmt.Sprintf("Bearer %s", token)},
-	}, nil
 }
 
 // BearerToken returns a new PerRPCAuth based on the given token.

--- a/config/configgrpc/bearer_token.go
+++ b/config/configgrpc/bearer_token.go
@@ -1,0 +1,63 @@
+// Copyright 2020 The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package configgrpc
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"regexp"
+
+	"google.golang.org/grpc/credentials"
+)
+
+var _ credentials.PerRPCCredentials = (*PerRPCAuth)(nil)
+
+// PerRPCAuth is a gRPC credentials.PerRPCCredentials implementation that returns an 'authorization' header
+type PerRPCAuth struct {
+	metadata map[string]string
+}
+
+// BearerTokenFromFile builds a new PerRPCAuth with bearer token authentication, reading the token from the specified file
+func BearerTokenFromFile(file string) (*PerRPCAuth, error) {
+	token, err := ioutil.ReadFile(file)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't obtain token from file: %w", err)
+	}
+
+	re := regexp.MustCompile(`[\s\n]`)
+	token = re.ReplaceAll(token, []byte(""))
+
+	return &PerRPCAuth{
+		metadata: map[string]string{"authorization": fmt.Sprintf("Bearer %s", token)},
+	}, nil
+}
+
+// BearerToken returns a new PerRPCAuth based on the given token
+func BearerToken(t string) *PerRPCAuth {
+	return &PerRPCAuth{
+		metadata: map[string]string{"authorization": fmt.Sprintf("Bearer %s", t)},
+	}
+}
+
+// GetRequestMetadata returns the request metadata to be used with the RPC
+func (c *PerRPCAuth) GetRequestMetadata(ctx context.Context, uri ...string) (map[string]string, error) {
+	return c.metadata, nil
+}
+
+// RequireTransportSecurity always returns true for this implementation. Passing bearer tokens in plain-text connections is a bad idea.
+func (c *PerRPCAuth) RequireTransportSecurity() bool {
+	return true
+}

--- a/config/configgrpc/bearer_token.go
+++ b/config/configgrpc/bearer_token.go
@@ -15,44 +15,45 @@
 package configgrpc
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io/ioutil"
-	"regexp"
 
 	"google.golang.org/grpc/credentials"
 )
 
 var _ credentials.PerRPCCredentials = (*PerRPCAuth)(nil)
 
-// PerRPCAuth is a gRPC credentials.PerRPCCredentials implementation that returns an 'authorization' header
+// PerRPCAuth is a gRPC credentials.PerRPCCredentials implementation that returns an 'authorization' header.
 type PerRPCAuth struct {
 	metadata map[string]string
 }
 
-// BearerTokenFromFile builds a new PerRPCAuth with bearer token authentication, reading the token from the specified file
+// BearerTokenFromFile builds a new PerRPCAuth with bearer token authentication, reading the token from the specified file.
 func BearerTokenFromFile(file string) (*PerRPCAuth, error) {
 	token, err := ioutil.ReadFile(file)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't obtain token from file: %w", err)
 	}
 
-	re := regexp.MustCompile(`[\s\n]`)
-	token = re.ReplaceAll(token, []byte(""))
+	// Replace all white space.
+	token = bytes.ReplaceAll(token, []byte(" "), []byte(""))
+	token = bytes.ReplaceAll(token, []byte("\n"), []byte(""))
 
 	return &PerRPCAuth{
 		metadata: map[string]string{"authorization": fmt.Sprintf("Bearer %s", token)},
 	}, nil
 }
 
-// BearerToken returns a new PerRPCAuth based on the given token
+// BearerToken returns a new PerRPCAuth based on the given token.
 func BearerToken(t string) *PerRPCAuth {
 	return &PerRPCAuth{
 		metadata: map[string]string{"authorization": fmt.Sprintf("Bearer %s", t)},
 	}
 }
 
-// GetRequestMetadata returns the request metadata to be used with the RPC
+// GetRequestMetadata returns the request metadata to be used with the RPC.
 func (c *PerRPCAuth) GetRequestMetadata(ctx context.Context, uri ...string) (map[string]string, error) {
 	return c.metadata, nil
 }

--- a/config/configgrpc/bearer_token_test.go
+++ b/config/configgrpc/bearer_token_test.go
@@ -1,0 +1,65 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package configgrpc
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBearerToken(t *testing.T) {
+	// test
+	result := BearerToken("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
+	metadata, err := result.GetRequestMetadata(context.Background())
+	require.NoError(t, err)
+
+	// verify
+	assert.Equal(t, "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...", metadata["authorization"])
+}
+
+func TestBearerTokenFileReaderRemoveSpaces(t *testing.T) {
+	// prepare
+	token := []byte("a\nbc def\n")
+	file, err := ioutil.TempFile("", "")
+	require.NoError(t, err)
+	defer os.Remove(file.Name())
+
+	_, err = file.Write(token)
+	require.NoError(t, err)
+	require.NoError(t, file.Close())
+
+	// test
+	result, err := BearerTokenFromFile(file.Name())
+	require.NoError(t, err)
+
+	metadata, err := result.GetRequestMetadata(context.Background())
+	require.NoError(t, err)
+
+	// verify
+	assert.Equal(t, "Bearer abcdef", metadata["authorization"])
+}
+
+func TestBearerTokenRequiresSecureTransport(t *testing.T) {
+	// test
+	token := BearerToken("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
+
+	// verify
+	assert.True(t, token.RequireTransportSecurity())
+}

--- a/config/configgrpc/bearer_token_test.go
+++ b/config/configgrpc/bearer_token_test.go
@@ -16,8 +16,6 @@ package configgrpc
 
 import (
 	"context"
-	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -32,28 +30,6 @@ func TestBearerToken(t *testing.T) {
 
 	// verify
 	assert.Equal(t, "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...", metadata["authorization"])
-}
-
-func TestBearerTokenFileReaderRemoveSpaces(t *testing.T) {
-	// prepare
-	token := []byte("a\nbc def\n")
-	file, err := ioutil.TempFile("", "")
-	require.NoError(t, err)
-	defer os.Remove(file.Name())
-
-	_, err = file.Write(token)
-	require.NoError(t, err)
-	require.NoError(t, file.Close())
-
-	// test
-	result, err := BearerTokenFromFile(file.Name())
-	require.NoError(t, err)
-
-	metadata, err := result.GetRequestMetadata(context.Background())
-	require.NoError(t, err)
-
-	// verify
-	assert.Equal(t, "Bearer abcdef", metadata["authorization"])
 }
 
 func TestBearerTokenRequiresSecureTransport(t *testing.T) {

--- a/config/configgrpc/configgrpc.go
+++ b/config/configgrpc/configgrpc.go
@@ -34,6 +34,8 @@ import (
 const (
 	CompressionUnsupported = ""
 	CompressionGzip        = "gzip"
+
+	PerRPCAuthTypeBearer = "bearer"
 )
 
 var (
@@ -84,11 +86,23 @@ type GRPCClientSettings struct {
 
 	// The headers associated with gRPC requests.
 	Headers map[string]string `mapstructure:"headers"`
+
+	// PerRPCAuth parameter configures the client to send authentication data on a per-RPC basis
+	PerRPCAuth *PerRPCAuthConfig `mapstructure:"per_rpc_auth"`
 }
 
 type KeepaliveServerConfig struct {
 	ServerParameters  *KeepaliveServerParameters  `mapstructure:"server_parameters,omitempty"`
 	EnforcementPolicy *KeepaliveEnforcementPolicy `mapstructure:"enforcement_policy,omitempty"`
+}
+
+// PerRPCAuthConfig specifies how the Per-RPC authentication data should be obtained
+type PerRPCAuthConfig struct {
+	// AuthType represents the authentication type to use. Currently, only 'bearer' is supported.
+	AuthType string `mapstructure:"type,omitempty"`
+
+	// BearerToken specifies the bearer token to use for every RPC. If the value starts with `file://`, reads the token from the specified file.
+	BearerToken string `mapstructure:"bearer_token,omitempty"`
 }
 
 // KeepaliveServerParameters allow configuration of the keepalive.ServerParameters.
@@ -174,6 +188,21 @@ func (gcs *GRPCClientSettings) ToDialOptions() ([]grpc.DialOption, error) {
 			PermitWithoutStream: gcs.Keepalive.PermitWithoutStream,
 		})
 		opts = append(opts, keepAliveOption)
+	}
+
+	if gcs.PerRPCAuth != nil {
+		if strings.EqualFold(gcs.PerRPCAuth.AuthType, PerRPCAuthTypeBearer) {
+			sToken := gcs.PerRPCAuth.BearerToken
+			token := BearerToken(sToken)
+			if strings.HasPrefix(sToken, "file://") {
+				token, err = BearerTokenFromFile(sToken[7:])
+				if err != nil {
+					return nil, err
+				}
+			}
+
+			opts = append(opts, grpc.WithPerRPCCredentials(token))
+		}
 	}
 
 	return opts, nil

--- a/config/configgrpc/configgrpc.go
+++ b/config/configgrpc/configgrpc.go
@@ -87,7 +87,7 @@ type GRPCClientSettings struct {
 	// The headers associated with gRPC requests.
 	Headers map[string]string `mapstructure:"headers"`
 
-	// PerRPCAuth parameter configures the client to send authentication data on a per-RPC basis
+	// PerRPCAuth parameter configures the client to send authentication data on a per-RPC basis.
 	PerRPCAuth *PerRPCAuthConfig `mapstructure:"per_rpc_auth"`
 }
 
@@ -96,7 +96,7 @@ type KeepaliveServerConfig struct {
 	EnforcementPolicy *KeepaliveEnforcementPolicy `mapstructure:"enforcement_policy,omitempty"`
 }
 
-// PerRPCAuthConfig specifies how the Per-RPC authentication data should be obtained
+// PerRPCAuthConfig specifies how the Per-RPC authentication data should be obtained.
 type PerRPCAuthConfig struct {
 	// AuthType represents the authentication type to use. Currently, only 'bearer' is supported.
 	AuthType string `mapstructure:"type,omitempty"`
@@ -202,6 +202,8 @@ func (gcs *GRPCClientSettings) ToDialOptions() ([]grpc.DialOption, error) {
 			}
 
 			opts = append(opts, grpc.WithPerRPCCredentials(token))
+		} else {
+			return nil, fmt.Errorf("unsupported per-RPC auth type %q", gcs.Compression)
 		}
 	}
 

--- a/config/configgrpc/configgrpc.go
+++ b/config/configgrpc/configgrpc.go
@@ -203,7 +203,7 @@ func (gcs *GRPCClientSettings) ToDialOptions() ([]grpc.DialOption, error) {
 
 			opts = append(opts, grpc.WithPerRPCCredentials(token))
 		} else {
-			return nil, fmt.Errorf("unsupported per-RPC auth type %q", gcs.Compression)
+			return nil, fmt.Errorf("unsupported per-RPC auth type %q", gcs.PerRPCAuth.AuthType)
 		}
 	}
 

--- a/config/configgrpc/configgrpc.go
+++ b/config/configgrpc/configgrpc.go
@@ -101,7 +101,7 @@ type PerRPCAuthConfig struct {
 	// AuthType represents the authentication type to use. Currently, only 'bearer' is supported.
 	AuthType string `mapstructure:"type,omitempty"`
 
-	// BearerToken specifies the bearer token to use for every RPC. If the value starts with `file://`, reads the token from the specified file.
+	// BearerToken specifies the bearer token to use for every RPC.
 	BearerToken string `mapstructure:"bearer_token,omitempty"`
 }
 
@@ -194,13 +194,6 @@ func (gcs *GRPCClientSettings) ToDialOptions() ([]grpc.DialOption, error) {
 		if strings.EqualFold(gcs.PerRPCAuth.AuthType, PerRPCAuthTypeBearer) {
 			sToken := gcs.PerRPCAuth.BearerToken
 			token := BearerToken(sToken)
-			if strings.HasPrefix(sToken, "file://") {
-				token, err = BearerTokenFromFile(sToken[7:])
-				if err != nil {
-					return nil, err
-				}
-			}
-
 			opts = append(opts, grpc.WithPerRPCCredentials(token))
 		} else {
 			return nil, fmt.Errorf("unsupported per-RPC auth type %q", gcs.PerRPCAuth.AuthType)

--- a/config/configgrpc/configgrpc_test.go
+++ b/config/configgrpc/configgrpc_test.go
@@ -16,16 +16,12 @@ package configgrpc
 
 import (
 	"context"
-	"fmt"
-	"io/ioutil"
-	"os"
 	"path"
 	"runtime"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 
 	"go.opentelemetry.io/collector/config/confignet"
@@ -464,46 +460,6 @@ func TestWithPerRPCAuthBearerToken(t *testing.T) {
 	// verify
 	assert.NoError(t, err)
 	assert.Len(t, dialOpts, 2) // WithInsecure and WithPerRPCCredentials
-}
-
-func TestWithPerRPCAuthBearerTokenFile(t *testing.T) {
-	// prepare
-	token := []byte("the-bearer-token")
-	file, err := ioutil.TempFile("", "")
-	require.NoError(t, err)
-	defer os.Remove(file.Name())
-
-	_, err = file.Write(token)
-	require.NoError(t, err)
-	require.NoError(t, file.Close())
-
-	// test
-	gcs := &GRPCClientSettings{
-		PerRPCAuth: &PerRPCAuthConfig{
-			AuthType:    "bearer",
-			BearerToken: fmt.Sprintf("file://%s", file.Name()),
-		},
-	}
-	dialOpts, err := gcs.ToDialOptions()
-
-	// verify
-	assert.NoError(t, err)
-	assert.Len(t, dialOpts, 2) // WithInsecure and WithPerRPCCredentials
-}
-
-func TestWithPerRPCAuthBearerTokenFileInvalidFile(t *testing.T) {
-	// test
-	gcs := &GRPCClientSettings{
-		PerRPCAuth: &PerRPCAuthConfig{
-			AuthType:    "bearer",
-			BearerToken: fmt.Sprintf("file://%s", "a-token-file"),
-		},
-	}
-	dialOpts, err := gcs.ToDialOptions()
-
-	// verify
-	assert.Error(t, err)
-	assert.Nil(t, dialOpts)
 }
 
 func TestWithPerRPCAuthInvalidAuthType(t *testing.T) {

--- a/config/configgrpc/configgrpc_test.go
+++ b/config/configgrpc/configgrpc_test.go
@@ -505,3 +505,17 @@ func TestWithPerRPCAuthBearerTokenFileInvalidFile(t *testing.T) {
 	assert.Error(t, err)
 	assert.Nil(t, dialOpts)
 }
+
+func TestWithPerRPCAuthInvalidAuthType(t *testing.T) {
+	// test
+	gcs := &GRPCClientSettings{
+		PerRPCAuth: &PerRPCAuthConfig{
+			AuthType: "non-existing",
+		},
+	}
+	dialOpts, err := gcs.ToDialOptions()
+
+	// verify
+	assert.Error(t, err)
+	assert.Nil(t, dialOpts)
+}

--- a/exporter/otlpexporter/config_test.go
+++ b/exporter/otlpexporter/config_test.go
@@ -69,6 +69,10 @@ func TestLoadConfig(t *testing.T) {
 					Timeout:             30 * time.Second,
 				},
 				WriteBufferSize: 512 * 1024,
+				PerRPCAuth: &configgrpc.PerRPCAuthConfig{
+					AuthType:    "bearer",
+					BearerToken: "file:///var/run/secrets/kubernetes.io/serviceaccount/token",
+				},
 			},
 		})
 }

--- a/exporter/otlpexporter/config_test.go
+++ b/exporter/otlpexporter/config_test.go
@@ -71,7 +71,7 @@ func TestLoadConfig(t *testing.T) {
 				WriteBufferSize: 512 * 1024,
 				PerRPCAuth: &configgrpc.PerRPCAuthConfig{
 					AuthType:    "bearer",
-					BearerToken: "file:///var/run/secrets/kubernetes.io/serviceaccount/token",
+					BearerToken: "some-token",
 				},
 			},
 		})

--- a/exporter/otlpexporter/testdata/config.yaml
+++ b/exporter/otlpexporter/testdata/config.yaml
@@ -10,6 +10,9 @@ exporters:
     endpoint: "1.2.3.4:1234"
     compression: "on"
     ca_file: /var/lib/mycert.pem
+    per_rpc_auth:
+      type: bearer
+      bearer_token: file:///var/run/secrets/kubernetes.io/serviceaccount/token
     headers:
       "can you have a . here?": "F0000000-0000-0000-0000-000000000000"
       header1: 234

--- a/exporter/otlpexporter/testdata/config.yaml
+++ b/exporter/otlpexporter/testdata/config.yaml
@@ -12,7 +12,7 @@ exporters:
     ca_file: /var/lib/mycert.pem
     per_rpc_auth:
       type: bearer
-      bearer_token: file:///var/run/secrets/kubernetes.io/serviceaccount/token
+      bearer_token: some-token
     headers:
       "can you have a . here?": "F0000000-0000-0000-0000-000000000000"
       header1: 234


### PR DESCRIPTION
Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>

**Description:** 
This PR adds support for including a per-RPC authentication to gRPC settings. Initially, only "bearer" token has been added, but can be easily extended in the future based on real-world needs. The token can be read directly from the configuration file or from an external token file, such as the ones injected by Kubernetes into pods.

**Link to tracking Issue:** n/a

**Testing:** this was successfully tested with a custom processor, reading the bearer token from the context via `metadata.FromIncomingContext(ctx)`. Additionally, unit tests were added to this PR.

**Documentation:** the `config.yaml` reference file has been updated to include this new option.