### PR TITLE
Refine configsource interface

### DIFF
--- a/config/internal/configsource/component.go
+++ b/config/internal/configsource/component.go
@@ -97,8 +97,8 @@ type WatchableRetrieved interface {
 	//    on first instances of transient errors, optionally there should be
 	//    configurable thresholds to control for how long such errors can be ignored.
 	//
-	// This method must be only called when all calls to the Retrieve methods of the
-	// Session that retrieved the value were made.
+	// This method must only be called when the RetrieveEnd method of the Session that
+	// retrieved the value was successfully completed.
 	WatchForUpdate() error
 }
 

--- a/config/internal/configsource/component.go
+++ b/config/internal/configsource/component.go
@@ -101,7 +101,3 @@ type WatchableRetrieved interface {
 	// retrieved the value was successfully completed.
 	WatchForUpdate() error
 }
-
-// WatchForUpdate defines the signature used by the method used to monitor for updates
-// on a retrieved configuration.
-type WatchForUpdate func() error

--- a/config/internal/configsource/component.go
+++ b/config/internal/configsource/component.go
@@ -31,6 +31,12 @@ var ErrSessionClosed = errors.New("parent session was closed")
 // specific error must use errors.Is.
 var ErrValueUpdated = errors.New("configuration must retrieve the updated value")
 
+// ErrWatcherNotSupported is returned by WatchForUpdate functions when the configuration
+// source can't watch for updates on the value.
+// This error can be wrapped with additional information. Callers trying to identify this
+// specific error must use errors.Is.
+var ErrWatcherNotSupported = errors.New("value watcher is not supported")
+
 // ConfigSource is the interface to be implemented by objects used by the collector
 // to retrieve external configuration information.
 type ConfigSource interface {
@@ -78,12 +84,6 @@ type Session interface {
 type Retrieved interface {
 	// Value is the retrieved data that will be injected on the configuration.
 	Value() interface{}
-}
-
-// WatchableRetrieved holds the result of a call to the Retrieve method of a Session object
-// for a value that can be watched for updates.
-type WatchableRetrieved interface {
-	Retrieved
 
 	// WatchForUpdate must not return until one of the following happens:
 	//

--- a/config/internal/configsource/component.go
+++ b/config/internal/configsource/component.go
@@ -85,7 +85,7 @@ type Retrieved interface {
 	// Value is the retrieved data that will be injected on the configuration.
 	Value() interface{}
 
-	// WatchForUpdate is used to monitor for updates on the retrived value.
+	// WatchForUpdate is used to monitor for updates on the retrieved value.
 	//
 	// If a watcher is not supported by the configuration store in general or for the specific
 	// retrieved value the WatchForUpdate must immediately return ErrWatcherNotSupported or

--- a/config/internal/configsource/component.go
+++ b/config/internal/configsource/component.go
@@ -85,7 +85,13 @@ type Retrieved interface {
 	// Value is the retrieved data that will be injected on the configuration.
 	Value() interface{}
 
-	// WatchForUpdate must not return until one of the following happens:
+	// WatchForUpdate is used to monitor for updates on the retrived value.
+	//
+	// If a watcher is not supported by the configuration store in general or for the specific
+	// retrieved value the WatchForUpdate must immediately return ErrWatcherNotSupported or
+	// an error wrapping it.
+	//
+	// When watching is supported WatchForUpdate must not return until one of the following happens:
 	//
 	// 1. An update is detected for the monitored value. In this case the function should
 	//    return ErrValueUpdated or an error wrapping it.


### PR DESCRIPTION
Small refinements to the configsource interface:

- Changing Retrieved to interface;
- Separating the watching capability in a separate interface: WatchableRetrieved;
- Adding a specific error to signal that the watched value was updated;