### PR TITLE
Add example and test for scraping Pod metrics with Prometheus receiver

### DIFF
--- a/receiver/prometheusreceiver/README.md
+++ b/receiver/prometheusreceiver/README.md
@@ -23,14 +23,18 @@ receivers:
     prometheus:
       config:
         scrape_configs:
-          - job_name: 'opencensus_service'
+          - job_name: 'otel-collector'
             scrape_interval: 5s
             static_configs:
-              - targets: ['0.0.0.0:8889']
-          - job_name: 'jdbc_apps'
-            scrape_interval: 3s
-            static_configs:
-              - targets: ['0.0.0.0:9777']
+              - targets: ['0.0.0.0:8888']
+          - job_name: k8s
+            kubernetes_sd_configs:
+            - role: pod
+            relabel_configs:
+            - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+              regex: "true"
+              action: keep
+
 ```
 
 ### Include Filter

--- a/receiver/prometheusreceiver/README.md
+++ b/receiver/prometheusreceiver/README.md
@@ -17,7 +17,9 @@ receivers:
     config:
 ```
 
-For example:
+This receiver is a drop-in replacement for getting Prometheus to scrape your 
+services. It supports the full set of Prometheus configuration, including 
+service discovery. For example:
 ```yaml
 receivers:
     prometheus:
@@ -34,7 +36,10 @@ receivers:
             - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
               regex: "true"
               action: keep
-
+            metric_relabel_configs:
+            - source_labels: [__name__]
+              regex: "(request_duration_seconds.*|response_duration_seconds.*)"
+              action: keep
 ```
 
 ### Include Filter

--- a/receiver/prometheusreceiver/README.md
+++ b/receiver/prometheusreceiver/README.md
@@ -4,7 +4,8 @@ Receives metric data in [Prometheus](https://prometheus.io/) format. See the
 [Design](DESIGN.md) for additional information on this receiver.
 
 This receiver is a drop-in replacement for getting Prometheus to scrape your
-services. Just like you would write in a YAML configuration file before
+services. It supports the full set of Prometheus configuration, including 
+service discovery. Just like you would write in a YAML configuration file before
 starting Prometheus, such as with:
 ```shell
 prometheus --config.file=prom.yaml
@@ -17,9 +18,7 @@ receivers:
     config:
 ```
 
-This receiver is a drop-in replacement for getting Prometheus to scrape your 
-services. It supports the full set of Prometheus configuration, including 
-service discovery. For example:
+For example:
 ```yaml
 receivers:
     prometheus:

--- a/receiver/prometheusreceiver/testdata/config_k8s.yaml
+++ b/receiver/prometheusreceiver/testdata/config_k8s.yaml
@@ -1,0 +1,42 @@
+receivers:
+  prometheus:
+    config:
+      scrape_configs:
+      - job_name: apps
+        kubernetes_sd_configs:
+        - role: pod
+          selectors:
+          - role: pod
+            # only scrape data from pods running on the same node as collector
+            field: "spec.nodeName=$NODE_NAME"
+        relabel_configs:
+        # scrape pods annotated with "prometheus.io/scrape: true"
+        - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+          regex: "true"
+          action: keep
+        # read the port from "prometheus.io/port: <port>" annotation and update scraping address accordingly
+        - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+          action: replace
+          target_label: __address__
+          regex: ([^:]+)(?::\d+)?;(\d+)
+          # escaped $1:$2
+          replacement: $$1:$$2
+        - source_labels: [__meta_kubernetes_namespace]
+          action: replace
+          target_label: kubernetes_namespace
+        - source_labels: [__meta_kubernetes_pod_name]
+          action: replace
+          target_label: kubernetes_pod_name
+
+processors:
+  exampleprocessor:
+
+exporters:
+  exampleexporter:
+
+service:
+  pipelines:
+    traces:
+      receivers: [prometheus]
+      processors: [exampleprocessor]
+      exporters: [exampleexporter]


### PR DESCRIPTION
**Description:** 
Added a test for Prometheus receiver configured to scrape metrics from Kubernetes Pods.
Also includes check for environment variable substitution with escaping support.

**Testing:** Unit test

**Documentation:** README is also update to include a basic K8s config