### PR TITLE
Fix overflowing batch size

### DIFF
--- a/processor/batchprocessor/README.md
+++ b/processor/batchprocessor/README.md
@@ -19,9 +19,10 @@ The following configuration options can be modified:
 batch will be sent.
 - `timeout` (default = 200ms): Time duration after which a batch will be sent
 regardless of size.
-- `enfoce_batch_size` (default = false): Ensures that batch size does not overflow `send_batch_size`.
- Note that this setting might have affect performance because the processor might split large batches into smaller
- units. It is currently implemented only for the trace pipeline.
+- `send_batch_max_size` (default = 0): The maximum number of items in a batch.
+ This property ensures that larger batches are split into smaller units. 
+ By default (`0`), there is no upper limit of the batch size. 
+ It is currently supported only for the trace pipeline.
 
 Examples:
 

--- a/processor/batchprocessor/README.md
+++ b/processor/batchprocessor/README.md
@@ -19,6 +19,9 @@ The following configuration options can be modified:
 batch will be sent.
 - `timeout` (default = 200ms): Time duration after which a batch will be sent
 regardless of size.
+- `enfoce_batch_size` (default = false): Ensures that batch size does not overflow `send_batch_size`.
+ Note that this setting might have affect performance because the processor might split large batches into smaller
+ units. It is currently implemented only for the trace pipeline.
 
 Examples:
 

--- a/processor/batchprocessor/batch_processor_test.go
+++ b/processor/batchprocessor/batch_processor_test.go
@@ -74,6 +74,48 @@ func TestBatchProcessorSpansDelivered(t *testing.T) {
 	}
 }
 
