### PR TITLE
Add Nomad examples on "Getting Started"

### DIFF
--- a/website_docs/getting-started.md
+++ b/website_docs/getting-started.md
@@ -100,6 +100,12 @@ features such as automatic upgrade handling, `Service` configuration based on
 the OpenTelemetry configuration, automatic sidecar injection into deployments,
 among others.
 
+### Nomad
+
+Reference job files to deploy the Collector as an agent, gateway and in the
+full demo can be found at
+[https://github.com/hashicorp/nomad-open-telemetry-getting-started](https://github.com/hashicorp/nomad-open-telemetry-getting-started).
+
 ### Linux Packaging
 
 Every Collector release includes DEB and RPM packaging for Linux amd64/arm64


### PR DESCRIPTION
Hi team,

I’m a developer at HashiCorp and I’ve been exploring what it would mean to integrate OpenTelemetry into a system like Nomad. As a first step I ported the “Getting Started” demo and sample files so they be deployed as Nomad jobs.

I don’t know if this is the type of contribution that is expected given the work towards the 1.0 GA, so feel free to close it. 

Also let me know if there are more meaningful contributions that I can make, and that are also more aligned with the roadmap, around integrating OpenTelemetry with Nomad. I would love to help 🙂 
 
Thank you.

**Description:** 
Port examples and demo to Nomad job files.

**Documentation:** 
Add "Getting Started" instructions for Nomad on how to run the collector as an agent or gateway, and the full demo.