### PR TITLE
Doc typo

### DIFF
--- a/examples/demo/app/main.go
+++ b/examples/demo/app/main.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Sample contains a program that exports to the OpenCensus service.
+// Sample contains a program that exports to the OpenTelemetry service.
 package main
 
 import (


### PR DESCRIPTION
**Description:**
Doc typo, this confused me as I was looking for an opencensus receiver example, but this is instrumented in opentelemetry.