### PR TITLE
Move file storage extension to core

### DIFF
--- a/extension/storage/Makefile
+++ b/extension/storage/Makefile
@@ -1,0 +1,1 @@
+include ../../Makefile.Common

--- a/extension/storage/README.md
+++ b/extension/storage/README.md
@@ -1,0 +1,16 @@
+# Storage
+
+A storage extension persists state beyond the collector process. Other components can request a storage client from the storage extension and use it to manage state. 
+
+The `storage.Extension` interface extends `component.Extension` by adding the following method:
+```
+GetClient(component.Kind, component.Kind, config.ComponentID) (Client, error)
+```
+
+The `storage.Client` interface contains the following methods:
+```
+Get(string) ([]byte, error)
+Set(string, []byte) error
+Delete(string) error
+```
+Note: All methods should return error only if a problem occurred. (For example, if a file is no longer accessible, or if a remote service is unavailable.)

--- a/extension/storage/doc.go
+++ b/extension/storage/doc.go
@@ -1,0 +1,17 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package stanzareceiver implements a receiver that can be used by the
+// Opentelemetry collector to receive logs using the stanza log agent
+package storage

--- a/extension/storage/filestorage/Makefile
+++ b/extension/storage/filestorage/Makefile
@@ -1,0 +1,1 @@
+include ../../Makefile.Common

--- a/extension/storage/filestorage/README.md
+++ b/extension/storage/filestorage/README.md
@@ -1,0 +1,36 @@
+# File Storage
+
+> :construction: This extension is in alpha. Configuration and functionality are subject to change.
+
+The File Storage extension can persist state to the local file system. 
+
+The extension requires read and write access to a directory. A default directory can be used, but it must already exist in order for the extension to operate.
+
+`directory` is the relative or absolute path to the dedicated data storage directory. 
+
+`timeout` is the maximum time to wait for a file lock. This value does not need to be modified in most circumstances.
+
+
+```
+extensions:
+  file_storage:
+  file_storage/all_settings:
+    directory: /var/lib/otelcol/mydir
+    timeout: 1s
+
+service:
+  extensions: [file_storage, file_storage/all_settings]
+  pipelines:
+    traces:
+      receivers: [nop]
+      processors: [nop]
+      exporters: [nop]
+
+# Data pipeline is required to load the config.
+receivers:
+  nop:
+processors:
+  nop:
+exporters:
+  nop:
+```

