### PR TITLE
Remove calls to InitEmpty when not necessary, remove AttributeValue.InitEmpty

### DIFF
--- a/cmd/pdatagen/internal/base_slices.go
+++ b/cmd/pdatagen/internal/base_slices.go
@@ -381,7 +381,6 @@ const sliceValueTestTemplate = `func Test${structName}(t *testing.T) {
 
 	es.Resize(7)
 	emptyVal := New${elementName}()
-	emptyVal.InitEmpty()
 	testVal := generateTest${elementName}()
 	assert.EqualValues(t, 7, es.Len())
 	for i := 0; i < es.Len(); i++ {
@@ -434,7 +433,6 @@ func Test${structName}_CopyTo(t *testing.T) {
 func Test${structName}_Resize(t *testing.T) {
 	es := generateTest${structName}()
 	emptyVal := New${elementName}()
-	emptyVal.InitEmpty()
 	// Test Resize less elements.
 	const resizeSmallLen = 4
 	expectedEs := make(map[*${originName}]bool, resizeSmallLen)
@@ -477,13 +475,11 @@ func Test${structName}_Resize(t *testing.T) {
 func Test${structName}_Append(t *testing.T) {
 	es := generateTest${structName}()
 	emptyVal := New${elementName}()
-	emptyVal.InitEmpty()
 
 	es.Append(emptyVal)
 	assert.EqualValues(t, *(es.At(7)).orig, *emptyVal.orig)
 
 	emptyVal2 := New${elementName}()
-	emptyVal2.InitEmpty()
 
 	es.Append(emptyVal2)
 	assert.EqualValues(t, *(es.At(8)).orig, *emptyVal2.orig)

--- a/consumer/pdata/common.go
+++ b/consumer/pdata/common.go
@@ -136,10 +136,6 @@ func NewAttributeValueArray() AttributeValue {
 	return AttributeValue{orig: orig}
 }
 
-func (a AttributeValue) InitEmpty() {
-	*a.orig = otlpcommon.AnyValue{}
-}
-
 // Type returns the type of the value for this AttributeValue.
 // Calling this function on zero-initialized AttributeValue will cause a panic.
 func (a AttributeValue) Type() AttributeValueType {

--- a/consumer/pdata/generated_common_test.go
+++ b/consumer/pdata/generated_common_test.go
@@ -57,7 +57,6 @@ func TestAnyValueArray(t *testing.T) {
 
 	es.Resize(7)
 	emptyVal := NewAttributeValue()
-	emptyVal.InitEmpty()
 	testVal := generateTestAttributeValue()
 	assert.EqualValues(t, 7, es.Len())
 	for i := 0; i < es.Len(); i++ {
@@ -110,7 +109,6 @@ func TestAnyValueArray_CopyTo(t *testing.T) {
 func TestAnyValueArray_Resize(t *testing.T) {
 	es := generateTestAnyValueArray()
 	emptyVal := NewAttributeValue()
-	emptyVal.InitEmpty()
 	// Test Resize less elements.
 	const resizeSmallLen = 4
 	expectedEs := make(map[*otlpcommon.AnyValue]bool, resizeSmallLen)
@@ -153,13 +151,11 @@ func TestAnyValueArray_Resize(t *testing.T) {
 func TestAnyValueArray_Append(t *testing.T) {
 	es := generateTestAnyValueArray()
 	emptyVal := NewAttributeValue()
-	emptyVal.InitEmpty()
 
 	es.Append(emptyVal)
 	assert.EqualValues(t, *(es.At(7)).orig, *emptyVal.orig)
 
 	emptyVal2 := NewAttributeValue()
-	emptyVal2.InitEmpty()
 
 	es.Append(emptyVal2)
 	assert.EqualValues(t, *(es.At(8)).orig, *emptyVal2.orig)

--- a/receiver/fluentforwardreceiver/conversion.go
+++ b/receiver/fluentforwardreceiver/conversion.go
@@ -176,7 +176,6 @@ func (melr *MessageEventLogRecord) LogRecords() pdata.LogSlice {
 func (melr *MessageEventLogRecord) DecodeMsg(dc *msgp.Reader) error {
 	melr.LogSlice = pdata.NewLogSlice()
 	melr.LogSlice.Resize(1)
-	melr.LogSlice.At(0).Body().InitEmpty()
 
 	var arrLen uint32
 	var err error
@@ -276,7 +275,6 @@ func (fe *ForwardEventLogRecords) DecodeMsg(dc *msgp.Reader) (err error) {
 	fe.LogSlice.Resize(int(entryLen))
 	for i := 0; i < int(entryLen); i++ {
 		lr := fe.LogSlice.At(i)
-		lr.Body().InitEmpty()
 
 		err = parseEntryToLogRecord(dc, lr)
 		if err != nil {
@@ -400,7 +398,6 @@ func (pfe *PackedForwardEventLogRecords) parseEntries(entriesRaw []byte, isGzipp
 	for {
 		lr := pdata.NewLogRecord()
 		lr.InitEmpty()
-		lr.Body().InitEmpty()
 
 		err := parseEntryToLogRecord(msgpReader, lr)
 		if err != nil {


### PR DESCRIPTION
Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
