### PR TITLE
Deprecate NopExporter, add NopConsumer

### DIFF
--- a/consumer/consumertest/nop.go
+++ b/consumer/consumertest/nop.go
@@ -1,0 +1,55 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package consumertest
+
+import (
+	"context"
+
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/consumer/pdata"
+)
+
+var (
+	nopInstance = &nopConsumer{}
+)
+
+type nopConsumer struct{}
+
+func (nc *nopConsumer) ConsumeTraces(context.Context, pdata.Traces) error {
+	return nil
+}
+
+func (nc *nopConsumer) ConsumeMetrics(context.Context, pdata.Metrics) error {
+	return nil
+}
+
+func (nc *nopConsumer) ConsumeLogs(context.Context, pdata.Logs) error {
+	return nil
+}
+
+// NewNopTraces creates an TraceConsumer that just drops the received data.
+func NewNopTraces() consumer.TraceConsumer {
+	return nopInstance
+}
+
+// NewNopMetrics creates an MetricsConsumer that just drops the received data.
+func NewNopMetrics() consumer.MetricsConsumer {
+	return nopInstance
+}
+
+// NewNopLogs creates an LogsConsumer that just drops the received data.
+func NewNopLogs() consumer.LogsConsumer {
+	return nopInstance
+}

--- a/consumer/consumertest/nop.go
+++ b/consumer/consumertest/nop.go
@@ -39,17 +39,17 @@ func (nc *nopConsumer) ConsumeLogs(context.Context, pdata.Logs) error {
 	return nil
 }
 
-// NewNopTraces creates an TraceConsumer that just drops the received data.
-func NewNopTraces() consumer.TraceConsumer {
+// NewTracesNop creates an TraceConsumer that just drops the received data.
+func NewTracesNop() consumer.TraceConsumer {
 	return nopInstance
 }
 
-// NewNopMetrics creates an MetricsConsumer that just drops the received data.
-func NewNopMetrics() consumer.MetricsConsumer {
+// NewMetricsNop creates an MetricsConsumer that just drops the received data.
+func NewMetricsNop() consumer.MetricsConsumer {
 	return nopInstance
 }
 
-// NewNopLogs creates an LogsConsumer that just drops the received data.
-func NewNopLogs() consumer.LogsConsumer {
+// NewLogsNop creates an LogsConsumer that just drops the received data.
+func NewLogsNop() consumer.LogsConsumer {
 	return nopInstance
 }

--- a/consumer/consumertest/nop_test.go
+++ b/consumer/consumertest/nop_test.go
@@ -24,19 +24,19 @@ import (
 )
 
 func TestNewNopTraces(t *testing.T) {
-	nt := NewNopTraces()
+	nt := NewTracesNop()
 	require.NotNil(t, nt)
 	require.NoError(t, nt.ConsumeTraces(context.Background(), pdata.NewTraces()))
 }
 
 func TestNewNopMetrics(t *testing.T) {
-	nm := NewNopMetrics()
+	nm := NewMetricsNop()
 	require.NotNil(t, nm)
 	require.NoError(t, nm.ConsumeMetrics(context.Background(), pdata.NewMetrics()))
 }
 
 func TestNopLogsConsumer(t *testing.T) {
-	nl := NewNopLogs()
+	nl := NewLogsNop()
 	require.NotNil(t, nl)
 	require.NoError(t, nl.ConsumeLogs(context.Background(), pdata.NewLogs()))
 }

--- a/consumer/consumertest/nop_test.go
+++ b/consumer/consumertest/nop_test.go
@@ -1,0 +1,42 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package consumertest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/collector/consumer/pdata"
+)
+
+func TestNewNopTraces(t *testing.T) {
+	nt := NewNopTraces()
+	require.NotNil(t, nt)
+	require.NoError(t, nt.ConsumeTraces(context.Background(), pdata.NewTraces()))
+}
+
+func TestNewNopMetrics(t *testing.T) {
+	nm := NewNopMetrics()
+	require.NotNil(t, nm)
+	require.NoError(t, nm.ConsumeMetrics(context.Background(), pdata.NewMetrics()))
+}
+
+func TestNopLogsConsumer(t *testing.T) {
+	nl := NewNopLogs()
+	require.NotNil(t, nl)
+	require.NoError(t, nl.ConsumeLogs(context.Background(), pdata.NewLogs()))
+}

--- a/exporter/exporterhelper/factory_test.go
+++ b/exporter/exporterhelper/factory_test.go
@@ -25,7 +25,7 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configerror"
 	"go.opentelemetry.io/collector/config/configmodels"
-	"go.opentelemetry.io/collector/exporter/exportertest"
+	"go.opentelemetry.io/collector/consumer/pdata"
 )
 
 const typeStr = "test"
@@ -35,9 +35,15 @@ var (
 		TypeVal: typeStr,
 		NameVal: typeStr,
 	}
-	nopTracesExporter  = exportertest.NewNopTraceExporter()
-	nopMetricsExporter = exportertest.NewNopMetricsExporter()
-	nopLogsExporter    = exportertest.NewNopLogsExporter()
+	nopTracesExporter, _ = NewTraceExporter(defaultCfg, func(ctx context.Context, td pdata.Traces) (droppedSpans int, err error) {
+		return 0, nil
+	})
+	nopMetricsExporter, _ = NewMetricsExporter(defaultCfg, func(ctx context.Context, md pdata.Metrics) (droppedTimeSeries int, err error) {
+		return 0, nil
+	})
+	nopLogsExporter, _ = NewLogsExporter(defaultCfg, func(ctx context.Context, md pdata.Logs) (droppedTimeSeries int, err error) {
+		return 0, nil
+	})
 )
 
 func TestNewFactory(t *testing.T) {

--- a/exporter/exportertest/nop_exporter.go
+++ b/exporter/exportertest/nop_exporter.go
@@ -21,31 +21,22 @@ import (
 	"go.opentelemetry.io/collector/consumer/pdata"
 )
 
-const (
-	nopTraceExporterName   = "nop_trace"
-	nopMetricsExporterName = "nop_metrics"
-	nopLogsExporterName    = "nop_log"
-)
-
-type nopExporter struct {
-	name     string
-	retError error
-}
+type nopExporter struct{}
 
 func (ne *nopExporter) Start(context.Context, component.Host) error {
 	return nil
 }
 
 func (ne *nopExporter) ConsumeTraces(context.Context, pdata.Traces) error {
-	return ne.retError
+	return nil
 }
 
 func (ne *nopExporter) ConsumeMetrics(context.Context, pdata.Metrics) error {
-	return ne.retError
+	return nil
 }
 
 func (ne *nopExporter) ConsumeLogs(context.Context, pdata.Logs) error {
-	return ne.retError
+	return nil
 }
 
 // Shutdown stops the exporter and is invoked during shutdown.
@@ -54,25 +45,19 @@ func (ne *nopExporter) Shutdown(context.Context) error {
 }
 
 // NewNopTraceExporter creates an TraceExporter that just drops the received data.
+// Deprecated: Use consumertest.NewNopTraces.
 func NewNopTraceExporter() component.TraceExporter {
-	ne := &nopExporter{
-		name: nopTraceExporterName,
-	}
-	return ne
+	return &nopExporter{}
 }
 
 // NewNopMetricsExporter creates an MetricsExporter that just drops the received data.
+// Deprecated: Use consumertest.NewNopMetrics.
 func NewNopMetricsExporter() component.MetricsExporter {
-	ne := &nopExporter{
-		name: nopMetricsExporterName,
-	}
-	return ne
+	return &nopExporter{}
 }
 
 // NewNopLogsExporter creates an LogsExporter that just drops the received data.
+// Deprecated: Use consumertest.NewNopLogs.
 func NewNopLogsExporter() component.LogsExporter {
-	ne := &nopExporter{
-		name: nopLogsExporterName,
-	}
-	return ne
+	return &nopExporter{}
 }

--- a/exporter/exportertest/nop_exporter_test.go
+++ b/exporter/exportertest/nop_exporter_test.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package exportertest
 
 import (

--- a/processor/attributesprocessor/attributes_test.go
+++ b/processor/attributesprocessor/attributes_test.go
@@ -23,8 +23,8 @@ import (
 	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/consumer/pdata"
-	"go.opentelemetry.io/collector/exporter/exportertest"
 	"go.opentelemetry.io/collector/internal/data/testdata"
 	"go.opentelemetry.io/collector/internal/processor/filterconfig"
 	"go.opentelemetry.io/collector/internal/processor/filterset"
@@ -143,7 +143,7 @@ func TestSpanProcessor_NilEmptyData(t *testing.T) {
 		{Key: "attribute1", Action: processorhelper.DELETE},
 	}
 
-	tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, oCfg, exportertest.NewNopTraceExporter())
+	tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, oCfg, consumertest.NewNopTraces())
 	require.Nil(t, err)
 	require.NotNil(t, tp)
 	for i := range testCases {
@@ -210,7 +210,7 @@ func TestAttributes_FilterSpans(t *testing.T) {
 		},
 		Config: *createConfig(filterset.Strict),
 	}
-	tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{}, cfg, exportertest.NewNopTraceExporter())
+	tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{}, cfg, consumertest.NewNopTraces())
 	require.Nil(t, err)
 	require.NotNil(t, tp)
 
@@ -278,7 +278,7 @@ func TestAttributes_FilterSpansByNameStrict(t *testing.T) {
 		SpanNames: []string{"dont_apply"},
 		Config:    *createConfig(filterset.Strict),
 	}
-	tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{}, cfg, exportertest.NewNopTraceExporter())
+	tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{}, cfg, consumertest.NewNopTraces())
 	require.Nil(t, err)
 	require.NotNil(t, tp)
 
@@ -346,7 +346,7 @@ func TestAttributes_FilterSpansByNameRegexp(t *testing.T) {
 		SpanNames: []string{".*dont_apply$"},
 		Config:    *createConfig(filterset.Regexp),
 	}
-	tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{}, cfg, exportertest.NewNopTraceExporter())
+	tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{}, cfg, consumertest.NewNopTraces())
 	require.Nil(t, err)
 	require.NotNil(t, tp)
 
@@ -405,7 +405,7 @@ func TestAttributes_Hash(t *testing.T) {
 		{Key: "user.authenticated", Action: processorhelper.HASH},
 	}
 
-	tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{}, cfg, exportertest.NewNopTraceExporter())
+	tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{}, cfg, consumertest.NewNopTraces())
 	require.Nil(t, err)
 	require.NotNil(t, tp)
 
@@ -449,7 +449,7 @@ func BenchmarkAttributes_FilterSpansByName(b *testing.B) {
 	oCfg.Include = &filterconfig.MatchProperties{
 		SpanNames: []string{"^apply.*"},
 	}
-	tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{}, cfg, exportertest.NewNopTraceExporter())
+	tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{}, cfg, consumertest.NewNopTraces())
 	require.Nil(b, err)
 	require.NotNil(b, tp)
 

--- a/processor/attributesprocessor/attributes_test.go
+++ b/processor/attributesprocessor/attributes_test.go
@@ -143,7 +143,7 @@ func TestSpanProcessor_NilEmptyData(t *testing.T) {
 		{Key: "attribute1", Action: processorhelper.DELETE},
 	}
 
-	tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, oCfg, consumertest.NewNopTraces())
+	tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, oCfg, consumertest.NewTracesNop())
 	require.Nil(t, err)
 	require.NotNil(t, tp)
 	for i := range testCases {
@@ -210,7 +210,7 @@ func TestAttributes_FilterSpans(t *testing.T) {
 		},
 		Config: *createConfig(filterset.Strict),
 	}
-	tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{}, cfg, consumertest.NewNopTraces())
+	tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{}, cfg, consumertest.NewTracesNop())
 	require.Nil(t, err)
 	require.NotNil(t, tp)
 
@@ -278,7 +278,7 @@ func TestAttributes_FilterSpansByNameStrict(t *testing.T) {
 		SpanNames: []string{"dont_apply"},
 		Config:    *createConfig(filterset.Strict),
 	}
-	tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{}, cfg, consumertest.NewNopTraces())
+	tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{}, cfg, consumertest.NewTracesNop())
 	require.Nil(t, err)
 	require.NotNil(t, tp)
 
@@ -346,7 +346,7 @@ func TestAttributes_FilterSpansByNameRegexp(t *testing.T) {
 		SpanNames: []string{".*dont_apply$"},
 		Config:    *createConfig(filterset.Regexp),
 	}
-	tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{}, cfg, consumertest.NewNopTraces())
+	tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{}, cfg, consumertest.NewTracesNop())
 	require.Nil(t, err)
 	require.NotNil(t, tp)
 
@@ -405,7 +405,7 @@ func TestAttributes_Hash(t *testing.T) {
 		{Key: "user.authenticated", Action: processorhelper.HASH},
 	}
 
-	tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{}, cfg, consumertest.NewNopTraces())
+	tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{}, cfg, consumertest.NewTracesNop())
 	require.Nil(t, err)
 	require.NotNil(t, tp)
 
