### PR TITLE
Always include Zipkin's localEndpoint serviceName

### DIFF
--- a/translator/trace/zipkin/protospan_to_zipkinv1.go
+++ b/translator/trace/zipkin/protospan_to_zipkinv1.go
@@ -79,6 +79,11 @@ func zipkinEndpointFromAttributes(
 ) (endpoint *zipkinmodel.Endpoint) {
 
 	if attrMap == nil {
+		if serviceName != "" {
+			return &zipkinmodel.Endpoint{
+				ServiceName: serviceName,
+			}
+		}
 		return nil
 	}
 


### PR DESCRIPTION
**Description:** 

Fixes a bug with service name being skipped when span contains no attributes

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector/issues/1480

**Testing:** Added unit test and tested manually

**Documentation:** No extra documentation added