### PR TITLE
Fix the inaccurate mention of headers in prwe

### DIFF
--- a/exporter/prometheusremotewriteexporter/README.md
+++ b/exporter/prometheusremotewriteexporter/README.md
@@ -33,8 +33,8 @@ As a result, the following parameters are also required:
 The following settings can be optionally configured:
 
 - `external_labels`: list of labels to be attached to each metric data point
-- `headers`: additional headers attached to each HTTP request. If
-  `X-Prometheus-Remote-Write-Version` is set, its value must be `0.1.0`
+- `headers`: additional headers attached to each HTTP request. 
+  - *Note the following headers cannot be changed: `Content-Encoding`, `Content-Type`, `X-Prometheus-Remote-Write-Version`, and `User-Agent`.*
 - `namespace`: prefix attached to each exported metric name.
 
 Example:


### PR DESCRIPTION
**Description:** 

This PR is a documentation change addressing this [issue](https://github.com/open-telemetry/opentelemetry-collector/issues/2268). We now specify that certain headers such as (`Content-Encoding`, `Content-Type`, `X-Prometheus-Remote-Write-Version`, and `User-Agent`) cannot be changed in the optional configuration.

**Link to tracking Issue:**  https://github.com/open-telemetry/opentelemetry-collector/issues/2268

**Documentation:** 

The Prometheus Remote Write Exporter documentation was changed to reflect the behavior of the exporter.
