### PR TITLE
Avoid using Append when easy to use Resize

### DIFF
--- a/internal/data/testdata/metric.go
+++ b/internal/data/testdata/metric.go
@@ -297,27 +297,18 @@ func GenerateMetricsAllTypesEmptyDataPoint() pdata.Metrics {
 	ms := ilm0.Metrics()
 	ms.Resize(6)
 
-	emptyInt := pdata.NewIntDataPoint()
-	emptyInt.InitEmpty()
-	emptyDouble := pdata.NewDoubleDataPoint()
-	emptyDouble.InitEmpty()
-	emptyDoubleHistogram := pdata.NewDoubleHistogramDataPoint()
-	emptyDoubleHistogram.InitEmpty()
-	emptyIntHistogram := pdata.NewIntHistogramDataPoint()
-	emptyIntHistogram.InitEmpty()
-
 	initMetric(ms.At(0), TestGaugeDoubleMetricName, pdata.MetricDataTypeDoubleGauge)
-	ms.At(0).DoubleGauge().DataPoints().Append(&emptyDouble)
+	ms.At(0).DoubleGauge().DataPoints().Resize(1)
 	initMetric(ms.At(1), TestGaugeIntMetricName, pdata.MetricDataTypeIntGauge)
-	ms.At(1).IntGauge().DataPoints().Append(&emptyInt)
+	ms.At(1).IntGauge().DataPoints().Resize(1)
 	initMetric(ms.At(2), TestCounterDoubleMetricName, pdata.MetricDataTypeDoubleSum)
-	ms.At(2).DoubleSum().DataPoints().Append(&emptyDouble)
+	ms.At(2).DoubleSum().DataPoints().Resize(1)
 	initMetric(ms.At(3), TestCounterIntMetricName, pdata.MetricDataTypeIntSum)
-	ms.At(3).IntSum().DataPoints().Append(&emptyInt)
+	ms.At(3).IntSum().DataPoints().Resize(1)
 	initMetric(ms.At(4), TestDoubleHistogramMetricName, pdata.MetricDataTypeDoubleHistogram)
-	ms.At(4).DoubleHistogram().DataPoints().Append(&emptyDoubleHistogram)
+	ms.At(4).DoubleHistogram().DataPoints().Resize(1)
 	initMetric(ms.At(5), TestIntHistogramMetricName, pdata.MetricDataTypeIntHistogram)
-	ms.At(5).IntHistogram().DataPoints().Append(&emptyIntHistogram)
+	ms.At(5).IntHistogram().DataPoints().Resize(1)
 	return md
 }
 

--- a/processor/groupbytraceprocessor/storage_memory_test.go
+++ b/processor/groupbytraceprocessor/storage_memory_test.go
@@ -32,16 +32,12 @@ func TestMemoryCreateAndGetTrace(t *testing.T) {
 		{2, 3, 4, 5},
 	}
 
-	span := pdata.NewSpan()
-	span.InitEmpty()
-
-	ils := pdata.NewInstrumentationLibrarySpans()
-	ils.InitEmpty()
-	ils.Spans().Append(&span)
-
 	baseTrace := pdata.NewResourceSpans()
 	baseTrace.InitEmpty()
