### PR TITLE
Handle errors in exporters

### DIFF
--- a/exporter/opencensusexporter/opencensus.go
+++ b/exporter/opencensusexporter/opencensus.go
@@ -156,7 +156,7 @@ func (oce *ocAgentExporter) PushTraceData(ctx context.Context, td consumerdata.T
 			code: errAlreadyStopped,
 			msg:  "OpenCensus exporter was already stopped.",
 		}
-		return len(td.Spans), err
+		return len(td.Spans), fmt.Errorf("failed to push trace data via OpenCensus exporter: %w", err)
 	}
 
 	err := exporter.ExportTraceServiceRequest(
@@ -168,7 +168,7 @@ func (oce *ocAgentExporter) PushTraceData(ctx context.Context, td consumerdata.T
 	)
 	oce.exporters <- exporter
 	if err != nil {
-		return len(td.Spans), err
+		return len(td.Spans), fmt.Errorf("failed to push trace data via OpenCensus exporter: %w", err)
 	}
 	return 0, nil
 }
@@ -181,7 +181,7 @@ func (oce *ocAgentExporter) PushMetricsData(ctx context.Context, md consumerdata
 			code: errAlreadyStopped,
 			msg:  "OpenCensus exporter was already stopped.",
 		}
-		return exporterhelper.NumTimeSeries(md), err
+		return exporterhelper.NumTimeSeries(md), fmt.Errorf("failed to push metrics data via OpenCensus exporter: %w", err)
 	}
 
 	req := &agentmetricspb.ExportMetricsServiceRequest{
@@ -192,7 +192,7 @@ func (oce *ocAgentExporter) PushMetricsData(ctx context.Context, md consumerdata
 	err := exporter.ExportMetricsServiceRequest(req)
 	oce.exporters <- exporter
 	if err != nil {
-		return exporterhelper.NumTimeSeries(md), err
+		return exporterhelper.NumTimeSeries(md), fmt.Errorf("failed to push metrics data via OpenCensus exporter: %w", err)
 	}
 	return 0, nil
 }

--- a/exporter/otlpexporter/otlp.go
+++ b/exporter/otlpexporter/otlp.go
@@ -158,7 +158,7 @@ func (oce *otlpExporter) pushTraceData(ctx context.Context, td pdata.Traces) (in
 	err := oce.exporter.exportTrace(ctx, request)
 
 	if err != nil {
-		return td.SpanCount(), err
+		return td.SpanCount(), fmt.Errorf("failed to push trace data via OTLP exporter: %w", err)
 	}
 	return 0, nil
 }
@@ -171,7 +171,7 @@ func (oce *otlpExporter) pushMetricsData(ctx context.Context, md pdata.Metrics) 
 	err := oce.exporter.exportMetrics(ctx, request)
 
 	if err != nil {
-		return imd.MetricCount(), err
+		return imd.MetricCount(), fmt.Errorf("failed to push metrics data via OTLP exporter: %w", err)
 	}
 	return 0, nil
 }
@@ -183,7 +183,7 @@ func (oce *otlpExporter) pushLogData(ctx context.Context, logs data.Logs) (int, 
 	err := oce.exporter.exportLogs(ctx, request)
 
 	if err != nil {
-		return logs.LogRecordCount(), err
+		return logs.LogRecordCount(), fmt.Errorf("failed to push log data via OTLP exporter: %w", err)
 	}
 	return 0, nil
 }

--- a/processor/batchprocessor/batch_processor.go
+++ b/processor/batchprocessor/batch_processor.go
@@ -171,9 +171,11 @@ func (bp *batchTraceProcessor) resetTimer() {
 func (bp *batchTraceProcessor) sendItems(measure *stats.Int64Measure) {
 	// Add that it came form the trace pipeline?
 	statsTags := []tag.Mutator{tag.Insert(processor.TagProcessorNameKey, bp.name)}
-	_ = stats.RecordWithTags(context.Background(), statsTags, measure.M(1))
+	stats.RecordWithTags(context.Background(), statsTags, measure.M(1))
 
-	_ = bp.traceConsumer.ConsumeTraces(context.Background(), bp.batchTraces.getTraceData())
+	if err := bp.traceConsumer.ConsumeTraces(context.Background(), bp.batchTraces.getTraceData()); err != nil {
+		bp.logger.Warn("Sender failed", zap.Error(err))
+	}
 	bp.batchTraces.reset()
 }
 


### PR DESCRIPTION
This PR changes the batch processor to not ignore the errors returned by the exporters. It also adds more context to the messages, to make it clear which exporter failed.

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>

