### PR TITLE
Rename traces methods/objects to include Traces in Kafka receiver

### DIFF
--- a/receiver/kafkareceiver/factory.go
+++ b/receiver/kafkareceiver/factory.go
@@ -44,11 +44,11 @@ const (
 // FactoryOption applies changes to kafkaReceiverFactory.
 type FactoryOption func(factory *kafkaReceiverFactory)
 
-// WithAddUnmarshallers adds marshallers.
-func WithAddUnmarshallers(encodingMarshaller map[string]Unmarshaller) FactoryOption {
+// WithAddTracesUnmarshallers adds marshallers.
+func WithAddTracesUnmarshallers(encodingMarshaller map[string]TracesUnmarshaller) FactoryOption {
 	return func(factory *kafkaReceiverFactory) {
 		for encoding, unmarshaller := range encodingMarshaller {
-			factory.unmarshalers[encoding] = unmarshaller
+			factory.tracesUnmarshalers[encoding] = unmarshaller
 		}
 	}
 }
@@ -65,8 +65,8 @@ func WithAddLogsUnmarshallers(encodingMarshaller map[string]LogsUnmarshaller) Fa
 // NewFactory creates Kafka receiver factory.
 func NewFactory(options ...FactoryOption) component.ReceiverFactory {
 	f := &kafkaReceiverFactory{
-		unmarshalers:     defaultUnmarshallers(),
-		logsUnmarshaller: defaultLogsUnmarshallers(),
+		tracesUnmarshalers: defaultTracesUnmarshallers(),
+		logsUnmarshaller:   defaultLogsUnmarshallers(),
 	}
 	for _, o := range options {
 		o(f)
@@ -101,8 +101,8 @@ func createDefaultConfig() config.Receiver {
 }
 
 type kafkaReceiverFactory struct {
-	unmarshalers     map[string]Unmarshaller
-	logsUnmarshaller map[string]LogsUnmarshaller
+	tracesUnmarshalers map[string]TracesUnmarshaller
+	logsUnmarshaller   map[string]LogsUnmarshaller
 }
 
 func (f *kafkaReceiverFactory) createTracesReceiver(
@@ -112,7 +112,7 @@ func (f *kafkaReceiverFactory) createTracesReceiver(
 	nextConsumer consumer.Traces,
 ) (component.TracesReceiver, error) {
 	c := cfg.(*Config)
-	r, err := newReceiver(*c, params, f.unmarshalers, nextConsumer)
+	r, err := newTracesReceiver(*c, params, f.tracesUnmarshalers, nextConsumer)
 	if err != nil {
 		return nil, err
 	}

--- a/receiver/kafkareceiver/factory_test.go
+++ b/receiver/kafkareceiver/factory_test.go
@@ -40,7 +40,7 @@ func TestCreateTracesReceiver(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)
 	cfg.Brokers = []string{"invalid:9092"}
 	cfg.ProtocolVersion = "2.0.0"
-	f := kafkaReceiverFactory{unmarshalers: defaultUnmarshallers()}
+	f := kafkaReceiverFactory{tracesUnmarshalers: defaultTracesUnmarshallers()}
 	r, err := f.createTracesReceiver(context.Background(), component.ReceiverCreateParams{}, cfg, nil)
 	// no available broker
 	require.Error(t, err)
@@ -52,15 +52,15 @@ func TestCreateTracesReceiver_error(t *testing.T) {
 	cfg.ProtocolVersion = "2.0.0"
 	// disable contacting broker at startup
 	cfg.Metadata.Full = false
-	f := kafkaReceiverFactory{unmarshalers: defaultUnmarshallers()}
+	f := kafkaReceiverFactory{tracesUnmarshalers: defaultTracesUnmarshallers()}
 	r, err := f.createTracesReceiver(context.Background(), component.ReceiverCreateParams{}, cfg, nil)
 	require.NoError(t, err)
 	assert.NotNil(t, r)
 }
 
-func TestWithUnmarshallers(t *testing.T) {
-	unmarshaller := &customUnmarshaller{}
-	f := NewFactory(WithAddUnmarshallers(map[string]Unmarshaller{unmarshaller.Encoding(): unmarshaller}))
+func TestWithTracesUnmarshallers(t *testing.T) {
+	unmarshaller := &customTracesUnmarshaller{}
+	f := NewFactory(WithAddTracesUnmarshallers(map[string]TracesUnmarshaller{unmarshaller.Encoding(): unmarshaller}))
 	cfg := createDefaultConfig().(*Config)
 	// disable contacting broker
 	cfg.Metadata.Full = false
@@ -124,19 +124,19 @@ func TestWithLogsUnmarshallers(t *testing.T) {
 	})
 }
 
-type customUnmarshaller struct {
+type customTracesUnmarshaller struct {
 }
 
 type customLogsUnmarshaller struct {
 }
 
-var _ Unmarshaller = (*customUnmarshaller)(nil)
+var _ TracesUnmarshaller = (*customTracesUnmarshaller)(nil)
 
-func (c customUnmarshaller) Unmarshal([]byte) (pdata.Traces, error) {
+func (c customTracesUnmarshaller) Unmarshal([]byte) (pdata.Traces, error) {
 	panic("implement me")
 }
 
-func (c customUnmarshaller) Encoding() string {
+func (c customTracesUnmarshaller) Encoding() string {
 	return "custom"
 }
 

--- a/receiver/kafkareceiver/jaeger_unmarshaller.go
+++ b/receiver/kafkareceiver/jaeger_unmarshaller.go
@@ -27,7 +27,7 @@ import (
 type jaegerProtoSpanUnmarshaller struct {
 }
 
-var _ Unmarshaller = (*jaegerProtoSpanUnmarshaller)(nil)
+var _ TracesUnmarshaller = (*jaegerProtoSpanUnmarshaller)(nil)
 
 func (j jaegerProtoSpanUnmarshaller) Unmarshal(bytes []byte) (pdata.Traces, error) {
 	span := &jaegerproto.Span{}
@@ -45,7 +45,7 @@ func (j jaegerProtoSpanUnmarshaller) Encoding() string {
 type jaegerJSONSpanUnmarshaller struct {
 }
 
-var _ Unmarshaller = (*jaegerJSONSpanUnmarshaller)(nil)
+var _ TracesUnmarshaller = (*jaegerJSONSpanUnmarshaller)(nil)
 
 func (j jaegerJSONSpanUnmarshaller) Unmarshal(data []byte) (pdata.Traces, error) {
 	span := &jaegerproto.Span{}

--- a/receiver/kafkareceiver/jaeger_unmarshaller_test.go
+++ b/receiver/kafkareceiver/jaeger_unmarshaller_test.go
@@ -47,7 +47,7 @@ func TestUnmarshallJaeger(t *testing.T) {
 	jsonMarshaller.Marshal(jsonBytes, batches[0].Spans[0])
 
 	tests := []struct {
-		unmarshaller Unmarshaller
+		unmarshaller TracesUnmarshaller
 		encoding     string
 		bytes        []byte
 	}{

--- a/receiver/kafkareceiver/otlp_unmarshaller.go
+++ b/receiver/kafkareceiver/otlp_unmarshaller.go
@@ -21,7 +21,7 @@ import (
 type otlpTracesPbUnmarshaller struct {
 }
 
-var _ Unmarshaller = (*otlpTracesPbUnmarshaller)(nil)
+var _ TracesUnmarshaller = (*otlpTracesPbUnmarshaller)(nil)
 
 func (p *otlpTracesPbUnmarshaller) Unmarshal(bytes []byte) (pdata.Traces, error) {
 	return pdata.TracesFromOtlpProtoBytes(bytes)

--- a/receiver/kafkareceiver/otlp_unmarshaller_test.go
+++ b/receiver/kafkareceiver/otlp_unmarshaller_test.go
@@ -24,7 +24,7 @@ import (
 	"go.opentelemetry.io/collector/internal/testdata"
 )
 
-func TestUnmarshallOTLP(t *testing.T) {
+func TestUnmarshallOTLPTraces(t *testing.T) {
 	td := pdata.NewTraces()
 	td.ResourceSpans().Resize(1)
 	td.ResourceSpans().At(0).Resource().Attributes().InsertString("foo", "bar")
@@ -40,7 +40,7 @@ func TestUnmarshallOTLP(t *testing.T) {
 	assert.Equal(t, "otlp_proto", p.Encoding())
 }
 
-func TestUnmarshallOTLP_error(t *testing.T) {
+func TestUnmarshallOTLPTraces_error(t *testing.T) {
 	p := otlpTracesPbUnmarshaller{}
 	_, err := p.Unmarshal([]byte("+$%"))
 	assert.Error(t, err)

--- a/receiver/kafkareceiver/unmarshaller.go
+++ b/receiver/kafkareceiver/unmarshaller.go
@@ -18,8 +18,8 @@ import (
 	"go.opentelemetry.io/collector/consumer/pdata"
 )
 
-// Unmarshaller deserializes the message body.
-type Unmarshaller interface {
+// TracesUnmarshaller deserializes the message body.
+type TracesUnmarshaller interface {
 	// Unmarshal deserializes the message body into traces.
 	Unmarshal([]byte) (pdata.Traces, error)
 
@@ -36,15 +36,15 @@ type LogsUnmarshaller interface {
 	Encoding() string
 }
 
-// defaultUnmarshallers returns map of supported encodings with Unmarshaller.
-func defaultUnmarshallers() map[string]Unmarshaller {
+// defaultTracesUnmarshallers returns map of supported encodings with TracesUnmarshaller.
+func defaultTracesUnmarshallers() map[string]TracesUnmarshaller {
 	otlp := &otlpTracesPbUnmarshaller{}
 	jaegerProto := jaegerProtoSpanUnmarshaller{}
 	jaegerJSON := jaegerJSONSpanUnmarshaller{}
 	zipkinProto := zipkinProtoSpanUnmarshaller{}
 	zipkinJSON := zipkinJSONSpanUnmarshaller{}
 	zipkinThrift := zipkinThriftSpanUnmarshaller{}
-	return map[string]Unmarshaller{
+	return map[string]TracesUnmarshaller{
 		otlp.Encoding():         otlp,
 		jaegerProto.Encoding():  jaegerProto,
 		jaegerJSON.Encoding():   jaegerJSON,

--- a/receiver/kafkareceiver/unmarshaller_test.go
+++ b/receiver/kafkareceiver/unmarshaller_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestDefaultUnMarshaller(t *testing.T) {
+func TestDefaultTracesUnMarshaller(t *testing.T) {
 	expectedEncodings := []string{
 		"otlp_proto",
 		"jaeger_proto",
@@ -30,7 +30,7 @@ func TestDefaultUnMarshaller(t *testing.T) {
 		"zipkin_json",
 		"zipkin_thrift",
 	}
-	marshallers := defaultUnmarshallers()
+	marshallers := defaultTracesUnmarshallers()
 	assert.Equal(t, len(expectedEncodings), len(marshallers))
 	for _, e := range expectedEncodings {
 		t.Run(e, func(t *testing.T) {

--- a/receiver/kafkareceiver/zipkin_unmarshaller.go
+++ b/receiver/kafkareceiver/zipkin_unmarshaller.go
@@ -29,7 +29,7 @@ import (
 type zipkinProtoSpanUnmarshaller struct {
 }
 
-var _ Unmarshaller = (*zipkinProtoSpanUnmarshaller)(nil)
+var _ TracesUnmarshaller = (*zipkinProtoSpanUnmarshaller)(nil)
 
 func (z zipkinProtoSpanUnmarshaller) Unmarshal(bytes []byte) (pdata.Traces, error) {
 	parseSpans, err := zipkin_proto3.ParseSpans(bytes, false)
@@ -46,7 +46,7 @@ func (z zipkinProtoSpanUnmarshaller) Encoding() string {
 type zipkinJSONSpanUnmarshaller struct {
 }
 
-var _ Unmarshaller = (*zipkinJSONSpanUnmarshaller)(nil)
+var _ TracesUnmarshaller = (*zipkinJSONSpanUnmarshaller)(nil)
 
 func (z zipkinJSONSpanUnmarshaller) Unmarshal(bytes []byte) (pdata.Traces, error) {
 	var spans []*zipkinmodel.SpanModel
@@ -63,7 +63,7 @@ func (z zipkinJSONSpanUnmarshaller) Encoding() string {
 type zipkinThriftSpanUnmarshaller struct {
 }
 
-var _ Unmarshaller = (*zipkinThriftSpanUnmarshaller)(nil)
+var _ TracesUnmarshaller = (*zipkinThriftSpanUnmarshaller)(nil)
 
 func (z zipkinThriftSpanUnmarshaller) Unmarshal(bytes []byte) (pdata.Traces, error) {
 	spans, err := deserializeZipkinThrift(bytes)

--- a/receiver/kafkareceiver/zipkin_unmarshaller_test.go
+++ b/receiver/kafkareceiver/zipkin_unmarshaller_test.go
@@ -64,7 +64,7 @@ func TestUnmarshallZipkin(t *testing.T) {
 	require.NoError(t, err)
 
 	tests := []struct {
-		unmarshaller Unmarshaller
+		unmarshaller TracesUnmarshaller
 		encoding     string
 		bytes        []byte
 		expected     pdata.Traces


### PR DESCRIPTION
**Description:**
Renamed methods/objects used by Traces to include "Traces" in Kafka receiver.
Fixed https://github.com/open-telemetry/opentelemetry-collector/pull/2944#discussion_r615000738
