### PR TITLE
Make logs SeverityNumber publicly available

### DIFF
--- a/cmd/pdatagen/internal/base_structs.go
+++ b/cmd/pdatagen/internal/base_structs.go
@@ -251,7 +251,7 @@ func Test${structName}_Append(t *testing.T) {
 	es.Append(&emptyVal)
 	assert.EqualValues(t, *(es.At(7)).orig, *emptyVal.orig)
 
-	emptyVal2:= New${elementName}()
+	emptyVal2 := New${elementName}()
 	emptyVal2.InitEmpty()
 
 	es.Append(&emptyVal2)

--- a/cmd/pdatagen/internal/log_structs.go
+++ b/cmd/pdatagen/internal/log_structs.go
@@ -112,10 +112,10 @@ var logRecord = &messageStruct{
 		&primitiveTypedField{
 			fieldMame:       "SeverityNumber",
 			originFieldName: "SeverityNumber",
-			returnType:      "otlplogs.SeverityNumber",
+			returnType:      "SeverityNumber",
 			rawType:         "otlplogs.SeverityNumber",
-			defaultVal:      `otlplogs.SeverityNumber_UNDEFINED_SEVERITY_NUMBER`,
-			testVal:         `otlplogs.SeverityNumber_INFO`,
+			defaultVal:      `SeverityNumberUNDEFINED`,
+			testVal:         `SeverityNumberINFO`,
 		},
 		&primitiveField{
 			fieldMame:       "Name",

--- a/consumer/pdata/generated_log.go
+++ b/consumer/pdata/generated_log.go
@@ -638,14 +638,14 @@ func (ms LogRecord) SetSeverityText(v string) {
 // SeverityNumber returns the severitynumber associated with this LogRecord.
 //
 // Important: This causes a runtime error if IsNil() returns "true".
-func (ms LogRecord) SeverityNumber() otlplogs.SeverityNumber {
-	return otlplogs.SeverityNumber((*ms.orig).SeverityNumber)
+func (ms LogRecord) SeverityNumber() SeverityNumber {
+	return SeverityNumber((*ms.orig).SeverityNumber)
 }
 
 // SetSeverityNumber replaces the severitynumber associated with this LogRecord.
 //
 // Important: This causes a runtime error if IsNil() returns "true".
-func (ms LogRecord) SetSeverityNumber(v otlplogs.SeverityNumber) {
+func (ms LogRecord) SetSeverityNumber(v SeverityNumber) {
 	(*ms.orig).SeverityNumber = otlplogs.SeverityNumber(v)
 }
 

--- a/consumer/pdata/generated_log_test.go
+++ b/consumer/pdata/generated_log_test.go
@@ -510,8 +510,8 @@ func TestLogRecord_SeverityText(t *testing.T) {
 func TestLogRecord_SeverityNumber(t *testing.T) {
 	ms := NewLogRecord()
 	ms.InitEmpty()
-	assert.EqualValues(t, otlplogs.SeverityNumber_UNDEFINED_SEVERITY_NUMBER, ms.SeverityNumber())
-	testValSeverityNumber := otlplogs.SeverityNumber_INFO
+	assert.EqualValues(t, SeverityNumberUNDEFINED, ms.SeverityNumber())
+	testValSeverityNumber := SeverityNumberINFO
 	ms.SetSeverityNumber(testValSeverityNumber)
 	assert.EqualValues(t, testValSeverityNumber, ms.SeverityNumber())
 }
@@ -631,7 +631,7 @@ func fillTestLogRecord(tv LogRecord) {
 	tv.SetSpanID(NewSpanID([]byte{1, 2, 3, 4, 5, 6, 7, 8}))
 	tv.SetFlags(uint32(0x01))
 	tv.SetSeverityText("INFO")
-	tv.SetSeverityNumber(otlplogs.SeverityNumber_INFO)
+	tv.SetSeverityNumber(SeverityNumberINFO)
 	tv.SetName("test_name")
 	tv.Body().InitEmpty()
 	fillTestAttributeValue(tv.Body())

--- a/consumer/pdata/log.go
+++ b/consumer/pdata/log.go
@@ -84,3 +84,34 @@ func (ld Logs) LogRecordCount() int {
 func (ld Logs) ResourceLogs() ResourceLogsSlice {
 	return ResourceLogsSlice(ld)
 }
+
+// SeverityNumber is the public alias of otlplogs.SeverityNumber from internal package.
+type SeverityNumber otlplogs.SeverityNumber
+
+const (
+	SeverityNumberUNDEFINED = SeverityNumber(otlplogs.SeverityNumber_UNDEFINED_SEVERITY_NUMBER)
+	SeverityNumberTRACE     = SeverityNumber(otlplogs.SeverityNumber_TRACE)
+	SeverityNumberTRACE2    = SeverityNumber(otlplogs.SeverityNumber_TRACE2)
+	SeverityNumberTRACE3    = SeverityNumber(otlplogs.SeverityNumber_TRACE3)
+	SeverityNumberTRACE4    = SeverityNumber(otlplogs.SeverityNumber_TRACE4)
+	SeverityNumberDEBUG     = SeverityNumber(otlplogs.SeverityNumber_DEBUG)
+	SeverityNumberDEBUG2    = SeverityNumber(otlplogs.SeverityNumber_DEBUG2)
+	SeverityNumberDEBUG3    = SeverityNumber(otlplogs.SeverityNumber_DEBUG3)
+	SeverityNumberDEBUG4    = SeverityNumber(otlplogs.SeverityNumber_DEBUG4)
+	SeverityNumberINFO      = SeverityNumber(otlplogs.SeverityNumber_INFO)
+	SeverityNumberINFO2     = SeverityNumber(otlplogs.SeverityNumber_INFO2)
+	SeverityNumberINFO3     = SeverityNumber(otlplogs.SeverityNumber_INFO3)
+	SeverityNumberINFO4     = SeverityNumber(otlplogs.SeverityNumber_INFO4)
+	SeverityNumberWARN      = SeverityNumber(otlplogs.SeverityNumber_WARN)
+	SeverityNumberWARN2     = SeverityNumber(otlplogs.SeverityNumber_WARN2)
+	SeverityNumberWARN3     = SeverityNumber(otlplogs.SeverityNumber_WARN3)
+	SeverityNumberWARN4     = SeverityNumber(otlplogs.SeverityNumber_WARN4)
+	SeverityNumberERROR     = SeverityNumber(otlplogs.SeverityNumber_ERROR)
+	SeverityNumberERROR2    = SeverityNumber(otlplogs.SeverityNumber_ERROR2)
+	SeverityNumberERROR3    = SeverityNumber(otlplogs.SeverityNumber_ERROR3)
+	SeverityNumberERROR4    = SeverityNumber(otlplogs.SeverityNumber_ERROR4)
+	SeverityNumberFATAL     = SeverityNumber(otlplogs.SeverityNumber_FATAL)
+	SeverityNumberFATAL2    = SeverityNumber(otlplogs.SeverityNumber_FATAL2)
+	SeverityNumberFATAL3    = SeverityNumber(otlplogs.SeverityNumber_FATAL3)
+	SeverityNumberFATAL4    = SeverityNumber(otlplogs.SeverityNumber_FATAL4)
+)

--- a/internal/data/testdata/log.go
+++ b/internal/data/testdata/log.go
@@ -266,7 +266,7 @@ func fillLogOne(log pdata.LogRecord) {
 	log.SetName("logA")
 	log.SetTimestamp(TestLogTimestamp)
 	log.SetDroppedAttributesCount(1)
-	log.SetSeverityNumber(otlplogs.SeverityNumber_INFO)
+	log.SetSeverityNumber(pdata.SeverityNumberINFO)
 	log.SetSeverityText("Info")
 	log.SetSpanID([]byte{0x01, 0x02, 0x04, 0x08})
 	log.SetTraceID([]byte{0x08, 0x04, 0x02, 0x01})
@@ -305,7 +305,7 @@ func fillLogTwo(log pdata.LogRecord) {
 	log.SetName("logB")
 	log.SetTimestamp(TestLogTimestamp)
 	log.SetDroppedAttributesCount(1)
-	log.SetSeverityNumber(otlplogs.SeverityNumber_INFO)
+	log.SetSeverityNumber(pdata.SeverityNumberINFO)
 	log.SetSeverityText("Info")
 
 	attrs := log.Attributes()
@@ -340,7 +340,7 @@ func fillLogThree(log pdata.LogRecord) {
 	log.SetName("logC")
 	log.SetTimestamp(TestLogTimestamp)
 	log.SetDroppedAttributesCount(1)
-	log.SetSeverityNumber(otlplogs.SeverityNumber_WARN)
+	log.SetSeverityNumber(pdata.SeverityNumberWARN)
 	log.SetSeverityText("Warning")
 
 	log.Body().SetStringVal("something else happened")


### PR DESCRIPTION
It was previously available in internal package only.
Now we have the public alias for it.

This is consistent with how we treat other enums, e.g. SpanKind.
