### PR TITLE
Add expr pdata.Metric filtering support to filterprocessor 1/2

### DIFF
--- a/internal/processor/filtermetric/config.go
+++ b/internal/processor/filtermetric/config.go
@@ -16,13 +16,22 @@ package filtermetric
 
 import (
 	"go.opentelemetry.io/collector/internal/processor/filterset"
+	"go.opentelemetry.io/collector/internal/processor/filterset/regexp"
+)
+
+type MatchType string
+
+const (
+	Regexp MatchType = MatchType(filterset.Regexp)
+	Strict MatchType = MatchType(filterset.Strict)
+	Expr   MatchType = "expr"
 )
 
 // MatchProperties specifies the set of properties in a metric to match against and the
 // type of string pattern matching to use.
 type MatchProperties struct {
-	// MatchConfig configures the matching patterns used when matching metric properties.
-	filterset.Config `mapstructure:",squash"`
+	MatchType    MatchType      `mapstructure:"match_type"`
+	RegexpConfig *regexp.Config `mapstructure:"regexp"`
 
 	// MetricNames specifies the list of string patterns to match metric names against.
 	// A match occurs if the metric name matches at least one string pattern in this list.

--- a/internal/processor/filtermetric/config.go
+++ b/internal/processor/filtermetric/config.go
@@ -29,8 +29,8 @@ type MatchType string
 // These are the MatchTypes that users can specify for filtering
 // `pdata.Metric`s.
 const (
-	Regexp MatchType = MatchType(filterset.Regexp)
-	Strict MatchType = MatchType(filterset.Strict)
+	Regexp           = MatchType(filterset.Regexp)
+	Strict           = MatchType(filterset.Strict)
 	Expr   MatchType = "expr"
 )
 

--- a/internal/processor/filtermetric/config.go
+++ b/internal/processor/filtermetric/config.go
@@ -19,8 +19,15 @@ import (
 	"go.opentelemetry.io/collector/internal/processor/filterset/regexp"
 )
 
+// MatchType specifies the strategy for matching against `pdata.Metric`s. This
+// is distinct from filterset.MatchType which matches against metric (and
+// tracing) names only. To support matching against metric names and
+// `pdata.Metric`s, filtermetric.MatchType is effectively a superset of
+// filterset.MatchType.
 type MatchType string
 
+// These are the MatchTypes that users can specify for filtering
+// `pdata.Metric`s.
 const (
 	Regexp MatchType = MatchType(filterset.Regexp)
 	Strict MatchType = MatchType(filterset.Strict)
@@ -30,7 +37,9 @@ const (
 // MatchProperties specifies the set of properties in a metric to match against and the
 // type of string pattern matching to use.
 type MatchProperties struct {
-	MatchType    MatchType      `mapstructure:"match_type"`
+	// MatchType specifies the type of matching desired
+	MatchType MatchType `mapstructure:"match_type"`
+	// RegexpConfig specifies options for the Regexp match type
 	RegexpConfig *regexp.Config `mapstructure:"regexp"`
 
 	// MetricNames specifies the list of string patterns to match metric names against.

--- a/internal/processor/filtermetric/config_test.go
+++ b/internal/processor/filtermetric/config_test.go
@@ -42,7 +42,7 @@ var (
 
 func createConfigWithRegexpOptions(filters []string, rCfg *regexp.Config) *MatchProperties {
 	cfg := createConfig(filters, filterset.Regexp)
-	cfg.Config.RegexpConfig = rCfg
+	cfg.RegexpConfig = rCfg
 	return cfg
 }
 

--- a/internal/processor/filtermetric/filtermetric.go
+++ b/internal/processor/filtermetric/filtermetric.go
@@ -32,7 +32,13 @@ type Matcher struct {
 // The metric Matcher supports matching by the following metric properties:
 // - Metric name
 func NewMatcher(config *MatchProperties) (Matcher, error) {
-	nameFS, err := filterset.CreateFilterSet(config.MetricNames, &config.Config)
+	nameFS, err := filterset.CreateFilterSet(
+		config.MetricNames,
+		&filterset.Config{
+			MatchType:    filterset.MatchType(config.MatchType),
+			RegexpConfig: config.RegexpConfig,
+		},
+	)
 	if err != nil {
 		return Matcher{}, err
 	}

--- a/internal/processor/filtermetric/helpers_test.go
+++ b/internal/processor/filtermetric/helpers_test.go
@@ -20,9 +20,7 @@ import (
 
 func createConfig(filters []string, matchType filterset.MatchType) *MatchProperties {
 	return &MatchProperties{
-		Config: filterset.Config{
-			MatchType: matchType,
-		},
+		MatchType:   MatchType(matchType),
 		MetricNames: filters,
 	}
 }

--- a/processor/filterprocessor/config_test.go
+++ b/processor/filterprocessor/config_test.go
@@ -25,7 +25,6 @@ import (
 	"go.opentelemetry.io/collector/config/configmodels"
 	"go.opentelemetry.io/collector/config/configtest"
 	"go.opentelemetry.io/collector/internal/processor/filtermetric"
-	"go.opentelemetry.io/collector/internal/processor/filterset"
 	fsregexp "go.opentelemetry.io/collector/internal/processor/filterset/regexp"
 )
 
@@ -38,9 +37,7 @@ func TestLoadingConfigStrict(t *testing.T) {
 	}
 
 	testDataMetricProperties := &filtermetric.MatchProperties{
-		Config: filterset.Config{
-			MatchType: filterset.Strict,
-		},
+		MatchType:   filtermetric.Strict,
 		MetricNames: testDataFilters,
 	}
 
@@ -67,9 +64,7 @@ func TestLoadingConfigStrict(t *testing.T) {
 				},
 				Metrics: MetricFilters{
 					Include: &filtermetric.MatchProperties{
-						Config: filterset.Config{
-							MatchType: filterset.Strict,
-						},
+						MatchType: filtermetric.Strict,
 					},
 				},
 			},
@@ -105,9 +100,7 @@ func TestLoadingConfigStrict(t *testing.T) {
 				Metrics: MetricFilters{
 					Include: testDataMetricProperties,
 					Exclude: &filtermetric.MatchProperties{
-						Config: filterset.Config{
-							MatchType: filterset.Strict,
-						},
+						MatchType:   filtermetric.Strict,
 						MetricNames: []string{"hello_world"},
 					},
 				},
@@ -138,9 +131,7 @@ func TestLoadingConfigRegexp(t *testing.T) {
 	}
 
 	testDataMetricProperties := &filtermetric.MatchProperties{
-		Config: filterset.Config{
-			MatchType: filterset.Regexp,
-		},
+		MatchType:   filtermetric.Regexp,
 		MetricNames: testDataFilters,
 	}
 
@@ -189,11 +180,9 @@ func TestLoadingConfigRegexp(t *testing.T) {
 				},
 				Metrics: MetricFilters{
 					Include: &filtermetric.MatchProperties{
-						Config: filterset.Config{
-							MatchType: filterset.Regexp,
-							RegexpConfig: &fsregexp.Config{
-								CacheEnabled: true,
-							},
+						MatchType: filtermetric.Regexp,
+						RegexpConfig: &fsregexp.Config{
+							CacheEnabled: true,
 						},
 						MetricNames: testDataFilters,
 					},
@@ -208,12 +197,10 @@ func TestLoadingConfigRegexp(t *testing.T) {
 				},
 				Metrics: MetricFilters{
 					Exclude: &filtermetric.MatchProperties{
-						Config: filterset.Config{
-							MatchType: filterset.Regexp,
-							RegexpConfig: &fsregexp.Config{
-								CacheEnabled:       true,
-								CacheMaxNumEntries: 10,
-							},
+						MatchType: filtermetric.Regexp,
+						RegexpConfig: &fsregexp.Config{
+							CacheEnabled:       true,
+							CacheMaxNumEntries: 10,
 						},
 						MetricNames: testDataFilters,
 					},

--- a/processor/filterprocessor/filter_processor_test.go
+++ b/processor/filterprocessor/filter_processor_test.go
@@ -32,7 +32,6 @@ import (
 	etest "go.opentelemetry.io/collector/exporter/exportertest"
 	"go.opentelemetry.io/collector/internal/goldendataset"
 	"go.opentelemetry.io/collector/internal/processor/filtermetric"
-	"go.opentelemetry.io/collector/internal/processor/filterset"
 	"go.opentelemetry.io/collector/translator/internaldata"
 )
 
@@ -75,9 +74,7 @@ var (
 	}
 
 	regexpMetricsFilterProperties = &filtermetric.MatchProperties{
-		Config: filterset.Config{
-			MatchType: filterset.Regexp,
-		},
+		MatchType:   filtermetric.Regexp,
 		MetricNames: validFilters,
 	}
 
@@ -114,9 +111,7 @@ var (
 			name: "includeAndExclude",
 			inc:  regexpMetricsFilterProperties,
 			exc: &filtermetric.MatchProperties{
-				Config: filterset.Config{
-					MatchType: filterset.Strict,
-				},
+				MatchType: filtermetric.Strict,
 				MetricNames: []string{
 					"prefix_test_match",
 					"test_contains_match",
@@ -141,9 +136,7 @@ var (
 			name: "includeAndExcludeWithEmptyAndNil",
 			inc:  regexpMetricsFilterProperties,
 			exc: &filtermetric.MatchProperties{
-				Config: filterset.Config{
-					MatchType: filterset.Strict,
-				},
+				MatchType: filtermetric.Strict,
 				MetricNames: []string{
 					"prefix_test_match",
 					"test_contains_match",
@@ -169,9 +162,7 @@ var (
 		{
 			name: "emptyFilterInclude",
 			inc: &filtermetric.MatchProperties{
-				Config: filterset.Config{
-					MatchType: filterset.Strict,
-				},
+				MatchType: filtermetric.Strict,
 			},
 			inMN:               [][]*metricspb.Metric{metricsWithName(inMetricNames)},
 			allMetricsFiltered: true,
@@ -179,9 +170,7 @@ var (
 		{
 			name: "emptyFilterExclude",
 			exc: &filtermetric.MatchProperties{
-				Config: filterset.Config{
-					MatchType: filterset.Strict,
-				},
+				MatchType: filtermetric.Strict,
 			},
 			inMN:  [][]*metricspb.Metric{metricsWithName(inMetricNames)},
 			outMN: [][]string{inMetricNames},
@@ -275,9 +264,7 @@ func BenchmarkFilter(b *testing.B) {
 	pcfg := cfg.(*Config)
 	pcfg.Metrics = MetricFilters{
 		Exclude: &filtermetric.MatchProperties{
-			Config: filterset.Config{
-				MatchType: "strict",
-			},
+			MatchType:   "strict",
 			MetricNames: []string{"p10_metric_0"},
 		},
 	}
@@ -382,9 +369,7 @@ func requireNotPanics(t *testing.T, metrics pdata.Metrics) {
 	pcfg := cfg.(*Config)
 	pcfg.Metrics = MetricFilters{
 		Exclude: &filtermetric.MatchProperties{
-			Config: filterset.Config{
-				MatchType: "strict",
-			},
+			MatchType:   "strict",
 			MetricNames: []string{"foo"},
 		},
 	}


### PR DESCRIPTION
This is the first of two PRs to add support for filtering `pdata.Metric`s by arbitrary [expr](https://github.com/antonmedv/expr) expressions. The capabilities of the existing `filterprocessor`, which currently filters just metric _names_ by matching against regexes or strings, will be expanded to allow for filtering `pdata.Metric` _structs_ based on expressions such as `MetricName == "foo" && Label("mylabel") == "bar"`.

This change adds support for `match_type: expr` while maintaining backward compatibility with existing filterprocessor config yamls. Because the expr filter will be the first one that checks for matches against entire `pdata.Metric`s, rather than just their names, some minor changes are required to the structure of the configs that the filterprocessor uses.

For reference, a current filterprocessor config look might like the following:

```
processors:
  filter/1:
    metrics:
      exclude:
        match_type: regexp
        metric_names:
        - prefix/.*
```

After the second PR, the intent is for another possible config to be:

```
processors:
  filter/1:
    metrics:
      exclude:
        match_type: expr
        expressions:
        - "MetricName == 'foo' && Label('mylabel') == 'bar'"
```

This PR just adds support for `match_type: expr`.
