### PR TITLE
Remove usages of InternalRep when possible in pdata tests

### DIFF
--- a/consumer/pdata/logs_test.go
+++ b/consumer/pdata/logs_test.go
@@ -48,17 +48,17 @@ func TestLogRecordCount(t *testing.T) {
 
 func TestLogRecordCountWithEmpty(t *testing.T) {
 	assert.Zero(t, NewLogs().LogRecordCount())
-	assert.Zero(t, LogsFromInternalRep(internal.LogsFromOtlp(&otlpcollectorlog.ExportLogsServiceRequest{
+	assert.Zero(t, Logs{orig: &otlpcollectorlog.ExportLogsServiceRequest{
 		ResourceLogs: []*otlplogs.ResourceLogs{{}},
-	})).LogRecordCount())
-	assert.Zero(t, LogsFromInternalRep(internal.LogsFromOtlp(&otlpcollectorlog.ExportLogsServiceRequest{
+	}}.LogRecordCount())
+	assert.Zero(t, Logs{orig: &otlpcollectorlog.ExportLogsServiceRequest{
 		ResourceLogs: []*otlplogs.ResourceLogs{
 			{
 				InstrumentationLibraryLogs: []*otlplogs.InstrumentationLibraryLogs{{}},
 			},
 		},
-	})).LogRecordCount())
-	assert.Equal(t, 1, LogsFromInternalRep(internal.LogsFromOtlp(&otlpcollectorlog.ExportLogsServiceRequest{
+	}}.LogRecordCount())
+	assert.Equal(t, 1, Logs{orig: &otlpcollectorlog.ExportLogsServiceRequest{
 		ResourceLogs: []*otlplogs.ResourceLogs{
 			{
 				InstrumentationLibraryLogs: []*otlplogs.InstrumentationLibraryLogs{
@@ -68,7 +68,7 @@ func TestLogRecordCountWithEmpty(t *testing.T) {
 				},
 			},
 		},
-	})).LogRecordCount())
+	}}.LogRecordCount())
 }
 
 func TestToFromLogProto(t *testing.T) {

--- a/consumer/pdata/traces_test.go
+++ b/consumer/pdata/traces_test.go
@@ -49,14 +49,14 @@ func TestSpanCount(t *testing.T) {
 	assert.EqualValues(t, 6, md.SpanCount())
 }
 
-func TestSize(t *testing.T) {
+func TestTracesSize(t *testing.T) {
+	assert.Equal(t, 0, NewTraces().OtlpProtoSize())
 	td := NewTraces()
-	assert.Equal(t, 0, td.OtlpProtoSize())
 	rms := td.ResourceSpans()
 	rms.AppendEmpty().InstrumentationLibrarySpans().AppendEmpty().Spans().AppendEmpty().SetName("foo")
-	otlp := internal.TracesToOtlp(td.InternalRep())
-	size := otlp.Size()
-	bytes, err := otlp.Marshal()
+	orig := td.orig
+	size := orig.Size()
+	bytes, err := orig.Marshal()
 	require.NoError(t, err)
 	assert.Equal(t, size, td.OtlpProtoSize())
 	assert.Equal(t, len(bytes), td.OtlpProtoSize())


### PR DESCRIPTION
Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
