### PR TITLE
Add flag to keep internal metrics in prometheus receiver.

### DIFF
--- a/receiver/prometheusreceiver/config.go
+++ b/receiver/prometheusreceiver/config.go
@@ -30,6 +30,7 @@ type Config struct {
 	BufferCount                   int            `mapstructure:"buffer_count"`
 	UseStartTimeMetric            bool           `mapstructure:"use_start_time_metric"`
 	StartTimeMetricRegex          string         `mapstructure:"start_time_metric_regex"`
+	KeepInternalMetrics           bool           `mapstructure:"keep_internal_metrics"`
 
 	// ConfigPlaceholder is just an entry to make the configuration pass a check
 	// that requires that all keys present in the config actually exist on the

--- a/receiver/prometheusreceiver/config_test.go
+++ b/receiver/prometheusreceiver/config_test.go
@@ -56,6 +56,7 @@ func TestLoadConfig(t *testing.T) {
 	assert.Equal(t, time.Duration(r1.PrometheusConfig.ScrapeConfigs[0].ScrapeInterval), 5*time.Second)
 	assert.Equal(t, r1.UseStartTimeMetric, true)
 	assert.Equal(t, r1.StartTimeMetricRegex, "^(.+_)*process_start_time_seconds$")
+	assert.Equal(t, r1.KeepInternalMetrics, true)
 }
 
 func TestLoadConfigWithEnvVar(t *testing.T) {

--- a/receiver/prometheusreceiver/internal/metadata.go
+++ b/receiver/prometheusreceiver/internal/metadata.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/pkg/textparse"
 	"github.com/prometheus/prometheus/scrape"
 )
 
@@ -57,8 +58,42 @@ type mCache struct {
 	t *scrape.Target
 }
 
+var internalMetrics = map[string]scrape.MetricMetadata{
+	"up": {
+		Metric: "up",
+		Type:   textparse.MetricTypeGauge,
+		Help:   "",
+		Unit:   "",
+	},
+	"up": {
+		Metric: "up",
+		Type:   textparse.MetricTypeGauge,
+		Help:   "",
+		Unit:   "",
+	},
+	"up": {
+		Metric: "up",
+		Type:   textparse.MetricTypeGauge,
+		Help:   "",
+		Unit:   "",
+	},
+	"up": {
+		Metric: "up",
+		Type:   textparse.MetricTypeGauge,
+		Help:   "",
+		Unit:   "",
+	},
+	"up": {
+		Metric: "up",
+		Type:   textparse.MetricTypeGauge,
+		Help:   "",
+		Unit:   "",
+	},
+}
+
 func (m *mCache) Metadata(metricName string) (scrape.MetricMetadata, bool) {
-	return m.t.Metadata(metricName)
+	metadata, ok := m.t.Metadata(metricName)
+	return metadata, ok
 }
 
 func (m *mCache) SharedLabels() labels.Labels {

--- a/receiver/prometheusreceiver/internal/metricfamily.go
+++ b/receiver/prometheusreceiver/internal/metricfamily.go
@@ -51,7 +51,7 @@ func newMetricFamily(metricName string, mc MetadataCache) MetricFamily {
 
 	// lookup metadata based on familyName
 	metadata, ok := mc.Metadata(familyName)
-	if !ok && metricName != familyName {
+	if !ok {
 		// use the original metricName as metricFamily
 		familyName = metricName
 		// perform a 2nd lookup with the original metric name. it can happen if there's a metric which is not histogram

--- a/receiver/prometheusreceiver/internal/metricsbuilder_test.go
+++ b/receiver/prometheusreceiver/internal/metricsbuilder_test.go
@@ -97,7 +97,7 @@ func runBuilderTests(t *testing.T, tests []buildTestData) {
 			mc := newMockMetadataCache(testMetadata)
 			st := startTs
 			for i, page := range tt.inputs {
-				b := newMetricBuilder(mc, true, "", testLogger)
+				b := newMetricBuilder(mc, true, "", false, testLogger)
 				b.startTime = defaultBuilderStartTime // set to a non-zero value
 				for _, pt := range page.pts {
 					// set ts for testing
@@ -120,7 +120,7 @@ func runBuilderStartTimeTests(t *testing.T, tests []buildTestData,
 			mc := newMockMetadataCache(testMetadata)
 			st := startTs
 			for _, page := range tt.inputs {
-				b := newMetricBuilder(mc, true, startTimeMetricRegex,
+				b := newMetricBuilder(mc, true, startTimeMetricRegex, false,
 					testLogger)
 				b.startTime = defaultBuilderStartTime // set to a non-zero value
 				for _, pt := range page.pts {
@@ -1141,7 +1141,7 @@ func Test_metricBuilder_skipped(t *testing.T) {
 func Test_metricBuilder_baddata(t *testing.T) {
 	t.Run("empty-metric-name", func(t *testing.T) {
 		mc := newMockMetadataCache(testMetadata)
-		b := newMetricBuilder(mc, true, "", testLogger)
+		b := newMetricBuilder(mc, true, "", true, testLogger)
 		b.startTime = 1.0 // set to a non-zero value
 		if err := b.AddDataPoint(labels.FromStrings("a", "b"), startTs, 123); err != errMetricNameNotFound {
 			t.Error("expecting errMetricNameNotFound error, but get nil")
@@ -1155,7 +1155,7 @@ func Test_metricBuilder_baddata(t *testing.T) {
 
 	t.Run("histogram-datapoint-no-bucket-label", func(t *testing.T) {
 		mc := newMockMetadataCache(testMetadata)
-		b := newMetricBuilder(mc, true, "", testLogger)
+		b := newMetricBuilder(mc, true, "", true, testLogger)
 		b.startTime = 1.0 // set to a non-zero value
 		if err := b.AddDataPoint(createLabels("hist_test", "k", "v"), startTs, 123); err != errEmptyBoundaryLabel {
 			t.Error("expecting errEmptyBoundaryLabel error, but get nil")
@@ -1164,7 +1164,7 @@ func Test_metricBuilder_baddata(t *testing.T) {
 
 	t.Run("summary-datapoint-no-quantile-label", func(t *testing.T) {
 		mc := newMockMetadataCache(testMetadata)
-		b := newMetricBuilder(mc, true, "", testLogger)
+		b := newMetricBuilder(mc, true, "", true, testLogger)
 		b.startTime = 1.0 // set to a non-zero value
 		if err := b.AddDataPoint(createLabels("summary_test", "k", "v"), startTs, 123); err != errEmptyBoundaryLabel {
 			t.Error("expecting errEmptyBoundaryLabel error, but get nil")

--- a/receiver/prometheusreceiver/internal/ocastore_test.go
+++ b/receiver/prometheusreceiver/internal/ocastore_test.go
@@ -26,7 +26,7 @@ import (
 
 func TestOcaStore(t *testing.T) {
 
-	o := NewOcaStore(context.Background(), nil, nil, nil, false, "", "prometheus")
+	o := NewOcaStore(context.Background(), nil, nil, nil, false, "", false, "prometheus")
 	o.SetScrapeManager(&scrape.Manager{})
 
 	app := o.Appender(context.Background())

--- a/receiver/prometheusreceiver/internal/transaction_test.go
+++ b/receiver/prometheusreceiver/internal/transaction_test.go
@@ -63,7 +63,7 @@ func Test_transaction(t *testing.T) {
 
 	t.Run("Commit Without Adding", func(t *testing.T) {
 		nomc := consumertest.NewMetricsNop()
-		tr := newTransaction(context.Background(), nil, true, "", rn, ms, nomc, testLogger)
+		tr := newTransaction(context.Background(), nil, true, "", true, rn, ms, nomc, testLogger)
 		if got := tr.Commit(); got != nil {
 			t.Errorf("expecting nil from Commit() but got err %v", got)
 		}
@@ -71,7 +71,7 @@ func Test_transaction(t *testing.T) {
 
 	t.Run("Rollback dose nothing", func(t *testing.T) {
 		nomc := consumertest.NewMetricsNop()
-		tr := newTransaction(context.Background(), nil, true, "", rn, ms, nomc, testLogger)
+		tr := newTransaction(context.Background(), nil, true, "", true, rn, ms, nomc, testLogger)
 		if got := tr.Rollback(); got != nil {
 			t.Errorf("expecting nil from Rollback() but got err %v", got)
 		}
@@ -80,7 +80,7 @@ func Test_transaction(t *testing.T) {
 	badLabels := labels.Labels([]labels.Label{{Name: "foo", Value: "bar"}})
 	t.Run("Add One No Target", func(t *testing.T) {
 		nomc := consumertest.NewMetricsNop()
-		tr := newTransaction(context.Background(), nil, true, "", rn, ms, nomc, testLogger)
+		tr := newTransaction(context.Background(), nil, true, "", true, rn, ms, nomc, testLogger)
 		if _, got := tr.Add(badLabels, time.Now().Unix()*1000, 1.0); got == nil {
 			t.Errorf("expecting error from Add() but got nil")
 		}
@@ -92,7 +92,7 @@ func Test_transaction(t *testing.T) {
 		{Name: "foo", Value: "bar"}})
 	t.Run("Add One Job not found", func(t *testing.T) {
 		nomc := consumertest.NewMetricsNop()
-		tr := newTransaction(context.Background(), nil, true, "", rn, ms, nomc, testLogger)
+		tr := newTransaction(context.Background(), nil, true, "", true, rn, ms, nomc, testLogger)
 		if _, got := tr.Add(jobNotFoundLb, time.Now().Unix()*1000, 1.0); got == nil {
 			t.Errorf("expecting error from Add() but got nil")
 		}
@@ -103,7 +103,7 @@ func Test_transaction(t *testing.T) {
 		{Name: "__name__", Value: "foo"}})
 	t.Run("Add One Good", func(t *testing.T) {
 		sink := new(consumertest.MetricsSink)
-		tr := newTransaction(context.Background(), nil, true, "", rn, ms, sink, testLogger)
+		tr := newTransaction(context.Background(), nil, true, "", true, rn, ms, sink, testLogger)
 		if _, got := tr.Add(goodLabels, time.Now().Unix()*1000, 1.0); got != nil {
 			t.Errorf("expecting error == nil from Add() but got: %v\n", got)
 		}
@@ -133,7 +133,7 @@ func Test_transaction(t *testing.T) {
 
 	t.Run("Error when start time is zero", func(t *testing.T) {
 		sink := new(consumertest.MetricsSink)
-		tr := newTransaction(context.Background(), nil, true, "", rn, ms, sink, testLogger)
+		tr := newTransaction(context.Background(), nil, true, "", true, rn, ms, sink, testLogger)
 		if _, got := tr.Add(goodLabels, time.Now().Unix()*1000, 1.0); got != nil {
 			t.Errorf("expecting error == nil from Add() but got: %v\n", got)
 		}
@@ -148,7 +148,7 @@ func Test_transaction(t *testing.T) {
 
 	t.Run("Drop NaN value", func(t *testing.T) {
 		sink := new(consumertest.MetricsSink)
-		tr := newTransaction(context.Background(), nil, true, "", rn, ms, sink, testLogger)
+		tr := newTransaction(context.Background(), nil, true, "", true, rn, ms, sink, testLogger)
 		if _, got := tr.Add(goodLabels, time.Now().Unix()*1000, math.NaN()); got != nil {
 			t.Errorf("expecting error == nil from Add() but got: %v\n", got)
 		}

--- a/receiver/prometheusreceiver/metrics_receiver.go
+++ b/receiver/prometheusreceiver/metrics_receiver.go
@@ -73,8 +73,14 @@ func (r *pReceiver) Start(ctx context.Context, host component.Host) error {
 	if !r.cfg.UseStartTimeMetric {
 		jobsMap = internal.NewJobsMap(2 * time.Minute)
 	}
-	ocaStore := internal.NewOcaStore(ctx, r.consumer, r.logger, jobsMap, r.cfg.UseStartTimeMetric, r.cfg.StartTimeMetricRegex, r.cfg.Name())
-
+	if r.cfg.KeepInternalMetrics {
+		r.logger.Info("keep internal metrics")
+	} else {
+		r.logger.Info("drop internal metrics")
+	}
+	r.logger.Info("Start new oca store")
+	ocaStore := internal.NewOcaStore(ctx, r.consumer, r.logger, jobsMap, r.cfg.UseStartTimeMetric, r.cfg.StartTimeMetricRegex, r.cfg.KeepInternalMetrics, r.cfg.Name())
+	r.logger.Info("End new oca store")
 	scrapeManager := scrape.NewManager(logger, ocaStore)
 	ocaStore.SetScrapeManager(scrapeManager)
 	if err := scrapeManager.ApplyConfig(r.cfg.PrometheusConfig); err != nil {

--- a/receiver/prometheusreceiver/testdata/config.yaml
+++ b/receiver/prometheusreceiver/testdata/config.yaml
@@ -5,6 +5,7 @@ receivers:
     buffer_count: 45
     use_start_time_metric: true
     start_time_metric_regex: '^(.+_)*process_start_time_seconds$'
+    keep_internal_metrics: true
     config:
       scrape_configs:
         - job_name: 'demo'


### PR DESCRIPTION
**Description:** <Describe what has changed. 
Add a flag to keep internal metrics (up, scrape_*) in prometheus receiver.

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** < Describe what testing was performed and which tests were added.>

**Documentation:** < Describe the documentation added.>
