### PR TITLE
Fix pipelines typo in config loader test config

### DIFF
--- a/config/configloader/testdata/empty-all-sections.yaml
+++ b/config/configloader/testdata/empty-all-sections.yaml
@@ -2,4 +2,4 @@ receivers:
 exporters:
 processors:
 service:
-  pipeline:
+  pipelines:


### PR DESCRIPTION
**Description:**
per https://github.com/open-telemetry/opentelemetry-collector/pull/3337#discussion_r643949551 these changes fix a typo that leads to a test failure when using koanf, whose UnmarshalExact method is functional for maps with nil values.
