### PR TITLE
Add note about escaping $ in prometheus config

### DIFF
--- a/receiver/prometheusreceiver/README.md
+++ b/receiver/prometheusreceiver/README.md
@@ -25,6 +25,11 @@ services. It supports the full set of Prometheus configuration, including
 service discovery. Just like you would write in a YAML configuration file
 before starting Prometheus, such as with:
 
+**Note**: Since the collector configuration supports env variable substitution
+`$` charaters in your prometheus configuration are interpreted as environment
+variables.  If you want to use $ charaters in your prometheus configuration,
+you must escape them using `$$`.
+
 ```shell
 prometheus --config.file=prom.yaml
 ```


### PR DESCRIPTION
I've helped at least 4 people at this point whose problems using the prometheus receiver came down to using $ characters without escaping them.  Its a common enough problem, i'd like to add warnings to more places.  The Readme seems like a good place to start

Issues:
https://github.com/open-telemetry/opentelemetry-collector/issues/557 added docs to opentelemetry.io, but not in the repo.  https://github.com/open-telemetry/opentelemetry-collector/issues/1077#issuecomment-638801113 is an example of someone confused about this as well.


