### PR TITLE
fix bug  issue#3118 and issue#3161

### DIFF
--- a/exporter/prometheusexporter/accumulator.go
+++ b/exporter/prometheusexporter/accumulator.go
@@ -376,7 +376,7 @@ func timeseriesSignature(ilmName string, metric pdata.Metric, labels pdata.Strin
 	b.WriteString(metric.DataType().String())
 	b.WriteString("*" + ilmName)
 	b.WriteString("*" + metric.Name())
-	labels.Range(func(k string, v string) bool {
+	labels.Sort().Range(func(k string, v string) bool {
 		b.WriteString("*" + k + "*" + v)
 		return true
 	})


### PR DESCRIPTION
I have met same problem like these issues  #3118,#3161, and I debug found here:
<img width="788" alt="image" src="https://user-images.githubusercontent.com/27889201/119601511-e462b280-be1b-11eb-9cb1-49c267294f29.png">
Same metric with different order lablemap will get a different key in accumulator's map. And same metric will be in the Map with different key, when accumulator is collecting, only the first one will be exported to prometheus. Some key will never be exported because of prometheus will only get the first one. I found sort it before generate the key, there will only one metric in accumulator's map, and every metric will be exported.