### PR TITLE
Ensure Zipkin shutdown correctness

### DIFF
--- a/receiver/opencensusreceiver/opencensus.go
+++ b/receiver/opencensusreceiver/opencensus.go
@@ -261,7 +261,7 @@ func (ocr *ocReceiver) startServer(host component.Host) error {
 			}
 		}()
 		go func() {
-			if errHTTP := ocr.httpServer().Serve(httpL); errHTTP != nil {
+			if errHTTP := ocr.httpServer().Serve(httpL); errHTTP != http.ErrServerClosed {
 				host.ReportFatalError(errHTTP)
 			}
 		}()

--- a/receiver/otlpreceiver/otlp.go
+++ b/receiver/otlpreceiver/otlp.go
@@ -119,7 +119,7 @@ func (r *otlpReceiver) startHTTPServer(cfg *confighttp.HTTPServerSettings, host 
 	go func() {
 		defer r.shutdownWG.Done()
 
-		if errHTTP := r.serverHTTP.Serve(hln); errHTTP != nil && errHTTP != http.ErrServerClosed {
+		if errHTTP := r.serverHTTP.Serve(hln); errHTTP != http.ErrServerClosed {
 			host.ReportFatalError(errHTTP)
 		}
 	}()

--- a/receiver/zipkinreceiver/trace_receiver_test.go
+++ b/receiver/zipkinreceiver/trace_receiver_test.go
@@ -114,26 +114,6 @@ func TestZipkinReceiverPortAlreadyInUse(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestZipkinReceiverLifecycle(t *testing.T) {
-	factory := NewFactory()
-	cfg := factory.CreateDefaultConfig().(*Config)
-	consumer := consumertest.NewTracesNop()
-	fstReceiver, err := New(cfg, consumer)
-	require.NoError(t, err)
-
-	ctx := context.Background()
-	mh := newAssertNoErrorHost(t)
-	require.NoError(t, fstReceiver.Start(ctx, mh))
-
-	sndReceiver, err := New(cfg, consumer)
-	assert.NoError(t, err)
-
-	require.NoError(t, fstReceiver.Shutdown(ctx))
-
-	require.NoError(t, sndReceiver.Start(ctx, mh))
-	require.NoError(t, sndReceiver.Shutdown(ctx))
-}
-
 func TestConvertSpansToTraceSpans_json(t *testing.T) {
 	// Using Adrian Cole's sample at https://gist.github.com/adriancole/e8823c19dfed64e2eb71
 	blob, err := ioutil.ReadFile("./testdata/sample1.json")
@@ -618,20 +598,4 @@ func TestReceiverConvertsStringsToTypes(t *testing.T) {
 		t.Error("next consumer did not receive the batch")
 		break
 	}
-}
-
-type assertNoErrorHost struct {
-	component.Host
-	*testing.T
-}
-
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
 }

--- a/service/defaultcomponents/default_receivers_test.go
+++ b/service/defaultcomponents/default_receivers_test.go
@@ -75,8 +75,7 @@ func TestDefaultReceivers(t *testing.T) {
 			},
 		},
 		{
-			receiver:     "zipkin",
-			skipLifecyle: true, // TODO: Upcoming PR to fix zipkin lifecycle.
+			receiver: "zipkin",
 		},
 	}
 


### PR DESCRIPTION
**Description:** 
Zipkin shutdown method was returning before its server goroutine was completed and not checking for the expected `http.ErrServerClosed`. This PR ensures shutdown only returns after the goroutine completes, no errors are reported when the server is closed. Opportunistic fix: remove an improper call to `ReportFatalError` for a synchronous error when the port is already in use.

**Testing:**
Enabled lifecycle test for Zipkin receiver.
