### PR TITLE
make logLevel ENV case-insensitive

### DIFF
--- a/exporter/loggingexporter/logging_exporter.go
+++ b/exporter/loggingexporter/logging_exporter.go
@@ -395,7 +395,7 @@ func (s *loggingExporter) pushMetricsData(
 // received data and logs debugging messages.
 func newTraceExporter(config configmodels.Exporter, level string, logger *zap.Logger) (component.TracesExporter, error) {
 	s := &loggingExporter{
-		debug:  level == "debug",
+		debug:  strings.ToLower(level) == "debug",
 		logger: logger,
 	}
 
@@ -415,7 +415,7 @@ func newTraceExporter(config configmodels.Exporter, level string, logger *zap.Lo
 // received data and logs debugging messages.
 func newMetricsExporter(config configmodels.Exporter, level string, logger *zap.Logger) (component.MetricsExporter, error) {
 	s := &loggingExporter{
-		debug:  level == "debug",
+		debug:  strings.ToLower(level) == "debug",
 		logger: logger,
 	}
 
@@ -435,7 +435,7 @@ func newMetricsExporter(config configmodels.Exporter, level string, logger *zap.
 // received data and logs debugging messages.
 func newLogsExporter(config configmodels.Exporter, level string, logger *zap.Logger) (component.LogsExporter, error) {
 	s := &loggingExporter{
-		debug:  level == "debug",
+		debug:  strings.ToLower(level) == "debug",
 		logger: logger,
 	}
 

--- a/exporter/loggingexporter/logging_exporter_test.go
+++ b/exporter/loggingexporter/logging_exporter_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func TestLoggingTraceExporterNoErrors(t *testing.T) {
-	lte, err := newTraceExporter(&configmodels.ExporterSettings{}, "debug", zap.NewNop())
+	lte, err := newTraceExporter(&configmodels.ExporterSettings{}, "Debug", zap.NewNop())
 	require.NotNil(t, lte)
 	assert.NoError(t, err)
 
@@ -38,7 +38,7 @@ func TestLoggingTraceExporterNoErrors(t *testing.T) {
 }
 
 func TestLoggingMetricsExporterNoErrors(t *testing.T) {
-	lme, err := newMetricsExporter(&configmodels.ExporterSettings{}, "debug", zap.NewNop())
+	lme, err := newMetricsExporter(&configmodels.ExporterSettings{}, "DEBUG", zap.NewNop())
 	require.NotNil(t, lme)
 	assert.NoError(t, err)
 


### PR DESCRIPTION
**Description:** 
Make `logLevel` ENV case-insensitive for **logging_exporter**
