### PR TITLE
Add custom expression parsers for Resource and InstrumentationLibrary

### DIFF
--- a/cmd/schemagen/go.sum
+++ b/cmd/schemagen/go.sum
@@ -106,6 +106,10 @@ github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
+github.com/alecthomas/participle/v2 v2.0.0-alpha3 h1:7aeHdGgRXADjrDEHwCpXiMMZqppOw2dpQfmVTyBN5cY=
+github.com/alecthomas/participle/v2 v2.0.0-alpha3/go.mod h1:Z1zPLDbcGsVsBYsThKXY00i84575bN/nMczzIrU4rWU=
+github.com/alecthomas/repr v0.0.0-20181024024818-d37bc2a10ba1 h1:GDQdwm/gAcJcLAKQQZGOJ4knlw+7rfEQQcmwTbt4p5E=
+github.com/alecthomas/repr v0.0.0-20181024024818-d37bc2a10ba1/go.mod h1:xTS7Pm1pD1mvyM075QCDSRqH6qRLXylzS24ZTpRiSzQ=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/OneOfOne/xxhash v1.2.5 // indirect
 	github.com/Shopify/sarama v1.27.2
 	github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6 // indirect
+	github.com/alecthomas/participle/v2 v2.0.0-alpha3
 	github.com/antonmedv/expr v1.8.9
 	github.com/apache/thrift v0.13.0
 	github.com/cenkalti/backoff v2.2.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -107,6 +107,10 @@ github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
+github.com/alecthomas/participle/v2 v2.0.0-alpha3 h1:7aeHdGgRXADjrDEHwCpXiMMZqppOw2dpQfmVTyBN5cY=
+github.com/alecthomas/participle/v2 v2.0.0-alpha3/go.mod h1:Z1zPLDbcGsVsBYsThKXY00i84575bN/nMczzIrU4rWU=
+github.com/alecthomas/repr v0.0.0-20181024024818-d37bc2a10ba1 h1:GDQdwm/gAcJcLAKQQZGOJ4knlw+7rfEQQcmwTbt4p5E=
+github.com/alecthomas/repr v0.0.0-20181024024818-d37bc2a10ba1/go.mod h1:xTS7Pm1pD1mvyM075QCDSRqH6qRLXylzS24ZTpRiSzQ=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafoB+tBA3gMyHYHrpOtNuDiK/uB5uXxq5wM=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=

--- a/internal/processor/filterexpr/attr_expr.go
+++ b/internal/processor/filterexpr/attr_expr.go
@@ -1,0 +1,107 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filterexpr
+
+import (
+	"go.opentelemetry.io/collector/consumer/pdata"
+)
+
+// AttributeExpr is an interface that evaluates boolean expressions against pdata.AttributeMap.
+type AttributeExpr interface {
+	Evaluate(attributes pdata.AttributeMap) bool
+}
+
+type hasAttribute struct {
+	key string
+}
+
+func newHasAttributeExpr(key string) AttributeExpr {
+	return &hasAttribute{
+		key: key,
+	}
+}
+
+func (ha *hasAttribute) Evaluate(attributes pdata.AttributeMap) bool {
+	_, ok := attributes.Get(ha.key)
+	return ok
+}
+
+type doubleAttribute struct {
+	key  string
+	expr DoubleExpr
+}
+
+func newDoubleAttributeExpr(key string, expr DoubleExpr) AttributeExpr {
+	return &doubleAttribute{
+		key:  key,
+		expr: expr,
+	}
+}
+
+func (da *doubleAttribute) Evaluate(attributes pdata.AttributeMap) bool {
+	val, ok := attributes.Get(da.key)
+	return ok && da.expr.Evaluate(val.DoubleVal())
+}
+
+type intAttribute struct {
+	key  string
+	expr IntExpr
+}
+
+func newIntAttributeExpr(key string, expr IntExpr) AttributeExpr {
+	return &intAttribute{
+		key:  key,
+		expr: expr,
+	}
+}
+
+func (ia *intAttribute) Evaluate(attributes pdata.AttributeMap) bool {
+	val, ok := attributes.Get(ia.key)
+	return ok && ia.expr.Evaluate(val.IntVal())
+}
+
+type boolAttribute struct {
+	key string
+	val bool
+}
+
+func newBoolAttributeExpr(key string, val bool) AttributeExpr {
+	return &boolAttribute{
+		key: key,
+		val: val,
+	}
+}
+
+func (ba *boolAttribute) Evaluate(attributes pdata.AttributeMap) bool {
+	val, ok := attributes.Get(ba.key)
+	return ok && val.BoolVal() == ba.val
+}
+
+type stringAttribute struct {
+	key  string
+	expr StringExpr
+}
+
+func newStringAttributeExpr(key string, expr StringExpr) AttributeExpr {
+	return &stringAttribute{
+		key:  key,
+		expr: expr,
+	}
+}
+
+func (sa *stringAttribute) Evaluate(attributes pdata.AttributeMap) bool {
+	val, ok := attributes.Get(sa.key)
+	return ok && sa.expr.Evaluate(val.StringVal())
+}

