### PR TITLE
Add span name character substitution to spanprocessor

### DIFF
--- a/processor/spanprocessor/README.md
+++ b/processor/spanprocessor/README.md
@@ -14,10 +14,12 @@ The following actions are supported:
 
 ### Name a span
 
-The following settings are required:
+Either `from_attributes` or `replace_chars` is required:
 
 - `from_attributes`: The attribute value for the keys are used to create a
 new name in the order specified in the configuration.
+
+- `replace_chars`: Replace or remove illegal characters.
 
 The following settings can be optionally configured:
 
@@ -35,6 +37,11 @@ span:
     from_attributes: [<key1>, <key2>, ...]
     # Separator is the string used to concatenate various parts of the span name.
     separator: <value>
+    # replace_chars represents the illegal characters to replace or remove from span name.
+    replace_chars:
+      - from_char: <original char>
+        to_char: <replacement char>
+      - from_char: <original char>
 ```
 
 Example:
@@ -44,6 +51,10 @@ span:
   name:
     from_attributes: ["db.svc", "operation"]
     separator: "::"
+    replace_chars:
+      - from_char: "*"
+        to_char: "+"
+      - from_char: "~"
 ```
 
 Refer to [config.yaml](./testdata/config.yaml) for detailed

--- a/processor/spanprocessor/config.go
+++ b/processor/spanprocessor/config.go
@@ -62,6 +62,7 @@ type Name struct {
 	ReplaceChars []*ReplaceChar `mapstructure:"replace_chars"`
 }
 
+// ToAttributes specifies rules to extract attribute values from span name.
 type ToAttributes struct {
 	// Rules is a list of rules to extract attribute values from span name. The values
 	// in the span name are replaced by extracted attribute names. Each rule in the list

--- a/processor/spanprocessor/config.go
+++ b/processor/spanprocessor/config.go
@@ -57,6 +57,9 @@ type Name struct {
 
 	// ToAttributes specifies a configuration to extract attributes from span name.
 	ToAttributes *ToAttributes `mapstructure:"to_attributes"`
+
+	// ReplaceChars contains array of substitution characters for the span name
+	ReplaceChars []*ReplaceChar `mapstructure:"replace_chars"`
 }
 
 type ToAttributes struct {
@@ -76,4 +79,13 @@ type ToAttributes struct {
 	// match. If it is false rule processing will continue to be performed over the
 	// modified span name.
 	BreakAfterMatch bool `mapstructure:"break_after_match"`
+}
+
+// ReplaceChar contains character to replace and the substitution character.
+type ReplaceChar struct {
+	// FromChar specifies the character to replace.
+	FromChar string `mapstructure:"from_char"`
+
+	// ToChar specifies the substitution character.
+	ToChar string `mapstructure:"to_char"`
 }

--- a/processor/spanprocessor/config_test.go
+++ b/processor/spanprocessor/config_test.go
@@ -99,6 +99,56 @@ func TestLoadConfig(t *testing.T) {
 			},
 		},
 	})
