### PR TITLE
Fix make misspell hanging on internal/tools

### DIFF
--- a/Makefile.Common
+++ b/Makefile.Common
@@ -79,11 +79,15 @@ lint: lint-static-check
 
 .PHONY: misspell
 misspell:
+ifdef ALL_DOC
 	$(MISSPELL) $(ALL_DOC)
+endif
 
 .PHONY: misspell-correction
 misspell-correction:
+ifdef ALL_DOC
 	$(MISSPELL_CORRECTION) $(ALL_DOC)
+endif
 
 .PHONY: impi
 impi:


### PR DESCRIPTION
**Description:**

When running `make` to run tests, the `misspell` target is run on the `internal/tools` directory (since https://github.com/open-telemetry/opentelemetry-collector/pull/2131).
As there are no `.md` nor `.yaml` files in this directory, the `ALL_DOC` variable (defined as `ALL_DOC := $(shell find . \( -name "*.md" -o -name "*.yaml" \) -type f | sort`) is empty.
Therefore, the `misspell` target runs `misspell -error` without any argument, causing `misspell` to read `stdin`, hanging. The only way to make `make` not hang is to send `EOF` (eg. with `echo -n | make`).

I suspect that this doesn't affect the CI as it automatically sends `EOF` to stdin.

This PR fixes makes the `misspell -error` by making the `misspell` command conditionally run, only if `ALL_DOC` is defined and not empty.

**Link to tracking Issue:** n/a

**Testing:** Run `make` before and after the fix. Check that the `misspell` step doesn't hang after the fix.

**Documentation:** n/a
