### PR TITLE
Use Endpoint for health check extention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,9 @@
 - obsReport.NewExporter accepts a settings struct (#2668)
 
 ## 💡 Enhancements 💡
+
 - `batch` processor: - Support max batch size for logs (#2736)
+- Use `Endpoint` for health check extension (#2782)
 
 ## 🧰 Bug fixes 🧰
 

--- a/extension/healthcheckextension/README.md
+++ b/extension/healthcheckextension/README.md
@@ -6,7 +6,8 @@ liveness and/or readiness probe on Kubernetes.
 
 The following settings are required:
 
-- `port` (default = 13133): What port to expose HTTP health information.
+- `endpoint` (default = localhost:13133): Address to publish the health check status to
+- `port` (default = 13133): [deprecated] What port to expose HTTP health information.
 
 Example:
 

--- a/extension/healthcheckextension/config.go
+++ b/extension/healthcheckextension/config.go
@@ -16,6 +16,7 @@ package healthcheckextension
 
 import (
 	"go.opentelemetry.io/collector/config/configmodels"
+	"go.opentelemetry.io/collector/config/confignet"
 )
 
 // Config has the configuration for the extension enabling the health check
@@ -28,7 +29,8 @@ type Config struct {
 	// Deprecated: use Endpoint instead.
 	Port uint16 `mapstructure:"port"`
 
-	// Endpoint is the address and port used to publish the health check status.
-	// The default value is "localhost:13133".
-	Endpoint string `mapstructure:"endpoint"`
+	// TCPAddr represents a tcp endpoint address that is to publish the health
+	// check status.
+	// The default endpoint is "localhost:13133".
+	TCPAddr confignet.TCPAddr `mapstructure:",squash"`
 }

--- a/extension/healthcheckextension/config.go
+++ b/extension/healthcheckextension/config.go
@@ -23,6 +23,11 @@ import (
 type Config struct {
 	configmodels.ExtensionSettings `mapstructure:",squash"`
 
+	// Port is the port used to publish the health check status.
+	// The default value is 13133.
+	// Deprecated: use Endpoint instead.
+	Port uint16 `mapstructure:"port"`
+
 	// Endpoint is the address and port used to publish the health check status.
 	// The default value is "localhost:13133".
 	Endpoint string `mapstructure:"endpoint"`

--- a/extension/healthcheckextension/config.go
+++ b/extension/healthcheckextension/config.go
@@ -23,7 +23,7 @@ import (
 type Config struct {
 	configmodels.ExtensionSettings `mapstructure:",squash"`
 
-	// Port is the port used to publish the health check status.
-	// The default value is 13133.
-	Port uint16 `mapstructure:"port"`
+	// Endpoint is the address and port used to publish the health check status.
+	// The default value is "localhost:13133".
+	Endpoint string `mapstructure:"endpoint"`
 }

--- a/extension/healthcheckextension/config_test.go
+++ b/extension/healthcheckextension/config_test.go
@@ -21,6 +21,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.opentelemetry.io/collector/config/confignet"
+
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/configmodels"
 	"go.opentelemetry.io/collector/config/configtest"
@@ -47,7 +49,9 @@ func TestLoadConfig(t *testing.T) {
 				TypeVal: "health_check",
 				NameVal: "health_check/1",
 			},
-			Endpoint: "localhost:13",
+			TCPAddr: confignet.TCPAddr{
+				Endpoint: "localhost:13",
+			},
 		},
 		ext1)
 

--- a/extension/healthcheckextension/config_test.go
+++ b/extension/healthcheckextension/config_test.go
@@ -21,10 +21,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"go.opentelemetry.io/collector/config/confignet"
-
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/configmodels"
+	"go.opentelemetry.io/collector/config/confignet"
 	"go.opentelemetry.io/collector/config/configtest"
 )
 

--- a/extension/healthcheckextension/config_test.go
+++ b/extension/healthcheckextension/config_test.go
@@ -47,7 +47,7 @@ func TestLoadConfig(t *testing.T) {
 				TypeVal: "health_check",
 				NameVal: "health_check/1",
 			},
-			Port: 13,
+			Endpoint: "localhost:13",
 		},
 		ext1)
 

--- a/extension/healthcheckextension/factory.go
+++ b/extension/healthcheckextension/factory.go
@@ -26,6 +26,8 @@ import (
 const (
 	// The value of extension "type" in configuration.
 	typeStr = "health_check"
+
+	defaultEndpoint = "localhost:13133"
 )
 
 // NewFactory creates a factory for HealthCheck extension.
@@ -43,7 +45,7 @@ func createDefaultConfig() configmodels.Extension {
 			NameVal: typeStr,
 		},
 		TCPAddr: confignet.TCPAddr{
-			Endpoint: "localhost:13133",
+			Endpoint: defaultEndpoint,
 		},
 	}
 }

