### PR TITLE
Fix multiple exporters panic

### DIFF
--- a/service/builder/pipelines_builder.go
+++ b/service/builder/pipelines_builder.go
@@ -269,8 +269,8 @@ func (pb *PipelinesBuilder) buildFanoutExportersLogConsumer(
 	}
 
 	exporters := make([]consumer.LogsConsumer, len(builtExporters))
-	for _, builtExp := range builtExporters {
-		exporters = append(exporters, builtExp.le)
+	for i, builtExp := range builtExporters {
+		exporters[i] = builtExp.le
 	}
 
 	// Create a junction point that fans out to all exporters.


### PR DESCRIPTION
**Description:**
Fixing a bug

While using more than one exporter the panic runtime exception occured,
because the array allocated for exporters was as twice as big as it should

**Link to tracking Issue:** N/A

**Testing:**

Using more than one exporter results with panic runtime error:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x510ca95]

goroutine 108 [running]:
go.opentelemetry.io/collector/processor.LogFanOutConnector.ConsumeLogs(0xc0002c0d40, 0x4, 0x4, 0x88ab900, 0xc0002c10c0, 0xc00082a000, 0xc000c19880, 0x2)
        .../processor/fanoutconnector.go:171 +0xb5
```

**Documentation:** N/A

Signed-off-by: Dominik Rosiek <drosiek@sumologic.com>