### PR TITLE
Rename SignalTestComplete to Shutdown

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -231,7 +231,9 @@ func (app *Application) RegisterZPages(mux *http.ServeMux, pathPrefix string) {
 	mux.HandleFunc(path.Join(pathPrefix, extensionzPath), app.handleExtensionzRequest)
 }
 
-func (app *Application) SignalTestComplete() {
+func (app *Application) Shutdown() {
+	// TODO: Implement a proper shutdown with graceful draining of the pipeline.
+	// See https://github.com/open-telemetry/opentelemetry-collector/issues/483.
 	defer func() {
 		if r := recover(); r != nil {
 			app.logger.Info("stopTestChan already closed")

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -167,8 +167,8 @@ func TestApplication_StartAsGoRoutine(t *testing.T) {
 	assert.Equal(t, Starting, <-app.GetStateChannel())
 	assert.Equal(t, Running, <-app.GetStateChannel())
 
-	app.SignalTestComplete()
-	app.SignalTestComplete()
+	app.Shutdown()
+	app.Shutdown()
 	<-appDone
 	assert.Equal(t, Closing, <-app.GetStateChannel())
 	assert.Equal(t, Closed, <-app.GetStateChannel())

--- a/testbed/testbed/otelcol_runner.go
+++ b/testbed/testbed/otelcol_runner.go
@@ -142,7 +142,7 @@ func (ipp *InProcessCollector) Start(args StartParams) error {
 func (ipp *InProcessCollector) Stop() (stopped bool, err error) {
 	if !ipp.stopped {
 		ipp.stopped = true
-		ipp.svc.SignalTestComplete()
+		ipp.svc.Shutdown()
 	}
 	<-ipp.appDone
 	stopped = ipp.stopped


### PR DESCRIPTION
SignalTestComplete shouldn't be in the public API and Application should provide a Shutdown method instead. This change is fixing the public API, behavior of Shutdown will be fixed in the future.

Fixes #2260.

