### PR TITLE
exporter/zipkin: fix example yaml indentation

### DIFF
--- a/exporter/zipkinexporter/README.md
+++ b/exporter/zipkinexporter/README.md
@@ -26,8 +26,8 @@ Example:
 
 ```yaml
 exporters:
-zipkin:
- endpoint: "http://some.url:9411/api/v2/spans"
+  zipkin:
+    endpoint: "http://some.url:9411/api/v2/spans"
 ```
 
 The full list of settings exposed for this exporter are documented [here](./config.go)


### PR DESCRIPTION
**Description:** 
The existing yaml example is not indented correctly. Minor fixup to
indent it correctly.

**Link to tracking Issue:** none

**Testing:** none

**Documentation:** none
