### PR TITLE
Don't run contribtest on master. We only want to run it for PRs and releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -236,12 +236,17 @@ workflows:
     jobs:
       - setup-environment:
           filters:
+            branches:
+              ignore: master
             tags:
               only: /^v[0-9]+\.[0-9]+\.[0-9]+.*/
       - contribtest:
           requires:
             - setup-environment
           filters:
+            branches:
+              # Don't run contribtest on master. We only want to run it for PRs and releases.
+              ignore: master
             tags:
               only: /^v[0-9]+\.[0-9]+\.[0-9]+.*/
 


### PR DESCRIPTION
We want contribtest to run on PRs to make it clear when we are making
a breaking change. We also want to run it on release branches to prevent
making a core release when contrib is broken.

However, there is no point in running the contribtest on master branch, it does
not help and only pollutes the view with failures that are always ignored.
