### PR TITLE
 Change some Prometheus remote write exporter functions to public and update link to design in README.md

### DIFF
--- a/exporter/prometheusremotewriteexporter/README.md
+++ b/exporter/prometheusremotewriteexporter/README.md
@@ -28,4 +28,4 @@ prometheusremotewrite:
 The full list of settings exposed for this exporter are documented [here](./config.go)
 with detailed sample configurations [here](./testdata/config.yaml).
 
-_Here is a link to the overall project [design](https://github.com/open-telemetry/opentelemetry-collector/pull/1464)_
+_Here is a link to the overall project [design](./DESIGN.md)_

--- a/exporter/prometheusremotewriteexporter/exporter.go
+++ b/exporter/prometheusremotewriteexporter/exporter.go
@@ -38,8 +38,8 @@ import (
 	"go.opentelemetry.io/collector/internal/dataold"
 )
 
-// prwExporter converts OTLP metrics to Prometheus remote write TimeSeries and sends them to a remote endpoint
-type prwExporter struct {
+// PrwExporter converts OTLP metrics to Prometheus remote write TimeSeries and sends them to a remote endpoint
+type PrwExporter struct {
 	namespace   string
 	endpointURL *url.URL
 	client      *http.Client
@@ -47,9 +47,9 @@ type prwExporter struct {
 	closeChan   chan struct{}
 }
 
-// newPrwExporter initializes a new prwExporter instance and sets fields accordingly.
+// NewPrwExporter initializes a new PrwExporter instance and sets fields accordingly.
 // client parameter cannot be nil.
-func newPrwExporter(namespace string, endpoint string, client *http.Client) (*prwExporter, error) {
+func NewPrwExporter(namespace string, endpoint string, client *http.Client) (*PrwExporter, error) {
 
 	if client == nil {
 		return nil, errors.New("http client cannot be nil")
@@ -60,7 +60,7 @@ func newPrwExporter(namespace string, endpoint string, client *http.Client) (*pr
 		return nil, errors.New("invalid endpoint")
 	}
 
-	return &prwExporter{
+	return &PrwExporter{
 		namespace:   namespace,
 		endpointURL: endpointURL,
 		client:      client,
@@ -69,18 +69,18 @@ func newPrwExporter(namespace string, endpoint string, client *http.Client) (*pr
 	}, nil
 }
 
-// shutdown stops the exporter from accepting incoming calls(and return error), and wait for current export operations
+// Shutdown stops the exporter from accepting incoming calls(and return error), and wait for current export operations
 // to finish before returning
-func (prwe *prwExporter) shutdown(context.Context) error {
+func (prwe *PrwExporter) Shutdown(context.Context) error {
 	close(prwe.closeChan)
 	prwe.wg.Wait()
 	return nil
 }
 
-// pushMetrics converts metrics to Prometheus remote write TimeSeries and send to remote endpoint. It maintain a map of
+// PushMetrics converts metrics to Prometheus remote write TimeSeries and send to remote endpoint. It maintain a map of
 // TimeSeries, validates and handles each individual metric, adding the converted TimeSeries to the map, and finally
 // exports the map.
-func (prwe *prwExporter) pushMetrics(ctx context.Context, md pdata.Metrics) (int, error) {
+func (prwe *PrwExporter) PushMetrics(ctx context.Context, md pdata.Metrics) (int, error) {
 	prwe.wg.Add(1)
 	defer prwe.wg.Done()
 	select {
@@ -149,7 +149,7 @@ func (prwe *prwExporter) pushMetrics(ctx context.Context, md pdata.Metrics) (int
 // handleScalarMetric processes data points in a single OTLP scalar metric by adding the each point as a Sample into
 // its corresponding TimeSeries in tsMap.
 // tsMap and metric cannot be nil, and metric must have a non-nil descriptor
-func (prwe *prwExporter) handleScalarMetric(tsMap map[string]*prompb.TimeSeries, metric *otlp.Metric) error {
+func (prwe *PrwExporter) handleScalarMetric(tsMap map[string]*prompb.TimeSeries, metric *otlp.Metric) error {
 
 	mType := metric.MetricDescriptor.Type
 
@@ -199,7 +199,7 @@ func (prwe *prwExporter) handleScalarMetric(tsMap map[string]*prompb.TimeSeries,
 // handleHistogramMetric processes data points in a single OTLP histogram metric by mapping the sum, count and each
 // bucket of every data point as a Sample, and adding each Sample to its corresponding TimeSeries.
 // tsMap and metric cannot be nil.
-func (prwe *prwExporter) handleHistogramMetric(tsMap map[string]*prompb.TimeSeries, metric *otlp.Metric) error {
+func (prwe *PrwExporter) handleHistogramMetric(tsMap map[string]*prompb.TimeSeries, metric *otlp.Metric) error {
 
 	if metric.HistogramDataPoints == nil {
 		return fmt.Errorf("nil data point field in metric %s", metric.GetMetricDescriptor().Name)
@@ -258,7 +258,7 @@ func (prwe *prwExporter) handleHistogramMetric(tsMap map[string]*prompb.TimeSeri
 }
 
 // export sends a Snappy-compressed WriteRequest containing TimeSeries to a remote write endpoint in order
-func (prwe *prwExporter) export(ctx context.Context, tsMap map[string]*prompb.TimeSeries) error {
+func (prwe *PrwExporter) export(ctx context.Context, tsMap map[string]*prompb.TimeSeries) error {
 	//Calls the helper function to convert the TsMap to the desired format
 	req, err := wrapTimeSeries(tsMap)
 	if err != nil {

--- a/exporter/prometheusremotewriteexporter/factory.go
+++ b/exporter/prometheusremotewriteexporter/factory.go
@@ -50,7 +50,7 @@ func createMetricsExporter(_ context.Context, _ component.ExporterCreateParams,
 		return nil, err
 	}
 
-	prwe, err := newPrwExporter(prwCfg.Namespace, prwCfg.HTTPClientSettings.Endpoint, client)
+	prwe, err := NewPrwExporter(prwCfg.Namespace, prwCfg.HTTPClientSettings.Endpoint, client)
 
 	if err != nil {
 		return nil, err
@@ -58,11 +58,11 @@ func createMetricsExporter(_ context.Context, _ component.ExporterCreateParams,
 
 	prwexp, err := exporterhelper.NewMetricsExporter(
 		cfg,
-		prwe.pushMetrics,
+		prwe.PushMetrics,
 		exporterhelper.WithTimeout(prwCfg.TimeoutSettings),
 		exporterhelper.WithQueue(prwCfg.QueueSettings),
 		exporterhelper.WithRetry(prwCfg.RetrySettings),
-		exporterhelper.WithShutdown(prwe.shutdown),
+		exporterhelper.WithShutdown(prwe.Shutdown),
 	)
 
 	return prwexp, err


### PR DESCRIPTION
This PR changes the following methods in the Prometheus remote write exporter to public:

* `prometheusremotewriteexporter.prwExporter -> PrwExporter`
* `prometheusremotewriteexporter.newExporter -> NewExporter`
* `prometheusremotewriteexporter.pushMetrics -> PushMetric`
* `prometheusremotewriteexporter.shutdown    -> Shutdown`

These changes allows the creation of  a new exporter that use the Prometheus remote write exporter implementation. 

The new exporter can have a custom configuration and factory, and pass the Prometheus remote write exporter a different http.Client that does custom authentication.   

This PR also updates the link to the design PR in README.md to point to the merged DESIGN.md

Related PR: #1643

cc: @bogdandrutu @jmacd @alolita @huyan0 