### PR TITLE
Pass version (& other app info) into components in params struct

### DIFF
--- a/cmd/otelcol/main.go
+++ b/cmd/otelcol/main.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"log"
 
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/internal/version"
 	"go.opentelemetry.io/collector/service"
 	"go.opentelemetry.io/collector/service/defaultcomponents"
@@ -31,7 +32,7 @@ func main() {
 		log.Fatalf("failed to build default components: %v", err)
 	}
 
-	info := service.ApplicationStartInfo{
+	info := component.ApplicationStartInfo{
 		ExeName:  "otelcol",
 		LongName: "OpenTelemetry Collector",
 		Version:  version.Version,

--- a/component/component.go
+++ b/component/component.go
@@ -107,3 +107,19 @@ type ConfigUnmarshaler interface {
 // intoCfg interface{}
 //   An empty interface wrapping a pointer to the config struct to unmarshal into.
 type CustomUnmarshaler func(componentViperSection *viper.Viper, intoCfg interface{}) error
+
+// ApplicationStartInfo is the information that is logged at the application start and
+// passed into each component. This information can be overridden in custom builds.
+type ApplicationStartInfo struct {
+	// Executable file name, e.g. "otelcol".
+	ExeName string
+
+	// Long name, used e.g. in the logs.
+	LongName string
+
+	// Version string.
+	Version string
+
+	// Git hash of the source code.
+	GitHash string
+}

--- a/component/componenttest/application_start_info.go
+++ b/component/componenttest/application_start_info.go
@@ -1,0 +1,29 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package componenttest
+
+import (
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/internal/version"
+)
+
+func TestApplicationStartInfo() component.ApplicationStartInfo {
+	return component.ApplicationStartInfo{
+		ExeName:  "otelcol",
+		LongName: "InProcess Collector",
+		Version:  version.Version,
+		GitHash:  version.GitHash,
+	}
+}

--- a/component/exporter.go
+++ b/component/exporter.go
@@ -51,6 +51,9 @@ type ExporterCreateParams struct {
 	// Logger that the factory can use during creation and can pass to the created
 	// component to be used later as well.
 	Logger *zap.Logger
+
+	// ApplicationStartInfo can be used by components for informational purposes
+	ApplicationStartInfo ApplicationStartInfo
 }
 
 // ExporterFactory can create TraceExporter and MetricsExporter. This is the

--- a/component/extension.go
+++ b/component/extension.go
@@ -51,6 +51,9 @@ type ExtensionCreateParams struct {
 	// Logger that the factory can use during creation and can pass to the created
 	// component to be used later as well.
 	Logger *zap.Logger
+
+	// ApplicationStartInfo can be used by components for informational purposes
+	ApplicationStartInfo ApplicationStartInfo
 }
 
 // ExtensionFactory is a factory interface for extensions to the service.

--- a/component/processor.go
+++ b/component/processor.go
@@ -65,6 +65,9 @@ type ProcessorCreateParams struct {
 	// Logger that the factory can use during creation and can pass to the created
 	// component to be used later as well.
 	Logger *zap.Logger
+
+	// ApplicationStartInfo can be used by components for informational purposes
+	ApplicationStartInfo ApplicationStartInfo
 }
 
 // ProcessorFactory is factory interface for processors. This is the

--- a/component/receiver.go
+++ b/component/receiver.go
@@ -60,6 +60,9 @@ type ReceiverCreateParams struct {
 	// Logger that the factory can use during creation and can pass to the created
 	// component to be used later as well.
 	Logger *zap.Logger
+
+	// ApplicationStartInfo can be used by components for informational purposes
+	ApplicationStartInfo ApplicationStartInfo
 }
 
 // ReceiverFactory can create TraceReceiver and MetricsReceiver. This is the

--- a/service/builder/exporters_builder_test.go
+++ b/service/builder/exporters_builder_test.go
@@ -61,7 +61,7 @@ func TestExportersBuilder_Build(t *testing.T) {
 		},
 	}
 
-	exporters, err := NewExportersBuilder(zap.NewNop(), component.ApplicationStartInfo{}, cfg, factories.Exporters).Build()
+	exporters, err := NewExportersBuilder(zap.NewNop(), componenttest.TestApplicationStartInfo(), cfg, factories.Exporters).Build()
 
 	assert.NoError(t, err)
 	require.NotNil(t, exporters)
@@ -89,7 +89,7 @@ func TestExportersBuilder_Build(t *testing.T) {
 	// This should result in creating an exporter that has none of consumption
 	// functions set.
 	delete(cfg.Service.Pipelines, "trace")
-	exporters, err = NewExportersBuilder(zap.NewNop(), component.ApplicationStartInfo{}, cfg, factories.Exporters).Build()
+	exporters, err = NewExportersBuilder(zap.NewNop(), componenttest.TestApplicationStartInfo(), cfg, factories.Exporters).Build()
 	assert.NotNil(t, exporters)
 	assert.NoError(t, err)
 
@@ -129,7 +129,7 @@ func TestExportersBuilder_BuildLogs(t *testing.T) {
 		},
 	}
 
-	exporters, err := NewExportersBuilder(zap.NewNop(), component.ApplicationStartInfo{}, cfg, factories.Exporters).Build()
+	exporters, err := NewExportersBuilder(zap.NewNop(), componenttest.TestApplicationStartInfo(), cfg, factories.Exporters).Build()
 
 	assert.NoError(t, err)
 	require.NotNil(t, exporters)
@@ -154,7 +154,7 @@ func TestExportersBuilder_BuildLogs(t *testing.T) {
 	// This should result in creating an exporter that has none of consumption
 	// functions set.
 	delete(cfg.Service.Pipelines, "logs")
-	exporters, err = NewExportersBuilder(zap.NewNop(), component.ApplicationStartInfo{}, cfg, factories.Exporters).Build()
+	exporters, err = NewExportersBuilder(zap.NewNop(), componenttest.TestApplicationStartInfo(), cfg, factories.Exporters).Build()
 	assert.NotNil(t, exporters)
 	assert.Nil(t, err)
 
@@ -241,7 +241,7 @@ func TestExportersBuilder_ErrorOnNilExporter(t *testing.T) {
 				},
 			}
 
-			exporters, err := NewExportersBuilder(zap.NewNop(), component.ApplicationStartInfo{}, cfg, fm).Build()
+			exporters, err := NewExportersBuilder(zap.NewNop(), componenttest.TestApplicationStartInfo(), cfg, fm).Build()
 			assert.Error(t, err)
 			assert.Zero(t, len(exporters))
 		})

