### PR TITLE
Extract OTLP text logging from logging exporter

### DIFF
--- a/exporter/loggingexporter/logging_exporter.go
+++ b/exporter/loggingexporter/logging_exporter.go
@@ -16,9 +16,7 @@ package loggingexporter
 
 import (
 	"context"
-	"fmt"
 	"os"
-	"strconv"
 	"strings"
 
 	"go.uber.org/zap"
@@ -27,296 +25,8 @@ import (
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
-	tracetranslator "go.opentelemetry.io/collector/translator/trace"
+	"go.opentelemetry.io/collector/internal/otlptext"
 )
-
-type logDataBuffer struct {
-	str strings.Builder
-}
-
-func (b *logDataBuffer) logEntry(format string, a ...interface{}) {
-	b.str.WriteString(fmt.Sprintf(format, a...))
-	b.str.WriteString("\n")
-}
-
-func (b *logDataBuffer) logAttr(label string, value string) {
-	b.logEntry("    %-15s: %s", label, value)
-}
-
-func (b *logDataBuffer) logAttributeMap(label string, am pdata.AttributeMap) {
-	if am.Len() == 0 {
-		return
-	}
-
-	b.logEntry("%s:", label)
-	am.Range(func(k string, v pdata.AttributeValue) bool {
-		b.logEntry("     -> %s: %s(%s)", k, v.Type().String(), attributeValueToString(v))
-		return true
-	})
-}
-
-func (b *logDataBuffer) logStringMap(description string, sm pdata.StringMap) {
-	if sm.Len() == 0 {
-		return
-	}
-
-	b.logEntry("%s:", description)
-	sm.Range(func(k string, v string) bool {
-		b.logEntry("     -> %s: %s", k, v)
-		return true
-	})
-}
-
-func (b *logDataBuffer) logInstrumentationLibrary(il pdata.InstrumentationLibrary) {
-	b.logEntry(
-		"InstrumentationLibrary %s %s",
-		il.Name(),
-		il.Version())
-}
-
-func (b *logDataBuffer) logMetricDescriptor(md pdata.Metric) {
-	b.logEntry("Descriptor:")
-	b.logEntry("     -> Name: %s", md.Name())
-	b.logEntry("     -> Description: %s", md.Description())
-	b.logEntry("     -> Unit: %s", md.Unit())
-	b.logEntry("     -> DataType: %s", md.DataType().String())
-}
-
-func (b *logDataBuffer) logMetricDataPoints(m pdata.Metric) {
-	switch m.DataType() {
-	case pdata.MetricDataTypeNone:
-		return
-	case pdata.MetricDataTypeIntGauge:
-		b.logIntDataPoints(m.IntGauge().DataPoints())
-	case pdata.MetricDataTypeDoubleGauge:
-		b.logDoubleDataPoints(m.DoubleGauge().DataPoints())
-	case pdata.MetricDataTypeIntSum:
-		data := m.IntSum()
-		b.logEntry("     -> IsMonotonic: %t", data.IsMonotonic())
-		b.logEntry("     -> AggregationTemporality: %s", data.AggregationTemporality().String())
-		b.logIntDataPoints(data.DataPoints())
-	case pdata.MetricDataTypeDoubleSum:
-		data := m.DoubleSum()
-		b.logEntry("     -> IsMonotonic: %t", data.IsMonotonic())
-		b.logEntry("     -> AggregationTemporality: %s", data.AggregationTemporality().String())
-		b.logDoubleDataPoints(data.DataPoints())
-	case pdata.MetricDataTypeIntHistogram:
-		data := m.IntHistogram()
-		b.logEntry("     -> AggregationTemporality: %s", data.AggregationTemporality().String())
-		b.logIntHistogramDataPoints(data.DataPoints())
-	case pdata.MetricDataTypeHistogram:
-		data := m.Histogram()
-		b.logEntry("     -> AggregationTemporality: %s", data.AggregationTemporality().String())
-		b.logDoubleHistogramDataPoints(data.DataPoints())
-	case pdata.MetricDataTypeSummary:
-		data := m.Summary()
-		b.logDoubleSummaryDataPoints(data.DataPoints())
-	}
-}
-
-func (b *logDataBuffer) logIntDataPoints(ps pdata.IntDataPointSlice) {
-	for i := 0; i < ps.Len(); i++ {
-		p := ps.At(i)
-		b.logEntry("IntDataPoints #%d", i)
-		b.logDataPointLabels(p.LabelsMap())
-
-		b.logEntry("StartTimestamp: %d", p.StartTimestamp())
-		b.logEntry("Timestamp: %d", p.Timestamp())
-		b.logEntry("Value: %d", p.Value())
-	}
-}
-
-func (b *logDataBuffer) logDoubleDataPoints(ps pdata.DoubleDataPointSlice) {
-	for i := 0; i < ps.Len(); i++ {
-		p := ps.At(i)
-		b.logEntry("DoubleDataPoints #%d", i)
-		b.logDataPointLabels(p.LabelsMap())
-
-		b.logEntry("StartTimestamp: %d", p.StartTimestamp())
-		b.logEntry("Timestamp: %d", p.Timestamp())
-		b.logEntry("Value: %f", p.Value())
-	}
-}
-
-func (b *logDataBuffer) logDoubleHistogramDataPoints(ps pdata.HistogramDataPointSlice) {
-	for i := 0; i < ps.Len(); i++ {
-		p := ps.At(i)
-		b.logEntry("HistogramDataPoints #%d", i)
-		b.logDataPointLabels(p.LabelsMap())
-
-		b.logEntry("StartTimestamp: %d", p.StartTimestamp())
-		b.logEntry("Timestamp: %d", p.Timestamp())
-		b.logEntry("Count: %d", p.Count())
-		b.logEntry("Sum: %f", p.Sum())
-
-		bounds := p.ExplicitBounds()
-		if len(bounds) != 0 {
-			for i, bound := range bounds {
-				b.logEntry("ExplicitBounds #%d: %f", i, bound)
-			}
-		}
-
-		buckets := p.BucketCounts()
-		if len(buckets) != 0 {
-			for j, bucket := range buckets {
-				b.logEntry("Buckets #%d, Count: %d", j, bucket)
-			}
-		}
-	}
-}
-
-func (b *logDataBuffer) logIntHistogramDataPoints(ps pdata.IntHistogramDataPointSlice) {
-	for i := 0; i < ps.Len(); i++ {
-		p := ps.At(i)
-		b.logEntry("HistogramDataPoints #%d", i)
-		b.logDataPointLabels(p.LabelsMap())
-
-		b.logEntry("StartTimestamp: %d", p.StartTimestamp())
-		b.logEntry("Timestamp: %d", p.Timestamp())
-		b.logEntry("Count: %d", p.Count())
-		b.logEntry("Sum: %d", p.Sum())
-
-		bounds := p.ExplicitBounds()
-		if len(bounds) != 0 {
-			for i, bound := range bounds {
-				b.logEntry("ExplicitBounds #%d: %f", i, bound)
-			}
-		}
-
-		buckets := p.BucketCounts()
-		if len(buckets) != 0 {
-			for j, bucket := range buckets {
-				b.logEntry("Buckets #%d, Count: %d", j, bucket)
-			}
-		}
-	}
-}
-
-func (b *logDataBuffer) logDoubleSummaryDataPoints(ps pdata.SummaryDataPointSlice) {
-	for i := 0; i < ps.Len(); i++ {
-		p := ps.At(i)
-		b.logEntry("SummaryDataPoints #%d", i)
-		b.logDataPointLabels(p.LabelsMap())
-
-		b.logEntry("StartTimestamp: %d", p.StartTimestamp())
-		b.logEntry("Timestamp: %d", p.Timestamp())
-		b.logEntry("Count: %d", p.Count())
-		b.logEntry("Sum: %f", p.Sum())
-
-		quantiles := p.QuantileValues()
-		for i := 0; i < quantiles.Len(); i++ {
-			quantile := quantiles.At(i)
-			b.logEntry("QuantileValue #%d: Quantile %f, Value %f", i, quantile.Quantile(), quantile.Value())
-		}
-	}
-}
-
-func (b *logDataBuffer) logDataPointLabels(labels pdata.StringMap) {
-	b.logStringMap("Data point labels", labels)
-}
-
-func (b *logDataBuffer) logLogRecord(lr pdata.LogRecord) {
-	b.logEntry("Timestamp: %d", lr.Timestamp())
-	b.logEntry("Severity: %s", lr.SeverityText())
-	b.logEntry("ShortName: %s", lr.Name())
-	b.logEntry("Body: %s", attributeValueToString(lr.Body()))
-	b.logAttributeMap("Attributes", lr.Attributes())
-}
-
-func (b *logDataBuffer) logEvents(description string, se pdata.SpanEventSlice) {
-	if se.Len() == 0 {
-		return
-	}
-
-	b.logEntry("%s:", description)
-	for i := 0; i < se.Len(); i++ {
-		e := se.At(i)
-		b.logEntry("SpanEvent #%d", i)
-		b.logEntry("     -> Name: %s", e.Name())
-		b.logEntry("     -> Timestamp: %d", e.Timestamp())
-		b.logEntry("     -> DroppedAttributesCount: %d", e.DroppedAttributesCount())
-
-		if e.Attributes().Len() == 0 {
-			continue
-		}
-		b.logEntry("     -> Attributes:")
-		e.Attributes().Range(func(k string, v pdata.AttributeValue) bool {
-			b.logEntry("         -> %s: %s(%s)", k, v.Type().String(), attributeValueToString(v))
-			return true
-		})
-	}
-}
-
-func (b *logDataBuffer) logLinks(description string, sl pdata.SpanLinkSlice) {
-	if sl.Len() == 0 {
-		return
-	}
-
-	b.logEntry("%s:", description)
-
-	for i := 0; i < sl.Len(); i++ {
-		l := sl.At(i)
-		b.logEntry("SpanLink #%d", i)
-		b.logEntry("     -> Trace ID: %s", l.TraceID().HexString())
-		b.logEntry("     -> ID: %s", l.SpanID().HexString())
-		b.logEntry("     -> TraceState: %s", l.TraceState())
-		b.logEntry("     -> DroppedAttributesCount: %d", l.DroppedAttributesCount())
-		if l.Attributes().Len() == 0 {
-			continue
-		}
-		b.logEntry("     -> Attributes:")
-		l.Attributes().Range(func(k string, v pdata.AttributeValue) bool {
-			b.logEntry("         -> %s: %s(%s)", k, v.Type().String(), attributeValueToString(v))
-			return true
-		})
-	}
-}
-
-func attributeValueToString(av pdata.AttributeValue) string {
-	switch av.Type() {
-	case pdata.AttributeValueSTRING:
-		return av.StringVal()
-	case pdata.AttributeValueBOOL:
-		return strconv.FormatBool(av.BoolVal())
-	case pdata.AttributeValueDOUBLE:
-		return strconv.FormatFloat(av.DoubleVal(), 'f', -1, 64)
-	case pdata.AttributeValueINT:
-		return strconv.FormatInt(av.IntVal(), 10)
-	case pdata.AttributeValueARRAY:
-		return attributeValueArrayToString(av.ArrayVal())
-	case pdata.AttributeValueMAP:
-		return attributeMapToString(av.MapVal())
-	default:
-		return fmt.Sprintf("<Unknown OpenTelemetry attribute value type %q>", av.Type())
-	}
-}
-
-func attributeValueArrayToString(av pdata.AnyValueArray) string {
-	var b strings.Builder
-	b.WriteByte('[')
-	for i := 0; i < av.Len(); i++ {
-		if i < av.Len()-1 {
-			fmt.Fprintf(&b, "%s, ", attributeValueToString(av.At(i)))
-		} else {
-			b.WriteString(attributeValueToString(av.At(i)))
-		}
-	}
-
-	b.WriteByte(']')
-	return b.String()
-}
-
-func attributeMapToString(av pdata.AttributeMap) string {
-	var b strings.Builder
-	b.WriteString("{\n")
-
-	av.Sort().Range(func(k string, v pdata.AttributeValue) bool {
-		fmt.Fprintf(&b, "     -> %s: %s(%s)\n", k, v.Type(), tracetranslator.AttributeValueToString(v, false))
-		return true
-	})
-	b.WriteByte('}')
-	return b.String()
-}
 
 type loggingExporter struct {
 	logger *zap.Logger
@@ -334,40 +44,7 @@ func (s *loggingExporter) pushTraceData(
 		return nil
 	}
 
-	buf := logDataBuffer{}
-	rss := td.ResourceSpans()
-	for i := 0; i < rss.Len(); i++ {
-		buf.logEntry("ResourceSpans #%d", i)
-		rs := rss.At(i)
-		buf.logAttributeMap("Resource labels", rs.Resource().Attributes())
-		ilss := rs.InstrumentationLibrarySpans()
-		for j := 0; j < ilss.Len(); j++ {
-			buf.logEntry("InstrumentationLibrarySpans #%d", j)
-			ils := ilss.At(j)
-			buf.logInstrumentationLibrary(ils.InstrumentationLibrary())
-
-			spans := ils.Spans()
-			for k := 0; k < spans.Len(); k++ {
-				buf.logEntry("Span #%d", k)
-				span := spans.At(k)
-				buf.logAttr("Trace ID", span.TraceID().HexString())
-				buf.logAttr("Parent ID", span.ParentSpanID().HexString())
-				buf.logAttr("ID", span.SpanID().HexString())
-				buf.logAttr("Name", span.Name())
-				buf.logAttr("Kind", span.Kind().String())
-				buf.logAttr("Start time", span.StartTimestamp().String())
-				buf.logAttr("End time", span.EndTimestamp().String())
-
-				buf.logAttr("Status code", span.Status().Code().String())
-				buf.logAttr("Status message", span.Status().Message())
-
-				buf.logAttributeMap("Attributes", span.Attributes())
-				buf.logEvents("Events", span.Events())
-				buf.logLinks("Links", span.Links())
-			}
-		}
-	}
-	s.logger.Debug(buf.str.String())
+	s.logger.Debug(otlptext.Traces(td))
 
 	return nil
 }
@@ -382,28 +59,7 @@ func (s *loggingExporter) pushMetricsData(
 		return nil
 	}
 
-	buf := logDataBuffer{}
-	rms := md.ResourceMetrics()
-	for i := 0; i < rms.Len(); i++ {
-		buf.logEntry("ResourceMetrics #%d", i)
-		rm := rms.At(i)
-		buf.logAttributeMap("Resource labels", rm.Resource().Attributes())
-		ilms := rm.InstrumentationLibraryMetrics()
-		for j := 0; j < ilms.Len(); j++ {
-			buf.logEntry("InstrumentationLibraryMetrics #%d", j)
-			ilm := ilms.At(j)
-			buf.logInstrumentationLibrary(ilm.InstrumentationLibrary())
-			metrics := ilm.Metrics()
-			for k := 0; k < metrics.Len(); k++ {
-				buf.logEntry("Metric #%d", k)
-				metric := metrics.At(k)
-				buf.logMetricDescriptor(metric)
-				buf.logMetricDataPoints(metric)
-			}
-		}
-	}
-
-	s.logger.Debug(buf.str.String())
+	s.logger.Debug(otlptext.Metrics(md))
 
 	return nil
 }
