### PR TITLE
Add receiverhelper functions for creating simple "scraper" metrics receiver

### DIFF
--- a/receiver/receiverhelper/receiver.go
+++ b/receiver/receiverhelper/receiver.go
@@ -1,0 +1,79 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package receiverhelper
+
+import (
+	"context"
+
+	"go.opentelemetry.io/collector/component"
+)
+
+// Start specifies the function invoked when the receiver is being started.
+type Start func(context.Context, component.Host) error
+
+// Shutdown specifies the function invoked when the receiver is being shutdown.
+type Shutdown func(context.Context) error
+
+// Option apply changes to internal options.
+type Option func(*baseReceiver)
+
+// WithStart overrides the default Start function for a receiver.
+// The default shutdown function does nothing and always returns nil.
+func WithStart(start Start) Option {
+	return func(o *baseReceiver) {
+		o.start = start
+	}
+}
+
+// WithShutdown overrides the default Shutdown function for a receiver.
+// The default shutdown function does nothing and always returns nil.
+func WithShutdown(shutdown Shutdown) Option {
+	return func(o *baseReceiver) {
+		o.shutdown = shutdown
+	}
+}
+
+type baseReceiver struct {
+	fullName string
+	start    Start
+	shutdown Shutdown
+}
+
+// Construct the internalOptions from multiple Option.
+func newBaseReceiver(fullName string, options ...Option) baseReceiver {
+	br := baseReceiver{fullName: fullName}
+
+	for _, op := range options {
+		op(&br)
+	}
+
+	return br
+}
+
+// Start the receiver, invoked during service start.
+func (br *baseReceiver) Start(ctx context.Context, host component.Host) error {
+	if br.start != nil {
+		return br.start(ctx, host)
+	}
+	return nil
+}
+
+// Shutdown the receiver, invoked during service shutdown.
+func (br *baseReceiver) Shutdown(ctx context.Context) error {
+	if br.shutdown != nil {
+		return br.shutdown(ctx)
+	}
+	return nil
+}

--- a/receiver/receiverhelper/receiver_test.go
+++ b/receiver/receiverhelper/receiver_test.go
@@ -1,0 +1,62 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package receiverhelper
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/componenttest"
+)
+
+const testFullName = "testFullName"
+
+func TestWithStart(t *testing.T) {
+	startCalled := false
+	start := func(context.Context, component.Host) error { startCalled = true; return nil }
+
+	bp := newBaseReceiver(testFullName, WithStart(start))
+	assert.NoError(t, bp.Start(context.Background(), componenttest.NewNopHost()))
+	assert.True(t, startCalled)
+}
+
+func TestWithStart_ReturnError(t *testing.T) {
+	want := errors.New("my_error")
+	start := func(context.Context, component.Host) error { return want }
+
+	bp := newBaseReceiver(testFullName, WithStart(start))
+	assert.Equal(t, want, bp.Start(context.Background(), componenttest.NewNopHost()))
+}
+
+func TestWithShutdown(t *testing.T) {
+	shutdownCalled := false
+	shutdown := func(context.Context) error { shutdownCalled = true; return nil }
+
+	bp := newBaseReceiver(testFullName, WithShutdown(shutdown))
+	assert.NoError(t, bp.Shutdown(context.Background()))
+	assert.True(t, shutdownCalled)
+}
+
+func TestWithShutdown_ReturnError(t *testing.T) {
+	want := errors.New("my_error")
+	shutdownErr := func(context.Context) error { return want }
+
+	bp := newBaseReceiver(testFullName, WithShutdown(shutdownErr))
+	assert.Equal(t, want, bp.Shutdown(context.Background()))
+}

