### PR TITLE
Convert to the new proto library usage all the time

### DIFF
--- a/exporter/prometheusexporter/prometheus_test.go
+++ b/exporter/prometheusexporter/prometheus_test.go
@@ -23,10 +23,10 @@ import (
 	"testing"
 
 	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
-	"github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer/consumerdata"
@@ -139,7 +139,7 @@ func metricBuilder(delta int64) []*metricspb.Metric {
 			},
 			Timeseries: []*metricspb.TimeSeries{
 				{
-					StartTimestamp: &timestamp.Timestamp{
+					StartTimestamp: &timestamppb.Timestamp{
 						Seconds: 1543160298,
 						Nanos:   100000090,
 					},
@@ -149,7 +149,7 @@ func metricBuilder(delta int64) []*metricspb.Metric {
 					},
 					Points: []*metricspb.Point{
 						{
-							Timestamp: &timestamp.Timestamp{
+							Timestamp: &timestamppb.Timestamp{
 								Seconds: 1543160298,
 								Nanos:   100000997,
 							},
@@ -174,7 +174,7 @@ func metricBuilder(delta int64) []*metricspb.Metric {
 			},
 			Timeseries: []*metricspb.TimeSeries{
 				{
-					StartTimestamp: &timestamp.Timestamp{
+					StartTimestamp: &timestamppb.Timestamp{
 						Seconds: 1543160298,
 						Nanos:   100000090,
 					},
@@ -184,7 +184,7 @@ func metricBuilder(delta int64) []*metricspb.Metric {
 					},
 					Points: []*metricspb.Point{
 						{
-							Timestamp: &timestamp.Timestamp{
+							Timestamp: &timestamppb.Timestamp{
 								Seconds: 1543160298,
 								Nanos:   100000997,
 							},

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -17,39 +17,24 @@ package internal
 import (
 	"time"
 
-	"github.com/golang/protobuf/ptypes/timestamp"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"go.opentelemetry.io/collector/consumer/pdata"
 )
 
-// TimeToTimestamp converts a time.Time to a timestamp.Timestamp pointer.
-func TimeToTimestamp(t time.Time) *timestamp.Timestamp {
-	if t.IsZero() {
+func TimestampToUnixNano(ts *timestamppb.Timestamp) (t pdata.TimestampUnixNano) {
+	if ts == nil {
+		return
+	}
+	return pdata.TimestampUnixNano(uint64(ts.AsTime().UnixNano()))
+}
+
+func UnixNanoToTimestamp(u pdata.TimestampUnixNano) *timestamppb.Timestamp {
+	// 0 is a special case and want to make sure we return nil.
+	if u == 0 {
 		return nil
 	}
-	nanoTime := t.UnixNano()
-	return &timestamp.Timestamp{
-		Seconds: nanoTime / 1e9,
-		Nanos:   int32(nanoTime % 1e9),
-	}
-}
-
-func TimestampToTime(ts *timestamp.Timestamp) (t time.Time) {
-	if ts == nil {
-		return
-	}
-	return time.Unix(ts.Seconds, int64(ts.Nanos))
-}
-
-func TimestampToUnixNano(ts *timestamp.Timestamp) (t pdata.TimestampUnixNano) {
-	if ts == nil {
-		return
-	}
-	return pdata.TimestampUnixNano(uint64(TimestampToTime(ts).UnixNano()))
-}
-
-func UnixNanoToTimestamp(u pdata.TimestampUnixNano) *timestamp.Timestamp {
-	return TimeToTimestamp(UnixNanoToTime(u))
+	return timestamppb.New(UnixNanoToTime(u))
 }
 
 func UnixNanoToTime(u pdata.TimestampUnixNano) time.Time {

--- a/internal/internal_test.go
+++ b/internal/internal_test.go
@@ -18,21 +18,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"go.opentelemetry.io/collector/consumer/pdata"
 )
-
-func TestTimeConverters(t *testing.T) {
-	// Ensure that we nanoseconds but that they are also preserved.
-	t1 := time.Date(2018, 10, 31, 19, 43, 35, 789, time.UTC)
-
-	assert.EqualValues(t, int64(1541015015000000789), t1.UnixNano())
-	tp := TimeToTimestamp(t1)
-	assert.EqualValues(t, &timestamp.Timestamp{Seconds: 1541015015, Nanos: 789}, tp)
-	assert.EqualValues(t, int64(1541015015000000789), TimestampToTime(tp).UnixNano())
-}
 
 func TestUnixNanosConverters(t *testing.T) {
 	t1 := time.Date(2020, 03, 24, 1, 13, 23, 789, time.UTC)
@@ -40,12 +30,12 @@ func TestUnixNanosConverters(t *testing.T) {
 
 	assert.EqualValues(t, uint64(1585012403000000789), tun)
 	tp := UnixNanoToTimestamp(tun)
-	assert.EqualValues(t, &timestamp.Timestamp{Seconds: 1585012403, Nanos: 789}, tp)
+	assert.EqualValues(t, &timestamppb.Timestamp{Seconds: 1585012403, Nanos: 789}, tp)
 	assert.EqualValues(t, tun, TimestampToUnixNano(tp))
 }
 
 func TestZeroTimestamps(t *testing.T) {
-	assert.Nil(t, TimeToTimestamp(time.Time{}))
+	assert.Zero(t, TimestampToUnixNano(nil))
 	assert.Nil(t, UnixNanoToTimestamp(0))
 	assert.True(t, UnixNanoToTime(0).IsZero())
 }

--- a/receiver/opencensusreceiver/ocmetrics/opencensus_test.go
+++ b/receiver/opencensusreceiver/ocmetrics/opencensus_test.go
@@ -34,6 +34,7 @@ import (
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -41,7 +42,6 @@ import (
 	"go.opentelemetry.io/collector/consumer/pdatautil"
 	"go.opentelemetry.io/collector/exporter/exportertest"
 	"go.opentelemetry.io/collector/exporter/opencensusexporter"
-	"go.opentelemetry.io/collector/internal"
 	"go.opentelemetry.io/collector/internal/data/testdata"
 	"go.opentelemetry.io/collector/obsreport"
 	"go.opentelemetry.io/collector/testutil"
@@ -403,14 +403,14 @@ func makeMetric(val int) *metricspb.Metric {
 
 	now := time.Now().UTC()
 	point := &metricspb.Point{
-		Timestamp: internal.TimeToTimestamp(now.Add(20 * time.Second)),
+		Timestamp: timestamppb.New(now.Add(20 * time.Second)),
 		Value: &metricspb.Point_Int64Value{
 			Int64Value: int64(val),
 		},
 	}
 
 	ts := &metricspb.TimeSeries{
-		StartTimestamp: internal.TimeToTimestamp(now.Add(-10 * time.Second)),
+		StartTimestamp: timestamppb.New(now.Add(-10 * time.Second)),
 		LabelValues:    []*metricspb.LabelValue{value},
 		Points:         []*metricspb.Point{point},
 	}

--- a/receiver/opencensusreceiver/opencensus_test.go
+++ b/receiver/opencensusreceiver/opencensus_test.go
@@ -42,11 +42,11 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/consumer/consumerdata"
 	"go.opentelemetry.io/collector/exporter/exportertest"
-	"go.opentelemetry.io/collector/internal"
 	"go.opentelemetry.io/collector/obsreport/obsreporttest"
 	"go.opentelemetry.io/collector/testutil"
 	"go.opentelemetry.io/collector/translator/internaldata"
@@ -137,8 +137,8 @@ func TestGrpcGateway_endToEnd(t *testing.T) {
 				TraceId:   []byte{0x5B, 0x8E, 0xFF, 0xF7, 0x98, 0x3, 0x81, 0x3, 0xD2, 0x69, 0xB6, 0x33, 0x81, 0x3F, 0xC6, 0xC},
 				SpanId:    []byte{0xEE, 0xE1, 0x9B, 0x7E, 0xC3, 0xC1, 0xB1, 0x73},
 				Name:      &tracepb.TruncatableString{Value: "testSpan"},
-				StartTime: internal.TimeToTimestamp(time.Unix(1544712660, 0).UTC()),
-				EndTime:   internal.TimeToTimestamp(time.Unix(1544712661, 0).UTC()),
+				StartTime: timestamppb.New(time.Unix(1544712660, 0).UTC()),
+				EndTime:   timestamppb.New(time.Unix(1544712661, 0).UTC()),
 				Attributes: &tracepb.Span_Attributes{
 					AttributeMap: map[string]*tracepb.AttributeValue{
 						"attr1": {
@@ -608,7 +608,7 @@ func TestOCReceiverMetrics_HandleNextConsumerResponse(t *testing.T) {
 		Type:        metricspb.MetricDescriptor_GAUGE_INT64,
 	}
 	point := &metricspb.Point{
-		Timestamp: internal.TimeToTimestamp(time.Now().UTC()),
+		Timestamp: timestamppb.New(time.Now().UTC()),
 		Value: &metricspb.Point_Int64Value{
 			Int64Value: int64(1),
 		},

--- a/receiver/prometheusreceiver/internal/metricfamily.go
+++ b/receiver/prometheusreceiver/internal/metricfamily.go
@@ -19,11 +19,11 @@ import (
 	"strings"
 
 	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
-	"github.com/golang/protobuf/ptypes/timestamp"
-	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/pkg/textparse"
 	"github.com/prometheus/prometheus/scrape"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 // MetricFamily is unit which is corresponding to the metrics items which shared the same TYPE/UNIT/... metadata from
@@ -335,8 +335,8 @@ func (mg *metricGroup) toSummaryTimeSeries(orderedLabelKeys []string) *metricspb
 	// at the global level of the metricspb.SummaryValue
 
 	summaryValue := &metricspb.SummaryValue{
-		Sum:      &wrappers.DoubleValue{Value: mg.sum},
-		Count:    &wrappers.Int64Value{Value: int64(mg.count)},
+		Sum:      &wrapperspb.DoubleValue{Value: mg.sum},
+		Count:    &wrapperspb.Int64Value{Value: int64(mg.count)},
 		Snapshot: snapshot,
 	}
 	return &metricspb.TimeSeries{
@@ -349,7 +349,7 @@ func (mg *metricGroup) toSummaryTimeSeries(orderedLabelKeys []string) *metricspb
 }
 
 func (mg *metricGroup) toDoubleValueTimeSeries(orderedLabelKeys []string) *metricspb.TimeSeries {
-	var startTs *timestamp.Timestamp
+	var startTs *timestamppb.Timestamp
 	// gauge/undefined types has no start time
 	if mg.family.isCumulativeType() {
 		startTs = timestampFromMs(mg.ts)

--- a/receiver/prometheusreceiver/internal/metrics_adjuster.go
+++ b/receiver/prometheusreceiver/internal/metrics_adjuster.go
@@ -21,8 +21,8 @@ import (
 	"time"
 
 	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
-	"github.com/golang/protobuf/ptypes/wrappers"
 	"go.uber.org/zap"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 // Notes on garbage collection (gc):
@@ -349,9 +349,9 @@ func (ma *MetricsAdjuster) adjustPoint(metricType metricspb.MetricDescriptor_Typ
 			return false
 		}
 		current.GetSummaryValue().Count =
-			&wrappers.Int64Value{Value: currentCount - initialCount}
+			&wrapperspb.Int64Value{Value: currentCount - initialCount}
 		current.GetSummaryValue().Sum =
-			&wrappers.DoubleValue{Value: currentSum - initialSum}
+			&wrapperspb.DoubleValue{Value: currentSum - initialSum}
 	default:
 		// this shouldn't happen
 		ma.logger.Info("Adjust - skipping unexpected point", zap.String("type", metricType.String()))

--- a/receiver/prometheusreceiver/internal/metricsbuilder.go
+++ b/receiver/prometheusreceiver/internal/metricsbuilder.go
@@ -22,11 +22,11 @@ import (
 	"strings"
 
 	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
-	"github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/pkg/textparse"
 	"go.uber.org/zap"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 const (
@@ -293,9 +293,9 @@ func heuristicalMetricAndKnownUnits(metricName, parsedUnit string) string {
 	return unit
 }
 
-func timestampFromMs(timeAtMs int64) *timestamp.Timestamp {
+func timestampFromMs(timeAtMs int64) *timestamppb.Timestamp {
 	secs, ns := timeAtMs/1e3, (timeAtMs%1e3)*1e6
-	return &timestamp.Timestamp{
+	return &timestamppb.Timestamp{
 		Seconds: secs,
 		Nanos:   int32(ns),
 	}

--- a/receiver/prometheusreceiver/internal/metricsbuilder_test.go
+++ b/receiver/prometheusreceiver/internal/metricsbuilder_test.go
@@ -19,12 +19,12 @@ import (
 	"testing"
 
 	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
-	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/pkg/textparse"
 	"github.com/prometheus/prometheus/scrape"
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 const startTs = int64(1555366610000)
@@ -1050,8 +1050,8 @@ func Test_metricBuilder_summary(t *testing.T) {
 									{
 										Timestamp: timestampFromMs(startTs), Value: &metricspb.Point_SummaryValue{
 											SummaryValue: &metricspb.SummaryValue{
-												Sum:   &wrappers.DoubleValue{Value: 100.0},
-												Count: &wrappers.Int64Value{Value: 500},
+												Sum:   &wrapperspb.DoubleValue{Value: 100.0},
+												Count: &wrapperspb.Int64Value{Value: 500},
 											},
 										},
 									},
@@ -1089,8 +1089,8 @@ func Test_metricBuilder_summary(t *testing.T) {
 								Points: []*metricspb.Point{
 									{Timestamp: timestampFromMs(startTs), Value: &metricspb.Point_SummaryValue{
 										SummaryValue: &metricspb.SummaryValue{
-											Sum:   &wrappers.DoubleValue{Value: 100.0},
-											Count: &wrappers.Int64Value{Value: 500},
+											Sum:   &wrapperspb.DoubleValue{Value: 100.0},
+											Count: &wrapperspb.Int64Value{Value: 500},
 											Snapshot: &metricspb.SummaryValue_Snapshot{
 												PercentileValues: []*metricspb.SummaryValue_Snapshot_ValueAtPercentile{
 													{Percentile: 50.0, Value: 1},

--- a/receiver/prometheusreceiver/internal/transaction.go
+++ b/receiver/prometheusreceiver/internal/transaction.go
@@ -23,7 +23,6 @@ import (
 
 	commonpb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
 	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
-	"github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/storage"
@@ -31,6 +30,7 @@ import (
 	"go.opencensus.io/stats"
 	"go.opencensus.io/tag"
 	"go.uber.org/zap"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumerdata"
@@ -210,10 +210,10 @@ func adjustStartTime(startTime float64, metrics []*metricspb.Metric) {
 	}
 }
 
-func timestampFromFloat64(ts float64) *timestamp.Timestamp {
+func timestampFromFloat64(ts float64) *timestamppb.Timestamp {
 	secs := int64(ts)
 	nanos := int64((ts - float64(secs)) * 1e9)
-	return &timestamp.Timestamp{
+	return &timestamppb.Timestamp{
 		Seconds: secs,
 		Nanos:   int32(nanos),
 	}

--- a/receiver/prometheusreceiver/metrics_receiver_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_test.go
@@ -29,12 +29,12 @@ import (
 
 	commonpb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
 	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
-	timestamppb "github.com/golang/protobuf/ptypes/timestamp"
-	"github.com/golang/protobuf/ptypes/wrappers"
 	promcfg "github.com/prometheus/prometheus/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 	"gopkg.in/yaml.v2"
 
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -379,8 +379,8 @@ func verifyTarget1(t *testing.T, td *testData, mds []consumerdata.MetricsData) {
 							{
 								Timestamp: ts2, Value: &metricspb.Point_SummaryValue{
 									SummaryValue: &metricspb.SummaryValue{
-										Sum:   &wrappers.DoubleValue{Value: 2.0},
-										Count: &wrappers.Int64Value{Value: 1},
+										Sum:   &wrapperspb.DoubleValue{Value: 2.0},
+										Count: &wrapperspb.Int64Value{Value: 1},
 										Snapshot: &metricspb.SummaryValue_Snapshot{
 											PercentileValues: []*metricspb.SummaryValue_Snapshot_ValueAtPercentile{
 												{Percentile: 1.0, Value: 1},
@@ -889,8 +889,8 @@ func verifyTarget3(t *testing.T, td *testData, mds []consumerdata.MetricsData) {
 							{
 								Timestamp: ts2, Value: &metricspb.Point_SummaryValue{
 									SummaryValue: &metricspb.SummaryValue{
-										Sum:   &wrappers.DoubleValue{Value: 100.0},
-										Count: &wrappers.Int64Value{Value: 50},
+										Sum:   &wrapperspb.DoubleValue{Value: 100.0},
+										Count: &wrapperspb.Int64Value{Value: 50},
 										Snapshot: &metricspb.SummaryValue_Snapshot{
 											PercentileValues: []*metricspb.SummaryValue_Snapshot_ValueAtPercentile{
 												{Percentile: 1.0, Value: 32},
@@ -912,8 +912,8 @@ func verifyTarget3(t *testing.T, td *testData, mds []consumerdata.MetricsData) {
 							{
 								Timestamp: ts2, Value: &metricspb.Point_SummaryValue{
 									SummaryValue: &metricspb.SummaryValue{
-										Sum:   &wrappers.DoubleValue{Value: 1.0},
-										Count: &wrappers.Int64Value{Value: 5},
+										Sum:   &wrapperspb.DoubleValue{Value: 1.0},
+										Count: &wrapperspb.Int64Value{Value: 5},
 									},
 								},
 							},

--- a/testutil/metricstestutil/metricsutil.go
+++ b/testutil/metricstestutil/metricsutil.go
@@ -18,8 +18,8 @@ import (
 	"time"
 
 	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
-	timestamppb "github.com/golang/protobuf/ptypes/timestamp"
-	wrapperspb "github.com/golang/protobuf/ptypes/wrappers"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 // Gauge creates a gauge metric.

--- a/testutil/metricstestutil/metricsutil_test.go
+++ b/testutil/metricstestutil/metricsutil_test.go
@@ -19,9 +19,9 @@ import (
 	"time"
 
 	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
-	timestamppb "github.com/golang/protobuf/ptypes/timestamp"
-	wrapperspb "github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 func TestResourceProcessor(t *testing.T) {

--- a/translator/internaldata/metrics_to_oc.go
+++ b/translator/internaldata/metrics_to_oc.go
@@ -18,7 +18,7 @@ import (
 	"sort"
 
 	ocmetrics "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
-	"github.com/golang/protobuf/ptypes/wrappers"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"go.opentelemetry.io/collector/consumer/consumerdata"
 	"go.opentelemetry.io/collector/consumer/pdata"
@@ -440,14 +440,14 @@ func labelValuesToOC(labels pdata.StringMap, labelKeys *labelKeys) []*ocmetrics.
 	return labelValues
 }
 
-func int64Value(val uint64) *wrappers.Int64Value {
-	return &wrappers.Int64Value{
+func int64Value(val uint64) *wrapperspb.Int64Value {
+	return &wrapperspb.Int64Value{
 		Value: int64(val),
 	}
 }
 
-func doubleValue(val float64) *wrappers.DoubleValue {
-	return &wrappers.DoubleValue{
+func doubleValue(val float64) *wrapperspb.DoubleValue {
+	return &wrapperspb.DoubleValue{
 		Value: val,
 	}
 }

--- a/translator/internaldata/metrics_to_oc_test.go
+++ b/translator/internaldata/metrics_to_oc_test.go
@@ -21,8 +21,8 @@ import (
 	occommon "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
 	ocmetrics "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
 	ocresource "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
-	"github.com/golang/protobuf/ptypes"
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"go.opentelemetry.io/collector/consumer/consumerdata"
 	"go.opentelemetry.io/collector/consumer/pdata"
@@ -149,7 +149,7 @@ func TestMetricsDataToOC(t *testing.T) {
 			name:     "sample-metric",
 			internal: sampleMetricData,
 			oc: []consumerdata.MetricsData{
-				generateOCTestData(t),
+				generateOCTestData(),
 			},
 		},
 	}
@@ -162,9 +162,8 @@ func TestMetricsDataToOC(t *testing.T) {
 	}
 }
 
-func generateOCTestData(t *testing.T) consumerdata.MetricsData {
-	ts, err := ptypes.TimestampProto(time.Date(2020, 2, 11, 20, 26, 0, 0, time.UTC))
-	assert.NoError(t, err)
+func generateOCTestData() consumerdata.MetricsData {
+	ts := timestamppb.New(time.Date(2020, 2, 11, 20, 26, 0, 0, time.UTC))
 
 	return consumerdata.MetricsData{
 		Node: &occommon.Node{

--- a/translator/internaldata/oc_testdata_test.go
+++ b/translator/internaldata/oc_testdata_test.go
@@ -21,11 +21,11 @@ import (
 	occommon "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
 	ocmetrics "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
 	ocresource "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
-	"github.com/golang/protobuf/ptypes/wrappers"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"go.opentelemetry.io/collector/consumer/consumerdata"
 	"go.opentelemetry.io/collector/consumer/pdata"
-	"go.opentelemetry.io/collector/internal"
 	"go.opentelemetry.io/collector/internal/data/testdata"
 	"go.opentelemetry.io/collector/translator/conventions"
 )
@@ -170,7 +170,7 @@ func generateOCTestMetricInt() *ocmetrics.Metric {
 		},
 		Timeseries: []*ocmetrics.TimeSeries{
 			{
-				StartTimestamp: internal.TimeToTimestamp(testdata.TestMetricStartTime),
+				StartTimestamp: timestamppb.New(testdata.TestMetricStartTime),
 				LabelValues: []*ocmetrics.LabelValue{
 					{
 						// key1
@@ -184,7 +184,7 @@ func generateOCTestMetricInt() *ocmetrics.Metric {
 				},
 				Points: []*ocmetrics.Point{
 					{
-						Timestamp: internal.TimeToTimestamp(testdata.TestMetricTime),
+						Timestamp: timestamppb.New(testdata.TestMetricTime),
 						Value: &ocmetrics.Point_Int64Value{
 							Int64Value: 123,
 						},
@@ -192,7 +192,7 @@ func generateOCTestMetricInt() *ocmetrics.Metric {
 				},
 			},
 			{
-				StartTimestamp: internal.TimeToTimestamp(testdata.TestMetricStartTime),
+				StartTimestamp: timestamppb.New(testdata.TestMetricStartTime),
 				LabelValues: []*ocmetrics.LabelValue{
 					{
 						// key1
@@ -206,7 +206,7 @@ func generateOCTestMetricInt() *ocmetrics.Metric {
 				},
 				Points: []*ocmetrics.Point{
 					{
-						Timestamp: internal.TimeToTimestamp(testdata.TestMetricTime),
+						Timestamp: timestamppb.New(testdata.TestMetricTime),
 						Value: &ocmetrics.Point_Int64Value{
 							Int64Value: 456,
 						},
@@ -231,7 +231,7 @@ func generateOCTestMetricDouble() *ocmetrics.Metric {
 		},
 		Timeseries: []*ocmetrics.TimeSeries{
 			{
-				StartTimestamp: internal.TimeToTimestamp(testdata.TestMetricStartTime),
+				StartTimestamp: timestamppb.New(testdata.TestMetricStartTime),
 				LabelValues: []*ocmetrics.LabelValue{
 					{
 						// key1
@@ -250,7 +250,7 @@ func generateOCTestMetricDouble() *ocmetrics.Metric {
 				},
 				Points: []*ocmetrics.Point{
 					{
-						Timestamp: internal.TimeToTimestamp(testdata.TestMetricTime),
+						Timestamp: timestamppb.New(testdata.TestMetricTime),
 						Value: &ocmetrics.Point_DoubleValue{
 							DoubleValue: 1.23,
 						},
@@ -258,7 +258,7 @@ func generateOCTestMetricDouble() *ocmetrics.Metric {
 				},
 			},
 			{
-				StartTimestamp: internal.TimeToTimestamp(testdata.TestMetricStartTime),
+				StartTimestamp: timestamppb.New(testdata.TestMetricStartTime),
 				LabelValues: []*ocmetrics.LabelValue{
 					{
 						// key1
@@ -277,7 +277,7 @@ func generateOCTestMetricDouble() *ocmetrics.Metric {
 				},
 				Points: []*ocmetrics.Point{
 					{
-						Timestamp: internal.TimeToTimestamp(testdata.TestMetricTime),
+						Timestamp: timestamppb.New(testdata.TestMetricTime),
 						Value: &ocmetrics.Point_DoubleValue{
 							DoubleValue: 4.56,
 						},
@@ -303,7 +303,7 @@ func generateOCTestMetricHistogram() *ocmetrics.Metric {
 		},
 		Timeseries: []*ocmetrics.TimeSeries{
 			{
-				StartTimestamp: internal.TimeToTimestamp(testdata.TestMetricStartTime),
+				StartTimestamp: timestamppb.New(testdata.TestMetricStartTime),
 				LabelValues: []*ocmetrics.LabelValue{
 					{
 						// key1
@@ -322,7 +322,7 @@ func generateOCTestMetricHistogram() *ocmetrics.Metric {
 				},
 				Points: []*ocmetrics.Point{
 					{
-						Timestamp: internal.TimeToTimestamp(testdata.TestMetricTime),
+						Timestamp: timestamppb.New(testdata.TestMetricTime),
 						Value: &ocmetrics.Point_DistributionValue{
 							DistributionValue: &ocmetrics.DistributionValue{
 								Count: 1,
@@ -333,7 +333,7 @@ func generateOCTestMetricHistogram() *ocmetrics.Metric {
 				},
 			},
 			{
-				StartTimestamp: internal.TimeToTimestamp(testdata.TestMetricStartTime),
+				StartTimestamp: timestamppb.New(testdata.TestMetricStartTime),
 				LabelValues: []*ocmetrics.LabelValue{
 					{
 						// key1
@@ -351,7 +351,7 @@ func generateOCTestMetricHistogram() *ocmetrics.Metric {
 				},
 				Points: []*ocmetrics.Point{
 					{
-						Timestamp: internal.TimeToTimestamp(testdata.TestMetricTime),
+						Timestamp: timestamppb.New(testdata.TestMetricTime),
 						Value: &ocmetrics.Point_DistributionValue{
 							DistributionValue: &ocmetrics.DistributionValue{
 								Count: 1,
@@ -370,7 +370,7 @@ func generateOCTestMetricHistogram() *ocmetrics.Metric {
 									{
 										Count: 1,
 										Exemplar: &ocmetrics.DistributionValue_Exemplar{
-											Timestamp:   internal.TimeToTimestamp(testdata.TestMetricExemplarTime),
+											Timestamp:   timestamppb.New(testdata.TestMetricExemplarTime),
 											Value:       15,
 											Attachments: map[string]string{testdata.TestAttachmentKey: testdata.TestAttachmentValue},
 										},
@@ -398,7 +398,7 @@ func generateOCTestMetricSummary() *ocmetrics.Metric {
 		},
 		Timeseries: []*ocmetrics.TimeSeries{
 			{
-				StartTimestamp: internal.TimeToTimestamp(testdata.TestMetricStartTime),
+				StartTimestamp: timestamppb.New(testdata.TestMetricStartTime),
 				LabelValues: []*ocmetrics.LabelValue{
 					{
 						// key1
@@ -408,13 +408,13 @@ func generateOCTestMetricSummary() *ocmetrics.Metric {
 				},
 				Points: []*ocmetrics.Point{
 					{
-						Timestamp: internal.TimeToTimestamp(testdata.TestMetricTime),
+						Timestamp: timestamppb.New(testdata.TestMetricTime),
 						Value: &ocmetrics.Point_SummaryValue{
 							SummaryValue: &ocmetrics.SummaryValue{
-								Count: &wrappers.Int64Value{
+								Count: &wrapperspb.Int64Value{
 									Value: 1,
 								},
-								Sum: &wrappers.DoubleValue{
+								Sum: &wrapperspb.DoubleValue{
 									Value: 15,
 								},
 							},
@@ -423,7 +423,7 @@ func generateOCTestMetricSummary() *ocmetrics.Metric {
 				},
 			},
 			{
-				StartTimestamp: internal.TimeToTimestamp(testdata.TestMetricStartTime),
+				StartTimestamp: timestamppb.New(testdata.TestMetricStartTime),
 				LabelValues: []*ocmetrics.LabelValue{
 					{
 						// key1
@@ -433,13 +433,13 @@ func generateOCTestMetricSummary() *ocmetrics.Metric {
 				},
 				Points: []*ocmetrics.Point{
 					{
-						Timestamp: internal.TimeToTimestamp(testdata.TestMetricTime),
+						Timestamp: timestamppb.New(testdata.TestMetricTime),
 						Value: &ocmetrics.Point_SummaryValue{
 							SummaryValue: &ocmetrics.SummaryValue{
-								Count: &wrappers.Int64Value{
+								Count: &wrapperspb.Int64Value{
 									Value: 1,
 								},
-								Sum: &wrappers.DoubleValue{
+								Sum: &wrapperspb.DoubleValue{
 									Value: 15,
 								},
 								Snapshot: &ocmetrics.SummaryValue_Snapshot{
@@ -478,7 +478,7 @@ func generateResourceWithOcNodeAndResource() pdata.Resource {
 }
 
 func generateOcNode() *occommon.Node {
-	ts := internal.TimeToTimestamp(time.Date(2020, 2, 11, 20, 26, 0, 0, time.UTC))
+	ts := timestamppb.New(time.Date(2020, 2, 11, 20, 26, 0, 0, time.UTC))
 
 	return &occommon.Node{
 		Identifier: &occommon.ProcessIdentifier{

--- a/translator/internaldata/oc_to_resource.go
+++ b/translator/internaldata/oc_to_resource.go
@@ -15,9 +15,10 @@
 package internaldata
 
 import (
+	"time"
+
 	occommon "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
 	ocresource "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
-	"github.com/golang/protobuf/ptypes"
 
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/translator/conventions"
@@ -79,7 +80,7 @@ func ocNodeResourceToInternal(ocNode *occommon.Node, ocResource *ocresource.Reso
 		}
 		if ocNode.Identifier != nil {
 			if ocNode.Identifier.StartTimestamp != nil {
-				attrs.UpsertString(conventions.OCAttributeProcessStartTime, ptypes.TimestampString(ocNode.Identifier.StartTimestamp))
+				attrs.UpsertString(conventions.OCAttributeProcessStartTime, ocNode.Identifier.StartTimestamp.AsTime().Format(time.RFC3339Nano))
 			}
 			if ocNode.Identifier.HostName != "" {
 				attrs.UpsertString(conventions.AttributeHostHostname, ocNode.Identifier.HostName)

--- a/translator/internaldata/oc_to_traces_test.go
+++ b/translator/internaldata/oc_to_traces_test.go
@@ -21,13 +21,12 @@ import (
 	occommon "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
 	ocresource "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
 	octrace "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
-	"github.com/golang/protobuf/ptypes"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"go.opentelemetry.io/collector/consumer/consumerdata"
 	"go.opentelemetry.io/collector/consumer/pdata"
-	"go.opentelemetry.io/collector/internal"
 	otlptrace "go.opentelemetry.io/collector/internal/data/opentelemetry-proto-gen/trace/v1"
 	"go.opentelemetry.io/collector/internal/data/testdata"
 )
@@ -205,12 +204,9 @@ func TestOcToInternal(t *testing.T) {
 	ocResource1 := &ocresource.Resource{Labels: map[string]string{"resource-attr": "resource-attr-val-1"}}
 	ocResource2 := &ocresource.Resource{Labels: map[string]string{"resource-attr": "resource-attr-val-2"}}
 
-	startTime, err := ptypes.TimestampProto(testdata.TestSpanStartTime)
-	assert.NoError(t, err)
-	eventTime, err := ptypes.TimestampProto(testdata.TestSpanEventTime)
-	assert.NoError(t, err)
-	endTime, err := ptypes.TimestampProto(testdata.TestSpanEndTime)
-	assert.NoError(t, err)
+	startTime := timestamppb.New(testdata.TestSpanStartTime)
+	eventTime := timestamppb.New(testdata.TestSpanEventTime)
+	endTime := timestamppb.New(testdata.TestSpanEndTime)
 
 	ocSpan1 := &octrace.Span{
 		Name:      &octrace.TruncatableString{Value: "operationA"},
@@ -458,8 +454,8 @@ func wrapTraceWithEmptyResource(td pdata.Traces) pdata.Traces {
 }
 
 func generateSpanWithAttributes(len int) *octrace.Span {
-	startTime := internal.TimeToTimestamp(testdata.TestSpanStartTime)
-	endTime := internal.TimeToTimestamp(testdata.TestSpanEndTime)
+	startTime := timestamppb.New(testdata.TestSpanStartTime)
+	endTime := timestamppb.New(testdata.TestSpanEndTime)
 	ocSpan2 := &octrace.Span{
 		Name:      &octrace.TruncatableString{Value: "operationB"},
 		StartTime: startTime,

--- a/translator/internaldata/resource_to_oc.go
+++ b/translator/internaldata/resource_to_oc.go
@@ -22,8 +22,8 @@ import (
 
 	occommon "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
 	ocresource "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
-	"github.com/golang/protobuf/ptypes"
 	"go.opencensus.io/resource/resourcekeys"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/translator/conventions"
@@ -92,10 +92,7 @@ func internalResourceToOC(resource pdata.Resource) (*occommon.Node, *ocresource.
 			if err != nil {
 				return
 			}
-			ts, err := ptypes.TimestampProto(t)
-			if err != nil {
-				return
-			}
+			ts := timestamppb.New(t)
 			if ocNode.Identifier == nil {
 				ocNode.Identifier = &occommon.ProcessIdentifier{}
 			}

--- a/translator/internaldata/traces_to_oc_test.go
+++ b/translator/internaldata/traces_to_oc_test.go
@@ -20,8 +20,8 @@ import (
 	occommon "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
 	ocresource "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
 	octrace "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
-	"github.com/golang/protobuf/ptypes"
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"go.opentelemetry.io/collector/consumer/consumerdata"
 	"go.opentelemetry.io/collector/consumer/pdata"
@@ -194,12 +194,9 @@ func TestInternalToOC(t *testing.T) {
 	ocResource1 := &ocresource.Resource{Labels: map[string]string{"resource-attr": "resource-attr-val-1"}}
 	ocResource2 := &ocresource.Resource{Labels: map[string]string{"resource-attr": "resource-attr-val-2"}}
 
-	startTime, err := ptypes.TimestampProto(testdata.TestSpanStartTime)
-	assert.NoError(t, err)
-	eventTime, err := ptypes.TimestampProto(testdata.TestSpanEventTime)
-	assert.NoError(t, err)
-	endTime, err := ptypes.TimestampProto(testdata.TestSpanEndTime)
-	assert.NoError(t, err)
+	startTime := timestamppb.New(testdata.TestSpanStartTime)
+	eventTime := timestamppb.New(testdata.TestSpanEventTime)
+	endTime := timestamppb.New(testdata.TestSpanEndTime)
 
 	ocSpan1 := &octrace.Span{
 		Name:      &octrace.TruncatableString{Value: "operationA"},

--- a/translator/trace/zipkin/zipkinv1_thrift_to_protospan.go
+++ b/translator/trace/zipkin/zipkinv1_thrift_to_protospan.go
@@ -23,9 +23,9 @@ import (
 	"net"
 
 	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
-	"github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/jaegertracing/jaeger/thrift-gen/zipkincore"
 	"github.com/pkg/errors"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"go.opentelemetry.io/collector/consumer/consumerdata"
 	tracetranslator "go.opentelemetry.io/collector/translator/trace"
@@ -69,7 +69,7 @@ func zipkinV1ThriftToOCSpan(zSpan *zipkincore.Span) (*tracepb.Span, *annotationP
 		parsedAnnotations.Endpoint.ServiceName = localComponent
 	}
 
-	var startTime, endTime *timestamp.Timestamp
+	var startTime, endTime *timestamppb.Timestamp
 	if zSpan.Timestamp == nil {
 		startTime = parsedAnnotations.EarlyAnnotationTime
 		endTime = parsedAnnotations.LateAnnotationTime

--- a/translator/trace/zipkin/zipkinv1_to_protospan_test.go
+++ b/translator/trace/zipkin/zipkinv1_to_protospan_test.go
@@ -25,15 +25,14 @@ import (
 
 	commonpb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
 	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
-	"github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/google/go-cmp/cmp"
 	zipkinmodel "github.com/openzipkin/zipkin-go/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"go.opentelemetry.io/collector/consumer/consumerdata"
-	"go.opentelemetry.io/collector/internal"
 	tracetranslator "go.opentelemetry.io/collector/translator/trace"
 )
 
@@ -542,7 +541,7 @@ func TestSpanWithoutTimestampGetsTag(t *testing.T) {
 	assert.NotNil(t, gs.StartTime)
 	assert.NotNil(t, gs.EndTime)
 
-	assert.True(t, internal.TimestampToTime(gs.StartTime).Sub(testStart) >= 0)
+	assert.True(t, gs.StartTime.AsTime().Sub(testStart) >= 0)
 
 	wantAttributes := &tracepb.Span_Attributes{
 		AttributeMap: map[string]*tracepb.AttributeValue{
@@ -602,8 +601,8 @@ var ocBatchesFromZipkinV1 = []consumerdata.TraceData{
 				ParentSpanId: nil,
 				Name:         &tracepb.TruncatableString{Value: "checkAvailability"},
 				Kind:         tracepb.Span_CLIENT,
-				StartTime:    &timestamp.Timestamp{Seconds: 1544805927, Nanos: 446743000},
-				EndTime:      &timestamp.Timestamp{Seconds: 1544805927, Nanos: 459699000},
+				StartTime:    &timestamppb.Timestamp{Seconds: 1544805927, Nanos: 446743000},
+				EndTime:      &timestamppb.Timestamp{Seconds: 1544805927, Nanos: 459699000},
 				TimeEvents:   nil,
 			},
 		},
@@ -620,12 +619,12 @@ var ocBatchesFromZipkinV1 = []consumerdata.TraceData{
 				ParentSpanId: nil,
 				Name:         &tracepb.TruncatableString{Value: "checkAvailability"},
 				Kind:         tracepb.Span_SERVER,
-				StartTime:    &timestamp.Timestamp{Seconds: 1544805927, Nanos: 448081000},
-				EndTime:      &timestamp.Timestamp{Seconds: 1544805927, Nanos: 460102000},
+				StartTime:    &timestamppb.Timestamp{Seconds: 1544805927, Nanos: 448081000},
+				EndTime:      &timestamppb.Timestamp{Seconds: 1544805927, Nanos: 460102000},
 				TimeEvents: &tracepb.Span_TimeEvents{
 					TimeEvent: []*tracepb.Span_TimeEvent{
 						{
-							Time: &timestamp.Timestamp{Seconds: 1544805927, Nanos: 450000000},
+							Time: &timestamppb.Timestamp{Seconds: 1544805927, Nanos: 450000000},
 							Value: &tracepb.Span_TimeEvent_Annotation_{
 								Annotation: &tracepb.Span_TimeEvent_Annotation{
 									Description: &tracepb.TruncatableString{Value: "custom time event"},
@@ -641,8 +640,8 @@ var ocBatchesFromZipkinV1 = []consumerdata.TraceData{
 				ParentSpanId: []byte{0x0e, 0xd2, 0xe6, 0x3c, 0xbe, 0x71, 0xf5, 0xa8},
 				Name:         &tracepb.TruncatableString{Value: "checkStock"},
 				Kind:         tracepb.Span_CLIENT,
-				StartTime:    &timestamp.Timestamp{Seconds: 1544805927, Nanos: 453923000},
-				EndTime:      &timestamp.Timestamp{Seconds: 1544805927, Nanos: 457663000},
+				StartTime:    &timestamppb.Timestamp{Seconds: 1544805927, Nanos: 453923000},
+				EndTime:      &timestamppb.Timestamp{Seconds: 1544805927, Nanos: 457663000},
 				TimeEvents:   nil,
 			},
 		},
@@ -659,8 +658,8 @@ var ocBatchesFromZipkinV1 = []consumerdata.TraceData{
 				ParentSpanId: []byte{0x0e, 0xd2, 0xe6, 0x3c, 0xbe, 0x71, 0xf5, 0xa8},
 				Name:         &tracepb.TruncatableString{Value: "checkStock"},
 				Kind:         tracepb.Span_SERVER,
-				StartTime:    &timestamp.Timestamp{Seconds: 1544805927, Nanos: 454487000},
-				EndTime:      &timestamp.Timestamp{Seconds: 1544805927, Nanos: 457320000},
+				StartTime:    &timestamppb.Timestamp{Seconds: 1544805927, Nanos: 454487000},
+				EndTime:      &timestamppb.Timestamp{Seconds: 1544805927, Nanos: 457320000},
 				Status: &tracepb.Status{
 					Code: 0,
 				},
@@ -692,8 +691,8 @@ var ocBatchesFromZipkinV1 = []consumerdata.TraceData{
 				ParentSpanId: []byte{0x0e, 0xd2, 0xe6, 0x3c, 0xbe, 0x71, 0xf5, 0xa8},
 				Name:         &tracepb.TruncatableString{Value: "checkStock"},
 				Kind:         tracepb.Span_SPAN_KIND_UNSPECIFIED,
-				StartTime:    &timestamp.Timestamp{Seconds: 1544805927, Nanos: 453923000},
-				EndTime:      &timestamp.Timestamp{Seconds: 1544805927, Nanos: 457663000},
+				StartTime:    &timestamppb.Timestamp{Seconds: 1544805927, Nanos: 453923000},
+				EndTime:      &timestamppb.Timestamp{Seconds: 1544805927, Nanos: 457663000},
 				Attributes:   nil,
 			},
 		},


### PR DESCRIPTION
The module "github.com/golang/protobuf" was deprecated and replaced by the "google.golang.org/protobuf".
