### PR TITLE
Bug 2506

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ## 💡 Enhancements 💡
 
 ## 🧰 Bug fixes 🧰
+- `zipkin` translator: Handle missing starttime case for zipkin json v2 format spans (#2506)
 
 ## v0.22.0 Beta
 

--- a/translator/trace/zipkin/zipkinv2_to_traces.go
+++ b/translator/trace/zipkin/zipkinv2_to_traces.go
@@ -436,7 +436,7 @@ func setTimestampsIfUnset2(span pdata.Span, destAttrs pdata.AttributeMap) {
 	// zipkin allows timestamp to be unset, but opentelemetry-collector expects it to have a value.
 	// unset gets converted to zero somewhere along the way.  If timestamp is unset,
 	// the conversion from this internal format back to zipkin format in zipkin exporter fails
-	if span.StartTime().AsTime().IsZero() {
+	if span.StartTime().AsTime().Unix() <= 0 {
 		now := pdata.TimestampFromTime(time.Now())
 		span.SetStartTime(now)
 		span.SetEndTime(now)

--- a/translator/trace/zipkin/zipkinv2_to_traces_test.go
+++ b/translator/trace/zipkin/zipkinv2_to_traces_test.go
@@ -15,6 +15,7 @@
 package zipkin
 
 import (
+	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
 	"testing"
 	"time"
 
@@ -162,4 +163,59 @@ func generateTraceSingleSpanErrorStatus() pdata.Traces {
 	span.Attributes().InitEmptyWithCapacity(0)
 	span.Status().SetCode(pdata.StatusCodeError)
 	return td
+}
+
+func TestV2SpanWithoutTimestampGetsTag(t *testing.T) {
+	testStart := time.Now()
+	spans := make([]*zipkinmodel.SpanModel, 1)
+	spans[0] = &zipkinmodel.SpanModel{
+		SpanContext: zipkinmodel.SpanContext{
+			TraceID: convertTraceID(
+				pdata.NewTraceID([16]byte{0xF1, 0xF2, 0xF3, 0xF4, 0xF5, 0xF6, 0xF7, 0xF8, 0xF9, 0xFA, 0xFB, 0xFC, 0xFD, 0xFE, 0xFF, 0x80})),
+			ID: convertSpanID(pdata.NewSpanID([8]byte{0xAF, 0xAE, 0xAD, 0xAC, 0xAB, 0xAA, 0xA9, 0xA8})),
+		},
+		Name:           "MinimalData",
+		Kind:           zipkinmodel.Client,
+		Duration:       1000000,
+		Shared:         false,
+		LocalEndpoint:  nil,
+		RemoteEndpoint: nil,
+		Annotations:    nil,
+		Tags:           nil,
+	}
+
+	//testStartTimestamp := pdata.TimestampFromTime(testStart)
+
+	gb, err := V2SpansToInternalTraces(spans, false)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+		return
+	}
+
+	gs := gb.ResourceSpans().At(0).InstrumentationLibrarySpans().At(0).Spans().At(0)
+	assert.NotNil(t, gs.StartTime)
+	assert.NotNil(t, gs.EndTime)
+	println("output span starttime")
+	println(gs.StartTime())
+
+	println("test starttime")
+	println(testStart.UnixNano())
+
+	//timediff := gs.StartTime() - testStartTimestamp
+	timediff := gs.StartTime().AsTime().Sub(testStart)
+	println("time diff")
+	println(timediff)
+	assert.True(t, timediff >= 0)
+
+	wantAttributes := &tracepb.Span_Attributes{
+		AttributeMap: map[string]*tracepb.AttributeValue{
+			StartTimeAbsent: {
+				Value: &tracepb.AttributeValue_BoolValue{
+					BoolValue: true,
+				},
+			},
+		},
+	}
+
+	assert.EqualValues(t, gs.Attributes, wantAttributes)
 }


### PR DESCRIPTION


**Description:**
Fixing a bug - As outlined in the submitted issue, otel-collector previously fixed an issue with zipkin json_v1 formatted spans not containing a startTimestamp.  This fixes the same case for zipkin json_v2 format.

**Link to tracking Issue:**
https://github.com/open-telemetry/opentelemetry-collector/issues/2506

**Testing:**
added a unit test around the new method, similar to the one already in place for zipkin json_v1 handling.

**Documentation:**
added changelog entry only, as this is a bug fix.