### PR TITLE
FluentBit Subprocess Extension

### DIFF
--- a/extension/fluentbitextension/README.md
+++ b/extension/fluentbitextension/README.md
@@ -1,0 +1,65 @@
+# FluentBit Subprocess Extension
+
+**This extension is experimental and may receive breaking changes or be removed
+at any time.**
+
+The `fluentbit` extension facilitates running a FluentBit subprocess of the
+collector.  This is meant to be used in conjunction with the `fluentforward`
+receiver such that the FluentBit subprocess will be configured to send to the
+TCP socket opened by the `fluentforward` receiver. This extension does not
+actually listen for the logs from FluentBit, it just starts a FluentBit
+subprocess that will generally send to a `fluentforward` receiver, which must
+be configured separately.
+
+You are responsible for providing a configuration to FluentBit via the `config`
+config option.  This will be provided to the subprocess, along with a few other
+config options to enhance the integration with the collector.
+
+**As of now, this extension is only targeted for Linux environments.  It does not
+work on Windows or MacOS.**
+
+
+## Example Config
+
+```yaml
+extensions:
+  health_check:
+  fluentbit:
+    executable_path: /usr/src/fluent-bit/build/bin/fluent-bit
+    tcp_endpoint: 127.0.0.1:8006
+    config: |
+      [SERVICE]
+          parsers_file /usr/src/fluent-bit/conf/parsers.conf
+      [INPUT]
+          name tail
+          path /var/log/mylog
+          parser apache
+receivers:
+  fluentforward:
+    endpoint: 0.0.0.0:8006
+  prometheus:
+    config:
+      scrape_configs:
+        - job_name: 'otel-collector'
+          scrape_interval: 1s
+          static_configs:
+            - targets: ['127.0.0.1:8888']
+        # This will connect to the Fluent Bit subprocess's built-in HTTP
+        # monitoring server to grab Promtheus metrics.
+        - job_name: 'fluentbit'
+          scrape_interval: 1s
+          metrics_path: '/api/v1/metrics/prometheus'
+          static_configs:
+            - targets: ['127.0.0.1:2020']
+service:
+  pipelines:
+    logs:
+      receivers: [fluentforward]
+      processors: []
+      exporters: [mylogsexporter]
+    metrics:
+      receivers: [prometheus]
+      processors: [batch]
+      exporters: [mymetricsexporter]
+  extensions: [health_check, zpages, fluentbit, pprof]
+```

--- a/extension/fluentbitextension/config.go
+++ b/extension/fluentbitextension/config.go
@@ -1,0 +1,50 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fluentbitextension
+
+import (
+	"go.opentelemetry.io/collector/config/configmodels"
+)
+
+// Config has the configuration for the fluentbit extension.
+type Config struct {
+	configmodels.ExtensionSettings `mapstructure:",squash"`
+
+	// The TCP `host:port` to which the subprocess should send log entries.
+	// This is required unless you are overridding `args` and providing the
+	// output configuration yourself either in `args` or `config`.
+	TCPEndpoint string `mapstructure:"tcp_endpoint"`
+
+	// The path to the executable for FluentBit. Ideally should be an absolute
+	// path since the CWD of the collector is not guaranteed to be stable.
+	ExecutablePath string `mapstructure:"executable_path"`
+
+	// Exec arguments to the FluentBit process.  If you provide this, none of
+	// the standard args will be set, and only these provided args will be
+	// passed to FluentBit.  The standard args will set the flush interval to 1
+	// second, configure the forward output with the given `tcp_endpoint`
+	// option, enable the HTTP monitoring server in FluentBit, and set the
+	// config file to stdin. The only required arg is `--config=/dev/stdin`,
+	// since this extension passes the provided config to FluentBit via stdin.
+	// If you set args manually, you will be responsible for setting the
+	// forward output to the right port for the fluentforward receiver. See
+	// `process.go#constructArgs` of this extension source to see the current
+	// default args.
+	Args []string `mapstructure:"args"`
+
+	// A configuration for FluentBit.  This is the text content of the config
+	// itself, not a path to a config file.
+	Config string `mapstructure:"config"`
+}

