### PR TITLE
Allow adding new signals in ProcessorFactory by forcing everyone to embed BaseProcessorFactory

### DIFF
--- a/component/componenttest/nop_processor.go
+++ b/component/componenttest/nop_processor.go
@@ -25,7 +25,9 @@ import (
 )
 
 // nopProcessorFactory is factory for nopProcessor.
-type nopProcessorFactory struct{}
+type nopProcessorFactory struct {
+	component.BaseProcessorFactory
+}
 
 var nopProcessorFactoryInstance = &nopProcessorFactory{}
 

--- a/component/processor.go
+++ b/component/processor.go
@@ -118,7 +118,7 @@ type ProcessorFactory interface {
 		nextConsumer consumer.Logs,
 	) (LogsProcessor, error)
 
-	// unexportedExtension is a dummy method to force this interface to not be implemented.
+	// unexportedProcessor is a dummy method to force this interface to not be implemented.
 	unexportedProcessor()
 }
 

--- a/component/processor.go
+++ b/component/processor.go
@@ -20,6 +20,7 @@ import (
 	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/config/configerror"
 	"go.opentelemetry.io/collector/consumer"
 )
 
@@ -72,6 +73,9 @@ type ProcessorCreateParams struct {
 
 // ProcessorFactory is factory interface for processors. This is the
 // new factory type that can create new style processors.
+//
+// This interface cannot be directly implemented, implementations need to embed
+// the BaseProcessorFactory or use the processorhelper.NewFactory to implement it.
 type ProcessorFactory interface {
 	Factory
 
@@ -113,4 +117,39 @@ type ProcessorFactory interface {
 		cfg config.Processor,
 		nextConsumer consumer.Logs,
 	) (LogsProcessor, error)
+
+	// unexportedExtension is a dummy method to force this interface to not be implemented.
+	unexportedProcessor()
 }
+
+// BaseProcessorFactory is the interface that must be embedded by all ProcessorFactory implementations.
+type BaseProcessorFactory struct{}
+
+var _ ProcessorFactory = (*BaseProcessorFactory)(nil)
+
+// Type must be override.
+func (b BaseProcessorFactory) Type() config.Type {
+	panic("implement me")
+}
+
+// CreateDefaultConfig must be override.
+func (b BaseProcessorFactory) CreateDefaultConfig() config.Processor {
+	panic("implement me")
+}
+
+// CreateTracesProcessor default implemented as not supported date type.
+func (b BaseProcessorFactory) CreateTracesProcessor(context.Context, ProcessorCreateParams, config.Processor, consumer.Traces) (TracesProcessor, error) {
+	return nil, configerror.ErrDataTypeIsNotSupported
+}
+
+// CreateMetricsProcessor default implemented as not supported date type.
+func (b BaseProcessorFactory) CreateMetricsProcessor(context.Context, ProcessorCreateParams, config.Processor, consumer.Metrics) (MetricsProcessor, error) {
+	return nil, configerror.ErrDataTypeIsNotSupported
+}
+
+// CreateLogsProcessor default implemented as not supported date type.
+func (b BaseProcessorFactory) CreateLogsProcessor(context.Context, ProcessorCreateParams, config.Processor, consumer.Logs) (LogsProcessor, error) {
+	return nil, configerror.ErrDataTypeIsNotSupported
+}
+
+func (b BaseProcessorFactory) unexportedProcessor() {}


### PR DESCRIPTION
The reason to do this is to allow us to add factory methods for new signals in the future without breaking implementations.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
