### PR TITLE
Copy contrib's storage interface to core

### DIFF
--- a/extension/storage/Makefile
+++ b/extension/storage/Makefile
@@ -1,0 +1,1 @@
+include ../../Makefile.Common

--- a/extension/storage/README.md
+++ b/extension/storage/README.md
@@ -1,0 +1,21 @@
+# Storage
+
+**Status: under development; This is currently just the interface**
+
+A storage extension persists state beyond the collector process. Other components can request a storage client from the storage extension and use it to manage state. 
+
+The `storage.Extension` interface extends `component.Extension` by adding the following method:
+```
+GetClient(context.Context, component.Kind, config.ComponentID, string) (Client, error)
+```
+
+The `storage.Client` interface contains the following methods:
+```
+Get(context.Context, string) ([]byte, error)
+Set(context.Context, string, []byte) error
+Delete(context.Context, string) error
+Close(context.Context) error
+```
+Note: All methods should return error only if a problem occurred. (For example, if a file is no longer accessible, or if a remote service is unavailable.)
+
+Note: It is the responsibility of each component to `Close` a storage client that it has requested.

--- a/extension/storage/README.md
+++ b/extension/storage/README.md
@@ -17,13 +17,21 @@ Delete(context.Context, string) error
 Close(context.Context) error
 ```
 
-It is possible to execute several operations in a single transaction via `BatchOp`. The method takes
-two collections as arguments:
-* list of keys for which the values are retrieved and returned,
-* a map, which specifies the key/value pairs that are going to be updated; when a value is `nil`, the key is deleted.
+It is possible to execute several operations in a single transaction via `Batch`. The method takes a collection of
+`Operation` arguments (each of which contains `Key`, `Value` and `Type` properties):
 ```
-BatchOp(context.Context, []string, map[]string[]byte) ([][]byte, error)
+Batch(context.Context, ...Operation) error
 ```
+
+The elements itself can be created using:
+
+```
+SetOperation(string, []byte) Operation
+GetOperation(string) Operation
+DeleteOperation(string) Operation
+```
+
+Get operation results are stored in-place into the given Operation and can be retrieved using its `Value` property.
 
 Note: All methods should return error only if a problem occurred. (For example, if a file is no longer accessible, or if a remote service is unavailable.)
 

--- a/extension/storage/README.md
+++ b/extension/storage/README.md
@@ -17,11 +17,12 @@ Delete(context.Context, string) error
 Close(context.Context) error
 ```
 
-As well as their batch counterparts (executed in a single transaction):
+It is possible to execute several operations in a single transaction via `BatchOp`. The method takes
+two collections as arguments:
+* list of keys for which the values are retrieved and returned,
+* a map, which specifies the key/value pairs that are going to be updated; when a value is `nil`, the key is deleted.
 ```
-GetBatch(context.Context, []string) ([][]byte, error)
-SetBatch(context.Context, map[string][]byte) error
-DeleteBatch(context.Context, []string) error
+BatchOp(context.Context, []string, map[]string[]byte) ([][]byte, error)
 ```
 
 Note: All methods should return error only if a problem occurred. (For example, if a file is no longer accessible, or if a remote service is unavailable.)