--- a/extension/healthcheckextension/factory.go
+++ b/extension/healthcheckextension/factory.go
@@ -19,6 +19,7 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configmodels"
+	"go.opentelemetry.io/collector/config/confignet"
 	"go.opentelemetry.io/collector/extension/extensionhelper"
 )
 
@@ -41,7 +42,9 @@ func createDefaultConfig() configmodels.Extension {
 			TypeVal: typeStr,
 			NameVal: typeStr,
 		},
-		Endpoint: "localhost:13133",
+		TCPAddr: confignet.TCPAddr{
+			Endpoint: "localhost:13133",
+		},
 	}
 }
 

--- a/extension/healthcheckextension/factory.go
+++ b/extension/healthcheckextension/factory.go
@@ -41,7 +41,7 @@ func createDefaultConfig() configmodels.Extension {
 			TypeVal: typeStr,
 			NameVal: typeStr,
 		},
-		Port: 13133,
+		Endpoint: "localhost:13133",
 	}
 }
 

--- a/extension/healthcheckextension/factory_test.go
+++ b/extension/healthcheckextension/factory_test.go
@@ -35,7 +35,7 @@ func TestFactory_CreateDefaultConfig(t *testing.T) {
 			NameVal: typeStr,
 			TypeVal: typeStr,
 		},
-		Port: 13133,
+		Endpoint: "localhost:13133",
 	},
 		cfg)
 
@@ -47,7 +47,7 @@ func TestFactory_CreateDefaultConfig(t *testing.T) {
 
 func TestFactory_CreateExtension(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)
-	cfg.Port = testutil.GetAvailablePort(t)
+	cfg.Endpoint = testutil.GetAvailableLocalAddress(t)
 
 	ext, err := createExtension(context.Background(), component.ExtensionCreateParams{Logger: zap.NewNop()}, cfg)
 	require.NoError(t, err)

--- a/extension/healthcheckextension/factory_test.go
+++ b/extension/healthcheckextension/factory_test.go
@@ -22,11 +22,10 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
-	"go.opentelemetry.io/collector/config/confignet"
-
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configcheck"
 	"go.opentelemetry.io/collector/config/configmodels"
+	"go.opentelemetry.io/collector/config/confignet"
 	"go.opentelemetry.io/collector/testutil"
 )
 

--- a/extension/healthcheckextension/factory_test.go
+++ b/extension/healthcheckextension/factory_test.go
@@ -22,6 +22,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
+	"go.opentelemetry.io/collector/config/confignet"
+
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configcheck"
 	"go.opentelemetry.io/collector/config/configmodels"
@@ -35,9 +37,10 @@ func TestFactory_CreateDefaultConfig(t *testing.T) {
 			NameVal: typeStr,
 			TypeVal: typeStr,
 		},
