### PR TITLE
Add custom expressions for Resource and InstrumentationLibraryInfo

### DIFF
--- a/internal/processor/filterexpr/attr_expr.go
+++ b/internal/processor/filterexpr/attr_expr.go
@@ -1,0 +1,153 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filterexpr
+
+import (
+	"go.opentelemetry.io/collector/consumer/pdata"
+)
+
+// AttributeExpr is an interface that evaluates boolean expressions for pdata.AttributeMap.
+type AttributeExpr interface {
+	Evaluate(attributes pdata.AttributeMap) bool
+}
+
+type notAttribute struct {
+	a AttributeExpr
+}
+
+func NewNotAttributeExpr(a AttributeExpr) AttributeExpr {
+	return &notAttribute{
+		a: a,
+	}
+}
+
+func (na *notAttribute) Evaluate(attributes pdata.AttributeMap) bool {
+	return !na.a.Evaluate(attributes)
+}
+
+type orAttribute struct {
+	a AttributeExpr
+	b AttributeExpr
+}
+
+func NewOrAttributeExpr(a, b AttributeExpr) AttributeExpr {
+	return &orAttribute{
+		a: a,
+		b: b,
+	}
+}
+
+func (oa *orAttribute) Evaluate(attributes pdata.AttributeMap) bool {
+	return oa.a.Evaluate(attributes) || oa.b.Evaluate(attributes)
+}
+
+type andAttribute struct {
+	a AttributeExpr
+	b AttributeExpr
+}
+
+func NewAndAttributeExpr(a, b AttributeExpr) AttributeExpr {
+	return &andAttribute{
+		a: a,
+		b: b,
+	}
+}
+
+func (aa *andAttribute) Evaluate(attributes pdata.AttributeMap) bool {
+	return aa.a.Evaluate(attributes) && aa.b.Evaluate(attributes)
+}
+
+type hasAttribute struct {
+	key string
+}
+
+func NewHasAttributeExpr(key string) AttributeExpr {
+	return &hasAttribute{
+		key: key,
+	}
+}
+
+func (ha *hasAttribute) Evaluate(attributes pdata.AttributeMap) bool {
+	_, ok := attributes.Get(ha.key)
+	return ok
+}
+
+type doubleAttribute struct {
+	key string
+	val float64
+}
+
+func NewDoubleAttributeExpr(key string, val float64) AttributeExpr {
+	return &doubleAttribute{
+		key: key,
+		val: val,
+	}
+}
+
+func (da *doubleAttribute) Evaluate(attributes pdata.AttributeMap) bool {
+	val, ok := attributes.Get(da.key)
+	return ok && val.DoubleVal() == da.val
+}
+
+type intAttribute struct {
+	key string
+	val int64
+}
+
+func NewIntAttributeExpr(key string, val int64) AttributeExpr {
+	return &intAttribute{
+		key: key,
+		val: val,
+	}
+}
+
+func (ia *intAttribute) Evaluate(attributes pdata.AttributeMap) bool {
+	val, ok := attributes.Get(ia.key)
+	return ok && val.IntVal() == ia.val
+}
+
+type boolAttribute struct {
+	key string
+	val bool
+}
+
+func NewBoolAttributeExpr(key string, val bool) AttributeExpr {
+	return &boolAttribute{
+		key: key,
+		val: val,
+	}
+}
+
+func (ba *boolAttribute) Evaluate(attributes pdata.AttributeMap) bool {
+	val, ok := attributes.Get(ba.key)
+	return ok && val.BoolVal() == ba.val
+}
+
+type stringAttribute struct {
+	key  string
+	expr StringExpr
+}
+
+func NewStringAttributeExpr(key string, expr StringExpr) AttributeExpr {
+	return &stringAttribute{
+		key:  key,
+		expr: expr,
+	}
+}
+
+func (sa *stringAttribute) Evaluate(attributes pdata.AttributeMap) bool {
+	val, ok := attributes.Get(sa.key)
+	return ok && sa.expr.Evaluate(val.StringVal())
+}

