### PR TITLE
Proposal: refactor CreateLogsProcessor arguments order to make it consistent

### DIFF
--- a/component/componenttest/example_factories.go
+++ b/component/componenttest/example_factories.go
@@ -407,8 +407,8 @@ func (f *ExampleProcessorFactory) CreateMetricsProcessor(
 func (f *ExampleProcessorFactory) CreateLogsProcessor(
 	_ context.Context,
 	_ component.ProcessorCreateParams,
-	_ configmodels.Processor,
 	nextConsumer consumer.LogsConsumer,
+	_ configmodels.Processor,
 ) (component.LogsProcessor, error) {
 	return &ExampleProcessor{nextLogs: nextConsumer}, nil
 }

--- a/component/processor.go
+++ b/component/processor.go
@@ -99,10 +99,6 @@ type ProcessorFactory interface {
 	// CreateLogsProcessor creates a processor based on the config.
 	// If the processor type does not support logs or if the config is not valid
 	// error will be returned instead.
-	CreateLogsProcessor(
-		ctx context.Context,
-		params ProcessorCreateParams,
-		cfg configmodels.Processor,
-		nextConsumer consumer.LogsConsumer,
-	) (LogsProcessor, error)
+	CreateLogsProcessor(ctx context.Context,params ProcessorCreateParams,
+		nextConsumer consumer.LogsConsumer, cfg configmodels.Processor) (LogsProcessor, error)
 }

--- a/component/processor_test.go
+++ b/component/processor_test.go
@@ -50,7 +50,7 @@ func (f *TestProcessorFactory) CreateMetricsProcessor(context.Context, Processor
 }
 
 // CreateMetricsProcessor creates a metrics processor based on this config.
-func (f *TestProcessorFactory) CreateLogsProcessor(context.Context, ProcessorCreateParams, configmodels.Processor, consumer.LogsConsumer) (LogsProcessor, error) {
+func (f *TestProcessorFactory) CreateLogsProcessor(context.Context, ProcessorCreateParams, consumer.LogsConsumer, configmodels.Processor) (LogsProcessor, error) {
 	return nil, configerror.ErrDataTypeIsNotSupported
 }
 

--- a/processor/batchprocessor/factory_test.go
+++ b/processor/batchprocessor/factory_test.go
@@ -46,7 +46,7 @@ func TestCreateProcessor(t *testing.T) {
 	assert.NotNil(t, mp)
 	assert.NoError(t, err, "cannot create metric processor")
 
-	lp, err := factory.CreateLogsProcessor(context.Background(), creationParams, cfg, nil)
+	lp, err := factory.CreateLogsProcessor(context.Background(), creationParams, nil, cfg)
 	assert.NotNil(t, lp)
 	assert.NoError(t, err, "cannot create logs processor")
 }

--- a/processor/memorylimiter/factory_test.go
+++ b/processor/memorylimiter/factory_test.go
@@ -52,7 +52,7 @@ func TestCreateProcessor(t *testing.T) {
 	assert.Nil(t, mp)
 	assert.Error(t, err, "created processor with invalid settings")
 
-	lp, err := factory.CreateLogsProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, cfg, exportertest.NewNopLogsExporter())
+	lp, err := factory.CreateLogsProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, exportertest.NewNopLogsExporter(), cfg)
 	assert.Nil(t, lp)
 	assert.Error(t, err, "created processor with invalid settings")
 
@@ -73,7 +73,7 @@ func TestCreateProcessor(t *testing.T) {
 	assert.NotNil(t, mp)
 	assert.NoError(t, mp.Shutdown(context.Background()))
 
-	lp, err = factory.CreateLogsProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, cfg, exportertest.NewNopLogsExporter())
+	lp, err = factory.CreateLogsProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, exportertest.NewNopLogsExporter(), cfg)
 	assert.NoError(t, err)
 	assert.NotNil(t, lp)
 	assert.NoError(t, lp.Shutdown(context.Background()))

--- a/processor/processorhelper/factory.go
+++ b/processor/processorhelper/factory.go
@@ -136,9 +136,8 @@ func (f *factory) CreateMetricsProcessor(
 func (f *factory) CreateLogsProcessor(
 	ctx context.Context,
 	params component.ProcessorCreateParams,
-	cfg configmodels.Processor,
 	nextConsumer consumer.LogsConsumer,
-) (component.LogsProcessor, error) {
+	cfg configmodels.Processor) (component.LogsProcessor, error) {
 	if f.createLogsProcessor != nil {
 		return f.createLogsProcessor(ctx, params, cfg, nextConsumer)
 	}

--- a/processor/processorhelper/factory_test.go
+++ b/processor/processorhelper/factory_test.go
@@ -46,7 +46,7 @@ func TestNewTrace(t *testing.T) {
 	assert.Error(t, err)
 	_, err = factory.CreateMetricsProcessor(context.Background(), component.ProcessorCreateParams{}, nil, defaultCfg)
 	assert.Error(t, err)
-	_, err = factory.CreateLogsProcessor(context.Background(), component.ProcessorCreateParams{}, defaultCfg, nil)
+	_, err = factory.CreateLogsProcessor(context.Background(), component.ProcessorCreateParams{}, nil, defaultCfg)
 	assert.Error(t, err)
 }
 
@@ -71,7 +71,7 @@ func TestNewMetrics_WithConstructors(t *testing.T) {
 	_, err = factory.CreateMetricsProcessor(context.Background(), component.ProcessorCreateParams{}, nil, defaultCfg)
 	assert.NoError(t, err)
 
-	_, err = factory.CreateLogsProcessor(context.Background(), component.ProcessorCreateParams{}, defaultCfg, nil)
+	_, err = factory.CreateLogsProcessor(context.Background(), component.ProcessorCreateParams{}, nil, defaultCfg)
 	assert.NoError(t, err)
 }
 

--- a/service/builder/pipelines_builder.go
+++ b/service/builder/pipelines_builder.go
@@ -179,7 +179,7 @@ func (pb *PipelinesBuilder) buildPipeline(ctx context.Context, pipelineCfg *conf
 
 		case configmodels.LogsDataType:
 			var proc component.LogsProcessor
-			proc, err = factory.CreateLogsProcessor(ctx, creationParams, procCfg, lc)
+			proc, err = factory.CreateLogsProcessor(ctx, creationParams, lc, procCfg)
 			if proc != nil {
 				mutatesConsumedData = mutatesConsumedData || proc.GetCapabilities().MutatesConsumedData
 			}


### PR DESCRIPTION
**Description:** 

Refactors `CreateLogsProcessor` factory arguments order to make it consistent with `CreateMetricsProcessor` and `CreateLogsProcessor`

**Link to tracking Issue:** N/A

**Testing:** N/A

**Documentation:** N/A