--- a/internal/processor/filterexpr/attr_expr_test.go
+++ b/internal/processor/filterexpr/attr_expr_test.go
@@ -1,0 +1,156 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filterexpr
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"go.opentelemetry.io/collector/consumer/pdata"
+)
+
+func TestAttributesMatching(t *testing.T) {
+	attr := pdata.NewAttributeMap().InitFromMap(map[string]pdata.AttributeValue{
+		"keyString": pdata.NewAttributeValueString("value"),
+		"keyInt":    pdata.NewAttributeValueInt(123),
+		"keyDouble": pdata.NewAttributeValueDouble(12.3),
+		"keyBool":   pdata.NewAttributeValueBool(true),
+		"keyExists": pdata.NewAttributeValueString("present"),
+	})
+	testcases := []struct {
+		name     string
+		expr     AttributeExpr
+		expected bool
+	}{
+		{
+			name:     "has_attribute_true",
+			expr:     newHasAttributeExpr("keyExists"),
+			expected: true,
+		},
+		{
+			name:     "has_attribute_false",
+			expr:     newHasAttributeExpr("keyExists2"),
+			expected: false,
+		},
+		{
+			name:     "int_attribute_true",
+			expr:     newIntAttributeExpr("keyInt", newEqualIntExpr(123)),
+			expected: true,
+		},
+		{
+			name:     "int_attribute_no_key",
+			expr:     newIntAttributeExpr("keyInt2", newEqualIntExpr(123)),
+			expected: false,
+		},
+		{
+			name:     "int_attribute_different_value",
+			expr:     newIntAttributeExpr("keyInt", newEqualIntExpr(234)),
+			expected: false,
+		},
+		{
+			name:     "double_attribute_true",
+			expr:     newDoubleAttributeExpr("keyDouble", newEqualDoubleExpr(12.3)),
+			expected: true,
+		},
+		{
+			name:     "double_attribute_no_key",
+			expr:     newDoubleAttributeExpr("keyDouble2", newEqualDoubleExpr(12.3)),
+			expected: false,
+		},
+		{
+			name:     "double_attribute_different_value",
+			expr:     newDoubleAttributeExpr("keyDouble", newEqualDoubleExpr(23.4)),
+			expected: false,
+		},
+		{
+			name:     "string_attribute_true",
+			expr:     newStringAttributeExpr("keyString", newEqualStringExpr("value")),
+			expected: true,
+		},
+		{
+			name:     "string_attribute_no_key",
+			expr:     newStringAttributeExpr("keyString2", newEqualStringExpr("value")),
+			expected: false,
+		},
+		{
+			name:     "string_attribute_different_value",
+			expr:     newStringAttributeExpr("keyString", newEqualStringExpr("other_value")),
+			expected: false,
+		},
+		{
+			name:     "bool_attribute_true",
+			expr:     newBoolAttributeExpr("keyBool", true),
+			expected: true,
+		},
+		{
+			name:     "bool_attribute_no_key",
+			expr:     newBoolAttributeExpr("keyBool2", true),
+			expected: false,
+		},
+		{
+			name:     "bool_attribute_different_value",
+			expr:     newBoolAttributeExpr("keyBool", false),
+			expected: false,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.expr.Evaluate(attr))
+		})
+	}
+}
+
+func TestEmptyAttributesMatching(t *testing.T) {
+	attr := pdata.NewAttributeMap()
+	testcases := []struct {
+		name     string
+		expr     AttributeExpr
+		expected bool
+	}{
+		{
+			name:     "has_attribute",
+			expr:     newHasAttributeExpr("key"),
+			expected: false,
+		},
+		{
+			name:     "int_attribute",
+			expr:     newIntAttributeExpr("key", newEqualIntExpr(123)),
+			expected: false,
+		},
+		{
+			name:     "double_attribute",
+			expr:     newDoubleAttributeExpr("key", newEqualDoubleExpr(12.3)),
+			expected: false,
+		},
+		{
+			name:     "string_attribute",
+			expr:     newStringAttributeExpr("key", newEqualStringExpr("value")),
+			expected: false,
+		},
+		{
+			name:     "bool_attribute",
+			expr:     newBoolAttributeExpr("key", true),
+			expected: false,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.expr.Evaluate(attr))
+		})
+	}
+}

--- a/internal/processor/filterexpr/doc.go
+++ b/internal/processor/filterexpr/doc.go
@@ -1,0 +1,17 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package filterexpr provides an implementation to filter pdata.Resource, pdata.InstrumentationLibrary
+// pdata.Span, pdata.Metric, and pdata.LogRecord using an expressions to match against.
+package filterexpr

--- a/internal/processor/filterexpr/il_expr.go
+++ b/internal/processor/filterexpr/il_expr.go
@@ -1,0 +1,99 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filterexpr
+
+import (
+	"go.opentelemetry.io/collector/consumer/pdata"
+)
+
+// IlExpr is an interface that evaluates boolean expressions against pdata.InstrumentationLibrary.
+type IlExpr interface {
+	Evaluate(ils pdata.InstrumentationLibrary) bool
+}
+
+type notIl struct {
+	a IlExpr
+}
+
+func newNotIlExpr(a IlExpr) IlExpr {
+	return &notIl{
+		a: a,
+	}
+}
+
+func (na *notIl) Evaluate(ils pdata.InstrumentationLibrary) bool {
+	return !na.a.Evaluate(ils)
+}
+
+type orIl struct {
+	a IlExpr
+	b IlExpr
+}
+
+func newOrIlExpr(a, b IlExpr) IlExpr {
+	return &orIl{
+		a: a,
+		b: b,
+	}
+}
+
+func (oa *orIl) Evaluate(ils pdata.InstrumentationLibrary) bool {
+	a := oa.a.Evaluate(ils)
+	return a || oa.b.Evaluate(ils)
+}
+
+type andIl struct {
+	a IlExpr
+	b IlExpr
+}
+
+func newAndIlExpr(a, b IlExpr) IlExpr {
+	return &andIl{
+		a: a,
+		b: b,
+	}
+}
+
+func (aa *andIl) Evaluate(ils pdata.InstrumentationLibrary) bool {
+	return aa.a.Evaluate(ils) && aa.b.Evaluate(ils)
+}
+
+type nameIl struct {
+	expr StringExpr
+}
+
+func newNameIlExpr(expr StringExpr) IlExpr {
+	return &nameIl{
+		expr: expr,
+	}
+}
+
+func (nils *nameIl) Evaluate(ils pdata.InstrumentationLibrary) bool {
+	return nils.expr.Evaluate(ils.Name())
+}
+
+type versionIl struct {
+	expr StringExpr
+}
+
+func newVersionIlExpr(expr StringExpr) IlExpr {
+	return &versionIl{
+		expr: expr,
+	}
+}
+
+func (vils *versionIl) Evaluate(ils pdata.InstrumentationLibrary) bool {
+	return vils.expr.Evaluate(ils.Version())
+}

