### PR TITLE
Standarize Settings, Params and Parameters in Exporters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Move BigEndian helper functions in `tracetranslator` to an internal package.(#3298)
 - Rename `configtest.LoadConfigFile` to `configtest.LoadConfigAndValidate` (#3306)
 - Replace `ExtensionCreateParams` with `ExtensionCreateSettings` (#3294)
+- Replace `ExporterCreateParams` with `ExporterCreateSettings` (#3164)
 
 ## 💡 Enhancements 💡
 

--- a/component/componenttest/nop_exporter.go
+++ b/component/componenttest/nop_exporter.go
@@ -52,7 +52,7 @@ func (f *nopExporterFactory) CreateDefaultConfig() config.Exporter {
 // CreateTracesExporter implements component.ExporterFactory interface.
 func (f *nopExporterFactory) CreateTracesExporter(
 	_ context.Context,
-	_ component.ExporterCreateParams,
+	_ component.ExporterCreateSettings,
 	_ config.Exporter,
 ) (component.TracesExporter, error) {
 	return nopExporterInstance, nil
@@ -61,7 +61,7 @@ func (f *nopExporterFactory) CreateTracesExporter(
 // CreateMetricsExporter implements component.ExporterFactory interface.
 func (f *nopExporterFactory) CreateMetricsExporter(
 	_ context.Context,
-	_ component.ExporterCreateParams,
+	_ component.ExporterCreateSettings,
 	_ config.Exporter,
 ) (component.MetricsExporter, error) {
 	return nopExporterInstance, nil
@@ -70,7 +70,7 @@ func (f *nopExporterFactory) CreateMetricsExporter(
 // CreateLogsExporter implements component.ExporterFactory interface.
 func (f *nopExporterFactory) CreateLogsExporter(
 	_ context.Context,
-	_ component.ExporterCreateParams,
+	_ component.ExporterCreateSettings,
 	_ config.Exporter,
 ) (component.LogsExporter, error) {
 	return nopExporterInstance, nil

--- a/component/componenttest/nop_exporter_test.go
+++ b/component/componenttest/nop_exporter_test.go
@@ -33,19 +33,19 @@ func TestNewNopExporterFactory(t *testing.T) {
 	cfg := factory.CreateDefaultConfig()
 	assert.Equal(t, &nopExporterConfig{ExporterSettings: config.NewExporterSettings(config.NewID("nop"))}, cfg)
 
-	traces, err := factory.CreateTracesExporter(context.Background(), component.ExporterCreateParams{}, cfg)
+	traces, err := factory.CreateTracesExporter(context.Background(), component.ExporterCreateSettings{}, cfg)
 	require.NoError(t, err)
 	assert.NoError(t, traces.Start(context.Background(), NewNopHost()))
 	assert.NoError(t, traces.ConsumeTraces(context.Background(), pdata.NewTraces()))
 	assert.NoError(t, traces.Shutdown(context.Background()))
 
-	metrics, err := factory.CreateMetricsExporter(context.Background(), component.ExporterCreateParams{}, cfg)
+	metrics, err := factory.CreateMetricsExporter(context.Background(), component.ExporterCreateSettings{}, cfg)
 	require.NoError(t, err)
 	assert.NoError(t, metrics.Start(context.Background(), NewNopHost()))
 	assert.NoError(t, metrics.ConsumeMetrics(context.Background(), pdata.NewMetrics()))
 	assert.NoError(t, metrics.Shutdown(context.Background()))
 
-	logs, err := factory.CreateLogsExporter(context.Background(), component.ExporterCreateParams{}, cfg)
+	logs, err := factory.CreateLogsExporter(context.Background(), component.ExporterCreateSettings{}, cfg)
 	require.NoError(t, err)
 	assert.NoError(t, logs.Start(context.Background(), NewNopHost()))
 	assert.NoError(t, logs.ConsumeLogs(context.Background(), pdata.NewLogs()))

--- a/component/exporter.go
+++ b/component/exporter.go
@@ -46,8 +46,8 @@ type LogsExporter interface {
 	consumer.Logs
 }
 
-// ExporterCreateParams configures Exporter creators.
-type ExporterCreateParams struct {
+// ExporterCreateSettings configures Exporter creators.
+type ExporterCreateSettings struct {
 	// Logger that the factory can use during creation and can pass to the created
 	// component to be used later as well.
 	Logger *zap.Logger
@@ -73,18 +73,18 @@ type ExporterFactory interface {
 	// CreateTracesExporter creates a trace exporter based on this config.
 	// If the exporter type does not support tracing or if the config is not valid,
 	// an error will be returned instead.
-	CreateTracesExporter(ctx context.Context, params ExporterCreateParams,
+	CreateTracesExporter(ctx context.Context, set ExporterCreateSettings,
 		cfg config.Exporter) (TracesExporter, error)
 
 	// CreateMetricsExporter creates a metrics exporter based on this config.
 	// If the exporter type does not support metrics or if the config is not valid,
 	// an error will be returned instead.
-	CreateMetricsExporter(ctx context.Context, params ExporterCreateParams,
+	CreateMetricsExporter(ctx context.Context, set ExporterCreateSettings,
 		cfg config.Exporter) (MetricsExporter, error)
 
 	// CreateLogsExporter creates an exporter based on the config.
 	// If the exporter type does not support logs or if the config is not valid,
 	// an error will be returned instead.
-	CreateLogsExporter(ctx context.Context, params ExporterCreateParams,
+	CreateLogsExporter(ctx context.Context, set ExporterCreateSettings,
 		cfg config.Exporter) (LogsExporter, error)
 }

--- a/component/exporter_test.go
+++ b/component/exporter_test.go
@@ -39,17 +39,17 @@ func (f *TestExporterFactory) CreateDefaultConfig() config.Exporter {
 }
 
 // CreateTracesExporter creates a trace exporter based on this config.
-func (f *TestExporterFactory) CreateTracesExporter(context.Context, ExporterCreateParams, config.Exporter) (TracesExporter, error) {
+func (f *TestExporterFactory) CreateTracesExporter(context.Context, ExporterCreateSettings, config.Exporter) (TracesExporter, error) {
 	return nil, componenterror.ErrDataTypeIsNotSupported
 }
 
 // CreateMetricsExporter creates a metrics exporter based on this config.
-func (f *TestExporterFactory) CreateMetricsExporter(context.Context, ExporterCreateParams, config.Exporter) (MetricsExporter, error) {
+func (f *TestExporterFactory) CreateMetricsExporter(context.Context, ExporterCreateSettings, config.Exporter) (MetricsExporter, error) {
 	return nil, componenterror.ErrDataTypeIsNotSupported
 }
 
 // CreateLogsExporter creates a logs exporter based on this config.
-func (f *TestExporterFactory) CreateLogsExporter(context.Context, ExporterCreateParams, config.Exporter) (LogsExporter, error) {
+func (f *TestExporterFactory) CreateLogsExporter(context.Context, ExporterCreateSettings, config.Exporter) (LogsExporter, error) {
 	return nil, componenterror.ErrDataTypeIsNotSupported
 }
 

--- a/exporter/exporterhelper/factory.go
+++ b/exporter/exporterhelper/factory.go
@@ -29,13 +29,13 @@ type FactoryOption func(o *factory)
 type CreateDefaultConfig func() config.Exporter
 
 // CreateTracesExporter is the equivalent of component.ExporterFactory.CreateTracesExporter()
-type CreateTracesExporter func(context.Context, component.ExporterCreateParams, config.Exporter) (component.TracesExporter, error)
+type CreateTracesExporter func(context.Context, component.ExporterCreateSettings, config.Exporter) (component.TracesExporter, error)
 
 // CreateMetricsExporter is the equivalent of component.ExporterFactory.CreateMetricsExporter()
-type CreateMetricsExporter func(context.Context, component.ExporterCreateParams, config.Exporter) (component.MetricsExporter, error)
+type CreateMetricsExporter func(context.Context, component.ExporterCreateSettings, config.Exporter) (component.MetricsExporter, error)
 
 // CreateLogsExporter is the equivalent of component.ExporterFactory.CreateLogsExporter()
-type CreateLogsExporter func(context.Context, component.ExporterCreateParams, config.Exporter) (component.LogsExporter, error)
+type CreateLogsExporter func(context.Context, component.ExporterCreateSettings, config.Exporter) (component.LogsExporter, error)
 
 type factory struct {
 	cfgType               config.Type
@@ -94,10 +94,10 @@ func (f *factory) CreateDefaultConfig() config.Exporter {
 // CreateTracesExporter creates a component.TracesExporter based on this config.
 func (f *factory) CreateTracesExporter(
 	ctx context.Context,
-	params component.ExporterCreateParams,
+	set component.ExporterCreateSettings,
 	cfg config.Exporter) (component.TracesExporter, error) {
 	if f.createTracesExporter != nil {
-		return f.createTracesExporter(ctx, params, cfg)
+		return f.createTracesExporter(ctx, set, cfg)
 	}
 	return nil, componenterror.ErrDataTypeIsNotSupported
 }
@@ -105,10 +105,10 @@ func (f *factory) CreateTracesExporter(
 // CreateMetricsExporter creates a component.MetricsExporter based on this config.
 func (f *factory) CreateMetricsExporter(
 	ctx context.Context,
-	params component.ExporterCreateParams,
+	set component.ExporterCreateSettings,
 	cfg config.Exporter) (component.MetricsExporter, error) {
 	if f.createMetricsExporter != nil {
-		return f.createMetricsExporter(ctx, params, cfg)
+		return f.createMetricsExporter(ctx, set, cfg)
 	}
 	return nil, componenterror.ErrDataTypeIsNotSupported
 }
@@ -116,11 +116,11 @@ func (f *factory) CreateMetricsExporter(
 // CreateLogsExporter creates a metrics processor based on this config.
 func (f *factory) CreateLogsExporter(
 	ctx context.Context,
-	params component.ExporterCreateParams,
+	set component.ExporterCreateSettings,
 	cfg config.Exporter,
 ) (component.LogsExporter, error) {
 	if f.createLogsExporter != nil {
-		return f.createLogsExporter(ctx, params, cfg)
+		return f.createLogsExporter(ctx, set, cfg)
 	}
 	return nil, componenterror.ErrDataTypeIsNotSupported
 }

--- a/exporter/exporterhelper/factory_test.go
+++ b/exporter/exporterhelper/factory_test.go
@@ -48,11 +48,11 @@ func TestNewFactory(t *testing.T) {
 		defaultConfig)
 	assert.EqualValues(t, typeStr, factory.Type())
 	assert.EqualValues(t, &defaultCfg, factory.CreateDefaultConfig())
-	_, err := factory.CreateTracesExporter(context.Background(), component.ExporterCreateParams{Logger: zap.NewNop()}, &defaultCfg)
+	_, err := factory.CreateTracesExporter(context.Background(), component.ExporterCreateSettings{Logger: zap.NewNop()}, &defaultCfg)
 	assert.Equal(t, componenterror.ErrDataTypeIsNotSupported, err)
-	_, err = factory.CreateMetricsExporter(context.Background(), component.ExporterCreateParams{Logger: zap.NewNop()}, &defaultCfg)
+	_, err = factory.CreateMetricsExporter(context.Background(), component.ExporterCreateSettings{Logger: zap.NewNop()}, &defaultCfg)
 	assert.Equal(t, componenterror.ErrDataTypeIsNotSupported, err)
-	_, err = factory.CreateLogsExporter(context.Background(), component.ExporterCreateParams{Logger: zap.NewNop()}, &defaultCfg)
+	_, err = factory.CreateLogsExporter(context.Background(), component.ExporterCreateSettings{Logger: zap.NewNop()}, &defaultCfg)
 	assert.Equal(t, componenterror.ErrDataTypeIsNotSupported, err)
 }
 
@@ -66,15 +66,15 @@ func TestNewFactory_WithConstructors(t *testing.T) {
 	assert.EqualValues(t, typeStr, factory.Type())
 	assert.EqualValues(t, &defaultCfg, factory.CreateDefaultConfig())
 
-	te, err := factory.CreateTracesExporter(context.Background(), component.ExporterCreateParams{Logger: zap.NewNop()}, &defaultCfg)
+	te, err := factory.CreateTracesExporter(context.Background(), component.ExporterCreateSettings{Logger: zap.NewNop()}, &defaultCfg)
 	assert.NoError(t, err)
 	assert.Same(t, nopTracesExporter, te)
 
-	me, err := factory.CreateMetricsExporter(context.Background(), component.ExporterCreateParams{Logger: zap.NewNop()}, &defaultCfg)
+	me, err := factory.CreateMetricsExporter(context.Background(), component.ExporterCreateSettings{Logger: zap.NewNop()}, &defaultCfg)
 	assert.NoError(t, err)
 	assert.Same(t, nopMetricsExporter, me)
 
-	le, err := factory.CreateLogsExporter(context.Background(), component.ExporterCreateParams{Logger: zap.NewNop()}, &defaultCfg)
+	le, err := factory.CreateLogsExporter(context.Background(), component.ExporterCreateSettings{Logger: zap.NewNop()}, &defaultCfg)
 	assert.NoError(t, err)
 	assert.Same(t, nopLogsExporter, le)
 }
@@ -83,14 +83,14 @@ func defaultConfig() config.Exporter {
 	return &defaultCfg
 }
 
-func createTracesExporter(context.Context, component.ExporterCreateParams, config.Exporter) (component.TracesExporter, error) {
+func createTracesExporter(context.Context, component.ExporterCreateSettings, config.Exporter) (component.TracesExporter, error) {
 	return nopTracesExporter, nil
 }
 
-func createMetricsExporter(context.Context, component.ExporterCreateParams, config.Exporter) (component.MetricsExporter, error) {
+func createMetricsExporter(context.Context, component.ExporterCreateSettings, config.Exporter) (component.MetricsExporter, error) {
 	return nopMetricsExporter, nil
 }
 
-func createLogsExporter(context.Context, component.ExporterCreateParams, config.Exporter) (component.LogsExporter, error) {
+func createLogsExporter(context.Context, component.ExporterCreateSettings, config.Exporter) (component.LogsExporter, error) {
 	return nopLogsExporter, nil
 }

--- a/exporter/fileexporter/factory.go
+++ b/exporter/fileexporter/factory.go
@@ -46,7 +46,7 @@ func createDefaultConfig() config.Exporter {
 
 func createTracesExporter(
 	_ context.Context,
-	params component.ExporterCreateParams,
+	set component.ExporterCreateSettings,
 	cfg config.Exporter,
 ) (component.TracesExporter, error) {
 	fe := exporters.GetOrAdd(cfg, func() component.Component {
@@ -54,7 +54,7 @@ func createTracesExporter(
 	})
 	return exporterhelper.NewTracesExporter(
 		cfg,
-		params.Logger,
+		set.Logger,
 		fe.Unwrap().(*fileExporter).ConsumeTraces,
 		exporterhelper.WithStart(fe.Start),
 		exporterhelper.WithShutdown(fe.Shutdown),
@@ -63,7 +63,7 @@ func createTracesExporter(
 
 func createMetricsExporter(
 	_ context.Context,
-	params component.ExporterCreateParams,
+	set component.ExporterCreateSettings,
 	cfg config.Exporter,
 ) (component.MetricsExporter, error) {
 	fe := exporters.GetOrAdd(cfg, func() component.Component {
@@ -71,7 +71,7 @@ func createMetricsExporter(
 	})
 	return exporterhelper.NewMetricsExporter(
 		cfg,
-		params.Logger,
+		set.Logger,
 		fe.Unwrap().(*fileExporter).ConsumeMetrics,
 		exporterhelper.WithStart(fe.Start),
 		exporterhelper.WithShutdown(fe.Shutdown),
@@ -80,7 +80,7 @@ func createMetricsExporter(
 
 func createLogsExporter(
 	_ context.Context,
-	params component.ExporterCreateParams,
+	set component.ExporterCreateSettings,
 	cfg config.Exporter,
 ) (component.LogsExporter, error) {
 	fe := exporters.GetOrAdd(cfg, func() component.Component {
@@ -88,7 +88,7 @@ func createLogsExporter(
 	})
 	return exporterhelper.NewLogsExporter(
 		cfg,
-		params.Logger,
+		set.Logger,
 		fe.Unwrap().(*fileExporter).ConsumeLogs,
 		exporterhelper.WithStart(fe.Start),
 		exporterhelper.WithShutdown(fe.Shutdown),

--- a/exporter/fileexporter/factory_test.go
+++ b/exporter/fileexporter/factory_test.go
@@ -36,7 +36,7 @@ func TestCreateMetricsExporter(t *testing.T) {
 	cfg := createDefaultConfig()
 	exp, err := createMetricsExporter(
 		context.Background(),
-		component.ExporterCreateParams{Logger: zap.NewNop()},
+		component.ExporterCreateSettings{Logger: zap.NewNop()},
 		cfg)
 	assert.NoError(t, err)
 	require.NotNil(t, exp)
@@ -46,7 +46,7 @@ func TestCreateTracesExporter(t *testing.T) {
 	cfg := createDefaultConfig()
 	exp, err := createTracesExporter(
 		context.Background(),
-		component.ExporterCreateParams{Logger: zap.NewNop()},
+		component.ExporterCreateSettings{Logger: zap.NewNop()},
 		cfg)
 	assert.NoError(t, err)
 	require.NotNil(t, exp)
@@ -56,7 +56,7 @@ func TestCreateLogsExporter(t *testing.T) {
 	cfg := createDefaultConfig()
 	exp, err := createLogsExporter(
 		context.Background(),
-		component.ExporterCreateParams{Logger: zap.NewNop()},
+		component.ExporterCreateSettings{Logger: zap.NewNop()},
 		cfg)
 	assert.NoError(t, err)
 	require.NotNil(t, exp)

--- a/exporter/jaegerexporter/config_test.go
+++ b/exporter/jaegerexporter/config_test.go
@@ -71,8 +71,8 @@ func TestLoadConfig(t *testing.T) {
 			},
 		})
 
-	params := component.ExporterCreateParams{Logger: zap.NewNop()}
-	te, err := factory.CreateTracesExporter(context.Background(), params, e1)
+	set := component.ExporterCreateSettings{Logger: zap.NewNop()}
+	te, err := factory.CreateTracesExporter(context.Background(), set, e1)
 	require.NoError(t, err)
 	require.NotNil(t, te)
 }

--- a/exporter/jaegerexporter/exporter_test.go
+++ b/exporter/jaegerexporter/exporter_test.go
@@ -223,7 +223,7 @@ func TestMutualTLS(t *testing.T) {
 			ServerName: "localhost",
 		},
 	}
-	exporter, err := factory.CreateTracesExporter(context.Background(), component.ExporterCreateParams{Logger: zap.NewNop()}, cfg)
+	exporter, err := factory.CreateTracesExporter(context.Background(), component.ExporterCreateSettings{Logger: zap.NewNop()}, cfg)
 	require.NoError(t, err)
 	err = exporter.Start(context.Background(), componenttest.NewNopHost())
 	require.NoError(t, err)

--- a/exporter/jaegerexporter/factory.go
+++ b/exporter/jaegerexporter/factory.go
@@ -52,7 +52,7 @@ func createDefaultConfig() config.Exporter {
 
 func createTracesExporter(
 	_ context.Context,
-	params component.ExporterCreateParams,
+	set component.ExporterCreateSettings,
 	config config.Exporter,
 ) (component.TracesExporter, error) {
 
@@ -64,5 +64,5 @@ func createTracesExporter(
 			expCfg.ID().String())
 	}
 
-	return newTracesExporter(expCfg, params.Logger)
+	return newTracesExporter(expCfg, set.Logger)
 }

--- a/exporter/jaegerexporter/factory_test.go
+++ b/exporter/jaegerexporter/factory_test.go
@@ -37,8 +37,8 @@ func TestCreateMetricsExporter(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
 
-	params := component.ExporterCreateParams{Logger: zap.NewNop()}
-	_, err := factory.CreateMetricsExporter(context.Background(), params, cfg)
+	set := component.ExporterCreateSettings{Logger: zap.NewNop()}
+	_, err := factory.CreateMetricsExporter(context.Background(), set, cfg)
 	assert.Error(t, err, componenterror.ErrDataTypeIsNotSupported)
 }
 
@@ -49,8 +49,8 @@ func TestCreateInstanceViaFactory(t *testing.T) {
 
 	// Default config doesn't have default endpoint so creating from it should
 	// fail.
-	params := component.ExporterCreateParams{Logger: zap.NewNop()}
-	exp, err := factory.CreateTracesExporter(context.Background(), params, cfg)
+	set := component.ExporterCreateSettings{Logger: zap.NewNop()}
+	exp, err := factory.CreateTracesExporter(context.Background(), set, cfg)
 	assert.NotNil(t, err)
 	assert.Equal(t, "\"jaeger\" config requires a non-empty \"endpoint\"", err.Error())
 	assert.Nil(t, exp)
@@ -58,7 +58,7 @@ func TestCreateInstanceViaFactory(t *testing.T) {
 	// Endpoint doesn't have a default value so set it directly.
 	expCfg := cfg.(*Config)
 	expCfg.Endpoint = "some.target.org:12345"
-	exp, err = factory.CreateTracesExporter(context.Background(), params, cfg)
+	exp, err = factory.CreateTracesExporter(context.Background(), set, cfg)
 	assert.NoError(t, err)
 	assert.NotNil(t, exp)
 

--- a/exporter/kafkaexporter/factory.go
+++ b/exporter/kafkaexporter/factory.go
@@ -98,20 +98,20 @@ type kafkaExporterFactory struct {
 
 func (f *kafkaExporterFactory) createTracesExporter(
 	_ context.Context,
-	params component.ExporterCreateParams,
+	set component.ExporterCreateSettings,
 	cfg config.Exporter,
 ) (component.TracesExporter, error) {
 	oCfg := cfg.(*Config)
 	if oCfg.Topic == "" {
 		oCfg.Topic = defaultTracesTopic
 	}
-	exp, err := newTracesExporter(*oCfg, params, f.tracesMarshalers)
+	exp, err := newTracesExporter(*oCfg, set, f.tracesMarshalers)
 	if err != nil {
 		return nil, err
 	}
 	return exporterhelper.NewTracesExporter(
 		cfg,
-		params.Logger,
+		set.Logger,
 		exp.tracesPusher,
 		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
 		// Disable exporterhelper Timeout, because we cannot pass a Context to the Producer,
@@ -124,20 +124,20 @@ func (f *kafkaExporterFactory) createTracesExporter(
 
 func (f *kafkaExporterFactory) createMetricsExporter(
 	_ context.Context,
-	params component.ExporterCreateParams,
+	set component.ExporterCreateSettings,
 	cfg config.Exporter,
 ) (component.MetricsExporter, error) {
 	oCfg := cfg.(*Config)
 	if oCfg.Topic == "" {
 		oCfg.Topic = defaultMetricsTopic
 	}
-	exp, err := newMetricsExporter(*oCfg, params, f.metricsMarshalers)
+	exp, err := newMetricsExporter(*oCfg, set, f.metricsMarshalers)
 	if err != nil {
 		return nil, err
 	}
 	return exporterhelper.NewMetricsExporter(
 		cfg,
-		params.Logger,
+		set.Logger,
 		exp.metricsDataPusher,
 		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
 		// Disable exporterhelper Timeout, because we cannot pass a Context to the Producer,
@@ -150,20 +150,20 @@ func (f *kafkaExporterFactory) createMetricsExporter(
 
 func (f *kafkaExporterFactory) createLogsExporter(
 	_ context.Context,
-	params component.ExporterCreateParams,
+	set component.ExporterCreateSettings,
 	cfg config.Exporter,
 ) (component.LogsExporter, error) {
 	oCfg := cfg.(*Config)
 	if oCfg.Topic == "" {
 		oCfg.Topic = defaultLogsTopic
 	}
-	exp, err := newLogsExporter(*oCfg, params, f.logsMarshalers)
+	exp, err := newLogsExporter(*oCfg, set, f.logsMarshalers)
 	if err != nil {
 		return nil, err
 	}
 	return exporterhelper.NewLogsExporter(
 		cfg,
-		params.Logger,
+		set.Logger,
 		exp.logsDataPusher,
 		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
 		// Disable exporterhelper Timeout, because we cannot pass a Context to the Producer,

--- a/exporter/kafkaexporter/factory_test.go
+++ b/exporter/kafkaexporter/factory_test.go
@@ -43,7 +43,7 @@ func TestCreateTracesExporter(t *testing.T) {
 	// this disables contacting the broker so we can successfully create the exporter
 	cfg.Metadata.Full = false
 	f := kafkaExporterFactory{tracesMarshalers: tracesMarshalers()}
-	r, err := f.createTracesExporter(context.Background(), component.ExporterCreateParams{Logger: zap.NewNop()}, cfg)
+	r, err := f.createTracesExporter(context.Background(), component.ExporterCreateSettings{Logger: zap.NewNop()}, cfg)
 	require.NoError(t, err)
 	assert.NotNil(t, r)
 }
@@ -55,7 +55,7 @@ func TestCreateMetricsExport(t *testing.T) {
 	// this disables contacting the broker so we can successfully create the exporter
 	cfg.Metadata.Full = false
 	mf := kafkaExporterFactory{metricsMarshalers: metricsMarshalers()}
-	mr, err := mf.createMetricsExporter(context.Background(), component.ExporterCreateParams{Logger: zap.NewNop()}, cfg)
+	mr, err := mf.createMetricsExporter(context.Background(), component.ExporterCreateSettings{Logger: zap.NewNop()}, cfg)
 	require.NoError(t, err)
 	assert.NotNil(t, mr)
 }
@@ -67,7 +67,7 @@ func TestCreateLogsExport(t *testing.T) {
 	// this disables contacting the broker so we can successfully create the exporter
 	cfg.Metadata.Full = false
 	mf := kafkaExporterFactory{logsMarshalers: logsMarshalers()}
-	mr, err := mf.createLogsExporter(context.Background(), component.ExporterCreateParams{Logger: zap.NewNop()}, cfg)
+	mr, err := mf.createLogsExporter(context.Background(), component.ExporterCreateSettings{Logger: zap.NewNop()}, cfg)
 	require.NoError(t, err)
 	assert.NotNil(t, mr)
 }
@@ -77,7 +77,7 @@ func TestCreateTracesExporter_err(t *testing.T) {
 	cfg.Brokers = []string{"invalid:9092"}
 	cfg.ProtocolVersion = "2.0.0"
 	f := kafkaExporterFactory{tracesMarshalers: tracesMarshalers()}
-	r, err := f.createTracesExporter(context.Background(), component.ExporterCreateParams{Logger: zap.NewNop()}, cfg)
+	r, err := f.createTracesExporter(context.Background(), component.ExporterCreateSettings{Logger: zap.NewNop()}, cfg)
 	// no available broker
 	require.Error(t, err)
 	assert.Nil(t, r)
@@ -88,7 +88,7 @@ func TestCreateMetricsExporter_err(t *testing.T) {
 	cfg.Brokers = []string{"invalid:9092"}
 	cfg.ProtocolVersion = "2.0.0"
 	mf := kafkaExporterFactory{metricsMarshalers: metricsMarshalers()}
-	mr, err := mf.createMetricsExporter(context.Background(), component.ExporterCreateParams{Logger: zap.NewNop()}, cfg)
+	mr, err := mf.createMetricsExporter(context.Background(), component.ExporterCreateSettings{Logger: zap.NewNop()}, cfg)
 	require.Error(t, err)
 	assert.Nil(t, mr)
 }
@@ -98,7 +98,7 @@ func TestCreateLogsExporter_err(t *testing.T) {
 	cfg.Brokers = []string{"invalid:9092"}
 	cfg.ProtocolVersion = "2.0.0"
 	mf := kafkaExporterFactory{logsMarshalers: logsMarshalers()}
-	mr, err := mf.createLogsExporter(context.Background(), component.ExporterCreateParams{Logger: zap.NewNop()}, cfg)
+	mr, err := mf.createLogsExporter(context.Background(), component.ExporterCreateSettings{Logger: zap.NewNop()}, cfg)
 	require.Error(t, err)
 	assert.Nil(t, mr)
 }
@@ -112,13 +112,13 @@ func TestWithMarshalers(t *testing.T) {
 
 	t.Run("custom_encoding", func(t *testing.T) {
 		cfg.Encoding = cm.Encoding()
-		exporter, err := f.CreateTracesExporter(context.Background(), component.ExporterCreateParams{Logger: zap.NewNop()}, cfg)
+		exporter, err := f.CreateTracesExporter(context.Background(), component.ExporterCreateSettings{Logger: zap.NewNop()}, cfg)
 		require.NoError(t, err)
 		require.NotNil(t, exporter)
 	})
 	t.Run("default_encoding", func(t *testing.T) {
 		cfg.Encoding = new(otlpTracesPbMarshaler).Encoding()
-		exporter, err := f.CreateTracesExporter(context.Background(), component.ExporterCreateParams{Logger: zap.NewNop()}, cfg)
+		exporter, err := f.CreateTracesExporter(context.Background(), component.ExporterCreateSettings{Logger: zap.NewNop()}, cfg)
 		require.NoError(t, err)
 		assert.NotNil(t, exporter)
 	})

--- a/exporter/kafkaexporter/kafka_exporter.go
+++ b/exporter/kafkaexporter/kafka_exporter.go
@@ -129,7 +129,7 @@ func newSaramaProducer(config Config) (sarama.SyncProducer, error) {
 	return producer, nil
 }
 
-func newMetricsExporter(config Config, params component.ExporterCreateParams, marshalers map[string]MetricsMarshaler) (*kafkaMetricsProducer, error) {
+func newMetricsExporter(config Config, set component.ExporterCreateSettings, marshalers map[string]MetricsMarshaler) (*kafkaMetricsProducer, error) {
 	marshaler := marshalers[config.Encoding]
 	if marshaler == nil {
 		return nil, errUnrecognizedEncoding
@@ -143,13 +143,13 @@ func newMetricsExporter(config Config, params component.ExporterCreateParams, ma
 		producer:  producer,
 		topic:     config.Topic,
 		marshaler: marshaler,
-		logger:    params.Logger,
+		logger:    set.Logger,
 	}, nil
 
 }
 
 // newTracesExporter creates Kafka exporter.
-func newTracesExporter(config Config, params component.ExporterCreateParams, marshalers map[string]TracesMarshaler) (*kafkaTracesProducer, error) {
+func newTracesExporter(config Config, set component.ExporterCreateSettings, marshalers map[string]TracesMarshaler) (*kafkaTracesProducer, error) {
 	marshaler := marshalers[config.Encoding]
 	if marshaler == nil {
 		return nil, errUnrecognizedEncoding
@@ -162,11 +162,11 @@ func newTracesExporter(config Config, params component.ExporterCreateParams, mar
 		producer:  producer,
 		topic:     config.Topic,
 		marshaler: marshaler,
-		logger:    params.Logger,
+		logger:    set.Logger,
 	}, nil
 }
 
-func newLogsExporter(config Config, params component.ExporterCreateParams, marshalers map[string]LogsMarshaler) (*kafkaLogsProducer, error) {
+func newLogsExporter(config Config, set component.ExporterCreateSettings, marshalers map[string]LogsMarshaler) (*kafkaLogsProducer, error) {
 	marshaler := marshalers[config.Encoding]
 	if marshaler == nil {
 		return nil, errUnrecognizedEncoding
@@ -180,7 +180,7 @@ func newLogsExporter(config Config, params component.ExporterCreateParams, marsh
 		producer:  producer,
 		topic:     config.Topic,
 		marshaler: marshaler,
-		logger:    params.Logger,
+		logger:    set.Logger,
 	}, nil
 
 }

--- a/exporter/kafkaexporter/kafka_exporter_test.go
+++ b/exporter/kafkaexporter/kafka_exporter_test.go
@@ -33,56 +33,56 @@ import (
 
 func TestNewExporter_err_version(t *testing.T) {
 	c := Config{ProtocolVersion: "0.0.0", Encoding: defaultEncoding}
-	texp, err := newTracesExporter(c, component.ExporterCreateParams{Logger: zap.NewNop()}, tracesMarshalers())
+	texp, err := newTracesExporter(c, component.ExporterCreateSettings{Logger: zap.NewNop()}, tracesMarshalers())
 	assert.Error(t, err)
 	assert.Nil(t, texp)
 }
 
 func TestNewExporter_err_encoding(t *testing.T) {
 	c := Config{Encoding: "foo"}
-	texp, err := newTracesExporter(c, component.ExporterCreateParams{Logger: zap.NewNop()}, tracesMarshalers())
+	texp, err := newTracesExporter(c, component.ExporterCreateSettings{Logger: zap.NewNop()}, tracesMarshalers())
 	assert.EqualError(t, err, errUnrecognizedEncoding.Error())
 	assert.Nil(t, texp)
 }
 
 func TestNewMetricsExporter_err_version(t *testing.T) {
 	c := Config{ProtocolVersion: "0.0.0", Encoding: defaultEncoding}
-	mexp, err := newMetricsExporter(c, component.ExporterCreateParams{Logger: zap.NewNop()}, metricsMarshalers())
+	mexp, err := newMetricsExporter(c, component.ExporterCreateSettings{Logger: zap.NewNop()}, metricsMarshalers())
 	assert.Error(t, err)
 	assert.Nil(t, mexp)
 }
 
 func TestNewMetricsExporter_err_encoding(t *testing.T) {
 	c := Config{Encoding: "bar"}
-	mexp, err := newMetricsExporter(c, component.ExporterCreateParams{Logger: zap.NewNop()}, metricsMarshalers())
+	mexp, err := newMetricsExporter(c, component.ExporterCreateSettings{Logger: zap.NewNop()}, metricsMarshalers())
 	assert.EqualError(t, err, errUnrecognizedEncoding.Error())
 	assert.Nil(t, mexp)
 }
 
 func TestNewMetricsExporter_err_traces_encoding(t *testing.T) {
 	c := Config{Encoding: "jaeger_proto"}
-	mexp, err := newMetricsExporter(c, component.ExporterCreateParams{Logger: zap.NewNop()}, metricsMarshalers())
+	mexp, err := newMetricsExporter(c, component.ExporterCreateSettings{Logger: zap.NewNop()}, metricsMarshalers())
 	assert.EqualError(t, err, errUnrecognizedEncoding.Error())
 	assert.Nil(t, mexp)
 }
 
 func TestNewLogsExporter_err_version(t *testing.T) {
 	c := Config{ProtocolVersion: "0.0.0", Encoding: defaultEncoding}
-	mexp, err := newLogsExporter(c, component.ExporterCreateParams{Logger: zap.NewNop()}, logsMarshalers())
+	mexp, err := newLogsExporter(c, component.ExporterCreateSettings{Logger: zap.NewNop()}, logsMarshalers())
 	assert.Error(t, err)
 	assert.Nil(t, mexp)
 }
 
 func TestNewLogsExporter_err_encoding(t *testing.T) {
 	c := Config{Encoding: "bar"}
-	mexp, err := newLogsExporter(c, component.ExporterCreateParams{Logger: zap.NewNop()}, logsMarshalers())
+	mexp, err := newLogsExporter(c, component.ExporterCreateSettings{Logger: zap.NewNop()}, logsMarshalers())
 	assert.EqualError(t, err, errUnrecognizedEncoding.Error())
 	assert.Nil(t, mexp)
 }
 
 func TestNewLogsExporter_err_traces_encoding(t *testing.T) {
 	c := Config{Encoding: "jaeger_proto"}
-	mexp, err := newLogsExporter(c, component.ExporterCreateParams{Logger: zap.NewNop()}, logsMarshalers())
+	mexp, err := newLogsExporter(c, component.ExporterCreateSettings{Logger: zap.NewNop()}, logsMarshalers())
 	assert.EqualError(t, err, errUnrecognizedEncoding.Error())
 	assert.Nil(t, mexp)
 }
@@ -102,15 +102,15 @@ func TestNewExporter_err_auth_type(t *testing.T) {
 			Full: false,
 		},
 	}
-	texp, err := newTracesExporter(c, component.ExporterCreateParams{Logger: zap.NewNop()}, tracesMarshalers())
+	texp, err := newTracesExporter(c, component.ExporterCreateSettings{Logger: zap.NewNop()}, tracesMarshalers())
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to load TLS config")
 	assert.Nil(t, texp)
-	mexp, err := newMetricsExporter(c, component.ExporterCreateParams{Logger: zap.NewNop()}, metricsMarshalers())
+	mexp, err := newMetricsExporter(c, component.ExporterCreateSettings{Logger: zap.NewNop()}, metricsMarshalers())
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to load TLS config")
 	assert.Nil(t, mexp)
-	lexp, err := newLogsExporter(c, component.ExporterCreateParams{Logger: zap.NewNop()}, logsMarshalers())
+	lexp, err := newLogsExporter(c, component.ExporterCreateSettings{Logger: zap.NewNop()}, logsMarshalers())
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to load TLS config")
 	assert.Nil(t, lexp)

--- a/exporter/loggingexporter/factory.go
+++ b/exporter/loggingexporter/factory.go
@@ -51,7 +51,7 @@ func createDefaultConfig() config.Exporter {
 	}
 }
 
-func createTracesExporter(_ context.Context, _ component.ExporterCreateParams, config config.Exporter) (component.TracesExporter, error) {
+func createTracesExporter(_ context.Context, _ component.ExporterCreateSettings, config config.Exporter) (component.TracesExporter, error) {
 	cfg := config.(*Config)
 
 	exporterLogger, err := createLogger(cfg)
@@ -62,7 +62,7 @@ func createTracesExporter(_ context.Context, _ component.ExporterCreateParams, c
 	return newTracesExporter(config, cfg.LogLevel, exporterLogger)
 }
 
-func createMetricsExporter(_ context.Context, _ component.ExporterCreateParams, config config.Exporter) (component.MetricsExporter, error) {
+func createMetricsExporter(_ context.Context, _ component.ExporterCreateSettings, config config.Exporter) (component.MetricsExporter, error) {
 	cfg := config.(*Config)
 
 	exporterLogger, err := createLogger(cfg)
@@ -73,7 +73,7 @@ func createMetricsExporter(_ context.Context, _ component.ExporterCreateParams, 
 	return newMetricsExporter(config, cfg.LogLevel, exporterLogger)
 }
 
-func createLogsExporter(_ context.Context, _ component.ExporterCreateParams, config config.Exporter) (component.LogsExporter, error) {
+func createLogsExporter(_ context.Context, _ component.ExporterCreateSettings, config config.Exporter) (component.LogsExporter, error) {
 	cfg := config.(*Config)
 
 	exporterLogger, err := createLogger(cfg)

--- a/exporter/loggingexporter/factory_test.go
+++ b/exporter/loggingexporter/factory_test.go
@@ -36,7 +36,7 @@ func TestCreateMetricsExporter(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
 
-	me, err := factory.CreateMetricsExporter(context.Background(), component.ExporterCreateParams{Logger: zap.NewNop()}, cfg)
+	me, err := factory.CreateMetricsExporter(context.Background(), component.ExporterCreateSettings{Logger: zap.NewNop()}, cfg)
 	assert.NoError(t, err)
 	assert.NotNil(t, me)
 }
@@ -45,7 +45,7 @@ func TestCreateTracesExporter(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
 
-	te, err := factory.CreateTracesExporter(context.Background(), component.ExporterCreateParams{Logger: zap.NewNop()}, cfg)
+	te, err := factory.CreateTracesExporter(context.Background(), component.ExporterCreateSettings{Logger: zap.NewNop()}, cfg)
 	assert.NoError(t, err)
 	assert.NotNil(t, te)
 }
@@ -54,7 +54,7 @@ func TestCreateLogsExporter(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
 
-	te, err := factory.CreateLogsExporter(context.Background(), component.ExporterCreateParams{Logger: zap.NewNop()}, cfg)
+	te, err := factory.CreateLogsExporter(context.Background(), component.ExporterCreateSettings{Logger: zap.NewNop()}, cfg)
 	assert.NoError(t, err)
 	assert.NotNil(t, te)
 }

--- a/exporter/opencensusexporter/factory.go
+++ b/exporter/opencensusexporter/factory.go
@@ -50,7 +50,7 @@ func createDefaultConfig() config.Exporter {
 	}
 }
 
-func createTracesExporter(ctx context.Context, params component.ExporterCreateParams, cfg config.Exporter) (component.TracesExporter, error) {
+func createTracesExporter(ctx context.Context, set component.ExporterCreateSettings, cfg config.Exporter) (component.TracesExporter, error) {
 	oCfg := cfg.(*Config)
 	oce, err := newTracesExporter(ctx, oCfg)
 	if err != nil {
@@ -59,7 +59,7 @@ func createTracesExporter(ctx context.Context, params component.ExporterCreatePa
 
 	return exporterhelper.NewTracesExporter(
 		cfg,
-		params.Logger,
+		set.Logger,
 		oce.pushTraces,
 		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
 		exporterhelper.WithRetry(oCfg.RetrySettings),
@@ -68,7 +68,7 @@ func createTracesExporter(ctx context.Context, params component.ExporterCreatePa
 		exporterhelper.WithShutdown(oce.shutdown))
 }
 
-func createMetricsExporter(ctx context.Context, params component.ExporterCreateParams, cfg config.Exporter) (component.MetricsExporter, error) {
+func createMetricsExporter(ctx context.Context, set component.ExporterCreateSettings, cfg config.Exporter) (component.MetricsExporter, error) {
 	oCfg := cfg.(*Config)
 	oce, err := newMetricsExporter(ctx, oCfg)
 	if err != nil {
@@ -77,7 +77,7 @@ func createMetricsExporter(ctx context.Context, params component.ExporterCreateP
 
 	return exporterhelper.NewMetricsExporter(
 		cfg,
-		params.Logger,
+		set.Logger,
 		oce.pushMetrics,
 		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
 		exporterhelper.WithRetry(oCfg.RetrySettings),

--- a/exporter/opencensusexporter/factory_test.go
+++ b/exporter/opencensusexporter/factory_test.go
@@ -173,10 +173,10 @@ func TestCreateTracesExporter(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			params := component.ExporterCreateParams{Logger: zap.NewNop()}
-			tExporter, tErr := createTracesExporter(context.Background(), params, &tt.config)
+			set := component.ExporterCreateSettings{Logger: zap.NewNop()}
+			tExporter, tErr := createTracesExporter(context.Background(), set, &tt.config)
 			checkErrorsAndStartAndShutdown(t, tExporter, tErr, tt.mustFailOnCreate, tt.mustFailOnStart)
-			mExporter, mErr := createMetricsExporter(context.Background(), params, &tt.config)
+			mExporter, mErr := createMetricsExporter(context.Background(), set, &tt.config)
 			checkErrorsAndStartAndShutdown(t, mExporter, mErr, tt.mustFailOnCreate, tt.mustFailOnStart)
 		})
 	}

--- a/exporter/opencensusexporter/opencensus_test.go
+++ b/exporter/opencensusexporter/opencensus_test.go
@@ -39,8 +39,8 @@ func TestSendTraces(t *testing.T) {
 	rCfg := rFactory.CreateDefaultConfig().(*opencensusreceiver.Config)
 	endpoint := testutil.GetAvailableLocalAddress(t)
 	rCfg.GRPCServerSettings.NetAddr.Endpoint = endpoint
-	params := component.ReceiverCreateParams{Logger: zap.NewNop()}
-	recv, err := rFactory.CreateTracesReceiver(context.Background(), params, rCfg, sink)
+	set := component.ReceiverCreateParams{Logger: zap.NewNop()}
+	recv, err := rFactory.CreateTracesReceiver(context.Background(), set, rCfg, sink)
 	assert.NoError(t, err)
 	assert.NoError(t, recv.Start(context.Background(), componenttest.NewNopHost()))
 	t.Cleanup(func() {
@@ -56,7 +56,7 @@ func TestSendTraces(t *testing.T) {
 		},
 	}
 	cfg.NumWorkers = 1
-	exp, err := factory.CreateTracesExporter(context.Background(), component.ExporterCreateParams{Logger: zap.NewNop()}, cfg)
+	exp, err := factory.CreateTracesExporter(context.Background(), component.ExporterCreateSettings{Logger: zap.NewNop()}, cfg)
 	require.NoError(t, err)
 	require.NotNil(t, exp)
 	host := componenttest.NewNopHost()
@@ -96,7 +96,7 @@ func TestSendTraces_NoBackend(t *testing.T) {
 			Insecure: true,
 		},
 	}
-	exp, err := factory.CreateTracesExporter(context.Background(), component.ExporterCreateParams{Logger: zap.NewNop()}, cfg)
+	exp, err := factory.CreateTracesExporter(context.Background(), component.ExporterCreateSettings{Logger: zap.NewNop()}, cfg)
 	require.NoError(t, err)
 	require.NotNil(t, exp)
 	host := componenttest.NewNopHost()
@@ -120,7 +120,7 @@ func TestSendTraces_AfterStop(t *testing.T) {
 			Insecure: true,
 		},
 	}
-	exp, err := factory.CreateTracesExporter(context.Background(), component.ExporterCreateParams{Logger: zap.NewNop()}, cfg)
+	exp, err := factory.CreateTracesExporter(context.Background(), component.ExporterCreateSettings{Logger: zap.NewNop()}, cfg)
 	require.NoError(t, err)
 	require.NotNil(t, exp)
 	host := componenttest.NewNopHost()
@@ -137,8 +137,8 @@ func TestSendMetrics(t *testing.T) {
 	rCfg := rFactory.CreateDefaultConfig().(*opencensusreceiver.Config)
 	endpoint := testutil.GetAvailableLocalAddress(t)
 	rCfg.GRPCServerSettings.NetAddr.Endpoint = endpoint
-	params := component.ReceiverCreateParams{Logger: zap.NewNop()}
-	recv, err := rFactory.CreateMetricsReceiver(context.Background(), params, rCfg, sink)
+	set := component.ReceiverCreateParams{Logger: zap.NewNop()}
+	recv, err := rFactory.CreateMetricsReceiver(context.Background(), set, rCfg, sink)
 	assert.NoError(t, err)
 	assert.NoError(t, recv.Start(context.Background(), componenttest.NewNopHost()))
 	t.Cleanup(func() {
@@ -154,7 +154,7 @@ func TestSendMetrics(t *testing.T) {
 		},
 	}
 	cfg.NumWorkers = 1
-	exp, err := factory.CreateMetricsExporter(context.Background(), component.ExporterCreateParams{Logger: zap.NewNop()}, cfg)
+	exp, err := factory.CreateMetricsExporter(context.Background(), component.ExporterCreateSettings{Logger: zap.NewNop()}, cfg)
 	require.NoError(t, err)
 	require.NotNil(t, exp)
 	host := componenttest.NewNopHost()
@@ -193,7 +193,7 @@ func TestSendMetrics_NoBackend(t *testing.T) {
 			Insecure: true,
 		},
 	}
-	exp, err := factory.CreateMetricsExporter(context.Background(), component.ExporterCreateParams{Logger: zap.NewNop()}, cfg)
+	exp, err := factory.CreateMetricsExporter(context.Background(), component.ExporterCreateSettings{Logger: zap.NewNop()}, cfg)
 	require.NoError(t, err)
 	require.NotNil(t, exp)
 	host := componenttest.NewNopHost()
@@ -217,7 +217,7 @@ func TestSendMetrics_AfterStop(t *testing.T) {
 			Insecure: true,
 		},
 	}
-	exp, err := factory.CreateMetricsExporter(context.Background(), component.ExporterCreateParams{Logger: zap.NewNop()}, cfg)
+	exp, err := factory.CreateMetricsExporter(context.Background(), component.ExporterCreateSettings{Logger: zap.NewNop()}, cfg)
 	require.NoError(t, err)
 	require.NotNil(t, exp)
 	host := componenttest.NewNopHost()

--- a/exporter/otlpexporter/factory.go
+++ b/exporter/otlpexporter/factory.go
@@ -55,7 +55,7 @@ func createDefaultConfig() config.Exporter {
 
 func createTracesExporter(
 	_ context.Context,
-	params component.ExporterCreateParams,
+	set component.ExporterCreateSettings,
 	cfg config.Exporter,
 ) (component.TracesExporter, error) {
 	oce, err := newExporter(cfg)
@@ -65,7 +65,7 @@ func createTracesExporter(
 	oCfg := cfg.(*Config)
 	return exporterhelper.NewTracesExporter(
 		cfg,
-		params.Logger,
+		set.Logger,
 		oce.pushTraces,
 		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
 		exporterhelper.WithTimeout(oCfg.TimeoutSettings),
@@ -77,7 +77,7 @@ func createTracesExporter(
 
 func createMetricsExporter(
 	_ context.Context,
-	params component.ExporterCreateParams,
+	set component.ExporterCreateSettings,
 	cfg config.Exporter,
 ) (component.MetricsExporter, error) {
 	oce, err := newExporter(cfg)
@@ -87,7 +87,7 @@ func createMetricsExporter(
 	oCfg := cfg.(*Config)
 	return exporterhelper.NewMetricsExporter(
 		cfg,
-		params.Logger,
+		set.Logger,
 		oce.pushMetrics,
 		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
 		exporterhelper.WithTimeout(oCfg.TimeoutSettings),
@@ -100,7 +100,7 @@ func createMetricsExporter(
 
 func createLogsExporter(
 	_ context.Context,
-	params component.ExporterCreateParams,
+	set component.ExporterCreateSettings,
 	cfg config.Exporter,
 ) (component.LogsExporter, error) {
 	oce, err := newExporter(cfg)
@@ -110,7 +110,7 @@ func createLogsExporter(
 	oCfg := cfg.(*Config)
 	return exporterhelper.NewLogsExporter(
 		cfg,
-		params.Logger,
+		set.Logger,
 		oce.pushLogs,
 		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
 		exporterhelper.WithTimeout(oCfg.TimeoutSettings),

--- a/exporter/otlpexporter/factory_test.go
+++ b/exporter/otlpexporter/factory_test.go
@@ -50,8 +50,8 @@ func TestCreateMetricsExporter(t *testing.T) {
 	cfg := factory.CreateDefaultConfig().(*Config)
 	cfg.GRPCClientSettings.Endpoint = testutil.GetAvailableLocalAddress(t)
 
-	creationParams := component.ExporterCreateParams{Logger: zap.NewNop()}
-	oexp, err := factory.CreateMetricsExporter(context.Background(), creationParams, cfg)
+	set := component.ExporterCreateSettings{Logger: zap.NewNop()}
+	oexp, err := factory.CreateMetricsExporter(context.Background(), set, cfg)
 	require.Nil(t, err)
 	require.NotNil(t, oexp)
 }
@@ -177,8 +177,8 @@ func TestCreateTracesExporter(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			factory := NewFactory()
-			creationParams := component.ExporterCreateParams{Logger: zap.NewNop()}
-			consumer, err := factory.CreateTracesExporter(context.Background(), creationParams, &tt.config)
+			set := component.ExporterCreateSettings{Logger: zap.NewNop()}
+			consumer, err := factory.CreateTracesExporter(context.Background(), set, &tt.config)
 			if tt.mustFailOnCreate {
 				assert.NotNil(t, err)
 				return
@@ -206,8 +206,8 @@ func TestCreateLogsExporter(t *testing.T) {
 	cfg := factory.CreateDefaultConfig().(*Config)
 	cfg.GRPCClientSettings.Endpoint = testutil.GetAvailableLocalAddress(t)
 
-	creationParams := component.ExporterCreateParams{Logger: zap.NewNop()}
-	oexp, err := factory.CreateLogsExporter(context.Background(), creationParams, cfg)
+	set := component.ExporterCreateSettings{Logger: zap.NewNop()}
+	oexp, err := factory.CreateLogsExporter(context.Background(), set, cfg)
 	require.Nil(t, err)
 	require.NotNil(t, oexp)
 }

--- a/exporter/otlpexporter/otlp_test.go
+++ b/exporter/otlpexporter/otlp_test.go
@@ -183,8 +183,8 @@ func TestSendTraces(t *testing.T) {
 			"header": "header-value",
 		},
 	}
-	creationParams := component.ExporterCreateParams{Logger: zap.NewNop()}
-	exp, err := factory.CreateTracesExporter(context.Background(), creationParams, cfg)
+	set := component.ExporterCreateSettings{Logger: zap.NewNop()}
+	exp, err := factory.CreateTracesExporter(context.Background(), set, cfg)
 	require.NoError(t, err)
 	require.NotNil(t, exp)
 
@@ -251,8 +251,8 @@ func TestSendMetrics(t *testing.T) {
 			"header": "header-value",
 		},
 	}
-	creationParams := component.ExporterCreateParams{Logger: zap.NewNop()}
-	exp, err := factory.CreateMetricsExporter(context.Background(), creationParams, cfg)
+	set := component.ExporterCreateSettings{Logger: zap.NewNop()}
+	exp, err := factory.CreateMetricsExporter(context.Background(), set, cfg)
 	require.NoError(t, err)
 	require.NotNil(t, exp)
 	defer func() {
@@ -319,8 +319,8 @@ func TestSendTraceDataServerDownAndUp(t *testing.T) {
 		// Do not rely on external retry logic here, if that is intended set InitialInterval to 100ms.
 		WaitForReady: true,
 	}
-	creationParams := component.ExporterCreateParams{Logger: zap.NewNop()}
-	exp, err := factory.CreateTracesExporter(context.Background(), creationParams, cfg)
+	set := component.ExporterCreateSettings{Logger: zap.NewNop()}
+	exp, err := factory.CreateTracesExporter(context.Background(), set, cfg)
 	require.NoError(t, err)
 	require.NotNil(t, exp)
 	defer func() {
@@ -376,8 +376,8 @@ func TestSendTraceDataServerStartWhileRequest(t *testing.T) {
 			Insecure: true,
 		},
 	}
-	creationParams := component.ExporterCreateParams{Logger: zap.NewNop()}
-	exp, err := factory.CreateTracesExporter(context.Background(), creationParams, cfg)
+	set := component.ExporterCreateSettings{Logger: zap.NewNop()}
+	exp, err := factory.CreateTracesExporter(context.Background(), set, cfg)
 	require.NoError(t, err)
 	require.NotNil(t, exp)
 	defer func() {
@@ -452,8 +452,8 @@ func TestSendLogData(t *testing.T) {
 			Insecure: true,
 		},
 	}
-	creationParams := component.ExporterCreateParams{Logger: zap.NewNop()}
-	exp, err := factory.CreateLogsExporter(context.Background(), creationParams, cfg)
+	set := component.ExporterCreateSettings{Logger: zap.NewNop()}
+	exp, err := factory.CreateLogsExporter(context.Background(), set, cfg)
 	require.NoError(t, err)
 	require.NotNil(t, exp)
 	defer func() {

--- a/exporter/otlphttpexporter/factory.go
+++ b/exporter/otlphttpexporter/factory.go
@@ -74,10 +74,10 @@ func composeSignalURL(oCfg *Config, signalOverrideURL string, signalName string)
 
 func createTracesExporter(
 	_ context.Context,
-	params component.ExporterCreateParams,
+	set component.ExporterCreateSettings,
 	cfg config.Exporter,
 ) (component.TracesExporter, error) {
-	oce, err := newExporter(cfg, params.Logger)
+	oce, err := newExporter(cfg, set.Logger)
 	if err != nil {
 		return nil, err
 	}
@@ -90,7 +90,7 @@ func createTracesExporter(
 
 	return exporterhelper.NewTracesExporter(
 		cfg,
-		params.Logger,
+		set.Logger,
 		oce.pushTraces,
 		exporterhelper.WithStart(oce.start),
 		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
@@ -102,10 +102,10 @@ func createTracesExporter(
 
 func createMetricsExporter(
 	_ context.Context,
-	params component.ExporterCreateParams,
+	set component.ExporterCreateSettings,
 	cfg config.Exporter,
 ) (component.MetricsExporter, error) {
-	oce, err := newExporter(cfg, params.Logger)
+	oce, err := newExporter(cfg, set.Logger)
 	if err != nil {
 		return nil, err
 	}
@@ -118,7 +118,7 @@ func createMetricsExporter(
 
 	return exporterhelper.NewMetricsExporter(
 		cfg,
-		params.Logger,
+		set.Logger,
 		oce.pushMetrics,
 		exporterhelper.WithStart(oce.start),
 		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
@@ -130,10 +130,10 @@ func createMetricsExporter(
 
 func createLogsExporter(
 	_ context.Context,
-	params component.ExporterCreateParams,
+	set component.ExporterCreateSettings,
 	cfg config.Exporter,
 ) (component.LogsExporter, error) {
-	oce, err := newExporter(cfg, params.Logger)
+	oce, err := newExporter(cfg, set.Logger)
 	if err != nil {
 		return nil, err
 	}
@@ -146,7 +146,7 @@ func createLogsExporter(
 
 	return exporterhelper.NewLogsExporter(
 		cfg,
-		params.Logger,
+		set.Logger,
 		oce.pushLogs,
 		exporterhelper.WithStart(oce.start),
 		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),

--- a/exporter/otlphttpexporter/factory_test.go
+++ b/exporter/otlphttpexporter/factory_test.go
@@ -53,8 +53,8 @@ func TestCreateMetricsExporter(t *testing.T) {
 	cfg := factory.CreateDefaultConfig().(*Config)
 	cfg.HTTPClientSettings.Endpoint = "http://" + testutil.GetAvailableLocalAddress(t)
 
-	creationParams := component.ExporterCreateParams{Logger: zap.NewNop()}
-	oexp, err := factory.CreateMetricsExporter(context.Background(), creationParams, cfg)
+	set := component.ExporterCreateSettings{Logger: zap.NewNop()}
+	oexp, err := factory.CreateMetricsExporter(context.Background(), set, cfg)
 	require.Nil(t, err)
 	require.NotNil(t, oexp)
 }
@@ -138,8 +138,8 @@ func TestCreateTracesExporter(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			factory := NewFactory()
-			creationParams := component.ExporterCreateParams{Logger: zap.NewNop()}
-			consumer, err := factory.CreateTracesExporter(context.Background(), creationParams, &tt.config)
+			set := component.ExporterCreateSettings{Logger: zap.NewNop()}
+			consumer, err := factory.CreateTracesExporter(context.Background(), set, &tt.config)
 
 			if tt.mustFailOnCreate {
 				assert.Error(t, err)
@@ -167,8 +167,8 @@ func TestCreateLogsExporter(t *testing.T) {
 	cfg := factory.CreateDefaultConfig().(*Config)
 	cfg.HTTPClientSettings.Endpoint = "http://" + testutil.GetAvailableLocalAddress(t)
 
-	creationParams := component.ExporterCreateParams{Logger: zap.NewNop()}
-	oexp, err := factory.CreateLogsExporter(context.Background(), creationParams, cfg)
+	set := component.ExporterCreateSettings{Logger: zap.NewNop()}
+	oexp, err := factory.CreateLogsExporter(context.Background(), set, cfg)
 	require.Nil(t, err)
 	require.NotNil(t, oexp)
 }

--- a/exporter/otlphttpexporter/otlp_test.go
+++ b/exporter/otlphttpexporter/otlp_test.go
@@ -51,12 +51,12 @@ func TestInvalidConfig(t *testing.T) {
 		},
 	}
 	f := NewFactory()
-	params := component.ExporterCreateParams{Logger: zap.NewNop()}
-	_, err := f.CreateTracesExporter(context.Background(), params, config)
+	set := component.ExporterCreateSettings{Logger: zap.NewNop()}
+	_, err := f.CreateTracesExporter(context.Background(), set, config)
 	require.Error(t, err)
-	_, err = f.CreateMetricsExporter(context.Background(), params, config)
+	_, err = f.CreateMetricsExporter(context.Background(), set, config)
 	require.Error(t, err)
-	_, err = f.CreateLogsExporter(context.Background(), params, config)
+	_, err = f.CreateLogsExporter(context.Background(), set, config)
 	require.Error(t, err)
 }
 
@@ -165,7 +165,7 @@ func TestCompressionOptions(t *testing.T) {
 			factory := NewFactory()
 			cfg := createExporterConfig(test.baseURL, factory.CreateDefaultConfig())
 			cfg.Compression = test.compression
-			exp, _ := factory.CreateTracesExporter(context.Background(), component.ExporterCreateParams{Logger: zap.NewNop()}, cfg)
+			exp, _ := factory.CreateTracesExporter(context.Background(), component.ExporterCreateSettings{Logger: zap.NewNop()}, cfg)
 			err := exp.Start(context.Background(), componenttest.NewNopHost())
 			t.Cleanup(func() {
 				require.NoError(t, exp.Shutdown(context.Background()))
@@ -297,7 +297,7 @@ func startTracesExporter(t *testing.T, baseURL string, overrideURL string) compo
 	factory := NewFactory()
 	cfg := createExporterConfig(baseURL, factory.CreateDefaultConfig())
 	cfg.TracesEndpoint = overrideURL
-	exp, err := factory.CreateTracesExporter(context.Background(), component.ExporterCreateParams{Logger: zap.NewNop()}, cfg)
+	exp, err := factory.CreateTracesExporter(context.Background(), component.ExporterCreateSettings{Logger: zap.NewNop()}, cfg)
 	require.NoError(t, err)
 	startAndCleanup(t, exp)
 	return exp
@@ -307,7 +307,7 @@ func startMetricsExporter(t *testing.T, baseURL string, overrideURL string) comp
 	factory := NewFactory()
 	cfg := createExporterConfig(baseURL, factory.CreateDefaultConfig())
 	cfg.MetricsEndpoint = overrideURL
-	exp, err := factory.CreateMetricsExporter(context.Background(), component.ExporterCreateParams{Logger: zap.NewNop()}, cfg)
+	exp, err := factory.CreateMetricsExporter(context.Background(), component.ExporterCreateSettings{Logger: zap.NewNop()}, cfg)
 	require.NoError(t, err)
 	startAndCleanup(t, exp)
 	return exp
@@ -317,7 +317,7 @@ func startLogsExporter(t *testing.T, baseURL string, overrideURL string) compone
 	factory := NewFactory()
 	cfg := createExporterConfig(baseURL, factory.CreateDefaultConfig())
 	cfg.LogsEndpoint = overrideURL
-	exp, err := factory.CreateLogsExporter(context.Background(), component.ExporterCreateParams{Logger: zap.NewNop()}, cfg)
+	exp, err := factory.CreateLogsExporter(context.Background(), component.ExporterCreateSettings{Logger: zap.NewNop()}, cfg)
 	require.NoError(t, err)
 	startAndCleanup(t, exp)
 	return exp
@@ -450,7 +450,7 @@ func TestErrorResponses(t *testing.T) {
 				// Create without QueueSettings and RetrySettings so that ConsumeTraces
 				// returns the errors that we want to check immediately.
 			}
-			exp, err := createTracesExporter(context.Background(), component.ExporterCreateParams{Logger: zap.NewNop()}, cfg)
+			exp, err := createTracesExporter(context.Background(), component.ExporterCreateSettings{Logger: zap.NewNop()}, cfg)
 			require.NoError(t, err)
 
 			// start the exporter

--- a/exporter/prometheusexporter/end_to_end_test.go
+++ b/exporter/prometheusexporter/end_to_end_test.go
@@ -74,8 +74,8 @@ func TestEndToEndSummarySupport(t *testing.T) {
 		MetricExpiration: 2 * time.Hour,
 	}
 	exporterFactory := NewFactory()
-	creationParams := component.ExporterCreateParams{Logger: zap.NewNop()}
-	exporter, err := exporterFactory.CreateMetricsExporter(ctx, creationParams, exporterCfg)
+	set := component.ExporterCreateSettings{Logger: zap.NewNop()}
+	exporter, err := exporterFactory.CreateMetricsExporter(ctx, set, exporterCfg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -102,7 +102,7 @@ func TestEndToEndSummarySupport(t *testing.T) {
 	}
 
 	receiverFactory := prometheusreceiver.NewFactory()
-	receiverCreateParams := component.ReceiverCreateParams{
+	receiverCreateSettings := component.ReceiverCreateParams{
 		Logger: zap.NewNop(),
 	}
 	rcvCfg := &prometheusreceiver.Config{
@@ -110,7 +110,7 @@ func TestEndToEndSummarySupport(t *testing.T) {
 		ReceiverSettings: config.NewReceiverSettings(config.NewID("prometheus")),
 	}
 	// 3.5 Create the Prometheus receiver and pass in the preivously created Prometheus exporter.
-	prometheusReceiver, err := receiverFactory.CreateMetricsReceiver(ctx, receiverCreateParams, rcvCfg, exporter)
+	prometheusReceiver, err := receiverFactory.CreateMetricsReceiver(ctx, receiverCreateSettings, rcvCfg, exporter)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/exporter/prometheusexporter/factory.go
+++ b/exporter/prometheusexporter/factory.go
@@ -48,19 +48,19 @@ func createDefaultConfig() config.Exporter {
 
 func createMetricsExporter(
 	_ context.Context,
-	params component.ExporterCreateParams,
+	set component.ExporterCreateSettings,
 	cfg config.Exporter,
 ) (component.MetricsExporter, error) {
 	pcfg := cfg.(*Config)
 
-	prometheus, err := newPrometheusExporter(pcfg, params.Logger)
+	prometheus, err := newPrometheusExporter(pcfg, set.Logger)
 	if err != nil {
 		return nil, err
 	}
 
 	exporter, err := exporterhelper.NewMetricsExporter(
 		cfg,
-		params.Logger,
+		set.Logger,
 		prometheus.ConsumeMetrics,
 		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
 		exporterhelper.WithStart(prometheus.Start),

--- a/exporter/prometheusexporter/factory_test.go
+++ b/exporter/prometheusexporter/factory_test.go
@@ -38,7 +38,7 @@ func TestCreateMetricsExporter(t *testing.T) {
 	oCfg.Endpoint = ""
 	exp, err := createMetricsExporter(
 		context.Background(),
-		component.ExporterCreateParams{Logger: zap.NewNop()},
+		component.ExporterCreateSettings{Logger: zap.NewNop()},
 		cfg)
 	require.Equal(t, errBlankPrometheusAddress, err)
 	require.Nil(t, exp)
@@ -53,7 +53,7 @@ func TestCreateMetricsExporterExportHelperError(t *testing.T) {
 	// Should give us an exporterhelper.errNilLogger
 	exp, err := createMetricsExporter(
 		context.Background(),
-		component.ExporterCreateParams{Logger: nil},
+		component.ExporterCreateSettings{Logger: nil},
 		cfg)
 
 	assert.Nil(t, exp)

--- a/exporter/prometheusexporter/prometheus_test.go
+++ b/exporter/prometheusexporter/prometheus_test.go
@@ -72,11 +72,11 @@ func TestPrometheusExporter(t *testing.T) {
 	}
 
 	factory := NewFactory()
-	creationParams := component.ExporterCreateParams{Logger: zap.NewNop()}
+	set := component.ExporterCreateSettings{Logger: zap.NewNop()}
 	for _, tt := range tests {
 		// Run it a few times to ensure that shutdowns exit cleanly.
 		for j := 0; j < 3; j++ {
-			exp, err := factory.CreateMetricsExporter(context.Background(), creationParams, tt.config)
+			exp, err := factory.CreateMetricsExporter(context.Background(), set, tt.config)
 
 			if tt.wantErr != "" {
 				require.Error(t, err)
@@ -114,8 +114,8 @@ func TestPrometheusExporter_endToEnd(t *testing.T) {
 	}
 
 	factory := NewFactory()
-	creationParams := component.ExporterCreateParams{Logger: zap.NewNop()}
-	exp, err := factory.CreateMetricsExporter(context.Background(), creationParams, cfg)
+	set := component.ExporterCreateSettings{Logger: zap.NewNop()}
+	exp, err := factory.CreateMetricsExporter(context.Background(), set, cfg)
 	assert.NoError(t, err)
 
 	t.Cleanup(func() {
@@ -192,8 +192,8 @@ func TestPrometheusExporter_endToEndWithTimestamps(t *testing.T) {
 	}
 
 	factory := NewFactory()
-	creationParams := component.ExporterCreateParams{Logger: zap.NewNop()}
-	exp, err := factory.CreateMetricsExporter(context.Background(), creationParams, cfg)
+	set := component.ExporterCreateSettings{Logger: zap.NewNop()}
+	exp, err := factory.CreateMetricsExporter(context.Background(), set, cfg)
 	assert.NoError(t, err)
 
 	t.Cleanup(func() {
@@ -273,8 +273,8 @@ func TestPrometheusExporter_endToEndWithResource(t *testing.T) {
 	}
 
 	factory := NewFactory()
-	creationParams := component.ExporterCreateParams{Logger: zap.NewNop()}
-	exp, err := factory.CreateMetricsExporter(context.Background(), creationParams, cfg)
+	set := component.ExporterCreateSettings{Logger: zap.NewNop()}
+	exp, err := factory.CreateMetricsExporter(context.Background(), set, cfg)
 	assert.NoError(t, err)
 
 	t.Cleanup(func() {

--- a/exporter/prometheusremotewriteexporter/factory.go
+++ b/exporter/prometheusremotewriteexporter/factory.go
@@ -37,7 +37,7 @@ func NewFactory() component.ExporterFactory {
 		exporterhelper.WithMetrics(createMetricsExporter))
 }
 
-func createMetricsExporter(_ context.Context, params component.ExporterCreateParams,
+func createMetricsExporter(_ context.Context, set component.ExporterCreateSettings,
 	cfg config.Exporter) (component.MetricsExporter, error) {
 
 	prwCfg, ok := cfg.(*Config)
@@ -45,7 +45,7 @@ func createMetricsExporter(_ context.Context, params component.ExporterCreatePar
 		return nil, errors.New("invalid configuration")
 	}
 
-	prwe, err := NewPRWExporter(prwCfg, params.BuildInfo)
+	prwe, err := NewPRWExporter(prwCfg, set.BuildInfo)
 	if err != nil {
 		return nil, err
 	}
@@ -58,7 +58,7 @@ func createMetricsExporter(_ context.Context, params component.ExporterCreatePar
 	// "out of order samples" errors.
 	return exporterhelper.NewMetricsExporter(
 		cfg,
-		params.Logger,
+		set.Logger,
 		prwe.PushMetrics,
 		exporterhelper.WithTimeout(prwCfg.TimeoutSettings),
 		exporterhelper.WithQueue(exporterhelper.QueueSettings{

--- a/exporter/prometheusremotewriteexporter/factory_test.go
+++ b/exporter/prometheusremotewriteexporter/factory_test.go
@@ -54,31 +54,31 @@ func Test_createMetricsExporter(t *testing.T) {
 	tests := []struct {
 		name                string
 		cfg                 config.Exporter
-		params              component.ExporterCreateParams
+		set                 component.ExporterCreateSettings
 		returnErrorOnCreate bool
 		returnErrorOnStart  bool
 	}{
 		{"success_case",
 			createDefaultConfig(),
-			component.ExporterCreateParams{Logger: zap.NewNop()},
+			component.ExporterCreateSettings{Logger: zap.NewNop()},
 			false,
 			false,
 		},
 		{"fail_case",
 			nil,
-			component.ExporterCreateParams{Logger: zap.NewNop()},
+			component.ExporterCreateSettings{Logger: zap.NewNop()},
 			true,
 			false,
 		},
 		{"invalid_config_case",
 			invalidConfig,
-			component.ExporterCreateParams{Logger: zap.NewNop()},
+			component.ExporterCreateSettings{Logger: zap.NewNop()},
 			true,
 			false,
 		},
 		{"invalid_tls_config_case",
 			invalidTLSConfig,
-			component.ExporterCreateParams{Logger: zap.NewNop()},
+			component.ExporterCreateSettings{Logger: zap.NewNop()},
 			false,
 			true,
 		},
@@ -86,7 +86,7 @@ func Test_createMetricsExporter(t *testing.T) {
 	// run tests
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			exp, err := createMetricsExporter(context.Background(), tt.params, tt.cfg)
+			exp, err := createMetricsExporter(context.Background(), tt.set, tt.cfg)
 			if tt.returnErrorOnCreate {
 				assert.Error(t, err)
 				return

--- a/exporter/zipkinexporter/config_test.go
+++ b/exporter/zipkinexporter/config_test.go
@@ -73,7 +73,7 @@ func TestLoadConfig(t *testing.T) {
 		Format:             "proto",
 		DefaultServiceName: "test_name",
 	}, e1)
-	params := component.ExporterCreateParams{Logger: zap.NewNop()}
-	_, err = factory.CreateTracesExporter(context.Background(), params, e1)
+	set := component.ExporterCreateSettings{Logger: zap.NewNop()}
+	_, err = factory.CreateTracesExporter(context.Background(), set, e1)
 	require.NoError(t, err)
 }

--- a/exporter/zipkinexporter/factory.go
+++ b/exporter/zipkinexporter/factory.go
@@ -61,7 +61,7 @@ func createDefaultConfig() config.Exporter {
 
 func createTracesExporter(
 	_ context.Context,
-	params component.ExporterCreateParams,
+	set component.ExporterCreateSettings,
 	cfg config.Exporter,
 ) (component.TracesExporter, error) {
 	zc := cfg.(*Config)
@@ -77,7 +77,7 @@ func createTracesExporter(
 	}
 	return exporterhelper.NewTracesExporter(
 		zc,
-		params.Logger,
+		set.Logger,
 		ze.pushTraces,
 		exporterhelper.WithStart(ze.start),
 		// explicitly disable since we rely on http.Client timeout logic.

--- a/exporter/zipkinexporter/factory_test.go
+++ b/exporter/zipkinexporter/factory_test.go
@@ -36,14 +36,14 @@ func TestCreateInstanceViaFactory(t *testing.T) {
 
 	// Default config doesn't have default endpoint so creating from it should
 	// fail.
-	ze, err := createTracesExporter(context.Background(), component.ExporterCreateParams{Logger: zap.NewNop()}, cfg)
+	ze, err := createTracesExporter(context.Background(), component.ExporterCreateSettings{Logger: zap.NewNop()}, cfg)
 	assert.Error(t, err)
 	assert.Nil(t, ze)
 
 	// URL doesn't have a default value so set it directly.
 	zeCfg := cfg.(*Config)
 	zeCfg.Endpoint = "http://some.location.org:9411/api/v2/spans"
-	ze, err = createTracesExporter(context.Background(), component.ExporterCreateParams{Logger: zap.NewNop()}, cfg)
+	ze, err = createTracesExporter(context.Background(), component.ExporterCreateSettings{Logger: zap.NewNop()}, cfg)
 	assert.NoError(t, err)
 	assert.NotNil(t, ze)
 }

--- a/exporter/zipkinexporter/zipkin_test.go
+++ b/exporter/zipkinexporter/zipkin_test.go
@@ -65,7 +65,7 @@ func TestZipkinExporter_roundtripJSON(t *testing.T) {
 		},
 		Format: "json",
 	}
-	zexp, err := NewFactory().CreateTracesExporter(context.Background(), component.ExporterCreateParams{Logger: zap.NewNop()}, cfg)
+	zexp, err := NewFactory().CreateTracesExporter(context.Background(), component.ExporterCreateSettings{Logger: zap.NewNop()}, cfg)
 	assert.NoError(t, err)
 	require.NotNil(t, zexp)
 
@@ -291,8 +291,8 @@ func TestZipkinExporter_invalidFormat(t *testing.T) {
 		Format: "foobar",
 	}
 	f := NewFactory()
-	params := component.ExporterCreateParams{Logger: zap.NewNop()}
-	_, err := f.CreateTracesExporter(context.Background(), params, config)
+	set := component.ExporterCreateSettings{Logger: zap.NewNop()}
+	_, err := f.CreateTracesExporter(context.Background(), set, config)
 	require.Error(t, err)
 }
 
@@ -313,7 +313,7 @@ func TestZipkinExporter_roundtripProto(t *testing.T) {
 		},
 		Format: "proto",
 	}
-	zexp, err := NewFactory().CreateTracesExporter(context.Background(), component.ExporterCreateParams{Logger: zap.NewNop()}, cfg)
+	zexp, err := NewFactory().CreateTracesExporter(context.Background(), component.ExporterCreateSettings{Logger: zap.NewNop()}, cfg)
 	require.NoError(t, err)
 
 	require.NoError(t, zexp.Start(context.Background(), componenttest.NewNopHost()))

--- a/internal/testcomponents/example_exporter.go
+++ b/internal/testcomponents/example_exporter.go
@@ -64,7 +64,7 @@ func createExporterDefaultConfig() config.Exporter {
 
 func createTracesExporter(
 	_ context.Context,
-	_ component.ExporterCreateParams,
+	_ component.ExporterCreateSettings,
 	_ config.Exporter,
 ) (component.TracesExporter, error) {
 	return &ExampleExporterConsumer{}, nil
@@ -72,7 +72,7 @@ func createTracesExporter(
 
 func createMetricsExporter(
 	_ context.Context,
-	_ component.ExporterCreateParams,
+	_ component.ExporterCreateSettings,
 	_ config.Exporter,
 ) (component.MetricsExporter, error) {
 	return &ExampleExporterConsumer{}, nil
@@ -80,7 +80,7 @@ func createMetricsExporter(
 
 func createLogsExporter(
 	_ context.Context,
-	_ component.ExporterCreateParams,
+	_ component.ExporterCreateSettings,
 	_ config.Exporter,
 ) (component.LogsExporter, error) {
 	return &ExampleExporterConsumer{}, nil

--- a/receiver/opencensusreceiver/ocmetrics/opencensus_test.go
+++ b/receiver/opencensusreceiver/ocmetrics/opencensus_test.go
@@ -57,7 +57,7 @@ func TestReceiver_endToEnd(t *testing.T) {
 	expCfg.GRPCClientSettings.TLSSetting.Insecure = true
 	expCfg.Endpoint = addr.String()
 	expCfg.WaitForReady = true
-	oce, err := expFactory.CreateMetricsExporter(context.Background(), component.ExporterCreateParams{Logger: zap.NewNop()}, expCfg)
+	oce, err := expFactory.CreateMetricsExporter(context.Background(), component.ExporterCreateSettings{Logger: zap.NewNop()}, expCfg)
 	require.NoError(t, err)
 	err = oce.Start(context.Background(), componenttest.NewNopHost())
 	require.NoError(t, err)

--- a/receiver/opencensusreceiver/octrace/opencensus_test.go
+++ b/receiver/opencensusreceiver/octrace/opencensus_test.go
@@ -55,7 +55,7 @@ func TestReceiver_endToEnd(t *testing.T) {
 	expCfg.GRPCClientSettings.TLSSetting.Insecure = true
 	expCfg.Endpoint = addr.String()
 	expCfg.WaitForReady = true
-	oce, err := expFactory.CreateTracesExporter(context.Background(), component.ExporterCreateParams{Logger: zap.NewNop()}, expCfg)
+	oce, err := expFactory.CreateTracesExporter(context.Background(), component.ExporterCreateSettings{Logger: zap.NewNop()}, expCfg)
 	require.NoError(t, err)
 	err = oce.Start(context.Background(), componenttest.NewNopHost())
 	require.NoError(t, err)

--- a/receiver/zipkinreceiver/trace_receiver_test.go
+++ b/receiver/zipkinreceiver/trace_receiver_test.go
@@ -224,8 +224,8 @@ func TestConversionRoundtrip(t *testing.T) {
 	factory := zipkinexporter.NewFactory()
 	config := factory.CreateDefaultConfig().(*zipkinexporter.Config)
 	config.Endpoint = backend.URL
-	params := component.ExporterCreateParams{Logger: zap.NewNop()}
-	ze, err := factory.CreateTracesExporter(context.Background(), params, config)
+	set := component.ExporterCreateSettings{Logger: zap.NewNop()}
+	ze, err := factory.CreateTracesExporter(context.Background(), set, config)
 	require.NoError(t, err)
 	require.NotNil(t, ze)
 	require.NoError(t, ze.Start(context.Background(), componenttest.NewNopHost()))

--- a/service/defaultcomponents/default_exporters_test.go
+++ b/service/defaultcomponents/default_exporters_test.go
@@ -163,7 +163,7 @@ type getExporterConfigFn func() config.Exporter
 func verifyExporterLifecycle(t *testing.T, factory component.ExporterFactory, getConfigFn getExporterConfigFn) {
 	ctx := context.Background()
 	host := newAssertNoErrorHost(t)
-	expCreateParams := component.ExporterCreateParams{
+	expCreateSettings := component.ExporterCreateSettings{
 		Logger:    zap.NewNop(),
 		BuildInfo: component.DefaultBuildInfo(),
 	}
@@ -182,7 +182,7 @@ func verifyExporterLifecycle(t *testing.T, factory component.ExporterFactory, ge
 	for i := 0; i < 2; i++ {
 		var exps []component.Exporter
 		for _, createFn := range createFns {
-			exp, err := createFn(ctx, expCreateParams, cfg)
+			exp, err := createFn(ctx, expCreateSettings, cfg)
 			if errors.Is(err, componenterror.ErrDataTypeIsNotSupported) {
 				continue
 			}
@@ -198,24 +198,24 @@ func verifyExporterLifecycle(t *testing.T, factory component.ExporterFactory, ge
 
 type createExporterFn func(
 	ctx context.Context,
-	params component.ExporterCreateParams,
+	set component.ExporterCreateSettings,
 	cfg config.Exporter,
 ) (component.Exporter, error)
 
 func wrapCreateLogsExp(factory component.ExporterFactory) createExporterFn {
-	return func(ctx context.Context, params component.ExporterCreateParams, cfg config.Exporter) (component.Exporter, error) {
-		return factory.CreateLogsExporter(ctx, params, cfg)
+	return func(ctx context.Context, set component.ExporterCreateSettings, cfg config.Exporter) (component.Exporter, error) {
+		return factory.CreateLogsExporter(ctx, set, cfg)
 	}
 }
 
 func wrapCreateTracesExp(factory component.ExporterFactory) createExporterFn {
-	return func(ctx context.Context, params component.ExporterCreateParams, cfg config.Exporter) (component.Exporter, error) {
-		return factory.CreateTracesExporter(ctx, params, cfg)
+	return func(ctx context.Context, set component.ExporterCreateSettings, cfg config.Exporter) (component.Exporter, error) {
+		return factory.CreateTracesExporter(ctx, set, cfg)
 	}
 }
 
 func wrapCreateMetricsExp(factory component.ExporterFactory) createExporterFn {
-	return func(ctx context.Context, params component.ExporterCreateParams, cfg config.Exporter) (component.Exporter, error) {
-		return factory.CreateMetricsExporter(ctx, params, cfg)
+	return func(ctx context.Context, set component.ExporterCreateSettings, cfg config.Exporter) (component.Exporter, error) {
+		return factory.CreateMetricsExporter(ctx, set, cfg)
 	}
 }

--- a/service/internal/builder/exporters_builder.go
+++ b/service/internal/builder/exporters_builder.go
@@ -232,7 +232,7 @@ func (eb *exportersBuilder) buildExporter(
 		return exporter, nil
 	}
 
-	creationParams := component.ExporterCreateParams{
+	set := component.ExporterCreateSettings{
 		Logger:    logger,
 		BuildInfo: buildInfo,
 	}
@@ -242,13 +242,13 @@ func (eb *exportersBuilder) buildExporter(
 	for dataType, requirement := range inputDataTypes {
 		switch dataType {
 		case config.TracesDataType:
-			createdExporter, err = factory.CreateTracesExporter(ctx, creationParams, cfg)
+			createdExporter, err = factory.CreateTracesExporter(ctx, set, cfg)
 
 		case config.MetricsDataType:
-			createdExporter, err = factory.CreateMetricsExporter(ctx, creationParams, cfg)
+			createdExporter, err = factory.CreateMetricsExporter(ctx, set, cfg)
 
 		case config.LogsDataType:
-			createdExporter, err = factory.CreateLogsExporter(ctx, creationParams, cfg)
+			createdExporter, err = factory.CreateLogsExporter(ctx, set, cfg)
 
 		default:
 			// Could not create because this exporter does not support this data type.

--- a/testbed/testbed/senders.go
+++ b/testbed/testbed/senders.go
@@ -608,6 +608,6 @@ func (pds *PrometheusDataSender) ProtocolName() string {
 	return "prometheus"
 }
 
-func defaultExporterParams() component.ExporterCreateParams {
-	return component.ExporterCreateParams{Logger: zap.L()}
+func defaultExporterParams() component.ExporterCreateSettings {
+	return component.ExporterCreateSettings{Logger: zap.L()}
 }


### PR DESCRIPTION
**Description:** 
Continuation work from https://github.com/open-telemetry/opentelemetry-collector/pull/2991
Fixes #2650
Replace ExporterCreateParams with ExporterCreateSettings.
Replace all dependencies in Exporters.

**Link to tracking Issue:** 
#2650 

**Testing:** 
Update unit tests

**Documentation:** 
In code comments

