### PR TITLE
POC/Proposal for exposing configuration schemas

### DIFF
--- a/cmd/cfgmetagen/all.go
+++ b/cmd/cfgmetagen/all.go
@@ -1,0 +1,37 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import "go.opentelemetry.io/collector/service/defaultcomponents"
+
+// allCfgs creates config yaml metadata files for all registered components
+func allCfgs() {
+	components, err := defaultcomponents.Components()
+	if err != nil {
+		panic(err)
+	}
+	for _, f := range components.Receivers {
+		genMeta(f.CreateDefaultConfig())
+	}
+	for _, f := range components.Extensions {
+		genMeta(f.CreateDefaultConfig())
+	}
+	for _, f := range components.Processors {
+		genMeta(f.CreateDefaultConfig())
+	}
+	for _, f := range components.Exporters {
+		genMeta(f.CreateDefaultConfig())
+	}
+}

--- a/cmd/cfgmetagen/comments.go
+++ b/cmd/cfgmetagen/comments.go
@@ -1,0 +1,94 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"reflect"
+	"strings"
+)
+
+// fieldCommentsForStruct returns a map of fieldname -> comment for a struct
+func fieldCommentsForStruct(v reflect.Value) map[string]string {
+	elem := v
+	if v.Kind() == reflect.Ptr {
+		elem = v.Elem()
+	}
+	path := typePath(elem.Type())
+	name := trimPackage(elem)
+	return fieldCommentsForName(path, name)
+}
+
+func typePath(t reflect.Type) string {
+	const moduleName = "go.opentelemetry.io/collector/"
+	return strings.TrimPrefix(t.PkgPath(), moduleName)
+}
+
+func trimPackage(elem reflect.Value) string {
+	typeName := elem.Type().String()
+	split := strings.Split(typeName, ".")
+	return split[1]
+}
+
+func fieldCommentsForName(packageDir, structName string) map[string]string {
+	configStruct := parseDir(packageDir, structName)
+	if configStruct == nil {
+		return nil
+	}
+	fieldComments := map[string]string{}
+	if structType, ok := configStruct.Type.(*ast.StructType); ok {
+		for _, field := range structType.Fields.List {
+			key := ""
+			if field.Names != nil {
+				key = field.Names[0].Name
+			} else if typ, ok := field.Type.(*ast.SelectorExpr); ok {
+				key = typ.Sel.Name
+			} else if typ, ok := field.Type.(*ast.Ident); ok {
+				key = typ.Name
+			} else {
+				continue
+			}
+			fieldComments[key] = field.Doc.Text()
+		}
+	}
+	return fieldComments
+}
+
+func parseDir(packageDir, structName string) *ast.TypeSpec {
+	fset := token.NewFileSet()
+	pkgs, err := parser.ParseDir(fset, packageDir, nil, parser.ParseComments)
+	if err != nil {
+		panic(err)
+	}
+	for _, pkg := range pkgs {
+		for _, file := range pkg.Files {
+			cmap := ast.NewCommentMap(fset, file, file.Comments)
+			for node := range cmap {
+				if t, ok := node.(*ast.GenDecl); ok {
+					if t.Tok != token.TYPE {
+						continue
+					}
+					spec := t.Specs[0] // i've only ever seen len(t.Specs) == 1
+					if typeSpec, ok := spec.(*ast.TypeSpec); ok && typeSpec.Name.Name == structName {
+						return typeSpec
+					}
+				}
+			}
+		}
+	}
+	return nil
+}

--- a/cmd/cfgmetagen/main.go
+++ b/cmd/cfgmetagen/main.go
@@ -1,0 +1,40 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"os"
+)
+
+func main() {
+	switch len(os.Args) {
+	case 2:
+		if os.Args[1] == "all" {
+			allCfgs()
+		} else {
+			printUsage()
+		}
+	case 3:
+		singleCfg()
+	default:
+		printUsage()
+	}
+}
+
+func printUsage() {
+	println("usage:")
+	println("	cfgmeta all")
+	println("	cfgmeta <componentType> <componentName>")
+}

