### PR TITLE
remove legacy grpc receiver endpoint for GA release

### DIFF
--- a/receiver/otlpreceiver/factory.go
+++ b/receiver/otlpreceiver/factory.go
@@ -33,7 +33,6 @@ const (
 
 	defaultGRPCEndpoint = "0.0.0.0:4317"
 	defaultHTTPEndpoint = "0.0.0.0:55681"
-	legacyGRPCEndpoint  = "0.0.0.0:55680"
 )
 
 // NewFactory creates a new OTLP receiver factory.

--- a/receiver/otlpreceiver/otlp.go
+++ b/receiver/otlpreceiver/otlp.go
@@ -145,18 +145,6 @@ func (r *otlpReceiver) startProtocolServers(host component.Host) error {
 		if err != nil {
 			return err
 		}
-		if r.cfg.GRPC.NetAddr.Endpoint == defaultGRPCEndpoint {
-			r.logger.Info("Setting up a second GRPC listener on legacy endpoint " + legacyGRPCEndpoint)
-
-			// Copy the config.
-			cfgLegacyGRPC := r.cfg.GRPC
-			// And use the legacy endpoint.
-			cfgLegacyGRPC.NetAddr.Endpoint = legacyGRPCEndpoint
-			err = r.startGRPCServer(cfgLegacyGRPC, host)
-			if err != nil {
-				return err
-			}
-		}
 	}
 	if r.cfg.HTTP != nil {
 		r.serverHTTP = r.cfg.HTTP.ToServer(


### PR DESCRIPTION
**Description:** <Describe what has changed. 
Removed OTLP receiver legacy endpoint which was still accepting data even after we switched to port `4317` for easy migration. Submitted a PR to remove legacy endpoint for GA release. Not sure when is the good time to merge this PR but thought this will be required before GA release.

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector/issues/2565

**Testing:** Ran `otlpreceiver` package unit tests by running 
`go test -race go.opentelemetry.io/collector/receiver/otlpreceiver` command

**Documentation:** < Describe the documentation added.>

_Please delete paragraphs that you did not use before submitting._