@@ -449,7 +449,7 @@ func BenchmarkAttributes_FilterSpansByName(b *testing.B) {
 	oCfg.Include = &filterconfig.MatchProperties{
 		SpanNames: []string{"^apply.*"},
 	}
-	tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{}, cfg, consumertest.NewNopTraces())
+	tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{}, cfg, consumertest.NewTracesNop())
 	require.Nil(b, err)
 	require.NotNil(b, tp)
 

--- a/processor/attributesprocessor/factory_test.go
+++ b/processor/attributesprocessor/factory_test.go
@@ -25,7 +25,7 @@ import (
 	"go.opentelemetry.io/collector/config/configcheck"
 	"go.opentelemetry.io/collector/config/configerror"
 	"go.opentelemetry.io/collector/config/configmodels"
-	"go.opentelemetry.io/collector/exporter/exportertest"
+	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/processor/processorhelper"
 )
 
@@ -49,7 +49,7 @@ func TestFactory_CreateDefaultConfig(t *testing.T) {
 func TestFactoryCreateTraceProcessor_EmptyActions(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
-	ap, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{}, cfg, exportertest.NewNopTraceExporter())
+	ap, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{}, cfg, consumertest.NewNopTraces())
 	assert.Error(t, err)
 	assert.Nil(t, ap)
 }
@@ -62,7 +62,7 @@ func TestFactoryCreateTraceProcessor_InvalidActions(t *testing.T) {
 	oCfg.Actions = []processorhelper.ActionKeyValue{
 		{Key: "", Value: 123, Action: processorhelper.UPSERT},
 	}
-	ap, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{}, cfg, exportertest.NewNopTraceExporter())
+	ap, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{}, cfg, consumertest.NewNopTraces())
 	assert.Error(t, err)
 	assert.Nil(t, ap)
 }
@@ -75,7 +75,7 @@ func TestFactoryCreateTraceProcessor(t *testing.T) {
 		{Key: "a key", Action: processorhelper.DELETE},
 	}
 
-	tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{}, cfg, exportertest.NewNopTraceExporter())
+	tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{}, cfg, consumertest.NewNopTraces())
 	assert.NotNil(t, tp)
 	assert.NoError(t, err)
 
@@ -86,7 +86,7 @@ func TestFactoryCreateTraceProcessor(t *testing.T) {
 	oCfg.Actions = []processorhelper.ActionKeyValue{
 		{Action: processorhelper.DELETE},
 	}
-	tp, err = factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{}, cfg, exportertest.NewNopTraceExporter())
+	tp, err = factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{}, cfg, consumertest.NewNopTraces())
 	assert.Nil(t, tp)
 	assert.Error(t, err)
 }

--- a/processor/attributesprocessor/factory_test.go
+++ b/processor/attributesprocessor/factory_test.go
@@ -49,7 +49,7 @@ func TestFactory_CreateDefaultConfig(t *testing.T) {
 func TestFactoryCreateTraceProcessor_EmptyActions(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
-	ap, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{}, cfg, consumertest.NewNopTraces())
+	ap, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{}, cfg, consumertest.NewTracesNop())
 	assert.Error(t, err)
 	assert.Nil(t, ap)
 }
@@ -62,7 +62,7 @@ func TestFactoryCreateTraceProcessor_InvalidActions(t *testing.T) {
 	oCfg.Actions = []processorhelper.ActionKeyValue{
 		{Key: "", Value: 123, Action: processorhelper.UPSERT},
 	}
-	ap, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{}, cfg, consumertest.NewNopTraces())
+	ap, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{}, cfg, consumertest.NewTracesNop())
 	assert.Error(t, err)
 	assert.Nil(t, ap)
 }
@@ -75,7 +75,7 @@ func TestFactoryCreateTraceProcessor(t *testing.T) {
 		{Key: "a key", Action: processorhelper.DELETE},
 	}
 
-	tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{}, cfg, consumertest.NewNopTraces())
+	tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{}, cfg, consumertest.NewTracesNop())
 	assert.NotNil(t, tp)
 	assert.NoError(t, err)
 
@@ -86,7 +86,7 @@ func TestFactoryCreateTraceProcessor(t *testing.T) {
 	oCfg.Actions = []processorhelper.ActionKeyValue{
 		{Action: processorhelper.DELETE},
 	}
-	tp, err = factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{}, cfg, consumertest.NewNopTraces())
+	tp, err = factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{}, cfg, consumertest.NewTracesNop())
 	assert.Nil(t, tp)
 	assert.Error(t, err)
 }

--- a/processor/cloningfanoutconnector_test.go
+++ b/processor/cloningfanoutconnector_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func TestTraceProcessorCloningNotMultiplexing(t *testing.T) {
-	nop := consumertest.NewNopTraces()
+	nop := consumertest.NewTracesNop()
 	tfc := NewTracesCloningFanOutConnector([]consumer.TraceConsumer{nop})
 	assert.Same(t, nop, tfc)
 }
@@ -70,7 +70,7 @@ func TestTraceProcessorCloningMultiplexing(t *testing.T) {
 }
 
 func TestMetricsProcessorCloningNotMultiplexing(t *testing.T) {
-	nop := consumertest.NewNopMetrics()
+	nop := consumertest.NewMetricsNop()
 	mfc := NewMetricsFanOutConnector([]consumer.MetricsConsumer{nop})
 	assert.Same(t, nop, mfc)
 }
@@ -113,7 +113,7 @@ func TestMetricsProcessorCloningMultiplexing(t *testing.T) {
 }
 
 func TestLogsProcessorCloningNotMultiplexing(t *testing.T) {
-	nop := consumertest.NewNopLogs()
+	nop := consumertest.NewLogsNop()
 	lfc := NewLogsCloningFanOutConnector([]consumer.LogsConsumer{nop})
 	assert.Same(t, nop, lfc)
 }

--- a/processor/cloningfanoutconnector_test.go
+++ b/processor/cloningfanoutconnector_test.go
@@ -21,12 +21,13 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/exporter/exportertest"
 	"go.opentelemetry.io/collector/internal/data/testdata"
 )
 
 func TestTraceProcessorCloningNotMultiplexing(t *testing.T) {
-	nop := exportertest.NewNopTraceExporter()
+	nop := consumertest.NewNopTraces()
 	tfc := NewTracesCloningFanOutConnector([]consumer.TraceConsumer{nop})
 	assert.Same(t, nop, tfc)
 }
@@ -69,7 +70,7 @@ func TestTraceProcessorCloningMultiplexing(t *testing.T) {
 }
 
 func TestMetricsProcessorCloningNotMultiplexing(t *testing.T) {
-	nop := exportertest.NewNopMetricsExporter()
+	nop := consumertest.NewNopMetrics()
 	mfc := NewMetricsFanOutConnector([]consumer.MetricsConsumer{nop})
 	assert.Same(t, nop, mfc)
 }
@@ -112,7 +113,7 @@ func TestMetricsProcessorCloningMultiplexing(t *testing.T) {
 }
 
 func TestLogsProcessorCloningNotMultiplexing(t *testing.T) {
-	nop := exportertest.NewNopLogsExporter()
+	nop := consumertest.NewNopLogs()
 	lfc := NewLogsCloningFanOutConnector([]consumer.LogsConsumer{nop})
 	assert.Same(t, nop, lfc)
 }

--- a/processor/fanoutconnector_test.go
+++ b/processor/fanoutconnector_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func TestTracesProcessorNotMultiplexing(t *testing.T) {
-	nop := consumertest.NewNopTraces()
+	nop := consumertest.NewTracesNop()
 	tfc := NewTracesFanOutConnector([]consumer.TraceConsumer{nop})
 	assert.Same(t, nop, tfc)
 }
@@ -87,7 +87,7 @@ func TestTraceProcessorWhenOneErrors(t *testing.T) {
 }
 
 func TestMetricsProcessorNotMultiplexing(t *testing.T) {
-	nop := consumertest.NewNopMetrics()
+	nop := consumertest.NewMetricsNop()
 	mfc := NewMetricsFanOutConnector([]consumer.MetricsConsumer{nop})
 	assert.Same(t, nop, mfc)
 }
@@ -146,7 +146,7 @@ func TestMetricsProcessorWhenOneErrors(t *testing.T) {
 }
 
 func TestLogsProcessorNotMultiplexing(t *testing.T) {
-	nop := consumertest.NewNopLogs()
+	nop := consumertest.NewLogsNop()
 	lfc := NewLogsFanOutConnector([]consumer.LogsConsumer{nop})
 	assert.Same(t, nop, lfc)
 }

--- a/processor/fanoutconnector_test.go
+++ b/processor/fanoutconnector_test.go
@@ -22,12 +22,13 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/exporter/exportertest"
 	"go.opentelemetry.io/collector/internal/data/testdata"
 )
 
 func TestTracesProcessorNotMultiplexing(t *testing.T) {
-	nop := exportertest.NewNopTraceExporter()
+	nop := consumertest.NewNopTraces()
 	tfc := NewTracesFanOutConnector([]consumer.TraceConsumer{nop})
 	assert.Same(t, nop, tfc)
 }
@@ -86,7 +87,7 @@ func TestTraceProcessorWhenOneErrors(t *testing.T) {
 }
 
 func TestMetricsProcessorNotMultiplexing(t *testing.T) {
-	nop := exportertest.NewNopMetricsExporter()
+	nop := consumertest.NewNopMetrics()
 	mfc := NewMetricsFanOutConnector([]consumer.MetricsConsumer{nop})
 	assert.Same(t, nop, mfc)
 }
@@ -145,7 +146,7 @@ func TestMetricsProcessorWhenOneErrors(t *testing.T) {
 }
 
 func TestLogsProcessorNotMultiplexing(t *testing.T) {
-	nop := exportertest.NewNopLogsExporter()
+	nop := consumertest.NewNopLogs()
 	lfc := NewLogsFanOutConnector([]consumer.LogsConsumer{nop})
 	assert.Same(t, nop, lfc)
 }

--- a/processor/filterprocessor/factory_test.go
+++ b/processor/filterprocessor/factory_test.go
@@ -80,12 +80,12 @@ func TestCreateProcessors(t *testing.T) {
 			t.Run(fmt.Sprintf("%s/%s", test.configName, name), func(t *testing.T) {
 				factory := NewFactory()
 
-				tp, tErr := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, cfg, consumertest.NewNopTraces())
+				tp, tErr := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, cfg, consumertest.NewTracesNop())
 				// Not implemented error
 				assert.NotNil(t, tErr)
 				assert.Nil(t, tp)
 
-				mp, mErr := factory.CreateMetricsProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, cfg, consumertest.NewNopMetrics())
+				mp, mErr := factory.CreateMetricsProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, cfg, consumertest.NewMetricsNop())
 				assert.Equal(t, test.succeed, mp != nil)
 				assert.Equal(t, test.succeed, mErr == nil)
 			})

--- a/processor/filterprocessor/factory_test.go
+++ b/processor/filterprocessor/factory_test.go
@@ -28,7 +28,7 @@ import (
 	"go.opentelemetry.io/collector/config/configcheck"
 	"go.opentelemetry.io/collector/config/configmodels"
 	"go.opentelemetry.io/collector/config/configtest"
-	"go.opentelemetry.io/collector/exporter/exportertest"
+	"go.opentelemetry.io/collector/consumer/consumertest"
 )
 
 func TestType(t *testing.T) {
@@ -80,12 +80,12 @@ func TestCreateProcessors(t *testing.T) {
 			t.Run(fmt.Sprintf("%s/%s", test.configName, name), func(t *testing.T) {
 				factory := NewFactory()
 
-				tp, tErr := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, cfg, exportertest.NewNopTraceExporter())
+				tp, tErr := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, cfg, consumertest.NewNopTraces())
 				// Not implemented error
 				assert.NotNil(t, tErr)
 				assert.Nil(t, tp)
 
-				mp, mErr := factory.CreateMetricsProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, cfg, exportertest.NewNopMetricsExporter())
+				mp, mErr := factory.CreateMetricsProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, cfg, consumertest.NewNopMetrics())
 				assert.Equal(t, test.succeed, mp != nil)
 				assert.Equal(t, test.succeed, mErr == nil)
 			})

--- a/processor/memorylimiter/factory_test.go
+++ b/processor/memorylimiter/factory_test.go
@@ -25,7 +25,7 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configcheck"
-	"go.opentelemetry.io/collector/exporter/exportertest"
+	"go.opentelemetry.io/collector/consumer/consumertest"
 )
 
 func TestCreateDefaultConfig(t *testing.T) {
@@ -44,15 +44,15 @@ func TestCreateProcessor(t *testing.T) {
 	cfg := factory.CreateDefaultConfig()
 
 	// This processor can't be created with the default config.
-	tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, cfg, exportertest.NewNopTraceExporter())
+	tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, cfg, consumertest.NewNopTraces())
 	assert.Nil(t, tp)
 	assert.Error(t, err, "created processor with invalid settings")
 
