### PR TITLE
Remove extraneous %v from interactive CLI logs

### DIFF
--- a/cmd/otelcol/main.go
+++ b/cmd/otelcol/main.go
@@ -17,9 +17,8 @@
 package main
 
 import (
+	"fmt"
 	"log"
-
-	"github.com/pkg/errors"
 
 	"go.opentelemetry.io/collector/internal/version"
 	"go.opentelemetry.io/collector/service"
@@ -47,12 +46,12 @@ func main() {
 func runInteractive(params service.Parameters) error {
 	app, err := service.New(params)
 	if err != nil {
-		return errors.Wrap(err, "failed to construct the application")
+		return fmt.Errorf("failed to construct the application: %v", err)
 	}
 
 	err = app.Start()
 	if err != nil {
-		return errors.Wrap(err, "application run finished with error: %v")
+		return fmt.Errorf("application run finished with error: %v", err)
 	}
 
 	return nil

--- a/cmd/otelcol/main.go
+++ b/cmd/otelcol/main.go
@@ -46,12 +46,12 @@ func main() {
 func runInteractive(params service.Parameters) error {
 	app, err := service.New(params)
 	if err != nil {
-		return fmt.Errorf("failed to construct the application: %v", err)
+		return fmt.Errorf("failed to construct the application: %w", err)
 	}
 
 	err = app.Start()
 	if err != nil {
-		return fmt.Errorf("application run finished with error: %v", err)
+		return fmt.Errorf("application run finished with error: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
**Description:**
Cleanup: The characters "%v" are extraneous in this case since errors.Wrap appends the two strings together instead. Additionally, errors.Wrapf is not used, which means the %v is added to the logs incorrectly.

**Testing:** Re-compiled with change and the error log was correct.

**Documentation:** n/a