### PR TITLE
Remove the number of items from returned values in Push funcs

### DIFF
--- a/exporter/exporterhelper/common.go
+++ b/exporter/exporterhelper/common.go
@@ -45,7 +45,7 @@ type request interface {
 	context() context.Context
 	// setContext updates the Context of the requests.
 	setContext(context.Context)
-	export(ctx context.Context) (int, error)
+	export(ctx context.Context) error
 	// Returns a new request that contains the items left to be sent.
 	onPartialError(consumererror.PartialError) request
 	// Returns the count of spans/metric points or log records.
@@ -54,7 +54,7 @@ type request interface {
 
 // requestSender is an abstraction of a sender for a request independent of the type of the data (traces, metrics, logs).
 type requestSender interface {
-	send(req request) (int, error)
+	send(req request) error
 }
 
 // baseRequest is a base implementation for the request.
@@ -205,7 +205,7 @@ type timeoutSender struct {
 }
 
 // send implements the requestSender interface
-func (ts *timeoutSender) send(req request) (int, error) {
+func (ts *timeoutSender) send(req request) error {
 	// Intentionally don't overwrite the context inside the request, because in case of retries deadline will not be
 	// updated because this deadline most likely is before the next one.
 	ctx := req.context()

--- a/exporter/exporterhelper/factory_test.go
+++ b/exporter/exporterhelper/factory_test.go
@@ -36,14 +36,14 @@ var (
 		TypeVal: typeStr,
 		NameVal: typeStr,
 	}
-	nopTracesExporter, _ = NewTraceExporter(defaultCfg, zap.NewNop(), func(ctx context.Context, td pdata.Traces) (droppedSpans int, err error) {
-		return 0, nil
+	nopTracesExporter, _ = NewTraceExporter(defaultCfg, zap.NewNop(), func(ctx context.Context, td pdata.Traces) error {
+		return nil
 	})
-	nopMetricsExporter, _ = NewMetricsExporter(defaultCfg, zap.NewNop(), func(ctx context.Context, md pdata.Metrics) (droppedTimeSeries int, err error) {
-		return 0, nil
+	nopMetricsExporter, _ = NewMetricsExporter(defaultCfg, zap.NewNop(), func(ctx context.Context, md pdata.Metrics) error {
+		return nil
 	})
-	nopLogsExporter, _ = NewLogsExporter(defaultCfg, zap.NewNop(), func(ctx context.Context, md pdata.Logs) (droppedTimeSeries int, err error) {
-		return 0, nil
+	nopLogsExporter, _ = NewLogsExporter(defaultCfg, zap.NewNop(), func(ctx context.Context, md pdata.Logs) error {
+		return nil
 	})
 )
 

--- a/exporter/exporterhelper/logshelper_test.go
+++ b/exporter/exporterhelper/logshelper_test.go
@@ -57,13 +57,13 @@ func TestLogsRequest(t *testing.T) {
 }
 
 func TestLogsExporter_InvalidName(t *testing.T) {
-	le, err := NewLogsExporter(nil, zap.NewNop(), newPushLogsData(0, nil))
+	le, err := NewLogsExporter(nil, zap.NewNop(), newPushLogsData(nil))
 	require.Nil(t, le)
 	require.Equal(t, errNilConfig, err)
 }
 
 func TestLogsExporter_NilLogger(t *testing.T) {
-	le, err := NewLogsExporter(fakeLogsExporterConfig, nil, newPushLogsData(0, nil))
+	le, err := NewLogsExporter(fakeLogsExporterConfig, nil, newPushLogsData(nil))
 	require.Nil(t, le)
 	require.Equal(t, errNilLogger, err)
 }
@@ -76,7 +76,7 @@ func TestLogsExporter_NilPushLogsData(t *testing.T) {
 
 func TestLogsExporter_Default(t *testing.T) {
 	ld := testdata.GenerateLogDataEmpty()
-	le, err := NewLogsExporter(fakeLogsExporterConfig, zap.NewNop(), newPushLogsData(0, nil))
+	le, err := NewLogsExporter(fakeLogsExporterConfig, zap.NewNop(), newPushLogsData(nil))
 	assert.NotNil(t, le)
 	assert.NoError(t, err)
 
@@ -87,22 +87,14 @@ func TestLogsExporter_Default(t *testing.T) {
 func TestLogsExporter_Default_ReturnError(t *testing.T) {
 	ld := testdata.GenerateLogDataEmpty()
 	want := errors.New("my_error")
-	le, err := NewLogsExporter(fakeLogsExporterConfig, zap.NewNop(), newPushLogsData(0, want))
+	le, err := NewLogsExporter(fakeLogsExporterConfig, zap.NewNop(), newPushLogsData(want))
 	require.Nil(t, err)
 	require.NotNil(t, le)
 	require.Equal(t, want, le.ConsumeLogs(context.Background(), ld))
 }
 
 func TestLogsExporter_WithRecordLogs(t *testing.T) {
-	le, err := NewLogsExporter(fakeLogsExporterConfig, zap.NewNop(), newPushLogsData(0, nil))
-	require.Nil(t, err)
-	require.NotNil(t, le)
-
-	checkRecordedMetricsForLogsExporter(t, le, nil)
-}
-
-func TestLogsExporter_WithRecordLogs_NonZeroDropped(t *testing.T) {
-	le, err := NewLogsExporter(fakeLogsExporterConfig, zap.NewNop(), newPushLogsData(1, nil))
+	le, err := NewLogsExporter(fakeLogsExporterConfig, zap.NewNop(), newPushLogsData(nil))
 	require.Nil(t, err)
 	require.NotNil(t, le)
 
@@ -111,7 +103,7 @@ func TestLogsExporter_WithRecordLogs_NonZeroDropped(t *testing.T) {
 
 func TestLogsExporter_WithRecordLogs_ReturnError(t *testing.T) {
 	want := errors.New("my_error")
-	le, err := NewLogsExporter(fakeLogsExporterConfig, zap.NewNop(), newPushLogsData(0, want))
+	le, err := NewLogsExporter(fakeLogsExporterConfig, zap.NewNop(), newPushLogsData(want))
 	require.Nil(t, err)
 	require.NotNil(t, le)
 
@@ -119,14 +111,7 @@ func TestLogsExporter_WithRecordLogs_ReturnError(t *testing.T) {
 }
 
 func TestLogsExporter_WithSpan(t *testing.T) {
-	le, err := NewLogsExporter(fakeLogsExporterConfig, zap.NewNop(), newPushLogsData(0, nil))
-	require.Nil(t, err)
-	require.NotNil(t, le)
-	checkWrapSpanForLogsExporter(t, le, nil, 1)
-}
-
-func TestLogsExporter_WithSpan_NonZeroDropped(t *testing.T) {
-	le, err := NewLogsExporter(fakeLogsExporterConfig, zap.NewNop(), newPushLogsData(1, nil))
+	le, err := NewLogsExporter(fakeLogsExporterConfig, zap.NewNop(), newPushLogsData(nil))
 	require.Nil(t, err)
 	require.NotNil(t, le)
 	checkWrapSpanForLogsExporter(t, le, nil, 1)
@@ -134,7 +119,7 @@ func TestLogsExporter_WithSpan_NonZeroDropped(t *testing.T) {
 
 func TestLogsExporter_WithSpan_ReturnError(t *testing.T) {
 	want := errors.New("my_error")
-	le, err := NewLogsExporter(fakeLogsExporterConfig, zap.NewNop(), newPushLogsData(0, want))
+	le, err := NewLogsExporter(fakeLogsExporterConfig, zap.NewNop(), newPushLogsData(want))
 	require.Nil(t, err)
 	require.NotNil(t, le)
 	checkWrapSpanForLogsExporter(t, le, want, 1)
@@ -144,7 +129,7 @@ func TestLogsExporter_WithShutdown(t *testing.T) {
 	shutdownCalled := false
 	shutdown := func(context.Context) error { shutdownCalled = true; return nil }
 
-	le, err := NewLogsExporter(fakeLogsExporterConfig, zap.NewNop(), newPushLogsData(0, nil), WithShutdown(shutdown))
+	le, err := NewLogsExporter(fakeLogsExporterConfig, zap.NewNop(), newPushLogsData(nil), WithShutdown(shutdown))
 	assert.NotNil(t, le)
 	assert.NoError(t, err)
 
@@ -156,16 +141,16 @@ func TestLogsExporter_WithShutdown_ReturnError(t *testing.T) {
 	want := errors.New("my_error")
 	shutdownErr := func(context.Context) error { return want }
 
-	le, err := NewLogsExporter(fakeLogsExporterConfig, zap.NewNop(), newPushLogsData(0, nil), WithShutdown(shutdownErr))
+	le, err := NewLogsExporter(fakeLogsExporterConfig, zap.NewNop(), newPushLogsData(nil), WithShutdown(shutdownErr))
 	assert.NotNil(t, le)
 	assert.NoError(t, err)
 
 	assert.Equal(t, le.Shutdown(context.Background()), want)
 }
 
-func newPushLogsData(droppedTimeSeries int, retError error) PushLogs {
-	return func(ctx context.Context, td pdata.Logs) (int, error) {
-		return droppedTimeSeries, retError
+func newPushLogsData(retError error) PushLogs {
+	return func(ctx context.Context, td pdata.Logs) error {
+		return retError
 	}
 }
 

--- a/exporter/exporterhelper/metricshelper_test.go
+++ b/exporter/exporterhelper/metricshelper_test.go
@@ -57,13 +57,13 @@ func TestMetricsRequest(t *testing.T) {
 }
 
 func TestMetricsExporter_InvalidName(t *testing.T) {
-	me, err := NewMetricsExporter(nil, zap.NewNop(), newPushMetricsData(0, nil))
+	me, err := NewMetricsExporter(nil, zap.NewNop(), newPushMetricsData(nil))
 	require.Nil(t, me)
 	require.Equal(t, errNilConfig, err)
 }
 
 func TestMetricsExporter_NilLogger(t *testing.T) {
-	me, err := NewMetricsExporter(fakeMetricsExporterConfig, nil, newPushMetricsData(0, nil))
+	me, err := NewMetricsExporter(fakeMetricsExporterConfig, nil, newPushMetricsData(nil))
 	require.Nil(t, me)
 	require.Equal(t, errNilLogger, err)
 }
@@ -76,7 +76,7 @@ func TestMetricsExporter_NilPushMetricsData(t *testing.T) {
 
 func TestMetricsExporter_Default(t *testing.T) {
 	md := testdata.GenerateMetricsEmpty()
-	me, err := NewMetricsExporter(fakeMetricsExporterConfig, zap.NewNop(), newPushMetricsData(0, nil))
+	me, err := NewMetricsExporter(fakeMetricsExporterConfig, zap.NewNop(), newPushMetricsData(nil))
 	assert.NotNil(t, me)
 	assert.NoError(t, err)
 
@@ -87,22 +87,14 @@ func TestMetricsExporter_Default(t *testing.T) {
 func TestMetricsExporter_Default_ReturnError(t *testing.T) {
 	md := testdata.GenerateMetricsEmpty()
 	want := errors.New("my_error")
-	me, err := NewMetricsExporter(fakeMetricsExporterConfig, zap.NewNop(), newPushMetricsData(0, want))
+	me, err := NewMetricsExporter(fakeMetricsExporterConfig, zap.NewNop(), newPushMetricsData(want))
 	require.Nil(t, err)
 	require.NotNil(t, me)
 	require.Equal(t, want, me.ConsumeMetrics(context.Background(), md))
 }
 
 func TestMetricsExporter_WithRecordMetrics(t *testing.T) {
-	me, err := NewMetricsExporter(fakeMetricsExporterConfig, zap.NewNop(), newPushMetricsData(0, nil))
-	require.Nil(t, err)
-	require.NotNil(t, me)
-
-	checkRecordedMetricsForMetricsExporter(t, me, nil)
-}
-
-func TestMetricsExporter_WithRecordMetrics_NonZeroDropped(t *testing.T) {
-	me, err := NewMetricsExporter(fakeMetricsExporterConfig, zap.NewNop(), newPushMetricsData(1, nil))
+	me, err := NewMetricsExporter(fakeMetricsExporterConfig, zap.NewNop(), newPushMetricsData(nil))
 	require.Nil(t, err)
 	require.NotNil(t, me)
 
@@ -111,7 +103,7 @@ func TestMetricsExporter_WithRecordMetrics_NonZeroDropped(t *testing.T) {
 
 func TestMetricsExporter_WithRecordMetrics_ReturnError(t *testing.T) {
 	want := errors.New("my_error")
-	me, err := NewMetricsExporter(fakeMetricsExporterConfig, zap.NewNop(), newPushMetricsData(0, want))
+	me, err := NewMetricsExporter(fakeMetricsExporterConfig, zap.NewNop(), newPushMetricsData(want))
 	require.Nil(t, err)
 	require.NotNil(t, me)
 
@@ -119,14 +111,7 @@ func TestMetricsExporter_WithRecordMetrics_ReturnError(t *testing.T) {
 }
 
 func TestMetricsExporter_WithSpan(t *testing.T) {
-	me, err := NewMetricsExporter(fakeMetricsExporterConfig, zap.NewNop(), newPushMetricsData(0, nil))
-	require.Nil(t, err)
-	require.NotNil(t, me)
-	checkWrapSpanForMetricsExporter(t, me, nil, 1)
-}
-
-func TestMetricsExporter_WithSpan_NonZeroDropped(t *testing.T) {
-	me, err := NewMetricsExporter(fakeMetricsExporterConfig, zap.NewNop(), newPushMetricsData(1, nil))
+	me, err := NewMetricsExporter(fakeMetricsExporterConfig, zap.NewNop(), newPushMetricsData(nil))
 	require.Nil(t, err)
 	require.NotNil(t, me)
 	checkWrapSpanForMetricsExporter(t, me, nil, 1)
@@ -134,7 +119,7 @@ func TestMetricsExporter_WithSpan_NonZeroDropped(t *testing.T) {
 
 func TestMetricsExporter_WithSpan_ReturnError(t *testing.T) {
 	want := errors.New("my_error")
-	me, err := NewMetricsExporter(fakeMetricsExporterConfig, zap.NewNop(), newPushMetricsData(0, want))
+	me, err := NewMetricsExporter(fakeMetricsExporterConfig, zap.NewNop(), newPushMetricsData(want))
 	require.Nil(t, err)
 	require.NotNil(t, me)
 	checkWrapSpanForMetricsExporter(t, me, want, 1)
@@ -144,7 +129,7 @@ func TestMetricsExporter_WithShutdown(t *testing.T) {
 	shutdownCalled := false
 	shutdown := func(context.Context) error { shutdownCalled = true; return nil }
 
-	me, err := NewMetricsExporter(fakeMetricsExporterConfig, zap.NewNop(), newPushMetricsData(0, nil), WithShutdown(shutdown))
+	me, err := NewMetricsExporter(fakeMetricsExporterConfig, zap.NewNop(), newPushMetricsData(nil), WithShutdown(shutdown))
 	assert.NotNil(t, me)
 	assert.NoError(t, err)
 
@@ -154,7 +139,7 @@ func TestMetricsExporter_WithShutdown(t *testing.T) {
 
 func TestMetricsExporter_WithResourceToTelemetryConversionDisabled(t *testing.T) {
 	md := testdata.GenerateMetricsTwoMetrics()
-	me, err := NewMetricsExporter(fakeMetricsExporterConfig, zap.NewNop(), newPushMetricsData(0, nil), WithResourceToTelemetryConversion(defaultResourceToTelemetrySettings()))
+	me, err := NewMetricsExporter(fakeMetricsExporterConfig, zap.NewNop(), newPushMetricsData(nil), WithResourceToTelemetryConversion(defaultResourceToTelemetrySettings()))
 	assert.NotNil(t, me)
 	assert.NoError(t, err)
 
@@ -164,7 +149,7 @@ func TestMetricsExporter_WithResourceToTelemetryConversionDisabled(t *testing.T)
 
 func TestMetricsExporter_WithResourceToTelemetryConversionEbabled(t *testing.T) {
 	md := testdata.GenerateMetricsTwoMetrics()
-	me, err := NewMetricsExporter(fakeMetricsExporterConfig, zap.NewNop(), newPushMetricsData(0, nil), WithResourceToTelemetryConversion(ResourceToTelemetrySettings{Enabled: true}))
+	me, err := NewMetricsExporter(fakeMetricsExporterConfig, zap.NewNop(), newPushMetricsData(nil), WithResourceToTelemetryConversion(ResourceToTelemetrySettings{Enabled: true}))
 	assert.NotNil(t, me)
 	assert.NoError(t, err)
 
@@ -176,16 +161,16 @@ func TestMetricsExporter_WithShutdown_ReturnError(t *testing.T) {
 	want := errors.New("my_error")
 	shutdownErr := func(context.Context) error { return want }
 
-	me, err := NewMetricsExporter(fakeMetricsExporterConfig, zap.NewNop(), newPushMetricsData(0, nil), WithShutdown(shutdownErr))
+	me, err := NewMetricsExporter(fakeMetricsExporterConfig, zap.NewNop(), newPushMetricsData(nil), WithShutdown(shutdownErr))
 	assert.NotNil(t, me)
 	assert.NoError(t, err)
 
 	assert.Equal(t, me.Shutdown(context.Background()), want)
 }
 
-func newPushMetricsData(droppedTimeSeries int, retError error) PushMetrics {
-	return func(ctx context.Context, td pdata.Metrics) (int, error) {
-		return droppedTimeSeries, retError
+func newPushMetricsData(retError error) PushMetrics {
+	return func(ctx context.Context, td pdata.Metrics) error {
+		return retError
 	}
 }
 

--- a/exporter/exporterhelper/tracehelper_test.go
+++ b/exporter/exporterhelper/tracehelper_test.go
@@ -66,13 +66,13 @@ func (tote *testOCTraceExporter) ExportSpan(sd *trace.SpanData) {
 }
 
 func TestTraceExporter_InvalidName(t *testing.T) {
-	te, err := NewTraceExporter(nil, zap.NewNop(), newTraceDataPusher(0, nil))
+	te, err := NewTraceExporter(nil, zap.NewNop(), newTraceDataPusher(nil))
 	require.Nil(t, te)
 	require.Equal(t, errNilConfig, err)
 }
 
 func TestTraceExporter_NilLogger(t *testing.T) {
-	te, err := NewTraceExporter(fakeTraceExporterConfig, nil, newTraceDataPusher(0, nil))
+	te, err := NewTraceExporter(fakeTraceExporterConfig, nil, newTraceDataPusher(nil))
 	require.Nil(t, te)
 	require.Equal(t, errNilLogger, err)
 }
@@ -85,7 +85,7 @@ func TestTraceExporter_NilPushTraceData(t *testing.T) {
 
 func TestTraceExporter_Default(t *testing.T) {
 	td := pdata.NewTraces()
-	te, err := NewTraceExporter(fakeTraceExporterConfig, zap.NewNop(), newTraceDataPusher(0, nil))
+	te, err := NewTraceExporter(fakeTraceExporterConfig, zap.NewNop(), newTraceDataPusher(nil))
 	assert.NotNil(t, te)
 	assert.NoError(t, err)
 
@@ -96,7 +96,7 @@ func TestTraceExporter_Default(t *testing.T) {
 func TestTraceExporter_Default_ReturnError(t *testing.T) {
 	td := pdata.NewTraces()
 	want := errors.New("my_error")
-	te, err := NewTraceExporter(fakeTraceExporterConfig, zap.NewNop(), newTraceDataPusher(0, want))
+	te, err := NewTraceExporter(fakeTraceExporterConfig, zap.NewNop(), newTraceDataPusher(want))
 	require.Nil(t, err)
 	require.NotNil(t, te)
 
@@ -105,15 +105,7 @@ func TestTraceExporter_Default_ReturnError(t *testing.T) {
 }
 
 func TestTraceExporter_WithRecordMetrics(t *testing.T) {
-	te, err := NewTraceExporter(fakeTraceExporterConfig, zap.NewNop(), newTraceDataPusher(0, nil))
-	require.Nil(t, err)
-	require.NotNil(t, te)
-
-	checkRecordedMetricsForTraceExporter(t, te, nil)
-}
-
-func TestTraceExporter_WithRecordMetrics_NonZeroDropped(t *testing.T) {
-	te, err := NewTraceExporter(fakeTraceExporterConfig, zap.NewNop(), newTraceDataPusher(1, nil))
+	te, err := NewTraceExporter(fakeTraceExporterConfig, zap.NewNop(), newTraceDataPusher(nil))
 	require.Nil(t, err)
 	require.NotNil(t, te)
 
@@ -122,7 +114,7 @@ func TestTraceExporter_WithRecordMetrics_NonZeroDropped(t *testing.T) {
 
 func TestTraceExporter_WithRecordMetrics_ReturnError(t *testing.T) {
 	want := errors.New("my_error")
-	te, err := NewTraceExporter(fakeTraceExporterConfig, zap.NewNop(), newTraceDataPusher(0, want))
+	te, err := NewTraceExporter(fakeTraceExporterConfig, zap.NewNop(), newTraceDataPusher(want))
 	require.Nil(t, err)
 	require.NotNil(t, te)
 
@@ -130,15 +122,7 @@ func TestTraceExporter_WithRecordMetrics_ReturnError(t *testing.T) {
 }
 
 func TestTraceExporter_WithSpan(t *testing.T) {
-	te, err := NewTraceExporter(fakeTraceExporterConfig, zap.NewNop(), newTraceDataPusher(0, nil))
-	require.Nil(t, err)
-	require.NotNil(t, te)
-
-	checkWrapSpanForTraceExporter(t, te, nil, 1)
-}
-
-func TestTraceExporter_WithSpan_NonZeroDropped(t *testing.T) {
-	te, err := NewTraceExporter(fakeTraceExporterConfig, zap.NewNop(), newTraceDataPusher(1, nil))
+	te, err := NewTraceExporter(fakeTraceExporterConfig, zap.NewNop(), newTraceDataPusher(nil))
 	require.Nil(t, err)
 	require.NotNil(t, te)
 
@@ -147,7 +131,7 @@ func TestTraceExporter_WithSpan_NonZeroDropped(t *testing.T) {
 
 func TestTraceExporter_WithSpan_ReturnError(t *testing.T) {
 	want := errors.New("my_error")
-	te, err := NewTraceExporter(fakeTraceExporterConfig, zap.NewNop(), newTraceDataPusher(0, want))
+	te, err := NewTraceExporter(fakeTraceExporterConfig, zap.NewNop(), newTraceDataPusher(want))
 	require.Nil(t, err)
 	require.NotNil(t, te)
 
@@ -158,7 +142,7 @@ func TestTraceExporter_WithShutdown(t *testing.T) {
 	shutdownCalled := false
 	shutdown := func(context.Context) error { shutdownCalled = true; return nil }
 
-	te, err := NewTraceExporter(fakeTraceExporterConfig, zap.NewNop(), newTraceDataPusher(0, nil), WithShutdown(shutdown))
+	te, err := NewTraceExporter(fakeTraceExporterConfig, zap.NewNop(), newTraceDataPusher(nil), WithShutdown(shutdown))
 	assert.NotNil(t, te)
 	assert.NoError(t, err)
 
@@ -170,16 +154,16 @@ func TestTraceExporter_WithShutdown_ReturnError(t *testing.T) {
 	want := errors.New("my_error")
 	shutdownErr := func(context.Context) error { return want }
 
-	te, err := NewTraceExporter(fakeTraceExporterConfig, zap.NewNop(), newTraceDataPusher(0, nil), WithShutdown(shutdownErr))
+	te, err := NewTraceExporter(fakeTraceExporterConfig, zap.NewNop(), newTraceDataPusher(nil), WithShutdown(shutdownErr))
 	assert.NotNil(t, te)
 	assert.NoError(t, err)
 
 	assert.Equal(t, te.Shutdown(context.Background()), want)
 }
 
-func newTraceDataPusher(droppedSpans int, retError error) PushTraces {
-	return func(ctx context.Context, td pdata.Traces) (int, error) {
-		return droppedSpans, retError
+func newTraceDataPusher(retError error) PushTraces {
+	return func(ctx context.Context, td pdata.Traces) error {
+		return retError
 	}
 }
 

--- a/exporter/kafkaexporter/kafka_exporter.go
+++ b/exporter/kafkaexporter/kafka_exporter.go
@@ -36,16 +36,16 @@ type kafkaTracesProducer struct {
 	logger     *zap.Logger
 }
 
-func (e *kafkaTracesProducer) traceDataPusher(_ context.Context, td pdata.Traces) (int, error) {
+func (e *kafkaTracesProducer) traceDataPusher(_ context.Context, td pdata.Traces) error {
 	messages, err := e.marshaller.Marshal(td)
 	if err != nil {
-		return td.SpanCount(), consumererror.Permanent(err)
+		return consumererror.Permanent(err)
 	}
 	err = e.producer.SendMessages(producerMessages(messages, e.topic))
 	if err != nil {
-		return td.SpanCount(), err
+		return err
 	}
-	return 0, nil
+	return nil
 }
 
 func (e *kafkaTracesProducer) Close(context.Context) error {
@@ -60,16 +60,16 @@ type kafkaMetricsProducer struct {
 	logger     *zap.Logger
 }
 
-func (e *kafkaMetricsProducer) metricsDataPusher(_ context.Context, md pdata.Metrics) (int, error) {
+func (e *kafkaMetricsProducer) metricsDataPusher(_ context.Context, md pdata.Metrics) error {
 	messages, err := e.marshaller.Marshal(md)
 	if err != nil {
-		return md.MetricCount(), consumererror.Permanent(err)
+		return consumererror.Permanent(err)
 	}
 	err = e.producer.SendMessages(producerMessages(messages, e.topic))
 	if err != nil {
-		return md.MetricCount(), err
+		return err
 	}
-	return 0, nil
+	return nil
 }
 
 func (e *kafkaMetricsProducer) Close(context.Context) error {

--- a/exporter/kafkaexporter/kafka_exporter_test.go
+++ b/exporter/kafkaexporter/kafka_exporter_test.go
@@ -103,9 +103,8 @@ func TestTraceDataPusher(t *testing.T) {
 	t.Cleanup(func() {
 		require.NoError(t, p.Close(context.Background()))
 	})
-	droppedSpans, err := p.traceDataPusher(context.Background(), testdata.GenerateTraceDataTwoSpansSameResource())
+	err := p.traceDataPusher(context.Background(), testdata.GenerateTraceDataTwoSpansSameResource())
 	require.NoError(t, err)
-	assert.Equal(t, 0, droppedSpans)
 }
 
 func TestTraceDataPusher_err(t *testing.T) {
@@ -123,9 +122,8 @@ func TestTraceDataPusher_err(t *testing.T) {
 		require.NoError(t, p.Close(context.Background()))
 	})
 	td := testdata.GenerateTraceDataTwoSpansSameResource()
-	droppedSpans, err := p.traceDataPusher(context.Background(), td)
+	err := p.traceDataPusher(context.Background(), td)
 	assert.EqualError(t, err, expErr.Error())
-	assert.Equal(t, td.SpanCount(), droppedSpans)
 }
 
 func TestTraceDataPusher_marshall_error(t *testing.T) {
@@ -135,10 +133,9 @@ func TestTraceDataPusher_marshall_error(t *testing.T) {
 		logger:     zap.NewNop(),
 	}
 	td := testdata.GenerateTraceDataTwoSpansSameResource()
-	droppedSpans, err := p.traceDataPusher(context.Background(), td)
+	err := p.traceDataPusher(context.Background(), td)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), expErr.Error())
-	assert.Equal(t, td.SpanCount(), droppedSpans)
 }
 
 func TestMetricsDataPusher(t *testing.T) {
@@ -153,9 +150,8 @@ func TestMetricsDataPusher(t *testing.T) {
 	t.Cleanup(func() {
 		require.NoError(t, p.Close(context.Background()))
 	})
-	dropped, err := p.metricsDataPusher(context.Background(), testdata.GenerateMetricsTwoMetrics())
+	err := p.metricsDataPusher(context.Background(), testdata.GenerateMetricsTwoMetrics())
 	require.NoError(t, err)
-	assert.Equal(t, 0, dropped)
 }
 
 func TestMetricsDataPusher_err(t *testing.T) {
@@ -173,9 +169,8 @@ func TestMetricsDataPusher_err(t *testing.T) {
 		require.NoError(t, p.Close(context.Background()))
 	})
 	md := testdata.GenerateMetricsTwoMetrics()
-	dropped, err := p.metricsDataPusher(context.Background(), md)
+	err := p.metricsDataPusher(context.Background(), md)
 	assert.EqualError(t, err, expErr.Error())
-	assert.Equal(t, md.MetricCount(), dropped)
 }
 
 func TestMetricsDataPusher_marshal_error(t *testing.T) {
@@ -185,10 +180,9 @@ func TestMetricsDataPusher_marshal_error(t *testing.T) {
 		logger:     zap.NewNop(),
 	}
 	md := testdata.GenerateMetricsTwoMetrics()
-	dropped, err := p.metricsDataPusher(context.Background(), md)
+	err := p.metricsDataPusher(context.Background(), md)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), expErr.Error())
-	assert.Equal(t, md.MetricCount(), dropped)
 }
 
 type tracesErrorMarshaller struct {

--- a/exporter/loggingexporter/logging_exporter.go
+++ b/exporter/loggingexporter/logging_exporter.go
@@ -322,12 +322,12 @@ type loggingExporter struct {
 func (s *loggingExporter) pushTraceData(
 	_ context.Context,
 	td pdata.Traces,
-) (int, error) {
+) error {
 
 	s.logger.Info("TracesExporter", zap.Int("#spans", td.SpanCount()))
 
 	if !s.debug {
-		return 0, nil
+		return nil
 	}
 
 	buf := logDataBuffer{}
@@ -365,17 +365,17 @@ func (s *loggingExporter) pushTraceData(
 	}
 	s.logger.Debug(buf.str.String())
 
-	return 0, nil
+	return nil
 }
 
 func (s *loggingExporter) pushMetricsData(
 	_ context.Context,
 	md pdata.Metrics,
-) (int, error) {
+) error {
 	s.logger.Info("MetricsExporter", zap.Int("#metrics", md.MetricCount()))
 
 	if !s.debug {
-		return 0, nil
+		return nil
 	}
 
 	buf := logDataBuffer{}
@@ -401,7 +401,7 @@ func (s *loggingExporter) pushMetricsData(
 
 	s.logger.Debug(buf.str.String())
 
-	return 0, nil
+	return nil
 }
 
 // newTraceExporter creates an exporter.TracesExporter that just drops the
@@ -467,11 +467,11 @@ func newLogsExporter(config configmodels.Exporter, level string, logger *zap.Log
 func (s *loggingExporter) pushLogData(
 	_ context.Context,
 	ld pdata.Logs,
-) (int, error) {
+) error {
 	s.logger.Info("LogsExporter", zap.Int("#logs", ld.LogRecordCount()))
 
 	if !s.debug {
-		return 0, nil
+		return nil
 	}
 
 	buf := logDataBuffer{}
@@ -497,7 +497,7 @@ func (s *loggingExporter) pushLogData(
 
 	s.logger.Debug(buf.str.String())
 
-	return 0, nil
+	return nil
 }
 
 func loggerSync(logger *zap.Logger) func(context.Context) error {

--- a/exporter/opencensusexporter/opencensus.go
+++ b/exporter/opencensusexporter/opencensus.go
@@ -136,12 +136,12 @@ func newMetricsExporter(ctx context.Context, cfg *Config) (*ocExporter, error) {
 	return oce, nil
 }
 
-func (oce *ocExporter) pushTraceData(_ context.Context, td pdata.Traces) (int, error) {
+func (oce *ocExporter) pushTraceData(_ context.Context, td pdata.Traces) error {
 	// Get first available trace Client.
 	tClient, ok := <-oce.tracesClients
 	if !ok {
 		err := errors.New("failed to push traces, OpenCensus exporter was already stopped")
-		return td.SpanCount(), err
+		return err
 	}
 
 	// In any of the metricsClients channel we keep always NumWorkers object (sometimes nil),
@@ -154,7 +154,7 @@ func (oce *ocExporter) pushTraceData(_ context.Context, td pdata.Traces) (int, e
 		if err != nil {
 			// Cannot create an RPC, put back nil to keep the number of workers constant.
 			oce.tracesClients <- nil
-			return td.SpanCount(), err
+			return err
 		}
 	}
 
@@ -178,19 +178,19 @@ func (oce *ocExporter) pushTraceData(_ context.Context, td pdata.Traces) (int, e
 			// put back nil to keep the number of workers constant.
 			tClient.cancel()
 			oce.tracesClients <- nil
-			return td.SpanCount(), err
+			return err
 		}
 	}
 	oce.tracesClients <- tClient
-	return 0, nil
+	return nil
 }
 
-func (oce *ocExporter) pushMetricsData(_ context.Context, md pdata.Metrics) (int, error) {
+func (oce *ocExporter) pushMetricsData(_ context.Context, md pdata.Metrics) error {
 	// Get first available mClient.
 	mClient, ok := <-oce.metricsClients
 	if !ok {
 		err := errors.New("failed to push metrics, OpenCensus exporter was already stopped")
-		return metricPointCount(md), err
+		return err
 	}
 
 	// In any of the metricsClients channel we keep always NumWorkers object (sometimes nil),
@@ -203,7 +203,7 @@ func (oce *ocExporter) pushMetricsData(_ context.Context, md pdata.Metrics) (int
 		if err != nil {
 			// Cannot create an RPC, put back nil to keep the number of workers constant.
 			oce.metricsClients <- nil
-			return metricPointCount(md), err
+			return err
 		}
 	}
 
@@ -228,11 +228,11 @@ func (oce *ocExporter) pushMetricsData(_ context.Context, md pdata.Metrics) (int
 			// put back nil to keep the number of workers constant.
 			mClient.cancel()
 			oce.metricsClients <- nil
-			return metricPointCount(md), err
+			return err
 		}
 	}
 	oce.metricsClients <- mClient
-	return 0, nil
+	return nil
 }
 
 func (oce *ocExporter) createTraceServiceRPC() (*tracesClientWithCancel, error) {
@@ -263,9 +263,4 @@ func (oce *ocExporter) createMetricsServiceRPC() (*metricsClientWithCancel, erro
 		return nil, fmt.Errorf("MetricsServiceClient: %w", err)
 	}
 	return &metricsClientWithCancel{cancel: cancel, msec: metricsClient}, nil
-}
-
-func metricPointCount(md pdata.Metrics) int {
-	_, pc := md.MetricAndDataPointCount()
-	return pc
 }

--- a/exporter/otlpexporter/otlp.go
+++ b/exporter/otlpexporter/otlp.go
@@ -65,40 +65,34 @@ func (e *exporterImp) shutdown(context.Context) error {
 	return e.w.stop()
 }
 
-func (e *exporterImp) pushTraceData(ctx context.Context, td pdata.Traces) (int, error) {
+func (e *exporterImp) pushTraceData(ctx context.Context, td pdata.Traces) error {
 	request := &otlptrace.ExportTraceServiceRequest{
 		ResourceSpans: pdata.TracesToOtlp(td),
 	}
-	err := e.w.exportTrace(ctx, request)
-
-	if err != nil {
-		return td.SpanCount(), fmt.Errorf("failed to push trace data via OTLP exporter: %w", err)
+	if err := e.w.exportTrace(ctx, request); err != nil {
+		return fmt.Errorf("failed to push trace data via OTLP exporter: %w", err)
 	}
-	return 0, nil
+	return nil
 }
 
-func (e *exporterImp) pushMetricsData(ctx context.Context, md pdata.Metrics) (int, error) {
+func (e *exporterImp) pushMetricsData(ctx context.Context, md pdata.Metrics) error {
 	request := &otlpmetrics.ExportMetricsServiceRequest{
 		ResourceMetrics: pdata.MetricsToOtlp(md),
 	}
-	err := e.w.exportMetrics(ctx, request)
-
-	if err != nil {
-		return md.MetricCount(), fmt.Errorf("failed to push metrics data via OTLP exporter: %w", err)
+	if err := e.w.exportMetrics(ctx, request); err != nil {
+		return fmt.Errorf("failed to push metrics data via OTLP exporter: %w", err)
 	}
-	return 0, nil
+	return nil
 }
 
-func (e *exporterImp) pushLogData(ctx context.Context, logs pdata.Logs) (int, error) {
+func (e *exporterImp) pushLogData(ctx context.Context, logs pdata.Logs) error {
 	request := &otlplogs.ExportLogsServiceRequest{
 		ResourceLogs: internal.LogsToOtlp(logs.InternalRep()),
 	}
-	err := e.w.exportLogs(ctx, request)
-
-	if err != nil {
-		return logs.LogRecordCount(), fmt.Errorf("failed to push log data via OTLP exporter: %w", err)
+	if err := e.w.exportLogs(ctx, request); err != nil {
+		return fmt.Errorf("failed to push log data via OTLP exporter: %w", err)
 	}
-	return 0, nil
+	return nil
 }
 
 type grpcSender struct {

--- a/exporter/otlphttpexporter/otlp.go
+++ b/exporter/otlphttpexporter/otlp.go
@@ -85,46 +85,46 @@ func newExporter(cfg configmodels.Exporter, logger *zap.Logger) (*exporterImp, e
 	}, nil
 }
 
-func (e *exporterImp) pushTraceData(ctx context.Context, traces pdata.Traces) (int, error) {
+func (e *exporterImp) pushTraceData(ctx context.Context, traces pdata.Traces) error {
 	request, err := traces.ToOtlpProtoBytes()
 	if err != nil {
-		return traces.SpanCount(), consumererror.Permanent(err)
+		return consumererror.Permanent(err)
 	}
 
 	err = e.export(ctx, e.tracesURL, request)
 	if err != nil {
-		return traces.SpanCount(), err
+		return err
 	}
 
-	return 0, nil
+	return nil
 }
 
-func (e *exporterImp) pushMetricsData(ctx context.Context, metrics pdata.Metrics) (int, error) {
+func (e *exporterImp) pushMetricsData(ctx context.Context, metrics pdata.Metrics) error {
 	request, err := metrics.ToOtlpProtoBytes()
 	if err != nil {
-		return metrics.MetricCount(), consumererror.Permanent(err)
+		return consumererror.Permanent(err)
 	}
 
 	err = e.export(ctx, e.metricsURL, request)
 	if err != nil {
-		return metrics.MetricCount(), err
+		return err
 	}
 
-	return 0, nil
+	return nil
 }
 
-func (e *exporterImp) pushLogData(ctx context.Context, logs pdata.Logs) (int, error) {
+func (e *exporterImp) pushLogData(ctx context.Context, logs pdata.Logs) error {
 	request, err := logs.ToOtlpProtoBytes()
 	if err != nil {
-		return logs.LogRecordCount(), consumererror.Permanent(err)
+		return consumererror.Permanent(err)
 	}
 
 	err = e.export(ctx, e.logsURL, request)
 	if err != nil {
-		return logs.LogRecordCount(), err
+		return err
 	}
 
-	return 0, nil
+	return nil
 }
 
 func (e *exporterImp) export(ctx context.Context, url string, request []byte) error {

--- a/exporter/prometheusremotewriteexporter/exporter.go
+++ b/exporter/prometheusremotewriteexporter/exporter.go
@@ -90,13 +90,13 @@ func (prwe *PrwExporter) Shutdown(context.Context) error {
 // PushMetrics converts metrics to Prometheus remote write TimeSeries and send to remote endpoint. It maintain a map of
 // TimeSeries, validates and handles each individual metric, adding the converted TimeSeries to the map, and finally
 // exports the map.
-func (prwe *PrwExporter) PushMetrics(ctx context.Context, md pdata.Metrics) (int, error) {
+func (prwe *PrwExporter) PushMetrics(ctx context.Context, md pdata.Metrics) error {
 	prwe.wg.Add(1)
 	defer prwe.wg.Done()
 
 	select {
 	case <-prwe.closeChan:
-		return md.MetricCount(), errors.New("shutdown has been called")
+		return errors.New("shutdown has been called")
 	default:
 		tsMap := map[string]*prompb.TimeSeries{}
 		dropped := 0
@@ -154,10 +154,10 @@ func (prwe *PrwExporter) PushMetrics(ctx context.Context, md pdata.Metrics) (int
 		}
 
 		if dropped != 0 {
-			return dropped, consumererror.CombineErrors(errs)
+			return consumererror.CombineErrors(errs)
 		}
 
-		return 0, nil
+		return nil
 	}
 }
 

--- a/exporter/prometheusremotewriteexporter/exporter_test.go
+++ b/exporter/prometheusremotewriteexporter/exporter_test.go
@@ -137,8 +137,7 @@ func Test_Shutdown(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			_, ok := prwe.PushMetrics(context.Background(), testdata.GenerateMetricsEmpty())
-			errChan <- ok
+			errChan <- prwe.PushMetrics(context.Background(), testdata.GenerateMetricsEmpty())
 		}()
 	}
 	wg.Wait()
@@ -157,7 +156,7 @@ func Test_export(t *testing.T) {
 	sample2 := getSample(floatVal2, msTime2)
 	ts1 := getTimeSeries(labels, sample1, sample2)
 	handleFunc := func(w http.ResponseWriter, r *http.Request, code int) {
-		// The following is a handler function that reads the sent httpRequest, unmarshals, and checks if the WriteRequest
+		// The following is a handler function that reads the sent httpRequest, unmarshal, and checks if the WriteRequest
 		// preserves the TimeSeries data correctly
 		body, err := ioutil.ReadAll(r.Body)
 		if err != nil {
@@ -486,13 +485,12 @@ func Test_PushMetrics(t *testing.T) {
 	}
 
 	tests := []struct {
-		name                 string
-		md                   *pdata.Metrics
-		reqTestFunc          func(t *testing.T, r *http.Request, expected int)
-		expectedTimeSeries   int
-		httpResponseCode     int
-		numDroppedTimeSeries int
-		returnErr            bool
+		name               string
+		md                 *pdata.Metrics
+		reqTestFunc        func(t *testing.T, r *http.Request, expected int)
+		expectedTimeSeries int
+		httpResponseCode   int
+		returnErr          bool
 	}{
 		{
 			"invalid_type_case",
@@ -500,7 +498,6 @@ func Test_PushMetrics(t *testing.T) {
 			nil,
 			0,
 			http.StatusAccepted,
-			invalidTypeBatch.MetricCount(),
 			true,
 		},
 		{
@@ -509,7 +506,6 @@ func Test_PushMetrics(t *testing.T) {
 			checkFunc,
 			2,
 			http.StatusAccepted,
-			0,
 			false,
 		},
 		{
@@ -518,7 +514,6 @@ func Test_PushMetrics(t *testing.T) {
 			checkFunc,
 			2,
 			http.StatusAccepted,
-			0,
 			false,
 		},
 		{
@@ -527,7 +522,6 @@ func Test_PushMetrics(t *testing.T) {
 			checkFunc,
 			2,
 			http.StatusAccepted,
-			0,
 			false,
 		},
 		{
@@ -536,7 +530,6 @@ func Test_PushMetrics(t *testing.T) {
 			checkFunc,
 			2,
 			http.StatusAccepted,
-			0,
 			false,
 		},
 		{
@@ -545,7 +538,6 @@ func Test_PushMetrics(t *testing.T) {
 			checkFunc,
 			12,
 			http.StatusAccepted,
-			0,
 			false,
 		},
 		{
@@ -554,7 +546,6 @@ func Test_PushMetrics(t *testing.T) {
 			checkFunc,
 			12,
 			http.StatusAccepted,
-			0,
 			false,
 		},
 		{
@@ -563,7 +554,6 @@ func Test_PushMetrics(t *testing.T) {
 			checkFunc,
 			10,
 			http.StatusAccepted,
-			0,
 			false,
 		},
 		{
@@ -572,7 +562,6 @@ func Test_PushMetrics(t *testing.T) {
 			checkFunc,
 			5,
 			http.StatusAccepted,
-			0,
 			false,
 		},
 		{
@@ -581,7 +570,6 @@ func Test_PushMetrics(t *testing.T) {
 			checkFunc,
 			5,
 			http.StatusAccepted,
-			0,
 			false,
 		},
 		{
@@ -590,7 +578,6 @@ func Test_PushMetrics(t *testing.T) {
 			checkFunc,
 			5,
 			http.StatusServiceUnavailable,
-			1,
 			true,
 		},
 		{
@@ -599,7 +586,6 @@ func Test_PushMetrics(t *testing.T) {
 			checkFunc,
 			0,
 			http.StatusAccepted,
-			nilDataPointDoubleGaugeBatch.MetricCount(),
 			true,
 		},
 		{
@@ -608,7 +594,6 @@ func Test_PushMetrics(t *testing.T) {
 			checkFunc,
 			0,
 			http.StatusAccepted,
-			nilDataPointIntGaugeBatch.MetricCount(),
 			true,
 		},
 		{
@@ -617,7 +602,6 @@ func Test_PushMetrics(t *testing.T) {
 			checkFunc,
 			0,
 			http.StatusAccepted,
-			nilDataPointDoubleSumBatch.MetricCount(),
 			true,
 		},
 		{
@@ -626,7 +610,6 @@ func Test_PushMetrics(t *testing.T) {
 			checkFunc,
 			0,
 			http.StatusAccepted,
-			nilDataPointIntSumBatch.MetricCount(),
 			true,
 		},
 		{
@@ -635,7 +618,6 @@ func Test_PushMetrics(t *testing.T) {
 			checkFunc,
 			0,
 			http.StatusAccepted,
-			nilDataPointDoubleHistogramBatch.MetricCount(),
 			true,
 		},
 		{
@@ -644,7 +626,6 @@ func Test_PushMetrics(t *testing.T) {
 			checkFunc,
 			0,
 			http.StatusAccepted,
-			nilDataPointIntHistogramBatch.MetricCount(),
 			true,
 		},
 		{
@@ -653,7 +634,6 @@ func Test_PushMetrics(t *testing.T) {
 			checkFunc,
 			0,
 			http.StatusAccepted,
-			nilDataPointDoubleSummaryBatch.MetricCount(),
 			true,
 		},
 	}
@@ -691,8 +671,7 @@ func Test_PushMetrics(t *testing.T) {
 			c := http.DefaultClient
 			prwe, nErr := NewPrwExporter(config.Namespace, serverURL.String(), c, map[string]string{})
 			require.NoError(t, nErr)
-			numDroppedTimeSeries, err := prwe.PushMetrics(context.Background(), *tt.md)
-			assert.Equal(t, tt.numDroppedTimeSeries, numDroppedTimeSeries)
+			err := prwe.PushMetrics(context.Background(), *tt.md)
 			if tt.returnErr {
 				assert.Error(t, err)
 				return


### PR DESCRIPTION
Even in code for metrics we did not have a consistent implementation,
also most important thing was not used anymore in observability helper.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
