### PR TITLE
docs(zipkin): bring back zipkin.io as it is back after a very short unavailability

### DIFF
--- a/exporter/zipkinexporter/README.md
+++ b/exporter/zipkinexporter/README.md
@@ -1,6 +1,6 @@
 # Zipkin Exporter
- 
-Exports trace data to a Zipkin back-end.
+
+Exports trace data to a [Zipkin](https://zipkin.io/) back-end.
 
 The following settings are required:
 

--- a/receiver/zipkinreceiver/README.md
+++ b/receiver/zipkinreceiver/README.md
@@ -1,6 +1,6 @@
 # Zipkin Receiver
 
-This receiver receives spans from Zipkin (V1 and V2).
+This receiver receives spans from [Zipkin](https://zipkin.io/) (V1 and V2).
 
 To get started, all that is required to enable the Zipkin receiver is to
 include it in the receiver definitions. This will enable the default values as


### PR DESCRIPTION
**Description:** zipkin.io was down for a short period of time but it is fixed now ([click here](https://zipkin.io)).

**Documentation:** Brought back the links to the documentation as they were removed just yesterday by https://github.com/open-telemetry/opentelemetry-collector/pull/1417

Ping @bogdandrutu 