### PR TITLE
Handle translation of OC span.kind attribute for client/server

### DIFF
--- a/translator/internaldata/oc_to_traces.go
+++ b/translator/internaldata/oc_to_traces.go
@@ -249,6 +249,10 @@ func ocSpanKindToInternal(ocKind octrace.Span_SpanKind, ocAttrs *octrace.Span_At
 				if ok && strVal != nil {
 					var otlpKind pdata.SpanKind
 					switch tracetranslator.OpenTracingSpanKind(strVal.StringValue.GetValue()) {
+					case tracetranslator.OpenTracingSpanKindClient:
+						otlpKind = pdata.SpanKindCLIENT
+					case tracetranslator.OpenTracingSpanKindServer:
+						otlpKind = pdata.SpanKindSERVER
 					case tracetranslator.OpenTracingSpanKindConsumer:
 						otlpKind = pdata.SpanKindCONSUMER
 					case tracetranslator.OpenTracingSpanKindProducer:

--- a/translator/internaldata/oc_to_traces_test.go
+++ b/translator/internaldata/oc_to_traces_test.go
@@ -165,6 +165,26 @@ func TestOcSpanKindToInternal(t *testing.T) {
 			ocKind: octrace.Span_SPAN_KIND_UNSPECIFIED,
 			ocAttrs: &octrace.Span_Attributes{
 				AttributeMap: map[string]*octrace.AttributeValue{
+					"span.kind": {Value: &octrace.AttributeValue_StringValue{
+						StringValue: &octrace.TruncatableString{Value: "client"}}},
+				},
+			},
+			otlpKind: otlptrace.Span_CLIENT,
+		},
+		{
+			ocKind: octrace.Span_SPAN_KIND_UNSPECIFIED,
+			ocAttrs: &octrace.Span_Attributes{
+				AttributeMap: map[string]*octrace.AttributeValue{
+					"span.kind": {Value: &octrace.AttributeValue_StringValue{
+						StringValue: &octrace.TruncatableString{Value: "server"}}},
+				},
+			},
+			otlpKind: otlptrace.Span_SERVER,
+		},
+		{
+			ocKind: octrace.Span_SPAN_KIND_UNSPECIFIED,
+			ocAttrs: &octrace.Span_Attributes{
+				AttributeMap: map[string]*octrace.AttributeValue{
 					"span.kind": {Value: &octrace.AttributeValue_IntValue{
 						IntValue: 123}},
 				},


### PR DESCRIPTION
Signed-off-by: Gary Brown <gary@brownuk.com>

**Description:** 
Currently OpenCensus seems to allow span kind to be reported via a field (only `client` and `server` values) or an attribute (only `consumer` and `producer` values).

This PR extends support for handling `client` and `server` values via the attribute. This additional flexibility will enable Envoy (using the current C++ opencensus client with no span kind field support) to report the span kind value.

**Link to tracking Issue:** <Issue number if applicable>
Fixes #1608 

**Testing:**
Unit test.

**Documentation:**