--- a/extension/storage/filestorage/client.go
+++ b/extension/storage/filestorage/client.go
@@ -1,0 +1,99 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filestorage
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"go.etcd.io/bbolt"
+)
+
+var defaultBucket = []byte(`default`)
+
+type fileStorageClient struct {
+	db *bbolt.DB
+}
+
+func newClient(filePath string, timeout time.Duration) (*fileStorageClient, error) {
+	options := &bbolt.Options{
+		Timeout: timeout,
+		NoSync:  true,
+	}
+	db, err := bbolt.Open(filePath, 0600, options)
+	if err != nil {
+		return nil, err
+	}
+
+	initBucket := func(tx *bbolt.Tx) error {
+		_, err := tx.CreateBucketIfNotExists(defaultBucket)
+		return err
+	}
+	if err := db.Update(initBucket); err != nil {
+		return nil, err
+	}
+
+	return &fileStorageClient{db}, nil
+}
+
+// Get will retrieve data from storage that corresponds to the specified key
+func (c *fileStorageClient) Get(_ context.Context, key string) ([]byte, error) {
+	var result []byte
+	get := func(tx *bbolt.Tx) error {
+		bucket := tx.Bucket(defaultBucket)
+		if bucket == nil {
+			return errors.New("storage not initialized")
+		}
+		result = bucket.Get([]byte(key))
+		return nil // no error
+	}
+
+	if err := c.db.Update(get); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// Set will store data. The data can be retrieved using the same key
+func (c *fileStorageClient) Set(_ context.Context, key string, value []byte) error {
+	set := func(tx *bbolt.Tx) error {
+		bucket := tx.Bucket(defaultBucket)
+		if bucket == nil {
+			return errors.New("storage not initialized")
+		}
+		return bucket.Put([]byte(key), value)
+	}
+
+	return c.db.Update(set)
+}
+
+// Delete will delete data associated with the specified key
+func (c *fileStorageClient) Delete(_ context.Context, key string) error {
+	delete := func(tx *bbolt.Tx) error {
+		bucket := tx.Bucket(defaultBucket)
+		if bucket == nil {
+			return errors.New("storage not initialized")
+		}
+		return bucket.Delete([]byte(key))
+	}
+
+	return c.db.Update(delete)
+}
+
+// Close will close the database
+func (c *fileStorageClient) close() error {
+	return c.db.Close()
+}

--- a/extension/storage/filestorage/client_test.go
+++ b/extension/storage/filestorage/client_test.go
@@ -1,0 +1,194 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filestorage
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.etcd.io/bbolt"
+)
+
+func TestClientOperations(t *testing.T) {
+	tempDir := newTempDir(t)
+	dbFile := filepath.Join(tempDir, "my_db")
+
+	client, err := newClient(dbFile, time.Second)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	testKey := "testKey"
+	testValue := []byte("testValue")
+
+	// Make sure nothing is there
+	value, err := client.Get(ctx, testKey)
+	require.NoError(t, err)
+	require.Nil(t, value)
+
+	// Set it
+	err = client.Set(ctx, testKey, testValue)
+	require.NoError(t, err)
+
+	// Get it back out, make sure it's right
+	value, err = client.Get(ctx, testKey)
+	require.NoError(t, err)
+	require.Equal(t, testValue, value)
+
+	// Delete it
+	err = client.Delete(ctx, testKey)
+	require.NoError(t, err)
+
+	// Make sure it's gone
+	value, err = client.Get(ctx, testKey)
+	require.NoError(t, err)
+	require.Nil(t, value)
+}
+
+func TestNewClientTransactionErrors(t *testing.T) {
+	timeout := 100 * time.Millisecond
+
+	testKey := "testKey"
+	testValue := []byte("testValue")
+
+	testCases := []struct {
+		name     string
+		setup    func(*bbolt.Tx) error
+		validate func(*testing.T, *fileStorageClient)
+	}{
+		{
+			name: "get",
+			setup: func(tx *bbolt.Tx) error {
+				return tx.DeleteBucket(defaultBucket)
+			},
+			validate: func(t *testing.T, c *fileStorageClient) {
+				value, err := c.Get(context.Background(), testKey)
+				require.Error(t, err)
+				require.Equal(t, "storage not initialized", err.Error())
+				require.Nil(t, value)
+			},
+		},
+		{
+			name: "set",
+			setup: func(tx *bbolt.Tx) error {
+				return tx.DeleteBucket(defaultBucket)
+			},
+			validate: func(t *testing.T, c *fileStorageClient) {
+				err := c.Set(context.Background(), testKey, testValue)
+				require.Error(t, err)
+				require.Equal(t, "storage not initialized", err.Error())
+			},
+		},
+		{
+			name: "delete",
+			setup: func(tx *bbolt.Tx) error {
+				return tx.DeleteBucket(defaultBucket)
+			},
+			validate: func(t *testing.T, c *fileStorageClient) {
+				err := c.Delete(context.Background(), testKey)
+				require.Error(t, err)
+				require.Equal(t, "storage not initialized", err.Error())
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			tempDir := newTempDir(t)
+			dbFile := filepath.Join(tempDir, "my_db")
+
+			client, err := newClient(dbFile, timeout)
+			require.NoError(t, err)
+
+			// Create a problem
+			client.db.Update(tc.setup)
+
+			// Validate expected behavior
+			tc.validate(t, client)
+		})
+	}
+}
+
+func TestNewClientErrorsOnInvalidBucket(t *testing.T) {
+	temp := defaultBucket
+	defaultBucket = nil
+
+	tempDir := newTempDir(t)
+	dbFile := filepath.Join(tempDir, "my_db")
+
+	client, err := newClient(dbFile, time.Second)
+	require.Error(t, err)
+	require.Nil(t, client)
+
+	defaultBucket = temp
+}
+
+func BenchmarkClientGet(b *testing.B) {
+	tempDir := newTempDir(b)
+	dbFile := filepath.Join(tempDir, "my_db")
+
+	client, err := newClient(dbFile, time.Second)
+	require.NoError(b, err)
+
+	ctx := context.Background()
+	testKey := "testKey"
+
+	for n := 0; n < b.N; n++ {
+		client.Get(ctx, testKey)
+	}
+}
+
+func BenchmarkClientSet(b *testing.B) {
+	tempDir := newTempDir(b)
+	dbFile := filepath.Join(tempDir, "my_db")
+
+	client, err := newClient(dbFile, time.Second)
+	require.NoError(b, err)
+
+	ctx := context.Background()
+	testKey := "testKey"
+	testValue := []byte("testValue")
+
+	for n := 0; n < b.N; n++ {
+		client.Set(ctx, testKey, testValue)
+	}
+}
+
+func BenchmarkClientDelete(b *testing.B) {
+	tempDir := newTempDir(b)
+	dbFile := filepath.Join(tempDir, "my_db")
+
+	client, err := newClient(dbFile, time.Second)
+	require.NoError(b, err)
+
+	ctx := context.Background()
+	testKey := "testKey"
+
+	for n := 0; n < b.N; n++ {
+		client.Delete(ctx, testKey)
+	}
+}
+
+func newTempDir(tb testing.TB) string {
+	tempDir, err := ioutil.TempDir("", "")
+	require.NoError(tb, err)
+	tb.Cleanup(func() { os.RemoveAll(tempDir) })
+	return tempDir
+}

