### PR TITLE
zipkinv2 implement directly Marshaler/Unmarshaler interface

### DIFF
--- a/exporter/zipkinexporter/zipkin.go
+++ b/exporter/zipkinexporter/zipkin.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"net/http"
 
-	zipkinmodel "github.com/openzipkin/zipkin-go/model"
 	"github.com/openzipkin/zipkin-go/proto/zipkin_proto3"
 	zipkinreporter "github.com/openzipkin/zipkin-go/reporter"
 
@@ -74,11 +73,10 @@ func (ze *zipkinExporter) start(_ context.Context, host component.Host) (err err
 }
 
 func (ze *zipkinExporter) pushTraces(ctx context.Context, td pdata.Traces) error {
-	tbatch, err := translator.FromTraces(td)
+	spans, err := translator.FromTraces(td)
 	if err != nil {
 		return consumererror.Permanent(fmt.Errorf("failed to push trace data via Zipkin exporter: %w", err))
 	}
-	spans := tbatch.([]*zipkinmodel.SpanModel)
 
 	body, err := ze.serializer.Serialize(spans)
 	if err != nil {

--- a/receiver/kafkareceiver/zipkin_unmarshaler_test.go
+++ b/receiver/kafkareceiver/zipkin_unmarshaler_test.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/apache/thrift/lib/go/thrift"
 	"github.com/jaegertracing/jaeger/thrift-gen/zipkincore"
-	zipkinmodel "github.com/openzipkin/zipkin-go/model"
 	"github.com/openzipkin/zipkin-go/proto/zipkin_proto3"
 	zipkinreporter "github.com/openzipkin/zipkin-go/reporter"
 	"github.com/stretchr/testify/assert"
@@ -45,9 +44,8 @@ func TestUnmarshalZipkin(t *testing.T) {
 	span.SetTraceID(pdata.NewTraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}))
 	span.SetSpanID(pdata.NewSpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8}))
 	span.SetParentSpanID(pdata.NewSpanID([8]byte{0, 0, 0, 0, 0, 0, 0, 0}))
-	ret, err := v2FromTranslator.FromTraces(td)
+	spans, err := v2FromTranslator.FromTraces(td)
 	require.NoError(t, err)
-	spans := ret.([]*zipkinmodel.SpanModel)
 
 	serializer := zipkinreporter.JSONSerializer{}
 	jsonBytes, err := serializer.Serialize(spans)

--- a/receiver/zipkinreceiver/trace_receiver_test.go
+++ b/receiver/zipkinreceiver/trace_receiver_test.go
@@ -424,7 +424,7 @@ func TestReceiverInvalidContentType(t *testing.T) {
 	zr.ServeHTTP(req, r)
 
 	require.Equal(t, 400, req.Code)
-	require.Equal(t, "unmarshal failed: invalid character 'i' looking for beginning of object key string\n", req.Body.String())
+	require.Equal(t, "invalid character 'i' looking for beginning of object key string\n", req.Body.String())
 }
 
 func TestReceiverConsumerError(t *testing.T) {

--- a/translator/trace/zipkinv2/from_translator.go
+++ b/translator/trace/zipkinv2/from_translator.go
@@ -37,8 +37,7 @@ const (
 )
 
 var (
-	sampled                            = true
-	_       pdata.FromTracesTranslator = (*FromTranslator)(nil)
+	sampled = true
 )
 
 // FromTranslator converts from pdata to Zipkin data model.
@@ -46,7 +45,7 @@ type FromTranslator struct{}
 
 // FromTraces translates internal trace data into Zipkin v2 spans.
 // Returns a slice of Zipkin SpanModel's.
-func (t FromTranslator) FromTraces(td pdata.Traces) (interface{}, error) {
+func (t FromTranslator) FromTraces(td pdata.Traces) ([]*zipkinmodel.SpanModel, error) {
 	resourceSpans := td.ResourceSpans()
 	if resourceSpans.Len() == 0 {
 		return nil, nil

--- a/translator/trace/zipkinv2/from_translator_test.go
+++ b/translator/trace/zipkinv2/from_translator_test.go
@@ -71,12 +71,11 @@ func TestInternalTracesToZipkinSpans(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			zss, err := FromTranslator{}.FromTraces(test.td)
+			spans, err := FromTranslator{}.FromTraces(test.td)
 			assert.EqualValues(t, test.err, err)
 			if test.name == "empty" {
-				assert.Nil(t, zss)
+				assert.Nil(t, spans)
 			} else {
-				spans := zss.([]*zipkinmodel.SpanModel)
 				assert.Equal(t, len(test.zs), len(spans))
 				assert.EqualValues(t, test.zs, spans)
 			}
@@ -90,8 +89,7 @@ func TestInternalTracesToZipkinSpansAndBack(t *testing.T) {
 		"../../../internal/goldendataset/testdata/generated_pict_pairs_spans.txt")
 	assert.NoError(t, err)
 	for _, td := range tds {
-		ret, err := FromTranslator{}.FromTraces(td)
-		zipkinSpans := ret.([]*zipkinmodel.SpanModel)
+		zipkinSpans, err := FromTranslator{}.FromTraces(td)
 		assert.NoError(t, err)
 		assert.Equal(t, td.SpanCount(), len(zipkinSpans))
 		tdFromZS, zErr := ToTranslator{}.ToTraces(zipkinSpans)

--- a/translator/trace/zipkinv2/to_translator.go
+++ b/translator/trace/zipkinv2/to_translator.go
@@ -35,21 +35,14 @@ import (
 	"go.opentelemetry.io/collector/translator/trace/internal/zipkin"
 )
 
-var _ pdata.ToTracesTranslator = (*ToTranslator)(nil)
-
 // ToTranslator converts from Zipkin data model to pdata.
 type ToTranslator struct {
 	// ParseStringTags should be set to true if tags should be converted to numbers when possible.
 	ParseStringTags bool
 }
 
-// ToTraces translates Zipkin v2 spans into internal trace data.
-func (t ToTranslator) ToTraces(src interface{}) (pdata.Traces, error) {
-	zipkinSpans, ok := src.([]*zipkinmodel.SpanModel)
-	if !ok {
-		return pdata.Traces{}, pdata.NewErrIncompatibleType([]*zipkinmodel.SpanModel{}, src)
-	}
-
+// ToTraces translates Zipkin v2 spans into pdata.Traces.
+func (t ToTranslator) ToTraces(zipkinSpans []*zipkinmodel.SpanModel) (pdata.Traces, error) {
 	traceData := pdata.NewTraces()
 	if len(zipkinSpans) == 0 {
 		return traceData, nil


### PR DESCRIPTION
Keep the To/From translator, but update them to accept/return zipkin model.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
