### PR TITLE
add `validatable` interface to all the component config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+## 🛑 Breaking changes 🛑
+
+## 💡 Enhancements 💡
+
+- Add `validatable` interface with `Validate()` to all `config.<component>` (#2898)
+  - add the empty `Validate()` implementation for all component configs
+
 ## v0.24.0 Beta
 
 ## 🛑 Breaking changes 🛑

--- a/config/config.go
+++ b/config/config.go
@@ -76,6 +76,23 @@ func (cfg *Config) Validate() error {
 		return errMissingExporters
 	}
 
+	// Validate the exporter configuration.
+	for exp, expCfg := range cfg.Exporters {
+		if err := expCfg.Validate(); err != nil {
+			return fmt.Errorf("exporter \"%s\" has invalid configuration: %w", exp, err)
+		}
+	}
+
+	// Validate the processor configuration if there is any processor
+	// configured in the pipeline
+	if len(cfg.Processors) != 0 {
+		for proc, procCfg := range cfg.Processors {
+			if err := procCfg.Validate(); err != nil {
+				return fmt.Errorf("processor \"%s\" has invalid configuration: %w", proc, err)
+			}
+		}
+	}
+
 	// Check that all enabled extensions in the service are configured
 	if err := cfg.validateServiceExtensions(); err != nil {
 		return err
@@ -92,6 +109,13 @@ func (cfg *Config) validateServiceExtensions() error {
 		// Check that the name referenced in the Service extensions exists in the top-level extensions
 		if cfg.Extensions[ref] == nil {
 			return fmt.Errorf("service references extension %q which does not exist", ref)
+		}
+	}
+
+	// Validate the extension configuration.
+	for ext, extCfg := range cfg.Extensions {
+		if err := extCfg.Validate(); err != nil {
+			return fmt.Errorf("extension \"%s\" has invalid configuration: %w", ext, err)
 		}
 	}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -22,15 +22,51 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var errInvalidConfig = errors.New("invalid receiver config")
+var errInvalidRecvConfig = errors.New("invalid receiver config")
+var errInvalidExpConfig = errors.New("invalid exporter config")
+var errInvalidProcConfig = errors.New("invalid processor config")
+var errInvalidExtConfig = errors.New("invalid extension config")
 
-type nopConfig struct {
+type nopRecvConfig struct {
 	ReceiverSettings
 }
 
-func (nc *nopConfig) Validate() error {
+func (nc *nopRecvConfig) Validate() error {
 	if nc.TypeVal != "nop" {
-		return errInvalidConfig
+		return errInvalidRecvConfig
+	}
+	return nil
+}
+
+type nopExpConfig struct {
+	ExporterSettings
+}
+
+func (nc *nopExpConfig) Validate() error {
+	if nc.TypeVal != "nop" {
+		return errInvalidExpConfig
+	}
+	return nil
+}
+
+type nopProcConfig struct {
+	ProcessorSettings
+}
+
+func (nc *nopProcConfig) Validate() error {
+	if nc.TypeVal != "nop" {
+		return errInvalidProcConfig
+	}
+	return nil
+}
+
+type nopExtConfig struct {
+	ExtensionSettings
+}
+
+func (nc *nopExtConfig) Validate() error {
+	if nc.TypeVal != "nop" {
+		return errInvalidExtConfig
 	}
 	return nil
 }
@@ -136,14 +172,53 @@ func TestConfigValidate(t *testing.T) {
 			name: "invalid-receiver-config",
 			cfgFn: func() *Config {
 				cfg := generateConfig()
-				cfg.Receivers["nop"] = &nopConfig{
+				cfg.Receivers["nop"] = &nopRecvConfig{
 					ReceiverSettings: ReceiverSettings{
 						TypeVal: "invalid_rec_type",
 					},
 				}
 				return cfg
 			},
-			expected: fmt.Errorf(`receiver "nop" has invalid configuration: %w`, errInvalidConfig),
+			expected: fmt.Errorf(`receiver "nop" has invalid configuration: %w`, errInvalidRecvConfig),
+		},
+		{
+			name: "invalid-exporter-config",
+			cfgFn: func() *Config {
+				cfg := generateConfig()
+				cfg.Exporters["nop"] = &nopExpConfig{
+					ExporterSettings: ExporterSettings{
+						TypeVal: "invalid_exp_type",
+					},
+				}
+				return cfg
+			},
+			expected: fmt.Errorf(`exporter "nop" has invalid configuration: %w`, errInvalidExpConfig),
+		},
+		{
+			name: "invalid-processor-config",
+			cfgFn: func() *Config {
+				cfg := generateConfig()
+				cfg.Processors["nop"] = &nopProcConfig{
+					ProcessorSettings: ProcessorSettings{
+						TypeVal: "invalid_proc_type",
+					},
+				}
+				return cfg
+			},
+			expected: fmt.Errorf(`processor "nop" has invalid configuration: %w`, errInvalidProcConfig),
+		},
+		{
+			name: "invalid-extension-config",
+			cfgFn: func() *Config {
+				cfg := generateConfig()
+				cfg.Extensions["nop"] = &nopExtConfig{
+					ExtensionSettings: ExtensionSettings{
+						TypeVal: "invalid_ext_type",
+					},
+				}
+				return cfg
+			},
+			expected: fmt.Errorf(`extension "nop" has invalid configuration: %w`, errInvalidExtConfig),
 		},
 	}
 
@@ -158,20 +233,32 @@ func TestConfigValidate(t *testing.T) {
 func generateConfig() *Config {
 	return &Config{
 		Receivers: map[string]Receiver{
-			"nop": &nopConfig{
+			"nop": &nopRecvConfig{
 				ReceiverSettings: ReceiverSettings{
 					TypeVal: "nop",
 				},
 			},
 		},
 		Exporters: map[string]Exporter{
-			"nop": &ExporterSettings{TypeVal: "nop"},
+			"nop": &nopExpConfig{
+				ExporterSettings: ExporterSettings{
+					TypeVal: "nop",
+				},
+			},
 		},
 		Processors: map[string]Processor{
-			"nop": &ProcessorSettings{TypeVal: "nop"},
+			"nop": &nopProcConfig{
+				ProcessorSettings: ProcessorSettings{
+					TypeVal: "nop",
+				},
+			},
 		},
 		Extensions: map[string]Extension{
-			"nop": &ExtensionSettings{TypeVal: "nop"},
+			"nop": &nopExtConfig{
+				ExtensionSettings: ExtensionSettings{
+					TypeVal: "nop",
+				},
+			},
 		},
 		Service: Service{
 			Extensions: []string{"nop"},

--- a/config/exporter.go
+++ b/config/exporter.go
@@ -15,8 +15,10 @@
 package config
 
 // Exporter is the configuration of an exporter.
+// Embedded validatable will force each exporter to implement Validate() function
 type Exporter interface {
 	NamedEntity
+	validatable
 }
 
 // Exporters is a map of names to Exporters.
@@ -50,4 +52,9 @@ func (es *ExporterSettings) SetName(name string) {
 // Type sets the exporter type.
 func (es *ExporterSettings) Type() Type {
 	return es.TypeVal
+}
+
+// Validate validates the configuration and returns an error if invalid.
+func (es *ExporterSettings) Validate() error {
+	return nil
 }

--- a/config/extension.go
+++ b/config/extension.go
@@ -17,8 +17,10 @@ package config
 // Extension is the configuration of a service extension. Specific extensions
 // must implement this interface and will typically embed ExtensionSettings
 // struct or a struct that extends it.
+// Embedded validatable will force each extension to implement Validate() function
 type Extension interface {
 	NamedEntity
+	validatable
 }
 
 // Extensions is a map of names to extensions.
@@ -52,4 +54,9 @@ func (ext *ExtensionSettings) SetName(name string) {
 // Type sets the extension type.
 func (ext *ExtensionSettings) Type() Type {
 	return ext.TypeVal
+}
+
+// Validate validates the configuration and returns an error if invalid.
+func (ext *ExtensionSettings) Validate() error {
+	return nil
 }

--- a/config/processor.go
+++ b/config/processor.go
@@ -16,8 +16,10 @@ package config
 
 // Processor is the configuration of a processor. Specific processors must implement this
 // interface and will typically embed ProcessorSettings struct or a struct that extends it.
+// Embedded validatable will force each processor to implement Validate() function
 type Processor interface {
 	NamedEntity
+	validatable
 }
 
 // Processors is a map of names to Processors.
@@ -51,4 +53,9 @@ func (proc *ProcessorSettings) SetName(name string) {
 // Type sets the processor type.
 func (proc *ProcessorSettings) Type() Type {
 	return proc.TypeVal
+}
+
+// Validate validates the configuration and returns an error if invalid.
+func (proc *ProcessorSettings) Validate() error {
+	return nil
 }

--- a/exporter/fileexporter/config.go
+++ b/exporter/fileexporter/config.go
@@ -25,3 +25,10 @@ type Config struct {
 	// Path of the file to write to. Path is relative to current directory.
 	Path string `mapstructure:"path"`
 }
+
+var _ config.Exporter = (*Config)(nil)
+
+// Validate checks if the exporter configuration is valid
+func (cfg *Config) Validate() error {
+	return nil
+}

--- a/exporter/jaegerexporter/config.go
+++ b/exporter/jaegerexporter/config.go
@@ -29,3 +29,10 @@ type Config struct {
 
 	configgrpc.GRPCClientSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct.
 }
+
+var _ config.Exporter = (*Config)(nil)
+
+// Validate checks if the exporter configuration is valid
+func (cfg *Config) Validate() error {
+	return nil
+}

--- a/exporter/kafkaexporter/config.go
+++ b/exporter/kafkaexporter/config.go
@@ -69,3 +69,10 @@ type MetadataRetry struct {
 	// (default 250ms). Similar to the JVM's `retry.backoff.ms`.
 	Backoff time.Duration `mapstructure:"backoff"`
 }
+
+var _ config.Exporter = (*Config)(nil)
+
+// Validate checks if the exporter configuration is valid
+func (cfg *Config) Validate() error {
+	return nil
+}

--- a/exporter/loggingexporter/config.go
+++ b/exporter/loggingexporter/config.go
@@ -31,3 +31,10 @@ type Config struct {
 	// SamplingThereafter defines the sampling rate after the initial samples are logged.
 	SamplingThereafter int `mapstructure:"sampling_thereafter"`
 }
+
+var _ config.Exporter = (*Config)(nil)
+
+// Validate checks if the exporter configuration is valid
+func (cfg *Config) Validate() error {
+	return nil
+}

--- a/exporter/opencensusexporter/config.go
+++ b/exporter/opencensusexporter/config.go
@@ -30,3 +30,10 @@ type Config struct {
 	// The number of workers that send the gRPC requests.
 	NumWorkers int `mapstructure:"num_workers"`
 }
+
+var _ config.Exporter = (*Config)(nil)
+
+// Validate checks if the exporter configuration is valid
+func (cfg *Config) Validate() error {
+	return nil
+}

--- a/exporter/otlpexporter/config.go
+++ b/exporter/otlpexporter/config.go
@@ -29,3 +29,10 @@ type Config struct {
 
 	configgrpc.GRPCClientSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct.
 }
+
+var _ config.Exporter = (*Config)(nil)
+
+// Validate checks if the exporter configuration is valid
+func (cfg *Config) Validate() error {
+	return nil
+}

--- a/exporter/otlphttpexporter/config.go
+++ b/exporter/otlphttpexporter/config.go
@@ -40,3 +40,10 @@ type Config struct {
 	// collector. Currently the only supported mode is `gzip`.
 	Compression string `mapstructure:"compression"`
 }
+
+var _ config.Exporter = (*Config)(nil)
+
+// Validate checks if the exporter configuration is valid
+func (cfg *Config) Validate() error {
+	return nil
+}

--- a/exporter/prometheusexporter/config.go
+++ b/exporter/prometheusexporter/config.go
@@ -41,3 +41,10 @@ type Config struct {
 	// MetricExpiration defines how long metrics are kept without updates
 	MetricExpiration time.Duration `mapstructure:"metric_expiration"`
 }
+
+var _ config.Exporter = (*Config)(nil)
+
+// Validate checks if the exporter configuration is valid
+func (cfg *Config) Validate() error {
+	return nil
+}

--- a/exporter/prometheusremotewriteexporter/config.go
+++ b/exporter/prometheusremotewriteexporter/config.go
@@ -36,3 +36,10 @@ type Config struct {
 
 	HTTPClientSettings confighttp.HTTPClientSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct.
 }
+
+var _ config.Exporter = (*Config)(nil)
+
+// Validate checks if the exporter configuration is valid
+func (cfg *Config) Validate() error {
+	return nil
+}

--- a/exporter/zipkinexporter/config.go
+++ b/exporter/zipkinexporter/config.go
@@ -34,3 +34,10 @@ type Config struct {
 
 	DefaultServiceName string `mapstructure:"default_service_name"`
 }
+
+var _ config.Exporter = (*Config)(nil)
+
+// Validate checks if the exporter configuration is valid
+func (cfg *Config) Validate() error {
+	return nil
+}

--- a/extension/healthcheckextension/config.go
+++ b/extension/healthcheckextension/config.go
@@ -34,3 +34,10 @@ type Config struct {
 	// The default endpoint is "0.0.0.0:13133".
 	TCPAddr confignet.TCPAddr `mapstructure:",squash"`
 }
+
+var _ config.Extension = (*Config)(nil)
+
+// Validate checks if the extension configuration is valid
+func (cfg *Config) Validate() error {
+	return nil
+}

--- a/extension/pprofextension/config.go
+++ b/extension/pprofextension/config.go
@@ -42,3 +42,10 @@ type Config struct {
 	// Collector starts and is saved to the file when the Collector is terminated.
 	SaveToFile string `mapstructure:"save_to_file"`
 }
+
+var _ config.Extension = (*Config)(nil)
+
+// Validate checks if the extension configuration is valid
+func (cfg *Config) Validate() error {
+	return nil
+}

--- a/extension/zpagesextension/config.go
+++ b/extension/zpagesextension/config.go
@@ -28,3 +28,10 @@ type Config struct {
 	// make it available on all network interfaces.
 	TCPAddr confignet.TCPAddr `mapstructure:",squash"`
 }
+
+var _ config.Extension = (*Config)(nil)
+
+// Validate checks if the extension configuration is valid
+func (cfg *Config) Validate() error {
+	return nil
+}

--- a/processor/attributesprocessor/config.go
+++ b/processor/attributesprocessor/config.go
@@ -37,3 +37,10 @@ type Config struct {
 	// This is a required field.
 	processorhelper.Settings `mapstructure:",squash"`
 }
+
+var _ config.Processor = (*Config)(nil)
+
+// Validate checks if the processor configuration is valid
+func (cfg *Config) Validate() error {
+	return nil
+}

--- a/processor/batchprocessor/config.go
+++ b/processor/batchprocessor/config.go
@@ -34,3 +34,10 @@ type Config struct {
 	// Default value is 0, that means no maximum size.
 	SendBatchMaxSize uint32 `mapstructure:"send_batch_max_size,omitempty"`
 }
+
+var _ config.Processor = (*Config)(nil)
+
+// Validate checks if the processor configuration is valid
+func (cfg *Config) Validate() error {
+	return nil
+}

--- a/processor/filterprocessor/config.go
+++ b/processor/filterprocessor/config.go
@@ -37,3 +37,10 @@ type MetricFilters struct {
 	// If both Include and Exclude are specified, Include filtering occurs first.
 	Exclude *filtermetric.MatchProperties `mapstructure:"exclude"`
 }
+
+var _ config.Processor = (*Config)(nil)
+
+// Validate checks if the processor configuration is valid
+func (cfg *Config) Validate() error {
+	return nil
+}

--- a/processor/memorylimiter/config.go
+++ b/processor/memorylimiter/config.go
@@ -52,5 +52,12 @@ type Config struct {
 	MemorySpikePercentage uint32 `mapstructure:"spike_limit_percentage"`
 }
 
+var _ config.Processor = (*Config)(nil)
+
+// Validate checks if the processor configuration is valid
+func (cfg *Config) Validate() error {
+	return nil
+}
+
 // Name of BallastSizeMiB config option.
 const ballastSizeMibKey = "ballast_size_mib"

--- a/processor/probabilisticsamplerprocessor/config.go
+++ b/processor/probabilisticsamplerprocessor/config.go
@@ -29,3 +29,10 @@ type Config struct {
 	// different sampling rates, configuring different seeds avoids that.
 	HashSeed uint32 `mapstructure:"hash_seed"`
 }
+
+var _ config.Processor = (*Config)(nil)
+
+// Validate checks if the processor configuration is valid
+func (cfg *Config) Validate() error {
+	return nil
+}

--- a/processor/resourceprocessor/config.go
+++ b/processor/resourceprocessor/config.go
@@ -27,3 +27,10 @@ type Config struct {
 	// The set of actions are {INSERT, UPDATE, UPSERT, DELETE, HASH, EXTRACT}.
 	AttributesActions []processorhelper.ActionKeyValue `mapstructure:"attributes"`
 }
+
+var _ config.Processor = (*Config)(nil)
+
+// Validate checks if the processor configuration is valid
+func (cfg *Config) Validate() error {
+	return nil
+}

--- a/processor/spanprocessor/config.go
+++ b/processor/spanprocessor/config.go
@@ -78,3 +78,10 @@ type ToAttributes struct {
 	// modified span name.
 	BreakAfterMatch bool `mapstructure:"break_after_match"`
 }
+
+var _ config.Processor = (*Config)(nil)
+
+// Validate checks if the processor configuration is valid
+func (cfg *Config) Validate() error {
+	return nil
+}


### PR DESCRIPTION
**Description:** 
Extend previous PR - https://github.com/open-telemetry/opentelemetry-collector/pull/2856. Add `validatable` interface to `config.processor | extension | exporter`. And add the config validation in `config.Validate()`

**Next** 
Implement the empty `Validate()` func in component `Config`. For at least the core component we want to release stable.

**Link to tracking Issue:** 
https://github.com/open-telemetry/opentelemetry-collector/issues/2541
