### PR TITLE
Contibuting: rename opentelemetry-service to opentelemetry-collector

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,7 @@ Follow the instructions below to create your PR.
 In the interest of keeping this repository clean and manageable, you should
 work from a fork. To create a fork, click the 'Fork' button at the top of the
 repository, then clone the fork locally using `git clone
-git@github.com:USERNAME/opentelemetry-service.git`.
+git@github.com:USERNAME/opentelemetry-collector.git`.
 
 You should also add this repository as an "upstream" repo to your local copy,
 in order to keep it up to date. You can add this as a remote like so:
@@ -110,7 +110,7 @@ Add your fork as an origin:
 
 ```shell
 $ cd $(go env GOPATH)/src/go.opentelemetry.io/collector
-$ git remote add fork git@github.com:YOUR_GITHUB_USERNAME/opentelemetry-service.git
+$ git remote add fork git@github.com:YOUR_GITHUB_USERNAME/opentelemetry-collector.git
 ```
 
 Run tests, fmt and lint:


### PR DESCRIPTION
**Description:** Repository named `opentelemetry-collector` but CONTRIBUTING guide refers to it as `opentelemetry-service`

**Documentation:** links with `opentelemetry-service` have been changed to `opentelemetry-collector`