### PR TITLE
GitHub Actions - fixing flaky build package job

### DIFF
--- a/internal/buildscripts/packaging/fpm/common.sh
+++ b/internal/buildscripts/packaging/fpm/common.sh
@@ -38,7 +38,9 @@ install_pkg() {
     local pkg_base=$( basename "$pkg_path" )
 
     echo "Installing $pkg_base ..."
+    echo "$(ls -l $pkg_path)"
     docker cp "$pkg_path" $image_name:/tmp/$pkg_base
+    sleep 5
     if [[ "${pkg_base##*.}" = "deb" ]]; then
         $docker_exec dpkg -i /tmp/$pkg_base
     else

--- a/internal/buildscripts/packaging/fpm/common.sh
+++ b/internal/buildscripts/packaging/fpm/common.sh
@@ -38,9 +38,8 @@ install_pkg() {
     local pkg_base=$( basename "$pkg_path" )
 
     echo "Installing $pkg_base ..."
-    echo "$(ls -l $pkg_path)"
-    docker cp "$pkg_path" $image_name:/tmp/$pkg_base
-    sleep 5
+    docker cp "$pkg_path" $image_name:/tmp/$pkg_base &
+    wait $!
     if [[ "${pkg_base##*.}" = "deb" ]]; then
         $docker_exec dpkg -i /tmp/$pkg_base
     else

--- a/internal/buildscripts/packaging/fpm/common.sh
+++ b/internal/buildscripts/packaging/fpm/common.sh
@@ -38,8 +38,7 @@ install_pkg() {
     local pkg_base=$( basename "$pkg_path" )
 
     echo "Installing $pkg_base ..."
-    docker cp "$pkg_path" $image_name:/tmp/$pkg_base &
-    wait $!
+    docker cp "$pkg_path" $image_name:/tmp/$pkg_base & wait $!
     if [[ "${pkg_base##*.}" = "deb" ]]; then
         $docker_exec dpkg -i /tmp/$pkg_base
     else


### PR DESCRIPTION
The build deb package job is a little flaky due to the following err:

```
Installing otel-collector_0.17.0-post_amd64.deb ...
Error response from daemon: Error processing tar file(exit status 1): lchown /tmp/otel-collector_0.17.0-post_amd64.deb: no such file or directory
Error: Process completed with exit code 1.
```

I suspect the problem is in line 43 of common.sh where `dpkg -i` is called before the `docker cp` is complete. Adding a sleep and another instruction between the two steps seemed to fix the flakiness on my fork 