### PR TITLE
Add minimal support for array value type

### DIFF
--- a/cmd/pdatagen/internal/common_structs.go
+++ b/cmd/pdatagen/internal/common_structs.go
@@ -23,9 +23,12 @@ var commonFile = &File{
 		`"testing"`,
 		``,
 		`"github.com/stretchr/testify/assert"`,
+		``,
+		`otlpcommon "go.opentelemetry.io/collector/internal/data/opentelemetry-proto-gen/common/v1"`,
 	},
 	structs: []baseStruct{
 		instrumentationLibrary,
+		anyValueArray,
 	},
 }
 
@@ -113,4 +116,9 @@ var nameField = &primitiveField{
 var anyValue = &messageStruct{
 	structName:     "AttributeValue",
 	originFullName: "otlpcommon.AnyValue",
+}
+
+var anyValueArray = &sliceStruct{
+	structName: "AnyValueArray",
+	element:    anyValue,
 }

--- a/go.sum
+++ b/go.sum
@@ -519,6 +519,7 @@ github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgf
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/grpc-ecosystem/grpc-gateway v1.13.0/go.mod h1:8XEsbTttt/W+VvjtQhLACqCisSPWTxCZ7sBRjU6iH9c=
+github.com/grpc-ecosystem/grpc-gateway v1.14.6 h1:8ERzHx8aj1Sc47mu9n/AksaKCSWrMchFtkdrS4BIj5o=
 github.com/grpc-ecosystem/grpc-gateway v1.14.6/go.mod h1:zdiPV4Yse/1gnckTHtghG4GkDEdKCRJduHpTxT3/jcw=
 github.com/grpc-ecosystem/grpc-gateway v1.14.7 h1:Nk5kuHrnWUTf/0GL1a/vchH/om9Ap2/HnVna+jYZgTY=
 github.com/grpc-ecosystem/grpc-gateway v1.14.7/go.mod h1:oYZKL012gGh6LMyg/xA7Q2yq6j8bu0wa+9w14EEthWU=

--- a/translator/internaldata/resource_to_oc.go
+++ b/translator/internaldata/resource_to_oc.go
@@ -185,11 +185,28 @@ func attributeValueToString(attr pdata.AttributeValue, jsonLike bool) string {
 		sb.WriteString("}")
 		return sb.String()
 
+	case pdata.AttributeValueARRAY:
+		// OpenCensus attributes cannot represent arrays natively. Convert the
+		// array to a JSON-like string.
+		var sb strings.Builder
+		sb.WriteString("[")
+		m := attr.ArrayVal()
+		first := true
+		len := m.Len()
+		for i := 0; i < len; i++ {
+			v := m.At(i)
+			if !first {
+				sb.WriteString(",")
+			}
+			first = false
+			sb.WriteString(attributeValueToString(v, true))
+		}
+		sb.WriteString("]")
+		return sb.String()
+
 	default:
 		return fmt.Sprintf("<Unknown OpenTelemetry attribute value type %q>", attr.Type())
 	}
-
-	// TODO: Add support for ARRAY type.
 }
 
 func inferResourceType(labels map[string]string) (string, bool) {

--- a/translator/internaldata/resource_to_oc_test.go
+++ b/translator/internaldata/resource_to_oc_test.go
@@ -131,6 +131,17 @@ func TestAttributeValueToString(t *testing.T) {
 	v.MapVal().Insert("d", pdata.NewAttributeValueNull())
 	v.MapVal().Insert("e", v)
 	assert.EqualValues(t, `{"a\"\\":"b\"\\","c":123,"d":null,"e":{"a\"\\":"b\"\\","c":123,"d":null}}`, attributeValueToString(v, false))
+
+	v = pdata.NewAttributeValueArray()
+	av := pdata.NewAttributeValueString(`b"\`)
+	v.ArrayVal().Append(&av)
+	av = pdata.NewAttributeValueInt(123)
+	v.ArrayVal().Append(&av)
+	av = pdata.NewAttributeValueNull()
+	v.ArrayVal().Append(&av)
+	av = pdata.NewAttributeValueArray()
+	v.ArrayVal().Append(&av)
+	assert.EqualValues(t, `["b\"\\",123,null,[]]`, attributeValueToString(v, false))
 }
 
 func TestInferResourceType(t *testing.T) {


### PR DESCRIPTION
Array value type was added to AnyValue Protobuf definition but corresponding
support in the Collector was missing.

This commit adds AnyValueArray internal data type which wraps an a slice of
AnyValue pointers.

AnyValueArray supports minimal set of functions for now. We will add more
functions if needed in the future.