### PR TITLE
Add missing documentation

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -132,6 +132,15 @@ issues:
     - text: "G402:"
       linters:
         - gosec
+    # Exclude internal and testbed packages for now.
+    - path: ".*internal.*|.*testbed.*"
+      text: "should have comment|should be of the form"
+      linters:
+        - golint
+    # Exclude documenting constant blocks.
+    - text: "or a comment on this block"
+      linters:
+        - golint
 
   # The list of ids of default excludes to include or disable. By default it's empty.
   # See the list of default excludes here https://golangci-lint.run/usage/configuration.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -133,22 +133,11 @@ issues:
       linters:
         - gosec
 
-    # Exclude internal and testbed packages for now.
-    - path: ".*internal.*|.*testbed.*"
-      text: "should have comment|should be of the form"
-      linters:
-        - golint
-
-    # Exclude documenting constant blocks.
-    - text: "or a comment on this block"
-      linters:
-        - golint
-
   # The list of ids of default excludes to include or disable. By default it's empty.
   # See the list of default excludes here https://golangci-lint.run/usage/configuration.
   include:
     - EXC0001
-    - EXC0002
+    # - EXC0002 - TODO: Enable this
     - EXC0003
     - EXC0004
     - EXC0005

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -133,16 +133,27 @@ issues:
       linters:
         - gosec
 
+    # Exclude internal and testbed packages for now.
+    - path: ".*internal.*|.*testbed.*"
+      text: "should have comment|should be of the form"
+      linters:
+        - golint
+
+    # Exclude documenting constant blocks.
+    - text: "or a comment on this block"
+      linters:
+        - golint
+
   # The list of ids of default excludes to include or disable. By default it's empty.
   # See the list of default excludes here https://golangci-lint.run/usage/configuration.
   include:
     - EXC0001
-    # - EXC0002 - TODO: Enable this
+    - EXC0002
     - EXC0003
     - EXC0004
     - EXC0005
     - EXC0006
-    # - EXC0007 - TODO: Enable this
+    - EXC0007
     # - EXC0008 - Duplicated errcheck checks
     - EXC0009
     - EXC0010

--- a/cmd/mdatagen/metricdata.go
+++ b/cmd/mdatagen/metricdata.go
@@ -76,12 +76,14 @@ type MetricData interface {
 	HasAggregated() bool
 }
 
+// Aggregated defines a metric aggregation type.
 type Aggregated struct {
 	// Aggregation describes if the aggregator reports delta changes
 	// since last report time, or cumulative changes since a fixed start time.
 	Aggregation string `yaml:"aggregation" validate:"oneof=delta cumulative"`
 }
 
