### PR TITLE
testbed: Compare ints in 10 base not in hex

### DIFF
--- a/testbed/testbed/validator.go
+++ b/testbed/testbed/validator.go
@@ -39,7 +39,9 @@ type TestCaseValidator interface {
 type PerfTestValidator struct{}
 
 func (v *PerfTestValidator) Validate(tc *TestCase) {
-	if assert.EqualValues(tc.t, tc.LoadGenerator.DataItemsSent(), tc.MockBackend.DataItemsReceived(),
+	if assert.EqualValues(tc.t,
+		int64(tc.LoadGenerator.DataItemsSent()),
+		int64(tc.MockBackend.DataItemsReceived()),
 		"Received and sent counters do not match.") {
 		log.Printf("Sent and received data matches.")
 	}
@@ -89,7 +91,9 @@ func NewCorrectTestValidator(senderName string, receiverName string, provider Da
 }
 
 func (v *CorrectnessTestValidator) Validate(tc *TestCase) {
-	if assert.EqualValues(tc.t, tc.LoadGenerator.DataItemsSent(), tc.MockBackend.DataItemsReceived(),
+	if assert.EqualValues(tc.t,
+		int64(tc.LoadGenerator.DataItemsSent()),
+		int64(tc.MockBackend.DataItemsReceived()),
 		"Received and sent counters do not match.") {
 		log.Printf("Sent and received data counters match.")
 	}


### PR DESCRIPTION
**Description:** Print more human readable 10 base integers instead of hexes when comparing testbed results.

Instead of

```
    validator.go:42:
                Error Trace:    validator.go:42
                                                        test_case.go:277
                                                        scenarios.go:190
                                                        log_test.go:159
                Error:          Not equal:
                                expected: 0x222e0
                                actual  : 0x210e8
                Test:           TestLog10kDPS/syslog-udp
                Messages:       Received and sent counters do not match.
```

print the following (more readable) output:

```
    validator.go:42:
                Error Trace:    validator.go:42
                                                        test_case.go:277
                                                        scenarios.go:190
                                                        log_test.go:159
                Error:          Not equal:
                                expected: 140000
                                actual  : 135400
                Test:           TestLog10kDPS/syslog-udp
                Messages:       Received and sent counters do not match.
```
