### PR TITLE
Don't drop instance and job labels in the Prometheus Remote Write Exporter

### DIFF
--- a/exporter/prometheusremotewriteexporter/helper_test.go
+++ b/exporter/prometheusremotewriteexporter/helper_test.go
@@ -24,6 +24,7 @@ import (
 	"go.opentelemetry.io/collector/consumer/pdata"
 	common "go.opentelemetry.io/collector/internal/data/protogen/common/v1"
 	otlp "go.opentelemetry.io/collector/internal/data/protogen/metrics/v1"
+	resourcev1 "go.opentelemetry.io/collector/internal/data/protogen/resource/v1"
 )
 
 // Test_validateMetrics checks validateMetrics return true if a type and temporality combination is valid, false
@@ -185,6 +186,7 @@ func Test_timeSeriesSignature(t *testing.T) {
 func Test_createLabelSet(t *testing.T) {
 	tests := []struct {
 		name           string
+		resource       resourcev1.Resource
 		orig           []common.StringKeyValue
 		externalLabels map[string]string
 		extras         []string
@@ -192,13 +194,38 @@ func Test_createLabelSet(t *testing.T) {
 	}{
 		{
 			"labels_clean",
+			resourcev1.Resource{
+				Attributes: []common.KeyValue{},
+			},
 			lbs1,
 			map[string]string{},
 			[]string{label31, value31, label32, value32},
 			getPromLabels(label11, value11, label12, value12, label31, value31, label32, value32),
 		},
 		{
+			"labels_with_resource",
+			resourcev1.Resource{
+				Attributes: []common.KeyValue{
+					{
+						Key:   "job",
+						Value: common.AnyValue{Value: &common.AnyValue_StringValue{StringValue: "prometheus"}},
+					},
+					{
+						Key:   "instance",
+						Value: common.AnyValue{Value: &common.AnyValue_StringValue{StringValue: "127.0.0.1:8080"}},
+					},
+				},
+			},
+			lbs1,
+			map[string]string{},
+			[]string{label31, value31, label32, value32},
+			getPromLabels(label11, value11, label12, value12, label31, value31, label32, value32, "job", "prometheus", "instance", "127.0.0.1:8080"),
+		},
+		{
 			"labels_duplicate_in_extras",
+			resourcev1.Resource{
+				Attributes: []common.KeyValue{},
+			},
 			lbs1,
 			map[string]string{},
 			[]string{label11, value31},
@@ -206,6 +233,9 @@ func Test_createLabelSet(t *testing.T) {
 		},
 		{
 			"labels_dirty",
+			resourcev1.Resource{
+				Attributes: []common.KeyValue{},
+			},
 			lbs1Dirty,
 			map[string]string{},
 			[]string{label31 + dirty1, value31, label32, value32},
@@ -213,6 +243,9 @@ func Test_createLabelSet(t *testing.T) {
 		},
 		{
 			"no_original_case",
+			resourcev1.Resource{
+				Attributes: []common.KeyValue{},
+			},
 			nil,
 			nil,
 			[]string{label31, value31, label32, value32},
@@ -220,6 +253,9 @@ func Test_createLabelSet(t *testing.T) {
 		},
 		{
 			"empty_extra_case",
+			resourcev1.Resource{
+				Attributes: []common.KeyValue{},
+			},
 			lbs1,
 			map[string]string{},
 			[]string{"", ""},
@@ -227,6 +263,9 @@ func Test_createLabelSet(t *testing.T) {
 		},
 		{
 			"single_left_over_case",
+			resourcev1.Resource{
+				Attributes: []common.KeyValue{},
+			},
 			lbs1,
 			map[string]string{},
 			[]string{label31, value31, label32},
@@ -234,6 +273,9 @@ func Test_createLabelSet(t *testing.T) {
 		},
 		{
 			"valid_external_labels",
+			resourcev1.Resource{
+				Attributes: []common.KeyValue{},
+			},
 			lbs1,
 			exlbs1,
 			[]string{label31, value31, label32, value32},
@@ -241,6 +283,9 @@ func Test_createLabelSet(t *testing.T) {
 		},
 		{
 			"overwritten_external_labels",
+			resourcev1.Resource{
+				Attributes: []common.KeyValue{},
+			},
 			lbs1,
 			exlbs2,
 			[]string{label31, value31, label32, value32},
@@ -250,7 +295,7 @@ func Test_createLabelSet(t *testing.T) {
 	// run tests
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.ElementsMatch(t, tt.want, createLabelSet(tt.orig, tt.externalLabels, tt.extras...))
+			assert.ElementsMatch(t, tt.want, createLabelSet(tt.resource, tt.orig, tt.externalLabels, tt.extras...))
 		})
 	}
 }


### PR DESCRIPTION
This is a follow up to #2897. Even though the instance and job labels are scraped, we were not using them during the export. This change makes sure that the remote write exporter is labelling the outgoing samples with "job" and "instance". 

Fixes #575
Fixes #2499
Fixes #2363
Fixes open-telemetry/wg-prometheus#37
Fixes open-telemetry/wg-prometheus#39

Passing compliance tests:

$ go test --tags=compliance -run "TestRemoteWrite/otelcollector/Job.+" -v ./
=== RUN TestRemoteWrite
=== RUN TestRemoteWrite/otelcollector
=== RUN TestRemoteWrite/otelcollector/JobLabel
=== PAUSE TestRemoteWrite/otelcollector/JobLabel
=== CONT TestRemoteWrite/otelcollector/JobLabel
--- PASS: TestRemoteWrite (10.02s)
--- PASS: TestRemoteWrite/otelcollector (0.00s)
--- PASS: TestRemoteWrite/otelcollector/JobLabel (10.02s)
PASS
ok github.com/prometheus/compliance/remote_write 10.382s
$ go test --tags=compliance -run "TestRemoteWrite/otelcollector/Instance.+" -v ./
=== RUN TestRemoteWrite
=== RUN TestRemoteWrite/otelcollector
=== RUN TestRemoteWrite/otelcollector/InstanceLabel
=== PAUSE TestRemoteWrite/otelcollector/InstanceLabel
=== CONT TestRemoteWrite/otelcollector/InstanceLabel
--- PASS: TestRemoteWrite (10.01s)
--- PASS: TestRemoteWrite/otelcollector (0.00s)
--- PASS: TestRemoteWrite/otelcollector/InstanceLabel (10.01s)
PASS
ok github.com/prometheus/compliance/remote_write 10.291s


