### PR TITLE
Bump OpenCensus trace load test memory limit to avoid spurious failures

### DIFF
--- a/testbed/tests/trace_test.go
+++ b/testbed/tests/trace_test.go
@@ -61,7 +61,7 @@ func TestTrace10kSPS(t *testing.T) {
 			testbed.NewOCDataReceiver(testbed.GetAvailablePort(t)),
 			testbed.ResourceSpec{
 				ExpectedMaxCPU: 39,
-				ExpectedMaxRAM: 70,
+				ExpectedMaxRAM: 82,
 			},
 		},
 		{


### PR DESCRIPTION
Historically 70MB was very close to observed max. We typically used +15%
to observed max, so I bumped it to 82MB.
