### PR TITLE
Add Prometheus Remote Write Exporter supporting Cortex - conversion and export for Histogram OTLP metrics

### DIFF
--- a/exporter/prometheusremotewriteexporter/helper.go
+++ b/exporter/prometheusremotewriteexporter/helper.go
@@ -30,6 +30,11 @@ import (
 
 const (
 	nameStr   = "__name__"
+	sumStr    = "_sum"
+	countStr  = "_count"
+	bucketStr = "_bucket"
+	leStr     = "le"
+	pInfStr   = "+Inf"
 	totalStr  = "total"
 	delimeter = "_"
 	keyStr    = "key"

--- a/exporter/prometheusremotewriteexporter/testutil_test.go
+++ b/exporter/prometheusremotewriteexporter/testutil_test.go
@@ -156,6 +156,25 @@ func getDoubleDataPoint(labels []*commonpb.StringKeyValue, value float64, ts uin
 	}
 }
 
+func getHistogramDataPoint(labels []*commonpb.StringKeyValue, ts uint64, sum float64, count uint64, bounds []float64, buckets []uint64) *otlp.HistogramDataPoint {
+	bks := []*otlp.HistogramDataPoint_Bucket{}
+	for _, c := range buckets {
+		bks = append(bks, &otlp.HistogramDataPoint_Bucket{
+			Count:    c,
+			Exemplar: nil,
+		})
+	}
+	return &otlp.HistogramDataPoint{
+		Labels:            labels,
+		StartTimeUnixNano: 0,
+		TimeUnixNano:      ts,
+		Count:             count,
+		Sum:               sum,
+		Buckets:           bks,
+		ExplicitBounds:    bounds,
+	}
+}
+
 // Prometheus TimeSeries
 func getPromLabels(lbs ...string) []prompb.Label {
 	pbLbs := prompb.Labels{
@@ -188,12 +207,11 @@ func getTimeSeries(labels []prompb.Label, samples ...prompb.Sample) *prompb.Time
 	}
 }
 
-//setCumulative is for creating the dataold.MetricData to test with
-func setTemporality(metricsData *dataold.MetricData, temp otlp.MetricDescriptor_Temporality) {
+func setCumulative(metricsData *dataold.MetricData) {
 	for _, r := range dataold.MetricDataToOtlp(*metricsData) {
 		for _, instMetrics := range r.InstrumentationLibraryMetrics {
 			for _, m := range instMetrics.Metrics {
-				m.MetricDescriptor.Temporality = temp
+				m.MetricDescriptor.Temporality = otlp.MetricDescriptor_CUMULATIVE
 			}
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,6 @@ require (
 	github.com/orijtech/prometheus-go-metrics-exporter v0.0.5
 	github.com/ory/go-acc v0.2.5
 	github.com/pavius/impi v0.0.3
-	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.7.1
 	github.com/prometheus/common v0.11.1
 	github.com/prometheus/prometheus v1.8.2-0.20200626085723-c448ada63d83

--- a/service/defaultcomponents/defaults.go
+++ b/service/defaultcomponents/defaults.go
@@ -25,6 +25,7 @@ import (
 	"go.opentelemetry.io/collector/exporter/opencensusexporter"
 	"go.opentelemetry.io/collector/exporter/otlpexporter"
 	"go.opentelemetry.io/collector/exporter/prometheusexporter"
+	"go.opentelemetry.io/collector/exporter/prometheusremotewriteexporter"
 	"go.opentelemetry.io/collector/exporter/zipkinexporter"
 	"go.opentelemetry.io/collector/extension/fluentbitextension"
 	"go.opentelemetry.io/collector/extension/healthcheckextension"
@@ -85,6 +86,7 @@ func Components() (
 	exporters, err := component.MakeExporterFactoryMap(
 		opencensusexporter.NewFactory(),
 		prometheusexporter.NewFactory(),
+		prometheusremotewriteexporter.NewFactory(),
 		loggingexporter.NewFactory(),
 		zipkinexporter.NewFactory(),
 		jaegerexporter.NewFactory(),

--- a/service/defaultcomponents/defaults_test.go
+++ b/service/defaultcomponents/defaults_test.go
@@ -57,6 +57,7 @@ func TestDefaultComponents(t *testing.T) {
 	expectedExporters := []configmodels.Type{
 		"opencensus",
 		"prometheus",
+		"prometheusremotewrite",
 		"logging",
 		"zipkin",
 		"jaeger",


### PR DESCRIPTION
This PR is part of a series of PRs implementing a Prometheus remote write exporter supporting Cortex. 
**See  related PR #1577**  

**Description:** This PR adds export support for histogram and summary metrics for Prometheus remote write [integrated backends](https://prometheus.io/docs/operating/integrations/#remote-endpoints-and-storage), such as Cortex. The exporter drops non-cumulative monotonic, histogram, and summary OTLP metrics.

Please note this metrics exporter does not support Prometheus default labels such as `job` or `instance` labels. An issue addressing Prometheus default labels will be filed later. Another related feature is to derive labels from a Resource. This functionality already exists in the Go SDK and will be implemented in another PR. This feature could allow users to specify which attributes they want to add as labels.

**Link to tracking Issue:**  #1150
Related issues are: 
Metrics aggregation proposal: #1422
Prometheus exporter not functional: #1255
Related spec discussion: [#731](https://github.com/open-telemetry/opentelemetry-specification/issues/731)

**Documentation:** 

* readme.md with sample configuration, file structure, and assumptions

* Design documentation: PR #1464

cc: @huyan0 @alolita @jmacd @bogdandrutu 