### PR TITLE
Fix otlpreceiver README (was incorrect about bytes being base64 encoded)

### DIFF
--- a/receiver/otlpreceiver/README.md
+++ b/receiver/otlpreceiver/README.md
@@ -44,8 +44,6 @@ gRPC. The HTTP/JSON address is the same as gRPC as the protocol is recognized
 and processed accordingly. Note the format needs to be [protobuf JSON
 serialization](https://developers.google.com/protocol-buffers/docs/proto3#json).
 
-IMPORTANT: bytes fields are encoded as base64 strings.
-
 To write traces with HTTP/JSON, `POST` to `[address]/v1/traces` for traces,
 to `[address]/v1/metrics` for metrics, to `[address]/v1/logs` for logs. The default
 port is `55681`.


### PR DESCRIPTION
The comment was about traceid/spanid "bytes" fields. This comment is incorrect since
we have changed traceid/spanid fields to use hex encoding (as required by the spec).

In the future if we add any other "bytes" fields to the proto they will be encoded as base64
as it is expected and is default behavior of Protobuf/JSON, but this does not require an
explicit comment, so I am deleting it.