--- a/internal/processor/filterexpr/il_expr_test.go
+++ b/internal/processor/filterexpr/il_expr_test.go
@@ -1,0 +1,188 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filterexpr
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"go.opentelemetry.io/collector/consumer/pdata"
+)
+
+func TestIlMatching(t *testing.T) {
+	ils := pdata.NewInstrumentationLibrary()
+	ils.SetName("name")
+	ils.SetVersion("version")
+	testcases := []struct {
+		name     string
+		expr     IlExpr
+		expected bool
+	}{
+		{
+			name:     "name",
+			expr:     newNameIlExpr(newEqualStringExpr("name")),
+			expected: true,
+		},
+		{
+			name:     "empty_name",
+			expr:     newNameIlExpr(newEqualStringExpr("")),
+			expected: false,
+		},
+		{
+			name:     "version",
+			expr:     newVersionIlExpr(newEqualStringExpr("version")),
+			expected: true,
+		},
+		{
+			name:     "empty_version",
+			expr:     newVersionIlExpr(newEqualStringExpr("")),
+			expected: false,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.expr.Evaluate(ils))
+		})
+	}
+}
+
+func TestEmptyIlsMatching(t *testing.T) {
+	ils := pdata.NewInstrumentationLibrary()
+	testcases := []struct {
+		name     string
+		expr     IlExpr
+		expected bool
+	}{
+		{
+			name:     "name",
+			expr:     newNameIlExpr(newEqualStringExpr("name")),
+			expected: false,
+		},
+		{
+			name:     "empty_name",
+			expr:     newNameIlExpr(newEqualStringExpr("")),
+			expected: true,
+		},
+		{
+			name:     "version",
+			expr:     newVersionIlExpr(newEqualStringExpr("version")),
+			expected: false,
+		},
+		{
+			name:     "empty_version",
+			expr:     newVersionIlExpr(newEqualStringExpr("")),
+			expected: true,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.expr.Evaluate(ils))
+		})
+	}
+}
+
+func TestIlLogicalOperators(t *testing.T) {
+	testcases := []struct {
+		name     string
+		expr     IlExpr
+		expected bool
+	}{
+		{
+			name:     "or_attribute_true_true",
+			expr:     newOrIlExpr(trueIlExpr, falseIlExpr),
+			expected: true,
+		},
+		{
+			name:     "or_attribute_true_false",
+			expr:     newOrIlExpr(trueIlExpr, falseIlExpr),
+			expected: true,
+		},
+		{
+			name:     "or_attribute_false_true",
+			expr:     newOrIlExpr(falseIlExpr, trueIlExpr),
+			expected: true,
+		},
+		{
+			name:     "or_attribute_false_false",
+			expr:     newOrIlExpr(falseIlExpr, falseIlExpr),
+			expected: false,
+		},
+		{
+			name:     "and_attribute_true_true",
+			expr:     newAndIlExpr(trueIlExpr, trueIlExpr),
+			expected: true,
+		},
+		{
+			name:     "and_attribute_true_false",
+			expr:     newAndIlExpr(trueIlExpr, falseIlExpr),
+			expected: false,
+		},
+		{
+			name:     "and_attribute_false_true",
+			expr:     newAndIlExpr(falseIlExpr, trueIlExpr),
+			expected: false,
+		},
+		{
+			name:     "and_attribute_false_false",
+			expr:     newAndIlExpr(falseIlExpr, falseIlExpr),
+			expected: false,
+		},
+		{
+			name:     "not_attribute_true",
+			expr:     newNotIlExpr(trueIlExpr),
+			expected: false,
+		},
+		{
+			name:     "not_attribute_false",
+			expr:     newNotIlExpr(falseIlExpr),
+			expected: true,
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.expr.Evaluate(pdata.NewInstrumentationLibrary()))
+		})
+	}
+}
+
+type boolIlExpr bool
+
+func (bae boolIlExpr) Evaluate(_ pdata.InstrumentationLibrary) bool {
+	return bool(bae)
+}
+
+var trueIlExpr = boolIlExpr(true)
+var falseIlExpr = boolIlExpr(false)
+
+func BenchmarkEvaluateIl(b *testing.B) {
+	library := pdata.NewInstrumentationLibrary()
+	library.SetName("lib")
+	library.SetVersion("ver")
+
+	ils := newAndIlExpr(
+		newNameIlExpr(newEqualStringExpr("lib")),
+		newVersionIlExpr(newEqualStringExpr("ver")))
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		if !ils.Evaluate(library) {
+			b.Fail()
+		}
+	}
+}

--- a/internal/processor/filterexpr/il_parser.go
+++ b/internal/processor/filterexpr/il_parser.go
@@ -1,0 +1,166 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filterexpr
+
+import (
+	"errors"
+
+	"github.com/alecthomas/participle/v2"
+)
+
+type ilsExpression struct {
+	LogicalOr *ilsLogicalOr `parser:"@@"`
+}
+
+func (expr *ilsExpression) toIlExpr() (IlExpr, error) {
+	if expr.LogicalOr == nil {
+		return nil, nil
+	}
+	return expr.LogicalOr.toIlExpr()
+}
+
+type ilsLogicalOr struct {
+	LogicalAnd *ilsLogicalAnd `parser:" @@"`
+	Op         string         `parser:" [ @( '|' '|' ) "`
+	Next       *ilsLogicalOr  `parser:"   @@ ] "`
+}
+
+func (lor *ilsLogicalOr) toIlExpr() (IlExpr, error) {
+	if lor.Op != "" {
+		expr1, err := lor.LogicalAnd.toIlExpr()
+		if err != nil {
+			return nil, err
+		}
+		var expr2 IlExpr
+		expr2, err = lor.Next.toIlExpr()
+		if err != nil {
+			return nil, err
+		}
+		return newOrIlExpr(expr1, expr2), nil
+	}
+	return lor.LogicalAnd.toIlExpr()
+}
+
+type ilsLogicalAnd struct {
+	Equality *ilsEquality   `parser:" @@ "`
+	Op       string         `parser:" [ @( '&' '&') "`
+	Next     *ilsLogicalAnd `parser:"  @@ ] "`
+}
+
+func (land *ilsLogicalAnd) toIlExpr() (IlExpr, error) {
+	if land.Op != "" {
+		expr1, err := land.Equality.toIlExpr()
+		if err != nil {
+			return nil, err
+		}
+		var expr2 IlExpr
+		expr2, err = land.Next.toIlExpr()
+		if err != nil {
+			return nil, err
+		}
+		return newAndIlExpr(expr1, expr2), nil
+	}
+	return land.Equality.toIlExpr()
+}
+
+type ilsEquality struct {
+	Field   string    `parser:" ( @Ident"`
+	Op      string    `parser:"   @( '!' '=' | '=' '=' | '~' '=') "`
+	Literal string    `parser:"  @String ) "`
+	Unary   *ilsUnary `parser:"| @@ "`
+}
+
+func (eq *ilsEquality) toIlExpr() (IlExpr, error) {
+	switch eq.Op {
+	case "!=":
+		switch eq.Field {
+		case "Name":
+			return newNameIlExpr(newNotEqualStringExpr(eq.Literal)), nil
+		case "Version":
+			return newVersionIlExpr(newNotEqualStringExpr(eq.Literal)), nil
+		}
+		return nil, errors.New("unrecognized field for equality operation")
+	case "==":
+		switch eq.Field {
+		case "Name":
+			return newNameIlExpr(newEqualStringExpr(eq.Literal)), nil
+		case "Version":
+			return newVersionIlExpr(newEqualStringExpr(eq.Literal)), nil
+		}
+		return nil, errors.New("unrecognized field for equality operation")
+	case "~=":
+		switch eq.Field {
+		case "Name":
+			expr, err := newRegexpStringExpr(eq.Literal)
+			if err != nil {
+				return nil, err
+			}
+			return newNameIlExpr(expr), nil
+		case "Version":
+			expr, err := newRegexpStringExpr(eq.Literal)
+			if err != nil {
+				return nil, err
+			}
+			return newVersionIlExpr(expr), nil
+		}
+		return nil, errors.New("unrecognized field for equality operation")
+	}
+	return eq.Unary.toIlExpr()
+}
+
+type ilsUnary struct {
+	Op            string         `parser:" ( @( '!' ) "`
+	Unary         *ilsUnary      `parser:"   @@ ) "`
+	SubExpression *ilsExpression `parser:" | '(' @@ ')' "`
+}
+
+func (una *ilsUnary) toIlExpr() (IlExpr, error) {
+	if una.Op != "" {
+		expr, err := una.Unary.toIlExpr()
+		if err != nil {
+			return nil, err
+		}
+		return newNotIlExpr(expr), nil
+	}
+	return una.SubExpression.toIlExpr()
+}
+
+var ilsParser = participle.MustBuild(&ilsExpression{}, participle.UseLookahead(10), participle.Unquote())
+
+// CompileIlExpr compiles an expression and returns a IlExpr that can be used
+// to evaluate the expression against a pdata.InstrumentationLibrary.
+//
+// The expression uses the following grammar:
+// expression     → logicalOr ;
+// logicalOr      → logicalAnd ( ( "||" ) logicalAnd )* ;
+// logicalAnd     → equality ( ( "&&" ) equality )* ;
+// equality       → ( (Name|Version) ( "!=" | "==" | "~=" ) STRING )* | unary ;
+// unary          → ( ( "!" ) unary )* | "(" expression ")" ;
+//
+// Available Fields:
+//   * Name - access the name field of the instrumentation library.
+//   * Version - access the version field of the instrumentation library.
+//
+// All equalities must start use the field as the first term.
+func CompileIlExpr(exprStr string) (IlExpr, error) {
+	if exprStr == "" {
+		return nil, nil
+	}
+	expr := &ilsExpression{}
+	if err := ilsParser.ParseString("", exprStr, expr); err != nil {
+		return nil, err
+	}
+	return expr.toIlExpr()
+}

