### PR TITLE
Add disk.pending_operations metric

### DIFF
--- a/receiver/hostmetricsreceiver/hostmetrics_receiver_test.go
+++ b/receiver/hostmetricsreceiver/hostmetrics_receiver_test.go
@@ -47,6 +47,7 @@ var standardMetrics = []string{
 	"system.memory.usage",
 	"system.disk.io",
 	"system.disk.ops",
+	"system.disk.pending_operations",
 	"system.disk.time",
 	"system.filesystem.usage",
 	"system.cpu.load_average.1m",

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_metadata.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_metadata.go
@@ -64,6 +64,16 @@ var diskTimeDescriptor = func() pdata.MetricDescriptor {
 	return descriptor
 }()
 
+var diskPendingOperationsDescriptor = func() pdata.MetricDescriptor {
+	descriptor := pdata.NewMetricDescriptor()
+	descriptor.InitEmpty()
+	descriptor.SetName("system.disk.pending_operations")
+	descriptor.SetDescription("The queue size of pending I/O operations.")
+	descriptor.SetUnit("1")
+	descriptor.SetType(pdata.MetricTypeInt64)
+	return descriptor
+}()
+
 var diskMergedDescriptor = func() pdata.MetricDescriptor {
 	descriptor := pdata.NewMetricDescriptor()
 	descriptor.InitEmpty()

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_others_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_others_test.go
@@ -88,9 +88,10 @@ func TestScrapeMetrics_Others(t *testing.T) {
 			assertInt64DiskMetricValid(t, metrics.At(0), diskIODescriptor, test.expectedStartTime)
 			assertInt64DiskMetricValid(t, metrics.At(1), diskOpsDescriptor, test.expectedStartTime)
 			assertDoubleDiskMetricValid(t, metrics.At(2), diskTimeDescriptor, test.expectedStartTime)
+			assertDiskPendingOperationsMetricValid(t, metrics.At(3))
 
 			if runtime.GOOS == "linux" {
-				assertInt64DiskMetricValid(t, metrics.At(3), diskMergedDescriptor, test.expectedStartTime)
+				assertInt64DiskMetricValid(t, metrics.At(4), diskMergedDescriptor, test.expectedStartTime)
 			}
 		})
 	}

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_test.go
@@ -79,14 +79,15 @@ func TestScrapeMetrics(t *testing.T) {
 				return
 			}
 
-			assert.GreaterOrEqual(t, metrics.Len(), 3)
+			assert.GreaterOrEqual(t, metrics.Len(), 4)
 
 			assertInt64DiskMetricValid(t, metrics.At(0), diskIODescriptor, 0)
 			assertInt64DiskMetricValid(t, metrics.At(1), diskOpsDescriptor, 0)
 			assertDoubleDiskMetricValid(t, metrics.At(2), diskTimeDescriptor, 0)
+			assertDiskPendingOperationsMetricValid(t, metrics.At(3))
 
 			if runtime.GOOS == "linux" {
-				assertInt64DiskMetricValid(t, metrics.At(3), diskMergedDescriptor, 0)
+				assertInt64DiskMetricValid(t, metrics.At(4), diskMergedDescriptor, 0)
 			}
 		})
 	}
@@ -98,6 +99,7 @@ func assertInt64DiskMetricValid(t *testing.T, metric pdata.Metric, expectedDescr
 		internal.AssertInt64MetricStartTimeEquals(t, metric, startTime)
 	}
 	assert.GreaterOrEqual(t, metric.Int64DataPoints().Len(), 2)
+	internal.AssertInt64MetricLabelExists(t, metric, 0, deviceLabelName)
 	internal.AssertInt64MetricLabelHasValue(t, metric, 0, directionLabelName, readDirectionLabelValue)
 	internal.AssertInt64MetricLabelHasValue(t, metric, 1, directionLabelName, writeDirectionLabelValue)
 }
@@ -108,6 +110,13 @@ func assertDoubleDiskMetricValid(t *testing.T, metric pdata.Metric, expectedDesc
 		internal.AssertInt64MetricStartTimeEquals(t, metric, startTime)
 	}
 	assert.GreaterOrEqual(t, metric.DoubleDataPoints().Len(), 2)
+	internal.AssertDoubleMetricLabelExists(t, metric, 0, deviceLabelName)
 	internal.AssertDoubleMetricLabelHasValue(t, metric, 0, directionLabelName, readDirectionLabelValue)
 	internal.AssertDoubleMetricLabelHasValue(t, metric, metric.DoubleDataPoints().Len()-1, directionLabelName, writeDirectionLabelValue)
+}
+
+func assertDiskPendingOperationsMetricValid(t *testing.T, metric pdata.Metric) {
+	internal.AssertDescriptorEqual(t, diskPendingOperationsDescriptor, metric.MetricDescriptor())
+	assert.GreaterOrEqual(t, metric.Int64DataPoints().Len(), 1)
+	internal.AssertInt64MetricLabelExists(t, metric, 0, deviceLabelName)
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_windows_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_windows_test.go
@@ -36,6 +36,7 @@ func TestScrapeMetrics_Error(t *testing.T) {
 		diskWritesPerSecCounterReturnValue     interface{}
 		avgDiskSecsPerReadCounterReturnValue   interface{}
 		avgDiskSecsPerWriteCounterReturnValue  interface{}
+		diskQueueLengthCounterReturnValue      interface{}
 		expectedErr                            string
 	}
 
@@ -70,6 +71,11 @@ func TestScrapeMetrics_Error(t *testing.T) {
 			avgDiskSecsPerWriteCounterReturnValue: errors.New("err1"),
 			expectedErr:                           "err1",
 		},
+		{
+			name:                              "avgDiskQueueLengthError",
+			diskQueueLengthCounterReturnValue: errors.New("err1"),
+			expectedErr:                       "err1",
+		},
 	}
 
 	for _, test := range testCases {
@@ -87,6 +93,7 @@ func TestScrapeMetrics_Error(t *testing.T) {
 			scraper.diskWritesPerSecCounter = pdh.NewMockPerfCounter(test.diskWritesPerSecCounterReturnValue)
 			scraper.avgDiskSecsPerReadCounter = pdh.NewMockPerfCounter(test.avgDiskSecsPerReadCounterReturnValue)
 			scraper.avgDiskSecsPerWriteCounter = pdh.NewMockPerfCounter(test.avgDiskSecsPerWriteCounterReturnValue)
+			scraper.diskQueueLengthCounter = pdh.NewMockPerfCounter(test.diskQueueLengthCounterReturnValue)
 
 			_, err = scraper.ScrapeMetrics(context.Background())
 			assert.EqualError(t, err, test.expectedErr)


### PR DESCRIPTION
Adds `disk.pending_operations` metric.

On Windows this is the "Current disk queue length", obtained via a [perf counter](http://www.appadmintools.com/documents/windows-performance-counters-explained/) whereas on Linux this is the "I/Os currently in progress" value returned by [procfs/disktats](https://www.kernel.org/doc/Documentation/ABI/testing/procfs-diskstats).