@@ -478,28 +134,7 @@ func (s *loggingExporter) pushLogData(
 		return nil
 	}
 
-	buf := logDataBuffer{}
-	rls := ld.ResourceLogs()
-	for i := 0; i < rls.Len(); i++ {
-		buf.logEntry("ResourceLog #%d", i)
-		rl := rls.At(i)
-		buf.logAttributeMap("Resource labels", rl.Resource().Attributes())
-		ills := rl.InstrumentationLibraryLogs()
-		for j := 0; j < ills.Len(); j++ {
-			buf.logEntry("InstrumentationLibraryLogs #%d", j)
-			ils := ills.At(j)
-			buf.logInstrumentationLibrary(ils.InstrumentationLibrary())
-
-			logs := ils.Logs()
-			for k := 0; k < logs.Len(); k++ {
-				buf.logEntry("LogRecord #%d", k)
-				lr := logs.At(k)
-				buf.logLogRecord(lr)
-			}
-		}
-	}
-
-	s.logger.Debug(buf.str.String())
+	s.logger.Debug(otlptext.Logs(ld))
 
 	return nil
 }

--- a/exporter/loggingexporter/logging_exporter_test.go
+++ b/exporter/loggingexporter/logging_exporter_test.go
@@ -22,7 +22,6 @@ import (
 	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/config"
-	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/internal/testdata"
 )
 
