### PR TITLE
Allow to configure the default executable file name in testbed

### DIFF
--- a/testbed/testbed/child_process.go
+++ b/testbed/testbed/child_process.go
@@ -205,7 +205,7 @@ func (cp *ChildProcess) Start(params StartParams) error {
 	cp.resourceSpec = params.resourceSpec
 
 	if cp.AgentExePath == "" {
-		cp.AgentExePath = "../../bin/otelcol_{{.GOOS}}_{{.GOARCH}}"
+		cp.AgentExePath = GlobalConfig.DefaultAgentExeRelativeFile
 	}
 	exePath := expandExeFileName(cp.AgentExePath)
 	exePath, err := filepath.Abs(exePath)

--- a/testbed/testbed/test_bed.go
+++ b/testbed/testbed/test_bed.go
@@ -46,6 +46,23 @@ func SaveResults(resultsSummary TestResultsSummary) {
 
 const testBedEnableEnvVarName = "RUN_TESTBED"
 
+var GlobalConfig = struct {
+	// Relative path to default agent executable to test.
+	// Can be set in the contrib repo to use a different executable name.
+	// Set this before calling DoTestMain().
+	//
+	// If used in the path, {{.GOOS}} and {{.GOARCH}} will be expanded to the current
+	// OS and ARCH correspondingly.
+	//
+	// Individual tests can override this by setting the AgentExePath of ChildProcess
+	// that is passed to the TestCase.
+	DefaultAgentExeRelativeFile string
+}{
+	// The default exe that is produced by Makefile "otelcol" target relative
+	// to testbed/tests directory.
+	DefaultAgentExeRelativeFile: "../../bin/otelcol_{{.GOOS}}_{{.GOARCH}}",
+}
+
 // DoTestMain is intended to be run from TestMain somewhere in the test suit.
 // This enables the testbed.
 func DoTestMain(m *testing.M, resultsSummary TestResultsSummary) {


### PR DESCRIPTION
This is necessary because the file name in the contrib repo is
different from the file name in the core repo.
