### PR TITLE
Add customroundtripper to httpclientconfig

### DIFF
--- a/config/confighttp/confighttp.go
+++ b/config/confighttp/confighttp.go
@@ -46,7 +46,7 @@ type HTTPClientSettings struct {
 	// Existing header values are overwritten if collision happens.
 	Headers map[string]string `mapstructure:"headers,omitempty"`
 
-	// Custom Round Tripper to allow for individual components to intercepting HTTP requests
+	// Custom Round Tripper to allow for individual components to intercept HTTP requests
 	CustomRoundTripper func(next http.RoundTripper) http.RoundTripper
 }
 

--- a/config/confighttp/confighttp.go
+++ b/config/confighttp/confighttp.go
@@ -47,7 +47,7 @@ type HTTPClientSettings struct {
 	Headers map[string]string `mapstructure:"headers,omitempty"`
 
 	// Custom Round Tripper to allow for individual components to intercept HTTP requests
-	CustomRoundTripper func(next http.RoundTripper) http.RoundTripper
+	CustomRoundTripper func(next http.RoundTripper) (http.RoundTripper, error)
 }
 
 func (hcs *HTTPClientSettings) ToClient() (*http.Client, error) {
@@ -75,7 +75,10 @@ func (hcs *HTTPClientSettings) ToClient() (*http.Client, error) {
 	}
 
 	if hcs.CustomRoundTripper != nil {
-		clientTransport = hcs.CustomRoundTripper(clientTransport)
+		clientTransport, err = hcs.CustomRoundTripper(clientTransport)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return &http.Client{

--- a/config/confighttp/confighttp.go
+++ b/config/confighttp/confighttp.go
@@ -45,6 +45,9 @@ type HTTPClientSettings struct {
 	// Additional headers attached to each HTTP request sent by the client.
 	// Existing header values are overwritten if collision happens.
 	Headers map[string]string `mapstructure:"headers,omitempty"`
+
+	// Custom Round Tripper to allow for individual components to intercepting HTTP requests
+	CustomRoundTripper func(next http.RoundTripper) http.RoundTripper
 }
 
 func (hcs *HTTPClientSettings) ToClient() (*http.Client, error) {
@@ -69,6 +72,10 @@ func (hcs *HTTPClientSettings) ToClient() (*http.Client, error) {
 			transport: transport,
 			headers:   hcs.Headers,
 		}
+	}
+
+	if hcs.CustomRoundTripper != nil {
+		clientTransport = hcs.CustomRoundTripper(clientTransport)
 	}
 
 	return &http.Client{

--- a/config/confighttp/confighttp_test.go
+++ b/config/confighttp/confighttp_test.go
@@ -36,8 +36,9 @@ func TestAllHTTPClientSettings(t *testing.T) {
 		TLSSetting: configtls.TLSClientSetting{
 			Insecure: false,
 		},
-		ReadBufferSize:  1024,
-		WriteBufferSize: 512,
+		ReadBufferSize:     1024,
+		WriteBufferSize:    512,
+		CustomRoundTripper: func(next http.RoundTripper) http.RoundTripper { return next },
 	}
 	client, err := hcs.ToClient()
 	assert.NoError(t, err)

--- a/config/confighttp/confighttp_test.go
+++ b/config/confighttp/confighttp_test.go
@@ -15,6 +15,7 @@
 package confighttp
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -31,20 +32,52 @@ import (
 )
 
 func TestAllHTTPClientSettings(t *testing.T) {
-	hcs := &HTTPClientSettings{
-		Endpoint: "localhost:1234",
-		TLSSetting: configtls.TLSClientSetting{
-			Insecure: false,
+	tests := []struct {
+		name        string
+		settings    HTTPClientSettings
+		shouldError bool
+	}{
+		{
+			name: "all_valid_settings",
+			settings: HTTPClientSettings{
+				Endpoint: "localhost:1234",
+				TLSSetting: configtls.TLSClientSetting{
+					Insecure: false,
+				},
+				ReadBufferSize:     1024,
+				WriteBufferSize:    512,
+				CustomRoundTripper: func(next http.RoundTripper) (http.RoundTripper, error) { return next, nil },
+			},
+			shouldError: false,
 		},
-		ReadBufferSize:     1024,
-		WriteBufferSize:    512,
-		CustomRoundTripper: func(next http.RoundTripper) http.RoundTripper { return next },
+		{
+			name: "error_round_tripper_returned",
+			settings: HTTPClientSettings{
+				Endpoint: "localhost:1234",
+				TLSSetting: configtls.TLSClientSetting{
+					Insecure: false,
+				},
+				ReadBufferSize:     1024,
+				WriteBufferSize:    512,
+				CustomRoundTripper: func(next http.RoundTripper) (http.RoundTripper, error) { return nil, errors.New("error") },
+			},
+			shouldError: true,
+		},
 	}
-	client, err := hcs.ToClient()
-	assert.NoError(t, err)
-	transport := client.Transport.(*http.Transport)
-	assert.EqualValues(t, 1024, transport.ReadBufferSize)
-	assert.EqualValues(t, 512, transport.WriteBufferSize)
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client, err := test.settings.ToClient()
+			if test.shouldError {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			transport := client.Transport.(*http.Transport)
+			assert.EqualValues(t, 1024, transport.ReadBufferSize)
+			assert.EqualValues(t, 512, transport.WriteBufferSize)
+		})
+	}
 }
 
 func TestHTTPClientSettingsError(t *testing.T) {


### PR DESCRIPTION
**Description:** 
This is a fully backwards compatible change that allows optional configuration of a custom round tripper for components that use the confighttp package

An example use case can be seen here: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/1497

-- cc @bogdandrutu 