### PR TITLE
Add SharedPerConfig option to receiverhelper

### DIFF
--- a/receiver/otlpreceiver/factory_test.go
+++ b/receiver/otlpreceiver/factory_test.go
@@ -348,7 +348,6 @@ func TestCreateLogReceiver(t *testing.T) {
 				require.NoError(t, mr.Start(context.Background(), componenttest.NewNopHost()))
 				assert.NoError(t, mr.Shutdown(context.Background()))
 			}
-			receivers = map[*Config]*otlpReceiver{}
 		})
 	}
 }

--- a/receiver/receiverhelper/factory.go
+++ b/receiver/receiverhelper/factory.go
@@ -56,6 +56,36 @@ func WithLogs(createLogsReceiver CreateLogsReceiver) FactoryOption {
 	}
 }
 
+// WithSharedTraces overrides the default "error not supported" implementation for CreateTraceReceiver.
+func WithSharedTraces(createSharedTraceReceiver CreateSharedTraceReceiver) FactoryOption {
+	return func(o *factory) {
+		o.createSharedTraceReceiver = createSharedTraceReceiver
+	}
+}
+
+// WithSharedMetrics overrides the default "error not supported" implementation for createSharedSharedMetricsReceiver.
+func WithSharedMetrics(createSharedMetricsReceiver CreateSharedMetricsReceiver) FactoryOption {
+	return func(o *factory) {
+		o.createSharedMetricsReceiver = createSharedMetricsReceiver
+	}
+}
+
+// WithSharedLogs overrides the default "error not supported" implementation for createSharedSharedLogsReceiver.
+func WithSharedLogs(createSharedLogsReceiver CreateSharedLogsReceiver) FactoryOption {
+	return func(o *factory) {
+		o.createSharedLogsReceiver = createSharedLogsReceiver
+	}
+}
+
+// WithSharedPerConfig can be set to a function that will create a generic
+// instance of something that will be provided to each Create*Receiver method
+// as part of the params.SharedPerConfig object.
+func WithSharedPerConfig(f func(configmodels.Receiver, component.ReceiverCreateParams) (interface{}, error)) FactoryOption {
+	return func(o *factory) {
+		o.sharedPerConfigMaker = f
+	}
+}
+
 // CreateDefaultConfig is the equivalent of component.ReceiverFactory.CreateDefaultConfig()
 type CreateDefaultConfig func() configmodels.Receiver
 
