### PR TITLE
Logging exporter ignore invalid handle on close

### DIFF
--- a/exporter/loggingexporter/known_sync_error.go
+++ b/exporter/loggingexporter/known_sync_error.go
@@ -1,0 +1,34 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !windows
+
+package loggingexporter
+
+// knownSyncError returns true if the given error is one of the known
+// non-actionable errors returned by Sync on Linux and macOS:
+//
+// Linux:
+// - sync /dev/stdout: invalid argument
+//
+// macOS:
+// - sync /dev/stdout: inappropriate ioctl for device
+//
+func knownSyncError(err error) bool {
+	switch err {
+	case syscall.EINVAL, syscall.ENOTSUP, syscall.ENOTTY:
+		return true
+	}
+	return false
+}

--- a/exporter/loggingexporter/known_sync_error.go
+++ b/exporter/loggingexporter/known_sync_error.go
@@ -16,6 +16,10 @@
 
 package loggingexporter
 
+import (
+	"syscall"
+)
+
 // knownSyncError returns true if the given error is one of the known
 // non-actionable errors returned by Sync on Linux and macOS:
 //

--- a/exporter/loggingexporter/known_sync_error_windows.go
+++ b/exporter/loggingexporter/known_sync_error_windows.go
@@ -1,0 +1,28 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build windows
+
+package loggingexporter
+
+import "golang.org/x/sys/windows"
+
+// knownSyncError returns true if the given error is one of the known
+// non-actionable errors returned by Sync on Windows:
+//
+// - sync /dev/stderr: The handle is invalid.
+//
+func knownSyncError(err error) bool {
+	return err == windows.ERROR_INVALID_HANDLE
+}

--- a/exporter/loggingexporter/logging_exporter.go
+++ b/exporter/loggingexporter/logging_exporter.go
@@ -17,15 +17,17 @@ package loggingexporter
 import (
 	"context"
 	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"go.uber.org/zap"
+
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 	tracetranslator "go.opentelemetry.io/collector/translator/trace"
-	"go.uber.org/zap"
-	"os"
-	"strconv"
-	"strings"
 )
 
 type logDataBuffer struct {


### PR DESCRIPTION
Similar to what happens in Linux and macOS the logger.Sync call on loggingexporter also returns an error that should be ignored on Windows.
