### PR TITLE
loggingexporter: add support for AttributeMap

### DIFF
--- a/exporter/loggingexporter/logging_exporter.go
+++ b/exporter/loggingexporter/logging_exporter.go
@@ -28,6 +28,7 @@ import (
 	"go.opentelemetry.io/collector/config/configmodels"
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
+	tracetranslator "go.opentelemetry.io/collector/translator/trace"
 )
 
 type logDataBuffer struct {
@@ -280,6 +281,8 @@ func attributeValueToString(av pdata.AttributeValue) string {
 		return strconv.FormatInt(av.IntVal(), 10)
 	case pdata.AttributeValueARRAY:
 		return attributeValueArrayToString(av.ArrayVal())
+	case pdata.AttributeValueMAP:
+		return attributeMapToString(av.MapVal())
 	default:
 		return fmt.Sprintf("<Unknown OpenTelemetry attribute value type %q>", av.Type())
 	}
@@ -297,6 +300,17 @@ func attributeValueArrayToString(av pdata.AnyValueArray) string {
 	}
 
 	b.WriteByte(']')
+	return b.String()
+}
+
+func attributeMapToString(av pdata.AttributeMap) string {
+	var b strings.Builder
+	b.WriteString("{\n")
+
+	av.Sort().ForEach(func(k string, v pdata.AttributeValue) {
+		fmt.Fprintf(&b, "     -> %s: %s(%s)\n", k, v.Type(), tracetranslator.AttributeValueToString(v, false))
+	})
+	b.WriteByte('}')
 	return b.String()
 }
 

--- a/exporter/loggingexporter/logging_exporter_test.go
+++ b/exporter/loggingexporter/logging_exporter_test.go
@@ -78,3 +78,22 @@ func TestNestedArraySerializesCorrectly(t *testing.T) {
 	assert.Equal(t, 3, ava.ArrayVal().Len())
 	assert.Equal(t, "[foo, 42, [bar]]", attributeValueToString(ava))
 }
+
+func TestNestedMapSerializesCorrectly(t *testing.T) {
+	ava := pdata.NewAttributeValueMap()
+	av := ava.MapVal()
+	av.Insert("foo", pdata.NewAttributeValueString("test"))
+
+	ava2 := pdata.NewAttributeValueMap()
+	av2 := ava2.MapVal()
+	av2.InsertInt("bar", 13)
+	av.Insert("zoo", ava2)
+
+	expected := `{
+     -> foo: STRING(test)
+     -> zoo: MAP({"bar":13})
+}`
+
+	assert.Equal(t, 2, ava.MapVal().Len())
+	assert.Equal(t, expected, attributeValueToString(ava))
+}


### PR DESCRIPTION
**Description:**

Add printing map to logging exporter.
Currently maps are printed as `<Unknown OpenTelemetry attribute value type MAP>`. An idea of the PR is to put it in more usable form. Nested maps are stringified jsons

Example output:
```
Some text: {
     -> foo: STRING(test)
     -> zoo: MAP({"bar":13})
}
````

**Testing:**
unit tests