### PR TITLE
Infer OpenCensus resource type based on OpenTelemetry's semantic conventions

### DIFF
--- a/translator/internaldata/resource_to_oc.go
+++ b/translator/internaldata/resource_to_oc.go
@@ -29,36 +29,36 @@ import (
 	"go.opentelemetry.io/collector/translator/conventions"
 )
 
-type ocResourceTypeDetector struct {
+type ocInferredResourceType struct {
 	// label presence to check against
-	labelKey string
-	// matching resource type
+	labelKeyPresent string
+	// inferred resource type
 	resourceType string
 }
 
 // mapping of label presence to inferred OC resource type
 // NOTE: defined in the priority order (first match wins)
-var attributeToResourceType = []ocResourceTypeDetector{
+var labelPresenceToResourceType = []ocInferredResourceType{
 	{
 		// See https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/resource/semantic_conventions/container.md
-		labelKey:     conventions.AttributeContainerName,
-		resourceType: resourcekeys.ContainerType,
+		labelKeyPresent: conventions.AttributeContainerName,
+		resourceType:    resourcekeys.ContainerType,
 	},
 	{
 		// See https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/resource/semantic_conventions/k8s.md#pod
-		labelKey: conventions.AttributeK8sPod,
+		labelKeyPresent: conventions.AttributeK8sPod,
 		// NOTE: OpenCensus is using "k8s" rather than "k8s.pod" for Pod
 		resourceType: resourcekeys.K8SType,
 	},
 	{
 		// See https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/resource/semantic_conventions/host.md
-		labelKey:     conventions.AttributeHostName,
-		resourceType: resourcekeys.HostType,
+		labelKeyPresent: conventions.AttributeHostName,
+		resourceType:    resourcekeys.HostType,
 	},
 	{
 		// See https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/resource/semantic_conventions/cloud.md
-		labelKey:     conventions.AttributeCloudProvider,
-		resourceType: resourcekeys.CloudType,
+		labelKeyPresent: conventions.AttributeCloudProvider,
+		resourceType:    resourcekeys.CloudType,
 	},
 }
 
@@ -200,9 +200,9 @@ func inferResourceType(labels map[string]string) (string, bool) {
 		return "", false
 	}
 
-	for _, detector := range attributeToResourceType {
-		if _, ok := labels[detector.labelKey]; ok {
-			return detector.resourceType, true
+	for _, mapping := range labelPresenceToResourceType {
+		if _, ok := labels[mapping.labelKeyPresent]; ok {
+			return mapping.resourceType, true
 		}
 	}
 

--- a/translator/internaldata/resource_to_oc.go
+++ b/translator/internaldata/resource_to_oc.go
@@ -41,23 +41,23 @@ type ocResourceTypeDetector struct {
 var attributeToResourceType = []ocResourceTypeDetector{
 	{
 		// See https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/resource/semantic_conventions/container.md
-		labelKey:     resourcekeys.ContainerKeyName,
+		labelKey:     conventions.AttributeContainerName,
 		resourceType: resourcekeys.ContainerType,
 	},
 	{
 		// See https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/resource/semantic_conventions/k8s.md#pod
-		labelKey: resourcekeys.K8SKeyPodName,
+		labelKey: conventions.AttributeK8sPod,
 		// NOTE: OpenCensus is using "k8s" rather than "k8s.pod" for Pod
 		resourceType: resourcekeys.K8SType,
 	},
 	{
 		// See https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/resource/semantic_conventions/host.md
-		labelKey:     resourcekeys.HostKeyName,
+		labelKey:     conventions.AttributeHostName,
 		resourceType: resourcekeys.HostType,
 	},
 	{
 		// See https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/resource/semantic_conventions/cloud.md
-		labelKey:     resourcekeys.CloudKeyProvider,
+		labelKey:     conventions.AttributeCloudProvider,
 		resourceType: resourcekeys.CloudType,
 	},
 }

--- a/translator/internaldata/resource_to_oc_test.go
+++ b/translator/internaldata/resource_to_oc_test.go
@@ -21,6 +21,7 @@ import (
 	agenttracepb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/trace/v1"
 	ocresource "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
 	"github.com/stretchr/testify/assert"
+	"go.opencensus.io/resource/resourcekeys"
 	"google.golang.org/protobuf/proto"
 
 	"go.opentelemetry.io/collector/consumer/pdata"
@@ -88,6 +89,78 @@ func TestAttributeValueToString(t *testing.T) {
 	v.MapVal().Insert("d", pdata.NewAttributeValueNull())
 	v.MapVal().Insert("e", v)
 	assert.EqualValues(t, `{"a\"\\":"b\"\\","c":123,"d":null,"e":{"a\"\\":"b\"\\","c":123,"d":null}}`, attributeValueToString(v, false))
+}
+
+func TestInferResourceType(t *testing.T) {
+	tests := []struct {
+		name             string
+		labels           map[string]string
+		wantResourceType string
+		wantOk           bool
+	}{
+		{
+			name:   "empty labels",
+			labels: nil,
+			wantOk: false,
+		},
+		{
+			name: "container",
+			labels: map[string]string{
+				resourcekeys.K8SKeyClusterName:   "cluster1",
+				resourcekeys.K8SKeyPodName:       "pod1",
+				resourcekeys.K8SKeyNamespaceName: "namespace1",
+				resourcekeys.ContainerKeyName:    "container-name1",
+				resourcekeys.CloudKeyAccountID:   "proj1",
+				resourcekeys.CloudKeyZone:        "zone1",
+			},
+			wantResourceType: resourcekeys.ContainerType,
+			wantOk:           true,
+		},
+		{
+			name: "pod",
+			labels: map[string]string{
+				resourcekeys.K8SKeyClusterName:   "cluster1",
+				resourcekeys.K8SKeyPodName:       "pod1",
+				resourcekeys.K8SKeyNamespaceName: "namespace1",
+				resourcekeys.CloudKeyZone:        "zone1",
+			},
+			wantResourceType: resourcekeys.K8SType,
+			wantOk:           true,
+		},
+		{
+			name: "host",
+			labels: map[string]string{
+				resourcekeys.K8SKeyClusterName: "cluster1",
+				resourcekeys.CloudKeyZone:      "zone1",
+				resourcekeys.HostKeyName:       "node1",
+			},
+			wantResourceType: resourcekeys.HostType,
+			wantOk:           true,
+		},
+		{
+			name: "gce",
+			labels: map[string]string{
+				resourcekeys.CloudKeyProvider: resourcekeys.CloudProviderGCP,
+				resourcekeys.HostKeyID:        "inst1",
+				resourcekeys.CloudKeyZone:     "zone1",
+			},
+			wantResourceType: resourcekeys.CloudType,
+			wantOk:           true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			resourceType, ok := inferResourceType(tc.labels)
+			if tc.wantOk {
+				assert.True(t, ok)
+				assert.Equal(t, tc.wantResourceType, resourceType)
+			} else {
+				assert.False(t, ok)
+				assert.Equal(t, "", resourceType)
+			}
+		})
+	}
 }
 
 func BenchmarkInternalResourceToOC(b *testing.B) {

--- a/translator/internaldata/resource_to_oc_test.go
+++ b/translator/internaldata/resource_to_oc_test.go
@@ -22,6 +22,7 @@ import (
 	ocresource "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
 	"github.com/stretchr/testify/assert"
 	"go.opencensus.io/resource/resourcekeys"
+	"go.opentelemetry.io/collector/translator/conventions"
 	"google.golang.org/protobuf/proto"
 
 	"go.opentelemetry.io/collector/consumer/pdata"
@@ -106,12 +107,12 @@ func TestInferResourceType(t *testing.T) {
 		{
 			name: "container",
 			labels: map[string]string{
-				resourcekeys.K8SKeyClusterName:   "cluster1",
-				resourcekeys.K8SKeyPodName:       "pod1",
-				resourcekeys.K8SKeyNamespaceName: "namespace1",
-				resourcekeys.ContainerKeyName:    "container-name1",
-				resourcekeys.CloudKeyAccountID:   "proj1",
-				resourcekeys.CloudKeyZone:        "zone1",
+				conventions.AttributeK8sCluster:    "cluster1",
+				conventions.AttributeK8sPod:        "pod1",
+				conventions.AttributeK8sNamespace:  "namespace1",
+				conventions.AttributeContainerName: "container-name1",
+				conventions.AttributeCloudAccount:  "proj1",
+				conventions.AttributeCloudZone:     "zone1",
 			},
 			wantResourceType: resourcekeys.ContainerType,
 			wantOk:           true,
@@ -119,10 +120,10 @@ func TestInferResourceType(t *testing.T) {
 		{
 			name: "pod",
 			labels: map[string]string{
-				resourcekeys.K8SKeyClusterName:   "cluster1",
-				resourcekeys.K8SKeyPodName:       "pod1",
-				resourcekeys.K8SKeyNamespaceName: "namespace1",
-				resourcekeys.CloudKeyZone:        "zone1",
+				conventions.AttributeK8sCluster:   "cluster1",
+				conventions.AttributeK8sPod:       "pod1",
+				conventions.AttributeK8sNamespace: "namespace1",
+				conventions.AttributeCloudZone:    "zone1",
 			},
 			wantResourceType: resourcekeys.K8SType,
 			wantOk:           true,
@@ -130,9 +131,9 @@ func TestInferResourceType(t *testing.T) {
 		{
 			name: "host",
 			labels: map[string]string{
-				resourcekeys.K8SKeyClusterName: "cluster1",
-				resourcekeys.CloudKeyZone:      "zone1",
-				resourcekeys.HostKeyName:       "node1",
+				conventions.AttributeK8sCluster: "cluster1",
+				conventions.AttributeCloudZone:  "zone1",
+				conventions.AttributeHostName:   "node1",
 			},
 			wantResourceType: resourcekeys.HostType,
 			wantOk:           true,
@@ -140,9 +141,9 @@ func TestInferResourceType(t *testing.T) {
 		{
 			name: "gce",
 			labels: map[string]string{
-				resourcekeys.CloudKeyProvider: resourcekeys.CloudProviderGCP,
-				resourcekeys.HostKeyID:        "inst1",
-				resourcekeys.CloudKeyZone:     "zone1",
+				conventions.AttributeCloudProvider: "gcp",
+				conventions.AttributeHostID:        "inst1",
+				conventions.AttributeCloudZone:     "zone1",
 			},
 			wantResourceType: resourcekeys.CloudType,
 			wantOk:           true,

--- a/translator/internaldata/resource_to_oc_test.go
+++ b/translator/internaldata/resource_to_oc_test.go
@@ -23,11 +23,11 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	"go.opencensus.io/resource/resourcekeys"
-	"go.opentelemetry.io/collector/translator/conventions"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/testing/protocmp"
 
 	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.opentelemetry.io/collector/translator/conventions"
 )
 
 func TestResourceToOC(t *testing.T) {
@@ -103,6 +103,15 @@ func TestContainerResourceToOC(t *testing.T) {
 	}
 
 	_, ocResource := internalResourceToOC(resource)
+	if diff := cmp.Diff(want, ocResource, protocmp.Transform()); diff != "" {
+		t.Errorf("Unexpected difference:\n%v", diff)
+	}
+
+	// Also test that the explicit resource type is preserved if present
+	resource.Attributes().InsertString(conventions.OCAttributeResourceType, "other-type")
+	want.Type = "other-type"
+
+	_, ocResource = internalResourceToOC(resource)
 	if diff := cmp.Diff(want, ocResource, protocmp.Transform()); diff != "" {
 		t.Errorf("Unexpected difference:\n%v", diff)
 	}


### PR DESCRIPTION
**Disclaimer**: I have initially tried to fix this issue for Stackdriver exporter only (https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/581), but it seems generic enough to be part of the core.

**Description:** 
Reverse mapping from [OpenTelemetry's semantic conventions](https://github.com/open-telemetry/opentelemetry-specification/tree/master/specification/resource/semantic_conventions) to OpenCensus resource type.

Since OpenTelemetry has switched to using semantic conventions over explicit resource types, the resource type may now be missing when converted to OpenCensus resource.
In that case we will try to infer the resource type based on documented conventions.

**Link to tracking Issue:**
The issue has been originally discussed in https://github.com/open-telemetry/opentelemetry-python/issues/951#issuecomment-666095032, pointing to inconsistency between OpenCensus and OpenTelemetry which needs to be addressed.



**Testing:** Unit tests added for new functionality

**Documentation:** No documentation needed, we may just refer to the already documented semantic conventions.

/cc @james-bebbington