### PR TITLE
Avoid exposing OpenCensus reference in public APIs

### DIFF
--- a/exporter/exporterhelper/logs_test.go
+++ b/exporter/exporterhelper/logs_test.go
@@ -30,8 +30,8 @@ import (
 	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/consumer/consumerhelper"
 	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.opentelemetry.io/collector/internal/obsreportconfig/obsmetrics"
 	"go.opentelemetry.io/collector/internal/testdata"
-	"go.opentelemetry.io/collector/obsreport"
 	"go.opentelemetry.io/collector/obsreport/obsreporttest"
 )
 
@@ -222,7 +222,7 @@ func checkWrapSpanForLogsExporter(t *testing.T, le component.LogsExporter, wantE
 			sentLogRecords = 0
 			failedToSendLogRecords = numLogRecords
 		}
-		require.Equalf(t, sentLogRecords, sd.Attributes[obsreport.SentLogRecordsKey], "SpanData %v", sd)
-		require.Equalf(t, failedToSendLogRecords, sd.Attributes[obsreport.FailedToSendLogRecordsKey], "SpanData %v", sd)
+		require.Equalf(t, sentLogRecords, sd.Attributes[obsmetrics.SentLogRecordsKey], "SpanData %v", sd)
+		require.Equalf(t, failedToSendLogRecords, sd.Attributes[obsmetrics.FailedToSendLogRecordsKey], "SpanData %v", sd)
 	}
 }

--- a/exporter/exporterhelper/metrics_test.go
+++ b/exporter/exporterhelper/metrics_test.go
@@ -30,8 +30,8 @@ import (
 	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/consumer/consumerhelper"
 	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.opentelemetry.io/collector/internal/obsreportconfig/obsmetrics"
 	"go.opentelemetry.io/collector/internal/testdata"
-	"go.opentelemetry.io/collector/obsreport"
 	"go.opentelemetry.io/collector/obsreport/obsreporttest"
 )
 
@@ -246,7 +246,7 @@ func checkWrapSpanForMetricsExporter(t *testing.T, me component.MetricsExporter,
 			sentMetricPoints = 0
 			failedToSendMetricPoints = numMetricPoints
 		}
-		require.Equalf(t, sentMetricPoints, sd.Attributes[obsreport.SentMetricPointsKey], "SpanData %v", sd)
-		require.Equalf(t, failedToSendMetricPoints, sd.Attributes[obsreport.FailedToSendMetricPointsKey], "SpanData %v", sd)
+		require.Equalf(t, sentMetricPoints, sd.Attributes[obsmetrics.SentMetricPointsKey], "SpanData %v", sd)
+		require.Equalf(t, failedToSendMetricPoints, sd.Attributes[obsmetrics.FailedToSendMetricPointsKey], "SpanData %v", sd)
 	}
 }

--- a/exporter/exporterhelper/queued_retry.go
+++ b/exporter/exporterhelper/queued_retry.go
@@ -30,16 +30,16 @@ import (
 	"go.uber.org/zap/zapcore"
 
 	"go.opentelemetry.io/collector/consumer/consumererror"
-	"go.opentelemetry.io/collector/obsreport"
+	"go.opentelemetry.io/collector/internal/obsreportconfig/obsmetrics"
 )
 
 var (
 	r = metric.NewRegistry()
 
 	queueSizeGauge, _ = r.AddInt64DerivedGauge(
-		obsreport.ExporterKey+"/queue_size",
+		obsmetrics.ExporterKey+"/queue_size",
 		metric.WithDescription("Current size of the retry queue (in batches)"),
-		metric.WithLabelKeys(obsreport.ExporterKey),
+		metric.WithLabelKeys(obsmetrics.ExporterKey),
 		metric.WithUnit(metricdata.UnitDimensionless))
 )
 
