### PR TITLE
Support max batch size for metrics

### DIFF
--- a/processor/batchprocessor/README.md
+++ b/processor/batchprocessor/README.md
@@ -20,9 +20,8 @@ batch will be sent.
 - `timeout` (default = 200ms): Time duration after which a batch will be sent
 regardless of size.
 - `send_batch_max_size` (default = 0): The maximum number of items in a batch.
- This property ensures that larger batches are split into smaller units. 
- By default (`0`), there is no upper limit of the batch size. 
- It is currently supported only for the trace pipeline.
+ This property ensures that larger batches are split into smaller units.
+ By default (`0`), there is no upper limit of the batch size.
 
 Examples:
 

--- a/processor/batchprocessor/README.md
+++ b/processor/batchprocessor/README.md
@@ -22,6 +22,7 @@ regardless of size.
 - `send_batch_max_size` (default = 0): The maximum number of items in a batch.
  This property ensures that larger batches are split into smaller units.
  By default (`0`), there is no upper limit of the batch size.
+ It is currently supported only for the trace and metric pipelines.
 
 Examples:
 

--- a/processor/batchprocessor/batch_processor.go
+++ b/processor/batchprocessor/batch_processor.go
@@ -160,6 +160,16 @@ func (bp *batchProcessor) processItem(item interface{}) {
 				}()
 			}
 		}
+		if td, ok := item.(pdata.Metrics); ok {
+			itemCount := bp.batch.itemCount()
+			if itemCount+uint32(td.MetricCount()) > bp.sendBatchMaxSize {
+				tdRemainSize := splitMetrics(int(bp.sendBatchSize-itemCount), td)
+				item = tdRemainSize
+				go func() {
+					bp.newItem <- td
+				}()
+			}
+		}
 	}
 
 	bp.batch.add(item)

--- a/processor/batchprocessor/splitmetrics.go
+++ b/processor/batchprocessor/splitmetrics.go
@@ -1,0 +1,65 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package batchprocessor
+
+import (
+	"go.opentelemetry.io/collector/consumer/pdata"
+)
+
+// splitMetrics removes metrics from the input data and returns a new data of the specified size.
+func splitMetrics(size int, toSplit pdata.Metrics) pdata.Metrics {
+	if toSplit.MetricCount() <= size {
+		return toSplit
+	}
+	copiedMetrics := 0
+	result := pdata.NewMetrics()
+	rms := toSplit.ResourceMetrics()
+	for i := rms.Len() - 1; i >= 0; i-- {
+		rm := rms.At(i)
+		destRs := pdata.NewResourceMetrics()
+		rm.Resource().CopyTo(destRs.Resource())
+		result.ResourceMetrics().Append(destRs)
+
+		for j := rm.InstrumentationLibraryMetrics().Len() - 1; j >= 0; j-- {
+			instMetrics := rm.InstrumentationLibraryMetrics().At(j)
+			destInstMetrics := pdata.NewInstrumentationLibraryMetrics()
+			destRs.InstrumentationLibraryMetrics().Append(destInstMetrics)
+			instMetrics.InstrumentationLibrary().CopyTo(destInstMetrics.InstrumentationLibrary())
+
+			if size-copiedMetrics >= instMetrics.Metrics().Len() {
+				destInstMetrics.Metrics().Resize(instMetrics.Metrics().Len())
+			} else {
+				destInstMetrics.Metrics().Resize(size - copiedMetrics)
+			}
+			for k, destIdx := instMetrics.Metrics().Len()-1, 0; k >= 0 && copiedMetrics < size; k, destIdx = k-1, destIdx+1 {
+				metric := instMetrics.Metrics().At(k)
+				metric.CopyTo(destInstMetrics.Metrics().At(destIdx))
+				copiedMetrics++
+				// remove metric
+				instMetrics.Metrics().Resize(instMetrics.Metrics().Len() - 1)
+			}
+			if instMetrics.Metrics().Len() == 0 {
+				rm.InstrumentationLibraryMetrics().Resize(rm.InstrumentationLibraryMetrics().Len() - 1)
+			}
+			if copiedMetrics == size {
+				return result
+			}
+		}
+		if rm.InstrumentationLibraryMetrics().Len() == 0 {
+			rms.Resize(rms.Len() - 1)
+		}
+	}
+	return result
+}

