### PR TITLE
Set resource at the OC metric level during translation

### DIFF
--- a/translator/internaldata/metrics_to_oc.go
+++ b/translator/internaldata/metrics_to_oc.go
@@ -18,6 +18,7 @@ import (
 	"sort"
 
 	ocmetrics "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
+	ocresource "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
 
 	"go.opentelemetry.io/collector/consumer/consumerdata"
 	"go.opentelemetry.io/collector/consumer/pdata"
@@ -72,7 +73,7 @@ func resourceMetricsToOC(rm pdata.ResourceMetrics) consumerdata.MetricsData {
 			if m.IsNil() {
 				continue
 			}
-			ocMetrics = append(ocMetrics, metricToOC(m))
+			ocMetrics = append(ocMetrics, metricToOC(m, ocMetricsData.Resource))
 		}
 	}
 	if len(ocMetrics) != 0 {
@@ -81,12 +82,12 @@ func resourceMetricsToOC(rm pdata.ResourceMetrics) consumerdata.MetricsData {
 	return ocMetricsData
 }
 
-func metricToOC(metric pdata.Metric) *ocmetrics.Metric {
+func metricToOC(metric pdata.Metric, res *ocresource.Resource) *ocmetrics.Metric {
 	labelKeys := collectLabelKeys(metric)
 	return &ocmetrics.Metric{
 		MetricDescriptor: descriptorToOC(metric, labelKeys),
 		Timeseries:       dataPointsToTimeseries(metric, labelKeys),
-		Resource:         nil,
+		Resource:         res,
 	}
 }
 

--- a/translator/internaldata/metrics_to_oc_test.go
+++ b/translator/internaldata/metrics_to_oc_test.go
@@ -147,7 +147,7 @@ func TestMetricsToOC(t *testing.T) {
 			name:     "sample-metric",
 			internal: sampleMetricData,
 			oc: []consumerdata.MetricsData{
-				generateOCTestData(),
+				withMetricResource(generateOCTestData()),
 			},
 		},
 	}
@@ -163,7 +163,7 @@ func TestMetricsToOC(t *testing.T) {
 func TestMetricsToOC_InvalidDataType(t *testing.T) {
 	internal := testdata.GenerateMetricsMetricTypeInvalid()
 	want := []consumerdata.MetricsData{
-		{
+		withMetricResource(consumerdata.MetricsData{
 			Node: &occommon.Node{},
 			Resource: &ocresource.Resource{
 				Labels: map[string]string{"resource-attr": "resource-attr-val-1"},
@@ -178,7 +178,7 @@ func TestMetricsToOC_InvalidDataType(t *testing.T) {
 					},
 				},
 			},
-		},
+		}),
 	}
 	got := MetricsToOC(internal)
 	assert.EqualValues(t, want, got)

--- a/translator/internaldata/oc_testdata_test.go
+++ b/translator/internaldata/oc_testdata_test.go
@@ -39,7 +39,7 @@ func generateOCTestDataNoMetrics() consumerdata.MetricsData {
 }
 
 func generateOCTestDataNoPoints() consumerdata.MetricsData {
-	return consumerdata.MetricsData{
+	md := consumerdata.MetricsData{
 		Node: &occommon.Node{},
 		Resource: &ocresource.Resource{
 			Labels: map[string]string{"resource-attr": "resource-attr-val-1"},
@@ -95,6 +95,7 @@ func generateOCTestDataNoPoints() consumerdata.MetricsData {
 			},
 		},
 	}
+	return withMetricResource(md)
 }
 
 func generateOCTestDataNoLabels() consumerdata.MetricsData {
@@ -102,57 +103,62 @@ func generateOCTestDataNoLabels() consumerdata.MetricsData {
 	m.MetricDescriptor.LabelKeys = nil
 	m.Timeseries[0].LabelValues = nil
 	m.Timeseries[1].LabelValues = nil
-	return consumerdata.MetricsData{
+	md := consumerdata.MetricsData{
 		Node: &occommon.Node{},
 		Resource: &ocresource.Resource{
 			Labels: map[string]string{"resource-attr": "resource-attr-val-1"},
 		},
 		Metrics: []*ocmetrics.Metric{m},
 	}
+	return withMetricResource(md)
 }
 
 func generateOCTestDataMetricsOneMetric() consumerdata.MetricsData {
-	return consumerdata.MetricsData{
+	md := consumerdata.MetricsData{
 		Node: &occommon.Node{},
 		Resource: &ocresource.Resource{
 			Labels: map[string]string{"resource-attr": "resource-attr-val-1"},
 		},
 		Metrics: []*ocmetrics.Metric{generateOCTestMetricInt()},
 	}
+	return withMetricResource(md)
 }
 
 func generateOCTestDataMetricsOneMetricOneNil() consumerdata.MetricsData {
-	return consumerdata.MetricsData{
+	md := consumerdata.MetricsData{
 		Node: &occommon.Node{},
 		Resource: &ocresource.Resource{
 			Labels: map[string]string{"resource-attr": "resource-attr-val-1"},
 		},
 		Metrics: []*ocmetrics.Metric{generateOCTestMetricInt(), nil},
 	}
+	return withMetricResource(md)
 }
 
 func generateOCTestDataMetricsOneMetricOneNilTimeseries() consumerdata.MetricsData {
 	m := generateOCTestMetricInt()
 	m.Timeseries = append(m.Timeseries, nil)
-	return consumerdata.MetricsData{
+	md := consumerdata.MetricsData{
 		Node: &occommon.Node{},
 		Resource: &ocresource.Resource{
 			Labels: map[string]string{"resource-attr": "resource-attr-val-1"},
 		},
 		Metrics: []*ocmetrics.Metric{m},
 	}
+	return withMetricResource(md)
 }
 
 func generateOCTestDataMetricsOneMetricOneNilPoint() consumerdata.MetricsData {
 	m := generateOCTestMetricInt()
 	m.Timeseries[0].Points = append(m.Timeseries[0].Points, nil)
-	return consumerdata.MetricsData{
+	md := consumerdata.MetricsData{
 		Node: &occommon.Node{},
 		Resource: &ocresource.Resource{
 			Labels: map[string]string{"resource-attr": "resource-attr-val-1"},
 		},
 		Metrics: []*ocmetrics.Metric{m},
 	}
+	return withMetricResource(md)
 }
 
 func generateOCTestMetricInt() *ocmetrics.Metric {
@@ -510,4 +516,13 @@ func generateOcResource() *ocresource.Resource {
 			"resource-int-attr": "123",
 		},
 	}
+}
+
+// Copy resource to metric level, as that's part of the OC model
+func withMetricResource(md consumerdata.MetricsData) consumerdata.MetricsData {
+	for _, m := range md.Metrics {
+		m.Resource = md.Resource
+	}
+
+	return md
 }


### PR DESCRIPTION
**Description:**
Similarly to #1803 (but in reverse direction), After removal of `pdatautil` package in #1739, I've migrated our custom components from `pdatautil.MetricsToMetricsData` to `internaldata.MetricsToOC`, and some tests are failing due to a missing `metric.Resource`.
While setting resource at Metric level may seem redundant within `consumerdata.MetricsData` which itself has `Resource` field at the top level, this breaks the OC model.

As far as I understand, if you do `OC -> OT -> OC` translation, you will find that resource has disappeared from OC Metric (even though it's now present at the `MetricsData` level.
Either way this behavior is definitely different from the deleted `pdatautil.MetricsToMetricsData` and it is affecting us.

**Testing:** Updated unit tests