### PR TITLE
Rename `ProcessorObsReport` to `Processor`

### DIFF
--- a/obsreport/obsreport.go
+++ b/obsreport/obsreport.go
@@ -66,7 +66,7 @@ func Configure(level configtelemetry.Level) (views []*view.View) {
 	gLevel = level
 
 	if gLevel != configtelemetry.LevelNone {
-		gProcessorObsReport.level = level
+		gProcessor.level = level
 		views = append(views, AllViews()...)
 	}
 

--- a/obsreport/obsreport_processor.go
+++ b/obsreport/obsreport_processor.go
@@ -114,22 +114,22 @@ func ProcessorMetricViews(configType string, legacyViews []*view.View) []*view.V
 	return allViews
 }
 
-var gProcessorObsReport = &ProcessorObsReport{level: configtelemetry.LevelNone}
+var gProcessor = &Processor{level: configtelemetry.LevelNone}
 
-type ProcessorObsReport struct {
+type Processor struct {
 	level    configtelemetry.Level
 	mutators []tag.Mutator
 }
 
-func NewProcessorObsReport(level configtelemetry.Level, processorName string) *ProcessorObsReport {
-	return &ProcessorObsReport{
+func NewProcessor(level configtelemetry.Level, processorName string) *Processor {
+	return &Processor{
 		level:    level,
 		mutators: []tag.Mutator{tag.Upsert(tagKeyProcessor, processorName, tag.WithTTL(tag.TTLNoPropagation))},
 	}
 }
 
 // TracesAccepted reports that the trace data was accepted.
-func (por *ProcessorObsReport) TracesAccepted(ctx context.Context, numSpans int) {
+func (por *Processor) TracesAccepted(ctx context.Context, numSpans int) {
 	if por.level != configtelemetry.LevelNone {
 		stats.RecordWithTags(
 			ctx,
@@ -142,7 +142,7 @@ func (por *ProcessorObsReport) TracesAccepted(ctx context.Context, numSpans int)
 }
 
 // TracesRefused reports that the trace data was refused.
-func (por *ProcessorObsReport) TracesRefused(ctx context.Context, numSpans int) {
+func (por *Processor) TracesRefused(ctx context.Context, numSpans int) {
 	if por.level != configtelemetry.LevelNone {
 		stats.RecordWithTags(
 			ctx,
@@ -155,7 +155,7 @@ func (por *ProcessorObsReport) TracesRefused(ctx context.Context, numSpans int) 
 }
 
 // TracesDropped reports that the trace data was dropped.
-func (por *ProcessorObsReport) TracesDropped(ctx context.Context, numSpans int) {
+func (por *Processor) TracesDropped(ctx context.Context, numSpans int) {
 	if por.level != configtelemetry.LevelNone {
 		stats.RecordWithTags(
 			ctx,
@@ -168,7 +168,7 @@ func (por *ProcessorObsReport) TracesDropped(ctx context.Context, numSpans int) 
 }
 
 // MetricsAccepted reports that the metrics were accepted.
-func (por *ProcessorObsReport) MetricsAccepted(ctx context.Context, numPoints int) {
+func (por *Processor) MetricsAccepted(ctx context.Context, numPoints int) {
 	if por.level != configtelemetry.LevelNone {
 		stats.RecordWithTags(
 			ctx,
@@ -181,7 +181,7 @@ func (por *ProcessorObsReport) MetricsAccepted(ctx context.Context, numPoints in
 }
 
 // MetricsRefused reports that the metrics were refused.
-func (por *ProcessorObsReport) MetricsRefused(ctx context.Context, numPoints int) {
+func (por *Processor) MetricsRefused(ctx context.Context, numPoints int) {
 	if por.level != configtelemetry.LevelNone {
 		stats.RecordWithTags(
 			ctx,
@@ -194,7 +194,7 @@ func (por *ProcessorObsReport) MetricsRefused(ctx context.Context, numPoints int
 }
 
 // MetricsDropped reports that the metrics were dropped.
-func (por *ProcessorObsReport) MetricsDropped(ctx context.Context, numPoints int) {
+func (por *Processor) MetricsDropped(ctx context.Context, numPoints int) {
 	if por.level != configtelemetry.LevelNone {
 		stats.RecordWithTags(
 			ctx,
@@ -207,7 +207,7 @@ func (por *ProcessorObsReport) MetricsDropped(ctx context.Context, numPoints int
 }
 
 // LogsAccepted reports that the logs were accepted.
-func (por *ProcessorObsReport) LogsAccepted(ctx context.Context, numRecords int) {
+func (por *Processor) LogsAccepted(ctx context.Context, numRecords int) {
 	if por.level != configtelemetry.LevelNone {
 		stats.RecordWithTags(
 			ctx,
@@ -220,7 +220,7 @@ func (por *ProcessorObsReport) LogsAccepted(ctx context.Context, numRecords int)
 }
 
 // LogsRefused reports that the logs were refused.
-func (por *ProcessorObsReport) LogsRefused(ctx context.Context, numRecords int) {
+func (por *Processor) LogsRefused(ctx context.Context, numRecords int) {
 	if por.level != configtelemetry.LevelNone {
 		stats.RecordWithTags(
 			ctx,
@@ -233,7 +233,7 @@ func (por *ProcessorObsReport) LogsRefused(ctx context.Context, numRecords int) 
 }
 
 // LogsDropped reports that the logs were dropped.
-func (por *ProcessorObsReport) LogsDropped(ctx context.Context, numRecords int) {
+func (por *Processor) LogsDropped(ctx context.Context, numRecords int) {
 	if por.level != configtelemetry.LevelNone {
 		stats.RecordWithTags(
 			ctx,

--- a/obsreport/obsreport_test.go
+++ b/obsreport/obsreport_test.go
@@ -551,7 +551,7 @@ func TestProcessorTraceData(t *testing.T) {
 	const refusedSpans = 19
 	const droppedSpans = 13
 
-	obsrep := obsreport.NewProcessorObsReport(configtelemetry.LevelNormal, processor)
+	obsrep := obsreport.NewProcessor(configtelemetry.LevelNormal, processor)
 	obsrep.TracesAccepted(context.Background(), acceptedSpans)
 	obsrep.TracesRefused(context.Background(), refusedSpans)
 	obsrep.TracesDropped(context.Background(), droppedSpans)
@@ -568,7 +568,7 @@ func TestProcessorMetricsData(t *testing.T) {
 	const refusedPoints = 11
 	const droppedPoints = 17
 
-	obsrep := obsreport.NewProcessorObsReport(configtelemetry.LevelNormal, processor)
+	obsrep := obsreport.NewProcessor(configtelemetry.LevelNormal, processor)
 	obsrep.MetricsAccepted(context.Background(), acceptedPoints)
 	obsrep.MetricsRefused(context.Background(), refusedPoints)
 	obsrep.MetricsDropped(context.Background(), droppedPoints)
@@ -639,7 +639,7 @@ func TestProcessorLogRecords(t *testing.T) {
 	const refusedRecords = 11
 	const droppedRecords = 17
 
-	obsrep := obsreport.NewProcessorObsReport(configtelemetry.LevelNormal, processor)
+	obsrep := obsreport.NewProcessor(configtelemetry.LevelNormal, processor)
 	obsrep.LogsAccepted(context.Background(), acceptedRecords)
 	obsrep.LogsRefused(context.Background(), refusedRecords)
 	obsrep.LogsDropped(context.Background(), droppedRecords)

--- a/processor/memorylimiter/memorylimiter.go
+++ b/processor/memorylimiter/memorylimiter.go
@@ -82,7 +82,7 @@ type memoryLimiter struct {
 	logger                 *zap.Logger
 	configMismatchedLogged bool
 
-	obsrep *obsreport.ProcessorObsReport
+	obsrep *obsreport.Processor
 }
 
 // Minimum interval between forced GC when in soft limited mode. We don't want to
@@ -118,7 +118,7 @@ func newMemoryLimiter(logger *zap.Logger, cfg *Config) (*memoryLimiter, error) {
 		readMemStatsFn: runtime.ReadMemStats,
 		procName:       cfg.Name(),
 		logger:         logger,
-		obsrep:         obsreport.NewProcessorObsReport(configtelemetry.GetMetricsLevelFlagValue(), cfg.Name()),
+		obsrep:         obsreport.NewProcessor(configtelemetry.GetMetricsLevelFlagValue(), cfg.Name()),
 	}
 
 	ml.startMonitoring()

--- a/processor/memorylimiter/memorylimiter_test.go
+++ b/processor/memorylimiter/memorylimiter_test.go
@@ -110,7 +110,7 @@ func TestMetricsMemoryPressureResponse(t *testing.T) {
 		readMemStatsFn: func(ms *runtime.MemStats) {
 			ms.Alloc = currentMemAlloc
 		},
-		obsrep: obsreport.NewProcessorObsReport(configtelemetry.LevelNone, ""),
+		obsrep: obsreport.NewProcessor(configtelemetry.LevelNone, ""),
 		logger: zap.NewNop(),
 	}
 	mp, err := processorhelper.NewMetricsProcessor(
@@ -181,7 +181,7 @@ func TestTraceMemoryPressureResponse(t *testing.T) {
 		readMemStatsFn: func(ms *runtime.MemStats) {
 			ms.Alloc = currentMemAlloc
 		},
-		obsrep: obsreport.NewProcessorObsReport(configtelemetry.LevelNone, ""),
+		obsrep: obsreport.NewProcessor(configtelemetry.LevelNone, ""),
 		logger: zap.NewNop(),
 	}
 	tp, err := processorhelper.NewTraceProcessor(
@@ -252,7 +252,7 @@ func TestLogMemoryPressureResponse(t *testing.T) {
 		readMemStatsFn: func(ms *runtime.MemStats) {
 			ms.Alloc = currentMemAlloc
 		},
-		obsrep: obsreport.NewProcessorObsReport(configtelemetry.LevelNone, ""),
+		obsrep: obsreport.NewProcessor(configtelemetry.LevelNone, ""),
 		logger: zap.NewNop(),
 	}
 	lp, err := processorhelper.NewLogsProcessor(


### PR DESCRIPTION
since obsreport is the package name.

Fixes #2639
