### PR TITLE
Persistent storage in queued_retry, backed by file storage extension

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,7 +114,7 @@ jobs:
       - attach_to_workspace
       - run:
           name: Build collector for all archs
-          command: grep ^binaries-all-sys Makefile|fmt -w 1|tail -n +2|circleci tests split|xargs make
+          command: grep ^binaries-all-sys Makefile|fmt -w 1|grep -v binaries-all-sys|circleci tests split|xargs make
       - run:
           name: Log checksums to console
           command: shasum -a 256 bin/*

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -167,3 +167,13 @@ jobs:
         with:
           name: collector-binaries
           path: ./bin.tar
+      - name: Build Unstable Collector for All Architectures
+        run: make binaries-all-sys-unstable
+      - name: Create Unstable Collector Binaries Archive
+        run: tar -cvf bin-unstable.tar ./bin/*unstable
+      - name: Upload Unstable Collector Binaries
+        uses: actions/upload-artifact@v2.2.4
+        with:
+          name: collector-binaries-unstable
+          path: ./bin-unstable.tar
+

--- a/Makefile
+++ b/Makefile
@@ -241,9 +241,9 @@ binaries-linux_arm64:
 binaries-windows_amd64:
 	GOOS=windows GOARCH=amd64 EXTENSION=.exe $(MAKE) build-binary-internal
 
-.PHONY: binaries-darwin_amd64
-binaries-darwin_amd64:
-	GOOS=darwin  GOARCH=amd64 $(MAKE) build-binary-internal
+.PHONY: binaries-darwin_amd64-unstable
+binaries-darwin_amd64-unstable:
+	GOOS=darwin  GOARCH=amd64 $(MAKE) build-binary-internal-unstable
 
 .PHONY: binaries-darwin_arm64-unstable
 binaries-darwin_arm64-unstable:

--- a/Makefile
+++ b/Makefile
@@ -218,6 +218,9 @@ docker-otelcol:
 .PHONY: binaries-all-sys
 binaries-all-sys: binaries-darwin_amd64 binaries-darwin_arm64 binaries-linux_amd64 binaries-linux_arm64 binaries-windows_amd64
 
+.PHONY: binaries-all-sys-unstable
+binaries-all-sys-unstable: binaries-darwin_amd64-unstable binaries-darwin_arm64-unstable binaries-linux_amd64-unstable binaries-linux_arm64-unstable binaries-windows_amd64-unstable
+
 .PHONY: binaries-darwin_amd64
 binaries-darwin_amd64:
 	GOOS=darwin  GOARCH=amd64 $(MAKE) build-binary-internal
@@ -237,6 +240,26 @@ binaries-linux_arm64:
 .PHONY: binaries-windows_amd64
 binaries-windows_amd64:
 	GOOS=windows GOARCH=amd64 EXTENSION=.exe $(MAKE) build-binary-internal
+
+.PHONY: binaries-darwin_amd64
+binaries-darwin_amd64:
+	GOOS=darwin  GOARCH=amd64 $(MAKE) build-binary-internal
+
+.PHONY: binaries-darwin_arm64-unstable
+binaries-darwin_arm64-unstable:
+	GOOS=darwin  GOARCH=arm64 $(MAKE) build-binary-internal-unstable
+
+.PHONY: binaries-linux_amd64-unstable
+binaries-linux_amd64-unstable:
+	GOOS=linux   GOARCH=amd64 $(MAKE) build-binary-internal-unstable
+
+.PHONY: binaries-linux_arm64-unstable
+binaries-linux_arm64-unstable:
+	GOOS=linux   GOARCH=arm64 $(MAKE) build-binary-internal-unstable
+
+.PHONY: binaries-windows_amd64-unstable
+binaries-windows_amd64-unstable:
+	GOOS=windows GOARCH=amd64 EXTENSION=.exe $(MAKE) build-binary-internal-unstable
 
 .PHONY: build-binary-internal
 build-binary-internal:

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ gotestinstall:
 
 .PHONY: gotest
 gotest:
-	@$(MAKE) for-all CMD="make test"
+	@$(MAKE) for-all CMD="make test test-unstable"
 
 .PHONY: gobenchmark
 gobenchmark:
@@ -81,7 +81,7 @@ gotest-with-cover:
 
 .PHONY: golint
 golint:
-	@$(MAKE) for-all CMD="make lint"
+	@$(MAKE) for-all CMD="make lint lint-unstable"
 
 .PHONY: goimpi
 goimpi:
@@ -147,6 +147,11 @@ install-tools:
 otelcol:
 	go generate ./...
 	$(MAKE) build-binary-internal
+
+.PHONY: otelcol-unstable
+otelcol-unstable:
+	go generate ./...
+	$(MAKE) build-binary-internal-unstable
 
 .PHONY: run
 run:
@@ -236,6 +241,10 @@ binaries-windows_amd64:
 .PHONY: build-binary-internal
 build-binary-internal:
 	GO111MODULE=on CGO_ENABLED=0 go build -trimpath -o ./bin/otelcol_$(GOOS)_$(GOARCH)$(EXTENSION) $(BUILD_INFO) ./cmd/otelcol
+
+.PHONY: build-binary-internal-unstable
+build-binary-internal-unstable:
+	GO111MODULE=on CGO_ENABLED=0 go build -trimpath -o ./bin/otelcol_$(GOOS)_$(GOARCH)$(EXTENSION)_unstable $(BUILD_INFO) -tags enable_unstable ./cmd/otelcol
 
 .PHONY: deb-rpm-package
 %-package: ARCH ?= amd64

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -12,6 +12,10 @@ IMPI=impi
 test:
 	@echo $(ALL_PKGS) | xargs -n 10 $(GOTEST) $(GOTEST_OPT)
 
+.PHONY: test-unstable
+test-unstable:
+	@echo $(ALL_PKGS) | xargs -n 10 $(GOTEST) $(GOTEST_OPT) -tags enable_unstable
+
 .PHONY: benchmark
 benchmark:
 	$(GOTEST) -bench=. -run=notests ./...
@@ -24,6 +28,10 @@ fmt:
 .PHONY: lint
 lint:
 	$(LINT) run --allow-parallel-runners
+
+.PHONY: lint-unstable
+lint-unstable:
+	$(LINT) run --allow-parallel-runners --build-tags enable_unstable
 
 .PHONY: impi
 impi:

--- a/exporter/exporterhelper/README.md
+++ b/exporter/exporterhelper/README.md
@@ -17,12 +17,52 @@ The following configuration options can be modified:
 - `sending_queue`
   - `enabled` (default = true)
   - `num_consumers` (default = 10): Number of consumers that dequeue batches; ignored if `enabled` is `false`
-  - `queue_size` (default = 5000): Maximum number of batches kept in memory before data; ignored if `enabled` is `false`;
+  - `queue_size` (default = 5000): Maximum number of batches kept in memory or on disk (for persistent storage) before dropping; ignored if `enabled` is `false`
   User should calculate this as `num_seconds * requests_per_second` where:
     - `num_seconds` is the number of seconds to buffer in case of a backend outage
     - `requests_per_second` is the average number of requests per seconds.
+  - `persistent_enabled` (default = false): When set, enables persistence via a file extension
 - `resource_to_telemetry_conversion`
   - `enabled` (default = false): If `enabled` is `true`, all the resource attributes will be converted to metric labels by default.
 - `timeout` (default = 5s): Time to wait per individual attempt to send data to a backend.
 
 The full list of settings exposed for this helper exporter are documented [here](factory.go).
+
+### Persistent Queue
+
+**Status: under development**
+
+When `persistent_enabled` is set, the queue is being buffered to disk by the 
+[file storage extension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/storage/filestorage). 
+It currently can be enabled only in OpenTelemetry Collector Contrib.
+
+This has some limitations currently. The items that have been passed to consumer for the actual exporting 
+are removed from persistent queue. In effect, in case of a sudden shutdown, they might be lost.
+
+```
+                                                   ┌─Consumer #1─┐
+                                                   │    ┌───┐    │
+                         ┌──Deleted──┐        ┌───►│    │ 1 │    ├───► Success
+                         X     x     x        │    │    └───┘    │
+                         x     x     x        │    │             │
+                         x     x     x        │    └─────────────┘
+                         x     x     x        │
+ ┌─────────Persistent queue────x─────x───┐    │    ┌─Consumer #2─┐
+ │                       x     x     x   │    │    │    ┌───┐    │
+ │     ┌───┐     ┌───┐ ┌─x─┐ ┌─x─┐ ┌─x─┐ │    │    │    │ 2 │    ├───► Permanent -> X
+ │ n+1 │ n │ ... │ 4 │ │ 3 │ │ 2 │ │ 1 │ ├────┼───►│    └───┘    │      failure
+ │     └───┘     └───┘ └───┘ └───┘ └───┘ │    │    │             │
+ │                                       │    │    └─────────────┘
+ └───────────────────────────────────────┘    │
+    ▲              ▲                          │    ┌─Consumer #3─┐
+    │              │                          │    │    ┌───┐    │     Temporary
+    │              │                          └───►│    │ 3 │    ├───►  failure
+  write          read                              │    └───┘    │
+  index          index                             │             │         │
+    ▲                                              └─────────────┘         │
+    │                                                     ▲                │
+    │                                                     └── Retry ───────┤
+    │                                                                      │
+    │                                                                      │
+    └───────────────────────── Requeuing ◄────────── Retry limit exceeded ─┘
+```

--- a/exporter/exporterhelper/README.md
+++ b/exporter/exporterhelper/README.md
@@ -21,7 +21,7 @@ The following configuration options can be modified:
   User should calculate this as `num_seconds * requests_per_second` where:
     - `num_seconds` is the number of seconds to buffer in case of a backend outage
     - `requests_per_second` is the average number of requests per seconds.
-  - `persistent_enabled` (default = false): When set, enables persistence via a file extension
+  - `persistent_storage_enabled` (default = false): When set, enables persistence via a file storage extension
 - `resource_to_telemetry_conversion`
   - `enabled` (default = false): If `enabled` is `true`, all the resource attributes will be converted to metric labels by default.
 - `timeout` (default = 5s): Time to wait per individual attempt to send data to a backend.
@@ -32,37 +32,42 @@ The full list of settings exposed for this helper exporter are documented [here]
 
 **Status: under development**
 
-When `persistent_enabled` is set, the queue is being buffered to disk by the 
+When `persistent_storage_enabled` is set to true, the queue is being buffered to disk by the 
 [file storage extension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/storage/filestorage). 
 It currently can be enabled only in OpenTelemetry Collector Contrib.
 
-This has some limitations currently. The items that have been passed to consumer for the actual exporting 
-are removed from persistent queue. In effect, in case of a sudden shutdown, they might be lost.
 
 ```
-                                                   ┌─Consumer #1─┐
-                                                   │    ┌───┐    │
-                         ┌──Deleted──┐        ┌───►│    │ 1 │    ├───► Success
-                         X     x     x        │    │    └───┘    │
-                         x     x     x        │    │             │
-                         x     x     x        │    └─────────────┘
-                         x     x     x        │
- ┌─────────Persistent queue────x─────x───┐    │    ┌─Consumer #2─┐
- │                       x     x     x   │    │    │    ┌───┐    │
- │     ┌───┐     ┌───┐ ┌─x─┐ ┌─x─┐ ┌─x─┐ │    │    │    │ 2 │    ├───► Permanent -> X
- │ n+1 │ n │ ... │ 4 │ │ 3 │ │ 2 │ │ 1 │ ├────┼───►│    └───┘    │      failure
- │     └───┘     └───┘ └───┘ └───┘ └───┘ │    │    │             │
- │                                       │    │    └─────────────┘
- └───────────────────────────────────────┘    │
-    ▲              ▲                          │    ┌─Consumer #3─┐
-    │              │                          │    │    ┌───┐    │     Temporary
-    │              │                          └───►│    │ 3 │    ├───►  failure
-  write          read                              │    └───┘    │
-  index          index                             │             │         │
-    ▲                                              └─────────────┘         │
-    │                                                     ▲                │
-    │                                                     └── Retry ───────┤
-    │                                                                      │
-    │                                                                      │
-    └───────────────────────── Requeuing ◄────────── Retry limit exceeded ─┘
+                                                              ┌─Consumer #1─┐
+                                                              │    ┌───┐    │
+                              ──────Deleted──────        ┌───►│    │ 1 │    ├───► Success
+        Waiting in channel    x           x     x        │    │    └───┘    │
+        for consumer ───┐     x           x     x        │    │             │
+                        │     x           x     x        │    └─────────────┘
+                        ▼     x           x     x        │
+┌─────────────────────────────────────────x─────x───┐    │    ┌─Consumer #2─┐
+│                             x           x     x   │    │    │    ┌───┐    │
+│     ┌───┐     ┌───┐ ┌───┐ ┌─x─┐ ┌───┐ ┌─x─┐ ┌─x─┐ │    │    │    │ 2 │    ├───► Permanent -> X
+│ n+1 │ n │ ... │ 6 │ │ 5 │ │ 4 │ │ 3 │ │ 2 │ │ 1 │ ├────┼───►│    └───┘    │      failure
+│     └───┘     └───┘ └───┘ └───┘ └───┘ └───┘ └───┘ │    │    │             │
+│                                                   │    │    └─────────────┘
+└───────────────────────────────────────────────────┘    │
+   ▲              ▲     ▲           ▲                    │    ┌─Consumer #3─┐
+   │              │     │           │                    │    │    ┌───┐    │
+   │              │     │           │                    │    │    │ 3 │    ├───► (in progress)
+ write          read    └─────┬─────┘                    ├───►│    └───┘    │
+ index          index         │                          │    │             │
+   ▲                          │                          │    └─────────────┘
+   │                          │                          │
+   │                      currently                      │    ┌─Consumer #4─┐
+   │                      processed                      │    │    ┌───┐    │     Temporary
+   │                                                     └───►│    │ 4 │    ├───►  failure
+   │                                                          │    └───┘    │         │
+   │                                                          │             │         │
+   │                                                          └─────────────┘         │
+   │                                                                 ▲                │
+   │                                                                 └── Retry ───────┤
+   │                                                                                  │
+   │                                                                                  │
+   └────────────────────────────────────── Requeuing  ◄────── Retry limit exceeded ───┘
 ```

--- a/exporter/exporterhelper/README.md
+++ b/exporter/exporterhelper/README.md
@@ -21,7 +21,7 @@ The following configuration options can be modified:
   User should calculate this as `num_seconds * requests_per_second` where:
     - `num_seconds` is the number of seconds to buffer in case of a backend outage
     - `requests_per_second` is the average number of requests per seconds.
-  - `persistent_storage_enabled` (default = false): When set, enables persistence via a file storage extension
+  - `persistent_storage_enabled` (default = false): When set, enables persistence via a file storage extension (note, `unable_unstable` compilation flag needs to be enabled first)
 - `resource_to_telemetry_conversion`
   - `enabled` (default = false): If `enabled` is `true`, all the resource attributes will be converted to metric labels by default.
 - `timeout` (default = 5s): Time to wait per individual attempt to send data to a backend.
@@ -34,7 +34,7 @@ The full list of settings exposed for this helper exporter are documented [here]
 
 When `persistent_storage_enabled` is set to true, the queue is being buffered to disk by the 
 [file storage extension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/storage/filestorage). 
-It currently can be enabled only in OpenTelemetry Collector Contrib.
+It currently can be enabled only in OpenTelemetry Collector Contrib. Also, `unable_unstable` compilation flag needs to be enabled.
 
 
 ```

--- a/exporter/exporterhelper/README.md
+++ b/exporter/exporterhelper/README.md
@@ -60,7 +60,7 @@ It currently can be enabled only in OpenTelemetry Collector Contrib. Also, `unab
    ▲                          │                          │    └─────────────┘
    │                          │                          │
    │                      currently                      │    ┌─Consumer #4─┐
-   │                      processed                      │    │    ┌───┐    │     Temporary
+   │                      dispatched                     │    │    ┌───┐    │     Temporary
    │                                                     └───►│    │ 4 │    ├───►  failure
    │                                                          │    └───┘    │         │
    │                                                          │             │         │

--- a/exporter/exporterhelper/README.md
+++ b/exporter/exporterhelper/README.md
@@ -21,7 +21,8 @@ The following configuration options can be modified:
   User should calculate this as `num_seconds * requests_per_second` where:
     - `num_seconds` is the number of seconds to buffer in case of a backend outage
     - `requests_per_second` is the average number of requests per seconds.
-  - `persistent_storage_enabled` (default = false): When set, enables persistence via a file storage extension (note, `unable_unstable` compilation flag needs to be enabled first)
+  - `persistent_storage_enabled` (default = false): When set, enables persistence via a file storage extension 
+    (note, `unable_unstable` build tag needs to be enabled first, see below for more details)
 - `resource_to_telemetry_conversion`
   - `enabled` (default = false): If `enabled` is `true`, all the resource attributes will be converted to metric labels by default.
 - `timeout` (default = 5s): Time to wait per individual attempt to send data to a backend.
@@ -32,10 +33,13 @@ The full list of settings exposed for this helper exporter are documented [here]
 
 **Status: under development**
 
-When `persistent_storage_enabled` is set to true, the queue is being buffered to disk by the 
-[file storage extension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/storage/filestorage). 
-It currently can be enabled only in OpenTelemetry Collector Contrib. Also, `unable_unstable` compilation flag needs to be enabled.
+> :warning: The capability is under development and currently can be enabled only in OpenTelemetry
+> Collector Contrib with `unable_unstable` build tag set. 
 
+When `persistent_storage_enabled` is set to true, the queue is being buffered to disk using 
+[file storage extension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/storage/filestorage).
+If collector instance is killed while having some items in the persistent queue, on restart the items are being picked and
+the exporting is continued.
 
 ```
                                                               ┌─Consumer #1─┐
@@ -70,4 +74,35 @@ It currently can be enabled only in OpenTelemetry Collector Contrib. Also, `unab
    │                                                                                  │
    │                                                                                  │
    └────────────────────────────────────── Requeuing  ◄────── Retry limit exceeded ───┘
+```
+
+Example:
+
+```
+receivers:
+  otlp:
+    protocols:
+      grpc:
+exporters:
+  otlp:
+    endpoint: <ENDPOINT>
+    sending_queue:
+      persistent_storage_enabled: true
+extensions:
+  file_storage:
+    directory: /var/lib/storage/otc
+    timeout: 10s
+service:
+  extensions: [file_storage]
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      exporters: [otlp]
+    logs:
+      receivers: [otlp]
+      exporters: [otlp]
+    traces:
+      receivers: [otlp]
+      exporters: [otlp]
+
 ```

--- a/exporter/exporterhelper/README.md
+++ b/exporter/exporterhelper/README.md
@@ -22,7 +22,7 @@ The following configuration options can be modified:
     - `num_seconds` is the number of seconds to buffer in case of a backend outage
     - `requests_per_second` is the average number of requests per seconds.
   - `persistent_storage_enabled` (default = false): When set, enables persistence via a file storage extension 
-    (note, `unable_unstable` build tag needs to be enabled first, see below for more details)
+    (note, `enable_unstable` build tag needs to be enabled first, see below for more details)
 - `resource_to_telemetry_conversion`
   - `enabled` (default = false): If `enabled` is `true`, all the resource attributes will be converted to metric labels by default.
 - `timeout` (default = 5s): Time to wait per individual attempt to send data to a backend.
@@ -34,7 +34,7 @@ The full list of settings exposed for this helper exporter are documented [here]
 **Status: under development**
 
 > :warning: The capability is under development and currently can be enabled only in OpenTelemetry
-> Collector Contrib with `unable_unstable` build tag set. 
+> Collector Contrib with `enable_unstable` build tag set. 
 
 When `persistent_storage_enabled` is set to true, the queue is being buffered to disk using 
 [file storage extension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/storage/filestorage).

--- a/exporter/exporterhelper/common.go
+++ b/exporter/exporterhelper/common.go
@@ -179,7 +179,7 @@ type baseExporter struct {
 	qrSender *queuedRetrySender
 }
 
-func newBaseExporter(cfg config.Exporter, set component.ExporterCreateSettings, bs *baseSettings, signal config.DataType, reqUnnmarshaler requestUnmarshaler) *baseExporter {
+func newBaseExporter(cfg config.Exporter, set component.ExporterCreateSettings, bs *baseSettings, signal config.DataType, reqUnmarshaler requestUnmarshaler) *baseExporter {
 	be := &baseExporter{
 		Component: componenthelper.New(bs.componentOptions...),
 	}
@@ -189,7 +189,7 @@ func newBaseExporter(cfg config.Exporter, set component.ExporterCreateSettings, 
 		ExporterID:             cfg.ID(),
 		ExporterCreateSettings: set,
 	})
-	be.qrSender = newQueuedRetrySender(cfg.ID(), signal, bs.QueueSettings, bs.RetrySettings, reqUnnmarshaler, &timeoutSender{cfg: bs.TimeoutSettings}, set.Logger)
+	be.qrSender = newQueuedRetrySender(cfg.ID(), signal, bs.QueueSettings, bs.RetrySettings, reqUnmarshaler, &timeoutSender{cfg: bs.TimeoutSettings}, set.Logger)
 	be.sender = be.qrSender
 
 	return be

--- a/exporter/exporterhelper/common.go
+++ b/exporter/exporterhelper/common.go
@@ -40,7 +40,7 @@ func DefaultTimeoutSettings() TimeoutSettings {
 	}
 }
 
-// request is an abstraction of an individual request (batchStruct of data) independent of the type of the data (traces, metrics, logs).
+// request is an abstraction of an individual request (batch of data) independent of the type of the data (traces, metrics, logs).
 type request interface {
 	// context returns the Context of the requests.
 	context() context.Context
@@ -54,8 +54,9 @@ type request interface {
 	count() int
 	// marshal serializes the current request into a byte stream
 	marshal() ([]byte, error)
-	// onProcessingFinished provides capability to do the cleanup (e.g. remove item from persistent queue)
+	// onProcessingFinished calls the optional callback function to handle cleanup after all processing is finished
 	onProcessingFinished()
+	// setOnProcessingFinished allows to set an optional callback function to do the cleanup (e.g. remove the item from persistent queue)
 	setOnProcessingFinished(callback func())
 }
 
@@ -178,15 +179,7 @@ type baseExporter struct {
 	qrSender *queuedRetrySender
 }
 
-type signalType string
-
-const (
-	signalLogs    = signalType("logs")
-	signalMetrics = signalType("metrics")
-	signalTraces  = signalType("traces")
-)
-
-func newBaseExporter(cfg config.Exporter, set component.ExporterCreateSettings, bs *baseSettings, signal signalType, reqUnnmarshaler requestUnmarshaler) *baseExporter {
+func newBaseExporter(cfg config.Exporter, set component.ExporterCreateSettings, bs *baseSettings, signal config.DataType, reqUnnmarshaler requestUnmarshaler) *baseExporter {
 	be := &baseExporter{
 		Component: componenthelper.New(bs.componentOptions...),
 	}

--- a/exporter/exporterhelper/common.go
+++ b/exporter/exporterhelper/common.go
@@ -40,7 +40,7 @@ func DefaultTimeoutSettings() TimeoutSettings {
 	}
 }
 
-// request is an abstraction of an individual request (batch of data) independent of the type of the data (traces, metrics, logs).
+// request is an abstraction of an individual request (batchStruct of data) independent of the type of the data (traces, metrics, logs).
 type request interface {
 	// context returns the Context of the requests.
 	context() context.Context

--- a/exporter/exporterhelper/common.go
+++ b/exporter/exporterhelper/common.go
@@ -56,7 +56,7 @@ type request interface {
 	marshal() ([]byte, error)
 }
 
-// requestUnmarshaler defines a function which can take a byte stream and unmarshal it into a relevant request
+// requestUnmarshaler defines a function which takes a byte slice and unmarshal it into a relevant request
 type requestUnmarshaler func([]byte) (request, error)
 
 // requestSender is an abstraction of a sender for a request independent of the type of the data (traces, metrics, logs).

--- a/exporter/exporterhelper/consumers_queue.go
+++ b/exporter/exporterhelper/consumers_queue.go
@@ -1,0 +1,31 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exporterhelper
+
+// consumersQueue is largely based on queue.BoundedQueue and matches the subset used in the collector
+// It describes a producer-consumer exchange which can be backed by e.g. the memory-based ring buffer queue
+// (queue.BoundedQueue) or via disk-based queue (persistentQueue)
+type consumersQueue interface {
+	// StartConsumers starts a given number of goroutines consuming items from the queue
+	// and passing them into the consumer callback.
+	StartConsumers(num int, callback func(item interface{}))
+	// Produce is used by the producer to submit new item to the queue. Returns false in case of queue overflow.
+	Produce(item interface{}) bool
+	// Stop stops all consumers, as well as the length reporter if started,
+	// and releases the items channel. It blocks until all consumers have stopped.
+	Stop()
+	// Size returns the current Size of the queue
+	Size() int
+}

--- a/exporter/exporterhelper/consumers_queue.go
+++ b/exporter/exporterhelper/consumers_queue.go
@@ -21,7 +21,8 @@ type consumersQueue interface {
 	// StartConsumers starts a given number of goroutines consuming items from the queue
 	// and passing them into the consumer callback.
 	StartConsumers(num int, callback func(item interface{}))
-	// Produce is used by the producer to submit new item to the queue. Returns false in case of queue overflow.
+	// Produce is used by the producer to submit new item to the queue. Returns false if the item wasn't added
+	// to the queue due to queue overflow.
 	Produce(item interface{}) bool
 	// Stop stops all consumers, as well as the length reporter if started,
 	// and releases the items channel. It blocks until all consumers have stopped.

--- a/exporter/exporterhelper/logs.go
+++ b/exporter/exporterhelper/logs.go
@@ -99,7 +99,7 @@ func NewLogsExporter(
 	}
 
 	bs := fromOptions(options...)
-	be := newBaseExporter(cfg, set, bs, signalLogs, newLogsRequestUnmarshalerFunc(pusher))
+	be := newBaseExporter(cfg, set, bs, config.LogsDataType, newLogsRequestUnmarshalerFunc(pusher))
 	be.wrapConsumerSender(func(nextSender requestSender) requestSender {
 		return &logsExporterWithObservability{
 			obsrep:     be.obsrep,

--- a/exporter/exporterhelper/logs.go
+++ b/exporter/exporterhelper/logs.go
@@ -99,7 +99,7 @@ func NewLogsExporter(
 	}
 
 	bs := fromOptions(options...)
-	be := newBaseExporter(cfg, set, bs, "logs", newLogsRequestUnmarshalerFunc(pusher))
+	be := newBaseExporter(cfg, set, bs, signalLogs, newLogsRequestUnmarshalerFunc(pusher))
 	be.wrapConsumerSender(func(nextSender requestSender) requestSender {
 		return &logsExporterWithObservability{
 			obsrep:     be.obsrep,

--- a/exporter/exporterhelper/logs.go
+++ b/exporter/exporterhelper/logs.go
@@ -23,8 +23,12 @@ import (
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/consumer/consumerhelper"
+	"go.opentelemetry.io/collector/model/otlp"
 	"go.opentelemetry.io/collector/model/pdata"
 )
+
+var logsMarshaler = otlp.NewProtobufLogsMarshaler()
+var logsUnmarshaler = otlp.NewProtobufLogsUnmarshaler()
 
 type logsRequest struct {
 	baseRequest
@@ -40,6 +44,16 @@ func newLogsRequest(ctx context.Context, ld pdata.Logs, pusher consumerhelper.Co
 	}
 }
 
+func newLogsRequestUnmarshalerFunc(pusher consumerhelper.ConsumeLogsFunc) requestUnmarshaler {
+	return func(bytes []byte) (request, error) {
+		logs, err := logsUnmarshaler.UnmarshalLogs(bytes)
+		if err != nil {
+			return nil, err
+		}
+		return newLogsRequest(context.Background(), logs, pusher), nil
+	}
+}
+
 func (req *logsRequest) onError(err error) request {
 	var logError consumererror.Logs
 	if consumererror.AsLogs(err, &logError) {
@@ -50,6 +64,10 @@ func (req *logsRequest) onError(err error) request {
 
 func (req *logsRequest) export(ctx context.Context) error {
 	return req.pusher(ctx, req.ld)
+}
+
+func (req *logsRequest) marshal() ([]byte, error) {
+	return logsMarshaler.MarshalLogs(req.ld)
 }
 
 func (req *logsRequest) count() int {
@@ -81,7 +99,7 @@ func NewLogsExporter(
 	}
 
 	bs := fromOptions(options...)
-	be := newBaseExporter(cfg, set, bs)
+	be := newBaseExporter(cfg, set, bs, "logs", newLogsRequestUnmarshalerFunc(pusher))
 	be.wrapConsumerSender(func(nextSender requestSender) requestSender {
 		return &logsExporterWithObservability{
 			obsrep:     be.obsrep,

--- a/exporter/exporterhelper/metrics.go
+++ b/exporter/exporterhelper/metrics.go
@@ -99,7 +99,7 @@ func NewMetricsExporter(
 	}
 
 	bs := fromOptions(options...)
-	be := newBaseExporter(cfg, set, bs, signalMetrics, newMetricsRequestUnmarshalerFunc(pusher))
+	be := newBaseExporter(cfg, set, bs, config.MetricsDataType, newMetricsRequestUnmarshalerFunc(pusher))
 	be.wrapConsumerSender(func(nextSender requestSender) requestSender {
 		return &metricsSenderWithObservability{
 			obsrep:     be.obsrep,

--- a/exporter/exporterhelper/metrics.go
+++ b/exporter/exporterhelper/metrics.go
@@ -23,8 +23,12 @@ import (
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/consumer/consumerhelper"
+	"go.opentelemetry.io/collector/model/otlp"
 	"go.opentelemetry.io/collector/model/pdata"
 )
+
+var metricsMarshaler = otlp.NewProtobufMetricsMarshaler()
+var metricsUnmarshaler = otlp.NewProtobufMetricsUnmarshaler()
 
 type metricsRequest struct {
 	baseRequest
@@ -40,6 +44,16 @@ func newMetricsRequest(ctx context.Context, md pdata.Metrics, pusher consumerhel
 	}
 }
 
+func newMetricsRequestUnmarshalerFunc(pusher consumerhelper.ConsumeMetricsFunc) requestUnmarshaler {
+	return func(bytes []byte) (request, error) {
+		metrics, err := metricsUnmarshaler.UnmarshalMetrics(bytes)
+		if err != nil {
+			return nil, err
+		}
+		return newMetricsRequest(context.Background(), metrics, pusher), nil
+	}
+}
+
 func (req *metricsRequest) onError(err error) request {
 	var metricsError consumererror.Metrics
 	if consumererror.AsMetrics(err, &metricsError) {
@@ -50,6 +64,10 @@ func (req *metricsRequest) onError(err error) request {
 
 func (req *metricsRequest) export(ctx context.Context) error {
 	return req.pusher(ctx, req.md)
+}
+
+func (req *metricsRequest) marshal() ([]byte, error) {
+	return metricsMarshaler.MarshalMetrics(req.md)
 }
 
 func (req *metricsRequest) count() int {
@@ -81,7 +99,7 @@ func NewMetricsExporter(
 	}
 
 	bs := fromOptions(options...)
-	be := newBaseExporter(cfg, set, bs)
+	be := newBaseExporter(cfg, set, bs, "metrics", newMetricsRequestUnmarshalerFunc(pusher))
 	be.wrapConsumerSender(func(nextSender requestSender) requestSender {
 		return &metricsSenderWithObservability{
 			obsrep:     be.obsrep,

--- a/exporter/exporterhelper/metrics.go
+++ b/exporter/exporterhelper/metrics.go
@@ -99,7 +99,7 @@ func NewMetricsExporter(
 	}
 
 	bs := fromOptions(options...)
-	be := newBaseExporter(cfg, set, bs, "metrics", newMetricsRequestUnmarshalerFunc(pusher))
+	be := newBaseExporter(cfg, set, bs, signalMetrics, newMetricsRequestUnmarshalerFunc(pusher))
 	be.wrapConsumerSender(func(nextSender requestSender) requestSender {
 		return &metricsSenderWithObservability{
 			obsrep:     be.obsrep,

--- a/exporter/exporterhelper/persistent_queue.go
+++ b/exporter/exporterhelper/persistent_queue.go
@@ -1,0 +1,343 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exporterhelper
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/jaegertracing/jaeger/pkg/queue"
+	"go.uber.org/atomic"
+	"go.uber.org/zap"
+
+	"go.opentelemetry.io/collector/extension/storage"
+)
+
+// persistentQueue holds the queue backed by file storage
+type persistentQueue struct {
+	logger     *zap.Logger
+	stopWG     sync.WaitGroup
+	produceMu  sync.Mutex
+	exitChan   chan int
+	capacity   int
+	numWorkers int
+
+	storage persistentStorage
+}
+
+// persistentStorage provides an interface for request storage operations
+type persistentStorage interface {
+	// put appends the request to the storage
+	put(req request) error
+	// get returns the next available request; not the channel is unbuffered
+	get() <-chan request
+	// size returns the current size of the storage in number of requets
+	size() int
+	// stop gracefully stops the storage
+	stop()
+}
+
+// persistentContiguousStorage provides a persistent queue implementation backed by file storage extension
+//
+// Write index describes the position at which next item is going to be stored
+// Read index describes which item needs to be read next
+// When Write index = Read index, no elements are in the queue
+//
+//   ┌─file extension-backed queue─┐
+//   │                             │
+//   │     ┌───┐     ┌───┐ ┌───┐   │
+//   │ n+1 │ n │ ... │ 4 │ │ 3 │   │
+//   │     └───┘     └───┘ └─x─┘   │
+//   │                       x     │
+//   └───────────────────────x─────┘
+//      ▲              ▲     x
+//      │              │     xxx deleted
+//      │              │
+//    write          read
+//    index          index
+//
+type persistentContiguousStorage struct {
+	logger        *zap.Logger
+	client        storage.Client
+	mu            sync.Mutex
+	queueName     string
+	readIndex     uint64
+	writeIndex    uint64
+	readIndexKey  string
+	writeIndexKey string
+	retryDelay    time.Duration
+	unmarshaler   requestUnmarshaler
+	reqChan       chan request
+	stopped       *atomic.Uint32
+}
+
+const (
+	queueNameKey      = "queueName"
+	zapItemKey        = "itemKey"
+	itemKeyTemplate   = "it-%d"
+	readIndexKey      = "ri"
+	writeIndexKey     = "wi"
+	defaultRetryDelay = 500 * time.Millisecond
+)
+
+// newPersistentQueue creates a new queue backed by file storage
+func newPersistentQueue(ctx context.Context, name string, capacity int, logger *zap.Logger, client storage.Client, unmarshaler requestUnmarshaler) *persistentQueue {
+	return &persistentQueue{
+		logger:   logger,
+		exitChan: make(chan int),
+		capacity: capacity,
+		storage:  newPersistentContiguousStorage(ctx, name, logger, client, unmarshaler),
+	}
+}
+
+// StartConsumers starts the given number of consumers which will be consuming items
+func (pq *persistentQueue) StartConsumers(num int, callback func(item interface{})) {
+	pq.numWorkers = num
+	var startWG sync.WaitGroup
+
+	factory := func() queue.Consumer {
+		return queue.ConsumerFunc(callback)
+	}
+
+	for i := 0; i < pq.numWorkers; i++ {
+		pq.stopWG.Add(1)
+		startWG.Add(1)
+		go func() {
+			startWG.Done()
+			defer pq.stopWG.Done()
+			consumer := factory()
+
+			for {
+				select {
+				case req := <-pq.storage.get():
+					consumer.Consume(req)
+				case <-pq.exitChan:
+					return
+				}
+			}
+		}()
+	}
+	startWG.Wait()
+}
+
+// Produce adds an item to the queue and returns true if it was accepted
+func (pq *persistentQueue) Produce(item interface{}) bool {
+	pq.produceMu.Lock()
+	defer pq.produceMu.Unlock()
+
+	if pq.storage.size() >= pq.capacity {
+		return false
+	}
+	err := pq.storage.put(item.(request))
+	return err == nil
+}
+
+// Stop stops accepting items, shuts down the queue and closes the persistent queue
+func (pq *persistentQueue) Stop() {
+	pq.storage.stop()
+	close(pq.exitChan)
+	pq.stopWG.Wait()
+}
+
+// Size returns the current depth of the queue
+func (pq *persistentQueue) Size() int {
+	return pq.storage.size()
+}
+
+// newPersistentContiguousStorage creates a new file-storage extension backed queue. It needs to be initialized separately
+func newPersistentContiguousStorage(ctx context.Context, queueName string, logger *zap.Logger, client storage.Client, unmarshaler requestUnmarshaler) *persistentContiguousStorage {
+	wcs := &persistentContiguousStorage{
+		logger:      logger,
+		client:      client,
+		queueName:   queueName,
+		unmarshaler: unmarshaler,
+		reqChan:     make(chan request),
+		stopped:     atomic.NewUint32(0),
+		retryDelay:  defaultRetryDelay,
+	}
+	initPersistentContiguousStorage(ctx, wcs)
+	go wcs.loop(ctx)
+	return wcs
+}
+
+func initPersistentContiguousStorage(ctx context.Context, wcs *persistentContiguousStorage) {
+	wcs.readIndexKey = wcs.buildReadIndexKey()
+	wcs.writeIndexKey = wcs.buildWriteIndexKey()
+
+	readIndexBytes, err := wcs.client.Get(ctx, wcs.readIndexKey)
+	if err != nil || readIndexBytes == nil {
+		wcs.logger.Debug("failed getting read index, starting with a new one", zap.String(queueNameKey, wcs.queueName))
+		wcs.readIndex = 0
+	} else {
+		val, conversionErr := bytesToUint64(readIndexBytes)
+		if conversionErr != nil {
+			wcs.logger.Warn("read index corrupted, starting with a new one", zap.String(queueNameKey, wcs.queueName))
+			wcs.readIndex = 0
+		} else {
+			wcs.readIndex = val
+		}
+	}
+
+	writeIndexBytes, err := wcs.client.Get(ctx, wcs.writeIndexKey)
+	if err != nil || writeIndexBytes == nil {
+		wcs.logger.Debug("failed getting write index, starting with a new one", zap.String(queueNameKey, wcs.queueName))
+		wcs.writeIndex = 0
+	} else {
+		val, conversionErr := bytesToUint64(writeIndexBytes)
+		if conversionErr != nil {
+			wcs.logger.Warn("write index corrupted, starting with a new one", zap.String(queueNameKey, wcs.queueName))
+			wcs.writeIndex = 0
+		} else {
+			wcs.writeIndex = val
+		}
+	}
+}
+
+// Put marshals the request and puts it into the persistent queue
+func (pcs *persistentContiguousStorage) put(req request) error {
+	buf, err := req.marshal()
+	if err != nil {
+		return err
+	}
+
+	pcs.mu.Lock()
+	defer pcs.mu.Unlock()
+
+	itemKey := pcs.buildItemKey(pcs.writeIndex)
+	err = pcs.client.Set(context.Background(), itemKey, buf)
+	if err != nil {
+		return err
+	}
+
+	pcs.writeIndex++
+	writeIndexBytes, err := uint64ToBytes(pcs.writeIndex)
+	if err != nil {
+		pcs.logger.Warn("failed converting write index uint64 to bytes", zap.Error(err))
+	}
+
+	return pcs.client.Set(context.Background(), pcs.writeIndexKey, writeIndexBytes)
+}
+
+// getNextItem pulls the next available item from the persistent storage; if none is found, returns (nil, false)
+func (pcs *persistentContiguousStorage) getNextItem(ctx context.Context) (request, bool) {
+	pcs.mu.Lock()
+	defer pcs.mu.Unlock()
+
+	if pcs.readIndex < pcs.writeIndex {
+		itemKey := pcs.buildItemKey(pcs.readIndex)
+		// Increase here, so despite errors it would still progress
+		pcs.readIndex++
+
+		buf, err := pcs.client.Get(ctx, itemKey)
+		if err != nil {
+			pcs.logger.Error("error when getting item from persistent storage",
+				zap.String(queueNameKey, pcs.queueName), zap.String(zapItemKey, itemKey), zap.Error(err))
+			return nil, false
+		}
+		req, unmarshalErr := pcs.unmarshaler(buf)
+		pcs.updateItemRead(ctx, itemKey)
+		if unmarshalErr != nil {
+			pcs.logger.Error("error when unmarshalling item from persistent storage",
+				zap.String(queueNameKey, pcs.queueName), zap.String(zapItemKey, itemKey), zap.Error(unmarshalErr))
+			return nil, false
+		}
+
+		return req, true
+	}
+
+	return nil, false
+}
+
+func (pcs *persistentContiguousStorage) loop(ctx context.Context) {
+	for {
+		if pcs.stopped.Load() != 0 {
+			return
+		}
+
+		req, found := pcs.getNextItem(ctx)
+		if found {
+			pcs.reqChan <- req
+		} else {
+			time.Sleep(pcs.retryDelay)
+		}
+	}
+}
+
+// get returns the next request from the queue as available via the channel
+func (pcs *persistentContiguousStorage) get() <-chan request {
+	return pcs.reqChan
+}
+
+func (pcs *persistentContiguousStorage) size() int {
+	pcs.mu.Lock()
+	defer pcs.mu.Unlock()
+	return int(pcs.writeIndex - pcs.readIndex)
+}
+
+func (pcs *persistentContiguousStorage) stop() {
+	pcs.logger.Debug("stopping persistentContiguousStorage", zap.String(queueNameKey, pcs.queueName))
+	pcs.stopped.Store(1)
+}
+
+func (pcs *persistentContiguousStorage) updateItemRead(ctx context.Context, itemKey string) {
+	err := pcs.client.Delete(ctx, itemKey)
+	if err != nil {
+		pcs.logger.Debug("failed deleting item", zap.String(zapItemKey, itemKey))
+	}
+
+	readIndexBytes, err := uint64ToBytes(pcs.readIndex)
+	if err != nil {
+		pcs.logger.Warn("failed converting read index uint64 to bytes", zap.Error(err))
+	} else {
+		err = pcs.client.Set(ctx, pcs.readIndexKey, readIndexBytes)
+		if err != nil {
+			pcs.logger.Warn("failed storing read index", zap.Error(err))
+		}
+	}
+}
+
+func (pcs *persistentContiguousStorage) buildItemKey(index uint64) string {
+	return fmt.Sprintf(itemKeyTemplate, index)
+}
+
+func (pcs *persistentContiguousStorage) buildReadIndexKey() string {
+	return readIndexKey
+}
+
+func (pcs *persistentContiguousStorage) buildWriteIndexKey() string {
+	return writeIndexKey
+}
+
+func uint64ToBytes(val uint64) ([]byte, error) {
+	var buf bytes.Buffer
+	err := binary.Write(&buf, binary.LittleEndian, val)
+	if err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), err
+}
+
+func bytesToUint64(b []byte) (uint64, error) {
+	var val uint64
+	err := binary.Read(bytes.NewReader(b), binary.LittleEndian, &val)
+	if err != nil {
+		return val, err
+	}
+	return val, nil
+}

--- a/exporter/exporterhelper/persistent_queue.go
+++ b/exporter/exporterhelper/persistent_queue.go
@@ -43,7 +43,7 @@ func newPersistentQueue(ctx context.Context, name string, capacity int, logger *
 		logger:   logger,
 		stopChan: make(chan struct{}),
 		capacity: capacity,
-		storage:  newPersistentContiguousStorage(ctx, name, logger, client, unmarshaler),
+		storage:  newPersistentContiguousStorage(ctx, name, capacity, logger, client, unmarshaler),
 	}
 }
 

--- a/exporter/exporterhelper/persistent_queue.go
+++ b/exporter/exporterhelper/persistent_queue.go
@@ -18,9 +18,9 @@ import (
 	"context"
 	"sync"
 
-	"github.com/jaegertracing/jaeger/pkg/queue"
 	"go.uber.org/zap"
 
+	"go.opentelemetry.io/collector/exporter/exporterhelper/internal"
 	"go.opentelemetry.io/collector/extension/storage"
 )
 
@@ -51,8 +51,8 @@ func newPersistentQueue(ctx context.Context, name string, capacity int, logger *
 func (pq *persistentQueue) StartConsumers(num int, callback func(item interface{})) {
 	pq.numWorkers = num
 
-	factory := func() queue.Consumer {
-		return queue.ConsumerFunc(callback)
+	factory := func() internal.Consumer {
+		return internal.ConsumerFunc(callback)
 	}
 
 	for i := 0; i < pq.numWorkers; i++ {

--- a/exporter/exporterhelper/persistent_queue.go
+++ b/exporter/exporterhelper/persistent_queue.go
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build enable_unstable
+// +build enable_unstable
+
 package exporterhelper
 
 import (

--- a/exporter/exporterhelper/persistent_queue_test.go
+++ b/exporter/exporterhelper/persistent_queue_test.go
@@ -47,9 +47,6 @@ func createTestQueue(extension storage.Extension, capacity int) *persistentQueue
 	}
 
 	wq := newPersistentQueue(context.Background(), "foo", capacity, logger, client, newTraceRequestUnmarshalerFunc(nopTracePusher()))
-	wq.storage.(*persistentContiguousStorage).mu.Lock()
-	wq.storage.(*persistentContiguousStorage).retryDelay = 10 * time.Millisecond
-	wq.storage.(*persistentContiguousStorage).mu.Unlock()
 	return wq
 }
 

--- a/exporter/exporterhelper/persistent_queue_test.go
+++ b/exporter/exporterhelper/persistent_queue_test.go
@@ -1,0 +1,314 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exporterhelper
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.opentelemetry.io/collector/extension/storage"
+)
+
+func createStorageExtension(_ string) storage.Extension {
+	// After having storage moved to core, we could leverage storagetest.NewTestExtension(nil, path)
+	return newMockStorageExtension()
+}
+
+func createTestQueue(extension storage.Extension, capacity int) *persistentQueue {
+	logger, _ := zap.NewDevelopment()
+
+	client, err := extension.GetClient(context.Background(), component.KindReceiver, config.ComponentID{}, "")
+	if err != nil {
+		panic(err)
+	}
+
+	wq := newPersistentQueue(context.Background(), "foo", capacity, logger, client, newTraceRequestUnmarshalerFunc(nopTracePusher()))
+	wq.storage.(*persistentContiguousStorage).mu.Lock()
+	wq.storage.(*persistentContiguousStorage).retryDelay = 10 * time.Millisecond
+	wq.storage.(*persistentContiguousStorage).mu.Unlock()
+	return wq
+}
+
+func createTestPersistentStorage(extension storage.Extension) persistentStorage {
+	logger, _ := zap.NewDevelopment()
+
+	client, err := extension.GetClient(context.Background(), component.KindReceiver, config.ComponentID{}, "")
+	if err != nil {
+		panic(err)
+	}
+
+	return newPersistentContiguousStorage(context.Background(), "foo", logger, client, newTraceRequestUnmarshalerFunc(nopTracePusher()))
+}
+
+func createTemporaryDirectory() string {
+	directory, err := ioutil.TempDir("", "persistent-test")
+	if err != nil {
+		panic(err)
+	}
+	return directory
+}
+
+func TestPersistentQueue_RepeatPutCloseReadClose(t *testing.T) {
+	path := createTemporaryDirectory()
+	defer os.RemoveAll(path)
+
+	traces := newTraces(5, 10)
+	req := newTracesRequest(context.Background(), traces, nopTracePusher())
+
+	for i := 0; i < 10; i++ {
+		ext := createStorageExtension(path)
+		ps := createTestPersistentStorage(ext)
+		require.Equal(t, 0, ps.size())
+		err := ps.put(req)
+		require.NoError(t, err)
+		err = ext.Shutdown(context.Background())
+		require.NoError(t, err)
+
+		// TODO: when replacing mock with real storage, this could actually be uncommented
+		// ext = createStorageExtension(path)
+		// ps = createTestPersistentStorage(ext)
+
+		require.Equal(t, 1, ps.size())
+		readReq := <-ps.get()
+		require.Equal(t, 0, ps.size())
+		require.Equal(t, req.(*tracesRequest).td, readReq.(*tracesRequest).td)
+		err = ext.Shutdown(context.Background())
+		require.NoError(t, err)
+	}
+
+	// No more items
+	ext := createStorageExtension(path)
+	wq := createTestQueue(ext, 5000)
+	require.Equal(t, 0, wq.Size())
+	ext.Shutdown(context.Background())
+}
+
+func TestPersistentQueue_Capacity(t *testing.T) {
+	path := createTemporaryDirectory()
+	defer os.RemoveAll(path)
+
+	ext := createStorageExtension(path)
+	defer ext.Shutdown(context.Background())
+
+	wq := createTestQueue(ext, 5)
+	require.Equal(t, 0, wq.Size())
+
+	traces := newTraces(1, 10)
+	req := newTracesRequest(context.Background(), traces, nopTracePusher())
+
+	for i := 0; i < 10; i++ {
+		result := wq.Produce(req)
+		if i < 5 {
+			require.True(t, result)
+		} else {
+			require.False(t, result)
+		}
+	}
+	require.Equal(t, 5, wq.Size())
+}
+
+func TestPersistentQueue_ConsumersProducers(t *testing.T) {
+	cases := []struct {
+		numMessagesProduced int
+		numConsumers        int
+	}{
+		{
+			numMessagesProduced: 1,
+			numConsumers:        1,
+		},
+		{
+			numMessagesProduced: 100,
+			numConsumers:        1,
+		},
+		{
+			numMessagesProduced: 100,
+			numConsumers:        3,
+		},
+		{
+			numMessagesProduced: 1,
+			numConsumers:        100,
+		},
+		{
+			numMessagesProduced: 100,
+			numConsumers:        100,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(fmt.Sprintf("#messages: %d #consumers: %d", c.numMessagesProduced, c.numConsumers), func(t *testing.T) {
+			path := createTemporaryDirectory()
+
+			traces := newTraces(1, 10)
+			req := newTracesRequest(context.Background(), traces, nopTracePusher())
+
+			ext := createStorageExtension(path)
+			tq := createTestQueue(ext, 5000)
+
+			defer os.RemoveAll(path)
+			defer tq.Stop()
+			defer ext.Shutdown(context.Background())
+
+			numMessagesConsumed := int32(0)
+			tq.StartConsumers(c.numConsumers, func(item interface{}) {
+				if item != nil {
+					atomic.AddInt32(&numMessagesConsumed, 1)
+				}
+			})
+
+			for i := 0; i < c.numMessagesProduced; i++ {
+				tq.Produce(req)
+			}
+
+			require.Eventually(t, func() bool {
+				return c.numMessagesProduced == int(atomic.LoadInt32(&numMessagesConsumed))
+			}, 500*time.Millisecond, 10*time.Millisecond)
+		})
+	}
+}
+
+func BenchmarkPersistentQueue_1Trace10Spans(b *testing.B) {
+	cases := []struct {
+		numTraces        int
+		numSpansPerTrace int
+	}{
+		{
+			numTraces:        1,
+			numSpansPerTrace: 1,
+		},
+		{
+			numTraces:        1,
+			numSpansPerTrace: 10,
+		},
+		{
+			numTraces:        10,
+			numSpansPerTrace: 10,
+		},
+	}
+
+	for _, c := range cases {
+		b.Run(fmt.Sprintf("#traces: %d #spansPerTrace: %d", c.numTraces, c.numSpansPerTrace), func(bb *testing.B) {
+			path := createTemporaryDirectory()
+			defer os.RemoveAll(path)
+			ext := createStorageExtension(path)
+			ps := createTestPersistentStorage(ext)
+
+			traces := newTraces(c.numTraces, c.numSpansPerTrace)
+			req := newTracesRequest(context.Background(), traces, nopTracePusher())
+
+			bb.ResetTimer()
+
+			for i := 0; i < bb.N; i++ {
+				err := ps.put(req)
+				require.NoError(bb, err)
+			}
+
+			for i := 0; i < bb.N; i++ {
+				req := ps.get()
+				require.NotNil(bb, req)
+			}
+			ext.Shutdown(context.Background())
+		})
+	}
+}
+
+func newTraces(numTraces int, numSpans int) pdata.Traces {
+	traces := pdata.NewTraces()
+	batch := traces.ResourceSpans().AppendEmpty()
+	batch.Resource().Attributes().InsertString("resource-attr", "some-resource")
+	batch.Resource().Attributes().InsertInt("num-traces", int64(numTraces))
+	batch.Resource().Attributes().InsertInt("num-spans", int64(numSpans))
+
+	for i := 0; i < numTraces; i++ {
+		traceID := pdata.NewTraceID([16]byte{1, 2, 3, byte(i)})
+		ils := batch.InstrumentationLibrarySpans().AppendEmpty()
+		for j := 0; j < numSpans; j++ {
+			span := ils.Spans().AppendEmpty()
+			span.SetTraceID(traceID)
+			span.SetSpanID(pdata.NewSpanID([8]byte{1, 2, 3, byte(j)}))
+			span.SetName("should-not-be-changed")
+			span.Attributes().InsertInt("int-attribute", int64(j))
+			span.Attributes().InsertString("str-attribute-1", "foobar")
+			span.Attributes().InsertString("str-attribute-2", "fdslafjasdk12312312jkl")
+			span.Attributes().InsertString("str-attribute-3", "AbcDefGeKKjkfdsafasdfsdasdf")
+			span.Attributes().InsertString("str-attribute-4", "xxxxxx")
+			span.Attributes().InsertString("str-attribute-5", "abcdef")
+		}
+	}
+
+	return traces
+}
+
+type mockStorageExtension struct{}
+
+func (m mockStorageExtension) Start(_ context.Context, _ component.Host) error {
+	return nil
+}
+
+func (m mockStorageExtension) Shutdown(_ context.Context) error {
+	return nil
+}
+
+func (m mockStorageExtension) GetClient(ctx context.Context, kind component.Kind, id config.ComponentID, s string) (storage.Client, error) {
+	return newMockStorageClient(), nil
+}
+
+func newMockStorageExtension() storage.Extension {
+	return &mockStorageExtension{}
+}
+
+func newMockStorageClient() storage.Client {
+	return &mockStorageClient{
+		st: map[string][]byte{},
+	}
+}
+
+type mockStorageClient struct {
+	st map[string][]byte
+}
+
+func (m mockStorageClient) Get(_ context.Context, s string) ([]byte, error) {
+	val, found := m.st[s]
+	if !found {
+		return []byte{}, errors.New("key not found")
+	}
+
+	return val, nil
+}
+
+func (m mockStorageClient) Set(_ context.Context, s string, bytes []byte) error {
+	m.st[s] = bytes
+	return nil
+}
+
+func (m mockStorageClient) Delete(_ context.Context, s string) error {
+	delete(m.st, s)
+	return nil
+}
+
+func (m mockStorageClient) Close(_ context.Context) error {
+	return nil
+}

--- a/exporter/exporterhelper/persistent_queue_test.go
+++ b/exporter/exporterhelper/persistent_queue_test.go
@@ -27,8 +27,8 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config"
-	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/extension/storage"
+	"go.opentelemetry.io/collector/model/pdata"
 )
 
 func createTestQueue(extension storage.Extension, capacity int) *persistentQueue {

--- a/exporter/exporterhelper/persistent_queue_test.go
+++ b/exporter/exporterhelper/persistent_queue_test.go
@@ -65,7 +65,7 @@ func TestPersistentQueue_Capacity(t *testing.T) {
 				require.False(t, result)
 			}
 
-			// Lets make sure the loop picks the first element into the channel,
+			// Let's make sure the loop picks the first element into the channel,
 			// so the capacity could be used in full
 			if i == 0 {
 				require.Eventually(t, func() bool {

--- a/exporter/exporterhelper/persistent_queue_test.go
+++ b/exporter/exporterhelper/persistent_queue_test.go
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build enable_unstable
+// +build enable_unstable
+
 package exporterhelper
 
 import (

--- a/exporter/exporterhelper/persistent_storage.go
+++ b/exporter/exporterhelper/persistent_storage.go
@@ -164,20 +164,18 @@ func (pcs *persistentContiguousStorage) loop() {
 	}
 
 	for {
-		for {
-			req, found := pcs.getNextItem(context.Background())
-			if found {
-				select {
-				case <-pcs.stopChan:
-					return
-				case pcs.reqChan <- req:
-				}
-			} else {
-				select {
-				case <-pcs.stopChan:
-					return
-				case <-time.After(pcs.retryDelay):
-				}
+		req, found := pcs.getNextItem(context.Background())
+		if found {
+			select {
+			case <-pcs.stopChan:
+				return
+			case pcs.reqChan <- req:
+			}
+		} else {
+			select {
+			case <-pcs.stopChan:
+				return
+			case <-time.After(pcs.retryDelay):
 			}
 		}
 	}

--- a/exporter/exporterhelper/persistent_storage.go
+++ b/exporter/exporterhelper/persistent_storage.go
@@ -216,6 +216,11 @@ func (pcs *persistentContiguousStorage) stop() {
 
 // put marshals the request and puts it into the persistent queue
 func (pcs *persistentContiguousStorage) put(req request) error {
+	// Nil requests are ignored
+	if req == nil {
+		return nil
+	}
+
 	pcs.mu.Lock()
 	defer pcs.mu.Unlock()
 

--- a/exporter/exporterhelper/persistent_storage.go
+++ b/exporter/exporterhelper/persistent_storage.go
@@ -1,0 +1,442 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exporterhelper
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"go.opencensus.io/metric/metricdata"
+	"go.uber.org/zap"
+
+	"go.opentelemetry.io/collector/extension/storage"
+)
+
+// persistentStorage provides an interface for request storage operations
+type persistentStorage interface {
+	// put appends the request to the storage
+	put(req request) error
+	// get returns the next available request; note that the channel is unbuffered
+	get() <-chan request
+	// size returns the current size of the storage with items waiting for processing
+	size() int
+	// stop gracefully stops the storage
+	stop()
+}
+
+// persistentContiguousStorage provides a persistent queue implementation backed by file storage extension
+//
+// Write index describes the position at which next item is going to be stored.
+// Read index describes which item needs to be read next.
+// When Write index = Read index, no elements are in the queue.
+//
+// The items currently processed by consumers are not deleted until the processing is finished.
+// Their list is stored under a separate key.
+//
+//
+//   ┌───────file extension-backed queue───────┐
+//   │                                         │
+//   │     ┌───┐     ┌───┐ ┌───┐ ┌───┐ ┌───┐   │
+//   │ n+1 │ n │ ... │ 4 │ │ 3 │ │ 2 │ │ 1 │   │
+//   │     └───┘     └───┘ └─x─┘ └─|─┘ └─x─┘   │
+//   │                       x     |     x     │
+//   └───────────────────────x─────|─────x─────┘
+//      ▲              ▲     x     |     x
+//      │              │     x     |     xxxx deleted
+//      │              │     x     |
+//    write          read    x     └── currently processed item
+//    index          index   x
+//                           xxxx deleted
+//
+type persistentContiguousStorage struct {
+	logger      *zap.Logger
+	queueName   string
+	client      storage.Client
+	retryDelay  time.Duration
+	unmarshaler requestUnmarshaler
+
+	reqChan  chan request
+	stopOnce sync.Once
+	stopChan chan struct{}
+
+	mu                      sync.Mutex
+	readIndex               itemIndex
+	writeIndex              itemIndex
+	currentlyProcessedItems []itemIndex
+}
+
+type itemIndex uint64
+
+const (
+	zapKey           = "key"
+	zapQueueNameKey  = "queueName"
+	zapErrorCount    = "errorCount"
+	zapNumberOfItems = "numberOfItems"
+
+	defaultRetryDelay = 100 * time.Millisecond
+
+	readIndexKey               = "ri"
+	writeIndexKey              = "wi"
+	currentlyProcessedItemsKey = "pi"
+)
+
+var (
+	errStoringItemToQueue = errors.New("item could not be stored to persistent queue")
+	errUpdatingIndex      = errors.New("index could not be updated")
+)
+
+// newPersistentContiguousStorage creates a new file-storage extension backed queue. It needs to be initialized separately
+func newPersistentContiguousStorage(ctx context.Context, queueName string, logger *zap.Logger, client storage.Client, unmarshaler requestUnmarshaler) *persistentContiguousStorage {
+	wcs := &persistentContiguousStorage{
+		logger:      logger,
+		client:      client,
+		queueName:   queueName,
+		unmarshaler: unmarshaler,
+		reqChan:     make(chan request),
+		stopChan:    make(chan struct{}),
+		retryDelay:  defaultRetryDelay,
+	}
+
+	initPersistentContiguousStorage(ctx, wcs)
+
+	err := currentlyProcessedBatchesGauge.UpsertEntry(func() int64 {
+		return int64(wcs.numberOfCurrentlyProcessedItems())
+	}, metricdata.NewLabelValue(wcs.queueName))
+	if err != nil {
+		logger.Error("failed to create number of currently processed items metric", zap.Error(err))
+	}
+
+	go wcs.loop()
+	return wcs
+}
+
+func initPersistentContiguousStorage(ctx context.Context, wcs *persistentContiguousStorage) {
+	readIndexIf := wcs._clientGet(ctx, readIndexKey, bytesToItemIndex)
+	if readIndexIf == nil {
+		wcs.logger.Debug("failed getting read index, starting with a new one",
+			zap.String(zapQueueNameKey, wcs.queueName))
+		wcs.readIndex = 0
+	} else {
+		wcs.readIndex = readIndexIf.(itemIndex)
+	}
+
+	writeIndexIf := wcs._clientGet(ctx, writeIndexKey, bytesToItemIndex)
+	if writeIndexIf == nil {
+		wcs.logger.Debug("failed getting write index, starting with a new one",
+			zap.String(zapQueueNameKey, wcs.queueName))
+		wcs.writeIndex = 0
+	} else {
+		wcs.writeIndex = writeIndexIf.(itemIndex)
+	}
+}
+
+// loop is the main loop that handles fetching items from the persistent buffer
+func (pcs *persistentContiguousStorage) loop() {
+	// We want to run it here so it's not blocking
+	reqs := pcs.retrieveUnprocessedItems(context.Background())
+	if len(reqs) > 0 {
+		errCount := 0
+		for _, req := range reqs {
+			if pcs.put(req) != nil {
+				errCount++
+			}
+		}
+		pcs.logger.Info("moved items for processing back to queue",
+			zap.String(zapQueueNameKey, pcs.queueName),
+			zap.Int(zapNumberOfItems, len(reqs)), zap.Int(zapErrorCount, errCount))
+	}
+
+	for {
+		for {
+			req, found := pcs.getNextItem(context.Background())
+			if found {
+				select {
+				case <-pcs.stopChan:
+					return
+				case pcs.reqChan <- req:
+				}
+			} else {
+				select {
+				case <-pcs.stopChan:
+					return
+				case <-time.After(pcs.retryDelay):
+				}
+			}
+		}
+	}
+}
+
+// get returns the request channel that all the requests will be send on
+func (pcs *persistentContiguousStorage) get() <-chan request {
+	return pcs.reqChan
+}
+
+// size returns the number of currently available items, which were not picked by consumers yet
+func (pcs *persistentContiguousStorage) size() int {
+	pcs.mu.Lock()
+	defer pcs.mu.Unlock()
+	return int(pcs.writeIndex - pcs.readIndex)
+}
+
+// numberOfCurrentlyProcessedItems returns the count of batches for which processing started but hasn't finish yet
+func (pcs *persistentContiguousStorage) numberOfCurrentlyProcessedItems() int {
+	pcs.mu.Lock()
+	defer pcs.mu.Unlock()
+	return len(pcs.currentlyProcessedItems)
+}
+
+func (pcs *persistentContiguousStorage) stop() {
+	pcs.logger.Debug("stopping persistentContiguousStorage", zap.String(zapQueueNameKey, pcs.queueName))
+	pcs.stopOnce.Do(func() {
+		_ = currentlyProcessedBatchesGauge.UpsertEntry(func() int64 {
+			return int64(0)
+		}, metricdata.NewLabelValue(pcs.queueName))
+		close(pcs.stopChan)
+	})
+}
+
+// put marshals the request and puts it into the persistent queue
+func (pcs *persistentContiguousStorage) put(req request) error {
+	pcs.mu.Lock()
+	defer pcs.mu.Unlock()
+
+	ctx := context.Background()
+
+	itemKey := pcs.itemKey(pcs.writeIndex)
+	if !pcs._clientSet(ctx, itemKey, req, requestToBytes) {
+		return errStoringItemToQueue
+	}
+
+	pcs.writeIndex++
+	if !pcs._clientSet(ctx, writeIndexKey, pcs.writeIndex, itemIndexToBytes) {
+		return errUpdatingIndex
+	}
+
+	return nil
+}
+
+// getNextItem pulls the next available item from the persistent storage; if none is found, returns (nil, false)
+func (pcs *persistentContiguousStorage) getNextItem(ctx context.Context) (request, bool) {
+	pcs.mu.Lock()
+	defer pcs.mu.Unlock()
+
+	if pcs.readIndex < pcs.writeIndex {
+		index := pcs.readIndex
+		// Increase here, so even if errors happen below, it always iterates
+		pcs.readIndex++
+
+		pcs.updateReadIndex(ctx)
+		pcs.itemProcessingStart(ctx, index)
+
+		req := pcs._clientGet(ctx, pcs.itemKey(index), pcs.bytesToRequest).(request)
+		if req == nil {
+			return nil, false
+		}
+
+		req.setOnProcessingFinished(func() {
+			pcs.mu.Lock()
+			defer pcs.mu.Unlock()
+			pcs.itemProcessingFinish(ctx, index)
+		})
+		return req, true
+	}
+
+	return nil, false
+}
+
+// retrieveUnprocessedItems gets the items for which processing was not finished, cleans the storage
+// and moves the items back to the queue
+func (pcs *persistentContiguousStorage) retrieveUnprocessedItems(ctx context.Context) []request {
+	var reqs []request
+	pcs.mu.Lock()
+	defer pcs.mu.Unlock()
+
+	pcs.logger.Debug("checking if there are items left by consumers")
+	processedItemsIf := pcs._clientGet(ctx, currentlyProcessedItemsKey, bytesToItemIndexArray)
+	if processedItemsIf == nil {
+		return reqs
+	}
+	processedItems, ok := processedItemsIf.([]itemIndex)
+	if !ok {
+		pcs.logger.Warn("failed fetching list of unprocessed items",
+			zap.String(zapQueueNameKey, pcs.queueName))
+		return reqs
+	}
+
+	if len(processedItems) > 0 {
+		pcs.logger.Info("fetching items left for processing by consumers",
+			zap.String(zapQueueNameKey, pcs.queueName), zap.Int(zapNumberOfItems, len(processedItems)))
+	} else {
+		pcs.logger.Debug("no items left for processing by consumers")
+	}
+
+	for _, it := range processedItems {
+		req := pcs._clientGet(ctx, pcs.itemKey(it), pcs.bytesToRequest).(request)
+		pcs._clientDelete(ctx, pcs.itemKey(it))
+		reqs = append(reqs, req)
+	}
+
+	return reqs
+}
+
+// itemProcessingStart appends the item to the list of currently processed items
+func (pcs *persistentContiguousStorage) itemProcessingStart(ctx context.Context, index itemIndex) {
+	pcs.currentlyProcessedItems = append(pcs.currentlyProcessedItems, index)
+	pcs._clientSet(ctx, currentlyProcessedItemsKey, pcs.currentlyProcessedItems, itemIndexArrayToBytes)
+}
+
+// itemProcessingFinish removes the item from the list of currently processed items and deletes it from the persistent queue
+func (pcs *persistentContiguousStorage) itemProcessingFinish(ctx context.Context, index itemIndex) {
+	var updatedProcessedItems []itemIndex
+	for _, it := range pcs.currentlyProcessedItems {
+		if it != index {
+			updatedProcessedItems = append(updatedProcessedItems, it)
+		}
+	}
+	pcs.currentlyProcessedItems = updatedProcessedItems
+
+	pcs._clientSet(ctx, currentlyProcessedItemsKey, pcs.currentlyProcessedItems, itemIndexArrayToBytes)
+	pcs._clientDelete(ctx, pcs.itemKey(index))
+}
+
+func (pcs *persistentContiguousStorage) updateReadIndex(ctx context.Context) {
+	pcs._clientSet(ctx, readIndexKey, pcs.readIndex, itemIndexToBytes)
+}
+
+func (pcs *persistentContiguousStorage) itemKey(index itemIndex) string {
+	return fmt.Sprintf("%d", index)
+}
+
+func (pcs *persistentContiguousStorage) _clientSet(ctx context.Context, key string, value interface{}, marshal func(interface{}) ([]byte, error)) bool {
+	valueBytes, err := marshal(value)
+	if err != nil {
+		pcs.logger.Warn("failed marshaling item",
+			zap.String(zapQueueNameKey, pcs.queueName), zap.String(zapKey, key), zap.Error(err))
+		return false
+	}
+
+	return pcs._clientSetBuf(ctx, key, valueBytes)
+}
+
+func (pcs *persistentContiguousStorage) _clientGet(ctx context.Context, key string, unmarshal func([]byte) (interface{}, error)) interface{} {
+	valueBytes := pcs._clientGetBuf(ctx, key)
+	if valueBytes == nil {
+		return nil
+	}
+
+	item, err := unmarshal(valueBytes)
+	if err != nil {
+		pcs.logger.Warn("failed unmarshaling item",
+			zap.String(zapQueueNameKey, pcs.queueName), zap.String(zapKey, key), zap.Error(err))
+		return nil
+	}
+
+	return item
+}
+
+func (pcs *persistentContiguousStorage) _clientDelete(ctx context.Context, key string) {
+	err := pcs.client.Delete(ctx, key)
+	if err != nil {
+		pcs.logger.Warn("failed deleting item",
+			zap.String(zapQueueNameKey, pcs.queueName), zap.String(zapKey, key))
+	}
+}
+
+func (pcs *persistentContiguousStorage) _clientGetBuf(ctx context.Context, key string) []byte {
+	buf, err := pcs.client.Get(ctx, key)
+	if err != nil {
+		pcs.logger.Debug("error when getting item from persistent storage",
+			zap.String(zapQueueNameKey, pcs.queueName), zap.String(zapKey, key), zap.Error(err))
+		return nil
+	}
+	return buf
+}
+
+func (pcs *persistentContiguousStorage) _clientSetBuf(ctx context.Context, key string, buf []byte) bool {
+	err := pcs.client.Set(ctx, key, buf)
+	if err != nil {
+		pcs.logger.Debug("error when storing item to persistent storage",
+			zap.String(zapQueueNameKey, pcs.queueName), zap.String(zapKey, key), zap.Error(err))
+		return false
+	}
+	return true
+}
+
+func itemIndexToBytes(val interface{}) ([]byte, error) {
+	var buf bytes.Buffer
+	err := binary.Write(&buf, binary.LittleEndian, val)
+	if err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), err
+}
+
+func bytesToItemIndex(b []byte) (interface{}, error) {
+	var val itemIndex
+	err := binary.Read(bytes.NewReader(b), binary.LittleEndian, &val)
+	if err != nil {
+		return val, err
+	}
+	return val, nil
+}
+
+func itemIndexArrayToBytes(arr interface{}) ([]byte, error) {
+	var buf bytes.Buffer
+	count := 0
+
+	if arr != nil {
+		arrItemIndex, ok := arr.([]itemIndex)
+		if ok {
+			count = len(arrItemIndex)
+		}
+	}
+
+	err := binary.Write(&buf, binary.LittleEndian, uint32(count))
+	if err != nil {
+		return nil, err
+	}
+
+	err = binary.Write(&buf, binary.LittleEndian, arr)
+	if err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), err
+}
+
+func bytesToItemIndexArray(b []byte) (interface{}, error) {
+	var size uint32
+	reader := bytes.NewReader(b)
+	err := binary.Read(reader, binary.LittleEndian, &size)
+	if err != nil {
+		return nil, err
+	}
+
+	val := make([]itemIndex, size)
+	err = binary.Read(reader, binary.LittleEndian, &val)
+	return val, err
+}
+
+func requestToBytes(req interface{}) ([]byte, error) {
+	return req.(request).marshal()
+}
+
+func (pcs *persistentContiguousStorage) bytesToRequest(b []byte) (interface{}, error) {
+	return pcs.unmarshaler(b)
+}

--- a/exporter/exporterhelper/persistent_storage.go
+++ b/exporter/exporterhelper/persistent_storage.go
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build enable_unstable
+// +build enable_unstable
+
 package exporterhelper
 
 import (

--- a/exporter/exporterhelper/persistent_storage_batch.go
+++ b/exporter/exporterhelper/persistent_storage_batch.go
@@ -1,0 +1,229 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exporterhelper
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"sync"
+
+	"go.uber.org/zap"
+
+	"go.opentelemetry.io/collector/extension/storage"
+)
+
+// batchStruct provides convenience capabilities for creating and processing storage extension batches
+type batchStruct struct {
+	logger *zap.Logger
+	pcs    *persistentContiguousStorage
+
+	mu sync.Mutex
+
+	operations    []storage.Operation
+	getOperations map[string]storage.Operation
+}
+
+func newBatch(pcs *persistentContiguousStorage) *batchStruct {
+	return &batchStruct{
+		logger:        pcs.logger,
+		pcs:           pcs,
+		operations:    []storage.Operation{},
+		getOperations: map[string]storage.Operation{},
+	}
+}
+
+// execute runs the provided operations in order
+func (bof *batchStruct) execute(ctx context.Context) (*batchStruct, error) {
+	bof.mu.Lock()
+	defer bof.mu.Unlock()
+
+	err := bof.pcs.client.Batch(ctx, bof.operations...)
+	if err != nil {
+		return nil, err
+	}
+
+	return bof, nil
+}
+
+// set adds a Set operation to the batch
+func (bof *batchStruct) set(key string, value interface{}, marshal func(interface{}) ([]byte, error)) *batchStruct {
+	bof.mu.Lock()
+	defer bof.mu.Unlock()
+
+	valueBytes, err := marshal(value)
+	if err != nil {
+		bof.logger.Warn("failed marshaling item, skipping it", zap.String(zapKey, key), zap.Error(err))
+	}
+
+	bof.operations = append(bof.operations, storage.SetOperation(key, valueBytes))
+	return bof
+}
+
+// get adds a Get operation to the batch. After executing, its result will be available through getResult
+func (bof *batchStruct) get(keys ...string) *batchStruct {
+	bof.mu.Lock()
+	defer bof.mu.Unlock()
+
+	for _, key := range keys {
+		op := storage.GetOperation(key)
+		bof.getOperations[key] = op
+		bof.operations = append(bof.operations, op)
+	}
+
+	return bof
+}
+
+// delete adds a Delete operation to the batch
+func (bof *batchStruct) delete(keys ...string) *batchStruct {
+	bof.mu.Lock()
+	defer bof.mu.Unlock()
+
+	for _, key := range keys {
+		bof.operations = append(bof.operations, storage.DeleteOperation(key))
+	}
+
+	return bof
+}
+
+// getResult returns the result of a Get operation for a given key using the provided unmarshal function.
+// It should be called after execute
+func (bof *batchStruct) getResult(key string, unmarshal func([]byte) (interface{}, error)) (interface{}, error) {
+	op := bof.getOperations[key]
+	if op == nil {
+		return nil, errKeyNotPresentInBatch
+	}
+
+	if op.Value == nil {
+		return nil, nil
+	}
+
+	return unmarshal(op.Value)
+}
+
+// getRequestResult returns the result of a Get operation as a request
+func (bof *batchStruct) getRequestResult(key string) (request, error) {
+	reqIf, err := bof.getResult(key, bof.bytesToRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	return reqIf.(request), nil
+}
+
+// getItemIndexResult returns the result of a Get operation as an itemIndex
+func (bof *batchStruct) getItemIndexResult(key string) (itemIndex, error) {
+	itemIndexIf, err := bof.getResult(key, bytesToItemIndex)
+	if err != nil {
+		return itemIndex(0), err
+	}
+
+	if itemIndexIf == nil {
+		return itemIndex(0), errValueNotSet
+	}
+
+	return itemIndexIf.(itemIndex), nil
+}
+
+// getItemIndexArrayResult returns the result of a Get operation as a itemIndexArray
+func (bof *batchStruct) getItemIndexArrayResult(key string) ([]itemIndex, error) {
+	itemIndexArrIf, err := bof.getResult(key, bytesToItemIndexArray)
+	if err != nil {
+		return nil, err
+	}
+
+	if itemIndexArrIf == nil {
+		return nil, nil
+	}
+
+	return itemIndexArrIf.([]itemIndex), nil
+}
+
+// setRequest adds Set operation over a given request to the batch
+func (bof *batchStruct) setRequest(key string, value request) *batchStruct {
+	return bof.set(key, value, requestToBytes)
+}
+
+// setItemIndex adds Set operation over a given itemIndex to the batch
+func (bof *batchStruct) setItemIndex(key string, value itemIndex) *batchStruct {
+	return bof.set(key, value, itemIndexToBytes)
+}
+
+// setItemIndexArray adds Set operation over a given itemIndex array to the batch
+func (bof *batchStruct) setItemIndexArray(key string, value []itemIndex) *batchStruct {
+	return bof.set(key, value, itemIndexArrayToBytes)
+}
+
+func itemIndexToBytes(val interface{}) ([]byte, error) {
+	var buf bytes.Buffer
+	err := binary.Write(&buf, binary.LittleEndian, val)
+	if err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), err
+}
+
+func bytesToItemIndex(b []byte) (interface{}, error) {
+	var val itemIndex
+	err := binary.Read(bytes.NewReader(b), binary.LittleEndian, &val)
+	if err != nil {
+		return val, err
+	}
+	return val, nil
+}
+
+func itemIndexArrayToBytes(arr interface{}) ([]byte, error) {
+	var buf bytes.Buffer
+	count := 0
+
+	if arr != nil {
+		arrItemIndex, ok := arr.([]itemIndex)
+		if ok {
+			count = len(arrItemIndex)
+		}
+	}
+
+	err := binary.Write(&buf, binary.LittleEndian, uint32(count))
+	if err != nil {
+		return nil, err
+	}
+
+	err = binary.Write(&buf, binary.LittleEndian, arr)
+	if err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), err
+}
+
+func bytesToItemIndexArray(b []byte) (interface{}, error) {
+	var size uint32
+	reader := bytes.NewReader(b)
+	err := binary.Read(reader, binary.LittleEndian, &size)
+	if err != nil {
+		return nil, err
+	}
+
+	val := make([]itemIndex, size)
+	err = binary.Read(reader, binary.LittleEndian, &val)
+	return val, err
+}
+
+func requestToBytes(req interface{}) ([]byte, error) {
+	return req.(request).marshal()
+}
+
+func (bof *batchStruct) bytesToRequest(b []byte) (interface{}, error) {
+	return bof.pcs.unmarshaler(b)
+}

--- a/exporter/exporterhelper/persistent_storage_batch.go
+++ b/exporter/exporterhelper/persistent_storage_batch.go
@@ -69,9 +69,10 @@ func (bof *batchStruct) set(key string, value interface{}, marshal func(interfac
 	valueBytes, err := marshal(value)
 	if err != nil {
 		bof.logger.Debug("failed marshaling item, skipping it", zap.String(zapKey, key), zap.Error(err))
+	} else {
+		bof.operations = append(bof.operations, storage.SetOperation(key, valueBytes))
 	}
 
-	bof.operations = append(bof.operations, storage.SetOperation(key, valueBytes))
 	return bof
 }
 

--- a/exporter/exporterhelper/persistent_storage_batch.go
+++ b/exporter/exporterhelper/persistent_storage_batch.go
@@ -59,7 +59,7 @@ func (bof *batchStruct) execute(ctx context.Context) (*batchStruct, error) {
 func (bof *batchStruct) set(key string, value interface{}, marshal func(interface{}) ([]byte, error)) *batchStruct {
 	valueBytes, err := marshal(value)
 	if err != nil {
-		bof.logger.Debug("failed marshaling item, skipping it", zap.String(zapKey, key), zap.Error(err))
+		bof.logger.Debug("Failed marshaling item, skipping it", zap.String(zapKey, key), zap.Error(err))
 	} else {
 		bof.operations = append(bof.operations, storage.SetOperation(key, valueBytes))
 	}

--- a/exporter/exporterhelper/persistent_storage_batch.go
+++ b/exporter/exporterhelper/persistent_storage_batch.go
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build enable_unstable
+// +build enable_unstable
+
 package exporterhelper
 
 import (

--- a/exporter/exporterhelper/persistent_storage_batch_test.go
+++ b/exporter/exporterhelper/persistent_storage_batch_test.go
@@ -1,0 +1,70 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exporterhelper
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPersistentStorageBatch_Operations(t *testing.T) {
+	path := createTemporaryDirectory()
+	defer os.RemoveAll(path)
+
+	ext := createStorageExtension(path)
+	client := createTestClient(ext)
+	ps := createTestPersistentStorage(client)
+
+	itemIndexValue := itemIndex(123)
+	itemIndexArrayValue := []itemIndex{itemIndex(1), itemIndex(2)}
+
+	_, err := newBatch(ps).
+		setItemIndex("index", itemIndexValue).
+		setItemIndexArray("arr", itemIndexArrayValue).
+		execute(context.Background())
+
+	require.NoError(t, err)
+
+	batch, err := newBatch(ps).
+		get("index", "arr").
+		execute(context.Background())
+	require.NoError(t, err)
+
+	retrievedItemIndexValue, err := batch.getItemIndexResult("index")
+	require.NoError(t, err)
+	require.Equal(t, itemIndexValue, retrievedItemIndexValue)
+
+	retrievedItemIndexArrayValue, err := batch.getItemIndexArrayResult("arr")
+	require.NoError(t, err)
+	require.Equal(t, itemIndexArrayValue, retrievedItemIndexArrayValue)
+
+	_, err = newBatch(ps).delete("index", "arr").execute(context.Background())
+	require.NoError(t, err)
+
+	batch, err = newBatch(ps).
+		get("index", "arr").
+		execute(context.Background())
+	require.NoError(t, err)
+
+	_, err = batch.getItemIndexResult("index")
+	require.Error(t, err, errValueNotSet)
+
+	retrievedItemIndexArrayValue, err = batch.getItemIndexArrayResult("arr")
+	require.NoError(t, err)
+	require.Nil(t, retrievedItemIndexArrayValue)
+}

--- a/exporter/exporterhelper/persistent_storage_batch_test.go
+++ b/exporter/exporterhelper/persistent_storage_batch_test.go
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build enable_unstable
+// +build enable_unstable
+
 package exporterhelper
 
 import (

--- a/exporter/exporterhelper/persistent_storage_test.go
+++ b/exporter/exporterhelper/persistent_storage_test.go
@@ -1,0 +1,337 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exporterhelper
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.opencensus.io/tag"
+	"go.uber.org/zap"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/extension/storage"
+)
+
+func createStorageExtension(_ string) storage.Extension {
+	// After having storage moved to core, we could leverage storagetest.NewTestExtension(nil, path)
+	return newMockStorageExtension()
+}
+
+func createTestClient(extension storage.Extension) storage.Client {
+	client, err := extension.GetClient(context.Background(), component.KindReceiver, config.ComponentID{}, "")
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
+func createTestPersistentStorage(client storage.Client) *persistentContiguousStorage {
+	logger, _ := zap.NewDevelopment()
+	return newPersistentContiguousStorage(context.Background(), "foo", logger, client, newTraceRequestUnmarshalerFunc(nopTracePusher()))
+}
+
+func createTemporaryDirectory() string {
+	directory, err := ioutil.TempDir("", "persistent-test")
+	if err != nil {
+		panic(err)
+	}
+	return directory
+}
+
+func TestPersistentStorage_CurrentlyProcessedItems(t *testing.T) {
+	path := createTemporaryDirectory()
+	defer os.RemoveAll(path)
+
+	traces := newTraces(5, 10)
+	req := newTracesRequest(context.Background(), traces, nopTracePusher())
+
+	ext := createStorageExtension(path)
+	client := createTestClient(ext)
+	ps := createTestPersistentStorage(client)
+
+	for i := 0; i < 5; i++ {
+		err := ps.put(req)
+		require.NoError(t, err)
+	}
+
+	requireItemIndexesEqual(t, ps, []itemIndex{0})
+
+	readReq := getItemFromChannel(t, ps)
+	require.Equal(t, req.(*tracesRequest).td, readReq.(*tracesRequest).td)
+
+	requireItemIndexesEqual(t, ps, []itemIndex{0, 1})
+
+	secondReadReq := getItemFromChannel(t, ps)
+	requireItemIndexesEqual(t, ps, []itemIndex{0, 1, 2})
+
+	secondReadReq.onProcessingFinished()
+	requireItemIndexesEqual(t, ps, []itemIndex{0, 2})
+
+	// Reload the storage and check how many items are there, which, after the current one is fetched should go to 3
+	newPs := createTestPersistentStorage(client)
+	require.Eventually(t, func() bool {
+		return newPs.size() == 3
+	}, 500*time.Millisecond, 10*time.Millisecond)
+
+	requireItemIndexesEqual(t, newPs, []itemIndex{3})
+
+	for i := 0; i < 4; i++ {
+		req := getItemFromChannel(t, newPs)
+		req.onProcessingFinished()
+	}
+
+	requireItemIndexesEqual(t, newPs, nil)
+	require.Eventually(t, func() bool {
+		return newPs.size() == 0
+	}, 500*time.Millisecond, 10*time.Millisecond)
+
+	// The writeIndex should be now set accordingly
+	require.Equal(t, 7, int(newPs.writeIndex))
+	// There should be no items left in the storage
+	for i := 0; i < int(newPs.writeIndex); i++ {
+		require.Nil(t, newPs._clientGetBuf(context.Background(), newPs.itemKey(itemIndex(i))))
+	}
+}
+
+func TestPersistentStorage_MetricsReported(t *testing.T) {
+	path := createTemporaryDirectory()
+	defer os.RemoveAll(path)
+
+	traces := newTraces(5, 10)
+	req := newTracesRequest(context.Background(), traces, nopTracePusher())
+
+	ext := createStorageExtension(path)
+	client := createTestClient(ext)
+	ps := createTestPersistentStorage(client)
+
+	for i := 0; i < 5; i++ {
+		err := ps.put(req)
+		require.NoError(t, err)
+	}
+
+	_ = getItemFromChannel(t, ps)
+	requireItemIndexesEqual(t, ps, []itemIndex{0, 1})
+	checkValueForProducer(t, []tag.Tag{{Key: exporterTag, Value: "foo"}}, int64(2), "exporter/processed_batches_size")
+
+	ps.stop()
+	checkValueForProducer(t, []tag.Tag{{Key: exporterTag, Value: "foo"}}, int64(0), "exporter/processed_batches_size")
+}
+
+func TestPersistentStorage_RepeatPutCloseReadClose(t *testing.T) {
+	path := createTemporaryDirectory()
+	defer os.RemoveAll(path)
+
+	traces := newTraces(5, 10)
+	req := newTracesRequest(context.Background(), traces, nopTracePusher())
+
+	for i := 0; i < 10; i++ {
+		ext := createStorageExtension(path)
+		client := createTestClient(ext)
+		ps := createTestPersistentStorage(client)
+		require.Equal(t, 0, ps.size())
+
+		// Put two elements
+		err := ps.put(req)
+		require.NoError(t, err)
+		err = ps.put(req)
+		require.NoError(t, err)
+
+		err = ext.Shutdown(context.Background())
+		require.NoError(t, err)
+
+		// TODO: when replacing mock with real storage, this could actually be uncommented
+		// ext = createStorageExtension(path)
+		// ps = createTestPersistentStorage(ext)
+
+		// The first element should be already picked by loop
+		require.Eventually(t, func() bool {
+			return ps.size() == 1
+		}, 500*time.Millisecond, 10*time.Millisecond)
+
+		// Lets read both of the elements we put
+		readReq := getItemFromChannel(t, ps)
+		require.Equal(t, req.(*tracesRequest).td, readReq.(*tracesRequest).td)
+
+		readReq = getItemFromChannel(t, ps)
+		require.Equal(t, req.(*tracesRequest).td, readReq.(*tracesRequest).td)
+		require.Equal(t, 0, ps.size())
+
+		err = ext.Shutdown(context.Background())
+		require.NoError(t, err)
+	}
+
+	// No more items
+	ext := createStorageExtension(path)
+	wq := createTestQueue(ext, 5000)
+	require.Equal(t, 0, wq.Size())
+	ext.Shutdown(context.Background())
+}
+
+func BenchmarkPersistentStorage_TraceSpans(b *testing.B) {
+	cases := []struct {
+		numTraces        int
+		numSpansPerTrace int
+	}{
+		{
+			numTraces:        1,
+			numSpansPerTrace: 1,
+		},
+		{
+			numTraces:        1,
+			numSpansPerTrace: 10,
+		},
+		{
+			numTraces:        10,
+			numSpansPerTrace: 10,
+		},
+	}
+
+	for _, c := range cases {
+		b.Run(fmt.Sprintf("#traces: %d #spansPerTrace: %d", c.numTraces, c.numSpansPerTrace), func(bb *testing.B) {
+			path := createTemporaryDirectory()
+			defer os.RemoveAll(path)
+			ext := createStorageExtension(path)
+			client := createTestClient(ext)
+			ps := createTestPersistentStorage(client)
+
+			traces := newTraces(c.numTraces, c.numSpansPerTrace)
+			req := newTracesRequest(context.Background(), traces, nopTracePusher())
+
+			bb.ResetTimer()
+
+			for i := 0; i < bb.N; i++ {
+				err := ps.put(req)
+				require.NoError(bb, err)
+			}
+
+			for i := 0; i < bb.N; i++ {
+				req := ps.get()
+				require.NotNil(bb, req)
+			}
+			ext.Shutdown(context.Background())
+		})
+	}
+}
+
+func TestPersistentStorage_ItemIndexMarshaling(t *testing.T) {
+	cases := []struct {
+		arr1 []itemIndex
+		arr2 []itemIndex
+	}{
+		{
+			arr1: []itemIndex{0, 1, 2},
+			arr2: []itemIndex{0, 1, 2},
+		},
+		{
+			arr1: []itemIndex{},
+			arr2: []itemIndex{},
+		},
+		{
+			arr1: nil,
+			arr2: []itemIndex{},
+		},
+	}
+
+	for _, c := range cases {
+		count := 0
+		if c.arr1 != nil {
+			count = len(c.arr1)
+		}
+		t.Run(fmt.Sprintf("#elements:%d", count), func(tt *testing.T) {
+			barr, err := itemIndexArrayToBytes(c.arr1)
+			require.NoError(t, err)
+			arr2, err := bytesToItemIndexArray(barr)
+			require.NoError(t, err)
+			require.Equal(t, c.arr2, arr2)
+		})
+	}
+}
+
+func getItemFromChannel(t *testing.T, pcs *persistentContiguousStorage) request {
+	var readReq request
+	require.Eventually(t, func() bool {
+		readReq = <-pcs.get()
+		return true
+	}, 500*time.Millisecond, 10*time.Millisecond)
+	return readReq
+}
+
+func requireItemIndexesEqual(t *testing.T, pcs *persistentContiguousStorage, compare []itemIndex) {
+	require.Eventually(t, func() bool {
+		pcs.mu.Lock()
+		defer pcs.mu.Unlock()
+		return reflect.DeepEqual(pcs.currentlyProcessedItems, compare)
+	}, 500*time.Millisecond, 10*time.Millisecond)
+}
+
+type mockStorageExtension struct{}
+
+func (m mockStorageExtension) Start(_ context.Context, _ component.Host) error {
+	return nil
+}
+
+func (m mockStorageExtension) Shutdown(_ context.Context) error {
+	return nil
+}
+
+func (m mockStorageExtension) GetClient(ctx context.Context, kind component.Kind, id config.ComponentID, s string) (storage.Client, error) {
+	return newMockStorageClient(), nil
+}
+
+func newMockStorageExtension() storage.Extension {
+	return &mockStorageExtension{}
+}
+
+func newMockStorageClient() storage.Client {
+	return &mockStorageClient{
+		st: map[string][]byte{},
+	}
+}
+
+type mockStorageClient struct {
+	st map[string][]byte
+}
+
+func (m mockStorageClient) Get(_ context.Context, s string) ([]byte, error) {
+	val, found := m.st[s]
+	if !found {
+		return []byte{}, errors.New("key not found")
+	}
+
+	return val, nil
+}
+
+func (m mockStorageClient) Set(_ context.Context, s string, bytes []byte) error {
+	m.st[s] = bytes
+	return nil
+}
+
+func (m mockStorageClient) Delete(_ context.Context, s string) error {
+	delete(m.st, s)
+	return nil
+}
+
+func (m mockStorageClient) Close(_ context.Context) error {
+	return nil
+}

--- a/exporter/exporterhelper/persistent_storage_test.go
+++ b/exporter/exporterhelper/persistent_storage_test.go
@@ -199,6 +199,25 @@ func TestPersistentStorage_RepeatPutCloseReadClose(t *testing.T) {
 	ext.Shutdown(context.Background())
 }
 
+func TestPersistentStorage_EmptyRequest(t *testing.T) {
+	path := createTemporaryDirectory()
+	defer os.RemoveAll(path)
+
+	ext := createStorageExtension(path)
+	client := createTestClient(ext)
+	ps := createTestPersistentStorage(client)
+
+	require.Equal(t, 0, ps.size())
+
+	err := ps.put(nil)
+	require.NoError(t, err)
+
+	require.Equal(t, 0, ps.size())
+
+	err = ext.Shutdown(context.Background())
+	require.NoError(t, err)
+}
+
 func BenchmarkPersistentStorage_TraceSpans(b *testing.B) {
 	cases := []struct {
 		numTraces        int

--- a/exporter/exporterhelper/persistent_storage_test.go
+++ b/exporter/exporterhelper/persistent_storage_test.go
@@ -147,10 +147,10 @@ func TestPersistentStorage_MetricsReported(t *testing.T) {
 
 	_ = getItemFromChannel(t, ps)
 	requireCurrentItemIndexesEqual(t, ps, []itemIndex{0, 1})
-	checkValueForProducer(t, []tag.Tag{{Key: exporterTag, Value: "foo"}}, int64(2), "exporter/processed_batches_size")
+	checkValueForProducer(t, []tag.Tag{{Key: exporterTag, Value: "foo"}}, int64(2), "exporter/currently_processed_batches")
 
 	ps.stop()
-	checkValueForProducer(t, []tag.Tag{{Key: exporterTag, Value: "foo"}}, int64(2), "exporter/processed_batches_size")
+	checkValueForProducer(t, []tag.Tag{{Key: exporterTag, Value: "foo"}}, int64(2), "exporter/currently_processed_batches")
 }
 
 func TestPersistentStorage_RepeatPutCloseReadClose(t *testing.T) {

--- a/exporter/exporterhelper/persistent_storage_test.go
+++ b/exporter/exporterhelper/persistent_storage_test.go
@@ -47,13 +47,13 @@ func createTestClient(extension storage.Extension) storage.Client {
 	return client
 }
 
-func createTestPersistentStorageWithCapacity(client storage.Client, capacity uint64) *persistentContiguousStorage {
-	logger, _ := zap.NewDevelopment()
+func createTestPersistentStorageWithLoggingAndCapacity(client storage.Client, logger *zap.Logger, capacity uint64) *persistentContiguousStorage {
 	return newPersistentContiguousStorage(context.Background(), "foo", capacity, logger, client, newTraceRequestUnmarshalerFunc(nopTracePusher()))
 }
 
 func createTestPersistentStorage(client storage.Client) *persistentContiguousStorage {
-	return createTestPersistentStorageWithCapacity(client, 1000)
+	logger, _ := zap.NewDevelopment()
+	return createTestPersistentStorageWithLoggingAndCapacity(client, logger, 1000)
 }
 
 func createTemporaryDirectory() string {
@@ -247,7 +247,7 @@ func BenchmarkPersistentStorage_TraceSpans(b *testing.B) {
 			defer os.RemoveAll(path)
 			ext := createStorageExtension(path)
 			client := createTestClient(ext)
-			ps := createTestPersistentStorageWithCapacity(client, 10000000)
+			ps := createTestPersistentStorageWithLoggingAndCapacity(client, zap.NewNop(), 10000000)
 
 			traces := newTraces(c.numTraces, c.numSpansPerTrace)
 			req := newTracesRequest(context.Background(), traces, nopTracePusher())

--- a/exporter/exporterhelper/persistent_storage_test.go
+++ b/exporter/exporterhelper/persistent_storage_test.go
@@ -146,7 +146,7 @@ func TestPersistentStorage_MetricsReported(t *testing.T) {
 	checkValueForProducer(t, []tag.Tag{{Key: exporterTag, Value: "foo"}}, int64(2), "exporter/processed_batches_size")
 
 	ps.stop()
-	checkValueForProducer(t, []tag.Tag{{Key: exporterTag, Value: "foo"}}, int64(0), "exporter/processed_batches_size")
+	checkValueForProducer(t, []tag.Tag{{Key: exporterTag, Value: "foo"}}, int64(2), "exporter/processed_batches_size")
 }
 
 func TestPersistentStorage_RepeatPutCloseReadClose(t *testing.T) {

--- a/exporter/exporterhelper/persistent_storage_test.go
+++ b/exporter/exporterhelper/persistent_storage_test.go
@@ -49,7 +49,7 @@ func createTestClient(extension storage.Extension) storage.Client {
 
 func createTestPersistentStorage(client storage.Client) *persistentContiguousStorage {
 	logger, _ := zap.NewDevelopment()
-	return newPersistentContiguousStorage(context.Background(), "foo", logger, client, newTraceRequestUnmarshalerFunc(nopTracePusher()))
+	return newPersistentContiguousStorage(context.Background(), "foo", 1000, logger, client, newTraceRequestUnmarshalerFunc(nopTracePusher()))
 }
 
 func createTemporaryDirectory() string {

--- a/exporter/exporterhelper/persistent_storage_test.go
+++ b/exporter/exporterhelper/persistent_storage_test.go
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build enable_unstable
+// +build enable_unstable
+
 package exporterhelper
 
 import (

--- a/exporter/exporterhelper/queued_retry.go
+++ b/exporter/exporterhelper/queued_retry.go
@@ -441,7 +441,7 @@ func (rs *retrySender) send(req request) error {
 		)
 		retryNum++
 
-		// back-off, but Get interrupted when shutting down or request is cancelled or timed out.
+		// back-off, but get interrupted when shutting down or request is cancelled or timed out.
 		select {
 		case <-req.context().Done():
 			return fmt.Errorf("request is cancelled or timed out %w", err)

--- a/exporter/exporterhelper/queued_retry.go
+++ b/exporter/exporterhelper/queued_retry.go
@@ -97,7 +97,7 @@ type RetrySettings struct {
 	// MaxInterval is the upper bound on backoff interval. Once this value is reached the delay between
 	// consecutive retries will always be `MaxInterval`.
 	MaxInterval time.Duration `mapstructure:"max_interval"`
-	// MaxElapsedTime is the maximum amount of time (including retries) spent trying to send a request/batch.
+	// MaxElapsedTime is the maximum amount of time (including retries) spent trying to send a request/batchStruct.
 	// Once this value is reached, the data is discarded.
 	MaxElapsedTime time.Duration `mapstructure:"max_elapsed_time"`
 }
@@ -423,7 +423,7 @@ func (rs *retrySender) send(req request) error {
 
 		backoffDelay := expBackoff.NextBackOff()
 		if backoffDelay == backoff.Stop {
-			// throw away the batch
+			// throw away the batchStruct
 			err = fmt.Errorf("max elapsed time expired %w", err)
 			return rs.onTemporaryFailure(req, err)
 		}

--- a/exporter/exporterhelper/queued_retry.go
+++ b/exporter/exporterhelper/queued_retry.go
@@ -47,7 +47,7 @@ var (
 		metric.WithUnit(metricdata.UnitDimensionless))
 
 	currentlyProcessedBatchesGauge, _ = r.AddInt64DerivedGauge(
-		obsmetrics.ExporterKey+"/processed_batches_size",
+		obsmetrics.ExporterKey+"/currently_processed_batches",
 		metric.WithDescription("Number of currently processed batches"),
 		metric.WithLabelKeys(obsmetrics.ExporterKey),
 		metric.WithUnit(metricdata.UnitDimensionless))

--- a/exporter/exporterhelper/queued_retry.go
+++ b/exporter/exporterhelper/queued_retry.go
@@ -29,8 +29,11 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/exporter/exporterhelper/internal"
+	"go.opentelemetry.io/collector/extension/storage"
 	"go.opentelemetry.io/collector/internal/obsreportconfig/obsmetrics"
 )
 
@@ -43,7 +46,9 @@ var (
 		metric.WithLabelKeys(obsmetrics.ExporterKey),
 		metric.WithUnit(metricdata.UnitDimensionless))
 
-	errSendingQueueIsFull = errors.New("sending_queue is full")
+	errNoStorageClient        = errors.New("no storage client extension found")
+	errMultipleStorageClients = errors.New("multiple storage extensions found")
+	errSendingQueueIsFull     = errors.New("sending_queue is full")
 )
 
 func init() {
@@ -58,6 +63,8 @@ type QueueSettings struct {
 	NumConsumers int `mapstructure:"num_consumers"`
 	// QueueSize is the maximum number of batches allowed in queue at a given time.
 	QueueSize int `mapstructure:"queue_size"`
+	// PersistentEnabled describes whether persistency via storage file extension should be enabled
+	PersistentEnabled bool `mapstructure:"persistent_enabled"`
 }
 
 // DefaultQueueSettings returns the default settings for QueueSettings.
@@ -69,7 +76,8 @@ func DefaultQueueSettings() QueueSettings {
 		// This is a pretty decent value for production.
 		// User should calculate this from the perspective of how many seconds to buffer in case of a backend outage,
 		// multiply that by the number of requests per seconds.
-		QueueSize: 5000,
+		QueueSize:         5000,
+		PersistentEnabled: false,
 	}
 }
 
@@ -99,13 +107,16 @@ func DefaultRetrySettings() RetrySettings {
 }
 
 type queuedRetrySender struct {
-	fullName        string
-	cfg             QueueSettings
-	consumerSender  requestSender
-	queue           *internal.BoundedQueue
-	retryStopCh     chan struct{}
-	traceAttributes []attribute.KeyValue
-	logger          *zap.Logger
+	id                 config.ComponentID
+	signalName         string
+	cfg                QueueSettings
+	consumerSender     requestSender
+	queue              consumersQueue
+	retryStopCh        chan struct{}
+	traceAttributes    []attribute.KeyValue
+	logger             *zap.Logger
+	requeuingEnabled   bool
+	requestUnmarshaler requestUnmarshaler
 }
 
 func createSampledLogger(logger *zap.Logger) *zap.Logger {
@@ -127,29 +138,128 @@ func createSampledLogger(logger *zap.Logger) *zap.Logger {
 	return logger.WithOptions(opts)
 }
 
-func newQueuedRetrySender(fullName string, qCfg QueueSettings, rCfg RetrySettings, nextSender requestSender, logger *zap.Logger) *queuedRetrySender {
+func newQueuedRetrySender(id config.ComponentID, signalName string, qCfg QueueSettings, rCfg RetrySettings, reqUnmarshaler requestUnmarshaler, nextSender requestSender, logger *zap.Logger) *queuedRetrySender {
 	retryStopCh := make(chan struct{})
 	sampledLogger := createSampledLogger(logger)
-	traceAttr := attribute.String(obsmetrics.ExporterKey, fullName)
-	return &queuedRetrySender{
-		fullName: fullName,
-		cfg:      qCfg,
-		consumerSender: &retrySender{
-			traceAttribute: traceAttr,
-			cfg:            rCfg,
-			nextSender:     nextSender,
-			stopCh:         retryStopCh,
-			logger:         sampledLogger,
-		},
-		queue:           internal.NewBoundedQueue(qCfg.QueueSize, func(item interface{}) {}),
-		retryStopCh:     retryStopCh,
-		traceAttributes: []attribute.KeyValue{traceAttr},
-		logger:          sampledLogger,
+	traceAttr := attribute.String(obsmetrics.ExporterKey, id.String())
+
+	qrs := &queuedRetrySender{
+		id:                 id,
+		signalName:         signalName,
+		cfg:                qCfg,
+		retryStopCh:        retryStopCh,
+		traceAttributes:    []attribute.KeyValue{traceAttr},
+		logger:             sampledLogger,
+		requestUnmarshaler: reqUnmarshaler,
 	}
+
+	qrs.consumerSender = &retrySender{
+		traceAttribute: traceAttr,
+		cfg:            rCfg,
+		nextSender:     nextSender,
+		stopCh:         retryStopCh,
+		logger:         sampledLogger,
+		// Following three functions are provided in such way because they actually depend on queuedRetrySender
+		onSuccess:          qrs.onSuccess,
+		onTemporaryFailure: qrs.onTemporaryFailure,
+		onPermanentFailure: qrs.onPermanentFailure,
+	}
+
+	if !qCfg.PersistentEnabled {
+		qrs.queue = internal.NewBoundedQueue(qrs.cfg.QueueSize, func(item interface{}) {})
+	}
+	// The Persistent Queue is initialized separately as it needs extra information about the component
+
+	return qrs
+}
+
+func (qrs *queuedRetrySender) onSuccess(req request, err error) error {
+	return nil
+}
+
+func (qrs *queuedRetrySender) onPermanentFailure(req request, err error) error {
+	return err
+}
+
+func (qrs *queuedRetrySender) onTemporaryFailure(req request, err error) error {
+	if qrs.requeuingEnabled && qrs.queue != nil {
+		if qrs.queue.Produce(req) {
+			qrs.logger.Error(
+				"Exporting failed. Putting back to the end of the queue.",
+				zap.Error(err),
+			)
+		} else {
+			qrs.logger.Error(
+				"Exporting failed. Queue did not accept requeuing request. Dropping data.",
+				zap.Error(err),
+				zap.Int("dropped_items", req.count()),
+			)
+		}
+		return err
+	}
+
+	qrs.logger.Error(
+		"Exporting failed. No more retries left. Dropping data.",
+		zap.Error(err),
+		zap.Int("dropped_items", req.count()),
+	)
+	return err
+}
+
+func getStorageClient(ctx context.Context, host component.Host, id config.ComponentID, signalName string) (*storage.Client, error) {
+	var storageExtension storage.Extension
+	for _, ext := range host.GetExtensions() {
+		if se, ok := ext.(storage.Extension); ok {
+			if storageExtension != nil {
+				return nil, errMultipleStorageClients
+			}
+			storageExtension = se
+		}
+	}
+
+	if storageExtension == nil {
+		return nil, errNoStorageClient
+	}
+
+	client, err := storageExtension.GetClient(ctx, component.KindExporter, id, signalName)
+	if err != nil {
+		return nil, err
+	}
+
+	return &client, err
+}
+
+// initializePersistentQueue uses extra information for initialization available from component.Host
+func (qrs *queuedRetrySender) initializePersistentQueue(ctx context.Context, host component.Host) error {
+	if qrs.cfg.PersistentEnabled {
+		storageClient, err := getStorageClient(ctx, host, qrs.id, qrs.signalName)
+		if err != nil {
+			return err
+		}
+
+		qrs.queue = newPersistentQueue(ctx, qrs.fullName(), qrs.cfg.QueueSize, qrs.logger, *storageClient, qrs.requestUnmarshaler)
+
+		// TODO: this can be further exposed as a config param rather than relying on a type of queue
+		qrs.requeuingEnabled = true
+	}
+
+	return nil
+}
+
+func (qrs *queuedRetrySender) fullName() string {
+	if qrs.signalName == "" {
+		return qrs.id.String()
+	}
+	return fmt.Sprintf("%s-%s", qrs.id.String(), qrs.signalName)
 }
 
 // start is invoked during service startup.
-func (qrs *queuedRetrySender) start() error {
+func (qrs *queuedRetrySender) start(ctx context.Context, host component.Host) error {
+	err := qrs.initializePersistentQueue(ctx, host)
+	if err != nil {
+		return err
+	}
+
 	qrs.queue.StartConsumers(qrs.cfg.NumConsumers, func(item interface{}) {
 		req := item.(request)
 		_ = qrs.consumerSender.send(req)
@@ -159,7 +269,7 @@ func (qrs *queuedRetrySender) start() error {
 	if qrs.cfg.Enabled {
 		err := queueSizeGauge.UpsertEntry(func() int64 {
 			return int64(qrs.queue.Size())
-		}, metricdata.NewLabelValue(qrs.fullName))
+		}, metricdata.NewLabelValue(qrs.fullName()))
 		if err != nil {
 			return fmt.Errorf("failed to create retry queue size metric: %v", err)
 		}
@@ -205,15 +315,17 @@ func (qrs *queuedRetrySender) shutdown() {
 	if qrs.cfg.Enabled {
 		_ = queueSizeGauge.UpsertEntry(func() int64 {
 			return int64(0)
-		}, metricdata.NewLabelValue(qrs.fullName))
+		}, metricdata.NewLabelValue(qrs.fullName()))
 	}
 
-	// First stop the retry goroutines, so that unblocks the queue workers.
+	// First Stop the retry goroutines, so that unblocks the queue numWorkers.
 	close(qrs.retryStopCh)
 
 	// Stop the queued sender, this will drain the queue and will call the retry (which is stopped) that will only
 	// try once every request.
-	qrs.queue.Stop()
+	if qrs.queue != nil {
+		qrs.queue.Stop()
+	}
 }
 
 // TODO: Clean this by forcing all exporters to return an internal error type that always include the information about retries.
@@ -238,12 +350,17 @@ func NewThrottleRetry(err error, delay time.Duration) error {
 	}
 }
 
+type onRequestHandlingFinishedFunc func(request, error) error
+
 type retrySender struct {
-	traceAttribute attribute.KeyValue
-	cfg            RetrySettings
-	nextSender     requestSender
-	stopCh         chan struct{}
-	logger         *zap.Logger
+	traceAttribute     attribute.KeyValue
+	cfg                RetrySettings
+	nextSender         requestSender
+	stopCh             chan struct{}
+	logger             *zap.Logger
+	onSuccess          onRequestHandlingFinishedFunc
+	onTemporaryFailure onRequestHandlingFinishedFunc
+	onPermanentFailure onRequestHandlingFinishedFunc
 }
 
 // send implements the requestSender interface
@@ -280,7 +397,7 @@ func (rs *retrySender) send(req request) error {
 
 		err := rs.nextSender.send(req)
 		if err == nil {
-			return nil
+			return rs.onSuccess(req, nil)
 		}
 
 		// Immediately drop data on permanent errors.
@@ -290,7 +407,7 @@ func (rs *retrySender) send(req request) error {
 				zap.Error(err),
 				zap.Int("dropped_items", req.count()),
 			)
-			return err
+			return rs.onPermanentFailure(req, err)
 		}
 
 		// Give the request a chance to extract signal data to retry if only some data
@@ -301,12 +418,7 @@ func (rs *retrySender) send(req request) error {
 		if backoffDelay == backoff.Stop {
 			// throw away the batch
 			err = fmt.Errorf("max elapsed time expired %w", err)
-			rs.logger.Error(
-				"Exporting failed. No more retries left. Dropping data.",
-				zap.Error(err),
-				zap.Int("dropped_items", req.count()),
-			)
-			return err
+			return rs.onTemporaryFailure(req, err)
 		}
 
 		throttleErr := throttleRetry{}
@@ -329,7 +441,7 @@ func (rs *retrySender) send(req request) error {
 		)
 		retryNum++
 
-		// back-off, but get interrupted when shutting down or request is cancelled or timed out.
+		// back-off, but Get interrupted when shutting down or request is cancelled or timed out.
 		select {
 		case <-req.context().Done():
 			return fmt.Errorf("request is cancelled or timed out %w", err)

--- a/exporter/exporterhelper/queued_retry.go
+++ b/exporter/exporterhelper/queued_retry.go
@@ -46,6 +46,12 @@ var (
 		metric.WithLabelKeys(obsmetrics.ExporterKey),
 		metric.WithUnit(metricdata.UnitDimensionless))
 
+	currentlyProcessedBatchesGauge, _ = r.AddInt64DerivedGauge(
+		obsmetrics.ExporterKey+"/processed_batches_size",
+		metric.WithDescription("Number of currently processed batches"),
+		metric.WithLabelKeys(obsmetrics.ExporterKey),
+		metric.WithUnit(metricdata.UnitDimensionless))
+
 	errNoStorageClient        = errors.New("no storage client extension found")
 	errMultipleStorageClients = errors.New("multiple storage extensions found")
 	errSendingQueueIsFull     = errors.New("sending_queue is full")
@@ -63,8 +69,8 @@ type QueueSettings struct {
 	NumConsumers int `mapstructure:"num_consumers"`
 	// QueueSize is the maximum number of batches allowed in queue at a given time.
 	QueueSize int `mapstructure:"queue_size"`
-	// PersistentEnabled describes whether persistency via storage file extension should be enabled
-	PersistentEnabled bool `mapstructure:"persistent_enabled"`
+	// PersistentStorageEnabled describes whether persistence via a file storage extension is enabled
+	PersistentStorageEnabled bool `mapstructure:"persistent_storage_enabled"`
 }
 
 // DefaultQueueSettings returns the default settings for QueueSettings.
@@ -76,8 +82,8 @@ func DefaultQueueSettings() QueueSettings {
 		// This is a pretty decent value for production.
 		// User should calculate this from the perspective of how many seconds to buffer in case of a backend outage,
 		// multiply that by the number of requests per seconds.
-		QueueSize:         5000,
-		PersistentEnabled: false,
+		QueueSize:                5000,
+		PersistentStorageEnabled: false,
 	}
 }
 
@@ -108,7 +114,7 @@ func DefaultRetrySettings() RetrySettings {
 
 type queuedRetrySender struct {
 	id                 config.ComponentID
-	signalName         string
+	signal             signalType
 	cfg                QueueSettings
 	consumerSender     requestSender
 	queue              consumersQueue
@@ -138,14 +144,14 @@ func createSampledLogger(logger *zap.Logger) *zap.Logger {
 	return logger.WithOptions(opts)
 }
 
-func newQueuedRetrySender(id config.ComponentID, signalName string, qCfg QueueSettings, rCfg RetrySettings, reqUnmarshaler requestUnmarshaler, nextSender requestSender, logger *zap.Logger) *queuedRetrySender {
+func newQueuedRetrySender(id config.ComponentID, signal signalType, qCfg QueueSettings, rCfg RetrySettings, reqUnmarshaler requestUnmarshaler, nextSender requestSender, logger *zap.Logger) *queuedRetrySender {
 	retryStopCh := make(chan struct{})
 	sampledLogger := createSampledLogger(logger)
 	traceAttr := attribute.String(obsmetrics.ExporterKey, id.String())
 
 	qrs := &queuedRetrySender{
 		id:                 id,
-		signalName:         signalName,
+		signal:             signal,
 		cfg:                qCfg,
 		retryStopCh:        retryStopCh,
 		traceAttributes:    []attribute.KeyValue{traceAttr},
@@ -165,7 +171,7 @@ func newQueuedRetrySender(id config.ComponentID, signalName string, qCfg QueueSe
 		onPermanentFailure: qrs.onPermanentFailure,
 	}
 
-	if !qCfg.PersistentEnabled {
+	if !qCfg.PersistentStorageEnabled {
 		qrs.queue = internal.NewBoundedQueue(qrs.cfg.QueueSize, func(item interface{}) {})
 	}
 	// The Persistent Queue is initialized separately as it needs extra information about the component
@@ -173,40 +179,40 @@ func newQueuedRetrySender(id config.ComponentID, signalName string, qCfg QueueSe
 	return qrs
 }
 
-func (qrs *queuedRetrySender) onSuccess(req request, err error) error {
+func (qrs *queuedRetrySender) onSuccess(_ request, _ error) error {
 	return nil
 }
 
-func (qrs *queuedRetrySender) onPermanentFailure(req request, err error) error {
+func (qrs *queuedRetrySender) onPermanentFailure(_ request, err error) error {
 	return err
 }
 
 func (qrs *queuedRetrySender) onTemporaryFailure(req request, err error) error {
-	if qrs.requeuingEnabled && qrs.queue != nil {
-		if qrs.queue.Produce(req) {
-			qrs.logger.Error(
-				"Exporting failed. Putting back to the end of the queue.",
-				zap.Error(err),
-			)
-		} else {
-			qrs.logger.Error(
-				"Exporting failed. Queue did not accept requeuing request. Dropping data.",
-				zap.Error(err),
-				zap.Int("dropped_items", req.count()),
-			)
-		}
+	if !qrs.requeuingEnabled || qrs.queue == nil {
+		qrs.logger.Error(
+			"Exporting failed. No more retries left. Dropping data.",
+			zap.Error(err),
+			zap.Int("dropped_items", req.count()),
+		)
 		return err
 	}
 
-	qrs.logger.Error(
-		"Exporting failed. No more retries left. Dropping data.",
-		zap.Error(err),
-		zap.Int("dropped_items", req.count()),
-	)
+	if qrs.queue.Produce(req) {
+		qrs.logger.Error(
+			"Exporting failed. Putting back to the end of the queue.",
+			zap.Error(err),
+		)
+	} else {
+		qrs.logger.Error(
+			"Exporting failed. Queue did not accept requeuing request. Dropping data.",
+			zap.Error(err),
+			zap.Int("dropped_items", req.count()),
+		)
+	}
 	return err
 }
 
-func getStorageClient(ctx context.Context, host component.Host, id config.ComponentID, signalName string) (*storage.Client, error) {
+func getStorageClient(ctx context.Context, host component.Host, id config.ComponentID, signal signalType) (*storage.Client, error) {
 	var storageExtension storage.Extension
 	for _, ext := range host.GetExtensions() {
 		if se, ok := ext.(storage.Extension); ok {
@@ -221,7 +227,7 @@ func getStorageClient(ctx context.Context, host component.Host, id config.Compon
 		return nil, errNoStorageClient
 	}
 
-	client, err := storageExtension.GetClient(ctx, component.KindExporter, id, signalName)
+	client, err := storageExtension.GetClient(ctx, component.KindExporter, id, string(signal))
 	if err != nil {
 		return nil, err
 	}
@@ -231,8 +237,8 @@ func getStorageClient(ctx context.Context, host component.Host, id config.Compon
 
 // initializePersistentQueue uses extra information for initialization available from component.Host
 func (qrs *queuedRetrySender) initializePersistentQueue(ctx context.Context, host component.Host) error {
-	if qrs.cfg.PersistentEnabled {
-		storageClient, err := getStorageClient(ctx, host, qrs.id, qrs.signalName)
+	if qrs.cfg.PersistentStorageEnabled {
+		storageClient, err := getStorageClient(ctx, host, qrs.id, qrs.signal)
 		if err != nil {
 			return err
 		}
@@ -247,10 +253,10 @@ func (qrs *queuedRetrySender) initializePersistentQueue(ctx context.Context, hos
 }
 
 func (qrs *queuedRetrySender) fullName() string {
-	if qrs.signalName == "" {
+	if qrs.signal == "" {
 		return qrs.id.String()
 	}
-	return fmt.Sprintf("%s-%s", qrs.id.String(), qrs.signalName)
+	return fmt.Sprintf("%s-%s", qrs.id.String(), qrs.signal)
 }
 
 // start is invoked during service startup.
@@ -263,6 +269,7 @@ func (qrs *queuedRetrySender) start(ctx context.Context, host component.Host) er
 	qrs.queue.StartConsumers(qrs.cfg.NumConsumers, func(item interface{}) {
 		req := item.(request)
 		_ = qrs.consumerSender.send(req)
+		req.onProcessingFinished()
 	})
 
 	// Start reporting queue length metric

--- a/exporter/exporterhelper/queued_retry_experimental.go
+++ b/exporter/exporterhelper/queued_retry_experimental.go
@@ -34,7 +34,7 @@ import (
 	"go.opentelemetry.io/collector/internal/obsreportconfig/obsmetrics"
 )
 
-// queued_retry_v2 includes the code for both memory-backed and persistent-storage backed queued retry helpers
+// queued_retry_experimental includes the code for both memory-backed and persistent-storage backed queued retry helpers
 // enabled by setting "enable_unstable" build tag
 
 var (

--- a/exporter/exporterhelper/queued_retry_inmemory.go
+++ b/exporter/exporterhelper/queued_retry_inmemory.go
@@ -31,7 +31,7 @@ import (
 	"go.opentelemetry.io/collector/internal/obsreportconfig/obsmetrics"
 )
 
-// queued_retry_v1 includes the code for memory-backed (original) queued retry helper only
+// queued_retry_inmemory includes the code for memory-backed (original) queued retry helper only
 // enabled when "enable_unstable" build tag is not set
 
 type queuedRetrySender struct {

--- a/exporter/exporterhelper/queued_retry_test.go
+++ b/exporter/exporterhelper/queued_retry_test.go
@@ -32,6 +32,7 @@ import (
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/internal/testdata"
+	"go.opentelemetry.io/collector/model/otlp"
 	"go.opentelemetry.io/collector/model/pdata"
 	"go.opentelemetry.io/collector/obsreport/obsreporttest"
 )
@@ -414,7 +415,7 @@ func (m *mockRequest) export(ctx context.Context) error {
 }
 
 func (m *mockRequest) marshal() ([]byte, error) {
-	return pdata.NewTraces().ToOtlpProtoBytes()
+	return otlp.NewProtobufTracesMarshaler().MarshalTraces(pdata.NewTraces())
 }
 
 func (m *mockRequest) onError(error) request {

--- a/exporter/exporterhelper/queued_retry_v1.go
+++ b/exporter/exporterhelper/queued_retry_v1.go
@@ -1,0 +1,116 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !enable_unstable
+// +build !enable_unstable
+
+package exporterhelper
+
+import (
+	"context"
+	"fmt"
+
+	"go.opencensus.io/metric/metricdata"
+	"go.opentelemetry.io/otel/attribute"
+	"go.uber.org/zap"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/exporter/exporterhelper/internal"
+	"go.opentelemetry.io/collector/internal/obsreportconfig/obsmetrics"
+)
+
+// queued_retry_v1 includes the code for memory-backed (original) queued retry helper only
+// enabled when "enable_unstable" build tag is not set
+
+type queuedRetrySender struct {
+	fullName        string
+	cfg             QueueSettings
+	consumerSender  requestSender
+	queue           consumersQueue
+	retryStopCh     chan struct{}
+	traceAttributes []attribute.KeyValue
+	logger          *zap.Logger
+}
+
+func newQueuedRetrySender(id config.ComponentID, _ config.DataType, qCfg QueueSettings, rCfg RetrySettings, _ requestUnmarshaler, nextSender requestSender, logger *zap.Logger) *queuedRetrySender {
+	retryStopCh := make(chan struct{})
+	sampledLogger := createSampledLogger(logger)
+	traceAttr := attribute.String(obsmetrics.ExporterKey, id.String())
+	return &queuedRetrySender{
+		fullName: id.String(),
+		cfg:      qCfg,
+		consumerSender: &retrySender{
+			traceAttribute:     traceAttr,
+			cfg:                rCfg,
+			nextSender:         nextSender,
+			stopCh:             retryStopCh,
+			logger:             sampledLogger,
+			onTemporaryFailure: onTemporaryFailure,
+		},
+		queue:           internal.NewBoundedQueue(qCfg.QueueSize, func(item interface{}) {}),
+		retryStopCh:     retryStopCh,
+		traceAttributes: []attribute.KeyValue{traceAttr},
+		logger:          sampledLogger,
+	}
+}
+
+func onTemporaryFailure(logger *zap.Logger, req request, err error) error {
+	logger.Error(
+		"Exporting failed. No more retries left. Dropping data.",
+		zap.Error(err),
+		zap.Int("dropped_items", req.count()),
+	)
+	return err
+}
+
+// start is invoked during service startup.
+func (qrs *queuedRetrySender) start(ctx context.Context, host component.Host) error {
+	qrs.queue.StartConsumers(qrs.cfg.NumConsumers, func(item interface{}) {
+		req := item.(request)
+		_ = qrs.consumerSender.send(req)
+		req.onProcessingFinished()
+	})
+
+	// Start reporting queue length metric
+	if qrs.cfg.Enabled {
+		err := queueSizeGauge.UpsertEntry(func() int64 {
+			return int64(qrs.queue.Size())
+		}, metricdata.NewLabelValue(qrs.fullName))
+		if err != nil {
+			return fmt.Errorf("failed to create retry queue size metric: %v", err)
+		}
+	}
+
+	return nil
+}
+
+// shutdown is invoked during service shutdown.
+func (qrs *queuedRetrySender) shutdown() {
+	// Cleanup queue metrics reporting
+	if qrs.cfg.Enabled {
+		_ = queueSizeGauge.UpsertEntry(func() int64 {
+			return int64(0)
+		}, metricdata.NewLabelValue(qrs.fullName))
+	}
+
+	// First Stop the retry goroutines, so that unblocks the queue numWorkers.
+	close(qrs.retryStopCh)
+
+	// Stop the queued sender, this will drain the queue and will call the retry (which is stopped) that will only
+	// try once every request.
+	if qrs.queue != nil {
+		qrs.queue.Stop()
+	}
+}

--- a/exporter/exporterhelper/queued_retry_v2.go
+++ b/exporter/exporterhelper/queued_retry_v2.go
@@ -1,0 +1,212 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build enable_unstable
+// +build enable_unstable
+
+package exporterhelper
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"go.opencensus.io/metric"
+	"go.opencensus.io/metric/metricdata"
+	"go.opentelemetry.io/otel/attribute"
+	"go.uber.org/zap"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/exporter/exporterhelper/internal"
+	"go.opentelemetry.io/collector/extension/storage"
+	"go.opentelemetry.io/collector/internal/obsreportconfig/obsmetrics"
+)
+
+// queued_retry_v2 includes the code for both memory-backed and persistent-storage backed queued retry helpers
+// enabled by setting "enable_unstable" build tag
+
+var (
+	currentlyProcessedBatchesGauge, _ = r.AddInt64DerivedGauge(
+		obsmetrics.ExporterKey+"/currently_processed_batches",
+		metric.WithDescription("Number of currently processed batches"),
+		metric.WithLabelKeys(obsmetrics.ExporterKey),
+		metric.WithUnit(metricdata.UnitDimensionless))
+
+	errNoStorageClient        = errors.New("no storage client extension found")
+	errMultipleStorageClients = errors.New("multiple storage extensions found")
+)
+
+type queuedRetrySender struct {
+	id                 config.ComponentID
+	signal             config.DataType
+	cfg                QueueSettings
+	consumerSender     requestSender
+	queue              consumersQueue
+	retryStopCh        chan struct{}
+	traceAttributes    []attribute.KeyValue
+	logger             *zap.Logger
+	requeuingEnabled   bool
+	requestUnmarshaler requestUnmarshaler
+}
+
+func (qrs *queuedRetrySender) fullName() string {
+	if qrs.signal == "" {
+		return qrs.id.String()
+	}
+	return fmt.Sprintf("%s-%s", qrs.id.String(), qrs.signal)
+}
+
+func newQueuedRetrySender(id config.ComponentID, signal config.DataType, qCfg QueueSettings, rCfg RetrySettings, reqUnmarshaler requestUnmarshaler, nextSender requestSender, logger *zap.Logger) *queuedRetrySender {
+	retryStopCh := make(chan struct{})
+	sampledLogger := createSampledLogger(logger)
+	traceAttr := attribute.String(obsmetrics.ExporterKey, id.String())
+
+	qrs := &queuedRetrySender{
+		id:                 id,
+		signal:             signal,
+		cfg:                qCfg,
+		retryStopCh:        retryStopCh,
+		traceAttributes:    []attribute.KeyValue{traceAttr},
+		logger:             sampledLogger,
+		requestUnmarshaler: reqUnmarshaler,
+	}
+
+	qrs.consumerSender = &retrySender{
+		traceAttribute: traceAttr,
+		cfg:            rCfg,
+		nextSender:     nextSender,
+		stopCh:         retryStopCh,
+		logger:         sampledLogger,
+		// Following three functions actually depend on queuedRetrySender
+		onTemporaryFailure: qrs.onTemporaryFailure,
+	}
+
+	if !qCfg.PersistentStorageEnabled {
+		qrs.queue = internal.NewBoundedQueue(qrs.cfg.QueueSize, func(item interface{}) {})
+	}
+	// The Persistent Queue is initialized separately as it needs extra information about the component
+
+	return qrs
+}
+
+func getStorageClient(ctx context.Context, host component.Host, id config.ComponentID, signal config.DataType) (*storage.Client, error) {
+	var storageExtension storage.Extension
+	for _, ext := range host.GetExtensions() {
+		if se, ok := ext.(storage.Extension); ok {
+			if storageExtension != nil {
+				return nil, errMultipleStorageClients
+			}
+			storageExtension = se
+		}
+	}
+
+	if storageExtension == nil {
+		return nil, errNoStorageClient
+	}
+
+	client, err := storageExtension.GetClient(ctx, component.KindExporter, id, string(signal))
+	if err != nil {
+		return nil, err
+	}
+
+	return &client, err
+}
+
+// initializePersistentQueue uses extra information for initialization available from component.Host
+func (qrs *queuedRetrySender) initializePersistentQueue(ctx context.Context, host component.Host) error {
+	if qrs.cfg.PersistentStorageEnabled {
+		storageClient, err := getStorageClient(ctx, host, qrs.id, qrs.signal)
+		if err != nil {
+			return err
+		}
+
+		qrs.queue = newPersistentQueue(ctx, qrs.fullName(), qrs.cfg.QueueSize, qrs.logger, *storageClient, qrs.requestUnmarshaler)
+
+		// TODO: this can be further exposed as a config param rather than relying on a type of queue
+		qrs.requeuingEnabled = true
+	}
+
+	return nil
+}
+
+func (qrs *queuedRetrySender) onTemporaryFailure(logger *zap.Logger, req request, err error) error {
+	if !qrs.requeuingEnabled || qrs.queue == nil {
+		logger.Error(
+			"Exporting failed. No more retries left. Dropping data.",
+			zap.Error(err),
+			zap.Int("dropped_items", req.count()),
+		)
+		return err
+	}
+
+	if qrs.queue.Produce(req) {
+		logger.Error(
+			"Exporting failed. Putting back to the end of the queue.",
+			zap.Error(err),
+		)
+	} else {
+		logger.Error(
+			"Exporting failed. Queue did not accept requeuing request. Dropping data.",
+			zap.Error(err),
+			zap.Int("dropped_items", req.count()),
+		)
+	}
+	return err
+}
+
+// start is invoked during service startup.
+func (qrs *queuedRetrySender) start(ctx context.Context, host component.Host) error {
+	err := qrs.initializePersistentQueue(ctx, host)
+	if err != nil {
+		return err
+	}
+
+	qrs.queue.StartConsumers(qrs.cfg.NumConsumers, func(item interface{}) {
+		req := item.(request)
+		_ = qrs.consumerSender.send(req)
+		req.onProcessingFinished()
+	})
+
+	// Start reporting queue length metric
+	if qrs.cfg.Enabled {
+		err := queueSizeGauge.UpsertEntry(func() int64 {
+			return int64(qrs.queue.Size())
+		}, metricdata.NewLabelValue(qrs.fullName()))
+		if err != nil {
+			return fmt.Errorf("failed to create retry queue size metric: %v", err)
+		}
+	}
+
+	return nil
+}
+
+// shutdown is invoked during service shutdown.
+func (qrs *queuedRetrySender) shutdown() {
+	// Cleanup queue metrics reporting
+	if qrs.cfg.Enabled {
+		_ = queueSizeGauge.UpsertEntry(func() int64 {
+			return int64(0)
+		}, metricdata.NewLabelValue(qrs.fullName()))
+	}
+
+	// First Stop the retry goroutines, so that unblocks the queue numWorkers.
+	close(qrs.retryStopCh)
+
+	// Stop the queued sender, this will drain the queue and will call the retry (which is stopped) that will only
+	// try once every request.
+	if qrs.queue != nil {
+		qrs.queue.Stop()
+	}
+}

--- a/exporter/exporterhelper/queued_retry_v2.go
+++ b/exporter/exporterhelper/queued_retry_v2.go
@@ -38,9 +38,9 @@ import (
 // enabled by setting "enable_unstable" build tag
 
 var (
-	currentlyProcessedBatchesGauge, _ = r.AddInt64DerivedGauge(
-		obsmetrics.ExporterKey+"/currently_processed_batches",
-		metric.WithDescription("Number of currently processed batches"),
+	currentlyDispatchedBatchesGauge, _ = r.AddInt64DerivedGauge(
+		obsmetrics.ExporterKey+"/currently_dispatched_batches",
+		metric.WithDescription("Number of batches that are currently being sent"),
 		metric.WithLabelKeys(obsmetrics.ExporterKey),
 		metric.WithUnit(metricdata.UnitDimensionless))
 

--- a/exporter/exporterhelper/traces.go
+++ b/exporter/exporterhelper/traces.go
@@ -100,7 +100,7 @@ func NewTracesExporter(
 	}
 
 	bs := fromOptions(options...)
-	be := newBaseExporter(cfg, set, bs, signalTraces, newTraceRequestUnmarshalerFunc(pusher))
+	be := newBaseExporter(cfg, set, bs, config.TracesDataType, newTraceRequestUnmarshalerFunc(pusher))
 	be.wrapConsumerSender(func(nextSender requestSender) requestSender {
 		return &tracesExporterWithObservability{
 			obsrep:     be.obsrep,

--- a/exporter/exporterhelper/traces.go
+++ b/exporter/exporterhelper/traces.go
@@ -23,8 +23,12 @@ import (
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/consumer/consumerhelper"
+	"go.opentelemetry.io/collector/model/otlp"
 	"go.opentelemetry.io/collector/model/pdata"
 )
+
+var tracesMarshaler = otlp.NewProtobufTracesMarshaler()
+var tracesUnmarshaler = otlp.NewProtobufTracesUnmarshaler()
 
 type tracesRequest struct {
 	baseRequest
@@ -38,6 +42,20 @@ func newTracesRequest(ctx context.Context, td pdata.Traces, pusher consumerhelpe
 		td:          td,
 		pusher:      pusher,
 	}
+}
+
+func newTraceRequestUnmarshalerFunc(pusher consumerhelper.ConsumeTracesFunc) requestUnmarshaler {
+	return func(bytes []byte) (request, error) {
+		traces, err := tracesUnmarshaler.UnmarshalTraces(bytes)
+		if err != nil {
+			return nil, err
+		}
+		return newTracesRequest(context.Background(), traces, pusher), nil
+	}
+}
+
+func (req *tracesRequest) marshal() ([]byte, error) {
+	return tracesMarshaler.MarshalTraces(req.td)
 }
 
 func (req *tracesRequest) onError(err error) request {
@@ -82,7 +100,7 @@ func NewTracesExporter(
 	}
 
 	bs := fromOptions(options...)
-	be := newBaseExporter(cfg, set, bs)
+	be := newBaseExporter(cfg, set, bs, "traces", newTraceRequestUnmarshalerFunc(pusher))
 	be.wrapConsumerSender(func(nextSender requestSender) requestSender {
 		return &tracesExporterWithObservability{
 			obsrep:     be.obsrep,

--- a/exporter/exporterhelper/traces.go
+++ b/exporter/exporterhelper/traces.go
@@ -100,7 +100,7 @@ func NewTracesExporter(
 	}
 
 	bs := fromOptions(options...)
-	be := newBaseExporter(cfg, set, bs, "traces", newTraceRequestUnmarshalerFunc(pusher))
+	be := newBaseExporter(cfg, set, bs, signalTraces, newTraceRequestUnmarshalerFunc(pusher))
 	be.wrapConsumerSender(func(nextSender requestSender) requestSender {
 		return &tracesExporterWithObservability{
 			obsrep:     be.obsrep,


### PR DESCRIPTION
**Description:**

Persistent queue implementation within queued_retry, aimed at being compatible with Jager's [BoundedQueue](https://github.com/jaegertracing/jaeger/blob/master/pkg/queue/bounded_queue.go) interface (providing a simple replacement) and backed by [file storage extension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/storage/filestorage) for storing WAL.

Currently, to run the persistent queue, OpenTelemetry Collector Contrib with `enable_unstable` build tag is required.

**Link to tracking Issue:** #2285 

[Design doc](https://docs.google.com/document/d/1Y4vNthCGdYI61ezeAzL5dXWgiZ73y9eSjIDitk3zXsU/edit#)

**Testing:** Unit Tests and manual testing, more to come

**Documentation:** README.md updated, including an example