### PR TITLE
Stop pusher after exporter in sample app

### DIFF
--- a/examples/demo/app/main.go
+++ b/examples/demo/app/main.go
@@ -87,8 +87,8 @@ func initProvider() func() {
 
 	return func() {
 		handleErr(tracerProvider.Shutdown(ctx), "failed to shutdown provider")
-		handleErr(exp.Shutdown(ctx), "failed to stop exporter")
 		pusher.Stop() // pushes any last exports to the receiver
+		handleErr(exp.Shutdown(ctx), "failed to stop exporter")
 	}
 }
 


### PR DESCRIPTION
Stopping exporter before stopping pusher causes the pusher to flush
the buffered metrics to a stopped exporter, which basically means
sending metrics to /dev/null.

This has shown up for me, when I limited the number of metrics to a small number. So after shutdown the collector didn't receive any metrics (traces were fine). After the fix, metrics appeared as they should.