### PR TITLE
scraperhelper: use common scraping interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 🧰 Bug fixes 🧰
+
+- `scraperhelper`: Include the scraper name in log messages (#3487)
+
 ## v0.29.0 Beta
 
 ## 🛑 Breaking changes 🛑

--- a/receiver/hostmetricsreceiver/factory.go
+++ b/receiver/hostmetricsreceiver/factory.go
@@ -124,7 +124,7 @@ func createAddScraperOptions(
 		}
 
 		if ok {
-			scraperControllerOptions = append(scraperControllerOptions, scraperhelper.AddMetricsScraper(hostMetricsScraper))
+			scraperControllerOptions = append(scraperControllerOptions, scraperhelper.AddScraper(hostMetricsScraper))
 			continue
 		}
 
@@ -134,7 +134,7 @@ func createAddScraperOptions(
 		}
 
 		if ok {
-			scraperControllerOptions = append(scraperControllerOptions, scraperhelper.AddResourceMetricsScraper(resourceMetricsScraper))
+			scraperControllerOptions = append(scraperControllerOptions, scraperhelper.AddScraper(resourceMetricsScraper))
 			continue
 		}
 
@@ -144,7 +144,7 @@ func createAddScraperOptions(
 	return scraperControllerOptions, nil
 }
 
-func createHostMetricsScraper(ctx context.Context, logger *zap.Logger, key string, cfg internal.Config, factories map[string]internal.ScraperFactory) (scraper scraperhelper.MetricsScraper, ok bool, err error) {
+func createHostMetricsScraper(ctx context.Context, logger *zap.Logger, key string, cfg internal.Config, factories map[string]internal.ScraperFactory) (scraper scraperhelper.Scraper, ok bool, err error) {
 	factory := factories[key]
 	if factory == nil {
 		ok = false
@@ -156,7 +156,7 @@ func createHostMetricsScraper(ctx context.Context, logger *zap.Logger, key strin
 	return
 }
 
-func createResourceMetricsScraper(ctx context.Context, logger *zap.Logger, key string, cfg internal.Config, factories map[string]internal.ResourceScraperFactory) (scraper scraperhelper.ResourceMetricsScraper, ok bool, err error) {
+func createResourceMetricsScraper(ctx context.Context, logger *zap.Logger, key string, cfg internal.Config, factories map[string]internal.ResourceScraperFactory) (scraper scraperhelper.Scraper, ok bool, err error) {
 	factory := factories[key]
 	if factory == nil {
 		ok = false

--- a/receiver/hostmetricsreceiver/hostmetrics_receiver_test.go
+++ b/receiver/hostmetricsreceiver/hostmetrics_receiver_test.go
@@ -213,32 +213,32 @@ type mockFactory struct{ mock.Mock }
 type mockScraper struct{ mock.Mock }
 
 func (m *mockFactory) CreateDefaultConfig() internal.Config { return &mockConfig{} }
-func (m *mockFactory) CreateMetricsScraper(context.Context, *zap.Logger, internal.Config) (scraperhelper.MetricsScraper, error) {
+func (m *mockFactory) CreateMetricsScraper(context.Context, *zap.Logger, internal.Config) (scraperhelper.Scraper, error) {
 	args := m.MethodCalled("CreateMetricsScraper")
-	return args.Get(0).(scraperhelper.MetricsScraper), args.Error(1)
+	return args.Get(0).(scraperhelper.Scraper), args.Error(1)
 }
 
 func (m *mockScraper) ID() config.ComponentID                      { return config.NewID("") }
 func (m *mockScraper) Start(context.Context, component.Host) error { return nil }
 func (m *mockScraper) Shutdown(context.Context) error              { return nil }
-func (m *mockScraper) Scrape(context.Context, config.ComponentID) (pdata.MetricSlice, error) {
-	return pdata.NewMetricSlice(), errors.New("err1")
+func (m *mockScraper) Scrape(context.Context, config.ComponentID) (pdata.Metrics, error) {
+	return pdata.NewMetrics(), errors.New("err1")
 }
 
 type mockResourceFactory struct{ mock.Mock }
 type mockResourceScraper struct{ mock.Mock }
 
 func (m *mockResourceFactory) CreateDefaultConfig() internal.Config { return &mockConfig{} }
-func (m *mockResourceFactory) CreateResourceMetricsScraper(context.Context, *zap.Logger, internal.Config) (scraperhelper.ResourceMetricsScraper, error) {
+func (m *mockResourceFactory) CreateResourceMetricsScraper(context.Context, *zap.Logger, internal.Config) (scraperhelper.Scraper, error) {
 	args := m.MethodCalled("CreateResourceMetricsScraper")
-	return args.Get(0).(scraperhelper.ResourceMetricsScraper), args.Error(1)
+	return args.Get(0).(scraperhelper.Scraper), args.Error(1)
 }
 
 func (m *mockResourceScraper) ID() config.ComponentID                      { return config.NewID("") }
 func (m *mockResourceScraper) Start(context.Context, component.Host) error { return nil }
 func (m *mockResourceScraper) Shutdown(context.Context) error              { return nil }
-func (m *mockResourceScraper) Scrape(context.Context, config.ComponentID) (pdata.ResourceMetricsSlice, error) {
-	return pdata.NewResourceMetricsSlice(), errors.New("err2")
+func (m *mockResourceScraper) Scrape(context.Context, config.ComponentID) (pdata.Metrics, error) {
+	return pdata.NewMetrics(), errors.New("err2")
 }
 
 func TestGatherMetrics_ScraperKeyConfigError(t *testing.T) {

--- a/receiver/hostmetricsreceiver/internal/scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper.go
@@ -34,7 +34,7 @@ type ScraperFactory interface {
 
 	// CreateMetricsScraper creates a scraper based on this config.
 	// If the config is not valid, error will be returned instead.
-	CreateMetricsScraper(ctx context.Context, logger *zap.Logger, cfg Config) (scraperhelper.MetricsScraper, error)
+	CreateMetricsScraper(ctx context.Context, logger *zap.Logger, cfg Config) (scraperhelper.Scraper, error)
 }
 
 // ResourceScraperFactory can create a ResourceScraper.
@@ -43,7 +43,7 @@ type ResourceScraperFactory interface {
 
 	// CreateResourceMetricsScraper creates a resource scraper based on this
 	// config. If the config is not valid, error will be returned instead.
-	CreateResourceMetricsScraper(ctx context.Context, logger *zap.Logger, cfg Config) (scraperhelper.ResourceMetricsScraper, error)
+	CreateResourceMetricsScraper(ctx context.Context, logger *zap.Logger, cfg Config) (scraperhelper.Scraper, error)
 }
 
 // Config is the configuration of a scraper.

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/factory.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/factory.go
@@ -44,7 +44,7 @@ func (f *Factory) CreateMetricsScraper(
 	ctx context.Context,
 	_ *zap.Logger,
 	config internal.Config,
-) (scraperhelper.MetricsScraper, error) {
+) (scraperhelper.Scraper, error) {
 	cfg := config.(*Config)
 	s := newCPUScraper(ctx, cfg)
 

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/factory.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/factory.go
@@ -44,7 +44,7 @@ func (f *Factory) CreateMetricsScraper(
 	ctx context.Context,
 	_ *zap.Logger,
 	config internal.Config,
-) (scraperhelper.MetricsScraper, error) {
+) (scraperhelper.Scraper, error) {
 	cfg := config.(*Config)
 	s, err := newDiskScraper(ctx, cfg)
 	if err != nil {

--- a/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/factory.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/factory.go
@@ -49,7 +49,7 @@ func (f *Factory) CreateMetricsScraper(
 	ctx context.Context,
 	_ *zap.Logger,
 	config internal.Config,
-) (scraperhelper.MetricsScraper, error) {
+) (scraperhelper.Scraper, error) {
 	cfg := config.(*Config)
 	s, err := newFileSystemScraper(ctx, cfg)
 	if err != nil {

--- a/receiver/hostmetricsreceiver/internal/scraper/loadscraper/factory.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/loadscraper/factory.go
@@ -44,7 +44,7 @@ func (f *Factory) CreateMetricsScraper(
 	ctx context.Context,
 	logger *zap.Logger,
 	config internal.Config,
-) (scraperhelper.MetricsScraper, error) {
+) (scraperhelper.Scraper, error) {
 	cfg := config.(*Config)
 	s := newLoadScraper(ctx, logger, cfg)
 

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/factory.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/factory.go
@@ -44,7 +44,7 @@ func (f *Factory) CreateMetricsScraper(
 	ctx context.Context,
 	_ *zap.Logger,
 	config internal.Config,
-) (scraperhelper.MetricsScraper, error) {
+) (scraperhelper.Scraper, error) {
 	cfg := config.(*Config)
 	s := newMemoryScraper(ctx, cfg)
 

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/factory.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/factory.go
@@ -44,7 +44,7 @@ func (f *Factory) CreateMetricsScraper(
 	ctx context.Context,
 	_ *zap.Logger,
 	config internal.Config,
-) (scraperhelper.MetricsScraper, error) {
+) (scraperhelper.Scraper, error) {
 	cfg := config.(*Config)
 	s, err := newNetworkScraper(ctx, cfg)
 	if err != nil {

--- a/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/factory.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/factory.go
@@ -44,7 +44,7 @@ func (f *Factory) CreateMetricsScraper(
 	ctx context.Context,
 	_ *zap.Logger,
 	config internal.Config,
-) (scraperhelper.MetricsScraper, error) {
+) (scraperhelper.Scraper, error) {
 	cfg := config.(*Config)
 	s := newPagingScraper(ctx, cfg)
 

--- a/receiver/hostmetricsreceiver/internal/scraper/processesscraper/factory.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processesscraper/factory.go
@@ -44,7 +44,7 @@ func (f *Factory) CreateMetricsScraper(
 	ctx context.Context,
 	_ *zap.Logger,
 	config internal.Config,
-) (scraperhelper.MetricsScraper, error) {
+) (scraperhelper.Scraper, error) {
 	cfg := config.(*Config)
 	s := newProcessesScraper(ctx, cfg)
 

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/factory.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/factory.go
@@ -47,7 +47,7 @@ func (f *Factory) CreateResourceMetricsScraper(
 	_ context.Context,
 	_ *zap.Logger,
 	cfg internal.Config,
-) (scraperhelper.ResourceMetricsScraper, error) {
+) (scraperhelper.Scraper, error) {
 	if runtime.GOOS != "linux" && runtime.GOOS != "windows" {
 		return nil, errors.New("process scraper only available on Linux or Windows")
 	}

--- a/receiver/scraperhelper/scraper.go
+++ b/receiver/scraperhelper/scraper.go
@@ -37,27 +37,14 @@ type baseSettings struct {
 // ScraperOption apply changes to internal options.
 type ScraperOption func(*baseSettings)
 
-// BaseScraper is the base interface for scrapers.
-type BaseScraper interface {
+// Scraper is the base interface for scrapers.
+type Scraper interface {
 	component.Component
 
 	// ID returns the scraper id.
 	ID() config.ComponentID
+	Scrape(context.Context, config.ComponentID) (pdata.Metrics, error)
 }
-
-// MetricsScraper is an interface for scrapers that scrape metrics.
-type MetricsScraper interface {
-	BaseScraper
-	Scrape(context.Context, config.ComponentID) (pdata.MetricSlice, error)
-}
-
-// ResourceMetricsScraper is an interface for scrapers that scrape resource metrics.
-type ResourceMetricsScraper interface {
-	BaseScraper
-	Scrape(context.Context, config.ComponentID) (pdata.ResourceMetricsSlice, error)
-}
-
-var _ BaseScraper = (*baseScraper)(nil)
 
 type baseScraper struct {
 	component.Component
@@ -87,7 +74,7 @@ type metricsScraper struct {
 	ScrapeMetrics
 }
 
-var _ MetricsScraper = (*metricsScraper)(nil)
+var _ Scraper = (*metricsScraper)(nil)
 
 // NewMetricsScraper creates a Scraper that calls Scrape at the specified
 // collection interval, reports observability information, and passes the
@@ -96,7 +83,7 @@ func NewMetricsScraper(
 	name string,
 	scrape ScrapeMetrics,
 	options ...ScraperOption,
-) MetricsScraper {
+) Scraper {
 	set := &baseSettings{}
 	for _, op := range options {
 		op(set)
@@ -113,7 +100,7 @@ func NewMetricsScraper(
 	return ms
 }
 
-func (ms metricsScraper) Scrape(ctx context.Context, receiverID config.ComponentID) (pdata.MetricSlice, error) {
+func (ms metricsScraper) Scrape(ctx context.Context, receiverID config.ComponentID) (pdata.Metrics, error) {
 	ctx = obsreport.ScraperContext(ctx, receiverID, ms.ID())
 	scrp := obsreport.NewScraper(obsreport.ScraperSettings{ReceiverID: receiverID, Scraper: ms.ID()})
 	ctx = scrp.StartMetricsOp(ctx)
@@ -122,8 +109,12 @@ func (ms metricsScraper) Scrape(ctx context.Context, receiverID config.Component
 	if err == nil {
 		count = metrics.Len()
 	}
+	md := pdata.NewMetrics()
+	if metrics.Len() > 0 {
+		metrics.MoveAndAppendTo(md.ResourceMetrics().AppendEmpty().InstrumentationLibraryMetrics().AppendEmpty().Metrics())
+	}
 	scrp.EndMetricsOp(ctx, count, err)
-	return metrics, err
+	return md, err
 }
 
 type resourceMetricsScraper struct {
@@ -131,7 +122,7 @@ type resourceMetricsScraper struct {
 	ScrapeResourceMetrics
 }
 
-var _ ResourceMetricsScraper = (*resourceMetricsScraper)(nil)
+var _ Scraper = (*resourceMetricsScraper)(nil)
 
 // NewResourceMetricsScraper creates a Scraper that calls Scrape at the
 // specified collection interval, reports observability information, and
@@ -140,7 +131,7 @@ func NewResourceMetricsScraper(
 	id config.ComponentID,
 	scrape ScrapeResourceMetrics,
 	options ...ScraperOption,
-) ResourceMetricsScraper {
+) Scraper {
 	set := &baseSettings{}
 	for _, op := range options {
 		op(set)
@@ -157,7 +148,7 @@ func NewResourceMetricsScraper(
 	return rms
 }
 
-func (rms resourceMetricsScraper) Scrape(ctx context.Context, receiverID config.ComponentID) (pdata.ResourceMetricsSlice, error) {
+func (rms resourceMetricsScraper) Scrape(ctx context.Context, receiverID config.ComponentID) (pdata.Metrics, error) {
 	ctx = obsreport.ScraperContext(ctx, receiverID, rms.ID())
 	scrp := obsreport.NewScraper(obsreport.ScraperSettings{ReceiverID: receiverID, Scraper: rms.ID()})
 	ctx = scrp.StartMetricsOp(ctx)
@@ -166,8 +157,14 @@ func (rms resourceMetricsScraper) Scrape(ctx context.Context, receiverID config.
 	if err == nil {
 		count = metricCount(resourceMetrics)
 	}
+
+	md := pdata.NewMetrics()
+	if resourceMetrics.Len() > 0 {
+		resourceMetrics.MoveAndAppendTo(md.ResourceMetrics())
+	}
+
 	scrp.EndMetricsOp(ctx, count, err)
-	return resourceMetrics, err
+	return md, err
 }
 
 func metricCount(resourceMetrics pdata.ResourceMetricsSlice) int {

--- a/receiver/scraperhelper/scrapercontroller.go
+++ b/receiver/scraperhelper/scrapercontroller.go
@@ -51,26 +51,14 @@ func DefaultScraperControllerSettings(cfgType config.Type) ScraperControllerSett
 // ScraperControllerOption apply changes to internal options.
 type ScraperControllerOption func(*controller)
 
-// AddMetricsScraper configures the provided scrape function to be called
+// AddScraper configures the provided scrape function to be called
 // with the specified options, and at the specified collection interval.
 //
 // Observability information will be reported, and the scraped metrics
 // will be passed to the next consumer.
-func AddMetricsScraper(scraper MetricsScraper) ScraperControllerOption {
+func AddScraper(scraper Scraper) ScraperControllerOption {
 	return func(o *controller) {
-		o.metricsScrapers.scrapers = append(o.metricsScrapers.scrapers, scraper)
-	}
-}
-
-// AddResourceMetricsScraper configures the provided scrape function to
-// be called with the specified options, and at the specified collection
-// interval.
-//
-// Observability information will be reported, and the scraped resource
-// metrics will be passed to the next consumer.
-func AddResourceMetricsScraper(scraper ResourceMetricsScraper) ScraperControllerOption {
-	return func(o *controller) {
-		o.resourceMetricScrapers = append(o.resourceMetricScrapers, scraper)
+		o.scrapers = append(o.scrapers, scraper)
 	}
 }
 
@@ -89,8 +77,7 @@ type controller struct {
 	collectionInterval time.Duration
 	nextConsumer       consumer.Metrics
 
-	metricsScrapers        *multiMetricScraper
-	resourceMetricScrapers []ResourceMetricsScraper
+	scrapers []Scraper
 
 	tickerCh <-chan time.Time
 
@@ -121,7 +108,6 @@ func NewScraperControllerReceiver(
 		logger:             logger,
 		collectionInterval: cfg.CollectionInterval,
 		nextConsumer:       nextConsumer,
-		metricsScrapers:    &multiMetricScraper{},
 		done:               make(chan struct{}),
 		terminated:         make(chan struct{}),
 		obsrecv:            obsreport.NewReceiver(obsreport.ReceiverSettings{ReceiverID: cfg.ID(), Transport: ""}),
@@ -131,16 +117,12 @@ func NewScraperControllerReceiver(
 		op(sc)
 	}
 
-	if len(sc.metricsScrapers.scrapers) > 0 {
-		sc.resourceMetricScrapers = append(sc.resourceMetricScrapers, sc.metricsScrapers)
-	}
-
 	return sc, nil
 }
 
 // Start the receiver, invoked during service start.
 func (sc *controller) Start(ctx context.Context, host component.Host) error {
-	for _, scraper := range sc.resourceMetricScrapers {
+	for _, scraper := range sc.scrapers {
 		if err := scraper.Start(ctx, host); err != nil {
 			return err
 		}
@@ -161,11 +143,12 @@ func (sc *controller) Shutdown(ctx context.Context) error {
 	}
 
 	var errs []error
-	for _, scraper := range sc.resourceMetricScrapers {
+	for _, scraper := range sc.scrapers {
 		if err := scraper.Shutdown(ctx); err != nil {
 			errs = append(errs, err)
 		}
 	}
+
 	return consumererror.Combine(errs)
 }
 
@@ -199,16 +182,16 @@ func (sc *controller) scrapeMetricsAndReport(ctx context.Context) {
 	ctx = obsreport.ReceiverContext(ctx, sc.id, "")
 	metrics := pdata.NewMetrics()
 
-	for _, rms := range sc.resourceMetricScrapers {
-		resourceMetrics, err := rms.Scrape(ctx, sc.id)
+	for _, scraper := range sc.scrapers {
+		md, err := scraper.Scrape(ctx, sc.id)
 		if err != nil {
-			sc.logger.Error("Error scraping metrics", zap.Error(err))
+			sc.logger.Error("Error scraping metrics", zap.Error(err), zap.Stringer("scraper", scraper.ID()))
 
 			if !scrapererror.IsPartialScrapeError(err) {
 				continue
 			}
 		}
-		resourceMetrics.MoveAndAppendTo(metrics.ResourceMetrics())
+		md.ResourceMetrics().MoveAndAppendTo(metrics.ResourceMetrics())
 	}
 
 	_, dataPointCount := metrics.MetricAndDataPointCount()
@@ -221,54 +204,4 @@ func (sc *controller) scrapeMetricsAndReport(ctx context.Context) {
 // stopScraping stops the ticker
 func (sc *controller) stopScraping() {
 	close(sc.done)
-}
-
-var _ ResourceMetricsScraper = (*multiMetricScraper)(nil)
-
-type multiMetricScraper struct {
-	scrapers []MetricsScraper
-}
-
-func (mms *multiMetricScraper) ID() config.ComponentID {
-	return config.NewID("")
-}
-
-func (mms *multiMetricScraper) Start(ctx context.Context, host component.Host) error {
-	for _, scraper := range mms.scrapers {
-		if err := scraper.Start(ctx, host); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (mms *multiMetricScraper) Shutdown(ctx context.Context) error {
-	var errs []error
-	for _, scraper := range mms.scrapers {
-		if err := scraper.Shutdown(ctx); err != nil {
-			errs = append(errs, err)
-		}
-	}
-	return consumererror.Combine(errs)
-}
-
-func (mms *multiMetricScraper) Scrape(ctx context.Context, receiverID config.ComponentID) (pdata.ResourceMetricsSlice, error) {
-	rms := pdata.NewResourceMetricsSlice()
-	ilm := rms.AppendEmpty().InstrumentationLibraryMetrics().AppendEmpty()
-
-	var errs scrapererror.ScrapeErrors
-	for _, scraper := range mms.scrapers {
-		metrics, err := scraper.Scrape(ctx, receiverID)
-		if err != nil {
-			partialErr, isPartial := err.(scrapererror.PartialScrapeError)
-			if isPartial {
-				errs.AddPartial(partialErr.Failed, partialErr)
-			}
-
-			continue
-		}
-
-		metrics.MoveAndAppendTo(ilm.Metrics())
-	}
-	return rms, errs.Combine()
 }

--- a/receiver/scraperhelper/scrapercontroller_test.go
+++ b/receiver/scraperhelper/scrapercontroller_test.go
@@ -290,7 +290,7 @@ func configureMetricOptions(test metricsTestCase, initializeChs []chan bool, scr
 
 		scrapeMetricsChs[i] = make(chan int)
 		tsm := &testScrapeMetrics{ch: scrapeMetricsChs[i], err: test.scrapeErr}
-		metricOptions = append(metricOptions, AddMetricsScraper(NewMetricsScraper("scraper", tsm.scrape, scraperOptions...)))
+		metricOptions = append(metricOptions, AddScraper(NewMetricsScraper("scraper", tsm.scrape, scraperOptions...)))
 	}
 
 	for i := 0; i < test.resourceScrapers; i++ {
@@ -308,7 +308,7 @@ func configureMetricOptions(test metricsTestCase, initializeChs []chan bool, scr
 
 		testScrapeResourceMetricsChs[i] = make(chan int)
 		tsrm := &testScrapeResourceMetrics{ch: testScrapeResourceMetricsChs[i], err: test.scrapeErr}
-		metricOptions = append(metricOptions, AddResourceMetricsScraper(NewResourceMetricsScraper(config.NewID("scraper"), tsrm.scrape, scraperOptions...)))
+		metricOptions = append(metricOptions, AddScraper(NewResourceMetricsScraper(config.NewID("scraper"), tsrm.scrape, scraperOptions...)))
 	}
 
 	return metricOptions
@@ -430,8 +430,8 @@ func TestSingleScrapePerTick(t *testing.T) {
 		cfg,
 		zap.NewNop(),
 		new(consumertest.MetricsSink),
-		AddMetricsScraper(NewMetricsScraper("", tsm.scrape)),
-		AddResourceMetricsScraper(NewResourceMetricsScraper(config.NewID("scraper"), tsrm.scrape)),
+		AddScraper(NewMetricsScraper("", tsm.scrape)),
+		AddScraper(NewResourceMetricsScraper(config.NewID("scraper"), tsrm.scrape)),
 		WithTickerChannel(tickerCh),
 	)
 	require.NoError(t, err)


### PR DESCRIPTION
This removes the MetricsScraper and ResourceMetricsScraper interfaces in favor
of a single Scraper interface that scrapes and returns pdata.Metrics. There
were already helper wrappers that allow users to return MetricSlices and
ResourceMetricSlices. These helpers package those results into pdata.Metrics
for the base interface.

Resolves #3085: This also removes the multiMetricScraper which wrapped multiple
scrapers to appear as a single scraper but then functions like scraper.ID()
would be empty. This was evident when trying to log errors and you couldn't
figure out what scraper made the error because it was wrapped in the
multiscraper.
