### PR TITLE
Give more time for otlp gRPC server to start

### DIFF
--- a/exporter/otlpexporter/otlp_test.go
+++ b/exporter/otlpexporter/otlp_test.go
@@ -424,7 +424,7 @@ func startServerAndMakeRequest(t *testing.T, exp component.TraceExporter, td pda
 	assert.EqualValues(t, 0, atomic.LoadInt32(&rcv.requestCount))
 
 	// Resend the request, this should succeed.
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	assert.NoError(t, exp.ConsumeTraces(ctx, td))
 	cancel()
 


### PR DESCRIPTION
https://app.circleci.com/pipelines/github/open-telemetry/opentelemetry-collector/2284/workflows/8b1d2b7b-71d1-4f28-a1d8-92246fc9471e/jobs/18340/parallel-runs/0/steps/0-103