### PR TITLE
Introduce TraceID custom data type

### DIFF
--- a/internal/data/opentelemetry-proto-gen/common/v1/traceid.go
+++ b/internal/data/opentelemetry-proto-gen/common/v1/traceid.go
@@ -1,0 +1,120 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import (
+	"bytes"
+	"encoding/hex"
+	"fmt"
+)
+
+// TraceID is a custom data type that is used for all trace_id fields in OTLP
+// Protobuf messages.
+type TraceID struct {
+	// Just wrap a byte slice for now. In the future we may change to a fixed array
+	// or a pair of 64 bit integers to reduce allocations.
+	id []byte
+}
+
+// NewTraceID creates a TraceID from a byte slice.
+func NewTraceID(bytes []byte) (tid TraceID) {
+	return TraceID{id: bytes}
+}
+
+// Bytes returns the byte slice representation of the ID.
+func (t TraceID) Bytes() []byte {
+	return t.id
+}
+
+// HexString returns hex representation of the ID.
+func (t TraceID) HexString() string {
+	return hex.EncodeToString(t.id)
+}
+
+// Size returns the size of the data to serialize.
+func (t *TraceID) Size() int {
+	return len(t.id)
+}
+
+// Equal returns true if ids are equal.
+func (t TraceID) Equal(that TraceID) bool {
+	return bytes.Equal(t.id, that.id)
+}
+
+// Compare the ids. See bytes.Compare for expected return values.
+func (t TraceID) Compare(that TraceID) int {
+	return bytes.Compare(t.id, that.id)
+}
+
+// MarshalTo converts trace ID into a binary representation. Called by Protobuf serialization.
+func (t *TraceID) MarshalTo(data []byte) (n int, err error) {
+	if len(data) < len(t.id) {
+		return 0, fmt.Errorf("buffer is too short")
+	}
+	return copy(data, t.id), nil
+}
+
+// Unmarshal inflates this trace ID from binary representation. Called by Protobuf serialization.
+func (t *TraceID) Unmarshal(data []byte) error {
+	if t.id == nil {
+		if len(data) == 0 {
+			t.id = nil
+			return nil
+		}
+		t.id = make([]byte, len(data))
+	}
+	copy(t.id, data)
+	t.id = t.id[0:len(data)]
+	return nil
+}
+
+// MarshalJSON converts trace id into a hex string enclosed in quotes.
+func (t TraceID) MarshalJSON() ([]byte, error) {
+	if t.id == nil {
+		return []byte(`""`), nil
+	}
+
+	byteLen := len(t.id)
+
+	// 2 chars per byte plus 2 quote chars at the start and end.
+	hexLen := 2*byteLen + 2
+
+	b := make([]byte, hexLen)
+	hex.Encode(b[1:hexLen-1], t.id)
+	b[0], b[hexLen-1] = '"', '"'
+
+	return b, nil
+}
+
+// UnmarshalJSON inflates trace id from hex string, possibly enclosed in quotes.
+// Called by Protobuf JSON deserialization.
+func (t *TraceID) UnmarshalJSON(data []byte) error {
+	l := len(data)
+	if l < 2 || data[0] != '"' || data[l-1] != '"' {
+		return fmt.Errorf("cannot unmarshal TraceId from string '%s'", string(data))
+	}
+	data = data[1 : l-1]
+	s := string(data)
+	if s == `""` {
+		t.id = nil
+		return nil
+	}
+
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		return fmt.Errorf("cannot unmarshal TraceId from string '%s': %v", string(data), err)
+	}
+	return t.Unmarshal(b)
+}

