### PR TITLE
Log the listen addresses of zpages and pprof extensions

### DIFF
--- a/extension/pprofextension/pprofextension.go
+++ b/extension/pprofextension/pprofextension.go
@@ -45,7 +45,9 @@ func (p *pprofExtension) Start(_ context.Context, host component.Host) error {
 	runtime.SetBlockProfileRate(p.config.BlockProfileFraction)
 	runtime.SetMutexProfileFraction(p.config.MutexProfileFraction)
 
-	p.logger.Info("Starting net/http/pprof server", zap.Any("config", p.config))
+	p.logger.Info("Starting net/http/pprof server",
+		zap.Any("listen_addr", ln.Addr()),
+		zap.Any("config", p.config))
 	go func() {
 		// The listener ownership goes to the server.
 		if err := p.server.Serve(ln); err != nil && err != http.ErrServerClosed {

--- a/extension/zpagesextension/zpagesextension.go
+++ b/extension/zpagesextension/zpagesextension.go
@@ -52,7 +52,9 @@ func (zpe *zpagesExtension) Start(_ context.Context, host component.Host) error 
 		return err
 	}
 
-	zpe.logger.Info("Starting zPages extension", zap.Any("config", zpe.config))
+	zpe.logger.Info("Starting zPages extension",
+		zap.Any("listen_addr", ln.Addr()),
+		zap.Any("config", zpe.config))
 	zpe.server = http.Server{Handler: zPagesMux}
 	go func() {
 		if err := zpe.server.Serve(ln); err != nil && err != http.ErrServerClosed {


### PR DESCRIPTION
net.Listen will find an available port and will default to "127.0.0.1" if user doesn't specify a host or port. For example,

```
endpoint: "localhost:"
```

will listen to an available port on localhost. It's not possible from the logs what port is listened because we never log the listener's address.
