### PR TITLE
Enable otlp trace by default in the released docker image

### DIFF
--- a/cmd/otelcol/config.yaml
+++ b/cmd/otelcol/config.yaml
@@ -43,7 +43,7 @@ service:
   pipelines:
 
     traces:
-      receivers: [opencensus, jaeger, zipkin]
+      receivers: [otlp, opencensus, jaeger, zipkin]
       processors: [batch]
       exporters: [logging]
 


### PR DESCRIPTION
Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>