### PR TITLE
Mark as deprecated NewAttributeValue

### DIFF
--- a/consumer/pdata/common.go
+++ b/consumer/pdata/common.go
@@ -66,7 +66,7 @@ func (avt AttributeValueType) String() string {
 }
 
 // AttributeValue represents a value of an attribute. Typically used in AttributeMap.
-// Must use one of NewAttributeValue* functions below to create new instances.
+// Must use one of NewAttributeValue+ functions below to create new instances.
 //
 // Intended to be passed by value since internally it is just a pointer to actual
 // value representation. For the same reason passing by value and calling setters
@@ -101,6 +101,7 @@ func NewAttributeValueNull() AttributeValue {
 	return AttributeValue{orig: &orig}
 }
 
+// Deprecated: Use NewAttributeValueNull()
 func NewAttributeValue() AttributeValue {
 	return NewAttributeValueNull()
 }

--- a/translator/trace/protospan_translation_test.go
+++ b/translator/trace/protospan_translation_test.go
@@ -85,7 +85,7 @@ func TestAttributeValueToString(t *testing.T) {
 		},
 		{
 			name:     "array",
-			input:    pdata.NewAttributeValue(),
+			input:    pdata.NewAttributeValueNull(),
 			jsonLike: false,
 			expected: "",
 		},


### PR DESCRIPTION
Remove usages from non generated call. It is strange to have two new functions that do the same thing.
