### PR TITLE
Remove ApplicationStartInfo.LongName, the usage as long help was wrong anyway

### DIFF
--- a/cmd/otelcol/main.go
+++ b/cmd/otelcol/main.go
@@ -33,10 +33,9 @@ func main() {
 	}
 
 	info := component.ApplicationStartInfo{
-		ExeName:  "otelcol",
-		LongName: "OpenTelemetry Collector",
-		Version:  version.Version,
-		GitHash:  version.GitHash,
+		ExeName: "otelcol",
+		Version: version.Version,
+		GitHash: version.GitHash,
 	}
 
 	if err := run(service.Parameters{ApplicationStartInfo: info, Factories: factories}); err != nil {

--- a/component/application_info.go
+++ b/component/application_info.go
@@ -20,9 +20,6 @@ type ApplicationStartInfo struct {
 	// Executable file name, e.g. "otelcol".
 	ExeName string
 
-	// Long name, used e.g. in the logs.
-	LongName string
-
 	// Version string.
 	Version string
 
@@ -33,9 +30,8 @@ type ApplicationStartInfo struct {
 // DefaultApplicationStartInfo returns the default ApplicationStartInfo.
 func DefaultApplicationStartInfo() ApplicationStartInfo {
 	return ApplicationStartInfo{
-		ExeName:  "otelcol",
-		LongName: "OpenTelemetry Collector",
-		Version:  "latest",
-		GitHash:  "<NOT PROPERLY GENERATED>",
+		ExeName: "otelcol",
+		Version: "latest",
+		GitHash: "<NOT PROPERLY GENERATED>",
 	}
 }

--- a/service/application.go
+++ b/service/application.go
@@ -107,8 +107,8 @@ func New(params Parameters) (*Application, error) {
 	}
 
 	rootCmd := &cobra.Command{
-		Use:  params.ApplicationStartInfo.ExeName,
-		Long: params.ApplicationStartInfo.LongName,
+		Use:     params.ApplicationStartInfo.ExeName,
+		Version: params.ApplicationStartInfo.Version,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
 			if app.logger, err = newLogger(params.LoggingOptions); err != nil {
@@ -278,7 +278,7 @@ func (app *Application) setupConfigurationComponents(ctx context.Context) error 
 }
 
 func (app *Application) execute(ctx context.Context) error {
-	app.logger.Info("Starting "+app.info.LongName+"...",
+	app.logger.Info("Starting "+app.info.ExeName+"...",
 		zap.String("Version", app.info.Version),
 		zap.String("GitHash", app.info.GitHash),
 		zap.Int("NumCPU", runtime.NumCPU()),

--- a/testbed/testbed/otelcol_runner.go
+++ b/testbed/testbed/otelcol_runner.go
@@ -86,10 +86,9 @@ func (ipp *InProcessCollector) PrepareConfig(configStr string) (configCleanup fu
 func (ipp *InProcessCollector) Start(args StartParams) error {
 	params := service.Parameters{
 		ApplicationStartInfo: component.ApplicationStartInfo{
-			ExeName:  "otelcol",
-			LongName: "InProcess Collector",
-			Version:  version.Version,
-			GitHash:  version.GitHash,
+			ExeName: "otelcol",
+			Version: version.Version,
+			GitHash: version.GitHash,
 		},
 		ParserProvider: parserprovider.NewInMemory(strings.NewReader(ipp.configStr)),
 		Factories:      ipp.factories,


### PR DESCRIPTION
Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
