### PR TITLE
Change instrumentation to use otel-go for trace

### DIFF
--- a/exporter/exporterhelper/common_test.go
+++ b/exporter/exporterhelper/common_test.go
@@ -19,7 +19,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"go.opencensus.io/trace"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -29,11 +28,6 @@ import (
 var defaultExporterCfg = &configmodels.ExporterSettings{
 	TypeVal: "test",
 	NameVal: "test",
-}
-
-func TestErrorToStatus(t *testing.T) {
-	require.Equal(t, okStatus, errToStatus(nil))
-	require.Equal(t, trace.Status{Code: trace.StatusCodeUnknown, Message: "my_error"}, errToStatus(errors.New("my_error")))
 }
 
 func TestBaseExporter(t *testing.T) {
@@ -49,11 +43,4 @@ func TestBaseExporterWithOptions(t *testing.T) {
 		WithShutdown(func(ctx context.Context) error { return errors.New("my error") }))
 	require.Error(t, be.Start(context.Background(), componenttest.NewNopHost()))
 	require.Error(t, be.Shutdown(context.Background()))
-}
-
-func errToStatus(err error) trace.Status {
-	if err != nil {
-		return trace.Status{Code: trace.StatusCodeUnknown, Message: err.Error()}
-	}
-	return okStatus
 }

--- a/exporter/exporterhelper/logshelper_test.go
+++ b/exporter/exporterhelper/logshelper_test.go
@@ -20,14 +20,11 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.opencensus.io/trace"
 
-	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configmodels"
 	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/internal/data/testdata"
-	"go.opentelemetry.io/collector/obsreport"
 	"go.opentelemetry.io/collector/obsreport/obsreporttest"
 )
 
@@ -82,51 +79,16 @@ func TestLogsExporter_Default_ReturnError(t *testing.T) {
 	require.Equal(t, want, me.ConsumeLogs(context.Background(), ld))
 }
 