--- a/cmd/cfgmetagen/meta.go
+++ b/cmd/cfgmetagen/meta.go
@@ -1,0 +1,145 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"io/ioutil"
+	"path"
+	"reflect"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v2"
+)
+
+type field struct {
+	Name    string      `yaml:",omitempty"`
+	Type    string      `yaml:",omitempty"`
+	Kind    string      `yaml:",omitempty"`
+	Default interface{} `yaml:",omitempty"`
+	Doc     string      `yaml:",omitempty"`
+	Meta    string      `yaml:",omitempty"`
+	Fields  []*field    `yaml:",omitempty"`
+}
+
+// genMeta creates a `cfgMeta.yaml` file in the directory of the passed-in
+// config instance. The yaml file contains the recursive field names, types,
+// tags, comments, and default values for the config struct.
+func genMeta(cfg interface{}) {
+	cfgVal := reflect.ValueOf(cfg)
+	cfgType := cfgVal.Type()
+	field := &field{
+		Type: cfgType.String(),
+	}
+	buildField(cfgVal, field)
+	marshaled, err := yaml.Marshal(field)
+	if err != nil {
+		panic(err)
+	}
+	pth := typePath(cfgType.Elem())
+	err = ioutil.WriteFile(path.Join(pth, "cfgMeta.yaml"), marshaled, 0600)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func buildField(v reflect.Value, f *field) {
+	if v.Kind() == reflect.Ptr {
+		buildField(v.Elem(), f)
+	}
+	if v.Kind() != reflect.Struct {
+		return
+	}
+	comments := fieldCommentsForStruct(v)
+	for i := 0; i < v.NumField(); i++ {
+		structField := v.Type().Field(i)
+		yamlName, meta := splitTag(structField.Tag)
+		if yamlName == "-" {
+			continue
+		}
+		fv := v.Field(i)
+		next := f
+		if meta != "squash" {
+			doc := comments[structField.Name]
+			name := yamlName
+			if name == "" {
+				name = strings.ToLower(structField.Name)
+			}
+			kindStr := fv.Kind().String()
+			typeStr := fv.Type().String()
+			if typeStr == kindStr {
+				typeStr = "" // omit if redundant
+			}
+			next = &field{
+				Name: name,
+				Type: typeStr,
+				Kind: kindStr,
+				Doc:  doc,
+				Meta: meta,
+			}
+			f.Fields = append(f.Fields, next)
+		}
+		handleKinds(fv, next)
+	}
+}
+
+func handleKinds(v reflect.Value, f *field) {
+	switch v.Kind() {
+	case reflect.Struct:
+		buildField(v, f)
+	case reflect.Ptr:
+		if v.IsNil() {
+			buildField(reflect.New(v.Type().Elem()), f)
+		} else {
+			buildField(v.Addr(), f)
+		}
+	case reflect.Slice:
+		e := v.Type().Elem()
+		if e.Kind() == reflect.Struct {
+			buildField(reflect.New(e), f)
+		} else if e.Kind() == reflect.Ptr {
+			buildField(reflect.New(e.Elem()), f)
+		}
+	case reflect.String:
+		if v.String() != "" {
+			f.Default = v.String()
+		}
+	case reflect.Bool:
+		f.Default = v.Bool()
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		if v.Int() != 0 {
+			if v.Type() == reflect.TypeOf(time.Duration(0)) {
+				f.Default = time.Duration(v.Int()).String()
+			} else {
+				f.Default = v.Int()
+			}
+		}
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		if v.Uint() != 0 {
+			f.Default = v.Uint()
+		}
+	}
+}
+
+func splitTag(s reflect.StructTag) (string, string) {
+	ms := strings.TrimPrefix(string(s), "mapstructure:")
+	trimmed := strings.Trim(ms, `"`)
+	split := strings.Split(trimmed, ",")
+	meta := ""
+	if len(split) == 2 {
+		meta = strings.TrimSpace(split[1])
+	}
+	return split[0], meta
+}

--- a/cmd/cfgmetagen/meta.go
+++ b/cmd/cfgmetagen/meta.go
@@ -24,14 +24,15 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+type fieldMap map[string]*field
+
 type field struct {
-	Name    string      `yaml:",omitempty"`
 	Type    string      `yaml:",omitempty"`
 	Kind    string      `yaml:",omitempty"`
 	Default interface{} `yaml:",omitempty"`
 	Doc     string      `yaml:",omitempty"`
 	Meta    string      `yaml:",omitempty"`
-	Fields  []*field    `yaml:",omitempty"`
+	Fields  fieldMap    `yaml:",omitempty"`
 }
 
 // genMeta creates a `cfgMeta.yaml` file in the directory of the passed-in
@@ -41,7 +42,8 @@ func genMeta(cfg interface{}) {
 	cfgVal := reflect.ValueOf(cfg)
 	cfgType := cfgVal.Type()
 	field := &field{
-		Type: cfgType.String(),
+		Type:   cfgType.String(),
+		Fields: fieldMap{},
 	}
 	buildField(cfgVal, field)
 	marshaled, err := yaml.Marshal(field)
@@ -83,13 +85,13 @@ func buildField(v reflect.Value, f *field) {
 				typeStr = "" // omit if redundant
 			}
 			next = &field{
-				Name: name,
-				Type: typeStr,
-				Kind: kindStr,
-				Doc:  doc,
-				Meta: meta,
+				Type:   typeStr,
+				Kind:   kindStr,
+				Doc:    doc,
+				Meta:   meta,
+				Fields: fieldMap{},
 			}
-			f.Fields = append(f.Fields, next)
+			f.Fields[name] = next
 		}
 		handleKinds(fv, next)
 	}

