### PR TITLE
Add a method in mock_backend to count the number of traces

### DIFF
--- a/consumer/consumer.go
+++ b/consumer/consumer.go
@@ -68,3 +68,11 @@ type LogConsumer interface {
 	// ConsumeLogs receives data.Logs for processing.
 	ConsumeLogs(ctx context.Context, ld data.Logs) error
 }
+
+// TestBedTraceConsumer is an interface that receives pdata.Traces,
+// and counts the number of traces received by the mock backend
+type TestBedTraceConsumer interface {
+	TraceConsumerBase
+	// ConsumeTraces receives pdata.Traces for processing.
+	ConsumeTestbedTraces(spansCount int) error
+}

--- a/testbed/testbed/mock_backend.go
+++ b/testbed/testbed/mock_backend.go
@@ -269,3 +269,8 @@ func (mc *MockMetricConsumer) ConsumeMetricsData(ctx context.Context, md consume
 
 	return nil
 }
+
+func (tc *MockTraceConsumer) ConsumeTestbedTraces(spansCount int) error {
+	tc.spansReceived.Add(uint64(spansCount))
+	return nil
+}


### PR DESCRIPTION
**Description:** Right now I can see that if someone wants to make use of the testbed and create a load tests, for some exporter it is mandatory to have a receiver to mock the backend and receive the traces or data while the work of the mocked backend is to just receive the data and count the number of spans,
so I am just adding a simple method which only counts the number of traces received by the backend.    

**Link to tracking Issue:**  https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/372

**Testing:** Tested this by creating the load tests for the awsxrayexporter.
```
=== RUN TestTrace10kSPS/AwsXray
2020/07/07 09:31:08 Starting mock backend...
2020/07/07 09:31:08 The receiver is listening on endpoint localhost:63954
2020/07/07 09:31:08 Starting Agent (/Volumes/unix/opentelemetry-collector-contrib/bin/otelcontribcol_darwin_amd64)
2020/07/07 09:31:08 Writing Agent log to /Volumes/unix/opentelemetry-collector-contrib/testbed/tests/results/TestTrace10kSPS/AwsXray/agent.log
2020/07/07 09:31:08 Agent running, pid=26034
2020/07/07 09:31:08 Starting load generator at 10000 items/sec.
2020/07/07 09:31:11 Agent RAM (RES): 13 MiB, CPU: 0.0%, Sent:22400 items, Received:22000 items
2020/07/07 09:31:14 Agent RAM (RES): 47 MiB, CPU:41.7%, Sent:47500 items, Received:45450 items
2020/07/07 09:31:17 Agent RAM (RES): 48 MiB, CPU:42.0%, Sent:72400 items, Received:70100 items
2020/07/07 09:31:20 Agent RAM (RES): 48 MiB, CPU:40.7%, Sent:97200 items, Received:95300 items
2020/07/07 09:31:23 Agent RAM (RES): 48 MiB, CPU:41.9%, Sent:122200 items, Received:120300 items
2020/07/07 09:31:23 Stopped generator. Sent:122900 items
2020/07/07 09:31:24 Gracefully terminating Agent pid=26034, sending SIGTEM...
2020/07/07 09:31:24 Stopping process monitor.
2020/07/07 09:31:24 Agent process stopped, exit code=1
2020/07/07 09:31:24 Agent execution failed: exit status 1
2020/07/07 09:31:24 Sent and received data matches.
2020/07/07 09:31:24 Stopping mock backend...
2020/07/07 09:31:24 Stopped backend. Received:122900 items
2020/07/07 09:31:24 Fatal error reported: http: Server closed
--- PASS: TestTrace10kSPS/AwsXray (15.46s)
PASS

Process finished with exit code 0
```