### PR TITLE
Switch to `revive` from `golint`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -69,7 +69,7 @@ linters-settings:
     disable:
       - fieldalignment
 
-  golint:
+  revive:
     # minimal confidence for issues, default is 0.8
     min-confidence: 0.8
 
@@ -103,10 +103,10 @@ linters:
     - gocritic
     - gofmt
     - goimports
-    - golint
     - gosec
     - govet
     - misspell
+    - revive
     - staticcheck
     - unconvert
     - unparam
@@ -133,11 +133,11 @@ issues:
     - path: ".*internal.*|.*testbed.*"
       text: "should have comment|should be of the form"
       linters:
-        - golint
+        - revive
     # Exclude documenting constant blocks.
     - text: "or a comment on this block"
       linters:
-        - golint
+        - revive
 
   # The list of ids of default excludes to include or disable. By default it's empty.
   # See the list of default excludes here https://golangci-lint.run/usage/configuration.

--- a/internal/processor/filterlog/filterlog.go
+++ b/internal/processor/filterlog/filterlog.go
@@ -54,7 +54,7 @@ func NewMatcher(mp *filterconfig.MatchProperties) (Matcher, error) {
 		return nil, err
 	}
 
-	var nameFS filterset.FilterSet = nil
+	var nameFS filterset.FilterSet
 	if len(mp.LogNames) > 0 {
 		nameFS, err = filterset.CreateFilterSet(mp.LogNames, &mp.Config)
 		if err != nil {

--- a/internal/processor/filterspan/filterspan.go
+++ b/internal/processor/filterspan/filterspan.go
@@ -58,7 +58,7 @@ func NewMatcher(mp *filterconfig.MatchProperties) (Matcher, error) {
 		return nil, err
 	}
 
-	var serviceFS filterset.FilterSet = nil
+	var serviceFS filterset.FilterSet
 	if len(mp.Services) > 0 {
 		serviceFS, err = filterset.CreateFilterSet(mp.Services, &mp.Config)
 		if err != nil {
@@ -66,7 +66,7 @@ func NewMatcher(mp *filterconfig.MatchProperties) (Matcher, error) {
 		}
 	}
 
-	var nameFS filterset.FilterSet = nil
+	var nameFS filterset.FilterSet
 	if len(mp.SpanNames) > 0 {
 		nameFS, err = filterset.CreateFilterSet(mp.SpanNames, &mp.Config)
 		if err != nil {

--- a/receiver/jaegerreceiver/trace_receiver.go
+++ b/receiver/jaegerreceiver/trace_receiver.go
@@ -184,11 +184,7 @@ func (jr *jReceiver) Start(_ context.Context, host component.Host) error {
 		return err
 	}
 
-	if err := jr.startCollector(host); err != nil {
-		return err
-	}
-
-	return nil
+	return jr.startCollector(host)
 }
 
 func (jr *jReceiver) Shutdown(ctx context.Context) error {

--- a/service/application.go
+++ b/service/application.go
@@ -115,11 +115,7 @@ func New(params Parameters) (*Application, error) {
 				return fmt.Errorf("failed to get logger: %w", err)
 			}
 
-			if err := app.execute(context.Background()); err != nil {
-				return err
-			}
-
-			return nil
+			return app.execute(context.Background())
 		},
 	}
 

--- a/testbed/testbed/receivers.go
+++ b/testbed/testbed/receivers.go
@@ -118,10 +118,7 @@ func (or *OCDataReceiver) Stop() error {
 	if err := or.traceReceiver.Shutdown(context.Background()); err != nil {
 		return err
 	}
-	if err := or.metricsReceiver.Shutdown(context.Background()); err != nil {
-		return err
-	}
-	return nil
+	return or.metricsReceiver.Shutdown(context.Background())
 }
 
 func (or *OCDataReceiver) GenConfigYAMLStr() string {


### PR DESCRIPTION
**Description:** 

Switch `golint` linter to `revive`. `golint` has been deprecated (see golang/go#38968). `golangci-lint` recommends `revive` as a replacement.

**Link to tracking Issue:** n/a
