### PR TITLE
Minor change to doCompare

### DIFF
--- a/receiver/prometheusreceiver/metrics_receiver_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_test.go
@@ -180,7 +180,7 @@ func verifyNumScrapeResults(t *testing.T, td *testData, mds []internaldata.Metri
 	}
 }
 
-func doCompare(name string, t *testing.T, want, got interface{}) {
+func doCompare(name string, t *testing.T, want, got *internaldata.MetricsData) {
 	t.Run(name, func(t *testing.T) {
 		assert.EqualValues(t, want, got)
 	})
@@ -277,8 +277,18 @@ func verifyTarget1(t *testing.T, td *testData, mds []internaldata.MetricsData) {
 	ts1 := gotG1.Timeseries[0].Points[0].Timestamp
 	// set this timestamp to wantG1
 	wantG1.Timeseries[0].Points[0].Timestamp = ts1
-	doCompare("scrape1", t, wantG1, gotG1)
-
+	doCompare("scrape1", t,
+		&internaldata.MetricsData{
+			Node:     td.node,
+			Resource: td.resource,
+			Metrics:  []*metricspb.Metric{wantG1},
+		},
+		&internaldata.MetricsData{
+			Node:     td.node,
+			Resource: td.resource,
+			Metrics:  []*metricspb.Metric{gotG1},
+		},
+	)
 	// verify the 2nd metricData
 	m2 := mds[1]
 	ts2 := m2.Metrics[0].Timeseries[0].Points[0].Timestamp
@@ -503,8 +513,18 @@ func verifyTarget2(t *testing.T, td *testData, mds []internaldata.MetricsData) {
 	ts1 := gotG1.Timeseries[0].Points[0].Timestamp
 	// set this timestamp to wantG1
 	wantG1.Timeseries[0].Points[0].Timestamp = ts1
-	doCompare("scrape1", t, wantG1, gotG1)
-
+	doCompare("scrape1", t,
+		&internaldata.MetricsData{
+			Node:     td.node,
+			Resource: td.resource,
+			Metrics:  []*metricspb.Metric{wantG1},
+		},
+		&internaldata.MetricsData{
+			Node:     td.node,
+			Resource: td.resource,
+			Metrics:  []*metricspb.Metric{gotG1},
+		},
+	)
 	// verify the 2nd metricData
 	m2 := mds[1]
 	ts2 := m2.Metrics[0].Timeseries[0].Points[0].Timestamp
@@ -820,8 +840,18 @@ func verifyTarget3(t *testing.T, td *testData, mds []internaldata.MetricsData) {
 	ts1 := gotG1.Timeseries[0].Points[0].Timestamp
 	// set this timestamp to wantG1
 	wantG1.Timeseries[0].Points[0].Timestamp = ts1
-	doCompare("scrape1", t, wantG1, gotG1)
-
+	doCompare("scrape1", t,
+		&internaldata.MetricsData{
+			Node:     td.node,
+			Resource: td.resource,
+			Metrics:  []*metricspb.Metric{wantG1},
+		},
+		&internaldata.MetricsData{
+			Node:     td.node,
+			Resource: td.resource,
+			Metrics:  []*metricspb.Metric{gotG1},
+		},
+	)
 	// verify the 2nd metricData
 	m2 := mds[1]
 	ts2 := m2.Metrics[0].Timeseries[0].Points[0].Timestamp


### PR DESCRIPTION
This change was a part of #2964 but it's closed now. Having typed
arguments make it easier to massage the arguments before comparing.
Contributing this change for future maintainers.

Merge after stability.