### PR TITLE
Update filter processor to use pdata

### DIFF
--- a/internal/processor/filtermetric/filtermetric.go
+++ b/internal/processor/filtermetric/filtermetric.go
@@ -15,21 +15,13 @@
 package filtermetric
 
 import (
-	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
-
+	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/internal/processor/filterset"
 )
 
 // Matcher matches metrics by metric properties against prespecified values for each property.
 type Matcher struct {
 	nameFilters filterset.FilterSet
-}
-
-// MatchMetric matches a metric using the metric properties configured on the Matcher.
-// A metric only matches if every metric property configured on the Matcher is a match.
-func (m *Matcher) MatchMetric(metric *metricspb.Metric) bool {
-	name := metric.GetMetricDescriptor().GetName()
-	return m.nameFilters.Matches(name)
 }
 
 // NewMatcher constructs a metric Matcher that can be used to match metrics by metric properties.
@@ -48,4 +40,10 @@ func NewMatcher(config *MatchProperties) (Matcher, error) {
 	return Matcher{
 		nameFilters: nameFS,
 	}, nil
+}
+
+// MatchMetric matches a metric using the metric properties configured on the Matcher.
+// A metric only matches if every metric property configured on the Matcher is a match.
+func (m *Matcher) MatchMetric(metric pdata.Metric) bool {
+	return m.nameFilters.Matches(metric.Name())
 }

--- a/internal/processor/filtermetric/filtermetric_test.go
+++ b/internal/processor/filtermetric/filtermetric_test.go
@@ -17,9 +17,9 @@ package filtermetric
 import (
 	"testing"
 
-	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
 	"github.com/stretchr/testify/assert"
 
+	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/internal/processor/filterset"
 )
 
@@ -42,19 +42,18 @@ var (
 	}
 )
 
