### PR TITLE
Fix host metrics disk tests

### DIFF
--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_test.go
@@ -124,7 +124,13 @@ func assertInt64DiskMetricValid(t *testing.T, metric pdata.Metric, expectedDescr
 	if startTime != 0 {
 		internal.AssertIntSumMetricStartTimeEquals(t, metric, startTime)
 	}
-	assert.GreaterOrEqual(t, metric.IntSum().DataPoints().Len(), 2)
+
+	minExpectedPoints := 1
+	if expectDirectionLabels {
+		minExpectedPoints = 2
+	}
+	assert.GreaterOrEqual(t, metric.IntSum().DataPoints().Len(), minExpectedPoints)
+
 	internal.AssertIntSumMetricLabelExists(t, metric, 0, deviceLabelName)
 	if expectDirectionLabels {
 		internal.AssertIntSumMetricLabelHasValue(t, metric, 0, directionLabelName, readDirectionLabelValue)
@@ -137,7 +143,13 @@ func assertDoubleDiskMetricValid(t *testing.T, metric pdata.Metric, expectedDesc
 	if startTime != 0 {
 		internal.AssertDoubleSumMetricStartTimeEquals(t, metric, startTime)
 	}
-	assert.GreaterOrEqual(t, metric.DoubleSum().DataPoints().Len(), 2)
+
+	minExpectedPoints := 1
+	if expectDirectionLabels {
+		minExpectedPoints = 2
+	}
+	assert.GreaterOrEqual(t, metric.DoubleSum().DataPoints().Len(), minExpectedPoints)
+
 	internal.AssertDoubleSumMetricLabelExists(t, metric, 0, deviceLabelName)
 	if expectDirectionLabels {
 		internal.AssertDoubleSumMetricLabelHasValue(t, metric, 0, directionLabelName, readDirectionLabelValue)


### PR DESCRIPTION
**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector/issues/2041

**Description:**

- The `disk.io_time` metric only reports a single value: the total time the disk was active. Unlike other disk metrics, it does not report read & write data points. Therefore, we would only expect one data point per disk.
- The test checked for a minimum of two data points. Therefore, if this test was run on a machine with a single disk drive, the test would fail.

Fixed the test to check for a minimum of one data point for this metric.

---

_Note to maintainers: please merge #1949 before this PR 😄_