--- a/internal/processor/filterexpr/il_parser_test.go
+++ b/internal/processor/filterexpr/il_parser_test.go
@@ -1,0 +1,133 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filterexpr
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/collector/consumer/pdata"
+)
+
+func TestToIlExpr(t *testing.T) {
+	expr, err := CompileIlExpr(`Name != "test" || Name == "test" && Version ~= "^ver.*"`)
+	require.NoError(t, err)
+	assert.True(t, expr.Evaluate(newIl("name", "")))
+	assert.True(t, expr.Evaluate(newIl("test", "version")))
+	assert.False(t, expr.Evaluate(newIl("test", "subver")))
+}
+
+func TestToIlExpr_Complex(t *testing.T) {
+	expr, err := CompileIlExpr(
+		`(Name != "name" && Name != "other") || !( Name != "name" || Version != "version" ) || (Name == "other" && Version == "testver" )`)
+	require.NoError(t, err)
+	assert.False(t, expr.Evaluate(newIl("name", "")))
+	assert.True(t, expr.Evaluate(newIl("name", "version")))
+	assert.False(t, expr.Evaluate(newIl("other", "")))
+	assert.True(t, expr.Evaluate(newIl("other", "testver")))
+}
+
+func TestToIlExpr_NotRegexp(t *testing.T) {
+	expr, err := CompileIlExpr(`!( Name ~= "^te.*" )`)
+	require.NoError(t, err)
+	assert.True(t, expr.Evaluate(newIl("name", "")))
+	assert.False(t, expr.Evaluate(newIl("test", "")))
+}
+
+func TestToIlExpr_Empty(t *testing.T) {
+	expr, err := CompileIlExpr(``)
+	require.NoError(t, err)
+	assert.Nil(t, expr)
+}
+
+func TestCompileIlError(t *testing.T) {
+	testcases := []struct {
+		name       string
+		exprString string
+	}{
+		{
+			name:       "And_NameRegexp",
+			exprString: `Name ~= "[a-z)*" && Version ~= "[a-z]*"`,
+		},
+		{
+			name:       "And_VersionRegexp",
+			exprString: `Name ~= "[a-z]*" && Version ~= "[a-z)*"`,
+		},
+		{
+			name:       "Or_NameRegexp",
+			exprString: `Name ~= "[a-z)*" || Version ~= "[a-z]*"`,
+		},
+		{
+			name:       "Or_VersionRegexp",
+			exprString: `Name ~= "[a-z]*" || Version ~= "[a-z)*"`,
+		},
+		{
+			name:       "Not_NameRegexp",
+			exprString: `!(Name ~= "[a-z)*")`,
+		},
+		{
+			name:       "invalid_name",
+			exprString: `Naame != "test"`,
+		},
+		{
+			name:       "invalid_version",
+			exprString: `Veersion == "test"`,
+		},
+		{
+			name:       "invalid_id",
+			exprString: `Id ~= "test"`,
+		},
+		{
+			name:       "invalid_order",
+			exprString: `"test" == Name`,
+		},
+		{
+			name:       "invalid_not",
+			exprString: `!Name == "test"`,
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := CompileIlExpr(tc.exprString)
+			assert.Error(t, err)
+		})
+	}
+}
+
+func newIl(name, version string) pdata.InstrumentationLibrary {
+	ils := pdata.NewInstrumentationLibrary()
+	ils.SetName(name)
+	ils.SetVersion(version)
+	return ils
+}
+
+func BenchmarkEvaluateIlExpr(b *testing.B) {
+	library := pdata.NewInstrumentationLibrary()
+	library.SetName("lib")
+	library.SetVersion("ver")
+
+	ils, err := CompileIlExpr(`Name == "lib" && Version == "ver"`)
+	require.NoError(b, err)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		if !ils.Evaluate(library) {
+			b.Fail()
+		}
+	}
+}

--- a/internal/processor/filterexpr/matcher_test.go
+++ b/internal/processor/filterexpr/matcher_test.go
@@ -343,3 +343,24 @@ func matchDoubleHistogram(t *testing.T, metricName string) bool {
 	assert.NoError(t, err)
 	return matched
 }
+
+func BenchmarkMatchMetric(b *testing.B) {
+	matcher, err := NewMatcher(`MetricName == 'my.metric'`)
+	require.NoError(b, err)
+
+	m := pdata.NewMetric()
+	m.SetName("my.metric")
+	m.SetDataType(pdata.MetricDataTypeIntHistogram)
+	dps := m.IntHistogram().DataPoints()
+	pt := pdata.NewIntHistogramDataPoint()
+	dps.Append(pt)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		matched, err := matcher.MatchMetric(m)
+		if err != nil || !matched {
+			b.Fail()
+		}
+	}
+}

