### PR TITLE
[DRAFT]Support for Custom Exporter Authenticators as Extensions

### DIFF
--- a/cmd/issuegenerator/go.sum
+++ b/cmd/issuegenerator/go.sum
@@ -109,10 +109,8 @@ github.com/joshdk/go-junit v0.0.0-20210226021600-6145f504ca0d/go.mod h1:TiiV0Pqk
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
-github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
-github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -376,7 +374,6 @@ google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGj
 google.golang.org/protobuf v1.25.0 h1:Ejskq+SyPohKW+1uil0JJMtmHCgJPJ/qWTxr8qp+R4c=
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=

--- a/config/configauth/clientauth.go
+++ b/config/configauth/clientauth.go
@@ -1,0 +1,47 @@
+package configauth
+
+import (
+	"fmt"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config"
+	"google.golang.org/grpc/credentials"
+	"net/http"
+)
+
+
+type ClientAuth interface {
+	component.Extension
+}
+
+type HTTPClientAuth interface {
+	ClientAuth
+	RoundTripper(base http.RoundTripper) http.RoundTripper
+}
+
+type GRPCClientAuth interface {
+	ClientAuth
+	PerRPCCredential()(credentials.PerRPCCredentials, error)
+}
+
+
+func GetHTTPClientAuth(extensions map[config.NamedEntity]component.Extension, requested string) (HTTPClientAuth, error) {
+	if requested == "" {
+		return nil, errAuthenticatorNotProvided
+	}
+
+	for name, ext := range extensions {
+		if name.Name() == requested {
+			if auth, ok := ext.(HTTPClientAuth); ok {
+				return auth, nil
+			} else {
+				return nil, fmt.Errorf("requested authenticator is not for HTTP clients")
+			}
+		}
+	}
+	return nil, fmt.Errorf("failed to resolve authenticator %q: %w", requested, errAuthenticatorNotFound)
+}
+
+
+func GetGRPCClientAuth(extensions map[config.NamedEntity]component.Extension, requested string) (GRPCClientAuth, error) {
+		return nil, fmt.Errorf("not implemented ")
+}

--- a/config/configauth/clientauth.go
+++ b/config/configauth/clientauth.go
@@ -9,21 +9,30 @@ import (
 )
 
 
+// ClientAuth is an Extension that can be used as an authenticator for the configauth.Authentication option.
+// Authenticators are then included as part of OpenTelemetry Collector builds and can be referenced by their
+// names from the Authentication configuration. .
 type ClientAuth interface {
 	component.Extension
 }
 
+// HTTPClientAuth is a ClientAuth that can be used as an authenticator for the configauth.Authentication option for HTTP
+// clients.
 type HTTPClientAuth interface {
 	ClientAuth
 	RoundTripper(base http.RoundTripper) http.RoundTripper
 }
 
+// GRPCClientAuth is a ClientAuth that can be used as an authenticator for the configauth.Authentication option for gRPC
+// clients.
 type GRPCClientAuth interface {
 	ClientAuth
-	PerRPCCredential()(credentials.PerRPCCredentials, error)
+	PerRPCCredential() (credentials.PerRPCCredentials, error)
 }
 
