### PR TITLE
Handle missing starttime case for zipkin json v2 format spans (#2506)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- `zipkin` translator: Handle missing starttime case for zipkin json v2 format spans (#2506)
+
 ## 🛑 Breaking changes 🛑
 
 ## 💡 Enhancements 💡

--- a/translator/trace/zipkin/testdata/zipkin_v2_notimestamp.json
+++ b/translator/trace/zipkin/testdata/zipkin_v2_notimestamp.json
@@ -1,0 +1,65 @@
+[{
+  "traceId": "13c3518297c3b59f",
+  "id": "c698c56b63c5f5cb",
+  "name": "http:/parent/resource/abc",
+  "parentId": "62a165c66951ced3",
+  "annotations": [
+    {
+      "timestamp": 1615821510040000,
+      "value": "sr",
+      "endpoint": {
+        "serviceName": "baz",
+        "ipv4": "10.254.85.134",
+        "port": 8080
+      }
+    },
+    {
+      "timestamp": 1615821510041000,
+      "value": "ss",
+      "endpoint": {
+        "serviceName": "baz",
+        "ipv4": "10.254.85.134",
+        "port": 8080
+      }
+    }
+  ],
+  "binaryAnnotations": [
+    {
+      "key": "http.host",
+      "value": "10.3.32.70",
+      "endpoint": {
+        "serviceName": "baz",
+        "ipv4": "10.254.85.134",
+        "port": 8080
+      }
+    },
+    {
+      "key": "http.method",
+      "value": "GET",
+      "endpoint": {
+        "serviceName": "baz",
+        "ipv4": "10.254.85.134",
+        "port": 8080
+      }
+    },
+    {
+      "key": "http.path",
+      "value": "/resource/abc",
+      "endpoint": {
+        "serviceName": "baz",
+        "ipv4": "10.254.85.134",
+        "port": 8080
+      }
+    },
+    {
+      "key": "http.url",
+      "value": "http://10.3.32.70:32059/resource/abc?foo=bar",
+      "endpoint": {
+        "serviceName": "baz",
+        "ipv4": "10.254.85.134",
+        "port": 8080
+      }
+    }
+  ]
+}
+]

--- a/translator/trace/zipkin/traces_to_zipkinv2.go
+++ b/translator/trace/zipkin/traces_to_zipkinv2.go
@@ -121,7 +121,17 @@ func spanToZipkinSpan(
 
 	zs.Sampled = &sampled
 	zs.Name = span.Name()
-	zs.Timestamp = span.StartTimestamp().AsTime()
+	startTime := span.StartTimestamp().AsTime()
+
+	// leave timestamp unset on zs (zipkin span) if
+	// otel span startTime is zero.  Zipkin has a
+	// case where startTime is not set on the span.
+	// See handling of this (and setting of otel span
+	// to unix time zero) in zipkinv2_to_traces.go
+	if startTime.Unix() != 0 {
+		zs.Timestamp = startTime
+	}
+
 	if span.EndTimestamp() != 0 {
 		zs.Duration = time.Duration(span.EndTimestamp() - span.StartTimestamp())
 	}

--- a/translator/trace/zipkin/zipkinv2_to_traces.go
+++ b/translator/trace/zipkin/zipkinv2_to_traces.go
@@ -21,6 +21,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	zipkinmodel "github.com/openzipkin/zipkin-go/model"
 
@@ -133,8 +134,6 @@ func zSpanToInternal(zspan *zipkinmodel.SpanModel, tags map[string]string, dest 
 	}
 
 	dest.SetName(zspan.Name)
-	dest.SetStartTimestamp(pdata.TimestampFromTime(zspan.Timestamp))
-	dest.SetEndTimestamp(pdata.TimestampFromTime(zspan.Timestamp.Add(zspan.Duration)))
 	dest.SetKind(zipkinKindToSpanKind(zspan.Kind, tags))
 
 	populateSpanStatus(tags, dest.Status())
@@ -148,6 +147,8 @@ func zSpanToInternal(zspan *zipkinmodel.SpanModel, tags map[string]string, dest 
 	if err := zTagsToInternalAttrs(zspan, tags, attrs, parseStringTags); err != nil {
 		return err
 	}
+
+	setTimestampsV2(zspan, dest, attrs)
 
 	err := populateSpanEvents(zspan, dest.Events())
 	return err
@@ -428,4 +429,23 @@ func extractInstrumentationLibrary(zspan *zipkinmodel.SpanModel) string {
 		return ""
 	}
 	return zspan.Tags[conventions.InstrumentationLibraryName]
+}
+
+func setTimestampsV2(zspan *zipkinmodel.SpanModel, dest pdata.Span, destAttrs pdata.AttributeMap) {
+	// zipkin allows timestamp to be unset, but otel span expects startTimestamp to have a value.
+	// unset gets converted to zero on the zspan object during json deserialization because
+	// time.Time (the type of Timestamp field) cannot be nil.  If timestamp is zero, the
+	// conversion from this internal format back to zipkin format in zipkin exporter fails.
+	// Instead, set to *unix* time zero, and convert back in traces_to_zipkinv2.go
+	if zspan.Timestamp.IsZero() {
+		unixTimeZero := pdata.TimestampFromTime(time.Unix(0, 0))
+		zeroPlusDuration := pdata.TimestampFromTime(time.Unix(0, 0).Add(zspan.Duration))
+		dest.SetStartTimestamp(unixTimeZero)
+		dest.SetEndTimestamp(zeroPlusDuration)
+
+		destAttrs.InsertBool(startTimeAbsent, true)
+	} else {
+		dest.SetStartTimestamp(pdata.TimestampFromTime(zspan.Timestamp))
+		dest.SetEndTimestamp(pdata.TimestampFromTime(zspan.Timestamp.Add(zspan.Duration)))
+	}
 }

--- a/translator/trace/zipkin/zipkinv2_to_traces_test.go
+++ b/translator/trace/zipkin/zipkinv2_to_traces_test.go
@@ -160,3 +160,44 @@ func generateTraceSingleSpanErrorStatus() pdata.Traces {
 	span.Status().SetCode(pdata.StatusCodeError)
 	return td
 }
+
+func TestV2SpanWithoutTimestampGetsTag(t *testing.T) {
+	duration := int64(2948533333)
+	spans := make([]*zipkinmodel.SpanModel, 1)
+	spans[0] = &zipkinmodel.SpanModel{
+		SpanContext: zipkinmodel.SpanContext{
+			TraceID: convertTraceID(
+				pdata.NewTraceID([16]byte{0xF1, 0xF2, 0xF3, 0xF4, 0xF5, 0xF6, 0xF7, 0xF8, 0xF9, 0xFA, 0xFB, 0xFC, 0xFD, 0xFE, 0xFF, 0x80})),
+			ID: convertSpanID(pdata.NewSpanID([8]byte{0xAF, 0xAE, 0xAD, 0xAC, 0xAB, 0xAA, 0xA9, 0xA8})),
+		},
+		Name:           "NoTimestamps",
+		Kind:           zipkinmodel.Client,
+		Duration:       time.Duration(duration),
+		Shared:         false,
+		LocalEndpoint:  nil,
+		RemoteEndpoint: nil,
+		Annotations:    nil,
+		Tags:           nil,
+	}
+
+	gb, err := V2SpansToInternalTraces(spans, false)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+		return
+	}
+
+	gs := gb.ResourceSpans().At(0).InstrumentationLibrarySpans().At(0).Spans().At(0)
+	assert.NotNil(t, gs.StartTimestamp)
+	assert.NotNil(t, gs.EndTimestamp)
+
+	// expect starttime to be set to zero (unix time)
+	unixTime := gs.StartTimestamp().AsTime().Unix()
+	assert.Equal(t, int64(0), unixTime)
+
+	// expect end time to be zero (unix time) plus the duration
+	assert.Equal(t, duration, gs.EndTimestamp().AsTime().UnixNano())
+
+	wasAbsent, mapContainedKey := gs.Attributes().Get(startTimeAbsent)
+	assert.True(t, mapContainedKey)
+	assert.True(t, wasAbsent.BoolVal())
+}


### PR DESCRIPTION
**Description:**
Fixing a bug - As outlined in the submitted issue, otel-collector previously fixed an issue with zipkin json_v1 formatted spans not containing a startTimestamp. This fixes the same case for zipkin json_v2 format.

**Link to tracking Issue:**
https://github.com/open-telemetry/opentelemetry-collector/issues/2506

**Testing:**
added a unit test around the new method, similar to the one already in place for zipkin json_v1 handling.

**Documentation:**
added changelog entry only, as this is a bug fix.
