### PR TITLE
zipkin receiver: allow receiver to parse string tags

### DIFF
--- a/receiver/kafkareceiver/zipkin_unmarshaller.go
+++ b/receiver/kafkareceiver/zipkin_unmarshaller.go
@@ -36,7 +36,7 @@ func (z zipkinProtoSpanUnmarshaller) Unmarshal(bytes []byte) (pdata.Traces, erro
 	if err != nil {
 		return pdata.NewTraces(), err
 	}
-	return zipkintranslator.V2SpansToInternalTraces(parseSpans)
+	return zipkintranslator.V2SpansToInternalTraces(parseSpans, false)
 }
 
 func (z zipkinProtoSpanUnmarshaller) Encoding() string {
@@ -53,7 +53,7 @@ func (z zipkinJSONSpanUnmarshaller) Unmarshal(bytes []byte) (pdata.Traces, error
 	if err := json.Unmarshal(bytes, &spans); err != nil {
 		return pdata.NewTraces(), err
 	}
-	return zipkintranslator.V2SpansToInternalTraces(spans)
+	return zipkintranslator.V2SpansToInternalTraces(spans, false)
 }
 
 func (z zipkinJSONSpanUnmarshaller) Encoding() string {

--- a/receiver/zipkinreceiver/config.go
+++ b/receiver/zipkinreceiver/config.go
@@ -25,4 +25,6 @@ type Config struct {
 
 	// Configures the receiver server protocol.
 	confighttp.HTTPServerSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
+
+	ParseStringTags bool `mapstructure:"parse_string_tags"`
 }

--- a/receiver/zipkinreceiver/config.go
+++ b/receiver/zipkinreceiver/config.go
@@ -26,5 +26,7 @@ type Config struct {
 	// Configures the receiver server protocol.
 	confighttp.HTTPServerSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
 
+	// If enabled the zipkin receiver will attempt to parse string tags/binary annotations into int/bool/float.
+	// Disabled by default
 	ParseStringTags bool `mapstructure:"parse_string_tags"`
 }

--- a/receiver/zipkinreceiver/config_test.go
+++ b/receiver/zipkinreceiver/config_test.go
@@ -38,7 +38,7 @@ func TestLoadConfig(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, cfg)
 
-	assert.Equal(t, len(cfg.Receivers), 2)
+	assert.Equal(t, len(cfg.Receivers), 3)
 
 	r0 := cfg.Receivers["zipkin"]
 	assert.Equal(t, r0, factory.CreateDefaultConfig())
@@ -53,5 +53,18 @@ func TestLoadConfig(t *testing.T) {
 			HTTPServerSettings: confighttp.HTTPServerSettings{
 				Endpoint: "localhost:8765",
 			},
+		})
+
+	r2 := cfg.Receivers["zipkin/parse_strings"].(*Config)
+	assert.Equal(t, r2,
+		&Config{
+			ReceiverSettings: configmodels.ReceiverSettings{
+				TypeVal: typeStr,
+				NameVal: "zipkin/parse_strings",
+			},
+			HTTPServerSettings: confighttp.HTTPServerSettings{
+				Endpoint: "0.0.0.0:9411",
+			},
+			ParseStringTags: true,
 		})
 }

--- a/receiver/zipkinreceiver/factory.go
+++ b/receiver/zipkinreceiver/factory.go
@@ -52,6 +52,7 @@ func createDefaultConfig() configmodels.Receiver {
 		HTTPServerSettings: confighttp.HTTPServerSettings{
 			Endpoint: defaultBindEndpoint,
 		},
+		ParseStringTags: false,
 	}
 }
 

--- a/receiver/zipkinreceiver/proto_parse_test.go
+++ b/receiver/zipkinreceiver/proto_parse_test.go
@@ -101,6 +101,7 @@ func TestConvertSpansToTraceSpans_protobuf(t *testing.T) {
 	protoBlob, err := proto.Marshal(payloadFromWild)
 	require.NoError(t, err, "Failed to protobuf serialize payload: %v", err)
 	zi := new(ZipkinReceiver)
+	zi.config = createDefaultConfig().(*Config)
 	hdr := make(http.Header)
 	hdr.Set("Content-Type", "application/x-protobuf")
 

--- a/receiver/zipkinreceiver/testdata/config.yaml
+++ b/receiver/zipkinreceiver/testdata/config.yaml
@@ -2,6 +2,8 @@ receivers:
   zipkin:
   zipkin/customname:
     endpoint: "localhost:8765"
+  zipkin/parse_strings:
+    parse_string_tags: true
 
 processors:
   exampleprocessor:

--- a/receiver/zipkinreceiver/trace_receiver.go
+++ b/receiver/zipkinreceiver/trace_receiver.go
@@ -124,7 +124,7 @@ func (zr *ZipkinReceiver) v1ToTraceSpans(blob []byte, hdr http.Header) (reqs pda
 
 		return zipkin.V1ThriftBatchToInternalTraces(zSpans)
 	}
-	return zipkin.V1JSONBatchToInternalTraces(blob)
+	return zipkin.V1JSONBatchToInternalTraces(blob, zr.config.ParseStringTags)
 }
 
 // deserializeThrift decodes Thrift bytes to a list of spans.

