### PR TITLE
Use cmd's context instead of background

### DIFF
--- a/service/application.go
+++ b/service/application.go
@@ -100,7 +100,7 @@ func New(set AppSettings) (*Application, error) {
 				return fmt.Errorf("failed to get logger: %w", err)
 			}
 
-			return app.execute(context.Background())
+			return app.execute(cmd.Context())
 		},
 	}
 


### PR DESCRIPTION
**Description:** Uses the cmd's context rather than background. By default, `cobra.Command` will use `context.Background()` if the context is unset, but propagating the context can be useful for people using the app's command directly and calling `ExecuteContext`.

The collector uses `Execute`, which does not set a context in the cmd, so there is no change in the application's behaviour.
