### PR TITLE
Remove InternalRep wrapper, return directly the proto

### DIFF
--- a/consumer/pdata/logs.go
+++ b/consumer/pdata/logs.go
@@ -15,7 +15,6 @@
 package pdata
 
 import (
-	"go.opentelemetry.io/collector/internal"
 	otlpcollectorlog "go.opentelemetry.io/collector/internal/data/protogen/collector/logs/v1"
 	otlplogs "go.opentelemetry.io/collector/internal/data/protogen/logs/v1"
 )
@@ -40,8 +39,8 @@ func NewLogs() Logs {
 // LogsFromInternalRep creates the internal Logs representation from the ProtoBuf. Should
 // not be used outside this module. This is intended to be used only by OTLP exporter and
 // File exporter, which legitimately need to work with OTLP Protobuf structs.
-func LogsFromInternalRep(logs internal.LogsWrapper) Logs {
-	return Logs{orig: internal.LogsToOtlp(logs)}
+func LogsFromInternalRep(internalRep interface{}) Logs {
+	return Logs{orig: internalRep.(*otlpcollectorlog.ExportLogsServiceRequest)}
 }
 
 // LogsFromOtlpProtoBytes converts OTLP Collector ExportLogsServiceRequest
@@ -59,8 +58,8 @@ func LogsFromOtlpProtoBytes(data []byte) (Logs, error) {
 // InternalRep returns internal representation of the logs. Should not be used outside
 // this module. This is intended to be used only by OTLP exporter and File exporter,
 // which legitimately need to work with OTLP Protobuf structs.
-func (ld Logs) InternalRep() internal.LogsWrapper {
-	return internal.LogsFromOtlp(ld.orig)
+func (ld Logs) InternalRep() interface{} {
+	return ld.orig
 }
 
 // ToOtlpProtoBytes converts this Logs to the OTLP Collector ExportLogsServiceRequest

--- a/consumer/pdata/logs_test.go
+++ b/consumer/pdata/logs_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"go.opentelemetry.io/collector/internal"
 	otlpcollectorlog "go.opentelemetry.io/collector/internal/data/protogen/collector/logs/v1"
 	otlplogs "go.opentelemetry.io/collector/internal/data/protogen/logs/v1"
 )
@@ -71,11 +70,11 @@ func TestLogRecordCountWithEmpty(t *testing.T) {
 	}}.LogRecordCount())
 }
 
