### PR TITLE
Adjust default retry settings for the PRW Exporter

### DIFF
--- a/exporter/prometheusremotewriteexporter/factory.go
+++ b/exporter/prometheusremotewriteexporter/factory.go
@@ -17,6 +17,7 @@ package prometheusremotewriteexporter
 import (
 	"context"
 	"errors"
+	"time"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config"
@@ -79,7 +80,12 @@ func createDefaultConfig() config.Exporter {
 		Namespace:        "",
 		ExternalLabels:   map[string]string{},
 		TimeoutSettings:  exporterhelper.DefaultTimeoutSettings(),
-		RetrySettings:    exporterhelper.DefaultRetrySettings(),
+		RetrySettings: exporterhelper.RetrySettings{
+			Enabled:         true,
+			InitialInterval: 50 * time.Millisecond,
+			MaxInterval:     200 * time.Millisecond,
+			MaxElapsedTime:  1 * time.Minute,
+		},
 		HTTPClientSettings: confighttp.HTTPClientSettings{
 			Endpoint: "http://some.url:9411/api/prom/push",
 			// We almost read 0 bytes, so no need to tune ReadBufferSize.


### PR DESCRIPTION
The default retry settings are far off from the Prometheus
Server's behavior. Retry more aggressively to avoid excessive
in-memory buffering.

Fixes open-telemetry/wg-prometheus#54 because the test
times out before the retry is sent.
