### PR TITLE
Queued Retry Helper: Fix Flaky Test

### DIFF
--- a/exporter/exporterhelper/queued_retry_test.go
+++ b/exporter/exporterhelper/queued_retry_test.go
@@ -385,7 +385,9 @@ func (m *mockRequest) onPartialError(consumererror.PartialError) request {
 }
 
 func (m *mockRequest) checkNumRequests(t *testing.T, want int) {
-	assert.EqualValues(t, want, atomic.LoadInt64(m.requestCount))
+	assert.Eventually(t, func() bool {
+		return int64(want) == atomic.LoadInt64(m.requestCount)
+	}, time.Second, 1*time.Millisecond)
 }
 
 func (m *mockRequest) count() int {


### PR DESCRIPTION
The mock send is asynchronous so there is no guarantee that the request
count will be 1 at the point when it is asserted to be so in the test.

This has lead to flaky tests so do an Eventually to repeatedly check it for
a full second to make the test more robust.

Should fix one of the issues in #1711.