### PR TITLE
Include Prometheus Remote Write Exporter in the default components list

### DIFF
--- a/service/defaultcomponents/defaults.go
+++ b/service/defaultcomponents/defaults.go
@@ -25,6 +25,7 @@ import (
 	"go.opentelemetry.io/collector/exporter/opencensusexporter"
 	"go.opentelemetry.io/collector/exporter/otlpexporter"
 	"go.opentelemetry.io/collector/exporter/prometheusexporter"
+	"go.opentelemetry.io/collector/exporter/prometheusremotewriteexporter"
 	"go.opentelemetry.io/collector/exporter/zipkinexporter"
 	"go.opentelemetry.io/collector/extension/fluentbitextension"
 	"go.opentelemetry.io/collector/extension/healthcheckextension"
@@ -85,6 +86,7 @@ func Components() (
 	exporters, err := component.MakeExporterFactoryMap(
 		opencensusexporter.NewFactory(),
 		prometheusexporter.NewFactory(),
+		prometheusremotewriteexporter.NewFactory(),
 		loggingexporter.NewFactory(),
 		zipkinexporter.NewFactory(),
 		jaegerexporter.NewFactory(),


### PR DESCRIPTION
**Description:** Adds `prometheusremotewriteexporter` to the list of exporter factories - seems it was missed (or not added on purpose?)

**Link to tracking Issue:** N/A

**Testing:** Simply running the OpenTelemetry Collector with `prometheusremotewriteexporter` config

**Documentation:** N/A