### PR TITLE
Make [Metrics/Logs/Traces][Accepted/Refused/Dropped] return an error

### DIFF
--- a/obsreport/obsreport_processor.go
+++ b/obsreport/obsreport_processor.go
@@ -137,9 +137,9 @@ func NewProcessor(cfg ProcessorSettings) *Processor {
 }
 
 // TracesAccepted reports that the trace data was accepted.
-func (por *Processor) TracesAccepted(ctx context.Context, numSpans int) {
+func (por *Processor) TracesAccepted(ctx context.Context, numSpans int) error {
 	if por.level != configtelemetry.LevelNone {
-		stats.RecordWithTags(
+		return stats.RecordWithTags(
 			ctx,
 			por.mutators,
 			mProcessorAcceptedSpans.M(int64(numSpans)),
@@ -147,12 +147,13 @@ func (por *Processor) TracesAccepted(ctx context.Context, numSpans int) {
 			mProcessorDroppedSpans.M(0),
 		)
 	}
+	return nil
 }
 
 // TracesRefused reports that the trace data was refused.
-func (por *Processor) TracesRefused(ctx context.Context, numSpans int) {
+func (por *Processor) TracesRefused(ctx context.Context, numSpans int) error {
 	if por.level != configtelemetry.LevelNone {
-		stats.RecordWithTags(
+		return stats.RecordWithTags(
 			ctx,
 			por.mutators,
 			mProcessorAcceptedSpans.M(0),
@@ -160,12 +161,13 @@ func (por *Processor) TracesRefused(ctx context.Context, numSpans int) {
 			mProcessorDroppedSpans.M(0),
 		)
 	}
+	return nil
 }
 
 // TracesDropped reports that the trace data was dropped.
-func (por *Processor) TracesDropped(ctx context.Context, numSpans int) {
+func (por *Processor) TracesDropped(ctx context.Context, numSpans int) error {
 	if por.level != configtelemetry.LevelNone {
-		stats.RecordWithTags(
+		return stats.RecordWithTags(
 			ctx,
 			por.mutators,
 			mProcessorAcceptedSpans.M(0),
@@ -173,12 +175,13 @@ func (por *Processor) TracesDropped(ctx context.Context, numSpans int) {
 			mProcessorDroppedSpans.M(int64(numSpans)),
 		)
 	}
+	return nil
 }
 
 // MetricsAccepted reports that the metrics were accepted.
-func (por *Processor) MetricsAccepted(ctx context.Context, numPoints int) {
+func (por *Processor) MetricsAccepted(ctx context.Context, numPoints int) error {
 	if por.level != configtelemetry.LevelNone {
-		stats.RecordWithTags(
+		return stats.RecordWithTags(
 			ctx,
 			por.mutators,
 			mProcessorAcceptedMetricPoints.M(int64(numPoints)),
@@ -186,12 +189,13 @@ func (por *Processor) MetricsAccepted(ctx context.Context, numPoints int) {
 			mProcessorDroppedMetricPoints.M(0),
 		)
 	}
+	return nil
 }
 
 // MetricsRefused reports that the metrics were refused.
-func (por *Processor) MetricsRefused(ctx context.Context, numPoints int) {
+func (por *Processor) MetricsRefused(ctx context.Context, numPoints int) error {
 	if por.level != configtelemetry.LevelNone {
-		stats.RecordWithTags(
+		return stats.RecordWithTags(
 			ctx,
 			por.mutators,
 			mProcessorAcceptedMetricPoints.M(0),
@@ -199,12 +203,13 @@ func (por *Processor) MetricsRefused(ctx context.Context, numPoints int) {
 			mProcessorDroppedMetricPoints.M(0),
 		)
 	}
+	return nil
 }
 
 // MetricsDropped reports that the metrics were dropped.
-func (por *Processor) MetricsDropped(ctx context.Context, numPoints int) {
+func (por *Processor) MetricsDropped(ctx context.Context, numPoints int) error {
 	if por.level != configtelemetry.LevelNone {
-		stats.RecordWithTags(
+		return stats.RecordWithTags(
 			ctx,
 			por.mutators,
 			mProcessorAcceptedMetricPoints.M(0),
@@ -212,12 +217,13 @@ func (por *Processor) MetricsDropped(ctx context.Context, numPoints int) {
 			mProcessorDroppedMetricPoints.M(int64(numPoints)),
 		)
 	}
+	return nil
 }
 
 // LogsAccepted reports that the logs were accepted.
-func (por *Processor) LogsAccepted(ctx context.Context, numRecords int) {
+func (por *Processor) LogsAccepted(ctx context.Context, numRecords int) error {
 	if por.level != configtelemetry.LevelNone {
-		stats.RecordWithTags(
+		return stats.RecordWithTags(
 			ctx,
 			por.mutators,
 			mProcessorAcceptedLogRecords.M(int64(numRecords)),
@@ -225,12 +231,13 @@ func (por *Processor) LogsAccepted(ctx context.Context, numRecords int) {
 			mProcessorDroppedLogRecords.M(0),
 		)
 	}
+	return nil
 }
 
 // LogsRefused reports that the logs were refused.
-func (por *Processor) LogsRefused(ctx context.Context, numRecords int) {
+func (por *Processor) LogsRefused(ctx context.Context, numRecords int) error {
 	if por.level != configtelemetry.LevelNone {
-		stats.RecordWithTags(
+		return stats.RecordWithTags(
 			ctx,
 			por.mutators,
 			mProcessorAcceptedLogRecords.M(0),
@@ -238,12 +245,13 @@ func (por *Processor) LogsRefused(ctx context.Context, numRecords int) {
 			mProcessorDroppedMetricPoints.M(0),
 		)
 	}
+	return nil
 }
 
 // LogsDropped reports that the logs were dropped.
-func (por *Processor) LogsDropped(ctx context.Context, numRecords int) {
+func (por *Processor) LogsDropped(ctx context.Context, numRecords int) error {
 	if por.level != configtelemetry.LevelNone {
-		stats.RecordWithTags(
+		return stats.RecordWithTags(
 			ctx,
 			por.mutators,
 			mProcessorAcceptedLogRecords.M(0),
@@ -251,4 +259,5 @@ func (por *Processor) LogsDropped(ctx context.Context, numRecords int) {
 			mProcessorDroppedLogRecords.M(int64(numRecords)),
 		)
 	}
+	return nil
 }

--- a/obsreport/obsreport_test.go
+++ b/obsreport/obsreport_test.go
@@ -548,9 +548,12 @@ func TestProcessorTraceData(t *testing.T) {
 	const droppedSpans = 13
 
 	obsrep := obsreport.NewProcessor(obsreport.ProcessorSettings{configtelemetry.LevelNormal, processor})
-	obsrep.TracesAccepted(context.Background(), acceptedSpans)
-	obsrep.TracesRefused(context.Background(), refusedSpans)
-	obsrep.TracesDropped(context.Background(), droppedSpans)
+	err = obsrep.TracesAccepted(context.Background(), acceptedSpans)
+	require.NoError(t, err)
+	err = obsrep.TracesRefused(context.Background(), refusedSpans)
+	require.NoError(t, err)
+	err = obsrep.TracesDropped(context.Background(), droppedSpans)
+	require.NoError(t, err)
 
 	obsreporttest.CheckProcessorTracesViews(t, processor, acceptedSpans, refusedSpans, droppedSpans)
 }
@@ -565,10 +568,12 @@ func TestProcessorMetricsData(t *testing.T) {
 	const droppedPoints = 17
 
 	obsrep := obsreport.NewProcessor(obsreport.ProcessorSettings{configtelemetry.LevelNormal, processor})
-	obsrep.MetricsAccepted(context.Background(), acceptedPoints)
-	obsrep.MetricsRefused(context.Background(), refusedPoints)
-	obsrep.MetricsDropped(context.Background(), droppedPoints)
-
+	err = obsrep.MetricsAccepted(context.Background(), acceptedPoints)
+	require.NoError(t, err)
+	err = obsrep.MetricsRefused(context.Background(), refusedPoints)
+	require.NoError(t, err)
+	err = obsrep.MetricsDropped(context.Background(), droppedPoints)
+	require.NoError(t, err)
 	obsreporttest.CheckProcessorMetricsViews(t, processor, acceptedPoints, refusedPoints, droppedPoints)
 }
 

--- a/processor/memorylimiter/memorylimiter.go
+++ b/processor/memorylimiter/memorylimiter.go
@@ -165,14 +165,20 @@ func (ml *memoryLimiter) ProcessTraces(ctx context.Context, td pdata.Traces) (pd
 		// 	to a receiver (ie.: a receiver is on the call stack). For now it
 		// 	assumes that the pipeline is properly configured and a receiver is on the
 		// 	callstack.
-		ml.obsrep.TracesRefused(ctx, numSpans)
+		err := ml.obsrep.TracesRefused(ctx, numSpans)
+		if err != nil {
+			return td, err
+		}
 
 		return td, errForcedDrop
 	}
 
 	// Even if the next consumer returns error record the data as accepted by
 	// this processor.
-	ml.obsrep.TracesAccepted(ctx, numSpans)
+	err := ml.obsrep.TracesAccepted(ctx, numSpans)
+	if err != nil {
+		return td, nil
+	}
 	return td, nil
 }
 
@@ -185,14 +191,19 @@ func (ml *memoryLimiter) ProcessMetrics(ctx context.Context, md pdata.Metrics) (
 		// 	to a receiver (ie.: a receiver is on the call stack). For now it
 		// 	assumes that the pipeline is properly configured and a receiver is on the
 		// 	callstack.
-		ml.obsrep.MetricsRefused(ctx, numDataPoints)
-
+		err := ml.obsrep.MetricsRefused(ctx, numDataPoints)
+		if err != nil {
+			return md, err
+		}
 		return md, errForcedDrop
 	}
 
 	// Even if the next consumer returns error record the data as accepted by
 	// this processor.
-	ml.obsrep.MetricsAccepted(ctx, numDataPoints)
+	err := ml.obsrep.MetricsAccepted(ctx, numDataPoints)
+	if err != nil {
+		return md, err
+	}
 	return md, nil
 }
 
@@ -205,14 +216,19 @@ func (ml *memoryLimiter) ProcessLogs(ctx context.Context, ld pdata.Logs) (pdata.
 		// 	to a receiver (ie.: a receiver is on the call stack). For now it
 		// 	assumes that the pipeline is properly configured and a receiver is on the
 		// 	callstack.
-		ml.obsrep.LogsRefused(ctx, numRecords)
-
+		err := ml.obsrep.LogsRefused(ctx, numRecords)
+		if err != nil {
+			return ld, err
+		}
 		return ld, errForcedDrop
 	}
 
 	// Even if the next consumer returns error record the data as accepted by
 	// this processor.
-	ml.obsrep.LogsAccepted(ctx, numRecords)
+	err := ml.obsrep.LogsAccepted(ctx, numRecords)
+	if err != nil {
+		return ld, err
+	}
 	return ld, nil
 }
 


### PR DESCRIPTION
**Description:** 

- Change `obsreport.Processor`'s reporting functions to return an error when `RecordWithTags` fails, detected by `errcheck`. An alternative is to just ignore the error, but I think this is better.

**Link to tracking Issue:** Updates #2789 (`errcheck` was reporting this)

To be tracked on #2819.