### PR TITLE
Zipkin Receiver: Always set the endtime

### DIFF
--- a/translator/trace/zipkin/zipkinv2_to_traces.go
+++ b/translator/trace/zipkin/zipkinv2_to_traces.go
@@ -166,9 +166,7 @@ func zSpanToInternal(zspan *zipkinmodel.SpanModel, tags map[string]string, dest 
 	dest.SetName(zspan.Name)
 	startNano := zspan.Timestamp.UnixNano()
 	dest.SetStartTime(pdata.TimestampUnixNano(startNano))
-	if zspan.Duration.Nanoseconds() > 0 {
-		dest.SetEndTime(pdata.TimestampUnixNano(startNano + zspan.Duration.Nanoseconds()))
-	}
+	dest.SetEndTime(pdata.TimestampUnixNano(startNano + zspan.Duration.Nanoseconds()))
 	dest.SetKind(zipkinKindToSpanKind(zspan.Kind, tags))
 
 	populateSpanStatus(tags, dest.Status())


### PR DESCRIPTION
**Description:** 
Fixes https://github.com/open-telemetry/opentelemetry-collector/issues/1749 allowing the zipkin span duration to be zero

