### PR TITLE
Fix batch processor traces reorder, improve performance

### DIFF
--- a/internal/testdata/trace.go
+++ b/internal/testdata/trace.go
@@ -314,3 +314,13 @@ func generateOtlpSpanThree() *otlptrace.Span {
 		DroppedAttributesCount: 5,
 	}
 }
+
+func GenerateTracesManySpansSameResource(spansCount int) pdata.Traces {
+	td := GenerateTraceDataOneEmptyInstrumentationLibrary()
+	rs0ilm0 := td.ResourceSpans().At(0).InstrumentationLibrarySpans().At(0)
+	rs0ilm0.Spans().Resize(spansCount)
+	for i := 0; i < spansCount; i++ {
+		fillSpanOne(rs0ilm0.Spans().At(i))
+	}
+	return td
+}

--- a/processor/batchprocessor/batch_processor.go
+++ b/processor/batchprocessor/batch_processor.go
@@ -244,7 +244,7 @@ func (bt *batchTraces) add(item interface{}) {
 func (bt *batchTraces) export(ctx context.Context, sendBatchMaxSize int) error {
 	var req pdata.Traces
 	if sendBatchMaxSize > 0 && bt.itemCount() > sendBatchMaxSize {
-		req = splitTrace(sendBatchMaxSize, bt.traceData)
+		req = splitTraces(sendBatchMaxSize, bt.traceData)
 		bt.spanCount -= sendBatchMaxSize
 	} else {
 		req = bt.traceData

--- a/processor/batchprocessor/splitmetrics.go
+++ b/processor/batchprocessor/splitmetrics.go
@@ -26,44 +26,44 @@ func splitMetrics(size int, src pdata.Metrics) pdata.Metrics {
 	totalCopiedMetrics := 0
 	dest := pdata.NewMetrics()
 
-	src.ResourceMetrics().RemoveIf(func(srcRm pdata.ResourceMetrics) bool {
+	src.ResourceMetrics().RemoveIf(func(srcRs pdata.ResourceMetrics) bool {
 		// If we are done skip everything else.
 		if totalCopiedMetrics == size {
 			return false
 		}
 
 		destRs := dest.ResourceMetrics().AppendEmpty()
-		srcRm.Resource().CopyTo(destRs.Resource())
+		srcRs.Resource().CopyTo(destRs.Resource())
 
-		srcRm.InstrumentationLibraryMetrics().RemoveIf(func(srcIm pdata.InstrumentationLibraryMetrics) bool {
+		srcRs.InstrumentationLibraryMetrics().RemoveIf(func(srcIlm pdata.InstrumentationLibraryMetrics) bool {
 			// If we are done skip everything else.
 			if totalCopiedMetrics == size {
 				return false
 			}
 
-			destIms := destRs.InstrumentationLibraryMetrics().AppendEmpty()
-			srcIm.InstrumentationLibrary().CopyTo(destIms.InstrumentationLibrary())
+			destIlm := destRs.InstrumentationLibraryMetrics().AppendEmpty()
+			srcIlm.InstrumentationLibrary().CopyTo(destIlm.InstrumentationLibrary())
 
 			// If possible to move all metrics do that.
-			srcMetricsLen := srcIm.Metrics().Len()
+			srcMetricsLen := srcIlm.Metrics().Len()
 			if size-totalCopiedMetrics >= srcMetricsLen {
 				totalCopiedMetrics += srcMetricsLen
-				srcIm.Metrics().MoveAndAppendTo(destIms.Metrics())
+				srcIlm.Metrics().MoveAndAppendTo(destIlm.Metrics())
 				return true
 			}
 
-			srcIm.Metrics().RemoveIf(func(srcMetric pdata.Metric) bool {
+			srcIlm.Metrics().RemoveIf(func(srcMetric pdata.Metric) bool {
 				// If we are done skip everything else.
 				if totalCopiedMetrics == size {
 					return false
 				}
-				srcMetric.CopyTo(destIms.Metrics().AppendEmpty())
+				srcMetric.CopyTo(destIlm.Metrics().AppendEmpty())
 				totalCopiedMetrics++
 				return true
 			})
 			return false
 		})
-		return srcRm.InstrumentationLibraryMetrics().Len() == 0
+		return srcRs.InstrumentationLibraryMetrics().Len() == 0
 	})
 
 	return dest

--- a/processor/batchprocessor/splittraces.go
+++ b/processor/batchprocessor/splittraces.go
@@ -18,51 +18,53 @@ import (
 	"go.opentelemetry.io/collector/consumer/pdata"
 )
 
-// splitTrace removes spans from the input trace and returns a new trace of the specified size.
-func splitTrace(size int, toSplit pdata.Traces) pdata.Traces {
-	if toSplit.SpanCount() <= size {
-		return toSplit
+// splitTraces removes spans from the input trace and returns a new trace of the specified size.
+func splitTraces(size int, src pdata.Traces) pdata.Traces {
+	if src.SpanCount() <= size {
+		return src
 	}
-	copiedSpans := 0
-	result := pdata.NewTraces()
-	rss := toSplit.ResourceSpans()
-	result.ResourceSpans().Resize(rss.Len())
-	rssCount := 0
-	for i := rss.Len() - 1; i >= 0; i-- {
-		rssCount++
-		rs := rss.At(i)
-		destRs := result.ResourceSpans().At(result.ResourceSpans().Len() - 1 - i)
-		rs.Resource().CopyTo(destRs.Resource())
+	totalCopiedSpans := 0
+	dest := pdata.NewTraces()
 
-		for j := rs.InstrumentationLibrarySpans().Len() - 1; j >= 0; j-- {
-			instSpans := rs.InstrumentationLibrarySpans().At(j)
-			destInstSpans := destRs.InstrumentationLibrarySpans().AppendEmpty()
-			instSpans.InstrumentationLibrary().CopyTo(destInstSpans.InstrumentationLibrary())
+	src.ResourceSpans().RemoveIf(func(srcRs pdata.ResourceSpans) bool {
+		// If we are done skip everything else.
+		if totalCopiedSpans == size {
+			return false
+		}
 
-			if size-copiedSpans >= instSpans.Spans().Len() {
-				destInstSpans.Spans().Resize(instSpans.Spans().Len())
-			} else {
-				destInstSpans.Spans().Resize(size - copiedSpans)
+		destRs := dest.ResourceSpans().AppendEmpty()
+		srcRs.Resource().CopyTo(destRs.Resource())
+
+		srcRs.InstrumentationLibrarySpans().RemoveIf(func(srcIls pdata.InstrumentationLibrarySpans) bool {
+			// If we are done skip everything else.
+			if totalCopiedSpans == size {
+				return false
 			}
-			for k, destIdx := instSpans.Spans().Len()-1, 0; k >= 0 && copiedSpans < size; k, destIdx = k-1, destIdx+1 {
-				span := instSpans.Spans().At(k)
-				span.CopyTo(destInstSpans.Spans().At(destIdx))
-				copiedSpans++
-				// remove span
-				instSpans.Spans().Resize(instSpans.Spans().Len() - 1)
+
+			destIls := destRs.InstrumentationLibrarySpans().AppendEmpty()
+			srcIls.InstrumentationLibrary().CopyTo(destIls.InstrumentationLibrary())
+
+			// If possible to move all metrics do that.
+			srcSpansLen := srcIls.Spans().Len()
+			if size-totalCopiedSpans >= srcSpansLen {
+				totalCopiedSpans += srcSpansLen
+				srcIls.Spans().MoveAndAppendTo(destIls.Spans())
+				return true
 			}
-			if instSpans.Spans().Len() == 0 {
-				rs.InstrumentationLibrarySpans().Resize(rs.InstrumentationLibrarySpans().Len() - 1)
-			}
-			if copiedSpans == size {
-				result.ResourceSpans().Resize(rssCount)
-				return result
-			}
-		}
-		if rs.InstrumentationLibrarySpans().Len() == 0 {
-			rss.Resize(rss.Len() - 1)
-		}
-	}
-	result.ResourceSpans().Resize(rssCount)
-	return result
+
+			srcIls.Spans().RemoveIf(func(srcSpan pdata.Span) bool {
+				// If we are done skip everything else.
+				if totalCopiedSpans == size {
+					return false
+				}
+				srcSpan.CopyTo(destIls.Spans().AppendEmpty())
+				totalCopiedSpans++
+				return true
+			})
+			return false
+		})
+		return srcRs.InstrumentationLibrarySpans().Len() == 0
+	})
+
+	return dest
 }


### PR DESCRIPTION
Benchmarks Before:

```
goos: darwin
goarch: amd64
pkg: go.opentelemetry.io/collector/processor/batchprocessor
cpu: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
BenchmarkSplitTraces
BenchmarkSplitTraces-16    	    8277	    135600 ns/op	  222440 B/op	    1725 allocs/op
PASS
```

Benchmarks After:

```
goos: darwin
goarch: amd64
pkg: go.opentelemetry.io/collector/processor/batchprocessor
cpu: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
BenchmarkSplitTraces
BenchmarkSplitTraces-16    	    9896	    108060 ns/op	  172409 B/op	    1372 allocs/op
PASS
```

Benchmarks Reference Clone:

```
goos: darwin
goarch: amd64
pkg: go.opentelemetry.io/collector/processor/batchprocessor
cpu: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
BenchmarkCloneSpans
BenchmarkCloneSpans-16    	   12393	     97528 ns/op	  167896 B/op	    1303 allocs/op
PASS
```

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
