### PR TITLE
Demo docker-compose file: change the host port of collector

### DIFF
--- a/examples/demo/docker-compose.yaml
+++ b/examples/demo/docker-compose.yaml
@@ -27,7 +27,7 @@ services:
       - "8889:8889"   # Prometheus exporter metrics
       - "13133:13133" # health_check extension
       - "55678"       # OpenCensus receiver
-      - "55680:55679" # zpages extension
+      - "55670:55679" # zpages extension
     depends_on:
       - jaeger-all-in-one
       - zipkin-all-in-one


### PR DESCRIPTION
- 55680 is the default port of otlp receiver. To avoid confusion,
  it's better to use a different number.

Signed-off-by: Hui Kang <kangh@us.ibm.com>