-	mp, err := factory.CreateMetricsProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, cfg, exportertest.NewNopMetricsExporter())
+	mp, err := factory.CreateMetricsProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, cfg, consumertest.NewNopMetrics())
 	assert.Nil(t, mp)
 	assert.Error(t, err, "created processor with invalid settings")
 
-	lp, err := factory.CreateLogsProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, cfg, exportertest.NewNopLogsExporter())
+	lp, err := factory.CreateLogsProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, cfg, consumertest.NewNopLogs())
 	assert.Nil(t, lp)
 	assert.Error(t, err, "created processor with invalid settings")
 
@@ -63,17 +63,17 @@ func TestCreateProcessor(t *testing.T) {
 	pCfg.BallastSizeMiB = 2048
 	pCfg.CheckInterval = 100 * time.Millisecond
 
-	tp, err = factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, cfg, exportertest.NewNopTraceExporter())
+	tp, err = factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, cfg, consumertest.NewNopTraces())
 	assert.NoError(t, err)
 	assert.NotNil(t, tp)
 	assert.NoError(t, tp.Shutdown(context.Background()))
 
-	mp, err = factory.CreateMetricsProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, cfg, exportertest.NewNopMetricsExporter())
+	mp, err = factory.CreateMetricsProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, cfg, consumertest.NewNopMetrics())
 	assert.NoError(t, err)
 	assert.NotNil(t, mp)
 	assert.NoError(t, mp.Shutdown(context.Background()))
 
-	lp, err = factory.CreateLogsProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, cfg, exportertest.NewNopLogsExporter())
+	lp, err = factory.CreateLogsProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, cfg, consumertest.NewNopLogs())
 	assert.NoError(t, err)
 	assert.NotNil(t, lp)
 	assert.NoError(t, lp.Shutdown(context.Background()))

--- a/processor/memorylimiter/factory_test.go
+++ b/processor/memorylimiter/factory_test.go
@@ -44,15 +44,15 @@ func TestCreateProcessor(t *testing.T) {
 	cfg := factory.CreateDefaultConfig()
 
 	// This processor can't be created with the default config.
-	tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, cfg, consumertest.NewNopTraces())
+	tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, cfg, consumertest.NewTracesNop())
 	assert.Nil(t, tp)
 	assert.Error(t, err, "created processor with invalid settings")
 
-	mp, err := factory.CreateMetricsProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, cfg, consumertest.NewNopMetrics())
+	mp, err := factory.CreateMetricsProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, cfg, consumertest.NewMetricsNop())
 	assert.Nil(t, mp)
 	assert.Error(t, err, "created processor with invalid settings")
 
-	lp, err := factory.CreateLogsProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, cfg, consumertest.NewNopLogs())
+	lp, err := factory.CreateLogsProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, cfg, consumertest.NewLogsNop())
 	assert.Nil(t, lp)
 	assert.Error(t, err, "created processor with invalid settings")
 
@@ -63,17 +63,17 @@ func TestCreateProcessor(t *testing.T) {
 	pCfg.BallastSizeMiB = 2048
 	pCfg.CheckInterval = 100 * time.Millisecond
 
-	tp, err = factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, cfg, consumertest.NewNopTraces())
+	tp, err = factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, cfg, consumertest.NewTracesNop())
 	assert.NoError(t, err)
 	assert.NotNil(t, tp)
 	assert.NoError(t, tp.Shutdown(context.Background()))
 
-	mp, err = factory.CreateMetricsProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, cfg, consumertest.NewNopMetrics())
+	mp, err = factory.CreateMetricsProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, cfg, consumertest.NewMetricsNop())
 	assert.NoError(t, err)
 	assert.NotNil(t, mp)
 	assert.NoError(t, mp.Shutdown(context.Background()))
 
-	lp, err = factory.CreateLogsProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, cfg, consumertest.NewNopLogs())
+	lp, err = factory.CreateLogsProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, cfg, consumertest.NewLogsNop())
 	assert.NoError(t, err)
 	assert.NotNil(t, lp)
 	assert.NoError(t, lp.Shutdown(context.Background()))

--- a/processor/memorylimiter/memorylimiter_test.go
+++ b/processor/memorylimiter/memorylimiter_test.go
@@ -117,7 +117,7 @@ func TestMetricsMemoryPressureResponse(t *testing.T) {
 				NameVal: typeStr,
 			},
 		},
-		consumertest.NewNopMetrics(),
+		consumertest.NewMetricsNop(),
 		ml,
 		processorhelper.WithCapabilities(processorCapabilities),
 		processorhelper.WithShutdown(ml.shutdown))
@@ -186,7 +186,7 @@ func TestTraceMemoryPressureResponse(t *testing.T) {
 				NameVal: typeStr,
 			},
 		},
-		consumertest.NewNopTraces(),
+		consumertest.NewTracesNop(),
 		ml,
 		processorhelper.WithCapabilities(processorCapabilities),
 		processorhelper.WithShutdown(ml.shutdown))
@@ -255,7 +255,7 @@ func TestLogMemoryPressureResponse(t *testing.T) {
 				NameVal: typeStr,
 			},
 		},
-		consumertest.NewNopLogs(),
+		consumertest.NewLogsNop(),
 		ml,
 		processorhelper.WithCapabilities(processorCapabilities),
 		processorhelper.WithShutdown(ml.shutdown))

--- a/processor/memorylimiter/memorylimiter_test.go
+++ b/processor/memorylimiter/memorylimiter_test.go
@@ -26,6 +26,7 @@ import (
 
 	"go.opentelemetry.io/collector/config/configmodels"
 	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/exporter/exportertest"
 	"go.opentelemetry.io/collector/processor/memorylimiter/internal/iruntime"
@@ -116,7 +117,7 @@ func TestMetricsMemoryPressureResponse(t *testing.T) {
 				NameVal: typeStr,
 			},
 		},
-		exportertest.NewNopMetricsExporter(),
+		consumertest.NewNopMetrics(),
 		ml,
 		processorhelper.WithCapabilities(processorCapabilities),
 		processorhelper.WithShutdown(ml.shutdown))
@@ -185,7 +186,7 @@ func TestTraceMemoryPressureResponse(t *testing.T) {
 				NameVal: typeStr,
 			},
 		},
-		exportertest.NewNopTraceExporter(),
+		consumertest.NewNopTraces(),
 		ml,
 		processorhelper.WithCapabilities(processorCapabilities),
 		processorhelper.WithShutdown(ml.shutdown))
@@ -254,7 +255,7 @@ func TestLogMemoryPressureResponse(t *testing.T) {
 				NameVal: typeStr,
 			},
 		},
-		exportertest.NewNopLogsExporter(),
+		consumertest.NewNopLogs(),
 		ml,
 		processorhelper.WithCapabilities(processorCapabilities),
 		processorhelper.WithShutdown(ml.shutdown))

--- a/processor/processorhelper/processor_test.go
+++ b/processor/processorhelper/processor_test.go
@@ -26,8 +26,8 @@ import (
 	"go.opentelemetry.io/collector/component/componenterror"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/configmodels"
+	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/consumer/pdata"
-	"go.opentelemetry.io/collector/exporter/exportertest"
 	"go.opentelemetry.io/collector/internal/data/testdata"
 )
 
