### PR TITLE
Add support for gzip encoded payload in OTLP/HTTP receiver

### DIFF
--- a/internal/middleware/compression.go
+++ b/internal/middleware/compression.go
@@ -1,0 +1,95 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package middleware
+
+import (
+	"compress/gzip"
+	"compress/zlib"
+	"io"
+	"net/http"
+)
+
+type ErrorHandler func(w http.ResponseWriter, r *http.Request, errorMsg string, statusCode int)
+
+type decompressor struct {
+	errorHandler ErrorHandler
+}
+
+type DecompressorOption func(d *decompressor)
+
+func WithErrorHandler(e ErrorHandler) DecompressorOption {
+	return func(d *decompressor) {
+		d.errorHandler = e
+	}
+}
+
+// HTTPContentDecompressor is a middleware that offloads the task of handling compressed
+// HTTP requests by identifying the compression format in the "Content-Encoding" header and re-writing
+// request body so that the handlers further in the chain can work on decompressed data.
+// It supports gzip and deflate/zlib compression.
+func HTTPContentDecompressor(h http.Handler, opts ...DecompressorOption) http.Handler {
+	d := &decompressor{}
+	for _, o := range opts {
+		o(d)
+	}
+	if d.errorHandler == nil {
+		d.errorHandler = defaultErrorHandler
+	}
+	return d.wrap(h)
+}
+
+func (d *decompressor) wrap(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		newBody, err := newBodyReader(r)
+		if err != nil {
+			d.errorHandler(w, r, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if newBody != nil {
+			defer newBody.Close()
+			// "Content-Encoding" header is removed to avoid decompressing twice
+			// in case the next handler(s) have implemented a similar mechanism.
+			r.Header.Del("Content-Encoding")
+			// "Content-Length" is set to -1 as the size of the decompressed body is unknown.
+			r.Header.Del("Content-Length")
+			r.ContentLength = -1
+			r.Body = newBody
+		}
+		h.ServeHTTP(w, r)
+	})
+}
+
+func newBodyReader(r *http.Request) (io.ReadCloser, error) {
+	switch r.Header.Get("Content-Encoding") {
+	case "gzip":
+		gr, err := gzip.NewReader(r.Body)
+		if err != nil {
+			return nil, err
+		}
+		return gr, nil
+	case "deflate", "zlib":
+		zr, err := zlib.NewReader(r.Body)
+		if err != nil {
+			return nil, err
+		}
+		return zr, nil
+	}
+	return nil, nil
+}
+
+// defaultErrorHandler writes the error message in plain text.
+func defaultErrorHandler(w http.ResponseWriter, _ *http.Request, errMsg string, statusCode int) {
+	http.Error(w, errMsg, statusCode)
+}

--- a/internal/middleware/compression_test.go
+++ b/internal/middleware/compression_test.go
@@ -1,0 +1,157 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package middleware
+
+import (
+	"bytes"
+	"compress/gzip"
+	"compress/zlib"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/collector/testutil"
+)
+
+func TestHTTPContentDecompressionHandler(t *testing.T) {
+	testBody := []byte("uncompressed_text")
+	tests := []struct {
+		name        string
+		encoding    string
+		reqBodyFunc func() (*bytes.Buffer, error)
+		respCode    int
+		respBody    string
+	}{
+		{
+			name:     "NoCompression",
+			encoding: "",
+			reqBodyFunc: func() (*bytes.Buffer, error) {
+				return bytes.NewBuffer(testBody), nil
+			},
+			respCode: 200,
+		},
+		{
+			name:     "ValidGzip",
+			encoding: "gzip",
+			reqBodyFunc: func() (*bytes.Buffer, error) {
+				return compressGzip(testBody)
+			},
+			respCode: 200,
+		},
+		{
+			name:     "ValidZlib",
+			encoding: "zlib",
+			reqBodyFunc: func() (*bytes.Buffer, error) {
+				return compressZlib(testBody)
+			},
+			respCode: 200,
+		},
+		{
+			name:     "InvalidGzip",
+			encoding: "gzip",
+			reqBodyFunc: func() (*bytes.Buffer, error) {
+				return bytes.NewBuffer(testBody), nil
+			},
+			respCode: 400,
+			respBody: "gzip: invalid header\n",
+		},
+
+		{
+			name:     "InvalidZlib",
+			encoding: "zlib",
+			reqBodyFunc: func() (*bytes.Buffer, error) {
+				return bytes.NewBuffer(testBody), nil
+			},
+			respCode: 400,
+			respBody: "zlib: invalid header\n",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				body, err := ioutil.ReadAll(r.Body)
+				require.NoError(t, err, "failed to read request body: %v", err)
+				assert.EqualValues(t, testBody, string(body))
+				w.WriteHeader(200)
+			})
+
+			addr := testutil.GetAvailableLocalAddress(t)
+			ln, err := net.Listen("tcp", addr)
+			require.NoError(t, err, "failed to create listener: %v", err)
+			srv := &http.Server{
+				Handler: HTTPContentDecompressor(handler),
+			}
+			go func() {
+				_ = srv.Serve(ln)
+			}()
+			// Wait for the servers to start
+			<-time.After(10 * time.Millisecond)
+
+			serverURL := fmt.Sprintf("http://%s", ln.Addr().String())
+			reqBody, err := tt.reqBodyFunc()
+			require.NoError(t, err, "failed to generate request body: %v", err)
+
+			req, err := http.NewRequest("GET", serverURL, reqBody)
+			require.NoError(t, err, "failed to create request to test handler")
+			req.Header.Set("Content-Encoding", tt.encoding)
+
+			client := http.Client{}
+			res, err := client.Do(req)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.respCode, res.StatusCode, "test handler returned unexpected status code ")
+			if tt.respBody != "" {
+				body, err := ioutil.ReadAll(res.Body)
+				require.NoError(t, res.Body.Close(), "failed to close request body: %v", err)
+				assert.Equal(t, tt.respBody, string(body))
+			}
+			require.NoError(t, srv.Close())
+		})
+	}
+}
+
+func compressGzip(body []byte) (*bytes.Buffer, error) {
+	var buf bytes.Buffer
+
+	gw := gzip.NewWriter(&buf)
+	defer gw.Close()
+
+	_, err := gw.Write(body)
+	if err != nil {
+		return nil, err
+	}
+
+	return &buf, nil
+}
+
+func compressZlib(body []byte) (*bytes.Buffer, error) {
+	var buf bytes.Buffer
+
+	zw := zlib.NewWriter(&buf)
+	defer zw.Close()
+
+	_, err := zw.Write(body)
+	if err != nil {
+		return nil, err
+	}
+
+	return &buf, nil
+}

