### PR TITLE
Add Unwrap methods to consumer errors

### DIFF
--- a/consumer/consumererror/permanent.go
+++ b/consumer/consumererror/permanent.go
@@ -35,6 +35,11 @@ func (p permanent) Error() string {
 	return "Permanent error: " + p.err.Error()
 }
 
+// Unwrap returns the wrapped error for functions Is and As in standard package errors.
+func (p permanent) Unwrap() error {
+	return p.err
+}
+
 // IsPermanent checks if an error was wrapped with the Permanent function, that
 // is used to indicate that a given error will always be returned in the case
 // that its sources receives the same input.

--- a/consumer/consumererror/permanent_test.go
+++ b/consumer/consumererror/permanent_test.go
@@ -22,6 +22,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type testErrorType struct {
+	s string
+}
+
+func (t testErrorType) Error() string {
+	return ""
+}
+
 func TestPermanent(t *testing.T) {
 	err := errors.New("testError")
 	require.False(t, IsPermanent(err))
@@ -36,4 +44,21 @@ func TestPermanent(t *testing.T) {
 func TestIsPermanent_NilError(t *testing.T) {
 	var err error
 	require.False(t, IsPermanent(err))
+}
+
+func TestPermanent_Unwrap(t *testing.T) {
+	var err error = testErrorType{"testError"}
+	require.False(t, IsPermanent(err))
+
+	// Wrapping testErrorType err with permanent error.
+	permanentErr := Permanent(err)
+	require.True(t, IsPermanent(permanentErr))
+
+	target := testErrorType{}
+	require.NotEqual(t, err, target)
+
+	isTestErrorTypeWrapped := errors.As(permanentErr, &target)
+	require.True(t, isTestErrorTypeWrapped)
+
+	require.Equal(t, err, target)
 }

--- a/consumer/consumererror/signalerrors.go
+++ b/consumer/consumererror/signalerrors.go
@@ -49,6 +49,11 @@ func (err Traces) GetTraces() pdata.Traces {
 	return err.failed
 }
 
+// Unwrap returns the wrapped error for functions Is and As in standard package errors.
+func (err Traces) Unwrap() error {
+	return err.error
+}
+
 // Logs is an error that may carry associated Log data for a subset of received data
 // that failed to be processed or sent.
 type Logs struct {
@@ -78,6 +83,11 @@ func (err Logs) GetLogs() pdata.Logs {
 	return err.failed
 }
 
+// Unwrap returns the wrapped error for functions Is and As in standard package errors.
+func (err Logs) Unwrap() error {
+	return err.error
+}
+
 // Metrics is an error that may carry associated Metrics data for a subset of received data
 // that failed to be processed or sent.
 type Metrics struct {
@@ -105,4 +115,9 @@ func AsMetrics(err error, target *Metrics) bool {
 // GetMetrics returns failed metrics from the associated error.
 func (err Metrics) GetMetrics() pdata.Metrics {
 	return err.failed
+}
+
+// Unwrap returns the wrapped error for functions Is and As in standard package errors.
+func (err Metrics) Unwrap() error {
+	return err.error
 }

--- a/consumer/consumererror/signalerrors_test.go
+++ b/consumer/consumererror/signalerrors_test.go
@@ -15,10 +15,12 @@
 package consumererror
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/collector/internal/testdata"
 )
@@ -35,6 +37,18 @@ func TestTraces(t *testing.T) {
 	assert.Equal(t, td, target.GetTraces())
 }
 
+func TestTraces_Unwrap(t *testing.T) {
+	td := testdata.GenerateTraceDataOneSpan()
+	var err error = testErrorType{"some error"}
+	// Wrapping err with error Traces.
+	traceErr := NewTraces(err, td)
+	target := testErrorType{}
+	require.NotEqual(t, err, target)
+	// Unwrapping traceErr for err and assigning to target.
+	require.True(t, errors.As(traceErr, &target))
+	require.Equal(t, err, target)
+}
+
 func TestLogs(t *testing.T) {
 	td := testdata.GenerateLogDataOneLog()
 	err := fmt.Errorf("some error")
@@ -47,6 +61,18 @@ func TestLogs(t *testing.T) {
 	assert.Equal(t, td, target.GetLogs())
 }
 
+func TestLogs_Unwrap(t *testing.T) {
+	td := testdata.GenerateLogDataOneLog()
+	var err error = testErrorType{"some error"}
+	// Wrapping err with error Logs.
+	logsErr := NewLogs(err, td)
+	target := testErrorType{}
+	require.NotEqual(t, err, target)
+	// Unwrapping logsErr for err and assigning to target.
+	require.True(t, errors.As(logsErr, &target))
+	require.Equal(t, err, target)
+}
+
 func TestMetrics(t *testing.T) {
 	td := testdata.GenerateMetricsOneMetric()
 	err := fmt.Errorf("some error")
@@ -57,4 +83,16 @@ func TestMetrics(t *testing.T) {
 	assert.False(t, AsMetrics(err, &target))
 	assert.True(t, AsMetrics(metricErr, &target))
 	assert.Equal(t, td, target.GetMetrics())
+}
+
+func TestMetrics_Unwrap(t *testing.T) {
+	td := testdata.GenerateMetricsOneMetric()
+	var err error = testErrorType{"some error"}
+	// Wrapping err with error Metrics.
+	metricErr := NewMetrics(err, td)
+	target := testErrorType{}
+	require.NotEqual(t, err, target)
+	// Unwrapping metricErr for err and assigning to target.
+	require.True(t, errors.As(metricErr, &target))
+	require.Equal(t, err, target)
 }


### PR DESCRIPTION
**Description:** Fixing a bug - Add Unwrap method to consumer errors permanent, Traces, Logs and Metrics. Functions Is and As in standard package errors use Unwrap to retrieve wrapped errors.

**Testing:** Created error type testErrorType. Wrapped testErrorType values with the consumer errors. Used function errors.As to retrieve wrapped testErrorType values. Added tests:
- TestPermanent_Unwrap
- TestTraces_Unwrap
- TestLogs_Unwrap
- TestMetrics_Unwrap