--- a/internal/data/opentelemetry-proto-gen/common/v1/traceid_test.go
+++ b/internal/data/opentelemetry-proto-gen/common/v1/traceid_test.go
@@ -1,0 +1,148 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewTraceID(t *testing.T) {
+	tid := NewTraceID(nil)
+	assert.EqualValues(t, []byte(nil), tid.id)
+	assert.EqualValues(t, 0, tid.Size())
+
+	b := []byte{1, 2, 3}
+	tid = NewTraceID(b)
+	assert.EqualValues(t, b, tid.id)
+	assert.EqualValues(t, b, tid.Bytes())
+	assert.EqualValues(t, 3, tid.Size())
+}
+
+func TestTraceIDHexString(t *testing.T) {
+	tid := NewTraceID(nil)
+	assert.EqualValues(t, "", tid.HexString())
+
+	tid = NewTraceID([]byte{})
+	assert.EqualValues(t, "", tid.HexString())
+
+	tid = NewTraceID([]byte{0x12, 0x23, 0xAD})
+	assert.EqualValues(t, "1223ad", tid.HexString())
+}
+
+func TestTraceIDEqual(t *testing.T) {
+	tid := NewTraceID(nil)
+	assert.True(t, tid.Equal(tid))
+	assert.True(t, tid.Equal(NewTraceID(nil)))
+	assert.True(t, tid.Equal(NewTraceID([]byte{})))
+	assert.False(t, tid.Equal(NewTraceID([]byte{1})))
+
+	tid = NewTraceID([]byte{0x12, 0x23, 0xAD})
+	assert.False(t, tid.Equal(NewTraceID(nil)))
+	assert.True(t, tid.Equal(tid))
+	assert.True(t, tid.Equal(NewTraceID([]byte{0x12, 0x23, 0xAD})))
+}
+
+func TestTraceIDCompare(t *testing.T) {
+	tid := NewTraceID(nil)
+	assert.EqualValues(t, 0, tid.Compare(tid))
+	assert.EqualValues(t, 0, tid.Compare(NewTraceID(nil)))
+	assert.EqualValues(t, 0, tid.Compare(NewTraceID([]byte{})))
+	assert.EqualValues(t, -1, tid.Compare(NewTraceID([]byte{1})))
+
+	tid = NewTraceID([]byte{0x12, 0x23, 0xAD})
+	assert.EqualValues(t, 1, tid.Compare(NewTraceID(nil)))
+	assert.EqualValues(t, 0, tid.Compare(tid))
+	assert.EqualValues(t, 0, tid.Compare(NewTraceID([]byte{0x12, 0x23, 0xAD})))
+	assert.EqualValues(t, 1, tid.Compare(NewTraceID([]byte{0x12, 0x23, 0xAC})))
+	assert.EqualValues(t, -1, tid.Compare(NewTraceID([]byte{0x12, 0x23, 0xAE})))
+	assert.EqualValues(t, 1, tid.Compare(NewTraceID([]byte{0x12, 0x23})))
+	assert.EqualValues(t, -1, tid.Compare(NewTraceID([]byte{0x12, 0x24})))
+}
+
+func TestTraceIDMarshal(t *testing.T) {
+	buf := make([]byte, 10)
+
+	tid := NewTraceID(nil)
+	n, err := tid.MarshalTo(buf)
+	assert.EqualValues(t, 0, n)
+	assert.NoError(t, err)
+
+	tid = NewTraceID([]byte{0x12, 0x23, 0xAD})
+	n, err = tid.MarshalTo(buf)
+	assert.EqualValues(t, 3, n)
+	assert.EqualValues(t, []byte{0x12, 0x23, 0xAD}, buf[0:3])
+	assert.NoError(t, err)
+
+	_, err = tid.MarshalTo(buf[0:1])
+	assert.Error(t, err)
+}
+
+func TestTraceIDMarshalJSON(t *testing.T) {
+	tid := NewTraceID(nil)
+	json, err := tid.MarshalJSON()
+	assert.EqualValues(t, []byte(`""`), json)
+	assert.NoError(t, err)
+
+	tid = NewTraceID([]byte{0x12, 0x23, 0xAD})
+	json, err = tid.MarshalJSON()
+	assert.EqualValues(t, []byte(`"1223ad"`), json)
+	assert.NoError(t, err)
+}
+
+func TestTraceIDUnmarshal(t *testing.T) {
+	buf := []byte{0x12, 0x23, 0xAD}
+
+	tid := TraceID{}
+	err := tid.Unmarshal(buf[0:3])
+	assert.NoError(t, err)
+	assert.EqualValues(t, []byte{0x12, 0x23, 0xAD}, tid.id)
+
+	err = tid.Unmarshal(buf[0:0])
+	assert.NoError(t, err)
+	assert.EqualValues(t, []byte{}, tid.id)
+
+	tid = TraceID{}
+	err = tid.Unmarshal(nil)
+	assert.NoError(t, err)
+	assert.EqualValues(t, []byte(nil), tid.id)
+}
+
+func TestTraceIDUnmarshalJSON(t *testing.T) {
+	tid := TraceID{}
+	err := tid.UnmarshalJSON([]byte(`""`))
+	assert.NoError(t, err)
+	assert.EqualValues(t, []byte(nil), tid.id)
+
+	err = tid.UnmarshalJSON([]byte(`"1234"`))
+	assert.NoError(t, err)
+	assert.EqualValues(t, []byte{0x12, 0x34}, tid.id)
+
+	err = tid.UnmarshalJSON([]byte(`1234`))
+	assert.Error(t, err)
+
+	err = tid.UnmarshalJSON([]byte(`"nothex"`))
+	assert.Error(t, err)
+
+	err = tid.UnmarshalJSON([]byte(`"1"`))
+	assert.Error(t, err)
+
+	err = tid.UnmarshalJSON([]byte(`"123"`))
+	assert.Error(t, err)
+
+	err = tid.UnmarshalJSON([]byte(`"`))
+	assert.Error(t, err)
+}


### PR DESCRIPTION
The TraceID type uses custom data type so that JSON serialization
is in hex format instead of base64 (which is the default Protobuf JSON
format). Hex format is required by OTLP spec:
https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/protocol/otlp.md#request
SpanID must be also modified similarly. Will be done in a future PR
to avoid creating a huge PR.

TraceID data is not yet used in the codebase. This is just an introductory
commit that adds the type and tests but does not yet use them for actual
serialization of OTLP messages. It will be done in a future PR.

Contributes to https://github.com/open-telemetry/opentelemetry-collector/issues/1177