### PR TITLE
Refactored PromRemoteWriteExporter to create client in Start to accomodate future update to ToClient() apis 

### DIFF
--- a/exporter/prometheusremotewriteexporter/exporter.go
+++ b/exporter/prometheusremotewriteexporter/exporter.go
@@ -28,6 +28,8 @@ import (
 	"strings"
 	"sync"
 
+	"go.opentelemetry.io/collector/config/confighttp"
+
 	"github.com/gogo/protobuf/proto"
 	"github.com/golang/snappy"
 	"github.com/prometheus/prometheus/prompb"
@@ -49,15 +51,11 @@ type PRWExporter struct {
 	closeChan       chan struct{}
 	concurrency     int
 	userAgentHeader string
+	clientSettings  *confighttp.HTTPClientSettings
 }
 
 // NewPRWExporter initializes a new PRWExporter instance and sets fields accordingly.
 func NewPRWExporter(cfg *Config, buildInfo component.BuildInfo) (*PRWExporter, error) {
-	client, err := cfg.HTTPClientSettings.ToClient()
-	if err != nil {
-		return nil, err
-	}
-
 	sanitizedLabels, err := validateAndSanitizeExternalLabels(cfg.ExternalLabels)
 	if err != nil {
 		return nil, err
@@ -74,12 +72,18 @@ func NewPRWExporter(cfg *Config, buildInfo component.BuildInfo) (*PRWExporter, e
 		namespace:       cfg.Namespace,
 		externalLabels:  sanitizedLabels,
 		endpointURL:     endpointURL,
-		client:          client,
 		wg:              new(sync.WaitGroup),
 		closeChan:       make(chan struct{}),
 		userAgentHeader: userAgentHeader,
 		concurrency:     cfg.RemoteWriteQueue.NumConsumers,
+		clientSettings:  &cfg.HTTPClientSettings,
 	}, nil
+}
+
+// Start creates the prometheus client
+func (prwe *PRWExporter) Start(_ context.Context, _ component.Host) (err error) {
+	prwe.client, err = prwe.clientSettings.ToClient()
+	return err
 }
 
 // Shutdown stops the exporter from accepting incoming calls(and return error), and wait for current export operations

--- a/exporter/prometheusremotewriteexporter/exporter.go
+++ b/exporter/prometheusremotewriteexporter/exporter.go
@@ -28,13 +28,12 @@ import (
 	"strings"
 	"sync"
 
-	"go.opentelemetry.io/collector/config/confighttp"
-
 	"github.com/gogo/protobuf/proto"
 	"github.com/golang/snappy"
 	"github.com/prometheus/prometheus/prompb"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/consumer/pdata"
 )

--- a/exporter/prometheusremotewriteexporter/exporter_test.go
+++ b/exporter/prometheusremotewriteexporter/exporter_test.go
@@ -23,6 +23,9 @@ import (
 	"sync"
 	"testing"
 
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/config/configtls"
+
 	"github.com/gogo/protobuf/proto"
 	"github.com/golang/snappy"
 	"github.com/prometheus/prometheus/prompb"
@@ -53,59 +56,52 @@ func Test_NewPRWExporter(t *testing.T) {
 	}
 
 	tests := []struct {
-		name           string
-		config         *Config
-		namespace      string
-		endpoint       string
-		concurrency    int
-		externalLabels map[string]string
-		client         *http.Client
-		returnError    bool
-		buildInfo      component.BuildInfo
+		name                string
+		config              *Config
+		namespace           string
+		endpoint            string
+		concurrency         int
+		externalLabels      map[string]string
+		returnErrorOnCreate bool
+		buildInfo           component.BuildInfo
 	}{
 		{
-			"invalid_URL",
-			cfg,
-			"test",
-			"invalid URL",
-			5,
-			map[string]string{"Key1": "Val1"},
-			http.DefaultClient,
-			true,
-			buildInfo,
+			name:                "invalid_URL",
+			config:              cfg,
+			namespace:           "test",
+			endpoint:            "invalid URL",
+			concurrency:         5,
+			externalLabels:      map[string]string{"Key1": "Val1"},
+			returnErrorOnCreate: true,
+			buildInfo:           buildInfo,
 		},
 		{
-			"invalid_labels_case",
-			cfg,
-			"test",
-			"http://some.url:9411/api/prom/push",
-			5,
-			map[string]string{"Key1": ""},
-			http.DefaultClient,
-			true,
-			buildInfo,
+			name:                "invalid_labels_case",
+			config:              cfg,
+			namespace:           "test",
+			endpoint:            "http://some.url:9411/api/prom/push",
+			concurrency:         5,
+			externalLabels:      map[string]string{"Key1": ""},
+			returnErrorOnCreate: true,
+			buildInfo:           buildInfo,
 		},
 		{
-			"success_case",
-			cfg,
-			"test",
-			"http://some.url:9411/api/prom/push",
-			5,
-			map[string]string{"Key1": "Val1"},
-			http.DefaultClient,
-			false,
-			buildInfo,
+			name:           "success_case",
+			config:         cfg,
+			namespace:      "test",
+			endpoint:       "http://some.url:9411/api/prom/push",
+			concurrency:    5,
+			externalLabels: map[string]string{"Key1": "Val1"},
+			buildInfo:      buildInfo,
 		},
 		{
-			"success_case_no_labels",
-			cfg,
-			"test",
-			"http://some.url:9411/api/prom/push",
-			5,
-			map[string]string{},
-			http.DefaultClient,
-			false,
-			buildInfo,
+			name:           "success_case_no_labels",
+			config:         cfg,
+			namespace:      "test",
+			endpoint:       "http://some.url:9411/api/prom/push",
+			concurrency:    5,
+			externalLabels: map[string]string{},
+			buildInfo:      buildInfo,
 		},
 	}
 
@@ -117,7 +113,7 @@ func Test_NewPRWExporter(t *testing.T) {
 			cfg.RemoteWriteQueue.NumConsumers = 1
 			prwe, err := NewPRWExporter(cfg, tt.buildInfo)
 
-			if tt.returnError {
+			if tt.returnErrorOnCreate {
 				assert.Error(t, err)
 				return
 			}
@@ -125,10 +121,87 @@ func Test_NewPRWExporter(t *testing.T) {
 			assert.NotNil(t, prwe.namespace)
 			assert.NotNil(t, prwe.endpointURL)
 			assert.NotNil(t, prwe.externalLabels)
-			assert.NotNil(t, prwe.client)
 			assert.NotNil(t, prwe.closeChan)
 			assert.NotNil(t, prwe.wg)
 			assert.NotNil(t, prwe.userAgentHeader)
+			assert.NotNil(t, prwe.clientSettings)
+		})
+	}
+}
+
+// Test_Start checks if the client is properly created as expected.
+func Test_Start(t *testing.T) {
+	cfg := &Config{
+		ExporterSettings: config.NewExporterSettings(config.NewID(typeStr)),
+		TimeoutSettings:  exporterhelper.TimeoutSettings{},
+		RetrySettings:    exporterhelper.RetrySettings{},
+		Namespace:        "",
+		ExternalLabels:   map[string]string{},
+	}
+	buildInfo := component.BuildInfo{
+		Description: "OpenTelemetry Collector",
+		Version:     "1.0",
+	}
+	tests := []struct {
+		name                 string
+		config               *Config
+		namespace            string
+		concurrency          int
+		externalLabels       map[string]string
+		returnErrorOnStartUp bool
+		buildInfo            component.BuildInfo
+		endpoint             string
+		clientSettings       confighttp.HTTPClientSettings
+	}{
+		{
+			name:           "success_case",
+			config:         cfg,
+			namespace:      "test",
+			concurrency:    5,
+			externalLabels: map[string]string{"Key1": "Val1"},
+			buildInfo:      buildInfo,
+			clientSettings: confighttp.HTTPClientSettings{Endpoint: "https://some.url:9411/api/prom/push"},
+		},
+		{
+			name:                 "invalid_tls",
+			config:               cfg,
+			namespace:            "test",
+			concurrency:          5,
+			externalLabels:       map[string]string{"Key1": "Val1"},
+			buildInfo:            buildInfo,
+			returnErrorOnStartUp: true,
+			clientSettings: confighttp.HTTPClientSettings{
+				Endpoint: "https://some.url:9411/api/prom/push",
+				TLSSetting: configtls.TLSClientSetting{
+					TLSSetting: configtls.TLSSetting{
+						CAFile:   "non-existent file",
+						CertFile: "",
+						KeyFile:  "",
+					},
+					Insecure:   false,
+					ServerName: "",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg.ExternalLabels = tt.externalLabels
+			cfg.Namespace = tt.namespace
+			cfg.RemoteWriteQueue.NumConsumers = 1
+			cfg.HTTPClientSettings = tt.clientSettings
+
+			prwe, err := NewPRWExporter(cfg, tt.buildInfo)
+			assert.NoError(t, err)
+			assert.NotNil(t, prwe)
+
+			err = prwe.Start(context.Background(), componenttest.NewNopHost())
+			if tt.returnErrorOnStartUp {
+				assert.Error(t, err)
+				return
+			}
+			assert.NotNil(t, prwe.client)
 		})
 	}
 }
@@ -195,11 +268,11 @@ func Test_export(t *testing.T) {
 	// Create in test table format to check if different HTTP response codes or server errors
 	// are properly identified
 	tests := []struct {
-		name             string
-		ts               prompb.TimeSeries
-		serverUp         bool
-		httpResponseCode int
-		returnError      bool
+		name                string
+		ts                  prompb.TimeSeries
+		serverUp            bool
+		httpResponseCode    int
+		returnErrorOnCreate bool
 	}{
 		{"success_case",
 			*ts1,
@@ -236,7 +309,7 @@ func Test_export(t *testing.T) {
 				server.Close()
 			}
 			errs := runExportPipeline(ts1, serverURL)
-			if tt.returnError {
+			if tt.returnErrorOnCreate {
 				assert.Error(t, errs[0])
 				return
 			}
@@ -266,6 +339,12 @@ func runExportPipeline(ts *prompb.TimeSeries, endpoint *url.URL) []error {
 		errs = append(errs, err)
 		return errs
 	}
+
+	if err = prwe.Start(context.Background(), componenttest.NewNopHost()); err != nil {
+		errs = append(errs, err)
+		return errs
+	}
+
 	errs = append(errs, prwe.export(context.Background(), testmap)...)
 	return errs
 }
@@ -515,6 +594,7 @@ func Test_PushMetrics(t *testing.T) {
 			}
 			prwe, nErr := NewPRWExporter(cfg, buildInfo)
 			require.NoError(t, nErr)
+			require.NoError(t, prwe.Start(context.Background(), componenttest.NewNopHost()))
 			err := prwe.PushMetrics(context.Background(), *tt.md)
 			if tt.returnErr {
 				assert.Error(t, err)
@@ -527,10 +607,10 @@ func Test_PushMetrics(t *testing.T) {
 
 func Test_validateAndSanitizeExternalLabels(t *testing.T) {
 	tests := []struct {
-		name           string
-		inputLabels    map[string]string
-		expectedLabels map[string]string
-		returnError    bool
+		name                string
+		inputLabels         map[string]string
+		expectedLabels      map[string]string
+		returnErrorOnCreate bool
 	}{
 		{"success_case_no_labels",
 			map[string]string{},
@@ -562,7 +642,7 @@ func Test_validateAndSanitizeExternalLabels(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			newLabels, err := validateAndSanitizeExternalLabels(tt.inputLabels)
-			if tt.returnError {
+			if tt.returnErrorOnCreate {
 				assert.Error(t, err)
 				return
 			}

--- a/exporter/prometheusremotewriteexporter/exporter_test.go
+++ b/exporter/prometheusremotewriteexporter/exporter_test.go
@@ -23,9 +23,6 @@ import (
 	"sync"
 	"testing"
 
-	"go.opentelemetry.io/collector/component/componenttest"
-	"go.opentelemetry.io/collector/config/configtls"
-
 	"github.com/gogo/protobuf/proto"
 	"github.com/golang/snappy"
 	"github.com/prometheus/prometheus/prompb"
@@ -33,8 +30,10 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/confighttp"
+	"go.opentelemetry.io/collector/config/configtls"
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 	"go.opentelemetry.io/collector/internal/testdata"

--- a/exporter/prometheusremotewriteexporter/factory.go
+++ b/exporter/prometheusremotewriteexporter/factory.go
@@ -68,6 +68,7 @@ func createMetricsExporter(_ context.Context, params component.ExporterCreatePar
 		}),
 		exporterhelper.WithRetry(prwCfg.RetrySettings),
 		exporterhelper.WithResourceToTelemetryConversion(prwCfg.ResourceToTelemetrySettings),
+		exporterhelper.WithStart(prwe.Start),
 		exporterhelper.WithShutdown(prwe.Shutdown),
 	)
 }

--- a/exporter/prometheusremotewriteexporter/factory_test.go
+++ b/exporter/prometheusremotewriteexporter/factory_test.go
@@ -91,6 +91,7 @@ func Test_createMetricsExporter(t *testing.T) {
 				assert.Error(t, err)
 				return
 			}
+			assert.NoError(t, err)
 			assert.NotNil(t, exp)
 			err = exp.Start(context.Background(), componenttest.NewNopHost())
 			if tt.returnErrorOnStart {

--- a/exporter/prometheusremotewriteexporter/factory_test.go
+++ b/exporter/prometheusremotewriteexporter/factory_test.go
@@ -18,12 +18,11 @@ import (
 	"context"
 	"testing"
 
-	"go.opentelemetry.io/collector/component/componenttest"
-
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/configcheck"
 	"go.opentelemetry.io/collector/config/confighttp"


### PR DESCRIPTION
Description:

Updated PrometheusRemoteWriteExporter for upcoming client auth extension changes. Moved httpClient creation to Start method of the component. This ensures the call to ToClient() method gets access to host object which is required in the next version of ToClient() apis. 

Link to tracking Issue:
#3287 #3282

Testing:
Unit tests

Documentation:
Unit tests