### PR TITLE
Add misc changes for metrics correctness

### DIFF
--- a/internal/goldendataset/metric_gen_test.go
+++ b/internal/goldendataset/metric_gen_test.go
@@ -42,7 +42,7 @@ func TestGenDefault(t *testing.T) {
 	require.Equal(t, 1, ms.Len())
 	pdm := ms.At(0)
 	desc := pdm.MetricDescriptor()
-	require.Equal(t, "my-md-name", desc.Name())
+	require.Equal(t, "metric_0", desc.Name())
 	require.Equal(t, "my-md-description", desc.Description())
 	require.Equal(t, "my-md-units", desc.Unit())
 

--- a/internal/goldendataset/pict_metric_gen.go
+++ b/internal/goldendataset/pict_metric_gen.go
@@ -15,6 +15,8 @@
 package goldendataset
 
 import (
+	"fmt"
+
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/internal/data"
 )
@@ -37,6 +39,7 @@ func GenerateMetricDatas(metricPairsFile string) ([]data.MetricData, error) {
 			NumPtLabels:     PICTNumPtLabels(values[2]),
 		}
 		cfg := pictToCfg(metricInputs)
+		cfg.MetricNamePrefix = fmt.Sprintf("pict_%d_", i)
 		md := MetricDataFromCfg(cfg)
 		out = append(out, md)
 	}

