### PR TITLE
Fix client_ca_file config section

### DIFF
--- a/config/configtls/README.md
+++ b/config/configtls/README.md
@@ -99,9 +99,9 @@ receivers:
   otlp/mtls:
     protocols:
       grpc:
-        client_ca_file: client.pem
         endpoint: mysite.local:55690
         tls_settings:
+          client_ca_file: client.pem
           cert_file: server.crt
           key_file: server.key
   otlp/notls:


### PR DESCRIPTION
**Description:**
Fixing example configuration bug. The `client_ca_file` option was under the wrong section.

**Testing:**
Ran locally. This config worked, previous did not.
