### PR TITLE
Fix typo in examples/k8s/otel-config.yaml

### DIFF
--- a/examples/k8s/otel-config.yaml
+++ b/examples/k8s/otel-config.yaml
@@ -162,7 +162,7 @@ spec:
     port: 55680
     protocol: TCP
     targetPort: 55680
-  - name: jaeger-grpc # Default endpoing for Jaeger gRPC receiver
+  - name: jaeger-grpc # Default endpoint for Jaeger gRPC receiver
     port: 14250
   - name: jaeger-thrift-http # Default endpoint for Jaeger HTTP receiver.
     port: 14268

--- a/examples/k8s/otel-config.yaml
+++ b/examples/k8s/otel-config.yaml
@@ -162,7 +162,7 @@ spec:
     port: 55680
     protocol: TCP
     targetPort: 55680
-  - name: jaeger-grpc # Default endpoint for Jaeger gRPC receiver
+  - name: jaeger-grpc # Default endpoint for Jaeger gRPC receiver -- temp commit to trigger CI
     port: 14250
   - name: jaeger-thrift-http # Default endpoint for Jaeger HTTP receiver.
     port: 14268

--- a/examples/k8s/otel-config.yaml
+++ b/examples/k8s/otel-config.yaml
@@ -162,7 +162,7 @@ spec:
     port: 55680
     protocol: TCP
     targetPort: 55680
-  - name: jaeger-grpc # Default endpoint for Jaeger gRPC receiver -- temp commit to trigger CI
+  - name: jaeger-grpc # Default endpoint for Jaeger gRPC receiver
     port: 14250
   - name: jaeger-thrift-http # Default endpoint for Jaeger HTTP receiver.
     port: 14268


### PR DESCRIPTION
**Description:** Change `endpoing` to `endpoint` in `examples/k8s/otel-config.yaml`

