### PR TITLE
Add send_timestamps option to Prometheus Exporter.

### DIFF
--- a/exporter/prometheusexporter/README.md
+++ b/exporter/prometheusexporter/README.md
@@ -10,6 +10,8 @@ The following settings can be optionally configured:
 
 - `constlabels` (no default): key/values that are applied for every exported metric.
 - `namespace` (no default): if set, exports metrics under the provided value.
+- `send_timestamps` (default false): if true, sends the timestamp of the underlying
+  metric sample in the response.
 
 Example:
 
@@ -21,6 +23,7 @@ exporters:
     const_labels:
       label1: value1
       "another label": spaced value
+    send_timestamps: true
 ```
 
 The full list of settings exposed for this exporter are documented [here](./config.go)

--- a/exporter/prometheusexporter/config.go
+++ b/exporter/prometheusexporter/config.go
@@ -32,4 +32,7 @@ type Config struct {
 
 	// ConstLabels are values that are applied for every exported metric.
 	ConstLabels prometheus.Labels `mapstructure:"const_labels"`
+
+	// SendTimestamps will send the underlying scrape timestamp with the export
+	SendTimestamps bool `mapstructure:"send_timestamps"`
 }

--- a/exporter/prometheusexporter/config_test.go
+++ b/exporter/prometheusexporter/config_test.go
@@ -53,5 +53,6 @@ func TestLoadConfig(t *testing.T) {
 				"label1":        "value1",
 				"another label": "spaced value",
 			},
+			SendTimestamps: true,
 		})
 }

--- a/exporter/prometheusexporter/factory.go
+++ b/exporter/prometheusexporter/factory.go
@@ -46,7 +46,8 @@ func createDefaultConfig() configmodels.Exporter {
 			TypeVal: typeStr,
 			NameVal: typeStr,
 		},
-		ConstLabels: map[string]string{},
+		ConstLabels:    map[string]string{},
+		SendTimestamps: false,
 	}
 }
 
@@ -63,8 +64,9 @@ func createMetricsExporter(
 	}
 
 	opts := prometheus.Options{
-		Namespace:   pcfg.Namespace,
-		ConstLabels: pcfg.ConstLabels,
+		Namespace:      pcfg.Namespace,
+		ConstLabels:    pcfg.ConstLabels,
+		SendTimestamps: pcfg.SendTimestamps,
 	}
 	pe, err := prometheus.New(opts)
 	if err != nil {

--- a/exporter/prometheusexporter/prometheus_test.go
+++ b/exporter/prometheusexporter/prometheus_test.go
@@ -42,10 +42,11 @@ func TestPrometheusExporter(t *testing.T) {
 			config: &Config{
 				Namespace: "test",
 				ConstLabels: map[string]string{
-					"foo":  "bar",
-					"code": "one",
+					"foo0":  "bar0",
+					"code0": "one0",
 				},
-				Endpoint: ":8999",
+				Endpoint:       ":8999",
+				SendTimestamps: false,
 			},
 		},
 		{
@@ -80,8 +81,8 @@ func TestPrometheusExporter_endToEnd(t *testing.T) {
 	config := &Config{
 		Namespace: "test",
 		ConstLabels: map[string]string{
-			"foo":  "bar",
-			"code": "one",
+			"foo1":  "bar1",
+			"code1": "one1",
 		},
 		Endpoint: ":7777",
 	}
@@ -93,6 +94,8 @@ func TestPrometheusExporter_endToEnd(t *testing.T) {
 
 	t.Cleanup(func() {
 		require.NoError(t, exp.Shutdown(context.Background()))
+		// trigger a get so that the server cleans up our keepalive socket
+		http.Get("http://localhost:7777/metrics")
 	})
 
 	assert.NotNil(t, exp)
@@ -112,8 +115,59 @@ func TestPrometheusExporter_endToEnd(t *testing.T) {
 		want := []string{
 			`# HELP test_this_one_there_where_ Extra ones`,
 			`# TYPE test_this_one_there_where_ counter`,
