### PR TITLE
Renamed ExeName to Command, added Description in start info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,10 @@
 - Rename `marshall` to `marshal` in all the occurrences (#2977)
 - Remove `componenterror.ErrAlreadyStarted` and `componenterror.ErrAlreadyStopped`, components should not protect against this, Service will start/stop once.
 - Rename `ApplicationStartInfo` to `BuildInfo`
+- Rename `ApplicationStartInfo.ExeName` to `BuildInfo.Command`
 
 ## 💡 Enhancements 💡
+ - Add `Description` to `BuildInfo`
 
 ## 🧰 Bug fixes 🧰
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,9 @@
 - Remove `componenterror.ErrAlreadyStarted` and `componenterror.ErrAlreadyStopped`, components should not protect against this, Service will start/stop once.
 - Rename `ApplicationStartInfo` to `BuildInfo`
 - Rename `ApplicationStartInfo.ExeName` to `BuildInfo.Command`
+- Rename `ApplicationStartInfo.LongName` to `BuildInfo.Description`
 
 ## 💡 Enhancements 💡
- - Add `Description` to `BuildInfo`
 
 ## 🧰 Bug fixes 🧰
 

--- a/cmd/otelcol/main.go
+++ b/cmd/otelcol/main.go
@@ -33,8 +33,9 @@ func main() {
 	}
 
 	info := component.BuildInfo{
-		ExeName: "otelcol",
-		Version: version.Version,
+		Command:     "otelcol",
+		Description: "OpenTelemetry Collector",
+		Version:     version.Version,
 	}
 
 	if err := run(service.Parameters{BuildInfo: info, Factories: factories}); err != nil {

--- a/component/build_info.go
+++ b/component/build_info.go
@@ -18,7 +18,10 @@ package component
 // passed into each component. This information can be overridden in custom builds.
 type BuildInfo struct {
 	// Executable file name, e.g. "otelcol".
-	ExeName string
+	Command string
+
+	// Full name of the collector, e.g. "OpenTelemetry Collector".
+	Description string
 
 	// Version string.
 	Version string
@@ -27,7 +30,8 @@ type BuildInfo struct {
 // DefaultBuildInfo returns the default BuildInfo.
 func DefaultBuildInfo() BuildInfo {
 	return BuildInfo{
-		ExeName: "otelcol",
-		Version: "latest",
+		Command:     "otelcol",
+		Description: "OpenTelemetry Collector",
+		Version:     "latest",
 	}
 }

--- a/service/application.go
+++ b/service/application.go
@@ -107,7 +107,7 @@ func New(params Parameters) (*Application, error) {
 	}
 
 	rootCmd := &cobra.Command{
-		Use:     params.BuildInfo.ExeName,
+		Use:     params.BuildInfo.Command,
 		Version: params.BuildInfo.Version,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
@@ -278,7 +278,7 @@ func (app *Application) setupConfigurationComponents(ctx context.Context) error 
 }
 
 func (app *Application) execute(ctx context.Context) error {
-	app.logger.Info("Starting "+app.info.ExeName+"...",
+	app.logger.Info("Starting "+app.info.Command+"...",
 		zap.String("Version", app.info.Version),
 		zap.Int("NumCPU", runtime.NumCPU()),
 	)

--- a/testbed/testbed/otelcol_runner.go
+++ b/testbed/testbed/otelcol_runner.go
@@ -86,7 +86,7 @@ func (ipp *InProcessCollector) PrepareConfig(configStr string) (configCleanup fu
 func (ipp *InProcessCollector) Start(args StartParams) error {
 	params := service.Parameters{
 		BuildInfo: component.BuildInfo{
-			ExeName: "otelcol",
+			Command: "otelcol",
 			Version: version.Version,
 		},
 		ParserProvider: parserprovider.NewInMemory(strings.NewReader(ipp.configStr)),


### PR DESCRIPTION
**Description:**
- Renamed ExeName to Command
- Added Description to store the full name of the collector