### PR TITLE
Add batched exports to the Prometheus Remote Write Exporter 

### DIFF
--- a/exporter/prometheusremotewriteexporter/exporter.go
+++ b/exporter/prometheusremotewriteexporter/exporter.go
@@ -143,9 +143,9 @@ func (prwe *PrwExporter) PushMetrics(ctx context.Context, md pdata.Metrics) (int
 			}
 		}
 
-		if err := prwe.export(ctx, tsMap); err != nil {
+		if exportErrs := prwe.export(ctx, tsMap); len(exportErrs) != 0 {
 			dropped = md.MetricCount()
-			errs = append(errs, consumererror.Permanent(err))
+			errs = append(errs, ...exportErrs)
 		}
 
 		if dropped != 0 {
@@ -252,13 +252,33 @@ func (prwe *PrwExporter) handleSummaryMetric(tsMap map[string]*prompb.TimeSeries
 }
 
 // export sends a Snappy-compressed WriteRequest containing TimeSeries to a remote write endpoint in order
-func (prwe *PrwExporter) export(ctx context.Context, tsMap map[string]*prompb.TimeSeries) error {
-	// Calls the helper function to convert the TsMap to the desired format
-	req, err := wrapTimeSeries(tsMap)
+func (prwe *PrwExporter) export(ctx context.Context, tsMap map[string]*prompb.TimeSeries) []error {
+	var errs []error
+	// Calls the helper function to convert and batch the TsMap to the desired format
+	requests, err := wrapAndBatchTimeSeries(tsMap)
 	if err != nil {
-		return consumererror.Permanent(err)
+		errs = append(errs, consumererror.Permanent(err))
 	}
 
+	var wg sync.WaitGroup
+
+	// performs the batched requests concurrently
+	for _, request := range requests {
+		wg.Add(1)
+		go func(req *prompb.WriteRequest) {
+			err := prwe.execute(ctx, req)
+			if err != nil {
+				errs = append(errs, consumererror.Permanent(err))
+			}
+			wg.Done()
+		}(request)
+	}
+	wg.Wait()
+
+	return errs
+}
+
+func (prwe *PrwExporter) execute(ctx context.Context, req *prompb.WriteRequest) error {
 	// Uses proto.Marshal to convert the WriteRequest into bytes array
 	data, err := proto.Marshal(req)
 	if err != nil {

--- a/exporter/prometheusremotewriteexporter/exporter.go
+++ b/exporter/prometheusremotewriteexporter/exporter.go
@@ -37,7 +37,10 @@ import (
 	"go.opentelemetry.io/collector/internal/version"
 )
 
-const maxConcurrentRequests = 5
+const (
+	maxConcurrentRequests = 5
+	maxBatchByteSize      = 3000000
+)
 
 // PrwExporter converts OTLP metrics to Prometheus remote write TimeSeries and sends them to a remote endpoint
 type PrwExporter struct {
@@ -257,7 +260,7 @@ func (prwe *PrwExporter) handleSummaryMetric(tsMap map[string]*prompb.TimeSeries
 func (prwe *PrwExporter) export(ctx context.Context, tsMap map[string]*prompb.TimeSeries) []error {
 	var errs []error
 	// Calls the helper function to convert and batch the TsMap to the desired format
-	requests, err := batchTimeSeries(tsMap)
+	requests, err := batchTimeSeries(tsMap, maxBatchByteSize)
 	if err != nil {
 		errs = append(errs, consumererror.Permanent(err))
 		return errs

--- a/exporter/prometheusremotewriteexporter/exporter.go
+++ b/exporter/prometheusremotewriteexporter/exporter.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"net/url"
 	"sync"
@@ -275,11 +276,12 @@ func (prwe *PrwExporter) export(ctx context.Context, tsMap map[string]*prompb.Ti
 	var mu sync.Mutex
 	var wg sync.WaitGroup
 
-	wg.Add(maxConcurrentRequests) // used to wait for workers to be finished
+	concurrencyLimit := int(math.Min(maxConcurrentRequests, float64(len(requests))))
+	wg.Add(concurrencyLimit) // used to wait for workers to be finished
 
 	// Run concurrencyLimit of workers until there
 	// is no more requests to execute in the input channel.
-	for i := 0; i < maxConcurrentRequests; i++ {
+	for i := 0; i < concurrencyLimit; i++ {
 		go func() {
 			defer wg.Done()
 

--- a/exporter/prometheusremotewriteexporter/exporter.go
+++ b/exporter/prometheusremotewriteexporter/exporter.go
@@ -143,7 +143,7 @@ func (prwe *PrwExporter) PushMetrics(ctx context.Context, md pdata.Metrics) (int
 			}
 		}
 
-		if exportErrors := prwe.export(ctx, tsMap); exportErrors != nil {
+		if exportErrors := prwe.export(ctx, tsMap); len(exportErrors) != 0 {
 			dropped = md.MetricCount()
 			errs = append(errs, exportErrors...)
 		}
@@ -264,7 +264,6 @@ func (prwe *PrwExporter) export(ctx context.Context, tsMap map[string]*prompb.Ti
 	var wg sync.WaitGroup
 	var mtx sync.Mutex
 
-	// performs the batched requests concurrently
 	for _, request := range requests {
 		wg.Add(1)
 		go func(req *prompb.WriteRequest) {

--- a/exporter/prometheusremotewriteexporter/exporter.go
+++ b/exporter/prometheusremotewriteexporter/exporter.go
@@ -269,11 +269,10 @@ func (prwe *PrwExporter) export(ctx context.Context, tsMap map[string]*prompb.Ti
 
 	for i := 0; i < numOfRequests; i += maxConcurrentRequests {
 		var wg sync.WaitGroup
-		fmt.Println("next batch of requests")
+
 		for k := i; k < int(math.Min(float64(i+maxConcurrentRequests), float64(numOfRequests))); k++ {
 			wg.Add(1)
 			go func(i int, req *prompb.WriteRequest) {
-				fmt.Println("making request " + fmt.Sprintf("%d", i))
 				requestError := prwe.execute(ctx, req)
 				if requestError != nil {
 					mu.Lock()
@@ -283,6 +282,7 @@ func (prwe *PrwExporter) export(ctx context.Context, tsMap map[string]*prompb.Ti
 				wg.Done()
 			}(k, requests[k])
 		}
+
 		wg.Wait()
 	}
 

--- a/exporter/prometheusremotewriteexporter/exporter.go
+++ b/exporter/prometheusremotewriteexporter/exporter.go
@@ -257,7 +257,7 @@ func (prwe *PrwExporter) export(ctx context.Context, tsMap map[string]*prompb.Ti
 	// Calls the helper function to convert and batch the TsMap to the desired format
 	requests, err := wrapAndBatchTimeSeries(tsMap)
 	if err != nil {
-		errs = append(errs, err)
+		errs = append(errs, consumererror.Permanent(err))
 		return errs
 	}
 
@@ -271,7 +271,7 @@ func (prwe *PrwExporter) export(ctx context.Context, tsMap map[string]*prompb.Ti
 			requestError := prwe.execute(ctx, req)
 			if requestError != nil {
 				mtx.Lock()
-				errs = append(errs, consumererror.Permanent(requestError))
+				errs = append(errs, requestError)
 				mtx.Unlock()
 			}
 			wg.Done()

--- a/exporter/prometheusremotewriteexporter/helper.go
+++ b/exporter/prometheusremotewriteexporter/helper.go
@@ -41,8 +41,6 @@ const (
 	totalStr    = "total"
 	delimeter   = "_"
 	keyStr      = "key"
-
-	maxBatchByteSize = 3000000
 )
 
 // ByLabelName enables the usage of sort.Sort() with a slice of labels
@@ -218,7 +216,7 @@ func getPromMetricName(metric *otlp.Metric, ns string) string {
 }
 
 // batchTimeSeries splits series into multiple batch write requests.
-func batchTimeSeries(tsMap map[string]*prompb.TimeSeries) ([]*prompb.WriteRequest, error) {
+func batchTimeSeries(tsMap map[string]*prompb.TimeSeries, maxBatchByteSize int) ([]*prompb.WriteRequest, error) {
 	if len(tsMap) == 0 {
 		return nil, errors.New("invalid tsMap: cannot be empty map")
 	}

--- a/exporter/prometheusremotewriteexporter/helper.go
+++ b/exporter/prometheusremotewriteexporter/helper.go
@@ -240,8 +240,10 @@ func batchTimeSeries(tsMap map[string]*prompb.TimeSeries, maxBatchByteSize int) 
 		sizeOfCurrentBatch += sizeOfSeries
 	}
 
-	wrapped := convertTimeseriesToRequest(tsArray)
-	requests = append(requests, wrapped)
+	if len(tsArray) != 0 {
+		wrapped := convertTimeseriesToRequest(tsArray)
+		requests = append(requests, wrapped)
+	}
 
 	return requests, nil
 }

--- a/exporter/prometheusremotewriteexporter/helper.go
+++ b/exporter/prometheusremotewriteexporter/helper.go
@@ -16,7 +16,6 @@ package prometheusremotewriteexporter
 
 import (
 	"errors"
-	"fmt"
 	"log"
 	"sort"
 	"strconv"
@@ -228,15 +227,10 @@ func batchTimeSeries(tsMap map[string]*prompb.TimeSeries) ([]*prompb.WriteReques
 	var tsArray []prompb.TimeSeries
 	sizeOfCurrentBatch := 0
 
-	fmt.Println("total metrics to process: " + fmt.Sprintf("%d", len(tsMap)))
-
 	for _, v := range tsMap {
 		sizeOfSeries := v.Size()
 
 		if sizeOfCurrentBatch+sizeOfSeries >= maxBatchByteSize {
-			fmt.Println("tsArray length: " + fmt.Sprintf("%d", len(tsArray)))
-			fmt.Println("sizeOfCurrentBatch: " + fmt.Sprintf("%d", sizeOfCurrentBatch))
-
 			wrapped := convertTimeseriesToRequest(tsArray)
 			requests = append(requests, wrapped)
 
@@ -249,9 +243,6 @@ func batchTimeSeries(tsMap map[string]*prompb.TimeSeries) ([]*prompb.WriteReques
 	}
 
 	if sizeOfCurrentBatch != 0 {
-		fmt.Println("tsArray length: " + fmt.Sprintf("%d", len(tsArray)))
-		fmt.Println("sizeOfCurrentBatch: " + fmt.Sprintf("%d", sizeOfCurrentBatch))
-
 		wrapped := convertTimeseriesToRequest(tsArray)
 		requests = append(requests, wrapped)
 	}
@@ -495,7 +486,7 @@ func addSingleDoubleSummaryDataPoint(pt *otlp.DoubleSummaryDataPoint, metric *ot
 }
 
 func convertTimeseriesToRequest(tsArray []prompb.TimeSeries) *prompb.WriteRequest {
-	// the remotewrite endpoint only needs the timeseries.
+	// the remote_write endpoint only requires the timeseries.
 	// otlp defines it's own way to handle metric metadata
 	return &prompb.WriteRequest{
 		Timeseries: tsArray,

--- a/exporter/prometheusremotewriteexporter/helper.go
+++ b/exporter/prometheusremotewriteexporter/helper.go
@@ -241,7 +241,7 @@ func wrapAndBatchTimeSeries(tsMap map[string]*prompb.TimeSeries) ([]*prompb.Writ
 				// Other parameters of the WriteRequest are unnecessary for our Export
 			}
 
-			if proto.Size(&wrapped) >= maxBatchByteSize || len(tsArray) >= maxBatchMetric {
+			if b := proto.Size(&wrapped); b >= maxBatchByteSize || len(tsArray) >= maxBatchMetric {
 				requests = append(requests, &wrapped)
 				tsArray = make([]prompb.TimeSeries, 0)
 

--- a/exporter/prometheusremotewriteexporter/helper.go
+++ b/exporter/prometheusremotewriteexporter/helper.go
@@ -242,10 +242,8 @@ func batchTimeSeries(tsMap map[string]*prompb.TimeSeries) ([]*prompb.WriteReques
 		sizeOfCurrentBatch += sizeOfSeries
 	}
 
-	if sizeOfCurrentBatch != 0 {
-		wrapped := convertTimeseriesToRequest(tsArray)
-		requests = append(requests, wrapped)
-	}
+	wrapped := convertTimeseriesToRequest(tsArray)
+	requests = append(requests, wrapped)
 
 	return requests, nil
 }

--- a/exporter/prometheusremotewriteexporter/helper_test.go
+++ b/exporter/prometheusremotewriteexporter/helper_test.go
@@ -303,3 +303,61 @@ func Test_getPromMetricName(t *testing.T) {
 		})
 	}
 }
+
+// Test_batchTimeSeries checks batchTimeSeries return the correct number of requests
+// depending on byte size.
+func Test_batchTimeSeries(t *testing.T) {
+	// First we will instantiate a dummy TimeSeries instance to pass into both the export call and compare the http request
+	labels := getPromLabels(label11, value11, label12, value12, label21, value21, label22, value22)
+	sample1 := getSample(floatVal1, msTime1)
+	sample2 := getSample(floatVal2, msTime2)
+	sample3 := getSample(floatVal3, msTime3)
+	ts1 := getTimeSeries(labels, sample1, sample2)
+	ts2 := getTimeSeries(labels, sample1, sample2, sample3)
+
+	tsMap1 := getTimeseriesMap([]*prompb.TimeSeries{})
+	tsMap2 := getTimeseriesMap([]*prompb.TimeSeries{ts1})
+	tsMap3 := getTimeseriesMap([]*prompb.TimeSeries{ts1, ts2})
+
+	tests := []struct {
+		name                string
+		tsMap               map[string]*prompb.TimeSeries
+		maxBatchByteSize    int
+		numExpectedRequests int
+		returnErr           bool
+	}{
+		{
+			"no_timeseries",
+			tsMap1,
+			100,
+			-1,
+			true,
+		},
+		{
+			"normal_case",
+			tsMap2,
+			300,
+			1,
+			false,
+		},
+		{
+			"two_requests",
+			tsMap3,
+			300,
+			2,
+			false,
+		},
+	}
+	// run tests
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			requests, err := batchTimeSeries(tt.tsMap, tt.maxBatchByteSize)
+			if tt.returnErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.numExpectedRequests, len(requests))
+		})
+	}
+}

--- a/exporter/prometheusremotewriteexporter/testutil_test.go
+++ b/exporter/prometheusremotewriteexporter/testutil_test.go
@@ -15,6 +15,7 @@
 package prometheusremotewriteexporter
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/prometheus/prometheus/prompb"
@@ -25,9 +26,11 @@ import (
 
 var (
 	time1   = uint64(time.Now().UnixNano())
-	time2   = uint64(time.Date(1970, 1, 0, 0, 0, 0, 0, time.UTC).UnixNano())
+	time2   = uint64(time.Now().UnixNano() - 5)
+	time3   = uint64(time.Date(1970, 1, 0, 0, 0, 0, 0, time.UTC).UnixNano())
 	msTime1 = int64(time1 / uint64(int64(time.Millisecond)/int64(time.Nanosecond)))
 	msTime2 = int64(time2 / uint64(int64(time.Millisecond)/int64(time.Nanosecond)))
+	msTime3 = int64(time3 / uint64(int64(time.Millisecond)/int64(time.Nanosecond)))
 
 	label11 = "test_label11"
 	value11 = "test_value11"
@@ -50,6 +53,7 @@ var (
 	intVal2   int64 = 2
 	floatVal1       = 1.0
 	floatVal2       = 2.0
+	floatVal3       = 3.0
 
 	lbs1      = getLabels(label11, value11, label12, value12)
 	lbs2      = getLabels(label21, value21, label22, value22)
@@ -563,4 +567,14 @@ func getQuantiles(bounds []float64, values []float64) []*otlp.DoubleSummaryDataP
 		}
 	}
 	return quantiles
+}
+
+func getTimeseriesMap(timeseries []*prompb.TimeSeries) map[string]*prompb.TimeSeries {
+	tsMap := make(map[string]*prompb.TimeSeries)
+
+	for i, v := range timeseries {
+		tsMap[fmt.Sprintf("%s%d", "timeseries_name", i)] = v
+	}
+
+	return tsMap
 }


### PR DESCRIPTION
**Description:** 

Currently, there is no limit on the size of the remote_write export request to a Cortex instance. This could create problems if one Prometheus scrape produces an extreme amount of timeseries metrics. 

This PR creates a batch of concurrent requests where the max size of a request is 3MB and the max number of timeseries per request is 40,000.

A future PR will tackle making the max size of each request configurable.

**Testing:** 

* Unit tests were fixed
* Performance tests were done with 15000 Prometheus metrics (around 100k timeseries) per scrape. The first and last metric of each Prometheus metric type were all found.
