### PR TITLE
Skip creation of redundant nil resource in translation from OC if there are no combined metrics

### DIFF
--- a/translator/internaldata/oc_to_metrics.go
+++ b/translator/internaldata/oc_to_metrics.go
@@ -90,9 +90,10 @@ func appendOcToMetrics(md consumerdata.MetricsData, dest pdata.Metrics) {
 		}
 	}
 	// Total number of resources is equal to:
-	// 1 (for all metrics with nil resource) + numMetricsWithResource (distinctResourceCount).
+	// initial + numMetricsWithResource + (optional) 1
 	resourceCount := initialRmsLen + distinctResourceCount
 	if combinedMetricCount > 0 {
+		// +1 for all metrics with nil resource
 		resourceCount++
 	}
 	rms.Resize(resourceCount)

--- a/translator/internaldata/oc_to_metrics.go
+++ b/translator/internaldata/oc_to_metrics.go
@@ -91,23 +91,52 @@ func appendOcToMetrics(md consumerdata.MetricsData, dest pdata.Metrics) {
 	}
 	// Total number of resources is equal to:
 	// 1 (for all metrics with nil resource) + numMetricsWithResource (distinctResourceCount).
-	rms.Resize(initialRmsLen + distinctResourceCount + 1)
-	rm0 := rms.At(initialRmsLen)
-	ocNodeResourceToInternal(md.Node, md.Resource, rm0.Resource())
+	resourceCount := initialRmsLen + distinctResourceCount
+	if combinedMetricCount > 0 {
+		resourceCount++
+	}
+	rms.Resize(resourceCount)
 
-	// Allocate a slice for metrics that need to be combined into first ResourceMetrics.
-	ilms := rm0.InstrumentationLibraryMetrics()
-	ilms.Resize(1)
-	combinedMetrics := ilms.At(0).Metrics()
-	combinedMetrics.Resize(combinedMetricCount)
+	// Translate "combinedMetrics" first
 
-	// Now do the metric translation and place them in appropriate ResourceMetrics
-	// instances.
+	if combinedMetricCount > 0 {
+		rm0 := rms.At(initialRmsLen)
+		ocNodeResourceToInternal(md.Node, md.Resource, rm0.Resource())
 
-	// Index to next available slot in "combinedMetrics" slice.
-	combinedMetricIdx := 0
-	// First resourcemetric is used for the default resource, so start with 1.
-	resourceMetricIdx := 1
+		// Allocate a slice for metrics that need to be combined into first ResourceMetrics.
+		ilms := rm0.InstrumentationLibraryMetrics()
+		ilms.Resize(1)
+		combinedMetrics := ilms.At(0).Metrics()
+		combinedMetrics.Resize(combinedMetricCount)
+
+		// Index to next available slot in "combinedMetrics" slice.
+		combinedMetricIdx := 0
+
+		for _, ocMetric := range md.Metrics {
+			if ocMetric == nil {
+				// Skip nil metrics.
+				continue
+			}
+
+			if ocMetric.Resource != nil {
+				continue // Those are processed separately below.
+			}
+
+			// Add the metric to the "combinedMetrics". combinedMetrics length is equal
+			// to combinedMetricCount. The loop above that calculates combinedMetricCount
+			// has exact same conditions as we have here in this loop.
+			ocMetricToMetrics(ocMetric, combinedMetrics.At(combinedMetricIdx))
+			combinedMetricIdx++
+		}
+	}
+
+	// Translate distinct metrics
+
+	resourceMetricIdx := 0
+	if combinedMetricCount > 0 {
+		// First resourcemetric is used for the default resource, so start with 1.
+		resourceMetricIdx = 1
+	}
 	for _, ocMetric := range md.Metrics {
 		if ocMetric == nil {
 			// Skip nil metrics.
@@ -115,18 +144,14 @@ func appendOcToMetrics(md consumerdata.MetricsData, dest pdata.Metrics) {
 		}
 
 		if ocMetric.Resource == nil {
-			// Add the metric to the "combinedMetrics". combinedMetrics length is equal
-			// to combinedMetricCount. The loop above that calculates combinedMetricCount
-			// has exact same conditions as we have here in this loop.
-			ocMetricToMetrics(ocMetric, combinedMetrics.At(combinedMetricIdx))
-			combinedMetricIdx++
-		} else {
-			// This metric has a different Resource and must be placed in a different
-			// ResourceMetrics instance. Create a separate ResourceMetrics item just for this metric
-			// and store at resourceMetricIdx.
-			ocMetricToResourceMetrics(ocMetric, md.Node, rms.At(initialRmsLen+resourceMetricIdx))
-			resourceMetricIdx++
+			continue // Already processed above.
 		}
+
+		// This metric has a different Resource and must be placed in a different
+		// ResourceMetrics instance. Create a separate ResourceMetrics item just for this metric
+		// and store at resourceMetricIdx.
+		ocMetricToResourceMetrics(ocMetric, md.Node, rms.At(initialRmsLen+resourceMetricIdx))
+		resourceMetricIdx++
 	}
 }
 

--- a/translator/internaldata/oc_to_metrics_test.go
+++ b/translator/internaldata/oc_to_metrics_test.go
@@ -178,6 +178,19 @@ func TestOCToMetrics_ResourceInMetric(t *testing.T) {
 	assert.EqualValues(t, want, got)
 }
 
+func TestOCToMetrics_ResourceInMetricOnly(t *testing.T) {
+	internal := testdata.GenerateMetricsOneMetric()
+	want := pdata.NewMetrics()
+	internal.Clone().ResourceMetrics().MoveAndAppendTo(want.ResourceMetrics())
+	oc := generateOCTestDataMetricsOneMetric()
+	// Move resource to metric level.
+	// We shouldn't have a "combined" resource after conversion
+	oc.Metrics[0].Resource = oc.Resource
+	oc.Resource = nil
+	got := OCToMetrics(oc)
+	assert.EqualValues(t, want, got)
+}
+
 func BenchmarkMetricIntOCToMetrics(b *testing.B) {
 	ocMetric := consumerdata.MetricsData{
 		Resource: generateOCTestResource(),


### PR DESCRIPTION
**Description:** Getting rid of redundant nil `ResourceObject` when all metrics have resource specified.

After removal of `pdatautil` package in #1739, I've migrated our custom components from `pdatautil.MetricsFromMetricsData` to `internaldata.OCToMetrics` and found that some tests are failing due to converted metrics having an extra "empty" `ResourceMetrics` object in the slice.

**Testing:** Added unit test reproducing the issue

/cc @bogdandrutu 