### PR TITLE
Add -trimpath to go build args.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -228,6 +228,9 @@ jobs:
       - run:
           name: Build collector for all archs
           command: grep ^binaries-all-sys Makefile|fmt -w 1|tail -n +2|circleci tests split|xargs make
+      - run:
+          name: Log checksums to console
+          command: shasum -a 256 bin/*
       - persist_to_workspace:
           root: ~/
           paths: project/bin

--- a/Makefile
+++ b/Makefile
@@ -242,7 +242,7 @@ binaries-windows_amd64:
 
 .PHONY: build-binary-internal
 build-binary-internal:
-	GO111MODULE=on CGO_ENABLED=0 go build -o ./bin/otelcol_$(GOOS)_$(GOARCH)$(EXTENSION) $(BUILD_INFO) ./cmd/otelcol
+	GO111MODULE=on CGO_ENABLED=0 go build -trimpath -o ./bin/otelcol_$(GOOS)_$(GOARCH)$(EXTENSION) $(BUILD_INFO) ./cmd/otelcol
 
 
 .PHONY: deb-rpm-package


### PR DESCRIPTION
**Description:** 
This strips off absolute paths referring to GOPATH, modules and the
project from the build taking us a step closer to reproducible builds.

This has an effect on debugging when developing locally as full paths will not be present in the stack traces anymore but it should should be pretty easy to figure out.

Before:
```
2021/04/24 02:49:56 manual panic
panic: manual panic

goroutine 1 [running]:
log.Panicf(0x3a21de8, 0xc, 0x0, 0x0, 0x0)
	/usr/local/go/src/log/log.go:361 +0xc5
go.opentelemetry.io/collector/receiver/otlpreceiver.newOtlpReceiver(0xc0007a3ad0, 0xc000802840, 0xc0007a3ad0, 0x5247cc0, 0xc00018f600)
	/Users/olone/Projects/opentelemetry/opentelemetry-collector/receiver/otlpreceiver/otlp.go:75 +0x96
go.opentelemetry.io/collector/receiver/otlpreceiver.createReceiver(0x3f1d070, 0xc0007a3ad0, 0xc000802840, 0x3a30208, 0x13, 0x1)
	/Users/olone/Projects/opentelemetry/opentelemetry-collector/receiver/otlpreceiver/factory.go:135 +0x9a
go.opentelemetry.io/collector/receiver/otlpreceiver.createTracesReceiver(0x3f1bd68, 0xc0001a4008, 0xc000802840, 0x3a194b8, 0x7, 0x3a39a38, 0x17, 0x3e6d580, 0x14, 0x3e682c8, ...)
	/Users/olone/Projects/opentelemetry/opentelemetry-collector/receiver/otlpreceiver/factory.go:80 +0x49
go.opentelemetry.io/collector/receiver/receiverhelper.(*factory).CreateTracesReceiver(0xc0005be060, 0x3f1bd68, 0xc0001a4008, 0xc000802840, 0x3a194b8, 0x7, 0x3a39a38, 0x17, 0x3e6d580, 0x14, ...)
	/Users/olone/Projects/opentelemetry/opentelemetry-collector/receiver/receiverhelper/factory.go:102 +0xdc
go.opentelemetry.io/collector/service/internal/builder.(*receiversBuilder).attachReceiverToPipelines(0xc00092f560, 0x3f1bd68, 0xc0001a4008, 0xc000802840, 0x3a194b8, 0x7, 0x3a39a38, 0x17, 0x3e6d580, 0x14, ...)
	/Users/olone/Projects/opentelemetry/opentelemetry-collector/service/internal/builder/receivers_builder.go:184 +0x9c8
go.opentelemetry.io/collector/service/internal/builder.(*receiversBuilder).buildReceiver(0xc00092f560, 0x3f1bd68, 0xc0001a4008, 0xc000802840, 0x3a194b8, 0x7, 0x3a39a38, 0x17, 0x3e6d580, 0x14, ...)
	/Users/olone/Projects/opentelemetry/opentelemetry-collector/service/internal/builder/receivers_builder.go:261 +0x2a5
go.opentelemetry.io/collector/service/internal/builder.BuildReceivers(0xc0005bd560, 0x3a194b8, 0x7, 0x3a39a38, 0x17, 0x3e6d580, 0x14, 0x3e682c8, 0x8, 0xc0001ae000, ...)
	/Users/olone/Projects/opentelemetry/opentelemetry-collector/service/internal/builder/receivers_builder.go:102 +0x486
go.opentelemetry.io/collector/service.(*service).buildPipelines(0xc0002f5ea0, 0x0, 0x0)
	/Users/olone/Projects/opentelemetry/opentelemetry-collector/service/service.go:191 +0x354
go.opentelemetry.io/collector/service.newService(0xc00092f848, 0x3a3df68, 0x19, 0x0)
	/Users/olone/Projects/opentelemetry/opentelemetry-collector/service/service.go:78 +0x205
go.opentelemetry.io/collector/service.(*Application).setupConfigurationComponents(0xc0000f6370, 0x3f1bd68, 0xc0001a4008, 0x0, 0x0)
	/Users/olone/Projects/opentelemetry/opentelemetry-collector/service/application.go:242 +0x370
go.opentelemetry.io/collector/service.(*Application).execute(0xc0000f6370, 0x3f1bd68, 0xc0001a4008, 0xc0005bd560, 0x0)
	/Users/olone/Projects/opentelemetry/opentelemetry-collector/service/application.go:299 +0x471
go.opentelemetry.io/collector/service.New.func1(0xc000230780, 0xc0007522c0, 0x0, 0x2, 0x0, 0x0)
	/Users/olone/Projects/opentelemetry/opentelemetry-collector/service/application.go:118 +0x11a
github.com/spf13/cobra.(*Command).execute(0xc000230780, 0xc00018e190, 0x2, 0x2, 0xc000230780, 0xc00018e190)
	/Users/olone/go/pkg/mod/github.com/spf13/cobra@v1.1.3/command.go:852 +0x472
github.com/spf13/cobra.(*Command).ExecuteC(0xc000230780, 0xc0005be5a0, 0xc0005be420, 0xc00077b380)
	/Users/olone/go/pkg/mod/github.com/spf13/cobra@v1.1.3/command.go:960 +0x375
github.com/spf13/cobra.(*Command).Execute(...)
	/Users/olone/go/pkg/mod/github.com/spf13/cobra@v1.1.3/command.go:897
go.opentelemetry.io/collector/service.(*Application).Run(...)
	/Users/olone/Projects/opentelemetry/opentelemetry-collector/service/application.go:157
main.runInteractive(0xc0005be150, 0xc0005be5a0, 0xc0005be420, 0xc00077b380, 0x3a194b8, 0x7, 0x3a39a38, 0x17, 0x3e6d580, 0x14, ...)
	/Users/olone/Projects/opentelemetry/opentelemetry-collector/cmd/otelcol/main.go:53 +0x12b
main.run(...)
	/Users/olone/Projects/opentelemetry/opentelemetry-collector/cmd/otelcol/main_others.go:22
main.main()
	/Users/olone/Projects/opentelemetry/opentelemetry-collector/cmd/otelcol/main.go:42 +0x258
```


After:
```
2021/04/24 02:48:31 manual panic
panic: manual panic

goroutine 1 [running]:
log.Panicf(0x3a21de8, 0xc, 0x0, 0x0, 0x0)
	log/log.go:361 +0xc5
go.opentelemetry.io/collector/receiver/otlpreceiver.newOtlpReceiver(0xc0000cc7b0, 0xc0003a9c20, 0xc0000cc7b0, 0x5234cc0, 0xc000181500)
	go.opentelemetry.io/collector/receiver/otlpreceiver/otlp.go:75 +0x96
go.opentelemetry.io/collector/receiver/otlpreceiver.createReceiver(0x3f1d070, 0xc0000cc7b0, 0xc0003a9c20, 0x3a30208, 0x13, 0x1)
	go.opentelemetry.io/collector/receiver/otlpreceiver/factory.go:135 +0x9a
go.opentelemetry.io/collector/receiver/otlpreceiver.createTracesReceiver(0x3f1bd68, 0xc00019a000, 0xc0003a9c20, 0x3a194b8, 0x7, 0x3a39a38, 0x17, 0x3e6d570, 0x14, 0x3e682d0, ...)
	go.opentelemetry.io/collector/receiver/otlpreceiver/factory.go:80 +0x49
go.opentelemetry.io/collector/receiver/receiverhelper.(*factory).CreateTracesReceiver(0xc0008e4510, 0x3f1bd68, 0xc00019a000, 0xc0003a9c20, 0x3a194b8, 0x7, 0x3a39a38, 0x17, 0x3e6d570, 0x14, ...)
	go.opentelemetry.io/collector/receiver/receiverhelper/factory.go:102 +0xdc
go.opentelemetry.io/collector/service/internal/builder.(*receiversBuilder).attachReceiverToPipelines(0xc00091f560, 0x3f1bd68, 0xc00019a000, 0xc0003a9c20, 0x3a194b8, 0x7, 0x3a39a38, 0x17, 0x3e6d570, 0x14, ...)
	go.opentelemetry.io/collector/service/internal/builder/receivers_builder.go:184 +0x9c8
go.opentelemetry.io/collector/service/internal/builder.(*receiversBuilder).buildReceiver(0xc00091f560, 0x3f1bd68, 0xc00019a000, 0xc0003a9c20, 0x3a194b8, 0x7, 0x3a39a38, 0x17, 0x3e6d570, 0x14, ...)
	go.opentelemetry.io/collector/service/internal/builder/receivers_builder.go:261 +0x2a5
go.opentelemetry.io/collector/service/internal/builder.BuildReceivers(0xc0003a8960, 0x3a194b8, 0x7, 0x3a39a38, 0x17, 0x3e6d570, 0x14, 0x3e682d0, 0x8, 0xc0000decc0, ...)
	go.opentelemetry.io/collector/service/internal/builder/receivers_builder.go:102 +0x486
go.opentelemetry.io/collector/service.(*service).buildPipelines(0xc0002888c0, 0x0, 0x0)
	go.opentelemetry.io/collector/service/service.go:191 +0x354
go.opentelemetry.io/collector/service.newService(0xc00091f848, 0x3a3df68, 0x19, 0x0)
	go.opentelemetry.io/collector/service/service.go:78 +0x205
go.opentelemetry.io/collector/service.(*Application).setupConfigurationComponents(0xc0007c7970, 0x3f1bd68, 0xc00019a000, 0x0, 0x0)
	go.opentelemetry.io/collector/service/application.go:242 +0x370
go.opentelemetry.io/collector/service.(*Application).execute(0xc0007c7970, 0x3f1bd68, 0xc00019a000, 0xc0003a8960, 0x0)
	go.opentelemetry.io/collector/service/application.go:299 +0x471
go.opentelemetry.io/collector/service.New.func1(0xc0004b6000, 0xc0008e2b60, 0x0, 0x2, 0x0, 0x0)
	go.opentelemetry.io/collector/service/application.go:118 +0x11a
github.com/spf13/cobra.(*Command).execute(0xc0004b6000, 0xc000180040, 0x2, 0x2, 0xc0004b6000, 0xc000180040)
	github.com/spf13/cobra@v1.1.3/command.go:852 +0x472
github.com/spf13/cobra.(*Command).ExecuteC(0xc0004b6000, 0xc0008e4a50, 0xc0008e48d0, 0xc0008e4420)
	github.com/spf13/cobra@v1.1.3/command.go:960 +0x375
github.com/spf13/cobra.(*Command).Execute(...)
	github.com/spf13/cobra@v1.1.3/command.go:897
go.opentelemetry.io/collector/service.(*Application).Run(...)
	go.opentelemetry.io/collector/service/application.go:157
main.runInteractive(0xc0008e4600, 0xc0008e4a50, 0xc0008e48d0, 0xc0008e4420, 0x3a194b8, 0x7, 0x3a39a38, 0x17, 0x3e6d570, 0x14, ...)
	go.opentelemetry.io/collector/cmd/otelcol/main.go:53 +0x12b
main.run(...)
	go.opentelemetry.io/collector/cmd/otelcol/main_others.go:22
main.main()
	go.opentelemetry.io/collector/cmd/otelcol/main.go:42 +0x258
```