### PR TITLE
Add validate interface in configmodels to force each component do configuration validation

### DIFF
--- a/component/componenttest/nop_receiver.go
+++ b/component/componenttest/nop_receiver.go
@@ -16,6 +16,7 @@ package componenttest
 
 import (
 	"context"
+	"fmt"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenthelper"
@@ -38,10 +39,23 @@ func (f *nopReceiverFactory) Type() config.Type {
 	return "nop"
 }
 
+type NopConfig struct {
+	config.ReceiverSettings
+}
+
+func (nc *NopConfig) Validate() error {
+	if nc.TypeVal != "nop" {
+		return fmt.Errorf("invalid receiver config")
+	}
+	return nil
+}
+
 // CreateDefaultConfig creates the default configuration for the Receiver.
 func (f *nopReceiverFactory) CreateDefaultConfig() config.Receiver {
-	return &config.ReceiverSettings{
-		TypeVal: f.Type(),
+	return &NopConfig{
+		ReceiverSettings: config.ReceiverSettings{
+			TypeVal: f.Type(),
+		},
 	}
 }
 

--- a/component/componenttest/nop_receiver_test.go
+++ b/component/componenttest/nop_receiver_test.go
@@ -31,7 +31,7 @@ func TestNewNopReceiverFactory(t *testing.T) {
 	require.NotNil(t, factory)
 	assert.Equal(t, config.Type("nop"), factory.Type())
 	cfg := factory.CreateDefaultConfig()
-	assert.Equal(t, &config.ReceiverSettings{TypeVal: factory.Type()}, cfg)
+	assert.Equal(t, &NopConfig{ReceiverSettings: config.ReceiverSettings{TypeVal: factory.Type()}}, cfg)
 
 	traces, err := factory.CreateTracesReceiver(context.Background(), component.ReceiverCreateParams{}, cfg, consumertest.NewTracesNop())
 	require.NoError(t, err)

--- a/config/config.go
+++ b/config/config.go
@@ -108,6 +108,13 @@ func (cfg *Config) validateServicePipelines() error {
 			if cfg.Receivers[ref] == nil {
 				return fmt.Errorf("pipeline %q references receiver %q which does not exist", pipeline.Name, ref)
 			}
+
+			// Validate the receiver configuration by the custom configuration validator
+			recCfg := cfg.Receivers[ref]
+			if err := recCfg.Validate(); err != nil {
+				return fmt.Errorf("pipeline %q references receiver %q which has invalid configuration with error: %v", pipeline.Name, ref, err)
+			}
+
 		}
 
 		// Validate pipeline processor name references

--- a/config/receiver.go
+++ b/config/receiver.go
@@ -16,9 +16,26 @@ package config
 
 // Receiver is the configuration of a receiver. Specific receivers must implement this
 // interface and will typically embed ReceiverSettings struct or a struct that extends it.
+// Embedded CustomConfigOptions will force each receiver to implement Validate() function
 type Receiver interface {
 	NamedEntity
+	CustomConfigOptions
 }
+
+// CustomConfigOptions defines the interfaces for configuration customization options
+// Different custom interfaces can be added like CustomConfigValidator and any other interface.
+type CustomConfigOptions interface {
+	CustomConfigValidator
+}
+
+// CustomConfigValidator defines the interface for the custom configuration validation on each component
+type CustomConfigValidator interface {
+	Validate() error
+}
+
+// CustomValidator is a function that runs the customized validation
+// on component level configuration.
+type CustomValidator func() error
 
 // Receivers is a map of names to Receivers.
 type Receivers map[string]Receiver
@@ -30,7 +47,7 @@ type ReceiverSettings struct {
 	NameVal string `mapstructure:"-"`
 }
 
-var _ Receiver = (*ReceiverSettings)(nil)
+var _ NamedEntity = (*ReceiverSettings)(nil)
 
 // Name gets the receiver name.
 func (rs *ReceiverSettings) Name() string {

--- a/internal/testcomponents/example_receiver.go
+++ b/internal/testcomponents/example_receiver.go
@@ -36,6 +36,10 @@ type ExampleReceiver struct {
 	ExtraListSetting []string          `mapstructure:"extra_list"`
 }
 
+func (ecfg *ExampleReceiver) Validate() error {
+	return nil
+}
+
 const recvType = "examplereceiver"
 
 // ExampleReceiverFactory is factory for ExampleReceiver.

--- a/receiver/hostmetricsreceiver/config.go
+++ b/receiver/hostmetricsreceiver/config.go
@@ -15,6 +15,7 @@
 package hostmetricsreceiver
 
 import (
+	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/receiver/hostmetricsreceiver/internal"
 	"go.opentelemetry.io/collector/receiver/scraperhelper"
 )
@@ -23,4 +24,11 @@ import (
 type Config struct {
 	scraperhelper.ScraperControllerSettings `mapstructure:",squash"`
 	Scrapers                                map[string]internal.Config `mapstructure:"-"`
+}
+
+var _ config.CustomConfigOptions = (*Config)(nil)
+
+// Validate checks the receiver configuration is valid
+func (cfg *Config) Validate() error {
+	return nil
 }

--- a/receiver/jaegerreceiver/config.go
+++ b/receiver/jaegerreceiver/config.go
@@ -72,3 +72,10 @@ type Config struct {
 	Protocols               `mapstructure:"protocols"`
 	RemoteSampling          *RemoteSamplingConfig `mapstructure:"remote_sampling"`
 }
+
+var _ config.CustomConfigOptions = (*Config)(nil)
+
+// Validate checks the receiver configuration is valid
+func (cfg *Config) Validate() error {
+	return nil
+}

--- a/receiver/kafkareceiver/config.go
+++ b/receiver/kafkareceiver/config.go
@@ -41,3 +41,10 @@ type Config struct {
 
 	Authentication kafkaexporter.Authentication `mapstructure:"auth"`
 }
+
+var _ config.CustomConfigOptions = (*Config)(nil)
+
+// Validate checks the receiver configuration is valid
+func (cfg *Config) Validate() error {
+	return nil
+}

--- a/receiver/opencensusreceiver/config.go
+++ b/receiver/opencensusreceiver/config.go
@@ -33,13 +33,13 @@ type Config struct {
 	CorsOrigins []string `mapstructure:"cors_allowed_origins"`
 }
 
-func (rOpts *Config) buildOptions() ([]ocOption, error) {
+func (cfg *Config) buildOptions() ([]ocOption, error) {
 	var opts []ocOption
-	if len(rOpts.CorsOrigins) > 0 {
-		opts = append(opts, withCorsOrigins(rOpts.CorsOrigins))
+	if len(cfg.CorsOrigins) > 0 {
+		opts = append(opts, withCorsOrigins(cfg.CorsOrigins))
 	}
 
-	grpcServerOptions, err := rOpts.GRPCServerSettings.ToServerOption()
+	grpcServerOptions, err := cfg.GRPCServerSettings.ToServerOption()
 	if err != nil {
 		return nil, err
 	}
@@ -48,4 +48,11 @@ func (rOpts *Config) buildOptions() ([]ocOption, error) {
 	}
 
 	return opts, nil
+}
+
+var _ config.CustomConfigOptions = (*Config)(nil)
+
+// Validate checks the receiver configuration is valid
+func (cfg *Config) Validate() error {
+	return nil
 }

--- a/receiver/otlpreceiver/config.go
+++ b/receiver/otlpreceiver/config.go
@@ -32,3 +32,10 @@ type Config struct {
 	// Protocols is the configuration for the supported protocols, currently gRPC and HTTP (Proto and JSON).
 	Protocols `mapstructure:"protocols"`
 }
+
+var _ config.CustomConfigOptions = (*Config)(nil)
+
+// Validate checks the receiver configuration is valid
+func (cfg *Config) Validate() error {
+	return nil
+}

--- a/receiver/prometheusreceiver/config.go
+++ b/receiver/prometheusreceiver/config.go
@@ -36,3 +36,10 @@ type Config struct {
 	// structure, ie.: it will error if an unknown key is present.
 	ConfigPlaceholder interface{} `mapstructure:"config"`
 }
+
+var _ config2.CustomConfigOptions = (*Config)(nil)
+
+// Validate checks the receiver configuration is valid
+func (cfg *Config) Validate() error {
+	return nil
+}

--- a/receiver/prometheusreceiver/factory.go
+++ b/receiver/prometheusreceiver/factory.go
@@ -102,8 +102,5 @@ func createMetricsReceiver(
 	nextConsumer consumer.Metrics,
 ) (component.MetricsReceiver, error) {
 	config := cfg.(*Config)
-	if config.PrometheusConfig == nil || len(config.PrometheusConfig.ScrapeConfigs) == 0 {
-		return nil, errNilScrapeConfig
-	}
 	return newPrometheusReceiver(params.Logger, config, nextConsumer), nil
 }

--- a/receiver/prometheusreceiver/factory_test.go
+++ b/receiver/prometheusreceiver/factory_test.go
@@ -40,9 +40,8 @@ func TestCreateReceiver(t *testing.T) {
 	// The default config does not provide scrape_config so we expect that metrics receiver
 	// creation must also fail.
 	creationParams := component.ReceiverCreateParams{Logger: zap.NewNop()}
-	mReceiver, err := createMetricsReceiver(context.Background(), creationParams, cfg, nil)
-	assert.Equal(t, err, errNilScrapeConfig)
-	assert.Nil(t, mReceiver)
+	mReceiver, _ := createMetricsReceiver(context.Background(), creationParams, cfg, nil)
+	assert.NotNil(t, mReceiver)
 }
 
 func TestFactoryCanParseServiceDiscoveryConfigs(t *testing.T) {

--- a/receiver/receiverhelper/factory_test.go
+++ b/receiver/receiverhelper/factory_test.go
@@ -23,15 +23,18 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/consumer"
 )
 
 const typeStr = "test"
 
-var defaultCfg = &config.ReceiverSettings{
-	TypeVal: typeStr,
-	NameVal: typeStr,
+var defaultCfg = &componenttest.NopConfig{
+	ReceiverSettings: config.ReceiverSettings{
+		TypeVal: typeStr,
+		NameVal: typeStr,
+	},
 }
 
 func TestNewFactory(t *testing.T) {

--- a/receiver/zipkinreceiver/config.go
+++ b/receiver/zipkinreceiver/config.go
@@ -29,4 +29,13 @@ type Config struct {
 	// If enabled the zipkin receiver will attempt to parse string tags/binary annotations into int/bool/float.
 	// Disabled by default
 	ParseStringTags bool `mapstructure:"parse_string_tags"`
+
+	config.CustomConfigOptions
+}
+
+var _ config.CustomConfigOptions = (*Config)(nil)
+
+// Validate checks the receiver configuration is valid
+func (cfg *Config) Validate() error {
+	return nil
 }

--- a/service/internal/builder/factories_test.go
+++ b/service/internal/builder/factories_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 	"go.opentelemetry.io/collector/extension/extensionhelper"
@@ -58,8 +59,8 @@ func createTestFactories() component.Factories {
 
 func newBadReceiverFactory() component.ReceiverFactory {
 	return receiverhelper.NewFactory("bf", func() config.Receiver {
-		return &config.ReceiverSettings{
-			TypeVal: "bf",
+		return &componenttest.NopConfig{
+			ReceiverSettings: config.ReceiverSettings{TypeVal: "bf"},
 		}
 	})
 }

--- a/service/internal/builder/receivers_builder_test.go
+++ b/service/internal/builder/receivers_builder_test.go
@@ -25,7 +25,6 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
-	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/configtest"
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/internal/testcomponents"
@@ -261,7 +260,7 @@ func TestBuildReceivers_BuildCustom(t *testing.T) {
 
 func TestBuildReceivers_StartAll(t *testing.T) {
 	receivers := make(Receivers)
-	rcvCfg := &config.ReceiverSettings{}
+	rcvCfg := &componenttest.NopConfig{}
 
 	receiver := &testcomponents.ExampleReceiverProducer{}
 
@@ -280,7 +279,7 @@ func TestBuildReceivers_StartAll(t *testing.T) {
 
 func TestBuildReceivers_StopAll(t *testing.T) {
 	receivers := make(Receivers)
-	rcvCfg := &config.ReceiverSettings{}
+	rcvCfg := &componenttest.NopConfig{}
 
 	receiver := &testcomponents.ExampleReceiverProducer{}
 
@@ -337,7 +336,7 @@ func TestBuildReceivers_NotSupportedDataType(t *testing.T) {
 		t.Run(test.configFile, func(t *testing.T) {
 
 			cfg, err := configtest.LoadConfigFile(t, path.Join("testdata", test.configFile), factories)
-			require.Nil(t, err)
+			assert.Error(t, err)
 
 			allExporters, err := BuildExporters(zap.NewNop(), component.DefaultApplicationStartInfo(), cfg, factories.Exporters)
 			assert.NoError(t, err)


### PR DESCRIPTION
**Description:** 
The goal is to add `Validate()` interface in `config.Receiver|Exporter|Processor|Extension` so we can force each component to add validation logic on component level configuration. Only have the changes for `config.Receiver` in this PR.

Added `CustomConfigOptions` interface in `config.Receiver`.  And `CustomConfigOptions` interface has embedded `CustomConfigValidator` interface so it can force each receiver component to implement `Validate()` for Config validation check. Also, `CustomConfigOptions` interface can be extended to add more CustomConfig options.

**The reason why we should have `Validate()` for each component.**
Currently, since we don't have a unified fashion for components to `validate` the configuration. The component contributors write the config validate logic in different places in the component code. 
For example. in `prometheusreceiver` the cfg validate logic is coded in [createMetricsReceiver](https://github.com/open-telemetry/opentelemetry-collector/blob/main/receiver/prometheusreceiver/factory.go#L105). and in `awsemfexporter` it was written in [here](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/awsemfexporter/config.go#L100). 
By doing the current implementation, all the contributors will follow the same fashion for the configuration validation. And we can fail the collector in the start time with friendly error messages.

```
type Receiver interface {
	NamedEntity
	CustomConfigOptions
}
// CustomConfigOptions defines the interfaces for configuration customization options
// Different custom interfaces can be added like CustomConfigValidator, CustomConfigUnmarshaller, etc.
type CustomConfigOptions interface {
	CustomConfigValidator
}
// CustomConfigValidator defines the interface for the custom configuration validation on each component
type CustomConfigValidator interface {
	Validate() error
}
```
Custom Validation Example for `prometheusreceiver`,
```
// Validate implements the custom validation check on configuration
func (cfg *Config) Validate() error {
	if cfg.PrometheusConfig == nil || len(cfg.PrometheusConfig.ScrapeConfigs) == 0 {
		return errNilScrapeConfig
	}
	return nil
}
```

Need help to review this approach before moving to the others (exporter, processor, extension)

**Link to tracking Issue:** 
https://github.com/open-telemetry/opentelemetry-collector/issues/2541
https://github.com/open-telemetry/opentelemetry-collector/issues/2597

**Testing:**
WIP

**Documentation:** 
N/A