### PR TITLE
Support zipkin proto in Kafka receiver

### DIFF
--- a/receiver/kafkareceiver/README.md
+++ b/receiver/kafkareceiver/README.md
@@ -12,8 +12,9 @@ The following settings can be optionally configured:
   - `otlp_proto`: the payload is deserialized to `ExportTraceServiceRequest`.
   - `jaeger_proto`: the payload is deserialized to a single Jaeger proto `Span`.
   - `jaeger_json`: the payload is deserialized to a single Jaeger JSON Span using `jsonpb`.
-  - `zipkin_thrift`: the payload is deserialized into Zipkin Thrift spans.
+  - `zipkin_proto`: the payload is deserialized into Zipkin proto spans.
   - `zipkin_json`: the payload is deserialized into Zipkin V2 JSON spans.
+  - `zipkin_thrift`: the payload is deserialized into Zipkin Thrift spans.
 - `group_id` (default = otel-collector):  The consumer group that receiver will be consuming messages from
 - `client_id` (default = otel-collector): The consumer client ID that receiver will use
 - `metadata`

--- a/receiver/kafkareceiver/unmarshaller.go
+++ b/receiver/kafkareceiver/unmarshaller.go
@@ -32,12 +32,14 @@ func defaultUnmarshallers() map[string]Unmarshaller {
 	otlp := &otlpProtoUnmarshaller{}
 	jaegerProto := jaegerProtoSpanUnmarshaller{}
 	jaegerJSON := jaegerJSONSpanUnmarshaller{}
+	zipkinProto := zipkinProtoSpanUnmarshaller{}
 	zipkinJSON := zipkinJSONSpanUnmarshaller{}
 	zipkinThrift := zipkinThriftSpanUnmarshaller{}
 	return map[string]Unmarshaller{
 		otlp.Encoding():         otlp,
 		jaegerProto.Encoding():  jaegerProto,
 		jaegerJSON.Encoding():   jaegerJSON,
+		zipkinProto.Encoding():  zipkinProto,
 		zipkinJSON.Encoding():   zipkinJSON,
 		zipkinThrift.Encoding(): zipkinThrift,
 	}

--- a/receiver/kafkareceiver/unmarshaller_test.go
+++ b/receiver/kafkareceiver/unmarshaller_test.go
@@ -26,6 +26,7 @@ func TestDefaultUnMarshaller(t *testing.T) {
 		"otlp_proto",
 		"jaeger_proto",
 		"jaeger_json",
+		"zipkin_proto",
 		"zipkin_json",
 		"zipkin_thrift",
 	}

--- a/receiver/kafkareceiver/zipkin_unmarshaller.go
+++ b/receiver/kafkareceiver/zipkin_unmarshaller.go
@@ -34,7 +34,7 @@ var _ Unmarshaller = (*zipkinProtoSpanUnmarshaller)(nil)
 func (z zipkinProtoSpanUnmarshaller) Unmarshal(bytes []byte) (pdata.Traces, error) {
 	parseSpans, err := zipkinproto.ParseSpans(bytes, false)
 	if err != nil {
-		return pdata.Traces{}, err
+		return pdata.NewTraces(), err
 	}
 	return zipkintranslator.V2SpansToInternalTraces(parseSpans)
 }

--- a/receiver/kafkareceiver/zipkin_unmarshaller.go
+++ b/receiver/kafkareceiver/zipkin_unmarshaller.go
@@ -20,10 +20,28 @@ import (
 	"github.com/apache/thrift/lib/go/thrift"
 	"github.com/jaegertracing/jaeger/thrift-gen/zipkincore"
 	zipkinmodel "github.com/openzipkin/zipkin-go/model"
+	zipkinproto "github.com/openzipkin/zipkin-go/proto/v2"
 
 	"go.opentelemetry.io/collector/consumer/pdata"
 	zipkintranslator "go.opentelemetry.io/collector/translator/trace/zipkin"
 )
+
+type zipkinProtoSpanUnmarshaller struct {
+}
+
+var _ Unmarshaller = (*zipkinProtoSpanUnmarshaller)(nil)
+
+func (z zipkinProtoSpanUnmarshaller) Unmarshal(bytes []byte) (pdata.Traces, error) {
+	parseSpans, err := zipkinproto.ParseSpans(bytes, false)
+	if err != nil {
+		return pdata.Traces{}, err
+	}
+	return zipkintranslator.V2SpansToInternalTraces(parseSpans)
+}
+
+func (z zipkinProtoSpanUnmarshaller) Encoding() string {
+	return "zipkin_proto"
+}
 
 type zipkinJSONSpanUnmarshaller struct {
 }


### PR DESCRIPTION
Signed-off-by: Pavol Loffay <ploffay@redhat.com>

**Description:** 

Add support for Zipkin proto in Kafka receiver. 

Created from https://github.com/open-telemetry/opentelemetry-collector/pull/1584#issuecomment-679187515

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** < Describe what testing was performed and which tests were added.>

some unit tests

**Documentation:** < Describe the documentation added.>

Added to readme