--- a/extension/storage/filestorage/config.go
+++ b/extension/storage/filestorage/config.go
@@ -1,0 +1,29 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filestorage
+
+import (
+	"time"
+
+	"go.opentelemetry.io/collector/config"
+)
+
+// Config defines configuration for http forwarder extension.
+type Config struct {
+	config.ExtensionSettings `mapstructure:",squash"`
+
+	Directory string        `mapstructure:"directory,omitempty"`
+	Timeout   time.Duration `mapstructure:"timeout,omitempty"`
+}

--- a/extension/storage/filestorage/config_test.go
+++ b/extension/storage/filestorage/config_test.go
@@ -1,0 +1,54 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filestorage
+
+import (
+	"path"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/config/configtest"
+)
+
+func TestLoadConfig(t *testing.T) {
+	factories, err := componenttest.NopFactories()
+	assert.NoError(t, err)
+
+	factory := NewFactory()
+	factories.Extensions[typeStr] = factory
+	cfg, err := configtest.LoadConfigFile(t, path.Join(".", "testdata", "config.yaml"), factories)
+
+	require.Nil(t, err)
+	require.NotNil(t, cfg)
+
+	require.Len(t, cfg.Extensions, 2)
+
+	ext0 := cfg.Extensions[config.NewID(typeStr)]
+	assert.Equal(t, factory.CreateDefaultConfig(), ext0)
+
+	ext1 := cfg.Extensions[config.NewIDWithName(typeStr, "all_settings")]
+	assert.Equal(t,
+		&Config{
+			ExtensionSettings: config.NewExtensionSettings(config.NewIDWithName(typeStr, "all_settings")),
+			Directory:         "/var/lib/otelcol/mydir",
+			Timeout:           2 * time.Second,
+		},
+		ext1)
+}

--- a/extension/storage/filestorage/default_others.go
+++ b/extension/storage/filestorage/default_others.go
@@ -1,0 +1,21 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !windows
+
+package filestorage
+
+func getDefaultDirectory() string {
+	return "/var/lib/otelcol/file_storage"
+}

--- a/extension/storage/filestorage/default_windows.go
+++ b/extension/storage/filestorage/default_windows.go
@@ -1,0 +1,26 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build windows
+
+package filestorage
+
+import (
+	"os"
+	"path/filepath"
+)
+
+func getDefaultDirectory() string {
+	return filepath.Join(os.Getenv("ProgramData"), "Otelcol", "FileStorage")
+}

--- a/extension/storage/filestorage/extension.go
+++ b/extension/storage/filestorage/extension.go
@@ -1,0 +1,97 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filestorage
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"go.uber.org/zap"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/extension/storage"
+)
+
+type localFileStorage struct {
+	directory string
+	timeout   time.Duration
+	logger    *zap.Logger
+	clients   []*fileStorageClient
+}
+
+// Ensure this storage extension implements the appropriate interface
+var _ storage.Extension = (*localFileStorage)(nil)
+
+func newLocalFileStorage(logger *zap.Logger, config *Config) (component.Extension, error) {
+	info, err := os.Stat(config.Directory)
+	if (err != nil && os.IsNotExist(err)) || !info.IsDir() {
+		return nil, fmt.Errorf("directory must exist: %v", err)
+	}
+
+	return &localFileStorage{
+		directory: filepath.Clean(config.Directory),
+		timeout:   config.Timeout,
+		logger:    logger,
+		clients:   []*fileStorageClient{},
+	}, nil
+}
+
+// Start does nothing
+func (lfs *localFileStorage) Start(context.Context, component.Host) error {
+	return nil
+}
+
+// Shutdown will close any open databases
+func (lfs *localFileStorage) Shutdown(context.Context) error {
+	for _, client := range lfs.clients {
+		client.close()
+	}
+	// TODO clean up data files that did not have a client
+	// and are older than a threshold (possibly configurable)
+	return nil
+}
+
+// GetClient returns a storage client for an individual component
+func (lfs *localFileStorage) GetClient(ctx context.Context, kind component.Kind, ent config.ComponentID) (storage.Client, error) {
+	rawName := fmt.Sprintf("%s_%s_%s", kindString(kind), ent.Type(), ent.Name())
+	// TODO sanitize rawName
+	absoluteName := filepath.Join(lfs.directory, rawName)
+
+	client, err := newClient(absoluteName, lfs.timeout)
+	if err != nil {
+		return nil, fmt.Errorf("create client: %v", err)
+	}
+	lfs.clients = append(lfs.clients, client)
+	return client, nil
+}
+
+func kindString(k component.Kind) string {
+	switch k {
+	case component.KindReceiver:
+		return "receiver"
+	case component.KindProcessor:
+		return "processor"
+	case component.KindExporter:
+		return "exporter"
+	case component.KindExtension:
+		return "extension"
+	default:
+		return "other" // not expected
+	}
+}