-func TestToFromLogProto(t *testing.T) {
-	wrapper := internal.LogsFromOtlp(&otlpcollectorlog.ExportLogsServiceRequest{})
-	ld := LogsFromInternalRep(wrapper)
+func TestLogsToFromInternalRep(t *testing.T) {
+	rep := &otlpcollectorlog.ExportLogsServiceRequest{}
+	ld := LogsFromInternalRep(rep)
 	assert.EqualValues(t, NewLogs(), ld)
-	assert.EqualValues(t, &otlpcollectorlog.ExportLogsServiceRequest{}, ld.orig)
+	assert.Same(t, rep, ld.orig)
 }
 
 func TestLogsToFromOtlpProtoBytes(t *testing.T) {

--- a/consumer/pdata/metrics.go
+++ b/consumer/pdata/metrics.go
@@ -15,7 +15,6 @@
 package pdata
 
 import (
-	"go.opentelemetry.io/collector/internal"
 	otlpcollectormetrics "go.opentelemetry.io/collector/internal/data/protogen/collector/metrics/v1"
 	otlpmetrics "go.opentelemetry.io/collector/internal/data/protogen/metrics/v1"
 )
@@ -54,8 +53,8 @@ func NewMetrics() Metrics {
 
 // MetricsFromInternalRep creates Metrics from the internal representation.
 // Should not be used outside this module.
-func MetricsFromInternalRep(wrapper internal.MetricsWrapper) Metrics {
-	return Metrics{orig: internal.MetricsToOtlp(wrapper)}
+func MetricsFromInternalRep(internalRep interface{}) Metrics {
+	return Metrics{orig: internalRep.(*otlpcollectormetrics.ExportMetricsServiceRequest)}
 }
 
 // MetricsFromOtlpProtoBytes converts the OTLP Collector ExportMetricsServiceRequest
@@ -72,8 +71,8 @@ func MetricsFromOtlpProtoBytes(data []byte) (Metrics, error) {
 
 // InternalRep returns internal representation of the Metrics.
 // Should not be used outside this module.
-func (md Metrics) InternalRep() internal.MetricsWrapper {
-	return internal.MetricsFromOtlp(md.orig)
+func (md Metrics) InternalRep() interface{} {
+	return md.orig
 }
 
 // ToOtlpProtoBytes converts this Metrics to the OTLP Collector ExportMetricsServiceRequest

--- a/consumer/pdata/traces.go
+++ b/consumer/pdata/traces.go
@@ -34,8 +34,8 @@ func NewTraces() Traces {
 
 // TracesFromInternalRep creates Traces from the internal representation.
 // Should not be used outside this module.
-func TracesFromInternalRep(wrapper internal.TracesWrapper) Traces {
-	return Traces{orig: internal.TracesToOtlp(wrapper)}
+func TracesFromInternalRep(internalRep interface{}) Traces {
+	return Traces{orig: internalRep.(*otlpcollectortrace.ExportTraceServiceRequest)}
 }
 
 // TracesFromOtlpProtoBytes converts OTLP Collector ExportTraceServiceRequest
@@ -53,8 +53,8 @@ func TracesFromOtlpProtoBytes(data []byte) (Traces, error) {
 
 // InternalRep returns internal representation of the Traces.
 // Should not be used outside this module.
-func (td Traces) InternalRep() internal.TracesWrapper {
-	return internal.TracesFromOtlp(td.orig)
+func (td Traces) InternalRep() interface{} {
+	return td.orig
 }
 
 // ToOtlpProtoBytes converts this Traces to the OTLP Collector ExportTraceServiceRequest

--- a/consumer/pdata/traces_test.go
+++ b/consumer/pdata/traces_test.go
@@ -23,7 +23,6 @@ import (
 	goproto "google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/emptypb"
 
-	"go.opentelemetry.io/collector/internal"
 	otlpcollectortrace "go.opentelemetry.io/collector/internal/data/protogen/collector/trace/v1"
 	otlptrace "go.opentelemetry.io/collector/internal/data/protogen/trace/v1"
 )
@@ -119,13 +118,11 @@ func TestSpanStatusCode(t *testing.T) {
 	assert.EqualValues(t, otlptrace.Status_DEPRECATED_STATUS_CODE_UNKNOWN_ERROR, status.orig.DeprecatedCode)
 }
 
-func TestToFromOtlp(t *testing.T) {
-	otlp := &otlpcollectortrace.ExportTraceServiceRequest{}
-	td := TracesFromInternalRep(internal.TracesFromOtlp(otlp))
-	assert.EqualValues(t, NewTraces(), td)
-	assert.EqualValues(t, otlp, internal.TracesToOtlp(td.InternalRep()))
-	// More tests in ./tracedata/traces_test.go. Cannot have them here because of
-	// circular dependency.
+func TestTracesToFromInternalRep(t *testing.T) {
+	rep := &otlpcollectortrace.ExportTraceServiceRequest{}
+	td := TracesFromInternalRep(rep)
+	assert.Same(t, rep, td.orig)
+	assert.Same(t, rep, td.InternalRep())
 }
 
 func TestResourceSpansWireCompatibility(t *testing.T) {

--- a/consumer/simple/metrics_test.go
+++ b/consumer/simple/metrics_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/collector/consumer/pdata"
-	"go.opentelemetry.io/collector/internal"
+	otlpcollectormetrics "go.opentelemetry.io/collector/internal/data/protogen/collector/metrics/v1"
 	"go.opentelemetry.io/collector/testutil/metricstestutil"
 )
 
@@ -284,7 +284,7 @@ func TestMetrics(t *testing.T) {
 	mCount, dpCount := metrics.MetricAndDataPointCount()
 	require.Equal(t, 7, mCount)
 	require.Equal(t, 8, dpCount)
-	req := internal.MetricsToOtlp(metricstestutil.SortedMetrics(metrics).InternalRep())
+	req := metricstestutil.SortedMetrics(metrics).InternalRep().(*otlpcollectormetrics.ExportMetricsServiceRequest)
 	asJSON, _ := json.MarshalIndent(req.ResourceMetrics, "", "  ")
 	require.Equal(t, expected, string(asJSON))
 }

--- a/internal/otlp/from_translator.go
+++ b/internal/otlp/from_translator.go
@@ -16,7 +16,6 @@ package otlp
 
 import (
 	"go.opentelemetry.io/collector/consumer/pdata"
-	"go.opentelemetry.io/collector/internal"
 )
 
 type fromTranslator struct{}
@@ -26,13 +25,13 @@ func newFromTranslator() *fromTranslator {
 }
 
 func (d *fromTranslator) FromLogs(ld pdata.Logs) (interface{}, error) {
-	return internal.LogsToOtlp(ld.InternalRep()), nil
+	return ld.InternalRep(), nil
 }
 
 func (d *fromTranslator) FromMetrics(md pdata.Metrics) (interface{}, error) {
-	return internal.MetricsToOtlp(md.InternalRep()), nil
+	return md.InternalRep(), nil
 }
 
 func (d *fromTranslator) FromTraces(td pdata.Traces) (interface{}, error) {
-	return internal.TracesToOtlp(td.InternalRep()), nil
+	return td.InternalRep(), nil
 }

--- a/internal/otlp/to_translator.go
+++ b/internal/otlp/to_translator.go
@@ -16,7 +16,6 @@ package otlp
 
 import (
 	"go.opentelemetry.io/collector/consumer/pdata"
-	"go.opentelemetry.io/collector/internal"
 	otlpcollectorlogs "go.opentelemetry.io/collector/internal/data/protogen/collector/logs/v1"
 	otlpcollectormetrics "go.opentelemetry.io/collector/internal/data/protogen/collector/metrics/v1"
 	otlpcollectortrace "go.opentelemetry.io/collector/internal/data/protogen/collector/trace/v1"
@@ -34,7 +33,7 @@ func (d *toTranslator) ToLogs(modelData interface{}) (pdata.Logs, error) {
 	if !ok {
 		return pdata.Logs{}, model.NewErrIncompatibleType(&otlpcollectorlogs.ExportLogsServiceRequest{}, modelData)
 	}
-	return pdata.LogsFromInternalRep(internal.LogsFromOtlp(ld)), nil
+	return pdata.LogsFromInternalRep(ld), nil
 }
 
 func (d *toTranslator) ToMetrics(modelData interface{}) (pdata.Metrics, error) {
@@ -42,7 +41,7 @@ func (d *toTranslator) ToMetrics(modelData interface{}) (pdata.Metrics, error) {
 	if !ok {
 		return pdata.Metrics{}, model.NewErrIncompatibleType(&otlpcollectormetrics.ExportMetricsServiceRequest{}, modelData)
 	}
-	return pdata.MetricsFromInternalRep(internal.MetricsFromOtlp(ld)), nil
+	return pdata.MetricsFromInternalRep(ld), nil
 }
 
 func (d *toTranslator) ToTraces(modelData interface{}) (pdata.Traces, error) {
@@ -50,5 +49,5 @@ func (d *toTranslator) ToTraces(modelData interface{}) (pdata.Traces, error) {
 	if !ok {
 		return pdata.Traces{}, model.NewErrIncompatibleType(&otlpcollectortrace.ExportTraceServiceRequest{}, modelData)
 	}
-	return pdata.TracesFromInternalRep(internal.TracesFromOtlp(td)), nil
+	return pdata.TracesFromInternalRep(td), nil
 }

--- a/internal/otlp_wrapper.go
+++ b/internal/otlp_wrapper.go
@@ -15,45 +15,9 @@
 package internal
 
 import (
-	otlpcollectorlog "go.opentelemetry.io/collector/internal/data/protogen/collector/logs/v1"
-	otlpcollectormetrics "go.opentelemetry.io/collector/internal/data/protogen/collector/metrics/v1"
 	otlpcollectortrace "go.opentelemetry.io/collector/internal/data/protogen/collector/trace/v1"
 	otlptrace "go.opentelemetry.io/collector/internal/data/protogen/trace/v1"
 )
-
-// MetricsWrapper is an intermediary struct that is declared in an internal package
-// as a way to prevent certain functions of pdata.Metrics data type to be callable by
-// any code outside of this module.
-type MetricsWrapper struct {
-	req *otlpcollectormetrics.ExportMetricsServiceRequest
-}
-
-// MetricsToOtlp internal helper to convert MetricsWrapper to protobuf representation.
-func MetricsToOtlp(mw MetricsWrapper) *otlpcollectormetrics.ExportMetricsServiceRequest {
-	return mw.req
-}
-
-// MetricsFromOtlp internal helper to convert protobuf representation to MetricsWrapper.
-func MetricsFromOtlp(req *otlpcollectormetrics.ExportMetricsServiceRequest) MetricsWrapper {
-	return MetricsWrapper{req: req}
-}
-
-// TracesWrapper is an intermediary struct that is declared in an internal package
-// as a way to prevent certain functions of pdata.Traces data type to be callable by
-// any code outside of this module.
-type TracesWrapper struct {
-	req *otlpcollectortrace.ExportTraceServiceRequest
-}
-
-// TracesToOtlp internal helper to convert TracesWrapper to protobuf representation.
-func TracesToOtlp(mw TracesWrapper) *otlpcollectortrace.ExportTraceServiceRequest {
-	return mw.req
-}
-
-// TracesFromOtlp internal helper to convert protobuf representation to TracesWrapper.
-func TracesFromOtlp(req *otlpcollectortrace.ExportTraceServiceRequest) TracesWrapper {
-	return TracesWrapper{req: req}
-}
 
 // TracesCompatibilityChanges performs backward compatibility conversion of Span Status code according to
 // OTLP specification as we are a new receiver and sender (we are pushing data to the pipelines):
@@ -77,21 +41,4 @@ func TracesCompatibilityChanges(req *otlpcollectortrace.ExportTraceServiceReques
 			}
 		}
 	}
-}
-
-// LogsWrapper is an intermediary struct that is declared in an internal package
-// as a way to prevent certain functions of pdata.Logs data type to be callable by
-// any code outside of this module.
-type LogsWrapper struct {
-	req *otlpcollectorlog.ExportLogsServiceRequest
-}
-
-// LogsToOtlp internal helper to convert LogsWrapper to protobuf representation.
-func LogsToOtlp(l LogsWrapper) *otlpcollectorlog.ExportLogsServiceRequest {
-	return l.req
-}
-
-// LogsFromOtlp internal helper to convert protobuf representation to LogsWrapper.
-func LogsFromOtlp(req *otlpcollectorlog.ExportLogsServiceRequest) LogsWrapper {
-	return LogsWrapper{req: req}
 }

--- a/internal/pdatagrpc/logs.go
+++ b/internal/pdatagrpc/logs.go
@@ -20,7 +20,6 @@ import (
 	"google.golang.org/grpc"
 
 	"go.opentelemetry.io/collector/consumer/pdata"
-	"go.opentelemetry.io/collector/internal"
 	otlpcollectorlogs "go.opentelemetry.io/collector/internal/data/protogen/collector/logs/v1"
 )
 
@@ -57,7 +56,7 @@ func NewLogsClient(cc *grpc.ClientConn) LogsClient {
 }
 
 func (c *logsClient) Export(ctx context.Context, in pdata.Logs, opts ...grpc.CallOption) (LogsResponse, error) {
-	rsp, err := c.rawClient.Export(ctx, internal.LogsToOtlp(in.InternalRep()), opts...)
+	rsp, err := c.rawClient.Export(ctx, in.InternalRep().(*otlpcollectorlogs.ExportLogsServiceRequest), opts...)
 	return LogsResponse{orig: rsp}, err
 }
 
@@ -80,6 +79,6 @@ type rawLogsServer struct {
 }
 
 func (s rawLogsServer) Export(ctx context.Context, request *otlpcollectorlogs.ExportLogsServiceRequest) (*otlpcollectorlogs.ExportLogsServiceResponse, error) {
-	rsp, err := s.srv.Export(ctx, pdata.LogsFromInternalRep(internal.LogsFromOtlp(request)))
+	rsp, err := s.srv.Export(ctx, pdata.LogsFromInternalRep(request))
 	return rsp.orig, err
 }

--- a/internal/pdatagrpc/metrics.go
+++ b/internal/pdatagrpc/metrics.go
@@ -20,7 +20,6 @@ import (
 	"google.golang.org/grpc"
 
 	"go.opentelemetry.io/collector/consumer/pdata"
-	"go.opentelemetry.io/collector/internal"
 	otlpcollectormetrics "go.opentelemetry.io/collector/internal/data/protogen/collector/metrics/v1"
 )
 
@@ -57,7 +56,7 @@ func NewMetricsClient(cc *grpc.ClientConn) MetricsClient {
 }
 
 func (c *metricsClient) Export(ctx context.Context, in pdata.Metrics, opts ...grpc.CallOption) (MetricsResponse, error) {
-	rsp, err := c.rawClient.Export(ctx, internal.MetricsToOtlp(in.InternalRep()), opts...)
+	rsp, err := c.rawClient.Export(ctx, in.InternalRep().(*otlpcollectormetrics.ExportMetricsServiceRequest), opts...)
 	return MetricsResponse{orig: rsp}, err
 }
 
@@ -80,6 +79,6 @@ type rawMetricsServer struct {
 }
 
 func (s rawMetricsServer) Export(ctx context.Context, request *otlpcollectormetrics.ExportMetricsServiceRequest) (*otlpcollectormetrics.ExportMetricsServiceResponse, error) {
-	rsp, err := s.srv.Export(ctx, pdata.MetricsFromInternalRep(internal.MetricsFromOtlp(request)))
+	rsp, err := s.srv.Export(ctx, pdata.MetricsFromInternalRep(request))
 	return rsp.orig, err
 }

--- a/internal/pdatagrpc/traces.go
+++ b/internal/pdatagrpc/traces.go
@@ -58,7 +58,7 @@ func NewTracesClient(cc *grpc.ClientConn) TracesClient {
 
 // Export implements the TracesClient interface.
 func (c *tracesClient) Export(ctx context.Context, in pdata.Traces, opts ...grpc.CallOption) (TracesResponse, error) {
-	rsp, err := c.rawClient.Export(ctx, internal.TracesToOtlp(in.InternalRep()), opts...)
+	rsp, err := c.rawClient.Export(ctx, in.InternalRep().(*otlpcollectortraces.ExportTraceServiceRequest), opts...)
 	return TracesResponse{orig: rsp}, err
 }
 
@@ -82,6 +82,6 @@ type rawTracesServer struct {
 
 func (s rawTracesServer) Export(ctx context.Context, request *otlpcollectortraces.ExportTraceServiceRequest) (*otlpcollectortraces.ExportTraceServiceResponse, error) {
 	internal.TracesCompatibilityChanges(request)
-	rsp, err := s.srv.Export(ctx, pdata.TracesFromInternalRep(internal.TracesFromOtlp(request)))
+	rsp, err := s.srv.Export(ctx, pdata.TracesFromInternalRep(request))
 	return rsp.orig, err
 }


### PR DESCRIPTION
This change is a no-op since users cannot convert the returned interface to the proto representation since no access to them.

This removes an extra redirection, with no behavior change.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
