### PR TITLE
Add unmarshalling for pdata.Traces

### DIFF
--- a/consumer/pdata/trace.go
+++ b/consumer/pdata/trace.go
@@ -40,13 +40,23 @@ func TracesToOtlp(td Traces) []*otlptrace.ResourceSpans {
 	return *td.orig
 }
 
-// ToOtlpProtoBytes returns the internal Traces to OTLP Collector
-// ExportTraceServiceRequest ProtoBuf bytes. This is intended to export OTLP
-// Protobuf bytes for OTLP/HTTP transports.
+// ToOtlpProtoBytes converts the internal Traces to OTLP Collector
+// ExportTraceServiceRequest ProtoBuf bytes.
 func (td Traces) ToOtlpProtoBytes() ([]byte, error) {
 	return proto.Marshal(&otlpcollectortrace.ExportTraceServiceRequest{
 		ResourceSpans: *td.orig,
 	})
+}
+
+// TracesFromOtlpProtoBytes converts OTLP Collector ExportTraceServiceRequest
+// ProtoBuf bytes to the internal Traces.
+func TracesFromOtlpProtoBytes(data []byte) (Traces, error) {
+	traces := &otlpcollectortrace.ExportTraceServiceRequest{}
+	err := proto.Unmarshal(data, traces)
+	if err != nil {
+		return NewTraces(), err
+	}
+	return TracesFromOtlp(traces.ResourceSpans), nil
 }
 
 // NewTraces creates a new Traces.

--- a/consumer/pdata/trace.go
+++ b/consumer/pdata/trace.go
@@ -50,6 +50,8 @@ func (td Traces) ToOtlpProtoBytes() ([]byte, error) {
 
 // FromOtlpProtoBytes converts OTLP Collector ExportTraceServiceRequest
 // ProtoBuf bytes to the internal Traces. Overrides current data.
+// Calling this function on zero-initialized structure causes panic.
+// Use it with NewTraces or on existing initialized Traces
 func (td Traces) FromOtlpProtoBytes(data []byte) error {
 	traces := &otlpcollectortrace.ExportTraceServiceRequest{}
 	if err := proto.Unmarshal(data, traces); err != nil {

--- a/consumer/pdata/trace.go
+++ b/consumer/pdata/trace.go
@@ -48,15 +48,15 @@ func (td Traces) ToOtlpProtoBytes() ([]byte, error) {
 	})
 }
 
-// TracesFromOtlpProtoBytes converts OTLP Collector ExportTraceServiceRequest
-// ProtoBuf bytes to the internal Traces.
-func TracesFromOtlpProtoBytes(data []byte) (Traces, error) {
+// FromOtlpProtoBytes converts OTLP Collector ExportTraceServiceRequest
+// ProtoBuf bytes to the internal Traces. Overrides current data.
+func (td Traces) FromOtlpProtoBytes(data []byte) error {
 	traces := &otlpcollectortrace.ExportTraceServiceRequest{}
-	err := proto.Unmarshal(data, traces)
-	if err != nil {
-		return NewTraces(), err
+	if err := proto.Unmarshal(data, traces); err != nil {
+		return err
 	}
-	return TracesFromOtlp(traces.ResourceSpans), nil
+	*td.orig = traces.ResourceSpans
+	return nil
 }
 
 // NewTraces creates a new Traces.

--- a/consumer/pdata/trace_test.go
+++ b/consumer/pdata/trace_test.go
@@ -159,7 +159,10 @@ func TestFromOtlpProtoBytes(t *testing.T) {
 	bytes, err := td.ToOtlpProtoBytes()
 	assert.Nil(t, err)
 
-	tdFromBytes, err := TracesFromOtlpProtoBytes(bytes)
+	err = td.FromOtlpProtoBytes(bytes)
 	assert.Nil(t, err)
-	assert.EqualValues(t, td, tdFromBytes)
+	assert.EqualValues(t, NewTraces(), td)
+
+	err = td.FromOtlpProtoBytes([]byte{0xFF})
+	assert.EqualError(t, err, "unexpected EOF")
 }

--- a/consumer/pdata/trace_test.go
+++ b/consumer/pdata/trace_test.go
@@ -143,7 +143,7 @@ func TestResourceSpansWireCompatibility(t *testing.T) {
 	assert.EqualValues(t, *pdataRS.orig, &gogoprotoRS2)
 }
 
-func TestTraces_ToOtlpProtoBytes(t *testing.T) {
+func TestToOtlpProtoBytes(t *testing.T) {
 	td := NewTraces()
 	bytes, err := td.ToOtlpProtoBytes()
 	assert.Nil(t, err)
@@ -152,4 +152,14 @@ func TestTraces_ToOtlpProtoBytes(t *testing.T) {
 	err = gogoproto.Unmarshal(bytes, &etsr)
 	assert.Nil(t, err)
 	assert.EqualValues(t, etsr.ResourceSpans, TracesToOtlp(td))
+}
+
+func TestFromOtlpProtoBytes(t *testing.T) {
+	td := NewTraces()
+	bytes, err := td.ToOtlpProtoBytes()
+	assert.Nil(t, err)
+
+	tdFromBytes, err := TracesFromOtlpProtoBytes(bytes)
+	assert.Nil(t, err)
+	assert.EqualValues(t, td, tdFromBytes)
 }


### PR DESCRIPTION
**Description:**
Adding a feature - allow to unmarshal pdata.Traces from protobuf

**Link to tracking Issue:** #1939 

**Testing:** unmarshal(marshal(trace)) = trace
