### PR TITLE
Fix a few readability issues on the prometheusremotewriteexporter

### DIFF
--- a/exporter/prometheusremotewriteexporter/config_test.go
+++ b/exporter/prometheusremotewriteexporter/config_test.go
@@ -76,12 +76,9 @@ func Test_loadConfig(t *testing.T) {
 					},
 					Insecure: false,
 				},
-				ReadBufferSize: 0,
-
+				ReadBufferSize:  0,
 				WriteBufferSize: 512 * 1024,
-
-				Timeout: 5 * time.Second,
-
+				Timeout:         5 * time.Second,
 				Headers: map[string]string{
 					"prometheus-remote-write-version": "0.1.0",
 					"x-scope-orgid":                   "234"},

--- a/exporter/prometheusremotewriteexporter/factory.go
+++ b/exporter/prometheusremotewriteexporter/factory.go
@@ -45,13 +45,11 @@ func createMetricsExporter(_ context.Context, params component.ExporterCreatePar
 	}
 
 	client, err := prwCfg.HTTPClientSettings.ToClient()
-
 	if err != nil {
 		return nil, err
 	}
 
 	prwe, err := NewPrwExporter(prwCfg.Namespace, prwCfg.HTTPClientSettings.Endpoint, client, prwCfg.ExternalLabels)
-
 	if err != nil {
 		return nil, err
 	}

--- a/exporter/prometheusremotewriteexporter/helper.go
+++ b/exporter/prometheusremotewriteexporter/helper.go
@@ -126,7 +126,6 @@ func timeSeriesSignature(metric *otlp.Metric, labels *[]prompb.Label) string {
 // Unpaired string value is ignored. String pairs overwrites OTLP labels if collision happens, and the overwrite is
 // logged. Resultant label names are sanitized.
 func createLabelSet(labels []common.StringKeyValue, externalLabels map[string]string, extras ...string) []prompb.Label {
-
 	// map ensures no duplicate label name
 	l := map[string]prompb.Label{}
 
@@ -165,7 +164,6 @@ func createLabelSet(labels []common.StringKeyValue, externalLabels map[string]st
 	}
 
 	s := make([]prompb.Label, 0, len(l))
-
 	for _, lb := range l {
 		s = append(s, lb)
 	}
@@ -176,7 +174,6 @@ func createLabelSet(labels []common.StringKeyValue, externalLabels map[string]st
 // getPromMetricName creates a Prometheus metric name by attaching namespace prefix, and _total suffix for Monotonic
 // metrics.
 func getPromMetricName(metric *otlp.Metric, ns string) string {
-
 	if metric == nil {
 		return ""
 	}

--- a/exporter/prometheusremotewriteexporter/testutil_test.go
+++ b/exporter/prometheusremotewriteexporter/testutil_test.go
@@ -571,10 +571,8 @@ func getQuantiles(bounds []float64, values []float64) []*otlp.DoubleSummaryDataP
 
 func getTimeseriesMap(timeseries []*prompb.TimeSeries) map[string]*prompb.TimeSeries {
 	tsMap := make(map[string]*prompb.TimeSeries)
-
 	for i, v := range timeseries {
 		tsMap[fmt.Sprintf("%s%d", "timeseries_name", i)] = v
 	}
-
 	return tsMap
 }


### PR DESCRIPTION
A few changes:
- Removal of arbitrary whitespace
- Fixing the package godoc
- Use of canonical variable names such as req/resp

And more. Can't break any APIs right now otherwise would rename PrwExporter to Exporter.