### PR TITLE
Rename Push functions to be consistent across signals in exporterhelper

### DIFF
--- a/exporter/exporterhelper/constants.go
+++ b/exporter/exporterhelper/constants.go
@@ -23,10 +23,10 @@ var (
 	errNilConfig = errors.New("nil config")
 	// errNilLogger is returned when a logger is nil
 	errNilLogger = errors.New("nil logger")
-	// errNilPushTraceData is returned when a nil traceDataPusher is given.
-	errNilPushTraceData = errors.New("nil traceDataPusher")
-	// errNilPushMetricsData is returned when a nil pushMetricsData is given.
-	errNilPushMetricsData = errors.New("nil pushMetricsData")
-	// errNilPushLogsData is returned when a nil pushLogsData is given.
-	errNilPushLogsData = errors.New("nil pushLogsData")
+	// errNilPushTraceData is returned when a nil PushTraces is given.
+	errNilPushTraceData = errors.New("nil PushTraces")
+	// errNilPushMetricsData is returned when a nil PushMetrics is given.
+	errNilPushMetricsData = errors.New("nil PushMetrics")
+	// errNilPushLogsData is returned when a nil PushLogs is given.
+	errNilPushLogsData = errors.New("nil PushLogs")
 )

--- a/exporter/exporterhelper/logshelper_test.go
+++ b/exporter/exporterhelper/logshelper_test.go
@@ -163,7 +163,7 @@ func TestLogsExporter_WithShutdown_ReturnError(t *testing.T) {
 	assert.Equal(t, le.Shutdown(context.Background()), want)
 }
 
