### PR TITLE
added array serialization to logging_exporter

### DIFF
--- a/exporter/loggingexporter/logging_exporter.go
+++ b/exporter/loggingexporter/logging_exporter.go
@@ -278,9 +278,24 @@ func attributeValueToString(av pdata.AttributeValue) string {
 		return strconv.FormatFloat(av.DoubleVal(), 'f', -1, 64)
 	case pdata.AttributeValueINT:
 		return strconv.FormatInt(av.IntVal(), 10)
+	case pdata.AttributeValueARRAY:
+		return attributeValueArrayToString(av.ArrayVal())
 	default:
 		return fmt.Sprintf("<Unknown OpenTelemetry attribute value type %q>", av.Type())
 	}
+}
+
+func attributeValueArrayToString(av pdata.AnyValueArray) string {
+	retStr := "["
+	for i := 0; i < av.Len(); i++ {
+		retStr += attributeValueToString(av.At(i))
+
+		if i < av.Len() - 1 {
+			retStr += ", "
+		}
+	}
+
+	return retStr + "]"
 }
 
 type loggingExporter struct {

--- a/exporter/loggingexporter/logging_exporter.go
+++ b/exporter/loggingexporter/logging_exporter.go
@@ -286,16 +286,18 @@ func attributeValueToString(av pdata.AttributeValue) string {
 }
 
 func attributeValueArrayToString(av pdata.AnyValueArray) string {
-	retStr := "["
+	var b strings.Builder
+	b.WriteByte('[')
 	for i := 0; i < av.Len(); i++ {
-		retStr += attributeValueToString(av.At(i))
-
 		if i < av.Len()-1 {
-			retStr += ", "
+			fmt.Fprintf(&b, "%s, ", attributeValueToString(av.At(i)))
+		} else {
+			b.WriteString(attributeValueToString(av.At(i)))
 		}
 	}
 
-	return retStr + "]"
+	b.WriteByte(']')
+	return b.String()
 }
 
 type loggingExporter struct {

--- a/exporter/loggingexporter/logging_exporter.go
+++ b/exporter/loggingexporter/logging_exporter.go
@@ -290,7 +290,7 @@ func attributeValueArrayToString(av pdata.AnyValueArray) string {
 	for i := 0; i < av.Len(); i++ {
 		retStr += attributeValueToString(av.At(i))
 
-		if i < av.Len() - 1 {
+		if i < av.Len()-1 {
 			retStr += ", "
 		}
 	}


### PR DESCRIPTION
**Description:** Bug fix - adds serialization of array attributes, including nested arrays, in the `logging_exporter`. This allows them to be printed like the primitive attribute types when debugging. AFAICT, there aren't any attributes with array values today, but they are permitted types in the [spec](https://github.com/open-telemetry/opentelemetry-specification/blob/master/semantic_conventions/syntax.md#attributes), and I will be contributing a resource detector that uses array attributes in the future. 

**Testing:** Added unit test

