### PR TITLE
Move timestamp functions to pdata package

### DIFF
--- a/consumer/pdata/timestamp.go
+++ b/consumer/pdata/timestamp.go
@@ -1,0 +1,44 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pdata
+
+import (
+	"time"
+
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func TimestampToUnixNano(ts *timestamppb.Timestamp) (t TimestampUnixNano) {
+	if ts == nil {
+		return
+	}
+	return TimestampUnixNano(uint64(ts.AsTime().UnixNano()))
+}
+
+func UnixNanoToTimestamp(u TimestampUnixNano) *timestamppb.Timestamp {
+	// 0 is a special case and want to make sure we return nil.
+	if u == 0 {
+		return nil
+	}
+	return timestamppb.New(UnixNanoToTime(u))
+}
+
+func UnixNanoToTime(u TimestampUnixNano) time.Time {
+	// 0 is a special case and want to make sure we return a time that IsZero() returns true.
+	if u == 0 {
+		return time.Time{}
+	}
+	return time.Unix(0, int64(u)).UTC()
+}

--- a/consumer/pdata/timestamp_test.go
+++ b/consumer/pdata/timestamp_test.go
@@ -1,0 +1,39 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pdata
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func TestUnixNanosConverters(t *testing.T) {
+	t1 := time.Date(2020, 03, 24, 1, 13, 23, 789, time.UTC)
+	tun := TimestampUnixNano(t1.UnixNano())
+
+	assert.EqualValues(t, uint64(1585012403000000789), tun)
+	tp := UnixNanoToTimestamp(tun)
+	assert.EqualValues(t, &timestamppb.Timestamp{Seconds: 1585012403, Nanos: 789}, tp)
+	assert.EqualValues(t, tun, TimestampToUnixNano(tp))
+}
+
+func TestZeroTimestamps(t *testing.T) {
+	assert.Zero(t, TimestampToUnixNano(nil))
+	assert.Nil(t, UnixNanoToTimestamp(0))
+	assert.True(t, UnixNanoToTime(0).IsZero())
+}

--- a/translator/internaldata/metrics_to_oc.go
+++ b/translator/internaldata/metrics_to_oc.go
@@ -21,7 +21,6 @@ import (
 
 	"go.opentelemetry.io/collector/consumer/consumerdata"
 	"go.opentelemetry.io/collector/consumer/pdata"
-	"go.opentelemetry.io/collector/internal"
 	"go.opentelemetry.io/collector/internal/data"
 )
 
@@ -279,11 +278,11 @@ func intPointsToOC(dps pdata.IntDataPointSlice, labelKeys *labelKeys) []*ocmetri
 			continue
 		}
 		ts := &ocmetrics.TimeSeries{
-			StartTimestamp: internal.UnixNanoToTimestamp(ip.StartTime()),
+			StartTimestamp: pdata.UnixNanoToTimestamp(ip.StartTime()),
 			LabelValues:    labelValuesToOC(ip.LabelsMap(), labelKeys),
 			Points: []*ocmetrics.Point{
 				{
-					Timestamp: internal.UnixNanoToTimestamp(ip.Timestamp()),
+					Timestamp: pdata.UnixNanoToTimestamp(ip.Timestamp()),
 					Value: &ocmetrics.Point_Int64Value{
 						Int64Value: ip.Value(),
 					},
@@ -306,11 +305,11 @@ func doublePointToOC(dps pdata.DoubleDataPointSlice, labelKeys *labelKeys) []*oc
 			continue
 		}
 		ts := &ocmetrics.TimeSeries{
-			StartTimestamp: internal.UnixNanoToTimestamp(dp.StartTime()),
+			StartTimestamp: pdata.UnixNanoToTimestamp(dp.StartTime()),
 			LabelValues:    labelValuesToOC(dp.LabelsMap(), labelKeys),
 			Points: []*ocmetrics.Point{
 				{
-					Timestamp: internal.UnixNanoToTimestamp(dp.Timestamp()),
+					Timestamp: pdata.UnixNanoToTimestamp(dp.Timestamp()),
 					Value: &ocmetrics.Point_DoubleValue{
 						DoubleValue: dp.Value(),
 					},
@@ -337,11 +336,11 @@ func doubleHistogramPointToOC(dps pdata.DoubleHistogramDataPointSlice, labelKeys
 		doubleExemplarsToOC(dp.ExplicitBounds(), buckets, dp.Exemplars())
 
 		ts := &ocmetrics.TimeSeries{
-			StartTimestamp: internal.UnixNanoToTimestamp(dp.StartTime()),
+			StartTimestamp: pdata.UnixNanoToTimestamp(dp.StartTime()),
 			LabelValues:    labelValuesToOC(dp.LabelsMap(), labelKeys),
 			Points: []*ocmetrics.Point{
 				{
-					Timestamp: internal.UnixNanoToTimestamp(dp.Timestamp()),
+					Timestamp: pdata.UnixNanoToTimestamp(dp.Timestamp()),
 					Value: &ocmetrics.Point_DistributionValue{
 						DistributionValue: &ocmetrics.DistributionValue{
 							Count:                 int64(dp.Count()),
@@ -374,11 +373,11 @@ func intHistogramPointToOC(dps pdata.IntHistogramDataPointSlice, labelKeys *labe
 		intExemplarsToOC(dp.ExplicitBounds(), buckets, dp.Exemplars())
 
 		ts := &ocmetrics.TimeSeries{
-			StartTimestamp: internal.UnixNanoToTimestamp(dp.StartTime()),
+			StartTimestamp: pdata.UnixNanoToTimestamp(dp.StartTime()),
 			LabelValues:    labelValuesToOC(dp.LabelsMap(), labelKeys),
 			Points: []*ocmetrics.Point{
 				{
-					Timestamp: internal.UnixNanoToTimestamp(dp.Timestamp()),
+					Timestamp: pdata.UnixNanoToTimestamp(dp.Timestamp()),
 					Value: &ocmetrics.Point_DistributionValue{
 						DistributionValue: &ocmetrics.DistributionValue{
 							Count:                 int64(dp.Count()),
@@ -479,7 +478,7 @@ func exemplarToOC(filteredLabels pdata.StringMap, value float64, timestamp pdata
 
 	return &ocmetrics.DistributionValue_Exemplar{
 		Value:       value,
-		Timestamp:   internal.UnixNanoToTimestamp(timestamp),
+		Timestamp:   pdata.UnixNanoToTimestamp(timestamp),
 		Attachments: labels,
 	}
 }

--- a/translator/internaldata/oc_to_metrics.go
+++ b/translator/internaldata/oc_to_metrics.go
@@ -20,7 +20,6 @@ import (
 
 	"go.opentelemetry.io/collector/consumer/consumerdata"
 	"go.opentelemetry.io/collector/consumer/pdata"
-	"go.opentelemetry.io/collector/internal"
 	"go.opentelemetry.io/collector/internal/data"
 )
 
@@ -247,7 +246,7 @@ func fillIntDataPoint(ocMetric *ocmetrics.Metric, dps pdata.IntDataPointSlice) {
 		if timeseries == nil {
 			continue
 		}
-		startTimestamp := internal.TimestampToUnixNano(timeseries.GetStartTimestamp())
+		startTimestamp := pdata.TimestampToUnixNano(timeseries.GetStartTimestamp())
 
 		for _, point := range timeseries.GetPoints() {
 			if point == nil {
@@ -258,7 +257,7 @@ func fillIntDataPoint(ocMetric *ocmetrics.Metric, dps pdata.IntDataPointSlice) {
 			pos++
 
 			dp.SetStartTime(startTimestamp)
-			dp.SetTimestamp(internal.TimestampToUnixNano(point.GetTimestamp()))
+			dp.SetTimestamp(pdata.TimestampToUnixNano(point.GetTimestamp()))
 			setLabelsMap(ocLabelsKeys, timeseries.LabelValues, dp.LabelsMap())
 			dp.SetValue(point.GetInt64Value())
 		}
@@ -275,7 +274,7 @@ func fillDoubleDataPoint(ocMetric *ocmetrics.Metric, dps pdata.DoubleDataPointSl
 		if timeseries == nil {
 			continue
 		}
-		startTimestamp := internal.TimestampToUnixNano(timeseries.GetStartTimestamp())
+		startTimestamp := pdata.TimestampToUnixNano(timeseries.GetStartTimestamp())
 
 		for _, point := range timeseries.GetPoints() {
 			if point == nil {
@@ -286,7 +285,7 @@ func fillDoubleDataPoint(ocMetric *ocmetrics.Metric, dps pdata.DoubleDataPointSl
 			pos++
 
 			dp.SetStartTime(startTimestamp)
-			dp.SetTimestamp(internal.TimestampToUnixNano(point.GetTimestamp()))
+			dp.SetTimestamp(pdata.TimestampToUnixNano(point.GetTimestamp()))
 			setLabelsMap(ocLabelsKeys, timeseries.LabelValues, dp.LabelsMap())
 			dp.SetValue(point.GetDoubleValue())
 		}
@@ -303,7 +302,7 @@ func fillDoubleHistogramDataPoint(ocMetric *ocmetrics.Metric, dps pdata.DoubleHi
 		if timeseries == nil {
 			continue
 		}
-		startTimestamp := internal.TimestampToUnixNano(timeseries.GetStartTimestamp())
+		startTimestamp := pdata.TimestampToUnixNano(timeseries.GetStartTimestamp())
 
 		for _, point := range timeseries.GetPoints() {
 			if point == nil {
@@ -314,7 +313,7 @@ func fillDoubleHistogramDataPoint(ocMetric *ocmetrics.Metric, dps pdata.DoubleHi
 			pos++
 
 			dp.SetStartTime(startTimestamp)
-			dp.SetTimestamp(internal.TimestampToUnixNano(point.GetTimestamp()))
+			dp.SetTimestamp(pdata.TimestampToUnixNano(point.GetTimestamp()))
 			setLabelsMap(ocLabelsKeys, timeseries.LabelValues, dp.LabelsMap())
 			distributionValue := point.GetDistributionValue()
 			dp.SetSum(distributionValue.GetSum())
@@ -345,7 +344,7 @@ func ocHistogramBucketsToMetrics(ocBuckets []*ocmetrics.DistributionValue_Bucket
 
 func exemplarToMetrics(ocExemplar *ocmetrics.DistributionValue_Exemplar, exemplar pdata.DoubleExemplar) {
 	if ocExemplar.GetTimestamp() != nil {
-		exemplar.SetTimestamp(internal.TimestampToUnixNano(ocExemplar.GetTimestamp()))
+		exemplar.SetTimestamp(pdata.TimestampToUnixNano(ocExemplar.GetTimestamp()))
 	}
 	exemplar.SetValue(ocExemplar.GetValue())
 	attachments := exemplar.FilteredLabels()

--- a/translator/internaldata/oc_to_old_metrics.go
+++ b/translator/internaldata/oc_to_old_metrics.go
@@ -19,7 +19,7 @@ import (
 	ocmetrics "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
 
 	"go.opentelemetry.io/collector/consumer/consumerdata"
-	"go.opentelemetry.io/collector/internal"
+	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/internal/dataold"
 )
 
@@ -197,13 +197,13 @@ func setDataPointsToOldMetrics(ocMetric *ocmetrics.Metric, metric dataold.Metric
 		if timeseries == nil {
 			continue
 		}
-		startTimestamp := internal.TimestampToUnixNano(timeseries.GetStartTimestamp())
+		startTimestamp := pdata.TimestampToUnixNano(timeseries.GetStartTimestamp())
 
 		for _, point := range timeseries.GetPoints() {
 			if point == nil {
 				continue
 			}
-			pointTimestamp := internal.TimestampToUnixNano(point.GetTimestamp())
+			pointTimestamp := pdata.TimestampToUnixNano(point.GetTimestamp())
 			switch point.Value.(type) {
 
 			case *ocmetrics.Point_Int64Value:
@@ -296,7 +296,7 @@ func histogramBucketsToOldMetrics(ocBuckets []*ocmetrics.DistributionValue_Bucke
 
 func exemplarToOldMetrics(ocExemplar *ocmetrics.DistributionValue_Exemplar, exemplar dataold.HistogramBucketExemplar) {
 	if ocExemplar.GetTimestamp() != nil {
-		exemplar.SetTimestamp(internal.TimestampToUnixNano(ocExemplar.GetTimestamp()))
+		exemplar.SetTimestamp(pdata.TimestampToUnixNano(ocExemplar.GetTimestamp()))
 	}
 	exemplar.SetValue(ocExemplar.GetValue())
 	attachments := exemplar.Attachments()

--- a/translator/internaldata/oc_to_traces.go
+++ b/translator/internaldata/oc_to_traces.go
@@ -23,7 +23,6 @@ import (
 
 	"go.opentelemetry.io/collector/consumer/consumerdata"
 	"go.opentelemetry.io/collector/consumer/pdata"
-	"go.opentelemetry.io/collector/internal"
 	"go.opentelemetry.io/collector/translator/conventions"
 	tracetranslator "go.opentelemetry.io/collector/translator/trace"
 )
@@ -147,8 +146,8 @@ func ocSpanToInternal(src *octrace.Span, dest pdata.Span) {
 	}
 
 	dest.SetName(src.Name.GetValue())
-	dest.SetStartTime(internal.TimestampToUnixNano(src.StartTime))
-	dest.SetEndTime(internal.TimestampToUnixNano(src.EndTime))
+	dest.SetStartTime(pdata.TimestampToUnixNano(src.StartTime))
+	dest.SetEndTime(pdata.TimestampToUnixNano(src.EndTime))
 
 	initAttributeMapFromOC(src.Attributes, dest.Attributes())
 	dest.SetDroppedAttributesCount(ocAttrsToDroppedAttributes(src.Attributes))
@@ -294,7 +293,7 @@ func ocEventsToInternal(ocEvents *octrace.Span_TimeEvents, dest pdata.Span) {
 		event := events.At(i)
 		i++
 
-		event.SetTimestamp(internal.TimestampToUnixNano(ocEvent.Time))
+		event.SetTimestamp(pdata.TimestampToUnixNano(ocEvent.Time))
 
 		switch teValue := ocEvent.Value.(type) {
 		case *octrace.Span_TimeEvent_Annotation_:

--- a/translator/internaldata/old_metrics_to_oc.go
+++ b/translator/internaldata/old_metrics_to_oc.go
@@ -22,7 +22,6 @@ import (
 
 	"go.opentelemetry.io/collector/consumer/consumerdata"
 	"go.opentelemetry.io/collector/consumer/pdata"
-	"go.opentelemetry.io/collector/internal"
 	"go.opentelemetry.io/collector/internal/dataold"
 )
 
@@ -250,11 +249,11 @@ func oldMetricDataPointsToTimeseries(metric dataold.Metric, labelKeys *labelKeys
 
 func oldMetricInt64PointToOC(point dataold.Int64DataPoint, labelKeys *labelKeys) *ocmetrics.TimeSeries {
 	return &ocmetrics.TimeSeries{
-		StartTimestamp: internal.UnixNanoToTimestamp(point.StartTime()),
+		StartTimestamp: pdata.UnixNanoToTimestamp(point.StartTime()),
 		LabelValues:    labelValuesToOC(point.LabelsMap(), labelKeys),
 		Points: []*ocmetrics.Point{
 			{
-				Timestamp: internal.UnixNanoToTimestamp(point.Timestamp()),
+				Timestamp: pdata.UnixNanoToTimestamp(point.Timestamp()),
 				Value: &ocmetrics.Point_Int64Value{
 					Int64Value: point.Value(),
 				},
@@ -265,11 +264,11 @@ func oldMetricInt64PointToOC(point dataold.Int64DataPoint, labelKeys *labelKeys)
 
 func oldMetricDoublePointToOC(point dataold.DoubleDataPoint, labelKeys *labelKeys) *ocmetrics.TimeSeries {
 	return &ocmetrics.TimeSeries{
-		StartTimestamp: internal.UnixNanoToTimestamp(point.StartTime()),
+		StartTimestamp: pdata.UnixNanoToTimestamp(point.StartTime()),
 		LabelValues:    labelValuesToOC(point.LabelsMap(), labelKeys),
 		Points: []*ocmetrics.Point{
 			{
-				Timestamp: internal.UnixNanoToTimestamp(point.Timestamp()),
+				Timestamp: pdata.UnixNanoToTimestamp(point.Timestamp()),
 				Value: &ocmetrics.Point_DoubleValue{
 					DoubleValue: point.Value(),
 				},
@@ -280,11 +279,11 @@ func oldMetricDoublePointToOC(point dataold.DoubleDataPoint, labelKeys *labelKey
 
 func oldMetricHistogramPointToOC(point dataold.HistogramDataPoint, labelKeys *labelKeys) *ocmetrics.TimeSeries {
 	return &ocmetrics.TimeSeries{
-		StartTimestamp: internal.UnixNanoToTimestamp(point.StartTime()),
+		StartTimestamp: pdata.UnixNanoToTimestamp(point.StartTime()),
 		LabelValues:    labelValuesToOC(point.LabelsMap(), labelKeys),
 		Points: []*ocmetrics.Point{
 			{
-				Timestamp: internal.UnixNanoToTimestamp(point.Timestamp()),
+				Timestamp: pdata.UnixNanoToTimestamp(point.Timestamp()),
 				Value: &ocmetrics.Point_DistributionValue{
 					DistributionValue: &ocmetrics.DistributionValue{
 						Count:                 int64(point.Count()),
@@ -337,7 +336,7 @@ func oldMetricExemplarToOC(exemplar dataold.HistogramBucketExemplar) *ocmetrics.
 	if attachments.Len() == 0 {
 		return &ocmetrics.DistributionValue_Exemplar{
 			Value:       exemplar.Value(),
-			Timestamp:   internal.UnixNanoToTimestamp(exemplar.Timestamp()),
+			Timestamp:   pdata.UnixNanoToTimestamp(exemplar.Timestamp()),
 			Attachments: nil,
 		}
 	}
@@ -348,18 +347,18 @@ func oldMetricExemplarToOC(exemplar dataold.HistogramBucketExemplar) *ocmetrics.
 	})
 	return &ocmetrics.DistributionValue_Exemplar{
 		Value:       exemplar.Value(),
-		Timestamp:   internal.UnixNanoToTimestamp(exemplar.Timestamp()),
+		Timestamp:   pdata.UnixNanoToTimestamp(exemplar.Timestamp()),
 		Attachments: labels,
 	}
 }
 
 func oldMetricSummaryPointToOC(point dataold.SummaryDataPoint, labelKeys *labelKeys) *ocmetrics.TimeSeries {
 	return &ocmetrics.TimeSeries{
-		StartTimestamp: internal.UnixNanoToTimestamp(point.StartTime()),
+		StartTimestamp: pdata.UnixNanoToTimestamp(point.StartTime()),
 		LabelValues:    labelValuesToOC(point.LabelsMap(), labelKeys),
 		Points: []*ocmetrics.Point{
 			{
-				Timestamp: internal.UnixNanoToTimestamp(point.Timestamp()),
+				Timestamp: pdata.UnixNanoToTimestamp(point.Timestamp()),
 				Value: &ocmetrics.Point_SummaryValue{
 					SummaryValue: &ocmetrics.SummaryValue{
 						Count:    int64Value(point.Count()),

--- a/translator/internaldata/traces_to_oc.go
+++ b/translator/internaldata/traces_to_oc.go
@@ -23,7 +23,6 @@ import (
 
 	"go.opentelemetry.io/collector/consumer/consumerdata"
 	"go.opentelemetry.io/collector/consumer/pdata"
-	"go.opentelemetry.io/collector/internal"
 	"go.opentelemetry.io/collector/translator/conventions"
 	tracetranslator "go.opentelemetry.io/collector/translator/trace"
 )
@@ -105,8 +104,8 @@ func spanToOC(span pdata.Span) *octrace.Span {
 		ParentSpanId:            span.ParentSpanID().Bytes(),
 		Name:                    stringToTruncatableString(span.Name()),
 		Kind:                    spanKindToOC(span.Kind()),
-		StartTime:               internal.UnixNanoToTimestamp(span.StartTime()),
-		EndTime:                 internal.UnixNanoToTimestamp(span.EndTime()),
+		StartTime:               pdata.UnixNanoToTimestamp(span.StartTime()),
+		EndTime:                 pdata.UnixNanoToTimestamp(span.EndTime()),
 		Attributes:              attributes,
 		TimeEvents:              eventsToOC(span.Events(), span.DroppedEventsCount()),
 		Links:                   linksToOC(span.Links(), span.DroppedLinksCount()),
@@ -305,7 +304,7 @@ func eventToOC(event pdata.SpanEvent) *octrace.Span_TimeEvent {
 			ocMessageEventType := ocMessageEventAttrValues[conventions.OCTimeEventMessageEventType]
 			ocMessageEventTypeVal := octrace.Span_TimeEvent_MessageEvent_Type_value[ocMessageEventType.StringVal()]
 			return &octrace.Span_TimeEvent{
-				Time: internal.UnixNanoToTimestamp(event.Timestamp()),
+				Time: pdata.UnixNanoToTimestamp(event.Timestamp()),
 				Value: &octrace.Span_TimeEvent_MessageEvent_{
 					MessageEvent: &octrace.Span_TimeEvent_MessageEvent{
 						Type:             octrace.Span_TimeEvent_MessageEvent_Type(ocMessageEventTypeVal),
@@ -320,7 +319,7 @@ func eventToOC(event pdata.SpanEvent) *octrace.Span_TimeEvent {
 
 	ocAttributes := attributesMapToOCSpanAttributes(attrs, event.DroppedAttributesCount())
 	return &octrace.Span_TimeEvent{
-		Time: internal.UnixNanoToTimestamp(event.Timestamp()),
+		Time: pdata.UnixNanoToTimestamp(event.Timestamp()),
 		Value: &octrace.Span_TimeEvent_Annotation_{
 			Annotation: &octrace.Span_TimeEvent_Annotation{
 				Description: stringToTruncatableString(event.Name()),

--- a/translator/trace/jaeger/traces_to_jaegerproto.go
+++ b/translator/trace/jaeger/traces_to_jaegerproto.go
@@ -20,7 +20,6 @@ import (
 	"github.com/jaegertracing/jaeger/model"
 
 	"go.opentelemetry.io/collector/consumer/pdata"
-	"go.opentelemetry.io/collector/internal"
 	otlptrace "go.opentelemetry.io/collector/internal/data/opentelemetry-proto-gen/trace/v1"
 	"go.opentelemetry.io/collector/translator/conventions"
 	tracetranslator "go.opentelemetry.io/collector/translator/trace"
@@ -197,7 +196,7 @@ func spanToJaegerProto(span pdata.Span) (*model.Span, error) {
 		return nil, fmt.Errorf("error converting span links to Jaeger references: %w", err)
 	}
 
-	startTime := internal.UnixNanoToTime(span.StartTime())
+	startTime := pdata.UnixNanoToTime(span.StartTime())
 
 	return &model.Span{
 		TraceID:       traceID,
@@ -205,7 +204,7 @@ func spanToJaegerProto(span pdata.Span) (*model.Span, error) {
 		OperationName: span.Name(),
 		References:    jReferences,
 		StartTime:     startTime,
-		Duration:      internal.UnixNanoToTime(span.EndTime()).Sub(startTime),
+		Duration:      pdata.UnixNanoToTime(span.EndTime()).Sub(startTime),
 		Tags:          getJaegerProtoSpanTags(span),
 		Logs:          spanEventsToJaegerProtoLogs(span.Events()),
 	}, nil
@@ -378,7 +377,7 @@ func spanEventsToJaegerProtoLogs(events pdata.SpanEventSlice) []model.Log {
 		}
 		fields = appendTagsFromAttributes(fields, event.Attributes())
 		logs = append(logs, model.Log{
-			Timestamp: internal.UnixNanoToTime(event.Timestamp()),
+			Timestamp: pdata.UnixNanoToTime(event.Timestamp()),
 			Fields:    fields,
 		})
 	}

--- a/translator/trace/zipkin/traces_to_zipkinv2.go
+++ b/translator/trace/zipkin/traces_to_zipkinv2.go
@@ -24,7 +24,6 @@ import (
 	zipkinmodel "github.com/openzipkin/zipkin-go/model"
 
 	"go.opentelemetry.io/collector/consumer/pdata"
-	"go.opentelemetry.io/collector/internal"
 	"go.opentelemetry.io/collector/translator/conventions"
 	tracetranslator "go.opentelemetry.io/collector/translator/trace"
 )
@@ -142,7 +141,7 @@ func spanToZipkinSpan(
 
 	zs.Sampled = &sampled
 	zs.Name = span.Name()
-	zs.Timestamp = internal.UnixNanoToTime(span.StartTime())
+	zs.Timestamp = pdata.UnixNanoToTime(span.StartTime())
 	if span.EndTime() != 0 {
 		zs.Duration = time.Duration(span.EndTime() - span.StartTime())
 	}
@@ -202,7 +201,7 @@ func spanEventsToZipkinAnnotations(events pdata.SpanEventSlice, zs *zipkinmodel.
 			}
 			if event.Attributes().Len() == 0 && event.DroppedAttributesCount() == 0 {
 				zAnnos[i] = zipkinmodel.Annotation{
-					Timestamp: internal.UnixNanoToTime(event.Timestamp()),
+					Timestamp: pdata.UnixNanoToTime(event.Timestamp()),
 					Value:     event.Name(),
 				}
 			} else {
@@ -212,7 +211,7 @@ func spanEventsToZipkinAnnotations(events pdata.SpanEventSlice, zs *zipkinmodel.
 					return err
 				}
 				zAnnos[i] = zipkinmodel.Annotation{
-					Timestamp: internal.UnixNanoToTime(event.Timestamp()),
+					Timestamp: pdata.UnixNanoToTime(event.Timestamp()),
 					Value: fmt.Sprintf(tracetranslator.SpanEventDataFormat, event.Name(), jsonStr,
 						event.DroppedAttributesCount()),
 				}


### PR DESCRIPTION
This is necessary to prevent circular package dependency that
can arise when we need to hide certain pdata functions in the
internal package in a commit that is coming soon in
https://github.com/open-telemetry/opentelemetry-collector/pull/1703
