### PR TITLE
Use default/hardcoded configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## 🛑 Breaking changes 🛑
 
+- Use default/hardcoded configuration #1273.
 - Remove `reconnection_delay` from OpenCensus exporter #1516.
 - Remove old receiver factories and receiver base factory #1583.
 - Remove logs factories and merge with normal factories #1569.

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/grpc-ecosystem/grpc-gateway v1.14.7
 	github.com/hashicorp/go-msgpack v0.5.5 // indirect
+	github.com/imdario/mergo v0.3.9
 	github.com/jaegertracing/jaeger v1.18.2-0.20200707061226-97d2319ff2be
 	github.com/joshdk/go-junit v0.0.0-20200702055522-6efcf4050909
 	github.com/jstemmer/go-junit-report v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -519,7 +519,6 @@ github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgf
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/grpc-ecosystem/grpc-gateway v1.13.0/go.mod h1:8XEsbTttt/W+VvjtQhLACqCisSPWTxCZ7sBRjU6iH9c=
-github.com/grpc-ecosystem/grpc-gateway v1.14.6 h1:8ERzHx8aj1Sc47mu9n/AksaKCSWrMchFtkdrS4BIj5o=
 github.com/grpc-ecosystem/grpc-gateway v1.14.6/go.mod h1:zdiPV4Yse/1gnckTHtghG4GkDEdKCRJduHpTxT3/jcw=
 github.com/grpc-ecosystem/grpc-gateway v1.14.7 h1:Nk5kuHrnWUTf/0GL1a/vchH/om9Ap2/HnVna+jYZgTY=
 github.com/grpc-ecosystem/grpc-gateway v1.14.7/go.mod h1:oYZKL012gGh6LMyg/xA7Q2yq6j8bu0wa+9w14EEthWU=
@@ -589,6 +588,8 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/hudl/fargo v1.3.0/go.mod h1:y3CKSmjA+wD2gak7sUSXTAoopbhU08POFhmITJgmKTg=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
+github.com/imdario/mergo v0.3.9 h1:UauaLniWCFHWd+Jp9oCEkTBj8VO/9DKg3PV3VCNMDIg=
+github.com/imdario/mergo v0.3.9/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/flux v0.65.0/go.mod h1:BwN2XG2lMszOoquQaFdPET8FRQfrXiZsWmcMO9rkaVY=
@@ -1083,6 +1084,7 @@ go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.opencensus.io v0.22.3/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.opencensus.io v0.22.4 h1:LYy1Hy3MJdrCdMwwzxA/dRok4ejH+RwNGbuoD9fCjto=
 go.opencensus.io v0.22.4/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
+go.opentelemetry.io v0.1.0 h1:EANZoRCOP+A3faIlw/iN6YEWoYb1vleZRKm1EvH8T48=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.5.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=

--- a/service/defaultconfig/config.go
+++ b/service/defaultconfig/config.go
@@ -20,6 +20,7 @@ import (
 )
 
 // CreateDefaultConfig creates default configuration for a given configuration.
