### PR TITLE
Improve diagnostic logging for exporters

### DIFF
--- a/exporter/exporterhelper/common.go
+++ b/exporter/exporterhelper/common.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"go.opencensus.io/trace"
+	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenterror"
@@ -164,7 +165,7 @@ type baseExporter struct {
 	shutdownOnce sync.Once
 }
 
-func newBaseExporter(cfg configmodels.Exporter, options ...ExporterOption) *baseExporter {
+func newBaseExporter(cfg configmodels.Exporter, logger *zap.Logger, options ...ExporterOption) *baseExporter {
 	opts := fromConfiguredOptions(options...)
 	be := &baseExporter{
 		cfg:      cfg,
@@ -172,7 +173,7 @@ func newBaseExporter(cfg configmodels.Exporter, options ...ExporterOption) *base
 		shutdown: opts.Shutdown,
 	}
 
-	be.qrSender = newQueuedRetrySender(opts.QueueSettings, opts.RetrySettings, &timeoutSender{cfg: opts.TimeoutSettings})
+	be.qrSender = newQueuedRetrySender(opts.QueueSettings, opts.RetrySettings, &timeoutSender{cfg: opts.TimeoutSettings}, logger)
 	be.sender = be.qrSender
 
 	return be

--- a/exporter/exporterhelper/common_test.go
+++ b/exporter/exporterhelper/common_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"go.opencensus.io/trace"
+	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -37,7 +38,7 @@ func TestErrorToStatus(t *testing.T) {
 }
 
 func TestBaseExporter(t *testing.T) {
-	be := newBaseExporter(defaultExporterCfg)
+	be := newBaseExporter(defaultExporterCfg, zap.NewNop())
 	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
 	require.NoError(t, be.Shutdown(context.Background()))
 }
@@ -45,6 +46,7 @@ func TestBaseExporter(t *testing.T) {
 func TestBaseExporterWithOptions(t *testing.T) {
 	be := newBaseExporter(
 		defaultExporterCfg,
+		zap.NewNop(),
 		WithStart(func(ctx context.Context, host component.Host) error { return errors.New("my error") }),
 		WithShutdown(func(ctx context.Context) error { return errors.New("my error") }))
 	require.Error(t, be.Start(context.Background(), componenttest.NewNopHost()))

--- a/exporter/exporterhelper/factory_test.go
+++ b/exporter/exporterhelper/factory_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configerror"
@@ -35,13 +36,13 @@ var (
 		TypeVal: typeStr,
 		NameVal: typeStr,
 	}
-	nopTracesExporter, _ = NewTraceExporter(defaultCfg, func(ctx context.Context, td pdata.Traces) (droppedSpans int, err error) {
+	nopTracesExporter, _ = NewTraceExporter(defaultCfg, zap.NewNop(), func(ctx context.Context, td pdata.Traces) (droppedSpans int, err error) {
 		return 0, nil
 	})
-	nopMetricsExporter, _ = NewMetricsExporter(defaultCfg, func(ctx context.Context, md pdata.Metrics) (droppedTimeSeries int, err error) {
+	nopMetricsExporter, _ = NewMetricsExporter(defaultCfg, zap.NewNop(), func(ctx context.Context, md pdata.Metrics) (droppedTimeSeries int, err error) {
 		return 0, nil
 	})
-	nopLogsExporter, _ = NewLogsExporter(defaultCfg, func(ctx context.Context, md pdata.Logs) (droppedTimeSeries int, err error) {
+	nopLogsExporter, _ = NewLogsExporter(defaultCfg, zap.NewNop(), func(ctx context.Context, md pdata.Logs) (droppedTimeSeries int, err error) {
 		return 0, nil
 	})
 )
@@ -54,11 +55,11 @@ func TestNewFactory(t *testing.T) {
 	assert.EqualValues(t, defaultCfg, factory.CreateDefaultConfig())
 	_, ok := factory.(component.ConfigUnmarshaler)
 	assert.False(t, ok)
-	_, err := factory.CreateTraceExporter(context.Background(), component.ExporterCreateParams{}, defaultCfg)
+	_, err := factory.CreateTraceExporter(context.Background(), component.ExporterCreateParams{Logger: zap.NewNop()}, defaultCfg)
 	assert.Equal(t, configerror.ErrDataTypeIsNotSupported, err)
-	_, err = factory.CreateMetricsExporter(context.Background(), component.ExporterCreateParams{}, defaultCfg)
+	_, err = factory.CreateMetricsExporter(context.Background(), component.ExporterCreateParams{Logger: zap.NewNop()}, defaultCfg)
 	assert.Equal(t, configerror.ErrDataTypeIsNotSupported, err)
-	_, err = factory.CreateLogsExporter(context.Background(), component.ExporterCreateParams{}, defaultCfg)
+	_, err = factory.CreateLogsExporter(context.Background(), component.ExporterCreateParams{Logger: zap.NewNop()}, defaultCfg)
 	assert.Equal(t, configerror.ErrDataTypeIsNotSupported, err)
 }
 
@@ -77,15 +78,15 @@ func TestNewFactory_WithConstructors(t *testing.T) {
 	assert.True(t, ok)
 	assert.Equal(t, errors.New("my error"), fu.Unmarshal(nil, nil))
 
-	te, err := factory.CreateTraceExporter(context.Background(), component.ExporterCreateParams{}, defaultCfg)
+	te, err := factory.CreateTraceExporter(context.Background(), component.ExporterCreateParams{Logger: zap.NewNop()}, defaultCfg)
 	assert.NoError(t, err)
 	assert.Same(t, nopTracesExporter, te)
 
-	me, err := factory.CreateMetricsExporter(context.Background(), component.ExporterCreateParams{}, defaultCfg)
+	me, err := factory.CreateMetricsExporter(context.Background(), component.ExporterCreateParams{Logger: zap.NewNop()}, defaultCfg)
 	assert.NoError(t, err)
 	assert.Same(t, nopMetricsExporter, me)
 
-	le, err := factory.CreateLogsExporter(context.Background(), component.ExporterCreateParams{}, defaultCfg)
+	le, err := factory.CreateLogsExporter(context.Background(), component.ExporterCreateParams{Logger: zap.NewNop()}, defaultCfg)
 	assert.NoError(t, err)
 	assert.Same(t, nopLogsExporter, le)
 }

--- a/exporter/exporterhelper/logshelper.go
+++ b/exporter/exporterhelper/logshelper.go
@@ -17,6 +17,8 @@ package exporterhelper
 import (
 	"context"
 
+	"go.uber.org/zap"
+
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configmodels"
 	"go.opentelemetry.io/collector/consumer/consumererror"
@@ -67,7 +69,12 @@ func (lexp *logsExporter) ConsumeLogs(ctx context.Context, ld pdata.Logs) error 
 }
 
 // NewLogsExporter creates an LogsExporter that records observability metrics and wraps every request with a Span.
-func NewLogsExporter(cfg configmodels.Exporter, pushLogsData PushLogsData, options ...ExporterOption) (component.LogsExporter, error) {
+func NewLogsExporter(
+	cfg configmodels.Exporter,
+	logger *zap.Logger,
+	pushLogsData PushLogsData,
+	options ...ExporterOption,
+) (component.LogsExporter, error) {
 	if cfg == nil {
 		return nil, errNilConfig
 	}
@@ -76,7 +83,7 @@ func NewLogsExporter(cfg configmodels.Exporter, pushLogsData PushLogsData, optio
 		return nil, errNilPushLogsData
 	}
 
-	be := newBaseExporter(cfg, options...)
+	be := newBaseExporter(cfg, logger, options...)
 	be.wrapConsumerSender(func(nextSender requestSender) requestSender {
 		return &logsExporterWithObservability{
 			exporterName: cfg.Name(),

--- a/exporter/exporterhelper/logshelper_test.go
+++ b/exporter/exporterhelper/logshelper_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opencensus.io/trace"
+	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configmodels"
@@ -52,20 +53,20 @@ func TestLogsRequest(t *testing.T) {
 }
 
 func TestLogsExporter_InvalidName(t *testing.T) {
-	me, err := NewLogsExporter(nil, newPushLogsData(0, nil))
+	me, err := NewLogsExporter(nil, zap.NewNop(), newPushLogsData(0, nil))
 	require.Nil(t, me)
 	require.Equal(t, errNilConfig, err)
 }
 
 func TestLogsExporter_NilPushLogsData(t *testing.T) {
-	me, err := NewLogsExporter(fakeLogsExporterConfig, nil)
+	me, err := NewLogsExporter(fakeLogsExporterConfig, zap.NewNop(), nil)
 	require.Nil(t, me)
 	require.Equal(t, errNilPushLogsData, err)
 }
 
 func TestLogsExporter_Default(t *testing.T) {
 	ld := testdata.GenerateLogDataEmpty()
-	me, err := NewLogsExporter(fakeLogsExporterConfig, newPushLogsData(0, nil))
+	me, err := NewLogsExporter(fakeLogsExporterConfig, zap.NewNop(), newPushLogsData(0, nil))
 	assert.NotNil(t, me)
 	assert.NoError(t, err)
 
@@ -76,14 +77,14 @@ func TestLogsExporter_Default(t *testing.T) {
 func TestLogsExporter_Default_ReturnError(t *testing.T) {
 	ld := testdata.GenerateLogDataEmpty()
 	want := errors.New("my_error")
-	me, err := NewLogsExporter(fakeLogsExporterConfig, newPushLogsData(0, want))
+	me, err := NewLogsExporter(fakeLogsExporterConfig, zap.NewNop(), newPushLogsData(0, want))
 	require.Nil(t, err)
 	require.NotNil(t, me)
 	require.Equal(t, want, me.ConsumeLogs(context.Background(), ld))
 }
 
 func TestLogsExporter_WithRecordLogs(t *testing.T) {
-	me, err := NewLogsExporter(fakeLogsExporterConfig, newPushLogsData(0, nil))
+	me, err := NewLogsExporter(fakeLogsExporterConfig, zap.NewNop(), newPushLogsData(0, nil))
 	require.Nil(t, err)
 	require.NotNil(t, me)
 
@@ -91,7 +92,7 @@ func TestLogsExporter_WithRecordLogs(t *testing.T) {
 }
 
 func TestLogsExporter_WithRecordLogs_NonZeroDropped(t *testing.T) {
-	me, err := NewLogsExporter(fakeLogsExporterConfig, newPushLogsData(1, nil))
+	me, err := NewLogsExporter(fakeLogsExporterConfig, zap.NewNop(), newPushLogsData(1, nil))
 	require.Nil(t, err)
 	require.NotNil(t, me)
 
@@ -100,7 +101,7 @@ func TestLogsExporter_WithRecordLogs_NonZeroDropped(t *testing.T) {
 
 func TestLogsExporter_WithRecordLogs_ReturnError(t *testing.T) {
 	want := errors.New("my_error")
-	me, err := NewLogsExporter(fakeLogsExporterConfig, newPushLogsData(0, want))
+	me, err := NewLogsExporter(fakeLogsExporterConfig, zap.NewNop(), newPushLogsData(0, want))
 	require.Nil(t, err)
 	require.NotNil(t, me)
 
@@ -108,14 +109,14 @@ func TestLogsExporter_WithRecordLogs_ReturnError(t *testing.T) {
 }
 
 func TestLogsExporter_WithSpan(t *testing.T) {
-	me, err := NewLogsExporter(fakeLogsExporterConfig, newPushLogsData(0, nil))
+	me, err := NewLogsExporter(fakeLogsExporterConfig, zap.NewNop(), newPushLogsData(0, nil))
 	require.Nil(t, err)
 	require.NotNil(t, me)
 	checkWrapSpanForLogsExporter(t, me, nil, 1)
 }
 
 func TestLogsExporter_WithSpan_NonZeroDropped(t *testing.T) {
-	me, err := NewLogsExporter(fakeLogsExporterConfig, newPushLogsData(1, nil))
+	me, err := NewLogsExporter(fakeLogsExporterConfig, zap.NewNop(), newPushLogsData(1, nil))
 	require.Nil(t, err)
 	require.NotNil(t, me)
 	checkWrapSpanForLogsExporter(t, me, nil, 1)
@@ -123,7 +124,7 @@ func TestLogsExporter_WithSpan_NonZeroDropped(t *testing.T) {
 
 func TestLogsExporter_WithSpan_ReturnError(t *testing.T) {
 	want := errors.New("my_error")
-	me, err := NewLogsExporter(fakeLogsExporterConfig, newPushLogsData(0, want))
+	me, err := NewLogsExporter(fakeLogsExporterConfig, zap.NewNop(), newPushLogsData(0, want))
 	require.Nil(t, err)
 	require.NotNil(t, me)
 	checkWrapSpanForLogsExporter(t, me, want, 1)
@@ -133,7 +134,7 @@ func TestLogsExporter_WithShutdown(t *testing.T) {
 	shutdownCalled := false
 	shutdown := func(context.Context) error { shutdownCalled = true; return nil }
 
-	me, err := NewLogsExporter(fakeLogsExporterConfig, newPushLogsData(0, nil), WithShutdown(shutdown))
+	me, err := NewLogsExporter(fakeLogsExporterConfig, zap.NewNop(), newPushLogsData(0, nil), WithShutdown(shutdown))
 	assert.NotNil(t, me)
 	assert.NoError(t, err)
 
@@ -145,7 +146,7 @@ func TestLogsExporter_WithShutdown_ReturnError(t *testing.T) {
 	want := errors.New("my_error")
 	shutdownErr := func(context.Context) error { return want }
 
-	me, err := NewLogsExporter(fakeLogsExporterConfig, newPushLogsData(0, nil), WithShutdown(shutdownErr))
+	me, err := NewLogsExporter(fakeLogsExporterConfig, zap.NewNop(), newPushLogsData(0, nil), WithShutdown(shutdownErr))
 	assert.NotNil(t, me)
 	assert.NoError(t, err)
 

--- a/exporter/exporterhelper/metricshelper.go
+++ b/exporter/exporterhelper/metricshelper.go
@@ -17,6 +17,8 @@ package exporterhelper
 import (
 	"context"
 
+	"go.uber.org/zap"
+
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configmodels"
 	"go.opentelemetry.io/collector/consumer/consumerdata"
@@ -79,7 +81,12 @@ func (mexp *metricsExporter) ConsumeMetrics(ctx context.Context, md pdata.Metric
 }
 
 // NewMetricsExporter creates an MetricsExporter that records observability metrics and wraps every request with a Span.
-func NewMetricsExporter(cfg configmodels.Exporter, pushMetricsData PushMetricsData, options ...ExporterOption) (component.MetricsExporter, error) {
+func NewMetricsExporter(
+	cfg configmodels.Exporter,
+	logger *zap.Logger,
+	pushMetricsData PushMetricsData,
+	options ...ExporterOption,
+) (component.MetricsExporter, error) {
 	if cfg == nil {
 		return nil, errNilConfig
 	}
@@ -88,7 +95,7 @@ func NewMetricsExporter(cfg configmodels.Exporter, pushMetricsData PushMetricsDa
 		return nil, errNilPushMetricsData
 	}
 
-	be := newBaseExporter(cfg, options...)
+	be := newBaseExporter(cfg, logger, options...)
 	be.wrapConsumerSender(func(nextSender requestSender) requestSender {
 		return &metricsSenderWithObservability{
 			exporterName: cfg.Name(),

--- a/exporter/exporterhelper/metricshelper_test.go
+++ b/exporter/exporterhelper/metricshelper_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opencensus.io/trace"
+	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configmodels"
@@ -53,20 +54,20 @@ func TestMetricsRequest(t *testing.T) {
 }
 
 func TestMetricsExporter_InvalidName(t *testing.T) {
-	me, err := NewMetricsExporter(nil, newPushMetricsData(0, nil))
+	me, err := NewMetricsExporter(nil, zap.NewNop(), newPushMetricsData(0, nil))
 	require.Nil(t, me)
 	require.Equal(t, errNilConfig, err)
 }
 
 func TestMetricsExporter_NilPushMetricsData(t *testing.T) {
-	me, err := NewMetricsExporter(fakeMetricsExporterConfig, nil)
+	me, err := NewMetricsExporter(fakeMetricsExporterConfig, zap.NewNop(), nil)
 	require.Nil(t, me)
 	require.Equal(t, errNilPushMetricsData, err)
 }
 
 func TestMetricsExporter_Default(t *testing.T) {
 	md := testdata.GenerateMetricsEmpty()
-	me, err := NewMetricsExporter(fakeMetricsExporterConfig, newPushMetricsData(0, nil))
+	me, err := NewMetricsExporter(fakeMetricsExporterConfig, zap.NewNop(), newPushMetricsData(0, nil))
 	assert.NotNil(t, me)
 	assert.NoError(t, err)
 
@@ -77,14 +78,14 @@ func TestMetricsExporter_Default(t *testing.T) {
 func TestMetricsExporter_Default_ReturnError(t *testing.T) {
 	md := testdata.GenerateMetricsEmpty()
 	want := errors.New("my_error")
-	me, err := NewMetricsExporter(fakeMetricsExporterConfig, newPushMetricsData(0, want))
+	me, err := NewMetricsExporter(fakeMetricsExporterConfig, zap.NewNop(), newPushMetricsData(0, want))
 	require.Nil(t, err)
 	require.NotNil(t, me)
 	require.Equal(t, want, me.ConsumeMetrics(context.Background(), md))
 }
 
 func TestMetricsExporter_WithRecordMetrics(t *testing.T) {
-	me, err := NewMetricsExporter(fakeMetricsExporterConfig, newPushMetricsData(0, nil))
+	me, err := NewMetricsExporter(fakeMetricsExporterConfig, zap.NewNop(), newPushMetricsData(0, nil))
 	require.Nil(t, err)
 	require.NotNil(t, me)
 
@@ -92,7 +93,7 @@ func TestMetricsExporter_WithRecordMetrics(t *testing.T) {
 }
 
 func TestMetricsExporter_WithRecordMetrics_NonZeroDropped(t *testing.T) {
-	me, err := NewMetricsExporter(fakeMetricsExporterConfig, newPushMetricsData(1, nil))
+	me, err := NewMetricsExporter(fakeMetricsExporterConfig, zap.NewNop(), newPushMetricsData(1, nil))
 	require.Nil(t, err)
 	require.NotNil(t, me)
 
@@ -101,7 +102,7 @@ func TestMetricsExporter_WithRecordMetrics_NonZeroDropped(t *testing.T) {
 
 func TestMetricsExporter_WithRecordMetrics_ReturnError(t *testing.T) {
 	want := errors.New("my_error")
-	me, err := NewMetricsExporter(fakeMetricsExporterConfig, newPushMetricsData(0, want))
+	me, err := NewMetricsExporter(fakeMetricsExporterConfig, zap.NewNop(), newPushMetricsData(0, want))
 	require.Nil(t, err)
 	require.NotNil(t, me)
 
@@ -109,14 +110,14 @@ func TestMetricsExporter_WithRecordMetrics_ReturnError(t *testing.T) {
 }
 
 func TestMetricsExporter_WithSpan(t *testing.T) {
-	me, err := NewMetricsExporter(fakeMetricsExporterConfig, newPushMetricsData(0, nil))
+	me, err := NewMetricsExporter(fakeMetricsExporterConfig, zap.NewNop(), newPushMetricsData(0, nil))
 	require.Nil(t, err)
 	require.NotNil(t, me)
 	checkWrapSpanForMetricsExporter(t, me, nil, 1)
 }
 
 func TestMetricsExporter_WithSpan_NonZeroDropped(t *testing.T) {
-	me, err := NewMetricsExporter(fakeMetricsExporterConfig, newPushMetricsData(1, nil))
+	me, err := NewMetricsExporter(fakeMetricsExporterConfig, zap.NewNop(), newPushMetricsData(1, nil))
 	require.Nil(t, err)
 	require.NotNil(t, me)
 	checkWrapSpanForMetricsExporter(t, me, nil, 1)
@@ -124,7 +125,7 @@ func TestMetricsExporter_WithSpan_NonZeroDropped(t *testing.T) {
 
 func TestMetricsExporter_WithSpan_ReturnError(t *testing.T) {
 	want := errors.New("my_error")
-	me, err := NewMetricsExporter(fakeMetricsExporterConfig, newPushMetricsData(0, want))
+	me, err := NewMetricsExporter(fakeMetricsExporterConfig, zap.NewNop(), newPushMetricsData(0, want))
 	require.Nil(t, err)
 	require.NotNil(t, me)
 	checkWrapSpanForMetricsExporter(t, me, want, 1)
@@ -134,7 +135,7 @@ func TestMetricsExporter_WithShutdown(t *testing.T) {
 	shutdownCalled := false
 	shutdown := func(context.Context) error { shutdownCalled = true; return nil }
 
-	me, err := NewMetricsExporter(fakeMetricsExporterConfig, newPushMetricsData(0, nil), WithShutdown(shutdown))
+	me, err := NewMetricsExporter(fakeMetricsExporterConfig, zap.NewNop(), newPushMetricsData(0, nil), WithShutdown(shutdown))
 	assert.NotNil(t, me)
 	assert.NoError(t, err)
 
@@ -146,7 +147,7 @@ func TestMetricsExporter_WithShutdown_ReturnError(t *testing.T) {
 	want := errors.New("my_error")
 	shutdownErr := func(context.Context) error { return want }
 
-	me, err := NewMetricsExporter(fakeMetricsExporterConfig, newPushMetricsData(0, nil), WithShutdown(shutdownErr))
+	me, err := NewMetricsExporter(fakeMetricsExporterConfig, zap.NewNop(), newPushMetricsData(0, nil), WithShutdown(shutdownErr))
 	assert.NotNil(t, me)
 	assert.NoError(t, err)
 

--- a/exporter/exporterhelper/queued_retry_test.go
+++ b/exporter/exporterhelper/queued_retry_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/consumer/consumererror"
@@ -34,7 +35,7 @@ import (
 func TestQueuedRetry_DropOnPermanentError(t *testing.T) {
 	qCfg := CreateDefaultQueueSettings()
 	rCfg := CreateDefaultRetrySettings()
-	be := newBaseExporter(defaultExporterCfg, WithRetry(rCfg), WithQueue(qCfg))
+	be := newBaseExporter(defaultExporterCfg, zap.NewNop(), WithRetry(rCfg), WithQueue(qCfg))
 	ocs := newObservabilityConsumerSender(be.qrSender.consumerSender)
 	be.qrSender.consumerSender = ocs
 	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
@@ -60,7 +61,7 @@ func TestQueuedRetry_DropOnNoRetry(t *testing.T) {
 	qCfg := CreateDefaultQueueSettings()
 	rCfg := CreateDefaultRetrySettings()
 	rCfg.Enabled = false
-	be := newBaseExporter(defaultExporterCfg, WithRetry(rCfg), WithQueue(qCfg))
+	be := newBaseExporter(defaultExporterCfg, zap.NewNop(), WithRetry(rCfg), WithQueue(qCfg))
 	ocs := newObservabilityConsumerSender(be.qrSender.consumerSender)
 	be.qrSender.consumerSender = ocs
 	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
@@ -87,7 +88,7 @@ func TestQueuedRetry_PartialError(t *testing.T) {
 	qCfg.NumConsumers = 1
 	rCfg := CreateDefaultRetrySettings()
 	rCfg.InitialInterval = 0
-	be := newBaseExporter(defaultExporterCfg, WithRetry(rCfg), WithQueue(qCfg))
+	be := newBaseExporter(defaultExporterCfg, zap.NewNop(), WithRetry(rCfg), WithQueue(qCfg))
 	ocs := newObservabilityConsumerSender(be.qrSender.consumerSender)
 	be.qrSender.consumerSender = ocs
 	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
@@ -115,7 +116,7 @@ func TestQueuedRetry_StopWhileWaiting(t *testing.T) {
 	qCfg := CreateDefaultQueueSettings()
 	qCfg.NumConsumers = 1
 	rCfg := CreateDefaultRetrySettings()
-	be := newBaseExporter(defaultExporterCfg, WithRetry(rCfg), WithQueue(qCfg))
+	be := newBaseExporter(defaultExporterCfg, zap.NewNop(), WithRetry(rCfg), WithQueue(qCfg))
 	ocs := newObservabilityConsumerSender(be.qrSender.consumerSender)
 	be.qrSender.consumerSender = ocs
 	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
@@ -152,7 +153,7 @@ func TestQueuedRetry_DoNotPreserveCancellation(t *testing.T) {
 	qCfg := CreateDefaultQueueSettings()
 	qCfg.NumConsumers = 1
 	rCfg := CreateDefaultRetrySettings()
-	be := newBaseExporter(defaultExporterCfg, WithRetry(rCfg), WithQueue(qCfg))
+	be := newBaseExporter(defaultExporterCfg, zap.NewNop(), WithRetry(rCfg), WithQueue(qCfg))
 	ocs := newObservabilityConsumerSender(be.qrSender.consumerSender)
 	be.qrSender.consumerSender = ocs
 	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
@@ -183,7 +184,7 @@ func TestQueuedRetry_MaxElapsedTime(t *testing.T) {
 	rCfg := CreateDefaultRetrySettings()
 	rCfg.InitialInterval = time.Millisecond
 	rCfg.MaxElapsedTime = 100 * time.Millisecond
-	be := newBaseExporter(defaultExporterCfg, WithRetry(rCfg), WithQueue(qCfg))
+	be := newBaseExporter(defaultExporterCfg, zap.NewNop(), WithRetry(rCfg), WithQueue(qCfg))
 	ocs := newObservabilityConsumerSender(be.qrSender.consumerSender)
 	be.qrSender.consumerSender = ocs
 	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
@@ -225,7 +226,7 @@ func TestQueuedRetry_ThrottleError(t *testing.T) {
 	qCfg.NumConsumers = 1
 	rCfg := CreateDefaultRetrySettings()
 	rCfg.InitialInterval = 10 * time.Millisecond
-	be := newBaseExporter(defaultExporterCfg, WithRetry(rCfg), WithQueue(qCfg))
+	be := newBaseExporter(defaultExporterCfg, zap.NewNop(), WithRetry(rCfg), WithQueue(qCfg))
 	ocs := newObservabilityConsumerSender(be.qrSender.consumerSender)
 	be.qrSender.consumerSender = ocs
 	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
@@ -258,7 +259,7 @@ func TestQueuedRetry_RetryOnError(t *testing.T) {
 	qCfg.QueueSize = 1
 	rCfg := CreateDefaultRetrySettings()
 	rCfg.InitialInterval = 0
-	be := newBaseExporter(defaultExporterCfg, WithRetry(rCfg), WithQueue(qCfg))
+	be := newBaseExporter(defaultExporterCfg, zap.NewNop(), WithRetry(rCfg), WithQueue(qCfg))
 	ocs := newObservabilityConsumerSender(be.qrSender.consumerSender)
 	be.qrSender.consumerSender = ocs
 	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
@@ -286,7 +287,7 @@ func TestQueuedRetry_DropOnFull(t *testing.T) {
 	qCfg := CreateDefaultQueueSettings()
 	qCfg.QueueSize = 0
 	rCfg := CreateDefaultRetrySettings()
-	be := newBaseExporter(defaultExporterCfg, WithRetry(rCfg), WithQueue(qCfg))
+	be := newBaseExporter(defaultExporterCfg, zap.NewNop(), WithRetry(rCfg), WithQueue(qCfg))
 	ocs := newObservabilityConsumerSender(be.qrSender.consumerSender)
 	be.qrSender.consumerSender = ocs
 	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
@@ -305,7 +306,7 @@ func TestQueuedRetryHappyPath(t *testing.T) {
 
 	qCfg := CreateDefaultQueueSettings()
 	rCfg := CreateDefaultRetrySettings()
-	be := newBaseExporter(defaultExporterCfg, WithRetry(rCfg), WithQueue(qCfg))
+	be := newBaseExporter(defaultExporterCfg, zap.NewNop(), WithRetry(rCfg), WithQueue(qCfg))
 	ocs := newObservabilityConsumerSender(be.qrSender.consumerSender)
 	be.qrSender.consumerSender = ocs
 	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))

--- a/exporter/exporterhelper/tracehelper.go
+++ b/exporter/exporterhelper/tracehelper.go
@@ -17,6 +17,8 @@ package exporterhelper
 import (
 	"context"
 
+	"go.uber.org/zap"
+
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configmodels"
 	"go.opentelemetry.io/collector/consumer/consumererror"
@@ -69,6 +71,7 @@ func (texp *traceExporter) ConsumeTraces(ctx context.Context, td pdata.Traces) e
 // NewTraceExporter creates a TraceExporter that records observability metrics and wraps every request with a Span.
 func NewTraceExporter(
 	cfg configmodels.Exporter,
+	logger *zap.Logger,
 	dataPusher traceDataPusher,
 	options ...ExporterOption,
 ) (component.TraceExporter, error) {
@@ -81,7 +84,7 @@ func NewTraceExporter(
 		return nil, errNilPushTraceData
 	}
 
-	be := newBaseExporter(cfg, options...)
+	be := newBaseExporter(cfg, logger, options...)
 	be.wrapConsumerSender(func(nextSender requestSender) requestSender {
 		return &tracesExporterWithObservability{
 			exporterName: cfg.Name(),

--- a/exporter/exporterhelper/tracehelper_test.go
+++ b/exporter/exporterhelper/tracehelper_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opencensus.io/trace"
+	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configmodels"
@@ -65,20 +66,20 @@ func (tote *testOCTraceExporter) ExportSpan(sd *trace.SpanData) {
 }
 
 func TestTraceExporter_InvalidName(t *testing.T) {
-	te, err := NewTraceExporter(nil, newTraceDataPusher(0, nil))
+	te, err := NewTraceExporter(nil, zap.NewNop(), newTraceDataPusher(0, nil))
 	require.Nil(t, te)
 	require.Equal(t, errNilConfig, err)
 }
 
 func TestTraceExporter_NilPushTraceData(t *testing.T) {
-	te, err := NewTraceExporter(fakeTraceExporterConfig, nil)
+	te, err := NewTraceExporter(fakeTraceExporterConfig, zap.NewNop(), nil)
 	require.Nil(t, te)
 	require.Equal(t, errNilPushTraceData, err)
 }
 
 func TestTraceExporter_Default(t *testing.T) {
 	td := pdata.NewTraces()
-	te, err := NewTraceExporter(fakeTraceExporterConfig, newTraceDataPusher(0, nil))
+	te, err := NewTraceExporter(fakeTraceExporterConfig, zap.NewNop(), newTraceDataPusher(0, nil))
 	assert.NotNil(t, te)
 	assert.NoError(t, err)
 
@@ -89,7 +90,7 @@ func TestTraceExporter_Default(t *testing.T) {
 func TestTraceExporter_Default_ReturnError(t *testing.T) {
 	td := pdata.NewTraces()
 	want := errors.New("my_error")
-	te, err := NewTraceExporter(fakeTraceExporterConfig, newTraceDataPusher(0, want))
+	te, err := NewTraceExporter(fakeTraceExporterConfig, zap.NewNop(), newTraceDataPusher(0, want))
 	require.Nil(t, err)
 	require.NotNil(t, te)
 
@@ -98,7 +99,7 @@ func TestTraceExporter_Default_ReturnError(t *testing.T) {
 }
 
 func TestTraceExporter_WithRecordMetrics(t *testing.T) {
-	te, err := NewTraceExporter(fakeTraceExporterConfig, newTraceDataPusher(0, nil))
+	te, err := NewTraceExporter(fakeTraceExporterConfig, zap.NewNop(), newTraceDataPusher(0, nil))
 	require.Nil(t, err)
 	require.NotNil(t, te)
 
@@ -106,7 +107,7 @@ func TestTraceExporter_WithRecordMetrics(t *testing.T) {
 }
 
 func TestTraceExporter_WithRecordMetrics_NonZeroDropped(t *testing.T) {
-	te, err := NewTraceExporter(fakeTraceExporterConfig, newTraceDataPusher(1, nil))
+	te, err := NewTraceExporter(fakeTraceExporterConfig, zap.NewNop(), newTraceDataPusher(1, nil))
 	require.Nil(t, err)
 	require.NotNil(t, te)
 
@@ -115,7 +116,7 @@ func TestTraceExporter_WithRecordMetrics_NonZeroDropped(t *testing.T) {
 
 func TestTraceExporter_WithRecordMetrics_ReturnError(t *testing.T) {
 	want := errors.New("my_error")
-	te, err := NewTraceExporter(fakeTraceExporterConfig, newTraceDataPusher(0, want))
+	te, err := NewTraceExporter(fakeTraceExporterConfig, zap.NewNop(), newTraceDataPusher(0, want))
 	require.Nil(t, err)
 	require.NotNil(t, te)
 
@@ -123,7 +124,7 @@ func TestTraceExporter_WithRecordMetrics_ReturnError(t *testing.T) {
 }
 
 func TestTraceExporter_WithSpan(t *testing.T) {
-	te, err := NewTraceExporter(fakeTraceExporterConfig, newTraceDataPusher(0, nil))
+	te, err := NewTraceExporter(fakeTraceExporterConfig, zap.NewNop(), newTraceDataPusher(0, nil))
 	require.Nil(t, err)
 	require.NotNil(t, te)
 
@@ -131,7 +132,7 @@ func TestTraceExporter_WithSpan(t *testing.T) {
 }
 
 func TestTraceExporter_WithSpan_NonZeroDropped(t *testing.T) {
-	te, err := NewTraceExporter(fakeTraceExporterConfig, newTraceDataPusher(1, nil))
+	te, err := NewTraceExporter(fakeTraceExporterConfig, zap.NewNop(), newTraceDataPusher(1, nil))
 	require.Nil(t, err)
 	require.NotNil(t, te)
 
@@ -140,7 +141,7 @@ func TestTraceExporter_WithSpan_NonZeroDropped(t *testing.T) {
 
 func TestTraceExporter_WithSpan_ReturnError(t *testing.T) {
 	want := errors.New("my_error")
-	te, err := NewTraceExporter(fakeTraceExporterConfig, newTraceDataPusher(0, want))
+	te, err := NewTraceExporter(fakeTraceExporterConfig, zap.NewNop(), newTraceDataPusher(0, want))
 	require.Nil(t, err)
 	require.NotNil(t, te)
 
@@ -151,7 +152,7 @@ func TestTraceExporter_WithShutdown(t *testing.T) {
 	shutdownCalled := false
 	shutdown := func(context.Context) error { shutdownCalled = true; return nil }
 
-	te, err := NewTraceExporter(fakeTraceExporterConfig, newTraceDataPusher(0, nil), WithShutdown(shutdown))
+	te, err := NewTraceExporter(fakeTraceExporterConfig, zap.NewNop(), newTraceDataPusher(0, nil), WithShutdown(shutdown))
 	assert.NotNil(t, te)
 	assert.NoError(t, err)
 
@@ -163,7 +164,7 @@ func TestTraceExporter_WithShutdown_ReturnError(t *testing.T) {
 	want := errors.New("my_error")
 	shutdownErr := func(context.Context) error { return want }
 
-	te, err := NewTraceExporter(fakeTraceExporterConfig, newTraceDataPusher(0, nil), WithShutdown(shutdownErr))
+	te, err := NewTraceExporter(fakeTraceExporterConfig, zap.NewNop(), newTraceDataPusher(0, nil), WithShutdown(shutdownErr))
 	assert.NotNil(t, te)
 	assert.NoError(t, err)
 

--- a/exporter/jaegerexporter/exporter.go
+++ b/exporter/jaegerexporter/exporter.go
@@ -54,7 +54,7 @@ func newTraceExporter(cfg *Config, logger *zap.Logger) (component.TraceExporter,
 	}
 
 	exp, err := exporterhelper.NewTraceExporter(
-		cfg, s.pushTraceData,
+		cfg, logger, s.pushTraceData,
 		exporterhelper.WithTimeout(cfg.TimeoutSettings),
 		exporterhelper.WithRetry(cfg.RetrySettings),
 		exporterhelper.WithQueue(cfg.QueueSettings),

--- a/exporter/jaegerexporter/exporter_test.go
+++ b/exporter/jaegerexporter/exporter_test.go
@@ -225,7 +225,7 @@ func TestMutualTLS(t *testing.T) {
 			ServerName: "localhost",
 		},
 	}
-	exporter, err := factory.CreateTraceExporter(context.Background(), component.ExporterCreateParams{}, cfg)
+	exporter, err := factory.CreateTraceExporter(context.Background(), component.ExporterCreateParams{Logger: zap.NewNop()}, cfg)
 	require.NoError(t, err)
 	err = exporter.Start(context.Background(), nil)
 	require.NoError(t, err)

--- a/exporter/kafkaexporter/factory.go
+++ b/exporter/kafkaexporter/factory.go
@@ -100,6 +100,7 @@ func (f *kafkaExporterFactory) createTraceExporter(
 	}
 	return exporterhelper.NewTraceExporter(
 		cfg,
+		params.Logger,
 		exp.traceDataPusher,
 		// Disable exporterhelper Timeout, because we cannot pass a Context to the Producer,
 		// and will rely on the sarama Producer Timeout logic.

--- a/exporter/kafkaexporter/factory_test.go
+++ b/exporter/kafkaexporter/factory_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configcheck"
@@ -41,7 +42,7 @@ func TestCreateTracesExporter(t *testing.T) {
 	// this disables contacting the broker so we can successfully create the exporter
 	cfg.Metadata.Full = false
 	f := kafkaExporterFactory{marshallers: defaultMarshallers()}
-	r, err := f.createTraceExporter(context.Background(), component.ExporterCreateParams{}, cfg)
+	r, err := f.createTraceExporter(context.Background(), component.ExporterCreateParams{Logger: zap.NewNop()}, cfg)
 	require.NoError(t, err)
 	assert.NotNil(t, r)
 }
@@ -51,7 +52,7 @@ func TestCreateTracesExporter_err(t *testing.T) {
 	cfg.Brokers = []string{"invalid:9092"}
 	cfg.ProtocolVersion = "2.0.0"
 	f := kafkaExporterFactory{marshallers: defaultMarshallers()}
-	r, err := f.createTraceExporter(context.Background(), component.ExporterCreateParams{}, cfg)
+	r, err := f.createTraceExporter(context.Background(), component.ExporterCreateParams{Logger: zap.NewNop()}, cfg)
 	// no available broker
 	require.Error(t, err)
 	assert.Nil(t, r)
@@ -66,13 +67,13 @@ func TestWithMarshallers(t *testing.T) {
 
 	t.Run("custom_encoding", func(t *testing.T) {
 		cfg.Encoding = cm.Encoding()
-		exporter, err := f.CreateTraceExporter(context.Background(), component.ExporterCreateParams{}, cfg)
+		exporter, err := f.CreateTraceExporter(context.Background(), component.ExporterCreateParams{Logger: zap.NewNop()}, cfg)
 		require.NoError(t, err)
 		require.NotNil(t, exporter)
 	})
 	t.Run("default_encoding", func(t *testing.T) {
 		cfg.Encoding = new(otlpProtoMarshaller).Encoding()
-		exporter, err := f.CreateTraceExporter(context.Background(), component.ExporterCreateParams{}, cfg)
+		exporter, err := f.CreateTraceExporter(context.Background(), component.ExporterCreateParams{Logger: zap.NewNop()}, cfg)
 		require.NoError(t, err)
 		assert.NotNil(t, exporter)
 	})

--- a/exporter/kafkaexporter/kafka_exporter_test.go
+++ b/exporter/kafkaexporter/kafka_exporter_test.go
@@ -33,14 +33,14 @@ import (
 
 func TestNewExporter_err_version(t *testing.T) {
 	c := Config{ProtocolVersion: "0.0.0", Encoding: defaultEncoding}
-	exp, err := newExporter(c, component.ExporterCreateParams{}, defaultMarshallers())
+	exp, err := newExporter(c, component.ExporterCreateParams{Logger: zap.NewNop()}, defaultMarshallers())
 	assert.Error(t, err)
 	assert.Nil(t, exp)
 }
 
 func TestNewExporter_err_encoding(t *testing.T) {
 	c := Config{Encoding: "foo"}
-	exp, err := newExporter(c, component.ExporterCreateParams{}, defaultMarshallers())
+	exp, err := newExporter(c, component.ExporterCreateParams{Logger: zap.NewNop()}, defaultMarshallers())
 	assert.EqualError(t, err, errUnrecognizedEncoding.Error())
 	assert.Nil(t, exp)
 }
@@ -60,7 +60,7 @@ func TestNewExporter_err_auth_type(t *testing.T) {
 			Full: false,
 		},
 	}
-	exp, err := newExporter(c, component.ExporterCreateParams{}, defaultMarshallers())
+	exp, err := newExporter(c, component.ExporterCreateParams{Logger: zap.NewNop()}, defaultMarshallers())
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to load TLS config")
 	assert.Nil(t, exp)

--- a/exporter/loggingexporter/logging_exporter.go
+++ b/exporter/loggingexporter/logging_exporter.go
@@ -435,6 +435,7 @@ func newTraceExporter(config configmodels.Exporter, level string, logger *zap.Lo
 
 	return exporterhelper.NewTraceExporter(
 		config,
+		logger,
 		s.pushTraceData,
 		// Disable Timeout/RetryOnFailure and SendingQueue
 		exporterhelper.WithTimeout(exporterhelper.TimeoutSettings{Timeout: 0}),
@@ -454,6 +455,7 @@ func newMetricsExporter(config configmodels.Exporter, level string, logger *zap.
 
 	return exporterhelper.NewMetricsExporter(
 		config,
+		logger,
 		s.pushMetricsData,
 		// Disable Timeout/RetryOnFailure and SendingQueue
 		exporterhelper.WithTimeout(exporterhelper.TimeoutSettings{Timeout: 0}),
@@ -473,6 +475,7 @@ func newLogsExporter(config configmodels.Exporter, level string, logger *zap.Log
 
 	return exporterhelper.NewLogsExporter(
 		config,
+		logger,
 		s.pushLogData,
 		// Disable Timeout/RetryOnFailure and SendingQueue
 		exporterhelper.WithTimeout(exporterhelper.TimeoutSettings{Timeout: 0}),

--- a/exporter/opencensusexporter/factory.go
+++ b/exporter/opencensusexporter/factory.go
@@ -52,12 +52,12 @@ func createDefaultConfig() configmodels.Exporter {
 	}
 }
 
-func createTraceExporter(ctx context.Context, _ component.ExporterCreateParams, config configmodels.Exporter) (component.TraceExporter, error) {
+func createTraceExporter(ctx context.Context, params component.ExporterCreateParams, config configmodels.Exporter) (component.TraceExporter, error) {
 	oCfg := config.(*Config)
-	return newTraceExporter(ctx, oCfg)
+	return newTraceExporter(ctx, oCfg, params.Logger)
 }
 
-func createMetricsExporter(ctx context.Context, _ component.ExporterCreateParams, config configmodels.Exporter) (component.MetricsExporter, error) {
+func createMetricsExporter(ctx context.Context, params component.ExporterCreateParams, config configmodels.Exporter) (component.MetricsExporter, error) {
 	oCfg := config.(*Config)
-	return newMetricsExporter(ctx, oCfg)
+	return newMetricsExporter(ctx, oCfg, params.Logger)
 }

--- a/exporter/opencensusexporter/opencensus.go
+++ b/exporter/opencensusexporter/opencensus.go
@@ -23,6 +23,7 @@ import (
 	agentmetricspb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/metrics/v1"
 	agenttracepb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/trace/v1"
 	resourcepb "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
+	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 
@@ -106,7 +107,7 @@ func (oce *ocExporter) shutdown(context.Context) error {
 	return oce.grpcClientConn.Close()
 }
 
-func newTraceExporter(ctx context.Context, cfg *Config) (component.TraceExporter, error) {
+func newTraceExporter(ctx context.Context, cfg *Config, logger *zap.Logger) (component.TraceExporter, error) {
 	oce, err := newOcExporter(ctx, cfg)
 	if err != nil {
 		return nil, err
@@ -122,11 +123,12 @@ func newTraceExporter(ctx context.Context, cfg *Config) (component.TraceExporter
 
 	return exporterhelper.NewTraceExporter(
 		cfg,
+		logger,
 		oce.pushTraceData,
 		exporterhelper.WithShutdown(oce.shutdown))
 }
 
-func newMetricsExporter(ctx context.Context, cfg *Config) (component.MetricsExporter, error) {
+func newMetricsExporter(ctx context.Context, cfg *Config, logger *zap.Logger) (component.MetricsExporter, error) {
 	oce, err := newOcExporter(ctx, cfg)
 	if err != nil {
 		return nil, err
@@ -142,6 +144,7 @@ func newMetricsExporter(ctx context.Context, cfg *Config) (component.MetricsExpo
 
 	return exporterhelper.NewMetricsExporter(
 		cfg,
+		logger,
 		oce.pushMetricsData,
 		exporterhelper.WithShutdown(oce.shutdown))
 }

--- a/exporter/otlpexporter/factory.go
+++ b/exporter/otlpexporter/factory.go
@@ -57,7 +57,7 @@ func createDefaultConfig() configmodels.Exporter {
 
 func createTraceExporter(
 	_ context.Context,
-	_ component.ExporterCreateParams,
+	params component.ExporterCreateParams,
 	cfg configmodels.Exporter,
 ) (component.TraceExporter, error) {
 	oce, err := newExporter(cfg)
@@ -67,6 +67,7 @@ func createTraceExporter(
 	oCfg := cfg.(*Config)
 	oexp, err := exporterhelper.NewTraceExporter(
 		cfg,
+		params.Logger,
 		oce.pushTraceData,
 		exporterhelper.WithTimeout(oCfg.TimeoutSettings),
 		exporterhelper.WithRetry(oCfg.RetrySettings),
@@ -81,7 +82,7 @@ func createTraceExporter(
 
 func createMetricsExporter(
 	_ context.Context,
-	_ component.ExporterCreateParams,
+	params component.ExporterCreateParams,
 	cfg configmodels.Exporter,
 ) (component.MetricsExporter, error) {
 	oce, err := newExporter(cfg)
@@ -91,6 +92,7 @@ func createMetricsExporter(
 	oCfg := cfg.(*Config)
 	oexp, err := exporterhelper.NewMetricsExporter(
 		cfg,
+		params.Logger,
 		oce.pushMetricsData,
 		exporterhelper.WithTimeout(oCfg.TimeoutSettings),
 		exporterhelper.WithRetry(oCfg.RetrySettings),
@@ -106,7 +108,7 @@ func createMetricsExporter(
 
 func createLogsExporter(
 	_ context.Context,
-	_ component.ExporterCreateParams,
+	params component.ExporterCreateParams,
 	cfg configmodels.Exporter,
 ) (component.LogsExporter, error) {
 	oce, err := newExporter(cfg)
@@ -116,6 +118,7 @@ func createLogsExporter(
 	oCfg := cfg.(*Config)
 	oexp, err := exporterhelper.NewLogsExporter(
 		cfg,
+		params.Logger,
 		oce.pushLogData,
 		exporterhelper.WithTimeout(oCfg.TimeoutSettings),
 		exporterhelper.WithRetry(oCfg.RetrySettings),

--- a/exporter/otlphttpexporter/factory.go
+++ b/exporter/otlphttpexporter/factory.go
@@ -76,10 +76,10 @@ func composeSignalURL(oCfg *Config, signalOverrideURL string, signalName string)
 
 func createTraceExporter(
 	_ context.Context,
-	_ component.ExporterCreateParams,
+	params component.ExporterCreateParams,
 	cfg configmodels.Exporter,
 ) (component.TraceExporter, error) {
-	oce, err := newExporter(cfg)
+	oce, err := newExporter(cfg, params.Logger)
 	if err != nil {
 		return nil, err
 	}
@@ -92,6 +92,7 @@ func createTraceExporter(
 
 	return exporterhelper.NewTraceExporter(
 		cfg,
+		params.Logger,
 		oce.pushTraceData,
 		// explicitly disable since we rely on http.Client timeout logic.
 		exporterhelper.WithTimeout(exporterhelper.TimeoutSettings{Timeout: 0}),
@@ -101,10 +102,10 @@ func createTraceExporter(
 
 func createMetricsExporter(
 	_ context.Context,
-	_ component.ExporterCreateParams,
+	params component.ExporterCreateParams,
 	cfg configmodels.Exporter,
 ) (component.MetricsExporter, error) {
-	oce, err := newExporter(cfg)
+	oce, err := newExporter(cfg, params.Logger)
 	if err != nil {
 		return nil, err
 	}
@@ -117,6 +118,7 @@ func createMetricsExporter(
 
 	return exporterhelper.NewMetricsExporter(
 		cfg,
+		params.Logger,
 		oce.pushMetricsData,
 		// explicitly disable since we rely on http.Client timeout logic.
 		exporterhelper.WithTimeout(exporterhelper.TimeoutSettings{Timeout: 0}),
@@ -126,10 +128,10 @@ func createMetricsExporter(
 
 func createLogsExporter(
 	_ context.Context,
-	_ component.ExporterCreateParams,
+	params component.ExporterCreateParams,
 	cfg configmodels.Exporter,
 ) (component.LogsExporter, error) {
-	oce, err := newExporter(cfg)
+	oce, err := newExporter(cfg, params.Logger)
 	if err != nil {
 		return nil, err
 	}
@@ -142,6 +144,7 @@ func createLogsExporter(
 
 	return exporterhelper.NewLogsExporter(
 		cfg,
+		params.Logger,
 		oce.pushLogData,
 		// explicitly disable since we rely on http.Client timeout logic.
 		exporterhelper.WithTimeout(exporterhelper.TimeoutSettings{Timeout: 0}),

--- a/exporter/prometheusremotewriteexporter/factory.go
+++ b/exporter/prometheusremotewriteexporter/factory.go
@@ -36,7 +36,7 @@ func NewFactory() component.ExporterFactory {
 		exporterhelper.WithMetrics(createMetricsExporter))
 }
 
-func createMetricsExporter(_ context.Context, _ component.ExporterCreateParams,
+func createMetricsExporter(_ context.Context, params component.ExporterCreateParams,
 	cfg configmodels.Exporter) (component.MetricsExporter, error) {
 
 	prwCfg, ok := cfg.(*Config)
@@ -58,6 +58,7 @@ func createMetricsExporter(_ context.Context, _ component.ExporterCreateParams,
 
 	prwexp, err := exporterhelper.NewMetricsExporter(
 		cfg,
+		params.Logger,
 		prwe.PushMetrics,
 		exporterhelper.WithTimeout(prwCfg.TimeoutSettings),
 		exporterhelper.WithQueue(prwCfg.QueueSettings),

--- a/exporter/prometheusremotewriteexporter/factory_test.go
+++ b/exporter/prometheusremotewriteexporter/factory_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configcheck"
@@ -57,22 +58,22 @@ func Test_createMetricsExporter(t *testing.T) {
 	}{
 		{"success_case",
 			createDefaultConfig(),
-			component.ExporterCreateParams{},
+			component.ExporterCreateParams{Logger: zap.NewNop()},
 			false,
 		},
 		{"fail_case",
 			nil,
-			component.ExporterCreateParams{},
+			component.ExporterCreateParams{Logger: zap.NewNop()},
 			true,
 		},
 		{"invalid_config_case",
 			invalidConfig,
-			component.ExporterCreateParams{},
+			component.ExporterCreateParams{Logger: zap.NewNop()},
 			true,
 		},
 		{"invalid_tls_config_case",
 			invalidTLSConfig,
-			component.ExporterCreateParams{},
+			component.ExporterCreateParams{Logger: zap.NewNop()},
 			true,
 		},
 	}

--- a/exporter/zipkinexporter/factory.go
+++ b/exporter/zipkinexporter/factory.go
@@ -64,7 +64,7 @@ func createDefaultConfig() configmodels.Exporter {
 
 func createTraceExporter(
 	_ context.Context,
-	_ component.ExporterCreateParams,
+	params component.ExporterCreateParams,
 	cfg configmodels.Exporter,
 ) (component.TraceExporter, error) {
 	zc := cfg.(*Config)
@@ -80,6 +80,7 @@ func createTraceExporter(
 	}
 	return exporterhelper.NewTraceExporter(
 		zc,
+		params.Logger,
 		ze.pushTraceData,
 		// explicitly disable since we rely on http.Client timeout logic.
 		exporterhelper.WithTimeout(exporterhelper.TimeoutSettings{Timeout: 0}),

--- a/exporter/zipkinexporter/zipkin_test.go
+++ b/exporter/zipkinexporter/zipkin_test.go
@@ -65,7 +65,7 @@ func TestZipkinExporter_roundtripJSON(t *testing.T) {
 		},
 		Format: "json",
 	}
-	zexp, err := NewFactory().CreateTraceExporter(context.Background(), component.ExporterCreateParams{}, config)
+	zexp, err := NewFactory().CreateTraceExporter(context.Background(), component.ExporterCreateParams{Logger: zap.NewNop()}, config)
 	assert.NoError(t, err)
 	require.NotNil(t, zexp)
 
@@ -313,7 +313,7 @@ func TestZipkinExporter_roundtripProto(t *testing.T) {
 		},
 		Format: "proto",
 	}
-	zexp, err := NewFactory().CreateTraceExporter(context.Background(), component.ExporterCreateParams{}, config)
+	zexp, err := NewFactory().CreateTraceExporter(context.Background(), component.ExporterCreateParams{Logger: zap.NewNop()}, config)
 	require.NoError(t, err)
 
 	// The test requires the spans from zipkinSpansJSONJavaLibrary to be sent in a single batch, use

--- a/service/builder/exporters_builder.go
+++ b/service/builder/exporters_builder.go
@@ -232,7 +232,7 @@ func (eb *ExportersBuilder) buildExporter(
 
 	inputDataTypes := exportersInputDataTypes[config]
 	if inputDataTypes == nil {
-		logger.Info("Ignoring exporter as it is not used by any pipeline")
+		eb.logger.Info("Ignoring exporter as it is not used by any pipeline")
 		return exporter, nil
 	}
 


### PR DESCRIPTION
This change introduces diagnostic debug, info and error logging in
queued_retry exporter helpers. The logging will be applied to all
exporters which use the helpers.

All logging is heavily sampled to avoid flooding the logs. We will
likely need to revise the contributing guide here to clarify that
such sampled logging is allowed:
https://github.com/open-telemetry/opentelemetry-collector/blob/master/CONTRIBUTING.md#logging

We will likely also want to fix the logging for batch processor
which currently outputs not very user friendly messages on failures.

Resolves https://github.com/open-telemetry/opentelemetry-collector/issues/2013

Sample output with otlphttp exporter and destination unavailable:

```
{"level":"info","ts":1603846135.431853,"caller":"service/service.go:252","msg":"Everything is ready. Begin running and processing data."}
{"level":"info","ts":1603846140.7589068,"caller":"exporterhelper/queued_retry.go:250","msg":"Exporting failed. Will retry the request after interval.","component_kind":"exporter","component_type":"otlphttp","component_name":"otlphttp","error":"failed to make an HTTP request: Post \"http://localhost:1234\": dial tcp [::1]:1234: connect: connection refused","interval":"3.571319363s"}
{"level":"info","ts":1603846151.5628319,"caller":"exporterhelper/queued_retry.go:250","msg":"Exporting failed. Will retry the request after interval.","component_kind":"exporter","component_type":"otlphttp","component_name":"otlphttp","error":"failed to make an HTTP request: Post \"http://localhost:1234\": dial tcp [::1]:1234: connect: connection refused","interval":"13.463090615s"}
{"level":"error","ts":1603846153.3259032,"caller":"exporterhelper/queued_retry.go:238","msg":"Exporting failed. No more retries left. Dropping data.","component_kind":"exporter","component_type":"otlphttp","component_name":"otlphttp","error":"max elapsed time expired failed to make an HTTP request: Post \"http://localhost:1234\": dial tcp [::1]:1234: connect: connection refused","dropped_items":10,"stacktrace":"go.opentelemetry.io/collector/exporter/exporterhelper.(*retrySender).send\n\t/Users/tnajaryan/work/repos/collector-core/exporter/exporterhelper/queued_retry.go:238\ngo.opentelemetry.io/collector/exporter/exporterhelper.(*metricsSenderWithObservability).send\n\t/Users/tnajaryan/work/repos/collector-core/exporter/exporterhelper/metricshelper.go:119\ngo.opentelemetry.io/collector/exporter/exporterhelper.(*queuedRetrySender).start.func1\n\t/Users/tnajaryan/work/repos/collector-core/exporter/exporterhelper/queued_retry.go:129\ngithub.com/jaegertracing/jaeger/pkg/queue.(*BoundedQueue).StartConsumers.func1\n\t/Users/tnajaryan/.go/pkg/mod/github.com/jaegertracing/jaeger@v1.20.0/pkg/queue/bounded_queue.go:77"}
{"level":"info","ts":1603846162.86763,"caller":"exporterhelper/queued_retry.go:250","msg":"Exporting failed. Will retry the request after interval.","component_kind":"exporter","component_type":"otlphttp","component_name":"otlphttp","error":"failed to make an HTTP request: Post \"http://localhost:1234\": dial tcp [::1]:1234: connect: connection refused","interval":"7.729392865s"}
{"level":"error","ts":1603846163.918241,"caller":"exporterhelper/queued_retry.go:238","msg":"Exporting failed. No more retries left. Dropping data.","component_kind":"exporter","component_type":"otlphttp","component_name":"otlphttp","error":"max elapsed time expired failed to make an HTTP request: Post \"http://localhost:1234\": dial tcp [::1]:1234: connect: connection refused","dropped_items":10,"stacktrace":"go.opentelemetry.io/collector/exporter/exporterhelper.(*retrySender).send\n\t/Users/tnajaryan/work/repos/collector-core/exporter/exporterhelper/queued_retry.go:238\ngo.opentelemetry.io/collector/exporter/exporterhelper.(*metricsSenderWithObservability).send\n\t/Users/tnajaryan/work/repos/collector-core/exporter/exporterhelper/metricshelper.go:119\ngo.opentelemetry.io/collector/exporter/exporterhelper.(*queuedRetrySender).start.func1\n\t/Users/tnajaryan/work/repos/collector-core/exporter/exporterhelper/queued_retry.go:129\ngithub.com/jaegertracing/jaeger/pkg/queue.(*BoundedQueue).StartConsumers.func1\n\t/Users/tnajaryan/.go/pkg/mod/github.com/jaegertracing/jaeger@v1.20.0/pkg/queue/bounded_queue.go:77"}
{"level":"error","ts":1603846174.1390579,"caller":"exporterhelper/queued_retry.go:238","msg":"Exporting failed. No more retries left. Dropping data.","component_kind":"exporter","component_type":"otlphttp","component_name":"otlphttp","error":"max elapsed time expired failed to make an HTTP request: Post \"http://localhost:1234\": dial tcp [::1]:1234: connect: connection refused","dropped_items":12,"stacktrace":"go.opentelemetry.io/collector/exporter/exporterhelper.(*retrySender).send\n\t/Users/tnajaryan/work/repos/collector-core/exporter/exporterhelper/queued_retry.go:238\ngo.opentelemetry.io/collector/exporter/exporterhelper.(*metricsSenderWithObservability).send\n\t/Users/tnajaryan/work/repos/collector-core/exporter/exporterhelper/metricshelper.go:119\ngo.opentelemetry.io/collector/exporter/exporterhelper.(*queuedRetrySender).start.func1\n\t/Users/tnajaryan/work/repos/collector-core/exporter/exporterhelper/queued_retry.go:129\ngithub.com/jaegertracing/jaeger/pkg/queue.(*BoundedQueue).StartConsumers.func1\n\t/Users/tnajaryan/.go/pkg/mod/github.com/jaegertracing/jaeger@v1.20.0/pkg/queue/bounded_queue.go:77"}
{"level":"info","ts":1603846174.140094,"caller":"exporterhelper/queued_retry.go:250","msg":"Exporting failed. Will retry the request after interval.","component_kind":"exporter","component_type":"otlphttp","component_name":"otlphttp","error":"failed to make an HTTP request: Post \"http://localhost:1234\": dial tcp [::1]:1234: connect: connection refused","interval":"6.505275214s"}
{"level":"error","ts":1603846177.78816,"caller":"exporterhelper/queued_retry.go:150","msg":"Dropping data because sending_queue is full. Try increasing queue_size.","component_kind":"exporter","component_type":"otlphttp","component_name":"otlphttp","dropped_items":12,"stacktrace":"go.opentelemetry.io/collector/exporter/exporterhelper.(*queuedRetrySender).send\n\t/Users/tnajaryan/work/repos/collector-core/exporter/exporterhelper/queued_retry.go:150\ngo.opentelemetry.io/collector/exporter/exporterhelper.(*metricsExporter).ConsumeMetrics\n\t/Users/tnajaryan/work/repos/collector-core/exporter/exporterhelper/metricshelper.go:79\ngo.opentelemetry.io/collector/processor/batchprocessor.(*batchMetrics).export\n\t/Users/tnajaryan/work/repos/collector-core/processor/batchprocessor/batch_processor.go:260\ngo.opentelemetry.io/collector/processor/batchprocessor.(*batchProcessor).sendItems\n\t/Users/tnajaryan/work/repos/collector-core/processor/batchprocessor/batch_processor.go:165\ngo.opentelemetry.io/collector/processor/batchprocessor.(*batchProcessor).startProcessingCycle\n\t/Users/tnajaryan/work/repos/collector-core/processor/batchprocessor/batch_processor.go:145"}
{"level":"warn","ts":1603846177.78847,"caller":"batchprocessor/batch_processor.go:166","msg":"Sender failed","component_kind":"processor","component_type":"batch","component_name":"batch","error":"Dropping data because sending_queue is full. Try increasing queue_size."}
{"level":"warn","ts":1603846179.797478,"caller":"batchprocessor/batch_processor.go:166","msg":"Sender failed","component_kind":"processor","component_type":"batch","component_name":"batch","error":"Dropping data because sending_queue is full. Try increasing queue_size."}
{"level":"warn","ts":1603846180.798402,"caller":"batchprocessor/batch_processor.go:166","msg":"Sender failed","component_kind":"processor","component_type":"batch","component_name":"batch","error":"Dropping data because sending_queue is full. Try increasing queue_size."}
{"level":"warn","ts":1603846181.8058171,"caller":"batchprocessor/batch_processor.go:166","msg":"Sender failed","component_kind":"processor","component_type":"batch","component_name":"batch","error":"Dropping data because sending_queue is full. Try increasing queue_size."}
{"level":"error","ts":1603846185.3383482,"caller":"exporterhelper/queued_retry.go:238","msg":"Exporting failed. No more retries left. Dropping data.","component_kind":"exporter","component_type":"otlphttp","component_name":"otlphttp","error":"max elapsed time expired failed to make an HTTP request: Post \"http://localhost:1234\": dial tcp [::1]:1234: connect: connection refused","dropped_items":12,"stacktrace":"go.opentelemetry.io/collector/exporter/exporterhelper.(*retrySender).send\n\t/Users/tnajaryan/work/repos/collector-core/exporter/exporterhelper/queued_retry.go:238\ngo.opentelemetry.io/collector/exporter/exporterhelper.(*metricsSenderWithObservability).send\n\t/Users/tnajaryan/work/repos/collector-core/exporter/exporterhelper/metricshelper.go:119\ngo.opentelemetry.io/collector/exporter/exporterhelper.(*queuedRetrySender).start.func1\n\t/Users/tnajaryan/work/repos/collector-core/exporter/exporterhelper/queued_retry.go:129\ngithub.com/jaegertracing/jaeger/pkg/queue.(*BoundedQueue).StartConsumers.func1\n\t/Users/tnajaryan/.go/pkg/mod/github.com/jaegertracing/jaeger@v1.20.0/pkg/queue/bounded_queue.go:77"}
{"level":"info","ts":1603846185.339205,"caller":"exporterhelper/queued_retry.go:250","msg":"Exporting failed. Will retry the request after interval.","component_kind":"exporter","component_type":"otlphttp","component_name":"otlphttp","error":"failed to make an HTTP request: Post \"http://localhost:1234\": dial tcp [::1]:1234: connect: connection refused","interval":"5.318897979s"}
^C{"level":"info","ts":1603846187.05004,"caller":"service/service.go:265","msg":"Received signal from OS","signal":"interrupt"}
{"level":"info","ts":1603846187.050097,"caller":"service/service.go:432","msg":"Starting shutdown..."}
```
