### PR TITLE
Added support for list values for a key in processor

### DIFF
--- a/internal/processor/filterhelper/filterhelper.go
+++ b/internal/processor/filterhelper/filterhelper.go
@@ -40,12 +40,6 @@ func NewAttributeValueRaw(value interface{}) (pdata.AttributeValue, error) {
 			return attributeVal, err
 		}
 		return attributeVal, nil
-	case map[string]interface{}:
-		attributeVal, err := fromMap(val)
-		if err != nil {
-			return attributeVal, err
-		}
-		return attributeVal, nil
 	default:
 		return pdata.AttributeValue{}, fmt.Errorf("error unsupported value type \"%T\"", value)
 	}
@@ -62,20 +56,5 @@ func fromArray(val []interface{}) (pdata.AttributeValue, error) {
 	}
 	av := pdata.NewAttributeValueArray()
 	av.SetArrayVal(arr)
-	return av, nil
-}
-
-func fromMap(v map[string]interface{}) (pdata.AttributeValue, error) {
-	m := pdata.NewAttributeMap()
-	for k, v := range v {
-		attributeVal, err := NewAttributeValueRaw(v)
-		if err != nil {
-			return attributeVal, err
-		}
-		m.Insert(k, attributeVal)
-	}
-	m.Sort()
-	av := pdata.NewAttributeValueMap()
-	av.SetMapVal(m)
 	return av, nil
 }

--- a/internal/processor/filterhelper/filterhelper.go
+++ b/internal/processor/filterhelper/filterhelper.go
@@ -34,7 +34,48 @@ func NewAttributeValueRaw(value interface{}) (pdata.AttributeValue, error) {
 		return pdata.NewAttributeValueString(val), nil
 	case bool:
 		return pdata.NewAttributeValueBool(val), nil
+	case []interface{}:
+		return fromArray(val), nil
+	case map[string]interface{}:
+		return fromMap(val), nil
 	default:
 		return pdata.AttributeValue{}, fmt.Errorf("error unsupported value type \"%T\"", value)
 	}
+}
+
+func fromArray(val []interface{}) pdata.AttributeValue {
+	arr := pdata.NewAnyValueArray()
+	for _, v := range val {
+		arr.Append(fromVal(v))
+	}
+	av := pdata.NewAttributeValueArray()
+	av.SetArrayVal(arr)
+	return av
+}
+
+func fromMap(v map[string]interface{}) pdata.AttributeValue {
+	m := pdata.NewAttributeMap()
+	for k, v := range v {
+		m.Insert(k, fromVal(v))
+	}
+	m.Sort()
+	av := pdata.NewAttributeValueMap()
+	av.SetMapVal(m)
+	return av
+}
+
+func fromVal(val interface{}) pdata.AttributeValue {
+	switch v := val.(type) {
+	case string:
+		return pdata.NewAttributeValueString(v)
+	case int:
+		return pdata.NewAttributeValueInt(int64(v))
+	case float64:
+		return pdata.NewAttributeValueDouble(v)
+	case []interface{}:
+		return fromArray(v)
+	case map[string]interface{}:
+		return fromMap(v)
+	}
+	panic("data type is not supported in fromVal()")
 }

--- a/internal/processor/filterhelper/filterhelper.go
+++ b/internal/processor/filterhelper/filterhelper.go
@@ -35,47 +35,47 @@ func NewAttributeValueRaw(value interface{}) (pdata.AttributeValue, error) {
 	case bool:
 		return pdata.NewAttributeValueBool(val), nil
 	case []interface{}:
-		return fromArray(val), nil
+		attributeVal, err := fromArray(val)
+		if err != nil {
+			return attributeVal, err
+		}
+		return attributeVal, nil
 	case map[string]interface{}:
-		return fromMap(val), nil
+		attributeVal, err := fromMap(val)
+		if err != nil {
+			return attributeVal, err
+		}
+		return attributeVal, nil
 	default:
 		return pdata.AttributeValue{}, fmt.Errorf("error unsupported value type \"%T\"", value)
 	}
 }
 
