### PR TITLE
Partially revert #1336 to check the theory for carbon performance downgrade

### DIFF
--- a/testbed/tests/scenarios.go
+++ b/testbed/tests/scenarios.go
@@ -129,7 +129,7 @@ func Scenario10kItemsPerSecond(
 	options := testbed.LoadOptions{
 		DataItemsPerSecond: 10_000,
 		ItemsPerBatch:      100,
-		Parallel:           4,
+		Parallel:           1,
 	}
 	agentProc := &testbed.ChildProcess{}
 	configStr := createConfigYaml(t, sender, receiver, resultDir, processors)


### PR DESCRIPTION
See https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/436 which cannot pass the loadtest