--- a/internal/processor/filterexpr/attr_expr_test.go
+++ b/internal/processor/filterexpr/attr_expr_test.go
@@ -1,0 +1,229 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filterexpr
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"go.opentelemetry.io/collector/consumer/pdata"
+)
+
+func TestAttributesMatching(t *testing.T) {
+	attr := pdata.NewAttributeMap().InitFromMap(map[string]pdata.AttributeValue{
+		"keyString": pdata.NewAttributeValueString("value"),
+		"keyInt":    pdata.NewAttributeValueInt(123),
+		"keyDouble": pdata.NewAttributeValueDouble(12.3),
+		"keyBool":   pdata.NewAttributeValueBool(true),
+		"keyExists": pdata.NewAttributeValueString("present"),
+	})
+	testcases := []struct {
+		name     string
+		expr     AttributeExpr
+		expected bool
+	}{
+		{
+			name:     "has_attribute_true",
+			expr:     NewHasAttributeExpr("keyExists"),
+			expected: true,
+		},
+		{
+			name:     "has_attribute_false",
+			expr:     NewHasAttributeExpr("keyExists2"),
+			expected: false,
+		},
+		{
+			name:     "int_attribute_true",
+			expr:     NewIntAttributeExpr("keyInt", 123),
+			expected: true,
+		},
+		{
+			name:     "int_attribute_no_key",
+			expr:     NewIntAttributeExpr("keyInt2", 123),
+			expected: false,
+		},
+		{
+			name:     "int_attribute_different_value",
+			expr:     NewIntAttributeExpr("keyInt", 234),
+			expected: false,
+		},
+		{
+			name:     "double_attribute_true",
+			expr:     NewDoubleAttributeExpr("keyDouble", 12.3),
+			expected: true,
+		},
+		{
+			name:     "double_attribute_no_key",
+			expr:     NewDoubleAttributeExpr("keyDouble2", 12.3),
+			expected: false,
+		},
+		{
+			name:     "double_attribute_different_value",
+			expr:     NewDoubleAttributeExpr("keyDouble", 23.4),
+			expected: false,
+		},
+		{
+			name:     "string_attribute_true",
+			expr:     NewStringAttributeExpr("keyString", NewStrictStringExpr("value")),
+			expected: true,
+		},
+		{
+			name:     "string_attribute_no_key",
+			expr:     NewStringAttributeExpr("keyString2", NewStrictStringExpr("value")),
+			expected: false,
+		},
+		{
+			name:     "string_attribute_different_value",
+			expr:     NewStringAttributeExpr("keyString", NewStrictStringExpr("other_value")),
+			expected: false,
+		},
+		{
+			name:     "bool_attribute_true",
+			expr:     NewBoolAttributeExpr("keyBool", true),
+			expected: true,
+		},
+		{
+			name:     "bool_attribute_no_key",
+			expr:     NewBoolAttributeExpr("keyBool2", true),
+			expected: false,
+		},
+		{
+			name:     "bool_attribute_different_value",
+			expr:     NewBoolAttributeExpr("keyBool", false),
+			expected: false,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.expr.Evaluate(attr))
+		})
+	}
+}
+
+func TestEmptyAttributesMatching(t *testing.T) {
+	attr := pdata.NewAttributeMap()
+	testcases := []struct {
+		name     string
+		expr     AttributeExpr
+		expected bool
+	}{
+		{
+			name:     "has_attribute",
+			expr:     NewHasAttributeExpr("key"),
+			expected: false,
+		},
+		{
+			name:     "int_attribute",
+			expr:     NewIntAttributeExpr("key", 123),
+			expected: false,
+		},
+		{
+			name:     "double_attribute",
+			expr:     NewDoubleAttributeExpr("key", 12.3),
+			expected: false,
+		},
+		{
+			name:     "string_attribute",
+			expr:     NewStringAttributeExpr("key", NewStrictStringExpr("value")),
+			expected: false,
+		},
+		{
+			name:     "bool_attribute",
+			expr:     NewBoolAttributeExpr("key", true),
+			expected: false,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.expr.Evaluate(attr))
+		})
+	}
+}
+
+func TestAttributesLogicalOperators(t *testing.T) {
+	testcases := []struct {
+		name     string
+		expr     AttributeExpr
+		expected bool
+	}{
+		{
+			name:     "or_attribute_true_true",
+			expr:     NewOrAttributeExpr(trueAttributeExpr, falseAttributeExpr),
+			expected: true,
+		},
+		{
+			name:     "or_attribute_true_false",
+			expr:     NewOrAttributeExpr(trueAttributeExpr, falseAttributeExpr),
+			expected: true,
+		},
+		{
+			name:     "or_attribute_false_true",
+			expr:     NewOrAttributeExpr(falseAttributeExpr, trueAttributeExpr),
+			expected: true,
+		},
+		{
+			name:     "or_attribute_false_false",
+			expr:     NewOrAttributeExpr(falseAttributeExpr, falseAttributeExpr),
+			expected: false,
+		},
+		{
+			name:     "and_attribute_true_true",
+			expr:     NewAndAttributeExpr(trueAttributeExpr, trueAttributeExpr),
+			expected: true,
+		},
+		{
+			name:     "and_attribute_true_false",
+			expr:     NewAndAttributeExpr(trueAttributeExpr, falseAttributeExpr),
+			expected: false,
+		},
+		{
+			name:     "and_attribute_false_true",
+			expr:     NewAndAttributeExpr(falseAttributeExpr, trueAttributeExpr),
+			expected: false,
+		},
+		{
+			name:     "and_attribute_false_false",
+			expr:     NewAndAttributeExpr(falseAttributeExpr, falseAttributeExpr),
+			expected: false,
+		},
+		{
+			name:     "not_attribute_true",
+			expr:     NewNotAttributeExpr(trueAttributeExpr),
+			expected: false,
+		},
+		{
+			name:     "not_attribute_false",
+			expr:     NewNotAttributeExpr(falseAttributeExpr),
+			expected: true,
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.expr.Evaluate(pdata.NewAttributeMap()))
+		})
+	}
+}
+
+type boolAttributeExpr bool
+
+func (bae boolAttributeExpr) Evaluate(_ pdata.AttributeMap) bool {
+	return bool(bae)
+}
+
+var trueAttributeExpr = boolAttributeExpr(true)
+var falseAttributeExpr = boolAttributeExpr(false)

