### PR TITLE
Add new FactoryUnmarshaler support to all components, deprecate old way

### DIFF
--- a/component/component.go
+++ b/component/component.go
@@ -17,6 +17,8 @@ package component
 import (
 	"context"
 
+	"github.com/spf13/viper"
+
 	"go.opentelemetry.io/collector/config/configmodels"
 )
 
@@ -86,3 +88,22 @@ type Factory interface {
 	// Type gets the type of the component created by this factory.
 	Type() configmodels.Type
 }
+
+// ConfigUnmarshaler interface is an optional interface that if implemented by a Factory,
+// the configuration loading system will use to unmarshal the config.
+type ConfigUnmarshaler interface {
+	// Unmarshal is a function that un-marshals a viper data into a config struct in a custom way.
+	// componentViperSection *viper.Viper
+	//   The config for this specific component. May be nil or empty if no config available.
+	// intoCfg interface{}
+	//   An empty interface wrapping a pointer to the config struct to unmarshal into.
+	Unmarshal(componentViperSection *viper.Viper, intoCfg interface{}) error
+}
+
+// CustomUnmarshaler is a function that un-marshals a viper data into a config struct
+// in a custom way.
+// componentViperSection *viper.Viper
+//   The config for this specific component. May be nil or empty if no config available.
+// intoCfg interface{}
+//   An empty interface wrapping a pointer to the config struct to unmarshal into.
+type CustomUnmarshaler func(componentViperSection *viper.Viper, intoCfg interface{}) error

