### PR TITLE
Fix godoc wording and inconsistencies

### DIFF
--- a/component/component.go
+++ b/component/component.go
@@ -20,18 +20,18 @@ import (
 	"go.opentelemetry.io/collector/config"
 )
 
-// Component is either a receiver, exporter, processor or extension.
+// Component is either a receiver, exporter, processor or an extension.
+//
+// A component's lifecycle has the following phases:
+//
+//   1. Creation: The component is create using the factory, via a Create* call.
+//   2. Start: The component's Start method is called.
+//   3. Running: The component is up and running.
+//   4. Shutdown: The component's Shutdown method is called and the lifecycle is complete.
+//
+// Once the lifecycle is complete it may be repeated, in which case a new component
+// is created, starts, runs and is shutdown again.
 type Component interface {
-	// Components lifecycle goes through the following phases:
-	//
-	// 1. Creation. The component is created using the factory, via Create* call.
-	// 2. Start. The component's Start() method is called.
-	// 3. Running. The component is up and running.
-	// 4. Shutdown. The component's Shutdown() method is called, the lifecycle is complete.
-	//
-	// Once the lifecycle is complete it may be repeated, in which case a new component
-	// is created and goes through the lifecycle.
-
 	// Start tells the component to start. Host parameter can be used for communicating
 	// with the host after Start() has already returned. If error is returned by
 	// Start() then the collector startup will be aborted.
@@ -60,7 +60,7 @@ type Component interface {
 	Shutdown(ctx context.Context) error
 }
 
-// Kind specified one of the 4 components kinds, see consts below.
+// Kind represents component kinds.
 type Kind int
 
 const (
@@ -71,7 +71,7 @@ const (
 	KindExtension
 )
 
-// Factory interface must be implemented by all component factories.
+// Factory is implemented by all component factories.
 type Factory interface {
 	// Type gets the type of the component created by this factory.
 	Type() config.Type

--- a/component/exporter.go
+++ b/component/exporter.go
@@ -23,12 +23,12 @@ import (
 	"go.opentelemetry.io/collector/consumer"
 )
 
-// Exporter defines functions that all exporters must implement.
+// Exporter exports telemetry data from the collector to a destination.
 type Exporter interface {
 	Component
 }
 
-// TracesExporter is a Exporter that can consume traces.
+// TracesExporter is an Exporter that can consume traces.
 type TracesExporter interface {
 	Exporter
 	consumer.Traces
@@ -46,7 +46,7 @@ type LogsExporter interface {
 	consumer.Logs
 }
 
-// ExporterCreateParams is passed to Create*Exporter functions.
+// ExporterCreateParams configures Exporter creators.
 type ExporterCreateParams struct {
 	// Logger that the factory can use during creation and can pass to the created
 	// component to be used later as well.
@@ -56,8 +56,8 @@ type ExporterCreateParams struct {
 	ApplicationStartInfo ApplicationStartInfo
 }
 
-// ExporterFactory can create TracesExporter and MetricsExporter. This is the
-// new factory type that can create new style exporters.
+// ExporterFactory can create MetricsExporter, TracesExporter and
+// LogsExporter. This is the new preferred factory type to create exporters.
 type ExporterFactory interface {
 	Factory
 
@@ -73,27 +73,18 @@ type ExporterFactory interface {
 	// CreateTracesExporter creates a trace exporter based on this config.
 	// If the exporter type does not support tracing or if the config is not valid
 	// error will be returned instead.
-	CreateTracesExporter(
-		ctx context.Context,
-		params ExporterCreateParams,
-		cfg config.Exporter,
-	) (TracesExporter, error)
+	CreateTracesExporter(ctx context.Context, params ExporterCreateParams,
+		cfg config.Exporter) (TracesExporter, error)
 
 	// CreateMetricsExporter creates a metrics exporter based on this config.
 	// If the exporter type does not support metrics or if the config is not valid
 	// error will be returned instead.
-	CreateMetricsExporter(
-		ctx context.Context,
-		params ExporterCreateParams,
-		cfg config.Exporter,
-	) (MetricsExporter, error)
+	CreateMetricsExporter(ctx context.Context, params ExporterCreateParams,
+		cfg config.Exporter) (MetricsExporter, error)
 
 	// CreateLogsExporter creates an exporter based on the config.
 	// If the exporter type does not support logs or if the config is not valid
 	// error will be returned instead.
-	CreateLogsExporter(
-		ctx context.Context,
-		params ExporterCreateParams,
-		cfg config.Exporter,
-	) (LogsExporter, error)
+	CreateLogsExporter(ctx context.Context, params ExporterCreateParams,
+		cfg config.Exporter) (LogsExporter, error)
 }

--- a/component/receiver.go
+++ b/component/receiver.go
@@ -37,7 +37,7 @@ type TracesReceiver interface {
 	Receiver
 }
 
-// A MetricsReceiver recieves metrics.
+// A MetricsReceiver receives metrics.
 // Its purpose is to translate data from any format to the collector's internal metrics format.
 // MetricsReceiver feeds a consumer.Metrics with data.
 //

--- a/component/receiver.go
+++ b/component/receiver.go
@@ -23,13 +23,13 @@ import (
 	"go.opentelemetry.io/collector/consumer"
 )
 
-// Receiver defines functions that trace and metric receivers must implement.
+// Receiver allows the collector to recieve metrics, traces and logs.
 type Receiver interface {
 	Component
 }
 
-// A TracesReceiver is an "arbitrary data"-to-"internal format" converter.
-// Its purpose is to translate data from the wild into internal trace format.
+// A TracesReceiver recieves traces.
+// Its purpose is to translate data from any format to the collector's internal trace format.
 // TracesReceiver feeds a consumer.Traces with data.
 //
 // For example it could be Zipkin data source which translates Zipkin spans into pdata.Traces.
@@ -37,8 +37,8 @@ type TracesReceiver interface {
 	Receiver
 }
 
-// A MetricsReceiver is an "arbitrary data"-to-"internal format" converter.
-// Its purpose is to translate data from the wild into internal metrics format.
+// A MetricsReceiver recieves metrics.
+// Its purpose is to translate data from any format to the collector's internal metrics format.
 // MetricsReceiver feeds a consumer.Metrics with data.
 //
 // For example it could be Prometheus data source which translates Prometheus metrics into pdata.Metrics.
@@ -46,14 +46,16 @@ type MetricsReceiver interface {
 	Receiver
 }
 
-// A LogsReceiver is a "log data"-to-"internal format" converter.
-// Its purpose is to translate data from the wild into internal data format.
+// A LogsReceiver recieves logs.
+// Its purpose is to translate data from any format to the collector's internal logs data format.
 // LogsReceiver feeds a consumer.Logs with data.
+//
+// For example a LogsReceiver can read syslogs and convert them into pdata.Logs.
 type LogsReceiver interface {
 	Receiver
 }
 
-// ReceiverCreateParams is passed to ReceiverFactory.Create* functions.
+// ReceiverCreateParams configures Receiver creators.
 type ReceiverCreateParams struct {
 	// Logger that the factory can use during creation and can pass to the created
 	// component to be used later as well.
@@ -64,7 +66,7 @@ type ReceiverCreateParams struct {
 }
 
 // ReceiverFactory can create TracesReceiver and MetricsReceiver. This is the
-// new factory type that can create new style receivers.
+// new preferred factory type to create receivers.
 type ReceiverFactory interface {
 	Factory
 

--- a/component/receiver.go
+++ b/component/receiver.go
@@ -46,7 +46,7 @@ type MetricsReceiver interface {
 	Receiver
 }
 
-// A LogsReceiver recieves logs.
+// A LogsReceiver receives logs.
 // Its purpose is to translate data from any format to the collector's internal logs data format.
 // LogsReceiver feeds a consumer.Logs with data.
 //

--- a/component/receiver.go
+++ b/component/receiver.go
@@ -28,7 +28,7 @@ type Receiver interface {
 	Component
 }
 
-// A TracesReceiver recieves traces.
+// A TracesReceiver receives traces.
 // Its purpose is to translate data from any format to the collector's internal trace format.
 // TracesReceiver feeds a consumer.Traces with data.
 //

--- a/component/receiver.go
+++ b/component/receiver.go
@@ -23,7 +23,7 @@ import (
 	"go.opentelemetry.io/collector/consumer"
 )
 
-// Receiver allows the collector to recieve metrics, traces and logs.
+// Receiver allows the collector to receive metrics, traces and logs.
 type Receiver interface {
 	Component
 }


### PR DESCRIPTION
1. Move the component lifecycle to interface godoc so the godoc can render it
2. Avoid using below/above, godoc already groups things correctly.
3. Avoid giving references to what functions/methods implement what. Instead, mention what they do.
4. Fix inconsistencies in new lines for long lines.

Related to #3049.