### PR TITLE
Return concrete error type

### DIFF
--- a/receiver/scrapererror/partialscrapeerror.go
+++ b/receiver/scrapererror/partialscrapeerror.go
@@ -16,8 +16,8 @@ package scrapererror
 
 import "errors"
 
-// PartialScrapeError can be used to signalize that a subset of metrics were failed
-// to be scraped
+// PartialScrapeError is an error to represent
+// that a subset of metrics were failed to be scraped.
 type PartialScrapeError struct {
 	error
 	Failed int
@@ -25,7 +25,7 @@ type PartialScrapeError struct {
 
 // NewPartialScrapeError creates PartialScrapeError for failed metrics.
 // Use this error type only when a subset of data was failed to be scraped.
-func NewPartialScrapeError(err error, failed int) error {
+func NewPartialScrapeError(err error, failed int) PartialScrapeError {
 	return PartialScrapeError{
 		error:  err,
 		Failed: failed,

--- a/receiver/scrapererror/partialscrapeerror_test.go
+++ b/receiver/scrapererror/partialscrapeerror_test.go
@@ -28,7 +28,7 @@ func TestPartialScrapeError(t *testing.T) {
 	err := fmt.Errorf("some error")
 	partialErr := NewPartialScrapeError(err, failed)
 	assert.Equal(t, err.Error(), partialErr.Error())
-	assert.Equal(t, failed, partialErr.(PartialScrapeError).Failed)
+	assert.Equal(t, failed, partialErr.Failed)
 }
 
 func TestIsPartialScrapeError(t *testing.T) {


### PR DESCRIPTION
Go development practices favors returning concrete types over interfaces, so the users don't have to force cast the return value to the concrete type and the APIs self document the returned error type.