--- a/internal/processor/filterexpr/primitive_expr.go
+++ b/internal/processor/filterexpr/primitive_expr.go
@@ -1,0 +1,107 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filterexpr
+
+import (
+	"regexp"
+)
+
+type IntExpr interface {
+	Evaluate(val int64) bool
+}
+
+type notEqualIntExpr int64
+
+func newNotEqualIntExpr(val int64) IntExpr {
+	return notEqualIntExpr(val)
+}
+
+func (ssp notEqualIntExpr) Evaluate(val int64) bool {
+	return int64(ssp) != val
+}
+
+type equalIntExpr int64
+
+func newEqualIntExpr(val int64) IntExpr {
+	return equalIntExpr(val)
+}
+
+func (ssp equalIntExpr) Evaluate(val int64) bool {
+	return int64(ssp) == val
+}
+
+type DoubleExpr interface {
+	Evaluate(val float64) bool
+}
+
+type notEqualDoubleExpr float64
+
+func newNotEqualDoubleExpr(val float64) DoubleExpr {
+	return notEqualDoubleExpr(val)
+}
+
+func (ssp notEqualDoubleExpr) Evaluate(val float64) bool {
+	return float64(ssp) != val
+}
+
+type equalDoubleExpr float64
+
+func newEqualDoubleExpr(val float64) DoubleExpr {
+	return equalDoubleExpr(val)
+}
+
+func (ssp equalDoubleExpr) Evaluate(val float64) bool {
+	return float64(ssp) == val
+}
+
+type StringExpr interface {
+	Evaluate(val string) bool
+}
+
+type notEqualStringExpr string
+
+func newNotEqualStringExpr(val string) StringExpr {
+	return notEqualStringExpr(val)
+}
+
+func (ssp notEqualStringExpr) Evaluate(val string) bool {
+	return string(ssp) != val
+}
+
+type equalStringExpr string
+
+func newEqualStringExpr(val string) StringExpr {
+	return equalStringExpr(val)
+}
+
+func (ssp equalStringExpr) Evaluate(val string) bool {
+	return string(ssp) == val
+}
+
+type regexpStringExpr struct {
+	re *regexp.Regexp
+}
+
+func newRegexpStringExpr(val string) (StringExpr, error) {
+	re, err := regexp.Compile(val)
+	if err != nil {
+		return nil, err
+	}
+	return &regexpStringExpr{re: re}, nil
+}
+
+func (rsp *regexpStringExpr) Evaluate(val string) bool {
+	return rsp.re.MatchString(val)
+}

--- a/internal/processor/filterexpr/primitive_expr_test.go
+++ b/internal/processor/filterexpr/primitive_expr_test.go
@@ -1,0 +1,189 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filterexpr
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/collector/consumer/pdata"
+)
+
+func TestIntMatching(t *testing.T) {
+	ils := pdata.NewInstrumentationLibrary()
+	ils.SetName("name")
+	ils.SetVersion("version")
+	testcases := []struct {
+		name     string
+		value    int64
+		expr     IntExpr
+		expected bool
+	}{
+		{
+			name:     "not_equal",
+			value:    123,
+			expr:     newNotEqualIntExpr(234),
+			expected: true,
+		},
+		{
+			name:     "not_equal/same_value",
+			value:    123,
+			expr:     newNotEqualIntExpr(123),
+			expected: false,
+		},
+		{
+			name:     "equal",
+			value:    123,
+			expr:     newEqualIntExpr(123),
+			expected: true,
+		},
+		{
+			name:     "equal/other_value",
+			value:    123,
+			expr:     newEqualIntExpr(234),
+			expected: false,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.expr.Evaluate(tc.value))
+		})
+	}
+}
+
+func TestDoubleMatching(t *testing.T) {
+	ils := pdata.NewInstrumentationLibrary()
+	ils.SetName("name")
+	ils.SetVersion("version")
+	testcases := []struct {
+		name     string
+		value    float64
+		expr     DoubleExpr
+		expected bool
+	}{
+		{
+			name:     "not_equal",
+			value:    12.3,
+			expr:     newNotEqualDoubleExpr(23.4),
+			expected: true,
+		},
+		{
+			name:     "not_equal/same_value",
+			value:    12.3,
+			expr:     newNotEqualDoubleExpr(12.3),
+			expected: false,
+		},
+		{
+			name:     "equal",
+			value:    12.3,
+			expr:     newEqualDoubleExpr(12.3),
+			expected: true,
+		},
+		{
+			name:     "equal/other_value",
+			value:    12.3,
+			expr:     newEqualDoubleExpr(23.4),
+			expected: false,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.expr.Evaluate(tc.value))
+		})
+	}
+}
+
+func TestStringMatching(t *testing.T) {
+	ils := pdata.NewInstrumentationLibrary()
+	ils.SetName("name")
+	ils.SetVersion("version")
+	testcases := []struct {
+		name     string
+		value    string
+		expr     StringExpr
+		expected bool
+	}{
+		{
+			name:     "not_equal",
+			value:    "value",
+			expr:     newNotEqualStringExpr("other"),
+			expected: true,
+		},
+		{
+			name:     "not_equal/empty_value",
+			value:    "",
+			expr:     newNotEqualStringExpr("value"),
+			expected: true,
+		},
+		{
+			name:     "not_equal/same_value",
+			value:    "value",
+			expr:     newNotEqualStringExpr("value"),
+			expected: false,
+		},
+		{
+			name:     "equal",
+			value:    "value",
+			expr:     newEqualStringExpr("value"),
+			expected: true,
+		},
+		{
+			name:     "equal/empty_value",
+			value:    "",
+			expr:     newEqualStringExpr("value"),
+			expected: false,
+		},
+		{
+			name:     "equal/other_value",
+			value:    "other_value",
+			expr:     newEqualStringExpr("value"),
+			expected: false,
+		},
+		{
+			name:     "regexp",
+			value:    "value",
+			expr:     newMustRegexpStringExpr(t, "^val.*"),
+			expected: true,
+		},
+		{
+			name:     "regexp/empty_value",
+			value:    "",
+			expr:     newMustRegexpStringExpr(t, "^val.*"),
+			expected: false,
+		},
+		{
+			name:     "regexp/other_value",
+			value:    "other_value",
+			expr:     newMustRegexpStringExpr(t, "^val.*"),
+			expected: false,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.expr.Evaluate(tc.value))
+		})
+	}
+}
+
+func newMustRegexpStringExpr(t *testing.T, str string) StringExpr {
+	se, err := newRegexpStringExpr(str)
+	require.NoError(t, err)
+	return se
+}

