### PR TITLE
Default TLS settings for otlpexporter

### DIFF
--- a/config/configgrpc/configgrpc.go
+++ b/config/configgrpc/configgrpc.go
@@ -16,6 +16,7 @@
 package configgrpc
 
 import (
+	"crypto/x509"
 	"fmt"
 	"net"
 	"strings"
@@ -181,6 +182,13 @@ func (gcs *GRPCClientSettings) ToDialOptions() ([]grpc.DialOption, error) {
 	tlsDialOption := grpc.WithInsecure()
 	if tlsCfg != nil {
 		tlsDialOption = grpc.WithTransportCredentials(credentials.NewTLS(tlsCfg))
+	} else if strings.HasPrefix(strings.ToLower(gcs.Endpoint), "https://") {
+		certPool, err := x509.SystemCertPool()
+		if err != nil {
+			return nil, err
+		}
+		creds := credentials.NewClientTLSFromCert(certPool, "")
+		tlsDialOption = grpc.WithTransportCredentials(creds)
 	}
 	opts = append(opts, tlsDialOption)
 

--- a/exporter/otlpexporter/factory_test.go
+++ b/exporter/otlpexporter/factory_test.go
@@ -46,7 +46,7 @@ func TestCreateDefaultConfig(t *testing.T) {
 func TestCreateMetricsExporter(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig().(*Config)
-	cfg.GRPCClientSettings.Endpoint = testutil.GetAvailableLocalAddress(t)
+	cfg.GRPCClientSettings.Endpoint = "http://" + testutil.GetAvailableLocalAddress(t)
 
 	creationParams := component.ExporterCreateParams{Logger: zap.NewNop()}
 	oexp, err := factory.CreateMetricsExporter(context.Background(), creationParams, cfg)
@@ -55,7 +55,7 @@ func TestCreateMetricsExporter(t *testing.T) {
 }
 
 func TestCreateTraceExporter(t *testing.T) {
-	endpoint := testutil.GetAvailableLocalAddress(t)
+	endpoint := "http://" + testutil.GetAvailableLocalAddress(t)
 
 	tests := []struct {
 		name     string
@@ -189,7 +189,7 @@ func TestCreateTraceExporter(t *testing.T) {
 func TestCreateLogsExporter(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig().(*Config)
-	cfg.GRPCClientSettings.Endpoint = testutil.GetAvailableLocalAddress(t)
+	cfg.GRPCClientSettings.Endpoint = "http://" + testutil.GetAvailableLocalAddress(t)
 
 	creationParams := component.ExporterCreateParams{Logger: zap.NewNop()}
 	oexp, err := factory.CreateLogsExporter(context.Background(), creationParams, cfg)

--- a/exporter/otlpexporter/otlp.go
+++ b/exporter/otlpexporter/otlp.go
@@ -121,7 +121,7 @@ func newGrpcSender(config *Config) (*grpcSender, error) {
 	var clientConn *grpc.ClientConn
 	var endpoint *url.URL
 	if endpoint, err = url.Parse(config.GRPCClientSettings.Endpoint); err != nil {
-		return nil, err
+		return nil, errors.New("endpoint must be a valid URL")
 	}
 	if clientConn, err = grpc.Dial(endpoint.Host, dialOpts...); err != nil {
 		return nil, err

--- a/exporter/otlpexporter/otlp.go
+++ b/exporter/otlpexporter/otlp.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/url"
 	"time"
 
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
@@ -118,7 +119,11 @@ func newGrpcSender(config *Config) (*grpcSender, error) {
 	}
 
 	var clientConn *grpc.ClientConn
-	if clientConn, err = grpc.Dial(config.GRPCClientSettings.Endpoint, dialOpts...); err != nil {
+	var endpoint *url.URL
+	if endpoint, err = url.Parse(config.GRPCClientSettings.Endpoint); err != nil {
+		return nil, err
+	}
+	if clientConn, err = grpc.Dial(endpoint.Host, dialOpts...); err != nil {
 		return nil, err
 	}
 

--- a/exporter/otlpexporter/otlp_test.go
+++ b/exporter/otlpexporter/otlp_test.go
@@ -200,7 +200,7 @@ func TestSendTraces(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig().(*Config)
 	cfg.GRPCClientSettings = configgrpc.GRPCClientSettings{
-		Endpoint: ln.Addr().String(),
+		Endpoint: "http://" + ln.Addr().String(),
 		TLSSetting: configtls.TLSClientSetting{
 			Insecure: true,
 		},
@@ -272,7 +272,7 @@ func TestSendMetrics(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig().(*Config)
 	cfg.GRPCClientSettings = configgrpc.GRPCClientSettings{
-		Endpoint: ln.Addr().String(),
+		Endpoint: "http://" + ln.Addr().String(),
 		TLSSetting: configtls.TLSClientSetting{
 			Insecure: true,
 		},
@@ -344,7 +344,7 @@ func TestSendTraceDataServerDownAndUp(t *testing.T) {
 	// otherwise we will not see the error.
 	cfg.QueueSettings.Enabled = false
 	cfg.GRPCClientSettings = configgrpc.GRPCClientSettings{
-		Endpoint: ln.Addr().String(),
+		Endpoint: "http://" + ln.Addr().String(),
 		TLSSetting: configtls.TLSClientSetting{
 			Insecure: true,
 		},
@@ -404,7 +404,7 @@ func TestSendTraceDataServerStartWhileRequest(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig().(*Config)
 	cfg.GRPCClientSettings = configgrpc.GRPCClientSettings{
-		Endpoint: ln.Addr().String(),
+		Endpoint: "http://" + ln.Addr().String(),
 		TLSSetting: configtls.TLSClientSetting{
 			Insecure: true,
 		},
@@ -481,7 +481,7 @@ func TestSendLogData(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig().(*Config)
 	cfg.GRPCClientSettings = configgrpc.GRPCClientSettings{
-		Endpoint: ln.Addr().String(),
+		Endpoint: "http://" + ln.Addr().String(),
 		TLSSetting: configtls.TLSClientSetting{
 			Insecure: true,
 		},


### PR DESCRIPTION
**Description:** 

This PR seeks to address some issues with the configuration of the `otlpexporter`. The motivation for this PR is two-fold.

##### 1. Default TLS configuration for https

~~As it stands, in order to use TLS over gRPC, one must specify TLS Settings requiring a `cert_file` and `key_file`. This PR proposes that the TLS settings default to using system certificates when the scheme of the endpoint configuration is `https`. This has also been proposed by @vmihailenco in the opentelemetry-go project: https://github.com/open-telemetry/opentelemetry-go/issues/1584.~~

**Update:** Turns out this is not true. You do _not_ need to declare a `cert_file`/`key_file`. This was my misunderstanding. Communication over https just work. However, I'm still interested in hearing people's thoughts regarding my proposal below for aligning the configuration with the spec and requiring a scheme in the endpoint configuration.

##### 2. Align `otlpexporter` endpoint configuration with the specification

From the [OTLP exporter specification](https://github.com/open-telemetry/opentelemetry-specification/blob/1afab39e5658f807315abf2f3256809293bfd421/specification/protocol/exporter.md#configuration-options) regarding endpoint configuration:

> The endpoint MUST be a valid URL with scheme (http or https) and host, and MAY contain a port and path. A scheme of https indicates a secure connection.

Currently, as I noted in #2539, including a scheme in the endpoint configuration for the `otlpexporter` causes the error `too many colons in address` upon export. This PR aligns the `otlpexporter` with the specification by requiring that endpoint be a valid URL. My understanding is the spec requires this irrespective of what protocol is used - i.e., `http` or `grpc`. It appears the the `otlphttpexporter` [already requires a valid URL](https://github.com/open-telemetry/opentelemetry-collector/blob/733449ee6558cfb7bbf2a0c5bac8db6c8dfcef6c/exporter/otlphttpexporter/otlp.go#L61-L66).

**Question** If a scheme is not included in the endpoint configuration an error occurs but only upon export. Does it make sense to:

1. error upon start up?, or
2. continue to support configuring the endpoint without a scheme (contrary to the specification)?

**Link to tracking Issue:**

#2539

**Testing:**

TODO - I will complete test coverage if the direction of this PR is acceptable.

**Documentation:**

TODO - The [TLS Configuration Settings](https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/configtls/README.md) documentation will need to be updated.
