### PR TITLE
Change default OTLP port number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 ## 💡 Enhancements 💡
 
 - Add --log-format command line option (default to "console") #2177.
+- Change default OTLP/gRPC port number to 4317, also continue receiving on legacy port
+  55680 during transition period (#2104).
 
 ## v0.14.0 Beta
 

--- a/receiver/otlpreceiver/README.md
+++ b/receiver/otlpreceiver/README.md
@@ -25,9 +25,9 @@ receivers:
 
 The following settings are configurable:
 
-- `endpoint` (default = 0.0.0.0:55680): host:port to which the receiver is
-  going to receive data. The valid syntax is described at
-  https://github.com/grpc/grpc/blob/master/doc/naming.md.
+- `endpoint` (default = 0.0.0.0:4317 for grpc protocol, 0.0.0.0:55681 http protocol):
+  host:port to which the receiver is going to receive data. The valid syntax is
+  described at https://github.com/grpc/grpc/blob/master/doc/naming.md.
 
 ## Advanced Configuration
 

--- a/receiver/otlpreceiver/config_test.go
+++ b/receiver/otlpreceiver/config_test.go
@@ -82,7 +82,7 @@ func TestLoadConfig(t *testing.T) {
 			Protocols: Protocols{
 				GRPC: &configgrpc.GRPCServerSettings{
 					NetAddr: confignet.NetAddr{
-						Endpoint:  "0.0.0.0:55680",
+						Endpoint:  "0.0.0.0:4317",
 						Transport: "tcp",
 					},
 					ReadBufferSize: 512 * 1024,
@@ -112,7 +112,7 @@ func TestLoadConfig(t *testing.T) {
 			Protocols: Protocols{
 				GRPC: &configgrpc.GRPCServerSettings{
 					NetAddr: confignet.NetAddr{
-						Endpoint:  "0.0.0.0:55680",
+						Endpoint:  "0.0.0.0:4317",
 						Transport: "tcp",
 					},
 					MaxRecvMsgSizeMiB:    32,
@@ -139,7 +139,7 @@ func TestLoadConfig(t *testing.T) {
 			Protocols: Protocols{
 				GRPC: &configgrpc.GRPCServerSettings{
 					NetAddr: confignet.NetAddr{
-						Endpoint:  "0.0.0.0:55680",
+						Endpoint:  "0.0.0.0:4317",
 						Transport: "tcp",
 					},
 					TLSSetting: &configtls.TLSServerSetting{

--- a/receiver/otlpreceiver/otlp_test.go
+++ b/receiver/otlpreceiver/otlp_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 	spb "google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -698,7 +699,7 @@ func TestGRPCInvalidTLSCredentials(t *testing.T) {
 	}
 
 	// TLS is resolved during Creation of the receiver for GRPC.
-	_, err := createReceiver(cfg)
+	_, err := createReceiver(cfg, zap.NewNop())
 	assert.EqualError(t, err,
 		`failed to load TLS config: for auth via TLS, either both certificate and key must be supplied, or neither`)
 }
@@ -745,7 +746,7 @@ func newHTTPReceiver(t *testing.T, endpoint string, tc consumer.TracesConsumer, 
 }
 
 func newReceiver(t *testing.T, factory component.ReceiverFactory, cfg *Config, tc consumer.TracesConsumer, mc consumer.MetricsConsumer) *otlpReceiver {
-	r, err := createReceiver(cfg)
+	r, err := createReceiver(cfg, zap.NewNop())
 	require.NoError(t, err)
 	if tc != nil {
 		params := component.ReceiverCreateParams{}


### PR DESCRIPTION
This implements specification change https://github.com/open-telemetry/opentelemetry-specification/pull/1221

To make transition to new port numbers less painful OTLP receiver will
also accept data on the legacy port numbers when it is configured to
use the default endpoint. Users who use the default Collector config
can continue sending data to the legacy ports and have a graceful period
to update their senders to start sending to the new ports.

Note that OTLP/HTTP continues using a separate port number from OTLP/gRPC.
There is separate work in progress to use one port for both.

This must be merged after https://github.com/open-telemetry/opentelemetry-specification/pull/1221 is merged.