### PR TITLE
Increase max RAM for load test

### DIFF
--- a/testbed/tests/trace_test.go
+++ b/testbed/tests/trace_test.go
@@ -149,7 +149,7 @@ func TestTraceNoBackend10kSPS(t *testing.T) {
 		{
 			Name:                "NoMemoryLimit",
 			Processor:           noLimitProcessors,
-			ExpectedMaxRAM:      170,
+			ExpectedMaxRAM:      190,
 			ExpectedMinFinalRAM: 100,
 		},
 		{


### PR DESCRIPTION
Closes #2911 by increasing the max allowed RAM usage for the 10k SPS load test. The other limits seem to still be within boundaries.