### PR TITLE
Add StatusCode enum values to avoid usage of the proto generated values

### DIFF
--- a/consumer/pdata/trace.go
+++ b/consumer/pdata/trace.go
@@ -142,4 +142,24 @@ const (
 // and is numerically equal to Standard GRPC codes https://github.com/grpc/grpc/blob/master/doc/statuscodes.md
 type StatusCode otlptrace.Status_StatusCode
 
+const (
+	StatusCodeOk                 = StatusCode(otlptrace.Status_STATUS_CODE_OK)
+	StatusCodeCancelled          = StatusCode(otlptrace.Status_STATUS_CODE_CANCELLED)
+	StatusCodeUnknownError       = StatusCode(otlptrace.Status_STATUS_CODE_UNKNOWN_ERROR)
+	StatusCodeInvalidArgument    = StatusCode(otlptrace.Status_STATUS_CODE_INVALID_ARGUMENT)
+	StatusCodeDeadlineExceeded   = StatusCode(otlptrace.Status_STATUS_CODE_DEADLINE_EXCEEDED)
+	StatusCodeNotFound           = StatusCode(otlptrace.Status_STATUS_CODE_NOT_FOUND)
+	StatusCodeAlreadyExists      = StatusCode(otlptrace.Status_STATUS_CODE_ALREADY_EXISTS)
+	StatusCodePermissionDenied   = StatusCode(otlptrace.Status_STATUS_CODE_PERMISSION_DENIED)
+	StatusCodeResourceExhausted  = StatusCode(otlptrace.Status_STATUS_CODE_RESOURCE_EXHAUSTED)
+	StatusCodeFailedPrecondition = StatusCode(otlptrace.Status_STATUS_CODE_FAILED_PRECONDITION)
+	StatusCodeAborted            = StatusCode(otlptrace.Status_STATUS_CODE_ABORTED)
+	StatusCodeOutOfRange         = StatusCode(otlptrace.Status_STATUS_CODE_OUT_OF_RANGE)
+	StatusCodeUnimplemented      = StatusCode(otlptrace.Status_STATUS_CODE_UNIMPLEMENTED)
+	StatusCodeInternalError      = StatusCode(otlptrace.Status_STATUS_CODE_INTERNAL_ERROR)
+	StatusCodeUnavailable        = StatusCode(otlptrace.Status_STATUS_CODE_UNAVAILABLE)
+	StatusCodeDataLoss           = StatusCode(otlptrace.Status_STATUS_CODE_DATA_LOSS)
+	StatusCodeUnauthenticated    = StatusCode(otlptrace.Status_STATUS_CODE_UNAUTHENTICATED)
+)
+
 func (sc StatusCode) String() string { return otlptrace.Status_StatusCode(sc).String() }

--- a/internal/data/testdata/trace.go
+++ b/internal/data/testdata/trace.go
@@ -286,7 +286,7 @@ func fillSpanOne(span pdata.Span) {
 	span.SetDroppedEventsCount(1)
 	status := span.Status()
 	status.InitEmpty()
-	status.SetCode(pdata.StatusCode(1))
+	status.SetCode(pdata.StatusCodeCancelled)
 	status.SetMessage("status-cancelled")
 }
 

--- a/receiver/jaegerreceiver/trace_receiver_test.go
+++ b/receiver/jaegerreceiver/trace_receiver_test.go
@@ -49,7 +49,6 @@ import (
 	"go.opentelemetry.io/collector/config/configtls"
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/exporter/exportertest"
-	otlptrace "go.opentelemetry.io/collector/internal/data/opentelemetry-proto-gen/trace/v1"
 	"go.opentelemetry.io/collector/testutil"
 	"go.opentelemetry.io/collector/translator/conventions"
 	tracetranslator "go.opentelemetry.io/collector/translator/trace"
@@ -322,7 +321,7 @@ func expectedTraceData(t1, t2, t3 time.Time) pdata.Traces {
 	span0.SetStartTime(pdata.TimestampUnixNano(uint64(t1.UnixNano())))
 	span0.SetEndTime(pdata.TimestampUnixNano(uint64(t2.UnixNano())))
 	span0.Status().InitEmpty()
-	span0.Status().SetCode(pdata.StatusCode(otlptrace.Status_STATUS_CODE_NOT_FOUND))
+	span0.Status().SetCode(pdata.StatusCodeNotFound)
 	span0.Status().SetMessage("Stale indices")
 
 	span1 := rs.InstrumentationLibrarySpans().At(0).Spans().At(1)
@@ -332,7 +331,7 @@ func expectedTraceData(t1, t2, t3 time.Time) pdata.Traces {
 	span1.SetStartTime(pdata.TimestampUnixNano(uint64(t2.UnixNano())))
 	span1.SetEndTime(pdata.TimestampUnixNano(uint64(t3.UnixNano())))
 	span1.Status().InitEmpty()
-	span1.Status().SetCode(pdata.StatusCode(otlptrace.Status_STATUS_CODE_INTERNAL_ERROR))
+	span1.Status().SetCode(pdata.StatusCodeInternalError)
 	span1.Status().SetMessage("Frontend crash")
 
 	return traces

--- a/translator/trace/jaeger/jaegerproto_to_traces_test.go
+++ b/translator/trace/jaeger/jaegerproto_to_traces_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/collector/consumer/pdata"
-	otlptrace "go.opentelemetry.io/collector/internal/data/opentelemetry-proto-gen/trace/v1"
 	"go.opentelemetry.io/collector/internal/data/testdata"
 	"go.opentelemetry.io/collector/translator/conventions"
 	tracetranslator "go.opentelemetry.io/collector/translator/trace"
@@ -54,35 +53,35 @@ func TestGetStatusCodeFromAttr(t *testing.T) {
 		{
 			name: "ok-string",
 			attr: pdata.NewAttributeValueString("0"),
-			code: pdata.StatusCode(0),
+			code: pdata.StatusCodeOk,
 			err:  nil,
 		},
 
 		{
 			name: "ok-int",
 			attr: pdata.NewAttributeValueInt(1),
-			code: pdata.StatusCode(1),
+			code: pdata.StatusCodeCancelled,
 			err:  nil,
 		},
 
 		{
 			name: "wrong-type",
 			attr: pdata.NewAttributeValueBool(true),
-			code: pdata.StatusCode(0),
+			code: pdata.StatusCodeOk,
 			err:  fmt.Errorf("invalid status code attribute type: BOOL"),
 		},
 
 		{
 			name: "invalid-string",
 			attr: pdata.NewAttributeValueString("inf"),
-			code: pdata.StatusCode(0),
+			code: pdata.StatusCodeOk,
 			err:  invalidNumErr,
 		},
 
 		{
 			name: "invalid-int",
 			attr: pdata.NewAttributeValueInt(1844674407370955),
-			code: pdata.StatusCode(0),
+			code: pdata.StatusCodeOk,
 			err:  fmt.Errorf("invalid status code value: 1844674407370955"),
 		},
 	}
@@ -105,30 +104,30 @@ func TestGetStatusCodeFromHTTPStatusAttr(t *testing.T) {
 		{
 			name: "string-unknown",
 			attr: pdata.NewAttributeValueString("10"),
-			code: pdata.StatusCode(otlptrace.Status_STATUS_CODE_UNKNOWN_ERROR),
+			code: pdata.StatusCodeUnknownError,
 		},
 
 		{
 			name: "string-ok",
 			attr: pdata.NewAttributeValueString("101"),
-			code: pdata.StatusCode(otlptrace.Status_STATUS_CODE_OK),
+			code: pdata.StatusCodeOk,
 		},
 
 		{
 			name: "int-not-found",
 			attr: pdata.NewAttributeValueInt(404),
-			code: pdata.StatusCode(otlptrace.Status_STATUS_CODE_NOT_FOUND),
+			code: pdata.StatusCodeNotFound,
 		},
 		{
 			name: "int-invalid-arg",
 			attr: pdata.NewAttributeValueInt(408),
-			code: pdata.StatusCode(otlptrace.Status_STATUS_CODE_INVALID_ARGUMENT),
+			code: pdata.StatusCodeInvalidArgument,
 		},
 
 		{
 			name: "int-internal",
 			attr: pdata.NewAttributeValueInt(500),
-			code: pdata.StatusCode(otlptrace.Status_STATUS_CODE_INTERNAL_ERROR),
+			code: pdata.StatusCodeInternalError,
 		},
 	}
 
@@ -269,28 +268,28 @@ func TestSetInternalSpanStatus(t *testing.T) {
 
 	okStatus := pdata.NewSpanStatus()
 	okStatus.InitEmpty()
-	okStatus.SetCode(pdata.StatusCode(otlptrace.Status_STATUS_CODE_OK))
+	okStatus.SetCode(pdata.StatusCodeOk)
 
 	unknownStatus := pdata.NewSpanStatus()
 	unknownStatus.InitEmpty()
-	unknownStatus.SetCode(pdata.StatusCode(otlptrace.Status_STATUS_CODE_UNKNOWN_ERROR))
+	unknownStatus.SetCode(pdata.StatusCodeUnknownError)
 
 	canceledStatus := pdata.NewSpanStatus()
 	canceledStatus.InitEmpty()
-	canceledStatus.SetCode(pdata.StatusCode(otlptrace.Status_STATUS_CODE_CANCELLED))
+	canceledStatus.SetCode(pdata.StatusCodeCancelled)
 
 	invalidStatusWithMessage := pdata.NewSpanStatus()
 	invalidStatusWithMessage.InitEmpty()
-	invalidStatusWithMessage.SetCode(pdata.StatusCode(otlptrace.Status_STATUS_CODE_INVALID_ARGUMENT))
+	invalidStatusWithMessage.SetCode(pdata.StatusCodeInvalidArgument)
 	invalidStatusWithMessage.SetMessage("Error: Invalid argument")
 
 	notFoundStatus := pdata.NewSpanStatus()
 	notFoundStatus.InitEmpty()
-	notFoundStatus.SetCode(pdata.StatusCode(otlptrace.Status_STATUS_CODE_NOT_FOUND))
+	notFoundStatus.SetCode(pdata.StatusCodeNotFound)
 
 	notFoundStatusWithMessage := pdata.NewSpanStatus()
 	notFoundStatusWithMessage.InitEmpty()
-	notFoundStatusWithMessage.SetCode(pdata.StatusCode(otlptrace.Status_STATUS_CODE_NOT_FOUND))
+	notFoundStatusWithMessage.SetCode(pdata.StatusCodeNotFound)
 	notFoundStatusWithMessage.SetMessage("HTTP 404: Not Found")
 
 	tests := []struct {
@@ -649,7 +648,7 @@ func generateTraceDataTwoSpansChildParent() pdata.Traces {
 	span.SetStartTime(spans.At(0).StartTime())
 	span.SetEndTime(spans.At(0).EndTime())
 	span.Status().InitEmpty()
-	span.Status().SetCode(pdata.StatusCode(otlptrace.Status_STATUS_CODE_NOT_FOUND))
+	span.Status().SetCode(pdata.StatusCodeNotFound)
 	span.Attributes().InitFromMap(map[string]pdata.AttributeValue{
 		tracetranslator.TagHTTPStatusCode: pdata.NewAttributeValueInt(404),
 	})
@@ -703,7 +702,7 @@ func generateTraceDataTwoSpansWithFollower() pdata.Traces {
 	span.SetEndTime(spans.At(0).EndTime() + 1000000)
 	span.SetKind(pdata.SpanKindCONSUMER)
 	span.Status().InitEmpty()
-	span.Status().SetCode(pdata.StatusCode(otlptrace.Status_STATUS_CODE_OK))
+	span.Status().SetCode(pdata.StatusCodeOk)
 	span.Status().SetMessage("status-ok")
 	span.Links().Resize(1)
 	span.Links().At(0).SetTraceID(span.TraceID())

--- a/translator/trace/jaeger/traces_to_jaegerproto.go
+++ b/translator/trace/jaeger/traces_to_jaegerproto.go
@@ -20,7 +20,6 @@ import (
 	"github.com/jaegertracing/jaeger/model"
 
 	"go.opentelemetry.io/collector/consumer/pdata"
-	otlptrace "go.opentelemetry.io/collector/internal/data/opentelemetry-proto-gen/trace/v1"
 	"go.opentelemetry.io/collector/translator/conventions"
 	tracetranslator "go.opentelemetry.io/collector/translator/trace"
 )
@@ -418,7 +417,7 @@ func getTagFromStatusCode(statusCode pdata.StatusCode) (model.KeyValue, bool) {
 }
 
 func getErrorTagFromStatusCode(statusCode pdata.StatusCode) (model.KeyValue, bool) {
-	if statusCode == pdata.StatusCode(otlptrace.Status_STATUS_CODE_OK) {
+	if statusCode == pdata.StatusCodeOk {
 		return model.KeyValue{}, false
 	}
 	return model.KeyValue{

--- a/translator/trace/jaeger/traces_to_jaegerproto_test.go
+++ b/translator/trace/jaeger/traces_to_jaegerproto_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/collector/consumer/pdata"
-	otlptrace "go.opentelemetry.io/collector/internal/data/opentelemetry-proto-gen/trace/v1"
 	"go.opentelemetry.io/collector/internal/data/testdata"
 	"go.opentelemetry.io/collector/translator/conventions"
 	tracetranslator "go.opentelemetry.io/collector/translator/trace"
@@ -36,30 +35,30 @@ func TestGetTagFromStatusCode(t *testing.T) {
 	}{
 		{
 			name: "ok",
-			code: pdata.StatusCode(otlptrace.Status_STATUS_CODE_OK),
+			code: pdata.StatusCodeOk,
 			tag: model.KeyValue{
 				Key:    tracetranslator.TagStatusCode,
-				VInt64: int64(otlptrace.Status_STATUS_CODE_OK),
+				VInt64: int64(pdata.StatusCodeOk),
 				VType:  model.ValueType_INT64,
 			},
 		},
 
 		{
 			name: "unknown",
-			code: pdata.StatusCode(otlptrace.Status_STATUS_CODE_UNKNOWN_ERROR),
+			code: pdata.StatusCodeUnknownError,
 			tag: model.KeyValue{
 				Key:    tracetranslator.TagStatusCode,
-				VInt64: int64(otlptrace.Status_STATUS_CODE_UNKNOWN_ERROR),
+				VInt64: int64(pdata.StatusCodeUnknownError),
 				VType:  model.ValueType_INT64,
 			},
 		},
 
 		{
 			name: "not-found",
-			code: pdata.StatusCode(otlptrace.Status_STATUS_CODE_NOT_FOUND),
+			code: pdata.StatusCodeNotFound,
 			tag: model.KeyValue{
 				Key:    tracetranslator.TagStatusCode,
-				VInt64: int64(otlptrace.Status_STATUS_CODE_NOT_FOUND),
+				VInt64: int64(pdata.StatusCodeNotFound),
 				VType:  model.ValueType_INT64,
 			},
 		},
@@ -81,14 +80,14 @@ func TestGetErrorTagFromStatusCode(t *testing.T) {
 		VType: model.ValueType_BOOL,
 	}
 
-	_, ok := getErrorTagFromStatusCode(pdata.StatusCode(otlptrace.Status_STATUS_CODE_OK))
+	_, ok := getErrorTagFromStatusCode(pdata.StatusCodeOk)
 	assert.False(t, ok)
 
-	got, ok := getErrorTagFromStatusCode(pdata.StatusCode(otlptrace.Status_STATUS_CODE_UNKNOWN_ERROR))
+	got, ok := getErrorTagFromStatusCode(pdata.StatusCodeUnknownError)
 	assert.True(t, ok)
 	assert.EqualValues(t, errTag, got)
 
-	got, ok = getErrorTagFromStatusCode(pdata.StatusCode(otlptrace.Status_STATUS_CODE_NOT_FOUND))
+	got, ok = getErrorTagFromStatusCode(pdata.StatusCodeNotFound)
 	assert.True(t, ok)
 	assert.EqualValues(t, errTag, got)
 }


### PR DESCRIPTION
Will allow contrib to remove dependency on opentelemetry-proto which had the generated proto files.