### PR TITLE
Use confignet.TCPAddr in extentions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 - `batch` processor: - Support max batch size for logs (#2736)
 - Use `Endpoint` for health check extension (#2782)
+- Use `confignet.TCPAddr` for `pprof` and `zpages` extensions (#2829)
 
 ## 🧰 Bug fixes 🧰
 

--- a/extension/pprofextension/config.go
+++ b/extension/pprofextension/config.go
@@ -16,6 +16,7 @@ package pprofextension
 
 import (
 	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/config/confignet"
 )
 
 // Config has the configuration for the extension enabling the golang
@@ -23,10 +24,10 @@ import (
 type Config struct {
 	config.ExtensionSettings `mapstructure:",squash"`
 
-	// Endpoint is the address and port in which the pprof will be listening to.
+	// TCPAddr is the address and port in which the pprof will be listening to.
 	// Use localhost:<port> to make it available only locally, or ":<port>" to
 	// make it available on all network interfaces.
-	Endpoint string `mapstructure:"endpoint"`
+	TCPAddr confignet.TCPAddr `mapstructure:",squash"`
 
 	// Fraction of blocking events that are profiled. A value <= 0 disables
 	// profiling. See https://golang.org/pkg/runtime/#SetBlockProfileRate for details.

--- a/extension/pprofextension/config_test.go
+++ b/extension/pprofextension/config_test.go
@@ -23,6 +23,7 @@ import (
 
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/config/confignet"
 	"go.opentelemetry.io/collector/config/configtest"
 )
 
@@ -47,7 +48,7 @@ func TestLoadConfig(t *testing.T) {
 				TypeVal: "pprof",
 				NameVal: "pprof/1",
 			},
-			Endpoint:             "0.0.0.0:1777",
+			TCPAddr:              confignet.TCPAddr{Endpoint: "0.0.0.0:1777"},
 			BlockProfileFraction: 3,
 			MutexProfileFraction: 5,
 		},

--- a/extension/pprofextension/factory.go
+++ b/extension/pprofextension/factory.go
@@ -20,12 +20,15 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/config/confignet"
 	"go.opentelemetry.io/collector/extension/extensionhelper"
 )
 
 const (
 	// The value of extension "type" in configuration.
 	typeStr = "pprof"
+
+	defaultEndpoint = "localhost:1777"
 )
 
 // NewFactory creates a factory for pprof extension.
@@ -42,13 +45,15 @@ func createDefaultConfig() config.Extension {
 			TypeVal: typeStr,
 			NameVal: typeStr,
 		},
-		Endpoint: "localhost:1777",
+		TCPAddr: confignet.TCPAddr{
+			Endpoint: defaultEndpoint,
+		},
 	}
 }
 
 func createExtension(_ context.Context, params component.ExtensionCreateParams, cfg config.Extension) (component.Extension, error) {
 	config := cfg.(*Config)
-	if config.Endpoint == "" {
+	if config.TCPAddr.Endpoint == "" {
 		return nil, errors.New("\"endpoint\" is required when using the \"pprof\" extension")
 	}
 

--- a/extension/pprofextension/factory_test.go
+++ b/extension/pprofextension/factory_test.go
@@ -25,6 +25,7 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/configcheck"
+	"go.opentelemetry.io/collector/config/confignet"
 	"go.opentelemetry.io/collector/testutil"
 )
 
@@ -35,7 +36,7 @@ func TestFactory_CreateDefaultConfig(t *testing.T) {
 			NameVal: typeStr,
 			TypeVal: typeStr,
 		},
-		Endpoint: "localhost:1777",
+		TCPAddr: confignet.TCPAddr{Endpoint: defaultEndpoint},
 	},
 		cfg)
 
