### PR TITLE
Added disk.pending_operations metric

### DIFF
--- a/receiver/hostmetricsreceiver/hostmetrics_receiver_test.go
+++ b/receiver/hostmetricsreceiver/hostmetrics_receiver_test.go
@@ -47,6 +47,7 @@ var standardMetrics = []string{
 	"system.memory.usage",
 	"system.disk.io",
 	"system.disk.ops",
+	"system.disk.pending_operations",
 	"system.disk.time",
 	"system.filesystem.usage",
 	"system.cpu.load_average.1m",

--- a/receiver/hostmetricsreceiver/hostmetrics_receiver_test.go
+++ b/receiver/hostmetricsreceiver/hostmetrics_receiver_test.go
@@ -73,7 +73,6 @@ var systemSpecificMetrics = map[string][]string{
 	"freebsd": {"system.filesystem.inodes.usage", "system.processes.running", "system.processes.blocked", "system.swap.page_faults"},
 	"openbsd": {"system.filesystem.inodes.usage", "system.processes.running", "system.processes.blocked", "system.swap.page_faults"},
 	"solaris": {"system.filesystem.inodes.usage", "system.swap.page_faults"},
-	"windows": {"system.disk.operation_time"},
 }
 
 var factories = map[string]internal.ScraperFactory{

--- a/receiver/hostmetricsreceiver/hostmetrics_receiver_test.go
+++ b/receiver/hostmetricsreceiver/hostmetrics_receiver_test.go
@@ -47,6 +47,7 @@ var standardMetrics = []string{
 	"system.memory.usage",
 	"system.disk.io",
 	"system.disk.ops",
+	"system.disk.time",
 	"system.filesystem.usage",
 	"system.cpu.load_average.1m",
 	"system.cpu.load_average.5m",
@@ -67,11 +68,12 @@ var resourceMetrics = []string{
 }
 
 var systemSpecificMetrics = map[string][]string{
-	"linux":   {"system.disk.merged", "system.disk.time", "system.filesystem.inodes.usage", "system.processes.running", "system.processes.blocked", "system.swap.page_faults"},
-	"darwin":  {"system.disk.time", "system.filesystem.inodes.usage", "system.processes.running", "system.processes.blocked", "system.swap.page_faults"},
-	"freebsd": {"system.disk.time", "system.filesystem.inodes.usage", "system.processes.running", "system.processes.blocked", "system.swap.page_faults"},
-	"openbsd": {"system.disk.time", "system.filesystem.inodes.usage", "system.processes.running", "system.processes.blocked", "system.swap.page_faults"},
-	"solaris": {"system.disk.time", "system.filesystem.inodes.usage", "system.swap.page_faults"},
+	"linux":   {"system.disk.merged", "system.filesystem.inodes.usage", "system.processes.running", "system.processes.blocked", "system.swap.page_faults"},
+	"darwin":  {"system.filesystem.inodes.usage", "system.processes.running", "system.processes.blocked", "system.swap.page_faults"},
+	"freebsd": {"system.filesystem.inodes.usage", "system.processes.running", "system.processes.blocked", "system.swap.page_faults"},
+	"openbsd": {"system.filesystem.inodes.usage", "system.processes.running", "system.processes.blocked", "system.swap.page_faults"},
+	"solaris": {"system.filesystem.inodes.usage", "system.swap.page_faults"},
+	"windows": {"system.disk.operation_time"},
 }
 
 var factories = map[string]internal.ScraperFactory{

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_metadata.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_metadata.go
@@ -64,16 +64,6 @@ var diskTimeDescriptor = func() pdata.MetricDescriptor {
 	return descriptor
 }()
 
-var diskAvgOperationTimeDescriptor = func() pdata.MetricDescriptor {
-	descriptor := pdata.NewMetricDescriptor()
-	descriptor.InitEmpty()
-	descriptor.SetName("system.disk.operation_time")
-	descriptor.SetDescription("Average time an I/O-operation took to complete.")
-	descriptor.SetUnit("s")
-	descriptor.SetType(pdata.MetricTypeDouble)
-	return descriptor
-}()
-
 var diskMergedDescriptor = func() pdata.MetricDescriptor {
 	descriptor := pdata.NewMetricDescriptor()
 	descriptor.InitEmpty()

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_metadata.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_metadata.go
@@ -59,8 +59,18 @@ var diskTimeDescriptor = func() pdata.MetricDescriptor {
 	descriptor.InitEmpty()
 	descriptor.SetName("system.disk.time")
 	descriptor.SetDescription("Time spent in disk operations.")
-	descriptor.SetUnit("ms")
-	descriptor.SetType(pdata.MetricTypeMonotonicInt64)
+	descriptor.SetUnit("s")
+	descriptor.SetType(pdata.MetricTypeMonotonicDouble)
+	return descriptor
+}()
+
+var diskAvgOperationTimeDescriptor = func() pdata.MetricDescriptor {
+	descriptor := pdata.NewMetricDescriptor()
+	descriptor.InitEmpty()
+	descriptor.SetName("system.disk.operation_time")
+	descriptor.SetDescription("Average time an I/O-operation took to complete.")
+	descriptor.SetUnit("s")
+	descriptor.SetType(pdata.MetricTypeDouble)
 	return descriptor
 }()
 

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_metadata.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_metadata.go
@@ -64,6 +64,16 @@ var diskTimeDescriptor = func() pdata.MetricDescriptor {
 	return descriptor
 }()
 
+var diskPendingOperationsDescriptor = func() pdata.MetricDescriptor {
+	descriptor := pdata.NewMetricDescriptor()
+	descriptor.InitEmpty()
+	descriptor.SetName("system.disk.pending_operations")
+	descriptor.SetDescription("The queue size of pending I/O operations. On Windows, this is the average queue size over the collection interval.")
+	descriptor.SetUnit("1")
+	descriptor.SetType(pdata.MetricTypeInt64)
+	return descriptor
+}()
+
 var diskMergedDescriptor = func() pdata.MetricDescriptor {
 	descriptor := pdata.NewMetricDescriptor()
 	descriptor.InitEmpty()

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_others.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_others.go
@@ -110,8 +110,8 @@ func initializeDiskIOMetric(metric pdata.Metric, startTime pdata.TimestampUnixNa
 
 	idx := 0
 	for device, ioCounter := range ioCounters {
-		initializeDataPoint(idps.At(idx+0), startTime, device, readDirectionLabelValue, int64(ioCounter.ReadBytes))
-		initializeDataPoint(idps.At(idx+1), startTime, device, writeDirectionLabelValue, int64(ioCounter.WriteBytes))
+		initializeInt64DataPoint(idps.At(idx+0), startTime, device, readDirectionLabelValue, int64(ioCounter.ReadBytes))
+		initializeInt64DataPoint(idps.At(idx+1), startTime, device, writeDirectionLabelValue, int64(ioCounter.WriteBytes))
 		idx += 2
 	}
 }
@@ -124,8 +124,8 @@ func initializeDiskOpsMetric(metric pdata.Metric, startTime pdata.TimestampUnixN
 
 	idx := 0
 	for device, ioCounter := range ioCounters {
-		initializeDataPoint(idps.At(idx+0), startTime, device, readDirectionLabelValue, int64(ioCounter.ReadCount))
-		initializeDataPoint(idps.At(idx+1), startTime, device, writeDirectionLabelValue, int64(ioCounter.WriteCount))
+		initializeInt64DataPoint(idps.At(idx+0), startTime, device, readDirectionLabelValue, int64(ioCounter.ReadCount))
+		initializeInt64DataPoint(idps.At(idx+1), startTime, device, writeDirectionLabelValue, int64(ioCounter.WriteCount))
 		idx += 2
 	}
 }
@@ -138,13 +138,22 @@ func initializeDiskTimeMetric(metric pdata.Metric, startTime pdata.TimestampUnix
 
 	idx := 0
 	for device, ioCounter := range ioCounters {
-		initializeDataPoint(idps.At(idx+0), startTime, device, readDirectionLabelValue, int64(ioCounter.ReadTime))
-		initializeDataPoint(idps.At(idx+1), startTime, device, writeDirectionLabelValue, int64(ioCounter.WriteTime))
+		initializeDoubleDataPoint(idps.At(idx+0), startTime, device, readDirectionLabelValue, float64(ioCounter.ReadTime)/1e3)
+		initializeDoubleDataPoint(idps.At(idx+1), startTime, device, writeDirectionLabelValue, float64(ioCounter.WriteTime)1e3)
 		idx += 2
 	}
 }
 
-func initializeDataPoint(dataPoint pdata.Int64DataPoint, startTime pdata.TimestampUnixNano, deviceLabel string, directionLabel string, value int64) {
+func initializeInt64DataPoint(dataPoint pdata.Int64DataPoint, startTime pdata.TimestampUnixNano, deviceLabel string, directionLabel string, value int64) {
+	labelsMap := dataPoint.LabelsMap()
+	labelsMap.Insert(deviceLabelName, deviceLabel)
+	labelsMap.Insert(directionLabelName, directionLabel)
+	dataPoint.SetStartTime(startTime)
+	dataPoint.SetTimestamp(pdata.TimestampUnixNano(uint64(time.Now().UnixNano())))
+	dataPoint.SetValue(value)
+}
+
+func initializeDoubleDataPoint(dataPoint pdata.Int64DataPoint, startTime pdata.TimestampUnixNano, deviceLabel string, directionLabel string, value float64) {
 	labelsMap := dataPoint.LabelsMap()
 	labelsMap.Insert(deviceLabelName, deviceLabel)
 	labelsMap.Insert(directionLabelName, directionLabel)

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_others.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_others.go
@@ -133,13 +133,13 @@ func initializeDiskOpsMetric(metric pdata.Metric, startTime pdata.TimestampUnixN
 func initializeDiskTimeMetric(metric pdata.Metric, startTime pdata.TimestampUnixNano, ioCounters map[string]disk.IOCountersStat) {
 	diskTimeDescriptor.CopyTo(metric.MetricDescriptor())
 
-	idps := metric.Int64DataPoints()
-	idps.Resize(2 * len(ioCounters))
+	ddps := metric.DoubleDataPoints()
+	ddps.Resize(2 * len(ioCounters))
 
 	idx := 0
 	for device, ioCounter := range ioCounters {
-		initializeDoubleDataPoint(idps.At(idx+0), startTime, device, readDirectionLabelValue, float64(ioCounter.ReadTime)/1e3)
-		initializeDoubleDataPoint(idps.At(idx+1), startTime, device, writeDirectionLabelValue, float64(ioCounter.WriteTime)1e3)
+		initializeDoubleDataPoint(ddps.At(idx+0), startTime, device, readDirectionLabelValue, float64(ioCounter.ReadTime)/1e3)
+		initializeDoubleDataPoint(ddps.At(idx+1), startTime, device, writeDirectionLabelValue, float64(ioCounter.WriteTime)/1e3)
 		idx += 2
 	}
 }
@@ -153,7 +153,7 @@ func initializeInt64DataPoint(dataPoint pdata.Int64DataPoint, startTime pdata.Ti
 	dataPoint.SetValue(value)
 }
 
-func initializeDoubleDataPoint(dataPoint pdata.Int64DataPoint, startTime pdata.TimestampUnixNano, deviceLabel string, directionLabel string, value float64) {
+func initializeDoubleDataPoint(dataPoint pdata.DoubleDataPoint, startTime pdata.TimestampUnixNano, deviceLabel string, directionLabel string, value float64) {
 	labelsMap := dataPoint.LabelsMap()
 	labelsMap.Insert(deviceLabelName, deviceLabel)
 	labelsMap.Insert(directionLabelName, directionLabel)

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_others_linux.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_others_linux.go
@@ -33,8 +33,8 @@ func appendSystemSpecificMetrics(metrics pdata.MetricSlice, startIdx int, startT
 
 	idx := 0
 	for device, ioCounter := range ioCounters {
-		initializeDataPoint(idps.At(idx+0), startTime, device, readDirectionLabelValue, int64(ioCounter.MergedReadCount))
-		initializeDataPoint(idps.At(idx+1), startTime, device, writeDirectionLabelValue, int64(ioCounter.MergedWriteCount))
+		initializeInt64DataPoint(idps.At(idx+0), startTime, device, readDirectionLabelValue, int64(ioCounter.MergedReadCount))
+		initializeInt64DataPoint(idps.At(idx+1), startTime, device, writeDirectionLabelValue, int64(ioCounter.MergedWriteCount))
 		idx += 2
 	}
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_others_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_others_test.go
@@ -88,9 +88,10 @@ func TestScrapeMetrics_Others(t *testing.T) {
 			assertInt64DiskMetricValid(t, metrics.At(0), diskIODescriptor, test.expectedStartTime)
 			assertInt64DiskMetricValid(t, metrics.At(1), diskOpsDescriptor, test.expectedStartTime)
 			assertDoubleDiskMetricValid(t, metrics.At(2), diskTimeDescriptor, test.expectedStartTime)
+			assertDiskPendingOperationsMetricValid(t, metrics.At(3))
 
 			if runtime.GOOS == "linux" {
-				assertInt64DiskMetricValid(t, metrics.At(3), diskMergedDescriptor, test.expectedStartTime)
+				assertInt64DiskMetricValid(t, metrics.At(4), diskMergedDescriptor, test.expectedStartTime)
 			}
 		})
 	}

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_others_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_others_test.go
@@ -85,12 +85,12 @@ func TestScrapeMetrics_Others(t *testing.T) {
 
 			require.NoError(t, err, "Failed to scrape metrics: %v", err)
 
-			assertDiskMetricValid(t, metrics.At(0), diskIODescriptor, test.expectedStartTime)
-			assertDiskMetricValid(t, metrics.At(1), diskOpsDescriptor, test.expectedStartTime)
-			assertDiskMetricValid(t, metrics.At(2), diskTimeDescriptor, test.expectedStartTime)
+			assertInt64DiskMetricValid(t, metrics.At(0), diskIODescriptor, test.expectedStartTime)
+			assertInt64DiskMetricValid(t, metrics.At(1), diskOpsDescriptor, test.expectedStartTime)
+			assertDoubleDiskMetricValid(t, metrics.At(2), diskTimeDescriptor, test.expectedStartTime)
 
 			if runtime.GOOS == "linux" {
-				assertDiskMetricValid(t, metrics.At(3), diskMergedDescriptor, test.expectedStartTime)
+				assertInt64DiskMetricValid(t, metrics.At(3), diskMergedDescriptor, test.expectedStartTime)
 			}
 		})
 	}

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_test.go
@@ -79,14 +79,15 @@ func TestScrapeMetrics(t *testing.T) {
 				return
 			}
 
-			assert.GreaterOrEqual(t, metrics.Len(), 3)
+			assert.GreaterOrEqual(t, metrics.Len(), 4)
 
 			assertInt64DiskMetricValid(t, metrics.At(0), diskIODescriptor, 0)
 			assertInt64DiskMetricValid(t, metrics.At(1), diskOpsDescriptor, 0)
 			assertDoubleDiskMetricValid(t, metrics.At(2), diskTimeDescriptor, 0)
+			assertDiskPendingOperationsMetricValid(t, metrics.At(3))
 
 			if runtime.GOOS == "linux" {
-				assertInt64DiskMetricValid(t, metrics.At(3), diskMergedDescriptor, 0)
+				assertInt64DiskMetricValid(t, metrics.At(4), diskMergedDescriptor, 0)
 			}
 		})
 	}
@@ -98,6 +99,7 @@ func assertInt64DiskMetricValid(t *testing.T, metric pdata.Metric, expectedDescr
 		internal.AssertInt64MetricStartTimeEquals(t, metric, startTime)
 	}
 	assert.GreaterOrEqual(t, metric.Int64DataPoints().Len(), 2)
+	internal.AssertInt64MetricLabelExists(t, metric, 0, deviceLabelName)
 	internal.AssertInt64MetricLabelHasValue(t, metric, 0, directionLabelName, readDirectionLabelValue)
 	internal.AssertInt64MetricLabelHasValue(t, metric, 1, directionLabelName, writeDirectionLabelValue)
 }
@@ -108,6 +110,13 @@ func assertDoubleDiskMetricValid(t *testing.T, metric pdata.Metric, expectedDesc
 		internal.AssertInt64MetricStartTimeEquals(t, metric, startTime)
 	}
 	assert.GreaterOrEqual(t, metric.DoubleDataPoints().Len(), 2)
+	internal.AssertDoubleMetricLabelExists(t, metric, 0, deviceLabelName)
 	internal.AssertDoubleMetricLabelHasValue(t, metric, 0, directionLabelName, readDirectionLabelValue)
 	internal.AssertDoubleMetricLabelHasValue(t, metric, metric.DoubleDataPoints().Len()-1, directionLabelName, writeDirectionLabelValue)
+}
+
+func assertDiskPendingOperationsMetricValid(t *testing.T, metric pdata.Metric) {
+	internal.AssertDescriptorEqual(t, diskPendingOperationsDescriptor, metric.MetricDescriptor())
+	assert.GreaterOrEqual(t, metric.Int64DataPoints().Len(), 1)
+	internal.AssertInt64MetricLabelExists(t, metric, 0, deviceLabelName)
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_test.go
@@ -85,10 +85,6 @@ func TestScrapeMetrics(t *testing.T) {
 			assertInt64DiskMetricValid(t, metrics.At(1), diskOpsDescriptor, 0)
 			assertDoubleDiskMetricValid(t, metrics.At(2), diskTimeDescriptor, 0)
 
-			if runtime.GOOS == "windows" {
-				assertDoubleDiskMetricValid(t, metrics.At(3), diskAvgOperationTimeDescriptor, 0)
-			}
-
 			if runtime.GOOS == "linux" {
 				assertInt64DiskMetricValid(t, metrics.At(3), diskMergedDescriptor, 0)
 			}

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_test.go
@@ -79,23 +79,24 @@ func TestScrapeMetrics(t *testing.T) {
 				return
 			}
 
-			assert.GreaterOrEqual(t, metrics.Len(), 2)
+			assert.GreaterOrEqual(t, metrics.Len(), 3)
 
-			assertDiskMetricValid(t, metrics.At(0), diskIODescriptor, 0)
-			assertDiskMetricValid(t, metrics.At(1), diskOpsDescriptor, 0)
+			assertInt64DiskMetricValid(t, metrics.At(0), diskIODescriptor, 0)
+			assertInt64DiskMetricValid(t, metrics.At(1), diskOpsDescriptor, 0)
+			assertDoubleDiskMetricValid(t, metrics.At(2), diskTimeDescriptor, 0)
 
-			if runtime.GOOS != "windows" {
-				assertDiskMetricValid(t, metrics.At(2), diskTimeDescriptor, 0)
+			if runtime.GOOS == "windows" {
+				assertDoubleDiskMetricValid(t, metrics.At(3), diskAvgOperationTimeDescriptor, 0)
 			}
 
 			if runtime.GOOS == "linux" {
-				assertDiskMetricValid(t, metrics.At(3), diskMergedDescriptor, 0)
+				assertInt64DiskMetricValid(t, metrics.At(3), diskMergedDescriptor, 0)
 			}
 		})
 	}
 }
 
-func assertDiskMetricValid(t *testing.T, metric pdata.Metric, expectedDescriptor pdata.MetricDescriptor, startTime pdata.TimestampUnixNano) {
+func assertInt64DiskMetricValid(t *testing.T, metric pdata.Metric, expectedDescriptor pdata.MetricDescriptor, startTime pdata.TimestampUnixNano) {
 	internal.AssertDescriptorEqual(t, expectedDescriptor, metric.MetricDescriptor())
 	if startTime != 0 {
 		internal.AssertInt64MetricStartTimeEquals(t, metric, startTime)
@@ -103,4 +104,14 @@ func assertDiskMetricValid(t *testing.T, metric pdata.Metric, expectedDescriptor
 	assert.GreaterOrEqual(t, metric.Int64DataPoints().Len(), 2)
 	internal.AssertInt64MetricLabelHasValue(t, metric, 0, directionLabelName, readDirectionLabelValue)
 	internal.AssertInt64MetricLabelHasValue(t, metric, 1, directionLabelName, writeDirectionLabelValue)
+}
+
+func assertDoubleDiskMetricValid(t *testing.T, metric pdata.Metric, expectedDescriptor pdata.MetricDescriptor, startTime pdata.TimestampUnixNano) {
+	internal.AssertDescriptorEqual(t, expectedDescriptor, metric.MetricDescriptor())
+	if startTime != 0 {
+		internal.AssertInt64MetricStartTimeEquals(t, metric, startTime)
+	}
+	assert.GreaterOrEqual(t, metric.DoubleDataPoints().Len(), 2)
+	internal.AssertDoubleMetricLabelHasValue(t, metric, 0, directionLabelName, readDirectionLabelValue)
+	internal.AssertDoubleMetricLabelHasValue(t, metric, metric.DoubleDataPoints().Len()-1, directionLabelName, writeDirectionLabelValue)
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_windows.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_windows.go
@@ -23,14 +23,22 @@ import (
 	"go.opentelemetry.io/collector/component/componenterror"
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/internal/processor/filterset"
+	"go.opentelemetry.io/collector/receiver/hostmetricsreceiver/internal/third_party/telegraf/win_perf_counters"
 	"go.opentelemetry.io/collector/receiver/hostmetricsreceiver/internal/windows/pdh"
 )
 
 const (
-	logicalDiskReadsPerSecPath      = `\LogicalDisk(*)\Disk Reads/sec`
-	logicalDiskWritesPerSecPath     = `\LogicalDisk(*)\Disk Writes/sec`
+	logicalDiskReadsPerSecPath  = `\LogicalDisk(*)\Disk Reads/sec`
+	logicalDiskWritesPerSecPath = `\LogicalDisk(*)\Disk Writes/sec`
+
 	logicalDiskReadBytesPerSecPath  = `\LogicalDisk(*)\Disk Read Bytes/sec`
 	logicalDiskWriteBytesPerSecPath = `\LogicalDisk(*)\Disk Write Bytes/sec`
+
+	logicalAvgDiskSecsPerReadPath  = `\LogicalDisk(*)\Avg. Disk sec/Read`
+	logicalAvgDiskSecsPerWritePath = `\LogicalDisk(*)\Avg. Disk sec/Write`
+
+	// TODO
+	// logicalAvgDiskQueueLengthPath = `\LogicalDisk(*)\Avg. Disk Queue Length`
 )
 
 // scraper for Disk Metrics
@@ -46,8 +54,12 @@ type scraper struct {
 	diskReadsPerSecCounter      pdh.PerfCounterScraper
 	diskWritesPerSecCounter     pdh.PerfCounterScraper
 
-	cumulativeDiskIO  cumulativeDiskValues
-	cumulativeDiskOps cumulativeDiskValues
+	avgDiskSecsPerReadCounter  pdh.PerfCounterScraper
+	avgDiskSecsPerWriteCounter pdh.PerfCounterScraper
+
+	cumulativeDiskIO   cumulativeDiskValues
+	cumulativeDiskOps  cumulativeDiskValues
+	cumulativeDiskTime cumulativeDiskValues
 }
 
 type cumulativeDiskValues map[string]*value
@@ -70,9 +82,10 @@ type value struct {
 // newDiskScraper creates a Disk Scraper
 func newDiskScraper(_ context.Context, cfg *Config) (*scraper, error) {
 	scraper := &scraper{
-		config:            cfg,
-		cumulativeDiskIO:  map[string]*value{},
-		cumulativeDiskOps: map[string]*value{},
+		config:             cfg,
+		cumulativeDiskIO:   map[string]*value{},
+		cumulativeDiskOps:  map[string]*value{},
+		cumulativeDiskTime: map[string]*value{},
 	}
 
 	var err error
@@ -121,6 +134,16 @@ func (s *scraper) Initialize(_ context.Context) error {
 		return err
 	}
 
+	s.avgDiskSecsPerReadCounter, err = pdh.NewPerfCounter(logicalAvgDiskSecsPerReadPath, true)
+	if err != nil {
+		return err
+	}
+
+	s.avgDiskSecsPerWriteCounter, err = pdh.NewPerfCounter(logicalAvgDiskSecsPerWritePath, true)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -148,6 +171,18 @@ func (s *scraper) Close(_ context.Context) error {
 
 	if s.diskWritesPerSecCounter != nil && !reflect.ValueOf(s.diskWritesPerSecCounter).IsNil() {
 		if err := s.diskWritesPerSecCounter.Close(); err != nil {
+			errors = append(errors, err)
+		}
+	}
+
+	if s.avgDiskSecsPerReadCounter != nil && !reflect.ValueOf(s.avgDiskSecsPerReadCounter).IsNil() {
+		if err := s.avgDiskSecsPerReadCounter.Close(); err != nil {
+			errors = append(errors, err)
+		}
+	}
+
+	if s.avgDiskSecsPerWriteCounter != nil && !reflect.ValueOf(s.avgDiskSecsPerWriteCounter).IsNil() {
+		if err := s.avgDiskSecsPerWriteCounter.Close(); err != nil {
 			errors = append(errors, err)
 		}
 	}
@@ -211,22 +246,8 @@ func (s *scraper) scrapeAndAppendDiskIOMetric(metrics pdata.MetricSlice, duratio
 
 	idx := metrics.Len()
 	metrics.Resize(idx + 1)
-	initializeDiskIOMetric(metrics.At(idx), s.startTime, s.cumulativeDiskIO)
+	initializeDiskCumulativeInt64Metric(metrics.At(idx), diskIODescriptor, s.startTime, s.cumulativeDiskIO)
 	return nil
-}
-
-func initializeDiskIOMetric(metric pdata.Metric, startTime pdata.TimestampUnixNano, io cumulativeDiskValues) {
-	diskIODescriptor.CopyTo(metric.MetricDescriptor())
-
-	idps := metric.Int64DataPoints()
-	idps.Resize(2 * len(io))
-
-	idx := 0
-	for device, value := range io {
-		initializeDataPoint(idps.At(idx+0), startTime, device, readDirectionLabelValue, int64(value.read))
-		initializeDataPoint(idps.At(idx+1), startTime, device, writeDirectionLabelValue, int64(value.write))
-		idx += 2
-	}
 }
 
 func (s *scraper) scrapeAndAppendDiskOpsMetric(metrics pdata.MetricSlice, durationSinceLastScraped float64) error {
@@ -240,43 +261,124 @@ func (s *scraper) scrapeAndAppendDiskOpsMetric(metrics pdata.MetricSlice, durati
 		return err
 	}
 
+	avgDiskSecsPerReadValues, err := s.avgDiskSecsPerReadCounter.ScrapeData()
+	if err != nil {
+		return err
+	}
+	avgDiskSecsPerReadMap := toMap(avgDiskSecsPerReadValues)
+
+	avgDiskSecsPerWriteValues, err := s.avgDiskSecsPerWriteCounter.ScrapeData()
+	if err != nil {
+		return err
+	}
+	avgDiskSecsPerWriteMap := toMap(avgDiskSecsPerWriteValues)
+
 	for _, diskReadsPerSec := range diskReadsPerSecValues {
-		if s.includeDevice(diskReadsPerSec.InstanceName) {
-			s.cumulativeDiskOps.getOrAdd(diskReadsPerSec.InstanceName).read += (diskReadsPerSec.Value * durationSinceLastScraped)
+		device := diskReadsPerSec.InstanceName
+		if !s.includeDevice(device) {
+			delete(avgDiskSecsPerReadMap, device)
+			continue
+		}
+
+		s.cumulativeDiskOps.getOrAdd(device).read += (diskReadsPerSec.Value * durationSinceLastScraped)
+		if avgDiskSecsPerRead, ok := avgDiskSecsPerReadMap[device]; ok {
+			s.cumulativeDiskTime.getOrAdd(device).read += (diskReadsPerSec.Value * avgDiskSecsPerRead)
 		}
 	}
 
 	for _, diskWritesPerSec := range diskWritesPerSecValues {
-		if s.includeDevice(diskWritesPerSec.InstanceName) {
-			s.cumulativeDiskOps.getOrAdd(diskWritesPerSec.InstanceName).write += (diskWritesPerSec.Value * durationSinceLastScraped)
+		device := diskWritesPerSec.InstanceName
+		if !s.includeDevice(device) {
+			delete(avgDiskSecsPerWriteMap, device)
+			continue
+		}
+
+		s.cumulativeDiskOps.getOrAdd(device).write += (diskWritesPerSec.Value * durationSinceLastScraped)
+		if avgDiskSecsPerWrite, ok := avgDiskSecsPerWriteMap[device]; ok {
+			s.cumulativeDiskTime.getOrAdd(device).write += (diskWritesPerSec.Value * avgDiskSecsPerWrite)
 		}
 	}
 
-	if len(s.cumulativeDiskIO) == 0 {
-		return nil
+	idx := metrics.Len()
+
+	if len(s.cumulativeDiskIO) > 0 {
+		metrics.Resize(idx + 1)
+		initializeDiskCumulativeInt64Metric(metrics.At(idx), diskOpsDescriptor, s.startTime, s.cumulativeDiskOps)
+		idx++
 	}
 
-	idx := metrics.Len()
-	metrics.Resize(idx + 1)
-	initializeDiskOpsMetric(metrics.At(idx), s.startTime, s.cumulativeDiskOps)
+	if len(s.cumulativeDiskTime) > 0 {
+		metrics.Resize(idx + 1)
+		initializeDiskCumulativeDoubleMetric(metrics.At(idx), diskTimeDescriptor, s.startTime, s.cumulativeDiskTime)
+		idx++
+	}
+
+	if len(avgDiskSecsPerReadMap) > 0 || len(avgDiskSecsPerWriteMap) > 0 {
+		metrics.Resize(idx + 1)
+		initializeDiskAvgOperationTimeMetric(metrics.At(idx), s.startTime, avgDiskSecsPerReadMap, avgDiskSecsPerWriteMap)
+		idx++
+	}
+
 	return nil
 }
 
-func initializeDiskOpsMetric(metric pdata.Metric, startTime pdata.TimestampUnixNano, ops cumulativeDiskValues) {
-	diskOpsDescriptor.CopyTo(metric.MetricDescriptor())
+func initializeDiskCumulativeInt64Metric(metric pdata.Metric, descriptor pdata.MetricDescriptor, startTime pdata.TimestampUnixNano, ops cumulativeDiskValues) {
+	descriptor.CopyTo(metric.MetricDescriptor())
 
 	idps := metric.Int64DataPoints()
 	idps.Resize(2 * len(ops))
 
 	idx := 0
 	for device, value := range ops {
-		initializeDataPoint(idps.At(idx+0), startTime, device, readDirectionLabelValue, int64(value.read))
-		initializeDataPoint(idps.At(idx+1), startTime, device, writeDirectionLabelValue, int64(value.write))
+		initializeInt64DataPoint(idps.At(idx+0), startTime, device, readDirectionLabelValue, int64(value.read))
+		initializeInt64DataPoint(idps.At(idx+1), startTime, device, writeDirectionLabelValue, int64(value.write))
 		idx += 2
 	}
 }
 
-func initializeDataPoint(dataPoint pdata.Int64DataPoint, startTime pdata.TimestampUnixNano, deviceLabel string, directionLabel string, value int64) {
+func initializeDiskCumulativeDoubleMetric(metric pdata.Metric, descriptor pdata.MetricDescriptor, startTime pdata.TimestampUnixNano, ops cumulativeDiskValues) {
+	descriptor.CopyTo(metric.MetricDescriptor())
+
+	ddps := metric.DoubleDataPoints()
+	ddps.Resize(2 * len(ops))
+
+	idx := 0
+	for device, value := range ops {
+		initializeDoubleDataPoint(ddps.At(idx+0), startTime, device, readDirectionLabelValue, value.read)
+		initializeDoubleDataPoint(ddps.At(idx+1), startTime, device, writeDirectionLabelValue, value.write)
+		idx += 2
+	}
+}
+
+func initializeDiskAvgOperationTimeMetric(metric pdata.Metric, startTime pdata.TimestampUnixNano, avgSecsPerReadValues map[string]float64, avgSecsPerWriteValues map[string]float64) {
+	diskAvgOperationTimeDescriptor.CopyTo(metric.MetricDescriptor())
+
+	ddps := metric.DoubleDataPoints()
+	ddps.Resize(len(avgSecsPerReadValues) + len(avgSecsPerWriteValues))
+
+	idx := 0
+
+	for device, value := range avgSecsPerReadValues {
+		initializeDoubleDataPoint(ddps.At(idx), startTime, device, readDirectionLabelValue, value)
+		idx++
+	}
+
+	for device, value := range avgSecsPerWriteValues {
+		initializeDoubleDataPoint(ddps.At(idx), startTime, device, writeDirectionLabelValue, value)
+		idx++
+	}
+}
+
+func initializeInt64DataPoint(dataPoint pdata.Int64DataPoint, startTime pdata.TimestampUnixNano, deviceLabel string, directionLabel string, value int64) {
+	labelsMap := dataPoint.LabelsMap()
+	labelsMap.Insert(deviceLabelName, deviceLabel)
+	labelsMap.Insert(directionLabelName, directionLabel)
+	dataPoint.SetStartTime(startTime)
+	dataPoint.SetTimestamp(pdata.TimestampUnixNano(uint64(time.Now().UnixNano())))
+	dataPoint.SetValue(value)
+}
+
+func initializeDoubleDataPoint(dataPoint pdata.DoubleDataPoint, startTime pdata.TimestampUnixNano, deviceLabel string, directionLabel string, value float64) {
 	labelsMap := dataPoint.LabelsMap()
 	labelsMap.Insert(deviceLabelName, deviceLabel)
 	labelsMap.Insert(directionLabelName, directionLabel)
@@ -288,4 +390,12 @@ func initializeDataPoint(dataPoint pdata.Int64DataPoint, startTime pdata.Timesta
 func (s *scraper) includeDevice(deviceName string) bool {
 	return (s.includeFS == nil || s.includeFS.Matches(deviceName)) &&
 		(s.excludeFS == nil || !s.excludeFS.Matches(deviceName))
+}
+
+func toMap(values []win_perf_counters.CounterValue) map[string]float64 {
+	mp := make(map[string]float64, len(values))
+	for _, value := range values {
+		mp[value.InstanceName] = value.Value
+	}
+	return mp
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_windows.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_windows.go
@@ -37,8 +37,7 @@ const (
 	logicalAvgDiskSecsPerReadPath  = `\LogicalDisk(*)\Avg. Disk sec/Read`
 	logicalAvgDiskSecsPerWritePath = `\LogicalDisk(*)\Avg. Disk sec/Write`
 
-	// TODO
-	// logicalAvgDiskQueueLengthPath = `\LogicalDisk(*)\Avg. Disk Queue Length`
+	logicalAvgDiskQueueLengthPath = `\LogicalDisk(*)\Avg. Disk Queue Length`
 )
 
 // scraper for Disk Metrics
@@ -53,9 +52,9 @@ type scraper struct {
 	diskWriteBytesPerSecCounter pdh.PerfCounterScraper
 	diskReadsPerSecCounter      pdh.PerfCounterScraper
 	diskWritesPerSecCounter     pdh.PerfCounterScraper
-
-	avgDiskSecsPerReadCounter  pdh.PerfCounterScraper
-	avgDiskSecsPerWriteCounter pdh.PerfCounterScraper
+	avgDiskSecsPerReadCounter   pdh.PerfCounterScraper
+	avgDiskSecsPerWriteCounter  pdh.PerfCounterScraper
+	avgDiskQueueLengthCounter   pdh.PerfCounterScraper
 
 	cumulativeDiskIO   cumulativeDiskValues
 	cumulativeDiskOps  cumulativeDiskValues
@@ -144,6 +143,11 @@ func (s *scraper) Initialize(_ context.Context) error {
 		return err
 	}
 
+	s.avgDiskQueueLengthCounter, err = pdh.NewPerfCounter(logicalAvgDiskQueueLengthPath, true)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -187,6 +191,12 @@ func (s *scraper) Close(_ context.Context) error {
 		}
 	}
 
+	if s.avgDiskQueueLengthCounter != nil && !reflect.ValueOf(s.avgDiskQueueLengthCounter).IsNil() {
+		if err := s.avgDiskQueueLengthCounter.Close(); err != nil {
+			errors = append(errors, err)
+		}
+	}
+
 	return componenterror.CombineErrors(errors)
 }
 
@@ -206,6 +216,11 @@ func (s *scraper) ScrapeMetrics(_ context.Context) (pdata.MetricSlice, error) {
 	}
 
 	err = s.scrapeAndAppendDiskOpsMetric(metrics, durationSinceLastScraped)
+	if err != nil {
+		errors = append(errors, err)
+	}
+
+	err = s.scrapeAndAppendDiskPendingOperationsMetric(metrics)
 	if err != nil {
 		errors = append(errors, err)
 	}
@@ -316,6 +331,23 @@ func (s *scraper) scrapeAndAppendDiskOpsMetric(metrics pdata.MetricSlice, durati
 	return nil
 }
 
+func (s *scraper) scrapeAndAppendDiskPendingOperationsMetric(metrics pdata.MetricSlice) error {
+	avgDiskQueueLengthValues, err := s.avgDiskQueueLengthCounter.ScrapeData()
+	if err != nil {
+		return err
+	}
+
+	filteredAvgDiskQueueLengthValues := s.filterByDevice(avgDiskQueueLengthValues)
+	if len(filteredAvgDiskQueueLengthValues) == 0 {
+		return nil
+	}
+
+	idx := metrics.Len()
+	metrics.Resize(idx + 1)
+	initializeDiskPendingOperationsMetric(metrics.At(idx), filteredAvgDiskQueueLengthValues)
+	return nil
+}
+
 func initializeDiskInt64Metric(metric pdata.Metric, descriptor pdata.MetricDescriptor, startTime pdata.TimestampUnixNano, ops cumulativeDiskValues) {
 	descriptor.CopyTo(metric.MetricDescriptor())
 
@@ -344,6 +376,17 @@ func initializeDiskDoubleMetric(metric pdata.Metric, descriptor pdata.MetricDesc
 	}
 }
 
+func initializeDiskPendingOperationsMetric(metric pdata.Metric, avgDiskQueueLengthValues []win_perf_counters.CounterValue) {
+	diskPendingOperationsDescriptor.CopyTo(metric.MetricDescriptor())
+
+	idps := metric.Int64DataPoints()
+	idps.Resize(len(avgDiskQueueLengthValues))
+
+	for idx, avgDiskQueueLengthValue := range avgDiskQueueLengthValues {
+		initializeDiskPendingDataPoint(idps.At(idx), avgDiskQueueLengthValue.InstanceName, int64(avgDiskQueueLengthValue.Value))
+	}
+}
+
 func initializeInt64DataPoint(dataPoint pdata.Int64DataPoint, startTime pdata.TimestampUnixNano, deviceLabel string, directionLabel string, value int64) {
 	labelsMap := dataPoint.LabelsMap()
 	labelsMap.Insert(deviceLabelName, deviceLabel)
@@ -360,6 +403,27 @@ func initializeDoubleDataPoint(dataPoint pdata.DoubleDataPoint, startTime pdata.
 	dataPoint.SetStartTime(startTime)
 	dataPoint.SetTimestamp(pdata.TimestampUnixNano(uint64(time.Now().UnixNano())))
 	dataPoint.SetValue(value)
+}
+
+func initializeDiskPendingDataPoint(dataPoint pdata.Int64DataPoint, deviceLabel string, value int64) {
+	labelsMap := dataPoint.LabelsMap()
+	labelsMap.Insert(deviceLabelName, deviceLabel)
+	dataPoint.SetTimestamp(pdata.TimestampUnixNano(uint64(time.Now().UnixNano())))
+	dataPoint.SetValue(value)
+}
+
+func (s *scraper) filterByDevice(values []win_perf_counters.CounterValue) []win_perf_counters.CounterValue {
+	if s.includeFS == nil && s.excludeFS == nil {
+		return values
+	}
+
+	filteredValues := make([]win_perf_counters.CounterValue, 0, len(values))
+	for _, value := range values {
+		if s.includeDevice(value.InstanceName) {
+			filteredValues = append(filteredValues, value)
+		}
+	}
+	return filteredValues
 }
 
 func (s *scraper) includeDevice(deviceName string) bool {

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_windows_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_windows_test.go
@@ -34,6 +34,8 @@ func TestScrapeMetrics_Error(t *testing.T) {
 		diskWriteBytesPerSecCounterReturnValue interface{}
 		diskReadsPerSecCounterReturnValue      interface{}
 		diskWritesPerSecCounterReturnValue     interface{}
+		avgDiskSecsPerReadCounterReturnValue   interface{}
+		avgDiskSecsPerWriteCounterReturnValue  interface{}
 		expectedErr                            string
 	}
 
@@ -58,6 +60,16 @@ func TestScrapeMetrics_Error(t *testing.T) {
 			diskWritesPerSecCounterReturnValue: errors.New("err1"),
 			expectedErr:                        "err1",
 		},
+		{
+			name:                                 "avgSecsPerReadCounterError",
+			avgDiskSecsPerReadCounterReturnValue: errors.New("err1"),
+			expectedErr:                          "err1",
+		},
+		{
+			name:                                  "avgSecsPerReadWriteError",
+			avgDiskSecsPerWriteCounterReturnValue: errors.New("err1"),
+			expectedErr:                           "err1",
+		},
 	}
 
 	for _, test := range testCases {
@@ -73,6 +85,8 @@ func TestScrapeMetrics_Error(t *testing.T) {
 			scraper.diskWriteBytesPerSecCounter = pdh.NewMockPerfCounter(test.diskWriteBytesPerSecCounterReturnValue)
 			scraper.diskReadsPerSecCounter = pdh.NewMockPerfCounter(test.diskReadsPerSecCounterReturnValue)
 			scraper.diskWritesPerSecCounter = pdh.NewMockPerfCounter(test.diskWritesPerSecCounterReturnValue)
+			scraper.avgDiskSecsPerReadCounter = pdh.NewMockPerfCounter(test.avgDiskSecsPerReadCounterReturnValue)
+			scraper.avgDiskSecsPerWriteCounter = pdh.NewMockPerfCounter(test.avgDiskSecsPerWriteCounterReturnValue)
 
 			_, err = scraper.ScrapeMetrics(context.Background())
 			assert.EqualError(t, err, test.expectedErr)

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_windows_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_windows_test.go
@@ -36,6 +36,7 @@ func TestScrapeMetrics_Error(t *testing.T) {
 		diskWritesPerSecCounterReturnValue     interface{}
 		avgDiskSecsPerReadCounterReturnValue   interface{}
 		avgDiskSecsPerWriteCounterReturnValue  interface{}
+		avgDiskQueueLengthCounterReturnValue   interface{}
 		expectedErr                            string
 	}
 
@@ -70,6 +71,11 @@ func TestScrapeMetrics_Error(t *testing.T) {
 			avgDiskSecsPerWriteCounterReturnValue: errors.New("err1"),
 			expectedErr:                           "err1",
 		},
+		{
+			name:                                 "avgDiskQueueLengthError",
+			avgDiskQueueLengthCounterReturnValue: errors.New("err1"),
+			expectedErr:                          "err1",
+		},
 	}
 
 	for _, test := range testCases {
@@ -87,6 +93,7 @@ func TestScrapeMetrics_Error(t *testing.T) {
 			scraper.diskWritesPerSecCounter = pdh.NewMockPerfCounter(test.diskWritesPerSecCounterReturnValue)
 			scraper.avgDiskSecsPerReadCounter = pdh.NewMockPerfCounter(test.avgDiskSecsPerReadCounterReturnValue)
 			scraper.avgDiskSecsPerWriteCounter = pdh.NewMockPerfCounter(test.avgDiskSecsPerWriteCounterReturnValue)
+			scraper.avgDiskQueueLengthCounter = pdh.NewMockPerfCounter(test.avgDiskQueueLengthCounterReturnValue)
 
 			_, err = scraper.ScrapeMetrics(context.Background())
 			assert.EqualError(t, err, test.expectedErr)


### PR DESCRIPTION
To avoid future conflicts, this is branched from https://github.com/open-telemetry/opentelemetry-collector/pull/1408. Please merge that before reviewing this PR.

Adds `disk.pending_operations` metric