-	baseTrace.InstrumentationLibrarySpans().Append(&ils)
+	baseTrace.InstrumentationLibrarySpans().Resize(1)
+	ils := baseTrace.InstrumentationLibrarySpans().At(0)
+	ils.Spans().Resize(1)
+	span := ils.Spans().At(0)
 
 	// test
 	for _, traceID := range traceIDs {
@@ -68,17 +64,14 @@ func TestMemoryDeleteTrace(t *testing.T) {
 	st := newMemoryStorage()
 
 	traceID := pdata.NewTraceID([]byte{1, 2, 3, 4})
-	span := pdata.NewSpan()
-	span.InitEmpty()
-	span.SetTraceID(traceID)
-
-	ils := pdata.NewInstrumentationLibrarySpans()
-	ils.InitEmpty()
-	ils.Spans().Append(&span)
 
 	trace := pdata.NewResourceSpans()
 	trace.InitEmpty()
-	trace.InstrumentationLibrarySpans().Append(&ils)
+	trace.InstrumentationLibrarySpans().Resize(1)
+	ils := trace.InstrumentationLibrarySpans().At(0)
+	ils.Spans().Resize(1)
+	span := ils.Spans().At(0)
+	span.SetTraceID(traceID)
 
 	st.createOrAppend(traceID, trace)
 
@@ -99,45 +92,34 @@ func TestMemoryAppendSpans(t *testing.T) {
 	st := newMemoryStorage()
 
 	traceID := pdata.NewTraceID([]byte{1, 2, 3, 4})
-	span := pdata.NewSpan()
-	span.InitEmpty()
-	span.SetTraceID(traceID)
-	span.SetSpanID(pdata.NewSpanID([]byte{1, 2, 3, 4}))
-
-	ils := pdata.NewInstrumentationLibrarySpans()
-	ils.InitEmpty()
-	ils.Spans().Append(&span)
 
 	batch := pdata.NewResourceSpans()
 	batch.InitEmpty()
-	batch.InstrumentationLibrarySpans().Append(&ils)
+	batch.InstrumentationLibrarySpans().Resize(1)
+	ils := batch.InstrumentationLibrarySpans().At(0)
+	ils.Spans().Resize(1)
+	span := ils.Spans().At(0)
+	span.SetTraceID(traceID)
+	span.SetSpanID(pdata.NewSpanID([]byte{1, 2, 3, 4}))
 
 	st.createOrAppend(traceID, batch)
 
-	secondSpan := pdata.NewSpan()
-	secondSpan.InitEmpty()
+	secondBatch := pdata.NewResourceSpans()
+	secondBatch.InitEmpty()
+	secondBatch.InstrumentationLibrarySpans().Resize(1)
+	secondIls := secondBatch.InstrumentationLibrarySpans().At(0)
+	secondIls.Spans().Resize(1)
+	secondSpan := secondIls.Spans().At(0)
 	secondSpan.SetName("second-name")
 	secondSpan.SetTraceID(traceID)
 	secondSpan.SetSpanID(pdata.NewSpanID([]byte{5, 6, 7, 8}))
-
-	secondIls := pdata.NewInstrumentationLibrarySpans()
-	secondIls.InitEmpty()
-	secondIls.Spans().Append(&secondSpan)
-
-	secondBatch := pdata.NewResourceSpans()
-	secondBatch.InitEmpty()
-	secondBatch.InstrumentationLibrarySpans().Append(&secondIls)
-
-	expectedIls := pdata.NewInstrumentationLibrarySpans()
-	expectedIls.InitEmpty()
-	expectedIls.Spans().Append(&span)
 
 	expected := []pdata.ResourceSpans{
 		pdata.NewResourceSpans(),
 		pdata.NewResourceSpans(),
 	}
 	expected[0].InitEmpty()
-	expected[0].InstrumentationLibrarySpans().Append(&expectedIls)
+	expected[0].InstrumentationLibrarySpans().Append(&ils)
 
 	expected[1].InitEmpty()
 	expected[1].InstrumentationLibrarySpans().Append(&secondIls)
@@ -164,19 +146,16 @@ func TestMemoryTraceIsBeingCloned(t *testing.T) {
 	// prepare
 	st := newMemoryStorage()
 	traceID := pdata.NewTraceID([]byte{1, 2, 3, 4})
-	span := pdata.NewSpan()
-	span.InitEmpty()
-	span.SetTraceID(traceID)
-	span.SetSpanID(pdata.NewSpanID([]byte{1, 2, 3, 4}))
-	span.SetName("should-not-be-changed")
-
-	ils := pdata.NewInstrumentationLibrarySpans()
-	ils.InitEmpty()
-	ils.Spans().Append(&span)
 
 	batch := pdata.NewResourceSpans()
 	batch.InitEmpty()
-	batch.InstrumentationLibrarySpans().Append(&ils)
+	batch.InstrumentationLibrarySpans().Resize(1)
+	ils := batch.InstrumentationLibrarySpans().At(0)
+	ils.Spans().Resize(1)
+	span := ils.Spans().At(0)
+	span.SetTraceID(traceID)
+	span.SetSpanID(pdata.NewSpanID([]byte{1, 2, 3, 4}))
+	span.SetName("should-not-be-changed")
 
 	// test
 	err := st.createOrAppend(traceID, batch)


### PR DESCRIPTION
This is a preparation to fix the `Append` func on the slices to not accept pointers.