--- a/component/receiver.go
+++ b/component/receiver.go
@@ -17,7 +17,6 @@ package component
 import (
 	"context"
 
-	"github.com/spf13/viper"
 	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/config/configmodels"
@@ -68,20 +67,7 @@ type ReceiverFactoryBase interface {
 	// 'configcheck.ValidateConfig'. It is recommended to have such check in the
 	// tests of any implementation of the Factory interface.
 	CreateDefaultConfig() configmodels.Receiver
-
-	// CustomUnmarshaler returns a custom unmarshaler for the configuration or nil if
-	// there is no need for custom unmarshaling. This is typically used if viper.UnmarshalExact()
-	// is not sufficient to unmarshal correctly.
-	CustomUnmarshaler() CustomUnmarshaler
 }
-
-// CustomUnmarshaler is a function that un-marshals a viper data into a config struct
-// in a custom way.
-// componentViperSection *viper.Viper
-//   The config for this specific component. May be nil or empty if no config available.
-// intoCfg interface{}
-//   An empty interface wrapping a pointer to the config struct to unmarshal into.
-type CustomUnmarshaler func(componentViperSection *viper.Viper, intoCfg interface{}) error
 
 // ReceiverFactoryOld can create TraceReceiver and MetricsReceiver.
 type ReceiverFactoryOld interface {

--- a/component/receiver_test.go
+++ b/component/receiver_test.go
@@ -34,11 +34,6 @@ func (f *TestReceiverFactory) Type() configmodels.Type {
 	return f.name
 }
 
-// CustomUnmarshaler returns nil because we don't need custom unmarshaling for this factory.
-func (f *TestReceiverFactory) CustomUnmarshaler() CustomUnmarshaler {
-	return nil
-}
-
 // CreateDefaultConfig creates the default configuration for the Receiver.
 func (f *TestReceiverFactory) CreateDefaultConfig() configmodels.Receiver {
 	return nil

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -421,8 +421,10 @@ func TestDecodeConfig_MultiProto(t *testing.T) {
 
 	assert.Equal(t,
 		&componenttest.MultiProtoReceiver{
-			TypeVal: "multireceiver",
-			NameVal: "multireceiver",
+			ReceiverSettings: configmodels.ReceiverSettings{
+				TypeVal: "multireceiver",
+				NameVal: "multireceiver",
+			},
 			Protocols: map[string]componenttest.MultiProtoReceiverOneCfg{
 				"http": {
 					Endpoint:     "example.com:8888",
@@ -439,8 +441,10 @@ func TestDecodeConfig_MultiProto(t *testing.T) {
 
 	assert.Equal(t,
 		&componenttest.MultiProtoReceiver{
-			TypeVal: "multireceiver",
-			NameVal: "multireceiver/myreceiver",
+			ReceiverSettings: configmodels.ReceiverSettings{
+				TypeVal: "multireceiver",
+				NameVal: "multireceiver/myreceiver",
+			},
 			Protocols: map[string]componenttest.MultiProtoReceiverOneCfg{
 				"http": {
 					Endpoint:     "localhost:12345",

--- a/receiver/jaegerreceiver/factory_test.go
+++ b/receiver/jaegerreceiver/factory_test.go
@@ -313,12 +313,12 @@ func TestRemoteSamplingFileRequiresGRPC(t *testing.T) {
 func TestCustomUnmarshalErrors(t *testing.T) {
 	factory := NewFactory()
 
-	f := factory.CustomUnmarshaler()
-	assert.NotNil(t, f, "custom unmarshal function should not be nil")
+	fu, ok := factory.(component.ConfigUnmarshaler)
+	assert.True(t, ok)
 
-	err := f(config.NewViper(), nil)
+	err := fu.Unmarshal(config.NewViper(), nil)
 	assert.Error(t, err, "should not have been able to marshal to a nil config")
 
-	err = f(config.NewViper(), &RemoteSamplingConfig{})
+	err = fu.Unmarshal(config.NewViper(), &RemoteSamplingConfig{})
 	assert.Error(t, err, "should not have been able to marshal to a non-jaegerreceiver config")
 }

--- a/receiver/opencensusreceiver/factory.go
+++ b/receiver/opencensusreceiver/factory.go
@@ -40,11 +40,6 @@ func (f *Factory) Type() configmodels.Type {
 	return typeStr
 }
 
-// CustomUnmarshaler returns nil because we don't need custom unmarshaling for this config.
-func (f *Factory) CustomUnmarshaler() component.CustomUnmarshaler {
-	return nil
-}
-
 // CreateDefaultConfig creates the default configuration for receiver.
 func (f *Factory) CreateDefaultConfig() configmodels.Receiver {
 	return &Config{
@@ -65,8 +60,8 @@ func (f *Factory) CreateDefaultConfig() configmodels.Receiver {
 
 // CreateTraceReceiver creates a  trace receiver based on provided config.
 func (f *Factory) CreateTraceReceiver(
-	ctx context.Context,
-	logger *zap.Logger,
+	_ context.Context,
+	_ *zap.Logger,
 	cfg configmodels.Receiver,
 	nextConsumer consumer.TraceConsumerOld,
 ) (component.TraceReceiver, error) {
@@ -81,7 +76,7 @@ func (f *Factory) CreateTraceReceiver(
 }
 
 // CreateMetricsReceiver creates a metrics receiver based on provided config.
-func (f *Factory) CreateMetricsReceiver(ctx context.Context, logger *zap.Logger, cfg configmodels.Receiver, nextConsumer consumer.MetricsConsumerOld) (component.MetricsReceiver, error) {
+func (f *Factory) CreateMetricsReceiver(_ context.Context, _ *zap.Logger, cfg configmodels.Receiver, nextConsumer consumer.MetricsConsumerOld) (component.MetricsReceiver, error) {
 
 	r, err := f.createReceiver(cfg)
 	if err != nil {

--- a/receiver/prometheusreceiver/factory.go
+++ b/receiver/prometheusreceiver/factory.go
@@ -53,12 +53,7 @@ func (f *Factory) Type() configmodels.Type {
 }
 
 // CustomUnmarshaler returns custom unmarshaler for this config.
-func (f *Factory) CustomUnmarshaler() component.CustomUnmarshaler {
-	return CustomUnmarshalerFunc
-}
-
-// CustomUnmarshalerFunc performs custom unmarshaling of config.
-func CustomUnmarshalerFunc(componentViperSection *viper.Viper, intoCfg interface{}) error {
+func (f *Factory) Unmarshal(componentViperSection *viper.Viper, intoCfg interface{}) error {
 	if componentViperSection == nil {
 		return nil
 	}

--- a/service/builder/receivers_builder_test.go
+++ b/service/builder/receivers_builder_test.go
@@ -427,10 +427,6 @@ func (b *badReceiverFactory) CreateDefaultConfig() configmodels.Receiver {
 	return &configmodels.ReceiverSettings{}
 }
 
-func (b *badReceiverFactory) CustomUnmarshaler() component.CustomUnmarshaler {
-	return nil
-}
-
 func (b *badReceiverFactory) CreateTraceReceiver(
 	_ context.Context,
 	_ *zap.Logger,
@@ -453,10 +449,6 @@ func (b *newStyleReceiverFactory) Type() configmodels.Type {
 
 func (b *newStyleReceiverFactory) CreateDefaultConfig() configmodels.Receiver {
 	return &configmodels.ReceiverSettings{}
-}
-
-func (b *newStyleReceiverFactory) CustomUnmarshaler() component.CustomUnmarshaler {
-	return nil
 }
 
 func (b *newStyleReceiverFactory) CreateTraceReceiver(


### PR DESCRIPTION
Updates https://github.com/open-telemetry/opentelemetry-collector/issues/882 - need custom unmarshaler for the exporter to allow multi protocols support.

Fixes https://github.com/open-telemetry/opentelemetry-collector/issues/292