### PR TITLE
Add "compression" option to otlphttp exporter

### DIFF
--- a/exporter/otlphttpexporter/README.md
+++ b/exporter/otlphttpexporter/README.md
@@ -33,6 +33,8 @@ The following settings can be optionally configured:
 - `key_file` path to the TLS key to use for TLS required connections. Should
   only be used if `insecure` is set to false.
 
+- `compression` (default = none): Compression type to use (only gzip is supported today)
+
 - `timeout` (default = 30s): HTTP request time limit. For details see https://golang.org/pkg/net/http/#Client
 - `read_buffer_size` (default = 0): ReadBufferSize for HTTP client.
 - `write_buffer_size` (default = 512 * 1024): WriteBufferSize for HTTP client.

--- a/exporter/otlphttpexporter/config.go
+++ b/exporter/otlphttpexporter/config.go
@@ -35,4 +35,8 @@ type Config struct {
 
 	// The URL to send logs to. If omitted the Endpoint + "/v1/logs" will be used.
 	LogsEndpoint string `mapstructure:"logs_endpoint"`
+
+	// The compression key for supported compression types within
+	// collector. Currently the only supported mode is `gzip`.
+	Compression string `mapstructure:"compression"`
 }

--- a/exporter/otlphttpexporter/config_test.go
+++ b/exporter/otlphttpexporter/config_test.go
@@ -81,5 +81,6 @@ func TestLoadConfig(t *testing.T) {
 				WriteBufferSize: 345,
 				Timeout:         time.Second * 10,
 			},
+			Compression: "gzip",
 		})
 }

--- a/exporter/otlphttpexporter/testdata/config.yaml
+++ b/exporter/otlphttpexporter/testdata/config.yaml
@@ -28,6 +28,7 @@ exporters:
       "can you have a . here?": "F0000000-0000-0000-0000-000000000000"
       header1: 234
       another: "somevalue"
+    compression: gzip
 
 service:
   pipelines:

--- a/testbed/tests/trace_test.go
+++ b/testbed/tests/trace_test.go
@@ -66,7 +66,7 @@ func TestTrace10kSPS(t *testing.T) {
 			},
 		},
 		{
-			"OTLP",
+			"OTLP-gRPC",
 			testbed.NewOTLPTraceDataSender(testbed.DefaultHost, testbed.GetAvailablePort(t)),
 			testbed.NewOTLPDataReceiver(testbed.GetAvailablePort(t)),
 			testbed.ResourceSpec{
@@ -75,11 +75,29 @@ func TestTrace10kSPS(t *testing.T) {
 			},
 		},
 		{
+			"OTLP-gRPC-gzip",
+			testbed.NewOTLPTraceDataSender(testbed.DefaultHost, testbed.GetAvailablePort(t)),
+			testbed.NewOTLPDataReceiver(testbed.GetAvailablePort(t)).WithCompression("gzip"),
+			testbed.ResourceSpec{
+				ExpectedMaxCPU: 30,
+				ExpectedMaxRAM: 100,
+			},
+		},
+		{
 			"OTLP-HTTP",
 			testbed.NewOTLPHTTPTraceDataSender(testbed.DefaultHost, testbed.GetAvailablePort(t)),
 			testbed.NewOTLPHTTPDataReceiver(testbed.GetAvailablePort(t)),
 			testbed.ResourceSpec{
 				ExpectedMaxCPU: 20,
+				ExpectedMaxRAM: 100,
+			},
+		},
+		{
+			"OTLP-HTTP-gzip",
+			testbed.NewOTLPHTTPTraceDataSender(testbed.DefaultHost, testbed.GetAvailablePort(t)),
+			testbed.NewOTLPHTTPDataReceiver(testbed.GetAvailablePort(t)).WithCompression("gzip"),
+			testbed.ResourceSpec{
+				ExpectedMaxCPU: 25,
 				ExpectedMaxRAM: 100,
 			},
 		},


### PR DESCRIPTION
The default value of "compression" option is empty and results in no compression,
which is the same as the old behavior. You can also specify "compression: gzip"
which will result in gzip encoding of outgoing http requests.