### PR TITLE
Log metric data points in logging exporter

### DIFF
--- a/exporter/loggingexporter/logging_exporter_test.go
+++ b/exporter/loggingexporter/logging_exporter_test.go
@@ -50,6 +50,10 @@ func TestLoggingMetricsExporterNoErrors(t *testing.T) {
 	assert.NoError(t, lme.ConsumeMetrics(context.Background(), pdatautil.MetricsFromInternalMetrics(testdata.GenerateMetricDataOneEmptyOneNilInstrumentationLibrary())))
 	assert.NoError(t, lme.ConsumeMetrics(context.Background(), pdatautil.MetricsFromInternalMetrics(testdata.GenerateMetricDataOneMetricOneNil())))
 	assert.NoError(t, lme.ConsumeMetrics(context.Background(), pdatautil.MetricsFromInternalMetrics(testdata.GenerateMetricDataWithCountersHistogramAndSummary())))
+	assert.NoError(t, lme.ConsumeMetrics(context.Background(), pdatautil.MetricsFromInternalMetrics(testdata.GenerateMetricDataAllTypesNilDataPoint())))
+	assert.NoError(t, lme.ConsumeMetrics(context.Background(), pdatautil.MetricsFromInternalMetrics(testdata.GenerateMetricDataAllTypesEmptyDataPoint())))
+	assert.NoError(t, lme.ConsumeMetrics(context.Background(), pdatautil.MetricsFromInternalMetrics(testdata.GenerateMetricDataNilMetricDescriptor())))
+	assert.NoError(t, lme.ConsumeMetrics(context.Background(), pdatautil.MetricsFromInternalMetrics(testdata.GenerateMetricDataMetricTypeInvalid())))
 
 	assert.NoError(t, lme.Shutdown(context.Background()))
 }

--- a/internal/data/testdata/metric.go
+++ b/internal/data/testdata/metric.go
@@ -256,6 +256,93 @@ func GenerateMetricDataAllTypesNoDataPoints() data.MetricData {
 	return md
 }
 
