### PR TITLE
Allow configuring URLs per signal in OTLP/HTTP exporter

### DIFF
--- a/exporter/otlphttpexporter/README.md
+++ b/exporter/otlphttpexporter/README.md
@@ -5,9 +5,19 @@ Exports traces and/or metrics via HTTP using
 
 The following settings are required:
 
-- `endpoint` (no default): The target URL to send data to (e.g.: https://example.com:55681/v1/traces).
+- `endpoint` (no default): The target base URL to send data to (e.g.: https://example.com:55681).
+  To send each signal a corresponding path will be added to this base URL, i.e. for traces
+  "/v1/traces" will appended, for metrics "/v1/metrics" will be appended, for logs
+  "/v1/logs" will be appended. 
 
 The following settings can be optionally configured:
+
+- `traces_endpoint` (no default): The target URL to send trace data to (e.g.: https://example.com:55681/v1/traces).
+   If this setting is present the the `endpoint` setting is ignored for traces.
+- `metrics_endpoint` (no default): The target URL to send metric data to (e.g.: https://example.com:55681/v1/metrics).
+   If this setting is present the the `endpoint` setting is ignored for metrics.
+- `logs_endpoint` (no default): The target URL to send log data to (e.g.: https://example.com:55681/v1/logs).
+   If this setting is present the the `endpoint` setting is ignored logs.
 
 - `insecure` (default = false): when set to true disables verifying the server's
   certificate chain and host name. The connection is still encrypted but server identity
@@ -18,6 +28,7 @@ The following settings can be optionally configured:
   only be used if `insecure` is set to false.
 - `key_file` path to the TLS key to use for TLS required connections. Should
   only be used if `insecure` is set to false.
+
 - `timeout` (default = 30s): HTTP request time limit. For details see https://golang.org/pkg/net/http/#Client
 - `read_buffer_size` (default = 0): ReadBufferSize for HTTP client.
 - `write_buffer_size` (default = 512 * 1024): WriteBufferSize for HTTP client.

--- a/exporter/otlphttpexporter/config.go
+++ b/exporter/otlphttpexporter/config.go
@@ -26,4 +26,13 @@ type Config struct {
 	confighttp.HTTPClientSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct.
 	exporterhelper.QueueSettings  `mapstructure:"sending_queue"`
 	exporterhelper.RetrySettings  `mapstructure:"retry_on_failure"`
+
+	// The URL to send traces to. If omitted the Endpoint + "/v1/traces" will be used.
+	TracesEndpoint string `mapstructure:"traces_endpoint"`
+
+	// The URL to send metrics to. If omitted the Endpoint + "/v1/metrics" will be used.
+	MetricsEndpoint string `mapstructure:"metrics_endpoint"`
+
+	// The URL to send logs to. If omitted the Endpoint + "/v1/logs" will be used.
+	LogsEndpoint string `mapstructure:"logs_endpoint"`
 }

--- a/exporter/otlphttpexporter/factory_test.go
+++ b/exporter/otlphttpexporter/factory_test.go
@@ -49,7 +49,7 @@ func TestCreateDefaultConfig(t *testing.T) {
 func TestCreateMetricsExporter(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig().(*Config)
-	cfg.HTTPClientSettings.Endpoint = testutil.GetAvailableLocalAddress(t)
+	cfg.HTTPClientSettings.Endpoint = "http://" + testutil.GetAvailableLocalAddress(t)
 
 	creationParams := component.ExporterCreateParams{Logger: zap.NewNop()}
 	oexp, err := factory.CreateMetricsExporter(context.Background(), creationParams, cfg)
@@ -58,7 +58,7 @@ func TestCreateMetricsExporter(t *testing.T) {
 }
 
 func TestCreateTraceExporter(t *testing.T) {
-	endpoint := testutil.GetAvailableLocalAddress(t)
+	endpoint := "http://" + testutil.GetAvailableLocalAddress(t)
 
 	tests := []struct {
 		name     string
@@ -152,7 +152,7 @@ func TestCreateTraceExporter(t *testing.T) {
 func TestCreateLogsExporter(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig().(*Config)
-	cfg.HTTPClientSettings.Endpoint = testutil.GetAvailableLocalAddress(t)
+	cfg.HTTPClientSettings.Endpoint = "http://" + testutil.GetAvailableLocalAddress(t)
 
 	creationParams := component.ExporterCreateParams{Logger: zap.NewNop()}
 	oexp, err := factory.CreateLogsExporter(context.Background(), creationParams, cfg)


### PR DESCRIPTION
See README for explanation of configuration changes. We need
this in order to be able to override destination URL per signal.
The OTLP specification defines the defaults for each signal.
This change allows the overrides per signal.
