### PR TITLE
Add support for generating metric data for testing

### DIFF
--- a/internal/goldendataset/metric_gen.go
+++ b/internal/goldendataset/metric_gen.go
@@ -1,0 +1,201 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package goldendataset
+
+import (
+	"fmt"
+
+	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.opentelemetry.io/collector/internal/data"
+)
+
+// Simple utilities for generating metrics for testing
+
+type MetricCfg struct {
+	MetricDescriptorType pdata.MetricType
+	NumBuckets           int
+	NumIlm               int
+	NumMetrics           int
+	NumPtLabels          int
+	NumPts               int
+	NumResourceAttrs     int
+	NumResourceMetrics   int
+	PtVal                int64
+	StartTime            uint64
+	StepSize             uint64
+}
+
+func DefaultCfg() MetricCfg {
+	return MetricCfg{
+		MetricDescriptorType: pdata.MetricTypeInt64,
+		NumBuckets:           1,
+		NumIlm:               1,
+		NumMetrics:           1,
+		NumPtLabels:          1,
+		NumPts:               1,
+		NumResourceAttrs:     1,
+		NumResourceMetrics:   1,
+		PtVal:                1,
+		StartTime:            940000000000000000,
+		StepSize:             42,
+	}
+}
+
+func DefaultMetricData() data.MetricData {
+	return MetricDataFromCfg(DefaultCfg())
+}
+
+func MetricDataFromCfg(cfg MetricCfg) data.MetricData {
+	md := data.NewMetricData()
+	rms := md.ResourceMetrics()
+	rms.Resize(cfg.NumResourceMetrics)
+	for i := 0; i < cfg.NumResourceMetrics; i++ {
+		rm := rms.At(i)
+		resource := rm.Resource()
+		resource.InitEmpty()
+		for j := 0; j < cfg.NumResourceAttrs; j++ {
+			resource.Attributes().Insert(
+				fmt.Sprintf("resource-attr-name-%d", j),
+				pdata.NewAttributeValueString(fmt.Sprintf("resource-attr-val-%d", j)),
+			)
+		}
+		populateIlm(cfg, rm)
+	}
+	return md
+}
+
+func populateIlm(cfg MetricCfg, rm pdata.ResourceMetrics) {
+	ilms := rm.InstrumentationLibraryMetrics()
+	ilms.Resize(cfg.NumIlm)
+	for i := 0; i < cfg.NumIlm; i++ {
+		ilm := ilms.At(i)
+		populateMetrics(cfg, ilm)
+	}
+}
+
+func populateMetrics(cfg MetricCfg, ilm pdata.InstrumentationLibraryMetrics) {
+	metrics := ilm.Metrics()
+	metrics.Resize(cfg.NumMetrics)
+	for i := 0; i < cfg.NumMetrics; i++ {
+		metric := metrics.At(i)
+		metric.InitEmpty()
+		populateMetricDesc(cfg, metric)
+		switch cfg.MetricDescriptorType {
+		case pdata.MetricTypeInt64, pdata.MetricTypeMonotonicInt64:
+			populateIntPoints(cfg, metric)
+		case pdata.MetricTypeDouble, pdata.MetricTypeMonotonicDouble:
+			populateDblPoints(cfg, metric)
+		case pdata.MetricTypeHistogram:
+			populateHistogramPoints(cfg, metric)
+		case pdata.MetricTypeSummary:
+			populateSummaryPoints(cfg, metric)
+		}
+	}
+}
+
+func populateMetricDesc(cfg MetricCfg, metric pdata.Metric) {
+	desc := metric.MetricDescriptor()
+	desc.InitEmpty()
+	desc.SetName("my-md-name")
+	desc.SetDescription("my-md-description")
+	desc.SetUnit("my-md-units")
+	desc.SetType(cfg.MetricDescriptorType)
+}
+
+func populateIntPoints(cfg MetricCfg, metric pdata.Metric) {
+	pts := metric.Int64DataPoints()
+	pts.Resize(cfg.NumPts)
+	for i := 0; i < cfg.NumPts; i++ {
+		pt := pts.At(i)
+		pt.SetStartTime(pdata.TimestampUnixNano(cfg.StartTime))
+		pt.SetTimestamp(getTimestamp(cfg.StartTime, cfg.StepSize, i))
+		pt.SetValue(cfg.PtVal + int64(i))
+		populatePtLabels(cfg, pt.LabelsMap())
+	}
+}
+
+func populateDblPoints(cfg MetricCfg, metric pdata.Metric) {
+	pts := metric.DoubleDataPoints()
+	pts.Resize(cfg.NumPts)
+	for i := 0; i < cfg.NumPts; i++ {
+		v := cfg.PtVal + int64(i)
+		pt := pts.At(i)
+		pt.SetStartTime(pdata.TimestampUnixNano(cfg.StartTime))
+		pt.SetTimestamp(getTimestamp(cfg.StartTime, cfg.StepSize, i))
+		pt.SetValue(float64(v))
+		populatePtLabels(cfg, pt.LabelsMap())
+	}
+}
+
+func populateHistogramPoints(cfg MetricCfg, metric pdata.Metric) {
+	pts := metric.HistogramDataPoints()
+	pts.Resize(cfg.NumPts)
+	for i := 0; i < cfg.NumPts; i++ {
+		pt := pts.At(i)
+		pt.SetStartTime(pdata.TimestampUnixNano(cfg.StartTime))
+		pt.SetTimestamp(getTimestamp(cfg.StartTime, cfg.StepSize, i))
+		populatePtLabels(cfg, pt.LabelsMap())
+		setHistogramBounds(pt, 1, 2, 3, 4, 5)
+		addHistogramVal(pt, 1)
+		addHistogramVal(pt, 3)
+		addHistogramVal(pt, 3)
+		addHistogramVal(pt, 5)
+	}
+}
+
+func setHistogramBounds(hdp pdata.HistogramDataPoint, bounds ...float64) {
+	hdp.Buckets().Resize(len(bounds))
+	hdp.SetExplicitBounds(bounds)
+}
+
+func addHistogramVal(hdp pdata.HistogramDataPoint, val float64) {
+	hdp.SetCount(hdp.Count() + 1)
+	hdp.SetSum(hdp.Sum() + val)
+	buckets := hdp.Buckets()
+	bounds := hdp.ExplicitBounds()
+	for i := 0; i < len(bounds); i++ {
+		bound := bounds[i]
+		if val <= bound {
+			bucket := buckets.At(i)
+			bucket.SetCount(bucket.Count() + 1)
+			break
+		}
+	}
+}
+
+func populateSummaryPoints(cfg MetricCfg, metric pdata.Metric) {
+	pts := metric.SummaryDataPoints()
+	pts.Resize(cfg.NumPts)
+	for i := 0; i < cfg.NumPts; i++ {
+		pt := pts.At(i)
+		pt.SetStartTime(pdata.TimestampUnixNano(cfg.StartTime))
+		pt.SetTimestamp(getTimestamp(cfg.StartTime, cfg.StepSize, i))
+		pt.SetCount(uint64(i + 1))
+		pt.SetSum(float64(cfg.PtVal))
+		populatePtLabels(cfg, pt.LabelsMap())
+	}
+}
+
+func populatePtLabels(cfg MetricCfg, lm pdata.StringMap) {
+	for i := 0; i < cfg.NumPtLabels; i++ {
+		k := fmt.Sprintf("pt-label-key-%d", i)
+		v := fmt.Sprintf("pt-label-val-%d", i)
+		lm.Insert(k, v)
+	}
+}
+
+func getTimestamp(startTime uint64, stepSize uint64, i int) pdata.TimestampUnixNano {
+	return pdata.TimestampUnixNano(startTime + (stepSize * uint64(i+1)))
+}