--- a/extension/storage/filestorage/extension_test.go
+++ b/extension/storage/filestorage/extension_test.go
@@ -1,0 +1,245 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filestorage
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/extension/storage"
+)
+
+func TestExtensionIntegrity(t *testing.T) {
+	ctx := context.Background()
+	se := newTestExtension(t)
+
+	type mockComponent struct {
+		kind component.Kind
+		name config.ComponentID
+	}
+
+	components := []mockComponent{
+		{kind: component.KindReceiver, name: newTestEntity("receiver_one")},
+		{kind: component.KindReceiver, name: newTestEntity("receiver_two")},
+		{kind: component.KindProcessor, name: newTestEntity("processor_one")},
+		{kind: component.KindProcessor, name: newTestEntity("processor_two")},
+		{kind: component.KindExporter, name: newTestEntity("exporter_one")},
+		{kind: component.KindExporter, name: newTestEntity("exporter_two")},
+		{kind: component.KindExtension, name: newTestEntity("extension_one")},
+		{kind: component.KindExtension, name: newTestEntity("extension_two")},
+	}
+
+	// Make a client for each component
+	clients := make(map[config.ComponentID]storage.Client)
+	for _, c := range components {
+		client, err := se.GetClient(ctx, c.kind, c.name)
+		require.NoError(t, err)
+		clients[c.name] = client
+	}
+
+	thrashClient := func(wg *sync.WaitGroup, n config.ComponentID, c storage.Client) {
+		// keys and values
+		keys := []string{"a", "b", "c", "d", "e"}
+		myBytes := []byte(n.Name())
+
+		// Set my values
+		for i := 0; i < len(keys); i++ {
+			err := c.Set(ctx, keys[i], myBytes)
+			require.NoError(t, err)
+		}
+
+		// Repeatedly thrash client
+		for j := 0; j < 100; j++ {
+
+			// Make sure my values are still mine
+			for i := 0; i < len(keys); i++ {
+				v, err := c.Get(ctx, keys[i])
+				require.NoError(t, err)
+				require.Equal(t, myBytes, v)
+			}
+
+			// Delete my values
+			for i := 0; i < len(keys); i++ {
+				err := c.Delete(ctx, keys[i])
+				require.NoError(t, err)
+			}
+
+			// Reset my values
+			for i := 0; i < len(keys); i++ {
+				err := c.Set(ctx, keys[i], myBytes)
+				require.NoError(t, err)
+			}
+		}
+		wg.Done()
+	}
+
+	// Use clients concurrently
+	var wg sync.WaitGroup
+	for name, client := range clients {
+		wg.Add(1)
+		go thrashClient(&wg, name, client)
+	}
+	wg.Wait()
+}
+
+func TestShutdownClosesClients(t *testing.T) {
+	ctx := context.Background()
+	se := newTestExtension(t)
+
+	myReceiverClient, err := se.GetClient(
+		ctx,
+		component.KindReceiver,
+		newTestEntity("my_receiver"),
+	)
+	require.NoError(t, err)
+	err = myReceiverClient.Set(ctx, "key", []byte("value"))
+	require.NoError(t, err)
+
+	myExporterClient, err := se.GetClient(
+		ctx,
+		component.KindReceiver,
+		newTestEntity("my_exporter"),
+	)
+	require.NoError(t, err)
+	err = myExporterClient.Set(ctx, "key", []byte("value"))
+	require.NoError(t, err)
+
+	// Shutdown should close clients
+	require.NoError(t, se.Shutdown(ctx))
+
+	err = myReceiverClient.Set(ctx, "key", []byte("value"))
+	require.Error(t, err)
+	require.Equal(t, err.Error(), "database not open")
+
+	err = myExporterClient.Set(ctx, "key", []byte("value"))
+	require.Error(t, err)
+	require.Equal(t, err.Error(), "database not open")
+}
+
+func TestClientHandlesSimpleCases(t *testing.T) {
+	ctx := context.Background()
+	se := newTestExtension(t)
+
+	client, err := se.GetClient(
+		ctx,
+		component.KindReceiver,
+		newTestEntity("my_component"),
+	)
+
+	myBytes := []byte("value")
+	require.NoError(t, err)
+
+	// Set the data
+	err = client.Set(ctx, "key", myBytes)
+	require.NoError(t, err)
+
+	// Set it again (nop does not error)
+	err = client.Set(ctx, "key", myBytes)
+	require.NoError(t, err)
+
+	// Get actual data
+	data, err := client.Get(ctx, "key")
+	require.NoError(t, err)
+	require.Equal(t, myBytes, data)
+
+	// Delete the data
+	err = client.Delete(ctx, "key")
+	require.NoError(t, err)
+
+	// Delete it again (nop does not error)
+	err = client.Delete(ctx, "key")
+	require.NoError(t, err)
+
+	// Get missing data
+	data, err = client.Get(ctx, "key")
+	require.NoError(t, err)
+	require.Nil(t, data)
+
+}
+
+func TestNewExtensionErrorsOnMissingDirectory(t *testing.T) {
+	f := NewFactory()
+	cfg := f.CreateDefaultConfig().(*Config)
+	cfg.Directory = "/not/a/dir"
+
+	params := component.ExtensionCreateParams{Logger: zaptest.NewLogger(t)}
+
+	extension, err := f.CreateExtension(context.Background(), params, cfg)
+	require.Error(t, err)
+	require.Nil(t, extension)
+}
+
+func TestGetClientErrorsOnDeletedDirectory(t *testing.T) {
+	ctx := context.Background()
+
+	tempDir, err := ioutil.TempDir("", "")
+	require.NoError(t, err)
+
+	f := NewFactory()
+	cfg := f.CreateDefaultConfig().(*Config)
+	cfg.Directory = tempDir
+
+	params := component.ExtensionCreateParams{Logger: zaptest.NewLogger(t)}
+
+	extension, err := f.CreateExtension(context.Background(), params, cfg)
+	require.NoError(t, err)
+
+	se, ok := extension.(storage.Extension)
+	require.True(t, ok)
+
+	// Delete the directory before getting client
+	err = os.RemoveAll(tempDir)
+	require.NoError(t, err)
+
+	client, err := se.GetClient(
+		ctx,
+		component.KindReceiver,
+		newTestEntity("my_component"),
+	)
+
+	require.Error(t, err)
+	require.Nil(t, client)
+}
+
+func newTestExtension(t *testing.T) storage.Extension {
+	tempDir, err := ioutil.TempDir("", "")
+	require.NoError(t, err)
+
+	f := NewFactory()
+	cfg := f.CreateDefaultConfig().(*Config)
+	cfg.Directory = tempDir
+
+	params := component.ExtensionCreateParams{Logger: zaptest.NewLogger(t)}
+
+	extension, err := f.CreateExtension(context.Background(), params, cfg)
+	require.NoError(t, err)
+
+	se, ok := extension.(storage.Extension)
+	require.True(t, ok)
+
+	return se
+}
+
+func newTestEntity(name string) config.ComponentID {
+	return config.NewIDWithName("nop", name)
+}

