### PR TITLE
Show correct CPU usage when the process is terminated early

### DIFF
--- a/testbed/testbed/child_process.go
+++ b/testbed/testbed/child_process.go
@@ -425,6 +425,10 @@ func (cp *ChildProcess) fetchCPUUsage() {
 	// Calculate elapsed and process CPU time deltas in seconds
 	deltaElapsedTime := now.Sub(cp.lastElapsedTime).Seconds()
 	deltaCPUTime := times.Total() - cp.lastProcessTimes.Total()
+	if deltaCPUTime < 0 {
+		// We sometimes get negative difference when the process is terminated.
+		deltaCPUTime = 0
+	}
 
 	cp.lastProcessTimes = times
 	cp.lastElapsedTime = now


### PR DESCRIPTION
When the process is terminated its CPU time calculation could be incorrect since 
gopsutil sometimes returns CPU times that are lower than previously returned times.
This was resulting in negative CPU time delta, which was then converted to uint32
percent resulting in overflowing of the negative number into large positive number
and very large incorrect CPU percentages shown.

This changes fixes the problem by ensuring the calculated CPU time delta is never
negative.
