### PR TITLE
[exporter-helper] [resource_to_label_conversion] add helper function and expose exporter settings

### DIFF
--- a/exporter/exporterhelper/README.md
+++ b/exporter/exporterhelper/README.md
@@ -21,7 +21,7 @@ The following configuration options can be modified:
   User should calculate this as `num_seconds * requests_per_second` where:
     - `num_seconds` is the number of seconds to buffer in case of a backend outage
     - `requests_per_second` is the average number of requests per seconds.
-- `resource_to_label_conversion`
+- `resource_to_telemetry_conversion`
   - `enabled` (default = false): If `enabled` is `true`, all the resource attributes will be converted to metric labels by default.
 
 The full list of settings exposed for this helper exporter are documented [here](factory.go).

--- a/exporter/exporterhelper/README.md
+++ b/exporter/exporterhelper/README.md
@@ -1,7 +1,7 @@
 # Exporter Helper
 
 This is a helper exporter that other exporters can depend on. Today, it
-primarily offers queued retries capabilities.
+primarily offers queued retries  and resource attributes to metric labels conversion.
 
 > :warning: This exporter should not be added to a service pipeline.
 
@@ -21,5 +21,7 @@ The following configuration options can be modified:
   User should calculate this as `num_seconds * requests_per_second` where:
     - `num_seconds` is the number of seconds to buffer in case of a backend outage
     - `requests_per_second` is the average number of requests per seconds.
+- `resource_to_label_conversion`
+  - `enabled` (default = false): If `enabled` is `true`, all the resource attributes will be converted to metric labels by default.
 
 The full list of settings exposed for this helper exporter are documented [here](factory.go).

--- a/exporter/exporterhelper/common.go
+++ b/exporter/exporterhelper/common.go
@@ -87,6 +87,7 @@ type internalOptions struct {
 	TimeoutSettings
 	QueueSettings
 	RetrySettings
+	ResourceToLabelSettings
 	Start
 	Shutdown
 }
@@ -99,9 +100,10 @@ func fromConfiguredOptions(options ...ExporterOption) *internalOptions {
 		// TODO: Enable queuing by default (call CreateDefaultQueueSettings)
 		QueueSettings: QueueSettings{Enabled: false},
 		// TODO: Enable retry by default (call CreateDefaultRetrySettings)
-		RetrySettings: RetrySettings{Enabled: false},
-		Start:         func(ctx context.Context, host component.Host) error { return nil },
-		Shutdown:      func(ctx context.Context) error { return nil },
+		RetrySettings:           RetrySettings{Enabled: false},
+		ResourceToLabelSettings: CreateDefaultResourceToLabelSettings(),
+		Start:                   func(ctx context.Context, host component.Host) error { return nil },
+		Shutdown:                func(ctx context.Context) error { return nil },
 	}
 
 	for _, op := range options {
@@ -151,6 +153,14 @@ func WithRetry(retrySettings RetrySettings) ExporterOption {
 func WithQueue(queueSettings QueueSettings) ExporterOption {
 	return func(o *internalOptions) {
 		o.QueueSettings = queueSettings
+	}
+}
+
+// WithResourceToLabelConversion overrides the default ResourceToLabelSettings for an exporter.
+// The default ResourceToLabelSettings is to disable resource attributes to labels conversion.
+func WithResourceToLabelConversion(resourceToLabelSettings ResourceToLabelSettings) ExporterOption {
+	return func(o *internalOptions) {
+		o.ResourceToLabelSettings = resourceToLabelSettings
 	}
 }
 

--- a/exporter/exporterhelper/common_test.go
+++ b/exporter/exporterhelper/common_test.go
@@ -49,7 +49,7 @@ func TestBaseExporterWithOptions(t *testing.T) {
 		zap.NewNop(),
 		WithStart(func(ctx context.Context, host component.Host) error { return errors.New("my error") }),
 		WithShutdown(func(ctx context.Context) error { return errors.New("my error") }),
-		WithResourceToLabelConversion(createDefaultResourceToLabelSettings()),
+		WithResourceToTelemetryConversion(createDefaultResourceToTelemetrySettings()),
 		WithTimeout(CreateDefaultTimeoutSettings()),
 	)
 	require.Error(t, be.Start(context.Background(), componenttest.NewNopHost()))

--- a/exporter/exporterhelper/common_test.go
+++ b/exporter/exporterhelper/common_test.go
@@ -48,7 +48,10 @@ func TestBaseExporterWithOptions(t *testing.T) {
 		defaultExporterCfg,
 		zap.NewNop(),
 		WithStart(func(ctx context.Context, host component.Host) error { return errors.New("my error") }),
-		WithShutdown(func(ctx context.Context) error { return errors.New("my error") }))
+		WithShutdown(func(ctx context.Context) error { return errors.New("my error") }),
+		WithResourceToLabelConversion(createDefaultResourceToLabelSettings()),
+		WithTimeout(CreateDefaultTimeoutSettings()),
+	)
 	require.Error(t, be.Start(context.Background(), componenttest.NewNopHost()))
 	require.Error(t, be.Shutdown(context.Background()))
 }

