### PR TITLE
Add authentication data as part of the resource

### DIFF
--- a/auth/context.go
+++ b/auth/context.go
@@ -1,0 +1,65 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auth
+
+import "context"
+
+var (
+	rawKey     = rawType{}
+	subjectKey = subjectType{}
+	groupsKey  = groupsType{}
+)
+
+type rawType struct{}
+type subjectType struct{}
+type groupsType struct{}
+
+// NewContextFromRaw creates a new context derived from the given context,
+// adding the raw authentication string to the result.
+func NewContextFromRaw(ctx context.Context, raw string) context.Context {
+	return context.WithValue(ctx, rawKey, raw)
+}
+
+// NewContextFromSubject creates a new context derived from the given context,
+// adding the subject to the result.
+func NewContextFromSubject(ctx context.Context, subject string) context.Context {
+	return context.WithValue(ctx, subjectKey, subject)
+}
+
+// NewContextFromMemberships creates a new context derived from the given context,
+// adding the memberships to the result.
+func NewContextFromMemberships(ctx context.Context, groups []string) context.Context {
+	return context.WithValue(ctx, groupsKey, groups)
+}
+
+// RawFromContext returns the raw authentication string used to perform the authentication.
+// It's typically the string value for a single HTTP header, such as the "Authentication" header.
+// Example: "Basic ZGV2ZWxvcGVyOmN1cmlvdXM=".
+func RawFromContext(ctx context.Context) (string, bool) {
+	value, ok := ctx.Value(rawKey).(string)
+	return value, ok
+}
+
+// SubjectFromContext returns the subject that was extracted from the raw authentication string.
+func SubjectFromContext(ctx context.Context) (string, bool) {
+	value, ok := ctx.Value(subjectKey).(string)
+	return value, ok
+}
+
+// GroupsFromContext returns the list of groups the subject belongs.
+func GroupsFromContext(ctx context.Context) ([]string, bool) {
+	value, ok := ctx.Value(groupsKey).([]string)
+	return value, ok
+}

--- a/auth/resource.go
+++ b/auth/resource.go
@@ -1,0 +1,21 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auth
+
+const (
+	SubjectAttributeKey     = "__auth_subject"
+	RawAttributeKey         = "__auth_raw"
+	MembershipsAttributeKey = "__auth_memberships"
+)

--- a/config/configauth/mock_serverauth.go
+++ b/config/configauth/mock_serverauth.go
@@ -35,9 +35,9 @@ type MockAuthenticator struct {
 }
 
 // Authenticate executes the mock's AuthenticateFunc, if provided, or just returns the given context unchanged.