@@ -61,36 +60,4 @@ func TestLoggingLogsExporterNoErrors(t *testing.T) {
 	assert.NoError(t, lle.ConsumeLogs(context.Background(), testdata.GenerateLogDataOneEmptyLogs()))
 
 	assert.NoError(t, lle.Shutdown(context.Background()))
-}
-
-func TestNestedArraySerializesCorrectly(t *testing.T) {
-	ava := pdata.NewAttributeValueArray()
-	ava.ArrayVal().AppendEmpty().SetStringVal("foo")
-	ava.ArrayVal().AppendEmpty().SetIntVal(42)
-
-	ava2 := pdata.NewAttributeValueArray()
-	ava2.ArrayVal().AppendEmpty().SetStringVal("bar")
-	ava2.CopyTo(ava.ArrayVal().AppendEmpty())
-
-	assert.Equal(t, 3, ava.ArrayVal().Len())
-	assert.Equal(t, "[foo, 42, [bar]]", attributeValueToString(ava))
-}
-
-func TestNestedMapSerializesCorrectly(t *testing.T) {
-	ava := pdata.NewAttributeValueMap()
-	av := ava.MapVal()
-	av.Insert("foo", pdata.NewAttributeValueString("test"))
-
-	ava2 := pdata.NewAttributeValueMap()
-	av2 := ava2.MapVal()
-	av2.InsertInt("bar", 13)
-	av.Insert("zoo", ava2)
-
-	expected := `{
-     -> foo: STRING(test)
-     -> zoo: MAP({"bar":13})
-}`
-
-	assert.Equal(t, 2, ava.MapVal().Len())
-	assert.Equal(t, expected, attributeValueToString(ava))
 }

