### PR TITLE
Fix some race conditions in queued retry tests, fix initial interval initialization

### DIFF
--- a/exporter/exporterhelper/queued_retry.go
+++ b/exporter/exporterhelper/queued_retry.go
@@ -152,8 +152,8 @@ func (rs *retrySender) send(req request) (int, error) {
 		return rs.nextSender.send(req)
 	}
 
-	// Cannot use NewExponentialBackOff because if update the InitialInterval
-	// need to reset again, and an unnecessary clock Now is called.
+	// Do not use NewExponentialBackOff since it calls Reset and the code here must
+	// call Reset after changing the InitialInterval (this saves an unnecessary call to Now).
 	expBackoff := backoff.ExponentialBackOff{
 		InitialInterval:     rs.cfg.InitialInterval,
 		RandomizationFactor: backoff.DefaultRandomizationFactor,

--- a/exporter/exporterhelper/queued_retry_test.go
+++ b/exporter/exporterhelper/queued_retry_test.go
@@ -32,305 +32,272 @@ import (
 )
 
 func TestQueuedRetry_DropOnPermanentError(t *testing.T) {
-	mockP := newMockConcurrentExporter()
-	mockP.updateError(consumererror.Permanent(errors.New("bad data")))
-
 	qCfg := CreateDefaultQueueSettings()
 	rCfg := CreateDefaultRetrySettings()
-	rCfg.InitialInterval = 30 * time.Second
 	be := newBaseExporter(defaultExporterCfg, WithRetry(rCfg), WithQueue(qCfg))
+	ocs := newObservabilityConsumerSender(be.qrSender.consumerSender)
+	be.qrSender.consumerSender = ocs
 	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
 	t.Cleanup(func() {
-		mockP.stop()
 		assert.NoError(t, be.Shutdown(context.Background()))
 	})
 
-	mockP.run(func() {
+	mockR := newMockRequest(context.Background(), 2, consumererror.Permanent(errors.New("bad data")))
+	ocs.run(func() {
 		// This is asynchronous so it should just enqueue, no errors expected.
-		droppedItems, err := be.sender.send(newMockRequest(context.Background(), 2, mockP))
+		droppedItems, err := be.sender.send(mockR)
 		require.NoError(t, err)
 		assert.Equal(t, 0, droppedItems)
 	})
-	mockP.awaitAsyncProcessing()
-	<-time.After(200 * time.Millisecond)
-	require.Zero(t, be.qrSender.queue.Size())
+	ocs.awaitAsyncProcessing()
+	// In the newMockConcurrentExporter we count requests and items even for failed requests
+	mockR.checkNumRequests(t, 1)
+	ocs.checkSendItemsCount(t, 0)
+	ocs.checkDroppedItemsCount(t, 2)
 }
 
 func TestQueuedRetry_DropOnNoRetry(t *testing.T) {
-	mockP := newMockConcurrentExporter()
-	mockP.updateError(errors.New("transient error"))
-
 	qCfg := CreateDefaultQueueSettings()
 	rCfg := CreateDefaultRetrySettings()
 	rCfg.Enabled = false
 	be := newBaseExporter(defaultExporterCfg, WithRetry(rCfg), WithQueue(qCfg))
+	ocs := newObservabilityConsumerSender(be.qrSender.consumerSender)
+	be.qrSender.consumerSender = ocs
 	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
 	t.Cleanup(func() {
-		mockP.stop()
 		assert.NoError(t, be.Shutdown(context.Background()))
 	})
 
-	mockP.run(func() {
+	mockR := newMockRequest(context.Background(), 2, errors.New("transient error"))
+	ocs.run(func() {
 		// This is asynchronous so it should just enqueue, no errors expected.
-		droppedItems, err := be.sender.send(newMockRequest(context.Background(), 2, mockP))
+		droppedItems, err := be.sender.send(mockR)
 		require.NoError(t, err)
 		assert.Equal(t, 0, droppedItems)
 	})
-	mockP.awaitAsyncProcessing()
-	<-time.After(200 * time.Millisecond)
-	require.Zero(t, be.qrSender.queue.Size())
+	ocs.awaitAsyncProcessing()
+	// In the newMockConcurrentExporter we count requests and items even for failed requests
+	mockR.checkNumRequests(t, 1)
+	ocs.checkSendItemsCount(t, 0)
+	ocs.checkDroppedItemsCount(t, 2)
 }
 
 func TestQueuedRetry_PartialError(t *testing.T) {
-	partialErr := consumererror.PartialTracesError(errors.New("some error"), testdata.GenerateTraceDataOneSpan())
-	mockP := newMockConcurrentExporter()
-	mockP.updateError(partialErr)
-
 	qCfg := CreateDefaultQueueSettings()
 	qCfg.NumConsumers = 1
 	rCfg := CreateDefaultRetrySettings()
-	rCfg.InitialInterval = 30 * time.Second
+	rCfg.InitialInterval = 0
 	be := newBaseExporter(defaultExporterCfg, WithRetry(rCfg), WithQueue(qCfg))
-	ocs := &observabilityConsumerSender{nextSender: be.qrSender.consumerSender}
+	ocs := newObservabilityConsumerSender(be.qrSender.consumerSender)
 	be.qrSender.consumerSender = ocs
 	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
 	t.Cleanup(func() {
-		mockP.stop()
 		assert.NoError(t, be.Shutdown(context.Background()))
 	})
 
-	mockP.run(func() {
+	partialErr := consumererror.PartialTracesError(errors.New("some error"), testdata.GenerateTraceDataOneSpan())
+	mockR := newMockRequest(context.Background(), 2, partialErr)
+	ocs.run(func() {
 		// This is asynchronous so it should just enqueue, no errors expected.
-		droppedItems, err := be.sender.send(newMockRequest(context.Background(), 2, mockP))
+		droppedItems, err := be.sender.send(mockR)
 		require.NoError(t, err)
 		assert.Equal(t, 0, droppedItems)
 	})
-	mockP.awaitAsyncProcessing()
-	// There is a small race condition in this test, but expect to execute this in less than 1 second.
-	mockP.updateError(nil)
-	mockP.waitGroup.Add(1)
-	mockP.awaitAsyncProcessing()
+	ocs.awaitAsyncProcessing()
 
 	// In the newMockConcurrentExporter we count requests and items even for failed requests
-	mockP.checkNumRequests(t, 2)
+	mockR.checkNumRequests(t, 2)
 	ocs.checkSendItemsCount(t, 2)
 	ocs.checkDroppedItemsCount(t, 0)
-	require.Zero(t, be.qrSender.queue.Size())
 }
 
 func TestQueuedRetry_StopWhileWaiting(t *testing.T) {
-	mockP := newMockConcurrentExporter()
-	mockP.updateError(errors.New("transient error"))
-
 	qCfg := CreateDefaultQueueSettings()
 	qCfg.NumConsumers = 1
 	rCfg := CreateDefaultRetrySettings()
-	rCfg.InitialInterval = 30 * time.Minute
 	be := newBaseExporter(defaultExporterCfg, WithRetry(rCfg), WithQueue(qCfg))
-	ocs := &observabilityConsumerSender{nextSender: be.qrSender.consumerSender}
+	ocs := newObservabilityConsumerSender(be.qrSender.consumerSender)
 	be.qrSender.consumerSender = ocs
 	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
 
-	mockP.run(func() {
+	firstMockR := newMockRequest(context.Background(), 2, errors.New("transient error"))
+	ocs.run(func() {
 		// This is asynchronous so it should just enqueue, no errors expected.
-		droppedItems, err := be.sender.send(newMockRequest(context.Background(), 2, mockP))
+		droppedItems, err := be.sender.send(firstMockR)
 		require.NoError(t, err)
 		assert.Equal(t, 0, droppedItems)
 	})
-	mockP.awaitAsyncProcessing()
 
 	// Enqueue another request to ensure when calling shutdown we drain the queue.
-	mockP.run(func() {
+	secondMockR := newMockRequest(context.Background(), 3, nil)
+	ocs.run(func() {
 		// This is asynchronous so it should just enqueue, no errors expected.
-		droppedItems, err := be.sender.send(newMockRequest(context.Background(), 3, mockP))
+		droppedItems, err := be.sender.send(secondMockR)
 		require.NoError(t, err)
 		assert.Equal(t, 0, droppedItems)
 	})
 
-	mockP.stop()
 	assert.NoError(t, be.Shutdown(context.Background()))
 
-	mockP.checkNumRequests(t, 1)
 	// TODO: Ensure that queue is drained, and uncomment the next 3 lines.
 	//  https://github.com/jaegertracing/jaeger/pull/2349
+	firstMockR.checkNumRequests(t, 1)
+	// secondMockR.checkNumRequests(t, 1)
 	// ocs.checkSendItemsCount(t, 3)
 	ocs.checkDroppedItemsCount(t, 2)
 	// require.Zero(t, be.qrSender.queue.Size())
 }
 
 func TestQueuedRetry_PreserveCancellation(t *testing.T) {
-	mockP := newMockConcurrentExporter()
-	mockP.updateError(errors.New("transient error"))
-
 	qCfg := CreateDefaultQueueSettings()
 	qCfg.NumConsumers = 1
 	rCfg := CreateDefaultRetrySettings()
-	rCfg.InitialInterval = 30 * time.Second
 	be := newBaseExporter(defaultExporterCfg, WithRetry(rCfg), WithQueue(qCfg))
-	ocs := &observabilityConsumerSender{nextSender: be.qrSender.consumerSender}
+	ocs := newObservabilityConsumerSender(be.qrSender.consumerSender)
 	be.qrSender.consumerSender = ocs
 	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
+
 	ctx, cancelFunc := context.WithCancel(context.Background())
+	mockR := newMockRequest(ctx, 2, errors.New("transient error"))
 	start := time.Now()
-	mockP.run(func() {
+	ocs.run(func() {
 		// This is asynchronous so it should just enqueue, no errors expected.
-		droppedItems, err := be.sender.send(newMockRequest(ctx, 2, mockP))
+		droppedItems, err := be.sender.send(mockR)
 		require.NoError(t, err)
 		assert.Equal(t, 0, droppedItems)
 	})
-	mockP.awaitAsyncProcessing()
-
 	cancelFunc()
 
-	mockP.checkNumRequests(t, 1)
-	require.Zero(t, be.qrSender.queue.Size())
-
 	// Stop should succeed and not retry.
-	mockP.stop()
 	assert.NoError(t, be.Shutdown(context.Background()))
 
-	// We should ensure that we actually did not wait for the initial backoff (30 sec).
+	// We should ensure that we actually did not wait for the initial backoff (5 sec).
 	assert.True(t, 5*time.Second > time.Since(start))
 
 	// In the newMockConcurrentExporter we count requests and items even for failed requests.
-	mockP.checkNumRequests(t, 1)
+	mockR.checkNumRequests(t, 1)
 	ocs.checkSendItemsCount(t, 0)
 	ocs.checkDroppedItemsCount(t, 2)
 	require.Zero(t, be.qrSender.queue.Size())
 }
 
 func TestQueuedRetry_MaxElapsedTime(t *testing.T) {
-	mockP := newMockConcurrentExporter()
-
 	qCfg := CreateDefaultQueueSettings()
 	qCfg.NumConsumers = 1
 	rCfg := CreateDefaultRetrySettings()
-	rCfg.InitialInterval = 100 * time.Millisecond
-	rCfg.MaxElapsedTime = 1 * time.Second
+	rCfg.InitialInterval = time.Millisecond
+	rCfg.MaxElapsedTime = 100 * time.Millisecond
 	be := newBaseExporter(defaultExporterCfg, WithRetry(rCfg), WithQueue(qCfg))
-	ocs := &observabilityConsumerSender{nextSender: be.qrSender.consumerSender}
+	ocs := newObservabilityConsumerSender(be.qrSender.consumerSender)
 	be.qrSender.consumerSender = ocs
 	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
 	t.Cleanup(func() {
-		mockP.stop()
 		assert.NoError(t, be.Shutdown(context.Background()))
 	})
 
-	// Add an item that will always fail.
-	droppedItems, err := be.sender.send(newErrorRequest(context.Background()))
-	require.NoError(t, err)
-	assert.Equal(t, 0, droppedItems)
-
-	mockP.run(func() {
-		// This is asynchronous so it should just enqueue, no errors expected.
-		droppedItems, err := be.sender.send(newMockRequest(context.Background(), 2, mockP))
+	ocs.run(func() {
+		// Add an item that will always fail.
+		droppedItems, err := be.sender.send(newErrorRequest(context.Background()))
 		require.NoError(t, err)
 		assert.Equal(t, 0, droppedItems)
 	})
-	mockP.awaitAsyncProcessing()
+
+	mockR := newMockRequest(context.Background(), 2, nil)
+	start := time.Now()
+	ocs.run(func() {
+		// This is asynchronous so it should just enqueue, no errors expected.
+		droppedItems, err := be.sender.send(mockR)
+		require.NoError(t, err)
+		assert.Equal(t, 0, droppedItems)
+	})
+	ocs.awaitAsyncProcessing()
+
+	// We should ensure that we wait for more than MaxElapsedTime, but not too much.
+	waitingTime := time.Since(start)
+	assert.True(t, 100*time.Millisecond < waitingTime)
+	assert.True(t, 5*time.Second > waitingTime)
 
 	// In the newMockConcurrentExporter we count requests and items even for failed requests.
-	mockP.checkNumRequests(t, 1)
+	mockR.checkNumRequests(t, 1)
 	ocs.checkSendItemsCount(t, 2)
 	ocs.checkDroppedItemsCount(t, 7)
 	require.Zero(t, be.qrSender.queue.Size())
 }
 
 func TestQueuedRetry_ThrottleError(t *testing.T) {
-	mockP := newMockConcurrentExporter()
-	mockP.updateError(NewThrottleRetry(errors.New("throttle error"), 1*time.Second))
-
 	qCfg := CreateDefaultQueueSettings()
 	qCfg.NumConsumers = 1
 	rCfg := CreateDefaultRetrySettings()
-	rCfg.InitialInterval = 100 * time.Millisecond
+	rCfg.InitialInterval = 10 * time.Millisecond
 	be := newBaseExporter(defaultExporterCfg, WithRetry(rCfg), WithQueue(qCfg))
-	ocs := &observabilityConsumerSender{nextSender: be.qrSender.consumerSender}
+	ocs := newObservabilityConsumerSender(be.qrSender.consumerSender)
 	be.qrSender.consumerSender = ocs
 	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
 	t.Cleanup(func() {
-		mockP.stop()
 		assert.NoError(t, be.Shutdown(context.Background()))
 	})
 
+	mockR := newMockRequest(context.Background(), 2, NewThrottleRetry(errors.New("throttle error"), 100*time.Millisecond))
 	start := time.Now()
-	mockP.run(func() {
+	ocs.run(func() {
 		// This is asynchronous so it should just enqueue, no errors expected.
-		droppedItems, err := be.sender.send(newMockRequest(context.Background(), 2, mockP))
+		droppedItems, err := be.sender.send(mockR)
 		require.NoError(t, err)
 		assert.Equal(t, 0, droppedItems)
 	})
-	mockP.awaitAsyncProcessing()
-	// There is a small race condition in this test, but expect to execute this in less than 2 second.
-	mockP.updateError(nil)
-	mockP.waitGroup.Add(1)
-	mockP.awaitAsyncProcessing()
+	ocs.awaitAsyncProcessing()
 
-	// The initial backoff is 100ms, but because of the throttle this should wait at least 1 seconds.
-	assert.True(t, 1*time.Second < time.Since(start))
+	// The initial backoff is 10ms, but because of the throttle this should wait at least 100ms.
+	assert.True(t, 100*time.Millisecond < time.Since(start))
 
-	mockP.checkNumRequests(t, 2)
+	mockR.checkNumRequests(t, 2)
 	ocs.checkSendItemsCount(t, 2)
 	ocs.checkDroppedItemsCount(t, 0)
 	require.Zero(t, be.qrSender.queue.Size())
 }
 
 func TestQueuedRetry_RetryOnError(t *testing.T) {
-	mockP := newMockConcurrentExporter()
-	mockP.updateError(errors.New("transient error"))
-
 	qCfg := CreateDefaultQueueSettings()
 	qCfg.NumConsumers = 1
 	qCfg.QueueSize = 1
 	rCfg := CreateDefaultRetrySettings()
-	rCfg.InitialInterval = 2 * time.Second
+	rCfg.InitialInterval = 0
 	be := newBaseExporter(defaultExporterCfg, WithRetry(rCfg), WithQueue(qCfg))
-	ocs := &observabilityConsumerSender{nextSender: be.qrSender.consumerSender}
+	ocs := newObservabilityConsumerSender(be.qrSender.consumerSender)
 	be.qrSender.consumerSender = ocs
 	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
 	t.Cleanup(func() {
-		mockP.stop()
 		assert.NoError(t, be.Shutdown(context.Background()))
 	})
 
-	mockP.run(func() {
+	mockR := newMockRequest(context.Background(), 2, errors.New("transient error"))
+	ocs.run(func() {
 		// This is asynchronous so it should just enqueue, no errors expected.
-		droppedItems, err := be.sender.send(newMockRequest(context.Background(), 2, mockP))
+		droppedItems, err := be.sender.send(mockR)
 		require.NoError(t, err)
 		assert.Equal(t, 0, droppedItems)
 	})
-	mockP.awaitAsyncProcessing()
-	ocs.checkSendItemsCount(t, 0)
-	ocs.checkDroppedItemsCount(t, 0)
-
-	// There is a small race condition in this test, but expect to execute this in less than 2 second.
-	mockP.updateError(nil)
-	mockP.waitGroup.Add(1)
-	mockP.awaitAsyncProcessing()
+	ocs.awaitAsyncProcessing()
 
 	// In the newMockConcurrentExporter we count requests and items even for failed requests
-	mockP.checkNumRequests(t, 2)
+	mockR.checkNumRequests(t, 2)
 	ocs.checkSendItemsCount(t, 2)
 	ocs.checkDroppedItemsCount(t, 0)
 	require.Zero(t, be.qrSender.queue.Size())
 }
 
 func TestQueuedRetry_DropOnFull(t *testing.T) {
-	mockP := newMockConcurrentExporter()
-	mockP.updateError(errors.New("transient error"))
-
 	qCfg := CreateDefaultQueueSettings()
 	qCfg.QueueSize = 0
 	rCfg := CreateDefaultRetrySettings()
 	be := newBaseExporter(defaultExporterCfg, WithRetry(rCfg), WithQueue(qCfg))
-	ocs := &observabilityConsumerSender{nextSender: be.qrSender.consumerSender}
+	ocs := newObservabilityConsumerSender(be.qrSender.consumerSender)
 	be.qrSender.consumerSender = ocs
 	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
 	t.Cleanup(func() {
-		mockP.stop()
 		assert.NoError(t, be.Shutdown(context.Background()))
 	})
-	droppedItems, err := be.sender.send(newMockRequest(context.Background(), 2, mockP))
+	droppedItems, err := be.sender.send(newMockRequest(context.Background(), 2, errors.New("transient error")))
 	require.Error(t, err)
 	assert.Equal(t, 2, droppedItems)
 }
@@ -340,31 +307,28 @@ func TestQueuedRetryHappyPath(t *testing.T) {
 	require.NoError(t, err)
 	defer doneFn()
 
-	mockP := newMockConcurrentExporter()
 	qCfg := CreateDefaultQueueSettings()
 	rCfg := CreateDefaultRetrySettings()
 	be := newBaseExporter(defaultExporterCfg, WithRetry(rCfg), WithQueue(qCfg))
-	ocs := &observabilityConsumerSender{nextSender: be.qrSender.consumerSender}
+	ocs := newObservabilityConsumerSender(be.qrSender.consumerSender)
 	be.qrSender.consumerSender = ocs
 	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
 	t.Cleanup(func() {
-		mockP.stop()
 		assert.NoError(t, be.Shutdown(context.Background()))
 	})
 
 	wantRequests := 10
 	for i := 0; i < wantRequests; i++ {
-		mockP.run(func() {
-			droppedItems, err := be.sender.send(newMockRequest(context.Background(), 2, mockP))
+		ocs.run(func() {
+			droppedItems, err := be.sender.send(newMockRequest(context.Background(), 2, nil))
 			require.NoError(t, err)
 			assert.Equal(t, 0, droppedItems)
 		})
 	}
 
 	// Wait until all batches received
-	mockP.awaitAsyncProcessing()
+	ocs.awaitAsyncProcessing()
 
-	mockP.checkNumRequests(t, wantRequests)
 	ocs.checkSendItemsCount(t, 2*wantRequests)
 	ocs.checkDroppedItemsCount(t, 0)
 }
@@ -393,12 +357,18 @@ func newErrorRequest(ctx context.Context) request {
 
 type mockRequest struct {
 	baseRequest
-	cnt int
-	mce *mockConcurrentExporter
+	cnt          int
+	mu           sync.Mutex
+	consumeError error
+	requestCount *int64
 }
 
 func (m *mockRequest) export(_ context.Context) (int, error) {
-	err := m.mce.export()
+	atomic.AddInt64(m.requestCount, 1)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	err := m.consumeError
+	m.consumeError = nil
 	if err != nil {
 		return m.cnt, err
 	}
@@ -407,81 +377,56 @@ func (m *mockRequest) export(_ context.Context) (int, error) {
 
 func (m *mockRequest) onPartialError(consumererror.PartialError) request {
 	return &mockRequest{
-		baseRequest: m.baseRequest,
-		cnt:         1,
-		mce:         m.mce,
+		baseRequest:  m.baseRequest,
+		cnt:          1,
+		consumeError: nil,
+		requestCount: m.requestCount,
 	}
+}
+
+func (m *mockRequest) checkNumRequests(t *testing.T, want int) {
+	assert.EqualValues(t, want, atomic.LoadInt64(m.requestCount))
 }
 
 func (m *mockRequest) count() int {
 	return m.cnt
 }
 
-func newMockRequest(ctx context.Context, cnt int, mce *mockConcurrentExporter) request {
+func newMockRequest(ctx context.Context, cnt int, consumeError error) *mockRequest {
 	return &mockRequest{
-		baseRequest: baseRequest{ctx: ctx},
-		cnt:         cnt,
-		mce:         mce,
+		baseRequest:  baseRequest{ctx: ctx},
+		cnt:          cnt,
+		consumeError: consumeError,
+		requestCount: new(int64),
 	}
-}
-
-type mockConcurrentExporter struct {
-	waitGroup    *sync.WaitGroup
-	mu           sync.Mutex
-	consumeError error
-	requestCount int64
-	stopped      int32
-}
-
-func newMockConcurrentExporter() *mockConcurrentExporter {
-	return &mockConcurrentExporter{waitGroup: new(sync.WaitGroup)}
-}
-
-func (p *mockConcurrentExporter) export() error {
-	if atomic.LoadInt32(&p.stopped) == 1 {
-		return nil
-	}
-	atomic.AddInt64(&p.requestCount, 1)
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	defer p.waitGroup.Done()
-	return p.consumeError
-}
-
-func (p *mockConcurrentExporter) updateError(err error) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	p.consumeError = err
-}
-
-func (p *mockConcurrentExporter) checkNumRequests(t *testing.T, want int) {
-	assert.EqualValues(t, want, atomic.LoadInt64(&p.requestCount))
-}
-
-func (p *mockConcurrentExporter) run(fn func()) {
-	p.waitGroup.Add(1)
-	fn()
-}
-
-func (p *mockConcurrentExporter) awaitAsyncProcessing() {
-	p.waitGroup.Wait()
-}
-
-func (p *mockConcurrentExporter) stop() {
-	atomic.StoreInt32(&p.stopped, 1)
 }
 
 type observabilityConsumerSender struct {
+	waitGroup         *sync.WaitGroup
 	sentItemsCount    int64
 	droppedItemsCount int64
 	nextSender        requestSender
+}
+
+func newObservabilityConsumerSender(nextSender requestSender) *observabilityConsumerSender {
+	return &observabilityConsumerSender{waitGroup: new(sync.WaitGroup), nextSender: nextSender}
 }
 
 func (ocs *observabilityConsumerSender) send(req request) (int, error) {
 	dic, err := ocs.nextSender.send(req)
 	atomic.AddInt64(&ocs.sentItemsCount, int64(req.count()-dic))
 	atomic.AddInt64(&ocs.droppedItemsCount, int64(dic))
+	ocs.waitGroup.Done()
 	return dic, err
+}
+
+func (ocs *observabilityConsumerSender) run(fn func()) {
+	ocs.waitGroup.Add(1)
+	fn()
+}
+
+func (ocs *observabilityConsumerSender) awaitAsyncProcessing() {
+	ocs.waitGroup.Wait()
 }
 
 func (ocs *observabilityConsumerSender) checkSendItemsCount(t *testing.T, want int) {

--- a/exporter/otlpexporter/otlp_test.go
+++ b/exporter/otlpexporter/otlp_test.go
@@ -321,6 +321,9 @@ func TestSendTraceDataServerDownAndUp(t *testing.T) {
 		TLSSetting: configtls.TLSClientSetting{
 			Insecure: true,
 		},
+		// Need to wait for every request blocking until either request timeouts or succeed.
+		// Do not rely on external retry logic here, if that is intended set InitialInterval to 100ms.
+		WaitForReady: true,
 	}
 	creationParams := component.ExporterCreateParams{Logger: zap.NewNop()}
 	exp, err := factory.CreateTraceExporter(context.Background(), creationParams, cfg)
@@ -421,7 +424,7 @@ func startServerAndMakeRequest(t *testing.T, exp component.TraceExporter, td pda
 	assert.EqualValues(t, 0, atomic.LoadInt32(&rcv.requestCount))
 
 	// Resend the request, this should succeed.
-	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	assert.NoError(t, exp.ConsumeTraces(ctx, td))
 	cancel()
 


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-collector/issues/1354

Changes in otlp_test are required because the fix of InitialInterval (5 second) will timeout requests that are sent with 4seconds timeout, so decided to make calls blocking.