### PR TITLE
LoggingExporter: Add logging of span events and links

### DIFF
--- a/exporter/loggingexporter/logging_exporter.go
+++ b/exporter/loggingexporter/logging_exporter.go
@@ -219,6 +219,59 @@ func (b *logDataBuffer) logLogRecord(lr pdata.LogRecord) {
 	b.logAttributeMap("Attributes", lr.Attributes())
 }
 
+func (b *logDataBuffer) logEvents(description string, se pdata.SpanEventSlice) {
+	if se.Len() == 0 {
+		return
+	}
+
+	b.logEntry("%s:", description)
+	for i := 0; i < se.Len(); i++ {
+		e := se.At(i)
+		if e.IsNil() {
+			continue
+		}
+		b.logEntry("SpanEvent #%d", i)
+		b.logEntry("     -> Name: %s", e.Name())
+		b.logEntry("     -> Timestamp: %d", e.Timestamp())
+		b.logEntry("     -> DroppedAttributesCount: %d", e.DroppedAttributesCount())
+
+		if e.Attributes().Len() == 0 {
+			return
+		}
+		b.logEntry("     -> Attributes:")
+		e.Attributes().ForEach(func(k string, v pdata.AttributeValue) {
+			b.logEntry("         -> %s: %s(%s)", k, v.Type().String(), attributeValueToString(v))
+		})
+	}
+}
+
+func (b *logDataBuffer) logLinks(description string, sl pdata.SpanLinkSlice) {
+	if sl.Len() == 0 {
+		return
+	}
+
+	b.logEntry("%s:", description)
+
+	for i := 0; i < sl.Len(); i++ {
+		l := sl.At(i)
+		if l.IsNil() {
+			continue
+		}
+		b.logEntry("SpanLink #%d", i)
+		b.logEntry("     ->  Trace ID: %s", l.TraceID().String())
+		b.logEntry("     ->  ID: %s", l.SpanID().String())
+		b.logEntry("     ->  TraceState: %s", l.TraceState())
+		b.logEntry("     ->  DroppedAttributesCount: %d", l.DroppedAttributesCount())
+		if l.Attributes().Len() == 0 {
+			return
+		}
+		b.logEntry("     -> Attributes:")
+		l.Attributes().ForEach(func(k string, v pdata.AttributeValue) {
+			b.logEntry("         -> %s: %s(%s)", k, v.Type().String(), attributeValueToString(v))
+		})
+	}
+}
+
 func attributeValueToString(av pdata.AttributeValue) string {
 	switch av.Type() {
 	case pdata.AttributeValueSTRING:
@@ -296,8 +349,8 @@ func (s *loggingExporter) pushTraceData(
 				}
 
 				buf.logAttributeMap("Attributes", span.Attributes())
-
-				// TODO: Add logging for the rest of the span properties: events, links.
+				buf.logEvents("Events", span.Events())
+				buf.logLinks("Links", span.Links())
 			}
 		}
 	}

--- a/exporter/loggingexporter/logging_exporter.go
+++ b/exporter/loggingexporter/logging_exporter.go
@@ -258,10 +258,10 @@ func (b *logDataBuffer) logLinks(description string, sl pdata.SpanLinkSlice) {
 			continue
 		}
 		b.logEntry("SpanLink #%d", i)
-		b.logEntry("     ->  Trace ID: %s", l.TraceID().String())
-		b.logEntry("     ->  ID: %s", l.SpanID().String())
-		b.logEntry("     ->  TraceState: %s", l.TraceState())
-		b.logEntry("     ->  DroppedAttributesCount: %d", l.DroppedAttributesCount())
+		b.logEntry("     -> Trace ID: %s", l.TraceID().String())
+		b.logEntry("     -> ID: %s", l.SpanID().String())
+		b.logEntry("     -> TraceState: %s", l.TraceState())
+		b.logEntry("     -> DroppedAttributesCount: %d", l.DroppedAttributesCount())
 		if l.Attributes().Len() == 0 {
 			return
 		}


### PR DESCRIPTION
Resolves #1454

Output not very intuitive and readable, but I just tried to follow existing conventions. Looks like following:

```
2020-08-06T16:18:37.528+0300  INFO  TraceExporter  {"#spans": 3}
2020-08-06T16:18:37.528+0300  DEBUG  ResourceSpans #0
Resource labels:
     -> resource-attr: STRING(resource-attr-val-1)
InstrumentationLibrarySpans #0
Span #0
    Trace ID       :
    Parent ID      :
    ID             :
    Name           : operationA
    Kind           : SPAN_KIND_UNSPECIFIED
    Start time     : 2020-02-11 23:26:12.000000321 +0300 MSK
    End time       : 2020-02-11 23:26:13.000000789 +0300 MSK
    Status code    : Cancelled
    Status message : status-cancelled
Events:
SpanEvent #0
     -> Name: event-with-attr
     -> Timestamp: 1581452773000000123
     -> DroppedAttributesCount: 2
     -> Attributes:
         -> span-event-attr: STRING(span-event-attr-val)
SpanEvent #1
     -> Name: event
     -> Timestamp: 1581452773000000123
     -> DroppedAttributesCount: 2
Span #1
    Trace ID       :
    Parent ID      :
    ID             :
    Name           : operationB
    Kind           : SPAN_KIND_UNSPECIFIED
    Start time     : 2020-02-11 23:26:12.000000321 +0300 MSK
    End time       : 2020-02-11 23:26:13.000000789 +0300 MSK
Links:
SpanLink #0
     -> Trace ID:
     -> ID:
     -> TraceState:
     -> DroppedAttributesCount: 4
     -> Attributes:
         -> span-link-attr: STRING(span-link-attr-val)
SpanLink #1
     -> Trace ID:
     -> ID:
     -> TraceState:
     -> DroppedAttributesCount: 4
```