### PR TITLE
Wrap viper instance

### DIFF
--- a/component/component.go
+++ b/component/component.go
@@ -17,9 +17,8 @@ package component
 import (
 	"context"
 
-	"github.com/spf13/viper"
-
 	"go.opentelemetry.io/collector/config/configmodels"
+	"go.opentelemetry.io/collector/config/viper"
 )
 
 // Component is either a receiver, exporter, processor or extension.

--- a/component/componenttest/example_factories.go
+++ b/component/componenttest/example_factories.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/spf13/viper"
+	"go.opentelemetry.io/collector/config/viper"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configerror"

--- a/config/configtest/configtest.go
+++ b/config/configtest/configtest.go
@@ -17,13 +17,13 @@ package configtest
 import (
 	"testing"
 
-	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/configmodels"
+	"go.opentelemetry.io/collector/config/viper"
 )
 
 // NewViperFromYamlFile creates a viper instance that reads the given fileName as yaml config
@@ -31,7 +31,7 @@ import (
 // Example usage for testing can be found in configtest_test.go
 func NewViperFromYamlFile(t *testing.T, fileName string) *viper.Viper {
 	// Read yaml config from file
-	v := config.NewViper()
+	v := viper.NewViper()
 	v.SetConfigFile(fileName)
 	require.NoErrorf(t, v.ReadInConfig(), "unable to read the file %v", fileName)
 

--- a/config/viper/decoders.go
+++ b/config/viper/decoders.go
@@ -1,0 +1,46 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package viper
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/alecthomas/units"
+)
+
+// Size is a human-friendly data size in bytes.
+type Size int64
+
+func humanStringToBytes(
+	f reflect.Type,
+	t reflect.Type,
+	data interface{},
+) (interface{}, error) {
+	if f.Kind() != reflect.String {
+		return data, nil
+	}
+	if t != reflect.TypeOf(Size(0)) {
+		return data, nil
+	}
+
+	// Convert it by parsing.
+	conv, err := units.ParseStrictBytes(data.(string))
+	if err != nil {
+		return data, fmt.Errorf("error converting %q to byte size: %v", data.(string), err)
+	}
+
+	return Size(conv), nil
+}

--- a/config/viper/viper.go
+++ b/config/viper/viper.go
@@ -1,0 +1,79 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package viper
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/mitchellh/mapstructure"
+	"github.com/spf13/cast"
+	"github.com/spf13/viper"
+)
+
+const (
+	// ViperDelimiter is used as the default key delimiter in the default viper instance
+	ViperDelimiter = "::"
+)
+
+var defaultOptions = []viper.DecoderConfigOption{viper.DecodeHook(mapstructure.ComposeDecodeHookFunc(
+	mapstructure.StringToTimeDurationHookFunc(),
+	mapstructure.StringToSliceHookFunc(","),
+	humanStringToBytes,
+))}
+
+type Viper struct {
+	*viper.Viper
+}
+
+func (v *Viper) UnmarshalKey(key string, rawVal interface{}, opts ...viper.DecoderConfigOption) error {
+	return v.Viper.UnmarshalKey(key, rawVal, append(defaultOptions, opts...)...)
+}
+
+func (v *Viper) Unmarshal(rawVal interface{}, opts ...viper.DecoderConfigOption) error {
+	return v.Viper.Unmarshal(rawVal, append(defaultOptions, opts...)...)
+}
+
+func (v *Viper) UnmarshalExact(rawVal interface{}, opts ...viper.DecoderConfigOption) error {
+	return v.Viper.UnmarshalExact(rawVal, append(defaultOptions, opts...)...)
+}
+
+func (v *Viper) Sub(key string) *Viper {
+	return &Viper{Viper: v.Viper.Sub(key)}
+}
+
+// Copied from the Viper but changed to use the same delimiter
+// and return error if the sub is not a map.
+// See https://github.com/spf13/viper/issues/871
+func (v *Viper) SubExact(key string) (*Viper, error) {
+	data := v.Get(key)
+	if data == nil {
+		return NewViper(), nil
+	}
+
+	if reflect.TypeOf(data).Kind() == reflect.Map {
+		subv := NewViper()
+		// Cannot return error because the subv is empty.
+		_ = subv.MergeConfigMap(cast.ToStringMap(data))
+		return subv, nil
+	}
+	return nil, fmt.Errorf("unexpected sub-config value kind for key:%s value:%v kind:%v)", key, data, reflect.TypeOf(data).Kind())
+}
+
+// Creates a new Viper instance with a different key-delimitor "::" instead of the
+// default ".". This way configs can have keys that contain ".".
+func NewViper() *Viper {
+	return &Viper{Viper: viper.NewWithOptions(viper.KeyDelimiter(ViperDelimiter))}
+}