@@ -81,7 +81,7 @@ func TestWithCapabilities(t *testing.T) {
 }
 
 func TestNewTraceExporter(t *testing.T) {
-	me, err := NewTraceProcessor(testCfg, exportertest.NewNopTraceExporter(), newTestTProcessor(nil))
+	me, err := NewTraceProcessor(testCfg, consumertest.NewNopTraces(), newTestTProcessor(nil))
 	require.NoError(t, err)
 
 	assert.NoError(t, me.Start(context.Background(), componenttest.NewNopHost()))
@@ -90,7 +90,7 @@ func TestNewTraceExporter(t *testing.T) {
 }
 
 func TestNewTraceExporter_NilRequiredFields(t *testing.T) {
-	_, err := NewTraceProcessor(testCfg, exportertest.NewNopTraceExporter(), nil)
+	_, err := NewTraceProcessor(testCfg, consumertest.NewNopTraces(), nil)
 	assert.Error(t, err)
 
 	_, err = NewTraceProcessor(testCfg, nil, newTestTProcessor(nil))
@@ -99,13 +99,13 @@ func TestNewTraceExporter_NilRequiredFields(t *testing.T) {
 
 func TestNewTraceExporter_ProcessTraceError(t *testing.T) {
 	want := errors.New("my_error")
-	me, err := NewTraceProcessor(testCfg, exportertest.NewNopTraceExporter(), newTestTProcessor(want))
+	me, err := NewTraceProcessor(testCfg, consumertest.NewNopTraces(), newTestTProcessor(want))
 	require.NoError(t, err)
 	assert.Equal(t, want, me.ConsumeTraces(context.Background(), testdata.GenerateTraceDataEmpty()))
 }
 
 func TestNewMetricsExporter(t *testing.T) {
-	me, err := NewMetricsProcessor(testCfg, exportertest.NewNopMetricsExporter(), newTestMProcessor(nil))
+	me, err := NewMetricsProcessor(testCfg, consumertest.NewNopMetrics(), newTestMProcessor(nil))
 	require.NoError(t, err)
 
 	assert.NoError(t, me.Start(context.Background(), componenttest.NewNopHost()))
@@ -114,7 +114,7 @@ func TestNewMetricsExporter(t *testing.T) {
 }
 
 func TestNewMetricsExporter_NilRequiredFields(t *testing.T) {
-	_, err := NewMetricsProcessor(testCfg, exportertest.NewNopMetricsExporter(), nil)
+	_, err := NewMetricsProcessor(testCfg, consumertest.NewNopMetrics(), nil)
 	assert.Error(t, err)
 
 	_, err = NewMetricsProcessor(testCfg, nil, newTestMProcessor(nil))
@@ -123,19 +123,19 @@ func TestNewMetricsExporter_NilRequiredFields(t *testing.T) {
 
 func TestNewMetricsExporter_ProcessMetricsError(t *testing.T) {
 	want := errors.New("my_error")
-	me, err := NewMetricsProcessor(testCfg, exportertest.NewNopMetricsExporter(), newTestMProcessor(want))
+	me, err := NewMetricsProcessor(testCfg, consumertest.NewNopMetrics(), newTestMProcessor(want))
 	require.NoError(t, err)
 	assert.Equal(t, want, me.ConsumeMetrics(context.Background(), testdata.GenerateMetricsEmpty()))
 }
 
 func TestNewMetricsExporter_ProcessMetricsErrSkipProcessingData(t *testing.T) {
-	me, err := NewMetricsProcessor(testCfg, exportertest.NewNopMetricsExporter(), newTestMProcessor(ErrSkipProcessingData))
+	me, err := NewMetricsProcessor(testCfg, consumertest.NewNopMetrics(), newTestMProcessor(ErrSkipProcessingData))
 	require.NoError(t, err)
 	assert.Equal(t, nil, me.ConsumeMetrics(context.Background(), testdata.GenerateMetricsEmpty()))
 }
 
 func TestNewLogsExporter(t *testing.T) {
-	me, err := NewLogsProcessor(testCfg, exportertest.NewNopLogsExporter(), newTestLProcessor(nil))
+	me, err := NewLogsProcessor(testCfg, consumertest.NewNopLogs(), newTestLProcessor(nil))
 	require.NoError(t, err)
 
 	assert.NoError(t, me.Start(context.Background(), componenttest.NewNopHost()))
@@ -144,7 +144,7 @@ func TestNewLogsExporter(t *testing.T) {
 }
 
 func TestNewLogsExporter_NilRequiredFields(t *testing.T) {
-	_, err := NewLogsProcessor(testCfg, exportertest.NewNopLogsExporter(), nil)
+	_, err := NewLogsProcessor(testCfg, consumertest.NewNopLogs(), nil)
 	assert.Error(t, err)
 
 	_, err = NewLogsProcessor(testCfg, nil, newTestLProcessor(nil))
@@ -153,7 +153,7 @@ func TestNewLogsExporter_NilRequiredFields(t *testing.T) {
 
 func TestNewLogsExporter_ProcessLogError(t *testing.T) {
 	want := errors.New("my_error")
-	me, err := NewLogsProcessor(testCfg, exportertest.NewNopLogsExporter(), newTestLProcessor(want))
+	me, err := NewLogsProcessor(testCfg, consumertest.NewNopLogs(), newTestLProcessor(want))
 	require.NoError(t, err)
 	assert.Equal(t, want, me.ConsumeLogs(context.Background(), testdata.GenerateLogDataEmpty()))
 }

--- a/processor/processorhelper/processor_test.go
+++ b/processor/processorhelper/processor_test.go
@@ -81,7 +81,7 @@ func TestWithCapabilities(t *testing.T) {
 }
 
 func TestNewTraceExporter(t *testing.T) {
-	me, err := NewTraceProcessor(testCfg, consumertest.NewNopTraces(), newTestTProcessor(nil))
+	me, err := NewTraceProcessor(testCfg, consumertest.NewTracesNop(), newTestTProcessor(nil))
 	require.NoError(t, err)
 
 	assert.NoError(t, me.Start(context.Background(), componenttest.NewNopHost()))
@@ -90,7 +90,7 @@ func TestNewTraceExporter(t *testing.T) {
 }
 
 func TestNewTraceExporter_NilRequiredFields(t *testing.T) {
-	_, err := NewTraceProcessor(testCfg, consumertest.NewNopTraces(), nil)
+	_, err := NewTraceProcessor(testCfg, consumertest.NewTracesNop(), nil)
 	assert.Error(t, err)
 
 	_, err = NewTraceProcessor(testCfg, nil, newTestTProcessor(nil))
@@ -99,13 +99,13 @@ func TestNewTraceExporter_NilRequiredFields(t *testing.T) {
 
 func TestNewTraceExporter_ProcessTraceError(t *testing.T) {
 	want := errors.New("my_error")
-	me, err := NewTraceProcessor(testCfg, consumertest.NewNopTraces(), newTestTProcessor(want))
+	me, err := NewTraceProcessor(testCfg, consumertest.NewTracesNop(), newTestTProcessor(want))
 	require.NoError(t, err)
 	assert.Equal(t, want, me.ConsumeTraces(context.Background(), testdata.GenerateTraceDataEmpty()))
 }
 
 func TestNewMetricsExporter(t *testing.T) {
-	me, err := NewMetricsProcessor(testCfg, consumertest.NewNopMetrics(), newTestMProcessor(nil))
+	me, err := NewMetricsProcessor(testCfg, consumertest.NewMetricsNop(), newTestMProcessor(nil))
 	require.NoError(t, err)
 
 	assert.NoError(t, me.Start(context.Background(), componenttest.NewNopHost()))
@@ -114,7 +114,7 @@ func TestNewMetricsExporter(t *testing.T) {
 }
 
 func TestNewMetricsExporter_NilRequiredFields(t *testing.T) {
-	_, err := NewMetricsProcessor(testCfg, consumertest.NewNopMetrics(), nil)
+	_, err := NewMetricsProcessor(testCfg, consumertest.NewMetricsNop(), nil)
 	assert.Error(t, err)
 
 	_, err = NewMetricsProcessor(testCfg, nil, newTestMProcessor(nil))
@@ -123,19 +123,19 @@ func TestNewMetricsExporter_NilRequiredFields(t *testing.T) {
 
 func TestNewMetricsExporter_ProcessMetricsError(t *testing.T) {
 	want := errors.New("my_error")
-	me, err := NewMetricsProcessor(testCfg, consumertest.NewNopMetrics(), newTestMProcessor(want))
+	me, err := NewMetricsProcessor(testCfg, consumertest.NewMetricsNop(), newTestMProcessor(want))
 	require.NoError(t, err)
 	assert.Equal(t, want, me.ConsumeMetrics(context.Background(), testdata.GenerateMetricsEmpty()))
 }
 
 func TestNewMetricsExporter_ProcessMetricsErrSkipProcessingData(t *testing.T) {
-	me, err := NewMetricsProcessor(testCfg, consumertest.NewNopMetrics(), newTestMProcessor(ErrSkipProcessingData))
+	me, err := NewMetricsProcessor(testCfg, consumertest.NewMetricsNop(), newTestMProcessor(ErrSkipProcessingData))
 	require.NoError(t, err)
 	assert.Equal(t, nil, me.ConsumeMetrics(context.Background(), testdata.GenerateMetricsEmpty()))
 }
 
 func TestNewLogsExporter(t *testing.T) {
-	me, err := NewLogsProcessor(testCfg, consumertest.NewNopLogs(), newTestLProcessor(nil))
+	me, err := NewLogsProcessor(testCfg, consumertest.NewLogsNop(), newTestLProcessor(nil))
 	require.NoError(t, err)
 
 	assert.NoError(t, me.Start(context.Background(), componenttest.NewNopHost()))
@@ -144,7 +144,7 @@ func TestNewLogsExporter(t *testing.T) {
 }
 
 func TestNewLogsExporter_NilRequiredFields(t *testing.T) {
-	_, err := NewLogsProcessor(testCfg, consumertest.NewNopLogs(), nil)
+	_, err := NewLogsProcessor(testCfg, consumertest.NewLogsNop(), nil)
 	assert.Error(t, err)
 
 	_, err = NewLogsProcessor(testCfg, nil, newTestLProcessor(nil))
@@ -153,7 +153,7 @@ func TestNewLogsExporter_NilRequiredFields(t *testing.T) {
 
 func TestNewLogsExporter_ProcessLogError(t *testing.T) {
 	want := errors.New("my_error")
-	me, err := NewLogsProcessor(testCfg, consumertest.NewNopLogs(), newTestLProcessor(want))
+	me, err := NewLogsProcessor(testCfg, consumertest.NewLogsNop(), newTestLProcessor(want))
 	require.NoError(t, err)
 	assert.Equal(t, want, me.ConsumeLogs(context.Background(), testdata.GenerateLogDataEmpty()))
 }

--- a/processor/resourceprocessor/factory_test.go
+++ b/processor/resourceprocessor/factory_test.go
@@ -24,7 +24,7 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configcheck"
 	"go.opentelemetry.io/collector/config/configmodels"
-	"go.opentelemetry.io/collector/exporter/exportertest"
+	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/processor/processorhelper"
 )
 
@@ -47,11 +47,11 @@ func TestCreateProcessor(t *testing.T) {
 		},
 	}
 
-	tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{}, cfg, exportertest.NewNopTraceExporter())
+	tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{}, cfg, consumertest.NewNopTraces())
 	assert.NoError(t, err)
 	assert.NotNil(t, tp)
 
-	mp, err := factory.CreateMetricsProcessor(context.Background(), component.ProcessorCreateParams{}, cfg, exportertest.NewNopMetricsExporter())
+	mp, err := factory.CreateMetricsProcessor(context.Background(), component.ProcessorCreateParams{}, cfg, consumertest.NewNopMetrics())
 	assert.NoError(t, err)
 	assert.NotNil(t, mp)
 }
@@ -60,10 +60,10 @@ func TestInvalidEmptyActions(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
 
-	_, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{}, cfg, exportertest.NewNopTraceExporter())
+	_, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{}, cfg, consumertest.NewNopTraces())
 	assert.Error(t, err)
 
-	_, err = factory.CreateMetricsProcessor(context.Background(), component.ProcessorCreateParams{}, cfg, exportertest.NewNopMetricsExporter())
+	_, err = factory.CreateMetricsProcessor(context.Background(), component.ProcessorCreateParams{}, cfg, consumertest.NewNopMetrics())
 	assert.Error(t, err)
 }
 

--- a/processor/resourceprocessor/factory_test.go
+++ b/processor/resourceprocessor/factory_test.go
@@ -47,11 +47,11 @@ func TestCreateProcessor(t *testing.T) {
 		},
 	}
 
-	tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{}, cfg, consumertest.NewNopTraces())
+	tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{}, cfg, consumertest.NewTracesNop())
 	assert.NoError(t, err)
 	assert.NotNil(t, tp)
 
-	mp, err := factory.CreateMetricsProcessor(context.Background(), component.ProcessorCreateParams{}, cfg, consumertest.NewNopMetrics())
+	mp, err := factory.CreateMetricsProcessor(context.Background(), component.ProcessorCreateParams{}, cfg, consumertest.NewMetricsNop())
 	assert.NoError(t, err)
 	assert.NotNil(t, mp)
 }
@@ -60,10 +60,10 @@ func TestInvalidEmptyActions(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
 
-	_, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{}, cfg, consumertest.NewNopTraces())
+	_, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{}, cfg, consumertest.NewTracesNop())
 	assert.Error(t, err)
 
-	_, err = factory.CreateMetricsProcessor(context.Background(), component.ProcessorCreateParams{}, cfg, consumertest.NewNopMetrics())
+	_, err = factory.CreateMetricsProcessor(context.Background(), component.ProcessorCreateParams{}, cfg, consumertest.NewMetricsNop())
 	assert.Error(t, err)
 }
 

--- a/processor/samplingprocessor/probabilisticsamplerprocessor/factory_test.go
+++ b/processor/samplingprocessor/probabilisticsamplerprocessor/factory_test.go
@@ -35,7 +35,7 @@ func TestCreateDefaultConfig(t *testing.T) {
 func TestCreateProcessor(t *testing.T) {
 	cfg := createDefaultConfig()
 	params := component.ProcessorCreateParams{Logger: zap.NewNop()}
-	tp, err := createTraceProcessor(context.Background(), params, cfg, consumertest.NewNopTraces())
+	tp, err := createTraceProcessor(context.Background(), params, cfg, consumertest.NewTracesNop())
 	assert.NotNil(t, tp)
 	assert.NoError(t, err, "cannot create trace processor")
 }

--- a/processor/samplingprocessor/probabilisticsamplerprocessor/factory_test.go
+++ b/processor/samplingprocessor/probabilisticsamplerprocessor/factory_test.go
@@ -23,7 +23,7 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configcheck"
-	"go.opentelemetry.io/collector/exporter/exportertest"
+	"go.opentelemetry.io/collector/consumer/consumertest"
 )
 
 func TestCreateDefaultConfig(t *testing.T) {
@@ -35,7 +35,7 @@ func TestCreateDefaultConfig(t *testing.T) {
 func TestCreateProcessor(t *testing.T) {
 	cfg := createDefaultConfig()
 	params := component.ProcessorCreateParams{Logger: zap.NewNop()}
-	tp, err := createTraceProcessor(context.Background(), params, cfg, exportertest.NewNopTraceExporter())
+	tp, err := createTraceProcessor(context.Background(), params, cfg, consumertest.NewNopTraces())
 	assert.NotNil(t, tp)
 	assert.NoError(t, err, "cannot create trace processor")
 }

--- a/processor/samplingprocessor/probabilisticsamplerprocessor/probabilisticsampler_test.go
+++ b/processor/samplingprocessor/probabilisticsamplerprocessor/probabilisticsampler_test.go
@@ -46,23 +46,23 @@ func TestNewTraceProcessor(t *testing.T) {
 		},
 		{
 			name:         "happy_path",
-			nextConsumer: consumertest.NewNopTraces(),
+			nextConsumer: consumertest.NewTracesNop(),
 			cfg: Config{
 				SamplingPercentage: 15.5,
 			},
 			want: &tracesamplerprocessor{
-				nextConsumer: consumertest.NewNopTraces(),
+				nextConsumer: consumertest.NewTracesNop(),
 			},
 		},
 		{
 			name:         "happy_path_hash_seed",
-			nextConsumer: consumertest.NewNopTraces(),
+			nextConsumer: consumertest.NewTracesNop(),
 			cfg: Config{
 				SamplingPercentage: 13.33,
 				HashSeed:           4321,
 			},
 			want: &tracesamplerprocessor{
-				nextConsumer: consumertest.NewNopTraces(),
+				nextConsumer: consumertest.NewTracesNop(),
 				hashSeed:     4321,
 			},
 		},

--- a/processor/samplingprocessor/probabilisticsamplerprocessor/probabilisticsampler_test.go
+++ b/processor/samplingprocessor/probabilisticsamplerprocessor/probabilisticsampler_test.go
@@ -26,6 +26,7 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/exporter/exportertest"
 	tracetranslator "go.opentelemetry.io/collector/translator/trace"
@@ -45,23 +46,23 @@ func TestNewTraceProcessor(t *testing.T) {
 		},
 		{
 			name:         "happy_path",
-			nextConsumer: exportertest.NewNopTraceExporter(),
+			nextConsumer: consumertest.NewNopTraces(),
 			cfg: Config{
 				SamplingPercentage: 15.5,
 			},
 			want: &tracesamplerprocessor{
-				nextConsumer: exportertest.NewNopTraceExporter(),
+				nextConsumer: consumertest.NewNopTraces(),
 			},
 		},
 		{
 			name:         "happy_path_hash_seed",
-			nextConsumer: exportertest.NewNopTraceExporter(),
+			nextConsumer: consumertest.NewNopTraces(),
 			cfg: Config{
 				SamplingPercentage: 13.33,
 				HashSeed:           4321,
 			},
 			want: &tracesamplerprocessor{
-				nextConsumer: exportertest.NewNopTraceExporter(),
+				nextConsumer: consumertest.NewNopTraces(),
 				hashSeed:     4321,
 			},
 		},

--- a/processor/samplingprocessor/tailsamplingprocessor/factory_test.go
+++ b/processor/samplingprocessor/tailsamplingprocessor/factory_test.go
@@ -23,7 +23,7 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configcheck"
-	"go.opentelemetry.io/collector/exporter/exportertest"
+	"go.opentelemetry.io/collector/consumer/consumertest"
 )
 
 func TestCreateDefaultConfig(t *testing.T) {
@@ -46,7 +46,7 @@ func TestCreateProcessor(t *testing.T) {
 	}
 
 	params := component.ProcessorCreateParams{Logger: zap.NewNop()}
-	tp, err := factory.CreateTraceProcessor(context.Background(), params, cfg, exportertest.NewNopTraceExporter())
+	tp, err := factory.CreateTraceProcessor(context.Background(), params, cfg, consumertest.NewNopTraces())
 	assert.NotNil(t, tp)
 	assert.NoError(t, err, "cannot create trace processor")
 }

--- a/processor/samplingprocessor/tailsamplingprocessor/factory_test.go
+++ b/processor/samplingprocessor/tailsamplingprocessor/factory_test.go
@@ -46,7 +46,7 @@ func TestCreateProcessor(t *testing.T) {
 	}
 
 	params := component.ProcessorCreateParams{Logger: zap.NewNop()}
-	tp, err := factory.CreateTraceProcessor(context.Background(), params, cfg, consumertest.NewNopTraces())
+	tp, err := factory.CreateTraceProcessor(context.Background(), params, cfg, consumertest.NewTracesNop())
 	assert.NotNil(t, tp)
 	assert.NoError(t, err, "cannot create trace processor")
 }

--- a/processor/samplingprocessor/tailsamplingprocessor/processor_test.go
+++ b/processor/samplingprocessor/tailsamplingprocessor/processor_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
+	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/exporter/exportertest"
 	"go.opentelemetry.io/collector/internal/data/testdata"
@@ -48,7 +49,7 @@ func TestSequentialTraceArrival(t *testing.T) {
 		ExpectedNewTracesPerSec: 64,
 		PolicyCfgs:              testPolicy,
 	}
-	sp, _ := newTraceProcessor(zap.NewNop(), exportertest.NewNopTraceExporter(), cfg)
+	sp, _ := newTraceProcessor(zap.NewNop(), consumertest.NewNopTraces(), cfg)
 	tsp := sp.(*tailSamplingSpanProcessor)
 	for _, batch := range batches {
 		tsp.ConsumeTraces(context.Background(), batch)
@@ -72,7 +73,7 @@ func TestConcurrentTraceArrival(t *testing.T) {
 		ExpectedNewTracesPerSec: 64,
 		PolicyCfgs:              testPolicy,
 	}
-	sp, _ := newTraceProcessor(zap.NewNop(), exportertest.NewNopTraceExporter(), cfg)
+	sp, _ := newTraceProcessor(zap.NewNop(), consumertest.NewNopTraces(), cfg)
 	tsp := sp.(*tailSamplingSpanProcessor)
 	for _, batch := range batches {
 		// Add the same traceId twice.
@@ -106,7 +107,7 @@ func TestSequentialTraceMapSize(t *testing.T) {
 		ExpectedNewTracesPerSec: 64,
 		PolicyCfgs:              testPolicy,
 	}
-	sp, _ := newTraceProcessor(zap.NewNop(), exportertest.NewNopTraceExporter(), cfg)
+	sp, _ := newTraceProcessor(zap.NewNop(), consumertest.NewNopTraces(), cfg)
 	tsp := sp.(*tailSamplingSpanProcessor)
 	for _, batch := range batches {
 		tsp.ConsumeTraces(context.Background(), batch)
@@ -129,7 +130,7 @@ func TestConcurrentTraceMapSize(t *testing.T) {
 		ExpectedNewTracesPerSec: 64,
 		PolicyCfgs:              testPolicy,
 	}
-	sp, _ := newTraceProcessor(zap.NewNop(), exportertest.NewNopTraceExporter(), cfg)
+	sp, _ := newTraceProcessor(zap.NewNop(), consumertest.NewNopTraces(), cfg)
 	tsp := sp.(*tailSamplingSpanProcessor)
 	for _, batch := range batches {
 		wg.Add(1)

--- a/processor/samplingprocessor/tailsamplingprocessor/processor_test.go
+++ b/processor/samplingprocessor/tailsamplingprocessor/processor_test.go
@@ -49,7 +49,7 @@ func TestSequentialTraceArrival(t *testing.T) {
 		ExpectedNewTracesPerSec: 64,
 		PolicyCfgs:              testPolicy,
 	}
-	sp, _ := newTraceProcessor(zap.NewNop(), consumertest.NewNopTraces(), cfg)
+	sp, _ := newTraceProcessor(zap.NewNop(), consumertest.NewTracesNop(), cfg)
 	tsp := sp.(*tailSamplingSpanProcessor)
 	for _, batch := range batches {
 		tsp.ConsumeTraces(context.Background(), batch)
@@ -73,7 +73,7 @@ func TestConcurrentTraceArrival(t *testing.T) {
 		ExpectedNewTracesPerSec: 64,
 		PolicyCfgs:              testPolicy,
 	}
-	sp, _ := newTraceProcessor(zap.NewNop(), consumertest.NewNopTraces(), cfg)
+	sp, _ := newTraceProcessor(zap.NewNop(), consumertest.NewTracesNop(), cfg)
 	tsp := sp.(*tailSamplingSpanProcessor)
 	for _, batch := range batches {
 		// Add the same traceId twice.
@@ -107,7 +107,7 @@ func TestSequentialTraceMapSize(t *testing.T) {
 		ExpectedNewTracesPerSec: 64,
 		PolicyCfgs:              testPolicy,
 	}
-	sp, _ := newTraceProcessor(zap.NewNop(), consumertest.NewNopTraces(), cfg)
+	sp, _ := newTraceProcessor(zap.NewNop(), consumertest.NewTracesNop(), cfg)
 	tsp := sp.(*tailSamplingSpanProcessor)
 	for _, batch := range batches {
 		tsp.ConsumeTraces(context.Background(), batch)
@@ -130,7 +130,7 @@ func TestConcurrentTraceMapSize(t *testing.T) {
 		ExpectedNewTracesPerSec: 64,
 		PolicyCfgs:              testPolicy,
 	}
-	sp, _ := newTraceProcessor(zap.NewNop(), consumertest.NewNopTraces(), cfg)
+	sp, _ := newTraceProcessor(zap.NewNop(), consumertest.NewTracesNop(), cfg)
 	tsp := sp.(*tailSamplingSpanProcessor)
 	for _, batch := range batches {
 		wg.Add(1)

--- a/processor/spanprocessor/factory_test.go
+++ b/processor/spanprocessor/factory_test.go
@@ -27,7 +27,7 @@ import (
 	"go.opentelemetry.io/collector/config/configcheck"
 	"go.opentelemetry.io/collector/config/configerror"
 	"go.opentelemetry.io/collector/config/configmodels"
-	"go.opentelemetry.io/collector/exporter/exportertest"
+	"go.opentelemetry.io/collector/consumer/consumertest"
 )
 
 func TestFactory_Type(t *testing.T) {
@@ -53,7 +53,7 @@ func TestFactory_CreateTraceProcessor(t *testing.T) {
 
 	// Name.FromAttributes field needs to be set for the configuration to be valid.
 	oCfg.Rename.FromAttributes = []string{"test-key"}
-	tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, oCfg, exportertest.NewNopTraceExporter())
+	tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, oCfg, consumertest.NewNopTraces())
 
 	require.Nil(t, err)
 	assert.NotNil(t, tp)
@@ -90,7 +90,7 @@ func TestFactory_CreateTraceProcessor_InvalidConfig(t *testing.T) {
 			cfg := factory.CreateDefaultConfig().(*Config)
 			cfg.Rename = test.cfg
 
-			tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, cfg, exportertest.NewNopTraceExporter())
+			tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, cfg, consumertest.NewNopTraces())
 			require.Nil(t, tp)
 			assert.EqualValues(t, err, test.err)
 		})

--- a/processor/spanprocessor/factory_test.go
+++ b/processor/spanprocessor/factory_test.go
@@ -53,7 +53,7 @@ func TestFactory_CreateTraceProcessor(t *testing.T) {
 
 	// Name.FromAttributes field needs to be set for the configuration to be valid.
 	oCfg.Rename.FromAttributes = []string{"test-key"}
-	tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, oCfg, consumertest.NewNopTraces())
+	tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, oCfg, consumertest.NewTracesNop())
 
 	require.Nil(t, err)
 	assert.NotNil(t, tp)
@@ -90,7 +90,7 @@ func TestFactory_CreateTraceProcessor_InvalidConfig(t *testing.T) {
 			cfg := factory.CreateDefaultConfig().(*Config)
 			cfg.Rename = test.cfg
 
-			tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, cfg, consumertest.NewNopTraces())
+			tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, cfg, consumertest.NewTracesNop())
 			require.Nil(t, tp)
 			assert.EqualValues(t, err, test.err)
 		})

--- a/processor/spanprocessor/span_test.go
+++ b/processor/spanprocessor/span_test.go
@@ -41,7 +41,7 @@ func TestNewTraceProcessor(t *testing.T) {
 	require.Error(t, componenterror.ErrNilNextConsumer, err)
 	require.Nil(t, tp)
 
-	tp, err = factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{}, cfg, consumertest.NewNopTraces())
+	tp, err = factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{}, cfg, consumertest.NewTracesNop())
 	require.Nil(t, err)
 	require.NotNil(t, tp)
 }
@@ -156,7 +156,7 @@ func TestSpanProcessor_NilEmptyData(t *testing.T) {
 	}
 	oCfg.Rename.FromAttributes = []string{"key"}
 
-	tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, oCfg, consumertest.NewNopTraces())
+	tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, oCfg, consumertest.NewTracesNop())
 	require.Nil(t, err)
 	require.NotNil(t, tp)
 	for i := range testCases {
@@ -260,7 +260,7 @@ func TestSpanProcessor_Values(t *testing.T) {
 	oCfg := cfg.(*Config)
 	oCfg.Rename.FromAttributes = []string{"key1"}
 
-	tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, oCfg, consumertest.NewNopTraces())
+	tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, oCfg, consumertest.NewTracesNop())
 	require.Nil(t, err)
 	require.NotNil(t, tp)
 	for _, tc := range testCases {
@@ -336,7 +336,7 @@ func TestSpanProcessor_MissingKeys(t *testing.T) {
 	oCfg.Rename.FromAttributes = []string{"key1", "key2", "key3", "key4"}
 	oCfg.Rename.Separator = "::"
 
-	tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, oCfg, consumertest.NewNopTraces())
+	tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, oCfg, consumertest.NewTracesNop())
 	require.Nil(t, err)
 	require.NotNil(t, tp)
 	for _, tc := range testCases {
@@ -354,7 +354,7 @@ func TestSpanProcessor_Separator(t *testing.T) {
 	oCfg.Rename.FromAttributes = []string{"key1"}
 	oCfg.Rename.Separator = "::"
 
-	tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, oCfg, consumertest.NewNopTraces())
+	tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, oCfg, consumertest.NewTracesNop())
 	require.Nil(t, err)
 	require.NotNil(t, tp)
 
@@ -383,7 +383,7 @@ func TestSpanProcessor_NoSeparatorMultipleKeys(t *testing.T) {
 	oCfg.Rename.FromAttributes = []string{"key1", "key2"}
 	oCfg.Rename.Separator = ""
 
-	tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, oCfg, consumertest.NewNopTraces())
+	tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, oCfg, consumertest.NewTracesNop())
 	require.Nil(t, err)
 	require.NotNil(t, tp)
 
@@ -413,7 +413,7 @@ func TestSpanProcessor_SeparatorMultipleKeys(t *testing.T) {
 	oCfg.Rename.FromAttributes = []string{"key1", "key2", "key3", "key4"}
 	oCfg.Rename.Separator = "::"
 
-	tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, oCfg, consumertest.NewNopTraces())
+	tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, oCfg, consumertest.NewTracesNop())
 	require.Nil(t, err)
 	require.NotNil(t, tp)
 
