### PR TITLE
Fix "run" Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ endif
 BUILD_X3=-X $(BUILD_INFO_IMPORT_PATH).BuildType=$(BUILD_TYPE)
 BUILD_INFO=-ldflags "${BUILD_X1} ${BUILD_X2} ${BUILD_X3}"
 
-RUN_CONFIG?=examples/otel-local-config.yaml
+RUN_CONFIG?=examples/local/otel-config.yaml
 
 CONTRIB_PATH=$(CURDIR)/../opentelemetry-collector-contrib
 


### PR DESCRIPTION
After moving the default config, the configs make run is broken
