### PR TITLE
Refactor the Prometheus remote write exporter to use OTLP v0.5.0

### DIFF
--- a/exporter/prometheusremotewriteexporter/helper.go
+++ b/exporter/prometheusremotewriteexporter/helper.go
@@ -18,14 +18,16 @@ import (
 	"errors"
 	"log"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 	"unicode"
 
 	"github.com/prometheus/prometheus/prompb"
 
+	"go.opentelemetry.io/collector/consumer/pdata"
 	common "go.opentelemetry.io/collector/internal/data/opentelemetry-proto-gen/common/v1"
-	otlp "go.opentelemetry.io/collector/internal/data/opentelemetry-proto-gen/metrics/v1old"
+	otlp "go.opentelemetry.io/collector/internal/data/opentelemetry-proto-gen/metrics/v1"
 )
 
 const (
@@ -47,34 +49,43 @@ func (a ByLabelName) Len() int           { return len(a) }
 func (a ByLabelName) Less(i, j int) bool { return a[i].Name < a[j].Name }
 func (a ByLabelName) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
 
-// validateMetrics returns a bool representing whether the metric has a valid type and temporality combination.
-func validateMetrics(desc *otlp.MetricDescriptor) bool {
-
-	if desc == nil {
+// validateMetrics returns a bool representing whether the metric has a valid type and temporality combination and a
+// matching metric type and field
+func validateMetrics(metric *otlp.Metric) bool {
+	if metric == nil || metric.Data == nil {
 		return false
 	}
-
-	switch desc.GetType() {
-	case otlp.MetricDescriptor_MONOTONIC_DOUBLE, otlp.MetricDescriptor_MONOTONIC_INT64,
-		otlp.MetricDescriptor_HISTOGRAM, otlp.MetricDescriptor_SUMMARY:
-		return desc.GetTemporality() == otlp.MetricDescriptor_CUMULATIVE
-	case otlp.MetricDescriptor_INT64, otlp.MetricDescriptor_DOUBLE:
-		return true
+	switch metric.Data.(type) {
+	case *otlp.Metric_DoubleGauge:
+		return metric.GetDoubleGauge() != nil
+	case *otlp.Metric_IntGauge:
+		return metric.GetIntGauge() != nil
+	case *otlp.Metric_DoubleSum:
+		return metric.GetDoubleSum() != nil && metric.GetDoubleSum().GetAggregationTemporality() ==
+			otlp.AggregationTemporality_AGGREGATION_TEMPORALITY_CUMULATIVE
+	case *otlp.Metric_IntSum:
+		return metric.GetIntSum() != nil && metric.GetIntSum().GetAggregationTemporality() ==
+			otlp.AggregationTemporality_AGGREGATION_TEMPORALITY_CUMULATIVE
+	case *otlp.Metric_DoubleHistogram:
+		return metric.GetDoubleHistogram() != nil && metric.GetDoubleHistogram().GetAggregationTemporality() ==
+			otlp.AggregationTemporality_AGGREGATION_TEMPORALITY_CUMULATIVE
+	case *otlp.Metric_IntHistogram:
+		return metric.GetIntHistogram() != nil && metric.GetIntHistogram().GetAggregationTemporality() ==
+			otlp.AggregationTemporality_AGGREGATION_TEMPORALITY_CUMULATIVE
 	}
-
 	return false
 }
 
 // addSample finds a TimeSeries in tsMap that corresponds to the label set labels, and add sample to the TimeSeries; it
 // creates a new TimeSeries in the map if not found. tsMap is unmodified if either of its parameters is nil.
 func addSample(tsMap map[string]*prompb.TimeSeries, sample *prompb.Sample, labels []prompb.Label,
-	ty otlp.MetricDescriptor_Type) {
+	metric *otlp.Metric) {
 
 	if sample == nil || labels == nil || tsMap == nil {
 		return
 	}
 
-	sig := timeSeriesSignature(ty, &labels)
+	sig := timeSeriesSignature(metric, &labels)
 	ts, ok := tsMap[sig]
 
 	if ok {
@@ -92,9 +103,9 @@ func addSample(tsMap map[string]*prompb.TimeSeries, sample *prompb.Sample, label
 // 		TYPE-label1-value1- ...  -labelN-valueN
 // the label slice should not contain duplicate label names; this method sorts the slice by label name before creating
 // the signature.
-func timeSeriesSignature(t otlp.MetricDescriptor_Type, labels *[]prompb.Label) string {
+func timeSeriesSignature(metric *otlp.Metric, labels *[]prompb.Label) string {
 	b := strings.Builder{}
-	b.WriteString(t.String())
+	b.WriteString(getTypeString(metric))
 
 	sort.Sort(ByLabelName(*labels))
 
@@ -153,14 +164,16 @@ func createLabelSet(labels []*common.StringKeyValue, extras ...string) []prompb.
 
 // getPromMetricName creates a Prometheus metric name by attaching namespace prefix, and _total suffix for Monotonic
 // metrics.
-func getPromMetricName(desc *otlp.MetricDescriptor, ns string) string {
+func getPromMetricName(metric *otlp.Metric, ns string) string {
 
-	if desc == nil {
+	if metric == nil {
 		return ""
 	}
-	// whether _total suffix should be applied
-	isCounter := desc.Type == otlp.MetricDescriptor_MONOTONIC_INT64 ||
-		desc.Type == otlp.MetricDescriptor_MONOTONIC_DOUBLE
+
+	// if the metric is counter, _total suffix should be applied
+	_, isCounter1 := metric.Data.(*otlp.Metric_DoubleSum)
+	_, isCounter2 := metric.Data.(*otlp.Metric_IntSum)
+	isCounter := isCounter1 || isCounter2
 
 	b := strings.Builder{}
 
@@ -169,7 +182,11 @@ func getPromMetricName(desc *otlp.MetricDescriptor, ns string) string {
 	if b.Len() > 0 {
 		b.WriteString(delimeter)
 	}
-	b.WriteString(desc.GetName())
+	name := metric.GetName()
+	b.WriteString(name)
+
+	// do not add the total suffix if the metric name already ends in "total"
+	isCounter = isCounter && name[len(name)-len(totalStr):] != totalStr
 
 	// Including units makes two metrics with the same name and label set belong to two different TimeSeries if the
 	// units are different.
@@ -237,4 +254,168 @@ func sanitizeRune(r rune) rune {
 	}
 	// Everything else turns into an underscore
 	return '_'
+}
+
+func getTypeString(metric *otlp.Metric) string {
+	switch metric.Data.(type) {
+	case *otlp.Metric_DoubleGauge:
+		return strconv.Itoa(int(pdata.MetricDataTypeDoubleGauge))
+	case *otlp.Metric_IntGauge:
+		return strconv.Itoa(int(pdata.MetricDataTypeIntGauge))
+	case *otlp.Metric_DoubleSum:
+		return strconv.Itoa(int(pdata.MetricDataTypeDoubleSum))
+	case *otlp.Metric_IntSum:
+		return strconv.Itoa(int(pdata.MetricDataTypeIntSum))
+	case *otlp.Metric_DoubleHistogram:
+		return strconv.Itoa(int(pdata.MetricDataTypeDoubleHistogram))
+	case *otlp.Metric_IntHistogram:
+		return strconv.Itoa(int(pdata.MetricDataTypeIntHistogram))
+	}
+	return ""
+}
+
+// addSingleDoubleDataPoint converts the metric value stored in pt to a Prometheus sample, and add the sample
+// to its corresponding time series in tsMap
+func addSingleDoubleDataPoint(pt *otlp.DoubleDataPoint, metric *otlp.Metric, namespace string,
+	tsMap map[string]*prompb.TimeSeries) {
+	if pt == nil {
+		return
+	}
+	// create parameters for addSample
+	name := getPromMetricName(metric, namespace)
+	labels := createLabelSet(pt.GetLabels(), nameStr, name)
+	sample := &prompb.Sample{
+		Value: pt.Value,
+		// convert ns to ms
+		Timestamp: convertTimeStamp(pt.TimeUnixNano),
+	}
+	addSample(tsMap, sample, labels, metric)
+}
+
+// addSingleIntDataPoint converts the metric value stored in pt to a Prometheus sample, and add the sample
+// to its corresponding time series in tsMap
+func addSingleIntDataPoint(pt *otlp.IntDataPoint, metric *otlp.Metric, namespace string,
+	tsMap map[string]*prompb.TimeSeries) {
+	if pt == nil {
+		return
+	}
+	// create parameters for addSample
+	name := getPromMetricName(metric, namespace)
+	labels := createLabelSet(pt.GetLabels(), nameStr, name)
+	sample := &prompb.Sample{
+		Value: float64(pt.Value),
+		// convert ns to ms
+		Timestamp: convertTimeStamp(pt.TimeUnixNano),
+	}
+	addSample(tsMap, sample, labels, metric)
+}
+
+// addSingleIntHistogramDataPoint converts pt to 2 + min(len(ExplicitBounds), len(BucketCount)) + 1 samples. It
+// ignore extra buckets if len(ExplicitBounds) > len(BucketCounts)
+func addSingleIntHistogramDataPoint(pt *otlp.IntHistogramDataPoint, metric *otlp.Metric, namespace string,
+	tsMap map[string]*prompb.TimeSeries) {
+	if pt == nil {
+		return
+	}
+	time := convertTimeStamp(pt.TimeUnixNano)
+	// sum, count, and buckets of the histogram should append suffix to baseName
+	baseName := getPromMetricName(metric, namespace)
+	// treat sum as a sample in an individual TimeSeries
+	sum := &prompb.Sample{
+		Value:     float64(pt.GetSum()),
+		Timestamp: time,
+	}
+
+	sumlabels := createLabelSet(pt.GetLabels(), nameStr, baseName+sumStr)
+	addSample(tsMap, sum, sumlabels, metric)
+
+	// treat count as a sample in an individual TimeSeries
+	count := &prompb.Sample{
+		Value:     float64(pt.GetCount()),
+		Timestamp: time,
+	}
+	countlabels := createLabelSet(pt.GetLabels(), nameStr, baseName+countStr)
+	addSample(tsMap, count, countlabels, metric)
+
+	// count for +Inf bound
+	var totalCount uint64
+
+	// process each bound, ignore extra bucket values
+	for index, bound := range pt.GetExplicitBounds() {
+		if index >= len(pt.GetBucketCounts()) {
+			break
+		}
+		bk := pt.GetBucketCounts()[index]
+		bucket := &prompb.Sample{
+			Value:     float64(bk),
+			Timestamp: time,
+		}
+		boundStr := strconv.FormatFloat(bound, 'f', -1, 64)
+		labels := createLabelSet(pt.GetLabels(), nameStr, baseName+bucketStr, leStr, boundStr)
+		addSample(tsMap, bucket, labels, metric)
+
+		totalCount += bk
+	}
+	// add le=+Inf bucket
+	infBucket := &prompb.Sample{
+		Value:     float64(totalCount),
+		Timestamp: time,
+	}
+	infLabels := createLabelSet(pt.GetLabels(), nameStr, baseName+bucketStr, leStr, pInfStr)
+	addSample(tsMap, infBucket, infLabels, metric)
+}
+
+// addSingleDoubleHistogramDataPoint converts pt to 2 + min(len(ExplicitBounds), len(BucketCount)) + 1 samples. It
+//// ignore extra buckets if len(ExplicitBounds) > len(BucketCounts)
+func addSingleDoubleHistogramDataPoint(pt *otlp.DoubleHistogramDataPoint, metric *otlp.Metric, namespace string,
+	tsMap map[string]*prompb.TimeSeries) {
+	if pt == nil {
+		return
+	}
+	time := convertTimeStamp(pt.TimeUnixNano)
+	// sum, count, and buckets of the histogram should append suffix to baseName
+	baseName := getPromMetricName(metric, namespace)
+	// treat sum as a sample in an individual TimeSeries
+	sum := &prompb.Sample{
+		Value:     pt.GetSum(),
+		Timestamp: time,
+	}
+
+	sumlabels := createLabelSet(pt.GetLabels(), nameStr, baseName+sumStr)
+	addSample(tsMap, sum, sumlabels, metric)
+
+	// treat count as a sample in an individual TimeSeries
+	count := &prompb.Sample{
+		Value:     float64(pt.GetCount()),
+		Timestamp: time,
+	}
+	countlabels := createLabelSet(pt.GetLabels(), nameStr, baseName+countStr)
+	addSample(tsMap, count, countlabels, metric)
+
+	// count for +Inf bound
+	var totalCount uint64
+
+	// process each bound, ignore extra bucket values
+	for index, bound := range pt.GetExplicitBounds() {
+		if index >= len(pt.GetBucketCounts()) {
+			break
+		}
+		bk := pt.GetBucketCounts()[index]
+		bucket := &prompb.Sample{
+			Value:     float64(bk),
+			Timestamp: time,
+		}
+		boundStr := strconv.FormatFloat(bound, 'f', -1, 64)
+		labels := createLabelSet(pt.GetLabels(), nameStr, baseName+bucketStr, leStr, boundStr)
+		addSample(tsMap, bucket, labels, metric)
+
+		totalCount += bk
+	}
+	// add le=+Inf bucket
+	infBucket := &prompb.Sample{
+		Value:     float64(totalCount),
+		Timestamp: time,
+	}
+	infLabels := createLabelSet(pt.GetLabels(), nameStr, baseName+bucketStr, leStr, pInfStr)
+	addSample(tsMap, infBucket, infLabels, metric)
 }

--- a/exporter/prometheusremotewriteexporter/helper.go
+++ b/exporter/prometheusremotewriteexporter/helper.go
@@ -366,7 +366,7 @@ func addSingleIntHistogramDataPoint(pt *otlp.IntHistogramDataPoint, metric *otlp
 }
 
 // addSingleDoubleHistogramDataPoint converts pt to 2 + min(len(ExplicitBounds), len(BucketCount)) + 1 samples. It
-//// ignore extra buckets if len(ExplicitBounds) > len(BucketCounts)
+// ignore extra buckets if len(ExplicitBounds) > len(BucketCounts)
 func addSingleDoubleHistogramDataPoint(pt *otlp.DoubleHistogramDataPoint, metric *otlp.Metric, namespace string,
 	tsMap map[string]*prompb.TimeSeries) {
 	if pt == nil {

--- a/exporter/prometheusremotewriteexporter/testutil_test.go
+++ b/exporter/prometheusremotewriteexporter/testutil_test.go
@@ -20,26 +20,14 @@ import (
 	"github.com/prometheus/prometheus/prompb"
 
 	commonpb "go.opentelemetry.io/collector/internal/data/opentelemetry-proto-gen/common/v1"
-	otlp "go.opentelemetry.io/collector/internal/data/opentelemetry-proto-gen/metrics/v1old"
-	"go.opentelemetry.io/collector/internal/dataold"
+	otlp "go.opentelemetry.io/collector/internal/data/opentelemetry-proto-gen/metrics/v1"
 )
-
-type combination struct {
-	ty   otlp.MetricDescriptor_Type
-	temp otlp.MetricDescriptor_Temporality
-}
 
 var (
 	time1   = uint64(time.Now().UnixNano())
 	time2   = uint64(time.Date(1970, 1, 0, 0, 0, 0, 0, time.UTC).UnixNano())
 	msTime1 = int64(time1 / uint64(int64(time.Millisecond)/int64(time.Nanosecond)))
 	msTime2 = int64(time2 / uint64(int64(time.Millisecond)/int64(time.Nanosecond)))
-
-	typeInt64           = "INT64"
-	typeMonotonicInt64  = "MONOTONIC_INT64"
-	typeMonotonicDouble = "MONOTONIC_DOUBLE"
-	typeHistogram       = "HISTOGRAM"
-	typeSummary         = "SUMMARY"
 
 	label11 = "test_label11"
 	value11 = "test_value11"
@@ -71,47 +59,352 @@ var (
 	lb1Sig = "-" + label11 + "-" + value11 + "-" + label12 + "-" + value12
 	lb2Sig = "-" + label21 + "-" + value21 + "-" + label22 + "-" + value22
 	ns1    = "test_ns"
-	name1  = "valid_single_int_point"
 
-	monotonicInt64Comb  = 0
-	monotonicDoubleComb = 1
-	histogramComb       = 2
-	summaryComb         = 3
-	validCombinations   = []combination{
-		{otlp.MetricDescriptor_MONOTONIC_INT64, otlp.MetricDescriptor_CUMULATIVE},
-		{otlp.MetricDescriptor_MONOTONIC_DOUBLE, otlp.MetricDescriptor_CUMULATIVE},
-		{otlp.MetricDescriptor_HISTOGRAM, otlp.MetricDescriptor_CUMULATIVE},
-		{otlp.MetricDescriptor_SUMMARY, otlp.MetricDescriptor_CUMULATIVE},
-		{otlp.MetricDescriptor_INT64, otlp.MetricDescriptor_DELTA},
-		{otlp.MetricDescriptor_DOUBLE, otlp.MetricDescriptor_DELTA},
-		{otlp.MetricDescriptor_INT64, otlp.MetricDescriptor_INSTANTANEOUS},
-		{otlp.MetricDescriptor_DOUBLE, otlp.MetricDescriptor_INSTANTANEOUS},
-		{otlp.MetricDescriptor_INT64, otlp.MetricDescriptor_CUMULATIVE},
-		{otlp.MetricDescriptor_DOUBLE, otlp.MetricDescriptor_CUMULATIVE},
-	}
-	invalidCombinations = []combination{
-		{otlp.MetricDescriptor_MONOTONIC_INT64, otlp.MetricDescriptor_DELTA},
-		{otlp.MetricDescriptor_MONOTONIC_DOUBLE, otlp.MetricDescriptor_DELTA},
-		{otlp.MetricDescriptor_HISTOGRAM, otlp.MetricDescriptor_DELTA},
-		{otlp.MetricDescriptor_SUMMARY, otlp.MetricDescriptor_DELTA},
-		{otlp.MetricDescriptor_MONOTONIC_INT64, otlp.MetricDescriptor_DELTA},
-		{otlp.MetricDescriptor_MONOTONIC_DOUBLE, otlp.MetricDescriptor_DELTA},
-		{otlp.MetricDescriptor_HISTOGRAM, otlp.MetricDescriptor_DELTA},
-		{otlp.MetricDescriptor_SUMMARY, otlp.MetricDescriptor_DELTA},
-		{ty: otlp.MetricDescriptor_INVALID_TYPE},
-		{temp: otlp.MetricDescriptor_INVALID_TEMPORALITY},
-		{},
-	}
 	twoPointsSameTs = map[string]*prompb.TimeSeries{
-		typeInt64 + "-" + label11 + "-" + value11 + "-" + label12 + "-" + value12: getTimeSeries(getPromLabels(label11, value11, label12, value12),
+		"2" + "-" + label11 + "-" + value11 + "-" + label12 + "-" + value12: getTimeSeries(getPromLabels(label11, value11, label12, value12),
 			getSample(float64(intVal1), msTime1),
 			getSample(float64(intVal2), msTime2)),
 	}
 	twoPointsDifferentTs = map[string]*prompb.TimeSeries{
-		typeInt64 + "-" + label11 + "-" + value11 + "-" + label12 + "-" + value12: getTimeSeries(getPromLabels(label11, value11, label12, value12),
+		"1" + "-" + label11 + "-" + value11 + "-" + label12 + "-" + value12: getTimeSeries(getPromLabels(label11, value11, label12, value12),
 			getSample(float64(intVal1), msTime1)),
-		typeInt64 + "-" + label21 + "-" + value21 + "-" + label22 + "-" + value22: getTimeSeries(getPromLabels(label21, value21, label22, value22),
+		"1" + "-" + label21 + "-" + value21 + "-" + label22 + "-" + value22: getTimeSeries(getPromLabels(label21, value21, label22, value22),
 			getSample(float64(intVal1), msTime2)),
+	}
+	bounds  = []float64{0.1, 0.5, 0.99}
+	buckets = []uint64{1, 2, 3}
+
+	validIntGauge        = "valid_IntGauge"
+	validDoubleGauge     = "valid_DoubleGauge"
+	validIntSum          = "valid_IntSum"
+	validDoubleSum       = "valid_DoubleSum"
+	validIntHistogram    = "valid_IntHistogram"
+	validDoubleHistogram = "valid_DoubleHistogram"
+
+	validIntGaugeDirty = "*valid_IntGauge$"
+
+	unmatchedBoundBucketIntHist    = "unmatchedBoundBucketIntHist"
+	unmatchedBoundBucketDoubleHist = "unmatchedBoundBucketDoubleHist"
+
+	// valid metrics as input should not return error
+	validMetrics1 = map[string]*otlp.Metric{
+		validIntGauge: {
+			Name: validIntGauge,
+			Data: &otlp.Metric_IntGauge{
+				IntGauge: &otlp.IntGauge{
+					DataPoints: []*otlp.IntDataPoint{
+						getIntDataPoint(lbs1, intVal1, time1),
+						nil,
+					},
+				},
+			},
+		},
+		validDoubleGauge: {
+			Name: validDoubleGauge,
+			Data: &otlp.Metric_DoubleGauge{
+				DoubleGauge: &otlp.DoubleGauge{
+					DataPoints: []*otlp.DoubleDataPoint{
+						getDoubleDataPoint(lbs1, floatVal1, time1),
+						nil,
+					},
+				},
+			},
+		},
+		validIntSum: {
+			Name: validIntSum,
+			Data: &otlp.Metric_IntSum{
+				IntSum: &otlp.IntSum{
+					DataPoints: []*otlp.IntDataPoint{
+						getIntDataPoint(lbs1, intVal1, time1),
+						nil,
+					},
+					AggregationTemporality: otlp.AggregationTemporality_AGGREGATION_TEMPORALITY_CUMULATIVE,
+				},
+			},
+		},
+		validDoubleSum: {
+			Name: validDoubleSum,
+			Data: &otlp.Metric_DoubleSum{
+				DoubleSum: &otlp.DoubleSum{
+					DataPoints: []*otlp.DoubleDataPoint{
+						getDoubleDataPoint(lbs1, floatVal1, time1),
+						nil,
+					},
+					AggregationTemporality: otlp.AggregationTemporality_AGGREGATION_TEMPORALITY_CUMULATIVE,
+				},
+			},
+		},
+		validIntHistogram: {
+			Name: validIntHistogram,
+			Data: &otlp.Metric_IntHistogram{
+				IntHistogram: &otlp.IntHistogram{
+					DataPoints: []*otlp.IntHistogramDataPoint{
+						getIntHistogramDataPoint(lbs1, time1, floatVal1, uint64(intVal1), bounds, buckets),
+						nil,
+					},
+					AggregationTemporality: otlp.AggregationTemporality_AGGREGATION_TEMPORALITY_CUMULATIVE,
+				},
+			},
+		},
+		validDoubleHistogram: {
+			Name: validDoubleHistogram,
+			Data: &otlp.Metric_DoubleHistogram{
+				DoubleHistogram: &otlp.DoubleHistogram{
+					DataPoints: []*otlp.DoubleHistogramDataPoint{
+						getDoubleHistogramDataPoint(lbs1, time1, floatVal1, uint64(intVal1), bounds, buckets),
+						nil,
+					},
+					AggregationTemporality: otlp.AggregationTemporality_AGGREGATION_TEMPORALITY_CUMULATIVE,
+				},
+			},
+		},
+	}
+	validMetrics2 = map[string]*otlp.Metric{
+		validIntGauge: {
+			Name: validIntGauge,
+			Data: &otlp.Metric_IntGauge{
+				IntGauge: &otlp.IntGauge{
+					DataPoints: []*otlp.IntDataPoint{
+						getIntDataPoint(lbs2, intVal2, time2),
+					},
+				},
+			},
+		},
+		validDoubleGauge: {
+			Name: validDoubleGauge,
+			Data: &otlp.Metric_DoubleGauge{
+				DoubleGauge: &otlp.DoubleGauge{
+					DataPoints: []*otlp.DoubleDataPoint{
+						getDoubleDataPoint(lbs2, floatVal2, time2),
+					},
+				},
+			},
+		},
+		validIntSum: {
+			Name: validIntSum,
+			Data: &otlp.Metric_IntSum{
+				IntSum: &otlp.IntSum{
+					DataPoints: []*otlp.IntDataPoint{
+						getIntDataPoint(lbs2, intVal2, time2),
+					},
+					AggregationTemporality: otlp.AggregationTemporality_AGGREGATION_TEMPORALITY_CUMULATIVE,
+				},
+			},
+		},
+		validDoubleSum: {
+			Name: validDoubleSum,
+			Data: &otlp.Metric_DoubleSum{
+				DoubleSum: &otlp.DoubleSum{
+					DataPoints: []*otlp.DoubleDataPoint{
+						getDoubleDataPoint(lbs2, floatVal2, time2),
+					},
+					AggregationTemporality: otlp.AggregationTemporality_AGGREGATION_TEMPORALITY_CUMULATIVE,
+				},
+			},
+		},
+		validIntHistogram: {
+			Name: validIntHistogram,
+			Data: &otlp.Metric_IntHistogram{
+				IntHistogram: &otlp.IntHistogram{
+					DataPoints: []*otlp.IntHistogramDataPoint{
+						getIntHistogramDataPoint(lbs2, time2, floatVal2, uint64(intVal2), bounds, buckets),
+					},
+					AggregationTemporality: otlp.AggregationTemporality_AGGREGATION_TEMPORALITY_CUMULATIVE,
+				},
+			},
+		},
+		validDoubleHistogram: {
+			Name: validDoubleHistogram,
+			Data: &otlp.Metric_DoubleHistogram{
+				DoubleHistogram: &otlp.DoubleHistogram{
+					DataPoints: []*otlp.DoubleHistogramDataPoint{
+						getDoubleHistogramDataPoint(lbs2, time2, floatVal2, uint64(intVal2), bounds, buckets),
+					},
+					AggregationTemporality: otlp.AggregationTemporality_AGGREGATION_TEMPORALITY_CUMULATIVE,
+				},
+			},
+		},
+		validIntGaugeDirty: {
+			Name: validIntGaugeDirty,
+			Data: &otlp.Metric_IntGauge{
+				IntGauge: &otlp.IntGauge{
+					DataPoints: []*otlp.IntDataPoint{
+						getIntDataPoint(lbs1, intVal1, time1),
+						nil,
+					},
+				},
+			},
+		},
+		unmatchedBoundBucketIntHist: {
+			Name: unmatchedBoundBucketIntHist,
+			Data: &otlp.Metric_IntHistogram{
+				IntHistogram: &otlp.IntHistogram{
+					DataPoints: []*otlp.IntHistogramDataPoint{
+						{
+							ExplicitBounds: []float64{0.1, 0.2, 0.3},
+							BucketCounts:   []uint64{1, 2},
+						},
+					},
+					AggregationTemporality: otlp.AggregationTemporality_AGGREGATION_TEMPORALITY_CUMULATIVE,
+				},
+			},
+		},
+		unmatchedBoundBucketDoubleHist: {
+			Name: unmatchedBoundBucketDoubleHist,
+			Data: &otlp.Metric_DoubleHistogram{
+				DoubleHistogram: &otlp.DoubleHistogram{
+					DataPoints: []*otlp.DoubleHistogramDataPoint{
+						{
+							ExplicitBounds: []float64{0.1, 0.2, 0.3},
+							BucketCounts:   []uint64{1, 2},
+						},
+					},
+					AggregationTemporality: otlp.AggregationTemporality_AGGREGATION_TEMPORALITY_CUMULATIVE,
+				},
+			},
+		},
+	}
+
+	nilMetric = "nil"
+	empty     = "empty"
+
+	// Category 1: type and data field doesn't match
+	notMatchIntGauge        = "noMatchIntGauge"
+	notMatchDoubleGauge     = "notMatchDoubleGauge"
+	notMatchIntSum          = "notMatchIntSum"
+	notMatchDoubleSum       = "notMatchDoubleSum"
+	notMatchIntHistogram    = "notMatchIntHistogram"
+	notMatchDoubleHistogram = "notMatchDoubleHistogram"
+
+	// Category 2: invalid type and temporality combination
+	invalidIntSum          = "invalidIntSum"
+	invalidDoubleSum       = "invalidDoubleSum"
+	invalidIntHistogram    = "invalidIntHistogram"
+	invalidDoubleHistogram = "invalidDoubleHistogram"
+
+	//Category 3: nil data points
+	nilDataPointIntGauge        = "nilDataPointIntGauge"
+	nilDataPointDoubleGauge     = "nilDataPointDoubleGauge"
+	nilDataPointIntSum          = "nilDataPointIntSum"
+	nilDataPointDoubleSum       = "nilDataPointDoubleSum"
+	nilDataPointIntHistogram    = "nilDataPointIntHistogram"
+	nilDataPointDoubleHistogram = "nilDataPointDoubleHistogram"
+
+	// different metrics that will not pass validate metrics
+	invalidMetrics = map[string]*otlp.Metric{
+		// nil
+		nilMetric: nil,
+		// Data = nil
+		empty: {},
+		notMatchIntGauge: {
+			Name: notMatchIntGauge,
+			Data: &otlp.Metric_IntGauge{},
+		},
+		notMatchDoubleGauge: {
+			Name: notMatchDoubleGauge,
+			Data: &otlp.Metric_DoubleGauge{},
+		},
+		notMatchIntSum: {
+			Name: notMatchIntSum,
+			Data: &otlp.Metric_IntSum{},
+		},
+		notMatchDoubleSum: {
+			Name: notMatchDoubleSum,
+			Data: &otlp.Metric_DoubleSum{},
+		},
+		notMatchIntHistogram: {
+			Name: notMatchIntHistogram,
+			Data: &otlp.Metric_IntHistogram{},
+		},
+		notMatchDoubleHistogram: {
+			Name: notMatchDoubleHistogram,
+			Data: &otlp.Metric_DoubleHistogram{},
+		},
+		invalidIntSum: {
+			Name: invalidIntSum,
+			Data: &otlp.Metric_IntSum{
+				IntSum: &otlp.IntSum{
+					AggregationTemporality: otlp.AggregationTemporality_AGGREGATION_TEMPORALITY_DELTA,
+				},
+			},
+		},
+		invalidDoubleSum: {
+			Name: invalidDoubleSum,
+			Data: &otlp.Metric_DoubleSum{
+				DoubleSum: &otlp.DoubleSum{
+					AggregationTemporality: otlp.AggregationTemporality_AGGREGATION_TEMPORALITY_DELTA,
+				},
+			},
+		},
+		invalidIntHistogram: {
+			Name: invalidIntHistogram,
+			Data: &otlp.Metric_IntHistogram{
+				IntHistogram: &otlp.IntHistogram{
+					AggregationTemporality: otlp.AggregationTemporality_AGGREGATION_TEMPORALITY_DELTA,
+				},
+			},
+		},
+		invalidDoubleHistogram: {
+			Name: invalidDoubleHistogram,
+			Data: &otlp.Metric_DoubleHistogram{
+				DoubleHistogram: &otlp.DoubleHistogram{
+					AggregationTemporality: otlp.AggregationTemporality_AGGREGATION_TEMPORALITY_DELTA,
+				},
+			},
+		},
+	}
+
+	// different metrics that will cause the exporter to return an error
+	errorMetrics = map[string]*otlp.Metric{
+
+		nilDataPointIntGauge: {
+			Name: nilDataPointIntGauge,
+			Data: &otlp.Metric_IntGauge{
+				IntGauge: &otlp.IntGauge{DataPoints: nil},
+			},
+		},
+		nilDataPointDoubleGauge: {
+			Name: nilDataPointDoubleGauge,
+			Data: &otlp.Metric_DoubleGauge{
+				DoubleGauge: &otlp.DoubleGauge{DataPoints: nil},
+			},
+		},
+		nilDataPointIntSum: {
+			Name: nilDataPointIntSum,
+			Data: &otlp.Metric_IntSum{
+				IntSum: &otlp.IntSum{
+					DataPoints:             nil,
+					AggregationTemporality: otlp.AggregationTemporality_AGGREGATION_TEMPORALITY_CUMULATIVE,
+				},
+			},
+		},
+		nilDataPointDoubleSum: {
+			Name: nilDataPointDoubleSum,
+			Data: &otlp.Metric_DoubleSum{
+				DoubleSum: &otlp.DoubleSum{
+					DataPoints:             nil,
+					AggregationTemporality: otlp.AggregationTemporality_AGGREGATION_TEMPORALITY_CUMULATIVE,
+				},
+			},
+		},
+		nilDataPointIntHistogram: {
+			Name: nilDataPointIntHistogram,
+			Data: &otlp.Metric_IntHistogram{
+				IntHistogram: &otlp.IntHistogram{
+					DataPoints:             nil,
+					AggregationTemporality: otlp.AggregationTemporality_AGGREGATION_TEMPORALITY_CUMULATIVE,
+				},
+			},
+		},
+		nilDataPointDoubleHistogram: {
+			Name: nilDataPointDoubleHistogram,
+			Data: &otlp.Metric_DoubleHistogram{
+				DoubleHistogram: &otlp.DoubleHistogram{
+					DataPoints:             nil,
+					AggregationTemporality: otlp.AggregationTemporality_AGGREGATION_TEMPORALITY_CUMULATIVE,
+				},
+			},
+		},
 	}
 )
 
@@ -128,18 +421,8 @@ func getLabels(labels ...string) []*commonpb.StringKeyValue {
 	return set
 }
 
-func getDescriptor(name string, i int, comb []combination) *otlp.MetricDescriptor {
-	return &otlp.MetricDescriptor{
-		Name:        name,
-		Description: "",
-		Unit:        "",
-		Type:        comb[i].ty,
-		Temporality: comb[i].temp,
-	}
-}
-
-func getIntDataPoint(labels []*commonpb.StringKeyValue, value int64, ts uint64) *otlp.Int64DataPoint {
-	return &otlp.Int64DataPoint{
+func getIntDataPoint(labels []*commonpb.StringKeyValue, value int64, ts uint64) *otlp.IntDataPoint {
+	return &otlp.IntDataPoint{
 		Labels:            labels,
 		StartTimeUnixNano: 0,
 		TimeUnixNano:      ts,
@@ -156,22 +439,29 @@ func getDoubleDataPoint(labels []*commonpb.StringKeyValue, value float64, ts uin
 	}
 }
 
-func getHistogramDataPoint(labels []*commonpb.StringKeyValue, ts uint64, sum float64, count uint64, bounds []float64, buckets []uint64) *otlp.HistogramDataPoint {
-	bks := []*otlp.HistogramDataPoint_Bucket{}
-	for _, c := range buckets {
-		bks = append(bks, &otlp.HistogramDataPoint_Bucket{
-			Count:    c,
-			Exemplar: nil,
-		})
-	}
-	return &otlp.HistogramDataPoint{
+func getIntHistogramDataPoint(labels []*commonpb.StringKeyValue, ts uint64, sum float64, count uint64, bounds []float64,
+	buckets []uint64) *otlp.IntHistogramDataPoint {
+	return &otlp.IntHistogramDataPoint{
 		Labels:            labels,
 		StartTimeUnixNano: 0,
 		TimeUnixNano:      ts,
 		Count:             count,
-		Sum:               sum,
-		Buckets:           bks,
+		Sum:               int64(sum),
+		BucketCounts:      buckets,
 		ExplicitBounds:    bounds,
+		Exemplars:         nil,
+	}
+}
+
+func getDoubleHistogramDataPoint(labels []*commonpb.StringKeyValue, ts uint64, sum float64, count uint64,
+	bounds []float64, buckets []uint64) *otlp.DoubleHistogramDataPoint {
+	return &otlp.DoubleHistogramDataPoint{
+		Labels:         labels,
+		TimeUnixNano:   ts,
+		Count:          count,
+		Sum:            sum,
+		BucketCounts:   buckets,
+		ExplicitBounds: bounds,
 	}
 }
 
@@ -204,55 +494,5 @@ func getTimeSeries(labels []prompb.Label, samples ...prompb.Sample) *prompb.Time
 	return &prompb.TimeSeries{
 		Labels:  labels,
 		Samples: samples,
-	}
-}
-
-func setCumulative(metricsData *dataold.MetricData) {
-	for _, r := range dataold.MetricDataToOtlp(*metricsData) {
-		for _, instMetrics := range r.InstrumentationLibraryMetrics {
-			for _, m := range instMetrics.Metrics {
-				m.MetricDescriptor.Temporality = otlp.MetricDescriptor_CUMULATIVE
-			}
-		}
-	}
-}
-
-//setDataPointToNil is for creating the dataold.MetricData to test with
-func setDataPointToNil(metricsData *dataold.MetricData, dataField string) {
-	for _, r := range dataold.MetricDataToOtlp(*metricsData) {
-		for _, instMetrics := range r.InstrumentationLibraryMetrics {
-			for _, m := range instMetrics.Metrics {
-				switch dataField {
-				case typeMonotonicInt64:
-					m.Int64DataPoints = nil
-				case typeMonotonicDouble:
-					m.DoubleDataPoints = nil
-				case typeHistogram:
-					m.HistogramDataPoints = nil
-				case typeSummary:
-					m.SummaryDataPoints = nil
-				}
-			}
-		}
-	}
-}
-
-//setType is for creating the dataold.MetricData to test with
-func setType(metricsData *dataold.MetricData, dataField string) {
-	for _, r := range dataold.MetricDataToOtlp(*metricsData) {
-		for _, instMetrics := range r.InstrumentationLibraryMetrics {
-			for _, m := range instMetrics.Metrics {
-				switch dataField {
-				case typeMonotonicInt64:
-					m.GetMetricDescriptor().Type = otlp.MetricDescriptor_MONOTONIC_INT64
-				case typeMonotonicDouble:
-					m.GetMetricDescriptor().Type = otlp.MetricDescriptor_MONOTONIC_DOUBLE
-				case typeHistogram:
-					m.GetMetricDescriptor().Type = otlp.MetricDescriptor_HISTOGRAM
-				case typeSummary:
-					m.GetMetricDescriptor().Type = otlp.MetricDescriptor_SUMMARY
-				}
-			}
-		}
 	}
 }


### PR DESCRIPTION
This PR removes dependency on dataold and the old v0.4.0 OTLP definitions. It refactors code for metric conversion to convert from OTLP v0.5.0. 

Changes in this PR includes: 

* Replace references:
    *  dataold.MetricsData -> data.MetricsData
    *  pdatautil.OldInternal -> pdatautil.Internal
    * testdataold -> testdata (prefix was changed GenerateMetricData -> GenerateMetrics)
* Change helper methods to take in a pointer to a metric rather than a metric descriptor
* Create helper methods to get the type string from the metric
* Create helper methods for IntDataPoint, DoubleDataPoint, IntHistogramDataPoint , and DoubleHistogramDataPoint
* Replace OTLPv0.4.0 metrics with  v0.5.0 metrics as inputs for unit tests. This accounted for a lot of the changes

Linked Issue: resolves #1681
Related PR: #1643

cc: @bogdandrutu @jmacd @alolita @huyan0
