### PR TITLE
Fixed typo in security documentation

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -193,6 +193,6 @@ permissions in order to perform service discovery. For example, the
 
 Extensions may also be used to run subprocesses. This can be useful when
 collection mechanisms that cannot natively be run by the Collector (e.g.
-FluentBit). Subprocesses expose a completely separate attack vendor that would
+FluentBit). Subprocesses expose a completely separate attack vector that would
 depend on the subprocess itself. In general, care should be taken before
 running any subprocesses alongside the Collector.


### PR DESCRIPTION
**Description:** 
Fixed typo in security documentation. 

**Link to tracking Issue:**
N/A

**Testing:**
N/A

**Documentation:**
N/A
