### PR TITLE
Rename OIDC auth extension

### DIFF
--- a/extension/oidcauthextension/README.md
+++ b/extension/oidcauthextension/README.md
@@ -7,17 +7,16 @@ This extension implements a `configauth.Authenticator`, to be used in receivers 
 ```yaml
 extensions:
   oidc:
-    issuer_url: https://tenant1.example.com/
+    issuer_url: http://localhost:8080/auth/realms/opentelemetry
     issuer_ca_path: /etc/pki/tls/cert.pem
-    client_id: my-oidc-client
+    audience: account
     username_claim: email
 
 receivers:
   otlp:
     protocols:
       grpc:
-        authentication:
-          attribute: authorization
+        auth:
           authenticator: oidc
 
 processors:

--- a/extension/oidcauthextension/config.go
+++ b/extension/oidcauthextension/config.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package authoidcextension
+package oidcauthextension
 
 import "go.opentelemetry.io/collector/config"
 

--- a/extension/oidcauthextension/extension.go
+++ b/extension/oidcauthextension/extension.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package authoidcextension
+package oidcauthextension
 
 import (
 	"context"

--- a/extension/oidcauthextension/extension_test.go
+++ b/extension/oidcauthextension/extension_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package authoidcextension
+package oidcauthextension
 
 import (
 	"context"

--- a/extension/oidcauthextension/factory.go
+++ b/extension/oidcauthextension/factory.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package authoidcextension
+package oidcauthextension
 
 import (
 	"context"

--- a/extension/oidcauthextension/factory_test.go
+++ b/extension/oidcauthextension/factory_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package authoidcextension
+package oidcauthextension
 
 import (
 	"context"

--- a/extension/oidcauthextension/oidc_server_test.go
+++ b/extension/oidcauthextension/oidc_server_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package authoidcextension
+package oidcauthextension
 
 import (
 	"bytes"

--- a/service/defaultcomponents/defaults.go
+++ b/service/defaultcomponents/defaults.go
@@ -28,8 +28,8 @@ import (
 	"go.opentelemetry.io/collector/exporter/prometheusexporter"
 	"go.opentelemetry.io/collector/exporter/prometheusremotewriteexporter"
 	"go.opentelemetry.io/collector/exporter/zipkinexporter"
-	"go.opentelemetry.io/collector/extension/authoidcextension"
 	"go.opentelemetry.io/collector/extension/healthcheckextension"
+	"go.opentelemetry.io/collector/extension/oidcauthextension"
 	"go.opentelemetry.io/collector/extension/pprofextension"
 	"go.opentelemetry.io/collector/extension/zpagesextension"
 	"go.opentelemetry.io/collector/processor/attributesprocessor"
@@ -57,7 +57,7 @@ func Components() (
 	var errs []error
 
 	extensions, err := component.MakeExtensionFactoryMap(
-		authoidcextension.NewFactory(),
+		oidcauthextension.NewFactory(),
 		healthcheckextension.NewFactory(),
 		pprofextension.NewFactory(),
 		zpagesextension.NewFactory(),


### PR DESCRIPTION
This PR renames the OIDC Auth Extension to oidcauthextension, following the naming pattern agreed as part of #3128