### PR TITLE
Add library for filtering by metrics+labels

### DIFF
--- a/internal/processor/filterlabel/config.go
+++ b/internal/processor/filterlabel/config.go
@@ -1,0 +1,35 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filterlabel
+
+// Config configures a filterlabel Matcher. It is nested and can be up to three
+// levels deep. The first level matches against metric names, the second level
+// against label keys, and the third level against label values. The second and
+// third levels are optional.
+type Config struct {
+	str       string
+	matchType MatchType
+	next      []Config
+}
+
+// MatchType indicates the type of string matching to perform: strict or regexp.
+type MatchType string
+
+const (
+	// The full string must match exactly
+	MatchTypeStrict MatchType = "strict"
+	// A partial-string regexp must match
+	MatchTypeRegexp MatchType = "regexp"
+)

--- a/internal/processor/filterlabel/filterlabel.go
+++ b/internal/processor/filterlabel/filterlabel.go
@@ -1,0 +1,79 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filterlabel
+
+import metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
+
+// Matcher tests a metric for a match by three levels: metric name, label key,
+// and label value. Matches can be strict or regexp for any of the search
+// strings and multiple searches may be supplied to test against at any level.
+type Matcher struct {
+	nodes []node
+}
+
+// NewMatcher creates a Matcher struct. Pass in one or more nested Config
+// structs. Each top-level struct matches against a metric name, and below that
+// against label keys then label values.
+func NewMatcher(cfgs ...Config) (*Matcher, error) {
+	m := &Matcher{}
+	for _, c := range cfgs {
+		n, err := newNode(c)
+		if err != nil {
+			return nil, err
+		}
+		m.nodes = append(m.nodes, n)
+	}
+	return m, nil
+}
+
+// MatchMetric takes a metric and returns true if there is a match along any of
+// the Config graphs supplied to the constructor.
+func (m *Matcher) MatchMetric(metric *metricspb.Metric) bool {
+	for _, n := range m.nodes {
+		if n.match(metric.MetricDescriptor.Name) && matchLblKeys(n.next(), metric) {
+			return true
+		}
+	}
+	return false
+}
+
+func matchLblKeys(nodes []node, metric *metricspb.Metric) bool {
+	if nodes == nil {
+		return true
+	}
+	for i, lblKey := range metric.MetricDescriptor.LabelKeys {
+		for _, n := range nodes {
+			if n.match(lblKey.Key) && matchLblVals(n.next(), metric, i) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func matchLblVals(nodes []node, metric *metricspb.Metric, lblNum int) bool {
+	if nodes == nil {
+		return true
+	}
+	for _, n := range nodes {
+		for _, ts := range metric.Timeseries {
+			lblVal := ts.LabelValues[lblNum]
+			if lblVal.HasValue && n.match(lblVal.Value) {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/internal/processor/filterlabel/filterlabel_test.go
+++ b/internal/processor/filterlabel/filterlabel_test.go
@@ -1,0 +1,377 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filterlabel
+
+import (
+	"fmt"
+	"testing"
+
+	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
+	"github.com/crossdock/crossdock-go/require"
+)
+
+func TestEmptyMatchType(t *testing.T) {
+	matcher, err := NewMatcher(Config{next: []Config{{}}})
+	require.Nil(t, matcher)
+	require.Error(t, err, "matchType cannot be empty")
+}
+
+func TestInvalidMatchType(t *testing.T) {
+	matcher, err := NewMatcher(Config{matchType: "foo"})
+	require.Nil(t, matcher)
+	require.Error(t, err, "invalid matchType %q", "foo")
+}
+
+func TestMatchMetric_Strict(t *testing.T) {
+	cfg := Config{
+		str:       "metric.name",
+		matchType: MatchTypeStrict,
+		next: []Config{{
+			str:       "k-1",
+			matchType: MatchTypeStrict,
+			next: []Config{{
+				str:       "v-0-1",
+				matchType: MatchTypeStrict,
+			}},
+		}},
+	}
+	matcher := testMatcher(t, cfg)
+	m := testMetrics(2, 4)
+	matches := matcher.MatchMetric(m)
+	require.True(t, matches)
+}
+
+func TestMatchMetric_Strict_MetricOnly(t *testing.T) {
+	cfg := Config{
+		str:       "metric.name",
+		matchType: MatchTypeStrict,
+	}
+	matcher := testMatcher(t, cfg)
+	m := testMetrics(2, 4)
+	matches := matcher.MatchMetric(m)
+	require.True(t, matches)
+}
+
+func TestMatchMetric_Strict_MetricLblOnly(t *testing.T) {
+	cfg := Config{
+		str:       "metric.name",
+		matchType: MatchTypeStrict,
+		next: []Config{{
+			str:       "k-1",
+			matchType: MatchTypeStrict,
+		}},
+	}
+	matcher := testMatcher(t, cfg)
+	m := testMetrics(2, 4)
+	matches := matcher.MatchMetric(m)
+	require.True(t, matches)
+}
+
+func TestMatchMetric_Strict_LblValWrongPos(t *testing.T) {
+	cfg := Config{
+		str:       "metric.name",
+		matchType: MatchTypeStrict,
+		next: []Config{{
+			str:       "k-2",
+			matchType: MatchTypeStrict,
+			next: []Config{{
+				str:       "v-0-3", // lbl val exists but in wrong position
+				matchType: MatchTypeStrict,
+			}},
+		}},
+	}
+	matcher := testMatcher(t, cfg)
+	m := testMetrics(4, 4)
+	matches := matcher.MatchMetric(m)
+	require.False(t, matches)
+}
+
+func TestMatchMetric_Strict_MismatchedKey(t *testing.T) {
+	cfg := Config{
+		str:       "metric.name",
+		matchType: MatchTypeStrict,
+		next: []Config{{
+			str:       "foo",
+			matchType: MatchTypeStrict,
+			next: []Config{{
+				str:       "v-1-1",
+				matchType: MatchTypeStrict,
+			}},
+		}},
+	}
+	matcher := testMatcher(t, cfg)
+	m := testMetrics(4, 4)
+	matches := matcher.MatchMetric(m)
+	require.False(t, matches)
+}
+
+func TestMatchMetric_Strict_MismatchedMetric(t *testing.T) {
+	cfg := Config{
+		str:       "foo",
+		matchType: MatchTypeStrict,
+		next: []Config{{
+			str:       "k-1",
+			matchType: MatchTypeStrict,
+			next: []Config{{
+				str:       "v-1-1",
+				matchType: MatchTypeStrict,
+			}},
+		}},
+	}
+	matcher := testMatcher(t, cfg)
+	m := testMetrics(2, 4)
+	matches := matcher.MatchMetric(m)
+	require.False(t, matches)
+}
+
+func TestMatchMetric_Strict_MultiMetricCfg(t *testing.T) {
+	cfg := []Config{{
+		str:       "foo",
+		matchType: MatchTypeStrict,
+		next: []Config{{
+			str:       "k-1",
+			matchType: MatchTypeStrict,
+			next: []Config{{
+				str:       "v-1-1",
+				matchType: MatchTypeStrict,
+			}},
+		}},
+	}, {
+		str:       "metric.name",
+		matchType: MatchTypeStrict,
+		next: []Config{{
+			str:       "k-1",
+			matchType: MatchTypeStrict,
+			next: []Config{{
+				str:       "v-1-1",
+				matchType: MatchTypeStrict,
+			}},
+		}},
+	}}
+	matcher := testMatcher(t, cfg...)
+	m := testMetrics(2, 4)
+	matches := matcher.MatchMetric(m)
+	require.True(t, matches)
+}
+
+func TestMatchMetric_Strict_MultiKeyCfg(t *testing.T) {
+	cfg := Config{
+		str:       "metric.name",
+		matchType: MatchTypeStrict,
+		next: []Config{{
+			str:       "k-1",
+			matchType: MatchTypeStrict,
+			next: []Config{{
+				str:       "foo",
+				matchType: MatchTypeStrict,
+			}},
+		}, {
+			str:       "k-2",
+			matchType: MatchTypeStrict,
+			next: []Config{{
+				str:       "v-2-2",
+				matchType: MatchTypeStrict,
+			}},
+		}},
+	}
+	matcher := testMatcher(t, cfg)
+	m := testMetrics(4, 4)
+	matches := matcher.MatchMetric(m)
+	require.True(t, matches)
+}
+
+func TestMatchMetric_Strict_MultiLblCfg(t *testing.T) {
+	cfg := Config{
+		str:       "metric.name",
+		matchType: MatchTypeStrict,
+		next: []Config{{
+			str:       "k-1",
+			matchType: MatchTypeStrict,
+			next: []Config{{
+				str:       "foo",
+				matchType: MatchTypeStrict,
+			}, {
+				str:       "v-1-1",
+				matchType: MatchTypeStrict,
+			}},
+		}},
+	}
+	matcher := testMatcher(t, cfg)
+	m := testMetrics(4, 4)
+	matches := matcher.MatchMetric(m)
+	require.True(t, matches)
+}
+
+func TestMatchMetric_Regexp_Metric(t *testing.T) {
+	cfg := Config{
+		str:       ".*",
+		matchType: MatchTypeRegexp,
+		next: []Config{{
+			str:       "k-1",
+			matchType: MatchTypeStrict,
+			next: []Config{{
+				str:       "v-0-1",
+				matchType: MatchTypeStrict,
+			}},
+		}},
+	}
+	matcher := testMatcher(t, cfg)
+	m := testMetrics(2, 4)
+	matches := matcher.MatchMetric(m)
+	require.True(t, matches)
+}
+
+func TestMatchMetric_Regexp_LblKey(t *testing.T) {
+	cfg := Config{
+		str:       "metric.name",
+		matchType: MatchTypeStrict,
+		next: []Config{{
+			str:       "k-[0-9]",
+			matchType: MatchTypeRegexp,
+			next: []Config{{
+				str:       "v-0-1",
+				matchType: MatchTypeStrict,
+			}},
+		}},
+	}
+	matcher := testMatcher(t, cfg)
+	m := testMetrics(2, 4)
+	matches := matcher.MatchMetric(m)
+	require.True(t, matches)
+}
+
+func TestMatchMetric_Regexp_LblVal(t *testing.T) {
+	cfg := Config{
+		str:       "metric.name",
+		matchType: MatchTypeStrict,
+		next: []Config{{
+			str:       "k-1",
+			matchType: MatchTypeStrict,
+			next: []Config{{
+				str:       "v-[0-9]-1",
+				matchType: MatchTypeRegexp,
+			}},
+		}},
+	}
+	matcher := testMatcher(t, cfg)
+	m := testMetrics(2, 4)
+	matches := matcher.MatchMetric(m)
+	require.True(t, matches)
+}
+
+func BenchmarkStrictMatch32MetricsBestCase(b *testing.B) {
+	cfg := Config{
+		str:       "metric.name",
+		matchType: MatchTypeStrict,
+		next: []Config{{
+			str:       "k-0",
+			matchType: MatchTypeStrict,
+			next: []Config{{
+				str:       "v-0-0",
+				matchType: MatchTypeStrict,
+			}},
+		}},
+	}
+	matcher, _ := NewMatcher(cfg)
+	m := testMetrics(32, 32)
+	for i := 0; i < b.N; i++ {
+		_ = matcher.MatchMetric(m)
+	}
+}
+
+func BenchmarkStrictMatch32MetricsWorstCase(b *testing.B) {
+	cfg := Config{
+		str:       "metric.name",
+		matchType: MatchTypeStrict,
+		next: []Config{{
+			str:       "k-31",
+			matchType: MatchTypeStrict,
+			next: []Config{{
+				str:       "v-31-31",
+				matchType: MatchTypeStrict,
+			}},
+		}},
+	}
+	matcher, _ := NewMatcher(cfg)
+	m := testMetrics(32, 32)
+	for i := 0; i < b.N; i++ {
+		matched := matcher.MatchMetric(m)
+		require.True(b, matched)
+	}
+}
+
+func BenchmarkRegexpMatch32Metrics(b *testing.B) {
+	cfg := Config{
+		str:       ".*\\w$",
+		matchType: MatchTypeRegexp,
+		next: []Config{{
+			str:       ".*\\w.*\\D.*3.*1.*",
+			matchType: MatchTypeRegexp,
+			next: []Config{{
+				str:       ".*\\w.*\\D.*3.*1.*\\D.*3.*1.*",
+				matchType: MatchTypeRegexp,
+			}},
+		}},
+	}
+	matcher, _ := NewMatcher(cfg)
+	m := testMetrics(32, 32)
+	for i := 0; i < b.N; i++ {
+		matched := matcher.MatchMetric(m)
+		require.True(b, matched)
+	}
+}
+
+func testMatcher(t *testing.T, cfg ...Config) *Matcher {
+	matcher, err := NewMatcher(cfg...)
+	require.NoError(t, err)
+	return matcher
+}
+
+func testMetrics(numTS int, numLbls int) *metricspb.Metric {
+	return &metricspb.Metric{
+		MetricDescriptor: &metricspb.MetricDescriptor{
+			Name:      "metric.name",
+			LabelKeys: testLblk(numLbls),
+		},
+		Timeseries: testTs(numTS, numLbls),
+	}
+}
+
+func testTs(numTs int, numValues int) []*metricspb.TimeSeries {
+	var out []*metricspb.TimeSeries
+	for i := 0; i < numTs; i++ {
+		out = append(out, &metricspb.TimeSeries{LabelValues: testLblv(i, numValues)})
+	}
+	return out
+}
+
+func testLblk(numLbls int) []*metricspb.LabelKey {
+	var out []*metricspb.LabelKey
+	for i := 0; i < numLbls; i++ {
+		out = append(out, &metricspb.LabelKey{Key: fmt.Sprintf("k-%d", i)})
+	}
+	return out
+}
+
+func testLblv(index int, numValues int) []*metricspb.LabelValue {
+	var out []*metricspb.LabelValue
+	for i := 0; i < numValues; i++ {
+		out = append(out, &metricspb.LabelValue{
+			Value:    fmt.Sprintf("v-%d-%d", index, i),
+			HasValue: true,
+		})
+	}
+	return out
+}

--- a/internal/processor/filterlabel/node.go
+++ b/internal/processor/filterlabel/node.go
@@ -1,0 +1,91 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filterlabel
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+)
+
+type node interface {
+	match(string) bool
+	next() []node
+}
+
+func newNode(cfg Config) (node, error) {
+	nodes, err := newNodes(cfg.next)
+	if err != nil {
+		return nil, err
+	}
+	switch cfg.matchType {
+	case MatchTypeRegexp:
+		return regexpNode{
+			r:     regexp.MustCompile(cfg.str),
+			nodes: nodes,
+		}, nil
+	case MatchTypeStrict:
+		return strictNode{
+			s:     cfg.str,
+			nodes: nodes,
+		}, nil
+	case "":
+		return nil, errors.New("matchType cannot be empty")
+	default:
+		return nil, fmt.Errorf("invalid matchType %q", cfg.matchType)
+	}
+}
+
+func newNodes(cfgs []Config) ([]node, error) {
+	var out []node
+	for _, cfg := range cfgs {
+		n, err := newNode(cfg)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, n)
+	}
+	return out, nil
+}
+
+// strictNode
+
+type strictNode struct {
+	s     string
+	nodes []node
+}
+
+func (n strictNode) next() []node {
+	return n.nodes
+}
+
+func (n strictNode) match(s string) bool {
+	return n.s == s
+}
+
+// regexpNode
+
+type regexpNode struct {
+	r     *regexp.Regexp
+	nodes []node
+}
+
+func (n regexpNode) match(s string) bool {
+	return n.r.MatchString(s)
+}
+
+func (n regexpNode) next() []node {
+	return n.nodes
+}


### PR DESCRIPTION
This change adds support for filtering metrics by name+label keys+label values.

There is already support for filtering by metric names only, functionality which
lives in the `filtermetric` package. This is a work in progress, but when it's done we
may want to supersede that functionality with this, and use the `filtermetric` package
name.