### PR TITLE
[WIP] Add Windows container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,6 +171,13 @@ docker-component: check-component
 	docker build -t $(COMPONENT) ./cmd/$(COMPONENT)/
 	rm ./cmd/$(COMPONENT)/$(COMPONENT)
 
+.PHONY: docker-windows-component # Not intended to be used directly
+docker-windows-component: check-component
+	GOOS=windows $(MAKE) $(COMPONENT)
+	cp ./bin/$(COMPONENT)_windows_amd64 ./cmd/$(COMPONENT)/$(COMPONENT).exe
+	docker build -t $(COMPONENT) -f ./cmd/$(COMPONENT)/Dockerfile_windows ./cmd/$(COMPONENT)/
+	rm ./cmd/$(COMPONENT)/$(COMPONENT)
+
 .PHONY: for-all
 for-all:
 	@echo "running $${CMD} in root"
@@ -220,6 +227,10 @@ delete-tag:
 .PHONY: docker-otelcol
 docker-otelcol:
 	COMPONENT=otelcol $(MAKE) docker-component
+
+.PHONY: docker-windows-otelcol
+docker-windows-otelcol:
+	COMPONENT=otelcol $(MAKE) docker-windows-component
 
 .PHONY: binaries-all-sys
 binaries-all-sys: binaries-darwin_amd64 binaries-linux_amd64 binaries-linux_arm64 binaries-windows_amd64

--- a/Makefile
+++ b/Makefile
@@ -175,7 +175,7 @@ docker-component: check-component
 docker-windows-component: check-component
 	GOOS=windows $(MAKE) $(COMPONENT)
 	cp ./bin/$(COMPONENT)_windows_amd64 ./cmd/$(COMPONENT)/$(COMPONENT).exe
-	docker build -t $(COMPONENT) -f ./cmd/$(COMPONENT)/Dockerfile_windows ./cmd/$(COMPONENT)/
+	docker build -t $(COMPONENT)-windows -f ./cmd/$(COMPONENT)/Dockerfile_windows ./cmd/$(COMPONENT)/
 	rm ./cmd/$(COMPONENT)/$(COMPONENT)
 
 .PHONY: for-all

--- a/cmd/otelcol/Dockerfile_windows
+++ b/cmd/otelcol/Dockerfile_windows
@@ -1,0 +1,8 @@
+FROM mcr.microsoft.com/windows/nanoserver:20H2
+
+COPY otelcol.exe .
+COPY config.yaml .
+
+ENTRYPOINT ["otelcol"]
+CMD ["--config", "config.yaml"]
+EXPOSE 4317 55678 55679


### PR DESCRIPTION
Fixes: https://github.com/open-telemetry/opentelemetry-collector/issues/2715

## TODO

- Update GitHub Actions and CircleCI workflows

## Does nanoeserver have default certificate authorities?

Yes. I have written a little Go program to verify it:

```
func main() {
	resp, err := http.Get(os.Args[1])
	if err != nil {
		log.Fatal(err)
	}
	log.Println(resp)
}
```

and Dockerfile for it:

```
FROM mcr.microsoft.com/windows/nanoserver:20H2
COPY certtest.exe .
ENTRYPOINT ["certtest"]
```

See the results of testing:
```
$ make my-test
COMPONENT=certtest C:/TDM-GCC-64/bin/make docker-windows-component
make[1]: Entering directory 'C:/repos/opentelemetry-collector'
GOOS=windows C:/TDM-GCC-64/bin/make certtest
make[2]: Entering directory 'C:/repos/opentelemetry-collector'
GO111MODULE=on CGO_ENABLED=0 go build -o ./bin/certtest_windows_amd64 -ldflags "-X go.opentelemetry.io/collector/internal/version.GitHash=fffc15e6 -X go.opentelemetry.io/collector/internal/version.Version=v0.24.0-15-gfffc15e6 -X go.opentelemetry.io/collector/internal/version.BuildType=release" ./cmd/certtest
make[2]: Leaving directory 'C:/repos/opentelemetry-collector'
cp ./bin/certtest_windows_amd64 ./cmd/certtest/certtest.exe
docker build -t certtest -f ./cmd/certtest/Dockerfile_windows ./cmd/certtest/
Sending build context to Docker daemon  6.194MB
Step 1/3 : FROM mcr.microsoft.com/windows/nanoserver:20H2
 ---> 10f2e1bb70d2
Step 2/3 : COPY certtest.exe .
 ---> addee6dcde96
Step 3/3 : ENTRYPOINT ["certtest"]
 ---> Running in c2a65bb8e147
Removing intermediate container c2a65bb8e147
 ---> 44054f93a832
Successfully built 44054f93a832
Successfully tagged certtest:latest
rm ./cmd/certtest/certtest
make[1]: Leaving directory 'C:/repos/opentelemetry-collector'
docker run --rm certtest https://example.com
2021/04/13 08:08:45 &{200 OK 200 HTTP/2.0 2 0 map[Accept-Ranges:[bytes] Age:[304445] Cache-Control:[max-age=604800] Content-Type:[text/html; charset=UTF-8] Date:[Tue, 13 Apr 2021 06:08:46 GMT] Etag:["3147526947"] Expires:[Tue, 20 Apr 2021 06:08:46 GMT] Last-Modified:[Thu, 17 Oct 2019 07:18:26 GMT] Server:[ECS (nyb/1D04)] Vary:[Accept-Encoding] X-Cache:[HIT]] 0xc00017e3f0 -1 [] false true map[] 0xc000132000 0xc000114420}     
docker run --rm certtest https://badexample.com
2021/04/13 08:08:47 Get "https://badexample.com": x509: certificate signed by unknown authority
Makefile:237: recipe for target 'my-test' failed
make: *** [my-test] Error 1
```

---------------------------------------

## Important (read before submitting)
We are currently preparing for the upcoming 1.0 GA release. Pull requests that are not aligned with
the current roadmap https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/roadmap.md
and are not aimed at stabilizing and preparing the Collector for the release will not be accepted.

_Delete this paragraph before submitting._

**Description:** <Describe what has changed. 
Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.>

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** < Describe what testing was performed and which tests were added.>

**Documentation:** < Describe the documentation added.>

_Please delete paragraphs that you did not use before submitting._
