### PR TITLE
Fix panic when adjusting buckets

### DIFF
--- a/receiver/prometheusreceiver/internal/metrics_adjuster.go
+++ b/receiver/prometheusreceiver/internal/metrics_adjuster.go
@@ -363,6 +363,7 @@ func (ma *MetricsAdjuster) adjustBuckets(current, initial []*metricspb.Distribut
 	if len(current) != len(initial) {
 		// this shouldn't happen
 		ma.logger.Info("Bucket sizes not equal", zap.Int("len(current)", len(current)), zap.Int("len(initial)", len(initial)))
+		return
 	}
 	for i := 0; i < len(current); i++ {
 		current[i].Count -= initial[i].Count


### PR DESCRIPTION
**Description:**
Return after finding that two arrays differ in length.  Otherwise, the function will panic.

**Link to tracking Issue:** <Issue number if applicable>
Fixes: https://github.com/open-telemetry/opentelemetry-collector/issues/2167
