### PR TITLE
Add equal for AttributeValue arrays type

### DIFF
--- a/consumer/pdata/common.go
+++ b/consumer/pdata/common.go
@@ -308,8 +308,7 @@ func (a AttributeValue) Equal(av AttributeValue) bool {
 			val := val
 			av := newAttributeValue(&vv[i])
 
-			switch av.orig.Value.(type) {
-			case *otlpcommon.AnyValue_ArrayValue, *otlpcommon.AnyValue_KvlistValue:
+			if avType := av.Type(); avType == AttributeValueARRAY || avType == AttributeValueMAP {
 				return false
 			}
 

--- a/consumer/pdata/common.go
+++ b/consumer/pdata/common.go
@@ -319,6 +319,8 @@ func (a AttributeValue) Equal(av AttributeValue) bool {
 		}
 		return true
 	}
+
+	// TODO: handle MAP data type
 	return false
 }
 

--- a/consumer/pdata/common.go
+++ b/consumer/pdata/common.go
@@ -308,6 +308,7 @@ func (a AttributeValue) Equal(av AttributeValue) bool {
 			val := val
 			av := newAttributeValue(&vv[i])
 
+			// According to the specification, array values must be scalar.
 			if avType := av.Type(); avType == AttributeValueARRAY || avType == AttributeValueMAP {
 				return false
 			}

--- a/consumer/pdata/common.go
+++ b/consumer/pdata/common.go
@@ -305,6 +305,7 @@ func (a AttributeValue) Equal(av AttributeValue) bool {
 		}
 
 		for i, val := range avv {
+			val := val
 			av := newAttributeValue(&vv[i])
 
 			switch av.orig.Value.(type) {

--- a/consumer/pdata/common_test.go
+++ b/consumer/pdata/common_test.go
@@ -264,6 +264,24 @@ func TestAttributeValueEqual(t *testing.T) {
 
 	av1 = NewAttributeValueBool(false)
 	assert.False(t, av1.Equal(av2))
+
+	av1 = NewAttributeValueArray()
+	av1.ArrayVal().Append(NewAttributeValueInt(123))
+	assert.False(t, av1.Equal(av2))
+	assert.False(t, av2.Equal(av1))
+
+	av2 = NewAttributeValueArray()
+	av2.ArrayVal().Append(NewAttributeValueDouble(123))
+	assert.False(t, av1.Equal(av2))
+
+	NewAttributeValueInt(123).CopyTo(av2.ArrayVal().At(0))
+	assert.True(t, av1.Equal(av2))
+
+	av1.ArrayVal().Append(av1)
+	av2.ArrayVal().Append(av1)
+	assert.False(t, av1.Equal(av2))
+
+	assert.True(t, av1.Equal(av1))
 }
 
 func TestNilAttributeMap(t *testing.T) {


### PR DESCRIPTION
**Description:**
Adding support for array type for `AttributeValue` equal. This is according to the spec - https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/common/common.md

**Testing:**
Added test for array of scalar types

