### PR TITLE
Remove out of date Prometheus Include Filter docs

### DIFF
--- a/receiver/prometheusreceiver/README.md
+++ b/receiver/prometheusreceiver/README.md
@@ -41,28 +41,5 @@ receivers:
               action: keep
 ```
 
-### Include Filter
-Include Filter provides ability to filter scraping metrics per target. If a
-filter is specified for a target then only those metrics which exactly matches
-one of the metrics specified in the `Include Filter` list will be scraped. Rest
-of the metrics from the targets will be dropped.
-
-#### Syntax
-* Endpoint should be double quoted.
-* Metrics should be specified in form of a list.
-
-#### Example
-```yaml
-receivers:
-    prometheus:
-      include_filter: {
-        "0.0.0.0:9777" : [http/server/server_latency, custom_metric1],
-        "0.0.0.0:9778" : [http/client/roundtrip_latency],
-      }
-      config:
-        scrape_configs:
-          ...
-```
-
 The full list of settings exposed for this receiver are documented [here](./config.go)
 with detailed sample configurations [here](./testdata/config.yaml).


### PR DESCRIPTION
**Description:** Removing out of date documentation for prometheus reciever with regards to IncludeFilter.

**Link to tracking Issue:** N/A, [PR 416](https://github.com/open-telemetry/opentelemetry-collector/pull/416) removed code that this documentation is describing.

**Testing:** N/A

**Documentation:** Removal of incorrect documentation.