### PR TITLE
Rename `ExporterObsReport` to `Exporter`

### DIFF
--- a/exporter/exporterhelper/logshelper.go
+++ b/exporter/exporterhelper/logshelper.go
@@ -90,7 +90,7 @@ func NewLogsExporter(
 	be := newBaseExporter(cfg, logger, options...)
 	be.wrapConsumerSender(func(nextSender requestSender) requestSender {
 		return &logsExporterWithObservability{
-			obsrep:     obsreport.NewExporterObsReport(configtelemetry.GetMetricsLevelFlagValue(), cfg.Name()),
+			obsrep:     obsreport.NewExporter(configtelemetry.GetMetricsLevelFlagValue(), cfg.Name()),
 			nextSender: nextSender,
 		}
 	})
@@ -102,7 +102,7 @@ func NewLogsExporter(
 }
 
 type logsExporterWithObservability struct {
-	obsrep     *obsreport.ExporterObsReport
+	obsrep     *obsreport.Exporter
 	nextSender requestSender
 }
 

--- a/exporter/exporterhelper/metricshelper.go
+++ b/exporter/exporterhelper/metricshelper.go
@@ -95,7 +95,7 @@ func NewMetricsExporter(
 	be := newBaseExporter(cfg, logger, options...)
 	be.wrapConsumerSender(func(nextSender requestSender) requestSender {
 		return &metricsSenderWithObservability{
-			obsrep:     obsreport.NewExporterObsReport(configtelemetry.GetMetricsLevelFlagValue(), cfg.Name()),
+			obsrep:     obsreport.NewExporter(configtelemetry.GetMetricsLevelFlagValue(), cfg.Name()),
 			nextSender: nextSender,
 		}
 	})
@@ -107,7 +107,7 @@ func NewMetricsExporter(
 }
 
 type metricsSenderWithObservability struct {
-	obsrep     *obsreport.ExporterObsReport
+	obsrep     *obsreport.Exporter
 	nextSender requestSender
 }
 

--- a/exporter/exporterhelper/tracehelper.go
+++ b/exporter/exporterhelper/tracehelper.go
@@ -92,7 +92,7 @@ func NewTraceExporter(
 	be := newBaseExporter(cfg, logger, options...)
 	be.wrapConsumerSender(func(nextSender requestSender) requestSender {
 		return &tracesExporterWithObservability{
-			obsrep:     obsreport.NewExporterObsReport(configtelemetry.GetMetricsLevelFlagValue(), cfg.Name()),
+			obsrep:     obsreport.NewExporter(configtelemetry.GetMetricsLevelFlagValue(), cfg.Name()),
 			nextSender: nextSender,
 		}
 	})
@@ -104,7 +104,7 @@ func NewTraceExporter(
 }
 
 type tracesExporterWithObservability struct {
-	obsrep     *obsreport.ExporterObsReport
+	obsrep     *obsreport.Exporter
 	nextSender requestSender
 }
 

--- a/exporter/prometheusexporter/prometheus.go
+++ b/exporter/prometheusexporter/prometheus.go
@@ -38,7 +38,7 @@ type prometheusExporter struct {
 	handler      http.Handler
 	collector    *collector
 	registry     *prometheus.Registry
-	obsrep       *obsreport.ExporterObsReport
+	obsrep       *obsreport.Exporter
 }
 
 var errBlankPrometheusAddress = errors.New("expecting a non-blank address to run the Prometheus metrics handler")
@@ -49,7 +49,7 @@ func newPrometheusExporter(config *Config, logger *zap.Logger) (*prometheusExpor
 		return nil, errBlankPrometheusAddress
 	}
 
-	obsrep := obsreport.NewExporterObsReport(configtelemetry.GetMetricsLevelFlagValue(), config.Name())
+	obsrep := obsreport.NewExporter(configtelemetry.GetMetricsLevelFlagValue(), config.Name())
 
 	collector := newCollector(config, logger)
 	registry := prometheus.NewRegistry()

--- a/obsreport/obsreport_exporter.go
+++ b/obsreport/obsreport_exporter.go
@@ -92,14 +92,14 @@ func ExporterContext(ctx context.Context, exporterName string) context.Context {
 	return ctx
 }
 
-type ExporterObsReport struct {
+type Exporter struct {
 	level        configtelemetry.Level
 	exporterName string
 	mutators     []tag.Mutator
 }
 
-func NewExporterObsReport(level configtelemetry.Level, exporterName string) *ExporterObsReport {
-	return &ExporterObsReport{
+func NewExporter(level configtelemetry.Level, exporterName string) *Exporter {
+	return &Exporter{
 		level:        level,
 		exporterName: exporterName,
 		mutators:     []tag.Mutator{tag.Upsert(tagKeyProcessor, exporterName, tag.WithTTL(tag.TTLNoPropagation))},
@@ -107,43 +107,43 @@ func NewExporterObsReport(level configtelemetry.Level, exporterName string) *Exp
 }
 
 // StartTracesExportOp is called at the start of an Export operation.
-// The returned context should be used in other calls to the ExporterObsReport functions
+// The returned context should be used in other calls to the Exporter functions
 // dealing with the same export operation.
-func (eor *ExporterObsReport) StartTracesExportOp(ctx context.Context) context.Context {
+func (eor *Exporter) StartTracesExportOp(ctx context.Context) context.Context {
 	return eor.startSpan(ctx, exportTraceDataOperationSuffix)
 }
 
 // EndTracesExportOp completes the export operation that was started with StartTracesExportOp.
-func (eor *ExporterObsReport) EndTracesExportOp(ctx context.Context, numSpans int, err error) {
+func (eor *Exporter) EndTracesExportOp(ctx context.Context, numSpans int, err error) {
 	numSent, numFailedToSend := toNumItems(numSpans, err)
 	recordMetrics(ctx, numSent, numFailedToSend, mExporterSentSpans, mExporterFailedToSendSpans)
 	endSpan(ctx, err, numSent, numFailedToSend, SentSpansKey, FailedToSendSpansKey)
 }
 
 // StartMetricsExportOp is called at the start of an Export operation.
-// The returned context should be used in other calls to the ExporterObsReport functions
+// The returned context should be used in other calls to the Exporter functions
 // dealing with the same export operation.
-func (eor *ExporterObsReport) StartMetricsExportOp(ctx context.Context) context.Context {
+func (eor *Exporter) StartMetricsExportOp(ctx context.Context) context.Context {
 	return eor.startSpan(ctx, exportMetricsOperationSuffix)
 }
 
 // EndMetricsExportOp completes the export operation that was started with
 // StartMetricsExportOp.
-func (eor *ExporterObsReport) EndMetricsExportOp(ctx context.Context, numMetricPoints int, err error) {
+func (eor *Exporter) EndMetricsExportOp(ctx context.Context, numMetricPoints int, err error) {
 	numSent, numFailedToSend := toNumItems(numMetricPoints, err)
 	recordMetrics(ctx, numSent, numFailedToSend, mExporterSentMetricPoints, mExporterFailedToSendMetricPoints)
 	endSpan(ctx, err, numSent, numFailedToSend, SentMetricPointsKey, FailedToSendMetricPointsKey)
 }
 
 // StartLogsExportOp is called at the start of an Export operation.
-// The returned context should be used in other calls to the ExporterObsReport functions
+// The returned context should be used in other calls to the Exporter functions
 // dealing with the same export operation.
-func (eor *ExporterObsReport) StartLogsExportOp(ctx context.Context) context.Context {
+func (eor *Exporter) StartLogsExportOp(ctx context.Context) context.Context {
 	return eor.startSpan(ctx, exportLogsOperationSuffix)
 }
 
 // EndLogsExportOp completes the export operation that was started with StartLogsExportOp.
-func (eor *ExporterObsReport) EndLogsExportOp(ctx context.Context, numLogRecords int, err error) {
+func (eor *Exporter) EndLogsExportOp(ctx context.Context, numLogRecords int, err error) {
 	numSent, numFailedToSend := toNumItems(numLogRecords, err)
 	recordMetrics(ctx, numSent, numFailedToSend, mExporterSentLogRecords, mExporterFailedToSendLogRecords)
 	endSpan(ctx, err, numSent, numFailedToSend, SentLogRecordsKey, FailedToSendLogRecordsKey)
@@ -151,7 +151,7 @@ func (eor *ExporterObsReport) EndLogsExportOp(ctx context.Context, numLogRecords
 
 // startSpan creates the span used to trace the operation. Returning
 // the updated context and the created span.
-func (eor *ExporterObsReport) startSpan(ctx context.Context, operationSuffix string) context.Context {
+func (eor *Exporter) startSpan(ctx context.Context, operationSuffix string) context.Context {
 	spanName := exporterPrefix + eor.exporterName + operationSuffix
 	ctx, _ = trace.StartSpan(ctx, spanName)
 	return ctx

--- a/obsreport/obsreport_test.go
+++ b/obsreport/obsreport_test.go
@@ -339,7 +339,7 @@ func TestExportTraceDataOp(t *testing.T) {
 	defer parentSpan.End()
 
 	exporterCtx := obsreport.ExporterContext(parentCtx, exporter)
-	obsrep := obsreport.NewExporterObsReport(configtelemetry.LevelNormal, exporter)
+	obsrep := obsreport.NewExporter(configtelemetry.LevelNormal, exporter)
 	errs := []error{nil, errFake}
 	numExportedSpans := []int{22, 14}
 	for i, err := range errs {
@@ -387,7 +387,7 @@ func TestExportMetricsOp(t *testing.T) {
 	defer parentSpan.End()
 
 	exporterCtx := obsreport.ExporterContext(parentCtx, exporter)
-	obsrep := obsreport.NewExporterObsReport(configtelemetry.LevelNormal, exporter)
+	obsrep := obsreport.NewExporter(configtelemetry.LevelNormal, exporter)
 
 	errs := []error{nil, errFake}
 	toSendMetricPoints := []int{17, 23}
@@ -437,7 +437,7 @@ func TestExportLogsOp(t *testing.T) {
 	defer parentSpan.End()
 
 	exporterCtx := obsreport.ExporterContext(parentCtx, exporter)
-	obsrep := obsreport.NewExporterObsReport(configtelemetry.LevelNormal, exporter)
+	obsrep := obsreport.NewExporter(configtelemetry.LevelNormal, exporter)
 
 	errs := []error{nil, errFake}
 	toSendLogRecords := []int{17, 23}

--- a/obsreport/obsreporttest/obsreporttest_test.go
+++ b/obsreport/obsreporttest/obsreporttest_test.go
@@ -81,7 +81,7 @@ func TestCheckExporterTracesViews(t *testing.T) {
 	require.NoError(t, err)
 	defer doneFn()
 
-	obsrep := obsreport.NewExporterObsReport(configtelemetry.LevelNormal, exporter)
+	obsrep := obsreport.NewExporter(configtelemetry.LevelNormal, exporter)
 	exporterCtx := obsreport.ExporterContext(context.Background(), exporter)
 	ctx := obsrep.StartTracesExportOp(exporterCtx)
 	assert.NotNil(t, ctx)
@@ -96,7 +96,7 @@ func TestCheckExporterMetricsViews(t *testing.T) {
 	require.NoError(t, err)
 	defer doneFn()
 
-	obsrep := obsreport.NewExporterObsReport(configtelemetry.LevelNormal, exporter)
+	obsrep := obsreport.NewExporter(configtelemetry.LevelNormal, exporter)
 	exporterCtx := obsreport.ExporterContext(context.Background(), exporter)
 	ctx := obsrep.StartMetricsExportOp(exporterCtx)
 	assert.NotNil(t, ctx)
@@ -111,7 +111,7 @@ func TestCheckExporterLogsViews(t *testing.T) {
 	require.NoError(t, err)
 	defer doneFn()
 
-	obsrep := obsreport.NewExporterObsReport(configtelemetry.LevelNormal, exporter)
+	obsrep := obsreport.NewExporter(configtelemetry.LevelNormal, exporter)
 	exporterCtx := obsreport.ExporterContext(context.Background(), exporter)
 	ctx := obsrep.StartLogsExportOp(exporterCtx)
 	assert.NotNil(t, ctx)


### PR DESCRIPTION
since obsreport is the package name

fixes #2642