--- a/internal/processor/filterexpr/ils_expr.go
+++ b/internal/processor/filterexpr/ils_expr.go
@@ -1,0 +1,98 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filterexpr
+
+import (
+	"go.opentelemetry.io/collector/consumer/pdata"
+)
+
+// IlsExpr is an interface that evaluates boolean expressions for pdata.InstrumentationLibrary.
+type IlsExpr interface {
+	Evaluate(ils pdata.InstrumentationLibrary) bool
+}
+
+type notIls struct {
+	a IlsExpr
+}
+
+func NewNotIlsExpr(a IlsExpr) IlsExpr {
+	return &notIls{
+		a: a,
+	}
+}
+
+func (na *notIls) Evaluate(ils pdata.InstrumentationLibrary) bool {
+	return !na.a.Evaluate(ils)
+}
+
+type orIls struct {
+	a IlsExpr
+	b IlsExpr
+}
+
+func NewOrIlsExpr(a, b IlsExpr) IlsExpr {
+	return &orIls{
+		a: a,
+		b: b,
+	}
+}
+
+func (oa *orIls) Evaluate(ils pdata.InstrumentationLibrary) bool {
+	return oa.a.Evaluate(ils) || oa.b.Evaluate(ils)
+}
+
+type andIls struct {
+	a IlsExpr
+	b IlsExpr
+}
+
+func NewAndIlsExpr(a, b IlsExpr) IlsExpr {
+	return &andIls{
+		a: a,
+		b: b,
+	}
+}
+
+func (aa *andIls) Evaluate(ils pdata.InstrumentationLibrary) bool {
+	return aa.a.Evaluate(ils) && aa.b.Evaluate(ils)
+}
+
+type nameIls struct {
+	expr StringExpr
+}
+
+func NewNameIlsExpr(expr StringExpr) IlsExpr {
+	return &nameIls{
+		expr: expr,
+	}
+}
+
+func (nils *nameIls) Evaluate(ils pdata.InstrumentationLibrary) bool {
+	return nils.expr.Evaluate(ils.Name())
+}
+
+type versionIls struct {
+	expr StringExpr
+}
+
+func NewVersionIlsExpr(expr StringExpr) IlsExpr {
+	return &versionIls{
+		expr: expr,
+	}
+}
+
+func (vils *versionIls) Evaluate(ils pdata.InstrumentationLibrary) bool {
+	return vils.expr.Evaluate(ils.Version())
+}

