### PR TITLE
Avoid exposing internal types via type aliasing

### DIFF
--- a/consumer/pdata/common.go
+++ b/consumer/pdata/common.go
@@ -24,7 +24,7 @@ import (
 )
 
 // AttributeValueType specifies the type of AttributeValue.
-type AttributeValueType int
+type AttributeValueType int32
 
 const (
 	AttributeValueNULL AttributeValueType = iota

--- a/consumer/pdata/log.go
+++ b/consumer/pdata/log.go
@@ -101,7 +101,7 @@ func (ld Logs) ResourceLogs() ResourceLogsSlice {
 }
 
 // SeverityNumber is the public alias of otlplogs.SeverityNumber from internal package.
-type SeverityNumber otlplogs.SeverityNumber
+type SeverityNumber int32
 
 const (
 	SeverityNumberUNDEFINED = SeverityNumber(otlplogs.SeverityNumber_SEVERITY_NUMBER_UNSPECIFIED)
@@ -130,3 +130,5 @@ const (
 	SeverityNumberFATAL3    = SeverityNumber(otlplogs.SeverityNumber_SEVERITY_NUMBER_FATAL3)
 	SeverityNumberFATAL4    = SeverityNumber(otlplogs.SeverityNumber_SEVERITY_NUMBER_FATAL4)
 )
+
+func (sn SeverityNumber) String() string { return otlplogs.SeverityNumber(sn).String() }

--- a/consumer/pdata/metric.go
+++ b/consumer/pdata/metric.go
@@ -20,7 +20,7 @@ import (
 	otlpmetrics "go.opentelemetry.io/collector/internal/data/protogen/metrics/v1"
 )
 
-type AggregationTemporality otlpmetrics.AggregationTemporality
+type AggregationTemporality int32
 
 const (
 	AggregationTemporalityUnspecified = AggregationTemporality(otlpmetrics.AggregationTemporality_AGGREGATION_TEMPORALITY_UNSPECIFIED)
@@ -144,7 +144,7 @@ func (md Metrics) MetricAndDataPointCount() (metricCount int, dataPointCount int
 }
 
 // MetricDataType specifies the type of data in a Metric.
-type MetricDataType int
+type MetricDataType int32
 
 const (
 	MetricDataTypeNone MetricDataType = iota

--- a/consumer/pdata/trace.go
+++ b/consumer/pdata/trace.go
@@ -95,13 +95,13 @@ func (td Traces) ResourceSpans() ResourceSpansSlice {
 // TraceState in w3c-trace-context format: https://www.w3.org/TR/trace-context/#tracestate-header
 type TraceState string
 
-type SpanKind otlptrace.Span_SpanKind
-
-func (sk SpanKind) String() string { return otlptrace.Span_SpanKind(sk).String() }
-
 const (
 	TraceStateEmpty TraceState = ""
 )
+
+type SpanKind int32
+
+func (sk SpanKind) String() string { return otlptrace.Span_SpanKind(sk).String() }
 
 const (
 	SpanKindUNSPECIFIED = SpanKind(0)
@@ -114,7 +114,7 @@ const (
 
 // StatusCode mirrors the codes defined at
 // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#set-status
-type StatusCode otlptrace.Status_StatusCode
+type StatusCode int32
 
 const (
 	StatusCodeUnset = StatusCode(otlptrace.Status_STATUS_CODE_UNSET)


### PR DESCRIPTION
This is not the case right now (we are not using type aliasing, but type definition), but to avoid any possible future mistakes better to define the enums as `int32`. Also fixes other places where we define enums as int and change them to `int32` for consistency.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
