### PR TITLE
correct minor typo

### DIFF
--- a/exporter/README.md
+++ b/exporter/README.md
@@ -22,9 +22,9 @@ Available metric exporters (sorted alphabetically):
 
 Available log exporters (sorted alphabetically):
 
+- [Kafka](kafkaexporter/README.md)
 - [OTLP gRPC](otlpexporter/README.md)
 - [OTLP HTTP](otlphttpexporter/README.md)
-- [Kafka](kafkaexporter/README.md)
 
 Available local exporters (sorted alphabetically):
 

--- a/exporter/README.md
+++ b/exporter/README.md
@@ -22,9 +22,9 @@ Available metric exporters (sorted alphabetically):
 
 Available log exporters (sorted alphabetically):
 
-- [Kafka](kafkaexporter/README.md)
 - [OTLP gRPC](otlpexporter/README.md)
 - [OTLP HTTP](otlphttpexporter/README.md)
+- [Kafka](kafkaexporter/README.md)
 
 Available local exporters (sorted alphabetically):
 

--- a/receiver/README.md
+++ b/receiver/README.md
@@ -23,8 +23,8 @@ Available metric receivers (sorted alphabetically):
 
 Available log receivers (sorted alphabetically):
 
-- [OTLP Receiver](otlpreceiver/README.md)
 - [Kafka Receiver](kafkareceiver/README.md)
+- [OTLP Receiver](otlpreceiver/README.md)
 
 The [contrib repository](https://github.com/open-telemetry/opentelemetry-collector-contrib)
  has more receivers that can be added to custom builds of the collector.


### PR DESCRIPTION
**Documentation:**
Fixing a minor bug in the README: The log receivers were not sorted alphabetically, fixed it.
