### PR TITLE
Config Source Manager: support current env var syntax

### DIFF
--- a/config/internal/configsource/manager.go
+++ b/config/internal/configsource/manager.go
@@ -511,16 +511,18 @@ func expandEnvVars(s string) string {
 
 // Does the same behavior as os.ExpandEnv
 func osExpandEnv(buf []byte, name string, w int) []byte {
-	if name == "" && w > 0 {
+	switch {
+	case name == "" && w > 0:
 		// Encountered invalid syntax; eat the
 		// characters.
-	} else if name == "" {
+	case name == "":
 		// Valid syntax, but $ was not followed by a
 		// name. Leave the dollar character untouched.
 		buf = append(buf, expandPrefixChar)
-	} else {
+	default:
 		buf = append(buf, os.Getenv(name)...)
 	}
+
 	return buf
 }
 

--- a/config/internal/configsource/manager.go
+++ b/config/internal/configsource/manager.go
@@ -148,6 +148,10 @@ type (
 //      field_0: ${file:/var/secret.txt} # Injects the data from a config sourced named "file" using the selector "/var/secret.txt".
 //      field_1: ${file}:/var/secret.txt # Expands the environment variable "file" and adds the suffix ":/var/secret.txt" to it.
 //
+// If the the character following the '$' is in the set {'*', '#', '$', '@', '!', '?', '-', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9'}
+// the code will consider it to be the name of an environment variable to expand, or config source if followed by ':'. Do not use any of these
+// characters as the first char on the name of a config source or an environment variable (even if allowed by the system) to avoid unexpected
+// results.
 type Manager struct {
 	// configSources is map from ConfigSource names (as defined in the configuration)
 	// and the respective instances.

--- a/config/internal/configsource/manager.go
+++ b/config/internal/configsource/manager.go
@@ -361,18 +361,14 @@ func (m *Manager) expandString(ctx context.Context, s string) (interface{}, erro
 					buf = osExpandEnv(buf, content, w)
 				} else {
 					consumedAll := j+w+1 == len(s)
-					if consumedAll {
-						if len(buf) == 0 {
-							// This is the only content on the string, config
-							// source is free to return interface{}.
-							return retrieved, nil
-						}
-
-						// Convert the retrieved value to string.
-						return string(buf) + fmt.Sprintf("%v", retrieved), nil
+					if consumedAll && len(buf) == 0 {
+						// This is the only content on the string, config
+						// source is free to return interface{}.
+						return retrieved, nil
 					}
 
-					// There are still characters to be processed.
+					// Either there was a prefix already or there are still
+					// characters to be processed.
 					buf = append(buf, fmt.Sprintf("%v", retrieved)...)
 				}
 
@@ -387,6 +383,7 @@ func (m *Manager) expandString(ctx context.Context, s string) (interface{}, erro
 					if err != nil {
 						return nil, err
 					}
+
 					if len(buf) == 0 {
 						// This is the only content on the string, config
 						// source is free to return interface{}
@@ -401,7 +398,7 @@ func (m *Manager) expandString(ctx context.Context, s string) (interface{}, erro
 				buf = osExpandEnv(buf, name, w)
 			}
 
-			j += w    // move the index of the char being (j) checked by the number of characters consumed (w) on this iteration.
+			j += w    // move the index of the char being checked (j) by the number of characters consumed (w) on this iteration.
 			i = j + 1 // next slice to be copied start
 		}
 	}

--- a/config/internal/configsource/manager.go
+++ b/config/internal/configsource/manager.go
@@ -322,8 +322,7 @@ func (m *Manager) expandString(ctx context.Context, s string) (interface{}, erro
 	// Using i, j, and w variables to keep correspondence with os.Expand code.
 	// i tracks the index in s from which a slice to be appended to buf should start.
 	// j tracks the char being currently checked and also the end of the slice to be appended to buf.
-	// w tracks the number of characters being consumed after a prefix identifying and env var or
-	// config source.
+	// w tracks the number of characters being consumed after a prefix identifying env vars or config sources.
 	i := 0
 	for j := 0; j < len(s); j++ {
 		if s[j] == expandPrefixChar && j+1 < len(s) {
@@ -346,7 +345,7 @@ func (m *Manager) expandString(ctx context.Context, s string) (interface{}, erro
 				// Bracketed usage, consume everything until first '}' exactly as os.Expand.
 				var content string
 				content, w = getShellName(s[j+1:])
-				content = strings.Trim(content, " ") // Allow for some spacing but just on outside of expression.
+				content = strings.Trim(content, " ") // Allow for some spaces.
 				if len(content) > 1 && content[0] == expandPrefixChar {
 					name, _ := getShellName(content[1:])
 					if cfgSrc, ok := m.configSources[name]; ok {
@@ -404,7 +403,7 @@ func (m *Manager) expandString(ctx context.Context, s string) (interface{}, erro
 			}
 
 			j += w    // move the index of the char being checked (j) by the number of characters consumed (w) on this iteration.
-			i = j + 1 // next slice to be copied start
+			i = j + 1 // update start index (i) of next slice of bytes to be copied.
 		}
 	}
 
@@ -413,8 +412,7 @@ func (m *Manager) expandString(ctx context.Context, s string) (interface{}, erro
 		return s, nil
 	}
 
-	// Return whatever was accumulated on the buffer plus the remaining of the
-	// original string.
+	// Return whatever was accumulated on the buffer plus the remaining of the original string.
 	return string(buf) + s[i:], nil
 }
 
@@ -515,7 +513,8 @@ func expandEnvVars(s string) string {
 	})
 }
 
-// Does the same behavior as os.ExpandEnv
+// osExpandEnv replicate the internal behavior of os.ExpandEnv when handling env
+// vars updating the buffer accordingly.
 func osExpandEnv(buf []byte, name string, w int) []byte {
 	switch {
 	case name == "" && w > 0:

--- a/config/internal/configsource/manager.go
+++ b/config/internal/configsource/manager.go
@@ -122,7 +122,8 @@ type (
 //
 //    component:
 //      # Retrieves the value from the file text.txt located on the path specified by the environment
-//      # variable DATA_PATH.
+//      # variable DATA_PATH. The name of the environment variable is the string after the delimiter
+//      # until the first character different than '_' and non-alpha-numeric.
 //      text_from_file: $file:$DATA_PATH/text.txt
 //
 type Manager struct {
@@ -337,6 +338,7 @@ func (m *Manager) expandString(ctx context.Context, s string) (interface{}, erro
 	for j := 0; j < len(s); j++ {
 		if s[j] == expandPrefixChar && j+1 < len(s) {
 			if buf == nil {
+				// Assuming that the length of the string will double after expansion of env vars and config sources.
 				buf = make([]byte, 0, 2*len(s))
 			}
 			buf = append(buf, s[i:j]...)
@@ -347,7 +349,8 @@ func (m *Manager) expandString(ctx context.Context, s string) (interface{}, erro
 
 			switch {
 			case s[j+1] == expandPrefixChar:
-				// Escaped prefix:
+				// Escaping the prefix so $$ becomes a single $ without attempting
+				// to treat the string after it as a config source or env var.
 				buf = append(buf, s[j])
 				w = 1 // consumed a single char
 

--- a/config/internal/configsource/manager_test.go
+++ b/config/internal/configsource/manager_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"path"
 	"testing"
 
@@ -81,15 +82,6 @@ func TestConfigSourceManager_ResolveErrors(t *testing.T) {
 		config          map[string]interface{}
 		configSourceMap map[string]ConfigSource
 	}{
-		{
-			name: "not_found_config_source",
-			config: map[string]interface{}{
-				"cfgsrc": "$unknown:test_selector",
-			},
-			configSourceMap: map[string]ConfigSource{
-				"tstcfgsrc": &testConfigSource{},
-			},
-		},
 		{
 			name: "incorrect_cfgsrc_ref",
 			config: map[string]interface{}{
@@ -335,38 +327,155 @@ func TestConfigSourceManager_MultipleWatchForUpdate(t *testing.T) {
 	assert.NoError(t, manager.Close(ctx))
 }
 
-func TestConfigSourceManager_expandConfigSources(t *testing.T) {
+func TestConfigSourceManager_EnvVarHandling(t *testing.T) {
+	require.NoError(t, os.Setenv("envvar", "envvar_value"))
+	defer func() {
+		assert.NoError(t, os.Unsetenv("envvar"))
+	}()
+
+	ctx := context.Background()
+	tstCfgSrc := testConfigSource{
+		ValueMap: map[string]valueEntry{
+			"int_key": {Value: 42},
+		},
+	}
+
+	// Intercept "params_key" and create an entry with the params themselves.
+	tstCfgSrc.OnRetrieve = func(ctx context.Context, selector string, params interface{}) error {
+		if selector == "params_key" {
+			tstCfgSrc.ValueMap[selector] = valueEntry{Value: params}
+		}
+		return nil
+	}
+
+	manager, err := NewManager(nil)
+	require.NoError(t, err)
+	manager.configSources = map[string]ConfigSource{
+		"tstcfgsrc": &tstCfgSrc,
+	}
+
+	file := path.Join("testdata", "envvar_cfgsrc_mix.yaml")
+	cp, err := config.NewParserFromFile(file)
+	require.NoError(t, err)
+
+	expectedFile := path.Join("testdata", "envvar_cfgsrc_mix_expected.yaml")
+	expectedParser, err := config.NewParserFromFile(expectedFile)
+	require.NoError(t, err)
+	expectedCfg := expectedParser.Viper().AllSettings()
+
+	res, err := manager.Resolve(ctx, cp)
+	require.NoError(t, err)
+	actualCfg := res.Viper().AllSettings()
+	assert.Equal(t, expectedCfg, actualCfg)
+	assert.NoError(t, manager.Close(ctx))
+}
+
+func TestManager_expandString(t *testing.T) {
 	ctx := context.Background()
 	csp, err := NewManager(nil)
 	require.NoError(t, err)
 	csp.configSources = map[string]ConfigSource{
 		"tstcfgsrc": &testConfigSource{
 			ValueMap: map[string]valueEntry{
-				"test_selector": {Value: "test_value"},
+				"str_key": {Value: "test_value"},
+				"int_key": {Value: 1},
 			},
 		},
 	}
 
-	v, err := csp.expandConfigSources(ctx, "")
-	assert.NoError(t, err)
-	assert.Equal(t, "", v)
+	require.NoError(t, os.Setenv("envvar", "envvar_value"))
+	defer func() {
+		assert.NoError(t, os.Unsetenv("envvar"))
+	}()
+	require.NoError(t, os.Setenv("envvar_str_key", "str_key"))
+	defer func() {
+		assert.NoError(t, os.Unsetenv("envvar_str_key"))
+	}()
 
-	v, err = csp.expandConfigSources(ctx, "no_cfgsrc")
-	assert.NoError(t, err)
-	assert.Equal(t, "no_cfgsrc", v)
-
-	// Not found config source.
-	v, err = csp.expandConfigSources(ctx, "$cfgsrc:selector")
-	assert.Error(t, err)
-	assert.Nil(t, v)
-
-	v, err = csp.expandConfigSources(ctx, "$tstcfgsrc:test_selector")
-	assert.NoError(t, err)
-	assert.Equal(t, "test_value", v)
-
-	v, err = csp.expandConfigSources(ctx, "$tstcfgsrc:invalid_selector")
-	assert.Error(t, err)
-	assert.Nil(t, v)
+	tests := []struct {
+		name    string
+		input   string
+		want    interface{}
+		wantErr error
+	}{
+		{
+			name:  "literal_string",
+			input: "literal_string",
+			want:  "literal_string",
+		},
+		{
+			name:  "escaped_$",
+			input: "$$tstcfgsrc:int_key$$envvar",
+			want:  "$tstcfgsrc:int_key$envvar",
+		},
+		{
+			name:  "cfgsrc_int",
+			input: "$tstcfgsrc:int_key",
+			want:  1,
+		},
+		{
+			name:  "concatenate_cfgsrc_string",
+			input: "prefix-$tstcfgsrc:str_key",
+			want:  "prefix-test_value",
+		},
+		{
+			name:  "concatenate_cfgsrc_non_string",
+			input: "prefix-$tstcfgsrc:int_key",
+			want:  "prefix-1",
+		},
+		{
+			name:  "envvar",
+			input: "$envvar",
+			want:  "envvar_value",
+		},
+		{
+			name:  "prefixed_envvar",
+			input: "prefix-$envvar",
+			want:  "prefix-envvar_value",
+		},
+		{
+			name:  "suffixed_envvar",
+			input: "$envvar:suffix",
+			want:  "envvar_value:suffix",
+		},
+		{
+			name:  "envvar",
+			input: "$envvar:suffix",
+			want:  "envvar_value:suffix",
+		},
+		{
+			name:  "cfgsrc_using_envvar",
+			input: "$tstcfgsrc:$envvar_str_key",
+			want:  "test_value",
+		},
+		{
+			name:  "envvar_cfgsrc_using_envvar",
+			input: "$envvar/$tstcfgsrc:$envvar_str_key",
+			want:  "envvar_value/test_value",
+		},
+		{
+			name:  "delimited_cfgsrc",
+			input: "${$tstcfgsrc:int_key}",
+			want:  1,
+		},
+		{
+			name:  "delimited_cfgsrc_with_spaces",
+			input: "${ $tstcfgsrc: int_key }",
+			want:  1,
+		},
+		{
+			name:  "interpolated_and_delimited_cfgsrc",
+			input: "0/${ $tstcfgsrc: $envvar_str_key }/2/${$tstcfgsrc:int_key}",
+			want:  "0/test_value/2/1",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := csp.expandString(ctx, tt.input)
+			require.ErrorIs(t, err, tt.wantErr)
+			require.Equal(t, tt.want, got)
+		})
+	}
 }
 
 func Test_parseCfgSrc(t *testing.T) {
@@ -398,6 +507,17 @@ func Test_parseCfgSrc(t *testing.T) {
 				"p0": 1,
 				"p1": "a_string",
 				"p2": true,
+			},
+		},
+		{
+			name:       "query_pass_nil",
+			str:        "cfgsrc:selector?p0&p1&p2",
+			cfgSrcName: "cfgsrc",
+			selector:   "selector",
+			params: map[string]interface{}{
+				"p0": nil,
+				"p1": nil,
+				"p2": nil,
 			},
 		},
 		{

--- a/config/internal/configsource/manager_test.go
+++ b/config/internal/configsource/manager_test.go
@@ -434,14 +434,9 @@ func TestManager_expandString(t *testing.T) {
 			want:  "prefix-envvar_value",
 		},
 		{
-			name:  "suffixed_envvar",
-			input: "$envvar:suffix",
-			want:  "envvar_value:suffix",
-		},
-		{
-			name:  "envvar",
-			input: "$envvar:suffix",
-			want:  "envvar_value:suffix",
+			name:    "envvar_treated_as_cfgsrc",
+			input:   "$envvar:suffix",
+			wantErr: &errUnknownConfigSource{},
 		},
 		{
 			name:  "cfgsrc_using_envvar",
@@ -472,7 +467,7 @@ func TestManager_expandString(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := csp.expandString(ctx, tt.input)
-			require.ErrorIs(t, err, tt.wantErr)
+			require.IsType(t, tt.wantErr, err)
 			require.Equal(t, tt.want, got)
 		})
 	}

--- a/config/internal/configsource/manager_test.go
+++ b/config/internal/configsource/manager_test.go
@@ -454,6 +454,11 @@ func TestManager_expandString(t *testing.T) {
 			want:  1,
 		},
 		{
+			name:    "unknown_delimited_cfgsrc",
+			input:   "${cfgsrc:int_key}",
+			wantErr: &errUnknownConfigSource{},
+		},
+		{
 			name:  "delimited_cfgsrc_with_spaces",
 			input: "${ tstcfgsrc: int_key }",
 			want:  1,

--- a/config/internal/configsource/manager_test.go
+++ b/config/internal/configsource/manager_test.go
@@ -450,17 +450,17 @@ func TestManager_expandString(t *testing.T) {
 		},
 		{
 			name:  "delimited_cfgsrc",
-			input: "${$tstcfgsrc:int_key}",
+			input: "${tstcfgsrc:int_key}",
 			want:  1,
 		},
 		{
 			name:  "delimited_cfgsrc_with_spaces",
-			input: "${ $tstcfgsrc: int_key }",
+			input: "${ tstcfgsrc: int_key }",
 			want:  1,
 		},
 		{
 			name:  "interpolated_and_delimited_cfgsrc",
-			input: "0/${ $tstcfgsrc: $envvar_str_key }/2/${$tstcfgsrc:int_key}",
+			input: "0/${ tstcfgsrc: $envvar_str_key }/2/${tstcfgsrc:int_key}",
 			want:  "0/test_value/2/1",
 		},
 	}

--- a/config/internal/configsource/testdata/envvar_cfgsrc_mix.yaml
+++ b/config/internal/configsource/testdata/envvar_cfgsrc_mix.yaml
@@ -8,10 +8,10 @@ envvar_legacy_03: ${/test
 envvar_legacy_04: ${1}/test
 envvar_legacy_05: $1/test
 cfgsrc_suffix: prefix-$tstcfgsrc:int_key
-cfgsrc_middle: prefix-${$tstcfgsrc:int_key}-suffix
-cfgsrc_in_str: integer ${$tstcfgsrc:int_key} injected as string
-cfgsrc_params0: ${$tstcfgsrc:params_key?p0=true&p1=$envvar&p2=42}
-cfgsrc_params1: "${$tstcfgsrc:params_key?p0=false&p1=42&p2=$envvar}"
+cfgsrc_middle: prefix-${tstcfgsrc:int_key}-suffix
+cfgsrc_in_str: integer ${tstcfgsrc:int_key} injected as string
+cfgsrc_params0: ${tstcfgsrc:params_key?p0=true&p1=$envvar&p2=42}
+cfgsrc_params1: "${tstcfgsrc:params_key?p0=false&p1=42&p2=$envvar}"
 cfgsrc_params2: $tstcfgsrc:params_key?p0=$$envvar
 multi_line_envvars: |
   $tstcfgsrc: params_key

--- a/config/internal/configsource/testdata/envvar_cfgsrc_mix.yaml
+++ b/config/internal/configsource/testdata/envvar_cfgsrc_mix.yaml
@@ -1,0 +1,19 @@
+envvar: $envvar
+escapedDelim: $$envvar
+envvar_bracketed: ${envvar}tests
+envvar_legacy_00: $/not/valid$
+envvar_legacy_01: $not_found_envvar/test
+envvar_legacy_02: ${}/test
+envvar_legacy_03: ${/test
+envvar_legacy_04: ${1}/test
+envvar_legacy_05: $1/test
+cfgsrc_suffix: prefix-$tstcfgsrc:int_key
+cfgsrc_middle: prefix-${$tstcfgsrc:int_key}-suffix
+cfgsrc_in_str: integer ${$tstcfgsrc:int_key} injected as string
+cfgsrc_params0: ${$tstcfgsrc:params_key?p0=true&p1=$envvar&p2=42}
+cfgsrc_params1: "${$tstcfgsrc:params_key?p0=false&p1=42&p2=$envvar}"
+cfgsrc_params2: $tstcfgsrc:params_key?p0=$$envvar
+multi_line_envvars: |
+  $tstcfgsrc: params_key
+  p0: $envvar
+  p1: $${envvar}

--- a/config/internal/configsource/testdata/envvar_cfgsrc_mix_expected.yaml
+++ b/config/internal/configsource/testdata/envvar_cfgsrc_mix_expected.yaml
@@ -1,0 +1,25 @@
+envvar: envvar_value
+escapedDelim: $envvar
+envvar_bracketed: envvar_valuetests
+envvar_legacy_00: $/not/valid$
+envvar_legacy_01: /test
+envvar_legacy_02: /test
+envvar_legacy_03: /test
+envvar_legacy_04: /test
+envvar_legacy_05: /test
+cfgsrc_suffix: prefix-42
+cfgsrc_middle: prefix-42-suffix
+cfgsrc_in_str: integer 42 injected as string
+cfgsrc_params0:
+  p0: true
+  p1: envvar_value
+  p2: 42
+cfgsrc_params1:
+  p0: false
+  p1: 42
+  p2: envvar_value
+cfgsrc_params2:
+  p0: $envvar
+multi_line_envvars:
+  p0: envvar_value
+  p1: ${envvar}


### PR DESCRIPTION
Adding support to existing env var syntax per https://github.com/open-telemetry/opentelemetry-collector/pull/2857#issuecomment-815078669