### PR TITLE
feat: make configgrpc support more encodings

### DIFF
--- a/config/configgrpc/README.md
+++ b/config/configgrpc/README.md
@@ -16,7 +16,8 @@ configuration. For more information, see [configtls
 README](../configtls/README.md).
 
 - [`balancer_name`](https://github.com/grpc/grpc-go/blob/master/examples/features/load_balancing/README.md)
-- `compression` (default = gzip): Compression type to use (only gzip is supported today)
+- `compression`: compression to use among `gzip` (default), `lz4`,
+  `snappy` and `zstd`
 - `endpoint`: Valid value syntax available [here](https://github.com/grpc/grpc/blob/master/doc/naming.md)
 - `headers`: name/value pairs added to the request
 - [`keepalive`](https://godoc.org/google.golang.org/grpc/keepalive#ClientParameters)

--- a/config/configgrpc/README.md
+++ b/config/configgrpc/README.md
@@ -16,8 +16,7 @@ configuration. For more information, see [configtls
 README](../configtls/README.md).
 
 - [`balancer_name`](https://github.com/grpc/grpc-go/blob/master/examples/features/load_balancing/README.md)
-- `compression`: compression to use among `gzip` (default), `lz4`,
-  `snappy` and `zstd`
+- `compression`: compression to use among `gzip`, `lz4`, `snappy` and `zstd`
 - `endpoint`: Valid value syntax available [here](https://github.com/grpc/grpc/blob/master/doc/naming.md)
 - `headers`: name/value pairs added to the request
 - [`keepalive`](https://godoc.org/google.golang.org/grpc/keepalive#ClientParameters)

--- a/config/configgrpc/configgrpc.go
+++ b/config/configgrpc/configgrpc.go
@@ -76,7 +76,7 @@ type GRPCClientSettings struct {
 	Endpoint string `mapstructure:"endpoint"`
 
 	// The compression key for supported compression types within
-	// collector. Currently the only supported mode is `gzip`.
+	// collector.
 	Compression string `mapstructure:"compression"`
 
 	// TLSSetting struct exposes TLS client configuration.

--- a/config/configgrpc/configgrpc.go
+++ b/config/configgrpc/configgrpc.go
@@ -21,6 +21,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/mostynb/go-grpc-compression/lz4"
+	"github.com/mostynb/go-grpc-compression/snappy"
+	"github.com/mostynb/go-grpc-compression/zstd"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/balancer/roundrobin"
 	"google.golang.org/grpc/credentials"
@@ -36,6 +39,9 @@ import (
 const (
 	CompressionUnsupported = ""
 	CompressionGzip        = "gzip"
+	CompressionLz4         = "lz4"
+	CompressionSnappy      = "snappy"
+	CompressionZstd        = "zstd"
 
 	PerRPCAuthTypeBearer = "bearer"
 )
@@ -43,7 +49,10 @@ const (
 var (
 	// Map of opentelemetry compression types to grpc registered compression types
 	grpcCompressionKeyMap = map[string]string{
-		CompressionGzip: gzip.Name,
+		CompressionGzip:   gzip.Name,
+		CompressionLz4:    lz4.Name,
+		CompressionSnappy: snappy.Name,
+		CompressionZstd:   zstd.Name,
 	}
 )
 

--- a/config/configgrpc/configgrpc_test.go
+++ b/config/configgrpc/configgrpc_test.go
@@ -292,6 +292,30 @@ func TestGetGRPCCompressionKey(t *testing.T) {
 		t.Error("Capitalization of CompressionGzip should not matter")
 	}
 
+	if GetGRPCCompressionKey("lz4") != CompressionLz4 {
+		t.Error("lz4 is marked as supported but returned unsupported")
+	}
+
+	if GetGRPCCompressionKey("Lz4") != CompressionLz4 {
+		t.Error("Capitalization of CompressionLz4 should not matter")
+	}
+
+	if GetGRPCCompressionKey("snappy") != CompressionSnappy {
+		t.Error("snappy is marked as supported but returned unsupported")
+	}
+
+	if GetGRPCCompressionKey("Snappy") != CompressionSnappy {
+		t.Error("Capitalization of CompressionSnappy should not matter")
+	}
+
+	if GetGRPCCompressionKey("zstd") != CompressionZstd {
+		t.Error("zstd is marked as supported but returned unsupported")
+	}
+
+	if GetGRPCCompressionKey("Zstd") != CompressionZstd {
+		t.Error("Capitalization of CompressionZstd should not matter")
+	}
+
 	if GetGRPCCompressionKey("badType") != CompressionUnsupported {
 		t.Error("badType is not supported but was returned as supported")
 	}

--- a/exporter/opencensusexporter/factory_test.go
+++ b/exporter/opencensusexporter/factory_test.go
@@ -103,6 +103,36 @@ func TestCreateTraceExporter(t *testing.T) {
 			},
 		},
 		{
+			name: "Lz4Compression",
+			config: Config{
+				GRPCClientSettings: configgrpc.GRPCClientSettings{
+					Endpoint:    endpoint,
+					Compression: configgrpc.CompressionLz4,
+				},
+				NumWorkers: 3,
+			},
+		},
+		{
+			name: "SnappyCompression",
+			config: Config{
+				GRPCClientSettings: configgrpc.GRPCClientSettings{
+					Endpoint:    endpoint,
+					Compression: configgrpc.CompressionSnappy,
+				},
+				NumWorkers: 3,
+			},
+		},
+		{
+			name: "ZstdCompression",
+			config: Config{
+				GRPCClientSettings: configgrpc.GRPCClientSettings{
+					Endpoint:    endpoint,
+					Compression: configgrpc.CompressionZstd,
+				},
+				NumWorkers: 3,
+			},
+		},
+		{
 			name: "Headers",
 			config: Config{
 				GRPCClientSettings: configgrpc.GRPCClientSettings{

--- a/exporter/otlpexporter/cfg-schema.yaml
+++ b/exporter/otlpexporter/cfg-schema.yaml
@@ -62,7 +62,6 @@ fields:
     https://github.com/grpc/grpc/blob/master/doc/naming.md.
 - name: compression
   kind: string
-  default: gzip
   doc: |
     The compression key for supported compression types within
     collector.

--- a/exporter/otlpexporter/cfg-schema.yaml
+++ b/exporter/otlpexporter/cfg-schema.yaml
@@ -62,9 +62,10 @@ fields:
     https://github.com/grpc/grpc/blob/master/doc/naming.md.
 - name: compression
   kind: string
+  default: gzip
   doc: |
     The compression key for supported compression types within
-    collector. Currently the only supported mode is `gzip`.
+    collector.
 - name: ca_file
   kind: string
   doc: |

--- a/exporter/otlpexporter/factory_test.go
+++ b/exporter/otlpexporter/factory_test.go
@@ -105,6 +105,33 @@ func TestCreateTraceExporter(t *testing.T) {
 			},
 		},
 		{
+			name: "Lz4Compression",
+			config: Config{
+				GRPCClientSettings: configgrpc.GRPCClientSettings{
+					Endpoint:    endpoint,
+					Compression: configgrpc.CompressionLz4,
+				},
+			},
+		},
+		{
+			name: "SnappyCompression",
+			config: Config{
+				GRPCClientSettings: configgrpc.GRPCClientSettings{
+					Endpoint:    endpoint,
+					Compression: configgrpc.CompressionSnappy,
+				},
+			},
+		},
+		{
+			name: "ZstdCompression",
+			config: Config{
+				GRPCClientSettings: configgrpc.GRPCClientSettings{
+					Endpoint:    endpoint,
+					Compression: configgrpc.CompressionZstd,
+				},
+			},
+		},
+		{
 			name: "Headers",
 			config: Config{
 				GRPCClientSettings: configgrpc.GRPCClientSettings{

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0
 	github.com/jaegertracing/jaeger v1.22.0
 	github.com/leoluk/perflib_exporter v0.1.0
+	github.com/mostynb/go-grpc-compression v1.1.7
 	github.com/openzipkin/zipkin-go v0.2.5
 	github.com/pquerna/cachecontrol v0.0.0-20201205024021-ac21108117ac // indirect
 	github.com/prometheus/client_golang v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -254,6 +254,7 @@ github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHqu
 github.com/franela/goblin v0.0.0-20200105215937-c9ffbefa60db/go.mod h1:7dvUGVsVBjqR7JHJk0brhHOZYGmfBYOrK0ZhYMEtBr4=
 github.com/franela/goreq v0.0.0-20171204163338-bcd34c9993f8/go.mod h1:ZhphrRTfi2rbfLwlschooIH4+wKKDR4Pdxhh+TRoA20=
 github.com/frankban/quicktest v1.7.3/go.mod h1:V1d2J5pfxYH6EjBAgSK7YNXcXlTWxUHdE1sVDXkjnig=
+github.com/frankban/quicktest v1.10.1/go.mod h1:z7wHrVXJKCWP1Ev7B3iy2DivmuL5uGeeJDWYz/6LLhY=
 github.com/frankban/quicktest v1.11.3 h1:8sXhOn0uLys67V8EsXLc6eszDs8VXWxL3iRvebPhedY=
 github.com/frankban/quicktest v1.11.3/go.mod h1:wRf/ReqHper53s+kmmSZizM8NamnL3IM0I9ntUbOk+k=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
@@ -643,8 +644,9 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.4.0/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
 github.com/klauspost/compress v1.9.5/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
-github.com/klauspost/compress v1.11.7 h1:0hzRabrMN4tSTvMfnL3SCv1ZGeAP23ynzodBgaHeMeg=
 github.com/klauspost/compress v1.11.7/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
+github.com/klauspost/compress v1.11.13 h1:eSvu8Tmq6j2psUJqJrLcWH6K3w5Dwc+qipbaA6eVEN4=
+github.com/klauspost/compress v1.11.13/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/klauspost/cpuid v0.0.0-20170728055534-ae7887de9fa5/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
 github.com/klauspost/crc32 v0.0.0-20161016154125-cb6bfca970f6/go.mod h1:+ZoRqAPRLkC4NPOvfYeR5KNOrY6TD+/sAC3HXPZgDYg=
 github.com/klauspost/pgzip v1.0.2-0.20170402124221-0bf5dcad4ada/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
@@ -739,6 +741,8 @@ github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3Rllmb
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
 github.com/morikuni/aec v1.0.0 h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A=
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
+github.com/mostynb/go-grpc-compression v1.1.7 h1:x27zbmWj66TZOsBG3XEqMiQp3a6JTA+5rM3ak6DxDSI=
+github.com/mostynb/go-grpc-compression v1.1.7/go.mod h1:nd4JasKFOd2/vb1VjM2Ex6ukDelx7Xl0UDT6BY3XoKc=
 github.com/mozilla/tls-observatory v0.0.0-20190404164649-a3c1b6cfecfd/go.mod h1:SrKMQvPiws7F7iqYp8/TX+IhxCYhzr6N/1yb8cwHsGk=
 github.com/mschoch/smat v0.0.0-20160514031455-90eadee771ae/go.mod h1:qAyveg+e4CE+eKJXWVjKXM4ck2QobLqTDytGJbLLhJg=
 github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
@@ -815,6 +819,7 @@ github.com/pierrec/lz4 v0.0.0-20190327172049-315a67e90e41/go.mod h1:3/3N9NVKO0je
 github.com/pierrec/lz4 v1.0.2-0.20190131084431-473cd7ce01a1/go.mod h1:3/3N9NVKO0jef7pBehbT1qWhCMrIgbYNnFAZCqQ5LRc=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pierrec/lz4 v2.4.1+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
+github.com/pierrec/lz4 v2.5.2+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pierrec/lz4 v2.6.0+incompatible h1:Ix9yFKn1nSPBLFl/yZknTp8TU5G4Ps0JDmguYK6iH1A=
 github.com/pierrec/lz4 v2.6.0+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=


### PR DESCRIPTION
add support for lz4, snappy and zstd by means of
https://github.com/mostynb/go-grpc-compression to configgrcpc.go's
grpc client compression setting

fixes #2548

To test, I ran the docker-compose with a locally built image and configured the exporter with `lz4` compression. No error was emitted:

```yaml
...
exporters:
  otlp:
    endpoint: "otel-collector:4317"
    insecure: true
    compression: lz4
 ...
```