### PR TITLE
Bump memory limit for TestTraceNoBackend10kSPS/MemoryLimit

### DIFF
--- a/testbed/tests/trace_test.go
+++ b/testbed/tests/trace_test.go
@@ -155,7 +155,7 @@ func TestTraceNoBackend10kSPS(t *testing.T) {
 		{
 			Name:                "MemoryLimit",
 			Processor:           limitProcessors,
-			ExpectedMaxRAM:      70,
+			ExpectedMaxRAM:      80,
 			ExpectedMinFinalRAM: 40,
 		},
 	}


### PR DESCRIPTION
We are running very close to limit (e.g. 66MB in this run https://app.circleci.com/pipelines/github/open-telemetry/opentelemetry-collector/6834/workflows/146b061a-c3dc-4601-ac43-4a31c201c064/jobs/78320) and sometime exceed it and fail the build.

Bumping slightly to avoid failures. The limit is still low enough to ensure memory limiter work (the max is lower than the min without limiter).
