### PR TITLE
exporter/prometheusremotewrite: add a Write-Ahead-Log

### DIFF
--- a/exporter/prometheusremotewriteexporter/README.md
+++ b/exporter/prometheusremotewriteexporter/README.md
@@ -46,6 +46,10 @@ Example:
 exporters:
   prometheusremotewrite:
     endpoint: "http://some.url:9411/api/prom/push"
+    wal: # Enabling the Write-Ahead-Log for the exporter
+        directory: "DIRECTORY_HERE"
+        truncate_frequency: "Optional Frequency to determine how often the WAL should be truncated; it is a time.ParseDuration https://golang.org/pkg/time/#ParseDuration; default of 1m"
+        cache_size: "An optional number of elements to be held in the WAL before truncating; default of 300"
 ```
 
 ## Advanced Configuration

--- a/exporter/prometheusremotewriteexporter/config.go
+++ b/exporter/prometheusremotewriteexporter/config.go
@@ -36,6 +36,7 @@ type Config struct {
 	// QueueConfig allows users to fine tune the queues
 	// that handle outgoing requests.
 	RemoteWriteQueue RemoteWriteQueue `mapstructure:"remote_write_queue"`
+	WALConfig        *walConfig       `mapstructure:"wal"`
 
 	// ExternalLabels defines a map of label keys and values that are allowed to start with reserved prefix "__"
 	ExternalLabels map[string]string `mapstructure:"external_labels"`

--- a/exporter/prometheusremotewriteexporter/config.go
+++ b/exporter/prometheusremotewriteexporter/config.go
@@ -36,7 +36,12 @@ type Config struct {
 	// QueueConfig allows users to fine tune the queues
 	// that handle outgoing requests.
 	RemoteWriteQueue RemoteWriteQueue `mapstructure:"remote_write_queue"`
-	WALConfig        *walConfig       `mapstructure:"wal"`
+
+	// WALConfig creates a Write-Ahead-Log to which translated OTLP->PrometheusProto requests
+	// will be persisted until they are read during exporting. This ensures that
+	// sudden shutdown won't lose data, and that we can recover on restart and continue
+	// exporting the previously saved data.
+	WALConfig *walConfig `mapstructure:"wal"`
 
 	// ExternalLabels defines a map of label keys and values that are allowed to start with reserved prefix "__"
 	ExternalLabels map[string]string `mapstructure:"external_labels"`

--- a/exporter/prometheusremotewriteexporter/exporter.go
+++ b/exporter/prometheusremotewriteexporter/exporter.go
@@ -78,7 +78,7 @@ func NewPrwExporter(namespace string, endpoint string, client *http.Client, exte
 	}
 
 	userAgentHeader := fmt.Sprintf("%s/%s", strings.ReplaceAll(strings.ToLower(buildInfo.Description), " ", "-"), buildInfo.Version)
-	prwe := &PrwExporter{
+	return &PrwExporter{
 		namespace:       namespace,
 		externalLabels:  sanitizedLabels,
 		endpointURL:     endpointURL,
@@ -88,12 +88,7 @@ func NewPrwExporter(namespace string, endpoint string, client *http.Client, exte
 		walConfig:       walCfg,
 		userAgentHeader: userAgentHeader,
 		concurrency:     concurrency,
-	}
-
-	if err := prwe.turnOnWALIfEnabled(); err != nil {
-		return nil, err
-	}
-	return prwe, nil
+	}, nil
 }
 
 var errAlreadyClosed = errors.New("already closed")
@@ -109,6 +104,11 @@ func (prwe *PrwExporter) Shutdown(context.Context) error {
 	prwe.wg.Wait()
 	prwe.closeWAL()
 	return nil
+}
+
+// Start turns on the Write-Ahead-Log (WAL).
+func (prwe *PrwExporter) Start(ctx context.Context, host component.Host) error {
+	return prwe.turnOnWALIfEnabled()
 }
 
 // PushMetrics converts metrics to Prometheus remote write TimeSeries and send to remote endpoint. It maintain a map of

--- a/exporter/prometheusremotewriteexporter/exporter_test.go
+++ b/exporter/prometheusremotewriteexporter/exporter_test.go
@@ -123,7 +123,7 @@ func Test_NewPrwExporter(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			prwe, err := NewPrwExporter(tt.namespace, tt.endpoint, tt.client, tt.externalLabels, 1, tt.buildInfo)
+			prwe, err := NewPrwExporter(tt.namespace, tt.endpoint, tt.client, tt.externalLabels, 1, tt.buildInfo, nil)
 			if tt.returnError {
 				assert.Error(t, err)
 				return
@@ -244,6 +244,7 @@ func Test_export(t *testing.T) {
 			}
 			errs := runExportPipeline(ts1, serverURL)
 			if tt.returnError {
+				require.NotZero(t, len(errs))
 				assert.Error(t, errs[0])
 				return
 			}
@@ -266,7 +267,7 @@ func runExportPipeline(ts *prompb.TimeSeries, endpoint *url.URL) []error {
 		Version:     "1.0",
 	}
 	// after this, instantiate a CortexExporter with the current HTTP client and endpoint set to passed in endpoint
-	prwe, err := NewPrwExporter("test", endpoint.String(), HTTPClient, map[string]string{}, 1, buildInfo)
+	prwe, err := NewPrwExporter("test", endpoint.String(), HTTPClient, map[string]string{}, 1, buildInfo, nil)
 	if err != nil {
 		errs = append(errs, err)
 		return errs
@@ -521,7 +522,7 @@ func Test_PushMetrics(t *testing.T) {
 				Description: "OpenTelemetry Collector",
 				Version:     "1.0",
 			}
-			prwe, nErr := NewPrwExporter(config.Namespace, serverURL.String(), c, map[string]string{}, 5, buildInfo)
+			prwe, nErr := NewPrwExporter(config.Namespace, serverURL.String(), c, map[string]string{}, 5, buildInfo, nil)
 			require.NoError(t, nErr)
 			err := prwe.PushMetrics(context.Background(), *tt.md)
 			if tt.returnErr {

--- a/exporter/prometheusremotewriteexporter/factory.go
+++ b/exporter/prometheusremotewriteexporter/factory.go
@@ -56,6 +56,7 @@ func createMetricsExporter(_ context.Context, params component.ExporterCreatePar
 		client, prwCfg.ExternalLabels,
 		prwCfg.RemoteWriteQueue.NumConsumers,
 		params.BuildInfo,
+		prwCfg.WALConfig,
 	)
 	if err != nil {
 		return nil, err

--- a/exporter/prometheusremotewriteexporter/wal.go
+++ b/exporter/prometheusremotewriteexporter/wal.go
@@ -1,0 +1,246 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package prometheusremotewriteexporter
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"time"
+
+	"github.com/gogo/protobuf/proto"
+	"github.com/prometheus/prometheus/prompb"
+	"github.com/tidwall/wal"
+
+	"go.opentelemetry.io/collector/consumer/consumererror"
+)
+
+type walConfig struct {
+	// Note: These variable names mirror what Prometheus' WAL uses for field names per
+	// https://docs.google.com/document/d/1cCcoFgjDFwU2n823tKuMvrIhzHty4UDyn0IcfUHiyyI/edit#heading=h.mlf37ibqjgov
+	// except that we are using underscores "_" instead of dashes "-".
+	Dir               string        `mapstructure:"directory"`
+	NBeforeTruncation int           `mapstructure:"cache_size"`
+	RefreshDuration   time.Duration `mapstructure:"truncate_frequency"`
+}
+
+func (wc *walConfig) createWAL() (*wal.Log, error) {
+	if wc == nil {
+		// There are cases for which the WAL can be disabled.
+		// TODO: Perhaps log that the WAL wasn't enabled.
+		return nil, nil
+	}
+	wal, err := wal.Open(filepath.Join(wc.Dir, "prom_rw"), &wal.Options{
+		SegmentCacheSize: wc.nBeforeTruncation(),
+		NoCopy:           true,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("prometheusremotewriteexporter: failed to open WAL: %w", err)
+	}
+	return wal, nil
+}
+
+func (wc *walConfig) nBeforeTruncation() int {
+	if wc == nil {
+		return 0
+	}
+	if wc.NBeforeTruncation <= 0 {
+		return 300
+	}
+	return wc.NBeforeTruncation
+}
+
+func (wc *walConfig) refreshDuration() time.Duration {
+	if wc == nil {
+		return 0
+	}
+	if wc.RefreshDuration <= 0 {
+		// Following what Prometheus's WAL defaults.
+		return 1 * time.Minute
+	}
+	return wc.RefreshDuration
+}
+
+func (prwe *PrwExporter) walEnabled() bool { return prwe.walConfig != nil }
+
+var errWALDisabled = errors.New("WAL is disabled")
+
+func (prwe *PrwExporter) retrieveWALIndices(context.Context) (err error) {
+	if !prwe.walEnabled() {
+		return errWALDisabled
+	}
+
+	prwe.walMu.Lock()
+	defer prwe.walMu.Unlock()
+
+	wal, err := prwe.walConfig.createWAL()
+	if err != nil {
+		return err
+	}
+	prwe.wal = wal
+
+	prwe.rWALIndex, err = prwe.wal.FirstIndex()
+	if err != nil {
+		return fmt.Errorf("prometheusremotewriteexporter: failed to retrieve the last WAL index: %w", err)
+	}
+	prwe.wWALIndex, err = prwe.wal.LastIndex()
+	if err != nil {
+		return fmt.Errorf("prometheusremotewriteexporter: failed to retrieve the first WAL index: %w", err)
+	}
+	return nil
+}
+
+// exportThenTruncateWAL uploads the serialized data to the remote write endpoint,
+// and then truncates and retrieves the new indices for the WAL.
+func (prwe *PrwExporter) exportThenTruncateWAL(ctx context.Context, reqL []*prompb.WriteRequest) error {
+	if len(reqL) == 0 {
+		return nil
+	}
+	// Otherwise, time to flush.
+	if errs := prwe.exportWriteRequests(ctx, reqL); len(errs) != 0 {
+		return consumererror.Combine(errs)
+	}
+	// Save all the entries that aren't yet committed, to the tail of the WAL.
+	if err := prwe.wal.Sync(); err != nil {
+		return err
+	}
+	// Truncate the WAL from the front for the entries that we already
+	// read from the WAL and then exported.
+	if err := prwe.wal.TruncateFront(prwe.rWALIndex); err != nil && err != wal.ErrOutOfRange {
+		return err
+	}
+	// Reset by retrieving the respective read and write WAL indices.
+	return prwe.retrieveWALIndices(ctx)
+}
+
+func (prwe *PrwExporter) turnOnWALIfEnabled() error {
+	if !prwe.walEnabled() {
+		return nil
+	}
+
+	// From this point down below, the Write-Ahead-Log is enabled.
+	shutdownCtx, cancel := context.WithCancel(context.Background())
+	if err := prwe.retrieveWALIndices(shutdownCtx); err != nil {
+		cancel()
+		return err
+	}
+
+	go func() {
+		<-prwe.closeChan
+		cancel()
+	}()
+
+	prwe.wg.Add(1)
+	go func() {
+		defer prwe.wg.Done()
+
+		_ = prwe.readFromWALThenExport(shutdownCtx)
+	}()
+
+	return nil
+}
+
+func (prwe *PrwExporter) closeWAL() {
+	prwe.walMu.Lock()
+	defer prwe.walMu.Unlock()
+
+	if prwe.wal != nil {
+		prwe.wal.Close()
+		prwe.wal = nil
+	}
+}
+
+func (prwe *PrwExporter) writeToWAL(requests []*prompb.WriteRequest) error {
+	if !prwe.walEnabled() {
+		return errWALDisabled
+	}
+
+	// Write in batch.
+	batch := new(wal.Batch)
+	for _, req := range requests {
+		protoBlob, err := proto.Marshal(req)
+		if err != nil {
+			return err
+		}
+		prwe.wWALIndex++
+		batch.Write(prwe.wWALIndex, protoBlob)
+	}
+
+	return prwe.wal.WriteBatch(batch)
+}
+
+func (prwe *PrwExporter) readFromWALThenExport(ctx context.Context) error {
+	var reqL []*prompb.WriteRequest
+
+	defer func() {
+		// Keeping it within a closure to ensure that the later
+		// updated value of reqL is always flushed to disk.
+		prwe.exportThenTruncateWAL(ctx, reqL)
+	}()
+
+	freshTimer := func() *time.Timer {
+		return time.NewTimer(prwe.walConfig.refreshDuration())
+	}
+
+	timer := freshTimer()
+	maxCountPerUpload := prwe.walConfig.nBeforeTruncation()
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		protoBlob, err := prwe.wal.Read(prwe.rWALIndex)
+		if err == wal.ErrNotFound {
+			// Perhaps the WAL is not yet ready.
+			time.Sleep(1 * time.Second)
+			continue
+		}
+		if err != nil {
+			return err
+		}
+		req := new(prompb.WriteRequest)
+		if err := proto.Unmarshal(protoBlob, req); err != nil {
+			return err
+		}
+
+		reqL = append(reqL, req)
+		prwe.rWALIndex++
+
+		shouldExport := false
+
+		select {
+		case <-timer.C:
+			shouldExport = true
+			timer.Stop()
+			timer = freshTimer()
+		default:
+			shouldExport = len(reqL) >= maxCountPerUpload
+		}
+
+		if !shouldExport {
+			continue
+		}
+
+		// Otherwise, it is time to export, flush and then truncate the WAL!
+		if err := prwe.exportThenTruncateWAL(ctx, reqL); err != nil {
+			return err
+		}
+		// Reset but reuse the write requests slice.
+		reqL = reqL[:0]
+	}
+}

--- a/exporter/prometheusremotewriteexporter/wal_test.go
+++ b/exporter/prometheusremotewriteexporter/wal_test.go
@@ -104,8 +104,11 @@ wal:
 	prwe, err := NewPrwExporter("test_ns", prweServer.URL, prweServer.Client(), nil, 1, defaultBuildInfo, walConfig)
 	assert.Nil(t, err)
 	ctx := context.Background()
+	require.Nil(t, prwe.Start(ctx, nil))
 	defer prwe.Shutdown(ctx)
 	defer close(exiting)
+	require.Nil(t, prwe.Start(ctx, nil))
+	require.NotNil(t, prwe.wal)
 
 	assert.NotNil(t, prwe.wal)
 
@@ -171,7 +174,9 @@ wal:
 	// Read from that same WAL, export to the RWExporter server.
 	prwe2, err := NewPrwExporter("test_ns", prweServer.URL, prweServer.Client(), nil, 1, defaultBuildInfo, walConfig)
 	assert.Nil(t, err)
+	require.Nil(t, prwe2.Start(ctx, nil))
 	defer prwe2.Shutdown(ctx)
+	require.NotNil(t, prwe2.wal)
 
 	snappyEncodedBytes := <-uploadedBytesCh
 	decodeBuffer := make([]byte, len(snappyEncodedBytes))

--- a/exporter/prometheusremotewriteexporter/wal_test.go
+++ b/exporter/prometheusremotewriteexporter/wal_test.go
@@ -1,0 +1,218 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package prometheusremotewriteexporter
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gogo/protobuf/proto"
+	"github.com/golang/snappy"
+	"github.com/prometheus/prometheus/prompb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config"
+)
+
+func TestWALCreation_nilConfig(t *testing.T) {
+	config := (*walConfig)(nil)
+	wal, err := config.createWAL()
+	assert.Nil(t, wal)
+	assert.Nil(t, err)
+}
+
+func TestWALCreation_nonNilConfig(t *testing.T) {
+	config := &walConfig{Dir: t.TempDir()}
+	wal, err := config.createWAL()
+	assert.NotNil(t, wal)
+	assert.Nil(t, err)
+	wal.Close()
+}
+
+var defaultBuildInfo = component.BuildInfo{
+	Description: "OpenTelemetry Collector",
+	Version:     "1.0",
+}
+
+// Ensures that when we attach the Write-Ahead-Log(WAL) to the exporter,
+// that it successfully writes the serialized prompb.WriteRequests to the WAL,
+// and that we can retrieve those exact requests back from the WAL, when the
+// exporter starts up once again, that it picks up where it left off.
+func TestWALOnExporterRoundTrip(t *testing.T) {
+	if testing.Short() {
+		t.Skip("This could be a long running test")
+	}
+
+	// 1. Create the WAL configuration, create the
+	// exporter and export some time series!
+	tempDir := t.TempDir()
+	yamlConfig := fmt.Sprintf(`
+wal:
+    directory:           %s
+    truncate_frequency:  60us
+    cache_size:          1
+        `, tempDir)
+
+	parser, err := config.NewParserFromBuffer(strings.NewReader(yamlConfig))
+	require.Nil(t, err)
+
+	fullConfig := new(Config)
+	if err = parser.UnmarshalExact(fullConfig); err != nil {
+		t.Fatalf("Failed to parse config from YAML: %v", err)
+	}
+	walConfig := fullConfig.WALConfig
+	require.NotNil(t, walConfig)
+	require.Equal(t, walConfig.RefreshDuration, 60*time.Microsecond)
+	require.Equal(t, walConfig.Dir, tempDir)
+
+	// 1. Create a mock Prometheus Remote Write Exporter that'll just
+	// receive the bytes uploaded to it by our exporter.
+	uploadedBytesCh := make(chan []byte, 1)
+	exiting := make(chan bool)
+	prweServer := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		uploaded, err2 := ioutil.ReadAll(req.Body)
+		assert.Nil(t, err2, "Error while reading from HTTP upload")
+		select {
+		case uploadedBytesCh <- uploaded:
+		case <-exiting:
+			return
+		}
+	}))
+	defer prweServer.Close()
+
+	prwe, err := NewPrwExporter("test_ns", prweServer.URL, prweServer.Client(), nil, 1, defaultBuildInfo, walConfig)
+	assert.Nil(t, err)
+	ctx := context.Background()
+	defer prwe.Shutdown(ctx)
+	defer close(exiting)
+
+	assert.NotNil(t, prwe.wal)
+
+	ts1 := &prompb.TimeSeries{
+		Labels:  []prompb.Label{{Name: "ts1l1", Value: "ts1k1"}},
+		Samples: []prompb.Sample{{Value: 1, Timestamp: 100}},
+	}
+	ts2 := &prompb.TimeSeries{
+		Labels:  []prompb.Label{{Name: "ts2l1", Value: "ts2k1"}},
+		Samples: []prompb.Sample{{Value: 2, Timestamp: 200}},
+	}
+	tsMap := map[string]*prompb.TimeSeries{
+		"timeseries1": ts1,
+		"timeseries2": ts2,
+	}
+	errs := prwe.export(ctx, tsMap)
+	assert.Nil(t, errs)
+	// Shutdown after we've written to the WAL.
+	prwe.Shutdown(ctx)
+
+	// 2. Let's now read back all of the WAL records and ensure
+	// that all the prompb.WriteRequest values exist as we sent them.
+	wal, err := walConfig.createWAL()
+	assert.Nil(t, err)
+	assert.NotNil(t, wal)
+	defer wal.Close()
+
+	// Read all the indices.
+	firstIndex, err := wal.FirstIndex()
+	assert.Nil(t, err)
+	lastIndex, err := wal.LastIndex()
+	assert.Nil(t, err)
+
+	var reqs []*prompb.WriteRequest
+	for i := firstIndex; i <= lastIndex; i++ {
+		protoBlob, perr := wal.Read(i)
+		assert.Nil(t, perr)
+		assert.NotNil(t, protoBlob)
+		req := new(prompb.WriteRequest)
+		err = proto.Unmarshal(protoBlob, req)
+		assert.Nil(t, err)
+		reqs = append(reqs, req)
+	}
+	assert.Equal(t, 1, len(reqs))
+	// We MUST have 2 time series as were passed into tsMap.
+	gotFromWAL := reqs[0]
+	assert.Equal(t, 2, len(gotFromWAL.Timeseries))
+	want := &prompb.WriteRequest{
+		Timeseries: orderBySampleTimestamp([]prompb.TimeSeries{
+			*ts1, *ts2,
+		}),
+	}
+
+	// Even after sorting timeseries, we need to sort them
+	// also by Label to ensure deterministic ordering.
+	orderByLabelValue(gotFromWAL)
+	orderByLabelValue(want)
+
+	assert.Equal(t, want, gotFromWAL)
+
+	// 3. Finally, ensure that the bytes that were uploaded to the
+	// Prometheus Remote Write endpoint are exactly as were saved in the WAL.
+	// Read from that same WAL, export to the RWExporter server.
+	prwe2, err := NewPrwExporter("test_ns", prweServer.URL, prweServer.Client(), nil, 1, defaultBuildInfo, walConfig)
+	assert.Nil(t, err)
+	defer prwe2.Shutdown(ctx)
+
+	snappyEncodedBytes := <-uploadedBytesCh
+	decodeBuffer := make([]byte, len(snappyEncodedBytes))
+	uploadedBytes, err := snappy.Decode(decodeBuffer, snappyEncodedBytes)
+	require.Nil(t, err)
+	gotFromUpload := new(prompb.WriteRequest)
+	err = proto.Unmarshal(uploadedBytes, gotFromUpload)
+	assert.Nil(t, err)
+	gotFromUpload.Timeseries = orderBySampleTimestamp(gotFromUpload.Timeseries)
+	// Even after sorting timeseries, we need to sort them
+	// also by Label to ensure deterministic ordering.
+	orderByLabelValue(gotFromUpload)
+
+	// 4. Ensure that all the various combinations match up.
+	// To ensure a deterministic ordering, sort the TimeSeries by Label Name.
+	assert.Equal(t, want, gotFromUpload)
+	assert.Equal(t, gotFromWAL, gotFromUpload)
+}
+
+func orderByLabelValue(wreq *prompb.WriteRequest) {
+	// Sort the timeSeries by their labels.
+	type byLabelMessage struct {
+		label  *prompb.Label
+		sample *prompb.Sample
+	}
+
+	for _, timeSeries := range wreq.Timeseries {
+		bMsgs := make([]*byLabelMessage, 0, len(wreq.Timeseries)*10)
+		for i := range timeSeries.Labels {
+			bMsgs = append(bMsgs, &byLabelMessage{
+				label:  &timeSeries.Labels[i],
+				sample: &timeSeries.Samples[i],
+			})
+		}
+		sort.Slice(bMsgs, func(i, j int) bool {
+			return bMsgs[i].label.Value < bMsgs[j].label.Value
+		})
+
+		for i := range bMsgs {
+			timeSeries.Labels[i] = *bMsgs[i].label
+			timeSeries.Samples[i] = *bMsgs[i].sample
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/viper v1.7.1
 	github.com/stretchr/testify v1.7.0
+	github.com/tidwall/wal v0.1.4
 	github.com/tklauser/go-sysconf v0.3.5 // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible
 	github.com/xdg-go/scram v0.0.0-20180814205039-7eeb5667e42c

--- a/go.sum
+++ b/go.sum
@@ -974,7 +974,17 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
+github.com/tidwall/gjson v1.6.1 h1:LRbvNuNuvAiISWg6gxLEFuCe72UKy5hDqhxW/8183ws=
+github.com/tidwall/gjson v1.6.1/go.mod h1:BaHyNc5bjzYkPqgLq7mdVzeiRtULKULXLgZFKsxEHI0=
+github.com/tidwall/match v1.0.1 h1:PnKP62LPNxHKTwvHHZZzdOAOCtsJTjo6dZLCwpKm5xc=
+github.com/tidwall/match v1.0.1/go.mod h1:LujAq0jyVjBy028G1WhWfIzbpQfMO8bBZ6Tyb0+pL9E=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
+github.com/tidwall/pretty v1.0.2 h1:Z7S3cePv9Jwm1KwS0513MRaoUe3S01WPbLNV40pwWZU=
+github.com/tidwall/pretty v1.0.2/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
+github.com/tidwall/tinylru v1.0.2 h1:W4mp7iUz4cnVMqAvWy2zbzC35ASv5sqdyyEjoQKKBFg=
+github.com/tidwall/tinylru v1.0.2/go.mod h1:HDVL7TsWeezQ4g44Um84TOVBMFcq7Xa9giqNc805KJ8=
+github.com/tidwall/wal v0.1.4 h1:YDUbo2ShwiaGoEu74tC2oQlQFj4iDw+iA9qkkanSKC4=
+github.com/tidwall/wal v0.1.4/go.mod h1:ww7Pd44/KnyETODJPUPKrzLlYjI72GZWlucNKt7pOt0=
 github.com/tinylib/msgp v1.0.2/go.mod h1:+d+yLhGm8mzTaHzB+wgMYrodPfmZrzkirds8fDWklFE=
 github.com/tklauser/go-sysconf v0.3.5 h1:uu3Xl4nkLzQfXNsWn15rPc/HQCJKObbt1dKJeWp3vU4=
 github.com/tklauser/go-sysconf v0.3.5/go.mod h1:MkWzOF4RMCshBAMXuhXJs64Rte09mITnppBXY/rYEFI=


### PR DESCRIPTION
Uses an off the shelf WAL implementation to add capabilities
to the Prometheus remote exporter using github.com/tidwall/wal.

By default the WAL will be on and to configure the WAL location,
please use this prometheusremotewrite exporter YAML configuration:

```yaml
exporters:
  prometheusremotewrite:
    endpoint: "http://some.url:9411/api/prom/push"
    wal:
        directory: ./waldir/wal_directory
        truncate_frequency: 200s
        cache_size: 300
```

whose fields are quite similar to Prometheus' WAL fields per https://docs.google.com/document/d/1cCcoFgjDFwU2n823tKuMvrIhzHty4UDyn0IcfUHiyyI/edit#heading=h.mlf37ibqjgov

We are using an off-the-shelf WAL because:
By the time that we get OTLP metrics, we can convert to Prometheus proto,
but trying to implement the Prometheus storage interfaces would involve
either by-passing to-Prometheus-Proto and then save to Prometheus raw Go,
then retrieve Prometheus raw Go and then convert to Prometheus Proto.
It is much easier to get an off the shelf WAL implementation and add
it to the Prometheus implementation.

Fixes https://github.com/open-telemetry/wg-prometheus/issues/9