### PR TITLE
Support set flag for component configs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,6 +47,7 @@ require (
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	github.com/spf13/cast v1.3.1
 	github.com/spf13/cobra v1.0.0
+	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.7.1
 	github.com/stretchr/testify v1.6.1
 	github.com/tcnksm/ghr v0.13.0

--- a/service/service.go
+++ b/service/service.go
@@ -119,14 +119,13 @@ func FileLoaderConfigFactory(v *viper.Viper, cmd *cobra.Command, factories compo
 	if file == "" {
 		return nil, errors.New("config file not specified")
 	}
-	viperFile := config.NewViper()
-	viperFile.SetConfigFile(file)
-	err := viperFile.ReadInConfig()
+	v.SetConfigFile(file)
+	err := v.ReadInConfig()
 	if err != nil {
 		return nil, fmt.Errorf("error loading config file %q: %v", file, err)
 	}
-	for _, k := range viperFile.AllKeys() {
-		v.Set(k, viperFile.Get(k))
+	for _, k := range v.AllKeys() {
+		v.Set(k, v.Get(k))
 	}
 
 	// handle --set flag and override properties from the configuration file

--- a/service/service.go
+++ b/service/service.go
@@ -104,13 +104,15 @@ type Parameters struct {
 	ApplicationStartInfo component.ApplicationStartInfo
 	// ConfigFactory that creates the configuration.
 	// If it is not provided the default factory (FileLoaderConfigFactory) is used.
-	// The default factory loads the configuration specified as a command line flag.
+	// The default factory loads the configuration file and overrides component's configuration
+	// properties supplied via --set flag..
 	ConfigFactory ConfigFactory
 	// LoggingHooks provides a way to supply a hook into logging events
 	LoggingHooks []func(zapcore.Entry) error
 }
 
 // ConfigFactory creates config.
+// The ConfigFactory implementation should call AddSetFlagProperties to enable configuration passed via `--set` flag.
 type ConfigFactory func(v *viper.Viper, cmd *cobra.Command, factories component.Factories) (*configmodels.Config, error)
 
 // FileLoaderConfigFactory implements ConfigFactory and it creates configuration from file.
@@ -129,7 +131,7 @@ func FileLoaderConfigFactory(v *viper.Viper, cmd *cobra.Command, factories compo
 	}
 
 	// handle --set flag and override properties from the configuration file
-	if err := addSetFlagProperties(v, cmd); err != nil {
+	if err := AddSetFlagProperties(v, cmd); err != nil {
 		return nil, fmt.Errorf("failed to process set flag: %v", err)
 	}
 	return config.Load(v, factories)

--- a/service/service.go
+++ b/service/service.go
@@ -119,15 +119,14 @@ func FileLoaderConfigFactory(v *viper.Viper, cmd *cobra.Command, factories compo
 	if file == "" {
 		return nil, errors.New("config file not specified")
 	}
-	v.SetConfigFile(file)
-	err := v.ReadInConfig()
+	viperFile := config.NewViper()
+	viperFile.SetConfigFile(file)
+	err := viperFile.ReadInConfig()
 	if err != nil {
 		return nil, fmt.Errorf("error loading config file %q: %v", file, err)
 	}
-
-	all := v.AllSettings()
-	for key, value := range all {
-		v.Set(key, value)
+	for _, k := range viperFile.AllKeys() {
+		v.Set(k, viperFile.Get(k))
 	}
 
 	// handle --set flag and override properties from the configuration file

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -19,15 +19,22 @@ import (
 	"bufio"
 	"context"
 	"errors"
+	"flag"
 	"fmt"
+	"go.opentelemetry.io/collector/processor/attributesprocessor"
+	"go.opentelemetry.io/collector/processor/batchprocessor"
+	"go.opentelemetry.io/collector/receiver/jaegerreceiver"
+	"go.opentelemetry.io/collector/service/builder"
 	"net/http"
 	"sort"
 	"strconv"
 	"strings"
 	"syscall"
 	"testing"
+	"time"
 
 	"github.com/prometheus/common/expfmt"
+	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -137,7 +144,7 @@ func TestApplication_StartAsGoRoutine(t *testing.T) {
 
 	params := Parameters{
 		ApplicationStartInfo: componenttest.TestApplicationStartInfo(),
-		ConfigFactory: func(v *viper.Viper, factories component.Factories) (*configmodels.Config, error) {
+		ConfigFactory: func(v *viper.Viper, command *cobra.Command, factories component.Factories) (*configmodels.Config, error) {
 			return constructMimumalOpConfig(t, factories), nil
 		},
 		Factories: factories,
@@ -412,7 +419,7 @@ func createExampleApplication(t *testing.T) *Application {
 
 	app, err := New(Parameters{
 		Factories: factories,
-		ConfigFactory: func(v *viper.Viper, factories component.Factories) (c *configmodels.Config, err error) {
+		ConfigFactory: func(v *viper.Viper, cmd *cobra.Command, factories component.Factories) (c *configmodels.Config, err error) {
 			config := &configmodels.Config{
 				Receivers: map[string]configmodels.Receiver{
 					string(exampleReceiverFactory.Type()): exampleReceiverFactory.CreateDefaultConfig(),
@@ -510,6 +517,96 @@ func TestApplication_GetExporters(t *testing.T) {
 	close(app.stopTestChan)
 	<-appDone
 }
+
+func TestSetFlag(t *testing.T) {
+	factories, err := defaultcomponents.Components()
+	require.NoError(t, err)
+	params := Parameters{
+		Factories: factories,
+	}
+	t.Run("unknown_component", func(t *testing.T) {
+		app, err := New(params)
+		require.NoError(t, err)
+		err = app.rootCmd.ParseFlags([]string{
+			"--config=testdata/otelcol-config.yaml",
+			"--set=processors.doesnotexist.timeout=2s",
+		})
+		require.NoError(t, err)
+		cfg, err := FileLoaderConfigFactory(app.v, app.rootCmd, factories)
+		require.Error(t, err)
+		require.Nil(t, cfg)
+	})
+	t.Run("unknown_component_instance", func(t *testing.T) {
+		app, err := New(params)
+		require.NoError(t, err)
+		err = app.rootCmd.ParseFlags([]string{
+			"--config=testdata/otelcol-config.yaml",
+			"--set=processors.batch/foo.timeout=2s",
+		})
+		require.NoError(t, err)
+		cfg, err := FileLoaderConfigFactory(app.v, app.rootCmd, factories)
+		require.NoError(t, err)
+		assert.NotNil(t, cfg)
+
+		err = config.ValidateConfig(cfg, zap.NewNop())
+		require.Error(t, err)
+	})
+	t.Run("ok", func(t *testing.T) {
+		app, err := New(params)
+		require.NoError(t, err)
+
+		err = app.rootCmd.ParseFlags([]string{
+			"--config=testdata/otelcol-config.yaml",
+			"--set=processors.batch.timeout=2s",
+			// Arrays are overridden and object arrays cannot be indexed
+			// this creates actions array of size 1
+			"--set=processors.attributes.actions.key=foo",
+			"--set=processors.attributes.actions.value=bar",
+			"--set=receivers.jaeger.protocols.grpc.endpoint=localhost:12345",
+			"--set=extensions.health_check.port=8080",
+		})
+		require.NoError(t, err)
+		cfg, err := FileLoaderConfigFactory(app.v, app.rootCmd, factories)
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+
+		assert.Equal(t, 3, len(cfg.Processors))
+		batch := cfg.Processors["batch"].(*batchprocessor.Config)
+		assert.Equal(t, time.Second*2, batch.Timeout)
+		jaeger := cfg.Receivers["jaeger"].(*jaegerreceiver.Config)
+		assert.Equal(t, "localhost:12345", jaeger.GRPC.NetAddr.Endpoint)
+		attributes := cfg.Processors["attributes"].(*attributesprocessor.Config)
+		require.Equal(t, 1, len(attributes.Actions))
+		assert.Equal(t, "foo", attributes.Actions[0].Key)
+		assert.Equal(t, "bar", attributes.Actions[0].Value)
+	})
+
+}
+
+func TestSetFlag_component_does_not_exist(t *testing.T) {
+	factories, err := defaultcomponents.Components()
+	require.NoError(t, err)
+
+	v := config.NewViper()
+	cmd := &cobra.Command{}
+	addSetFlag(cmd.Flags())
+	fs := &flag.FlagSet{}
+	builder.Flags(fs)
+	cmd.Flags().AddGoFlagSet(fs)
+	cmd.ParseFlags([]string{
+		"--config=testdata/otelcol-config.yaml",
+		"--set=processors.batch.timeout=2s",
+		// Arrays are overridden and object arrays cannot be indexed
+		// this creates actions array of size 1
+		"--set=processors.attributes.actions.key=foo",
+		"--set=processors.attributes.actions.value=bar",
+		"--set=receivers.jaeger.protocols.grpc.endpoint=localhost:12345",
+	})
+	cfg, err := FileLoaderConfigFactory(v, cmd, factories)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+}
+
 
 func constructMimumalOpConfig(t *testing.T, factories component.Factories) *configmodels.Config {
 	configStr := `

--- a/service/set_flag.go
+++ b/service/set_flag.go
@@ -32,7 +32,7 @@ const (
 )
 
 func addSetFlag(flagSet *pflag.FlagSet) {
-	flagSet.StringArray(setFlagName, []string{}, "Set arbitrary component config property. The component has to be defined in the config file. The flag has a higher precedence over config file. The arrays are overridden. Example --set=processors.batch.timeout=2s")
+	flagSet.StringArray(setFlagName, []string{}, "Set arbitrary component config property. The component has to be defined in the config file and the flag has a higher precedence over config file. Arrays config properties are overridden and maps are joined, note that only a single (first) array property can be set e.g. -set=processors.attributes.actions.key=some_key. Example --set=processors.batch.timeout=2s")
 }
 
 // AddSetFlagProperties overrides properties from set flag(s) in supplied viper instance.
@@ -59,6 +59,8 @@ func AddSetFlagProperties(v *viper.Viper, cmd *cobra.Command) error {
 		return fmt.Errorf("failed to read set flag config: %v", err)
 	}
 
+	// flagProperties cannot be applied to v directly because
+	// v.MergeConfig(io.Reader) or v.MergeConfigMap(map[string]interface) does not work properly.
 	for _, k := range viperFlags.AllKeys() {
 		v.Set(k, viperFlags.Get(k))
 	}

--- a/service/set_flag.go
+++ b/service/set_flag.go
@@ -32,7 +32,7 @@ const (
 )
 
 func addSetFlag(flagSet *pflag.FlagSet) {
-	flagSet.StringArray(setFlagName, []string{}, "Set arbitrary component config property. The component has to be defined in the config file and the flag has a higher precedence over config file. Arrays config properties are overridden and maps are joined, note that only a single (first) array property can be set e.g. -set=processors.attributes.actions.key=some_key. Example --set=processors.batch.timeout=2s")
+	flagSet.StringArray(setFlagName, []string{}, "Set arbitrary component config property. The component has to be defined in the config file and the flag has a higher precedence. Array config properties are overridden and maps are joined, note that only a single (first) array property can be set e.g. -set=processors.attributes.actions.key=some_key. Example --set=processors.batch.timeout=2s")
 }
 
 // AddSetFlagProperties overrides properties from set flag(s) in supplied viper instance.

--- a/service/set_flag.go
+++ b/service/set_flag.go
@@ -35,9 +35,10 @@ func addSetFlag(flagSet *pflag.FlagSet) {
 	flagSet.StringArray(setFlagName, []string{}, "Set arbitrary component config property. The component has to be defined in the config file. The flag has a higher precedence over config file. The arrays are overridden. Example --set=processors.batch.timeout=2s")
 }
 
-// addSetFlagProperties sets/overrides properties from set flag(s) to supplied viper instance.
-// The implementation reads set flag(s) from the cmd and passes the content to viper as .properties file.
-func addSetFlagProperties(v *viper.Viper, cmd *cobra.Command) error {
+// AddSetFlagProperties overrides properties from set flag(s) in supplied viper instance.
+// The implementation reads set flag(s) from the cmd and passes the content to a new viper instance as .properties file.
+// Then the properties from new viper instance are read and set to the supplied viper.
+func AddSetFlagProperties(v *viper.Viper, cmd *cobra.Command) error {
 	flagProperties, err := cmd.Flags().GetStringArray(setFlagName)
 	if err != nil {
 		return err

--- a/service/set_flag.go
+++ b/service/set_flag.go
@@ -1,0 +1,65 @@
+// Copyright  The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+
+	"go.opentelemetry.io/collector/config"
+)
+
+const (
+	setFlagName = "set"
+	setFlagFileType = "properties"
+)
+
+func addSetFlag(flagSet *pflag.FlagSet) {
+	flagSet.StringArray(setFlagName, []string{}, "Set arbitrary component config property. The component has to be defined in the config file. The flag has a higher precedence over config file. The arrays are overridden. Example --set=processors.batch.timeout=2s")
+}
+
+// addSetFlagProperties sets/overrides properties from set flag(s) to supplied viper instance.
+// The implementation reads set flag(s) from the cmd and passes the content to viper as .properties file.
+func addSetFlagProperties(v *viper.Viper, cmd *cobra.Command) error {
+	flagProperties, err := cmd.Flags().GetStringArray(setFlagName)
+	if err != nil {
+		return err
+	}
+	if len(flagProperties) == 0 {
+		return nil
+	}
+	b := &bytes.Buffer{}
+	for _, property := range flagProperties {
+		property = strings.TrimSpace(property)
+		if _, err := fmt.Fprintf(b, "%s\n", property); err != nil {
+			return err
+		}
+	}
+	viperFlags := config.NewViper()
+	viperFlags.SetConfigType(setFlagFileType)
+	if err := viperFlags.ReadConfig(b); err != nil {
+		return fmt.Errorf("failed to read set flag config: %v", err)
+	}
+
+	for key, value := range viperFlags.AllSettings() {
+		v.Set(key, value)
+	}
+	return nil
+}

--- a/service/set_flag.go
+++ b/service/set_flag.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	setFlagName = "set"
+	setFlagName     = "set"
 	setFlagFileType = "properties"
 )
 
@@ -58,8 +58,8 @@ func addSetFlagProperties(v *viper.Viper, cmd *cobra.Command) error {
 		return fmt.Errorf("failed to read set flag config: %v", err)
 	}
 
-	for key, value := range viperFlags.AllSettings() {
-		v.Set(key, value)
+	for _, k := range viperFlags.AllKeys() {
+		v.Set(k, viperFlags.Get(k))
 	}
 	return nil
 }

--- a/service/set_flag_test.go
+++ b/service/set_flag_test.go
@@ -41,11 +41,11 @@ func TestSetFlags(t *testing.T) {
 	require.NoError(t, err)
 
 	settings := v.AllSettings()
-	assert.Equal(t, 3, len(settings))
-	assert.Equal(t, "2s", v.Get("processors.batch.timeout"))
-	assert.Equal(t, "3s", v.Get("processors.batch/foo.timeout"))
-	assert.Equal(t, "foo:9200,foo2:9200", v.Get("exporters.kafka.brokers"))
-	assert.Equal(t, "localhost:1818", v.Get("receivers.otlp.protocols.grpc.endpoint"))
+	assert.Equal(t, 4, len(settings))
+	assert.Equal(t, "2s", v.Get("processors::batch::timeout"))
+	assert.Equal(t, "3s", v.Get("processors::batch/foo::timeout"))
+	assert.Equal(t, "foo:9200,foo2:9200", v.Get("exporters::kafka::brokers"))
+	assert.Equal(t, "localhost:1818", v.Get("receivers::otlp::protocols::grpc::endpoint"))
 }
 
 func TestSetFlags_empty(t *testing.T) {

--- a/service/set_flag_test.go
+++ b/service/set_flag_test.go
@@ -36,7 +36,6 @@ func TestSetFlags(t *testing.T) {
 	require.NoError(t, err)
 
 	v := viper.New()
-	require.Equal(t, 0, len(v.AllSettings()))
 	err = addSetFlagProperties(v, cmd)
 	require.NoError(t, err)
 
@@ -46,6 +45,13 @@ func TestSetFlags(t *testing.T) {
 	assert.Equal(t, "3s", v.Get("processors::batch/foo::timeout"))
 	assert.Equal(t, "foo:9200,foo2:9200", v.Get("exporters::kafka::brokers"))
 	assert.Equal(t, "localhost:1818", v.Get("receivers::otlp::protocols::grpc::endpoint"))
+}
+
+func TestSetFlags_err_set_flag(t *testing.T) {
+	cmd := &cobra.Command{}
+	v := viper.New()
+	err := addSetFlagProperties(v, cmd)
+	require.Error(t, err)
 }
 
 func TestSetFlags_empty(t *testing.T) {

--- a/service/set_flag_test.go
+++ b/service/set_flag_test.go
@@ -36,7 +36,7 @@ func TestSetFlags(t *testing.T) {
 	require.NoError(t, err)
 
 	v := viper.New()
-	err = addSetFlagProperties(v, cmd)
+	err = AddSetFlagProperties(v, cmd)
 	require.NoError(t, err)
 
 	settings := v.AllSettings()
@@ -50,7 +50,7 @@ func TestSetFlags(t *testing.T) {
 func TestSetFlags_err_set_flag(t *testing.T) {
 	cmd := &cobra.Command{}
 	v := viper.New()
-	err := addSetFlagProperties(v, cmd)
+	err := AddSetFlagProperties(v, cmd)
 	require.Error(t, err)
 }
 
@@ -58,7 +58,7 @@ func TestSetFlags_empty(t *testing.T) {
 	cmd := &cobra.Command{}
 	addSetFlag(cmd.Flags())
 	v := viper.New()
-	err := addSetFlagProperties(v, cmd)
+	err := AddSetFlagProperties(v, cmd)
 	require.NoError(t, err)
 	assert.Equal(t, 0, len(v.AllSettings()))
 }

--- a/service/set_flag_test.go
+++ b/service/set_flag_test.go
@@ -1,0 +1,58 @@
+// Copyright  The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetFlags(t *testing.T) {
+	cmd := &cobra.Command{}
+	addSetFlag(cmd.Flags())
+
+	err := cmd.ParseFlags([]string{
+		"--set=processors.batch.timeout=2s",
+		"--set=processors.batch/foo.timeout=3s",
+		"--set=receivers.otlp.protocols.grpc.endpoint=localhost:1818",
+		"--set=exporters.kafka.brokers=foo:9200,foo2:9200",
+	})
+	require.NoError(t, err)
+
+	v := viper.New()
+	require.Equal(t, 0, len(v.AllSettings()))
+	err = addSetFlagProperties(v, cmd)
+	require.NoError(t, err)
+
+	settings := v.AllSettings()
+	assert.Equal(t, 3, len(settings))
+	assert.Equal(t, "2s", v.Get("processors.batch.timeout"))
+	assert.Equal(t, "3s", v.Get("processors.batch/foo.timeout"))
+	assert.Equal(t, "foo:9200,foo2:9200", v.Get("exporters.kafka.brokers"))
+	assert.Equal(t, "localhost:1818", v.Get("receivers.otlp.protocols.grpc.endpoint"))
+}
+
+func TestSetFlags_empty(t *testing.T) {
+	cmd := &cobra.Command{}
+	addSetFlag(cmd.Flags())
+	v := viper.New()
+	err := addSetFlagProperties(v, cmd)
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(v.AllSettings()))
+}

--- a/testbed/testbed/otelcol_runner.go
+++ b/testbed/testbed/otelcol_runner.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"github.com/shirou/gopsutil/process"
+	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -106,7 +107,7 @@ func (ipp *InProcessCollector) Start(args StartParams) (receiverAddr string, err
 			Version:  version.Version,
 			GitHash:  version.GitHash,
 		},
-		ConfigFactory: func(v *viper.Viper, factories component.Factories) (*configmodels.Config, error) {
+		ConfigFactory: func(v *viper.Viper, cmd *cobra.Command, factories component.Factories) (*configmodels.Config, error) {
 			return ipp.config, nil
 		},
 		Factories: ipp.factories,


### PR DESCRIPTION
Signed-off-by: Pavol Loffay <ploffay@redhat.com>

Creating as a draft to collect feedback. Once we agree I will clean it and add tests.

**Description:** 

This patch adds support for configuring components (receivers, processors, exporters...) via `--set` flag. For example `--set=processors.batch.timeout=12s` or `--receivers.otlp.protocols.grpc.endpoint=123456`.

```
--set stringArray             Set arbitrary component config property. The flag has a higher precedence over config file. The arrays are overridden. Example --set=processors.batch.timeout=2s
```

- Flags have higher precedence than config file
- The component has to be defined in the config to apply the configuration otherwise the flag is noop e.g. `--set=processor.queued_retry.queue_size=15` is noop if the `queued_retry` is not defined.
- The named components work e.g. `--set=processors.batch/bar.timeout=3s`
- The maps are joined with the existing (file) config
- The arrays are overridden 
- The object arrays are more complicated - with flag it's possible to set only the first entry e.g. `--set=processors.resource.attributes.key=key2`


The implementation creates a new viper instance that is initialized with a temporary properties file that contains values passed via set flag. Then the new viper is used to apply changes to an existing configuration (loaded via the main config file). 


**Link to tracking Issue:** <Issue number if applicable>

Resolves #873 

**Testing:** < Describe what testing was performed and which tests were added.>

Tested locally
`RUN_CONFIG=config.yaml make run`

```yaml
receivers:
    otlp:
        protocols:
            grpc:

exporters:
    logging:
        logLevel: debug

processors:
    batch:

service:
  pipelines:
    traces:
      receivers: [otlp]
      processors: [batch]
      exporters: [logging]
```

**Documentation:** < Describe the documentation added.>

None