--- a/internal/processor/filterexpr/ils_expr_test.go
+++ b/internal/processor/filterexpr/ils_expr_test.go
@@ -1,0 +1,188 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filterexpr
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"go.opentelemetry.io/collector/consumer/pdata"
+)
+
+func TestIlsMatching(t *testing.T) {
+	ils := pdata.NewInstrumentationLibrary()
+	ils.SetName("name")
+	ils.SetVersion("version")
+	testcases := []struct {
+		name     string
+		expr     IlsExpr
+		expected bool
+	}{
+		{
+			name:     "name",
+			expr:     NewNameIlsExpr(NewStrictStringExpr("name")),
+			expected: true,
+		},
+		{
+			name:     "empty_name",
+			expr:     NewNameIlsExpr(NewStrictStringExpr("")),
+			expected: false,
+		},
+		{
+			name:     "version",
+			expr:     NewVersionIlsExpr(NewStrictStringExpr("version")),
+			expected: true,
+		},
+		{
+			name:     "empty_version",
+			expr:     NewVersionIlsExpr(NewStrictStringExpr("")),
+			expected: false,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.expr.Evaluate(ils))
+		})
+	}
+}
+
+func TestEmptyIlssMatching(t *testing.T) {
+	ils := pdata.NewInstrumentationLibrary()
+	testcases := []struct {
+		name     string
+		expr     IlsExpr
+		expected bool
+	}{
+		{
+			name:     "name",
+			expr:     NewNameIlsExpr(NewStrictStringExpr("name")),
+			expected: false,
+		},
+		{
+			name:     "empty_name",
+			expr:     NewNameIlsExpr(NewStrictStringExpr("")),
+			expected: true,
+		},
+		{
+			name:     "version",
+			expr:     NewVersionIlsExpr(NewStrictStringExpr("version")),
+			expected: false,
+		},
+		{
+			name:     "empty_version",
+			expr:     NewVersionIlsExpr(NewStrictStringExpr("")),
+			expected: true,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.expr.Evaluate(ils))
+		})
+	}
+}
+
+func TestIlsLogicalOperators(t *testing.T) {
+	testcases := []struct {
+		name     string
+		expr     IlsExpr
+		expected bool
+	}{
+		{
+			name:     "or_attribute_true_true",
+			expr:     NewOrIlsExpr(trueIlsExpr, falseIlsExpr),
+			expected: true,
+		},
+		{
+			name:     "or_attribute_true_false",
+			expr:     NewOrIlsExpr(trueIlsExpr, falseIlsExpr),
+			expected: true,
+		},
+		{
+			name:     "or_attribute_false_true",
+			expr:     NewOrIlsExpr(falseIlsExpr, trueIlsExpr),
+			expected: true,
+		},
+		{
+			name:     "or_attribute_false_false",
+			expr:     NewOrIlsExpr(falseIlsExpr, falseIlsExpr),
+			expected: false,
+		},
+		{
+			name:     "and_attribute_true_true",
+			expr:     NewAndIlsExpr(trueIlsExpr, trueIlsExpr),
+			expected: true,
+		},
+		{
+			name:     "and_attribute_true_false",
+			expr:     NewAndIlsExpr(trueIlsExpr, falseIlsExpr),
+			expected: false,
+		},
+		{
+			name:     "and_attribute_false_true",
+			expr:     NewAndIlsExpr(falseIlsExpr, trueIlsExpr),
+			expected: false,
+		},
+		{
+			name:     "and_attribute_false_false",
+			expr:     NewAndIlsExpr(falseIlsExpr, falseIlsExpr),
+			expected: false,
+		},
+		{
+			name:     "not_attribute_true",
+			expr:     NewNotIlsExpr(trueIlsExpr),
+			expected: false,
+		},
+		{
+			name:     "not_attribute_false",
+			expr:     NewNotIlsExpr(falseIlsExpr),
+			expected: true,
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.expr.Evaluate(pdata.NewInstrumentationLibrary()))
+		})
+	}
+}
+
+type boolIlsExpr bool
+
+func (bae boolIlsExpr) Evaluate(_ pdata.InstrumentationLibrary) bool {
+	return bool(bae)
+}
+
+var trueIlsExpr = boolIlsExpr(true)
+var falseIlsExpr = boolIlsExpr(false)
+
+func BenchmarkEvaluateIls(b *testing.B) {
+	library := pdata.NewInstrumentationLibrary()
+	library.SetName("lib")
+	library.SetVersion("ver")
+
+	ils := NewAndIlsExpr(
+		NewNameIlsExpr(NewStrictStringExpr("lib")),
+		NewVersionIlsExpr(NewStrictStringExpr("ver")))
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		if !ils.Evaluate(library) {
+			b.Fail()
+		}
+	}
+}

