### PR TITLE
Add systemd environment file for deb/rpm packages

### DIFF
--- a/internal/buildscripts/packaging/fpm/common.sh
+++ b/internal/buildscripts/packaging/fpm/common.sh
@@ -29,6 +29,7 @@ SERVICE_NAME="otel-collector"
 PROCESS_NAME="otelcol"
 
 SERVICE_PATH="$FPM_DIR/$SERVICE_NAME.service"
+ENVFILE_PATH="$FPM_DIR/$SERVICE_NAME.conf"
 PREINSTALL_PATH="$FPM_DIR/preinstall.sh"
 POSTINSTALL_PATH="$FPM_DIR/postinstall.sh"
 PREUNINSTALL_PATH="$FPM_DIR/preuninstall.sh"

--- a/internal/buildscripts/packaging/fpm/deb/build.sh
+++ b/internal/buildscripts/packaging/fpm/deb/build.sh
@@ -40,6 +40,7 @@ fpm -s dir -t deb -n $PKG_NAME -v ${VERSION#v} -f -p "$OUTPUT_DIR" \
     --license "$PKG_LICENSE" \
     --url "$PKG_URL" \
     --architecture "$ARCH" \
+    --config-files /etc/otel-collector/otel-collector.conf \
     --config-files /etc/otel-collector/config.yaml \
     --deb-dist "stable" \
     --deb-user "$PKG_USER" \
@@ -49,4 +50,5 @@ fpm -s dir -t deb -n $PKG_NAME -v ${VERSION#v} -f -p "$OUTPUT_DIR" \
     --pre-uninstall "$PREUNINSTALL_PATH" \
     $OTELCOL_PATH=/usr/bin/$PROCESS_NAME \
     $SERVICE_PATH=/lib/systemd/system/$SERVICE_NAME.service \
+    $ENVFILE_PATH=/etc/otel-collector/otel-collector.conf \
     $CONFIG_PATH=/etc/otel-collector/config.yaml

--- a/internal/buildscripts/packaging/fpm/otel-collector.conf
+++ b/internal/buildscripts/packaging/fpm/otel-collector.conf
@@ -1,0 +1,5 @@
+# Systemd environment file for the otel-collector service
+
+# Command-line options for the otel-collector service.
+# Run `/usr/bin/otelcol --help` to see all available options.
+OTELCOL_OPTIONS="--config=/etc/otel-collector/config.yaml"

--- a/internal/buildscripts/packaging/fpm/otel-collector.service
+++ b/internal/buildscripts/packaging/fpm/otel-collector.service
@@ -3,7 +3,8 @@ Description=OpenTelemety Collector
 After=network.target
 
 [Service]
-ExecStart=/usr/bin/otelcol --config /etc/otel-collector/config.yaml
+EnvironmentFile=/etc/otel-collector/otel-collector.conf
+ExecStart=/usr/bin/otelcol $OTELCOL_OPTIONS
 KillMode=mixed
 Restart=on-failure
 Type=simple

--- a/internal/buildscripts/packaging/fpm/rpm/build.sh
+++ b/internal/buildscripts/packaging/fpm/rpm/build.sh
@@ -40,6 +40,7 @@ fpm -s dir -t rpm -n $PKG_NAME -v ${VERSION#v} -f -p "$OUTPUT_DIR" \
     --license "$PKG_LICENSE" \
     --url "$PKG_URL" \
     --architecture "$ARCH" \
+    --config-files /etc/otel-collector/otel-collector.conf \
     --config-files /etc/otel-collector/config.yaml \
     --rpm-summary "$PKG_DESCRIPTION" \
     --rpm-user "$PKG_USER" \
@@ -49,4 +50,5 @@ fpm -s dir -t rpm -n $PKG_NAME -v ${VERSION#v} -f -p "$OUTPUT_DIR" \
     --pre-uninstall "$PREUNINSTALL_PATH" \
     $OTELCOL_PATH=/usr/bin/$PROCESS_NAME \
     $SERVICE_PATH=/lib/systemd/system/$SERVICE_NAME.service \
+    $ENVFILE_PATH=/etc/otel-collector/otel-collector.conf \
     $CONFIG_PATH=/etc/otel-collector/config.yaml


### PR DESCRIPTION
**Description:**
Include a systemd environment file in the deb/rpm packages for the `otel-collector` service that allows the user to configure the otelcol startup options and add custom environment variables when running the collector as a service.  Default otelcol option is `--config=/etc/otel-collector/config.yaml`.

**Link to tracking Issue:**
#2255 

**Testing:**
Tested locally and in CI.

**Documentation:**
https://github.com/open-telemetry/opentelemetry.io/pull/500