### PR TITLE
Do not duplicate filesystem metrics for devices with many mount points.

### DIFF
--- a/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/filesystem_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/filesystem_scraper.go
@@ -91,6 +91,11 @@ func (s *scraper) ScrapeMetrics(_ context.Context) (pdata.MetricSlice, error) {
 	var errors []error
 	usages := make([]*deviceUsage, 0, len(partitions))
 	for _, partition := range partitions {
+		// Skip partition stats having more than one mount point for the same device
+		if deviceUsageAlreadySet(partition.Device, usages) {
+			continue
+		}
+
 		usage, err := s.usage(partition.Mountpoint)
 		if err != nil {
 			errors = append(errors, err)
@@ -111,6 +116,15 @@ func (s *scraper) ScrapeMetrics(_ context.Context) (pdata.MetricSlice, error) {
 	}
 
 	return metrics, componenterror.CombineErrors(errors)
+}
+
+func deviceUsageAlreadySet(device string, usages []*deviceUsage) bool {
+	for _, usage := range usages {
+		if device == usage.deviceName {
+			return true
+		}
+	}
+	return false
 }
 
 func initializeFileSystemUsageMetric(metric pdata.Metric, now pdata.TimestampUnixNano, deviceUsages []*deviceUsage) {

--- a/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/filesystem_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/filesystem_scraper_test.go
@@ -59,6 +59,20 @@ func TestScrapeMetrics(t *testing.T) {
 			expectedDeviceDataPoints: 1,
 		},
 		{
+			name: "No duplicate metrics for devices having many mount point",
+			partitionsFunc: func(bool) ([]disk.PartitionStat, error) {
+				return []disk.PartitionStat{
+					{Device: "a", Mountpoint: "/mnt/a1"},
+					{Device: "a", Mountpoint: "/mnt/a2"},
+				}, nil
+			},
+			usageFunc: func(string) (*disk.UsageStat, error) {
+				return &disk.UsageStat{}, nil
+			},
+			expectMetrics:            true,
+			expectedDeviceDataPoints: 1,
+		},
+		{
 			name:          "Include Filter that matches nothing",
 			config:        Config{Include: MatchConfig{filterset.Config{MatchType: "strict"}, []string{"@*^#&*$^#)"}}},
 			expectMetrics: false,


### PR DESCRIPTION
**Description:**
This PR fixes a bug that produces duplicate "filesystem" metric data points for linux devices that have more than one data point. For example:
```
{"device":"/dev/vda1","mountpoint":"/etc/resolv.conf","fstype":"ext4","opts":"rw,relatime"}
{"device":"/dev/vda1","mountpoint":"/etc/hostname","fstype":"ext4","opts":"rw,relatime"}
{"device":"/dev/vda1","mountpoint":"/etc/hosts","fstype":"ext4","opts":"rw,relatime"}
```

**Resolves:** https://github.com/open-telemetry/opentelemetry-collector/issues/1615

**Testing:** Added a unit test.
