### PR TITLE
Treating Summary and Histogram metric with out "_sum" counter as valid metric.

### DIFF
--- a/receiver/prometheusreceiver/internal/metricfamily.go
+++ b/receiver/prometheusreceiver/internal/metricfamily.go
@@ -261,7 +261,7 @@ func (mg *metricGroup) sortPoints() {
 }
 
 func (mg *metricGroup) toDistributionTimeSeries(orderedLabelKeys []string) *metricspb.TimeSeries {
-	if !(mg.hasCount && mg.hasSum) || len(mg.complexValue) == 0 {
+	if !(mg.hasCount) || len(mg.complexValue) == 0 {
 		return nil
 	}
 	mg.sortPoints()
@@ -308,10 +308,10 @@ func (mg *metricGroup) toDistributionTimeSeries(orderedLabelKeys []string) *metr
 }
 
 func (mg *metricGroup) toSummaryTimeSeries(orderedLabelKeys []string) *metricspb.TimeSeries {
-	// expecting count and sum to be provided, however, in the following two cases, they can be missed.
+	// expecting count to be provided, however, in the following two cases, they can be missed.
 	// 1. data is corrupted
 	// 2. ignored by startValue evaluation
-	if !(mg.hasCount && mg.hasSum) {
+	if !(mg.hasCount) {
 		return nil
 	}
 	mg.sortPoints()


### PR DESCRIPTION

**Description:** 
Fixing a bug - PrometheusReceiver ignores Summary and Histogram Metrics that do not have _sum counter. #2661

Modified the condition in `toDistributionTimeSeries` and `toSummaryTimeSeries` functions to ignore the `hasSum` check.


**Link to tracking Issue:** 
https://github.com/open-telemetry/opentelemetry-collector/issues/2661

**Testing:** 
Updated Unit test cases, and also tested with live application using DropWizard metrics framework.

**Documentation:**
None.

_Please delete paragraphs that you did not use before submitting._
