### PR TITLE
Fix data race between kafkareceiver and batchprocessor (#2956)

### DIFF
--- a/receiver/kafkareceiver/kafka_receiver.go
+++ b/receiver/kafkareceiver/kafka_receiver.go
@@ -171,8 +171,9 @@ func (c *consumerGroupHandler) ConsumeClaim(session sarama.ConsumerGroupSession,
 			return err
 		}
 
+		spanCount := traces.SpanCount()
 		err = c.nextConsumer.ConsumeTraces(session.Context(), traces)
-		obsreport.EndTraceDataReceiveOp(ctx, c.unmarshaller.Encoding(), traces.SpanCount(), err)
+		obsreport.EndTraceDataReceiveOp(ctx, c.unmarshaller.Encoding(), spanCount, err)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
**Description:**
Fix datarace between kafkareceiver and batchprocessor, more description see issue #2956 
kafkareceiver should not use `traces` varible  after invoke `nextConsumer.ConsumeTraces` because  `traces` object will be operated in batchprocessor in another goroutine.

```
==================
WARNING: DATA RACE
Write at 0x00c0001108d0 by goroutine 115:
  go.opentelemetry.io/collector/consumer/pdata.ResourceSpansSlice.MoveAndAppendTo()
      /Users/jimmiehan/github.com/hanjm/opentelemetry-collector/consumer/pdata/generated_trace.go:75 +0x237
  go.opentelemetry.io/collector/processor/batchprocessor.(*batchTraces).add()
      /Users/jimmiehan/github.com/hanjm/opentelemetry-collector/processor/batchprocessor/batch_processor.go:269 +0xe5
  go.opentelemetry.io/collector/processor/batchprocessor.(*batchProcessor).processItem()
      /Users/jimmiehan/github.com/hanjm/opentelemetry-collector/processor/batchprocessor/batch_processor.go:187 +0x138
  go.opentelemetry.io/collector/processor/batchprocessor.(*batchProcessor).startProcessingCycle()
      /Users/jimmiehan/github.com/hanjm/opentelemetry-collector/processor/batchprocessor/batch_processor.go:143 +0x284

Previous read at 0x00c0001108d0 by goroutine 123:
  go.opentelemetry.io/collector/consumer/pdata.ResourceSpansSlice.Len()
      /Users/jimmiehan/github.com/hanjm/opentelemetry-collector/consumer/pdata/generated_trace.go:52 +0x113
  go.opentelemetry.io/collector/consumer/pdata.Traces.SpanCount()
      /Users/jimmiehan/github.com/hanjm/opentelemetry-collector/consumer/pdata/trace.go:79 +0x3a
  go.opentelemetry.io/collector/receiver/kafkareceiver.(*consumerGroupHandler).ConsumeClaim()
      /Users/jimmiehan/github.com/hanjm/opentelemetry-collector/receiver/kafkareceiver/kafka_receiver.go:175 +0xd0b
  github.com/Shopify/sarama.(*consumerGroupSession).consume()
      /Users/jimmiehan/go/pkg/mod/github.com/!shopify/sarama@v1.28.0/consumer_group.go:690 +0x3a8
  github.com/Shopify/sarama.newConsumerGroupSession.func2()
      /Users/jimmiehan/go/pkg/mod/github.com/!shopify/sarama@v1.28.0/consumer_group.go:615 +0x104

Goroutine 115 (running) created at:
  go.opentelemetry.io/collector/processor/batchprocessor.(*batchProcessor).Start()
      /Users/jimmiehan/github.com/hanjm/opentelemetry-collector/processor/batchprocessor/batch_processor.go:103 +0x4c
  go.opentelemetry.io/collector/service/internal/builder.BuiltPipelines.StartProcessors()
      /Users/jimmiehan/github.com/hanjm/opentelemetry-collector/service/internal/builder/pipelines_builder.go:58 +0x154
  go.opentelemetry.io/collector/service.(*service).startPipelines()
      /Users/jimmiehan/github.com/hanjm/opentelemetry-collector/service/service.go:206 +0x264
  go.opentelemetry.io/collector/service.(*service).Start()
      /Users/jimmiehan/github.com/hanjm/opentelemetry-collector/service/service.go:90 +0x169
```

**Link to tracking Issue:**
#2956 

**Testing:**
run unittest and go run with --race 
