### PR TITLE
Fix Deadlock in groupbytrace

### DIFF
--- a/processor/groupbytraceprocessor/event.go
+++ b/processor/groupbytraceprocessor/event.go
@@ -29,12 +29,6 @@ const (
 	// traceID to be released
 	traceExpired
 
-	// released traces
-	traceReleased
-
-	// traceID to be removed
-	traceRemoved
-
 	// shutdown
 	stop
 )
@@ -56,8 +50,6 @@ type eventMachine struct {
 
 	onTraceReceived func(pdata.Traces) error
 	onTraceExpired  func(pdata.TraceID) error
-	onTraceReleased func([]pdata.ResourceSpans) error
-	onTraceRemoved  func(pdata.TraceID) error
 
 	onError func(event)
 
@@ -108,32 +100,6 @@ func (em *eventMachine) start() {
 				continue
 			}
 			em.onTraceExpired(payload)
-		case traceReleased:
-			if em.onTraceReleased == nil {
-				em.logger.Debug("onTraceReleased not set, skipping event")
-				em.callOnError(e)
-				continue
-			}
-			payload, ok := e.payload.([]pdata.ResourceSpans)
-			if !ok {
-				// the payload had an unexpected type!
-				em.callOnError(e)
-				continue
-			}
-			em.onTraceReleased(payload)
-		case traceRemoved:
-			if em.onTraceRemoved == nil {
-				em.logger.Debug("onTraceRemoved not set, skipping event")
-				em.callOnError(e)
-				continue
-			}
-			payload, ok := e.payload.(pdata.TraceID)
-			if !ok {
-				// the payload had an unexpected type!
-				em.callOnError(e)
-				continue
-			}
-			em.onTraceRemoved(payload)
 		case stop:
 			em.logger.Info("shuttting down the event machine")
 			em.shutdownLock.Lock()

--- a/processor/groupbytraceprocessor/event.go
+++ b/processor/groupbytraceprocessor/event.go
@@ -85,7 +85,9 @@ func (em *eventMachine) start() {
 				em.callOnError(e)
 				continue
 			}
-			em.onTraceReceived(payload)
+			if err := em.onTraceReceived(payload); err != nil {
+				em.logger.Debug("onTraceReceived failed", zap.Error(err))
+			}
 		case traceExpired:
 			if em.onTraceExpired == nil {
 				em.logger.Debug("onTraceExpired not set, skipping event")
@@ -98,7 +100,9 @@ func (em *eventMachine) start() {
 				em.callOnError(e)
 				continue
 			}
-			em.onTraceExpired(payload)
+			if err := em.onTraceExpired(payload); err != nil {
+				em.logger.Debug("onTraceExpired failed", zap.Error(err))
+			}
 		case stop:
 			em.logger.Info("shutting down the event machine")
 			close(em.done)

--- a/processor/groupbytraceprocessor/event_test.go
+++ b/processor/groupbytraceprocessor/event_test.go
@@ -56,29 +56,6 @@ func TestEventCallback(t *testing.T) {
 				}
 			},
 		},
