### PR TITLE
Report metric about current size of the exporter retry queue

### DIFF
--- a/exporter/exporterhelper/common.go
+++ b/exporter/exporterhelper/common.go
@@ -186,8 +186,7 @@ func (be *baseExporter) Start(ctx context.Context, host component.Host) error {
 	}
 
 	// If no error then start the queuedRetrySender.
-	be.qrSender.start()
-	return nil
+	return be.qrSender.start()
 }
 
 // Shutdown all senders and exporter and is invoked during service shutdown.

--- a/exporter/exporterhelper/common_test.go
+++ b/exporter/exporterhelper/common_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.opencensus.io/tag"
 	"go.opencensus.io/trace"
 	"go.uber.org/zap"
 
@@ -27,12 +28,20 @@ import (
 	"go.opentelemetry.io/collector/config"
 )
 
-var okStatus = trace.Status{Code: trace.StatusCodeOK}
+var (
+	okStatus = trace.Status{Code: trace.StatusCodeOK}
 
-var defaultExporterCfg = &config.ExporterSettings{
-	TypeVal: "test",
-	NameVal: "test",
-}
+	defaultExporterName = "test"
+	defaultExporterCfg  = &config.ExporterSettings{
+		TypeVal: "test",
+		NameVal: defaultExporterName,
+	}
+
+	exporterTag, _      = tag.NewKey("exporter")
+	defaultExporterTags = []tag.Tag{
+		{Key: exporterTag, Value: defaultExporterName},
+	}
+)
 
 func TestErrorToStatus(t *testing.T) {
 	require.Equal(t, okStatus, errToStatus(nil))


### PR DESCRIPTION
This commit adds observability to queue_retry exporter helper. It adds the first metric "queue_length" that indicates current size of the queue per exporter. The metrics is updated every second.

This is the first commit to address the issue https://github.com/open-telemetry/opentelemetry-collector/issues/2434

