### PR TITLE
Add capabilities to every consumer instead of only for processors

### DIFF
--- a/component/componenttest/example_factories.go
+++ b/component/componenttest/example_factories.go
@@ -330,6 +330,10 @@ func (exp *ExampleExporterConsumer) Start(_ context.Context, _ component.Host) e
 	return nil
 }
 
+func (exp *ExampleExporterConsumer) GetCapabilities() consumer.Capabilities {
+	return consumer.Capabilities{MutatesData: false}
+}
+
 // ConsumeTraceData receives consumerdata.TraceData for processing by the TracesConsumer.
 func (exp *ExampleExporterConsumer) ConsumeTraces(_ context.Context, td pdata.Traces) error {
 	exp.Traces = append(exp.Traces, td)
@@ -417,8 +421,8 @@ func (ep *ExampleProcessor) Shutdown(_ context.Context) error {
 	return nil
 }
 
-func (ep *ExampleProcessor) GetCapabilities() component.ProcessorCapabilities {
-	return component.ProcessorCapabilities{MutatesConsumedData: false}
+func (ep *ExampleProcessor) GetCapabilities() consumer.Capabilities {
+	return consumer.Capabilities{MutatesData: false}
 }
 
 func (ep *ExampleProcessor) ConsumeTraces(ctx context.Context, td pdata.Traces) error {

--- a/component/processor.go
+++ b/component/processor.go
@@ -27,9 +27,6 @@ import (
 // and MetricsProcessor.
 type Processor interface {
 	Component
-
-	// GetCapabilities must return the capabilities of the processor.
-	GetCapabilities() ProcessorCapabilities
 }
 
 // TracesProcessor is a processor that can consume traces.
@@ -48,16 +45,6 @@ type MetricsProcessor interface {
 type LogsProcessor interface {
 	Processor
 	consumer.LogsConsumer
-}
-
-// ProcessorCapabilities describes the capabilities of a Processor.
-type ProcessorCapabilities struct {
-	// MutatesConsumedData is set to true if Consume* function of the
-	// processor modifies the input TraceData or MetricsData argument.
-	// Processors which modify the input data MUST set this flag to true. If the processor
-	// does not modify the data it MUST set this flag to false. If the processor creates
-	// a copy of the data before modifying then this flag can be safely set to false.
-	MutatesConsumedData bool
 }
 
 // ProcessorCreateParams is passed to Create* functions in ProcessorFactory.

--- a/consumer/consumer.go
+++ b/consumer/consumer.go
@@ -21,22 +21,41 @@ import (
 	"go.opentelemetry.io/collector/consumer/pdata"
 )
 
-// MetricsConsumer is the new metrics consumer interface that receives pdata.MetricData, processes it
-// as needed, and sends it to the next processing node if any or to the destination.
-type MetricsConsumer interface {
-	ConsumeMetrics(ctx context.Context, md pdata.Metrics) error
+// Capabilities describes the capabilities of a Processor.
+type Capabilities struct {
+	// MutatesData is set to true if Consume* function of the Consumer modifies the input
+	// pdata.Traces, pdata.Metrics, or pdata.Logs argument.
+	// Consumer which modify the input data MUST set this flag to true. If the Consumer
+	// does not modify the data it MUST set this flag to false. If the Consumer creates
+	// a copy of the data before modifying then this flag can be safely set to false.
+	MutatesData bool
+}
+
+type Consumer interface {
+	// GetCapabilities must return the capabilities of the Consumer.
+	GetCapabilities() Capabilities
 }
 
 // TracesConsumer is an interface that receives pdata.Traces, processes it
 // as needed, and sends it to the next processing node if any or to the destination.
 type TracesConsumer interface {
-	// ConsumeTraces receives pdata.Traces for processing.
+	Consumer
+	// ConsumeTraces receives pdata.Traces for consumption.
 	ConsumeTraces(ctx context.Context, td pdata.Traces) error
+}
+
+// MetricsConsumer is the new metrics consumer interface that receives pdata.MetricData, processes it
+// as needed, and sends it to the next processing node if any or to the destination.
+type MetricsConsumer interface {
+	Consumer
+	// ConsumeMetrics receives pdata.Metrics for consumption.
+	ConsumeMetrics(ctx context.Context, md pdata.Metrics) error
 }
 
 // LogsConsumer is an interface that receives pdata.Logs, processes it
 // as needed, and sends it to the next processing node if any or to the destination.
 type LogsConsumer interface {
-	// ConsumeLogs receives pdata.Logs for processing.
+	Consumer
+	// ConsumeLogs receives pdata.Logs for consumption.
 	ConsumeLogs(ctx context.Context, ld pdata.Logs) error
 }

--- a/consumer/consumerhelper/consumer.go
+++ b/consumer/consumerhelper/consumer.go
@@ -1,3 +1,17 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package consumerhelper
 
 import (

--- a/consumer/consumerhelper/consumer.go
+++ b/consumer/consumerhelper/consumer.go
@@ -1,0 +1,20 @@
+package consumerhelper
+
+import (
+	"go.opentelemetry.io/collector/consumer"
+)
+
+type baseConsumer struct {
+	capabilities consumer.Capabilities
+}
+
+func (bc *baseConsumer) GetCapabilities() consumer.Capabilities {
+	return bc.capabilities
+}
+
+// NewConsumer returns a consumer.Consumer that implements the basic consumer functionality.
+func NewConsumer(capabilities consumer.Capabilities) consumer.Consumer {
+	return &baseConsumer{
+		capabilities: capabilities,
+	}
+}

--- a/consumer/consumertest/nop.go
+++ b/consumer/consumertest/nop.go
@@ -27,6 +27,10 @@ var (
 
 type nopConsumer struct{}
 
+func (nc *nopConsumer) GetCapabilities() consumer.Capabilities {
+	return consumer.Capabilities{MutatesData: false}
+}
+
 func (nc *nopConsumer) ConsumeTraces(context.Context, pdata.Traces) error {
 	return nil
 }

--- a/consumer/consumertest/sink.go
+++ b/consumer/consumertest/sink.go
@@ -27,6 +27,10 @@ type baseErrorConsumer struct {
 	consumeError error // to be returned by ConsumeTraces, if set
 }
 
+func (bec *baseErrorConsumer) GetCapabilities() consumer.Capabilities {
+	return consumer.Capabilities{MutatesData: false}
+}
+
 // SetConsumeError sets an error that will be returned by the Consume function.
 func (bec *baseErrorConsumer) SetConsumeError(err error) {
 	bec.mu.Lock()

--- a/exporter/exporterhelper/common.go
+++ b/exporter/exporterhelper/common.go
@@ -24,7 +24,9 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenthelper"
 	"go.opentelemetry.io/collector/config/configmodels"
+	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumererror"
+	"go.opentelemetry.io/collector/consumer/consumerhelper"
 )
 
 var (
@@ -157,6 +159,7 @@ func WithResourceToTelemetryConversion(resourceToTelemetrySettings ResourceToTel
 
 // baseExporter contains common fields between different exporter types.
 type baseExporter struct {
+	consumer.Consumer
 	component.Component
 	cfg                        configmodels.Exporter
 	sender                     requestSender
@@ -167,6 +170,7 @@ type baseExporter struct {
 func newBaseExporter(cfg configmodels.Exporter, logger *zap.Logger, options ...Option) *baseExporter {
 	bs := fromOptions(options)
 	be := &baseExporter{
+		Consumer:                   consumerhelper.NewConsumer(consumer.Capabilities{MutatesData: false}),
 		Component:                  componenthelper.NewComponent(bs.ComponentSettings),
 		cfg:                        cfg,
 		convertResourceToTelemetry: bs.ResourceToTelemetrySettings.Enabled,

--- a/exporter/exporterhelper/logshelper.go
+++ b/exporter/exporterhelper/logshelper.go
@@ -22,7 +22,9 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configmodels"
 	"go.opentelemetry.io/collector/config/configtelemetry"
+	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumererror"
+	"go.opentelemetry.io/collector/consumer/consumerhelper"
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/obsreport"
 )
@@ -59,6 +61,7 @@ func (req *logsRequest) count() int {
 
 type logsExporter struct {
 	*baseExporter
+	consumer.Consumer
 	pusher PushLogs
 }
 
@@ -97,6 +100,7 @@ func NewLogsExporter(
 
 	return &logsExporter{
 		baseExporter: be,
+		Consumer:     consumerhelper.NewConsumer(consumer.Capabilities{MutatesData: false}),
 		pusher:       pusher,
 	}, nil
 }

--- a/exporter/fileexporter/factory.go
+++ b/exporter/fileexporter/factory.go
@@ -20,6 +20,8 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configmodels"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/consumer/consumerhelper"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 )
 
@@ -85,7 +87,10 @@ func createExporter(config configmodels.Exporter) (*fileExporter, error) {
 		if err != nil {
 			return nil, err
 		}
-		exporter = &fileExporter{file: file}
+		exporter = &fileExporter{
+			Consumer: consumerhelper.NewConsumer(consumer.Capabilities{MutatesData: false}),
+			file:     file,
+		}
 
 		// Remember the receiver in the map
 		exporters[cfg] = exporter

--- a/exporter/fileexporter/file_exporter.go
+++ b/exporter/fileexporter/file_exporter.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/internal"
 	otlplogs "go.opentelemetry.io/collector/internal/data/opentelemetry-proto-gen/collector/logs/v1"
@@ -36,6 +37,7 @@ var marshaler = &jsonpb.Marshaler{}
 // fileExporter is the implementation of file exporter that writes telemetry data to a file
 // in Protobuf-JSON format.
 type fileExporter struct {
+	consumer.Consumer
 	file  io.WriteCloser
 	mutex sync.Mutex
 }

--- a/exporter/prometheusexporter/prometheus.go
+++ b/exporter/prometheusexporter/prometheus.go
@@ -25,6 +25,7 @@ import (
 	"github.com/orijtech/prometheus-go-metrics-exporter"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/translator/internaldata"
 )
@@ -35,6 +36,10 @@ type prometheusExporter struct {
 	name         string
 	exporter     *prometheus.Exporter
 	shutdownFunc func() error
+}
+
+func (pe *prometheusExporter) GetCapabilities() consumer.Capabilities {
+	return consumer.Capabilities{MutatesData: false}
 }
 
 func (pe *prometheusExporter) Start(_ context.Context, _ component.Host) error {

--- a/processor/README.md
+++ b/processor/README.md
@@ -61,7 +61,7 @@ From data ownership perspective pipelines can work in 2 modes:
 * Shared data ownership
 
 The mode is defined during startup based on data modification intent reported by the
-processors. The intent is reported by each processor via `MutatesConsumedData` field of
+processors. The intent is reported by each processor via `MutatesData` field of
 the struct returned by `GetCapabilities` function. If any processor in the pipeline
 declares an intent to modify the data then that pipeline will work in exclusive ownership
 mode. In addition, any other pipeline that receives data from a receiver that is attached
@@ -112,7 +112,7 @@ original `TraceData`/`MetricsData` argument (including referenced data, such as
 `Node`, `Resource`, `Spans`, etc) is allowed.
 
 If the processor uses such technique it should declare that it does not intend
-to modify the original data by setting `MutatesConsumedData=false` in its capabilities
+to modify the original data by setting `MutatesData=false` in its capabilities
 to avoid marking the pipeline for Exclusive ownership and to avoid the cost of
 data cloning described in Exclusive Ownership section.
 

--- a/processor/attributesprocessor/factory.go
+++ b/processor/attributesprocessor/factory.go
@@ -31,7 +31,7 @@ const (
 	typeStr = "attributes"
 )
 
-var processorCapabilities = component.ProcessorCapabilities{MutatesConsumedData: true}
+var processorCapabilities = consumer.Capabilities{MutatesData: true}
 
 // NewFactory returns a new factory for the Attributes processor.
 func NewFactory() component.ProcessorFactory {

--- a/processor/batchprocessor/batch_processor.go
+++ b/processor/batchprocessor/batch_processor.go
@@ -95,8 +95,8 @@ func newBatchProcessor(params component.ProcessorCreateParams, cfg *Config, batc
 	}
 }
 
-func (bp *batchProcessor) GetCapabilities() component.ProcessorCapabilities {
-	return component.ProcessorCapabilities{MutatesConsumedData: true}
+func (bp *batchProcessor) GetCapabilities() consumer.Capabilities {
+	return consumer.Capabilities{MutatesData: true}
 }
 
 // Start is invoked during service startup.

--- a/processor/filterprocessor/factory.go
+++ b/processor/filterprocessor/factory.go
@@ -28,7 +28,7 @@ const (
 	typeStr = "filter"
 )
 
-var processorCapabilities = component.ProcessorCapabilities{MutatesConsumedData: false}
+var processorCapabilities = consumer.Capabilities{MutatesData: false}
 
 // NewFactory returns a new factory for the Filter processor.
 func NewFactory() component.ProcessorFactory {

--- a/processor/filterprocessor/filter_processor_test.go
+++ b/processor/filterprocessor/filter_processor_test.go
@@ -207,7 +207,7 @@ func TestFilterMetricProcessor(t *testing.T) {
 			assert.Nil(t, err)
 
 			caps := fmp.GetCapabilities()
-			assert.False(t, caps.MutatesConsumedData)
+			assert.False(t, caps.MutatesData)
 			ctx := context.Background()
 			assert.NoError(t, fmp.Start(ctx, nil))
 

--- a/processor/memorylimiter/factory.go
+++ b/processor/memorylimiter/factory.go
@@ -28,7 +28,7 @@ const (
 	typeStr = "memory_limiter"
 )
 
-var processorCapabilities = component.ProcessorCapabilities{MutatesConsumedData: false}
+var processorCapabilities = consumer.Capabilities{MutatesData: false}
 
 // NewFactory returns a new factory for the Memory Limiter processor.
 func NewFactory() component.ProcessorFactory {

--- a/processor/processorhelper/processor_test.go
+++ b/processor/processorhelper/processor_test.go
@@ -26,6 +26,7 @@ import (
 	"go.opentelemetry.io/collector/component/componenterror"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/configmodels"
+	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/internal/testdata"
@@ -40,7 +41,7 @@ var testCfg = &configmodels.ProcessorSettings{
 
 func TestDefaultOptions(t *testing.T) {
 	bp := newBaseProcessor(testFullName)
-	assert.True(t, bp.GetCapabilities().MutatesConsumedData)
+	assert.True(t, bp.GetCapabilities().MutatesData)
 	assert.NoError(t, bp.Start(context.Background(), componenttest.NewNopHost()))
 	assert.NoError(t, bp.Shutdown(context.Background()))
 }
@@ -50,10 +51,10 @@ func TestWithOptions(t *testing.T) {
 	bp := newBaseProcessor(testFullName,
 		WithStart(func(context.Context, component.Host) error { return want }),
 		WithShutdown(func(context.Context) error { return want }),
-		WithCapabilities(component.ProcessorCapabilities{MutatesConsumedData: false}))
+		WithCapabilities(consumer.Capabilities{MutatesData: false}))
 	assert.Equal(t, want, bp.Start(context.Background(), componenttest.NewNopHost()))
 	assert.Equal(t, want, bp.Shutdown(context.Background()))
-	assert.False(t, bp.GetCapabilities().MutatesConsumedData)
+	assert.False(t, bp.GetCapabilities().MutatesData)
 }
 
 func TestNewTraceExporter(t *testing.T) {

--- a/processor/queuedprocessor/queued_processor.go
+++ b/processor/queuedprocessor/queued_processor.go
@@ -271,8 +271,8 @@ func (sp *queuedProcessor) ConsumeMetrics(ctx context.Context, md pdata.Metrics)
 	return nil
 }
 
-func (sp *queuedProcessor) GetCapabilities() component.ProcessorCapabilities {
-	return component.ProcessorCapabilities{MutatesConsumedData: false}
+func (sp *queuedProcessor) GetCapabilities() consumer.Capabilities {
+	return consumer.Capabilities{MutatesData: false}
 }
 
 // Shutdown is invoked during service shutdown.

--- a/processor/queuedprocessor/queued_processor_test.go
+++ b/processor/queuedprocessor/queued_processor_test.go
@@ -404,8 +404,8 @@ func (p *mockConcurrentSpanProcessor) ConsumeMetrics(_ context.Context, md pdata
 	return p.consumeError
 }
 
-func (p *mockConcurrentSpanProcessor) GetCapabilities() component.ProcessorCapabilities {
-	return component.ProcessorCapabilities{MutatesConsumedData: false}
+func (p *mockConcurrentSpanProcessor) GetCapabilities() consumer.Capabilities {
+	return consumer.Capabilities{MutatesData: false}
 }
 
 func (p *mockConcurrentSpanProcessor) checkNumBatches(t *testing.T, want int) {

--- a/processor/resourceprocessor/factory.go
+++ b/processor/resourceprocessor/factory.go
@@ -32,7 +32,7 @@ const (
 	typeStr = "resource"
 )
 
-var processorCapabilities = component.ProcessorCapabilities{MutatesConsumedData: true}
+var processorCapabilities = consumer.Capabilities{MutatesData: true}
 
 // NewFactory returns a new factory for the Resource processor.
 func NewFactory() component.ProcessorFactory {

--- a/processor/samplingprocessor/probabilisticsamplerprocessor/probabilisticsampler.go
+++ b/processor/samplingprocessor/probabilisticsamplerprocessor/probabilisticsampler.go
@@ -114,8 +114,8 @@ func (tsp *tracesamplerprocessor) processTraces(resourceSpans pdata.ResourceSpan
 	}
 }
 
-func (tsp *tracesamplerprocessor) GetCapabilities() component.ProcessorCapabilities {
-	return component.ProcessorCapabilities{MutatesConsumedData: false}
+func (tsp *tracesamplerprocessor) GetCapabilities() consumer.Capabilities {
+	return consumer.Capabilities{MutatesData: false}
 }
 
 // Start is invoked during service startup.

--- a/processor/spanprocessor/factory.go
+++ b/processor/spanprocessor/factory.go
@@ -29,7 +29,7 @@ const (
 	typeStr = "span"
 )
 
-var processorCapabilities = component.ProcessorCapabilities{MutatesConsumedData: true}
+var processorCapabilities = consumer.Capabilities{MutatesData: true}
 
 // errMissingRequiredField is returned when a required field in the config
 // is not specified.

--- a/receiver/hostmetricsreceiver/hostmetrics_receiver_test.go
+++ b/receiver/hostmetricsreceiver/hostmetrics_receiver_test.go
@@ -28,6 +28,7 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/receiver/hostmetricsreceiver/internal"
@@ -276,7 +277,11 @@ type notifyingSink struct {
 	ch              chan int
 }
 
-func (s *notifyingSink) ConsumeMetrics(ctx context.Context, md pdata.Metrics) error {
+func (s *notifyingSink) GetCapabilities() consumer.Capabilities {
+	return consumer.Capabilities{MutatesData: false}
+}
+
+func (s *notifyingSink) ConsumeMetrics(_ context.Context, md pdata.Metrics) error {
 	if md.MetricCount() > 0 {
 		s.receivedMetrics = true
 	}

--- a/receiver/jaegerreceiver/trace_receiver_test.go
+++ b/receiver/jaegerreceiver/trace_receiver_test.go
@@ -46,6 +46,8 @@ import (
 	"go.opentelemetry.io/collector/config/configgrpc"
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/config/configtls"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/consumer/consumerhelper"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/testutil"
@@ -63,6 +65,7 @@ func TestTraceSource(t *testing.T) {
 }
 
 type traceConsumer struct {
+	consumer.Consumer
 	cb func(context.Context, pdata.Traces)
 }
 
@@ -99,7 +102,8 @@ func TestClientIPDetection(t *testing.T) {
 	ch := make(chan context.Context)
 	jr := jReceiver{
 		nextConsumer: traceConsumer{
-			func(ctx context.Context, _ pdata.Traces) {
+			Consumer: consumerhelper.NewConsumer(consumer.Capabilities{MutatesData: false}),
+			cb: func(ctx context.Context, _ pdata.Traces) {
 				ch <- ctx
 			},
 		},

--- a/receiver/zipkinreceiver/trace_receiver_test.go
+++ b/receiver/zipkinreceiver/trace_receiver_test.go
@@ -524,6 +524,10 @@ type zipkinMockTraceConsumer struct {
 	err error
 }
 
+func (m *zipkinMockTraceConsumer) GetCapabilities() consumer.Capabilities {
+	return consumer.Capabilities{MutatesData: false}
+}
+
 func (m *zipkinMockTraceConsumer) ConsumeTraces(_ context.Context, td pdata.Traces) error {
 	m.ch <- td
 	return m.err

--- a/service/builder/pipelines_builder.go
+++ b/service/builder/pipelines_builder.go
@@ -36,9 +36,9 @@ type builtPipeline struct {
 	firstMC consumer.MetricsConsumer
 	firstLC consumer.LogsConsumer
 
-	// MutatesConsumedData is set to true if any processors in the pipeline
+	// MutatesData is set to true if any processors in the pipeline
 	// can mutate the TraceData or MetricsData input argument.
-	MutatesConsumedData bool
+	MutatesData bool
 
 	processors []component.Processor
 }
@@ -164,7 +164,7 @@ func (pb *PipelinesBuilder) buildPipeline(ctx context.Context, pipelineCfg *conf
 			var proc component.TracesProcessor
 			proc, err = factory.CreateTracesProcessor(ctx, creationParams, procCfg, tc)
 			if proc != nil {
-				mutatesConsumedData = mutatesConsumedData || proc.GetCapabilities().MutatesConsumedData
+				mutatesConsumedData = mutatesConsumedData || proc.GetCapabilities().MutatesData
 			}
 			processors[i] = proc
 			tc = proc
@@ -172,7 +172,7 @@ func (pb *PipelinesBuilder) buildPipeline(ctx context.Context, pipelineCfg *conf
 			var proc component.MetricsProcessor
 			proc, err = factory.CreateMetricsProcessor(ctx, creationParams, procCfg, mc)
 			if proc != nil {
-				mutatesConsumedData = mutatesConsumedData || proc.GetCapabilities().MutatesConsumedData
+				mutatesConsumedData = mutatesConsumedData || proc.GetCapabilities().MutatesData
 			}
 			processors[i] = proc
 			mc = proc
@@ -181,7 +181,7 @@ func (pb *PipelinesBuilder) buildPipeline(ctx context.Context, pipelineCfg *conf
 			var proc component.LogsProcessor
 			proc, err = factory.CreateLogsProcessor(ctx, creationParams, procCfg, lc)
 			if proc != nil {
-				mutatesConsumedData = mutatesConsumedData || proc.GetCapabilities().MutatesConsumedData
+				mutatesConsumedData = mutatesConsumedData || proc.GetCapabilities().MutatesData
 			}
 			processors[i] = proc
 			lc = proc

--- a/service/builder/receivers_builder.go
+++ b/service/builder/receivers_builder.go
@@ -286,7 +286,7 @@ func buildFanoutTraceConsumer(pipelines []*builtPipeline) consumer.TracesConsume
 	anyPipelineMutatesData := false
 	for _, pipeline := range pipelines {
 		pipelineConsumers = append(pipelineConsumers, pipeline.firstTC)
-		anyPipelineMutatesData = anyPipelineMutatesData || pipeline.MutatesConsumedData
+		anyPipelineMutatesData = anyPipelineMutatesData || pipeline.MutatesData
 	}
 
 	// Create a junction point that fans out to all pipelines.
@@ -311,7 +311,7 @@ func buildFanoutMetricConsumer(pipelines []*builtPipeline) consumer.MetricsConsu
 	anyPipelineMutatesData := false
 	for _, pipeline := range pipelines {
 		pipelineConsumers = append(pipelineConsumers, pipeline.firstMC)
-		anyPipelineMutatesData = anyPipelineMutatesData || pipeline.MutatesConsumedData
+		anyPipelineMutatesData = anyPipelineMutatesData || pipeline.MutatesData
 	}
 
 	// Create a junction point that fans out to all pipelines.
@@ -336,7 +336,7 @@ func buildFanoutLogConsumer(pipelines []*builtPipeline) consumer.LogsConsumer {
 	anyPipelineMutatesData := false
 	for _, pipeline := range pipelines {
 		pipelineConsumers = append(pipelineConsumers, pipeline.firstLC)
-		anyPipelineMutatesData = anyPipelineMutatesData || pipeline.MutatesConsumedData
+		anyPipelineMutatesData = anyPipelineMutatesData || pipeline.MutatesData
 	}
 
 	// Create a junction point that fans out to all pipelines.

--- a/service/internal/templates.go
+++ b/service/internal/templates.go
@@ -89,12 +89,12 @@ type SummaryPipelinesTableData struct {
 
 // SummaryPipelinesTableRowData contains data for one row in pipelines summary table template.
 type SummaryPipelinesTableRowData struct {
-	FullName            string
-	InputType           string
-	MutatesConsumedData bool
-	Receivers           []string
-	Processors          []string
-	Exporters           []string
+	FullName    string
+	InputType   string
+	MutatesData bool
+	Receivers   []string
+	Processors  []string
+	Exporters   []string
 }
 
 // WriteHTMLSummaryTable writes the summary table for one component type (receivers, processors, exporters).

--- a/service/internal/templates/pipelines_table.html
+++ b/service/internal/templates/pipelines_table.html
@@ -4,7 +4,7 @@
         <td>&nbsp;&nbsp;|&nbsp;&nbsp;</td>
         <td colspan=1 align=center><b>InputType</b></td>
         <td>&nbsp;&nbsp;|&nbsp;&nbsp;</td>
-        <td colspan=1 align=center><b>MutatesConsumedData</b></td>
+        <td colspan=1 align=center><b>MutatesData</b></td>
         <td>&nbsp;&nbsp;|&nbsp;&nbsp;</td>
         <td colspan=1 align=center><b>Receivers</b></td>
         <td>&nbsp;&nbsp;|&nbsp;&nbsp;</td>
@@ -20,7 +20,7 @@
             <tr>{{end -}}
         <td>{{$row.FullName}}</td><td>&nbsp;&nbsp;|&nbsp;&nbsp;</td>
         <td>{{$row.InputType}}</td><td>&nbsp;&nbsp;|&nbsp;&nbsp;</td>
-        <td>{{$row.MutatesConsumedData}}</td><td>&nbsp;&nbsp;|&nbsp;&nbsp;</td>
+        <td>{{$row.MutatesData}}</td><td>&nbsp;&nbsp;|&nbsp;&nbsp;</td>
         <td align="center">
             {{range $recindex, $rec := $row.Receivers}}
                 <a href="{{$a}}?zpipelinename={{$row.FullName}}&zcomponentname={{$rec}}&zcomponentkind=receiver">{{$rec}}</a>

--- a/service/internal/templates_test.go
+++ b/service/internal/templates_test.go
@@ -62,12 +62,12 @@ func TestNoCrash(t *testing.T) {
 		WriteHTMLPipelinesSummaryTable(buf, SummaryPipelinesTableData{
 			ComponentEndpoint: "pagez",
 			Rows: []SummaryPipelinesTableRowData{{
-				FullName:            "test",
-				InputType:           "metrics",
-				MutatesConsumedData: false,
-				Receivers:           []string{"oc"},
-				Processors:          []string{"nop"},
-				Exporters:           []string{"oc"},
+				FullName:    "test",
+				InputType:   "metrics",
+				MutatesData: false,
+				Receivers:   []string{"oc"},
+				Processors:  []string{"nop"},
+				Exporters:   []string{"oc"},
 			}},
 		})
 	})

--- a/service/service.go
+++ b/service/service.go
@@ -549,12 +549,12 @@ func (app *Application) getPipelinesSummaryTableData() internal.SummaryPipelines
 	data.Rows = make([]internal.SummaryPipelinesTableRowData, 0, len(app.builtExtensions))
 	for c, p := range app.builtPipelines {
 		row := internal.SummaryPipelinesTableRowData{
-			FullName:            c.Name,
-			InputType:           string(c.InputType),
-			MutatesConsumedData: p.MutatesConsumedData,
-			Receivers:           c.Receivers,
-			Processors:          c.Processors,
-			Exporters:           c.Exporters,
+			FullName:    c.Name,
+			InputType:   string(c.InputType),
+			MutatesData: p.MutatesData,
+			Receivers:   c.Receivers,
+			Processors:  c.Processors,
+			Exporters:   c.Exporters,
 		}
 		data.Rows = append(data.Rows, row)
 	}

--- a/testbed/correctness/metrics/metrics_test_harness.go
+++ b/testbed/correctness/metrics/metrics_test_harness.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/testbed/testbed"
 )
@@ -57,6 +58,10 @@ func newTestHarness(
 		diffConsumer:       diffConsumer,
 		allMetricsReceived: make(chan struct{}),
 	}
+}
+
+func (h *testHarness) GetCapabilities() consumer.Capabilities {
+	return consumer.Capabilities{MutatesData: false}
 }
 
 func (h *testHarness) ConsumeMetrics(_ context.Context, pdm pdata.Metrics) error {

--- a/testbed/testbed/mock_backend.go
+++ b/testbed/testbed/mock_backend.go
@@ -169,6 +169,10 @@ type MockTraceConsumer struct {
 	backend          *MockBackend
 }
 
+func (tc *MockTraceConsumer) GetCapabilities() consumer.Capabilities {
+	return consumer.Capabilities{MutatesData: false}
+}
+
 func (tc *MockTraceConsumer) ConsumeTraces(_ context.Context, td pdata.Traces) error {
 	tc.numSpansReceived.Add(uint64(td.SpanCount()))
 
@@ -212,6 +216,10 @@ type MockMetricConsumer struct {
 	backend            *MockBackend
 }
 
+func (mc *MockMetricConsumer) GetCapabilities() consumer.Capabilities {
+	return consumer.Capabilities{MutatesData: false}
+}
+
 func (mc *MockMetricConsumer) ConsumeMetrics(_ context.Context, md pdata.Metrics) error {
 	_, dataPoints := md.MetricAndDataPointCount()
 	mc.numMetricsReceived.Add(uint64(dataPoints))
@@ -234,9 +242,13 @@ type MockLogConsumer struct {
 	backend               *MockBackend
 }
 
-func (mc *MockLogConsumer) ConsumeLogs(_ context.Context, ld pdata.Logs) error {
+func (ml *MockLogConsumer) GetCapabilities() consumer.Capabilities {
+	return consumer.Capabilities{MutatesData: false}
+}
+
+func (ml *MockLogConsumer) ConsumeLogs(_ context.Context, ld pdata.Logs) error {
 	recordCount := ld.LogRecordCount()
-	mc.numLogRecordsReceived.Add(uint64(recordCount))
-	mc.backend.ConsumeLogs(ld)
+	ml.numLogRecordsReceived.Add(uint64(recordCount))
+	ml.backend.ConsumeLogs(ld)
 	return nil
 }

--- a/testbed/testbed/senders.go
+++ b/testbed/testbed/senders.go
@@ -667,6 +667,10 @@ func (f *FluentBitFileLogWriter) setupParsers() {
 	f.parsersFile.Close()
 }
 
+func (f *FluentBitFileLogWriter) GetCapabilities() consumer.Capabilities {
+	return consumer.Capabilities{MutatesData: false}
+}
+
 func (f *FluentBitFileLogWriter) ConsumeLogs(_ context.Context, logs pdata.Logs) error {
 	for i := 0; i < logs.ResourceLogs().Len(); i++ {
 		for j := 0; j < logs.ResourceLogs().At(i).InstrumentationLibraryLogs().Len(); j++ {


### PR DESCRIPTION
After this PR merges we need to:
1. Change the pipeline to clone pdata anytime any of the consumers (including exporters). Observed this problem in contrib.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>