-		Endpoint: "localhost:13133",
-	},
-		cfg)
+		TCPAddr: confignet.TCPAddr{
+			Endpoint: "localhost:13133",
+		},
+	}, cfg)
 
 	assert.NoError(t, configcheck.ValidateConfig(cfg))
 	ext, err := createExtension(context.Background(), component.ExtensionCreateParams{Logger: zap.NewNop()}, cfg)
@@ -47,7 +50,7 @@ func TestFactory_CreateDefaultConfig(t *testing.T) {
 
 func TestFactory_CreateExtension(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)
-	cfg.Endpoint = testutil.GetAvailableLocalAddress(t)
+	cfg.TCPAddr.Endpoint = testutil.GetAvailableLocalAddress(t)
 
 	ext, err := createExtension(context.Background(), component.ExtensionCreateParams{Logger: zap.NewNop()}, cfg)
 	require.NoError(t, err)

--- a/extension/healthcheckextension/factory_test.go
+++ b/extension/healthcheckextension/factory_test.go
@@ -38,7 +38,7 @@ func TestFactory_CreateDefaultConfig(t *testing.T) {
 			TypeVal: typeStr,
 		},
 		TCPAddr: confignet.TCPAddr{
-			Endpoint: "localhost:13133",
+			Endpoint: defaultEndpoint,
 		},
 	}, cfg)
 

--- a/extension/healthcheckextension/healthcheckextension.go
+++ b/extension/healthcheckextension/healthcheckextension.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"net"
 	"net/http"
-	"strconv"
 
 	"github.com/jaegertracing/jaeger/pkg/healthcheck"
 	"go.uber.org/zap"
@@ -41,8 +40,7 @@ func (hc *healthCheckExtension) Start(_ context.Context, host component.Host) er
 	hc.logger.Info("Starting health_check extension", zap.Any("config", hc.config))
 
 	// Initialize listener
-	portStr := ":" + strconv.Itoa(int(hc.config.Port))
-	ln, err := net.Listen("tcp", portStr)
+	ln, err := net.Listen("tcp", hc.config.Endpoint)
 	if err != nil {
 		return err
 	}

