### PR TITLE
Add initial implementation of the otlp HTTP exporter

### DIFF
--- a/exporter/otlphttpexporter/factory.go
+++ b/exporter/otlphttpexporter/factory.go
@@ -67,19 +67,13 @@ func createTraceExporter(
 		return nil, err
 	}
 	oCfg := cfg.(*Config)
-	oexp, err := exporterhelper.NewTraceExporter(
+	return exporterhelper.NewTraceExporter(
 		cfg,
 		oce.pushTraceData,
 		// explicitly disable since we rely on http.Client timeout logic.
 		exporterhelper.WithTimeout(exporterhelper.TimeoutSettings{Timeout: 0}),
 		exporterhelper.WithRetry(oCfg.RetrySettings),
-		exporterhelper.WithQueue(oCfg.QueueSettings),
-		exporterhelper.WithShutdown(oce.shutdown))
-	if err != nil {
-		return nil, err
-	}
-
-	return oexp, nil
+		exporterhelper.WithQueue(oCfg.QueueSettings))
 }
 
 func createMetricsExporter(
@@ -92,20 +86,13 @@ func createMetricsExporter(
 		return nil, err
 	}
 	oCfg := cfg.(*Config)
-	oexp, err := exporterhelper.NewMetricsExporter(
+	return exporterhelper.NewMetricsExporter(
 		cfg,
 		oce.pushMetricsData,
 		// explicitly disable since we rely on http.Client timeout logic.
 		exporterhelper.WithTimeout(exporterhelper.TimeoutSettings{Timeout: 0}),
 		exporterhelper.WithRetry(oCfg.RetrySettings),
-		exporterhelper.WithQueue(oCfg.QueueSettings),
-		exporterhelper.WithShutdown(oce.shutdown),
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	return oexp, nil
+		exporterhelper.WithQueue(oCfg.QueueSettings))
 }
 
 func createLogsExporter(
@@ -118,18 +105,11 @@ func createLogsExporter(
 		return nil, err
 	}
 	oCfg := cfg.(*Config)
-	oexp, err := exporterhelper.NewLogsExporter(
+	return exporterhelper.NewLogsExporter(
 		cfg,
 		oce.pushLogData,
 		// explicitly disable since we rely on http.Client timeout logic.
 		exporterhelper.WithTimeout(exporterhelper.TimeoutSettings{Timeout: 0}),
 		exporterhelper.WithRetry(oCfg.RetrySettings),
-		exporterhelper.WithQueue(oCfg.QueueSettings),
-		exporterhelper.WithShutdown(oce.shutdown),
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	return oexp, nil
+		exporterhelper.WithQueue(oCfg.QueueSettings))
 }

--- a/exporter/otlphttpexporter/factory_test.go
+++ b/exporter/otlphttpexporter/factory_test.go
@@ -122,7 +122,7 @@ func TestCreateTraceExporter(t *testing.T) {
 					},
 				},
 			},
-			mustFail: false, // TODO: change to true when error handling is implemented.
+			mustFail: true,
 		},
 	}
 
@@ -133,7 +133,7 @@ func TestCreateTraceExporter(t *testing.T) {
 			consumer, err := factory.CreateTraceExporter(context.Background(), creationParams, &tt.config)
 
 			if tt.mustFail {
-				assert.NotNil(t, err)
+				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
 				assert.NotNil(t, consumer)

--- a/exporter/otlphttpexporter/otlp.go
+++ b/exporter/otlphttpexporter/otlp.go
@@ -15,29 +15,21 @@
 package otlphttpexporter
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 
 	"go.opentelemetry.io/collector/config/configmodels"
+	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/consumer/pdata"
-	"go.opentelemetry.io/collector/internal"
-	otlplogs "go.opentelemetry.io/collector/internal/data/opentelemetry-proto-gen/collector/logs/v1"
-	otlpmetrics "go.opentelemetry.io/collector/internal/data/opentelemetry-proto-gen/collector/metrics/v1"
-	otlptrace "go.opentelemetry.io/collector/internal/data/opentelemetry-proto-gen/collector/trace/v1"
 )
 
 type exporterImp struct {
 	// Input configuration.
 	config *Config
-	w      sender
-}
-
-type sender interface {
-	exportTrace(ctx context.Context, request *otlptrace.ExportTraceServiceRequest) error
-	exportMetrics(ctx context.Context, request *otlpmetrics.ExportMetricsServiceRequest) error
-	exportLogs(ctx context.Context, request *otlplogs.ExportLogsServiceRequest) error
-	stop() error
+	client *http.Client
 }
 
 // Crete new exporter.
@@ -48,76 +40,77 @@ func newExporter(cfg configmodels.Exporter) (*exporterImp, error) {
 		return nil, errors.New("OTLP exporter config requires an Endpoint")
 	}
 
-	e := &exporterImp{}
-	e.config = oCfg
-	w, err := newHTTPSender(oCfg)
+	client, err := oCfg.HTTPClientSettings.ToClient()
 	if err != nil {
 		return nil, err
 	}
-	e.w = w
-	return e, nil
+
+	return &exporterImp{
+		config: oCfg,
+		client: client,
+	}, nil
 }
 