-func newPushLogsData(droppedTimeSeries int, retError error) PushLogsData {
+func newPushLogsData(droppedTimeSeries int, retError error) PushLogs {
 	return func(ctx context.Context, td pdata.Logs) (int, error) {
 		return droppedTimeSeries, retError
 	}

--- a/exporter/exporterhelper/metricshelper.go
+++ b/exporter/exporterhelper/metricshelper.go
@@ -27,17 +27,17 @@ import (
 	"go.opentelemetry.io/collector/obsreport"
 )
 
-// PushMetricsData is a helper function that is similar to ConsumeMetricsData but also returns
+// PushMetrics is a helper function that is similar to ConsumeMetrics but also returns
 // the number of dropped metrics.
-type PushMetricsData func(ctx context.Context, md pdata.Metrics) (droppedTimeSeries int, err error)
+type PushMetrics func(ctx context.Context, md pdata.Metrics) (droppedTimeSeries int, err error)
 
 type metricsRequest struct {
 	baseRequest
 	md     pdata.Metrics
-	pusher PushMetricsData
+	pusher PushMetrics
 }
 
-func newMetricsRequest(ctx context.Context, md pdata.Metrics, pusher PushMetricsData) request {
+func newMetricsRequest(ctx context.Context, md pdata.Metrics, pusher PushMetrics) request {
 	return &metricsRequest{
 		baseRequest: baseRequest{ctx: ctx},
 		md:          md,
@@ -60,7 +60,7 @@ func (req *metricsRequest) count() int {
 
 type metricsExporter struct {
 	*baseExporter
-	pusher PushMetricsData
+	pusher PushMetrics
 }
 
 func (mexp *metricsExporter) ConsumeMetrics(ctx context.Context, md pdata.Metrics) error {
@@ -77,7 +77,7 @@ func (mexp *metricsExporter) ConsumeMetrics(ctx context.Context, md pdata.Metric
 func NewMetricsExporter(
 	cfg configmodels.Exporter,
 	logger *zap.Logger,
-	pushMetricsData PushMetricsData,
+	pusher PushMetrics,
 	options ...Option,
 ) (component.MetricsExporter, error) {
 	if cfg == nil {
@@ -88,7 +88,7 @@ func NewMetricsExporter(
 		return nil, errNilLogger
 	}
 
-	if pushMetricsData == nil {
+	if pusher == nil {
 		return nil, errNilPushMetricsData
 	}
 
@@ -102,7 +102,7 @@ func NewMetricsExporter(
 
 	return &metricsExporter{
 		baseExporter: be,
-		pusher:       pushMetricsData,
+		pusher:       pusher,
 	}, nil
 }
 

--- a/exporter/exporterhelper/metricshelper_test.go
+++ b/exporter/exporterhelper/metricshelper_test.go
@@ -183,7 +183,7 @@ func TestMetricsExporter_WithShutdown_ReturnError(t *testing.T) {
 	assert.Equal(t, me.Shutdown(context.Background()), want)
 }
 
-func newPushMetricsData(droppedTimeSeries int, retError error) PushMetricsData {
+func newPushMetricsData(droppedTimeSeries int, retError error) PushMetrics {
 	return func(ctx context.Context, td pdata.Metrics) (int, error) {
 		return droppedTimeSeries, retError
 	}

--- a/exporter/exporterhelper/tracehelper.go
+++ b/exporter/exporterhelper/tracehelper.go
@@ -27,17 +27,17 @@ import (
 	"go.opentelemetry.io/collector/obsreport"
 )
 
-// traceDataPusher is a helper function that is similar to ConsumeTraceData but also
+// PushTraces is a helper function that is similar to ConsumeTraces but also
 // returns the number of dropped spans.
-type traceDataPusher func(ctx context.Context, td pdata.Traces) (droppedSpans int, err error)
+type PushTraces func(ctx context.Context, td pdata.Traces) (droppedSpans int, err error)
 
 type tracesRequest struct {
 	baseRequest
 	td     pdata.Traces
-	pusher traceDataPusher
+	pusher PushTraces
 }
 
-func newTracesRequest(ctx context.Context, td pdata.Traces, pusher traceDataPusher) request {
+func newTracesRequest(ctx context.Context, td pdata.Traces, pusher PushTraces) request {
 	return &tracesRequest{
 		baseRequest: baseRequest{ctx: ctx},
 		td:          td,
@@ -59,7 +59,7 @@ func (req *tracesRequest) count() int {
 
 type traceExporter struct {
 	*baseExporter
-	pusher traceDataPusher
+	pusher PushTraces
 }
 
 func (texp *traceExporter) ConsumeTraces(ctx context.Context, td pdata.Traces) error {
@@ -73,7 +73,7 @@ func (texp *traceExporter) ConsumeTraces(ctx context.Context, td pdata.Traces) e
 func NewTraceExporter(
 	cfg configmodels.Exporter,
 	logger *zap.Logger,
-	dataPusher traceDataPusher,
+	pusher PushTraces,
 	options ...Option,
 ) (component.TracesExporter, error) {
 
@@ -85,7 +85,7 @@ func NewTraceExporter(
 		return nil, errNilLogger
 	}
 
-	if dataPusher == nil {
+	if pusher == nil {
 		return nil, errNilPushTraceData
 	}
 
@@ -99,7 +99,7 @@ func NewTraceExporter(
 
 	return &traceExporter{
 		baseExporter: be,
-		pusher:       dataPusher,
+		pusher:       pusher,
 	}, nil
 }
 

--- a/exporter/exporterhelper/tracehelper_test.go
+++ b/exporter/exporterhelper/tracehelper_test.go
@@ -177,7 +177,7 @@ func TestTraceExporter_WithShutdown_ReturnError(t *testing.T) {
 	assert.Equal(t, te.Shutdown(context.Background()), want)
 }
 
-func newTraceDataPusher(droppedSpans int, retError error) traceDataPusher {
+func newTraceDataPusher(droppedSpans int, retError error) PushTraces {
 	return func(ctx context.Context, td pdata.Traces) (int, error) {
 		return droppedSpans, retError
 	}


### PR DESCRIPTION
Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>

