### PR TITLE
Remove deprecated NewAttributeValue, update pdatagen to avoid using it

### DIFF
--- a/cmd/pdatagen/internal/base_slices.go
+++ b/cmd/pdatagen/internal/base_slices.go
@@ -140,7 +140,7 @@ const slicePtrTestTemplate = `func Test${structName}(t *testing.T) {
 	assert.EqualValues(t, 0, es.Len())
 
 	es.Resize(7)
-	emptyVal := New${elementName}()
+	emptyVal := new${elementName}(&${originName}{})
 	testVal := generateTest${elementName}()
 	assert.EqualValues(t, 7, es.Len())
 	for i := 0; i < es.Len(); i++ {
@@ -192,7 +192,7 @@ func Test${structName}_CopyTo(t *testing.T) {
 
 func Test${structName}_Resize(t *testing.T) {
 	es := generateTest${structName}()
-	emptyVal := New${elementName}()
+	emptyVal := new${elementName}(&${originName}{})
 	// Test Resize less elements.
 	const resizeSmallLen = 4
 	expectedEs := make(map[*${originName}]bool, resizeSmallLen)
@@ -235,12 +235,11 @@ func Test${structName}_Resize(t *testing.T) {
 func Test${structName}_Append(t *testing.T) {
 	es := generateTest${structName}()
 
-	emptyVal := New${elementName}()
+	emptyVal := new${elementName}(&${originName}{})
 	es.Append(emptyVal)
 	assert.EqualValues(t, emptyVal.orig, es.At(7).orig)
 
-	value := New${elementName}()
-	fillTest${elementName}(value)
+	value := generateTest${elementName}()
 	es.Append(value)
 	assert.EqualValues(t, value.orig, es.At(8).orig)
 
@@ -376,7 +375,7 @@ const sliceValueTestTemplate = `func Test${structName}(t *testing.T) {
 	assert.EqualValues(t, 0, es.Len())
 
 	es.Resize(7)
-	emptyVal := New${elementName}()
+	emptyVal := new${elementName}(&${originName}{})
 	testVal := generateTest${elementName}()
 	assert.EqualValues(t, 7, es.Len())
 	for i := 0; i < es.Len(); i++ {
@@ -428,7 +427,7 @@ func Test${structName}_CopyTo(t *testing.T) {
 
 func Test${structName}_Resize(t *testing.T) {
 	es := generateTest${structName}()
-	emptyVal := New${elementName}()
+	emptyVal := new${elementName}(&${originName}{})
 	// Test Resize less elements.
 	const resizeSmallLen = 4
 	expectedEs := make(map[*${originName}]bool, resizeSmallLen)
@@ -471,12 +470,11 @@ func Test${structName}_Resize(t *testing.T) {
 func Test${structName}_Append(t *testing.T) {
 	es := generateTest${structName}()
 
-	emptyVal := New${elementName}()
+	emptyVal := new${elementName}(&${originName}{})
 	es.Append(emptyVal)
 	assert.EqualValues(t, emptyVal, es.At(7))
 
-	value := New${elementName}()
-	fillTest${elementName}(value)
+	value := generateTest${elementName}()
 	es.Append(value)
 	assert.EqualValues(t, value, es.At(8))
 

--- a/consumer/pdata/common.go
+++ b/consumer/pdata/common.go
@@ -82,50 +82,37 @@ func newAttributeValue(orig *otlpcommon.AnyValue) AttributeValue {
 
 // NewAttributeValueNull creates a new AttributeValue with a null value.
 func NewAttributeValueNull() AttributeValue {
-	orig := &otlpcommon.AnyValue{}
-	return AttributeValue{orig: orig}
-}
-
-// NewAttributeValue is deprecated.
-// Deprecated: Use NewAttributeValueNull()
-func NewAttributeValue() AttributeValue {
-	return NewAttributeValueNull()
+	return AttributeValue{orig: &otlpcommon.AnyValue{}}
 }
 
 // NewAttributeValueString creates a new AttributeValue with the given string value.
 func NewAttributeValueString(v string) AttributeValue {
-	orig := &otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_StringValue{StringValue: v}}
-	return AttributeValue{orig: orig}
+	return AttributeValue{orig: &otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_StringValue{StringValue: v}}}
 }
 
 // NewAttributeValueInt creates a new AttributeValue with the given int64 value.
 func NewAttributeValueInt(v int64) AttributeValue {
-	orig := &otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_IntValue{IntValue: v}}
-	return AttributeValue{orig: orig}
+	return AttributeValue{orig: &otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_IntValue{IntValue: v}}}
 }
 
 // NewAttributeValueDouble creates a new AttributeValue with the given float64 value.
 func NewAttributeValueDouble(v float64) AttributeValue {
-	orig := &otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_DoubleValue{DoubleValue: v}}
-	return AttributeValue{orig: orig}
+	return AttributeValue{orig: &otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_DoubleValue{DoubleValue: v}}}
 }
 
 // NewAttributeValueBool creates a new AttributeValue with the given bool value.
 func NewAttributeValueBool(v bool) AttributeValue {
-	orig := &otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_BoolValue{BoolValue: v}}
-	return AttributeValue{orig: orig}
+	return AttributeValue{orig: &otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_BoolValue{BoolValue: v}}}
 }
 
 // NewAttributeValueMap creates a new AttributeValue of map type.
 func NewAttributeValueMap() AttributeValue {
-	orig := &otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_KvlistValue{KvlistValue: &otlpcommon.KeyValueList{}}}
-	return AttributeValue{orig: orig}
+	return AttributeValue{orig: &otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_KvlistValue{KvlistValue: &otlpcommon.KeyValueList{}}}}
 }
 
 // NewAttributeValueArray creates a new AttributeValue of array type.
 func NewAttributeValueArray() AttributeValue {
-	orig := &otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_ArrayValue{ArrayValue: &otlpcommon.ArrayValue{}}}
-	return AttributeValue{orig: orig}
+	return AttributeValue{orig: &otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_ArrayValue{ArrayValue: &otlpcommon.ArrayValue{}}}}
 }
 
 // Type returns the type of the value for this AttributeValue.

