### PR TITLE
If host.name value is present add it to resource labels

### DIFF
--- a/translator/internaldata/metrics_to_oc_test.go
+++ b/translator/internaldata/metrics_to_oc_test.go
@@ -32,6 +32,7 @@ import (
 func TestMetricsToOC(t *testing.T) {
 	sampleMetricData := testdata.GeneratMetricsAllTypesWithSampleDatapoints()
 	attrs := sampleMetricData.ResourceMetrics().At(0).Resource().Attributes()
+	attrs.Upsert(conventions.OCAttributeResourceType, pdata.NewAttributeValueString("host_test"))
 	attrs.Upsert(conventions.AttributeHostName, pdata.NewAttributeValueString("host1"))
 	attrs.Upsert(conventions.AttributeProcessID, pdata.NewAttributeValueInt(123))
 	attrs.Upsert(conventions.OCAttributeProcessStartTime, pdata.NewAttributeValueString("2020-02-11T20:26:00Z"))
@@ -168,9 +169,12 @@ func generateOCTestData() MetricsData {
 			},
 		},
 		Resource: &ocresource.Resource{
+			Type: "host_test",
 			Labels: map[string]string{
 				"resource-attr": "resource-attr-val-1",
+				conventions.AttributeHostName: "host1",
 			},
+		},
 		},
 		Metrics: []*ocmetrics.Metric{
 			generateOCTestMetricInt(),

--- a/translator/internaldata/oc_testdata_test.go
+++ b/translator/internaldata/oc_testdata_test.go
@@ -536,6 +536,7 @@ func generateOcResource() *ocresource.Resource {
 		Labels: map[string]string{
 			"resource-str-attr": "resource-str-attr-val",
 			"resource-int-attr": "123",
+			conventions.AttributeHostName: "host1",
 		},
 	}
 }

--- a/translator/internaldata/resource_to_oc.go
+++ b/translator/internaldata/resource_to_oc.go
@@ -104,6 +104,8 @@ func internalResourceToOC(resource pdata.Resource) (*occommon.Node, *ocresource.
 			getProcessIdentifier(ocNode).StartTimestamp = ts
 		case conventions.AttributeHostName:
 			getProcessIdentifier(ocNode).HostName = val
+			// Put the hostname in labels too
+			labels[k] = val
 		case conventions.AttributeProcessID:
 			pid, err := strconv.Atoi(val)
 			if err != nil {


### PR DESCRIPTION
**Description:**
I am proposing a change to resource translation (internal to OC). 
It is motivated by the bug in [stackdriverexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/stackdriverexporter), from the exporter perspective the `host.name` label is lost and the it is not exported by the pipeline.
I am proposing adding said label both to the node and resource labels.

**Testing:**
I've run unit tests for the changed library.
There seem to be so E2E failing tests, but I didn't debug them yet.
