### PR TITLE
Format Generated protobufs Properly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -243,6 +243,7 @@ genproto:
 	# Call a sub-make to ensure OPENTELEMETRY_PROTO_FILES is populated after the submodule
 	# files are present.
 	$(MAKE) genproto_sub
+	$(MAKE) fmt
 
 genproto_sub:
 	@echo Generating code for the following files:

--- a/consumer/pdata/generated_log_test.go
+++ b/consumer/pdata/generated_log_test.go
@@ -134,7 +134,7 @@ func TestResourceLogsSlice_Append(t *testing.T) {
 	es.Append(&emptyVal)
 	assert.EqualValues(t, *(es.At(7)).orig, *emptyVal.orig)
 
-	emptyVal2:= NewResourceLogs()
+	emptyVal2 := NewResourceLogs()
 	emptyVal2.InitEmpty()
 
 	es.Append(&emptyVal2)
@@ -286,7 +286,7 @@ func TestInstrumentationLibraryLogsSlice_Append(t *testing.T) {
 	es.Append(&emptyVal)
 	assert.EqualValues(t, *(es.At(7)).orig, *emptyVal.orig)
 
-	emptyVal2:= NewInstrumentationLibraryLogs()
+	emptyVal2 := NewInstrumentationLibraryLogs()
 	emptyVal2.InitEmpty()
 
 	es.Append(&emptyVal2)
@@ -438,7 +438,7 @@ func TestLogSlice_Append(t *testing.T) {
 	es.Append(&emptyVal)
 	assert.EqualValues(t, *(es.At(7)).orig, *emptyVal.orig)
 
-	emptyVal2:= NewLogRecord()
+	emptyVal2 := NewLogRecord()
 	emptyVal2.InitEmpty()
 
 	es.Append(&emptyVal2)

--- a/consumer/pdata/generated_metrics_test.go
+++ b/consumer/pdata/generated_metrics_test.go
@@ -134,7 +134,7 @@ func TestResourceMetricsSlice_Append(t *testing.T) {
 	es.Append(&emptyVal)
 	assert.EqualValues(t, *(es.At(7)).orig, *emptyVal.orig)
 
-	emptyVal2:= NewResourceMetrics()
+	emptyVal2 := NewResourceMetrics()
 	emptyVal2.InitEmpty()
 
 	es.Append(&emptyVal2)
@@ -286,7 +286,7 @@ func TestInstrumentationLibraryMetricsSlice_Append(t *testing.T) {
 	es.Append(&emptyVal)
 	assert.EqualValues(t, *(es.At(7)).orig, *emptyVal.orig)
 
-	emptyVal2:= NewInstrumentationLibraryMetrics()
+	emptyVal2 := NewInstrumentationLibraryMetrics()
 	emptyVal2.InitEmpty()
 
 	es.Append(&emptyVal2)
@@ -438,7 +438,7 @@ func TestMetricSlice_Append(t *testing.T) {
 	es.Append(&emptyVal)
 	assert.EqualValues(t, *(es.At(7)).orig, *emptyVal.orig)
 
-	emptyVal2:= NewMetric()
+	emptyVal2 := NewMetric()
 	emptyVal2.InitEmpty()
 
 	es.Append(&emptyVal2)
@@ -668,7 +668,7 @@ func TestInt64DataPointSlice_Append(t *testing.T) {
 	es.Append(&emptyVal)
 	assert.EqualValues(t, *(es.At(7)).orig, *emptyVal.orig)
 
-	emptyVal2:= NewInt64DataPoint()
+	emptyVal2 := NewInt64DataPoint()
 	emptyVal2.InitEmpty()
 
 	es.Append(&emptyVal2)
@@ -837,7 +837,7 @@ func TestDoubleDataPointSlice_Append(t *testing.T) {
 	es.Append(&emptyVal)
 	assert.EqualValues(t, *(es.At(7)).orig, *emptyVal.orig)
 
-	emptyVal2:= NewDoubleDataPoint()
+	emptyVal2 := NewDoubleDataPoint()
 	emptyVal2.InitEmpty()
 
 	es.Append(&emptyVal2)
@@ -1006,7 +1006,7 @@ func TestHistogramDataPointSlice_Append(t *testing.T) {
 	es.Append(&emptyVal)
 	assert.EqualValues(t, *(es.At(7)).orig, *emptyVal.orig)
 
-	emptyVal2:= NewHistogramDataPoint()
+	emptyVal2 := NewHistogramDataPoint()
 	emptyVal2.InitEmpty()
 
 	es.Append(&emptyVal2)
@@ -1202,7 +1202,7 @@ func TestHistogramBucketSlice_Append(t *testing.T) {
 	es.Append(&emptyVal)
 	assert.EqualValues(t, *(es.At(7)).orig, *emptyVal.orig)
 
-	emptyVal2:= NewHistogramBucket()
+	emptyVal2 := NewHistogramBucket()
 	emptyVal2.InitEmpty()
 
 	es.Append(&emptyVal2)
@@ -1396,7 +1396,7 @@ func TestSummaryDataPointSlice_Append(t *testing.T) {
 	es.Append(&emptyVal)
 	assert.EqualValues(t, *(es.At(7)).orig, *emptyVal.orig)
 
-	emptyVal2:= NewSummaryDataPoint()
+	emptyVal2 := NewSummaryDataPoint()
 	emptyVal2.InitEmpty()
 
 	es.Append(&emptyVal2)
@@ -1583,7 +1583,7 @@ func TestSummaryValueAtPercentileSlice_Append(t *testing.T) {
 	es.Append(&emptyVal)
 	assert.EqualValues(t, *(es.At(7)).orig, *emptyVal.orig)
 
-	emptyVal2:= NewSummaryValueAtPercentile()
+	emptyVal2 := NewSummaryValueAtPercentile()
 	emptyVal2.InitEmpty()
 
 	es.Append(&emptyVal2)

--- a/consumer/pdata/generated_trace_test.go
+++ b/consumer/pdata/generated_trace_test.go
@@ -134,7 +134,7 @@ func TestResourceSpansSlice_Append(t *testing.T) {
 	es.Append(&emptyVal)
 	assert.EqualValues(t, *(es.At(7)).orig, *emptyVal.orig)
 
-	emptyVal2:= NewResourceSpans()
+	emptyVal2 := NewResourceSpans()
 	emptyVal2.InitEmpty()
 
 	es.Append(&emptyVal2)
@@ -286,7 +286,7 @@ func TestInstrumentationLibrarySpansSlice_Append(t *testing.T) {
 	es.Append(&emptyVal)
 	assert.EqualValues(t, *(es.At(7)).orig, *emptyVal.orig)
 
-	emptyVal2:= NewInstrumentationLibrarySpans()
+	emptyVal2 := NewInstrumentationLibrarySpans()
 	emptyVal2.InitEmpty()
 
 	es.Append(&emptyVal2)
@@ -438,7 +438,7 @@ func TestSpanSlice_Append(t *testing.T) {
 	es.Append(&emptyVal)
 	assert.EqualValues(t, *(es.At(7)).orig, *emptyVal.orig)
 
-	emptyVal2:= NewSpan()
+	emptyVal2 := NewSpan()
 	emptyVal2.InitEmpty()
 
 	es.Append(&emptyVal2)
@@ -707,7 +707,7 @@ func TestSpanEventSlice_Append(t *testing.T) {
 	es.Append(&emptyVal)
 	assert.EqualValues(t, *(es.At(7)).orig, *emptyVal.orig)
 
-	emptyVal2:= NewSpanEvent()
+	emptyVal2 := NewSpanEvent()
 	emptyVal2.InitEmpty()
 
 	es.Append(&emptyVal2)
@@ -876,7 +876,7 @@ func TestSpanLinkSlice_Append(t *testing.T) {
 	es.Append(&emptyVal)
 	assert.EqualValues(t, *(es.At(7)).orig, *emptyVal.orig)
 
-	emptyVal2:= NewSpanLink()
+	emptyVal2 := NewSpanLink()
 	emptyVal2.InitEmpty()
 
 	es.Append(&emptyVal2)

--- a/internal/data/opentelemetry-proto-gen/collector/logs/v1/logs_service.pb.go
+++ b/internal/data/opentelemetry-proto-gen/collector/logs/v1/logs_service.pb.go
@@ -6,14 +6,16 @@ package v1
 import (
 	context "context"
 	fmt "fmt"
-	proto "github.com/gogo/protobuf/proto"
-	v1 "go.opentelemetry.io/collector/internal/data/opentelemetry-proto-gen/logs/v1"
-	grpc "google.golang.org/grpc"
-	codes "google.golang.org/grpc/codes"
-	status "google.golang.org/grpc/status"
 	io "io"
 	math "math"
 	math_bits "math/bits"
+
+	proto "github.com/gogo/protobuf/proto"
+	grpc "google.golang.org/grpc"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
+
+	v1 "go.opentelemetry.io/collector/internal/data/opentelemetry-proto-gen/logs/v1"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/internal/data/opentelemetry-proto-gen/collector/metrics/v1/metrics_service.pb.go
+++ b/internal/data/opentelemetry-proto-gen/collector/metrics/v1/metrics_service.pb.go
@@ -6,14 +6,16 @@ package v1
 import (
 	context "context"
 	fmt "fmt"
-	proto "github.com/gogo/protobuf/proto"
-	v1 "go.opentelemetry.io/collector/internal/data/opentelemetry-proto-gen/metrics/v1"
-	grpc "google.golang.org/grpc"
-	codes "google.golang.org/grpc/codes"
-	status "google.golang.org/grpc/status"
 	io "io"
 	math "math"
 	math_bits "math/bits"
+
+	proto "github.com/gogo/protobuf/proto"
+	grpc "google.golang.org/grpc"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
+
+	v1 "go.opentelemetry.io/collector/internal/data/opentelemetry-proto-gen/metrics/v1"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/internal/data/opentelemetry-proto-gen/collector/trace/v1/trace_config.pb.go
+++ b/internal/data/opentelemetry-proto-gen/collector/trace/v1/trace_config.pb.go
@@ -6,10 +6,11 @@ package v1
 import (
 	encoding_binary "encoding/binary"
 	fmt "fmt"
-	proto "github.com/gogo/protobuf/proto"
 	io "io"
 	math "math"
 	math_bits "math/bits"
+
+	proto "github.com/gogo/protobuf/proto"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/internal/data/opentelemetry-proto-gen/collector/trace/v1/trace_service.pb.go
+++ b/internal/data/opentelemetry-proto-gen/collector/trace/v1/trace_service.pb.go
@@ -6,14 +6,16 @@ package v1
 import (
 	context "context"
 	fmt "fmt"
-	proto "github.com/gogo/protobuf/proto"
-	v1 "go.opentelemetry.io/collector/internal/data/opentelemetry-proto-gen/trace/v1"
-	grpc "google.golang.org/grpc"
-	codes "google.golang.org/grpc/codes"
-	status "google.golang.org/grpc/status"
 	io "io"
 	math "math"
 	math_bits "math/bits"
+
+	proto "github.com/gogo/protobuf/proto"
+	grpc "google.golang.org/grpc"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
+
+	v1 "go.opentelemetry.io/collector/internal/data/opentelemetry-proto-gen/trace/v1"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/internal/data/opentelemetry-proto-gen/common/v1/common.pb.go
+++ b/internal/data/opentelemetry-proto-gen/common/v1/common.pb.go
@@ -6,10 +6,11 @@ package v1
 import (
 	encoding_binary "encoding/binary"
 	fmt "fmt"
-	proto "github.com/gogo/protobuf/proto"
 	io "io"
 	math "math"
 	math_bits "math/bits"
+
+	proto "github.com/gogo/protobuf/proto"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/internal/data/opentelemetry-proto-gen/logs/v1/logs.pb.go
+++ b/internal/data/opentelemetry-proto-gen/logs/v1/logs.pb.go
@@ -6,12 +6,14 @@ package v1
 import (
 	encoding_binary "encoding/binary"
 	fmt "fmt"
-	proto "github.com/gogo/protobuf/proto"
-	v11 "go.opentelemetry.io/collector/internal/data/opentelemetry-proto-gen/common/v1"
-	v1 "go.opentelemetry.io/collector/internal/data/opentelemetry-proto-gen/resource/v1"
 	io "io"
 	math "math"
 	math_bits "math/bits"
+
+	proto "github.com/gogo/protobuf/proto"
+
+	v11 "go.opentelemetry.io/collector/internal/data/opentelemetry-proto-gen/common/v1"
+	v1 "go.opentelemetry.io/collector/internal/data/opentelemetry-proto-gen/resource/v1"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/internal/data/opentelemetry-proto-gen/metrics/v1/metrics.pb.go
+++ b/internal/data/opentelemetry-proto-gen/metrics/v1/metrics.pb.go
@@ -6,12 +6,14 @@ package v1
 import (
 	encoding_binary "encoding/binary"
 	fmt "fmt"
-	proto "github.com/gogo/protobuf/proto"
-	v11 "go.opentelemetry.io/collector/internal/data/opentelemetry-proto-gen/common/v1"
-	v1 "go.opentelemetry.io/collector/internal/data/opentelemetry-proto-gen/resource/v1"
 	io "io"
 	math "math"
 	math_bits "math/bits"
+
+	proto "github.com/gogo/protobuf/proto"
+
+	v11 "go.opentelemetry.io/collector/internal/data/opentelemetry-proto-gen/common/v1"
+	v1 "go.opentelemetry.io/collector/internal/data/opentelemetry-proto-gen/resource/v1"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/internal/data/opentelemetry-proto-gen/resource/v1/resource.pb.go
+++ b/internal/data/opentelemetry-proto-gen/resource/v1/resource.pb.go
@@ -5,11 +5,13 @@ package v1
 
 import (
 	fmt "fmt"
-	proto "github.com/gogo/protobuf/proto"
-	v1 "go.opentelemetry.io/collector/internal/data/opentelemetry-proto-gen/common/v1"
 	io "io"
 	math "math"
 	math_bits "math/bits"
+
+	proto "github.com/gogo/protobuf/proto"
+
+	v1 "go.opentelemetry.io/collector/internal/data/opentelemetry-proto-gen/common/v1"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/internal/data/opentelemetry-proto-gen/trace/v1/trace.pb.go
+++ b/internal/data/opentelemetry-proto-gen/trace/v1/trace.pb.go
@@ -6,12 +6,14 @@ package v1
 import (
 	encoding_binary "encoding/binary"
 	fmt "fmt"
-	proto "github.com/gogo/protobuf/proto"
-	v11 "go.opentelemetry.io/collector/internal/data/opentelemetry-proto-gen/common/v1"
-	v1 "go.opentelemetry.io/collector/internal/data/opentelemetry-proto-gen/resource/v1"
 	io "io"
 	math "math"
 	math_bits "math/bits"
+
+	proto "github.com/gogo/protobuf/proto"
+
+	v11 "go.opentelemetry.io/collector/internal/data/opentelemetry-proto-gen/common/v1"
+	v1 "go.opentelemetry.io/collector/internal/data/opentelemetry-proto-gen/resource/v1"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.


### PR DESCRIPTION
This ensures that you can run 'make fmt' and not have to manually
fix a bunch of stuff that shouldn't be in a PR.