### PR TITLE
Fix fluentforwardreceiver config example

### DIFF
--- a/receiver/fluentforwardreceiver/README.md
+++ b/receiver/fluentforwardreceiver/README.md
@@ -20,7 +20,7 @@ on port 8006:
 ```yaml
 receivers:
   fluentforward:
-    listenAddress: 0.0.0.0:8006
+    endpoint: 0.0.0.0:8006
 ```
 
 


### PR DESCRIPTION
**Description:** 
Fixed fluentforwardreceiver example configuration. The example configuration specified `listenerAddress`; however, it should be `endpoint` based on the [Config struct](https://github.com/open-telemetry/opentelemetry-collector/blob/6ac579e9bc9b6a1bf06ffc07975d2c746ad1bdef/receiver/fluentforwardreceiver/config.go#L28).

**Testing:**
Configured fluentforwardreceiver and specified the correct configuration based on the Config struct. 

**Documentation:**
See commit.