### PR TITLE
Update processor recommendation for k8s_tagger

### DIFF
--- a/processor/README.md
+++ b/processor/README.md
@@ -36,14 +36,14 @@ processor documentation for more information.
 
 1. [memory_limiter](memorylimiter/README.md)
 2. *any sampling processors*
-3. `k8s_tagger` if using (must be before `batch` else receiving context is lost)
+3. Any processor relying on sending source from `Context` (e.g. `k8s_tagger`)
 3. [batch](batchprocessor/README.md)
 4. *any other processors*
 
 ### Metrics
 
 1. [memory_limiter](memorylimiter/README.md)
-2. `k8s_tagger` if using (must be before `batch` else receiving context is lost)
+2. Any processor relying on sending source from `Context` (e.g. `k8s_tagger`)
 3. [batch](batchprocessor/README.md)
 4. *any other processors*
 

--- a/processor/README.md
+++ b/processor/README.md
@@ -36,14 +36,16 @@ processor documentation for more information.
 
 1. [memory_limiter](memorylimiter/README.md)
 2. *any sampling processors*
+3. `k8s_tagger` if using (must be before `batch` else receiving context is lost)
 3. [batch](batchprocessor/README.md)
 4. *any other processors*
 
 ### Metrics
 
 1. [memory_limiter](memorylimiter/README.md)
-2. [batch](batchprocessor/README.md)
-3. *any other processors*
+2. `k8s_tagger` if using (must be before `batch` else receiving context is lost)
+3. [batch](batchprocessor/README.md)
+4. *any other processors*
 
 ## <a name="data-ownership"></a>Data Ownership
 


### PR DESCRIPTION
k8s_tagger relies on the `context.Context` object to find the pod IP of the incoming telemetry. This context gets lost when batch processor is hit. Adding recommendation here even though k8s_tagger is a contrib to because this is where ordering recommendations are made and it's a common processor.