### PR TITLE
Host Metrics receiver: use correct TCP state labels on Unix systems

### DIFF
--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/network_others.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/network_others.go
@@ -1,0 +1,32 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !windows
+
+package networkscraper
+
+var allTCPStates = []string{
+	"CLOSE_WAIT",
+	"CLOSE",
+	"CLOSING",
+	"DELETE",
+	"ESTABLISHED",
+	"FIN_WAIT_1",
+	"FIN_WAIT_2",
+	"LAST_ACK",
+	"LISTEN",
+	"SYN_SENT",
+	"SYN_RECV",
+	"TIME_WAIT",
+}

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/network_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/network_scraper.go
@@ -194,19 +194,9 @@ func (s *scraper) scrapeAndAppendNetworkTCPConnectionsMetric(metrics pdata.Metri
 }
 
 func getTCPConnectionStatusCounts(connections []net.ConnectionStat) map[string]int64 {
-	var tcpStatuses = map[string]int64{
-		"CLOSE_WAIT":   0,
-		"CLOSED":       0,
-		"CLOSING":      0,
-		"DELETE":       0,
-		"ESTABLISHED":  0,
-		"FIN_WAIT_1":   0,
-		"FIN_WAIT_2":   0,
-		"LAST_ACK":     0,
-		"LISTEN":       0,
-		"SYN_SENT":     0,
-		"SYN_RECEIVED": 0,
-		"TIME_WAIT":    0,
+	tcpStatuses := make(map[string]int64, len(allTCPStates))
+	for _, state := range allTCPStates {
+		tcpStatuses[state] = 0
 	}
 
 	for _, connection := range connections {

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/network_windows.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/network_windows.go
@@ -1,0 +1,32 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build windows
+
+package networkscraper
+
+var allTCPStates = []string{
+	"CLOSE_WAIT",
+	"CLOSED",
+	"CLOSING",
+	"DELETE",
+	"ESTABLISHED",
+	"FIN_WAIT_1",
+	"FIN_WAIT_2",
+	"LAST_ACK",
+	"LISTEN",
+	"SYN_SENT",
+	"SYN_RECEIVED",
+	"TIME_WAIT",
+}


### PR DESCRIPTION
For the tcp_connections metric, we want to always return a data point for each TCP state label. Unix uses slightly different TCP state labels than Windows:

- Linux: [gopsutil](https://github.com/shirou/gopsutil/blob/c4663018cc3b6dfb0ae893bf2ca5f861fe3de3c0/net/net_linux.go#L309) / [Linux src](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/net/tcp_states.h?id=HEAD) (this seems to match other Unix systems as well)
- Windows: [gopsutil](https://github.com/shirou/gopsutil/blob/c4663018cc3b6dfb0ae893bf2ca5f861fe3de3c0/net/net_windows.go#L563) / [MS docs](https://docs.microsoft.com/en-us/windows/win32/api/tcpmib/ns-tcpmib-mib_tcprow2)

This PR updates the code to set the tcp state labels based on OS. This also fixes a test that would fail intermittently on Linux if any connections were in state `CLOSE` or `SYN_RECV` when the test ran, since the label value differs slightly from the Windows labels that were previously always used.

I considered also making the test less restrictive (i.e. don't fail if unexpected state values are returned, and thus additional data points are created), but the test failure was very useful for detecting this bug so I have left as is for now.

Fixes https://github.com/open-telemetry/opentelemetry-collector/issues/2033