### PR TITLE
Enable the queue for the Prometheus Remote Write Exporter internally

### DIFF
--- a/exporter/prometheusremotewriteexporter/factory.go
+++ b/exporter/prometheusremotewriteexporter/factory.go
@@ -69,7 +69,9 @@ func createMetricsExporter(_ context.Context, params component.ExporterCreatePar
 		exporterhelper.WithQueue(exporterhelper.QueueSettings{
 			Enabled:      true,
 			NumConsumers: 1,
-			// TODO(jbd): Allow users to modify the queue size.
+			QueueSize:    10000,
+			// TODO(jbd): Adjust the default queue size
+			// and allow users to modify the queue size.
 		}),
 		exporterhelper.WithRetry(prwCfg.RetrySettings),
 		exporterhelper.WithShutdown(prwe.Shutdown),

--- a/exporter/prometheusremotewriteexporter/factory.go
+++ b/exporter/prometheusremotewriteexporter/factory.go
@@ -66,6 +66,11 @@ func createMetricsExporter(_ context.Context, params component.ExporterCreatePar
 		params.Logger,
 		prwe.PushMetrics,
 		exporterhelper.WithTimeout(prwCfg.TimeoutSettings),
+		exporterhelper.WithQueue(exporterhelper.QueueSettings{
+			Enabled:      true,
+			NumConsumers: 1,
+			// TODO(jbd): Allow users to modify the queue size.
+		}),
 		exporterhelper.WithRetry(prwCfg.RetrySettings),
 		exporterhelper.WithShutdown(prwe.Shutdown),
 	)


### PR DESCRIPTION
This is a follow up to #2951.

When we disable the queue completely, it causes the export to happen
not in a consumer goroutine. Enable the queue internally that export
gets its own goroutine not to block the entire collector pipeline.
