### PR TITLE
Minor API refactor to use a single batch in Jaeger

### DIFF
--- a/receiver/jaegerreceiver/trace_receiver.go
+++ b/receiver/jaegerreceiver/trace_receiver.go
@@ -287,11 +287,8 @@ func (h *agentHandler) EmitBatch(_ context.Context, batch *jaeger.Batch) error {
 	ctx := obsreport.StartTraceDataReceiveOp(
 		h.ctx, h.name, h.transport)
 
-	td := jaegertranslator.ThriftBatchToInternalTraces(batch)
-
-	err := h.nextConsumer.ConsumeTraces(ctx, td)
-	obsreport.EndTraceDataReceiveOp(ctx, thriftFormat, len(batch.Spans), err)
-
+	numSpans, err := consumeTraces(ctx, batch, h.nextConsumer)
+	obsreport.EndTraceDataReceiveOp(ctx, thriftFormat, numSpans, err)
 	return err
 }
 

--- a/receiver/jaegerreceiver/trace_receiver.go
+++ b/receiver/jaegerreceiver/trace_receiver.go
@@ -257,20 +257,12 @@ func (jr *jReceiver) stopTraceReceptionLocked() error {
 	return err
 }
 
-func consumeTraces(ctx context.Context, batches []*jaeger.Batch, consumer consumer.TraceConsumer) (int, error) {
-	var consumerErrors []error
-	numSpans := 0
-	for _, batch := range batches {
-		numSpans += len(batch.Spans)
-
-		td := jaegertranslator.ThriftBatchToInternalTraces(batch)
-		err := consumer.ConsumeTraces(ctx, td)
-		if err != nil {
-			consumerErrors = append(consumerErrors, err)
-		}
+func consumeTraces(ctx context.Context, batch *jaeger.Batch, consumer consumer.TraceConsumer) (int, error) {
+	if batch == nil {
+		return 0, nil
 	}
-
-	return numSpans, componenterror.CombineErrors(consumerErrors)
+	td := jaegertranslator.ThriftBatchToInternalTraces(batch)
+	return len(batch.Spans), consumer.ConsumeTraces(ctx, td)
 }
 
 var _ agent.Agent = (*agentHandler)(nil)
@@ -477,7 +469,7 @@ func (jr *jReceiver) HandleThriftHTTPBatch(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	numSpans, err := consumeTraces(ctx, []*jaeger.Batch{batch}, jr.nextConsumer)
+	numSpans, err := consumeTraces(ctx, batch, jr.nextConsumer)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Cannot submit Jaeger batch: %v", err), http.StatusInternalServerError)
 	} else {

--- a/receiver/jaegerreceiver/trace_receiver_test.go
+++ b/receiver/jaegerreceiver/trace_receiver_test.go
@@ -621,3 +621,23 @@ func randomAvailablePort() (int, error) {
 	defer listener.Close()
 	return listener.Addr().(*net.TCPAddr).Port, nil
 }
+
+func TestConsumeThriftTrace(t *testing.T) {
+	tests := []struct {
+		batch    *tJaeger.Batch
+		numSpans int
+	}{
+		{
+			batch: nil,
+		},
+		{
+			batch:    &tJaeger.Batch{Spans: []*tJaeger.Span{{}}},
+			numSpans: 1,
+		},
+	}
+	for _, test := range tests {
+		numSpans, err := consumeTraces(context.Background(), test.batch, exportertest.NewNopTraceExporter())
+		require.NoError(t, err)
+		assert.Equal(t, test.numSpans, numSpans)
+	}
+}


### PR DESCRIPTION
Signed-off-by: Pavol Loffay <ploffay@redhat.com>

**Description:** <Describe what has changed. 

A minor API refactor to use a single batch in Jaeger receiver. 

@pjanotti could you please review? 

**Link to tracking Issue:** <Issue number if applicable>

Fixes #579 

**Testing:** < Describe what testing was performed and which tests were added.>

**Documentation:** < Describe the documentation added.>