### PR TITLE
Remove BuildInfo used only in two places

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,10 +33,7 @@ GIT_SHA=$(shell git rev-parse --short HEAD)
 BUILD_X1=-X $(BUILD_INFO_IMPORT_PATH).GitHash=$(GIT_SHA)
 VERSION=$(shell git describe --match "v[0-9]*" HEAD)
 BUILD_X2=-X $(BUILD_INFO_IMPORT_PATH).Version=$(VERSION)
-# BUILD_TYPE should be one of (dev, release).
-BUILD_TYPE?=release
-BUILD_X3=-X $(BUILD_INFO_IMPORT_PATH).BuildType=$(BUILD_TYPE)
-BUILD_INFO=-ldflags "${BUILD_X1} ${BUILD_X2} ${BUILD_X3}"
+BUILD_INFO=-ldflags "${BUILD_X1} ${BUILD_X2}"
 
 RUN_CONFIG?=examples/local/otel-config.yaml
 

--- a/internal/collector/telemetry/telemetry.go
+++ b/internal/collector/telemetry/telemetry.go
@@ -17,8 +17,6 @@ package telemetry
 
 import (
 	"flag"
-
-	"go.opentelemetry.io/collector/internal/version"
 )
 
 const (
@@ -56,10 +54,6 @@ func Flags(flags *flag.FlagSet) {
 // GetMetricsAddrDefault returns the default metrics bind address and port depending on
 // the current build type.
 func GetMetricsAddrDefault() string {
-	if version.IsDevBuild() {
-		// Listen on localhost by default for dev builds to avoid security prompts.
-		return "localhost:8888"
-	}
 	return ":8888"
 }
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -21,20 +21,12 @@ import (
 	"time"
 )
 
-const (
-	buildDev     = "dev"
-	buildRelease = "release"
-)
-
 var (
 	// Version variable will be replaced at link time after `make` has been run.
 	Version = "latest"
 
 	// GitHash variable will be replaced at link time after `make` has been run.
 	GitHash = "<NOT PROPERLY GENERATED>"
-
-	// BuildType should be one of (dev, release).
-	BuildType = buildDev
 
 	// startTime
 	startTime time.Time
@@ -44,21 +36,10 @@ func init() {
 	startTime = time.Now()
 }
 
-// IsDevBuild returns true if this is a development (local) build.
-func IsDevBuild() bool {
-	return BuildType == buildDev
-}
-
-// IsReleaseBuild returns true if this is a release build.
-func IsReleaseBuild() bool {
-	return BuildType == buildRelease
-}
-
 // InfoVar is a singleton instance of the Info struct.
 var InfoVar = Info{
 	{"Version", Version},
 	{"GitHash", GitHash},
-	{"BuildType", BuildType},
 	{"GoVersion", runtime.Version()},
 	{"OS", runtime.GOOS},
 	{"Architecture", runtime.GOARCH},


### PR DESCRIPTION
* For logger profile use flag "log-profile"
* For telemetry address this is not a breaking change

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
