### PR TITLE
Add retry to getAvailablePort to avoid spordic CI failure on windows

### DIFF
--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -80,6 +80,11 @@ func GetAvailableLocalAddress(t *testing.T) string {
 // available for opening when this function returns provided that there is no
 // race by some other code to grab the same port immediately.
 func GetAvailablePort(t *testing.T) uint16 {
+	// Retry has been added for windows as net.Listen can return a port that is not actually available. Details can be
+	// found in https://github.com/docker/for-win/issues/3171 but to summarize Hyper-V will reserve ranges of ports
+	// which do not show up under the "netstat -ano" but can only be found by
+	// "netsh interface ipv4 show excludedportrange protocol=tcp".  We'll use []exclusions to hold those ranges and
+	// retry if the port returned by GetAvailableLocalAddress falls in one of those them.
 	var exclusions []portpair
 	portFound := false
 	var port string

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -23,6 +23,8 @@ import (
 	"io/ioutil"
 	"net"
 	"os"
+	"os/exec"
+	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -30,6 +32,11 @@ import (
 
 	"github.com/stretchr/testify/require"
 )
+
+type portpair struct {
+	first string
+	last  string
+}
 
 // GenerateNormalizedJSON generates a normalized JSON from the string
 // given to the function. Useful to compare JSON contents that
@@ -73,14 +80,62 @@ func GetAvailableLocalAddress(t *testing.T) string {
 // available for opening when this function returns provided that there is no
 // race by some other code to grab the same port immediately.
 func GetAvailablePort(t *testing.T) uint16 {
-	endpoint := GetAvailableLocalAddress(t)
-	_, port, err := net.SplitHostPort(endpoint)
-	require.NoError(t, err)
+	var exclusions []portpair
+	portFound := false
+	var port string
+	var err error
+	if runtime.GOOS == "windows" {
+		exclusions = getExclusionsList(t)
+	}
+
+	for !portFound {
+		endpoint := GetAvailableLocalAddress(t)
+		_, port, err = net.SplitHostPort(endpoint)
+		require.NoError(t, err)
+		portFound = true
+		if runtime.GOOS == "windows" {
+			for _, pair := range exclusions {
+				if port >= pair.first && port <= pair.last {
+					portFound = false
+					break
+				}
+			}
+		}
+	}
 
 	portInt, err := strconv.Atoi(port)
 	require.NoError(t, err)
 
 	return uint16(portInt)
+}
+
+// Get excluded ports on Windows from the command: netsh interface ipv4 show excludedportrange protocol=tcp
+func getExclusionsList(t *testing.T) []portpair {
+	cmd := exec.Command("netsh", "interface", "ipv4", "show", "excludedportrange", "protocol=tcp")
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err)
+
+	exclusions := createExclusionsList(string(output), t)
+	return exclusions
+}
+
+func createExclusionsList(exclusionsText string, t *testing.T) []portpair {
+	exclusions := []portpair{}
+
+	parts := strings.Split(exclusionsText, "--------")
+	require.Equal(t, len(parts), 3)
+	portsText := strings.Split(parts[2], "*")
+	require.Equal(t, len(portsText), 2)
+	lines := strings.Split(portsText[0], "\n")
+	for _, line := range lines {
+		if strings.TrimSpace(line) != "" {
+			entries := strings.Fields(strings.TrimSpace(line))
+			require.Equal(t, len(entries), 2)
+			pair := portpair{entries[0], entries[1]}
+			exclusions = append(exclusions, pair)
+		}
+	}
+	return exclusions
 }
 
 // WaitForPort repeatedly attempts to open a local port until it either succeeds or 5 seconds pass

--- a/testutil/testutil_test.go
+++ b/testutil/testutil_test.go
@@ -63,3 +63,30 @@ func testEndpointAvailable(t *testing.T, endpoint string) {
 	require.Error(t, err)
 	require.Nil(t, ln1)
 }
+
+func TestCreateExclusionsList(t *testing.T) {
+	// Test two examples of typical output from "netsh interface ipv4 show excludedportrange protocol=tcp"
+	emptyExclusionsText := `
+
+Protocol tcp Port Exclusion Ranges
+
+Start Port    End Port      
+----------    --------      
+
+* - Administered port exclusions.`
+
+	exclusionsText := `
+
+Start Port    End Port
+----------    --------
+     49697       49796
+     49797       49896
+
+* - Administered port exclusions.
+`
+	exclusions := createExclusionsList(exclusionsText, t)
+	require.Equal(t, len(exclusions), 2)
+
+	emptyExclusions := createExclusionsList(emptyExclusionsText, t)
+	require.Equal(t, len(emptyExclusions), 0)
+}


### PR DESCRIPTION

Signed-off-by: Kevin Earls <kearls@redhat.com>

**Description:** Add a retry mechanism when finding ports for tests on windows, as net.Listen will occasionally return a port that is actually not available.   Details are available here https://github.com/docker/for-win/issues/3171, but to summarize Hyper-V will reserve ranges of ports which do not show up under the "netstat -ano" command but can only be found by "netsh interface ipv4 show excludedportrange protocol=tcp"

This PR updates the testutil/GetAvailablePort function so when run on windows it will get the excludedportranges from the netsh command and retry if GetAvailableLocalAddress returns a port within those ranges

**Link to tracking Issue:** #2111 NOTE: there are several failures referred to in that issue which were not caused by this.  This PR only fixes the jaeger_agent_test failures.

**Testing:** As this is an intermittent error is it difficult to confirm.  However I did run some standalone tests where I added ranges to the list of excluded ports and from that was able to confirm the retry mechanism worked.




