### PR TITLE
Migrate CircleCI contrib-test workflow to GitHub Actions

### DIFF
--- a/.github/workflows/contrib-tests.yml
+++ b/.github/workflows/contrib-tests.yml
@@ -1,0 +1,23 @@
+name: contrib-tests
+on:
+  push:
+    branches: [master]
+    tags:
+      - v[0-9]+.[0-9]+.[0-9]+.*
+  pull_request:
+
+jobs:
+  contrib_tests:
+    runs-on: ubuntu-latest
+    container:
+      image: cimg/go:1.15
+    steps:
+      - name: Setup Permissions
+        run: sudo chmod -R 777 $GITHUB_WORKSPACE /github /__w/_temp
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      - name: Run Contrib Tests
+        run: |
+          contrib_path=/tmp/opentelemetry-collector-contrib
+          git clone https://github.com/open-telemetry/opentelemetry-collector-contrib.git $contrib_path
+          make CONTRIB_PATH=$contrib_path check-contrib


### PR DESCRIPTION
## Which problem is this solving?
As part of [issue](https://github.com/open-telemetry/opentelemetry-collector/issues/1234), this pull request migrates the contrib_test workflow that was contained in the config.yml file to GitHub Actions.

## Migration Plan
I suggest having CircleCI and GitHub Actions jobs run in parallel while the migration is in progress. In the last migration Pull Request, we will remove the existing CircleCI workflows.

## Related PRs
A series of other PRs authored by @AzfaarQureshi and myself will be filed concurrently with this one migrating the build_and_test workflow in small chunks on the collector main repo and then on the collector-contrib repo.

cc- @alolita @AzfaarQureshi 