### PR TITLE
translator/conventions: add deployment.environment

### DIFF
--- a/translator/conventions/opentelemetry.go
+++ b/translator/conventions/opentelemetry.go
@@ -67,6 +67,7 @@ const (
 	AttributeCloudAccount          = "cloud.account.id"
 	AttributeCloudRegion           = "cloud.region"
 	AttributeCloudZone             = "cloud.zone"
+	AttributeDeploymentEnvironment = "deployment.environment"
 )
 
 // GetResourceSemanticConventionAttributeNames a slice with all the Resource Semantic Conventions attribute names.
@@ -107,6 +108,7 @@ func GetResourceSemanticConventionAttributeNames() []string {
 		AttributeCloudAccount,
 		AttributeCloudRegion,
 		AttributeCloudZone,
+		AttributeDeploymentEnvironment,
 	}
 }
 


### PR DESCRIPTION
Add a constant for the recently introduced deployment environment resource attribute: https://github.com/open-telemetry/opentelemetry-specification/pull/606