### PR TITLE
Preserve original error messages in OTLP exporter

### DIFF
--- a/exporter/otlpexporter/otlp.go
+++ b/exporter/otlpexporter/otlp.go
@@ -42,10 +42,6 @@ type exporterImp struct {
 	w      *grpcSender
 }
 
-var (
-	errPermanentError = consumererror.Permanent(errors.New("fatal error sending to server"))
-)
-
 // Crete new exporter and start it. The exporter will begin connecting but
 // this function may return before the connection is established.
 func newExporter(cfg configmodels.Exporter) (*exporterImp, error) {
@@ -184,7 +180,7 @@ func processError(err error) error {
 
 	if !shouldRetry(st.Code()) {
 		// It is not a retryable error, we should not retry.
-		return errPermanentError
+		return consumererror.Permanent(err)
 	}
 
 	// Need to retry.


### PR DESCRIPTION
**Description:** 
I was troubleshooting an issue where un-retryable exports were being retried. #2455 fixes the root cause and this PR improves error messages from the OTLP exporter. The exporter returns the same permanent error instance for each export which masks the underlying error and makes failures hard to debug. This PR preserves the original error by wrapping it in a permament error and returning it.

Previously all log message looked as follows:

```
failed to push metrics data via OTLP exporter: Permanent error: fatal error sending to server
```

Now they preserve the original error message:

```
failed to push metrics data via OTLP exporter: Permanent error: rpc error: code = InvalidArgument desc = [otlp: empty data point]
```
