### PR TITLE
Fix OTLP/HTTP receiver's path to be /v1/traces

### DIFF
--- a/config/confighttp/confighttp.go
+++ b/config/confighttp/confighttp.go
@@ -27,7 +27,7 @@ import (
 )
 
 type HTTPClientSettings struct {
-	// The target URL to send data to (e.g.: http://some.url:9411/v1/trace).
+	// The target URL to send data to (e.g.: http://some.url:9411/v1/traces).
 	Endpoint string `mapstructure:"endpoint"`
 
 	// TLSSetting struct exposes TLS client configuration.

--- a/exporter/otlphttpexporter/otlp_test.go
+++ b/exporter/otlphttpexporter/otlp_test.go
@@ -57,7 +57,7 @@ func TestInvalidConfig(t *testing.T) {
 
 func TestTraceNoBackend(t *testing.T) {
 	addr := testutil.GetAvailableLocalAddress(t)
-	exp := startTraceExporter(t, "", fmt.Sprintf("http://%s/v1/trace", addr))
+	exp := startTraceExporter(t, "", fmt.Sprintf("http://%s/v1/traces", addr))
 	td := testdata.GenerateTraceDataOneSpan()
 	assert.Error(t, exp.ConsumeTraces(context.Background(), td))
 }
@@ -78,7 +78,7 @@ func TestTraceError(t *testing.T) {
 	sink := new(exportertest.SinkTraceExporter)
 	sink.SetConsumeTraceError(errors.New("my_error"))
 	startTraceReceiver(t, addr, sink)
-	exp := startTraceExporter(t, "", fmt.Sprintf("http://%s/v1/trace", addr))
+	exp := startTraceExporter(t, "", fmt.Sprintf("http://%s/v1/traces", addr))
 
 	td := testdata.GenerateTraceDataOneSpan()
 	assert.Error(t, exp.ConsumeTraces(context.Background(), td))
@@ -95,19 +95,17 @@ func TestTraceRoundTrip(t *testing.T) {
 		{
 			name:        "wrongbase",
 			baseURL:     "http://wronghostname",
-			overrideURL: fmt.Sprintf("http://%s/v1/trace", addr),
+			overrideURL: fmt.Sprintf("http://%s/v1/traces", addr),
 		},
-		// TODO: open this test case after fixing this bug:
-		// https://github.com/open-telemetry/opentelemetry-collector/issues/1968
-		// {
-		//	name:        "onlybase",
-		//	baseURL:     fmt.Sprintf("http://%s", addr),
-		//	overrideURL: "",
-		// },
+		{
+			name:        "onlybase",
+			baseURL:     fmt.Sprintf("http://%s", addr),
+			overrideURL: "",
+		},
 		{
 			name:        "override",
 			baseURL:     "",
-			overrideURL: fmt.Sprintf("http://%s/v1/trace", addr),
+			overrideURL: fmt.Sprintf("http://%s/v1/traces", addr),
 		},
 	}
 

--- a/internal/data/opentelemetry-proto-gen/collector/trace/v1/trace_service_gateway_aliases.go
+++ b/internal/data/opentelemetry-proto-gen/collector/trace/v1/trace_service_gateway_aliases.go
@@ -1,0 +1,80 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import (
+	context "context"
+	"net/http"
+
+	"github.com/grpc-ecosystem/grpc-gateway/runtime"
+)
+
+// The aliases in this file are necessary to fix the bug:
+// https://github.com/open-telemetry/opentelemetry-collector/issues/1968
+
+// patternTraceServiceExport0Alias is an alias for the incorrect pattern
+// pattern_TraceService_Export_0 defined in trace_service.pb.gw.go.
+//
+// The path in the pattern_TraceService_Export_0 pattern is incorrect because it is
+// composed from the historical name of the package v1.trace used in the Protobuf
+// declarations in trace_service.proto file and results in the path of /v1/trace.
+//
+// This is incorrect since the OTLP spec requires the default path to be /v1/traces,
+// see https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/protocol/otlp.md#request.
+//
+// We set the correct path in this alias.
+var patternTraceServiceExport0Alias = runtime.MustPattern(
+	runtime.NewPattern(
+		1,
+		[]int{2, 0, 2, 1},
+		[]string{"v1", "traces"}, // Patch the path to be /v1/traces.
+		"",
+		runtime.AssumeColonVerbOpt(true)),
+)
+
+// RegisterTraceServiceHandlerServerAlias registers the http handlers for service TraceService to "mux".
+// UnaryRPC     :call TraceServiceServer directly.
+// StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
+//
+// RegisterTraceServiceHandlerServerAlias is the alias version of
+// RegisterTraceServiceHandlerServer, and uses patternTraceServiceExport0Alias
+// instead of pattern_TraceService_Export_0.
+func RegisterTraceServiceHandlerServerAlias(ctx context.Context, mux *runtime.ServeMux, server TraceServiceServer) error {
+
+	// pattern_TraceService_Export_0 is replaced by patternTraceServiceExport0Alias
+	// in the following line. This is the only change in this func compared to
+	// RegisterTraceServiceHandlerServer.
+	mux.Handle("POST", patternTraceServiceExport0Alias, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateIncomingContext(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_TraceService_Export_0(rctx, inboundMarshaler, server, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_TraceService_Export_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	return nil
+}

--- a/receiver/otlpreceiver/README.md
+++ b/receiver/otlpreceiver/README.md
@@ -76,7 +76,8 @@ serialization](https://developers.google.com/protocol-buffers/docs/proto3#json).
 
 IMPORTANT: bytes fields are encoded as base64 strings.
 
-To write traces with HTTP/JSON, `POST` to `[address]/v1/trace`. The default
+To write traces with HTTP/JSON, `POST` to `[address]/v1/traces` for traces,
+to `[address]/v1/metrics` for metrics, to `[address]/v1/logs` for logs. The default
 port is `55681`.
 
 The HTTP/JSON endpoint can also optionally configure

--- a/receiver/otlpreceiver/otlp.go
+++ b/receiver/otlpreceiver/otlp.go
@@ -151,7 +151,12 @@ func (r *otlpReceiver) registerTraceConsumer(ctx context.Context, tc consumer.Tr
 		collectortrace.RegisterTraceServiceServer(r.serverGRPC, r.traceReceiver)
 	}
 	if r.gatewayMux != nil {
-		return collectortrace.RegisterTraceServiceHandlerServer(ctx, r.gatewayMux, r.traceReceiver)
+		err := collectortrace.RegisterTraceServiceHandlerServer(ctx, r.gatewayMux, r.traceReceiver)
+		if err != nil {
+			return err
+		}
+		// Also register an alias handler. This fixes bug https://github.com/open-telemetry/opentelemetry-collector/issues/1968
+		return collectortrace.RegisterTraceServiceHandlerServerAlias(ctx, r.gatewayMux, r.traceReceiver)
 	}
 	return nil
 }


### PR DESCRIPTION
OTLP/HTTP receiver was incorrectly expecting traces on /v1/trace.
OTLP spec require the path to be /v1/traces. This change adds /v1/traces
as a supported alias in the receiver to match what spec requires.

We will keep both paths supported for a while and then will eventually
retire /v1/trace.

Note that the OTLP/HTTP exporter already correctly uses /v1/traces path.

Fixes: https://github.com/open-telemetry/opentelemetry-collector/issues/1968