--- a/cmd/cfgmetagen/single.go
+++ b/cmd/cfgmetagen/single.go
@@ -1,0 +1,70 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"errors"
+	"os"
+
+	"go.opentelemetry.io/collector/config/configmodels"
+	"go.opentelemetry.io/collector/service/defaultcomponents"
+)
+
+// singleCfg creates a config metadata yaml file for a single component
+func singleCfg() {
+	componentType := os.Args[1]
+	componentName := os.Args[2]
+
+	cfg, err := createConfig(componentType, componentName)
+	if err != nil {
+		panic(err)
+	}
+	genMeta(cfg)
+}
+
+func createConfig(componentType string, componentName string) (configmodels.NamedEntity, error) {
+	components, err := defaultcomponents.Components()
+	if err != nil {
+		return nil, err
+	}
+	t := configmodels.Type(componentName)
+	switch componentType {
+	case "receiver":
+		c := components.Receivers[t]
+		if c == nil {
+			return nil, errors.New("unknown receiver name " + componentName)
+		}
+		return c.CreateDefaultConfig(), nil
+	case "processor":
+		c := components.Processors[t]
+		if c == nil {
+			return nil, errors.New("unknown processor name " + componentName)
+		}
+		return c.CreateDefaultConfig(), nil
+	case "exporter":
+		c := components.Exporters[t]
+		if c == nil {
+			return nil, errors.New("unknown exporter name " + componentName)
+		}
+		return c.CreateDefaultConfig(), nil
+	case "extension":
+		c := components.Extensions[t]
+		if c == nil {
+			return nil, errors.New("unknown extension name " + componentName)
+		}
+		return c.CreateDefaultConfig(), nil
+	}
+	return nil, errors.New("unknown component type " + componentType)
+}

