### PR TITLE
Fix `make test`

### DIFF
--- a/internal/empty.go
+++ b/internal/empty.go
@@ -1,0 +1,18 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+// This file is needed to please `go list` which otherwise complains that tools.go is
+// only file in this package and that build constraints exclude it.

--- a/internal/empty_test.go
+++ b/internal/empty_test.go
@@ -1,0 +1,15 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal


### PR DESCRIPTION
empty.go file is needed to please `go list` which otherwise complains that tools.go is
only file in the internal package and that build constraints exclude it.

This results in empty list of tests when using `make test` command which then
silently skips all tests.

This fixes the problem and `make test` works properly.
