### PR TITLE
Add expr pdata.Metric filtering support to filterprocessor 2/2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/HdrHistogram/hdrhistogram-go v0.9.0 // indirect
 	github.com/OneOfOne/xxhash v1.2.5 // indirect
 	github.com/Shopify/sarama v1.27.0
+	github.com/antonmedv/expr v1.8.9
 	github.com/apache/thrift v0.13.0
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/census-instrumentation/opencensus-proto v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -114,6 +114,8 @@ github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo
 github.com/andybalholm/brotli v1.0.0/go.mod h1:loMXtMfwqflxFJPmdbJO0a3KNoPuLBgiu3qAvBg8x/Y=
 github.com/antihax/optional v0.0.0-20180407024304-ca021399b1a6/go.mod h1:V8iCPQYkqmusNa815XgQio277wI47sdRh1dUOLdyC6Q=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
+github.com/antonmedv/expr v1.8.9 h1:O9stiHmHHww9b4ozhPx7T6BK7fXfOCHJ8ybxf0833zw=
+github.com/antonmedv/expr v1.8.9/go.mod h1:5qsM3oLGDND7sDmQGDXHkYfkjYMUX14qsgqmHhwGEk8=
 github.com/apache/arrow/go/arrow v0.0.0-20191024131854-af6fa24be0db/go.mod h1:VTxUBvSJ3s3eHAg65PNgrsn5BtqCRPdmyXh6rAfdxN0=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0 h1:5hryIiq9gtn+MiLVn0wP37kb/uTeRZgN08WoCsAhIhI=
@@ -194,6 +196,7 @@ github.com/crossdock/crossdock-go v0.0.0-20160816171116-049aabb0122b/go.mod h1:v
 github.com/daixiang0/gci v0.2.4 h1:BUCKk5nlK2m+kRIsoj+wb/5hazHvHeZieBKWd9Afa8Q=
 github.com/daixiang0/gci v0.2.4/go.mod h1:+AV8KmHTGxxwp/pY84TLQfFKp2vuKXXJVzF3kD/hfR4=
 github.com/dave/jennifer v1.2.0/go.mod h1:fIb+770HOpJ2fmN9EPPKOqm1vMGhB+TwXKMZhrIygKg=
+github.com/davecgh/go-spew v0.0.0-20161028175848-04cdfd42973b/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -259,6 +262,8 @@ github.com/frankban/quicktest v1.10.0/go.mod h1:ui7WezCLWMWxVWr1GETZY3smRy0G4KWq
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
+github.com/gdamore/encoding v1.0.0/go.mod h1:alR0ol34c49FCSBLjhosxzcPHQbf2trDkoo5dl+VrEg=
+github.com/gdamore/tcell v1.3.0/go.mod h1:Hjvr+Ofd+gLglo7RYKxxnzCBmev3BzsS67MebKS4zMM=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -709,6 +714,8 @@ github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lightstep/lightstep-tracer-common/golang/gogo v0.0.0-20190605223551-bc2310a04743/go.mod h1:qklhhLq1aX+mtWk9cPHPzaBjWImj5ULL6C7HFJtXQMM=
 github.com/lightstep/lightstep-tracer-go v0.18.1/go.mod h1:jlF1pusYV4pidLvZ+XD0UBX0ZE6WURAspgAczcDHrL4=
 github.com/logrusorgru/aurora v0.0.0-20181002194514-a7b3b318ed4e/go.mod h1:7rIyQOR62GCctdiQpZ/zOJlFyk6y+94wXzv6RNZgaR4=
+github.com/lucasb-eyer/go-colorful v1.0.2/go.mod h1:0MS4r+7BZKSJ5mw4/S5MPN+qHFF1fYclkSPilDOKW0s=
+github.com/lucasb-eyer/go-colorful v1.0.3/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/lyft/protoc-gen-validate v0.0.13/go.mod h1:XbGvPuh87YZc5TdIa2/I4pLk0QoUACkjt2znoq26NVQ=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.1 h1:ZC2Vc7/ZFkGmsVC9KvOjumD+G5lXy2RtTKyzRKO2BQ4=
@@ -742,6 +749,8 @@ github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHX
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.3/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
+github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
+github.com/mattn/go-runewidth v0.0.8/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-sqlite3 v1.9.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/mattn/go-sqlite3 v1.11.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/mattn/go-tty v0.0.0-20180907095812-13ff1204f104/go.mod h1:XPvLUNfbS4fJH25nqRHfWLMa1ONC8Amw+mIA639KxkE=
@@ -890,6 +899,7 @@ github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/profile v1.2.1/go.mod h1:hJw3o1OdXxsrSjjVksARp5W95eeEaEfptyVZyv6JUPA=
 github.com/pkg/term v0.0.0-20180730021639-bffc007b7fd5/go.mod h1:eCbImbZ95eXtAUIbLAuAVnBnwf83mjf6QIVH8SHYwqQ=
+github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
@@ -956,6 +966,8 @@ github.com/rcrowley/go-metrics v0.0.0-20190826022208-cac0b30c2563/go.mod h1:bCqn
 github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0 h1:MkV+77GLUNo5oJ0jf870itWm3D0Sjh7+Za9gazKc5LQ=
 github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/retailnext/hllpp v1.0.1-0.20180308014038-101a6d2f8b52/go.mod h1:RDpi1RftBQPUCDRw6SmxeaREsAaRKnOclghuzp/WRzc=
+github.com/rivo/tview v0.0.0-20200219210816-cd38d7432498/go.mod h1:6lkG1x+13OShEf0EaOCaTQYyB7d5nSbb181KtjlS+84=
+github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.1.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
@@ -976,6 +988,7 @@ github.com/ryanuber/columnize v2.1.0+incompatible/go.mod h1:sm1tb6uqfes/u+d4ooFo
 github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da/go.mod h1:gi+0XIa01GRL2eRQVjQkKGqKF3SF9vZR/HnPullcV2E=
 github.com/samuel/go-zookeeper v0.0.0-20200724154423-2164a8ac840e h1:CGjiMQ0wMH4wtNWrlj6kiTbkPt2F3rbYnhGX6TWLfco=
 github.com/samuel/go-zookeeper v0.0.0-20200724154423-2164a8ac840e/go.mod h1:gi+0XIa01GRL2eRQVjQkKGqKF3SF9vZR/HnPullcV2E=
