### PR TITLE
Edit Type/Function Documentation in the Config Package

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -97,7 +97,7 @@ func (cfg *Config) Validate() error {
 		}
 	}
 
-	// Check that all enabled extensions in the service are configured
+	// Check that all enabled extensions in the service are configured.
 	if err := cfg.validateServiceExtensions(); err != nil {
 		return err
 	}
@@ -110,7 +110,7 @@ func (cfg *Config) Validate() error {
 func (cfg *Config) validateServiceExtensions() error {
 	// Validate extensions.
 	for _, ref := range cfg.Service.Extensions {
-		// Check that the name referenced in the Service extensions exists in the top-level extensions
+		// Check that the name referenced in the Service extensions exists in the top-level extensions.
 		if cfg.Extensions[ref] == nil {
 			return fmt.Errorf("service references extension %q which does not exist", ref)
 		}
@@ -134,13 +134,13 @@ func (cfg *Config) validateServicePipelines() error {
 
 		// Validate pipeline receiver name references.
 		for _, ref := range pipeline.Receivers {
-			// Check that the name referenced in the pipeline's receivers exists in the top-level receivers
+			// Check that the name referenced in the pipeline's receivers exists in the top-level receivers.
 			if cfg.Receivers[ref] == nil {
 				return fmt.Errorf("pipeline %q references receiver %q which does not exist", pipeline.Name, ref)
 			}
 		}
 
-		// Validate pipeline processor name references
+		// Validate pipeline processor name references.
 		for _, ref := range pipeline.Processors {
 			// Check that the name referenced in the pipeline's processors exists in the top-level processors.
 			if cfg.Processors[ref] == nil {
@@ -148,14 +148,14 @@ func (cfg *Config) validateServicePipelines() error {
 			}
 		}
 
-		// Validate pipeline has at least one exporter
+		// Validate pipeline has at least one exporter.
 		if len(pipeline.Exporters) == 0 {
 			return fmt.Errorf("pipeline %q must have at least one exporter", pipeline.Name)
 		}
 
 		// Validate pipeline exporter name references.
 		for _, ref := range pipeline.Exporters {
-			// Check that the name referenced in the pipeline's Exporters exists in the top-level Exporters
+			// Check that the name referenced in the pipeline's Exporters exists in the top-level Exporters.
 			if cfg.Exporters[ref] == nil {
 				return fmt.Errorf("pipeline %q references exporter %q which does not exist", pipeline.Name, ref)
 			}
@@ -166,10 +166,10 @@ func (cfg *Config) validateServicePipelines() error {
 
 // Service defines the configurable components of the service.
 type Service struct {
-	// Extensions is the ordered list of extensions configured for the service.
+	// Extensions are the ordered list of extensions configured for the service.
 	Extensions []ComponentID
 
-	// Pipelines is the set of data pipelines configured for the service.
+	// Pipelines are the set of data pipelines configured for the service.
 	Pipelines Pipelines
 }
 

--- a/config/configauth/configauth.go
+++ b/config/configauth/configauth.go
@@ -27,12 +27,13 @@ var (
 	errAuthenticatorNotProvided = errors.New("authenticator not provided")
 )
 
-// Authentication defines the auth settings for the receiver
+// Authentication defines the auth settings for the receiver.
 type Authentication struct {
 	// Authenticator specifies the name of the extension to use in order to authenticate the incoming data point.
 	AuthenticatorName string `mapstructure:"authenticator"`
 }
 
+<<<<<<< HEAD
 // GetAuthenticator attempts to select the appropriate from the list of extensions, based on the requested extension name.
 // If an authenticator is not found, an error is returned.
 func GetAuthenticator(extensions map[config.ComponentID]component.Extension, requested string) (Authenticator, error) {
@@ -45,6 +46,11 @@ func GetAuthenticator(extensions map[config.ComponentID]component.Extension, req
 		return nil, err
 	}
 
+=======
+// GetServerAuthenticator attempts to select the appropriate ServerAuthenticator from the list of extensions, based on the requested extension name.
+// If authenticator is not found, an error is returned.
+func GetServerAuthenticator(extensions map[config.ComponentID]component.Extension, componentID config.ComponentID) (ServerAuthenticator, error) {
+>>>>>>> bf891180 (Fix typos in Config Package)
 	for name, ext := range extensions {
 		if auth, ok := ext.(Authenticator); ok {
 			if name == reqID {

--- a/config/configauth/configauth.go
+++ b/config/configauth/configauth.go
@@ -33,8 +33,7 @@ type Authentication struct {
 	AuthenticatorName string `mapstructure:"authenticator"`
 }
 
-<<<<<<< HEAD
-// GetAuthenticator attempts to select the appropriate from the list of extensions, based on the requested extension name.
+// GetAuthenticator attempts to select the appropriate Authenticator from the list of extensions, based on the requested extension name.
 // If an authenticator is not found, an error is returned.
 func GetAuthenticator(extensions map[config.ComponentID]component.Extension, requested string) (Authenticator, error) {
 	if requested == "" {
@@ -46,11 +45,6 @@ func GetAuthenticator(extensions map[config.ComponentID]component.Extension, req
 		return nil, err
 	}
 
-=======
-// GetServerAuthenticator attempts to select the appropriate ServerAuthenticator from the list of extensions, based on the requested extension name.
-// If authenticator is not found, an error is returned.
-func GetServerAuthenticator(extensions map[config.ComponentID]component.Extension, componentID config.ComponentID) (ServerAuthenticator, error) {
->>>>>>> bf891180 (Fix typos in Config Package)
 	for name, ext := range extensions {
 		if auth, ok := ext.(Authenticator); ok {
 			if name == reqID {

--- a/config/configcheck/configcheck.go
+++ b/config/configcheck/configcheck.go
@@ -167,7 +167,7 @@ func checkStructFieldTags(f reflect.StructField) error {
 
 	switch f.Type.Kind() {
 	case reflect.Struct:
-		// It is another struct, continue down-level
+		// It is another struct, continue down-level.
 		return validateConfigDataType(f.Type)
 
 	case reflect.Map, reflect.Slice, reflect.Array:

--- a/config/configgrpc/configgrpc.go
+++ b/config/configgrpc/configgrpc.go
@@ -171,13 +171,8 @@ type GRPCServerSettings struct {
 	Auth *configauth.Authentication `mapstructure:"auth,omitempty"`
 }
 
-<<<<<<< HEAD
-// ToDialOptions maps configgrpc.GRPCClientSettings to a slice of dial options for gRPC
-func (gcs *GRPCClientSettings) ToDialOptions() ([]grpc.DialOption, error) {
-=======
 // ToDialOptions maps configgrpc.GRPCClientSettings to a slice of dial options for gRPC.
-func (gcs *GRPCClientSettings) ToDialOptions(ext map[config.ComponentID]component.Extension) ([]grpc.DialOption, error) {
->>>>>>> bf891180 (Fix typos in Config Package)
+func (gcs *GRPCClientSettings) ToDialOptions() ([]grpc.DialOption, error) {
 	var opts []grpc.DialOption
 	if gcs.Compression != "" {
 		if compressionKey := GetGRPCCompressionKey(gcs.Compression); compressionKey != CompressionUnsupported {

--- a/config/configgrpc/configgrpc.go
+++ b/config/configgrpc/configgrpc.go
@@ -34,7 +34,7 @@ import (
 	"go.opentelemetry.io/collector/config/configtls"
 )
 
-// Compression gRPC keys for supported compression types within collector
+// Compression gRPC keys for supported compression types within collector.
 const (
 	CompressionUnsupported = ""
 	CompressionGzip        = "gzip"
@@ -43,13 +43,13 @@ const (
 )
 
 var (
-	// Map of opentelemetry compression types to grpc registered compression types
+	// Map of opentelemetry compression types to grpc registered compression types.
 	grpcCompressionKeyMap = map[string]string{
 		CompressionGzip: gzip.Name,
 	}
 )
 
-// Allowed balancer names to be set in grpclb_policy to discover the servers
+// Allowed balancer names to be set in grpclb_policy to discover the servers.
 var allowedBalancerNames = []string{roundrobin.Name, grpc.PickFirstBalancerName}
 
 // KeepaliveClientConfig exposes the keepalive.ClientParameters to be used by the exporter.
@@ -75,15 +75,15 @@ type GRPCClientSettings struct {
 	// TLSSetting struct exposes TLS client configuration.
 	TLSSetting configtls.TLSClientSetting `mapstructure:",squash"`
 
-	// The keepalive parameters for gRPC client. See grpc.WithKeepaliveParams
+	// The keepalive parameters for gRPC client. See grpc.WithKeepaliveParams.
 	// (https://godoc.org/google.golang.org/grpc#WithKeepaliveParams).
 	Keepalive *KeepaliveClientConfig `mapstructure:"keepalive"`
 
-	// ReadBufferSize for gRPC client. See grpc.WithReadBufferSize
+	// ReadBufferSize for gRPC client. See grpc.WithReadBufferSize.
 	// (https://godoc.org/google.golang.org/grpc#WithReadBufferSize).
 	ReadBufferSize int `mapstructure:"read_buffer_size"`
 
-	// WriteBufferSize for gRPC gRPC. See grpc.WithWriteBufferSize
+	// WriteBufferSize for gRPC gRPC. See grpc.WithWriteBufferSize.
 	// (https://godoc.org/google.golang.org/grpc#WithWriteBufferSize).
 	WriteBufferSize int `mapstructure:"write_buffer_size"`
 
@@ -94,10 +94,14 @@ type GRPCClientSettings struct {
 	// The headers associated with gRPC requests.
 	Headers map[string]string `mapstructure:"headers"`
 
+<<<<<<< HEAD
 	// PerRPCAuth parameter configures the client to send authentication data on a per-RPC basis.
 	PerRPCAuth *PerRPCAuthConfig `mapstructure:"per_rpc_auth"`
 
 	// Sets the balancer in grpclb_policy to discover the servers. Default is pick_first
+=======
+	// Sets the balancer in grpclb_policy to discover the servers. Default is pick_first.
+>>>>>>> bf891180 (Fix typos in Config Package)
 	// https://github.com/grpc/grpc-go/blob/master/examples/features/load_balancing/README.md
 	BalancerName string `mapstructure:"balancer_name"`
 }
@@ -152,11 +156,11 @@ type GRPCServerSettings struct {
 	// It has effect only for streaming RPCs.
 	MaxConcurrentStreams uint32 `mapstructure:"max_concurrent_streams"`
 
-	// ReadBufferSize for gRPC server. See grpc.ReadBufferSize
+	// ReadBufferSize for gRPC server. See grpc.ReadBufferSize.
 	// (https://godoc.org/google.golang.org/grpc#ReadBufferSize).
 	ReadBufferSize int `mapstructure:"read_buffer_size"`
 
-	// WriteBufferSize for gRPC server. See grpc.WriteBufferSize
+	// WriteBufferSize for gRPC server. See grpc.WriteBufferSize.
 	// (https://godoc.org/google.golang.org/grpc#WriteBufferSize).
 	WriteBufferSize int `mapstructure:"write_buffer_size"`
 
@@ -167,8 +171,13 @@ type GRPCServerSettings struct {
 	Auth *configauth.Authentication `mapstructure:"auth,omitempty"`
 }
 
+<<<<<<< HEAD
 // ToDialOptions maps configgrpc.GRPCClientSettings to a slice of dial options for gRPC
 func (gcs *GRPCClientSettings) ToDialOptions() ([]grpc.DialOption, error) {
+=======
+// ToDialOptions maps configgrpc.GRPCClientSettings to a slice of dial options for gRPC.
+func (gcs *GRPCClientSettings) ToDialOptions(ext map[config.ComponentID]component.Extension) ([]grpc.DialOption, error) {
+>>>>>>> bf891180 (Fix typos in Config Package)
 	var opts []grpc.DialOption
 	if gcs.Compression != "" {
 		if compressionKey := GetGRPCCompressionKey(gcs.Compression); compressionKey != CompressionUnsupported {
@@ -240,7 +249,7 @@ func (gss *GRPCServerSettings) ToListener() (net.Listener, error) {
 	return gss.NetAddr.Listen()
 }
 
-// ToServerOption maps configgrpc.GRPCServerSettings to a slice of server options for gRPC
+// ToServerOption maps configgrpc.GRPCServerSettings to a slice of server options for gRPC.
 func (gss *GRPCServerSettings) ToServerOption(ext map[config.ComponentID]component.Extension) ([]grpc.ServerOption, error) {
 	var opts []grpc.ServerOption
 
@@ -312,7 +321,7 @@ func (gss *GRPCServerSettings) ToServerOption(ext map[config.ComponentID]compone
 }
 
 // GetGRPCCompressionKey returns the grpc registered compression key if the
-// passed in compression key is supported, and CompressionUnsupported otherwise
+// passed in compression key is supported, and CompressionUnsupported otherwise.
 func GetGRPCCompressionKey(compressionType string) string {
 	compressionKey := strings.ToLower(compressionType)
 	if encodingKey, ok := grpcCompressionKeyMap[compressionKey]; ok {

--- a/config/configgrpc/configgrpc.go
+++ b/config/configgrpc/configgrpc.go
@@ -94,14 +94,10 @@ type GRPCClientSettings struct {
 	// The headers associated with gRPC requests.
 	Headers map[string]string `mapstructure:"headers"`
 
-<<<<<<< HEAD
 	// PerRPCAuth parameter configures the client to send authentication data on a per-RPC basis.
 	PerRPCAuth *PerRPCAuthConfig `mapstructure:"per_rpc_auth"`
 
-	// Sets the balancer in grpclb_policy to discover the servers. Default is pick_first
-=======
 	// Sets the balancer in grpclb_policy to discover the servers. Default is pick_first.
->>>>>>> bf891180 (Fix typos in Config Package)
 	// https://github.com/grpc/grpc-go/blob/master/examples/features/load_balancing/README.md
 	BalancerName string `mapstructure:"balancer_name"`
 }

--- a/config/configgrpc/gzip.go
+++ b/config/configgrpc/gzip.go
@@ -15,6 +15,6 @@
 package configgrpc
 
 import (
-	// import the gzip package with auto-registers the gzip grpc compressor
+	// Import the gzip package with auto-registers the gzip gRPC compressor.
 	_ "google.golang.org/grpc/encoding/gzip"
 )

--- a/config/configgrpc/gzip.go
+++ b/config/configgrpc/gzip.go
@@ -15,6 +15,6 @@
 package configgrpc
 
 import (
-	// Import the gzip package with auto-registers the gzip gRPC compressor.
+	// Import the gzip package which auto-registers the gzip gRPC compressor.
 	_ "google.golang.org/grpc/encoding/gzip"
 )

--- a/config/confighttp/confighttp.go
+++ b/config/confighttp/confighttp.go
@@ -89,7 +89,7 @@ func (hcs *HTTPClientSettings) ToClient() (*http.Client, error) {
 	}, nil
 }
 
-// Custom RoundTripper that add headers
+// Custom RoundTripper that add headers.
 type headerRoundTripper struct {
 	transport http.RoundTripper
 	headers   map[string]string

--- a/config/configloader/config.go
+++ b/config/configloader/config.go
@@ -35,7 +35,7 @@ import (
 type configErrorCode int
 
 const (
-	_ configErrorCode = iota // skip 0, start errors codes from 1.
+	_ configErrorCode = iota // Skip 0, start errors codes from 1.
 	errInvalidTypeAndNameKey
 	errUnknownType
 	errDuplicateName
@@ -43,15 +43,15 @@ const (
 )
 
 type configError struct {
-	msg  string          // human readable error message.
-	code configErrorCode // internal error code.
+	msg  string          // Human readable error message.
+	code configErrorCode // Internal error code.
 }
 
 func (e *configError) Error() string {
 	return e.msg
 }
 
-// YAML top-level configuration keys
+// YAML top-level configuration keys.
 const (
 	// extensionsKeyName is the configuration key name for extensions section.
 	extensionsKeyName = "extensions"
@@ -89,7 +89,7 @@ type pipelineSettings struct {
 }
 
 // Load loads a Config from Parser.
-// After loading the config, need to check if it is valid by calling `ValidateConfig`.
+// After loading the config, `ValidateConfig` must be called to validate.
 func Load(v *config.Parser, factories component.Factories) (*config.Config, error) {
 
 	var cfg config.Config
@@ -196,7 +196,7 @@ func loadExtensions(exts map[string]interface{}, factories map[config.Type]compo
 			return nil, errorUnknownType(extensionsKeyName, id)
 		}
 
-		// Create the default config for this extension
+		// Create the default config for this extension.
 		extensionCfg := factory.CreateDefaultConfig()
 		extensionCfg.SetIDName(id.Name())
 		expandEnvLoadedConfig(extensionCfg)
@@ -255,7 +255,7 @@ func LoadReceiver(componentConfig *config.Parser, id config.ComponentID, factory
 }
 
 func loadReceivers(recvs map[string]interface{}, factories map[config.Type]component.ReceiverFactory) (config.Receivers, error) {
-	// Prepare resulting map
+	// Prepare resulting map.
 	receivers := make(config.Receivers)
 
 	// Iterate over input map and create a config for each.
@@ -269,7 +269,7 @@ func loadReceivers(recvs map[string]interface{}, factories map[config.Type]compo
 			return nil, errorInvalidTypeAndNameKey(receiversKeyName, key, err)
 		}
 
-		// Find receiver factory based on "type" that we read from config source
+		// Find receiver factory based on "type" that we read from config source.
 		factory := factories[id.Type()]
 		if factory == nil {
 			return nil, errorUnknownType(receiversKeyName, id)
@@ -292,7 +292,7 @@ func loadReceivers(recvs map[string]interface{}, factories map[config.Type]compo
 }
 
 func loadExporters(exps map[string]interface{}, factories map[config.Type]component.ExporterFactory) (config.Exporters, error) {
-	// Prepare resulting map
+	// Prepare resulting map.
 	exporters := make(config.Exporters)
 
 	// Iterate over Exporters and create a config for each.
@@ -306,13 +306,13 @@ func loadExporters(exps map[string]interface{}, factories map[config.Type]compon
 			return nil, errorInvalidTypeAndNameKey(exportersKeyName, key, err)
 		}
 
-		// Find exporter factory based on "type" that we read from config source
+		// Find exporter factory based on "type" that we read from config source.
 		factory := factories[id.Type()]
 		if factory == nil {
 			return nil, errorUnknownType(exportersKeyName, id)
 		}
 
-		// Create the default config for this exporter
+		// Create the default config for this exporter.
 		exporterCfg := factory.CreateDefaultConfig()
 		exporterCfg.SetIDName(id.Name())
 		expandEnvLoadedConfig(exporterCfg)
@@ -477,27 +477,33 @@ func expandEnvLoadedConfigPointer(s interface{}) {
 	if value.Kind() != reflect.Ptr {
 		return
 	}
-	// Run expandLoadedConfigValue on the value behind the pointer
+	// Run expandLoadedConfigValue on the value behind the pointer.
 	expandEnvLoadedConfigValue(value.Elem())
 }
 
 func expandEnvLoadedConfigValue(value reflect.Value) {
-	// The value given is a string, we expand it (if allowed)
+	// The value given is a string, we expand it (if allowed).
 	if value.Kind() == reflect.String && value.CanSet() {
 		value.SetString(expandEnv(value.String()))
 	}
-	// The value given is a struct, we go through its fields
+	// The value given is a struct, we go through its fields.
 	if value.Kind() == reflect.Struct {
 		for i := 0; i < value.NumField(); i++ {
-			field := value.Field(i) // Returns the content of the field
-			if field.CanSet() {     // Only try to modify a field if it can be modified (eg. skip unexported private fields)
+			// Returns the content of the field.
+			field := value.Field(i)
+
+			// Only try to modify a field if it can be modified (eg. skip unexported private fields).
+			if field.CanSet() {
 				switch field.Kind() {
-				case reflect.String: // The current field is a string, we want to expand it
-					field.SetString(expandEnv(field.String())) // Expand env variables in the string
-				case reflect.Ptr: // The current field is a pointer
-					expandEnvLoadedConfigPointer(field.Interface()) // Run the expansion function on the pointer
-				case reflect.Struct: // The current field is a nested struct
-					expandEnvLoadedConfigValue(field) // Go through the nested struct
+				case reflect.String:
+					// The current field is a string, expand env variables in the string.
+					field.SetString(expandEnv(field.String()))
+				case reflect.Ptr:
+					// The current field is a pointer, run the expansion function on the pointer.
+					expandEnvLoadedConfigPointer(field.Interface())
+				case reflect.Struct:
+					// The current field is a nested struct, go through the nested struct
+					expandEnvLoadedConfigValue(field)
 				}
 			}
 		}

--- a/config/configloader/config.go
+++ b/config/configloader/config.go
@@ -35,7 +35,9 @@ import (
 type configErrorCode int
 
 const (
-	_ configErrorCode = iota // Skip 0, start errors codes from 1.
+	// Skip 0, start errors codes from 1.
+	_ configErrorCode = iota
+
 	errInvalidTypeAndNameKey
 	errUnknownType
 	errDuplicateName
@@ -43,8 +45,11 @@ const (
 )
 
 type configError struct {
-	msg  string          // Human readable error message.
-	code configErrorCode // Internal error code.
+	// Human readable error message.
+	msg string
+
+	// Internal error code.
+	code configErrorCode
 }
 
 func (e *configError) Error() string {

--- a/config/configloader/config.go
+++ b/config/configloader/config.go
@@ -94,7 +94,7 @@ type pipelineSettings struct {
 }
 
 // Load loads a Config from Parser.
-// After loading the config, `ValidateConfig` must be called to validate.
+// After loading the config, `Validate()` must be called to validate.
 func Load(v *config.Parser, factories component.Factories) (*config.Config, error) {
 
 	var cfg config.Config

--- a/config/confignet/confignet.go
+++ b/config/confignet/confignet.go
@@ -42,7 +42,7 @@ func (na *NetAddr) Listen() (net.Listener, error) {
 	return net.Listen(na.Transport, na.Endpoint)
 }
 
-// TCPAddr represents a tcp endpoint address.
+// TCPAddr represents a TCP endpoint address.
 type TCPAddr struct {
 	// Endpoint configures the address for this network connection.
 	// The address has the form "host:port". The host must be a literal IP address, or a host name that can be

--- a/config/configtelemetry/configtelemetry.go
+++ b/config/configtelemetry/configtelemetry.go
@@ -40,7 +40,7 @@ const (
 
 var metricsLevelPtr = new(Level)
 
-// Flags is a helper func, to add the telemetry config flags to the service that exposes
+// Flags is a helper function to add telemetry config flags to the service that exposes
 // the application flags.
 func Flags(flags *flag.FlagSet) {
 	flags.Var(

--- a/config/configtest/configtest.go
+++ b/config/configtest/configtest.go
@@ -26,7 +26,7 @@ import (
 
 // LoadConfigFile loads a config from file.
 func LoadConfigFile(t *testing.T, fileName string, factories component.Factories) (*config.Config, error) {
-	// Read yaml config from file
+	// Read yaml config from file.
 	cp, err := config.NewParserFromFile(fileName)
 	require.NoError(t, err)
 	// Load the config from viper using the given factories.

--- a/config/configtls/configtls.go
+++ b/config/configtls/configtls.go
@@ -40,7 +40,8 @@ type TLSSetting struct {
 // connections in addition to the common configurations. This should be used by
 // components configuring TLS client connections.
 type TLSClientSetting struct {
-	TLSSetting `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
+	// squash ensures fields are correctly decoded in embedded struct.
+	TLSSetting `mapstructure:",squash"`
 
 	// These are config options specific to client connections.
 
@@ -63,7 +64,8 @@ type TLSClientSetting struct {
 // connections in addition to the common configurations. This should be used by
 // components configuring TLS server connections.
 type TLSServerSetting struct {
-	TLSSetting `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
+	// squash ensures fields are correctly decoded in embedded struct.
+	TLSSetting `mapstructure:",squash"`
 
 	// These are config options specific to server connections.
 
@@ -81,7 +83,7 @@ func (c TLSSetting) loadTLSConfig() (*tls.Config, error) {
 	var err error
 	var certPool *x509.CertPool
 	if len(c.CAFile) != 0 {
-		// setup user specified truststore
+		// Set up user specified truststore.
 		certPool, err = c.loadCert(c.CAFile)
 		if err != nil {
 			return nil, fmt.Errorf("failed to load CA CertPool: %w", err)
@@ -120,7 +122,7 @@ func (c TLSSetting) loadCert(caPath string) (*x509.CertPool, error) {
 	return certPool, nil
 }
 
-// LoadTLSConfig loads the tls configuration.
+// LoadTLSConfig loads the TLS configuration.
 func (c TLSClientSetting) LoadTLSConfig() (*tls.Config, error) {
 	if c.Insecure && c.CAFile == "" {
 		return nil, nil
@@ -135,7 +137,7 @@ func (c TLSClientSetting) LoadTLSConfig() (*tls.Config, error) {
 	return tlsCfg, nil
 }
 
-// LoadTLSConfig loads the tls configuration.
+// LoadTLSConfig loads the TLS configuration.
 func (c TLSServerSetting) LoadTLSConfig() (*tls.Config, error) {
 	tlsCfg, err := c.loadTLSConfig()
 	if err != nil {

--- a/config/exporter.go
+++ b/config/exporter.go
@@ -25,7 +25,7 @@ type Exporter interface {
 type Exporters map[ComponentID]Exporter
 
 // ExporterSettings defines common settings for an exporter configuration.
-// Specific exporters can embed this struct, and extend it with more fields if needed.
+// Specific exporters can embed this struct and extend it with more fields if needed.
 // When embedded in the exporter config, it must be with `mapstructure:",squash"` tag.
 type ExporterSettings struct {
 	id ComponentID `mapstructure:"-"`

--- a/config/exporter.go
+++ b/config/exporter.go
@@ -25,8 +25,8 @@ type Exporter interface {
 type Exporters map[ComponentID]Exporter
 
 // ExporterSettings defines common settings for an exporter configuration.
-// Specific exporters can embed this struct and extend it with more fields if needed.
-// When embedded in the exporter config it must be with `mapstructure:",squash"` tag.
+// Specific exporters can embed this struct, and extend it with more fields if needed.
+// When embedded in the exporter config, it must be with `mapstructure:",squash"` tag.
 type ExporterSettings struct {
 	id ComponentID `mapstructure:"-"`
 }

--- a/config/extension.go
+++ b/config/extension.go
@@ -17,7 +17,7 @@ package config
 // Extension is the configuration of a service extension. Specific extensions
 // must implement this interface and will typically embed ExtensionSettings
 // struct or a struct that extends it.
-// Embedded validatable will force each extension to implement Validate() function
+// Embedded validatable will force each extension to implement Validate() function.
 type Extension interface {
 	identifiable
 	validatable
@@ -28,7 +28,7 @@ type Extensions map[ComponentID]Extension
 
 // ExtensionSettings defines common settings for an extension configuration.
 // Specific processors can embed this struct and extend it with more fields if needed.
-// When embedded in the extension config it must be with `mapstructure:",squash"` tag.
+// When embedded in the extension config, it must be with `mapstructure:",squash"` tag.
 type ExtensionSettings struct {
 	id ComponentID `mapstructure:"-"`
 }

--- a/config/internal/configsource/manager.go
+++ b/config/internal/configsource/manager.go
@@ -36,7 +36,7 @@ const (
 	// either environment variables or config sources.
 	expandPrefixChar = '$'
 	// configSourceNameDelimChar is the char used to terminate the name of config source
-	// when it is used to retrieve values to inject in the configuration
+	// when it is used to retrieve values to inject in the configuration.
 	configSourceNameDelimChar = ':'
 )
 
@@ -47,7 +47,7 @@ type (
 
 // Manager is used to inject data from config sources into a configuration and also
 // to monitor for updates on the items injected into the configuration.  All methods
-// of a Manager must be called only once and have a expected sequence:
+// of a Manager must be called only once and have an expected sequence:
 //
 // 1. NewManager to create a new instance;
 // 2. Resolve to inject the data from config sources into a configuration;
@@ -385,7 +385,8 @@ func (m *Manager) expandString(ctx context.Context, s string) (interface{}, erro
 			case s[j+1] == '{':
 				// Bracketed usage, consume everything until first '}' exactly as os.Expand.
 				expandableContent, w = getShellName(s[j+1:])
-				expandableContent = strings.Trim(expandableContent, " ") // Allow for some spaces.
+				// Allow for some spaces.
+				expandableContent = strings.Trim(expandableContent, " ")
 				if len(expandableContent) > 1 && strings.Contains(expandableContent, string(configSourceNameDelimChar)) {
 					// Bracket expandableContent contains ':' treating it as a config source.
 					cfgSrcName, _ = getShellName(expandableContent)
@@ -613,12 +614,14 @@ func getShellName(s string) (string, int) {
 		for i := 1; i < len(s); i++ {
 			if s[i] == '}' {
 				if i == 1 {
-					return "", 2 // Bad syntax; eat "${}"
+					// Bad syntax; eat "${}"
+					return "", 2
 				}
 				return s[1:i], i + 1
 			}
 		}
-		return "", 1 // Bad syntax; eat "${"
+		// Bad syntax; eat "${"
+		return "", 1
 	case isShellSpecialVar(s[0]):
 		return s[0:1], 1
 	}

--- a/config/parser.go
+++ b/config/parser.go
@@ -38,7 +38,7 @@ func NewParser() *Parser {
 
 // NewParserFromFile creates a new Parser by reading the given file.
 func NewParserFromFile(fileName string) (*Parser, error) {
-	// Read yaml config from file
+	// Read yaml config from file.
 	p := NewParser()
 	p.v.SetConfigFile(fileName)
 	if err := p.v.ReadInConfig(); err != nil {
@@ -71,13 +71,13 @@ type Parser struct {
 }
 
 // AllKeys returns all keys holding a value, regardless of where they are set.
-// Nested keys are returned with a KeyDelimiter separator
+// Nested keys are returned with a KeyDelimiter separator.
 func (l *Parser) AllKeys() []string {
 	return l.v.AllKeys()
 }
 
-// Unmarshal unmarshals the config into a struct. Make sure that the tags
-// on the fields of the structure are properly set.
+// Unmarshal unmarshals the config into a struct.
+// Tags on the fields of the structure must be properly set.
 func (l *Parser) Unmarshal(rawVal interface{}) error {
 	return l.v.Unmarshal(rawVal)
 }
@@ -142,8 +142,8 @@ func deepSearch(m map[string]interface{}, path []string) map[string]interface{} 
 	for _, k := range path {
 		m2, ok := m[k]
 		if !ok {
-			// intermediate key does not exist
-			// => create it and continue from there
+			// Intermediate key does not exist:
+			// create it and continue from there.
 			m3 := make(map[string]interface{})
 			m[k] = m3
 			m = m3
@@ -151,8 +151,8 @@ func deepSearch(m map[string]interface{}, path []string) map[string]interface{} 
 		}
 		m3, ok := m2.(map[string]interface{})
 		if !ok {
-			// intermediate key is a value
-			// => replace with a new map
+			// Intermediate key is a value:
+			// replace with a new map.
 			m3 = make(map[string]interface{})
 			m[k] = m3
 		}
@@ -164,17 +164,17 @@ func deepSearch(m map[string]interface{}, path []string) map[string]interface{} 
 
 // ToStringMap creates a map[string]interface{} from a Parser.
 func (l *Parser) ToStringMap() map[string]interface{} {
-	// This is equivalent to l.v.AllSettings() but it maps nil values
+	// This is equivalent to l.v.AllSettings() but it maps nil values.
 	// We can't use AllSettings here because of https://github.com/spf13/viper/issues/819
 
 	m := map[string]interface{}{}
-	// start from the list of keys, and construct the map one value at a time
+	// Start from the list of keys, and construct the map one value at a time.
 	for _, k := range l.v.AllKeys() {
 		value := l.v.Get(k)
 		path := strings.Split(k, KeyDelimiter)
 		lastKey := strings.ToLower(path[len(path)-1])
 		deepestMap := deepSearch(m, path[0:len(path)-1])
-		// set innermost value
+		// Set innermost value.
 		deepestMap[lastKey] = value
 	}
 	return m

--- a/config/processor.go
+++ b/config/processor.go
@@ -16,7 +16,7 @@ package config
 
 // Processor is the configuration of a processor. Specific processors must implement this
 // interface and will typically embed ProcessorSettings struct or a struct that extends it.
-// Embedded validatable will force each processor to implement Validate() function
+// Embedded validatable will force each processor to implement Validate() function.
 type Processor interface {
 	identifiable
 	validatable

--- a/config/receiver.go
+++ b/config/receiver.go
@@ -16,7 +16,7 @@ package config
 
 // Receiver is the configuration of a receiver. Specific receivers must implement this
 // interface and will typically embed ReceiverSettings struct or a struct that extends it.
-// Embedded validatable will force each receiver to implement Validate() function
+// Embedded validatable will force each receiver to implement Validate() function.
 type Receiver interface {
 	identifiable
 	validatable


### PR DESCRIPTION
**Description:** 
This PR is one of the three PRs working to review and improve the Config package. Changes were made to update the documentation of type and func declarations in the configuration package and all of its sub-packages, with a focus on ensuring that the documentation follows the [best practices](https://blog.golang.org/godoc) recommended by Go, and that there is no grammar mistakes.

**Link to tracking Issue:** <Issue number if applicable>
Addresses part of #3051