--- a/exporter/exporterhelper/factory.go
+++ b/exporter/exporterhelper/factory.go
@@ -17,7 +17,7 @@ package exporterhelper
 import (
 	"context"
 
-	"github.com/spf13/viper"
+	"go.opentelemetry.io/collector/config/viper"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configerror"

--- a/exporter/exporterhelper/factory_test.go
+++ b/exporter/exporterhelper/factory_test.go
@@ -19,7 +19,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/spf13/viper"
+	"go.opentelemetry.io/collector/config/viper"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 

--- a/extension/extensionhelper/factory.go
+++ b/extension/extensionhelper/factory.go
@@ -17,7 +17,7 @@ package extensionhelper
 import (
 	"context"
 
-	"github.com/spf13/viper"
+	"go.opentelemetry.io/collector/config/viper"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configmodels"

--- a/extension/extensionhelper/factory_test.go
+++ b/extension/extensionhelper/factory_test.go
@@ -19,7 +19,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/spf13/viper"
+	"go.opentelemetry.io/collector/config/viper"
 	"github.com/stretchr/testify/assert"
 
 	"go.opentelemetry.io/collector/component"

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/OneOfOne/xxhash v1.2.5 // indirect
 	github.com/Shopify/sarama v1.27.2
 	github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6 // indirect
+	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d
 	github.com/antonmedv/expr v1.8.9
 	github.com/apache/thrift v0.13.0
 	github.com/cenkalti/backoff v2.2.1+incompatible
@@ -28,7 +29,7 @@ require (
 	github.com/jaegertracing/jaeger v1.21.0
 	github.com/leoluk/perflib_exporter v0.1.0
 	github.com/mattn/go-colorable v0.1.7 // indirect
-	github.com/mitchellh/mapstructure v1.3.2 // indirect
+	github.com/mitchellh/mapstructure v1.3.2
 	github.com/onsi/ginkgo v1.14.1 // indirect
 	github.com/onsi/gomega v1.10.2 // indirect
 	github.com/openzipkin/zipkin-go v0.2.5

--- a/processor/processorhelper/factory.go
+++ b/processor/processorhelper/factory.go
@@ -17,7 +17,7 @@ package processorhelper
 import (
 	"context"
 
-	"github.com/spf13/viper"
+	"go.opentelemetry.io/collector/config/viper"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configerror"

--- a/processor/processorhelper/factory_test.go
+++ b/processor/processorhelper/factory_test.go
@@ -19,7 +19,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/spf13/viper"
+	"go.opentelemetry.io/collector/config/viper"
 	"github.com/stretchr/testify/assert"
 
 	"go.opentelemetry.io/collector/component"

--- a/receiver/hostmetricsreceiver/factory.go
+++ b/receiver/hostmetricsreceiver/factory.go
@@ -19,11 +19,11 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/spf13/viper"
 	"go.uber.org/zap"
 
+	"go.opentelemetry.io/collector/config/viper"
+
 	"go.opentelemetry.io/collector/component"
-	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/configmodels"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/receiver/hostmetricsreceiver/internal"
@@ -93,7 +93,7 @@ func customUnmarshaler(componentViperSection *viper.Viper, intoCfg interface{}) 
 
 	cfg.Scrapers = map[string]internal.Config{}
 
-	scrapersViperSection, err := config.ViperSubExact(componentViperSection, scrapersKey)
+	scrapersViperSection, err := componentViperSection.SubExact(scrapersKey)
 	if err != nil {
 		return err
 	}
@@ -108,7 +108,7 @@ func customUnmarshaler(componentViperSection *viper.Viper, intoCfg interface{}) 
 		}
 
 		collectorCfg := factory.CreateDefaultConfig()
-		collectorViperSection, err := config.ViperSubExact(scrapersViperSection, key)
+		collectorViperSection, err := scrapersViperSection.SubExact(key)
 		if err != nil {
 			return err
 		}

--- a/receiver/jaegerreceiver/factory.go
+++ b/receiver/jaegerreceiver/factory.go
@@ -22,7 +22,7 @@ import (
 	"net"
 	"strconv"
 
-	"github.com/spf13/viper"
+	"go.opentelemetry.io/collector/config/viper"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configgrpc"

--- a/receiver/otlpreceiver/factory.go
+++ b/receiver/otlpreceiver/factory.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/spf13/viper"
+	"go.opentelemetry.io/collector/config/viper"
 	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/component"

--- a/receiver/prometheusreceiver/factory.go
+++ b/receiver/prometheusreceiver/factory.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 
 	_ "github.com/prometheus/prometheus/discovery/install" // init() of this package registers service discovery impl.
-	"github.com/spf13/viper"
+	"go.opentelemetry.io/collector/config/viper"
 	"gopkg.in/yaml.v2"
 
 	"go.opentelemetry.io/collector/component"

--- a/receiver/receiverhelper/factory.go
+++ b/receiver/receiverhelper/factory.go
@@ -17,7 +17,7 @@ package receiverhelper
 import (
 	"context"
 
-	"github.com/spf13/viper"
+	"go.opentelemetry.io/collector/config/viper"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configerror"

--- a/receiver/receiverhelper/factory_test.go
+++ b/receiver/receiverhelper/factory_test.go
@@ -19,7 +19,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/spf13/viper"
+	"go.opentelemetry.io/collector/config/viper"
 	"github.com/stretchr/testify/assert"
 
 	"go.opentelemetry.io/collector/component"

--- a/service/service.go
+++ b/service/service.go
@@ -30,7 +30,7 @@ import (
 	"syscall"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
+	"go.opentelemetry.io/collector/config/viper"
 	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/component"
@@ -142,7 +142,7 @@ func FileLoaderConfigFactory(v *viper.Viper, cmd *cobra.Command, factories compo
 func New(params Parameters) (*Application, error) {
 	app := &Application{
 		info:         params.ApplicationStartInfo,
-		v:            config.NewViper(),
+		v:            viper.NewViper(),
 		factories:    params.Factories,
 		stateChannel: make(chan State, Closed+1),
 	}

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -31,7 +31,7 @@ import (
 
 	"github.com/prometheus/common/expfmt"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
+	"go.opentelemetry.io/collector/config/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"

--- a/service/set_flag.go
+++ b/service/set_flag.go
@@ -21,9 +21,8 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"github.com/spf13/viper"
 
-	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/config/viper"
 )
 
 const (
@@ -53,7 +52,7 @@ func AddSetFlagProperties(v *viper.Viper, cmd *cobra.Command) error {
 			return err
 		}
 	}
-	viperFlags := config.NewViper()
+	viperFlags := viper.NewViper()
 	viperFlags.SetConfigType(setFlagFileType)
 	if err := viperFlags.ReadConfig(b); err != nil {
 		return fmt.Errorf("failed to read set flag config: %v", err)
@@ -78,7 +77,7 @@ func AddSetFlagProperties(v *viper.Viper, cmd *cobra.Command) error {
 
 	rootKeys := map[string]struct{}{}
 	for _, k := range viperFlags.AllKeys() {
-		keys := strings.Split(k, config.ViperDelimiter)
+		keys := strings.Split(k, viper.ViperDelimiter)
 		if len(keys) > 0 {
 			rootKeys[keys[0]] = struct{}{}
 		}

--- a/service/set_flag_test.go
+++ b/service/set_flag_test.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
+	"go.opentelemetry.io/collector/config/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/testbed/testbed/otelcol_runner.go
+++ b/testbed/testbed/otelcol_runner.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/shirou/gopsutil/process"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
+	"go.opentelemetry.io/collector/config/viper"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
@@ -82,7 +82,7 @@ func (ipp *InProcessCollector) PrepareConfig(configStr string) (configCleanup fu
 		return configCleanup, err
 	}
 	ipp.logger = logger
-	v := config.NewViper()
+	v := viper.NewViper()
 	v.SetConfigType("yaml")
 	v.ReadConfig(strings.NewReader(configStr))
 	cfg, err := config.Load(v, ipp.factories)


### PR DESCRIPTION
This replaces all usages of the spf13 viper.Viper with our own Viper instance. The reasons for doing this are:

1. We want to call the viper.Unmarshal* functions with additional decoders. (e.g. so that we can decode things like `10MB` to bytes). Without this change all callers would have to make sure to always pass in these extra decoders. This centralizes it so that the decoders are always passed from the wrapper.
2. ViperSubExact acted like a method but was done as a function. This puts it on the wrapper as `SubExact` which seems more natural.

See [this example](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/2270/files#diff-dd30775edab74de75de50194f33297b2119b07d5dcb70e9f3d3c1667b23aaf3dR66) for how it would be used in code.
