### PR TITLE
Fix "process/memory/rss" metric units

### DIFF
--- a/service/internal/telemetry/process_telemetry.go
+++ b/service/internal/telemetry/process_telemetry.go
@@ -97,7 +97,7 @@ var viewCPUSeconds = &view.View{
 var mRSSMemory = stats.Int64(
 	"process/memory/rss",
 	"Total physical memory (resident set size)",
-	stats.UnitDimensionless)
+	stats.UnitBytes)
 var viewRSSMemory = &view.View{
 	Name:        mRSSMemory.Name(),
 	Description: mRSSMemory.Description(),


### PR DESCRIPTION
This metric is in bytes, it was incorrectly marked as unitless.