+// The default configuration is not created if the pipeline does not exist.
 func CreateDefaultConfig(factories component.Factories, forConfig *configmodels.Config) *configmodels.Config {
 	// the default config cannot be installed to the missing pipeline
 	// because the service will fail to start as there is no default exporter.

--- a/service/defaultconfig/config.go
+++ b/service/defaultconfig/config.go
@@ -1,0 +1,44 @@
+// Copyright 2020 The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package defaultconfig
+
+import (
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config/configmodels"
+)
+
+// CreateDefaultConfig creates default configuration for a given configuration.
+func CreateDefaultConfig(factories component.Factories, forConfig *configmodels.Config) *configmodels.Config {
+	// the default config cannot be installed to the missing pipeline
+	// because the service will fail to start as there is no default exporter.
+	if forConfig == nil || forConfig.Service.Pipelines["traces"] == nil {
+		return nil
+	}
+	otlpRec := factories.Receivers["otlp"].CreateDefaultConfig()
+	batch := factories.Processors["batch"].CreateDefaultConfig()
+	return &configmodels.Config{
+		Receivers:  configmodels.Receivers{otlpRec.Name(): otlpRec},
+		Processors: configmodels.Processors{batch.Name(): batch},
+		Service: configmodels.Service{
+			Pipelines: configmodels.Pipelines{
+				string(configmodels.TracesDataType): {
+					InputType:  configmodels.TracesDataType,
+					Receivers:  []string{otlpRec.Name()},
+					Processors: []string{batch.Name()},
+				},
+			},
+		},
+	}
+}

--- a/service/defaultconfig/config_test.go
+++ b/service/defaultconfig/config_test.go
@@ -1,0 +1,53 @@
+// Copyright 2020 The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package defaultconfig
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/config/configmodels"
+	"go.opentelemetry.io/collector/service/defaultcomponents"
+)
+
+func TestDefaultConfig(t *testing.T) {
+	factories, err := defaultcomponents.Components()
+	require.NoError(t, err)
+	cfg := CreateDefaultConfig(factories, &configmodels.Config{Service: configmodels.Service{Pipelines: configmodels.Pipelines{"traces": &configmodels.Pipeline{}}}})
+	err = config.ValidateConfig(cfg, zap.NewNop())
+	require.Error(t, err, "no enabled exporters specified in config")
+	assert.Equal(t, configmodels.Service{
+		Pipelines: configmodels.Pipelines{
+			string(configmodels.TracesDataType): {
+				InputType:  configmodels.TracesDataType,
+				Receivers:  []string{"otlp"},
+				Processors: []string{"batch"},
+			},
+		},
+	}, cfg.Service)
+	assert.Equal(t, factories.Receivers["otlp"].CreateDefaultConfig(), cfg.Receivers["otlp"])
+	assert.Equal(t, factories.Processors["batch"].CreateDefaultConfig(), cfg.Processors["batch"])
+}
+
+func TestDefaultConfig_nil(t *testing.T) {
+	factories, err := defaultcomponents.Components()
+	require.NoError(t, err)
+	cfg := CreateDefaultConfig(factories, nil)
+	assert.Nil(t, cfg)
+}

--- a/service/defaultconfig/merge.go
+++ b/service/defaultconfig/merge.go
@@ -21,7 +21,8 @@ import (
 )
 
 // MergeConfigs merges two configs.
