### PR TITLE
loggingexporter: fix handling the loop for empty attributes

### DIFF
--- a/exporter/loggingexporter/logging_exporter.go
+++ b/exporter/loggingexporter/logging_exporter.go
@@ -235,7 +235,7 @@ func (b *logDataBuffer) logEvents(description string, se pdata.SpanEventSlice) {
 		b.logEntry("     -> DroppedAttributesCount: %d", e.DroppedAttributesCount())
 
 		if e.Attributes().Len() == 0 {
-			return
+			continue
 		}
 		b.logEntry("     -> Attributes:")
 		e.Attributes().ForEach(func(k string, v pdata.AttributeValue) {
@@ -259,7 +259,7 @@ func (b *logDataBuffer) logLinks(description string, sl pdata.SpanLinkSlice) {
 		b.logEntry("     -> TraceState: %s", l.TraceState())
 		b.logEntry("     -> DroppedAttributesCount: %d", l.DroppedAttributesCount())
 		if l.Attributes().Len() == 0 {
-			return
+			continue
 		}
 		b.logEntry("     -> Attributes:")
 		l.Attributes().ForEach(func(k string, v pdata.AttributeValue) {


### PR DESCRIPTION
**Description:** 

When span was containing several events, only the first one was printed out by the logging exporter. After checking the code it, turned out that handling the case with no attributes returns from the iteration loop altogether, which is wrong. The same bug was introduced for span links.

**Link to tracking Issue:** N/A

**Testing:** Just manual tests performed for Span Events

**Documentation:** N/A