### PR TITLE
Fix panic while processing Zipkin spans with empty service name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 - Fix multiple exporters panic (#1563)
 - Allow `attribute` processor for external use (#1574)
 - Do not duplicate filesystem metrics for devices with many mount points (#1617)
+- Fix a panic issue while processing Zipkin spans with an empty service name (#1742)
 
 ## v0.8.0 Beta
 

--- a/receiver/zipkinreceiver/testdata/sample2.json
+++ b/receiver/zipkinreceiver/testdata/sample2.json
@@ -1,0 +1,32 @@
+[
+  {
+    "traceId": "4d1e00c0db9010db86154a4ba6e91385",
+    "parentId": "86154a4ba6e91385",
+    "id": "4d1e00c0db9010db",
+    "kind": "CLIENT",
+    "name": "get",
+    "timestamp": 1472470996199000,
+    "duration": 207000,
+    "localEndpoint": {
+      "ipv6": "7::0.128.128.127"
+    },
+    "remoteEndpoint": {
+      "ipv4": "192.168.99.101",
+      "port": 9000
+    },
+    "annotations": [
+      {
+        "timestamp": 1472470996238000,
+        "value": "foo"
+      },
+      {
+        "timestamp": 1472470996403000,
+        "value": "bar"
+      }
+    ],
+    "tags": {
+      "http.path": "/api",
+      "clnt/finagle.version": "6.45.0"
+    }
+  }
+]

--- a/receiver/zipkinreceiver/trace_receiver_test.go
+++ b/receiver/zipkinreceiver/trace_receiver_test.go
@@ -122,7 +122,7 @@ func TestConvertSpansToTraceSpans_json(t *testing.T) {
 	reqs, err := zi.v2ToTraceSpans(blob, nil)
 	require.NoError(t, err, "Failed to parse convert Zipkin spans in JSON to Trace spans: %v", err)
 
-	require.Equal(t, reqs.ResourceSpans().Len(), 1, "Expecting only one request since all spans share same node/localEndpoint: %v", reqs.ResourceSpans().Len())
+	require.Equal(t, 1, reqs.ResourceSpans().Len(), "Expecting only one request since all spans share same node/localEndpoint: %v", reqs.ResourceSpans().Len())
 
 	req := reqs.ResourceSpans().At(0)
 	sn, _ := req.Resource().Attributes().Get(conventions.AttributeServiceName)
@@ -525,4 +525,17 @@ type zipkinMockTraceConsumer struct {
 func (m *zipkinMockTraceConsumer) ConsumeTraces(_ context.Context, td pdata.Traces) error {
 	m.ch <- td
 	return m.err
+}
+
+func TestConvertSpansToTraceSpans_JSONWithoutSerivceName(t *testing.T) {
+	blob, err := ioutil.ReadFile("./testdata/sample2.json")
+	require.NoError(t, err, "Failed to read sample JSON file: %v", err)
+	zi := new(ZipkinReceiver)
+	reqs, err := zi.v2ToTraceSpans(blob, nil)
+	require.NoError(t, err, "Failed to parse convert Zipkin spans in JSON to Trace spans: %v", err)
+
+	require.Equal(t, 1, reqs.ResourceSpans().Len(), "Expecting only one request since all spans share same node/localEndpoint: %v", reqs.ResourceSpans().Len())
+
+	// Expecting 1 non-nil spans
+	require.Equal(t, 1, reqs.SpanCount(), "Incorrect non-nil spans count")
 }

--- a/translator/trace/zipkin/zipkinv2_to_traces.go
+++ b/translator/trace/zipkin/zipkinv2_to_traces.go
@@ -449,7 +449,7 @@ func copySpanTags(tags map[string]string) map[string]string {
 }
 
 func extractLocalServiceName(zspan *zipkinmodel.SpanModel) string {
-	if zspan == nil || zspan.LocalEndpoint == nil {
+	if zspan == nil || zspan.LocalEndpoint == nil || zspan.LocalEndpoint.ServiceName == "" {
 		return tracetranslator.ResourceNotSet
 	}
 	return zspan.LocalEndpoint.ServiceName


### PR DESCRIPTION
**Description:**

Fix a panic issue while processing Zipkin spans with an empty service name.

**Testing:** 

`receiver/zipkinreceiver/TestConvertSpansToTraceSpans_JSONWithoutSerivceName`