--- a/extension/fluentbitextension/config_test.go
+++ b/extension/fluentbitextension/config_test.go
@@ -1,0 +1,56 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fluentbitextension
+
+import (
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/config/configmodels"
+	"go.opentelemetry.io/collector/config/configtest"
+)
+
+func TestLoadConfig(t *testing.T) {
+	factories, err := componenttest.ExampleComponents()
+	assert.NoError(t, err)
+
+	factory := &Factory{}
+	factories.Extensions[typeStr] = factory
+	cfg, err := configtest.LoadConfigFile(t, path.Join(".", "testdata", "config.yaml"), factories)
+
+	require.Nil(t, err)
+	require.NotNil(t, cfg)
+
+	ext0 := cfg.Extensions["fluentbit"]
+	assert.Equal(t, factory.CreateDefaultConfig(), ext0)
+
+	ext1 := cfg.Extensions["fluentbit/1"]
+	assert.Equal(t,
+		&Config{
+			ExtensionSettings: configmodels.ExtensionSettings{
+				TypeVal: "fluentbit",
+				NameVal: "fluentbit/1",
+			},
+			ExecutablePath: "/usr/local/bin/fluent-bit",
+		},
+		ext1)
+
+	assert.Equal(t, 1, len(cfg.Service.Extensions))
+	assert.Equal(t, "fluentbit/1", cfg.Service.Extensions[0])
+}

--- a/extension/fluentbitextension/factory.go
+++ b/extension/fluentbitextension/factory.go
@@ -1,0 +1,53 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fluentbitextension
+
+import (
+	"context"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config/configmodels"
+)
+
+const (
+	// The value of extension "type" in configuration.
+	typeStr = "fluentbit"
+)
+
+// ExtensionFactory is the factory for the extension.
+type Factory struct {
+}
+
+// Type gets the type of the config created by this factory.
+func (f *Factory) Type() configmodels.Type {
+	return typeStr
+}
+
+// CreateDefaultConfig creates the default configuration for the extension.
+func (f *Factory) CreateDefaultConfig() configmodels.Extension {
+	return &Config{
+		ExtensionSettings: configmodels.ExtensionSettings{
+			TypeVal: typeStr,
+			NameVal: typeStr,
+		},
+	}
+}
+
+// CreateExtension creates the extension based on this config.
+func (f *Factory) CreateExtension(_ context.Context, params component.ExtensionCreateParams, cfg configmodels.Extension) (component.ServiceExtension, error) {
+	config := cfg.(*Config)
+
+	return newProcessManager(config, params.Logger), nil
+}

--- a/extension/fluentbitextension/factory_test.go
+++ b/extension/fluentbitextension/factory_test.go
@@ -1,0 +1,59 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fluentbitextension
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config/configcheck"
+	"go.opentelemetry.io/collector/config/configmodels"
+)
+
+func TestFactory_Type(t *testing.T) {
+	factory := Factory{}
+	require.Equal(t, configmodels.Type(typeStr), factory.Type())
+}
+
+func TestFactory_CreateDefaultConfig(t *testing.T) {
+	factory := Factory{}
+	cfg := factory.CreateDefaultConfig()
+	assert.Equal(t, &Config{
+		ExtensionSettings: configmodels.ExtensionSettings{
+			NameVal: typeStr,
+			TypeVal: typeStr,
+		},
+	},
+		cfg)
+
+	assert.NoError(t, configcheck.ValidateConfig(cfg))
+	ext, err := factory.CreateExtension(context.Background(), component.ExtensionCreateParams{Logger: zap.NewNop()}, cfg)
+	require.NoError(t, err)
+	require.NotNil(t, ext)
+}
+
+func TestFactory_CreateExtension(t *testing.T) {
+	factory := Factory{}
+	cfg := factory.CreateDefaultConfig().(*Config)
+
+	ext, err := factory.CreateExtension(context.Background(), component.ExtensionCreateParams{Logger: zap.NewNop()}, cfg)
+	require.NoError(t, err)
+	require.NotNil(t, ext)
+}