--- a/service/builder/exporters_builder_test.go
+++ b/service/builder/exporters_builder_test.go
@@ -61,7 +61,7 @@ func TestExportersBuilder_Build(t *testing.T) {
 		},
 	}
 
-	exporters, err := NewExportersBuilder(zap.NewNop(), cfg, factories.Exporters).Build()
+	exporters, err := NewExportersBuilder(zap.NewNop(), component.ApplicationStartInfo{}, cfg, factories.Exporters).Build()
 
 	assert.NoError(t, err)
 	require.NotNil(t, exporters)
@@ -89,7 +89,7 @@ func TestExportersBuilder_Build(t *testing.T) {
 	// This should result in creating an exporter that has none of consumption
 	// functions set.
 	delete(cfg.Service.Pipelines, "trace")
-	exporters, err = NewExportersBuilder(zap.NewNop(), cfg, factories.Exporters).Build()
+	exporters, err = NewExportersBuilder(zap.NewNop(), component.ApplicationStartInfo{}, cfg, factories.Exporters).Build()
 	assert.NotNil(t, exporters)
 	assert.NoError(t, err)
 
@@ -129,7 +129,7 @@ func TestExportersBuilder_BuildLogs(t *testing.T) {
 		},
 	}
 
-	exporters, err := NewExportersBuilder(zap.NewNop(), cfg, factories.Exporters).Build()
+	exporters, err := NewExportersBuilder(zap.NewNop(), component.ApplicationStartInfo{}, cfg, factories.Exporters).Build()
 
 	assert.NoError(t, err)
 	require.NotNil(t, exporters)
@@ -154,7 +154,7 @@ func TestExportersBuilder_BuildLogs(t *testing.T) {
 	// This should result in creating an exporter that has none of consumption
 	// functions set.
 	delete(cfg.Service.Pipelines, "logs")
-	exporters, err = NewExportersBuilder(zap.NewNop(), cfg, factories.Exporters).Build()
+	exporters, err = NewExportersBuilder(zap.NewNop(), component.ApplicationStartInfo{}, cfg, factories.Exporters).Build()
 	assert.NotNil(t, exporters)
 	assert.Nil(t, err)
 
@@ -241,7 +241,7 @@ func TestExportersBuilder_ErrorOnNilExporter(t *testing.T) {
 				},
 			}
 
-			exporters, err := NewExportersBuilder(zap.NewNop(), cfg, fm).Build()
+			exporters, err := NewExportersBuilder(zap.NewNop(), component.ApplicationStartInfo{}, cfg, fm).Build()
 			assert.Error(t, err)
 			assert.Zero(t, len(exporters))
 		})

