### PR TITLE
Fix make list test commands to not inlude the last line

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,11 +65,11 @@ testbed-correctness: otelcol
 
 .PHONY: testbed-list-loadtest
 testbed-list-loadtest:
-	TESTBED_CONFIG=local.yaml $(GOTEST) -v ./testbed/tests --test.list '.*'|head -n 20
+	TESTBED_CONFIG=local.yaml $(GOTEST) -v ./testbed/tests --test.list '.*'| grep "^Test"
 
 .PHONY: testbed-list-correctness
 testbed-list-correctness:
-	TESTBED_CONFIG=inprocess.yaml $(GOTEST) -v ./testbed/correctness --test.list '.*'|head -n 10
+	TESTBED_CONFIG=inprocess.yaml $(GOTEST) -v ./testbed/correctness --test.list '.*'| grep "^Test"
 
 .PHONY: test
 test:


### PR DESCRIPTION
This causes some tests to not run:

```
GO111MODULE=on CGO_ENABLED=0 go build -o ./bin/otelcol_linux_amd64 -ldflags "-X go.opentelemetry.io/collector/internal/version.GitHash=a8f3d716  -X go.opentelemetry.io/collector/internal/version.BuildType=release" ./cmd/otelcol
cd ./testbed/tests && ./runtests.sh
-test.run=TestTrace10kSPS|ok|go.opentelemetry.io/collector/testbed/tests|0.025s
=== RUN   TestTrace10kSPS
--- PASS: TestTrace10kSPS (0.00s)
testing: warning: no tests to run
```