--- a/internal/otlptext/databuffer.go
+++ b/internal/otlptext/databuffer.go
@@ -1,0 +1,312 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package otlptext
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"go.opentelemetry.io/collector/consumer/pdata"
+	tracetranslator "go.opentelemetry.io/collector/translator/trace"
+)
+
+type dataBuffer struct {
+	str strings.Builder
+}
+
+func (b *dataBuffer) logEntry(format string, a ...interface{}) {
+	b.str.WriteString(fmt.Sprintf(format, a...))
+	b.str.WriteString("\n")
+}
+
+func (b *dataBuffer) logAttr(label string, value string) {
+	b.logEntry("    %-15s: %s", label, value)
+}
+
+func (b *dataBuffer) logAttributeMap(label string, am pdata.AttributeMap) {
+	if am.Len() == 0 {
+		return
+	}
+
+	b.logEntry("%s:", label)
+	am.Range(func(k string, v pdata.AttributeValue) bool {
+		b.logEntry("     -> %s: %s(%s)", k, v.Type().String(), attributeValueToString(v))
+		return true
+	})
+}
+
+func (b *dataBuffer) logStringMap(description string, sm pdata.StringMap) {
+	if sm.Len() == 0 {
+		return
+	}
+
+	b.logEntry("%s:", description)
+	sm.Range(func(k string, v string) bool {
+		b.logEntry("     -> %s: %s", k, v)
+		return true
+	})
+}
+
+func (b *dataBuffer) logInstrumentationLibrary(il pdata.InstrumentationLibrary) {
+	b.logEntry(
+		"InstrumentationLibrary %s %s",
+		il.Name(),
+		il.Version())
+}
+
+func (b *dataBuffer) logMetricDescriptor(md pdata.Metric) {
+	b.logEntry("Descriptor:")
+	b.logEntry("     -> Name: %s", md.Name())
+	b.logEntry("     -> Description: %s", md.Description())
+	b.logEntry("     -> Unit: %s", md.Unit())
+	b.logEntry("     -> DataType: %s", md.DataType().String())
+}
+
+func (b *dataBuffer) logMetricDataPoints(m pdata.Metric) {
+	switch m.DataType() {
+	case pdata.MetricDataTypeNone:
+		return
+	case pdata.MetricDataTypeIntGauge:
+		b.logIntDataPoints(m.IntGauge().DataPoints())
+	case pdata.MetricDataTypeDoubleGauge:
+		b.logDoubleDataPoints(m.DoubleGauge().DataPoints())
+	case pdata.MetricDataTypeIntSum:
+		data := m.IntSum()
+		b.logEntry("     -> IsMonotonic: %t", data.IsMonotonic())
+		b.logEntry("     -> AggregationTemporality: %s", data.AggregationTemporality().String())
+		b.logIntDataPoints(data.DataPoints())
+	case pdata.MetricDataTypeDoubleSum:
+		data := m.DoubleSum()
+		b.logEntry("     -> IsMonotonic: %t", data.IsMonotonic())
+		b.logEntry("     -> AggregationTemporality: %s", data.AggregationTemporality().String())
+		b.logDoubleDataPoints(data.DataPoints())
+	case pdata.MetricDataTypeIntHistogram:
+		data := m.IntHistogram()
+		b.logEntry("     -> AggregationTemporality: %s", data.AggregationTemporality().String())
+		b.logIntHistogramDataPoints(data.DataPoints())
+	case pdata.MetricDataTypeHistogram:
+		data := m.Histogram()
+		b.logEntry("     -> AggregationTemporality: %s", data.AggregationTemporality().String())
+		b.logDoubleHistogramDataPoints(data.DataPoints())
+	case pdata.MetricDataTypeSummary:
+		data := m.Summary()
+		b.logDoubleSummaryDataPoints(data.DataPoints())
+	}
+}
+
+func (b *dataBuffer) logIntDataPoints(ps pdata.IntDataPointSlice) {
+	for i := 0; i < ps.Len(); i++ {
+		p := ps.At(i)
+		b.logEntry("IntDataPoints #%d", i)
+		b.logDataPointLabels(p.LabelsMap())
+
+		b.logEntry("StartTimestamp: %d", p.StartTimestamp())
+		b.logEntry("Timestamp: %d", p.Timestamp())
+		b.logEntry("Value: %d", p.Value())
+	}
+}
+
+func (b *dataBuffer) logDoubleDataPoints(ps pdata.DoubleDataPointSlice) {
+	for i := 0; i < ps.Len(); i++ {
+		p := ps.At(i)
+		b.logEntry("DoubleDataPoints #%d", i)
+		b.logDataPointLabels(p.LabelsMap())
+
+		b.logEntry("StartTimestamp: %d", p.StartTimestamp())
+		b.logEntry("Timestamp: %d", p.Timestamp())
+		b.logEntry("Value: %f", p.Value())
+	}
+}
+
+func (b *dataBuffer) logDoubleHistogramDataPoints(ps pdata.HistogramDataPointSlice) {
+	for i := 0; i < ps.Len(); i++ {
+		p := ps.At(i)
+		b.logEntry("HistogramDataPoints #%d", i)
+		b.logDataPointLabels(p.LabelsMap())
+
+		b.logEntry("StartTimestamp: %d", p.StartTimestamp())
+		b.logEntry("Timestamp: %d", p.Timestamp())
+		b.logEntry("Count: %d", p.Count())
+		b.logEntry("Sum: %f", p.Sum())
+
+		bounds := p.ExplicitBounds()
+		if len(bounds) != 0 {
+			for i, bound := range bounds {
+				b.logEntry("ExplicitBounds #%d: %f", i, bound)
+			}
+		}
+
+		buckets := p.BucketCounts()
+		if len(buckets) != 0 {
+			for j, bucket := range buckets {
+				b.logEntry("Buckets #%d, Count: %d", j, bucket)
+			}
+		}
+	}
+}
+
+func (b *dataBuffer) logIntHistogramDataPoints(ps pdata.IntHistogramDataPointSlice) {
+	for i := 0; i < ps.Len(); i++ {
+		p := ps.At(i)
+		b.logEntry("HistogramDataPoints #%d", i)
+		b.logDataPointLabels(p.LabelsMap())
+
+		b.logEntry("StartTimestamp: %d", p.StartTimestamp())
+		b.logEntry("Timestamp: %d", p.Timestamp())
+		b.logEntry("Count: %d", p.Count())
+		b.logEntry("Sum: %d", p.Sum())
+
+		bounds := p.ExplicitBounds()
+		if len(bounds) != 0 {
+			for i, bound := range bounds {
+				b.logEntry("ExplicitBounds #%d: %f", i, bound)
+			}
+		}
+
+		buckets := p.BucketCounts()
+		if len(buckets) != 0 {
+			for j, bucket := range buckets {
+				b.logEntry("Buckets #%d, Count: %d", j, bucket)
+			}
+		}
+	}
+}
+
+func (b *dataBuffer) logDoubleSummaryDataPoints(ps pdata.SummaryDataPointSlice) {
+	for i := 0; i < ps.Len(); i++ {
+		p := ps.At(i)
+		b.logEntry("SummaryDataPoints #%d", i)
+		b.logDataPointLabels(p.LabelsMap())
+
+		b.logEntry("StartTimestamp: %d", p.StartTimestamp())
+		b.logEntry("Timestamp: %d", p.Timestamp())
+		b.logEntry("Count: %d", p.Count())
+		b.logEntry("Sum: %f", p.Sum())
+
+		quantiles := p.QuantileValues()
+		for i := 0; i < quantiles.Len(); i++ {
+			quantile := quantiles.At(i)
+			b.logEntry("QuantileValue #%d: Quantile %f, Value %f", i, quantile.Quantile(), quantile.Value())
+		}
+	}
+}
+
+func (b *dataBuffer) logDataPointLabels(labels pdata.StringMap) {
+	b.logStringMap("Data point labels", labels)
+}
+
+func (b *dataBuffer) logLogRecord(lr pdata.LogRecord) {
+	b.logEntry("Timestamp: %d", lr.Timestamp())
+	b.logEntry("Severity: %s", lr.SeverityText())
+	b.logEntry("ShortName: %s", lr.Name())
+	b.logEntry("Body: %s", attributeValueToString(lr.Body()))
+	b.logAttributeMap("Attributes", lr.Attributes())
+}
+
+func (b *dataBuffer) logEvents(description string, se pdata.SpanEventSlice) {
+	if se.Len() == 0 {
+		return
+	}
+
+	b.logEntry("%s:", description)
+	for i := 0; i < se.Len(); i++ {
+		e := se.At(i)
+		b.logEntry("SpanEvent #%d", i)
+		b.logEntry("     -> Name: %s", e.Name())
+		b.logEntry("     -> Timestamp: %d", e.Timestamp())
+		b.logEntry("     -> DroppedAttributesCount: %d", e.DroppedAttributesCount())
+
+		if e.Attributes().Len() == 0 {
+			continue
+		}
+		b.logEntry("     -> Attributes:")
+		e.Attributes().Range(func(k string, v pdata.AttributeValue) bool {
+			b.logEntry("         -> %s: %s(%s)", k, v.Type().String(), attributeValueToString(v))
+			return true
+		})
+	}
+}
+
+func (b *dataBuffer) logLinks(description string, sl pdata.SpanLinkSlice) {
+	if sl.Len() == 0 {
+		return
+	}
+
+	b.logEntry("%s:", description)
+
+	for i := 0; i < sl.Len(); i++ {
+		l := sl.At(i)
+		b.logEntry("SpanLink #%d", i)
+		b.logEntry("     -> Trace ID: %s", l.TraceID().HexString())
+		b.logEntry("     -> ID: %s", l.SpanID().HexString())
+		b.logEntry("     -> TraceState: %s", l.TraceState())
+		b.logEntry("     -> DroppedAttributesCount: %d", l.DroppedAttributesCount())
+		if l.Attributes().Len() == 0 {
+			continue
+		}
+		b.logEntry("     -> Attributes:")
+		l.Attributes().Range(func(k string, v pdata.AttributeValue) bool {
+			b.logEntry("         -> %s: %s(%s)", k, v.Type().String(), attributeValueToString(v))
+			return true
+		})
+	}
+}
+
+func attributeValueToString(av pdata.AttributeValue) string {
+	switch av.Type() {
+	case pdata.AttributeValueSTRING:
+		return av.StringVal()
+	case pdata.AttributeValueBOOL:
+		return strconv.FormatBool(av.BoolVal())
+	case pdata.AttributeValueDOUBLE:
+		return strconv.FormatFloat(av.DoubleVal(), 'f', -1, 64)
+	case pdata.AttributeValueINT:
+		return strconv.FormatInt(av.IntVal(), 10)
+	case pdata.AttributeValueARRAY:
+		return attributeValueArrayToString(av.ArrayVal())
+	case pdata.AttributeValueMAP:
+		return attributeMapToString(av.MapVal())
+	default:
+		return fmt.Sprintf("<Unknown OpenTelemetry attribute value type %q>", av.Type())
+	}
+}
+
+func attributeValueArrayToString(av pdata.AnyValueArray) string {
+	var b strings.Builder
+	b.WriteByte('[')
+	for i := 0; i < av.Len(); i++ {
+		if i < av.Len()-1 {
+			fmt.Fprintf(&b, "%s, ", attributeValueToString(av.At(i)))
+		} else {
+			b.WriteString(attributeValueToString(av.At(i)))
+		}
+	}
+
+	b.WriteByte(']')
+	return b.String()
+}
+
+func attributeMapToString(av pdata.AttributeMap) string {
+	var b strings.Builder
+	b.WriteString("{\n")
+
+	av.Sort().Range(func(k string, v pdata.AttributeValue) bool {
+		fmt.Fprintf(&b, "     -> %s: %s(%s)\n", k, v.Type(), tracetranslator.AttributeValueToString(v, false))
+		return true
+	})
+	b.WriteByte('}')
+	return b.String()
+}

