### PR TITLE
Add EnsureInit to pdata structs

### DIFF
--- a/cmd/pdatagen/internal/base_structs.go
+++ b/cmd/pdatagen/internal/base_structs.go
@@ -304,6 +304,14 @@ func (ms ${structName}) InitEmpty() {
 	*ms.orig = &${originName}{}
 }
 
+// InitEmpty overwrites the current value with empty.
+func (ms ${structName}) EnsureInit() ${structName} {
+	if ms.IsNil() {
+		ms.InitEmpty()
+	}
+	return ms
+}
+
 // IsNil returns true if the underlying data are nil.
 //
 // Important: All other functions will cause a runtime error if this returns "true".
@@ -329,6 +337,16 @@ const messageTestTemplate = `func Test${structName}_InitEmpty(t *testing.T) {
 	ms.InitEmpty()
 	assert.False(t, ms.IsNil())
 }
+
+func Test${structName}_EnsureInit(t *testing.T) {
+	ms := New${structName}()
+	assert.True(t, ms.IsNil())
+	assert.False(t, ms.EnsureInit().IsNil())
+	oldOrig := ms.orig
+	assert.False(t, ms.EnsureInit().IsNil())
+	assert.Equal(t, oldOrig, ms.orig)
+}
+
 
 func Test${structName}_CopyTo(t *testing.T) {
 	ms := New${structName}()

--- a/consumer/pdata/generated_common.go
+++ b/consumer/pdata/generated_common.go
@@ -52,6 +52,14 @@ func (ms InstrumentationLibrary) InitEmpty() {
 	*ms.orig = &otlpcommon.InstrumentationLibrary{}
 }
 
+// InitEmpty overwrites the current value with empty.
+func (ms InstrumentationLibrary) EnsureInit() InstrumentationLibrary {
+	if ms.IsNil() {
+		ms.InitEmpty()
+	}
+	return ms
+}
+
 // IsNil returns true if the underlying data are nil.
 //
 // Important: All other functions will cause a runtime error if this returns "true".

--- a/consumer/pdata/generated_common_test.go
+++ b/consumer/pdata/generated_common_test.go
@@ -32,6 +32,15 @@ func TestInstrumentationLibrary_InitEmpty(t *testing.T) {
 	assert.False(t, ms.IsNil())
 }
 
+func TestInstrumentationLibrary_EnsureInit(t *testing.T) {
+	ms := NewInstrumentationLibrary()
+	assert.True(t, ms.IsNil())
+	assert.False(t, ms.EnsureInit().IsNil())
+	oldOrig := ms.orig
+	assert.False(t, ms.EnsureInit().IsNil())
+	assert.Equal(t, oldOrig, ms.orig)
+}
+
 func TestInstrumentationLibrary_CopyTo(t *testing.T) {
 	ms := NewInstrumentationLibrary()
 	NewInstrumentationLibrary().CopyTo(ms)

--- a/consumer/pdata/generated_log.go
+++ b/consumer/pdata/generated_log.go
@@ -175,6 +175,14 @@ func (ms ResourceLogs) InitEmpty() {
 	*ms.orig = &otlplogs.ResourceLogs{}
 }
 
+// InitEmpty overwrites the current value with empty.
+func (ms ResourceLogs) EnsureInit() ResourceLogs {
+	if ms.IsNil() {
+		ms.InitEmpty()
+	}
+	return ms
+}
+
 // IsNil returns true if the underlying data are nil.
 //
 // Important: All other functions will cause a runtime error if this returns "true".
@@ -364,6 +372,14 @@ func NewInstrumentationLibraryLogs() InstrumentationLibraryLogs {
 // InitEmpty overwrites the current value with empty.
 func (ms InstrumentationLibraryLogs) InitEmpty() {
 	*ms.orig = &otlplogs.InstrumentationLibraryLogs{}
+}
+
+// InitEmpty overwrites the current value with empty.
+func (ms InstrumentationLibraryLogs) EnsureInit() InstrumentationLibraryLogs {
+	if ms.IsNil() {
+		ms.InitEmpty()
+	}
+	return ms
 }
 
 // IsNil returns true if the underlying data are nil.
@@ -556,6 +572,14 @@ func NewLogRecord() LogRecord {
 // InitEmpty overwrites the current value with empty.
 func (ms LogRecord) InitEmpty() {
 	*ms.orig = &otlplogs.LogRecord{}
+}
+
+// InitEmpty overwrites the current value with empty.
+func (ms LogRecord) EnsureInit() LogRecord {
+	if ms.IsNil() {
+		ms.InitEmpty()
+	}
+	return ms
 }
 
 // IsNil returns true if the underlying data are nil.

--- a/consumer/pdata/generated_log_test.go
+++ b/consumer/pdata/generated_log_test.go
@@ -150,6 +150,15 @@ func TestResourceLogs_InitEmpty(t *testing.T) {
 	assert.False(t, ms.IsNil())
 }
 
+func TestResourceLogs_EnsureInit(t *testing.T) {
+	ms := NewResourceLogs()
+	assert.True(t, ms.IsNil())
+	assert.False(t, ms.EnsureInit().IsNil())
+	oldOrig := ms.orig
+	assert.False(t, ms.EnsureInit().IsNil())
+	assert.Equal(t, oldOrig, ms.orig)
+}
+
 func TestResourceLogs_CopyTo(t *testing.T) {
 	ms := NewResourceLogs()
 	NewResourceLogs().CopyTo(ms)
@@ -302,6 +311,15 @@ func TestInstrumentationLibraryLogs_InitEmpty(t *testing.T) {
 	assert.False(t, ms.IsNil())
 }
 
+func TestInstrumentationLibraryLogs_EnsureInit(t *testing.T) {
+	ms := NewInstrumentationLibraryLogs()
+	assert.True(t, ms.IsNil())
+	assert.False(t, ms.EnsureInit().IsNil())
+	oldOrig := ms.orig
+	assert.False(t, ms.EnsureInit().IsNil())
+	assert.Equal(t, oldOrig, ms.orig)
+}
+
 func TestInstrumentationLibraryLogs_CopyTo(t *testing.T) {
 	ms := NewInstrumentationLibraryLogs()
 	NewInstrumentationLibraryLogs().CopyTo(ms)
@@ -452,6 +470,15 @@ func TestLogRecord_InitEmpty(t *testing.T) {
 	assert.True(t, ms.IsNil())
 	ms.InitEmpty()
 	assert.False(t, ms.IsNil())
+}
+
+func TestLogRecord_EnsureInit(t *testing.T) {
+	ms := NewLogRecord()
+	assert.True(t, ms.IsNil())
+	assert.False(t, ms.EnsureInit().IsNil())
+	oldOrig := ms.orig
+	assert.False(t, ms.EnsureInit().IsNil())
+	assert.Equal(t, oldOrig, ms.orig)
 }
 
 func TestLogRecord_CopyTo(t *testing.T) {

--- a/consumer/pdata/generated_metrics.go
+++ b/consumer/pdata/generated_metrics.go
@@ -175,6 +175,14 @@ func (ms ResourceMetrics) InitEmpty() {
 	*ms.orig = &otlpmetrics.ResourceMetrics{}
 }
 
+// InitEmpty overwrites the current value with empty.
+func (ms ResourceMetrics) EnsureInit() ResourceMetrics {
+	if ms.IsNil() {
+		ms.InitEmpty()
+	}
+	return ms
+}
+
 // IsNil returns true if the underlying data are nil.
 //
 // Important: All other functions will cause a runtime error if this returns "true".
@@ -364,6 +372,14 @@ func NewInstrumentationLibraryMetrics() InstrumentationLibraryMetrics {
 // InitEmpty overwrites the current value with empty.
 func (ms InstrumentationLibraryMetrics) InitEmpty() {
 	*ms.orig = &otlpmetrics.InstrumentationLibraryMetrics{}
+}
+
+// InitEmpty overwrites the current value with empty.
+func (ms InstrumentationLibraryMetrics) EnsureInit() InstrumentationLibraryMetrics {
+	if ms.IsNil() {
+		ms.InitEmpty()
+	}
+	return ms
 }
 
 // IsNil returns true if the underlying data are nil.
@@ -558,6 +574,14 @@ func (ms Metric) InitEmpty() {
 	*ms.orig = &otlpmetrics.Metric{}
 }
 
+// InitEmpty overwrites the current value with empty.
+func (ms Metric) EnsureInit() Metric {
+	if ms.IsNil() {
+		ms.InitEmpty()
+	}
+	return ms
+}
+
 // IsNil returns true if the underlying data are nil.
 //
 // Important: All other functions will cause a runtime error if this returns "true".
@@ -653,6 +677,14 @@ func (ms IntGauge) InitEmpty() {
 	*ms.orig = &otlpmetrics.IntGauge{}
 }
 
+// InitEmpty overwrites the current value with empty.
+func (ms IntGauge) EnsureInit() IntGauge {
+	if ms.IsNil() {
+		ms.InitEmpty()
+	}
+	return ms
+}
+
 // IsNil returns true if the underlying data are nil.
 //
 // Important: All other functions will cause a runtime error if this returns "true".
@@ -710,6 +742,14 @@ func (ms DoubleGauge) InitEmpty() {
 	*ms.orig = &otlpmetrics.DoubleGauge{}
 }
 
+// InitEmpty overwrites the current value with empty.
+func (ms DoubleGauge) EnsureInit() DoubleGauge {
+	if ms.IsNil() {
+		ms.InitEmpty()
+	}
+	return ms
+}
+
 // IsNil returns true if the underlying data are nil.
 //
 // Important: All other functions will cause a runtime error if this returns "true".
@@ -765,6 +805,14 @@ func NewIntSum() IntSum {
 // InitEmpty overwrites the current value with empty.
 func (ms IntSum) InitEmpty() {
 	*ms.orig = &otlpmetrics.IntSum{}
+}
+
+// InitEmpty overwrites the current value with empty.
+func (ms IntSum) EnsureInit() IntSum {
+	if ms.IsNil() {
+		ms.InitEmpty()
+	}
+	return ms
 }
 
 // IsNil returns true if the underlying data are nil.
@@ -854,6 +902,14 @@ func (ms DoubleSum) InitEmpty() {
 	*ms.orig = &otlpmetrics.DoubleSum{}
 }
 
+// InitEmpty overwrites the current value with empty.
+func (ms DoubleSum) EnsureInit() DoubleSum {
+	if ms.IsNil() {
+		ms.InitEmpty()
+	}
+	return ms
+}
+
 // IsNil returns true if the underlying data are nil.
 //
 // Important: All other functions will cause a runtime error if this returns "true".
@@ -941,6 +997,14 @@ func (ms IntHistogram) InitEmpty() {
 	*ms.orig = &otlpmetrics.IntHistogram{}
 }
 
+// InitEmpty overwrites the current value with empty.
+func (ms IntHistogram) EnsureInit() IntHistogram {
+	if ms.IsNil() {
+		ms.InitEmpty()
+	}
+	return ms
+}
+
 // IsNil returns true if the underlying data are nil.
 //
 // Important: All other functions will cause a runtime error if this returns "true".
@@ -1011,6 +1075,14 @@ func NewDoubleHistogram() DoubleHistogram {
 // InitEmpty overwrites the current value with empty.
 func (ms DoubleHistogram) InitEmpty() {
 	*ms.orig = &otlpmetrics.DoubleHistogram{}
+}
+
+// InitEmpty overwrites the current value with empty.
+func (ms DoubleHistogram) EnsureInit() DoubleHistogram {
+	if ms.IsNil() {
+		ms.InitEmpty()
+	}
+	return ms
 }
 
 // IsNil returns true if the underlying data are nil.
@@ -1206,6 +1278,14 @@ func NewIntDataPoint() IntDataPoint {
 // InitEmpty overwrites the current value with empty.
 func (ms IntDataPoint) InitEmpty() {
 	*ms.orig = &otlpmetrics.IntDataPoint{}
+}
+
+// InitEmpty overwrites the current value with empty.
+func (ms IntDataPoint) EnsureInit() IntDataPoint {
+	if ms.IsNil() {
+		ms.InitEmpty()
+	}
+	return ms
 }
 
 // IsNil returns true if the underlying data are nil.
@@ -1441,6 +1521,14 @@ func (ms DoubleDataPoint) InitEmpty() {
 	*ms.orig = &otlpmetrics.DoubleDataPoint{}
 }
 
+// InitEmpty overwrites the current value with empty.
+func (ms DoubleDataPoint) EnsureInit() DoubleDataPoint {
+	if ms.IsNil() {
+		ms.InitEmpty()
+	}
+	return ms
+}
+
 // IsNil returns true if the underlying data are nil.
 //
 // Important: All other functions will cause a runtime error if this returns "true".
@@ -1672,6 +1760,14 @@ func NewIntHistogramDataPoint() IntHistogramDataPoint {
 // InitEmpty overwrites the current value with empty.
 func (ms IntHistogramDataPoint) InitEmpty() {
 	*ms.orig = &otlpmetrics.IntHistogramDataPoint{}
+}
+
+// InitEmpty overwrites the current value with empty.
+func (ms IntHistogramDataPoint) EnsureInit() IntHistogramDataPoint {
+	if ms.IsNil() {
+		ms.InitEmpty()
+	}
+	return ms
 }
 
 // IsNil returns true if the underlying data are nil.
@@ -1950,6 +2046,14 @@ func NewDoubleHistogramDataPoint() DoubleHistogramDataPoint {
 // InitEmpty overwrites the current value with empty.
 func (ms DoubleHistogramDataPoint) InitEmpty() {
 	*ms.orig = &otlpmetrics.DoubleHistogramDataPoint{}
+}
+
+// InitEmpty overwrites the current value with empty.
+func (ms DoubleHistogramDataPoint) EnsureInit() DoubleHistogramDataPoint {
+	if ms.IsNil() {
+		ms.InitEmpty()
+	}
+	return ms
 }
 
 // IsNil returns true if the underlying data are nil.
@@ -2233,6 +2337,14 @@ func (ms IntExemplar) InitEmpty() {
 	*ms.orig = &otlpmetrics.IntExemplar{}
 }
 
+// InitEmpty overwrites the current value with empty.
+func (ms IntExemplar) EnsureInit() IntExemplar {
+	if ms.IsNil() {
+		ms.InitEmpty()
+	}
+	return ms
+}
+
 // IsNil returns true if the underlying data are nil.
 //
 // Important: All other functions will cause a runtime error if this returns "true".
@@ -2444,6 +2556,14 @@ func NewDoubleExemplar() DoubleExemplar {
 // InitEmpty overwrites the current value with empty.
 func (ms DoubleExemplar) InitEmpty() {
 	*ms.orig = &otlpmetrics.DoubleExemplar{}
+}
+
+// InitEmpty overwrites the current value with empty.
+func (ms DoubleExemplar) EnsureInit() DoubleExemplar {
+	if ms.IsNil() {
+		ms.InitEmpty()
+	}
+	return ms
 }
 
 // IsNil returns true if the underlying data are nil.

--- a/consumer/pdata/generated_metrics_test.go
+++ b/consumer/pdata/generated_metrics_test.go
@@ -150,6 +150,15 @@ func TestResourceMetrics_InitEmpty(t *testing.T) {
 	assert.False(t, ms.IsNil())
 }
 
+func TestResourceMetrics_EnsureInit(t *testing.T) {
+	ms := NewResourceMetrics()
+	assert.True(t, ms.IsNil())
+	assert.False(t, ms.EnsureInit().IsNil())
+	oldOrig := ms.orig
+	assert.False(t, ms.EnsureInit().IsNil())
+	assert.Equal(t, oldOrig, ms.orig)
+}
+
 func TestResourceMetrics_CopyTo(t *testing.T) {
 	ms := NewResourceMetrics()
 	NewResourceMetrics().CopyTo(ms)
@@ -300,6 +309,15 @@ func TestInstrumentationLibraryMetrics_InitEmpty(t *testing.T) {
 	assert.True(t, ms.IsNil())
 	ms.InitEmpty()
 	assert.False(t, ms.IsNil())
+}
+
+func TestInstrumentationLibraryMetrics_EnsureInit(t *testing.T) {
+	ms := NewInstrumentationLibraryMetrics()
+	assert.True(t, ms.IsNil())
+	assert.False(t, ms.EnsureInit().IsNil())
+	oldOrig := ms.orig
+	assert.False(t, ms.EnsureInit().IsNil())
+	assert.Equal(t, oldOrig, ms.orig)
 }
 
 func TestInstrumentationLibraryMetrics_CopyTo(t *testing.T) {
@@ -454,6 +472,15 @@ func TestMetric_InitEmpty(t *testing.T) {
 	assert.False(t, ms.IsNil())
 }
 
+func TestMetric_EnsureInit(t *testing.T) {
+	ms := NewMetric()
+	assert.True(t, ms.IsNil())
+	assert.False(t, ms.EnsureInit().IsNil())
+	oldOrig := ms.orig
+	assert.False(t, ms.EnsureInit().IsNil())
+	assert.Equal(t, oldOrig, ms.orig)
+}
+
 func TestMetric_CopyTo(t *testing.T) {
 	ms := NewMetric()
 	NewMetric().CopyTo(ms)
@@ -496,6 +523,15 @@ func TestIntGauge_InitEmpty(t *testing.T) {
 	assert.False(t, ms.IsNil())
 }
 
+func TestIntGauge_EnsureInit(t *testing.T) {
+	ms := NewIntGauge()
+	assert.True(t, ms.IsNil())
+	assert.False(t, ms.EnsureInit().IsNil())
+	oldOrig := ms.orig
+	assert.False(t, ms.EnsureInit().IsNil())
+	assert.Equal(t, oldOrig, ms.orig)
+}
+
 func TestIntGauge_CopyTo(t *testing.T) {
 	ms := NewIntGauge()
 	NewIntGauge().CopyTo(ms)
@@ -520,6 +556,15 @@ func TestDoubleGauge_InitEmpty(t *testing.T) {
 	assert.False(t, ms.IsNil())
 }
 
+func TestDoubleGauge_EnsureInit(t *testing.T) {
+	ms := NewDoubleGauge()
+	assert.True(t, ms.IsNil())
+	assert.False(t, ms.EnsureInit().IsNil())
+	oldOrig := ms.orig
+	assert.False(t, ms.EnsureInit().IsNil())
+	assert.Equal(t, oldOrig, ms.orig)
+}
+
 func TestDoubleGauge_CopyTo(t *testing.T) {
 	ms := NewDoubleGauge()
 	NewDoubleGauge().CopyTo(ms)
@@ -542,6 +587,15 @@ func TestIntSum_InitEmpty(t *testing.T) {
 	assert.True(t, ms.IsNil())
 	ms.InitEmpty()
 	assert.False(t, ms.IsNil())
+}
+
+func TestIntSum_EnsureInit(t *testing.T) {
+	ms := NewIntSum()
+	assert.True(t, ms.IsNil())
+	assert.False(t, ms.EnsureInit().IsNil())
+	oldOrig := ms.orig
+	assert.False(t, ms.EnsureInit().IsNil())
+	assert.Equal(t, oldOrig, ms.orig)
 }
 
 func TestIntSum_CopyTo(t *testing.T) {
@@ -586,6 +640,15 @@ func TestDoubleSum_InitEmpty(t *testing.T) {
 	assert.False(t, ms.IsNil())
 }
 
+func TestDoubleSum_EnsureInit(t *testing.T) {
+	ms := NewDoubleSum()
+	assert.True(t, ms.IsNil())
+	assert.False(t, ms.EnsureInit().IsNil())
+	oldOrig := ms.orig
+	assert.False(t, ms.EnsureInit().IsNil())
+	assert.Equal(t, oldOrig, ms.orig)
+}
+
 func TestDoubleSum_CopyTo(t *testing.T) {
 	ms := NewDoubleSum()
 	NewDoubleSum().CopyTo(ms)
@@ -628,6 +691,15 @@ func TestIntHistogram_InitEmpty(t *testing.T) {
 	assert.False(t, ms.IsNil())
 }
 
+func TestIntHistogram_EnsureInit(t *testing.T) {
+	ms := NewIntHistogram()
+	assert.True(t, ms.IsNil())
+	assert.False(t, ms.EnsureInit().IsNil())
+	oldOrig := ms.orig
+	assert.False(t, ms.EnsureInit().IsNil())
+	assert.Equal(t, oldOrig, ms.orig)
+}
+
 func TestIntHistogram_CopyTo(t *testing.T) {
 	ms := NewIntHistogram()
 	NewIntHistogram().CopyTo(ms)
@@ -659,6 +731,15 @@ func TestDoubleHistogram_InitEmpty(t *testing.T) {
 	assert.True(t, ms.IsNil())
 	ms.InitEmpty()
 	assert.False(t, ms.IsNil())
+}
+
+func TestDoubleHistogram_EnsureInit(t *testing.T) {
+	ms := NewDoubleHistogram()
+	assert.True(t, ms.IsNil())
+	assert.False(t, ms.EnsureInit().IsNil())
+	oldOrig := ms.orig
+	assert.False(t, ms.EnsureInit().IsNil())
+	assert.Equal(t, oldOrig, ms.orig)
 }
 
 func TestDoubleHistogram_CopyTo(t *testing.T) {
@@ -810,6 +891,15 @@ func TestIntDataPoint_InitEmpty(t *testing.T) {
 	assert.True(t, ms.IsNil())
 	ms.InitEmpty()
 	assert.False(t, ms.IsNil())
+}
+
+func TestIntDataPoint_EnsureInit(t *testing.T) {
+	ms := NewIntDataPoint()
+	assert.True(t, ms.IsNil())
+	assert.False(t, ms.EnsureInit().IsNil())
+	oldOrig := ms.orig
+	assert.False(t, ms.EnsureInit().IsNil())
+	assert.Equal(t, oldOrig, ms.orig)
 }
 
 func TestIntDataPoint_CopyTo(t *testing.T) {
@@ -990,6 +1080,15 @@ func TestDoubleDataPoint_InitEmpty(t *testing.T) {
 	assert.False(t, ms.IsNil())
 }
 
+func TestDoubleDataPoint_EnsureInit(t *testing.T) {
+	ms := NewDoubleDataPoint()
+	assert.True(t, ms.IsNil())
+	assert.False(t, ms.EnsureInit().IsNil())
+	oldOrig := ms.orig
+	assert.False(t, ms.EnsureInit().IsNil())
+	assert.Equal(t, oldOrig, ms.orig)
+}
+
 func TestDoubleDataPoint_CopyTo(t *testing.T) {
 	ms := NewDoubleDataPoint()
 	NewDoubleDataPoint().CopyTo(ms)
@@ -1166,6 +1265,15 @@ func TestIntHistogramDataPoint_InitEmpty(t *testing.T) {
 	assert.True(t, ms.IsNil())
 	ms.InitEmpty()
 	assert.False(t, ms.IsNil())
+}
+
+func TestIntHistogramDataPoint_EnsureInit(t *testing.T) {
+	ms := NewIntHistogramDataPoint()
+	assert.True(t, ms.IsNil())
+	assert.False(t, ms.EnsureInit().IsNil())
+	oldOrig := ms.orig
+	assert.False(t, ms.EnsureInit().IsNil())
+	assert.Equal(t, oldOrig, ms.orig)
 }
 
 func TestIntHistogramDataPoint_CopyTo(t *testing.T) {
@@ -1373,6 +1481,15 @@ func TestDoubleHistogramDataPoint_InitEmpty(t *testing.T) {
 	assert.False(t, ms.IsNil())
 }
 
+func TestDoubleHistogramDataPoint_EnsureInit(t *testing.T) {
+	ms := NewDoubleHistogramDataPoint()
+	assert.True(t, ms.IsNil())
+	assert.False(t, ms.EnsureInit().IsNil())
+	oldOrig := ms.orig
+	assert.False(t, ms.EnsureInit().IsNil())
+	assert.Equal(t, oldOrig, ms.orig)
+}
+
 func TestDoubleHistogramDataPoint_CopyTo(t *testing.T) {
 	ms := NewDoubleHistogramDataPoint()
 	NewDoubleHistogramDataPoint().CopyTo(ms)
@@ -1578,6 +1695,15 @@ func TestIntExemplar_InitEmpty(t *testing.T) {
 	assert.False(t, ms.IsNil())
 }
 
+func TestIntExemplar_EnsureInit(t *testing.T) {
+	ms := NewIntExemplar()
+	assert.True(t, ms.IsNil())
+	assert.False(t, ms.EnsureInit().IsNil())
+	oldOrig := ms.orig
+	assert.False(t, ms.EnsureInit().IsNil())
+	assert.Equal(t, oldOrig, ms.orig)
+}
+
 func TestIntExemplar_CopyTo(t *testing.T) {
 	ms := NewIntExemplar()
 	NewIntExemplar().CopyTo(ms)
@@ -1736,6 +1862,15 @@ func TestDoubleExemplar_InitEmpty(t *testing.T) {
 	assert.True(t, ms.IsNil())
 	ms.InitEmpty()
 	assert.False(t, ms.IsNil())
+}
+
+func TestDoubleExemplar_EnsureInit(t *testing.T) {
+	ms := NewDoubleExemplar()
+	assert.True(t, ms.IsNil())
+	assert.False(t, ms.EnsureInit().IsNil())
+	oldOrig := ms.orig
+	assert.False(t, ms.EnsureInit().IsNil())
+	assert.Equal(t, oldOrig, ms.orig)
 }
 
 func TestDoubleExemplar_CopyTo(t *testing.T) {

--- a/consumer/pdata/generated_resource.go
+++ b/consumer/pdata/generated_resource.go
@@ -52,6 +52,14 @@ func (ms Resource) InitEmpty() {
 	*ms.orig = &otlpresource.Resource{}
 }
 
+// InitEmpty overwrites the current value with empty.
+func (ms Resource) EnsureInit() Resource {
+	if ms.IsNil() {
+		ms.InitEmpty()
+	}
+	return ms
+}
+
 // IsNil returns true if the underlying data are nil.
 //
 // Important: All other functions will cause a runtime error if this returns "true".

--- a/consumer/pdata/generated_resource_test.go
+++ b/consumer/pdata/generated_resource_test.go
@@ -30,6 +30,15 @@ func TestResource_InitEmpty(t *testing.T) {
 	assert.False(t, ms.IsNil())
 }
 
+func TestResource_EnsureInit(t *testing.T) {
+	ms := NewResource()
+	assert.True(t, ms.IsNil())
+	assert.False(t, ms.EnsureInit().IsNil())
+	oldOrig := ms.orig
+	assert.False(t, ms.EnsureInit().IsNil())
+	assert.Equal(t, oldOrig, ms.orig)
+}
+
 func TestResource_CopyTo(t *testing.T) {
 	ms := NewResource()
 	NewResource().CopyTo(ms)

--- a/consumer/pdata/generated_trace.go
+++ b/consumer/pdata/generated_trace.go
@@ -175,6 +175,14 @@ func (ms ResourceSpans) InitEmpty() {
 	*ms.orig = &otlptrace.ResourceSpans{}
 }
 
+// InitEmpty overwrites the current value with empty.
+func (ms ResourceSpans) EnsureInit() ResourceSpans {
+	if ms.IsNil() {
+		ms.InitEmpty()
+	}
+	return ms
+}
+
 // IsNil returns true if the underlying data are nil.
 //
 // Important: All other functions will cause a runtime error if this returns "true".
@@ -364,6 +372,14 @@ func NewInstrumentationLibrarySpans() InstrumentationLibrarySpans {
 // InitEmpty overwrites the current value with empty.
 func (ms InstrumentationLibrarySpans) InitEmpty() {
 	*ms.orig = &otlptrace.InstrumentationLibrarySpans{}
+}
+
+// InitEmpty overwrites the current value with empty.
+func (ms InstrumentationLibrarySpans) EnsureInit() InstrumentationLibrarySpans {
+	if ms.IsNil() {
+		ms.InitEmpty()
+	}
+	return ms
 }
 
 // IsNil returns true if the underlying data are nil.
@@ -556,6 +572,14 @@ func NewSpan() Span {
 // InitEmpty overwrites the current value with empty.
 func (ms Span) InitEmpty() {
 	*ms.orig = &otlptrace.Span{}
+}
+
+// InitEmpty overwrites the current value with empty.
+func (ms Span) EnsureInit() Span {
+	if ms.IsNil() {
+		ms.InitEmpty()
+	}
+	return ms
 }
 
 // IsNil returns true if the underlying data are nil.
@@ -931,6 +955,14 @@ func (ms SpanEvent) InitEmpty() {
 	*ms.orig = &otlptrace.Span_Event{}
 }
 
+// InitEmpty overwrites the current value with empty.
+func (ms SpanEvent) EnsureInit() SpanEvent {
+	if ms.IsNil() {
+		ms.InitEmpty()
+	}
+	return ms
+}
+
 // IsNil returns true if the underlying data are nil.
 //
 // Important: All other functions will cause a runtime error if this returns "true".
@@ -1157,6 +1189,14 @@ func (ms SpanLink) InitEmpty() {
 	*ms.orig = &otlptrace.Span_Link{}
 }
 
+// InitEmpty overwrites the current value with empty.
+func (ms SpanLink) EnsureInit() SpanLink {
+	if ms.IsNil() {
+		ms.InitEmpty()
+	}
+	return ms
+}
+
 // IsNil returns true if the underlying data are nil.
 //
 // Important: All other functions will cause a runtime error if this returns "true".
@@ -1273,6 +1313,14 @@ func NewSpanStatus() SpanStatus {
 // InitEmpty overwrites the current value with empty.
 func (ms SpanStatus) InitEmpty() {
 	*ms.orig = &otlptrace.Status{}
+}
+
+// InitEmpty overwrites the current value with empty.
+func (ms SpanStatus) EnsureInit() SpanStatus {
+	if ms.IsNil() {
+		ms.InitEmpty()
+	}
+	return ms
 }
 
 // IsNil returns true if the underlying data are nil.

--- a/consumer/pdata/generated_trace_test.go
+++ b/consumer/pdata/generated_trace_test.go
@@ -150,6 +150,15 @@ func TestResourceSpans_InitEmpty(t *testing.T) {
 	assert.False(t, ms.IsNil())
 }
 
+func TestResourceSpans_EnsureInit(t *testing.T) {
+	ms := NewResourceSpans()
+	assert.True(t, ms.IsNil())
+	assert.False(t, ms.EnsureInit().IsNil())
+	oldOrig := ms.orig
+	assert.False(t, ms.EnsureInit().IsNil())
+	assert.Equal(t, oldOrig, ms.orig)
+}
+
 func TestResourceSpans_CopyTo(t *testing.T) {
 	ms := NewResourceSpans()
 	NewResourceSpans().CopyTo(ms)
@@ -302,6 +311,15 @@ func TestInstrumentationLibrarySpans_InitEmpty(t *testing.T) {
 	assert.False(t, ms.IsNil())
 }
 
+func TestInstrumentationLibrarySpans_EnsureInit(t *testing.T) {
+	ms := NewInstrumentationLibrarySpans()
+	assert.True(t, ms.IsNil())
+	assert.False(t, ms.EnsureInit().IsNil())
+	oldOrig := ms.orig
+	assert.False(t, ms.EnsureInit().IsNil())
+	assert.Equal(t, oldOrig, ms.orig)
+}
+
 func TestInstrumentationLibrarySpans_CopyTo(t *testing.T) {
 	ms := NewInstrumentationLibrarySpans()
 	NewInstrumentationLibrarySpans().CopyTo(ms)
@@ -452,6 +470,15 @@ func TestSpan_InitEmpty(t *testing.T) {
 	assert.True(t, ms.IsNil())
 	ms.InitEmpty()
 	assert.False(t, ms.IsNil())
+}
+
+func TestSpan_EnsureInit(t *testing.T) {
+	ms := NewSpan()
+	assert.True(t, ms.IsNil())
+	assert.False(t, ms.EnsureInit().IsNil())
+	oldOrig := ms.orig
+	assert.False(t, ms.EnsureInit().IsNil())
+	assert.Equal(t, oldOrig, ms.orig)
 }
 
 func TestSpan_CopyTo(t *testing.T) {
@@ -723,6 +750,15 @@ func TestSpanEvent_InitEmpty(t *testing.T) {
 	assert.False(t, ms.IsNil())
 }
 
+func TestSpanEvent_EnsureInit(t *testing.T) {
+	ms := NewSpanEvent()
+	assert.True(t, ms.IsNil())
+	assert.False(t, ms.EnsureInit().IsNil())
+	oldOrig := ms.orig
+	assert.False(t, ms.EnsureInit().IsNil())
+	assert.Equal(t, oldOrig, ms.orig)
+}
+
 func TestSpanEvent_CopyTo(t *testing.T) {
 	ms := NewSpanEvent()
 	NewSpanEvent().CopyTo(ms)
@@ -892,6 +928,15 @@ func TestSpanLink_InitEmpty(t *testing.T) {
 	assert.False(t, ms.IsNil())
 }
 
+func TestSpanLink_EnsureInit(t *testing.T) {
+	ms := NewSpanLink()
+	assert.True(t, ms.IsNil())
+	assert.False(t, ms.EnsureInit().IsNil())
+	oldOrig := ms.orig
+	assert.False(t, ms.EnsureInit().IsNil())
+	assert.Equal(t, oldOrig, ms.orig)
+}
+
 func TestSpanLink_CopyTo(t *testing.T) {
 	ms := NewSpanLink()
 	NewSpanLink().CopyTo(ms)
@@ -950,6 +995,15 @@ func TestSpanStatus_InitEmpty(t *testing.T) {
 	assert.True(t, ms.IsNil())
 	ms.InitEmpty()
 	assert.False(t, ms.IsNil())
+}
+
+func TestSpanStatus_EnsureInit(t *testing.T) {
+	ms := NewSpanStatus()
+	assert.True(t, ms.IsNil())
+	assert.False(t, ms.EnsureInit().IsNil())
+	oldOrig := ms.orig
+	assert.False(t, ms.EnsureInit().IsNil())
+	assert.Equal(t, oldOrig, ms.orig)
 }
 
 func TestSpanStatus_CopyTo(t *testing.T) {


### PR DESCRIPTION
This makes it a bit easier to work with data where the current
logic does not know whether the object has been initialized already
or not.  This is especially useful with the list-like data structures.

This will come in very handy for some updates I want to make to #1540.