--- a/testbed/correctness/metrics/metric_diff.go
+++ b/testbed/correctness/metrics/metric_diff.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package testbed
+package metrics
 
 import (
 	"fmt"
@@ -26,13 +26,13 @@ import (
 // testing. Two MetricDatas, when compared, could produce a list of MetricDiffs containing all of their
 // differences, which could be used to correct the differences between the expected and actual values.
 type MetricDiff struct {
-	expectedValue interface{}
-	actualValue   interface{}
-	msg           string
+	ExpectedValue interface{}
+	ActualValue   interface{}
+	Msg           string
 }
 
 func (mf MetricDiff) String() string {
-	return fmt.Sprintf("{msg='%v' expected=[%v] actual=[%v]}\n", mf.msg, mf.expectedValue, mf.actualValue)
+	return fmt.Sprintf("{msg='%v' expected=[%v] actual=[%v]}\n", mf.Msg, mf.ExpectedValue, mf.ActualValue)
 }
 
 func pdmToPDRM(pdm []pdata.Metrics) (out []pdata.ResourceMetrics) {
@@ -51,9 +51,9 @@ func diffRMSlices(sent []pdata.ResourceMetrics, recd []pdata.ResourceMetrics) []
 	var diffs []*MetricDiff
 	if len(sent) != len(recd) {
 		return []*MetricDiff{{
-			expectedValue: len(sent),
-			actualValue:   len(recd),
-			msg:           "Sent vs received ResourceMetrics not equal length",
+			ExpectedValue: len(sent),
+			ActualValue:   len(recd),
+			Msg:           "Sent vs received ResourceMetrics not equal length",
 		}}
 	}
 	for i := 0; i < len(sent); i++ {
@@ -105,12 +105,12 @@ func diffMetrics(diffs []*MetricDiff, expected pdata.MetricSlice, actual pdata.M
 		return diffs
 	}
 	for i := 0; i < expected.Len(); i++ {
-		diffs = diffMetric(diffs, expected.At(i), actual.At(i))
+		diffs = DiffMetric(diffs, expected.At(i), actual.At(i))
 	}
 	return diffs
 }
 
-func diffMetric(diffs []*MetricDiff, expected pdata.Metric, actual pdata.Metric) []*MetricDiff {
+func DiffMetric(diffs []*MetricDiff, expected pdata.Metric, actual pdata.Metric) []*MetricDiff {
 	diffs = diffMetricDescriptor(diffs, expected.MetricDescriptor(), actual.MetricDescriptor())
 	diffs = diffInt64Pts(diffs, expected.Int64DataPoints(), actual.Int64DataPoints())
 	diffs = diffDoublePts(diffs, expected.DoubleDataPoints(), actual.DoubleDataPoints())
@@ -305,9 +305,9 @@ func diffResource(diffs []*MetricDiff, expected pdata.Resource, actual pdata.Res
 func diffAttrs(diffs []*MetricDiff, expected pdata.AttributeMap, actual pdata.AttributeMap) []*MetricDiff {
 	if !reflect.DeepEqual(expected, actual) {
 		diffs = append(diffs, &MetricDiff{
-			expectedValue: attrMapToString(expected),
-			actualValue:   attrMapToString(actual),
-			msg:           "Resource attributes",
+			ExpectedValue: attrMapToString(expected),
+			ActualValue:   attrMapToString(actual),
+			Msg:           "Resource attributes",
 		})
 	}
 	return diffs
@@ -326,9 +326,9 @@ func diffValues(
 ) ([]*MetricDiff, bool) {
 	if expected != actual {
 		return append(diffs, &MetricDiff{
-			msg:           msg,
-			expectedValue: expected,
-			actualValue:   actual,
+			Msg:           msg,
+			ExpectedValue: expected,
+			ActualValue:   actual,
 		}), true
 	}
 	return diffs, false

--- a/testbed/correctness/metrics/metric_diff_test.go
+++ b/testbed/correctness/metrics/metric_diff_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package testbed
+package metrics
 
 import (
 	"testing"

--- a/testbed/testbed/child_process.go
+++ b/testbed/testbed/child_process.go
@@ -114,10 +114,10 @@ type ChildProcess struct {
 }
 
 type StartParams struct {
-	name         string
-	logFilePath  string
-	cmd          string
-	cmdArgs      []string
+	Name         string
+	LogFilePath  string
+	Cmd          string
+	CmdArgs      []string
 	resourceSpec *ResourceSpec
 }
 
@@ -167,23 +167,23 @@ func (cp *ChildProcess) PrepareConfig(configStr string) (configCleanup func(), e
 // cmdArgs is the command line arguments to pass to the process.
 func (cp *ChildProcess) Start(params StartParams) (receiverAddr string, err error) {
 
-	cp.name = params.name
+	cp.name = params.Name
 	cp.doneSignal = make(chan struct{})
 	cp.resourceSpec = params.resourceSpec
 
-	log.Printf("Starting %s (%s)", cp.name, params.cmd)
+	log.Printf("Starting %s (%s)", cp.name, params.Cmd)
 
 	// Prepare log file
 	var logFile *os.File
-	logFile, err = os.Create(params.logFilePath)
+	logFile, err = os.Create(params.LogFilePath)
 	if err != nil {
-		return receiverAddr, fmt.Errorf("cannot create %s: %s", params.logFilePath, err.Error())
+		return receiverAddr, fmt.Errorf("cannot create %s: %s", params.LogFilePath, err.Error())
 	}
-	log.Printf("Writing %s log to %s", cp.name, params.logFilePath)
+	log.Printf("Writing %s log to %s", cp.name, params.LogFilePath)
 
 	// Prepare to start the process.
 	// #nosec
-	args := params.cmdArgs
+	args := params.CmdArgs
 	if !containsConfig(args) {
 		if cp.configFileName == "" {
 			configFile := path.Join("testdata", "agent-config.yaml")
@@ -195,21 +195,21 @@ func (cp *ChildProcess) Start(params StartParams) (receiverAddr string, err erro
 		args = append(args, "--config")
 		args = append(args, cp.configFileName)
 	}
-	cp.cmd = exec.Command(params.cmd, args...)
+	cp.cmd = exec.Command(params.Cmd, args...)
 
 	// Capture standard output and standard error.
 	stdoutIn, err := cp.cmd.StdoutPipe()
 	if err != nil {
-		return receiverAddr, fmt.Errorf("cannot capture stdout of %s: %s", params.cmd, err.Error())
+		return receiverAddr, fmt.Errorf("cannot capture stdout of %s: %s", params.Cmd, err.Error())
 	}
 	stderrIn, err := cp.cmd.StderrPipe()
 	if err != nil {
-		return receiverAddr, fmt.Errorf("cannot capture stderr of %s: %s", params.cmd, err.Error())
+		return receiverAddr, fmt.Errorf("cannot capture stderr of %s: %s", params.Cmd, err.Error())
 	}
 
 	// Start the process.
 	if err = cp.cmd.Start(); err != nil {
-		return receiverAddr, fmt.Errorf("cannot start executable at %s: %s", params.cmd, err.Error())
+		return receiverAddr, fmt.Errorf("cannot start executable at %s: %s", params.Cmd, err.Error())
 	}
 
 	cp.startTime = time.Now()

--- a/testbed/testbed/mock_backend.go
+++ b/testbed/testbed/mock_backend.go
@@ -23,6 +23,7 @@ import (
 
 	"go.uber.org/atomic"
 
+	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumerdata"
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/consumer/pdatautil"
@@ -124,7 +125,7 @@ func (mb *MockBackend) GetStats() string {
 
 // DataItemsReceived returns total number of received spans and metrics.
 func (mb *MockBackend) DataItemsReceived() uint64 {
-	return mb.tc.spansReceived.Load() + mb.mc.metricsReceived.Load()
+	return mb.tc.numSpansReceived.Load() + mb.mc.numMetricsReceived.Load()
 }
 
 // ClearReceivedItems clears the list of received traces and metrics. Note: counters
@@ -172,13 +173,20 @@ func (mb *MockBackend) ConsumeMetricOld(md consumerdata.MetricsData) {
 	}
 }
 
+type TraceDualConsumer interface {
+	consumer.TraceConsumer
+	consumer.TraceConsumerOld
+}
+
+var _ TraceDualConsumer = (*MockTraceConsumer)(nil)
+
 type MockTraceConsumer struct {
-	spansReceived atomic.Uint64
-	backend       *MockBackend
+	numSpansReceived atomic.Uint64
+	backend          *MockBackend
 }
 
 func (tc *MockTraceConsumer) ConsumeTraces(_ context.Context, td pdata.Traces) error {
-	tc.spansReceived.Add(uint64(td.SpanCount()))
+	tc.numSpansReceived.Add(uint64(td.SpanCount()))
 
 	rs := td.ResourceSpans()
 	for i := 0; i < rs.Len(); i++ {
@@ -214,7 +222,7 @@ func (tc *MockTraceConsumer) ConsumeTraces(_ context.Context, td pdata.Traces) e
 }
 
 func (tc *MockTraceConsumer) ConsumeTraceData(_ context.Context, td consumerdata.TraceData) error {
-	tc.spansReceived.Add(uint64(len(td.Spans)))
+	tc.numSpansReceived.Add(uint64(len(td.Spans)))
 
 	for _, span := range td.Spans {
 		var spanSeqnum int64
@@ -243,29 +251,28 @@ func (tc *MockTraceConsumer) ConsumeTraceData(_ context.Context, td consumerdata
 	return nil
 }
 
+type MetricsDualConsumer interface {
+	consumer.MetricsConsumer
+	consumer.MetricsConsumerOld
+}
+
+var _ MetricsDualConsumer = (*MockMetricConsumer)(nil)
+
 type MockMetricConsumer struct {
-	metricsReceived atomic.Uint64
-	backend         *MockBackend
+	numMetricsReceived atomic.Uint64
+	backend            *MockBackend
 }
 
 func (mc *MockMetricConsumer) ConsumeMetrics(_ context.Context, md pdata.Metrics) error {
 	_, dataPoints := pdatautil.MetricAndDataPointCount(md)
-	mc.metricsReceived.Add(uint64(dataPoints))
+	mc.numMetricsReceived.Add(uint64(dataPoints))
 	mc.backend.ConsumeMetric(md)
 	return nil
 }
 
 func (mc *MockMetricConsumer) ConsumeMetricsData(_ context.Context, md consumerdata.MetricsData) error {
-	dataPoints := 0
-	for _, metric := range md.Metrics {
-		for _, ts := range metric.Timeseries {
-			dataPoints += len(ts.Points)
-		}
-	}
-
-	mc.metricsReceived.Add(uint64(dataPoints))
-
+	_, dataPoints := pdatautil.TimeseriesAndPointCount(md)
+	mc.numMetricsReceived.Add(uint64(dataPoints))
 	mc.backend.ConsumeMetricOld(md)
-
 	return nil
 }

--- a/testbed/testbed/otelcol_runner.go
+++ b/testbed/testbed/otelcol_runner.go
@@ -115,7 +115,7 @@ func (ipp *InProcessCollector) Start(args StartParams) (receiverAddr string, err
 	if err != nil {
 		return receiverAddr, err
 	}
-	ipp.svc.Command().SetArgs(args.cmdArgs)
+	ipp.svc.Command().SetArgs(args.CmdArgs)
 
 	ipp.appDone = make(chan struct{})
 	go func() {

--- a/testbed/testbed/senders.go
+++ b/testbed/testbed/senders.go
@@ -28,6 +28,7 @@ import (
 	"go.opentelemetry.io/collector/exporter/jaegerexporter"
 	"go.opentelemetry.io/collector/exporter/opencensusexporter"
 	"go.opentelemetry.io/collector/exporter/otlpexporter"
+	"go.opentelemetry.io/collector/exporter/prometheusexporter"
 	"go.opentelemetry.io/collector/exporter/zipkinexporter"
 	"go.opentelemetry.io/collector/internal/data"
 )
@@ -344,6 +345,7 @@ func (ome *OTLPMetricsDataSender) Start() error {
 	factory := otlpexporter.NewFactory()
 	cfg := factory.CreateDefaultConfig().(*otlpexporter.Config)
 	cfg.Endpoint = fmt.Sprintf("%s:%d", ome.host, ome.port)
+
 	cfg.TLSSetting = configtls.TLSClientSetting{
 		Insecure: true,
 	}
@@ -422,4 +424,70 @@ func (zs *ZipkinDataSender) GenConfigYAMLStr() string {
 
 func (zs *ZipkinDataSender) ProtocolName() string {
 	return "zipkin"
+}
+
+// prometheus
+
+type PrometheusDataSender struct {
+	host      string
+	port      int
+	namespace string
+	exporter  component.MetricsExporter
+}
+
+var _ MetricDataSender = (*PrometheusDataSender)(nil)
+
+func NewPrometheusDataSender(host string, port int) *PrometheusDataSender {
+	return &PrometheusDataSender{
+		host: host,
+		port: port,
+	}
+}
+
+func (pds *PrometheusDataSender) Start() error {
+	factory := prometheusexporter.NewFactory()
+	cfg := factory.CreateDefaultConfig().(*prometheusexporter.Config)
+	cfg.Endpoint = pds.endpoint()
+	cfg.Namespace = pds.namespace
+
+	exporter, err := factory.CreateMetricsExporter(context.Background(), component.ExporterCreateParams{}, cfg)
+	if err != nil {
+		return err
+	}
+
+	pds.exporter = exporter
+	return nil
+}
+
+func (pds *PrometheusDataSender) endpoint() string {
+	return fmt.Sprintf("%s:%d", pds.host, pds.port)
+}
+
+func (pds *PrometheusDataSender) SendMetrics(md data.MetricData) error {
+	pdm := pdatautil.MetricsFromInternalMetrics(md)
+	return pds.exporter.ConsumeMetrics(context.Background(), pdm)
+}
+
+func (pds *PrometheusDataSender) Flush() {
+}
+
+func (pds *PrometheusDataSender) GenConfigYAMLStr() string {
+	format := `
+  prometheus:
+    config:
+      scrape_configs:
+        - job_name: 'testbed'
+          scrape_interval: 100ms
+          static_configs:
+            - targets: ['%s']
+`
+	return fmt.Sprintf(format, pds.endpoint())
+}
+
+func (pds *PrometheusDataSender) GetCollectorPort() int {
+	return pds.port
+}
+
+func (pds *PrometheusDataSender) ProtocolName() string {
+	return "prometheus"
 }

--- a/testbed/testbed/test_case.go
+++ b/testbed/testbed/test_case.go
@@ -141,7 +141,6 @@ func NewTestCase(
 func (tc *TestCase) composeTestResultFileName(fileName string) string {
 	fileName, err := filepath.Abs(path.Join(tc.resultDir, fileName))
 	require.NoError(tc.t, err, "Cannot resolve %s", fileName)
-
 	return fileName
 }
 
@@ -171,10 +170,10 @@ func (tc *TestCase) StartAgent(args ...string) {
 	logFileName := tc.composeTestResultFileName("agent.log")
 
 	_, err := tc.agentProc.Start(StartParams{
-		name:         "Agent",
-		logFilePath:  logFileName,
-		cmd:          testBedConfig.Agent,
-		cmdArgs:      args,
+		Name:         "Agent",
+		LogFilePath:  logFileName,
+		Cmd:          testBedConfig.Agent,
+		CmdArgs:      args,
 		resourceSpec: &tc.resourceSpec,
 	})
 


### PR DESCRIPTION
This is in support of issue #652.

This change:
- Adds support for setting a prefix on every metric name for metrics generated for testing. Doing so will be necessary to distinguish metric names for metrics generated from different rows in a PICT file.
- Exports some fields and functions in the `correctness` package so that they can be used from the `metrics` subdirectory/package.
- Replaces argument types that refer to the struct `MockTraceConsumer` and `MockMetricsConsumer` with the interfaces `MetricsDualConsumer` and `TraceDualConsumer`, both of which can consume old and new metrics/traces. This will be used in a forthcoming `TestHarness` type that implements `MetricsDualConsumer`.
- Adds a `PrometheusDataReceiver` and a `PrometheusDataSender` so that Prometheus correctness can be tested.