--- a/extension/fluentbitextension/process.go
+++ b/extension/fluentbitextension/process.go
@@ -1,0 +1,224 @@
+// Copyright 2020 The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fluentbitextension
+
+import (
+	"bufio"
+	"context"
+	"io"
+	"os"
+	"os/exec"
+	"syscall"
+	"time"
+
+	"go.uber.org/zap"
+
+	"go.opentelemetry.io/collector/component"
+)
+
+type processManager struct {
+	cancel         context.CancelFunc
+	conf           *Config
+	logger         *zap.Logger
+	shutdownSignal chan struct{}
+}
+
+func newProcessManager(conf *Config, logger *zap.Logger) *processManager {
+	return &processManager{
+		conf:           conf,
+		logger:         logger,
+		shutdownSignal: make(chan struct{}),
+	}
+}
+
+type procState string
+
+// A global var that is available only for testing
+var restartDelay = 10 * time.Second
+
+const (
+	Starting     procState = "starting"
+	Running      procState = "running"
+	ShuttingDown procState = "shutting-down"
+	Stopped      procState = "stopped"
+	Restarting   procState = "restarting"
+	Errored      procState = "errored"
+)
+
+func constructArgs(tcpEndpoint string) []string {
+	return []string{
+		"--config=/dev/stdin",
+		"--http",
+		"--port=2020",
+		"--flush=1",
+		"-o", "forward://" + tcpEndpoint,
+		"--match=*",
+	}
+}
+
+func (pm *processManager) Start(ctx context.Context, host component.Host) error {
+	childCtx, cancel := context.WithCancel(ctx)
+	pm.cancel = cancel
+
+	args := pm.conf.Args
+	if len(args) == 0 {
+		args = constructArgs(pm.conf.TCPEndpoint)
+	}
+	go func() {
+		run(childCtx, pm.conf.ExecutablePath, args, pm.conf.Config, pm.logger)
+		close(pm.shutdownSignal)
+	}()
+	return nil
+}
+
+// Shutdown is invoked during service shutdown.
+func (pm *processManager) Shutdown(ctx context.Context) error {
+	pm.cancel()
+	t := time.NewTimer(5 * time.Second)
+
+	// Wait for either the FluentBit process to terminate or the timeout
+	// period, whichever comes first.
+	select {
+	case <-pm.shutdownSignal:
+	case <-t.C:
+	}
+
+	return nil
+}
+
+func run(ctx context.Context, execPath string, args []string, config string, logger *zap.Logger) {
+	state := Starting
+
+	var cmd *exec.Cmd
+	var err error
+	var stdin io.WriteCloser
+	var stdout io.ReadCloser
+	// procWait is guaranteed to be sent exactly one message per successful process start
+	procWait := make(chan error)
+
+	// A state machine makes the management easier to understand and account
+	// for all of the edge cases when managing a subprocess.
+	for {
+		logger.Debug("Fluent extension changed state", zap.String("state", string(state)))
+
+		switch state {
+		case Errored:
+			logger.Error("FluentBit process died", zap.Error(err))
+			state = Restarting
+
+		case Starting:
+			cmd, stdin, stdout = createCommand(execPath, args)
+
+			logger.Debug("Starting fluent subprocess", zap.String("command", cmd.String()))
+			err = cmd.Start()
+			if err != nil {
+				state = Errored
+				continue
+			}
+
+			go signalWhenProcessDone(cmd, procWait)
+
+			state = Running
+
+		case Running:
+			go collectOutput(stdout, logger)
+
+			err = renderConfig(config, stdin)
+			stdin.Close()
+			if err != nil {
+				state = Errored
+				continue
+			}
+
+			select {
+			case err = <-procWait:
+				if ctx.Err() == nil {
+					// We aren't supposed to shutdown yet so this is an error
+					// state.
+					state = Errored
+					continue
+				}
+				state = Stopped
+			case <-ctx.Done():
+				state = ShuttingDown
+			}
+
+		case ShuttingDown:
+			_ = cmd.Process.Signal(syscall.SIGTERM)
+			<-procWait
+			stdout.Close()
+			state = Stopped
+
+		case Restarting:
+			_ = stdout.Close()
+			_ = stdin.Close()
+
+			// Sleep for a bit so we don't have a hot loop on repeated failures.
+			time.Sleep(restartDelay)
+			state = Starting
+
+		case Stopped:
+			return
+		}
+	}
+}
+
+func signalWhenProcessDone(cmd *exec.Cmd, procWait chan<- error) {
+	err := cmd.Wait()
+	procWait <- err
+}
+
+func renderConfig(config string, writer io.Writer) error {
+	if config == "" {
+		return nil
+	}
+
+	_, err := writer.Write([]byte(config))
+	return err
+}
+
+func createCommand(execPath string, args []string) (*exec.Cmd, io.WriteCloser, io.ReadCloser) {
+	cmd := exec.Command(execPath, args...)
+
+	inReader, inWriter, err := os.Pipe()
+	if err != nil {
+		panic("Input pipe could not be created for subprocess")
+	}
+
+	cmd.Stdin = inReader
+
+	outReader, outWriter, err := os.Pipe()
+	// If this errors things are really wrong with the system
+	if err != nil {
+		panic("Output pipe could not be created for subprocess")
+	}
+	cmd.Stdout = outWriter
+	cmd.Stderr = outWriter
+
+	cmd.Env = os.Environ()
+
+	applyOSSpecificCmdModifications(cmd)
+
+	return cmd, inWriter, outReader
+}
+
+func collectOutput(stdout io.Reader, logger *zap.Logger) {
+	scanner := bufio.NewScanner(stdout)
+
+	for scanner.Scan() {
+		logger.Debug(scanner.Text())
+	}
+	// Returns when stdout is closed when the process ends
+}

