### PR TITLE
[MINOR] Fixed documentation in exporterHelper module and OIDCExtension README

### DIFF
--- a/exporter/exporterhelper/common.go
+++ b/exporter/exporterhelper/common.go
@@ -102,7 +102,7 @@ func fromOptions(options []Option) *baseSettings {
 type Option func(*baseSettings)
 
 // WithStart overrides the default Start function for an exporter.
-// The default shutdown function does nothing and always returns nil.
+// The default start function does nothing and always returns nil.
 func WithStart(start componenthelper.StartFunc) Option {
 	return func(o *baseSettings) {
 		o.componentOptions = append(o.componentOptions, componenthelper.WithStart(start))

--- a/extension/authoidcextension/README.md
+++ b/extension/authoidcextension/README.md
@@ -27,6 +27,7 @@ exporters:
     logLevel: debug
 
 service:
+  extensions: [oidc]
   pipelines:
     traces:
       receivers: [otlp]


### PR DESCRIPTION
**Description:** 
While working on another PR noticed some typos in our documentation
1. oidcextension module's README sample example missed a key configuration 
2. exporterhelper module had a minor typo in one of its doc strings 

**Testing:** - Fixed comments