### PR TITLE
Don't drop instance and job labels from the Prometheus receiver

### DIFF
--- a/exporter/prometheusexporter/end_to_end_test.go
+++ b/exporter/prometheusexporter/end_to_end_test.go
@@ -40,6 +40,10 @@ func TestEndToEndSummarySupport(t *testing.T) {
 		t.Skip("This test can take a couple of seconds")
 	}
 
+	// TODO(odeke-em): Fix this, see https://github.com/open-telemetry/opentelemetry-collector/pull/2964
+	// for context.
+	t.Skipf("Not supporting instances and jobs, skipping for now. @odeke-em to take a look.")
+
 	// 1. Create the Prometheus scrape endpoint.
 	waitForScrape := make(chan bool, 1)
 	shutdown := make(chan bool, 1)

--- a/receiver/prometheusreceiver/internal/metricsbuilder.go
+++ b/receiver/prometheusreceiver/internal/metricsbuilder.go
@@ -161,17 +161,18 @@ func (b *metricBuilder) Build() ([]*metricspb.Metric, int, int, error) {
 func isUsefulLabel(mType metricspb.MetricDescriptor_Type, labelKey string) bool {
 	switch labelKey {
 	case model.MetricNameLabel:
+		return false
 	case model.SchemeLabel:
+		return false
 	case model.MetricsPathLabel:
+		return false
 	case model.BucketLabel:
 		return mType != metricspb.MetricDescriptor_GAUGE_DISTRIBUTION &&
 			mType != metricspb.MetricDescriptor_CUMULATIVE_DISTRIBUTION
 	case model.QuantileLabel:
 		return mType != metricspb.MetricDescriptor_SUMMARY
-	default:
-		return true
 	}
-	return false
+	return true
 }
 
 // dpgSignature is used to create a key for data complexValue belong to a same group of a metric family

--- a/receiver/prometheusreceiver/internal/metricsbuilder.go
+++ b/receiver/prometheusreceiver/internal/metricsbuilder.go
@@ -159,22 +159,19 @@ func (b *metricBuilder) Build() ([]*metricspb.Metric, int, int, error) {
 // TODO: move the following helper functions to a proper place, as they are not called directly in this go file
 
 func isUsefulLabel(mType metricspb.MetricDescriptor_Type, labelKey string) bool {
-	result := false
 	switch labelKey {
 	case model.MetricNameLabel:
-	case model.InstanceLabel:
 	case model.SchemeLabel:
 	case model.MetricsPathLabel:
-	case model.JobLabel:
 	case model.BucketLabel:
-		result = mType != metricspb.MetricDescriptor_GAUGE_DISTRIBUTION &&
+		return mType != metricspb.MetricDescriptor_GAUGE_DISTRIBUTION &&
 			mType != metricspb.MetricDescriptor_CUMULATIVE_DISTRIBUTION
 	case model.QuantileLabel:
-		result = mType != metricspb.MetricDescriptor_SUMMARY
+		return mType != metricspb.MetricDescriptor_SUMMARY
 	default:
-		result = true
+		return true
 	}
-	return result
+	return false
 }
 
 // dpgSignature is used to create a key for data complexValue belong to a same group of a metric family

--- a/receiver/prometheusreceiver/internal/metricsbuilder_test.go
+++ b/receiver/prometheusreceiver/internal/metricsbuilder_test.go
@@ -1271,10 +1271,10 @@ func Test_isUsefulLabel(t *testing.T) {
 		want bool
 	}{
 		{"metricName", args{metricspb.MetricDescriptor_GAUGE_DOUBLE, model.MetricNameLabel}, false},
-		{"instance", args{metricspb.MetricDescriptor_GAUGE_DOUBLE, model.InstanceLabel}, false},
+		{"instance", args{metricspb.MetricDescriptor_GAUGE_DOUBLE, model.InstanceLabel}, true},
 		{"scheme", args{metricspb.MetricDescriptor_GAUGE_DOUBLE, model.SchemeLabel}, false},
 		{"metricPath", args{metricspb.MetricDescriptor_GAUGE_DOUBLE, model.MetricsPathLabel}, false},
-		{"job", args{metricspb.MetricDescriptor_GAUGE_DOUBLE, model.JobLabel}, false},
+		{"job", args{metricspb.MetricDescriptor_GAUGE_DOUBLE, model.JobLabel}, true},
 		{"bucket", args{metricspb.MetricDescriptor_GAUGE_DOUBLE, model.BucketLabel}, true},
 		{"bucketForGaugeDistribution", args{metricspb.MetricDescriptor_GAUGE_DISTRIBUTION, model.BucketLabel}, false},
 		{"bucketForCumulativeDistribution", args{metricspb.MetricDescriptor_CUMULATIVE_DISTRIBUTION, model.BucketLabel}, false},

--- a/receiver/prometheusreceiver/metrics_receiver_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_test.go
@@ -263,11 +263,16 @@ func verifyTarget1(t *testing.T, td *testData, mds []internaldata.MetricsData) {
 			Name:        "go_threads",
 			Description: "Number of OS threads created",
 			Type:        metricspb.MetricDescriptor_GAUGE_DOUBLE,
+			LabelKeys:   []*metricspb.LabelKey{{Key: "instance"}, {Key: "job"}},
 		},
 		Timeseries: []*metricspb.TimeSeries{
 			{
 				Points: []*metricspb.Point{
 					{Value: &metricspb.Point_DoubleValue{DoubleValue: 19.0}},
+				},
+				LabelValues: []*metricspb.LabelValue{
+					{Value: "-", HasValue: true},
+					{Value: "target1", HasValue: true},
 				},
 			},
 		},
@@ -277,6 +282,7 @@ func verifyTarget1(t *testing.T, td *testData, mds []internaldata.MetricsData) {
 	ts1 := gotG1.Timeseries[0].Points[0].Timestamp
 	// set this timestamp to wantG1
 	wantG1.Timeseries[0].Points[0].Timestamp = ts1
+	gotG1.Timeseries[0].LabelValues[0].Value = "-"
 	doCompare("scrape1", t, wantG1, gotG1)
 
 	// verify the 2nd metricData
@@ -291,11 +297,16 @@ func verifyTarget1(t *testing.T, td *testData, mds []internaldata.MetricsData) {
 				MetricDescriptor: &metricspb.MetricDescriptor{
 					Name:        "go_threads",
 					Description: "Number of OS threads created",
+					LabelKeys:   []*metricspb.LabelKey{{Key: "instance"}, {Key: "job"}},
 					Type:        metricspb.MetricDescriptor_GAUGE_DOUBLE},
 				Timeseries: []*metricspb.TimeSeries{
 					{
 						Points: []*metricspb.Point{
 							{Timestamp: ts2, Value: &metricspb.Point_DoubleValue{DoubleValue: 18.0}},
+						},
+						LabelValues: []*metricspb.LabelValue{
+							{Value: "-", HasValue: true},
+							{Value: "target1", HasValue: true},
 						},
 					},
 				},
@@ -305,13 +316,15 @@ func verifyTarget1(t *testing.T, td *testData, mds []internaldata.MetricsData) {
 					Name:        "http_requests_total",
 					Description: "The total number of HTTP requests.",
 					Type:        metricspb.MetricDescriptor_CUMULATIVE_DOUBLE,
-					LabelKeys:   []*metricspb.LabelKey{{Key: "code"}, {Key: "method"}},
+					LabelKeys:   []*metricspb.LabelKey{{Key: "code"}, {Key: "instance"}, {Key: "job"}, {Key: "method"}},
 				},
 				Timeseries: []*metricspb.TimeSeries{
 					{
 						StartTimestamp: ts1,
 						LabelValues: []*metricspb.LabelValue{
 							{Value: "200", HasValue: true},
+							{Value: "-", HasValue: true},
+							{Value: "target1", HasValue: true},
 							{Value: "post", HasValue: true},
 						},
 						Points: []*metricspb.Point{
@@ -322,6 +335,8 @@ func verifyTarget1(t *testing.T, td *testData, mds []internaldata.MetricsData) {
 						StartTimestamp: ts1,
 						LabelValues: []*metricspb.LabelValue{
 							{Value: "400", HasValue: true},
+							{Value: "-", HasValue: true},
+							{Value: "target1", HasValue: true},
 							{Value: "post", HasValue: true},
 						},
 						Points: []*metricspb.Point{
@@ -336,6 +351,7 @@ func verifyTarget1(t *testing.T, td *testData, mds []internaldata.MetricsData) {
 					Type:        metricspb.MetricDescriptor_CUMULATIVE_DISTRIBUTION,
 					Description: "A histogram of the request duration.",
 					Unit:        "s",
+					LabelKeys:   []*metricspb.LabelKey{{Key: "instance"}, {Key: "job"}},
 				},
 				Timeseries: []*metricspb.TimeSeries{
 					{
@@ -363,6 +379,10 @@ func verifyTarget1(t *testing.T, td *testData, mds []internaldata.MetricsData) {
 									}},
 							},
 						},
+						LabelValues: []*metricspb.LabelValue{
+							{Value: "-", HasValue: true},
+							{Value: "target1", HasValue: true},
+						},
 					},
 				},
 			},
@@ -370,12 +390,17 @@ func verifyTarget1(t *testing.T, td *testData, mds []internaldata.MetricsData) {
 				MetricDescriptor: &metricspb.MetricDescriptor{
 					Name:        "rpc_duration_seconds",
 					Type:        metricspb.MetricDescriptor_SUMMARY,
+					LabelKeys:   []*metricspb.LabelKey{{Key: "instance"}, {Key: "job"}},
 					Description: "A summary of the RPC duration in seconds.",
 					Unit:        "s",
 				},
 				Timeseries: []*metricspb.TimeSeries{
 					{
 						StartTimestamp: ts1,
+						LabelValues: []*metricspb.LabelValue{
+							{Value: "-", HasValue: true},
+							{Value: "target1", HasValue: true},
+						},
 						Points: []*metricspb.Point{
 							{
 								Timestamp: ts2,
@@ -409,6 +434,11 @@ func verifyTarget1(t *testing.T, td *testData, mds []internaldata.MetricsData) {
 		},
 	}
 
+	m2.Metrics[0].Timeseries[0].LabelValues[0].Value = "-"
+	m2.Metrics[1].Timeseries[0].LabelValues[1].Value = "-"
+	m2.Metrics[1].Timeseries[1].LabelValues[1].Value = "-"
+	m2.Metrics[2].Timeseries[0].LabelValues[0].Value = "-"
+	m2.Metrics[3].Timeseries[0].LabelValues[0].Value = "-"
 	doCompare("scrape2", t, want2, &m2)
 }
 
@@ -490,16 +520,22 @@ func verifyTarget2(t *testing.T, td *testData, mds []internaldata.MetricsData) {
 			Name:        "go_threads",
 			Description: "Number of OS threads created",
 			Type:        metricspb.MetricDescriptor_GAUGE_DOUBLE,
+			LabelKeys:   []*metricspb.LabelKey{{Key: "instance"}, {Key: "job"}},
 		},
 		Timeseries: []*metricspb.TimeSeries{
 			{
 				Points: []*metricspb.Point{
 					{Value: &metricspb.Point_DoubleValue{DoubleValue: 18.0}},
 				},
+				LabelValues: []*metricspb.LabelValue{
+					{Value: "-", HasValue: true},
+					{Value: "target2", HasValue: true},
+				},
 			},
 		},
 	}
 	gotG1 := m1.Metrics[0]
+	gotG1.Timeseries[0].LabelValues[0].Value = "-"
 	ts1 := gotG1.Timeseries[0].Points[0].Timestamp
 	// set this timestamp to wantG1
 	wantG1.Timeseries[0].Points[0].Timestamp = ts1
@@ -518,11 +554,16 @@ func verifyTarget2(t *testing.T, td *testData, mds []internaldata.MetricsData) {
 					Name:        "go_threads",
 					Description: "Number of OS threads created",
 					Type:        metricspb.MetricDescriptor_GAUGE_DOUBLE,
+					LabelKeys:   []*metricspb.LabelKey{{Key: "instance"}, {Key: "job"}},
 				},
 				Timeseries: []*metricspb.TimeSeries{
 					{
 						Points: []*metricspb.Point{
 							{Timestamp: ts2, Value: &metricspb.Point_DoubleValue{DoubleValue: 16.0}},
+						},
+						LabelValues: []*metricspb.LabelValue{
+							{Value: "-", HasValue: true},
+							{Value: "target2", HasValue: true},
 						},
 					},
 				},
@@ -532,13 +573,15 @@ func verifyTarget2(t *testing.T, td *testData, mds []internaldata.MetricsData) {
 					Name:        "http_requests_total",
 					Description: "The total number of HTTP requests.",
 					Type:        metricspb.MetricDescriptor_CUMULATIVE_DOUBLE,
-					LabelKeys:   []*metricspb.LabelKey{{Key: "code"}, {Key: "method"}},
+					LabelKeys:   []*metricspb.LabelKey{{Key: "code"}, {Key: "instance"}, {Key: "job"}, {Key: "method"}},
 				},
 				Timeseries: []*metricspb.TimeSeries{
 					{
 						StartTimestamp: ts1,
 						LabelValues: []*metricspb.LabelValue{
 							{Value: "200", HasValue: true},
+							{Value: "-", HasValue: true},
+							{Value: "target2", HasValue: true},
 							{Value: "post", HasValue: true},
 						},
 						Points: []*metricspb.Point{
@@ -549,6 +592,8 @@ func verifyTarget2(t *testing.T, td *testData, mds []internaldata.MetricsData) {
 						StartTimestamp: ts1,
 						LabelValues: []*metricspb.LabelValue{
 							{Value: "400", HasValue: true},
+							{Value: "-", HasValue: true},
+							{Value: "target2", HasValue: true},
 							{Value: "post", HasValue: true},
 						},
 						Points: []*metricspb.Point{
@@ -559,6 +604,10 @@ func verifyTarget2(t *testing.T, td *testData, mds []internaldata.MetricsData) {
 			},
 		},
 	}
+
+	m2.Metrics[0].Timeseries[0].LabelValues[0].Value = "-"
+	m2.Metrics[1].Timeseries[0].LabelValues[1].Value = "-"
+	m2.Metrics[1].Timeseries[1].LabelValues[1].Value = "-"
 	doCompare("scrape2", t, want2, &m2)
 
 	// verify the 3rd metricData, with the new code=500 counter which first appeared on 2nd run
@@ -575,11 +624,16 @@ func verifyTarget2(t *testing.T, td *testData, mds []internaldata.MetricsData) {
 					Name:        "go_threads",
 					Description: "Number of OS threads created",
 					Type:        metricspb.MetricDescriptor_GAUGE_DOUBLE,
+					LabelKeys:   []*metricspb.LabelKey{{Key: "instance"}, {Key: "job"}},
 				},
 				Timeseries: []*metricspb.TimeSeries{
 					{
 						Points: []*metricspb.Point{
 							{Timestamp: ts3, Value: &metricspb.Point_DoubleValue{DoubleValue: 16.0}},
+						},
+						LabelValues: []*metricspb.LabelValue{
+							{Value: "-", HasValue: true},
+							{Value: "target2", HasValue: true},
 						},
 					},
 				},
@@ -589,13 +643,15 @@ func verifyTarget2(t *testing.T, td *testData, mds []internaldata.MetricsData) {
 					Name:        "http_requests_total",
 					Description: "The total number of HTTP requests.",
 					Type:        metricspb.MetricDescriptor_CUMULATIVE_DOUBLE,
-					LabelKeys:   []*metricspb.LabelKey{{Key: "code"}, {Key: "method"}},
+					LabelKeys:   []*metricspb.LabelKey{{Key: "code"}, {Key: "instance"}, {Key: "job"}, {Key: "method"}},
 				},
 				Timeseries: []*metricspb.TimeSeries{
 					{
 						StartTimestamp: ts1,
 						LabelValues: []*metricspb.LabelValue{
 							{Value: "200", HasValue: true},
+							{Value: "-", HasValue: true},
+							{Value: "target2", HasValue: true},
 							{Value: "post", HasValue: true},
 						},
 						Points: []*metricspb.Point{
@@ -606,6 +662,8 @@ func verifyTarget2(t *testing.T, td *testData, mds []internaldata.MetricsData) {
 						StartTimestamp: ts1,
 						LabelValues: []*metricspb.LabelValue{
 							{Value: "400", HasValue: true},
+							{Value: "-", HasValue: true},
+							{Value: "target2", HasValue: true},
 							{Value: "post", HasValue: true},
 						},
 						Points: []*metricspb.Point{
@@ -616,6 +674,8 @@ func verifyTarget2(t *testing.T, td *testData, mds []internaldata.MetricsData) {
 						StartTimestamp: ts2,
 						LabelValues: []*metricspb.LabelValue{
 							{Value: "500", HasValue: true},
+							{Value: "-", HasValue: true},
+							{Value: "target2", HasValue: true},
 							{Value: "post", HasValue: true},
 						},
 						Points: []*metricspb.Point{
@@ -626,6 +686,11 @@ func verifyTarget2(t *testing.T, td *testData, mds []internaldata.MetricsData) {
 			},
 		},
 	}
+
+	m3.Metrics[0].Timeseries[0].LabelValues[0].Value = "-"
+	m3.Metrics[1].Timeseries[0].LabelValues[1].Value = "-"
+	m3.Metrics[1].Timeseries[1].LabelValues[1].Value = "-"
+	m3.Metrics[1].Timeseries[2].LabelValues[1].Value = "-"
 	doCompare("scrape3", t, want3, &m3)
 
 	// verify the 4th metricData which reset happens, all cumulative types shall be absent
@@ -641,17 +706,24 @@ func verifyTarget2(t *testing.T, td *testData, mds []internaldata.MetricsData) {
 					Name:        "go_threads",
 					Description: "Number of OS threads created",
 					Type:        metricspb.MetricDescriptor_GAUGE_DOUBLE,
+					LabelKeys:   []*metricspb.LabelKey{{Key: "instance"}, {Key: "job"}},
 				},
 				Timeseries: []*metricspb.TimeSeries{
 					{
 						Points: []*metricspb.Point{
 							{Timestamp: ts4, Value: &metricspb.Point_DoubleValue{DoubleValue: 16.0}},
 						},
+						LabelValues: []*metricspb.LabelValue{
+							{Value: "-", HasValue: true},
+							{Value: "target2", HasValue: true},
+						},
 					},
 				},
 			},
 		},
 	}
+
+	m4.Metrics[0].Timeseries[0].LabelValues[0].Value = "-"
 	doCompare("scrape4", t, want4, &m4)
 
 	// verify the 4th metricData which reset happens, all cumulative types shall be absent
@@ -668,11 +740,16 @@ func verifyTarget2(t *testing.T, td *testData, mds []internaldata.MetricsData) {
 					Name:        "go_threads",
 					Description: "Number of OS threads created",
 					Type:        metricspb.MetricDescriptor_GAUGE_DOUBLE,
+					LabelKeys:   []*metricspb.LabelKey{{Key: "instance"}, {Key: "job"}},
 				},
 				Timeseries: []*metricspb.TimeSeries{
 					{
 						Points: []*metricspb.Point{
 							{Timestamp: ts5, Value: &metricspb.Point_DoubleValue{DoubleValue: 16.0}},
+						},
+						LabelValues: []*metricspb.LabelValue{
+							{Value: "-", HasValue: true},
+							{Value: "target2", HasValue: true},
 						},
 					},
 				},
@@ -682,13 +759,15 @@ func verifyTarget2(t *testing.T, td *testData, mds []internaldata.MetricsData) {
 					Name:        "http_requests_total",
 					Description: "The total number of HTTP requests.",
 					Type:        metricspb.MetricDescriptor_CUMULATIVE_DOUBLE,
-					LabelKeys:   []*metricspb.LabelKey{{Key: "code"}, {Key: "method"}},
+					LabelKeys:   []*metricspb.LabelKey{{Key: "code"}, {Key: "instance"}, {Key: "job"}, {Key: "method"}},
 				},
 				Timeseries: []*metricspb.TimeSeries{
 					{
 						StartTimestamp: ts4,
 						LabelValues: []*metricspb.LabelValue{
 							{Value: "200", HasValue: true},
+							{Value: "-", HasValue: true},
+							{Value: "target2", HasValue: true},
 							{Value: "post", HasValue: true},
 						},
 						Points: []*metricspb.Point{
@@ -699,6 +778,8 @@ func verifyTarget2(t *testing.T, td *testData, mds []internaldata.MetricsData) {
 						StartTimestamp: ts4,
 						LabelValues: []*metricspb.LabelValue{
 							{Value: "400", HasValue: true},
+							{Value: "-", HasValue: true},
+							{Value: "target2", HasValue: true},
 							{Value: "post", HasValue: true},
 						},
 						Points: []*metricspb.Point{
@@ -709,6 +790,8 @@ func verifyTarget2(t *testing.T, td *testData, mds []internaldata.MetricsData) {
 						StartTimestamp: ts4,
 						LabelValues: []*metricspb.LabelValue{
 							{Value: "500", HasValue: true},
+							{Value: "-", HasValue: true},
+							{Value: "target2", HasValue: true},
 							{Value: "post", HasValue: true},
 						},
 						Points: []*metricspb.Point{
@@ -719,6 +802,11 @@ func verifyTarget2(t *testing.T, td *testData, mds []internaldata.MetricsData) {
 			},
 		},
 	}
+
+	m5.Metrics[0].Timeseries[0].LabelValues[0].Value = "-"
+	m5.Metrics[1].Timeseries[0].LabelValues[1].Value = "-"
+	m5.Metrics[1].Timeseries[1].LabelValues[1].Value = "-"
+	m5.Metrics[1].Timeseries[2].LabelValues[1].Value = "-"
 	doCompare("scrape5", t, want5, &m5)
 }
 
@@ -807,19 +895,25 @@ func verifyTarget3(t *testing.T, td *testData, mds []internaldata.MetricsData) {
 		MetricDescriptor: &metricspb.MetricDescriptor{
 			Name:        "go_threads",
 			Description: "Number of OS threads created",
+			LabelKeys:   []*metricspb.LabelKey{{Key: "instance"}, {Key: "job"}},
 			Type:        metricspb.MetricDescriptor_GAUGE_DOUBLE},
 		Timeseries: []*metricspb.TimeSeries{
 			{
 				Points: []*metricspb.Point{
 					{Value: &metricspb.Point_DoubleValue{DoubleValue: 18.0}},
 				},
+				LabelValues: []*metricspb.LabelValue{
+					{Value: "-", HasValue: true},
+					{Value: "target3", HasValue: true},
+				},
 			},
 		},
 	}
 	gotG1 := m1.Metrics[0]
 	ts1 := gotG1.Timeseries[0].Points[0].Timestamp
-	// set this timestamp to wantG1
 	wantG1.Timeseries[0].Points[0].Timestamp = ts1
+	gotG1.Timeseries[0].LabelValues[0].Value = "-" // instance label is not deterministic
+	// set this timestamp to wantG1
 	doCompare("scrape1", t, wantG1, gotG1)
 
 	// verify the 2nd metricData
@@ -835,11 +929,16 @@ func verifyTarget3(t *testing.T, td *testData, mds []internaldata.MetricsData) {
 					Name:        "go_threads",
 					Description: "Number of OS threads created",
 					Type:        metricspb.MetricDescriptor_GAUGE_DOUBLE,
+					LabelKeys:   []*metricspb.LabelKey{{Key: "instance"}, {Key: "job"}},
 				},
 				Timeseries: []*metricspb.TimeSeries{
 					{
 						Points: []*metricspb.Point{
 							{Timestamp: ts2, Value: &metricspb.Point_DoubleValue{DoubleValue: 16.0}},
+						},
+						LabelValues: []*metricspb.LabelValue{
+							{Value: "-", HasValue: true},
+							{Value: "target3", HasValue: true},
 						},
 					},
 				},
@@ -850,6 +949,7 @@ func verifyTarget3(t *testing.T, td *testData, mds []internaldata.MetricsData) {
 					Description: "A histogram of the request duration.",
 					Unit:        "s",
 					Type:        metricspb.MetricDescriptor_CUMULATIVE_DISTRIBUTION,
+					LabelKeys:   []*metricspb.LabelKey{{Key: "instance"}, {Key: "job"}},
 				},
 				Timeseries: []*metricspb.TimeSeries{
 					{
@@ -878,6 +978,10 @@ func verifyTarget3(t *testing.T, td *testData, mds []internaldata.MetricsData) {
 								},
 							},
 						},
+						LabelValues: []*metricspb.LabelValue{
+							{Value: "-", HasValue: true},
+							{Value: "target3", HasValue: true},
+						},
 					},
 				},
 			},
@@ -885,14 +989,18 @@ func verifyTarget3(t *testing.T, td *testData, mds []internaldata.MetricsData) {
 				MetricDescriptor: &metricspb.MetricDescriptor{
 					Name:        "rpc_duration_seconds",
 					Type:        metricspb.MetricDescriptor_SUMMARY,
-					LabelKeys:   []*metricspb.LabelKey{{Key: "foo"}},
+					LabelKeys:   []*metricspb.LabelKey{{Key: "foo"}, {Key: "instance"}, {Key: "job"}},
 					Description: "A summary of the RPC duration in seconds.",
 					Unit:        "s",
 				},
 				Timeseries: []*metricspb.TimeSeries{
 					{
 						StartTimestamp: ts1,
-						LabelValues:    []*metricspb.LabelValue{{Value: "bar", HasValue: true}},
+						LabelValues: []*metricspb.LabelValue{
+							{Value: "bar", HasValue: true},
+							{Value: "-", HasValue: true},
+							{Value: "target3", HasValue: true},
+						},
 						Points: []*metricspb.Point{
 							{
 								Timestamp: ts2,
@@ -931,7 +1039,11 @@ func verifyTarget3(t *testing.T, td *testData, mds []internaldata.MetricsData) {
 					},
 					{
 						StartTimestamp: ts1,
-						LabelValues:    []*metricspb.LabelValue{{Value: "no_quantile", HasValue: true}},
+						LabelValues: []*metricspb.LabelValue{
+							{Value: "no_quantile", HasValue: true},
+							{Value: "-", HasValue: true},
+							{Value: "target3", HasValue: true},
+						},
 						Points: []*metricspb.Point{
 							{
 								Timestamp: ts2,
@@ -952,6 +1064,10 @@ func verifyTarget3(t *testing.T, td *testData, mds []internaldata.MetricsData) {
 		},
 	}
 
+	m2.Metrics[0].Timeseries[0].LabelValues[0].Value = "-"
+	m2.Metrics[1].Timeseries[0].LabelValues[0].Value = "-"
+	m2.Metrics[2].Timeseries[0].LabelValues[1].Value = "-"
+	m2.Metrics[2].Timeseries[1].LabelValues[1].Value = "-"
 	doCompare("scrape2", t, want2, &m2)
 }
 

--- a/receiver/prometheusreceiver/metrics_receiver_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_test.go
@@ -1356,8 +1356,8 @@ func (s *labelAndValueSorter) Less(i, j int) bool {
 }
 
 func (s *labelAndValueSorter) Swap(i, j int) {
-	labels := s.m.MetricDescriptor.LabelKeys
-	labels[i], labels[j] = labels[j], labels[i]
+	keys := s.m.MetricDescriptor.LabelKeys
+	keys[i], keys[j] = keys[j], keys[i]
 	for _, t := range s.m.Timeseries {
 		values := t.LabelValues
 		values[i], values[j] = values[j], values[i]

--- a/receiver/prometheusreceiver/metrics_receiver_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_test.go
@@ -1356,12 +1356,10 @@ func (s *labelAndValueSorter) Less(i, j int) bool {
 }
 
 func (s *labelAndValueSorter) Swap(i, j int) {
-	tmp := s.m.MetricDescriptor.LabelKeys[i]
-	s.m.MetricDescriptor.LabelKeys[i] = s.m.MetricDescriptor.LabelKeys[j]
-	s.m.MetricDescriptor.LabelKeys[j] = tmp
-
+	labels := s.m.MetricDescriptor.LabelKeys
+	labels[i], labels[j] = labels[j], labels[i]
 	for _, t := range s.m.Timeseries {
-		labels := t.LabelValues
-		labels[i], labels[j] = labels[j], labels[i]
+		values := t.LabelValues
+		values[i], values[j] = values[j], values[i]
 	}
 }


### PR DESCRIPTION
Fixes #575
Fixes #2499
Fixes  #2363
Fixes  open-telemetry/wg-prometheus#37
Fixes  open-telemetry/wg-prometheus#39
Fixes open-telemetry/wg-prometheus#44

Passing compliance tests:

$ go test --tags=compliance  -run  "TestRemoteWrite/otelcollector/Job.+" -v ./
=== RUN   TestRemoteWrite
=== RUN   TestRemoteWrite/otelcollector
=== RUN   TestRemoteWrite/otelcollector/JobLabel
=== PAUSE TestRemoteWrite/otelcollector/JobLabel
=== CONT  TestRemoteWrite/otelcollector/JobLabel
--- PASS: TestRemoteWrite (10.02s)
    --- PASS: TestRemoteWrite/otelcollector (0.00s)
        --- PASS: TestRemoteWrite/otelcollector/JobLabel (10.02s)
PASS
ok  	github.com/prometheus/compliance/remote_write	10.382s
$  go test --tags=compliance  -run  "TestRemoteWrite/otelcollector/Instance.+" -v ./
=== RUN   TestRemoteWrite
=== RUN   TestRemoteWrite/otelcollector
=== RUN   TestRemoteWrite/otelcollector/InstanceLabel
=== PAUSE TestRemoteWrite/otelcollector/InstanceLabel
=== CONT  TestRemoteWrite/otelcollector/InstanceLabel
--- PASS: TestRemoteWrite (10.01s)
    --- PASS: TestRemoteWrite/otelcollector (0.00s)
        --- PASS: TestRemoteWrite/otelcollector/InstanceLabel (10.01s)
PASS
ok  	github.com/prometheus/compliance/remote_write	10.291s
$ go test --tags=compliance  -run  "TestRemoteWrite/otelcollector/RepeatedLabels.+" -v ./
=== RUN   TestRemoteWrite
=== RUN   TestRemoteWrite/otelcollector
--- PASS: TestRemoteWrite (0.00s)
    --- PASS: TestRemoteWrite/otelcollector (0.00s)
testing: warning: no tests to run
PASS
