### PR TITLE
Add debug-level message on error for Jaeger Exporter

### DIFF
--- a/exporter/jaegerexporter/exporter_test.go
+++ b/exporter/jaegerexporter/exporter_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/jaegertracing/jaeger/proto-gen/api_v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 
@@ -154,7 +155,7 @@ func TestNew(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := newTraceExporter(&tt.args.config)
+			got, err := newTraceExporter(&tt.args.config, zap.NewNop())
 			if (err != nil) != tt.wantErr {
 				t.Errorf("newTraceExporter() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/exporter/jaegerexporter/factory.go
+++ b/exporter/jaegerexporter/factory.go
@@ -55,7 +55,7 @@ func createDefaultConfig() configmodels.Exporter {
 
 func createTraceExporter(
 	_ context.Context,
-	_ component.ExporterCreateParams,
+	params component.ExporterCreateParams,
 	config configmodels.Exporter,
 ) (component.TraceExporter, error) {
 
@@ -68,7 +68,7 @@ func createTraceExporter(
 		return nil, err
 	}
 
-	exp, err := newTraceExporter(expCfg)
+	exp, err := newTraceExporter(expCfg, params.Logger)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>

## Important (read before submitting)
**Description:** 
When trying to get the OpenTelemetry Collector to work with Jaeger, it's currently not easy to determine whether a batch has failed to be sent to Jaeger, as there are no logs recorded anywhere.
This PR adds a debug-level message with the error. Users doing an initial setup, or having problems, can enable debug logging and will be able to identify what's wrong.

Example output:

```
2020-10-15T14:35:55.203+0200	DEBUG	jaegerexporter/exporter.go:95	failed to push trace data to Jaeger	{"component_kind": "exporter", "component_type": "jaeger", "component_name": "jaeger/auth", "error": "rpc error: code = Unknown desc = authentication didn't succeed"}
```

**Link to tracking Issue:** n/a

**Testing:** manual test

**Documentation:** n/a
