### PR TITLE
Minor improvement to remove arbitary args from the Jaeger tests

### DIFF
--- a/exporter/jaegerexporter/exporter_test.go
+++ b/exporter/jaegerexporter/exporter_test.go
@@ -41,121 +41,106 @@ import (
 )
 
 func TestNew(t *testing.T) {
-	type args struct {
-		config Config
-	}
 	tests := []struct {
 		name    string
-		args    args
+		config  Config
 		wantErr bool
 	}{
 		{
 			name: "createExporter",
-			args: args{
-				config: Config{
-					ExporterSettings: config.NewExporterSettings(config.NewID(typeStr)),
-					GRPCClientSettings: configgrpc.GRPCClientSettings{
-						Headers:     nil,
-						Endpoint:    "foo.bar",
-						Compression: "",
-						TLSSetting: configtls.TLSClientSetting{
-							Insecure: true,
-						},
-						Keepalive: nil,
+			config: Config{
+				ExporterSettings: config.NewExporterSettings(config.NewID(typeStr)),
+				GRPCClientSettings: configgrpc.GRPCClientSettings{
+					Headers:     nil,
+					Endpoint:    "foo.bar",
+					Compression: "",
+					TLSSetting: configtls.TLSClientSetting{
+						Insecure: true,
 					},
+					Keepalive: nil,
 				},
 			},
 		},
 		{
 			name: "createExporterWithHeaders",
-			args: args{
-				config: Config{
-					ExporterSettings: config.NewExporterSettings(config.NewID(typeStr)),
-					GRPCClientSettings: configgrpc.GRPCClientSettings{
-						Headers:     map[string]string{"extra-header": "header-value"},
-						Endpoint:    "foo.bar",
-						Compression: "",
-						Keepalive:   nil,
-					},
+			config: Config{
+				ExporterSettings: config.NewExporterSettings(config.NewID(typeStr)),
+				GRPCClientSettings: configgrpc.GRPCClientSettings{
+					Headers:     map[string]string{"extra-header": "header-value"},
+					Endpoint:    "foo.bar",
+					Compression: "",
+					Keepalive:   nil,
 				},
 			},
 		},
 		{
 			name: "createBasicSecureExporter",
-			args: args{
-				config: Config{
-					ExporterSettings: config.NewExporterSettings(config.NewID(typeStr)),
-					GRPCClientSettings: configgrpc.GRPCClientSettings{
-						Headers:     nil,
-						Endpoint:    "foo.bar",
-						Compression: "",
-						Keepalive:   nil,
-					},
+			config: Config{
+				ExporterSettings: config.NewExporterSettings(config.NewID(typeStr)),
+				GRPCClientSettings: configgrpc.GRPCClientSettings{
+					Headers:     nil,
+					Endpoint:    "foo.bar",
+					Compression: "",
+					Keepalive:   nil,
 				},
 			},
 		},
 		{
 			name: "createSecureExporterWithClientTLS",
-			args: args{
-				config: Config{
-					ExporterSettings: config.NewExporterSettings(config.NewID(typeStr)),
-					GRPCClientSettings: configgrpc.GRPCClientSettings{
-						Headers:     nil,
-						Endpoint:    "foo.bar",
-						Compression: "",
-						TLSSetting: configtls.TLSClientSetting{
-							TLSSetting: configtls.TLSSetting{
-								CAFile: "testdata/test_cert.pem",
-							},
-							Insecure: false,
+			config: Config{
+				ExporterSettings: config.NewExporterSettings(config.NewID(typeStr)),
+				GRPCClientSettings: configgrpc.GRPCClientSettings{
+					Headers:     nil,
+					Endpoint:    "foo.bar",
+					Compression: "",
+					TLSSetting: configtls.TLSClientSetting{
+						TLSSetting: configtls.TLSSetting{
+							CAFile: "testdata/test_cert.pem",
 						},
-						Keepalive: nil,
+						Insecure: false,
 					},
+					Keepalive: nil,
 				},
 			},
 		},
 		{
 			name: "createSecureExporterWithKeepAlive",
-			args: args{
-				config: Config{
-					ExporterSettings: config.NewExporterSettings(config.NewID(typeStr)),
-					GRPCClientSettings: configgrpc.GRPCClientSettings{
-						Headers:     nil,
-						Endpoint:    "foo.bar",
-						Compression: "",
-						TLSSetting: configtls.TLSClientSetting{
-							TLSSetting: configtls.TLSSetting{
-								CAFile: "testdata/test_cert.pem",
-							},
-							Insecure:   false,
-							ServerName: "",
+			config: Config{
+				ExporterSettings: config.NewExporterSettings(config.NewID(typeStr)),
+				GRPCClientSettings: configgrpc.GRPCClientSettings{
+					Headers:     nil,
+					Endpoint:    "foo.bar",
+					Compression: "",
+					TLSSetting: configtls.TLSClientSetting{
+						TLSSetting: configtls.TLSSetting{
+							CAFile: "testdata/test_cert.pem",
 						},
-						Keepalive: &configgrpc.KeepaliveClientConfig{
-							Time:                0,
-							Timeout:             0,
-							PermitWithoutStream: false,
-						},
+						Insecure:   false,
+						ServerName: "",
+					},
+					Keepalive: &configgrpc.KeepaliveClientConfig{
+						Time:                0,
+						Timeout:             0,
+						PermitWithoutStream: false,
 					},
 				},
 			},
 		},
 		{
 			name: "createSecureExporterWithMissingFile",
-			args: args{
-				config: Config{
-					ExporterSettings: config.NewExporterSettings(config.NewID(typeStr)),
-					GRPCClientSettings: configgrpc.GRPCClientSettings{
-						Headers:     nil,
-						Endpoint:    "foo.bar",
-						Compression: "",
-						TLSSetting: configtls.TLSClientSetting{
-							TLSSetting: configtls.TLSSetting{
-								CAFile: "testdata/test_cert_missing.pem",
-							},
-							Insecure: false,
+			config: Config{
+				ExporterSettings: config.NewExporterSettings(config.NewID(typeStr)),
+				GRPCClientSettings: configgrpc.GRPCClientSettings{
+					Headers:     nil,
+					Endpoint:    "foo.bar",
+					Compression: "",
+					TLSSetting: configtls.TLSClientSetting{
+						TLSSetting: configtls.TLSSetting{
+							CAFile: "testdata/test_cert_missing.pem",
 						},
-						Keepalive: nil,
+						Insecure: false,
 					},
+					Keepalive: nil,
 				},
 			},
 			wantErr: true,
@@ -163,7 +148,7 @@ func TestNew(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := newTracesExporter(&tt.args.config, zap.NewNop())
+			got, err := newTracesExporter(&tt.config, zap.NewNop())
 			if (err != nil) != tt.wantErr {
 				t.Errorf("newTracesExporter() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
The args is autogenerated by table-driven test generator tools but it's arbitrary.
