### PR TITLE
Add obsreport to receiverhelper scrapers

### DIFF
--- a/consumer/consumererror/partialscrapeerror.go
+++ b/consumer/consumererror/partialscrapeerror.go
@@ -1,0 +1,43 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package consumererror
+
+import "errors"
+
+// PartialScrapeError can be used to signalize that a subset of metrics were failed
+// to be scraped
+type PartialScrapeError struct {
+	error
+	Failed int
+}
+
+// NewPartialScrapeError creates PartialScrapeError for failed metrics.
+// Use this error type only when a subset of data was failed to be scraped.
+func NewPartialScrapeError(err error, failed int) error {
+	return PartialScrapeError{
+		error:  err,
+		Failed: failed,
+	}
+}
+
+// IsPartialScrapeError checks if an error was wrapped with PartialScrapeError.
+func IsPartialScrapeError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	var partialScrapeErr PartialScrapeError
+	return errors.As(err, &partialScrapeErr)
+}

--- a/consumer/consumererror/partialscrapeerror_test.go
+++ b/consumer/consumererror/partialscrapeerror_test.go
@@ -1,0 +1,40 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package consumererror
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPartialScrapeError(t *testing.T) {
+	failed := 2
+	err := fmt.Errorf("some error")
+	partialErr := NewPartialScrapeError(err, failed)
+	assert.Equal(t, err.Error(), partialErr.Error())
+	assert.Equal(t, failed, partialErr.(PartialScrapeError).Failed)
+}
+
+func TestIsPartialScrapeError(t *testing.T) {
+	err := errors.New("testError")
+	require.False(t, IsPartialScrapeError(err))
+
+	err = NewPartialScrapeError(err, 2)
+	require.True(t, IsPartialScrapeError(err))
+}

--- a/obsreport/obsreport.go
+++ b/obsreport/obsreport.go
@@ -121,6 +121,14 @@ func AllViews() (views []*view.View) {
 	}
 	views = append(views, genViews(measures, tagKeys, view.Sum())...)
 
+	// Scraper views.
+	measures = []*stats.Int64Measure{
+		mScraperScrapedMetricPoints,
+		mScraperErroredMetricPoints,
+	}
+	tagKeys = []tag.Key{tagKeyReceiver, tagKeyScraper}
+	views = append(views, genViews(measures, tagKeys, view.Sum())...)
+
 	// Exporter views.
 	measures = []*stats.Int64Measure{
 		mExporterSentSpans,

--- a/obsreport/obsreport_scraper.go
+++ b/obsreport/obsreport_scraper.go
@@ -1,0 +1,131 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package obsreport
+
+import (
+	"context"
+
+	"go.opencensus.io/stats"
+	"go.opencensus.io/tag"
+	"go.opencensus.io/trace"
+
+	"go.opentelemetry.io/collector/config/configmodels"
+	"go.opentelemetry.io/collector/consumer/consumererror"
+)
+
+const (
+	// ScraperKey used to identify scrapers in metrics and traces.
+	ScraperKey = "scraper"
+
+	// ScrapedMetricPointsKey used to identify metric points scraped by the
+	// Collector.
+	ScrapedMetricPointsKey = "scraped_metric_points"
+	// ErroredMetricPointsKey used to identify metric points errored (i.e.
+	// unable to be scraped) by the Collector.
+	ErroredMetricPointsKey = "errored_metric_points"
+)
+
+const (
+	scraperPrefix                 = ScraperKey + nameSep
+	scraperMetricsOperationSuffix = nameSep + "MetricsScraped"
+)
+
+var (
+	tagKeyScraper, _ = tag.NewKey(ScraperKey)
+
+	mScraperScrapedMetricPoints = stats.Int64(
+		scraperPrefix+ScrapedMetricPointsKey,
+		"Number of metric points successfully scraped.",
+		stats.UnitDimensionless)
+	mScraperErroredMetricPoints = stats.Int64(
+		scraperPrefix+ErroredMetricPointsKey,
+		"Number of metric points that were unable to be scraped.",
+		stats.UnitDimensionless)
+)
+
+// ScraperContext adds the keys used when recording observability metrics to
+// the given context returning the newly created context. This context should
+// be used in related calls to the obsreport functions so metrics are properly
+// recorded.
+func ScraperContext(
+	ctx context.Context,
+	receiver string,
+	scraper string,
+) context.Context {
+	ctx, _ = tag.New(ctx, tag.Upsert(tagKeyReceiver, receiver, tag.WithTTL(tag.TTLNoPropagation)))
+	if scraper != "" {
+		ctx, _ = tag.New(ctx, tag.Upsert(tagKeyScraper, scraper, tag.WithTTL(tag.TTLNoPropagation)))
+	}
+
+	return ctx
+}
+
+// StartMetricsScrapeOp is called when a scrape operation is started. The
+// returned context should be used in other calls to the obsreport functions
+// dealing with the same scrape operation.
+func StartMetricsScrapeOp(
+	scraperCtx context.Context,
+	receiver string,
+	scraper string,
+) context.Context {
+	scraperName := receiver
+	if scraper != "" {
+		scraperName += "/" + scraper
+	}
+
+	spanName := scraperPrefix + scraperName + scraperMetricsOperationSuffix
+	ctx, _ := trace.StartSpan(scraperCtx, spanName)
+	return ctx
+}
+
+// EndMetricsScrapeOp completes the scrape operation that was started with
+// StartMetricsScrapeOp.
+func EndMetricsScrapeOp(
+	scraperCtx context.Context,
+	numScrapedMetrics int,
+	err error,
+) {
+	numErroredMetrics := 0
+	if err != nil {
+		if partialErr, isPartial := err.(consumererror.PartialScrapeError); isPartial {
+			numErroredMetrics = partialErr.Failed
+		} else {
+			numErroredMetrics = numScrapedMetrics
+			numScrapedMetrics = 0
+		}
+	}
+
+	span := trace.FromContext(scraperCtx)
+
+	if useNew {
+		stats.Record(
+			scraperCtx,
+			mScraperScrapedMetricPoints.M(int64(numScrapedMetrics)),
+			mScraperErroredMetricPoints.M(int64(numErroredMetrics)))
+	}
+
+	// end span according to errors
+	if span.IsRecordingEvents() {
+		span.AddAttributes(
+			trace.StringAttribute(FormatKey, string(configmodels.MetricsDataType)),
+			trace.Int64Attribute(ScrapedMetricPointsKey, int64(numScrapedMetrics)),
+			trace.Int64Attribute(ErroredMetricPointsKey, int64(numErroredMetrics)),
+		)
+
+		span.SetStatus(errToStatus(err))
+	}
+
+	span.End()
+}

--- a/receiver/receiverhelper/errors.go
+++ b/receiver/receiverhelper/errors.go
@@ -1,0 +1,53 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package receiverhelper
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"go.opentelemetry.io/collector/component/componenterror"
+	"go.opentelemetry.io/collector/consumer/consumererror"
+)
+
+// CombineScrapeErrors converts a list of errors into one error.
+func CombineScrapeErrors(errs []error) error {
+	partialScrapeErr := false
+	for _, err := range errs {
+		var partialError consumererror.PartialScrapeError
+		if errors.As(err, &partialError) {
+			partialScrapeErr = true
+			break
+		}
+	}
+
+	if !partialScrapeErr {
+		return componenterror.CombineErrors(errs)
+	}
+
+	errMsgs := make([]string, 0, len(errs))
+	failedScrapeCount := 0
+	for _, err := range errs {
+		if partialError, isPartial := err.(consumererror.PartialScrapeError); isPartial {
+			failedScrapeCount += partialError.Failed
+		}
+
+		errMsgs = append(errMsgs, err.Error())
+	}
+
+	err := fmt.Errorf("[%s]", strings.Join(errMsgs, "; "))
+	return consumererror.NewPartialScrapeError(err, failedScrapeCount)
+}

