### PR TITLE
Set unprivileged user to container image

### DIFF
--- a/cmd/otelcol/Dockerfile
+++ b/cmd/otelcol/Dockerfile
@@ -1,7 +1,7 @@
-FROM alpine:latest as certs
+FROM alpine:3.13 as certs
 RUN apk --update add ca-certificates
 
-FROM alpine:latest AS otelcol
+FROM alpine:3.13 AS otelcol
 COPY otelcol /
 # Note that this shouldn't be necessary, but in some cases the file seems to be
 # copied with the execute bit lost (see #1317)

--- a/cmd/otelcol/Dockerfile
+++ b/cmd/otelcol/Dockerfile
@@ -1,16 +1,20 @@
-FROM alpine:3.12 as certs
+FROM alpine:latest as certs
 RUN apk --update add ca-certificates
 
-FROM alpine:3.12 AS otelcol
+FROM alpine:latest AS otelcol
 COPY otelcol /
 # Note that this shouldn't be necessary, but in some cases the file seems to be
 # copied with the execute bit lost (see #1317)
 RUN chmod 755 /otelcol
 
 FROM scratch
+
+ARG USER_UID=10001
+USER ${USER_UID}
+
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=otelcol /otelcol /
 COPY config.yaml /etc/otel/config.yaml
 ENTRYPOINT ["/otelcol"]
 CMD ["--config", "/etc/otel/config.yaml"]
-EXPOSE 55678 55679
+EXPOSE 4317 55678 55679

--- a/examples/demo/app/Dockerfile
+++ b/examples/demo/app/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM golang:1.14
+FROM golang:1.16
 COPY . /usr/src/app/
 WORKDIR /usr/src/app/
 RUN go env -w GOPROXY=direct


### PR DESCRIPTION
Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>

**Description:** This change sets a custom user to the container image, under an ID that yields an unprivileged user.
