### PR TITLE
Add command to install .Net 3.5 explicitly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,6 @@ commands:
     parameters:
       files:
         type: string
-        # TODO: Add dist/otel-collector-*amd64.msi back
         default: |
             bin/otelcol_darwin_amd64
             bin/otelcol_linux_arm64
@@ -23,6 +22,7 @@ commands:
             dist/otel-collector_*amd64.deb
             dist/otel-collector-*x86_64.rpm
             dist/otel-collector_*arm64.deb
+            dist/otel-collector-*amd64.msi
     steps:
       - run:
           name: Check if files exist
@@ -145,6 +145,12 @@ workflows:
           filters:
             tags:
               only: /^v([0-9])+.([0-9])+.([0-9])+.*/
+      - windows-msi:
+          requires:
+            - cross-compile
+          filters:
+            tags:
+              only: /^v([0-9])+.([0-9])+.([0-9])+.*/
       - publish-check:
           requires:
             - cross-compile
@@ -155,6 +161,7 @@ workflows:
             - gosec
             - coverage
             - windows-test
+            - windows-msi
             - deb-package
             - rpm-package
       - publish-stable:
@@ -167,6 +174,7 @@ workflows:
             - gosec
             - coverage
             - windows-test
+            - windows-msi
             - deb-package
             - rpm-package
           filters:
@@ -184,6 +192,7 @@ workflows:
             - gosec
             - coverage
             - windows-test
+            - windows-msi
             - deb-package
             - rpm-package
           filters:

--- a/internal/buildscripts/packaging/msi/make.ps1
+++ b/internal/buildscripts/packaging/msi/make.ps1
@@ -17,7 +17,7 @@
     Makefile like build commands for the Collector on Windows.
     
     Usage:   .\make.ps1 <Command> [-<Param> <Value> ...]
-    Example: .\make.ps1 New-MSI -Config "./my-config.yaml"
+    Example: .\make.ps1 New-MSI -Config "./my-config.yaml" -Version "v0.0.2"
 .PARAMETER Target
     Build target to run (Install-Tools, New-MSI)
 #>
@@ -28,6 +28,12 @@ Param(
 $ErrorActionPreference = "Stop"
 
 function Install-Tools {
+    # disable progress bar support as this causes CircleCI to crash
+    $OriginalPref = $ProgressPreference
+    $ProgressPreference = "SilentlyContinue"
+    Install-WindowsFeature Net-Framework-Core
+    $ProgressPreference = $OriginalPref
+
     choco install wixtoolset -y
     setx /m PATH "%PATH%;C:\Program Files (x86)\WiX Toolset v3.11\bin"
     refreshenv


### PR DESCRIPTION
Something seems to have changed with the CircleCI Windows executor recently. .NET 3.5 was pre-installed before and is not now.

The `choco install wixtoolset` command has a dependency on the `dotnet3.5` module which doesn't work (if it detects .Net 3.5 is not already installed) when trying to install in some situations. See related discussion here: https://chocolatey.org/packages/DotNet3.5#comment-4490487735

Therefore, have updated the script to install .NET 3.5 explicitly (and restored the `windows-msi` build step)