--- a/internal/processor/filterexpr/resource_expr.go
+++ b/internal/processor/filterexpr/resource_expr.go
@@ -1,0 +1,84 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filterexpr
+
+import (
+	"go.opentelemetry.io/collector/consumer/pdata"
+)
+
+// ResourceExpr is an interface that evaluates boolean expressions against pdata.Resource.
+type ResourceExpr interface {
+	Evaluate(resource pdata.Resource) bool
+}
+
+type notResource struct {
+	a ResourceExpr
+}
+
+func newNotResourceExpr(a ResourceExpr) ResourceExpr {
+	return &notResource{
+		a: a,
+	}
+}
+
+func (na *notResource) Evaluate(resource pdata.Resource) bool {
+	return !na.a.Evaluate(resource)
+}
+
+type orResource struct {
+	a ResourceExpr
+	b ResourceExpr
+}
+
+func newOrResourceExpr(a, b ResourceExpr) ResourceExpr {
+	return &orResource{
+		a: a,
+		b: b,
+	}
+}
+
+func (oa *orResource) Evaluate(resource pdata.Resource) bool {
+	return oa.a.Evaluate(resource) || oa.b.Evaluate(resource)
+}
+
+type andResource struct {
+	a ResourceExpr
+	b ResourceExpr
+}
+
+func newAndResourceExpr(a, b ResourceExpr) ResourceExpr {
+	return &andResource{
+		a: a,
+		b: b,
+	}
+}
+
+func (aa *andResource) Evaluate(resource pdata.Resource) bool {
+	return aa.a.Evaluate(resource) && aa.b.Evaluate(resource)
+}
+
+type attributeResource struct {
+	expr AttributeExpr
+}
+
+func newAttributesResourceExpr(expr AttributeExpr) ResourceExpr {
+	return &attributeResource{
+		expr: expr,
+	}
+}
+
+func (ar *attributeResource) Evaluate(resource pdata.Resource) bool {
+	return ar.expr.Evaluate(resource.Attributes())
+}

--- a/internal/processor/filterexpr/resource_expr_test.go
+++ b/internal/processor/filterexpr/resource_expr_test.go
@@ -1,0 +1,146 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filterexpr
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.opentelemetry.io/collector/translator/conventions"
+)
+
+func TestResourceMatching(t *testing.T) {
+	resource := pdata.NewResource()
+	resource.Attributes().InitFromMap(map[string]pdata.AttributeValue{
+		"key": pdata.NewAttributeValueString("value"),
+	})
+	testcases := []struct {
+		name     string
+		expr     ResourceExpr
+		expected bool
+	}{
+		{
+			name:     "has_attribute",
+			expr:     newAttributesResourceExpr(newHasAttributeExpr("key")),
+			expected: true,
+		},
+		{
+			name:     "no_attribute",
+			expr:     newAttributesResourceExpr(newHasAttributeExpr("")),
+			expected: false,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.expr.Evaluate(resource))
+		})
+	}
+}
+
+func TestResourceLogicalOperators(t *testing.T) {
+	testcases := []struct {
+		name     string
+		expr     ResourceExpr
+		expected bool
+	}{
+		{
+			name:     "or_attribute_true_true",
+			expr:     newOrResourceExpr(trueResourceExpr, falseResourceExpr),
+			expected: true,
+		},
+		{
+			name:     "or_attribute_true_false",
+			expr:     newOrResourceExpr(trueResourceExpr, falseResourceExpr),
+			expected: true,
+		},
+		{
+			name:     "or_attribute_false_true",
+			expr:     newOrResourceExpr(falseResourceExpr, trueResourceExpr),
+			expected: true,
+		},
+		{
+			name:     "or_attribute_false_false",
+			expr:     newOrResourceExpr(falseResourceExpr, falseResourceExpr),
+			expected: false,
+		},
+		{
+			name:     "and_attribute_true_true",
+			expr:     newAndResourceExpr(trueResourceExpr, trueResourceExpr),
+			expected: true,
+		},
+		{
+			name:     "and_attribute_true_false",
+			expr:     newAndResourceExpr(trueResourceExpr, falseResourceExpr),
+			expected: false,
+		},
+		{
+			name:     "and_attribute_false_true",
+			expr:     newAndResourceExpr(falseResourceExpr, trueResourceExpr),
+			expected: false,
+		},
+		{
+			name:     "and_attribute_false_false",
+			expr:     newAndResourceExpr(falseResourceExpr, falseResourceExpr),
+			expected: false,
+		},
+		{
+			name:     "not_attribute_true",
+			expr:     newNotResourceExpr(trueResourceExpr),
+			expected: false,
+		},
+		{
+			name:     "not_attribute_false",
+			expr:     newNotResourceExpr(falseResourceExpr),
+			expected: true,
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.expr.Evaluate(pdata.NewResource()))
+		})
+	}
+}
+
+type boolResourceExpr bool
+
+func (bae boolResourceExpr) Evaluate(_ pdata.Resource) bool {
+	return bool(bae)
+}
+
+var trueResourceExpr = boolResourceExpr(true)
+var falseResourceExpr = boolResourceExpr(false)
+
+func BenchmarkEvaluateResource(b *testing.B) {
+	resource := pdata.NewResource()
+	resource.Attributes().InitFromMap(map[string]pdata.AttributeValue{
+		conventions.AttributeServiceName: pdata.NewAttributeValueString("svcA"),
+		"resString":                      pdata.NewAttributeValueString("arithmetic"),
+	})
+
+	res := newAndResourceExpr(
+		newAttributesResourceExpr(newStringAttributeExpr(conventions.AttributeServiceName, newEqualStringExpr("svcA"))),
+		newAttributesResourceExpr(newHasAttributeExpr("resString")))
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		if !res.Evaluate(resource) {
+			b.Fail()
+		}
+	}
+}

