### PR TITLE
Allow for more logging options to be passed to service.

### DIFF
--- a/service/logger.go
+++ b/service/logger.go
@@ -39,7 +39,7 @@ func loggerFlags(flags *flag.FlagSet) {
 	loggerProfilePtr = flags.String(logProfileCfg, "", "Logging profile to use (dev, prod)")
 }
 
-func newLogger(hooks ...func(zapcore.Entry) error) (*zap.Logger, error) {
+func newLogger(options []zap.Option) (*zap.Logger, error) {
 	var level zapcore.Level
 	err := (&level).UnmarshalText([]byte(*loggerLevelPtr))
 	if err != nil {
@@ -66,5 +66,5 @@ func newLogger(hooks ...func(zapcore.Entry) error) (*zap.Logger, error) {
 	conf.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
 
 	conf.Level.SetLevel(level)
-	return conf.Build(zap.Hooks(hooks...))
+	return conf.Build(options...)
 }

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -52,7 +52,7 @@ func TestApplication_Start(t *testing.T) {
 		return nil
 	}
 
-	app, err := New(Parameters{Factories: factories, ApplicationStartInfo: componenttest.TestApplicationStartInfo(), LoggingHooks: []func(entry zapcore.Entry) error{hook}})
+	app, err := New(Parameters{Factories: factories, ApplicationStartInfo: componenttest.TestApplicationStartInfo(), LoggingOptions: []zap.Option{zap.Hooks(hook)}})
 	require.NoError(t, err)
 	assert.Equal(t, app.rootCmd, app.Command())
 

--- a/service/service_windows.go
+++ b/service/service_windows.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"syscall"
 
+	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"golang.org/x/sys/windows/svc"
 	"golang.org/x/sys/windows/svc/eventlog"
@@ -120,9 +121,9 @@ func openEventLog(serviceName string) (*eventlog.Log, error) {
 }
 
 func newWithEventViewerLoggingHook(params Parameters, elog *eventlog.Log) (*Application, error) {
-	params.LoggingHooks = append(
-		params.LoggingHooks,
-		func(entry zapcore.Entry) error {
+	params.LoggingOptions = append(
+		params.LoggingOptions,
+		zap.Hooks(func(entry zapcore.Entry) error {
 			msg := fmt.Sprintf("%v\r\n\r\nStack Trace:\r\n%v", entry.Message, entry.Stack)
 
 			switch entry.Level {
@@ -139,7 +140,7 @@ func newWithEventViewerLoggingHook(params Parameters, elog *eventlog.Log) (*Appl
 
 			// ignore Debug level logs
 			return nil
-		},
+		}),
 	)
 
 	return New(params)


### PR DESCRIPTION
**Description:** 
This is a Feature request.
It extends parameters passed to service so that more than hooks can be passed to the zap library.

Currently it removes the `LoggingHooks`, as this field can be represented as `zap.Option`
But if you prefer to leave it and possibly generate deprecation message let me know.

**Testing:** 
I changed the unit tests, considering the size of the change it should be enough.
