### PR TITLE
Increase RaM limits for TestMetric10kDPS

### DIFF
--- a/testbed/tests/metric_test.go
+++ b/testbed/tests/metric_test.go
@@ -58,7 +58,7 @@ func TestMetric10kDPS(t *testing.T) {
 			testbed.NewOCDataReceiver(testbed.GetAvailablePort(t)),
 			testbed.ResourceSpec{
 				ExpectedMaxCPU: 85,
-				ExpectedMaxRAM: 75,
+				ExpectedMaxRAM: 85,
 			},
 		},
 		{
@@ -67,7 +67,7 @@ func TestMetric10kDPS(t *testing.T) {
 			testbed.NewOTLPDataReceiver(testbed.GetAvailablePort(t)),
 			testbed.ResourceSpec{
 				ExpectedMaxCPU: 50,
-				ExpectedMaxRAM: 65,
+				ExpectedMaxRAM: 85,
 			},
 		},
 		{
@@ -76,7 +76,7 @@ func TestMetric10kDPS(t *testing.T) {
 			testbed.NewOTLPHTTPDataReceiver(testbed.GetAvailablePort(t)),
 			testbed.ResourceSpec{
 				ExpectedMaxCPU: 50,
-				ExpectedMaxRAM: 65,
+				ExpectedMaxRAM: 85,
 			},
 		},
 	}


### PR DESCRIPTION
We were running close and sometimes failing on github actions: https://github.com/open-telemetry/opentelemetry-collector/pull/3073/checks?check_run_id=2494206342
