### PR TITLE
Rename pdata.Logs.SizeBytes to Size, consistent with metrics/traces

### DIFF
--- a/consumer/pdata/log.go
+++ b/consumer/pdata/log.go
@@ -91,9 +91,8 @@ func (ld Logs) LogRecordCount() int {
 	return logCount
 }
 
-// SizeBytes returns the number of bytes in the internal representation of the
-// logs.
-func (ld Logs) SizeBytes() int {
+// Size returns the number of bytes in the internal representation of the logs.
+func (ld Logs) Size() int {
 	return ld.orig.Size()
 }
 

--- a/processor/batchprocessor/batch_processor.go
+++ b/processor/batchprocessor/batch_processor.go
@@ -340,7 +340,7 @@ func (bm *batchLogs) itemCount() uint32 {
 }
 
 func (bm *batchLogs) size() int {
-	return bm.logData.SizeBytes()
+	return bm.logData.Size()
 }
 
 // resets the current batchLogs structure with zero/empty values.

--- a/processor/batchprocessor/batch_processor_test.go
+++ b/processor/batchprocessor/batch_processor_test.go
@@ -558,7 +558,7 @@ func TestBatchLogProcessor_BatchSize(t *testing.T) {
 	size := 0
 	for requestNum := 0; requestNum < requestCount; requestNum++ {
 		ld := testdata.GenerateLogDataManyLogsSameResource(logsPerRequest)
-		size += ld.SizeBytes()
+		size += ld.Size()
 		assert.NoError(t, batcher.ConsumeLogs(context.Background(), ld))
 	}
 	require.NoError(t, batcher.Shutdown(context.Background()))


### PR DESCRIPTION
Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
