### PR TITLE
receiver/jaegerreceiver: Support reloading remote sampling strategy periodically

### DIFF
--- a/receiver/jaegerreceiver/README.md
+++ b/receiver/jaegerreceiver/README.md
@@ -90,6 +90,7 @@ receivers:
       grpc:
     remote_sampling:
       strategy_file: "/etc/strategy.json"
+      reload_interval: 30s
 ```
 
 Note: the `grpc` protocol must be enabled for this to work as Jaeger serves its

--- a/receiver/jaegerreceiver/config.go
+++ b/receiver/jaegerreceiver/config.go
@@ -15,6 +15,8 @@
 package jaegerreceiver
 
 import (
+	"time"
+
 	"go.opentelemetry.io/collector/config/configgrpc"
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/config/configmodels"
@@ -33,8 +35,9 @@ const (
 
 // RemoteSamplingConfig defines config key for remote sampling fetch endpoint
 type RemoteSamplingConfig struct {
-	HostEndpoint                  string `mapstructure:"host_endpoint"`
-	StrategyFile                  string `mapstructure:"strategy_file"`
+	HostEndpoint                  string        `mapstructure:"host_endpoint"`
+	StrategyFile                  string        `mapstructure:"strategy_file"`
+	ReloadInterval                time.Duration `mapstructure:"reload_interval"`
 	configgrpc.GRPCClientSettings `mapstructure:",squash"`
 }
 

--- a/receiver/jaegerreceiver/config_test.go
+++ b/receiver/jaegerreceiver/config_test.go
@@ -17,6 +17,7 @@ package jaegerreceiver
 import (
 	"path"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -84,7 +85,8 @@ func TestLoadConfig(t *testing.T) {
 				GRPCClientSettings: configgrpc.GRPCClientSettings{
 					Endpoint: "jaeger-collector:1234",
 				},
-				StrategyFile: "/etc/strategies.json",
+				StrategyFile:   "/etc/strategies.json",
+				ReloadInterval: 30 * time.Second,
 			},
 		})
 

--- a/receiver/jaegerreceiver/factory.go
+++ b/receiver/jaegerreceiver/factory.go
@@ -219,6 +219,14 @@ func createTraceReceiver(
 
 			config.RemoteSamplingStrategyFile = remoteSamplingConfig.StrategyFile
 		}
+
+		if remoteSamplingConfig.ReloadInterval != 0 {
+			if config.CollectorGRPCPort == 0 {
+				return nil, fmt.Errorf("strategy file requires the GRPC protocol to be enabled")
+			}
+
+			config.RemoteSamplingReloadInterval = remoteSamplingConfig.ReloadInterval
+		}
 	}
 
 	if (rCfg.Protocols.GRPC == nil && rCfg.Protocols.ThriftHTTP == nil && rCfg.Protocols.ThriftBinary == nil && rCfg.Protocols.ThriftCompact == nil) ||

--- a/receiver/jaegerreceiver/testdata/config.yaml
+++ b/receiver/jaegerreceiver/testdata/config.yaml
@@ -25,6 +25,7 @@ receivers:
       host_endpoint: "0.0.0.0:5778"
       endpoint: "jaeger-collector:1234"
       strategy_file: "/etc/strategies.json"
+      reload_interval: "30s"
   # The following demonstrates how to enable protocols with defaults.
   jaeger/defaults:
     protocols:

--- a/receiver/jaegerreceiver/trace_receiver.go
+++ b/receiver/jaegerreceiver/trace_receiver.go
@@ -22,6 +22,7 @@ import (
 	"net"
 	"net/http"
 	"sync"
+	"time"
 
 	apacheThrift "github.com/apache/thrift/lib/go/thrift"
 	"github.com/gorilla/mux"
@@ -69,6 +70,7 @@ type configuration struct {
 	AgentHTTPPort                int
 	RemoteSamplingClientSettings configgrpc.GRPCClientSettings
 	RemoteSamplingStrategyFile   string
+	RemoteSamplingReloadInterval time.Duration
 }
 
 // Receiver type is used to receive spans that were originally intended to be sent to Jaeger.
@@ -489,6 +491,7 @@ func (jr *jReceiver) startCollector(host component.Host) error {
 		// init and register sampling strategy store
 		ss, gerr := staticStrategyStore.NewStrategyStore(staticStrategyStore.Options{
 			StrategiesFile: jr.config.RemoteSamplingStrategyFile,
+			ReloadInterval: jr.config.RemoteSamplingReloadInterval,
 		}, jr.logger)
 		if gerr != nil {
 			return fmt.Errorf("failed to create collector strategy store: %v", gerr)

--- a/receiver/jaegerreceiver/trace_receiver_test.go
+++ b/receiver/jaegerreceiver/trace_receiver_test.go
@@ -494,6 +494,7 @@ func TestSamplingStrategiesMutualTLS(t *testing.T) {
 	server, serverAddr := initializeGRPCTestServer(t, func(s *grpc.Server) {
 		ss, serr := staticStrategyStore.NewStrategyStore(staticStrategyStore.Options{
 			StrategiesFile: path.Join(".", "testdata", "strategies.json"),
+			ReloadInterval: 30 * time.Second,
 		}, zap.NewNop())
 		require.NoError(t, serr)
 		api_v2.RegisterSamplingManagerServer(s, collectorSampling.NewGRPCHandler(ss))


### PR DESCRIPTION
**Description:**
Adds support for periodically reloading the remote sampling strategy configuration

**Testing:**
This still needs manual testing with a configuration file and modifying
the file and seeing if the changes are picked up.

**Documentation:**
Includes the new configuration option in the jaegerreceiver readme.