### PR TITLE
Fix OTLP receiver configuration in examples

### DIFF
--- a/examples/k8s.yaml
+++ b/examples/k8s.yaml
@@ -9,7 +9,10 @@ metadata:
 data:
   otel-agent-config: |
     receivers:
-      otlp: {}
+      otlp:
+        protocols:
+          grpc:
+          http:
     exporters:
       otlp:
         endpoint: "otel-collector.default:55680" # TODO: Update me
@@ -105,7 +108,10 @@ metadata:
 data:
   otel-collector-config: |
     receivers:
-      otlp: {}
+      otlp:
+        protocols:
+          grpc:
+          http:
       jaeger:
         protocols:
           grpc:


### PR DESCRIPTION
Currently containers are failing with: "Error: cannot load configuration: error reading receivers configuration for otlp: empty config for OTLP receiver"