--- a/internal/otlptext/databuffer_test.go
+++ b/internal/otlptext/databuffer_test.go
@@ -1,0 +1,58 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package otlptext
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"go.opentelemetry.io/collector/consumer/pdata"
+)
+
+func TestNestedArraySerializesCorrectly(t *testing.T) {
+	ava := pdata.NewAttributeValueArray()
+	ava.ArrayVal().AppendEmpty().SetStringVal("foo")
+	ava.ArrayVal().AppendEmpty().SetIntVal(42)
+
+	ava2 := pdata.NewAttributeValueArray()
+	ava2.ArrayVal().AppendEmpty().SetStringVal("bar")
+	ava2.CopyTo(ava.ArrayVal().AppendEmpty())
+
+	ava.ArrayVal().AppendEmpty().SetBoolVal(true)
+	ava.ArrayVal().AppendEmpty().SetDoubleVal(5.5)
+
+	assert.Equal(t, 5, ava.ArrayVal().Len())
+	assert.Equal(t, "[foo, 42, [bar], true, 5.5]", attributeValueToString(ava))
+}
+
+func TestNestedMapSerializesCorrectly(t *testing.T) {
+	ava := pdata.NewAttributeValueMap()
+	av := ava.MapVal()
+	av.Insert("foo", pdata.NewAttributeValueString("test"))
+
+	ava2 := pdata.NewAttributeValueMap()
+	av2 := ava2.MapVal()
+	av2.InsertInt("bar", 13)
+	av.Insert("zoo", ava2)
+
+	expected := `{
+     -> foo: STRING(test)
+     -> zoo: MAP({"bar":13})
+}`
+
+	assert.Equal(t, 2, ava.MapVal().Len())
+	assert.Equal(t, expected, attributeValueToString(ava))
+}