-		{
-			casename: "onTraceReleased",
-			typ:      traceReleased,
-			payload:  []pdata.ResourceSpans{},
-			registerCallback: func(em *eventMachine, wg *sync.WaitGroup) {
-				em.onTraceReleased = func(expired []pdata.ResourceSpans) error {
-					wg.Done()
-					return nil
-				}
-			},
-		},
-		{
-			casename: "onTraceRemoved",
-			typ:      traceRemoved,
-			payload:  pdata.NewTraceID([]byte{1, 2, 3, 4}),
-			registerCallback: func(em *eventMachine, wg *sync.WaitGroup) {
-				em.onTraceRemoved = func(expired pdata.TraceID) error {
-					wg.Done()
-					assert.Equal(t, pdata.NewTraceID([]byte{1, 2, 3, 4}), expired)
-					return nil
-				}
-			},
-		},
 	} {
 		t.Run(tt.casename, func(t *testing.T) {
 			// prepare
@@ -117,14 +94,6 @@ func TestEventCallbackNotSet(t *testing.T) {
 		{
 			casename: "onTraceExpired",
 			typ:      traceExpired,
-		},
-		{
-			casename: "onTraceReleased",
-			typ:      traceReleased,
-		},
-		{
-			casename: "onTraceRemoved",
-			typ:      traceRemoved,
 		},
 	} {
 		t.Run(tt.casename, func(t *testing.T) {
@@ -172,24 +141,6 @@ func TestEventInvalidPayload(t *testing.T) {
 			typ:      traceExpired,
 			registerCallback: func(em *eventMachine, wg *sync.WaitGroup) {
 				em.onTraceExpired = func(expired pdata.TraceID) error {
-					return nil
-				}
-			},
-		},
-		{
-			casename: "onTraceReleased",
-			typ:      traceReleased,
-			registerCallback: func(em *eventMachine, wg *sync.WaitGroup) {
-				em.onTraceReleased = func(expired []pdata.ResourceSpans) error {
-					return nil
-				}
-			},
-		},
-		{
-			casename: "onTraceRemoved",
-			typ:      traceRemoved,
-			registerCallback: func(em *eventMachine, wg *sync.WaitGroup) {
-				em.onTraceRemoved = func(expired pdata.TraceID) error {
 					return nil
 				}
 			},

--- a/processor/groupbytraceprocessor/processor.go
+++ b/processor/groupbytraceprocessor/processor.go
@@ -220,7 +220,7 @@ func (sp *groupByTraceProcessor) releaseTrace(traceId pdata.TraceID, rss []pdata
 	}
 
 	if err := sp.nextConsumer.ConsumeTraces(context.Background(), trace); err != nil {
-		sp.logger.Error("next processor failed to process trace", zap.Error(err))
+		sp.logger.Debug("next processor failed to process trace", zap.Error(err))
 	}
 }
 

--- a/processor/groupbytraceprocessor/processor.go
+++ b/processor/groupbytraceprocessor/processor.go
@@ -307,6 +307,6 @@ type tTimer interface {
 
 type groupbyTimer struct{}
 
-func (_ *groupbyTimer) AfterFunc(d time.Duration, f func()) {
+func (*groupbyTimer) AfterFunc(d time.Duration, f func()) {
 	time.AfterFunc(d, f)
 }

--- a/processor/groupbytraceprocessor/processor.go
+++ b/processor/groupbytraceprocessor/processor.go
@@ -302,11 +302,11 @@ func splitByTrace(rs pdata.ResourceSpans) []*singleTraceBatch {
 
 // tTimer interface allows easier testing of ticker related functionality used by groupbytraceprocessor
 type tTimer interface {
-	AfterFunc(d time.Duration, f func()) *time.Timer
+	AfterFunc(d time.Duration, f func())
 }
 
 type groupbyTimer struct{}
 
-func (_ *groupbyTimer) AfterFunc(d time.Duration, f func()) *time.Timer {
-	return time.AfterFunc(d, f)
+func (_ *groupbyTimer) AfterFunc(d time.Duration, f func()) {
+	time.AfterFunc(d, f)
 }

--- a/processor/groupbytraceprocessor/processor_test.go
+++ b/processor/groupbytraceprocessor/processor_test.go
@@ -237,7 +237,7 @@ func TestTraceDisappearedFromStorageBeforeReleasing(t *testing.T) {
 	require.NotNil(t, p)
 
 	// Create the channel with no buffer so that the test is deterministic
-	p.eventMachine.events = make(chan event, 0)
+	p.eventMachine.events = make(chan event)
 
 	traceID := otlpcommon.NewTraceID([]byte{1, 2, 3, 4})
 	batch := []*v1.ResourceSpans{{
@@ -282,7 +282,7 @@ func TestTraceErrorFromStorageWhileReleasing(t *testing.T) {
 	require.NotNil(t, p)
 
 	// Create the channel with no buffer so that the test is deterministic
-	p.eventMachine.events = make(chan event, 0)
+	p.eventMachine.events = make(chan event)
 
 	traceID := otlpcommon.NewTraceID([]byte{1, 2, 3, 4})
 	batch := []*v1.ResourceSpans{{

--- a/processor/groupbytraceprocessor/processor_test.go
+++ b/processor/groupbytraceprocessor/processor_test.go
@@ -808,11 +808,8 @@ func TestHighConcurrency(t *testing.T) {
 	// Wait until all calls to ConsumeTraces have completed
 	wg.Wait()
 
-	// This should be ~100ms but there seems to be a performance bottleneck, give it some extra time
-	<-time.After(2 * time.Second)
-
-	// It should be possible to use Shutdown without the sleep above, but this triggers another deadlock condition
-	//p.Shutdown(ctx)
+	// All events have been emitted, this will wait until they are all consumed
+	p.Shutdown(ctx)
 
 	receivedTraceBatches := next.AllTraces()
 	// ideally this would equal len(traceIds) but its not always the case b/c of timing races of the enqueue/dequeue

--- a/processor/groupbytraceprocessor/storage_memory.go
+++ b/processor/groupbytraceprocessor/storage_memory.go
@@ -44,6 +44,8 @@ func (st *memoryStorage) createOrAppend(traceID pdata.TraceID, rs pdata.Resource
 	sTraceID := traceID.HexString()
 
 	st.Lock()
+	defer st.Unlock()
+
 	if _, ok := st.content[sTraceID]; !ok {
 		st.content[sTraceID] = []pdata.ResourceSpans{}
 	}
@@ -52,14 +54,14 @@ func (st *memoryStorage) createOrAppend(traceID pdata.TraceID, rs pdata.Resource
 	rs.CopyTo(newRS)
 	st.content[sTraceID] = append(st.content[sTraceID], newRS)
 
-	st.Unlock()
-
 	return nil
 }
 func (st *memoryStorage) get(traceID pdata.TraceID) ([]pdata.ResourceSpans, error) {
 	sTraceID := traceID.HexString()
 
 	st.RLock()
+	defer st.RUnlock()
+
 	rss, ok := st.content[sTraceID]
 	if !ok {
 		return nil, nil
@@ -71,7 +73,6 @@ func (st *memoryStorage) get(traceID pdata.TraceID) ([]pdata.ResourceSpans, erro
 		rs.CopyTo(newRS)
 		result = append(result, newRS)
 	}
-	st.RUnlock()
 
 	return result, nil
 }
@@ -82,6 +83,8 @@ func (st *memoryStorage) delete(traceID pdata.TraceID) ([]pdata.ResourceSpans, e
 	sTraceID := traceID.HexString()
 
 	st.Lock()
+	defer st.Unlock()
+
 	rss := st.content[sTraceID]
 	result := []pdata.ResourceSpans{}
 	for _, rs := range rss {
@@ -90,7 +93,6 @@ func (st *memoryStorage) delete(traceID pdata.TraceID) ([]pdata.ResourceSpans, e
 		result = append(result, newRS)
 	}
 	delete(st.content, sTraceID)
-	st.Unlock()
 
 	return result, nil
 }


### PR DESCRIPTION
**Description:** 
Fixes https://github.com/open-telemetry/opentelemetry-collector/issues/1811

The deadlock in the groupbytrace processor was caused by the consumer goroutine (the one consuming from the event machine) trying to write data to the channel. This would work sometimes because of the channel buffer but deadlock once the buffer became full. I've refactored the design so that the event machine is much simpler and only has two events `traceReceived` and `traceExpired`. By doing this I've removed the cases where the reader would need to write events, removing the possibility of deadlocks. This also moved all modifications to the datastructures to happen under the consumer goroutine which fixes some other synchronization bugs with concurrent access to the storage becoming out of sync with the ringbuffer.

A second deadlock was discovered in the shutdown procedure where the channel and mutex locks could be obtained in the inverse order, leading to deadlock. I replaced the mutex with a channel and select which will avoid this. 


**Testing:** 
Added test cases


@jpkrohling 
