### PR TITLE
Add goweight to circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -241,6 +241,30 @@ workflows:
           filters:
             tags:
               only: /^v[0-9]+\.[0-9]+\.[0-9]+.*/
+      - goweight:
+          requires:
+            - cross-compile
+          name: goweight-otelcol_linux_amd64
+          goos: linux
+          goarch: amd64
+      - goweight:
+          requires:
+            - cross-compile
+          name: goweight-otelcol_linux_arm64
+          goos: linux
+          goarch: arm64
+      - goweight:
+          requires:
+            - cross-compile
+          name: goweight-otelcol_darwin_amd64
+          goos: darwin
+          goarch: amd64
+      - goweight:
+          requires:
+            - cross-compile
+          name: goweight-otelcol_windows_amd64
+          goos: windows
+          goarch: amd64
   contrib-test:
     jobs:
       - setup-environment:
@@ -516,3 +540,44 @@ jobs:
       - persist_to_workspace:
           root: ~/
           paths: project/dist
+
+  goweight:
+    executor: golang
+    parameters:
+      goos:
+        type: enum
+        enum: ["darwin", "linux", "windows"]
+      goarch:
+        type: enum
+        enum: ["amd64", "arm64"]
+    steps:
+      - attach_to_workspace
+      - restore_cache:
+          key: v1-goweight-otelcol-<< parameters.goos >>-<< parameters.goarch >>
+      - run:
+          name: Download latest goweight artifact from master if cache not restored
+          environment:
+            GOOS: << parameters.goos >>
+            GOARCH: << parameters.goarch >>
+          command: |
+            if [[ -s ~/goweight/${CIRCLE_JOB}.json ]]; then
+                echo "${CIRCLE_JOB} cache already restored"
+                exit 0
+            fi
+            bash .circleci/goweight/get-master-goweight.sh || true
+      - run:
+          name: Run goweight for otelcol_<< parameters.goos >>_<< parameters.goarch >>
+          environment:
+            GOOS: << parameters.goos >>
+            GOARCH: << parameters.goarch >>
+          command: bash .circleci/goweight/run-goweight.sh
+      - store_artifacts:
+          path: ~/goweight
+      - when:
+          condition:
+            equal: [master, << pipeline.git.branch >>]
+          steps:
+            - save_cache:
+                key: v1-goweight-otelcol-<< parameters.goos >>-<< parameters.goarch >>
+                paths:
+                  - ~/goweight

--- a/.circleci/goweight/get-master-goweight.sh
+++ b/.circleci/goweight/get-master-goweight.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -exuo pipefail
+
+CIRCLE_PROJECT_USERNAME="${CIRCLE_PROJECT_USERNAME:-open-telemetry}"
+CIRCLE_PROJECT="${CIRCLE_PROJECT:-opentelemetry-collector}"
+GOOS="${GOOS:-linux}"
+GOARCH="${GOARCH:-amd64}"
+CIRCLE_JOB="${CIRCLE_JOB:-goweight-otelcol_${GOOS}_${GOARCH}}"
+API_URL="https://circleci.com/api/v1.1/project/github/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT}"
+
+max_offset=1000
+offset=0
+build_num=""
+while [[ -z "$build_num" || "$build_num" = "null" ]] && [[ $offset -le $max_offset ]]; do
+    build_num=$( curl -s "${API_URL}?filter=successful&limit=100&offset=${offset}" | jq -r "[.[] | select(.branch == \"master\" and .workflows.job_name == \"$CIRCLE_JOB\")][0] | .build_num" )
+    (( offset += 100 ))
+    sleep 2
+done
+
+if [[ -z "$build_num" || "$build_num" = "null" ]]; then
+    echo "Unable to get latest build number for master branch job $CIRCLE_JOB from last $max_offset builds"
+    exit 0
+fi
+
+url=$( curl -s "${API_URL}/${build_num}/artifacts" | jq -r '.[0] | .url' )
+if [[ -z "$url" || "$url" = "null" ]]; then
+    echo "Unable to get artifact url for build $build_num"
+    exit 0
+fi
+
+mkdir -p ~/goweight
+curl -sSL "$url" > ~/goweight/${CIRCLE_JOB}.json || true

--- a/.circleci/goweight/run-goweight.sh
+++ b/.circleci/goweight/run-goweight.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+GOOS="${GOOS:-linux}"
+GOARCH="${GOARCH:-amd64}"
+CIRCLE_JOB="${CIRCLE_JOB:-goweight-otelcol_${GOOS}_${GOARCH}}"
+OTELCOL_BIN="otelcol_${GOOS}_${GOARCH}"
+if [[ "$GOOS" = "windows" ]]; then
+    OTELCOL_BIN="${OTELCOL_BIN}.exe"
+fi
+
+mkdir -p ~/goweight
+goweight --json ./cmd/otelcol | jq . > ${CIRCLE_JOB}.json
+
+# add otelcol binary size to goweight results
+otelcol_size=$( du -b bin/${OTELCOL_BIN} | cut -f1 )
+otelcol_size_human=$( du -h bin/${OTELCOL_BIN} | cut -f1 )
+cat ${CIRCLE_JOB}.json | jq ". + [{\"path\": \"${OTELCOL_BIN}\", \"name\": \"${OTELCOL_BIN}\", \"size\": $otelcol_size, \"size_human\": \"$otelcol_size_human\"}]" | tee ~/goweight/${CIRCLE_JOB}.json

--- a/Makefile
+++ b/Makefile
@@ -153,6 +153,7 @@ install-tools:
 	go install github.com/securego/gosec/cmd/gosec
 	go install github.com/tcnksm/ghr
 	go install honnef.co/go/tools/cmd/staticcheck
+	go install github.com/jondot/goweight
 
 .PHONY: otelcol
 otelcol:


### PR DESCRIPTION
For https://github.com/open-telemetry/opentelemetry-collector/issues/1415

- Adds new circleci jobs to calculate goweight for the different GOOS/GOARCH builds (including the `otelcol` binaries).
- Each job will produce a json report that will be archived.  Master jobs will also cache reports that can later be restored and  used as a baseline for build sizes that PRs can compare with.
- TODO: Need to determine threshold for PR build sizes and how to notify contributors if the sizes exceed the threshold.