--- a/extension/healthcheckextension/healthcheckextension.go
+++ b/extension/healthcheckextension/healthcheckextension.go
@@ -16,7 +16,6 @@ package healthcheckextension
 
 import (
 	"context"
-	"net"
 	"net/http"
 
 	"github.com/jaegertracing/jaeger/pkg/healthcheck"
@@ -40,7 +39,7 @@ func (hc *healthCheckExtension) Start(_ context.Context, host component.Host) er
 	hc.logger.Info("Starting health_check extension", zap.Any("config", hc.config))
 
 	// Initialize listener
-	ln, err := net.Listen("tcp", hc.config.Endpoint)
+	ln, err := hc.config.TCPAddr.Listen()
 	if err != nil {
 		return err
 	}

--- a/extension/healthcheckextension/healthcheckextension.go
+++ b/extension/healthcheckextension/healthcheckextension.go
@@ -46,6 +46,7 @@ func (hc *healthCheckExtension) Start(_ context.Context, host component.Host) er
 		err error
 	)
 	if hc.config.Port != 0 && hc.config.TCPAddr.Endpoint == defaultEndpoint {
+		hc.logger.Warn("`Port` is deprecated, use `Endpoint` instead")
 		portStr := ":" + strconv.Itoa(int(hc.config.Port))
 		ln, err = net.Listen("tcp", portStr)
 	} else {

--- a/extension/healthcheckextension/healthcheckextension.go
+++ b/extension/healthcheckextension/healthcheckextension.go
@@ -16,7 +16,9 @@ package healthcheckextension
 
 import (
 	"context"
+	"net"
 	"net/http"
+	"strconv"
 
 	"github.com/jaegertracing/jaeger/pkg/healthcheck"
 	"go.uber.org/zap"
@@ -39,7 +41,16 @@ func (hc *healthCheckExtension) Start(_ context.Context, host component.Host) er
 	hc.logger.Info("Starting health_check extension", zap.Any("config", hc.config))
 
 	// Initialize listener
-	ln, err := hc.config.TCPAddr.Listen()
+	var (
+		ln  net.Listener
+		err error
+	)
+	if hc.config.Port != 0 && hc.config.TCPAddr.Endpoint == defaultEndpoint {
+		portStr := ":" + strconv.Itoa(int(hc.config.Port))
+		ln, err = net.Listen("tcp", portStr)
+	} else {
+		ln, err = hc.config.TCPAddr.Listen()
+	}
 	if err != nil {
 		return err
 	}

--- a/extension/healthcheckextension/healthcheckextension_test.go
+++ b/extension/healthcheckextension/healthcheckextension_test.go
@@ -25,6 +25,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
+	"go.opentelemetry.io/collector/config/confignet"
+
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/testutil"
@@ -32,7 +34,9 @@ import (
 
 func TestHealthCheckExtensionUsage(t *testing.T) {
 	config := Config{
-		Endpoint: testutil.GetAvailableLocalAddress(t),
+		TCPAddr: confignet.TCPAddr{
+			Endpoint: testutil.GetAvailableLocalAddress(t),
+		},
 	}
 
 	hcExt := newServer(config, zap.NewNop())
@@ -45,7 +49,7 @@ func TestHealthCheckExtensionUsage(t *testing.T) {
 	runtime.Gosched()
 
 	client := &http.Client{}
-	url := "http://" + config.Endpoint
+	url := "http://" + config.TCPAddr.Endpoint
 	resp0, err := client.Get(url)
 	require.NoError(t, err)
 	defer resp0.Body.Close()
@@ -76,7 +80,9 @@ func TestHealthCheckExtensionPortAlreadyInUse(t *testing.T) {
 	defer ln.Close()
 
 	config := Config{
-		Endpoint: endpoint,
+		TCPAddr: confignet.TCPAddr{
+			Endpoint: endpoint,
+		},
 	}
 	hcExt := newServer(config, zap.NewNop())
 	require.NotNil(t, hcExt)
@@ -87,7 +93,9 @@ func TestHealthCheckExtensionPortAlreadyInUse(t *testing.T) {
 
 func TestHealthCheckMultipleStarts(t *testing.T) {
 	config := Config{
-		Endpoint: testutil.GetAvailableLocalAddress(t),
+		TCPAddr: confignet.TCPAddr{
+			Endpoint: testutil.GetAvailableLocalAddress(t),
+		},
 	}
 
 	hcExt := newServer(config, zap.NewNop())
@@ -102,7 +110,9 @@ func TestHealthCheckMultipleStarts(t *testing.T) {
 
 func TestHealthCheckMultipleShutdowns(t *testing.T) {
 	config := Config{
-		Endpoint: testutil.GetAvailableLocalAddress(t),
+		TCPAddr: confignet.TCPAddr{
+			Endpoint: testutil.GetAvailableLocalAddress(t),
+		},
 	}
 
 	hcExt := newServer(config, zap.NewNop())
@@ -115,7 +125,9 @@ func TestHealthCheckMultipleShutdowns(t *testing.T) {
 
 func TestHealthCheckShutdownWithoutStart(t *testing.T) {
 	config := Config{
-		Endpoint: testutil.GetAvailableLocalAddress(t),
+		TCPAddr: confignet.TCPAddr{
+			Endpoint: testutil.GetAvailableLocalAddress(t),
+		},
 	}
 
 	hcExt := newServer(config, zap.NewNop())

--- a/extension/healthcheckextension/healthcheckextension_test.go
+++ b/extension/healthcheckextension/healthcheckextension_test.go
@@ -25,10 +25,9 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
-	"go.opentelemetry.io/collector/config/confignet"
-
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/config/confignet"
 	"go.opentelemetry.io/collector/testutil"
 )
 

--- a/extension/healthcheckextension/testdata/config.yaml
+++ b/extension/healthcheckextension/testdata/config.yaml
@@ -1,7 +1,7 @@
 extensions:
   health_check:
   health_check/1:
-    port: 13
+    endpoint: "localhost:13"
 
 service:
   extensions: [health_check/1]

--- a/service/application_test.go
+++ b/service/application_test.go
@@ -64,12 +64,12 @@ func TestApplication_Start(t *testing.T) {
 
 	const testPrefix = "a_test"
 	metricsPort := testutil.GetAvailablePort(t)
-	healthCheckPortStr := strconv.FormatUint(uint64(testutil.GetAvailablePort(t)), 10)
+	healthCheckEndpoint := testutil.GetAvailableLocalAddress(t)
 	app.rootCmd.SetArgs([]string{
 		"--config=testdata/otelcol-config.yaml",
 		"--metrics-addr=localhost:" + strconv.FormatUint(uint64(metricsPort), 10),
 		"--metrics-prefix=" + testPrefix,
-		"--set=extensions.health_check.port=" + healthCheckPortStr,
+		"--set=extensions.health_check.endpoint=" + healthCheckEndpoint,
 	})
 
 	appDone := make(chan struct{})
@@ -80,7 +80,7 @@ func TestApplication_Start(t *testing.T) {
 
 	assert.Equal(t, Starting, <-app.GetStateChannel())
 	assert.Equal(t, Running, <-app.GetStateChannel())
-	require.True(t, isAppAvailable(t, "http://localhost:"+healthCheckPortStr))
+	require.True(t, isAppAvailable(t, "http://"+healthCheckEndpoint))
 	assert.Equal(t, app.logger, app.GetLogger())
 	assert.True(t, loggingHookCalled)
 
@@ -275,7 +275,7 @@ func TestSetFlag(t *testing.T) {
 			"--set=processors.attributes.actions.key=foo",
 			"--set=processors.attributes.actions.value=bar",
 			"--set=receivers.jaeger.protocols.grpc.endpoint=localhost:12345",
-			"--set=extensions.health_check.port=8080",
+			"--set=extensions.health_check.endpoint=localhost:8080",
 		})
 		require.NoError(t, err)
 		cfg, err := FileLoaderConfigFactory(configload.NewViper(), app.rootCmd, factories)

--- a/service/defaultcomponents/default_extensions_test.go
+++ b/service/defaultcomponents/default_extensions_test.go
@@ -37,7 +37,6 @@ func TestDefaultExtensions(t *testing.T) {
 
 	extFactories := allFactories.Extensions
 	endpoint := testutil.GetAvailableLocalAddress(t)
-	port := testutil.GetAvailablePort(t)
 
 	tests := []struct {
 		extension   configmodels.Type
@@ -47,7 +46,7 @@ func TestDefaultExtensions(t *testing.T) {
 			extension: "health_check",
 			getConfigFn: func() configmodels.Extension {
 				cfg := extFactories["health_check"].CreateDefaultConfig().(*healthcheckextension.Config)
-				cfg.Port = port
+				cfg.Endpoint = endpoint
 				return cfg
 			},
 		},

--- a/service/defaultcomponents/default_extensions_test.go
+++ b/service/defaultcomponents/default_extensions_test.go
@@ -46,7 +46,7 @@ func TestDefaultExtensions(t *testing.T) {
 			extension: "health_check",
 			getConfigFn: func() configmodels.Extension {
 				cfg := extFactories["health_check"].CreateDefaultConfig().(*healthcheckextension.Config)
-				cfg.Endpoint = endpoint
+				cfg.TCPAddr.Endpoint = endpoint
 				return cfg
 			},
 		},


### PR DESCRIPTION
**Description:** 
Change health check extension's config to use `Endpoint` instead of `Port`, fix tests according to the changes.

**Link to tracking Issue:** #2764