@@ -127,7 +127,7 @@ func createSampledLogger(logger *zap.Logger) *zap.Logger {
 func newQueuedRetrySender(fullName string, qCfg QueueSettings, rCfg RetrySettings, nextSender requestSender, logger *zap.Logger) *queuedRetrySender {
 	retryStopCh := make(chan struct{})
 	sampledLogger := createSampledLogger(logger)
-	traceAttr := trace.StringAttribute(obsreport.ExporterKey, fullName)
+	traceAttr := trace.StringAttribute(obsmetrics.ExporterKey, fullName)
 	return &queuedRetrySender{
 		fullName: fullName,
 		cfg:      qCfg,

--- a/exporter/exporterhelper/traces_test.go
+++ b/exporter/exporterhelper/traces_test.go
@@ -31,8 +31,8 @@ import (
 	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/consumer/consumerhelper"
 	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.opentelemetry.io/collector/internal/obsreportconfig/obsmetrics"
 	"go.opentelemetry.io/collector/internal/testdata"
-	"go.opentelemetry.io/collector/obsreport"
 	"go.opentelemetry.io/collector/obsreport/obsreporttest"
 )
 
@@ -239,7 +239,7 @@ func checkWrapSpanForTracesExporter(t *testing.T, te component.TracesExporter, w
 			failedToSendSpans = numSpans
 		}
 
-		require.Equalf(t, sentSpans, sd.Attributes[obsreport.SentSpansKey], "SpanData %v", sd)
-		require.Equalf(t, failedToSendSpans, sd.Attributes[obsreport.FailedToSendSpansKey], "SpanData %v", sd)
+		require.Equalf(t, sentSpans, sd.Attributes[obsmetrics.SentSpansKey], "SpanData %v", sd)
+		require.Equalf(t, failedToSendSpans, sd.Attributes[obsmetrics.FailedToSendSpansKey], "SpanData %v", sd)
 	}
 }

--- a/internal/obsreportconfig/obsmetrics/obs_exporter.go
+++ b/internal/obsreportconfig/obsmetrics/obs_exporter.go
@@ -1,0 +1,79 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package obsmetrics
+
+import (
+	"go.opencensus.io/stats"
+	"go.opencensus.io/tag"
+)
+
+const (
+	// ExporterKey used to identify exporters in metrics and traces.
+	ExporterKey = "exporter"
+
+	// SentSpansKey used to track spans sent by exporters.
+	SentSpansKey = "sent_spans"
+	// FailedToSendSpansKey used to track spans that failed to be sent by exporters.
+	FailedToSendSpansKey = "send_failed_spans"
+
+	// SentMetricPointsKey used to track metric points sent by exporters.
+	SentMetricPointsKey = "sent_metric_points"
+	// FailedToSendMetricPointsKey used to track metric points that failed to be sent by exporters.
+	FailedToSendMetricPointsKey = "send_failed_metric_points"
+
+	// SentLogRecordsKey used to track logs sent by exporters.
+	SentLogRecordsKey = "sent_log_records"
+	// FailedToSendLogRecordsKey used to track logs that failed to be sent by exporters.
+	FailedToSendLogRecordsKey = "send_failed_log_records"
+)
+
+var (
+	TagKeyExporter, _ = tag.NewKey(ExporterKey)
+
+	ExporterPrefix                 = ExporterKey + NameSep
+	ExportTraceDataOperationSuffix = NameSep + "traces"
+	ExportMetricsOperationSuffix   = NameSep + "metrics"
+	ExportLogsOperationSuffix      = NameSep + "logs"
+
+	// Exporter metrics. Any count of data items below is in the final format
+	// that they were sent, reasoning: reconciliation is easier if measurements
+	// on backend and exporter are expected to be the same. Translation issues
+	// that result in a different number of elements should be reported in a
+	// separate way.
+	ExporterSentSpans = stats.Int64(
+		ExporterPrefix+SentSpansKey,
+		"Number of spans successfully sent to destination.",
+		stats.UnitDimensionless)
+	ExporterFailedToSendSpans = stats.Int64(
+		ExporterPrefix+FailedToSendSpansKey,
+		"Number of spans in failed attempts to send to destination.",
+		stats.UnitDimensionless)
+	ExporterSentMetricPoints = stats.Int64(
+		ExporterPrefix+SentMetricPointsKey,
+		"Number of metric points successfully sent to destination.",
+		stats.UnitDimensionless)
+	ExporterFailedToSendMetricPoints = stats.Int64(
+		ExporterPrefix+FailedToSendMetricPointsKey,
+		"Number of metric points in failed attempts to send to destination.",
+		stats.UnitDimensionless)
+	ExporterSentLogRecords = stats.Int64(
+		ExporterPrefix+SentLogRecordsKey,
+		"Number of log record successfully sent to destination.",
+		stats.UnitDimensionless)
+	ExporterFailedToSendLogRecords = stats.Int64(
+		ExporterPrefix+FailedToSendLogRecordsKey,
+		"Number of log records in failed attempts to send to destination.",
+		stats.UnitDimensionless)
+)

--- a/internal/obsreportconfig/obsmetrics/obs_processor.go
+++ b/internal/obsreportconfig/obsmetrics/obs_processor.go
@@ -1,0 +1,79 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package obsmetrics
+
+import (
+	"go.opencensus.io/stats"
+	"go.opencensus.io/tag"
+)
+
+const (
+	// ProcessorKey is the key used to identify processors in metrics and traces.
+	ProcessorKey = "processor"
+
+	// DroppedSpansKey is the key used to identify spans dropped by the Collector.
+	DroppedSpansKey = "dropped_spans"
+
+	// DroppedMetricPointsKey is the key used to identify metric points dropped by the Collector.
+	DroppedMetricPointsKey = "dropped_metric_points"
+
+	// DroppedLogRecordsKey is the key used to identify log records dropped by the Collector.
+	DroppedLogRecordsKey = "dropped_log_records"
+)
+
+var (
+	TagKeyProcessor, _ = tag.NewKey(ProcessorKey)
+
+	ProcessorPrefix = ProcessorKey + NameSep
+
+	// Processor metrics. Any count of data items below is in the internal format
+	// of the collector since processors only deal with internal format.
+	ProcessorAcceptedSpans = stats.Int64(
+		ProcessorPrefix+AcceptedSpansKey,
+		"Number of spans successfully pushed into the next component in the pipeline.",
+		stats.UnitDimensionless)
+	ProcessorRefusedSpans = stats.Int64(
+		ProcessorPrefix+RefusedSpansKey,
+		"Number of spans that were rejected by the next component in the pipeline.",
+		stats.UnitDimensionless)
+	ProcessorDroppedSpans = stats.Int64(
+		ProcessorPrefix+DroppedSpansKey,
+		"Number of spans that were dropped.",
+		stats.UnitDimensionless)
+	ProcessorAcceptedMetricPoints = stats.Int64(
+		ProcessorPrefix+AcceptedMetricPointsKey,
+		"Number of metric points successfully pushed into the next component in the pipeline.",
+		stats.UnitDimensionless)
+	ProcessorRefusedMetricPoints = stats.Int64(
+		ProcessorPrefix+RefusedMetricPointsKey,
+		"Number of metric points that were rejected by the next component in the pipeline.",
+		stats.UnitDimensionless)
+	ProcessorDroppedMetricPoints = stats.Int64(
+		ProcessorPrefix+DroppedMetricPointsKey,
+		"Number of metric points that were dropped.",
+		stats.UnitDimensionless)
+	ProcessorAcceptedLogRecords = stats.Int64(
+		ProcessorPrefix+AcceptedLogRecordsKey,
+		"Number of log records successfully pushed into the next component in the pipeline.",
+		stats.UnitDimensionless)
+	ProcessorRefusedLogRecords = stats.Int64(
+		ProcessorPrefix+RefusedLogRecordsKey,
+		"Number of log records that were rejected by the next component in the pipeline.",
+		stats.UnitDimensionless)
+	ProcessorDroppedLogRecords = stats.Int64(
+		ProcessorPrefix+DroppedLogRecordsKey,
+		"Number of log records that were dropped.",
+		stats.UnitDimensionless)
+)

--- a/internal/obsreportconfig/obsmetrics/obs_receiver.go
+++ b/internal/obsreportconfig/obsmetrics/obs_receiver.go
@@ -1,0 +1,86 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package obsmetrics
+
+import (
+	"go.opencensus.io/stats"
+	"go.opencensus.io/tag"
+)
+
+const (
+	// ReceiverKey used to identify receivers in metrics and traces.
+	ReceiverKey = "receiver"
+	// TransportKey used to identify the transport used to received the data.
+	TransportKey = "transport"
+	// FormatKey used to identify the format of the data received.
+	FormatKey = "format"
+
+	// AcceptedSpansKey used to identify spans accepted by the Collector.
+	AcceptedSpansKey = "accepted_spans"
+	// RefusedSpansKey used to identify spans refused (ie.: not ingested) by the Collector.
+	RefusedSpansKey = "refused_spans"
+
+	// AcceptedMetricPointsKey used to identify metric points accepted by the Collector.
+	AcceptedMetricPointsKey = "accepted_metric_points"
+	// RefusedMetricPointsKey used to identify metric points refused (ie.: not ingested) by the
+	// Collector.
+	RefusedMetricPointsKey = "refused_metric_points"
+
+	// AcceptedLogRecordsKey used to identify log records accepted by the Collector.
+	AcceptedLogRecordsKey = "accepted_log_records"
+	// RefusedLogRecordsKey used to identify log records refused (ie.: not ingested) by the
+	// Collector.
+	RefusedLogRecordsKey = "refused_log_records"
+)
+
+var (
+	TagKeyReceiver, _  = tag.NewKey(ReceiverKey)
+	TagKeyTransport, _ = tag.NewKey(TransportKey)
+
+	ReceiverPrefix                  = ReceiverKey + NameSep
+	ReceiveTraceDataOperationSuffix = NameSep + "TraceDataReceived"
+	ReceiverMetricsOperationSuffix  = NameSep + "MetricsReceived"
+	ReceiverLogsOperationSuffix     = NameSep + "LogsReceived"
+
+	// Receiver metrics. Any count of data items below is in the original format
+	// that they were received, reasoning: reconciliation is easier if measurement
+	// on clients and receiver are expected to be the same. Translation issues
+	// that result in a different number of elements should be reported in a
+	// separate way.
+	ReceiverAcceptedSpans = stats.Int64(
+		ReceiverPrefix+AcceptedSpansKey,
+		"Number of spans successfully pushed into the pipeline.",
+		stats.UnitDimensionless)
+	ReceiverRefusedSpans = stats.Int64(
+		ReceiverPrefix+RefusedSpansKey,
+		"Number of spans that could not be pushed into the pipeline.",
+		stats.UnitDimensionless)
+	ReceiverAcceptedMetricPoints = stats.Int64(
+		ReceiverPrefix+AcceptedMetricPointsKey,
+		"Number of metric points successfully pushed into the pipeline.",
+		stats.UnitDimensionless)
+	ReceiverRefusedMetricPoints = stats.Int64(
+		ReceiverPrefix+RefusedMetricPointsKey,
+		"Number of metric points that could not be pushed into the pipeline.",
+		stats.UnitDimensionless)
+	ReceiverAcceptedLogRecords = stats.Int64(
+		ReceiverPrefix+AcceptedLogRecordsKey,
+		"Number of log records successfully pushed into the pipeline.",
+		stats.UnitDimensionless)
+	ReceiverRefusedLogRecords = stats.Int64(
+		ReceiverPrefix+RefusedLogRecordsKey,
+		"Number of log records that could not be pushed into the pipeline.",
+		stats.UnitDimensionless)
+)

--- a/internal/obsreportconfig/obsmetrics/obs_scraper.go
+++ b/internal/obsreportconfig/obsmetrics/obs_scraper.go
@@ -1,0 +1,50 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package obsmetrics
+
+import (
+	"go.opencensus.io/stats"
+	"go.opencensus.io/tag"
+)
+
+const (
+	// ScraperKey used to identify scrapers in metrics and traces.
+	ScraperKey = "scraper"
+
+	// ScrapedMetricPointsKey used to identify metric points scraped by the
+	// Collector.
+	ScrapedMetricPointsKey = "scraped_metric_points"
+	// ErroredMetricPointsKey used to identify metric points errored (i.e.
+	// unable to be scraped) by the Collector.
+	ErroredMetricPointsKey = "errored_metric_points"
+)
+
+const (
+	ScraperPrefix                 = ScraperKey + NameSep
+	ScraperMetricsOperationSuffix = NameSep + "MetricsScraped"
+)
+
+var (
+	TagKeyScraper, _ = tag.NewKey(ScraperKey)
+
+	ScraperScrapedMetricPoints = stats.Int64(
+		ScraperPrefix+ScrapedMetricPointsKey,
+		"Number of metric points successfully scraped.",
+		stats.UnitDimensionless)
+	ScraperErroredMetricPoints = stats.Int64(
+		ScraperPrefix+ErroredMetricPointsKey,
+		"Number of metric points that were unable to be scraped.",
+		stats.UnitDimensionless)
+)

--- a/internal/obsreportconfig/obsmetrics/obsmetrics.go
+++ b/internal/obsreportconfig/obsmetrics/obsmetrics.go
@@ -1,0 +1,22 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package obsmetrics defines the obsreport metrics for each components
+// all the metrics is in OpenCensus format which will be replaced with OTEL Metrics
+// in the future
+package obsmetrics
+
+const (
+	NameSep = "/"
+)

--- a/internal/obsreportconfig/obsreportconfig.go
+++ b/internal/obsreportconfig/obsreportconfig.go
@@ -1,0 +1,124 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package obsreportconfig
+
+import (
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
+
+	"go.opentelemetry.io/collector/config/configtelemetry"
+	"go.opentelemetry.io/collector/internal/obsreportconfig/obsmetrics"
+)
+
+var (
+	Level = configtelemetry.LevelBasic
+)
+
+// ObsMetrics wraps OpenCensus View for Collector observability metrics
+type ObsMetrics struct {
+	Views []*view.View
+}
+
+// Configure is used to control the settings that will be used by the obsreport
+// package.
+func Configure(level configtelemetry.Level) *ObsMetrics {
+	Level = level
+	var views []*view.View
+
+	if Level != configtelemetry.LevelNone {
+		obsMetricViews := allViews()
+		views = append(views, obsMetricViews.Views...)
+	}
+
+	return &ObsMetrics{
+		Views: views,
+	}
+}
+
+// allViews return the list of all views that needs to be configured.
+func allViews() *ObsMetrics {
+	var views []*view.View
+	// Receiver views.
+	measures := []*stats.Int64Measure{
+		obsmetrics.ReceiverAcceptedSpans,
+		obsmetrics.ReceiverRefusedSpans,
+		obsmetrics.ReceiverAcceptedMetricPoints,
+		obsmetrics.ReceiverRefusedMetricPoints,
+		obsmetrics.ReceiverAcceptedLogRecords,
+		obsmetrics.ReceiverRefusedLogRecords,
+	}
+	tagKeys := []tag.Key{
+		obsmetrics.TagKeyReceiver, obsmetrics.TagKeyTransport,
+	}
+	views = append(views, genViews(measures, tagKeys, view.Sum())...)
+
+	// Scraper views.
+	measures = []*stats.Int64Measure{
+		obsmetrics.ScraperScrapedMetricPoints,
+		obsmetrics.ScraperErroredMetricPoints,
+	}
+	tagKeys = []tag.Key{obsmetrics.TagKeyReceiver, obsmetrics.TagKeyScraper}
+	views = append(views, genViews(measures, tagKeys, view.Sum())...)
+
+	// Exporter views.
+	measures = []*stats.Int64Measure{
+		obsmetrics.ExporterSentSpans,
+		obsmetrics.ExporterFailedToSendSpans,
+		obsmetrics.ExporterSentMetricPoints,
+		obsmetrics.ExporterFailedToSendMetricPoints,
+		obsmetrics.ExporterSentLogRecords,
+		obsmetrics.ExporterFailedToSendLogRecords,
+	}
+	tagKeys = []tag.Key{obsmetrics.TagKeyExporter}
+	views = append(views, genViews(measures, tagKeys, view.Sum())...)
+
+	// Processor views.
+	measures = []*stats.Int64Measure{
+		obsmetrics.ProcessorAcceptedSpans,
+		obsmetrics.ProcessorRefusedSpans,
+		obsmetrics.ProcessorDroppedSpans,
+		obsmetrics.ProcessorAcceptedMetricPoints,
+		obsmetrics.ProcessorRefusedMetricPoints,
+		obsmetrics.ProcessorDroppedMetricPoints,
+		obsmetrics.ProcessorAcceptedLogRecords,
+		obsmetrics.ProcessorRefusedLogRecords,
+		obsmetrics.ProcessorDroppedLogRecords,
+	}
+	tagKeys = []tag.Key{obsmetrics.TagKeyProcessor}
+	views = append(views, genViews(measures, tagKeys, view.Sum())...)
+
+	return &ObsMetrics{
+		Views: views,
+	}
+}
+
+func genViews(
+	measures []*stats.Int64Measure,
+	tagKeys []tag.Key,
+	aggregation *view.Aggregation,
+) []*view.View {
+	views := make([]*view.View, 0, len(measures))
+	for _, measure := range measures {
+		views = append(views, &view.View{
+			Name:        measure.Name(),
+			Description: measure.Description(),
+			TagKeys:     tagKeys,
+			Measure:     measure,
+			Aggregation: aggregation,
+		})
+	}
+	return views
+}

--- a/internal/obsreportconfig/obsreportconfig_test.go
+++ b/internal/obsreportconfig/obsreportconfig_test.go
@@ -1,0 +1,58 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package obsreportconfig
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opencensus.io/stats/view"
+
+	"go.opentelemetry.io/collector/config/configtelemetry"
+)
+
+func TestConfigure(t *testing.T) {
+	tests := []struct {
+		name      string
+		level     configtelemetry.Level
+		wantViews []*view.View
+	}{
+		{
+			name:  "none",
+			level: configtelemetry.LevelNone,
+		},
+		{
+			name:      "basic",
+			level:     configtelemetry.LevelBasic,
+			wantViews: allViews().Views,
+		},
+		{
+			name:      "normal",
+			level:     configtelemetry.LevelNormal,
+			wantViews: allViews().Views,
+		},
+		{
+			name:      "detailed",
+			level:     configtelemetry.LevelDetailed,
+			wantViews: allViews().Views,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotViews := Configure(tt.level)
+			assert.Equal(t, tt.wantViews, gotViews.Views)
+		})
+	}
+}

