### PR TITLE
Fix panic in otlp traces to zipkin

### DIFF
--- a/translator/trace/zipkin/traces_to_zipkinv2.go
+++ b/translator/trace/zipkin/traces_to_zipkinv2.go
@@ -78,11 +78,15 @@ func resourceSpansToZipkinSpans(rs pdata.ResourceSpans, estSpanCount int) ([]*zi
 		extractInstrumentationLibraryTags(ils.InstrumentationLibrary(), zTags)
 		spans := ils.Spans()
 		for j := 0; j < spans.Len(); j++ {
-			span, err := spanToZipkinSpan(spans.At(j), localServiceName, zTags)
+			span := spans.At(j)
+			if span.IsNil() {
+				continue
+			}
+			zSpan, err := spanToZipkinSpan(span, localServiceName, zTags)
 			if err != nil {
 				return zSpans, err
 			}
-			zSpans = append(zSpans, span)
+			zSpans = append(zSpans, zSpan)
 		}
 	}
 

--- a/translator/trace/zipkin/traces_to_zipkinv2_test.go
+++ b/translator/trace/zipkin/traces_to_zipkinv2_test.go
@@ -80,7 +80,7 @@ func TestInternalTracesToZipkinSpans(t *testing.T) {
 		{
 			name: "TwoSpansOneNil",
 			td:   generateTraceTwoSpansOneNil(),
-			zs:   []*zipkinmodel.SpanModel{ zipkinOneSpan() },
+			zs:   []*zipkinmodel.SpanModel{zipkinOneSpan()},
 			err:  nil,
 		},
 	}
@@ -141,12 +141,12 @@ func zipkinOneSpan() *zipkinmodel.SpanModel {
 			Sampled:  &trueBool,
 			Err:      nil,
 		},
-		LocalEndpoint:  &zipkinmodel.Endpoint{
+		LocalEndpoint: &zipkinmodel.Endpoint{
 			ServiceName: "OTLPResourceNoServiceName",
 		},
 		RemoteEndpoint: nil,
 		Annotations:    nil,
-		Tags:           map[string]string{
+		Tags: map[string]string{
 			"resource-attr": "resource-attr-val-1",
 		},
 	}


### PR DESCRIPTION
**Description:**
Fixing a bug. There was a panic converting internal traces to zipkin, which occured if there were both a valid span and a nil span. With only nil span the error was about absence of trace id. No check for nil span was present - that is the bug.

**Link to tracking Issue:** might be connected to #1845 

**Testing:** added test with 2 spans
