### PR TITLE
Fix publish CI job and add check to make sure publish doesn't break

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,33 @@ executors:
       - image: cimg/go:1.14
 
 commands:
+  verify_dist_files_exist:
+    parameters:
+      files:
+        type: string
+        default: |
+            bin/otelcol_darwin_amd64
+            bin/otelcol_linux_arm64
+            bin/otelcol_linux_amd64
+            bin/otelcol_windows_amd64.exe
+            dist/otel-collector-*arm64.rpm
+            dist/otel-collector_*amd64.deb
+            dist/otel-collector-*x86_64.rpm
+            dist/otel-collector_*arm64.deb
+            dist/opentelemetry-collector.msi
+    steps:
+      - run:
+          name: Check if files exist
+          command: |
+            files="<< parameters.files >>"
+            for f in $files; do
+              if [[ ! -f $f ]]
+              then
+                  echo "$f does not exist."
+                  exit 1 
+              fi
+            done
+
   attach_to_workspace:
     steps:
       - attach_workspace:
@@ -118,6 +145,17 @@ workflows:
           filters:
             tags:
               only: /^v([0-9])+.([0-9])+.([0-9])+.*/
+      - publish-check:
+          requires:
+            - cross-compile
+            - loadtest
+            - test
+            - gosec
+            - coverage
+            - windows-test
+            - windows-msi
+            - deb-package
+            - rpm-package
       - publish-stable:
           requires:
             - cross-compile
