### PR TITLE
Don't require GOPATH for development

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,13 +116,13 @@ Working with the project sources requires the following tools:
 Fork the repo, checkout the upstream repo to your GOPATH by:
 
 ```
-$ GO111MODULE="" go get -d go.opentelemetry.io/collector
+$ git clone git@github.com:open-telemetry/opentelemetry-collector.git
 ```
 
 Add your fork as an origin:
 
 ```shell
-$ cd $(go env GOPATH)/src/go.opentelemetry.io/collector
+$ cd opentelemetry-collector
 $ git remote add fork git@github.com:YOUR_GITHUB_USERNAME/opentelemetry-collector.git
 ```
 


### PR DESCRIPTION
With modules, GOPATH is  not commonly used by Go developers anymore. Switch to the non-GOPATH instructions.
