### PR TITLE
Fix log adapter in Prometheus receiver

### DIFF
--- a/receiver/prometheusreceiver/internal/logger.go
+++ b/receiver/prometheusreceiver/internal/logger.go
@@ -51,6 +51,8 @@ func (w *zapToGokitLogAdapter) Log(keyvals ...interface{}) error {
 	return nil
 }
 
+// extract go-kit log level from key value pairs, convert it to zap log level
+// and remove from the list to avoid duplication in log message
 func extractLogLevel(keyvals []interface{}) (zapcore.Level, []interface{}) {
 	zapLevel := zapcore.InfoLevel
 	output := make([]interface{}, 0, len(keyvals))
@@ -69,6 +71,8 @@ func extractLogLevel(keyvals []interface{}) (zapcore.Level, []interface{}) {
 	return zapLevel, output
 }
 
+// check if a given key-value pair represents go-kit log level and return
+// a corresponding zap log level
 func matchLogLevel(key interface{}, val interface{}) (*zapcore.Level, bool) {
 	strKey, ok := key.(string)
 	if !ok || strKey != "level" {
@@ -84,6 +88,7 @@ func matchLogLevel(key interface{}, val interface{}) (*zapcore.Level, bool) {
 	return &zapLevel, true
 }
 
+// convert go-kit log level to zap
 func toZapLevel(value level.Value) zapcore.Level {
 	// See https://github.com/go-kit/kit/blob/556100560949062d23fe05d9fda4ce173c30c59f/log/level/level.go#L184-L187
 	switch value.String() {
@@ -100,6 +105,7 @@ func toZapLevel(value level.Value) zapcore.Level {
 	}
 }
 
+// find a matching zap logging function to be used for a given level
 func levelToFunc(logger *zap.SugaredLogger, lvl zapcore.Level) (func(string, ...interface{}), error) {
 	switch lvl {
 	case zapcore.DebugLevel:

--- a/receiver/prometheusreceiver/internal/logger.go
+++ b/receiver/prometheusreceiver/internal/logger.go
@@ -101,9 +101,9 @@ func toZapLevel(value level.Value) zapcore.Level {
 		return zapcore.InfoLevel
 	case "debug":
 		return zapcore.DebugLevel
-	default:
-		return zapcore.InfoLevel
 	}
+
+	return zapcore.InfoLevel
 }
 
 // find a matching zap logging function to be used for a given level
@@ -117,12 +117,6 @@ func levelToFunc(logger *zap.SugaredLogger, lvl zapcore.Level) (func(string, ...
 		return logger.Warnf, nil
 	case zapcore.ErrorLevel:
 		return logger.Errorf, nil
-	case zapcore.DPanicLevel:
-		return logger.DPanicf, nil
-	case zapcore.PanicLevel:
-		return logger.Panicf, nil
-	case zapcore.FatalLevel:
-		return logger.Fatalf, nil
 	}
 	return nil, fmt.Errorf("unrecognized level: %q", lvl)
 }

--- a/receiver/prometheusreceiver/internal/logger.go
+++ b/receiver/prometheusreceiver/internal/logger.go
@@ -20,6 +20,11 @@ import (
 	"go.uber.org/zap"
 )
 
+const (
+	levelKey = "level"
+	msgKey   = "msg"
+)
+
 // NewZapToGokitLogAdapter create an adapter for zap.Logger to gokitLog.Logger
 func NewZapToGokitLogAdapter(logger *zap.Logger) gokitLog.Logger {
 	// need to skip two levels in order to get the correct caller
@@ -87,7 +92,7 @@ func extractLogData(keyvals []interface{}) *logData {
 // check if a given key-value pair represents go-kit log message and return it
 func matchLogMessage(key interface{}, val interface{}) (string, bool) {
 	strKey, ok := key.(string)
-	if !ok || strKey != "msg" {
+	if !ok || strKey != msgKey {
 		return "", false
 	}
 
@@ -102,7 +107,7 @@ func matchLogMessage(key interface{}, val interface{}) (string, bool) {
 // check if a given key-value pair represents go-kit log level and return it
 func matchLogLevel(key interface{}, val interface{}) (level.Value, bool) {
 	strKey, ok := key.(string)
-	if !ok || strKey != "level" {
+	if !ok || strKey != levelKey {
 		return nil, false
 	}
 

--- a/receiver/prometheusreceiver/internal/logger.go
+++ b/receiver/prometheusreceiver/internal/logger.go
@@ -38,8 +38,9 @@ type zapToGokitLogAdapter struct {
 func (w *zapToGokitLogAdapter) Log(keyvals ...interface{}) error {
 	// expecting key value pairs, the number of items need to be even
 	if len(keyvals)%2 == 0 {
-		zapLevel, keyvals := extractLogLevel(keyvals)
-		logFunc, err := levelToFunc(w.l, zapLevel)
+		var lvl zapcore.Level
+		lvl, keyvals = extractLogLevel(keyvals)
+		logFunc, err := levelToFunc(w.l, lvl)
 		if err != nil {
 			return err
 		}

--- a/receiver/prometheusreceiver/internal/logger_test.go
+++ b/receiver/prometheusreceiver/internal/logger_test.go
@@ -42,12 +42,30 @@ func TestExtractLogLevel(t *testing.T) {
 			wantOutput: []interface{}{},
 		},
 		{
+			name: "info level",
+			input: []interface{}{
+				"level",
+				level.InfoValue(),
+			},
+			wantLevel:  zapcore.InfoLevel,
+			wantOutput: []interface{}{},
+		},
+		{
 			name: "warn level",
 			input: []interface{}{
 				"level",
 				level.WarnValue(),
 			},
 			wantLevel:  zapcore.WarnLevel,
+			wantOutput: []interface{}{},
+		},
+		{
+			name: "error level",
+			input: []interface{}{
+				"level",
+				level.ErrorValue(),
+			},
+			wantLevel:  zapcore.ErrorLevel,
 			wantOutput: []interface{}{},
 		},
 		{

--- a/receiver/prometheusreceiver/internal/logger_test.go
+++ b/receiver/prometheusreceiver/internal/logger_test.go
@@ -1,0 +1,108 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"testing"
+
+	"github.com/bmizerany/assert"
+	"github.com/go-kit/kit/log/level"
+	"go.uber.org/zap/zapcore"
+)
+
+func TestExtractLogLevel(t *testing.T) {
+	tcs := []struct {
+		name       string
+		input      []interface{}
+		wantLevel  zapcore.Level
+		wantOutput []interface{}
+	}{
+		{
+			name:       "nil fields",
+			input:      nil,
+			wantLevel:  zapcore.InfoLevel, // Default
+			wantOutput: []interface{}{},
+		},
+		{
+			name:       "empty fields",
+			input:      []interface{}{},
+			wantLevel:  zapcore.InfoLevel, // Default
+			wantOutput: []interface{}{},
+		},
+		{
+			name: "warn level",
+			input: []interface{}{
+				"level",
+				level.WarnValue(),
+			},
+			wantLevel:  zapcore.WarnLevel,
+			wantOutput: []interface{}{},
+		},
+		{
+			name: "debug level + extra fields",
+			input: []interface{}{
+				"ts",
+				1596604719.955769,
+				"level",
+				level.DebugValue(),
+				"msg",
+				"http client error",
+			},
+			wantLevel: zapcore.DebugLevel,
+			wantOutput: []interface{}{
+				"ts",
+				1596604719.955769,
+				"msg",
+				"http client error",
+			},
+		},
+		{
+			name: "missing level field",
+			input: []interface{}{
+				"ts",
+				1596604719.955769,
+				"msg",
+				"http client error",
+			},
+			wantLevel: zapcore.InfoLevel, // Default
+			wantOutput: []interface{}{
+				"ts",
+				1596604719.955769,
+				"msg",
+				"http client error",
+			},
+		},
+		{
+			name: "invalid level type",
+			input: []interface{}{
+				"level",
+				"warn", // String is not recognized
+			},
+			wantLevel: zapcore.InfoLevel, // Default
+			wantOutput: []interface{}{
+				"level",
+				"warn", // Field is preserved
+			},
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			zapLevel, output := extractLogLevel(tc.input)
+			assert.Equal(t, tc.wantLevel, zapLevel)
+			assert.Equal(t, tc.wantOutput, output)
+		})
+	}
+}


### PR DESCRIPTION
**Description:**
Fixing a bug:
- deduplicate the "level" field in log messages coming from Prometheus
- use appropriate zap log level rather than always using `Info`

**Link to tracking Issue:** Fixes #1486

**Testing:** Added unit tests

**Documentation:** -