@@ -68,13 +98,27 @@ type CreateMetricsReceiver func(context.Context, component.ReceiverCreateParams,
 // CreateLogsReceiver is the equivalent of component.ReceiverFactory.CreateLogsReceiver()
 type CreateLogsReceiver func(context.Context, component.ReceiverCreateParams, configmodels.Receiver, consumer.LogsConsumer) (component.LogsReceiver, error)
 
+// CreateSharedTraceReceiver is the equivalent of component.ReceiverFactory.CreateTraceReceiver()
+type CreateSharedTraceReceiver func(context.Context, component.ReceiverCreateParams, configmodels.Receiver, consumer.TraceConsumer, interface{}) (component.TraceReceiver, error)
+
+// CreateSharedMetricsReceiver is the equivalent of component.ReceiverFactory.CreateMetricsReceiver()
+type CreateSharedMetricsReceiver func(context.Context, component.ReceiverCreateParams, configmodels.Receiver, consumer.MetricsConsumer, interface{}) (component.MetricsReceiver, error)
+
+// CreateSharedLogsReceiver is the equivalent of component.ReceiverFactory.CreateLogsReceiver()
+type CreateSharedLogsReceiver func(context.Context, component.ReceiverCreateParams, configmodels.Receiver, consumer.LogsConsumer, interface{}) (component.LogsReceiver, error)
+
 type factory struct {
-	cfgType               configmodels.Type
-	customUnmarshaler     component.CustomUnmarshaler
-	createDefaultConfig   CreateDefaultConfig
-	createTraceReceiver   CreateTraceReceiver
-	createMetricsReceiver CreateMetricsReceiver
-	createLogsReceiver    CreateLogsReceiver
+	cfgType                     configmodels.Type
+	sharedPerConfigMaker        func(configmodels.Receiver, component.ReceiverCreateParams) (interface{}, error)
+	sharedPerConfigInstances    map[configmodels.Receiver]interface{}
+	customUnmarshaler           component.CustomUnmarshaler
+	createDefaultConfig         CreateDefaultConfig
+	createTraceReceiver         CreateTraceReceiver
+	createMetricsReceiver       CreateMetricsReceiver
+	createLogsReceiver          CreateLogsReceiver
+	createSharedTraceReceiver   CreateSharedTraceReceiver
+	createSharedMetricsReceiver CreateSharedMetricsReceiver
+	createSharedLogsReceiver    CreateSharedLogsReceiver
 }
 
 // NewFactory returns a component.ReceiverFactory.
@@ -83,8 +127,9 @@ func NewFactory(
 	createDefaultConfig CreateDefaultConfig,
 	options ...FactoryOption) component.ReceiverFactory {
 	f := &factory{
-		cfgType:             cfgType,
-		createDefaultConfig: createDefaultConfig,
+		cfgType:                  cfgType,
+		createDefaultConfig:      createDefaultConfig,
+		sharedPerConfigInstances: make(map[configmodels.Receiver]interface{}),
 	}
 	for _, opt := range options {
 		opt(f)
@@ -108,6 +153,18 @@ func (f *factory) CreateDefaultConfig() configmodels.Receiver {
 	return f.createDefaultConfig()
 }
 
+func (f *factory) getSharedPerConfig(cfg configmodels.Receiver, params *component.ReceiverCreateParams) (interface{}, error) {
+	if f.sharedPerConfigMaker != nil && f.sharedPerConfigInstances[cfg] == nil {
+		inst, err := f.sharedPerConfigMaker(cfg, *params)
+		if err != nil {
+			return nil, err
+		}
+		f.sharedPerConfigInstances[cfg] = inst
+	}
+
+	return f.sharedPerConfigInstances[cfg], nil
+}
+
 // CreateTraceReceiver creates a component.TraceReceiver based on this config.
 func (f *factory) CreateTraceReceiver(
 	ctx context.Context,
@@ -116,6 +173,12 @@ func (f *factory) CreateTraceReceiver(
 	nextConsumer consumer.TraceConsumer) (component.TraceReceiver, error) {
 	if f.createTraceReceiver != nil {
 		return f.createTraceReceiver(ctx, params, cfg, nextConsumer)
+	} else if f.createSharedTraceReceiver != nil {
+		shared, err := f.getSharedPerConfig(cfg, &params)
+		if err != nil {
+			return nil, err
+		}
+		return f.createSharedTraceReceiver(ctx, params, cfg, nextConsumer, shared)
 	}
 	return nil, configerror.ErrDataTypeIsNotSupported
 }
@@ -128,6 +191,12 @@ func (f *factory) CreateMetricsReceiver(
 	nextConsumer consumer.MetricsConsumer) (component.MetricsReceiver, error) {
 	if f.createMetricsReceiver != nil {
 		return f.createMetricsReceiver(ctx, params, cfg, nextConsumer)
+	} else if f.createSharedMetricsReceiver != nil {
+		shared, err := f.getSharedPerConfig(cfg, &params)
+		if err != nil {
+			return nil, err
+		}
+		return f.createSharedMetricsReceiver(ctx, params, cfg, nextConsumer, shared)
 	}
 	return nil, configerror.ErrDataTypeIsNotSupported
 }
@@ -141,6 +210,12 @@ func (f *factory) CreateLogsReceiver(
 ) (component.LogsReceiver, error) {
 	if f.createLogsReceiver != nil {
 		return f.createLogsReceiver(ctx, params, cfg, nextConsumer)
+	} else if f.createSharedLogsReceiver != nil {
+		shared, err := f.getSharedPerConfig(cfg, &params)
+		if err != nil {
+			return nil, err
+		}
+		return f.createSharedLogsReceiver(ctx, params, cfg, nextConsumer, shared)
 	}
 	return nil, configerror.ErrDataTypeIsNotSupported
 }


### PR DESCRIPTION
Also involves adding CreateShared*Receiver factory options to
accommodate the new function signatures in a backward-comatible manner.

This allows reusing some generic instance of something between receiver
instances across pipeline types for the same configuration value.  This
replaces the old pattern that the otlp receiver used whereby a global map
was kept for this same purpose.  That receiver has also been updated to use
the new factory option.

This pattern will be needed for some upcoming work in the contrib repo.