--- a/exporter/exporterhelper/metricshelper.go
+++ b/exporter/exporterhelper/metricshelper.go
@@ -73,7 +73,7 @@ type metricsExporter struct {
 }
 
 func (mexp *metricsExporter) ConsumeMetrics(ctx context.Context, md pdata.Metrics) error {
-	if mexp.baseExporter.convertResourceToLabels {
+	if mexp.baseExporter.convertResourceToTelemetry {
 		md = convertResourceToLabels(md)
 	}
 	exporterCtx := obsreport.ExporterContext(ctx, mexp.cfg.Name())

--- a/exporter/exporterhelper/metricshelper.go
+++ b/exporter/exporterhelper/metricshelper.go
@@ -73,8 +73,17 @@ type metricsExporter struct {
 }
 
 func (mexp *metricsExporter) ConsumeMetrics(ctx context.Context, md pdata.Metrics) error {
+	var req request
+
 	exporterCtx := obsreport.ExporterContext(ctx, mexp.cfg.Name())
-	req := newMetricsRequest(exporterCtx, md, mexp.pusher)
+
+	if mexp.baseExporter.convertResourceToLabels {
+		newMd := convertResourceToLabels(md)
+		req = newMetricsRequest(exporterCtx, newMd, mexp.pusher)
+	} else {
+		req = newMetricsRequest(exporterCtx, md, mexp.pusher)
+	}
+
 	_, err := mexp.sender.send(req)
 	return err
 }

--- a/exporter/exporterhelper/metricshelper.go
+++ b/exporter/exporterhelper/metricshelper.go
@@ -73,17 +73,11 @@ type metricsExporter struct {
 }
 
 func (mexp *metricsExporter) ConsumeMetrics(ctx context.Context, md pdata.Metrics) error {
-	var req request
-
-	exporterCtx := obsreport.ExporterContext(ctx, mexp.cfg.Name())
-
 	if mexp.baseExporter.convertResourceToLabels {
-		newMd := convertResourceToLabels(md)
-		req = newMetricsRequest(exporterCtx, newMd, mexp.pusher)
-	} else {
-		req = newMetricsRequest(exporterCtx, md, mexp.pusher)
+		md = convertResourceToLabels(md)
 	}
-
+	exporterCtx := obsreport.ExporterContext(ctx, mexp.cfg.Name())
+	req := newMetricsRequest(exporterCtx, md, mexp.pusher)
 	_, err := mexp.sender.send(req)
 	return err
 }

--- a/exporter/exporterhelper/metricshelper_test.go
+++ b/exporter/exporterhelper/metricshelper_test.go
@@ -146,6 +146,26 @@ func TestMetricsExporter_WithShutdown(t *testing.T) {
 	assert.True(t, shutdownCalled)
 }
 
+func TestMetricsExporter_WithResourceToLabelConversionDisabled(t *testing.T) {
+	md := testdata.GenerateMetricsTwoMetrics()
+	me, err := NewMetricsExporter(fakeMetricsExporterConfig, zap.NewNop(), newPushMetricsData(0, nil), WithResourceToLabelConversion(createDefaultResourceToLabelSettings()))
+	assert.NotNil(t, me)
+	assert.NoError(t, err)
+
+	assert.Nil(t, me.ConsumeMetrics(context.Background(), md))
+	assert.Nil(t, me.Shutdown(context.Background()))
+}
+
+func TestMetricsExporter_WithResourceToLabelConversionEbabled(t *testing.T) {
+	md := testdata.GenerateMetricsTwoMetrics()
+	me, err := NewMetricsExporter(fakeMetricsExporterConfig, zap.NewNop(), newPushMetricsData(0, nil), WithResourceToLabelConversion(ResourceToLabelSettings{Enabled: true}))
+	assert.NotNil(t, me)
+	assert.NoError(t, err)
+
+	assert.Nil(t, me.ConsumeMetrics(context.Background(), md))
+	assert.Nil(t, me.Shutdown(context.Background()))
+}
+
 func TestMetricsExporter_WithShutdown_ReturnError(t *testing.T) {
 	want := errors.New("my_error")
 	shutdownErr := func(context.Context) error { return want }

--- a/exporter/exporterhelper/metricshelper_test.go
+++ b/exporter/exporterhelper/metricshelper_test.go
@@ -146,9 +146,9 @@ func TestMetricsExporter_WithShutdown(t *testing.T) {
 	assert.True(t, shutdownCalled)
 }
 
-func TestMetricsExporter_WithResourceToLabelConversionDisabled(t *testing.T) {
+func TestMetricsExporter_WithResourceToTelemetryConversionDisabled(t *testing.T) {
 	md := testdata.GenerateMetricsTwoMetrics()
-	me, err := NewMetricsExporter(fakeMetricsExporterConfig, zap.NewNop(), newPushMetricsData(0, nil), WithResourceToLabelConversion(createDefaultResourceToLabelSettings()))
+	me, err := NewMetricsExporter(fakeMetricsExporterConfig, zap.NewNop(), newPushMetricsData(0, nil), WithResourceToTelemetryConversion(createDefaultResourceToTelemetrySettings()))
 	assert.NotNil(t, me)
 	assert.NoError(t, err)
 
@@ -156,9 +156,9 @@ func TestMetricsExporter_WithResourceToLabelConversionDisabled(t *testing.T) {
 	assert.Nil(t, me.Shutdown(context.Background()))
 }
 
-func TestMetricsExporter_WithResourceToLabelConversionEbabled(t *testing.T) {
+func TestMetricsExporter_WithResourceToTelemetryConversionEbabled(t *testing.T) {
 	md := testdata.GenerateMetricsTwoMetrics()
-	me, err := NewMetricsExporter(fakeMetricsExporterConfig, zap.NewNop(), newPushMetricsData(0, nil), WithResourceToLabelConversion(ResourceToLabelSettings{Enabled: true}))
+	me, err := NewMetricsExporter(fakeMetricsExporterConfig, zap.NewNop(), newPushMetricsData(0, nil), WithResourceToTelemetryConversion(ResourceToTelemetrySettings{Enabled: true}))
 	assert.NotNil(t, me)
 	assert.NoError(t, err)
 

--- a/exporter/exporterhelper/resource_to_label.go
+++ b/exporter/exporterhelper/resource_to_label.go
@@ -97,9 +97,7 @@ func addLabelsToIntDataPoints(ps pdata.IntDataPointSlice, newLabelMap pdata.Stri
 		if dataPoint.IsNil() {
 			continue
 		}
-		newLabelMap.ForEach(func(k, v string) {
-			dataPoint.LabelsMap().Upsert(k, v)
-		})
+		joinStringMaps(newLabelMap, dataPoint.LabelsMap())
 	}
 }
 
@@ -109,9 +107,7 @@ func addLabelsToDoubleDataPoints(ps pdata.DoubleDataPointSlice, newLabelMap pdat
 		if dataPoint.IsNil() {
 			continue
 		}
-		newLabelMap.ForEach(func(k, v string) {
-			dataPoint.LabelsMap().Upsert(k, v)
-		})
+		joinStringMaps(newLabelMap, dataPoint.LabelsMap())
 	}
 }
 
@@ -121,9 +117,7 @@ func addLabelsToIntHistogramDataPoints(ps pdata.IntHistogramDataPointSlice, newL
 		if dataPoint.IsNil() {
 			continue
 		}
-		newLabelMap.ForEach(func(k, v string) {
-			dataPoint.LabelsMap().Upsert(k, v)
-		})
+		joinStringMaps(newLabelMap, dataPoint.LabelsMap())
 	}
 }
 
@@ -133,8 +127,12 @@ func addLabelsToDoubleHistogramDataPoints(ps pdata.DoubleHistogramDataPointSlice
 		if dataPoint.IsNil() {
 			continue
 		}
-		newLabelMap.ForEach(func(k, v string) {
-			dataPoint.LabelsMap().Upsert(k, v)
-		})
+		joinStringMaps(newLabelMap, dataPoint.LabelsMap())
 	}
+}
+
+func joinStringMaps(from, to pdata.StringMap) {
+	from.ForEach(func(k, v string) {
+		to.Upsert(k, v)
+	})
 }

--- a/exporter/exporterhelper/resource_to_label.go
+++ b/exporter/exporterhelper/resource_to_label.go
@@ -26,6 +26,19 @@ var (
 	resourceToLabels = &ResourceToLabels{}
 )
 
+// ResourceToLabelSettings defines configuration for converting resource attributes to labels
+type ResourceToLabelSettings struct {
+	// Enabled indicates whether to not convert resource attributes to labels
+	Enabled bool `mapstructure:"enabled"`
+}
+
+// CreateDefaultResourceToLabelSettings returns the default settings for ResourceToLabelSettings.
+func CreateDefaultResourceToLabelSettings() ResourceToLabelSettings {
+	return ResourceToLabelSettings{
+		Enabled: false,
+	}
+}
+
 // ResourceToLabels defines the consumer for converting resource attributes to labels
 type ResourceToLabels struct {
 	nextMetricsConsumer consumer.MetricsConsumer

--- a/exporter/exporterhelper/resource_to_label.go
+++ b/exporter/exporterhelper/resource_to_label.go
@@ -19,15 +19,15 @@ import (
 	tracetranslator "go.opentelemetry.io/collector/translator/trace"
 )
 
-// ResourceToLabelSettings defines configuration for converting resource attributes to labels
-type ResourceToLabelSettings struct {
-	// Enabled indicates whether to not convert resource attributes to labels
+// ResourceToTelemetrySettings defines configuration for converting resource attributes to metric labels.
+type ResourceToTelemetrySettings struct {
+	// Enabled indicates whether to not convert resource attributes to metric labels
 	Enabled bool `mapstructure:"enabled"`
 }
 
-// CreateDefaultResourceToLabelSettings returns the default settings for ResourceToLabelSettings.
-func createDefaultResourceToLabelSettings() ResourceToLabelSettings {
-	return ResourceToLabelSettings{
+// createDefaultResourceToTelemetrySettings returns the default settings for ResourceToTelemetrySettings.
+func createDefaultResourceToTelemetrySettings() ResourceToTelemetrySettings {
+	return ResourceToTelemetrySettings{
 		Enabled: false,
 	}
 }
@@ -68,7 +68,7 @@ func extractLabelsFromResource(resource *pdata.Resource) pdata.StringMap {
 	attrMap := resource.Attributes()
 	attrMap.ForEach(func(k string, av pdata.AttributeValue) {
 		stringLabel := tracetranslator.AttributeValueToString(av, false)
-		labelMap.Insert(k, stringLabel)
+		labelMap.Upsert(k, stringLabel)
 	})
 	return labelMap
 }

--- a/exporter/exporterhelper/resource_to_label.go
+++ b/exporter/exporterhelper/resource_to_label.go
@@ -15,15 +15,9 @@
 package exporterhelper
 
 import (
-	"context"
 	"strconv"
 
-	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/pdata"
-)
-
-var (
-	resourceToLabels = &ResourceToLabels{}
 )
 
 // ResourceToLabelSettings defines configuration for converting resource attributes to labels
@@ -33,30 +27,14 @@ type ResourceToLabelSettings struct {
 }
 
 // CreateDefaultResourceToLabelSettings returns the default settings for ResourceToLabelSettings.
-func CreateDefaultResourceToLabelSettings() ResourceToLabelSettings {
+func createDefaultResourceToLabelSettings() ResourceToLabelSettings {
 	return ResourceToLabelSettings{
 		Enabled: false,
 	}
 }
 
-// ResourceToLabels defines the consumer for converting resource attributes to labels
-type ResourceToLabels struct {
-	nextMetricsConsumer consumer.MetricsConsumer
-}
-
-// NewResourceToLabels creates a MetricsConsumer that converts the resource attributes to metric labels
-func NewResourceToLabels() consumer.MetricsConsumer {
-	return resourceToLabels
-}
-
-// ConsumeMetrics implements the consumer.ConsumeMetrics
-func (rtl *ResourceToLabels) ConsumeMetrics(ctx context.Context, md pdata.Metrics) error {
-	convertedMd := ConvertResourceToLabels(md)
-	return rtl.nextMetricsConsumer.ConsumeMetrics(ctx, convertedMd)
-}
-
-// ConvertResourceToLabels converts all resource attributes to metric labels
-func ConvertResourceToLabels(md pdata.Metrics) pdata.Metrics {
+// convertResourceToLabels converts all resource attributes to metric labels
+func convertResourceToLabels(md pdata.Metrics) pdata.Metrics {
 	cloneMd := md.Clone()
 	rms := cloneMd.ResourceMetrics()
 	for i := 0; i < rms.Len(); i++ {

--- a/exporter/exporterhelper/resource_to_label.go
+++ b/exporter/exporterhelper/resource_to_label.go
@@ -1,0 +1,181 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exporterhelper
+
+import (
+	"context"
+	"strconv"
+
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/consumer/pdata"
+)
+
+var (
+	resourceToLabels = &ResourceToLabels{}
+)
+
+// ResourceToLabels defines the consumer for converting resource attributes to labels
+type ResourceToLabels struct {
+	nextMetricsConsumer consumer.MetricsConsumer
+}
+
+// NewResourceToLabels creates a MetricsConsumer that converts the resource attributes to metric labels
+func NewResourceToLabels() consumer.MetricsConsumer {
+	return resourceToLabels
+}
+
+// ConsumeMetrics implements the consumer.ConsumeMetrics
+func (rtl *ResourceToLabels) ConsumeMetrics(ctx context.Context, md pdata.Metrics) error {
+	rms := md.ResourceMetrics()
+	for i := 0; i < rms.Len(); i++ {
+		resource := rms.At(i).Resource()
+		if resource.IsNil() {
+			continue
+		}
+		labelMap := extractLabelsFromResource(&resource)
+
+		ilms := rms.At(i).InstrumentationLibraryMetrics()
+		for j := 0; j < ilms.Len(); j++ {
+			ilm := ilms.At(j)
+			if ilm.IsNil() {
+				continue
+			}
+			metricSlice := ilm.Metrics()
+			for k := 0; k < metricSlice.Len(); k++ {
+				metric := metricSlice.At(k)
+				if metric.IsNil() {
+					continue
+				}
+				addLabelsToMetric(&metric, labelMap)
+			}
+		}
+	}
+	return rtl.nextMetricsConsumer.ConsumeMetrics(ctx, md)
+}
+
+// ConvertResourceToLabels converts all resource attributes to metric labels
+func ConvertResourceToLabels(md pdata.Metrics) {
+	rms := md.ResourceMetrics()
+	for i := 0; i < rms.Len(); i++ {
+		resource := rms.At(i).Resource()
+		if resource.IsNil() {
+			continue
+		}
+		labelMap := extractLabelsFromResource(&resource)
+
+		ilms := rms.At(i).InstrumentationLibraryMetrics()
+		for j := 0; j < ilms.Len(); j++ {
+			ilm := ilms.At(j)
+			if ilm.IsNil() {
+				continue
+			}
+			metricSlice := ilm.Metrics()
+			for k := 0; k < metricSlice.Len(); k++ {
+				metric := metricSlice.At(k)
+				if metric.IsNil() {
+					continue
+				}
+				addLabelsToMetric(&metric, labelMap)
+			}
+		}
+	}
+}
+
+// extractAttributesFromResource extracts the attributes from a given resource and
+// returns them as a StringMap.
+// Attribute values can be of multiple types. Only string, int, and boolean values are converted
+// to string data type and others are skipped.
+func extractLabelsFromResource(resource *pdata.Resource) pdata.StringMap {
+	labelMap := pdata.NewStringMap()
+
+	attrMap := resource.Attributes()
+	attrMap.ForEach(func(k string, av pdata.AttributeValue) {
+		switch av.Type() {
+		case pdata.AttributeValueSTRING:
+			labelMap.Insert(k, av.StringVal())
+		case pdata.AttributeValueBOOL:
+			labelMap.Insert(k, strconv.FormatBool(av.BoolVal()))
+		case pdata.AttributeValueINT:
+			labelMap.Insert(k, strconv.FormatInt(av.IntVal(), 10))
+		}
+	})
+	return labelMap
+}
+
+// addLabelsToMetric adds additional labels to the given metric
+func addLabelsToMetric(metric *pdata.Metric, labelMap pdata.StringMap) {
+	switch metric.DataType() {
+	case pdata.MetricDataTypeIntGauge:
+		addLabelsToIntDataPoints(metric.IntGauge().DataPoints(), labelMap)
+	case pdata.MetricDataTypeDoubleGauge:
+		addLabelsToDoubleDataPoints(metric.DoubleGauge().DataPoints(), labelMap)
+	case pdata.MetricDataTypeIntSum:
+		addLabelsToIntDataPoints(metric.IntSum().DataPoints(), labelMap)
+	case pdata.MetricDataTypeDoubleSum:
+		addLabelsToDoubleDataPoints(metric.DoubleSum().DataPoints(), labelMap)
+	case pdata.MetricDataTypeIntHistogram:
+		addLabelsToIntHistogramDataPoints(metric.IntHistogram().DataPoints(), labelMap)
+	case pdata.MetricDataTypeDoubleHistogram:
+		addLabelsToDoubleHistogramDataPoints(metric.DoubleHistogram().DataPoints(), labelMap)
+	}
+}
+
+func addLabelsToIntDataPoints(ps pdata.IntDataPointSlice, newLabelMap pdata.StringMap) {
+	for i := 0; i < ps.Len(); i++ {
+		dataPoint := ps.At(i)
+		if dataPoint.IsNil() {
+			continue
+		}
+		newLabelMap.ForEach(func(k, v string) {
+			dataPoint.LabelsMap().Upsert(k, v)
+		})
+	}
+}
+
+func addLabelsToDoubleDataPoints(ps pdata.DoubleDataPointSlice, newLabelMap pdata.StringMap) {
+	for i := 0; i < ps.Len(); i++ {
+		dataPoint := ps.At(i)
+		if dataPoint.IsNil() {
+			continue
+		}
+		newLabelMap.ForEach(func(k, v string) {
+			dataPoint.LabelsMap().Upsert(k, v)
+		})
+	}
+}
+
+func addLabelsToIntHistogramDataPoints(ps pdata.IntHistogramDataPointSlice, newLabelMap pdata.StringMap) {
+	for i := 0; i < ps.Len(); i++ {
+		dataPoint := ps.At(i)
+		if dataPoint.IsNil() {
+			continue
+		}
+		newLabelMap.ForEach(func(k, v string) {
+			dataPoint.LabelsMap().Upsert(k, v)
+		})
+	}
+}
+
+func addLabelsToDoubleHistogramDataPoints(ps pdata.DoubleHistogramDataPointSlice, newLabelMap pdata.StringMap) {
+	for i := 0; i < ps.Len(); i++ {
+		dataPoint := ps.At(i)
+		if dataPoint.IsNil() {
+			continue
+		}
+		newLabelMap.ForEach(func(k, v string) {
+			dataPoint.LabelsMap().Upsert(k, v)
+		})
+	}
+}

--- a/exporter/exporterhelper/resource_to_label_test.go
+++ b/exporter/exporterhelper/resource_to_label_test.go
@@ -29,7 +29,7 @@ func TestConvertResourceToLabels(t *testing.T) {
 	assert.Equal(t, 1, md.ResourceMetrics().At(0).Resource().Attributes().Len())
 	assert.Equal(t, 1, md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(0).IntSum().DataPoints().At(0).LabelsMap().Len())
 
-	cloneMd := ConvertResourceToLabels(md)
+	cloneMd := convertResourceToLabels(md)
 
 	// After converting resource to labels
 	assert.Equal(t, 1, cloneMd.ResourceMetrics().At(0).Resource().Attributes().Len())
@@ -53,7 +53,7 @@ func TestConvertResourceToLabelsAllDataTypes(t *testing.T) {
 	assert.Equal(t, 0, md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(4).DoubleHistogram().DataPoints().At(0).LabelsMap().Len())
 	assert.Equal(t, 0, md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(5).IntHistogram().DataPoints().At(0).LabelsMap().Len())
 
-	cloneMd := ConvertResourceToLabels(md)
+	cloneMd := convertResourceToLabels(md)
 
 	// After converting resource to labels
 	assert.Equal(t, 1, cloneMd.ResourceMetrics().At(0).Resource().Attributes().Len())
@@ -81,7 +81,7 @@ func TestConvertResourceToLabelsAllDataTypesNilDataPoint(t *testing.T) {
 	// Before converting resource to labels
 	assert.Equal(t, 1, md.ResourceMetrics().At(0).Resource().Attributes().Len())
 
-	cloneMd := ConvertResourceToLabels(md)
+	cloneMd := convertResourceToLabels(md)
 
 	// After converting resource to labels
 	assert.Equal(t, 1, cloneMd.ResourceMetrics().At(0).Resource().Attributes().Len())

--- a/exporter/exporterhelper/resource_to_label_test.go
+++ b/exporter/exporterhelper/resource_to_label_test.go
@@ -1,0 +1,35 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package exporterhelper
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/internal/data/testdata"
+)
+
+func TestConvertResourceToLabels(t *testing.T) {
+	md := testdata.GenerateMetricsOneMetric()
+	assert.NotNil(t, md)
+
+	// Before converting resource to labels
+	assert.Equal(t, 1, md.ResourceMetrics().At(0).Resource().Attributes().Len())
+	assert.Equal(t, 1, md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(0).IntSum().DataPoints().At(0).LabelsMap().Len())
+
+	ConvertResourceToLabels(md)
+
+	// After converting resource to labels
+	assert.Equal(t, 2, md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(0).IntSum().DataPoints().At(0).LabelsMap().Len())
+}

--- a/exporter/exporterhelper/resource_to_label_test.go
+++ b/exporter/exporterhelper/resource_to_label_test.go
@@ -88,3 +88,33 @@ func TestConvertResourceToLabelsAllDataTypesNilDataPoint(t *testing.T) {
 
 	assert.Equal(t, 1, md.ResourceMetrics().At(0).Resource().Attributes().Len())
 }
+
+func TestConvertResourceToLabelsOneMetricOneNil(t *testing.T) {
+	md := testdata.GenerateMetricsOneMetricOneNil()
+	assert.NotNil(t, md)
+
+	// Before converting resource to labels
+	assert.Equal(t, 1, md.ResourceMetrics().At(0).Resource().Attributes().Len())
+
+	cloneMd := convertResourceToLabels(md)
+
+	// After converting resource to labels
+	assert.Equal(t, 1, cloneMd.ResourceMetrics().At(0).Resource().Attributes().Len())
+
+	assert.Equal(t, 1, md.ResourceMetrics().At(0).Resource().Attributes().Len())
+}
+
+func TestConvertResourceToLabelsOneEmptyOneNilIlm(t *testing.T) {
+	md := testdata.GenerateMetricsOneEmptyOneNilInstrumentationLibrary()
+	assert.NotNil(t, md)
+
+	// Before converting resource to labels
+	assert.Equal(t, 1, md.ResourceMetrics().At(0).Resource().Attributes().Len())
+
+	cloneMd := convertResourceToLabels(md)
+
+	// After converting resource to labels
+	assert.Equal(t, 1, cloneMd.ResourceMetrics().At(0).Resource().Attributes().Len())
+
+	assert.Equal(t, 1, md.ResourceMetrics().At(0).Resource().Attributes().Len())
+}

--- a/exporter/exporterhelper/resource_to_label_test.go
+++ b/exporter/exporterhelper/resource_to_label_test.go
@@ -34,6 +34,10 @@ func TestConvertResourceToLabels(t *testing.T) {
 	// After converting resource to labels
 	assert.Equal(t, 1, cloneMd.ResourceMetrics().At(0).Resource().Attributes().Len())
 	assert.Equal(t, 2, cloneMd.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(0).IntSum().DataPoints().At(0).LabelsMap().Len())
+
+	assert.Equal(t, 1, md.ResourceMetrics().At(0).Resource().Attributes().Len())
+	assert.Equal(t, 1, md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(0).IntSum().DataPoints().At(0).LabelsMap().Len())
+
 }
 
 func TestConvertResourceToLabelsAllDataTypes(t *testing.T) {
@@ -59,6 +63,15 @@ func TestConvertResourceToLabelsAllDataTypes(t *testing.T) {
 	assert.Equal(t, 1, cloneMd.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(3).IntSum().DataPoints().At(0).LabelsMap().Len())
 	assert.Equal(t, 1, cloneMd.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(4).DoubleHistogram().DataPoints().At(0).LabelsMap().Len())
 	assert.Equal(t, 1, cloneMd.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(5).IntHistogram().DataPoints().At(0).LabelsMap().Len())
+
+	assert.Equal(t, 1, md.ResourceMetrics().At(0).Resource().Attributes().Len())
+	assert.Equal(t, 0, md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(0).DoubleGauge().DataPoints().At(0).LabelsMap().Len())
+	assert.Equal(t, 0, md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(1).IntGauge().DataPoints().At(0).LabelsMap().Len())
+	assert.Equal(t, 0, md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(2).DoubleSum().DataPoints().At(0).LabelsMap().Len())
+	assert.Equal(t, 0, md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(3).IntSum().DataPoints().At(0).LabelsMap().Len())
+	assert.Equal(t, 0, md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(4).DoubleHistogram().DataPoints().At(0).LabelsMap().Len())
+	assert.Equal(t, 0, md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(5).IntHistogram().DataPoints().At(0).LabelsMap().Len())
+
 }
 
 func TestConvertResourceToLabelsAllDataTypesNilDataPoint(t *testing.T) {
@@ -72,4 +85,6 @@ func TestConvertResourceToLabelsAllDataTypesNilDataPoint(t *testing.T) {
 
 	// After converting resource to labels
 	assert.Equal(t, 1, cloneMd.ResourceMetrics().At(0).Resource().Attributes().Len())
+
+	assert.Equal(t, 1, md.ResourceMetrics().At(0).Resource().Attributes().Len())
 }

--- a/exporter/exporterhelper/resource_to_label_test.go
+++ b/exporter/exporterhelper/resource_to_label_test.go
@@ -29,11 +29,11 @@ func TestConvertResourceToLabels(t *testing.T) {
 	assert.Equal(t, 1, md.ResourceMetrics().At(0).Resource().Attributes().Len())
 	assert.Equal(t, 1, md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(0).IntSum().DataPoints().At(0).LabelsMap().Len())
 
-	ConvertResourceToLabels(md)
+	cloneMd := ConvertResourceToLabels(md)
 
 	// After converting resource to labels
-	assert.Equal(t, 1, md.ResourceMetrics().At(0).Resource().Attributes().Len())
-	assert.Equal(t, 2, md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(0).IntSum().DataPoints().At(0).LabelsMap().Len())
+	assert.Equal(t, 1, cloneMd.ResourceMetrics().At(0).Resource().Attributes().Len())
+	assert.Equal(t, 2, cloneMd.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(0).IntSum().DataPoints().At(0).LabelsMap().Len())
 }
 
 func TestConvertResourceToLabelsAllDataTypes(t *testing.T) {
@@ -49,16 +49,16 @@ func TestConvertResourceToLabelsAllDataTypes(t *testing.T) {
 	assert.Equal(t, 0, md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(4).DoubleHistogram().DataPoints().At(0).LabelsMap().Len())
 	assert.Equal(t, 0, md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(5).IntHistogram().DataPoints().At(0).LabelsMap().Len())
 
-	ConvertResourceToLabels(md)
+	cloneMd := ConvertResourceToLabels(md)
 
 	// After converting resource to labels
-	assert.Equal(t, 1, md.ResourceMetrics().At(0).Resource().Attributes().Len())
-	assert.Equal(t, 1, md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(0).DoubleGauge().DataPoints().At(0).LabelsMap().Len())
-	assert.Equal(t, 1, md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(1).IntGauge().DataPoints().At(0).LabelsMap().Len())
-	assert.Equal(t, 1, md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(2).DoubleSum().DataPoints().At(0).LabelsMap().Len())
-	assert.Equal(t, 1, md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(3).IntSum().DataPoints().At(0).LabelsMap().Len())
-	assert.Equal(t, 1, md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(4).DoubleHistogram().DataPoints().At(0).LabelsMap().Len())
-	assert.Equal(t, 1, md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(5).IntHistogram().DataPoints().At(0).LabelsMap().Len())
+	assert.Equal(t, 1, cloneMd.ResourceMetrics().At(0).Resource().Attributes().Len())
+	assert.Equal(t, 1, cloneMd.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(0).DoubleGauge().DataPoints().At(0).LabelsMap().Len())
+	assert.Equal(t, 1, cloneMd.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(1).IntGauge().DataPoints().At(0).LabelsMap().Len())
+	assert.Equal(t, 1, cloneMd.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(2).DoubleSum().DataPoints().At(0).LabelsMap().Len())
+	assert.Equal(t, 1, cloneMd.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(3).IntSum().DataPoints().At(0).LabelsMap().Len())
+	assert.Equal(t, 1, cloneMd.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(4).DoubleHistogram().DataPoints().At(0).LabelsMap().Len())
+	assert.Equal(t, 1, cloneMd.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(5).IntHistogram().DataPoints().At(0).LabelsMap().Len())
 }
 
 func TestConvertResourceToLabelsAllDataTypesNilDataPoint(t *testing.T) {
@@ -68,8 +68,8 @@ func TestConvertResourceToLabelsAllDataTypesNilDataPoint(t *testing.T) {
 	// Before converting resource to labels
 	assert.Equal(t, 1, md.ResourceMetrics().At(0).Resource().Attributes().Len())
 
-	ConvertResourceToLabels(md)
+	cloneMd := ConvertResourceToLabels(md)
 
 	// After converting resource to labels
-	assert.Equal(t, 1, md.ResourceMetrics().At(0).Resource().Attributes().Len())
+	assert.Equal(t, 1, cloneMd.ResourceMetrics().At(0).Resource().Attributes().Len())
 }

--- a/exporter/exporterhelper/resource_to_label_test.go
+++ b/exporter/exporterhelper/resource_to_label_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
 	"go.opentelemetry.io/collector/internal/data/testdata"
 )
 
@@ -31,5 +32,44 @@ func TestConvertResourceToLabels(t *testing.T) {
 	ConvertResourceToLabels(md)
 
 	// After converting resource to labels
+	assert.Equal(t, 1, md.ResourceMetrics().At(0).Resource().Attributes().Len())
 	assert.Equal(t, 2, md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(0).IntSum().DataPoints().At(0).LabelsMap().Len())
+}
+
+func TestConvertResourceToLabelsAllDataTypes(t *testing.T) {
+	md := testdata.GenerateMetricsAllTypesEmptyDataPoint()
+	assert.NotNil(t, md)
+
+	// Before converting resource to labels
+	assert.Equal(t, 1, md.ResourceMetrics().At(0).Resource().Attributes().Len())
+	assert.Equal(t, 0, md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(0).DoubleGauge().DataPoints().At(0).LabelsMap().Len())
+	assert.Equal(t, 0, md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(1).IntGauge().DataPoints().At(0).LabelsMap().Len())
+	assert.Equal(t, 0, md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(2).DoubleSum().DataPoints().At(0).LabelsMap().Len())
+	assert.Equal(t, 0, md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(3).IntSum().DataPoints().At(0).LabelsMap().Len())
+	assert.Equal(t, 0, md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(4).DoubleHistogram().DataPoints().At(0).LabelsMap().Len())
+	assert.Equal(t, 0, md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(5).IntHistogram().DataPoints().At(0).LabelsMap().Len())
+
+	ConvertResourceToLabels(md)
+
+	// After converting resource to labels
+	assert.Equal(t, 1, md.ResourceMetrics().At(0).Resource().Attributes().Len())
+	assert.Equal(t, 1, md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(0).DoubleGauge().DataPoints().At(0).LabelsMap().Len())
+	assert.Equal(t, 1, md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(1).IntGauge().DataPoints().At(0).LabelsMap().Len())
+	assert.Equal(t, 1, md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(2).DoubleSum().DataPoints().At(0).LabelsMap().Len())
+	assert.Equal(t, 1, md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(3).IntSum().DataPoints().At(0).LabelsMap().Len())
+	assert.Equal(t, 1, md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(4).DoubleHistogram().DataPoints().At(0).LabelsMap().Len())
+	assert.Equal(t, 1, md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(5).IntHistogram().DataPoints().At(0).LabelsMap().Len())
+}
+
+func TestConvertResourceToLabelsAllDataTypesNilDataPoint(t *testing.T) {
+	md := testdata.GenerateMetricsAllTypesNilDataPoint()
+	assert.NotNil(t, md)
+
+	// Before converting resource to labels
+	assert.Equal(t, 1, md.ResourceMetrics().At(0).Resource().Attributes().Len())
+
+	ConvertResourceToLabels(md)
+
+	// After converting resource to labels
+	assert.Equal(t, 1, md.ResourceMetrics().At(0).Resource().Attributes().Len())
 }


### PR DESCRIPTION
**Description:** 
We need a common helper function which can convert resource attributes to metric labels and be utilized by every exporter. In the linked issue, @bogdandrutu suggested two possible ways- a consumer or a helper function. In this PR, we have both of the consumer and helper function ready. However, I was only able to utilize the helper function for end to end test modifying the `logging` exporter. Every exporter can call this helper function before exporting the metrics to destination. 

For the consumer setup, I cannot find a place to plug in this in between a processor and an exporter. I think I need more guidance on how we can make it a common utility for all exporters. Thanks in advance. 


**Link to tracking Issue:** 
Issue [1359](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/1359)

**Testing:** 
End_To_End Test: Tested manually with `awsecscontainermetrics` receiver and `logging` exporter.
Unit test added.