--- a/internal/processor/filterexpr/resource_parser.go
+++ b/internal/processor/filterexpr/resource_parser.go
@@ -1,0 +1,189 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filterexpr
+
+import (
+	"errors"
+
+	"github.com/alecthomas/participle/v2"
+)
+
+type resourceExpression struct {
+	LogicalOr *resourceLogicalOr `parser:"@@"`
+}
+
+func (expr *resourceExpression) toResourceExpr() (ResourceExpr, error) {
+	if expr.LogicalOr == nil {
+		return nil, nil
+	}
+	return expr.LogicalOr.toResourceExpr()
+}
+
+type resourceLogicalOr struct {
+	LogicalAnd *resourceLogicalAnd `parser:"@@"`
+	Op         string              `parser:" [ @( '|' '|' ) "`
+	Next       *resourceLogicalOr  `parser:"   @@ ] "`
+}
+
+func (lor *resourceLogicalOr) toResourceExpr() (ResourceExpr, error) {
+	if lor.Op != "" {
+		expr1, err := lor.LogicalAnd.toResourceExpr()
+		if err != nil {
+			return nil, err
+		}
+		var expr2 ResourceExpr
+		expr2, err = lor.Next.toResourceExpr()
+		if err != nil {
+			return nil, err
+		}
+		return newOrResourceExpr(expr1, expr2), nil
+	}
+	return lor.LogicalAnd.toResourceExpr()
+}
+
+type resourceLogicalAnd struct {
+	Equality *resourceEquality   `parser:"@@"`
+	Op       string              `parser:" [ @( '&' '&') "`
+	Next     *resourceLogicalAnd `parser:"   @@ ] "`
+}
+
+func (land *resourceLogicalAnd) toResourceExpr() (ResourceExpr, error) {
+	if land.Op != "" {
+		expr1, err := land.Equality.toResourceExpr()
+		if err != nil {
+			return nil, err
+		}
+		var expr2 ResourceExpr
+		expr2, err = land.Next.toResourceExpr()
+		if err != nil {
+			return nil, err
+		}
+		return newAndResourceExpr(expr1, expr2), nil
+	}
+	return land.Equality.toResourceExpr()
+}
+
+type resourceEquality struct {
+	AttributeKey string           `parser:" ( 'Attribute' '(' @String ')'"`
+	Op           string           `parser:"   @( '!' '=' | '=' '=' | '~' '=') "`
+	Literal      *resourceLiteral `parser:"   @@ ) "`
+	Unary        *resourceUnary   `parser:" | @@ "`
+}
+
+func (eq *resourceEquality) toResourceExpr() (ResourceExpr, error) {
+	switch eq.Op {
+	case "!=":
+		switch {
+		case eq.Literal.String != nil:
+			return newAttributesResourceExpr(newStringAttributeExpr(eq.AttributeKey, newNotEqualStringExpr(*eq.Literal.String))), nil
+		case eq.Literal.Int != nil:
+			return newAttributesResourceExpr(newIntAttributeExpr(eq.AttributeKey, newNotEqualIntExpr(*eq.Literal.Int))), nil
+		case eq.Literal.Double != nil:
+			return newAttributesResourceExpr(newDoubleAttributeExpr(eq.AttributeKey, newNotEqualDoubleExpr(*eq.Literal.Double))), nil
+		case eq.Literal.Bool != nil:
+			return newAttributesResourceExpr(newBoolAttributeExpr(eq.AttributeKey, !(*eq.Literal.Bool))), nil
+		}
+	case "==":
+		switch {
+		case eq.Literal.String != nil:
+			return newAttributesResourceExpr(newStringAttributeExpr(eq.AttributeKey, newEqualStringExpr(*eq.Literal.String))), nil
+		case eq.Literal.Int != nil:
+			return newAttributesResourceExpr(newIntAttributeExpr(eq.AttributeKey, newEqualIntExpr(*eq.Literal.Int))), nil
+		case eq.Literal.Double != nil:
+			return newAttributesResourceExpr(newDoubleAttributeExpr(eq.AttributeKey, newEqualDoubleExpr(*eq.Literal.Double))), nil
+		case eq.Literal.Bool != nil:
+			return newAttributesResourceExpr(newBoolAttributeExpr(eq.AttributeKey, *eq.Literal.Bool)), nil
+		}
+	case "~=":
+		if eq.Literal.String == nil {
+			return nil, errors.New("regexp supports only string")
+		}
+		expr, err := newRegexpStringExpr(*eq.Literal.String)
+		if err != nil {
+			return nil, err
+		}
+		return newAttributesResourceExpr(newStringAttributeExpr(eq.AttributeKey, expr)), nil
+	}
+	return eq.Unary.toResourceExpr()
+}
+
+type resourceUnary struct {
+	Op      string           `parser:" ( @( '!' ) "`
+	Unary   *resourceUnary   `parser:"   @@ ) "`
+	Primary *resourcePrimary `parser:" | @@ "`
+}
+
+func (una *resourceUnary) toResourceExpr() (ResourceExpr, error) {
+	if una.Op != "" {
+		expr, err := una.Unary.toResourceExpr()
+		if err != nil {
+			return nil, err
+		}
+		return newNotResourceExpr(expr), nil
+	}
+	return una.Primary.toResourceExpr()
+}
+
+type resourcePrimary struct {
+	HasAttributeKey *string             `parser:" ( 'HasAttribute' '(' @String ')' ) "`
+	SubExpression   *resourceExpression `parser:" | '(' @@ ')' "`
+}
+
+func (una *resourcePrimary) toResourceExpr() (ResourceExpr, error) {
+	if una.HasAttributeKey != nil {
+		return newAttributesResourceExpr(newHasAttributeExpr(*una.HasAttributeKey)), nil
+	}
+	return una.SubExpression.toResourceExpr()
+}
+
+type resourceLiteral struct {
+	String *string  `parser:" @String "`
+	Double *float64 `parser:" | @Float "`
+	Int    *int64   `parser:" | @Int "`
+	Bool   *bool    `parser:" | @('true' | 'false') "`
+}
+
+var resourceParser = participle.MustBuild(&resourceExpression{}, participle.UseLookahead(10), participle.Unquote())
+
+// CompileResourceExpr compiles an expression and returns a ResourceExpr that can be used
+// to evaluate the expression against a pdata.Resource.
+//
+// The expression uses the following grammar:
+// expression     → logicalOr ;
+// logicalOr      → logicalAnd ( ( "||" ) logicalAnd )* ;
+// logicalAnd     → equality ( ( "&&" ) equality )* ;
+// equality       → ( Attribute(STRING) ( "!=" | "==" | "~=" ) (STRING|FLOAT|INT|BOOL) )* | unary ;
+// unary          → ( ( "!" ) unary )* | primary ;
+// primary        → ( HasAttribute(STRING) )* | "(" expression ")" ;
+//
+// Available Fields:
+//   * HasAttribute("key") - function that returns if an attribute exists with the specified key.
+//   * Attribute("key") - function that returns the value of a resource attribute with the specified key.
+//     Attributes can have different value types, the type of the value to compare with is determined
+//     by the type of the second term of the equality.
+//
+// All equalities must start use the field as the first term.
+//
+// Caveat: For floats always use "." even if the value is integer (e.g. "2.0").
+func CompileResourceExpr(exprStr string) (ResourceExpr, error) {
+	if exprStr == "" {
+		return nil, nil
+	}
+	expr := &resourceExpression{}
+	if err := resourceParser.ParseString("", exprStr, expr); err != nil {
+		return nil, err
+	}
+	return expr.toResourceExpr()
+}