-			fmt.Sprintf(`test_this_one_there_where_{arch="x86",code="one",foo="bar",os="windows"} %v`, 99+delta),
-			fmt.Sprintf(`test_this_one_there_where_{arch="x86",code="one",foo="bar",os="linux"} %v`, 100+delta),
+			fmt.Sprintf(`test_this_one_there_where_{arch="x86",code1="one1",foo1="bar1",os="windows"} %v`, 99+delta),
+			fmt.Sprintf(`test_this_one_there_where_{arch="x86",code1="one1",foo1="bar1",os="linux"} %v`, 100+delta),
+		}
+
+		for _, w := range want {
+			if !strings.Contains(string(blob), w) {
+				t.Errorf("Missing %v from response:\n%v", w, string(blob))
+			}
+		}
+	}
+}
+
+func TestPrometheusExporter_endToEndWithTimestamps(t *testing.T) {
+	config := &Config{
+		Namespace: "test",
+		ConstLabels: map[string]string{
+			"foo2":  "bar2",
+			"code2": "one2",
+		},
+		Endpoint:       ":7777",
+		SendTimestamps: true,
+	}
+
+	factory := NewFactory()
+	creationParams := component.ExporterCreateParams{Logger: zap.NewNop()}
+	exp, err := factory.CreateMetricsExporter(context.Background(), creationParams, config)
+	assert.NoError(t, err)
+
+	t.Cleanup(func() {
+		require.NoError(t, exp.Shutdown(context.Background()))
+		// trigger a get so that the server cleans up our keepalive socket
+		http.Get("http://localhost:7777/metrics")
+	})
+
+	assert.NotNil(t, exp)
+
+	for delta := 0; delta <= 20; delta += 10 {
+		md := internaldata.OCToMetrics(consumerdata.MetricsData{Metrics: metricBuilder(int64(delta))})
+		assert.NoError(t, exp.ConsumeMetrics(context.Background(), md))
+
+		res, err := http.Get("http://localhost:7777/metrics")
+		require.NoError(t, err, "Failed to perform a scrape")
+
+		if g, w := res.StatusCode, 200; g != w {
+			t.Errorf("Mismatched HTTP response status code: Got: %d Want: %d", g, w)
+		}
+		blob, _ := ioutil.ReadAll(res.Body)
+		_ = res.Body.Close()
+		want := []string{
+			`# HELP test_this_one_there_where_ Extra ones`,
+			`# TYPE test_this_one_there_where_ counter`,
+			fmt.Sprintf(`test_this_one_there_where_{arch="x86",code2="one2",foo2="bar2",os="windows"} %v %v`, 99+delta, 1543160298100),
+			fmt.Sprintf(`test_this_one_there_where_{arch="x86",code2="one2",foo2="bar2",os="linux"} %v %v`, 100+delta, 1543160298100),
 		}
 
 		for _, w := range want {

--- a/exporter/prometheusexporter/testdata/config.yaml
+++ b/exporter/prometheusexporter/testdata/config.yaml
@@ -12,6 +12,7 @@ exporters:
     const_labels:
       label1: value1
       "another label": spaced value
+    send_timestamps: true
 
 service:
   pipelines:


### PR DESCRIPTION
**Description:**
Adds a `send_timestamps` option to the prometheus exporter to allow it to send scrape timestamps.

By default, when scraping, Prometheus records data assuming that the presented sample is at the instant of the scrape. For data sources that cache the underlying information and do not refresh on scrape, this can lead to metric samples being recorded at the wrong timestamp. For ex, cadvisor caches for many seconds (4-20 in our experience), and so a sample taken "now" may actually be a sample from 20s ago.

To handle this situation, the exposition format allows an exporter to advise the Prometheus server of the timestamp of the underlying scrape. OpenTelemetry is aware of the timestamp of the scrape.

This change adds an option to have OpenTelemetry send the timestamps of underlying samples out with the Prometheus exporter.

Visually, the image shows existing behavior prior to 9.45am and with `send_timestamps: true` set from 9.45am onwards. This is metrics for a job using a single CPU.
![image](https://user-images.githubusercontent.com/3196528/95892425-62fe5a00-0d3b-11eb-9023-af8e59652157.png)

**Related issues:**
https://github.com/google/cadvisor/issues/2526
https://github.com/orijtech/prometheus-go-metrics-exporter/pull/11

**Testing:**
Test cases have been added. In addition, for e2e test, see screenshot from our environment above.

**Documentation:**
The `prometheusexporter` README has been updated.
