### PR TITLE
Report Windows pagefile usage in bytes

### DIFF
--- a/receiver/hostmetricsreceiver/internal/scraper/swapscraper/swap_metadata.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/swapscraper/swap_metadata.go
@@ -54,7 +54,7 @@ var swapUsageDescriptor = func() pdata.Metric {
 	metric.InitEmpty()
 	metric.SetName("system.swap.usage")
 	metric.SetDescription("Swap (unix) or pagefile (windows) usage.")
-	metric.SetUnit("pages")
+	metric.SetUnit("bytes")
 	metric.SetDataType(pdata.MetricDataTypeIntSum)
 	sum := metric.IntSum()
 	sum.InitEmpty()

--- a/receiver/hostmetricsreceiver/internal/scraper/swapscraper/swap_scraper_windows_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/swapscraper/swap_scraper_windows_test.go
@@ -30,17 +30,32 @@ import (
 func TestScrapeMetrics_Errors(t *testing.T) {
 	type testCase struct {
 		name                               string
-		pageFileError                      error
+		pageSize                           uint64
+		getPageFileStats                   func() ([]*pageFileData, error)
 		pageReadsPerSecCounterReturnValue  interface{}
 		pageWritesPerSecCounterReturnValue interface{}
 		expectedError                      string
+		expectedUsedValue                  int64
+		expectedFreeValue                  int64
 	}
+
+	testPageSize := uint64(4096)
+	testPageFileData := &pageFileData{usedPages: 100, totalPages: 300}
 
 	testCases := []testCase{
 		{
-			name:          "pageFileError",
-			pageFileError: errors.New("err1"),
-			expectedError: "err1",
+			name:     "standard",
+			pageSize: testPageSize,
+			getPageFileStats: func() ([]*pageFileData, error) {
+				return []*pageFileData{testPageFileData}, nil
+			},
+			expectedUsedValue: int64(testPageFileData.usedPages * testPageSize),
+			expectedFreeValue: int64((testPageFileData.totalPages - testPageFileData.usedPages) * testPageSize),
+		},
+		{
+			name:             "pageFileError",
+			getPageFileStats: func() ([]*pageFileData, error) { return nil, errors.New("err1") },
+			expectedError:    "err1",
 		},
 		{
 			name:                              "readsPerSecCounterError",
@@ -55,7 +70,7 @@ func TestScrapeMetrics_Errors(t *testing.T) {
 		},
 		{
 			name:                              "multipleErrors",
-			pageFileError:                     errors.New("err1"),
+			getPageFileStats:                  func() ([]*pageFileData, error) { return nil, errors.New("err1") },
 			pageReadsPerSecCounterReturnValue: errors.New("err2"),
 			expectedError:                     "[err1; err2]",
 		},
@@ -64,8 +79,14 @@ func TestScrapeMetrics_Errors(t *testing.T) {
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
 			scraper := newSwapScraper(context.Background(), &Config{})
-			if test.pageFileError != nil {
-				scraper.pageFileStats = func() ([]*pageFileData, error) { return nil, test.pageFileError }
+			if test.getPageFileStats != nil {
+				scraper.pageFileStats = test.getPageFileStats
+			}
+			if test.pageSize > 0 {
+				scraper.pageSize = test.pageSize
+			} else {
+				assert.Greater(t, pageSize, uint64(0))
+				assert.Zero(t, pageSize%4096) // page size on Windows should always be a multiple of 4KB
 			}
 
 			err := scraper.Initialize(context.Background())
@@ -75,8 +96,15 @@ func TestScrapeMetrics_Errors(t *testing.T) {
 			scraper.pageReadsPerSecCounter = pdh.NewMockPerfCounter(test.pageReadsPerSecCounterReturnValue)
 			scraper.pageWritesPerSecCounter = pdh.NewMockPerfCounter(test.pageWritesPerSecCounterReturnValue)
 
-			_, err = scraper.ScrapeMetrics(context.Background())
-			assert.EqualError(t, err, test.expectedError)
+			metrics, err := scraper.ScrapeMetrics(context.Background())
+			if test.expectedError != "" {
+				assert.EqualError(t, err, test.expectedError)
+				return
+			}
+
+			swapUsageMetric := metrics.At(0)
+			assert.Equal(t, test.expectedUsedValue, swapUsageMetric.IntSum().DataPoints().At(0).Value())
+			assert.Equal(t, test.expectedFreeValue, swapUsageMetric.IntSum().DataPoints().At(1).Value())
 		})
 	}
 }


### PR DESCRIPTION
The current code inconsistently reports pagefile usage in pages on Windows and swap usage in bytes on Unix systems.

Updated the code to convert from pages to bytes on Windows so this is consistent.