### PR TITLE
loggingexporter: Add Log Support

### DIFF
--- a/exporter/loggingexporter/factory.go
+++ b/exporter/loggingexporter/factory.go
@@ -107,3 +107,21 @@ func (f *Factory) CreateMetricsExporter(_ context.Context, _ component.ExporterC
 	}
 	return lexp, nil
 }
+
+// CreateLogExporter creates a log exporter based on this config.
+func (f *Factory) CreateLogExporter(_ context.Context, _ component.ExporterCreateParams, config configmodels.Exporter) (component.LogExporter, error) {
+	cfg := config.(*Config)
+
+	exporterLogger, err := f.createLogger(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	lexp, err := NewLogExporter(config, cfg.LogLevel, exporterLogger)
+	if err != nil {
+		return nil, err
+	}
+	return lexp, nil
+}
+
+var _ component.LogExporterFactory = (*Factory)(nil)

--- a/exporter/loggingexporter/factory_test.go
+++ b/exporter/loggingexporter/factory_test.go
@@ -49,3 +49,12 @@ func TestCreateTraceExporter(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, te)
 }
+
+func TestCreateLogExporter(t *testing.T) {
+	factory := &Factory{}
+	cfg := factory.CreateDefaultConfig()
+
+	te, err := factory.CreateLogExporter(context.Background(), component.ExporterCreateParams{Logger: zap.NewNop()}, cfg)
+	assert.NoError(t, err)
+	assert.NotNil(t, te)
+}

--- a/exporter/loggingexporter/logging_exporter_test.go
+++ b/exporter/loggingexporter/logging_exporter_test.go
@@ -57,3 +57,17 @@ func TestLoggingMetricsExporterNoErrors(t *testing.T) {
 
 	assert.NoError(t, lme.Shutdown(context.Background()))
 }
+
+func TestLoggingLogExporterNoErrors(t *testing.T) {
+	lle, err := NewLogExporter(&configmodels.ExporterSettings{}, "debug", zap.NewNop())
+	require.NotNil(t, lle)
+	assert.NoError(t, err)
+
+	assert.NoError(t, lle.ConsumeLogs(context.Background(), testdata.GenerateLogDataEmpty()))
+	assert.NoError(t, lle.ConsumeLogs(context.Background(), testdata.GenerateLogDataOneEmptyResourceLogs()))
+	assert.NoError(t, lle.ConsumeLogs(context.Background(), testdata.GenerateLogDataOneEmptyOneNilResourceLogs()))
+	assert.NoError(t, lle.ConsumeLogs(context.Background(), testdata.GenerateLogDataNoLogRecords()))
+	assert.NoError(t, lle.ConsumeLogs(context.Background(), testdata.GenerateLogDataOneEmptyLogs()))
+
+	assert.NoError(t, lle.Shutdown(context.Background()))
+}


### PR DESCRIPTION
This makes the loggingexporter able to output in a log pipeline.