### PR TITLE
Change batch processor to use the new internal metrics structs

### DIFF
--- a/processor/batchprocessor/batch_processor.go
+++ b/processor/batchprocessor/batch_processor.go
@@ -28,7 +28,7 @@ import (
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/consumer/pdatautil"
 	"go.opentelemetry.io/collector/internal/collector/telemetry"
-	"go.opentelemetry.io/collector/internal/dataold"
+	"go.opentelemetry.io/collector/internal/data"
 	"go.opentelemetry.io/collector/processor"
 )
 
@@ -236,7 +236,7 @@ func (bt *batchTraces) reset() {
 
 type batchMetrics struct {
 	nextConsumer consumer.MetricsConsumer
-	metricData   dataold.MetricData
+	metricData   data.MetricData
 	metricCount  uint32
 }
 
@@ -247,7 +247,7 @@ func newBatchMetrics(nextConsumer consumer.MetricsConsumer) *batchMetrics {
 }
 
 func (bm *batchMetrics) export(ctx context.Context) error {
-	return bm.nextConsumer.ConsumeMetrics(ctx, pdatautil.MetricsFromOldInternalMetrics(bm.metricData))
+	return bm.nextConsumer.ConsumeMetrics(ctx, pdatautil.MetricsFromInternalMetrics(bm.metricData))
 }
 
 func (bm *batchMetrics) itemCount() uint32 {
@@ -260,12 +260,12 @@ func (bm *batchMetrics) size() int {
 
 // resets the current batchMetrics structure with zero/empty values.
 func (bm *batchMetrics) reset() {
-	bm.metricData = dataold.NewMetricData()
+	bm.metricData = data.NewMetricData()
 	bm.metricCount = 0
 }
 
 func (bm *batchMetrics) add(item interface{}) {
-	md := pdatautil.MetricsToOldInternalMetrics(item.(pdata.Metrics))
+	md := pdatautil.MetricsToInternalMetrics(item.(pdata.Metrics))
 
 	newMetricsCount := md.MetricCount()
 	if newMetricsCount == 0 {


### PR DESCRIPTION
Updates #1657

Will slowdown the OTLP loadtest because of an extra conversion newOTLP -> OC -> oldOTLP until the PR to change OTLP will be merged.