### PR TITLE
Add Metrics Only Receiver Factory type

### DIFF
--- a/component/receiver.go
+++ b/component/receiver.go
@@ -125,6 +125,21 @@ type ReceiverFactory interface {
 		cfg configmodels.Receiver, nextConsumer consumer.MetricsConsumer) (MetricsReceiver, error)
 }
 
+// MetricsReceiverFactory can create MetricsReceiver.
+type MetricsReceiverFactory interface {
+	ReceiverFactoryBase
+
+	// CreateMetricsReceiver creates a metrics receiver based on this config.
+	// If the receiver type does not support metrics or if the config is not valid
+	// error will be returned instead.
+	CreateMetricsReceiver(
+		ctx context.Context,
+		params ReceiverCreateParams,
+		cfg configmodels.Receiver,
+		nextConsumer consumer.MetricsConsumer,
+	) (MetricsReceiver, error)
+}
+
 // LogReceiverFactory can create a LogReceiver.
 type LogReceiverFactory interface {
 	ReceiverFactoryBase

--- a/service/builder/receivers_builder.go
+++ b/service/builder/receivers_builder.go
@@ -397,7 +397,7 @@ func createMetricsReceiver(
 	cfg configmodels.Receiver,
 	nextConsumer consumer.MetricsConsumerBase,
 ) (component.MetricsReceiver, error) {
-	if factory, ok := factoryBase.(component.ReceiverFactory); ok {
+	if factory, ok := factoryBase.(component.MetricsReceiverFactory); ok {
 		creationParams := component.ReceiverCreateParams{Logger: logger}
 
 		// If both receiver and consumer are of the new type (can manipulate on internal data structure),

--- a/service/builder/testdata/metrics_only_receiver_factory.yaml
+++ b/service/builder/testdata/metrics_only_receiver_factory.yaml
@@ -1,0 +1,13 @@
+receivers:
+  metricsonlyreceiver:
+processors:
+  nop:
+exporters:
+  exampleexporter:
+
+service:
+  pipelines:
+    metrics:
+      receivers: [metricsonlyreceiver]
+      processors: [nop] # trace pipeline requires a processor
+      exporters: [exampleexporter]


### PR DESCRIPTION
It is kind of annoying to have to define a boilerplate method for traces when
it has nothing to do with the receiver.