### PR TITLE
Add errWriter for fileexporter tests and remove testutils.LimitedWriter #3225

### DIFF
--- a/exporter/fileexporter/file_exporter_test.go
+++ b/exporter/fileexporter/file_exporter_test.go
@@ -16,6 +16,7 @@ package fileexporter
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -30,7 +31,6 @@ import (
 	collectormetrics "go.opentelemetry.io/collector/internal/data/protogen/collector/metrics/v1"
 	collectortrace "go.opentelemetry.io/collector/internal/data/protogen/collector/trace/v1"
 	"go.opentelemetry.io/collector/internal/testdata"
-	"go.opentelemetry.io/collector/testutil"
 )
 
 func TestFileTracesExporter(t *testing.T) {
@@ -51,9 +51,7 @@ func TestFileTracesExporter(t *testing.T) {
 }
 
 func TestFileTracesExporterError(t *testing.T) {
-	mf := &testutil.LimitedWriter{
-		MaxLen: 42,
-	}
+	mf := &errorWriter{}
 	fe := &fileExporter{file: mf}
 	require.NotNil(t, fe)
 
@@ -81,9 +79,7 @@ func TestFileMetricsExporter(t *testing.T) {
 }
 
 func TestFileMetricsExporterError(t *testing.T) {
-	mf := &testutil.LimitedWriter{
-		MaxLen: 42,
-	}
+	mf := &errorWriter{}
 	fe := &fileExporter{file: mf}
 	require.NotNil(t, fe)
 
@@ -111,9 +107,7 @@ func TestFileLogsExporter(t *testing.T) {
 }
 
 func TestFileLogsExporterErrors(t *testing.T) {
-	mf := &testutil.LimitedWriter{
-		MaxLen: 42,
-	}
+	mf := &errorWriter{}
 	fe := &fileExporter{file: mf}
 	require.NotNil(t, fe)
 
@@ -131,4 +125,16 @@ func tempFileName(t *testing.T) string {
 	socket := tmpfile.Name()
 	require.NoError(t, os.Remove(socket))
 	return socket
+}
+
+// errorWriter is an io.Writer that will return an error all ways
+type errorWriter struct {
+}
+
+func (e errorWriter) Write(p []byte) (n int, err error) {
+	return 0, errors.New("all ways return error")
+}
+
+func (e *errorWriter) Close() error {
+	return nil
 }

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -15,8 +15,6 @@
 package testutil
 
 import (
-	"bytes"
-	"io"
 	"io/ioutil"
 	"net"
 	"os"
@@ -122,26 +120,4 @@ func createExclusionsList(exclusionsText string, t *testing.T) []portpair {
 		}
 	}
 	return exclusions
-}
-
-// LimitedWriter is an io.Writer that will return an EOF error after MaxLen has
-// been reached.  If MaxLen is 0, Writes will always succeed.
-type LimitedWriter struct {
-	bytes.Buffer
-	MaxLen int
-}
-
-var _ io.Writer = new(LimitedWriter)
-
-// Write writes bytes to the underlying buffer until reaching the maximum length.
-func (lw *LimitedWriter) Write(p []byte) (n int, err error) {
-	if lw.MaxLen != 0 && len(p)+lw.Len() > lw.MaxLen {
-		return 0, io.EOF
-	}
-	return lw.Buffer.Write(p)
-}
-
-// Close closes the writer.
-func (lw *LimitedWriter) Close() error {
-	return nil
 }


### PR DESCRIPTION
This ticket is currently for Phase2-GA-Roadmap

**Description:** Add Error Writer to be used in file exporter tests where limited writer was being used. Then remove limited writer from 

**Link to tracking Issue:** #3225 

**Testing:** Ran all file export tests in Intellij go test configuration. Run all unit test using make command. 