### PR TITLE
Add initial implementation of pdatagrcp

### DIFF
--- a/exporter/otlpexporter/otlp.go
+++ b/exporter/otlpexporter/otlp.go
@@ -30,10 +30,7 @@ import (
 	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
-	"go.opentelemetry.io/collector/internal"
-	otlplogs "go.opentelemetry.io/collector/internal/data/protogen/collector/logs/v1"
-	otlpmetrics "go.opentelemetry.io/collector/internal/data/protogen/collector/metrics/v1"
-	otlptrace "go.opentelemetry.io/collector/internal/data/protogen/collector/trace/v1"
+	"go.opentelemetry.io/collector/internal/pdatagrpc"
 )
 
 type exporter struct {
@@ -66,23 +63,21 @@ func (e *exporter) shutdown(context.Context) error {
 }
 
 func (e *exporter) pushTraceData(ctx context.Context, td pdata.Traces) error {
-	if err := e.w.exportTrace(ctx, internal.TracesToOtlp(td.InternalRep())); err != nil {
+	if err := e.w.exportTrace(ctx, td); err != nil {
 		return fmt.Errorf("failed to push trace data via OTLP exporter: %w", err)
 	}
 	return nil
 }
 
 func (e *exporter) pushMetricsData(ctx context.Context, md pdata.Metrics) error {
-	req := internal.MetricsToOtlp(md.InternalRep())
-	if err := e.w.exportMetrics(ctx, req); err != nil {
+	if err := e.w.exportMetrics(ctx, md); err != nil {
 		return fmt.Errorf("failed to push metrics data via OTLP exporter: %w", err)
 	}
 	return nil
 }
 
 func (e *exporter) pushLogData(ctx context.Context, ld pdata.Logs) error {
-	request := internal.LogsToOtlp(ld.InternalRep())
-	if err := e.w.exportLogs(ctx, request); err != nil {
+	if err := e.w.exportLogs(ctx, ld); err != nil {
 		return fmt.Errorf("failed to push log data via OTLP exporter: %w", err)
 	}
 	return nil
@@ -90,9 +85,9 @@ func (e *exporter) pushLogData(ctx context.Context, ld pdata.Logs) error {
 
 type grpcSender struct {
 	// gRPC clients and connection.
-	traceExporter  otlptrace.TraceServiceClient
-	metricExporter otlpmetrics.MetricsServiceClient
-	logExporter    otlplogs.LogsServiceClient
+	traceExporter  pdatagrpc.TracesClient
+	metricExporter pdatagrpc.MetricsClient
+	logExporter    pdatagrpc.LogsClient
 	clientConn     *grpc.ClientConn
 	metadata       metadata.MD
 	callOptions    []grpc.CallOption
@@ -110,9 +105,9 @@ func newGrpcSender(config *Config) (*grpcSender, error) {
 	}
 
 	gs := &grpcSender{
-		traceExporter:  otlptrace.NewTraceServiceClient(clientConn),
-		metricExporter: otlpmetrics.NewMetricsServiceClient(clientConn),
-		logExporter:    otlplogs.NewLogsServiceClient(clientConn),
+		traceExporter:  pdatagrpc.NewTracesClient(clientConn),
+		metricExporter: pdatagrpc.NewMetricsClient(clientConn),
+		logExporter:    pdatagrpc.NewLogsClient(clientConn),
 		clientConn:     clientConn,
 		metadata:       metadata.New(config.GRPCClientSettings.Headers),
 		callOptions: []grpc.CallOption{
@@ -126,18 +121,18 @@ func (gs *grpcSender) stop() error {
 	return gs.clientConn.Close()
 }
 
-func (gs *grpcSender) exportTrace(ctx context.Context, request *otlptrace.ExportTraceServiceRequest) error {
-	_, err := gs.traceExporter.Export(gs.enhanceContext(ctx), request, gs.callOptions...)
+func (gs *grpcSender) exportTrace(ctx context.Context, td pdata.Traces) error {
+	_, err := gs.traceExporter.Export(gs.enhanceContext(ctx), td, gs.callOptions...)
 	return processError(err)
 }
 
-func (gs *grpcSender) exportMetrics(ctx context.Context, request *otlpmetrics.ExportMetricsServiceRequest) error {
-	_, err := gs.metricExporter.Export(gs.enhanceContext(ctx), request, gs.callOptions...)
+func (gs *grpcSender) exportMetrics(ctx context.Context, md pdata.Metrics) error {
+	_, err := gs.metricExporter.Export(gs.enhanceContext(ctx), md, gs.callOptions...)
 	return processError(err)
 }
 
-func (gs *grpcSender) exportLogs(ctx context.Context, request *otlplogs.ExportLogsServiceRequest) error {
-	_, err := gs.logExporter.Export(gs.enhanceContext(ctx), request, gs.callOptions...)
+func (gs *grpcSender) exportLogs(ctx context.Context, ld pdata.Logs) error {
+	_, err := gs.logExporter.Export(gs.enhanceContext(ctx), ld, gs.callOptions...)
 	return processError(err)
 }
 

--- a/internal/pdatagrpc/logs.go
+++ b/internal/pdatagrpc/logs.go
@@ -1,0 +1,74 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pdatagrpc
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+
+	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.opentelemetry.io/collector/internal"
+	otlpcollectorlogs "go.opentelemetry.io/collector/internal/data/protogen/collector/logs/v1"
+)
+
+// TODO: Consider to add `LogsRequest` and `LogsResponse`
+
+// LogsClient is the client API for OTLP-GRPC Logs service.
+//
+// For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
+type LogsClient interface {
+	// Export pdata.Logs to the server.
+	//
+	// For performance reasons, it is recommended to keep this RPC
+	// alive for the entire life of the application.
+	Export(ctx context.Context, in pdata.Logs, opts ...grpc.CallOption) (interface{}, error)
+}
+
+type logsClient struct {
+	rawClient otlpcollectorlogs.LogsServiceClient
+}
+
+// NewLogsClient returns a new LogsClient connected using the given connection.
+func NewLogsClient(cc *grpc.ClientConn) LogsClient {
+	return &logsClient{rawClient: otlpcollectorlogs.NewLogsServiceClient(cc)}
+}
+
+func (c *logsClient) Export(ctx context.Context, in pdata.Logs, opts ...grpc.CallOption) (interface{}, error) {
+	return c.rawClient.Export(ctx, internal.LogsToOtlp(in.InternalRep()), opts...)
+}
+
+// LogsServer is the server API for OTLP gRPC LogsService service.
+type LogsServer interface {
+	// Export is called every time a new request is received.
+	//
+	// For performance reasons, it is recommended to keep this RPC
+	// alive for the entire life of the application.
+	Export(context.Context, pdata.Logs) (interface{}, error)
+}
+
+// RegisterLogsServer registers the LogsServer to the grpc.Server.
+func RegisterLogsServer(s *grpc.Server, srv LogsServer) {
+	otlpcollectorlogs.RegisterLogsServiceServer(s, &rawLogsServer{srv: srv})
+}
+
+type rawLogsServer struct {
+	srv LogsServer
+}
+
+func (s rawLogsServer) Export(ctx context.Context, request *otlpcollectorlogs.ExportLogsServiceRequest) (*otlpcollectorlogs.ExportLogsServiceResponse, error) {
+	_, err := s.srv.Export(ctx, pdata.LogsFromInternalRep(internal.LogsFromOtlp(request)))
+	return &otlpcollectorlogs.ExportLogsServiceResponse{}, err
+}

--- a/internal/pdatagrpc/logs.go
+++ b/internal/pdatagrpc/logs.go
@@ -24,7 +24,9 @@ import (
 	otlpcollectorlogs "go.opentelemetry.io/collector/internal/data/protogen/collector/logs/v1"
 )
 
-// TODO: Consider to add `LogsRequest` and `LogsResponse`
+// TODO: Consider to add `LogsRequest` and `LogsResponse`. Right now the funcs return interface{},
+//  it would be better and future proof to create a LogsResponse empty struct and return that.
+//  So if we ever add things in the OTLP response I can deal with that. Similar for request if we add non pdata properties.
 
 // LogsClient is the client API for OTLP-GRPC Logs service.
 //

--- a/internal/pdatagrpc/metrics.go
+++ b/internal/pdatagrpc/metrics.go
@@ -24,7 +24,9 @@ import (
 	otlpcollectormetrics "go.opentelemetry.io/collector/internal/data/protogen/collector/metrics/v1"
 )
 
-// TODO: Consider to add `MetricsRequest` and `MetricsResponse`
+// TODO: Consider to add `MetricsRequest` and `MetricsResponse`. Right now the funcs return interface{},
+//  it would be better and future proof to create a MetricsResponse empty struct and return that.
+//  So if we ever add things in the OTLP response I can deal with that. Similar for request if we add non pdata properties.
 
 // MetricsClient is the client API for OTLP-GRPC Metrics service.
 //

--- a/internal/pdatagrpc/metrics.go
+++ b/internal/pdatagrpc/metrics.go
@@ -1,0 +1,74 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pdatagrpc
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+
+	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.opentelemetry.io/collector/internal"
+	otlpcollectormetrics "go.opentelemetry.io/collector/internal/data/protogen/collector/metrics/v1"
+)
+
+// TODO: Consider to add `MetricsRequest` and `MetricsResponse`
+
+// MetricsClient is the client API for OTLP-GRPC Metrics service.
+//
+// For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
+type MetricsClient interface {
+	// Export pdata.Metrics to the server.
+	//
+	// For performance reasons, it is recommended to keep this RPC
+	// alive for the entire life of the application.
+	Export(ctx context.Context, in pdata.Metrics, opts ...grpc.CallOption) (interface{}, error)
+}
+
+type metricsClient struct {
+	rawClient otlpcollectormetrics.MetricsServiceClient
+}
+
+// NewMetricsClient returns a new MetricsClient connected using the given connection.
+func NewMetricsClient(cc *grpc.ClientConn) MetricsClient {
+	return &metricsClient{rawClient: otlpcollectormetrics.NewMetricsServiceClient(cc)}
+}
+
+func (c *metricsClient) Export(ctx context.Context, in pdata.Metrics, opts ...grpc.CallOption) (interface{}, error) {
+	return c.rawClient.Export(ctx, internal.MetricsToOtlp(in.InternalRep()), opts...)
+}
+
+// MetricsServer is the server API for OTLP gRPC MetricsService service.
+type MetricsServer interface {
+	// Export is called every time a new request is received.
+	//
+	// For performance reasons, it is recommended to keep this RPC
+	// alive for the entire life of the application.
+	Export(context.Context, pdata.Metrics) (interface{}, error)
+}
+
+// RegisterMetricsServer registers the MetricsServer to the grpc.Server.
+func RegisterMetricsServer(s *grpc.Server, srv MetricsServer) {
+	otlpcollectormetrics.RegisterMetricsServiceServer(s, &rawMetricsServer{srv: srv})
+}
+
+type rawMetricsServer struct {
+	srv MetricsServer
+}
+
+func (s rawMetricsServer) Export(ctx context.Context, request *otlpcollectormetrics.ExportMetricsServiceRequest) (*otlpcollectormetrics.ExportMetricsServiceResponse, error) {
+	_, err := s.srv.Export(ctx, pdata.MetricsFromInternalRep(internal.MetricsFromOtlp(request)))
+	return &otlpcollectormetrics.ExportMetricsServiceResponse{}, err
+}

--- a/internal/pdatagrpc/traces.go
+++ b/internal/pdatagrpc/traces.go
@@ -24,7 +24,9 @@ import (
 	otlpcollectortraces "go.opentelemetry.io/collector/internal/data/protogen/collector/trace/v1"
 )
 
-// TODO: Consider to add `TracesRequest` and `TracesResponse`
+// TODO: Consider to add `TracesRequest` and `TracesResponse`. Right now the funcs return interface{},
+//  it would be better and future proof to create a TracesResponse empty struct and return that.
+//  So if we ever add things in the OTLP response I can deal with that. Similar for request if we add non pdata properties.
 
 // TracesClient is the client API for OTLP-GRPC Traces service.
 //

--- a/internal/pdatagrpc/traces.go
+++ b/internal/pdatagrpc/traces.go
@@ -1,0 +1,75 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pdatagrpc
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+
+	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.opentelemetry.io/collector/internal"
+	otlpcollectortraces "go.opentelemetry.io/collector/internal/data/protogen/collector/trace/v1"
+)
+
+// TODO: Consider to add `TracesRequest` and `TracesResponse`
+
+// TracesClient is the client API for OTLP-GRPC Traces service.
+//
+// For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
+type TracesClient interface {
+	// Export pdata.Traces to the server.
+	//
+	// For performance reasons, it is recommended to keep this RPC
+	// alive for the entire life of the application.
+	Export(ctx context.Context, in pdata.Traces, opts ...grpc.CallOption) (interface{}, error)
+}
+
+type tracesClient struct {
+	rawClient otlpcollectortraces.TraceServiceClient
+}
+
+// NewTracesClient returns a new TracesClient connected using the given connection.
+func NewTracesClient(cc *grpc.ClientConn) TracesClient {
+	return &tracesClient{rawClient: otlpcollectortraces.NewTraceServiceClient(cc)}
+}
+
+// Export implements the TracesClient interface.
+func (c *tracesClient) Export(ctx context.Context, in pdata.Traces, opts ...grpc.CallOption) (interface{}, error) {
+	return c.rawClient.Export(ctx, internal.TracesToOtlp(in.InternalRep()), opts...)
+}
+
+// TracesServer is the server API for OTLP gRPC TracesService service.
+type TracesServer interface {
+	// Export is called every time a new request is received.
+	//
+	// For performance reasons, it is recommended to keep this RPC
+	// alive for the entire life of the application.
+	Export(context.Context, pdata.Traces) (interface{}, error)
+}
+
+// RegisterTracesServer registers the TracesServer to the grpc.Server.
+func RegisterTracesServer(s *grpc.Server, srv TracesServer) {
+	otlpcollectortraces.RegisterTraceServiceServer(s, &rawTracesServer{srv: srv})
+}
+
+type rawTracesServer struct {
+	srv TracesServer
+}
+
+func (s rawTracesServer) Export(ctx context.Context, request *otlpcollectortraces.ExportTraceServiceRequest) (*otlpcollectortraces.ExportTraceServiceResponse, error) {
+	_, err := s.srv.Export(ctx, pdata.TracesFromInternalRep(internal.TracesFromOtlp(request)))
+	return &otlpcollectortraces.ExportTraceServiceResponse{}, err
+}


### PR DESCRIPTION
This is needed because if we split pdata, we will nolonger be able to depend on the InternalRep or generated proto classes (raw, grpc).

The pdatagrcp will eventually be public once we stabilize the API.

The API in the pdatagrcp package is inspired from the grpc generated classes and redirects all calls to the generated classes. Some simple renames:
* TraceService[Client|Server] -> Traces[Client|Server]
* MetricsService[Client|Server] -> Metrics[Client|Server]
* LogsService[Client|Server] -> Logs[Client|Server]

Other changes:
* Replace usages of grpc generated classes in otlpexporter to excercise this new package.
* Left some TODOs for the moment until this package is used more to determine the right API.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>

Updates https://github.com/open-telemetry/opentelemetry-collector/issues/3104