--- a/extension/storage/filestorage/factory.go
+++ b/extension/storage/filestorage/factory.go
@@ -1,0 +1,51 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filestorage
+
+import (
+	"context"
+	"time"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/extension/extensionhelper"
+)
+
+// The value of extension "type" in configuration.
+const typeStr config.Type = "file_storage"
+
+// NewFactory creates a factory for HostObserver extension.
+func NewFactory() component.ExtensionFactory {
+	return extensionhelper.NewFactory(
+		typeStr,
+		createDefaultConfig,
+		createExtension)
+}
+
+func createDefaultConfig() config.Extension {
+	return &Config{
+		ExtensionSettings: config.NewExtensionSettings(config.NewID(typeStr)),
+		Directory:         getDefaultDirectory(),
+		Timeout:           time.Second,
+	}
+}
+
+func createExtension(
+	_ context.Context,
+	params component.ExtensionCreateParams,
+	cfg config.Extension,
+) (component.Extension, error) {
+	return newLocalFileStorage(params.Logger, cfg.(*Config))
+}

--- a/extension/storage/filestorage/factory_test.go
+++ b/extension/storage/filestorage/factory_test.go
@@ -1,0 +1,105 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filestorage
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/config"
+)
+
+func TestFactory(t *testing.T) {
+	f := NewFactory()
+	require.Equal(t, typeStr, f.Type())
+
+	cfg := f.CreateDefaultConfig().(*Config)
+	require.Equal(t, config.NewID(typeStr), cfg.ID())
+
+	if runtime.GOOS != "windows" {
+		require.Equal(t, "/var/lib/otelcol/file_storage", cfg.Directory)
+	} else {
+		expected := filepath.Join(os.Getenv("ProgramData"), "Otelcol", "FileStorage")
+		require.Equal(t, expected, cfg.Directory)
+	}
+	require.Equal(t, time.Second, cfg.Timeout)
+
+	tests := []struct {
+		name           string
+		config         *Config
+		wantErr        bool
+		wantErrMessage string
+	}{
+		{
+			name:           "Default",
+			config:         cfg,
+			wantErr:        true,
+			wantErrMessage: "directory must exist",
+		},
+		{
+			name: "Invalid directory",
+			config: &Config{
+				Directory: "/not/very/likely/a/real/dir",
+			},
+			wantErr:        true,
+			wantErrMessage: "directory must exist",
+		},
+		{
+			name: "Default",
+			config: func() *Config {
+				tempDir, _ := ioutil.TempDir("", "")
+				return &Config{
+					Directory: tempDir,
+				}
+			}(),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			e, err := f.CreateExtension(
+				context.Background(),
+				component.ExtensionCreateParams{
+					Logger: zap.NewNop(),
+				},
+				test.config,
+			)
+			if test.wantErr {
+				if test.wantErrMessage != "" {
+					require.True(t, strings.HasPrefix(err.Error(), test.wantErrMessage))
+				}
+				require.Error(t, err)
+				require.Nil(t, e)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, e)
+				ctx := context.Background()
+				require.NoError(t, e.Start(ctx, componenttest.NewNopHost()))
+				require.NoError(t, e.Shutdown(ctx))
+			}
+		})
+	}
+}

