### PR TITLE
Remove support to set map and array to attribute value

### DIFF
--- a/exporter/loggingexporter/logging_exporter_test.go
+++ b/exporter/loggingexporter/logging_exporter_test.go
@@ -72,18 +72,16 @@ func TestLoggingLogsExporterNoErrors(t *testing.T) {
 }
 
 func TestNestedArraySerializesCorrectly(t *testing.T) {
-	av := pdata.NewAnyValueArray()
 	ava := pdata.NewAttributeValueArray()
+	av := ava.ArrayVal()
 	av.Append(pdata.NewAttributeValueString("foo"))
 	av.Append(pdata.NewAttributeValueInt(42))
 
-	av2 := pdata.NewAnyValueArray()
-	av2.Append(pdata.NewAttributeValueString("bar"))
 	ava2 := pdata.NewAttributeValueArray()
-	ava2.SetArrayVal(av2)
+	av2 := ava2.ArrayVal()
+	av2.Append(pdata.NewAttributeValueString("bar"))
 
 	av.Append(ava2)
-	ava.SetArrayVal(av)
 
 	assert.Equal(t, 3, ava.ArrayVal().Len())
 	assert.Equal(t, "[foo, 42, [bar]]", attributeValueToString(ava))


### PR DESCRIPTION
This makes things consistent with other generated code where we do not allow
to set non immutable fields.

User can get access to the Map/Array and change that in-place.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
