### PR TITLE
Fix resource processor for old metrics

### DIFF
--- a/processor/resourceprocessor/resource_processor.go
+++ b/processor/resourceprocessor/resource_processor.go
@@ -54,5 +54,5 @@ func (rp *resourceProcessor) ProcessMetrics(_ context.Context, md pdata.Metrics)
 		}
 		rp.attrProc.Process(resource.Attributes())
 	}
-	return md, nil
+	return pdatautil.MetricsFromInternalMetrics(imd), nil
 }


### PR DESCRIPTION
**Description:** 
Need to wrap metric before sending out from resource processor, wrapping was lost during this change https://github.com/open-telemetry/opentelemetry-collector/commit/afc47961e03ef146922151a7006e9f9c4fbf8efc
