### PR TITLE
Upgrade build package machine

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -199,6 +199,7 @@ workflows:
             tags:
               only: /^v[0-9]+\.[0-9]+\.[0-9]+.*/
       - publish-check:
+          name: publish-check-main
           requires:
             - cross-compile
             - loadtest-with-github-reports
@@ -211,6 +212,7 @@ workflows:
             branches:
               only: main
       - publish-check:
+          name: publish-check-pr
           requires:
             - cross-compile
             - loadtest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -428,7 +428,7 @@ jobs:
 
   build-package:
     machine:
-      image: ubuntu-1604:202007-01
+      image: ubuntu-2004:202104-01
     parameters:
       package_type:
         type: enum


### PR DESCRIPTION
See https://circleci.com/docs/2.0/configuration-reference/#available-machine-images for the end of life of ubuntu-16-04

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