--- a/extension/storage/filestorage/testdata/config.yaml
+++ b/extension/storage/filestorage/testdata/config.yaml
@@ -1,0 +1,21 @@
+extensions:
+  file_storage:
+  file_storage/all_settings:
+    directory: /var/lib/otelcol/mydir
+    timeout: 2s
+
+service:
+  extensions: [file_storage, file_storage/all_settings]
+  pipelines:
+    traces:
+      receivers: [nop]
+      processors: [nop]
+      exporters: [nop]
+
+# Data pipeline is required to load the config.
+receivers:
+  nop:
+processors:
+  nop:
+exporters:
+  nop:

--- a/extension/storage/nop_client.go
+++ b/extension/storage/nop_client.go
@@ -1,0 +1,46 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import "context"
+
+type nopClient struct{}
+
+var nopClientInstance Client = &nopClient{}
+
+// NewNopClient returns a nop client
+func NewNopClient() Client {
+	return nopClientInstance
+}
+
+// Get does nothing, and returns nil, nil
+func (c nopClient) Get(context.Context, string) ([]byte, error) {
+	return nil, nil // no result, but no problem
+}
+
+// Set does nothing and returns nil
+func (c nopClient) Set(context.Context, string, []byte) error {
+	return nil // no problem
+}
+
+// Delete does nothing and returns nil
+func (c nopClient) Delete(context.Context, string) error {
+	return nil // no problem
+}
+
+// Close does nothing and returns nil
+func (c nopClient) Close(context.Context) error {
+	return nil
+}

