### PR TITLE
Bump CPU limit for a TraceNoBackend10kSPS/JaegerGRPC load test

### DIFF
--- a/testbed/tests/trace_test.go
+++ b/testbed/tests/trace_test.go
@@ -152,7 +152,7 @@ func TestTraceNoBackend10kSPS(t *testing.T) {
 			testbed.NewJaegerGRPCDataSender(testbed.DefaultHost, testbed.DefaultJaegerPort),
 			testbed.NewOCDataReceiver(testbed.DefaultOCPort),
 			testbed.ResourceSpec{
-				ExpectedMaxCPU: 60,
+				ExpectedMaxCPU: 70,
 				ExpectedMaxRAM: 198,
 			},
 			processorsConfig,


### PR DESCRIPTION
**Description:**
TraceNoBackend10kSPS/JaegerGRPC/NoMemoryLimit load test is flaky and often goes over 60%.  Looking through the history wasn't able to identify if something might cause a regression.

Resolves: https://github.com/open-telemetry/opentelemetry-collector/issues/1281