### PR TITLE
Deprecate OpenCensus-based internal data structures

### DIFF
--- a/consumer/consumerdata/consumerdata.go
+++ b/consumer/consumerdata/consumerdata.go
@@ -23,6 +23,7 @@ import (
 )
 
 // MetricsData is a struct that groups proto metrics with a unique node and a resource.
+// Deprecated: use pdata.Metrics instead.
 type MetricsData struct {
 	Node     *commonpb.Node
 	Resource *resourcepb.Resource
@@ -30,6 +31,7 @@ type MetricsData struct {
 }
 
 // TraceData is a struct that groups proto spans with a unique node and a resource.
+// Deprecated: use pdata.Traces instead.
 type TraceData struct {
 	Node         *commonpb.Node
 	Resource     *resourcepb.Resource

--- a/translator/internaldata/metrics_to_oc.go
+++ b/translator/internaldata/metrics_to_oc.go
@@ -31,6 +31,8 @@ type labelKeys struct {
 	keyIndices map[string]int
 }
 
+// MetricsToOC may be used only by OpenCensus receiver and exporter implementations.
+// TODO: move this function to OpenCensus package.
 func MetricsToOC(md pdata.Metrics) []consumerdata.MetricsData {
 	resourceMetrics := md.ResourceMetrics()
 

--- a/translator/internaldata/oc_to_metrics.go
+++ b/translator/internaldata/oc_to_metrics.go
@@ -23,6 +23,7 @@ import (
 )
 
 // OCSliceToMetricData converts a slice of OC data format to data.MetricData.
+// Deprecated: use pdata.Metrics instead.
 func OCSliceToMetrics(ocmds []consumerdata.MetricsData) pdata.Metrics {
 	metricData := pdata.NewMetrics()
 	if len(ocmds) == 0 {
@@ -35,6 +36,8 @@ func OCSliceToMetrics(ocmds []consumerdata.MetricsData) pdata.Metrics {
 }
 
 // OCToMetricData converts OC data format to data.MetricData.
+// Deprecated: use pdata.Metrics instead. OCToMetrics may be used only by OpenCensus
+// receiver and exporter implementations.
 func OCToMetrics(md consumerdata.MetricsData) pdata.Metrics {
 	metricData := pdata.NewMetrics()
 	appendOcToMetrics(md, metricData)

--- a/translator/internaldata/oc_to_traces.go
+++ b/translator/internaldata/oc_to_traces.go
@@ -28,6 +28,8 @@ import (
 )
 
 // OCToTraceData converts OC data format to Traces.
+// Deprecated: use pdata.Traces instead. OCToTraceData may be used only by OpenCensus
+// receiver and exporter implementations.
 func OCToTraceData(td consumerdata.TraceData) pdata.Traces {
 	traceData := pdata.NewTraces()
 	if td.Node == nil && td.Resource == nil && len(td.Spans) == 0 {

--- a/translator/internaldata/traces_to_oc.go
+++ b/translator/internaldata/traces_to_oc.go
@@ -33,6 +33,8 @@ var (
 	defaultProcessID = 0
 )
 
+// TraceDataToOC may be used only by OpenCensus receiver and exporter implementations.
+// TODO: move this function to OpenCensus package.
 func TraceDataToOC(td pdata.Traces) []consumerdata.TraceData {
 	resourceSpans := td.ResourceSpans()
 
@@ -47,13 +49,13 @@ func TraceDataToOC(td pdata.Traces) []consumerdata.TraceData {
 		if rs.IsNil() {
 			continue
 		}
-		ocResourceSpansList = append(ocResourceSpansList, ResourceSpansToOC(rs))
+		ocResourceSpansList = append(ocResourceSpansList, resourceSpansToOC(rs))
 	}
 
 	return ocResourceSpansList
 }
 
-func ResourceSpansToOC(rs pdata.ResourceSpans) consumerdata.TraceData {
+func resourceSpansToOC(rs pdata.ResourceSpans) consumerdata.TraceData {
 	ocTraceData := consumerdata.TraceData{
 		SourceFormat: sourceFormat,
 	}


### PR DESCRIPTION
All new code must use the new pdata.* structures.

TODO: move a few remaining functions that translate between
OpenCensus-data and pdata to OpenCensus packages.

