### PR TITLE
Increase max wait time on host metrics test

### DIFF
--- a/receiver/hostmetricsreceiver/hostmetrics_receiver_test.go
+++ b/receiver/hostmetricsreceiver/hostmetrics_receiver_test.go
@@ -126,7 +126,7 @@ func TestGatherMetrics_EndToEnd(t *testing.T) {
 	cancelFn()
 
 	const tick = 50 * time.Millisecond
-	const waitFor = time.Second
+	const waitFor = 5 * time.Second
 	require.Eventuallyf(t, func() bool {
 		got := sink.AllMetrics()
 		if len(got) == 0 {


### PR DESCRIPTION
The Windows CI sees this test fail very occasionally, presumably because system metric collection is slow (lots of processes running or sys calls blocked for some reason). Try increasing the max wait time before resorting to anything more drastic.

Resolves: https://github.com/open-telemetry/opentelemetry-collector/issues/1445#issuecomment-668315543