### PR TITLE
Added extension to support OAuth2 client credentials authentication on HTTP and gRPC exporters.

### DIFF
--- a/extension/oauth2authextension/README.md
+++ b/extension/oauth2authextension/README.md
@@ -1,0 +1,43 @@
+# Authenticator - OAuth2 Client Credentials
+
+This extension implements a `configauth.Authenticator`, to be used based exporter (HTTP and gRPC based)
+inside the `auth` settings. The authenticator type has to be set to `oauth2`.
+
+## Configuration
+
+```yaml
+extensions:
+  oauth2:
+    client_id: someclientid
+    client_secret: someclientsecret
+    token_url: https://someserver.com/oauth2/default/v1/token
+    scopes: ["api.metrics"]
+
+receivers:
+  hostmetrics:
+    scrapers:
+      memory:
+  otlp:
+    protocols:
+      grpc:
+
+exporters:
+  otlphttp/withauth:
+    endpoint: http://localhost:9000
+    auth:
+      authenticator: oauth2
+      
+  otlp/withauth:
+    endpoint: 0.0.0.0:5000
+    ca_file: /tmp/certs/ca.pem
+    auth:
+      authenticator: oauth2
+
+service:
+  extensions: [oauth2]
+  pipelines:
+    metrics:
+      receivers: [hostmetrics]
+      processors: []
+      exporters: [otlphttp/withauth, otlp/withauth]
+```

--- a/extension/oauth2authextension/README.md
+++ b/extension/oauth2authextension/README.md
@@ -1,7 +1,7 @@
 # Authenticator - OAuth2 Client Credentials
 
-This extension implements a `configauth.Authenticator`, to be used based exporter (HTTP and gRPC based)
-inside the `auth` settings. The authenticator type has to be set to `oauth2`.
+This extension implements a `configauth.Authenticator` and is to be used by HTTP and gRPC based exporters.
+The authenticator type has to be set to `oauth2`.
 
 ## Configuration
 

--- a/extension/oauth2authextension/README.md
+++ b/extension/oauth2authextension/README.md
@@ -1,6 +1,6 @@
 # Authenticator - OAuth2 Client Credentials
 
-This extension implements a `configauth.Authenticator` and is to be used by HTTP and gRPC based exporters.
+This extension implements a `configauth.ClientAuthenticator` and is to be used by HTTP and gRPC based exporters.
 The authenticator type has to be set to `oauth2`.
 
 ## Configuration

