### PR TITLE
Make Kafka payload encoding configurable

### DIFF
--- a/exporter/kafkaexporter/README.md
+++ b/exporter/kafkaexporter/README.md
@@ -14,8 +14,6 @@ The following settings can be optionally configured:
   - `otlp_proto`: the payload is serialized to `ExportTraceServiceRequest`.
   - `jaeger_proto`: the payload is serialized to a single Jaeger proto `Span`.
   - `jaeger_json`: the payload is serialized to a single Jaeger JSON Span using `jsonpb`.
-  - `zipkin_thrift`: the payload is serialized into Zipkin Thrift spans.
-  - `zipkin_json`: the payload is serialized into Zipkin V2 JSON spans.
 - `metadata`
   - `full` (default = true): Whether to maintain a full set of metadata. 
                                     When disabled the client does not make the initial request to broker at the startup.

--- a/exporter/kafkaexporter/README.md
+++ b/exporter/kafkaexporter/README.md
@@ -2,16 +2,20 @@
 
 Kafka exporter exports traces to Kafka. This exporter uses a synchronous producer
 that blocks and does not batch messages, therefore it should be used with batch and queued retry
-processors for higher throughput and resiliency.
+processors for higher throughput and resiliency. Message payload encoding is configurable.
  
-Message payloads are serialized OTLP `ExportTraceServiceRequest`.
-
 The following settings are required:
 - `protocol_version` (no default): Kafka protocol version e.g. 2.0.0
 
 The following settings can be optionally configured:
 - `brokers` (default = localhost:9092): The list of kafka brokers
 - `topic` (default = otlp_spans): The name of the kafka topic to export to
+- `encoding` (default = otlp_proto): The encoding of the payload sent to kafka. Available encodings:
+  - `otlp_proto`: the payload is serialized to `ExportTraceServiceRequest`.
+  - `jaeger_proto`: the payload is serialized to a single Jaeger proto `Span`.
+  - `jaeger_json`: the payload is serialized to a single Jaeger JSON Span using `jsonpb`.
+  - `zipkin_thrift`: the payload is serialized into Zipkin Thrift spans.
+  - `zipkin_json`: the payload is serialized into Zipkin V2 JSON spans.
 - `metadata`
   - `full` (default = true): Whether to maintain a full set of metadata. 
                                     When disabled the client does not make the initial request to broker at the startup.