@@ -448,7 +448,7 @@ func TestSpanProcessor_NilName(t *testing.T) {
 	oCfg.Rename.FromAttributes = []string{"key1"}
 	oCfg.Rename.Separator = "::"
 
-	tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, oCfg, consumertest.NewNopTraces())
+	tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, oCfg, consumertest.NewTracesNop())
 	require.Nil(t, err)
 	require.NotNil(t, tp)
 
@@ -545,7 +545,7 @@ func TestSpanProcessor_ToAttributes(t *testing.T) {
 	for _, tc := range testCases {
 		oCfg.Rename.ToAttributes.Rules = tc.rules
 		oCfg.Rename.ToAttributes.BreakAfterMatch = tc.breakAfterMatch
-		tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, oCfg, consumertest.NewNopTraces())
+		tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, oCfg, consumertest.NewTracesNop())
 		require.Nil(t, err)
 		require.NotNil(t, tp)
 
@@ -612,7 +612,7 @@ func TestSpanProcessor_skipSpan(t *testing.T) {
 	oCfg.Rename.ToAttributes = &ToAttributes{
 		Rules: []string{`(?P<operation_website>.*?)$`},
 	}
-	tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, oCfg, consumertest.NewNopTraces())
+	tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, oCfg, consumertest.NewTracesNop())
 	require.Nil(t, err)
 	require.NotNil(t, tp)
 