--- a/receiver/zipkinreceiver/trace_receiver.go
+++ b/receiver/zipkinreceiver/trace_receiver.go
@@ -177,7 +177,7 @@ func (zr *ZipkinReceiver) v2ToTraceSpans(blob []byte, hdr http.Header) (reqs pda
 		return pdata.Traces{}, err
 	}
 
-	return zipkin.V2SpansToInternalTraces(zipkinSpans)
+	return zipkin.V2SpansToInternalTraces(zipkinSpans, zr.config.ParseStringTags)
 }
 
 func (zr *ZipkinReceiver) deserializeFromJSON(jsonBlob []byte, debugWasSet bool) (zs []*zipkinmodel.SpanModel, err error) {

--- a/translator/trace/zipkin/status_code_test.go
+++ b/translator/trace/zipkin/status_code_test.go
@@ -270,7 +270,7 @@ func attributesFromMap(mapValues map[string]string) map[string]*tracepb.Attribut
 	res := map[string]*tracepb.AttributeValue{}
 
 	for k, v := range mapValues {
-		pbAttrib := parseAnnotationValue(v)
+		pbAttrib := parseAnnotationValue(v, false)
 		res[k] = pbAttrib
 	}
 	return res

--- a/translator/trace/zipkin/testdata/zipkin_v1_multiple_batches.json
+++ b/translator/trace/zipkin/testdata/zipkin_v1_multiple_batches.json
@@ -132,6 +132,10 @@
                 {
                     "key": "success",
                     "value": "true"
+                },
+                {
+                  "key": "processed",
+                  "value": "1.5"
                 }
             ]
         }

--- a/translator/trace/zipkin/testdata/zipkin_v1_single_batch.json
+++ b/translator/trace/zipkin/testdata/zipkin_v1_single_batch.json
@@ -125,6 +125,10 @@
             {
                 "key": "success",
                 "value": "true"
+            },
+            {
+              "key": "processed",
+              "value": "1.5"
             }
         ]
     },

--- a/translator/trace/zipkin/testdata/zipkin_v1_thrift_single_batch.json
+++ b/translator/trace/zipkin/testdata/zipkin_v1_thrift_single_batch.json
@@ -128,6 +128,11 @@
                 "key": "success",
                 "annotation_type": "BOOL",
                 "value": "AQ=="
+            },
+            {
+              "key": "processed",
+              "annotation_type": "DOUBLE",
+              "value": "P/gAAAAAAAA="
             }
         ]
     },