-func (m *MockAuthenticator) Authenticate(ctx context.Context, headers map[string][]string) error {
+func (m *MockAuthenticator) Authenticate(ctx context.Context, headers map[string][]string) (context.Context, error) {
 	if m.AuthenticateFunc == nil {
-		return nil
+		return context.Background(), nil
 	}
 	return m.AuthenticateFunc(ctx, headers)
 }

--- a/config/configauth/mock_serverauth_test.go
+++ b/config/configauth/mock_serverauth_test.go
@@ -25,16 +25,17 @@ func TestAuthenticateFunc(t *testing.T) {
 	// prepare
 	m := &MockAuthenticator{}
 	called := false
-	m.AuthenticateFunc = func(c context.Context, m map[string][]string) error {
+	m.AuthenticateFunc = func(c context.Context, m map[string][]string) (context.Context, error) {
 		called = true
-		return nil
+		return context.Background(), nil
 	}
 
 	// test
-	err := m.Authenticate(context.Background(), nil)
+	ctx, err := m.Authenticate(context.Background(), nil)
 
 	// verify
 	assert.NoError(t, err)
+	assert.NotNil(t, ctx)
 	assert.True(t, called)
 }
 
@@ -46,8 +47,9 @@ func TestNilOperations(t *testing.T) {
 	origCtx := context.Background()
 
 	{
-		err := m.Authenticate(origCtx, nil)
+		ctx, err := m.Authenticate(origCtx, nil)
 		assert.NoError(t, err)
+		assert.NotNil(t, ctx)
 	}
 
 	{

--- a/config/configauth/serverauth_test.go
+++ b/config/configauth/serverauth_test.go
@@ -28,9 +28,9 @@ func TestDefaultUnaryInterceptorAuthSucceeded(t *testing.T) {
 	// prepare
 	handlerCalled := false
 	authCalled := false
-	authFunc := func(context.Context, map[string][]string) error {
+	authFunc := func(context.Context, map[string][]string) (context.Context, error) {
 		authCalled = true
-		return nil
+		return context.Background(), nil
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		handlerCalled = true
@@ -52,9 +52,9 @@ func TestDefaultUnaryInterceptorAuthFailure(t *testing.T) {
 	// prepare
 	authCalled := false
 	expectedErr := fmt.Errorf("not authenticated")
-	authFunc := func(context.Context, map[string][]string) error {
+	authFunc := func(context.Context, map[string][]string) (context.Context, error) {
 		authCalled = true
-		return expectedErr
+		return context.Background(), expectedErr
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		assert.FailNow(t, "the handler should not have been called on auth failure!")
@@ -73,9 +73,9 @@ func TestDefaultUnaryInterceptorAuthFailure(t *testing.T) {
 
 func TestDefaultUnaryInterceptorMissingMetadata(t *testing.T) {
 	// prepare
-	authFunc := func(context.Context, map[string][]string) error {
+	authFunc := func(context.Context, map[string][]string) (context.Context, error) {
 		assert.FailNow(t, "the auth func should not have been called!")
-		return nil
+		return context.Background(), nil
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		assert.FailNow(t, "the handler should not have been called!")
@@ -94,9 +94,9 @@ func TestDefaultStreamInterceptorAuthSucceeded(t *testing.T) {
 	// prepare
 	handlerCalled := false
 	authCalled := false
-	authFunc := func(context.Context, map[string][]string) error {
+	authFunc := func(context.Context, map[string][]string) (context.Context, error) {
 		authCalled = true
-		return nil
+		return context.Background(), nil
 	}
 	handler := func(srv interface{}, stream grpc.ServerStream) error {
 		handlerCalled = true
@@ -120,9 +120,9 @@ func TestDefaultStreamInterceptorAuthFailure(t *testing.T) {
 	// prepare
 	authCalled := false
 	expectedErr := fmt.Errorf("not authenticated")
-	authFunc := func(context.Context, map[string][]string) error {
+	authFunc := func(context.Context, map[string][]string) (context.Context, error) {
 		authCalled = true
-		return expectedErr
+		return context.Background(), expectedErr
 	}
 	handler := func(srv interface{}, stream grpc.ServerStream) error {
 		assert.FailNow(t, "the handler should not have been called on auth failure!")
@@ -143,9 +143,9 @@ func TestDefaultStreamInterceptorAuthFailure(t *testing.T) {
 
 func TestDefaultStreamInterceptorMissingMetadata(t *testing.T) {
 	// prepare
-	authFunc := func(context.Context, map[string][]string) error {
+	authFunc := func(context.Context, map[string][]string) (context.Context, error) {
 		assert.FailNow(t, "the auth func should not have been called!")
-		return nil
+		return context.Background(), nil
 	}
 	handler := func(srv interface{}, stream grpc.ServerStream) error {
 		assert.FailNow(t, "the handler should not have been called!")

--- a/consumer/pdata/auth.go
+++ b/consumer/pdata/auth.go
@@ -1,0 +1,24 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pdata
+
+// Auth holds the authentication information stored by the authenticators used by the receivers.
+type Auth struct {
+	Raw     string
+	Subject string
+	Groups  []string
+}
+
+// TODO(jpkroehling): CopyTo, Clone, NewAuth, ...

--- a/consumer/pdata/log.go
+++ b/consumer/pdata/log.go
@@ -29,12 +29,29 @@ import (
 // Must use NewLogs functions to create new instances.
 // Important: zero-initialized instance is not valid for use.
 type Logs struct {
+	auth *Auth
 	orig *otlpcollectorlog.ExportLogsServiceRequest
 }
 
 // NewLogs creates a new Logs.
 func NewLogs() Logs {
 	return Logs{orig: &otlpcollectorlog.ExportLogsServiceRequest{}}
+}
+
+// NewLogsWithAuth creates a new Logs with the given Auth information.
+func NewLogsWithAuth(auth *Auth) Logs {
+	return Logs{
+		orig: &otlpcollectorlog.ExportLogsServiceRequest{},
+		auth: auth,
+	}
+}
+
+// LogsWithAuth creates a new Logs containing the given Auth information.
+func LogsWithAuth(logs Logs, auth *Auth) Logs {
+	return Logs{
+		orig: logs.orig,
+		auth: auth,
+	}
 }
 
 // LogsFromInternalRep creates the internal Logs representation from the ProtoBuf. Should
@@ -73,7 +90,7 @@ func (ld Logs) ToOtlpProtoBytes() ([]byte, error) {
 
 // Clone returns a copy of Logs.
 func (ld Logs) Clone() Logs {
-	cloneLd := NewLogs()
+	cloneLd := NewLogsWithAuth(ld.auth)
 	ld.ResourceLogs().CopyTo(cloneLd.ResourceLogs())
 	return cloneLd
 }
@@ -102,6 +119,11 @@ func (ld Logs) OtlpProtoSize() int {
 // ResourceLogs returns the ResourceLogsSlice associated with this Logs.
 func (ld Logs) ResourceLogs() ResourceLogsSlice {
 	return newResourceLogsSlice(&ld.orig.ResourceLogs)
+}
+
+// Auth returns a copy of the Auth stored as part of this Logs.
+func (ld Logs) Auth() *Auth {
+	return ld.auth
 }
 
 // SeverityNumber is the public alias of otlplogs.SeverityNumber from internal package.

--- a/consumer/pdata/metric.go
+++ b/consumer/pdata/metric.go
@@ -44,12 +44,29 @@ func (at AggregationTemporality) String() string {
 // Outside of the core repository the metrics pipeline cannot be converted to the new model since data.MetricData is
 // part of the internal package.
 type Metrics struct {
+	auth *Auth
 	orig *otlpcollectormetrics.ExportMetricsServiceRequest
 }
 
 // NewMetrics creates a new Metrics.
 func NewMetrics() Metrics {
 	return Metrics{orig: &otlpcollectormetrics.ExportMetricsServiceRequest{}}
+}
+
+// NewMetricsWithAuth creates a new Metrics with the given Auth information.
+func NewMetricsWithAuth(auth *Auth) Metrics {
+	return Metrics{
+		orig: &otlpcollectormetrics.ExportMetricsServiceRequest{},
+		auth: auth,
+	}
+}
+
+// MetricsWithAuth creates a new Metrics containing the given Auth information.
+func MetricsWithAuth(metrics Metrics, auth *Auth) Metrics {
+	return Metrics{
+		orig: metrics.orig,
+		auth: auth,
+	}
 }
 
 // MetricsFromInternalRep creates Metrics from the internal representation.
@@ -86,7 +103,7 @@ func (md Metrics) ToOtlpProtoBytes() ([]byte, error) {
 
 // Clone returns a copy of MetricData.
 func (md Metrics) Clone() Metrics {
-	cloneMd := NewMetrics()
+	cloneMd := NewMetricsWithAuth(md.auth)
 	md.ResourceMetrics().CopyTo(cloneMd.ResourceMetrics())
 	return cloneMd
 }
@@ -150,6 +167,11 @@ func (md Metrics) MetricAndDataPointCount() (metricCount int, dataPointCount int
 		}
 	}
 	return
+}
+
+// Auth returns a copy of the Auth stored as part of this Metrics.
+func (md Metrics) Auth() *Auth {
+	return md.auth
 }
 
 // MetricDataType specifies the type of data in a Metric.

--- a/consumer/pdata/trace.go
+++ b/consumer/pdata/trace.go
@@ -24,12 +24,29 @@ import (
 
 // Traces is the top-level struct that is propagated through the traces pipeline.
 type Traces struct {
+	auth *Auth
 	orig *otlpcollectortrace.ExportTraceServiceRequest
 }
 
 // NewTraces creates a new Traces.
 func NewTraces() Traces {
 	return Traces{orig: &otlpcollectortrace.ExportTraceServiceRequest{}}
+}
+
+// NewTracesWithAuth creates a new Traces with the given Auth information.
+func NewTracesWithAuth(auth *Auth) Traces {
+	return Traces{
+		orig: &otlpcollectortrace.ExportTraceServiceRequest{},
+		auth: auth,
+	}
+}
+
+// TracesWithAuth creates a new Traces containing the given Auth information.
+func TracesWithAuth(traces Traces, auth *Auth) Traces {
+	return Traces{
+		orig: traces.orig,
+		auth: auth,
+	}
 }
 
 // TracesFromInternalRep creates Traces from the internal representation.
@@ -67,7 +84,7 @@ func (td Traces) ToOtlpProtoBytes() ([]byte, error) {
 
 // Clone returns a copy of Traces.
 func (td Traces) Clone() Traces {
-	cloneTd := NewTraces()
+	cloneTd := NewTracesWithAuth(td.auth)
 	td.ResourceSpans().CopyTo(cloneTd.ResourceSpans())
 	return cloneTd
 }
@@ -92,9 +109,14 @@ func (td Traces) OtlpProtoSize() int {
 	return td.orig.Size()
 }
 
-// ResourceSpans returns the ResourceSpansSlice associated with this Metrics.
+// ResourceSpans returns the ResourceSpansSlice associated with this Traces.
 func (td Traces) ResourceSpans() ResourceSpansSlice {
 	return newResourceSpansSlice(&td.orig.ResourceSpans)
+}
+
+// Auth returns a copy of the Auth stored as part of this Traces.
+func (td Traces) Auth() *Auth {
+	return td.auth
 }
 
 // TraceState in w3c-trace-context format: https://www.w3.org/TR/trace-context/#tracestate-header

--- a/service/internal/builder/receivers_builder_test.go
+++ b/service/internal/builder/receivers_builder_test.go
@@ -383,22 +383,16 @@ func TestJunctionUsesContextToResourceConsumer(t *testing.T) {
 
 	{ // verify the traces part
 		c := exporter.getTracesExporter().(*testcomponents.ExampleExporterConsumer)
-		val, found := c.Traces[0].ResourceSpans().At(0).Resource().Attributes().Get("__auth_subject")
-		assert.True(t, found)
-		assert.Equal(t, "jdoe", val.StringVal())
+		assert.Equal(t, "jdoe", c.Traces[0].Auth().Subject)
 	}
 
 	{ // verify the metrics part
 		c := exporter.getMetricExporter().(*testcomponents.ExampleExporterConsumer)
-		val, found := c.Metrics[0].ResourceMetrics().At(0).Resource().Attributes().Get("__auth_subject")
-		assert.True(t, found)
-		assert.Equal(t, "jdoe", val.StringVal())
+		assert.Equal(t, "jdoe", c.Metrics[0].Auth().Subject)
 	}
 
 	{ // verify the logs part
 		c := exporter.getLogExporter().(*testcomponents.ExampleExporterConsumer)
-		val, found := c.Logs[0].ResourceLogs().At(0).Resource().Attributes().Get("__auth_subject")
-		assert.True(t, found)
-		assert.Equal(t, "jdoe", val.StringVal())
+		assert.Equal(t, "jdoe", c.Logs[0].Auth().Subject)
 	}
 }

--- a/service/internal/builder/testdata/junction.yaml
+++ b/service/internal/builder/testdata/junction.yaml
@@ -1,0 +1,21 @@
+receivers:
+  examplereceiver:
+
+processors:
+
+exporters:
+  exampleexporter:
+
+service:
+  pipelines:
+    traces:
+      receivers: [examplereceiver]
+      exporters: [exampleexporter]
+
+    metrics:
+      receivers: [examplereceiver]
+      exporters: [exampleexporter]
+
+    logs:
+      receivers: [examplereceiver]
+      exporters: [exampleexporter]

--- a/service/internal/contexttoresourceconsumer/consumer.go
+++ b/service/internal/contexttoresourceconsumer/consumer.go
@@ -1,0 +1,119 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package contexttoresourceconsumer contains implementations of Traces/Metrics/Logs consumers
+// placing important information stored from the context.Context into the each data point's
+// pdata.Resource attributes.
+package contexttoresourceconsumer
+
+import (
+	"context"
+	"strings"
+
+	"go.opentelemetry.io/collector/auth"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/consumer/consumerhelper"
+	"go.opentelemetry.io/collector/consumer/pdata"
+)
+
+type wrappedConsumer struct {
+	traces  consumer.Traces
+	metrics consumer.Metrics
+	logs    consumer.Logs
+}
+
+func NewTraces(toConsume consumer.Traces) (consumer.Traces, error) {
+	tc := &wrappedConsumer{
+		traces: toConsume,
+	}
+	return consumerhelper.NewTraces(
+		tc.consumeTraces,
+		consumerhelper.WithCapabilities(consumer.Capabilities{MutatesData: true}),
+	)
+}
+
+func NewMetrics(toConsume consumer.Metrics) (consumer.Metrics, error) {
+	tc := &wrappedConsumer{
+		metrics: toConsume,
+	}
+	return consumerhelper.NewMetrics(
+		tc.consumeMetrics,
+		consumerhelper.WithCapabilities(consumer.Capabilities{MutatesData: true}),
+	)
+}
+
+func NewLogs(toConsume consumer.Logs) (consumer.Logs, error) {
+	tc := &wrappedConsumer{
+		logs: toConsume,
+	}
+	return consumerhelper.NewLogs(
+		tc.consumeLogs,
+		consumerhelper.WithCapabilities(consumer.Capabilities{MutatesData: true}),
+	)
+}
+
+func (tc wrappedConsumer) consumeTraces(ctx context.Context, td pdata.Traces) error {
+	raw, subject, groups := extractFromContext(ctx)
+
+	for i := 0; i < td.ResourceSpans().Len(); i++ {
+		rs := td.ResourceSpans().At(i).Resource()
+		injectIntoResource(rs, raw, subject, groups)
+	}
+
+	return tc.traces.ConsumeTraces(ctx, td)
+}
+
+func (tc wrappedConsumer) consumeMetrics(ctx context.Context, md pdata.Metrics) error {
+	raw, subject, groups := extractFromContext(ctx)
+
+	for i := 0; i < md.ResourceMetrics().Len(); i++ {
+		rs := md.ResourceMetrics().At(i).Resource()
+		injectIntoResource(rs, raw, subject, groups)
+	}
+
+	return tc.metrics.ConsumeMetrics(ctx, md)
+}
+
+func (tc wrappedConsumer) consumeLogs(ctx context.Context, ld pdata.Logs) error {
+	raw, subject, groups := extractFromContext(ctx)
+
+	for i := 0; i < ld.ResourceLogs().Len(); i++ {
+		rs := ld.ResourceLogs().At(i).Resource()
+		injectIntoResource(rs, raw, subject, groups)
+	}
+
+	return tc.logs.ConsumeLogs(ctx, ld)
+}
+
+func extractFromContext(ctx context.Context) (raw, subject, groups string) {
+	raw, _ = auth.RawFromContext(ctx)
+	subject, _ = auth.SubjectFromContext(ctx)
+	groupsSlice, _ := auth.GroupsFromContext(ctx)
+	groups = strings.Join(groupsSlice, ",")
+	return
+}
+
+func injectIntoResource(rs pdata.Resource, raw, subject, groups string) {
+	if len(raw) > 0 {
+		rs.Attributes().UpsertString(auth.RawAttributeKey, raw)
+	}
+
+	if len(subject) > 0 {
+		rs.Attributes().UpsertString(auth.SubjectAttributeKey, subject)
+	}
+
+	if len(groups) > 0 {
+		rs.Attributes().UpsertString(auth.MembershipsAttributeKey, groups)
+	}
+}

--- a/service/internal/contexttoresourceconsumer/consumer_test.go
+++ b/service/internal/contexttoresourceconsumer/consumer_test.go
@@ -1,0 +1,177 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package contexttoresourceconsumer
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/auth"
+	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.opentelemetry.io/collector/internal/testdata"
+)
+
+var (
+	raw            = "jdoe:password"
+	sub            = "jdoe"
+	groups         = []string{"tenant1", "tenant2"}
+	expectedGroups = "tenant1,tenant2"
+)
+
+func TestTraces(t *testing.T) {
+	testCases := []struct {
+		desc string
+		td   pdata.Traces
+	}{
+		{
+			desc: "one-span",
+			td:   testdata.GenerateTracesOneSpan(),
+		},
+		{
+			desc: "one-empty-resource-span",
+			td:   testdata.GenerateTracesOneEmptyResourceSpans(),
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			// prepare
+			next := new(consumertest.TracesSink)
+			tc, err := NewTraces(next)
+			require.NoError(t, err)
+
+			ctx := prepareContext()
+
+			// test
+			tc.ConsumeTraces(ctx, tC.td)
+
+			// verify
+			for _, trace := range next.AllTraces() {
+				for i := 0; i < trace.ResourceSpans().Len(); i++ {
+					rs := trace.ResourceSpans().At(i).Resource()
+					assertValuesInResource(t, rs, raw, sub, expectedGroups)
+				}
+			}
+
+		})
+	}
+}
+
+func TestMetrics(t *testing.T) {
+	testCases := []struct {
+		desc string
+		td   pdata.Metrics
+	}{
+		{
+			desc: "one-metric",
+			td:   testdata.GenerateMetricsOneMetric(),
+		},
+		{
+			desc: "no-resource",
+			td:   testdata.GenerateMetricsOneMetricNoResource(),
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			next := new(consumertest.MetricsSink)
+			tc, err := NewMetrics(next)
+			require.NoError(t, err)
+
+			ctx := prepareContext()
+
+			// test
+			tc.ConsumeMetrics(ctx, tC.td)
+
+			// verify
+			for _, metric := range next.AllMetrics() {
+				for i := 0; i < metric.ResourceMetrics().Len(); i++ {
+					rs := metric.ResourceMetrics().At(i).Resource()
+					assertValuesInResource(t, rs, raw, sub, expectedGroups)
+				}
+			}
+		})
+	}
+}
+
+func TestLogs(t *testing.T) {
+	testCases := []struct {
+		desc string
+		td   pdata.Logs
+	}{
+		{
+			desc: "one-log",
+			td:   testdata.GenerateLogsOneLogRecord(),
+		},
+		{
+			desc: "no-logs",
+			td:   testdata.GenerateLogsNoLogRecords(),
+		},
+		{
+			desc: "no-resource",
+			td:   testdata.GenerateLogsOneLogRecordNoResource(),
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			// prepare
+			next := new(consumertest.LogsSink)
+			tc, err := NewLogs(next)
+			require.NoError(t, err)
+
+			ctx := prepareContext()
+
+			// test
+			tc.ConsumeLogs(ctx, tC.td)
+
+			// verify
+			for _, log := range next.AllLogs() {
+				for i := 0; i < log.ResourceLogs().Len(); i++ {
+					rs := log.ResourceLogs().At(i).Resource()
+					assertValuesInResource(t, rs, raw, sub, expectedGroups)
+				}
+			}
+		})
+	}
+}
+
+func assertValuesInResource(t *testing.T, rs pdata.Resource, raw, sub, groups string) {
+	{
+		v, exists := rs.Attributes().Get(auth.RawAttributeKey)
+		assert.True(t, exists)
+		assert.Equal(t, raw, v.StringVal())
+	}
+
+	{
+		v, exists := rs.Attributes().Get(auth.SubjectAttributeKey)
+		assert.True(t, exists)
+		assert.Equal(t, sub, v.StringVal())
+	}
+
+	{
+		v, exists := rs.Attributes().Get(auth.MembershipsAttributeKey)
+		assert.True(t, exists)
+		assert.Equal(t, groups, v.StringVal())
+	}
+}
+
+func prepareContext() context.Context {
+	ctx := context.Background()
+	ctx = auth.NewContextFromRaw(ctx, raw)
+	ctx = auth.NewContextFromSubject(ctx, sub)
+	ctx = auth.NewContextFromMemberships(ctx, groups)
+	return ctx
+}

--- a/service/internal/contexttoresourceconsumer/consumer_test.go
+++ b/service/internal/contexttoresourceconsumer/consumer_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.opentelemetry.io/collector/auth"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/consumer/pdata"


### PR DESCRIPTION
Closes #2733 by storing the authentication information in the context, and then by copying the context information into the pdata.Resource's contained in the batch, for all signals.

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>