--- a/processor/spanprocessor/span_test.go
+++ b/processor/spanprocessor/span_test.go
@@ -24,8 +24,8 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenterror"
+	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/consumer/pdata"
-	"go.opentelemetry.io/collector/exporter/exportertest"
 	"go.opentelemetry.io/collector/internal/data/testdata"
 	"go.opentelemetry.io/collector/internal/processor/filterconfig"
 	"go.opentelemetry.io/collector/internal/processor/filterset"
@@ -41,7 +41,7 @@ func TestNewTraceProcessor(t *testing.T) {
 	require.Error(t, componenterror.ErrNilNextConsumer, err)
 	require.Nil(t, tp)
 
-	tp, err = factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{}, cfg, exportertest.NewNopTraceExporter())
+	tp, err = factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{}, cfg, consumertest.NewNopTraces())
 	require.Nil(t, err)
 	require.NotNil(t, tp)
 }
@@ -156,7 +156,7 @@ func TestSpanProcessor_NilEmptyData(t *testing.T) {
 	}
 	oCfg.Rename.FromAttributes = []string{"key"}
 
-	tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, oCfg, exportertest.NewNopTraceExporter())
+	tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, oCfg, consumertest.NewNopTraces())
 	require.Nil(t, err)
 	require.NotNil(t, tp)
 	for i := range testCases {
@@ -260,7 +260,7 @@ func TestSpanProcessor_Values(t *testing.T) {
 	oCfg := cfg.(*Config)
 	oCfg.Rename.FromAttributes = []string{"key1"}
 
-	tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, oCfg, exportertest.NewNopTraceExporter())
+	tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, oCfg, consumertest.NewNopTraces())
 	require.Nil(t, err)
 	require.NotNil(t, tp)
 	for _, tc := range testCases {
@@ -336,7 +336,7 @@ func TestSpanProcessor_MissingKeys(t *testing.T) {
 	oCfg.Rename.FromAttributes = []string{"key1", "key2", "key3", "key4"}
 	oCfg.Rename.Separator = "::"
 
-	tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, oCfg, exportertest.NewNopTraceExporter())
+	tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, oCfg, consumertest.NewNopTraces())
 	require.Nil(t, err)
 	require.NotNil(t, tp)
 	for _, tc := range testCases {
@@ -354,7 +354,7 @@ func TestSpanProcessor_Separator(t *testing.T) {
 	oCfg.Rename.FromAttributes = []string{"key1"}
 	oCfg.Rename.Separator = "::"
 
-	tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, oCfg, exportertest.NewNopTraceExporter())
+	tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, oCfg, consumertest.NewNopTraces())
 	require.Nil(t, err)
 	require.NotNil(t, tp)
 
@@ -383,7 +383,7 @@ func TestSpanProcessor_NoSeparatorMultipleKeys(t *testing.T) {
 	oCfg.Rename.FromAttributes = []string{"key1", "key2"}
 	oCfg.Rename.Separator = ""
 
-	tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, oCfg, exportertest.NewNopTraceExporter())
+	tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, oCfg, consumertest.NewNopTraces())
 	require.Nil(t, err)
 	require.NotNil(t, tp)
 
@@ -413,7 +413,7 @@ func TestSpanProcessor_SeparatorMultipleKeys(t *testing.T) {
 	oCfg.Rename.FromAttributes = []string{"key1", "key2", "key3", "key4"}
 	oCfg.Rename.Separator = "::"
 
-	tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, oCfg, exportertest.NewNopTraceExporter())
+	tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, oCfg, consumertest.NewNopTraces())
 	require.Nil(t, err)
 	require.NotNil(t, tp)
 
@@ -448,7 +448,7 @@ func TestSpanProcessor_NilName(t *testing.T) {
 	oCfg.Rename.FromAttributes = []string{"key1"}
 	oCfg.Rename.Separator = "::"
 
-	tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, oCfg, exportertest.NewNopTraceExporter())
+	tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, oCfg, consumertest.NewNopTraces())
 	require.Nil(t, err)
 	require.NotNil(t, tp)
 
@@ -545,7 +545,7 @@ func TestSpanProcessor_ToAttributes(t *testing.T) {
 	for _, tc := range testCases {
 		oCfg.Rename.ToAttributes.Rules = tc.rules
 		oCfg.Rename.ToAttributes.BreakAfterMatch = tc.breakAfterMatch
-		tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, oCfg, exportertest.NewNopTraceExporter())
+		tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, oCfg, consumertest.NewNopTraces())
 		require.Nil(t, err)
 		require.NotNil(t, tp)
 
@@ -612,7 +612,7 @@ func TestSpanProcessor_skipSpan(t *testing.T) {
 	oCfg.Rename.ToAttributes = &ToAttributes{
 		Rules: []string{`(?P<operation_website>.*?)$`},
 	}
-	tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, oCfg, exportertest.NewNopTraceExporter())
+	tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, oCfg, consumertest.NewNopTraces())
 	require.Nil(t, err)
 	require.NotNil(t, tp)
 

--- a/receiver/fluentforwardreceiver/factory_test.go
+++ b/receiver/fluentforwardreceiver/factory_test.go
@@ -42,7 +42,7 @@ func TestCreateReceiver(t *testing.T) {
 
 	require.Equal(t, configmodels.Type("fluentforward"), factory.Type())
 
-	tReceiver, err := factory.CreateLogsReceiver(context.Background(), component.ReceiverCreateParams{Logger: zap.NewNop()}, cfg, consumertest.NewNopLogs())
+	tReceiver, err := factory.CreateLogsReceiver(context.Background(), component.ReceiverCreateParams{Logger: zap.NewNop()}, cfg, consumertest.NewLogsNop())
 	assert.Nil(t, err, "receiver creation failed")
 	assert.NotNil(t, tReceiver, "receiver creation failed")
 }

--- a/receiver/fluentforwardreceiver/factory_test.go
+++ b/receiver/fluentforwardreceiver/factory_test.go
@@ -25,7 +25,7 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configcheck"
 	"go.opentelemetry.io/collector/config/configmodels"
