### PR TITLE
receiver/prometheus: add .ToMetric() directly to pdata.Metric

### DIFF
--- a/receiver/prometheusreceiver/internal/otlp_metricfamily.go
+++ b/receiver/prometheusreceiver/internal/otlp_metricfamily.go
@@ -15,6 +15,7 @@
 package internal
 
 import (
+	"fmt"
 	"sort"
 	"strings"
 
@@ -23,6 +24,16 @@ import (
 
 	"go.opentelemetry.io/collector/model/pdata"
 )
+
+// MetricFamilyPdata is unit which is corresponding to the metrics items which shared the same TYPE/UNIT/... metadata from
+// a single scrape.
+type MetricFamilyPdata interface {
+	Add(metricName string, ls labels.Labels, t int64, v float64) error
+	IsSameFamily(metricName string) bool
+	ToMetricPdata() (*pdata.Metric, int, int)
+}
+
+var _ MetricFamilyPdata = (*metricFamilyPdata)(nil)
 
 type metricFamilyPdata struct {
 	// We are composing the already present metricFamily to
@@ -77,21 +88,100 @@ func newMetricFamilyPdata(metricName string, mc MetadataCache) MetricFamily {
 	}
 }
 
+func (mg *metricGroupPdata) toDistributionPoint(orderedLabelKeys []string) *pdata.HistogramDataPoint {
+	if !(mg.hasCount) || len(mg.complexValue) == 0 {
+		return nil
+	}
+
+	mg.sortPoints()
+
+	// for OCAgent Proto, the bounds won't include +inf
+	// TODO: (@odeke-em) should we also check OpenTelemetry Pdata for bucket bounds?
+	bounds := make([]float64, len(mg.complexValue)-1)
+	bucketCounts := make([]uint64, len(mg.complexValue))
+
+	for i := 0; i < len(mg.complexValue); i++ {
+		if i != len(mg.complexValue)-1 {
+			// not need to add +inf as bound to oc proto
+			bounds[i] = mg.complexValue[i].boundary
+		}
+		adjustedCount := mg.complexValue[i].value
+		if i != 0 {
+			adjustedCount -= mg.complexValue[i-1].value
+		}
+		bucketCounts[i] = uint64(adjustedCount)
+	}
+
+	point := pdata.NewHistogramDataPoint()
+	point.SetExplicitBounds(bounds)
+	point.SetCount(uint64(mg.count))
+	point.SetSum(mg.sum)
+	point.SetBucketCounts(bucketCounts)
+	point.SetStartTimestamp(pdata.Timestamp(mg.ts))
+	point.SetTimestamp(pdata.Timestamp(mg.ts))
+
+	return &point
+}
+
+func (mg *metricGroupPdata) toSummaryPoint(orderedLabelKeys []string) *pdata.SummaryDataPoint {
+	// expecting count to be provided, however, in the following two cases, they can be missed.
+	// 1. data is corrupted
+	// 2. ignored by startValue evaluation
+	if !(mg.hasCount) {
+		return nil
+	}
+
+	mg.sortPoints()
+
+	quantileValues := pdata.NewValueAtQuantileSlice()
+	for _, p := range mg.complexValue {
+		quantile := pdata.NewValueAtQuantile()
+		quantile.SetValue(p.value)
+		quantile.SetQuantile(p.boundary * 100)
+	}
+
+	point := pdata.NewSummaryDataPoint()
+	quantileValues.CopyTo(point.QuantileValues())
+
+	strMap := populateLabelValuesPdata(orderedLabelKeys, mg.ls)
+	strMap.CopyTo(point.LabelsMap())
+
+	// Based on the summary description from https://prometheus.io/docs/concepts/metric_types/#summary
+	// the quantiles are calculated over a sliding time window, however, the count is the total count of
+	// observations and the corresponding sum is a sum of all observed values, thus the sum and count used
+	// at the global level of the metricspb.SummaryValue
+	point.SetStartTimestamp(pdata.Timestamp(mg.ts))
+	point.SetTimestamp(pdata.Timestamp(mg.ts))
+	point.SetSum(mg.sum)
+	point.SetCount(uint64(mg.count))
+
+	return &point
+}
+
+func populateLabelValuesPdata(orderedKeys []string, ls labels.Labels) pdata.StringMap {
+	strMap := pdata.NewStringMap()
+	lmap := ls.Map()
+	for _, key := range orderedKeys {
+		strMap.Insert(key, lmap[key])
+	}
+	return strMap
+}
+
 // updateLabelKeys is used to store all the label keys of a same metric family in observed order. since prometheus
 // receiver removes any label with empty value before feeding it to an appender, in order to figure out all the labels
 // from the same metric family we will need to keep track of what labels have ever been observed.
 func (mf *metricFamilyPdata) updateLabelKeys(ls labels.Labels) {
 	for _, l := range ls {
-		if isUsefulLabelPdata(mf.mtype, l.Name) {
-			if _, ok := mf.labelKeys[l.Name]; !ok {
-				mf.labelKeys[l.Name] = true
-				// use insertion sort to maintain order
-				i := sort.SearchStrings(mf.labelKeysOrdered, l.Name)
-				mf.labelKeysOrdered = append(mf.labelKeysOrdered, "")
-				copy(mf.labelKeysOrdered[i+1:], mf.labelKeysOrdered[i:])
-				mf.labelKeysOrdered[i] = l.Name
-
-			}
+		if !isUsefulLabelPdata(mf.mtype, l.Name) {
+			continue
+		}
+		if _, ok := mf.labelKeys[l.Name]; !ok {
+			mf.labelKeys[l.Name] = true
+			// use insertion sort to maintain order
+			i := sort.SearchStrings(mf.labelKeysOrdered, l.Name)
+			mf.labelKeysOrdered = append(mf.labelKeysOrdered, "")
+			copy(mf.labelKeysOrdered[i+1:], mf.labelKeysOrdered[i:])
+			mf.labelKeysOrdered[i] = l.Name
 		}
 	}
 }
@@ -152,4 +242,106 @@ func (mf *metricFamilyPdata) Add(metricName string, ls labels.Labels, t int64, v
 	}
 
 	return nil
+}
+
+// getGroups to return groups in insertion order
+func (mf *metricFamilyPdata) getGroups() []*metricGroupPdata {
+	groups := make([]*metricGroupPdata, len(mf.groupOrders))
+	for k, v := range mf.groupOrders {
+		groups[v] = mf.groups[k]
+	}
+	return groups
+}
+
+func (mf *metricFamilyPdata) ToMetricPdata() (metric *pdata.Metric, nTotalTimeseries, droppedTimeseries int) {
+	numTimeseries := 0
+	switch mf.mtype {
+	// not supported currently
+	// case metricspb.MetricDescriptor_GAUGE_DISTRIBUTION:
+	//	return nil
+	case pdata.MetricDataTypeHistogram:
+		histogramDataPoints := pdata.NewHistogramDataPointSlice()
+		for _, mg := range mf.getGroups() {
+			histogramPoint := mg.toDistributionPoint(mf.labelKeysOrdered)
+			if histogramPoint != nil {
+				histogramDataPoints.Append(*histogramPoint)
+			} else {
+				mf.droppedTimeseries++
+			}
+		}
+
+		numTimeseries = histogramDataPoints.Len()
+		if numTimeseries != 0 {
+			pm := pdata.NewMetric()
+			metric = &pm
+			metric.SetDataType(mf.mtype)
+			histogram := metric.Histogram()
+			histogramDataPoints.CopyTo(histogram.DataPoints())
+		}
+
+	case pdata.MetricDataTypeSummary:
+		summaryDataPoints := pdata.NewSummaryDataPointSlice()
+		for _, mg := range mf.getGroups() {
+			summaryPoint := mg.toSummaryPoint(mf.labelKeysOrdered)
+			if summaryPoint != nil {
+				summaryDataPoints.Append(*summaryPoint)
+			} else {
+				mf.droppedTimeseries++
+			}
+		}
+
+		numTimeseries = summaryDataPoints.Len()
+		if numTimeseries != 0 {
+			pm := pdata.NewMetric()
+			metric = &pm
+			metric.SetDataType(mf.mtype)
+			summary := metric.Summary()
+			summaryDataPoints.CopyTo(summary.DataPoints())
+		}
+
+	default:
+		doubleDataPoints := pdata.NewDoubleDataPointSlice()
+		for _, mg := range mf.getGroups() {
+			doublePoint := mg.toDoublePoint(mf.labelKeysOrdered)
+			if doublePoint != nil {
+				doubleDataPoints.Append(*doublePoint)
+			} else {
+				mf.droppedTimeseries++
+			}
+		}
+
+		numTimeseries = doubleDataPoints.Len()
+		if numTimeseries != 0 {
+			pm := pdata.NewMetric()
+			metric = &pm
+			metric.SetDataType(mf.mtype)
+			panic(fmt.Sprintf("We need a specialized converter for %s", mf.mtype))
+		}
+	}
+
+	// note: the total number of timeseries is the length of timeseries plus the number of dropped timeseries.
+	if numTimeseries == 0 {
+		return nil, mf.droppedTimeseries, mf.droppedTimeseries
+	}
+
+	metric.SetName(mf.name)
+	metric.SetDescription(mf.metadata.Help)
+	metric.SetUnit(heuristicalMetricAndKnownUnits(mf.name, mf.metadata.Unit))
+	metric.SetDataType(mf.mtype)
+	return metric, numTimeseries + mf.droppedTimeseries, mf.droppedTimeseries
+}
+
+func (mg *metricGroupPdata) toDoublePoint(orderedLabelKeys []string) *pdata.DoubleDataPoint {
+	var startTs int64
+	// gauge/undefined types has no start time
+	if mg.family.isCumulativeTypePdata() {
+		startTs = mg.ts
+	}
+
+	point := pdata.NewDoubleDataPoint()
+	point.SetStartTimestamp(pdata.Timestamp(startTs))
+	point.SetTimestamp(pdata.Timestamp(mg.ts))
+	point.SetValue(mg.value)
+
+	return &point
 }

--- a/receiver/prometheusreceiver/internal/otlp_metrics_adjuster.go
+++ b/receiver/prometheusreceiver/internal/otlp_metrics_adjuster.go
@@ -1,0 +1,305 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+/*
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"go.opentelemetry.io/collector/consumer/pdata"
+	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
+	"go.uber.org/zap"
+)
+
+// Notes on garbage collection (gc):
+//
+// Job-level gc:
+// The Prometheus receiver will likely execute in a long running service whose lifetime may exceed
+// the lifetimes of many of the jobs that it is collecting from. In order to keep the JobsMap from
+// leaking memory for entries of no-longer existing jobs, the JobsMap needs to remove entries that
+// haven't been accessed for a long period of time.
+//
+// Timeseries-level gc:
+// Some jobs that the Prometheus receiver is collecting from may export timeseries based on metrics
+// from other jobs (e.g. cAdvisor). In order to keep the timeseriesMap from leaking memory for entries
+// of no-longer existing jobs, the timeseriesMap for each job needs to remove entries that haven't
+// been accessed for a long period of time.
+//
+// The gc strategy uses a standard mark-and-sweep approach - each time a timeseriesMap is accessed,
+// it is marked. Similarly, each time a timeseriesinfo is accessed, it is also marked.
+//
+// At the end of each JobsMap.get(), if the last time the JobsMap was gc'd exceeds the 'gcInterval',
+// the JobsMap is locked and any timeseriesMaps that are unmarked are removed from the JobsMap
+// otherwise the timeseriesMap is gc'd
+//
+// The gc for the timeseriesMap is straightforward - the map is locked and, for each timeseriesinfo
+// in the map, if it has not been marked, it is removed otherwise it is unmarked.
+//
+// Alternative Strategies
+// 1. If the job-level gc doesn't run often enough, or runs too often, a separate go routine can
+//    be spawned at JobMap creation time that gc's at periodic intervals. This approach potentially
+//    adds more contention and latency to each scrape so the current approach is used. Note that
+//    the go routine will need to be cancelled upon Shutdown().
+// 2. If the gc of each timeseriesMap during the gc of the JobsMap causes too much contention,
+//    the gc of timeseriesMaps can be moved to the end of MetricsAdjuster().AdjustMetrics(). This
+//    approach requires adding 'lastGC' Time and (potentially) a gcInterval duration to
+//    timeseriesMap so the current approach is used instead.
+
+// timeseriesinfo contains the information necessary to adjust from the initial point and to detect
+// resets.
+type timeseriesinfoPdata struct {
+	timeseriesinfo
+	mark     bool
+	initial  *pdatametricspb.TimeSeries
+	previous *metricspb.TimeSeries
+}
+
+// timeseriesMap maps from a timeseries instance (metric * label values) to the timeseries info for
+// the instance.
+type timeseriesMapPdata struct {
+	sync.RWMutex
+	mark   bool
+	tsiMap map[string]*timeseriesinfo
+}
+
+// Get the timeseriesinfo for the timeseries associated with the metric and label values.
+func (tsm *timeseriesMapPdata) get(
+	metric *metricspb.Metric, values []*metricspb.LabelValue) *timeseriesinfo {
+	name := metric.GetMetricDescriptor().GetName()
+	sig := getTimeseriesSignature(name, values)
+	tsi, ok := tsm.tsiMap[sig]
+	if !ok {
+		tsi = &timeseriesinfo{}
+		tsm.tsiMap[sig] = tsi
+	}
+	tsm.mark = true
+	tsi.mark = true
+	return tsi
+}
+
+// Remove timeseries that have aged out.
+func (tsm *timeseriesMapPdata) gc() {
+	tsm.Lock()
+	defer tsm.Unlock()
+	// this shouldn't happen under the current gc() strategy
+	if !tsm.mark {
+		return
+	}
+	for ts, tsi := range tsm.tsiMap {
+		if !tsi.mark {
+			delete(tsm.tsiMap, ts)
+		} else {
+			tsi.mark = false
+		}
+	}
+	tsm.mark = false
+}
+
+func newTimeseriesMapPdata() *timeseriesMapPdata {
+	return &timeseriesMapPdata{mark: true, tsiMap: map[string]*timeseriesinfo{}}
+}
+
+// Create a unique timeseries signature consisting of the metric name and label values.
+func getTimeseriesSignaturePdata(name string, values []*metricspb.LabelValue) string {
+	labelValues := make([]string, 0, len(values))
+	for _, label := range values {
+		if label.GetValue() != "" {
+			labelValues = append(labelValues, label.GetValue())
+		}
+	}
+	return fmt.Sprintf("%s,%s", name, strings.Join(labelValues, ","))
+}
+
+// JobsMapPdata maps from a job instance to a map of timeseries instances for the job.
+type JobsMapPdata struct {
+	sync.RWMutex
+	gcInterval time.Duration
+	lastGC     time.Time
+	jobsMap    map[string]*timeseriesMap
+}
+
+// NewJobsMap creates a new (empty) JobsMap.
+func NewJobsMapPdata(gcInterval time.Duration) *JobsMapPdata {
+	return &JobsMapPdata{gcInterval: gcInterval, lastGC: time.Now(), jobsMap: make(map[string]*timeseriesMap)}
+}
+
+// Remove jobs and timeseries that have aged out.
+func (jm *JobsMapPdata) gc() {
+	jm.Lock()
+	defer jm.Unlock()
+	// once the structure is locked, confirm that gc() is still necessary
+	if time.Since(jm.lastGC) > jm.gcInterval {
+		for sig, tsm := range jm.jobsMap {
+			tsm.RLock()
+			tsmNotMarked := !tsm.mark
+			tsm.RUnlock()
+			if tsmNotMarked {
+				delete(jm.jobsMap, sig)
+			} else {
+				tsm.gc()
+			}
+		}
+		jm.lastGC = time.Now()
+	}
+}
+
+func (jm *JobsMapPdata) maybeGC() {
+	// speculatively check if gc() is necessary, recheck once the structure is locked
+	jm.RLock()
+	defer jm.RUnlock()
+	if time.Since(jm.lastGC) > jm.gcInterval {
+		go jm.gc()
+	}
+}
+
+func (jm *JobsMapPdata) get(job, instance string) *timeseriesMapPdata {
+	sig := job + ":" + instance
+	jm.RLock()
+	tsm, ok := jm.jobsMap[sig]
+	jm.RUnlock()
+	defer jm.maybeGC()
+	if ok {
+		return tsm
+	}
+	jm.Lock()
+	defer jm.Unlock()
+	tsm2, ok2 := jm.jobsMap[sig]
+	if ok2 {
+		return tsm2
+	}
+	tsm2 = newTimeseriesMap()
+	jm.jobsMap[sig] = tsm2
+	return tsm2
+}
+
+// MetricsAdjuster takes a map from a metric instance to the initial point in the metrics instance
+// and provides AdjustMetrics, which takes a sequence of metrics and adjust their start times based on
+// the initial points.
+type MetricsAdjusterPdata struct {
+	tsm    *timeseriesMapPdata
+	logger *zap.Logger
+}
+
+// NewMetricsAdjuster is a constructor for MetricsAdjuster.
+func NewMetricsAdjusterPdata(tsm *timeseriesMapPdata, logger *zap.Logger) *MetricsAdjusterPdata {
+	return &MetricsAdjusterPdata{
+		tsm:    tsm,
+		logger: logger,
+	}
+}
+
+// AdjustMetrics takes a sequence of metrics and adjust their start times based on the initial and
+// previous points in the timeseriesMap.
+// Returns the total number of timeseries that had reset start times.
+func (ma *MetricsAdjusterPdata) AdjustMetricsPdata(metrics []*pdata.Metric) ([]*pdata.Metric, int) {
+	var adjusted = make([]*pdata.Metric, 0, len(metrics))
+	resets := 0
+	ma.tsm.Lock()
+	defer ma.tsm.Unlock()
+	for _, metric := range metrics {
+		d := ma.adjustMetric(metric)
+		resets += d
+		adjusted = append(adjusted, metric)
+	}
+	return adjusted, resets
+}
+
+// Returns the number of timeseries with reset start times.
+//
+// Types of metrics returned supported by prometheus:
+// - pdata.MetricDataTypeDoubleGauge
+// - pdata.MetricDataTypeIntHistogram
+// - pdata.MetricDataTypeDoubleSum
+// - pdata.MetricDataTypeHistogram
+// - pdata.MetricDataTypeSummary
+func (ma *MetricsAdjusterPdata) adjustMetricPdata(metric *pdata.Metric) int {
+	switch metric.DataType() {
+	case pdata.MetricDataTypeDoubleGauge, pdata.MetricDataTypeIntHistogram:
+		// gauges don't need to be adjusted so no additional processing is necessary
+		return 0
+	default:
+		return ma.adjustMetricTimeseries(metric)
+	}
+}
+
+// Returns  the number of timeseries that had reset start times.
+func (ma *MetricsAdjusterPdata) adjustMetricTimeseries(metric *pdata.Metric) int {
+	resets := 0
+	filtered := make([]*metricspb.TimeSeries, 0, len(metric.GetTimeseries()))
+	for _, current := range metric.GetTimeseries() {
+		tsi := ma.tsm.get(metric, current.GetLabelValues())
+		if tsi.initial == nil || !ma.adjustTimeseries(metric.MetricDescriptor.Type, current, tsi.initial, tsi.previous) {
+			// initial || reset timeseries
+			tsi.initial = current
+			resets++
+		}
+		tsi.previous = current
+		filtered = append(filtered, current)
+	}
+	metric.Timeseries = filtered
+	return resets
+}
+
+// Returns true if 'current' was adjusted and false if 'current' is an the initial occurrence or a
+// reset of the timeseries.
+func (ma *MetricsAdjusterPdata) adjustTimeseries(metricType pdata.MetricDataType, current, initial, previous *metricspb.TimeSeries) bool {
+	if !ma.adjustPoints(metricType, current.GetPoints(), initial.GetPoints(), previous.GetPoints()) {
+		return false
+	}
+	current.StartTimestamp = initial.StartTimestamp
+	return true
+}
+
+func (ma *MetricsAdjusterPdata) adjustPoints(metricType pdata.MetricDataType, current, initial, previous []*metricspb.Point) bool {
+	if len(current) != 1 || len(initial) != 1 || len(current) != 1 {
+		ma.logger.Info("Adjusting Points, all lengths should be 1",
+			zap.Int("len(current)", len(current)), zap.Int("len(initial)", len(initial)), zap.Int("len(previous)", len(previous)))
+		return true
+	}
+	return ma.isReset(metricType, current[0], previous[0])
+}
+
+func (ma *MetricsAdjusterPdata) isReset(metricType pdata.MetricDataType, current, previous *metricspb.Point) bool {
+	switch metricType {
+	case pdata.MetricDataTypeDoubleSum:
+		if current.GetDoubleValue() < previous.GetDoubleValue() {
+			// reset detected
+			return false
+		}
+	case pdata.MetricDataTypeHistogram:
+		// note: sum of squared deviation not currently supported
+		currentDist := current.GetDistributionValue()
+		previousDist := previous.GetDistributionValue()
+		if currentDist.Count < previousDist.Count || currentDist.Sum < previousDist.Sum {
+			// reset detected
+			return false
+		}
+	case metricspb.MetricDescriptor_SUMMARY:
+		currentSummary := current.GetSummaryValue()
+		previousSummary := previous.GetSummaryValue()
+		if currentSummary.Count.GetValue() < previousSummary.Count.GetValue() || currentSummary.Sum.GetValue() < previousSummary.Sum.GetValue() {
+			// reset detected
+			return false
+		}
+	default:
+		// this shouldn't happen
+		ma.logger.Info("Adjust - skipping unexpected point", zap.String("type", metricType.String()))
+	}
+	return true
+}
+*/

--- a/receiver/prometheusreceiver/internal/otlp_transaction.go
+++ b/receiver/prometheusreceiver/internal/otlp_transaction.go
@@ -1,0 +1,219 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"context"
+	"math"
+	"sync/atomic"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/storage"
+	"go.uber.org/zap"
+
+	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.opentelemetry.io/collector/obsreport"
+	"go.opentelemetry.io/collector/translator/internaldata"
+)
+
+// A transaction is corresponding to an individual scrape operation or stale report.
+// That said, whenever prometheus receiver scrapped a target metric endpoint a page of raw metrics is returned,
+// a transaction, which acts as appender, is created to process this page of data, the scrapeLoop will call the Add or
+// AddFast method to insert metrics data points, when finished either Commit, which means success, is called and data
+// will be flush to the downstream consumer, or Rollback, which means discard all the data, is called and all data
+// points are discarded.
+type transactionPdata struct {
+	*transaction
+	resource      pdata.Resource
+	metricBuilder *metricBuilderPdata
+}
+
+func newTransactionPdata(
+	ctx context.Context,
+	jobsMap *JobsMap,
+	useStartTimeMetric bool,
+	startTimeMetricRegex string,
+	receiverID config.ComponentID,
+	ms *metadataService,
+	sink consumer.Metrics,
+	externalLabels labels.Labels,
+	logger *zap.Logger) *transactionPdata {
+	return &transactionPdata{
+		transaction: &transaction{
+			id:                   atomic.AddInt64(&idSeq, 1),
+			ctx:                  ctx,
+			isNew:                true,
+			sink:                 sink,
+			jobsMap:              jobsMap,
+			useStartTimeMetric:   useStartTimeMetric,
+			startTimeMetricRegex: startTimeMetricRegex,
+			receiverID:           receiverID,
+			ms:                   ms,
+			externalLabels:       externalLabels,
+			logger:               logger,
+			obsrecv:              obsreport.NewReceiver(obsreport.ReceiverSettings{ReceiverID: receiverID, Transport: transport}),
+		},
+	}
+}
+
+// ensure *transaction has implemented the storage.Appender interface
+var _ storage.Appender = (*transactionPdata)(nil)
+
+// Append always returns 0 to disable label caching.
+func (tr *transactionPdata) Append(ref uint64, ls labels.Labels, t int64, v float64) (uint64, error) {
+	// Important, must handle. prometheus will still try to feed the appender some data even if it failed to
+	// scrape the remote target,  if the previous scrape was success and some data were cached internally
+	// in our case, we don't need these data, simply drop them shall be good enough. more details:
+	// https://github.com/prometheus/prometheus/blob/851131b0740be7291b98f295567a97f32fffc655/scrape/scrape.go#L933-L935
+	if math.IsNaN(v) {
+		return 0, nil
+	}
+
+	select {
+	case <-tr.ctx.Done():
+		return 0, errTransactionAborted
+	default:
+	}
+	if len(tr.externalLabels) > 0 {
+		// TODO(jbd): Improve the allocs.
+		ls = append(ls, tr.externalLabels...)
+	}
+	if tr.isNew {
+		if err := tr.initTransaction(ls); err != nil {
+			return 0, err
+		}
+	}
+	return 0, tr.metricBuilder.AddDataPoint(ls, t, v)
+}
+
+func (tr *transactionPdata) initTransaction(ls labels.Labels) error {
+	job, instance := ls.Get(model.JobLabel), ls.Get(model.InstanceLabel)
+	if job == "" || instance == "" {
+		return errNoJobInstance
+	}
+	// discover the binding target when this method is called for the first time during a transaction
+	mc, err := tr.ms.Get(job, instance)
+	if err != nil {
+		return err
+	}
+	if tr.jobsMap != nil {
+		tr.job = job
+		tr.instance = instance
+	}
+	tr.resource = createNodeAndResourcePdata(job, instance, mc.SharedLabels().Get(model.SchemeLabel))
+	tr.metricBuilder = newMetricBuilderPdata(mc, tr.useStartTimeMetric, tr.startTimeMetricRegex, tr.logger)
+	tr.isNew = false
+	return nil
+}
+
+// Commit submits metrics data to consumers.
+func (tr *transactionPdata) Commit() error {
+	if tr.isNew {
+		// In a situation like not able to connect to the remote server, scrapeloop will still commit even if it had
+		// never added any data points, that the transaction has not been initialized.
+		return nil
+	}
+
+	ctx := tr.obsrecv.StartMetricsOp(tr.ctx)
+	metrics, _, _, err := tr.metricBuilder.Build()
+	if err != nil {
+		// Only error by Build() is errNoDataToBuild, with numReceivedPoints set to zero.
+		tr.obsrecv.EndMetricsOp(ctx, dataformat, 0, err)
+		return err
+	}
+
+	if tr.useStartTimeMetric {
+		// startTime is mandatory in this case, but may be zero when the
+		// process_start_time_seconds metric is missing from the target endpoint.
+		if tr.metricBuilder.startTime == 0.0 {
+			// Since we are unable to adjust metrics properly, we will drop them
+			// and return an error.
+			err = errNoStartTimeMetrics
+			tr.obsrecv.EndMetricsOp(ctx, dataformat, 0, err)
+			return err
+		}
+
+		adjustStartTimestampPdata(tr.metricBuilder.startTime, metrics)
+	} else {
+		// AdjustMetrics - jobsMap has to be non-nil in this case.
+		// Note: metrics could be empty after adjustment, which needs to be checked before passing it on to ConsumeMetrics()
+		metrics, _ = NewMetricsAdjuster(tr.jobsMap.get(tr.job, tr.instance), tr.logger).AdjustMetrics(metrics)
+	}
+
+	numPoints := 0
+	if len(metrics) > 0 {
+                numPoints = 
+		err = tr.sink.ConsumeMetrics(ctx, metrics)
+	}
+	tr.obsrecv.EndMetricsOp(ctx, dataformat, numPoints, err)
+	return err
+}
+
+func adjustStartTimestampPdata(startTime float64, metrics []*pdata.Metric) {
+	startTimeTs := pdata.Timestamp(startTime)
+	for _, metric := range metrics {
+		switch metric.MetricDataType() {
+		case pdata.MetricDataTypeDoubleGauge, pdata.MetricDataTypeHistogram:
+			continue
+
+		// For all the other metrics, update the startTimestamp to startTimeTs.
+
+		case pdata.MetricDataTypeIntHistogram:
+			dataPoints := metric.IntHistogram().DataPoints()
+			for i := 0; i < dataPoints.Len(); i++ {
+				point := dataPoints.At(i)
+				point.SetStartTimestamp(startTimeTs)
+			}
+
+		case pdata.MetricDataTypeIntGauge:
+			dataPoints := metric.IntGauge().DataPoints()
+			for i := 0; i < dataPoints.Len(); i++ {
+				point := dataPoints.At(i)
+				point.SetStartTimestamp(startTimeTs)
+			}
+
+		case pdata.MetricDataTypeIntSum:
+			dataPoints := metric.IntSum().DataPoints()
+			for i := 0; i < dataPoints.Len(); i++ {
+				point := dataPoints.At(i)
+				point.SetStartTimestamp(startTimeTs)
+			}
+
+		case pdata.MetricDataTypeDoubleSum:
+			dataPoints := metric.DoubleSum().DataPoints()
+			for i := 0; i < dataPoints.Len(); i++ {
+				point := dataPoints.At(i)
+				point.SetStartTimestamp(startTimeTs)
+			}
+
+		case pdata.MetricDataTypeIntHistogram:
+			dataPoints := metric.IntHistogram().DataPoints()
+			for i := 0; i < dataPoints.Len(); i++ {
+				point := dataPoints.At(i)
+				point.SetStartTimestamp(startTimeTs)
+			}
+
+		case pdata.MetricDataTypeSummary:
+			dataPoints := metric.Summary().DataPoints()
+			for i := 0; i < dataPoints.Len(); i++ {
+				point := dataPoints.At(i)
+				point.SetStartTimestamp(startTimeTs)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Adds point-to-point converters for the various types so that
we can eventually replace with a direct Prometheus to OTLP
conversion. This change solely focuses on

    (*metricFamilyPdata).ToMetric()

Updates #3137
