### PR TITLE
High level encode/decode APIs

### DIFF
--- a/internal/model/decoder.go
+++ b/internal/model/decoder.go
@@ -1,0 +1,42 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"fmt"
+
+	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.opentelemetry.io/collector/internal/model/serializer"
+	"go.opentelemetry.io/collector/internal/model/translator"
+)
+
+// TracesDecoder decodes bytes into pdata.Traces.
+type TracesDecoder struct {
+	translate translator.TracesDecoder
+	serialize serializer.TracesUnmarshaler
+}
+
+// Decode bytes into pdata.Traces.
+func (t *TracesDecoder) Decode(buf []byte) (pdata.Traces, error) {
+	model, err := t.serialize.UnmarshalTraces(buf)
+	if err != nil {
+		return pdata.NewTraces(), fmt.Errorf("unmarshal failed: %w", err)
+	}
+	td, err := t.translate.ToTraces(model)
+	if err != nil {
+		return pdata.NewTraces(), fmt.Errorf("converting model to pdata failed: %w", err)
+	}
+	return td, nil
+}

--- a/internal/model/decoder.go
+++ b/internal/model/decoder.go
@@ -28,15 +28,15 @@ type TracesDecoder struct {
 	serialize serializer.TracesUnmarshaler
 }
 
-// Decode bytes into pdata.Traces.
+// Decode bytes into pdata.Traces. On error pdata.Traces is invalid.
 func (t *TracesDecoder) Decode(buf []byte) (pdata.Traces, error) {
 	model, err := t.serialize.UnmarshalTraces(buf)
 	if err != nil {
-		return pdata.NewTraces(), fmt.Errorf("unmarshal failed: %w", err)
+		return pdata.Traces{}, fmt.Errorf("unmarshal failed: %w", err)
 	}
-	td, err := t.translate.ToTraces(model)
+	td, err := t.translate.DecodeTraces(model)
 	if err != nil {
-		return pdata.NewTraces(), fmt.Errorf("converting model to pdata failed: %w", err)
+		return pdata.Traces{}, fmt.Errorf("converting model to pdata failed: %w", err)
 	}
 	return td, nil
 }

--- a/internal/model/decoder_test.go
+++ b/internal/model/decoder_test.go
@@ -1,0 +1,87 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"go.opentelemetry.io/collector/consumer/pdata"
+)
+
+func TestTracesDecoder_SerializeError(t *testing.T) {
+	translate := &mockTranslator{}
+	serialize := &mockSerializer{}
+
+	d := &TracesDecoder{
+		translate: translate,
+		serialize: serialize,
+	}
+
+	expectedBytes := []byte{1, 2, 3}
+	expectedModel := struct{}{}
+
+	serialize.On("UnmarshalTraces", expectedBytes).Return(expectedModel, errors.New("decode failed"))
+
+	_, err := d.Decode(expectedBytes)
+
+	assert.Error(t, err)
+	assert.EqualError(t, err, "unmarshal failed: decode failed")
+}
+
+func TestTracesDecoder_TranslationError(t *testing.T) {
+	translate := &mockTranslator{}
+	serialize := &mockSerializer{}
+
+	d := &TracesDecoder{
+		translate: translate,
+		serialize: serialize,
+	}
+
+	expectedBytes := []byte{1, 2, 3}
+	expectedModel := struct{}{}
+
+	serialize.On("UnmarshalTraces", expectedBytes).Return(expectedModel, nil)
+	translate.On("ToTraces", expectedModel).Return(pdata.NewTraces(), errors.New("translation failed"))
+
+	_, err := d.Decode(expectedBytes)
+
+	assert.Error(t, err)
+	assert.EqualError(t, err, "converting model to pdata failed: translation failed")
+}
+
+func TestTracesDecoder_Decode(t *testing.T) {
+	translate := &mockTranslator{}
+	serialize := &mockSerializer{}
+
+	d := &TracesDecoder{
+		translate: translate,
+		serialize: serialize,
+	}
+
+	expectedTraces := pdata.NewTraces()
+	expectedBytes := []byte{1, 2, 3}
+	expectedModel := struct{}{}
+
+	serialize.On("UnmarshalTraces", expectedBytes).Return(expectedModel, nil)
+	translate.On("ToTraces", expectedModel).Return(expectedTraces, nil)
+
+	actualTraces, err := d.Decode(expectedBytes)
+
+	assert.NoError(t, err)
+	assert.Equal(t, expectedTraces, actualTraces)
+}

