### PR TITLE
[consumer] Fix comments referencing MetricsData

### DIFF
--- a/consumer/consumer.go
+++ b/consumer/consumer.go
@@ -21,7 +21,7 @@ import (
 	"go.opentelemetry.io/collector/consumer/pdata"
 )
 
-// MetricsConsumer is the new metrics consumer interface that receives pdata.MetricData, processes it
+// MetricsConsumer is the new metrics consumer interface that receives pdata.Metrics, processes it
 // as needed, and sends it to the next processing node if any or to the destination.
 type MetricsConsumer interface {
 	ConsumeMetrics(ctx context.Context, md pdata.Metrics) error

--- a/consumer/pdata/metric.go
+++ b/consumer/pdata/metric.go
@@ -40,18 +40,18 @@ type Metrics struct {
 	orig *[]*otlpmetrics.ResourceMetrics
 }
 
-// NewMetricData creates a new MetricData.
+// NewMetrics creates a new Metrics.
 func NewMetrics() Metrics {
 	orig := []*otlpmetrics.ResourceMetrics(nil)
 	return Metrics{&orig}
 }
 
-// MetricDataFromOtlp creates the internal MetricData representation from the OTLP.
+// MetricsFromOtlp creates the internal Metrics representation from the OTLP.
 func MetricsFromOtlp(orig []*otlpmetrics.ResourceMetrics) Metrics {
 	return Metrics{&orig}
 }
 
-// MetricDataToOtlp converts the internal MetricData to the OTLP.
+// MetricsToOtlp converts the internal Metrics to the OTLP.
 func MetricsToOtlp(md Metrics) []*otlpmetrics.ResourceMetrics {
 	return *md.orig
 }


### PR DESCRIPTION
**Description:**

- Fix comments introduced in #1720 that kept the old name (MetricsData) instead of the new one (Metrics)

**Link to tracking Issue:** n/a

**Testing:** n/a this is a docs change

**Documentation:** Updated strings that used the old name.
