### PR TITLE
Add .devcontainer dir to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,8 @@ dist/
 *.iml
 
 # VS Code
-.vscode
+.vscode/
+.devcontainer/
 
 # Emacs
 *~


### PR DESCRIPTION
.devcontainer is used by VS Code to develop from docker images.