--- a/receiver/receiverhelper/scraper.go
+++ b/receiver/receiverhelper/scraper.go
@@ -1,0 +1,154 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package receiverhelper
+
+import (
+	"context"
+	"time"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/componenterror"
+	"go.opentelemetry.io/collector/config/configmodels"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/consumer/pdata"
+)
+
+// Scraper provides a function to scrape metrics.
+type Scraper interface {
+	Scrape(context.Context) (pdata.Metrics, error)
+}
+
+// Scrape specifies the function that will be invoked every collection interval when
+// the receiver is configured as a Scraper.
+type Scrape func(context.Context) (pdata.Metrics, error)
+
+// ScraperConfig provides functions to get and set the collection interval.
+type ScraperConfig interface {
+	configmodels.Receiver
+
+	CollectionInterval() time.Duration
+	SetCollectionInterval(time.Duration)
+}
+
+// ScraperSettings defines common settings for scraper configuration.
+// Specific scrapers can embed this struct and extend it with more fields if needed.
+type ScraperSettings struct {
+	configmodels.ReceiverSettings `mapstructure:",squash"`
+	CollectionIntervalVal         time.Duration `mapstructure:"collection_interval"`
+}
+
+// CollectionInterval gets the scraper collection interval.
+func (ss *ScraperSettings) CollectionInterval() time.Duration {
+	return ss.CollectionIntervalVal
+}
+
+// SetCollectionInterval sets the scraper collection interval.
+func (ss *ScraperSettings) SetCollectionInterval(collectionInterval time.Duration) {
+	ss.CollectionIntervalVal = collectionInterval
+}
+
+// ScraperOption apply changes to internal scraper options.
+type ScraperOption func(*baseScraper)
+
+type baseScraper struct {
+	baseReceiver
+	collectionInterval time.Duration
+	scraper            Scraper
+	nextConsumer       consumer.MetricsConsumer
+	done               chan struct{}
+}
+
+// NewScraper creates a MetricsReceiver that calls Scrape at the specified collection
+// interval, reports observability information, and passes the scraped metrics to the
+// next consumer.
+func NewScraper(
+	config ScraperConfig,
+	scraper Scraper,
+	nextConsumer consumer.MetricsConsumer,
+	options ...Option,
+) (component.Receiver, error) {
+	if nextConsumer == nil {
+		return nil, componenterror.ErrNilNextConsumer
+	}
+
+	bs := &baseScraper{
+		baseReceiver:       newBaseReceiver(config.Name(), options...),
+		collectionInterval: config.CollectionInterval(),
+		scraper:            scraper,
+		nextConsumer:       nextConsumer,
+		done:               make(chan struct{}),
+	}
+
+	// wrap the start function with a call to start scraping
+	start := bs.start
+	bs.start = func(ctx context.Context, host component.Host) error {
+		if start != nil {
+			if err := start(ctx, host); err != nil {
+				return err
+			}
+		}
+
+		bs.startScraping()
+		return nil
+	}
+
+	// wrap the shutdown function with a call to stop scraping
+	shutdown := bs.shutdown
+	bs.shutdown = func(ctx context.Context) error {
+		bs.stopScraping()
+
+		if shutdown != nil {
+			shutdown(ctx)
+		}
+		return nil
+	}
+
+	return bs, nil
+}
+
+// startScraping initiates a ticker that calls Scrape based on the configured
+// collection interval.
+func (bs *baseScraper) startScraping() {
+	go func() {
+		ticker := time.NewTicker(bs.collectionInterval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ticker.C:
+				bs.scrapeAndReport(context.Background())
+			case <-bs.done:
+				return
+			}
+		}
+	}()
+}
+
+// scrapeAndReport calls the Scrape function of the provided Scraper, records
+// observability information, and passes the scraped metrics to the next component.
+// TODO: Add observability metrics support
+func (bs *baseScraper) scrapeAndReport(ctx context.Context) {
+	metrics, err := bs.scraper.Scrape(ctx)
+	if err != nil {
+		return
+	}
+
+	bs.nextConsumer.ConsumeMetrics(ctx, metrics)
+}
+
+// stopScraping stops the ticker
+func (bs *baseScraper) stopScraping() {
+	close(bs.done)
+}

--- a/receiver/receiverhelper/scraper_test.go
+++ b/receiver/receiverhelper/scraper_test.go
@@ -1,0 +1,93 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package receiverhelper
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/componenterror"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/config/configmodels"
+	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.opentelemetry.io/collector/exporter/exportertest"
+)
+
+var testCfg = &ScraperSettings{
+	ReceiverSettings: configmodels.ReceiverSettings{
+		TypeVal: testFullName,
+		NameVal: testFullName,
+	},
+	CollectionIntervalVal: time.Microsecond,
+}
+
+func TestNewScraper(t *testing.T) {
+	var startCalled, shutdownCalled bool
+	start := func(context.Context, component.Host) error { startCalled = true; return nil }
+	shutdown := func(context.Context) error { shutdownCalled = true; return nil }
+
+	ch := make(chan int, 10)
+
+	ts, err := NewScraper(testCfg, &testScraper{ch: ch}, exportertest.NewNopMetricsExporter(), WithStart(start), WithShutdown(shutdown))
+	require.NoError(t, err)
+
+	assert.NoError(t, ts.Start(context.Background(), componenttest.NewNopHost()))
+	assert.True(t, startCalled)
+
+	require.Eventually(t, func() bool { return (<-ch) > 5 }, 100*time.Millisecond, time.Millisecond)
+
+	assert.NoError(t, ts.Shutdown(context.Background()))
+	assert.True(t, shutdownCalled)
+}
+
+type testScraper struct {
+	ch                chan int
+	timesScrapeCalled int
+}
+
+func (ts *testScraper) Scrape(ctx context.Context) (pdata.Metrics, error) {
+	ts.timesScrapeCalled++
+	ts.ch <- ts.timesScrapeCalled
+	return pdata.NewMetrics(), nil
+}
+
+func TestNewScraper_ScrapeError(t *testing.T) {
+	want := errors.New("my_error")
+	ts, err := NewScraper(testCfg, &testScraperError{err: want}, exportertest.NewNopMetricsExporter())
+	require.NoError(t, err)
+
+	assert.NoError(t, ts.Start(context.Background(), componenttest.NewNopHost()))
+	// TODO validate observability data populated correctly
+	assert.NoError(t, ts.Shutdown(context.Background()))
+}
+
+type testScraperError struct {
+	err error
+}
+
+func (ts *testScraperError) Scrape(ctx context.Context) (pdata.Metrics, error) {
+	return pdata.NewMetrics(), ts.err
+}
+
+func TestNewScraper_Error(t *testing.T) {
+	_, err := NewScraper(testCfg, nil, nil)
+	assert.Equal(t, componenterror.ErrNilNextConsumer, err)
+}


### PR DESCRIPTION
Added `receiverhelper` functions following a similar pattern to the other component helpers. Also added `scraper` functions to make it easy to construct a simple receiver that scrapes metrics at a configured frequency.

I've currently only only implemented basic functionality, and only implemented this for Metrics as I don't believe the "scrape" model applies to Traces or Logs.

Resolves https://github.com/open-telemetry/opentelemetry-collector/issues/934