### PR TITLE
Remove the internal memory ballast

### DIFF
--- a/service/collector.go
+++ b/service/collector.go
@@ -169,11 +169,7 @@ func (col *Collector) Shutdown() {
 func (col *Collector) setupTelemetry() error {
 	col.logger.Info("Setting up own telemetry...")
 
-	// Set memory ballast
-	ballast, ballastSizeBytes := col.createMemoryBallast()
-	runtime.KeepAlive(ballast)
-
-	err := applicationTelemetry.init(col.asyncErrorChannel, ballastSizeBytes, col.logger)
+	err := applicationTelemetry.init(col.asyncErrorChannel, col.logger)
 	if err != nil {
 		return fmt.Errorf("failed to initialize telemetry: %w", err)
 	}
@@ -312,17 +308,6 @@ func (col *Collector) execute(ctx context.Context) error {
 	close(col.stateChannel)
 
 	return consumererror.Combine(errs)
-}
-
-func (col *Collector) createMemoryBallast() ([]byte, uint64) {
-	ballastSizeMiB := builder.MemBallastSize()
-	if ballastSizeMiB > 0 {
-		ballastSizeBytes := uint64(ballastSizeMiB) * 1024 * 1024
-		ballast := make([]byte, ballastSizeBytes)
-		col.logger.Info("Using memory ballast", zap.Int("MiBs", ballastSizeMiB))
-		return ballast, ballastSizeBytes
-	}
-	return nil, 0
 }
 
 // reloadService shutdowns the current col.service and setups a new one according

--- a/service/collector_test.go
+++ b/service/collector_test.go
@@ -106,7 +106,7 @@ func TestCollector_Start(t *testing.T) {
 
 type mockAppTelemetry struct{}
 
-func (tel *mockAppTelemetry) init(chan<- error, uint64, *zap.Logger) error {
+func (tel *mockAppTelemetry) init(chan<- error, *zap.Logger) error {
 	return nil
 }
 

--- a/service/internal/telemetry/process_telemetry.go
+++ b/service/internal/telemetry/process_telemetry.go
@@ -28,7 +28,6 @@ import (
 // ProcessMetricsViews is a struct that contains views related to process metrics (cpu, mem, etc)
 type ProcessMetricsViews struct {
 	prevTimeUnixNano int64
-	ballastSizeBytes uint64
 	views            []*view.View
 	done             chan struct{}
 	proc             *process.Process
@@ -108,10 +107,9 @@ var viewRSSMemory = &view.View{
 
 // NewProcessMetricsViews creates a new set of ProcessMetrics (mem, cpu) that can be used to measure
 // basic information about this process.
-func NewProcessMetricsViews(ballastSizeBytes uint64) (*ProcessMetricsViews, error) {
+func NewProcessMetricsViews() (*ProcessMetricsViews, error) {
 	pmv := &ProcessMetricsViews{
 		prevTimeUnixNano: time.Now().UnixNano(),
-		ballastSizeBytes: ballastSizeBytes,
 		views:            []*view.View{viewProcessUptime, viewAllocMem, viewTotalAllocMem, viewSysMem, viewCPUSeconds, viewRSSMemory},
 		done:             make(chan struct{}),
 	}
@@ -176,8 +174,4 @@ func (pmv *ProcessMetricsViews) updateViews() {
 
 func (pmv *ProcessMetricsViews) readMemStats(ms *runtime.MemStats) {
 	runtime.ReadMemStats(ms)
-	ms.Alloc -= pmv.ballastSizeBytes
-	ms.HeapAlloc -= pmv.ballastSizeBytes
-	ms.HeapSys -= pmv.ballastSizeBytes
-	ms.HeapInuse -= pmv.ballastSizeBytes
 }

--- a/service/internal/telemetry/process_telemetry_test.go
+++ b/service/internal/telemetry/process_telemetry_test.go
@@ -24,9 +24,7 @@ import (
 )
 
 func TestProcessTelemetry(t *testing.T) {
-	const ballastSizeBytes uint64 = 0
-
-	pmv, err := NewProcessMetricsViews(ballastSizeBytes)
+	pmv, err := NewProcessMetricsViews()
 	require.NoError(t, err)
 	assert.NotNil(t, pmv)
 

--- a/service/telemetry.go
+++ b/service/telemetry.go
@@ -38,7 +38,7 @@ import (
 var applicationTelemetry appTelemetryExporter = &appTelemetry{}
 
 type appTelemetryExporter interface {
-	init(asyncErrorChannel chan<- error, ballastSizeBytes uint64, logger *zap.Logger) error
+	init(asyncErrorChannel chan<- error, logger *zap.Logger) error
 	shutdown() error
 }
 
@@ -47,7 +47,7 @@ type appTelemetry struct {
 	server *http.Server
 }
 
-func (tel *appTelemetry) init(asyncErrorChannel chan<- error, ballastSizeBytes uint64, logger *zap.Logger) error {
+func (tel *appTelemetry) init(asyncErrorChannel chan<- error, logger *zap.Logger) error {
 	level := configtelemetry.GetMetricsLevelFlagValue()
 	metricsAddr := telemetry.GetMetricsAddr()
 
@@ -55,7 +55,7 @@ func (tel *appTelemetry) init(asyncErrorChannel chan<- error, ballastSizeBytes u
 		return nil
 	}
 
-	processMetricsViews, err := telemetry2.NewProcessMetricsViews(ballastSizeBytes)
+	processMetricsViews, err := telemetry2.NewProcessMetricsViews()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
A ballast can now be set by the ballastextension.

Closes #3492.