--- a/internal/processor/filterexpr/resource_parser_test.go
+++ b/internal/processor/filterexpr/resource_parser_test.go
@@ -1,0 +1,183 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filterexpr
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.opentelemetry.io/collector/translator/conventions"
+)
+
+func TestToResourceExpr(t *testing.T) {
+	expr, err := CompileResourceExpr(
+		`Attribute("name") != "test" || Attribute("name") == "test" && !HasAttribute("version")`)
+	require.NoError(t, err)
+	assert.True(t, expr.Evaluate(newResource(map[string]pdata.AttributeValue{
+		"name": pdata.NewAttributeValueString("test")})))
+	assert.True(t, expr.Evaluate(newResource(map[string]pdata.AttributeValue{
+		"name": pdata.NewAttributeValueString("other")})))
+	assert.False(t, expr.Evaluate(newResource(map[string]pdata.AttributeValue{
+		"name":    pdata.NewAttributeValueString("test"),
+		"version": pdata.NewAttributeValueString("version")})))
+}
+
+func TestToResourceExpr_AllEqual(t *testing.T) {
+	expr, err := CompileResourceExpr(
+		`Attribute("string") == "test" && Attribute("int") == 123 && Attribute("double") == 12.3 && Attribute("bool") == true`)
+	require.NoError(t, err)
+	assert.True(t, expr.Evaluate(newResource(map[string]pdata.AttributeValue{
+		"string": pdata.NewAttributeValueString("test"),
+		"int":    pdata.NewAttributeValueInt(123),
+		"double": pdata.NewAttributeValueDouble(12.3),
+		"bool":   pdata.NewAttributeValueBool(true)})))
+	assert.False(t, expr.Evaluate(newResource(map[string]pdata.AttributeValue{
+		"string": pdata.NewAttributeValueString("test"),
+		"int":    pdata.NewAttributeValueInt(234),
+		"double": pdata.NewAttributeValueDouble(12.3),
+		"bool":   pdata.NewAttributeValueBool(true)})))
+	assert.False(t, expr.Evaluate(newResource(map[string]pdata.AttributeValue{
+		"string": pdata.NewAttributeValueString("test"),
+		"int":    pdata.NewAttributeValueInt(123),
+		"double": pdata.NewAttributeValueDouble(23.4),
+		"bool":   pdata.NewAttributeValueBool(true)})))
+	assert.False(t, expr.Evaluate(newResource(map[string]pdata.AttributeValue{
+		"string": pdata.NewAttributeValueString("test"),
+		"int":    pdata.NewAttributeValueInt(123),
+		"double": pdata.NewAttributeValueDouble(12.3),
+		"bool":   pdata.NewAttributeValueBool(false)})))
+}
+
+func TestToResourceExpr_AllNotEqual(t *testing.T) {
+	expr, err := CompileResourceExpr(
+		`Attribute("string") != "test" || Attribute("int") != 123 || Attribute("double") != 12.3 || Attribute("bool") != true`)
+	require.NoError(t, err)
+	assert.False(t, expr.Evaluate(newResource(map[string]pdata.AttributeValue{
+		"string": pdata.NewAttributeValueString("test"),
+		"int":    pdata.NewAttributeValueInt(123),
+		"double": pdata.NewAttributeValueDouble(12.3),
+		"bool":   pdata.NewAttributeValueBool(true)})))
+	assert.True(t, expr.Evaluate(newResource(map[string]pdata.AttributeValue{
+		"string": pdata.NewAttributeValueString("test"),
+		"int":    pdata.NewAttributeValueInt(234),
+		"double": pdata.NewAttributeValueDouble(12.3),
+		"bool":   pdata.NewAttributeValueBool(true)})))
+	assert.True(t, expr.Evaluate(newResource(map[string]pdata.AttributeValue{
+		"string": pdata.NewAttributeValueString("test"),
+		"int":    pdata.NewAttributeValueInt(123),
+		"double": pdata.NewAttributeValueDouble(23.4),
+		"bool":   pdata.NewAttributeValueBool(true)})))
+	assert.True(t, expr.Evaluate(newResource(map[string]pdata.AttributeValue{
+		"string": pdata.NewAttributeValueString("test"),
+		"int":    pdata.NewAttributeValueInt(123),
+		"double": pdata.NewAttributeValueDouble(12.3),
+		"bool":   pdata.NewAttributeValueBool(false)})))
+}
+
+func TestToResourceExpr_Empty(t *testing.T) {
+	expr, err := CompileResourceExpr(``)
+	require.NoError(t, err)
+	assert.Nil(t, expr)
+}
+
+func TestCompileResourceError(t *testing.T) {
+	testcases := []struct {
+		name       string
+		exprString string
+	}{
+		{
+			name:       "And_FirstRegexp",
+			exprString: `Attribute("test") ~= "[a-z)*" && Attribute("test") ~= "[a-z]*"`,
+		},
+		{
+			name:       "And_SecondRegexp",
+			exprString: `Attribute("test") ~= "[a-z]*" && Attribute("test") ~= "[a-z)*"`,
+		},
+		{
+			name:       "Or_FirstRegexp",
+			exprString: `Attribute("test") ~= "[a-z)*" || Attribute("test") ~= "[a-z]*"`,
+		},
+		{
+			name:       "Or_SecondRegexp",
+			exprString: `Attribute("test") ~= "[a-z]*" || Attribute("test") ~= "[a-z)*"`,
+		},
+		{
+			name:       "Not_NameRegexp",
+			exprString: `!(Attribute("test") ~= "[a-z)*")`,
+		},
+		{
+			name:       "regexp_int",
+			exprString: `Attribute("test") ~= 123`,
+		},
+		{
+			name:       "regexp_double",
+			exprString: `Attribute("test") ~= 12.3`,
+		},
+		{
+			name:       "regexp_bool",
+			exprString: `Attribute("test") ~= true`,
+		},
+		{
+			name:       "invalid_attribute_call",
+			exprString: `Attribute["test") != "test"`,
+		},
+		{
+			name:       "invalid_attribute",
+			exprString: `Atttribute("test") != "test"`,
+		},
+		{
+			name:       "invalid_order",
+			exprString: `"test" == Attribute("test")`,
+		},
+		{
+			name:       "invalid_not",
+			exprString: `!Attribute("test") == "test"`,
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := CompileResourceExpr(tc.exprString)
+			assert.Error(t, err)
+		})
+	}
+}
+
+func newResource(attrs map[string]pdata.AttributeValue) pdata.Resource {
+	res := pdata.NewResource()
+	res.Attributes().InitFromMap(attrs)
+	return res
+}
+
+func BenchmarkEvaluateResourceExpr(b *testing.B) {
+	resource := pdata.NewResource()
+	resource.Attributes().InitFromMap(map[string]pdata.AttributeValue{
+		conventions.AttributeServiceName: pdata.NewAttributeValueString("svcA"),
+		"resString":                      pdata.NewAttributeValueString("arithmetic"),
+	})
+
+	res, err := CompileResourceExpr(`Attribute("service.name") == "svcA" && HasAttribute("resString")`)
+	require.NoError(b, err)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		if !res.Evaluate(resource) {
+			b.Fail()
+		}
+	}
+}


### PR DESCRIPTION
Benchmarks:
```
goos: darwin
goarch: amd64
pkg: go.opentelemetry.io/collector/internal/processor/filterexpr
BenchmarkEvaluateIls
BenchmarkEvaluateIls-16    	80174056	        12.8 ns/op	       0 B/op	       0 allocs/op
PASS

goos: darwin
goarch: amd64
pkg: go.opentelemetry.io/collector/internal/processor/filterexpr
BenchmarkEvaluateResource
BenchmarkEvaluateResource-16    	51025928	        21.2 ns/op	       0 B/op	       0 allocs/op
PASS
```

Tested with the current PropertiesMatcher and for Resource and InstrumentationLibraryInfo saw similar results.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>