--- a/internal/otlptext/logs.go
+++ b/internal/otlptext/logs.go
@@ -1,0 +1,43 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package otlptext
+
+import "go.opentelemetry.io/collector/consumer/pdata"
+
+// Logs data to text
+func Logs(ld pdata.Logs) string {
+	buf := dataBuffer{}
+	rls := ld.ResourceLogs()
+	for i := 0; i < rls.Len(); i++ {
+		buf.logEntry("ResourceLog #%d", i)
+		rl := rls.At(i)
+		buf.logAttributeMap("Resource labels", rl.Resource().Attributes())
+		ills := rl.InstrumentationLibraryLogs()
+		for j := 0; j < ills.Len(); j++ {
+			buf.logEntry("InstrumentationLibraryLogs #%d", j)
+			ils := ills.At(j)
+			buf.logInstrumentationLibrary(ils.InstrumentationLibrary())
+
+			logs := ils.Logs()
+			for k := 0; k < logs.Len(); k++ {
+				buf.logEntry("LogRecord #%d", k)
+				lr := logs.At(k)
+				buf.logLogRecord(lr)
+			}
+		}
+	}
+
+	return buf.str.String()
+}

--- a/internal/otlptext/logs_test.go
+++ b/internal/otlptext/logs_test.go
@@ -1,0 +1,48 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package otlptext
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.opentelemetry.io/collector/internal/testdata"
+)
+
+func TestLogs(t *testing.T) {
+	type args struct {
+		ld pdata.Logs
+	}
+	tests := []struct {
+		name  string
+		args  args
+		empty bool
+	}{
+		{"empty logs", args{testdata.GenerateLogDataEmpty()}, true},
+		{"logs data with empty resource log", args{testdata.GenerateLogDataOneEmptyResourceLogs()}, false},
+		{"logs data with no log records", args{testdata.GenerateLogDataNoLogRecords()}, false},
+		{"logs with one empty log", args{testdata.GenerateLogDataOneEmptyLogs()}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logs := Logs(tt.args.ld)
+			if !tt.empty {
+				assert.NotEmpty(t, logs)
+			}
+		})
+	}
+}

