### PR TITLE
If filterprocessor filters all data, stop further processing

### DIFF
--- a/processor/README.md
+++ b/processor/README.md
@@ -134,6 +134,8 @@ are checked before the `exclude` properties.
 
 ```yaml
 filter:
+  # metrics indicates this processor applies to metrics
+  metrics:
     # include and/or exclude can be specified. However, the include properties
     # are always checked before the exclude properties.
     {include, exclude}:
@@ -148,7 +150,7 @@ filter:
 
       # metric_names specify an array of items to match the metric name against.
       # This is a required field.
-      metric_name: [<item1>, ..., <itemN>]
+      metric_names: [<item1>, ..., <itemN>]
 ```
 
 #### Match Configuration

--- a/processor/processorhelper/processor.go
+++ b/processor/processorhelper/processor.go
@@ -26,6 +26,11 @@ import (
 	"go.opentelemetry.io/collector/obsreport"
 )
 
+// ErrSkipProcessingData is a sentinel value to indicate when traces or metrics should intentionally be dropped
+// from further processing in the pipeline because the data is determined to be irrelevant. A processor can return this error
+// to stop further processing without propagating an error back up the pipeline to logs.
+var ErrSkipProcessingData = errors.New("sentinel error to skip processing data from the remainder of the pipeline")
+
 // Start specifies the function invoked when the processor is being started.
 type Start func(context.Context, component.Host) error
 
@@ -172,6 +177,9 @@ func (mp *metricsProcessor) ConsumeMetrics(ctx context.Context, md pdata.Metrics
 	var err error
 	md, err = mp.processor.ProcessMetrics(processorCtx, md)
 	if err != nil {
+		if err == ErrSkipProcessingData {
+			return nil
+		}
 		return err
 	}
 	return mp.nextConsumer.ConsumeMetrics(ctx, md)

--- a/processor/processorhelper/processor_test.go
+++ b/processor/processorhelper/processor_test.go
@@ -129,6 +129,12 @@ func TestNewMetricsExporter_ProcessMetricsError(t *testing.T) {
 	assert.Equal(t, want, me.ConsumeMetrics(context.Background(), pdatautil.MetricsFromInternalMetrics(testdata.GenerateMetricDataEmpty())))
 }
 
+func TestNewMetricsExporter_ProcessMetricsErrSkipProcessingData(t *testing.T) {
+	me, err := NewMetricsProcessor(testCfg, exportertest.NewNopMetricsExporter(), newTestMProcessor(ErrSkipProcessingData))
+	require.NoError(t, err)
+	assert.Equal(t, nil, me.ConsumeMetrics(context.Background(), pdatautil.MetricsFromInternalMetrics(testdata.GenerateMetricDataEmpty())))
+}
+
 func TestNewLogsExporter(t *testing.T) {
 	me, err := NewLogsProcessor(testCfg, exportertest.NewNopLogsExporter(), newTestLProcessor(nil))
 	require.NoError(t, err)


### PR DESCRIPTION
**Description:**
Add a sentinel error to `processhelper` package that can be returned by other processors to indicate that the incoming batch of metrics data has been determined to be irrelevant and should be skipped for any further processing. If skipped, `processhelper` will nullify the sentinel error and return `nil`. 

Have the filterprocessor return the sentinel error if all metrics are filtered out by the filters. This prevents any further unnecessary processing and exporting of the empty metrics data.

**Link to tracking Issue:** #1491 

**Testing:** Unit tests

**Documentation:** N/A, no user-facing changes to fix big (though I did fix some typos in existing doc).