### PR TITLE
Sanitize prometheus labels

### DIFF
--- a/exporter/prometheusexporter/collector.go
+++ b/exporter/prometheusexporter/collector.go
@@ -87,7 +87,7 @@ func (c *collector) getMetricMetadata(metric pdata.Metric, labels pdata.StringMa
 	values := make([]string, 0, labels.Len())
 
 	labels.ForEach(func(k string, v string) {
-		keys = append(keys, k)
+		keys = append(keys, sanitize(k))
 		values = append(values, v)
 	})
 


### PR DESCRIPTION
This fixes #2700

**Description:** 

This fix allows the prometheus exporter to work with standard labels that follow the naming convention of using periods instead of underscores.

**Link to tracking Issue:**

https://github.com/open-telemetry/opentelemetry-collector/issues/2700

**Testing:**

I will add tests in a second commit

**Documentation:**

No additional documentation added, is it worth mentioning?
