### PR TITLE
Wrap metrics going from resource processor in pdata.Metrics structure

### DIFF
--- a/processor/resourceprocessor/resource_processor.go
+++ b/processor/resourceprocessor/resource_processor.go
@@ -106,5 +106,5 @@ func (rmp *resourceMetricProcessor) ConsumeMetrics(ctx context.Context, md pdata
 		}
 		rmp.attrProc.Process(resource.Attributes())
 	}
-	return rmp.next.ConsumeMetrics(ctx, md)
+	return rmp.next.ConsumeMetrics(ctx, pdatautil.MetricsFromInternalMetrics(imd))
 }


### PR DESCRIPTION
**Description:**
Resource processor misses a wrapper of the output result into pdata.Metrics structure. It causes the result of the processor work to be dropped if there is a component working with the old data model downstream in the pipeline. There are no tests catching this at the moment. Hopefully we will open the new data interface for metrics and remove this wrapper soon.