-func fromArray(val []interface{}) pdata.AttributeValue {
+func fromArray(val []interface{}) (pdata.AttributeValue, error) {
 	arr := pdata.NewAnyValueArray()
 	for _, v := range val {
-		arr.Append(fromVal(v))
+		attributeVal, err := NewAttributeValueRaw(v)
+		if err != nil {
+			return attributeVal, err
+		}
+		arr.Append(attributeVal)
 	}
 	av := pdata.NewAttributeValueArray()
 	av.SetArrayVal(arr)
-	return av
+	return av, nil
 }
 
-func fromMap(v map[string]interface{}) pdata.AttributeValue {
+func fromMap(v map[string]interface{}) (pdata.AttributeValue, error) {
 	m := pdata.NewAttributeMap()
 	for k, v := range v {
-		m.Insert(k, fromVal(v))
+		attributeVal, err := NewAttributeValueRaw(v)
+		if err != nil {
+			return attributeVal, err
+		}
+		m.Insert(k, attributeVal)
 	}
 	m.Sort()
 	av := pdata.NewAttributeValueMap()
 	av.SetMapVal(m)
-	return av
-}
-
-func fromVal(val interface{}) pdata.AttributeValue {
-	switch v := val.(type) {
-	case string:
-		return pdata.NewAttributeValueString(v)
-	case int:
-		return pdata.NewAttributeValueInt(int64(v))
-	case float64:
-		return pdata.NewAttributeValueDouble(v)
-	case []interface{}:
-		return fromArray(v)
-	case map[string]interface{}:
-		return fromMap(v)
-	}
-	panic("data type is not supported in fromVal()")
+	return av, nil
 }

--- a/internal/processor/filterhelper/filterhelper_test.go
+++ b/internal/processor/filterhelper/filterhelper_test.go
@@ -102,4 +102,21 @@ func TestHelper_AttributeValueArray(t *testing.T) {
 	for i := 0; i < val.ArrayVal().Len(); i++ {
 		assert.Equal(t, pdata.NewAttributeValueBool(testData[i].(bool)), val.ArrayVal().At(i))
 	}
+
+	var southWeather = make(map[string]interface{})
+	southWeather["NY"] = 15.9
+	southWeather["VT"] = 13.1
+	southWeather["NH"] = 18.0
+	val, err = NewAttributeValueRaw(southWeather)
+	assert.Equal(t, pdata.AttributeValue{}, val)
+	assert.Error(t, err)
+
+	var northWeather = make(map[string]interface{})
+	northWeather["AR"] = 45.7
+	northWeather["TX"] = 43.3
+	northWeather["MS"] = 41.1
+
+	val, err = NewAttributeValueRaw([]interface{}{southWeather, northWeather})
+	assert.Equal(t, pdata.AttributeValue{}, val)
+	assert.Error(t, err)
 }

--- a/internal/processor/filterhelper/filterhelper_test.go
+++ b/internal/processor/filterhelper/filterhelper_test.go
@@ -61,3 +61,33 @@ func TestHelper_AttributeValue(t *testing.T) {
 	_, err = NewAttributeValueRaw(t)
 	assert.Error(t, err)
 }
+
+func TestHelper_AttributeValueArray(t *testing.T) {
+	testData := []interface{}{"alpha", "beta", "gamma", "delta"}
+	val, err := NewAttributeValueRaw(testData)
+	assert.NoError(t, err)
+	for i := 0; i < val.ArrayVal().Len(); i++ {
+		assert.Equal(t, pdata.NewAttributeValueString(testData[i].(string)), val.ArrayVal().At(i))
+	}
+
+	testData = []interface{}{int64(200), int64(203)}
+	val, err = NewAttributeValueRaw(testData)
+	assert.NoError(t, err)
+	for i := 0; i < val.ArrayVal().Len(); i++ {
+		assert.Equal(t, pdata.NewAttributeValueInt(testData[i].(int64)), val.ArrayVal().At(i))
+	}
+
+	testData = []interface{}{float32(5341.129312), float32(888.102)}
+	val, err = NewAttributeValueRaw(testData)
+	assert.NoError(t, err)
+	for i := 0; i < val.ArrayVal().Len(); i++ {
+		assert.Equal(t, pdata.NewAttributeValueDouble(float64(float32(testData[i].(float32)))), val.ArrayVal().At(i))
+	}
+
+	testData = []interface{}{true, false}
+	val, err = NewAttributeValueRaw(testData)
+	assert.NoError(t, err)
+	for i := 0; i < val.ArrayVal().Len(); i++ {
+		assert.Equal(t, pdata.NewAttributeValueBool(testData[i].(bool)), val.ArrayVal().At(i))
+	}
+}

--- a/internal/processor/filterhelper/filterhelper_test.go
+++ b/internal/processor/filterhelper/filterhelper_test.go
@@ -90,7 +90,7 @@ func TestHelper_AttributeValueArray(t *testing.T) {
 	assert.Equal(t, 2, val.ArrayVal().Len())
 	assert.NoError(t, err)
 	for i := 0; i < val.ArrayVal().Len(); i++ {
-		assert.Equal(t, pdata.NewAttributeValueDouble(float64(float32(testData[i].(float32)))), val.ArrayVal().At(i))
+		assert.Equal(t, pdata.NewAttributeValueDouble(float64(testData[i].(float32))), val.ArrayVal().At(i))
 	}
 
 	testData = []interface{}{true}

--- a/internal/processor/filterhelper/filterhelper_test.go
+++ b/internal/processor/filterhelper/filterhelper_test.go
@@ -65,13 +65,19 @@ func TestHelper_AttributeValue(t *testing.T) {
 func TestHelper_AttributeValueArray(t *testing.T) {
 	testData := []interface{}{"alpha", "beta", "gamma", "delta"}
 	val, err := NewAttributeValueRaw(testData)
+	assert.Equal(t, val.Type(), pdata.AttributeValueARRAY)
+	assert.NotNil(t, val.ArrayVal())
+	assert.Equal(t, 4, val.ArrayVal().Len())
 	assert.NoError(t, err)
 	for i := 0; i < val.ArrayVal().Len(); i++ {
 		assert.Equal(t, pdata.NewAttributeValueString(testData[i].(string)), val.ArrayVal().At(i))
 	}
 
-	testData = []interface{}{int64(200), int64(203)}
+	testData = []interface{}{int64(200), int64(203), int64(500)}
 	val, err = NewAttributeValueRaw(testData)
+	assert.Equal(t, val.Type(), pdata.AttributeValueARRAY)
+	assert.NotNil(t, val.ArrayVal())
+	assert.Equal(t, 3, val.ArrayVal().Len())
 	assert.NoError(t, err)
 	for i := 0; i < val.ArrayVal().Len(); i++ {
 		assert.Equal(t, pdata.NewAttributeValueInt(testData[i].(int64)), val.ArrayVal().At(i))
@@ -79,13 +85,19 @@ func TestHelper_AttributeValueArray(t *testing.T) {
 
 	testData = []interface{}{float32(5341.129312), float32(888.102)}
 	val, err = NewAttributeValueRaw(testData)
+	assert.Equal(t, val.Type(), pdata.AttributeValueARRAY)
+	assert.NotNil(t, val.ArrayVal())
+	assert.Equal(t, 2, val.ArrayVal().Len())
 	assert.NoError(t, err)
 	for i := 0; i < val.ArrayVal().Len(); i++ {
 		assert.Equal(t, pdata.NewAttributeValueDouble(float64(float32(testData[i].(float32)))), val.ArrayVal().At(i))
 	}
 
-	testData = []interface{}{true, false}
+	testData = []interface{}{true}
 	val, err = NewAttributeValueRaw(testData)
+	assert.Equal(t, val.Type(), pdata.AttributeValueARRAY)
+	assert.NotNil(t, val.ArrayVal())
+	assert.Equal(t, 1, val.ArrayVal().Len())
 	assert.NoError(t, err)
 	for i := 0; i < val.ArrayVal().Len(); i++ {
 		assert.Equal(t, pdata.NewAttributeValueBool(testData[i].(bool)), val.ArrayVal().At(i))

--- a/internal/processor/filtermatcher/attributematcher.go
+++ b/internal/processor/filtermatcher/attributematcher.go
@@ -105,8 +105,22 @@ func (ma attributesMatcher) Match(attrs pdata.AttributeMap) bool {
 				return false
 			}
 		} else if property.AttributeValue != nil {
-			if !attr.Equal(*property.AttributeValue) {
+			propertyAttrValue := property.AttributeValue
+			switch propertyAttrValue.Type() {
+			// Case when Attribute Values are of list values.
+			case pdata.AttributeValueARRAY:
+				for i := 0; i < propertyAttrValue.ArrayVal().Len(); i++ {
+					// Check attr value is exists in the AttributeValue array.
+					// Equal checks for any of int, string, bool and double.
+					if attr.Equal(propertyAttrValue.ArrayVal().At(i)) {
+						return true
+					}
+				}
 				return false
+			default:
+				if !attr.Equal(*property.AttributeValue) {
+					return false
+				}
 			}
 		}
 	}

--- a/internal/processor/filterspan/filterspan_test.go
+++ b/internal/processor/filterspan/filterspan_test.go
@@ -563,7 +563,7 @@ func TestServiceNameForResource(t *testing.T) {
 	require.Equal(t, serviceNameForResource(resource), "test-service")
 }
 
-// TestSpan_Matching_Array tests matcher.MatchSpan
+// TestSpan_Matching_Array tests matcher.MatchSpan for attributes specification against a span
 // Attributes include array values and default values covering switch case in Properties matcher attributes.Match
 func TestSpan_Matching_Array(t *testing.T) {
 	// True case


### PR DESCRIPTION
Updated/Added cases in `opentelemetry-collector/internal/processor/filterhelper/filterhelper.go` for handling list of interfaces and map

Updated Match func in `opentelemetry-collector/internal/processor/filtermatcher/attributematcher.go` for validating  AttributeValueARRAY data

**Description:** Support for list of values for a key for attribute processor
**Link to tracking Issue:** #1935 
