### PR TITLE
Force execute bit on otelcol binary in Docker image

### DIFF
--- a/cmd/otelcol/Dockerfile
+++ b/cmd/otelcol/Dockerfile
@@ -1,12 +1,18 @@
-FROM alpine:3.9 as certs
+FROM alpine:3.12 as certs
 RUN apk --update add ca-certificates
 RUN mkdir -m 777 /scratchtmp
+
+FROM alpine:3.12 AS otelcol
+COPY otelcol /
+# Note that this shouldn't be necessary, but in some cases the file seems to be
+# copied with the execute bit lost (see #1317)
+RUN chmod 755 /otelcol
 
 FROM scratch
 # Make an empty /tmp directory as the Kubernetes client-go library tries to log to here.
 # If it is unable to do so, it causes the collector to exit (see issue #587).
 COPY --from=certs /scratchtmp /tmp
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
-COPY otelcol /
+COPY --from=otelcol /otelcol /
 ENTRYPOINT ["/otelcol"]
 EXPOSE 55678 55679


### PR DESCRIPTION
**Description:** 

An attempted fix for #1317. It _shouldn't_ be necessary, but obviously the image is _somehow_ being built without an execute bit on the `otelcol` binary!

Also this bumps the base alpine to 3.12 (3.9 is pretty old). Pretty much a no-op though, since the `ca-certificates` package hasn't changed much.

**Link to tracking Issue:** #1317

**Testing:**

```
$ make docker-otelcol                                                      
COMPONENT=otelcol /Applications/Xcode.app/Contents/Developer/usr/bin/make docker-component
GOOS=linux /Applications/Xcode.app/Contents/Developer/usr/bin/make otelcol
GO111MODULE=on CGO_ENABLED=0 go build -o ./bin/otelcol_linux_amd64 -ldflags "-X go.opentelemetry.io/collector/internal/version.GitHash=7c2ba895  -X go.opentelemetry.io/collector/internal/version.BuildType=release" ./cmd/otelcol
cp ./bin/otelcol_linux_amd64 ./cmd/otelcol/otelcol
docker build -t otelcol ./cmd/otelcol/
[+] Building 4.2s (13/13) FINISHED                                                                                                                                                                                                                                                                   
 => [internal] load .dockerignore                                                                                                                                                                                                                                                               0.0s
 => => transferring context: 2B                                                                                                                                                                                                                                                                 0.0s
 => [internal] load build definition from Dockerfile                                                                                                                                                                                                                                            0.0s
 => => transferring dockerfile: 714B                                                                                                                                                                                                                                                            0.0s
 => [internal] load metadata for docker.io/library/alpine:3.12                                                                                                                                                                                                                                  1.0s
 => [internal] load build context                                                                                                                                                                                                                                                               1.6s
 => => transferring context: 80.90MB                                                                                                                                                                                                                                                            1.6s
 => CACHED [otelcol 1/3] FROM docker.io/library/alpine:3.12@sha256:185518070891758909c9f839cf4ca393ee977ac378609f700f60a771a2dfe321                                                                                                                                                             0.0s
 => [certs 2/3] RUN apk --update add ca-certificates                                                                                                                                                                                                                                            1.9s
 => [otelcol 2/3] COPY otelcol /                                                                                                                                                                                                                                                                0.3s
 => [certs 3/3] RUN mkdir -m 777 /scratchtmp                                                                                                                                                                                                                                                    0.3s
 => [otelcol 3/3] RUN chmod 755 /otelcol                                                                                                                                                                                                                                                        0.4s
 => CACHED [stage-2 1/3] COPY --from=certs /scratchtmp /tmp                                                                                                                                                                                                                                     0.0s 
 => [stage-2 2/3] COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt                                                                                                                                                                                       0.0s 
 => [stage-2 3/3] COPY --from=otelcol /otelcol /                                                                                                                                                                                                                                                0.2s 
 => exporting to image                                                                                                                                                                                                                                                                          0.3s 
 => => exporting layers                                                                                                                                                                                                                                                                         0.3s
 => => writing image sha256:4ee0ecdfe87c6161fd39bc028a1f18a5dd78e3f468e2f51f146f49a704b6db7a                                                                                                                                                                                                    0.0s
 => => naming to docker.io/library/otelcol                                                                                                                                                                                                                                                      0.0s
rm ./cmd/otelcol/otelcol
$ docker run -it --rm otelcol:latest
{"level":"info","ts":1594413005.2882507,"caller":"service/service.go:416","msg":"Starting OpenTelemetry Collector...","Version":"latest","GitHash":"7c2ba895","NumCPU":3}
{"level":"info","ts":1594413005.2886264,"caller":"service/service.go:256","msg":"Setting up own telemetry..."}
{"level":"info","ts":1594413005.2894032,"caller":"service/telemetry.go:98","msg":"Serving Prometheus metrics","address":":8888","legacy_metrics":false,"new_metrics":true,"level":3,"service.instance.id":"3113483a-55e2-4c1b-80ba-f3418fe0ccfb"}
{"level":"info","ts":1594413005.2897274,"caller":"service/service.go:293","msg":"Loading configuration..."}
Error: cannot load configuration: config file not specified
2020/07/10 20:30:05 application run finished with error: %v: cannot load configuration: config file not specified
```

Behaviour is fixed relative to #1317 

**Documentation:** n/a

Signed-off-by: Dave Henderson <dhenderson@gmail.com>