### PR TITLE
Adding caching to GHA setup-environment job

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -49,6 +49,13 @@ jobs:
         run: |
           echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
           echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
+      - name: Restore module cache
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-go-modules
+        with:
+          path: /home/runner/go/pkg/mod
+          key: go-pkg-mod-${{ runner.os }}-${{ hashFiles('./go.mod') }}
       - name: Install tools
         run: make install-tools
       - name: Upload tool binaries


### PR DESCRIPTION
## Which problem is this solving?

Related to [issue](https://github.com/open-telemetry/opentelemetry-collector/issues/1234) and PR #2298 . This PR adds caching to the setup-environment job to make its runtime a little faster. 

cc- @alolita, @shovnik 