+func TestBatchProcessorSpansDeliveredEnforceBatchSize(t *testing.T) {
+	sink := &exportertest.SinkTraceExporter{}
+	cfg := createDefaultConfig().(*Config)
+	cfg.SendBatchSize = 128
+	cfg.EnforceBatchSize = true
+	creationParams := component.ProcessorCreateParams{Logger: zap.NewNop()}
+	batcher := newBatchTracesProcessor(creationParams, sink, cfg)
+	require.NoError(t, batcher.Start(context.Background(), componenttest.NewNopHost()))
+
+	requestCount := 1000
+	spansPerRequest := 100
+	for requestNum := 0; requestNum < requestCount; requestNum++ {
+		td := testdata.GenerateTraceDataManySpansSameResource(spansPerRequest)
+		spans := td.ResourceSpans().At(0).InstrumentationLibrarySpans().At(0).Spans()
+		for spanIndex := 0; spanIndex < spansPerRequest; spanIndex++ {
+			spans.At(spanIndex).SetName(getTestSpanName(requestNum, spanIndex))
+		}
+		assert.NoError(t, batcher.ConsumeTraces(context.Background(), td))
+	}
+
+	// Added to test logic that check for empty resources.
+	td := testdata.GenerateTraceDataEmpty()
+	batcher.ConsumeTraces(context.Background(), td)
+
+	// wait for all spans to be reported
+	for {
+		if sink.SpansCount() == requestCount*spansPerRequest {
+			break
+		}
+		<-time.After(cfg.Timeout)
+	}
+
+	require.NoError(t, batcher.Shutdown(context.Background()))
+
+	require.Equal(t, requestCount*spansPerRequest, sink.SpansCount())
+	for i := 0; i < len(sink.AllTraces())-1; i++ {
+		assert.Equal(t, cfg.SendBatchSize, uint32(sink.AllTraces()[i].SpanCount()))
+	}
+	// the last batch has the remaining size
+	assert.Equal(t, (requestCount*spansPerRequest)%int(cfg.SendBatchSize), sink.AllTraces()[len(sink.AllTraces())-1].SpanCount())
+}
+
 func TestBatchProcessorSentBySize(t *testing.T) {
 	views := MetricViews()
 	require.NoError(t, view.Register(views...))

--- a/processor/batchprocessor/batch_processor_test.go
+++ b/processor/batchprocessor/batch_processor_test.go
@@ -78,13 +78,13 @@ func TestBatchProcessorSpansDeliveredEnforceBatchSize(t *testing.T) {
 	sink := &exportertest.SinkTraceExporter{}
 	cfg := createDefaultConfig().(*Config)
 	cfg.SendBatchSize = 128
-	cfg.EnforceBatchSize = true
+	cfg.SendBatchMaxSize = 128
 	creationParams := component.ProcessorCreateParams{Logger: zap.NewNop()}
 	batcher := newBatchTracesProcessor(creationParams, sink, cfg)
 	require.NoError(t, batcher.Start(context.Background(), componenttest.NewNopHost()))
 
 	requestCount := 1000
-	spansPerRequest := 100
+	spansPerRequest := 150
 	for requestNum := 0; requestNum < requestCount; requestNum++ {
 		td := testdata.GenerateTraceDataManySpansSameResource(spansPerRequest)
 		spans := td.ResourceSpans().At(0).InstrumentationLibrarySpans().At(0).Spans()

--- a/processor/batchprocessor/config.go
+++ b/processor/batchprocessor/config.go
@@ -30,6 +30,7 @@ type Config struct {
 	// SendBatchSize is the size of a batch which after hit, will trigger it to be sent.
 	SendBatchSize uint32 `mapstructure:"send_batch_size,omitempty"`
 
-	// EnforceBatchSize ensures that batch size does not overflow SendBatchSize.
-	EnforceBatchSize bool `mapstructure:"enforce_batch_size,omitempty"`
+	// SendBatchMaxSize is the maximum size of a batch. Larger batches are split into smaller units.
+	// Default value is 0, that means no maximum size.
+	SendBatchMaxSize uint32 `mapstructure:"send_batch_max_size,omitempty"`
 }

--- a/processor/batchprocessor/config.go
+++ b/processor/batchprocessor/config.go
@@ -29,4 +29,7 @@ type Config struct {
 
 	// SendBatchSize is the size of a batch which after hit, will trigger it to be sent.
 	SendBatchSize uint32 `mapstructure:"send_batch_size,omitempty"`
+
+	// EnforceBatchSize ensures that batch size does not overflow SendBatchSize.
+	EnforceBatchSize bool `mapstructure:"enforce_batch_size,omitempty"`
 }

--- a/processor/batchprocessor/config_test.go
+++ b/processor/batchprocessor/config_test.go
@@ -44,6 +44,7 @@ func TestLoadConfig(t *testing.T) {
 
 	timeout := time.Second * 10
 	sendBatchSize := uint32(10000)
+	sendBatchMaxSize := uint32(11000)
 
 	assert.Equal(t, p1,
 		&Config{
@@ -51,7 +52,8 @@ func TestLoadConfig(t *testing.T) {
 				TypeVal: "batch",
 				NameVal: "batch/2",
 			},
-			SendBatchSize: sendBatchSize,
-			Timeout:       timeout,
+			SendBatchSize:    sendBatchSize,
+			SendBatchMaxSize: sendBatchMaxSize,
+			Timeout:          timeout,
 		})
 }

--- a/processor/batchprocessor/splittraces.go
+++ b/processor/batchprocessor/splittraces.go
@@ -1,0 +1,67 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package batchprocessor
+
+import (
+	"go.opentelemetry.io/collector/consumer/pdata"
+)
+
+// splitTrace removes spans from the input trace and returns a new trace of the specified size.
+func splitTrace(size int, toSplit pdata.Traces) pdata.Traces {
+	if toSplit.SpanCount() <= size {
+		return toSplit
+	}
+	copiedSpans := 0
+	result := pdata.NewTraces()
+	rss := toSplit.ResourceSpans()
+	for i := rss.Len() - 1; i >= 0; i-- {
+		rs := rss.At(i)
+		destRs := pdata.NewResourceSpans()
+		destRs.InitEmpty()
+		rs.Resource().CopyTo(destRs.Resource())
+		result.ResourceSpans().Append(&destRs)
+
+		for j := rs.InstrumentationLibrarySpans().Len() - 1; j >= 0; j-- {
+			instSpans := rs.InstrumentationLibrarySpans().At(j)
+			destInstSpans := pdata.NewInstrumentationLibrarySpans()
+			destInstSpans.InitEmpty()
+			destRs.InstrumentationLibrarySpans().Append(&destInstSpans)
+			instSpans.InstrumentationLibrary().CopyTo(destInstSpans.InstrumentationLibrary())
+
+			if size-copiedSpans >= instSpans.Spans().Len() {
+				destInstSpans.Spans().Resize(instSpans.Spans().Len())
+			} else {
+				destInstSpans.Spans().Resize(size - copiedSpans)
+			}
+			for k, destIdx := instSpans.Spans().Len()-1, 0; k >= 0 && copiedSpans < size; k, destIdx = k-1, destIdx+1 {
+				span := instSpans.Spans().At(k)
+				span.CopyTo(destInstSpans.Spans().At(destIdx))
+				copiedSpans++
+				// remove span
+				instSpans.Spans().Resize(instSpans.Spans().Len() - 1)
+			}
+			if instSpans.Spans().Len() == 0 {
+				rs.InstrumentationLibrarySpans().Resize(rs.InstrumentationLibrarySpans().Len() - 1)
+			}
+			if copiedSpans == size {
+				return result
+			}
+		}
+		if rs.InstrumentationLibrarySpans().Len() == 0 {
+			rss.Resize(rss.Len() - 1)
+		}
+	}
+	return result
+}

--- a/processor/batchprocessor/splittraces_test.go
+++ b/processor/batchprocessor/splittraces_test.go
@@ -1,0 +1,113 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package batchprocessor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.opentelemetry.io/collector/internal/data/testdata"
+)
+
+func TestSplitTraces_noop(t *testing.T) {
+	td := testdata.GenerateTraceDataManySpansSameResource(20)
+	splitSize := 40
+	split := splitTrace(splitSize, td)
+	assert.Equal(t, td, split)
+
+	td.ResourceSpans().At(0).InstrumentationLibrarySpans().At(0).Spans().Resize(5)
+	assert.EqualValues(t, td, split)
+}
+
+func TestSplitTraces(t *testing.T) {
+	td := testdata.GenerateTraceDataManySpansSameResource(20)
+	spans := td.ResourceSpans().At(0).InstrumentationLibrarySpans().At(0).Spans()
+	for i := 0; i < spans.Len(); i++ {
+		spans.At(i).SetName(getTestSpanName(0, i))
+	}
+	cp := pdata.NewTraces()
+	cp.ResourceSpans().Resize(1)
+	cp.ResourceSpans().At(0).InstrumentationLibrarySpans().Resize(1)
+	cp.ResourceSpans().At(0).InstrumentationLibrarySpans().At(0).Spans().Resize(5)
+	cpSpans := cp.ResourceSpans().At(0).InstrumentationLibrarySpans().At(0).Spans()
+	td.ResourceSpans().At(0).Resource().CopyTo(
+		cp.ResourceSpans().At(0).Resource())
+	td.ResourceSpans().At(0).InstrumentationLibrarySpans().At(0).InstrumentationLibrary().CopyTo(
+		cp.ResourceSpans().At(0).InstrumentationLibrarySpans().At(0).InstrumentationLibrary())
+	spans.At(19).CopyTo(cpSpans.At(0))
+	spans.At(18).CopyTo(cpSpans.At(1))
+	spans.At(17).CopyTo(cpSpans.At(2))
+	spans.At(16).CopyTo(cpSpans.At(3))
+	spans.At(15).CopyTo(cpSpans.At(4))
+
+	splitSize := 5
+	split := splitTrace(splitSize, td)
+	assert.Equal(t, splitSize, split.SpanCount())
+	assert.Equal(t, cp, split)
+	assert.Equal(t, 15, td.SpanCount())
+	assert.Equal(t, "test-span-0-19", split.ResourceSpans().At(0).InstrumentationLibrarySpans().At(0).Spans().At(0).Name())
+	assert.Equal(t, "test-span-0-15", split.ResourceSpans().At(0).InstrumentationLibrarySpans().At(0).Spans().At(4).Name())
+}
+
+func TestSplitTracesMultipleResourceSpans(t *testing.T) {
+	td := testdata.GenerateTraceDataManySpansSameResource(20)
+	spans := td.ResourceSpans().At(0).InstrumentationLibrarySpans().At(0).Spans()
+	for i := 0; i < spans.Len(); i++ {
+		spans.At(i).SetName(getTestSpanName(0, i))
+	}
+	td.ResourceSpans().Resize(2)
+	// add second index to resource spans
+	testdata.GenerateTraceDataManySpansSameResource(20).
+		ResourceSpans().At(0).CopyTo(td.ResourceSpans().At(1))
+	spans = td.ResourceSpans().At(1).InstrumentationLibrarySpans().At(0).Spans()
+	for i := 0; i < spans.Len(); i++ {
+		spans.At(i).SetName(getTestSpanName(1, i))
+	}
+
+	splitSize := 5
+	split := splitTrace(splitSize, td)
+	assert.Equal(t, splitSize, split.SpanCount())
+	assert.Equal(t, 35, td.SpanCount())
+	assert.Equal(t, "test-span-1-19", split.ResourceSpans().At(0).InstrumentationLibrarySpans().At(0).Spans().At(0).Name())
+	assert.Equal(t, "test-span-1-15", split.ResourceSpans().At(0).InstrumentationLibrarySpans().At(0).Spans().At(4).Name())
+}
+
+func TestSplitTracesMultipleResourceSpans_split_size_greater_than_span_size(t *testing.T) {
+	td := testdata.GenerateTraceDataManySpansSameResource(20)
+	spans := td.ResourceSpans().At(0).InstrumentationLibrarySpans().At(0).Spans()
+	for i := 0; i < spans.Len(); i++ {
+		spans.At(i).SetName(getTestSpanName(0, i))
+	}
+	td.ResourceSpans().Resize(2)
+	// add second index to resource spans
+	testdata.GenerateTraceDataManySpansSameResource(20).
+		ResourceSpans().At(0).CopyTo(td.ResourceSpans().At(1))
+	spans = td.ResourceSpans().At(1).InstrumentationLibrarySpans().At(0).Spans()
+	for i := 0; i < spans.Len(); i++ {
+		spans.At(i).SetName(getTestSpanName(1, i))
+	}
+
+	splitSize := 25
+	split := splitTrace(splitSize, td)
+	assert.Equal(t, splitSize, split.SpanCount())
+	assert.Equal(t, 40-splitSize, td.SpanCount())
+	assert.Equal(t, 1, td.ResourceSpans().Len())
+	assert.Equal(t, "test-span-1-19", split.ResourceSpans().At(0).InstrumentationLibrarySpans().At(0).Spans().At(0).Name())
+	assert.Equal(t, "test-span-1-0", split.ResourceSpans().At(0).InstrumentationLibrarySpans().At(0).Spans().At(19).Name())
+	assert.Equal(t, "test-span-0-19", split.ResourceSpans().At(1).InstrumentationLibrarySpans().At(0).Spans().At(0).Name())
+	assert.Equal(t, "test-span-0-15", split.ResourceSpans().At(1).InstrumentationLibrarySpans().At(0).Spans().At(4).Name())
+}

--- a/processor/batchprocessor/testdata/config.yaml
+++ b/processor/batchprocessor/testdata/config.yaml
@@ -6,7 +6,7 @@ processors:
   batch/2:
     timeout: 10s
     send_batch_size: 10000
-    enforce_batch_size: false
+    send_batch_max_size: 11000
 
 exporters:
   exampleexporter:

--- a/processor/batchprocessor/testdata/config.yaml
+++ b/processor/batchprocessor/testdata/config.yaml
@@ -6,6 +6,7 @@ processors:
   batch/2:
     timeout: 10s
     send_batch_size: 10000
+    enforce_batch_size: false
 
 exporters:
   exampleexporter:


### PR DESCRIPTION
Signed-off-by: Pavol Loffay <ploffay@redhat.com>

**Description:** <Describe what has changed. 

This PR adds configuration property `enfoce_batch_size` to batch processor that ensures that batch size does not overflow the configured `max_batch_size`. The default value is `false` hence it does not change the default behavior. 

If the incoming batch size is bigger than available space in cached traces then the incoming batch is split into reaming size and size of the maximum batch size. The spans that would overflow the buffer are sent again in trace data over the channel. 

**Link to tracking Issue:** <Issue number if applicable>

Resolves #1140
Related to https://github.com/open-telemetry/opentelemetry-collector/issues/1020

**Testing:** < Describe what testing was performed and which tests were added.>

**Documentation:** < Describe the documentation added.>

`enfoce_batch_size` has been added to the readme.