### PR TITLE
Bump memory requirements for TestMetric10kDPS/OpenCensus  to avoid sporadic failures

### DIFF
--- a/testbed/tests/metric_test.go
+++ b/testbed/tests/metric_test.go
@@ -58,7 +58,7 @@ func TestMetric10kDPS(t *testing.T) {
 			testbed.NewOCDataReceiver(testbed.GetAvailablePort(t)),
 			testbed.ResourceSpec{
 				ExpectedMaxCPU: 85,
-				ExpectedMaxRAM: 60,
+				ExpectedMaxRAM: 75,
 			},
 		},
 		{


### PR DESCRIPTION
See https://app.circleci.com/pipelines/github/open-telemetry/opentelemetry-collector/3751/workflows/00409594-d070-4f95-addb-928c6438426b/jobs/40533
