### PR TITLE
Enable unparam linter, removes unused params from not exported funcs

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -102,6 +102,7 @@ linters:
     - scopelint
     - unconvert
     - gocritic
+    - unparam
 
 issues:
   # Excluding configuration per-path, per-linter, per-text and per-source

--- a/exporter/exporterhelper/logshelper_test.go
+++ b/exporter/exporterhelper/logshelper_test.go
@@ -92,7 +92,7 @@ func TestLogsExporter_WithRecordLogs(t *testing.T) {
 	require.Nil(t, err)
 	require.NotNil(t, me)
 
-	checkRecordedMetricsForLogsExporter(t, me, nil, 0)
+	checkRecordedMetricsForLogsExporter(t, me, nil)
 }
 
 func TestLogsExporter_WithRecordLogs_NonZeroDropped(t *testing.T) {
@@ -100,7 +100,7 @@ func TestLogsExporter_WithRecordLogs_NonZeroDropped(t *testing.T) {
 	require.Nil(t, err)
 	require.NotNil(t, me)
 
-	checkRecordedMetricsForLogsExporter(t, me, nil, 1)
+	checkRecordedMetricsForLogsExporter(t, me, nil)
 }
 
 func TestLogsExporter_WithRecordLogs_ReturnError(t *testing.T) {
@@ -109,7 +109,7 @@ func TestLogsExporter_WithRecordLogs_ReturnError(t *testing.T) {
 	require.Nil(t, err)
 	require.NotNil(t, me)
 
-	checkRecordedMetricsForLogsExporter(t, me, want, 0)
+	checkRecordedMetricsForLogsExporter(t, me, want)
 }
 
 func TestLogsExporter_WithSpan(t *testing.T) {
@@ -163,7 +163,7 @@ func newPushLogsData(droppedTimeSeries int, retError error) PushLogsData {
 	}
 }
 
-func checkRecordedMetricsForLogsExporter(t *testing.T, me component.LogsExporter, wantError error, droppedLogRecords int) {
+func checkRecordedMetricsForLogsExporter(t *testing.T, me component.LogsExporter, wantError error) {
 	doneFn, err := obsreporttest.SetupRecordedMetricsTest()
 	require.NoError(t, err)
 	defer doneFn()

--- a/exporter/exporterhelper/metricshelper_test.go
+++ b/exporter/exporterhelper/metricshelper_test.go
@@ -92,7 +92,7 @@ func TestMetricsExporter_WithRecordMetrics(t *testing.T) {
 	require.Nil(t, err)
 	require.NotNil(t, me)
 
-	checkRecordedMetricsForMetricsExporter(t, me, nil, 0)
+	checkRecordedMetricsForMetricsExporter(t, me, nil)
 }
 
 func TestMetricsExporter_WithRecordMetrics_NonZeroDropped(t *testing.T) {
@@ -100,7 +100,7 @@ func TestMetricsExporter_WithRecordMetrics_NonZeroDropped(t *testing.T) {
 	require.Nil(t, err)
 	require.NotNil(t, me)
 
-	checkRecordedMetricsForMetricsExporter(t, me, nil, 1)
+	checkRecordedMetricsForMetricsExporter(t, me, nil)
 }
 
 func TestMetricsExporter_WithRecordMetrics_ReturnError(t *testing.T) {
@@ -109,7 +109,7 @@ func TestMetricsExporter_WithRecordMetrics_ReturnError(t *testing.T) {
 	require.Nil(t, err)
 	require.NotNil(t, me)
 
-	checkRecordedMetricsForMetricsExporter(t, me, want, 0)
+	checkRecordedMetricsForMetricsExporter(t, me, want)
 }
 
 func TestMetricsExporter_WithSpan(t *testing.T) {
@@ -183,7 +183,7 @@ func newPushMetricsData(droppedTimeSeries int, retError error) PushMetricsData {
 	}
 }
 
-func checkRecordedMetricsForMetricsExporter(t *testing.T, me component.MetricsExporter, wantError error, droppedTimeSeries int) {
+func checkRecordedMetricsForMetricsExporter(t *testing.T, me component.MetricsExporter, wantError error) {
 	doneFn, err := obsreporttest.SetupRecordedMetricsTest()
 	require.NoError(t, err)
 	defer doneFn()

--- a/exporter/exporterhelper/tracehelper_test.go
+++ b/exporter/exporterhelper/tracehelper_test.go
@@ -103,7 +103,7 @@ func TestTraceExporter_WithRecordMetrics(t *testing.T) {
 	require.Nil(t, err)
 	require.NotNil(t, te)
 
-	checkRecordedMetricsForTraceExporter(t, te, nil, 0)
+	checkRecordedMetricsForTraceExporter(t, te, nil)
 }
 
 func TestTraceExporter_WithRecordMetrics_NonZeroDropped(t *testing.T) {
@@ -111,7 +111,7 @@ func TestTraceExporter_WithRecordMetrics_NonZeroDropped(t *testing.T) {
 	require.Nil(t, err)
 	require.NotNil(t, te)
 
-	checkRecordedMetricsForTraceExporter(t, te, nil, 1)
+	checkRecordedMetricsForTraceExporter(t, te, nil)
 }
 
 func TestTraceExporter_WithRecordMetrics_ReturnError(t *testing.T) {
@@ -120,7 +120,7 @@ func TestTraceExporter_WithRecordMetrics_ReturnError(t *testing.T) {
 	require.Nil(t, err)
 	require.NotNil(t, te)
 
-	checkRecordedMetricsForTraceExporter(t, te, want, 0)
+	checkRecordedMetricsForTraceExporter(t, te, want)
 }
 
 func TestTraceExporter_WithSpan(t *testing.T) {
@@ -177,7 +177,7 @@ func newTraceDataPusher(droppedSpans int, retError error) traceDataPusher {
 	}
 }
 
-func checkRecordedMetricsForTraceExporter(t *testing.T, te component.TracesExporter, wantError error, droppedSpans int) {
+func checkRecordedMetricsForTraceExporter(t *testing.T, te component.TracesExporter, wantError error) {
 	doneFn, err := obsreporttest.SetupRecordedMetricsTest()
 	require.NoError(t, err)
 	defer doneFn()

--- a/exporter/prometheusremotewriteexporter/exporter_test.go
+++ b/exporter/prometheusremotewriteexporter/exporter_test.go
@@ -227,7 +227,7 @@ func Test_export(t *testing.T) {
 			if !tt.serverUp {
 				server.Close()
 			}
-			err := runExportPipeline(t, ts1, serverURL)
+			err := runExportPipeline(ts1, serverURL)
 			if tt.returnError {
 				assert.Error(t, err)
 				return
@@ -237,7 +237,7 @@ func Test_export(t *testing.T) {
 	}
 }
 
-func runExportPipeline(t *testing.T, ts *prompb.TimeSeries, endpoint *url.URL) error {
+func runExportPipeline(ts *prompb.TimeSeries, endpoint *url.URL) error {
 	// First we will construct a TimeSeries array from the testutils package
 	testmap := make(map[string]*prompb.TimeSeries)
 	testmap["test"] = ts

--- a/processor/samplingprocessor/probabilisticsamplerprocessor/probabilisticsampler.go
+++ b/processor/samplingprocessor/probabilisticsamplerprocessor/probabilisticsampler.go
@@ -77,12 +77,12 @@ func (tsp *tracesamplerprocessor) ConsumeTraces(ctx context.Context, td pdata.Tr
 		if rspan.IsNil() {
 			continue
 		}
-		tsp.processTraces(ctx, rspan, sampledTraceData)
+		tsp.processTraces(rspan, sampledTraceData)
 	}
 	return tsp.nextConsumer.ConsumeTraces(ctx, sampledTraceData)
 }
 
-func (tsp *tracesamplerprocessor) processTraces(ctx context.Context, resourceSpans pdata.ResourceSpans, sampledTraceData pdata.Traces) {
+func (tsp *tracesamplerprocessor) processTraces(resourceSpans pdata.ResourceSpans, sampledTraceData pdata.Traces) {
 	scaledSamplingRate := tsp.scaledSamplingRate
 
 	sampledTraceData.ResourceSpans().Resize(sampledTraceData.ResourceSpans().Len() + 1)

--- a/receiver/jaegerreceiver/factory.go
+++ b/receiver/jaegerreceiver/factory.go
@@ -231,7 +231,7 @@ func createTraceReceiver(
 	}
 
 	// Create the receiver.
-	return newJaegerReceiver(rCfg.Name(), &config, nextConsumer, params)
+	return newJaegerReceiver(rCfg.Name(), &config, nextConsumer, params), nil
 }
 
 // extract the port number from string in "address:port" format. If the

--- a/receiver/jaegerreceiver/jaeger_agent_test.go
+++ b/receiver/jaegerreceiver/jaeger_agent_test.go
@@ -61,11 +61,9 @@ func TestJaegerAgentUDP_ThriftCompact_InvalidPort(t *testing.T) {
 		AgentCompactThriftPort: port,
 	}
 	params := component.ReceiverCreateParams{Logger: zap.NewNop()}
-	jr, err := newJaegerReceiver(jaegerAgent, config, nil, params)
-	assert.NoError(t, err, "Failed to create new Jaeger Receiver")
+	jr := newJaegerReceiver(jaegerAgent, config, nil, params)
 
-	err = jr.Start(context.Background(), componenttest.NewNopHost())
-	assert.Error(t, err, "should not have been able to startTraceReception")
+	assert.Error(t, jr.Start(context.Background(), componenttest.NewNopHost()), "should not have been able to startTraceReception")
 
 	jr.Shutdown(context.Background())
 }
@@ -86,11 +84,9 @@ func TestJaegerAgentUDP_ThriftBinary_PortInUse(t *testing.T) {
 		AgentBinaryThriftPort: int(port),
 	}
 	params := component.ReceiverCreateParams{Logger: zap.NewNop()}
-	jr, err := newJaegerReceiver(jaegerAgent, config, nil, params)
-	assert.NoError(t, err, "Failed to create new Jaeger Receiver")
+	jr := newJaegerReceiver(jaegerAgent, config, nil, params)
 
-	err = jr.startAgent(componenttest.NewNopHost())
-	assert.NoError(t, err, "Start failed")
+	assert.NoError(t, jr.startAgent(componenttest.NewNopHost()), "Start failed")
 	defer jr.Shutdown(context.Background())
 
 	l, err := net.Listen("udp", fmt.Sprintf("localhost:%d", port))
@@ -108,11 +104,9 @@ func TestJaegerAgentUDP_ThriftBinary_InvalidPort(t *testing.T) {
 		AgentBinaryThriftPort: port,
 	}
 	params := component.ReceiverCreateParams{Logger: zap.NewNop()}
-	jr, err := newJaegerReceiver(jaegerAgent, config, nil, params)
-	assert.NoError(t, err, "Failed to create new Jaeger Receiver")
+	jr := newJaegerReceiver(jaegerAgent, config, nil, params)
 
-	err = jr.Start(context.Background(), componenttest.NewNopHost())
-	assert.Error(t, err, "should not have been able to startTraceReception")
+	assert.Error(t, jr.Start(context.Background(), componenttest.NewNopHost()), "should not have been able to startTraceReception")
 
 	jr.Shutdown(context.Background())
 }
@@ -153,16 +147,13 @@ func TestJaegerHTTP(t *testing.T) {
 		},
 	}
 	params := component.ReceiverCreateParams{Logger: zap.NewNop()}
-	jr, err := newJaegerReceiver(jaegerAgent, config, nil, params)
-	assert.NoError(t, err, "Failed to create new Jaeger Receiver")
+	jr := newJaegerReceiver(jaegerAgent, config, nil, params)
 	defer jr.Shutdown(context.Background())
 
-	err = jr.Start(context.Background(), componenttest.NewNopHost())
-	assert.NoError(t, err, "Start failed")
+	assert.NoError(t, jr.Start(context.Background(), componenttest.NewNopHost()), "Start failed")
 
 	// allow http server to start
-	err = testutil.WaitForPort(t, port)
-	assert.NoError(t, err, "WaitForPort failed")
+	assert.NoError(t, testutil.WaitForPort(t, port), "WaitForPort failed")
 
 	testURL := fmt.Sprintf("http://localhost:%d/sampling?service=test", port)
 	resp, err := http.Get(testURL)
@@ -190,12 +181,10 @@ func testJaegerAgent(t *testing.T, agentEndpoint string, receiverConfig *configu
 	// 1. Create the Jaeger receiver aka "server"
 	sink := new(consumertest.TracesSink)
 	params := component.ReceiverCreateParams{Logger: zap.NewNop()}
-	jr, err := newJaegerReceiver(jaegerAgent, receiverConfig, sink, params)
-	assert.NoError(t, err, "Failed to create new Jaeger Receiver")
+	jr := newJaegerReceiver(jaegerAgent, receiverConfig, sink, params)
 	defer jr.Shutdown(context.Background())
 
-	err = jr.Start(context.Background(), componenttest.NewNopHost())
-	assert.NoError(t, err, "Start failed")
+	assert.NoError(t, jr.Start(context.Background(), componenttest.NewNopHost()), "Start failed")
 
 	// 2. Then send spans to the Jaeger receiver.
 	jexp, err := newClientUDP(agentEndpoint, jr.agentBinaryThriftEnabled())

--- a/receiver/jaegerreceiver/trace_receiver.go
+++ b/receiver/jaegerreceiver/trace_receiver.go
@@ -124,13 +124,13 @@ func newJaegerReceiver(
 	config *configuration,
 	nextConsumer consumer.TracesConsumer,
 	params component.ReceiverCreateParams,
-) (*jReceiver, error) {
+) *jReceiver {
 	return &jReceiver{
 		config:       config,
 		nextConsumer: nextConsumer,
 		instanceName: instanceName,
 		logger:       params.Logger,
-	}, nil
+	}
 }
 
 func (jr *jReceiver) agentCompactThriftAddr() string {

--- a/receiver/jaegerreceiver/trace_receiver_test.go
+++ b/receiver/jaegerreceiver/trace_receiver_test.go
@@ -58,8 +58,7 @@ const jaegerReceiver = "jaeger_receiver_test"
 
 func TestTraceSource(t *testing.T) {
 	params := component.ReceiverCreateParams{Logger: zap.NewNop()}
-	jr, err := newJaegerReceiver(jaegerReceiver, &configuration{}, nil, params)
-	assert.NoError(t, err, "should not have failed to create the Jaeger receiver")
+	jr := newJaegerReceiver(jaegerReceiver, &configuration{}, nil, params)
 	require.NotNil(t, jr)
 }
 
@@ -136,9 +135,8 @@ func TestReception(t *testing.T) {
 	sink := new(consumertest.TracesSink)
 
 	params := component.ReceiverCreateParams{Logger: zap.NewNop()}
-	jr, err := newJaegerReceiver(jaegerReceiver, config, sink, params)
+	jr := newJaegerReceiver(jaegerReceiver, config, sink, params)
 	defer jr.Shutdown(context.Background())
-	assert.NoError(t, err, "should not have failed to create the Jaeger received")
 
 	t.Log("Starting")
 
@@ -170,8 +168,7 @@ func TestPortsNotOpen(t *testing.T) {
 	sink := new(consumertest.TracesSink)
 
 	params := component.ReceiverCreateParams{Logger: zap.NewNop()}
-	jr, err := newJaegerReceiver(jaegerReceiver, config, sink, params)
-	assert.NoError(t, err, "should not have failed to create a new receiver")
+	jr := newJaegerReceiver(jaegerReceiver, config, sink, params)
 	defer jr.Shutdown(context.Background())
 
 	require.NoError(t, jr.Start(context.Background(), componenttest.NewNopHost()))
@@ -200,8 +197,7 @@ func TestGRPCReception(t *testing.T) {
 	sink := new(consumertest.TracesSink)
 
 	params := component.ReceiverCreateParams{Logger: zap.NewNop()}
-	jr, err := newJaegerReceiver(jaegerReceiver, config, sink, params)
-	assert.NoError(t, err, "should not have failed to create a new receiver")
+	jr := newJaegerReceiver(jaegerReceiver, config, sink, params)
 	defer jr.Shutdown(context.Background())
 
 	require.NoError(t, jr.Start(context.Background(), componenttest.NewNopHost()))
@@ -257,8 +253,7 @@ func TestGRPCReceptionWithTLS(t *testing.T) {
 	sink := new(consumertest.TracesSink)
 
 	params := component.ReceiverCreateParams{Logger: zap.NewNop()}
-	jr, err := newJaegerReceiver(jaegerReceiver, config, sink, params)
-	assert.NoError(t, err, "should not have failed to create a new receiver")
+	jr := newJaegerReceiver(jaegerReceiver, config, sink, params)
 	defer jr.Shutdown(context.Background())
 
 	require.NoError(t, jr.Start(context.Background(), componenttest.NewNopHost()))
@@ -395,8 +390,7 @@ func TestSampling(t *testing.T) {
 	sink := new(consumertest.TracesSink)
 
 	params := component.ReceiverCreateParams{Logger: zap.NewNop()}
-	jr, err := newJaegerReceiver(jaegerReceiver, config, sink, params)
-	assert.NoError(t, err, "should not have failed to create a new receiver")
+	jr := newJaegerReceiver(jaegerReceiver, config, sink, params)
 	defer jr.Shutdown(context.Background())
 
 	require.NoError(t, jr.Start(context.Background(), componenttest.NewNopHost()))
@@ -448,8 +442,7 @@ func TestSamplingFailsOnNotConfigured(t *testing.T) {
 	sink := new(consumertest.TracesSink)
 
 	params := component.ReceiverCreateParams{Logger: zap.NewNop()}
-	jr, err := newJaegerReceiver(jaegerReceiver, config, sink, params)
-	assert.NoError(t, err, "should not have failed to create a new receiver")
+	jr := newJaegerReceiver(jaegerReceiver, config, sink, params)
 	defer jr.Shutdown(context.Background())
 
 	require.NoError(t, jr.Start(context.Background(), componenttest.NewNopHost()))
@@ -478,8 +471,7 @@ func TestSamplingFailsOnBadFile(t *testing.T) {
 	sink := new(consumertest.TracesSink)
 
 	params := component.ReceiverCreateParams{Logger: zap.NewNop()}
-	jr, err := newJaegerReceiver(jaegerReceiver, config, sink, params)
-	assert.NoError(t, err, "should not have failed to create a new receiver")
+	jr := newJaegerReceiver(jaegerReceiver, config, sink, params)
 	defer jr.Shutdown(context.Background())
 	assert.Error(t, jr.Start(context.Background(), componenttest.NewNopHost()))
 }

--- a/receiver/zipkinreceiver/trace_receiver.go
+++ b/receiver/zipkinreceiver/trace_receiver.go
@@ -170,7 +170,7 @@ func (zr *ZipkinReceiver) v2ToTraceSpans(blob []byte, hdr http.Header) (reqs pda
 		zipkinSpans, err = zipkin_proto3.ParseSpans(blob, debugWasSet)
 
 	default: // By default, we'll assume using JSON
-		zipkinSpans, err = zr.deserializeFromJSON(blob, debugWasSet)
+		zipkinSpans, err = zr.deserializeFromJSON(blob)
 	}
 
 	if err != nil {
@@ -180,7 +180,7 @@ func (zr *ZipkinReceiver) v2ToTraceSpans(blob []byte, hdr http.Header) (reqs pda
 	return zipkin.V2SpansToInternalTraces(zipkinSpans, zr.config.ParseStringTags)
 }
 
-func (zr *ZipkinReceiver) deserializeFromJSON(jsonBlob []byte, debugWasSet bool) (zs []*zipkinmodel.SpanModel, err error) {
+func (zr *ZipkinReceiver) deserializeFromJSON(jsonBlob []byte) (zs []*zipkinmodel.SpanModel, err error) {
 	if err = json.Unmarshal(jsonBlob, &zs); err != nil {
 		return nil, err
 	}

--- a/testbed/tests/resource_processor_test.go
+++ b/testbed/tests/resource_processor_test.go
@@ -130,7 +130,7 @@ type resourceProcessorTestCase struct {
 	expectedMetricData       pdata.Metrics
 }
 
-func getResourceProcessorTestCases(t *testing.T) []resourceProcessorTestCase {
+func getResourceProcessorTestCases() []resourceProcessorTestCase {
 
 	tests := []resourceProcessorTestCase{
 		{
@@ -147,7 +147,7 @@ func getResourceProcessorTestCases(t *testing.T) []resourceProcessorTestCase {
     - key: opencensus.resourcetype
       action: delete
 `,
-			mockedConsumedMetricData: getMetricDataFrom(t, mockedConsumedResourceWithType),
+			mockedConsumedMetricData: getMetricDataFrom(mockedConsumedResourceWithType),
 			expectedMetricData: getMetricDataFromResourceMetrics(&otlpmetrics.ResourceMetrics{
 				Resource: otlpresource.Resource{
 					Attributes: []otlpcommon.KeyValue{
@@ -173,7 +173,7 @@ func getResourceProcessorTestCases(t *testing.T) []resourceProcessorTestCase {
       action: insert
 
 `,
-			mockedConsumedMetricData: getMetricDataFrom(t, mockedConsumedResourceNil),
+			mockedConsumedMetricData: getMetricDataFrom(mockedConsumedResourceNil),
 			expectedMetricData: getMetricDataFromResourceMetrics(&otlpmetrics.ResourceMetrics{
 				Resource: otlpresource.Resource{
 					Attributes: []otlpcommon.KeyValue{
@@ -194,7 +194,7 @@ func getResourceProcessorTestCases(t *testing.T) []resourceProcessorTestCase {
       value: additional-label-value
       action: insert
 `,
-			mockedConsumedMetricData: getMetricDataFrom(t, mockedConsumedResourceWithoutAttributes),
+			mockedConsumedMetricData: getMetricDataFrom(mockedConsumedResourceWithoutAttributes),
 			expectedMetricData: getMetricDataFromResourceMetrics(&otlpmetrics.ResourceMetrics{
 				Resource: otlpresource.Resource{
 					Attributes: []otlpcommon.KeyValue{
@@ -215,7 +215,7 @@ func getMetricDataFromResourceMetrics(rm *otlpmetrics.ResourceMetrics) pdata.Met
 	return pdata.MetricsFromOtlp([]*otlpmetrics.ResourceMetrics{rm})
 }
 
-func getMetricDataFrom(t *testing.T, rm *otlpmetrics.ResourceMetrics) pdata.Metrics {
+func getMetricDataFrom(rm *otlpmetrics.ResourceMetrics) pdata.Metrics {
 	return pdata.MetricsFromOtlp([]*otlpmetrics.ResourceMetrics{rm})
 }
 
@@ -223,7 +223,7 @@ func TestMetricResourceProcessor(t *testing.T) {
 	sender := testbed.NewOTLPMetricDataSender(testbed.DefaultHost, testbed.GetAvailablePort(t))
 	receiver := testbed.NewOTLPDataReceiver(testbed.GetAvailablePort(t))
 
-	tests := getResourceProcessorTestCases(t)
+	tests := getResourceProcessorTestCases()
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>

