### PR TITLE
Add registries to the application, exposed to components

### DIFF
--- a/component/exporter.go
+++ b/component/exporter.go
@@ -54,6 +54,8 @@ type ExporterCreateParams struct {
 
 	// ApplicationStartInfo can be used by components for informational purposes
 	ApplicationStartInfo ApplicationStartInfo
+
+	Registries *Registries
 }
 
 // ExporterFactory can create TracesExporter and MetricsExporter. This is the

--- a/component/extension.go
+++ b/component/extension.go
@@ -54,6 +54,8 @@ type ExtensionCreateParams struct {
 
 	// ApplicationStartInfo can be used by components for informational purposes
 	ApplicationStartInfo ApplicationStartInfo
+
+	Registries *Registries
 }
 
 // ExtensionFactory is a factory interface for extensions to the service.

--- a/component/processor.go
+++ b/component/processor.go
@@ -68,6 +68,8 @@ type ProcessorCreateParams struct {
 
 	// ApplicationStartInfo can be used by components for informational purposes
 	ApplicationStartInfo ApplicationStartInfo
+
+	Registries *Registries
 }
 
 // ProcessorFactory is factory interface for processors. This is the

--- a/component/receiver.go
+++ b/component/receiver.go
@@ -63,6 +63,8 @@ type ReceiverCreateParams struct {
 
 	// ApplicationStartInfo can be used by components for informational purposes
 	ApplicationStartInfo ApplicationStartInfo
+
+	Registries *Registries
 }
 
 // ReceiverFactory can create TracesReceiver and MetricsReceiver. This is the

--- a/component/registries.go
+++ b/component/registries.go
@@ -1,0 +1,40 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package component
+
+// Registries struct holds in a single type all registries available for an application.
+// Each registry should provide a hook for items to self-register and for consumers to obtain items.
+type Registries struct {
+	items map[string]*Registry
+}
+
+func NewRegistries(items map[string]*Registry) *Registries {
+	return &Registries{
+		items: items,
+	}
+}
+
+// Registry holds the instances registered with a particular registry
+type Registry []interface{}
+
+// Get returns the registry with the given name, or nil in case none exists under that name
+func (r *Registries) Get(registry string) *Registry {
+	return r.items[registry]
+}
+
+// WantsRegistries defines the interface for components that want to get the list of registries injected.
+type WantsRegistries interface {
+	SetRegistries(*Registries)
+}

--- a/service/builder/exporters_builder.go
+++ b/service/builder/exporters_builder.go
@@ -142,10 +142,11 @@ type exportersRequiredDataTypes map[configmodels.Exporter]dataTypeRequirements
 
 // ExportersBuilder builds exporters from config.
 type ExportersBuilder struct {
-	logger    *zap.Logger
-	appInfo   component.ApplicationStartInfo
-	config    *configmodels.Config
-	factories map[configmodels.Type]component.ExporterFactory
+	logger     *zap.Logger
+	appInfo    component.ApplicationStartInfo
+	config     *configmodels.Config
+	registries *component.Registries
+	factories  map[configmodels.Type]component.ExporterFactory
 }
 
 // NewExportersBuilder creates a new ExportersBuilder. Call BuildExporters() on the returned value.
@@ -153,12 +154,13 @@ func NewExportersBuilder(
 	logger *zap.Logger,
 	appInfo component.ApplicationStartInfo,
 	config *configmodels.Config,
+	registries *component.Registries,
 	factories map[configmodels.Type]component.ExporterFactory,
 ) *ExportersBuilder {
-	return &ExportersBuilder{logger.With(zap.String(kindLogKey, kindLogsExporter)), appInfo, config, factories}
+	return &ExportersBuilder{logger.With(zap.String(kindLogKey, kindLogsExporter)), appInfo, config, registries, factories}
 }
 
