### PR TITLE
Allow multiple OTLP to be created

### DIFF
--- a/receiver/otlpreceiver/factory.go
+++ b/receiver/otlpreceiver/factory.go
@@ -121,7 +121,7 @@ func customUnmarshaler(componentViperSection *viper.Viper, intoCfg interface{}) 
 
 // CreateTracesReceiver creates a  trace receiver based on provided config.
 func createTraceReceiver(
-	ctx context.Context,
+	_ context.Context,
 	params component.ReceiverCreateParams,
 	cfg configmodels.Receiver,
 	nextConsumer consumer.TracesConsumer,
@@ -130,7 +130,7 @@ func createTraceReceiver(
 	if err != nil {
 		return nil, err
 	}
-	if err = r.registerTraceConsumer(ctx, nextConsumer); err != nil {
+	if err = r.registerTraceConsumer(nextConsumer); err != nil {
 		return nil, err
 	}
 	return r, nil
@@ -138,7 +138,7 @@ func createTraceReceiver(
 
 // CreateMetricsReceiver creates a metrics receiver based on provided config.
 func createMetricsReceiver(
-	ctx context.Context,
+	_ context.Context,
 	params component.ReceiverCreateParams,
 	cfg configmodels.Receiver,
 	consumer consumer.MetricsConsumer,
@@ -147,7 +147,7 @@ func createMetricsReceiver(
 	if err != nil {
 		return nil, err
 	}
-	if err = r.registerMetricsConsumer(ctx, consumer); err != nil {
+	if err = r.registerMetricsConsumer(consumer); err != nil {
 		return nil, err
 	}
 	return r, nil
@@ -155,7 +155,7 @@ func createMetricsReceiver(
 
 // CreateLogReceiver creates a log receiver based on provided config.
 func createLogReceiver(
-	ctx context.Context,
+	_ context.Context,
 	params component.ReceiverCreateParams,
 	cfg configmodels.Receiver,
 	consumer consumer.LogsConsumer,
@@ -164,7 +164,7 @@ func createLogReceiver(
 	if err != nil {
 		return nil, err
 	}
-	if err = r.registerLogsConsumer(ctx, consumer); err != nil {
+	if err = r.registerLogsConsumer(consumer); err != nil {
 		return nil, err
 	}
 	return r, nil

--- a/receiver/otlpreceiver/factory.go
+++ b/receiver/otlpreceiver/factory.go
@@ -121,7 +121,7 @@ func customUnmarshaler(componentViperSection *viper.Viper, intoCfg interface{}) 
 
 // CreateTracesReceiver creates a  trace receiver based on provided config.
 func createTraceReceiver(
-	_ context.Context,
+	ctx context.Context,
 	params component.ReceiverCreateParams,
 	cfg configmodels.Receiver,
 	nextConsumer consumer.TracesConsumer,
@@ -130,7 +130,7 @@ func createTraceReceiver(
 	if err != nil {
 		return nil, err
 	}
-	if err = r.registerTraceConsumer(nextConsumer); err != nil {
+	if err = r.registerTraceConsumer(ctx, nextConsumer); err != nil {
 		return nil, err
 	}
 	return r, nil
@@ -138,7 +138,7 @@ func createTraceReceiver(
 
 // CreateMetricsReceiver creates a metrics receiver based on provided config.
 func createMetricsReceiver(
-	_ context.Context,
+	ctx context.Context,
 	params component.ReceiverCreateParams,
 	cfg configmodels.Receiver,
 	consumer consumer.MetricsConsumer,
@@ -147,7 +147,7 @@ func createMetricsReceiver(
 	if err != nil {
 		return nil, err
 	}
-	if err = r.registerMetricsConsumer(consumer); err != nil {
+	if err = r.registerMetricsConsumer(ctx, consumer); err != nil {
 		return nil, err
 	}
 	return r, nil
@@ -155,7 +155,7 @@ func createMetricsReceiver(
 
 // CreateLogReceiver creates a log receiver based on provided config.
 func createLogReceiver(
-	_ context.Context,
+	ctx context.Context,
 	params component.ReceiverCreateParams,
 	cfg configmodels.Receiver,
 	consumer consumer.LogsConsumer,
@@ -164,7 +164,7 @@ func createLogReceiver(
 	if err != nil {
 		return nil, err
 	}
-	if err = r.registerLogsConsumer(consumer); err != nil {
+	if err = r.registerLogsConsumer(ctx, consumer); err != nil {
 		return nil, err
 	}
 	return r, nil
@@ -195,4 +195,6 @@ func createReceiver(cfg configmodels.Receiver, logger *zap.Logger) (*otlpReceive
 // We maintain this map because the Factory is asked trace and metric receivers separately
 // when it gets CreateTracesReceiver() and CreateMetricsReceiver() but they must not
 // create separate objects, they must use one otlpReceiver object per configuration.
+// When the receiver is shutdown it should be removed from this map so the same configuration
+// can be recreated successfully.
 var receivers = map[*Config]*otlpReceiver{}

--- a/receiver/otlpreceiver/otlp.go
+++ b/receiver/otlpreceiver/otlp.go
@@ -190,7 +190,9 @@ func (r *otlpReceiver) Shutdown(ctx context.Context) error {
 
 		r.shutdownWG.Wait()
 
-		// delete the receiver from the map.
+		// delete the receiver from the map so it doesn't leak and it becomes possible to create
+		// another instance with the same configuration that functions properly. Notice that an
+		// OTLP object can only be started and shutdown once.
 		delete(receivers, r.cfg)
 	})
 	return err

--- a/receiver/otlpreceiver/otlp.go
+++ b/receiver/otlpreceiver/otlp.go
@@ -126,7 +126,7 @@ func (r *otlpReceiver) startHTTPServer(cfg *confighttp.HTTPServerSettings, host 
 	return nil
 }
 
-func (r *otlpReceiver) startProtocolServers(_ context.Context, host component.Host) error {
+func (r *otlpReceiver) startProtocolServers(host component.Host) error {
 	var err error
 	if r.cfg.GRPC != nil {
 		err = r.startGRPCServer(r.cfg.GRPC, host)
@@ -162,14 +162,14 @@ func (r *otlpReceiver) startProtocolServers(_ context.Context, host component.Ho
 
 // Start runs the trace receiver on the gRPC server. Currently
 // it also enables the metrics receiver too.
-func (r *otlpReceiver) Start(ctx context.Context, host component.Host) error {
+func (r *otlpReceiver) Start(_ context.Context, host component.Host) error {
 	if r.traceReceiver == nil && r.metricsReceiver == nil && r.logReceiver == nil {
 		return errors.New("cannot start receiver: no consumers were specified")
 	}
 
 	var err error
 	r.startServerOnce.Do(func() {
-		err = r.startProtocolServers(ctx, host)
+		err = r.startProtocolServers(host)
 	})
 	return err
 }

--- a/receiver/otlpreceiver/otlp_test.go
+++ b/receiver/otlpreceiver/otlp_test.go
@@ -558,11 +558,9 @@ func TestReceiverLifecycle(t *testing.T) {
 	fstReceiver := newReceiver(t, factory, cfg, tracesSink, metricsSink)
 	mh := newAssertNoErrorHost(t)
 	require.NoError(t, fstReceiver.Start(context.Background(), mh))
-
-	sndReceiver := newReceiver(t, factory, cfg, tracesSink, metricsSink)
-
 	require.NoError(t, fstReceiver.Shutdown(context.Background()))
 
+	sndReceiver := newReceiver(t, factory, cfg, tracesSink, metricsSink)
 	require.NoError(t, sndReceiver.Start(context.Background(), mh))
 	require.NoError(t, sndReceiver.Shutdown(context.Background()))
 }

--- a/receiver/otlpreceiver/otlp_test.go
+++ b/receiver/otlpreceiver/otlp_test.go
@@ -542,29 +542,6 @@ func TestHTTPNewPortAlreadyUsed(t *testing.T) {
 	require.Error(t, r.Start(context.Background(), componenttest.NewNopHost()))
 }
 
-func TestReceiverLifecycle(t *testing.T) {
-	endpointGrpc := testutil.GetAvailableLocalAddress(t)
-	endpointHTTP := testutil.GetAvailableLocalAddress(t)
-
-	tracesSink := new(consumertest.TracesSink)
-	metricsSink := new(consumertest.MetricsSink)
-
-	// Create OTLP receiver with gRPC and HTTP protocols.
-	factory := NewFactory()
-	cfg := factory.CreateDefaultConfig().(*Config)
-	cfg.GRPC.NetAddr.Endpoint = endpointGrpc
-	cfg.HTTP.Endpoint = endpointHTTP
-
-	fstReceiver := newReceiver(t, factory, cfg, tracesSink, metricsSink)
-	mh := newAssertNoErrorHost(t)
-	require.NoError(t, fstReceiver.Start(context.Background(), mh))
-	require.NoError(t, fstReceiver.Shutdown(context.Background()))
-
-	sndReceiver := newReceiver(t, factory, cfg, tracesSink, metricsSink)
-	require.NoError(t, sndReceiver.Start(context.Background(), mh))
-	require.NoError(t, sndReceiver.Shutdown(context.Background()))
-}
-
 func TestGRPCStartWithoutConsumers(t *testing.T) {
 	addr := testutil.GetAvailableLocalAddress(t)
 	r := newGRPCReceiver(t, otlpReceiverName, addr, nil, nil)
@@ -882,20 +859,4 @@ loop:
 
 	// Indicate that we are done.
 	close(doneSignal)
-}
-
-type assertNoErrorHost struct {
-	component.Host
-	*testing.T
-}
-
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
 }

--- a/service/defaultcomponents/default_receivers_test.go
+++ b/service/defaultcomponents/default_receivers_test.go
@@ -60,8 +60,7 @@ func TestDefaultReceivers(t *testing.T) {
 			skipLifecyle: true, // TODO: Usage of CMux doesn't allow proper shutdown.
 		},
 		{
-			receiver:     "otlp",
-			skipLifecyle: true, // TODO: Upcoming PR to fix zipkin lifecycle.
+			receiver: "otlp",
 		},
 		{
 			receiver: "prometheus",


### PR DESCRIPTION
## Why
To allow the OTLP receiver to be created while one instance is already running. This allows changing the components without restarting the process. See related #2741

## What
**Description:**
Move the registration of the receiver servers to when the receiver is started. Also check in the goroutines serving requests if the errors are not the ones expected when shutting down the receiver (avoid useless calls to ReportFatalError).

**Tests:**
Added tests to the otlp package to check for the issues being fixed.
