### PR TITLE
Change health_check default endpoint to 0.0.0.0:13133

### DIFF
--- a/extension/healthcheckextension/README.md
+++ b/extension/healthcheckextension/README.md
@@ -6,7 +6,7 @@ liveness and/or readiness probe on Kubernetes.
 
 The following settings are required:
 
-- `endpoint` (default = localhost:13133): Address to publish the health check status to
+- `endpoint` (default = 0.0.0.0:13133): Address to publish the health check status to
 - `port` (default = 13133): [deprecated] What port to expose HTTP health information.
 
 Example:

--- a/extension/healthcheckextension/config.go
+++ b/extension/healthcheckextension/config.go
@@ -31,6 +31,6 @@ type Config struct {
 
 	// TCPAddr represents a tcp endpoint address that is to publish the health
 	// check status.
-	// The default endpoint is "localhost:13133".
+	// The default endpoint is "0.0.0.0:13133".
 	TCPAddr confignet.TCPAddr `mapstructure:",squash"`
 }

--- a/extension/healthcheckextension/factory.go
+++ b/extension/healthcheckextension/factory.go
@@ -27,7 +27,9 @@ const (
 	// The value of extension "type" in configuration.
 	typeStr = "health_check"
 
-	defaultEndpoint = "localhost:13133"
+	// Use 0.0.0.0 to make the health check endpoint accessible
+	// in container orchestration environments like Kubernetes.
+	defaultEndpoint = "0.0.0.0:13133"
 )
 
 // NewFactory creates a factory for HealthCheck extension.


### PR DESCRIPTION
This commits brings back default configuration of the health_check extension to make sure it works in k8s-like environments without extra configuration as it was before the latest change https://github.com/open-telemetry/opentelemetry-collector/pull/2782.

Resolves: https://github.com/open-telemetry/opentelemetry-collector/issues/2827