--- a/internal/processor/filterexpr/primitive_expr.go
+++ b/internal/processor/filterexpr/primitive_expr.go
@@ -1,0 +1,49 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filterexpr
+
+import (
+	"regexp"
+)
+
+type StringExpr interface {
+	Evaluate(val string) bool
+}
+
+type strictStringExpr string
+
+func NewStrictStringExpr(val string) StringExpr {
+	return strictStringExpr(val)
+}
+
+func (ssp strictStringExpr) Evaluate(val string) bool {
+	return string(ssp) == val
+}
+
+type regexpStringExpr struct {
+	re *regexp.Regexp
+}
+
+func NewRegexpStringExpr(val string) (StringExpr, error) {
+	re, err := regexp.Compile(val)
+	if err != nil {
+		return nil, err
+	}
+	return &regexpStringExpr{re: re}, nil
+}
+
+func (rsp *regexpStringExpr) Evaluate(val string) bool {
+	return rsp.re.MatchString(val)
+}

--- a/internal/processor/filterexpr/primitive_expr_test.go
+++ b/internal/processor/filterexpr/primitive_expr_test.go
@@ -1,0 +1,85 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filterexpr
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/collector/consumer/pdata"
+)
+
+func TestStringMatching(t *testing.T) {
+	ils := pdata.NewInstrumentationLibrary()
+	ils.SetName("name")
+	ils.SetVersion("version")
+	testcases := []struct {
+		name     string
+		value    string
+		expr     StringExpr
+		expected bool
+	}{
+		{
+			name:     "strict",
+			value:    "value",
+			expr:     NewStrictStringExpr("value"),
+			expected: true,
+		},
+		{
+			name:     "strict/empty_value",
+			value:    "",
+			expr:     NewStrictStringExpr("value"),
+			expected: false,
+		},
+		{
+			name:     "strict/other_value",
+			value:    "other_value",
+			expr:     NewStrictStringExpr("value"),
+			expected: false,
+		},
+		{
+			name:     "regexp",
+			value:    "value",
+			expr:     newRegexpStringExpr(t, "^val.*"),
+			expected: true,
+		},
+		{
+			name:     "regexp/empty_value",
+			value:    "",
+			expr:     newRegexpStringExpr(t, "^val.*"),
+			expected: false,
+		},
+		{
+			name:     "regexp/other_value",
+			value:    "other_value",
+			expr:     newRegexpStringExpr(t, "^val.*"),
+			expected: false,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.expr.Evaluate(tc.value))
+		})
+	}
+}
+
+func newRegexpStringExpr(t *testing.T, str string) StringExpr {
+	se, err := NewRegexpStringExpr(str)
+	require.NoError(t, err)
+	return se
+}

--- a/internal/processor/filterexpr/resource_expr.go
+++ b/internal/processor/filterexpr/resource_expr.go
@@ -1,0 +1,84 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filterexpr
+
+import (
+	"go.opentelemetry.io/collector/consumer/pdata"
+)
+
+// ResourceExpr is an interface that evaluates boolean expressions for pdata.Resource.
+type ResourceExpr interface {
+	Evaluate(resource pdata.Resource) bool
+}
+
+type notResource struct {
+	a ResourceExpr
+}
+
+func NewNotResourceExpr(a ResourceExpr) ResourceExpr {
+	return &notResource{
+		a: a,
+	}
+}
+
+func (na *notResource) Evaluate(resource pdata.Resource) bool {
+	return !na.a.Evaluate(resource)
+}
+
+type orResource struct {
+	a ResourceExpr
+	b ResourceExpr
+}
+
+func NewOrResourceExpr(a, b ResourceExpr) ResourceExpr {
+	return &orResource{
+		a: a,
+		b: b,
+	}
+}
+
+func (oa *orResource) Evaluate(resource pdata.Resource) bool {
+	return oa.a.Evaluate(resource) || oa.b.Evaluate(resource)
+}
+
+type andResource struct {
+	a ResourceExpr
+	b ResourceExpr
+}
+
+func NewAndResourceExpr(a, b ResourceExpr) ResourceExpr {
+	return &andResource{
+		a: a,
+		b: b,
+	}
+}
+
+func (aa *andResource) Evaluate(resource pdata.Resource) bool {
+	return aa.a.Evaluate(resource) && aa.b.Evaluate(resource)
+}
+
+type attributeResource struct {
+	expr AttributeExpr
+}
+
+func NewAttributesResourceExpr(expr AttributeExpr) ResourceExpr {
+	return &attributeResource{
+		expr: expr,
+	}
+}
+
+func (ar *attributeResource) Evaluate(resource pdata.Resource) bool {
+	return ar.expr.Evaluate(resource.Attributes())
+}

