### PR TITLE
Upgrade to Go1.16

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 executors:
   golang:
     docker:
-      - image: cimg/go:1.15
+      - image: cimg/go:1.16
 
 commands:
   verify_dist_files_exist:
@@ -310,7 +310,7 @@ jobs:
 
   publish-check:
     docker:
-      - image: cimg/go:1.15
+      - image: cimg/go:1.16
     steps:
       - attach_to_workspace
       - setup_remote_docker
@@ -326,7 +326,7 @@ jobs:
 
   publish-stable:
     docker:
-      - image: cimg/go:1.15
+      - image: cimg/go:1.16
     steps:
       - attach_to_workspace
       - verify_dist_files_exist
@@ -347,7 +347,7 @@ jobs:
 
   publish-dev:
     docker:
-      - image: cimg/go:1.15
+      - image: cimg/go:1.16
     steps:
       - attach_to_workspace
       - verify_dist_files_exist

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2.1.3
         with:
-          go-version: 1.15
+          go-version: 1.16
       - name: Setup Go Environment
         run: |
           echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
@@ -48,7 +48,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2.1.3
         with:
-          go-version: 1.15
+          go-version: 1.16
       - name: Setup Go Environment
         run: |
           echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
@@ -91,7 +91,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2.1.3
         with:
-          go-version: 1.15
+          go-version: 1.16
       - name: Setup Go Environment
         run: |
           echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
@@ -133,7 +133,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2.1.3
         with:
-          go-version: 1.15
+          go-version: 1.16
       - name: Setup Go Environment
         run: |
           echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
@@ -177,7 +177,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2.1.3
         with:
-          go-version: 1.15
+          go-version: 1.16
       - name: Setup Go Environment
         run: |
           echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
@@ -221,7 +221,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2.1.3
         with:
-          go-version: 1.15
+          go-version: 1.16
       - name: Setup Go Environment
         run: |
           echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
@@ -273,7 +273,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2.1.3
         with:
-          go-version: 1.15
+          go-version: 1.16
       - name: Setup Go Environment
         run: |
           echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
@@ -317,7 +317,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2.1.3
         with:
-          go-version: 1.15
+          go-version: 1.16
       - name: Setup Go Environment
         run: |
           echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
@@ -373,7 +373,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2.1.3
         with:
-          go-version: 1.15
+          go-version: 1.16
       - name: Setup Go Environment
         run: |
           echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
@@ -408,7 +408,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2.1.3
         with:
-          go-version: 1.15
+          go-version: 1.16
       - name: Setup Go Environment
         run: |
           echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
@@ -468,7 +468,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2.1.3
         with:
-          go-version: 1.15
+          go-version: 1.16
       - name: Setup Go Environment
         run: |
           echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV

--- a/.github/workflows/contrib-tests.yml
+++ b/.github/workflows/contrib-tests.yml
@@ -10,7 +10,7 @@ jobs:
   contrib_tests:
     runs-on: ubuntu-latest
     container:
-      image: cimg/go:1.15
+      image: cimg/go:1.16
     steps:
       - name: Setup Permissions
         run: sudo chmod -R 777 $GITHUB_WORKSPACE /github /__w/_temp

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,7 +107,7 @@ section of general project contributing guide.
 Working with the project sources requires the following tools:
 
 1. [git](https://git-scm.com/)
-2. [go](https://golang.org/) (version 1.15 and up)
+2. [go](https://golang.org/) (version 1.16 and up)
 3. [make](https://www.gnu.org/software/make/)
 4. [docker](https://www.docker.com/)
 

--- a/cmd/checkdoc/go.mod
+++ b/cmd/checkdoc/go.mod
@@ -1,5 +1,5 @@
 module go.opentelemetry.io/collector/cmd/checkdoc
 
-go 1.15
+go 1.16
 
 require github.com/stretchr/testify v1.7.0

--- a/cmd/issuegenerator/go.mod
+++ b/cmd/issuegenerator/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/cmd/issuegenerator
 
-go 1.15
+go 1.16
 
 require (
 	github.com/google/go-github v17.0.0+incompatible

--- a/cmd/mdatagen/go.mod
+++ b/cmd/mdatagen/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/cmd/mdatagen
 
-go 1.15
+go 1.16
 
 require (
 	github.com/go-playground/locales v0.13.0

--- a/examples/demo/app/go.mod
+++ b/examples/demo/app/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/examples/demo/app
 
-go 1.15
+go 1.16
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector
 
-go 1.15
+go 1.16
 
 require (
 	contrib.go.opencensus.io/exporter/prometheus v0.3.0

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/internal/tools
 
-go 1.15
+go 1.16
 
 require (
 	github.com/client9/misspell v0.3.4


### PR DESCRIPTION

**Description:** 

Updated CI and makefile to use Go 1.16.

In 1.16, `go install` accepts versions so the tools trick to pin tool versions is not required anymore.