--- a/obsreport/obsreport_test.go
+++ b/obsreport/obsreport_test.go
@@ -12,9 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// obsreport_test instead of just obsreport to avoid dependency cycle between
-// obsreport_test and obsreporttest
-package obsreport_test
+package obsreport
 
 import (
 	"context"
@@ -30,7 +28,8 @@ import (
 
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/configtelemetry"
-	"go.opentelemetry.io/collector/obsreport"
+	"go.opentelemetry.io/collector/internal/obsreportconfig"
+	"go.opentelemetry.io/collector/internal/obsreportconfig/obsmetrics"
 	"go.opentelemetry.io/collector/obsreport/obsreporttest"
 	"go.opentelemetry.io/collector/receiver/scrapererror"
 )
@@ -55,40 +54,6 @@ type receiveTestParams struct {
 	err       error
 }
 
-func TestConfigure(t *testing.T) {
-	tests := []struct {
-		name      string
-		level     configtelemetry.Level
-		wantViews []*view.View
-	}{
-		{
-			name:  "none",
-			level: configtelemetry.LevelNone,
-		},
-		{
-			name:      "basic",
-			level:     configtelemetry.LevelBasic,
-			wantViews: obsreport.AllViews(),
-		},
-		{
-			name:      "normal",
-			level:     configtelemetry.LevelNormal,
-			wantViews: obsreport.AllViews(),
-		},
-		{
-			name:      "detailed",
-			level:     configtelemetry.LevelDetailed,
-			wantViews: obsreport.AllViews(),
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			gotViews := obsreport.Configure(tt.level)
-			assert.Equal(t, tt.wantViews, gotViews)
-		})
-	}
-}
-
 func TestReceiveTraceDataOp(t *testing.T) {
 	doneFn, err := obsreporttest.SetupRecordedMetricsTest()
 	require.NoError(t, err)
@@ -102,14 +67,14 @@ func TestReceiveTraceDataOp(t *testing.T) {
 		t.Name(), trace.WithSampler(trace.AlwaysSample()))
 	defer parentSpan.End()
 
-	receiverCtx := obsreport.ReceiverContext(parentCtx, receiver, transport)
+	receiverCtx := ReceiverContext(parentCtx, receiver, transport)
 	params := []receiveTestParams{
 		{transport, errFake},
 		{"", nil},
 	}
 	rcvdSpans := []int{13, 42}
 	for i, param := range params {
-		rec := obsreport.NewReceiver(obsreport.ReceiverSettings{ReceiverID: receiver, Transport: param.transport})
+		rec := NewReceiver(ReceiverSettings{ReceiverID: receiver, Transport: param.transport})
 		ctx := rec.StartTraceDataReceiveOp(receiverCtx)
 		assert.NotNil(t, ctx)
 
@@ -129,22 +94,22 @@ func TestReceiveTraceDataOp(t *testing.T) {
 		switch params[i].err {
 		case nil:
 			acceptedSpans += rcvdSpans[i]
-			assert.Equal(t, int64(rcvdSpans[i]), span.Attributes[obsreport.AcceptedSpansKey])
-			assert.Equal(t, int64(0), span.Attributes[obsreport.RefusedSpansKey])
+			assert.Equal(t, int64(rcvdSpans[i]), span.Attributes[obsmetrics.AcceptedSpansKey])
+			assert.Equal(t, int64(0), span.Attributes[obsmetrics.RefusedSpansKey])
 			assert.Equal(t, trace.Status{Code: trace.StatusCodeOK}, span.Status)
 		case errFake:
 			refusedSpans += rcvdSpans[i]
-			assert.Equal(t, int64(0), span.Attributes[obsreport.AcceptedSpansKey])
-			assert.Equal(t, int64(rcvdSpans[i]), span.Attributes[obsreport.RefusedSpansKey])
+			assert.Equal(t, int64(0), span.Attributes[obsmetrics.AcceptedSpansKey])
+			assert.Equal(t, int64(rcvdSpans[i]), span.Attributes[obsmetrics.RefusedSpansKey])
 			assert.Equal(t, params[i].err.Error(), span.Status.Message)
 		default:
 			t.Fatalf("unexpected param: %v", params[i])
 		}
 		switch params[i].transport {
 		case "":
-			assert.NotContains(t, span.Attributes, obsreport.TransportKey)
+			assert.NotContains(t, span.Attributes, obsmetrics.TransportKey)
 		default:
-			assert.Equal(t, params[i].transport, span.Attributes[obsreport.TransportKey])
+			assert.Equal(t, params[i].transport, span.Attributes[obsmetrics.TransportKey])
 		}
 	}
 	obsreporttest.CheckReceiverTraces(t, receiver, transport, int64(acceptedSpans), int64(refusedSpans))
@@ -163,14 +128,14 @@ func TestReceiveLogsOp(t *testing.T) {
 		t.Name(), trace.WithSampler(trace.AlwaysSample()))
 	defer parentSpan.End()
 
-	receiverCtx := obsreport.ReceiverContext(parentCtx, receiver, transport)
+	receiverCtx := ReceiverContext(parentCtx, receiver, transport)
 	params := []receiveTestParams{
 		{transport, errFake},
 		{"", nil},
 	}
 	rcvdLogRecords := []int{13, 42}
 	for i, param := range params {
-		rec := obsreport.NewReceiver(obsreport.ReceiverSettings{ReceiverID: receiver, Transport: param.transport})
+		rec := NewReceiver(ReceiverSettings{ReceiverID: receiver, Transport: param.transport})
 		ctx := rec.StartLogsReceiveOp(receiverCtx)
 		assert.NotNil(t, ctx)
 
@@ -190,22 +155,22 @@ func TestReceiveLogsOp(t *testing.T) {
 		switch params[i].err {
 		case nil:
 			acceptedLogRecords += rcvdLogRecords[i]
-			assert.Equal(t, int64(rcvdLogRecords[i]), span.Attributes[obsreport.AcceptedLogRecordsKey])
-			assert.Equal(t, int64(0), span.Attributes[obsreport.RefusedLogRecordsKey])
+			assert.Equal(t, int64(rcvdLogRecords[i]), span.Attributes[obsmetrics.AcceptedLogRecordsKey])
+			assert.Equal(t, int64(0), span.Attributes[obsmetrics.RefusedLogRecordsKey])
 			assert.Equal(t, trace.Status{Code: trace.StatusCodeOK}, span.Status)
 		case errFake:
 			refusedLogRecords += rcvdLogRecords[i]
-			assert.Equal(t, int64(0), span.Attributes[obsreport.AcceptedLogRecordsKey])
-			assert.Equal(t, int64(rcvdLogRecords[i]), span.Attributes[obsreport.RefusedLogRecordsKey])
+			assert.Equal(t, int64(0), span.Attributes[obsmetrics.AcceptedLogRecordsKey])
+			assert.Equal(t, int64(rcvdLogRecords[i]), span.Attributes[obsmetrics.RefusedLogRecordsKey])
 			assert.Equal(t, params[i].err.Error(), span.Status.Message)
 		default:
 			t.Fatalf("unexpected param: %v", params[i])
 		}
 		switch params[i].transport {
 		case "":
-			assert.NotContains(t, span.Attributes, obsreport.TransportKey)
+			assert.NotContains(t, span.Attributes, obsmetrics.TransportKey)
 		default:
-			assert.Equal(t, params[i].transport, span.Attributes[obsreport.TransportKey])
+			assert.Equal(t, params[i].transport, span.Attributes[obsmetrics.TransportKey])
 		}
 	}
 	obsreporttest.CheckReceiverLogs(t, receiver, transport, int64(acceptedLogRecords), int64(refusedLogRecords))
@@ -224,14 +189,14 @@ func TestReceiveMetricsOp(t *testing.T) {
 		t.Name(), trace.WithSampler(trace.AlwaysSample()))
 	defer parentSpan.End()
 
-	receiverCtx := obsreport.ReceiverContext(parentCtx, receiver, transport)
+	receiverCtx := ReceiverContext(parentCtx, receiver, transport)
 	params := []receiveTestParams{
 		{transport, errFake},
 		{"", nil},
 	}
 	rcvdMetricPts := []int{23, 29}
 	for i, param := range params {
-		rec := obsreport.NewReceiver(obsreport.ReceiverSettings{ReceiverID: receiver, Transport: param.transport})
+		rec := NewReceiver(ReceiverSettings{ReceiverID: receiver, Transport: param.transport})
 		ctx := rec.StartMetricsReceiveOp(receiverCtx)
 		assert.NotNil(t, ctx)
 
@@ -251,22 +216,22 @@ func TestReceiveMetricsOp(t *testing.T) {
 		switch params[i].err {
 		case nil:
 			acceptedMetricPoints += rcvdMetricPts[i]
-			assert.Equal(t, int64(rcvdMetricPts[i]), span.Attributes[obsreport.AcceptedMetricPointsKey])
-			assert.Equal(t, int64(0), span.Attributes[obsreport.RefusedMetricPointsKey])
+			assert.Equal(t, int64(rcvdMetricPts[i]), span.Attributes[obsmetrics.AcceptedMetricPointsKey])
+			assert.Equal(t, int64(0), span.Attributes[obsmetrics.RefusedMetricPointsKey])
 			assert.Equal(t, trace.Status{Code: trace.StatusCodeOK}, span.Status)
 		case errFake:
 			refusedMetricPoints += rcvdMetricPts[i]
-			assert.Equal(t, int64(0), span.Attributes[obsreport.AcceptedMetricPointsKey])
-			assert.Equal(t, int64(rcvdMetricPts[i]), span.Attributes[obsreport.RefusedMetricPointsKey])
+			assert.Equal(t, int64(0), span.Attributes[obsmetrics.AcceptedMetricPointsKey])
+			assert.Equal(t, int64(rcvdMetricPts[i]), span.Attributes[obsmetrics.RefusedMetricPointsKey])
 			assert.Equal(t, params[i].err.Error(), span.Status.Message)
 		default:
 			t.Fatalf("unexpected param: %v", params[i])
 		}
 		switch params[i].transport {
 		case "":
-			assert.NotContains(t, span.Attributes, obsreport.TransportKey)
+			assert.NotContains(t, span.Attributes, obsmetrics.TransportKey)
 		default:
-			assert.Equal(t, params[i].transport, span.Attributes[obsreport.TransportKey])
+			assert.Equal(t, params[i].transport, span.Attributes[obsmetrics.TransportKey])
 		}
 	}
 
@@ -286,14 +251,14 @@ func TestScrapeMetricsDataOp(t *testing.T) {
 		t.Name(), trace.WithSampler(trace.AlwaysSample()))
 	defer parentSpan.End()
 
-	receiverCtx := obsreport.ScraperContext(parentCtx, receiver, scraper)
+	receiverCtx := ScraperContext(parentCtx, receiver, scraper)
 	errParams := []error{partialErrFake, errFake, nil}
 	scrapedMetricPts := []int{23, 29, 15}
 	for i, err := range errParams {
-		ctx := obsreport.StartMetricsScrapeOp(receiverCtx, receiver, scraper)
+		ctx := StartMetricsScrapeOp(receiverCtx, receiver, scraper)
 		assert.NotNil(t, ctx)
 
-		obsreport.EndMetricsScrapeOp(
+		EndMetricsScrapeOp(
 			ctx,
 			scrapedMetricPts[i],
 			err)
@@ -308,19 +273,19 @@ func TestScrapeMetricsDataOp(t *testing.T) {
 		switch errParams[i] {
 		case nil:
 			scrapedMetricPoints += scrapedMetricPts[i]
-			assert.Equal(t, int64(scrapedMetricPts[i]), span.Attributes[obsreport.ScrapedMetricPointsKey])
-			assert.Equal(t, int64(0), span.Attributes[obsreport.ErroredMetricPointsKey])
+			assert.Equal(t, int64(scrapedMetricPts[i]), span.Attributes[obsmetrics.ScrapedMetricPointsKey])
+			assert.Equal(t, int64(0), span.Attributes[obsmetrics.ErroredMetricPointsKey])
 			assert.Equal(t, trace.Status{Code: trace.StatusCodeOK}, span.Status)
 		case errFake:
 			erroredMetricPoints += scrapedMetricPts[i]
-			assert.Equal(t, int64(0), span.Attributes[obsreport.ScrapedMetricPointsKey])
-			assert.Equal(t, int64(scrapedMetricPts[i]), span.Attributes[obsreport.ErroredMetricPointsKey])
+			assert.Equal(t, int64(0), span.Attributes[obsmetrics.ScrapedMetricPointsKey])
+			assert.Equal(t, int64(scrapedMetricPts[i]), span.Attributes[obsmetrics.ErroredMetricPointsKey])
 			assert.Equal(t, errParams[i].Error(), span.Status.Message)
 		case partialErrFake:
 			scrapedMetricPoints += scrapedMetricPts[i]
 			erroredMetricPoints++
-			assert.Equal(t, int64(scrapedMetricPts[i]), span.Attributes[obsreport.ScrapedMetricPointsKey])
-			assert.Equal(t, int64(1), span.Attributes[obsreport.ErroredMetricPointsKey])
+			assert.Equal(t, int64(scrapedMetricPts[i]), span.Attributes[obsmetrics.ScrapedMetricPointsKey])
+			assert.Equal(t, int64(1), span.Attributes[obsmetrics.ErroredMetricPointsKey])
 			assert.Equal(t, errParams[i].Error(), span.Status.Message)
 		default:
 			t.Fatalf("unexpected err param: %v", errParams[i])
@@ -343,7 +308,7 @@ func TestExportTraceDataOp(t *testing.T) {
 		t.Name(), trace.WithSampler(trace.AlwaysSample()))
 	defer parentSpan.End()
 
-	obsrep := obsreport.NewExporter(obsreport.ExporterSettings{Level: configtelemetry.LevelNormal, ExporterID: exporter})
+	obsrep := NewExporter(ExporterSettings{Level: configtelemetry.LevelNormal, ExporterID: exporter})
 	errs := []error{nil, errFake}
 	numExportedSpans := []int{22, 14}
 	for i, err := range errs {
@@ -361,13 +326,13 @@ func TestExportTraceDataOp(t *testing.T) {
 		switch errs[i] {
 		case nil:
 			sentSpans += numExportedSpans[i]
-			assert.Equal(t, int64(numExportedSpans[i]), span.Attributes[obsreport.SentSpansKey])
-			assert.Equal(t, int64(0), span.Attributes[obsreport.FailedToSendSpansKey])
+			assert.Equal(t, int64(numExportedSpans[i]), span.Attributes[obsmetrics.SentSpansKey])
+			assert.Equal(t, int64(0), span.Attributes[obsmetrics.FailedToSendSpansKey])
 			assert.Equal(t, trace.Status{Code: trace.StatusCodeOK}, span.Status)
 		case errFake:
 			failedToSendSpans += numExportedSpans[i]
-			assert.Equal(t, int64(0), span.Attributes[obsreport.SentSpansKey])
-			assert.Equal(t, int64(numExportedSpans[i]), span.Attributes[obsreport.FailedToSendSpansKey])
+			assert.Equal(t, int64(0), span.Attributes[obsmetrics.SentSpansKey])
+			assert.Equal(t, int64(numExportedSpans[i]), span.Attributes[obsmetrics.FailedToSendSpansKey])
 			assert.Equal(t, errs[i].Error(), span.Status.Message)
 		default:
 			t.Fatalf("unexpected error: %v", errs[i])
@@ -390,7 +355,7 @@ func TestExportMetricsOp(t *testing.T) {
 		t.Name(), trace.WithSampler(trace.AlwaysSample()))
 	defer parentSpan.End()
 
-	obsrep := obsreport.NewExporter(obsreport.ExporterSettings{Level: configtelemetry.LevelNormal, ExporterID: exporter})
+	obsrep := NewExporter(ExporterSettings{Level: configtelemetry.LevelNormal, ExporterID: exporter})
 
 	errs := []error{nil, errFake}
 	toSendMetricPoints := []int{17, 23}
@@ -410,13 +375,13 @@ func TestExportMetricsOp(t *testing.T) {
 		switch errs[i] {
 		case nil:
 			sentMetricPoints += toSendMetricPoints[i]
-			assert.Equal(t, int64(toSendMetricPoints[i]), span.Attributes[obsreport.SentMetricPointsKey])
-			assert.Equal(t, int64(0), span.Attributes[obsreport.FailedToSendMetricPointsKey])
+			assert.Equal(t, int64(toSendMetricPoints[i]), span.Attributes[obsmetrics.SentMetricPointsKey])
+			assert.Equal(t, int64(0), span.Attributes[obsmetrics.FailedToSendMetricPointsKey])
 			assert.Equal(t, trace.Status{Code: trace.StatusCodeOK}, span.Status)
 		case errFake:
 			failedToSendMetricPoints += toSendMetricPoints[i]
-			assert.Equal(t, int64(0), span.Attributes[obsreport.SentMetricPointsKey])
-			assert.Equal(t, int64(toSendMetricPoints[i]), span.Attributes[obsreport.FailedToSendMetricPointsKey])
+			assert.Equal(t, int64(0), span.Attributes[obsmetrics.SentMetricPointsKey])
+			assert.Equal(t, int64(toSendMetricPoints[i]), span.Attributes[obsmetrics.FailedToSendMetricPointsKey])
 			assert.Equal(t, errs[i].Error(), span.Status.Message)
 		default:
 			t.Fatalf("unexpected error: %v", errs[i])
@@ -439,7 +404,7 @@ func TestExportLogsOp(t *testing.T) {
 		t.Name(), trace.WithSampler(trace.AlwaysSample()))
 	defer parentSpan.End()
 
-	obsrep := obsreport.NewExporter(obsreport.ExporterSettings{Level: configtelemetry.LevelNormal, ExporterID: exporter})
+	obsrep := NewExporter(ExporterSettings{Level: configtelemetry.LevelNormal, ExporterID: exporter})
 	errs := []error{nil, errFake}
 	toSendLogRecords := []int{17, 23}
 	for i, err := range errs {
@@ -458,13 +423,13 @@ func TestExportLogsOp(t *testing.T) {
 		switch errs[i] {
 		case nil:
 			sentLogRecords += toSendLogRecords[i]
-			assert.Equal(t, int64(toSendLogRecords[i]), span.Attributes[obsreport.SentLogRecordsKey])
-			assert.Equal(t, int64(0), span.Attributes[obsreport.FailedToSendLogRecordsKey])
+			assert.Equal(t, int64(toSendLogRecords[i]), span.Attributes[obsmetrics.SentLogRecordsKey])
+			assert.Equal(t, int64(0), span.Attributes[obsmetrics.FailedToSendLogRecordsKey])
 			assert.Equal(t, trace.Status{Code: trace.StatusCodeOK}, span.Status)
 		case errFake:
 			failedToSendLogRecords += toSendLogRecords[i]
-			assert.Equal(t, int64(0), span.Attributes[obsreport.SentLogRecordsKey])
-			assert.Equal(t, int64(toSendLogRecords[i]), span.Attributes[obsreport.FailedToSendLogRecordsKey])
+			assert.Equal(t, int64(0), span.Attributes[obsmetrics.SentLogRecordsKey])
+			assert.Equal(t, int64(toSendLogRecords[i]), span.Attributes[obsmetrics.FailedToSendLogRecordsKey])
 			assert.Equal(t, errs[i].Error(), span.Status.Message)
 		default:
 			t.Fatalf("unexpected error: %v", errs[i])
@@ -491,7 +456,7 @@ func TestReceiveWithLongLivedCtx(t *testing.T) {
 	parentCtx, parentSpan := trace.StartSpan(context.Background(), t.Name())
 	defer parentSpan.End()
 
-	longLivedCtx := obsreport.ReceiverContext(parentCtx, receiver, transport)
+	longLivedCtx := ReceiverContext(parentCtx, receiver, transport)
 	ops := []struct {
 		numSpans int
 		err      error
@@ -502,10 +467,10 @@ func TestReceiveWithLongLivedCtx(t *testing.T) {
 	for _, op := range ops {
 		// Use a new context on each operation to simulate distinct operations
 		// under the same long lived context.
-		rec := obsreport.NewReceiver(obsreport.ReceiverSettings{ReceiverID: receiver, Transport: transport})
+		rec := NewReceiver(ReceiverSettings{ReceiverID: receiver, Transport: transport})
 		ctx := rec.StartTraceDataReceiveOp(
 			longLivedCtx,
-			obsreport.WithLongLivedCtx())
+			WithLongLivedCtx())
 		assert.NotNil(t, ctx)
 
 		rec.EndTraceDataReceiveOp(
@@ -526,15 +491,15 @@ func TestReceiveWithLongLivedCtx(t *testing.T) {
 		assert.Equal(t, parentSpan.SpanContext().TraceID, link.TraceID)
 		assert.Equal(t, parentSpan.SpanContext().SpanID, link.SpanID)
 		assert.Equal(t, "receiver/"+receiver.String()+"/TraceDataReceived", span.Name)
-		assert.Equal(t, transport, span.Attributes[obsreport.TransportKey])
+		assert.Equal(t, transport, span.Attributes[obsmetrics.TransportKey])
 		switch ops[i].err {
 		case nil:
-			assert.Equal(t, int64(ops[i].numSpans), span.Attributes[obsreport.AcceptedSpansKey])
-			assert.Equal(t, int64(0), span.Attributes[obsreport.RefusedSpansKey])
+			assert.Equal(t, int64(ops[i].numSpans), span.Attributes[obsmetrics.AcceptedSpansKey])
+			assert.Equal(t, int64(0), span.Attributes[obsmetrics.RefusedSpansKey])
 			assert.Equal(t, trace.Status{Code: trace.StatusCodeOK}, span.Status)
 		case errFake:
-			assert.Equal(t, int64(0), span.Attributes[obsreport.AcceptedSpansKey])
-			assert.Equal(t, int64(ops[i].numSpans), span.Attributes[obsreport.RefusedSpansKey])
+			assert.Equal(t, int64(0), span.Attributes[obsmetrics.AcceptedSpansKey])
+			assert.Equal(t, int64(ops[i].numSpans), span.Attributes[obsmetrics.RefusedSpansKey])
 			assert.Equal(t, ops[i].err.Error(), span.Status.Message)
 		default:
 			t.Fatalf("unexpected error: %v", ops[i].err)
@@ -551,7 +516,7 @@ func TestProcessorTraceData(t *testing.T) {
 	const refusedSpans = 19
 	const droppedSpans = 13
 
-	obsrep := obsreport.NewProcessor(obsreport.ProcessorSettings{Level: configtelemetry.LevelNormal, ProcessorID: processor})
+	obsrep := NewProcessor(ProcessorSettings{Level: configtelemetry.LevelNormal, ProcessorID: processor})
 	obsrep.TracesAccepted(context.Background(), acceptedSpans)
 	obsrep.TracesRefused(context.Background(), refusedSpans)
 	obsrep.TracesDropped(context.Background(), droppedSpans)
@@ -568,7 +533,7 @@ func TestProcessorMetricsData(t *testing.T) {
 	const refusedPoints = 11
 	const droppedPoints = 17
 
-	obsrep := obsreport.NewProcessor(obsreport.ProcessorSettings{Level: configtelemetry.LevelNormal, ProcessorID: processor})
+	obsrep := NewProcessor(ProcessorSettings{Level: configtelemetry.LevelNormal, ProcessorID: processor})
 	obsrep.MetricsAccepted(context.Background(), acceptedPoints)
 	obsrep.MetricsRefused(context.Background(), refusedPoints)
 	obsrep.MetricsDropped(context.Background(), droppedPoints)
@@ -623,9 +588,9 @@ func TestProcessorMetricViews(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			obsreport.Configure(tt.level)
-			got := obsreport.ProcessorMetricViews("test_type", legacyViews)
-			assert.Equal(t, tt.want, got)
+			obsreportconfig.Configure(tt.level)
+			got := ProcessorMetricViews("test_type", &obsreportconfig.ObsMetrics{Views: legacyViews})
+			assert.Equal(t, tt.want, got.Views)
 		})
 	}
 }
@@ -639,7 +604,7 @@ func TestProcessorLogRecords(t *testing.T) {
 	const refusedRecords = 11
 	const droppedRecords = 17
 
-	obsrep := obsreport.NewProcessor(obsreport.ProcessorSettings{Level: configtelemetry.LevelNormal, ProcessorID: processor})
+	obsrep := NewProcessor(ProcessorSettings{Level: configtelemetry.LevelNormal, ProcessorID: processor})
 	obsrep.LogsAccepted(context.Background(), acceptedRecords)
 	obsrep.LogsRefused(context.Background(), refusedRecords)
 	obsrep.LogsDropped(context.Background(), droppedRecords)

--- a/obsreport/obsreporttest/obsreporttest.go
+++ b/obsreport/obsreporttest/obsreporttest.go
@@ -25,7 +25,7 @@ import (
 
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/configtelemetry"
-	"go.opentelemetry.io/collector/obsreport"
+	"go.opentelemetry.io/collector/internal/obsreportconfig"
 )
 
 var (
@@ -45,7 +45,8 @@ var (
 // SetupRecordedMetricsTest does setup the testing environment to check the metrics recorded by receivers, producers or exporters.
 // The returned function should be deferred.
 func SetupRecordedMetricsTest() (func(), error) {
-	views := obsreport.Configure(configtelemetry.LevelNormal)
+	obsMetrics := obsreportconfig.Configure(configtelemetry.LevelNormal)
+	views := obsMetrics.Views
 	err := view.Register(views...)
 	if err != nil {
 		return nil, err

--- a/processor/batchprocessor/metrics.go
+++ b/processor/batchprocessor/metrics.go
@@ -19,11 +19,13 @@ import (
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
 
+	"go.opentelemetry.io/collector/internal/obsreportconfig"
+	"go.opentelemetry.io/collector/internal/obsreportconfig/obsmetrics"
 	"go.opentelemetry.io/collector/obsreport"
 )
 
 var (
-	processorTagKey          = tag.MustNewKey(obsreport.ProcessorKey)
+	processorTagKey          = tag.MustNewKey(obsmetrics.ProcessorKey)
 	statBatchSizeTriggerSend = stats.Int64("batch_size_trigger_send", "Number of times the batch was sent due to a size trigger", stats.UnitDimensionless)
 	statTimeoutTriggerSend   = stats.Int64("timeout_trigger_send", "Number of times the batch was sent due to a timeout trigger", stats.UnitDimensionless)
 	statBatchSendSize        = stats.Int64("batch_send_size", "Number of units in the batch", stats.UnitDimensionless)
@@ -68,12 +70,14 @@ func MetricViews() []*view.View {
 			1000_000, 2000_000, 3000_000, 4000_000, 5000_000, 6000_000, 7000_000, 8000_000, 9000_000),
 	}
 
-	legacyViews := []*view.View{
-		countBatchSizeTriggerSendView,
-		countTimeoutTriggerSendView,
-		distributionBatchSendSizeView,
-		distributionBatchSendSizeBytesView,
+	legacyViews := &obsreportconfig.ObsMetrics{
+		Views: []*view.View{
+			countBatchSizeTriggerSendView,
+			countTimeoutTriggerSendView,
+			distributionBatchSendSizeView,
+			distributionBatchSendSizeBytesView,
+		},
 	}
 
-	return obsreport.ProcessorMetricViews(typeStr, legacyViews)
+	return obsreport.ProcessorMetricViews(typeStr, legacyViews).Views
 }

--- a/processor/processorhelper/processor.go
+++ b/processor/processorhelper/processor.go
@@ -23,7 +23,7 @@ import (
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumerhelper"
-	"go.opentelemetry.io/collector/obsreport"
+	"go.opentelemetry.io/collector/internal/obsreportconfig/obsmetrics"
 )
 
 // ErrSkipProcessingData is a sentinel value to indicate when traces or metrics should intentionally be dropped
@@ -79,6 +79,6 @@ func fromOptions(options []Option) *baseSettings {
 
 func spanAttributes(id config.ComponentID) []trace.Attribute {
 	return []trace.Attribute{
-		trace.StringAttribute(obsreport.ProcessorKey, id.String()),
+		trace.StringAttribute(obsmetrics.ProcessorKey, id.String()),
 	}
 }

--- a/service/telemetry.go
+++ b/service/telemetry.go
@@ -27,7 +27,7 @@ import (
 	"go.opentelemetry.io/collector/config/configtelemetry"
 	"go.opentelemetry.io/collector/exporter/jaegerexporter"
 	"go.opentelemetry.io/collector/internal/collector/telemetry"
-	"go.opentelemetry.io/collector/obsreport"
+	"go.opentelemetry.io/collector/internal/obsreportconfig"
 	"go.opentelemetry.io/collector/processor/batchprocessor"
 	"go.opentelemetry.io/collector/receiver/kafkareceiver"
 	telemetry2 "go.opentelemetry.io/collector/service/internal/telemetry"
@@ -61,10 +61,11 @@ func (tel *appTelemetry) init(asyncErrorChannel chan<- error, ballastSizeBytes u
 	}
 
 	var views []*view.View
+	obsMetrics := obsreportconfig.Configure(level)
 	views = append(views, batchprocessor.MetricViews()...)
 	views = append(views, jaegerexporter.MetricViews()...)
 	views = append(views, kafkareceiver.MetricViews()...)
-	views = append(views, obsreport.Configure(level)...)
+	views = append(views, obsMetrics.Views...)
 	views = append(views, processMetricsViews.Views()...)
 
 	tel.views = views


### PR DESCRIPTION
**Description:**
Hide OpenCensus references from public APIs in `obsreport` and `obsreporttest` packages, there are 3 public APIs in `obsreport` are using OpenCensus View.

**Changes**
1. Moved `obsreport.Configure()` and `AllViews()` into internal folder `obsreportconfig` and made `AllViews` private, only keep the necessary telemetry APIs in `obsreport`. It helps to separate obsreport telemetry setup and collector telemetry reporting. Also, it hides the unnecessary public APIs.
2. Moved the OpenCensus metrics(`stats`) defines for each components into internal folder `obsreportconfig/obsmetrics` 

**TODO**
1. Remove `obsreport.ProcessorMetricViews`from the package and update it's consumer
2. update `contrib` package for above changes.

**Checklist,**
obsreport
 - [x] doc.go
 - [x] observability.go
 - [ ] obsreport.go
   * `func Configure(level configtelemetry.Level) (views []*view.View) {}`
   * `func AllViews() (views []*view.View) {}`
 - [x] obsreport_exporter.go
 - [ ] obsreport_processor.go
   * `func ProcessorMetricViews(configType string, legacyViews []*view.View) []*view.View {}`
 - [x] obsreport_receiver.go
 - [x] obsreport_scraper.go
 - [x] obsreport_test.go
 - obsreporttest
     - [x] obsreporttest.go
     - [x] obsreporttest_test.go

**Link to tracking Issue:** 
https://github.com/open-telemetry/opentelemetry-collector/issues/2648

**Testing:**
`make all`

