### PR TITLE
Fix "process/cpu_seconds" metrics

### DIFF
--- a/service/internal/telemetry/process_telemetry.go
+++ b/service/internal/telemetry/process_telemetry.go
@@ -82,10 +82,10 @@ var viewSysMem = &view.View{
 	TagKeys:     nil,
 }
 
-var mCPUSeconds = stats.Int64(
+var mCPUSeconds = stats.Float64(
 	"process/cpu_seconds",
 	"Total CPU user and system time in seconds",
-	stats.UnitDimensionless)
+	stats.UnitSeconds)
 var viewCPUSeconds = &view.View{
 	Name:        mCPUSeconds.Name(),
 	Description: mCPUSeconds.Description(),
@@ -166,7 +166,7 @@ func (pmv *ProcessMetricsViews) updateViews() {
 
 	if pmv.proc != nil {
 		if times, err := pmv.proc.Times(); err == nil {
-			stats.Record(context.Background(), mCPUSeconds.M(int64(times.Total())))
+			stats.Record(context.Background(), mCPUSeconds.M(times.Total()))
 		}
 		if mem, err := pmv.proc.MemoryInfo(); err == nil {
 			stats.Record(context.Background(), mRSSMemory.M(int64(mem.RSS)))


### PR DESCRIPTION
It was incorrectly declared as a unitless int64 metric. It needs to be a float64, and units are seconds.