+github.com/sanity-io/litter v1.2.0/go.mod h1:JF6pZUFgu2Q0sBZ+HSV35P8TVPI1TTzEwyu9FXAw2W4=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/satori/go.uuid v1.2.1-0.20181028125025-b2ce2384e17b/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sclevine/agouti v3.0.0+incompatible/go.mod h1:b4WX9W9L1sfQKXeJf1mUTLZKJ48R1S7H23Ji7oFO5Bw=
@@ -1052,6 +1065,7 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0 h1:Hbg2NidpLE8veEBkEZTL3CvlkUIVzuU9jDplZO54c48=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
+github.com/stretchr/testify v0.0.0-20161117074351-18a02ba4a312/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.0/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
@@ -1297,6 +1311,7 @@ golang.org/x/sys v0.0.0-20190531175056-4c3a928424d2/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190616124812-15dcb6c0061f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190626150813-e07cf5db2756/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190904154756-749cb33beabd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/internal/processor/filterexpr/matcher.go
+++ b/internal/processor/filterexpr/matcher.go
@@ -1,0 +1,195 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filterexpr
+
+import (
+	"log"
+
+	"github.com/antonmedv/expr"
+	"github.com/antonmedv/expr/vm"
+
+	"go.opentelemetry.io/collector/consumer/pdata"
+)
+
+type Matcher struct {
+	program *vm.Program
+	v       vm.VM
+}
+
+type env struct {
+	MetricName string
+	HasLabel   func(key string) bool
+	Label      func(key string) string
+}
+
+func NewMatcher(expression string) (*Matcher, error) {
+	program, err := expr.Compile(expression)
+	if err != nil {
+		return nil, err
+	}
+	return &Matcher{program: program, v: vm.VM{}}, nil
+}
+
+func (m *Matcher) MatchMetric(metric pdata.Metric) bool {
+	metricName := metric.Name()
+	switch metric.DataType() {
+	case pdata.MetricDataTypeIntGauge:
+		return m.matchIntGauge(metricName, metric.IntGauge())
+	case pdata.MetricDataTypeDoubleGauge:
+		return m.matchDoubleGauge(metricName, metric.DoubleGauge())
+	case pdata.MetricDataTypeIntSum:
+		return m.matchIntSum(metricName, metric.IntSum())
+	case pdata.MetricDataTypeDoubleSum:
+		return m.matchDoubleSum(metricName, metric.DoubleSum())
+	case pdata.MetricDataTypeIntHistogram:
+		return m.matchIntHistogram(metricName, metric.IntHistogram())
+	case pdata.MetricDataTypeDoubleHistogram:
+		return m.matchDoubleHistogram(metricName, metric.DoubleHistogram())
+	default:
+		return false
+	}
+}
+
+func (m *Matcher) matchIntGauge(metricName string, gauge pdata.IntGauge) bool {
+	if gauge.IsNil() {
+		return false
+	}
+	pts := gauge.DataPoints()
+	for i := 0; i < pts.Len(); i++ {
+		pt := pts.At(i)
+		if pt.IsNil() {
+			continue
+		}
+		if m.matchEnv(metricName, pt.LabelsMap()) {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *Matcher) matchDoubleGauge(metricName string, gauge pdata.DoubleGauge) bool {
+	if gauge.IsNil() {
+		return false
+	}
+	pts := gauge.DataPoints()
+	for i := 0; i < pts.Len(); i++ {
+		pt := pts.At(i)
+		if pt.IsNil() {
+			continue
+		}
+		if m.matchEnv(metricName, pt.LabelsMap()) {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *Matcher) matchDoubleSum(metricName string, sum pdata.DoubleSum) bool {
+	if sum.IsNil() {
+		return false
+	}
+	pts := sum.DataPoints()
+	for i := 0; i < pts.Len(); i++ {
+		pt := pts.At(i)
+		if pt.IsNil() {
+			continue
+		}
+		if m.matchEnv(metricName, pt.LabelsMap()) {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *Matcher) matchIntSum(metricName string, sum pdata.IntSum) bool {
+	if sum.IsNil() {
+		return false
+	}
+	pts := sum.DataPoints()
+	for i := 0; i < pts.Len(); i++ {
+		pt := pts.At(i)
+		if pt.IsNil() {
+			continue
+		}
+		if m.matchEnv(metricName, pt.LabelsMap()) {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *Matcher) matchIntHistogram(metricName string, histogram pdata.IntHistogram) bool {
+	if histogram.IsNil() {
+		return false
+	}
+	pts := histogram.DataPoints()
+	for i := 0; i < pts.Len(); i++ {
+		pt := pts.At(i)
+		if pt.IsNil() {
+			continue
+		}
+		if m.matchEnv(metricName, pt.LabelsMap()) {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *Matcher) matchDoubleHistogram(metricName string, histogram pdata.DoubleHistogram) bool {
+	if histogram.IsNil() {
+		return false
+	}
+	pts := histogram.DataPoints()
+	for i := 0; i < pts.Len(); i++ {
+		pt := pts.At(i)
+		if pt.IsNil() {
+			continue
+		}
+		if m.matchEnv(metricName, pt.LabelsMap()) {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *Matcher) matchEnv(metricName string, labelsMap pdata.StringMap) bool {
+	return m.match(createEnv(metricName, labelsMap))
+}
+
+func createEnv(metricName string, labelsMap pdata.StringMap) env {
+	return env{
+		MetricName: metricName,
+		HasLabel: func(key string) bool {
+			_, ok := labelsMap.Get(key)
+			return ok
+		},
+		Label: func(key string) string {
+			v, ok := labelsMap.Get(key)
+			if !ok {
+				return ""
+			}
+			return v.Value()
+		},
+	}
+}
+
+func (m *Matcher) match(env env) bool {
+	result, err := m.v.Run(m.program, env)
+	if err != nil {
+		log.Printf("expr run error: %s", err.Error())
+		return false
+	}
+	return result.(bool)
+}

--- a/internal/processor/filterexpr/matcher.go
+++ b/internal/processor/filterexpr/matcher.go
@@ -15,8 +15,6 @@
 package filterexpr
 
 import (
-	"log"
-
 	"github.com/antonmedv/expr"
 	"github.com/antonmedv/expr/vm"
 
@@ -42,7 +40,7 @@ func NewMatcher(expression string) (*Matcher, error) {
 	return &Matcher{program: program, v: vm.VM{}}, nil
 }
 
-func (m *Matcher) MatchMetric(metric pdata.Metric) bool {
+func (m *Matcher) MatchMetric(metric pdata.Metric) (bool, error) {
 	metricName := metric.Name()
 	switch metric.DataType() {
 	case pdata.MetricDataTypeIntGauge:
@@ -58,13 +56,13 @@ func (m *Matcher) MatchMetric(metric pdata.Metric) bool {
 	case pdata.MetricDataTypeDoubleHistogram:
 		return m.matchDoubleHistogram(metricName, metric.DoubleHistogram())
 	default:
-		return false
+		return false, nil
 	}
 }
 
-func (m *Matcher) matchIntGauge(metricName string, gauge pdata.IntGauge) bool {
+func (m *Matcher) matchIntGauge(metricName string, gauge pdata.IntGauge) (bool, error) {
 	if gauge.IsNil() {
-		return false
+		return false, nil
 	}
 	pts := gauge.DataPoints()
 	for i := 0; i < pts.Len(); i++ {
@@ -72,16 +70,20 @@ func (m *Matcher) matchIntGauge(metricName string, gauge pdata.IntGauge) bool {
 		if pt.IsNil() {
 			continue
 		}
-		if m.matchEnv(metricName, pt.LabelsMap()) {
-			return true
+		matched, err := m.matchEnv(metricName, pt.LabelsMap())
+		if err != nil {
+			return false, err
+		}
+		if matched {
+			return true, nil
 		}
 	}
-	return false
+	return false, nil
 }
 
-func (m *Matcher) matchDoubleGauge(metricName string, gauge pdata.DoubleGauge) bool {
+func (m *Matcher) matchDoubleGauge(metricName string, gauge pdata.DoubleGauge) (bool, error) {
 	if gauge.IsNil() {
-		return false
+		return false, nil
 	}
 	pts := gauge.DataPoints()
 	for i := 0; i < pts.Len(); i++ {
@@ -89,16 +91,20 @@ func (m *Matcher) matchDoubleGauge(metricName string, gauge pdata.DoubleGauge) b
 		if pt.IsNil() {
 			continue
 		}
-		if m.matchEnv(metricName, pt.LabelsMap()) {
-			return true
+		matched, err := m.matchEnv(metricName, pt.LabelsMap())
+		if err != nil {
+			return false, err
+		}
+		if matched {
+			return true, nil
 		}
 	}
-	return false
+	return false, nil
 }
 
-func (m *Matcher) matchDoubleSum(metricName string, sum pdata.DoubleSum) bool {
+func (m *Matcher) matchDoubleSum(metricName string, sum pdata.DoubleSum) (bool, error) {
 	if sum.IsNil() {
-		return false
+		return false, nil
 	}
 	pts := sum.DataPoints()
 	for i := 0; i < pts.Len(); i++ {
@@ -106,16 +112,20 @@ func (m *Matcher) matchDoubleSum(metricName string, sum pdata.DoubleSum) bool {
 		if pt.IsNil() {
 			continue
 		}
-		if m.matchEnv(metricName, pt.LabelsMap()) {
-			return true
+		matched, err := m.matchEnv(metricName, pt.LabelsMap())
+		if err != nil {
+			return false, err
+		}
+		if matched {
+			return true, nil
 		}
 	}
-	return false
+	return false, nil
 }
 
-func (m *Matcher) matchIntSum(metricName string, sum pdata.IntSum) bool {
+func (m *Matcher) matchIntSum(metricName string, sum pdata.IntSum) (bool, error) {
 	if sum.IsNil() {
-		return false
+		return false, nil
 	}
 	pts := sum.DataPoints()
 	for i := 0; i < pts.Len(); i++ {
@@ -123,16 +133,20 @@ func (m *Matcher) matchIntSum(metricName string, sum pdata.IntSum) bool {
 		if pt.IsNil() {
 			continue
 		}
-		if m.matchEnv(metricName, pt.LabelsMap()) {
-			return true
+		matched, err := m.matchEnv(metricName, pt.LabelsMap())
+		if err != nil {
+			return false, err
+		}
+		if matched {
+			return true, nil
 		}
 	}
-	return false
+	return false, nil
 }
 
-func (m *Matcher) matchIntHistogram(metricName string, histogram pdata.IntHistogram) bool {
+func (m *Matcher) matchIntHistogram(metricName string, histogram pdata.IntHistogram) (bool, error) {
 	if histogram.IsNil() {
-		return false
+		return false, nil
 	}
 	pts := histogram.DataPoints()
 	for i := 0; i < pts.Len(); i++ {
@@ -140,16 +154,20 @@ func (m *Matcher) matchIntHistogram(metricName string, histogram pdata.IntHistog
 		if pt.IsNil() {
 			continue
 		}
-		if m.matchEnv(metricName, pt.LabelsMap()) {
-			return true
+		matched, err := m.matchEnv(metricName, pt.LabelsMap())
+		if err != nil {
+			return false, err
+		}
+		if matched {
+			return true, nil
 		}
 	}
-	return false
+	return false, nil
 }
 
-func (m *Matcher) matchDoubleHistogram(metricName string, histogram pdata.DoubleHistogram) bool {
+func (m *Matcher) matchDoubleHistogram(metricName string, histogram pdata.DoubleHistogram) (bool, error) {
 	if histogram.IsNil() {
-		return false
+		return false, nil
 	}
 	pts := histogram.DataPoints()
 	for i := 0; i < pts.Len(); i++ {
@@ -157,14 +175,18 @@ func (m *Matcher) matchDoubleHistogram(metricName string, histogram pdata.Double
 		if pt.IsNil() {
 			continue
 		}
-		if m.matchEnv(metricName, pt.LabelsMap()) {
-			return true
+		matched, err := m.matchEnv(metricName, pt.LabelsMap())
+		if err != nil {
+			return false, err
+		}
+		if matched {
+			return true, nil
 		}
 	}
-	return false
+	return false, nil
 }
 
-func (m *Matcher) matchEnv(metricName string, labelsMap pdata.StringMap) bool {
+func (m *Matcher) matchEnv(metricName string, labelsMap pdata.StringMap) (bool, error) {
 	return m.match(createEnv(metricName, labelsMap))
 }
 
@@ -185,11 +207,10 @@ func createEnv(metricName string, labelsMap pdata.StringMap) env {
 	}
 }
 
-func (m *Matcher) match(env env) bool {
+func (m *Matcher) match(env env) (bool, error) {
 	result, err := m.v.Run(m.program, env)
 	if err != nil {
-		log.Printf("expr run error: %s", err.Error())
-		return false
+		return false, err
 	}
-	return result.(bool)
+	return result.(bool), nil
 }

--- a/internal/processor/filterexpr/matcher_test.go
+++ b/internal/processor/filterexpr/matcher_test.go
@@ -1,0 +1,384 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filterexpr
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/collector/consumer/pdata"
+)
+
+func TestCompileExprError(t *testing.T) {
+	_, err := NewMatcher("")
+	require.Error(t, err)
+}
+
+func TestRunExprError(t *testing.T) {
+	matcher, err := NewMatcher("foo")
+	require.NoError(t, err)
+	matched := matcher.match(env{})
+	require.False(t, matched)
+}
+
+func TestUnknownDataType(t *testing.T) {
+	matcher, err := NewMatcher(`MetricName == 'my.metric'`)
+	require.NoError(t, err)
+	m := pdata.NewMetric()
+	m.InitEmpty()
+	m.SetName("my.metric")
+	m.SetDataType(-1)
+	matched := matcher.MatchMetric(m)
+	assert.False(t, matched)
+}
+
+func TestNilIntGauge(t *testing.T) {
+	dataType := pdata.MetricDataTypeIntGauge
+	testNilValue(t, dataType)
+}
+
+func TestNilDoubleGauge(t *testing.T) {
+	dataType := pdata.MetricDataTypeDoubleGauge
+	testNilValue(t, dataType)
+}
+
+func TestNilDoubleSum(t *testing.T) {
+	dataType := pdata.MetricDataTypeDoubleSum
+	testNilValue(t, dataType)
+}
+
+func TestNilIntSum(t *testing.T) {
+	dataType := pdata.MetricDataTypeIntSum
+	testNilValue(t, dataType)
+}
+
+func TestNilIntHistogram(t *testing.T) {
+	dataType := pdata.MetricDataTypeIntHistogram
+	testNilValue(t, dataType)
+}
+
+func TestNilDoubleHistogram(t *testing.T) {
+	dataType := pdata.MetricDataTypeDoubleHistogram
+	testNilValue(t, dataType)
+}
+
+func testNilValue(t *testing.T, dataType pdata.MetricDataType) {
+	matcher, err := NewMatcher(`MetricName == 'my.metric'`)
+	require.NoError(t, err)
+	m := pdata.NewMetric()
+	m.InitEmpty()
+	m.SetName("my.metric")
+	m.SetDataType(dataType)
+	matched := matcher.MatchMetric(m)
+	assert.False(t, matched)
+}
+
+func TestIntGaugeNilDataPoint(t *testing.T) {
+	matcher, err := NewMatcher(`MetricName == 'my.metric'`)
+	require.NoError(t, err)
+	m := pdata.NewMetric()
+	m.InitEmpty()
+	m.SetName("my.metric")
+	m.SetDataType(pdata.MetricDataTypeIntGauge)
+	gauge := m.IntGauge()
+	gauge.InitEmpty()
+	dps := gauge.DataPoints()
+	pt := pdata.NewIntDataPoint()
+	dps.Append(pt)
+	matched := matcher.MatchMetric(m)
+	assert.False(t, matched)
+}
+
+func TestDoubleGaugeNilDataPoint(t *testing.T) {
+	matcher, err := NewMatcher(`MetricName == 'my.metric'`)
+	require.NoError(t, err)
+	m := pdata.NewMetric()
+	m.InitEmpty()
+	m.SetName("my.metric")
+	m.SetDataType(pdata.MetricDataTypeDoubleGauge)
+	gauge := m.DoubleGauge()
+	gauge.InitEmpty()
+	dps := gauge.DataPoints()
+	pt := pdata.NewDoubleDataPoint()
+	dps.Append(pt)
+	matched := matcher.MatchMetric(m)
+	assert.False(t, matched)
+}
+
+func TestDoubleSumNilDataPoint(t *testing.T) {
+	matcher, err := NewMatcher(`MetricName == 'my.metric'`)
+	require.NoError(t, err)
+	m := pdata.NewMetric()
+	m.InitEmpty()
+	m.SetName("my.metric")
+	m.SetDataType(pdata.MetricDataTypeDoubleSum)
+	sum := m.DoubleSum()
+	sum.InitEmpty()
+	dps := sum.DataPoints()
+	pt := pdata.NewDoubleDataPoint()
+	dps.Append(pt)
+	matched := matcher.MatchMetric(m)
+	assert.False(t, matched)
+}
+
+func TestIntSumNilDataPoint(t *testing.T) {
+	matcher, err := NewMatcher(`MetricName == 'my.metric'`)
+	require.NoError(t, err)
+	m := pdata.NewMetric()
+	m.InitEmpty()
+	m.SetName("my.metric")
+	m.SetDataType(pdata.MetricDataTypeIntSum)
+	sum := m.IntSum()
+	sum.InitEmpty()
+	dps := sum.DataPoints()
+	pt := pdata.NewIntDataPoint()
+	dps.Append(pt)
+	matched := matcher.MatchMetric(m)
+	assert.False(t, matched)
+}
+
+func TestIntHistogramNilDataPoint(t *testing.T) {
+	matcher, err := NewMatcher(`MetricName == 'my.metric'`)
+	require.NoError(t, err)
+	m := pdata.NewMetric()
+	m.InitEmpty()
+	m.SetName("my.metric")
+	m.SetDataType(pdata.MetricDataTypeIntHistogram)
+	h := m.IntHistogram()
+	h.InitEmpty()
+	dps := h.DataPoints()
+	pt := pdata.NewIntHistogramDataPoint()
+	dps.Append(pt)
+	matched := matcher.MatchMetric(m)
+	assert.False(t, matched)
+}
+
+func TestDoubleHistogramNilDataPoint(t *testing.T) {
+	matcher, err := NewMatcher(`MetricName == 'my.metric'`)
+	require.NoError(t, err)
+	m := pdata.NewMetric()
+	m.InitEmpty()
+	m.SetName("my.metric")
+	m.SetDataType(pdata.MetricDataTypeDoubleHistogram)
+	h := m.DoubleHistogram()
+	h.InitEmpty()
+	dps := h.DataPoints()
+	pt := pdata.NewDoubleHistogramDataPoint()
+	dps.Append(pt)
+	matched := matcher.MatchMetric(m)
+	assert.False(t, matched)
+}
+
+func TestMatchIntGaugeByMetricName(t *testing.T) {
+	expression := `MetricName == 'my.metric'`
+	assert.True(t, testMatchIntGauge(t, "my.metric", expression, nil))
+}
+
+func TestNonMatchIntGaugeByMetricName(t *testing.T) {
+	expression := `MetricName == 'my.metric'`
+	assert.False(t, testMatchIntGauge(t, "foo.metric", expression, nil))
+}
+
+func TestNonMatchIntGaugeDataPointByMetricAndHasLabel(t *testing.T) {
+	expression := `MetricName == 'my.metric' && HasLabel("foo")`
+	assert.False(t, testMatchIntGauge(t, "foo.metric", expression, nil))
+}
+
+func TestMatchIntGaugeDataPointByMetricAndHasLabel(t *testing.T) {
+	expression := `MetricName == 'my.metric' && HasLabel("foo")`
+	assert.True(t, testMatchIntGauge(t, "my.metric", expression, map[string]string{"foo": ""}))
+}
+
+func TestMatchIntGaugeDataPointByMetricAndLabelValue(t *testing.T) {
+	expression := `MetricName == 'my.metric' && Label("foo") == "bar"`
+	assert.False(t, testMatchIntGauge(t, "my.metric", expression, map[string]string{"foo": ""}))
+}
+
+func TestNonMatchIntGaugeDataPointByMetricAndLabelValue(t *testing.T) {
+	expression := `MetricName == 'my.metric' && Label("foo") == "bar"`
+	assert.False(t, testMatchIntGauge(t, "my.metric", expression, map[string]string{"foo": ""}))
+}
+
+func testMatchIntGauge(t *testing.T, metricName, expression string, lbls map[string]string) bool {
+	matcher, err := NewMatcher(expression)
+	require.NoError(t, err)
+	m := pdata.NewMetric()
+	m.InitEmpty()
+	m.SetName(metricName)
+	m.SetDataType(pdata.MetricDataTypeIntGauge)
+	gauge := m.IntGauge()
+	gauge.InitEmpty()
+	dps := gauge.DataPoints()
+	pt := pdata.NewIntDataPoint()
+	pt.InitEmpty()
+	if lbls != nil {
+		pt.LabelsMap().InitFromMap(lbls)
+	}
+	dps.Append(pt)
+	return matcher.MatchMetric(m)
+}
+
+func TestMatchIntGaugeDataPointByMetricAndSecondPointLabelValue(t *testing.T) {
+	matcher, err := NewMatcher(
+		`MetricName == 'my.metric' && Label("baz") == "glarch"`,
+	)
+	require.NoError(t, err)
+	m := pdata.NewMetric()
+	m.InitEmpty()
+	m.SetName("my.metric")
+	m.SetDataType(pdata.MetricDataTypeIntGauge)
+	gauge := m.IntGauge()
+	gauge.InitEmpty()
+	dps := gauge.DataPoints()
+
+	pt1 := pdata.NewIntDataPoint()
+	pt1.InitEmpty()
+	pt1.LabelsMap().Insert("foo", "bar")
+	dps.Append(pt1)
+
+	pt2 := pdata.NewIntDataPoint()
+	pt2.InitEmpty()
+	pt2.LabelsMap().Insert("baz", "glarch")
+	dps.Append(pt2)
+
+	matched := matcher.MatchMetric(m)
+	assert.True(t, matched)
+}
+
+func TestMatchDoubleGaugeByMetricName(t *testing.T) {
+	assert.True(t, testMatchDoubleGauge(t, "my.metric"))
+}
+
+func TestNonMatchDoubleGaugeByMetricName(t *testing.T) {
+	assert.False(t, testMatchDoubleGauge(t, "foo.metric"))
+}
+
+func testMatchDoubleGauge(t *testing.T, metricName string) bool {
+	matcher, err := NewMatcher(`MetricName == 'my.metric'`)
+	require.NoError(t, err)
+	m := pdata.NewMetric()
+	m.InitEmpty()
+	m.SetName(metricName)
+	m.SetDataType(pdata.MetricDataTypeDoubleGauge)
+	gauge := m.DoubleGauge()
+	gauge.InitEmpty()
+	dps := gauge.DataPoints()
+	pt := pdata.NewDoubleDataPoint()
+	pt.InitEmpty()
+	dps.Append(pt)
+	return matcher.MatchMetric(m)
+}
+
+func TestMatchDoubleSumByMetricName(t *testing.T) {
+	assert.True(t, matchDoubleSum(t, "my.metric"))
+}
+
+func TestNonMatchDoubleSumByMetricName(t *testing.T) {
+	assert.False(t, matchDoubleSum(t, "foo.metric"))
+}
+
+func matchDoubleSum(t *testing.T, metricName string) bool {
+	matcher, err := NewMatcher(`MetricName == 'my.metric'`)
+	require.NoError(t, err)
+	m := pdata.NewMetric()
+	m.InitEmpty()
+	m.SetName(metricName)
+	m.SetDataType(pdata.MetricDataTypeDoubleSum)
+	sum := m.DoubleSum()
+	sum.InitEmpty()
+	dps := sum.DataPoints()
+	pt := pdata.NewDoubleDataPoint()
+	pt.InitEmpty()
+	dps.Append(pt)
+	matched := matcher.MatchMetric(m)
+	return matched
+}
+
+func TestMatchIntSumByMetricName(t *testing.T) {
+	assert.True(t, matchIntSum(t, "my.metric"))
+}
+
+func TestNonMatchIntSumByMetricName(t *testing.T) {
+	assert.False(t, matchIntSum(t, "foo.metric"))
+}
+
+func matchIntSum(t *testing.T, metricName string) bool {
+	matcher, err := NewMatcher(`MetricName == 'my.metric'`)
+	require.NoError(t, err)
+	m := pdata.NewMetric()
+	m.InitEmpty()
+	m.SetName(metricName)
+	m.SetDataType(pdata.MetricDataTypeIntSum)
+	sum := m.IntSum()
+	sum.InitEmpty()
+	dps := sum.DataPoints()
+	pt := pdata.NewIntDataPoint()
+	pt.InitEmpty()
+	dps.Append(pt)
+	matched := matcher.MatchMetric(m)
+	return matched
+}
+
+func TestMatchIntHistogramByMetricName(t *testing.T) {
+	assert.True(t, matchIntHistogram(t, "my.metric"))
+}
+
+func TestNonMatchIntHistogramByMetricName(t *testing.T) {
+	assert.False(t, matchIntHistogram(t, "foo.metric"))
+}
+
+func matchIntHistogram(t *testing.T, metricName string) bool {
+	matcher, err := NewMatcher(`MetricName == 'my.metric'`)
+	require.NoError(t, err)
+	m := pdata.NewMetric()
+	m.InitEmpty()
+	m.SetName(metricName)
+	m.SetDataType(pdata.MetricDataTypeIntHistogram)
+	sum := m.IntHistogram()
+	sum.InitEmpty()
+	dps := sum.DataPoints()
+	pt := pdata.NewIntHistogramDataPoint()
+	pt.InitEmpty()
+	dps.Append(pt)
+	matched := matcher.MatchMetric(m)
+	return matched
+}
+
+func TestMatchDoubleHistogramByMetricName(t *testing.T) {
+	assert.True(t, matchDoubleHistogram(t, "my.metric"))
+}
+
+func TestNonMatchDoubleHistogramByMetricName(t *testing.T) {
+	assert.False(t, matchDoubleHistogram(t, "foo.metric"))
+}
+
+func matchDoubleHistogram(t *testing.T, metricName string) bool {
+	matcher, err := NewMatcher(`MetricName == 'my.metric'`)
+	require.NoError(t, err)
+	m := pdata.NewMetric()
+	m.InitEmpty()
+	m.SetName(metricName)
+	m.SetDataType(pdata.MetricDataTypeDoubleHistogram)
+	sum := m.DoubleHistogram()
+	sum.InitEmpty()
+	dps := sum.DataPoints()
+	pt := pdata.NewDoubleHistogramDataPoint()
+	pt.InitEmpty()
+	dps.Append(pt)
+	matched := matcher.MatchMetric(m)
+	return matched
+}

--- a/internal/processor/filterexpr/matcher_test.go
+++ b/internal/processor/filterexpr/matcher_test.go
@@ -31,7 +31,7 @@ func TestCompileExprError(t *testing.T) {
 func TestRunExprError(t *testing.T) {
 	matcher, err := NewMatcher("foo")
 	require.NoError(t, err)
-	matched := matcher.match(env{})
+	matched, _ := matcher.match(env{})
 	require.False(t, matched)
 }
 
@@ -42,7 +42,8 @@ func TestUnknownDataType(t *testing.T) {
 	m.InitEmpty()
 	m.SetName("my.metric")
 	m.SetDataType(-1)
-	matched := matcher.MatchMetric(m)
+	matched, err := matcher.MatchMetric(m)
+	assert.NoError(t, err)
 	assert.False(t, matched)
 }
 
@@ -83,7 +84,8 @@ func testNilValue(t *testing.T, dataType pdata.MetricDataType) {
 	m.InitEmpty()
 	m.SetName("my.metric")
 	m.SetDataType(dataType)
-	matched := matcher.MatchMetric(m)
+	matched, err := matcher.MatchMetric(m)
+	assert.NoError(t, err)
 	assert.False(t, matched)
 }
 
@@ -99,7 +101,8 @@ func TestIntGaugeNilDataPoint(t *testing.T) {
 	dps := gauge.DataPoints()
 	pt := pdata.NewIntDataPoint()
 	dps.Append(pt)
-	matched := matcher.MatchMetric(m)
+	matched, err := matcher.MatchMetric(m)
+	assert.NoError(t, err)
 	assert.False(t, matched)
 }
 
@@ -115,7 +118,8 @@ func TestDoubleGaugeNilDataPoint(t *testing.T) {
 	dps := gauge.DataPoints()
 	pt := pdata.NewDoubleDataPoint()
 	dps.Append(pt)
-	matched := matcher.MatchMetric(m)
+	matched, err := matcher.MatchMetric(m)
+	assert.NoError(t, err)
 	assert.False(t, matched)
 }
 
@@ -131,7 +135,8 @@ func TestDoubleSumNilDataPoint(t *testing.T) {
 	dps := sum.DataPoints()
 	pt := pdata.NewDoubleDataPoint()
 	dps.Append(pt)
-	matched := matcher.MatchMetric(m)
+	matched, err := matcher.MatchMetric(m)
+	assert.NoError(t, err)
 	assert.False(t, matched)
 }
 
@@ -147,7 +152,8 @@ func TestIntSumNilDataPoint(t *testing.T) {
 	dps := sum.DataPoints()
 	pt := pdata.NewIntDataPoint()
 	dps.Append(pt)
-	matched := matcher.MatchMetric(m)
+	matched, err := matcher.MatchMetric(m)
+	assert.NoError(t, err)
 	assert.False(t, matched)
 }
 
@@ -163,7 +169,8 @@ func TestIntHistogramNilDataPoint(t *testing.T) {
 	dps := h.DataPoints()
 	pt := pdata.NewIntHistogramDataPoint()
 	dps.Append(pt)
-	matched := matcher.MatchMetric(m)
+	matched, err := matcher.MatchMetric(m)
+	assert.NoError(t, err)
 	assert.False(t, matched)
 }
 
@@ -179,7 +186,8 @@ func TestDoubleHistogramNilDataPoint(t *testing.T) {
 	dps := h.DataPoints()
 	pt := pdata.NewDoubleHistogramDataPoint()
 	dps.Append(pt)
-	matched := matcher.MatchMetric(m)
+	matched, err := matcher.MatchMetric(m)
+	assert.NoError(t, err)
 	assert.False(t, matched)
 }
 
@@ -229,7 +237,9 @@ func testMatchIntGauge(t *testing.T, metricName, expression string, lbls map[str
 		pt.LabelsMap().InitFromMap(lbls)
 	}
 	dps.Append(pt)
-	return matcher.MatchMetric(m)
+	match, err := matcher.MatchMetric(m)
+	assert.NoError(t, err)
+	return match
 }
 
 func TestMatchIntGaugeDataPointByMetricAndSecondPointLabelValue(t *testing.T) {
@@ -255,7 +265,8 @@ func TestMatchIntGaugeDataPointByMetricAndSecondPointLabelValue(t *testing.T) {
 	pt2.LabelsMap().Insert("baz", "glarch")
 	dps.Append(pt2)
 
-	matched := matcher.MatchMetric(m)
+	matched, err := matcher.MatchMetric(m)
+	assert.NoError(t, err)
 	assert.True(t, matched)
 }
 
@@ -280,7 +291,9 @@ func testMatchDoubleGauge(t *testing.T, metricName string) bool {
 	pt := pdata.NewDoubleDataPoint()
 	pt.InitEmpty()
 	dps.Append(pt)
-	return matcher.MatchMetric(m)
+	match, err := matcher.MatchMetric(m)
+	assert.NoError(t, err)
+	return match
 }
 
 func TestMatchDoubleSumByMetricName(t *testing.T) {
@@ -304,7 +317,8 @@ func matchDoubleSum(t *testing.T, metricName string) bool {
 	pt := pdata.NewDoubleDataPoint()
 	pt.InitEmpty()
 	dps.Append(pt)
-	matched := matcher.MatchMetric(m)
+	matched, err := matcher.MatchMetric(m)
+	assert.NoError(t, err)
 	return matched
 }
 
@@ -329,7 +343,8 @@ func matchIntSum(t *testing.T, metricName string) bool {
 	pt := pdata.NewIntDataPoint()
 	pt.InitEmpty()
 	dps.Append(pt)
-	matched := matcher.MatchMetric(m)
+	matched, err := matcher.MatchMetric(m)
+	assert.NoError(t, err)
 	return matched
 }
 
@@ -354,7 +369,8 @@ func matchIntHistogram(t *testing.T, metricName string) bool {
 	pt := pdata.NewIntHistogramDataPoint()
 	pt.InitEmpty()
 	dps.Append(pt)
-	matched := matcher.MatchMetric(m)
+	matched, err := matcher.MatchMetric(m)
+	assert.NoError(t, err)
 	return matched
 }
 
@@ -379,6 +395,7 @@ func matchDoubleHistogram(t *testing.T, metricName string) bool {
 	pt := pdata.NewDoubleHistogramDataPoint()
 	pt.InitEmpty()
 	dps.Append(pt)
-	matched := matcher.MatchMetric(m)
+	matched, err := matcher.MatchMetric(m)
+	assert.NoError(t, err)
 	return matched
 }

--- a/internal/processor/filtermetric/config.go
+++ b/internal/processor/filtermetric/config.go
@@ -45,4 +45,8 @@ type MatchProperties struct {
 	// MetricNames specifies the list of string patterns to match metric names against.
 	// A match occurs if the metric name matches at least one string pattern in this list.
 	MetricNames []string `mapstructure:"metric_names"`
+
+	// Expressions specifies the list of expr expressions to match metrics against.
+	// A match occurs if any datapoint in a metric matches at least one expression in this list.
+	Expressions []string `mapstructure:"expressions"`
 }

--- a/internal/processor/filtermetric/expr_matcher.go
+++ b/internal/processor/filtermetric/expr_matcher.go
@@ -35,11 +35,15 @@ func newExprMatcher(expressions []string) (*exprMatcher, error) {
 	return m, nil
 }
 
-func (m *exprMatcher) MatchMetric(metric pdata.Metric) bool {
+func (m *exprMatcher) MatchMetric(metric pdata.Metric) (bool, error) {
 	for _, matcher := range m.matchers {
-		if matcher.MatchMetric(metric) {
-			return true
+		matched, err := matcher.MatchMetric(metric)
+		if err != nil {
+			return false, err
+		}
+		if matched {
+			return true, nil
 		}
 	}
-	return false
+	return false, nil
 }

--- a/internal/processor/filtermetric/filtermetric.go
+++ b/internal/processor/filtermetric/filtermetric.go
@@ -19,7 +19,7 @@ import (
 )
 
 type Matcher interface {
-	MatchMetric(metric pdata.Metric) bool
+	MatchMetric(metric pdata.Metric) (bool, error)
 }
 
 // NewMatcher constructs a metric Matcher. If an 'expr' match type is specified,

--- a/internal/processor/filtermetric/filtermetric_test.go
+++ b/internal/processor/filtermetric/filtermetric_test.go
@@ -90,7 +90,9 @@ func TestMatcherMatches(t *testing.T) {
 			assert.NotNil(t, matcher)
 			assert.NoError(t, err)
 
-			assert.Equal(t, test.shouldMatch, matcher.MatchMetric(test.metric))
+			matches, err := matcher.MatchMetric(test.metric)
+			assert.NoError(t, err)
+			assert.Equal(t, test.shouldMatch, matches)
 		})
 	}
 }

--- a/internal/processor/filtermetric/name_matcher.go
+++ b/internal/processor/filtermetric/name_matcher.go
@@ -1,0 +1,47 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filtermetric
+
+import (
+	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.opentelemetry.io/collector/internal/processor/filterset"
+)
+
+// nameMatcher matches metrics by metric properties against prespecified values for each property.
+type nameMatcher struct {
+	nameFilters filterset.FilterSet
+}
+
+func newNameMatcher(config *MatchProperties) (*nameMatcher, error) {
+	nameFS, err := filterset.CreateFilterSet(
+		config.MetricNames,
+		&filterset.Config{
+			MatchType:    filterset.MatchType(config.MatchType),
+			RegexpConfig: config.RegexpConfig,
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &nameMatcher{
+		nameFilters: nameFS,
+	}, nil
+}
+
+// MatchMetric matches a metric using the metric properties configured on the nameMatcher.
+// A metric only matches if every metric property configured on the nameMatcher is a match.
+func (m *nameMatcher) MatchMetric(metric pdata.Metric) bool {
+	return m.nameFilters.Matches(metric.Name())
+}

--- a/internal/processor/filtermetric/name_matcher.go
+++ b/internal/processor/filtermetric/name_matcher.go
@@ -42,6 +42,6 @@ func newNameMatcher(config *MatchProperties) (*nameMatcher, error) {
 
 // MatchMetric matches a metric using the metric properties configured on the nameMatcher.
 // A metric only matches if every metric property configured on the nameMatcher is a match.
-func (m *nameMatcher) MatchMetric(metric pdata.Metric) bool {
-	return m.nameFilters.Matches(metric.Name())
+func (m *nameMatcher) MatchMetric(metric pdata.Metric) (bool, error) {
+	return m.nameFilters.Matches(metric.Name()), nil
 }

--- a/processor/filterprocessor/README.md
+++ b/processor/filterprocessor/README.md
@@ -3,8 +3,9 @@
 Supported pipeline types: metrics
 
 The filter processor can be configured to include or exclude metrics based on
-metric name. Please refer to [config.go](./config.go) for the
-config spec.
+metric name in the case of the 'strict' or 'regexp' match types, or based on other
+metric attributes in the case of the 'expr' match type. Please refer to
+[config.go](./config.go) for the config spec.
 
 It takes a pipeline type, of which only `metrics` is supported, followed by an
 action:
@@ -44,7 +45,7 @@ examples on using the processor.
 In addition to matching metric names with the 'strict' or 'regexp' match types, the filter processor
 supports matching entire `Metric`s using the [expr](https://github.com/antonmedv/expr) expression engine.
 
-The expr filter evaluates the supplied boolean expressions _per datapoint_ on a metric, and returns a result
+The 'expr' filter evaluates the supplied boolean expressions _per datapoint_ on a metric, and returns a result
 for the entire metric. If any datapoint evaluates to true then the entire metric evaluates to true, otherwise
 false.
 
@@ -72,4 +73,35 @@ processors:
 ```
 
 The above config will filter out any Metric that both has the name "my.metric" and has at least one datapoint
-with a label of `my_label="abc123"`.
+with a label of 'my_label="abc123"'.
+
+##### Support for multiple expressions
+
+As with "strict" and "regexp", multiple "expr" `expressions` are allowed.
+
+For example, the following two filters have the same effect: they filter out metrics named "system.cpu.time" and
+"system.disk.io". 
+
+```
+processors:
+  filter/expr:
+    metrics:
+      exclude:
+        match_type: expr
+        expressions:
+          - MetricName == "system.cpu.time"
+          - MetricName == "system.disk.io"
+  filter/strict:
+    metrics:
+      exclude:
+        match_type: strict
+        metric_names:
+          - system.cpu.time
+          - system.disk.io
+```
+
+The expressions are effectively ORed per datapoint. So for the above 'expr' configuration, given a datapoint, if its
+parent Metric's name is "system.cpu.time" or "system.disk.io" then there's a match. The conditions are tested against
+all the datapoints in a Metric until there's a match, in which case the entire Metric is considered a match, and in
+the above example the Metric will be excluded. If after testing all the datapoints in a Metric against all the
+expressions there isn't a match, the entire Metric is considered to be not matching.

--- a/processor/filterprocessor/README.md
+++ b/processor/filterprocessor/README.md
@@ -12,8 +12,9 @@ action:
 - `exclude`: Any names matching filters are excluded from remainder of pipeline
 
 For the actions the following parameters are required:
- - `match_type`: strict|regexp
- - `metric_names`: list of strings or re2 regex patterns
+ - `match_type`: strict|regexp|expr
+ - `metric_names`: (only for a `match_type` of 'strict' or 'regexp') list of strings or re2 regex patterns
+ - `expressions`: (only for a `match_type` of 'expr') list of expr expressions (see "Using an 'expr' match_type" below)
 
 More details can found at [include/exclude metrics](../README.md#includeexclude-metrics).
 
@@ -37,3 +38,38 @@ processors:
 
 Refer to the config files in [testdata](./testdata) for detailed
 examples on using the processor.
+
+### Using an 'expr' match_type
+
+In addition to matching metric names with the 'strict' or 'regexp' match types, the filter processor
+supports matching entire `Metric`s using the [expr](https://github.com/antonmedv/expr) expression engine.
+
+The expr filter evaluates the supplied boolean expressions _per datapoint_ on a metric, and returns a result
+for the entire metric. If any datapoint evaluates to true then the entire metric evaluates to true, otherwise
+false.
+
+Made available to the expression environment are the following:
+
+* `MetricName`
+    a variable containing the current Metric's name
+* `Label(name)`
+    a function that takes a label name string as an argument and returns a string: the value of a label with that
+    name if one exists, or ""
+* `HasLabel(name)`
+    a function that takes a label name string as an argument and returns a boolean: true if the datapoint has a label
+    with that name, false otherwise
+
+Example:
+
+```yaml
+processors:
+  filter/1:
+    metrics:
+      exclude:
+        match_type: expr
+        expressions:
+        - MetricName == "my.metric" && Label("my_label") == "abc123"
+```
+
+The above config will filter out any Metric that both has the name "my.metric" and has at least one datapoint
+with a label of `my_label="abc123"`.

--- a/processor/filterprocessor/expr_test.go
+++ b/processor/filterprocessor/expr_test.go
@@ -1,0 +1,181 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filterprocessor
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config/configmodels"
+	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.opentelemetry.io/collector/exporter/exportertest"
+	"go.opentelemetry.io/collector/internal/goldendataset"
+	"go.opentelemetry.io/collector/internal/processor/filtermetric"
+)
+
+const filteredMetric = "p0_metric_1"
+const filteredLblKey = "pt-label-key-1"
+const filteredLblVal = "pt-label-val-1"
+
+func TestExprProcessor(t *testing.T) {
+	testFilter(t, pdata.MetricDataTypeIntGauge)
+	testFilter(t, pdata.MetricDataTypeDoubleGauge)
+	testFilter(t, pdata.MetricDataTypeIntSum)
+	testFilter(t, pdata.MetricDataTypeDoubleSum)
+	testFilter(t, pdata.MetricDataTypeIntHistogram)
+	testFilter(t, pdata.MetricDataTypeDoubleHistogram)
+}
+
+func testFilter(t *testing.T, mdType pdata.MetricDataType) {
+	format := "MetricName == '%s' && Label('%s') == '%s'"
+	q := fmt.Sprintf(format, filteredMetric, filteredLblKey, filteredLblVal)
+
+	mds := testDataSlice(2, mdType)
+	totMetricCount := 0
+	for _, md := range mds {
+		totMetricCount += md.MetricCount()
+	}
+	expectedMetricCount := totMetricCount - 1
+	filtered := filterMetrics(t, nil, []string{q}, mds)
+	filteredMetricCount := 0
+	for _, metrics := range filtered {
+		filteredMetricCount += metrics.MetricCount()
+		rmsSlice := metrics.ResourceMetrics()
+		for i := 0; i < rmsSlice.Len(); i++ {
+			rms := rmsSlice.At(i)
+			ilms := rms.InstrumentationLibraryMetrics()
+			for j := 0; j < ilms.Len(); j++ {
+				ilm := ilms.At(j)
+				metricSlice := ilm.Metrics()
+				for k := 0; k < metricSlice.Len(); k++ {
+					metric := metricSlice.At(k)
+					if metric.Name() == filteredMetric {
+						dt := metric.DataType()
+						switch dt {
+						case pdata.MetricDataTypeIntGauge:
+							pts := metric.IntGauge().DataPoints()
+							for l := 0; l < pts.Len(); l++ {
+								assertFiltered(t, pts.At(l).LabelsMap())
+							}
+						case pdata.MetricDataTypeDoubleGauge:
+							pts := metric.DoubleGauge().DataPoints()
+							for l := 0; l < pts.Len(); l++ {
+								assertFiltered(t, pts.At(l).LabelsMap())
+							}
+						case pdata.MetricDataTypeIntSum:
+							pts := metric.IntSum().DataPoints()
+							for l := 0; l < pts.Len(); l++ {
+								assertFiltered(t, pts.At(l).LabelsMap())
+							}
+						case pdata.MetricDataTypeDoubleSum:
+							pts := metric.DoubleSum().DataPoints()
+							for l := 0; l < pts.Len(); l++ {
+								assertFiltered(t, pts.At(l).LabelsMap())
+							}
+						case pdata.MetricDataTypeIntHistogram:
+							pts := metric.IntHistogram().DataPoints()
+							for l := 0; l < pts.Len(); l++ {
+								assertFiltered(t, pts.At(l).LabelsMap())
+							}
+						case pdata.MetricDataTypeDoubleHistogram:
+							pts := metric.DoubleHistogram().DataPoints()
+							for l := 0; l < pts.Len(); l++ {
+								assertFiltered(t, pts.At(l).LabelsMap())
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	assert.Equal(t, expectedMetricCount, filteredMetricCount)
+}
+
+func assertFiltered(t *testing.T, lm pdata.StringMap) {
+	lm.ForEach(func(k string, v pdata.StringValue) {
+		if k == filteredLblKey && v.Value() == filteredLblVal {
+			assert.Fail(t, "found metric that should have been filtered out")
+		}
+	})
+}
+
+func filterMetrics(t *testing.T, include []string, exclude []string, mds []pdata.Metrics) []pdata.Metrics {
+	factory := NewFactory()
+
+	cfg := exprConfig(factory, include, exclude)
+
+	ctx := context.Background()
+	next := &exportertest.SinkMetricsExporter{}
+	proc, err := factory.CreateMetricsProcessor(
+		ctx,
+		component.ProcessorCreateParams{},
+		cfg,
+		next,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, proc)
+
+	for _, md := range mds {
+		err = proc.ConsumeMetrics(ctx, md)
+		require.NoError(t, err)
+	}
+	return next.AllMetrics()
+}
+
+func exprConfig(factory component.ProcessorFactory, include []string, exclude []string) configmodels.Processor {
+	cfg := factory.CreateDefaultConfig()
+	pCfg := cfg.(*Config)
+	pCfg.Metrics = MetricFilters{}
+	if include != nil {
+		pCfg.Metrics.Include = &filtermetric.MatchProperties{
+			MatchType:   "expr",
+			Expressions: include,
+		}
+	}
+	if exclude != nil {
+		pCfg.Metrics.Exclude = &filtermetric.MatchProperties{
+			MatchType:   "expr",
+			Expressions: exclude,
+		}
+	}
+	return cfg
+}
+
+func testDataSlice(size int, mdType pdata.MetricDataType) []pdata.Metrics {
+	var out []pdata.Metrics
+	for i := 0; i < 16; i++ {
+		out = append(out, testData(fmt.Sprintf("p%d_", i), size, mdType))
+	}
+	return out
+}
+
+func testData(prefix string, size int, mdType pdata.MetricDataType) pdata.Metrics {
+	c := goldendataset.MetricCfg{
+		MetricDescriptorType: mdType,
+		MetricNamePrefix:     prefix,
+		NumILMPerResource:    size,
+		NumMetricsPerILM:     size,
+		NumPtLabels:          size,
+		NumPtsPerMetric:      size,
+		NumResourceAttrs:     size,
+		NumResourceMetrics:   size,
+	}
+	return goldendataset.MetricDataFromCfg(c)
+}

--- a/processor/filterprocessor/expr_test.go
+++ b/processor/filterprocessor/expr_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configmodels"
@@ -125,7 +126,9 @@ func filterMetrics(t *testing.T, include []string, exclude []string, mds []pdata
 	next := &exportertest.SinkMetricsExporter{}
 	proc, err := factory.CreateMetricsProcessor(
 		ctx,
-		component.ProcessorCreateParams{},
+		component.ProcessorCreateParams{
+			Logger: zap.NewNop(),
+		},
 		cfg,
 		next,
 	)

--- a/processor/filterprocessor/factory.go
+++ b/processor/filterprocessor/factory.go
@@ -49,11 +49,11 @@ func createDefaultConfig() configmodels.Processor {
 
 func createMetricsProcessor(
 	_ context.Context,
-	_ component.ProcessorCreateParams,
+	params component.ProcessorCreateParams,
 	cfg configmodels.Processor,
 	nextConsumer consumer.MetricsConsumer,
 ) (component.MetricsProcessor, error) {
-	fp, err := newFilterMetricProcessor(cfg.(*Config))
+	fp, err := newFilterMetricProcessor(params.Logger, cfg.(*Config))
 	if err != nil {
 		return nil, err
 	}

--- a/processor/filterprocessor/filter_processor.go
+++ b/processor/filterprocessor/filter_processor.go
@@ -24,8 +24,8 @@ import (
 
 type filterMetricProcessor struct {
 	cfg     *Config
-	include *filtermetric.Matcher
-	exclude *filtermetric.Matcher
+	include filtermetric.Matcher
+	exclude filtermetric.Matcher
 }
 
 func newFilterMetricProcessor(cfg *Config) (*filterMetricProcessor, error) {
@@ -46,18 +46,12 @@ func newFilterMetricProcessor(cfg *Config) (*filterMetricProcessor, error) {
 	}, nil
 }
 
-func createMatcher(mp *filtermetric.MatchProperties) (*filtermetric.Matcher, error) {
+func createMatcher(mp *filtermetric.MatchProperties) (filtermetric.Matcher, error) {
 	// Nothing specified in configuration
 	if mp == nil {
 		return nil, nil
 	}
-
-	matcher, err := filtermetric.NewMatcher(mp)
-	if err != nil {
-		return nil, err
-	}
-
-	return &matcher, nil
+	return filtermetric.NewMatcher(mp)
 }
 
 // ProcessMetrics filters the given metrics based off the filterMetricProcessor's filters.

--- a/processor/filterprocessor/filter_processor.go
+++ b/processor/filterprocessor/filter_processor.go
@@ -17,6 +17,8 @@ package filterprocessor
 import (
 	"context"
 
+	"go.uber.org/zap"
+
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/internal/processor/filtermetric"
 	"go.opentelemetry.io/collector/processor/processorhelper"
@@ -26,9 +28,10 @@ type filterMetricProcessor struct {
 	cfg     *Config
 	include filtermetric.Matcher
 	exclude filtermetric.Matcher
+	logger  *zap.Logger
 }
 
-func newFilterMetricProcessor(cfg *Config) (*filterMetricProcessor, error) {
+func newFilterMetricProcessor(logger *zap.Logger, cfg *Config) (*filterMetricProcessor, error) {
 	inc, err := createMatcher(cfg.Metrics.Include)
 	if err != nil {
 		return nil, err
@@ -39,10 +42,33 @@ func newFilterMetricProcessor(cfg *Config) (*filterMetricProcessor, error) {
 		return nil, err
 	}
 
+	includeMatchType := ""
+	var includeExpressions []string
+	if cfg.Metrics.Include != nil {
+		includeMatchType = string(cfg.Metrics.Include.MatchType)
+		includeExpressions = cfg.Metrics.Include.Expressions
+	}
+
+	excludeMatchType := ""
+	var excludeExpressions []string
+	if cfg.Metrics.Exclude != nil {
+		excludeMatchType = string(cfg.Metrics.Exclude.MatchType)
+		excludeExpressions = cfg.Metrics.Exclude.Expressions
+	}
+
+	logger.Info(
+		"Metric filter configured",
+		zap.String("include match_type", includeMatchType),
+		zap.Strings("include", includeExpressions),
+		zap.String("exclude match_type", excludeMatchType),
+		zap.Strings("exclude", excludeExpressions),
+	)
+
 	return &filterMetricProcessor{
 		cfg:     cfg,
 		include: inc,
 		exclude: exc,
+		logger:  logger,
 	}, nil
 }
 
@@ -75,7 +101,12 @@ func (fmp *filterMetricProcessor) ProcessMetrics(_ context.Context, pdm pdata.Me
 				if metric.IsNil() {
 					continue
 				}
-				if fmp.shouldKeepMetric(metric) {
+				keep, err := fmp.shouldKeepMetric(metric)
+				if err != nil {
+					fmp.logger.Error("shouldKeepMetric failed", zap.Error(err))
+					// don't `continue`, keep the metric if there's an error
+				}
+				if keep {
 					idx.add(i, j, k)
 				}
 			}
@@ -87,18 +118,27 @@ func (fmp *filterMetricProcessor) ProcessMetrics(_ context.Context, pdm pdata.Me
 	return idx.extract(pdm), nil
 }
 
-func (fmp *filterMetricProcessor) shouldKeepMetric(metric pdata.Metric) bool {
+func (fmp *filterMetricProcessor) shouldKeepMetric(metric pdata.Metric) (bool, error) {
 	if fmp.include != nil {
-		if !fmp.include.MatchMetric(metric) {
-			return false
+		matches, err := fmp.include.MatchMetric(metric)
+		if err != nil {
+			// default to keep if there's an error
+			return true, err
+		}
+		if !matches {
+			return false, nil
 		}
 	}
 
 	if fmp.exclude != nil {
-		if fmp.exclude.MatchMetric(metric) {
-			return false
+		matches, err := fmp.exclude.MatchMetric(metric)
+		if err != nil {
+			return true, err
+		}
+		if matches {
+			return false, nil
 		}
 	}
 
-	return true
+	return true, nil
 }

--- a/processor/filterprocessor/filter_processor.go
+++ b/processor/filterprocessor/filter_processor.go
@@ -44,24 +44,30 @@ func newFilterMetricProcessor(logger *zap.Logger, cfg *Config) (*filterMetricPro
 
 	includeMatchType := ""
 	var includeExpressions []string
+	var includeMetricNames []string
 	if cfg.Metrics.Include != nil {
 		includeMatchType = string(cfg.Metrics.Include.MatchType)
 		includeExpressions = cfg.Metrics.Include.Expressions
+		includeMetricNames = cfg.Metrics.Include.MetricNames
 	}
 
 	excludeMatchType := ""
 	var excludeExpressions []string
+	var excludeMetricNames []string
 	if cfg.Metrics.Exclude != nil {
 		excludeMatchType = string(cfg.Metrics.Exclude.MatchType)
 		excludeExpressions = cfg.Metrics.Exclude.Expressions
+		excludeMetricNames = cfg.Metrics.Exclude.MetricNames
 	}
 
 	logger.Info(
 		"Metric filter configured",
 		zap.String("include match_type", includeMatchType),
-		zap.Strings("include", includeExpressions),
+		zap.Strings("include expressions", includeExpressions),
+		zap.Strings("include metric names", includeMetricNames),
 		zap.String("exclude match_type", excludeMatchType),
-		zap.Strings("exclude", excludeExpressions),
+		zap.Strings("exclude expressions", excludeExpressions),
+		zap.Strings("exclude metric names", excludeMetricNames),
 	)
 
 	return &filterMetricProcessor{

--- a/processor/filterprocessor/filter_processor_test.go
+++ b/processor/filterprocessor/filter_processor_test.go
@@ -258,15 +258,36 @@ func metricsWithName(names []string) []*metricspb.Metric {
 	return ret
 }
 
-func BenchmarkFilter(b *testing.B) {
+func BenchmarkStrictFilter(b *testing.B) {
+	mp := &filtermetric.MatchProperties{
+		MatchType:   "strict",
+		MetricNames: []string{"p10_metric_0"},
+	}
+	benchmarkFilter(b, mp)
+}
+
+func BenchmarkRegexpFilter(b *testing.B) {
+	mp := &filtermetric.MatchProperties{
+		MatchType:   "regexp",
+		MetricNames: []string{"p10_metric_0"},
+	}
+	benchmarkFilter(b, mp)
+}
+
+func BenchmarkExprFilter(b *testing.B) {
+	mp := &filtermetric.MatchProperties{
+		MatchType:   "expr",
+		Expressions: []string{`MetricName == "p10_metric_0"`},
+	}
+	benchmarkFilter(b, mp)
+}
+
+func benchmarkFilter(b *testing.B, mp *filtermetric.MatchProperties) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
 	pcfg := cfg.(*Config)
 	pcfg.Metrics = MetricFilters{
-		Exclude: &filtermetric.MatchProperties{
-			MatchType:   "strict",
-			MetricNames: []string{"p10_metric_0"},
-		},
+		Exclude: mp,
 	}
 	next := &etest.SinkMetricsExporter{}
 	ctx := context.Background()

--- a/processor/filterprocessor/filter_processor_test.go
+++ b/processor/filterprocessor/filter_processor_test.go
@@ -23,6 +23,7 @@ import (
 	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"go.opentelemetry.io/collector/component"
@@ -194,7 +195,14 @@ func TestFilterMetricProcessor(t *testing.T) {
 				},
 			}
 			factory := NewFactory()
-			fmp, err := factory.CreateMetricsProcessor(context.Background(), component.ProcessorCreateParams{}, cfg, next)
+			fmp, err := factory.CreateMetricsProcessor(
+				context.Background(),
+				component.ProcessorCreateParams{
+					Logger: zap.NewNop(),
+				},
+				cfg,
+				next,
+			)
 			assert.NotNil(t, fmp)
 			assert.Nil(t, err)
 
@@ -398,7 +406,9 @@ func requireNotPanics(t *testing.T, metrics pdata.Metrics) {
 	ctx := context.Background()
 	proc, _ := factory.CreateMetricsProcessor(
 		ctx,
-		component.ProcessorCreateParams{},
+		component.ProcessorCreateParams{
+			Logger: zap.NewNop(),
+		},
 		cfg,
 		next,
 	)

--- a/processor/filterprocessor/testdata/config_expr.yaml
+++ b/processor/filterprocessor/testdata/config_expr.yaml
@@ -1,0 +1,41 @@
+receivers:
+    examplereceiver:
+
+processors:
+    filter/empty:
+        metrics:
+            include:
+                match_type: expr
+    filter/include:
+        metrics:
+            include:
+                match_type: expr
+                expressions:
+                    - Label("foo") == "bar"
+                    - HasLabel("baz")
+    filter/exclude:
+        metrics:
+            exclude:
+                match_type: expr
+                expressions:
+                    - Label("foo") == "bar"
+                    - HasLabel("baz")
+    filter/includeexclude:
+        metrics:
+            include:
+                match_type: expr
+                expressions:
+                    - HasLabel("foo")
+            exclude:
+                match_type: expr
+                expressions:
+                    - HasLabel("bar")
+exporters:
+    exampleexporter:
+
+service:
+    pipelines:
+        metrics:
+            receivers: [examplereceiver]
+            processors: [filter/empty]
+            exporters: [exampleexporter]


### PR DESCRIPTION
This is the second part of the expr metric filtering implementation.

The first PR is here (the description has some additional explanation): https://github.com/open-telemetry/opentelemetry-collector/pull/1940

There's also usage info in the [README](https://github.com/open-telemetry/opentelemetry-collector/pull/1996/files#diff-142d49d9de1b5c15f12404dce18ade26e9a8777110030d7f9d80281b96fa35b3).