### PR TITLE
Add support to skip TLS verification

### DIFF
--- a/config/configtls/README.md
+++ b/config/configtls/README.md
@@ -27,6 +27,13 @@ A certificate authority may also need to be defined:
   certificate. For a server this verifies client certificates. If empty uses
   system root CA. Should only be used if `insecure` is set to false.
 
+Additionally you can configure TLS to be enabled but skip verifying the server's
+certificate chain. This cannot be combined with `insecure` since `insecure`
+won't use TLS at all.
+
+- `insecure_skip_verify` (default = false): whether to skip verifying the
+  certificate or not.
+
 How TLS/mTLS is configured depends on whether configuring the client or server.
 See below for examples.
 
@@ -59,6 +66,10 @@ exporters:
   otlp/insecure:
     endpoint: myserver.local:55690
     insecure: true
+  otlp/secure_no_verify:
+    endpoint: myserver.local:55690
+    insecure: false
+    insecure_skip_verify: true
 ```
 
 ## Server Configuration

--- a/config/configtls/configtls.go
+++ b/config/configtls/configtls.go
@@ -50,10 +50,9 @@ type TLSClientSetting struct {
 	// (InsecureSkipVerify in the tls Config). Please refer to
 	// https://godoc.org/crypto/tls#Config for more information.
 	// (optional, default false)
-	// TODO(ccaraman): With further research InsecureSkipVerify is a valid option
-	// for gRPC connections. Add that ability to the TLSClientSettings in a subsequent
-	// pr.
 	Insecure bool `mapstructure:"insecure"`
+	// InsecureSkipVerify will enable TLS but not verify the certificate.
+	InsecureSkipVerify bool `mapstructure:"insecure_skip_verify"`
 	// ServerName requested by client for virtual hosting.
 	// This sets the ServerName in the TLSConfig. Please refer to
 	// https://godoc.org/crypto/tls#Config for more information. (optional)
@@ -131,6 +130,7 @@ func (c TLSClientSetting) LoadTLSConfig() (*tls.Config, error) {
 		return nil, fmt.Errorf("failed to load TLS config: %w", err)
 	}
 	tlsCfg.ServerName = c.ServerName
+	tlsCfg.InsecureSkipVerify = c.InsecureSkipVerify
 	return tlsCfg, nil
 }
 

--- a/config/configtls/configtls_test.go
+++ b/config/configtls/configtls_test.go
@@ -146,6 +146,14 @@ func TestLoadTLSClientConfig(t *testing.T) {
 	tlsCfg, err = tlsSetting.LoadTLSConfig()
 	assert.NoError(t, err)
 	assert.NotNil(t, tlsCfg)
+
+	tlsSetting = TLSClientSetting{
+		InsecureSkipVerify: true,
+	}
+	tlsCfg, err = tlsSetting.LoadTLSConfig()
+	assert.NoError(t, err)
+	assert.NotNil(t, tlsCfg)
+	assert.True(t, tlsCfg.InsecureSkipVerify)
 }
 
 func TestLoadTLSServerConfigError(t *testing.T) {


### PR DESCRIPTION
Follow up from #933 where InsecureSkipVerify was discussed but not
implemented.

**Description:** Add support to set `InsecureSkipVerify` to `tls.Config`. This will use a secure connection which `Insecure` does not, however it will not verify the certificate.

**Link to tracking Issue:** No issue but followup on #933.

**Testing:** Added test for the configuration to ensure settings were properly set.

**Documentation:** Updated `configtls` README with example.

/cc @ccaraman