### PR TITLE
Correctly handle gauge distributions in OCSliceToMetrics

### DIFF
--- a/internal/data/testdata/metric.go
+++ b/internal/data/testdata/metric.go
@@ -362,13 +362,14 @@ func GeneratMetricsAllTypesWithSampleDatapoints() pdata.Metrics {
 	rms.At(0).InstrumentationLibraryMetrics().Resize(1)
 
 	ilms := rms.At(0).InstrumentationLibraryMetrics()
-	ilms.At(0).Metrics().Resize(5)
+	ilms.At(0).Metrics().Resize(6)
 	ms := ilms.At(0).Metrics()
 	initCounterIntMetric(ms.At(0))
 	initSumDoubleMetric(ms.At(1))
 	initDoubleHistogramMetric(ms.At(2))
 	initIntHistogramMetric(ms.At(3))
 	initDoubleSummaryMetric(ms.At(4))
+	initDoubleGaugeHistogramMetric(ms.At(5))
 
 	return metricData
 }
@@ -504,6 +505,38 @@ func initDoubleHistogramMetric(hm pdata.Metric) {
 	exemplar.SetValue(15)
 	initMetricAttachment(exemplar.FilteredLabels())
 	hdp1.SetExplicitBounds([]float64{1})
+}
+
+func initDoubleGaugeHistogramMetric(hm pdata.Metric) {
+	hm.InitEmpty()
+        hm.SetName(TestDoubleHistogramMetricName)
+        hm.SetDescription("")
+        hm.SetUnit("1")
+        hm.SetDataType(pdata.MetricDataTypeDoubleHistogram)
+        hm.DoubleHistogram().InitEmpty()
+
+        hdps := hm.DoubleHistogram().DataPoints()
+        hdps.Resize(2)
+        hdp0 := hdps.At(0)
+        initMetricLabels13(hdp0.LabelsMap())
+        hdp0.SetStartTime(TestMetricStartTimestamp)
+        hdp0.SetTimestamp(TestMetricTimestamp)
+        hdp0.SetCount(1)
+        hdp0.SetSum(15)
+        hdp1 := hdps.At(1)
+        initMetricLabels2(hdp1.LabelsMap())
+        hdp1.SetStartTime(TestMetricStartTimestamp)
+        hdp1.SetTimestamp(TestMetricTimestamp)
+        hdp1.SetCount(1)
+        hdp1.SetSum(15)
+        hdp1.SetBucketCounts([]uint64{0, 1})
+        exemplars := hdp1.Exemplars()
+        exemplars.Resize(1)
+        exemplar := exemplars.At(0)
+        exemplar.SetTimestamp(TestMetricExemplarTimestamp)
+        exemplar.SetValue(15)
+        initMetricAttachment(exemplar.FilteredLabels())
+        hdp1.SetExplicitBounds([]float64{1})
 }
 
 func generateOtlpDoubleHistogramMetric() *otlpmetrics.Metric {

--- a/internal/data/testdata/metric.go
+++ b/internal/data/testdata/metric.go
@@ -33,14 +33,15 @@ var (
 )
 
 const (
-	TestGaugeDoubleMetricName     = "gauge-double"
-	TestGaugeIntMetricName        = "gauge-int"
-	TestCounterDoubleMetricName   = "counter-double"
-	TestCounterIntMetricName      = "counter-int"
-	TestDoubleHistogramMetricName = "double-histogram"
-	TestIntHistogramMetricName    = "int-histogram"
-	TestDoubleSummaryMetricName   = "double-summary"
-	NumMetricTests                = 14
+	TestGaugeDoubleMetricName          = "gauge-double"
+	TestGaugeIntMetricName             = "gauge-int"
+	TestCounterDoubleMetricName        = "counter-double"
+	TestCounterIntMetricName           = "counter-int"
+	TestDoubleHistogramMetricName      = "double-histogram"
+	TestGaugeDoubleHistogramMetricName = "gauge-double-histogram"
+	TestIntHistogramMetricName         = "int-histogram"
+	TestDoubleSummaryMetricName        = "double-summary"
+	NumMetricTests                     = 14
 )
 
 func GenerateMetricsEmpty() pdata.Metrics {
@@ -369,7 +370,7 @@ func GeneratMetricsAllTypesWithSampleDatapoints() pdata.Metrics {
 	initDoubleHistogramMetric(ms.At(2))
 	initIntHistogramMetric(ms.At(3))
 	initDoubleSummaryMetric(ms.At(4))
-	initDoubleGaugeHistogramMetric(ms.At(5))
+	initGaugeDoubleHistogramMetric(ms.At(5))
 
 	return metricData
 }
@@ -507,36 +508,36 @@ func initDoubleHistogramMetric(hm pdata.Metric) {
 	hdp1.SetExplicitBounds([]float64{1})
 }
 
-func initDoubleGaugeHistogramMetric(hm pdata.Metric) {
+func initGaugeDoubleHistogramMetric(hm pdata.Metric) {
 	hm.InitEmpty()
-        hm.SetName(TestDoubleHistogramMetricName)
-        hm.SetDescription("")
-        hm.SetUnit("1")
-        hm.SetDataType(pdata.MetricDataTypeDoubleHistogram)
-        hm.DoubleHistogram().InitEmpty()
+	hm.SetName(TestGaugeDoubleHistogramMetricName)
+	hm.SetDescription("")
+	hm.SetUnit("1")
+	hm.SetDataType(pdata.MetricDataTypeDoubleHistogram)
+	hm.DoubleHistogram().InitEmpty()
 
-        hdps := hm.DoubleHistogram().DataPoints()
-        hdps.Resize(2)
-        hdp0 := hdps.At(0)
-        initMetricLabels13(hdp0.LabelsMap())
-        hdp0.SetStartTime(TestMetricStartTimestamp)
-        hdp0.SetTimestamp(TestMetricTimestamp)
-        hdp0.SetCount(1)
-        hdp0.SetSum(15)
-        hdp1 := hdps.At(1)
-        initMetricLabels2(hdp1.LabelsMap())
-        hdp1.SetStartTime(TestMetricStartTimestamp)
-        hdp1.SetTimestamp(TestMetricTimestamp)
-        hdp1.SetCount(1)
-        hdp1.SetSum(15)
-        hdp1.SetBucketCounts([]uint64{0, 1})
-        exemplars := hdp1.Exemplars()
-        exemplars.Resize(1)
-        exemplar := exemplars.At(0)
-        exemplar.SetTimestamp(TestMetricExemplarTimestamp)
-        exemplar.SetValue(15)
-        initMetricAttachment(exemplar.FilteredLabels())
-        hdp1.SetExplicitBounds([]float64{1})
+	hdps := hm.DoubleHistogram().DataPoints()
+	hdps.Resize(2)
+	hdp0 := hdps.At(0)
+	initMetricLabels13(hdp0.LabelsMap())
+	hdp0.SetStartTime(TestMetricStartTimestamp)
+	hdp0.SetTimestamp(TestMetricTimestamp)
+	hdp0.SetCount(1)
+	hdp0.SetSum(15)
+	hdp1 := hdps.At(1)
+	initMetricLabels2(hdp1.LabelsMap())
+	hdp1.SetStartTime(TestMetricStartTimestamp)
+	hdp1.SetTimestamp(TestMetricTimestamp)
+	hdp1.SetCount(1)
+	hdp1.SetSum(15)
+	hdp1.SetBucketCounts([]uint64{0, 1})
+	exemplars := hdp1.Exemplars()
+	exemplars.Resize(1)
+	exemplar := exemplars.At(0)
+	exemplar.SetTimestamp(TestMetricExemplarTimestamp)
+	exemplar.SetValue(15)
+	initMetricAttachment(exemplar.FilteredLabels())
+	hdp1.SetExplicitBounds([]float64{1})
 }
 
 func generateOtlpDoubleHistogramMetric() *otlpmetrics.Metric {

--- a/translator/internaldata/metrics_to_oc_test.go
+++ b/translator/internaldata/metrics_to_oc_test.go
@@ -211,6 +211,7 @@ func generateOCTestData() consumerdata.MetricsData {
 			generateOCTestMetricDoubleHistogram(),
 			generateOCTestMetricIntHistogram(),
 			generateOCTestMetricDoubleSummary(),
+			generateOCTestMetricDoubleGaugeHistogram(),
 		},
 	}
 }

--- a/translator/internaldata/metrics_to_oc_test.go
+++ b/translator/internaldata/metrics_to_oc_test.go
@@ -211,7 +211,7 @@ func generateOCTestData() consumerdata.MetricsData {
 			generateOCTestMetricDoubleHistogram(),
 			generateOCTestMetricIntHistogram(),
 			generateOCTestMetricDoubleSummary(),
-			generateOCTestMetricDoubleGaugeHistogram(),
+			generateOCTestMetricGaugeDoubleHistogram(),
 		},
 	}
 }

