### PR TITLE
Increase TestIdleMode memory limit

### DIFF
--- a/testbed/tests/e2e_test.go
+++ b/testbed/tests/e2e_test.go
@@ -42,7 +42,7 @@ func TestIdleMode(t *testing.T) {
 	)
 	defer tc.Stop()
 
-	tc.SetResourceLimits(testbed.ResourceSpec{ExpectedMaxCPU: 4, ExpectedMaxRAM: 55})
+	tc.SetResourceLimits(testbed.ResourceSpec{ExpectedMaxCPU: 4, ExpectedMaxRAM: 70})
 	tc.StartAgent()
 
 	tc.Sleep(tc.Duration)


### PR DESCRIPTION
We are running close to the limit and sometimes fail on CI: https://github.com/open-telemetry/opentelemetry-collector/pull/3073/checks?check_run_id=2494206292

This should avoid spurious failures.