+
+	p4 := cfg.Processors["span/replace_char"]
+	assert.Equal(t, p4, &Config{
+		ProcessorSettings: configmodels.ProcessorSettings{
+			TypeVal: typeStr,
+			NameVal: "span/replace_char",
+		},
+		Rename: Name{
+			ReplaceChars: []*ReplaceChar{
+				{
+					FromChar: "*",
+					ToChar:   "+",
+				},
+			},
+		},
+	})
+
+	p5 := cfg.Processors["span/remove_char"]
+	assert.Equal(t, p5, &Config{
+		ProcessorSettings: configmodels.ProcessorSettings{
+			TypeVal: typeStr,
+			NameVal: "span/remove_char",
+		},
+		Rename: Name{
+			ReplaceChars: []*ReplaceChar{
+				{
+					FromChar: "~",
+				},
+			},
+		},
+	})
+
+	p6 := cfg.Processors["span/combo_chars"]
+	assert.Equal(t, p6, &Config{
+		ProcessorSettings: configmodels.ProcessorSettings{
+			TypeVal: typeStr,
+			NameVal: "span/combo_chars",
+		},
+		Rename: Name{
+			ReplaceChars: []*ReplaceChar{
+				{
+					FromChar: "*",
+					ToChar:   "+",
+				},
+				{
+					FromChar: "~",
+				},
+			},
+		},
+	})
 }
 
 func createMatchConfig(matchType filterset.MatchType) *filterset.Config {

--- a/processor/spanprocessor/factory.go
+++ b/processor/spanprocessor/factory.go
@@ -35,7 +35,7 @@ var processorCapabilities = component.ProcessorCapabilities{MutatesConsumedData:
 // is not specified.
 // TODO https://github.com/open-telemetry/opentelemetry-collector/issues/215
 //	Move this to the error package that allows for span name and field to be specified.
-var errMissingRequiredField = errors.New("error creating \"span\" processor: either \"from_attributes\" or \"to_attributes\" must be specified in \"name:\"")
+var errMissingRequiredField = errors.New("error creating \"span\" processor: either \"from_attributes\" or \"to_attributes\" or \"replace_chars\" must be specified in \"name:\"")
 
 // NewFactory returns a new factory for the Span processor.
 func NewFactory() component.ProcessorFactory {
@@ -61,11 +61,12 @@ func createTraceProcessor(
 	nextConsumer consumer.TracesConsumer,
 ) (component.TraceProcessor, error) {
 
-	// 'from_attributes' or 'to_attributes' under 'name' has to be set for the span
+	// 'from_attributes' or 'to_attributes' or 'replace_chars' under 'name' has to be set for the span
 	// processor to be valid. If not set and not enforced, the processor would do no work.
 	oCfg := cfg.(*Config)
 	if len(oCfg.Rename.FromAttributes) == 0 &&
-		(oCfg.Rename.ToAttributes == nil || len(oCfg.Rename.ToAttributes.Rules) == 0) {
+		(oCfg.Rename.ToAttributes == nil || len(oCfg.Rename.ToAttributes.Rules) == 0) &&
+		(oCfg.Rename.ReplaceChars == nil || len(oCfg.Rename.ReplaceChars) == 0) {
 		return nil, errMissingRequiredField
 	}
 

--- a/processor/spanprocessor/span.go
+++ b/processor/spanprocessor/span.go
@@ -246,7 +246,7 @@ func (sp *spanProcessor) processReplaceChars(span pdata.Span) {
 	for i := 0; i < len(sp.config.Rename.ReplaceChars); i++ {
 		fromChar := sp.config.Rename.ReplaceChars[i].FromChar
 		toChar := sp.config.Rename.ReplaceChars[i].ToChar
-		name = strings.Replace(name, fromChar, toChar, -1)
+		name = strings.ReplaceAll(name, fromChar, toChar)
 	}
 
 	span.SetName(name)

--- a/processor/spanprocessor/span.go
+++ b/processor/spanprocessor/span.go
@@ -106,6 +106,7 @@ func (sp *spanProcessor) ProcessTraces(_ context.Context, td pdata.Traces) (pdat
 				}
 				sp.processFromAttributes(s)
 				sp.processToAttributes(s)
+				sp.processReplaceChars(s)
 			}
 		}
 	}
@@ -228,4 +229,25 @@ func (sp *spanProcessor) processToAttributes(span pdata.Span) {
 			break
 		}
 	}
+}
+
+func (sp *spanProcessor) processReplaceChars(span pdata.Span) {
+	if span.Name() == "" {
+		// There is no span name to work on.
+		return
+	}
+
+	if len(sp.config.Rename.ReplaceChars) == 0 {
+		// There are no ReplaceChars mappings.
+		return
+	}
+
+	name := span.Name()
+	for i := 0; i < len(sp.config.Rename.ReplaceChars); i++ {
+		fromChar := sp.config.Rename.ReplaceChars[i].FromChar
+		toChar := sp.config.Rename.ReplaceChars[i].ToChar
+		name = strings.Replace(name, fromChar, toChar, -1)
+	}
+
+	span.SetName(name)
 }

--- a/processor/spanprocessor/span_test.go
+++ b/processor/spanprocessor/span_test.go
@@ -53,7 +53,6 @@ type testCase struct {
 	inputAttributes  map[string]pdata.AttributeValue
 	outputName       string
 	outputAttributes map[string]pdata.AttributeValue
-	replaceChars     []*ReplaceChar
 }
 
 // runIndividualTestCase is the common logic of passing trace data through a configured attributes processor.

--- a/processor/spanprocessor/testdata/config.yaml
+++ b/processor/spanprocessor/testdata/config.yaml
@@ -84,6 +84,27 @@ processors:
         rules:
           - "(?P<operation_website>.*?)$"
 
+  # The following demonstrates substitution of illegal characters
+  span/replace_char:
+    name:
+      replace_chars:
+        - from_char: '*'
+          to_char: '+'
+
+  # The following demonstrates removal of illegal characters
+  span/remove_char:
+    name:
+      replace_chars:
+        - from_char: '~'
+
+  # The following demonstrates combination of substitution and removal of illegal characters
+  span/combo_chars:
+    name:
+      replace_chars:
+        - from_char: '*'
+          to_char: '+'
+        - from_char: '~'
+
 exporters:
   exampleexporter:
 

--- a/service/internal/resources.go
+++ b/service/internal/resources.go
@@ -227,7 +227,7 @@ var _escData = map[string]*_escFile{
 		name:    "component_header.html",
 		local:   "templates/component_header.html",
 		size:    156,
-		modtime: 1594178791,
+		modtime: 1603284944,
 		compressed: `
 H4sIAAAAAAAC/1SMsQqDMBRFd7/iIq7q5lBiltKt9B8CPklQX6R1e9x/L6ZQ2vXcc65ZE3AZ0V3ztmcV
 PW467TnpQVZmzZp0Kfs96VJQizTjw1uyAgAXB+8C4lPmsT4fydqbdY+wCen64F0fB19iWV/yF/54X0en
@@ -239,7 +239,7 @@ U3kHAAD//zT+SdCcAAAA
 		name:    "extensions_table.html",
 		local:   "templates/extensions_table.html",
 		size:    353,
-		modtime: 1594178791,
+		modtime: 1603284944,
 		compressed: `
 H4sIAAAAAAAC/2SQwU7DMBBE7/2KlemRNJwjxxwQHDnwB248DRbOOnK2tGD531HTQIvqk1fzZjU7Wuw2
 gCb5CmjVNiaHVE2j7Tz3DT0osyIiynltqWlp8xSHMTJYntmN0bOUsgDJcg9ap3jw7HC8n7+z5y0epgU7
@@ -252,7 +252,7 @@ oxX5HeETfMGv9NPTkv4i2e6jT3HPrqE7AEui8yaECbdWkzPYUXWlaHFkg++5VR1YkJTRlt4Tdq06HVfK
 		name:    "footer.html",
 		local:   "templates/footer.html",
 		size:    15,
-		modtime: 1594178791,
+		modtime: 1603284944,
 		compressed: `
 H4sIAAAAAAAC/7LRT8pPqbTjstHPKMnNsQMEAAD//wEFevAPAAAA
 `,
@@ -262,7 +262,7 @@ H4sIAAAAAAAC/7LRT8pPqbTjstHPKMnNsQMEAAD//wEFevAPAAAA
 		name:    "header.html",
 		local:   "templates/header.html",
 		size:    467,
-		modtime: 1594178791,
+		modtime: 1603284944,
 		compressed: `
 H4sIAAAAAAAC/5TRMU8sIRAH8P4+BY/25eC9szGGxUItLIwW11giO7uMB8wG5rxsLvfdDdnTxNhoBeFP
 fpnM3/y5fbzZPj/dicAp2pVph4guj52ELK0J4Hq7EkIIk4Cd8MGVCtzJPQ/rS3mOGDmCPR7Vtl1OJ6OX
@@ -276,7 +276,7 @@ vuDEoocBiqjF/5RszGuV1uhFsCujl0bMC/Vz62vzZe1hY98DAAD//7qRGmLTAQAA
 		name:    "pipelines_table.html",
 		local:   "templates/pipelines_table.html",
 		size:    1946,
-		modtime: 1594178791,
+		modtime: 1603284944,
 		compressed: `
 H4sIAAAAAAAC/7SVwXLTMBCG7zyFxnRyIjVcU1scSpnhAMN0eAFZ2gRNlZVmJbdujd+dsWyrTp0LtL5k
 rOjX/tlv/8hFEJUB5sOjgTKrLCmgrXdCajzs2MeMv2OMsSLQ8DAsFJPWeCew/MSE0QcsDewDLyr+tTbm
@@ -293,7 +293,7 @@ QeMmXNC4hCvdNKvQgsYtacFoGWFFxSvCNl+lu3HQFXl8JfO/AQAA//9We3KLmgcAAA==
 		name:    "properties_table.html",
 		local:   "templates/properties_table.html",
 		size:    420,
-		modtime: 1594178791,
+		modtime: 1603284944,
 		compressed: `
 H4sIAAAAAAAC/2SRwW7DIBBE7/6KVRr1VMc5u5gfqFT11Ds2U8sqWVuwqRoR/r1yTCpb4YAEO48ZDarV
 MR7ezQkp1apqdaHEtA4U5OLQ7NrRW/gyTKYbuK/puNMFEVGMtB/Y4pfqho6UUr71hnvk0Qvt4XACyyw6


### PR DESCRIPTION
**Description:**
Adding a feature - Add character substitution to spanprocessor to allow replacement or removal of illegal characters from span name.

**Testing:** Unit tests updated to include `replace_chars`.

**Documentation:** Updated `processor/spanprocessor/README.md`
