### PR TITLE
Remove /tmp from docker image

### DIFF
--- a/cmd/otelcol/Dockerfile
+++ b/cmd/otelcol/Dockerfile
@@ -1,6 +1,5 @@
 FROM alpine:3.12 as certs
 RUN apk --update add ca-certificates
-RUN mkdir -m 777 /scratchtmp
 
 FROM alpine:3.12 AS otelcol
 COPY otelcol /
@@ -9,9 +8,6 @@ COPY otelcol /
 RUN chmod 755 /otelcol
 
 FROM scratch
-# Make an empty /tmp directory as the Kubernetes client-go library tries to log to here.
-# If it is unable to do so, it causes the collector to exit (see issue #587).
-COPY --from=certs /scratchtmp /tmp
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=otelcol /otelcol /
 ENTRYPOINT ["/otelcol"]


### PR DESCRIPTION
**Description:** Removes the workaround for issue #587 since it is not necessary anymore. There is risk in this change since some may have taken a dependency on it existing but it will keep things clean and we will be alerted if some other component is logging to that path.

**Link to tracking Issue:** Fixes #608 (technically it is already fixed but this will detect any other component logging to `/tmp`)

**Testing:** Manual validation using minikube