### PR TITLE
Host scrapers: Use same scrape time for all data points coming from same source

### DIFF
--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper.go
@@ -22,6 +22,7 @@ import (
 	"github.com/shirou/gopsutil/host"
 
 	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.opentelemetry.io/collector/receiver/hostmetricsreceiver/internal"
 )
 
 // scraper for CPU Metrics
@@ -59,29 +60,30 @@ func (s *scraper) Close(_ context.Context) error {
 func (s *scraper) ScrapeMetrics(_ context.Context) (pdata.MetricSlice, error) {
 	metrics := pdata.NewMetricSlice()
 
+	now := internal.TimeToUnixNano(time.Now())
 	cpuTimes, err := s.times( /*percpu=*/ true)
 	if err != nil {
 		return metrics, err
 	}
 
 	metrics.Resize(1)
-	initializeCPUTimeMetric(metrics.At(0), s.startTime, cpuTimes)
+	initializeCPUTimeMetric(metrics.At(0), s.startTime, now, cpuTimes)
 	return metrics, nil
 }
 
-func initializeCPUTimeMetric(metric pdata.Metric, startTime pdata.TimestampUnixNano, cpuTimes []cpu.TimesStat) {
+func initializeCPUTimeMetric(metric pdata.Metric, startTime, now pdata.TimestampUnixNano, cpuTimes []cpu.TimesStat) {
 	cpuTimeDescriptor.CopyTo(metric.MetricDescriptor())
 
 	ddps := metric.DoubleDataPoints()
 	ddps.Resize(len(cpuTimes) * cpuStatesLen)
 	for i, cpuTime := range cpuTimes {
-		appendCPUTimeStateDataPoints(ddps, i*cpuStatesLen, startTime, cpuTime)
+		appendCPUTimeStateDataPoints(ddps, i*cpuStatesLen, startTime, now, cpuTime)
 	}
 }
 
 const gopsCPUTotal string = "cpu-total"
 
-func initializeCPUTimeDataPoint(dataPoint pdata.DoubleDataPoint, startTime pdata.TimestampUnixNano, cpuLabel string, stateLabel string, value float64) {
+func initializeCPUTimeDataPoint(dataPoint pdata.DoubleDataPoint, startTime, now pdata.TimestampUnixNano, cpuLabel string, stateLabel string, value float64) {
 	labelsMap := dataPoint.LabelsMap()
 	// ignore cpu label if reporting "total" cpu usage
 	if cpuLabel != gopsCPUTotal {
@@ -90,6 +92,6 @@ func initializeCPUTimeDataPoint(dataPoint pdata.DoubleDataPoint, startTime pdata
 	labelsMap.Insert(stateLabelName, stateLabel)
 
 	dataPoint.SetStartTime(startTime)
-	dataPoint.SetTimestamp(pdata.TimestampUnixNano(uint64(time.Now().UnixNano())))
+	dataPoint.SetTimestamp(now)
 	dataPoint.SetValue(value)
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_linux.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_linux.go
@@ -24,13 +24,13 @@ import (
 
 const cpuStatesLen = 8
 
-func appendCPUTimeStateDataPoints(ddps pdata.DoubleDataPointSlice, startIdx int, startTime pdata.TimestampUnixNano, cpuTime cpu.TimesStat) {
-	initializeCPUTimeDataPoint(ddps.At(startIdx+0), startTime, cpuTime.CPU, userStateLabelValue, cpuTime.User)
-	initializeCPUTimeDataPoint(ddps.At(startIdx+1), startTime, cpuTime.CPU, systemStateLabelValue, cpuTime.System)
-	initializeCPUTimeDataPoint(ddps.At(startIdx+2), startTime, cpuTime.CPU, idleStateLabelValue, cpuTime.Idle)
-	initializeCPUTimeDataPoint(ddps.At(startIdx+3), startTime, cpuTime.CPU, interruptStateLabelValue, cpuTime.Irq)
-	initializeCPUTimeDataPoint(ddps.At(startIdx+4), startTime, cpuTime.CPU, niceStateLabelValue, cpuTime.Nice)
-	initializeCPUTimeDataPoint(ddps.At(startIdx+5), startTime, cpuTime.CPU, softIRQStateLabelValue, cpuTime.Softirq)
-	initializeCPUTimeDataPoint(ddps.At(startIdx+6), startTime, cpuTime.CPU, stealStateLabelValue, cpuTime.Steal)
-	initializeCPUTimeDataPoint(ddps.At(startIdx+7), startTime, cpuTime.CPU, waitStateLabelValue, cpuTime.Iowait)
+func appendCPUTimeStateDataPoints(ddps pdata.DoubleDataPointSlice, startIdx int, startTime, now pdata.TimestampUnixNano, cpuTime cpu.TimesStat) {
+	initializeCPUTimeDataPoint(ddps.At(startIdx+0), startTime, now, cpuTime.CPU, userStateLabelValue, cpuTime.User)
+	initializeCPUTimeDataPoint(ddps.At(startIdx+1), startTime, now, cpuTime.CPU, systemStateLabelValue, cpuTime.System)
+	initializeCPUTimeDataPoint(ddps.At(startIdx+2), startTime, now, cpuTime.CPU, idleStateLabelValue, cpuTime.Idle)
+	initializeCPUTimeDataPoint(ddps.At(startIdx+3), startTime, now, cpuTime.CPU, interruptStateLabelValue, cpuTime.Irq)
+	initializeCPUTimeDataPoint(ddps.At(startIdx+4), startTime, now, cpuTime.CPU, niceStateLabelValue, cpuTime.Nice)
+	initializeCPUTimeDataPoint(ddps.At(startIdx+5), startTime, now, cpuTime.CPU, softIRQStateLabelValue, cpuTime.Softirq)
+	initializeCPUTimeDataPoint(ddps.At(startIdx+6), startTime, now, cpuTime.CPU, stealStateLabelValue, cpuTime.Steal)
+	initializeCPUTimeDataPoint(ddps.At(startIdx+7), startTime, now, cpuTime.CPU, waitStateLabelValue, cpuTime.Iowait)
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_others.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_others.go
@@ -24,9 +24,9 @@ import (
 
 const cpuStatesLen = 4
 
-func appendCPUTimeStateDataPoints(ddps pdata.DoubleDataPointSlice, startIdx int, startTime pdata.TimestampUnixNano, cpuTime cpu.TimesStat) {
-	initializeCPUTimeDataPoint(ddps.At(startIdx+0), startTime, cpuTime.CPU, userStateLabelValue, cpuTime.User)
-	initializeCPUTimeDataPoint(ddps.At(startIdx+1), startTime, cpuTime.CPU, systemStateLabelValue, cpuTime.System)
-	initializeCPUTimeDataPoint(ddps.At(startIdx+2), startTime, cpuTime.CPU, idleStateLabelValue, cpuTime.Idle)
-	initializeCPUTimeDataPoint(ddps.At(startIdx+3), startTime, cpuTime.CPU, interruptStateLabelValue, cpuTime.Irq)
+func appendCPUTimeStateDataPoints(ddps pdata.DoubleDataPointSlice, startIdx int, startTime, now pdata.TimestampUnixNano, cpuTime cpu.TimesStat) {
+	initializeCPUTimeDataPoint(ddps.At(startIdx+0), startTime, now, cpuTime.CPU, userStateLabelValue, cpuTime.User)
+	initializeCPUTimeDataPoint(ddps.At(startIdx+1), startTime, now, cpuTime.CPU, systemStateLabelValue, cpuTime.System)
+	initializeCPUTimeDataPoint(ddps.At(startIdx+2), startTime, now, cpuTime.CPU, idleStateLabelValue, cpuTime.Idle)
+	initializeCPUTimeDataPoint(ddps.At(startIdx+3), startTime, now, cpuTime.CPU, interruptStateLabelValue, cpuTime.Irq)
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_test.go
@@ -91,6 +91,8 @@ func TestScrapeMetrics(t *testing.T) {
 			if runtime.GOOS == "linux" {
 				assertCPUMetricHasLinuxSpecificStateLabels(t, metrics.At(0))
 			}
+
+			internal.AssertSameTimeStampForAllMetrics(t, metrics)
 		})
 	}
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_others_fallback.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_others_fallback.go
@@ -24,5 +24,5 @@ import (
 
 const systemSpecificMetricsLen = 0
 
-func appendSystemSpecificMetrics(metrics pdata.MetricSlice, startIdx int, startTime pdata.TimestampUnixNano, ioCounters map[string]disk.IOCountersStat) {
+func appendSystemSpecificMetrics(metrics pdata.MetricSlice, startIdx int, startTime, now pdata.TimestampUnixNano, ioCounters map[string]disk.IOCountersStat) {
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_others_linux.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_others_linux.go
@@ -24,7 +24,7 @@ import (
 
 const systemSpecificMetricsLen = 1
 
-func appendSystemSpecificMetrics(metrics pdata.MetricSlice, startIdx int, startTime pdata.TimestampUnixNano, ioCounters map[string]disk.IOCountersStat) {
+func appendSystemSpecificMetrics(metrics pdata.MetricSlice, startIdx int, startTime, now pdata.TimestampUnixNano, ioCounters map[string]disk.IOCountersStat) {
 	metric := metrics.At(startIdx)
 	diskMergedDescriptor.CopyTo(metric.MetricDescriptor())
 
@@ -33,8 +33,8 @@ func appendSystemSpecificMetrics(metrics pdata.MetricSlice, startIdx int, startT
 
 	idx := 0
 	for device, ioCounter := range ioCounters {
-		initializeInt64DataPoint(idps.At(idx+0), startTime, device, readDirectionLabelValue, int64(ioCounter.MergedReadCount))
-		initializeInt64DataPoint(idps.At(idx+1), startTime, device, writeDirectionLabelValue, int64(ioCounter.MergedWriteCount))
+		initializeInt64DataPoint(idps.At(idx+0), startTime, now, device, readDirectionLabelValue, int64(ioCounter.MergedReadCount))
+		initializeInt64DataPoint(idps.At(idx+1), startTime, now, device, writeDirectionLabelValue, int64(ioCounter.MergedWriteCount))
 		idx += 2
 	}
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_test.go
@@ -89,6 +89,8 @@ func TestScrapeMetrics(t *testing.T) {
 			if runtime.GOOS == "linux" {
 				assertInt64DiskMetricValid(t, metrics.At(4), diskMergedDescriptor, 0)
 			}
+
+			internal.AssertSameTimeStampForAllMetrics(t, metrics)
 		})
 	}
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/filesystem_scraper_others.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/filesystem_scraper_others.go
@@ -22,12 +22,12 @@ import (
 
 const fileSystemStatesLen = 2
 
-func appendFileSystemUsageStateDataPoints(idps pdata.Int64DataPointSlice, startIdx int, deviceUsage *deviceUsage) {
-	initializeFileSystemUsageDataPoint(idps.At(startIdx+0), deviceUsage.deviceName, usedLabelValue, int64(deviceUsage.usage.Used))
-	initializeFileSystemUsageDataPoint(idps.At(startIdx+1), deviceUsage.deviceName, freeLabelValue, int64(deviceUsage.usage.Free))
+func appendFileSystemUsageStateDataPoints(idps pdata.Int64DataPointSlice, startIdx int, now pdata.TimestampUnixNano, deviceUsage *deviceUsage) {
+	initializeFileSystemUsageDataPoint(idps.At(startIdx+0), now, deviceUsage.deviceName, usedLabelValue, int64(deviceUsage.usage.Used))
+	initializeFileSystemUsageDataPoint(idps.At(startIdx+1), now, deviceUsage.deviceName, freeLabelValue, int64(deviceUsage.usage.Free))
 }
 
 const systemSpecificMetricsLen = 0
 
-func appendSystemSpecificMetrics(metrics pdata.MetricSlice, startIdx int, deviceUsages []*deviceUsage) {
+func appendSystemSpecificMetrics(metrics pdata.MetricSlice, startIdx int, now pdata.TimestampUnixNano, deviceUsages []*deviceUsage) {
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/filesystem_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/filesystem_scraper_test.go
@@ -126,6 +126,8 @@ func TestScrapeMetrics(t *testing.T) {
 				assertFileSystemUsageMetricHasUnixSpecificStateLabels(t, metrics.At(0))
 				assertFileSystemUsageMetricValid(t, metrics.At(1), fileSystemINodesUsageDescriptor, test.expectedDeviceDataPoints*2)
 			}
+
+			internal.AssertSameTimeStampForAllMetrics(t, metrics)
 		})
 	}
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/filesystem_scraper_unix.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/filesystem_scraper_unix.go
@@ -22,15 +22,15 @@ import (
 
 const fileSystemStatesLen = 3
 
-func appendFileSystemUsageStateDataPoints(idps pdata.Int64DataPointSlice, startIdx int, deviceUsage *deviceUsage) {
-	initializeFileSystemUsageDataPoint(idps.At(startIdx+0), deviceUsage.deviceName, usedLabelValue, int64(deviceUsage.usage.Used))
-	initializeFileSystemUsageDataPoint(idps.At(startIdx+1), deviceUsage.deviceName, freeLabelValue, int64(deviceUsage.usage.Free))
-	initializeFileSystemUsageDataPoint(idps.At(startIdx+2), deviceUsage.deviceName, reservedLabelValue, int64(deviceUsage.usage.Total-deviceUsage.usage.Used-deviceUsage.usage.Free))
+func appendFileSystemUsageStateDataPoints(idps pdata.Int64DataPointSlice, startIdx int, now pdata.TimestampUnixNano, deviceUsage *deviceUsage) {
+	initializeFileSystemUsageDataPoint(idps.At(startIdx+0), now, deviceUsage.deviceName, usedLabelValue, int64(deviceUsage.usage.Used))
+	initializeFileSystemUsageDataPoint(idps.At(startIdx+1), now, deviceUsage.deviceName, freeLabelValue, int64(deviceUsage.usage.Free))
+	initializeFileSystemUsageDataPoint(idps.At(startIdx+2), now, deviceUsage.deviceName, reservedLabelValue, int64(deviceUsage.usage.Total-deviceUsage.usage.Used-deviceUsage.usage.Free))
 }
 
 const systemSpecificMetricsLen = 1
 
-func appendSystemSpecificMetrics(metrics pdata.MetricSlice, startIdx int, deviceUsages []*deviceUsage) {
+func appendSystemSpecificMetrics(metrics pdata.MetricSlice, startIdx int, now pdata.TimestampUnixNano, deviceUsages []*deviceUsage) {
 	metric := metrics.At(startIdx)
 	fileSystemINodesUsageDescriptor.CopyTo(metric.MetricDescriptor())
 
@@ -38,7 +38,7 @@ func appendSystemSpecificMetrics(metrics pdata.MetricSlice, startIdx int, device
 	idps.Resize(2 * len(deviceUsages))
 	for idx, deviceUsage := range deviceUsages {
 		startIndex := 2 * idx
-		initializeFileSystemUsageDataPoint(idps.At(startIndex+0), deviceUsage.deviceName, usedLabelValue, int64(deviceUsage.usage.InodesUsed))
-		initializeFileSystemUsageDataPoint(idps.At(startIndex+1), deviceUsage.deviceName, freeLabelValue, int64(deviceUsage.usage.InodesFree))
+		initializeFileSystemUsageDataPoint(idps.At(startIndex+0), now, deviceUsage.deviceName, usedLabelValue, int64(deviceUsage.usage.InodesUsed))
+		initializeFileSystemUsageDataPoint(idps.At(startIndex+1), now, deviceUsage.deviceName, freeLabelValue, int64(deviceUsage.usage.InodesFree))
 	}
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/loadscraper/load_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/loadscraper/load_scraper.go
@@ -18,20 +18,25 @@ import (
 	"context"
 	"time"
 
+	"github.com/shirou/gopsutil/load"
 	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.opentelemetry.io/collector/receiver/hostmetricsreceiver/internal"
 )
 
 // scraper for Load Metrics
 type scraper struct {
 	logger *zap.Logger
 	config *Config
+
+	// for mocking
+	load func() (*load.AvgStat, error)
 }
 
 // newLoadScraper creates a set of Load related metrics
 func newLoadScraper(_ context.Context, logger *zap.Logger, cfg *Config) *scraper {
-	return &scraper{logger: logger, config: cfg}
+	return &scraper{logger: logger, config: cfg, load: getSampledLoadAverages}
 }
 
 // Initialize
@@ -48,24 +53,25 @@ func (s *scraper) Close(ctx context.Context) error {
 func (s *scraper) ScrapeMetrics(_ context.Context) (pdata.MetricSlice, error) {
 	metrics := pdata.NewMetricSlice()
 
-	avgLoadValues, err := getSampledLoadAverages()
+	now := internal.TimeToUnixNano(time.Now())
+	avgLoadValues, err := s.load()
 	if err != nil {
 		return metrics, err
 	}
 
 	metrics.Resize(3)
-	initializeLoadMetric(metrics.At(0), loadAvg1MDescriptor, avgLoadValues.Load1)
-	initializeLoadMetric(metrics.At(1), loadAvg5mDescriptor, avgLoadValues.Load5)
-	initializeLoadMetric(metrics.At(2), loadAvg15mDescriptor, avgLoadValues.Load15)
+	initializeLoadMetric(metrics.At(0), loadAvg1MDescriptor, now, avgLoadValues.Load1)
+	initializeLoadMetric(metrics.At(1), loadAvg5mDescriptor, now, avgLoadValues.Load5)
+	initializeLoadMetric(metrics.At(2), loadAvg15mDescriptor, now, avgLoadValues.Load15)
 	return metrics, nil
 }
 
-func initializeLoadMetric(metric pdata.Metric, metricDescriptor pdata.MetricDescriptor, value float64) {
+func initializeLoadMetric(metric pdata.Metric, metricDescriptor pdata.MetricDescriptor, now pdata.TimestampUnixNano, value float64) {
 	metricDescriptor.CopyTo(metric.MetricDescriptor())
 
 	idps := metric.DoubleDataPoints()
 	idps.Resize(1)
 	dp := idps.At(0)
-	dp.SetTimestamp(pdata.TimestampUnixNano(uint64(time.Now().UnixNano())))
+	dp.SetTimestamp(now)
 	dp.SetValue(value)
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/memory_scraper_linux.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/memory_scraper_linux.go
@@ -24,11 +24,11 @@ import (
 
 const memStatesLen = 6
 
-func appendMemoryUsageStateDataPoints(idps pdata.Int64DataPointSlice, memInfo *mem.VirtualMemoryStat) {
-	initializeMemoryUsageDataPoint(idps.At(0), usedStateLabelValue, int64(memInfo.Used))
-	initializeMemoryUsageDataPoint(idps.At(1), freeStateLabelValue, int64(memInfo.Free))
-	initializeMemoryUsageDataPoint(idps.At(2), bufferedStateLabelValue, int64(memInfo.Buffers))
-	initializeMemoryUsageDataPoint(idps.At(3), cachedStateLabelValue, int64(memInfo.Cached))
-	initializeMemoryUsageDataPoint(idps.At(4), slabReclaimableStateLabelValue, int64(memInfo.SReclaimable))
-	initializeMemoryUsageDataPoint(idps.At(5), slabUnreclaimableStateLabelValue, int64(memInfo.SUnreclaim))
+func appendMemoryUsageStateDataPoints(idps pdata.Int64DataPointSlice, now pdata.TimestampUnixNano, memInfo *mem.VirtualMemoryStat) {
+	initializeMemoryUsageDataPoint(idps.At(0), now, usedStateLabelValue, int64(memInfo.Used))
+	initializeMemoryUsageDataPoint(idps.At(1), now, freeStateLabelValue, int64(memInfo.Free))
+	initializeMemoryUsageDataPoint(idps.At(2), now, bufferedStateLabelValue, int64(memInfo.Buffers))
+	initializeMemoryUsageDataPoint(idps.At(3), now, cachedStateLabelValue, int64(memInfo.Cached))
+	initializeMemoryUsageDataPoint(idps.At(4), now, slabReclaimableStateLabelValue, int64(memInfo.SReclaimable))
+	initializeMemoryUsageDataPoint(idps.At(5), now, slabUnreclaimableStateLabelValue, int64(memInfo.SUnreclaim))
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/memory_scraper_others.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/memory_scraper_others.go
@@ -24,8 +24,8 @@ import (
 
 const memStatesLen = 3
 
-func appendMemoryUsageStateDataPoints(idps pdata.Int64DataPointSlice, memInfo *mem.VirtualMemoryStat) {
-	initializeMemoryUsageDataPoint(idps.At(0), usedStateLabelValue, int64(memInfo.Used))
-	initializeMemoryUsageDataPoint(idps.At(1), freeStateLabelValue, int64(memInfo.Free))
-	initializeMemoryUsageDataPoint(idps.At(2), inactiveStateLabelValue, int64(memInfo.Inactive))
+func appendMemoryUsageStateDataPoints(idps pdata.Int64DataPointSlice, now pdata.TimestampUnixNano, memInfo *mem.VirtualMemoryStat) {
+	initializeMemoryUsageDataPoint(idps.At(0), now, usedStateLabelValue, int64(memInfo.Used))
+	initializeMemoryUsageDataPoint(idps.At(1), now, freeStateLabelValue, int64(memInfo.Free))
+	initializeMemoryUsageDataPoint(idps.At(2), now, inactiveStateLabelValue, int64(memInfo.Inactive))
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/memory_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/memory_scraper_test.go
@@ -73,6 +73,8 @@ func TestScrapeMetrics(t *testing.T) {
 			} else if runtime.GOOS != "windows" {
 				internal.AssertInt64MetricLabelHasValue(t, metrics.At(0), 2, stateLabelName, inactiveStateLabelValue)
 			}
+
+			internal.AssertSameTimeStampForAllMetrics(t, metrics)
 		})
 	}
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/memory_scraper_windows.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/memory_scraper_windows.go
@@ -24,7 +24,7 @@ import (
 
 const memStatesLen = 2
 
-func appendMemoryUsageStateDataPoints(idps pdata.Int64DataPointSlice, memInfo *mem.VirtualMemoryStat) {
-	initializeMemoryUsageDataPoint(idps.At(0), usedStateLabelValue, int64(memInfo.Used))
-	initializeMemoryUsageDataPoint(idps.At(1), freeStateLabelValue, int64(memInfo.Available))
+func appendMemoryUsageStateDataPoints(idps pdata.Int64DataPointSlice, now pdata.TimestampUnixNano, memInfo *mem.VirtualMemoryStat) {
+	initializeMemoryUsageDataPoint(idps.At(0), now, usedStateLabelValue, int64(memInfo.Used))
+	initializeMemoryUsageDataPoint(idps.At(1), now, freeStateLabelValue, int64(memInfo.Available))
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/network_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/network_scraper_test.go
@@ -132,9 +132,12 @@ func TestScrapeMetrics(t *testing.T) {
 				assertNetworkIOMetricValid(t, metrics.At(idx+1), networkDroppedPacketsDescriptor, test.expectedStartTime)
 				assertNetworkIOMetricValid(t, metrics.At(idx+2), networkErrorsDescriptor, test.expectedStartTime)
 				assertNetworkIOMetricValid(t, metrics.At(idx+3), networkIODescriptor, test.expectedStartTime)
+				internal.AssertSameTimeStampForMetrics(t, metrics, 0, 4)
 				idx += 4
 			}
+
 			assertNetworkTCPConnectionsMetricValid(t, metrics.At(idx+0))
+			internal.AssertSameTimeStampForMetrics(t, metrics, idx, idx+1)
 		})
 	}
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/processesscraper/processes_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processesscraper/processes_scraper_test.go
@@ -77,6 +77,8 @@ func TestScrapeMetrics(t *testing.T) {
 			for i, expectedMetricDescriptor := range expectedMetrics {
 				assertProcessesMetricValid(t, metrics.At(i), expectedMetricDescriptor)
 			}
+
+			internal.AssertSameTimeStampForAllMetrics(t, metrics)
 		})
 	}
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/swapscraper/swap_scraper_others.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/swapscraper/swap_scraper_others.go
@@ -25,6 +25,7 @@ import (
 
 	"go.opentelemetry.io/collector/component/componenterror"
 	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.opentelemetry.io/collector/receiver/hostmetricsreceiver/internal"
 )
 
 // scraper for Swap Metrics
@@ -79,6 +80,7 @@ func (s *scraper) ScrapeMetrics(_ context.Context) (pdata.MetricSlice, error) {
 }
 
 func (s *scraper) scrapeAndAppendSwapUsageMetric(metrics pdata.MetricSlice) error {
+	now := internal.TimeToUnixNano(time.Now())
 	vmem, err := s.virtualMemory()
 	if err != nil {
 		return err
@@ -86,28 +88,29 @@ func (s *scraper) scrapeAndAppendSwapUsageMetric(metrics pdata.MetricSlice) erro
 
 	idx := metrics.Len()
 	metrics.Resize(idx + 1)
-	initializeSwapUsageMetric(metrics.At(idx), vmem)
+	initializeSwapUsageMetric(metrics.At(idx), now, vmem)
 	return nil
 }
 
-func initializeSwapUsageMetric(metric pdata.Metric, vmem *mem.VirtualMemoryStat) {
+func initializeSwapUsageMetric(metric pdata.Metric, now pdata.TimestampUnixNano, vmem *mem.VirtualMemoryStat) {
 	swapUsageDescriptor.CopyTo(metric.MetricDescriptor())
 
 	idps := metric.Int64DataPoints()
 	idps.Resize(3)
-	initializeSwapUsageDataPoint(idps.At(0), usedLabelValue, int64(vmem.SwapTotal-vmem.SwapFree-vmem.SwapCached))
-	initializeSwapUsageDataPoint(idps.At(1), freeLabelValue, int64(vmem.SwapFree))
-	initializeSwapUsageDataPoint(idps.At(2), cachedLabelValue, int64(vmem.SwapCached))
+	initializeSwapUsageDataPoint(idps.At(0), now, usedLabelValue, int64(vmem.SwapTotal-vmem.SwapFree-vmem.SwapCached))
+	initializeSwapUsageDataPoint(idps.At(1), now, freeLabelValue, int64(vmem.SwapFree))
+	initializeSwapUsageDataPoint(idps.At(2), now, cachedLabelValue, int64(vmem.SwapCached))
 }
 
-func initializeSwapUsageDataPoint(dataPoint pdata.Int64DataPoint, stateLabel string, value int64) {
+func initializeSwapUsageDataPoint(dataPoint pdata.Int64DataPoint, now pdata.TimestampUnixNano, stateLabel string, value int64) {
 	labelsMap := dataPoint.LabelsMap()
 	labelsMap.Insert(stateLabelName, stateLabel)
-	dataPoint.SetTimestamp(pdata.TimestampUnixNano(uint64(time.Now().UnixNano())))
+	dataPoint.SetTimestamp(now)
 	dataPoint.SetValue(value)
 }
 
 func (s *scraper) scrapeAndAppendPagingMetrics(metrics pdata.MetricSlice) error {
+	now := internal.TimeToUnixNano(time.Now())
 	swap, err := s.swapMemory()
 	if err != nil {
 		return err
@@ -115,43 +118,43 @@ func (s *scraper) scrapeAndAppendPagingMetrics(metrics pdata.MetricSlice) error 
 
 	idx := metrics.Len()
 	metrics.Resize(idx + 2)
-	initializePagingMetric(metrics.At(idx+0), s.startTime, swap)
-	initializePageFaultsMetric(metrics.At(idx+1), s.startTime, swap)
+	initializePagingMetric(metrics.At(idx+0), s.startTime, now, swap)
+	initializePageFaultsMetric(metrics.At(idx+1), s.startTime, now, swap)
 	return nil
 }
 
-func initializePagingMetric(metric pdata.Metric, startTime pdata.TimestampUnixNano, swap *mem.SwapMemoryStat) {
+func initializePagingMetric(metric pdata.Metric, startTime, now pdata.TimestampUnixNano, swap *mem.SwapMemoryStat) {
 	swapPagingDescriptor.CopyTo(metric.MetricDescriptor())
 
 	idps := metric.Int64DataPoints()
 	idps.Resize(4)
-	initializePagingDataPoint(idps.At(0), startTime, majorTypeLabelValue, inDirectionLabelValue, int64(swap.Sin))
-	initializePagingDataPoint(idps.At(1), startTime, majorTypeLabelValue, outDirectionLabelValue, int64(swap.Sout))
-	initializePagingDataPoint(idps.At(2), startTime, minorTypeLabelValue, inDirectionLabelValue, int64(swap.PgIn))
-	initializePagingDataPoint(idps.At(3), startTime, minorTypeLabelValue, outDirectionLabelValue, int64(swap.PgOut))
+	initializePagingDataPoint(idps.At(0), startTime, now, majorTypeLabelValue, inDirectionLabelValue, int64(swap.Sin))
+	initializePagingDataPoint(idps.At(1), startTime, now, majorTypeLabelValue, outDirectionLabelValue, int64(swap.Sout))
+	initializePagingDataPoint(idps.At(2), startTime, now, minorTypeLabelValue, inDirectionLabelValue, int64(swap.PgIn))
+	initializePagingDataPoint(idps.At(3), startTime, now, minorTypeLabelValue, outDirectionLabelValue, int64(swap.PgOut))
 }
 
-func initializePagingDataPoint(dataPoint pdata.Int64DataPoint, startTime pdata.TimestampUnixNano, typeLabel string, directionLabel string, value int64) {
+func initializePagingDataPoint(dataPoint pdata.Int64DataPoint, startTime, now pdata.TimestampUnixNano, typeLabel string, directionLabel string, value int64) {
 	labelsMap := dataPoint.LabelsMap()
 	labelsMap.Insert(typeLabelName, typeLabel)
 	labelsMap.Insert(directionLabelName, directionLabel)
 	dataPoint.SetStartTime(startTime)
-	dataPoint.SetTimestamp(pdata.TimestampUnixNano(uint64(time.Now().UnixNano())))
+	dataPoint.SetTimestamp(now)
 	dataPoint.SetValue(value)
 }
 
-func initializePageFaultsMetric(metric pdata.Metric, startTime pdata.TimestampUnixNano, swap *mem.SwapMemoryStat) {
+func initializePageFaultsMetric(metric pdata.Metric, startTime, now pdata.TimestampUnixNano, swap *mem.SwapMemoryStat) {
 	swapPageFaultsDescriptor.CopyTo(metric.MetricDescriptor())
 
 	idps := metric.Int64DataPoints()
 	idps.Resize(1)
-	initializePageFaultDataPoint(idps.At(0), startTime, minorTypeLabelValue, int64(swap.PgFault))
+	initializePageFaultDataPoint(idps.At(0), startTime, now, minorTypeLabelValue, int64(swap.PgFault))
 	// TODO add swap.PgMajFault once available in gopsutil
 }
 
-func initializePageFaultDataPoint(dataPoint pdata.Int64DataPoint, startTime pdata.TimestampUnixNano, typeLabel string, value int64) {
+func initializePageFaultDataPoint(dataPoint pdata.Int64DataPoint, startTime, now pdata.TimestampUnixNano, typeLabel string, value int64) {
 	dataPoint.LabelsMap().Insert(typeLabelName, typeLabel)
 	dataPoint.SetStartTime(startTime)
-	dataPoint.SetTimestamp(pdata.TimestampUnixNano(uint64(time.Now().UnixNano())))
+	dataPoint.SetTimestamp(now)
 	dataPoint.SetValue(value)
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/swapscraper/swap_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/swapscraper/swap_scraper_test.go
@@ -43,10 +43,13 @@ func TestScrapeMetrics(t *testing.T) {
 	assert.Equal(t, expectedMetrics, metrics.Len())
 
 	assertSwapUsageMetricValid(t, metrics.At(0))
+	internal.AssertSameTimeStampForMetrics(t, metrics, 0, 1)
+
 	assertPagingMetricValid(t, metrics.At(1), 0)
 	if runtime.GOOS != "windows" {
 		assertPageFaultsMetricValid(t, metrics.At(2), 0)
 	}
+	internal.AssertSameTimeStampForMetrics(t, metrics, 1, metrics.Len())
 }
 
 func assertSwapUsageMetricValid(t *testing.T, hostSwapUsageMetric pdata.Metric) {

--- a/receiver/hostmetricsreceiver/internal/testutils.go
+++ b/receiver/hostmetricsreceiver/internal/testutils.go
@@ -70,3 +70,30 @@ func AssertDoubleMetricStartTimeEquals(t *testing.T, metric pdata.Metric, startT
 		require.Equal(t, startTime, ddps.At(i).StartTime())
 	}
 }
+
+func AssertSameTimeStampForAllMetrics(t *testing.T, metrics pdata.MetricSlice) {
+	AssertSameTimeStampForMetrics(t, metrics, 0, metrics.Len())
+}
+
+func AssertSameTimeStampForMetrics(t *testing.T, metrics pdata.MetricSlice, startIdx, endIdx int) {
+	var ts pdata.TimestampUnixNano
+	for i := startIdx; i < endIdx; i++ {
+		metric := metrics.At(i)
+
+		idps := metric.Int64DataPoints()
+		for j := 0; j < idps.Len(); j++ {
+			if ts == 0 {
+				ts = idps.At(j).Timestamp()
+			}
+			require.Equalf(t, ts, idps.At(j).Timestamp(), "metrics contained different end timestamp values")
+		}
+
+		ddps := metric.DoubleDataPoints()
+		for j := 0; j < ddps.Len(); j++ {
+			if ts == 0 {
+				ts = ddps.At(j).Timestamp()
+			}
+			require.Equalf(t, ts, ddps.At(j).Timestamp(), "metrics contained different end timestamp values")
+		}
+	}
+}

--- a/receiver/hostmetricsreceiver/internal/utils.go
+++ b/receiver/hostmetricsreceiver/internal/utils.go
@@ -15,6 +15,8 @@
 package internal
 
 import (
+	"time"
+
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/internal/data"
 )
@@ -28,4 +30,8 @@ func InitializeMetricSlice(metricData data.MetricData) pdata.MetricSlice {
 	ilms.Resize(1)
 	ilm := ilms.At(0)
 	return ilm.Metrics()
+}
+
+func TimeToUnixNano(t time.Time) pdata.TimestampUnixNano {
+	return pdata.TimestampUnixNano(uint64(t.UnixNano()))
 }


### PR DESCRIPTION
**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector/issues/1271

Updated all metrics that come from the same source to use the same timestamp, calculated when scraping the system.

Note there are a couple of places where we get data from different sources within the same scraper which possibly indicates that these should be separated (will consider this change for a future PR):

1. `network`: Network Interface info is obtained separately from Connection Counts
2. `swap`: Swap / Page File Usage is obtained separately from Paging IO

(have not done `process` scraper yet, will do in a separate PR)