--- a/internal/processor/filterexpr/resource_expr_test.go
+++ b/internal/processor/filterexpr/resource_expr_test.go
@@ -1,0 +1,147 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filterexpr
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.opentelemetry.io/collector/translator/conventions"
+)
+
+func TestResourceMatching(t *testing.T) {
+	resource := pdata.NewResource()
+	resource.Attributes().InitFromMap(map[string]pdata.AttributeValue{
+		"key": pdata.NewAttributeValueString("value"),
+	})
+	testcases := []struct {
+		name     string
+		expr     ResourceExpr
+		expected bool
+	}{
+		{
+			name:     "has_attribute",
+			expr:     NewAttributesResourceExpr(NewHasAttributeExpr("key")),
+			expected: true,
+		},
+		{
+			name:     "no_attribute",
+			expr:     NewAttributesResourceExpr(NewHasAttributeExpr("")),
+			expected: false,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.expr.Evaluate(resource))
+		})
+	}
+}
+
+func TestResourceLogicalOperators(t *testing.T) {
+	testcases := []struct {
+		name     string
+		expr     ResourceExpr
+		expected bool
+	}{
+		{
+			name:     "or_attribute_true_true",
+			expr:     NewOrResourceExpr(trueResourceExpr, falseResourceExpr),
+			expected: true,
+		},
+		{
+			name:     "or_attribute_true_false",
+			expr:     NewOrResourceExpr(trueResourceExpr, falseResourceExpr),
+			expected: true,
+		},
+		{
+			name:     "or_attribute_false_true",
+			expr:     NewOrResourceExpr(falseResourceExpr, trueResourceExpr),
+			expected: true,
+		},
+		{
+			name:     "or_attribute_false_false",
+			expr:     NewOrResourceExpr(falseResourceExpr, falseResourceExpr),
+			expected: false,
+		},
+		{
+			name:     "and_attribute_true_true",
+			expr:     NewAndResourceExpr(trueResourceExpr, trueResourceExpr),
+			expected: true,
+		},
+		{
+			name:     "and_attribute_true_false",
+			expr:     NewAndResourceExpr(trueResourceExpr, falseResourceExpr),
+			expected: false,
+		},
+		{
+			name:     "and_attribute_false_true",
+			expr:     NewAndResourceExpr(falseResourceExpr, trueResourceExpr),
+			expected: false,
+		},
+		{
+			name:     "and_attribute_false_false",
+			expr:     NewAndResourceExpr(falseResourceExpr, falseResourceExpr),
+			expected: false,
+		},
+		{
+			name:     "not_attribute_true",
+			expr:     NewNotResourceExpr(trueResourceExpr),
+			expected: false,
+		},
+		{
+			name:     "not_attribute_false",
+			expr:     NewNotResourceExpr(falseResourceExpr),
+			expected: true,
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.expr.Evaluate(pdata.NewResource()))
+		})
+	}
+}
+
+type boolResourceExpr bool
+
+func (bae boolResourceExpr) Evaluate(_ pdata.Resource) bool {
+	return bool(bae)
+}
+
+var trueResourceExpr = boolResourceExpr(true)
+var falseResourceExpr = boolResourceExpr(false)
+
+func BenchmarkEvaluateResource(b *testing.B) {
+	resource := pdata.NewResource()
+	resource.Attributes().InitFromMap(map[string]pdata.AttributeValue{
+		conventions.AttributeServiceName: pdata.NewAttributeValueString("svcA"),
+		"resString":                      pdata.NewAttributeValueString("arithmetic"),
+	})
+
+	res := NewAttributesResourceExpr(
+		NewAndAttributeExpr(
+			NewStringAttributeExpr(conventions.AttributeServiceName, NewStrictStringExpr("svcA")),
+			NewHasAttributeExpr("resString")))
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		if !res.Evaluate(resource) {
+			b.Fail()
+		}
+	}
+}


### PR DESCRIPTION
Benchmarks:
```
goos: darwin
goarch: amd64
pkg: go.opentelemetry.io/collector/internal/processor/filterexpr
BenchmarkEvaluateIls
BenchmarkEvaluateIls-16    	80174056	        12.8 ns/op	       0 B/op	       0 allocs/op
PASS

goos: darwin
goarch: amd64
pkg: go.opentelemetry.io/collector/internal/processor/filterexpr
BenchmarkEvaluateResource
BenchmarkEvaluateResource-16    	51025928	        21.2 ns/op	       0 B/op	       0 allocs/op
PASS
```

Tested with the current PropertiesMatcher and for Resource and InstrumentationLibraryInfo saw ~30% improvement.
This will allow to support expressions for resource and instrumentation library info in the next PRs.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>