--- a/service/builder/pipelines_builder_test.go
+++ b/service/builder/pipelines_builder_test.go
@@ -134,7 +134,7 @@ func TestPipelinesBuilder_BuildVarious(t *testing.T) {
 			cfg := createExampleConfig(dataType)
 
 			// BuildProcessors the pipeline
-			allExporters, err := NewExportersBuilder(zap.NewNop(), cfg, factories.Exporters).Build()
+			allExporters, err := NewExportersBuilder(zap.NewNop(), component.ApplicationStartInfo{}, cfg, factories.Exporters).Build()
 			if test.shouldFail {
 				assert.Error(t, err)
 				return
@@ -142,7 +142,7 @@ func TestPipelinesBuilder_BuildVarious(t *testing.T) {
 
 			require.NoError(t, err)
 			require.EqualValues(t, 1, len(allExporters))
-			pipelineProcessors, err := NewPipelinesBuilder(zap.NewNop(), cfg, allExporters, factories.Processors).Build()
+			pipelineProcessors, err := NewPipelinesBuilder(zap.NewNop(), component.ApplicationStartInfo{}, cfg, allExporters, factories.Processors).Build()
 
 			assert.NoError(t, err)
 			require.NotNil(t, pipelineProcessors)
@@ -217,9 +217,9 @@ func testPipeline(t *testing.T, pipelineName string, exporterNames []string) {
 	require.Nil(t, err)
 
 	// BuildProcessors the pipeline
-	allExporters, err := NewExportersBuilder(zap.NewNop(), cfg, factories.Exporters).Build()
+	allExporters, err := NewExportersBuilder(zap.NewNop(), component.ApplicationStartInfo{}, cfg, factories.Exporters).Build()
 	assert.NoError(t, err)
-	pipelineProcessors, err := NewPipelinesBuilder(zap.NewNop(), cfg, allExporters, factories.Processors).Build()
+	pipelineProcessors, err := NewPipelinesBuilder(zap.NewNop(), component.ApplicationStartInfo{}, cfg, allExporters, factories.Processors).Build()
 
 	assert.NoError(t, err)
 	require.NotNil(t, pipelineProcessors)
@@ -281,12 +281,12 @@ func TestPipelinesBuilder_Error(t *testing.T) {
 	pipeline := cfg.Service.Pipelines["traces"]
 	pipeline.InputType = configmodels.MetricsDataType
 
-	exporters, err := NewExportersBuilder(zap.NewNop(), cfg, factories.Exporters).Build()
+	exporters, err := NewExportersBuilder(zap.NewNop(), component.ApplicationStartInfo{}, cfg, factories.Exporters).Build()
 	assert.NoError(t, err)
 
 	// This should fail because "attributes" processor defined in the config does
 	// not support metrics data type.
-	_, err = NewPipelinesBuilder(zap.NewNop(), cfg, exporters, factories.Processors).Build()
+	_, err = NewPipelinesBuilder(zap.NewNop(), component.ApplicationStartInfo{}, cfg, exporters, factories.Processors).Build()
 
 	assert.NotNil(t, err)
 }
@@ -301,7 +301,7 @@ func TestProcessorsBuilder_ErrorOnNilProcessor(t *testing.T) {
 	cfg, err := configtest.LoadConfigFile(t, "testdata/bad_processor_factory.yaml", factories)
 	require.Nil(t, err)
 
-	allExporters, err := NewExportersBuilder(zap.NewNop(), cfg, factories.Exporters).Build()
+	allExporters, err := NewExportersBuilder(zap.NewNop(), component.ApplicationStartInfo{}, cfg, factories.Exporters).Build()
 	assert.NoError(t, err)
 
 	// First test only trace receivers by removing the metrics pipeline.
@@ -309,7 +309,7 @@ func TestProcessorsBuilder_ErrorOnNilProcessor(t *testing.T) {
 	delete(cfg.Service.Pipelines, "metrics")
 	require.Equal(t, 1, len(cfg.Service.Pipelines))
 
-	pipelineProcessors, err := NewPipelinesBuilder(zap.NewNop(), cfg, allExporters, factories.Processors).Build()
+	pipelineProcessors, err := NewPipelinesBuilder(zap.NewNop(), component.ApplicationStartInfo{}, cfg, allExporters, factories.Processors).Build()
 	assert.Error(t, err)
 	assert.Zero(t, len(pipelineProcessors))
 
@@ -318,7 +318,7 @@ func TestProcessorsBuilder_ErrorOnNilProcessor(t *testing.T) {
 	cfg.Service.Pipelines["metrics"] = metricsPipeline
 	require.Equal(t, 1, len(cfg.Service.Pipelines))
 
-	pipelineProcessors, err = NewPipelinesBuilder(zap.NewNop(), cfg, allExporters, factories.Processors).Build()
+	pipelineProcessors, err = NewPipelinesBuilder(zap.NewNop(), component.ApplicationStartInfo{}, cfg, allExporters, factories.Processors).Build()
 	assert.Error(t, err)
 	assert.Zero(t, len(pipelineProcessors))
 }

--- a/service/builder/pipelines_builder_test.go
+++ b/service/builder/pipelines_builder_test.go
@@ -134,7 +134,7 @@ func TestPipelinesBuilder_BuildVarious(t *testing.T) {
 			cfg := createExampleConfig(dataType)
 
 			// BuildProcessors the pipeline
-			allExporters, err := NewExportersBuilder(zap.NewNop(), component.ApplicationStartInfo{}, cfg, factories.Exporters).Build()
+			allExporters, err := NewExportersBuilder(zap.NewNop(), componenttest.TestApplicationStartInfo(), cfg, factories.Exporters).Build()
 			if test.shouldFail {
 				assert.Error(t, err)
 				return
@@ -142,7 +142,7 @@ func TestPipelinesBuilder_BuildVarious(t *testing.T) {
 
 			require.NoError(t, err)
 			require.EqualValues(t, 1, len(allExporters))
-			pipelineProcessors, err := NewPipelinesBuilder(zap.NewNop(), component.ApplicationStartInfo{}, cfg, allExporters, factories.Processors).Build()
+			pipelineProcessors, err := NewPipelinesBuilder(zap.NewNop(), componenttest.TestApplicationStartInfo(), cfg, allExporters, factories.Processors).Build()
 
 			assert.NoError(t, err)
 			require.NotNil(t, pipelineProcessors)
@@ -217,9 +217,9 @@ func testPipeline(t *testing.T, pipelineName string, exporterNames []string) {
 	require.Nil(t, err)
 
 	// BuildProcessors the pipeline
-	allExporters, err := NewExportersBuilder(zap.NewNop(), component.ApplicationStartInfo{}, cfg, factories.Exporters).Build()
+	allExporters, err := NewExportersBuilder(zap.NewNop(), componenttest.TestApplicationStartInfo(), cfg, factories.Exporters).Build()
 	assert.NoError(t, err)
-	pipelineProcessors, err := NewPipelinesBuilder(zap.NewNop(), component.ApplicationStartInfo{}, cfg, allExporters, factories.Processors).Build()
+	pipelineProcessors, err := NewPipelinesBuilder(zap.NewNop(), componenttest.TestApplicationStartInfo(), cfg, allExporters, factories.Processors).Build()
 
 	assert.NoError(t, err)
 	require.NotNil(t, pipelineProcessors)
@@ -281,12 +281,12 @@ func TestPipelinesBuilder_Error(t *testing.T) {
 	pipeline := cfg.Service.Pipelines["traces"]
 	pipeline.InputType = configmodels.MetricsDataType
 
-	exporters, err := NewExportersBuilder(zap.NewNop(), component.ApplicationStartInfo{}, cfg, factories.Exporters).Build()
+	exporters, err := NewExportersBuilder(zap.NewNop(), componenttest.TestApplicationStartInfo(), cfg, factories.Exporters).Build()
 	assert.NoError(t, err)
 
 	// This should fail because "attributes" processor defined in the config does
 	// not support metrics data type.
-	_, err = NewPipelinesBuilder(zap.NewNop(), component.ApplicationStartInfo{}, cfg, exporters, factories.Processors).Build()
+	_, err = NewPipelinesBuilder(zap.NewNop(), componenttest.TestApplicationStartInfo(), cfg, exporters, factories.Processors).Build()
 
 	assert.NotNil(t, err)
 }
@@ -301,7 +301,7 @@ func TestProcessorsBuilder_ErrorOnNilProcessor(t *testing.T) {
 	cfg, err := configtest.LoadConfigFile(t, "testdata/bad_processor_factory.yaml", factories)
 	require.Nil(t, err)
 
-	allExporters, err := NewExportersBuilder(zap.NewNop(), component.ApplicationStartInfo{}, cfg, factories.Exporters).Build()
+	allExporters, err := NewExportersBuilder(zap.NewNop(), componenttest.TestApplicationStartInfo(), cfg, factories.Exporters).Build()
 	assert.NoError(t, err)
 
 	// First test only trace receivers by removing the metrics pipeline.
@@ -309,7 +309,7 @@ func TestProcessorsBuilder_ErrorOnNilProcessor(t *testing.T) {
 	delete(cfg.Service.Pipelines, "metrics")
 	require.Equal(t, 1, len(cfg.Service.Pipelines))
 
-	pipelineProcessors, err := NewPipelinesBuilder(zap.NewNop(), component.ApplicationStartInfo{}, cfg, allExporters, factories.Processors).Build()
+	pipelineProcessors, err := NewPipelinesBuilder(zap.NewNop(), componenttest.TestApplicationStartInfo(), cfg, allExporters, factories.Processors).Build()
 	assert.Error(t, err)
 	assert.Zero(t, len(pipelineProcessors))
 
@@ -318,7 +318,7 @@ func TestProcessorsBuilder_ErrorOnNilProcessor(t *testing.T) {
 	cfg.Service.Pipelines["metrics"] = metricsPipeline
 	require.Equal(t, 1, len(cfg.Service.Pipelines))
 
-	pipelineProcessors, err = NewPipelinesBuilder(zap.NewNop(), component.ApplicationStartInfo{}, cfg, allExporters, factories.Processors).Build()
+	pipelineProcessors, err = NewPipelinesBuilder(zap.NewNop(), componenttest.TestApplicationStartInfo(), cfg, allExporters, factories.Processors).Build()
 	assert.Error(t, err)
 	assert.Zero(t, len(pipelineProcessors))
 }

--- a/service/builder/receivers_builder_test.go
+++ b/service/builder/receivers_builder_test.go
@@ -102,11 +102,11 @@ func testReceivers(
 	require.Nil(t, err)
 
 	// Build the pipeline
-	allExporters, err := NewExportersBuilder(zap.NewNop(), cfg, factories.Exporters).Build()
+	allExporters, err := NewExportersBuilder(zap.NewNop(), component.ApplicationStartInfo{}, cfg, factories.Exporters).Build()
 	assert.NoError(t, err)
-	pipelineProcessors, err := NewPipelinesBuilder(zap.NewNop(), cfg, allExporters, factories.Processors).Build()
+	pipelineProcessors, err := NewPipelinesBuilder(zap.NewNop(), component.ApplicationStartInfo{}, cfg, allExporters, factories.Processors).Build()
 	assert.NoError(t, err)
-	receivers, err := NewReceiversBuilder(zap.NewNop(), cfg, pipelineProcessors, factories.Receivers).Build()
+	receivers, err := NewReceiversBuilder(zap.NewNop(), component.ApplicationStartInfo{}, cfg, pipelineProcessors, factories.Receivers).Build()
 
 	assert.NoError(t, err)
 	require.NotNil(t, receivers)
@@ -202,16 +202,16 @@ func TestReceiversBuilder_BuildCustom(t *testing.T) {
 			cfg := createExampleConfig(dataType)
 
 			// Build the pipeline
-			allExporters, err := NewExportersBuilder(zap.NewNop(), cfg, factories.Exporters).Build()
+			allExporters, err := NewExportersBuilder(zap.NewNop(), component.ApplicationStartInfo{}, cfg, factories.Exporters).Build()
 			if test.shouldFail {
 				assert.Error(t, err)
 				return
 			}
 
 			assert.NoError(t, err)
-			pipelineProcessors, err := NewPipelinesBuilder(zap.NewNop(), cfg, allExporters, factories.Processors).Build()
+			pipelineProcessors, err := NewPipelinesBuilder(zap.NewNop(), component.ApplicationStartInfo{}, cfg, allExporters, factories.Processors).Build()
 			assert.NoError(t, err)
-			receivers, err := NewReceiversBuilder(zap.NewNop(), cfg, pipelineProcessors, factories.Receivers).Build()
+			receivers, err := NewReceiversBuilder(zap.NewNop(), component.ApplicationStartInfo{}, cfg, pipelineProcessors, factories.Receivers).Build()
 
 			assert.NoError(t, err)
 			require.NotNil(t, receivers)
@@ -274,11 +274,11 @@ func TestReceiversBuilder_DataTypeError(t *testing.T) {
 	receiver.(*componenttest.ExampleReceiver).FailTraceCreation = true
 
 	// Build the pipeline
-	allExporters, err := NewExportersBuilder(zap.NewNop(), cfg, factories.Exporters).Build()
+	allExporters, err := NewExportersBuilder(zap.NewNop(), component.ApplicationStartInfo{}, cfg, factories.Exporters).Build()
 	assert.NoError(t, err)
-	pipelineProcessors, err := NewPipelinesBuilder(zap.NewNop(), cfg, allExporters, factories.Processors).Build()
+	pipelineProcessors, err := NewPipelinesBuilder(zap.NewNop(), component.ApplicationStartInfo{}, cfg, allExporters, factories.Processors).Build()
 	assert.NoError(t, err)
-	receivers, err := NewReceiversBuilder(zap.NewNop(), cfg, pipelineProcessors, factories.Receivers).Build()
+	receivers, err := NewReceiversBuilder(zap.NewNop(), component.ApplicationStartInfo{}, cfg, pipelineProcessors, factories.Receivers).Build()
 
 	// This should fail because "examplereceiver" is attached to "traces" pipeline
 	// which is a configuration error.
@@ -334,9 +334,9 @@ func TestReceiversBuilder_ErrorOnNilReceiver(t *testing.T) {
 	require.Nil(t, err)
 
 	// Build the pipeline
-	allExporters, err := NewExportersBuilder(zap.NewNop(), cfg, factories.Exporters).Build()
+	allExporters, err := NewExportersBuilder(zap.NewNop(), component.ApplicationStartInfo{}, cfg, factories.Exporters).Build()
 	assert.NoError(t, err)
-	pipelineProcessors, err := NewPipelinesBuilder(zap.NewNop(), cfg, allExporters, factories.Processors).Build()
+	pipelineProcessors, err := NewPipelinesBuilder(zap.NewNop(), component.ApplicationStartInfo{}, cfg, allExporters, factories.Processors).Build()
 	assert.NoError(t, err)
 
 	// First test only trace receivers by removing the metrics pipeline.
@@ -344,7 +344,7 @@ func TestReceiversBuilder_ErrorOnNilReceiver(t *testing.T) {
 	delete(cfg.Service.Pipelines, "metrics")
 	require.Equal(t, 1, len(cfg.Service.Pipelines))
 
-	receivers, err := NewReceiversBuilder(zap.NewNop(), cfg, pipelineProcessors, factories.Receivers).Build()
+	receivers, err := NewReceiversBuilder(zap.NewNop(), component.ApplicationStartInfo{}, cfg, pipelineProcessors, factories.Receivers).Build()
 	assert.Error(t, err)
 	assert.Zero(t, len(receivers))
 
@@ -353,7 +353,7 @@ func TestReceiversBuilder_ErrorOnNilReceiver(t *testing.T) {
 	cfg.Service.Pipelines["metrics"] = metricsPipeline
 	require.Equal(t, 1, len(cfg.Service.Pipelines))
 
-	receivers, err = NewReceiversBuilder(zap.NewNop(), cfg, pipelineProcessors, factories.Receivers).Build()
+	receivers, err = NewReceiversBuilder(zap.NewNop(), component.ApplicationStartInfo{}, cfg, pipelineProcessors, factories.Receivers).Build()
 	assert.Error(t, err)
 	assert.Zero(t, len(receivers))
 }
@@ -371,11 +371,11 @@ func TestReceiversBuilder_Unused(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Build the pipeline
-	allExporters, err := NewExportersBuilder(zap.NewNop(), cfg, factories.Exporters).Build()
+	allExporters, err := NewExportersBuilder(zap.NewNop(), component.ApplicationStartInfo{}, cfg, factories.Exporters).Build()
 	assert.NoError(t, err)
-	pipelineProcessors, err := NewPipelinesBuilder(zap.NewNop(), cfg, allExporters, factories.Processors).Build()
+	pipelineProcessors, err := NewPipelinesBuilder(zap.NewNop(), component.ApplicationStartInfo{}, cfg, allExporters, factories.Processors).Build()
 	assert.NoError(t, err)
-	receivers, err := NewReceiversBuilder(zap.NewNop(), cfg, pipelineProcessors, factories.Receivers).Build()
+	receivers, err := NewReceiversBuilder(zap.NewNop(), component.ApplicationStartInfo{}, cfg, pipelineProcessors, factories.Receivers).Build()
 	assert.NoError(t, err)
 	assert.NotNil(t, receivers)
 
@@ -394,11 +394,11 @@ func TestReceiversBuilder_InternalToOcTraceConverter(t *testing.T) {
 	require.Nil(t, err)
 
 	// Build the pipeline
-	allExporters, err := NewExportersBuilder(zap.NewNop(), cfg, factories.Exporters).Build()
+	allExporters, err := NewExportersBuilder(zap.NewNop(), component.ApplicationStartInfo{}, cfg, factories.Exporters).Build()
 	assert.NoError(t, err)
-	pipelineProcessors, err := NewPipelinesBuilder(zap.NewNop(), cfg, allExporters, factories.Processors).Build()
+	pipelineProcessors, err := NewPipelinesBuilder(zap.NewNop(), component.ApplicationStartInfo{}, cfg, allExporters, factories.Processors).Build()
 	assert.NoError(t, err)
-	receivers, err := NewReceiversBuilder(zap.NewNop(), cfg, pipelineProcessors, factories.Receivers).Build()
+	receivers, err := NewReceiversBuilder(zap.NewNop(), component.ApplicationStartInfo{}, cfg, pipelineProcessors, factories.Receivers).Build()
 	assert.NoError(t, err)
 	assert.NotNil(t, receivers)
 

--- a/service/builder/receivers_builder_test.go
+++ b/service/builder/receivers_builder_test.go
@@ -102,11 +102,11 @@ func testReceivers(
 	require.Nil(t, err)
 
 	// Build the pipeline
-	allExporters, err := NewExportersBuilder(zap.NewNop(), component.ApplicationStartInfo{}, cfg, factories.Exporters).Build()
+	allExporters, err := NewExportersBuilder(zap.NewNop(), componenttest.TestApplicationStartInfo(), cfg, factories.Exporters).Build()
 	assert.NoError(t, err)
-	pipelineProcessors, err := NewPipelinesBuilder(zap.NewNop(), component.ApplicationStartInfo{}, cfg, allExporters, factories.Processors).Build()
+	pipelineProcessors, err := NewPipelinesBuilder(zap.NewNop(), componenttest.TestApplicationStartInfo(), cfg, allExporters, factories.Processors).Build()
 	assert.NoError(t, err)
-	receivers, err := NewReceiversBuilder(zap.NewNop(), component.ApplicationStartInfo{}, cfg, pipelineProcessors, factories.Receivers).Build()
+	receivers, err := NewReceiversBuilder(zap.NewNop(), componenttest.TestApplicationStartInfo(), cfg, pipelineProcessors, factories.Receivers).Build()
 
 	assert.NoError(t, err)
 	require.NotNil(t, receivers)
@@ -202,16 +202,16 @@ func TestReceiversBuilder_BuildCustom(t *testing.T) {
 			cfg := createExampleConfig(dataType)
 
 			// Build the pipeline
-			allExporters, err := NewExportersBuilder(zap.NewNop(), component.ApplicationStartInfo{}, cfg, factories.Exporters).Build()
+			allExporters, err := NewExportersBuilder(zap.NewNop(), componenttest.TestApplicationStartInfo(), cfg, factories.Exporters).Build()
 			if test.shouldFail {
 				assert.Error(t, err)
 				return
 			}
 
 			assert.NoError(t, err)
-			pipelineProcessors, err := NewPipelinesBuilder(zap.NewNop(), component.ApplicationStartInfo{}, cfg, allExporters, factories.Processors).Build()
+			pipelineProcessors, err := NewPipelinesBuilder(zap.NewNop(), componenttest.TestApplicationStartInfo(), cfg, allExporters, factories.Processors).Build()
 			assert.NoError(t, err)
-			receivers, err := NewReceiversBuilder(zap.NewNop(), component.ApplicationStartInfo{}, cfg, pipelineProcessors, factories.Receivers).Build()
+			receivers, err := NewReceiversBuilder(zap.NewNop(), componenttest.TestApplicationStartInfo(), cfg, pipelineProcessors, factories.Receivers).Build()
 
 			assert.NoError(t, err)
 			require.NotNil(t, receivers)
@@ -274,11 +274,11 @@ func TestReceiversBuilder_DataTypeError(t *testing.T) {
 	receiver.(*componenttest.ExampleReceiver).FailTraceCreation = true
 
 	// Build the pipeline
-	allExporters, err := NewExportersBuilder(zap.NewNop(), component.ApplicationStartInfo{}, cfg, factories.Exporters).Build()
+	allExporters, err := NewExportersBuilder(zap.NewNop(), componenttest.TestApplicationStartInfo(), cfg, factories.Exporters).Build()
 	assert.NoError(t, err)
-	pipelineProcessors, err := NewPipelinesBuilder(zap.NewNop(), component.ApplicationStartInfo{}, cfg, allExporters, factories.Processors).Build()
+	pipelineProcessors, err := NewPipelinesBuilder(zap.NewNop(), componenttest.TestApplicationStartInfo(), cfg, allExporters, factories.Processors).Build()
 	assert.NoError(t, err)
-	receivers, err := NewReceiversBuilder(zap.NewNop(), component.ApplicationStartInfo{}, cfg, pipelineProcessors, factories.Receivers).Build()
+	receivers, err := NewReceiversBuilder(zap.NewNop(), componenttest.TestApplicationStartInfo(), cfg, pipelineProcessors, factories.Receivers).Build()
 
 	// This should fail because "examplereceiver" is attached to "traces" pipeline
 	// which is a configuration error.
@@ -334,9 +334,9 @@ func TestReceiversBuilder_ErrorOnNilReceiver(t *testing.T) {
 	require.Nil(t, err)
 
 	// Build the pipeline
-	allExporters, err := NewExportersBuilder(zap.NewNop(), component.ApplicationStartInfo{}, cfg, factories.Exporters).Build()
+	allExporters, err := NewExportersBuilder(zap.NewNop(), componenttest.TestApplicationStartInfo(), cfg, factories.Exporters).Build()
 	assert.NoError(t, err)
-	pipelineProcessors, err := NewPipelinesBuilder(zap.NewNop(), component.ApplicationStartInfo{}, cfg, allExporters, factories.Processors).Build()
+	pipelineProcessors, err := NewPipelinesBuilder(zap.NewNop(), componenttest.TestApplicationStartInfo(), cfg, allExporters, factories.Processors).Build()
 	assert.NoError(t, err)
 
 	// First test only trace receivers by removing the metrics pipeline.
@@ -344,7 +344,7 @@ func TestReceiversBuilder_ErrorOnNilReceiver(t *testing.T) {
 	delete(cfg.Service.Pipelines, "metrics")
 	require.Equal(t, 1, len(cfg.Service.Pipelines))
 
-	receivers, err := NewReceiversBuilder(zap.NewNop(), component.ApplicationStartInfo{}, cfg, pipelineProcessors, factories.Receivers).Build()
+	receivers, err := NewReceiversBuilder(zap.NewNop(), componenttest.TestApplicationStartInfo(), cfg, pipelineProcessors, factories.Receivers).Build()
 	assert.Error(t, err)
 	assert.Zero(t, len(receivers))
 
@@ -353,7 +353,7 @@ func TestReceiversBuilder_ErrorOnNilReceiver(t *testing.T) {
 	cfg.Service.Pipelines["metrics"] = metricsPipeline
 	require.Equal(t, 1, len(cfg.Service.Pipelines))
 
-	receivers, err = NewReceiversBuilder(zap.NewNop(), component.ApplicationStartInfo{}, cfg, pipelineProcessors, factories.Receivers).Build()
+	receivers, err = NewReceiversBuilder(zap.NewNop(), componenttest.TestApplicationStartInfo(), cfg, pipelineProcessors, factories.Receivers).Build()
 	assert.Error(t, err)
 	assert.Zero(t, len(receivers))
 }
@@ -371,11 +371,11 @@ func TestReceiversBuilder_Unused(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Build the pipeline
-	allExporters, err := NewExportersBuilder(zap.NewNop(), component.ApplicationStartInfo{}, cfg, factories.Exporters).Build()
+	allExporters, err := NewExportersBuilder(zap.NewNop(), componenttest.TestApplicationStartInfo(), cfg, factories.Exporters).Build()
 	assert.NoError(t, err)
-	pipelineProcessors, err := NewPipelinesBuilder(zap.NewNop(), component.ApplicationStartInfo{}, cfg, allExporters, factories.Processors).Build()
+	pipelineProcessors, err := NewPipelinesBuilder(zap.NewNop(), componenttest.TestApplicationStartInfo(), cfg, allExporters, factories.Processors).Build()
 	assert.NoError(t, err)
-	receivers, err := NewReceiversBuilder(zap.NewNop(), component.ApplicationStartInfo{}, cfg, pipelineProcessors, factories.Receivers).Build()
+	receivers, err := NewReceiversBuilder(zap.NewNop(), componenttest.TestApplicationStartInfo(), cfg, pipelineProcessors, factories.Receivers).Build()
 	assert.NoError(t, err)
 	assert.NotNil(t, receivers)
 
@@ -394,11 +394,11 @@ func TestReceiversBuilder_InternalToOcTraceConverter(t *testing.T) {
 	require.Nil(t, err)
 
 	// Build the pipeline
-	allExporters, err := NewExportersBuilder(zap.NewNop(), component.ApplicationStartInfo{}, cfg, factories.Exporters).Build()
+	allExporters, err := NewExportersBuilder(zap.NewNop(), componenttest.TestApplicationStartInfo(), cfg, factories.Exporters).Build()
 	assert.NoError(t, err)
-	pipelineProcessors, err := NewPipelinesBuilder(zap.NewNop(), component.ApplicationStartInfo{}, cfg, allExporters, factories.Processors).Build()
+	pipelineProcessors, err := NewPipelinesBuilder(zap.NewNop(), componenttest.TestApplicationStartInfo(), cfg, allExporters, factories.Processors).Build()
 	assert.NoError(t, err)
-	receivers, err := NewReceiversBuilder(zap.NewNop(), component.ApplicationStartInfo{}, cfg, pipelineProcessors, factories.Receivers).Build()
+	receivers, err := NewReceiversBuilder(zap.NewNop(), componenttest.TestApplicationStartInfo(), cfg, pipelineProcessors, factories.Receivers).Build()
 	assert.NoError(t, err)
 	assert.NotNil(t, receivers)
 

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -38,7 +38,6 @@ import (
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/configmodels"
-	"go.opentelemetry.io/collector/internal/version"
 	"go.opentelemetry.io/collector/service/defaultcomponents"
 	"go.opentelemetry.io/collector/testutil"
 )
@@ -53,7 +52,7 @@ func TestApplication_Start(t *testing.T) {
 		return nil
 	}
 
-	app, err := New(Parameters{Factories: factories, ApplicationStartInfo: component.ApplicationStartInfo{}, LoggingHooks: []func(entry zapcore.Entry) error{hook}})
+	app, err := New(Parameters{Factories: factories, ApplicationStartInfo: componenttest.TestApplicationStartInfo(), LoggingHooks: []func(entry zapcore.Entry) error{hook}})
 	require.NoError(t, err)
 	assert.Equal(t, app.rootCmd, app.Command())
 
@@ -113,7 +112,7 @@ func TestApplication_ReportError(t *testing.T) {
 	factories, err := defaultcomponents.Components()
 	require.NoError(t, err)
 
-	app, err := New(Parameters{Factories: factories, ApplicationStartInfo: component.ApplicationStartInfo{}})
+	app, err := New(Parameters{Factories: factories, ApplicationStartInfo: componenttest.TestApplicationStartInfo()})
 	require.NoError(t, err)
 
 	app.rootCmd.SetArgs([]string{"--config=testdata/otelcol-config-minimal.yaml"})
@@ -137,12 +136,7 @@ func TestApplication_StartAsGoRoutine(t *testing.T) {
 	require.NoError(t, err)
 
 	params := Parameters{
-		ApplicationStartInfo: component.ApplicationStartInfo{
-			ExeName:  "otelcol",
-			LongName: "InProcess Collector",
-			Version:  version.Version,
-			GitHash:  version.GitHash,
-		},
+		ApplicationStartInfo: componenttest.TestApplicationStartInfo(),
 		ConfigFactory: func(v *viper.Viper, factories component.Factories) (*configmodels.Config, error) {
 			return constructMimumalOpConfig(t, factories), nil
 		},

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -53,7 +53,7 @@ func TestApplication_Start(t *testing.T) {
 		return nil
 	}
 
-	app, err := New(Parameters{Factories: factories, ApplicationStartInfo: ApplicationStartInfo{}, LoggingHooks: []func(entry zapcore.Entry) error{hook}})
+	app, err := New(Parameters{Factories: factories, ApplicationStartInfo: component.ApplicationStartInfo{}, LoggingHooks: []func(entry zapcore.Entry) error{hook}})
 	require.NoError(t, err)
 	assert.Equal(t, app.rootCmd, app.Command())
 
@@ -113,7 +113,7 @@ func TestApplication_ReportError(t *testing.T) {
 	factories, err := defaultcomponents.Components()
 	require.NoError(t, err)
 
-	app, err := New(Parameters{Factories: factories, ApplicationStartInfo: ApplicationStartInfo{}})
+	app, err := New(Parameters{Factories: factories, ApplicationStartInfo: component.ApplicationStartInfo{}})
 	require.NoError(t, err)
 
 	app.rootCmd.SetArgs([]string{"--config=testdata/otelcol-config-minimal.yaml"})
@@ -137,7 +137,7 @@ func TestApplication_StartAsGoRoutine(t *testing.T) {
 	require.NoError(t, err)
 
 	params := Parameters{
-		ApplicationStartInfo: ApplicationStartInfo{
+		ApplicationStartInfo: component.ApplicationStartInfo{
 			ExeName:  "otelcol",
 			LongName: "InProcess Collector",
 			Version:  version.Version,

--- a/service/service_windows_test.go
+++ b/service/service_windows_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sys/windows/svc"
 
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/service/defaultcomponents"
 )
 
@@ -33,7 +34,7 @@ func TestWindowsService_Execute(t *testing.T) {
 	factories, err := defaultcomponents.Components()
 	require.NoError(t, err)
 
-	s := NewWindowsService(Parameters{Factories: factories, ApplicationStartInfo: ApplicationStartInfo{}})
+	s := NewWindowsService(Parameters{Factories: factories, ApplicationStartInfo: component.ApplicationStartInfo{}})
 
 	appDone := make(chan struct{})
 	requests := make(chan svc.ChangeRequest)

--- a/service/service_windows_test.go
+++ b/service/service_windows_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sys/windows/svc"
 
-	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/service/defaultcomponents"
 )
 
@@ -34,7 +34,7 @@ func TestWindowsService_Execute(t *testing.T) {
 	factories, err := defaultcomponents.Components()
 	require.NoError(t, err)
 
-	s := NewWindowsService(Parameters{Factories: factories, ApplicationStartInfo: component.ApplicationStartInfo{}})
+	s := NewWindowsService(Parameters{Factories: factories, ApplicationStartInfo: componenttest.TestApplicationStartInfo()})
 
 	appDone := make(chan struct{})
 	requests := make(chan svc.ChangeRequest)

--- a/testbed/testbed/otelcol_runner.go
+++ b/testbed/testbed/otelcol_runner.go
@@ -100,7 +100,7 @@ func (ipp *InProcessCollector) PrepareConfig(configStr string) (configCleanup fu
 
 func (ipp *InProcessCollector) Start(args StartParams) (receiverAddr string, err error) {
 	params := service.Parameters{
-		ApplicationStartInfo: service.ApplicationStartInfo{
+		ApplicationStartInfo: component.ApplicationStartInfo{
 			ExeName:  "otelcol",
 			LongName: "InProcess Collector",
 			Version:  version.Version,


### PR DESCRIPTION
**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector/issues/1559

Update service pipeline to pass ApplicationInfo into all new components as part of the `CreateParams` structs.

**Example Usage:** https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/758