### PR TITLE
Remove queue from the Prometheus remote write

### DIFF
--- a/exporter/prometheusremotewriteexporter/README.md
+++ b/exporter/prometheusremotewriteexporter/README.md
@@ -51,4 +51,4 @@ Several helper files are leveraged to provide additional capabilities automatica
 
 - [HTTP settings](https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/confighttp/README.md)
 - [TLS and mTLS settings](https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/configtls/README.md)
-- [Retry and timeout settings](https://github.com/open-telemetry/opentelemetry-collector/blob/main/exporter/exporterhelper/README.md), not that the exporter doesn't support `sending_queue`.
+- [Retry and timeout settings](https://github.com/open-telemetry/opentelemetry-collector/blob/main/exporter/exporterhelper/README.md), note that the exporter doesn't support `sending_queue`.

--- a/exporter/prometheusremotewriteexporter/README.md
+++ b/exporter/prometheusremotewriteexporter/README.md
@@ -51,4 +51,4 @@ Several helper files are leveraged to provide additional capabilities automatica
 
 - [HTTP settings](https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/confighttp/README.md)
 - [TLS and mTLS settings](https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/configtls/README.md)
-- [Queuing, retry and timeout settings](https://github.com/open-telemetry/opentelemetry-collector/blob/main/exporter/exporterhelper/README.md)
+- [Retry and timeout settings](https://github.com/open-telemetry/opentelemetry-collector/blob/main/exporter/exporterhelper/README.md), not that the exporter doesn't support `sending_queue`.

--- a/exporter/prometheusremotewriteexporter/factory.go
+++ b/exporter/prometheusremotewriteexporter/factory.go
@@ -56,6 +56,7 @@ func createMetricsExporter(_ context.Context, params component.ExporterCreatePar
 	}
 
 	// Don't support the queue.
+	// See https://github.com/open-telemetry/opentelemetry-collector/issues/2949.
 	// Prometheus remote write samples needs to be in chronological
 	// order for each timeseries. If we shard the incoming metrics
 	// without considering this limitation, we experience

--- a/exporter/prometheusremotewriteexporter/factory.go
+++ b/exporter/prometheusremotewriteexporter/factory.go
@@ -55,12 +55,16 @@ func createMetricsExporter(_ context.Context, params component.ExporterCreatePar
 		return nil, err
 	}
 
+	// Don't support the queue.
+	// Prometheus remote write samples needs to be in chronological
+	// order for each timeseries. If we shard the incoming metrics
+	// without considering this limitation, we experience
+	// "out of order samples" errors.
 	prwexp, err := exporterhelper.NewMetricsExporter(
 		cfg,
 		params.Logger,
 		prwe.PushMetrics,
 		exporterhelper.WithTimeout(prwCfg.TimeoutSettings),
-		exporterhelper.WithQueue(prwCfg.QueueSettings),
 		exporterhelper.WithRetry(prwCfg.RetrySettings),
 		exporterhelper.WithShutdown(prwe.Shutdown),
 	)
@@ -75,7 +79,6 @@ func createDefaultConfig() config.Exporter {
 		ExternalLabels:   map[string]string{},
 		TimeoutSettings:  exporterhelper.DefaultTimeoutSettings(),
 		RetrySettings:    exporterhelper.DefaultRetrySettings(),
-		QueueSettings:    exporterhelper.DefaultQueueSettings(),
 		HTTPClientSettings: confighttp.HTTPClientSettings{
 			Endpoint: "http://some.url:9411/api/prom/push",
 			// We almost read 0 bytes, so no need to tune ReadBufferSize.


### PR DESCRIPTION
Prometheus remote write (PWR) exporter is supporting queued retry
out of the box, but due to the strict requirements of PWR, the queue
causes "out of order sample" errors. The queue won't be suitable
for Prometheus unless it has a way to shard the data by timeseries.

This is not going to break the existing users because if they have
this feature enabled, they already can't use the PRW exporter correctly.

Fixes #2949.
