### PR TITLE
Add an option to pass command arguments with `make run`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,7 +162,7 @@ otelcol:
 
 .PHONY: run
 run:
-	GO111MODULE=on go run --race ./cmd/otelcol/... --config ${RUN_CONFIG}
+	GO111MODULE=on go run --race ./cmd/otelcol/... --config ${RUN_CONFIG} ${RUN_ARGS}
 
 .PHONY: docker-component # Not intended to be used directly
 docker-component: check-component


### PR DESCRIPTION
`make run` is a useful command, but there is no way to pass extra command arguments. This commit adds a way to do that with RUN_ARGS env variable
