### PR TITLE
Guard for nil data points

### DIFF
--- a/consumer/pdata/metric.go
+++ b/consumer/pdata/metric.go
@@ -147,16 +147,34 @@ func (md Metrics) MetricAndDataPointCount() (metricCount int, dataPointCount int
 				}
 				switch m.DataType() {
 				case MetricDataTypeIntGauge:
+					if m.IntGauge().IsNil() {
+						continue
+					}
 					dataPointCount += m.IntGauge().DataPoints().Len()
 				case MetricDataTypeDoubleGauge:
+					if m.DoubleGauge().IsNil() {
+						continue
+					}
 					dataPointCount += m.DoubleGauge().DataPoints().Len()
 				case MetricDataTypeIntSum:
+					if m.IntSum().IsNil() {
+						continue
+					}
 					dataPointCount += m.IntSum().DataPoints().Len()
 				case MetricDataTypeDoubleSum:
+					if m.DoubleSum().IsNil() {
+						continue
+					}
 					dataPointCount += m.DoubleSum().DataPoints().Len()
 				case MetricDataTypeIntHistogram:
+					if m.IntHistogram().IsNil() {
+						continue
+					}
 					dataPointCount += m.IntHistogram().DataPoints().Len()
 				case MetricDataTypeDoubleHistogram:
+					if m.DoubleHistogram().IsNil() {
+						continue
+					}
 					dataPointCount += m.DoubleHistogram().DataPoints().Len()
 				}
 			}

--- a/consumer/pdata/metric_test.go
+++ b/consumer/pdata/metric_test.go
@@ -332,6 +332,45 @@ func TestMetricAndDataPointCountWithNil(t *testing.T) {
 
 }
 
+func TestMetricAndDataPointCountWithNilDataPoints(t *testing.T) {
+	metrics := NewMetrics()
+	rm := NewResourceMetrics()
+	rm.InitEmpty()
+	metrics.ResourceMetrics().Append(rm)
+	ilm := NewInstrumentationLibraryMetrics()
+	ilm.InitEmpty()
+	rm.InstrumentationLibraryMetrics().Append(ilm)
+	intGauge := NewMetric()
+	intGauge.InitEmpty()
+	ilm.Metrics().Append(intGauge)
+	intGauge.SetDataType(MetricDataTypeIntGauge)
+	doubleGauge := NewMetric()
+	doubleGauge.InitEmpty()
+	ilm.Metrics().Append(doubleGauge)
+	doubleGauge.SetDataType(MetricDataTypeDoubleGauge)
+	intHistogram := NewMetric()
+	intHistogram.InitEmpty()
+	ilm.Metrics().Append(intHistogram)
+	intHistogram.SetDataType(MetricDataTypeIntHistogram)
+	doubleHistogram := NewMetric()
+	doubleHistogram.InitEmpty()
+	ilm.Metrics().Append(doubleHistogram)
+	doubleHistogram.SetDataType(MetricDataTypeDoubleHistogram)
+	intSum := NewMetric()
+	intSum.InitEmpty()
+	ilm.Metrics().Append(intSum)
+	intSum.SetDataType(MetricDataTypeIntSum)
+	doubleSum := NewMetric()
+	doubleSum.InitEmpty()
+	ilm.Metrics().Append(doubleSum)
+	doubleSum.SetDataType(MetricDataTypeDoubleSum)
+
+	ms, dps := metrics.MetricAndDataPointCount()
+
+	assert.EqualValues(t, 6, ms)
+	assert.EqualValues(t, 0, dps)
+}
+
 func TestOtlpToInternalReadOnly(t *testing.T) {
 	metricData := MetricsFromOtlp([]*otlpmetrics.ResourceMetrics{
 		{


### PR DESCRIPTION

**Description:** 
Add a guard for invalid metrics with no data points. The function `MetricAndDataPointCount` currently panics if the gauge, histogram or sum is nil.

**Testing:**
I added a unit test and reproduced the issue, making sure the issue is fixed with the test passing.

