### PR TITLE
Fix trace jaeger conversion to internal traces zero time bug

### DIFF
--- a/consumer/pdata/timestamp.go
+++ b/consumer/pdata/timestamp.go
@@ -42,3 +42,10 @@ func UnixNanoToTime(u TimestampUnixNano) time.Time {
 	}
 	return time.Unix(0, int64(u)).UTC()
 }
+
+func TimeToUnixNano(t time.Time) TimestampUnixNano {
+	if t.IsZero() {
+		return 0
+	}
+	return TimestampUnixNano(uint64(t.UnixNano()))
+}

--- a/consumer/pdata/timestamp.go
+++ b/consumer/pdata/timestamp.go
@@ -44,6 +44,7 @@ func UnixNanoToTime(u TimestampUnixNano) time.Time {
 }
 
 func TimeToUnixNano(t time.Time) TimestampUnixNano {
+	// 0 is a special case and want to make sure we return zero timestamp to support inverse function for UnixNanoToTime
 	if t.IsZero() {
 		return 0
 	}

--- a/consumer/pdata/timestamp_test.go
+++ b/consumer/pdata/timestamp_test.go
@@ -31,6 +31,7 @@ func TestUnixNanosConverters(t *testing.T) {
 	assert.EqualValues(t, &timestamppb.Timestamp{Seconds: 1585012403, Nanos: 789}, tp)
 	assert.EqualValues(t, tun, TimestampToUnixNano(tp))
 	assert.EqualValues(t, tun, TimeToUnixNano(t1))
+	assert.EqualValues(t, t1, UnixNanoToTime(TimeToUnixNano(t1)))
 }
 
 func TestZeroTimestamps(t *testing.T) {

--- a/consumer/pdata/timestamp_test.go
+++ b/consumer/pdata/timestamp_test.go
@@ -30,10 +30,12 @@ func TestUnixNanosConverters(t *testing.T) {
 	tp := UnixNanoToTimestamp(tun)
 	assert.EqualValues(t, &timestamppb.Timestamp{Seconds: 1585012403, Nanos: 789}, tp)
 	assert.EqualValues(t, tun, TimestampToUnixNano(tp))
+	assert.EqualValues(t, tun, TimeToUnixNano(t1))
 }
 
 func TestZeroTimestamps(t *testing.T) {
 	assert.Zero(t, TimestampToUnixNano(nil))
 	assert.Nil(t, UnixNanoToTimestamp(0))
 	assert.True(t, UnixNanoToTime(0).IsZero())
+	assert.Zero(t, TimeToUnixNano(time.Time{}))
 }

--- a/translator/trace/jaeger/jaegerproto_to_traces.go
+++ b/translator/trace/jaeger/jaegerproto_to_traces.go
@@ -180,12 +180,8 @@ func jSpanToInternal(span *model.Span) (pdata.Span, instrumentationLibrary) {
 	dest.SetTraceID(tracetranslator.UInt64ToTraceID(span.TraceID.High, span.TraceID.Low))
 	dest.SetSpanID(tracetranslator.UInt64ToSpanID(uint64(span.SpanID)))
 	dest.SetName(span.OperationName)
-	if span.StartTime != zeroTime {
-		dest.SetStartTime(pdata.TimestampUnixNano(uint64(span.StartTime.UnixNano())))
-	}
-	if endTime := span.StartTime.Add(span.Duration); endTime != zeroTime {
-		dest.SetEndTime(pdata.TimestampUnixNano(uint64(endTime.UnixNano())))
-	}
+	dest.SetStartTime(pdata.TimeToUnixNano(span.StartTime))
+	dest.SetEndTime(pdata.TimeToUnixNano(span.StartTime.Add(span.Duration)))
 
 	parentSpanID := span.ParentSpanID()
 	if parentSpanID != model.SpanID(0) {

--- a/translator/trace/jaeger/jaegerproto_to_traces.go
+++ b/translator/trace/jaeger/jaegerproto_to_traces.go
@@ -20,7 +20,6 @@ import (
 	"math"
 	"reflect"
 	"strconv"
-	"time"
 
 	"github.com/jaegertracing/jaeger/model"
 	"github.com/jaegertracing/jaeger/thrift-gen/jaeger"
@@ -30,11 +29,7 @@ import (
 	tracetranslator "go.opentelemetry.io/collector/translator/trace"
 )
 
-var (
-	blankJaegerProtoSpan = new(jaeger.Span)
-
-	zeroTime = time.Time{}
-)
+var blankJaegerProtoSpan = new(jaeger.Span)
 
 // ProtoBatchesToInternalTraces converts multiple Jaeger proto batches to internal traces
 func ProtoBatchesToInternalTraces(batches []*model.Batch) pdata.Traces {


### PR DESCRIPTION
**Description:**
Fixing a bug. When spans are converted from internal trace to jaeger trace the conversion is `zero timestamp -> time.Time{}` which is a reserved date.  When converted back, this date is interpreted as a usual one, so `ProtoBatchesToInternalTraces(InternalTracesToJaegerProto(traces)) != traces`. So I added a check on this one