### PR TITLE
Record process physical & virtual memory stats separately

### DIFF
--- a/receiver/hostmetricsreceiver/hostmetrics_receiver_test.go
+++ b/receiver/hostmetricsreceiver/hostmetrics_receiver_test.go
@@ -62,7 +62,8 @@ var standardMetrics = []string{
 
 var resourceMetrics = []string{
 	"process.cpu.time",
-	"process.memory.usage",
+	"process.memory.physical_usage",
+	"process.memory.virtual_usage",
 	"process.disk.io",
 }
 

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_metadata.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_metadata.go
@@ -56,11 +56,21 @@ var cpuTimeDescriptor = func() pdata.MetricDescriptor {
 	return descriptor
 }()
 
-var memoryUsageDescriptor = func() pdata.MetricDescriptor {
+var physicalMemoryUsageDescriptor = func() pdata.MetricDescriptor {
 	descriptor := pdata.NewMetricDescriptor()
 	descriptor.InitEmpty()
-	descriptor.SetName("process.memory.usage")
-	descriptor.SetDescription("Bytes of memory in use.")
+	descriptor.SetName("process.memory.physical_usage")
+	descriptor.SetDescription("The amount of physical memory in use.")
+	descriptor.SetUnit("bytes")
+	descriptor.SetType(pdata.MetricTypeInt64)
+	return descriptor
+}()
+
+var virtualMemoryUsageDescriptor = func() pdata.MetricDescriptor {
+	descriptor := pdata.NewMetricDescriptor()
+	descriptor.InitEmpty()
+	descriptor.SetName("process.memory.virtual_usage")
+	descriptor.SetDescription("Virtual memory size.")
 	descriptor.SetUnit("bytes")
 	descriptor.SetType(pdata.MetricTypeInt64)
 	return descriptor


### PR DESCRIPTION
On Linux:

- Physical usage = Resident set size
- Virtual usage = Virtual memory size

On Windows:

- Physical usage = Working set size
- Virtual usage = Commit size (private virtual memory), aka. Page File Usage

From what I can tell, there is one difference in that Virtual Usage on Windows does not include shared virtual memory whereas on Linux it does, but I think these concepts are similar enough to use the same metric. WDYT @jrcamp?