### PR TITLE
Temporarily skip test until it is fixed

### DIFF
--- a/processor/groupbytraceprocessor/processor_test.go
+++ b/processor/groupbytraceprocessor/processor_test.go
@@ -674,6 +674,10 @@ func TestSplitByTraceWithNilTraceID(t *testing.T) {
 }
 
 func TestErrorOnProcessResourceSpansContinuesProcessing(t *testing.T) {
+	// Skip it, this is failing on Windows. Bug submitted:
+	// https://github.com/open-telemetry/opentelemetry-collector/issues/1923
+	t.SkipNow()
+
 	// prepare
 	config := Config{
 		WaitDuration: time.Second, // we are not waiting for this whole time


### PR DESCRIPTION
This test is very unstable on windows.

Issue for proper fix is filed:
https://github.com/open-telemetry/opentelemetry-collector/issues/1923
