### PR TITLE
Include k8s.pod.hostname in semantic conventions

### DIFF
--- a/internal/goldendataset/resource_generator.go
+++ b/internal/goldendataset/resource_generator.go
@@ -111,6 +111,7 @@ func generateOnpremK8sAttributes() map[string]interface{} {
 	attrMap[conventions.AttributeK8sNamespace] = "cert-manager"
 	attrMap[conventions.AttributeK8sDeployment] = "cm-1-cert-manager"
 	attrMap[conventions.AttributeK8sPod] = "cm-1-cert-manager-6448b4949b-t2jtd"
+	attrMap[conventions.AttributeK8sPodHostname] = "cm-1-cert-manager"
 	attrMap[conventions.AttributeHostHostname] = "docker-desktop"
 	attrMap[conventions.AttributeHostName] = "192.168.65.3"
 	return attrMap

--- a/translator/conventions/opentelemetry.go
+++ b/translator/conventions/opentelemetry.go
@@ -49,6 +49,7 @@ const (
 	AttributeK8sJobUID             = "k8s.job.uid"
 	AttributeK8sNamespace          = "k8s.namespace.name"
 	AttributeK8sPod                = "k8s.pod.name"
+	AttributeK8sPodHostname        = "k8s.pod.hostname"
 	AttributeK8sPodUID             = "k8s.pod.uid"
 	AttributeK8sReplicaSet         = "k8s.replicaset.name"
 	AttributeK8sReplicaSetUID      = "k8s.replicaset.uid"
@@ -130,6 +131,7 @@ func GetResourceSemanticConventionAttributeNames() []string {
 		AttributeK8sJobUID,
 		AttributeK8sNamespace,
 		AttributeK8sPod,
+		AttributeK8sPodHostname,
 		AttributeK8sPodUID,
 		AttributeK8sReplicaSet,
 		AttributeK8sReplicaSetUID,


### PR DESCRIPTION
## Important (read before submitting)

**Description:** 

Adds `k8s.pod.hostname` to the list of K8s semantic conventions attributes following [OpenTelemetry Spec #1072](https://github.com/open-telemetry/opentelemetry-specification/pull/1072)

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-specification/pull/1072
