### PR TITLE
Add margin of error for TestBallastMemory

### DIFF
--- a/testbed/tests/e2e_test.go
+++ b/testbed/tests/e2e_test.go
@@ -84,7 +84,11 @@ func TestBallastMemory(t *testing.T) {
 			return vms > test.ballastSize
 		}, time.Second*2, "VMS must be greater than %d", test.ballastSize)
 
-		assert.LessOrEqual(t, rss, test.maxRSS)
+		// https://github.com/open-telemetry/opentelemetry-collector/issues/3233
+		// given that the maxRSS isn't an absolute maximum and that the actual maximum might be a bit off,
+		// we give some room here instead of failing when the memory usage isn't that much higher than the max
+		lenientMax := 1.1 * float32(test.maxRSS)
+		assert.LessOrEqual(t, rss, lenientMax)
 		tc.Stop()
 	}
 }


### PR DESCRIPTION
This PR adds a 10% margin of error to the TestBallastMemory, so that it won't fail if the memory usage is above the max, but not at unreasonable levels.

Closes #3233 