### PR TITLE
Correctness Tests: Extend Timeout for Item Count Check

### DIFF
--- a/testbed/correctness/traces/correctness_test.go
+++ b/testbed/correctness/traces/correctness_test.go
@@ -98,7 +98,7 @@ func testWithTracingGoldenDataset(
 	tc.StopLoad()
 
 	tc.WaitForN(func() bool { return tc.LoadGenerator.DataItemsSent() == tc.MockBackend.DataItemsReceived() },
-		duration, "all data items received")
+		duration*3, "all data items received")
 
 	tc.StopAgent()
 


### PR DESCRIPTION
This will hopefully fix #1671. The output of the failed tests indicates
that the received items eventually does equal the number of sent items
but several seconds after the condition timed out.