### PR TITLE
[prometheusremotewrite] fix: counter name check 

### DIFF
--- a/exporter/prometheusremotewriteexporter/helper.go
+++ b/exporter/prometheusremotewriteexporter/helper.go
@@ -31,16 +31,16 @@ import (
 )
 
 const (
-	nameStr     = "__name__"
-	sumStr      = "_sum"
-	countStr    = "_count"
-	bucketStr   = "_bucket"
-	leStr       = "le"
-	quantileStr = "quantile"
-	pInfStr     = "+Inf"
-	totalStr    = "total"
-	delimeter   = "_"
-	keyStr      = "key"
+	nameStr       = "__name__"
+	sumStr        = "_sum"
+	countStr      = "_count"
+	bucketStr     = "_bucket"
+	leStr         = "le"
+	quantileStr   = "quantile"
+	pInfStr       = "+Inf"
+	counterSuffix = "_total"
+	delimiter     = "_"
+	keyStr        = "key"
 )
 
 // ByLabelName enables the usage of sort.Sort() with a slice of labels
@@ -188,13 +188,10 @@ func getPromMetricName(metric *otlp.Metric, ns string) string {
 	b.WriteString(ns)
 
 	if b.Len() > 0 {
-		b.WriteString(delimeter)
+		b.WriteString(delimiter)
 	}
 	name := metric.GetName()
 	b.WriteString(name)
-
-	// do not add the total suffix if the metric name already ends in "total"
-	isCounter = isCounter && name[len(name)-len(totalStr):] != totalStr
 
 	// Including units makes two metrics with the same name and label set belong to two different TimeSeries if the
 	// units are different.
@@ -205,9 +202,12 @@ func getPromMetricName(metric *otlp.Metric, ns string) string {
 		}
 	*/
 
-	if b.Len() > 0 && isCounter {
-		b.WriteString(delimeter)
-		b.WriteString(totalStr)
+	counterSuffixLength := len(counterSuffix)
+	nameLength := len(name)
+	hasCounterSuffix := nameLength > counterSuffixLength && name[nameLength-counterSuffixLength:] == counterSuffix
+
+	if b.Len() > 0 && isCounter && !hasCounterSuffix {
+		b.WriteString(counterSuffix)
 	}
 	return sanitize(b.String())
 }
@@ -262,7 +262,7 @@ func sanitize(s string) string {
 	// See https://github.com/orijtech/prometheus-go-metrics-exporter/issues/4.
 	s = strings.Map(sanitizeRune, s)
 	if unicode.IsDigit(rune(s[0])) {
-		s = keyStr + delimeter + s
+		s = keyStr + delimiter + s
 	}
 	if s[0] == '_' {
 		s = keyStr + s

--- a/exporter/prometheusremotewriteexporter/helper.go
+++ b/exporter/prometheusremotewriteexporter/helper.go
@@ -202,11 +202,7 @@ func getPromMetricName(metric *otlp.Metric, ns string) string {
 		}
 	*/
 
-	counterSuffixLength := len(counterSuffix)
-	nameLength := len(name)
-	hasCounterSuffix := nameLength > counterSuffixLength && name[nameLength-counterSuffixLength:] == counterSuffix
-
-	if b.Len() > 0 && isCounter && !hasCounterSuffix {
+	if b.Len() > 0 && isCounter && !strings.HasSuffix(name, counterSuffix) {
 		b.WriteString(counterSuffix)
 	}
 	return sanitize(b.String())

--- a/exporter/prometheusremotewriteexporter/helper_test.go
+++ b/exporter/prometheusremotewriteexporter/helper_test.go
@@ -287,7 +287,7 @@ func Test_getPromMetricName(t *testing.T) {
 			"total_suffix",
 			validMetrics1[validIntSum],
 			ns1,
-			"test_ns_" + validIntSum + delimeter + totalStr,
+			"test_ns_" + validIntSum + counterSuffix,
 		},
 		{
 			"dirty_string",

--- a/exporter/prometheusremotewriteexporter/helper_test.go
+++ b/exporter/prometheusremotewriteexporter/helper_test.go
@@ -290,6 +290,12 @@ func Test_getPromMetricName(t *testing.T) {
 			"test_ns_" + validIntSum + counterSuffix,
 		},
 		{
+			"already_has_total_suffix",
+			validMetrics1[suffixedCounter],
+			ns1,
+			"test_ns_" + suffixedCounter,
+		},
+		{
 			"dirty_string",
 			validMetrics2[validIntGaugeDirty],
 			"7" + ns1,

--- a/exporter/prometheusremotewriteexporter/testutil_test.go
+++ b/exporter/prometheusremotewriteexporter/testutil_test.go
@@ -94,6 +94,7 @@ var (
 	validIntHistogram    = "valid_IntHistogram"
 	validDoubleHistogram = "valid_DoubleHistogram"
 	validDoubleSummary   = "valid_DoubleSummary"
+	suffixedCounter      = "valid_IntSum_total"
 
 	validIntGaugeDirty = "*valid_IntGauge$"
 
@@ -126,6 +127,18 @@ var (
 		},
 		validIntSum: {
 			Name: validIntSum,
+			Data: &otlp.Metric_IntSum{
+				IntSum: &otlp.IntSum{
+					DataPoints: []*otlp.IntDataPoint{
+						getIntDataPoint(lbs1, intVal1, time1),
+						nil,
+					},
+					AggregationTemporality: otlp.AggregationTemporality_AGGREGATION_TEMPORALITY_CUMULATIVE,
+				},
+			},
+		},
+		suffixedCounter: {
+			Name: suffixedCounter,
 			Data: &otlp.Metric_IntSum{
 				IntSum: &otlp.IntSum{
 					DataPoints: []*otlp.IntDataPoint{


### PR DESCRIPTION
fixes  #2608

~Ensure that the metric name is greater than the length of the
counter suffix ("_total") before checking if it contains the counter
suffix to prevent crashes for short (smaller or eq to the length of the
suffix) metric names.~

~The edge case where the metric name is "_total" is not handled (considered
not to have the suffix), but should not occur IRL.~

edit: Use `strings.hasSuffix()` to check if metric name has the counter suffix ("_total")

Also fix the spelling of "delimiter".


warning: this is one of my first PRs in Go 😅 