### PR TITLE
Fix slice of values generated code

### DIFF
--- a/cmd/pdatagen/internal/base_slices.go
+++ b/cmd/pdatagen/internal/base_slices.go
@@ -354,7 +354,7 @@ func (es ${structName}) Resize(newLen int) {
 	}
 
 	// Add extra empty elements to the array.
-	empty := otlpcommon.AnyValue{}
+	empty := ${originName}{}
 	for i := oldLen; i < newLen; i++ {
 		*es.orig = append(*es.orig, empty)
 	}


### PR DESCRIPTION
This was not a problem in the generated code because slice of values is used only with `AnyValue` for the moment.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
