### PR TITLE
Remove test step that can't be cleaned-up

### DIFF
--- a/service/application_test.go
+++ b/service/application_test.go
@@ -149,9 +149,6 @@ func TestApplication_StartAsGoRoutine(t *testing.T) {
 	}
 	app, err := New(params)
 	require.NoError(t, err)
-	app.Command().SetArgs([]string{
-		"--metrics-level=NONE",
-	})
 
 	appDone := make(chan struct{})
 	go func() {


### PR DESCRIPTION
The test TestApplication_StartAsGoRoutine is setting the metric level to none but there is no way to reset the flag to its default. This breaks the tests if one tries to run the tests multiple times in the same `go test` command. Since the setting was not required by tests opting to remove it.
