### PR TITLE
Improve test failure logging for TestBallastMemory

### DIFF
--- a/testbed/tests/e2e_test.go
+++ b/testbed/tests/e2e_test.go
@@ -18,7 +18,6 @@
 package tests
 
 import (
-	"fmt"
 	"strconv"
 	"testing"
 	"time"
@@ -85,7 +84,7 @@ func TestBallastMemory(t *testing.T) {
 			return vms > test.ballastSize
 		}, time.Second*2, "VMS must be greater than %d", test.ballastSize)
 
-		assert.True(t, rss <= test.maxRSS, fmt.Sprintf("RSS must be less than or equal to %d", test.maxRSS))
+		assert.LessOrEqual(t, rss, test.maxRSS)
 		tc.Stop()
 	}
 }


### PR DESCRIPTION
This change improves the failure message for the TestBallastMemory. While this won't solve the problem, it will help understand if we are barely above the limit, or if the test went considerably above the max.

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>