@@ -268,27 +306,50 @@ jobs:
           name: Code coverage
           command: bash <(curl -s https://codecov.io/bash)
 
-  publish-stable:
+  publish-check:
     docker:
       - image: cimg/go:1.14
     steps:
       - attach_to_workspace
       - setup_remote_docker
+      - verify_dist_files_exist
+      - run:
+          name: Check passed
+          command: echo "publish check passed meaning release CI jobs should work as expected"
+          when: on_success
+      - run:
+          name: Check failed
+          command: echo "publish check failed. This means release CI jobs will likely fail as well"
+          when: on_fail
+
+  publish-stable:
+    docker:
+      - image: cimg/go:1.14
+    steps:
+      - attach_to_workspace
+      - verify_dist_files_exist
+      - setup_remote_docker
       - publish_docker_images:
           repo: opentelemetry-collector
           tag: ${CIRCLE_TAG:1}
       - run:
+          name: Prepare release artifacts
+          command: |
+            cp bin/* dist/
+            mv dist/opentelemetry-collector.msi dist/otel-collector.msi
+      - run:
           name: Calculate checksums
-          command: cd bin && shasum -a 256 * > checksums.txt
+          command: cd dist && shasum -a 256 * > checksums.txt
       - run:
           name: Create Github release and upload artifacts
-          command: ghr -t $GITHUB_TOKEN -u $CIRCLE_PROJECT_USERNAME -r $CIRCLE_PROJECT_REPONAME --replace $CIRCLE_TAG bin/
+          command: ghr -t $GITHUB_TOKEN -u $CIRCLE_PROJECT_USERNAME -r $CIRCLE_PROJECT_REPONAME --replace $CIRCLE_TAG dist/
 
   publish-dev:
     docker:
       - image: cimg/go:1.14
     steps:
       - attach_to_workspace
+      - verify_dist_files_exist
       - setup_remote_docker
       - publish_docker_images:
           repo: opentelemetry-collector-dev
@@ -335,6 +396,8 @@ jobs:
     steps:
       - attach_to_workspace
       - run:
+          command: mkdir -p dist
+      - run:
           name: Install Wix Toolset
           command: .\internal\buildscripts\packaging\msi\make.ps1 Install-Tools
       - run:
@@ -347,7 +410,7 @@ jobs:
           command: .\internal\buildscripts\packaging\msi\make.ps1 Confirm-MSI
       - persist_to_workspace:
           root: ~/
-          paths: project/bin/*.msi
+          paths: project/dist/*.msi
 
   build-package:
     machine:
@@ -367,18 +430,18 @@ jobs:
             gem install --no-document fpm -v 1.11.0
       - run:
           name: Build << parameters.package_type >> amd64 package
-          command: ./internal/buildscripts/packaging/fpm/<< parameters.package_type >>/build.sh "${CIRCLE_TAG:-}" "amd64" "./bin/"
+          command: ./internal/buildscripts/packaging/fpm/<< parameters.package_type >>/build.sh "${CIRCLE_TAG:-}" "amd64" "./dist/"
       - run:
           name: Build << parameters.package_type >> arm64 package
-          command: ./internal/buildscripts/packaging/fpm/<< parameters.package_type >>/build.sh "${CIRCLE_TAG:-}" "arm64" "./bin/"
+          command: ./internal/buildscripts/packaging/fpm/<< parameters.package_type >>/build.sh "${CIRCLE_TAG:-}" "arm64" "./dist/"
       - run:
           name: Test << parameters.package_type >> package
           command: |
             if [[ "<< parameters.package_type >>" = "deb" ]]; then
-                ./internal/buildscripts/packaging/fpm/test.sh bin/otel-collector*amd64.deb
+                ./internal/buildscripts/packaging/fpm/test.sh dist/otel-collector*amd64.deb
             else
-                ./internal/buildscripts/packaging/fpm/test.sh bin/otel-collector*x86_64.rpm
+                ./internal/buildscripts/packaging/fpm/test.sh dist/otel-collector*x86_64.rpm
             fi
       - persist_to_workspace:
           root: ~/
-          paths: project/bin/*.<< parameters.package_type >>
+          paths: project/dist

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 bin/
 local/
+dist/
 
 # GoLand IDEA
 /.idea/

--- a/internal/buildscripts/packaging/fpm/Dockerfile
+++ b/internal/buildscripts/packaging/fpm/Dockerfile
@@ -11,6 +11,6 @@ WORKDIR /repo
 ENV PACKAGE="deb"
 ENV VERSION=""
 ENV ARCH="amd64"
-ENV OUTPUT_DIR="/repo/bin/"
+ENV OUTPUT_DIR="/repo/dist/"
 
 CMD ./internal/buildscripts/packaging/fpm/$PACKAGE/build.sh "$VERSION" "$ARCH" "$OUTPUT_DIR"

--- a/internal/buildscripts/packaging/fpm/deb/README.md
+++ b/internal/buildscripts/packaging/fpm/deb/README.md
@@ -3,7 +3,7 @@
 Build the otel-collector deb package with [fpm](https://github.com/jordansissel/fpm).
 
 To build the deb package, run `make deb-package` from the repo root directory. The deb package will be written to
-`bin/otel-collector_<version>_<arch>.deb`.
+`dist/otel-collector_<version>_<arch>.deb`.
 
 By default, `<arch>` is `amd64` and `<version>` is the latest git tag with `-post` appended, e.g. `1.2.3-post`.
 To override these defaults, set the `ARCH` and `VERSION` environment variables, e.g.

--- a/internal/buildscripts/packaging/fpm/deb/build.sh
+++ b/internal/buildscripts/packaging/fpm/deb/build.sh
@@ -6,9 +6,11 @@ SCRIPT_DIR="$( cd "$( dirname ${BASH_SOURCE[0]} )" && pwd )"
 REPO_DIR="$( cd "$SCRIPT_DIR/../../../../../" && pwd )"
 VERSION="${1:-}"
 ARCH="${2:-"amd64"}"
-OUTPUT_DIR="${3:-"$REPO_DIR/bin/"}"
+OUTPUT_DIR="${3:-"$REPO_DIR/dist/"}"
 OTELCOL_PATH="$REPO_DIR/bin/otelcol_linux_$ARCH"
 CONFIG_PATH="$REPO_DIR/examples/otel-local-config.yaml"
+
+mkdir -p $OUTPUT_DIR
 
 . $SCRIPT_DIR/../common.sh
 

--- a/internal/buildscripts/packaging/fpm/rpm/README.md
+++ b/internal/buildscripts/packaging/fpm/rpm/README.md
@@ -3,7 +3,7 @@
 Build the otel-collector rpm package with [fpm](https://github.com/jordansissel/fpm).
 
 To build the rpm package, run `make rpm-package` from the repo root directory. The rpm package will be written to
-`bin/otel-collector-<version>.<arch>.rpm`.
+`dist/otel-collector-<version>.<arch>.rpm`.
 
 By default, `<arch>` is `amd64` and `<version>` is the latest git tag with `~post` appended, e.g. `1.2.3~post`.
 To override these defaults, set the `ARCH` and `VERSION` environment variables, e.g.

--- a/internal/buildscripts/packaging/fpm/rpm/build.sh
+++ b/internal/buildscripts/packaging/fpm/rpm/build.sh
@@ -6,9 +6,11 @@ SCRIPT_DIR="$( cd "$( dirname ${BASH_SOURCE[0]} )" && pwd )"
 REPO_DIR="$( cd "$SCRIPT_DIR/../../../../../" && pwd )"
 VERSION="${1:-}"
 ARCH="${2:-"amd64"}"
-OUTPUT_DIR="${3:-"$REPO_DIR/bin/"}"
+OUTPUT_DIR="${3:-"$REPO_DIR/dist/"}"
 OTELCOL_PATH="$REPO_DIR/bin/otelcol_linux_$ARCH"
 CONFIG_PATH="$REPO_DIR/examples/otel-local-config.yaml"
+
+mkdir -p $OUTPUT_DIR
 
 . $SCRIPT_DIR/../common.sh
 

--- a/internal/buildscripts/packaging/msi/make.ps1
+++ b/internal/buildscripts/packaging/msi/make.ps1
@@ -39,7 +39,7 @@ function New-MSI(
 ) {
     candle -arch x64 -dVersion="$Version" -dConfig="$Config" internal/buildscripts/packaging/msi/opentelemetry-collector.wxs
     light opentelemetry-collector.wixobj
-    Move-Item -Force opentelemetry-collector.msi bin/opentelemetry-collector.msi
+    Move-Item -Force opentelemetry-collector.msi dist/opentelemetry-collector.msi
 }
 
 function Confirm-MSI {
@@ -47,7 +47,7 @@ function Confirm-MSI {
     $env:Path += ";C:\Windows\System32"
 
     # install msi, validate service is installed & running
-    Start-Process -Wait msiexec "/i `"$pwd\bin\opentelemetry-collector.msi`" /qn"
+    Start-Process -Wait msiexec "/i `"$pwd\dist\opentelemetry-collector.msi`" /qn"
     sc.exe query state=all | findstr "otelcol" | Out-Null
     if ($LASTEXITCODE -ne 0) { Throw "otelcol service failed to install" }
 
@@ -58,7 +58,7 @@ function Confirm-MSI {
     Start-Service otelcol
 
     # uninstall msi, validate service is uninstalled
-    Start-Process -Wait msiexec "/x `"$pwd\bin\opentelemetry-collector.msi`" /qn"
+    Start-Process -Wait msiexec "/x `"$pwd\dist\opentelemetry-collector.msi`" /qn"
     sc.exe query state=all | findstr "otelcol" | Out-Null
     if ($LASTEXITCODE -ne 1) { Throw "otelcol service failed to uninstall" }
 }


### PR DESCRIPTION
We were not able to release yesterday because the release CI job failed.
It failed because two sibling jobs persisted the same file(s) (bin/*) to the workspace.

- This commit fixes the issue by storing the packaged collector in `dist/` instead of `bin/`.
- In addition to that, the commit also adds job to catch any issues that
 might make the publish job fail two weeks down the line. It doesn't add any significant overhead. It just makes sure the job can run (no conflicting persisted files in workspace) and that the files expected by the real publish job are generated.