--- a/translator/trace/zipkin/traces_to_zipkinv2_test.go
+++ b/translator/trace/zipkin/traces_to_zipkinv2_test.go
@@ -111,7 +111,7 @@ func TestInternalTracesToZipkinSpansAndBack(t *testing.T) {
 		zipkinSpans, err := InternalTracesToZipkinSpans(td)
 		assert.NoError(t, err)
 		assert.Equal(t, td.SpanCount(), len(zipkinSpans))
-		tdFromZS, zErr := V2SpansToInternalTraces(zipkinSpans)
+		tdFromZS, zErr := V2SpansToInternalTraces(zipkinSpans, false)
 		assert.NoError(t, zErr, zipkinSpans)
 		assert.NotNil(t, tdFromZS)
 		assert.Equal(t, td.SpanCount(), tdFromZS.SpanCount())

--- a/translator/trace/zipkin/zipkinv1_to_protospan.go
+++ b/translator/trace/zipkin/zipkinv1_to_protospan.go
@@ -86,7 +86,7 @@ type binaryAnnotation struct {
 }
 
 // v1JSONBatchToOCProto converts a JSON blob with a list of Zipkin v1 spans to OC Proto.
-func v1JSONBatchToOCProto(blob []byte) ([]consumerdata.TraceData, error) {
+func v1JSONBatchToOCProto(blob []byte, parseStringTags bool) ([]consumerdata.TraceData, error) {
 	var zSpans []*zipkinV1Span
 	if err := json.Unmarshal(blob, &zSpans); err != nil {
 		return nil, fmt.Errorf("%s: %w", msgZipkinV1JSONUnmarshalError, err)
@@ -94,7 +94,7 @@ func v1JSONBatchToOCProto(blob []byte) ([]consumerdata.TraceData, error) {
 
 	ocSpansAndParsedAnnotations := make([]ocSpanAndParsedAnnotations, 0, len(zSpans))
 	for _, zSpan := range zSpans {
-		ocSpan, parsedAnnotations, err := zipkinV1ToOCSpan(zSpan)
+		ocSpan, parsedAnnotations, err := zipkinV1ToOCSpan(zSpan, parseStringTags)
 		if err != nil {
 			// error from internal package function, it already wraps the error to give better context.
 			return nil, err
@@ -128,7 +128,7 @@ func zipkinToOCProtoBatch(ocSpansAndParsedAnnotations []ocSpanAndParsedAnnotatio
 	return tds, nil
 }
 
-func zipkinV1ToOCSpan(zSpan *zipkinV1Span) (*tracepb.Span, *annotationParseResult, error) {
+func zipkinV1ToOCSpan(zSpan *zipkinV1Span, parseStringTags bool) (*tracepb.Span, *annotationParseResult, error) {
 	traceID, err := hexTraceIDToOCTraceID(zSpan.TraceID)
 	if err != nil {
 		return nil, nil, fmt.Errorf("%s: %w", msgZipkinV1TraceIDError, err)
@@ -147,7 +147,7 @@ func zipkinV1ToOCSpan(zSpan *zipkinV1Span) (*tracepb.Span, *annotationParseResul
 	}
 
 	parsedAnnotations := parseZipkinV1Annotations(zSpan.Annotations)
-	attributes, ocStatus, localComponent := zipkinV1BinAnnotationsToOCAttributes(zSpan.BinaryAnnotations)
+	attributes, ocStatus, localComponent := zipkinV1BinAnnotationsToOCAttributes(zSpan.BinaryAnnotations, parseStringTags)
 	if parsedAnnotations.Endpoint.ServiceName == unknownServiceName && localComponent != "" {
 		parsedAnnotations.Endpoint.ServiceName = localComponent
 	}
@@ -202,7 +202,7 @@ func setSpanKind(ocSpan *tracepb.Span, kind tracepb.Span_SpanKind, extendedKind 
 	}
 }
 
-func zipkinV1BinAnnotationsToOCAttributes(binAnnotations []*binaryAnnotation) (attributes *tracepb.Span_Attributes, status *tracepb.Status, fallbackServiceName string) {
+func zipkinV1BinAnnotationsToOCAttributes(binAnnotations []*binaryAnnotation, parseStringTags bool) (attributes *tracepb.Span_Attributes, status *tracepb.Status, fallbackServiceName string) {
 	if len(binAnnotations) == 0 {
 		return nil, nil, ""
 	}
@@ -216,7 +216,7 @@ func zipkinV1BinAnnotationsToOCAttributes(binAnnotations []*binaryAnnotation) (a
 			fallbackServiceName = binAnnotation.Endpoint.ServiceName
 		}
 
-		pbAttrib := parseAnnotationValue(binAnnotation.Value)
+		pbAttrib := parseAnnotationValue(binAnnotation.Value, parseStringTags)
 
 		key := binAnnotation.Key
 
@@ -250,20 +250,24 @@ func zipkinV1BinAnnotationsToOCAttributes(binAnnotations []*binaryAnnotation) (a
 	return attributes, status, fallbackServiceName
 }
 
-func parseAnnotationValue(value string) *tracepb.AttributeValue {
+func parseAnnotationValue(value string, parseStringTags bool) *tracepb.AttributeValue {
 	pbAttrib := &tracepb.AttributeValue{}
 
-	switch tracetranslator.DetermineValueType(value, false) {
-	case pdata.AttributeValueINT:
-		iValue, _ := strconv.ParseInt(value, 10, 64)
-		pbAttrib.Value = &tracepb.AttributeValue_IntValue{IntValue: iValue}
-	case pdata.AttributeValueDOUBLE:
-		fValue, _ := strconv.ParseFloat(value, 64)
-		pbAttrib.Value = &tracepb.AttributeValue_DoubleValue{DoubleValue: fValue}
-	case pdata.AttributeValueBOOL:
-		bValue, _ := strconv.ParseBool(value)
-		pbAttrib.Value = &tracepb.AttributeValue_BoolValue{BoolValue: bValue}
-	default:
+	if parseStringTags {
+		switch tracetranslator.DetermineValueType(value, false) {
+		case pdata.AttributeValueINT:
+			iValue, _ := strconv.ParseInt(value, 10, 64)
+			pbAttrib.Value = &tracepb.AttributeValue_IntValue{IntValue: iValue}
+		case pdata.AttributeValueDOUBLE:
+			fValue, _ := strconv.ParseFloat(value, 64)
+			pbAttrib.Value = &tracepb.AttributeValue_DoubleValue{DoubleValue: fValue}
+		case pdata.AttributeValueBOOL:
+			bValue, _ := strconv.ParseBool(value)
+			pbAttrib.Value = &tracepb.AttributeValue_BoolValue{BoolValue: bValue}
+		default:
+			pbAttrib.Value = &tracepb.AttributeValue_StringValue{StringValue: &tracepb.TruncatableString{Value: value}}
+		}
+	} else {
 		pbAttrib.Value = &tracepb.AttributeValue_StringValue{StringValue: &tracepb.TruncatableString{Value: value}}
 	}
 

--- a/translator/trace/zipkin/zipkinv1_to_protospan_test.go
+++ b/translator/trace/zipkin/zipkinv1_to_protospan_test.go
@@ -667,6 +667,9 @@ var ocBatchesFromZipkinV1 = []consumerdata.TraceData{
 						"success": {
 							Value: &tracepb.AttributeValue_BoolValue{BoolValue: true},
 						},
+						"processed": {
+							Value: &tracepb.AttributeValue_DoubleValue{DoubleValue: 1.5},
+						},
 					},
 				},
 				TimeEvents: nil,

--- a/translator/trace/zipkin/zipkinv1_to_protospan_test.go
+++ b/translator/trace/zipkin/zipkinv1_to_protospan_test.go
@@ -133,7 +133,7 @@ func TestZipkinJSONFallbackToLocalComponent(t *testing.T) {
 	blob, err := ioutil.ReadFile("./testdata/zipkin_v1_local_component.json")
 	require.NoError(t, err, "Failed to load test data")
 
-	reqs, err := v1JSONBatchToOCProto(blob)
+	reqs, err := v1JSONBatchToOCProto(blob, false)
 	require.NoError(t, err, "Failed to translate zipkinv1 to OC proto")
 	require.Equal(t, 2, len(reqs), "Invalid trace service requests count")
 
@@ -155,7 +155,8 @@ func TestSingleJSONV1BatchToOCProto(t *testing.T) {
 	blob, err := ioutil.ReadFile("./testdata/zipkin_v1_single_batch.json")
 	require.NoError(t, err, "Failed to load test data")
 
-	got, err := v1JSONBatchToOCProto(blob)
+	parseStringTags := true // This test relies on parsing int/bool to the typed span attributes
+	got, err := v1JSONBatchToOCProto(blob, parseStringTags)
 	require.NoError(t, err, "Failed to translate zipkinv1 to OC proto")
 
 	want := ocBatchesFromZipkinV1
@@ -179,7 +180,8 @@ func TestMultipleJSONV1BatchesToOCProto(t *testing.T) {
 		jsonBatch, err := json.Marshal(batch)
 		require.NoError(t, err, "Failed to marshal interface back to blob")
 
-		g, err := v1JSONBatchToOCProto(jsonBatch)
+		parseStringTags := true // This test relies on parsing int/bool to the typed span attributes
+		g, err := v1JSONBatchToOCProto(jsonBatch, parseStringTags)
 		require.NoError(t, err, "Failed to translate zipkinv1 to OC proto")
 
 		// Coalesce the nodes otherwise they will differ due to multiple
@@ -490,7 +492,9 @@ func TestZipkinAnnotationsToOCStatus(t *testing.T) {
 				t.Errorf("#%d: Unexpected error: %v", i, err)
 				return
 			}
-			gb, err := v1JSONBatchToOCProto(zBytes)
+
+			parseStringTags := true // This test relies on parsing int/bool to the typed span attributes
+			gb, err := v1JSONBatchToOCProto(zBytes, parseStringTags)
 			if err != nil {
 				t.Errorf("#%d: Unexpected error: %v", i, err)
 				return
@@ -520,7 +524,7 @@ func TestSpanWithoutTimestampGetsTag(t *testing.T) {
 
 	testStart := time.Now()
 
-	gb, err := v1JSONBatchToOCProto(zBytes)
+	gb, err := v1JSONBatchToOCProto(zBytes, false)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 		return
@@ -564,7 +568,7 @@ func TestJSONHTTPToGRPCStatusCode(t *testing.T) {
 			t.Errorf("#%d: Unexpected error: %v", i, err)
 			continue
 		}
-		gb, err := v1JSONBatchToOCProto(zBytes)
+		gb, err := v1JSONBatchToOCProto(zBytes, false)
 		if err != nil {
 			t.Errorf("#%d: Unexpected error: %v", i, err)
 			continue
@@ -740,7 +744,7 @@ func TestSpanKindTranslation(t *testing.T) {
 			}
 
 			// Translate to OC and verify that span kind is correctly translated.
-			ocSpan, parsedAnnotations, err := zipkinV1ToOCSpan(zSpan)
+			ocSpan, parsedAnnotations, err := zipkinV1ToOCSpan(zSpan, false)
 			assert.NoError(t, err)
 			assert.EqualValues(t, test.ocKind, ocSpan.Kind)
 			assert.NotNil(t, parsedAnnotations)
@@ -766,7 +770,7 @@ func TestZipkinV1ToOCSpanInvalidTraceId(t *testing.T) {
 			{Value: "cr"},
 		},
 	}
-	_, _, err := zipkinV1ToOCSpan(zSpan)
+	_, _, err := zipkinV1ToOCSpan(zSpan, false)
 	assert.EqualError(t, err, "zipkinV1 span traceId: hex traceId span has wrong length (expected 16 or 32)")
 }
 
@@ -778,6 +782,6 @@ func TestZipkinV1ToOCSpanInvalidSpanId(t *testing.T) {
 			{Value: "cr"},
 		},
 	}
-	_, _, err := zipkinV1ToOCSpan(zSpan)
+	_, _, err := zipkinV1ToOCSpan(zSpan, false)
 	assert.EqualError(t, err, "zipkinV1 span id: hex Id has wrong length (expected 16)")
 }

--- a/translator/trace/zipkin/zipkinv1_to_traces.go
+++ b/translator/trace/zipkin/zipkinv1_to_traces.go
@@ -19,10 +19,10 @@ import (
 	"go.opentelemetry.io/collector/translator/internaldata"
 )
 
-func V1JSONBatchToInternalTraces(blob []byte) (pdata.Traces, error) {
+func V1JSONBatchToInternalTraces(blob []byte, parseStringTags bool) (pdata.Traces, error) {
 	traces := pdata.NewTraces()
 
-	ocTraces, err := v1JSONBatchToOCProto(blob)
+	ocTraces, err := v1JSONBatchToOCProto(blob, parseStringTags)
 	if err != nil {
 		return traces, err
 	}

--- a/translator/trace/zipkin/zipkinv1_to_traces_test.go
+++ b/translator/trace/zipkin/zipkinv1_to_traces_test.go
@@ -26,7 +26,7 @@ func TestSingleJSONV1BatchToTraces(t *testing.T) {
 	blob, err := ioutil.ReadFile("./testdata/zipkin_v1_single_batch.json")
 	require.NoError(t, err, "Failed to load test data")
 
-	got, err := V1JSONBatchToInternalTraces(blob)
+	got, err := V1JSONBatchToInternalTraces(blob, false)
 	require.NoError(t, err, "Failed to translate zipkinv1 to OC proto")
 
 	assert.Equal(t, 5, got.SpanCount())
@@ -36,7 +36,7 @@ func TestErrorSpanToTraces(t *testing.T) {
 	blob, err := ioutil.ReadFile("./testdata/zipkin_v1_error_batch.json")
 	require.NoError(t, err, "Failed to load test data")
 
-	td, err := V1JSONBatchToInternalTraces(blob)
+	td, err := V1JSONBatchToInternalTraces(blob, false)
 	assert.Error(t, err, "Should have generated error")
 	assert.NotNil(t, td)
 }

--- a/translator/trace/zipkin/zipkinv2_to_traces_test.go
+++ b/translator/trace/zipkin/zipkinv2_to_traces_test.go
@@ -60,7 +60,7 @@ func TestZipkinSpansToInternalTraces(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			td, err := V2SpansToInternalTraces(test.zs)
+			td, err := V2SpansToInternalTraces(test.zs, false)
 			assert.EqualValues(t, test.err, err)
 			if test.name != "nilSpan" {
 				assert.Equal(t, len(test.zs), td.SpanCount())


### PR DESCRIPTION
**Description:**
Fixes https://github.com/open-telemetry/opentelemetry-collector/issues/1888

Previously the zipkin receiver parses string tags to other datatypes (int/bool/float), this adds the functionality back under a new configuration option `parse_string_tags` in the zipkin receiver.

To unify the behavior with the zipkin v1 I also disabled the parsing by default and check the same configuration option.

**Link to tracking Issue:** #1888 

**Testing:** 
Added test