### PR TITLE
Metadata Generator Enhancements

### DIFF
--- a/cmd/mdatagen/loader.go
+++ b/cmd/mdatagen/loader.go
@@ -43,7 +43,7 @@ type metric struct {
 	// Description of the metric.
 	Description string `validate:"required,notblank"`
 	// Unit of the metric.
-	Unit string `validate:"oneof=s By"`
+	Unit string `yaml:"unit"`
 
 	// Raw data that is used to set Data interface below.
 	YmlData *ymlMetricData `yaml:"data" validate:"required"`

--- a/cmd/mdatagen/metrics.tmpl
+++ b/cmd/mdatagen/metrics.tmpl
@@ -24,35 +24,91 @@ import (
 // Type is the component type name.
 const Type configmodels.Type = "{{ .Name }}"
 
-{{- /* Renders metric descriptors. */}}
-// Metrics contains the metric descriptors for the possible metrics.
-var Metrics = struct {
-	{{- range $name, $metric := .Metrics }}
-	// {{ $name.Render }} in {{ $metric.Unit }} ({{ $metric.Description }})
-	{{ $name.Render }} pdata.Metric
-	{{- end }}
-}{
-	{{- range $name, $metric := .Metrics }}
-	func() pdata.Metric {
-		metric := pdata.NewMetric()
-		metric.InitEmpty()
-		metric.SetName("{{ $name }}")
-		metric.SetDescription("{{ $metric.Description }}")
-		metric.SetUnit("{{ $metric.Unit }}")
-		metric.SetDataType(pdata.MetricDataType{{ $metric.Data.Type }})
-		data := metric.{{ $metric.Data.Type }}()
-		data.InitEmpty()
-		{{- if $metric.Data.HasMonotonic }}
-		data.SetIsMonotonic({{ $metric.Data.Monotonic }})
-		{{- end }}
-		{{- if $metric.Data.HasAggregated }}
-		data.SetAggregationTemporality({{ $metric.Data.Aggregated.Type }})
-		{{- end }}
+type metricIntf interface {
+	Name() string
+	New() pdata.Metric
+}
 
-		return metric
-    }(),
+// Intentionally not exposing this so that it is opaque and can change freely.
+type metricImpl struct {
+	name string
+	newFunc func() pdata.Metric
+}
+
+func (m *metricImpl) Name() string {
+	return m.name
+}
+
+func (m *metricImpl) New() pdata.Metric {
+	return m.newFunc()
+}
+
+type metricStruct struct {
+	{{- range $name, $metric := .Metrics }}
+	{{ $name.Render }} metricIntf
 	{{- end }}
 }
+
+// Names returns a list of all the metric name strings.
+func (m *metricStruct) Names() []string {
+    return []string {
+    {{- range $name, $metric := .Metrics }}
+        "{{ $name }}",
+    {{- end }}
+    }
+}
+
+var metricsByName = map[string]metricIntf {
+{{- range $name, $metric := .Metrics }}
+  "{{ $name }}": Metrics.{{ $name.Render }},
+{{- end }}
+}
+
+func (m *metricStruct) ByName(n string) metricIntf {
+    return metricsByName[n]
+}
+
+func (m *metricStruct) FactoriesByName() map[string]func() pdata.Metric {
+    return map[string]func() pdata.Metric {
+    {{- range $name, $metric := .Metrics }}
+      Metrics.{{ $name.Render }}.Name(): Metrics.{{ $name.Render }}.New,
+    {{- end }}
+    }
+}
+
+
+{{- /* Renders metric descriptors. */}}
+// Metrics contains a set of methods for each metric that help with
+// manipulating those metrics.
+var Metrics = &metricStruct{
+	{{- range $name, $metric := .Metrics }}
+	&metricImpl{
+		"{{ $name }}",
+		func() pdata.Metric {
+			metric := pdata.NewMetric()
+			metric.InitEmpty()
+			metric.SetName("{{ $name }}")
+			metric.SetDescription("{{ $metric.Description }}")
+			metric.SetUnit("{{ $metric.Unit }}")
+			metric.SetDataType(pdata.MetricDataType{{ $metric.Data.Type }})
+			data := metric.{{ $metric.Data.Type }}()
+			data.InitEmpty()
+			{{- if $metric.Data.HasMonotonic }}
+			data.SetIsMonotonic({{ $metric.Data.Monotonic }})
+			{{- end }}
+			{{- if $metric.Data.HasAggregated }}
+			data.SetAggregationTemporality({{ $metric.Data.Aggregated.Type }})
+			{{- end }}
+
+			return metric
+		},
+	},
+	{{- end }}
+}
+
+// M contains a set of methods for each metric that help with
+// manipulating those metrics. M is an alias for Metrics
+var M = Metrics
 
 {{- /* Renders label names. */}}
 // Labels contains the possible metric labels that can be used.
@@ -70,6 +126,10 @@ var Labels = struct {
     {{- end }}
     {{- end }}
 }
+
+// L contains the possible metric labels that can be used. L is an alias for
+// Labels.
+var L = Labels
 
 {{- /* Renders label enum values. */}}
 

--- a/receiver/hostmetricsreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/hostmetricsreceiver/internal/metadata/generated_metrics.go
@@ -24,42 +24,96 @@ import (
 // Type is the component type name.
 const Type configmodels.Type = "hostmetricsreceiver"
 
-// Metrics contains the metric descriptors for the possible metrics.
-var Metrics = struct {
-	// SystemCPUTime in s (Total CPU seconds broken down by different states.)
-	SystemCPUTime pdata.Metric
-	// SystemMemoryUsage in By (Bytes of memory in use.)
-	SystemMemoryUsage pdata.Metric
-}{
-	func() pdata.Metric {
-		metric := pdata.NewMetric()
-		metric.InitEmpty()
-		metric.SetName("system.cpu.time")
-		metric.SetDescription("Total CPU seconds broken down by different states.")
-		metric.SetUnit("s")
-		metric.SetDataType(pdata.MetricDataTypeDoubleSum)
-		data := metric.DoubleSum()
-		data.InitEmpty()
-		data.SetIsMonotonic(true)
-		data.SetAggregationTemporality(pdata.AggregationTemporalityCumulative)
-
-		return metric
-	}(),
-	func() pdata.Metric {
-		metric := pdata.NewMetric()
-		metric.InitEmpty()
-		metric.SetName("system.memory.usage")
-		metric.SetDescription("Bytes of memory in use.")
-		metric.SetUnit("By")
-		metric.SetDataType(pdata.MetricDataTypeIntSum)
-		data := metric.IntSum()
-		data.InitEmpty()
-		data.SetIsMonotonic(false)
-		data.SetAggregationTemporality(pdata.AggregationTemporalityCumulative)
-
-		return metric
-	}(),
+type metricIntf interface {
+	Name() string
+	New() pdata.Metric
 }
+
+// Intentionally not exposing this so that it is opaque and can change freely.
+type metricImpl struct {
+	name    string
+	newFunc func() pdata.Metric
+}
+
+func (m *metricImpl) Name() string {
+	return m.name
+}
+
+func (m *metricImpl) New() pdata.Metric {
+	return m.newFunc()
+}
+
+type metricStruct struct {
+	SystemCPUTime     metricIntf
+	SystemMemoryUsage metricIntf
+}
+
+// Names returns a list of all the metric name strings.
+func (m *metricStruct) Names() []string {
+	return []string{
+		"system.cpu.time",
+		"system.memory.usage",
+	}
+}
+
+var metricsByName = map[string]metricIntf{
+	"system.cpu.time":     Metrics.SystemCPUTime,
+	"system.memory.usage": Metrics.SystemMemoryUsage,
+}
+
+func (m *metricStruct) ByName(n string) metricIntf {
+	return metricsByName[n]
+}
+
+func (m *metricStruct) FactoriesByName() map[string]func() pdata.Metric {
+	return map[string]func() pdata.Metric{
+		Metrics.SystemCPUTime.Name():     Metrics.SystemCPUTime.New,
+		Metrics.SystemMemoryUsage.Name(): Metrics.SystemMemoryUsage.New,
+	}
+}
+
+// Metrics contains a set of methods for each metric that help with
+// manipulating those metrics.
+var Metrics = &metricStruct{
+	&metricImpl{
+		"system.cpu.time",
+		func() pdata.Metric {
+			metric := pdata.NewMetric()
+			metric.InitEmpty()
+			metric.SetName("system.cpu.time")
+			metric.SetDescription("Total CPU seconds broken down by different states.")
+			metric.SetUnit("s")
+			metric.SetDataType(pdata.MetricDataTypeDoubleSum)
+			data := metric.DoubleSum()
+			data.InitEmpty()
+			data.SetIsMonotonic(true)
+			data.SetAggregationTemporality(pdata.AggregationTemporalityCumulative)
+
+			return metric
+		},
+	},
+	&metricImpl{
+		"system.memory.usage",
+		func() pdata.Metric {
+			metric := pdata.NewMetric()
+			metric.InitEmpty()
+			metric.SetName("system.memory.usage")
+			metric.SetDescription("Bytes of memory in use.")
+			metric.SetUnit("By")
+			metric.SetDataType(pdata.MetricDataTypeIntSum)
+			data := metric.IntSum()
+			data.InitEmpty()
+			data.SetIsMonotonic(false)
+			data.SetAggregationTemporality(pdata.AggregationTemporalityCumulative)
+
+			return metric
+		},
+	},
+}
+
+// M contains a set of methods for each metric that help with
+// manipulating those metrics. M is an alias for Metrics
+var M = Metrics
 
 // Labels contains the possible metric labels that can be used.
 var Labels = struct {
@@ -74,6 +128,10 @@ var Labels = struct {
 	"state",
 	"state",
 }
+
+// L contains the possible metric labels that can be used. L is an alias for
+// Labels.
+var L = Labels
 
 // LabelCPUState are the possible values that the label "cpu.state" can have.
 var LabelCPUState = struct {

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper.go
@@ -73,7 +73,7 @@ func (s *scraper) ScrapeMetrics(_ context.Context) (pdata.MetricSlice, error) {
 }
 
 func initializeCPUTimeMetric(metric pdata.Metric, startTime, now pdata.TimestampUnixNano, cpuTimes []cpu.TimesStat) {
-	metadata.Metrics.SystemCPUTime.CopyTo(metric)
+	metadata.Metrics.SystemCPUTime.New().CopyTo(metric)
 
 	ddps := metric.DoubleSum().DataPoints()
 	ddps.Resize(len(cpuTimes) * cpuStatesLen)

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_test.go
@@ -87,7 +87,7 @@ func TestScrapeMetrics(t *testing.T) {
 
 			assert.Equal(t, 1, metrics.Len())
 
-			assertCPUMetricValid(t, metrics.At(0), metadata.Metrics.SystemCPUTime, test.expectedStartTime)
+			assertCPUMetricValid(t, metrics.At(0), metadata.Metrics.SystemCPUTime.New(), test.expectedStartTime)
 
 			if runtime.GOOS == "linux" {
 				assertCPUMetricHasLinuxSpecificStateLabels(t, metrics.At(0))

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/memory_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/memory_scraper.go
@@ -64,7 +64,7 @@ func (s *scraper) ScrapeMetrics(_ context.Context) (pdata.MetricSlice, error) {
 }
 
 func initializeMemoryUsageMetric(metric pdata.Metric, now pdata.TimestampUnixNano, memInfo *mem.VirtualMemoryStat) {
-	metadata.Metrics.SystemMemoryUsage.CopyTo(metric)
+	metadata.Metrics.SystemMemoryUsage.New().CopyTo(metric)
 
 	idps := metric.IntSum().DataPoints()
 	idps.Resize(memStatesLen)

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/memory_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/memory_scraper_test.go
@@ -67,7 +67,7 @@ func TestScrapeMetrics(t *testing.T) {
 
 			assert.Equal(t, 1, metrics.Len())
 
-			assertMemoryUsageMetricValid(t, metrics.At(0), metadata.Metrics.SystemMemoryUsage)
+			assertMemoryUsageMetricValid(t, metrics.At(0), metadata.Metrics.SystemMemoryUsage.New())
 
 			if runtime.GOOS == "linux" {
 				assertMemoryUsageMetricHasLinuxSpecificStateLabels(t, metrics.At(0))


### PR DESCRIPTION
This changes the Metrics fields to a struct that implements an interface
with the `New` and `Name` methods to create a new metric and get the
metric name, respectively.

It also adds some methods to Metrics:

- `Names()` that returns a slice of all the names of metrics
- `ByName(name string)` that looks up a metric by its name
- `FactoriesByName()` that returns a map of factories (`New` methods)
keyed by metric name.

This makes it possible to refer to metrics by name in an easily
comparable manner and between components without them having to
explicitly know about these metadata types.

It also removes the validation on the Unit field of metrics since there
are many metrics that have no standard units (e.g. connections).

It also adds an alias `M` that corresponds to `Metrics`, and `L` for
`Labels` to shorten things where appropiriate.

