### PR TITLE
Rename Start() to Run() since it's a blocking call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## 🛑 Breaking changes 🛑
 <<<<<<< HEAD
 
+- Rename service.Start() to Run() since it's a blocking call
 - Fix slice Append to accept by value the element in pdata
 - Change CreateTraceProcessor and CreateMetricsProcessor to use the same parameter order as receivers/logs processor and exporters.
 

--- a/cmd/otelcol/main.go
+++ b/cmd/otelcol/main.go
@@ -50,7 +50,7 @@ func runInteractive(params service.Parameters) error {
 		return fmt.Errorf("failed to construct the application: %w", err)
 	}
 
-	err = app.Start()
+	err = app.Run()
 	if err != nil {
 		return fmt.Errorf("application run finished with error: %w", err)
 	}

--- a/service/service.go
+++ b/service/service.go
@@ -458,9 +458,9 @@ func (app *Application) execute(ctx context.Context, factory ConfigFactory) erro
 	return componenterror.CombineErrors(errs)
 }
 
-// Start starts the collector according to the command and configuration
-// given by the user.
-func (app *Application) Start() error {
+// Run starts the collector according to the command and configuration
+// given by the user, and waits for it to complete.
+func (app *Application) Run() error {
 	// From this point on do not show usage in case of error.
 	app.rootCmd.SilenceUsage = true
 

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -67,7 +67,7 @@ func TestApplication_Start(t *testing.T) {
 	appDone := make(chan struct{})
 	go func() {
 		defer close(appDone)
-		assert.NoError(t, app.Start())
+		assert.NoError(t, app.Run())
 	}()
 
 	assert.Equal(t, Starting, <-app.GetStateChannel())
@@ -120,7 +120,7 @@ func TestApplication_ReportError(t *testing.T) {
 	appDone := make(chan struct{})
 	go func() {
 		defer close(appDone)
-		assert.EqualError(t, app.Start(), "failed to shutdown extensions: err1")
+		assert.EqualError(t, app.Run(), "failed to shutdown extensions: err1")
 	}()
 
 	assert.Equal(t, Starting, <-app.GetStateChannel())
@@ -151,7 +151,7 @@ func TestApplication_StartAsGoRoutine(t *testing.T) {
 	appDone := make(chan struct{})
 	go func() {
 		defer close(appDone)
-		appErr := app.Start()
+		appErr := app.Run()
 		if appErr != nil {
 			err = appErr
 		}
@@ -449,7 +449,7 @@ func TestApplication_GetExtensions(t *testing.T) {
 	appDone := make(chan struct{})
 	go func() {
 		defer close(appDone)
-		assert.NoError(t, app.Start())
+		assert.NoError(t, app.Run())
 	}()
 
 	assert.Equal(t, Starting, <-app.GetStateChannel())
@@ -478,7 +478,7 @@ func TestApplication_GetExporters(t *testing.T) {
 	appDone := make(chan struct{})
 	go func() {
 		defer close(appDone)
-		assert.NoError(t, app.Start())
+		assert.NoError(t, app.Run())
 	}()
 
 	assert.Equal(t, Starting, <-app.GetStateChannel())

--- a/service/service_windows.go
+++ b/service/service_windows.go
@@ -87,7 +87,7 @@ func (s *WindowsService) start(elog *eventlog.Log, appErrorChannel chan error) e
 
 	// app.Start blocks until receiving a SIGTERM signal, so needs to be started
 	// asynchronously, but it will exit early if an error occurs on startup
-	go func() { appErrorChannel <- s.app.Start() }()
+	go func() { appErrorChannel <- s.app.Run() }()
 
 	// wait until the app is in the Running state
 	go func() {

--- a/testbed/testbed/otelcol_runner.go
+++ b/testbed/testbed/otelcol_runner.go
@@ -120,7 +120,7 @@ func (ipp *InProcessCollector) Start(args StartParams) (receiverAddr string, err
 	ipp.appDone = make(chan struct{})
 	go func() {
 		defer close(ipp.appDone)
-		appErr := ipp.svc.Start()
+		appErr := ipp.svc.Run()
 		if appErr != nil {
 			err = appErr
 		}


### PR DESCRIPTION
**Description:**
Rename **Start()** to **Run()** to follow the naming pattern used in Go, e.g. see blocking [Cmd.Run](https://golang.org/pkg/os/exec/#Cmd.Run) vs non-blocking [Cmd.Start](https://golang.org/pkg/os/exec/#Cmd.Start).

Revisiting #615
@tigrannajaryan @bogdandrutu This is a trivial breaking one-line change compared to many other breaking changes introduced in the recent releases and affecting every single custom component, so I think it's worth reconsidering the [previous decision](https://github.com/open-telemetry/opentelemetry-collector/pull/615#issuecomment-597656638) before GA.

**Documentation:** Included into CHANGELOG as a breaking change