--- a/receiver/otlpreceiver/otlp.go
+++ b/receiver/otlpreceiver/otlp.go
@@ -26,6 +26,7 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenterror"
+	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/consumer"
 	collectorlog "go.opentelemetry.io/collector/internal/data/opentelemetry-proto-gen/collector/logs/v1"
 	collectormetrics "go.opentelemetry.io/collector/internal/data/opentelemetry-proto-gen/collector/metrics/v1"
@@ -104,7 +105,10 @@ func (r *otlpReceiver) Start(_ context.Context, host component.Host) error {
 			}()
 		}
 		if r.cfg.HTTP != nil {
-			r.serverHTTP = r.cfg.HTTP.ToServer(r.gatewayMux)
+			r.serverHTTP = r.cfg.HTTP.ToServer(
+				r.gatewayMux,
+				confighttp.WithErrorHandler(OTLPErrorHandler),
+			)
 			var hln net.Listener
 			hln, err = r.cfg.HTTP.ToListener()
 			if err != nil {

--- a/receiver/otlpreceiver/otlphttp.go
+++ b/receiver/otlpreceiver/otlphttp.go
@@ -15,7 +15,14 @@
 package otlpreceiver
 
 import (
+	"bytes"
+	"net/http"
+
+	"github.com/gogo/protobuf/jsonpb"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 )
 
 // xProtobufMarshaler is a Marshaler which wraps runtime.ProtoMarshaller
@@ -27,4 +34,43 @@ type xProtobufMarshaler struct {
 // ContentType always returns "application/x-protobuf".
 func (*xProtobufMarshaler) ContentType() string {
 	return "application/x-protobuf"
+}
+
+var jsonMarshaller = &jsonpb.Marshaler{}
+
+// OTLPErrorHandler encodes the HTTP error message inside a rpc.Status message as required
+// by the OTLP protocol.
+func OTLPErrorHandler(w http.ResponseWriter, r *http.Request, errMsg string, statusCode int) {
+	var (
+		msg []byte
+		s   *status.Status
+		err error
+	)
+	// Pre-computed status with code=Internal to be used in case of a marshaling error.
+	fallbackMsg := []byte(`{"code": 13, "message": "failed to marshal error message"}`)
+	fallbackContentType := "application/json"
+
+	if statusCode == http.StatusBadRequest {
+		s = status.New(codes.InvalidArgument, errMsg)
+	} else {
+		s = status.New(codes.Internal, errMsg)
+	}
+
+	contentType := r.Header.Get("Content-Type")
+	if contentType == "application/json" {
+		buf := new(bytes.Buffer)
+		err = jsonMarshaller.Marshal(buf, s.Proto())
+		msg = buf.Bytes()
+	} else {
+		msg, err = proto.Marshal(s.Proto())
+	}
+	if err != nil {
+		msg = fallbackMsg
+		contentType = fallbackContentType
+		statusCode = http.StatusInternalServerError
+	}
+
+	w.Header().Set("Content-Type", contentType)
+	w.WriteHeader(statusCode)
+	w.Write(msg)
 }


### PR DESCRIPTION

**Description:** 
Fixing a bug - OTLP/HTTP receiver does not support gzip. Fixed this by wrapping the HTTP handler generated by grpc-gateway to decompress prior to processing the request, similar to how it's done in https://github.com/open-telemetry/opentelemetry-collector/blob/c4a38294b0f8cab47f63ed7819cb66199c7c53f8/receiver/zipkinreceiver/trace_receiver.go#L208
**Link to tracking Issue:** 
https://github.com/open-telemetry/opentelemetry-collector/issues/1344

**Testing:** 
Modified unit tests to cover cases where request body is compressed via gzip/zlib.
