### PR TITLE
receiverhelper: Add option to filter metrics at receiver

### DIFF
--- a/processor/filterprocessor/config.go
+++ b/processor/filterprocessor/config.go
@@ -22,11 +22,11 @@ import (
 // Config defines configuration for Resource processor.
 type Config struct {
 	configmodels.ProcessorSettings `mapstructure:",squash"`
-	Metrics                        MetricFilters `mapstructure:"metrics"`
+	Metrics                        MetricsFilterConfig `mapstructure:"metrics"`
 }
 
 // MetricFilter filters by Metric properties.
-type MetricFilters struct {
+type MetricsFilterConfig struct {
 	// Include match properties describe metrics that should be included in the Collector Service pipeline,
 	// all other metrics should be dropped from further processing.
 	// If both Include and Exclude are specified, Include filtering occurs first.

--- a/processor/filterprocessor/config_test.go
+++ b/processor/filterprocessor/config_test.go
@@ -62,7 +62,7 @@ func TestLoadingConfigStrict(t *testing.T) {
 					NameVal: "filter/empty",
 					TypeVal: typeStr,
 				},
-				Metrics: MetricFilters{
+				Metrics: MetricsFilterConfig{
 					Include: &filtermetric.MatchProperties{
 						MatchType: filtermetric.Strict,
 					},
@@ -75,7 +75,7 @@ func TestLoadingConfigStrict(t *testing.T) {
 					NameVal: "filter/include",
 					TypeVal: typeStr,
 				},
-				Metrics: MetricFilters{
+				Metrics: MetricsFilterConfig{
 					Include: testDataMetricProperties,
 				},
 			},
@@ -86,7 +86,7 @@ func TestLoadingConfigStrict(t *testing.T) {
 					NameVal: "filter/exclude",
 					TypeVal: typeStr,
 				},
-				Metrics: MetricFilters{
+				Metrics: MetricsFilterConfig{
 					Exclude: testDataMetricProperties,
 				},
 			},
@@ -97,7 +97,7 @@ func TestLoadingConfigStrict(t *testing.T) {
 					NameVal: "filter/includeexclude",
 					TypeVal: typeStr,
 				},
-				Metrics: MetricFilters{
+				Metrics: MetricsFilterConfig{
 					Include: testDataMetricProperties,
 					Exclude: &filtermetric.MatchProperties{
 						MatchType:   filtermetric.Strict,
@@ -156,7 +156,7 @@ func TestLoadingConfigRegexp(t *testing.T) {
 					NameVal: "filter/include",
 					TypeVal: typeStr,
 				},
-				Metrics: MetricFilters{
+				Metrics: MetricsFilterConfig{
 					Include: testDataMetricProperties,
 				},
 			},
@@ -167,7 +167,7 @@ func TestLoadingConfigRegexp(t *testing.T) {
 					NameVal: "filter/exclude",
 					TypeVal: typeStr,
 				},
-				Metrics: MetricFilters{
+				Metrics: MetricsFilterConfig{
 					Exclude: testDataMetricProperties,
 				},
 			},
@@ -178,7 +178,7 @@ func TestLoadingConfigRegexp(t *testing.T) {
 					NameVal: "filter/unlimitedcache",
 					TypeVal: typeStr,
 				},
-				Metrics: MetricFilters{
+				Metrics: MetricsFilterConfig{
 					Include: &filtermetric.MatchProperties{
 						MatchType: filtermetric.Regexp,
 						RegexpConfig: &fsregexp.Config{
@@ -195,7 +195,7 @@ func TestLoadingConfigRegexp(t *testing.T) {
 					NameVal: "filter/limitedcache",
 					TypeVal: typeStr,
 				},
-				Metrics: MetricFilters{
+				Metrics: MetricsFilterConfig{
 					Exclude: &filtermetric.MatchProperties{
 						MatchType: filtermetric.Regexp,
 						RegexpConfig: &fsregexp.Config{
@@ -237,7 +237,7 @@ func TestLoadingConfigExpr(t *testing.T) {
 					NameVal: "filter/empty",
 					TypeVal: typeStr,
 				},
-				Metrics: MetricFilters{
+				Metrics: MetricsFilterConfig{
 					Include: &filtermetric.MatchProperties{
 						MatchType: filtermetric.Expr,
 					},
@@ -251,7 +251,7 @@ func TestLoadingConfigExpr(t *testing.T) {
 					NameVal: "filter/include",
 					TypeVal: typeStr,
 				},
-				Metrics: MetricFilters{
+				Metrics: MetricsFilterConfig{
 					Include: &filtermetric.MatchProperties{
 						MatchType: filtermetric.Expr,
 						Expressions: []string{
@@ -269,7 +269,7 @@ func TestLoadingConfigExpr(t *testing.T) {
 					NameVal: "filter/exclude",
 					TypeVal: typeStr,
 				},
-				Metrics: MetricFilters{
+				Metrics: MetricsFilterConfig{
 					Exclude: &filtermetric.MatchProperties{
 						MatchType: filtermetric.Expr,
 						Expressions: []string{
@@ -287,7 +287,7 @@ func TestLoadingConfigExpr(t *testing.T) {
 					NameVal: "filter/includeexclude",
 					TypeVal: typeStr,
 				},
-				Metrics: MetricFilters{
+				Metrics: MetricsFilterConfig{
 					Include: &filtermetric.MatchProperties{
 						MatchType: filtermetric.Expr,
 						Expressions: []string{

--- a/processor/filterprocessor/expr_test.go
+++ b/processor/filterprocessor/expr_test.go
@@ -168,7 +168,7 @@ func testProcessor(t *testing.T, include []string, exclude []string) (component.
 func exprConfig(factory component.ProcessorFactory, include []string, exclude []string) configmodels.Processor {
 	cfg := factory.CreateDefaultConfig()
 	pCfg := cfg.(*Config)
-	pCfg.Metrics = MetricFilters{}
+	pCfg.Metrics = MetricsFilterConfig{}
 	if include != nil {
 		pCfg.Metrics.Include = &filtermetric.MatchProperties{
 			MatchType:   "expr",

--- a/processor/filterprocessor/filter_processor.go
+++ b/processor/filterprocessor/filter_processor.go
@@ -24,8 +24,8 @@ import (
 )
 
 type filterMetricProcessor struct {
-	cfg           *Config
-	metricsFilter *MetricsFilter
+	cfg             *Config
+	metricsFilterer *MetricsFilterer
 }
 
 func newFilterMetricProcessor(logger *zap.Logger, cfg *Config) (*filterMetricProcessor, error) {
@@ -57,18 +57,18 @@ func newFilterMetricProcessor(logger *zap.Logger, cfg *Config) (*filterMetricPro
 		zap.Strings("exclude metric names", excludeMetricNames),
 	)
 
-	metricsFilter, err := NewMetricsFilter(cfg.Metrics.Include, cfg.Metrics.Exclude, logger)
+	metricsFilterer, err := NewMetricsFilterer(cfg.Metrics.Include, cfg.Metrics.Exclude, logger)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create metrics filter: %w", err)
 	}
 
 	return &filterMetricProcessor{
-		cfg:           cfg,
-		metricsFilter: metricsFilter,
+		cfg:             cfg,
+		metricsFilterer: metricsFilterer,
 	}, nil
 }
 
 // ProcessMetrics filters the given metrics based off the filterMetricProcessor's filters.
 func (fmp *filterMetricProcessor) ProcessMetrics(_ context.Context, pdm pdata.Metrics) (pdata.Metrics, error) {
-	return fmp.metricsFilter.FilterMetrics(pdm)
+	return fmp.metricsFilterer.FilterMetrics(pdm)
 }

--- a/processor/filterprocessor/filter_processor.go
+++ b/processor/filterprocessor/filter_processor.go
@@ -25,7 +25,7 @@ import (
 
 type filterMetricProcessor struct {
 	cfg             *Config
-	metricsFilterer *MetricsFilterer
+	metricsFilterer *MetricsFilter
 }
 
 func newFilterMetricProcessor(logger *zap.Logger, cfg *Config) (*filterMetricProcessor, error) {
@@ -57,7 +57,7 @@ func newFilterMetricProcessor(logger *zap.Logger, cfg *Config) (*filterMetricPro
 		zap.Strings("exclude metric names", excludeMetricNames),
 	)
 
-	metricsFilterer, err := NewMetricsFilterer(cfg.Metrics.Include, cfg.Metrics.Exclude, logger)
+	metricsFilterer, err := NewMetricsFilter(cfg.Metrics.Include, cfg.Metrics.Exclude, logger)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create metrics filter: %w", err)
 	}

--- a/processor/filterprocessor/filter_processor_test.go
+++ b/processor/filterprocessor/filter_processor_test.go
@@ -189,7 +189,7 @@ func TestFilterMetricProcessor(t *testing.T) {
 					TypeVal: typeStr,
 					NameVal: typeStr,
 				},
-				Metrics: MetricFilters{
+				Metrics: MetricsFilterConfig{
 					Include: test.inc,
 					Exclude: test.exc,
 				},
@@ -294,7 +294,7 @@ func benchmarkFilter(b *testing.B, mp *filtermetric.MatchProperties) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
 	pcfg := cfg.(*Config)
-	pcfg.Metrics = MetricFilters{
+	pcfg.Metrics = MetricsFilterConfig{
 		Exclude: mp,
 	}
 	ctx := context.Background()
@@ -392,7 +392,7 @@ func requireNotPanics(t *testing.T, metrics pdata.Metrics) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
 	pcfg := cfg.(*Config)
-	pcfg.Metrics = MetricFilters{
+	pcfg.Metrics = MetricsFilterConfig{
 		Exclude: &filtermetric.MatchProperties{
 			MatchType:   "strict",
 			MetricNames: []string{"foo"},

--- a/processor/filterprocessor/metric_filter.go
+++ b/processor/filterprocessor/metric_filter.go
@@ -1,0 +1,110 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filterprocessor
+
+import (
+	"go.uber.org/zap"
+
+	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.opentelemetry.io/collector/internal/processor/filtermetric"
+	"go.opentelemetry.io/collector/processor/processorhelper"
+)
+
+type MetricsFilter struct {
+	include filtermetric.Matcher
+	exclude filtermetric.Matcher
+
+	logger *zap.Logger
+}
+
+// FilterMetrics filters the given metrics based off the MetricsFilter's filters.
+func (f *MetricsFilter) FilterMetrics(pdm pdata.Metrics) (pdata.Metrics, error) {
+	rms := pdm.ResourceMetrics()
+	idx := newMetricIndex()
+	for i := 0; i < rms.Len(); i++ {
+		ilms := rms.At(i).InstrumentationLibraryMetrics()
+		for j := 0; j < ilms.Len(); j++ {
+			ms := ilms.At(j).Metrics()
+			for k := 0; k < ms.Len(); k++ {
+				keep, err := f.shouldKeepMetric(ms.At(k))
+				if err != nil {
+					f.logger.Error("shouldKeepMetric failed", zap.Error(err))
+					// don't `continue`, keep the metric if there's an error
+				}
+				if keep {
+					idx.add(i, j, k)
+				}
+			}
+		}
+	}
+	if idx.isEmpty() {
+		return pdm, processorhelper.ErrSkipProcessingData
+	}
+	return idx.extract(pdm), nil
+}
+
+func (f *MetricsFilter) shouldKeepMetric(metric pdata.Metric) (bool, error) {
+	if f.include != nil {
+		matches, err := f.include.MatchMetric(metric)
+		if err != nil {
+			// default to keep if there's an error
+			return true, err
+		}
+		if !matches {
+			return false, nil
+		}
+	}
+
+	if f.exclude != nil {
+		matches, err := f.exclude.MatchMetric(metric)
+		if err != nil {
+			return true, err
+		}
+		if matches {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+func NewMetricsFilter(
+	include *filtermetric.MatchProperties,
+	exclude *filtermetric.MatchProperties,
+	logger *zap.Logger) (*MetricsFilter, error) {
+	inc, err := createMatcher(include)
+	if err != nil {
+		return nil, err
+	}
+
+	exc, err := createMatcher(exclude)
+	if err != nil {
+		return nil, err
+	}
+
+	return &MetricsFilter{
+		include: inc,
+		exclude: exc,
+		logger:  logger,
+	}, nil
+}
+
+func createMatcher(mp *filtermetric.MatchProperties) (filtermetric.Matcher, error) {
+	// Nothing specified in configuration
+	if mp == nil {
+		return nil, nil
+	}
+	return filtermetric.NewMatcher(mp)
+}

--- a/processor/filterprocessor/metric_filter.go
+++ b/processor/filterprocessor/metric_filter.go
@@ -22,17 +22,17 @@ import (
 	"go.opentelemetry.io/collector/processor/processorhelper"
 )
 
-type MetricsFilterer struct {
+type MetricsFilter struct {
 	include filtermetric.Matcher
 	exclude filtermetric.Matcher
 
 	logger *zap.Logger
 }
 
-func NewMetricsFilterer(
+func NewMetricsFilter(
 	include *filtermetric.MatchProperties,
 	exclude *filtermetric.MatchProperties,
-	logger *zap.Logger) (*MetricsFilterer, error) {
+	logger *zap.Logger) (*MetricsFilter, error) {
 	inc, err := createMatcher(include)
 	if err != nil {
 		return nil, err
@@ -43,7 +43,7 @@ func NewMetricsFilterer(
 		return nil, err
 	}
 
-	return &MetricsFilterer{
+	return &MetricsFilter{
 		include: inc,
 		exclude: exc,
 		logger:  logger,
@@ -58,8 +58,8 @@ func createMatcher(mp *filtermetric.MatchProperties) (filtermetric.Matcher, erro
 	return filtermetric.NewMatcher(mp)
 }
 
-// FilterMetrics filters the given metrics based off the MetricsFilterer's filters.
-func (f *MetricsFilterer) FilterMetrics(pdm pdata.Metrics) (pdata.Metrics, error) {
+// FilterMetrics filters the given metrics based off the MetricsFilter's filters.
+func (f *MetricsFilter) FilterMetrics(pdm pdata.Metrics) (pdata.Metrics, error) {
 	rms := pdm.ResourceMetrics()
 	idx := newMetricIndex()
 	for i := 0; i < rms.Len(); i++ {
@@ -84,7 +84,7 @@ func (f *MetricsFilterer) FilterMetrics(pdm pdata.Metrics) (pdata.Metrics, error
 	return idx.extract(pdm), nil
 }
 
-func (f *MetricsFilterer) shouldKeepMetric(metric pdata.Metric) (bool, error) {
+func (f *MetricsFilter) shouldKeepMetric(metric pdata.Metric) (bool, error) {
 	if f.include != nil {
 		matches, err := f.include.MatchMetric(metric)
 		if err != nil {

--- a/receiver/receiverhelper/metricsfilter.go
+++ b/receiver/receiverhelper/metricsfilter.go
@@ -25,6 +25,10 @@ import (
 	"go.opentelemetry.io/collector/processor/filterprocessor"
 )
 
+type FilterSettings struct {
+	filterprocessor.MetricsFilterConfig `mapstructure:"metrics_filter"`
+}
+
 // consumerWithFilter wraps a consumer with *filterprocessor.MetricsFilter
 type consumerWithFilter struct {
 	metricsFilter *filterprocessor.MetricsFilter
@@ -36,8 +40,8 @@ type consumerWithFilter struct {
 func ConsumerWithFilter(
 	logger *zap.Logger,
 	consumer consumer.MetricsConsumer,
-	filterCfg filterprocessor.MetricsFilterConfig) (consumer.MetricsConsumer, error) {
-	metricsFilterer, err := filterprocessor.NewMetricsFilter(filterCfg.Include, filterCfg.Exclude, logger)
+	filterSettings FilterSettings) (consumer.MetricsConsumer, error) {
+	metricsFilterer, err := filterprocessor.NewMetricsFilter(filterSettings.Include, filterSettings.Exclude, logger)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create metrics filterCfg: %w", err)
 	}

--- a/receiver/receiverhelper/metricsfilter.go
+++ b/receiver/receiverhelper/metricsfilter.go
@@ -1,0 +1,61 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package receiverhelper
+
+import (
+	"context"
+	"fmt"
+
+	"go.uber.org/zap"
+
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.opentelemetry.io/collector/processor/filterprocessor"
+)
+
+type FilterSettings struct {
+	filterprocessor.MetricFilters `mapstructure:"metrics_filter"`
+}
+
+// consumerWithFilter wraps a consumer with *filterprocessor.MetricsFilter
+type consumerWithFilter struct {
+	metricsFilter *filterprocessor.MetricsFilter
+	nextConsumer  consumer.MetricsConsumer
+}
+
+// ConsumerWithFilter returns the consumer wrapped with a filter. This is an experimental
+// feature, expect breaking changes.
+func ConsumerWithFilter(
+	logger *zap.Logger,
+	consumer consumer.MetricsConsumer,
+	filterSettings FilterSettings) (consumer.MetricsConsumer, error) {
+	metricsFilter, err := filterprocessor.NewMetricsFilter(filterSettings.Include, filterSettings.Exclude, logger)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create metrics filter: %w", err)
+	}
+
+	return &consumerWithFilter{
+		metricsFilter: metricsFilter,
+		nextConsumer:  consumer,
+	}, nil
+}
+
+func (cwf *consumerWithFilter) ConsumeMetrics(ctx context.Context, pdm pdata.Metrics) error {
+	filteredPdm, err := cwf.metricsFilter.FilterMetrics(pdm)
+	if err != nil {
+		return err
+	}
+	return cwf.nextConsumer.ConsumeMetrics(ctx, filteredPdm)
+}

--- a/receiver/receiverhelper/metricsfilter.go
+++ b/receiver/receiverhelper/metricsfilter.go
@@ -25,13 +25,9 @@ import (
 	"go.opentelemetry.io/collector/processor/filterprocessor"
 )
 
-type FilterSettings struct {
-	filterprocessor.MetricFilters `mapstructure:"metrics_filter"`
-}
-
-// consumerWithFilter wraps a consumer with *filterprocessor.MetricsFilter
+// consumerWithFilter wraps a consumer with *filterprocessor.MetricsFilterer
 type consumerWithFilter struct {
-	metricsFilter *filterprocessor.MetricsFilter
+	metricsFilter *filterprocessor.MetricsFilterer
 	nextConsumer  consumer.MetricsConsumer
 }
 
@@ -40,14 +36,14 @@ type consumerWithFilter struct {
 func ConsumerWithFilter(
 	logger *zap.Logger,
 	consumer consumer.MetricsConsumer,
-	filterSettings FilterSettings) (consumer.MetricsConsumer, error) {
-	metricsFilter, err := filterprocessor.NewMetricsFilter(filterSettings.Include, filterSettings.Exclude, logger)
+	filter filterprocessor.MetricFilters) (consumer.MetricsConsumer, error) {
+	metricsFilterer, err := filterprocessor.NewMetricsFilterer(filter.Include, filter.Exclude, logger)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create metrics filter: %w", err)
 	}
 
 	return &consumerWithFilter{
-		metricsFilter: metricsFilter,
+		metricsFilter: metricsFilterer,
 		nextConsumer:  consumer,
 	}, nil
 }

--- a/receiver/receiverhelper/metricsfilter.go
+++ b/receiver/receiverhelper/metricsfilter.go
@@ -25,21 +25,21 @@ import (
 	"go.opentelemetry.io/collector/processor/filterprocessor"
 )
 
-// consumerWithFilter wraps a consumer with *filterprocessor.MetricsFilterer
+// consumerWithFilter wraps a consumer with *filterprocessor.MetricsFilter
 type consumerWithFilter struct {
-	metricsFilter *filterprocessor.MetricsFilterer
+	metricsFilter *filterprocessor.MetricsFilter
 	nextConsumer  consumer.MetricsConsumer
 }
 
-// ConsumerWithFilter returns the consumer wrapped with a filter. This is an experimental
+// ConsumerWithFilter returns the consumer wrapped with a filterCfg. This is an experimental
 // feature, expect breaking changes.
 func ConsumerWithFilter(
 	logger *zap.Logger,
 	consumer consumer.MetricsConsumer,
-	filter filterprocessor.MetricFilters) (consumer.MetricsConsumer, error) {
-	metricsFilterer, err := filterprocessor.NewMetricsFilterer(filter.Include, filter.Exclude, logger)
+	filterCfg filterprocessor.MetricsFilterConfig) (consumer.MetricsConsumer, error) {
+	metricsFilterer, err := filterprocessor.NewMetricsFilter(filterCfg.Include, filterCfg.Exclude, logger)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create metrics filter: %w", err)
+		return nil, fmt.Errorf("failed to create metrics filterCfg: %w", err)
 	}
 
 	return &consumerWithFilter{

--- a/receiver/receiverhelper/metricsfilter_test.go
+++ b/receiver/receiverhelper/metricsfilter_test.go
@@ -45,16 +45,16 @@ func TestConsumerWithFilter(t *testing.T) {
 	tests := []struct {
 		name                    string
 		consumer                *consumertest.MetricsSink
-		filter                  filterprocessor.MetricFilters
+		filterCfg               filterprocessor.MetricsFilterConfig
 		inputMetrics            pdata.Metrics
 		expectedMetrics         []string
 		wantErr                 bool
 		wantErrOnConsumeMetrics bool
 	}{
 		{
-			name:     "Empty filter",
-			consumer: &consumertest.MetricsSink{},
-			filter:   filterprocessor.MetricFilters{},
+			name:      "Empty filterCfg",
+			consumer:  &consumertest.MetricsSink{},
+			filterCfg: filterprocessor.MetricsFilterConfig{},
 			expectedMetrics: []string{
 				"metric_1",
 				"metric_2",
@@ -63,9 +63,9 @@ func TestConsumerWithFilter(t *testing.T) {
 			inputMetrics: inputMetrics,
 		},
 		{
-			name:     "Strict include filter",
+			name:     "Strict include filterCfg",
 			consumer: &consumertest.MetricsSink{},
-			filter: filterprocessor.MetricFilters{
+			filterCfg: filterprocessor.MetricsFilterConfig{
 				Include: &filtermetric.MatchProperties{
 					MatchType: "strict",
 					MetricNames: []string{
@@ -79,9 +79,9 @@ func TestConsumerWithFilter(t *testing.T) {
 			inputMetrics: inputMetrics,
 		},
 		{
-			name:     "Strict exclude filter",
+			name:     "Strict exclude filterCfg",
 			consumer: &consumertest.MetricsSink{},
-			filter: filterprocessor.MetricFilters{
+			filterCfg: filterprocessor.MetricsFilterConfig{
 				Exclude: &filtermetric.MatchProperties{
 					MatchType: "strict",
 					MetricNames: []string{
@@ -96,9 +96,9 @@ func TestConsumerWithFilter(t *testing.T) {
 			inputMetrics: inputMetrics,
 		},
 		{
-			name:     "Regex include filter",
+			name:     "Regex include filterCfg",
 			consumer: &consumertest.MetricsSink{},
-			filter: filterprocessor.MetricFilters{
+			filterCfg: filterprocessor.MetricsFilterConfig{
 				Include: &filtermetric.MatchProperties{
 					MatchType: "regexp",
 					MetricNames: []string{
@@ -112,9 +112,9 @@ func TestConsumerWithFilter(t *testing.T) {
 			inputMetrics: inputMetrics,
 		},
 		{
-			name:     "Regex exclude filter",
+			name:     "Regex exclude filterCfg",
 			consumer: &consumertest.MetricsSink{},
-			filter: filterprocessor.MetricFilters{
+			filterCfg: filterprocessor.MetricsFilterConfig{
 				Exclude: &filtermetric.MatchProperties{
 					MatchType: "regexp",
 					MetricNames: []string{
@@ -131,7 +131,7 @@ func TestConsumerWithFilter(t *testing.T) {
 		{
 			name:     "Filter error",
 			consumer: &consumertest.MetricsSink{},
-			filter: filterprocessor.MetricFilters{
+			filterCfg: filterprocessor.MetricsFilterConfig{
 				Exclude: &filtermetric.MatchProperties{
 					MatchType: "regexp",
 					MetricNames: []string{
@@ -145,7 +145,7 @@ func TestConsumerWithFilter(t *testing.T) {
 		{
 			name:                    "ConsumeMetrics error",
 			consumer:                &consumertest.MetricsSink{},
-			filter:                  filterprocessor.MetricFilters{},
+			filterCfg:               filterprocessor.MetricsFilterConfig{},
 			wantErrOnConsumeMetrics: true,
 			inputMetrics:            pdata.NewMetrics(),
 		},
@@ -154,7 +154,7 @@ func TestConsumerWithFilter(t *testing.T) {
 	logger := zap.NewNop()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := ConsumerWithFilter(logger, tt.consumer, tt.filter)
+			got, err := ConsumerWithFilter(logger, tt.consumer, tt.filterCfg)
 			if tt.wantErr {
 				require.Error(t, err)
 				require.Nil(t, got)

--- a/receiver/receiverhelper/metricsfilter_test.go
+++ b/receiver/receiverhelper/metricsfilter_test.go
@@ -45,16 +45,16 @@ func TestConsumerWithFilter(t *testing.T) {
 	tests := []struct {
 		name                    string
 		consumer                *consumertest.MetricsSink
-		filterCfg               filterprocessor.MetricsFilterConfig
+		filterSettings          FilterSettings
 		inputMetrics            pdata.Metrics
 		expectedMetrics         []string
 		wantErr                 bool
 		wantErrOnConsumeMetrics bool
 	}{
 		{
-			name:      "Empty filterCfg",
-			consumer:  &consumertest.MetricsSink{},
-			filterCfg: filterprocessor.MetricsFilterConfig{},
+			name:           "Empty filterCfg",
+			consumer:       &consumertest.MetricsSink{},
+			filterSettings: FilterSettings{},
 			expectedMetrics: []string{
 				"metric_1",
 				"metric_2",
@@ -65,11 +65,13 @@ func TestConsumerWithFilter(t *testing.T) {
 		{
 			name:     "Strict include filterCfg",
 			consumer: &consumertest.MetricsSink{},
-			filterCfg: filterprocessor.MetricsFilterConfig{
-				Include: &filtermetric.MatchProperties{
-					MatchType: "strict",
-					MetricNames: []string{
-						"metric_1",
+			filterSettings: FilterSettings{
+				MetricsFilterConfig: filterprocessor.MetricsFilterConfig{
+					Include: &filtermetric.MatchProperties{
+						MatchType: "strict",
+						MetricNames: []string{
+							"metric_1",
+						},
 					},
 				},
 			},
@@ -81,12 +83,14 @@ func TestConsumerWithFilter(t *testing.T) {
 		{
 			name:     "Strict exclude filterCfg",
 			consumer: &consumertest.MetricsSink{},
-			filterCfg: filterprocessor.MetricsFilterConfig{
-				Exclude: &filtermetric.MatchProperties{
-					MatchType: "strict",
-					MetricNames: []string{
-						"metric_2",
-						"metric_3",
+			filterSettings: FilterSettings{
+				MetricsFilterConfig: filterprocessor.MetricsFilterConfig{
+					Exclude: &filtermetric.MatchProperties{
+						MatchType: "strict",
+						MetricNames: []string{
+							"metric_2",
+							"metric_3",
+						},
 					},
 				},
 			},
@@ -98,11 +102,13 @@ func TestConsumerWithFilter(t *testing.T) {
 		{
 			name:     "Regex include filterCfg",
 			consumer: &consumertest.MetricsSink{},
-			filterCfg: filterprocessor.MetricsFilterConfig{
-				Include: &filtermetric.MatchProperties{
-					MatchType: "regexp",
-					MetricNames: []string{
-						".*1",
+			filterSettings: FilterSettings{
+				MetricsFilterConfig: filterprocessor.MetricsFilterConfig{
+					Include: &filtermetric.MatchProperties{
+						MatchType: "regexp",
+						MetricNames: []string{
+							".*1",
+						},
 					},
 				},
 			},
@@ -114,11 +120,13 @@ func TestConsumerWithFilter(t *testing.T) {
 		{
 			name:     "Regex exclude filterCfg",
 			consumer: &consumertest.MetricsSink{},
-			filterCfg: filterprocessor.MetricsFilterConfig{
-				Exclude: &filtermetric.MatchProperties{
-					MatchType: "regexp",
-					MetricNames: []string{
-						".*2",
+			filterSettings: FilterSettings{
+				MetricsFilterConfig: filterprocessor.MetricsFilterConfig{
+					Exclude: &filtermetric.MatchProperties{
+						MatchType: "regexp",
+						MetricNames: []string{
+							".*2",
+						},
 					},
 				},
 			},
@@ -131,11 +139,13 @@ func TestConsumerWithFilter(t *testing.T) {
 		{
 			name:     "Filter error",
 			consumer: &consumertest.MetricsSink{},
-			filterCfg: filterprocessor.MetricsFilterConfig{
-				Exclude: &filtermetric.MatchProperties{
-					MatchType: "regexp",
-					MetricNames: []string{
-						"*2",
+			filterSettings: FilterSettings{
+				MetricsFilterConfig: filterprocessor.MetricsFilterConfig{
+					Exclude: &filtermetric.MatchProperties{
+						MatchType: "regexp",
+						MetricNames: []string{
+							"*2",
+						},
 					},
 				},
 			},
@@ -145,7 +155,7 @@ func TestConsumerWithFilter(t *testing.T) {
 		{
 			name:                    "ConsumeMetrics error",
 			consumer:                &consumertest.MetricsSink{},
-			filterCfg:               filterprocessor.MetricsFilterConfig{},
+			filterSettings:          FilterSettings{},
 			wantErrOnConsumeMetrics: true,
 			inputMetrics:            pdata.NewMetrics(),
 		},
@@ -154,7 +164,7 @@ func TestConsumerWithFilter(t *testing.T) {
 	logger := zap.NewNop()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := ConsumerWithFilter(logger, tt.consumer, tt.filterCfg)
+			got, err := ConsumerWithFilter(logger, tt.consumer, tt.filterSettings)
 			if tt.wantErr {
 				require.Error(t, err)
 				require.Nil(t, got)

--- a/receiver/receiverhelper/metricsfilter_test.go
+++ b/receiver/receiverhelper/metricsfilter_test.go
@@ -45,16 +45,16 @@ func TestConsumerWithFilter(t *testing.T) {
 	tests := []struct {
 		name                    string
 		consumer                *consumertest.MetricsSink
-		filterSettings          FilterSettings
+		filter                  filterprocessor.MetricFilters
 		inputMetrics            pdata.Metrics
 		expectedMetrics         []string
 		wantErr                 bool
 		wantErrOnConsumeMetrics bool
 	}{
 		{
-			name:           "Empty filter",
-			consumer:       &consumertest.MetricsSink{},
-			filterSettings: FilterSettings{},
+			name:     "Empty filter",
+			consumer: &consumertest.MetricsSink{},
+			filter:   filterprocessor.MetricFilters{},
 			expectedMetrics: []string{
 				"metric_1",
 				"metric_2",
@@ -65,13 +65,11 @@ func TestConsumerWithFilter(t *testing.T) {
 		{
 			name:     "Strict include filter",
 			consumer: &consumertest.MetricsSink{},
-			filterSettings: FilterSettings{
-				MetricFilters: filterprocessor.MetricFilters{
-					Include: &filtermetric.MatchProperties{
-						MatchType: "strict",
-						MetricNames: []string{
-							"metric_1",
-						},
+			filter: filterprocessor.MetricFilters{
+				Include: &filtermetric.MatchProperties{
+					MatchType: "strict",
+					MetricNames: []string{
+						"metric_1",
 					},
 				},
 			},
@@ -83,14 +81,12 @@ func TestConsumerWithFilter(t *testing.T) {
 		{
 			name:     "Strict exclude filter",
 			consumer: &consumertest.MetricsSink{},
-			filterSettings: FilterSettings{
-				MetricFilters: filterprocessor.MetricFilters{
-					Exclude: &filtermetric.MatchProperties{
-						MatchType: "strict",
-						MetricNames: []string{
-							"metric_2",
-							"metric_3",
-						},
+			filter: filterprocessor.MetricFilters{
+				Exclude: &filtermetric.MatchProperties{
+					MatchType: "strict",
+					MetricNames: []string{
+						"metric_2",
+						"metric_3",
 					},
 				},
 			},
@@ -102,13 +98,11 @@ func TestConsumerWithFilter(t *testing.T) {
 		{
 			name:     "Regex include filter",
 			consumer: &consumertest.MetricsSink{},
-			filterSettings: FilterSettings{
-				MetricFilters: filterprocessor.MetricFilters{
-					Include: &filtermetric.MatchProperties{
-						MatchType: "regexp",
-						MetricNames: []string{
-							".*1",
-						},
+			filter: filterprocessor.MetricFilters{
+				Include: &filtermetric.MatchProperties{
+					MatchType: "regexp",
+					MetricNames: []string{
+						".*1",
 					},
 				},
 			},
@@ -120,13 +114,11 @@ func TestConsumerWithFilter(t *testing.T) {
 		{
 			name:     "Regex exclude filter",
 			consumer: &consumertest.MetricsSink{},
-			filterSettings: FilterSettings{
-				MetricFilters: filterprocessor.MetricFilters{
-					Exclude: &filtermetric.MatchProperties{
-						MatchType: "regexp",
-						MetricNames: []string{
-							".*2",
-						},
+			filter: filterprocessor.MetricFilters{
+				Exclude: &filtermetric.MatchProperties{
+					MatchType: "regexp",
+					MetricNames: []string{
+						".*2",
 					},
 				},
 			},
@@ -139,13 +131,11 @@ func TestConsumerWithFilter(t *testing.T) {
 		{
 			name:     "Filter error",
 			consumer: &consumertest.MetricsSink{},
-			filterSettings: FilterSettings{
-				MetricFilters: filterprocessor.MetricFilters{
-					Exclude: &filtermetric.MatchProperties{
-						MatchType: "regexp",
-						MetricNames: []string{
-							"*2",
-						},
+			filter: filterprocessor.MetricFilters{
+				Exclude: &filtermetric.MatchProperties{
+					MatchType: "regexp",
+					MetricNames: []string{
+						"*2",
 					},
 				},
 			},
@@ -155,7 +145,7 @@ func TestConsumerWithFilter(t *testing.T) {
 		{
 			name:                    "ConsumeMetrics error",
 			consumer:                &consumertest.MetricsSink{},
-			filterSettings:          FilterSettings{},
+			filter:                  filterprocessor.MetricFilters{},
 			wantErrOnConsumeMetrics: true,
 			inputMetrics:            pdata.NewMetrics(),
 		},
@@ -164,7 +154,7 @@ func TestConsumerWithFilter(t *testing.T) {
 	logger := zap.NewNop()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := ConsumerWithFilter(logger, tt.consumer, tt.filterSettings)
+			got, err := ConsumerWithFilter(logger, tt.consumer, tt.filter)
 			if tt.wantErr {
 				require.Error(t, err)
 				require.Nil(t, got)

--- a/receiver/receiverhelper/metricsfilter_test.go
+++ b/receiver/receiverhelper/metricsfilter_test.go
@@ -1,0 +1,190 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package receiverhelper
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.opentelemetry.io/collector/internal/processor/filtermetric"
+	"go.opentelemetry.io/collector/processor/filterprocessor"
+)
+
+func TestConsumerWithFilter(t *testing.T) {
+	inputMetrics := func() pdata.Metrics {
+		out := pdata.NewMetrics()
+		rm := out.ResourceMetrics()
+		rm.Resize(1)
+		ilm := rm.At(0).InstrumentationLibraryMetrics()
+		ilm.Resize(1)
+		metrics := ilm.At(0).Metrics()
+		metrics.Resize(3)
+		metrics.At(0).SetName("metric_1")
+		metrics.At(1).SetName("metric_2")
+		metrics.At(2).SetName("metric_3")
+		return out
+	}()
+
+	tests := []struct {
+		name                    string
+		consumer                *consumertest.MetricsSink
+		filterSettings          FilterSettings
+		inputMetrics            pdata.Metrics
+		expectedMetrics         []string
+		wantErr                 bool
+		wantErrOnConsumeMetrics bool
+	}{
+		{
+			name:           "Empty filter",
+			consumer:       &consumertest.MetricsSink{},
+			filterSettings: FilterSettings{},
+			expectedMetrics: []string{
+				"metric_1",
+				"metric_2",
+				"metric_3",
+			},
+			inputMetrics: inputMetrics,
+		},
+		{
+			name:     "Strict include filter",
+			consumer: &consumertest.MetricsSink{},
+			filterSettings: FilterSettings{
+				MetricFilters: filterprocessor.MetricFilters{
+					Include: &filtermetric.MatchProperties{
+						MatchType: "strict",
+						MetricNames: []string{
+							"metric_1",
+						},
+					},
+				},
+			},
+			expectedMetrics: []string{
+				"metric_1",
+			},
+			inputMetrics: inputMetrics,
+		},
+		{
+			name:     "Strict exclude filter",
+			consumer: &consumertest.MetricsSink{},
+			filterSettings: FilterSettings{
+				MetricFilters: filterprocessor.MetricFilters{
+					Exclude: &filtermetric.MatchProperties{
+						MatchType: "strict",
+						MetricNames: []string{
+							"metric_2",
+							"metric_3",
+						},
+					},
+				},
+			},
+			expectedMetrics: []string{
+				"metric_1",
+			},
+			inputMetrics: inputMetrics,
+		},
+		{
+			name:     "Regex include filter",
+			consumer: &consumertest.MetricsSink{},
+			filterSettings: FilterSettings{
+				MetricFilters: filterprocessor.MetricFilters{
+					Include: &filtermetric.MatchProperties{
+						MatchType: "regexp",
+						MetricNames: []string{
+							".*1",
+						},
+					},
+				},
+			},
+			expectedMetrics: []string{
+				"metric_1",
+			},
+			inputMetrics: inputMetrics,
+		},
+		{
+			name:     "Regex exclude filter",
+			consumer: &consumertest.MetricsSink{},
+			filterSettings: FilterSettings{
+				MetricFilters: filterprocessor.MetricFilters{
+					Exclude: &filtermetric.MatchProperties{
+						MatchType: "regexp",
+						MetricNames: []string{
+							".*2",
+						},
+					},
+				},
+			},
+			expectedMetrics: []string{
+				"metric_1",
+				"metric_3",
+			},
+			inputMetrics: inputMetrics,
+		},
+		{
+			name:     "Filter error",
+			consumer: &consumertest.MetricsSink{},
+			filterSettings: FilterSettings{
+				MetricFilters: filterprocessor.MetricFilters{
+					Exclude: &filtermetric.MatchProperties{
+						MatchType: "regexp",
+						MetricNames: []string{
+							"*2",
+						},
+					},
+				},
+			},
+			inputMetrics: inputMetrics,
+			wantErr:      true,
+		},
+		{
+			name:                    "ConsumeMetrics error",
+			consumer:                &consumertest.MetricsSink{},
+			filterSettings:          FilterSettings{},
+			wantErrOnConsumeMetrics: true,
+			inputMetrics:            pdata.NewMetrics(),
+		},
+	}
+
+	logger := zap.NewNop()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ConsumerWithFilter(logger, tt.consumer, tt.filterSettings)
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Nil(t, got)
+				return
+			}
+
+			err = got.ConsumeMetrics(context.Background(), tt.inputMetrics)
+			if tt.wantErrOnConsumeMetrics {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, len(tt.expectedMetrics), tt.consumer.MetricsCount())
+			rms := tt.consumer.AllMetrics()[0]
+			ilms := rms.ResourceMetrics().At(0).InstrumentationLibraryMetrics()
+			for i := 0; i < len(tt.expectedMetrics); i++ {
+				metric := ilms.At(0).Metrics().At(i)
+				require.Equal(t, tt.expectedMetrics[i], metric.Name())
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Description:** Add option to filter metrics at a receiver. The core filtering logic is reused from the `filterprocessor`. A sample receiver config with this filtering enabled would look like the following -

```yaml
  hostmetrics:
    collection_interval: 10s
    scrapers:
      load:
    metrics_filter:
      include:
        match_type: strict
        metric_names:
          - system.cpu.load_average.5m
```

With the above config, the receiver would only pass `system.cpu.load_average.5m` metric onto the next consumer. 

Also note, this PR does not use `receiverhelper.FilterSettings` in any receiver yet, it'll be added in subsequent PRs.

**Testing:** Added tests.