--- a/consumer/pdata/generated_common_test.go
+++ b/consumer/pdata/generated_common_test.go
@@ -54,7 +54,7 @@ func TestAnyValueArray(t *testing.T) {
 	assert.EqualValues(t, 0, es.Len())
 
 	es.Resize(7)
-	emptyVal := NewAttributeValue()
+	emptyVal := newAttributeValue(&otlpcommon.AnyValue{})
 	testVal := generateTestAttributeValue()
 	assert.EqualValues(t, 7, es.Len())
 	for i := 0; i < es.Len(); i++ {
@@ -106,7 +106,7 @@ func TestAnyValueArray_CopyTo(t *testing.T) {
 
 func TestAnyValueArray_Resize(t *testing.T) {
 	es := generateTestAnyValueArray()
-	emptyVal := NewAttributeValue()
+	emptyVal := newAttributeValue(&otlpcommon.AnyValue{})
 	// Test Resize less elements.
 	const resizeSmallLen = 4
 	expectedEs := make(map[*otlpcommon.AnyValue]bool, resizeSmallLen)
@@ -149,12 +149,11 @@ func TestAnyValueArray_Resize(t *testing.T) {
 func TestAnyValueArray_Append(t *testing.T) {
 	es := generateTestAnyValueArray()
 
-	emptyVal := NewAttributeValue()
+	emptyVal := newAttributeValue(&otlpcommon.AnyValue{})
 	es.Append(emptyVal)
 	assert.EqualValues(t, emptyVal, es.At(7))
 
-	value := NewAttributeValue()
-	fillTestAttributeValue(value)
+	value := generateTestAttributeValue()
 	es.Append(value)
 	assert.EqualValues(t, value, es.At(8))
 

--- a/consumer/pdata/generated_log_test.go
+++ b/consumer/pdata/generated_log_test.go
@@ -32,7 +32,7 @@ func TestResourceLogsSlice(t *testing.T) {
 	assert.EqualValues(t, 0, es.Len())
 
 	es.Resize(7)
-	emptyVal := NewResourceLogs()
+	emptyVal := newResourceLogs(&otlplogs.ResourceLogs{})
 	testVal := generateTestResourceLogs()
 	assert.EqualValues(t, 7, es.Len())
 	for i := 0; i < es.Len(); i++ {
@@ -84,7 +84,7 @@ func TestResourceLogsSlice_CopyTo(t *testing.T) {
 
 func TestResourceLogsSlice_Resize(t *testing.T) {
 	es := generateTestResourceLogsSlice()
-	emptyVal := NewResourceLogs()
+	emptyVal := newResourceLogs(&otlplogs.ResourceLogs{})
 	// Test Resize less elements.
 	const resizeSmallLen = 4
 	expectedEs := make(map[*otlplogs.ResourceLogs]bool, resizeSmallLen)
@@ -127,12 +127,11 @@ func TestResourceLogsSlice_Resize(t *testing.T) {
 func TestResourceLogsSlice_Append(t *testing.T) {
 	es := generateTestResourceLogsSlice()
 
-	emptyVal := NewResourceLogs()
+	emptyVal := newResourceLogs(&otlplogs.ResourceLogs{})
 	es.Append(emptyVal)
 	assert.EqualValues(t, emptyVal.orig, es.At(7).orig)
 
-	value := NewResourceLogs()
-	fillTestResourceLogs(value)
+	value := generateTestResourceLogs()
 	es.Append(value)
 	assert.EqualValues(t, value.orig, es.At(8).orig)
 
@@ -166,7 +165,7 @@ func TestInstrumentationLibraryLogsSlice(t *testing.T) {
 	assert.EqualValues(t, 0, es.Len())
 
 	es.Resize(7)
-	emptyVal := NewInstrumentationLibraryLogs()
+	emptyVal := newInstrumentationLibraryLogs(&otlplogs.InstrumentationLibraryLogs{})
 	testVal := generateTestInstrumentationLibraryLogs()
 	assert.EqualValues(t, 7, es.Len())
 	for i := 0; i < es.Len(); i++ {
@@ -218,7 +217,7 @@ func TestInstrumentationLibraryLogsSlice_CopyTo(t *testing.T) {
 
 func TestInstrumentationLibraryLogsSlice_Resize(t *testing.T) {
 	es := generateTestInstrumentationLibraryLogsSlice()
-	emptyVal := NewInstrumentationLibraryLogs()
+	emptyVal := newInstrumentationLibraryLogs(&otlplogs.InstrumentationLibraryLogs{})
 	// Test Resize less elements.
 	const resizeSmallLen = 4
 	expectedEs := make(map[*otlplogs.InstrumentationLibraryLogs]bool, resizeSmallLen)
@@ -261,12 +260,11 @@ func TestInstrumentationLibraryLogsSlice_Resize(t *testing.T) {
 func TestInstrumentationLibraryLogsSlice_Append(t *testing.T) {
 	es := generateTestInstrumentationLibraryLogsSlice()
 
-	emptyVal := NewInstrumentationLibraryLogs()
+	emptyVal := newInstrumentationLibraryLogs(&otlplogs.InstrumentationLibraryLogs{})
 	es.Append(emptyVal)
 	assert.EqualValues(t, emptyVal.orig, es.At(7).orig)
 
-	value := NewInstrumentationLibraryLogs()
-	fillTestInstrumentationLibraryLogs(value)
+	value := generateTestInstrumentationLibraryLogs()
 	es.Append(value)
 	assert.EqualValues(t, value.orig, es.At(8).orig)
 
@@ -300,7 +298,7 @@ func TestLogSlice(t *testing.T) {
 	assert.EqualValues(t, 0, es.Len())
 
 	es.Resize(7)
-	emptyVal := NewLogRecord()
+	emptyVal := newLogRecord(&otlplogs.LogRecord{})
 	testVal := generateTestLogRecord()
 	assert.EqualValues(t, 7, es.Len())
 	for i := 0; i < es.Len(); i++ {
@@ -352,7 +350,7 @@ func TestLogSlice_CopyTo(t *testing.T) {
 
 func TestLogSlice_Resize(t *testing.T) {
 	es := generateTestLogSlice()
-	emptyVal := NewLogRecord()
+	emptyVal := newLogRecord(&otlplogs.LogRecord{})
 	// Test Resize less elements.
 	const resizeSmallLen = 4
 	expectedEs := make(map[*otlplogs.LogRecord]bool, resizeSmallLen)
@@ -395,12 +393,11 @@ func TestLogSlice_Resize(t *testing.T) {
 func TestLogSlice_Append(t *testing.T) {
 	es := generateTestLogSlice()
 
-	emptyVal := NewLogRecord()
+	emptyVal := newLogRecord(&otlplogs.LogRecord{})
 	es.Append(emptyVal)
 	assert.EqualValues(t, emptyVal.orig, es.At(7).orig)
 
-	value := NewLogRecord()
-	fillTestLogRecord(value)
+	value := generateTestLogRecord()
 	es.Append(value)
 	assert.EqualValues(t, value.orig, es.At(8).orig)
 

--- a/consumer/pdata/generated_metrics_test.go
+++ b/consumer/pdata/generated_metrics_test.go
@@ -32,7 +32,7 @@ func TestResourceMetricsSlice(t *testing.T) {
 	assert.EqualValues(t, 0, es.Len())
 
 	es.Resize(7)
-	emptyVal := NewResourceMetrics()
+	emptyVal := newResourceMetrics(&otlpmetrics.ResourceMetrics{})
 	testVal := generateTestResourceMetrics()
 	assert.EqualValues(t, 7, es.Len())
 	for i := 0; i < es.Len(); i++ {
@@ -84,7 +84,7 @@ func TestResourceMetricsSlice_CopyTo(t *testing.T) {
 
 func TestResourceMetricsSlice_Resize(t *testing.T) {
 	es := generateTestResourceMetricsSlice()
-	emptyVal := NewResourceMetrics()
+	emptyVal := newResourceMetrics(&otlpmetrics.ResourceMetrics{})
 	// Test Resize less elements.
 	const resizeSmallLen = 4
 	expectedEs := make(map[*otlpmetrics.ResourceMetrics]bool, resizeSmallLen)
@@ -127,12 +127,11 @@ func TestResourceMetricsSlice_Resize(t *testing.T) {
 func TestResourceMetricsSlice_Append(t *testing.T) {
 	es := generateTestResourceMetricsSlice()
 
-	emptyVal := NewResourceMetrics()
+	emptyVal := newResourceMetrics(&otlpmetrics.ResourceMetrics{})
 	es.Append(emptyVal)
 	assert.EqualValues(t, emptyVal.orig, es.At(7).orig)
 
-	value := NewResourceMetrics()
-	fillTestResourceMetrics(value)
+	value := generateTestResourceMetrics()
 	es.Append(value)
 	assert.EqualValues(t, value.orig, es.At(8).orig)
 
@@ -166,7 +165,7 @@ func TestInstrumentationLibraryMetricsSlice(t *testing.T) {
 	assert.EqualValues(t, 0, es.Len())
 
 	es.Resize(7)
-	emptyVal := NewInstrumentationLibraryMetrics()
+	emptyVal := newInstrumentationLibraryMetrics(&otlpmetrics.InstrumentationLibraryMetrics{})
 	testVal := generateTestInstrumentationLibraryMetrics()
 	assert.EqualValues(t, 7, es.Len())
 	for i := 0; i < es.Len(); i++ {
@@ -218,7 +217,7 @@ func TestInstrumentationLibraryMetricsSlice_CopyTo(t *testing.T) {
 
 func TestInstrumentationLibraryMetricsSlice_Resize(t *testing.T) {
 	es := generateTestInstrumentationLibraryMetricsSlice()
-	emptyVal := NewInstrumentationLibraryMetrics()
+	emptyVal := newInstrumentationLibraryMetrics(&otlpmetrics.InstrumentationLibraryMetrics{})
 	// Test Resize less elements.
 	const resizeSmallLen = 4
 	expectedEs := make(map[*otlpmetrics.InstrumentationLibraryMetrics]bool, resizeSmallLen)
@@ -261,12 +260,11 @@ func TestInstrumentationLibraryMetricsSlice_Resize(t *testing.T) {
 func TestInstrumentationLibraryMetricsSlice_Append(t *testing.T) {
 	es := generateTestInstrumentationLibraryMetricsSlice()
 
-	emptyVal := NewInstrumentationLibraryMetrics()
+	emptyVal := newInstrumentationLibraryMetrics(&otlpmetrics.InstrumentationLibraryMetrics{})
 	es.Append(emptyVal)
 	assert.EqualValues(t, emptyVal.orig, es.At(7).orig)
 
-	value := NewInstrumentationLibraryMetrics()
-	fillTestInstrumentationLibraryMetrics(value)
+	value := generateTestInstrumentationLibraryMetrics()
 	es.Append(value)
 	assert.EqualValues(t, value.orig, es.At(8).orig)
 
@@ -300,7 +298,7 @@ func TestMetricSlice(t *testing.T) {
 	assert.EqualValues(t, 0, es.Len())
 
 	es.Resize(7)
-	emptyVal := NewMetric()
+	emptyVal := newMetric(&otlpmetrics.Metric{})
 	testVal := generateTestMetric()
 	assert.EqualValues(t, 7, es.Len())
 	for i := 0; i < es.Len(); i++ {
@@ -352,7 +350,7 @@ func TestMetricSlice_CopyTo(t *testing.T) {
 
 func TestMetricSlice_Resize(t *testing.T) {
 	es := generateTestMetricSlice()
-	emptyVal := NewMetric()
+	emptyVal := newMetric(&otlpmetrics.Metric{})
 	// Test Resize less elements.
 	const resizeSmallLen = 4
 	expectedEs := make(map[*otlpmetrics.Metric]bool, resizeSmallLen)
@@ -395,12 +393,11 @@ func TestMetricSlice_Resize(t *testing.T) {
 func TestMetricSlice_Append(t *testing.T) {
 	es := generateTestMetricSlice()
 
-	emptyVal := NewMetric()
+	emptyVal := newMetric(&otlpmetrics.Metric{})
 	es.Append(emptyVal)
 	assert.EqualValues(t, emptyVal.orig, es.At(7).orig)
 
-	value := NewMetric()
-	fillTestMetric(value)
+	value := generateTestMetric()
 	es.Append(value)
 	assert.EqualValues(t, value.orig, es.At(8).orig)
 
@@ -590,7 +587,7 @@ func TestIntDataPointSlice(t *testing.T) {
 	assert.EqualValues(t, 0, es.Len())
 
 	es.Resize(7)
-	emptyVal := NewIntDataPoint()
+	emptyVal := newIntDataPoint(&otlpmetrics.IntDataPoint{})
 	testVal := generateTestIntDataPoint()
 	assert.EqualValues(t, 7, es.Len())
 	for i := 0; i < es.Len(); i++ {
@@ -642,7 +639,7 @@ func TestIntDataPointSlice_CopyTo(t *testing.T) {
 
 func TestIntDataPointSlice_Resize(t *testing.T) {
 	es := generateTestIntDataPointSlice()
-	emptyVal := NewIntDataPoint()
+	emptyVal := newIntDataPoint(&otlpmetrics.IntDataPoint{})
 	// Test Resize less elements.
 	const resizeSmallLen = 4
 	expectedEs := make(map[*otlpmetrics.IntDataPoint]bool, resizeSmallLen)
@@ -685,12 +682,11 @@ func TestIntDataPointSlice_Resize(t *testing.T) {
 func TestIntDataPointSlice_Append(t *testing.T) {
 	es := generateTestIntDataPointSlice()
 
-	emptyVal := NewIntDataPoint()
+	emptyVal := newIntDataPoint(&otlpmetrics.IntDataPoint{})
 	es.Append(emptyVal)
 	assert.EqualValues(t, emptyVal.orig, es.At(7).orig)
 
-	value := NewIntDataPoint()
-	fillTestIntDataPoint(value)
+	value := generateTestIntDataPoint()
 	es.Append(value)
 	assert.EqualValues(t, value.orig, es.At(8).orig)
 
@@ -750,7 +746,7 @@ func TestDoubleDataPointSlice(t *testing.T) {
 	assert.EqualValues(t, 0, es.Len())
 
 	es.Resize(7)
-	emptyVal := NewDoubleDataPoint()
+	emptyVal := newDoubleDataPoint(&otlpmetrics.DoubleDataPoint{})
 	testVal := generateTestDoubleDataPoint()
 	assert.EqualValues(t, 7, es.Len())
 	for i := 0; i < es.Len(); i++ {
@@ -802,7 +798,7 @@ func TestDoubleDataPointSlice_CopyTo(t *testing.T) {
 
 func TestDoubleDataPointSlice_Resize(t *testing.T) {
 	es := generateTestDoubleDataPointSlice()
-	emptyVal := NewDoubleDataPoint()
+	emptyVal := newDoubleDataPoint(&otlpmetrics.DoubleDataPoint{})
 	// Test Resize less elements.
 	const resizeSmallLen = 4
 	expectedEs := make(map[*otlpmetrics.DoubleDataPoint]bool, resizeSmallLen)
@@ -845,12 +841,11 @@ func TestDoubleDataPointSlice_Resize(t *testing.T) {
 func TestDoubleDataPointSlice_Append(t *testing.T) {
 	es := generateTestDoubleDataPointSlice()
 
-	emptyVal := NewDoubleDataPoint()
+	emptyVal := newDoubleDataPoint(&otlpmetrics.DoubleDataPoint{})
 	es.Append(emptyVal)
 	assert.EqualValues(t, emptyVal.orig, es.At(7).orig)
 
-	value := NewDoubleDataPoint()
-	fillTestDoubleDataPoint(value)
+	value := generateTestDoubleDataPoint()
 	es.Append(value)
 	assert.EqualValues(t, value.orig, es.At(8).orig)
 
@@ -910,7 +905,7 @@ func TestIntHistogramDataPointSlice(t *testing.T) {
 	assert.EqualValues(t, 0, es.Len())
 
 	es.Resize(7)
-	emptyVal := NewIntHistogramDataPoint()
+	emptyVal := newIntHistogramDataPoint(&otlpmetrics.IntHistogramDataPoint{})
 	testVal := generateTestIntHistogramDataPoint()
 	assert.EqualValues(t, 7, es.Len())
 	for i := 0; i < es.Len(); i++ {
@@ -962,7 +957,7 @@ func TestIntHistogramDataPointSlice_CopyTo(t *testing.T) {
 
 func TestIntHistogramDataPointSlice_Resize(t *testing.T) {
 	es := generateTestIntHistogramDataPointSlice()
-	emptyVal := NewIntHistogramDataPoint()
+	emptyVal := newIntHistogramDataPoint(&otlpmetrics.IntHistogramDataPoint{})
 	// Test Resize less elements.
 	const resizeSmallLen = 4
 	expectedEs := make(map[*otlpmetrics.IntHistogramDataPoint]bool, resizeSmallLen)
@@ -1005,12 +1000,11 @@ func TestIntHistogramDataPointSlice_Resize(t *testing.T) {
 func TestIntHistogramDataPointSlice_Append(t *testing.T) {
 	es := generateTestIntHistogramDataPointSlice()
 
-	emptyVal := NewIntHistogramDataPoint()
+	emptyVal := newIntHistogramDataPoint(&otlpmetrics.IntHistogramDataPoint{})
 	es.Append(emptyVal)
 	assert.EqualValues(t, emptyVal.orig, es.At(7).orig)
 
-	value := NewIntHistogramDataPoint()
-	fillTestIntHistogramDataPoint(value)
+	value := generateTestIntHistogramDataPoint()
 	es.Append(value)
 	assert.EqualValues(t, value.orig, es.At(8).orig)
 
@@ -1094,7 +1088,7 @@ func TestHistogramDataPointSlice(t *testing.T) {
 	assert.EqualValues(t, 0, es.Len())
 
 	es.Resize(7)
-	emptyVal := NewHistogramDataPoint()
+	emptyVal := newHistogramDataPoint(&otlpmetrics.DoubleHistogramDataPoint{})
 	testVal := generateTestHistogramDataPoint()
 	assert.EqualValues(t, 7, es.Len())
 	for i := 0; i < es.Len(); i++ {
@@ -1146,7 +1140,7 @@ func TestHistogramDataPointSlice_CopyTo(t *testing.T) {
 
 func TestHistogramDataPointSlice_Resize(t *testing.T) {
 	es := generateTestHistogramDataPointSlice()
-	emptyVal := NewHistogramDataPoint()
+	emptyVal := newHistogramDataPoint(&otlpmetrics.DoubleHistogramDataPoint{})
 	// Test Resize less elements.
 	const resizeSmallLen = 4
 	expectedEs := make(map[*otlpmetrics.DoubleHistogramDataPoint]bool, resizeSmallLen)
@@ -1189,12 +1183,11 @@ func TestHistogramDataPointSlice_Resize(t *testing.T) {
 func TestHistogramDataPointSlice_Append(t *testing.T) {
 	es := generateTestHistogramDataPointSlice()
 
-	emptyVal := NewHistogramDataPoint()
+	emptyVal := newHistogramDataPoint(&otlpmetrics.DoubleHistogramDataPoint{})
 	es.Append(emptyVal)
 	assert.EqualValues(t, emptyVal.orig, es.At(7).orig)
 
-	value := NewHistogramDataPoint()
-	fillTestHistogramDataPoint(value)
+	value := generateTestHistogramDataPoint()
 	es.Append(value)
 	assert.EqualValues(t, value.orig, es.At(8).orig)
 
@@ -1278,7 +1271,7 @@ func TestSummaryDataPointSlice(t *testing.T) {
 	assert.EqualValues(t, 0, es.Len())
 
 	es.Resize(7)
-	emptyVal := NewSummaryDataPoint()
+	emptyVal := newSummaryDataPoint(&otlpmetrics.DoubleSummaryDataPoint{})
 	testVal := generateTestSummaryDataPoint()
 	assert.EqualValues(t, 7, es.Len())
 	for i := 0; i < es.Len(); i++ {
@@ -1330,7 +1323,7 @@ func TestSummaryDataPointSlice_CopyTo(t *testing.T) {
 
 func TestSummaryDataPointSlice_Resize(t *testing.T) {
 	es := generateTestSummaryDataPointSlice()
-	emptyVal := NewSummaryDataPoint()
+	emptyVal := newSummaryDataPoint(&otlpmetrics.DoubleSummaryDataPoint{})
 	// Test Resize less elements.
 	const resizeSmallLen = 4
 	expectedEs := make(map[*otlpmetrics.DoubleSummaryDataPoint]bool, resizeSmallLen)
@@ -1373,12 +1366,11 @@ func TestSummaryDataPointSlice_Resize(t *testing.T) {
 func TestSummaryDataPointSlice_Append(t *testing.T) {
 	es := generateTestSummaryDataPointSlice()
 
-	emptyVal := NewSummaryDataPoint()
+	emptyVal := newSummaryDataPoint(&otlpmetrics.DoubleSummaryDataPoint{})
 	es.Append(emptyVal)
 	assert.EqualValues(t, emptyVal.orig, es.At(7).orig)
 
-	value := NewSummaryDataPoint()
-	fillTestSummaryDataPoint(value)
+	value := generateTestSummaryDataPoint()
 	es.Append(value)
 	assert.EqualValues(t, value.orig, es.At(8).orig)
 
@@ -1446,7 +1438,7 @@ func TestValueAtQuantileSlice(t *testing.T) {
 	assert.EqualValues(t, 0, es.Len())
 
 	es.Resize(7)
-	emptyVal := NewValueAtQuantile()
+	emptyVal := newValueAtQuantile(&otlpmetrics.DoubleSummaryDataPoint_ValueAtQuantile{})
 	testVal := generateTestValueAtQuantile()
 	assert.EqualValues(t, 7, es.Len())
 	for i := 0; i < es.Len(); i++ {
@@ -1498,7 +1490,7 @@ func TestValueAtQuantileSlice_CopyTo(t *testing.T) {
 
 func TestValueAtQuantileSlice_Resize(t *testing.T) {
 	es := generateTestValueAtQuantileSlice()
-	emptyVal := NewValueAtQuantile()
+	emptyVal := newValueAtQuantile(&otlpmetrics.DoubleSummaryDataPoint_ValueAtQuantile{})
 	// Test Resize less elements.
 	const resizeSmallLen = 4
 	expectedEs := make(map[*otlpmetrics.DoubleSummaryDataPoint_ValueAtQuantile]bool, resizeSmallLen)
@@ -1541,12 +1533,11 @@ func TestValueAtQuantileSlice_Resize(t *testing.T) {
 func TestValueAtQuantileSlice_Append(t *testing.T) {
 	es := generateTestValueAtQuantileSlice()
 
-	emptyVal := NewValueAtQuantile()
+	emptyVal := newValueAtQuantile(&otlpmetrics.DoubleSummaryDataPoint_ValueAtQuantile{})
 	es.Append(emptyVal)
 	assert.EqualValues(t, emptyVal.orig, es.At(7).orig)
 
-	value := NewValueAtQuantile()
-	fillTestValueAtQuantile(value)
+	value := generateTestValueAtQuantile()
 	es.Append(value)
 	assert.EqualValues(t, value.orig, es.At(8).orig)
 
@@ -1582,7 +1573,7 @@ func TestIntExemplarSlice(t *testing.T) {
 	assert.EqualValues(t, 0, es.Len())
 
 	es.Resize(7)
-	emptyVal := NewIntExemplar()
+	emptyVal := newIntExemplar(&otlpmetrics.IntExemplar{})
 	testVal := generateTestIntExemplar()
 	assert.EqualValues(t, 7, es.Len())
 	for i := 0; i < es.Len(); i++ {
@@ -1634,7 +1625,7 @@ func TestIntExemplarSlice_CopyTo(t *testing.T) {
 
 func TestIntExemplarSlice_Resize(t *testing.T) {
 	es := generateTestIntExemplarSlice()
-	emptyVal := NewIntExemplar()
+	emptyVal := newIntExemplar(&otlpmetrics.IntExemplar{})
 	// Test Resize less elements.
 	const resizeSmallLen = 4
 	expectedEs := make(map[*otlpmetrics.IntExemplar]bool, resizeSmallLen)
@@ -1677,12 +1668,11 @@ func TestIntExemplarSlice_Resize(t *testing.T) {
 func TestIntExemplarSlice_Append(t *testing.T) {
 	es := generateTestIntExemplarSlice()
 
-	emptyVal := NewIntExemplar()
+	emptyVal := newIntExemplar(&otlpmetrics.IntExemplar{})
 	es.Append(emptyVal)
 	assert.EqualValues(t, emptyVal, es.At(7))
 
-	value := NewIntExemplar()
-	fillTestIntExemplar(value)
+	value := generateTestIntExemplar()
 	es.Append(value)
 	assert.EqualValues(t, value, es.At(8))
 
@@ -1726,7 +1716,7 @@ func TestExemplarSlice(t *testing.T) {
 	assert.EqualValues(t, 0, es.Len())
 
 	es.Resize(7)
-	emptyVal := NewExemplar()
+	emptyVal := newExemplar(&otlpmetrics.DoubleExemplar{})
 	testVal := generateTestExemplar()
 	assert.EqualValues(t, 7, es.Len())
 	for i := 0; i < es.Len(); i++ {
@@ -1778,7 +1768,7 @@ func TestExemplarSlice_CopyTo(t *testing.T) {
 
 func TestExemplarSlice_Resize(t *testing.T) {
 	es := generateTestExemplarSlice()
-	emptyVal := NewExemplar()
+	emptyVal := newExemplar(&otlpmetrics.DoubleExemplar{})
 	// Test Resize less elements.
 	const resizeSmallLen = 4
 	expectedEs := make(map[*otlpmetrics.DoubleExemplar]bool, resizeSmallLen)
@@ -1821,12 +1811,11 @@ func TestExemplarSlice_Resize(t *testing.T) {
 func TestExemplarSlice_Append(t *testing.T) {
 	es := generateTestExemplarSlice()
 
-	emptyVal := NewExemplar()
+	emptyVal := newExemplar(&otlpmetrics.DoubleExemplar{})
 	es.Append(emptyVal)
 	assert.EqualValues(t, emptyVal, es.At(7))
 
-	value := NewExemplar()
-	fillTestExemplar(value)
+	value := generateTestExemplar()
 	es.Append(value)
 	assert.EqualValues(t, value, es.At(8))
 

--- a/consumer/pdata/generated_trace_test.go
+++ b/consumer/pdata/generated_trace_test.go
@@ -32,7 +32,7 @@ func TestResourceSpansSlice(t *testing.T) {
 	assert.EqualValues(t, 0, es.Len())
 
 	es.Resize(7)
-	emptyVal := NewResourceSpans()
+	emptyVal := newResourceSpans(&otlptrace.ResourceSpans{})
 	testVal := generateTestResourceSpans()
 	assert.EqualValues(t, 7, es.Len())
 	for i := 0; i < es.Len(); i++ {
@@ -84,7 +84,7 @@ func TestResourceSpansSlice_CopyTo(t *testing.T) {
 
 func TestResourceSpansSlice_Resize(t *testing.T) {
 	es := generateTestResourceSpansSlice()
-	emptyVal := NewResourceSpans()
+	emptyVal := newResourceSpans(&otlptrace.ResourceSpans{})
 	// Test Resize less elements.
 	const resizeSmallLen = 4
 	expectedEs := make(map[*otlptrace.ResourceSpans]bool, resizeSmallLen)
@@ -127,12 +127,11 @@ func TestResourceSpansSlice_Resize(t *testing.T) {
 func TestResourceSpansSlice_Append(t *testing.T) {
 	es := generateTestResourceSpansSlice()
 
-	emptyVal := NewResourceSpans()
+	emptyVal := newResourceSpans(&otlptrace.ResourceSpans{})
 	es.Append(emptyVal)
 	assert.EqualValues(t, emptyVal.orig, es.At(7).orig)
 
-	value := NewResourceSpans()
-	fillTestResourceSpans(value)
+	value := generateTestResourceSpans()
 	es.Append(value)
 	assert.EqualValues(t, value.orig, es.At(8).orig)
 
@@ -166,7 +165,7 @@ func TestInstrumentationLibrarySpansSlice(t *testing.T) {
 	assert.EqualValues(t, 0, es.Len())
 
 	es.Resize(7)
-	emptyVal := NewInstrumentationLibrarySpans()
+	emptyVal := newInstrumentationLibrarySpans(&otlptrace.InstrumentationLibrarySpans{})
 	testVal := generateTestInstrumentationLibrarySpans()
 	assert.EqualValues(t, 7, es.Len())
 	for i := 0; i < es.Len(); i++ {
@@ -218,7 +217,7 @@ func TestInstrumentationLibrarySpansSlice_CopyTo(t *testing.T) {
 
 func TestInstrumentationLibrarySpansSlice_Resize(t *testing.T) {
 	es := generateTestInstrumentationLibrarySpansSlice()
-	emptyVal := NewInstrumentationLibrarySpans()
+	emptyVal := newInstrumentationLibrarySpans(&otlptrace.InstrumentationLibrarySpans{})
 	// Test Resize less elements.
 	const resizeSmallLen = 4
 	expectedEs := make(map[*otlptrace.InstrumentationLibrarySpans]bool, resizeSmallLen)
@@ -261,12 +260,11 @@ func TestInstrumentationLibrarySpansSlice_Resize(t *testing.T) {
 func TestInstrumentationLibrarySpansSlice_Append(t *testing.T) {
 	es := generateTestInstrumentationLibrarySpansSlice()
 
-	emptyVal := NewInstrumentationLibrarySpans()
+	emptyVal := newInstrumentationLibrarySpans(&otlptrace.InstrumentationLibrarySpans{})
 	es.Append(emptyVal)
 	assert.EqualValues(t, emptyVal.orig, es.At(7).orig)
 
-	value := NewInstrumentationLibrarySpans()
-	fillTestInstrumentationLibrarySpans(value)
+	value := generateTestInstrumentationLibrarySpans()
 	es.Append(value)
 	assert.EqualValues(t, value.orig, es.At(8).orig)
 
@@ -300,7 +298,7 @@ func TestSpanSlice(t *testing.T) {
 	assert.EqualValues(t, 0, es.Len())
 
 	es.Resize(7)
-	emptyVal := NewSpan()
+	emptyVal := newSpan(&otlptrace.Span{})
 	testVal := generateTestSpan()
 	assert.EqualValues(t, 7, es.Len())
 	for i := 0; i < es.Len(); i++ {
@@ -352,7 +350,7 @@ func TestSpanSlice_CopyTo(t *testing.T) {
 
 func TestSpanSlice_Resize(t *testing.T) {
 	es := generateTestSpanSlice()
-	emptyVal := NewSpan()
+	emptyVal := newSpan(&otlptrace.Span{})
 	// Test Resize less elements.
 	const resizeSmallLen = 4
 	expectedEs := make(map[*otlptrace.Span]bool, resizeSmallLen)
@@ -395,12 +393,11 @@ func TestSpanSlice_Resize(t *testing.T) {
 func TestSpanSlice_Append(t *testing.T) {
 	es := generateTestSpanSlice()
 
-	emptyVal := NewSpan()
+	emptyVal := newSpan(&otlptrace.Span{})
 	es.Append(emptyVal)
 	assert.EqualValues(t, emptyVal.orig, es.At(7).orig)
 
-	value := NewSpan()
-	fillTestSpan(value)
+	value := generateTestSpan()
 	es.Append(value)
 	assert.EqualValues(t, value.orig, es.At(8).orig)
 
@@ -538,7 +535,7 @@ func TestSpanEventSlice(t *testing.T) {
 	assert.EqualValues(t, 0, es.Len())
 
 	es.Resize(7)
-	emptyVal := NewSpanEvent()
+	emptyVal := newSpanEvent(&otlptrace.Span_Event{})
 	testVal := generateTestSpanEvent()
 	assert.EqualValues(t, 7, es.Len())
 	for i := 0; i < es.Len(); i++ {
@@ -590,7 +587,7 @@ func TestSpanEventSlice_CopyTo(t *testing.T) {
 
 func TestSpanEventSlice_Resize(t *testing.T) {
 	es := generateTestSpanEventSlice()
-	emptyVal := NewSpanEvent()
+	emptyVal := newSpanEvent(&otlptrace.Span_Event{})
 	// Test Resize less elements.
 	const resizeSmallLen = 4
 	expectedEs := make(map[*otlptrace.Span_Event]bool, resizeSmallLen)
@@ -633,12 +630,11 @@ func TestSpanEventSlice_Resize(t *testing.T) {
 func TestSpanEventSlice_Append(t *testing.T) {
 	es := generateTestSpanEventSlice()
 
-	emptyVal := NewSpanEvent()
+	emptyVal := newSpanEvent(&otlptrace.Span_Event{})
 	es.Append(emptyVal)
 	assert.EqualValues(t, emptyVal.orig, es.At(7).orig)
 
-	value := NewSpanEvent()
-	fillTestSpanEvent(value)
+	value := generateTestSpanEvent()
 	es.Append(value)
 	assert.EqualValues(t, value.orig, es.At(8).orig)
 
@@ -690,7 +686,7 @@ func TestSpanLinkSlice(t *testing.T) {
 	assert.EqualValues(t, 0, es.Len())
 
 	es.Resize(7)
-	emptyVal := NewSpanLink()
+	emptyVal := newSpanLink(&otlptrace.Span_Link{})
 	testVal := generateTestSpanLink()
 	assert.EqualValues(t, 7, es.Len())
 	for i := 0; i < es.Len(); i++ {
@@ -742,7 +738,7 @@ func TestSpanLinkSlice_CopyTo(t *testing.T) {
 
 func TestSpanLinkSlice_Resize(t *testing.T) {
 	es := generateTestSpanLinkSlice()
-	emptyVal := NewSpanLink()
+	emptyVal := newSpanLink(&otlptrace.Span_Link{})
 	// Test Resize less elements.
 	const resizeSmallLen = 4
 	expectedEs := make(map[*otlptrace.Span_Link]bool, resizeSmallLen)
@@ -785,12 +781,11 @@ func TestSpanLinkSlice_Resize(t *testing.T) {
 func TestSpanLinkSlice_Append(t *testing.T) {
 	es := generateTestSpanLinkSlice()
 
-	emptyVal := NewSpanLink()
+	emptyVal := newSpanLink(&otlptrace.Span_Link{})
 	es.Append(emptyVal)
 	assert.EqualValues(t, emptyVal.orig, es.At(7).orig)
 
-	value := NewSpanLink()
-	fillTestSpanLink(value)
+	value := generateTestSpanLink()
 	es.Append(value)
 	assert.EqualValues(t, value.orig, es.At(8).orig)
 


### PR DESCRIPTION
Updates https://github.com/open-telemetry/opentelemetry-collector/issues/2488

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
