### PR TITLE
Fix build-and-test GitHub Actions workflows

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -153,7 +153,7 @@ jobs:
     needs: [setup-environment]
     strategy:
       fail-fast: false
-      matrix: ${{ fromJson(needs.loadtestpre.outputs.matrix) }}
+      matrix: ${{ fromJson(needs.setup-environment.outputs.matrix) }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2


### PR DESCRIPTION
**Description:**
This refactor [PR](https://github.com/open-telemetry/opentelemetry-collector/pull/2313) I authored accidentally introduced an error into the build-and-test workflow which prevents the load-tests job from running altogether and fails every run of the build-and-test workflow. This one line fix should resolve the issue and allow the build-and-test workflow to pass once again.

**Link to tracking Issue:** #1234 

**Testing:** Workflow was run locally and it now runs load tests as intended.

cc- @AzfaarQureshi 