--- a/extension/storage/storage.go
+++ b/extension/storage/storage.go
@@ -1,0 +1,53 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"context"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config"
+)
+
+// Extension is the interface that storage extensions must implement
+type Extension interface {
+	component.Extension
+
+	// GetClient will create a client for use by the specified component.
+	// The component can use the client to manage state
+	GetClient(context.Context, component.Kind, config.ComponentID) (Client, error)
+}
+
+// Client is the interface that storage clients must implement
+// All methods should return error only if a problem occurred.
+// This mirrors the behavior of a golang map:
+//   - Set doesn't error if a key already exists - it just overwrites the value.
+//   - Get doesn't error if a key is not found - it just returns nil.
+//   - Delete doesn't error if the key doesn't exist - it just no-ops.
+// This also provides a way to differentiate data operations
+//   [overwrite | not-found | no-op] from "real" problems
+type Client interface {
+
+	// Get will retrieve data from storage that corresponds to the
+	// specified key. It should return nil, nil if not found
+	Get(context.Context, string) ([]byte, error)
+
+	// Set will store data. The data can be retrieved by the same
+	// component after a process restart, using the same key
+	Set(context.Context, string, []byte) error
+
+	// Delete will delete data associated with the specified key
+	Delete(context.Context, string) error
+}

--- a/extension/storage/storagetest/Makefile
+++ b/extension/storage/storagetest/Makefile
@@ -1,0 +1,1 @@
+include ../../../Makefile.Common

--- a/extension/storage/storagetest/doc.go
+++ b/extension/storage/storagetest/doc.go
@@ -1,0 +1,17 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package stanzareceiver implements a receiver that can be used by the
+// Opentelemetry collector to receive logs using the stanza log agent
+package storagetest

--- a/extension/storage/storagetest/storage.go
+++ b/extension/storage/storagetest/storage.go
@@ -1,0 +1,63 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storagetest
+
+import (
+	"context"
+	"testing"
+
+	"go.uber.org/zap/zaptest"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/extension/storage"
+	"go.opentelemetry.io/collector/extension/storage/filestorage"
+)
+
+type StorageHost struct {
+	component.Host
+	extensions map[config.ComponentID]component.Extension
+}
+
+func (h StorageHost) GetExtensions() map[config.ComponentID]component.Extension {
+	return h.extensions
+}
+
+func NewStorageHost(t *testing.T, directory string, extensionNames ...string) StorageHost {
+	h := StorageHost{
+		Host:       componenttest.NewNopHost(),
+		extensions: make(map[config.ComponentID]component.Extension),
+	}
+
+	for _, name := range extensionNames {
+		h.extensions[newTestEntity(name)] = NewTestExtension(t, directory)
+	}
+	return h
+}
+
+func NewTestExtension(t *testing.T, directory string) storage.Extension {
+	f := filestorage.NewFactory()
+	cfg := f.CreateDefaultConfig().(*filestorage.Config)
+	cfg.Directory = directory
+	params := component.ExtensionCreateParams{Logger: zaptest.NewLogger(t)}
+	extension, _ := f.CreateExtension(context.Background(), params, cfg)
+	se, _ := extension.(storage.Extension)
+	return se
+}
+
+func newTestEntity(name string) config.ComponentID {
+	return config.NewIDWithName("nop", name)
+}

--- a/extension/storage/storagetest/storage_test.go
+++ b/extension/storage/storagetest/storage_test.go
@@ -1,0 +1,38 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storagetest
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewStorageHost(t *testing.T) {
+	host := NewStorageHost(t, newTempDir(t), "test")
+	require.Equal(t, 1, len(host.GetExtensions()))
+
+	hostWithTwo := NewStorageHost(t, newTempDir(t), "one", "two")
+	require.Equal(t, 2, len(hostWithTwo.GetExtensions()))
+}
+
+func newTempDir(tb testing.TB) string {
+	tempDir, err := ioutil.TempDir("", "")
+	require.NoError(tb, err)
+	tb.Cleanup(func() { os.RemoveAll(tempDir) })
+	return tempDir
+}