--- a/internal/goldendataset/metric_gen.go
+++ b/internal/goldendataset/metric_gen.go
@@ -29,9 +29,9 @@ type MetricCfg struct {
 	// The type of metric to generate
 	MetricDescriptorType pdata.MetricType
 	// The number of instrumentation library metrics per resource
-	NumIlmPerResource int
+	NumILMPerResource int
 	// The size of the MetricSlice and number of Metrics
-	NumMetrics int
+	NumMetricsPerILM int
 	// The number of labels on the LabelsMap associated with each point
 	NumPtLabels int
 	// The number of points to generate per Metric
@@ -49,8 +49,8 @@ type MetricCfg struct {
 func DefaultCfg() MetricCfg {
 	return MetricCfg{
 		MetricDescriptorType: pdata.MetricTypeInt64,
-		NumIlmPerResource:    1,
-		NumMetrics:           1,
+		NumILMPerResource:    1,
+		NumMetricsPerILM:     1,
 		NumPtLabels:          1,
 		NumPts:               1,
 		NumResourceAttrs:     1,
@@ -85,8 +85,8 @@ func MetricDataFromCfg(cfg MetricCfg) data.MetricData {
 
 func populateIlm(cfg MetricCfg, rm pdata.ResourceMetrics) {
 	ilms := rm.InstrumentationLibraryMetrics()
-	ilms.Resize(cfg.NumIlmPerResource)
-	for i := 0; i < cfg.NumIlmPerResource; i++ {
+	ilms.Resize(cfg.NumILMPerResource)
+	for i := 0; i < cfg.NumILMPerResource; i++ {
 		ilm := ilms.At(i)
 		populateMetrics(cfg, ilm)
 	}
@@ -94,8 +94,8 @@ func populateIlm(cfg MetricCfg, rm pdata.ResourceMetrics) {
 
 func populateMetrics(cfg MetricCfg, ilm pdata.InstrumentationLibraryMetrics) {
 	metrics := ilm.Metrics()
-	metrics.Resize(cfg.NumMetrics)
-	for i := 0; i < cfg.NumMetrics; i++ {
+	metrics.Resize(cfg.NumMetricsPerILM)
+	for i := 0; i < cfg.NumMetricsPerILM; i++ {
 		metric := metrics.At(i)
 		metric.InitEmpty()
 		populateMetricDesc(cfg, metric)

--- a/internal/goldendataset/metric_gen_test.go
+++ b/internal/goldendataset/metric_gen_test.go
@@ -66,17 +66,17 @@ func TestHistogramFunctions(t *testing.T) {
 	require.Equal(t, 5, len(pt.ExplicitBounds()))
 	require.Equal(t, 5, pt.Buckets().Len())
 
-	addHistogramVal(pt, 1)
+	addHistogramVal(pt, 1, 0)
 	require.EqualValues(t, 1, pt.Count())
 	require.EqualValues(t, 1, pt.Sum())
 	require.EqualValues(t, 1, pt.Buckets().At(0).Count())
 
-	addHistogramVal(pt, 2)
+	addHistogramVal(pt, 2, 0)
 	require.EqualValues(t, 2, pt.Count())
 	require.EqualValues(t, 3, pt.Sum())
 	require.EqualValues(t, 1, pt.Buckets().At(1).Count())
 
-	addHistogramVal(pt, 2)
+	addHistogramVal(pt, 2, 0)
 	require.EqualValues(t, 3, pt.Count())
 	require.EqualValues(t, 5, pt.Sum())
 	require.EqualValues(t, 2, pt.Buckets().At(1).Count())
@@ -92,6 +92,23 @@ func TestGenHistogram(t *testing.T) {
 	require.Equal(t, 5, buckets.Len())
 	middleBucket := buckets.At(2)
 	require.EqualValues(t, 2, middleBucket.Count())
+	ex := pt.Buckets().At(0).Exemplar()
+	ex.Value()
+	require.EqualValues(t, 1, ex.Value())
+}
+
+func TestSummaryFunctions(t *testing.T) {
+	pt := pdata.NewSummaryDataPoint()
+	pt.InitEmpty()
+	setSummaryPercentiles(pt, 0, 50, 95)
+	addSummaryValue(pt, 55, 0)
+	addSummaryValue(pt, 70, 1)
+	addSummaryValue(pt, 90, 2)
+	require.EqualValues(t, 3, pt.Count())
+	v := pt.ValueAtPercentiles().At(2).Value()
+	require.EqualValues(t, 1, v)
+	pctile := pt.ValueAtPercentiles().At(2).Percentile()
+	require.EqualValues(t, 95, pctile)
 }
 
 func TestGenSummary(t *testing.T) {
@@ -102,8 +119,8 @@ func TestGenSummary(t *testing.T) {
 	pts := metric.SummaryDataPoints()
 	require.Equal(t, 1, pts.Len())
 	pt := pts.At(0)
-	require.EqualValues(t, 1, pt.Count())
-	require.EqualValues(t, 1, pt.Sum())
+	require.EqualValues(t, 3, pt.Count())
+	require.EqualValues(t, 215, pt.Sum())
 }
 
 func TestGenDouble(t *testing.T) {

--- a/internal/goldendataset/metric_gen_test.go
+++ b/internal/goldendataset/metric_gen_test.go
@@ -1,0 +1,122 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package goldendataset
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.opentelemetry.io/collector/internal/data"
+)
+
+func TestGenDefault(t *testing.T) {
+	md := DefaultMetricData()
+	mCount, ptCount := md.MetricAndDataPointCount()
+	require.Equal(t, 1, mCount)
+	require.Equal(t, 1, ptCount)
+	rms := md.ResourceMetrics()
+	rm := rms.At(0)
+	resource := rm.Resource()
+	rattrs := resource.Attributes()
+	rattrs.Len()
+	require.Equal(t, 1, rattrs.Len())
+	val, _ := rattrs.Get("resource-attr-name-0")
+	require.Equal(t, "resource-attr-val-0", val.StringVal())
+	ilms := rm.InstrumentationLibraryMetrics()
+	require.Equal(t, 1, ilms.Len())
+	ms := ilms.At(0).Metrics()
+	require.Equal(t, 1, ms.Len())
+	pdm := ms.At(0)
+	desc := pdm.MetricDescriptor()
+	require.Equal(t, "my-md-name", desc.Name())
+	require.Equal(t, "my-md-description", desc.Description())
+	require.Equal(t, "my-md-units", desc.Unit())
+
+	pts := pdm.Int64DataPoints()
+	require.Equal(t, 1, pts.Len())
+	pt := pts.At(0)
+
+	require.Equal(t, 1, pt.LabelsMap().Len())
+	ptLabels, _ := pt.LabelsMap().Get("pt-label-key-0")
+	require.Equal(t, "pt-label-val-0", ptLabels.Value())
+
+	require.EqualValues(t, 940000000000000000, pt.StartTime())
+	require.EqualValues(t, 940000000000000042, pt.Timestamp())
+	require.EqualValues(t, 1, pt.Value())
+}
+
+func TestHistogramFunctions(t *testing.T) {
+	pt := pdata.NewHistogramDataPoint()
+	pt.InitEmpty()
+	setHistogramBounds(pt, 1, 2, 3, 4, 5)
+	require.Equal(t, 5, len(pt.ExplicitBounds()))
+	require.Equal(t, 5, pt.Buckets().Len())
+
+	addHistogramVal(pt, 1)
+	require.EqualValues(t, 1, pt.Count())
+	require.EqualValues(t, 1, pt.Sum())
+	require.EqualValues(t, 1, pt.Buckets().At(0).Count())
+
+	addHistogramVal(pt, 2)
+	require.EqualValues(t, 2, pt.Count())
+	require.EqualValues(t, 3, pt.Sum())
+	require.EqualValues(t, 1, pt.Buckets().At(1).Count())
+
+	addHistogramVal(pt, 2)
+	require.EqualValues(t, 3, pt.Count())
+	require.EqualValues(t, 5, pt.Sum())
+	require.EqualValues(t, 2, pt.Buckets().At(1).Count())
+}
+
+func TestGenHistogram(t *testing.T) {
+	cfg := DefaultCfg()
+	cfg.MetricDescriptorType = pdata.MetricTypeHistogram
+	md := MetricDataFromCfg(cfg)
+	pts := getMetric(md).HistogramDataPoints()
+	pt := pts.At(0)
+	buckets := pt.Buckets()
+	require.Equal(t, 5, buckets.Len())
+	middleBucket := buckets.At(2)
+	require.EqualValues(t, 2, middleBucket.Count())
+}
+
+func TestGenSummary(t *testing.T) {
+	cfg := DefaultCfg()
+	cfg.MetricDescriptorType = pdata.MetricTypeSummary
+	md := MetricDataFromCfg(cfg)
+	metric := getMetric(md)
+	pts := metric.SummaryDataPoints()
+	require.Equal(t, 1, pts.Len())
+	pt := pts.At(0)
+	require.EqualValues(t, 1, pt.Count())
+	require.EqualValues(t, 1, pt.Sum())
+}
+
+func TestGenDouble(t *testing.T) {
+	cfg := DefaultCfg()
+	cfg.MetricDescriptorType = pdata.MetricTypeDouble
+	md := MetricDataFromCfg(cfg)
+	metric := getMetric(md)
+	pts := metric.DoubleDataPoints()
+	require.Equal(t, 1, pts.Len())
+	pt := pts.At(0)
+	require.EqualValues(t, 1, pt.Value())
+}
+
+func getMetric(md data.MetricData) pdata.Metric {
+	return md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(0)
+}


### PR DESCRIPTION
This is in support of issue #652 and in response to a request by the team to break up my last commit into smaller chunks. This is the first of those chunks.

We will need to generate MetricData content both for feeding to the testbed sender and for testing MetricData diff functionality which will be used for validation checking in the testbed.