--- a/extension/oauth2authextension/README.md
+++ b/extension/oauth2authextension/README.md
@@ -7,7 +7,7 @@ The authenticator type has to be set to `oauth2`.
 
 ```yaml
 extensions:
-  oauth2:
+  oauth2clientcredentials:
     client_id: someclientid
     client_secret: someclientsecret
     token_url: https://someserver.com/oauth2/default/v1/token
@@ -25,7 +25,7 @@ exporters:
   otlphttp/withauth:
     endpoint: http://localhost:9000
     auth:
-      authenticator: oauth2
+      authenticator: oauth2clientcredentials
       
   otlp/withauth:
     endpoint: 0.0.0.0:5000

--- a/extension/oauth2authextension/config.go
+++ b/extension/oauth2authextension/config.go
@@ -1,0 +1,61 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oauth2authextension
+
+import (
+	"errors"
+
+	"go.opentelemetry.io/collector/config"
+)
+
+var (
+	errNoClientIDProvided     = errors.New("no ClientID provided in the OAuth2 exporter configuration")
+	errNoTokenURLProvided     = errors.New("no TokenURL provided in OAuth Client Credentials configuration")
+	errNoClientSecretProvided = errors.New("no ClientSecret provided in OAuth Client Credentials configuration")
+)
+
+// OAuth2ClientSettings stores the configuration for OAuth2 Client Credentials (2-legged OAuth2 flow) setup
+type OAuth2ClientSettings struct {
+	config.ExtensionSettings `mapstructure:",squash"`
+
+	// ClientID is the application's ID.
+	ClientID string `mapstructure:"client_id"`
+
+	// ClientSecret is the application's secret.
+	ClientSecret string `mapstructure:"client_secret"`
+
+	// TokenURL is the resource server's token endpoint
+	// URL. This is a constant specific to each server.
+	TokenURL string `mapstructure:"token_url"`
+
+	// Scope specifies optional requested permissions.
+	Scopes []string `mapstructure:"scopes,omitempty"`
+}
+
+var _ config.Extension = (*OAuth2ClientSettings)(nil)
+
+// Validate checks if the extension configuration is valid
+func (cfg *OAuth2ClientSettings) Validate() error {
+	if cfg.ClientID == "" {
+		return errNoClientIDProvided
+	}
+	if cfg.ClientSecret == "" {
+		return errNoClientSecretProvided
+	}
+	if cfg.TokenURL == "" {
+		return errNoTokenURLProvided
+	}
+	return nil
+}

--- a/extension/oauth2authextension/config.go
+++ b/extension/oauth2authextension/config.go
@@ -26,8 +26,8 @@ var (
 	errNoClientSecretProvided = errors.New("no ClientSecret provided in OAuth Client Credentials configuration")
 )
 
-// OAuth2ClientSettings stores the configuration for OAuth2 Client Credentials (2-legged OAuth2 flow) setup
-type OAuth2ClientSettings struct {
+// Config stores the configuration for OAuth2 Client Credentials (2-legged OAuth2 flow) setup
+type Config struct {
 	config.ExtensionSettings `mapstructure:",squash"`
 
 	// ClientID is the application's ID.
@@ -44,10 +44,10 @@ type OAuth2ClientSettings struct {
 	Scopes []string `mapstructure:"scopes,omitempty"`
 }
 
-var _ config.Extension = (*OAuth2ClientSettings)(nil)
+var _ config.Extension = (*Config)(nil)
 
 // Validate checks if the extension configuration is valid
-func (cfg *OAuth2ClientSettings) Validate() error {
+func (cfg *Config) Validate() error {
 	if cfg.ClientID == "" {
 		return errNoClientIDProvided
 	}

--- a/extension/oauth2authextension/config_test.go
+++ b/extension/oauth2authextension/config_test.go
@@ -38,7 +38,7 @@ func TestLoadConfig(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, cfg)
 
-	expected := factory.CreateDefaultConfig().(*OAuth2ClientSettings)
+	expected := factory.CreateDefaultConfig().(*Config)
 	expected.ClientSecret = "someclientsecret"
 	expected.ClientID = "someclientid"
 	expected.Scopes = []string{"api.metrics"}
@@ -46,7 +46,7 @@ func TestLoadConfig(t *testing.T) {
 
 	ext := cfg.Extensions[config.NewIDWithName(typeStr, "1")]
 	assert.Equal(t,
-		&OAuth2ClientSettings{
+		&Config{
 			ExtensionSettings: config.NewExtensionSettings(config.NewIDWithName(typeStr, "1")),
 			ClientSecret:      "someclientsecret",
 			ClientID:          "someclientid",

--- a/extension/oauth2authextension/config_test.go
+++ b/extension/oauth2authextension/config_test.go
@@ -1,0 +1,90 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oauth2authextension
+
+import (
+	"fmt"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/config/configtest"
+)
+
+func TestLoadConfig(t *testing.T) {
+	factories, err := componenttest.NopFactories()
+	assert.NoError(t, err)
+
+	factory := NewFactory()
+	factories.Extensions[typeStr] = factory
+	cfg, err := configtest.LoadConfigFile(t, path.Join(".", "testdata", "config.yaml"), factories)
+
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+
+	expected := factory.CreateDefaultConfig().(*OAuth2ClientSettings)
+	expected.ClientSecret = "someclientsecret"
+	expected.ClientID = "someclientid"
+	expected.Scopes = []string{"api.metrics"}
+	expected.TokenURL = "https://someserver.com/oauth2/default/v1/token"
+
+	ext := cfg.Extensions[config.NewIDWithName(typeStr, "1")]
+	assert.Equal(t,
+		&OAuth2ClientSettings{
+			ExtensionSettings: config.NewExtensionSettings(config.NewIDWithName(typeStr, "1")),
+			ClientSecret:      "someclientsecret",
+			ClientID:          "someclientid",
+			Scopes:            []string{"api.metrics"},
+			TokenURL:          "https://someserver.com/oauth2/default/v1/token",
+		},
+		ext)
+
+	assert.Equal(t, 1, len(cfg.Service.Extensions))
+	assert.Equal(t, config.NewIDWithName(typeStr, "1"), cfg.Service.Extensions[0])
+}
+
+func TestLoadConfigError(t *testing.T) {
+	factories, err := componenttest.NopFactories()
+	assert.NoError(t, err)
+
+	tests := []struct {
+		configFile  string
+		expectedErr error
+	}{
+		{
+			"config_missing_url",
+			errNoTokenURLProvided,
+		},
+		{
+			"config_missing_client_id",
+			errNoClientIDProvided,
+		},
+		{
+			"config_missing_client_secret",
+			errNoClientSecretProvided,
+		},
+	}
+	for _, tt := range tests {
+		factory := NewFactory()
+		factories.Extensions[typeStr] = factory
+		configFile := fmt.Sprintf("%s.yaml", tt.configFile)
+		_, ferr := configtest.LoadConfigFile(t, path.Join(".", "testdata", configFile), factories)
+		require.ErrorIs(t, ferr, tt.expectedErr)
+	}
+}

--- a/extension/oauth2authextension/extension.go
+++ b/extension/oauth2authextension/extension.go
@@ -28,20 +28,20 @@ import (
 	"go.opentelemetry.io/collector/config/configauth"
 )
 
-// OAuth2Authenticator provides implementation for providing client authentication using OAuth2 client credentials
+// ClientCredentialsAuthenticator provides implementation for providing client authentication using OAuth2 client credentials
 // workflow for both gRPC and HTTP clients.
-type OAuth2Authenticator struct {
+type ClientCredentialsAuthenticator struct {
 	clientCredentials *clientcredentials.Config
 	logger            *zap.Logger
 }
 
-// OAuth2Authenticator implements both HTTPClientAuth and GRPCClientAuth
+// ClientCredentialsAuthenticator implements both HTTPClientAuth and GRPCClientAuth
 var (
-	_ configauth.HTTPClientAuthenticator = (*OAuth2Authenticator)(nil)
-	_ configauth.GRPCClientAuthenticator = (*OAuth2Authenticator)(nil)
+	_ configauth.HTTPClientAuthenticator = (*ClientCredentialsAuthenticator)(nil)
+	_ configauth.GRPCClientAuthenticator = (*ClientCredentialsAuthenticator)(nil)
 )
 
-func newOAuth2Extension(cfg *OAuth2ClientSettings, logger *zap.Logger) (*OAuth2Authenticator, error) {
+func newOAuth2Extension(cfg *Config, logger *zap.Logger) (*ClientCredentialsAuthenticator, error) {
 	if cfg.ClientID == "" {
 		return nil, errNoClientIDProvided
 	}
@@ -51,7 +51,7 @@ func newOAuth2Extension(cfg *OAuth2ClientSettings, logger *zap.Logger) (*OAuth2A
 	if cfg.TokenURL == "" {
 		return nil, errNoTokenURLProvided
 	}
-	return &OAuth2Authenticator{
+	return &ClientCredentialsAuthenticator{
 		clientCredentials: &clientcredentials.Config{
 			ClientID:     cfg.ClientID,
 			ClientSecret: cfg.ClientSecret,
@@ -62,19 +62,19 @@ func newOAuth2Extension(cfg *OAuth2ClientSettings, logger *zap.Logger) (*OAuth2A
 	}, nil
 }
 
-// Start for OAuth2Authenticator extension does nothing
-func (o *OAuth2Authenticator) Start(_ context.Context, _ component.Host) error {
+// Start for ClientCredentialsAuthenticator extension does nothing
+func (o *ClientCredentialsAuthenticator) Start(_ context.Context, _ component.Host) error {
 	return nil
 }
 
-// Shutdown for OAuth2Authenticator extension does nothing
-func (o *OAuth2Authenticator) Shutdown(_ context.Context) error {
+// Shutdown for ClientCredentialsAuthenticator extension does nothing
+func (o *ClientCredentialsAuthenticator) Shutdown(_ context.Context) error {
 	return nil
 }
 
 // RoundTripper returns oauth2.Transport, an http.RoundTripper that performs "client-credential" OAuth flow and
 // also auto refreshes OAuth tokens as needed.
-func (o *OAuth2Authenticator) RoundTripper(base http.RoundTripper) (http.RoundTripper, error) {
+func (o *ClientCredentialsAuthenticator) RoundTripper(base http.RoundTripper) (http.RoundTripper, error) {
 	return &oauth2.Transport{
 		Source: o.clientCredentials.TokenSource(context.Background()),
 		Base:   base,
@@ -83,7 +83,7 @@ func (o *OAuth2Authenticator) RoundTripper(base http.RoundTripper) (http.RoundTr
 
 // PerRPCCredentials returns gRPC PerRPCCredentials that supports "client-credential" OAuth flow. The underneath
 // oauth2.clientcredentials.Config instance will manage tokens performing auto refresh as necessary.
-func (o *OAuth2Authenticator) PerRPCCredentials() (credentials.PerRPCCredentials, error) {
+func (o *ClientCredentialsAuthenticator) PerRPCCredentials() (credentials.PerRPCCredentials, error) {
 	return grpcOAuth.TokenSource{
 		TokenSource: o.clientCredentials.TokenSource(context.Background()),
 	}, nil

--- a/extension/oauth2authextension/extension.go
+++ b/extension/oauth2authextension/extension.go
@@ -1,0 +1,90 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oauth2authextension
+
+import (
+	"context"
+	"net/http"
+
+	"go.uber.org/zap"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/clientcredentials"
+	"google.golang.org/grpc/credentials"
+	grpcOAuth "google.golang.org/grpc/credentials/oauth"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config/configauth"
+)
+
+// OAuth2Authenticator provides implementation for providing client authentication using OAuth2 client credentials
+// workflow for both gRPC and HTTP clients.
+type OAuth2Authenticator struct {
+	clientCredentials *clientcredentials.Config
+	logger            *zap.Logger
+}
+
+// OAuth2Authenticator implements both HTTPClientAuth and GRPCClientAuth
+var (
+	_ configauth.HTTPClientAuthenticator = (*OAuth2Authenticator)(nil)
+	_ configauth.GRPCClientAuthenticator = (*OAuth2Authenticator)(nil)
+)
+
+func newOAuth2Extension(cfg *OAuth2ClientSettings, logger *zap.Logger) (*OAuth2Authenticator, error) {
+	if cfg.ClientID == "" {
+		return nil, errNoClientIDProvided
+	}
+	if cfg.ClientSecret == "" {
+		return nil, errNoClientSecretProvided
+	}
+	if cfg.TokenURL == "" {
+		return nil, errNoTokenURLProvided
+	}
+	return &OAuth2Authenticator{
+		clientCredentials: &clientcredentials.Config{
+			ClientID:     cfg.ClientID,
+			ClientSecret: cfg.ClientSecret,
+			TokenURL:     cfg.TokenURL,
+			Scopes:       cfg.Scopes,
+		},
+		logger: logger,
+	}, nil
+}
+
+// Start for OAuth2Authenticator extension does nothing
+func (o *OAuth2Authenticator) Start(_ context.Context, _ component.Host) error {
+	return nil
+}
+
+// Shutdown for OAuth2Authenticator extension does nothing
+func (o *OAuth2Authenticator) Shutdown(_ context.Context) error {
+	return nil
+}
+
+// RoundTripper returns oauth2.Transport, an http.RoundTripper that performs "client-credential" OAuth flow and
+// also auto refreshes OAuth tokens as needed.
+func (o *OAuth2Authenticator) RoundTripper(base http.RoundTripper) (http.RoundTripper, error) {
+	return &oauth2.Transport{
+		Source: o.clientCredentials.TokenSource(context.Background()),
+		Base:   base,
+	}, nil
+}
+
+// PerRPCCredentials returns gRPC PerRPCCredentials that supports "client-credential" OAuth flow. The underneath
+// oauth2.clientcredentials.Config instance will manage tokens performing auto refresh as necessary.
+func (o *OAuth2Authenticator) PerRPCCredentials() (credentials.PerRPCCredentials, error) {
+	return grpcOAuth.TokenSource{
+		TokenSource: o.clientCredentials.TokenSource(context.Background()),
+	}, nil
+}

--- a/extension/oauth2authextension/extension_test.go
+++ b/extension/oauth2authextension/extension_test.go
@@ -1,0 +1,226 @@
+// Copyright  The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oauth2authextension
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+	"golang.org/x/oauth2"
+	grpcOAuth "google.golang.org/grpc/credentials/oauth"
+)
+
+func TestOAuthClientSettings(t *testing.T) {
+	tests := []struct {
+		name          string
+		settings      *OAuth2ClientSettings
+		shouldError   bool
+		expectedError error
+	}{
+		{
+			name: "all_valid_settings",
+			settings: &OAuth2ClientSettings{
+				ClientID:     "testclientid",
+				ClientSecret: "testsecret",
+				TokenURL:     "https://example.com/v1/token",
+				Scopes:       []string{"resource.read"},
+			},
+			shouldError:   false,
+			expectedError: nil,
+		},
+		{
+			name: "missing_client_id",
+			settings: &OAuth2ClientSettings{
+				ClientSecret: "testsecret",
+				TokenURL:     "https://example.com/v1/token",
+				Scopes:       []string{"resource.read"},
+			},
+			shouldError:   true,
+			expectedError: errNoClientIDProvided,
+		},
+		{
+			name: "missing_client_secret",
+			settings: &OAuth2ClientSettings{
+				ClientID: "testclientid",
+				TokenURL: "https://example.com/v1/token",
+				Scopes:   []string{"resource.read"},
+			},
+			shouldError:   true,
+			expectedError: errNoClientSecretProvided,
+		},
+		{
+			name: "missing_token_url",
+			settings: &OAuth2ClientSettings{
+				ClientID:     "testclientid",
+				ClientSecret: "testsecret",
+				Scopes:       []string{"resource.read"},
+			},
+			shouldError:   true,
+			expectedError: errNoTokenURLProvided,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			rc, err := newOAuth2Extension(test.settings, zap.NewNop())
+			if test.shouldError {
+				assert.Error(t, err)
+				assert.Equal(t, test.expectedError, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, test.settings.Scopes, rc.clientCredentials.Scopes)
+			assert.Equal(t, test.settings.TokenURL, rc.clientCredentials.TokenURL)
+			assert.Equal(t, test.settings.ClientSecret, rc.clientCredentials.ClientSecret)
+			assert.Equal(t, test.settings.ClientID, rc.clientCredentials.ClientID)
+		})
+	}
+}
+
+type testRoundTripper struct {
+	testString string
+}
+
+func (b *testRoundTripper) RoundTrip(_ *http.Request) (*http.Response, error) {
+	return nil, nil
+}
+
+func TestRoundTripper(t *testing.T) {
+	tests := []struct {
+		name        string
+		settings    *OAuth2ClientSettings
+		shouldError bool
+	}{
+		{
+			name: "returns_http_round_tripper",
+			settings: &OAuth2ClientSettings{
+				ClientID:     "testclientid",
+				ClientSecret: "testsecret",
+				TokenURL:     "https://example.com/v1/token",
+				Scopes:       []string{"resource.read"},
+			},
+			shouldError: false,
+		},
+		{
+			name: "invalid_client_settings_should_error",
+			settings: &OAuth2ClientSettings{
+				ClientID: "testclientid",
+				TokenURL: "https://example.com/v1/token",
+				Scopes:   []string{"resource.read"},
+			},
+			shouldError: true,
+		},
+	}
+
+	testString := "TestString"
+	baseRoundTripper := &testRoundTripper{testString}
+
+	for _, testcase := range tests {
+		t.Run(testcase.name, func(t *testing.T) {
+			oauth2Authenticator, err := newOAuth2Extension(testcase.settings, zap.NewNop())
+			if testcase.shouldError {
+				assert.Error(t, err)
+				assert.Nil(t, oauth2Authenticator)
+				return
+			}
+
+			assert.NotNil(t, oauth2Authenticator)
+			roundTripper, err := oauth2Authenticator.RoundTripper(baseRoundTripper)
+			assert.Nil(t, err)
+
+			// test roundTripper is an OAuth RoundTripper
+			oAuth2Transport, ok := roundTripper.(*oauth2.Transport)
+			assert.True(t, ok)
+
+			// test oAuthRoundTripper wrapped the base roundTripper properly
+			wrappedRoundTripper, ok := oAuth2Transport.Base.(*testRoundTripper)
+			assert.True(t, ok)
+			assert.Equal(t, wrappedRoundTripper.testString, testString)
+		})
+	}
+}
+
+func TestOAuth2PerRPCCredentials(t *testing.T) {
+	tests := []struct {
+		name        string
+		settings    *OAuth2ClientSettings
+		shouldError bool
+		expectedErr error
+	}{
+		{
+			name: "returns_http_round_tripper",
+			settings: &OAuth2ClientSettings{
+				ClientID:     "testclientid",
+				ClientSecret: "testsecret",
+				TokenURL:     "https://example.com/v1/token",
+				Scopes:       []string{"resource.read"},
+			},
+			shouldError: false,
+		},
+		{
+			name: "invalid_client_settings_should_error",
+			settings: &OAuth2ClientSettings{
+				ClientID: "testclientid",
+				TokenURL: "https://example.com/v1/token",
+				Scopes:   []string{"resource.read"},
+			},
+			shouldError: true,
+		},
+	}
+
+	for _, testcase := range tests {
+		t.Run(testcase.name, func(t *testing.T) {
+			oauth2Authenticator, err := newOAuth2Extension(testcase.settings, zap.NewNop())
+			if testcase.shouldError {
+				assert.Error(t, err)
+				assert.Nil(t, oauth2Authenticator)
+				return
+			}
+			assert.NoError(t, err)
+			perRPCCredentials, err := oauth2Authenticator.PerRPCCredentials()
+			assert.Nil(t, err)
+			// test perRPCCredentials is an grpc OAuthTokenSource
+			_, ok := perRPCCredentials.(grpcOAuth.TokenSource)
+			assert.True(t, ok)
+		})
+	}
+}
+
+func TestOAuthExtensionStart(t *testing.T) {
+	oAuthExtensionAuth, err := newOAuth2Extension(
+		&OAuth2ClientSettings{
+			ClientID:     "testclientid",
+			ClientSecret: "testsecret",
+			TokenURL:     "https://example.com/v1/token",
+			Scopes:       []string{"resource.read"},
+		}, nil)
+	assert.Nil(t, err)
+	assert.Nil(t, oAuthExtensionAuth.Start(context.Background(), nil))
+}
+
+func TestOAuthExtensionShutdown(t *testing.T) {
+	oAuthExtensionAuth, err := newOAuth2Extension(
+		&OAuth2ClientSettings{
+			ClientID:     "testclientid",
+			ClientSecret: "testsecret",
+			TokenURL:     "https://example.com/v1/token",
+			Scopes:       []string{"resource.read"},
+		}, nil)
+	assert.Nil(t, err)
+	assert.Nil(t, oAuthExtensionAuth.Shutdown(context.Background()))
+}

--- a/extension/oauth2authextension/extension_test.go
+++ b/extension/oauth2authextension/extension_test.go
@@ -28,13 +28,13 @@ import (
 func TestOAuthClientSettings(t *testing.T) {
 	tests := []struct {
 		name          string
-		settings      *OAuth2ClientSettings
+		settings      *Config
 		shouldError   bool
 		expectedError error
 	}{
 		{
 			name: "all_valid_settings",
-			settings: &OAuth2ClientSettings{
+			settings: &Config{
 				ClientID:     "testclientid",
 				ClientSecret: "testsecret",
 				TokenURL:     "https://example.com/v1/token",
@@ -45,7 +45,7 @@ func TestOAuthClientSettings(t *testing.T) {
 		},
 		{
 			name: "missing_client_id",
-			settings: &OAuth2ClientSettings{
+			settings: &Config{
 				ClientSecret: "testsecret",
 				TokenURL:     "https://example.com/v1/token",
 				Scopes:       []string{"resource.read"},
@@ -55,7 +55,7 @@ func TestOAuthClientSettings(t *testing.T) {
 		},
 		{
 			name: "missing_client_secret",
-			settings: &OAuth2ClientSettings{
+			settings: &Config{
 				ClientID: "testclientid",
 				TokenURL: "https://example.com/v1/token",
 				Scopes:   []string{"resource.read"},
@@ -65,7 +65,7 @@ func TestOAuthClientSettings(t *testing.T) {
 		},
 		{
 			name: "missing_token_url",
-			settings: &OAuth2ClientSettings{
+			settings: &Config{
 				ClientID:     "testclientid",
 				ClientSecret: "testsecret",
 				Scopes:       []string{"resource.read"},
@@ -103,12 +103,12 @@ func (b *testRoundTripper) RoundTrip(_ *http.Request) (*http.Response, error) {
 func TestRoundTripper(t *testing.T) {
 	tests := []struct {
 		name        string
-		settings    *OAuth2ClientSettings
+		settings    *Config
 		shouldError bool
 	}{
 		{
 			name: "returns_http_round_tripper",
-			settings: &OAuth2ClientSettings{
+			settings: &Config{
 				ClientID:     "testclientid",
 				ClientSecret: "testsecret",
 				TokenURL:     "https://example.com/v1/token",
@@ -118,7 +118,7 @@ func TestRoundTripper(t *testing.T) {
 		},
 		{
 			name: "invalid_client_settings_should_error",
-			settings: &OAuth2ClientSettings{
+			settings: &Config{
 				ClientID: "testclientid",
 				TokenURL: "https://example.com/v1/token",
 				Scopes:   []string{"resource.read"},
@@ -158,13 +158,13 @@ func TestRoundTripper(t *testing.T) {
 func TestOAuth2PerRPCCredentials(t *testing.T) {
 	tests := []struct {
 		name        string
-		settings    *OAuth2ClientSettings
+		settings    *Config
 		shouldError bool
 		expectedErr error
 	}{
 		{
 			name: "returns_http_round_tripper",
-			settings: &OAuth2ClientSettings{
+			settings: &Config{
 				ClientID:     "testclientid",
 				ClientSecret: "testsecret",
 				TokenURL:     "https://example.com/v1/token",
@@ -174,7 +174,7 @@ func TestOAuth2PerRPCCredentials(t *testing.T) {
 		},
 		{
 			name: "invalid_client_settings_should_error",
-			settings: &OAuth2ClientSettings{
+			settings: &Config{
 				ClientID: "testclientid",
 				TokenURL: "https://example.com/v1/token",
 				Scopes:   []string{"resource.read"},
@@ -203,7 +203,7 @@ func TestOAuth2PerRPCCredentials(t *testing.T) {
 
 func TestOAuthExtensionStart(t *testing.T) {
 	oAuthExtensionAuth, err := newOAuth2Extension(
-		&OAuth2ClientSettings{
+		&Config{
 			ClientID:     "testclientid",
 			ClientSecret: "testsecret",
 			TokenURL:     "https://example.com/v1/token",
@@ -215,7 +215,7 @@ func TestOAuthExtensionStart(t *testing.T) {
 
 func TestOAuthExtensionShutdown(t *testing.T) {
 	oAuthExtensionAuth, err := newOAuth2Extension(
-		&OAuth2ClientSettings{
+		&Config{
 			ClientID:     "testclientid",
 			ClientSecret: "testsecret",
 			TokenURL:     "https://example.com/v1/token",

--- a/extension/oauth2authextension/factory.go
+++ b/extension/oauth2authextension/factory.go
@@ -24,7 +24,7 @@ import (
 
 const (
 	// The value of extension "type" in configuration.
-	typeStr = "oauth2"
+	typeStr = "oauth2clientcredentials"
 )
 
 // NewFactory creates a factory for the OIDC Authenticator extension.
@@ -36,11 +36,11 @@ func NewFactory() component.ExtensionFactory {
 }
 
 func createDefaultConfig() config.Extension {
-	return &OAuth2ClientSettings{
+	return &Config{
 		ExtensionSettings: config.NewExtensionSettings(config.NewID(typeStr)),
 	}
 }
 
 func createExtension(_ context.Context, params component.ExtensionCreateParams, cfg config.Extension) (component.Extension, error) {
-	return newOAuth2Extension(cfg.(*OAuth2ClientSettings), params.Logger)
+	return newOAuth2Extension(cfg.(*Config), params.Logger)
 }

--- a/extension/oauth2authextension/factory.go
+++ b/extension/oauth2authextension/factory.go
@@ -1,0 +1,46 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oauth2authextension
+
+import (
+	"context"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/extension/extensionhelper"
+)
+
+const (
+	// The value of extension "type" in configuration.
+	typeStr = "oauth2"
+)
+
+// NewFactory creates a factory for the OIDC Authenticator extension.
+func NewFactory() component.ExtensionFactory {
+	return extensionhelper.NewFactory(
+		typeStr,
+		createDefaultConfig,
+		createExtension)
+}
+
+func createDefaultConfig() config.Extension {
+	return &OAuth2ClientSettings{
+		ExtensionSettings: config.NewExtensionSettings(config.NewID(typeStr)),
+	}
+}
+
+func createExtension(_ context.Context, params component.ExtensionCreateParams, cfg config.Extension) (component.Extension, error) {
+	return newOAuth2Extension(cfg.(*OAuth2ClientSettings), params.Logger)
+}

--- a/extension/oauth2authextension/factory_test.go
+++ b/extension/oauth2authextension/factory_test.go
@@ -28,7 +28,7 @@ import (
 
 func TestCreateDefaultConfig(t *testing.T) {
 	// prepare and test
-	expected := &OAuth2ClientSettings{
+	expected := &Config{
 		ExtensionSettings: config.NewExtensionSettings(config.NewID(typeStr)),
 	}
 
@@ -41,17 +41,17 @@ func TestCreateDefaultConfig(t *testing.T) {
 }
 
 func TestCreateExtension(t *testing.T) {
-	cfg := createDefaultConfig().(*OAuth2ClientSettings)
+	cfg := createDefaultConfig().(*Config)
 
 	tests := []struct {
 		name        string
-		settings    *OAuth2ClientSettings
+		settings    *Config
 		shouldError bool
 		expectedErr error
 	}{
 		{
 			name: "valid_settings",
-			settings: &OAuth2ClientSettings{
+			settings: &Config{
 				ClientID:     "testclientid",
 				ClientSecret: "testsecret",
 				TokenURL:     "https://example.com/v1/token",
@@ -61,7 +61,7 @@ func TestCreateExtension(t *testing.T) {
 		},
 		{
 			name: "invalid_client_settings_should_error",
-			settings: &OAuth2ClientSettings{
+			settings: &Config{
 				ClientID: "testclientid",
 				TokenURL: "https://example.com/v1/token",
 				Scopes:   []string{"resource.read"},

--- a/extension/oauth2authextension/factory_test.go
+++ b/extension/oauth2authextension/factory_test.go
@@ -1,0 +1,94 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oauth2authextension
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/config/configcheck"
+)
+
+func TestCreateDefaultConfig(t *testing.T) {
+	// prepare and test
+	expected := &OAuth2ClientSettings{
+		ExtensionSettings: config.NewExtensionSettings(config.NewID(typeStr)),
+	}
+
+	// test
+	cfg := createDefaultConfig()
+
+	// verify
+	assert.Equal(t, expected, cfg)
+	assert.NoError(t, configcheck.ValidateConfig(cfg))
+}
+
+func TestCreateExtension(t *testing.T) {
+	cfg := createDefaultConfig().(*OAuth2ClientSettings)
+
+	tests := []struct {
+		name        string
+		settings    *OAuth2ClientSettings
+		shouldError bool
+		expectedErr error
+	}{
+		{
+			name: "valid_settings",
+			settings: &OAuth2ClientSettings{
+				ClientID:     "testclientid",
+				ClientSecret: "testsecret",
+				TokenURL:     "https://example.com/v1/token",
+				Scopes:       []string{"resource.read"},
+			},
+			shouldError: false,
+		},
+		{
+			name: "invalid_client_settings_should_error",
+			settings: &OAuth2ClientSettings{
+				ClientID: "testclientid",
+				TokenURL: "https://example.com/v1/token",
+				Scopes:   []string{"resource.read"},
+			},
+			shouldError: true,
+		},
+	}
+
+	for _, testcase := range tests {
+		t.Run(testcase.name, func(t *testing.T) {
+			cfg.ClientID = testcase.settings.ClientID
+			cfg.ClientSecret = testcase.settings.ClientSecret
+			cfg.TokenURL = testcase.settings.TokenURL
+			cfg.Scopes = testcase.settings.Scopes
+			ext, err := createExtension(context.Background(), component.ExtensionCreateParams{Logger: zap.NewNop()}, cfg)
+			if testcase.shouldError {
+				assert.Error(t, err)
+				assert.Nil(t, ext)
+			} else {
+				assert.Nil(t, err)
+				assert.NotNil(t, ext)
+			}
+		})
+	}
+}
+
+func TestNewFactory(t *testing.T) {
+	f := NewFactory()
+	assert.NotNil(t, f)
+}

--- a/extension/oauth2authextension/testdata/config.yaml
+++ b/extension/oauth2authextension/testdata/config.yaml
@@ -1,0 +1,22 @@
+extensions:
+  oauth2/1:
+    client_id: someclientid
+    client_secret: someclientsecret
+    token_url: https://someserver.com/oauth2/default/v1/token
+    scopes: ["api.metrics"]
+
+# Data pipeline is required to load the config.
+receivers:
+  nop:
+processors:
+  nop:
+exporters:
+  nop:
+
+service:
+  extensions: [oauth2/1]
+  pipelines:
+    traces:
+      receivers: [nop]
+      processors: [nop]
+      exporters: [nop]

--- a/extension/oauth2authextension/testdata/config_missing_client_id.yaml
+++ b/extension/oauth2authextension/testdata/config_missing_client_id.yaml
@@ -1,0 +1,21 @@
+extensions:
+  oauth2/missingid:
+    client_secret: someclientsecret
+    token_url: https://someserver.com/oauth2/default/v1/token
+    scopes: ["api.metrics"]
+
+# Data pipeline is required to load the config.
+receivers:
+  nop:
+processors:
+  nop:
+exporters:
+  nop:
+
+service:
+  extensions: [oauth2/missingid]
+  pipelines:
+    traces:
+      receivers: [nop]
+      processors: [nop]
+      exporters: [nop]

--- a/extension/oauth2authextension/testdata/config_missing_client_secret.yaml
+++ b/extension/oauth2authextension/testdata/config_missing_client_secret.yaml
@@ -1,0 +1,21 @@
+extensions:
+  oauth2/missingseceret:
+    client_id: someclientid
+    token_url: https://someserver.com/oauth2/default/v1/token
+    scopes: ["api.metrics"]
+
+# Data pipeline is required to load the config.
+receivers:
+  nop:
+processors:
+  nop:
+exporters:
+  nop:
+
+service:
+  extensions: [oauth2/missingseceret]
+  pipelines:
+    traces:
+      receivers: [nop]
+      processors: [nop]
+      exporters: [nop]

--- a/extension/oauth2authextension/testdata/config_missing_url.yaml
+++ b/extension/oauth2authextension/testdata/config_missing_url.yaml
@@ -1,0 +1,21 @@
+extensions:
+  oauth2/missingurl:
+    client_id: someclientid
+    client_secret: someclientsecret
+    scopes: ["api.metrics"]
+
+# Data pipeline is required to load the config.
+receivers:
+  nop:
+processors:
+  nop:
+exporters:
+  nop:
+
+service:
+  extensions: [oauth2/missingurl]
+  pipelines:
+    traces:
+      receivers: [nop]
+      processors: [nop]
+      exporters: [nop]

--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	go.opencensus.io v0.23.0
 	go.uber.org/atomic v1.7.0
 	go.uber.org/zap v1.16.0
+	golang.org/x/oauth2 v0.0.0-20210323180902-22b0adad7558
 	golang.org/x/sys v0.0.0-20210423082822-04245dca01da
 	golang.org/x/text v0.3.6
 	google.golang.org/genproto v0.0.0-20210312152112-fc591d9ea70f

--- a/service/defaultcomponents/default_extensions_test.go
+++ b/service/defaultcomponents/default_extensions_test.go
@@ -27,6 +27,7 @@ import (
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/extension/bearertokenauthextension"
 	"go.opentelemetry.io/collector/extension/healthcheckextension"
+	"go.opentelemetry.io/collector/extension/oauth2authextension"
 	"go.opentelemetry.io/collector/extension/pprofextension"
 	"go.opentelemetry.io/collector/extension/zpagesextension"
 	"go.opentelemetry.io/collector/testutil"
@@ -72,6 +73,17 @@ func TestDefaultExtensions(t *testing.T) {
 			getConfigFn: func() config.Extension {
 				cfg := extFactories["bearertokenauth"].CreateDefaultConfig().(*bearertokenauthextension.Config)
 				cfg.BearerToken = "dummysecret"
+				return cfg
+			},
+		},
+		{
+			extension: "oauth2",
+			getConfigFn: func() config.Extension {
+				cfg := extFactories["oauth2"].CreateDefaultConfig().(*oauth2authextension.OAuth2ClientSettings)
+				cfg.ClientSecret = "dummysecret"
+				cfg.ClientID = "dummyid"
+				cfg.Scopes = []string{"scope.dummy"}
+				cfg.TokenURL = "https://some.url/default/oauth/token"
 				return cfg
 			},
 		},

--- a/service/defaultcomponents/default_extensions_test.go
+++ b/service/defaultcomponents/default_extensions_test.go
@@ -79,7 +79,7 @@ func TestDefaultExtensions(t *testing.T) {
 		{
 			extension: "oauth2",
 			getConfigFn: func() config.Extension {
-				cfg := extFactories["oauth2"].CreateDefaultConfig().(*oauth2authextension.OAuth2ClientSettings)
+				cfg := extFactories["oauth2"].CreateDefaultConfig().(*oauth2authextension.Config)
 				cfg.ClientSecret = "dummysecret"
 				cfg.ClientID = "dummyid"
 				cfg.Scopes = []string{"scope.dummy"}

--- a/service/defaultcomponents/defaults.go
+++ b/service/defaultcomponents/defaults.go
@@ -31,6 +31,7 @@ import (
 	"go.opentelemetry.io/collector/extension/authoidcextension"
 	"go.opentelemetry.io/collector/extension/bearertokenauthextension"
 	"go.opentelemetry.io/collector/extension/healthcheckextension"
+	"go.opentelemetry.io/collector/extension/oauth2authextension"
 	"go.opentelemetry.io/collector/extension/pprofextension"
 	"go.opentelemetry.io/collector/extension/zpagesextension"
 	"go.opentelemetry.io/collector/processor/attributesprocessor"
@@ -61,6 +62,7 @@ func Components() (
 		authoidcextension.NewFactory(),
 		bearertokenauthextension.NewFactory(),
 		healthcheckextension.NewFactory(),
+		oauth2authextension.NewFactory(),
 		pprofextension.NewFactory(),
 		zpagesextension.NewFactory(),
 	)


### PR DESCRIPTION
**Description:**
Adding a feature - Added an extension to support OAuth2 client credential based authentication for HTTP and gRPC clients

**Link to tracking Issue:** #2785  #2500 

**Testing:** 
- Unit Tests 
- Manual testing by verifying the token is getting automatically refreshed after expiry time in HTTP and gRPC OTLP exporters

**Documentation:** Added README.md
