### PR TITLE
Logging Exporter: Add index for histogram buckets count

### DIFF
--- a/exporter/loggingexporter/logging_exporter.go
+++ b/exporter/loggingexporter/logging_exporter.go
@@ -165,7 +165,7 @@ func (b *logDataBuffer) logDoubleHistogramDataPoints(ps pdata.DoubleHistogramDat
 
 		buckets := p.BucketCounts()
 		if len(buckets) != 0 {
-			for _, bucket := range buckets {
+			for i, bucket := range buckets {
 				b.logEntry("Buckets #%d, Count: %d", i, bucket)
 			}
 		}

--- a/exporter/loggingexporter/logging_exporter.go
+++ b/exporter/loggingexporter/logging_exporter.go
@@ -165,8 +165,8 @@ func (b *logDataBuffer) logDoubleHistogramDataPoints(ps pdata.DoubleHistogramDat
 
 		buckets := p.BucketCounts()
 		if len(buckets) != 0 {
-			for i, bucket := range buckets {
-				b.logEntry("Buckets #%d, Count: %d", i, bucket)
+			for j, bucket := range buckets {
+				b.logEntry("Buckets #%d, Count: %d", j, bucket)
 			}
 		}
 	}
@@ -196,8 +196,8 @@ func (b *logDataBuffer) logIntHistogramDataPoints(ps pdata.IntHistogramDataPoint
 
 		buckets := p.BucketCounts()
 		if len(buckets) != 0 {
-			for _, bucket := range buckets {
-				b.logEntry("Buckets #%d, Count: %d", i, bucket)
+			for j, bucket := range buckets {
+				b.logEntry("Buckets #%d, Count: %d", j, bucket)
 			}
 		}
 	}


### PR DESCRIPTION
## Description

This PR was introduced to fix the logging exporter to increment the histogram bucket labels (when logging out metrics). Previously, the bucket count stayed at 0. However, bucket labels should increment to conform with the Explicit Bound labels.

Related issue: https://github.com/open-telemetry/opentelemetry-collector/issues/2008