--- a/translator/internaldata/oc_testdata_test.go
+++ b/translator/internaldata/oc_testdata_test.go
@@ -295,6 +295,103 @@ func generateOCTestMetricDouble() *ocmetrics.Metric {
 	}
 }
 
+func generateOCTestMetricGaugeDoubleHistogram() *ocmetrics.Metric {
+	return &ocmetrics.Metric{
+		MetricDescriptor: &ocmetrics.MetricDescriptor{
+			Name:        testdata.TestDoubleHistogramMetricName,
+			Description: "",
+			Unit:        "1",
+			Type:        ocmetrics.MetricDescriptor_GAUGE_DISTRIBUTION,
+			LabelKeys: []*ocmetrics.LabelKey{
+				{Key: testdata.TestLabelKey1},
+				{Key: testdata.TestLabelKey2},
+				{Key: testdata.TestLabelKey3},
+			},
+		},
+		Timeseries: []*ocmetrics.TimeSeries{
+			{
+				StartTimestamp: timestamppb.New(testdata.TestMetricStartTime),
+				LabelValues: []*ocmetrics.LabelValue{
+					{
+						// key1
+						Value:    testdata.TestLabelValue1,
+						HasValue: true,
+					},
+					{
+						// key2
+						HasValue: false,
+					},
+					{
+						// key3
+						Value:    testdata.TestLabelValue3,
+						HasValue: true,
+					},
+				},
+				Points: []*ocmetrics.Point{
+					{
+						Timestamp: timestamppb.New(testdata.TestMetricTime),
+						Value: &ocmetrics.Point_DistributionValue{
+							DistributionValue: &ocmetrics.DistributionValue{
+								Count: 1,
+								Sum:   15,
+							},
+						},
+					},
+				},
+			},
+			{
+				StartTimestamp: timestamppb.New(testdata.TestMetricStartTime),
+				LabelValues: []*ocmetrics.LabelValue{
+					{
+						// key1
+						HasValue: false,
+					},
+					{
+						// key2
+						Value:    testdata.TestLabelValue2,
+						HasValue: true,
+					},
+					{
+						// key3
+						HasValue: false,
+					},
+				},
+				Points: []*ocmetrics.Point{
+					{
+						Timestamp: timestamppb.New(testdata.TestMetricTime),
+						Value: &ocmetrics.Point_DistributionValue{
+							DistributionValue: &ocmetrics.DistributionValue{
+								Count: 1,
+								Sum:   15,
+								BucketOptions: &ocmetrics.DistributionValue_BucketOptions{
+									Type: &ocmetrics.DistributionValue_BucketOptions_Explicit_{
+										Explicit: &ocmetrics.DistributionValue_BucketOptions_Explicit{
+											Bounds: []float64{1},
+										},
+									},
+								},
+								Buckets: []*ocmetrics.DistributionValue_Bucket{
+									{
+										Count: 0,
+									},
+									{
+										Count: 1,
+										Exemplar: &ocmetrics.DistributionValue_Exemplar{
+											Timestamp:   timestamppb.New(testdata.TestMetricExemplarTime),
+											Value:       15,
+											Attachments: map[string]string{testdata.TestAttachmentKey: testdata.TestAttachmentValue},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
 func generateOCTestMetricDoubleHistogram() *ocmetrics.Metric {
 	return &ocmetrics.Metric{
 		MetricDescriptor: &ocmetrics.MetricDescriptor{
@@ -392,6 +489,102 @@ func generateOCTestMetricDoubleHistogram() *ocmetrics.Metric {
 	}
 }
 
+func generateOCTestMetricDoubleGaugeHistogram() *ocmetrics.Metric {
+	return &ocmetrics.Metric{
+		MetricDescriptor: &ocmetrics.MetricDescriptor{
+			Name:        testdata.TestDoubleHistogramMetricName,
+			Description: "",
+			Unit:        "1",
+			Type:        ocmetrics.MetricDescriptor_GAUGE_DISTRIBUTION,
+			LabelKeys: []*ocmetrics.LabelKey{
+				{Key: testdata.TestLabelKey1},
+				{Key: testdata.TestLabelKey2},
+				{Key: testdata.TestLabelKey3},
+			},
+		},
+		Timeseries: []*ocmetrics.TimeSeries{
+			{
+				StartTimestamp: timestamppb.New(testdata.TestMetricStartTime),
+				LabelValues: []*ocmetrics.LabelValue{
+					{
+						// key1
+						Value:    testdata.TestLabelValue1,
+						HasValue: true,
+					},
+					{
+						// key2
+						HasValue: false,
+					},
+					{
+						// key3
+						Value:    testdata.TestLabelValue3,
+						HasValue: true,
+					},
+				},
+				Points: []*ocmetrics.Point{
+					{
+						Timestamp: timestamppb.New(testdata.TestMetricTime),
+						Value: &ocmetrics.Point_DistributionValue{
+							DistributionValue: &ocmetrics.DistributionValue{
+								Count: 1,
+								Sum:   15,
+							},
+						},
+					},
+				},
+			},
+			{
+				StartTimestamp: timestamppb.New(testdata.TestMetricStartTime),
+				LabelValues: []*ocmetrics.LabelValue{
+					{
+						// key1
+						HasValue: false,
+					},
+					{
+						// key2
+						Value:    testdata.TestLabelValue2,
+						HasValue: true,
+					},
+					{
+						// key3
+						HasValue: false,
+					},
+				},
+				Points: []*ocmetrics.Point{
+					{
+						Timestamp: timestamppb.New(testdata.TestMetricTime),
+						Value: &ocmetrics.Point_DistributionValue{
+							DistributionValue: &ocmetrics.DistributionValue{
+								Count: 1,
+								Sum:   15,
+								BucketOptions: &ocmetrics.DistributionValue_BucketOptions{
+									Type: &ocmetrics.DistributionValue_BucketOptions_Explicit_{
+										Explicit: &ocmetrics.DistributionValue_BucketOptions_Explicit{
+											Bounds: []float64{1},
+										},
+									},
+								},
+								Buckets: []*ocmetrics.DistributionValue_Bucket{
+									{
+										Count: 0,
+									},
+									{
+										Count: 1,
+										Exemplar: &ocmetrics.DistributionValue_Exemplar{
+											Timestamp:   timestamppb.New(testdata.TestMetricExemplarTime),
+											Value:       15,
+											Attachments: map[string]string{testdata.TestAttachmentKey: testdata.TestAttachmentValue},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
 func generateOCTestMetricIntHistogram() *ocmetrics.Metric {
 	m := generateOCTestMetricDoubleHistogram()
 	m.MetricDescriptor.Name = testdata.TestIntHistogramMetricName

--- a/translator/internaldata/oc_testdata_test.go
+++ b/translator/internaldata/oc_testdata_test.go
@@ -298,7 +298,7 @@ func generateOCTestMetricDouble() *ocmetrics.Metric {
 func generateOCTestMetricGaugeDoubleHistogram() *ocmetrics.Metric {
 	return &ocmetrics.Metric{
 		MetricDescriptor: &ocmetrics.MetricDescriptor{
-			Name:        testdata.TestDoubleHistogramMetricName,
+			Name:        testdata.TestGaugeDoubleHistogramMetricName,
 			Description: "",
 			Unit:        "1",
 			Type:        ocmetrics.MetricDescriptor_GAUGE_DISTRIBUTION,
@@ -489,102 +489,6 @@ func generateOCTestMetricDoubleHistogram() *ocmetrics.Metric {
 	}
 }
 
-func generateOCTestMetricDoubleGaugeHistogram() *ocmetrics.Metric {
-	return &ocmetrics.Metric{
-		MetricDescriptor: &ocmetrics.MetricDescriptor{
-			Name:        testdata.TestDoubleHistogramMetricName,
-			Description: "",
-			Unit:        "1",
-			Type:        ocmetrics.MetricDescriptor_GAUGE_DISTRIBUTION,
-			LabelKeys: []*ocmetrics.LabelKey{
-				{Key: testdata.TestLabelKey1},
-				{Key: testdata.TestLabelKey2},
-				{Key: testdata.TestLabelKey3},
-			},
-		},
-		Timeseries: []*ocmetrics.TimeSeries{
-			{
-				StartTimestamp: timestamppb.New(testdata.TestMetricStartTime),
-				LabelValues: []*ocmetrics.LabelValue{
-					{
-						// key1
-						Value:    testdata.TestLabelValue1,
-						HasValue: true,
-					},
-					{
-						// key2
-						HasValue: false,
-					},
-					{
-						// key3
-						Value:    testdata.TestLabelValue3,
-						HasValue: true,
-					},
-				},
-				Points: []*ocmetrics.Point{
-					{
-						Timestamp: timestamppb.New(testdata.TestMetricTime),
-						Value: &ocmetrics.Point_DistributionValue{
-							DistributionValue: &ocmetrics.DistributionValue{
-								Count: 1,
-								Sum:   15,
-							},
-						},
-					},
-				},
-			},
-			{
-				StartTimestamp: timestamppb.New(testdata.TestMetricStartTime),
-				LabelValues: []*ocmetrics.LabelValue{
-					{
-						// key1
-						HasValue: false,
-					},
-					{
-						// key2
-						Value:    testdata.TestLabelValue2,
-						HasValue: true,
-					},
-					{
-						// key3
-						HasValue: false,
-					},
-				},
-				Points: []*ocmetrics.Point{
-					{
-						Timestamp: timestamppb.New(testdata.TestMetricTime),
-						Value: &ocmetrics.Point_DistributionValue{
-							DistributionValue: &ocmetrics.DistributionValue{
-								Count: 1,
-								Sum:   15,
-								BucketOptions: &ocmetrics.DistributionValue_BucketOptions{
-									Type: &ocmetrics.DistributionValue_BucketOptions_Explicit_{
-										Explicit: &ocmetrics.DistributionValue_BucketOptions_Explicit{
-											Bounds: []float64{1},
-										},
-									},
-								},
-								Buckets: []*ocmetrics.DistributionValue_Bucket{
-									{
-										Count: 0,
-									},
-									{
-										Count: 1,
-										Exemplar: &ocmetrics.DistributionValue_Exemplar{
-											Timestamp:   timestamppb.New(testdata.TestMetricExemplarTime),
-											Value:       15,
-											Attachments: map[string]string{testdata.TestAttachmentKey: testdata.TestAttachmentValue},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-}
 func generateOCTestMetricIntHistogram() *ocmetrics.Metric {
 	m := generateOCTestMetricDoubleHistogram()
 	m.MetricDescriptor.Name = testdata.TestIntHistogramMetricName

--- a/translator/internaldata/oc_to_metrics.go
+++ b/translator/internaldata/oc_to_metrics.go
@@ -200,6 +200,11 @@ func descriptorTypeToMetrics(t ocmetrics.MetricDescriptor_Type, metric pdata.Met
 		metric.SetDataType(pdata.MetricDataTypeDoubleGauge)
 		metric.DoubleGauge().InitEmpty()
 		return pdata.MetricDataTypeDoubleGauge
+	case ocmetrics.MetricDescriptor_GAUGE_DISTRIBUTION:
+		metric.InitEmpty()
+		metric.SetDataType(pdata.MetricDataTypeDoubleHistogram)
+		metric.DoubleHistogram().InitEmpty()
+		return pdata.MetricDataTypeDoubleHistogram
 	case ocmetrics.MetricDescriptor_CUMULATIVE_INT64:
 		metric.InitEmpty()
 		metric.SetDataType(pdata.MetricDataTypeIntSum)

--- a/translator/internaldata/oc_to_metrics_test.go
+++ b/translator/internaldata/oc_to_metrics_test.go
@@ -131,6 +131,7 @@ func TestOCToMetrics(t *testing.T) {
 					generateOCTestMetricDoubleHistogram(),
 					generateOCTestMetricIntHistogram(),
 					generateOCTestMetricDoubleSummary(),
+					generateOCTestMetricGaugeDoubleHistogram(),
 				},
 			},
 			internal: sampleMetricData,


### PR DESCRIPTION
**Description:** internaldata.OCSliceToMetrics has been updated to correctly handle metrics of type MetricDescriptor_GAUGE_DISTRIBUTION. Previously metrics with this type were silently dropped.

**Link to tracking Issue:** Fixes #2096 

**Testing:** I've added unit tests that handle type gauge distribution to metrics_to_oc_test.go and oc_to_metrics_test.go. I also successfully manually tested exporting metrics of this type from a custom receiver to Stackdriver.

**Documentation:** no documentation updated
