### PR TITLE
Optimize dpgSignature function in Prometheus receiver

### DIFF
--- a/receiver/prometheusreceiver/internal/metricsbuilder.go
+++ b/receiver/prometheusreceiver/internal/metricsbuilder.go
@@ -179,15 +179,27 @@ func isUsefulLabel(mType metricspb.MetricDescriptor_Type, labelKey string) bool 
 
 // dpgSignature is used to create a key for data complexValue belong to a same group of a metric family
 func dpgSignature(orderedKnownLabelKeys []string, ls labels.Labels) string {
-	sign := make([]string, 0, len(orderedKnownLabelKeys))
+	size := 0
 	for _, k := range orderedKnownLabelKeys {
 		v := ls.Get(k)
 		if v == "" {
 			continue
 		}
-		sign = append(sign, k+"="+v)
+		// 2 enclosing quotes + 1 equality sign = 3 extra chars.
+		// Note: if any character in the label value requires escaping,
+		// we'll need more space than that, which will lead to some
+		// extra allocation.
+		size += 3 + len(k) + len(v)
 	}
-	return fmt.Sprintf("%#v", sign)
+	sign := make([]byte, 0, size)
+	for _, k := range orderedKnownLabelKeys {
+		v := ls.Get(k)
+		if v == "" {
+			continue
+		}
+		sign = strconv.AppendQuote(sign, k+"="+v)
+	}
+	return string(sign)
 }
 
 func normalizeMetricName(name string) string {


### PR DESCRIPTION

**Description:**

dpgSignature is invoked very often, which leads to high CPU usage when
collecting Prometheus metrics.

Benchmark results on my machine show 3x less CPU and almost 4x less
memory used. Since I'm also changing the format of returned values
(dropping superfluous characters), it will reduce overall memory usage
of the receiver, because they are used as map keys.

Benchmark result before this change:

Benchmark_dpgSignature-6   	 1284531	       969.6 ns/op	     120 B/op	       7 allocs/op

Benchmark result after this change:

Benchmark_dpgSignature-6   	 3515179	       313.9 ns/op	      32 B/op	       2 allocs/op

**Testing:** Added benchmark and updated unit tests.