-func createMetric(name string) *metricspb.Metric {
-	return &metricspb.Metric{
-		MetricDescriptor: &metricspb.MetricDescriptor{
-			Name: name,
-		},
-	}
+func createMetric(name string) pdata.Metric {
+	metric := pdata.NewMetric()
+	metric.InitEmpty()
+	metric.SetName(name)
+	return metric
 }
 
 func TestMatcherMatches(t *testing.T) {
 	tests := []struct {
 		name        string
 		cfg         *MatchProperties
-		metric      *metricspb.Metric
+		metric      pdata.Metric
 		shouldMatch bool
 	}{
 		{

--- a/processor/filterprocessor/filter_processor.go
+++ b/processor/filterprocessor/filter_processor.go
@@ -66,12 +66,21 @@ func (fmp *filterMetricProcessor) ProcessMetrics(_ context.Context, pdm pdata.Me
 	idx := newMetricIndex()
 	for i := 0; i < rms.Len(); i++ {
 		rm := rms.At(i)
+		if rm.IsNil() {
+			continue
+		}
 		ilms := rm.InstrumentationLibraryMetrics()
 		for j := 0; j < ilms.Len(); j++ {
 			ilm := ilms.At(j)
+			if ilm.IsNil() {
+				continue
+			}
 			ms := ilm.Metrics()
 			for k := 0; k < ms.Len(); k++ {
 				metric := ms.At(k)
+				if metric.IsNil() {
+					continue
+				}
 				if fmp.shouldKeepMetric(metric) {
 					idx.add(i, j, k)
 				}

--- a/processor/filterprocessor/filter_processor.go
+++ b/processor/filterprocessor/filter_processor.go
@@ -17,12 +17,9 @@ package filterprocessor
 import (
 	"context"
 
-	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
-
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/internal/processor/filtermetric"
 	"go.opentelemetry.io/collector/processor/processorhelper"
-	"go.opentelemetry.io/collector/translator/internaldata"
 )
 
 type filterMetricProcessor struct {
@@ -65,30 +62,32 @@ func createMatcher(mp *filtermetric.MatchProperties) (*filtermetric.Matcher, err
 
 // ProcessMetrics filters the given metrics based off the filterMetricProcessor's filters.
 func (fmp *filterMetricProcessor) ProcessMetrics(_ context.Context, md pdata.Metrics) (pdata.Metrics, error) {
-	mds := internaldata.MetricsToOC(md)
+	rms := md.ResourceMetrics()
 	foundMetricToKeep := false
-	for i := range mds {
-		if len(mds[i].Metrics) == 0 {
-			continue
-		}
-		keep := make([]*metricspb.Metric, 0, len(mds[i].Metrics))
-		for _, m := range mds[i].Metrics {
-			if fmp.shouldKeepMetric(m) {
-				foundMetricToKeep = true
-				keep = append(keep, m)
+	for i := 0; i < rms.Len(); i++ {
+		rm := rms.At(i)
+		ilms := rm.InstrumentationLibraryMetrics()
+		for j := 0; j < ilms.Len(); j++ {
+			ilm := ilms.At(j)
+			ms := ilm.Metrics()
+			filteredMetrics := pdata.NewMetricSlice()
+			for k := 0; k < ms.Len(); k++ {
+				metric := ms.At(k)
+				if fmp.shouldKeepMetric(metric) {
+					foundMetricToKeep = true
+					filteredMetrics.Append(metric)
+				}
 			}
+			filteredMetrics.CopyTo(ilm.Metrics())
 		}
-		mds[i].Metrics = keep
 	}
-
 	if !foundMetricToKeep {
 		return md, processorhelper.ErrSkipProcessingData
 	}
-	return internaldata.OCSliceToMetrics(mds), nil
+	return md, nil
 }
 
-// shouldKeepMetric determines whether a metric should be kept based off the filterMetricProcessor's filters.
-func (fmp *filterMetricProcessor) shouldKeepMetric(metric *metricspb.Metric) bool {
+func (fmp *filterMetricProcessor) shouldKeepMetric(metric pdata.Metric) bool {
 	if fmp.include != nil {
 		if !fmp.include.MatchMetric(metric) {
 			return false

--- a/processor/filterprocessor/filter_processor_test.go
+++ b/processor/filterprocessor/filter_processor_test.go
@@ -319,3 +319,26 @@ func pdm(prefix string, size int) pdata.Metrics {
 	}
 	return goldendataset.MetricDataFromCfg(c)
 }
+
+func TestMetricIndexSingle(t *testing.T) {
+	metrics := pdm("", 1)
+	idx := newMetricIndex()
+	idx.add(0, 0, 0)
+	extracted := idx.extract(metrics)
+	require.Equal(t, metrics, extracted)
+}
+
+func TestMetricIndexAll(t *testing.T) {
+	metrics := pdm("", 2)
+	idx := newMetricIndex()
+	idx.add(0, 0, 0)
+	idx.add(0, 0, 1)
+	idx.add(0, 1, 0)
+	idx.add(0, 1, 1)
+	idx.add(1, 0, 0)
+	idx.add(1, 0, 1)
+	idx.add(1, 1, 0)
+	idx.add(1, 1, 1)
+	extracted := idx.extract(metrics)
+	require.Equal(t, metrics, extracted)
+}

--- a/processor/filterprocessor/metric_index.go
+++ b/processor/filterprocessor/metric_index.go
@@ -23,7 +23,10 @@ import (
 // metricIndex holds paths to metrics in a pdata.Metrics struct via the indexes
 // ResourceMetrics -> InstrumentationLibraryMetrics -> Metrics. Once these
 // indexes are populated, you can extract a pdata.Metrics from an existing
-// pdata.Metrics with just the metrics at the specified paths.
+// pdata.Metrics with just the metrics at the specified paths. The motivation
+// for this type is to allow the output of filtered metrics to not contain
+// parent structs (InstrumentationLibrary, Resource, etc.) for a MetricSlice
+// that has become empty after filtering.
 type metricIndex struct {
 	m map[int]map[int]map[int]bool
 }

--- a/processor/filterprocessor/metric_index.go
+++ b/processor/filterprocessor/metric_index.go
@@ -1,0 +1,120 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filterprocessor
+
+import (
+	"sort"
+
+	"go.opentelemetry.io/collector/consumer/pdata"
+)
+
+// metricIndex holds paths to metrics in a pdata.Metrics struct via the indexes
+// ResourceMetrics -> InstrumentationLibraryMetrics -> Metrics. Once these
+// indexes are populated, you can extract a pdata.Metrics from an existing
+// pdata.Metrics with just the metrics at the specified paths.
+type metricIndex struct {
+	m map[int]map[int]map[int]bool
+}
+
+func newMetricIndex() *metricIndex {
+	return &metricIndex{m: map[int]map[int]map[int]bool{}}
+}
+
+func (idx metricIndex) add(rmIdx, ilmIdx, mIdx int) {
+	rmMap, ok := idx.m[rmIdx]
+	if !ok {
+		rmMap = map[int]map[int]bool{}
+		idx.m[rmIdx] = rmMap
+	}
+	ilmMap, ok := rmMap[ilmIdx]
+	if !ok {
+		ilmMap = map[int]bool{}
+		rmMap[ilmIdx] = ilmMap
+	}
+	ilmMap[mIdx] = true
+}
+
+func (idx metricIndex) extract(pdm pdata.Metrics) pdata.Metrics {
+	rmsIn := pdm.ResourceMetrics()
+	out := pdata.NewMetrics()
+	rmSliceOut := out.ResourceMetrics()
+	for _, rmIdx := range sortRM(idx.m) {
+		rmIn := rmsIn.At(rmIdx)
+		ilmSliceIn := rmIn.InstrumentationLibraryMetrics()
+
+		rmOut := pdata.NewResourceMetrics()
+		rmOut.InitEmpty()
+		rmSliceOut.Append(rmOut)
+		resourceOut := rmOut.Resource()
+		resourceOut.InitEmpty()
+		rmIn.Resource().CopyTo(resourceOut)
+		ilmSliceOut := rmOut.InstrumentationLibraryMetrics()
+		ilmIndexes := idx.m[rmIdx]
+		for _, ilmIdx := range sortILM(ilmIndexes) {
+			ilmIn := ilmSliceIn.At(ilmIdx)
+			mSliceIn := ilmIn.Metrics()
+
+			ilmOut := pdata.NewInstrumentationLibraryMetrics()
+			ilmOut.InitEmpty()
+			ilmSliceOut.Append(ilmOut)
+			ilOut := ilmOut.InstrumentationLibrary()
+			ilOut.InitEmpty()
+			ilmIn.InstrumentationLibrary().CopyTo(ilOut)
+			mSliceOut := ilmOut.Metrics()
+			for _, metricIdx := range sortMetrics(ilmIndexes[ilmIdx]) {
+				metric := mSliceIn.At(metricIdx)
+				mSliceOut.Append(metric)
+			}
+		}
+	}
+	return out
+}
+
+func sortRM(rmIndexes map[int]map[int]map[int]bool) []int {
+	var rmSorted = make([]int, len(rmIndexes))
+	i := 0
+	for key := range rmIndexes {
+		rmSorted[i] = key
+		i++
+	}
+	sort.Ints(rmSorted)
+	return rmSorted
+}
+
+func sortILM(ilmIndexes map[int]map[int]bool) []int {
+	var ilmSorted = make([]int, len(ilmIndexes))
+	i := 0
+	for key := range ilmIndexes {
+		ilmSorted[i] = key
+		i++
+	}
+	sort.Ints(ilmSorted)
+	return ilmSorted
+}
+
+func sortMetrics(metricIndexes map[int]bool) []int {
+	var metricIdxSorted = make([]int, len(metricIndexes))
+	i := 0
+	for key := range metricIndexes {
+		metricIdxSorted[i] = key
+		i++
+	}
+	sort.Ints(metricIdxSorted)
+	return metricIdxSorted
+}
+
+func (idx metricIndex) isEmpty() bool {
+	return len(idx.m) == 0
+}


### PR DESCRIPTION
Updated filter processor to use pdata rather than OC. There's still some OC stuff in filter_processor_test.go, but am hoping that can be updated in a separate change.

Also replaced a benchmark test with a new one. (The previous benchmark test failed with a nil pointer.) The new benchmark test has the following results: 

4233112 ns/op before this change
837378 ns/op after this change
