### PR TITLE
Log Support for memorylimiter Processor

### DIFF
--- a/exporter/exportertest/nop_exporter.go
+++ b/exporter/exportertest/nop_exporter.go
@@ -20,6 +20,7 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer/consumerdata"
 	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.opentelemetry.io/collector/internal/data"
 )
 
 type nopExporterOld struct {
@@ -47,6 +48,7 @@ func (ne *nopExporterOld) Shutdown(context.Context) error {
 const (
 	nopTraceExporterName   = "nop_trace"
 	nopMetricsExporterName = "nop_metrics"
+	nopLogExporterName     = "nop_log"
 )
 
 // NewNopTraceExporterOld creates an TraceExporter that just drops the received data.
@@ -82,6 +84,10 @@ func (ne *nopExporter) ConsumeMetrics(ctx context.Context, md pdata.Metrics) err
 	return ne.retError
 }
 
+func (ne *nopExporter) ConsumeLogs(ctx context.Context, ld data.Logs) error {
+	return ne.retError
+}
+
 // Shutdown stops the exporter and is invoked during shutdown.
 func (ne *nopExporter) Shutdown(context.Context) error {
 	return nil
@@ -99,6 +105,14 @@ func NewNopTraceExporter() component.TraceExporter {
 func NewNopMetricsExporter() component.MetricsExporter {
 	ne := &nopExporter{
 		name: nopMetricsExporterName,
+	}
+	return ne
+}
+
+// NewNopLogExporterOld creates an LogExporter that just drops the received data.
+func NewNopLogExporter() component.LogExporter {
+	ne := &nopExporter{
+		name: nopLogExporterName,
 	}
 	return ne
 }

--- a/exporter/exportertest/sink_exporter_test.go
+++ b/exporter/exportertest/sink_exporter_test.go
@@ -25,6 +25,7 @@ import (
 	"go.opentelemetry.io/collector/consumer/consumerdata"
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/consumer/pdatautil"
+	"go.opentelemetry.io/collector/internal/data"
 	"go.opentelemetry.io/collector/internal/data/testdata"
 )
 
@@ -81,5 +82,18 @@ func TestSinkMetricsExporter(t *testing.T) {
 		want = append(want, pdatautil.MetricsFromInternalMetrics(md))
 	}
 	got := sink.AllMetrics()
+	assert.Equal(t, want, got)
+}
+
+func TestSinkLogExporter(t *testing.T) {
+	sink := new(SinkLogExporter)
+	md := testdata.GenerateLogDataOneLogNoResource()
+	want := make([]data.Logs, 0, 7)
+	for i := 0; i < 7; i++ {
+		err := sink.ConsumeLogs(context.Background(), md)
+		require.Nil(t, err)
+		want = append(want, md)
+	}
+	got := sink.AllLogs()
 	assert.Equal(t, want, got)
 }

--- a/obsreport/obsreport.go
+++ b/obsreport/obsreport.go
@@ -137,6 +137,9 @@ func AllViews() (views []*view.View) {
 		mProcessorAcceptedMetricPoints,
 		mProcessorRefusedMetricPoints,
 		mProcessorDroppedMetricPoints,
+		mProcessorAcceptedLogRecords,
+		mProcessorRefusedLogRecords,
+		mProcessorDroppedLogRecords,
 	}
 	tagKeys = []tag.Key{tagKeyProcessor}
 	views = append(views, genViews(measures, tagKeys, view.Sum())...)

--- a/obsreport/obsreport_processor.go
+++ b/obsreport/obsreport_processor.go
@@ -31,6 +31,9 @@ const (
 
 	// Key used to identify metric points dropped by the Collector.
 	DroppedMetricPointsKey = "dropped_metric_points"
+
+	// Key used to identify log records dropped by the Collector.
+	DroppedLogRecordsKey = "dropped_log_records"
 )
 
 var (
@@ -63,6 +66,18 @@ var (
 	mProcessorDroppedMetricPoints = stats.Int64(
 		processorPrefix+DroppedMetricPointsKey,
 		"Number of metric points that were dropped.",
+		stats.UnitDimensionless)
+	mProcessorAcceptedLogRecords = stats.Int64(
+		processorPrefix+AcceptedLogRecordsKey,
+		"Number of log records successfully pushed into the next component in the pipeline.",
+		stats.UnitDimensionless)
+	mProcessorRefusedLogRecords = stats.Int64(
+		processorPrefix+RefusedLogRecordsKey,
+		"Number of log records that were rejected by the next component in the pipeline.",
+		stats.UnitDimensionless)
+	mProcessorDroppedLogRecords = stats.Int64(
+		processorPrefix+DroppedLogRecordsKey,
+		"Number of log records that were dropped.",
 		stats.UnitDimensionless)
 )
 
@@ -202,6 +217,51 @@ func ProcessorMetricsDataDropped(
 			mProcessorAcceptedMetricPoints.M(0),
 			mProcessorRefusedMetricPoints.M(0),
 			mProcessorDroppedMetricPoints.M(int64(numPoints)),
+		)
+	}
+}
+
+// ProcessorLogRecordsAccepted reports that the metrics were accepted.
+func ProcessorLogRecordsAccepted(
+	processorCtx context.Context,
+	numRecords int,
+) {
+	if useNew {
+		stats.Record(
+			processorCtx,
+			mProcessorAcceptedLogRecords.M(int64(numRecords)),
+			mProcessorRefusedLogRecords.M(0),
+			mProcessorDroppedLogRecords.M(0),
+		)
+	}
+}
+
+// ProcessorLogRecordsRefused reports that the metrics were refused.
+func ProcessorLogRecordsRefused(
+	processorCtx context.Context,
+	numRecords int,
+) {
+	if useNew {
+		stats.Record(
+			processorCtx,
+			mProcessorAcceptedLogRecords.M(0),
+			mProcessorRefusedLogRecords.M(int64(numRecords)),
+			mProcessorDroppedMetricPoints.M(0),
+		)
+	}
+}
+
+// ProcessorLogRecordsDropped reports that the metrics were dropped.
+func ProcessorLogRecordsDropped(
+	processorCtx context.Context,
+	numRecords int,
+) {
+	if useNew {
+		stats.Record(
+			processorCtx,
+			mProcessorAcceptedLogRecords.M(0),
+			mProcessorRefusedLogRecords.M(0),
+			mProcessorDroppedLogRecords.M(int64(numRecords)),
 		)
 	}
 }

--- a/obsreport/obsreport_receiver.go
+++ b/obsreport/obsreport_receiver.go
@@ -42,6 +42,12 @@ const (
 	// Key used to identify metric points refused (ie.: not ingested) by the
 	// Collector.
 	RefusedMetricPointsKey = "refused_metric_points"
+
+	// Key used to identify log records accepted by the Collector.
+	AcceptedLogRecordsKey = "accepted_log_records"
+	// Key used to identify log records refused (ie.: not ingested) by the
+	// Collector.
+	RefusedLogRecordsKey = "refused_log_records"
 )
 
 var (

--- a/obsreport/obsreport_test.go
+++ b/obsreport/obsreport_test.go
@@ -552,6 +552,27 @@ func Test_obsreport_ProcessorMetricViews(t *testing.T) {
 		})
 	}
 }