--- a/internal/model/decoder_test.go
+++ b/internal/model/decoder_test.go
@@ -56,7 +56,7 @@ func TestTracesDecoder_TranslationError(t *testing.T) {
 	expectedModel := struct{}{}
 
 	serialize.On("UnmarshalTraces", expectedBytes).Return(expectedModel, nil)
-	translate.On("ToTraces", expectedModel).Return(pdata.NewTraces(), errors.New("translation failed"))
+	translate.On("DecodeTraces", expectedModel).Return(pdata.NewTraces(), errors.New("translation failed"))
 
 	_, err := d.Decode(expectedBytes)
 
@@ -78,7 +78,7 @@ func TestTracesDecoder_Decode(t *testing.T) {
 	expectedModel := struct{}{}
 
 	serialize.On("UnmarshalTraces", expectedBytes).Return(expectedModel, nil)
-	translate.On("ToTraces", expectedModel).Return(expectedTraces, nil)
+	translate.On("DecodeTraces", expectedModel).Return(expectedTraces, nil)
 
 	actualTraces, err := d.Decode(expectedBytes)
 

--- a/internal/model/encoder.go
+++ b/internal/model/encoder.go
@@ -1,0 +1,42 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"fmt"
+
+	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.opentelemetry.io/collector/internal/model/serializer"
+	"go.opentelemetry.io/collector/internal/model/translator"
+)
+
+// TracesEncoder encodes pdata.Traces into bytes.
+type TracesEncoder struct {
+	translate translator.TracesEncoder
+	serialize serializer.TracesMarshaler
+}
+
+// Encode pdata.Traces into bytes.
+func (t *TracesEncoder) Encode(td pdata.Traces) ([]byte, error) {
+	model, err := t.translate.FromTraces(td)
+	if err != nil {
+		return nil, fmt.Errorf("converting pdata to model failed: %w", err)
+	}
+	buf, err := t.serialize.MarshalTraces(model)
+	if err != nil {
+		return nil, fmt.Errorf("marshal failed: %w", err)
+	}
+	return buf, nil
+}

--- a/internal/model/encoder.go
+++ b/internal/model/encoder.go
@@ -28,9 +28,9 @@ type TracesEncoder struct {
 	serialize serializer.TracesMarshaler
 }
 
-// Encode pdata.Traces into bytes.
+// Encode pdata.Traces into bytes. On error []byte is nil.
 func (t *TracesEncoder) Encode(td pdata.Traces) ([]byte, error) {
-	model, err := t.translate.FromTraces(td)
+	model, err := t.translate.EncodeTraces(td)
 	if err != nil {
 		return nil, fmt.Errorf("converting pdata to model failed: %w", err)
 	}

--- a/internal/model/encoder_test.go
+++ b/internal/model/encoder_test.go
@@ -34,7 +34,7 @@ func TestTracesEncoder_TranslationError(t *testing.T) {
 
 	td := pdata.NewTraces()
 
-	translate.On("FromTraces", td).Return(nil, errors.New("translation failed"))
+	translate.On("EncodeTraces", td).Return(nil, errors.New("translation failed"))
 
 	_, err := d.Encode(td)
 
@@ -54,7 +54,7 @@ func TestTracesEncoder_SerializeError(t *testing.T) {
 	td := pdata.NewTraces()
 	expectedModel := struct{}{}
 
-	translate.On("FromTraces", td).Return(expectedModel, nil)
+	translate.On("EncodeTraces", td).Return(expectedModel, nil)
 	serialize.On("MarshalTraces", expectedModel).Return(nil, errors.New("serialization failed"))
 
 	_, err := d.Encode(td)
@@ -76,7 +76,7 @@ func TestTracesEncoder_Encode(t *testing.T) {
 	expectedBytes := []byte{1, 2, 3}
 	expectedModel := struct{}{}
 
-	translate.On("FromTraces", expectedTraces).Return(expectedModel, nil)
+	translate.On("EncodeTraces", expectedTraces).Return(expectedModel, nil)
 	serialize.On("MarshalTraces", expectedModel).Return(expectedBytes, nil)
 
 	actualBytes, err := d.Encode(expectedTraces)

--- a/internal/model/encoder_test.go
+++ b/internal/model/encoder_test.go
@@ -1,0 +1,86 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"go.opentelemetry.io/collector/consumer/pdata"
+)
+
+func TestTracesEncoder_TranslationError(t *testing.T) {
+	translate := &mockTranslator{}
+	serialize := &mockSerializer{}
+
+	d := &TracesEncoder{
+		translate: translate,
+		serialize: serialize,
+	}
+
+	td := pdata.NewTraces()
+
+	translate.On("FromTraces", td).Return(nil, errors.New("translation failed"))
+
+	_, err := d.Encode(td)
+
+	assert.Error(t, err)
+	assert.EqualError(t, err, "converting pdata to model failed: translation failed")
+}
+
+func TestTracesEncoder_SerializeError(t *testing.T) {
+	translate := &mockTranslator{}
+	serialize := &mockSerializer{}
+
+	d := &TracesEncoder{
+		translate: translate,
+		serialize: serialize,
+	}
+
+	td := pdata.NewTraces()
+	expectedModel := struct{}{}
+
+	translate.On("FromTraces", td).Return(expectedModel, nil)
+	serialize.On("MarshalTraces", expectedModel).Return(nil, errors.New("serialization failed"))
+
+	_, err := d.Encode(td)
+
+	assert.Error(t, err)
+	assert.EqualError(t, err, "marshal failed: serialization failed")
+}
+
+func TestTracesEncoder_Encode(t *testing.T) {
+	translate := &mockTranslator{}
+	serialize := &mockSerializer{}
+
+	d := &TracesEncoder{
+		translate: translate,
+		serialize: serialize,
+	}
+
+	expectedTraces := pdata.NewTraces()
+	expectedBytes := []byte{1, 2, 3}
+	expectedModel := struct{}{}
+
+	translate.On("FromTraces", expectedTraces).Return(expectedModel, nil)
+	serialize.On("MarshalTraces", expectedModel).Return(expectedBytes, nil)
+
+	actualBytes, err := d.Encode(expectedTraces)
+
+	assert.NoError(t, err)
+	assert.Equal(t, expectedBytes, actualBytes)
+}

--- a/internal/model/mocks_test.go
+++ b/internal/model/mocks_test.go
@@ -54,12 +54,12 @@ type mockTranslator struct {
 	mock.Mock
 }
 
-func (m *mockTranslator) ToTraces(src interface{}) (pdata.Traces, error) {
+func (m *mockTranslator) DecodeTraces(src interface{}) (pdata.Traces, error) {
 	args := m.Called(src)
 	return args.Get(0).(pdata.Traces), args.Error(1)
 }
 
-func (m *mockTranslator) FromTraces(md pdata.Traces) (interface{}, error) {
+func (m *mockTranslator) EncodeTraces(md pdata.Traces) (interface{}, error) {
 	args := m.Called(md)
 	return args.Get(0), args.Error(1)
 }

--- a/internal/model/mocks_test.go
+++ b/internal/model/mocks_test.go
@@ -1,0 +1,65 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"github.com/stretchr/testify/mock"
+
+	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.opentelemetry.io/collector/internal/model/serializer"
+	"go.opentelemetry.io/collector/internal/model/translator"
+)
+
+var (
+	_ serializer.TracesMarshaler   = (*mockSerializer)(nil)
+	_ serializer.TracesUnmarshaler = (*mockSerializer)(nil)
+)
+
+type mockSerializer struct {
+	mock.Mock
+}
+
+func (m *mockSerializer) MarshalTraces(model interface{}) ([]byte, error) {
+	args := m.Called(model)
+	err := args.Error(1)
+	if err != nil {
+		return nil, err
+	}
+	return args.Get(0).([]byte), err
+}
+
+func (m *mockSerializer) UnmarshalTraces(bytes []byte) (interface{}, error) {
+	args := m.Called(bytes)
+	return args.Get(0), args.Error(1)
+}
+
+var (
+	_ translator.TracesEncoder = (*mockTranslator)(nil)
+	_ translator.TracesDecoder = (*mockTranslator)(nil)
+)
+
+type mockTranslator struct {
+	mock.Mock
+}
+
+func (m *mockTranslator) ToTraces(src interface{}) (pdata.Traces, error) {
+	args := m.Called(src)
+	return args.Get(0).(pdata.Traces), args.Error(1)
+}
+
+func (m *mockTranslator) FromTraces(md pdata.Traces) (interface{}, error) {
+	args := m.Called(md)
+	return args.Get(0), args.Error(1)
+}


### PR DESCRIPTION
This provides the high level wrappers around encoding pdata to bytes and
decoding bytes to pdata.

Just adds pdata.Traces for now. Would like to find a way to do code generation
since they're virtually identical for each telemetry type.
