### PR TITLE
Move some unmarshaling errors to the Validate method

### DIFF
--- a/receiver/hostmetricsreceiver/config.go
+++ b/receiver/hostmetricsreceiver/config.go
@@ -40,11 +40,19 @@ var _ config.CustomUnmarshable = (*Config)(nil)
 
 // Validate checks the receiver configuration is valid
 func (cfg *Config) Validate() error {
+	if len(cfg.Scrapers) == 0 {
+		return errors.New("must specify at least one scraper when using hostmetrics receiver")
+	}
+
 	return nil
 }
 
 // Unmarshal a config.Parser into the config struct.
 func (cfg *Config) Unmarshal(componentParser *config.Parser) error {
+	if componentParser == nil {
+		return nil
+	}
+
 	// load the non-dynamic config normally
 	err := componentParser.Unmarshal(cfg)
 	if err != nil {
@@ -58,9 +66,6 @@ func (cfg *Config) Unmarshal(componentParser *config.Parser) error {
 	scrapersSection, err := componentParser.Sub(scrapersKey)
 	if err != nil {
 		return err
-	}
-	if len(scrapersSection.AllKeys()) == 0 {
-		return errors.New("must specify at least one scraper when using hostmetrics receiver")
 	}
 
 	for key := range cast.ToStringMap(componentParser.Get(scrapersKey)) {

--- a/receiver/hostmetricsreceiver/config_test.go
+++ b/receiver/hostmetricsreceiver/config_test.go
@@ -103,7 +103,7 @@ func TestLoadInvalidConfig_NoScrapers(t *testing.T) {
 	factories.Receivers[typeStr] = factory
 	_, err = configtest.LoadConfigFile(t, path.Join(".", "testdata", "config-noscrapers.yaml"), factories)
 
-	require.EqualError(t, err, "error reading receivers configuration for hostmetrics: must specify at least one scraper when using hostmetrics receiver")
+	require.EqualError(t, err, "receiver \"hostmetrics\" has invalid configuration: must specify at least one scraper when using hostmetrics receiver")
 }
 
 func TestLoadInvalidConfig_InvalidScraperKey(t *testing.T) {

--- a/receiver/jaegerreceiver/config.go
+++ b/receiver/jaegerreceiver/config.go
@@ -86,6 +86,12 @@ var _ config.CustomUnmarshable = (*Config)(nil)
 
 // Validate checks the receiver configuration is valid
 func (cfg *Config) Validate() error {
+	if cfg.GRPC == nil &&
+		cfg.ThriftHTTP == nil &&
+		cfg.ThriftBinary == nil &&
+		cfg.ThriftCompact == nil {
+		return fmt.Errorf("must specify at least one protocol when using the Jaeger receiver")
+	}
 	return nil
 }
 
@@ -103,10 +109,6 @@ func (cfg *Config) Unmarshal(componentParser *config.Parser) error {
 	}
 
 	protocols := cast.ToStringMap(componentParser.Get(protocolsFieldName))
-	if len(protocols) == 0 {
-		return fmt.Errorf("must specify at least one protocol when using the Jaeger receiver")
-	}
-
 	knownProtocols := 0
 	if _, ok := protocols[protoGRPC]; !ok {
 		cfg.GRPC = nil

--- a/receiver/jaegerreceiver/config_test.go
+++ b/receiver/jaegerreceiver/config_test.go
@@ -178,7 +178,7 @@ func TestFailedLoadConfig(t *testing.T) {
 	assert.EqualError(t, err, "error reading receivers configuration for jaeger: 1 error(s) decoding:\n\n* 'protocols' has invalid keys: thrift_htttp")
 
 	_, err = configtest.LoadConfigFile(t, path.Join(".", "testdata", "bad_no_proto_config.yaml"), factories)
-	assert.EqualError(t, err, "error reading receivers configuration for jaeger: must specify at least one protocol when using the Jaeger receiver")
+	assert.EqualError(t, err, "receiver \"jaeger\" has invalid configuration: must specify at least one protocol when using the Jaeger receiver")
 
 	_, err = configtest.LoadConfigFile(t, path.Join(".", "testdata", "bad_empty_config.yaml"), factories)
 	assert.EqualError(t, err, "error reading receivers configuration for jaeger: empty config for Jaeger receiver")

--- a/receiver/otlpreceiver/config.go
+++ b/receiver/otlpreceiver/config.go
@@ -50,6 +50,10 @@ var _ config.CustomUnmarshable = (*Config)(nil)
 
 // Validate checks the receiver configuration is valid
 func (cfg *Config) Validate() error {
+	if cfg.GRPC == nil &&
+		cfg.HTTP == nil {
+		return fmt.Errorf("must specify at least one protocol when using the OTLP receiver")
+	}
 	return nil
 }
 
@@ -86,10 +90,5 @@ func (cfg *Config) Unmarshal(componentParser *config.Parser) error {
 	if len(protocols) != knownProtocols {
 		return fmt.Errorf("unknown protocols in the OTLP receiver")
 	}
-
-	if cfg.GRPC == nil && cfg.HTTP == nil {
-		return fmt.Errorf("must specify at least one protocol when using the OTLP receiver")
-	}
-
 	return nil
 }

--- a/receiver/otlpreceiver/config_test.go
+++ b/receiver/otlpreceiver/config_test.go
@@ -226,7 +226,7 @@ func TestFailedLoadConfig(t *testing.T) {
 	assert.EqualError(t, err, "error reading receivers configuration for otlp: 1 error(s) decoding:\n\n* 'protocols' has invalid keys: thrift")
 
 	_, err = configtest.LoadConfigFile(t, path.Join(".", "testdata", "bad_no_proto_config.yaml"), factories)
-	assert.EqualError(t, err, "error reading receivers configuration for otlp: must specify at least one protocol when using the OTLP receiver")
+	assert.EqualError(t, err, "receiver \"otlp\" has invalid configuration: must specify at least one protocol when using the OTLP receiver")
 
 	_, err = configtest.LoadConfigFile(t, path.Join(".", "testdata", "bad_empty_config.yaml"), factories)
 	assert.EqualError(t, err, "error reading receivers configuration for otlp: empty config for OTLP receiver")

--- a/receiver/prometheusreceiver/config.go
+++ b/receiver/prometheusreceiver/config.go
@@ -50,6 +50,9 @@ var _ config.CustomUnmarshable = (*Config)(nil)
 
 // Validate checks the receiver configuration is valid
 func (cfg *Config) Validate() error {
+	if cfg.PrometheusConfig != nil && len(cfg.PrometheusConfig.ScrapeConfigs) == 0 {
+		return errNilScrapeConfig
+	}
 	return nil
 }
 
@@ -79,9 +82,6 @@ func (cfg *Config) Unmarshal(componentParser *config.Parser) error {
 	err = yaml.UnmarshalStrict(out, &cfg.PrometheusConfig)
 	if err != nil {
 		return fmt.Errorf("prometheus receiver failed to unmarshal yaml to prometheus config: %s", err)
-	}
-	if len(cfg.PrometheusConfig.ScrapeConfigs) == 0 {
-		return errNilScrapeConfig
 	}
 	return nil
 }


### PR DESCRIPTION
**Description:** 

- Move some errors happening during unmarshaling to the new `Validate` method.

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector/pull/2867#discussion_r606354281

To be tracked on #2819