### PR TITLE
Add job and instance as well-known labels in prometheus receiver

### DIFF
--- a/receiver/prometheusreceiver/internal/transaction.go
+++ b/receiver/prometheusreceiver/internal/transaction.go
@@ -36,8 +36,10 @@ import (
 )
 
 const (
-	portAttr   = "port"
-	schemeAttr = "scheme"
+	portAttr     = "port"
+	schemeAttr   = "scheme"
+	jobAttr      = "job"
+	instanceAttr = "instance"
 
 	transport  = "http"
 	dataformat = "prometheus"
@@ -227,8 +229,10 @@ func createNodeAndResource(job, instance, scheme string) (*commonpb.Node, *resou
 	}
 	resource := &resourcepb.Resource{
 		Labels: map[string]string{
-			portAttr:   port,
-			schemeAttr: scheme,
+			jobAttr:      job,
+			instanceAttr: instance,
+			portAttr:     port,
+			schemeAttr:   scheme,
 		},
 	}
 	return node, resource

--- a/receiver/prometheusreceiver/metrics_receiver_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_test.go
@@ -155,8 +155,10 @@ func setupMockPrometheus(tds ...*testData) (*mockPrometheus, *promcfg.Config, er
 		}
 		t.resource = &resourcepb.Resource{
 			Labels: map[string]string{
-				"scheme": "http",
-				"port":   port,
+				"instance": u.Host,
+				"job":      t.name,
+				"scheme":   "http",
+				"port":     port,
 			},
 		}
 	}


### PR DESCRIPTION
In Prometheus, `job` and `instance` are the two auto generated labels, however they are both dropped by prometheus receiver. Although these information is still available in `service.name` and `host`:`port`, it breaks the data contract for most Prometheus users (who use `job` and `instance` to consume metrics in their own system).
This PR adds `job` and `instance` as well-known labels in prometheus receiver to fix the issue.

**Link to tracking Issue:** 
https://github.com/open-telemetry/opentelemetry-collector/issues/575
https://github.com/open-telemetry/opentelemetry-collector/issues/2499
https://github.com/open-telemetry/opentelemetry-collector/issues/2363
https://github.com/open-telemetry/wg-prometheus/issues/7
