### PR TITLE
Add FileDataProvider to the testbed

### DIFF
--- a/testbed/tests/testdata/k8s-metrics.json
+++ b/testbed/tests/testdata/k8s-metrics.json
@@ -1,0 +1,73 @@
+{
+    "resourceMetrics": [
+        {
+            "resource": {
+                "attributes": [
+                    {
+                        "key": "k8s.deployment.name",
+                        "value": {
+                            "stringValue": "frontend"
+                        }
+                    },
+                    {
+                        "key": "k8s.namespace.name",
+                        "value": {
+                            "stringValue": "default"
+                        }
+                    },
+                    {
+                        "key": "k8s.cluster.name",
+                        "value": {
+                            "stringValue": ""
+                        }
+                    },
+                    {
+                        "key": "k8s.deployment.uid",
+                        "value": {
+                            "stringValue": "2d61452e-f21c-4743-bedf-cd6183d660cf"
+                        }
+                    },
+                    {
+                        "key": "opencensus.resourcetype",
+                        "value": {
+                            "stringValue": "k8s"
+                        }
+                    }
+                ]
+            },
+            "instrumentationLibraryMetrics": [
+                {
+                    "instrumentationLibrary": {},
+                    "metrics": [
+                        {
+                            "name": "k8s.deployment.desired",
+                            "description": "Number of desired pods in this deployment",
+                            "unit": "1",
+                            "intGauge": {
+                                "dataPoints": [
+                                    {
+                                        "timeUnixNano": "1612819531934424200",
+                                        "value": "1"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "name": "k8s.deployment.available",
+                            "description": "Total number of available pods (ready for at least minReadySeconds) targeted by this deployment",
+                            "unit": "1",
+                            "intGauge": {
+                                "dataPoints": [
+                                    {
+                                        "timeUnixNano": "1612819531934424200",
+                                        "value": "1"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/testbed/tests/trace_test.go
+++ b/testbed/tests/trace_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.opentelemetry.io/collector/config/configmodels"
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/testbed/testbed"
 	"go.opentelemetry.io/collector/translator/conventions"
@@ -453,4 +454,64 @@ func TestTraceAttributesProcessor(t *testing.T) {
 			})
 		})
 	}
+}
+
+func TestMetricsFromFile(t *testing.T) {
+	// This test demonstrates usage of NewFileDataProvider to generate load using
+	// previously recorded data.
+
+	resultDir, err := filepath.Abs(path.Join("results", t.Name()))
+	require.NoError(t, err)
+
+	// Use metrics previously recorded using "file" exporter and "k8scluster" receiver.
+	dataProvider, err := testbed.NewFileDataProvider("testdata/k8s-metrics.json", configmodels.MetricsDataType)
+	assert.NoError(t, err)
+
+	options := testbed.LoadOptions{
+		DataItemsPerSecond: 1_000,
+		Parallel:           1,
+		// ItemsPerBatch is based on the data from the file.
+		ItemsPerBatch: dataProvider.ItemsPerBatch,
+	}
+	agentProc := &testbed.ChildProcess{}
+
+	sender := testbed.NewOTLPMetricDataSender(testbed.DefaultHost, testbed.GetAvailablePort(t))
+	receiver := testbed.NewOTLPDataReceiver(testbed.GetAvailablePort(t))
+
+	configStr := createConfigYaml(t, sender, receiver, resultDir, nil, nil)
+	configCleanup, err := agentProc.PrepareConfig(configStr)
+	require.NoError(t, err)
+	defer configCleanup()
+
+	tc := testbed.NewTestCase(
+		t,
+		dataProvider,
+		sender,
+		receiver,
+		agentProc,
+		&testbed.PerfTestValidator{},
+		performanceResultsSummary,
+	)
+	defer tc.Stop()
+
+	tc.SetResourceLimits(testbed.ResourceSpec{
+		ExpectedMaxCPU: 120,
+		ExpectedMaxRAM: 70,
+	})
+	tc.StartBackend()
+	tc.StartAgent("--log-level=debug")
+
+	tc.StartLoad(options)
+
+	tc.Sleep(tc.Duration)
+
+	tc.StopLoad()
+
+	tc.WaitFor(func() bool { return tc.LoadGenerator.DataItemsSent() > 0 }, "load generator started")
+	tc.WaitFor(func() bool { return tc.LoadGenerator.DataItemsSent() == tc.MockBackend.DataItemsReceived() },
+		"all data items received")
+
+	tc.StopAgent()
+
+	tc.ValidateData()
 }


### PR DESCRIPTION
FileDataProvider in an implementation of the DataProvider for use in end-to-end tests.
The data to send is loaded from a file. The file should contain one JSON-encoded
Export*ServiceRequest Protobuf message. The file can be recorded using the "file"
exporter.

FileDataProvider is useful for implementing end-to-end tests that use realistic data.
As an example I also added TestMetricsFromFile which uses testdata/k8s-metrics.json
real world data that I recorded using k8scluster receiver running on my local
Kubernetes cluster.