### PR TITLE
receiver/prometheus: propagate Prometheus.Debug error values into .Warn for easy display

### DIFF
--- a/receiver/prometheusreceiver/internal/logger_test.go
+++ b/receiver/prometheusreceiver/internal/logger_test.go
@@ -198,7 +198,7 @@ func TestExtractLogData(t *testing.T) {
 		},
 	}
 
-	for _, tc := range tcs[len(tcs)-2:] {
+	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			ld := extractLogData(tc.input)
 			assert.Equal(t, tc.wantLevel, ld.level)

--- a/receiver/prometheusreceiver/internal/logger_test.go
+++ b/receiver/prometheusreceiver/internal/logger_test.go
@@ -184,9 +184,21 @@ func TestExtractLogData(t *testing.T) {
 				"warn", // Field is preserved
 			},
 		},
+		{
+			name: "transform Prometheus Debug level err into Warn level",
+			input: []interface{}{
+				"level", level.DebugValue(),
+				"err",
+				`Get "http://0.0.0.0:9999/metrics": dial tcp 0.0.0.0:9999: connect: connection refused`,
+			},
+			wantLevel: level.WarnValue(), // The transformed level
+			wantOutput: []interface{}{
+				"err", `Get "http://0.0.0.0:9999/metrics": dial tcp 0.0.0.0:9999: connect: connection refused`,
+			},
+		},
 	}
 
-	for _, tc := range tcs {
+	for _, tc := range tcs[len(tcs)-2:] {
 		t.Run(tc.name, func(t *testing.T) {
 			ld := extractLogData(tc.input)
 			assert.Equal(t, tc.wantLevel, ld.level)


### PR DESCRIPTION
This change transforms Prometheus created .Debug level errors such as
failed scrape message reasons into a level that be displayed to
collector users, without them having to use --log-level=DEBUG.

In 2017, a Prometheus PR https://github.com/prometheus/prometheus/pull/3135
added the failure reason displays with a .Debug level.

This change now ensures that a Prometheus log that's routed from
say a scrape failure that was logged originally from Prometheus as:

    2021-04-09T22:58:51.732-0700	debug	scrape/scrape.go:1127
    Scrape failed	{"kind": "receiver", "name": "prometheus",
    "scrape_pool": "otel-collector", "target": "http://0.0.0.0:9999/metrics",
    "err": "Get \"http://0.0.0.0:9999/metrics\": dial tcp 0.0.0.0:9999: connect: connection refused"}

will now get transformed to:

    2021-04-09T23:24:41.733-0700	warn	internal/metricsbuilder.go:104
    Failed to scrape Prometheus endpoint    {"kind": "receiver", "name": "prometheus",
    "scrape_timestamp": 1618035881732, "target_labels": "map[instance:0.0.0.0:9999 job:otel-collector]"}

which will now be surfaced to users.

Fixes #2364