### PR TITLE
Add resource_to_telemetry_conversion config in prometheusremotewriteexp

### DIFF
--- a/exporter/prometheusremotewriteexporter/README.md
+++ b/exporter/prometheusremotewriteexporter/README.md
@@ -52,3 +52,4 @@ Several helper files are leveraged to provide additional capabilities automatica
 - [HTTP settings](https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/confighttp/README.md)
 - [TLS and mTLS settings](https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/configtls/README.md)
 - [Retry and timeout settings](https://github.com/open-telemetry/opentelemetry-collector/blob/main/exporter/exporterhelper/README.md), note that the exporter doesn't support `sending_queue`.
+- [Resource attributes to Metric labels](https://github.com/open-telemetry/opentelemetry-collector/blob/main/exporter/exporterhelper/README.md), 

--- a/exporter/prometheusremotewriteexporter/config.go
+++ b/exporter/prometheusremotewriteexporter/config.go
@@ -35,6 +35,11 @@ type Config struct {
 	ExternalLabels map[string]string `mapstructure:"external_labels"`
 
 	HTTPClientSettings confighttp.HTTPClientSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct.
+
+	// ResourceToTelemetrySettings is the option for converting resource attributes to telemetry attributes.
+	// "Enabled" - A boolean field to enable/disable this option. Default is `false`.
+	// If enabled, all the resource attributes will be converted to metric labels by default.
+	exporterhelper.ResourceToTelemetrySettings `mapstructure:"resource_to_telemetry_conversion"`
 }
 
 var _ config.Exporter = (*Config)(nil)

--- a/exporter/prometheusremotewriteexporter/config_test.go
+++ b/exporter/prometheusremotewriteexporter/config_test.go
@@ -83,5 +83,6 @@ func Test_loadConfig(t *testing.T) {
 					"prometheus-remote-write-version": "0.1.0",
 					"x-scope-orgid":                   "234"},
 			},
+			ResourceToTelemetrySettings: exporterhelper.ResourceToTelemetrySettings{Enabled: true},
 		})
 }

--- a/exporter/prometheusremotewriteexporter/factory.go
+++ b/exporter/prometheusremotewriteexporter/factory.go
@@ -74,6 +74,7 @@ func createMetricsExporter(_ context.Context, params component.ExporterCreatePar
 			// and allow users to modify the queue size.
 		}),
 		exporterhelper.WithRetry(prwCfg.RetrySettings),
+		exporterhelper.WithResourceToTelemetryConversion(prwCfg.ResourceToTelemetrySettings),
 		exporterhelper.WithShutdown(prwe.Shutdown),
 	)
 

--- a/exporter/prometheusremotewriteexporter/testdata/config.yaml
+++ b/exporter/prometheusremotewriteexporter/testdata/config.yaml
@@ -26,6 +26,8 @@ exporters:
         external_labels:
             key1: value1
             key2: value2
+        resource_to_telemetry_conversion:
+            enabled: true
 
 service:
     pipelines:


### PR DESCRIPTION
**Description:** 
Add `exporterhelper.ResourceToTelemetrySettings` support in `prometheusremotewriteexporter` config. It will allow both `prometheusremotewriteexporter` and `ampprometheusremotewriteexporter` be able to convert Resource attributes to Metric Labels for Prometheus metrics. 

```
    prometheusremotewrite:
        resource_to_telemetry_conversion:
            enabled: true
```

**Link to tracking Issue:** <Issue number if applicable>
https://github.com/aws-observability/aws-otel-collector/issues/472

**Testing:** 
`make all`


