### PR TITLE
add metrics to kafkareceiver

### DIFF
--- a/receiver/kafkareceiver/kafka_receiver_test.go
+++ b/receiver/kafkareceiver/kafka_receiver_test.go
@@ -195,7 +195,7 @@ func TestTracesConsumerGroupHandler_error_unmarshal(t *testing.T) {
 }
 
 func TestTracesConsumerGroupHandler_error_nextConsumer(t *testing.T) {
-	consumerError := errors.New("failed to consumer")
+	consumerError := errors.New("failed to consume")
 	c := tracesConsumerGroupHandler{
 		unmarshaler:  newPdataTracesUnmarshaler(otlp.NewProtobufTracesUnmarshaler(), defaultEncoding),
 		logger:       zap.NewNop(),
@@ -218,6 +218,190 @@ func TestTracesConsumerGroupHandler_error_nextConsumer(t *testing.T) {
 	td := pdata.NewTraces()
 	td.ResourceSpans().AppendEmpty()
 	bts, err := otlp.NewProtobufTracesMarshaler().Marshal(td)
+	require.NoError(t, err)
+	groupClaim.messageChan <- &sarama.ConsumerMessage{Value: bts}
+	close(groupClaim.messageChan)
+	wg.Wait()
+}
+
+func TestNewMetricsReceiver_version_err(t *testing.T) {
+	c := Config{
+		Encoding:        defaultEncoding,
+		ProtocolVersion: "none",
+	}
+	r, err := newMetricsReceiver(c, componenttest.NewNopReceiverCreateSettings(), defaultMetricsUnmarshalers(), consumertest.NewNop())
+	assert.Error(t, err)
+	assert.Nil(t, r)
+}
+
+func TestNewMetricsReceiver_encoding_err(t *testing.T) {
+	c := Config{
+		Encoding: "foo",
+	}
+	r, err := newMetricsReceiver(c, componenttest.NewNopReceiverCreateSettings(), defaultMetricsUnmarshalers(), consumertest.NewNop())
+	require.Error(t, err)
+	assert.Nil(t, r)
+	assert.EqualError(t, err, errUnrecognizedEncoding.Error())
+}
+
+func TestNewMetricsExporter_err_auth_type(t *testing.T) {
+	c := Config{
+		ProtocolVersion: "2.0.0",
+		Authentication: kafkaexporter.Authentication{
+			TLS: &configtls.TLSClientSetting{
+				TLSSetting: configtls.TLSSetting{
+					CAFile: "/doesnotexist",
+				},
+			},
+		},
+		Encoding: defaultEncoding,
+		Metadata: kafkaexporter.Metadata{
+			Full: false,
+		},
+	}
+	r, err := newMetricsReceiver(c, componenttest.NewNopReceiverCreateSettings(), defaultMetricsUnmarshalers(), consumertest.NewNop())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to load TLS config")
+	assert.Nil(t, r)
+}
+
+func TestMetricsReceiverStart(t *testing.T) {
+	c := kafkaMetricsConsumer{
+		nextConsumer:  consumertest.NewNop(),
+		logger:        zap.NewNop(),
+		consumerGroup: &testConsumerGroup{},
+	}
+
+	require.NoError(t, c.Start(context.Background(), nil))
+	require.NoError(t, c.Shutdown(context.Background()))
+}
+
+func TestMetricsReceiverStartConsume(t *testing.T) {
+	c := kafkaMetricsConsumer{
+		nextConsumer:  consumertest.NewNop(),
+		logger:        zap.NewNop(),
+		consumerGroup: &testConsumerGroup{},
+	}
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	c.cancelConsumeLoop = cancelFunc
+	require.NoError(t, c.Shutdown(context.Background()))
+	err := c.consumeLoop(ctx, &logsConsumerGroupHandler{
+		ready: make(chan bool),
+	})
+	assert.EqualError(t, err, context.Canceled.Error())
+}
+
+func TestMetricsReceiver_error(t *testing.T) {
+	zcore, logObserver := observer.New(zapcore.ErrorLevel)
+	logger := zap.New(zcore)
+
+	expectedErr := errors.New("handler error")
+	c := kafkaMetricsConsumer{
+		nextConsumer:  consumertest.NewNop(),
+		logger:        logger,
+		consumerGroup: &testConsumerGroup{err: expectedErr},
+	}
+
+	require.NoError(t, c.Start(context.Background(), componenttest.NewNopHost()))
+	require.NoError(t, c.Shutdown(context.Background()))
+	assert.Eventually(t, func() bool {
+		return logObserver.FilterField(zap.Error(expectedErr)).Len() > 0
+	}, 10*time.Second, time.Millisecond*100)
+}
+
+func TestMetricsConsumerGroupHandler(t *testing.T) {
+	views := MetricViews()
+	require.NoError(t, view.Register(views...))
+	defer view.Unregister(views...)
+
+	c := metricsConsumerGroupHandler{
+		unmarshaler:  newPdataMetricsUnmarshaler(otlp.NewProtobufMetricsUnmarshaler(), defaultEncoding),
+		logger:       zap.NewNop(),
+		ready:        make(chan bool),
+		nextConsumer: consumertest.NewNop(),
+		obsrecv:      obsreport.NewReceiver(obsreport.ReceiverSettings{}),
+	}
+
+	testSession := testConsumerGroupSession{}
+	require.NoError(t, c.Setup(testSession))
+	_, ok := <-c.ready
+	assert.False(t, ok)
+	viewData, err := view.RetrieveData(statPartitionStart.Name())
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(viewData))
+	distData := viewData[0].Data.(*view.SumData)
+	assert.Equal(t, float64(1), distData.Value)
+
+	require.NoError(t, c.Cleanup(testSession))
+	viewData, err = view.RetrieveData(statPartitionClose.Name())
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(viewData))
+	distData = viewData[0].Data.(*view.SumData)
+	assert.Equal(t, float64(1), distData.Value)
+
+	groupClaim := testConsumerGroupClaim{
+		messageChan: make(chan *sarama.ConsumerMessage),
+	}
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		require.NoError(t, c.ConsumeClaim(testSession, groupClaim))
+		wg.Done()
+	}()
+
+	groupClaim.messageChan <- &sarama.ConsumerMessage{}
+	close(groupClaim.messageChan)
+	wg.Wait()
+}
+
+func TestMetricsConsumerGroupHandler_error_unmarshal(t *testing.T) {
+	c := metricsConsumerGroupHandler{
+		unmarshaler:  newPdataMetricsUnmarshaler(otlp.NewProtobufMetricsUnmarshaler(), defaultEncoding),
+		logger:       zap.NewNop(),
+		ready:        make(chan bool),
+		nextConsumer: consumertest.NewNop(),
+		obsrecv:      obsreport.NewReceiver(obsreport.ReceiverSettings{}),
+	}
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	groupClaim := &testConsumerGroupClaim{
+		messageChan: make(chan *sarama.ConsumerMessage),
+	}
+	go func() {
+		err := c.ConsumeClaim(testConsumerGroupSession{}, groupClaim)
+		require.Error(t, err)
+		wg.Done()
+	}()
+	groupClaim.messageChan <- &sarama.ConsumerMessage{Value: []byte("!@#")}
+	close(groupClaim.messageChan)
+	wg.Wait()
+}
+
+func TestMetricsConsumerGroupHandler_error_nextConsumer(t *testing.T) {
+	consumerError := errors.New("failed to consume")
+	c := metricsConsumerGroupHandler{
+		unmarshaler:  newPdataMetricsUnmarshaler(otlp.NewProtobufMetricsUnmarshaler(), defaultEncoding),
+		logger:       zap.NewNop(),
+		ready:        make(chan bool),
+		nextConsumer: consumertest.NewErr(consumerError),
+		obsrecv:      obsreport.NewReceiver(obsreport.ReceiverSettings{}),
+	}
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	groupClaim := &testConsumerGroupClaim{
+		messageChan: make(chan *sarama.ConsumerMessage),
+	}
+	go func() {
+		e := c.ConsumeClaim(testConsumerGroupSession{}, groupClaim)
+		assert.EqualError(t, e, consumerError.Error())
+		wg.Done()
+	}()
+
+	ld := testdata.GenerateMetricsOneMetric()
+	bts, err := otlp.NewProtobufMetricsMarshaler().Marshal(ld)
 	require.NoError(t, err)
 	groupClaim.messageChan <- &sarama.ConsumerMessage{Value: bts}
 	close(groupClaim.messageChan)
@@ -380,7 +564,7 @@ func TestLogsConsumerGroupHandler_error_unmarshal(t *testing.T) {
 }
 
 func TestLogsConsumerGroupHandler_error_nextConsumer(t *testing.T) {
-	consumerError := errors.New("failed to consumer")
+	consumerError := errors.New("failed to consume")
 	c := logsConsumerGroupHandler{
 		unmarshaler:  newPdataLogsUnmarshaler(otlp.NewProtobufLogsUnmarshaler(), defaultEncoding),
 		logger:       zap.NewNop(),

--- a/receiver/kafkareceiver/pdata_unmarshaler.go
+++ b/receiver/kafkareceiver/pdata_unmarshaler.go
@@ -49,3 +49,19 @@ func newPdataTracesUnmarshaler(unmarshaler model.TracesUnmarshaler, encoding str
 		encoding:          encoding,
 	}
 }
+
+type pdataMetricsUnmarshaler struct {
+	model.MetricsUnmarshaler
+	encoding string
+}
+
+func (p pdataMetricsUnmarshaler) Encoding() string {
+	return p.encoding
+}
+
+func newPdataMetricsUnmarshaler(unmarshaler model.MetricsUnmarshaler, encoding string) MetricsUnmarshaler {
+	return pdataMetricsUnmarshaler{
+		MetricsUnmarshaler: unmarshaler,
+		encoding:           encoding,
+	}
+}

--- a/receiver/kafkareceiver/pdata_unmarshaler_test.go
+++ b/receiver/kafkareceiver/pdata_unmarshaler_test.go
@@ -27,6 +27,11 @@ func TestNewPdataTracesUnmarshaler(t *testing.T) {
 	assert.Equal(t, "test", um.Encoding())
 }
 
+func TestNewPdataMetricsUnmarshaler(t *testing.T) {
+	um := newPdataMetricsUnmarshaler(otlp.NewProtobufMetricsUnmarshaler(), "test")
+	assert.Equal(t, "test", um.Encoding())
+}
+
 func TestNewPdataLogsUnmarshaler(t *testing.T) {
 	um := newPdataLogsUnmarshaler(otlp.NewProtobufLogsUnmarshaler(), "test")
 	assert.Equal(t, "test", um.Encoding())

--- a/receiver/kafkareceiver/unmarshaler.go
+++ b/receiver/kafkareceiver/unmarshaler.go
@@ -30,6 +30,15 @@ type TracesUnmarshaler interface {
 	Encoding() string
 }
 
+// MetricsUnmarshaler deserializes the message body
+type MetricsUnmarshaler interface {
+	// Unmarshal deserializes the message body into traces
+	Unmarshal([]byte) (pdata.Metrics, error)
+
+	// Encoding of the serialized messages
+	Encoding() string
+}
+
 // LogsUnmarshaler deserializes the message body.
 type LogsUnmarshaler interface {
 	// Unmarshal deserializes the message body into traces.
@@ -54,6 +63,13 @@ func defaultTracesUnmarshalers() map[string]TracesUnmarshaler {
 		zipkinProto.Encoding():  zipkinProto,
 		zipkinJSON.Encoding():   zipkinJSON,
 		zipkinThrift.Encoding(): zipkinThrift,
+	}
+}
+
+func defaultMetricsUnmarshalers() map[string]MetricsUnmarshaler {
+	otlpPb := newPdataMetricsUnmarshaler(otlp.NewProtobufMetricsUnmarshaler(), defaultEncoding)
+	return map[string]MetricsUnmarshaler{
+		otlpPb.Encoding(): otlpPb,
 	}
 }
 

--- a/receiver/kafkareceiver/unmarshaler_test.go
+++ b/receiver/kafkareceiver/unmarshaler_test.go
@@ -41,6 +41,21 @@ func TestDefaultTracesUnMarshaler(t *testing.T) {
 	}
 }
 
+func TestDefaultMetricsUnMarshaler(t *testing.T) {
+	expectedEncodings := []string{
+		"otlp_proto",
+	}
+	marshalers := defaultMetricsUnmarshalers()
+	assert.Equal(t, len(expectedEncodings), len(marshalers))
+	for _, e := range expectedEncodings {
+		t.Run(e, func(t *testing.T) {
+			m, ok := marshalers[e]
+			require.True(t, ok)
+			assert.NotNil(t, m)
+		})
+	}
+}
+
 func TestDefaultLogsUnMarshaler(t *testing.T) {
 	expectedEncodings := []string{
 		"otlp_proto",


### PR DESCRIPTION
**Description:**
Currently _kafkareceiver_ doesn't support metrics type. This PR adds metrics support to it (almost a direct copy/substitute from traces/logs implementation).

**Testing:**

- `go test ./...`: under kafkareceiver folder, all pass
- `make test`: some cases failed locally but should be unrelated
- manual test with this configs (another collector configured with _hostmetrics_ receiver and _kafka_ exporter):

```yaml
receivers:
  otlp:
    protocols:
      grpc:
      http:
  kafka/a:
    protocol_version: "2.0.0"
    topic: asdf_traces
  kafka/b:
    protocol_version: "2.0.0"
    topic: asdf_metrics

processors:
  batch:

exporters:
  logging:
    logLevel: debug

service:
  pipelines:
    traces:
      receivers: [kafka/a]
      exporters: [logging]
    metrics:
      receivers: [kafka/b]
      exporters: [logging]
```

**Caveats:**

If same config is used between traces/metrics/logs, it will errors about:
> Error: cannot build pipelines: cannot build receivers: factory for kafka/a is implemented incorrectly: CreateTracesReceiver and CreateMetricsReceiver must return the same receiver pointer when creating receivers of different data types

The error message says `traces` and `metrics`, but this would actually also error when used against `traces` and `logs`. Because of this currently this receiver needs multiple kafka configs (and should use different topics) to use in traces/metrics/logs.

I thought about merging traces/metrics/logs into one `receiver`. However in that case we need separated `topic` config to differentiate between different data types, otherwise the receiver has no way to tell the type of the message its consuming without trial and error, which would be inefficient. This PR can be seen as a starting point of that and just enables using metrics in _kafkareceiver_.