-	"go.opentelemetry.io/collector/exporter/exportertest"
+	"go.opentelemetry.io/collector/consumer/consumertest"
 )
 
 func TestCreateDefaultConfig(t *testing.T) {
@@ -42,7 +42,7 @@ func TestCreateReceiver(t *testing.T) {
 
 	require.Equal(t, configmodels.Type("fluentforward"), factory.Type())
 
-	tReceiver, err := factory.CreateLogsReceiver(context.Background(), component.ReceiverCreateParams{Logger: zap.NewNop()}, cfg, exportertest.NewNopLogsExporter())
+	tReceiver, err := factory.CreateLogsReceiver(context.Background(), component.ReceiverCreateParams{Logger: zap.NewNop()}, cfg, consumertest.NewNopLogs())
 	assert.Nil(t, err, "receiver creation failed")
 	assert.NotNil(t, tReceiver, "receiver creation failed")
 }

--- a/receiver/jaegerreceiver/trace_receiver_test.go
+++ b/receiver/jaegerreceiver/trace_receiver_test.go
@@ -542,7 +542,7 @@ func TestSamplingStrategiesMutualTLS(t *testing.T) {
 	cfg.Protocols.ThriftHTTP = &confighttp.HTTPServerSettings{
 		Endpoint: fmt.Sprintf("localhost:%d", thriftHTTPPort),
 	}
-	exp, err := factory.CreateTraceReceiver(context.Background(), component.ReceiverCreateParams{Logger: zap.NewNop()}, cfg, consumertest.NewNopTraces())
+	exp, err := factory.CreateTraceReceiver(context.Background(), component.ReceiverCreateParams{Logger: zap.NewNop()}, cfg, consumertest.NewTracesNop())
 	require.NoError(t, err)
 	host := &componenttest.ErrorWaitingHost{}
 	err = exp.Start(context.Background(), host)
@@ -581,7 +581,7 @@ func TestConsumeThriftTrace(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		numSpans, err := consumeTraces(context.Background(), test.batch, consumertest.NewNopTraces())
+		numSpans, err := consumeTraces(context.Background(), test.batch, consumertest.NewTracesNop())
 		require.NoError(t, err)
 		assert.Equal(t, test.numSpans, numSpans)
 	}

--- a/receiver/jaegerreceiver/trace_receiver_test.go
+++ b/receiver/jaegerreceiver/trace_receiver_test.go
@@ -47,6 +47,7 @@ import (
 	"go.opentelemetry.io/collector/config/configgrpc"
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/config/configtls"
+	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/exporter/exportertest"
 	"go.opentelemetry.io/collector/testutil"
@@ -541,7 +542,7 @@ func TestSamplingStrategiesMutualTLS(t *testing.T) {
 	cfg.Protocols.ThriftHTTP = &confighttp.HTTPServerSettings{
 		Endpoint: fmt.Sprintf("localhost:%d", thriftHTTPPort),
 	}
-	exp, err := factory.CreateTraceReceiver(context.Background(), component.ReceiverCreateParams{Logger: zap.NewNop()}, cfg, exportertest.NewNopTraceExporter())
+	exp, err := factory.CreateTraceReceiver(context.Background(), component.ReceiverCreateParams{Logger: zap.NewNop()}, cfg, consumertest.NewNopTraces())
 	require.NoError(t, err)
 	host := &componenttest.ErrorWaitingHost{}
 	err = exp.Start(context.Background(), host)
@@ -580,7 +581,7 @@ func TestConsumeThriftTrace(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		numSpans, err := consumeTraces(context.Background(), test.batch, exportertest.NewNopTraceExporter())
+		numSpans, err := consumeTraces(context.Background(), test.batch, consumertest.NewNopTraces())
 		require.NoError(t, err)
 		assert.Equal(t, test.numSpans, numSpans)
 	}

--- a/receiver/kafkareceiver/kafka_receiver_test.go
+++ b/receiver/kafkareceiver/kafka_receiver_test.go
@@ -31,6 +31,7 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configtls"
+	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/exporter/exportertest"
 	"go.opentelemetry.io/collector/exporter/kafkaexporter"
@@ -42,7 +43,7 @@ func TestNewReceiver_version_err(t *testing.T) {
 		Encoding:        defaultEncoding,
 		ProtocolVersion: "none",
 	}
-	r, err := newReceiver(c, component.ReceiverCreateParams{}, defaultUnmarshallers(), exportertest.NewNopTraceExporter())
+	r, err := newReceiver(c, component.ReceiverCreateParams{}, defaultUnmarshallers(), consumertest.NewNopTraces())
 	assert.Error(t, err)
 	assert.Nil(t, r)
 }
@@ -51,7 +52,7 @@ func TestNewReceiver_encoding_err(t *testing.T) {
 	c := Config{
 		Encoding: "foo",
 	}
-	r, err := newReceiver(c, component.ReceiverCreateParams{}, defaultUnmarshallers(), exportertest.NewNopTraceExporter())
+	r, err := newReceiver(c, component.ReceiverCreateParams{}, defaultUnmarshallers(), consumertest.NewNopTraces())
 	require.Error(t, err)
 	assert.Nil(t, r)
 	assert.EqualError(t, err, errUnrecognizedEncoding.Error())
@@ -72,7 +73,7 @@ func TestNewExporter_err_auth_type(t *testing.T) {
 			Full: false,
 		},
 	}
-	r, err := newReceiver(c, component.ReceiverCreateParams{}, defaultUnmarshallers(), exportertest.NewNopTraceExporter())
+	r, err := newReceiver(c, component.ReceiverCreateParams{}, defaultUnmarshallers(), consumertest.NewNopTraces())
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to load TLS config")
 	assert.Nil(t, r)
@@ -81,7 +82,7 @@ func TestNewExporter_err_auth_type(t *testing.T) {
 func TestReceiverStart(t *testing.T) {
 	testClient := testConsumerGroup{once: &sync.Once{}}
 	c := kafkaConsumer{
-		nextConsumer:  exportertest.NewNopTraceExporter(),
+		nextConsumer:  consumertest.NewNopTraces(),
 		logger:        zap.NewNop(),
 		consumerGroup: testClient,
 	}
@@ -94,7 +95,7 @@ func TestReceiverStart(t *testing.T) {
 func TestReceiverStartConsume(t *testing.T) {
 	testClient := testConsumerGroup{once: &sync.Once{}}
 	c := kafkaConsumer{
-		nextConsumer:  exportertest.NewNopTraceExporter(),
+		nextConsumer:  consumertest.NewNopTraces(),
 		logger:        zap.NewNop(),
 		consumerGroup: testClient,
 	}
@@ -114,7 +115,7 @@ func TestReceiver_error(t *testing.T) {
 	expectedErr := fmt.Errorf("handler error")
 	testClient := testConsumerGroup{once: &sync.Once{}, err: expectedErr}
 	c := kafkaConsumer{
-		nextConsumer:  exportertest.NewNopTraceExporter(),
+		nextConsumer:  consumertest.NewNopTraces(),
 		logger:        logger,
 		consumerGroup: testClient,
 	}
@@ -137,7 +138,7 @@ func TestConsumerGroupHandler(t *testing.T) {
 		unmarshaller: &otlpProtoUnmarshaller{},
 		logger:       zap.NewNop(),
 		ready:        make(chan bool),
-		nextConsumer: exportertest.NewNopTraceExporter(),
+		nextConsumer: consumertest.NewNopTraces(),
 	}
 
 	testSession := testConsumerGroupSession{}
@@ -181,7 +182,7 @@ func TestConsumerGroupHandler_error_unmarshall(t *testing.T) {
 		unmarshaller: &otlpProtoUnmarshaller{},
 		logger:       zap.NewNop(),
 		ready:        make(chan bool),
-		nextConsumer: exportertest.NewNopTraceExporter(),
+		nextConsumer: consumertest.NewNopTraces(),
 	}
 
 	wg := sync.WaitGroup{}

--- a/receiver/kafkareceiver/kafka_receiver_test.go
+++ b/receiver/kafkareceiver/kafka_receiver_test.go
@@ -43,7 +43,7 @@ func TestNewReceiver_version_err(t *testing.T) {
 		Encoding:        defaultEncoding,
 		ProtocolVersion: "none",
 	}
-	r, err := newReceiver(c, component.ReceiverCreateParams{}, defaultUnmarshallers(), consumertest.NewNopTraces())
+	r, err := newReceiver(c, component.ReceiverCreateParams{}, defaultUnmarshallers(), consumertest.NewTracesNop())
 	assert.Error(t, err)
 	assert.Nil(t, r)
 }
@@ -52,7 +52,7 @@ func TestNewReceiver_encoding_err(t *testing.T) {
 	c := Config{
 		Encoding: "foo",
 	}
-	r, err := newReceiver(c, component.ReceiverCreateParams{}, defaultUnmarshallers(), consumertest.NewNopTraces())
+	r, err := newReceiver(c, component.ReceiverCreateParams{}, defaultUnmarshallers(), consumertest.NewTracesNop())
 	require.Error(t, err)
 	assert.Nil(t, r)
 	assert.EqualError(t, err, errUnrecognizedEncoding.Error())
@@ -73,7 +73,7 @@ func TestNewExporter_err_auth_type(t *testing.T) {
 			Full: false,
 		},
 	}
-	r, err := newReceiver(c, component.ReceiverCreateParams{}, defaultUnmarshallers(), consumertest.NewNopTraces())
+	r, err := newReceiver(c, component.ReceiverCreateParams{}, defaultUnmarshallers(), consumertest.NewTracesNop())
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to load TLS config")
 	assert.Nil(t, r)
@@ -82,7 +82,7 @@ func TestNewExporter_err_auth_type(t *testing.T) {
 func TestReceiverStart(t *testing.T) {
 	testClient := testConsumerGroup{once: &sync.Once{}}
 	c := kafkaConsumer{
-		nextConsumer:  consumertest.NewNopTraces(),
+		nextConsumer:  consumertest.NewTracesNop(),
 		logger:        zap.NewNop(),
 		consumerGroup: testClient,
 	}
@@ -95,7 +95,7 @@ func TestReceiverStart(t *testing.T) {
 func TestReceiverStartConsume(t *testing.T) {
 	testClient := testConsumerGroup{once: &sync.Once{}}
 	c := kafkaConsumer{
-		nextConsumer:  consumertest.NewNopTraces(),
+		nextConsumer:  consumertest.NewTracesNop(),
 		logger:        zap.NewNop(),
 		consumerGroup: testClient,
 	}
@@ -115,7 +115,7 @@ func TestReceiver_error(t *testing.T) {
 	expectedErr := fmt.Errorf("handler error")
 	testClient := testConsumerGroup{once: &sync.Once{}, err: expectedErr}
 	c := kafkaConsumer{
-		nextConsumer:  consumertest.NewNopTraces(),
+		nextConsumer:  consumertest.NewTracesNop(),
 		logger:        logger,
 		consumerGroup: testClient,
 	}
@@ -138,7 +138,7 @@ func TestConsumerGroupHandler(t *testing.T) {
 		unmarshaller: &otlpProtoUnmarshaller{},
 		logger:       zap.NewNop(),
 		ready:        make(chan bool),
-		nextConsumer: consumertest.NewNopTraces(),
+		nextConsumer: consumertest.NewTracesNop(),
 	}
 
 	testSession := testConsumerGroupSession{}
@@ -182,7 +182,7 @@ func TestConsumerGroupHandler_error_unmarshall(t *testing.T) {
 		unmarshaller: &otlpProtoUnmarshaller{},
 		logger:       zap.NewNop(),
 		ready:        make(chan bool),
-		nextConsumer: consumertest.NewNopTraces(),
+		nextConsumer: consumertest.NewTracesNop(),
 	}
 
 	wg := sync.WaitGroup{}

--- a/receiver/opencensusreceiver/factory_test.go
+++ b/receiver/opencensusreceiver/factory_test.go
@@ -111,7 +111,7 @@ func TestCreateTraceReceiver(t *testing.T) {
 	params := component.ReceiverCreateParams{Logger: zap.NewNop()}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tr, err := createTraceReceiver(ctx, params, tt.cfg, consumertest.NewNopTraces())
+			tr, err := createTraceReceiver(ctx, params, tt.cfg, consumertest.NewTracesNop())
 			if (err != nil) != tt.wantErr {
 				t.Errorf("factory.CreateTraceReceiver() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -187,7 +187,7 @@ func TestCreateMetricReceiver(t *testing.T) {
 	params := component.ReceiverCreateParams{Logger: zap.NewNop()}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tc, err := createMetricsReceiver(context.Background(), params, tt.cfg, consumertest.NewNopMetrics())
+			tc, err := createMetricsReceiver(context.Background(), params, tt.cfg, consumertest.NewMetricsNop())
 			if (err != nil) != tt.wantErr {
 				t.Errorf("factory.CreateMetricsReceiver() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/receiver/opencensusreceiver/factory_test.go
+++ b/receiver/opencensusreceiver/factory_test.go
@@ -29,7 +29,7 @@ import (
 	"go.opentelemetry.io/collector/config/configgrpc"
 	"go.opentelemetry.io/collector/config/configmodels"
 	"go.opentelemetry.io/collector/config/confignet"
-	"go.opentelemetry.io/collector/exporter/exportertest"
+	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/testutil"
 )
 
@@ -111,7 +111,7 @@ func TestCreateTraceReceiver(t *testing.T) {
 	params := component.ReceiverCreateParams{Logger: zap.NewNop()}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tr, err := createTraceReceiver(ctx, params, tt.cfg, exportertest.NewNopTraceExporter())
+			tr, err := createTraceReceiver(ctx, params, tt.cfg, consumertest.NewNopTraces())
 			if (err != nil) != tt.wantErr {
 				t.Errorf("factory.CreateTraceReceiver() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -187,7 +187,7 @@ func TestCreateMetricReceiver(t *testing.T) {
 	params := component.ReceiverCreateParams{Logger: zap.NewNop()}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tc, err := createMetricsReceiver(context.Background(), params, tt.cfg, exportertest.NewNopMetricsExporter())
+			tc, err := createMetricsReceiver(context.Background(), params, tt.cfg, consumertest.NewNopMetrics())
 			if (err != nil) != tt.wantErr {
 				t.Errorf("factory.CreateMetricsReceiver() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/receiver/opencensusreceiver/octrace/observability_test.go
+++ b/receiver/opencensusreceiver/octrace/observability_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opencensus.io/trace"
 
-	"go.opentelemetry.io/collector/exporter/exportertest"
+	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/obsreport/obsreporttest"
 )
 
@@ -44,7 +44,7 @@ func TestEnsureRecordedMetrics(t *testing.T) {
 	require.NoError(t, err)
 	defer doneFn()
 
-	port, doneReceiverFn := ocReceiverOnGRPCServer(t, exportertest.NewNopTraceExporter())
+	port, doneReceiverFn := ocReceiverOnGRPCServer(t, consumertest.NewNopTraces())
 	defer doneReceiverFn()
 
 	n := 20
@@ -66,7 +66,7 @@ func TestEnsureRecordedMetrics_zeroLengthSpansSender(t *testing.T) {
 	require.NoError(t, err)
 	defer doneFn()
 
-	port, doneFn := ocReceiverOnGRPCServer(t, exportertest.NewNopTraceExporter())
+	port, doneFn := ocReceiverOnGRPCServer(t, consumertest.NewNopTraces())
 	defer doneFn()
 
 	n := 20
@@ -96,7 +96,7 @@ func TestExportSpanLinkingMaintainsParentLink(t *testing.T) {
 	trace.RegisterExporter(ocSpansSaver)
 	defer trace.UnregisterExporter(ocSpansSaver)
 
-	port, doneFn := ocReceiverOnGRPCServer(t, exportertest.NewNopTraceExporter())
+	port, doneFn := ocReceiverOnGRPCServer(t, consumertest.NewNopTraces())
 	defer doneFn()
 
 	traceSvcClient, traceSvcDoneFn, err := makeTraceServiceClient(port)

--- a/receiver/opencensusreceiver/octrace/observability_test.go
+++ b/receiver/opencensusreceiver/octrace/observability_test.go
@@ -44,7 +44,7 @@ func TestEnsureRecordedMetrics(t *testing.T) {
 	require.NoError(t, err)
 	defer doneFn()
 
-	port, doneReceiverFn := ocReceiverOnGRPCServer(t, consumertest.NewNopTraces())
+	port, doneReceiverFn := ocReceiverOnGRPCServer(t, consumertest.NewTracesNop())
 	defer doneReceiverFn()
 
 	n := 20
@@ -66,7 +66,7 @@ func TestEnsureRecordedMetrics_zeroLengthSpansSender(t *testing.T) {
 	require.NoError(t, err)
 	defer doneFn()
 
-	port, doneFn := ocReceiverOnGRPCServer(t, consumertest.NewNopTraces())
+	port, doneFn := ocReceiverOnGRPCServer(t, consumertest.NewTracesNop())
 	defer doneFn()
 
 	n := 20
@@ -96,7 +96,7 @@ func TestExportSpanLinkingMaintainsParentLink(t *testing.T) {
 	trace.RegisterExporter(ocSpansSaver)
 	defer trace.UnregisterExporter(ocSpansSaver)
 
-	port, doneFn := ocReceiverOnGRPCServer(t, consumertest.NewNopTraces())
+	port, doneFn := ocReceiverOnGRPCServer(t, consumertest.NewTracesNop())
 	defer doneFn()
 
 	traceSvcClient, traceSvcDoneFn, err := makeTraceServiceClient(port)

--- a/receiver/opencensusreceiver/opencensus_test.go
+++ b/receiver/opencensusreceiver/opencensus_test.go
@@ -161,7 +161,7 @@ func TestTraceGrpcGatewayCors_endToEnd(t *testing.T) {
 	addr := testutil.GetAvailableLocalAddress(t)
 	corsOrigins := []string{"allowed-*.com"}
 
-	ocr, err := newOpenCensusReceiver(ocReceiverName, "tcp", addr, consumertest.NewNopTraces(), nil, withCorsOrigins(corsOrigins))
+	ocr, err := newOpenCensusReceiver(ocReceiverName, "tcp", addr, consumertest.NewTracesNop(), nil, withCorsOrigins(corsOrigins))
 	require.NoError(t, err, "Failed to create trace receiver: %v", err)
 	defer ocr.Shutdown(context.Background())
 
@@ -185,7 +185,7 @@ func TestMetricsGrpcGatewayCors_endToEnd(t *testing.T) {
 	addr := testutil.GetAvailableLocalAddress(t)
 	corsOrigins := []string{"allowed-*.com"}
 
-	ocr, err := newOpenCensusReceiver(ocReceiverName, "tcp", addr, nil, consumertest.NewNopMetrics(), withCorsOrigins(corsOrigins))
+	ocr, err := newOpenCensusReceiver(ocReceiverName, "tcp", addr, nil, consumertest.NewMetricsNop(), withCorsOrigins(corsOrigins))
 	require.NoError(t, err, "Failed to create metrics receiver: %v", err)
 	defer ocr.Shutdown(context.Background())
 
@@ -263,7 +263,7 @@ func TestNewPortAlreadyUsed(t *testing.T) {
 
 func TestMultipleStopReceptionShouldNotError(t *testing.T) {
 	addr := testutil.GetAvailableLocalAddress(t)
-	r, err := newOpenCensusReceiver(ocReceiverName, "tcp", addr, consumertest.NewNopTraces(), consumertest.NewNopMetrics())
+	r, err := newOpenCensusReceiver(ocReceiverName, "tcp", addr, consumertest.NewTracesNop(), consumertest.NewMetricsNop())
 	require.NoError(t, err)
 	require.NotNil(t, r)
 
@@ -291,7 +291,7 @@ func tempSocketName(t *testing.T) string {
 
 func TestReceiveOnUnixDomainSocket_endToEnd(t *testing.T) {
 	socketName := tempSocketName(t)
-	cbts := consumertest.NewNopTraces()
+	cbts := consumertest.NewTracesNop()
 	r, err := newOpenCensusReceiver(ocReceiverName, "unix", socketName, cbts, nil)
 	require.NoError(t, err)
 	require.NotNil(t, r)

--- a/receiver/opencensusreceiver/opencensus_test.go
+++ b/receiver/opencensusreceiver/opencensus_test.go
@@ -45,6 +45,7 @@ import (
 
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/consumer/consumerdata"
+	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/exporter/exportertest"
 	"go.opentelemetry.io/collector/obsreport/obsreporttest"
 	"go.opentelemetry.io/collector/testutil"
@@ -160,7 +161,7 @@ func TestTraceGrpcGatewayCors_endToEnd(t *testing.T) {
 	addr := testutil.GetAvailableLocalAddress(t)
 	corsOrigins := []string{"allowed-*.com"}
 
-	ocr, err := newOpenCensusReceiver(ocReceiverName, "tcp", addr, exportertest.NewNopTraceExporter(), nil, withCorsOrigins(corsOrigins))
+	ocr, err := newOpenCensusReceiver(ocReceiverName, "tcp", addr, consumertest.NewNopTraces(), nil, withCorsOrigins(corsOrigins))
 	require.NoError(t, err, "Failed to create trace receiver: %v", err)
 	defer ocr.Shutdown(context.Background())
 
@@ -184,7 +185,7 @@ func TestMetricsGrpcGatewayCors_endToEnd(t *testing.T) {
 	addr := testutil.GetAvailableLocalAddress(t)
 	corsOrigins := []string{"allowed-*.com"}
 
-	ocr, err := newOpenCensusReceiver(ocReceiverName, "tcp", addr, nil, exportertest.NewNopMetricsExporter(), withCorsOrigins(corsOrigins))
+	ocr, err := newOpenCensusReceiver(ocReceiverName, "tcp", addr, nil, consumertest.NewNopMetrics(), withCorsOrigins(corsOrigins))
 	require.NoError(t, err, "Failed to create metrics receiver: %v", err)
 	defer ocr.Shutdown(context.Background())
 
@@ -262,7 +263,7 @@ func TestNewPortAlreadyUsed(t *testing.T) {
 
 func TestMultipleStopReceptionShouldNotError(t *testing.T) {
 	addr := testutil.GetAvailableLocalAddress(t)
-	r, err := newOpenCensusReceiver(ocReceiverName, "tcp", addr, exportertest.NewNopTraceExporter(), exportertest.NewNopMetricsExporter())
+	r, err := newOpenCensusReceiver(ocReceiverName, "tcp", addr, consumertest.NewNopTraces(), consumertest.NewNopMetrics())
 	require.NoError(t, err)
 	require.NotNil(t, r)
 
@@ -290,7 +291,7 @@ func tempSocketName(t *testing.T) string {
 
 func TestReceiveOnUnixDomainSocket_endToEnd(t *testing.T) {
 	socketName := tempSocketName(t)
-	cbts := exportertest.NewNopTraceExporter()
+	cbts := consumertest.NewNopTraces()
 	r, err := newOpenCensusReceiver(ocReceiverName, "unix", socketName, cbts, nil)
 	require.NoError(t, err)
 	require.NotNil(t, r)

--- a/receiver/prometheusreceiver/internal/transaction_test.go
+++ b/receiver/prometheusreceiver/internal/transaction_test.go
@@ -63,7 +63,7 @@ func Test_transaction(t *testing.T) {
 	rn := "prometheus"
 
 	t.Run("Commit Without Adding", func(t *testing.T) {
-		nomc := consumertest.NewNopMetrics()
+		nomc := consumertest.NewMetricsNop()
 		tr := newTransaction(context.Background(), nil, true, "", rn, ms, nomc, testLogger)
 		if got := tr.Commit(); got != nil {
 			t.Errorf("expecting nil from Commit() but got err %v", got)
@@ -71,7 +71,7 @@ func Test_transaction(t *testing.T) {
 	})
 
 	t.Run("Rollback dose nothing", func(t *testing.T) {
-		nomc := consumertest.NewNopMetrics()
+		nomc := consumertest.NewMetricsNop()
 		tr := newTransaction(context.Background(), nil, true, "", rn, ms, nomc, testLogger)
 		if got := tr.Rollback(); got != nil {
 			t.Errorf("expecting nil from Rollback() but got err %v", got)
@@ -80,7 +80,7 @@ func Test_transaction(t *testing.T) {
 
 	badLabels := labels.Labels([]labels.Label{{Name: "foo", Value: "bar"}})
 	t.Run("Add One No Target", func(t *testing.T) {
-		nomc := consumertest.NewNopMetrics()
+		nomc := consumertest.NewMetricsNop()
 		tr := newTransaction(context.Background(), nil, true, "", rn, ms, nomc, testLogger)
 		if _, got := tr.Add(badLabels, time.Now().Unix()*1000, 1.0); got == nil {
 			t.Errorf("expecting error from Add() but got nil")
@@ -92,7 +92,7 @@ func Test_transaction(t *testing.T) {
 		{Name: "job", Value: "test2"},
 		{Name: "foo", Value: "bar"}})
 	t.Run("Add One Job not found", func(t *testing.T) {
-		nomc := consumertest.NewNopMetrics()
+		nomc := consumertest.NewMetricsNop()
 		tr := newTransaction(context.Background(), nil, true, "", rn, ms, nomc, testLogger)
 		if _, got := tr.Add(jobNotFoundLb, time.Now().Unix()*1000, 1.0); got == nil {
 			t.Errorf("expecting error from Add() but got nil")

--- a/receiver/prometheusreceiver/internal/transaction_test.go
+++ b/receiver/prometheusreceiver/internal/transaction_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/prometheus/prometheus/scrape"
 	"google.golang.org/protobuf/proto"
 
+	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/exporter/exportertest"
 	"go.opentelemetry.io/collector/translator/internaldata"
 )
@@ -62,7 +63,7 @@ func Test_transaction(t *testing.T) {
 	rn := "prometheus"
 
 	t.Run("Commit Without Adding", func(t *testing.T) {
-		nomc := exportertest.NewNopMetricsExporter()
+		nomc := consumertest.NewNopMetrics()
 		tr := newTransaction(context.Background(), nil, true, "", rn, ms, nomc, testLogger)
 		if got := tr.Commit(); got != nil {
 			t.Errorf("expecting nil from Commit() but got err %v", got)
@@ -70,7 +71,7 @@ func Test_transaction(t *testing.T) {
 	})
 
 	t.Run("Rollback dose nothing", func(t *testing.T) {
-		nomc := exportertest.NewNopMetricsExporter()
+		nomc := consumertest.NewNopMetrics()
 		tr := newTransaction(context.Background(), nil, true, "", rn, ms, nomc, testLogger)
 		if got := tr.Rollback(); got != nil {
 			t.Errorf("expecting nil from Rollback() but got err %v", got)
@@ -79,7 +80,7 @@ func Test_transaction(t *testing.T) {
 
 	badLabels := labels.Labels([]labels.Label{{Name: "foo", Value: "bar"}})
 	t.Run("Add One No Target", func(t *testing.T) {
-		nomc := exportertest.NewNopMetricsExporter()
+		nomc := consumertest.NewNopMetrics()
 		tr := newTransaction(context.Background(), nil, true, "", rn, ms, nomc, testLogger)
 		if _, got := tr.Add(badLabels, time.Now().Unix()*1000, 1.0); got == nil {
 			t.Errorf("expecting error from Add() but got nil")
@@ -91,7 +92,7 @@ func Test_transaction(t *testing.T) {
 		{Name: "job", Value: "test2"},
 		{Name: "foo", Value: "bar"}})
 	t.Run("Add One Job not found", func(t *testing.T) {
-		nomc := exportertest.NewNopMetricsExporter()
+		nomc := consumertest.NewNopMetrics()
 		tr := newTransaction(context.Background(), nil, true, "", rn, ms, nomc, testLogger)
 		if _, got := tr.Add(jobNotFoundLb, time.Now().Unix()*1000, 1.0); got == nil {
 			t.Errorf("expecting error from Add() but got nil")

--- a/receiver/zipkinreceiver/factory_test.go
+++ b/receiver/zipkinreceiver/factory_test.go
@@ -23,7 +23,7 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configcheck"
-	"go.opentelemetry.io/collector/exporter/exportertest"
+	"go.opentelemetry.io/collector/consumer/consumertest"
 )
 
 func TestCreateDefaultConfig(t *testing.T) {
@@ -39,7 +39,7 @@ func TestCreateReceiver(t *testing.T) {
 		context.Background(),
 		component.ReceiverCreateParams{Logger: zap.NewNop()},
 		cfg,
-		exportertest.NewNopTraceExporter())
+		consumertest.NewNopTraces())
 	assert.NoError(t, err, "receiver creation failed")
 	assert.NotNil(t, tReceiver, "receiver creation failed")
 
@@ -47,7 +47,7 @@ func TestCreateReceiver(t *testing.T) {
 		context.Background(),
 		component.ReceiverCreateParams{Logger: zap.NewNop()},
 		cfg,
-		exportertest.NewNopTraceExporter())
+		consumertest.NewNopTraces())
 	assert.NoError(t, err, "receiver creation failed")
 	assert.NotNil(t, tReceiver, "receiver creation failed")
 }

--- a/receiver/zipkinreceiver/factory_test.go
+++ b/receiver/zipkinreceiver/factory_test.go
@@ -39,7 +39,7 @@ func TestCreateReceiver(t *testing.T) {
 		context.Background(),
 		component.ReceiverCreateParams{Logger: zap.NewNop()},
 		cfg,
-		consumertest.NewNopTraces())
+		consumertest.NewTracesNop())
 	assert.NoError(t, err, "receiver creation failed")
 	assert.NotNil(t, tReceiver, "receiver creation failed")
 
@@ -47,7 +47,7 @@ func TestCreateReceiver(t *testing.T) {
 		context.Background(),
 		component.ReceiverCreateParams{Logger: zap.NewNop()},
 		cfg,
-		consumertest.NewNopTraces())
+		consumertest.NewTracesNop())
 	assert.NoError(t, err, "receiver creation failed")
 	assert.NotNil(t, tReceiver, "receiver creation failed")
 }

--- a/receiver/zipkinreceiver/trace_receiver_test.go
+++ b/receiver/zipkinreceiver/trace_receiver_test.go
@@ -42,6 +42,7 @@ import (
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/config/configmodels"
 	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/exporter/exportertest"
 	"go.opentelemetry.io/collector/exporter/zipkinexporter"
@@ -69,7 +70,7 @@ func TestNew(t *testing.T) {
 		{
 			name: "happy path",
 			args: args{
-				nextConsumer: exportertest.NewNopTraceExporter(),
+				nextConsumer: consumertest.NewNopTraces(),
 			},
 		},
 	}
@@ -108,7 +109,7 @@ func TestZipkinReceiverPortAlreadyInUse(t *testing.T) {
 			Endpoint: "localhost:" + portStr,
 		},
 	}
-	traceReceiver, err := New(cfg, exportertest.NewNopTraceExporter())
+	traceReceiver, err := New(cfg, consumertest.NewNopTraces())
 	require.NoError(t, err, "Failed to create receiver: %v", err)
 	err = traceReceiver.Start(context.Background(), componenttest.NewNopHost())
 	require.Error(t, err)
@@ -204,7 +205,7 @@ func TestConversionRoundtrip(t *testing.T) {
   }
 }]`)
 
-	zi := &ZipkinReceiver{nextConsumer: exportertest.NewNopTraceExporter()}
+	zi := &ZipkinReceiver{nextConsumer: consumertest.NewNopTraces()}
 	ereqs, err := zi.v2ToTraceSpans(receiverInputJSON, nil)
 	require.NoError(t, err)
 

--- a/receiver/zipkinreceiver/trace_receiver_test.go
+++ b/receiver/zipkinreceiver/trace_receiver_test.go
@@ -70,7 +70,7 @@ func TestNew(t *testing.T) {
 		{
 			name: "happy path",
 			args: args{
-				nextConsumer: consumertest.NewNopTraces(),
+				nextConsumer: consumertest.NewTracesNop(),
 			},
 		},
 	}
@@ -109,7 +109,7 @@ func TestZipkinReceiverPortAlreadyInUse(t *testing.T) {
 			Endpoint: "localhost:" + portStr,
 		},
 	}
-	traceReceiver, err := New(cfg, consumertest.NewNopTraces())
+	traceReceiver, err := New(cfg, consumertest.NewTracesNop())
 	require.NoError(t, err, "Failed to create receiver: %v", err)
 	err = traceReceiver.Start(context.Background(), componenttest.NewNopHost())
 	require.Error(t, err)
@@ -205,7 +205,7 @@ func TestConversionRoundtrip(t *testing.T) {
   }
 }]`)
 
-	zi := &ZipkinReceiver{nextConsumer: consumertest.NewNopTraces()}
+	zi := &ZipkinReceiver{nextConsumer: consumertest.NewTracesNop()}
 	ereqs, err := zi.v2ToTraceSpans(receiverInputJSON, nil)
 	require.NoError(t, err)
 


### PR DESCRIPTION
In few situations people complained about not having a nop consumer,
because of confusion that it was implemented as Exporter, even if only used as Consumer.
