### PR TITLE
Fix alphabetic ordering in READMEs

### DIFF
--- a/exporter/README.md
+++ b/exporter/README.md
@@ -6,10 +6,10 @@ exporter translates the internal format into another defined format.
 Supported trace exporters (sorted alphabetically):
 
 - [Jaeger](jaegerexporter/README.md)
+- [Kafka](kafkaexporter/README.md)
 - [OpenCensus](opencensusexporter/README.md)
 - [OTLP](otlpexporter/README.md)
 - [Zipkin](zipkinexporter/README.md)
-- [Kafka](kafkaexporter/README.md)
 
 Supported metric exporters (sorted alphabetically):
 

--- a/receiver/README.md
+++ b/receiver/README.md
@@ -8,10 +8,10 @@ The format of the traces and metrics supported are receiver specific.
 
 Supported trace receivers (sorted alphabetically):
 - [Jaeger Receiver](jaegerreceiver/README.md)
+- [Kafka Receiver](kafkareceiver/README.md)
 - [OpenCensus Receiver](opencensusreceiver/README.md)
 - [OpenTelemetry Receiver](otlpreceiver/README.md)
 - [Zipkin Receiver](zipkinreceiver/README.md)
-- [Kafka Receiver](kafkareceiver/README.md)
 
 Supported metric receivers (sorted alphabetically):
 - [Host Metrics Receiver](hostmetricsreceiver/README.md)


### PR DESCRIPTION
Small thing, but I think it's better to have the bullets consistent with the heading.
