### PR TITLE
Remove StringValue, do not return a pointer to the value in the map

### DIFF
--- a/consumer/pdata/common.go
+++ b/consumer/pdata/common.go
@@ -765,38 +765,6 @@ func (am AttributeMap) CopyTo(dest AttributeMap) {
 	*dest.orig = origs
 }
 
-// StringValue stores a string value.
-//
-// Intended to be passed by value since internally it is just a pointer to actual
-// value representation. For the same reason passing by value and calling setters
-// will modify the original, e.g.:
-//
-//   function f1(val StringValue) { val.SetValue("1234") }
-//   function f2() {
-//   	v := NewStringKeyValue("key", "a string")
-//      f1(v)
-//      _ := v.Value() // this will return "1234"
-//   }
-type StringValue struct {
-	orig *otlpcommon.StringKeyValue
-}
-
-// Value returns the value associated with this StringValue.
-// Calling this function on zero-initialized StringValue will cause a panic.
-func (akv StringValue) Value() string {
-	return akv.orig.Value
-}
-
-// SetValue replaces the value associated with this StringValue.
-// Calling this function on zero-initialized StringValue will cause a panic.
-func (akv StringValue) SetValue(v string) {
-	akv.orig.Value = v
-}
-
-func newStringKeyValue(k, v string) otlpcommon.StringKeyValue {
-	return otlpcommon.StringKeyValue{Key: k, Value: v}
-}
-
 // StringMap stores a map of attribute keys to values.
 type StringMap struct {
 	orig *[]otlpcommon.StringKeyValue
@@ -844,14 +812,10 @@ func (sm StringMap) InitEmptyWithCapacity(cap int) {
 // Get returns the StringValue associated with the key and true,
 // otherwise an invalid instance of the StringKeyValue and false.
 // Calling any functions on the returned invalid instance will cause a panic.
-func (sm StringMap) Get(k string) (StringValue, bool) {
-	for i := range *sm.orig {
-		skv := &(*sm.orig)[i]
-		if skv.Key == k {
-			return StringValue{skv}, true
-		}
-	}
-	return StringValue{nil}, false
+func (sm StringMap) Get(k string) (string, bool) {
+	skv, found := sm.get(k)
+	// GetValue handles the case where skv is nil.
+	return skv.GetValue(), found
 }
 
 // Delete deletes the entry associated with the key and returns true if the key
@@ -879,8 +843,8 @@ func (sm StringMap) Insert(k, v string) {
 // Update updates an existing string value with a value.
 // No action is applied to the map where the key does not exist.
 func (sm StringMap) Update(k, v string) {
-	if av, existing := sm.Get(k); existing {
-		av.SetValue(v)
+	if skv, existing := sm.get(k); existing {
+		skv.Value = v
 	}
 }
 
@@ -888,8 +852,8 @@ func (sm StringMap) Update(k, v string) {
 // insert to the map that did not originally have the key. The key/value is
 // updated to the map where the key already existed.
 func (sm StringMap) Upsert(k, v string) {
-	if av, existing := sm.Get(k); existing {
-		av.SetValue(v)
+	if skv, existing := sm.get(k); existing {
+		skv.Value = v
 	} else {
 		*sm.orig = append(*sm.orig, newStringKeyValue(k, v))
 	}
@@ -910,10 +874,10 @@ func (sm StringMap) Len() int {
 // it := sm.ForEach(func(k string, v StringValue) {
 //   ...
 // })
-func (sm StringMap) ForEach(f func(k string, v StringValue)) {
+func (sm StringMap) ForEach(f func(k string, v string)) {
 	for i := range *sm.orig {
 		skv := &(*sm.orig)[i]
-		f(skv.Key, StringValue{skv})
+		f(skv.Key, skv.Value)
 	}
 }
 
@@ -942,6 +906,16 @@ func (sm StringMap) CopyTo(dest StringMap) {
 	*dest.orig = origs
 }
 
+func (sm StringMap) get(k string) (*otlpcommon.StringKeyValue, bool) {
+	for i := range *sm.orig {
+		skv := &(*sm.orig)[i]
+		if skv.Key == k {
+			return skv, true
+		}
+	}
+	return nil, false
+}
+
 // Sort sorts the entries in the StringMap so two instances can be compared.
 // Returns the same instance to allow nicer code like:
 // assert.EqualValues(t, expected.Sort(), actual.Sort())
@@ -951,4 +925,8 @@ func (sm StringMap) Sort() StringMap {
 		return (*sm.orig)[i].Key < (*sm.orig)[j].Key
 	})
 	return sm
+}
+
+func newStringKeyValue(k, v string) otlpcommon.StringKeyValue {
+	return otlpcommon.StringKeyValue{Key: k, Value: v}
 }

--- a/consumer/pdata/common_test.go
+++ b/consumer/pdata/common_test.go
@@ -693,7 +693,7 @@ func TestNilStringMap(t *testing.T) {
 
 	val, exist := NewStringMap().Get("test_key")
 	assert.False(t, exist)
-	assert.EqualValues(t, StringValue{nil}, val)
+	assert.EqualValues(t, "", val)
 
 	insertMap := NewStringMap()
 	insertMap.Insert("k", "v")
@@ -728,27 +728,27 @@ func TestStringMapWithEmpty(t *testing.T) {
 	}
 	val, exist := sm.Get("test_key")
 	assert.True(t, exist)
-	assert.EqualValues(t, "test_value", val.Value())
+	assert.EqualValues(t, "test_value", val)
 
 	sm.Insert("other_key", "other_value")
 	val, exist = sm.Get("other_key")
 	assert.True(t, exist)
-	assert.EqualValues(t, "other_value", val.Value())
+	assert.EqualValues(t, "other_value", val)
 
 	sm.Update("other_key", "yet_another_value")
 	val, exist = sm.Get("other_key")
 	assert.True(t, exist)
-	assert.EqualValues(t, "yet_another_value", val.Value())
+	assert.EqualValues(t, "yet_another_value", val)
 
 	sm.Upsert("other_key", "other_value")
 	val, exist = sm.Get("other_key")
 	assert.True(t, exist)
-	assert.EqualValues(t, "other_value", val.Value())
+	assert.EqualValues(t, "other_value", val)
 
 	sm.Upsert("yet_another_key", "yet_another_value")
 	val, exist = sm.Get("yet_another_key")
 	assert.True(t, exist)
-	assert.EqualValues(t, "yet_another_value", val.Value())
+	assert.EqualValues(t, "yet_another_value", val)
 
 	assert.True(t, sm.Delete("other_key"))
 	assert.True(t, sm.Delete("yet_another_key"))
@@ -758,7 +758,7 @@ func TestStringMapWithEmpty(t *testing.T) {
 	// Test that the initial key is still there.
 	val, exist = sm.Get("test_key")
 	assert.True(t, exist)
-	assert.EqualValues(t, "test_value", val.Value())
+	assert.EqualValues(t, "test_value", val)
 
 	// Test Sort
 	assert.EqualValues(t, StringMap{orig: &origWithNil}, sm.Sort())
@@ -772,11 +772,11 @@ func TestStringMap(t *testing.T) {
 
 	val, exist := sm.Get("k2")
 	assert.True(t, exist)
-	assert.EqualValues(t, "v2", val.Value())
+	assert.EqualValues(t, "v2", val)
 
 	val, exist = sm.Get("k3")
 	assert.False(t, exist)
-	assert.EqualValues(t, StringValue{nil}, val)
+	assert.EqualValues(t, "", val)
 
 	sm.Insert("k1", "v1")
 	assert.EqualValues(t, origMap.Sort(), sm.Sort())
@@ -825,7 +825,7 @@ func TestStringMap(t *testing.T) {
 }
 
 func TestStringMapIterationNil(t *testing.T) {
-	NewStringMap().ForEach(func(k string, v StringValue) {
+	NewStringMap().ForEach(func(k string, v string) {
 		// Fail if any element is returned
 		t.Fail()
 	})
@@ -836,8 +836,8 @@ func TestStringMap_ForEach(t *testing.T) {
 	sm := NewStringMap().InitFromMap(rawMap)
 	assert.EqualValues(t, 3, sm.Len())
 
-	sm.ForEach(func(k string, v StringValue) {
-		assert.EqualValues(t, rawMap[k], v.Value())
+	sm.ForEach(func(k string, v string) {
+		assert.EqualValues(t, rawMap[k], v)
 		delete(rawMap, k)
 	})
 	assert.EqualValues(t, 0, len(rawMap))
@@ -967,7 +967,7 @@ func BenchmarkStringMap_ForEach(b *testing.B) {
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		numEls := 0
-		sm.ForEach(func(s string, value StringValue) {
+		sm.ForEach(func(s string, value string) {
 			numEls++
 		})
 		if numEls != numElements {
@@ -978,18 +978,17 @@ func BenchmarkStringMap_ForEach(b *testing.B) {
 
 func BenchmarkStringMap_RangeOverMap(b *testing.B) {
 	const numElements = 20
-	rawOrig := make(map[string]StringValue, numElements)
+	rawOrig := make(map[string]string, numElements)
 	for i := 0; i < numElements; i++ {
 		key := "k" + strconv.Itoa(i)
-		skv := newStringKeyValue(key, "v"+strconv.Itoa(i))
-		rawOrig[key] = StringValue{&skv}
+		rawOrig[key] = "v" + strconv.Itoa(i)
 	}
 
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		numEls := 0
 		for _, v := range rawOrig {
-			if v.orig == nil {
+			if v == "" {
 				continue
 			}
 			numEls++

--- a/exporter/loggingexporter/logging_exporter.go
+++ b/exporter/loggingexporter/logging_exporter.go
@@ -60,8 +60,8 @@ func (b *logDataBuffer) logStringMap(description string, sm pdata.StringMap) {
 	}
 
 	b.logEntry("%s:", description)
-	sm.ForEach(func(k string, v pdata.StringValue) {
-		b.logEntry("     -> %s: %s", k, v.Value())
+	sm.ForEach(func(k string, v string) {
+		b.logEntry("     -> %s: %s", k, v)
 	})
 }
 

--- a/internal/goldendataset/metric_gen_test.go
+++ b/internal/goldendataset/metric_gen_test.go
@@ -51,7 +51,7 @@ func TestGenDefault(t *testing.T) {
 
 	require.Equal(t, 1, pt.LabelsMap().Len())
 	ptLabels, _ := pt.LabelsMap().Get("pt-label-key-0")
-	require.Equal(t, "pt-label-val-0", ptLabels.Value())
+	require.Equal(t, "pt-label-val-0", ptLabels)
 
 	require.EqualValues(t, 940000000000000000, pt.StartTime())
 	require.EqualValues(t, 940000000000000042, pt.Timestamp())

--- a/receiver/hostmetricsreceiver/internal/testutils.go
+++ b/receiver/hostmetricsreceiver/internal/testutils.go
@@ -38,19 +38,19 @@ func AssertDescriptorEqual(t *testing.T, expected pdata.Metric, actual pdata.Met
 func AssertIntSumMetricLabelHasValue(t *testing.T, metric pdata.Metric, index int, labelName string, expectedVal string) {
 	val, ok := metric.IntSum().DataPoints().At(index).LabelsMap().Get(labelName)
 	assert.Truef(t, ok, "Missing label %q in metric %q", labelName, metric.Name())
-	assert.Equal(t, expectedVal, val.Value())
+	assert.Equal(t, expectedVal, val)
 }
 
 func AssertIntGaugeMetricLabelHasValue(t *testing.T, metric pdata.Metric, index int, labelName string, expectedVal string) {
 	val, ok := metric.IntGauge().DataPoints().At(index).LabelsMap().Get(labelName)
 	assert.Truef(t, ok, "Missing label %q in metric %q", labelName, metric.Name())
-	assert.Equal(t, expectedVal, val.Value())
+	assert.Equal(t, expectedVal, val)
 }
 
 func AssertDoubleSumMetricLabelHasValue(t *testing.T, metric pdata.Metric, index int, labelName string, expectedVal string) {
 	val, ok := metric.DoubleSum().DataPoints().At(index).LabelsMap().Get(labelName)
 	assert.Truef(t, ok, "Missing label %q in metric %q", labelName, metric.Name())
-	assert.Equal(t, expectedVal, val.Value())
+	assert.Equal(t, expectedVal, val)
 }
 
 func AssertIntSumMetricLabelExists(t *testing.T, metric pdata.Metric, index int, labelName string) {

--- a/translator/internaldata/metrics_to_oc.go
+++ b/translator/internaldata/metrics_to_oc.go
@@ -197,7 +197,7 @@ func collectLabelKeysDoubleHistogramDataPoints(dhdp pdata.DoubleHistogramDataPoi
 }
 
 func addLabelKeys(keySet map[string]struct{}, labels pdata.StringMap) {
-	labels.ForEach(func(k string, v pdata.StringValue) {
+	labels.ForEach(func(k string, v string) {
 		keySet[k] = struct{}{}
 	})
 }
@@ -472,8 +472,8 @@ func exemplarToOC(filteredLabels pdata.StringMap, value float64, timestamp pdata
 	var labels map[string]string
 	if filteredLabels.Len() != 0 {
 		labels = make(map[string]string, filteredLabels.Len())
-		filteredLabels.ForEach(func(k string, v pdata.StringValue) {
-			labels[k] = v.Value()
+		filteredLabels.ForEach(func(k string, v string) {
+			labels[k] = v
 		})
 	}
 
@@ -498,13 +498,13 @@ func labelValuesToOC(labels pdata.StringMap, labelKeys *labelKeys) []*ocmetrics.
 	}
 
 	// Visit all defined labels in the point and override defaults with actual values
-	labels.ForEach(func(k string, v pdata.StringValue) {
+	labels.ForEach(func(k string, v string) {
 		// Find the appropriate label value that we need to update
 		keyIndex := labelKeys.keyIndices[k]
 		labelValue := labelValues[keyIndex]
 
 		// Update label value
-		labelValue.Value = v.Value()
+		labelValue.Value = v
 		labelValue.HasValue = true
 	})
 


### PR DESCRIPTION
This is important since we changed to use slice of values instead of slice of pointers.
After that change we returned a pointer to the memory block to allow users to change the value
of the returned Get or when ForEach, this has a problem if the user keeps a reference to
the returned value by the Get call, then applies any mutation that may move the memory around
Delete, Insert/Upsert the returned pointer may point to other block of memory (different
value in the map) or to a block that is no longer part of the slice, if the slice has to be moved.
