### PR TITLE
Introduce a custom retrying mechanism for the PRW exporter

### DIFF
--- a/exporter/prometheusremotewriteexporter/README.md
+++ b/exporter/prometheusremotewriteexporter/README.md
@@ -39,6 +39,9 @@ The following settings can be optionally configured:
 - `remote_write_queue`: fine tuning for queueing and sending of the outgoing remote writes.
   - `queue_size`: number of OTLP metrics that can be queued.
   - `num_consumers`: minimum number of workers to use to fan out the outgoing requests.
+  - `min_backoff`: minimum time before a retry, e.g. "30ms". The backoff interval is doubled
+  for each failed requests up to max_backoff.
+  - `max_backoff` maximum time to wait before retrying, e.g. "100ms".
 
 Example:
 

--- a/exporter/prometheusremotewriteexporter/config.go
+++ b/exporter/prometheusremotewriteexporter/config.go
@@ -16,17 +16,22 @@ package prometheusremotewriteexporter
 
 import (
 	"fmt"
+	"time"
 
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 )
 
+const (
+	defaultRetryMinBackoff = 30 * time.Millisecond
+	defaultRetryMaxBackoff = 100 * time.Millisecond
+)
+
 // Config defines configuration for Remote Write exporter.
 type Config struct {
 	config.ExporterSettings        `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
 	exporterhelper.TimeoutSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct.
-	exporterhelper.RetrySettings   `mapstructure:"retry_on_failure"`
 
 	// prefix attached to each exported metric name
 	// See: https://prometheus.io/docs/practices/naming/#metric-names
@@ -56,6 +61,15 @@ type RemoteWriteQueue struct {
 	// NumWorkers configures the number of workers used by
 	// the collector to fan out remote write requests.
 	NumConsumers int `mapstructure:"num_consumers"`
+
+	// MinBackoff controls the minimum amount of time to wait before
+	// retrying a failed request. The backoff interval is doubled
+	// for each failed requests up to max_backoff.
+	MinBackoff time.Duration `mapstructure:"min_backoff"`
+
+	// MaxBackoff controls the maximum amount of time
+	// to wait before retrying a failed request.
+	MaxBackoff time.Duration `mapstructure:"max_backoff"`
 }
 
 // TODO(jbd): Add capacity, max_samples_per_send to QueueConfig.

--- a/exporter/prometheusremotewriteexporter/config_test.go
+++ b/exporter/prometheusremotewriteexporter/config_test.go
@@ -52,15 +52,11 @@ func Test_loadConfig(t *testing.T) {
 		&Config{
 			ExporterSettings: config.NewExporterSettings(config.NewIDWithName(typeStr, "2")),
 			TimeoutSettings:  exporterhelper.DefaultTimeoutSettings(),
-			RetrySettings: exporterhelper.RetrySettings{
-				Enabled:         true,
-				InitialInterval: 10 * time.Second,
-				MaxInterval:     1 * time.Minute,
-				MaxElapsedTime:  10 * time.Minute,
-			},
 			RemoteWriteQueue: RemoteWriteQueue{
 				QueueSize:    2000,
 				NumConsumers: 10,
+				MinBackoff:   30 * time.Millisecond,
+				MaxBackoff:   100 * time.Millisecond,
 			},
 			Namespace:      "test-space",
 			ExternalLabels: map[string]string{"key1": "value1", "key2": "value2"},

--- a/exporter/prometheusremotewriteexporter/factory.go
+++ b/exporter/prometheusremotewriteexporter/factory.go
@@ -51,10 +51,9 @@ func createMetricsExporter(_ context.Context, params component.ExporterCreatePar
 	}
 
 	prwe, err := NewPrwExporter(
-		prwCfg.Namespace,
+		prwCfg,
 		prwCfg.HTTPClientSettings.Endpoint,
-		client, prwCfg.ExternalLabels,
-		prwCfg.RemoteWriteQueue.NumConsumers,
+		client,
 		params.BuildInfo,
 	)
 	if err != nil {
@@ -77,7 +76,6 @@ func createMetricsExporter(_ context.Context, params component.ExporterCreatePar
 			NumConsumers: 1,
 			QueueSize:    prwCfg.RemoteWriteQueue.QueueSize,
 		}),
-		exporterhelper.WithRetry(prwCfg.RetrySettings),
 		exporterhelper.WithResourceToTelemetryConversion(prwCfg.ResourceToTelemetrySettings),
 		exporterhelper.WithShutdown(prwe.Shutdown),
 	)
@@ -89,7 +87,6 @@ func createDefaultConfig() config.Exporter {
 		Namespace:        "",
 		ExternalLabels:   map[string]string{},
 		TimeoutSettings:  exporterhelper.DefaultTimeoutSettings(),
-		RetrySettings:    exporterhelper.DefaultRetrySettings(),
 		HTTPClientSettings: confighttp.HTTPClientSettings{
 			Endpoint: "http://some.url:9411/api/prom/push",
 			// We almost read 0 bytes, so no need to tune ReadBufferSize.
@@ -102,6 +99,8 @@ func createDefaultConfig() config.Exporter {
 		RemoteWriteQueue: RemoteWriteQueue{
 			QueueSize:    10000,
 			NumConsumers: 5,
+			MinBackoff:   defaultRetryMinBackoff,
+			MaxBackoff:   defaultRetryMaxBackoff,
 		},
 	}
 }

--- a/exporter/prometheusremotewriteexporter/retry_test.go
+++ b/exporter/prometheusremotewriteexporter/retry_test.go
@@ -1,0 +1,53 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package prometheusremotewriteexporter
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"go.opentelemetry.io/collector/component"
+)
+
+func TestRetries(t *testing.T) {
+	var retries int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if retries == 3 {
+			w.WriteHeader(200)
+			return
+		}
+		w.WriteHeader(500) // retryable
+		retries++
+	}))
+	defer server.Close()
+
+	defaultConfig := createDefaultConfig().(*Config)
+	defaultConfig.RemoteWriteQueue.MinBackoff = 1 * time.Millisecond
+	defaultConfig.RemoteWriteQueue.MaxBackoff = 50 * time.Millisecond
+	buildInfo := component.BuildInfo{
+		Description: "OpenTelemetry Collector",
+		Version:     "1.0",
+	}
+	exporter, err := NewPrwExporter(defaultConfig, server.URL, http.DefaultClient, buildInfo)
+	assert.NoError(t, err)
+
+	req, _ := http.NewRequest("GET", server.URL, nil)
+	assert.NoError(t, exporter.makeReqWithRetries(req))
+	assert.Equal(t, retries, 3)
+}

--- a/exporter/prometheusremotewriteexporter/testdata/config.yaml
+++ b/exporter/prometheusremotewriteexporter/testdata/config.yaml
@@ -8,11 +8,6 @@ exporters:
     prometheusremotewrite:
     prometheusremotewrite/2:
         namespace: "test-space"
-        retry_on_failure:
-            enabled: true
-            initial_interval: 10s
-            max_interval: 60s
-            max_elapsed_time: 10m
         endpoint: "localhost:8888"
         ca_file: "/var/lib/mycert.pem"
         write_buffer_size: 524288


### PR DESCRIPTION
With the existing retry mechanism, we can see "out of the order" samples because a failed remote write with older samples can be retried after a successful remote write with relatively new samples. This change is removing the collector's retrying mechanism and replacing it with a custom retryer. min_backoff and max_backoff are similar to the settings available in the Prometheus server.

Fixes #3209.