@@ -47,7 +48,7 @@ func TestFactory_CreateDefaultConfig(t *testing.T) {
 
 func TestFactory_CreateExtension(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)
-	cfg.Endpoint = testutil.GetAvailableLocalAddress(t)
+	cfg.TCPAddr.Endpoint = testutil.GetAvailableLocalAddress(t)
 
 	ext, err := createExtension(context.Background(), component.ExtensionCreateParams{Logger: zap.NewNop()}, cfg)
 	require.NoError(t, err)

--- a/extension/pprofextension/pprofextension.go
+++ b/extension/pprofextension/pprofextension.go
@@ -68,7 +68,7 @@ func (p *pprofExtension) Start(_ context.Context, host component.Host) error {
 	// Start the listener here so we can have earlier failure if port is
 	// already in use.
 	var ln net.Listener
-	ln, startErr = net.Listen("tcp", p.config.Endpoint)
+	ln, startErr = p.config.TCPAddr.Listen()
 	if startErr != nil {
 		return startErr
 	}

--- a/extension/pprofextension/pprofextension_test.go
+++ b/extension/pprofextension/pprofextension_test.go
@@ -27,12 +27,15 @@ import (
 	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/config/confignet"
 	"go.opentelemetry.io/collector/testutil"
 )
 
 func TestPerformanceProfilerExtensionUsage(t *testing.T) {
 	config := Config{
-		Endpoint:             testutil.GetAvailableLocalAddress(t),
+		TCPAddr: confignet.TCPAddr{
+			Endpoint: testutil.GetAvailableLocalAddress(t),
+		},
 		BlockProfileFraction: 3,
 		MutexProfileFraction: 5,
 	}
@@ -46,7 +49,7 @@ func TestPerformanceProfilerExtensionUsage(t *testing.T) {
 	// Give a chance for the server goroutine to run.
 	runtime.Gosched()
 
-	_, pprofPort, err := net.SplitHostPort(config.Endpoint)
+	_, pprofPort, err := net.SplitHostPort(config.TCPAddr.Endpoint)
 	require.NoError(t, err)
 
 	client := &http.Client{}
@@ -64,7 +67,9 @@ func TestPerformanceProfilerExtensionPortAlreadyInUse(t *testing.T) {
 	defer ln.Close()
 
 	config := Config{
-		Endpoint: endpoint,
+		TCPAddr: confignet.TCPAddr{
+			Endpoint: endpoint,
+		},
 	}
 	pprofExt := newServer(config, zap.NewNop())
 	require.NotNil(t, pprofExt)
@@ -74,7 +79,9 @@ func TestPerformanceProfilerExtensionPortAlreadyInUse(t *testing.T) {
 
 func TestPerformanceProfilerMultipleStarts(t *testing.T) {
 	config := Config{
-		Endpoint: testutil.GetAvailableLocalAddress(t),
+		TCPAddr: confignet.TCPAddr{
+			Endpoint: testutil.GetAvailableLocalAddress(t),
+		},
 	}
 
 	pprofExt := newServer(config, zap.NewNop())
@@ -89,7 +96,9 @@ func TestPerformanceProfilerMultipleStarts(t *testing.T) {
 
 func TestPerformanceProfilerMultipleShutdowns(t *testing.T) {
 	config := Config{
-		Endpoint: testutil.GetAvailableLocalAddress(t),
+		TCPAddr: confignet.TCPAddr{
+			Endpoint: testutil.GetAvailableLocalAddress(t),
+		},
 	}
 
 	pprofExt := newServer(config, zap.NewNop())
@@ -102,7 +111,9 @@ func TestPerformanceProfilerMultipleShutdowns(t *testing.T) {
 
 func TestPerformanceProfilerShutdownWithoutStart(t *testing.T) {
 	config := Config{
-		Endpoint: testutil.GetAvailableLocalAddress(t),
+		TCPAddr: confignet.TCPAddr{
+			Endpoint: testutil.GetAvailableLocalAddress(t),
+		},
 	}
 
 	pprofExt := newServer(config, zap.NewNop())
@@ -120,7 +131,9 @@ func TestPerformanceProfilerLifecycleWithFile(t *testing.T) {
 	require.NoError(t, tmpFile.Close())
 
 	config := Config{
-		Endpoint:   testutil.GetAvailableLocalAddress(t),
+		TCPAddr: confignet.TCPAddr{
+			Endpoint: testutil.GetAvailableLocalAddress(t),
+		},
 		SaveToFile: tmpFile.Name(),
 	}
 

--- a/extension/zpagesextension/config.go
+++ b/extension/zpagesextension/config.go
@@ -16,14 +16,15 @@ package zpagesextension
 
 import (
 	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/config/confignet"
 )
 
 // Config has the configuration for the extension enabling the zPages extension.
 type Config struct {
 	config.ExtensionSettings `mapstructure:",squash"`
 
-	// Endpoint is the address and port in which the zPages will be listening to.
+	// TCPAddr is the address and port in which the zPages will be listening to.
 	// Use localhost:<port> to make it available only locally, or ":<port>" to
 	// make it available on all network interfaces.
-	Endpoint string `mapstructure:"endpoint"`
+	TCPAddr confignet.TCPAddr `mapstructure:",squash"`
 }

--- a/extension/zpagesextension/config_test.go
+++ b/extension/zpagesextension/config_test.go
@@ -23,6 +23,7 @@ import (
 
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/config/confignet"
 	"go.opentelemetry.io/collector/config/configtest"
 )
 
@@ -47,7 +48,9 @@ func TestLoadConfig(t *testing.T) {
 				TypeVal: "zpages",
 				NameVal: "zpages/1",
 			},
-			Endpoint: "localhost:56888",
+			TCPAddr: confignet.TCPAddr{
+				Endpoint: "localhost:56888",
+			},
 		},
 		ext1)
 

--- a/extension/zpagesextension/factory.go
+++ b/extension/zpagesextension/factory.go
@@ -20,12 +20,15 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/config/confignet"
 	"go.opentelemetry.io/collector/extension/extensionhelper"
 )
 
 const (
 	// The value of extension "type" in configuration.
 	typeStr = "zpages"
+
+	defaultEndpoint = "localhost:55679"
 )
 
 // NewFactory creates a factory for Z-Pages extension.
@@ -42,14 +45,16 @@ func createDefaultConfig() config.Extension {
 			TypeVal: typeStr,
 			NameVal: typeStr,
 		},
-		Endpoint: "localhost:55679",
+		TCPAddr: confignet.TCPAddr{
+			Endpoint: defaultEndpoint,
+		},
 	}
 }
 
 // createExtension creates the extension based on this config.
 func createExtension(_ context.Context, params component.ExtensionCreateParams, cfg config.Extension) (component.Extension, error) {
 	config := cfg.(*Config)
-	if config.Endpoint == "" {
+	if config.TCPAddr.Endpoint == "" {
 		return nil, errors.New("\"endpoint\" is required when using the \"zpages\" extension")
 	}
 

--- a/extension/zpagesextension/factory_test.go
+++ b/extension/zpagesextension/factory_test.go
@@ -25,6 +25,7 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/configcheck"
+	"go.opentelemetry.io/collector/config/confignet"
 	"go.opentelemetry.io/collector/testutil"
 )
 
@@ -35,7 +36,9 @@ func TestFactory_CreateDefaultConfig(t *testing.T) {
 			NameVal: typeStr,
 			TypeVal: typeStr,
 		},
-		Endpoint: "localhost:55679",
+		TCPAddr: confignet.TCPAddr{
+			Endpoint: "localhost:55679",
+		},
 	},
 		cfg)
 
@@ -47,7 +50,7 @@ func TestFactory_CreateDefaultConfig(t *testing.T) {
 
 func TestFactory_CreateExtension(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)
-	cfg.Endpoint = testutil.GetAvailableLocalAddress(t)
+	cfg.TCPAddr.Endpoint = testutil.GetAvailableLocalAddress(t)
 
 	ext, err := createExtension(context.Background(), component.ExtensionCreateParams{Logger: zap.NewNop()}, cfg)
 	require.NoError(t, err)

--- a/extension/zpagesextension/zpagesextension.go
+++ b/extension/zpagesextension/zpagesextension.go
@@ -16,7 +16,6 @@ package zpagesextension
 
 import (
 	"context"
-	"net"
 	"net/http"
 
 	"go.opencensus.io/zpages"
@@ -48,7 +47,7 @@ func (zpe *zpagesExtension) Start(_ context.Context, host component.Host) error 
 
 	// Start the listener here so we can have earlier failure if port is
 	// already in use.
-	ln, err := net.Listen("tcp", zpe.config.Endpoint)
+	ln, err := zpe.config.TCPAddr.Listen()
 	if err != nil {
 		return err
 	}

--- a/extension/zpagesextension/zpagesextension_test.go
+++ b/extension/zpagesextension/zpagesextension_test.go
@@ -25,12 +25,15 @@ import (
 	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/config/confignet"
 	"go.opentelemetry.io/collector/testutil"
 )
 
 func TestZPagesExtensionUsage(t *testing.T) {
 	config := Config{
-		Endpoint: testutil.GetAvailableLocalAddress(t),
+		TCPAddr: confignet.TCPAddr{
+			Endpoint: testutil.GetAvailableLocalAddress(t),
+		},
 	}
 
 	zpagesExt := newServer(config, zap.NewNop())
@@ -42,7 +45,7 @@ func TestZPagesExtensionUsage(t *testing.T) {
 	// Give a chance for the server goroutine to run.
 	runtime.Gosched()
 
-	_, zpagesPort, err := net.SplitHostPort(config.Endpoint)
+	_, zpagesPort, err := net.SplitHostPort(config.TCPAddr.Endpoint)
 	require.NoError(t, err)
 
 	client := &http.Client{}
@@ -60,7 +63,9 @@ func TestZPagesExtensionPortAlreadyInUse(t *testing.T) {
 	defer ln.Close()
 
 	config := Config{
-		Endpoint: endpoint,
+		TCPAddr: confignet.TCPAddr{
+			Endpoint: endpoint,
+		},
 	}
 	zpagesExt := newServer(config, zap.NewNop())
 	require.NotNil(t, zpagesExt)
@@ -70,7 +75,9 @@ func TestZPagesExtensionPortAlreadyInUse(t *testing.T) {
 
 func TestZPagesMultipleStarts(t *testing.T) {
 	config := Config{
-		Endpoint: testutil.GetAvailableLocalAddress(t),
+		TCPAddr: confignet.TCPAddr{
+			Endpoint: testutil.GetAvailableLocalAddress(t),
+		},
 	}
 
 	zpagesExt := newServer(config, zap.NewNop())
@@ -85,7 +92,9 @@ func TestZPagesMultipleStarts(t *testing.T) {
 
 func TestZPagesMultipleShutdowns(t *testing.T) {
 	config := Config{
-		Endpoint: testutil.GetAvailableLocalAddress(t),
+		TCPAddr: confignet.TCPAddr{
+			Endpoint: testutil.GetAvailableLocalAddress(t),
+		},
 	}
 
 	zpagesExt := newServer(config, zap.NewNop())
@@ -98,7 +107,9 @@ func TestZPagesMultipleShutdowns(t *testing.T) {
 
 func TestZPagesShutdownWithoutStart(t *testing.T) {
 	config := Config{
-		Endpoint: testutil.GetAvailableLocalAddress(t),
+		TCPAddr: confignet.TCPAddr{
+			Endpoint: testutil.GetAvailableLocalAddress(t),
+		},
 	}
 
 	zpagesExt := newServer(config, zap.NewNop())

--- a/service/defaultcomponents/default_extensions_test.go
+++ b/service/defaultcomponents/default_extensions_test.go
@@ -54,7 +54,7 @@ func TestDefaultExtensions(t *testing.T) {
 			extension: "pprof",
 			getConfigFn: func() config.Extension {
 				cfg := extFactories["pprof"].CreateDefaultConfig().(*pprofextension.Config)
-				cfg.Endpoint = endpoint
+				cfg.TCPAddr.Endpoint = endpoint
 				return cfg
 			},
 		},
@@ -62,7 +62,7 @@ func TestDefaultExtensions(t *testing.T) {
 			extension: "zpages",
 			getConfigFn: func() config.Extension {
 				cfg := extFactories["zpages"].CreateDefaultConfig().(*zpagesextension.Config)
-				cfg.Endpoint = endpoint
+				cfg.TCPAddr.Endpoint = endpoint
 				return cfg
 			},
 		},


### PR DESCRIPTION
**Description:**
Change `pprof` and `zpages` extensions' configs to use `confignet.TCPAddr` instead of `Endpoint` string.

**Link to tracking Issue:** #2764
