### PR TITLE
Mark internaldata traces translation as deprecated for external usage

### DIFF
--- a/translator/internaldata/oc_to_traces.go
+++ b/translator/internaldata/oc_to_traces.go
@@ -29,8 +29,9 @@ import (
 	tracetranslator "go.opentelemetry.io/collector/translator/trace"
 )
 
-// OCToTraces  may be used only by OpenCensus receiver and exporter implementations.
+// OCToTraces may be used only by OpenCensus receiver and exporter implementations.
 // Deprecated: use pdata.Traces instead.
+// TODO: move this function to OpenCensus package.
 func OCToTraces(node *occommon.Node, resource *ocresource.Resource, spans []*octrace.Span) pdata.Traces {
 	traceData := pdata.NewTraces()
 	if node == nil && resource == nil && len(spans) == 0 {


### PR DESCRIPTION
Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