+
+func Test_obsreport_ProcessorLogRecords(t *testing.T) {
+	doneFn, err := setupViews()
+	require.NoError(t, err)
+	defer doneFn()
+
+	const acceptedRecords = 29
+	const refusedRecords = 11
+	const droppedRecords = 17
+
+	processorCtx := obsreport.ProcessorContext(context.Background(), processor)
+	obsreport.ProcessorLogRecordsAccepted(processorCtx, acceptedRecords)
+	obsreport.ProcessorLogRecordsRefused(processorCtx, refusedRecords)
+	obsreport.ProcessorLogRecordsDropped(processorCtx, droppedRecords)
+
+	processorTags := processorViewTags(processor)
+	checkValueForSumView(t, "processor/accepted_log_records", processorTags, acceptedRecords)
+	checkValueForSumView(t, "processor/refused_log_records", processorTags, refusedRecords)
+	checkValueForSumView(t, "processor/dropped_log_records", processorTags, droppedRecords)
+}
+
 func setupViews() (doneFn func(), err error) {
 	views := obsreport.Configure(true, true)
 	err = view.Register(views...)

--- a/processor/memorylimiter/factory_test.go
+++ b/processor/memorylimiter/factory_test.go
@@ -52,6 +52,10 @@ func TestCreateProcessor(t *testing.T) {
 	assert.Nil(t, mp)
 	assert.Error(t, err, "created processor with invalid settings")
 
+	lp, err := factory.CreateLogProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, cfg, exportertest.NewNopLogExporter())
+	assert.Nil(t, lp)
+	assert.Error(t, err, "created processor with invalid settings")
+
 	// Create processor with a valid config.
 	pCfg := cfg.(*Config)
 	pCfg.MemoryLimitMiB = 5722
@@ -68,4 +72,9 @@ func TestCreateProcessor(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, mp)
 	assert.NoError(t, mp.Shutdown(context.Background()))
+
+	lp, err = factory.CreateLogProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, cfg, exportertest.NewNopLogExporter())
+	assert.NoError(t, err)
+	assert.NotNil(t, lp)
+	assert.NoError(t, lp.Shutdown(context.Background()))
 }

--- a/processor/metrics.go
+++ b/processor/metrics.go
@@ -60,6 +60,16 @@ var (
 		"metric_batches_dropped",
 		"counts the number of metric batches dropped",
 		stats.UnitDimensionless)
+
+	StatDroppedLogRecordsCount = stats.Int64(
+		"log_records_dropped",
+		"counts the number of log records dropped",
+		stats.UnitDimensionless)
+
+	StatLogBatchesDroppedCount = stats.Int64(
+		"log_batches_dropped",
+		"counts the number of log batches dropped",
+		stats.UnitDimensionless)
 )
 
 // SpanCountStats represents span count stats grouped by service if DETAILED telemetry level is set,


### PR DESCRIPTION
This adds the ability to use the memorylimiter process in log pipelines.