### PR TITLE
Add Logs to Test Bed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,6 +91,27 @@ commands:
                 command: go run cmd/issuegenerator/main.go ${TEST_RESULTS}
                 when: on_fail
 
+  install_fluentbit:
+    steps:
+      - run: |
+          sudo chmod 0777 -R /opt
+      - restore_cache: # restores saved cache if no changes are detected since last run
+          keys:
+            - "cimg-fluentbit-{{ arch }}-1.5.3"
+      - run: |
+          sudo ln -s /opt/td-agent-bit/bin/td-agent-bit /usr/local/bin/fluent-bit
+
+          if [[ -f /opt/td-agent-bit/bin/td-agent-bit ]]; then
+            exit 0
+          fi
+
+          wget https://packages.fluentbit.io/ubuntu/bionic/pool/main/t/td-agent-bit/td-agent-bit_1.5.3_amd64.deb
+          sudo dpkg -i ./td-agent-bit*.deb
+      - save_cache:
+          key: cimg-fluentbit-{{ arch }}-1.5.3
+          paths:
+            - /opt/td-agent-bit
+
 workflows:
   version: 2
   build-and-test:
@@ -280,6 +301,7 @@ jobs:
     resource_class: medium+
     steps:
       - attach_to_workspace
+      - install_fluentbit
       - run:
           name: Loadtest
           command: TEST_ARGS="-test.run=$(make -s testbed-list-loadtest | circleci tests split|xargs echo|sed 's/ /|/g')" make testbed-loadtest

--- a/testbed/tests/log_test.go
+++ b/testbed/tests/log_test.go
@@ -1,0 +1,42 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+// This file contains Test functions which initiate the tests. The tests can be either
+// coded in this file or use scenarios from perf_scenarios.go.
+
+import (
+	"testing"
+
+	"go.opentelemetry.io/collector/testbed/testbed"
+)
+
+func TestLog10kDPS(t *testing.T) {
+	flw := testbed.NewFluentBitFileLogWriter(testbed.DefaultHost, testbed.GetAvailablePort(t))
+
+	Scenario10kItemsPerSecond(
+		t,
+		flw,
+		testbed.NewOTLPDataReceiver(testbed.GetAvailablePort(t)),
+		testbed.ResourceSpec{
+			ExpectedMaxCPU: 50,
+			ExpectedMaxRAM: 75,
+		},
+		performanceResultsSummary,
+		nil,
+		flw.Extensions(),
+	)
+
+}

--- a/testbed/tests/metric_test.go
+++ b/testbed/tests/metric_test.go
@@ -81,6 +81,7 @@ func TestMetric10kDPS(t *testing.T) {
 				test.resourceSpec,
 				performanceResultsSummary,
 				nil,
+				nil,
 			)
 		})
 	}

--- a/testbed/tests/resource_processor_test.go
+++ b/testbed/tests/resource_processor_test.go
@@ -235,7 +235,7 @@ func TestMetricResourceProcessor(t *testing.T) {
 			processors := map[string]string{
 				"resource": test.resourceProcessorConfig,
 			}
-			configStr := createConfigYaml(t, sender, receiver, resultDir, processors)
+			configStr := createConfigYaml(t, sender, receiver, resultDir, processors, nil)
 			configCleanup, err := agentProc.PrepareConfig(configStr)
 			require.NoError(t, err)
 			defer configCleanup()

--- a/testbed/tests/trace_test.go
+++ b/testbed/tests/trace_test.go
@@ -99,6 +99,7 @@ func TestTrace10kSPS(t *testing.T) {
 				test.resourceSpec,
 				performanceResultsSummary,
 				processors,
+				nil,
 			)
 		})
 	}
@@ -405,7 +406,7 @@ func TestTraceAttributesProcessor(t *testing.T) {
 			}
 
 			agentProc := &testbed.ChildProcess{}
-			configStr := createConfigYaml(t, test.sender, test.receiver, resultDir, processors)
+			configStr := createConfigYaml(t, test.sender, test.receiver, resultDir, processors, nil)
 			configCleanup, err := agentProc.PrepareConfig(configStr)
 			require.NoError(t, err)
 			defer configCleanup()


### PR DESCRIPTION
This adds a simple 10k logs per second performance test that currently
passes with a fairly low bar.

This also involves adding support for logs to the otlpreceiver since it
is used to receive the logs by the mock backend.

Also expanding the receiverhelper to supportlog receiver factories.

