### PR TITLE
Remove ending period in hash function description

### DIFF
--- a/processor/samplingprocessor/probabilisticsamplerprocessor/probabilisticsampler.go
+++ b/processor/samplingprocessor/probabilisticsamplerprocessor/probabilisticsampler.go
@@ -189,7 +189,7 @@ func parseSpanSamplingPriority(span pdata.Span) samplingPriority {
 	return decision
 }
 
-// hash is a murmur3 hash function, see http://en.wikipedia.org/wiki/MurmurHash.
+// hash is a murmur3 hash function, see http://en.wikipedia.org/wiki/MurmurHash
 func hash(key []byte, seed uint32) (hash uint32) {
 	const (
 		c1 = 0xcc9e2d51


### PR DESCRIPTION
Github appends trailing periods (.) when rendering a URL which means it doesn't go where intended, eg "[https://en.wikipedia.org/wiki/MurmurHash.](https://en.wikipedia.org/wiki/MurmurHash.)"