### PR TITLE
Add pdata TraceID.IsEmpty() method

### DIFF
--- a/consumer/pdata/trace_test.go
+++ b/consumer/pdata/trace_test.go
@@ -103,9 +103,11 @@ func TestSpanID(t *testing.T) {
 func TestTraceID(t *testing.T) {
 	tid := InvalidTraceID()
 	assert.EqualValues(t, [16]byte{}, tid.Bytes())
+	assert.True(t, tid.IsEmpty())
 
 	tid = NewTraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 8, 7, 6, 5, 4, 3, 2, 1})
 	assert.EqualValues(t, [16]byte{1, 2, 3, 4, 5, 6, 7, 8, 8, 7, 6, 5, 4, 3, 2, 1}, tid.Bytes())
+	assert.False(t, tid.IsEmpty())
 }
 
 func TestSpanStatusCode(t *testing.T) {

--- a/consumer/pdata/traceid.go
+++ b/consumer/pdata/traceid.go
@@ -40,6 +40,7 @@ func (t TraceID) HexString() string {
 }
 
 // IsValid returns true if id contains at leas one non-zero byte.
+// Deprecated: use !IsEmpty() instead.
 func (t TraceID) IsValid() bool {
 	return data.TraceID(t).IsValid()
 }

--- a/consumer/pdata/traceid.go
+++ b/consumer/pdata/traceid.go
@@ -43,3 +43,8 @@ func (t TraceID) HexString() string {
 func (t TraceID) IsValid() bool {
 	return data.TraceID(t).IsValid()
 }
+
+// IsEmpty returns true if id doesn't contain at least one non-zero byte.
+func (t TraceID) IsEmpty() bool {
+	return !data.TraceID(t).IsValid()
+}


### PR DESCRIPTION
**Description:**  Add the new method that equals to calling !data.TraceID(t).IsValid() for
the internal data.TraceID.

**Link to tracking Issue:** #2014
