### PR TITLE
Add --log-format command line option (default to "console")

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Remove legacy metrics, they were marked as legacy for ~12 months #2105
 
+## 💡 Enhancements 💡
+
+- Add --log-format command line option (default to "console") #2177.
+
 ## v0.14.0 Beta
 
 ## 🚀 New components 🚀

--- a/service/logger.go
+++ b/service/logger.go
@@ -26,17 +26,22 @@ import (
 const (
 	logLevelCfg   = "log-level"
 	logProfileCfg = "log-profile"
+	logFormatCfg  = "log-format"
 )
 
 var (
 	// Command line pointer to logger level flag configuration.
 	loggerLevelPtr   *string
 	loggerProfilePtr *string
+	loggerFormatPtr  *string
 )
 
 func loggerFlags(flags *flag.FlagSet) {
 	loggerLevelPtr = flags.String(logLevelCfg, "INFO", "Output level of logs (DEBUG, INFO, WARN, ERROR, DPANIC, PANIC, FATAL)")
 	loggerProfilePtr = flags.String(logProfileCfg, "", "Logging profile to use (dev, prod)")
+
+	// Note: we use "console" by default for more human-friendly mode of logging (tab delimited, formatted timestamps).
+	loggerFormatPtr = flags.String(logFormatCfg, "console", "Format of logs to use (json, console)")
 }
 
 func newLogger(options []zap.Option) (*zap.Logger, error) {
@@ -61,9 +66,11 @@ func newLogger(options []zap.Option) (*zap.Logger, error) {
 		}
 	}
 
-	// Use more human-friendly mode of logging (tab delimited, formatted timestamps).
-	conf.Encoding = "console"
-	conf.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
+	conf.Encoding = *loggerFormatPtr
+	if conf.Encoding == "console" {
+		// Human-readable timestamps for console format of logs.
+		conf.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
+	}
 
 	conf.Level.SetLevel(level)
 	return conf.Build(options...)


### PR DESCRIPTION
Contributes to https://github.com/open-telemetry/opentelemetry-collector/issues/2102
