### PR TITLE
Remove already deprecated test funcs New*Nop and New*Err

### DIFF
--- a/consumer/consumertest/err.go
+++ b/consumer/consumertest/err.go
@@ -17,7 +17,6 @@ package consumertest
 import (
 	"context"
 
-	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/pdata"
 )
 
@@ -41,23 +40,5 @@ func (er *errConsumer) ConsumeLogs(context.Context, pdata.Logs) error {
 
 // NewErr returns a Consumer that just drops all received data and returns no error.
 func NewErr(err error) Consumer {
-	return &errConsumer{err: err}
-}
-
-// NewTracesErr returns a consumer.Traces that just drops all received data and returns the given error.
-// Deprecated: Use NewErr().
-func NewTracesErr(err error) consumer.Traces {
-	return &errConsumer{err: err}
-}
-
-// NewMetricsErr returns a consumer.Metrics that just drops all received data and returns the given error.
-// Deprecated: Use NewErr().
-func NewMetricsErr(err error) consumer.Metrics {
-	return &errConsumer{err: err}
-}
-
-// NewLogsErr returns a consumer.Logs that just drops all received data and returns the given error.
-// Deprecated: Use NewErr().
-func NewLogsErr(err error) consumer.Logs {
 	return &errConsumer{err: err}
 }

--- a/consumer/consumertest/err_test.go
+++ b/consumer/consumertest/err_test.go
@@ -34,24 +34,3 @@ func TestErr(t *testing.T) {
 	assert.Equal(t, err, ec.ConsumeMetrics(context.Background(), pdata.NewMetrics()))
 	assert.Equal(t, err, ec.ConsumeTraces(context.Background(), pdata.NewTraces()))
 }
-
-func TestTracesErr(t *testing.T) {
-	err := errors.New("my error")
-	nt := NewTracesErr(err)
-	require.NotNil(t, nt)
-	assert.Equal(t, err, nt.ConsumeTraces(context.Background(), pdata.NewTraces()))
-}
-
-func TestMetricsErr(t *testing.T) {
-	err := errors.New("my error")
-	nm := NewMetricsErr(err)
-	require.NotNil(t, nm)
-	assert.Equal(t, err, nm.ConsumeMetrics(context.Background(), pdata.NewMetrics()))
-}
-
-func TestLogsErr(t *testing.T) {
-	err := errors.New("my error")
-	nl := NewLogsErr(err)
-	require.NotNil(t, nl)
-	assert.Equal(t, err, nl.ConsumeLogs(context.Background(), pdata.NewLogs()))
-}

--- a/consumer/consumertest/nop.go
+++ b/consumer/consumertest/nop.go
@@ -17,7 +17,6 @@ package consumertest
 import (
 	"context"
 
-	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/pdata"
 )
 
@@ -43,23 +42,5 @@ func (nc *nopConsumer) ConsumeLogs(context.Context, pdata.Logs) error {
 
 // NewNop returns a Consumer that just drops all received data and returns no error.
 func NewNop() Consumer {
-	return nopInstance
-}
-
-// NewTracesNop returns a consumer.Traces that just drops all received data and returns no error.
-// Deprecated: Use NewNop().
-func NewTracesNop() consumer.Traces {
-	return nopInstance
-}
-
-// NewMetricsNop returns a consumer.Metrics that just drops all received data and returns no error.
-// Deprecated: Use NewNop().
-func NewMetricsNop() consumer.Metrics {
-	return nopInstance
-}
-
-// NewLogsNop returns a consumer.Logs that just drops all received data and returns no error.
-// Deprecated: Use NewNop().
-func NewLogsNop() consumer.Logs {
 	return nopInstance
 }

--- a/consumer/consumertest/nop_test.go
+++ b/consumer/consumertest/nop_test.go
@@ -32,21 +32,3 @@ func TestNop(t *testing.T) {
 	assert.NoError(t, nc.ConsumeMetrics(context.Background(), pdata.NewMetrics()))
 	assert.NoError(t, nc.ConsumeTraces(context.Background(), pdata.NewTraces()))
 }
-
-func TestTracesNop(t *testing.T) {
-	nt := NewTracesNop()
-	require.NotNil(t, nt)
-	assert.NoError(t, nt.ConsumeTraces(context.Background(), pdata.NewTraces()))
-}
-
-func TestMetricsNop(t *testing.T) {
-	nm := NewMetricsNop()
-	require.NotNil(t, nm)
-	assert.NoError(t, nm.ConsumeMetrics(context.Background(), pdata.NewMetrics()))
-}
-
-func TestLogsNop(t *testing.T) {
-	nl := NewLogsNop()
-	require.NotNil(t, nl)
-	assert.NoError(t, nl.ConsumeLogs(context.Background(), pdata.NewLogs()))
-}


### PR DESCRIPTION
Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
