### PR TITLE
Escape user input used in output

### DIFF
--- a/receiver/jaegerreceiver/trace_receiver.go
+++ b/receiver/jaegerreceiver/trace_receiver.go
@@ -17,6 +17,7 @@ package jaegerreceiver
 import (
 	"context"
 	"fmt"
+	"html"
 	"io/ioutil"
 	"mime"
 	"net"
@@ -441,7 +442,7 @@ func (jr *jReceiver) HandleThriftHTTPBatch(w http.ResponseWriter, r *http.Reques
 
 	batch, hErr := jr.decodeThriftHTTPBody(r)
 	if hErr != nil {
-		http.Error(w, hErr.msg, hErr.statusCode)
+		http.Error(w, html.EscapeString(hErr.msg), hErr.statusCode)
 		obsreport.EndTraceDataReceiveOp(ctx, thriftFormat, 0, hErr)
 		return
 	}


### PR DESCRIPTION
**Description:**
Escape the error message sent to clients, containing user-provided input.

Theoretically, this could allow an attacker to perform a reflected cross-site scripting attack. In my view, this would be hardly exploitable, as the Jaeger Receiver has Jaeger Client as the only clients, and browsers would have to be tricked into making requests directly to it with the bad payload. On the way out, the browser would interpret the Jaeger Receiver as a single domain, as each protocol is on its own port. No session data, or any other type of senstive information, would be available for the attacker to extract.

In any case, this here fixes the theoretical case, especially to prevent this from being used in a composite attack in a scenario that I can't think of...
