### PR TITLE
Remove outdated line from documentation

### DIFF
--- a/processor/README.md
+++ b/processor/README.md
@@ -208,7 +208,6 @@ are checked before the `exclude` properties.
 
       # Attributes specifies the list of attributes to match against.
       # All of these attributes must match exactly for a match to occur.
-      # Only match_type=strict is allowed if "attributes" are specified.
       # This is an optional field.
       attributes:
           # Key specifies the attribute to match against.


### PR DESCRIPTION
**Description:**

Documentation for processors states:

> Only match_type=strict is allowed if "attributes" are specified.

but this restriction was removed in https://github.com/open-telemetry/opentelemetry-collector/pull/928/files#diff-4548db28578c2ac90e2b277f24654cfa24fd0f99d854e0fcc4b50871c0b529caL166-R198, and so this doc appears to be outdated.

**Testing:**

I did not test this, but others (including @tigrannajaryan) have: https://github.com/open-telemetry/opentelemetry-collector/issues/1935#issuecomment-717259673

[btw, in case you're curious my interest in this, we are implementing a subset of this behavior at the java agent layer, as we aren't using otel collector. So far only in our vendor distro, though happy to move it to otel javaagent if/when others are interested.]