### PR TITLE
Propogate name and transport for prometheus receiver and exporter

### DIFF
--- a/receiver/prometheusreceiver/metrics_receiver.go
+++ b/receiver/prometheusreceiver/metrics_receiver.go
@@ -24,8 +24,11 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/obsreport"
 	"go.opentelemetry.io/collector/receiver/prometheusreceiver/internal"
 )
+
+const transport = "http"
 
 // pReceiver is the type that provides Prometheus scraper/receiver functionality.
 type pReceiver struct {
@@ -73,7 +76,8 @@ func (r *pReceiver) Start(ctx context.Context, host component.Host) error {
 	if !r.cfg.UseStartTimeMetric {
 		jobsMap = internal.NewJobsMap(2 * time.Minute)
 	}
-	ocaStore := internal.NewOcaStore(ctx, r.consumer, r.logger, jobsMap, r.cfg.UseStartTimeMetric, r.cfg.StartTimeMetricRegex, r.cfg.Name())
+	receiverCtx := obsreport.ReceiverContext(ctx, r.cfg.Name(), transport)
+	ocaStore := internal.NewOcaStore(receiverCtx, r.consumer, r.logger, jobsMap, r.cfg.UseStartTimeMetric, r.cfg.StartTimeMetricRegex, r.cfg.Name())
 
 	scrapeManager := scrape.NewManager(logger, ocaStore)
 	ocaStore.SetScrapeManager(scrapeManager)


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

**Description:** 
Fix the issue #2533 which the prometheus `receiver` and `exporter` names are not correctly propagated via the context.

**Link to tracking Issue:** #2533

**Testing:** < Describe what testing was performed and which tests were added.>
Only tested manually with the config below:

```
receivers:
  otlp:
    protocols:
      http:
  prometheus:
    config:
      scrape_configs:
        - job_name: "otel-collector"
          scrape_interval: 5s
          static_configs:
            - targets: ["localhost:8888"]
processors:
  batch:
extensions:
  health_check: {}
exporters:
  prometheusremotewrite:
    endpoint: "http://localhost:9090/api/v1/write"
    insecure: true
    external_labels:
      server: otel
  prometheus:
    endpoint: "0.0.0.0:8081"
    namespace: test-space
    const_labels:
      label1: value1
    send_timestamps: true
    metric_expiration: 180m
  logging:
    loglevel: debug
service:
  extensions: [health_check]
  pipelines:
    metrics:
      receivers: [otlp, prometheus]
      processors: [batch]
      exporters: [prometheusremotewrite, prometheus]
```

The metrics I can get from `localhost:8888/metrics` are

![Screenshot from 2021-03-11 18-36-59](https://user-images.githubusercontent.com/25150124/110869634-cfed3000-8298-11eb-8289-127bd05bcd98.png)



**Documentation:** < Describe the documentation added.>

_Please delete paragraphs that you did not use before submitting._
