### PR TITLE
Adds a new config StartTimeMetricRegex

### DIFF
--- a/receiver/prometheusreceiver/config.go
+++ b/receiver/prometheusreceiver/config.go
@@ -29,6 +29,7 @@ type Config struct {
 	BufferPeriod                  time.Duration  `mapstructure:"buffer_period"`
 	BufferCount                   int            `mapstructure:"buffer_count"`
 	UseStartTimeMetric            bool           `mapstructure:"use_start_time_metric"`
+	StartTimeMetricRegex          string         `mapstructure:"start_time_metric_regex"`
 
 	// ConfigPlaceholder is just an entry to make the configuration pass a check
 	// that requires that all keys present in the config actually exist on the

--- a/receiver/prometheusreceiver/config_test.go
+++ b/receiver/prometheusreceiver/config_test.go
@@ -54,6 +54,7 @@ func TestLoadConfig(t *testing.T) {
 	assert.Equal(t, r1.PrometheusConfig.ScrapeConfigs[0].JobName, "demo")
 	assert.Equal(t, time.Duration(r1.PrometheusConfig.ScrapeConfigs[0].ScrapeInterval), 5*time.Second)
 	assert.Equal(t, r1.UseStartTimeMetric, true)
+	assert.Equal(t, r1.StartTimeMetricRegex, "^(.+_)*process_start_time_seconds$")
 }
 
 func TestLoadConfigWithEnvVar(t *testing.T) {

--- a/receiver/prometheusreceiver/internal/ocastore_test.go
+++ b/receiver/prometheusreceiver/internal/ocastore_test.go
@@ -26,7 +26,7 @@ import (
 
 func TestOcaStore(t *testing.T) {
 
-	o := NewOcaStore(context.Background(), nil, nil, nil, false, "prometheus")
+	o := NewOcaStore(context.Background(), nil, nil, nil, false, "", "prometheus")
 	o.SetScrapeManager(&scrape.Manager{})
 
 	app := o.Appender()

--- a/receiver/prometheusreceiver/internal/transaction_test.go
+++ b/receiver/prometheusreceiver/internal/transaction_test.go
@@ -64,7 +64,7 @@ func Test_transaction(t *testing.T) {
 
 	t.Run("Commit Without Adding", func(t *testing.T) {
 		nomc := exportertest.NewNopMetricsExporter()
-		tr := newTransaction(context.Background(), nil, true, rn, ms, nomc, testLogger)
+		tr := newTransaction(context.Background(), nil, true, "", rn, ms, nomc, testLogger)
 		if got := tr.Commit(); got != nil {
 			t.Errorf("expecting nil from Commit() but got err %v", got)
 		}
@@ -72,7 +72,7 @@ func Test_transaction(t *testing.T) {
 
 	t.Run("Rollback dose nothing", func(t *testing.T) {
 		nomc := exportertest.NewNopMetricsExporter()
-		tr := newTransaction(context.Background(), nil, true, rn, ms, nomc, testLogger)
+		tr := newTransaction(context.Background(), nil, true, "", rn, ms, nomc, testLogger)
 		if got := tr.Rollback(); got != nil {
 			t.Errorf("expecting nil from Rollback() but got err %v", got)
 		}
@@ -81,7 +81,7 @@ func Test_transaction(t *testing.T) {
 	badLabels := labels.Labels([]labels.Label{{Name: "foo", Value: "bar"}})
 	t.Run("Add One No Target", func(t *testing.T) {
 		nomc := exportertest.NewNopMetricsExporter()
-		tr := newTransaction(context.Background(), nil, true, rn, ms, nomc, testLogger)
+		tr := newTransaction(context.Background(), nil, true, "", rn, ms, nomc, testLogger)
 		if _, got := tr.Add(badLabels, time.Now().Unix()*1000, 1.0); got == nil {
 			t.Errorf("expecting error from Add() but got nil")
 		}
@@ -93,7 +93,7 @@ func Test_transaction(t *testing.T) {
 		{Name: "foo", Value: "bar"}})
 	t.Run("Add One Job not found", func(t *testing.T) {
 		nomc := exportertest.NewNopMetricsExporter()
-		tr := newTransaction(context.Background(), nil, true, rn, ms, nomc, testLogger)
+		tr := newTransaction(context.Background(), nil, true, "", rn, ms, nomc, testLogger)
 		if _, got := tr.Add(jobNotFoundLb, time.Now().Unix()*1000, 1.0); got == nil {
 			t.Errorf("expecting error from Add() but got nil")
 		}
@@ -104,7 +104,7 @@ func Test_transaction(t *testing.T) {
 		{Name: "__name__", Value: "foo"}})
 	t.Run("Add One Good", func(t *testing.T) {
 		sink := new(exportertest.SinkMetricsExporter)
-		tr := newTransaction(context.Background(), nil, true, rn, ms, sink, testLogger)
+		tr := newTransaction(context.Background(), nil, true, "", rn, ms, sink, testLogger)
 		if _, got := tr.Add(goodLabels, time.Now().Unix()*1000, 1.0); got != nil {
 			t.Errorf("expecting error == nil from Add() but got: %v\n", got)
 		}
@@ -132,7 +132,7 @@ func Test_transaction(t *testing.T) {
 
 	t.Run("Drop NaN value", func(t *testing.T) {
 		sink := new(exportertest.SinkMetricsExporter)
-		tr := newTransaction(context.Background(), nil, true, rn, ms, sink, testLogger)
+		tr := newTransaction(context.Background(), nil, true, "", rn, ms, sink, testLogger)
 		if _, got := tr.Add(goodLabels, time.Now().Unix()*1000, math.NaN()); got != nil {
 			t.Errorf("expecting error == nil from Add() but got: %v\n", got)
 		}

--- a/receiver/prometheusreceiver/metrics_receiver.go
+++ b/receiver/prometheusreceiver/metrics_receiver.go
@@ -62,7 +62,7 @@ func (pr *pReceiver) Start(_ context.Context, host component.Host) error {
 		if !pr.cfg.UseStartTimeMetric {
 			jobsMap = internal.NewJobsMap(2 * time.Minute)
 		}
-		app := internal.NewOcaStore(c, pr.consumer, pr.logger, jobsMap, pr.cfg.UseStartTimeMetric, pr.cfg.Name())
+		app := internal.NewOcaStore(c, pr.consumer, pr.logger, jobsMap, pr.cfg.UseStartTimeMetric, pr.cfg.StartTimeMetricRegex, pr.cfg.Name())
 		// need to use a logger with the gokitLog interface
 		l := internal.NewZapToGokitLogAdapter(pr.logger)
 		scrapeManager := scrape.NewManager(l, app)

--- a/receiver/prometheusreceiver/testdata/config.yaml
+++ b/receiver/prometheusreceiver/testdata/config.yaml
@@ -4,6 +4,7 @@ receivers:
     buffer_period: 234
     buffer_count: 45
     use_start_time_metric: true
+    start_time_metric_regex: '^(.+_)*process_start_time_seconds$'
     config:
       scrape_configs:
         - job_name: 'demo'


### PR DESCRIPTION
Previously the prometheus receiver only accepts
`process_start_time_metric` as the start time when UseStartTimeMetric is
set. For applications that export similar metrics but with a prefix,
e.g., via NewProcessCollector(namespace), the receiver would drop such
metrics.
By adding StartTimeMetricRegex, at least we will be able to cover such
use cases.

related: #969 

**Testing:** Adds new unit tests and end-to-end test case in prometheus receiver.

**Documentation:** none.