### PR TITLE
Add guidelines for observability in the components

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -255,17 +255,6 @@ When using the regular helpers, you should have some metrics added around key
 events automatically. For instance, exporters should have `otelcol_exporter_sent_spans` 
 tracked without your exporter doing anything.
 
-In addition to that, go over your code and try to assess what kind of information 
-you'd ask your users if they open a bug report:
-
-- are there internal queues in your components? Add a gauge (`LastValue`) with their states.
-- are you making HTTP calls? Measure the latency and expose a histogram. Consider
-providing a counter with the number of calls that your processor made.
-- are you making sampling decisions? Provide a counter with the outcomes.
-
-At this moment, the collector is still using the OpenCensus Go client for the 
-instrumentation, and discussions are happening on the appropriate long-term solution.
-
 ### Resource Usage
 
 Limit usage of CPU, RAM or other resources that the code can use. Do not write code

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -246,6 +246,26 @@ the event happens.
 Make log message human readable and also include data that is needed for easier
 understanding of what happened and in what context.
 
+### Observability
+
+Out of the box, your users should be able to observe the state of your component. 
+The collector exposes an OpenMetrics endpoint at `/metrics` where your data will land.
+
+When using the regular helpers, you should have some metrics added around key 
+events automatically. For instance, exporters should have `otelcol_exporter_sent_spans` 
+tracked without your exporter doing anything.
+
+In addition to that, go over your code and try to assess what kind of information 
+you'd ask your users if they open a bug report:
+
+- are there internal queues in your components? Add a gauge (`LastValue`) with their states.
+- are you making HTTP calls? Measure the latency and expose a histogram. Consider
+providing a counter with the number of calls that your processor made.
+- are you making sampling decisions? Provide a counter with the outcomes.
+
+At this moment, the collector is still using the OpenCensus Go client for the 
+instrumentation, and discussions are happening on the appropriate long-term solution.
+
 ### Resource Usage
 
 Limit usage of CPU, RAM or other resources that the code can use. Do not write code

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -249,7 +249,8 @@ understanding of what happened and in what context.
 ### Observability
 
 Out of the box, your users should be able to observe the state of your component. 
-The collector exposes an OpenMetrics endpoint at `/metrics` where your data will land.
+The collector exposes an OpenMetrics endpoint at `http://localhost:8888/metrics`
+where your data will land.
 
 When using the regular helpers, you should have some metrics added around key 
 events automatically. For instance, exporters should have `otelcol_exporter_sent_spans` 


### PR DESCRIPTION
As part of #2430, this PR adds guidelines for component developers on how to appropriately make their components observable.

﻿Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>
