### PR TITLE
Add a struct for exporter obs report instead of using package level funcs

### DIFF
--- a/exporter/exporterhelper/logshelper.go
+++ b/exporter/exporterhelper/logshelper.go
@@ -21,6 +21,7 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configmodels"
+	"go.opentelemetry.io/collector/config/configtelemetry"
 	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/obsreport"
@@ -89,8 +90,8 @@ func NewLogsExporter(
 	be := newBaseExporter(cfg, logger, options...)
 	be.wrapConsumerSender(func(nextSender requestSender) requestSender {
 		return &logsExporterWithObservability{
-			exporterName: cfg.Name(),
-			nextSender:   nextSender,
+			obsrep:     obsreport.NewExporterObsReport(configtelemetry.GetMetricsLevelFlagValue(), cfg.Name()),
+			nextSender: nextSender,
 		}
 	})
 
@@ -101,13 +102,13 @@ func NewLogsExporter(
 }
 
 type logsExporterWithObservability struct {
-	exporterName string
-	nextSender   requestSender
+	obsrep     *obsreport.ExporterObsReport
+	nextSender requestSender
 }
 
 func (lewo *logsExporterWithObservability) send(req request) (int, error) {
-	req.setContext(obsreport.StartLogsExportOp(req.context(), lewo.exporterName))
+	req.setContext(lewo.obsrep.StartLogsExportOp(req.context()))
 	numDroppedLogs, err := lewo.nextSender.send(req)
-	obsreport.EndLogsExportOp(req.context(), req.count(), err)
+	lewo.obsrep.EndLogsExportOp(req.context(), req.count(), err)
 	return numDroppedLogs, err
 }

--- a/exporter/exporterhelper/tracehelper.go
+++ b/exporter/exporterhelper/tracehelper.go
@@ -21,6 +21,7 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configmodels"
+	"go.opentelemetry.io/collector/config/configtelemetry"
 	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/obsreport"
@@ -91,8 +92,8 @@ func NewTraceExporter(
 	be := newBaseExporter(cfg, logger, options...)
 	be.wrapConsumerSender(func(nextSender requestSender) requestSender {
 		return &tracesExporterWithObservability{
-			exporterName: cfg.Name(),
-			nextSender:   nextSender,
+			obsrep:     obsreport.NewExporterObsReport(configtelemetry.GetMetricsLevelFlagValue(), cfg.Name()),
+			nextSender: nextSender,
 		}
 	})
 
@@ -103,18 +104,18 @@ func NewTraceExporter(
 }
 
 type tracesExporterWithObservability struct {
-	exporterName string
-	nextSender   requestSender
+	obsrep     *obsreport.ExporterObsReport
+	nextSender requestSender
 }
 
 func (tewo *tracesExporterWithObservability) send(req request) (int, error) {
-	req.setContext(obsreport.StartTraceDataExportOp(req.context(), tewo.exporterName))
+	req.setContext(tewo.obsrep.StartTracesExportOp(req.context()))
 	// Forward the data to the next consumer (this pusher is the next).
 	droppedSpans, err := tewo.nextSender.send(req)
 
 	// TODO: this is not ideal: it should come from the next function itself.
 	// 	temporarily loading it from internal format. Once full switch is done
 	// 	to new metrics will remove this.
-	obsreport.EndTraceDataExportOp(req.context(), req.count(), err)
+	tewo.obsrep.EndTracesExportOp(req.context(), req.count(), err)
 	return droppedSpans, err
 }

--- a/obsreport/obsreport_test.go
+++ b/obsreport/obsreport_test.go
@@ -339,12 +339,13 @@ func TestExportTraceDataOp(t *testing.T) {
 	defer parentSpan.End()
 
 	exporterCtx := obsreport.ExporterContext(parentCtx, exporter)
+	obsrep := obsreport.NewExporterObsReport(configtelemetry.LevelNormal, exporter)
 	errs := []error{nil, errFake}
 	numExportedSpans := []int{22, 14}
 	for i, err := range errs {
-		ctx := obsreport.StartTraceDataExportOp(exporterCtx, exporter)
+		ctx := obsrep.StartTracesExportOp(exporterCtx)
 		assert.NotNil(t, ctx)
-		obsreport.EndTraceDataExportOp(ctx, numExportedSpans[i], err)
+		obsrep.EndTracesExportOp(ctx, numExportedSpans[i], err)
 	}
 
 	spans := ss.PullAllSpans()
@@ -352,7 +353,7 @@ func TestExportTraceDataOp(t *testing.T) {
 
 	var sentSpans, failedToSendSpans int
 	for i, span := range spans {
-		assert.Equal(t, "exporter/"+exporter+"/TraceDataExported", span.Name)
+		assert.Equal(t, "exporter/"+exporter+"/traces", span.Name)
 		switch errs[i] {
 		case nil:
 			sentSpans += numExportedSpans[i]
@@ -386,41 +387,90 @@ func TestExportMetricsOp(t *testing.T) {
 	defer parentSpan.End()
 
 	exporterCtx := obsreport.ExporterContext(parentCtx, exporter)
+	obsrep := obsreport.NewExporterObsReport(configtelemetry.LevelNormal, exporter)
+
 	errs := []error{nil, errFake}
-	toSendMetricPts := []int{17, 23}
+	toSendMetricPoints := []int{17, 23}
 	for i, err := range errs {
-		ctx := obsreport.StartMetricsExportOp(exporterCtx, exporter)
+		ctx := obsrep.StartMetricsExportOp(exporterCtx)
 		assert.NotNil(t, ctx)
 
-		obsreport.EndMetricsExportOp(
-			ctx,
-			toSendMetricPts[i],
-			err)
+		obsrep.EndMetricsExportOp(ctx, toSendMetricPoints[i], err)
 	}
 
 	spans := ss.PullAllSpans()
 	require.Equal(t, len(errs), len(spans))
 
-	var sentPoints, failedToSendPoints int
+	var sentMetricPoints, failedToSendMetricPoints int
 	for i, span := range spans {
-		assert.Equal(t, "exporter/"+exporter+"/MetricsExported", span.Name)
+		assert.Equal(t, "exporter/"+exporter+"/metrics", span.Name)
 		switch errs[i] {
 		case nil:
-			sentPoints += toSendMetricPts[i]
-			assert.Equal(t, int64(toSendMetricPts[i]), span.Attributes[obsreport.SentMetricPointsKey])
+			sentMetricPoints += toSendMetricPoints[i]
+			assert.Equal(t, int64(toSendMetricPoints[i]), span.Attributes[obsreport.SentMetricPointsKey])
 			assert.Equal(t, int64(0), span.Attributes[obsreport.FailedToSendMetricPointsKey])
 			assert.Equal(t, trace.Status{Code: trace.StatusCodeOK}, span.Status)
 		case errFake:
-			failedToSendPoints += toSendMetricPts[i]
+			failedToSendMetricPoints += toSendMetricPoints[i]
 			assert.Equal(t, int64(0), span.Attributes[obsreport.SentMetricPointsKey])
-			assert.Equal(t, int64(toSendMetricPts[i]), span.Attributes[obsreport.FailedToSendMetricPointsKey])
+			assert.Equal(t, int64(toSendMetricPoints[i]), span.Attributes[obsreport.FailedToSendMetricPointsKey])
 			assert.Equal(t, errs[i].Error(), span.Status.Message)
 		default:
 			t.Fatalf("unexpected error: %v", errs[i])
 		}
 	}
 
-	obsreporttest.CheckExporterMetricsViews(t, exporter, int64(sentPoints), int64(failedToSendPoints))
+	obsreporttest.CheckExporterMetricsViews(t, exporter, int64(sentMetricPoints), int64(failedToSendMetricPoints))
+}
+
+func TestExportLogsOp(t *testing.T) {
+	doneFn, err := obsreporttest.SetupRecordedMetricsTest()
+	require.NoError(t, err)
+	defer doneFn()
+
+	ss := &spanStore{}
+	trace.RegisterExporter(ss)
+	defer trace.UnregisterExporter(ss)
+
+	parentCtx, parentSpan := trace.StartSpan(context.Background(),
+		t.Name(), trace.WithSampler(trace.AlwaysSample()))
+	defer parentSpan.End()
+
+	exporterCtx := obsreport.ExporterContext(parentCtx, exporter)
+	obsrep := obsreport.NewExporterObsReport(configtelemetry.LevelNormal, exporter)
+
+	errs := []error{nil, errFake}
+	toSendLogRecords := []int{17, 23}
+	for i, err := range errs {
+		ctx := obsrep.StartLogsExportOp(exporterCtx)
+		assert.NotNil(t, ctx)
+
+		obsrep.EndLogsExportOp(ctx, toSendLogRecords[i], err)
+	}
+
+	spans := ss.PullAllSpans()
+	require.Equal(t, len(errs), len(spans))
+
+	var sentLogRecords, failedToSendLogRecords int
+	for i, span := range spans {
+		assert.Equal(t, "exporter/"+exporter+"/logs", span.Name)
+		switch errs[i] {
+		case nil:
+			sentLogRecords += toSendLogRecords[i]
+			assert.Equal(t, int64(toSendLogRecords[i]), span.Attributes[obsreport.SentLogRecordsKey])
+			assert.Equal(t, int64(0), span.Attributes[obsreport.FailedToSendLogRecordsKey])
+			assert.Equal(t, trace.Status{Code: trace.StatusCodeOK}, span.Status)
+		case errFake:
+			failedToSendLogRecords += toSendLogRecords[i]
+			assert.Equal(t, int64(0), span.Attributes[obsreport.SentLogRecordsKey])
+			assert.Equal(t, int64(toSendLogRecords[i]), span.Attributes[obsreport.FailedToSendLogRecordsKey])
+			assert.Equal(t, errs[i].Error(), span.Status.Message)
+		default:
+			t.Fatalf("unexpected error: %v", errs[i])
+		}
+	}
+
+	obsreporttest.CheckExporterLogsViews(t, exporter, int64(sentLogRecords), int64(failedToSendLogRecords))
 }
 
 func TestReceiveWithLongLivedCtx(t *testing.T) {

--- a/obsreport/obsreporttest/obsreporttest_test.go
+++ b/obsreport/obsreporttest/obsreporttest_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.opentelemetry.io/collector/config/configtelemetry"
 	"go.opentelemetry.io/collector/obsreport"
 	"go.opentelemetry.io/collector/obsreport/obsreporttest"
 )
@@ -80,11 +81,12 @@ func TestCheckExporterTracesViews(t *testing.T) {
 	require.NoError(t, err)
 	defer doneFn()
 
+	obsrep := obsreport.NewExporterObsReport(configtelemetry.LevelNormal, exporter)
 	exporterCtx := obsreport.ExporterContext(context.Background(), exporter)
-	ctx := obsreport.StartTraceDataExportOp(exporterCtx, exporter)
+	ctx := obsrep.StartTracesExportOp(exporterCtx)
 	assert.NotNil(t, ctx)
 
-	obsreport.EndTraceDataExportOp(ctx, 7, nil)
+	obsrep.EndTracesExportOp(ctx, 7, nil)
 
 	obsreporttest.CheckExporterTracesViews(t, exporter, 7, 0)
 }
@@ -94,11 +96,26 @@ func TestCheckExporterMetricsViews(t *testing.T) {
 	require.NoError(t, err)
 	defer doneFn()
 
+	obsrep := obsreport.NewExporterObsReport(configtelemetry.LevelNormal, exporter)
 	exporterCtx := obsreport.ExporterContext(context.Background(), exporter)
-	ctx := obsreport.StartMetricsExportOp(exporterCtx, exporter)
+	ctx := obsrep.StartMetricsExportOp(exporterCtx)
 	assert.NotNil(t, ctx)
 
-	obsreport.EndMetricsExportOp(ctx, 7, nil)
+	obsrep.EndMetricsExportOp(ctx, 7, nil)
 
 	obsreporttest.CheckExporterMetricsViews(t, exporter, 7, 0)
+}
+
+func TestCheckExporterLogsViews(t *testing.T) {
+	doneFn, err := obsreporttest.SetupRecordedMetricsTest()
+	require.NoError(t, err)
+	defer doneFn()
+
+	obsrep := obsreport.NewExporterObsReport(configtelemetry.LevelNormal, exporter)
+	exporterCtx := obsreport.ExporterContext(context.Background(), exporter)
+	ctx := obsrep.StartLogsExportOp(exporterCtx)
+	assert.NotNil(t, ctx)
+	obsrep.EndLogsExportOp(ctx, 7, nil)
+
+	obsreporttest.CheckExporterLogsViews(t, exporter, 7, 0)
 }


### PR DESCRIPTION
This is part of a longer effort to move all the obsreport package to use structs for every component type,
that allow configuring the level at the component level (every component instance will have it's own
obsreport struct instance).

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