--- a/processor/batchprocessor/splitmetrics_test.go
+++ b/processor/batchprocessor/splitmetrics_test.go
@@ -1,0 +1,113 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package batchprocessor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.opentelemetry.io/collector/internal/testdata"
+)
+
+func TestSplitMetrics_noop(t *testing.T) {
+	td := testdata.GenerateMetricsManyMetricsSameResource(20)
+	splitSize := 40
+	split := splitMetrics(splitSize, td)
+	assert.Equal(t, td, split)
+
+	td.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().Resize(5)
+	assert.EqualValues(t, td, split)
+}
+
+func TestSplitMetrics(t *testing.T) {
+	td := testdata.GenerateMetricsManyMetricsSameResource(20)
+	metrics := td.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics()
+	for i := 0; i < metrics.Len(); i++ {
+		metrics.At(i).SetName(getTestMetricName(0, i))
+	}
+	cp := pdata.NewMetrics()
+	cp.ResourceMetrics().Resize(1)
+	cp.ResourceMetrics().At(0).InstrumentationLibraryMetrics().Resize(1)
+	cp.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().Resize(5)
+	cpMetrics := cp.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics()
+	td.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).InstrumentationLibrary().CopyTo(
+		cp.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).InstrumentationLibrary())
+	td.ResourceMetrics().At(0).Resource().CopyTo(
+		cp.ResourceMetrics().At(0).Resource())
+	metrics.At(19).CopyTo(cpMetrics.At(0))
+	metrics.At(18).CopyTo(cpMetrics.At(1))
+	metrics.At(17).CopyTo(cpMetrics.At(2))
+	metrics.At(16).CopyTo(cpMetrics.At(3))
+	metrics.At(15).CopyTo(cpMetrics.At(4))
+
+	splitSize := 5
+	split := splitMetrics(splitSize, td)
+	assert.Equal(t, splitSize, split.MetricCount())
+	assert.Equal(t, cp, split)
+	assert.Equal(t, 15, td.MetricCount())
+	assert.Equal(t, "test-metric-int-0-19", split.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(0).Name())
+	assert.Equal(t, "test-metric-int-0-15", split.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(4).Name())
+}
+
+func TestSplitMetricsMultipleResourceSpans(t *testing.T) {
+	td := testdata.GenerateMetricsManyMetricsSameResource(20)
+	metrics := td.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics()
+	for i := 0; i < metrics.Len(); i++ {
+		metrics.At(i).SetName(getTestMetricName(0, i))
+	}
+	td.ResourceMetrics().Resize(2)
+	// add second index to resource metrics
+	testdata.GenerateMetricsManyMetricsSameResource(20).
+		ResourceMetrics().At(0).CopyTo(td.ResourceMetrics().At(1))
+	metrics = td.ResourceMetrics().At(1).InstrumentationLibraryMetrics().At(0).Metrics()
+	for i := 0; i < metrics.Len(); i++ {
+		metrics.At(i).SetName(getTestMetricName(1, i))
+	}
+
+	splitSize := 5
+	split := splitMetrics(splitSize, td)
+	assert.Equal(t, splitSize, split.MetricCount())
+	assert.Equal(t, 35, td.MetricCount())
+	assert.Equal(t, "test-metric-int-1-19", split.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(0).Name())
+	assert.Equal(t, "test-metric-int-1-15", split.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(4).Name())
+}
+
+func TestSplitMetricsMultipleResourceSpans_split_size_greater_than_metric_size(t *testing.T) {
+	td := testdata.GenerateMetricsManyMetricsSameResource(20)
+	metrics := td.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics()
+	for i := 0; i < metrics.Len(); i++ {
+		metrics.At(i).SetName(getTestMetricName(0, i))
+	}
+	td.ResourceMetrics().Resize(2)
+	// add second index to resource metrics
+	testdata.GenerateMetricsManyMetricsSameResource(20).
+		ResourceMetrics().At(0).CopyTo(td.ResourceMetrics().At(1))
+	metrics = td.ResourceMetrics().At(1).InstrumentationLibraryMetrics().At(0).Metrics()
+	for i := 0; i < metrics.Len(); i++ {
+		metrics.At(i).SetName(getTestMetricName(1, i))
+	}
+
+	splitSize := 25
+	split := splitMetrics(splitSize, td)
+	assert.Equal(t, splitSize, split.MetricCount())
+	assert.Equal(t, 40-splitSize, td.MetricCount())
+	assert.Equal(t, 1, td.ResourceMetrics().Len())
+	assert.Equal(t, "test-metric-int-1-19", split.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(0).Name())
+	assert.Equal(t, "test-metric-int-1-0", split.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(19).Name())
+	assert.Equal(t, "test-metric-int-0-19", split.ResourceMetrics().At(1).InstrumentationLibraryMetrics().At(0).Metrics().At(0).Name())
+	assert.Equal(t, "test-metric-int-0-15", split.ResourceMetrics().At(1).InstrumentationLibraryMetrics().At(0).Metrics().At(4).Name())
+}


### PR DESCRIPTION
During #2220 @arminru discovered that the max batch size was only applied to spans. This applies the same logic to metrics.