### PR TITLE
Remove obsreport.ExporterContext, always add exporter name as a tag to the metrics

### DIFF
--- a/exporter/exporterhelper/logshelper.go
+++ b/exporter/exporterhelper/logshelper.go
@@ -63,8 +63,7 @@ type logsExporter struct {
 }
 
 func (lexp *logsExporter) ConsumeLogs(ctx context.Context, ld pdata.Logs) error {
-	exporterCtx := obsreport.ExporterContext(ctx, lexp.cfg.Name())
-	_, err := lexp.sender.send(newLogsRequest(exporterCtx, ld, lexp.pusher))
+	_, err := lexp.sender.send(newLogsRequest(ctx, ld, lexp.pusher))
 	return err
 }
 

--- a/exporter/exporterhelper/metricshelper.go
+++ b/exporter/exporterhelper/metricshelper.go
@@ -67,9 +67,7 @@ func (mexp *metricsExporter) ConsumeMetrics(ctx context.Context, md pdata.Metric
 	if mexp.baseExporter.convertResourceToTelemetry {
 		md = convertResourceToLabels(md)
 	}
-	exporterCtx := obsreport.ExporterContext(ctx, mexp.cfg.Name())
-	req := newMetricsRequest(exporterCtx, md, mexp.pusher)
-	_, err := mexp.sender.send(req)
+	_, err := mexp.sender.send(newMetricsRequest(ctx, md, mexp.pusher))
 	return err
 }
 

--- a/exporter/exporterhelper/tracehelper.go
+++ b/exporter/exporterhelper/tracehelper.go
@@ -63,9 +63,7 @@ type traceExporter struct {
 }
 
 func (texp *traceExporter) ConsumeTraces(ctx context.Context, td pdata.Traces) error {
-	exporterCtx := obsreport.ExporterContext(ctx, texp.cfg.Name())
-	req := newTracesRequest(exporterCtx, td, texp.pusher)
-	_, err := texp.sender.send(req)
+	_, err := texp.sender.send(newTracesRequest(ctx, td, texp.pusher))
 	return err
 }
 

--- a/obsreport/obsreport_test.go
+++ b/obsreport/obsreport_test.go
@@ -338,12 +338,11 @@ func TestExportTraceDataOp(t *testing.T) {
 		t.Name(), trace.WithSampler(trace.AlwaysSample()))
 	defer parentSpan.End()
 
-	exporterCtx := obsreport.ExporterContext(parentCtx, exporter)
 	obsrep := obsreport.NewExporter(configtelemetry.LevelNormal, exporter)
 	errs := []error{nil, errFake}
 	numExportedSpans := []int{22, 14}
 	for i, err := range errs {
-		ctx := obsrep.StartTracesExportOp(exporterCtx)
+		ctx := obsrep.StartTracesExportOp(parentCtx)
 		assert.NotNil(t, ctx)
 		obsrep.EndTracesExportOp(ctx, numExportedSpans[i], err)
 	}
@@ -386,13 +385,12 @@ func TestExportMetricsOp(t *testing.T) {
 		t.Name(), trace.WithSampler(trace.AlwaysSample()))
 	defer parentSpan.End()
 
-	exporterCtx := obsreport.ExporterContext(parentCtx, exporter)
 	obsrep := obsreport.NewExporter(configtelemetry.LevelNormal, exporter)
 
 	errs := []error{nil, errFake}
 	toSendMetricPoints := []int{17, 23}
 	for i, err := range errs {
-		ctx := obsrep.StartMetricsExportOp(exporterCtx)
+		ctx := obsrep.StartMetricsExportOp(parentCtx)
 		assert.NotNil(t, ctx)
 
 		obsrep.EndMetricsExportOp(ctx, toSendMetricPoints[i], err)
@@ -436,13 +434,11 @@ func TestExportLogsOp(t *testing.T) {
 		t.Name(), trace.WithSampler(trace.AlwaysSample()))
 	defer parentSpan.End()
 
-	exporterCtx := obsreport.ExporterContext(parentCtx, exporter)
 	obsrep := obsreport.NewExporter(configtelemetry.LevelNormal, exporter)
-
 	errs := []error{nil, errFake}
 	toSendLogRecords := []int{17, 23}
 	for i, err := range errs {
-		ctx := obsrep.StartLogsExportOp(exporterCtx)
+		ctx := obsrep.StartLogsExportOp(parentCtx)
 		assert.NotNil(t, ctx)
 
 		obsrep.EndLogsExportOp(ctx, toSendLogRecords[i], err)

--- a/obsreport/obsreporttest/obsreporttest_test.go
+++ b/obsreport/obsreporttest/obsreporttest_test.go
@@ -82,8 +82,7 @@ func TestCheckExporterTracesViews(t *testing.T) {
 	defer doneFn()
 
 	obsrep := obsreport.NewExporter(configtelemetry.LevelNormal, exporter)
-	exporterCtx := obsreport.ExporterContext(context.Background(), exporter)
-	ctx := obsrep.StartTracesExportOp(exporterCtx)
+	ctx := obsrep.StartTracesExportOp(context.Background())
 	assert.NotNil(t, ctx)
 
 	obsrep.EndTracesExportOp(ctx, 7, nil)
@@ -97,8 +96,7 @@ func TestCheckExporterMetricsViews(t *testing.T) {
 	defer doneFn()
 
 	obsrep := obsreport.NewExporter(configtelemetry.LevelNormal, exporter)
-	exporterCtx := obsreport.ExporterContext(context.Background(), exporter)
-	ctx := obsrep.StartMetricsExportOp(exporterCtx)
+	ctx := obsrep.StartMetricsExportOp(context.Background())
 	assert.NotNil(t, ctx)
 
 	obsrep.EndMetricsExportOp(ctx, 7, nil)
@@ -112,8 +110,7 @@ func TestCheckExporterLogsViews(t *testing.T) {
 	defer doneFn()
 
 	obsrep := obsreport.NewExporter(configtelemetry.LevelNormal, exporter)
-	exporterCtx := obsreport.ExporterContext(context.Background(), exporter)
-	ctx := obsrep.StartLogsExportOp(exporterCtx)
+	ctx := obsrep.StartLogsExportOp(context.Background())
 	assert.NotNil(t, ctx)
 	obsrep.EndLogsExportOp(ctx, 7, nil)
 


### PR DESCRIPTION
Updates #2533

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