--- a/internal/otlptext/metrics.go
+++ b/internal/otlptext/metrics.go
@@ -1,0 +1,43 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package otlptext
+
+import "go.opentelemetry.io/collector/consumer/pdata"
+
+// Metrics data to text
+func Metrics(md pdata.Metrics) string {
+	buf := dataBuffer{}
+	rms := md.ResourceMetrics()
+	for i := 0; i < rms.Len(); i++ {
+		buf.logEntry("ResourceMetrics #%d", i)
+		rm := rms.At(i)
+		buf.logAttributeMap("Resource labels", rm.Resource().Attributes())
+		ilms := rm.InstrumentationLibraryMetrics()
+		for j := 0; j < ilms.Len(); j++ {
+			buf.logEntry("InstrumentationLibraryMetrics #%d", j)
+			ilm := ilms.At(j)
+			buf.logInstrumentationLibrary(ilm.InstrumentationLibrary())
+			metrics := ilm.Metrics()
+			for k := 0; k < metrics.Len(); k++ {
+				buf.logEntry("Metric #%d", k)
+				metric := metrics.At(k)
+				buf.logMetricDescriptor(metric)
+				buf.logMetricDataPoints(metric)
+			}
+		}
+	}
+
+	return buf.str.String()
+}

--- a/internal/otlptext/metrics_test.go
+++ b/internal/otlptext/metrics_test.go
@@ -1,0 +1,48 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package otlptext
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.opentelemetry.io/collector/internal/testdata"
+)
+
+func TestMetrics(t *testing.T) {
+	type args struct {
+		md pdata.Metrics
+	}
+	tests := []struct {
+		name  string
+		args  args
+		empty bool
+	}{
+		{"empty metrics", args{testdata.GenerateMetricsEmpty()}, true},
+		{"metrics with all types and datapoints", args{testdata.GeneratMetricsAllTypesWithSampleDatapoints()}, false},
+		{"metrics with all types without datapoints", args{testdata.GenerateMetricsAllTypesEmptyDataPoint()}, false},
+		{"metrics with invalid metric types", args{testdata.GenerateMetricsMetricTypeInvalid()}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			metrics := Metrics(tt.args.md)
+			if !tt.empty {
+				assert.NotEmpty(t, metrics)
+			}
+		})
+	}
+}

