### PR TITLE
Add version and arch to MSI filename

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ commands:
             dist/otel-collector_*amd64.deb
             dist/otel-collector-*x86_64.rpm
             dist/otel-collector_*arm64.deb
-            dist/opentelemetry-collector.msi
+            dist/otel-collector-*amd64.msi
     steps:
       - run:
           name: Check if files exist
@@ -336,7 +336,6 @@ jobs:
           name: Prepare release artifacts
           command: |
             cp bin/* dist/
-            mv dist/opentelemetry-collector.msi dist/otel-collector.msi
       - run:
           name: Calculate checksums
           command: cd dist && shasum -a 256 * > checksums.txt

--- a/internal/buildscripts/packaging/msi/make.ps1
+++ b/internal/buildscripts/packaging/msi/make.ps1
@@ -39,15 +39,17 @@ function New-MSI(
 ) {
     candle -arch x64 -dVersion="$Version" -dConfig="$Config" internal/buildscripts/packaging/msi/opentelemetry-collector.wxs
     light opentelemetry-collector.wixobj
-    Move-Item -Force opentelemetry-collector.msi dist/opentelemetry-collector.msi
+    mkdir dist -ErrorAction Ignore
+    Move-Item -Force opentelemetry-collector.msi dist/otel-collector-$Version-amd64.msi
 }
 
 function Confirm-MSI {
     # ensure system32 is in Path so we can use executables like msiexec & sc
     $env:Path += ";C:\Windows\System32"
+    $msipath = Resolve-Path "$pwd\dist\otel-collector-*-amd64.msi"
 
     # install msi, validate service is installed & running
-    Start-Process -Wait msiexec "/i `"$pwd\dist\opentelemetry-collector.msi`" /qn"
+    Start-Process -Wait msiexec "/i `"$msipath`" /qn"
     sc.exe query state=all | findstr "otelcol" | Out-Null
     if ($LASTEXITCODE -ne 0) { Throw "otelcol service failed to install" }
 
@@ -58,7 +60,7 @@ function Confirm-MSI {
     Start-Service otelcol
 
     # uninstall msi, validate service is uninstalled
-    Start-Process -Wait msiexec "/x `"$pwd\dist\opentelemetry-collector.msi`" /qn"
+    Start-Process -Wait msiexec "/x `"$msipath`" /qn"
     sc.exe query state=all | findstr "otelcol" | Out-Null
     if ($LASTEXITCODE -ne 1) { Throw "otelcol service failed to uninstall" }
 }


### PR DESCRIPTION
Renames the MSI from `otel-collector.msi` to `otel-collector-<version>-amd64.msi` at build time.