### PR TITLE
Small cleanups in pdata

### DIFF
--- a/consumer/pdata/trace.go
+++ b/consumer/pdata/trace.go
@@ -30,6 +30,12 @@ type Traces struct {
 	orig *[]*otlptrace.ResourceSpans
 }
 
+// NewTraces creates a new Traces.
+func NewTraces() Traces {
+	orig := []*otlptrace.ResourceSpans(nil)
+	return Traces{&orig}
+}
+
 // TracesFromOtlp creates the internal Traces representation from the OTLP.
 func TracesFromOtlp(orig []*otlptrace.ResourceSpans) Traces {
 	return Traces{&orig}
@@ -43,28 +49,23 @@ func TracesToOtlp(td Traces) []*otlptrace.ResourceSpans {
 // ToOtlpProtoBytes converts the internal Traces to OTLP Collector
 // ExportTraceServiceRequest ProtoBuf bytes.
 func (td Traces) ToOtlpProtoBytes() ([]byte, error) {
-	return proto.Marshal(&otlpcollectortrace.ExportTraceServiceRequest{
+	traces := otlpcollectortrace.ExportTraceServiceRequest{
 		ResourceSpans: *td.orig,
-	})
+	}
+	return traces.Marshal()
 }
 
 // FromOtlpProtoBytes converts OTLP Collector ExportTraceServiceRequest
 // ProtoBuf bytes to the internal Traces. Overrides current data.
 // Calling this function on zero-initialized structure causes panic.
-// Use it with NewTraces or on existing initialized Traces
+// Use it with NewTraces or on existing initialized Traces.
 func (td Traces) FromOtlpProtoBytes(data []byte) error {
-	traces := &otlpcollectortrace.ExportTraceServiceRequest{}
-	if err := proto.Unmarshal(data, traces); err != nil {
+	traces := otlpcollectortrace.ExportTraceServiceRequest{}
+	if err := traces.Unmarshal(data); err != nil {
 		return err
 	}
 	*td.orig = traces.ResourceSpans
 	return nil
-}
-
-// NewTraces creates a new Traces.
-func NewTraces() Traces {
-	orig := []*otlptrace.ResourceSpans(nil)
-	return Traces{&orig}
 }
 
 // Clone returns a copy of Traces.

--- a/consumer/pdata/trace_test.go
+++ b/consumer/pdata/trace_test.go
@@ -23,7 +23,6 @@ import (
 	goproto "google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/emptypb"
 
-	otlpcollectortrace "go.opentelemetry.io/collector/internal/data/opentelemetry-proto-gen/collector/trace/v1"
 	otlptrace "go.opentelemetry.io/collector/internal/data/opentelemetry-proto-gen/trace/v1"
 )
 
@@ -143,26 +142,19 @@ func TestResourceSpansWireCompatibility(t *testing.T) {
 	assert.EqualValues(t, *pdataRS.orig, &gogoprotoRS2)
 }
 
-func TestToOtlpProtoBytes(t *testing.T) {
-	td := NewTraces()
-	bytes, err := td.ToOtlpProtoBytes()
-	assert.Nil(t, err)
+func TestTracesToFromOtlpProtoBytes(t *testing.T) {
+	send := NewTraces()
+	fillTestResourceSpansSlice(send.ResourceSpans())
+	bytes, err := send.ToOtlpProtoBytes()
+	assert.NoError(t, err)
 
-	etsr := otlpcollectortrace.ExportTraceServiceRequest{}
-	err = gogoproto.Unmarshal(bytes, &etsr)
-	assert.Nil(t, err)
-	assert.EqualValues(t, etsr.ResourceSpans, TracesToOtlp(td))
+	recv := NewTraces()
+	err = recv.FromOtlpProtoBytes(bytes)
+	assert.NoError(t, err)
+	assert.EqualValues(t, send, recv)
 }
 
-func TestFromOtlpProtoBytes(t *testing.T) {
-	td := NewTraces()
-	bytes, err := td.ToOtlpProtoBytes()
-	assert.Nil(t, err)
-
-	err = td.FromOtlpProtoBytes(bytes)
-	assert.Nil(t, err)
-	assert.EqualValues(t, NewTraces(), td)
-
-	err = td.FromOtlpProtoBytes([]byte{0xFF})
+func TestTracesFromInvalidOtlpProtoBytes(t *testing.T) {
+	err := NewTraces().FromOtlpProtoBytes([]byte{0xFF})
 	assert.EqualError(t, err, "unexpected EOF")
 }


### PR DESCRIPTION
* Add FromOtlpProtoBytes to all signals;
* Remove deprecated unused function;
* Avoid creating new objects when possible;

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>

