### PR TITLE
Remove deprecated funcs inside the obsreceiver

### DIFF
--- a/obsreport/obsreport_receiver.go
+++ b/obsreport/obsreport_receiver.go
@@ -112,22 +112,6 @@ func (rec *Receiver) StartTraceDataReceiveOp(
 		opt...)
 }
 
-// StartTraceDataReceiveOp is deprecated but is called when a request is received from a client.
-// The returned context should be used in other calls to the obsreport functions
-// dealing with the same receive operation.
-func StartTraceDataReceiveOp(
-	operationCtx context.Context,
-	receiverID config.ComponentID,
-	transport string,
-	opt ...StartReceiveOption,
-) context.Context {
-	rec := NewReceiver(ReceiverSettings{ReceiverID: receiverID, Transport: transport})
-	return rec.traceReceiveOp(
-		operationCtx,
-		obsmetrics.ReceiveTraceDataOperationSuffix,
-		opt...)
-}
-
 // EndTraceDataReceiveOp completes the receive operation that was started with
 // StartTraceDataReceiveOp.
 func (rec *Receiver) EndTraceDataReceiveOp(
@@ -145,24 +129,6 @@ func (rec *Receiver) EndTraceDataReceiveOp(
 	)
 }
 
-// EndTraceDataReceiveOp is deprecated but completes the receive operation that was started with
-// StartTraceDataReceiveOp.
-func EndTraceDataReceiveOp(
-	receiverCtx context.Context,
-	format string,
-	numReceivedSpans int,
-	err error,
-) {
-	rec := NewReceiver(ReceiverSettings{})
-	rec.endReceiveOp(
-		receiverCtx,
-		format,
-		numReceivedSpans,
-		err,
-		config.TracesDataType,
-	)
-}
-
 // StartLogsReceiveOp is called when a request is received from a client.
 // The returned context should be used in other calls to the obsreport functions
 // dealing with the same receive operation.
@@ -170,22 +136,6 @@ func (rec *Receiver) StartLogsReceiveOp(
 	operationCtx context.Context,
 	opt ...StartReceiveOption,
 ) context.Context {
-	return rec.traceReceiveOp(
-		operationCtx,
-		obsmetrics.ReceiverLogsOperationSuffix,
-		opt...)
-}
-
-// StartLogsReceiveOp is deprecated but is called when a request is received from a client.
-// The returned context should be used in other calls to the obsreport functions
-// dealing with the same receive operation.
-func StartLogsReceiveOp(
-	operationCtx context.Context,
-	receiverID config.ComponentID,
-	transport string,
-	opt ...StartReceiveOption,
-) context.Context {
-	rec := NewReceiver(ReceiverSettings{ReceiverID: receiverID, Transport: transport})
 	return rec.traceReceiveOp(
 		operationCtx,
 		obsmetrics.ReceiverLogsOperationSuffix,
@@ -209,24 +159,6 @@ func (rec *Receiver) EndLogsReceiveOp(
 	)
 }
 
-// EndLogsReceiveOp is deprecated but completes the receive operation that was started with
-// StartLogsReceiveOp.
-func EndLogsReceiveOp(
-	receiverCtx context.Context,
-	format string,
-	numReceivedLogRecords int,
-	err error,
-) {
-	rec := NewReceiver(ReceiverSettings{})
-	rec.endReceiveOp(
-		receiverCtx,
-		format,
-		numReceivedLogRecords,
-		err,
-		config.LogsDataType,
-	)
-}
-
 // StartMetricsReceiveOp is called when a request is received from a client.
 // The returned context should be used in other calls to the obsreport functions
 // dealing with the same receive operation.
@@ -234,22 +166,6 @@ func (rec *Receiver) StartMetricsReceiveOp(
 	operationCtx context.Context,
 	opt ...StartReceiveOption,
 ) context.Context {
-	return rec.traceReceiveOp(
-		operationCtx,
-		obsmetrics.ReceiverMetricsOperationSuffix,
-		opt...)
-}
-
-// StartMetricsReceiveOp is deprecated but is called when a request is received from a client.
-// The returned context should be used in other calls to the obsreport functions
-// dealing with the same receive operation.
-func StartMetricsReceiveOp(
-	operationCtx context.Context,
-	receiverID config.ComponentID,
-	transport string,
-	opt ...StartReceiveOption,
-) context.Context {
-	rec := NewReceiver(ReceiverSettings{ReceiverID: receiverID, Transport: transport})
 	return rec.traceReceiveOp(
 		operationCtx,
 		obsmetrics.ReceiverMetricsOperationSuffix,
@@ -264,24 +180,6 @@ func (rec *Receiver) EndMetricsReceiveOp(
 	numReceivedPoints int,
 	err error,
 ) {
-	rec.endReceiveOp(
-		receiverCtx,
-		format,
-		numReceivedPoints,
-		err,
-		config.MetricsDataType,
-	)
-}
-
-// EndMetricsReceiveOp is deprecated but completes the receive operation that was started with
-// StartMetricsReceiveOp.
-func EndMetricsReceiveOp(
-	receiverCtx context.Context,
-	format string,
-	numReceivedPoints int,
-	err error,
-) {
-	rec := NewReceiver(ReceiverSettings{})
 	rec.endReceiveOp(
 		receiverCtx,
 		format,


### PR DESCRIPTION
**Description:** Removed the deprecated funcs for the obsreceiver after making changes to the collector-contrib repo

**Link to tracking Issue:** [Issue #2649](https://github.com/open-telemetry/opentelemetry-collector/issues/2649)