--- a/extension/storage/README.md
+++ b/extension/storage/README.md
@@ -16,6 +16,14 @@ Set(context.Context, string, []byte) error
 Delete(context.Context, string) error
 Close(context.Context) error
 ```
+
+As well as their batch counterparts (executed in a single transaction):
+```
+GetBatch(context.Context, []string) ([][]byte, error)
+SetBatch(context.Context, map[string][]byte) error
+DeleteBatch(context.Context, []string) error
+```
+
 Note: All methods should return error only if a problem occurred. (For example, if a file is no longer accessible, or if a remote service is unavailable.)
 
 Note: It is the responsibility of each component to `Close` a storage client that it has requested.

--- a/extension/storage/doc.go
+++ b/extension/storage/doc.go
@@ -1,0 +1,17 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package stanzareceiver implements a receiver that can be used by the
+// Opentelemetry collector to receive logs using the stanza log agent
+package storage

--- a/extension/storage/nop_client.go
+++ b/extension/storage/nop_client.go
@@ -46,6 +46,6 @@ func (c nopClient) Close(context.Context) error {
 }
 
 // Batch does nothing, and returns nil, nil
-func (c nopClient) Batch(ctx context.Context, strings []string, entries map[string][]byte) ([][]byte, error) {
-	return nil, nil // no result, but no problem
+func (c nopClient) Batch(context.Context, ...Operation) error {
+	return nil // no result, but no problem
 }

--- a/extension/storage/nop_client.go
+++ b/extension/storage/nop_client.go
@@ -1,0 +1,46 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import "context"
+
+type nopClient struct{}
+
+var nopClientInstance Client = &nopClient{}
+
+// NewNopClient returns a nop client
+func NewNopClient() Client {
+	return nopClientInstance
+}
+
+// Get does nothing, and returns nil, nil
+func (c nopClient) Get(context.Context, string) ([]byte, error) {
+	return nil, nil // no result, but no problem
+}
+
+// Set does nothing and returns nil
+func (c nopClient) Set(context.Context, string, []byte) error {
+	return nil // no problem
+}
+
+// Delete does nothing and returns nil
+func (c nopClient) Delete(context.Context, string) error {
+	return nil // no problem
+}
+
+// Close does nothing and returns nil
+func (c nopClient) Close(context.Context) error {
+	return nil
+}

--- a/extension/storage/nop_client.go
+++ b/extension/storage/nop_client.go
@@ -44,3 +44,18 @@ func (c nopClient) Delete(context.Context, string) error {
 func (c nopClient) Close(context.Context) error {
 	return nil
 }
+
+// GetBatch does nothing, and returns nil, nil
+func (c nopClient) GetBatch(ctx context.Context, strings []string) ([][]byte, error) {
+	return nil, nil // no result, but no problem
+}
+
+// SetBatch does nothing and returns nil
+func (c nopClient) SetBatch(ctx context.Context, entries map[string][]byte) error {
+	return nil // no problem
+}
+
+// DeleteBatch does nothing and returns nil
+func (c nopClient) DeleteBatch(ctx context.Context, strings []string) error {
+	return nil // no problem
+}

--- a/extension/storage/nop_client.go
+++ b/extension/storage/nop_client.go
@@ -45,17 +45,7 @@ func (c nopClient) Close(context.Context) error {
 	return nil
 }
 
-// GetBatch does nothing, and returns nil, nil
-func (c nopClient) GetBatch(ctx context.Context, strings []string) ([][]byte, error) {
+// Batch does nothing, and returns nil, nil
+func (c nopClient) Batch(ctx context.Context, strings []string, entries map[string][]byte) ([][]byte, error) {
 	return nil, nil // no result, but no problem
-}
-
-// SetBatch does nothing and returns nil
-func (c nopClient) SetBatch(ctx context.Context, entries map[string][]byte) error {
-	return nil // no problem
-}
-
-// DeleteBatch does nothing and returns nil
-func (c nopClient) DeleteBatch(ctx context.Context, strings []string) error {
-	return nil // no problem
 }

--- a/extension/storage/storage.go
+++ b/extension/storage/storage.go
@@ -33,9 +33,11 @@ type Extension interface {
 // Client is the interface that storage clients must implement
 // All methods should return error only if a problem occurred.
 // This mirrors the behavior of a golang map:
-//   - Set and SetBatch don't error if a key already exists - they just overwrite the value.
-//   - Get and GetBatch don't error if a key is not found - they just returns nil.
-//   - Delete and DeleteBatch don't error if the key doesn't exist - they just no-ops.
+//   - Set doesn't error if a key already exists - it just overwrites the value.
+//   - Get doesn't error if a key is not found - it just returns nil.
+//   - Delete doesn't error if the key doesn't exist - it just no-ops.
+// Similarly:
+//   - Batch doesn't error if any of the above happens for either retrieved or updated keys
 // This also provides a way to differentiate data operations
 //   [overwrite | not-found | no-op] from "real" problems
 type Client interface {
@@ -51,17 +53,10 @@ type Client interface {
 	// Delete will delete data associated with the specified key
 	Delete(context.Context, string) error
 
-	// GetBatch will retrieve data from storage that corresponds to the
-	// collection of keys. It will return an array of results, where each
+	// Batch will, respectively - get values for selected keys or upsert key/values. When the value specified
+	// is nil, the key is being deleted. It will return an array of results, where each
 	// one corresponds to a key at a given position and will be nil, if key is not found
-	GetBatch(context.Context, []string) ([][]byte, error)
-
-	// SetBatch will store data provided in the map.
-	// When a value for a given key is nil, the entry will be deleted
-	SetBatch(context.Context, map[string][]byte) error
-
-	// DeleteBatch will delete data associated with specified collection of keys
-	DeleteBatch(context.Context, []string) error
+	Batch(context.Context, []string, map[string][]byte) ([][]byte, error)
 
 	// Close will release any resources held by the client
 	Close(context.Context) error

--- a/extension/storage/storage.go
+++ b/extension/storage/storage.go
@@ -60,8 +60,10 @@ type Client interface {
 	Close(context.Context) error
 }
 
+type opType int
+
 const (
-	Get = iota
+	Get opType = iota
 	Set
 	Delete
 )
@@ -72,7 +74,7 @@ type operation struct {
 	// Value specifies value that is going to be set or holds result of get operation
 	Value []byte
 	// Type describes the operation type
-	Type int
+	Type opType
 }
 
 type Operation *operation

--- a/extension/storage/storage.go
+++ b/extension/storage/storage.go
@@ -53,11 +53,48 @@ type Client interface {
 	// Delete will delete data associated with the specified key
 	Delete(context.Context, string) error
 
-	// Batch will, respectively - get values for selected keys or upsert key/values. When the value specified
-	// is nil, the key is being deleted. It will return an array of results, where each
-	// one corresponds to a key at a given position and will be nil, if key is not found
-	Batch(context.Context, []string, map[string][]byte) ([][]byte, error)
+	// Batch handles specified operations in batch. Get operation results are put in-place
+	Batch(context.Context, ...Operation) error
 
 	// Close will release any resources held by the client
 	Close(context.Context) error
+}
+
+const (
+	Get = iota
+	Set
+	Delete
+)
+
+type operation struct {
+	// Key specifies key which is going to be get/set/deleted
+	Key string
+	// Value specifies value that is going to be set or holds result of get operation
+	Value []byte
+	// Type describes the operation type
+	Type int
+}
+
+type Operation *operation
+
+func SetOperation(key string, value []byte) Operation {
+	return &operation{
+		Key:   key,
+		Value: value,
+		Type:  Set,
+	}
+}
+
+func GetOperation(key string) Operation {
+	return &operation{
+		Key:  key,
+		Type: Get,
+	}
+}
+
+func DeleteOperation(key string) Operation {
+	return &operation{
+		Key:  key,
+		Type: Delete,
+	}
 }

--- a/extension/storage/storage.go
+++ b/extension/storage/storage.go
@@ -1,0 +1,56 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"context"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config"
+)
+
+// Extension is the interface that storage extensions must implement
+type Extension interface {
+	component.Extension
+
+	// GetClient will create a client for use by the specified component.
+	// The component can use the client to manage state
+	GetClient(context.Context, component.Kind, config.ComponentID, string) (Client, error)
+}
+
+// Client is the interface that storage clients must implement
+// All methods should return error only if a problem occurred.
+// This mirrors the behavior of a golang map:
+//   - Set doesn't error if a key already exists - it just overwrites the value.
+//   - Get doesn't error if a key is not found - it just returns nil.
+//   - Delete doesn't error if the key doesn't exist - it just no-ops.
+// This also provides a way to differentiate data operations
+//   [overwrite | not-found | no-op] from "real" problems
+type Client interface {
+
+	// Get will retrieve data from storage that corresponds to the
+	// specified key. It should return nil, nil if not found
+	Get(context.Context, string) ([]byte, error)
+
+	// Set will store data. The data can be retrieved by the same
+	// component after a process restart, using the same key
+	Set(context.Context, string, []byte) error
+
+	// Delete will delete data associated with the specified key
+	Delete(context.Context, string) error
+
+	// Close will release any resources held by the client
+	Close(context.Context) error
+}

--- a/extension/storage/storage.go
+++ b/extension/storage/storage.go
@@ -33,9 +33,9 @@ type Extension interface {
 // Client is the interface that storage clients must implement
 // All methods should return error only if a problem occurred.
 // This mirrors the behavior of a golang map:
-//   - Set doesn't error if a key already exists - it just overwrites the value.
-//   - Get doesn't error if a key is not found - it just returns nil.
-//   - Delete doesn't error if the key doesn't exist - it just no-ops.
+//   - Set and SetBatch don't error if a key already exists - they just overwrite the value.
+//   - Get and GetBatch don't error if a key is not found - they just returns nil.
+//   - Delete and DeleteBatch don't error if the key doesn't exist - they just no-ops.
 // This also provides a way to differentiate data operations
 //   [overwrite | not-found | no-op] from "real" problems
 type Client interface {
@@ -50,6 +50,18 @@ type Client interface {
 
 	// Delete will delete data associated with the specified key
 	Delete(context.Context, string) error
+
+	// GetBatch will retrieve data from storage that corresponds to the
+	// collection of keys. It will return an array of results, where each
+	// one corresponds to a key at a given position and will be nil, if key is not found
+	GetBatch(context.Context, []string) ([][]byte, error)
+
+	// SetBatch will store data provided in the map.
+	// When a value for a given key is nil, the entry will be deleted
+	SetBatch(context.Context, map[string][]byte) error
+
+	// DeleteBatch will delete data associated with specified collection of keys
+	DeleteBatch(context.Context, []string) error
 
 	// Close will release any resources held by the client
 	Close(context.Context) error

--- a/extension/storage/storage.go
+++ b/extension/storage/storage.go
@@ -27,7 +27,7 @@ type Extension interface {
 
 	// GetClient will create a client for use by the specified component.
 	// The component can use the client to manage state
-	GetClient(context.Context, component.Kind, config.ComponentID, string) (Client, error)
+	GetClient(ctx context.Context, kind component.Kind, id config.ComponentID, signalName string) (Client, error)
 }
 
 // Client is the interface that storage clients must implement
@@ -44,20 +44,20 @@ type Client interface {
 
 	// Get will retrieve data from storage that corresponds to the
 	// specified key. It should return (nil, nil) if not found
-	Get(context.Context, string) ([]byte, error)
+	Get(ctx context.Context, key string) ([]byte, error)
 
 	// Set will store data. The data can be retrieved by the same
 	// component after a process restart, using the same key
-	Set(context.Context, string, []byte) error
+	Set(ctx context.Context, key string, value []byte) error
 
 	// Delete will delete data associated with the specified key
-	Delete(context.Context, string) error
+	Delete(ctx context.Context, key string) error
 
 	// Batch handles specified operations in batch. Get operation results are put in-place
-	Batch(context.Context, ...Operation) error
+	Batch(ctx context.Context, ops ...Operation) error
 
 	// Close will release any resources held by the client
-	Close(context.Context) error
+	Close(ctx context.Context) error
 }
 
 type opType int

--- a/extension/storage/storage.go
+++ b/extension/storage/storage.go
@@ -43,7 +43,7 @@ type Extension interface {
 type Client interface {
 
 	// Get will retrieve data from storage that corresponds to the
-	// specified key. It should return nil, nil if not found
+	// specified key. It should return (nil, nil) if not found
 	Get(context.Context, string) ([]byte, error)
 
 	// Set will store data. The data can be retrieved by the same

--- a/extension/storage/storage.go
+++ b/extension/storage/storage.go
@@ -26,8 +26,10 @@ type Extension interface {
 	component.Extension
 
 	// GetClient will create a client for use by the specified component.
+	// Each component can have multiple storages (e.g. one for each signal),
+	// which can be identified using storageName parameter.
 	// The component can use the client to manage state
-	GetClient(ctx context.Context, kind component.Kind, id config.ComponentID, signalName string) (Client, error)
+	GetClient(ctx context.Context, kind component.Kind, id config.ComponentID, storageName string) (Client, error)
 }
 
 // Client is the interface that storage clients must implement


### PR DESCRIPTION
**Description:** As discussed during the SIG, we want to move storage extension to core, starting with the interface (this PR) so persistent buffer implementation (https://github.com/open-telemetry/opentelemetry-collector/issues/2285) could use it

**Link to tracking Issue:** #3424 

**Testing:** Just the interface, no tests

**Documentation:** README.md with API

cc @djaglowski @tigrannajaryan 