--- a/exporter/kafkaexporter/config.go
+++ b/exporter/kafkaexporter/config.go
@@ -34,6 +34,8 @@ type Config struct {
 	ProtocolVersion string `mapstructure:"protocol_version"`
 	// The name of the kafka topic to export to (default "otlp_spans")
 	Topic string `mapstructure:"topic"`
+	// Encoding of the messages (default "otlp_proto")
+	Encoding string `mapstructure:"encoding"`
 
 	// Metadata is the namespace for metadata management properties used by the
 	// Client, and shared by the Producer/Consumer.

--- a/exporter/kafkaexporter/config_test.go
+++ b/exporter/kafkaexporter/config_test.go
@@ -58,8 +58,9 @@ func TestLoadConfig(t *testing.T) {
 			NumConsumers: 2,
 			QueueSize:    10,
 		},
-		Topic:   "spans",
-		Brokers: []string{"foo:123", "bar:456"},
+		Topic:    "spans",
+		Encoding: "otlp_proto",
+		Brokers:  []string{"foo:123", "bar:456"},
 		Metadata: Metadata{
 			Full: false,
 			Retry: MetadataRetry{

--- a/exporter/kafkaexporter/config_test.go
+++ b/exporter/kafkaexporter/config_test.go
@@ -32,7 +32,7 @@ func TestLoadConfig(t *testing.T) {
 	factories, err := componenttest.ExampleComponents()
 	assert.NoError(t, err)
 
-	factory := NewFactory()
+	factory := NewFactory(DefaultMarshallers())
 	factories.Exporters[typeStr] = factory
 	cfg, err := configtest.LoadConfigFile(t, path.Join(".", "testdata", "config.yaml"), factories)
 	require.NoError(t, err)

--- a/exporter/kafkaexporter/config_test.go
+++ b/exporter/kafkaexporter/config_test.go
@@ -32,7 +32,7 @@ func TestLoadConfig(t *testing.T) {
 	factories, err := componenttest.ExampleComponents()
 	assert.NoError(t, err)
 
-	factory := NewFactory(DefaultMarshallers())
+	factory := NewFactory()
 	factories.Exporters[typeStr] = factory
 	cfg, err := configtest.LoadConfigFile(t, path.Join(".", "testdata", "config.yaml"), factories)
 	require.NoError(t, err)

--- a/exporter/kafkaexporter/factory.go
+++ b/exporter/kafkaexporter/factory.go
@@ -24,9 +24,10 @@ import (
 )
 
 const (
-	typeStr       = "kafka"
-	defaultTopic  = "otlp_spans"
-	defaultBroker = "localhost:9092"
+	typeStr         = "kafka"
+	defaultTopic    = "otlp_spans"
+	defaultEncoding = "otlp_proto"
+	defaultBroker   = "localhost:9092"
 	// default from sarama.NewConfig()
 	defaultMetadataRetryMax = 3
 	// default from sarama.NewConfig()
@@ -57,6 +58,7 @@ func createDefaultConfig() configmodels.Exporter {
 		QueueSettings:   qs,
 		Brokers:         []string{defaultBroker},
 		Topic:           defaultTopic,
+		Encoding:        defaultEncoding,
 		Metadata: Metadata{
 			Full: defaultMetadataFull,
 			Retry: MetadataRetry{

--- a/exporter/kafkaexporter/factory_test.go
+++ b/exporter/kafkaexporter/factory_test.go
@@ -23,6 +23,7 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configcheck"
+	"go.opentelemetry.io/collector/consumer/pdata"
 )
 
 func TestCreateDefaultConfig(t *testing.T) {
@@ -39,7 +40,7 @@ func TestCreateTracesExporter(t *testing.T) {
 	cfg.ProtocolVersion = "2.0.0"
 	// this disables contacting the broker so we can successfully create the exporter
 	cfg.Metadata.Full = false
-	f := kafkaExporterFactory{marshallers: DefaultMarshallers()}
+	f := kafkaExporterFactory{marshallers: defaultMarshallers()}
 	r, err := f.createTraceExporter(context.Background(), component.ExporterCreateParams{}, cfg)
 	require.NoError(t, err)
 	assert.NotNil(t, r)
@@ -49,9 +50,43 @@ func TestCreateTracesExporter_err(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)
 	cfg.Brokers = []string{"invalid:9092"}
 	cfg.ProtocolVersion = "2.0.0"
-	f := kafkaExporterFactory{marshallers: DefaultMarshallers()}
+	f := kafkaExporterFactory{marshallers: defaultMarshallers()}
 	r, err := f.createTraceExporter(context.Background(), component.ExporterCreateParams{}, cfg)
 	// no available broker
 	require.Error(t, err)
 	assert.Nil(t, r)
+}
+
+func TestWithMarshallers(t *testing.T) {
+	cm := &customMarshaller{}
+	f := NewFactory(WithAddMarshallers(map[string]Marshaller{cm.Encoding(): cm}))
+	cfg := createDefaultConfig().(*Config)
+	// disable contacting broker
+	cfg.Metadata.Full = false
+
+	t.Run("custom_encoding", func(t *testing.T) {
+		cfg.Encoding = cm.Encoding()
+		exporter, err := f.CreateTraceExporter(context.Background(), component.ExporterCreateParams{}, cfg)
+		require.NoError(t, err)
+		require.NotNil(t, exporter)
+	})
+	t.Run("default_encoding", func(t *testing.T) {
+		cfg.Encoding = new(otlpProtoMarshaller).Encoding()
+		exporter, err := f.CreateTraceExporter(context.Background(), component.ExporterCreateParams{}, cfg)
+		require.NoError(t, err)
+		assert.NotNil(t, exporter)
+	})
+}
+
+type customMarshaller struct {
+}
+
+var _ Marshaller = (*customMarshaller)(nil)
+
+func (c customMarshaller) Marshal(traces pdata.Traces) ([]Message, error) {
+	panic("implement me")
+}
+
+func (c customMarshaller) Encoding() string {
+	return "custom"
 }

--- a/exporter/kafkaexporter/factory_test.go
+++ b/exporter/kafkaexporter/factory_test.go
@@ -39,7 +39,8 @@ func TestCreateTracesExporter(t *testing.T) {
 	cfg.ProtocolVersion = "2.0.0"
 	// this disables contacting the broker so we can successfully create the exporter
 	cfg.Metadata.Full = false
-	r, err := createTraceExporter(context.Background(), component.ExporterCreateParams{}, cfg)
+	f := kafkaExporterFactory{marshallers: DefaultMarshallers()}
+	r, err := f.createTraceExporter(context.Background(), component.ExporterCreateParams{}, cfg)
 	require.NoError(t, err)
 	assert.NotNil(t, r)
 }
@@ -48,8 +49,9 @@ func TestCreateTracesExporter_err(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)
 	cfg.Brokers = []string{"invalid:9092"}
 	cfg.ProtocolVersion = "2.0.0"
-	// we get the error because the exporter
-	r, err := createTraceExporter(context.Background(), component.ExporterCreateParams{}, cfg)
+	f := kafkaExporterFactory{marshallers: DefaultMarshallers()}
+	r, err := f.createTraceExporter(context.Background(), component.ExporterCreateParams{}, cfg)
+	// no available broker
 	require.Error(t, err)
 	assert.Nil(t, r)
 }

--- a/exporter/kafkaexporter/jaeger_marshaller.go
+++ b/exporter/kafkaexporter/jaeger_marshaller.go
@@ -25,19 +25,6 @@ import (
 	jaegertranslator "go.opentelemetry.io/collector/translator/trace/jaeger"
 )
 
-func init() {
-	jaegerProtoMarshaller := &jaegerMarshaller{
-		marshaller: jaegerProtoSpanMarshaller{},
-	}
-	RegisterMarshaller(jaegerProtoMarshaller)
-	jaegerJSONMarshaller := &jaegerMarshaller{
-		marshaller: jaegerJSONSpanMarshaller{
-			pbMarshaller: &jsonpb.Marshaler{},
-		},
-	}
-	RegisterMarshaller(jaegerJSONMarshaller)
-}
-
 type jaegerMarshaller struct {
 	marshaller jaegerSpanMarshaller
 }
@@ -93,6 +80,12 @@ type jaegerJSONSpanMarshaller struct {
 }
 
 var _ jaegerSpanMarshaller = (*jaegerJSONSpanMarshaller)(nil)
+
+func newJaegerJSONMarshaller() *jaegerJSONSpanMarshaller {
+	return &jaegerJSONSpanMarshaller{
+		pbMarshaller: &jsonpb.Marshaler{},
+	}
+}
 
 func (p jaegerJSONSpanMarshaller) marshall(span *jaegerproto.Span) ([]byte, error) {
 	out := new(bytes.Buffer)

--- a/exporter/kafkaexporter/jaeger_marshaller.go
+++ b/exporter/kafkaexporter/jaeger_marshaller.go
@@ -1,0 +1,105 @@
+// Copyright 2020 The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kafkaexporter
+
+import (
+	"bytes"
+
+	"github.com/gogo/protobuf/jsonpb"
+	jaegerproto "github.com/jaegertracing/jaeger/model"
+
+	"go.opentelemetry.io/collector/component/componenterror"
+	"go.opentelemetry.io/collector/consumer/pdata"
+	jaegertranslator "go.opentelemetry.io/collector/translator/trace/jaeger"
+)
+
+func init() {
+	jaegerProtoMarshaller := &jaegerMarshaller{
+		marshaller: jaegerProtoSpanMarshaller{},
+	}
+	RegisterMarshaller(jaegerProtoMarshaller)
+	jaegerJSONMarshaller := &jaegerMarshaller{
+		marshaller: jaegerJSONSpanMarshaller{
+			pbMarshaller: &jsonpb.Marshaler{},
+		},
+	}
+	RegisterMarshaller(jaegerJSONMarshaller)
+}
+
+type jaegerMarshaller struct {
+	marshaller jaegerSpanMarshaller
+}
+
+var _ Marshaller = (*jaegerMarshaller)(nil)
+
+func (j jaegerMarshaller) Marshal(traces pdata.Traces) ([]Message, error) {
+	batches, err := jaegertranslator.InternalTracesToJaegerProto(traces)
+	if err != nil {
+		return nil, err
+	}
+	var messages []Message
+	var errs []error
+	for _, batch := range batches {
+		for _, span := range batch.Spans {
+			span.Process = batch.Process
+			bts, err := j.marshaller.marshall(span)
+			// continue to process spans that can be serialized
+			if err != nil {
+				errs = append(errs, err)
+				continue
+			}
+			messages = append(messages, Message{Value: bts})
+		}
+	}
+	return messages, componenterror.CombineErrors(errs)
+}
+
+func (j jaegerMarshaller) Encoding() string {
+	return j.marshaller.encoding()
+}
+
+type jaegerSpanMarshaller interface {
+	marshall(span *jaegerproto.Span) ([]byte, error)
+	encoding() string
+}
+
+type jaegerProtoSpanMarshaller struct {
+}
+
+var _ jaegerSpanMarshaller = (*jaegerProtoSpanMarshaller)(nil)
+
+func (p jaegerProtoSpanMarshaller) marshall(span *jaegerproto.Span) ([]byte, error) {
+	return span.Marshal()
+}
+
+func (p jaegerProtoSpanMarshaller) encoding() string {
+	return "jaeger_proto"
+}
+
+type jaegerJSONSpanMarshaller struct {
+	pbMarshaller *jsonpb.Marshaler
+}
+
+var _ jaegerSpanMarshaller = (*jaegerJSONSpanMarshaller)(nil)
+
+func (p jaegerJSONSpanMarshaller) marshall(span *jaegerproto.Span) ([]byte, error) {
+	out := new(bytes.Buffer)
+	err := p.pbMarshaller.Marshal(out, span)
+	return out.Bytes(), err
+}
+
+func (p jaegerJSONSpanMarshaller) encoding() string {
+	return "jaeger_json"
+}

--- a/exporter/kafkaexporter/jaeger_marshaller_test.go
+++ b/exporter/kafkaexporter/jaeger_marshaller_test.go
@@ -1,0 +1,95 @@
+// Copyright 2020 The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kafkaexporter
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/gogo/protobuf/jsonpb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/collector/consumer/pdata"
+	jaegertranslator "go.opentelemetry.io/collector/translator/trace/jaeger"
+)
+
+func TestJaegerMarshaller(t *testing.T) {
+	td := pdata.NewTraces()
+	td.ResourceSpans().Resize(1)
+	td.ResourceSpans().At(0).InstrumentationLibrarySpans().Resize(1)
+	td.ResourceSpans().At(0).InstrumentationLibrarySpans().At(0).Spans().Resize(1)
+	td.ResourceSpans().At(0).InstrumentationLibrarySpans().At(0).Spans().At(0).SetName("foo")
+	td.ResourceSpans().At(0).InstrumentationLibrarySpans().At(0).Spans().At(0).SetStartTime(pdata.TimestampUnixNano(10))
+	td.ResourceSpans().At(0).InstrumentationLibrarySpans().At(0).Spans().At(0).SetEndTime(pdata.TimestampUnixNano(20))
+	td.ResourceSpans().At(0).InstrumentationLibrarySpans().At(0).Spans().At(0).SetTraceID(pdata.NewTraceID([]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}))
+	td.ResourceSpans().At(0).InstrumentationLibrarySpans().At(0).Spans().At(0).SetSpanID(pdata.NewSpanID([]byte{1, 2, 3, 4, 5, 6, 7, 8}))
+	batches, err := jaegertranslator.InternalTracesToJaegerProto(td)
+	require.NoError(t, err)
+
+	batches[0].Spans[0].Process = batches[0].Process
+	jaegerProtoBytes, err := batches[0].Spans[0].Marshal()
+	require.NoError(t, err)
+	require.NotNil(t, jaegerProtoBytes)
+
+	jsonMarshaller := &jsonpb.Marshaler{}
+	jsonByteBuffer := new(bytes.Buffer)
+	require.NoError(t, jsonMarshaller.Marshal(jsonByteBuffer, batches[0].Spans[0]))
+
+	tests := []struct {
+		unmarshaller Marshaller
+		encoding     string
+		messages     []Message
+	}{
+		{
+			unmarshaller: jaegerMarshaller{
+				marshaller: jaegerProtoSpanMarshaller{},
+			},
+			encoding: "jaeger_proto",
+			messages: []Message{{Value: jaegerProtoBytes}},
+		},
+		{
+			unmarshaller: jaegerMarshaller{
+				marshaller: jaegerJSONSpanMarshaller{
+					pbMarshaller: &jsonpb.Marshaler{},
+				},
+			},
+			encoding: "jaeger_json",
+			messages: []Message{{Value: jsonByteBuffer.Bytes()}},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.encoding, func(t *testing.T) {
+			messages, err := test.unmarshaller.Marshal(td)
+			require.NoError(t, err)
+			assert.Equal(t, test.messages, messages)
+			assert.Equal(t, test.encoding, test.unmarshaller.Encoding())
+		})
+	}
+}
+
+func TestJaegerMarshaller_error_covert_traceID(t *testing.T) {
+	marshaller := jaegerMarshaller{
+		marshaller: jaegerProtoSpanMarshaller{},
+	}
+	td := pdata.NewTraces()
+	td.ResourceSpans().Resize(1)
+	td.ResourceSpans().At(0).InstrumentationLibrarySpans().Resize(1)
+	td.ResourceSpans().At(0).InstrumentationLibrarySpans().At(0).Spans().Resize(1)
+	// fails in zero traceID
+	messages, err := marshaller.Marshal(td)
+	require.Error(t, err)
+	assert.Nil(t, messages)
+}

--- a/exporter/kafkaexporter/kafka_exporter.go
+++ b/exporter/kafkaexporter/kafka_exporter.go
@@ -16,6 +16,7 @@ package kafkaexporter
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/Shopify/sarama"
 	"go.uber.org/zap"
@@ -25,16 +26,23 @@ import (
 	"go.opentelemetry.io/collector/consumer/pdata"
 )
 
+var errUnrecognizedEncoding = fmt.Errorf("unrecognized encoding")
+
 // kafkaProducer uses sarama to produce messages to Kafka.
 type kafkaProducer struct {
 	producer   sarama.SyncProducer
 	topic      string
-	marshaller marshaller
+	marshaller Marshaller
 	logger     *zap.Logger
 }
 
 // newExporter creates Kafka exporter.
 func newExporter(config Config, params component.ExporterCreateParams) (*kafkaProducer, error) {
+	marshaller := GetMarshaller(config.Encoding)
+	if marshaller == nil {
+		return nil, errUnrecognizedEncoding
+	}
+
 	c := sarama.NewConfig()
 	// These setting are required by the sarama.SyncProducer implementation.
 	c.Producer.Return.Successes = true
@@ -60,21 +68,17 @@ func newExporter(config Config, params component.ExporterCreateParams) (*kafkaPr
 	return &kafkaProducer{
 		producer:   producer,
 		topic:      config.Topic,
-		marshaller: &protoMarshaller{},
+		marshaller: marshaller,
 		logger:     params.Logger,
 	}, nil
 }
 
 func (e *kafkaProducer) traceDataPusher(_ context.Context, td pdata.Traces) (int, error) {
-	bts, err := e.marshaller.Marshal(td)
+	messages, err := e.marshaller.Marshal(td)
 	if err != nil {
 		return td.SpanCount(), consumererror.Permanent(err)
 	}
-	m := &sarama.ProducerMessage{
-		Topic: e.topic,
-		Value: sarama.ByteEncoder(bts),
-	}
-	_, _, err = e.producer.SendMessage(m)
+	err = e.producer.SendMessages(producerMessages(messages, e.topic))
 	if err != nil {
 		return td.SpanCount(), err
 	}
@@ -83,4 +87,15 @@ func (e *kafkaProducer) traceDataPusher(_ context.Context, td pdata.Traces) (int
 
 func (e *kafkaProducer) Close(context.Context) error {
 	return e.producer.Close()
+}
+
+func producerMessages(messages []Message, topic string) []*sarama.ProducerMessage {
+	producerMessages := make([]*sarama.ProducerMessage, len(messages))
+	for i := range messages {
+		producerMessages[i] = &sarama.ProducerMessage{
+			Topic: topic,
+			Value: sarama.ByteEncoder(messages[i].Value),
+		}
+	}
+	return producerMessages
 }

--- a/exporter/kafkaexporter/kafka_exporter.go
+++ b/exporter/kafkaexporter/kafka_exporter.go
@@ -37,8 +37,8 @@ type kafkaProducer struct {
 }
 
 // newExporter creates Kafka exporter.
-func newExporter(config Config, params component.ExporterCreateParams) (*kafkaProducer, error) {
-	marshaller := GetMarshaller(config.Encoding)
+func newExporter(config Config, params component.ExporterCreateParams, marshallers map[string]Marshaller) (*kafkaProducer, error) {
+	marshaller := marshallers[config.Encoding]
 	if marshaller == nil {
 		return nil, errUnrecognizedEncoding
 	}

--- a/exporter/kafkaexporter/kafka_exporter_test.go
+++ b/exporter/kafkaexporter/kafka_exporter_test.go
@@ -32,7 +32,7 @@ import (
 
 func TestNewExporter_err_version(t *testing.T) {
 	c := Config{ProtocolVersion: "0.0.0", Encoding: defaultEncoding}
-	exp, err := newExporter(c, component.ExporterCreateParams{}, DefaultMarshallers())
+	exp, err := newExporter(c, component.ExporterCreateParams{}, defaultMarshallers())
 	assert.Error(t, err)
 	assert.Nil(t, exp)
 }
@@ -51,7 +51,7 @@ func TestTraceDataPusher(t *testing.T) {
 
 	p := kafkaProducer{
 		producer:   producer,
-		marshaller: &protoMarshaller{},
+		marshaller: &otlpProtoMarshaller{},
 	}
 	t.Cleanup(func() {
 		require.NoError(t, p.Close(context.Background()))
@@ -69,7 +69,7 @@ func TestTraceDataPusher_err(t *testing.T) {
 
 	p := kafkaProducer{
 		producer:   producer,
-		marshaller: &protoMarshaller{},
+		marshaller: &otlpProtoMarshaller{},
 		logger:     zap.NewNop(),
 	}
 	t.Cleanup(func() {

--- a/exporter/kafkaexporter/kafka_exporter_test.go
+++ b/exporter/kafkaexporter/kafka_exporter_test.go
@@ -30,10 +30,17 @@ import (
 	"go.opentelemetry.io/collector/internal/data/testdata"
 )
 
-func TestNewExporter_wrong_version(t *testing.T) {
-	c := Config{ProtocolVersion: "0.0.0"}
+func TestNewExporter_err_version(t *testing.T) {
+	c := Config{ProtocolVersion: "0.0.0", Encoding: defaultEncoding}
 	exp, err := newExporter(c, component.ExporterCreateParams{})
 	assert.Error(t, err)
+	assert.Nil(t, exp)
+}
+
+func TestNewExporter_err_encoding(t *testing.T) {
+	c := Config{Encoding: "foo"}
+	exp, err := newExporter(c, component.ExporterCreateParams{})
+	assert.EqualError(t, err, errUnrecognizedEncoding.Error())
 	assert.Nil(t, exp)
 }
 
@@ -91,8 +98,12 @@ type errorMarshaller struct {
 	err error
 }
 
-var _ marshaller = (*errorMarshaller)(nil)
+var _ Marshaller = (*errorMarshaller)(nil)
 
-func (e errorMarshaller) Marshal(pdata.Traces) ([]byte, error) {
+func (e errorMarshaller) Marshal(traces pdata.Traces) ([]Message, error) {
 	return nil, e.err
+}
+
+func (e errorMarshaller) Encoding() string {
+	panic("implement me")
 }

--- a/exporter/kafkaexporter/kafka_exporter_test.go
+++ b/exporter/kafkaexporter/kafka_exporter_test.go
@@ -32,14 +32,14 @@ import (
 
 func TestNewExporter_err_version(t *testing.T) {
 	c := Config{ProtocolVersion: "0.0.0", Encoding: defaultEncoding}
-	exp, err := newExporter(c, component.ExporterCreateParams{})
+	exp, err := newExporter(c, component.ExporterCreateParams{}, DefaultMarshallers())
 	assert.Error(t, err)
 	assert.Nil(t, exp)
 }
 
 func TestNewExporter_err_encoding(t *testing.T) {
 	c := Config{Encoding: "foo"}
-	exp, err := newExporter(c, component.ExporterCreateParams{})
+	exp, err := newExporter(c, component.ExporterCreateParams{}, map[string]Marshaller{})
 	assert.EqualError(t, err, errUnrecognizedEncoding.Error())
 	assert.Nil(t, exp)
 }

--- a/exporter/kafkaexporter/marshaller.go
+++ b/exporter/kafkaexporter/marshaller.go
@@ -32,9 +32,9 @@ type Message struct {
 	Value []byte
 }
 
-// DefaultMarshallers returns map of supported encodings with Marshaller.
-func DefaultMarshallers() map[string]Marshaller {
-	otlp := &protoMarshaller{}
+// defaultMarshallers returns map of supported encodings with Marshaller.
+func defaultMarshallers() map[string]Marshaller {
+	otlp := &otlpProtoMarshaller{}
 	jaegerProto := jaegerMarshaller{marshaller: jaegerProtoSpanMarshaller{}}
 	jaegerJSON := jaegerMarshaller{marshaller: newJaegerJSONMarshaller()}
 	return map[string]Marshaller{

--- a/exporter/kafkaexporter/marshaller_test.go
+++ b/exporter/kafkaexporter/marshaller_test.go
@@ -27,7 +27,7 @@ func TestDefaultMarshallers(t *testing.T) {
 		"jaeger_proto",
 		"jaeger_json",
 	}
-	marshallers := DefaultMarshallers()
+	marshallers := defaultMarshallers()
 	assert.Equal(t, len(expectedEncodings), len(marshallers))
 	for _, e := range expectedEncodings {
 		t.Run(e, func(t *testing.T) {

--- a/exporter/kafkaexporter/marshaller_test.go
+++ b/exporter/kafkaexporter/marshaller_test.go
@@ -18,28 +18,22 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
-	"go.opentelemetry.io/collector/consumer/pdata"
+	"github.com/stretchr/testify/require"
 )
 
-const testEncoding = "test"
-
-func TestRegisterMarshaller(t *testing.T) {
-	sender := &testMarshaller{}
-	RegisterMarshaller(sender)
-	unmarshaller := GetMarshaller(testEncoding)
-	assert.Equal(t, sender, unmarshaller)
-}
-
-type testMarshaller struct {
-}
-
-var _ Marshaller = (*testMarshaller)(nil)
-
-func (t testMarshaller) Marshal(pdata.Traces) ([]Message, error) {
-	panic("implement me")
-}
-
-func (t testMarshaller) Encoding() string {
-	return testEncoding
+func TestDefaultMarshallers(t *testing.T) {
+	expectedEncodings := []string{
+		"otlp_proto",
+		"jaeger_proto",
+		"jaeger_json",
+	}
+	marshallers := DefaultMarshallers()
+	assert.Equal(t, len(expectedEncodings), len(marshallers))
+	for _, e := range expectedEncodings {
+		t.Run(e, func(t *testing.T) {
+			m, ok := marshallers[e]
+			require.True(t, ok)
+			assert.NotNil(t, m)
+		})
+	}
 }

--- a/exporter/kafkaexporter/marshaller_test.go
+++ b/exporter/kafkaexporter/marshaller_test.go
@@ -18,32 +18,28 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/collector/consumer/pdata"
-	otlptrace "go.opentelemetry.io/collector/internal/data/opentelemetry-proto-gen/collector/trace/v1"
 )
 
-func TestMarshall(t *testing.T) {
-	td := pdata.NewTraces()
-	td.ResourceSpans().Resize(1)
-	td.ResourceSpans().At(0).Resource().InitEmpty()
-	td.ResourceSpans().At(0).Resource().Attributes().InsertString("foo", "bar")
-	m := protoMarshaller{}
-	bts, err := m.Marshal(td)
-	require.NoError(t, err)
+const testEncoding = "test"
 
-	request := &otlptrace.ExportTraceServiceRequest{
-		ResourceSpans: pdata.TracesToOtlp(td),
-	}
-	expected, err := request.Marshal()
-	require.NoError(t, err)
-	assert.Equal(t, expected, bts)
+func TestRegisterMarshaller(t *testing.T) {
+	sender := &testMarshaller{}
+	RegisterMarshaller(sender)
+	unmarshaller := GetMarshaller(testEncoding)
+	assert.Equal(t, sender, unmarshaller)
 }
 
-func TestMarshall_empty(t *testing.T) {
-	m := protoMarshaller{}
-	bts, err := m.Marshal(pdata.NewTraces())
-	require.NoError(t, err)
-	assert.NotNil(t, bts)
+type testMarshaller struct {
+}
+
+var _ Marshaller = (*testMarshaller)(nil)
+
+func (t testMarshaller) Marshal(pdata.Traces) ([]Message, error) {
+	panic("implement me")
+}
+
+func (t testMarshaller) Encoding() string {
+	return testEncoding
 }

--- a/exporter/kafkaexporter/otlp_marshaller.go
+++ b/exporter/kafkaexporter/otlp_marshaller.go
@@ -19,16 +19,16 @@ import (
 	otlptrace "go.opentelemetry.io/collector/internal/data/opentelemetry-proto-gen/collector/trace/v1"
 )
 
-type protoMarshaller struct {
+type otlpProtoMarshaller struct {
 }
 
-var _ Marshaller = (*protoMarshaller)(nil)
+var _ Marshaller = (*otlpProtoMarshaller)(nil)
 
-func (m *protoMarshaller) Encoding() string {
+func (m *otlpProtoMarshaller) Encoding() string {
 	return defaultEncoding
 }
 
-func (m *protoMarshaller) Marshal(traces pdata.Traces) ([]Message, error) {
+func (m *otlpProtoMarshaller) Marshal(traces pdata.Traces) ([]Message, error) {
 	request := otlptrace.ExportTraceServiceRequest{
 		ResourceSpans: pdata.TracesToOtlp(traces),
 	}

--- a/exporter/kafkaexporter/otlp_marshaller.go
+++ b/exporter/kafkaexporter/otlp_marshaller.go
@@ -19,11 +19,6 @@ import (
 	otlptrace "go.opentelemetry.io/collector/internal/data/opentelemetry-proto-gen/collector/trace/v1"
 )
 
-func init() {
-	protoMarshaller := &protoMarshaller{}
-	RegisterMarshaller(protoMarshaller)
-}
-
 type protoMarshaller struct {
 }
 

--- a/exporter/kafkaexporter/otlp_marshaller.go
+++ b/exporter/kafkaexporter/otlp_marshaller.go
@@ -1,0 +1,45 @@
+// Copyright 2020 The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kafkaexporter
+
+import (
+	"go.opentelemetry.io/collector/consumer/pdata"
+	otlptrace "go.opentelemetry.io/collector/internal/data/opentelemetry-proto-gen/collector/trace/v1"
+)
+
+func init() {
+	protoMarshaller := &protoMarshaller{}
+	RegisterMarshaller(protoMarshaller)
+}
+
+type protoMarshaller struct {
+}
+
+var _ Marshaller = (*protoMarshaller)(nil)
+
+func (m *protoMarshaller) Encoding() string {
+	return defaultEncoding
+}
+
+func (m *protoMarshaller) Marshal(traces pdata.Traces) ([]Message, error) {
+	request := otlptrace.ExportTraceServiceRequest{
+		ResourceSpans: pdata.TracesToOtlp(traces),
+	}
+	bts, err := request.Marshal()
+	if err != nil {
+		return nil, err
+	}
+	return []Message{{Value: bts}}, nil
+}

--- a/exporter/kafkaexporter/otlp_marshaller_test.go
+++ b/exporter/kafkaexporter/otlp_marshaller_test.go
@@ -1,0 +1,44 @@
+// Copyright 2020 The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kafkaexporter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/collector/consumer/pdata"
+	otlptrace "go.opentelemetry.io/collector/internal/data/opentelemetry-proto-gen/collector/trace/v1"
+)
+
+func TestOTLPMarshaller(t *testing.T) {
+	td := pdata.NewTraces()
+	td.ResourceSpans().Resize(1)
+	td.ResourceSpans().At(0).Resource().InitEmpty()
+	td.ResourceSpans().At(0).Resource().Attributes().InsertString("foo", "bar")
+	request := &otlptrace.ExportTraceServiceRequest{
+		ResourceSpans: pdata.TracesToOtlp(td),
+	}
+	expected, err := request.Marshal()
+	require.NoError(t, err)
+	require.NotNil(t, expected)
+
+	m := protoMarshaller{}
+	assert.Equal(t, "otlp_proto", m.Encoding())
+	messages, err := m.Marshal(td)
+	require.NoError(t, err)
+	assert.Equal(t, []Message{{Value: expected}}, messages)
+}

--- a/exporter/kafkaexporter/otlp_marshaller_test.go
+++ b/exporter/kafkaexporter/otlp_marshaller_test.go
@@ -36,7 +36,7 @@ func TestOTLPMarshaller(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, expected)
 
-	m := protoMarshaller{}
+	m := otlpProtoMarshaller{}
 	assert.Equal(t, "otlp_proto", m.Encoding())
 	messages, err := m.Marshal(td)
 	require.NoError(t, err)

--- a/go.sum
+++ b/go.sum
@@ -519,7 +519,6 @@ github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgf
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/grpc-ecosystem/grpc-gateway v1.13.0/go.mod h1:8XEsbTttt/W+VvjtQhLACqCisSPWTxCZ7sBRjU6iH9c=
-github.com/grpc-ecosystem/grpc-gateway v1.14.6 h1:8ERzHx8aj1Sc47mu9n/AksaKCSWrMchFtkdrS4BIj5o=
 github.com/grpc-ecosystem/grpc-gateway v1.14.6/go.mod h1:zdiPV4Yse/1gnckTHtghG4GkDEdKCRJduHpTxT3/jcw=
 github.com/grpc-ecosystem/grpc-gateway v1.14.7 h1:Nk5kuHrnWUTf/0GL1a/vchH/om9Ap2/HnVna+jYZgTY=
 github.com/grpc-ecosystem/grpc-gateway v1.14.7/go.mod h1:oYZKL012gGh6LMyg/xA7Q2yq6j8bu0wa+9w14EEthWU=

--- a/receiver/kafkareceiver/README.md
+++ b/receiver/kafkareceiver/README.md
@@ -1,8 +1,6 @@
 # Kafka Receiver
 
-Kafka receiver receives traces from Kafka.
-
-Message payloads are deserialized into OTLP `ExportTraceServiceRequest`.
+Kafka receiver receives traces from Kafka. Message payload encoding is configurable.
 
 The following settings are required:
 - `protocol_version` (no default): Kafka protocol version e.g. 2.0.0
@@ -10,6 +8,12 @@ The following settings are required:
 The following settings can be optionally configured:
 - `brokers` (default = localhost:9092): The list of kafka brokers
 - `topic` (default = otlp_spans): The name of the kafka topic to export to
+- `encoding` (default = otlp_proto): The encoding of the payload sent to kafka. Available encodings:
+  - `otlp_proto`: the payload is deserialized to `ExportTraceServiceRequest`.
+  - `jaeger_proto`: the payload is deserialized to a single Jaeger proto `Span`.
+  - `jaeger_json`: the payload is deserialized to a single Jaeger JSON Span using `jsonpb`.
+  - `zipkin_thrift`: the payload is deserialized into Zipkin Thrift spans.
+  - `zipkin_json`: the payload is deserialized into Zipkin V2 JSON spans.
 - `group_id` (default = otel-collector):  The consumer group that receiver will be consuming messages from
 - `client_id` (default = otel-collector): The consumer client ID that receiver will use
 - `metadata`

--- a/receiver/kafkareceiver/config.go
+++ b/receiver/kafkareceiver/config.go
@@ -28,6 +28,8 @@ type Config struct {
 	ProtocolVersion string `mapstructure:"protocol_version"`
 	// The name of the kafka topic to consume from (default "otlp_spans")
 	Topic string `mapstructure:"topic"`
+	// Encoding of the messages (default "otlp_proto")
+	Encoding string `mapstructure:"encoding"`
 	// The consumer group that receiver will be consuming messages from (default "otel-collector")
 	GroupID string `mapstructure:"group_id"`
 	// The consumer client ID that receiver will use (default "otel-collector")

--- a/receiver/kafkareceiver/config_test.go
+++ b/receiver/kafkareceiver/config_test.go
@@ -45,6 +45,7 @@ func TestLoadConfig(t *testing.T) {
 			TypeVal: typeStr,
 		},
 		Topic:    "spans",
+		Encoding: "otlp_proto",
 		Brokers:  []string{"foo:123", "bar:456"},
 		ClientID: "otel-collector",
 		GroupID:  "otel-collector",

--- a/receiver/kafkareceiver/config_test.go
+++ b/receiver/kafkareceiver/config_test.go
@@ -32,7 +32,7 @@ func TestLoadConfig(t *testing.T) {
 	factories, err := componenttest.ExampleComponents()
 	assert.NoError(t, err)
 
-	factory := NewFactory(DefaultUnmarshallers())
+	factory := NewFactory()
 	factories.Receivers[typeStr] = factory
 	cfg, err := configtest.LoadConfigFile(t, path.Join(".", "testdata", "config.yaml"), factories)
 	require.NoError(t, err)

--- a/receiver/kafkareceiver/config_test.go
+++ b/receiver/kafkareceiver/config_test.go
@@ -32,7 +32,7 @@ func TestLoadConfig(t *testing.T) {
 	factories, err := componenttest.ExampleComponents()
 	assert.NoError(t, err)
 
-	factory := NewFactory()
+	factory := NewFactory(DefaultUnmarshallers())
 	factories.Receivers[typeStr] = factory
 	cfg, err := configtest.LoadConfigFile(t, path.Join(".", "testdata", "config.yaml"), factories)
 	require.NoError(t, err)

--- a/receiver/kafkareceiver/factory.go
+++ b/receiver/kafkareceiver/factory.go
@@ -28,6 +28,7 @@ import (
 const (
 	typeStr         = "kafka"
 	defaultTopic    = "otlp_spans"
+	defaultEncoding = "otlp_proto"
 	defaultBroker   = "localhost:9092"
 	defaultClientID = "otel-collector"
 	defaultGroupID  = defaultClientID
@@ -55,6 +56,7 @@ func createDefaultConfig() configmodels.Receiver {
 			NameVal: typeStr,
 		},
 		Topic:    defaultTopic,
+		Encoding: defaultEncoding,
 		Brokers:  []string{defaultBroker},
 		ClientID: defaultClientID,
 		GroupID:  defaultGroupID,

--- a/receiver/kafkareceiver/factory_test.go
+++ b/receiver/kafkareceiver/factory_test.go
@@ -39,7 +39,9 @@ func TestCreateTraceReceiver(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)
 	cfg.Brokers = []string{"invalid:9092"}
 	cfg.ProtocolVersion = "2.0.0"
-	r, err := createTraceReceiver(context.Background(), component.ReceiverCreateParams{}, cfg, nil)
+	f := kafkaReceiverFactory{unmarshalers: DefaultUnmarshallers()}
+	r, err := f.createTraceReceiver(context.Background(), component.ReceiverCreateParams{}, cfg, nil)
+	// no available broker
 	require.Error(t, err)
 	assert.Nil(t, r)
 }
@@ -49,7 +51,8 @@ func TestCreateTraceReceiver_error(t *testing.T) {
 	cfg.ProtocolVersion = "2.0.0"
 	// disable contacting broker at startup
 	cfg.Metadata.Full = false
-	r, err := createTraceReceiver(context.Background(), component.ReceiverCreateParams{}, cfg, nil)
+	f := kafkaReceiverFactory{unmarshalers: DefaultUnmarshallers()}
+	r, err := f.createTraceReceiver(context.Background(), component.ReceiverCreateParams{}, cfg, nil)
 	require.NoError(t, err)
 	assert.NotNil(t, r)
 }

--- a/receiver/kafkareceiver/factory_test.go
+++ b/receiver/kafkareceiver/factory_test.go
@@ -23,6 +23,7 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configcheck"
+	"go.opentelemetry.io/collector/consumer/pdata"
 )
 
 func TestCreateDefaultConfig(t *testing.T) {
@@ -39,7 +40,7 @@ func TestCreateTraceReceiver(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)
 	cfg.Brokers = []string{"invalid:9092"}
 	cfg.ProtocolVersion = "2.0.0"
-	f := kafkaReceiverFactory{unmarshalers: DefaultUnmarshallers()}
+	f := kafkaReceiverFactory{unmarshalers: defaultUnmarshallers()}
 	r, err := f.createTraceReceiver(context.Background(), component.ReceiverCreateParams{}, cfg, nil)
 	// no available broker
 	require.Error(t, err)
@@ -51,8 +52,43 @@ func TestCreateTraceReceiver_error(t *testing.T) {
 	cfg.ProtocolVersion = "2.0.0"
 	// disable contacting broker at startup
 	cfg.Metadata.Full = false
-	f := kafkaReceiverFactory{unmarshalers: DefaultUnmarshallers()}
+	f := kafkaReceiverFactory{unmarshalers: defaultUnmarshallers()}
 	r, err := f.createTraceReceiver(context.Background(), component.ReceiverCreateParams{}, cfg, nil)
 	require.NoError(t, err)
 	assert.NotNil(t, r)
+}
+
+func TestWithUnmarshallers(t *testing.T) {
+	cum := &customUnamarshaller{}
+	f := NewFactory(WithAddUnmarshallers(map[string]Unmarshaller{cum.Encoding(): cum}))
+	cfg := createDefaultConfig().(*Config)
+	// disable contacting broker
+	cfg.Metadata.Full = false
+	cfg.ProtocolVersion = "2.0.0"
+
+	t.Run("custom_encoding", func(t *testing.T) {
+		cfg.Encoding = cum.Encoding()
+		exporter, err := f.CreateTraceReceiver(context.Background(), component.ReceiverCreateParams{}, cfg, nil)
+		require.NoError(t, err)
+		require.NotNil(t, exporter)
+	})
+	t.Run("default_encoding", func(t *testing.T) {
+		cfg.Encoding = new(otlpProtoUnmarshaller).Encoding()
+		exporter, err := f.CreateTraceReceiver(context.Background(), component.ReceiverCreateParams{}, cfg, nil)
+		require.NoError(t, err)
+		assert.NotNil(t, exporter)
+	})
+}
+
+type customUnamarshaller struct {
+}
+
+var _ Unmarshaller = (*customUnamarshaller)(nil)
+
+func (c customUnamarshaller) Unmarshal(bytes []byte) (pdata.Traces, error) {
+	panic("implement me")
+}
+
+func (c customUnamarshaller) Encoding() string {
+	return "custom"
 }

--- a/receiver/kafkareceiver/jaeger_unmarshaller.go
+++ b/receiver/kafkareceiver/jaeger_unmarshaller.go
@@ -1,0 +1,76 @@
+// Copyright 2020 The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kafkareceiver
+
+import (
+	"bytes"
+
+	"github.com/gogo/protobuf/jsonpb"
+	jaegerproto "github.com/jaegertracing/jaeger/model"
+
+	"go.opentelemetry.io/collector/consumer/pdata"
+	jaegertranslator "go.opentelemetry.io/collector/translator/trace/jaeger"
+)
+
+func init() {
+	jaegerJSON := &jaegerJSONSpanUnmarshaller{}
+	RegisterUnmarshaller(jaegerJSON)
+	jaegerProto := &jaegerProtoSpanUnmarshaller{}
+	RegisterUnmarshaller(jaegerProto)
+}
+
+type jaegerProtoSpanUnmarshaller struct {
+}
+
+var _ Unmarshaller = (*jaegerProtoSpanUnmarshaller)(nil)
+
+func (j jaegerProtoSpanUnmarshaller) Unmarshal(bytes []byte) (pdata.Traces, error) {
+	span := &jaegerproto.Span{}
+	err := span.Unmarshal(bytes)
+	if err != nil {
+		return pdata.NewTraces(), err
+	}
+	return jaegerSpanToTraces(span), nil
+}
+
+func (j jaegerProtoSpanUnmarshaller) Encoding() string {
+	return "jaeger_proto"
+}
+
+type jaegerJSONSpanUnmarshaller struct {
+}
+
+var _ Unmarshaller = (*jaegerJSONSpanUnmarshaller)(nil)
+
+func (j jaegerJSONSpanUnmarshaller) Unmarshal(data []byte) (pdata.Traces, error) {
+	span := &jaegerproto.Span{}
+	err := jsonpb.Unmarshal(bytes.NewReader(data), span)
+	if err != nil {
+		return pdata.NewTraces(), err
+	}
+	return jaegerSpanToTraces(span), nil
+}
+
+func (j jaegerJSONSpanUnmarshaller) Encoding() string {
+	return "jaeger_json"
+}
+
+func jaegerSpanToTraces(span *jaegerproto.Span) pdata.Traces {
+	batch := jaegerproto.Batch{
+		Spans:   []*jaegerproto.Span{span},
+		Process: span.Process,
+	}
+	return jaegertranslator.ProtoBatchToInternalTraces(batch)
+}

--- a/receiver/kafkareceiver/jaeger_unmarshaller.go
+++ b/receiver/kafkareceiver/jaeger_unmarshaller.go
@@ -24,13 +24,6 @@ import (
 	jaegertranslator "go.opentelemetry.io/collector/translator/trace/jaeger"
 )
 
-func init() {
-	jaegerJSON := &jaegerJSONSpanUnmarshaller{}
-	RegisterUnmarshaller(jaegerJSON)
-	jaegerProto := &jaegerProtoSpanUnmarshaller{}
-	RegisterUnmarshaller(jaegerProto)
-}
-
 type jaegerProtoSpanUnmarshaller struct {
 }
 

--- a/receiver/kafkareceiver/jaeger_unmarshaller_test.go
+++ b/receiver/kafkareceiver/jaeger_unmarshaller_test.go
@@ -1,0 +1,87 @@
+// Copyright 2020 The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kafkareceiver
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/gogo/protobuf/jsonpb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/collector/consumer/pdata"
+	jaegertranslator "go.opentelemetry.io/collector/translator/trace/jaeger"
+)
+
+func TestUnmarshallJaeger(t *testing.T) {
+	td := pdata.NewTraces()
+	td.ResourceSpans().Resize(1)
+	td.ResourceSpans().At(0).InstrumentationLibrarySpans().Resize(1)
+	td.ResourceSpans().At(0).InstrumentationLibrarySpans().At(0).Spans().Resize(1)
+	td.ResourceSpans().At(0).InstrumentationLibrarySpans().At(0).Spans().At(0).SetName("foo")
+	td.ResourceSpans().At(0).InstrumentationLibrarySpans().At(0).Spans().At(0).SetStartTime(pdata.TimestampUnixNano(10))
+	td.ResourceSpans().At(0).InstrumentationLibrarySpans().At(0).Spans().At(0).SetEndTime(pdata.TimestampUnixNano(20))
+	td.ResourceSpans().At(0).InstrumentationLibrarySpans().At(0).Spans().At(0).SetTraceID(pdata.NewTraceID([]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}))
+	td.ResourceSpans().At(0).InstrumentationLibrarySpans().At(0).Spans().At(0).SetSpanID(pdata.NewSpanID([]byte{1, 2, 3, 4, 5, 6, 7, 8}))
+	batches, err := jaegertranslator.InternalTracesToJaegerProto(td)
+	require.NoError(t, err)
+
+	protoBytes, err := batches[0].Spans[0].Marshal()
+	require.NoError(t, err)
+
+	jsonMarshaller := &jsonpb.Marshaler{}
+	jsonBytes := new(bytes.Buffer)
+	jsonMarshaller.Marshal(jsonBytes, batches[0].Spans[0])
+
+	tests := []struct {
+		unmarshaller Unmarshaller
+		encoding     string
+		bytes        []byte
+	}{
+		{
+			unmarshaller: jaegerProtoSpanUnmarshaller{},
+			encoding:     "jaeger_proto",
+			bytes:        protoBytes,
+		},
+		{
+			unmarshaller: jaegerJSONSpanUnmarshaller{},
+			encoding:     "jaeger_json",
+			bytes:        jsonBytes.Bytes(),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.encoding, func(t *testing.T) {
+			got, err := test.unmarshaller.Unmarshal(test.bytes)
+			require.NoError(t, err)
+			assert.Equal(t, td, got)
+			assert.Equal(t, test.encoding, test.unmarshaller.Encoding())
+		})
+	}
+}
+
+func TestUnmarshallJaegerProto_error(t *testing.T) {
+	p := jaegerProtoSpanUnmarshaller{}
+	got, err := p.Unmarshal([]byte("+$%"))
+	assert.Equal(t, pdata.NewTraces(), got)
+	assert.Error(t, err)
+}
+
+func TestUnmarshallJaegerJSON_error(t *testing.T) {
+	p := jaegerJSONSpanUnmarshaller{}
+	got, err := p.Unmarshal([]byte("+$%"))
+	assert.Equal(t, pdata.NewTraces(), got)
+	assert.Error(t, err)
+}

--- a/receiver/kafkareceiver/kafka_receiver.go
+++ b/receiver/kafkareceiver/kafka_receiver.go
@@ -48,8 +48,8 @@ type kafkaConsumer struct {
 
 var _ component.Receiver = (*kafkaConsumer)(nil)
 
-func newReceiver(config Config, params component.ReceiverCreateParams, nextConsumer consumer.TraceConsumer) (*kafkaConsumer, error) {
-	unmarshaller := GetUnmarshaller(config.Encoding)
+func newReceiver(config Config, params component.ReceiverCreateParams, unmarshalers map[string]Unmarshaller, nextConsumer consumer.TraceConsumer) (*kafkaConsumer, error) {
+	unmarshaller := unmarshalers[config.Encoding]
 	if unmarshaller == nil {
 		return nil, errUnrecognizedEncoding
 	}

--- a/receiver/kafkareceiver/kafka_receiver.go
+++ b/receiver/kafkareceiver/kafka_receiver.go
@@ -16,6 +16,7 @@ package kafkareceiver
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/Shopify/sarama"
 	"go.opencensus.io/stats"
@@ -31,6 +32,8 @@ const (
 	transport = "kafka"
 )
 
+var errUnrecognizedEncoding = fmt.Errorf("unrecognized encoding")
+
 // kafkaConsumer uses sarama to consume and handle messages from kafka.
 type kafkaConsumer struct {
 	name              string
@@ -38,7 +41,7 @@ type kafkaConsumer struct {
 	nextConsumer      consumer.TraceConsumer
 	topics            []string
 	cancelConsumeLoop context.CancelFunc
-	unmarshaller      unmarshaller
+	unmarshaller      Unmarshaller
 
 	logger *zap.Logger
 }
@@ -46,6 +49,11 @@ type kafkaConsumer struct {
 var _ component.Receiver = (*kafkaConsumer)(nil)
 
 func newReceiver(config Config, params component.ReceiverCreateParams, nextConsumer consumer.TraceConsumer) (*kafkaConsumer, error) {
+	unmarshaller := GetUnmarshaller(config.Encoding)
+	if unmarshaller == nil {
+		return nil, errUnrecognizedEncoding
+	}
+
 	c := sarama.NewConfig()
 	c.ClientID = config.ClientID
 	c.Metadata.Full = config.Metadata.Full
@@ -67,7 +75,7 @@ func newReceiver(config Config, params component.ReceiverCreateParams, nextConsu
 		consumerGroup: client,
 		topics:        []string{config.Topic},
 		nextConsumer:  nextConsumer,
-		unmarshaller:  &protoUnmarshaller{},
+		unmarshaller:  unmarshaller,
 		logger:        params.Logger,
 	}, nil
 }
@@ -110,7 +118,7 @@ func (c *kafkaConsumer) Shutdown(context.Context) error {
 
 type consumerGroupHandler struct {
 	name         string
-	unmarshaller unmarshaller
+	unmarshaller Unmarshaller
 	nextConsumer consumer.TraceConsumer
 	ready        chan bool
 
@@ -156,7 +164,7 @@ func (c *consumerGroupHandler) ConsumeClaim(session sarama.ConsumerGroupSession,
 		}
 
 		err = c.nextConsumer.ConsumeTraces(session.Context(), traces)
-		obsreport.EndTraceDataReceiveOp(ctx, c.unmarshaller.Format(), traces.SpanCount(), err)
+		obsreport.EndTraceDataReceiveOp(ctx, c.unmarshaller.Encoding(), traces.SpanCount(), err)
 		if err != nil {
 			return err
 		}

--- a/receiver/kafkareceiver/kafka_receiver_test.go
+++ b/receiver/kafkareceiver/kafka_receiver_test.go
@@ -40,7 +40,7 @@ func TestNewReceiver_version_err(t *testing.T) {
 		Encoding:        defaultEncoding,
 		ProtocolVersion: "none",
 	}
-	r, err := newReceiver(c, component.ReceiverCreateParams{}, DefaultUnmarshallers(), exportertest.NewNopTraceExporter())
+	r, err := newReceiver(c, component.ReceiverCreateParams{}, defaultUnmarshallers(), exportertest.NewNopTraceExporter())
 	assert.Error(t, err)
 	assert.Nil(t, r)
 }
@@ -49,7 +49,7 @@ func TestNewReceiver_encoding_err(t *testing.T) {
 	c := Config{
 		Encoding: "foo",
 	}
-	r, err := newReceiver(c, component.ReceiverCreateParams{}, DefaultUnmarshallers(), exportertest.NewNopTraceExporter())
+	r, err := newReceiver(c, component.ReceiverCreateParams{}, defaultUnmarshallers(), exportertest.NewNopTraceExporter())
 	require.Error(t, err)
 	assert.Nil(t, r)
 	assert.EqualError(t, err, errUnrecognizedEncoding.Error())
@@ -111,7 +111,7 @@ func TestConsumerGroupHandler(t *testing.T) {
 	defer view.Unregister(views...)
 
 	c := consumerGroupHandler{
-		unmarshaller: &protoUnmarshaller{},
+		unmarshaller: &otlpProtoUnmarshaller{},
 		logger:       zap.NewNop(),
 		ready:        make(chan bool),
 		nextConsumer: exportertest.NewNopTraceExporter(),
@@ -155,7 +155,7 @@ func TestConsumerGroupHandler(t *testing.T) {
 
 func TestConsumerGroupHandler_error_unmarshall(t *testing.T) {
 	c := consumerGroupHandler{
-		unmarshaller: &protoUnmarshaller{},
+		unmarshaller: &otlpProtoUnmarshaller{},
 		logger:       zap.NewNop(),
 		ready:        make(chan bool),
 		nextConsumer: exportertest.NewNopTraceExporter(),
@@ -181,7 +181,7 @@ func TestConsumerGroupHandler_error_nextConsumer(t *testing.T) {
 	consumerError := fmt.Errorf("failed to consumer")
 	nextConsumer.SetConsumeTraceError(consumerError)
 	c := consumerGroupHandler{
-		unmarshaller: &protoUnmarshaller{},
+		unmarshaller: &otlpProtoUnmarshaller{},
 		logger:       zap.NewNop(),
 		ready:        make(chan bool),
 		nextConsumer: nextConsumer,

--- a/receiver/kafkareceiver/kafka_receiver_test.go
+++ b/receiver/kafkareceiver/kafka_receiver_test.go
@@ -37,11 +37,22 @@ import (
 
 func TestNewReceiver_version_err(t *testing.T) {
 	c := Config{
+		Encoding:        defaultEncoding,
 		ProtocolVersion: "none",
 	}
 	r, err := newReceiver(c, component.ReceiverCreateParams{}, exportertest.NewNopTraceExporter())
 	assert.Error(t, err)
 	assert.Nil(t, r)
+}
+
+func TestNewReceiver_encoding_err(t *testing.T) {
+	c := Config{
+		Encoding: "foo",
+	}
+	r, err := newReceiver(c, component.ReceiverCreateParams{}, exportertest.NewNopTraceExporter())
+	require.Error(t, err)
+	assert.Nil(t, r)
+	assert.EqualError(t, err, errUnrecognizedEncoding.Error())
 }
 
 func TestReceiverStart(t *testing.T) {

--- a/receiver/kafkareceiver/kafka_receiver_test.go
+++ b/receiver/kafkareceiver/kafka_receiver_test.go
@@ -40,7 +40,7 @@ func TestNewReceiver_version_err(t *testing.T) {
 		Encoding:        defaultEncoding,
 		ProtocolVersion: "none",
 	}
-	r, err := newReceiver(c, component.ReceiverCreateParams{}, exportertest.NewNopTraceExporter())
+	r, err := newReceiver(c, component.ReceiverCreateParams{}, DefaultUnmarshallers(), exportertest.NewNopTraceExporter())
 	assert.Error(t, err)
 	assert.Nil(t, r)
 }
@@ -49,7 +49,7 @@ func TestNewReceiver_encoding_err(t *testing.T) {
 	c := Config{
 		Encoding: "foo",
 	}
-	r, err := newReceiver(c, component.ReceiverCreateParams{}, exportertest.NewNopTraceExporter())
+	r, err := newReceiver(c, component.ReceiverCreateParams{}, DefaultUnmarshallers(), exportertest.NewNopTraceExporter())
 	require.Error(t, err)
 	assert.Nil(t, r)
 	assert.EqualError(t, err, errUnrecognizedEncoding.Error())

--- a/receiver/kafkareceiver/otlp_unmarshaller.go
+++ b/receiver/kafkareceiver/otlp_unmarshaller.go
@@ -19,11 +19,6 @@ import (
 	otlptrace "go.opentelemetry.io/collector/internal/data/opentelemetry-proto-gen/collector/trace/v1"
 )
 
-func init() {
-	otlpProto := &protoUnmarshaller{}
-	RegisterUnmarshaller(otlpProto)
-}
-
 type protoUnmarshaller struct {
 }
 

--- a/receiver/kafkareceiver/otlp_unmarshaller.go
+++ b/receiver/kafkareceiver/otlp_unmarshaller.go
@@ -19,12 +19,12 @@ import (
 	otlptrace "go.opentelemetry.io/collector/internal/data/opentelemetry-proto-gen/collector/trace/v1"
 )
 
-type protoUnmarshaller struct {
+type otlpProtoUnmarshaller struct {
 }
 
-var _ Unmarshaller = (*protoUnmarshaller)(nil)
+var _ Unmarshaller = (*otlpProtoUnmarshaller)(nil)
 
-func (p *protoUnmarshaller) Unmarshal(bytes []byte) (pdata.Traces, error) {
+func (p *otlpProtoUnmarshaller) Unmarshal(bytes []byte) (pdata.Traces, error) {
 	request := &otlptrace.ExportTraceServiceRequest{}
 	err := request.Unmarshal(bytes)
 	if err != nil {
@@ -33,6 +33,6 @@ func (p *protoUnmarshaller) Unmarshal(bytes []byte) (pdata.Traces, error) {
 	return pdata.TracesFromOtlp(request.GetResourceSpans()), nil
 }
 
-func (*protoUnmarshaller) Encoding() string {
+func (*otlpProtoUnmarshaller) Encoding() string {
 	return defaultEncoding
 }

--- a/receiver/kafkareceiver/otlp_unmarshaller.go
+++ b/receiver/kafkareceiver/otlp_unmarshaller.go
@@ -1,0 +1,43 @@
+// Copyright 2020 The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kafkareceiver
+
+import (
+	"go.opentelemetry.io/collector/consumer/pdata"
+	otlptrace "go.opentelemetry.io/collector/internal/data/opentelemetry-proto-gen/collector/trace/v1"
+)
+
+func init() {
+	otlpProto := &protoUnmarshaller{}
+	RegisterUnmarshaller(otlpProto)
+}
+
+type protoUnmarshaller struct {
+}
+
+var _ Unmarshaller = (*protoUnmarshaller)(nil)
+
+func (p *protoUnmarshaller) Unmarshal(bytes []byte) (pdata.Traces, error) {
+	request := &otlptrace.ExportTraceServiceRequest{}
+	err := request.Unmarshal(bytes)
+	if err != nil {
+		return pdata.NewTraces(), err
+	}
+	return pdata.TracesFromOtlp(request.GetResourceSpans()), nil
+}
+
+func (*protoUnmarshaller) Encoding() string {
+	return defaultEncoding
+}

--- a/receiver/kafkareceiver/otlp_unmarshaller_test.go
+++ b/receiver/kafkareceiver/otlp_unmarshaller_test.go
@@ -1,0 +1,50 @@
+// Copyright 2020 The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kafkareceiver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/collector/consumer/pdata"
+	otlptrace "go.opentelemetry.io/collector/internal/data/opentelemetry-proto-gen/collector/trace/v1"
+)
+
+func TestUnmarshallOTLP(t *testing.T) {
+	td := pdata.NewTraces()
+	td.ResourceSpans().Resize(1)
+	td.ResourceSpans().At(0).Resource().InitEmpty()
+	td.ResourceSpans().At(0).Resource().Attributes().InsertString("foo", "bar")
+	request := &otlptrace.ExportTraceServiceRequest{
+		ResourceSpans: pdata.TracesToOtlp(td),
+	}
+	expected, err := request.Marshal()
+	require.NoError(t, err)
+
+	p := protoUnmarshaller{}
+	got, err := p.Unmarshal(expected)
+	require.NoError(t, err)
+	assert.Equal(t, td, got)
+	assert.Equal(t, "otlp_proto", p.Encoding())
+}
+
+func TestUnmarshallOTLP_error(t *testing.T) {
+	p := protoUnmarshaller{}
+	got, err := p.Unmarshal([]byte("+$%"))
+	assert.Equal(t, pdata.NewTraces(), got)
+	assert.Error(t, err)
+}

--- a/receiver/kafkareceiver/otlp_unmarshaller_test.go
+++ b/receiver/kafkareceiver/otlp_unmarshaller_test.go
@@ -35,7 +35,7 @@ func TestUnmarshallOTLP(t *testing.T) {
 	expected, err := request.Marshal()
 	require.NoError(t, err)
 
-	p := protoUnmarshaller{}
+	p := otlpProtoUnmarshaller{}
 	got, err := p.Unmarshal(expected)
 	require.NoError(t, err)
 	assert.Equal(t, td, got)
@@ -43,7 +43,7 @@ func TestUnmarshallOTLP(t *testing.T) {
 }
 
 func TestUnmarshallOTLP_error(t *testing.T) {
-	p := protoUnmarshaller{}
+	p := otlpProtoUnmarshaller{}
 	got, err := p.Unmarshal([]byte("+$%"))
 	assert.Equal(t, pdata.NewTraces(), got)
 	assert.Error(t, err)

--- a/receiver/kafkareceiver/unmarshaller.go
+++ b/receiver/kafkareceiver/unmarshaller.go
@@ -27,14 +27,18 @@ type Unmarshaller interface {
 	Encoding() string
 }
 
-var unmarshallers = map[string]Unmarshaller{}
-
-// GetUnmarshaller returns unmarshaller for given encoding or nil if not found.
-func GetUnmarshaller(encoding string) Unmarshaller {
-	return unmarshallers[encoding]
-}
-
-// RegisterUnmarshaller registers unmarshaller.
-func RegisterUnmarshaller(unmarshaller Unmarshaller) {
-	unmarshallers[unmarshaller.Encoding()] = unmarshaller
+// DefaultUnmarshallers returns map of supported encodings with Unmarshaller.
+func DefaultUnmarshallers() map[string]Unmarshaller {
+	otlp := &protoUnmarshaller{}
+	jaegerProto := jaegerProtoSpanUnmarshaller{}
+	jaegerJSON := jaegerJSONSpanUnmarshaller{}
+	zipkinJSON := zipkinJSONSpanUnmarshaller{}
+	zipkinThrift := zipkinThriftSpanUnmarshaller{}
+	return map[string]Unmarshaller{
+		otlp.Encoding():         otlp,
+		jaegerProto.Encoding():  jaegerProto,
+		jaegerJSON.Encoding():   jaegerJSON,
+		zipkinJSON.Encoding():   zipkinJSON,
+		zipkinThrift.Encoding(): zipkinThrift,
+	}
 }

--- a/receiver/kafkareceiver/unmarshaller.go
+++ b/receiver/kafkareceiver/unmarshaller.go
@@ -27,9 +27,9 @@ type Unmarshaller interface {
 	Encoding() string
 }
 
-// DefaultUnmarshallers returns map of supported encodings with Unmarshaller.
-func DefaultUnmarshallers() map[string]Unmarshaller {
-	otlp := &protoUnmarshaller{}
+// defaultUnmarshallers returns map of supported encodings with Unmarshaller.
+func defaultUnmarshallers() map[string]Unmarshaller {
+	otlp := &otlpProtoUnmarshaller{}
 	jaegerProto := jaegerProtoSpanUnmarshaller{}
 	jaegerJSON := jaegerJSONSpanUnmarshaller{}
 	zipkinJSON := zipkinJSONSpanUnmarshaller{}

--- a/receiver/kafkareceiver/unmarshaller_test.go
+++ b/receiver/kafkareceiver/unmarshaller_test.go
@@ -18,28 +18,24 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
-	"go.opentelemetry.io/collector/consumer/pdata"
+	"github.com/stretchr/testify/require"
 )
 
-const testEncoding = "test"
-
-func TestRegisterUnmarshaller(t *testing.T) {
-	tun := &testUnmarshaller{}
-	RegisterUnmarshaller(tun)
-	unmarshaller := GetUnmarshaller(testEncoding)
-	assert.Equal(t, tun, unmarshaller)
-}
-
-type testUnmarshaller struct {
-}
-
-var _ Unmarshaller = (*testUnmarshaller)(nil)
-
-func (t testUnmarshaller) Unmarshal(bytes []byte) (pdata.Traces, error) {
-	panic("implement me")
-}
-
-func (t testUnmarshaller) Encoding() string {
-	return testEncoding
+func TestDefaultUnMarshaller(t *testing.T) {
+	expectedEncodings := []string{
+		"otlp_proto",
+		"jaeger_proto",
+		"jaeger_json",
+		"zipkin_json",
+		"zipkin_thrift",
+	}
+	marshallers := DefaultUnmarshallers()
+	assert.Equal(t, len(expectedEncodings), len(marshallers))
+	for _, e := range expectedEncodings {
+		t.Run(e, func(t *testing.T) {
+			m, ok := marshallers[e]
+			require.True(t, ok)
+			assert.NotNil(t, m)
+		})
+	}
 }

--- a/receiver/kafkareceiver/unmarshaller_test.go
+++ b/receiver/kafkareceiver/unmarshaller_test.go
@@ -29,7 +29,7 @@ func TestDefaultUnMarshaller(t *testing.T) {
 		"zipkin_json",
 		"zipkin_thrift",
 	}
-	marshallers := DefaultUnmarshallers()
+	marshallers := defaultUnmarshallers()
 	assert.Equal(t, len(expectedEncodings), len(marshallers))
 	for _, e := range expectedEncodings {
 		t.Run(e, func(t *testing.T) {

--- a/receiver/kafkareceiver/zipkin_unmarshaller.go
+++ b/receiver/kafkareceiver/zipkin_unmarshaller.go
@@ -25,13 +25,6 @@ import (
 	zipkintranslator "go.opentelemetry.io/collector/translator/trace/zipkin"
 )
 
-func init() {
-	zipkinThrift := &zipkinThriftSpanUnmarshaller{}
-	RegisterUnmarshaller(zipkinThrift)
-	zipkinJSON := &zipkinJSONSpanUnmarshaller{}
-	RegisterUnmarshaller(zipkinJSON)
-}
-
 type zipkinJSONSpanUnmarshaller struct {
 }
 

--- a/receiver/kafkareceiver/zipkin_unmarshaller.go
+++ b/receiver/kafkareceiver/zipkin_unmarshaller.go
@@ -1,0 +1,95 @@
+// Copyright 2020 The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kafkareceiver
+
+import (
+	"encoding/json"
+
+	"github.com/apache/thrift/lib/go/thrift"
+	"github.com/jaegertracing/jaeger/thrift-gen/zipkincore"
+	zipkinmodel "github.com/openzipkin/zipkin-go/model"
+
+	"go.opentelemetry.io/collector/consumer/pdata"
+	zipkintranslator "go.opentelemetry.io/collector/translator/trace/zipkin"
+)
+
+func init() {
+	zipkinThrift := &zipkinThriftSpanUnmarshaller{}
+	RegisterUnmarshaller(zipkinThrift)
+	zipkinJSON := &zipkinJSONSpanUnmarshaller{}
+	RegisterUnmarshaller(zipkinJSON)
+}
+
+type zipkinJSONSpanUnmarshaller struct {
+}
+
+var _ Unmarshaller = (*zipkinJSONSpanUnmarshaller)(nil)
+
+func (z zipkinJSONSpanUnmarshaller) Unmarshal(bytes []byte) (pdata.Traces, error) {
+	var spans []*zipkinmodel.SpanModel
+	if err := json.Unmarshal(bytes, &spans); err != nil {
+		return pdata.NewTraces(), err
+	}
+	return zipkintranslator.V2SpansToInternalTraces(spans)
+}
+
+func (z zipkinJSONSpanUnmarshaller) Encoding() string {
+	return "zipkin_json"
+}
+
+type zipkinThriftSpanUnmarshaller struct {
+}
+
+var _ Unmarshaller = (*zipkinThriftSpanUnmarshaller)(nil)
+
+func (z zipkinThriftSpanUnmarshaller) Unmarshal(bytes []byte) (pdata.Traces, error) {
+	spans, err := deserializeZipkinThrift(bytes)
+	if err != nil {
+		return pdata.NewTraces(), err
+	}
+	return zipkintranslator.V1ThriftBatchToInternalTraces(spans)
+
+}
+
+func (z zipkinThriftSpanUnmarshaller) Encoding() string {
+	return "zipkin_thrift"
+}
+
+// deserializeThrift decodes Thrift bytes to a list of spans.
+// This code comes from jaegertracing/jaeger, ideally we should have imported
+// it but this was creating many conflicts so brought the code to here.
+// https://github.com/jaegertracing/jaeger/blob/6bc0c122bfca8e737a747826ae60a22a306d7019/model/converter/thrift/zipkin/deserialize.go#L36
+func deserializeZipkinThrift(b []byte) ([]*zipkincore.Span, error) {
+	buffer := thrift.NewTMemoryBuffer()
+	buffer.Write(b)
+
+	transport := thrift.NewTBinaryProtocolTransport(buffer)
+	_, size, err := transport.ReadListBegin() // Ignore the returned element type
+	if err != nil {
+		return nil, err
+	}
+
+	// We don't depend on the size returned by ReadListBegin to preallocate the array because it
+	// sometimes returns a nil error on bad input and provides an unreasonably large int for size
+	var spans []*zipkincore.Span
+	for i := 0; i < size; i++ {
+		zs := &zipkincore.Span{}
+		if err = zs.Read(transport); err != nil {
+			return nil, err
+		}
+		spans = append(spans, zs)
+	}
+	return spans, nil
+}

--- a/receiver/kafkareceiver/zipkin_unmarshaller_test.go
+++ b/receiver/kafkareceiver/zipkin_unmarshaller_test.go
@@ -1,0 +1,98 @@
+// Copyright 2020 The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kafkareceiver
+
+import (
+	"testing"
+
+	"github.com/apache/thrift/lib/go/thrift"
+	"github.com/jaegertracing/jaeger/thrift-gen/zipkincore"
+	zipkinreporter "github.com/openzipkin/zipkin-go/reporter"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/collector/consumer/pdata"
+	zipkintranslator "go.opentelemetry.io/collector/translator/trace/zipkin"
+)
+
+func TestUnmarshallZipkin(t *testing.T) {
+	td := pdata.NewTraces()
+	td.ResourceSpans().Resize(1)
+	td.ResourceSpans().At(0).InstrumentationLibrarySpans().Resize(1)
+	td.ResourceSpans().At(0).InstrumentationLibrarySpans().At(0).Spans().Resize(1)
+	td.ResourceSpans().At(0).InstrumentationLibrarySpans().At(0).Spans().At(0).SetName("foo")
+	td.ResourceSpans().At(0).InstrumentationLibrarySpans().At(0).Spans().At(0).SetStartTime(pdata.TimestampUnixNano(1597759000))
+	td.ResourceSpans().At(0).InstrumentationLibrarySpans().At(0).Spans().At(0).Attributes().InitEmptyWithCapacity(1)
+	td.ResourceSpans().At(0).InstrumentationLibrarySpans().At(0).Spans().At(0).SetTraceID(pdata.NewTraceID([]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}))
+	td.ResourceSpans().At(0).InstrumentationLibrarySpans().At(0).Spans().At(0).SetSpanID(pdata.NewSpanID([]byte{1, 2, 3, 4, 5, 6, 7, 8}))
+	spans, err := zipkintranslator.InternalTracesToZipkinSpans(td)
+	require.NoError(t, err)
+
+	serializer := zipkinreporter.JSONSerializer{}
+	jsonBytes, err := serializer.Serialize(spans)
+	require.NoError(t, err)
+
+	tSpan := &zipkincore.Span{Name: "foo"}
+	thriftTransport := thrift.NewTMemoryBuffer()
+	protocolTransport := thrift.NewTBinaryProtocolTransport(thriftTransport)
+	require.NoError(t, protocolTransport.WriteListBegin(thrift.STRUCT, 1))
+	err = tSpan.Write(protocolTransport)
+	require.NoError(t, err)
+	require.NoError(t, protocolTransport.WriteListEnd())
+
+	tdThrift, err := zipkintranslator.V1ThriftBatchToInternalTraces([]*zipkincore.Span{tSpan})
+	require.NoError(t, err)
+	tests := []struct {
+		unmarshaller Unmarshaller
+		encoding     string
+		bytes        []byte
+		expected     pdata.Traces
+	}{
+		{
+			unmarshaller: zipkinJSONSpanUnmarshaller{},
+			encoding:     "zipkin_json",
+			bytes:        jsonBytes,
+			expected:     td,
+		},
+		{
+			unmarshaller: zipkinThriftSpanUnmarshaller{},
+			encoding:     "zipkin_thrift",
+			bytes:        thriftTransport.Buffer.Bytes(),
+			expected:     tdThrift,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.encoding, func(t *testing.T) {
+			traces, err := test.unmarshaller.Unmarshal(test.bytes)
+			require.NoError(t, err)
+			assert.Equal(t, test.expected, traces)
+			assert.Equal(t, test.encoding, test.unmarshaller.Encoding())
+		})
+	}
+}
+
+func TestUnmarshallZipkinThrift_error(t *testing.T) {
+	p := zipkinThriftSpanUnmarshaller{}
+	got, err := p.Unmarshal([]byte("+$%"))
+	assert.Equal(t, pdata.NewTraces(), got)
+	assert.Error(t, err)
+}
+
+func TestUnmarshallZipkinJSON_error(t *testing.T) {
+	p := zipkinJSONSpanUnmarshaller{}
+	got, err := p.Unmarshal([]byte("+$%"))
+	assert.Equal(t, pdata.NewTraces(), got)
+	assert.Error(t, err)
+}

--- a/service/defaultcomponents/defaults.go
+++ b/service/defaultcomponents/defaults.go
@@ -76,7 +76,7 @@ func Components() (
 		opencensusreceiver.NewFactory(),
 		otlpreceiver.NewFactory(),
 		hostmetricsreceiver.NewFactory(),
-		kafkareceiver.NewFactory(kafkareceiver.DefaultUnmarshallers()),
+		kafkareceiver.NewFactory(),
 	)
 	if err != nil {
 		errs = append(errs, err)
@@ -90,7 +90,7 @@ func Components() (
 		jaegerexporter.NewFactory(),
 		fileexporter.NewFactory(),
 		otlpexporter.NewFactory(),
-		kafkaexporter.NewFactory(kafkaexporter.DefaultMarshallers()),
+		kafkaexporter.NewFactory(),
 	)
 	if err != nil {
 		errs = append(errs, err)

--- a/service/defaultcomponents/defaults.go
+++ b/service/defaultcomponents/defaults.go
@@ -76,7 +76,7 @@ func Components() (
 		opencensusreceiver.NewFactory(),
 		otlpreceiver.NewFactory(),
 		hostmetricsreceiver.NewFactory(),
-		kafkareceiver.NewFactory(),
+		kafkareceiver.NewFactory(kafkareceiver.DefaultUnmarshallers()),
 	)
 	if err != nil {
 		errs = append(errs, err)
@@ -90,7 +90,7 @@ func Components() (
 		jaegerexporter.NewFactory(),
 		fileexporter.NewFactory(),
 		otlpexporter.NewFactory(),
-		kafkaexporter.NewFactory(),
+		kafkaexporter.NewFactory(kafkaexporter.DefaultMarshallers()),
 	)
 	if err != nil {
 		errs = append(errs, err)


### PR DESCRIPTION
Signed-off-by: Pavol Loffay <ploffay@redhat.com>

**Description:** 

This PR makes configurable encoding of Kafka message payloads. I have added support for Jaeger proto and JSON for both receiver and exporter and also Zipkin JSON and thrift for receiver to cover the functionality we had in Jaeger. This will allow users to migrate to the OTEL collector and also Jaeger project to use this new implementation directly. 

In addition to that additional encodings can be programmatically added via a registry. 

**Link to tracking Issue:** <Issue number if applicable>

Resolves #1580 

**Testing:** < Describe what testing was performed and which tests were added.>

**Documentation:** < Describe the documentation added.>

Added to readme