-
+// GetHTTPClientAuth attempts to select the appropriate HTTPClientAuth from the list of extensions,
+// based on the requested extension name. If an authenticator is not found, an error is returned. This should be only
+// used by HTTP clients.
 func GetHTTPClientAuth(extensions map[config.NamedEntity]component.Extension, requested string) (HTTPClientAuth, error) {
 	if requested == "" {
 		return nil, errAuthenticatorNotProvided
@@ -41,7 +50,9 @@ func GetHTTPClientAuth(extensions map[config.NamedEntity]component.Extension, re
 	return nil, fmt.Errorf("failed to resolve authenticator %q: %w", requested, errAuthenticatorNotFound)
 }
 
-
+// GetGRPCClientAuth attempts to select the appropriate HTTPClientAuth from the list of extensions,
+// based on the requested extension name. If an authenticator is not found, an error is returned. This shold only be used
+// by gRPC clients
 func GetGRPCClientAuth(extensions map[config.NamedEntity]component.Extension, requested string) (GRPCClientAuth, error) {
-		return nil, fmt.Errorf("not implemented ")
+	return nil, fmt.Errorf("not implemented ")
 }

--- a/config/confighttp/confighttp.go
+++ b/config/confighttp/confighttp.go
@@ -53,8 +53,8 @@ type HTTPClientSettings struct {
 	// Custom Round Tripper to allow for individual components to intercept HTTP requests
 	CustomRoundTripper func(next http.RoundTripper) (http.RoundTripper, error)
 
-	// Auth for the exporter
-	Auth *configauth.Authentication `mapstructure:"auth,omitempty"`
+	// Authenticator for the exporter referred from extensions.
+	Auth *configauth.Authentication `mapstructure:"authorization,omitempty"`
 }
 
 // ToClient creates an HTTP client.
@@ -102,7 +102,6 @@ func (hcs *HTTPClientSettings) AuthRoundTripper(clientBaseTransport http.RoundTr
 	}
 	return httpCustomAuthRoundTripper.RoundTripper(clientBaseTransport), nil
 }
-
 
 // Custom RoundTripper that add headers
 type headerRoundTripper struct {

--- a/config/confighttp/confighttp.go
+++ b/config/confighttp/confighttp.go
@@ -54,7 +54,7 @@ type HTTPClientSettings struct {
 	CustomRoundTripper func(next http.RoundTripper) (http.RoundTripper, error)
 
 	// Authenticator for the exporter referred from extensions.
-	Auth *configauth.Authentication `mapstructure:"authorization,omitempty"`
+	Auth *configauth.Authentication `mapstructure:"authentication,omitempty"`
 }
 
 // ToClient creates an HTTP client.

--- a/exporter/otlphttpexporter/factory.go
+++ b/exporter/otlphttpexporter/factory.go
@@ -91,6 +91,7 @@ func createTracesExporter(
 		cfg,
 		params.Logger,
 		oce.pushTraceData,
+		exporterhelper.WithStart(oce.start),
 		// explicitly disable since we rely on http.Client timeout logic.
 		exporterhelper.WithTimeout(exporterhelper.TimeoutSettings{Timeout: 0}),
 		exporterhelper.WithRetry(oCfg.RetrySettings),
@@ -117,6 +118,7 @@ func createMetricsExporter(
 		cfg,
 		params.Logger,
 		oce.pushMetricsData,
+		exporterhelper.WithStart(oce.start),
 		// explicitly disable since we rely on http.Client timeout logic.
 		exporterhelper.WithTimeout(exporterhelper.TimeoutSettings{Timeout: 0}),
 		exporterhelper.WithRetry(oCfg.RetrySettings),
@@ -143,6 +145,7 @@ func createLogsExporter(
 		cfg,
 		params.Logger,
 		oce.pushLogData,
+		exporterhelper.WithStart(oce.start),
 		// explicitly disable since we rely on http.Client timeout logic.
 		exporterhelper.WithTimeout(exporterhelper.TimeoutSettings{Timeout: 0}),
 		exporterhelper.WithRetry(oCfg.RetrySettings),

--- a/exporter/otlphttpexporter/otlp.go
+++ b/exporter/otlphttpexporter/otlp.go
@@ -86,12 +86,10 @@ func newExporter(cfg config.Exporter, logger *zap.Logger) (*exporterImp, error) 
 	}, nil
 }
 
-
+// start overrides defaults base exporters start (no op) to attach auth transport to the http client.
+// This is the only place we get hold of Extensions which are required to construct auth round tripper.
 func (e *exporterImp) start(_ context.Context, host component.Host) error {
-	for k, _ := range host.GetExtensions() {
-		e.logger.Info(k.Name())
-	}
-    if e.config.HTTPClientSettings.Auth != nil {
+	if e.config.HTTPClientSettings.Auth != nil {
 		transport, err := e.config.HTTPClientSettings.AuthRoundTripper(e.client.Transport, host.GetExtensions())
 		if err != nil {
 			return err

--- a/extension/oauth2clientextension/README.md
+++ b/extension/oauth2clientextension/README.md
@@ -1,0 +1,33 @@
+# Authenticator - OIDC
+
+This extension implements a `configauth.Authenticator`, to be used in exporter inside the `auth` settings. The authenticator type has to be set to `oauth2`.
+
+## Configuration
+
+```yaml
+extensions:
+  oauth2:
+    client_id: someclientidentifier
+    client_secret: someclientsecret
+    token_url: https://autz.server/oauth2/default/v1/token
+    scopes: ["some.resource.read"]
+
+receivers:
+  otlp:
+    protocols:
+      grpc:
+
+processors:
+
+exporter:
+  otlphttp/withauth:
+    authentication:
+      authenticator: oauth2
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: []
+      exporters: [otlphttp/withauth]
+```

--- a/extension/oauth2clientextension/config.go
+++ b/extension/oauth2clientextension/config.go
@@ -1,0 +1,35 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oauth2clientextension
+
+import "go.opentelemetry.io/collector/config"
+
+// OAuth2ClientSettings stores the configuration for OAuth2 Client Credentials (2-legged OAuth2 flow) setup
+type OAuth2ClientSettings struct {
+	config.ExtensionSettings `mapstructure:",squash"`
+
+	// ClientID is the application's ID.
+	ClientID string `mapstructure:"client_id"`
+
+	// ClientSecret is the application's secret.
+	ClientSecret string `mapstructure:"client_secret"`
+
+	// TokenURL is the resource server's token endpoint
+	// URL. This is a constant specific to each server.
+	TokenURL string `mapstructure:"token_url"`
+
+	// Scope specifies optional requested permissions.
+	Scopes []string `mapstructure:"scopes,omitempty"`
+}

--- a/extension/oauth2clientextension/extension.go
+++ b/extension/oauth2clientextension/extension.go
@@ -1,0 +1,84 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oauth2clientextension
+
+import (
+	"context"
+	"errors"
+	"go.opentelemetry.io/collector/component"
+	"go.uber.org/zap"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/clientcredentials"
+	"google.golang.org/grpc/credentials"
+	grpcOAuth "google.golang.org/grpc/credentials/oauth"
+	"net/http"
+)
+
+var (
+	errNoClientIDProvided     = errors.New("no ClientID provided in the OAuth2 exporter configuration")
+	errNoTokenURLProvided     = errors.New("no TokenURL provided in OAuth Client Credentials configuration")
+	errNoClientSecretProvided = errors.New("no ClientSecret provided in OAuth Client Credentials configuration")
+)
+
+type OAuth2Authenticator struct {
+	clientCredentials *clientcredentials.Config
+	logger *zap.Logger
+}
+
+func newOAuth2Extension(cfg *OAuth2ClientSettings, logger *zap.Logger) (*OAuth2Authenticator, error) {
+	if cfg.ClientID == "" {
+		return nil, errNoClientIDProvided
+	}
+	if cfg.ClientSecret == "" {
+		return nil, errNoClientSecretProvided
+	}
+	if cfg.TokenURL == "" {
+		return nil, errNoTokenURLProvided
+	}
+	return &OAuth2Authenticator{
+		clientCredentials:    &clientcredentials.Config{
+			ClientID:     cfg.ClientID,
+			ClientSecret: cfg.ClientSecret,
+			TokenURL:     cfg.TokenURL,
+			Scopes:       cfg.Scopes,
+		},
+		logger: logger,
+	}, nil
+}
+
+func (O *OAuth2Authenticator) Start(ctx context.Context, host component.Host) error {
+	return nil
+}
+
+func (O *OAuth2Authenticator) Shutdown(ctx context.Context) error {
+	return nil
+}
+
+// RoundTripper returns oauth2.Transport, an http.RoundTripper that performs "client-credential" OAuth flow and
+// also auto refreshes OAuth tokens as needed.
+func (O *OAuth2Authenticator) RoundTripper(base http.RoundTripper) http.RoundTripper {
+	return &oauth2.Transport{
+		Source: O.clientCredentials.TokenSource(context.Background()),
+		Base:   base,
+	}
+}
+
+// PerRPCCredential returns gRPC PerRPCCredentials that supports "client-credential" OAuth flow. The underneath
+// oauth2.clientcredentials.Config instance will manage tokens performing auto refresh as necessary.
+func (O *OAuth2Authenticator) PerRPCCredential() (credentials.PerRPCCredentials, error) {
+	 return grpcOAuth.TokenSource{
+	 	TokenSource: O.clientCredentials.TokenSource(context.Background()),
+	 }, nil
+}

--- a/extension/oauth2clientextension/factory.go
+++ b/extension/oauth2clientextension/factory.go
@@ -1,0 +1,48 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oauth2clientextension
+
+import (
+	"context"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/extension/extensionhelper"
+)
+
+const (
+	// The value of extension "type" in configuration.
+	typeStr = "oauth2"
+)
+
+// NewFactory creates a factory for the OIDC Authenticator extension.
+func NewFactory() component.ExtensionFactory {
+	return extensionhelper.NewFactory(
+		typeStr,
+		createDefaultConfig,
+		createExtension)
+}
+
+func createDefaultConfig() config.Extension {
+	return &OAuth2ClientSettings{
+		ExtensionSettings: config.ExtensionSettings{
+			TypeVal: typeStr,
+			NameVal: typeStr,
+		},
+	}
+}
+
+func createExtension(_ context.Context, params component.ExtensionCreateParams, cfg config.Extension) (component.Extension, error) {
+	return newOAuth2Extension(cfg.(*OAuth2ClientSettings), params.Logger)
+}

--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	go.opencensus.io v0.23.0
 	go.uber.org/atomic v1.7.0
 	go.uber.org/zap v1.16.0
+	golang.org/x/oauth2 v0.0.0-20210210192628-66670185b0cd // indirect
 	golang.org/x/sys v0.0.0-20210316164454-77fc1eacc6aa
 	golang.org/x/text v0.3.6
 	google.golang.org/genproto v0.0.0-20210302174412-5ede27ff9881

--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	go.opencensus.io v0.23.0
 	go.uber.org/atomic v1.7.0
 	go.uber.org/zap v1.16.0
-	golang.org/x/oauth2 v0.0.0-20210210192628-66670185b0cd // indirect
+	golang.org/x/oauth2 v0.0.0-20210210192628-66670185b0cd
 	golang.org/x/sys v0.0.0-20210316164454-77fc1eacc6aa
 	golang.org/x/text v0.3.6
 	google.golang.org/genproto v0.0.0-20210302174412-5ede27ff9881

--- a/service/defaultcomponents/defaults.go
+++ b/service/defaultcomponents/defaults.go
@@ -30,6 +30,7 @@ import (
 	"go.opentelemetry.io/collector/exporter/zipkinexporter"
 	"go.opentelemetry.io/collector/extension/authoidcextension"
 	"go.opentelemetry.io/collector/extension/healthcheckextension"
+	"go.opentelemetry.io/collector/extension/oauth2clientextension"
 	"go.opentelemetry.io/collector/extension/pprofextension"
 	"go.opentelemetry.io/collector/extension/zpagesextension"
 	"go.opentelemetry.io/collector/processor/attributesprocessor"
@@ -61,6 +62,7 @@ func Components() (
 		healthcheckextension.NewFactory(),
 		pprofextension.NewFactory(),
 		zpagesextension.NewFactory(),
+		oauth2clientextension.NewFactory(),
 	)
 	if err != nil {
 		errs = append(errs, err)


### PR DESCRIPTION
**Description:** 
Adding a feature - This PR adds support to add client side (exporter) authenticators for HTTP and gRPC clients through extension based authenticators. This is built of top of what was added  for receiver (server) side authenticators via extensions in #2603 

This PR is an initial take and I have added only OAuth2 extension to OAuth2 Client Credential support for HTTP clients to demonstrate the workflow. Once agreed I can add bearer token Auth and Oauth2 client credential Auth for gRPC side as well. 

**Link to tracking Issue:** #3115

**Pending** 
This is a draft PR to get an approval on the design and direction to start conversation. There are these pending items 
- [ ] Need to add unit test cases 
- [ ] Doc strings wherever applicable 
- [ ] Add grpc auth extensions 

**Testing:** 
Did a manual testing using oauth2 server for HTTP clients - works fine. 

