### PR TITLE
exporter/prometheusremotewriterexporter: close HTTP response body

### DIFF
--- a/exporter/prometheusremotewriteexporter/exporter.go
+++ b/exporter/prometheusremotewriteexporter/exporter.go
@@ -324,6 +324,7 @@ func (prwe *PrwExporter) execute(ctx context.Context, writeReq *prompb.WriteRequ
 	if err != nil {
 		return consumererror.Permanent(err)
 	}
+	defer resp.Body.Close()
 
 	// 2xx status code is considered a success
 	// 5xx errors are recoverable and the exporter should retry


### PR DESCRIPTION
Fixes a leak in HTTP responses after sending protobuf payloads
to Amazon's endpoints. This change ensures that connections
can be successfully reused, otherwise without invoking .Close()
they won't easily be reused.
Discovered while investigating for anything that could be averse
to scalability of the exporter.

Fixes #2874

/cc @Aneurysm9 @rakyll @alolita