--- a/internal/otlptext/traces.go
+++ b/internal/otlptext/traces.go
@@ -1,0 +1,56 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package otlptext
+
+import "go.opentelemetry.io/collector/consumer/pdata"
+
+// Traces data to text
+func Traces(td pdata.Traces) string {
+	buf := dataBuffer{}
+	rss := td.ResourceSpans()
+	for i := 0; i < rss.Len(); i++ {
+		buf.logEntry("ResourceSpans #%d", i)
+		rs := rss.At(i)
+		buf.logAttributeMap("Resource labels", rs.Resource().Attributes())
+		ilss := rs.InstrumentationLibrarySpans()
+		for j := 0; j < ilss.Len(); j++ {
+			buf.logEntry("InstrumentationLibrarySpans #%d", j)
+			ils := ilss.At(j)
+			buf.logInstrumentationLibrary(ils.InstrumentationLibrary())
+
+			spans := ils.Spans()
+			for k := 0; k < spans.Len(); k++ {
+				buf.logEntry("Span #%d", k)
+				span := spans.At(k)
+				buf.logAttr("Trace ID", span.TraceID().HexString())
+				buf.logAttr("Parent ID", span.ParentSpanID().HexString())
+				buf.logAttr("ID", span.SpanID().HexString())
+				buf.logAttr("Name", span.Name())
+				buf.logAttr("Kind", span.Kind().String())
+				buf.logAttr("Start time", span.StartTimestamp().String())
+				buf.logAttr("End time", span.EndTimestamp().String())
+
+				buf.logAttr("Status code", span.Status().Code().String())
+				buf.logAttr("Status message", span.Status().Message())
+
+				buf.logAttributeMap("Attributes", span.Attributes())
+				buf.logEvents("Events", span.Events())
+				buf.logLinks("Links", span.Links())
+			}
+		}
+	}
+
+	return buf.str.String()
+}

--- a/internal/otlptext/traces_test.go
+++ b/internal/otlptext/traces_test.go
@@ -1,0 +1,46 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package otlptext
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.opentelemetry.io/collector/internal/testdata"
+)
+
+func TestTraces(t *testing.T) {
+	type args struct {
+		td pdata.Traces
+	}
+	tests := []struct {
+		name  string
+		args  args
+		empty bool
+	}{
+		{"empty traces", args{testdata.GenerateTraceDataEmpty()}, true},
+		{"traces with two spans", args{testdata.GenerateTraceDataTwoSpansSameResourceOneDifferent()}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			traces := Traces(tt.args.td)
+			if !tt.empty {
+				assert.NotEmpty(t, traces)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The plan is to eventually use this as an unmarshaller (#3044) but for now make
it accessible from `internal/otlptext`.