### PR TITLE
Remove obsreport.ProcessorMetricViews, use BuildProcessorCustomMetricName where needed

### DIFF
--- a/obsreport/obsreport_processor.go
+++ b/obsreport/obsreport_processor.go
@@ -18,12 +18,10 @@ import (
 	"context"
 
 	"go.opencensus.io/stats"
-	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
 
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/configtelemetry"
-	"go.opentelemetry.io/collector/internal/obsreportconfig"
 	"go.opentelemetry.io/collector/internal/obsreportconfig/obsmetrics"
 )
 
@@ -32,32 +30,6 @@ import (
 // value used to identify the type on the config.
 func BuildProcessorCustomMetricName(configType, metric string) string {
 	return buildComponentPrefix(obsmetrics.ProcessorPrefix, configType) + metric
-}
-
-// ProcessorMetricViews builds the metric views for custom metrics of processors.
-func ProcessorMetricViews(configType string, legacyViews *obsreportconfig.ObsMetrics) *obsreportconfig.ObsMetrics {
-	var allViews []*view.View
-	if obsreportconfig.Level != configtelemetry.LevelNone {
-		for _, legacyView := range legacyViews.Views {
-			// Ignore any nil entry and views without measure or aggregation.
-			// These can't be registered but some code registering legacy views may
-			// ignore the errors.
-			if legacyView == nil || legacyView.Measure == nil || legacyView.Aggregation == nil {
-				continue
-			}
-			newView := *legacyView
-			viewName := legacyView.Name
-			if viewName == "" {
-				viewName = legacyView.Measure.Name()
-			}
-			newView.Name = BuildProcessorCustomMetricName(configType, viewName)
-			allViews = append(allViews, &newView)
-		}
-	}
-
-	return &obsreportconfig.ObsMetrics{
-		Views: allViews,
-	}
 }
 
 // Processor is a helper to add observability to a component.Processor.

--- a/obsreport/obsreport_test.go
+++ b/obsreport/obsreport_test.go
@@ -22,13 +22,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.opencensus.io/stats"
-	"go.opencensus.io/stats/view"
 	"go.opencensus.io/trace"
 
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/configtelemetry"
-	"go.opentelemetry.io/collector/internal/obsreportconfig"
 	"go.opentelemetry.io/collector/internal/obsreportconfig/obsmetrics"
 	"go.opentelemetry.io/collector/obsreport/obsreporttest"
 	"go.opentelemetry.io/collector/receiver/scrapererror"
@@ -541,56 +538,24 @@ func TestProcessorMetricsData(t *testing.T) {
 	obsreporttest.CheckProcessorMetrics(t, processor, acceptedPoints, refusedPoints, droppedPoints)
 }
 
-func TestProcessorMetricViews(t *testing.T) {
-	measures := []stats.Measure{
-		stats.Int64("firstMeasure", "test firstMeasure", stats.UnitDimensionless),
-		stats.Int64("secondMeasure", "test secondMeasure", stats.UnitBytes),
-	}
-	legacyViews := []*view.View{
-		{
-			Name:        measures[0].Name(),
-			Description: measures[0].Description(),
-			Measure:     measures[0],
-			Aggregation: view.Sum(),
-		},
-		{
-			Measure:     measures[1],
-			Aggregation: view.Count(),
-		},
-	}
-
+func TestBuildProcessorCustomMetricName(t *testing.T) {
 	tests := []struct {
-		name  string
-		level configtelemetry.Level
-		want  []*view.View
+		name string
+		want string
 	}{
 		{
-			name:  "none",
-			level: configtelemetry.LevelNone,
+			name: "firstMeasure",
+			want: "processor/test_type/firstMeasure",
 		},
 		{
-			name:  "basic",
-			level: configtelemetry.LevelBasic,
-			want: []*view.View{
-				{
-					Name:        "processor/test_type/" + measures[0].Name(),
-					Description: measures[0].Description(),
-					Measure:     measures[0],
-					Aggregation: view.Sum(),
-				},
-				{
-					Name:        "processor/test_type/" + measures[1].Name(),
-					Measure:     measures[1],
-					Aggregation: view.Count(),
-				},
-			},
+			name: "secondMeasure",
+			want: "processor/test_type/secondMeasure",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			obsreportconfig.Configure(tt.level)
-			got := ProcessorMetricViews("test_type", &obsreportconfig.ObsMetrics{Views: legacyViews})
-			assert.Equal(t, tt.want, got.Views)
+			got := BuildProcessorCustomMetricName("test_type", tt.name)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/processor/batchprocessor/metrics.go
+++ b/processor/batchprocessor/metrics.go
@@ -19,7 +19,6 @@ import (
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
 
-	"go.opentelemetry.io/collector/internal/obsreportconfig"
 	"go.opentelemetry.io/collector/internal/obsreportconfig/obsmetrics"
 	"go.opentelemetry.io/collector/obsreport"
 )
@@ -37,7 +36,7 @@ func MetricViews() []*view.View {
 	processorTagKeys := []tag.Key{processorTagKey}
 
 	countBatchSizeTriggerSendView := &view.View{
-		Name:        statBatchSizeTriggerSend.Name(),
+		Name:        obsreport.BuildProcessorCustomMetricName(typeStr, statBatchSizeTriggerSend.Name()),
 		Measure:     statBatchSizeTriggerSend,
 		Description: statBatchSizeTriggerSend.Description(),
 		TagKeys:     processorTagKeys,
@@ -45,7 +44,7 @@ func MetricViews() []*view.View {
 	}
 
 	countTimeoutTriggerSendView := &view.View{
-		Name:        statTimeoutTriggerSend.Name(),
+		Name:        obsreport.BuildProcessorCustomMetricName(typeStr, statTimeoutTriggerSend.Name()),
 		Measure:     statTimeoutTriggerSend,
 		Description: statTimeoutTriggerSend.Description(),
 		TagKeys:     processorTagKeys,
@@ -53,7 +52,7 @@ func MetricViews() []*view.View {
 	}
 
 	distributionBatchSendSizeView := &view.View{
-		Name:        statBatchSendSize.Name(),
+		Name:        obsreport.BuildProcessorCustomMetricName(typeStr, statBatchSendSize.Name()),
 		Measure:     statBatchSendSize,
 		Description: statBatchSendSize.Description(),
 		TagKeys:     processorTagKeys,
@@ -61,7 +60,7 @@ func MetricViews() []*view.View {
 	}
 
 	distributionBatchSendSizeBytesView := &view.View{
-		Name:        statBatchSendSizeBytes.Name(),
+		Name:        obsreport.BuildProcessorCustomMetricName(typeStr, statBatchSendSizeBytes.Name()),
 		Measure:     statBatchSendSizeBytes,
 		Description: statBatchSendSizeBytes.Description(),
 		TagKeys:     processorTagKeys,
@@ -70,14 +69,10 @@ func MetricViews() []*view.View {
 			1000_000, 2000_000, 3000_000, 4000_000, 5000_000, 6000_000, 7000_000, 8000_000, 9000_000),
 	}
 
-	legacyViews := &obsreportconfig.ObsMetrics{
-		Views: []*view.View{
-			countBatchSizeTriggerSendView,
-			countTimeoutTriggerSendView,
-			distributionBatchSendSizeView,
-			distributionBatchSendSizeBytesView,
-		},
+	return []*view.View{
+		countBatchSizeTriggerSendView,
+		countTimeoutTriggerSendView,
+		distributionBatchSendSizeView,
+		distributionBatchSendSizeBytesView,
 	}
-
-	return obsreport.ProcessorMetricViews(typeStr, legacyViews).Views
 }


### PR DESCRIPTION
Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>