### PR TITLE
batchprocessor: Fix shutdown race

### DIFF
--- a/processor/batchprocessor/batch_processor.go
+++ b/processor/batchprocessor/batch_processor.go
@@ -51,6 +51,9 @@ type batchProcessor struct {
 	done    chan struct{}
 	newItem chan interface{}
 	batch   batch
+
+	ctx    context.Context
+	cancel context.CancelFunc
 }
 
 type batch interface {
@@ -75,6 +78,7 @@ var _ consumer.MetricsConsumer = (*batchProcessor)(nil)
 var _ consumer.LogsConsumer = (*batchProcessor)(nil)
 
 func newBatchProcessor(params component.ProcessorCreateParams, cfg *Config, batch batch, telemetryLevel configtelemetry.Level) *batchProcessor {
+	ctx, cancel := context.WithCancel(context.Background())
 	return &batchProcessor{
 		name:           cfg.Name(),
 		logger:         params.Logger,
@@ -86,6 +90,8 @@ func newBatchProcessor(params component.ProcessorCreateParams, cfg *Config, batc
 		done:             make(chan struct{}, 1),
 		newItem:          make(chan interface{}, runtime.NumCPU()),
 		batch:            batch,
+		ctx:              ctx,
+		cancel:           cancel,
 	}
 }
 
@@ -101,7 +107,7 @@ func (bp *batchProcessor) Start(context.Context, component.Host) error {
 
 // Shutdown is invoked during service shutdown.
 func (bp *batchProcessor) Shutdown(context.Context) error {
-	close(bp.newItem)
+	bp.cancel()
 	<-bp.done
 	return nil
 }
@@ -110,42 +116,57 @@ func (bp *batchProcessor) startProcessingCycle() {
 	bp.timer = time.NewTimer(bp.timeout)
 	for {
 		select {
+		case <-bp.ctx.Done():
+		DONE:
+			for {
+				select {
+				case item := <-bp.newItem:
+					bp.processItem(item)
+				default:
+					break DONE
+				}
+			}
+			// This is the close of the channel
+			if bp.batch.itemCount() > 0 {
+				// TODO: Set a timeout on sendTraces or
+				// make it cancellable using the context that Shutdown gets as a parameter
+				bp.sendItems(statTimeoutTriggerSend)
+			}
+			close(bp.done)
+			return
 		case item := <-bp.newItem:
 			if item == nil {
-				// This is the close of the channel
-				if bp.batch.itemCount() > 0 {
-					// TODO: Set a timeout on sendTraces or
-					// make it cancellable using the context that Shutdown gets as a parameter
-					bp.sendItems(statTimeoutTriggerSend)
-				}
-				close(bp.done)
-				return
+				continue
 			}
-			if bp.sendBatchMaxSize > 0 {
-				if td, ok := item.(pdata.Traces); ok {
-					itemCount := bp.batch.itemCount()
-					if itemCount+uint32(td.SpanCount()) > bp.sendBatchMaxSize {
-						tdRemainSize := splitTrace(int(bp.sendBatchSize-itemCount), td)
-						item = tdRemainSize
-						go func() {
-							bp.newItem <- td
-						}()
-					}
-				}
-			}
-
-			bp.batch.add(item)
-			if bp.batch.itemCount() >= bp.sendBatchSize {
-				bp.timer.Stop()
-				bp.sendItems(statBatchSizeTriggerSend)
-				bp.resetTimer()
-			}
+			bp.processItem(item)
 		case <-bp.timer.C:
 			if bp.batch.itemCount() > 0 {
 				bp.sendItems(statTimeoutTriggerSend)
 			}
 			bp.resetTimer()
 		}
+	}
+}
+
+func (bp *batchProcessor) processItem(item interface{}) {
+	if bp.sendBatchMaxSize > 0 {
+		if td, ok := item.(pdata.Traces); ok {
+			itemCount := bp.batch.itemCount()
+			if itemCount+uint32(td.SpanCount()) > bp.sendBatchMaxSize {
+				tdRemainSize := splitTrace(int(bp.sendBatchSize-itemCount), td)
+				item = tdRemainSize
+				go func() {
+					bp.newItem <- td
+				}()
+			}
+		}
+	}
+
+	bp.batch.add(item)
+	if bp.batch.itemCount() >= bp.sendBatchSize {
+		bp.timer.Stop()
+		bp.sendItems(statBatchSizeTriggerSend)
+		bp.resetTimer()
 	}
 }
 


### PR DESCRIPTION
The newItem channel cannot be closed ever since Shutdown is not
guaranteed to be called after all Consume* calls to the same processor.

Even after Shutdown is finished, there is not hard guarantee that
nothing will ever call Consume*, so we need to just leave the channel
open until GC will clean it up.