### PR TITLE
Environment variable NO_WINDOWS_SERVICE to force interactive mode on Windows

### DIFF
--- a/cmd/otelcol/main_windows.go
+++ b/cmd/otelcol/main_windows.go
@@ -26,16 +26,16 @@ import (
 )
 
 func run(params service.Parameters) error {
-	if isInteractiveMode, err := checkInteractiveMode(); err != nil {
+	if useInteractiveMode, err := checkUseInteractiveMode(); err != nil {
 		return err
-	} else if isInteractiveMode {
+	} else if useInteractiveMode {
 		return runInteractive(params)
 	} else {
 		return runService(params)
 	}
 }
 
-func checkInteractiveMode() (bool, error) {
+func checkUseInteractiveMode() (bool, error) {
 	if value, present := os.LookupEnv("NO_WINDOWS_SERVICE"); present && value != "0" {
 		return true, nil
 	}

--- a/cmd/otelcol/main_windows.go
+++ b/cmd/otelcol/main_windows.go
@@ -36,6 +36,10 @@ func run(params service.Parameters) error {
 }
 
 func checkUseInteractiveMode() (bool, error) {
+	// If environment variable NO_WINDOWS_SERVICE is set with any value other
+	// than 0, use interactive mode instead of running as a service. This should
+	// be set in case running as a service is not possible or desired even
+	// though the current session is not detected to be interactive
 	if value, present := os.LookupEnv("NO_WINDOWS_SERVICE"); present && value != "0" {
 		return true, nil
 	}

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -258,3 +258,11 @@ More often than not, exporting data does not work because of a network
 configuration issue. This could be due to a firewall, DNS, or proxy
 issue. Note that the Collector does have
 [proxy support](https://github.com/open-telemetry/opentelemetry-collector/tree/master/exporter#proxy-support).
+
+### Startup failing in Windows Docker containers
+
+The process may fail to start in a Windows Docker container with the following
+error: `The service process could not connect to the service controller`. In
+this case the `NO_WINDOWS_SERVICE=1` environment variable should be set to force
+the collector to be started as if it were running in an interactive terminal,
+without attempting to run as a Windows service.


### PR DESCRIPTION
**Description:**
Adding a feature - adds a check for NO_WINDOWS_SERVICE environment variable on Windows to allow forcing interactive mode instead of running as a service.

This is required for using the collector in Windows Docker containers, as at least some of the Windows base images do not support services (fails with "The service process could not connect to the service controller"). Environment variable is used instead of automatic detection of Docker as it is uncertain if images that support services are possible and/or desired.

Running collector in Windows Docker containers is required to perform containerized integration tests of agents on Windows.