### PR TITLE
Disable codecov until the script is audited

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -304,9 +304,10 @@ jobs:
       - run:
           name: Coverage tests
           command: make gotest-with-cover
-      - run:
-          name: Code coverage
-          command: bash <(curl -s https://codecov.io/bash)
+# DISABLE CODECOV UNTIL THE SCRIPT IS AUDITED AND WE ARE CERTAIN IT IS OK TO TO EXECUTE IT.
+#      - run:
+#          name: Code coverage
+#          command: bash <(curl -s https://codecov.io/bash)
 
   publish-check:
     docker:


### PR DESCRIPTION
I am disabling until an audit is done and we are certain there
is nothing wrong with it.

We should decide how we prevent this from happening in the future.
