### PR TITLE
Enable memory ballast extension, update service to not create ballast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,16 @@
 
 ## Unreleased
 
+## 🚀 New components 🚀
+
+- Add memory ballast extension (#1958, #1959) 
+
 ## 🛑 Breaking changes 🛑
 
 - Use consumer for sender interface, remove unnecessary receiver address from Runner #1941
 - Enable sending queue by default in all exporters configured to use it #1924
+- Remove "mem-ballast-size-mib" flag, memory ballast can be configured as an extension.
+- Internal memory metric "process/runtime/heap_alloc_bytes", "process/runtime/total_alloc_bytes", and "process/runtime/total_sys_memory_bytes" no longer ignore memory ballast.
 
 ## 🧰 Bug fixes 🧰
 

--- a/extension/ballastextension/README.md
+++ b/extension/ballastextension/README.md
@@ -1,0 +1,16 @@
+# Health Check
+
+Memory Ballast extension enables applications to configure memory ballast for the process. For more details see:
+- [Go memory ballast blogpost](https://blog.twitch.tv/go-memory-ballast-how-i-learnt-to-stop-worrying-and-love-the-heap-26c2462549a2)
+- [Golang issue related to this](https://github.com/golang/go/issues/23044)
+
+The following settings can be configured:
+
+- `ballast_size_mib` (default = 0, disabled): Is the memory ballast size, in MiB.
+
+Example:
+
+```yaml
+extensions:
+  memory_ballast:
+```

--- a/extension/ballastextension/config.go
+++ b/extension/ballastextension/config.go
@@ -1,0 +1,28 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ballastextension
+
+import (
+	"go.opentelemetry.io/collector/config/configmodels"
+)
+
+// Config has the configuration for the fluentbit extension.
+type Config struct {
+	configmodels.ExtensionSettings `mapstructure:",squash"`
+
+	// BallastSizeMiB is the size, in MiB, of the memory ballast
+	// to be created for this process.
+	BallastSizeMiB uint32 `mapstructure:"ballast_size_mib"`
+}

--- a/extension/ballastextension/config_test.go
+++ b/extension/ballastextension/config_test.go
@@ -1,0 +1,56 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ballastextension
+
+import (
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/config/configmodels"
+	"go.opentelemetry.io/collector/config/configtest"
+)
+
+func TestLoadConfig(t *testing.T) {
+	factories, err := componenttest.ExampleComponents()
+	assert.NoError(t, err)
+
+	factory := NewFactory()
+	factories.Extensions[typeStr] = factory
+	cfg, err := configtest.LoadConfigFile(t, path.Join(".", "testdata", "config.yaml"), factories)
+
+	require.Nil(t, err)
+	require.NotNil(t, cfg)
+
+	ext0 := cfg.Extensions["memory_ballast"]
+	assert.Equal(t, factory.CreateDefaultConfig(), ext0)
+
+	ext1 := cfg.Extensions["memory_ballast/1"]
+	assert.Equal(t,
+		&Config{
+			ExtensionSettings: configmodels.ExtensionSettings{
+				TypeVal: "memory_ballast",
+				NameVal: "memory_ballast/1",
+			},
+			BallastSizeMiB: 123,
+		},
+		ext1)
+
+	assert.Equal(t, 1, len(cfg.Service.Extensions))
+	assert.Equal(t, "memory_ballast/1", cfg.Service.Extensions[0])
+}

--- a/extension/ballastextension/factory.go
+++ b/extension/ballastextension/factory.go
@@ -1,0 +1,50 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ballastextension
+
+import (
+	"context"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config/configmodels"
+	"go.opentelemetry.io/collector/extension/extensionhelper"
+)
+
+const (
+	// The value of extension "type" in configuration.
+	typeStr = "memory_ballast"
+)
+
+// NewFactory creates a factory for FluentBit extension.
+func NewFactory() component.ExtensionFactory {
+	return extensionhelper.NewFactory(
+		typeStr,
+		createDefaultConfig,
+		createExtension)
+}
+
+func createDefaultConfig() configmodels.Extension {
+	return &Config{
+		ExtensionSettings: configmodels.ExtensionSettings{
+			TypeVal: typeStr,
+			NameVal: typeStr,
+		},
+	}
+}
+
+func createExtension(_ context.Context, _ component.ExtensionCreateParams, cfg configmodels.Extension) (component.ServiceExtension, error) {
+	config := cfg.(*Config)
+	return newMemoryBallast(config), nil
+}

--- a/extension/ballastextension/factory.go
+++ b/extension/ballastextension/factory.go
@@ -44,7 +44,7 @@ func createDefaultConfig() configmodels.Extension {
 	}
 }
 
-func createExtension(_ context.Context, _ component.ExtensionCreateParams, cfg configmodels.Extension) (component.ServiceExtension, error) {
+func createExtension(_ context.Context, params component.ExtensionCreateParams, cfg configmodels.Extension) (component.ServiceExtension, error) {
 	config := cfg.(*Config)
-	return newMemoryBallast(config), nil
+	return newMemoryBallast(config, params.Logger), nil
 }

--- a/extension/ballastextension/factory_test.go
+++ b/extension/ballastextension/factory_test.go
@@ -1,0 +1,51 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ballastextension
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config/configcheck"
+	"go.opentelemetry.io/collector/config/configmodels"
+)
+
+func TestFactory_CreateDefaultConfig(t *testing.T) {
+	cfg := createDefaultConfig()
+	assert.Equal(t, &Config{
+		ExtensionSettings: configmodels.ExtensionSettings{
+			NameVal: typeStr,
+			TypeVal: typeStr,
+		},
+	},
+		cfg)
+
+	assert.NoError(t, configcheck.ValidateConfig(cfg))
+	ext, err := createExtension(context.Background(), component.ExtensionCreateParams{Logger: zap.NewNop()}, cfg)
+	require.NoError(t, err)
+	require.NotNil(t, ext)
+}
+
+func TestFactory_CreateExtension(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	ext, err := createExtension(context.Background(), component.ExtensionCreateParams{Logger: zap.NewNop()}, cfg)
+	require.NoError(t, err)
+	require.NotNil(t, ext)
+}

--- a/extension/ballastextension/memory_ballast.go
+++ b/extension/ballastextension/memory_ballast.go
@@ -1,3 +1,17 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package ballastextension
 
 import (

--- a/extension/ballastextension/memory_ballast.go
+++ b/extension/ballastextension/memory_ballast.go
@@ -1,0 +1,22 @@
+package ballastextension
+
+import (
+	"context"
+
+	"go.opentelemetry.io/collector/component"
+)
+
+type memoryBallast struct {
+}
+
+func (m memoryBallast) Start(_ context.Context, _ component.Host) error {
+	return nil
+}
+
+func (m memoryBallast) Shutdown(_ context.Context) error {
+	return nil
+}
+
+func newMemoryBallast(_ *Config) *memoryBallast {
+	return &memoryBallast{}
+}

--- a/extension/ballastextension/memory_ballast_test.go
+++ b/extension/ballastextension/memory_ballast_test.go
@@ -1,0 +1,56 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ballastextension
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"go.opentelemetry.io/collector/component/componenttest"
+)
+
+func TestMemoryBallast(t *testing.T) {
+	config := &Config{
+		BallastSizeMiB: 13,
+	}
+
+	mbExt := newMemoryBallast(config, zap.NewNop())
+	require.NotNil(t, mbExt)
+	assert.Nil(t, mbExt.ballast)
+
+	assert.NoError(t, mbExt.Start(context.Background(), componenttest.NewNopHost()))
+	assert.Equal(t, 13*megaBytes, len(mbExt.ballast))
+
+	assert.NoError(t, mbExt.Shutdown(context.Background()))
+	assert.Nil(t, mbExt.ballast)
+}
+
+func TestMemoryBallast_ZeroSize(t *testing.T) {
+	config := &Config{}
+
+	mbExt := newMemoryBallast(config, zap.NewNop())
+	require.NotNil(t, mbExt)
+	assert.Nil(t, mbExt.ballast)
+
+	assert.NoError(t, mbExt.Start(context.Background(), componenttest.NewNopHost()))
+	assert.Nil(t, mbExt.ballast)
+
+	assert.NoError(t, mbExt.Shutdown(context.Background()))
+	assert.Nil(t, mbExt.ballast)
+}

--- a/extension/ballastextension/testdata/config.yaml
+++ b/extension/ballastextension/testdata/config.yaml
@@ -1,0 +1,20 @@
+extensions:
+  memory_ballast:
+  memory_ballast/1:
+    ballast_size_mib: 123
+
+service:
+  extensions: [memory_ballast/1]
+  pipelines:
+    traces:
+      receivers: [examplereceiver]
+      processors: [exampleprocessor]
+      exporters: [exampleexporter]
+
+# Data pipeline is required to load the config.
+receivers:
+  examplereceiver:
+processors:
+  exampleprocessor:
+exporters:
+  exampleexporter:

--- a/service/builder/builder.go
+++ b/service/builder/builder.go
@@ -16,13 +16,11 @@ package builder
 
 import (
 	"flag"
-	"fmt"
 )
 
 const (
 	// flags
-	configCfg      = "config"
-	memBallastFlag = "mem-ballast-size-mib"
+	configCfg = "config"
 
 	kindLogKey        = "component_kind"
 	kindLogsReceiver  = "receiver"
@@ -34,24 +32,15 @@ const (
 )
 
 var (
-	configFile     *string
-	memBallastSize *uint
+	configFile *string
 )
 
 // Flags adds flags related to basic building of the collector application to the given flagset.
 func Flags(flags *flag.FlagSet) {
 	configFile = flags.String(configCfg, "", "Path to the config file")
-	memBallastSize = flags.Uint(memBallastFlag, 0,
-		fmt.Sprintf("Flag to specify size of memory (MiB) ballast to set. Ballast is not used when this is not specified. "+
-			"default settings: 0"))
 }
 
 // GetConfigFile gets the config file from the config file flag.
 func GetConfigFile() string {
 	return *configFile
-}
-
-// MemBallastSize returns the size of memory ballast to use in MBs
-func MemBallastSize() int {
-	return int(*memBallastSize)
 }

--- a/service/defaultcomponents/defaults.go
+++ b/service/defaultcomponents/defaults.go
@@ -27,6 +27,7 @@ import (
 	"go.opentelemetry.io/collector/exporter/prometheusexporter"
 	"go.opentelemetry.io/collector/exporter/prometheusremotewriteexporter"
 	"go.opentelemetry.io/collector/exporter/zipkinexporter"
+	"go.opentelemetry.io/collector/extension/ballastextension"
 	"go.opentelemetry.io/collector/extension/fluentbitextension"
 	"go.opentelemetry.io/collector/extension/healthcheckextension"
 	"go.opentelemetry.io/collector/extension/pprofextension"
@@ -59,10 +60,11 @@ func Components() (
 	var errs []error
 
 	extensions, err := component.MakeExtensionFactoryMap(
+		ballastextension.NewFactory(),
+		fluentbitextension.NewFactory(),
 		healthcheckextension.NewFactory(),
 		pprofextension.NewFactory(),
 		zpagesextension.NewFactory(),
-		fluentbitextension.NewFactory(),
 	)
 	if err != nil {
 		errs = append(errs, err)

--- a/service/defaultcomponents/defaults_test.go
+++ b/service/defaultcomponents/defaults_test.go
@@ -27,10 +27,11 @@ import (
 
 func TestDefaultComponents(t *testing.T) {
 	expectedExtensions := []configmodels.Type{
+		"fluentbit",
 		"health_check",
+		"memory_ballast",
 		"pprof",
 		"zpages",
-		"fluentbit",
 	}
 	expectedReceivers := []configmodels.Type{
 		"jaeger",

--- a/service/internal/telemetry/process_telemetry.go
+++ b/service/internal/telemetry/process_telemetry.go
@@ -108,6 +108,7 @@ var viewRSSMemory = &view.View{
 
 // NewProcessMetricsViews creates a new set of ProcessMetrics (mem, cpu) that can be used to measure
 // basic information about this process.
+// TODO: Remove ballast, these metric should not deal with the ballast.
 func NewProcessMetricsViews(ballastSizeBytes uint64) (*ProcessMetricsViews, error) {
 	pmv := &ProcessMetricsViews{
 		prevTimeUnixNano: time.Now().UnixNano(),


### PR DESCRIPTION
Breaking Changes:
- Remove "mem-ballast-size-mib" flag, memory ballast can be configured as an extension.
- Internal memory metric "process/runtime/heap_alloc_bytes", "process/runtime/total_alloc_bytes", and "process/runtime/total_sys_memory_bytes" no longer ignore memory ballast.

Depends on #1959 