### PR TITLE
Add doc.go files to the Config package

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -12,21 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package config defines the data models for entities. This file defines the
-// models for configuration format. The defined entities are:
-// Config (the top-level structure), Receivers, Exporters, Processors, Pipelines.
-//
-// Receivers, Exporters and Processors typically have common configuration settings, however
-// sometimes specific implementations will have extra configuration settings.
-// This requires the configuration data for these entities to be polymorphic.
-//
-// To satisfy these requirements we declare interfaces Receiver, Exporter, Processor,
-// which define the behavior. We also provide helper structs ReceiverSettings, ExporterSettings,
-// ProcessorSettings, which define the common settings and un-marshaling from config files.
-//
-// Specific Receivers/Exporters/Processors are expected to at the minimum implement the
-// corresponding interface and if they have additional settings they must also extend
-// the corresponding common settings struct (the easiest approach is to embed the common struct).
 package config
 
 import (

--- a/config/configauth/doc.go
+++ b/config/configauth/doc.go
@@ -1,0 +1,18 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package configauth implements the configuration settings to
+// ensure authentication on incoming requests, and allows
+// exporters to add authentication on outgoing requests.
+package configauth

--- a/config/configcheck/configcheck.go
+++ b/config/configcheck/configcheck.go
@@ -12,10 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package configcheck has checks to be applied to configuration
-// objects implemented by factories of components used in the OpenTelemetry
-// collector. It is recommended for implementers of components to run the
-// validations available on this package.
 package configcheck
 
 import (

--- a/config/configcheck/doc.go
+++ b/config/configcheck/doc.go
@@ -1,0 +1,19 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package configcheck has checks to be applied to configuration
+// objects implemented by factories of components used in the OpenTelemetry
+// collector. It is recommended for implementers of components to run the
+// validations available on this package.
+package configcheck

--- a/config/configgrpc/configgrpc.go
+++ b/config/configgrpc/configgrpc.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package configgrpc defines the gRPC configuration settings.
 package configgrpc
 
 import (

--- a/config/configgrpc/doc.go
+++ b/config/configgrpc/doc.go
@@ -1,0 +1,17 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package configgrpc defines the  configuration settings to create
+// a gRPC client and server.
+package configgrpc

--- a/config/confighttp/doc.go
+++ b/config/confighttp/doc.go
@@ -1,0 +1,17 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package confighttp defines the configuration settings
+// for creating an HTTP client and server.
+package confighttp

--- a/config/configloader/config.go
+++ b/config/configloader/config.go
@@ -12,9 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package configloader implements configuration loading from a config.Parser.
-// The implementation relies on registered factories that allow creating
-// default configuration for each type of receiver/exporter/processor.
 package configloader
 
 import (

--- a/config/configloader/doc.go
+++ b/config/configloader/doc.go
@@ -1,0 +1,18 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package configloader implements configuration loading from a config.Parser.
+// The implementation relies on registered factories that allow creating
+// default configuration for each type of receiver/exporter/processor.
+package configloader

--- a/config/confignet/doc.go
+++ b/config/confignet/doc.go
@@ -1,0 +1,17 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package confignet implements the configuration settings for protocols to
+// connect and transport data information.
+package confignet

--- a/config/configtelemetry/doc.go
+++ b/config/configtelemetry/doc.go
@@ -1,0 +1,18 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package configtelemetry defines various telemetry level for configuration.
+// It enables every component to have access to telemetry level
+// to enable metrics only when necessary.
+package configtelemetry

--- a/config/configtest/doc.go
+++ b/config/configtest/doc.go
@@ -1,0 +1,17 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package configtest loads the configuration to test packages
+// implementing the config package interfaces.
+package configtest

--- a/config/configtls/doc.go
+++ b/config/configtls/doc.go
@@ -1,0 +1,17 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package configtls implements the TLS settings to load and
+// configure TLS clients and servers.
+package configtls

--- a/config/doc.go
+++ b/config/doc.go
@@ -1,0 +1,30 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package config defines the data models for entities. This file defines the
+// models for configuration format. The defined entities are:
+// Config (the top-level structure), Receivers, Exporters, Processors, Pipelines.
+//
+// Receivers, Exporters and Processors typically have common configuration settings, however
+// sometimes specific implementations will have extra configuration settings.
+// This requires the configuration data for these entities to be polymorphic.
+//
+// To satisfy these requirements we declare interfaces Receiver, Exporter, Processor,
+// which define the behavior. We also provide helper structs ReceiverSettings, ExporterSettings,
+// ProcessorSettings, which define the common settings and un-marshaling from config files.
+//
+// Specific Receivers/Exporters/Processors are expected to at the minimum implement the
+// corresponding interface and if they have additional settings they must also extend
+// the corresponding common settings struct (the easiest approach is to embed the common struct).
+package config

--- a/config/experimental/configsource/component.go
+++ b/config/experimental/configsource/component.go
@@ -12,11 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package configsource is an experimental package that defines the interface of
-// "configuration sources," e.g., Vault, ZooKeeper, etcd2, and others. Configuration
-// sources retrieve values from their respective storages. A configuration parser/loader
-// can inject these values in the configuration data used by the collector.
-// ATTENTION: the package is still experimental and subject to changes without advanced notice.
 package configsource
 
 import (

--- a/config/experimental/configsource/doc.go
+++ b/config/experimental/configsource/doc.go
@@ -1,0 +1,20 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package configsource is an experimental package that defines the interface of
+// "configuration sources," e.g., Vault, ZooKeeper, etcd2, and others. Configuration
+// sources retrieve values from their respective storages. A configuration parser/loader
+// can inject these values in the configuration data used by the collector.
+// ATTENTION: the package is still experimental and subject to changes without advanced notice.
+package configsource

--- a/config/internal/configsource/doc.go
+++ b/config/internal/configsource/doc.go
@@ -1,0 +1,18 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package configsource is an internal package that implements methods
+// for injecting, watching, and updating data from ConfigSource into
+// configuration.
+package configsource


### PR DESCRIPTION
**Description:** 
This PR is one of the three PRs aiming to address the issue: Reviewing and Improving config package.
Changes were made to first create an overview for any missing sub-packages, and secondly, to move the existing documentations into a separate `doc.go` to maintain consistency with the other modules.

**Link to tracking Issue:** <Issue number if applicable>
Addresses part of #3051