### PR TITLE
Refactored Jaeger exporter to move connection into start for upcoming Auth changes.

### DIFF
--- a/exporter/jaegerexporter/exporter_test.go
+++ b/exporter/jaegerexporter/exporter_test.go
@@ -278,7 +278,6 @@ func TestConnectionStateChange(t *testing.T) {
 		wg.Done()
 	})
 
-
 	done := make(chan struct{})
 	go func() {
 		sender.startConnectionStatusReporter()


### PR DESCRIPTION
Description:
Updated JaegerExporter for upcoming client auth extension changes

Link to tracking Issue:
#3287 #3282

Testing:
Unit tests

Documentation:
Unit tests