### PR TITLE
Use otlp request in wrapper, hide members in the wrapper

### DIFF
--- a/exporter/fileexporter/file_exporter.go
+++ b/exporter/fileexporter/file_exporter.go
@@ -25,7 +25,6 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/internal"
-	otlplogs "go.opentelemetry.io/collector/internal/data/protogen/collector/logs/v1"
 	otlpmetrics "go.opentelemetry.io/collector/internal/data/protogen/collector/metrics/v1"
 	otlptrace "go.opentelemetry.io/collector/internal/data/protogen/collector/trace/v1"
 )
@@ -55,10 +54,8 @@ func (e *fileExporter) ConsumeMetrics(_ context.Context, md pdata.Metrics) error
 }
 
 func (e *fileExporter) ConsumeLogs(_ context.Context, ld pdata.Logs) error {
-	request := otlplogs.ExportLogsServiceRequest{
-		ResourceLogs: internal.LogsToOtlp(ld.InternalRep()),
-	}
-	return exportMessageAsLine(e, &request)
+	request := internal.LogsToOtlp(ld.InternalRep())
+	return exportMessageAsLine(e, request)
 }
 
 func exportMessageAsLine(e *fileExporter, message proto.Message) error {

--- a/exporter/fileexporter/file_exporter_test.go
+++ b/exporter/fileexporter/file_exporter_test.go
@@ -73,105 +73,109 @@ func TestFileLogsExporterNoErrors(t *testing.T) {
 	require.NotNil(t, exporter)
 
 	now := time.Now()
-	ld := []*logspb.ResourceLogs{
-		{
-			Resource: otresourcepb.Resource{
-				Attributes: []otlpcommon.KeyValue{
-					{
-						Key:   "attr1",
-						Value: otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_StringValue{StringValue: "value1"}},
-					},
-				},
-			},
-			InstrumentationLibraryLogs: []*logspb.InstrumentationLibraryLogs{
-				{
-					Logs: []*logspb.LogRecord{
+	otlp := &collectorlogs.ExportLogsServiceRequest{
+		ResourceLogs: []*logspb.ResourceLogs{
+			{
+				Resource: otresourcepb.Resource{
+					Attributes: []otlpcommon.KeyValue{
 						{
-							TimeUnixNano: uint64(now.UnixNano()),
-							Name:         "logA",
-						},
-						{
-							TimeUnixNano: uint64(now.UnixNano()),
-							Name:         "logB",
+							Key:   "attr1",
+							Value: otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_StringValue{StringValue: "value1"}},
 						},
 					},
 				},
-			},
-		},
-		{
-			Resource: otresourcepb.Resource{
-				Attributes: []otlpcommon.KeyValue{
+				InstrumentationLibraryLogs: []*logspb.InstrumentationLibraryLogs{
 					{
-						Key:   "attr2",
-						Value: otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_StringValue{StringValue: "value2"}},
+						Logs: []*logspb.LogRecord{
+							{
+								TimeUnixNano: uint64(now.UnixNano()),
+								Name:         "logA",
+							},
+							{
+								TimeUnixNano: uint64(now.UnixNano()),
+								Name:         "logB",
+							},
+						},
 					},
 				},
 			},
-			InstrumentationLibraryLogs: []*logspb.InstrumentationLibraryLogs{
-				{
-					Logs: []*logspb.LogRecord{
+			{
+				Resource: otresourcepb.Resource{
+					Attributes: []otlpcommon.KeyValue{
 						{
-							TimeUnixNano: uint64(now.UnixNano()),
-							Name:         "logC",
+							Key:   "attr2",
+							Value: otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_StringValue{StringValue: "value2"}},
+						},
+					},
+				},
+				InstrumentationLibraryLogs: []*logspb.InstrumentationLibraryLogs{
+					{
+						Logs: []*logspb.LogRecord{
+							{
+								TimeUnixNano: uint64(now.UnixNano()),
+								Name:         "logC",
+							},
 						},
 					},
 				},
 			},
 		},
 	}
-	assert.NoError(t, exporter.ConsumeLogs(context.Background(), pdata.LogsFromInternalRep(internal.LogsFromOtlp(ld))))
+	assert.NoError(t, exporter.ConsumeLogs(context.Background(), pdata.LogsFromInternalRep(internal.LogsFromOtlp(otlp))))
 	assert.NoError(t, exporter.Shutdown(context.Background()))
 
 	var unmarshaler = &jsonpb.Unmarshaler{}
 	var j collectorlogs.ExportLogsServiceRequest
 
 	assert.NoError(t, unmarshaler.Unmarshal(mf, &j))
-	assert.EqualValues(t, ld, j.ResourceLogs)
+	assert.EqualValues(t, otlp.ResourceLogs, j.ResourceLogs)
 }
 
 func TestFileLogsExporterErrors(t *testing.T) {
 
 	now := time.Now()
-	ld := []*logspb.ResourceLogs{
-		{
-			Resource: otresourcepb.Resource{
-				Attributes: []otlpcommon.KeyValue{
-					{
-						Key:   "attr1",
-						Value: otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_StringValue{StringValue: "value1"}},
-					},
-				},
-			},
-			InstrumentationLibraryLogs: []*logspb.InstrumentationLibraryLogs{
-				{
-					Logs: []*logspb.LogRecord{
+	otlp := &collectorlogs.ExportLogsServiceRequest{
+		ResourceLogs: []*logspb.ResourceLogs{
+			{
+				Resource: otresourcepb.Resource{
+					Attributes: []otlpcommon.KeyValue{
 						{
-							TimeUnixNano: uint64(now.UnixNano()),
-							Name:         "logA",
-						},
-						{
-							TimeUnixNano: uint64(now.UnixNano()),
-							Name:         "logB",
+							Key:   "attr1",
+							Value: otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_StringValue{StringValue: "value1"}},
 						},
 					},
 				},
-			},
-		},
-		{
-			Resource: otresourcepb.Resource{
-				Attributes: []otlpcommon.KeyValue{
+				InstrumentationLibraryLogs: []*logspb.InstrumentationLibraryLogs{
 					{
-						Key:   "attr2",
-						Value: otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_StringValue{StringValue: "value2"}},
+						Logs: []*logspb.LogRecord{
+							{
+								TimeUnixNano: uint64(now.UnixNano()),
+								Name:         "logA",
+							},
+							{
+								TimeUnixNano: uint64(now.UnixNano()),
+								Name:         "logB",
+							},
+						},
 					},
 				},
 			},
-			InstrumentationLibraryLogs: []*logspb.InstrumentationLibraryLogs{
-				{
-					Logs: []*logspb.LogRecord{
+			{
+				Resource: otresourcepb.Resource{
+					Attributes: []otlpcommon.KeyValue{
 						{
-							TimeUnixNano: uint64(now.UnixNano()),
-							Name:         "logC",
+							Key:   "attr2",
+							Value: otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_StringValue{StringValue: "value2"}},
+						},
+					},
+				},
+				InstrumentationLibraryLogs: []*logspb.InstrumentationLibraryLogs{
+					{
+						Logs: []*logspb.LogRecord{
+							{
+								TimeUnixNano: uint64(now.UnixNano()),
+								Name:         "logC",
+							},
 						},
 					},
 				},
@@ -210,7 +214,7 @@ func TestFileLogsExporterErrors(t *testing.T) {
 			exporter := &fileExporter{file: mf}
 			require.NotNil(t, exporter)
 
-			assert.Error(t, exporter.ConsumeLogs(context.Background(), pdata.LogsFromInternalRep(internal.LogsFromOtlp(ld))))
+			assert.Error(t, exporter.ConsumeLogs(context.Background(), pdata.LogsFromInternalRep(internal.LogsFromOtlp(otlp))))
 			assert.NoError(t, exporter.Shutdown(context.Background()))
 		})
 	}

--- a/exporter/otlpexporter/otlp.go
+++ b/exporter/otlpexporter/otlp.go
@@ -85,10 +85,8 @@ func (e *exporterImp) pushMetricsData(ctx context.Context, md pdata.Metrics) err
 	return nil
 }
 
-func (e *exporterImp) pushLogData(ctx context.Context, logs pdata.Logs) error {
-	request := &otlplogs.ExportLogsServiceRequest{
-		ResourceLogs: internal.LogsToOtlp(logs.InternalRep()),
-	}
+func (e *exporterImp) pushLogData(ctx context.Context, ld pdata.Logs) error {
+	request := internal.LogsToOtlp(ld.InternalRep())
 	if err := e.w.exportLogs(ctx, request); err != nil {
 		return fmt.Errorf("failed to push log data via OTLP exporter: %w", err)
 	}

--- a/exporter/otlpexporter/otlp_test.go
+++ b/exporter/otlpexporter/otlp_test.go
@@ -33,6 +33,7 @@ import (
 	"go.opentelemetry.io/collector/config/configgrpc"
 	"go.opentelemetry.io/collector/config/configtls"
 	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.opentelemetry.io/collector/internal"
 	otlplogs "go.opentelemetry.io/collector/internal/data/protogen/collector/logs/v1"
 	otlpmetrics "go.opentelemetry.io/collector/internal/data/protogen/collector/metrics/v1"
 	otlptraces "go.opentelemetry.io/collector/internal/data/protogen/collector/trace/v1"
@@ -515,10 +516,7 @@ func TestSendLogData(t *testing.T) {
 
 	// A request with 2 log entries.
 	td = testdata.GenerateLogDataTwoLogsSameResource()
-
-	expectedOTLPReq := &otlplogs.ExportLogsServiceRequest{
-		ResourceLogs: testdata.GenerateLogOtlpSameResourceTwoLogs(),
-	}
+	expectedOTLPReq := internal.LogsToOtlp(td.Clone().InternalRep())
 
 	err = exp.ConsumeLogs(context.Background(), td)
 	assert.NoError(t, err)

--- a/internal/otlp_wrapper.go
+++ b/internal/otlp_wrapper.go
@@ -14,19 +14,21 @@
 
 package internal
 
-import otlplogs "go.opentelemetry.io/collector/internal/data/protogen/logs/v1"
+import (
+	otlpcollectorlog "go.opentelemetry.io/collector/internal/data/protogen/collector/logs/v1"
+)
 
-// OtlpLogsWrapper is an intermediary struct that is declared in an internal package
+// LogsWrapper is an intermediary struct that is declared in an internal package
 // as a way to prevent certain functions of pdata.Logs data type to be callable by
 // any code outside of this module.
-type OtlpLogsWrapper struct {
-	Orig *[]*otlplogs.ResourceLogs
+type LogsWrapper struct {
+	req *otlpcollectorlog.ExportLogsServiceRequest
 }
 
-func LogsToOtlp(l OtlpLogsWrapper) []*otlplogs.ResourceLogs {
-	return *l.Orig
+func LogsToOtlp(l LogsWrapper) *otlpcollectorlog.ExportLogsServiceRequest {
+	return l.req
 }
 
-func LogsFromOtlp(logs []*otlplogs.ResourceLogs) OtlpLogsWrapper {
-	return OtlpLogsWrapper{Orig: &logs}
+func LogsFromOtlp(req *otlpcollectorlog.ExportLogsServiceRequest) LogsWrapper {
+	return LogsWrapper{req: req}
 }

--- a/internal/testdata/log.go
+++ b/internal/testdata/log.go
@@ -19,6 +19,7 @@ import (
 
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/internal/data"
+	otlpcollectorlog "go.opentelemetry.io/collector/internal/data/protogen/collector/logs/v1"
 	otlpcommon "go.opentelemetry.io/collector/internal/data/protogen/common/v1"
 	otlplogs "go.opentelemetry.io/collector/internal/data/protogen/logs/v1"
 )
@@ -33,8 +34,8 @@ func GenerateLogDataEmpty() pdata.Logs {
 	return ld
 }
 
-func generateLogOtlpEmpty() []*otlplogs.ResourceLogs {
-	return []*otlplogs.ResourceLogs(nil)
+func generateLogOtlpEmpty() *otlpcollectorlog.ExportLogsServiceRequest {
+	return &otlpcollectorlog.ExportLogsServiceRequest{}
 }
 
 func GenerateLogDataOneEmptyResourceLogs() pdata.Logs {
@@ -43,9 +44,11 @@ func GenerateLogDataOneEmptyResourceLogs() pdata.Logs {
 	return ld
 }
 
-func generateLogOtlpOneEmptyResourceLogs() []*otlplogs.ResourceLogs {
-	return []*otlplogs.ResourceLogs{
-		{},
+func generateLogOtlpOneEmptyResourceLogs() *otlpcollectorlog.ExportLogsServiceRequest {
+	return &otlpcollectorlog.ExportLogsServiceRequest{
+		ResourceLogs: []*otlplogs.ResourceLogs{
+			{},
+		},
 	}
 }
 
@@ -56,10 +59,12 @@ func GenerateLogDataNoLogRecords() pdata.Logs {
 	return ld
 }
 
-func generateLogOtlpNoLogRecords() []*otlplogs.ResourceLogs {
-	return []*otlplogs.ResourceLogs{
-		{
-			Resource: generateOtlpResource1(),
+func generateLogOtlpNoLogRecords() *otlpcollectorlog.ExportLogsServiceRequest {
+	return &otlpcollectorlog.ExportLogsServiceRequest{
+		ResourceLogs: []*otlplogs.ResourceLogs{
+			{
+				Resource: generateOtlpResource1(),
+			},
 		},
 	}
 }
@@ -72,14 +77,16 @@ func GenerateLogDataOneEmptyLogs() pdata.Logs {
 	return ld
 }
 
-func generateLogOtlpOneEmptyLogs() []*otlplogs.ResourceLogs {
-	return []*otlplogs.ResourceLogs{
-		{
-			Resource: generateOtlpResource1(),
-			InstrumentationLibraryLogs: []*otlplogs.InstrumentationLibraryLogs{
-				{
-					Logs: []*otlplogs.LogRecord{
-						{},
+func generateLogOtlpOneEmptyLogs() *otlpcollectorlog.ExportLogsServiceRequest {
+	return &otlpcollectorlog.ExportLogsServiceRequest{
+		ResourceLogs: []*otlplogs.ResourceLogs{
+			{
+				Resource: generateOtlpResource1(),
+				InstrumentationLibraryLogs: []*otlplogs.InstrumentationLibraryLogs{
+					{
+						Logs: []*otlplogs.LogRecord{
+							{},
+						},
 					},
 				},
 			},
@@ -97,13 +104,15 @@ func GenerateLogDataOneLogNoResource() pdata.Logs {
 	return ld
 }
 
-func generateLogOtlpOneLogNoResource() []*otlplogs.ResourceLogs {
-	return []*otlplogs.ResourceLogs{
-		{
-			InstrumentationLibraryLogs: []*otlplogs.InstrumentationLibraryLogs{
-				{
-					Logs: []*otlplogs.LogRecord{
-						generateOtlpLogOne(),
+func generateLogOtlpOneLogNoResource() *otlpcollectorlog.ExportLogsServiceRequest {
+	return &otlpcollectorlog.ExportLogsServiceRequest{
+		ResourceLogs: []*otlplogs.ResourceLogs{
+			{
+				InstrumentationLibraryLogs: []*otlplogs.InstrumentationLibraryLogs{
+					{
+						Logs: []*otlplogs.LogRecord{
+							generateOtlpLogOne(),
+						},
 					},
 				},
 			},
@@ -121,14 +130,16 @@ func GenerateLogDataOneLog() pdata.Logs {
 	return ld
 }
 
-func generateLogOtlpOneLog() []*otlplogs.ResourceLogs {
-	return []*otlplogs.ResourceLogs{
-		{
-			Resource: generateOtlpResource1(),
-			InstrumentationLibraryLogs: []*otlplogs.InstrumentationLibraryLogs{
-				{
-					Logs: []*otlplogs.LogRecord{
-						generateOtlpLogOne(),
+func generateLogOtlpOneLog() *otlpcollectorlog.ExportLogsServiceRequest {
+	return &otlpcollectorlog.ExportLogsServiceRequest{
+		ResourceLogs: []*otlplogs.ResourceLogs{
+			{
+				Resource: generateOtlpResource1(),
+				InstrumentationLibraryLogs: []*otlplogs.InstrumentationLibraryLogs{
+					{
+						Logs: []*otlplogs.LogRecord{
+							generateOtlpLogOne(),
+						},
 					},
 				},
 			},
@@ -146,16 +157,18 @@ func GenerateLogDataTwoLogsSameResource() pdata.Logs {
 	return ld
 }
 
-// GenerateLogOtlpSameResourceTwologs returns the OTLP representation of the GenerateLogOtlpSameResourceTwologs.
-func GenerateLogOtlpSameResourceTwoLogs() []*otlplogs.ResourceLogs {
-	return []*otlplogs.ResourceLogs{
-		{
-			Resource: generateOtlpResource1(),
-			InstrumentationLibraryLogs: []*otlplogs.InstrumentationLibraryLogs{
-				{
-					Logs: []*otlplogs.LogRecord{
-						generateOtlpLogOne(),
-						generateOtlpLogTwo(),
+// generateLogOtlpSameResourceTwologs returns the OTLP representation of the GenerateLogOtlpSameResourceTwologs.
+func generateLogOtlpSameResourceTwoLogs() *otlpcollectorlog.ExportLogsServiceRequest {
+	return &otlpcollectorlog.ExportLogsServiceRequest{
+		ResourceLogs: []*otlplogs.ResourceLogs{
+			{
+				Resource: generateOtlpResource1(),
+				InstrumentationLibraryLogs: []*otlplogs.InstrumentationLibraryLogs{
+					{
+						Logs: []*otlplogs.LogRecord{
+							generateOtlpLogOne(),
+							generateOtlpLogTwo(),
+						},
 					},
 				},
 			},
@@ -180,25 +193,27 @@ func GenerateLogDataTwoLogsSameResourceOneDifferent() pdata.Logs {
 	return ld
 }
 
-func generateLogOtlpTwoLogsSameResourceOneDifferent() []*otlplogs.ResourceLogs {
-	return []*otlplogs.ResourceLogs{
-		{
-			Resource: generateOtlpResource1(),
-			InstrumentationLibraryLogs: []*otlplogs.InstrumentationLibraryLogs{
-				{
-					Logs: []*otlplogs.LogRecord{
-						generateOtlpLogOne(),
-						generateOtlpLogTwo(),
+func generateLogOtlpTwoLogsSameResourceOneDifferent() *otlpcollectorlog.ExportLogsServiceRequest {
+	return &otlpcollectorlog.ExportLogsServiceRequest{
+		ResourceLogs: []*otlplogs.ResourceLogs{
+			{
+				Resource: generateOtlpResource1(),
+				InstrumentationLibraryLogs: []*otlplogs.InstrumentationLibraryLogs{
+					{
+						Logs: []*otlplogs.LogRecord{
+							generateOtlpLogOne(),
+							generateOtlpLogTwo(),
+						},
 					},
 				},
 			},
-		},
-		{
-			Resource: generateOtlpResource2(),
-			InstrumentationLibraryLogs: []*otlplogs.InstrumentationLibraryLogs{
-				{
-					Logs: []*otlplogs.LogRecord{
-						generateOtlpLogThree(),
+			{
+				Resource: generateOtlpResource2(),
+				InstrumentationLibraryLogs: []*otlplogs.InstrumentationLibraryLogs{
+					{
+						Logs: []*otlplogs.LogRecord{
+							generateOtlpLogThree(),
+						},
 					},
 				},
 			},

--- a/internal/testdata/log_test.go
+++ b/internal/testdata/log_test.go
@@ -21,13 +21,13 @@ import (
 
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/internal"
-	otlplogs "go.opentelemetry.io/collector/internal/data/protogen/logs/v1"
+	otlpcollectorlog "go.opentelemetry.io/collector/internal/data/protogen/collector/logs/v1"
 )
 
 type logTestCase struct {
 	name string
 	ld   pdata.Logs
-	otlp []*otlplogs.ResourceLogs
+	otlp *otlpcollectorlog.ExportLogsServiceRequest
 }
 
 func generateAllLogTestCases() []logTestCase {
@@ -65,7 +65,7 @@ func generateAllLogTestCases() []logTestCase {
 		{
 			name: "two-records-same-resource",
 			ld:   GenerateLogDataTwoLogsSameResource(),
-			otlp: GenerateLogOtlpSameResourceTwoLogs(),
+			otlp: generateLogOtlpSameResourceTwoLogs(),
 		},
 		{
 			name: "two-records-same-resource-one-different",

--- a/receiver/otlpreceiver/logs/otlp.go
+++ b/receiver/otlpreceiver/logs/otlp.go
@@ -54,7 +54,7 @@ func (r *Receiver) Export(ctx context.Context, req *collectorlog.ExportLogsServi
 	// We need to ensure that it propagates the receiver name as a tag
 	ctxWithReceiverName := obsreport.ReceiverContext(ctx, r.instanceName, receiverTransport)
 
-	ld := pdata.LogsFromInternalRep(internal.LogsFromOtlp(req.ResourceLogs))
+	ld := pdata.LogsFromInternalRep(internal.LogsFromOtlp(req))
 	err := r.sendToNextConsumer(ctxWithReceiverName, ld)
 	if err != nil {
 		return nil, err

--- a/testbed/testbed/data_providers.go
+++ b/testbed/testbed/data_providers.go
@@ -365,7 +365,7 @@ func NewFileDataProvider(filePath string, dataType configmodels.DataType) (*File
 		}
 		message = &msg
 
-		md := pdata.LogsFromInternalRep(internal.LogsFromOtlp(msg.ResourceLogs))
+		md := pdata.LogsFromInternalRep(internal.LogsFromOtlp(&msg))
 		dataPointCount = md.LogRecordCount()
 	}
 


### PR DESCRIPTION
Tested in contrib and was able to access InternalWrapper.Orig,
with this change this is no longer possible.

Also removes one extra allocation for the request object when 
using otlp receiver/exporter since we keep the initial pointer around.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
