### PR TITLE
Run make gotidy for check-contrib

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -358,6 +358,7 @@ genpdata:
 check-contrib:
 	@echo Setting contrib at $(CONTRIB_PATH) to use this core checkout
 	make -C $(CONTRIB_PATH) for-all CMD="go mod edit -replace go.opentelemetry.io/collector=$(CURDIR)"
+	make -C $(CONTRIB_PATH) gotidy
 	make -C $(CONTRIB_PATH) test
 	@echo Restoring contrib to no longer use this core checkout
 	make -C $(CONTRIB_PATH) for-all CMD="go mod edit -dropreplace go.opentelemetry.io/collector"


### PR DESCRIPTION
**Description:**
If there are core dependency changes that affect the contrib go module state the `check-contrib` make target will fail.  These changes run `make gotidy` in the contrib project before running the tests (per https://github.com/open-telemetry/opentelemetry-collector/pull/3337/files#r647145882)