### PR TITLE
Fix missing startTimestamp for processes scraper.

### DIFF
--- a/receiver/hostmetricsreceiver/internal/scraper/processesscraper/processes_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processesscraper/processes_scraper.go
@@ -45,8 +45,8 @@ func (s *scraper) start(context.Context, component.Host) error {
 	if err != nil {
 		return err
 	}
-
-	s.startTime = pdata.Timestamp(bootTime)
+	// bootTime is seconds since 1970, timestamps are in nanoseconds.
+	s.startTime = pdata.Timestamp(bootTime * 1e9)
 	return nil
 }
 

--- a/receiver/hostmetricsreceiver/internal/scraper/processesscraper/processes_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processesscraper/processes_scraper.go
@@ -52,6 +52,6 @@ func (s *scraper) start(context.Context, component.Host) error {
 
 func (s *scraper) scrape(_ context.Context) (pdata.MetricSlice, error) {
 	metrics := pdata.NewMetricSlice()
-	err := appendSystemSpecificProcessesMetrics(metrics, 0, s.misc)
+	err := appendSystemSpecificProcessesMetrics(metrics, s.startTime, 0, s.misc)
 	return metrics, err
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/processesscraper/processes_scraper_darwin.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processesscraper/processes_scraper_darwin.go
@@ -24,6 +24,6 @@ import (
 
 const unixSystemSpecificMetricsLen = 0
 
-func appendUnixSystemSpecificProcessesMetrics(metrics pdata.MetricSlice, startIndex int, now pdata.Timestamp, misc *load.MiscStat) error {
+func appendUnixSystemSpecificProcessesMetrics(metrics pdata.MetricSlice, startTime pdata.Timestamp, startIndex int, now pdata.Timestamp, misc *load.MiscStat) error {
 	return nil
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/processesscraper/processes_scraper_fallback.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processesscraper/processes_scraper_fallback.go
@@ -18,6 +18,6 @@ package processesscraper
 
 import "go.opentelemetry.io/collector/consumer/pdata"
 
-func appendSystemSpecificProcessesMetrics(metrics pdata.MetricSlice, startIndex int, miscFunc getMiscStats) error {
+func appendSystemSpecificProcessesMetrics(metrics pdata.MetricSlice, startTime pdata.Timestamp, startIndex int, miscFunc getMiscStats) error {
 	return nil
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/processesscraper/processes_scraper_linux.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processesscraper/processes_scraper_linux.go
@@ -25,14 +25,15 @@ import (
 
 const unixSystemSpecificMetricsLen = 1
 
-func appendUnixSystemSpecificProcessesMetrics(metrics pdata.MetricSlice, startIndex int, now pdata.Timestamp, misc *load.MiscStat) error {
-	initializeProcessesCreatedMetric(metrics.At(startIndex), now, misc)
+func appendUnixSystemSpecificProcessesMetrics(metrics pdata.MetricSlice, startTime pdata.Timestamp, startIndex int, now pdata.Timestamp, misc *load.MiscStat) error {
+	initializeProcessesCreatedMetric(metrics.At(startIndex), startTime, now, misc)
 	return nil
 }
 
-func initializeProcessesCreatedMetric(metric pdata.Metric, now pdata.Timestamp, misc *load.MiscStat) {
+func initializeProcessesCreatedMetric(metric pdata.Metric, startTime, now pdata.Timestamp, misc *load.MiscStat) {
 	metadata.Metrics.SystemProcessesCreated.Init(metric)
 	ddp := metric.IntSum().DataPoints().AppendEmpty()
+	ddp.SetStartTimestamp(startTime)
 	ddp.SetTimestamp(now)
 	ddp.SetValue(int64(misc.ProcsCreated))
 }

--- a/receiver/hostmetricsreceiver/internal/testutils.go
+++ b/receiver/hostmetricsreceiver/internal/testutils.go
@@ -66,7 +66,7 @@ func AssertDoubleSumMetricLabelExists(t *testing.T, metric pdata.Metric, index i
 func AssertIntSumMetricStartTimeEquals(t *testing.T, metric pdata.Metric, startTime pdata.Timestamp) {
 	idps := metric.IntSum().DataPoints()
 	for i := 0; i < idps.Len(); i++ {
-		require.Equal(t, startTime, idps.At(i).StartTimestamp())
+		require.Equal(t, startTime, idps.At(i).StartTimestamp(), "Start time %d not found in metric point: %q", startTime, idps.At(i))
 	}
 }
 


### PR DESCRIPTION
**Description:** 
The `processes` scraper in `hostmetricsreceiver` did not use boot startTime, unlike the rest of the scrapers.

While I'd consider this a bug, could be considered a minor feature request.   Specifically, the [OTLP spec](https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/metrics/v1/metrics.proto#L117) strongly recommends start timestamps for points with Aggregation Temporarily.   This is *not* required due to compatibility with non-OTel metric format, but we should have a really good reason not to provide a valid timestamp.

I just found this yesterday, can open a bug for this PR if needed.

Here's what I did:

- Wire boot timestamp through to processes scraper (matches all other host metrics receivers).
- Add a more verbose output on timestmap failure for easier diagnostics when making failing changes to these tests.
- Update tests to ensure starttime is set in resulting metrics.


**Testing:** 
Added unit tests and ran locally.
