### PR TITLE
Increase Zipkin perf test memory limit to avoid failures

### DIFF
--- a/testbed/tests/trace_test.go
+++ b/testbed/tests/trace_test.go
@@ -79,7 +79,7 @@ func TestTrace10kSPS(t *testing.T) {
 			testbed.NewZipkinDataReceiver(testbed.GetAvailablePort(t)),
 			testbed.ResourceSpec{
 				ExpectedMaxCPU: 80,
-				ExpectedMaxRAM: 70,
+				ExpectedMaxRAM: 80,
 			},
 		},
 	}


### PR DESCRIPTION
Zipkin appears to need more memory and randomly fails sometimes, e.g.:
https://app.circleci.com/pipelines/github/open-telemetry/opentelemetry-collector/3370/workflows/73f553df-16ba-40f4-aa04-8f01968b2728/jobs/34445