-func (e *exporterImp) shutdown(context.Context) error {
-	return e.w.stop()
-}
-
-func (e *exporterImp) pushTraceData(ctx context.Context, td pdata.Traces) (int, error) {
-	request := &otlptrace.ExportTraceServiceRequest{
-		ResourceSpans: pdata.TracesToOtlp(td),
-	}
-	err := e.w.exportTrace(ctx, request)
-
+func (e *exporterImp) pushTraceData(ctx context.Context, traces pdata.Traces) (int, error) {
+	request, err := traces.ToOtlpProtoBytes()
 	if err != nil {
-		return td.SpanCount(), fmt.Errorf("failed to push trace data via OTLP exporter: %w", err)
+		return traces.SpanCount(), consumererror.Permanent(err)
 	}
+
+	err = e.export(ctx, request)
+	if err != nil {
+		return traces.SpanCount(), err
+	}
+
 	return 0, nil
 }
 
-func (e *exporterImp) pushMetricsData(ctx context.Context, md pdata.Metrics) (int, error) {
-	request := &otlpmetrics.ExportMetricsServiceRequest{
-		ResourceMetrics: pdata.MetricsToOtlp(md),
-	}
-	err := e.w.exportMetrics(ctx, request)
-
+func (e *exporterImp) pushMetricsData(ctx context.Context, metrics pdata.Metrics) (int, error) {
+	request, err := metrics.ToOtlpProtoBytes()
 	if err != nil {
-		return md.MetricCount(), fmt.Errorf("failed to push metrics data via OTLP exporter: %w", err)
+		return metrics.MetricCount(), consumererror.Permanent(err)
 	}
+
+	err = e.export(ctx, request)
+	if err != nil {
+		return metrics.MetricCount(), err
+	}
+
 	return 0, nil
 }
 
 func (e *exporterImp) pushLogData(ctx context.Context, logs pdata.Logs) (int, error) {
-	request := &otlplogs.ExportLogsServiceRequest{
-		ResourceLogs: internal.LogsToOtlp(logs.InternalRep()),
-	}
-	err := e.w.exportLogs(ctx, request)
-
+	request, err := logs.ToOtlpProtoBytes()
 	if err != nil {
-		return logs.LogRecordCount(), fmt.Errorf("failed to push log data via OTLP exporter: %w", err)
+		return logs.LogRecordCount(), consumererror.Permanent(err)
 	}
+
+	err = e.export(ctx, request)
+	if err != nil {
+		return logs.LogRecordCount(), err
+	}
+
 	return 0, nil
 }
 
-type httpSender struct {
-}
+func (e *exporterImp) export(ctx context.Context, request []byte) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, e.config.Endpoint, bytes.NewReader(request))
+	if err != nil {
+		return consumererror.Permanent(err)
+	}
+	req.Header.Set("Content-Type", "application/x-protobuf")
 
-func newHTTPSender(config *Config) (sender, error) {
-	hs := &httpSender{}
-	return hs, nil
-}
+	resp, err := e.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to push trace data via OTLP exporter: %w", err)
+	}
 
-func (hs *httpSender) stop() error {
-	return nil
-}
+	_ = resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		// TODO: Parse status and decide if can or not retry.
+		// TODO: Parse status and decide throttling.
+		return fmt.Errorf("failed the request with status code %d", resp.StatusCode)
+	}
 
-func (hs *httpSender) exportTrace(ctx context.Context, request *otlptrace.ExportTraceServiceRequest) error {
-	return nil
-}
-
-func (hs *httpSender) exportMetrics(ctx context.Context, request *otlpmetrics.ExportMetricsServiceRequest) error {
-	return nil
-}
-
-func (hs *httpSender) exportLogs(ctx context.Context, request *otlplogs.ExportLogsServiceRequest) error {
 	return nil
 }

--- a/exporter/otlphttpexporter/otlp_test.go
+++ b/exporter/otlphttpexporter/otlp_test.go
@@ -14,4 +14,216 @@
 
 package otlphttpexporter
 
