### PR TITLE
Tidy up `consumer/consumererror` package.

### DIFF
--- a/consumer/consumererror/combineerrors.go
+++ b/consumer/consumererror/combineerrors.go
@@ -20,6 +20,12 @@ import (
 )
 
 // CombineErrors converts a list of errors into one error.
+//
+// If any of the errors in errs are Permanent then the returned
+// error will also be Permanent.
+//
+// Any signal data associated with a PartialError will be discarded
+// and the resulting error will not be a PartialError.
 func CombineErrors(errs []error) error {
 	numErrors := len(errs)
 	if numErrors == 0 {

--- a/consumer/consumererror/partialerror.go
+++ b/consumer/consumererror/partialerror.go
@@ -30,9 +30,9 @@ type PartialError struct {
 	failedMetrics pdata.Metrics
 }
 
-// PartialTracesError creates a PartialError for failed traces.
+// PartialTraces creates a PartialError for failed traces.
 // Use this error type only when a subset of the received data failed to be processed or sent.
-func PartialTracesError(err error, failedTraces pdata.Traces) error {
+func PartialTraces(err error, failedTraces pdata.Traces) error {
 	return PartialError{
 		error:        err,
 		failedTraces: failedTraces,
@@ -44,9 +44,9 @@ func (err PartialError) GetTraces() pdata.Traces {
 	return err.failedTraces
 }
 
-// PartialLogsError creates a PartialError for failed logs.
+// PartialLogs creates a PartialError for failed logs.
 // Use this error type only when a subset of the received data failed to be processed or sent.
-func PartialLogsError(err error, failedLogs pdata.Logs) error {
+func PartialLogs(err error, failedLogs pdata.Logs) error {
 	return PartialError{
 		error:      err,
 		failedLogs: failedLogs,
@@ -58,9 +58,9 @@ func (err PartialError) GetLogs() pdata.Logs {
 	return err.failedLogs
 }
 
-// PartialMetricsError creates a PartialError for failed metrics.
+// PartialMetrics creates a PartialError for failed metrics.
 // Use this error type only when a subset of the received data failed to be processed or sent.
-func PartialMetricsError(err error, failedMetrics pdata.Metrics) error {
+func PartialMetrics(err error, failedMetrics pdata.Metrics) error {
 	return PartialError{
 		error:         err,
 		failedMetrics: failedMetrics,
@@ -74,8 +74,8 @@ func (err PartialError) GetMetrics() pdata.Metrics {
 
 // IsPartial checks if an error was wrapped with a PartialError.
 func IsPartial(err error) bool {
-	if err != nil {
-		return errors.As(err, &PartialError{})
+	if err == nil {
+		return false
 	}
-	return false
+	return errors.As(err, &PartialError{})
 }

--- a/consumer/consumererror/partialerror_test.go
+++ b/consumer/consumererror/partialerror_test.go
@@ -15,6 +15,7 @@
 package consumererror
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
@@ -23,10 +24,10 @@ import (
 	"go.opentelemetry.io/collector/internal/testdata"
 )
 
-func TestPartialError(t *testing.T) {
+func TestPartialErrorTraces(t *testing.T) {
 	td := testdata.GenerateTraceDataOneSpan()
 	err := fmt.Errorf("some error")
-	partialErr := PartialTracesError(err, td)
+	partialErr := PartialTraces(err, td)
 	assert.True(t, IsPartial(partialErr))
 	assert.Equal(t, err.Error(), partialErr.Error())
 	assert.Equal(t, td, partialErr.(PartialError).GetTraces())
@@ -35,7 +36,7 @@ func TestPartialError(t *testing.T) {
 func TestPartialErrorLogs(t *testing.T) {
 	td := testdata.GenerateLogDataOneLog()
 	err := fmt.Errorf("some error")
-	partialErr := PartialLogsError(err, td)
+	partialErr := PartialLogs(err, td)
 	assert.True(t, IsPartial(partialErr))
 	assert.Equal(t, err.Error(), partialErr.Error())
 	assert.Equal(t, td, partialErr.(PartialError).GetLogs())
@@ -44,7 +45,7 @@ func TestPartialErrorLogs(t *testing.T) {
 func TestPartialErrorMetrics(t *testing.T) {
 	td := testdata.GenerateMetricsOneMetric()
 	err := fmt.Errorf("some error")
-	partialErr := PartialMetricsError(err, td)
+	partialErr := PartialMetrics(err, td)
 	assert.True(t, IsPartial(partialErr))
 	assert.Equal(t, err.Error(), partialErr.Error())
 	assert.Equal(t, td, partialErr.(PartialError).GetMetrics())
@@ -52,4 +53,26 @@ func TestPartialErrorMetrics(t *testing.T) {
 
 func TestIsPartialNilInput(t *testing.T) {
 	assert.False(t, IsPartial(nil))
+}
+
+func BenchmarkIsPartialNil(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		IsPartial(nil)
+	}
+}
+
+func BenchmarkIsPartialFalse(b *testing.B) {
+	err := errors.New("Test error")
+	for n := 0; n < b.N; n++ {
+		IsPartial(err)
+	}
+}
+
+func BenchmarkIsPartialTrue(b *testing.B) {
+	td := testdata.GenerateTraceDataOneSpan()
+	err := fmt.Errorf("some error")
+	partialErr := PartialTraces(err, td)
+	for n := 0; n < b.N; n++ {
+		IsPartial(partialErr)
+	}
 }

--- a/consumer/consumererror/partialerror_test.go
+++ b/consumer/consumererror/partialerror_test.go
@@ -27,22 +27,29 @@ func TestPartialError(t *testing.T) {
 	td := testdata.GenerateTraceDataOneSpan()
 	err := fmt.Errorf("some error")
 	partialErr := PartialTracesError(err, td)
+	assert.True(t, IsPartial(partialErr))
 	assert.Equal(t, err.Error(), partialErr.Error())
-	assert.Equal(t, td, partialErr.(PartialError).failed)
+	assert.Equal(t, td, partialErr.(PartialError).GetTraces())
 }
 
 func TestPartialErrorLogs(t *testing.T) {
 	td := testdata.GenerateLogDataOneLog()
 	err := fmt.Errorf("some error")
 	partialErr := PartialLogsError(err, td)
+	assert.True(t, IsPartial(partialErr))
 	assert.Equal(t, err.Error(), partialErr.Error())
-	assert.Equal(t, td, partialErr.(PartialError).failedLogs)
+	assert.Equal(t, td, partialErr.(PartialError).GetLogs())
 }
 
 func TestPartialErrorMetrics(t *testing.T) {
 	td := testdata.GenerateMetricsOneMetric()
 	err := fmt.Errorf("some error")
 	partialErr := PartialMetricsError(err, td)
+	assert.True(t, IsPartial(partialErr))
 	assert.Equal(t, err.Error(), partialErr.Error())
-	assert.Equal(t, td, partialErr.(PartialError).failedMetrics)
+	assert.Equal(t, td, partialErr.(PartialError).GetMetrics())
+}
+
+func TestIsPartialNilInput(t *testing.T) {
+	assert.False(t, IsPartial(nil))
 }

--- a/consumer/consumererror/permanenterror.go
+++ b/consumer/consumererror/permanenterror.go
@@ -15,7 +15,7 @@
 // Package consumererror provides wrappers to easily classify errors. This allows
 // appropriate action by error handlers without the need to know each individual
 // error type/instance.
-package consumererror // import "go.opentelemetry.io/collector/consumer/consumererror"
+package consumererror
 
 import "errors"
 
@@ -39,8 +39,8 @@ func (p permanent) Error() string {
 // is used to indicate that a given error will always be returned in the case
 // that its sources receives the same input.
 func IsPermanent(err error) bool {
-	if err != nil {
-		return errors.As(err, &permanent{})
+	if err == nil {
+		return false
 	}
-	return false
+	return errors.As(err, &permanent{})
 }

--- a/consumer/consumererror/permanenterror.go
+++ b/consumer/consumererror/permanenterror.go
@@ -15,7 +15,7 @@
 // Package consumererror provides wrappers to easily classify errors. This allows
 // appropriate action by error handlers without the need to know each individual
 // error type/instance.
-package consumererror
+package consumererror // import "go.opentelemetry.io/collector/consumer/consumererror"
 
 import "errors"
 
@@ -24,9 +24,6 @@ import "errors"
 type permanent struct {
 	err error
 }
-
-// permanentError exists to test errors for "IsPermanent"
-var permanentError = &permanent{}
 
 // Permanent wraps an error to indicate that it is a permanent error, i.e.: an
 // error that will be always returned if its source receives the same inputs.
@@ -43,7 +40,7 @@ func (p permanent) Error() string {
 // that its sources receives the same input.
 func IsPermanent(err error) bool {
 	if err != nil {
-		return errors.As(err, permanentError)
+		return errors.As(err, &permanent{})
 	}
 	return false
 }

--- a/exporter/exporterhelper/logshelper_test.go
+++ b/exporter/exporterhelper/logshelper_test.go
@@ -48,7 +48,7 @@ var (
 func TestLogsRequest(t *testing.T) {
 	lr := newLogsRequest(context.Background(), testdata.GenerateLogDataOneLog(), nil)
 
-	partialErr := consumererror.PartialLogsError(errors.New("some error"), testdata.GenerateLogDataEmpty())
+	partialErr := consumererror.PartialLogs(errors.New("some error"), testdata.GenerateLogDataEmpty())
 	assert.EqualValues(
 		t,
 		newLogsRequest(context.Background(), testdata.GenerateLogDataEmpty(), nil),

--- a/exporter/exporterhelper/metricshelper_test.go
+++ b/exporter/exporterhelper/metricshelper_test.go
@@ -48,7 +48,7 @@ var (
 func TestMetricsRequest(t *testing.T) {
 	mr := newMetricsRequest(context.Background(), testdata.GenerateMetricsOneMetric(), nil)
 
-	partialErr := consumererror.PartialMetricsError(errors.New("some error"), testdata.GenerateMetricsEmpty())
+	partialErr := consumererror.PartialMetrics(errors.New("some error"), testdata.GenerateMetricsEmpty())
 	assert.EqualValues(
 		t,
 		newMetricsRequest(context.Background(), testdata.GenerateMetricsEmpty(), nil),

--- a/exporter/exporterhelper/queued_retry_test.go
+++ b/exporter/exporterhelper/queued_retry_test.go
@@ -92,7 +92,7 @@ func TestQueuedRetry_PartialError(t *testing.T) {
 		assert.NoError(t, be.Shutdown(context.Background()))
 	})
 
-	partialErr := consumererror.PartialTracesError(errors.New("some error"), testdata.GenerateTraceDataOneSpan())
+	partialErr := consumererror.PartialTraces(errors.New("some error"), testdata.GenerateTraceDataOneSpan())
 	mockR := newMockRequest(context.Background(), 2, partialErr)
 	ocs.run(func() {
 		// This is asynchronous so it should just enqueue, no errors expected.

--- a/exporter/exporterhelper/tracehelper_test.go
+++ b/exporter/exporterhelper/tracehelper_test.go
@@ -49,7 +49,7 @@ var (
 func TestTracesRequest(t *testing.T) {
 	mr := newTracesRequest(context.Background(), testdata.GenerateTraceDataOneSpan(), nil)
 
-	partialErr := consumererror.PartialTracesError(errors.New("some error"), testdata.GenerateTraceDataEmpty())
+	partialErr := consumererror.PartialTraces(errors.New("some error"), testdata.GenerateTraceDataEmpty())
 	assert.EqualValues(t, newTracesRequest(context.Background(), testdata.GenerateTraceDataEmpty(), nil), mr.onPartialError(partialErr.(consumererror.PartialError)))
 }
 


### PR DESCRIPTION
* Updated docblocks for grammar and consistency
* Added `IsPartial()` predicate to match `IsPermanent()`
* Ensured tests for `PartialError` test the public interface

Fixes #2476.