### PR TITLE
fix zipkinv2 translation error tag handling

### DIFF
--- a/translator/trace/zipkin/zipkinv2_to_traces.go
+++ b/translator/trace/zipkin/zipkinv2_to_traces.go
@@ -165,8 +165,8 @@ func populateSpanStatus(tags map[string]string, status pdata.SpanStatus) {
 		}
 	}
 
-	if _, ok := tags[tracetranslator.TagError]; ok {
-		if value == "true" {
+	if val, ok := tags[tracetranslator.TagError]; ok {
+		if val == "true" {
 			status.SetCode(pdata.StatusCodeError)
 			delete(tags, tracetranslator.TagError)
 		}

--- a/translator/trace/zipkin/zipkinv2_to_traces.go
+++ b/translator/trace/zipkin/zipkinv2_to_traces.go
@@ -165,7 +165,7 @@ func populateSpanStatus(tags map[string]string, status pdata.SpanStatus) {
 		}
 	}
 
-	if value, ok := tags[tracetranslator.TagError]; ok {
+	if _, ok := tags[tracetranslator.TagError]; ok {
 		status.SetCode(pdata.StatusCodeError)
 		delete(tags, tracetranslator.TagError)
 	}

--- a/translator/trace/zipkin/zipkinv2_to_traces.go
+++ b/translator/trace/zipkin/zipkinv2_to_traces.go
@@ -164,6 +164,11 @@ func populateSpanStatus(tags map[string]string, status pdata.SpanStatus) {
 			delete(tags, tracetranslator.TagStatusMsg)
 		}
 	}
+
+	if value, ok := tags[tracetranslator.TagError]; ok {
+		status.SetCode(pdata.StatusCodeError)
+		delete(tags, tracetranslator.TagError)
+	}
 }
 
 func zipkinKindToSpanKind(kind zipkinmodel.Kind, tags map[string]string) pdata.SpanKind {

--- a/translator/trace/zipkin/zipkinv2_to_traces.go
+++ b/translator/trace/zipkin/zipkinv2_to_traces.go
@@ -166,8 +166,10 @@ func populateSpanStatus(tags map[string]string, status pdata.SpanStatus) {
 	}
 
 	if _, ok := tags[tracetranslator.TagError]; ok {
-		status.SetCode(pdata.StatusCodeError)
-		delete(tags, tracetranslator.TagError)
+		if value == "true" {
+			status.SetCode(pdata.StatusCodeError)
+			delete(tags, tracetranslator.TagError)
+		}
 	}
 }
 

--- a/translator/trace/zipkin/zipkinv2_to_traces_test.go
+++ b/translator/trace/zipkin/zipkinv2_to_traces_test.go
@@ -152,6 +152,13 @@ func generateTraceSingleSpanErrorStatus() pdata.Traces {
 	ils := rs.InstrumentationLibrarySpans().At(0)
 	ils.Spans().Resize(1)
 	span := ils.Spans().At(0)
+	span.SetTraceID(
+		pdata.NewTraceID([16]byte{0xF1, 0xF2, 0xF3, 0xF4, 0xF5, 0xF6, 0xF7, 0xF8, 0xF9, 0xFA, 0xFB, 0xFC, 0xFD, 0xFE, 0xFF, 0x80}))
+	span.SetSpanID(pdata.NewSpanID([8]byte{0xAF, 0xAE, 0xAD, 0xAC, 0xAB, 0xAA, 0xA9, 0xA8}))
+	span.SetName("MinimalData")
+	span.SetKind(pdata.SpanKindCLIENT)
+	span.SetStartTime(1596911098294000000)
+	span.SetEndTime(1596911098295000000)
 	span.Attributes().InitEmptyWithCapacity(0)
 	span.Status().SetCode(pdata.StatusCodeError)
 	return td

--- a/translator/trace/zipkin/zipkinv2_to_traces_test.go
+++ b/translator/trace/zipkin/zipkinv2_to_traces_test.go
@@ -59,7 +59,7 @@ func TestZipkinSpansToInternalTraces(t *testing.T) {
 		},
 		{
 			name: "errorTag",
-			zs:   generateSpanErrorTag(),
+			zs:   generateSpanErrorTags(),
 			td:   generateTraceSingleSpanErrorStatus(),
 			err:  nil,
 		},
@@ -107,9 +107,12 @@ func generateSpanNoTags() []*zipkinmodel.SpanModel {
 	return spans
 }
 
-func generateSpanErrorTag() []*zipkinmodel.SpanModel {
+func generateSpanError() []*zipkinmodel.SpanModel {
+	errorTags := make(map[string]string)
+	errorTags["error"] = "true"
+
 	spans := generateSpanNoEndpoints()
-	spans[0].Tags = &zipkinmodel.Tags{error: "true"}
+	spans[0].Tags = errorTags
 	return spans
 }
 

--- a/translator/trace/zipkin/zipkinv2_to_traces_test.go
+++ b/translator/trace/zipkin/zipkinv2_to_traces_test.go
@@ -107,7 +107,7 @@ func generateSpanNoTags() []*zipkinmodel.SpanModel {
 	return spans
 }
 
-func generateSpanError() []*zipkinmodel.SpanModel {
+func generateSpanErrorTags() []*zipkinmodel.SpanModel {
 	errorTags := make(map[string]string)
 	errorTags["error"] = "true"
 

--- a/translator/trace/zipkin/zipkinv2_to_traces_test.go
+++ b/translator/trace/zipkin/zipkinv2_to_traces_test.go
@@ -57,6 +57,12 @@ func TestZipkinSpansToInternalTraces(t *testing.T) {
 			td:   generateTraceSingleSpanMinmalResource(),
 			err:  nil,
 		},
+		{
+			name: "errorTag",
+			zs:   generateSpanErrorTag(),
+			td:   generateTraceSingleSpanErrorStatus(),
+			err:  nil,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -101,6 +107,12 @@ func generateSpanNoTags() []*zipkinmodel.SpanModel {
 	return spans
 }
 
+func generateSpanErrorTag() []*zipkinmodel.SpanModel {
+	spans := generateSpanNoEndpoints()
+	spans[0].Tags = &zipkinmodel.Tags{error: "true"}
+	return spans
+}
+
 func generateTraceSingleSpanNoResourceOrInstrLibrary() pdata.Traces {
 	td := pdata.NewTraces()
 	td.ResourceSpans().Resize(1)
@@ -126,5 +138,18 @@ func generateTraceSingleSpanMinmalResource() pdata.Traces {
 	rsc := rs.Resource()
 	rsc.Attributes().InitEmptyWithCapacity(1)
 	rsc.Attributes().UpsertString(conventions.AttributeServiceName, "SoleAttr")
+	return td
+}
+
+func generateTraceSingleSpanErrorStatus() pdata.Traces {
+	td := pdata.NewTraces()
+	td.ResourceSpans().Resize(1)
+	rs := td.ResourceSpans().At(0)
+	rs.InstrumentationLibrarySpans().Resize(1)
+	ils := rs.InstrumentationLibrarySpans().At(0)
+	ils.Spans().Resize(1)
+	span := ils.Spans().At(0)
+	span.Attributes().InitEmptyWithCapacity(0)
+	span.Status().SetCode(pdata.StatusCodeError)
 	return td
 }


### PR DESCRIPTION
**Description:** 

This PR addresses https://github.com/open-telemetry/opentelemetry-collector/issues/2214 and, by extension, https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/1644. ZipkinV2 internal translation was not taking into account the `error` tag. As mentioned in this Specification PR https://github.com/open-telemetry/opentelemetry-specification/pull/1257, and confirmed by @owais , any presence of the [`error` tag should be used to indicate a span status of `Error`](https://github.com/open-telemetry/opentelemetry-specification/pull/1257/files#diff-c50b2cac17490acd52955c504c267e15e9b8f1bfd51f15e02369cb1c83071e13R149) and is also [overriding on any other tag that denotes status for zipkin](https://github.com/open-telemetry/opentelemetry-specification/pull/1257/files#diff-60d9dfa59a8a1a0776c260526b6148549d4087deb626d42732fdd7616ef7a636R56)

**Link to tracking Issue:** <Issue number if applicable>

https://github.com/open-telemetry/opentelemetry-collector/issues/2214

**Testing:**

Added a unit test to current zipkin translation tests
