### PR TITLE
Flush out to the profile file before graceful shutdown

### DIFF
--- a/extension/pprofextension/pprofextension.go
+++ b/extension/pprofextension/pprofextension.go
@@ -31,6 +31,7 @@ import (
 type pprofExtension struct {
 	config Config
 	logger *zap.Logger
+	file   *os.File
 	server http.Server
 }
 
@@ -58,6 +59,7 @@ func (p *pprofExtension) Start(_ context.Context, host component.Host) error {
 		if err != nil {
 			return err
 		}
+		p.file = f
 		return pprof.StartCPUProfile(f)
 	}
 
@@ -65,8 +67,9 @@ func (p *pprofExtension) Start(_ context.Context, host component.Host) error {
 }
 
 func (p *pprofExtension) Shutdown(context.Context) error {
-	if p.config.SaveToFile != "" {
+	if p.file != nil {
 		pprof.StopCPUProfile()
+		p.file.Close() // ignore the error
 	}
 	return p.server.Close()
 }


### PR DESCRIPTION
Flush out the write buffer to the output profile file during the graceful shutdown. Ignore the Close error, trying to flush is the best we can do but is not worth to halt the shutdown if Close fails.
