### PR TITLE
Fix Darwin build

### DIFF
--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_others.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_others.go
@@ -25,6 +25,9 @@ import (
 const cpuStatesLen = 0
 
 func appendCPUTimeStateDataPoints(ddps pdata.DoubleDataPointSlice, startTime pdata.TimestampUnixNano, cpuTime *cpu.TimesStat) {
+	initializeCPUTimeDataPoint(ddps.At(0), startTime, cpuTime.User, userStateLabelValue)
+	initializeCPUTimeDataPoint(ddps.At(1), startTime, cpuTime.System, systemStateLabelValue)
+	initializeCPUTimeDataPoint(ddps.At(2), startTime, cpuTime.Iowait, waitStateLabelValue)
 }
 
 func getProcessExecutable(proc processHandle) (*executableMetadata, error) {


### PR DESCRIPTION
The build was failing with the following:

$ make
Check License finished successfully
staticcheck FAILED => static check errors:
receiver/hostmetricsreceiver/internal/scraper/processscraper/process_metadata.go:42:2: const userStateLabelValue is unused (U1000)
receiver/hostmetricsreceiver/internal/scraper/processscraper/process_metadata.go:43:2: const systemStateLabelValue is unused (U1000)
receiver/hostmetricsreceiver/internal/scraper/processscraper/process_metadata.go:44:2: const waitStateLabelValue is unused (U1000)
receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper.go:197:6: func initializeCPUTimeDataPoint is unused (U1000)

This change ensures initializeCPUTimeDataPoint is used on all platforms and silences
staticcheck on Darwin.