--- a/go.mod
+++ b/go.mod
@@ -37,9 +37,10 @@ require (
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/viper v1.7.1
 	github.com/stretchr/testify v1.7.0
-	github.com/tklauser/go-sysconf v0.3.5 // indirect
+	github.com/tklauser/go-sysconf v0.3.6 // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible
 	github.com/xdg-go/scram v0.0.0-20180814205039-7eeb5667e42c
+	go.etcd.io/bbolt v1.3.4
 	go.opencensus.io v0.23.0
 	go.uber.org/atomic v1.7.0
 	go.uber.org/zap v1.16.0

--- a/go.sum
+++ b/go.sum
@@ -976,8 +976,8 @@ github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tinylib/msgp v1.0.2/go.mod h1:+d+yLhGm8mzTaHzB+wgMYrodPfmZrzkirds8fDWklFE=
-github.com/tklauser/go-sysconf v0.3.5 h1:uu3Xl4nkLzQfXNsWn15rPc/HQCJKObbt1dKJeWp3vU4=
-github.com/tklauser/go-sysconf v0.3.5/go.mod h1:MkWzOF4RMCshBAMXuhXJs64Rte09mITnppBXY/rYEFI=
+github.com/tklauser/go-sysconf v0.3.6 h1:oc1sJWvKkmvIxhDHeKWvZS4f6AW+YcoguSfRF2/Hmo4=
+github.com/tklauser/go-sysconf v0.3.6/go.mod h1:MkWzOF4RMCshBAMXuhXJs64Rte09mITnppBXY/rYEFI=
 github.com/tklauser/numcpus v0.2.2 h1:oyhllyrScuYI6g+h/zUvNXNp1wy7x8qQy3t/piefldA=
 github.com/tklauser/numcpus v0.2.2/go.mod h1:x3qojaO3uyYt0i56EW/VUYs7uBvdl2fkfZFu0T9wgjM=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
@@ -1014,6 +1014,8 @@ github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
+go.etcd.io/bbolt v1.3.4 h1:hi1bXHMVrlQh6WwxAy+qZCV/SYIlqo+Ushwdpa4tAKg=
+go.etcd.io/bbolt v1.3.4/go.mod h1:G5EMThwa9y8QZGBClrRx5EY+Yw9kAhnjy3bSjsnlVTQ=
 go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738/go.mod h1:dnLIgRNXwCJa5e+c6mIZCrds/GIG4ncV9HhK5PX7jPg=
 go.mongodb.org/mongo-driver v1.0.3/go.mod h1:u7ryQJ+DOzQmeO7zB6MHyr8jkEQvC8vH7qLUO4lqsUM=
 go.mongodb.org/mongo-driver v1.1.1/go.mod h1:u7ryQJ+DOzQmeO7zB6MHyr8jkEQvC8vH7qLUO4lqsUM=

--- a/service/defaultcomponents/default_extensions_test.go
+++ b/service/defaultcomponents/default_extensions_test.go
@@ -16,6 +16,8 @@ package defaultcomponents
 
 import (
 	"context"
+	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -28,6 +30,7 @@ import (
 	"go.opentelemetry.io/collector/extension/bearertokenauthextension"
 	"go.opentelemetry.io/collector/extension/healthcheckextension"
 	"go.opentelemetry.io/collector/extension/pprofextension"
+	"go.opentelemetry.io/collector/extension/storage/filestorage"
 	"go.opentelemetry.io/collector/extension/zpagesextension"
 	"go.opentelemetry.io/collector/testutil"
 )
@@ -38,11 +41,21 @@ func TestDefaultExtensions(t *testing.T) {
 
 	extFactories := allFactories.Extensions
 	endpoint := testutil.GetAvailableLocalAddress(t)
+	tempDir, _ := ioutil.TempDir("", "")
+	defer os.RemoveAll(tempDir)
 
 	tests := []struct {
 		extension   config.Type
 		getConfigFn getExtensionConfigFn
 	}{
+		{
+			extension: "file_storage",
+			getConfigFn: func() config.Extension {
+				cfg := extFactories["file_storage"].CreateDefaultConfig().(*filestorage.Config)
+				cfg.Directory = tempDir
+				return cfg
+			},
+		},
 		{
 			extension: "health_check",
 			getConfigFn: func() config.Extension {

--- a/service/defaultcomponents/defaults.go
+++ b/service/defaultcomponents/defaults.go
@@ -32,6 +32,7 @@ import (
 	"go.opentelemetry.io/collector/extension/bearertokenauthextension"
 	"go.opentelemetry.io/collector/extension/healthcheckextension"
 	"go.opentelemetry.io/collector/extension/pprofextension"
+	"go.opentelemetry.io/collector/extension/storage/filestorage"
 	"go.opentelemetry.io/collector/extension/zpagesextension"
 	"go.opentelemetry.io/collector/processor/attributesprocessor"
 	"go.opentelemetry.io/collector/processor/batchprocessor"
@@ -63,6 +64,7 @@ func Components() (
 		healthcheckextension.NewFactory(),
 		pprofextension.NewFactory(),
 		zpagesextension.NewFactory(),
+		filestorage.NewFactory(),
 	)
 	if err != nil {
 		errs = append(errs, err)


### PR DESCRIPTION
**Description:**

This is a copy of [file storage extension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/storage/filestorage) moved into the core, which might be required for file-storage extension backed WAL implementation