### PR TITLE
Set start / boot time to nano-second value

### DIFF
--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper.go
@@ -29,23 +29,24 @@ type scraper struct {
 	config    *Config
 	startTime pdata.TimestampUnixNano
 
-	// for mocking gopsutil cpu.Times
-	times func(bool) ([]cpu.TimesStat, error)
+	// for mocking
+	bootTime func() (uint64, error)
+	times    func(bool) ([]cpu.TimesStat, error)
 }
 
 // newCPUScraper creates a set of CPU related metrics
 func newCPUScraper(_ context.Context, cfg *Config) *scraper {
-	return &scraper{config: cfg, times: cpu.Times}
+	return &scraper{config: cfg, bootTime: host.BootTime, times: cpu.Times}
 }
 
 // Initialize
 func (s *scraper) Initialize(_ context.Context) error {
-	bootTime, err := host.BootTime()
+	bootTime, err := s.bootTime()
 	if err != nil {
 		return err
 	}
 
-	s.startTime = pdata.TimestampUnixNano(bootTime)
+	s.startTime = pdata.TimestampUnixNano(bootTime * 1e9)
 	return nil
 }
 

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper.go
@@ -29,23 +29,24 @@ type scraper struct {
 	config    *Config
 	startTime pdata.TimestampUnixNano
 
-	// for mocking gopsutil disk.IOCounters
+	// for mocking
+	bootTime   func() (uint64, error)
 	ioCounters func(names ...string) (map[string]disk.IOCountersStat, error)
 }
 
 // newDiskScraper creates a Disk Scraper
 func newDiskScraper(_ context.Context, cfg *Config) *scraper {
-	return &scraper{config: cfg, ioCounters: disk.IOCounters}
+	return &scraper{config: cfg, bootTime: host.BootTime, ioCounters: disk.IOCounters}
 }
 
 // Initialize
 func (s *scraper) Initialize(_ context.Context) error {
-	bootTime, err := host.BootTime()
+	bootTime, err := s.bootTime()
 	if err != nil {
 		return err
 	}
 
-	s.startTime = pdata.TimestampUnixNano(bootTime)
+	s.startTime = pdata.TimestampUnixNano(bootTime * 1e9)
 	return nil
 }
 

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/network_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/network_scraper.go
@@ -30,24 +30,25 @@ type scraper struct {
 	config    *Config
 	startTime pdata.TimestampUnixNano
 
-	// for mocking gopsutil net.IOCounters & net.Connections
+	// for mocking
+	bootTime    func() (uint64, error)
 	ioCounters  func(bool) ([]net.IOCountersStat, error)
 	connections func(string) ([]net.ConnectionStat, error)
 }
 
 // newNetworkScraper creates a set of Network related metrics
 func newNetworkScraper(_ context.Context, cfg *Config) *scraper {
-	return &scraper{config: cfg, ioCounters: net.IOCounters, connections: net.Connections}
+	return &scraper{config: cfg, bootTime: host.BootTime, ioCounters: net.IOCounters, connections: net.Connections}
 }
 
 // Initialize
 func (s *scraper) Initialize(_ context.Context) error {
-	bootTime, err := host.BootTime()
+	bootTime, err := s.bootTime()
 	if err != nil {
 		return err
 	}
 
-	s.startTime = pdata.TimestampUnixNano(bootTime)
+	s.startTime = pdata.TimestampUnixNano(bootTime * 1e9)
 	return nil
 }
 

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper.go
@@ -35,12 +35,14 @@ type scraper struct {
 	includeFS filterset.FilterSet
 	excludeFS filterset.FilterSet
 
+	// for mocking
+	bootTime          func() (uint64, error)
 	getProcessHandles func() (processHandles, error)
 }
 
 // newProcessScraper creates a Process Scraper
 func newProcessScraper(cfg *Config) (*scraper, error) {
-	scraper := &scraper{config: cfg, getProcessHandles: getProcessHandlesInternal}
+	scraper := &scraper{config: cfg, bootTime: host.BootTime, getProcessHandles: getProcessHandlesInternal}
 
 	var err error
 
@@ -63,12 +65,12 @@ func newProcessScraper(cfg *Config) (*scraper, error) {
 
 // Initialize
 func (s *scraper) Initialize(_ context.Context) error {
-	bootTime, err := host.BootTime()
+	bootTime, err := s.bootTime()
 	if err != nil {
 		return err
 	}
 
-	s.startTime = pdata.TimestampUnixNano(bootTime)
+	s.startTime = pdata.TimestampUnixNano(bootTime * 1e9)
 	return nil
 }
 

--- a/receiver/hostmetricsreceiver/internal/scraper/swapscraper/swap_scraper_others.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/swapscraper/swap_scraper_others.go
@@ -32,24 +32,25 @@ type scraper struct {
 	config    *Config
 	startTime pdata.TimestampUnixNano
 
-	// for mocking gopsutil mem.VirtualMemory & mem.SwapMemory
+	// for mocking
+	bootTime      func() (uint64, error)
 	virtualMemory func() (*mem.VirtualMemoryStat, error)
 	swapMemory    func() (*mem.SwapMemoryStat, error)
 }
 
 // newSwapScraper creates a Swap Scraper
 func newSwapScraper(_ context.Context, cfg *Config) *scraper {
-	return &scraper{config: cfg, virtualMemory: mem.VirtualMemory, swapMemory: mem.SwapMemory}
+	return &scraper{config: cfg, bootTime: host.BootTime, virtualMemory: mem.VirtualMemory, swapMemory: mem.SwapMemory}
 }
 
 // Initialize
 func (s *scraper) Initialize(_ context.Context) error {
-	bootTime, err := host.BootTime()
+	bootTime, err := s.bootTime()
 	if err != nil {
 		return err
 	}
 
-	s.startTime = pdata.TimestampUnixNano(bootTime)
+	s.startTime = pdata.TimestampUnixNano(bootTime * 1e9)
 	return nil
 }
 

--- a/receiver/hostmetricsreceiver/internal/testutils.go
+++ b/receiver/hostmetricsreceiver/internal/testutils.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/collector/consumer/pdata"
 )
@@ -54,4 +55,18 @@ func AssertInt64MetricLabelExists(t *testing.T, metric pdata.Metric, index int, 
 func AssertDoubleMetricLabelExists(t *testing.T, metric pdata.Metric, index int, labelName string) {
 	_, ok := metric.DoubleDataPoints().At(index).LabelsMap().Get(labelName)
 	assert.Truef(t, ok, "Missing label %q in metric %q", labelName, metric.MetricDescriptor().Name())
+}
+
+func AssertInt64MetricStartTimeEquals(t *testing.T, metric pdata.Metric, startTime pdata.TimestampUnixNano) {
+	idps := metric.Int64DataPoints()
+	for i := 0; i < idps.Len(); i++ {
+		require.Equal(t, startTime, idps.At(i).StartTime())
+	}
+}
+
+func AssertDoubleMetricStartTimeEquals(t *testing.T, metric pdata.Metric, startTime pdata.TimestampUnixNano) {
+	ddps := metric.DoubleDataPoints()
+	for i := 0; i < ddps.Len(); i++ {
+		require.Equal(t, startTime, ddps.At(i).StartTime())
+	}
 }


### PR DESCRIPTION
**Fix:** Boot time is returned from gopsutil in seconds - we need to convert this to nano-seconds.

Added test cases to ensure this value is set correctly in the generated metrics and to cover the case where the call to get boot time fails.