### PR TITLE
Disallow renaming metrics using the prometheus receiver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Updated configgrpc `ToDialOptions` and confighttp `ToClient` apis to take extensions configuration map (#3340)
 - Remove `GenerateSequentialTraceID` and `GenerateSequentialSpanIDin` functions in testbed (#3390)
 - Change "grpc" to "GRPC" in configauth function/type names (#3285)
+- Disallow renaming metrics using metric relabel configs (#3410)
 
 ## 💡 Enhancements 💡
 

--- a/receiver/prometheusreceiver/config.go
+++ b/receiver/prometheusreceiver/config.go
@@ -51,8 +51,17 @@ var _ config.CustomUnmarshable = (*Config)(nil)
 
 // Validate checks the receiver configuration is valid
 func (cfg *Config) Validate() error {
-	if cfg.PrometheusConfig != nil && len(cfg.PrometheusConfig.ScrapeConfigs) == 0 {
-		return errNilScrapeConfig
+	if cfg.PrometheusConfig != nil {
+		if len(cfg.PrometheusConfig.ScrapeConfigs) == 0 {
+			return errNilScrapeConfig
+		}
+		for _, sc := range cfg.PrometheusConfig.ScrapeConfigs {
+			for _, rc := range sc.MetricRelabelConfigs {
+				if rc.TargetLabel == "__name__" {
+					return fmt.Errorf("error validating scrapeconfig for job %v: %w", sc.JobName, errRenamingDisallowed)
+				}
+			}
+		}
 	}
 	return nil
 }

--- a/receiver/prometheusreceiver/config.go
+++ b/receiver/prometheusreceiver/config.go
@@ -58,6 +58,7 @@ func (cfg *Config) Validate() error {
 		for _, sc := range cfg.PrometheusConfig.ScrapeConfigs {
 			for _, rc := range sc.MetricRelabelConfigs {
 				if rc.TargetLabel == "__name__" {
+					// TODO(#2297): Remove validation after renaming is fixed
 					return fmt.Errorf("error validating scrapeconfig for job %v: %w", sc.JobName, errRenamingDisallowed)
 				}
 			}

--- a/receiver/prometheusreceiver/config_test.go
+++ b/receiver/prometheusreceiver/config_test.go
@@ -125,3 +125,15 @@ func TestLoadConfigFailsOnUnknownPrometheusSection(t *testing.T) {
 	assert.Error(t, err)
 	assert.Nil(t, cfg)
 }
+
+// Renaming is not allowed
+func TestLoadConfigFailsOnRenameDisallowed(t *testing.T) {
+	factories, err := componenttest.NopFactories()
+	assert.NoError(t, err)
+
+	factory := NewFactory()
+	factories.Receivers[typeStr] = factory
+	cfg, err := configtest.LoadConfigAndValidate(path.Join(".", "testdata", "invalid-config-prometheus-relabel.yaml"), factories)
+	assert.Error(t, err)
+	assert.NotNil(t, cfg)
+}

--- a/receiver/prometheusreceiver/factory.go
+++ b/receiver/prometheusreceiver/factory.go
@@ -33,7 +33,8 @@ const (
 )
 
 var (
-	errNilScrapeConfig = errors.New("expecting a non-nil ScrapeConfig")
+	errNilScrapeConfig    = errors.New("expecting a non-nil ScrapeConfig")
+	errRenamingDisallowed = errors.New("metric renaming using metric_relabel_configs is disallowed")
 )
 
 // NewFactory creates a new Prometheus receiver factory.

--- a/receiver/prometheusreceiver/testdata/invalid-config-prometheus-relabel.yaml
+++ b/receiver/prometheusreceiver/testdata/invalid-config-prometheus-relabel.yaml
@@ -1,0 +1,22 @@
+receivers:
+  prometheus:
+    config:
+      scrape_configs:
+      - job_name: rename
+        metric_relabel_configs:
+          - source_labels: [__name__]
+            regex: "foo_(.*)"
+            target_label: __name__
+
+processors:
+  nop:
+
+exporters:
+  nop:
+
+service:
+  pipelines:
+    traces:
+      receivers: [prometheus]
+      processors: [nop]
+      exporters: [nop]


### PR DESCRIPTION
**Description:**

Don't allow changing the metric name using prometheus metric_relabel_configs.  This doesn't currently work (https://github.com/open-telemetry/opentelemetry-collector/issues/2297), and can't easily be made to work (https://github.com/prometheus/prometheus/issues/8893).  Until we can make it work correctly, we should fail loudly.

**Link to tracking Issue:**
Issue: https://github.com/open-telemetry/opentelemetry-collector/issues/2297

**Testing:**

Unit tests added