-func TestLogsExporter_WithRecordLogs(t *testing.T) {
-	me, err := NewLogsExporter(fakeLogsExporterConfig, newPushLogsData(0, nil))
-	require.Nil(t, err)
-	require.NotNil(t, me)
-
-	checkRecordedMetricsForLogsExporter(t, me, nil, 0)
+func TestLogsExporter_Observability(t *testing.T) {
+	checkObservabilityForLogsExporter(t, nil, 1, 0)
 }
 
-func TestLogsExporter_WithRecordLogs_NonZeroDropped(t *testing.T) {
-	me, err := NewLogsExporter(fakeLogsExporterConfig, newPushLogsData(1, nil))
-	require.Nil(t, err)
-	require.NotNil(t, me)
-
-	checkRecordedMetricsForLogsExporter(t, me, nil, 1)
+func TestLogsExporter_Observability_NonZeroDropped(t *testing.T) {
+	checkObservabilityForLogsExporter(t, nil, 1, 1)
 }
 
-func TestLogsExporter_WithRecordLogs_ReturnError(t *testing.T) {
-	want := errors.New("my_error")
-	me, err := NewLogsExporter(fakeLogsExporterConfig, newPushLogsData(0, want))
-	require.Nil(t, err)
-	require.NotNil(t, me)
-
-	checkRecordedMetricsForLogsExporter(t, me, want, 0)
-}
-
-func TestLogsExporter_WithSpan(t *testing.T) {
-	me, err := NewLogsExporter(fakeLogsExporterConfig, newPushLogsData(0, nil))
-	require.Nil(t, err)
-	require.NotNil(t, me)
-	checkWrapSpanForLogsExporter(t, me, nil, 1)
-}
-
-func TestLogsExporter_WithSpan_NonZeroDropped(t *testing.T) {
-	me, err := NewLogsExporter(fakeLogsExporterConfig, newPushLogsData(1, nil))
-	require.Nil(t, err)
-	require.NotNil(t, me)
-	checkWrapSpanForLogsExporter(t, me, nil, 1)
-}
-
-func TestLogsExporter_WithSpan_ReturnError(t *testing.T) {
-	want := errors.New("my_error")
-	me, err := NewLogsExporter(fakeLogsExporterConfig, newPushLogsData(0, want))
-	require.Nil(t, err)
-	require.NotNil(t, me)
-	checkWrapSpanForLogsExporter(t, me, want, 1)
+func TestLogsExporter_Observability_ReturnError(t *testing.T) {
+	checkObservabilityForLogsExporter(t, errors.New("my_error"), 1, 0)
 }
 
 func TestLogsExporter_WithShutdown(t *testing.T) {
@@ -152,70 +114,55 @@ func TestLogsExporter_WithShutdown_ReturnError(t *testing.T) {
 	assert.Equal(t, me.Shutdown(context.Background()), want)
 }
 
-func newPushLogsData(droppedTimeSeries int, retError error) PushLogsData {
+func newPushLogsData(droppedLogRecords int, retError error) PushLogsData {
 	return func(ctx context.Context, td pdata.Logs) (int, error) {
-		return droppedTimeSeries, retError
+		return droppedLogRecords, retError
 	}
 }
 
-func checkRecordedMetricsForLogsExporter(t *testing.T, me component.LogsExporter, wantError error, droppedLogRecords int) {
+func checkObservabilityForLogsExporter(t *testing.T, wantError error, numLogRecords, droppedLogRecords int) {
 	doneFn, err := obsreporttest.SetupRecordedMetricsTest()
 	require.NoError(t, err)
 	defer doneFn()
 
-	ld := testdata.GenerateLogDataTwoLogsSameResource()
-	const numBatches = 7
-	for i := 0; i < numBatches; i++ {
-		require.Equal(t, wantError, me.ConsumeLogs(context.Background(), ld))
-	}
+	traceProvider, ime := obsreporttest.SetupSdkTraceProviderTest(t)
+	tracer := traceProvider.Tracer("go.opentelemetry.io/collector/exporter/logshelper")
 
-	// TODO: When the new metrics correctly count partial dropped fix this.
-	if wantError != nil {
-		obsreporttest.CheckExporterLogsViews(t, fakeLogsExporterName, 0, int64(numBatches*ld.LogRecordCount()))
-	} else {
-		obsreporttest.CheckExporterLogsViews(t, fakeLogsExporterName, int64(numBatches*ld.LogRecordCount()), 0)
-	}
-}
-
-func generateLogsTraffic(t *testing.T, me component.LogsExporter, numRequests int, wantError error) {
-	ld := testdata.GenerateLogDataOneLog()
-	ctx, span := trace.StartSpan(context.Background(), fakeLogsParentSpanName, trace.WithSampler(trace.AlwaysSample()))
-	defer span.End()
-	for i := 0; i < numRequests; i++ {
-		require.Equal(t, wantError, me.ConsumeLogs(ctx, ld))
-	}
-}
-
-func checkWrapSpanForLogsExporter(t *testing.T, me component.LogsExporter, wantError error, numLogRecords int64) {
-	ocSpansSaver := new(testOCTraceExporter)
-	trace.RegisterExporter(ocSpansSaver)
-	defer trace.UnregisterExporter(ocSpansSaver)
+	me, err := NewLogsExporter(fakeLogsExporterConfig, newPushLogsData(droppedLogRecords, wantError), withOtelProviders(traceProvider))
+	require.Nil(t, err)
+	require.NotNil(t, me)
 
 	const numRequests = 5
-	generateLogsTraffic(t, me, numRequests, wantError)
+	ld := testdata.GenerateLogDataOneLog()
+	ctx, span := tracer.Start(context.Background(), fakeLogsParentSpanName)
+	for i := 0; i < numRequests; i++ {
+		assert.Equal(t, wantError, me.ConsumeLogs(ctx, ld))
+	}
+	span.End()
 
 	// Inspection time!
-	ocSpansSaver.mu.Lock()
-	defer ocSpansSaver.mu.Unlock()
-
-	require.NotEqual(t, 0, len(ocSpansSaver.spanData), "No exported span data")
-
-	gotSpanData := ocSpansSaver.spanData
-	require.Equal(t, numRequests+1, len(gotSpanData))
+	gotSpanData := ime.GetSpans()
+	require.Len(t, gotSpanData, numRequests+1, "No exported span data")
 
 	parentSpan := gotSpanData[numRequests]
 	require.Equalf(t, fakeLogsParentSpanName, parentSpan.Name, "SpanData %v", parentSpan)
 	for _, sd := range gotSpanData[:numRequests] {
-		require.Equalf(t, parentSpan.SpanContext.SpanID, sd.ParentSpanID, "Exporter span not a child\nSpanData %v", sd)
-		require.Equalf(t, errToStatus(wantError), sd.Status, "SpanData %v", sd)
+		assert.Equalf(t, parentSpan.SpanContext.SpanID, sd.ParentSpanID, "Exporter span not a child\nSpanData %v", sd)
+		obsreporttest.CheckSpanStatus(t, wantError, sd)
 
 		sentLogRecords := numLogRecords
-		var failedToSendLogRecords int64
+		failedToSendLogRecords := 0
 		if wantError != nil {
 			sentLogRecords = 0
 			failedToSendLogRecords = numLogRecords
 		}
-		require.Equalf(t, sentLogRecords, sd.Attributes[obsreport.SentLogRecordsKey], "SpanData %v", sd)
-		require.Equalf(t, failedToSendLogRecords, sd.Attributes[obsreport.FailedToSendLogRecordsKey], "SpanData %v", sd)
+		obsreporttest.CheckExporterLogsSpanAttributes(t, sd, int64(sentLogRecords), int64(failedToSendLogRecords))
+	}
+
+	// TODO: When the new metrics correctly count partial dropped fix this.
+	if wantError != nil {
+		obsreporttest.CheckExporterLogsViews(t, fakeLogsExporterName, 0, int64(numRequests*ld.LogRecordCount()))
+	} else {
+		obsreporttest.CheckExporterLogsViews(t, fakeLogsExporterName, int64(numRequests*ld.LogRecordCount()), 0)
 	}
 }

--- a/exporter/otlpexporter/otlp_test.go
+++ b/exporter/otlpexporter/otlp_test.go
@@ -36,7 +36,6 @@ import (
 	otlpmetrics "go.opentelemetry.io/collector/internal/data/opentelemetry-proto-gen/collector/metrics/v1"
 	otlptraces "go.opentelemetry.io/collector/internal/data/opentelemetry-proto-gen/collector/trace/v1"
 	"go.opentelemetry.io/collector/internal/data/testdata"
-	"go.opentelemetry.io/collector/obsreport"
 	"go.opentelemetry.io/collector/testutil"
 )
 
@@ -72,7 +71,7 @@ func (r *mockTraceReceiver) Export(
 func otlpTraceReceiverOnGRPCServer(ln net.Listener) *mockTraceReceiver {
 	rcv := &mockTraceReceiver{
 		mockReceiver: mockReceiver{
-			srv: obsreport.GRPCServerWithObservabilityEnabled(),
+			srv: grpc.NewServer(),
 		},
 	}
 
@@ -110,7 +109,7 @@ func (r *mockLogsReceiver) Export(
 func otlpLogsReceiverOnGRPCServer(ln net.Listener) *mockLogsReceiver {
 	rcv := &mockLogsReceiver{
 		mockReceiver: mockReceiver{
-			srv: obsreport.GRPCServerWithObservabilityEnabled(),
+			srv: grpc.NewServer(),
 		},
 	}
 
@@ -143,7 +142,7 @@ func (r *mockMetricsReceiver) Export(
 func otlpMetricsReceiverOnGRPCServer(ln net.Listener) *mockMetricsReceiver {
 	rcv := &mockMetricsReceiver{
 		mockReceiver: mockReceiver{
-			srv: obsreport.GRPCServerWithObservabilityEnabled(),
+			srv: grpc.NewServer(),
 		},
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -53,6 +53,9 @@ require (
 	github.com/tinylib/msgp v1.1.2
 	github.com/uber/jaeger-lib v2.2.0+incompatible
 	go.opencensus.io v0.22.4
+	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc v0.11.0
+	go.opentelemetry.io/otel v0.11.0
+	go.opentelemetry.io/otel/sdk v0.11.0
 	go.uber.org/atomic v1.7.0
 	go.uber.org/zap v1.16.0
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d

--- a/go.sum
+++ b/go.sum
@@ -65,6 +65,7 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
+github.com/DataDog/sketches-go v0.0.1/go.mod h1:Q5DbzQ+3AkgGwymQO7aZFNP7ns2lZKGtvRBzRXfdi60=
 github.com/DataDog/zstd v1.3.6-0.20190409195224-796139022798/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
 github.com/DataDog/zstd v1.4.4/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
 github.com/Djarvur/go-err113 v0.0.0-20200511133814-5174e21577d5 h1:XTrzB+F8+SpRmbhAH8HLxhiiG6nYNwaBZjrFps1oWEk=
@@ -131,6 +132,8 @@ github.com/aws/aws-sdk-go v1.27.0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN
 github.com/aws/aws-sdk-go v1.34.9 h1:cUGBW9CVdi0mS7K1hDzxIqTpfeWhpoQiguq81M1tjK0=
 github.com/aws/aws-sdk-go v1.34.9/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZwxzkQq9wy+g=
+github.com/benbjohnson/clock v1.0.3 h1:vkLuvpK4fmtSCuo60+yC63p7y0BmQ8gm5ZXGuBCJyXg=
+github.com/benbjohnson/clock v1.0.3/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -483,6 +486,7 @@ github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4rEjNlfyDHW9dolSY=
@@ -1110,6 +1114,12 @@ go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.opencensus.io v0.22.3/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.opencensus.io v0.22.4 h1:LYy1Hy3MJdrCdMwwzxA/dRok4ejH+RwNGbuoD9fCjto=
 go.opencensus.io v0.22.4/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
+go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc v0.11.0 h1:jx+6CPh/uE5xW4uCm5gCb5B36+/c/k58mH+8YQ1glZo=
+go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc v0.11.0/go.mod h1:+6Kxsolxctkb7k57eHfR2T1EF7ukt5btjo8s/92wk4M=
+go.opentelemetry.io/otel v0.11.0 h1:IN2tzQa9Gc4ZVKnTaMbPVcHjvzOdg5n9QfnmlqiET7E=
+go.opentelemetry.io/otel v0.11.0/go.mod h1:G8UCk+KooF2HLkgo8RHX9epABH/aRGYET7gQOqBVdB0=
+go.opentelemetry.io/otel/sdk v0.11.0 h1:bkDMymVj6gIkPfgC5ci5atq0OYbfUHSn8NvsmyfyMq4=
+go.opentelemetry.io/otel/sdk v0.11.0/go.mod h1:XbZ6MrzIZ+d+qr7pH0FwHIbCnANMvXYgkq4afL/IUMQ=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.5.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
@@ -1473,6 +1483,7 @@ google.golang.org/grpc v1.28.0-pre/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7K
 google.golang.org/grpc v1.28.0/go.mod h1:rpkK4SK4GF4Ach/+MFLZUBavHOvF2JJB5uozKKal+60=
 google.golang.org/grpc v1.29.1/go.mod h1:itym6AZVZYACWQqET3MqgPpjcuV5QH3BxFS3IjizoKk=
 google.golang.org/grpc v1.30.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
+google.golang.org/grpc v1.31.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
 google.golang.org/grpc v1.32.0 h1:zWTV+LMdc3kaiJMSTOFz2UgSBgx8RNQoTGiZu3fR9S0=
 google.golang.org/grpc v1.32.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
 google.golang.org/grpc/examples v0.0.0-20200728065043-dfc0c05b2da9 h1:f+/+gfZ/tfaHBXXiv1gWRmCej6wlX3mLY4bnLpI99wk=

--- a/obsreport/obsreport.go
+++ b/obsreport/obsreport.go
@@ -15,13 +15,11 @@
 package obsreport
 
 import (
-	"context"
 	"strings"
 
 	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
-	"go.opencensus.io/trace"
 
 	"go.opentelemetry.io/collector/consumer/consumerdata"
 )
@@ -34,33 +32,7 @@ var (
 	// Variables to control the usage of legacy and new metrics.
 	useLegacy = true
 	useNew    = true
-
-	okStatus = trace.Status{Code: trace.StatusCodeOK}
 )
-
-// setParentLink tries to retrieve a span from parentCtx and if one exists
-// sets its SpanID, TraceID as a link to the given child Span.
-// It returns true only if it retrieved a parent span from the context.
-//
-// This is typically used when the parentCtx may already have a trace and is
-// long lived (eg.: an gRPC stream, or TCP connection) and one desires distinct
-// traces for individual operations under the long lived trace associated to
-// the parentCtx. This function is a helper that encapsulates the work of
-// linking the short lived trace/span to the longer one.
-func setParentLink(parentCtx context.Context, childSpan *trace.Span) bool {
-	parentSpanFromRPC := trace.FromContext(parentCtx)
-	if parentSpanFromRPC == nil {
-		return false
-	}
-
-	psc := parentSpanFromRPC.SpanContext()
-	childSpan.AddLink(trace.Link{
-		SpanID:  psc.SpanID,
-		TraceID: psc.TraceID,
-		Type:    trace.LinkTypeParent,
-	})
-	return true
-}
 
 // Configure is used to control the settings that will be used by the obsreport
 // package.
@@ -167,11 +139,4 @@ func genViews(
 		})
 	}
 	return views
-}
-
-func errToStatus(err error) trace.Status {
-	if err != nil {
-		return trace.Status{Code: trace.StatusCodeUnknown, Message: err.Error()}
-	}
-	return okStatus
 }

--- a/receiver/opencensusreceiver/ocmetrics/opencensus_test.go
+++ b/receiver/opencensusreceiver/ocmetrics/opencensus_test.go
@@ -42,7 +42,6 @@ import (
 	"go.opentelemetry.io/collector/exporter/exportertest"
 	"go.opentelemetry.io/collector/exporter/opencensusexporter"
 	"go.opentelemetry.io/collector/internal/data/testdata"
-	"go.opentelemetry.io/collector/obsreport"
 	"go.opentelemetry.io/collector/testutil"
 	"go.opentelemetry.io/collector/translator/internaldata"
 )
@@ -371,7 +370,7 @@ func ocReceiverOnGRPCServer(t *testing.T, sr consumer.MetricsConsumer) (int, fun
 	require.NoError(t, err, "Failed to create the Receiver: %v", err)
 
 	// Now run it as a gRPC server
-	srv := obsreport.GRPCServerWithObservabilityEnabled()
+	srv := grpc.NewServer()
 	agentmetricspb.RegisterMetricsServiceServer(srv, oci)
 	go func() {
 		_ = srv.Serve(ln)

--- a/receiver/opencensusreceiver/octrace/observability_test.go
+++ b/receiver/opencensusreceiver/octrace/observability_test.go
@@ -15,18 +15,15 @@
 package octrace
 
 import (
-	"bytes"
-	"encoding/json"
-	"reflect"
-	"sync"
 	"testing"
 	"time"
 
 	commonpb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
 	agenttracepb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/trace/v1"
 	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.opencensus.io/trace"
+	"go.opentelemetry.io/otel/api/global"
 
 	"go.opentelemetry.io/collector/exporter/exportertest"
 	"go.opentelemetry.io/collector/obsreport/obsreporttest"
@@ -44,7 +41,7 @@ func TestEnsureRecordedMetrics(t *testing.T) {
 	require.NoError(t, err)
 	defer doneFn()
 
-	port, doneReceiverFn := ocReceiverOnGRPCServer(t, exportertest.NewNopTraceExporter())
+	port, doneReceiverFn := ocReceiverOnGRPCServer(t, exportertest.NewNopTraceExporter(), global.TraceProvider())
 	defer doneReceiverFn()
 
 	n := 20
@@ -66,7 +63,7 @@ func TestEnsureRecordedMetrics_zeroLengthSpansSender(t *testing.T) {
 	require.NoError(t, err)
 	defer doneFn()
 
-	port, doneFn := ocReceiverOnGRPCServer(t, exportertest.NewNopTraceExporter())
+	port, doneFn := ocReceiverOnGRPCServer(t, exportertest.NewNopTraceExporter(), global.TraceProvider())
 	defer doneFn()
 
 	n := 20
@@ -83,20 +80,8 @@ func TestEnsureRecordedMetrics_zeroLengthSpansSender(t *testing.T) {
 }
 
 func TestExportSpanLinkingMaintainsParentLink(t *testing.T) {
-	// Always sample for the purpose of examining all the spans in this test.
-	trace.ApplyConfig(trace.Config{DefaultSampler: trace.AlwaysSample()})
-
-	// TODO: File an issue with OpenCensus-Go to ask for a method to retrieve
-	// the default sampler because the current method of blindly changing the
-	// global sampler makes testing hard.
-	// Denoise this test by setting the sampler to never sample
-	defer trace.ApplyConfig(trace.Config{DefaultSampler: trace.NeverSample()})
-
-	ocSpansSaver := new(testOCTraceExporter)
-	trace.RegisterExporter(ocSpansSaver)
-	defer trace.UnregisterExporter(ocSpansSaver)
-
-	port, doneFn := ocReceiverOnGRPCServer(t, exportertest.NewNopTraceExporter())
+	tProvider, ime := obsreporttest.SetupSdkTraceProviderTest(t)
+	port, doneFn := ocReceiverOnGRPCServer(t, exportertest.NewNopTraceExporter(), tProvider)
 	defer doneFn()
 
 	traceSvcClient, traceSvcDoneFn, err := makeTraceServiceClient(port)
@@ -112,67 +97,23 @@ func TestExportSpanLinkingMaintainsParentLink(t *testing.T) {
 	flush(traceSvcDoneFn)
 
 	// Inspection time!
-	ocSpansSaver.mu.Lock()
-	defer ocSpansSaver.mu.Unlock()
-
-	require.NotEqual(
-		t,
-		len(ocSpansSaver.spanData),
-		0,
-		"Unfortunately did not receive an exported span data. Please check this library's implementation or go.opencensus.io/trace",
-	)
-
-	gotSpanData := ocSpansSaver.spanData
-	if g, w := len(gotSpanData), n+1; g != w {
-		blob, _ := json.MarshalIndent(gotSpanData, "  ", " ")
-		t.Fatalf("Spandata count: Got %d Want %d\n\nData: %s", g, w, blob)
-	}
+	gotSpanData := ime.GetSpans()
+	require.Len(t, gotSpanData, n+1)
 
 	receiverSpanData := gotSpanData[0]
-	if g, w := len(receiverSpanData.Links), 1; g != w {
-		t.Fatalf("Links count: Got %d Want %d\nGotSpanData: %#v", g, w, receiverSpanData)
-	}
+	require.Len(t, receiverSpanData.Links, 1)
+	assert.Equal(t, "receiver/oc_trace/TraceDataReceived", receiverSpanData.Name)
 
 	// The rpc span is always last in the list
 	rpcSpanData := gotSpanData[len(gotSpanData)-1]
-
-	// Ensure that the link matches up exactly!
-	wantLink := trace.Link{
-		SpanID:  rpcSpanData.SpanID,
-		TraceID: rpcSpanData.TraceID,
-		Type:    trace.LinkTypeParent,
-	}
-	if g, w := receiverSpanData.Links[0], wantLink; !reflect.DeepEqual(g, w) {
-		t.Errorf("Link:\nGot: %#v\nWant: %#v\n", g, w)
-	}
-	if g, w := receiverSpanData.Name, "receiver/oc_trace/TraceDataReceived"; g != w {
-		t.Errorf("ReceiverExport span's SpanData.Name:\nGot:  %q\nWant: %q\n", g, w)
-	}
+	assert.Equal(t, rpcSpanData.SpanContext, receiverSpanData.Links[0].SpanContext)
 
 	// And then for the receiverSpanData itself, it SHOULD NOT
 	// have a ParentID, so let's enforce all the conditions below:
 	// 1. That it doesn't have the RPC spanID as its ParentSpanID
 	// 2. That it actually has no ParentSpanID i.e. has a blank SpanID
-	if g, w := receiverSpanData.ParentSpanID[:], rpcSpanData.SpanID[:]; bytes.Equal(g, w) {
-		t.Errorf("ReceiverSpanData.ParentSpanID unfortunately was linked to the RPC span\nGot:  %x\nWant: %x", g, w)
-	}
-
-	var blankSpanID trace.SpanID
-	if g, w := receiverSpanData.ParentSpanID[:], blankSpanID[:]; !bytes.Equal(g, w) {
-		t.Errorf("ReceiverSpanData unfortunately has a parent and isn't NULL\nGot:  %x\nWant: %x", g, w)
-	}
-}
-
-type testOCTraceExporter struct {
-	mu       sync.Mutex
-	spanData []*trace.SpanData
-}
-
-func (tote *testOCTraceExporter) ExportSpan(sd *trace.SpanData) {
-	tote.mu.Lock()
-	defer tote.mu.Unlock()
-
-	tote.spanData = append(tote.spanData, sd)
+	assert.NotEqual(t, rpcSpanData.SpanContext.SpanID, receiverSpanData.ParentSpanID[:])
+	assert.False(t, receiverSpanData.ParentSpanID.IsValid())
 }
 
 // TODO: Determine how to do this deterministic.

--- a/receiver/opencensusreceiver/opencensus.go
+++ b/receiver/opencensusreceiver/opencensus.go
@@ -27,6 +27,7 @@ import (
 	gatewayruntime "github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/rs/cors"
 	"github.com/soheilhy/cmux"
+	"go.opentelemetry.io/otel/api/global"
 	"google.golang.org/grpc"
 
 	"go.opentelemetry.io/collector/component"
@@ -137,7 +138,7 @@ func (ocr *ocReceiver) grpcServer() *grpc.Server {
 	defer ocr.mu.Unlock()
 
 	if ocr.serverGRPC == nil {
-		ocr.serverGRPC = obsreport.GRPCServerWithObservabilityEnabled(ocr.grpcServerOptions...)
+		ocr.serverGRPC = obsreport.GRPCServerWithObservabilityEnabled(global.TraceProvider(), ocr.grpcServerOptions...)
 	}
 
 	return ocr.serverGRPC

--- a/receiver/otlpreceiver/logs/otlp_test.go
+++ b/receiver/otlpreceiver/logs/otlp_test.go
@@ -31,7 +31,6 @@ import (
 	"go.opentelemetry.io/collector/internal"
 	collectorlog "go.opentelemetry.io/collector/internal/data/opentelemetry-proto-gen/collector/logs/v1"
 	otlplog "go.opentelemetry.io/collector/internal/data/opentelemetry-proto-gen/logs/v1"
-	"go.opentelemetry.io/collector/obsreport"
 	"go.opentelemetry.io/collector/testutil"
 )
 
@@ -176,7 +175,7 @@ func otlpReceiverOnGRPCServer(t *testing.T, tc consumer.LogsConsumer) (int, func
 	require.NoError(t, err)
 
 	// Now run it as a gRPC server
-	srv := obsreport.GRPCServerWithObservabilityEnabled()
+	srv := grpc.NewServer()
 	collectorlog.RegisterLogsServiceServer(srv, r)
 	go func() {
 		_ = srv.Serve(ln)

--- a/receiver/otlpreceiver/metrics/otlp_test.go
+++ b/receiver/otlpreceiver/metrics/otlp_test.go
@@ -30,7 +30,6 @@ import (
 	collectormetrics "go.opentelemetry.io/collector/internal/data/opentelemetry-proto-gen/collector/metrics/v1"
 	otlpcommon "go.opentelemetry.io/collector/internal/data/opentelemetry-proto-gen/common/v1"
 	otlpmetrics "go.opentelemetry.io/collector/internal/data/opentelemetry-proto-gen/metrics/v1"
-	"go.opentelemetry.io/collector/obsreport"
 	"go.opentelemetry.io/collector/testutil"
 )
 
@@ -212,7 +211,7 @@ func otlpReceiverOnGRPCServer(t *testing.T, mc consumer.MetricsConsumer) (int, f
 
 	r := New(receiverTagValue, mc)
 	// Now run it as a gRPC server
-	srv := obsreport.GRPCServerWithObservabilityEnabled()
+	srv := grpc.NewServer()
 	collectormetrics.RegisterMetricsServiceServer(srv, r)
 	go func() {
 		_ = srv.Serve(ln)

--- a/receiver/otlpreceiver/trace/otlp_test.go
+++ b/receiver/otlpreceiver/trace/otlp_test.go
@@ -30,7 +30,6 @@ import (
 	"go.opentelemetry.io/collector/exporter/exportertest"
 	collectortrace "go.opentelemetry.io/collector/internal/data/opentelemetry-proto-gen/collector/trace/v1"
 	otlptrace "go.opentelemetry.io/collector/internal/data/opentelemetry-proto-gen/trace/v1"
-	"go.opentelemetry.io/collector/obsreport"
 	"go.opentelemetry.io/collector/testutil"
 )
 
@@ -179,7 +178,7 @@ func otlpReceiverOnGRPCServer(t *testing.T, tc consumer.TraceConsumer) (int, fun
 	require.NoError(t, err)
 
 	// Now run it as a gRPC server
-	srv := obsreport.GRPCServerWithObservabilityEnabled()
+	srv := grpc.NewServer()
 	collectortrace.RegisterTraceServiceServer(srv, r)
 	go func() {
 		_ = srv.Serve(ln)


### PR DESCRIPTION
Some "breaking" changes:
* Z-pages not yet available for otel-go trace (or not able to find them).
* For otlp-grpc we have not enabled tracing so everything continues to work correctly.
* For oc-grpc we used opencensus with grpc-trace-bin header. This will break, not sure if this is used anywhere.
