### PR TITLE
Log when dropping metrics due to missing process_start_time_seconds

### DIFF
--- a/receiver/prometheusreceiver/internal/transaction.go
+++ b/receiver/prometheusreceiver/internal/transaction.go
@@ -47,6 +47,7 @@ const (
 var errMetricNameNotFound = errors.New("metricName not found from labels")
 var errTransactionAborted = errors.New("transaction aborted")
 var errNoJobInstance = errors.New("job or instance cannot be found from labels")
+var errNoStartTimeMetrics = errors.New("process_start_time_seconds metric is missing")
 
 // A transaction is corresponding to an individual scrape operation or stale report.
 // That said, whenever prometheus receiver scrapped a target metric endpoint a page of raw metrics is returned,
@@ -161,16 +162,13 @@ func (tr *transaction) Commit() error {
 		// process_start_time_seconds metric is missing from the target endpoint.
 		if tr.metricBuilder.startTime == 0.0 {
 			// Since we are unable to adjust metrics properly, we will drop them
-			// and log a message.
-			tr.logger.Info(
-				"Dropping metrics - unable to adjust start time due to 'process_start_time_seconds' metric missing",
-				zap.String("prometheus_job", tr.job),
-				zap.String("prometheus_instance", tr.instance),
-				zap.Int("dropped_metrics_count", len(metrics)))
-			metrics = []*metricspb.Metric{}
-		} else {
-			adjustStartTime(tr.metricBuilder.startTime, metrics)
+			// and return an error.
+			err := errNoStartTimeMetrics
+			obsreport.EndMetricsReceiveOp(ctx, dataformat, 0, 0, err)
+			return err
 		}
+
+		adjustStartTime(tr.metricBuilder.startTime, metrics)
 	} else {
 		// AdjustMetrics - jobsMap has to be non-nil in this case.
 		// Note: metrics could be empty after adjustment, which needs to be checked before passing it on to ConsumeMetricsData()

--- a/receiver/prometheusreceiver/internal/transaction.go
+++ b/receiver/prometheusreceiver/internal/transaction.go
@@ -163,7 +163,7 @@ func (tr *transaction) Commit() error {
 		if tr.metricBuilder.startTime == 0.0 {
 			// Since we are unable to adjust metrics properly, we will drop them
 			// and return an error.
-			err := errNoStartTimeMetrics
+			err = errNoStartTimeMetrics
 			obsreport.EndMetricsReceiveOp(ctx, dataformat, 0, 0, err)
 			return err
 		}

--- a/receiver/prometheusreceiver/internal/transaction_test.go
+++ b/receiver/prometheusreceiver/internal/transaction_test.go
@@ -138,7 +138,7 @@ func Test_transaction(t *testing.T) {
 			t.Errorf("expecting error == nil from Add() but got: %v\n", got)
 		}
 		tr.metricBuilder.startTime = 0 // zero value means the start time metric is missing
-		got := tr.Commit();
+		got := tr.Commit()
 		if got == nil {
 			t.Error("expecting error from Commit() but got nil")
 		} else if got.Error() != errNoStartTimeMetrics.Error() {

--- a/receiver/prometheusreceiver/internal/transaction_test.go
+++ b/receiver/prometheusreceiver/internal/transaction_test.go
@@ -131,6 +131,21 @@ func Test_transaction(t *testing.T) {
 		// assert.Len(t, ocmds[0].Metrics, 1)
 	})
 
+	t.Run("Error when start time is zero", func(t *testing.T) {
+		sink := new(exportertest.SinkMetricsExporter)
+		tr := newTransaction(context.Background(), nil, true, "", rn, ms, sink, testLogger)
+		if _, got := tr.Add(goodLabels, time.Now().Unix()*1000, 1.0); got != nil {
+			t.Errorf("expecting error == nil from Add() but got: %v\n", got)
+		}
+		tr.metricBuilder.startTime = 0 // zero value means the start time metric is missing
+		got := tr.Commit();
+		if got == nil {
+			t.Error("expecting error from Commit() but got nil")
+		} else if got.Error() != errNoStartTimeMetrics.Error() {
+			t.Errorf("expected error %q but got %q", errNoStartTimeMetrics, got)
+		}
+	})
+
 	t.Run("Drop NaN value", func(t *testing.T) {
 		sink := new(exportertest.SinkMetricsExporter)
 		tr := newTransaction(context.Background(), nil, true, "", rn, ms, sink, testLogger)


### PR DESCRIPTION
**Description:** 
~- Log a message when metrics are dropped by Prometheus receiver due to missing `process_start_time_seconds` metric.~
- Report error via `obsreport.EndMetricsReceiveOp` and return error in transaction `Commit()`

**Link to tracking Issue:** Fixes #969