+// Type gets the metric aggregation type.
 func (agg Aggregated) Type() string {
 	switch agg.Aggregation {
 	case "delta":
@@ -93,6 +95,7 @@ func (agg Aggregated) Type() string {
 	}
 }
 
+// Mono defines the metric monotonicity.
 type Mono struct {
 	// Monotonic is true if the sum is monotonic.
 	Monotonic bool `yaml:"monotonic"`

--- a/cmd/schemagen/schemagen/cli.go
+++ b/cmd/schemagen/schemagen/cli.go
@@ -21,6 +21,7 @@ import (
 	"go.opentelemetry.io/collector/component"
 )
 
+// CLI defines the command-line interface for the schemagen util.
 func CLI(c component.Factories) {
 	prepUsage()
 

--- a/component/componenttest/shutdown_verifier.go
+++ b/component/componenttest/shutdown_verifier.go
@@ -62,6 +62,7 @@ func verifyTraceProcessorDoesntProduceAfterShutdown(t *testing.T, factory compon
 	assert.EqualValues(t, generatedCount, nextSink.SpansCount())
 }
 
+// VerifyProcessorShutdown verifies the processor doesn't produce telemetry data after shutdown.
 func VerifyProcessorShutdown(t *testing.T, factory component.ProcessorFactory, cfg config.Processor) {
 	verifyTraceProcessorDoesntProduceAfterShutdown(t, factory, cfg)
 	// TODO: add metrics and logs verification.

--- a/config/config.go
+++ b/config/config.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package configmodels defines the data models for entities. This file defines the
+// Package config defines the data models for entities. This file defines the
 // models for configuration format. The defined entities are:
 // Config (the top-level structure), Receivers, Exporters, Processors, Pipelines.
 //

--- a/config/confighttp/confighttp.go
+++ b/config/confighttp/confighttp.go
@@ -26,6 +26,7 @@ import (
 	"go.opentelemetry.io/collector/internal/middleware"
 )
 
+// HTTPClientSettings defines settings for creating an HTTP client.
 type HTTPClientSettings struct {
 	// The target URL to send data to (e.g.: http://some.url:9411/v1/traces).
 	Endpoint string `mapstructure:"endpoint"`
@@ -50,6 +51,7 @@ type HTTPClientSettings struct {
 	CustomRoundTripper func(next http.RoundTripper) (http.RoundTripper, error)
 }
 
+// ToClient creates an HTTP client.
 func (hcs *HTTPClientSettings) ToClient() (*http.Client, error) {
 	tlsCfg, err := hcs.TLSSetting.LoadTLSConfig()
 	if err != nil {
@@ -102,6 +104,7 @@ func (interceptor *headerRoundTripper) RoundTrip(req *http.Request) (*http.Respo
 	return interceptor.transport.RoundTrip(req)
 }
 
+// HTTPServerSettings defines settings for creating an HTTP server.
 type HTTPServerSettings struct {
 	// Endpoint configures the listening address for the server.
 	Endpoint string `mapstructure:"endpoint"`
@@ -122,6 +125,7 @@ type HTTPServerSettings struct {
 	CorsHeaders []string `mapstructure:"cors_allowed_headers"`
 }
 
+// ToListener creates a net.Listener.
 func (hss *HTTPServerSettings) ToListener() (net.Listener, error) {
 	listener, err := net.Listen("tcp", hss.Endpoint)
 	if err != nil {
@@ -145,6 +149,8 @@ type toServerOptions struct {
 	errorHandler middleware.ErrorHandler
 }
 
+// ToServerOption is an option to change the behavior of the HTTP server
+// returned by HTTPServerSettings.ToServer().
 type ToServerOption func(opts *toServerOptions)
 
 // WithErrorHandler overrides the HTTP error handler that gets invoked
@@ -155,6 +161,7 @@ func WithErrorHandler(e middleware.ErrorHandler) ToServerOption {
 	}
 }
 
+// ToServer creates an http.Server from settings object.
 func (hss *HTTPServerSettings) ToServer(handler http.Handler, opts ...ToServerOption) *http.Server {
 	serverOpts := &toServerOptions{}
 	for _, o := range opts {

--- a/config/configparser/config.go
+++ b/config/configparser/config.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package config implements loading of configuration from Viper configuration.
+// Package configparser implements loading of configuration from Viper configuration.
 // The implementation relies on registered factories that allow creating
 // default configuration for each type of receiver/exporter/processor.
 package configparser

--- a/config/configtelemetry/configtelemetry.go
+++ b/config/configtelemetry/configtelemetry.go
@@ -69,6 +69,7 @@ func (l *Level) String() string {
 	return "unknown"
 }
 
+// Set sets the telemetry level.
 func (l *Level) Set(s string) error {
 	lvl, err := parseLevel(s)
 	if err != nil {

--- a/config/parser.go
+++ b/config/parser.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package config implements the configuration Parser.
 package config
 
 import (

--- a/config/parser.go
+++ b/config/parser.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// package config implements the configuration Parser.
+// Package config implements the configuration Parser.
 package config
 
 import (
@@ -58,6 +58,7 @@ func ParserFromViper(v *viper.Viper) *Parser {
 	return &Parser{v: v}
 }
 
+// NewParserFromStringMap creates a parser from a map[string]interface{}.
 func NewParserFromStringMap(data map[string]interface{}) *Parser {
 	v := NewViper()
 	// Cannot return error because the subv is empty.

--- a/consumer/pdata/common.go
+++ b/consumer/pdata/common.go
@@ -266,6 +266,7 @@ func (a AttributeValue) copyTo(dest *otlpcommon.AnyValue) {
 	}
 }
 
+// CopyTo copies the attribute to a destination.
 func (a AttributeValue) CopyTo(dest AttributeValue) {
 	a.copyTo(dest.orig)
 }

--- a/consumer/pdata/log.go
+++ b/consumer/pdata/log.go
@@ -99,6 +99,7 @@ func (ld Logs) OtlpProtoSize() int {
 	return ld.orig.Size()
 }
 
+// ResourceLogs returns the ResourceLogsSlice associated with this Logs.
 func (ld Logs) ResourceLogs() ResourceLogsSlice {
 	return newResourceLogsSlice(&ld.orig.ResourceLogs)
 }

--- a/consumer/simple/metrics.go
+++ b/consumer/simple/metrics.go
@@ -122,7 +122,7 @@ func (mb *Metrics) WithLabels(l map[string]string) *Metrics {
 	return out
 }
 
-// AsSafeBuilder returns an instance of this builder wrapped in
+// AsSafe returns an instance of this builder wrapped in
 // SafeMetrics that ensures all of the public methods on this instance
 // will be thread-safe between goroutines.  You must explicitly type these
 // instances as SafeMetrics.
@@ -133,35 +133,41 @@ func (mb Metrics) AsSafe() *SafeMetrics {
 	}
 }
 
+// AddGaugeDataPoint adds an integer gauge data point.
 func (mb *Metrics) AddGaugeDataPoint(name string, metricValue int64) *Metrics {
 	typ := pdata.MetricDataTypeIntGauge
 	mb.addDataPoint(name, typ, metricValue)
 	return mb
 }
 
+// AddDGaugeDataPoint adds a double gauge data point.
 func (mb *Metrics) AddDGaugeDataPoint(name string, metricValue float64) *Metrics {
 	typ := pdata.MetricDataTypeDoubleGauge
 	mb.addDataPoint(name, typ, metricValue)
 	return mb
 }
 
+// AddSumDataPoint adds an integer sum data point.
 func (mb *Metrics) AddSumDataPoint(name string, metricValue int64) *Metrics {
 	typ := pdata.MetricDataTypeIntSum
 	mb.addDataPoint(name, typ, metricValue)
 	return mb
 }
 
+// AddDSumDataPoint adds a double sum data point.
 func (mb *Metrics) AddDSumDataPoint(name string, metricValue float64) *Metrics {
 	typ := pdata.MetricDataTypeDoubleSum
 	mb.addDataPoint(name, typ, metricValue)
 	return mb
 }
 
+// AddHistogramRawDataPoint adds an integer histogram data point.
 func (mb *Metrics) AddHistogramRawDataPoint(name string, hist pdata.IntHistogramDataPoint) *Metrics {
 	mb.addDataPoint(name, pdata.MetricDataTypeIntHistogram, hist)
 	return mb
 }
 
+// AddDHistogramRawDataPoint adds a double histogram data point.
 func (mb *Metrics) AddDHistogramRawDataPoint(name string, hist pdata.HistogramDataPoint) *Metrics {
 	mb.addDataPoint(name, pdata.MetricDataTypeHistogram, hist)
 	return mb
@@ -300,13 +306,14 @@ func cloneStringMap(m map[string]string) map[string]string {
 }
 
 // SafeMetrics is a wrapper for Metrics that ensures the wrapped
-// instance can be used safely across goroutines.  It is meant to be created
-// from the AsSafeBuilder on Metrics.
+// instance can be used safely across goroutines. It is meant to be created
+// from the AsSafe on Metrics.
 type SafeMetrics struct {
 	*sync.Mutex
 	*Metrics
 }
 
+// WithLabels wraps Metrics.WithLabels.
 func (mb *SafeMetrics) WithLabels(l map[string]string) *SafeMetrics {
 	mb.Lock()
 	defer mb.Unlock()
@@ -317,6 +324,7 @@ func (mb *SafeMetrics) WithLabels(l map[string]string) *SafeMetrics {
 	}
 }
 
+// AddGaugeDataPoint wraps Metrics.AddGaugeDataPoint.
 func (mb *SafeMetrics) AddGaugeDataPoint(name string, metricValue int64) *SafeMetrics {
 	mb.Lock()
 	mb.Metrics.AddGaugeDataPoint(name, metricValue)
@@ -324,6 +332,7 @@ func (mb *SafeMetrics) AddGaugeDataPoint(name string, metricValue int64) *SafeMe
 	return mb
 }
 
+// AddDGaugeDataPoint wraps Metrics.AddDGaugeDataPoint.
 func (mb *SafeMetrics) AddDGaugeDataPoint(name string, metricValue float64) *SafeMetrics {
 	mb.Lock()
 	mb.Metrics.AddDGaugeDataPoint(name, metricValue)
@@ -331,6 +340,7 @@ func (mb *SafeMetrics) AddDGaugeDataPoint(name string, metricValue float64) *Saf
 	return mb
 }
 
+// AddSumDataPoint wraps Metrics.AddSumDataPoint.
 func (mb *SafeMetrics) AddSumDataPoint(name string, metricValue int64) *SafeMetrics {
 	mb.Lock()
 	mb.Metrics.AddSumDataPoint(name, metricValue)
@@ -338,6 +348,7 @@ func (mb *SafeMetrics) AddSumDataPoint(name string, metricValue int64) *SafeMetr
 	return mb
 }
 
+// AddDSumDataPoint wraps Metrics.AddDSumDataPoint.
 func (mb *SafeMetrics) AddDSumDataPoint(name string, metricValue float64) *SafeMetrics {
 	mb.Lock()
 	mb.Metrics.AddDSumDataPoint(name, metricValue)
@@ -345,6 +356,7 @@ func (mb *SafeMetrics) AddDSumDataPoint(name string, metricValue float64) *SafeM
 	return mb
 }
 
+// AddHistogramRawDataPoint wraps Metrics.AddHistogramRawDataPoint.
 func (mb *SafeMetrics) AddHistogramRawDataPoint(name string, hist pdata.IntHistogramDataPoint) *SafeMetrics {
 	mb.Lock()
 	mb.Metrics.AddHistogramRawDataPoint(name, hist)
@@ -352,6 +364,7 @@ func (mb *SafeMetrics) AddHistogramRawDataPoint(name string, hist pdata.IntHisto
 	return mb
 }
 
+// AddDHistogramRawDataPoint wraps AddDHistogramRawDataPoint.
 func (mb *SafeMetrics) AddDHistogramRawDataPoint(name string, hist pdata.HistogramDataPoint) *SafeMetrics {
 	mb.Lock()
 	mb.Metrics.AddDHistogramRawDataPoint(name, hist)

--- a/exporter/exporterhelper/factory.go
+++ b/exporter/exporterhelper/factory.go
@@ -36,7 +36,7 @@ type CreateTracesExporter func(context.Context, component.ExporterCreateParams, 
 // CreateMetricsExporter is the equivalent of component.ExporterFactory.CreateMetricsExporter()
 type CreateMetricsExporter func(context.Context, component.ExporterCreateParams, config.Exporter) (component.MetricsExporter, error)
 
-// CreateMetricsExporter is the equivalent of component.ExporterFactory.CreateLogsExporter()
+// CreateLogsExporter is the equivalent of component.ExporterFactory.CreateLogsExporter()
 type CreateLogsExporter func(context.Context, component.ExporterCreateParams, config.Exporter) (component.LogsExporter, error)
 
 type factory struct {

--- a/exporter/exporterhelper/queued_retry.go
+++ b/exporter/exporterhelper/queued_retry.go
@@ -181,6 +181,7 @@ type throttleRetry struct {
 	delay time.Duration
 }
 
+// NewThrottleRetry creates a new throttle retry error.
 func NewThrottleRetry(err error, delay time.Duration) error {
 	return &throttleRetry{
 		error: err,

--- a/exporter/kafkaexporter/scram_client.go
+++ b/exporter/kafkaexporter/scram_client.go
@@ -28,6 +28,7 @@ type XDGSCRAMClient struct {
 	scram.HashGeneratorFcn
 }
 
+// Begin starts the XDGSCRAMClient conversation.
 func (x *XDGSCRAMClient) Begin(userName, password, authzID string) (err error) {
 	x.Client, err = x.HashGeneratorFcn.NewClient(userName, password, authzID)
 	if err != nil {
@@ -37,11 +38,17 @@ func (x *XDGSCRAMClient) Begin(userName, password, authzID string) (err error) {
 	return nil
 }
 
+// Step takes a string provided from a server (or just an empty string for the
+// very first conversation step) and attempts to move the authentication
+// conversation forward.  It returns a string to be sent to the server or an
+// error if the server message is invalid.  Calling Step after a conversation
+// completes is also an error.
 func (x *XDGSCRAMClient) Step(challenge string) (response string, err error) {
 	return x.ClientConversation.Step(challenge)
 
 }
 
+// Done returns true if the conversation is completed or has errored.
 func (x *XDGSCRAMClient) Done() bool {
 	return x.ClientConversation.Done()
 }

--- a/exporter/prometheusexporter/factory.go
+++ b/exporter/prometheusexporter/factory.go
@@ -28,6 +28,7 @@ const (
 	typeStr = "prometheus"
 )
 
+// NewFactory creates a new Prometheus exporter factory.
 func NewFactory() component.ExporterFactory {
 	return exporterhelper.NewFactory(
 		typeStr,

--- a/exporter/prometheusexporter/sanitize.go
+++ b/exporter/prometheusexporter/sanitize.go
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// The code for sanitize is mostly copied from:
-//  https://github.com/census-instrumentation/opencensus-go/blob/950a67f393d867cfbe91414063b69e511f42fefb/internal/sanitize.go#L1-L50
 package prometheusexporter
 
 import (
@@ -22,6 +20,8 @@ import (
 )
 
 // sanitize replaces non-alphanumeric characters with underscores in s.
+// The code for sanitize is mostly copied from:
+//  https://github.com/census-instrumentation/opencensus-go/blob/950a67f393d867cfbe91414063b69e511f42fefb/internal/sanitize.go#L1-L50
 func sanitize(s string) string {
 	if len(s) == 0 {
 		return s

--- a/exporter/prometheusremotewriteexporter/factory.go
+++ b/exporter/prometheusremotewriteexporter/factory.go
@@ -29,6 +29,7 @@ const (
 	typeStr = "prometheusremotewrite"
 )
 
+// NewFactory creates a new Prometheus Remote Write exporter.
 func NewFactory() component.ExporterFactory {
 	return exporterhelper.NewFactory(
 		typeStr,

--- a/obsreport/obsreport_exporter.go
+++ b/obsreport/obsreport_exporter.go
@@ -25,22 +25,22 @@ import (
 )
 
 const (
-	// Key used to identify exporters in metrics and traces.
+	// ExporterKey used to identify exporters in metrics and traces.
 	ExporterKey = "exporter"
 
-	// Key used to track spans sent by exporters.
+	// SentSpansKey used to track spans sent by exporters.
 	SentSpansKey = "sent_spans"
-	// Key used to track spans that failed to be sent by exporters.
+	// FailedToSendSpansKey used to track spans that failed to be sent by exporters.
 	FailedToSendSpansKey = "send_failed_spans"
 
-	// Key used to track metric points sent by exporters.
+	// SentMetricPointsKey used to track metric points sent by exporters.
 	SentMetricPointsKey = "sent_metric_points"
-	// Key used to track metric points that failed to be sent by exporters.
+	// FailedToSendMetricPointsKey used to track metric points that failed to be sent by exporters.
 	FailedToSendMetricPointsKey = "send_failed_metric_points"
 
-	// Key used to track logs sent by exporters.
+	// SentLogRecordsKey used to track logs sent by exporters.
 	SentLogRecordsKey = "sent_log_records"
-	// Key used to track logs that failed to be sent by exporters.
+	// FailedToSendLogRecordsKey used to track logs that failed to be sent by exporters.
 	FailedToSendLogRecordsKey = "send_failed_log_records"
 )
 
@@ -83,17 +83,20 @@ var (
 		stats.UnitDimensionless)
 )
 
+// Exporter is a helper to add observability to a component.Exporter.
 type Exporter struct {
 	level        configtelemetry.Level
 	exporterName string
 	mutators     []tag.Mutator
 }
 
+// ExporterSettings are settings for creating an Exporter.
 type ExporterSettings struct {
 	Level        configtelemetry.Level
 	ExporterName string
 }
 
+// NewExporter creates a new Exporter.
 func NewExporter(cfg ExporterSettings) *Exporter {
 	level, exporterName := cfg.Level, cfg.ExporterName
 	return &Exporter{

--- a/obsreport/obsreport_processor.go
+++ b/obsreport/obsreport_processor.go
@@ -25,16 +25,16 @@ import (
 )
 
 const (
-	// Key used to identify processors in metrics and traces.
+	// ProcessorKey is the key used to identify processors in metrics and traces.
 	ProcessorKey = "processor"
 
-	// Key used to identify spans dropped by the Collector.
+	// DroppedSpansKey is the key used to identify spans dropped by the Collector.
 	DroppedSpansKey = "dropped_spans"
 
-	// Key used to identify metric points dropped by the Collector.
+	// DroppedMetricPointsKey is the key used to identify metric points dropped by the Collector.
 	DroppedMetricPointsKey = "dropped_metric_points"
 
-	// Key used to identify log records dropped by the Collector.
+	// DroppedLogRecordsKey is the key used to identify log records dropped by the Collector.
 	DroppedLogRecordsKey = "dropped_log_records"
 )
 
@@ -116,16 +116,19 @@ func ProcessorMetricViews(configType string, legacyViews []*view.View) []*view.V
 
 var gProcessor = &Processor{level: configtelemetry.LevelNone}
 
+// Processor is a helper to add observability to a component.Processor.
 type Processor struct {
 	level    configtelemetry.Level
 	mutators []tag.Mutator
 }
 
+// ProcessorSettings are settings for creating a Processor.
 type ProcessorSettings struct {
 	Level         configtelemetry.Level
 	ProcessorName string
 }
 
+// NewProcessor creates a new Processor.
 func NewProcessor(cfg ProcessorSettings) *Processor {
 	return &Processor{
 		level:    cfg.Level,

--- a/processor/filterprocessor/config.go
+++ b/processor/filterprocessor/config.go
@@ -25,7 +25,7 @@ type Config struct {
 	Metrics                  MetricFilters `mapstructure:"metrics"`
 }
 
-// MetricFilter filters by Metric properties.
+// MetricFilters filters by Metric properties.
 type MetricFilters struct {
 	// Include match properties describe metrics that should be included in the Collector Service pipeline,
 	// all other metrics should be dropped from further processing.

--- a/processor/processorhelper/attraction.go
+++ b/processor/processorhelper/attraction.go
@@ -23,7 +23,7 @@ import (
 	"go.opentelemetry.io/collector/internal/processor/filterhelper"
 )
 
-// Settings
+// Settings specifies the processor settings.
 type Settings struct {
 	// Actions specifies the list of attributes to act on.
 	// The set of actions are {INSERT, UPDATE, UPSERT, DELETE, HASH, EXTRACT}.
@@ -128,6 +128,7 @@ type attributeAction struct {
 	AttributeValue *pdata.AttributeValue
 }
 
+// AttrProc is an attribute processor.
 type AttrProc struct {
 	actions []attributeAction
 }
@@ -210,6 +211,7 @@ func NewAttrProc(settings *Settings) (*AttrProc, error) {
 	return &AttrProc{actions: attributeActions}, nil
 }
 
+// Process applies the AttrProc to an attribute map.
 func (ap *AttrProc) Process(attrs pdata.AttributeMap) {
 	for _, action := range ap.actions {
 		// TODO https://go.opentelemetry.io/collector/issues/296

--- a/processor/processorhelper/processor.go
+++ b/processor/processorhelper/processor.go
@@ -74,7 +74,7 @@ func WithShutdown(shutdown componenthelper.Shutdown) Option {
 	}
 }
 
-// WithShutdown overrides the default GetCapabilities function for an processor.
+// WithCapabilities overrides the default GetCapabilities function for an processor.
 // The default GetCapabilities function returns mutable capabilities.
 func WithCapabilities(capabilities component.ProcessorCapabilities) Option {
 	return func(o *baseSettings) {

--- a/processor/spanprocessor/config.go
+++ b/processor/spanprocessor/config.go
@@ -59,6 +59,7 @@ type Name struct {
 	ToAttributes *ToAttributes `mapstructure:"to_attributes"`
 }
 
+// ToAttributes specifies a configuration to extract attributes from span name.
 type ToAttributes struct {
 	// Rules is a list of rules to extract attribute values from span name. The values
 	// in the span name are replaced by extracted attribute names. Each rule in the list

--- a/receiver/jaegerreceiver/config.go
+++ b/receiver/jaegerreceiver/config.go
@@ -38,6 +38,7 @@ type RemoteSamplingConfig struct {
 	configgrpc.GRPCClientSettings `mapstructure:",squash"`
 }
 
+// Protocols is the configuration for the supported protocols.
 type Protocols struct {
 	GRPC          *configgrpc.GRPCServerSettings `mapstructure:"grpc"`
 	ThriftHTTP    *confighttp.HTTPServerSettings `mapstructure:"thrift_http"`
@@ -45,11 +46,13 @@ type Protocols struct {
 	ThriftCompact *ProtocolUDP                   `mapstructure:"thrift_compact"`
 }
 
+// ProtocolUDP is the configuration for a UDP protocol.
 type ProtocolUDP struct {
 	Endpoint        string `mapstructure:"endpoint"`
 	ServerConfigUDP `mapstructure:",squash"`
 }
 
+// ServerConfigUDP is the server configuration for a UDP protocol.
 type ServerConfigUDP struct {
 	QueueSize        int `mapstructure:"queue_size"`
 	MaxPacketSize    int `mapstructure:"max_packet_size"`
@@ -57,6 +60,7 @@ type ServerConfigUDP struct {
 	SocketBufferSize int `mapstructure:"socket_buffer_size"`
 }
 
+// DefaultServerConfigUDP creates the default ServerConfigUDP.
 func DefaultServerConfigUDP() ServerConfigUDP {
 	return ServerConfigUDP{
 		QueueSize:        defaultQueueSize,

--- a/receiver/jaegerreceiver/factory.go
+++ b/receiver/jaegerreceiver/factory.go
@@ -52,6 +52,7 @@ const (
 	defaultAgentRemoteSamplingHTTPPort = 5778
 )
 
+// NewFactory creates a new Jaeger receiver factory.
 func NewFactory() component.ReceiverFactory {
 	return receiverhelper.NewFactory(
 		typeStr,

--- a/receiver/opencensusreceiver/factory.go
+++ b/receiver/opencensusreceiver/factory.go
@@ -30,6 +30,7 @@ const (
 	typeStr = "opencensus"
 )
 
+// NewFactory creates a new OpenCensus receiver factory.
 func NewFactory() component.ReceiverFactory {
 	return receiverhelper.NewFactory(
 		typeStr,

--- a/receiver/otlpreceiver/config.go
+++ b/receiver/otlpreceiver/config.go
@@ -20,6 +20,7 @@ import (
 	"go.opentelemetry.io/collector/config/confighttp"
 )
 
+// Protocols is the configuration for the supported protocols.
 type Protocols struct {
 	GRPC *configgrpc.GRPCServerSettings `mapstructure:"grpc"`
 	HTTP *confighttp.HTTPServerSettings `mapstructure:"http"`

--- a/receiver/otlpreceiver/factory.go
+++ b/receiver/otlpreceiver/factory.go
@@ -45,6 +45,7 @@ const (
 	legacyGRPCEndpoint  = "0.0.0.0:55680"
 )
 
+// NewFactory creates a new OTLP receiver factory.
 func NewFactory() component.ReceiverFactory {
 	return receiverhelper.NewFactory(
 		typeStr,

--- a/receiver/prometheusreceiver/factory.go
+++ b/receiver/prometheusreceiver/factory.go
@@ -44,6 +44,7 @@ var (
 	errNilScrapeConfig = errors.New("expecting a non-nil ScrapeConfig")
 )
 
+// NewFactory creates a new Prometheus receiver factory.
 func NewFactory() component.ReceiverFactory {
 	return receiverhelper.NewFactory(
 		typeStr,

--- a/receiver/scrapererror/scrapeerrors.go
+++ b/receiver/scrapererror/scrapeerrors.go
@@ -24,7 +24,7 @@ type ScrapeErrors struct {
 	failedScrapeCount int
 }
 
-// Add adds a PartialScrapeError with the provided failed count and error.
+// AddPartial adds a PartialScrapeError with the provided failed count and error.
 func (s *ScrapeErrors) AddPartial(failed int, err error) {
 	s.errs = append(s.errs, NewPartialScrapeError(err, failed))
 	s.failedScrapeCount += failed

--- a/receiver/scraperhelper/scraper.go
+++ b/receiver/scraperhelper/scraper.go
@@ -23,10 +23,10 @@ import (
 	"go.opentelemetry.io/collector/obsreport"
 )
 
-// Scrape metrics.
+// ScrapeMetrics scrapes metrics.
 type ScrapeMetrics func(context.Context) (pdata.MetricSlice, error)
 
-// Scrape resource metrics.
+// ScrapeResourceMetrics scrapes resource metrics.
 type ScrapeResourceMetrics func(context.Context) (pdata.ResourceMetricsSlice, error)
 
 type baseSettings struct {
@@ -36,6 +36,7 @@ type baseSettings struct {
 // ScraperOption apply changes to internal options.
 type ScraperOption func(*baseSettings)
 
+// BaseScraper is the base interface for scrapers.
 type BaseScraper interface {
 	component.Component
 

--- a/service/application.go
+++ b/service/application.go
@@ -183,6 +183,7 @@ func (app *Application) GetLogger() *zap.Logger {
 	return app.logger
 }
 
+// Shutdown shuts down the application.
 func (app *Application) Shutdown() {
 	// TODO: Implement a proper shutdown with graceful draining of the pipeline.
 	// See https://github.com/open-telemetry/opentelemetry-collector/issues/483.

--- a/testbed/testbed/child_process.go
+++ b/testbed/testbed/child_process.go
@@ -236,6 +236,7 @@ func (cp *ChildProcess) Start(params StartParams) error {
 		args = append(args, "--config")
 		args = append(args, cp.configFileName)
 	}
+	// #nosec
 	cp.cmd = exec.Command(exePath, args...)
 
 	// Capture standard output and standard error.

--- a/testutil/logstest/logs.go
+++ b/testutil/logstest/logs.go
@@ -18,13 +18,15 @@ import (
 	"go.opentelemetry.io/collector/consumer/pdata"
 )
 
+// Log is a convenience struct for constructing logs for tests.
+// See Logs for rationale.
 type Log struct {
 	Timestamp  int64
 	Body       pdata.AttributeValue
 	Attributes map[string]pdata.AttributeValue
 }
 
-// A convenience function for constructing logs for tests in a way that is
+// Logs is a convenience function for constructing logs for tests in a way that is
 // relatively easy to read and write declaratively compared to the highly
 // imperative and verbose method of using pdata directly.
 // Attributes are sorted by key name.

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -54,6 +54,7 @@ func GenerateNormalizedJSON(t *testing.T, jsonStr string) string {
 	return string(n)
 }
 
+// TempSocketName provides a temporary Unix socket name for testing.
 func TempSocketName(t *testing.T) string {
 	tmpfile, err := ioutil.TempFile("", "sock")
 	require.NoError(t, err)
@@ -223,6 +224,7 @@ type LimitedWriter struct {
 
 var _ io.Writer = new(LimitedWriter)
 
+// Write writes bytes to the underlying buffer until reaching the maximum length.
 func (lw *LimitedWriter) Write(p []byte) (n int, err error) {
 	if lw.MaxLen != 0 && len(p)+lw.Len() > lw.MaxLen {
 		return 0, io.EOF
@@ -230,6 +232,7 @@ func (lw *LimitedWriter) Write(p []byte) (n int, err error) {
 	return lw.Buffer.Write(p)
 }
 
+// Close closes the writer.
 func (lw *LimitedWriter) Close() error {
 	return nil
 }

--- a/translator/trace/jaeger/jaegerthrift_to_traces.go
+++ b/translator/trace/jaeger/jaegerthrift_to_traces.go
@@ -26,6 +26,7 @@ import (
 	tracetranslator "go.opentelemetry.io/collector/translator/trace"
 )
 
+// ThriftBatchToInternalTraces transforms a Thrift trace batch into pdata.Traces.
 func ThriftBatchToInternalTraces(batch *jaeger.Batch) pdata.Traces {
 	traceData := pdata.NewTraces()
 	jProcess := batch.GetProcess()

--- a/translator/trace/protospan_translation.go
+++ b/translator/trace/protospan_translation.go
@@ -161,6 +161,7 @@ func AttributeMapToMap(attrMap pdata.AttributeMap) map[string]interface{} {
 	return rawMap
 }
 
+// AttributeArrayToSlice creates a slice out of a pdata.AnyValueArray.
 func AttributeArrayToSlice(attrArray pdata.AnyValueArray) []interface{} {
 	rawSlice := make([]interface{}, 0, attrArray.Len())
 	for i := 0; i < attrArray.Len(); i++ {

--- a/translator/trace/zipkin/zipkinv1_thrift_to_traces.go
+++ b/translator/trace/zipkin/zipkinv1_thrift_to_traces.go
@@ -21,6 +21,7 @@ import (
 	"go.opentelemetry.io/collector/translator/internaldata"
 )
 
+// V1ThriftBatchToInternalTraces transforms Zipkin v1 spans into pdata.Traces.
 func V1ThriftBatchToInternalTraces(zSpans []*zipkincore.Span) (pdata.Traces, error) {
 	traces := pdata.NewTraces()
 	ocTraces, _ := v1ThriftBatchToOCProto(zSpans)

--- a/translator/trace/zipkin/zipkinv1_to_traces.go
+++ b/translator/trace/zipkin/zipkinv1_to_traces.go
@@ -19,6 +19,7 @@ import (
 	"go.opentelemetry.io/collector/translator/internaldata"
 )
 
+// V1JSONBatchToInternalTraces transforms a JSON blob with a list of Zipkin v1 spans into pdata.Traces.
 func V1JSONBatchToInternalTraces(blob []byte, parseStringTags bool) (pdata.Traces, error) {
 	traces := pdata.NewTraces()
 


### PR DESCRIPTION
**Description:** 

- Enable `EXC0007` and `EXC0002` for non-internal, non-testbed packages.
- Add missing documentation.
- Add `nosec` directive to testbed.

**Link to tracking Issue:** Updates #2789

To be tracked in #2819.
