### PR TITLE
Fix OTLP receiver Shutdown() bug

### DIFF
--- a/receiver/otlpreceiver/otlp.go
+++ b/receiver/otlpreceiver/otlp.go
@@ -168,7 +168,7 @@ func (r *otlpReceiver) Start(_ context.Context, host component.Host) error {
 }
 
 // Shutdown is a method to turn off receiving.
-func (r *otlpReceiver) Shutdown(context.Context) error {
+func (r *otlpReceiver) Shutdown(ctx context.Context) error {
 	var err error
 	r.stopOnce.Do(func() {
 		err = nil
@@ -179,6 +179,27 @@ func (r *otlpReceiver) Shutdown(context.Context) error {
 
 		if r.serverGRPC != nil {
 			r.serverGRPC.Stop()
+		}
+
+		if r.traceReceiver != nil {
+			err2 := r.traceReceiver.Shutdown(ctx)
+			if err == nil && err2 != nil {
+				err = err2
+			}
+		}
+
+		if r.metricsReceiver != nil {
+			err2 := r.metricsReceiver.Shutdown(ctx)
+			if err == nil && err2 != nil {
+				err = err2
+			}
+		}
+
+		if r.logReceiver != nil {
+			err2 := r.logReceiver.Shutdown(ctx)
+			if err == nil && err2 != nil {
+				err = err2
+			}
 		}
 	})
 	return err

--- a/receiver/otlpreceiver/otlp_test.go
+++ b/receiver/otlpreceiver/otlp_test.go
@@ -370,15 +370,13 @@ func TestProtoHttp(t *testing.T) {
 		}
 	}
 }
-func testHTTPProtobufRequest(
+
+func createHTTPProtobufRequest(
 	t *testing.T,
 	url string,
-	tSink *consumertest.TracesSink,
 	encoding string,
 	traceBytes []byte,
-	expectedErr error,
-	wantOtlp []*otlptrace.ResourceSpans,
-) {
+) *http.Request {
 	var buf *bytes.Buffer
 	var err error
 	switch encoding {
@@ -388,11 +386,25 @@ func testHTTPProtobufRequest(
 	default:
 		buf = bytes.NewBuffer(traceBytes)
 	}
-	tSink.SetConsumeError(expectedErr)
 	req, err := http.NewRequest("POST", url, buf)
 	require.NoError(t, err, "Error creating trace POST request: %v", err)
 	req.Header.Set("Content-Type", "application/x-protobuf")
 	req.Header.Set("Content-Encoding", encoding)
+	return req
+}
+
+func testHTTPProtobufRequest(
+	t *testing.T,
+	url string,
+	tSink *consumertest.TracesSink,
+	encoding string,
+	traceBytes []byte,
+	expectedErr error,
+	wantOtlp []*otlptrace.ResourceSpans,
+) {
+	tSink.SetConsumeError(expectedErr)
+
+	req := createHTTPProtobufRequest(t, url, encoding, traceBytes)
 
 	client := &http.Client{}
 	resp, err := client.Do(req)
@@ -402,14 +414,14 @@ func testHTTPProtobufRequest(
 	require.NoError(t, err, "Error reading response from trace grpc-gateway")
 	require.NoError(t, resp.Body.Close(), "Error closing response body")
 
-	allTraces := tSink.AllTraces()
-
 	require.Equal(t, "application/x-protobuf", resp.Header.Get("Content-Type"), "Unexpected response Content-Type")
+
+	allTraces := tSink.AllTraces()
 
 	if expectedErr == nil {
 		require.Equal(t, 200, resp.StatusCode, "Unexpected return status")
 		tmp := &collectortrace.ExportTraceServiceResponse{}
-		err = tmp.Unmarshal(respBytes)
+		err := tmp.Unmarshal(respBytes)
 		require.NoError(t, err, "Unable to unmarshal response to ExportTraceServiceResponse proto")
 
 		require.Len(t, allTraces, 1)
@@ -556,6 +568,29 @@ func TestHTTPStartWithoutConsumers(t *testing.T) {
 	require.Error(t, r.Start(context.Background(), componenttest.NewNopHost()))
 }
 
+func createSingleSpanTrace() *collectortrace.ExportTraceServiceRequest {
+	return &collectortrace.ExportTraceServiceRequest{
+		ResourceSpans: []*otlptrace.ResourceSpans{
+			{
+				InstrumentationLibrarySpans: []*otlptrace.InstrumentationLibrarySpans{
+					{
+						Spans: []*otlptrace.Span{
+							{
+								TraceId: data.NewTraceID(
+									[16]byte{
+										0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+										0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10,
+									},
+								),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
 // TestOTLPReceiverTrace_HandleNextConsumerResponse checks if the trace receiver
 // is returning the proper response (return and metrics) when the next consumer
 // in the pipeline reports error. The test changes the responses returned by the
@@ -595,26 +630,7 @@ func TestOTLPReceiverTrace_HandleNextConsumerResponse(t *testing.T) {
 	}
 
 	addr := testutil.GetAvailableLocalAddress(t)
-	req := &collectortrace.ExportTraceServiceRequest{
-		ResourceSpans: []*otlptrace.ResourceSpans{
-			{
-				InstrumentationLibrarySpans: []*otlptrace.InstrumentationLibrarySpans{
-					{
-						Spans: []*otlptrace.Span{
-							{
-								TraceId: data.NewTraceID(
-									[16]byte{
-										0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
-										0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10,
-									},
-								),
-							},
-						},
-					},
-				},
-			},
-		},
-	}
+	req := createSingleSpanTrace()
 
 	exportBidiFn := func(
 		t *testing.T,
@@ -774,4 +790,104 @@ func compressGzip(body []byte) (*bytes.Buffer, error) {
 	}
 
 	return &buf, nil
+}
+
+type senderFunc func(msg *collectortrace.ExportTraceServiceRequest)
+
+func TestShutdown(t *testing.T) {
+	endpointGrpc := testutil.GetAvailableLocalAddress(t)
+	endpointHTTP := testutil.GetAvailableLocalAddress(t)
+
+	nextSink := new(consumertest.TracesSink)
+
+	// Create OTLP receiver with gRPC and HTTP protocols.
+	factory := NewFactory()
+	cfg := factory.CreateDefaultConfig().(*Config)
+	cfg.SetName(otlpReceiverName)
+	cfg.GRPC.NetAddr.Endpoint = endpointGrpc
+	cfg.HTTP.Endpoint = endpointHTTP
+	ocr := newReceiver(t, factory, cfg, nextSink, nil)
+	require.NotNil(t, ocr)
+	require.NoError(t, ocr.Start(context.Background(), componenttest.NewNopHost()))
+
+	conn, err := grpc.Dial(endpointGrpc, grpc.WithInsecure(), grpc.WithBlock())
+	require.NoError(t, err)
+	defer conn.Close()
+
+	doneSignalGrpc := make(chan bool)
+	doneSignalHTTP := make(chan bool)
+
+	senderGrpc := func(msg *collectortrace.ExportTraceServiceRequest) {
+		// Send request via OTLP/gRPC.
+		client := collectortrace.NewTraceServiceClient(conn)
+		client.Export(context.Background(), msg)
+	}
+	senderHTTP := func(msg *collectortrace.ExportTraceServiceRequest) {
+		// Send request via OTLP/HTTP.
+		traceBytes, err2 := msg.Marshal()
+		if err2 != nil {
+			t.Errorf("Error marshaling protobuf: %v", err2)
+		}
+		url := fmt.Sprintf("http://%s/v1/traces", endpointHTTP)
+		req := createHTTPProtobufRequest(t, url, "", traceBytes)
+		client := &http.Client{}
+		resp, err2 := client.Do(req)
+		if err2 == nil {
+			ioutil.ReadAll(resp.Body)
+		}
+	}
+
+	// Send traces to the receiver until we signal via done channel, and then
+	// send one more trace after that.
+	go generateTraces(senderGrpc, doneSignalGrpc)
+	go generateTraces(senderHTTP, doneSignalHTTP)
+
+	// Wait until the receiver outputs anything to the sink.
+	assert.Eventually(t, func() bool {
+		return nextSink.SpansCount() > 0
+	}, time.Second, 1*time.Millisecond)
+
+	// Now shutdown the receiver, while continuing sending traces to it.
+	ctx, cancelFn := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancelFn()
+	err = ocr.Shutdown(ctx)
+	assert.NoError(t, err)
+
+	// Remember how many spans the sink received. This number should not change after this
+	// point because after Shutdown() returns the component is not allowed to produce
+	// any more data.
+	sinkSpanCountAfterShutdown := nextSink.SpansCount()
+
+	// Now signal to generateTraces to exit the main generation loop, then send
+	// one more trace and stop.
+	doneSignalGrpc <- true
+	doneSignalHTTP <- true
+
+	// Wait until all follow up traces are sent.
+	<-doneSignalGrpc
+	<-doneSignalHTTP
+
+	// The last, additional trace should not be received by sink, so the number of spans in
+	// the sink should not change.
+	assert.EqualValues(t, sinkSpanCountAfterShutdown, nextSink.SpansCount())
+}
+
+func generateTraces(senderFn senderFunc, doneSignal chan bool) {
+	// Continuously generate spans until signaled to stop.
+loop:
+	for {
+		select {
+		case <-doneSignal:
+			break loop
+		default:
+		}
+		senderFn(createSingleSpanTrace())
+	}
+
+	// After getting the signal to stop, send one more span and then
+	// finally stop. We should never receive this last span.
+	senderFn(createSingleSpanTrace())
+
+	// Indicate that we are done.
+	close(doneSignal)
 }

--- a/receiver/otlpreceiver/shutdownhelper/helper.go
+++ b/receiver/otlpreceiver/shutdownhelper/helper.go
@@ -1,0 +1,129 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shutdownhelper
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+)
+
+var errTimeout = errors.New("shutdown timed out while waiting for operation to complete")
+var errDuplicateShutdown = errors.New("shutdown attempted more than once")
+var errAlreadyShutdown = errors.New("trying to operate when already shutdown")
+
+// Helper for receivers to implement Shutdown() that ensures they are no longer
+// producing data.
+type Helper struct {
+	shutdownFlag     int64 // 0=false, 1=true
+	cond             *sync.Cond
+	activeOperations int64
+}
+
+func NewHelper() Helper {
+	return Helper{cond: sync.NewCond(&sync.Mutex{})}
+}
+
+// Shutdown() waits for the completion of any ongoing operations indicated via
+// BeginOperation/EndOperation calls and then returns. Shutdown() waits up to the
+// deadline specified in the ctx. If the deadline is exceeded Shutdown() returns with
+// an error.
+// Calling Shutdown() after it was already called will immediately return an error.
+// Once Shutdown() is called any subsequent calls to BeginOperation() will return an error.
+func (h *Helper) Shutdown(ctx context.Context) error {
+	// Indicate that we are shutdown.
+	if !atomic.CompareAndSwapInt64(&h.shutdownFlag, 0, 1) {
+		// Didn't swap because we are already shutdown.
+		return errDuplicateShutdown
+	}
+
+	// Wait until all active processing is completed.
+	doneWaitingForProcessing := make(chan struct{})
+	go func() {
+		// Wait until there are no active processes.
+		h.cond.L.Lock()
+		for atomic.LoadInt64(&h.activeOperations) > 0 {
+			h.cond.Wait()
+		}
+		h.cond.L.Unlock()
+
+		// Signal to outer func that we are done waiting.
+		close(doneWaitingForProcessing)
+	}()
+
+	select {
+	case <-ctx.Done():
+		return errTimeout
+	case <-doneWaitingForProcessing:
+	}
+	return nil
+}
+
+func (h *Helper) isShutdown() bool {
+	return atomic.LoadInt64(&h.shutdownFlag) != 0
+}
+
+// BeginOperation must be called to indicate the start of an operation that
+// must be protected. If Shutdown() function is called while the operation is in
+// the Shutdown() function will block until the operation is indicated to be complete
+// by calling EndOperation().
+// Will return an error if Shutdown() is already called.
+func (h *Helper) BeginOperation() error {
+	// Increment the counter of active operations.
+	atomic.AddInt64(&h.activeOperations, 1)
+
+	// Note that we must check shutdown flag after (not before) we increment the operation
+	// counter. If we check it before we may let Shutdown() finish while we also allow to
+	// enter processing, which is wrong.
+	if h.isShutdown() {
+		h.EndOperation()
+		return errAlreadyShutdown
+	}
+
+	return nil
+}
+
+// EndOperation must be called to indicate the end of an  operation. See
+// BeginOperation for help.
+func (h *Helper) EndOperation() {
+	// Decrement the counter that indicates how many active operations exist currently.
+	if atomic.AddInt64(&h.activeOperations, -1) > 0 {
+		// Optimize for the case when activeOperations > 0. This is important for
+		// the cases when there is significant concurrency in calling BeginOperation/
+		// EndOperation. For concurrency of 8 and very high contention this optimization
+		// reduces waiting time by 3x (see BenchmarkOperationsConcurrent).
+		// Since there are no other active operations we can safely return, there is no
+		// need to try to Signal to Shutdown().
+		return
+	}
+
+	if !h.isShutdown() {
+		// The Shutdown() did not yet start, there is no need to signal via cond.
+		// The Shutdown() will check activeOperations and will see that is 0.
+		// This optimization primarily helps the non-concurrent case and gives
+		// about 3x reduction in waiting time for non-concurrent case.
+		return
+	}
+
+	// Shutdown() has started and may be waiting for activeOperations to become 0.
+	// We need to signal and wake up the condition checking loop in Shutdown().
+
+	// Acquire lock to ensure we don't end up with "lost wakeup" problem (calling Signal()
+	// while the other party is not in Wait(), in which case Shutdown() will be stuck).
+	h.cond.L.Lock()
+	h.cond.Signal()
+	h.cond.L.Unlock()
+}

--- a/receiver/otlpreceiver/shutdownhelper/helper_test.go
+++ b/receiver/otlpreceiver/shutdownhelper/helper_test.go
@@ -1,0 +1,175 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shutdownhelper
+
+import (
+	"context"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestShutdownDuringCall(t *testing.T) {
+	for i := 0; i < 100; i++ {
+		h := NewHelper()
+
+		var cnt int64
+		ch := make(chan bool)
+		var shutdownFinished int64
+		go func() {
+			for {
+				// Protect the operation.
+				if err := h.BeginOperation(); err != nil {
+					assert.EqualError(t, err, errAlreadyShutdown.Error())
+					// We were shutdown, stop processing.
+					break
+				}
+				if atomic.LoadInt64(&shutdownFinished) == 1 {
+					assert.Fail(t, "Shutdown() returned, but we entered processing")
+				}
+
+				// This is our operation that is protected: increment a counter.
+				atomic.AddInt64(&cnt, 1)
+
+				// Indicate we are done with the operation.
+				h.EndOperation()
+			}
+			// Indicate that goroutine is one.
+			close(ch)
+		}()
+
+		for atomic.LoadInt64(&cnt) == 0 {
+			// Wait for cnt to be incremented in the goroutine. This ensures that the
+			// goroutine is started.
+		}
+
+		// Now shutdown the helper.
+		err := h.Shutdown(context.Background())
+		atomic.StoreInt64(&shutdownFinished, 1)
+
+		// Save the cnt value after shutdown.
+		v := atomic.LoadInt64(&cnt)
+		assert.NoError(t, err)
+
+		// Wait until the goroutine finishes.
+		<-ch
+
+		// cnt should not be changed. This is the guarantee provided by Helper.
+		assert.EqualValues(t, v, atomic.LoadInt64(&cnt))
+	}
+}
+
+func TestShutdownDeadline(t *testing.T) {
+	h := NewHelper()
+
+	var cnt int64
+	ch := make(chan bool)
+	go func() {
+		// Protect the operation.
+		if err := h.BeginOperation(); err != nil {
+			// We were shutdown, stop processing.
+			return
+		}
+
+		defer h.EndOperation()
+
+		// This is our operation that is protected: increment a counter.
+		atomic.AddInt64(&cnt, 1)
+
+		// Imitate long processing.
+		<-ch
+
+		// Indicate we are done.
+		close(ch)
+	}()
+
+	for atomic.LoadInt64(&cnt) == 0 {
+		// Wait for cnt to be incremented in the goroutine. This ensures that the
+		// goroutine is started.
+	}
+
+	// Now shutdown the helper.
+	ctx, cancelFn := context.WithTimeout(context.Background(), 1*time.Millisecond)
+	defer cancelFn()
+	err := h.Shutdown(ctx)
+
+	// This should be timeout error.
+	assert.EqualError(t, err, errTimeout.Error())
+
+	// Tell the goroutine to exit.
+	ch <- true
+
+	// Wait for it to exit.
+	<-ch
+}
+
+func TestDuplicateShutdown(t *testing.T) {
+	h := NewHelper()
+
+	err := h.Shutdown(context.Background())
+	assert.NoError(t, err)
+
+	err = h.Shutdown(context.Background())
+	// This should be timeout error.
+	assert.EqualError(t, err, errDuplicateShutdown.Error())
+}
+
+// This benchmark measures how much overhead the helper adds to the processing
+// of each request when there is no contention.
+//
+// A typical result for this benchmark for reference:
+// 	BenchmarkOperationsSingle-8       	100000000	        11.5 ns/op
+func BenchmarkOperationsSingle(b *testing.B) {
+	h := NewHelper()
+	for i := 0; i < b.N; i++ {
+		h.BeginOperation()
+		h.EndOperation()
+	}
+}
+
+// This benchmark measures how much overhead the helper adds to the processing
+// of each request when we process concurrently. Note that this is the worst case
+// when processing is nothing but calling BeginOperation/EndOperation. In realistic
+// scenarios when there is also real work done the contention is going to be smaller.
+// Typical output:
+//	BenchmarkOperationsConcurrent/Concurrency=1-8         	100000000	        11.4 ns/op
+//	BenchmarkOperationsConcurrent/Concurrency=2-8         	12334543	        97.0 ns/op
+//	BenchmarkOperationsConcurrent/Concurrency=4-8         	 6855817	       173 ns/op
+//	BenchmarkOperationsConcurrent/Concurrency=8-8         	 3543706	       339 ns/op
+func BenchmarkOperationsConcurrent(b *testing.B) {
+	h := NewHelper()
+
+	for c := 1; c <= 8; c *= 2 {
+		b.Run("Concurrency="+strconv.Itoa(c), func(b *testing.B) {
+			wg := sync.WaitGroup{}
+			for j := 0; j < c; j++ {
+				wg.Add(1)
+				go func() {
+					for i := 0; i < b.N; i++ {
+						h.BeginOperation()
+						h.EndOperation()
+					}
+					wg.Done()
+				}()
+			}
+
+			wg.Wait()
+		})
+	}
+}

--- a/receiver/otlpreceiver/trace/otlp.go
+++ b/receiver/otlpreceiver/trace/otlp.go
@@ -23,6 +23,7 @@ import (
 	collectortrace "go.opentelemetry.io/collector/internal/data/protogen/collector/trace/v1"
 	otlptrace "go.opentelemetry.io/collector/internal/data/protogen/trace/v1"
 	"go.opentelemetry.io/collector/obsreport"
+	"go.opentelemetry.io/collector/receiver/otlpreceiver/shutdownhelper"
 )
 
 const (
@@ -33,6 +34,7 @@ const (
 type Receiver struct {
 	instanceName string
 	nextConsumer consumer.TracesConsumer
+	helper       shutdownhelper.Helper
 }
 
 // New creates a new Receiver reference.
@@ -40,6 +42,7 @@ func New(instanceName string, nextConsumer consumer.TracesConsumer) *Receiver {
 	r := &Receiver{
 		instanceName: instanceName,
 		nextConsumer: nextConsumer,
+		helper:       shutdownhelper.NewHelper(),
 	}
 
 	return r
@@ -50,7 +53,17 @@ const (
 	receiverTransport = "grpc"
 )
 
+func (r *Receiver) Shutdown(ctx context.Context) error {
+	return r.helper.Shutdown(ctx)
+}
+
 func (r *Receiver) Export(ctx context.Context, req *collectortrace.ExportTraceServiceRequest) (*collectortrace.ExportTraceServiceResponse, error) {
+	// Protect Export from being interrupted by Shutdown().
+	if err := r.helper.BeginOperation(); err != nil {
+		return nil, err
+	}
+	defer r.helper.EndOperation()
+
 	// We need to ensure that it propagates the receiver name as a tag
 	ctxWithReceiverName := obsreport.ReceiverContext(ctx, r.instanceName, receiverTransport)
 


### PR DESCRIPTION
OTLP receiver had a bug due to which it could generate data after Shutdown()
was returned.

It was visible in TestShutdown, with the following symptoms (it was a racy bug):

```
=== RUN   TestShutdown
    otlp_test.go:871:
        	Error Trace:	otlp_test.go:871
        	Error:      	Not equal:
        	            	expected: 4
        	            	actual  : 5
        	Test:       	TestShutdown
    otlp_test.go:871:
        	Error Trace:	otlp_test.go:871
        	Error:      	Not equal:
        	            	expected: 6
        	            	actual  : 7
        	Test:       	TestShutdown
--- FAIL: TestShutdown (0.49s)
```

I added a Helper which allows to wait until all in-flight operations are complete
before the Shutdown() function returns.

The Helper can be used by other components too in the future.