+func GenerateMetricDataAllTypesNilDataPoint() data.MetricData {
+	md := GenerateMetricDataOneEmptyInstrumentationLibrary()
+	ilm0 := md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0)
+	ms := ilm0.Metrics()
+	ms.Resize(6)
+
+	nilInt64 := pdata.NewInt64DataPoint()
+	nilDouble := pdata.NewDoubleDataPoint()
+	nilHistogram := pdata.NewHistogramDataPoint()
+	nilSummary := pdata.NewSummaryDataPoint()
+
+	initMetricDescriptor(
+		ms.At(0).MetricDescriptor(), TestGaugeDoubleMetricName, pdata.MetricTypeDouble)
+	ms.At(0).DoubleDataPoints().Append(&nilDouble)
+	initMetricDescriptor(
+		ms.At(1).MetricDescriptor(), TestGaugeIntMetricName, pdata.MetricTypeInt64)
+	ms.At(1).Int64DataPoints().Append(&nilInt64)
+	initMetricDescriptor(
+		ms.At(2).MetricDescriptor(), TestCounterDoubleMetricName, pdata.MetricTypeMonotonicDouble)
+	ms.At(2).DoubleDataPoints().Append(&nilDouble)
+	initMetricDescriptor(
+		ms.At(3).MetricDescriptor(), TestCounterIntMetricName, pdata.MetricTypeMonotonicInt64)
+	ms.At(3).Int64DataPoints().Append(&nilInt64)
+	initMetricDescriptor(
+		ms.At(4).MetricDescriptor(), TestCumulativeHistogramMetricName, pdata.MetricTypeHistogram)
+	ms.At(4).HistogramDataPoints().Append(&nilHistogram)
+	initMetricDescriptor(
+		ms.At(5).MetricDescriptor(), TestSummaryMetricName, pdata.MetricTypeSummary)
+	ms.At(5).SummaryDataPoints().Append(&nilSummary)
+	return md
+}
+
+func GenerateMetricDataAllTypesEmptyDataPoint() data.MetricData {
+	md := GenerateMetricDataOneEmptyInstrumentationLibrary()
+	ilm0 := md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0)
+	ms := ilm0.Metrics()
+	ms.Resize(6)
+
+	emptyInt64 := pdata.NewInt64DataPoint()
+	emptyInt64.InitEmpty()
+	emptyDouble := pdata.NewDoubleDataPoint()
+	emptyDouble.InitEmpty()
+	emptyHistogram := pdata.NewHistogramDataPoint()
+	emptyHistogram.InitEmpty()
+	emptySummary := pdata.NewSummaryDataPoint()
+	emptySummary.InitEmpty()
+
+	initMetricDescriptor(
+		ms.At(0).MetricDescriptor(), TestGaugeDoubleMetricName, pdata.MetricTypeDouble)
+	ms.At(0).DoubleDataPoints().Append(&emptyDouble)
+	initMetricDescriptor(
+		ms.At(1).MetricDescriptor(), TestGaugeIntMetricName, pdata.MetricTypeInt64)
+	ms.At(1).Int64DataPoints().Append(&emptyInt64)
+	initMetricDescriptor(
+		ms.At(2).MetricDescriptor(), TestCounterDoubleMetricName, pdata.MetricTypeMonotonicDouble)
+	ms.At(2).DoubleDataPoints().Append(&emptyDouble)
+	initMetricDescriptor(
+		ms.At(3).MetricDescriptor(), TestCounterIntMetricName, pdata.MetricTypeMonotonicInt64)
+	ms.At(3).Int64DataPoints().Append(&emptyInt64)
+	initMetricDescriptor(
+		ms.At(4).MetricDescriptor(), TestCumulativeHistogramMetricName, pdata.MetricTypeHistogram)
+	ms.At(4).HistogramDataPoints().Append(&emptyHistogram)
+	initMetricDescriptor(
+		ms.At(5).MetricDescriptor(), TestSummaryMetricName, pdata.MetricTypeSummary)
+	ms.At(5).SummaryDataPoints().Append(&emptySummary)
+	return md
+}
+
+func GenerateMetricDataNilMetricDescriptor() data.MetricData {
+	md := GenerateMetricDataOneEmptyInstrumentationLibrary()
+	ilm0 := md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0)
+	ms := ilm0.Metrics()
+	ms.Resize(1)
+	return md
+}
+
+func GenerateMetricDataMetricTypeInvalid() data.MetricData {
+	md := GenerateMetricDataOneEmptyInstrumentationLibrary()
+	ilm0 := md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0)
+	ms := ilm0.Metrics()
+	ms.Resize(1)
+
+	initMetricDescriptor(
+		ms.At(0).MetricDescriptor(), TestGaugeDoubleMetricName, pdata.MetricTypeInvalid)
+	return md
+}
+
 func generateMetricOtlpAllTypesNoDataPoints() []*otlpmetrics.ResourceMetrics {
 	return []*otlpmetrics.ResourceMetrics{
 		{


### PR DESCRIPTION
**Description:**
Log metric data points in logging exporter.
Currently only resource labels are being logged.

**Link to tracking Issue:** -

**Testing:** Unit tests + tested manually:
```
ResourceMetrics #0
Resource labels:
     -> resource-attr: STRING(resource-attr-val-1)
InstrumentationLibraryMetrics #0
Metric #0
Descriptor:
     -> Name: counter-int
     -> Description: 
     -> Unit: 1
     -> Type: MONOTONIC_INT64
Int64DataPoints #0
Data point labels:
     -> label-1: label-value-1
StartTime: 1581452772000000321
Timestamp: 1581452773000000789
Value: 123
Int64DataPoints #1
Data point labels:
     -> label-2: label-value-2
StartTime: 1581452772000000321
Timestamp: 1581452773000000789
Value: 456
Metric #1
Descriptor:
     -> Name: counter-double
     -> Description: 
     -> Unit: 1
     -> Type: MONOTONIC_DOUBLE
DoubleDataPoints #0
Data point labels:
     -> label-1: label-value-1
     -> label-2: label-value-2
StartTime: 1581452772000000321
Timestamp: 1581452773000000789
Value: 1.230000
DoubleDataPoints #1
Data point labels:
     -> label-1: label-value-1
     -> label-3: label-value-3
StartTime: 1581452772000000321
Timestamp: 1581452773000000789
Value: 4.560000
Metric #2
Descriptor:
     -> Name: cumulative-histogram
     -> Description: 
     -> Unit: 1
     -> Type: HISTOGRAM
HistogramDataPoints #0
Data point labels:
     -> label-1: label-value-1
     -> label-3: label-value-3
StartTime: 1581452772000000321
Timestamp: 1581452773000000789
Count: 1
Sum: 15.000000
HistogramDataPoints #1
Data point labels:
     -> label-2: label-value-2
StartTime: 1581452772000000321
Timestamp: 1581452773000000789
Count: 1
Sum: 15.000000
Buckets #0, Count: 0
Buckets #1, Count: 1
ExplicitBounds #0: 1.000000
Metric #3
Descriptor:
     -> Name: summary
     -> Description: 
     -> Unit: 1
     -> Type: SUMMARY
SummaryDataPoints #0
Data point labels:
     -> label: label-value-1
StartTime: 1581452772000000321
Timestamp: 1581452773000000789
Count: 1
Sum: 15.000000
SummaryDataPoints #1
Data point labels:
     -> label: label-value-2
StartTime: 1581452772000000321
Timestamp: 1581452773000000789
Count: 1
Sum: 15.000000
ValueAtPercentiles #0, Value: 15.000000, Percentile: 1.000000

```

**Documentation:** -