--- a/extension/fluentbitextension/process_linux.go
+++ b/extension/fluentbitextension/process_linux.go
@@ -1,0 +1,30 @@
+// Copyright 2020 The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build linux
+
+package fluentbitextension
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+func applyOSSpecificCmdModifications(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		// This is Linux-specific and will cause the subprocess to be killed by the OS if
+		// the collector dies
+		Pdeathsig: syscall.SIGTERM,
+	}
+}

--- a/extension/fluentbitextension/process_linux_test.go
+++ b/extension/fluentbitextension/process_linux_test.go
@@ -1,0 +1,181 @@
+// Copyright 2020 The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fluentbitextension
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/shirou/gopsutil/process"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+const mockScript = `#!/bin/sh
+
+echo "Config:" 1>&2
+cat -
+
+sleep 100
+
+`
+
+func setup(t *testing.T, conf *Config) (*processManager, **process.Process, func() bool, func()) {
+	logCore, logObserver := observer.New(zap.DebugLevel)
+	logger := zap.New(logCore)
+
+	mockScriptFile, err := ioutil.TempFile("", "mocksubproc")
+	require.Nil(t, err)
+
+	cleanup := func() {
+		spew.Dump(logObserver.All())
+		os.Remove(mockScriptFile.Name())
+	}
+
+	_, err = mockScriptFile.Write([]byte(mockScript))
+	require.Nil(t, err)
+
+	err = mockScriptFile.Chmod(0700)
+	require.Nil(t, err)
+
+	mockScriptFile.Close()
+
+	conf.ExecutablePath = mockScriptFile.Name()
+	pm := newProcessManager(conf, logger)
+
+	var mockProc *process.Process
+	findSubproc := func() bool {
+		selfPid := os.Getpid()
+		procs, _ := process.Processes()
+		for _, proc := range procs {
+			if ppid, _ := proc.Ppid(); ppid == int32(selfPid) {
+				cmdline, _ := proc.Cmdline()
+				if strings.HasPrefix(cmdline, "/bin/sh "+mockScriptFile.Name()) {
+					mockProc = proc
+					return true
+				}
+			}
+		}
+		return false
+	}
+
+	return pm, &mockProc, findSubproc, cleanup
+}
+
+func TestProcessManager(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	pm, mockProc, findSubproc, cleanup := setup(t, &Config{
+		TCPEndpoint: "127.0.0.1:8000",
+		Config:      "example config",
+	})
+	defer cleanup()
+
+	pm.Start(ctx, nil)
+	defer pm.Shutdown(ctx)
+
+	require.Eventually(t, findSubproc, 5*time.Second, 100*time.Millisecond)
+	require.NotNil(t, *mockProc)
+
+	cmdline, err := (*mockProc).Cmdline()
+	require.Nil(t, err)
+	require.Equal(t,
+		"/bin/sh "+pm.conf.ExecutablePath+
+			" --config=/dev/stdin --http --port=2020 --flush=1 -o forward://127.0.0.1:8000 --match=*",
+		cmdline)
+
+	oldProcPid := (*mockProc).Pid
+	err = (*mockProc).Kill()
+	require.NoError(t, err)
+
+	// Should be restarted
+	require.Eventually(t, findSubproc, restartDelay+3*time.Second, 100*time.Millisecond)
+	require.NotNil(t, *mockProc)
+
+	require.NotEqual(t, (*mockProc).Pid, oldProcPid)
+}
+
+func TestProcessManagerArgs(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	pm, mockProc, findSubproc, cleanup := setup(t, &Config{
+		TCPEndpoint: "127.0.0.1:8000",
+		Config:      "example config",
+		Args:        []string{"--http"},
+	})
+	defer cleanup()
+
+	pm.Start(ctx, nil)
+	defer pm.Shutdown(ctx)
+
+	require.Eventually(t, findSubproc, 5*time.Second, 100*time.Millisecond)
+	require.NotNil(t, *mockProc)
+
+	cmdline, err := (*mockProc).Cmdline()
+	require.Nil(t, err)
+	require.Equal(t,
+		"/bin/sh "+pm.conf.ExecutablePath+
+			" --http",
+		cmdline)
+}
+
+func TestProcessManagerBadExec(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	logCore, logObserver := observer.New(zap.DebugLevel)
+	logger := zap.New(logCore)
+
+	pm := newProcessManager(&Config{
+		ExecutablePath: "/does/not/exist",
+		TCPEndpoint:    "127.0.0.1:8000",
+		Config:         "example config",
+	}, logger)
+
+	pm.Start(ctx, nil)
+	defer pm.Shutdown(ctx)
+
+	time.Sleep(restartDelay + 2*time.Second)
+	require.Len(t, logObserver.FilterMessage("FluentBit process died").All(), 2)
+}
+
+func TestProcessManagerEmptyConfig(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	pm, mockProc, findSubproc, cleanup := setup(t, &Config{
+		TCPEndpoint: "127.0.0.1:8000",
+		Config:      "",
+	})
+	defer cleanup()
+
+	pm.Start(ctx, nil)
+	defer pm.Shutdown(ctx)
+
+	require.Eventually(t, findSubproc, 15*time.Second, 100*time.Millisecond)
+	require.NotNil(t, *mockProc)
+}

--- a/extension/fluentbitextension/process_others.go
+++ b/extension/fluentbitextension/process_others.go
@@ -1,0 +1,21 @@
+// Copyright 2020 The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !linux
+
+package fluentbitextension
+
+import "os/exec"
+
+func applyOSSpecificCmdModifications(cmd *exec.Cmd) {}

--- a/extension/fluentbitextension/testdata/config.yaml
+++ b/extension/fluentbitextension/testdata/config.yaml
@@ -1,0 +1,20 @@
+extensions:
+  fluentbit:
+  fluentbit/1:
+    executable_path: /usr/local/bin/fluent-bit
+
+service:
+  extensions: [fluentbit/1]
+  pipelines:
+    traces:
+      receivers: [examplereceiver]
+      processors: [exampleprocessor]
+      exporters: [exampleexporter]
+
+# Data pipeline is required to load the config.
+receivers:
+  examplereceiver:
+processors:
+  exampleprocessor:
+exporters:
+  exampleexporter:

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/census-instrumentation/opencensus-proto v0.3.0
 	github.com/client9/misspell v0.3.4
+	github.com/davecgh/go-spew v1.1.1
 	github.com/evanphx/json-patch v4.5.0+incompatible // indirect
 	github.com/go-kit/kit v0.10.0
 	github.com/gogo/googleapis v1.3.0 // indirect

--- a/service/defaultcomponents/defaults.go
+++ b/service/defaultcomponents/defaults.go
@@ -25,6 +25,7 @@ import (
 	"go.opentelemetry.io/collector/exporter/otlpexporter"
 	"go.opentelemetry.io/collector/exporter/prometheusexporter"
 	"go.opentelemetry.io/collector/exporter/zipkinexporter"
+	"go.opentelemetry.io/collector/extension/fluentbitextension"
 	"go.opentelemetry.io/collector/extension/healthcheckextension"
 	"go.opentelemetry.io/collector/extension/pprofextension"
 	"go.opentelemetry.io/collector/extension/zpagesextension"
@@ -58,6 +59,7 @@ func Components() (
 		&healthcheckextension.Factory{},
 		&pprofextension.Factory{},
 		&zpagesextension.Factory{},
+		&fluentbitextension.Factory{},
 	)
 	if err != nil {
 		errs = append(errs, err)

--- a/service/defaultcomponents/defaults_test.go
+++ b/service/defaultcomponents/defaults_test.go
@@ -30,6 +30,7 @@ func TestDefaultComponents(t *testing.T) {
 		"health_check",
 		"pprof",
 		"zpages",
+		"fluentbit",
 	}
 	expectedReceivers := []configmodels.Type{
 		"jaeger",


### PR DESCRIPTION
This extension runs FluentBit as a subprocess and does some standard
configuration to make it talk to a fluentforward receiver running in the
same collector.

You still have to pass through the FluentBit config text but it makes
running FluentBit with the collector a bit easier.

Only the second commit is relevant for the extension.

