### PR TITLE
Remove level from all the MetricViews calls

### DIFF
--- a/processor/batchprocessor/batch_processor_test.go
+++ b/processor/batchprocessor/batch_processor_test.go
@@ -116,8 +116,8 @@ func TestBatchProcessorSpansDeliveredEnforceBatchSize(t *testing.T) {
 }
 
 func TestBatchProcessorSentBySize(t *testing.T) {
-	views := MetricViews(configtelemetry.LevelDetailed)
-	view.Register(views...)
+	views := MetricViews()
+	require.NoError(t, view.Register(views...))
 	defer view.Unregister(views...)
 
 	sink := new(consumertest.TracesSink)
@@ -297,8 +297,8 @@ func TestBatchMetricProcessor_ReceivingData(t *testing.T) {
 }
 
 func TestBatchMetricProcessor_BatchSize(t *testing.T) {
-	views := MetricViews(configtelemetry.LevelDetailed)
-	view.Register(views...)
+	views := MetricViews()
+	require.NoError(t, view.Register(views...))
 	defer view.Unregister(views...)
 
 	// Instantiate the batch processor with low config values to test data
@@ -553,8 +553,8 @@ func TestBatchLogProcessor_ReceivingData(t *testing.T) {
 }
 
 func TestBatchLogProcessor_BatchSize(t *testing.T) {
-	views := MetricViews(configtelemetry.LevelDetailed)
-	view.Register(views...)
+	views := MetricViews()
+	require.NoError(t, view.Register(views...))
 	defer view.Unregister(views...)
 
 	// Instantiate the batch processor with low config values to test data

--- a/processor/batchprocessor/metrics.go
+++ b/processor/batchprocessor/metrics.go
@@ -19,7 +19,6 @@ import (
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
 
-	"go.opentelemetry.io/collector/config/configtelemetry"
 	"go.opentelemetry.io/collector/obsreport"
 	"go.opentelemetry.io/collector/processor"
 )
@@ -32,11 +31,7 @@ var (
 )
 
 // MetricViews returns the metrics views related to batching
-func MetricViews(level configtelemetry.Level) []*view.View {
-	if level == configtelemetry.LevelNone {
-		return nil
-	}
-
+func MetricViews() []*view.View {
 	processorTagKeys := []tag.Key{processor.TagProcessorNameKey}
 
 	countBatchSizeTriggerSendView := &view.View{

--- a/processor/batchprocessor/metrics_test.go
+++ b/processor/batchprocessor/metrics_test.go
@@ -18,32 +18,17 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
-	"go.opentelemetry.io/collector/config/configtelemetry"
 )
 
 func TestBatchProcessorMetrics(t *testing.T) {
-	tests := []struct {
-		viewNames []string
-		level     configtelemetry.Level
-	}{
-		{
-			viewNames: []string{"batch_size_trigger_send", "timeout_trigger_send", "batch_send_size", "batch_send_size_bytes"},
-			level:     configtelemetry.LevelDetailed,
-		},
-		{
-			viewNames: []string{},
-			level:     configtelemetry.LevelNone,
-		},
+	viewNames := []string{
+		"batch_size_trigger_send",
+		"timeout_trigger_send",
+		"batch_send_size",
+		"batch_send_size_bytes",
 	}
-	for _, test := range tests {
-		views := MetricViews(test.level)
-		if test.viewNames == nil {
-			assert.Nil(t, views)
-			continue
-		}
-		for i, viewName := range test.viewNames {
-			assert.Equal(t, "processor/batch/"+viewName, views[i].Name)
-		}
+	views := MetricViews()
+	for i, viewName := range viewNames {
+		assert.Equal(t, "processor/batch/"+viewName, views[i].Name)
 	}
 }

--- a/processor/metrics.go
+++ b/processor/metrics.go
@@ -72,28 +72,16 @@ func (scm *SpanCountStats) GetAllSpansCount() int {
 }
 
 // MetricTagKeys returns the metric tag keys according to the given telemetry level.
-func MetricTagKeys(level configtelemetry.Level) []tag.Key {
-	var tagKeys []tag.Key
-	switch level {
-	case configtelemetry.LevelDetailed:
-		tagKeys = append(tagKeys, TagServiceNameKey)
-		fallthrough
-	case configtelemetry.LevelNormal, configtelemetry.LevelBasic:
-		tagKeys = append(tagKeys, TagProcessorNameKey)
-	default:
-		return nil
+func MetricTagKeys() []tag.Key {
+	return []tag.Key{
+		TagProcessorNameKey,
+		TagServiceNameKey,
 	}
-
-	return tagKeys
 }
 
 // MetricViews return the metrics views according to given telemetry level.
-func MetricViews(level configtelemetry.Level) []*view.View {
-	tagKeys := MetricTagKeys(level)
-	if tagKeys == nil {
-		return nil
-	}
-
+func MetricViews() []*view.View {
+	tagKeys := MetricTagKeys()
 	// There are some metrics enabled, return the views.
 	receivedBatchesView := &view.View{
 		Name:        "batches_received",

--- a/processor/queuedprocessor/metrics.go
+++ b/processor/queuedprocessor/metrics.go
@@ -19,7 +19,6 @@ import (
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
 
-	"go.opentelemetry.io/collector/config/configtelemetry"
 	"go.opentelemetry.io/collector/obsreport"
 	"go.opentelemetry.io/collector/processor"
 )
@@ -58,15 +57,8 @@ var (
 )
 
 // MetricViews return the metrics views according to given telemetry level.
-func MetricViews(level configtelemetry.Level) []*view.View {
-	if level == configtelemetry.LevelNone {
-		return nil
-	}
-
-	tagKeys := processor.MetricTagKeys(level)
-	if tagKeys == nil {
-		return nil
-	}
+func MetricViews() []*view.View {
+	tagKeys := processor.MetricTagKeys()
 
 	countSuccessSendView := &view.View{
 		Name:        statSuccessSendOps.Name(),

--- a/processor/queuedprocessor/queued_processor_test.go
+++ b/processor/queuedprocessor/queued_processor_test.go
@@ -30,7 +30,6 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
-	"go.opentelemetry.io/collector/config/configtelemetry"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/consumer/pdata"
@@ -289,7 +288,7 @@ func TestTraceQueueProcessorHappyPath(t *testing.T) {
 	require.NoError(t, err)
 	defer doneFn()
 
-	views := processor.MetricViews(configtelemetry.LevelDetailed)
+	views := processor.MetricViews()
 	assert.NoError(t, view.Register(views...))
 	defer view.Unregister(views...)
 

--- a/receiver/fluentforwardreceiver/observ/metrics.go
+++ b/receiver/fluentforwardreceiver/observ/metrics.go
@@ -19,8 +19,6 @@ package observ
 import (
 	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/view"
-
-	"go.opentelemetry.io/collector/config/configtelemetry"
 )
 
 var (
@@ -80,11 +78,7 @@ var (
 	}
 )
 
-func Views(level configtelemetry.Level) []*view.View {
-	if level == configtelemetry.LevelNone {
-		return nil
-	}
-
+func MetricViews() []*view.View {
 	return []*view.View{
 		connectionsOpenedView,
 		connectionsClosedView,

--- a/receiver/fluentforwardreceiver/observ/metrics_test.go
+++ b/receiver/fluentforwardreceiver/observ/metrics_test.go
@@ -18,11 +18,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
-	"go.opentelemetry.io/collector/config/configtelemetry"
 )
 
 func TestViews(t *testing.T) {
-	require.Greater(t, len(Views(configtelemetry.LevelBasic)), 2)
-	require.Len(t, Views(configtelemetry.LevelNone), 0)
+	require.Equal(t, len(MetricViews()), 5)
 }

--- a/service/telemetry.go
+++ b/service/telemetry.go
@@ -69,12 +69,12 @@ func (tel *appTelemetry) init(asyncErrorChannel chan<- error, ballastSizeBytes u
 
 	var views []*view.View
 	views = append(views, obsreport.Configure(level)...)
-	views = append(views, processor.MetricViews(level)...)
-	views = append(views, queuedprocessor.MetricViews(level)...)
-	views = append(views, batchprocessor.MetricViews(level)...)
+	views = append(views, processor.MetricViews()...)
+	views = append(views, queuedprocessor.MetricViews()...)
+	views = append(views, batchprocessor.MetricViews()...)
 	views = append(views, kafkareceiver.MetricViews()...)
 	views = append(views, processMetricsViews.Views()...)
-	views = append(views, fluentobserv.Views(level)...)
+	views = append(views, fluentobserv.MetricViews()...)
 	tel.views = views
 	if err = view.Register(views...); err != nil {
 		return err


### PR DESCRIPTION
This is a preparation for enabling per component telemetry level:
* Views are global and they must always be installed; they are no-op if nobody records data;
* Views are global and they must always contain all the labels; In case of measurements being recorded without one of the labels (for performance reasons)
  the extra label defined does not have impact, because all the timeseries will have that label as "null" (missing).
