### PR TITLE
Add metrics to groupbytraceprocessor, wait for queue to be drained during shutdown.

### DIFF
--- a/processor/groupbytraceprocessor/README.md
+++ b/processor/groupbytraceprocessor/README.md
@@ -27,5 +27,34 @@ processors:
     num_traces: 1000
 ```
 
-Refer to [config.yaml](./testdata/config.yaml) for detailed
-examples on using the processor.
+## Configuration
+
+Refer to [config.yaml](./testdata/config.yaml) for detailed examples on using the processor.
+
+The `num_traces` property tells the processor what's the maximum number of traces to keep in the internal storage. A higher `num_traces` might incur in a higher memory usage.
+
+The `wait_duration` property tells the processor for how long it should keep traces in the internal storage. Once a trace is kept for this duration, it's then released to the next consumer and removed from the internal storage. Spans from a trace that has been released will be kept for the entire duration again.
+
+## Metrics
+
+The following metrics are recorded by this processor:
+
+* `otelcol_processor_groupbytrace_conf_num_traces` represents the maximum number of traces that can be kept by the internal storage. This value comes from the processor's configuration and will never change over the lifecycle of the processor.
+* `otelcol_processor_groupbytrace_event_latency_bucket`, with the following `event` tag values:
+  * `onBatchReceived` represents the number of batches the processor has received from the previous components
+  * `onTraceExpired` represents the number of traces that finished waiting in memory for spans to arrive
+  * `onTraceReleased` represents the number of traces that have been marked as released to the next component
+  * `onTraceRemoved` represents the number of traces that have been marked for removal from the internal storage
+* `otelcol_processor_groupbytrace_num_events_in_queue` representing the state of the internal queue. Ideally, this number would be close to zero, but might have temporary spikes if the storage is slow.
+* `otelcol_processor_groupbytrace_num_traces_in_memory` representing the state of the internal trace storage, waiting for spans to arrive. It's common to have items in memory all the time if the processor has a continuous flow of data. The longer the `wait_duration`, the higher the amount of traces in memory should be, given enough traffic.
+* `otelcol_processor_groupbytrace_spans_released` and `otelcol_processor_groupbytrace_traces_released` represent the number of spans and traces effectively released to the next component.
+* `otelcol_processor_groupbytrace_traces_evicted` represents the number of traces that have been evicted from the internal storage due to capacity problems. Ideally, this should be zero, or very close to zero at all times. If you keep getting items evicted, increase the `num_traces`.
+* `otelcol_processor_groupbytrace_incomplete_releases` represents the traces that have been marked as expired, but had been previously been removed. This might be the case when a span from a trace has been received in a batch while the trace existed in the in-memory storage, but has since been released/removed before the span could be added to the trace. This should always be very close to 0, and a high value might indicate a software bug.
+
+A healthy system would have the same value for the metric `otelcol_processor_groupbytrace_spans_released` and for three events under `otelcol_processor_groupbytrace_event_latency_bucket`: `onTraceExpired`, `onTraceRemoved` and `onTraceReleased`.
+
+The metric `otelcol_processor_groupbytrace_event_latency_bucket` is a bucket and shows how long each event took to be processed in miliseconds. In most cases, it should take less than 5ms for an event to be processed, but it might be the case where an event could take 10ms. Higher latencies are possible, but it should never really reach the last item, representing 1s. Events taking more than 1s are killed automatically, and if you have multiple items in this bucket, it might indicate a bug in the software.
+
+Most metrics are updated when the events occur, except for the following ones, which are updated periodically:
+* `otelcol_processor_groupbytrace_num_events_in_queue`
+* `otelcol_processor_groupbytrace_num_traces_in_memory`

--- a/processor/groupbytraceprocessor/event.go
+++ b/processor/groupbytraceprocessor/event.go
@@ -15,8 +15,12 @@
 package groupbytraceprocessor
 
 import (
+	"context"
 	"sync"
+	"time"
 
+	"go.opencensus.io/stats"
+	"go.opencensus.io/tag"
 	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/consumer/pdata"
@@ -34,9 +38,6 @@ const (
 
 	// traceID to be removed
 	traceRemoved
-
-	// shutdown
-	stop
 )
 
 type eventType int
@@ -51,10 +52,14 @@ type event struct {
 // on the callbacks, otherwise, events might pile up. When enough events are piled up, firing an
 // event will block until enough capacity is available to accept the events.
 type eventMachine struct {
-	events chan event
+	events                    chan event
+	close                     chan struct{}
+	metricsCollectionInterval time.Duration
+	shutdownTimeout           time.Duration
+
 	logger *zap.Logger
 
-	onTraceReceived func(pdata.Traces) error
+	onBatchReceived func(pdata.Traces) error
 	onTraceExpired  func(pdata.TraceID) error
 	onTraceReleased func([]pdata.ResourceSpans) error
 	onTraceRemoved  func(pdata.TraceID) error
@@ -68,84 +73,119 @@ type eventMachine struct {
 
 func newEventMachine(logger *zap.Logger, bufferSize int) *eventMachine {
 	em := &eventMachine{
-		logger:       logger,
-		events:       make(chan event, bufferSize),
-		shutdownLock: &sync.RWMutex{},
+		logger:                    logger,
+		events:                    make(chan event, bufferSize),
+		close:                     make(chan struct{}),
+		shutdownLock:              &sync.RWMutex{},
+		metricsCollectionInterval: time.Second,
+		shutdownTimeout:           10 * time.Second,
 	}
 	return em
 }
 
 func (em *eventMachine) startInBackground() {
 	go em.start()
+	go em.periodicMetrics()
+}
+
+func (em *eventMachine) periodicMetrics() {
+	numEvents := len(em.events)
+	em.logger.Debug("recording current state of the queue", zap.Int("num-events", numEvents))
+	stats.Record(context.Background(), mNumEventsInQueue.M(int64(numEvents)))
+
+	em.shutdownLock.RLock()
+	closed := em.closed
+	em.shutdownLock.RUnlock()
+	if closed {
+		return
+	}
+
+	time.AfterFunc(em.metricsCollectionInterval, func() {
+		em.periodicMetrics()
+	})
 }
 
 func (em *eventMachine) start() {
-	for e := range em.events {
-		switch e.typ {
-		case traceReceived:
-			if em.onTraceReceived == nil {
-				em.logger.Debug("onTraceReceived not set, skipping event")
-				em.callOnError(e)
-				continue
-			}
-			payload, ok := e.payload.(pdata.Traces)
-			if !ok {
-				// the payload had an unexpected type!
-				em.callOnError(e)
-				continue
-			}
-			em.onTraceReceived(payload)
-		case traceExpired:
-			if em.onTraceExpired == nil {
-				em.logger.Debug("onTraceExpired not set, skipping event")
-				em.callOnError(e)
-				continue
-			}
-			payload, ok := e.payload.(pdata.TraceID)
-			if !ok {
-				// the payload had an unexpected type!
-				em.callOnError(e)
-				continue
-			}
-			em.onTraceExpired(payload)
-		case traceReleased:
-			if em.onTraceReleased == nil {
-				em.logger.Debug("onTraceReleased not set, skipping event")
-				em.callOnError(e)
-				continue
-			}
-			payload, ok := e.payload.([]pdata.ResourceSpans)
-			if !ok {
-				// the payload had an unexpected type!
-				em.callOnError(e)
-				continue
-			}
-			em.onTraceReleased(payload)
-		case traceRemoved:
-			if em.onTraceRemoved == nil {
-				em.logger.Debug("onTraceRemoved not set, skipping event")
-				em.callOnError(e)
-				continue
-			}
-			payload, ok := e.payload.(pdata.TraceID)
-			if !ok {
-				// the payload had an unexpected type!
-				em.callOnError(e)
-				continue
-			}
-			em.onTraceRemoved(payload)
-		case stop:
-			em.logger.Info("shuttting down the event machine")
-			em.shutdownLock.Lock()
-			em.closed = true
-			em.shutdownLock.Unlock()
-			e.payload.(*sync.WaitGroup).Done()
+	for {
+		select {
+		case e := <-em.events:
+			em.handleEvent(e)
+		case <-em.close:
 			return
-		default:
-			em.logger.Info("unknown event type", zap.Any("event", e.typ))
-			em.callOnError(e)
-			continue
 		}
+	}
+}
+
+func (em *eventMachine) handleEvent(e event) {
+	switch e.typ {
+	case traceReceived:
+		if em.onBatchReceived == nil {
+			em.logger.Debug("onBatchReceived not set, skipping event")
+			em.callOnError(e)
+			return
+		}
+		payload, ok := e.payload.(pdata.Traces)
+		if !ok {
+			// the payload had an unexpected type!
+			em.callOnError(e)
+			return
+		}
+
+		em.handleEventWithObservability("onBatchReceived", func() error {
+			return em.onBatchReceived(payload)
+		})
+	case traceExpired:
+		if em.onTraceExpired == nil {
+			em.logger.Debug("onTraceExpired not set, skipping event")
+			em.callOnError(e)
+			return
+		}
+		payload, ok := e.payload.(pdata.TraceID)
+		if !ok {
+			// the payload had an unexpected type!
+			em.callOnError(e)
+			return
+		}
+
+		em.handleEventWithObservability("onTraceExpired", func() error {
+			return em.onTraceExpired(payload)
+		})
+	case traceReleased:
+		if em.onTraceReleased == nil {
+			em.logger.Debug("onTraceReleased not set, skipping event")
+			em.callOnError(e)
+			return
+		}
+		payload, ok := e.payload.([]pdata.ResourceSpans)
+		if !ok {
+			// the payload had an unexpected type!
+			em.callOnError(e)
+			return
+		}
+
+		em.handleEventWithObservability("onTraceReleased", func() error {
+			return em.onTraceReleased(payload)
+		})
+	case traceRemoved:
+		if em.onTraceRemoved == nil {
+			em.logger.Debug("onTraceRemoved not set, skipping event")
+			em.callOnError(e)
+			return
+		}
+		payload, ok := e.payload.(pdata.TraceID)
+		if !ok {
+			// the payload had an unexpected type!
+			em.callOnError(e)
+			return
+		}
+
+		em.handleEventWithObservability("onTraceRemoved", func() error {
+			return em.onTraceRemoved(payload)
+		})
+	default:
+		em.logger.Info("unknown event type", zap.Any("event", e.typ))
+		em.callOnError(e)
+		return
 	}
 }
 
@@ -164,17 +204,66 @@ func (em *eventMachine) fire(events ...event) {
 }
 
 func (em *eventMachine) shutdown() {
-	wg := &sync.WaitGroup{}
-	wg.Add(1)
-	em.events <- event{
-		typ:     stop,
-		payload: wg,
+	em.logger.Info("shutting down the event manager", zap.Int("pending-events", len(em.events)))
+	em.shutdownLock.Lock()
+	em.closed = true
+	em.shutdownLock.Unlock()
+
+	// we never return an error here
+	ok, _ := doWithTimeout(em.shutdownTimeout, func() error {
+		for {
+			if len(em.events) == 0 {
+				return nil
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+	})
+
+	if !ok {
+		em.logger.Info("forcing the shutdown of the event manager", zap.Int("pending-events", len(em.events)))
 	}
-	wg.Wait()
+	close(em.close)
 }
 
 func (em *eventMachine) callOnError(e event) {
 	if em.onError != nil {
 		em.onError(e)
+	}
+}
+
+// handleEventWithObservability uses the given function to process and event,
+// recording the event's latency and timing out if it doesn't finish within a reasonable duration
+func (em *eventMachine) handleEventWithObservability(event string, do func() error) {
+	start := time.Now()
+	succeeded, err := doWithTimeout(time.Second, do)
+	duration := time.Since(start)
+
+	ctx, _ := tag.New(context.Background(), tag.Upsert(tag.MustNewKey("event"), event))
+	stats.Record(ctx, mEventLatency.M(duration.Milliseconds()))
+
+	logger := em.logger.With(zap.String("event", event))
+	if err != nil {
+		logger.Error("failed to process event", zap.Error(err))
+	}
+	if succeeded {
+		logger.Debug("event finished")
+	} else {
+		logger.Debug("event aborted")
+	}
+}
+
+// doWithTimeout wraps a function in a timeout, returning whether it succeeded before timing out.
+// If the function returns an error within the timeout, it's considered as succeeded and the error will be returned back to the caller.
+func doWithTimeout(timeout time.Duration, do func() error) (bool, error) {
+	done := make(chan error)
+	go func() {
+		done <- do()
+	}()
+
+	select {
+	case <-time.After(timeout):
+		return false, nil
+	case err := <-done:
+		return true, err
 	}
 }

--- a/processor/groupbytraceprocessor/event_test.go
+++ b/processor/groupbytraceprocessor/event_test.go
@@ -21,8 +21,11 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
 	"go.uber.org/zap"
 
+	"go.opentelemetry.io/collector/config/configtelemetry"
 	"go.opentelemetry.io/collector/consumer/pdata"
 )
 
@@ -38,7 +41,7 @@ func TestEventCallback(t *testing.T) {
 			typ:      traceReceived,
 			payload:  pdata.NewTraces(),
 			registerCallback: func(em *eventMachine, wg *sync.WaitGroup) {
-				em.onTraceReceived = func(expired pdata.Traces) error {
+				em.onBatchReceived = func(expired pdata.Traces) error {
 					wg.Done()
 					return nil
 				}
@@ -162,7 +165,7 @@ func TestEventInvalidPayload(t *testing.T) {
 			casename: "onTraceReceived",
 			typ:      traceReceived,
 			registerCallback: func(em *eventMachine, wg *sync.WaitGroup) {
-				em.onTraceReceived = func(expired pdata.Traces) error {
+				em.onBatchReceived = func(expired pdata.Traces) error {
 					return nil
 				}
 			},
@@ -249,14 +252,21 @@ func TestEventShutdown(t *testing.T) {
 	logger, err := zap.NewDevelopment()
 	require.NoError(t, err)
 
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+
 	traceReceivedFired, traceExpiredFired := false, false
 	em := newEventMachine(logger, 50)
-	em.onTraceReceived = func(pdata.Traces) error {
+	em.onBatchReceived = func(pdata.Traces) error {
 		traceReceivedFired = true
 		return nil
 	}
 	em.onTraceExpired = func(pdata.TraceID) error {
 		traceExpiredFired = true
+		return nil
+	}
+	em.onTraceRemoved = func(pdata.TraceID) error {
+		wg.Wait()
 		return nil
 	}
 	em.startInBackground()
@@ -266,7 +276,31 @@ func TestEventShutdown(t *testing.T) {
 		typ:     traceReceived,
 		payload: pdata.NewTraces(),
 	})
-	em.shutdown()
+	em.fire(event{
+		typ:     traceRemoved,
+		payload: pdata.NewTraceID([]byte{1, 2, 3, 4}),
+	})
+	em.fire(event{
+		typ:     traceRemoved,
+		payload: pdata.NewTraceID([]byte{1, 2, 3, 4}),
+	})
+
+	time.Sleep(10 * time.Millisecond) // give it a bit of time to process the items
+	assert.Len(t, em.events, 1)       // we should have one pending event in the queue, the second traceRemoved event
+
+	shutdownWg := sync.WaitGroup{}
+	shutdownWg.Add(1)
+	go func() {
+		em.shutdown()
+		shutdownWg.Done()
+	}()
+
+	wg.Done()                          // the pending event should be processed
+	time.Sleep(100 * time.Millisecond) // give it a bit of time to process the items
+
+	assert.Len(t, em.events, 0)
+
+	// new events should *not* be processed
 	em.fire(event{
 		typ:     traceExpired,
 		payload: pdata.NewTraceID([]byte{1, 2, 3, 4}),
@@ -278,6 +312,107 @@ func TestEventShutdown(t *testing.T) {
 	// If the code is wrong, there's a chance that the test will still pass
 	// in case the event is processed after the assertion.
 	// for this reason, we add a small delay here
-	<-time.After(10 * time.Millisecond)
+	time.Sleep(10 * time.Millisecond)
 	assert.False(t, traceExpiredFired)
+
+	// wait until the shutdown has returned
+	shutdownWg.Wait()
+}
+
+func TestPeriodicMetrics(t *testing.T) {
+	// prepare
+	views := MetricViews(configtelemetry.LevelDetailed)
+	view.Register(views...)
+	defer view.Unregister(views...)
+
+	logger, err := zap.NewDevelopment()
+	require.NoError(t, err)
+	em := newEventMachine(logger, 50)
+	em.metricsCollectionInterval = time.Millisecond
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		expected := 2
+		calls := 0
+		for range em.events {
+			// we expect two events, after which we just exit the loop
+			// if we return from here, we'd still have one item in the queue that is not going to be consumed
+			wg.Wait()
+			calls++
+
+			if calls == expected {
+				return
+			}
+		}
+	}()
+
+	// sanity check
+	assertGaugeNotCreated(t, mNumEventsInQueue)
+
+	// test
+	em.fire(event{typ: traceReceived})
+	em.fire(event{typ: traceReceived}) // the first is consumed right away, the second is in the queue
+	go em.periodicMetrics()
+
+	// ensure our gauge is showing 1 item in the queue
+	time.Sleep(10 * time.Millisecond) // wait enough time for the gauge to be updated
+	assertGauge(t, 1, mNumEventsInQueue)
+
+	wg.Done() // release all events
+	time.Sleep(5 * time.Millisecond)
+
+	// ensure our gauge is now showing no items in the queue
+	assertGauge(t, 0, mNumEventsInQueue)
+
+	// signal and wait for the recursive call to finish
+	em.shutdownLock.Lock()
+	em.closed = true
+	em.shutdownLock.Unlock()
+	time.Sleep(5 * time.Millisecond)
+}
+
+func TestForceShutdown(t *testing.T) {
+	// prepare
+	em := newEventMachine(logger, 50)
+	em.shutdownTimeout = 20 * time.Millisecond
+
+	// test
+	em.fire(event{typ: traceExpired})
+
+	start := time.Now()
+	em.shutdown() // should take about 20ms to return
+	duration := time.Since(start)
+
+	// verify
+	assert.True(t, duration > 20*time.Millisecond)
+}
+
+func TestDoWithTimeout(t *testing.T) {
+	// prepare
+	start := time.Now()
+
+	// test
+	doWithTimeout(10*time.Millisecond, func() error {
+		time.Sleep(20 * time.Second)
+		return nil
+	})
+
+	// verify
+	assert.WithinDuration(t, start, time.Now(), 20*time.Millisecond)
+}
+
+func assertGauge(t *testing.T, expected int, gauge *stats.Int64Measure) {
+	viewData, err := view.RetrieveData(gauge.Name())
+	require.NoError(t, err)
+	require.Len(t, viewData, 1) // we expect exactly one data point, the last value
+
+	sum := viewData[0].Data.(*view.LastValueData)
+	assert.EqualValues(t, expected, sum.Value)
+}
+
+func assertGaugeNotCreated(t *testing.T, gauge *stats.Int64Measure) {
+	viewData, err := view.RetrieveData(gauge.Name())
+	require.NoError(t, err)
+	assert.Len(t, viewData, 0, "gauge exists already but shouldn't")
 }

--- a/processor/groupbytraceprocessor/factory_test.go
+++ b/processor/groupbytraceprocessor/factory_test.go
@@ -19,8 +19,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/component"
 )
@@ -38,9 +36,6 @@ func TestDefaultConfiguration(t *testing.T) {
 
 func TestCreateTestProcessor(t *testing.T) {
 	c := createDefaultConfig().(*Config)
-
-	logger, err := zap.NewDevelopment()
-	require.NoError(t, err)
 
 	params := component.ProcessorCreateParams{
 		Logger: logger,

--- a/processor/groupbytraceprocessor/metrics.go
+++ b/processor/groupbytraceprocessor/metrics.go
@@ -1,0 +1,99 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package groupbytraceprocessor
+
+import (
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
+
+	"go.opentelemetry.io/collector/config/configtelemetry"
+	"go.opentelemetry.io/collector/obsreport"
+)
+
+var (
+	mNumTracesConf      = stats.Int64("conf_num_traces", "Maximum number of traces to hold in the internal storage", stats.UnitDimensionless)
+	mNumEventsInQueue   = stats.Int64("num_events_in_queue", "Number of events currently in the queue", stats.UnitDimensionless)
+	mNumTracesInMemory  = stats.Int64("num_traces_in_memory", "Number of traces currently in the in-memory storage", stats.UnitDimensionless)
+	mTracesEvicted      = stats.Int64("traces_evicted", "Traces evicted from the internal buffer", stats.UnitDimensionless)
+	mReleasedSpans      = stats.Int64("spans_released", "Spans released to the next consumer", stats.UnitDimensionless)
+	mReleasedTraces     = stats.Int64("traces_released", "Traces released to the next consumer", stats.UnitDimensionless)
+	mIncompleteReleases = stats.Int64("incomplete_releases", "Releases that are suspected to have been incomplete", stats.UnitDimensionless)
+	mEventLatency       = stats.Int64("event_latency", "How long the queue events are taking to be processed", stats.UnitMilliseconds)
+)
+
+// MetricViews return the metrics views according to given telemetry level.
+func MetricViews(level configtelemetry.Level) []*view.View {
+	if level == configtelemetry.LevelNone {
+		return nil
+	}
+
+	legacyViews := []*view.View{
+		{
+			Name:        mNumTracesConf.Name(),
+			Measure:     mNumTracesConf,
+			Description: mNumTracesConf.Description(),
+			Aggregation: view.LastValue(),
+		},
+		{
+			Name:        mNumEventsInQueue.Name(),
+			Measure:     mNumEventsInQueue,
+			Description: mNumEventsInQueue.Description(),
+			Aggregation: view.LastValue(),
+		},
+		{
+			Name:        mNumTracesInMemory.Name(),
+			Measure:     mNumTracesInMemory,
+			Description: mNumTracesInMemory.Description(),
+			Aggregation: view.LastValue(),
+		},
+		{
+			Name:        mTracesEvicted.Name(),
+			Measure:     mTracesEvicted,
+			Description: mTracesEvicted.Description(),
+			// sum allows us to start from 0, count will only show up if there's at least one eviction, which might take a while to happen (if ever!)
+			Aggregation: view.Sum(),
+		},
+		{
+			Name:        mReleasedSpans.Name(),
+			Measure:     mReleasedSpans,
+			Description: mReleasedSpans.Description(),
+			Aggregation: view.Sum(),
+		},
+		{
+			Name:        mReleasedTraces.Name(),
+			Measure:     mReleasedTraces,
+			Description: mReleasedTraces.Description(),
+			Aggregation: view.Sum(),
+		},
+		{
+			Name:        mIncompleteReleases.Name(),
+			Measure:     mIncompleteReleases,
+			Description: mIncompleteReleases.Description(),
+			Aggregation: view.Sum(),
+		},
+		{
+			Name:        mEventLatency.Name(),
+			Measure:     mEventLatency,
+			Description: mEventLatency.Description(),
+			TagKeys: []tag.Key{
+				tag.MustNewKey("event"),
+			},
+			Aggregation: view.Distribution(0, 5, 10, 20, 50, 100, 200, 500, 1000),
+		},
+	}
+
+	return obsreport.ProcessorMetricViews(string(typeStr), legacyViews)
+}

--- a/processor/groupbytraceprocessor/metrics_test.go
+++ b/processor/groupbytraceprocessor/metrics_test.go
@@ -1,0 +1,58 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package groupbytraceprocessor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"go.opentelemetry.io/collector/config/configtelemetry"
+)
+
+func TestProcessorMetrics(t *testing.T) {
+	tests := []struct {
+		viewNames []string
+		level     configtelemetry.Level
+	}{
+		{
+			viewNames: []string{
+				"conf_num_traces",
+				"num_events_in_queue",
+				"num_traces_in_memory",
+				"traces_evicted",
+				"spans_released",
+				"traces_released",
+				"incomplete_releases",
+				"event_latency",
+			},
+			level: configtelemetry.LevelDetailed,
+		},
+		{
+			viewNames: []string{},
+			level:     configtelemetry.LevelNone,
+		},
+	}
+	for _, test := range tests {
+		views := MetricViews(test.level)
+		if test.viewNames == nil {
+			assert.Nil(t, views)
+			continue
+		}
+		for i, viewName := range test.viewNames {
+			assert.Equal(t, viewName, views[i].Name)
+		}
+	}
+}

--- a/processor/groupbytraceprocessor/processor.go
+++ b/processor/groupbytraceprocessor/processor.go
@@ -62,7 +62,7 @@ var _ component.TraceProcessor = (*groupByTraceProcessor)(nil)
 
 // newGroupByTraceProcessor returns a new processor.
 func newGroupByTraceProcessor(logger *zap.Logger, st storage, nextConsumer consumer.TraceConsumer, config Config) (*groupByTraceProcessor, error) {
-	// the event machine will buffer up to 200 concurrent events before blocking
+	// the event machine will buffer up to N concurrent events before blocking
 	eventMachine := newEventMachine(logger, 10000)
 
 	sp := &groupByTraceProcessor{

--- a/processor/groupbytraceprocessor/processor.go
+++ b/processor/groupbytraceprocessor/processor.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"time"
 
+	"go.opencensus.io/stats"
 	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/component"
@@ -38,7 +39,7 @@ var (
 // Each in-flight trace is registered with a go routine, which will be called after the given duration and dispatched to the event
 // machine for further processing.
 // The typical data flow looks like this:
-// ConsumeTraces -> event(traceReceived) -> onTraceReceived -> AfterFunc(duration, event(traceExpired)) -> onTraceExpired
+// ConsumeTraces -> event(traceReceived) -> onBatchReceived -> AfterFunc(duration, event(traceExpired)) -> onTraceExpired
 // async markAsReleased -> event(traceReleased) -> onTraceReleased -> nextConsumer
 // This processor uses also a ring buffer to hold the in-flight trace IDs, so that we don't hold more than the given maximum number
 // of traces in memory/storage. Items that are evicted from the buffer are discarded without warning.
@@ -62,7 +63,7 @@ var _ component.TraceProcessor = (*groupByTraceProcessor)(nil)
 // newGroupByTraceProcessor returns a new processor.
 func newGroupByTraceProcessor(logger *zap.Logger, st storage, nextConsumer consumer.TraceConsumer, config Config) (*groupByTraceProcessor, error) {
 	// the event machine will buffer up to 200 concurrent events before blocking
-	eventMachine := newEventMachine(logger, 200)
+	eventMachine := newEventMachine(logger, 10000)
 
 	sp := &groupByTraceProcessor{
 		logger:       logger,
@@ -74,7 +75,7 @@ func newGroupByTraceProcessor(logger *zap.Logger, st storage, nextConsumer consu
 	}
 
 	// register the callbacks
-	eventMachine.onTraceReceived = sp.onTraceReceived
+	eventMachine.onBatchReceived = sp.onBatchReceived
 	eventMachine.onTraceExpired = sp.onTraceExpired
 	eventMachine.onTraceReleased = sp.onTraceReleased
 	eventMachine.onTraceRemoved = sp.onTraceRemoved
@@ -96,20 +97,25 @@ func (sp *groupByTraceProcessor) GetCapabilities() component.ProcessorCapabiliti
 
 // Start is invoked during service startup.
 func (sp *groupByTraceProcessor) Start(context.Context, component.Host) error {
+	// start these metrics, as it might take a while for them to receive their first event
+	stats.Record(context.Background(), mTracesEvicted.M(0))
+	stats.Record(context.Background(), mIncompleteReleases.M(0))
+	stats.Record(context.Background(), mNumTracesConf.M(int64(sp.config.NumTraces)))
+
 	sp.eventMachine.startInBackground()
-	return nil
+	return sp.st.start()
 }
 
 // Shutdown is invoked during service shutdown.
 func (sp *groupByTraceProcessor) Shutdown(_ context.Context) error {
 	sp.eventMachine.shutdown()
-	return nil
+	return sp.st.shutdown()
 }
 
-func (sp *groupByTraceProcessor) onTraceReceived(batch pdata.Traces) error {
+func (sp *groupByTraceProcessor) onBatchReceived(batch pdata.Traces) error {
 	for i := 0; i < batch.ResourceSpans().Len(); i++ {
 		if err := sp.processResourceSpans(batch.ResourceSpans().At(i)); err != nil {
-			sp.logger.Info("failed to process trace", zap.Error(err))
+			sp.logger.Info("failed to process batch", zap.Error(err))
 		}
 	}
 
@@ -124,7 +130,7 @@ func (sp *groupByTraceProcessor) processResourceSpans(rs pdata.ResourceSpans) er
 
 	for _, batch := range splitByTrace(rs) {
 		if err := sp.processBatch(batch); err != nil {
-			sp.logger.Info("failed to process batch", zap.Error(err),
+			sp.logger.Warn("failed to process batch", zap.Error(err),
 				zap.String("traceID", batch.traceID.HexString()))
 		}
 	}
@@ -156,7 +162,8 @@ func (sp *groupByTraceProcessor) processBatch(batch *singleTraceBatch) error {
 			payload: evicted,
 		})
 
-		// TODO: do we want another channel that receives evicted items? record a metric perhaps?
+		stats.Record(context.Background(), mTracesEvicted.M(1))
+
 		sp.logger.Info("trace evicted: in order to avoid this in the future, adjust the wait duration and/or number of traces to keep in memory",
 			zap.String("traceID", evicted.HexString()))
 	}
@@ -188,6 +195,8 @@ func (sp *groupByTraceProcessor) onTraceExpired(traceID pdata.TraceID) error {
 		// and released this trace already
 		sp.logger.Debug("skipping the processing of expired trace",
 			zap.String("traceID", traceID.HexString()))
+
+		stats.Record(context.Background(), mIncompleteReleases.M(1))
 		return nil
 	}
 
@@ -233,6 +242,8 @@ func (sp *groupByTraceProcessor) onTraceReleased(rss []pdata.ResourceSpans) erro
 	for _, rs := range rss {
 		trace.ResourceSpans().Append(rs)
 	}
+	stats.Record(context.Background(), mReleasedSpans.M(int64(trace.SpanCount())))
+	stats.Record(context.Background(), mReleasedTraces.M(1))
 	return sp.nextConsumer.ConsumeTraces(context.Background(), trace)
 }
 

--- a/processor/groupbytraceprocessor/storage.go
+++ b/processor/groupbytraceprocessor/storage.go
@@ -33,4 +33,10 @@ type storage interface {
 	// delete will remove the trace based on the given trace ID, returning the trace that was removed,
 	// or nil in case a trace cannot be found
 	delete(pdata.TraceID) ([]pdata.ResourceSpans, error)
+
+	// start gives the storage the opportunity to initialize any resources or procedures
+	start() error
+
+	// shutdown signals the storage that the processor is shutting down
+	shutdown() error
 }

--- a/service/telemetry.go
+++ b/service/telemetry.go
@@ -30,6 +30,7 @@ import (
 	"go.opentelemetry.io/collector/obsreport"
 	"go.opentelemetry.io/collector/processor"
 	"go.opentelemetry.io/collector/processor/batchprocessor"
+	"go.opentelemetry.io/collector/processor/groupbytraceprocessor"
 	"go.opentelemetry.io/collector/processor/queuedprocessor"
 	"go.opentelemetry.io/collector/processor/samplingprocessor/tailsamplingprocessor"
 	fluentobserv "go.opentelemetry.io/collector/receiver/fluentforwardreceiver/observ"
@@ -74,6 +75,7 @@ func (tel *appTelemetry) init(asyncErrorChannel chan<- error, ballastSizeBytes u
 	views = append(views, queuedprocessor.MetricViews(level)...)
 	views = append(views, batchprocessor.MetricViews(level)...)
 	views = append(views, tailsamplingprocessor.SamplingProcessorMetricViews(level)...)
+	views = append(views, groupbytraceprocessor.MetricViews(level)...)
 	views = append(views, kafkareceiver.MetricViews()...)
 	views = append(views, processMetricsViews.Views()...)
 	views = append(views, fluentobserv.Views(level)...)


### PR DESCRIPTION
Fixed deadlock in groupbytrace processor.

* Drain the queue upon shutdown, with a time limit. Fixes #1465.
* Added metrics to the groupbyprocessor, making it easier to understand what's going on in case of problems. See #1811.
* Changes the in-memory storage to unlock its RLock when the method returns. Fixes #1811.

Link to tracking Issue: #1465 and #1811
Testing: unit + manual tests
Documentation: see README.md

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>
