### PR TITLE
Move jrcamp from Triager to Approver

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,13 +65,13 @@ Objectives:
 See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 Triagers ([@open-telemetry/collector-triagers](https://github.com/orgs/open-telemetry/teams/collector-triager)):
-- [Jay Camp](https://github.com/jrcamp), Splunk
 - [Steve Flanders](https://github.com/flands), Splunk
 
 Approvers ([@open-telemetry/collector-approvers](https://github.com/orgs/open-telemetry/teams/collector-approvers)):
 
 - [Dmitrii Anoshin](https://github.com/dmitryax), Splunk
 - [James Bebbington](https://github.com/james-bebbington), Google
+- [Jay Camp](https://github.com/jrcamp), Splunk
 - [Nail Islamov](https://github.com/nilebox), Google
 - [Owais Lone](https://github.com/owais), Splunk
 


### PR DESCRIPTION
I am nominating jrcamp as an Approver. Jay has been a reviewer
for many months and authored tens of PRs in this repo.
