### PR TITLE
Validate that batch config max size is greater than send size

### DIFF
--- a/processor/batchprocessor/README.md
+++ b/processor/batchprocessor/README.md
@@ -16,13 +16,13 @@ Please refer to [config.go](./config.go) for the config spec.
 
 The following configuration options can be modified:
 - `send_batch_size` (default = 8192): Number of spans or metrics after which a
-batch will be sent.
+batch will be sent regardless of the timeout.
 - `timeout` (default = 200ms): Time duration after which a batch will be sent
 regardless of size.
 - `send_batch_max_size` (default = 0): The upper limit of the batch size.
   `0` means no upper limit of the batch size.
   This property ensures that larger batches are split into smaller units.
-  It must be larger than `send_batch_size`.
+  It must be greater or equal to `send_batch_size`.
 
 Examples:
 

--- a/processor/batchprocessor/README.md
+++ b/processor/batchprocessor/README.md
@@ -19,9 +19,10 @@ The following configuration options can be modified:
 batch will be sent.
 - `timeout` (default = 200ms): Time duration after which a batch will be sent
 regardless of size.
-- `send_batch_max_size` (default = 0): The maximum number of items in a batch.
- This property ensures that larger batches are split into smaller units.
- By default (`0`), there is no upper limit of the batch size.
+- `send_batch_max_size` (default = 0): The upper limit of the batch size.
+  `0` means no upper limit of the batch size.
+  This property ensures that larger batches are split into smaller units.
+  It must be larger than `send_batch_size`.
 
 Examples:
 

--- a/processor/batchprocessor/config.go
+++ b/processor/batchprocessor/config.go
@@ -15,6 +15,7 @@
 package batchprocessor
 
 import (
+	"errors"
 	"time"
 
 	"go.opentelemetry.io/collector/config"
@@ -30,7 +31,8 @@ type Config struct {
 	// SendBatchSize is the size of a batch which after hit, will trigger it to be sent.
 	SendBatchSize uint32 `mapstructure:"send_batch_size,omitempty"`
 
-	// SendBatchMaxSize is the maximum size of a batch. Larger batches are split into smaller units.
+	// SendBatchMaxSize is the maximum size of a batch. It must be larger than SendBatchSize.
+	// Larger batches are split into smaller units.
 	// Default value is 0, that means no maximum size.
 	SendBatchMaxSize uint32 `mapstructure:"send_batch_max_size,omitempty"`
 }
@@ -39,5 +41,8 @@ var _ config.Processor = (*Config)(nil)
 
 // Validate checks if the processor configuration is valid
 func (cfg *Config) Validate() error {
+	if cfg.SendBatchMaxSize > 0 && cfg.SendBatchMaxSize < cfg.SendBatchSize {
+		return errors.New("send_batch_max_size must be larger than send_batch_size")
+	}
 	return nil
 }

--- a/processor/batchprocessor/config.go
+++ b/processor/batchprocessor/config.go
@@ -42,7 +42,7 @@ var _ config.Processor = (*Config)(nil)
 // Validate checks if the processor configuration is valid
 func (cfg *Config) Validate() error {
 	if cfg.SendBatchMaxSize > 0 && cfg.SendBatchMaxSize < cfg.SendBatchSize {
-		return errors.New("send_batch_max_size must be larger than send_batch_size")
+		return errors.New("send_batch_max_size must be larger or equal to send_batch_size")
 	}
 	return nil
 }

--- a/processor/batchprocessor/config.go
+++ b/processor/batchprocessor/config.go
@@ -42,7 +42,7 @@ var _ config.Processor = (*Config)(nil)
 // Validate checks if the processor configuration is valid
 func (cfg *Config) Validate() error {
 	if cfg.SendBatchMaxSize > 0 && cfg.SendBatchMaxSize < cfg.SendBatchSize {
-		return errors.New("send_batch_max_size must be larger or equal to send_batch_size")
+		return errors.New("send_batch_max_size must be greater or equal to send_batch_size")
 	}
 	return nil
 }

--- a/processor/batchprocessor/config_test.go
+++ b/processor/batchprocessor/config_test.go
@@ -55,3 +55,31 @@ func TestLoadConfig(t *testing.T) {
 			Timeout:           timeout,
 		})
 }
+
+func TestValidateConfig_DefaultBatchMaxSize(t *testing.T) {
+	cfg := &Config{
+		ProcessorSettings: config.NewProcessorSettings(config.NewIDWithName(typeStr, "2")),
+		SendBatchSize:     100,
+		SendBatchMaxSize:  0,
+	}
+	assert.NoError(t, cfg.Validate())
+}
+
+func TestValidateConfig_ValidBatchSizes(t *testing.T) {
+	cfg := &Config{
+		ProcessorSettings: config.NewProcessorSettings(config.NewIDWithName(typeStr, "2")),
+		SendBatchSize:     100,
+		SendBatchMaxSize:  1000,
+	}
+	assert.NoError(t, cfg.Validate())
+
+}
+
+func TestValidateConfig_InvalidBatchSize(t *testing.T) {
+	cfg := &Config{
+		ProcessorSettings: config.NewProcessorSettings(config.NewIDWithName(typeStr, "2")),
+		SendBatchSize:     1000,
+		SendBatchMaxSize:  100,
+	}
+	assert.Error(t, cfg.Validate())
+}


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-collector/issues/3119

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
