### PR TITLE
Move example factories to componenttest

### DIFF
--- a/component/componenttest/example_factories.go
+++ b/component/componenttest/example_factories.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package config
+package componenttest
 
 import (
 	"context"
@@ -79,8 +79,8 @@ func (f *ExampleReceiverFactory) CreateDefaultConfig() configmodels.Receiver {
 
 // CreateTraceReceiver creates a trace receiver based on this config.
 func (f *ExampleReceiverFactory) CreateTraceReceiver(
-	ctx context.Context,
-	logger *zap.Logger,
+	_ context.Context,
+	_ *zap.Logger,
 	cfg configmodels.Receiver,
 	nextConsumer consumer.TraceConsumerOld,
 ) (component.TraceReceiver, error) {
@@ -110,7 +110,7 @@ func (f *ExampleReceiverFactory) createReceiver(cfg configmodels.Receiver) *Exam
 }
 
 // CreateMetricsReceiver creates a metrics receiver based on this config.
-func (f *ExampleReceiverFactory) CreateMetricsReceiver(ctx context.Context, logger *zap.Logger, cfg configmodels.Receiver, nextConsumer consumer.MetricsConsumerOld) (component.MetricsReceiver, error) {
+func (f *ExampleReceiverFactory) CreateMetricsReceiver(_ context.Context, _ *zap.Logger, cfg configmodels.Receiver, nextConsumer consumer.MetricsConsumerOld) (component.MetricsReceiver, error) {
 	if cfg.(*ExampleReceiver).FailMetricsCreation {
 		return nil, configerror.ErrDataTypeIsNotSupported
 	}
@@ -122,8 +122,8 @@ func (f *ExampleReceiverFactory) CreateMetricsReceiver(ctx context.Context, logg
 }
 
 func (f *ExampleReceiverFactory) CreateLogsReceiver(
-	ctx context.Context,
-	params component.ReceiverCreateParams,
+	_ context.Context,
+	_ component.ReceiverCreateParams,
 	cfg configmodels.Receiver,
 	nextConsumer consumer.LogsConsumer,
 ) (component.LogsReceiver, error) {
@@ -143,7 +143,7 @@ type ExampleReceiverProducer struct {
 }
 
 // Start tells the receiver to start its processing.
-func (erp *ExampleReceiverProducer) Start(ctx context.Context, host component.Host) error {
+func (erp *ExampleReceiverProducer) Start(_ context.Context, _ component.Host) error {
 	erp.Started = true
 	return nil
 }
@@ -230,17 +230,17 @@ func (f *MultiProtoReceiverFactory) CreateDefaultConfig() configmodels.Receiver 
 
 // CreateTraceReceiver creates a trace receiver based on this config.
 func (f *MultiProtoReceiverFactory) CreateTraceReceiver(
-	ctx context.Context,
-	logger *zap.Logger,
-	cfg configmodels.Receiver,
-	nextConsumer consumer.TraceConsumerOld,
+	_ context.Context,
+	_ *zap.Logger,
+	_ configmodels.Receiver,
+	_ consumer.TraceConsumerOld,
 ) (component.TraceReceiver, error) {
 	// Not used for this test, just return nil
 	return nil, nil
 }
 
 // CreateMetricsReceiver creates a metrics receiver based on this config.
-func (f *MultiProtoReceiverFactory) CreateMetricsReceiver(ctx context.Context, logger *zap.Logger, cfg configmodels.Receiver, nextConsumer consumer.MetricsConsumerOld) (component.MetricsReceiver, error) {
+func (f *MultiProtoReceiverFactory) CreateMetricsReceiver(_ context.Context, _ *zap.Logger, _ configmodels.Receiver, _ consumer.MetricsConsumerOld) (component.MetricsReceiver, error) {
 	// Not used for this test, just return nil
 	return nil, nil
 }
@@ -278,19 +278,19 @@ func (f *ExampleExporterFactory) CreateDefaultConfig() configmodels.Exporter {
 }
 
 // CreateTraceExporter creates a trace exporter based on this config.
-func (f *ExampleExporterFactory) CreateTraceExporter(logger *zap.Logger, cfg configmodels.Exporter) (component.TraceExporterOld, error) {
+func (f *ExampleExporterFactory) CreateTraceExporter(_ *zap.Logger, _ configmodels.Exporter) (component.TraceExporterOld, error) {
 	return &ExampleExporterConsumer{}, nil
 }
 
 // CreateMetricsExporter creates a metrics exporter based on this config.
-func (f *ExampleExporterFactory) CreateMetricsExporter(logger *zap.Logger, cfg configmodels.Exporter) (component.MetricsExporterOld, error) {
+func (f *ExampleExporterFactory) CreateMetricsExporter(_ *zap.Logger, _ configmodels.Exporter) (component.MetricsExporterOld, error) {
 	return &ExampleExporterConsumer{}, nil
 }
 
 func (f *ExampleExporterFactory) CreateLogsExporter(
-	ctx context.Context,
-	params component.ExporterCreateParams,
-	cfg configmodels.Exporter,
+	_ context.Context,
+	_ component.ExporterCreateParams,
+	_ configmodels.Exporter,
 ) (component.LogsExporter, error) {
 	return &ExampleExporterConsumer{}, nil
 }
@@ -307,24 +307,24 @@ type ExampleExporterConsumer struct {
 // Start tells the exporter to start. The exporter may prepare for exporting
 // by connecting to the endpoint. Host parameter can be used for communicating
 // with the host after Start() has already returned.
-func (exp *ExampleExporterConsumer) Start(ctx context.Context, host component.Host) error {
+func (exp *ExampleExporterConsumer) Start(_ context.Context, _ component.Host) error {
 	exp.ExporterStarted = true
 	return nil
 }
 
 // ConsumeTraceData receives consumerdata.TraceData for processing by the TraceConsumer.
-func (exp *ExampleExporterConsumer) ConsumeTraceData(ctx context.Context, td consumerdata.TraceData) error {
+func (exp *ExampleExporterConsumer) ConsumeTraceData(_ context.Context, td consumerdata.TraceData) error {
 	exp.Traces = append(exp.Traces, td)
 	return nil
 }
 
 // ConsumeMetricsData receives consumerdata.MetricsData for processing by the MetricsConsumer.
-func (exp *ExampleExporterConsumer) ConsumeMetricsData(ctx context.Context, md consumerdata.MetricsData) error {
+func (exp *ExampleExporterConsumer) ConsumeMetricsData(_ context.Context, md consumerdata.MetricsData) error {
 	exp.Metrics = append(exp.Metrics, md)
 	return nil
 }
 
-func (exp *ExampleExporterConsumer) ConsumeLogs(ctx context.Context, ld data.Logs) error {
+func (exp *ExampleExporterConsumer) ConsumeLogs(_ context.Context, ld data.Logs) error {
 	exp.Logs = append(exp.Logs, ld)
 	return nil
 }
@@ -373,26 +373,26 @@ func (f *ExampleProcessorFactory) CreateDefaultConfig() configmodels.Processor {
 
 // CreateTraceProcessor creates a trace processor based on this config.
 func (f *ExampleProcessorFactory) CreateTraceProcessor(
-	logger *zap.Logger,
-	nextConsumer consumer.TraceConsumerOld,
-	cfg configmodels.Processor,
+	_ *zap.Logger,
+	_ consumer.TraceConsumerOld,
+	_ configmodels.Processor,
 ) (component.TraceProcessorOld, error) {
 	return nil, configerror.ErrDataTypeIsNotSupported
 }
 
 // CreateMetricsProcessor creates a metrics processor based on this config.
 func (f *ExampleProcessorFactory) CreateMetricsProcessor(
-	logger *zap.Logger,
-	nextConsumer consumer.MetricsConsumerOld,
-	cfg configmodels.Processor,
+	_ *zap.Logger,
+	_ consumer.MetricsConsumerOld,
+	_ configmodels.Processor,
 ) (component.MetricsProcessorOld, error) {
 	return nil, configerror.ErrDataTypeIsNotSupported
 }
 
 func (f *ExampleProcessorFactory) CreateLogsProcessor(
-	ctx context.Context,
-	params component.ProcessorCreateParams,
-	cfg configmodels.Processor,
+	_ context.Context,
+	_ component.ProcessorCreateParams,
+	_ configmodels.Processor,
 	nextConsumer consumer.LogsConsumer,
 ) (component.LogsProcessor, error) {
 	return &ExampleProcessor{nextConsumer}, nil
@@ -402,11 +402,11 @@ type ExampleProcessor struct {
 	nextConsumer consumer.LogsConsumer
 }
 
-func (ep *ExampleProcessor) Start(ctx context.Context, host component.Host) error {
+func (ep *ExampleProcessor) Start(_ context.Context, _ component.Host) error {
 	return nil
 }
 
-func (ep *ExampleProcessor) Shutdown(ctx context.Context) error {
+func (ep *ExampleProcessor) Shutdown(_ context.Context) error {
 	return nil
 }
 
@@ -430,9 +430,9 @@ type ExampleExtensionCfg struct {
 type ExampleExtension struct {
 }
 
-func (e *ExampleExtension) Start(ctx context.Context, host component.Host) error { return nil }
+func (e *ExampleExtension) Start(_ context.Context, _ component.Host) error { return nil }
 
-func (e *ExampleExtension) Shutdown(ctx context.Context) error { return nil }
+func (e *ExampleExtension) Shutdown(_ context.Context) error { return nil }
 
 // ExampleExtensionFactory is factory for ExampleExtensionCfg.
 type ExampleExtensionFactory struct {
@@ -467,7 +467,7 @@ func (f *ExampleExtensionFactory) CreateExtension(_ context.Context, _ component
 
 // ExampleComponents registers example factories. This is only used by tests.
 func ExampleComponents() (
-	factories Factories,
+	factories component.Factories,
 	err error,
 ) {
 	if factories.Extensions, err = component.MakeExtensionFactoryMap(&ExampleExtensionFactory{}); err != nil {

--- a/component/componenttest/example_factories_test.go
+++ b/component/componenttest/example_factories_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package config
+package componenttest
 
 import (
 	"context"
@@ -20,13 +20,12 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/consumer/consumerdata"
 )
 
 func TestExampleExporterConsumer(t *testing.T) {
 	exp := &ExampleExporterConsumer{}
-	host := componenttest.NewNopHost()
+	host := NewNopHost()
 	assert.Equal(t, false, exp.ExporterStarted)
 	err := exp.Start(context.Background(), host)
 	assert.NoError(t, err)
@@ -50,7 +49,7 @@ func TestExampleExporterConsumer(t *testing.T) {
 
 func TestExampleReceiverProducer(t *testing.T) {
 	rcv := &ExampleReceiverProducer{}
-	host := componenttest.NewNopHost()
+	host := NewNopHost()
 	assert.Equal(t, false, rcv.Started)
 	err := rcv.Start(context.Background(), host)
 	assert.NoError(t, err)

--- a/component/factories.go
+++ b/component/factories.go
@@ -20,6 +20,22 @@ import (
 	"go.opentelemetry.io/collector/config/configmodels"
 )
 
+// Factories struct holds in a single type all component factories that
+// can be handled by the Config.
+type Factories struct {
+	// Receivers maps receiver type names in the config to the respective factory.
+	Receivers map[configmodels.Type]ReceiverFactoryBase
+
+	// Processors maps processor type names in the config to the respective factory.
+	Processors map[configmodels.Type]ProcessorFactoryBase
+
+	// Exporters maps exporter type names in the config to the respective factory.
+	Exporters map[configmodels.Type]ExporterFactoryBase
+
+	// Extensions maps extension type names in the config to the respective factory.
+	Extensions map[configmodels.Type]ExtensionFactory
+}
+
 // MakeReceiverFactoryMap takes a list of receiver factories and returns a map
 // with factory type as keys. It returns a non-nil error when more than one factories
 // have the same type.

--- a/config/config.go
+++ b/config/config.go
@@ -100,22 +100,6 @@ const (
 // typeAndNameSeparator is the separator that is used between type and name in type/name composite keys.
 const typeAndNameSeparator = "/"
 
-// Factories struct holds in a single type all component factories that
-// can be handled by the Config.
-type Factories struct {
-	// Receivers maps receiver type names in the config to the respective factory.
-	Receivers map[configmodels.Type]component.ReceiverFactoryBase
-
-	// Processors maps processor type names in the config to the respective factory.
-	Processors map[configmodels.Type]component.ProcessorFactoryBase
-
-	// Exporters maps exporter type names in the config to the respective factory.
-	Exporters map[configmodels.Type]component.ExporterFactoryBase
-
-	// Extensions maps extension type names in the config to the respective factory.
-	Extensions map[configmodels.Type]component.ExtensionFactory
-}
-
 // Creates a new Viper instance with a different key-delimitor "::" instead of the
 // default ".". This way configs can have keys that contain ".".
 func NewViper() *viper.Viper {
@@ -126,7 +110,7 @@ func NewViper() *viper.Viper {
 // After loading the config, need to check if it is valid by calling `ValidateConfig`.
 func Load(
 	v *viper.Viper,
-	factories Factories,
+	factories component.Factories,
 ) (*configmodels.Config, error) {
 
 	var config configmodels.Config
@@ -578,7 +562,7 @@ func loadPipelines(v *viper.Viper) (configmodels.Pipelines, error) {
 }
 
 // ValidateConfig validates config.
-func ValidateConfig(cfg *configmodels.Config, logger *zap.Logger) error {
+func ValidateConfig(cfg *configmodels.Config, _ *zap.Logger) error {
 	// This function performs basic validation of configuration. There may be more subtle
 	// invalid cases that we currently don't check for but which we may want to add in
 	// the future (e.g. disallowing receiving and exporting on the same endpoint).

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -22,12 +22,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/configmodels"
 	"go.opentelemetry.io/collector/config/confignet"
 )
 
 func TestDecodeConfig(t *testing.T) {
-	factories, err := ExampleComponents()
+	factories, err := componenttest.ExampleComponents()
 	assert.NoError(t, err)
 
 	// Load the config
@@ -36,7 +37,7 @@ func TestDecodeConfig(t *testing.T) {
 
 	// Verify extensions.
 	assert.Equal(t, 3, len(config.Extensions))
-	assert.Equal(t, "some string", config.Extensions["exampleextension/1"].(*ExampleExtensionCfg).ExtraSetting)
+	assert.Equal(t, "some string", config.Extensions["exampleextension/1"].(*componenttest.ExampleExtensionCfg).ExtraSetting)
 
 	// Verify service.
 	assert.Equal(t, 2, len(config.Service.Extensions))
@@ -47,7 +48,7 @@ func TestDecodeConfig(t *testing.T) {
 	assert.Equal(t, 2, len(config.Receivers), "Incorrect receivers count")
 
 	assert.Equal(t,
-		&ExampleReceiver{
+		&componenttest.ExampleReceiver{
 			ReceiverSettings: configmodels.ReceiverSettings{
 				TypeVal: "examplereceiver",
 				NameVal: "examplereceiver",
@@ -61,7 +62,7 @@ func TestDecodeConfig(t *testing.T) {
 		"Did not load receiver config correctly")
 
 	assert.Equal(t,
-		&ExampleReceiver{
+		&componenttest.ExampleReceiver{
 			ReceiverSettings: configmodels.ReceiverSettings{
 				TypeVal: "examplereceiver",
 				NameVal: "examplereceiver/myreceiver",
@@ -78,7 +79,7 @@ func TestDecodeConfig(t *testing.T) {
 	assert.Equal(t, 2, len(config.Exporters), "Incorrect exporters count")
 
 	assert.Equal(t,
-		&ExampleExporter{
+		&componenttest.ExampleExporter{
 			ExporterSettings: configmodels.ExporterSettings{
 				NameVal: "exampleexporter",
 				TypeVal: "exampleexporter",
@@ -89,7 +90,7 @@ func TestDecodeConfig(t *testing.T) {
 		"Did not load exporter config correctly")
 
 	assert.Equal(t,
-		&ExampleExporter{
+		&componenttest.ExampleExporter{
 			ExporterSettings: configmodels.ExporterSettings{
 				NameVal: "exampleexporter/myexporter",
 				TypeVal: "exampleexporter",
@@ -103,7 +104,7 @@ func TestDecodeConfig(t *testing.T) {
 	assert.Equal(t, 1, len(config.Processors), "Incorrect processors count")
 
 	assert.Equal(t,
-		&ExampleProcessorCfg{
+		&componenttest.ExampleProcessorCfg{
 			ProcessorSettings: configmodels.ProcessorSettings{
 				TypeVal: "exampleprocessor",
 				NameVal: "exampleprocessor",
@@ -195,7 +196,7 @@ func TestSimpleConfig(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
-			factories, err := ExampleComponents()
+			factories, err := componenttest.ExampleComponents()
 			assert.NoError(t, err)
 
 			// Load the config
@@ -205,7 +206,7 @@ func TestSimpleConfig(t *testing.T) {
 			// Verify extensions.
 			assert.Equalf(t, 1, len(config.Extensions), "TEST[%s]", test.name)
 			assert.Equalf(t,
-				&ExampleExtensionCfg{
+				&componenttest.ExampleExtensionCfg{
 					ExtensionSettings: configmodels.ExtensionSettings{
 						TypeVal: "exampleextension",
 						NameVal: "exampleextension",
@@ -225,7 +226,7 @@ func TestSimpleConfig(t *testing.T) {
 			assert.Equalf(t, 1, len(config.Receivers), "TEST[%s]", test.name)
 
 			assert.Equalf(t,
-				&ExampleReceiver{
+				&componenttest.ExampleReceiver{
 					ReceiverSettings: configmodels.ReceiverSettings{
 						TypeVal: "examplereceiver",
 						NameVal: "examplereceiver",
@@ -244,7 +245,7 @@ func TestSimpleConfig(t *testing.T) {
 			assert.Equalf(t, 1, len(config.Exporters), "TEST[%s]", test.name)
 
 			assert.Equalf(t,
-				&ExampleExporter{
+				&componenttest.ExampleExporter{
 					ExporterSettings: configmodels.ExporterSettings{
 						NameVal: "exampleexporter",
 						TypeVal: "exampleexporter",
@@ -261,7 +262,7 @@ func TestSimpleConfig(t *testing.T) {
 			assert.Equalf(t, 1, len(config.Processors), "TEST[%s]", test.name)
 
 			assert.Equalf(t,
-				&ExampleProcessorCfg{
+				&componenttest.ExampleProcessorCfg{
 					ProcessorSettings: configmodels.ProcessorSettings{
 						TypeVal: "exampleprocessor",
 						NameVal: "exampleprocessor",
@@ -297,7 +298,7 @@ func TestEscapedEnvVars(t *testing.T) {
 		assert.NoError(t, os.Unsetenv("RECEIVERS_EXAMPLERECEIVER_EXTRA_MAP_RECV_VALUE_2"))
 	}()
 
-	factories, err := ExampleComponents()
+	factories, err := componenttest.ExampleComponents()
 	assert.NoError(t, err)
 
 	// Load the config
@@ -307,7 +308,7 @@ func TestEscapedEnvVars(t *testing.T) {
 	// Verify extensions.
 	assert.Equal(t, 1, len(config.Extensions))
 	assert.Equal(t,
-		&ExampleExtensionCfg{
+		&componenttest.ExampleExtensionCfg{
 			ExtensionSettings: configmodels.ExtensionSettings{
 				TypeVal: "exampleextension",
 				NameVal: "exampleextension",
@@ -327,7 +328,7 @@ func TestEscapedEnvVars(t *testing.T) {
 	assert.Equal(t, 1, len(config.Receivers))
 
 	assert.Equal(t,
-		&ExampleReceiver{
+		&componenttest.ExampleReceiver{
 			ReceiverSettings: configmodels.ReceiverSettings{
 				TypeVal: "examplereceiver",
 				NameVal: "examplereceiver",
@@ -361,7 +362,7 @@ func TestEscapedEnvVars(t *testing.T) {
 	assert.Equal(t, 1, len(config.Exporters))
 
 	assert.Equal(t,
-		&ExampleExporter{
+		&componenttest.ExampleExporter{
 			ExporterSettings: configmodels.ExporterSettings{
 				NameVal: "exampleexporter",
 				TypeVal: "exampleexporter",
@@ -377,7 +378,7 @@ func TestEscapedEnvVars(t *testing.T) {
 	assert.Equal(t, 1, len(config.Processors))
 
 	assert.Equal(t,
-		&ExampleProcessorCfg{
+		&componenttest.ExampleProcessorCfg{
 			ProcessorSettings: configmodels.ProcessorSettings{
 				TypeVal: "exampleprocessor",
 				NameVal: "exampleprocessor",
@@ -405,7 +406,7 @@ func TestEscapedEnvVars(t *testing.T) {
 }
 
 func TestDecodeConfig_MultiProto(t *testing.T) {
-	factories, err := ExampleComponents()
+	factories, err := componenttest.ExampleComponents()
 	assert.NoError(t, err)
 
 	// Load the config
@@ -416,10 +417,10 @@ func TestDecodeConfig_MultiProto(t *testing.T) {
 	assert.Equal(t, 2, len(config.Receivers), "Incorrect receivers count")
 
 	assert.Equal(t,
-		&MultiProtoReceiver{
+		&componenttest.MultiProtoReceiver{
 			TypeVal: "multireceiver",
 			NameVal: "multireceiver",
-			Protocols: map[string]MultiProtoReceiverOneCfg{
+			Protocols: map[string]componenttest.MultiProtoReceiverOneCfg{
 				"http": {
 					Endpoint:     "example.com:8888",
 					ExtraSetting: "extra string 1",
@@ -434,10 +435,10 @@ func TestDecodeConfig_MultiProto(t *testing.T) {
 		"Did not load receiver config correctly")
 
 	assert.Equal(t,
-		&MultiProtoReceiver{
+		&componenttest.MultiProtoReceiver{
 			TypeVal: "multireceiver",
 			NameVal: "multireceiver/myreceiver",
-			Protocols: map[string]MultiProtoReceiverOneCfg{
+			Protocols: map[string]componenttest.MultiProtoReceiverOneCfg{
 				"http": {
 					Endpoint:     "localhost:12345",
 					ExtraSetting: "some string 1",
@@ -499,7 +500,7 @@ func TestDecodeConfig_Invalid(t *testing.T) {
 		{name: "invalid-pipeline-section", expected: errUnmarshalErrorOnPipeline},
 	}
 
-	factories, err := ExampleComponents()
+	factories, err := componenttest.ExampleComponents()
 	assert.NoError(t, err)
 
 	for _, test := range testCases {
@@ -526,7 +527,7 @@ func TestDecodeConfig_Invalid(t *testing.T) {
 }
 
 func TestLoadEmptyConfig(t *testing.T) {
-	factories, err := ExampleComponents()
+	factories, err := componenttest.ExampleComponents()
 	assert.NoError(t, err)
 
 	// Open the file for reading.

--- a/config/configcheck/configcheck.go
+++ b/config/configcheck/configcheck.go
@@ -24,8 +24,8 @@ import (
 	"regexp"
 	"strings"
 
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenterror"
-	"go.opentelemetry.io/collector/config"
 )
 
 // The regular expression for valid config field tag.
@@ -33,7 +33,7 @@ var configFieldTagRegExp = regexp.MustCompile("^[a-z0-9][a-z0-9_]*$")
 
 // ValidateConfigFromFactories checks if all configurations for the given factories
 // are satisfying the patterns used by the collector.
-func ValidateConfigFromFactories(factories config.Factories) error {
+func ValidateConfigFromFactories(factories component.Factories) error {
 	var errs []error
 	var configs []interface{}
 

--- a/config/test_helpers.go
+++ b/config/test_helpers.go
@@ -21,11 +21,12 @@ import (
 
 	"go.uber.org/zap"
 
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configmodels"
 )
 
 // LoadConfigFile loads a config from file.
-func LoadConfigFile(t *testing.T, fileName string, factories Factories) (*configmodels.Config, error) {
+func LoadConfigFile(t *testing.T, fileName string, factories component.Factories) (*configmodels.Config, error) {
 	// Open the file for reading.
 	file, err := os.Open(filepath.Clean(fileName))
 	if err != nil {

--- a/exporter/fileexporter/config_test.go
+++ b/exporter/fileexporter/config_test.go
@@ -21,12 +21,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/configmodels"
 )
 
 func TestLoadConfig(t *testing.T) {
-	factories, err := config.ExampleComponents()
+	factories, err := componenttest.ExampleComponents()
 	assert.NoError(t, err)
 
 	factory := &Factory{}

--- a/exporter/jaegerexporter/config_test.go
+++ b/exporter/jaegerexporter/config_test.go
@@ -25,6 +25,7 @@ import (
 	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/configgrpc"
 	"go.opentelemetry.io/collector/config/configmodels"
@@ -32,7 +33,7 @@ import (
 )
 
 func TestLoadConfig(t *testing.T) {
-	factories, err := config.ExampleComponents()
+	factories, err := componenttest.ExampleComponents()
 	assert.NoError(t, err)
 
 	factory := NewFactory()

--- a/exporter/loggingexporter/config_test.go
+++ b/exporter/loggingexporter/config_test.go
@@ -21,12 +21,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/configmodels"
 )
 
 func TestLoadConfig(t *testing.T) {
-	factories, err := config.ExampleComponents()
+	factories, err := componenttest.ExampleComponents()
 	assert.NoError(t, err)
 
 	factory := NewFactory()

--- a/exporter/opencensusexporter/config_test.go
+++ b/exporter/opencensusexporter/config_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/configgrpc"
 	"go.opentelemetry.io/collector/config/configmodels"
@@ -28,7 +29,7 @@ import (
 )
 
 func TestLoadConfig(t *testing.T) {
-	factories, err := config.ExampleComponents()
+	factories, err := componenttest.ExampleComponents()
 	assert.NoError(t, err)
 
 	factory := &Factory{}

--- a/exporter/otlpexporter/config_test.go
+++ b/exporter/otlpexporter/config_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/configgrpc"
 	"go.opentelemetry.io/collector/config/configmodels"
@@ -30,7 +31,7 @@ import (
 )
 
 func TestLoadConfig(t *testing.T) {
-	factories, err := config.ExampleComponents()
+	factories, err := componenttest.ExampleComponents()
 	assert.NoError(t, err)
 
 	factory := NewFactory()

--- a/exporter/prometheusexporter/config_test.go
+++ b/exporter/prometheusexporter/config_test.go
@@ -21,12 +21,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/configmodels"
 )
 
 func TestLoadConfig(t *testing.T) {
-	factories, err := config.ExampleComponents()
+	factories, err := componenttest.ExampleComponents()
 	assert.NoError(t, err)
 
 	factory := &Factory{}

--- a/exporter/zipkinexporter/config_test.go
+++ b/exporter/zipkinexporter/config_test.go
@@ -22,11 +22,12 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
+	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config"
 )
 
 func TestLoadConfig(t *testing.T) {
-	factories, err := config.ExampleComponents()
+	factories, err := componenttest.ExampleComponents()
 	assert.NoError(t, err)
 
 	factory := &Factory{}

--- a/extension/healthcheckextension/config_test.go
+++ b/extension/healthcheckextension/config_test.go
@@ -21,12 +21,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/configmodels"
 )
 
 func TestLoadConfig(t *testing.T) {
-	factories, err := config.ExampleComponents()
+	factories, err := componenttest.ExampleComponents()
 	assert.NoError(t, err)
 
 	factory := &Factory{}

--- a/extension/pprofextension/config_test.go
+++ b/extension/pprofextension/config_test.go
@@ -21,12 +21,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/configmodels"
 )
 
 func TestLoadConfig(t *testing.T) {
-	factories, err := config.ExampleComponents()
+	factories, err := componenttest.ExampleComponents()
 	assert.NoError(t, err)
 
 	factory := &Factory{}

--- a/extension/zpagesextension/config_test.go
+++ b/extension/zpagesextension/config_test.go
@@ -21,12 +21,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/configmodels"
 )
 
 func TestLoadConfig(t *testing.T) {
-	factories, err := config.ExampleComponents()
+	factories, err := componenttest.ExampleComponents()
 	assert.NoError(t, err)
 
 	factory := &Factory{}

--- a/processor/attributesprocessor/config_test.go
+++ b/processor/attributesprocessor/config_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/configmodels"
 	"go.opentelemetry.io/collector/internal/processor/attraction"
@@ -29,7 +30,7 @@ import (
 )
 
 func TestLoadingConifg(t *testing.T) {
-	factories, err := config.ExampleComponents()
+	factories, err := componenttest.ExampleComponents()
 	assert.NoError(t, err)
 
 	factory := NewFactory()

--- a/processor/batchprocessor/config_test.go
+++ b/processor/batchprocessor/config_test.go
@@ -22,12 +22,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/configmodels"
 )
 
 func TestLoadConfig(t *testing.T) {
-	factories, err := config.ExampleComponents()
+	factories, err := componenttest.ExampleComponents()
 	assert.NoError(t, err)
 
 	factory := NewFactory()

--- a/processor/filterprocessor/config_test.go
+++ b/processor/filterprocessor/config_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/configmodels"
 	"go.opentelemetry.io/collector/internal/processor/filtermetric"
@@ -43,7 +44,7 @@ func TestLoadingConfigStrict(t *testing.T) {
 		MetricNames: testDataFilters,
 	}
 
-	factories, err := config.ExampleComponents()
+	factories, err := componenttest.ExampleComponents()
 	assert.Nil(t, err)
 
 	factory := NewFactory()
@@ -143,7 +144,7 @@ func TestLoadingConfigRegexp(t *testing.T) {
 		MetricNames: testDataFilters,
 	}
 
-	factories, err := config.ExampleComponents()
+	factories, err := componenttest.ExampleComponents()
 	assert.Nil(t, err)
 
 	factory := NewFactory()

--- a/processor/filterprocessor/factory_test.go
+++ b/processor/filterprocessor/factory_test.go
@@ -24,6 +24,7 @@ import (
 	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/configcheck"
 	"go.opentelemetry.io/collector/config/configmodels"
@@ -67,7 +68,7 @@ func TestCreateProcessors(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		factories, err := config.ExampleComponents()
+		factories, err := componenttest.ExampleComponents()
 		assert.Nil(t, err)
 
 		factory := NewFactory()

--- a/processor/memorylimiter/config_test.go
+++ b/processor/memorylimiter/config_test.go
@@ -22,12 +22,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/configmodels"
 )
 
 func TestLoadConfig(t *testing.T) {
-	factories, err := config.ExampleComponents()
+	factories, err := componenttest.ExampleComponents()
 	require.NoError(t, err)
 	factory := NewFactory()
 	factories.Processors[typeStr] = factory

--- a/processor/queuedprocessor/config_test.go
+++ b/processor/queuedprocessor/config_test.go
@@ -22,12 +22,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/configmodels"
 )
 
 func TestLoadConfig(t *testing.T) {
-	factories, err := config.ExampleComponents()
+	factories, err := componenttest.ExampleComponents()
 	assert.NoError(t, err)
 
 	factory := NewFactory()

--- a/processor/resourceprocessor/config_test.go
+++ b/processor/resourceprocessor/config_test.go
@@ -20,13 +20,14 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/configmodels"
 	"go.opentelemetry.io/collector/internal/processor/attraction"
 )
 
 func TestLoadConfig(t *testing.T) {
-	factories, err := config.ExampleComponents()
+	factories, err := componenttest.ExampleComponents()
 	assert.NoError(t, err)
 
 	factories.Processors[typeStr] = NewFactory()

--- a/processor/samplingprocessor/probabilisticsamplerprocessor/config_test.go
+++ b/processor/samplingprocessor/probabilisticsamplerprocessor/config_test.go
@@ -22,12 +22,13 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/configmodels"
 )
 
 func TestLoadConfig(t *testing.T) {
-	factories, err := config.ExampleComponents()
+	factories, err := componenttest.ExampleComponents()
 	assert.NoError(t, err)
 
 	factory := &Factory{}
@@ -51,7 +52,7 @@ func TestLoadConfig(t *testing.T) {
 }
 
 func TestLoadConfigEmpty(t *testing.T) {
-	factories, err := config.ExampleComponents()
+	factories, err := componenttest.ExampleComponents()
 	require.NoError(t, err)
 	factories.Processors, err = component.MakeProcessorFactoryMap(&Factory{})
 	require.NotNil(t, factories.Processors)

--- a/processor/samplingprocessor/tailsamplingprocessor/config_test.go
+++ b/processor/samplingprocessor/tailsamplingprocessor/config_test.go
@@ -22,12 +22,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/configmodels"
 )
 
 func TestLoadConfig(t *testing.T) {
-	factories, err := config.ExampleComponents()
+	factories, err := componenttest.ExampleComponents()
 	assert.NoError(t, err)
 
 	factory := &Factory{}

--- a/processor/spanprocessor/config_test.go
+++ b/processor/spanprocessor/config_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/configmodels"
 	"go.opentelemetry.io/collector/internal/processor/filterset"
@@ -27,7 +28,7 @@ import (
 )
 
 func TestLoadConfig(t *testing.T) {
-	factories, err := config.ExampleComponents()
+	factories, err := componenttest.ExampleComponents()
 	assert.NoError(t, err)
 
 	factory := NewFactory()

--- a/receiver/fluentforwardreceiver/config_test.go
+++ b/receiver/fluentforwardreceiver/config_test.go
@@ -21,12 +21,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/configmodels"
 )
 
 func TestLoadConfig(t *testing.T) {
-	factories, err := config.ExampleComponents()
+	factories, err := componenttest.ExampleComponents()
 	assert.Nil(t, err)
 
 	factory := &Factory{}

--- a/receiver/hostmetricsreceiver/config_test.go
+++ b/receiver/hostmetricsreceiver/config_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/configmodels"
 	"go.opentelemetry.io/collector/internal/processor/filterset"
@@ -38,7 +39,7 @@ import (
 )
 
 func TestLoadConfig(t *testing.T) {
-	factories, err := config.ExampleComponents()
+	factories, err := componenttest.ExampleComponents()
 	require.NoError(t, err)
 
 	factory := NewFactory()
@@ -87,7 +88,7 @@ func TestLoadConfig(t *testing.T) {
 }
 
 func TestLoadInvalidConfig_NoScrapers(t *testing.T) {
-	factories, err := config.ExampleComponents()
+	factories, err := componenttest.ExampleComponents()
 	require.NoError(t, err)
 
 	factory := NewFactory()
@@ -98,7 +99,7 @@ func TestLoadInvalidConfig_NoScrapers(t *testing.T) {
 }
 
 func TestLoadInvalidConfig_InvalidScraperKey(t *testing.T) {
-	factories, err := config.ExampleComponents()
+	factories, err := componenttest.ExampleComponents()
 	require.NoError(t, err)
 
 	factory := NewFactory()

--- a/receiver/jaegerreceiver/config_test.go
+++ b/receiver/jaegerreceiver/config_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/configgrpc"
 	"go.opentelemetry.io/collector/config/confighttp"
@@ -30,7 +31,7 @@ import (
 )
 
 func TestLoadConfig(t *testing.T) {
-	factories, err := config.ExampleComponents()
+	factories, err := componenttest.ExampleComponents()
 	assert.NoError(t, err)
 
 	factory := NewFactory()
@@ -150,7 +151,7 @@ func TestLoadConfig(t *testing.T) {
 }
 
 func TestFailedLoadConfig(t *testing.T) {
-	factories, err := config.ExampleComponents()
+	factories, err := componenttest.ExampleComponents()
 	assert.NoError(t, err)
 
 	factory := NewFactory()

--- a/receiver/opencensusreceiver/config_test.go
+++ b/receiver/opencensusreceiver/config_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/configgrpc"
 	"go.opentelemetry.io/collector/config/configmodels"
@@ -30,7 +31,7 @@ import (
 )
 
 func TestLoadConfig(t *testing.T) {
-	factories, err := config.ExampleComponents()
+	factories, err := componenttest.ExampleComponents()
 	assert.NoError(t, err)
 
 	factory := &Factory{}

--- a/receiver/otlpreceiver/config_test.go
+++ b/receiver/otlpreceiver/config_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/configgrpc"
 	"go.opentelemetry.io/collector/config/confighttp"
@@ -31,7 +32,7 @@ import (
 )
 
 func TestLoadConfig(t *testing.T) {
-	factories, err := config.ExampleComponents()
+	factories, err := componenttest.ExampleComponents()
 	assert.NoError(t, err)
 
 	factory := NewFactory()
@@ -198,7 +199,7 @@ func TestLoadConfig(t *testing.T) {
 }
 
 func TestFailedLoadConfig(t *testing.T) {
-	factories, err := config.ExampleComponents()
+	factories, err := componenttest.ExampleComponents()
 	assert.NoError(t, err)
 
 	factory := NewFactory()

--- a/receiver/prometheusreceiver/config_test.go
+++ b/receiver/prometheusreceiver/config_test.go
@@ -23,12 +23,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/configmodels"
 )
 
 func TestLoadConfig(t *testing.T) {
-	factories, err := config.ExampleComponents()
+	factories, err := componenttest.ExampleComponents()
 	assert.NoError(t, err)
 
 	factory := &Factory{}
@@ -59,7 +60,7 @@ func TestLoadConfigWithEnvVar(t *testing.T) {
 	const jobnamevar = "JOBNAME"
 	os.Setenv(jobnamevar, jobname)
 
-	factories, err := config.ExampleComponents()
+	factories, err := componenttest.ExampleComponents()
 	assert.NoError(t, err)
 
 	factory := &Factory{}
@@ -79,7 +80,7 @@ func TestLoadConfigWithEnvVar(t *testing.T) {
 }
 
 func TestLoadConfigFailsOnUnknownSection(t *testing.T) {
-	factories, err := config.ExampleComponents()
+	factories, err := componenttest.ExampleComponents()
 	assert.NoError(t, err)
 
 	factory := &Factory{}
@@ -96,7 +97,7 @@ func TestLoadConfigFailsOnUnknownSection(t *testing.T) {
 // configuration as a subkey, ensure that invalid configuration
 // within the subkey will also raise an error.
 func TestLoadConfigFailsOnUnknownPrometheusSection(t *testing.T) {
-	factories, err := config.ExampleComponents()
+	factories, err := componenttest.ExampleComponents()
 	assert.NoError(t, err)
 
 	factory := &Factory{}

--- a/receiver/zipkinreceiver/config_test.go
+++ b/receiver/zipkinreceiver/config_test.go
@@ -21,13 +21,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/config/configmodels"
 )
 
 func TestLoadConfig(t *testing.T) {
-	factories, err := config.ExampleComponents()
+	factories, err := componenttest.ExampleComponents()
 	assert.NoError(t, err)
 
 	factory := &Factory{}

--- a/service/builder/exporters_builder_test.go
+++ b/service/builder/exporters_builder_test.go
@@ -24,14 +24,13 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
-	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/configgrpc"
 	"go.opentelemetry.io/collector/config/configmodels"
 	"go.opentelemetry.io/collector/exporter/opencensusexporter"
 )
 
 func TestExportersBuilder_Build(t *testing.T) {
-	factories, err := config.ExampleComponents()
+	factories, err := componenttest.ExampleComponents()
 	assert.NoError(t, err)
 
 	oceFactory := &opencensusexporter.Factory{}
@@ -104,12 +103,12 @@ func TestExportersBuilder_Build(t *testing.T) {
 }
 
 func TestExportersBuilder_BuildLogs(t *testing.T) {
-	factories, err := config.ExampleComponents()
+	factories, err := componenttest.ExampleComponents()
 	assert.Nil(t, err)
 
 	cfg := &configmodels.Config{
 		Exporters: map[string]configmodels.Exporter{
-			"exampleexporter": &config.ExampleExporter{
+			"exampleexporter": &componenttest.ExampleExporter{
 				ExporterSettings: configmodels.ExporterSettings{
 					NameVal: "exampleexporter",
 					TypeVal: "exampleexporter",
@@ -170,8 +169,8 @@ func TestExportersBuilder_BuildLogs(t *testing.T) {
 func TestExportersBuilder_StartAll(t *testing.T) {
 	exporters := make(Exporters)
 	expCfg := &configmodels.ExporterSettings{}
-	traceExporter := &config.ExampleExporterConsumer{}
-	metricExporter := &config.ExampleExporterConsumer{}
+	traceExporter := &componenttest.ExampleExporterConsumer{}
+	metricExporter := &componenttest.ExampleExporterConsumer{}
 	exporters[expCfg] = &builtExporter{
 		logger: zap.NewNop(),
 		te:     traceExporter,
@@ -189,8 +188,8 @@ func TestExportersBuilder_StartAll(t *testing.T) {
 func TestExportersBuilder_StopAll(t *testing.T) {
 	exporters := make(Exporters)
 	expCfg := &configmodels.ExporterSettings{}
-	traceExporter := &config.ExampleExporterConsumer{}
-	metricExporter := &config.ExampleExporterConsumer{}
+	traceExporter := &componenttest.ExampleExporterConsumer{}
+	metricExporter := &componenttest.ExampleExporterConsumer{}
 	exporters[expCfg] = &builtExporter{
 		logger: zap.NewNop(),
 		te:     traceExporter,

--- a/service/builder/pipelines_builder_test.go
+++ b/service/builder/pipelines_builder_test.go
@@ -63,12 +63,12 @@ func TestPipelinesBuilder_Build(t *testing.T) {
 	}
 }
 
-func createExampleFactories() config.Factories {
-	exampleReceiverFactory := &config.ExampleReceiverFactory{}
-	exampleProcessorFactory := &config.ExampleProcessorFactory{}
-	exampleExporterFactory := &config.ExampleExporterFactory{}
+func createExampleFactories() component.Factories {
+	exampleReceiverFactory := &componenttest.ExampleReceiverFactory{}
+	exampleProcessorFactory := &componenttest.ExampleProcessorFactory{}
+	exampleExporterFactory := &componenttest.ExampleExporterFactory{}
 
-	factories := config.Factories{
+	factories := component.Factories{
 		Receivers: map[configmodels.Type]component.ReceiverFactoryBase{
 			exampleReceiverFactory.Type(): exampleReceiverFactory,
 		},
@@ -85,9 +85,9 @@ func createExampleFactories() config.Factories {
 
 func createExampleConfig(dataType string) *configmodels.Config {
 
-	exampleReceiverFactory := &config.ExampleReceiverFactory{}
-	exampleProcessorFactory := &config.ExampleProcessorFactory{}
-	exampleExporterFactory := &config.ExampleExporterFactory{}
+	exampleReceiverFactory := &componenttest.ExampleReceiverFactory{}
+	exampleProcessorFactory := &componenttest.ExampleProcessorFactory{}
+	exampleExporterFactory := &componenttest.ExampleExporterFactory{}
 
 	cfg := &configmodels.Config{
 		Receivers: map[string]configmodels.Receiver{
@@ -177,9 +177,9 @@ func TestPipelinesBuilder_BuildVarious(t *testing.T) {
 			// Send Logs via processor and verify that all exporters of the pipeline receive it.
 
 			// First check that there are no logs in the exporters yet.
-			var exporterConsumers []*config.ExampleExporterConsumer
+			var exporterConsumers []*componenttest.ExampleExporterConsumer
 			for _, exporter := range exporters {
-				consumer := exporter.le.(*config.ExampleExporterConsumer)
+				consumer := exporter.le.(*componenttest.ExampleExporterConsumer)
 				exporterConsumers = append(exporterConsumers, consumer)
 				require.Equal(t, len(consumer.Logs), 0)
 			}
@@ -286,7 +286,7 @@ func assertEqualMetricsData(t *testing.T, expected consumerdata.MetricsData, act
 }
 
 func testPipeline(t *testing.T, pipelineName string, exporterNames []string) {
-	factories, err := config.ExampleComponents()
+	factories, err := componenttest.ExampleComponents()
 	assert.NoError(t, err)
 	attrFactory := attributesprocessor.NewFactory()
 	factories.Processors[attrFactory.Type()] = attrFactory
@@ -323,9 +323,9 @@ func testPipeline(t *testing.T, pipelineName string, exporterNames []string) {
 	// Send TraceData via processor and verify that all exporters of the pipeline receive it.
 
 	// First check that there are no traces in the exporters yet.
-	var exporterConsumers []*config.ExampleExporterConsumer
+	var exporterConsumers []*componenttest.ExampleExporterConsumer
 	for _, exporter := range exporters {
-		consumer := exporter.te.(*config.ExampleExporterConsumer)
+		consumer := exporter.te.(*componenttest.ExampleExporterConsumer)
 		exporterConsumers = append(exporterConsumers, consumer)
 		require.Equal(t, len(consumer.Traces), 0)
 	}
@@ -346,7 +346,7 @@ func testPipeline(t *testing.T, pipelineName string, exporterNames []string) {
 }
 
 func TestPipelinesBuilder_Error(t *testing.T) {
-	factories, err := config.ExampleComponents()
+	factories, err := componenttest.ExampleComponents()
 	assert.NoError(t, err)
 	attrFactory := attributesprocessor.NewFactory()
 	factories.Processors[attrFactory.Type()] = attrFactory
@@ -370,7 +370,7 @@ func TestPipelinesBuilder_Error(t *testing.T) {
 }
 
 func TestProcessorsBuilder_ErrorOnNilProcessor(t *testing.T) {
-	factories, err := config.ExampleComponents()
+	factories, err := componenttest.ExampleComponents()
 	assert.NoError(t, err)
 
 	bf := &badProcessorFactory{}

--- a/service/defaultcomponents/defaults.go
+++ b/service/defaultcomponents/defaults.go
@@ -18,7 +18,6 @@ package defaultcomponents
 import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenterror"
-	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/exporter/fileexporter"
 	"go.opentelemetry.io/collector/exporter/jaegerexporter"
 	"go.opentelemetry.io/collector/exporter/loggingexporter"
@@ -50,7 +49,7 @@ import (
 // Components returns the default set of components used by the
 // OpenTelemetry collector.
 func Components() (
-	config.Factories,
+	component.Factories,
 	error,
 ) {
 	errs := []error{}
@@ -105,7 +104,7 @@ func Components() (
 		errs = append(errs, err)
 	}
 
-	factories := config.Factories{
+	factories := component.Factories{
 		Extensions: extensions,
 		Receivers:  receivers,
 		Processors: processors,

--- a/service/service.go
+++ b/service/service.go
@@ -78,7 +78,7 @@ type Application struct {
 	builtExtensions builder.Extensions
 	stateChannel    chan State
 
-	factories config.Factories
+	factories component.Factories
 	config    *configmodels.Config
 
 	// stopTestChan is used to terminate the application in end to end tests.
@@ -115,7 +115,7 @@ type ApplicationStartInfo struct {
 // Parameters holds configuration for creating a new Application.
 type Parameters struct {
 	// Factories component factories.
-	Factories config.Factories
+	Factories component.Factories
 	// ApplicationStartInfo provides application start information.
 	ApplicationStartInfo ApplicationStartInfo
 	// ConfigFactory that creates the configuration.
@@ -127,10 +127,10 @@ type Parameters struct {
 }
 
 // ConfigFactory creates config.
-type ConfigFactory func(v *viper.Viper, factories config.Factories) (*configmodels.Config, error)
+type ConfigFactory func(v *viper.Viper, factories component.Factories) (*configmodels.Config, error)
 
 // FileLoaderConfigFactory implements ConfigFactory and it creates configuration from file.
-func FileLoaderConfigFactory(v *viper.Viper, factories config.Factories) (*configmodels.Config, error) {
+func FileLoaderConfigFactory(v *viper.Viper, factories component.Factories) (*configmodels.Config, error) {
 	file := builder.GetConfigFile()
 	if file == "" {
 		return nil, errors.New("config file not specified")

--- a/testbed/testbed/otelcol_runner.go
+++ b/testbed/testbed/otelcol_runner.go
@@ -23,6 +23,7 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/configmodels"
 	"go.opentelemetry.io/collector/internal/version"
@@ -56,7 +57,7 @@ type OtelcolRunner interface {
 // same process as the test executor.
 type InProcessCollector struct {
 	logger       *zap.Logger
-	factories    config.Factories
+	factories    component.Factories
 	receiverPort int
 	config       *configmodels.Config
 	svc          *service.Application
@@ -65,7 +66,7 @@ type InProcessCollector struct {
 }
 
 // NewInProcessCollector crewtes a new InProcessCollector using the supplied component factories.
-func NewInProcessCollector(factories config.Factories, receiverPort int) *InProcessCollector {
+func NewInProcessCollector(factories component.Factories, receiverPort int) *InProcessCollector {
 	return &InProcessCollector{
 		factories:    factories,
 		receiverPort: receiverPort,
@@ -105,7 +106,7 @@ func (ipp *InProcessCollector) Start(args StartParams) (receiverAddr string, err
 			Version:  version.Version,
 			GitHash:  version.GitHash,
 		},
-		ConfigFactory: func(v *viper.Viper, factories config.Factories) (*configmodels.Config, error) {
+		ConfigFactory: func(v *viper.Viper, factories component.Factories) (*configmodels.Config, error) {
 			return ipp.config, nil
 		},
 		Factories: ipp.factories,


### PR DESCRIPTION
I had to move "Factories" from config to component.

Fixes https://github.com/open-telemetry/opentelemetry-collector/issues/1290