--- a/receiver/receiverhelper/errors_test.go
+++ b/receiver/receiverhelper/errors_test.go
@@ -1,0 +1,88 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package receiverhelper
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"go.opentelemetry.io/collector/consumer/consumererror"
+)
+
+func TestCombineScrapeErrors(t *testing.T) {
+	testCases := []struct {
+		errors                    []error
+		expected                  string
+		expectNil                 bool
+		expectedPartialScrapeErr  bool
+		expectedFailedScrapeCount int
+	}{
+		{
+			errors:    []error{},
+			expectNil: true,
+		},
+		{
+			errors: []error{
+				fmt.Errorf("foo"),
+			},
+			expected: "foo",
+		},
+		{
+			errors: []error{
+				fmt.Errorf("foo"),
+				fmt.Errorf("bar"),
+			},
+			expected: "[foo; bar]",
+		},
+		{
+			errors: []error{
+				fmt.Errorf("foo"),
+				fmt.Errorf("bar"),
+				consumererror.NewPartialScrapeError(fmt.Errorf("partial"), 0)},
+			expected:                  "[foo; bar; partial]",
+			expectedPartialScrapeErr:  true,
+			expectedFailedScrapeCount: 0,
+		},
+		{
+			errors: []error{
+				fmt.Errorf("foo"),
+				fmt.Errorf("bar"),
+				consumererror.NewPartialScrapeError(fmt.Errorf("partial 1"), 2),
+				consumererror.NewPartialScrapeError(fmt.Errorf("partial 2"), 3)},
+			expected:                  "[foo; bar; partial 1; partial 2]",
+			expectedPartialScrapeErr:  true,
+			expectedFailedScrapeCount: 5,
+		},
+	}
+
+	for _, tc := range testCases {
+		got := CombineScrapeErrors(tc.errors)
+
+		if tc.expectNil {
+			assert.NoError(t, got, tc.expected)
+		} else {
+			assert.EqualError(t, got, tc.expected)
+		}
+
+		partialErr, isPartial := got.(consumererror.PartialScrapeError)
+		assert.Equal(t, tc.expectedPartialScrapeErr, isPartial)
+
+		if tc.expectedPartialScrapeErr && isPartial {
+			assert.Equal(t, tc.expectedFailedScrapeCount, partialErr.Failed)
+		}
+	}
+}


### PR DESCRIPTION
Add obsreport to receiverhelper scraper library

- Added `consumererror.PartialScrapeError` for denoting that a scrape was partially successful and recording the number of metrics that failed to be scraped
- Add `receiverhelper.CombineScrapeErrors` to support combining partial scrape errors
- Updated `obsreport` with Trace & Metric observability support for Scrapers. Obsreport records the number of failed scrapes based on the partial scrape error count if relevant
- Call obsreport in the receiverhelper scraper library 🎉 

**Blocks #1949**

---

**Sample Output:** (see #1949)

_Note in these examples we see quite a lot of errors scraping process data due to not running the Collector in "Administrative mode" on Windows:_

**Traces (from http://localhost:55679/debug/tracez?zspanname=scraper%2fprocess%2fMetricsScraped&ztype=2&zsubtype=0):**

![image](https://user-images.githubusercontent.com/568630/97541040-9833c900-1a18-11eb-80eb-6f1039756622.png)

**Metrics (from http://localhost:8888/metrics):**

![image](https://user-images.githubusercontent.com/568630/97546486-9cfc7b00-1a20-11eb-9118-65ac8930ca6f.png)