### PR TITLE
Use "console" encoding for own logs

### DIFF
--- a/service/logger.go
+++ b/service/logger.go
@@ -61,6 +61,10 @@ func newLogger(hooks ...func(zapcore.Entry) error) (*zap.Logger, error) {
 		}
 	}
 
+	// Use more human-friendly mode of logging (tab delimited, formatted timestamps).
+	conf.Encoding = "console"
+	conf.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
+
 	conf.Level.SetLevel(level)
 	return conf.Build(zap.Hooks(hooks...))
 }


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-collector/issues/2106

Make logs more human-readable locally: switch from "json" to "console" encoding
even when "prod" logging configuration is selected (but keep Production zap
Logger configuration for "prod" mode). This is still fairly well-defined
format that can be unambiguously parse on the backend if needed.
