### PR TITLE
Letting the transformation go ahead even if Timeseries or Histogram "sum" is unavailable.

### DIFF
--- a/receiver/prometheusreceiver/internal/metricfamily.go
+++ b/receiver/prometheusreceiver/internal/metricfamily.go
@@ -261,8 +261,11 @@ func (mg *metricGroup) sortPoints() {
 }
 
 func (mg *metricGroup) toDistributionTimeSeries(orderedLabelKeys []string) *metricspb.TimeSeries {
-	if !(mg.hasCount && mg.hasSum) || len(mg.complexValue) == 0 {
+	if !(mg.hasCount) || len(mg.complexValue) == 0 {
 		return nil
+	}
+	if !(mg.hasSum) {
+		mg.sum = 0
 	}
 	mg.sortPoints()
 	// for OCAgent Proto, the bounds won't include +inf
@@ -308,11 +311,14 @@ func (mg *metricGroup) toDistributionTimeSeries(orderedLabelKeys []string) *metr
 }
 
 func (mg *metricGroup) toSummaryTimeSeries(orderedLabelKeys []string) *metricspb.TimeSeries {
-	// expecting count and sum to be provided, however, in the following two cases, they can be missed.
+	// expecting count to be provided, however, in the following two cases, they can be missed.
 	// 1. data is corrupted
 	// 2. ignored by startValue evaluation
-	if !(mg.hasCount && mg.hasSum) {
+	if !(mg.hasCount) {
 		return nil
+	}
+	if !(mg.hasSum) {
+		mg.sum = 0
 	}
 	mg.sortPoints()
 	percentiles := make([]*metricspb.SummaryValue_Snapshot_ValueAtPercentile, len(mg.complexValue))

--- a/receiver/prometheusreceiver/internal/metricsbuilder_test.go
+++ b/receiver/prometheusreceiver/internal/metricsbuilder_test.go
@@ -1026,6 +1026,48 @@ func Test_metricBuilder_summary(t *testing.T) {
 			},
 		},
 		{
+			name: "no-sum",
+			inputs: []*testScrapedPage{
+				{
+					pts: []*testDataPoint{
+						createDataPoint("summary_test", 1, "foo", "bar", "quantile", "0.5"),
+						createDataPoint("summary_test", 2, "foo", "bar", "quantile", "0.75"),
+						createDataPoint("summary_test", 5, "foo", "bar", "quantile", "1"),
+						createDataPoint("summary_test_count", 500, "foo", "bar"),
+					},
+				},
+			},
+			wants: [][]*metricspb.Metric{
+				{
+					{
+						MetricDescriptor: &metricspb.MetricDescriptor{
+							Name:      "summary_test",
+							Type:      metricspb.MetricDescriptor_SUMMARY,
+							LabelKeys: []*metricspb.LabelKey{{Key: "foo"}}},
+						Timeseries: []*metricspb.TimeSeries{
+							{
+								StartTimestamp: timestampFromMs(startTs),
+								LabelValues:    []*metricspb.LabelValue{{Value: "bar", HasValue: true}},
+								Points: []*metricspb.Point{
+									{Timestamp: timestampFromMs(startTs), Value: &metricspb.Point_SummaryValue{
+										SummaryValue: &metricspb.SummaryValue{
+											Sum:   &wrapperspb.DoubleValue{Value: 0.0},
+											Count: &wrapperspb.Int64Value{Value: 500},
+											Snapshot: &metricspb.SummaryValue_Snapshot{
+												PercentileValues: []*metricspb.SummaryValue_Snapshot_ValueAtPercentile{
+													{Percentile: 50.0, Value: 1},
+													{Percentile: 75.0, Value: 2},
+													{Percentile: 100.0, Value: 5},
+												},
+											}}}},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "empty-quantiles",
 			inputs: []*testScrapedPage{
 				{


### PR DESCRIPTION
**Description:**
Fixing a bug - #2661 to enable Prometheus Receiver to process and accept the metric record even if "sum" is not available.

**Link to tracking Issue:** #2661 

**Testing:** Updated unit test case to test the condition. Also tested it using live setup to ingest DropWizard generated metrics into GoogleCloud (stack driver).

**Documentation:** None.