-// BuildExporters exporters from config.
+// Build exporters from config.
 func (eb *ExportersBuilder) Build() (Exporters, error) {
 	exporters := make(Exporters)
 
@@ -239,6 +241,7 @@ func (eb *ExportersBuilder) buildExporter(
 	creationParams := component.ExporterCreateParams{
 		Logger:               logger,
 		ApplicationStartInfo: appInfo,
+		Registries:           eb.registries,
 	}
 
 	for dataType, requirement := range inputDataTypes {

--- a/service/builder/pipelines_builder.go
+++ b/service/builder/pipelines_builder.go
@@ -80,11 +80,12 @@ func (bps BuiltPipelines) ShutdownProcessors(ctx context.Context) error {
 
 // PipelinesBuilder builds pipelines from config.
 type PipelinesBuilder struct {
-	logger    *zap.Logger
-	appInfo   component.ApplicationStartInfo
-	config    *configmodels.Config
-	exporters Exporters
-	factories map[configmodels.Type]component.ProcessorFactory
+	logger     *zap.Logger
+	appInfo    component.ApplicationStartInfo
+	config     *configmodels.Config
+	exporters  Exporters
+	factories  map[configmodels.Type]component.ProcessorFactory
+	registries *component.Registries
 }
 
 // NewPipelinesBuilder creates a new PipelinesBuilder. Requires exporters to be already
@@ -93,13 +94,14 @@ func NewPipelinesBuilder(
 	logger *zap.Logger,
 	appInfo component.ApplicationStartInfo,
 	config *configmodels.Config,
+	registries *component.Registries,
 	exporters Exporters,
 	factories map[configmodels.Type]component.ProcessorFactory,
 ) *PipelinesBuilder {
-	return &PipelinesBuilder{logger, appInfo, config, exporters, factories}
+	return &PipelinesBuilder{logger, appInfo, config, exporters, factories, registries}
 }
 
-// BuildProcessors pipeline processors from config.
+// Build pipeline processors from config.
 func (pb *PipelinesBuilder) Build() (BuiltPipelines, error) {
 	pipelineProcessors := make(BuiltPipelines)
 
@@ -157,6 +159,7 @@ func (pb *PipelinesBuilder) buildPipeline(ctx context.Context, pipelineCfg *conf
 		creationParams := component.ProcessorCreateParams{
 			Logger:               componentLogger,
 			ApplicationStartInfo: pb.appInfo,
+			Registries:           pb.registries,
 		}
 
 		switch pipelineCfg.InputType {

--- a/service/builder/receivers_builder.go
+++ b/service/builder/receivers_builder.go
@@ -51,7 +51,7 @@ func (rcv *builtReceiver) Shutdown(ctx context.Context) error {
 // Receivers is a map of receivers created from receiver configs.
 type Receivers map[configmodels.Receiver]*builtReceiver
 
-// StopAll stops all receivers.
+// ShutdownAll stops all receivers.
 func (rcvs Receivers) ShutdownAll(ctx context.Context) error {
 	var errs []error
 	for _, rcv := range rcvs {
@@ -84,6 +84,7 @@ type ReceiversBuilder struct {
 	config         *configmodels.Config
 	builtPipelines BuiltPipelines
 	factories      map[configmodels.Type]component.ReceiverFactory
+	registries     *component.Registries
 }
 
 // NewReceiversBuilder creates a new ReceiversBuilder. Call BuildProcessors() on the returned value.
@@ -91,13 +92,14 @@ func NewReceiversBuilder(
 	logger *zap.Logger,
 	appInfo component.ApplicationStartInfo,
 	config *configmodels.Config,
+	registries *component.Registries,
 	builtPipelines BuiltPipelines,
 	factories map[configmodels.Type]component.ReceiverFactory,
 ) *ReceiversBuilder {
-	return &ReceiversBuilder{logger.With(zap.String(kindLogKey, kindLogsReceiver)), appInfo, config, builtPipelines, factories}
+	return &ReceiversBuilder{logger.With(zap.String(kindLogKey, kindLogsReceiver)), appInfo, config, builtPipelines, factories, registries}
 }
 
-// BuildProcessors receivers from config.
+// Build receivers from config.
 func (rb *ReceiversBuilder) Build() (Receivers, error) {
 	receivers := make(Receivers)
 
@@ -181,6 +183,7 @@ func (rb *ReceiversBuilder) attachReceiverToPipelines(
 	creationParams := component.ReceiverCreateParams{
 		Logger:               logger,
 		ApplicationStartInfo: appInfo,
+		Registries:           rb.registries,
 	}
 
 	switch dataType {


### PR DESCRIPTION
This is an initial proposal for having a notion of registries in the collector. We have talked about it earlier in different contexts, and we could make use of it right away with the authentication mechanism, allowing new authenticators to add themselves to a registry, with the auth handlers consuming items from the auth registry. Another use case that this will benefit in the future is for downstream distributions, such as Jaeger, to provide a single storage instance shared between components, such as a query service (extension) and span writer (exporter).

This code is missing quite a lot of things, but I wanted to do a brainstorm before investing more effort into this. A few points to note:

- Each application has its own set of registries
- Each registry holds a list of objects
- The set of registries is passed down to extensions, receivers, processors, and exporters as part of their respective CreateParams. This means that exporter implementations that support multiple types (traces, metrics, and logs) are getting three registries, one for each CreateParam. While this seems a waste, the other option is to set the registries to the factories, but they aren't managed as part of the service -- they are typically created in the program's main entry point

Things that are not here yet, but that I intend to implement if we go forward:

- Each registry will be able to validate entries before adding them to their list
- Consumers can register a callback, to get notified in case of changes
- A function providing a list of items for individual registries will be implemented

﻿Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>