--- a/exporter/otlpexporter/cfgMeta.yaml
+++ b/exporter/otlpexporter/cfgMeta.yaml
@@ -1,0 +1,162 @@
+type: '*otlpexporter.Config'
+fields:
+- name: timeout
+  type: time.Duration
+  kind: int64
+  default: 5s
+  doc: |
+    Timeout is the timeout for every attempt to send data to the backend.
+- name: sending_queue
+  type: exporterhelper.QueueSettings
+  kind: struct
+  fields:
+  - name: enabled
+    kind: bool
+    default: true
+    doc: |
+      Enabled indicates whether to not enqueue batches before sending to the consumerSender.
+  - name: num_consumers
+    kind: int
+    default: 10
+    doc: |
+      NumConsumers is the number of consumers from the queue.
+  - name: queue_size
+    kind: int
+    default: 5000
+    doc: |
+      QueueSize is the maximum number of batches allowed in queue at a given time.
+- name: retry_on_failure
+  type: exporterhelper.RetrySettings
+  kind: struct
+  fields:
+  - name: enabled
+    kind: bool
+    default: true
+    doc: |
+      Enabled indicates whether to not retry sending batches in case of export failure.
+  - name: initial_interval
+    type: time.Duration
+    kind: int64
+    default: 5s
+    doc: |
+      InitialInterval the time to wait after the first failure before retrying.
+  - name: max_interval
+    type: time.Duration
+    kind: int64
+    default: 30s
+    doc: |
+      MaxInterval is the upper bound on backoff interval. Once this value is reached the delay between
+      consecutive retries will always be `MaxInterval`.
+  - name: max_elapsed_time
+    type: time.Duration
+    kind: int64
+    default: 5m0s
+    doc: |
+      MaxElapsedTime is the maximum amount of time (including retries) spent trying to send a request/batch.
+      Once this value is reached, the data is discarded.
+- name: endpoint
+  kind: string
+  doc: |
+    The target to which the exporter is going to send traces or metrics,
+    using the gRPC protocol. The valid syntax is described at
+    https://github.com/grpc/grpc/blob/master/doc/naming.md.
+- name: compression
+  kind: string
+  doc: |
+    The compression key for supported compression types within
+    collector. Currently the only supported mode is `gzip`.
+- name: ca_file
+  kind: string
+  doc: |
+    Path to the CA cert. For a client this verifies the server certificate.
+    For a server this verifies client certificates. If empty uses system root CA.
+    (optional)
+- name: cert_file
+  kind: string
+  doc: |
+    Path to the TLS cert to use for TLS required connections. (optional)
+- name: key_file
+  kind: string
+  doc: |
+    Path to the TLS key to use for TLS required connections. (optional)
+- name: insecure
+  kind: bool
+  default: false
+  doc: |
+    In gRPC when set to true, this is used to disable the client transport security.
+    See https://godoc.org/google.golang.org/grpc#WithInsecure.
+    In HTTP, this disables verifying the server's certificate chain and host name
+    (InsecureSkipVerify in the tls Config). Please refer to
+    https://godoc.org/crypto/tls#Config for more information.
+    (optional, default false)
+    TODO(ccaraman): With further research InsecureSkipVerify is a valid option
+    for gRPC connections. Add that ability to the TLSClientSettings in a subsequent
+    pr.
+- name: server_name_override
+  kind: string
+  doc: |
+    ServerName requested by client for virtual hosting.
+    This sets the ServerName in the TLSConfig. Please refer to
+    https://godoc.org/crypto/tls#Config for more information. (optional)
+- name: keepalive
+  type: '*configgrpc.KeepaliveClientConfig'
+  kind: ptr
+  doc: |
+    The keepalive parameters for gRPC client. See grpc.WithKeepaliveParams
+    (https://godoc.org/google.golang.org/grpc#WithKeepaliveParams).
+  fields:
+  - name: time
+    type: time.Duration
+    kind: int64
+    meta: omitempty
+  - name: timeout
+    type: time.Duration
+    kind: int64
+    meta: omitempty
+  - name: permit_without_stream
+    kind: bool
+    default: false
+    meta: omitempty
+- name: read_buffer_size
+  kind: int
+  doc: |
+    ReadBufferSize for gRPC client. See grpc.WithReadBufferSize
+    (https://godoc.org/google.golang.org/grpc#WithReadBufferSize).
+- name: write_buffer_size
+  kind: int
+  default: 524288
+  doc: |
+    WriteBufferSize for gRPC gRPC. See grpc.WithWriteBufferSize
+    (https://godoc.org/google.golang.org/grpc#WithWriteBufferSize).
+- name: wait_for_ready
+  kind: bool
+  default: false
+  doc: |
+    WaitForReady parameter configures client to wait for ready state before sending data.
+    (https://github.com/grpc/grpc/blob/master/doc/wait-for-ready.md)
+- name: headers
+  type: map[string]string
+  kind: map
+  doc: |
+    The headers associated with gRPC requests.
+- name: per_rpc_auth
+  type: '*configgrpc.PerRPCAuthConfig'
+  kind: ptr
+  doc: |
+    PerRPCAuth parameter configures the client to send authentication data on a per-RPC basis.
+  fields:
+  - name: type
+    kind: string
+    doc: |
+      AuthType represents the authentication type to use. Currently, only 'bearer' is supported.
+    meta: omitempty
+  - name: bearer_token
+    kind: string
+    doc: |
+      BearerToken specifies the bearer token to use for every RPC.
+    meta: omitempty
+- name: balancer_name
+  kind: string
+  doc: |
+    Sets the balancer in grpclb_policy to discover the servers. Default is pick_first
+    https://github.com/grpc/grpc-go/blob/master/examples/features/load_balancing/README.md

--- a/exporter/otlpexporter/cfgMeta.yaml
+++ b/exporter/otlpexporter/cfgMeta.yaml
@@ -1,162 +1,162 @@
 type: '*otlpexporter.Config'
 fields:
-- name: timeout
-  type: time.Duration
-  kind: int64
-  default: 5s
-  doc: |
-    Timeout is the timeout for every attempt to send data to the backend.
-- name: sending_queue
-  type: exporterhelper.QueueSettings
-  kind: struct
-  fields:
-  - name: enabled
+  balancer_name:
+    kind: string
+    doc: |
+      Sets the balancer in grpclb_policy to discover the servers. Default is pick_first
+      https://github.com/grpc/grpc-go/blob/master/examples/features/load_balancing/README.md
+  ca_file:
+    kind: string
+    doc: |
+      Path to the CA cert. For a client this verifies the server certificate.
+      For a server this verifies client certificates. If empty uses system root CA.
+      (optional)
+  cert_file:
+    kind: string
+    doc: |
+      Path to the TLS cert to use for TLS required connections. (optional)
+  compression:
+    kind: string
+    doc: |
+      The compression key for supported compression types within
+      collector. Currently the only supported mode is `gzip`.
+  endpoint:
+    kind: string
+    doc: |
+      The target to which the exporter is going to send traces or metrics,
+      using the gRPC protocol. The valid syntax is described at
+      https://github.com/grpc/grpc/blob/master/doc/naming.md.
+  headers:
+    type: map[string]string
+    kind: map
+    doc: |
+      The headers associated with gRPC requests.
+  insecure:
     kind: bool
-    default: true
+    default: false
     doc: |
-      Enabled indicates whether to not enqueue batches before sending to the consumerSender.
-  - name: num_consumers
+      In gRPC when set to true, this is used to disable the client transport security.
+      See https://godoc.org/google.golang.org/grpc#WithInsecure.
+      In HTTP, this disables verifying the server's certificate chain and host name
+      (InsecureSkipVerify in the tls Config). Please refer to
+      https://godoc.org/crypto/tls#Config for more information.
+      (optional, default false)
+      TODO(ccaraman): With further research InsecureSkipVerify is a valid option
+      for gRPC connections. Add that ability to the TLSClientSettings in a subsequent
+      pr.
+  keepalive:
+    type: '*configgrpc.KeepaliveClientConfig'
+    kind: ptr
+    doc: |
+      The keepalive parameters for gRPC client. See grpc.WithKeepaliveParams
+      (https://godoc.org/google.golang.org/grpc#WithKeepaliveParams).
+    fields:
+      permit_without_stream:
+        kind: bool
+        default: false
+        meta: omitempty
+      time:
+        type: time.Duration
+        kind: int64
+        meta: omitempty
+      timeout:
+        type: time.Duration
+        kind: int64
+        meta: omitempty
+  key_file:
+    kind: string
+    doc: |
+      Path to the TLS key to use for TLS required connections. (optional)
+  per_rpc_auth:
+    type: '*configgrpc.PerRPCAuthConfig'
+    kind: ptr
+    doc: |
+      PerRPCAuth parameter configures the client to send authentication data on a per-RPC basis.
+    fields:
+      bearer_token:
+        kind: string
+        doc: |
+          BearerToken specifies the bearer token to use for every RPC.
+        meta: omitempty
+      type:
+        kind: string
+        doc: |
+          AuthType represents the authentication type to use. Currently, only 'bearer' is supported.
+        meta: omitempty
+  read_buffer_size:
     kind: int
-    default: 10
     doc: |
-      NumConsumers is the number of consumers from the queue.
-  - name: queue_size
-    kind: int
-    default: 5000
+      ReadBufferSize for gRPC client. See grpc.WithReadBufferSize
+      (https://godoc.org/google.golang.org/grpc#WithReadBufferSize).
+  retry_on_failure:
+    type: exporterhelper.RetrySettings
+    kind: struct
+    fields:
+      enabled:
+        kind: bool
+        default: true
+        doc: |
+          Enabled indicates whether to not retry sending batches in case of export failure.
+      initial_interval:
+        type: time.Duration
+        kind: int64
+        default: 5s
+        doc: |
+          InitialInterval the time to wait after the first failure before retrying.
+      max_elapsed_time:
+        type: time.Duration
+        kind: int64
+        default: 5m0s
+        doc: |
+          MaxElapsedTime is the maximum amount of time (including retries) spent trying to send a request/batch.
+          Once this value is reached, the data is discarded.
+      max_interval:
+        type: time.Duration
+        kind: int64
+        default: 30s
+        doc: |
+          MaxInterval is the upper bound on backoff interval. Once this value is reached the delay between
+          consecutive retries will always be `MaxInterval`.
+  sending_queue:
+    type: exporterhelper.QueueSettings
+    kind: struct
+    fields:
+      enabled:
+        kind: bool
+        default: true
+        doc: |
+          Enabled indicates whether to not enqueue batches before sending to the consumerSender.
+      num_consumers:
+        kind: int
+        default: 10
+        doc: |
+          NumConsumers is the number of consumers from the queue.
+      queue_size:
+        kind: int
+        default: 5000
+        doc: |
+          QueueSize is the maximum number of batches allowed in queue at a given time.
+  server_name_override:
+    kind: string
     doc: |
-      QueueSize is the maximum number of batches allowed in queue at a given time.
-- name: retry_on_failure
-  type: exporterhelper.RetrySettings
-  kind: struct
-  fields:
-  - name: enabled
-    kind: bool
-    default: true
-    doc: |
-      Enabled indicates whether to not retry sending batches in case of export failure.
-  - name: initial_interval
+      ServerName requested by client for virtual hosting.
+      This sets the ServerName in the TLSConfig. Please refer to
+      https://godoc.org/crypto/tls#Config for more information. (optional)
+  timeout:
     type: time.Duration
     kind: int64
     default: 5s
     doc: |
-      InitialInterval the time to wait after the first failure before retrying.
-  - name: max_interval
-    type: time.Duration
-    kind: int64
-    default: 30s
-    doc: |
-      MaxInterval is the upper bound on backoff interval. Once this value is reached the delay between
-      consecutive retries will always be `MaxInterval`.
-  - name: max_elapsed_time
-    type: time.Duration
-    kind: int64
-    default: 5m0s
-    doc: |
-      MaxElapsedTime is the maximum amount of time (including retries) spent trying to send a request/batch.
-      Once this value is reached, the data is discarded.
-- name: endpoint
-  kind: string
-  doc: |
-    The target to which the exporter is going to send traces or metrics,
-    using the gRPC protocol. The valid syntax is described at
-    https://github.com/grpc/grpc/blob/master/doc/naming.md.
-- name: compression
-  kind: string
-  doc: |
-    The compression key for supported compression types within
-    collector. Currently the only supported mode is `gzip`.
-- name: ca_file
-  kind: string
-  doc: |
-    Path to the CA cert. For a client this verifies the server certificate.
-    For a server this verifies client certificates. If empty uses system root CA.
-    (optional)
-- name: cert_file
-  kind: string
-  doc: |
-    Path to the TLS cert to use for TLS required connections. (optional)
-- name: key_file
-  kind: string
-  doc: |
-    Path to the TLS key to use for TLS required connections. (optional)
-- name: insecure
-  kind: bool
-  default: false
-  doc: |
-    In gRPC when set to true, this is used to disable the client transport security.
-    See https://godoc.org/google.golang.org/grpc#WithInsecure.
-    In HTTP, this disables verifying the server's certificate chain and host name
-    (InsecureSkipVerify in the tls Config). Please refer to
-    https://godoc.org/crypto/tls#Config for more information.
-    (optional, default false)
-    TODO(ccaraman): With further research InsecureSkipVerify is a valid option
-    for gRPC connections. Add that ability to the TLSClientSettings in a subsequent
-    pr.
-- name: server_name_override
-  kind: string
-  doc: |
-    ServerName requested by client for virtual hosting.
-    This sets the ServerName in the TLSConfig. Please refer to
-    https://godoc.org/crypto/tls#Config for more information. (optional)
-- name: keepalive
-  type: '*configgrpc.KeepaliveClientConfig'
-  kind: ptr
-  doc: |
-    The keepalive parameters for gRPC client. See grpc.WithKeepaliveParams
-    (https://godoc.org/google.golang.org/grpc#WithKeepaliveParams).
-  fields:
-  - name: time
-    type: time.Duration
-    kind: int64
-    meta: omitempty
-  - name: timeout
-    type: time.Duration
-    kind: int64
-    meta: omitempty
-  - name: permit_without_stream
+      Timeout is the timeout for every attempt to send data to the backend.
+  wait_for_ready:
     kind: bool
     default: false
-    meta: omitempty
-- name: read_buffer_size
-  kind: int
-  doc: |
-    ReadBufferSize for gRPC client. See grpc.WithReadBufferSize
-    (https://godoc.org/google.golang.org/grpc#WithReadBufferSize).
-- name: write_buffer_size
-  kind: int
-  default: 524288
-  doc: |
-    WriteBufferSize for gRPC gRPC. See grpc.WithWriteBufferSize
-    (https://godoc.org/google.golang.org/grpc#WithWriteBufferSize).
-- name: wait_for_ready
-  kind: bool
-  default: false
-  doc: |
-    WaitForReady parameter configures client to wait for ready state before sending data.
-    (https://github.com/grpc/grpc/blob/master/doc/wait-for-ready.md)
-- name: headers
-  type: map[string]string
-  kind: map
-  doc: |
-    The headers associated with gRPC requests.
-- name: per_rpc_auth
-  type: '*configgrpc.PerRPCAuthConfig'
-  kind: ptr
-  doc: |
-    PerRPCAuth parameter configures the client to send authentication data on a per-RPC basis.
-  fields:
-  - name: type
-    kind: string
     doc: |
-      AuthType represents the authentication type to use. Currently, only 'bearer' is supported.
-    meta: omitempty
-  - name: bearer_token
-    kind: string
+      WaitForReady parameter configures client to wait for ready state before sending data.
+      (https://github.com/grpc/grpc/blob/master/doc/wait-for-ready.md)
+  write_buffer_size:
+    kind: int
+    default: 524288
     doc: |
-      BearerToken specifies the bearer token to use for every RPC.
-    meta: omitempty
-- name: balancer_name
-  kind: string
-  doc: |
-    Sets the balancer in grpclb_policy to discover the servers. Default is pick_first
-    https://github.com/grpc/grpc-go/blob/master/examples/features/load_balancing/README.md
+      WriteBufferSize for gRPC gRPC. See grpc.WithWriteBufferSize
+      (https://godoc.org/google.golang.org/grpc#WithWriteBufferSize).


### PR DESCRIPTION
POC/Proposal for exposing configuration schemas

Issue: https://github.com/open-telemetry/opentelemetry-collector/issues/1995

This change proposes a way to generate metadata for the configuration structs
used by Collector components. The generated metadata could be used for
documentation and tooling.

The way it works is, given a component, its configuration struct is found, and
its field names, types, tags, default values, and comments are retrieved and
put into a struct. This is done recursively, but respecting "squashed" fields,
and any fields omitted with a "-" tag. The final struct is marshaled to a yaml
file in the directory of the configuration type.

Also included are a simple command line interface and an example metadata
file. The CLI lets users create a metadata file for either a given component or
for all registered components.

Tests have not been included as this change is meant to be exploratory.