### PR TITLE
Return consumererror.Permanent in the Prometheus remote write exporter

### DIFF
--- a/exporter/prometheusremotewriteexporter/exporter_test.go
+++ b/exporter/prometheusremotewriteexporter/exporter_test.go
@@ -565,6 +565,15 @@ func Test_PushMetrics(t *testing.T) {
 			false,
 		},
 		{
+			"5xx_case",
+			&unmatchedBoundBucketDoubleHistBatch,
+			checkFunc,
+			5,
+			http.StatusServiceUnavailable,
+			1,
+			true,
+		},
+		{
 			"nilDataPointDoubleGauge_case",
 			&nilDataPointDoubleGaugeBatch,
 			checkFunc,


### PR DESCRIPTION
 This PR changes the Prometheus remote write to return error of consumererror.permanent type when a invalid metric is encountered or a non-5xx HTTP status code is received from the backend.

linked issue: resolves #1733 

cc: @bogdandrutu @alolita @jmacd @huyan0 