-// TODO: add exporter tests.
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/config/confighttp"
+	"go.opentelemetry.io/collector/config/configmodels"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/exporter/exportertest"
+	"go.opentelemetry.io/collector/internal/data/testdata"
+	"go.opentelemetry.io/collector/receiver/otlpreceiver"
+	"go.opentelemetry.io/collector/testutil"
+)
+
+// TODO: add tests for retryable/permanent errors logic.
+// TODO: add tests for throttling logic.
+
+func TestInvalidConfig(t *testing.T) {
+	config := &Config{
+		HTTPClientSettings: confighttp.HTTPClientSettings{
+			Endpoint: "",
+		},
+	}
+	f := NewFactory()
+	params := component.ExporterCreateParams{Logger: zap.NewNop()}
+	_, err := f.CreateTraceExporter(context.Background(), params, config)
+	require.Error(t, err)
+	_, err = f.CreateMetricsExporter(context.Background(), params, config)
+	require.Error(t, err)
+	_, err = f.CreateLogsExporter(context.Background(), params, config)
+	require.Error(t, err)
+}
+
+func TestTraceNoBackend(t *testing.T) {
+	addr := testutil.GetAvailableLocalAddress(t)
+	exp := startTraceExporter(t, fmt.Sprintf("http://%s/v1/trace", addr))
+	td := testdata.GenerateTraceDataOneSpan()
+	assert.Error(t, exp.ConsumeTraces(context.Background(), td))
+}
+
+func TestTraceInvalidUrl(t *testing.T) {
+	exp := startTraceExporter(t, "http:/\\//this_is_an/*/invalid_url")
+	td := testdata.GenerateTraceDataOneSpan()
+	assert.Error(t, exp.ConsumeTraces(context.Background(), td))
+}
+
+func TestTraceError(t *testing.T) {
+	addr := testutil.GetAvailableLocalAddress(t)
+
+	sink := new(exportertest.SinkTraceExporter)
+	sink.SetConsumeTraceError(errors.New("my_error"))
+	startTraceReceiver(t, addr, sink)
+	exp := startTraceExporter(t, fmt.Sprintf("http://%s/v1/trace", addr))
+
+	td := testdata.GenerateTraceDataOneSpan()
+	assert.Error(t, exp.ConsumeTraces(context.Background(), td))
+}
+
+func TestTraceRoundTrip(t *testing.T) {
+	addr := testutil.GetAvailableLocalAddress(t)
+
+	sink := new(exportertest.SinkTraceExporter)
+	startTraceReceiver(t, addr, sink)
+	exp := startTraceExporter(t, fmt.Sprintf("http://%s/v1/trace", addr))
+
+	td := testdata.GenerateTraceDataOneSpan()
+	assert.NoError(t, exp.ConsumeTraces(context.Background(), td))
+	require.Eventually(t, func() bool {
+		return sink.SpansCount() > 0
+	}, 1*time.Second, 10*time.Millisecond)
+	allTraces := sink.AllTraces()
+	require.Len(t, allTraces, 1)
+	assert.EqualValues(t, td, allTraces[0])
+}
+
+func TestMetricsError(t *testing.T) {
+	addr := testutil.GetAvailableLocalAddress(t)
+
+	sink := new(exportertest.SinkMetricsExporter)
+	sink.SetConsumeMetricsError(errors.New("my_error"))
+	startMetricsReceiver(t, addr, sink)
+	exp := startMetricsExporter(t, fmt.Sprintf("http://%s/v1/metrics", addr))
+
+	md := testdata.GenerateMetricsOneMetric()
+	assert.Error(t, exp.ConsumeMetrics(context.Background(), md))
+}
+
+func TestMetricsRoundTrip(t *testing.T) {
+	addr := testutil.GetAvailableLocalAddress(t)
+
+	sink := new(exportertest.SinkMetricsExporter)
+	startMetricsReceiver(t, addr, sink)
+	exp := startMetricsExporter(t, fmt.Sprintf("http://%s/v1/metrics", addr))
+
+	md := testdata.GenerateMetricsOneMetric()
+	assert.NoError(t, exp.ConsumeMetrics(context.Background(), md))
+	require.Eventually(t, func() bool {
+		return sink.MetricsCount() > 0
+	}, 1*time.Second, 10*time.Millisecond)
+	allMetrics := sink.AllMetrics()
+	require.Len(t, allMetrics, 1)
+	assert.EqualValues(t, md, allMetrics[0])
+}
+
+func TestLogsError(t *testing.T) {
+	addr := testutil.GetAvailableLocalAddress(t)
+
+	sink := new(exportertest.SinkLogsExporter)
+	sink.SetConsumeLogError(errors.New("my_error"))
+	startLogsReceiver(t, addr, sink)
+	exp := startLogsExporter(t, fmt.Sprintf("http://%s/v1/logs", addr))
+
+	md := testdata.GenerateLogDataOneLog()
+	assert.Error(t, exp.ConsumeLogs(context.Background(), md))
+}
+
+func TestLogsRoundTrip(t *testing.T) {
+	addr := testutil.GetAvailableLocalAddress(t)
+
+	sink := new(exportertest.SinkLogsExporter)
+	startLogsReceiver(t, addr, sink)
+	exp := startLogsExporter(t, fmt.Sprintf("http://%s/v1/logs", addr))
+
+	md := testdata.GenerateLogDataOneLog()
+	assert.NoError(t, exp.ConsumeLogs(context.Background(), md))
+	require.Eventually(t, func() bool {
+		return sink.LogRecordsCount() > 0
+	}, 1*time.Second, 10*time.Millisecond)
+	allLogs := sink.AllLogs()
+	require.Len(t, allLogs, 1)
+	assert.EqualValues(t, md, allLogs[0])
+}
+
+func startTraceExporter(t *testing.T, addr string) component.TraceExporter {
+	factory := NewFactory()
+	cfg := createExporterConfig(addr, factory.CreateDefaultConfig())
+	exp, err := factory.CreateTraceExporter(context.Background(), component.ExporterCreateParams{Logger: zap.NewNop()}, cfg)
+	require.NoError(t, err)
+	startAndCleanup(t, exp)
+	return exp
+}
+
+func startMetricsExporter(t *testing.T, addr string) component.MetricsExporter {
+	factory := NewFactory()
+	cfg := createExporterConfig(addr, factory.CreateDefaultConfig())
+	exp, err := factory.CreateMetricsExporter(context.Background(), component.ExporterCreateParams{Logger: zap.NewNop()}, cfg)
+	require.NoError(t, err)
+	startAndCleanup(t, exp)
+	return exp
+}
+
+func startLogsExporter(t *testing.T, addr string) component.LogsExporter {
+	factory := NewFactory()
+	cfg := createExporterConfig(addr, factory.CreateDefaultConfig())
+	exp, err := factory.CreateLogsExporter(context.Background(), component.ExporterCreateParams{Logger: zap.NewNop()}, cfg)
+	require.NoError(t, err)
+	startAndCleanup(t, exp)
+	return exp
+}
+
+func createExporterConfig(addr string, defaultCfg configmodels.Exporter) *Config {
+	cfg := defaultCfg.(*Config)
+	cfg.Endpoint = addr
+	cfg.QueueSettings.Enabled = false
+	cfg.RetrySettings.Enabled = false
+	return cfg
+}
+
+func startTraceReceiver(t *testing.T, addr string, next consumer.TraceConsumer) {
+	factory := otlpreceiver.NewFactory()
+	cfg := createReceiverConfig(addr, factory.CreateDefaultConfig())
+	recv, err := factory.CreateTraceReceiver(context.Background(), component.ReceiverCreateParams{Logger: zap.NewNop()}, cfg, next)
+	require.NoError(t, err)
+	startAndCleanup(t, recv)
+}
+
+func startMetricsReceiver(t *testing.T, addr string, next consumer.MetricsConsumer) {
+	factory := otlpreceiver.NewFactory()
+	cfg := createReceiverConfig(addr, factory.CreateDefaultConfig())
+	recv, err := factory.CreateMetricsReceiver(context.Background(), component.ReceiverCreateParams{Logger: zap.NewNop()}, cfg, next)
+	require.NoError(t, err)
+	startAndCleanup(t, recv)
+}
+
+func startLogsReceiver(t *testing.T, addr string, next consumer.LogsConsumer) {
+	factory := otlpreceiver.NewFactory()
+	cfg := createReceiverConfig(addr, factory.CreateDefaultConfig())
+	recv, err := factory.CreateLogsReceiver(context.Background(), component.ReceiverCreateParams{Logger: zap.NewNop()}, cfg, next)
+	require.NoError(t, err)
+	startAndCleanup(t, recv)
+}
+
+func createReceiverConfig(addr string, defaultCfg configmodels.Exporter) *otlpreceiver.Config {
+	cfg := defaultCfg.(*otlpreceiver.Config)
+	cfg.HTTP.Endpoint = addr
+	cfg.GRPC = nil
+	return cfg
+}
+
+func startAndCleanup(t *testing.T, cmp component.Component) {
+	require.NoError(t, cmp.Start(context.Background(), componenttest.NewNopHost()))
+	t.Cleanup(func() {
+		require.NoError(t, cmp.Shutdown(context.Background()))
+	})
+}


### PR DESCRIPTION
Some TODOs left:
- Parse status and decide if can or not retry.
- Parse status and decide throttling.
- Add tests for both of these.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
