### PR TITLE
Rename high-level interfaces to Marshaler/Unmarshaler

### DIFF
--- a/internal/model/marshaler.go
+++ b/internal/model/marshaler.go
@@ -22,21 +22,21 @@ import (
 	"go.opentelemetry.io/collector/internal/model/translator"
 )
 
-// TracesDecoder decodes bytes into pdata.Traces.
-type TracesDecoder struct {
-	translate translator.TracesDecoder
-	serialize serializer.TracesUnmarshaler
+// TracesMarshaler marshals pdata.Traces into bytes.
+type TracesMarshaler struct {
+	translate translator.TracesEncoder
+	serialize serializer.TracesMarshaler
 }
 
-// Decode bytes into pdata.Traces. On error pdata.Traces is invalid.
-func (t *TracesDecoder) Decode(buf []byte) (pdata.Traces, error) {
-	model, err := t.serialize.UnmarshalTraces(buf)
+// Marshal pdata.Traces into bytes. On error []byte is nil.
+func (t *TracesMarshaler) Marshal(td pdata.Traces) ([]byte, error) {
+	model, err := t.translate.EncodeTraces(td)
 	if err != nil {
-		return pdata.Traces{}, fmt.Errorf("unmarshal failed: %w", err)
+		return nil, fmt.Errorf("converting pdata to model failed: %w", err)
 	}
-	td, err := t.translate.DecodeTraces(model)
+	buf, err := t.serialize.MarshalTraces(model)
 	if err != nil {
-		return pdata.Traces{}, fmt.Errorf("converting model to pdata failed: %w", err)
+		return nil, fmt.Errorf("marshal failed: %w", err)
 	}
-	return td, nil
+	return buf, nil
 }

--- a/internal/model/marshaler_test.go
+++ b/internal/model/marshaler_test.go
@@ -27,7 +27,7 @@ func TestTracesEncoder_TranslationError(t *testing.T) {
 	translate := &mockTranslator{}
 	serialize := &mockSerializer{}
 
-	d := &TracesEncoder{
+	d := &TracesMarshaler{
 		translate: translate,
 		serialize: serialize,
 	}
@@ -36,7 +36,7 @@ func TestTracesEncoder_TranslationError(t *testing.T) {
 
 	translate.On("EncodeTraces", td).Return(nil, errors.New("translation failed"))
 
-	_, err := d.Encode(td)
+	_, err := d.Marshal(td)
 
 	assert.Error(t, err)
 	assert.EqualError(t, err, "converting pdata to model failed: translation failed")
@@ -46,7 +46,7 @@ func TestTracesEncoder_SerializeError(t *testing.T) {
 	translate := &mockTranslator{}
 	serialize := &mockSerializer{}
 
-	d := &TracesEncoder{
+	d := &TracesMarshaler{
 		translate: translate,
 		serialize: serialize,
 	}
@@ -57,7 +57,7 @@ func TestTracesEncoder_SerializeError(t *testing.T) {
 	translate.On("EncodeTraces", td).Return(expectedModel, nil)
 	serialize.On("MarshalTraces", expectedModel).Return(nil, errors.New("serialization failed"))
 
-	_, err := d.Encode(td)
+	_, err := d.Marshal(td)
 
 	assert.Error(t, err)
 	assert.EqualError(t, err, "marshal failed: serialization failed")
@@ -67,7 +67,7 @@ func TestTracesEncoder_Encode(t *testing.T) {
 	translate := &mockTranslator{}
 	serialize := &mockSerializer{}
 
-	d := &TracesEncoder{
+	d := &TracesMarshaler{
 		translate: translate,
 		serialize: serialize,
 	}
@@ -79,7 +79,7 @@ func TestTracesEncoder_Encode(t *testing.T) {
 	translate.On("EncodeTraces", expectedTraces).Return(expectedModel, nil)
 	serialize.On("MarshalTraces", expectedModel).Return(expectedBytes, nil)
 
-	actualBytes, err := d.Encode(expectedTraces)
+	actualBytes, err := d.Marshal(expectedTraces)
 
 	assert.NoError(t, err)
 	assert.Equal(t, expectedBytes, actualBytes)

--- a/internal/model/unmarshal.go
+++ b/internal/model/unmarshal.go
@@ -22,21 +22,21 @@ import (
 	"go.opentelemetry.io/collector/internal/model/translator"
 )
 
-// TracesEncoder encodes pdata.Traces into bytes.
-type TracesEncoder struct {
-	translate translator.TracesEncoder
-	serialize serializer.TracesMarshaler
+// TracesUnmarshaler unmarshalls bytes into pdata.Traces.
+type TracesUnmarshaler struct {
+	translate translator.TracesDecoder
+	serialize serializer.TracesUnmarshaler
 }
 
-// Encode pdata.Traces into bytes. On error []byte is nil.
-func (t *TracesEncoder) Encode(td pdata.Traces) ([]byte, error) {
-	model, err := t.translate.EncodeTraces(td)
+// Unmarshal bytes into pdata.Traces. On error pdata.Traces is invalid.
+func (t *TracesUnmarshaler) Unmarshal(buf []byte) (pdata.Traces, error) {
+	model, err := t.serialize.UnmarshalTraces(buf)
 	if err != nil {
-		return nil, fmt.Errorf("converting pdata to model failed: %w", err)
+		return pdata.Traces{}, fmt.Errorf("unmarshal failed: %w", err)
 	}
-	buf, err := t.serialize.MarshalTraces(model)
+	td, err := t.translate.DecodeTraces(model)
 	if err != nil {
-		return nil, fmt.Errorf("marshal failed: %w", err)
+		return pdata.Traces{}, fmt.Errorf("converting model to pdata failed: %w", err)
 	}
-	return buf, nil
+	return td, nil
 }

--- a/internal/model/unmarshal_test.go
+++ b/internal/model/unmarshal_test.go
@@ -27,7 +27,7 @@ func TestTracesDecoder_SerializeError(t *testing.T) {
 	translate := &mockTranslator{}
 	serialize := &mockSerializer{}
 
-	d := &TracesDecoder{
+	d := &TracesUnmarshaler{
 		translate: translate,
 		serialize: serialize,
 	}
@@ -37,7 +37,7 @@ func TestTracesDecoder_SerializeError(t *testing.T) {
 
 	serialize.On("UnmarshalTraces", expectedBytes).Return(expectedModel, errors.New("decode failed"))
 
-	_, err := d.Decode(expectedBytes)
+	_, err := d.Unmarshal(expectedBytes)
 
 	assert.Error(t, err)
 	assert.EqualError(t, err, "unmarshal failed: decode failed")
@@ -47,7 +47,7 @@ func TestTracesDecoder_TranslationError(t *testing.T) {
 	translate := &mockTranslator{}
 	serialize := &mockSerializer{}
 
-	d := &TracesDecoder{
+	d := &TracesUnmarshaler{
 		translate: translate,
 		serialize: serialize,
 	}
@@ -58,7 +58,7 @@ func TestTracesDecoder_TranslationError(t *testing.T) {
 	serialize.On("UnmarshalTraces", expectedBytes).Return(expectedModel, nil)
 	translate.On("DecodeTraces", expectedModel).Return(pdata.NewTraces(), errors.New("translation failed"))
 
-	_, err := d.Decode(expectedBytes)
+	_, err := d.Unmarshal(expectedBytes)
 
 	assert.Error(t, err)
 	assert.EqualError(t, err, "converting model to pdata failed: translation failed")
@@ -68,7 +68,7 @@ func TestTracesDecoder_Decode(t *testing.T) {
 	translate := &mockTranslator{}
 	serialize := &mockSerializer{}
 
-	d := &TracesDecoder{
+	d := &TracesUnmarshaler{
 		translate: translate,
 		serialize: serialize,
 	}
@@ -80,7 +80,7 @@ func TestTracesDecoder_Decode(t *testing.T) {
 	serialize.On("UnmarshalTraces", expectedBytes).Return(expectedModel, nil)
 	translate.On("DecodeTraces", expectedModel).Return(expectedTraces, nil)
 
-	actualTraces, err := d.Decode(expectedBytes)
+	actualTraces, err := d.Unmarshal(expectedBytes)
 
 	assert.NoError(t, err)
 	assert.Equal(t, expectedTraces, actualTraces)


### PR DESCRIPTION
Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
