### PR TITLE
prometheusremotewriteexporter: allow setting maximum batch size

### DIFF
--- a/exporter/prometheusremotewriteexporter/config.go
+++ b/exporter/prometheusremotewriteexporter/config.go
@@ -36,4 +36,8 @@ type Config struct {
 	ExternalLabels map[string]string `mapstructure:"external_labels"`
 
 	HTTPClientSettings confighttp.HTTPClientSettings `mapstructure:",squash"`
+
+	// MaxBatchByteSize sets the maximum uncompressed size to send in a single HTTP request.
+	// Default is 3000000
+	MaxBatchByteSize int `mapstructure:"max_batch_byte_size"`
 }

--- a/exporter/prometheusremotewriteexporter/config_test.go
+++ b/exporter/prometheusremotewriteexporter/config_test.go
@@ -83,5 +83,6 @@ func Test_loadConfig(t *testing.T) {
 					"prometheus-remote-write-version": "0.1.0",
 					"x-scope-orgid":                   "234"},
 			},
+			MaxBatchByteSize: 1048576,
 		})
 }

--- a/exporter/prometheusremotewriteexporter/exporter_test.go
+++ b/exporter/prometheusremotewriteexporter/exporter_test.go
@@ -119,6 +119,7 @@ func Test_NewPrwExporter(t *testing.T) {
 			assert.NotNil(t, prwe.client)
 			assert.NotNil(t, prwe.closeChan)
 			assert.NotNil(t, prwe.wg)
+			assert.Equal(t, defaultMaxBatchByteSize, prwe.maxBatchByteSize)
 		})
 	}
 }

--- a/exporter/prometheusremotewriteexporter/factory.go
+++ b/exporter/prometheusremotewriteexporter/factory.go
@@ -64,6 +64,10 @@ func createMetricsExporter(_ context.Context, params component.ExporterCreatePar
 		exporterhelper.WithShutdown(prwe.Shutdown),
 	)
 
+	if err == nil {
+		prwe.SetMaxBatchByteSize(prwCfg.MaxBatchByteSize)
+	}
+
 	return prwexp, err
 }
 
@@ -86,5 +90,6 @@ func createDefaultConfig() configmodels.Exporter {
 			Timeout:         exporterhelper.DefaultTimeoutSettings().Timeout,
 			Headers:         map[string]string{},
 		},
+		MaxBatchByteSize: defaultMaxBatchByteSize,
 	}
 }

--- a/exporter/prometheusremotewriteexporter/testdata/config.yaml
+++ b/exporter/prometheusremotewriteexporter/testdata/config.yaml
@@ -1,9 +1,9 @@
 receivers:
     examplereceiver:
-  
+
 processors:
     exampleprocessor:
- 
+
 exporters:
     prometheusremotewrite:
     prometheusremotewrite/2:
@@ -26,6 +26,7 @@ exporters:
         external_labels:
             key1: value1
             key2: value2
+        max_batch_byte_size: 1048576
 
 service:
     pipelines:
@@ -33,5 +34,5 @@ service:
             receivers: [examplereceiver]
             processors: [exampleprocessor]
             exporters: [prometheusremotewrite]
-    
-    
+
+


### PR DESCRIPTION
**Description:** Allow setting MaxBatchByteSize  for prometheusremotewriteexporter. This is currently hardcoded to 3000000. Some remote write targets (SaaS or self-hosted) either limit size to something smaller or are more efficient with larger batches. 