-// The src is merged into dst.
+// The src is merged into dst. The src overrides dst.
+// The maps are merged and arrays are overridden.
 func MergeConfigs(dst, src *configmodels.Config) error {
 	if src == nil || dst == nil {
 		return nil

--- a/service/defaultconfig/merge.go
+++ b/service/defaultconfig/merge.go
@@ -1,0 +1,30 @@
+// Copyright 2020 The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package defaultconfig
+
+import (
+	"github.com/imdario/mergo"
+
+	"go.opentelemetry.io/collector/config/configmodels"
+)
+
+// MergeConfigs merges two configs.
+// The src is merged into dst.
+func MergeConfigs(dst, src *configmodels.Config) error {
+	if src == nil {
+		return nil
+	}
+	return mergo.Merge(dst, src, mergo.WithOverride)
+}

--- a/service/defaultconfig/merge.go
+++ b/service/defaultconfig/merge.go
@@ -23,7 +23,7 @@ import (
 // MergeConfigs merges two configs.
 // The src is merged into dst.
 func MergeConfigs(dst, src *configmodels.Config) error {
-	if src == nil {
+	if src == nil || dst == nil {
 		return nil
 	}
 	return mergo.Merge(dst, src, mergo.WithOverride)

--- a/service/defaultconfig/merge_test.go
+++ b/service/defaultconfig/merge_test.go
@@ -43,9 +43,16 @@ func TestMergeConfigs_nil(t *testing.T) {
 			},
 		},
 	}
-	err := MergeConfigs(cfg, nil)
-	require.NoError(t, err)
-	assert.Equal(t, cfg, cfg)
+	t.Run("src_nil", func(t *testing.T) {
+		err := MergeConfigs(cfg, nil)
+		require.NoError(t, err)
+		assert.Equal(t, cfg, cfg)
+	})
+	t.Run("dest_nil", func(t *testing.T) {
+		err := MergeConfigs(nil, cfg)
+		require.NoError(t, err)
+		assert.Equal(t, cfg, cfg)
+	})
 }
 
 func TestMergeConfigs(t *testing.T) {

--- a/service/defaultconfig/merge_test.go
+++ b/service/defaultconfig/merge_test.go
@@ -1,0 +1,194 @@
+// Copyright 2020 The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package defaultconfig
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/config/configgrpc"
+	"go.opentelemetry.io/collector/config/confighttp"
+	"go.opentelemetry.io/collector/config/configmodels"
+	"go.opentelemetry.io/collector/config/confignet"
+	"go.opentelemetry.io/collector/processor/attributesprocessor"
+	"go.opentelemetry.io/collector/processor/batchprocessor"
+	"go.opentelemetry.io/collector/processor/processorhelper"
+	"go.opentelemetry.io/collector/receiver/jaegerreceiver"
+	"go.opentelemetry.io/collector/receiver/zipkinreceiver"
+	"go.opentelemetry.io/collector/service/defaultcomponents"
+)
+
+func TestMergeConfigs_nil(t *testing.T) {
+	cfg := &configmodels.Config{
+		Receivers: configmodels.Receivers{
+			"jaeger": &jaegerreceiver.Config{
+				RemoteSampling: &jaegerreceiver.RemoteSamplingConfig{StrategyFile: "file.json"},
+			},
+		},
+	}
+	err := MergeConfigs(cfg, nil)
+	require.NoError(t, err)
+	assert.Equal(t, cfg, cfg)
+}
+
+func TestMergeConfigs(t *testing.T) {
+	cfg := &configmodels.Config{
+		Receivers: configmodels.Receivers{
+			"jaeger": &jaegerreceiver.Config{
+				Protocols: jaegerreceiver.Protocols{
+					GRPC: &configgrpc.GRPCServerSettings{
+						NetAddr: confignet.NetAddr{
+							Endpoint: "def",
+						},
+					},
+					ThriftCompact: &confignet.TCPAddr{
+						Endpoint: "def",
+					},
+				},
+			},
+		},
+		Processors: configmodels.Processors{
+			"batch": &batchprocessor.Config{
+				SendBatchSize: uint32(160),
+			},
+		},
+		Service: configmodels.Service{
+			Extensions: []string{"def", "def2"},
+			Pipelines: configmodels.Pipelines{
+				"traces": &configmodels.Pipeline{
+					Receivers:  []string{"jaeger"},
+					Processors: []string{"batch"},
+				},
+			},
+		},
+	}
+	overrideCfg := &configmodels.Config{
+		Receivers: configmodels.Receivers{
+			"jaeger": &jaegerreceiver.Config{
+				Protocols: jaegerreceiver.Protocols{
+					GRPC: &configgrpc.GRPCServerSettings{
+						NetAddr: confignet.NetAddr{
+							Endpoint: "master_jager_url",
+						},
+					},
+				},
+			},
+			"zipkin": &zipkinreceiver.Config{
+				HTTPServerSettings: confighttp.HTTPServerSettings{
+					Endpoint: "master_zipkin_url",
+				},
+			},
+		},
+		Processors: configmodels.Processors{
+			"attributes": &attributesprocessor.Config{
+				Settings: processorhelper.Settings{
+					Actions: []processorhelper.ActionKeyValue{{Key: "foo"}},
+				},
+			},
+		},
+		Service: configmodels.Service{
+			Extensions: []string{"def", "master1", "master2"},
+			Pipelines: configmodels.Pipelines{
+				"traces": &configmodels.Pipeline{
+					Receivers:  []string{"jaeger", "zipkin"},
+					Processors: []string{"attributes"},
+				},
+				"traces/2": &configmodels.Pipeline{
+					Processors: []string{"example"},
+				},
+			},
+		},
+	}
+	expected := &configmodels.Config{
+		Receivers: configmodels.Receivers{
+			"jaeger": &jaegerreceiver.Config{
+				Protocols: jaegerreceiver.Protocols{
+					GRPC: &configgrpc.GRPCServerSettings{
+						NetAddr: confignet.NetAddr{
+							Endpoint: "master_jager_url",
+						},
+					},
+					ThriftCompact: &confignet.TCPAddr{
+						Endpoint: "def",
+					},
+				},
+			},
+			"zipkin": &zipkinreceiver.Config{
+				HTTPServerSettings: confighttp.HTTPServerSettings{
+					Endpoint: "master_zipkin_url",
+				},
+			},
+		},
+		Processors: configmodels.Processors{
+			"batch": &batchprocessor.Config{
+				SendBatchSize: uint32(160),
+			},
+			"attributes": &attributesprocessor.Config{
+				Settings: processorhelper.Settings{
+					Actions: []processorhelper.ActionKeyValue{{Key: "foo"}},
+				},
+			},
+		},
+		Service: configmodels.Service{
+			Extensions: []string{"def", "master1", "master2"},
+			Pipelines: configmodels.Pipelines{
+				"traces": &configmodels.Pipeline{
+					Receivers:  []string{"jaeger", "zipkin"},
+					Processors: []string{"attributes"},
+				},
+				"traces/2": &configmodels.Pipeline{
+					Processors: []string{"example"},
+				},
+			},
+		},
+	}
+	err := MergeConfigs(cfg, overrideCfg)
+	require.NoError(t, err)
+	assert.Equal(t, expected, cfg)
+}
+
+func TestMergeConfigFiles(t *testing.T) {
+	testFiles := []string{"emptyoverride", "addprocessor", "multiplecomponents"}
+	cmpts, err := defaultcomponents.Components()
+	require.NoError(t, err)
+	for _, f := range testFiles {
+		t.Run(f, func(t *testing.T) {
+			cfg, err := loadConfig(cmpts, fmt.Sprintf("testdata/%s.yaml", f))
+			require.NoError(t, err)
+			override, err := loadConfig(cmpts, fmt.Sprintf("testdata/%s-override.yaml", f))
+			require.NoError(t, err)
+			merged, err := loadConfig(cmpts, fmt.Sprintf("testdata/%s-merged.yaml", f))
+			require.NoError(t, err)
+			err = MergeConfigs(cfg, override)
+			require.NoError(t, err)
+			assert.Equal(t, merged, cfg)
+		})
+	}
+}
+
+func loadConfig(factories component.Factories, file string) (*configmodels.Config, error) {
+	v := config.NewViper()
+	v.SetConfigFile(file)
+	err := v.ReadInConfig()
+	if err != nil {
+		return nil, fmt.Errorf("error loading config file %q: %v", file, err)
+	}
+	return config.Load(v, factories)
+}

--- a/service/defaultconfig/testdata/addprocessor-merged.yaml
+++ b/service/defaultconfig/testdata/addprocessor-merged.yaml
@@ -1,0 +1,19 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+
+processors:
+  queued_retry: {}
+  batch:
+    timeout: 5s
+
+exporters:
+  otlp:
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [otlp]

--- a/service/defaultconfig/testdata/addprocessor-override.yaml
+++ b/service/defaultconfig/testdata/addprocessor-override.yaml
@@ -1,0 +1,8 @@
+processors:
+  batch:
+    timeout: 5s
+
+service:
+  pipelines:
+    traces:
+      processors: [batch]

--- a/service/defaultconfig/testdata/addprocessor.yaml
+++ b/service/defaultconfig/testdata/addprocessor.yaml
@@ -1,0 +1,17 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+
+processors:
+  queued_retry: {}
+
+exporters:
+  otlp:
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [queued_retry]
+      exporters: [otlp]

--- a/service/defaultconfig/testdata/emptyoverride-merged.yaml
+++ b/service/defaultconfig/testdata/emptyoverride-merged.yaml
@@ -1,0 +1,18 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+
+processors:
+  queued_retry: {}
+
+exporters:
+  otlp:
+    endpoint: "1.2.3.4:1234"
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [queued_retry]
+      exporters: [otlp]

--- a/service/defaultconfig/testdata/emptyoverride.yaml
+++ b/service/defaultconfig/testdata/emptyoverride.yaml
@@ -1,0 +1,18 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+
+processors:
+  queued_retry: {}
+
+exporters:
+  otlp:
+    endpoint: "1.2.3.4:1234"
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [queued_retry]
+      exporters: [otlp]

--- a/service/defaultconfig/testdata/multiplecomponents-merged.yaml
+++ b/service/defaultconfig/testdata/multiplecomponents-merged.yaml
@@ -1,0 +1,31 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+  opencensus:
+    endpoint: "localhost:55678"
+  prometheus:
+    config:
+      scrape_configs:
+        - job_name: "caching_cluster"
+          scrape_interval: 5s
+          static_configs:
+            - targets: ["localhost:8889"]
+
+processors:
+  queued_retry: {}
+  batch:
+    timeout: 5s
+
+exporters:
+  otlp:
+    endpoint: http://elasticsearch.default.svc:9200
+
+service:
+  pipelines:
+    traces:
+      receivers: [opencensus]
+      processors: [batch]
+      exporters: [otlp]
+    metrics:
+      receivers: [prometheus]

--- a/service/defaultconfig/testdata/multiplecomponents-override.yaml
+++ b/service/defaultconfig/testdata/multiplecomponents-override.yaml
@@ -1,0 +1,26 @@
+receivers:
+  opencensus:
+    endpoint: "localhost:55678"
+  prometheus:
+    config:
+      scrape_configs:
+        - job_name: "caching_cluster"
+          scrape_interval: 5s
+          static_configs:
+            - targets: ["localhost:8889"]
+
+exporters:
+  otlp:
+    endpoint: http://elasticsearch.default.svc:9200
+
+processors:
+  batch:
+    timeout: 5s
+
+service:
+  pipelines:
+    traces:
+      receivers: [opencensus]
+      processors: [batch]
+    metrics:
+      receivers: [prometheus]

--- a/service/defaultconfig/testdata/multiplecomponents.yaml
+++ b/service/defaultconfig/testdata/multiplecomponents.yaml
@@ -1,0 +1,18 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+
+processors:
+  queued_retry: {}
+
+exporters:
+  otlp:
+    endpoint: whatever
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [queued_retry]
+      exporters: [otlp]

--- a/service/service.go
+++ b/service/service.go
@@ -131,7 +131,7 @@ func FileLoaderConfigFactory(v *viper.Viper, factories component.Factories) (*co
 		return nil, err
 	}
 	defaultConfig := defaultconfig.CreateDefaultConfig(factories, cfg)
-	err = defaultconfig.MergeConfigs(cfg, defaultConfig)
+	err = defaultconfig.MergeConfigs(defaultConfig, cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -75,7 +75,7 @@ func TestApplication_Start(t *testing.T) {
 	require.True(t, isAppAvailable(t, "http://localhost:13133"))
 	assert.Equal(t, app.logger, app.GetLogger())
 	assert.True(t, loggingHookCalled)
-	assert.Equal(t, []string{"batch"}, app.config.Service.Pipelines["traces"].Processors)
+	assert.Equal(t, []string{"attributes", "batch", "queued_retry"}, app.config.Service.Pipelines["traces"].Processors)
 
 	// All labels added to all collector metrics by default are listed below.
 	// These labels are hard coded here in order to avoid inadvertent changes:

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -75,6 +75,7 @@ func TestApplication_Start(t *testing.T) {
 	require.True(t, isAppAvailable(t, "http://localhost:13133"))
 	assert.Equal(t, app.logger, app.GetLogger())
 	assert.True(t, loggingHookCalled)
+	assert.Equal(t, []string{"batch"}, app.config.Service.Pipelines["traces"].Processors)
 
 	// All labels added to all collector metrics by default are listed below.
 	// These labels are hard coded here in order to avoid inadvertent changes:


### PR DESCRIPTION
Signed-off-by: Pavol Loffay <ploffay@redhat.com>

**Description:** <Describe what has changed. 

This patch enabled default/hardcoded configuration. By default OTEL collector will use `batch` and `queued_retry` processors. User-defined processors take precedence over default configuration.

Merging configuration is done via https://github.com/imdario/mergo. Viper does not support merging of go structs. Alternatively, we could use https://godoc.org/github.com/spf13/viper#MergeConfig, but the default configuration would have to be specified as a string. Also the Mergo library is nicely configurable.   

**Link to tracking Issue:** <Issue number if applicable>

Partially implements https://github.com/open-telemetry/opentelemetry-collector/issues/886. Missing is `memory_limiter` and health check.

**Testing:** < Describe what testing was performed and which tests were added.>

**Documentation:** < Describe the documentation added.>