### PR TITLE
Standarize Settings, Params and Parameters in Receiver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Rename `configtest.LoadConfigFile` to `configtest.LoadConfigAndValidate` (#3306)
 - Replace `ExtensionCreateParams` with `ExtensionCreateSettings` (#3294)
 - Replace `ExporterCreateParams` with `ExporterCreateSettings` (#3164)
+- Replace `ReceiverCreateParams` with `ReceiverCreateSettings`. (#3167)
 
 ## 💡 Enhancements 💡
 

--- a/component/componenttest/nop_receiver.go
+++ b/component/componenttest/nop_receiver.go
@@ -52,7 +52,7 @@ func (f *nopReceiverFactory) CreateDefaultConfig() config.Receiver {
 // CreateTracesReceiver implements component.ReceiverFactory interface.
 func (f *nopReceiverFactory) CreateTracesReceiver(
 	_ context.Context,
-	_ component.ReceiverCreateParams,
+	_ component.ReceiverCreateSettings,
 	_ config.Receiver,
 	_ consumer.Traces,
 ) (component.TracesReceiver, error) {
@@ -62,7 +62,7 @@ func (f *nopReceiverFactory) CreateTracesReceiver(
 // CreateMetricsReceiver implements component.ReceiverFactory interface.
 func (f *nopReceiverFactory) CreateMetricsReceiver(
 	_ context.Context,
-	_ component.ReceiverCreateParams,
+	_ component.ReceiverCreateSettings,
 	_ config.Receiver,
 	_ consumer.Metrics,
 ) (component.MetricsReceiver, error) {
@@ -72,7 +72,7 @@ func (f *nopReceiverFactory) CreateMetricsReceiver(
 // CreateLogsReceiver implements component.ReceiverFactory interface.
 func (f *nopReceiverFactory) CreateLogsReceiver(
 	_ context.Context,
-	_ component.ReceiverCreateParams,
+	_ component.ReceiverCreateSettings,
 	_ config.Receiver,
 	_ consumer.Logs,
 ) (component.LogsReceiver, error) {

--- a/component/componenttest/nop_receiver_test.go
+++ b/component/componenttest/nop_receiver_test.go
@@ -33,17 +33,17 @@ func TestNewNopReceiverFactory(t *testing.T) {
 	cfg := factory.CreateDefaultConfig()
 	assert.Equal(t, &nopReceiverConfig{ReceiverSettings: config.NewReceiverSettings(config.NewID("nop"))}, cfg)
 
-	traces, err := factory.CreateTracesReceiver(context.Background(), component.ReceiverCreateParams{}, cfg, consumertest.NewNop())
+	traces, err := factory.CreateTracesReceiver(context.Background(), component.ReceiverCreateSettings{}, cfg, consumertest.NewNop())
 	require.NoError(t, err)
 	assert.NoError(t, traces.Start(context.Background(), NewNopHost()))
 	assert.NoError(t, traces.Shutdown(context.Background()))
 
-	metrics, err := factory.CreateMetricsReceiver(context.Background(), component.ReceiverCreateParams{}, cfg, consumertest.NewNop())
+	metrics, err := factory.CreateMetricsReceiver(context.Background(), component.ReceiverCreateSettings{}, cfg, consumertest.NewNop())
 	require.NoError(t, err)
 	assert.NoError(t, metrics.Start(context.Background(), NewNopHost()))
 	assert.NoError(t, metrics.Shutdown(context.Background()))
 
-	logs, err := factory.CreateLogsReceiver(context.Background(), component.ReceiverCreateParams{}, cfg, consumertest.NewNop())
+	logs, err := factory.CreateLogsReceiver(context.Background(), component.ReceiverCreateSettings{}, cfg, consumertest.NewNop())
 	require.NoError(t, err)
 	assert.NoError(t, logs.Start(context.Background(), NewNopHost()))
 	assert.NoError(t, logs.Shutdown(context.Background()))

--- a/component/receiver.go
+++ b/component/receiver.go
@@ -55,8 +55,8 @@ type LogsReceiver interface {
 	Receiver
 }
 
-// ReceiverCreateParams configures Receiver creators.
-type ReceiverCreateParams struct {
+// ReceiverCreateSettings configures Receiver creators.
+type ReceiverCreateSettings struct {
 	// Logger that the factory can use during creation and can pass to the created
 	// component to be used later as well.
 	Logger *zap.Logger
@@ -82,18 +82,18 @@ type ReceiverFactory interface {
 	// CreateTracesReceiver creates a trace receiver based on this config.
 	// If the receiver type does not support tracing or if the config is not valid
 	// an error will be returned instead.
-	CreateTracesReceiver(ctx context.Context, params ReceiverCreateParams,
+	CreateTracesReceiver(ctx context.Context, set ReceiverCreateSettings,
 		cfg config.Receiver, nextConsumer consumer.Traces) (TracesReceiver, error)
 
 	// CreateMetricsReceiver creates a metrics receiver based on this config.
 	// If the receiver type does not support metrics or if the config is not valid
 	// an error will be returned instead.
-	CreateMetricsReceiver(ctx context.Context, params ReceiverCreateParams,
+	CreateMetricsReceiver(ctx context.Context, set ReceiverCreateSettings,
 		cfg config.Receiver, nextConsumer consumer.Metrics) (MetricsReceiver, error)
 
 	// CreateLogsReceiver creates a log receiver based on this config.
 	// If the receiver type does not support the data type or if the config is not valid
 	// an error will be returned instead.
-	CreateLogsReceiver(ctx context.Context, params ReceiverCreateParams,
+	CreateLogsReceiver(ctx context.Context, set ReceiverCreateSettings,
 		cfg config.Receiver, nextConsumer consumer.Logs) (LogsReceiver, error)
 }

--- a/component/receiver_test.go
+++ b/component/receiver_test.go
@@ -40,17 +40,17 @@ func (f *TestReceiverFactory) CreateDefaultConfig() config.Receiver {
 }
 
 // CreateTracesReceiver creates a trace receiver based on this config.
-func (f *TestReceiverFactory) CreateTracesReceiver(context.Context, ReceiverCreateParams, config.Receiver, consumer.Traces) (TracesReceiver, error) {
+func (f *TestReceiverFactory) CreateTracesReceiver(context.Context, ReceiverCreateSettings, config.Receiver, consumer.Traces) (TracesReceiver, error) {
 	return nil, componenterror.ErrDataTypeIsNotSupported
 }
 
 // CreateMetricsReceiver creates a metrics receiver based on this config.
-func (f *TestReceiverFactory) CreateMetricsReceiver(context.Context, ReceiverCreateParams, config.Receiver, consumer.Metrics) (MetricsReceiver, error) {
+func (f *TestReceiverFactory) CreateMetricsReceiver(context.Context, ReceiverCreateSettings, config.Receiver, consumer.Metrics) (MetricsReceiver, error) {
 	return nil, componenterror.ErrDataTypeIsNotSupported
 }
 
 // CreateMetricsReceiver creates a metrics receiver based on this config.
-func (f *TestReceiverFactory) CreateLogsReceiver(context.Context, ReceiverCreateParams, config.Receiver, consumer.Logs) (LogsReceiver, error) {
+func (f *TestReceiverFactory) CreateLogsReceiver(context.Context, ReceiverCreateSettings, config.Receiver, consumer.Logs) (LogsReceiver, error) {
 	return nil, componenterror.ErrDataTypeIsNotSupported
 }
 

--- a/exporter/opencensusexporter/opencensus_test.go
+++ b/exporter/opencensusexporter/opencensus_test.go
@@ -39,7 +39,7 @@ func TestSendTraces(t *testing.T) {
 	rCfg := rFactory.CreateDefaultConfig().(*opencensusreceiver.Config)
 	endpoint := testutil.GetAvailableLocalAddress(t)
 	rCfg.GRPCServerSettings.NetAddr.Endpoint = endpoint
-	set := component.ReceiverCreateParams{Logger: zap.NewNop()}
+	set := component.ReceiverCreateSettings{Logger: zap.NewNop()}
 	recv, err := rFactory.CreateTracesReceiver(context.Background(), set, rCfg, sink)
 	assert.NoError(t, err)
 	assert.NoError(t, recv.Start(context.Background(), componenttest.NewNopHost()))
@@ -137,7 +137,7 @@ func TestSendMetrics(t *testing.T) {
 	rCfg := rFactory.CreateDefaultConfig().(*opencensusreceiver.Config)
 	endpoint := testutil.GetAvailableLocalAddress(t)
 	rCfg.GRPCServerSettings.NetAddr.Endpoint = endpoint
-	set := component.ReceiverCreateParams{Logger: zap.NewNop()}
+	set := component.ReceiverCreateSettings{Logger: zap.NewNop()}
 	recv, err := rFactory.CreateMetricsReceiver(context.Background(), set, rCfg, sink)
 	assert.NoError(t, err)
 	assert.NoError(t, recv.Start(context.Background(), componenttest.NewNopHost()))

--- a/exporter/otlphttpexporter/otlp_test.go
+++ b/exporter/otlphttpexporter/otlp_test.go
@@ -334,7 +334,7 @@ func createExporterConfig(baseURL string, defaultCfg config.Exporter) *Config {
 func startTracesReceiver(t *testing.T, addr string, next consumer.Traces) {
 	factory := otlpreceiver.NewFactory()
 	cfg := createReceiverConfig(addr, factory.CreateDefaultConfig())
-	recv, err := factory.CreateTracesReceiver(context.Background(), component.ReceiverCreateParams{Logger: zap.NewNop()}, cfg, next)
+	recv, err := factory.CreateTracesReceiver(context.Background(), component.ReceiverCreateSettings{Logger: zap.NewNop()}, cfg, next)
 	require.NoError(t, err)
 	startAndCleanup(t, recv)
 }
@@ -342,7 +342,7 @@ func startTracesReceiver(t *testing.T, addr string, next consumer.Traces) {
 func startMetricsReceiver(t *testing.T, addr string, next consumer.Metrics) {
 	factory := otlpreceiver.NewFactory()
 	cfg := createReceiverConfig(addr, factory.CreateDefaultConfig())
-	recv, err := factory.CreateMetricsReceiver(context.Background(), component.ReceiverCreateParams{Logger: zap.NewNop()}, cfg, next)
+	recv, err := factory.CreateMetricsReceiver(context.Background(), component.ReceiverCreateSettings{Logger: zap.NewNop()}, cfg, next)
 	require.NoError(t, err)
 	startAndCleanup(t, recv)
 }
@@ -350,7 +350,7 @@ func startMetricsReceiver(t *testing.T, addr string, next consumer.Metrics) {
 func startLogsReceiver(t *testing.T, addr string, next consumer.Logs) {
 	factory := otlpreceiver.NewFactory()
 	cfg := createReceiverConfig(addr, factory.CreateDefaultConfig())
-	recv, err := factory.CreateLogsReceiver(context.Background(), component.ReceiverCreateParams{Logger: zap.NewNop()}, cfg, next)
+	recv, err := factory.CreateLogsReceiver(context.Background(), component.ReceiverCreateSettings{Logger: zap.NewNop()}, cfg, next)
 	require.NoError(t, err)
 	startAndCleanup(t, recv)
 }

--- a/exporter/prometheusexporter/end_to_end_test.go
+++ b/exporter/prometheusexporter/end_to_end_test.go
@@ -102,7 +102,7 @@ func TestEndToEndSummarySupport(t *testing.T) {
 	}
 
 	receiverFactory := prometheusreceiver.NewFactory()
-	receiverCreateSettings := component.ReceiverCreateParams{
+	receiverCreateSet := component.ReceiverCreateSettings{
 		Logger: zap.NewNop(),
 	}
 	rcvCfg := &prometheusreceiver.Config{
@@ -110,7 +110,7 @@ func TestEndToEndSummarySupport(t *testing.T) {
 		ReceiverSettings: config.NewReceiverSettings(config.NewID("prometheus")),
 	}
 	// 3.5 Create the Prometheus receiver and pass in the preivously created Prometheus exporter.
-	prometheusReceiver, err := receiverFactory.CreateMetricsReceiver(ctx, receiverCreateSettings, rcvCfg, exporter)
+	prometheusReceiver, err := receiverFactory.CreateMetricsReceiver(ctx, receiverCreateSet, rcvCfg, exporter)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/testcomponents/example_receiver.go
+++ b/internal/testcomponents/example_receiver.go
@@ -61,7 +61,7 @@ func createReceiverDefaultConfig() config.Receiver {
 // CreateTracesReceiver creates a trace receiver based on this config.
 func createTracesReceiver(
 	_ context.Context,
-	_ component.ReceiverCreateParams,
+	_ component.ReceiverCreateSettings,
 	cfg config.Receiver,
 	nextConsumer consumer.Traces,
 ) (component.TracesReceiver, error) {
@@ -73,7 +73,7 @@ func createTracesReceiver(
 // CreateMetricsReceiver creates a metrics receiver based on this config.
 func createMetricsReceiver(
 	_ context.Context,
-	_ component.ReceiverCreateParams,
+	_ component.ReceiverCreateSettings,
 	cfg config.Receiver,
 	nextConsumer consumer.Metrics,
 ) (component.MetricsReceiver, error) {
@@ -84,7 +84,7 @@ func createMetricsReceiver(
 
 func createLogsReceiver(
 	_ context.Context,
-	_ component.ReceiverCreateParams,
+	_ component.ReceiverCreateSettings,
 	cfg config.Receiver,
 	nextConsumer consumer.Logs,
 ) (component.LogsReceiver, error) {

--- a/receiver/hostmetricsreceiver/factory.go
+++ b/receiver/hostmetricsreceiver/factory.go
@@ -89,20 +89,20 @@ func createDefaultConfig() config.Receiver {
 // createMetricsReceiver creates a metrics receiver based on provided config.
 func createMetricsReceiver(
 	ctx context.Context,
-	params component.ReceiverCreateParams,
+	set component.ReceiverCreateSettings,
 	cfg config.Receiver,
 	consumer consumer.Metrics,
 ) (component.MetricsReceiver, error) {
 	oCfg := cfg.(*Config)
 
-	addScraperOptions, err := createAddScraperOptions(ctx, params.Logger, oCfg, scraperFactories, resourceScraperFactories)
+	addScraperOptions, err := createAddScraperOptions(ctx, set.Logger, oCfg, scraperFactories, resourceScraperFactories)
 	if err != nil {
 		return nil, err
 	}
 
 	return scraperhelper.NewScraperControllerReceiver(
 		&oCfg.ScraperControllerSettings,
-		params.Logger,
+		set.Logger,
 		consumer,
 		addScraperOptions...,
 	)

--- a/receiver/hostmetricsreceiver/factory_test.go
+++ b/receiver/hostmetricsreceiver/factory_test.go
@@ -29,7 +29,7 @@ import (
 	"go.opentelemetry.io/collector/receiver/hostmetricsreceiver/internal"
 )
 
-var creationParams = component.ReceiverCreateParams{Logger: zap.NewNop()}
+var creationSet = component.ReceiverCreateSettings{Logger: zap.NewNop()}
 
 func TestCreateDefaultConfig(t *testing.T) {
 	factory := NewFactory()
@@ -42,15 +42,15 @@ func TestCreateReceiver(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
 
-	tReceiver, err := factory.CreateTracesReceiver(context.Background(), creationParams, cfg, consumertest.NewNop())
+	tReceiver, err := factory.CreateTracesReceiver(context.Background(), creationSet, cfg, consumertest.NewNop())
 	assert.Equal(t, err, componenterror.ErrDataTypeIsNotSupported)
 	assert.Nil(t, tReceiver)
 
-	mReceiver, err := factory.CreateMetricsReceiver(context.Background(), creationParams, cfg, consumertest.NewNop())
+	mReceiver, err := factory.CreateMetricsReceiver(context.Background(), creationSet, cfg, consumertest.NewNop())
 	assert.NoError(t, err)
 	assert.NotNil(t, mReceiver)
 
-	tLogs, err := factory.CreateLogsReceiver(context.Background(), creationParams, cfg, consumertest.NewNop())
+	tLogs, err := factory.CreateLogsReceiver(context.Background(), creationSet, cfg, consumertest.NewNop())
 	assert.Equal(t, err, componenterror.ErrDataTypeIsNotSupported)
 	assert.Nil(t, tLogs)
 }
@@ -61,6 +61,6 @@ func TestCreateReceiver_ScraperKeyConfigError(t *testing.T) {
 	factory := NewFactory()
 	cfg := &Config{Scrapers: map[string]internal.Config{errorKey: &mockConfig{}}}
 
-	_, err := factory.CreateMetricsReceiver(context.Background(), creationParams, cfg, consumertest.NewNop())
+	_, err := factory.CreateMetricsReceiver(context.Background(), creationSet, cfg, consumertest.NewNop())
 	assert.EqualError(t, err, fmt.Sprintf("host metrics scraper factory not found for key: %q", errorKey))
 }

--- a/receiver/hostmetricsreceiver/hostmetrics_receiver_test.go
+++ b/receiver/hostmetricsreceiver/hostmetrics_receiver_test.go
@@ -123,7 +123,7 @@ func TestGatherMetrics_EndToEnd(t *testing.T) {
 		cfg.Scrapers[processscraper.TypeStr] = &processscraper.Config{}
 	}
 
-	receiver, err := NewFactory().CreateMetricsReceiver(context.Background(), creationParams, cfg, sink)
+	receiver, err := NewFactory().CreateMetricsReceiver(context.Background(), creationSet, cfg, sink)
 
 	require.NoError(t, err, "Failed to create metrics receiver: %v", err)
 
@@ -247,7 +247,7 @@ func TestGatherMetrics_ScraperKeyConfigError(t *testing.T) {
 
 	sink := new(consumertest.MetricsSink)
 	cfg := &Config{Scrapers: map[string]internal.Config{"error": &mockConfig{}}}
-	_, err := NewFactory().CreateMetricsReceiver(context.Background(), creationParams, cfg, sink)
+	_, err := NewFactory().CreateMetricsReceiver(context.Background(), creationSet, cfg, sink)
 	require.Error(t, err)
 }
 
@@ -259,7 +259,7 @@ func TestGatherMetrics_CreateMetricsScraperError(t *testing.T) {
 
 	sink := new(consumertest.MetricsSink)
 	cfg := &Config{Scrapers: map[string]internal.Config{mockTypeStr: &mockConfig{}}}
-	_, err := NewFactory().CreateMetricsReceiver(context.Background(), creationParams, cfg, sink)
+	_, err := NewFactory().CreateMetricsReceiver(context.Background(), creationSet, cfg, sink)
 	require.Error(t, err)
 }
 
@@ -271,7 +271,7 @@ func TestGatherMetrics_CreateMetricsResourceScraperError(t *testing.T) {
 
 	sink := new(consumertest.MetricsSink)
 	cfg := &Config{Scrapers: map[string]internal.Config{mockResourceTypeStr: &mockConfig{}}}
-	_, err := NewFactory().CreateMetricsReceiver(context.Background(), creationParams, cfg, sink)
+	_, err := NewFactory().CreateMetricsReceiver(context.Background(), creationSet, cfg, sink)
 	require.Error(t, err)
 }
 

--- a/receiver/jaegerreceiver/factory.go
+++ b/receiver/jaegerreceiver/factory.go
@@ -85,7 +85,7 @@ func createDefaultConfig() config.Receiver {
 // createTracesReceiver creates a trace receiver based on provided config.
 func createTracesReceiver(
 	_ context.Context,
-	params component.ReceiverCreateParams,
+	set component.ReceiverCreateSettings,
 	cfg config.Receiver,
 	nextConsumer consumer.Traces,
 ) (component.TracesReceiver, error) {
@@ -174,7 +174,7 @@ func createTracesReceiver(
 	}
 
 	// Create the receiver.
-	return newJaegerReceiver(rCfg.ID(), &config, nextConsumer, params), nil
+	return newJaegerReceiver(rCfg.ID(), &config, nextConsumer, set), nil
 }
 
 // extract the port number from string in "address:port" format. If the

--- a/receiver/jaegerreceiver/factory_test.go
+++ b/receiver/jaegerreceiver/factory_test.go
@@ -59,12 +59,12 @@ func TestCreateReceiver(t *testing.T) {
 			Transport: "tcp",
 		},
 	}
-	params := component.ReceiverCreateParams{Logger: zap.NewNop()}
-	tReceiver, err := factory.CreateTracesReceiver(context.Background(), params, cfg, nil)
+	set := component.ReceiverCreateSettings{Logger: zap.NewNop()}
+	tReceiver, err := factory.CreateTracesReceiver(context.Background(), set, cfg, nil)
 	assert.NoError(t, err, "receiver creation failed")
 	assert.NotNil(t, tReceiver, "receiver creation failed")
 
-	mReceiver, err := factory.CreateMetricsReceiver(context.Background(), params, cfg, nil)
+	mReceiver, err := factory.CreateMetricsReceiver(context.Background(), set, cfg, nil)
 	assert.Equal(t, err, componenterror.ErrDataTypeIsNotSupported)
 	assert.Nil(t, mReceiver)
 }
@@ -83,12 +83,12 @@ func TestCreateReceiverGeneralConfig(t *testing.T) {
 	rCfg, ok := cfg.Receivers[config.NewIDWithName(typeStr, "customname")]
 	require.True(t, ok)
 
-	params := component.ReceiverCreateParams{Logger: zap.NewNop()}
-	tReceiver, err := factory.CreateTracesReceiver(context.Background(), params, rCfg, nil)
+	set := component.ReceiverCreateSettings{Logger: zap.NewNop()}
+	tReceiver, err := factory.CreateTracesReceiver(context.Background(), set, rCfg, nil)
 	assert.NoError(t, err, "receiver creation failed")
 	assert.NotNil(t, tReceiver, "receiver creation failed")
 
-	mReceiver, err := factory.CreateMetricsReceiver(context.Background(), params, rCfg, nil)
+	mReceiver, err := factory.CreateMetricsReceiver(context.Background(), set, rCfg, nil)
 	assert.Equal(t, err, componenterror.ErrDataTypeIsNotSupported)
 	assert.Nil(t, mReceiver)
 }
@@ -104,8 +104,8 @@ func TestCreateDefaultGRPCEndpoint(t *testing.T) {
 			Transport: "tcp",
 		},
 	}
-	params := component.ReceiverCreateParams{Logger: zap.NewNop()}
-	r, err := factory.CreateTracesReceiver(context.Background(), params, cfg, nil)
+	set := component.ReceiverCreateSettings{Logger: zap.NewNop()}
+	r, err := factory.CreateTracesReceiver(context.Background(), set, cfg, nil)
 
 	assert.NoError(t, err, "unexpected error creating receiver")
 	assert.Equal(t, 14250, r.(*jReceiver).config.CollectorGRPCPort, "grpc port should be default")
@@ -127,9 +127,9 @@ func TestCreateTLSGPRCEndpoint(t *testing.T) {
 			},
 		},
 	}
-	params := component.ReceiverCreateParams{Logger: zap.NewNop()}
+	set := component.ReceiverCreateSettings{Logger: zap.NewNop()}
 
-	_, err := factory.CreateTracesReceiver(context.Background(), params, cfg, nil)
+	_, err := factory.CreateTracesReceiver(context.Background(), set, cfg, nil)
 	assert.NoError(t, err, "tls-enabled receiver creation failed")
 }
 
@@ -147,9 +147,9 @@ func TestCreateTLSThriftHTTPEndpoint(t *testing.T) {
 		},
 	}
 
-	params := component.ReceiverCreateParams{Logger: zap.NewNop()}
+	set := component.ReceiverCreateSettings{Logger: zap.NewNop()}
 
-	_, err := factory.CreateTracesReceiver(context.Background(), params, cfg, nil)
+	_, err := factory.CreateTracesReceiver(context.Background(), set, cfg, nil)
 	assert.NoError(t, err, "tls-enabled receiver creation failed")
 }
 
@@ -160,8 +160,8 @@ func TestCreateInvalidHTTPEndpoint(t *testing.T) {
 	cfg.(*Config).Protocols.ThriftHTTP = &confighttp.HTTPServerSettings{
 		Endpoint: defaultHTTPBindEndpoint,
 	}
-	params := component.ReceiverCreateParams{Logger: zap.NewNop()}
-	r, err := factory.CreateTracesReceiver(context.Background(), params, cfg, nil)
+	set := component.ReceiverCreateSettings{Logger: zap.NewNop()}
+	r, err := factory.CreateTracesReceiver(context.Background(), set, cfg, nil)
 
 	assert.NoError(t, err, "unexpected error creating receiver")
 	assert.Equal(t, 14268, r.(*jReceiver).config.CollectorHTTPPort, "http port should be default")
@@ -174,8 +174,8 @@ func TestCreateInvalidThriftBinaryEndpoint(t *testing.T) {
 	cfg.(*Config).Protocols.ThriftBinary = &ProtocolUDP{
 		Endpoint: defaultThriftBinaryBindEndpoint,
 	}
-	params := component.ReceiverCreateParams{Logger: zap.NewNop()}
-	r, err := factory.CreateTracesReceiver(context.Background(), params, cfg, nil)
+	set := component.ReceiverCreateSettings{Logger: zap.NewNop()}
+	r, err := factory.CreateTracesReceiver(context.Background(), set, cfg, nil)
 
 	assert.NoError(t, err, "unexpected error creating receiver")
 	assert.Equal(t, 6832, r.(*jReceiver).config.AgentBinaryThriftPort, "thrift port should be default")
@@ -188,8 +188,8 @@ func TestCreateInvalidThriftCompactEndpoint(t *testing.T) {
 	cfg.(*Config).Protocols.ThriftCompact = &ProtocolUDP{
 		Endpoint: defaultThriftCompactBindEndpoint,
 	}
-	params := component.ReceiverCreateParams{Logger: zap.NewNop()}
-	r, err := factory.CreateTracesReceiver(context.Background(), params, cfg, nil)
+	set := component.ReceiverCreateSettings{Logger: zap.NewNop()}
+	r, err := factory.CreateTracesReceiver(context.Background(), set, cfg, nil)
 
 	assert.NoError(t, err, "unexpected error creating receiver")
 	assert.Equal(t, 6831, r.(*jReceiver).config.AgentCompactThriftPort, "thrift port should be default")
@@ -204,8 +204,8 @@ func TestDefaultAgentRemoteSamplingEndpointAndPort(t *testing.T) {
 		Endpoint: defaultThriftCompactBindEndpoint,
 	}
 	rCfg.RemoteSampling = &RemoteSamplingConfig{}
-	params := component.ReceiverCreateParams{Logger: zap.NewNop()}
-	r, err := factory.CreateTracesReceiver(context.Background(), params, cfg, nil)
+	set := component.ReceiverCreateSettings{Logger: zap.NewNop()}
+	r, err := factory.CreateTracesReceiver(context.Background(), set, cfg, nil)
 
 	assert.NoError(t, err, "create trace receiver should not error")
 	assert.Equal(t, defaultGRPCBindEndpoint, r.(*jReceiver).config.RemoteSamplingClientSettings.Endpoint)
@@ -226,8 +226,8 @@ func TestAgentRemoteSamplingEndpoint(t *testing.T) {
 			Endpoint: endpoint,
 		},
 	}
-	params := component.ReceiverCreateParams{Logger: zap.NewNop()}
-	r, err := factory.CreateTracesReceiver(context.Background(), params, cfg, nil)
+	set := component.ReceiverCreateSettings{Logger: zap.NewNop()}
+	r, err := factory.CreateTracesReceiver(context.Background(), set, cfg, nil)
 
 	assert.NoError(t, err, "create trace receiver should not error")
 	assert.Equal(t, endpoint, r.(*jReceiver).config.RemoteSamplingClientSettings.Endpoint)
@@ -241,8 +241,8 @@ func TestCreateNoPort(t *testing.T) {
 	cfg.(*Config).Protocols.ThriftHTTP = &confighttp.HTTPServerSettings{
 		Endpoint: "localhost:",
 	}
-	params := component.ReceiverCreateParams{Logger: zap.NewNop()}
-	_, err := factory.CreateTracesReceiver(context.Background(), params, cfg, nil)
+	set := component.ReceiverCreateSettings{Logger: zap.NewNop()}
+	_, err := factory.CreateTracesReceiver(context.Background(), set, cfg, nil)
 	assert.Error(t, err, "receiver creation with no port number must fail")
 }
 
@@ -253,8 +253,8 @@ func TestCreateLargePort(t *testing.T) {
 	cfg.(*Config).Protocols.ThriftHTTP = &confighttp.HTTPServerSettings{
 		Endpoint: "localhost:65536",
 	}
-	params := component.ReceiverCreateParams{Logger: zap.NewNop()}
-	_, err := factory.CreateTracesReceiver(context.Background(), params, cfg, nil)
+	set := component.ReceiverCreateSettings{Logger: zap.NewNop()}
+	_, err := factory.CreateTracesReceiver(context.Background(), set, cfg, nil)
 	assert.Error(t, err, "receiver creation with too large port number must fail")
 }
 
@@ -269,8 +269,8 @@ func TestCreateInvalidHost(t *testing.T) {
 		},
 	}
 
-	params := component.ReceiverCreateParams{Logger: zap.NewNop()}
-	_, err := factory.CreateTracesReceiver(context.Background(), params, cfg, nil)
+	set := component.ReceiverCreateSettings{Logger: zap.NewNop()}
+	_, err := factory.CreateTracesReceiver(context.Background(), set, cfg, nil)
 	assert.Error(t, err, "receiver creation with bad hostname must fail")
 }
 
@@ -279,8 +279,8 @@ func TestCreateNoProtocols(t *testing.T) {
 	cfg := factory.CreateDefaultConfig()
 
 	cfg.(*Config).Protocols = Protocols{}
-	params := component.ReceiverCreateParams{Logger: zap.NewNop()}
-	_, err := factory.CreateTracesReceiver(context.Background(), params, cfg, nil)
+	set := component.ReceiverCreateSettings{Logger: zap.NewNop()}
+	_, err := factory.CreateTracesReceiver(context.Background(), set, cfg, nil)
 	assert.Error(t, err, "receiver creation with no protocols must fail")
 }
 
@@ -291,8 +291,8 @@ func TestThriftBinaryBadPort(t *testing.T) {
 	cfg.(*Config).Protocols.ThriftBinary = &ProtocolUDP{
 		Endpoint: "localhost:65536",
 	}
-	params := component.ReceiverCreateParams{Logger: zap.NewNop()}
-	_, err := factory.CreateTracesReceiver(context.Background(), params, cfg, nil)
+	set := component.ReceiverCreateSettings{Logger: zap.NewNop()}
+	_, err := factory.CreateTracesReceiver(context.Background(), set, cfg, nil)
 	assert.Error(t, err, "receiver creation with a bad thrift binary port must fail")
 }
 
@@ -304,8 +304,8 @@ func TestThriftCompactBadPort(t *testing.T) {
 		Endpoint: "localhost:65536",
 	}
 
-	params := component.ReceiverCreateParams{Logger: zap.NewNop()}
-	_, err := factory.CreateTracesReceiver(context.Background(), params, cfg, nil)
+	set := component.ReceiverCreateSettings{Logger: zap.NewNop()}
+	_, err := factory.CreateTracesReceiver(context.Background(), set, cfg, nil)
 	assert.Error(t, err, "receiver creation with a bad thrift compact port must fail")
 }
 
@@ -330,8 +330,8 @@ func TestRemoteSamplingConfigPropagation(t *testing.T) {
 		HostEndpoint: fmt.Sprintf("localhost:%d", hostPort),
 		StrategyFile: strategyFile,
 	}
-	params := component.ReceiverCreateParams{Logger: zap.NewNop()}
-	r, err := factory.CreateTracesReceiver(context.Background(), params, cfg, nil)
+	set := component.ReceiverCreateSettings{Logger: zap.NewNop()}
+	r, err := factory.CreateTracesReceiver(context.Background(), set, cfg, nil)
 
 	assert.NoError(t, err, "create trace receiver should not error")
 	assert.Equal(t, endpoint, r.(*jReceiver).config.RemoteSamplingClientSettings.Endpoint)
@@ -352,8 +352,8 @@ func TestRemoteSamplingFileRequiresGRPC(t *testing.T) {
 	rCfg.RemoteSampling = &RemoteSamplingConfig{
 		StrategyFile: "strategies.json",
 	}
-	params := component.ReceiverCreateParams{Logger: zap.NewNop()}
-	_, err := factory.CreateTracesReceiver(context.Background(), params, cfg, nil)
+	set := component.ReceiverCreateSettings{Logger: zap.NewNop()}
+	_, err := factory.CreateTracesReceiver(context.Background(), set, cfg, nil)
 
 	assert.Error(t, err, "create trace receiver should error")
 }

--- a/receiver/jaegerreceiver/jaeger_agent_test.go
+++ b/receiver/jaegerreceiver/jaeger_agent_test.go
@@ -63,8 +63,8 @@ func TestJaegerAgentUDP_ThriftCompact_InvalidPort(t *testing.T) {
 	config := &configuration{
 		AgentCompactThriftPort: port,
 	}
-	params := component.ReceiverCreateParams{Logger: zap.NewNop()}
-	jr := newJaegerReceiver(jaegerAgent, config, nil, params)
+	set := component.ReceiverCreateSettings{Logger: zap.NewNop()}
+	jr := newJaegerReceiver(jaegerAgent, config, nil, set)
 
 	assert.Error(t, jr.Start(context.Background(), componenttest.NewNopHost()), "should not have been able to startTraceReception")
 
@@ -88,8 +88,8 @@ func TestJaegerAgentUDP_ThriftBinary_PortInUse(t *testing.T) {
 		AgentBinaryThriftPort:   int(port),
 		AgentBinaryThriftConfig: DefaultServerConfigUDP(),
 	}
-	params := component.ReceiverCreateParams{Logger: zap.NewNop()}
-	jr := newJaegerReceiver(jaegerAgent, config, nil, params)
+	set := component.ReceiverCreateSettings{Logger: zap.NewNop()}
+	jr := newJaegerReceiver(jaegerAgent, config, nil, set)
 
 	assert.NoError(t, jr.startAgent(componenttest.NewNopHost()), "Start failed")
 	t.Cleanup(func() { require.NoError(t, jr.Shutdown(context.Background())) })
@@ -108,8 +108,8 @@ func TestJaegerAgentUDP_ThriftBinary_InvalidPort(t *testing.T) {
 	config := &configuration{
 		AgentBinaryThriftPort: port,
 	}
-	params := component.ReceiverCreateParams{Logger: zap.NewNop()}
-	jr := newJaegerReceiver(jaegerAgent, config, nil, params)
+	set := component.ReceiverCreateSettings{Logger: zap.NewNop()}
+	jr := newJaegerReceiver(jaegerAgent, config, nil, set)
 
 	assert.Error(t, jr.Start(context.Background(), componenttest.NewNopHost()), "should not have been able to startTraceReception")
 
@@ -151,8 +151,8 @@ func TestJaegerHTTP(t *testing.T) {
 			},
 		},
 	}
-	params := component.ReceiverCreateParams{Logger: zap.NewNop()}
-	jr := newJaegerReceiver(jaegerAgent, config, nil, params)
+	set := component.ReceiverCreateSettings{Logger: zap.NewNop()}
+	jr := newJaegerReceiver(jaegerAgent, config, nil, set)
 	t.Cleanup(func() { require.NoError(t, jr.Shutdown(context.Background())) })
 
 	assert.NoError(t, jr.Start(context.Background(), componenttest.NewNopHost()), "Start failed")
@@ -189,8 +189,8 @@ func TestJaegerHTTP(t *testing.T) {
 func testJaegerAgent(t *testing.T, agentEndpoint string, receiverConfig *configuration) {
 	// 1. Create the Jaeger receiver aka "server"
 	sink := new(consumertest.TracesSink)
-	params := component.ReceiverCreateParams{Logger: zap.NewNop()}
-	jr := newJaegerReceiver(jaegerAgent, receiverConfig, sink, params)
+	set := component.ReceiverCreateSettings{Logger: zap.NewNop()}
+	jr := newJaegerReceiver(jaegerAgent, receiverConfig, sink, set)
 	t.Cleanup(func() { require.NoError(t, jr.Shutdown(context.Background())) })
 
 	assert.NoError(t, jr.Start(context.Background(), componenttest.NewNopHost()), "Start failed")

--- a/receiver/jaegerreceiver/trace_receiver.go
+++ b/receiver/jaegerreceiver/trace_receiver.go
@@ -120,13 +120,13 @@ func newJaegerReceiver(
 	id config.ComponentID,
 	config *configuration,
 	nextConsumer consumer.Traces,
-	params component.ReceiverCreateParams,
+	set component.ReceiverCreateSettings,
 ) *jReceiver {
 	return &jReceiver{
 		config:       config,
 		nextConsumer: nextConsumer,
 		id:           id,
-		logger:       params.Logger,
+		logger:       set.Logger,
 		grpcObsrecv:  obsreport.NewReceiver(obsreport.ReceiverSettings{ReceiverID: id, Transport: grpcTransport}),
 		httpObsrecv:  obsreport.NewReceiver(obsreport.ReceiverSettings{ReceiverID: id, Transport: collectorHTTPTransport}),
 	}

--- a/receiver/jaegerreceiver/trace_receiver_test.go
+++ b/receiver/jaegerreceiver/trace_receiver_test.go
@@ -60,8 +60,8 @@ import (
 var jaegerReceiver = config.NewIDWithName("jaeger", "receiver_test")
 
 func TestTraceSource(t *testing.T) {
-	params := component.ReceiverCreateParams{Logger: zap.NewNop()}
-	jr := newJaegerReceiver(jaegerReceiver, &configuration{}, nil, params)
+	set := component.ReceiverCreateSettings{Logger: zap.NewNop()}
+	jr := newJaegerReceiver(jaegerReceiver, &configuration{}, nil, set)
 	require.NotNil(t, jr)
 }
 
@@ -146,8 +146,8 @@ func TestReception(t *testing.T) {
 	}
 	sink := new(consumertest.TracesSink)
 
-	params := component.ReceiverCreateParams{Logger: zap.NewNop()}
-	jr := newJaegerReceiver(jaegerReceiver, config, sink, params)
+	set := component.ReceiverCreateSettings{Logger: zap.NewNop()}
+	jr := newJaegerReceiver(jaegerReceiver, config, sink, set)
 
 	require.NoError(t, jr.Start(context.Background(), componenttest.NewNopHost()))
 	t.Cleanup(func() { require.NoError(t, jr.Shutdown(context.Background())) })
@@ -175,8 +175,8 @@ func TestPortsNotOpen(t *testing.T) {
 
 	sink := new(consumertest.TracesSink)
 
-	params := component.ReceiverCreateParams{Logger: zap.NewNop()}
-	jr := newJaegerReceiver(jaegerReceiver, config, sink, params)
+	set := component.ReceiverCreateSettings{Logger: zap.NewNop()}
+	jr := newJaegerReceiver(jaegerReceiver, config, sink, set)
 
 	require.NoError(t, jr.Start(context.Background(), componenttest.NewNopHost()))
 	t.Cleanup(func() { require.NoError(t, jr.Shutdown(context.Background())) })
@@ -204,8 +204,8 @@ func TestGRPCReception(t *testing.T) {
 	}
 	sink := new(consumertest.TracesSink)
 
-	params := component.ReceiverCreateParams{Logger: zap.NewNop()}
-	jr := newJaegerReceiver(jaegerReceiver, config, sink, params)
+	set := component.ReceiverCreateSettings{Logger: zap.NewNop()}
+	jr := newJaegerReceiver(jaegerReceiver, config, sink, set)
 
 	require.NoError(t, jr.Start(context.Background(), componenttest.NewNopHost()))
 	t.Cleanup(func() { require.NoError(t, jr.Shutdown(context.Background())) })
@@ -259,8 +259,8 @@ func TestGRPCReceptionWithTLS(t *testing.T) {
 	}
 	sink := new(consumertest.TracesSink)
 
-	params := component.ReceiverCreateParams{Logger: zap.NewNop()}
-	jr := newJaegerReceiver(jaegerReceiver, config, sink, params)
+	set := component.ReceiverCreateSettings{Logger: zap.NewNop()}
+	jr := newJaegerReceiver(jaegerReceiver, config, sink, set)
 
 	require.NoError(t, jr.Start(context.Background(), componenttest.NewNopHost()))
 	t.Cleanup(func() { require.NoError(t, jr.Shutdown(context.Background())) })
@@ -392,8 +392,8 @@ func TestSampling(t *testing.T) {
 	}
 	sink := new(consumertest.TracesSink)
 
-	params := component.ReceiverCreateParams{Logger: zap.NewNop()}
-	jr := newJaegerReceiver(jaegerReceiver, config, sink, params)
+	set := component.ReceiverCreateSettings{Logger: zap.NewNop()}
+	jr := newJaegerReceiver(jaegerReceiver, config, sink, set)
 
 	require.NoError(t, jr.Start(context.Background(), componenttest.NewNopHost()))
 	t.Cleanup(func() { require.NoError(t, jr.Shutdown(context.Background())) })
@@ -443,8 +443,8 @@ func TestSamplingFailsOnNotConfigured(t *testing.T) {
 	}
 	sink := new(consumertest.TracesSink)
 
-	params := component.ReceiverCreateParams{Logger: zap.NewNop()}
-	jr := newJaegerReceiver(jaegerReceiver, config, sink, params)
+	set := component.ReceiverCreateSettings{Logger: zap.NewNop()}
+	jr := newJaegerReceiver(jaegerReceiver, config, sink, set)
 
 	require.NoError(t, jr.Start(context.Background(), componenttest.NewNopHost()))
 	t.Cleanup(func() { require.NoError(t, jr.Shutdown(context.Background())) })
@@ -471,8 +471,8 @@ func TestSamplingFailsOnBadFile(t *testing.T) {
 	}
 	sink := new(consumertest.TracesSink)
 
-	params := component.ReceiverCreateParams{Logger: zap.NewNop()}
-	jr := newJaegerReceiver(jaegerReceiver, config, sink, params)
+	set := component.ReceiverCreateSettings{Logger: zap.NewNop()}
+	jr := newJaegerReceiver(jaegerReceiver, config, sink, set)
 	assert.Error(t, jr.Start(context.Background(), componenttest.NewNopHost()))
 	t.Cleanup(func() { require.NoError(t, jr.Shutdown(context.Background())) })
 }
@@ -530,7 +530,7 @@ func TestSamplingStrategiesMutualTLS(t *testing.T) {
 	cfg.Protocols.ThriftHTTP = &confighttp.HTTPServerSettings{
 		Endpoint: fmt.Sprintf("localhost:%d", thriftHTTPPort),
 	}
-	exp, err := factory.CreateTracesReceiver(context.Background(), component.ReceiverCreateParams{Logger: zap.NewNop()}, cfg, consumertest.NewNop())
+	exp, err := factory.CreateTracesReceiver(context.Background(), component.ReceiverCreateSettings{Logger: zap.NewNop()}, cfg, consumertest.NewNop())
 	require.NoError(t, err)
 	require.NoError(t, exp.Start(context.Background(), newAssertNoErrorHost(t)))
 	t.Cleanup(func() { require.NoError(t, exp.Shutdown(context.Background())) })

--- a/receiver/kafkareceiver/factory.go
+++ b/receiver/kafkareceiver/factory.go
@@ -105,12 +105,12 @@ type kafkaReceiverFactory struct {
 
 func (f *kafkaReceiverFactory) createTracesReceiver(
 	_ context.Context,
-	params component.ReceiverCreateParams,
+	set component.ReceiverCreateSettings,
 	cfg config.Receiver,
 	nextConsumer consumer.Traces,
 ) (component.TracesReceiver, error) {
 	c := cfg.(*Config)
-	r, err := newTracesReceiver(*c, params, f.tracesUnmarshalers, nextConsumer)
+	r, err := newTracesReceiver(*c, set, f.tracesUnmarshalers, nextConsumer)
 	if err != nil {
 		return nil, err
 	}
@@ -119,12 +119,12 @@ func (f *kafkaReceiverFactory) createTracesReceiver(
 
 func (f *kafkaReceiverFactory) createLogsReceiver(
 	_ context.Context,
-	params component.ReceiverCreateParams,
+	set component.ReceiverCreateSettings,
 	cfg config.Receiver,
 	nextConsumer consumer.Logs,
 ) (component.LogsReceiver, error) {
 	c := cfg.(*Config)
-	r, err := newLogsReceiver(*c, params, f.logsUnmarshalers, nextConsumer)
+	r, err := newLogsReceiver(*c, set, f.logsUnmarshalers, nextConsumer)
 	if err != nil {
 		return nil, err
 	}

--- a/receiver/kafkareceiver/factory_test.go
+++ b/receiver/kafkareceiver/factory_test.go
@@ -41,7 +41,7 @@ func TestCreateTracesReceiver(t *testing.T) {
 	cfg.Brokers = []string{"invalid:9092"}
 	cfg.ProtocolVersion = "2.0.0"
 	f := kafkaReceiverFactory{tracesUnmarshalers: defaultTracesUnmarshalers()}
-	r, err := f.createTracesReceiver(context.Background(), component.ReceiverCreateParams{}, cfg, nil)
+	r, err := f.createTracesReceiver(context.Background(), component.ReceiverCreateSettings{}, cfg, nil)
 	// no available broker
 	require.Error(t, err)
 	assert.Nil(t, r)
@@ -53,7 +53,7 @@ func TestCreateTracesReceiver_error(t *testing.T) {
 	// disable contacting broker at startup
 	cfg.Metadata.Full = false
 	f := kafkaReceiverFactory{tracesUnmarshalers: defaultTracesUnmarshalers()}
-	r, err := f.createTracesReceiver(context.Background(), component.ReceiverCreateParams{}, cfg, nil)
+	r, err := f.createTracesReceiver(context.Background(), component.ReceiverCreateSettings{}, cfg, nil)
 	require.NoError(t, err)
 	assert.NotNil(t, r)
 }
@@ -68,13 +68,13 @@ func TestWithTracesUnmarshalers(t *testing.T) {
 
 	t.Run("custom_encoding", func(t *testing.T) {
 		cfg.Encoding = unmarshaler.Encoding()
-		receiver, err := f.CreateTracesReceiver(context.Background(), component.ReceiverCreateParams{}, cfg, nil)
+		receiver, err := f.CreateTracesReceiver(context.Background(), component.ReceiverCreateSettings{}, cfg, nil)
 		require.NoError(t, err)
 		require.NotNil(t, receiver)
 	})
 	t.Run("default_encoding", func(t *testing.T) {
 		cfg.Encoding = new(otlpTracesPbUnmarshaler).Encoding()
-		receiver, err := f.CreateTracesReceiver(context.Background(), component.ReceiverCreateParams{}, cfg, nil)
+		receiver, err := f.CreateTracesReceiver(context.Background(), component.ReceiverCreateSettings{}, cfg, nil)
 		require.NoError(t, err)
 		assert.NotNil(t, receiver)
 	})
@@ -85,7 +85,7 @@ func TestCreateLogsReceiver(t *testing.T) {
 	cfg.Brokers = []string{"invalid:9092"}
 	cfg.ProtocolVersion = "2.0.0"
 	f := kafkaReceiverFactory{logsUnmarshalers: defaultLogsUnmarshalers()}
-	r, err := f.createLogsReceiver(context.Background(), component.ReceiverCreateParams{}, cfg, nil)
+	r, err := f.createLogsReceiver(context.Background(), component.ReceiverCreateSettings{}, cfg, nil)
 	// no available broker
 	require.Error(t, err)
 	assert.Nil(t, r)
@@ -97,7 +97,7 @@ func TestCreateLogsReceiver_error(t *testing.T) {
 	// disable contacting broker at startup
 	cfg.Metadata.Full = false
 	f := kafkaReceiverFactory{logsUnmarshalers: defaultLogsUnmarshalers()}
-	r, err := f.createLogsReceiver(context.Background(), component.ReceiverCreateParams{}, cfg, nil)
+	r, err := f.createLogsReceiver(context.Background(), component.ReceiverCreateSettings{}, cfg, nil)
 	require.NoError(t, err)
 	assert.NotNil(t, r)
 }
@@ -112,13 +112,13 @@ func TestWithLogsUnmarshalers(t *testing.T) {
 
 	t.Run("custom_encoding", func(t *testing.T) {
 		cfg.Encoding = unmarshaler.Encoding()
-		exporter, err := f.CreateLogsReceiver(context.Background(), component.ReceiverCreateParams{}, cfg, nil)
+		exporter, err := f.CreateLogsReceiver(context.Background(), component.ReceiverCreateSettings{}, cfg, nil)
 		require.NoError(t, err)
 		require.NotNil(t, exporter)
 	})
 	t.Run("default_encoding", func(t *testing.T) {
 		cfg.Encoding = new(otlpLogsPbUnmarshaler).Encoding()
-		exporter, err := f.CreateLogsReceiver(context.Background(), component.ReceiverCreateParams{}, cfg, nil)
+		exporter, err := f.CreateLogsReceiver(context.Background(), component.ReceiverCreateSettings{}, cfg, nil)
 		require.NoError(t, err)
 		assert.NotNil(t, exporter)
 	})

--- a/receiver/kafkareceiver/kafka_receiver.go
+++ b/receiver/kafkareceiver/kafka_receiver.go
@@ -64,7 +64,7 @@ type kafkaLogsConsumer struct {
 var _ component.Receiver = (*kafkaTracesConsumer)(nil)
 var _ component.Receiver = (*kafkaLogsConsumer)(nil)
 
-func newTracesReceiver(config Config, params component.ReceiverCreateParams, unmarshalers map[string]TracesUnmarshaler, nextConsumer consumer.Traces) (*kafkaTracesConsumer, error) {
+func newTracesReceiver(config Config, set component.ReceiverCreateSettings, unmarshalers map[string]TracesUnmarshaler, nextConsumer consumer.Traces) (*kafkaTracesConsumer, error) {
 	unmarshaler := unmarshalers[config.Encoding]
 	if unmarshaler == nil {
 		return nil, errUnrecognizedEncoding
@@ -95,7 +95,7 @@ func newTracesReceiver(config Config, params component.ReceiverCreateParams, unm
 		topics:        []string{config.Topic},
 		nextConsumer:  nextConsumer,
 		unmarshaler:   unmarshaler,
-		logger:        params.Logger,
+		logger:        set.Logger,
 	}, nil
 }
 
@@ -136,7 +136,7 @@ func (c *kafkaTracesConsumer) Shutdown(context.Context) error {
 	return c.consumerGroup.Close()
 }
 
-func newLogsReceiver(config Config, params component.ReceiverCreateParams, unmarshalers map[string]LogsUnmarshaler, nextConsumer consumer.Logs) (*kafkaLogsConsumer, error) {
+func newLogsReceiver(config Config, set component.ReceiverCreateSettings, unmarshalers map[string]LogsUnmarshaler, nextConsumer consumer.Logs) (*kafkaLogsConsumer, error) {
 	unmarshaler := unmarshalers[config.Encoding]
 	if unmarshaler == nil {
 		return nil, errUnrecognizedEncoding
@@ -167,7 +167,7 @@ func newLogsReceiver(config Config, params component.ReceiverCreateParams, unmar
 		topics:        []string{config.Topic},
 		nextConsumer:  nextConsumer,
 		unmarshaler:   unmarshaler,
-		logger:        params.Logger,
+		logger:        set.Logger,
 	}, nil
 }
 

--- a/receiver/kafkareceiver/kafka_receiver_test.go
+++ b/receiver/kafkareceiver/kafka_receiver_test.go
@@ -44,7 +44,7 @@ func TestNewTracesReceiver_version_err(t *testing.T) {
 		Encoding:        defaultEncoding,
 		ProtocolVersion: "none",
 	}
-	r, err := newTracesReceiver(c, component.ReceiverCreateParams{}, defaultTracesUnmarshalers(), consumertest.NewNop())
+	r, err := newTracesReceiver(c, component.ReceiverCreateSettings{}, defaultTracesUnmarshalers(), consumertest.NewNop())
 	assert.Error(t, err)
 	assert.Nil(t, r)
 }
@@ -53,7 +53,7 @@ func TestNewTracesReceiver_encoding_err(t *testing.T) {
 	c := Config{
 		Encoding: "foo",
 	}
-	r, err := newTracesReceiver(c, component.ReceiverCreateParams{}, defaultTracesUnmarshalers(), consumertest.NewNop())
+	r, err := newTracesReceiver(c, component.ReceiverCreateSettings{}, defaultTracesUnmarshalers(), consumertest.NewNop())
 	require.Error(t, err)
 	assert.Nil(t, r)
 	assert.EqualError(t, err, errUnrecognizedEncoding.Error())
@@ -74,7 +74,7 @@ func TestNewTracesReceiver_err_auth_type(t *testing.T) {
 			Full: false,
 		},
 	}
-	r, err := newTracesReceiver(c, component.ReceiverCreateParams{}, defaultTracesUnmarshalers(), consumertest.NewNop())
+	r, err := newTracesReceiver(c, component.ReceiverCreateSettings{}, defaultTracesUnmarshalers(), consumertest.NewNop())
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to load TLS config")
 	assert.Nil(t, r)
@@ -229,7 +229,7 @@ func TestNewLogsReceiver_version_err(t *testing.T) {
 		Encoding:        defaultEncoding,
 		ProtocolVersion: "none",
 	}
-	r, err := newLogsReceiver(c, component.ReceiverCreateParams{}, defaultLogsUnmarshalers(), consumertest.NewNop())
+	r, err := newLogsReceiver(c, component.ReceiverCreateSettings{}, defaultLogsUnmarshalers(), consumertest.NewNop())
 	assert.Error(t, err)
 	assert.Nil(t, r)
 }
@@ -238,7 +238,7 @@ func TestNewLogsReceiver_encoding_err(t *testing.T) {
 	c := Config{
 		Encoding: "foo",
 	}
-	r, err := newLogsReceiver(c, component.ReceiverCreateParams{}, defaultLogsUnmarshalers(), consumertest.NewNop())
+	r, err := newLogsReceiver(c, component.ReceiverCreateSettings{}, defaultLogsUnmarshalers(), consumertest.NewNop())
 	require.Error(t, err)
 	assert.Nil(t, r)
 	assert.EqualError(t, err, errUnrecognizedEncoding.Error())
@@ -259,7 +259,7 @@ func TestNewLogsExporter_err_auth_type(t *testing.T) {
 			Full: false,
 		},
 	}
-	r, err := newLogsReceiver(c, component.ReceiverCreateParams{}, defaultLogsUnmarshalers(), consumertest.NewNop())
+	r, err := newLogsReceiver(c, component.ReceiverCreateSettings{}, defaultLogsUnmarshalers(), consumertest.NewNop())
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to load TLS config")
 	assert.Nil(t, r)

--- a/receiver/opencensusreceiver/factory.go
+++ b/receiver/opencensusreceiver/factory.go
@@ -53,7 +53,7 @@ func createDefaultConfig() config.Receiver {
 
 func createTracesReceiver(
 	_ context.Context,
-	_ component.ReceiverCreateParams,
+	_ component.ReceiverCreateSettings,
 	cfg config.Receiver,
 	nextConsumer consumer.Traces,
 ) (component.TracesReceiver, error) {
@@ -74,7 +74,7 @@ func createTracesReceiver(
 
 func createMetricsReceiver(
 	_ context.Context,
-	_ component.ReceiverCreateParams,
+	_ component.ReceiverCreateSettings,
 	cfg config.Receiver,
 	nextConsumer consumer.Metrics,
 ) (component.MetricsReceiver, error) {

--- a/receiver/opencensusreceiver/factory_test.go
+++ b/receiver/opencensusreceiver/factory_test.go
@@ -43,12 +43,12 @@ func TestCreateReceiver(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)
 	cfg.NetAddr.Endpoint = testutil.GetAvailableLocalAddress(t)
 
-	params := component.ReceiverCreateParams{Logger: zap.NewNop()}
-	tReceiver, err := createTracesReceiver(context.Background(), params, cfg, nil)
+	set := component.ReceiverCreateSettings{Logger: zap.NewNop()}
+	tReceiver, err := createTracesReceiver(context.Background(), set, cfg, nil)
 	assert.NotNil(t, tReceiver)
 	assert.NoError(t, err)
 
-	mReceiver, err := createMetricsReceiver(context.Background(), params, cfg, nil)
+	mReceiver, err := createMetricsReceiver(context.Background(), set, cfg, nil)
 	assert.NotNil(t, mReceiver)
 	assert.NoError(t, err)
 }
@@ -99,10 +99,10 @@ func TestCreateTracesReceiver(t *testing.T) {
 		},
 	}
 	ctx := context.Background()
-	params := component.ReceiverCreateParams{Logger: zap.NewNop()}
+	set := component.ReceiverCreateSettings{Logger: zap.NewNop()}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tr, err := createTracesReceiver(ctx, params, tt.cfg, consumertest.NewNop())
+			tr, err := createTracesReceiver(ctx, set, tt.cfg, consumertest.NewNop())
 			if (err != nil) != tt.wantErr {
 				t.Errorf("factory.CreateTracesReceiver() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -168,10 +168,10 @@ func TestCreateMetricReceiver(t *testing.T) {
 			},
 		},
 	}
-	params := component.ReceiverCreateParams{Logger: zap.NewNop()}
+	set := component.ReceiverCreateSettings{Logger: zap.NewNop()}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tc, err := createMetricsReceiver(context.Background(), params, tt.cfg, consumertest.NewNop())
+			tc, err := createMetricsReceiver(context.Background(), set, tt.cfg, consumertest.NewNop())
 			if (err != nil) != tt.wantErr {
 				t.Errorf("factory.CreateMetricsReceiver() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/receiver/otlpreceiver/factory.go
+++ b/receiver/otlpreceiver/factory.go
@@ -68,12 +68,12 @@ func createDefaultConfig() config.Receiver {
 // CreateTracesReceiver creates a  trace receiver based on provided config.
 func createTracesReceiver(
 	ctx context.Context,
-	params component.ReceiverCreateParams,
+	set component.ReceiverCreateSettings,
 	cfg config.Receiver,
 	nextConsumer consumer.Traces,
 ) (component.TracesReceiver, error) {
 	r := receivers.GetOrAdd(cfg, func() component.Component {
-		return newOtlpReceiver(cfg.(*Config), params.Logger)
+		return newOtlpReceiver(cfg.(*Config), set.Logger)
 	})
 
 	if err := r.Unwrap().(*otlpReceiver).registerTraceConsumer(ctx, nextConsumer); err != nil {
@@ -85,12 +85,12 @@ func createTracesReceiver(
 // CreateMetricsReceiver creates a metrics receiver based on provided config.
 func createMetricsReceiver(
 	ctx context.Context,
-	params component.ReceiverCreateParams,
+	set component.ReceiverCreateSettings,
 	cfg config.Receiver,
 	consumer consumer.Metrics,
 ) (component.MetricsReceiver, error) {
 	r := receivers.GetOrAdd(cfg, func() component.Component {
-		return newOtlpReceiver(cfg.(*Config), params.Logger)
+		return newOtlpReceiver(cfg.(*Config), set.Logger)
 	})
 
 	if err := r.Unwrap().(*otlpReceiver).registerMetricsConsumer(ctx, consumer); err != nil {
@@ -102,12 +102,12 @@ func createMetricsReceiver(
 // CreateLogReceiver creates a log receiver based on provided config.
 func createLogReceiver(
 	ctx context.Context,
-	params component.ReceiverCreateParams,
+	set component.ReceiverCreateSettings,
 	cfg config.Receiver,
 	consumer consumer.Logs,
 ) (component.LogsReceiver, error) {
 	r := receivers.GetOrAdd(cfg, func() component.Component {
-		return newOtlpReceiver(cfg.(*Config), params.Logger)
+		return newOtlpReceiver(cfg.(*Config), set.Logger)
 	})
 
 	if err := r.Unwrap().(*otlpReceiver).registerLogsConsumer(ctx, consumer); err != nil {

--- a/receiver/otlpreceiver/factory_test.go
+++ b/receiver/otlpreceiver/factory_test.go
@@ -47,12 +47,12 @@ func TestCreateReceiver(t *testing.T) {
 	cfg.GRPC.NetAddr.Endpoint = testutil.GetAvailableLocalAddress(t)
 	cfg.HTTP.Endpoint = testutil.GetAvailableLocalAddress(t)
 
-	creationParams := component.ReceiverCreateParams{Logger: zap.NewNop()}
-	tReceiver, err := factory.CreateTracesReceiver(context.Background(), creationParams, cfg, consumertest.NewNop())
+	creationSet := component.ReceiverCreateSettings{Logger: zap.NewNop()}
+	tReceiver, err := factory.CreateTracesReceiver(context.Background(), creationSet, cfg, consumertest.NewNop())
 	assert.NotNil(t, tReceiver)
 	assert.NoError(t, err)
 
-	mReceiver, err := factory.CreateMetricsReceiver(context.Background(), creationParams, cfg, consumertest.NewNop())
+	mReceiver, err := factory.CreateMetricsReceiver(context.Background(), creationSet, cfg, consumertest.NewNop())
 	assert.NotNil(t, mReceiver)
 	assert.NoError(t, err)
 }
@@ -115,11 +115,11 @@ func TestCreateTracesReceiver(t *testing.T) {
 		},
 	}
 	ctx := context.Background()
-	creationParams := component.ReceiverCreateParams{Logger: zap.NewNop()}
+	creationSet := component.ReceiverCreateSettings{Logger: zap.NewNop()}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			sink := new(consumertest.TracesSink)
-			tr, err := factory.CreateTracesReceiver(ctx, creationParams, tt.cfg, sink)
+			tr, err := factory.CreateTracesReceiver(ctx, creationSet, tt.cfg, sink)
 			assert.NoError(t, err)
 			require.NotNil(t, tr)
 			if tt.wantErr {
@@ -191,11 +191,11 @@ func TestCreateMetricReceiver(t *testing.T) {
 		},
 	}
 	ctx := context.Background()
-	creationParams := component.ReceiverCreateParams{Logger: zap.NewNop()}
+	creationSet := component.ReceiverCreateSettings{Logger: zap.NewNop()}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			sink := new(consumertest.MetricsSink)
-			mr, err := factory.CreateMetricsReceiver(ctx, creationParams, tt.cfg, sink)
+			mr, err := factory.CreateMetricsReceiver(ctx, creationSet, tt.cfg, sink)
 			assert.NoError(t, err)
 			require.NotNil(t, mr)
 			if tt.wantErr {
@@ -294,10 +294,10 @@ func TestCreateLogReceiver(t *testing.T) {
 		},
 	}
 	ctx := context.Background()
-	creationParams := component.ReceiverCreateParams{Logger: zap.NewNop()}
+	creationSet := component.ReceiverCreateSettings{Logger: zap.NewNop()}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mr, err := factory.CreateLogsReceiver(ctx, creationParams, tt.cfg, tt.sink)
+			mr, err := factory.CreateLogsReceiver(ctx, creationSet, tt.cfg, tt.sink)
 			if tt.wantErr {
 				assert.Error(t, err)
 				return

--- a/receiver/otlpreceiver/otlp_test.go
+++ b/receiver/otlpreceiver/otlp_test.go
@@ -656,7 +656,7 @@ func TestGRPCInvalidTLSCredentials(t *testing.T) {
 
 	r, err := NewFactory().CreateTracesReceiver(
 		context.Background(),
-		component.ReceiverCreateParams{Logger: zap.NewNop()},
+		component.ReceiverCreateSettings{Logger: zap.NewNop()},
 		cfg,
 		consumertest.NewNop())
 	require.NoError(t, err)
@@ -685,7 +685,7 @@ func TestHTTPInvalidTLSCredentials(t *testing.T) {
 	// TLS is resolved during Start for HTTP.
 	r, err := NewFactory().CreateTracesReceiver(
 		context.Background(),
-		component.ReceiverCreateParams{Logger: zap.NewNop()},
+		component.ReceiverCreateSettings{Logger: zap.NewNop()},
 		cfg,
 		consumertest.NewNop())
 	require.NoError(t, err)
@@ -713,15 +713,15 @@ func newHTTPReceiver(t *testing.T, endpoint string, tc consumer.Traces, mc consu
 }
 
 func newReceiver(t *testing.T, factory component.ReceiverFactory, cfg *Config, tc consumer.Traces, mc consumer.Metrics) component.Component {
-	params := component.ReceiverCreateParams{Logger: zap.NewNop()}
+	set := component.ReceiverCreateSettings{Logger: zap.NewNop()}
 	var r component.Component
 	var err error
 	if tc != nil {
-		r, err = factory.CreateTracesReceiver(context.Background(), params, cfg, tc)
+		r, err = factory.CreateTracesReceiver(context.Background(), set, cfg, tc)
 		require.NoError(t, err)
 	}
 	if mc != nil {
-		r, err = factory.CreateMetricsReceiver(context.Background(), params, cfg, mc)
+		r, err = factory.CreateMetricsReceiver(context.Background(), set, cfg, mc)
 		require.NoError(t, err)
 	}
 	return r
@@ -757,7 +757,7 @@ func TestShutdown(t *testing.T) {
 	cfg.HTTP.Endpoint = endpointHTTP
 	r, err := NewFactory().CreateTracesReceiver(
 		context.Background(),
-		component.ReceiverCreateParams{Logger: zap.NewNop()},
+		component.ReceiverCreateSettings{Logger: zap.NewNop()},
 		cfg,
 		nextSink)
 	require.NoError(t, err)

--- a/receiver/prometheusreceiver/factory.go
+++ b/receiver/prometheusreceiver/factory.go
@@ -52,9 +52,9 @@ func createDefaultConfig() config.Receiver {
 
 func createMetricsReceiver(
 	_ context.Context,
-	params component.ReceiverCreateParams,
+	set component.ReceiverCreateSettings,
 	cfg config.Receiver,
 	nextConsumer consumer.Metrics,
 ) (component.MetricsReceiver, error) {
-	return newPrometheusReceiver(params.Logger, cfg.(*Config), nextConsumer), nil
+	return newPrometheusReceiver(set.Logger, cfg.(*Config), nextConsumer), nil
 }

--- a/receiver/prometheusreceiver/factory_test.go
+++ b/receiver/prometheusreceiver/factory_test.go
@@ -39,8 +39,8 @@ func TestCreateReceiver(t *testing.T) {
 
 	// The default config does not provide scrape_config so we expect that metrics receiver
 	// creation must also fail.
-	creationParams := component.ReceiverCreateParams{Logger: zap.NewNop()}
-	mReceiver, _ := createMetricsReceiver(context.Background(), creationParams, cfg, nil)
+	creationSet := component.ReceiverCreateSettings{Logger: zap.NewNop()}
+	mReceiver, _ := createMetricsReceiver(context.Background(), creationSet, cfg, nil)
 	assert.NotNil(t, mReceiver)
 }
 

--- a/receiver/receiverhelper/factory.go
+++ b/receiver/receiverhelper/factory.go
@@ -51,13 +51,13 @@ func WithLogs(createLogsReceiver CreateLogsReceiver) FactoryOption {
 type CreateDefaultConfig func() config.Receiver
 
 // CreateTracesReceiver is the equivalent of component.ReceiverFactory.CreateTracesReceiver()
-type CreateTracesReceiver func(context.Context, component.ReceiverCreateParams, config.Receiver, consumer.Traces) (component.TracesReceiver, error)
+type CreateTracesReceiver func(context.Context, component.ReceiverCreateSettings, config.Receiver, consumer.Traces) (component.TracesReceiver, error)
 
 // CreateMetricsReceiver is the equivalent of component.ReceiverFactory.CreateMetricsReceiver()
-type CreateMetricsReceiver func(context.Context, component.ReceiverCreateParams, config.Receiver, consumer.Metrics) (component.MetricsReceiver, error)
+type CreateMetricsReceiver func(context.Context, component.ReceiverCreateSettings, config.Receiver, consumer.Metrics) (component.MetricsReceiver, error)
 
 // CreateLogsReceiver is the equivalent of component.ReceiverFactory.CreateLogsReceiver()
-type CreateLogsReceiver func(context.Context, component.ReceiverCreateParams, config.Receiver, consumer.Logs) (component.LogsReceiver, error)
+type CreateLogsReceiver func(context.Context, component.ReceiverCreateSettings, config.Receiver, consumer.Logs) (component.LogsReceiver, error)
 
 type factory struct {
 	cfgType               config.Type
@@ -95,11 +95,11 @@ func (f *factory) CreateDefaultConfig() config.Receiver {
 // CreateTracesReceiver creates a component.TracesReceiver based on this config.
 func (f *factory) CreateTracesReceiver(
 	ctx context.Context,
-	params component.ReceiverCreateParams,
+	set component.ReceiverCreateSettings,
 	cfg config.Receiver,
 	nextConsumer consumer.Traces) (component.TracesReceiver, error) {
 	if f.createTracesReceiver != nil {
-		return f.createTracesReceiver(ctx, params, cfg, nextConsumer)
+		return f.createTracesReceiver(ctx, set, cfg, nextConsumer)
 	}
 	return nil, componenterror.ErrDataTypeIsNotSupported
 }
@@ -107,11 +107,11 @@ func (f *factory) CreateTracesReceiver(
 // CreateMetricsReceiver creates a component.MetricsReceiver based on this config.
 func (f *factory) CreateMetricsReceiver(
 	ctx context.Context,
-	params component.ReceiverCreateParams,
+	set component.ReceiverCreateSettings,
 	cfg config.Receiver,
 	nextConsumer consumer.Metrics) (component.MetricsReceiver, error) {
 	if f.createMetricsReceiver != nil {
-		return f.createMetricsReceiver(ctx, params, cfg, nextConsumer)
+		return f.createMetricsReceiver(ctx, set, cfg, nextConsumer)
 	}
 	return nil, componenterror.ErrDataTypeIsNotSupported
 }
@@ -119,12 +119,12 @@ func (f *factory) CreateMetricsReceiver(
 // CreateLogsReceiver creates a metrics processor based on this config.
 func (f *factory) CreateLogsReceiver(
 	ctx context.Context,
-	params component.ReceiverCreateParams,
+	set component.ReceiverCreateSettings,
 	cfg config.Receiver,
 	nextConsumer consumer.Logs,
 ) (component.LogsReceiver, error) {
 	if f.createLogsReceiver != nil {
-		return f.createLogsReceiver(ctx, params, cfg, nextConsumer)
+		return f.createLogsReceiver(ctx, set, cfg, nextConsumer)
 	}
 	return nil, componenterror.ErrDataTypeIsNotSupported
 }

--- a/receiver/receiverhelper/factory_test.go
+++ b/receiver/receiverhelper/factory_test.go
@@ -35,11 +35,11 @@ func TestNewFactory(t *testing.T) {
 		defaultConfig)
 	assert.EqualValues(t, typeStr, factory.Type())
 	assert.EqualValues(t, &defaultCfg, factory.CreateDefaultConfig())
-	_, err := factory.CreateTracesReceiver(context.Background(), component.ReceiverCreateParams{}, factory.CreateDefaultConfig(), nil)
+	_, err := factory.CreateTracesReceiver(context.Background(), component.ReceiverCreateSettings{}, factory.CreateDefaultConfig(), nil)
 	assert.Error(t, err)
-	_, err = factory.CreateMetricsReceiver(context.Background(), component.ReceiverCreateParams{}, factory.CreateDefaultConfig(), nil)
+	_, err = factory.CreateMetricsReceiver(context.Background(), component.ReceiverCreateSettings{}, factory.CreateDefaultConfig(), nil)
 	assert.Error(t, err)
-	_, err = factory.CreateLogsReceiver(context.Background(), component.ReceiverCreateParams{}, factory.CreateDefaultConfig(), nil)
+	_, err = factory.CreateLogsReceiver(context.Background(), component.ReceiverCreateSettings{}, factory.CreateDefaultConfig(), nil)
 	assert.Error(t, err)
 }
 
@@ -53,13 +53,13 @@ func TestNewFactory_WithConstructors(t *testing.T) {
 	assert.EqualValues(t, typeStr, factory.Type())
 	assert.EqualValues(t, &defaultCfg, factory.CreateDefaultConfig())
 
-	_, err := factory.CreateTracesReceiver(context.Background(), component.ReceiverCreateParams{}, factory.CreateDefaultConfig(), nil)
+	_, err := factory.CreateTracesReceiver(context.Background(), component.ReceiverCreateSettings{}, factory.CreateDefaultConfig(), nil)
 	assert.NoError(t, err)
 
-	_, err = factory.CreateMetricsReceiver(context.Background(), component.ReceiverCreateParams{}, factory.CreateDefaultConfig(), nil)
+	_, err = factory.CreateMetricsReceiver(context.Background(), component.ReceiverCreateSettings{}, factory.CreateDefaultConfig(), nil)
 	assert.NoError(t, err)
 
-	_, err = factory.CreateLogsReceiver(context.Background(), component.ReceiverCreateParams{}, factory.CreateDefaultConfig(), nil)
+	_, err = factory.CreateLogsReceiver(context.Background(), component.ReceiverCreateSettings{}, factory.CreateDefaultConfig(), nil)
 	assert.NoError(t, err)
 }
 
@@ -67,14 +67,14 @@ func defaultConfig() config.Receiver {
 	return &defaultCfg
 }
 
-func createTracesReceiver(context.Context, component.ReceiverCreateParams, config.Receiver, consumer.Traces) (component.TracesReceiver, error) {
+func createTracesReceiver(context.Context, component.ReceiverCreateSettings, config.Receiver, consumer.Traces) (component.TracesReceiver, error) {
 	return nil, nil
 }
 
-func createMetricsReceiver(context.Context, component.ReceiverCreateParams, config.Receiver, consumer.Metrics) (component.MetricsReceiver, error) {
+func createMetricsReceiver(context.Context, component.ReceiverCreateSettings, config.Receiver, consumer.Metrics) (component.MetricsReceiver, error) {
 	return nil, nil
 }
 
-func createLogsReceiver(context.Context, component.ReceiverCreateParams, config.Receiver, consumer.Logs) (component.LogsReceiver, error) {
+func createLogsReceiver(context.Context, component.ReceiverCreateSettings, config.Receiver, consumer.Logs) (component.LogsReceiver, error) {
 	return nil, nil
 }

--- a/receiver/zipkinreceiver/factory.go
+++ b/receiver/zipkinreceiver/factory.go
@@ -55,7 +55,7 @@ func createDefaultConfig() config.Receiver {
 // createTracesReceiver creates a trace receiver based on provided config.
 func createTracesReceiver(
 	_ context.Context,
-	_ component.ReceiverCreateParams,
+	_ component.ReceiverCreateSettings,
 	cfg config.Receiver,
 	nextConsumer consumer.Traces,
 ) (component.TracesReceiver, error) {

--- a/receiver/zipkinreceiver/factory_test.go
+++ b/receiver/zipkinreceiver/factory_test.go
@@ -37,7 +37,7 @@ func TestCreateReceiver(t *testing.T) {
 
 	tReceiver, err := createTracesReceiver(
 		context.Background(),
-		component.ReceiverCreateParams{Logger: zap.NewNop()},
+		component.ReceiverCreateSettings{Logger: zap.NewNop()},
 		cfg,
 		consumertest.NewNop())
 	assert.NoError(t, err, "receiver creation failed")
@@ -45,7 +45,7 @@ func TestCreateReceiver(t *testing.T) {
 
 	tReceiver, err = createTracesReceiver(
 		context.Background(),
-		component.ReceiverCreateParams{Logger: zap.NewNop()},
+		component.ReceiverCreateSettings{Logger: zap.NewNop()},
 		cfg,
 		consumertest.NewNop())
 	assert.NoError(t, err, "receiver creation failed")

--- a/service/defaultcomponents/default_receivers_test.go
+++ b/service/defaultcomponents/default_receivers_test.go
@@ -105,7 +105,7 @@ type getReceiverConfigFn func() config.Receiver
 func verifyReceiverLifecycle(t *testing.T, factory component.ReceiverFactory, getConfigFn getReceiverConfigFn) {
 	ctx := context.Background()
 	host := newAssertNoErrorHost(t)
-	receiverCreateParams := component.ReceiverCreateParams{
+	receiverCreateSet := component.ReceiverCreateSettings{
 		Logger:    zap.NewNop(),
 		BuildInfo: component.DefaultBuildInfo(),
 	}
@@ -121,7 +121,7 @@ func verifyReceiverLifecycle(t *testing.T, factory component.ReceiverFactory, ge
 	}
 
 	for _, createFn := range createFns {
-		firstRcvr, err := createFn(ctx, receiverCreateParams, getConfigFn())
+		firstRcvr, err := createFn(ctx, receiverCreateSet, getConfigFn())
 		if errors.Is(err, componenterror.ErrDataTypeIsNotSupported) {
 			continue
 		}
@@ -129,7 +129,7 @@ func verifyReceiverLifecycle(t *testing.T, factory component.ReceiverFactory, ge
 		require.NoError(t, firstRcvr.Start(ctx, host))
 		require.NoError(t, firstRcvr.Shutdown(ctx))
 
-		secondRcvr, err := createFn(ctx, receiverCreateParams, getConfigFn())
+		secondRcvr, err := createFn(ctx, receiverCreateSet, getConfigFn())
 		require.NoError(t, err)
 		require.NoError(t, secondRcvr.Start(ctx, host))
 		require.NoError(t, secondRcvr.Shutdown(ctx))
@@ -139,24 +139,24 @@ func verifyReceiverLifecycle(t *testing.T, factory component.ReceiverFactory, ge
 // assertNoErrorHost implements a component.Host that asserts that there were no errors.
 type createReceiverFn func(
 	ctx context.Context,
-	params component.ReceiverCreateParams,
+	set component.ReceiverCreateSettings,
 	cfg config.Receiver,
 ) (component.Receiver, error)
 
 func wrapCreateLogsRcvr(factory component.ReceiverFactory) createReceiverFn {
-	return func(ctx context.Context, params component.ReceiverCreateParams, cfg config.Receiver) (component.Receiver, error) {
-		return factory.CreateLogsReceiver(ctx, params, cfg, consumertest.NewNop())
+	return func(ctx context.Context, set component.ReceiverCreateSettings, cfg config.Receiver) (component.Receiver, error) {
+		return factory.CreateLogsReceiver(ctx, set, cfg, consumertest.NewNop())
 	}
 }
 
 func wrapCreateMetricsRcvr(factory component.ReceiverFactory) createReceiverFn {
-	return func(ctx context.Context, params component.ReceiverCreateParams, cfg config.Receiver) (component.Receiver, error) {
-		return factory.CreateMetricsReceiver(ctx, params, cfg, consumertest.NewNop())
+	return func(ctx context.Context, set component.ReceiverCreateSettings, cfg config.Receiver) (component.Receiver, error) {
+		return factory.CreateMetricsReceiver(ctx, set, cfg, consumertest.NewNop())
 	}
 }
 
 func wrapCreateTracesRcvr(factory component.ReceiverFactory) createReceiverFn {
-	return func(ctx context.Context, params component.ReceiverCreateParams, cfg config.Receiver) (component.Receiver, error) {
-		return factory.CreateTracesReceiver(ctx, params, cfg, consumertest.NewNop())
+	return func(ctx context.Context, set component.ReceiverCreateSettings, cfg config.Receiver) (component.Receiver, error) {
+		return factory.CreateTracesReceiver(ctx, set, cfg, consumertest.NewNop())
 	}
 }

--- a/service/internal/builder/receivers_builder.go
+++ b/service/internal/builder/receivers_builder.go
@@ -173,7 +173,7 @@ func (rb *receiversBuilder) attachReceiverToPipelines(
 	// sure its output is fanned out to all attached pipelines.
 	var err error
 	var createdReceiver component.Receiver
-	creationParams := component.ReceiverCreateParams{
+	creationSet := component.ReceiverCreateSettings{
 		Logger:    logger,
 		BuildInfo: buildInfo,
 	}
@@ -181,15 +181,15 @@ func (rb *receiversBuilder) attachReceiverToPipelines(
 	switch dataType {
 	case config.TracesDataType:
 		junction := buildFanoutTraceConsumer(builtPipelines)
-		createdReceiver, err = factory.CreateTracesReceiver(ctx, creationParams, cfg, junction)
+		createdReceiver, err = factory.CreateTracesReceiver(ctx, creationSet, cfg, junction)
 
 	case config.MetricsDataType:
 		junction := buildFanoutMetricConsumer(builtPipelines)
-		createdReceiver, err = factory.CreateMetricsReceiver(ctx, creationParams, cfg, junction)
+		createdReceiver, err = factory.CreateMetricsReceiver(ctx, creationSet, cfg, junction)
 
 	case config.LogsDataType:
 		junction := buildFanoutLogConsumer(builtPipelines)
-		createdReceiver, err = factory.CreateLogsReceiver(ctx, creationParams, cfg, junction)
+		createdReceiver, err = factory.CreateLogsReceiver(ctx, creationSet, cfg, junction)
 
 	default:
 		err = componenterror.ErrDataTypeIsNotSupported

--- a/testbed/testbed/receivers.go
+++ b/testbed/testbed/receivers.go
@@ -101,11 +101,11 @@ func (or *OCDataReceiver) Start(tc consumer.Traces, mc consumer.Metrics, _ consu
 	cfg := factory.CreateDefaultConfig().(*opencensusreceiver.Config)
 	cfg.NetAddr = confignet.NetAddr{Endpoint: fmt.Sprintf("localhost:%d", or.Port), Transport: "tcp"}
 	var err error
-	params := component.ReceiverCreateParams{Logger: zap.NewNop()}
-	if or.traceReceiver, err = factory.CreateTracesReceiver(context.Background(), params, cfg, tc); err != nil {
+	set := component.ReceiverCreateSettings{Logger: zap.NewNop()}
+	if or.traceReceiver, err = factory.CreateTracesReceiver(context.Background(), set, cfg, tc); err != nil {
 		return err
 	}
-	if or.metricsReceiver, err = factory.CreateMetricsReceiver(context.Background(), params, cfg, mc); err != nil {
+	if or.metricsReceiver, err = factory.CreateMetricsReceiver(context.Background(), set, cfg, mc); err != nil {
 		return err
 	}
 	if err = or.traceReceiver.Start(context.Background(), or); err != nil {
@@ -154,8 +154,8 @@ func (jr *JaegerDataReceiver) Start(tc consumer.Traces, _ consumer.Metrics, _ co
 		NetAddr: confignet.NetAddr{Endpoint: fmt.Sprintf("localhost:%d", jr.Port), Transport: "tcp"},
 	}
 	var err error
-	params := component.ReceiverCreateParams{Logger: zap.NewNop()}
-	jr.receiver, err = factory.CreateTracesReceiver(context.Background(), params, cfg, tc)
+	set := component.ReceiverCreateSettings{Logger: zap.NewNop()}
+	jr.receiver, err = factory.CreateTracesReceiver(context.Background(), set, cfg, tc)
 	if err != nil {
 		return err
 	}
@@ -201,14 +201,14 @@ func (bor *BaseOTLPDataReceiver) Start(tc consumer.Traces, mc consumer.Metrics, 
 		cfg.GRPC = nil
 	}
 	var err error
-	params := component.ReceiverCreateParams{Logger: zap.NewNop()}
-	if bor.traceReceiver, err = factory.CreateTracesReceiver(context.Background(), params, cfg, tc); err != nil {
+	set := component.ReceiverCreateSettings{Logger: zap.NewNop()}
+	if bor.traceReceiver, err = factory.CreateTracesReceiver(context.Background(), set, cfg, tc); err != nil {
 		return err
 	}
-	if bor.metricsReceiver, err = factory.CreateMetricsReceiver(context.Background(), params, cfg, mc); err != nil {
+	if bor.metricsReceiver, err = factory.CreateMetricsReceiver(context.Background(), set, cfg, mc); err != nil {
 		return err
 	}
-	if bor.logReceiver, err = factory.CreateLogsReceiver(context.Background(), params, cfg, lc); err != nil {
+	if bor.logReceiver, err = factory.CreateLogsReceiver(context.Background(), set, cfg, lc); err != nil {
 		return err
 	}
 
@@ -296,9 +296,9 @@ func (zr *ZipkinDataReceiver) Start(tc consumer.Traces, _ consumer.Metrics, _ co
 	cfg := factory.CreateDefaultConfig().(*zipkinreceiver.Config)
 	cfg.Endpoint = fmt.Sprintf("localhost:%d", zr.Port)
 
-	params := component.ReceiverCreateParams{Logger: zap.NewNop()}
+	set := component.ReceiverCreateSettings{Logger: zap.NewNop()}
 	var err error
-	zr.receiver, err = factory.CreateTracesReceiver(context.Background(), params, cfg, tc)
+	zr.receiver, err = factory.CreateTracesReceiver(context.Background(), set, cfg, tc)
 
 	if err != nil {
 		return err
@@ -359,8 +359,8 @@ func (dr *PrometheusDataReceiver) Start(_ consumer.Traces, mc consumer.Metrics, 
 		}},
 	}
 	var err error
-	params := component.ReceiverCreateParams{Logger: zap.NewNop()}
-	dr.receiver, err = factory.CreateMetricsReceiver(context.Background(), params, cfg, mc)
+	set := component.ReceiverCreateSettings{Logger: zap.NewNop()}
+	dr.receiver, err = factory.CreateMetricsReceiver(context.Background(), set, cfg, mc)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**Description:** 
Continuation work from #2991
Fixes #2650
Replace ReceiverCreateParams with ReceiverCreateSettings.
Replace all dependencies in Receivers.

**Link to tracking Issue:** 
#2650 

**Testing:**
Unit tests

**Documentation:** 

