### PR TITLE
Fix the memory blast example

### DIFF
--- a/extension/ballastextension/README.md
+++ b/extension/ballastextension/README.md
@@ -13,4 +13,5 @@ Example:
 ```yaml
 extensions:
   memory_ballast:
+    size_mib: 64
 ```


### PR DESCRIPTION
The current example is a disabled case, give a non-zero size to enable the memory ballast in the example.
