### PR TITLE
Update demo app to build image

### DIFF
--- a/examples/demo/app/Dockerfile
+++ b/examples/demo/app/Dockerfile
@@ -1,0 +1,19 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+FROM golang:1.14
+COPY . /usr/src/app/
+WORKDIR /usr/src/app/
+RUN go env -w GOPROXY=direct
+RUN go install ./main.go
+CMD ["/go/bin/main"]

--- a/examples/demo/app/main.go
+++ b/examples/demo/app/main.go
@@ -47,7 +47,7 @@ func initProvider() func() {
 
 	otelAgentAddr, ok := os.LookupEnv("OTEL_AGENT_ENDPOINT")
 	if !ok {
-		otelAgentAddr = "0.0.0.0:55680"
+		otelAgentAddr = "0.0.0.0:4317"
 	}
 
 	exp, err := otlp.NewExporter(ctx, otlpgrpc.NewDriver(

--- a/examples/demo/docker-compose.yaml
+++ b/examples/demo/docker-compose.yaml
@@ -67,13 +67,11 @@ services:
       - otel-agent
 
   metrics-load-generator:
-    image: golang:1.12.7
-    volumes:
-      - ./app/main.go:/usr/src/main.go
+    build:
+      dockerfile: $PWD/app/Dockerfile
+      context: ./app
     environment:
-      - GO111MODULE=on
-      - OTEL_AGENT_ENDPOINT=otel-agent:55678
-    command: ["bash", "-c", "go run /usr/src/main.go"]
+      - OTEL_AGENT_ENDPOINT=otel-agent:4317
     depends_on:
       - otel-agent
 


### PR DESCRIPTION
**Description:** Updated the demo metrics generator application to build a container image rather than using `go run main.go` inside a `go:1.12` image.  Also updated the metrics generator application to use a `go:1.14` image as Go 1.12 is no longer supported.

**Testing:** Application was started with `docker-compose up -d` and metrics were observed via the Prometheus container.