### PR TITLE
Add validation on ballast size between memorylimiter and ballastextension

### DIFF
--- a/extension/ballastextension/memory_ballast.go
+++ b/extension/ballastextension/memory_ballast.go
@@ -24,6 +24,8 @@ import (
 
 const megaBytes = 1024 * 1024
 
+var ballastSizeBytes uint64
+
 type memoryBallast struct {
 	cfg         *Config
 	logger      *zap.Logger
@@ -32,7 +34,6 @@ type memoryBallast struct {
 }
 
 func (m *memoryBallast) Start(_ context.Context, _ component.Host) error {
-	var ballastSizeBytes uint64
 	// absolute value supersedes percentage setting
 	if m.cfg.SizeMiB > 0 {
 		ballastSizeBytes = m.cfg.SizeMiB * megaBytes
@@ -65,4 +66,9 @@ func newMemoryBallast(cfg *Config, logger *zap.Logger, getTotalMem func() (uint6
 		logger:      logger,
 		getTotalMem: getTotalMem,
 	}
+}
+
+// GetBallastSize returns the current ballast memory setting in bytes
+func GetBallastSize() uint64 {
+	return ballastSizeBytes
 }

--- a/processor/memorylimiter/README.md
+++ b/processor/memorylimiter/README.md
@@ -32,11 +32,10 @@ value (otherwise memory usage may exceed the hard limit - even if temporarily).
 A good starting point for `spike_limit_mib` is 20% of the hard limit. Bigger
 `spike_limit_mib` values may be necessary for spiky traffic or for longer check intervals.
 
-In addition, if the command line option `mem-ballast-size-mib` is used to specify a
-ballast (see command line help for details), the same value that is provided via the
-command line must also be defined in the memory_limiter processor using `ballast_size_mib`
-config option. If the command line option value and config option value don't match
-the behavior of the memory_limiter processor will be unpredictable.
+In addition, if the ballast size is specified in [ballastextension](../../extension/ballastextension), 
+the same value that is provided via the `ballastextension` must also be defined in 
+the memory_limiter processor using `ballast_size_mib` config option. If ballast size specified in `ballastextension`  
+doesn't match the config option in `memory_limitor` then the `memory_limiter` processor will fail to start.
 
 Note that while the processor can help mitigate out of memory situations,
 it is not a replacement for properly sizing and configuring the
@@ -44,8 +43,8 @@ collector. Keep in mind that if the soft limit is crossed, the collector will
 return errors to all receive operations until enough memory is freed. This will
 result in dropped data.
 
-It is highly recommended to configure the ballast command line option as well as the
-memory_limiter processor on every collector. The ballast should be configured to
+It is highly recommended to configure `ballastextension` as well as the
+`memory_limiter` processor on every collector. The ballast should be configured to
 be 1/3 to 1/2 of the memory allocated to the collector. The memory_limiter
 processor should be the first processor defined in the pipeline (immediately after
 the receivers). This is to ensure that backpressure can be sent to applicable
@@ -80,8 +79,8 @@ For instance setting of 25% with the total memory of 1GiB will result in the spi
 This option is intended to be used only with `limit_percentage`.
 
 The following configuration options can also be modified:
-- `ballast_size_mib` (default = 0): Must match the `mem-ballast-size-mib`
-command line option.
+- `ballast_size_mib` (default = 0): Must match the value of `ballast_size_mib` in `ballastextension` config.
+- `ballast_size_percentage` (default = 0): Must match the value of `size_in_percentage` in `ballastextension` config, and the value range is 0-100
 
 Examples:
 
@@ -98,6 +97,15 @@ processors:
 processors:
   memory_limiter:
     ballast_size_mib: 2000
+    check_interval: 1s
+    limit_percentage: 50
+    spike_limit_percentage: 30
+```
+
+```yaml
+processors:
+  memory_limiter:
+    ballast_size_percentage: 20
     check_interval: 1s
     limit_percentage: 50
     spike_limit_percentage: 30

--- a/processor/memorylimiter/README.md
+++ b/processor/memorylimiter/README.md
@@ -33,9 +33,9 @@ A good starting point for `spike_limit_mib` is 20% of the hard limit. Bigger
 `spike_limit_mib` values may be necessary for spiky traffic or for longer check intervals.
 
 In addition, if the ballast size is specified in [ballastextension](../../extension/ballastextension), 
-the same value that is provided via the `ballastextension` must also be defined in 
-the memory_limiter processor using `ballast_size_mib` config option. If ballast size specified in `ballastextension`  
-doesn't match the config option in `memory_limitor` then the `memory_limiter` processor will fail to start.
+the same value that is provided via the `ballastextension` will be used in `memory_limitor` for
+calculating the total allocated memory for the collector. 
+The `memory_limiter.ballast_size_mib` config has been deprecated and will be removed soon.
 
 Note that while the processor can help mitigate out of memory situations,
 it is not a replacement for properly sizing and configuring the
@@ -78,16 +78,14 @@ This option is used to calculate `spike_limit_mib` from the total available memo
 For instance setting of 25% with the total memory of 1GiB will result in the spike limit of 250MiB.
 This option is intended to be used only with `limit_percentage`.
 
-The following configuration options can also be modified:
-- `ballast_size_mib` (default = 0): Must match the value of `ballast_size_mib` in `ballastextension` config.
-- `ballast_size_percentage` (default = 0): Must match the value of `size_in_percentage` in `ballastextension` config, and the value range is 0-100
+The `ballast_size_mib` configuration has been deprecated and replaced by `ballast_extension`.
+- <del>`ballast_size_mib` (default = 0): Must match the value of `ballast_size_mib` in `ballastextension` config</del>
 
 Examples:
 
 ```yaml
 processors:
   memory_limiter:
-    ballast_size_mib: 2000
     check_interval: 1s
     limit_mib: 4000
     spike_limit_mib: 800
@@ -96,16 +94,6 @@ processors:
 ```yaml
 processors:
   memory_limiter:
-    ballast_size_mib: 2000
-    check_interval: 1s
-    limit_percentage: 50
-    spike_limit_percentage: 30
-```
-
-```yaml
-processors:
-  memory_limiter:
-    ballast_size_percentage: 20
     check_interval: 1s
     limit_percentage: 50
     spike_limit_percentage: 30

--- a/processor/memorylimiter/config.go
+++ b/processor/memorylimiter/config.go
@@ -42,7 +42,13 @@ type Config struct {
 
 	// BallastSizeMiB is the size, in MiB, of the ballast size being used by the
 	// process.
+	// The value has to match the value of `ballast_size_mib` in `ballastextension` if configured.
 	BallastSizeMiB uint32 `mapstructure:"ballast_size_mib"`
+
+	// BallastSizePercentage is the maximum ballast size, in % of the total memory,
+	// targeted to be used by the process.
+	// The value has to match the value of `size_in_percentage` in `ballastextension` if configured.
+	BallastSizePercentage uint32 `mapstructure:"ballast_size_percentage"`
 
 	// MemoryLimitPercentage is the maximum amount of memory, in %, targeted to be
 	// allocated by the process. The fixed memory settings MemoryLimitMiB has a higher precedence.

--- a/processor/memorylimiter/config.go
+++ b/processor/memorylimiter/config.go
@@ -42,13 +42,8 @@ type Config struct {
 
 	// BallastSizeMiB is the size, in MiB, of the ballast size being used by the
 	// process.
-	// The value has to match the value of `ballast_size_mib` in `ballastextension` if configured.
+	// Deprecated: use the ballast size configuration in `ballastextension` component instead.
 	BallastSizeMiB uint32 `mapstructure:"ballast_size_mib"`
-
-	// BallastSizePercentage is the maximum ballast size, in % of the total memory,
-	// targeted to be used by the process.
-	// The value has to match the value of `size_in_percentage` in `ballastextension` if configured.
-	BallastSizePercentage uint32 `mapstructure:"ballast_size_percentage"`
 
 	// MemoryLimitPercentage is the maximum amount of memory, in %, targeted to be
 	// allocated by the process. The fixed memory settings MemoryLimitMiB has a higher precedence.

--- a/processor/memorylimiter/factory.go
+++ b/processor/memorylimiter/factory.go
@@ -63,6 +63,7 @@ func createTracesProcessor(
 		nextConsumer,
 		ml,
 		processorhelper.WithCapabilities(processorCapabilities),
+		processorhelper.WithStart(ml.start),
 		processorhelper.WithShutdown(ml.shutdown))
 }
 

--- a/processor/memorylimiter/factory.go
+++ b/processor/memorylimiter/factory.go
@@ -63,7 +63,6 @@ func createTracesProcessor(
 		nextConsumer,
 		ml,
 		processorhelper.WithCapabilities(processorCapabilities),
-		processorhelper.WithStart(ml.start),
 		processorhelper.WithShutdown(ml.shutdown))
 }
 

--- a/processor/memorylimiter/memorylimiter.go
+++ b/processor/memorylimiter/memorylimiter.go
@@ -24,7 +24,6 @@ import (
 
 	"go.uber.org/zap"
 
-	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configtelemetry"
 	"go.opentelemetry.io/collector/extension/ballastextension"
 	"go.opentelemetry.io/collector/internal/iruntime"
@@ -90,10 +89,8 @@ const minGCIntervalWhenSoftLimited = 10 * time.Second
 
 // newMemoryLimiter returns a new memorylimiter processor.
 func newMemoryLimiter(logger *zap.Logger, cfg *Config) (*memoryLimiter, error) {
-	ballastSize, err := calculateBallastSize(cfg)
-	if err != nil {
-		return nil, err
-	}
+	// Get ballast size in bytes from ballastextension
+	ballastSize := ballastextension.GetBallastSize()
 
 	if cfg.CheckInterval <= 0 {
 		return nil, errCheckIntervalOutOfRange
@@ -145,14 +142,6 @@ func getMemUsageChecker(cfg *Config, logger *zap.Logger) (*memUsageChecker, erro
 		zap.Uint32("limit_percentage", cfg.MemoryLimitPercentage),
 		zap.Uint32("spike_limit_percentage", cfg.MemorySpikePercentage))
 	return newPercentageMemUsageChecker(totalMemory, uint64(cfg.MemoryLimitPercentage), uint64(cfg.MemorySpikePercentage))
-}
-
-func (ml *memoryLimiter) start(_ context.Context, _ component.Host) error {
-	ballastSize := ballastextension.GetBallastSize()
-	if ml.ballastSize != ballastSize {
-		return fmt.Errorf("memorylimiter processor has ballast size set to %d failed to match ballastextension ballast size %d ", ml.ballastSize/mibBytes, ballastSize/mibBytes)
-	}
-	return nil
 }
 
 func (ml *memoryLimiter) shutdown(context.Context) error {
@@ -230,8 +219,7 @@ func (ml *memoryLimiter) readMemStats() *runtime.MemStats {
 	} else if !ml.configMismatchedLogged {
 		// This indicates misconfiguration. Log it once.
 		ml.configMismatchedLogged = true
-		ml.logger.Warn(typeStr + " is likely incorrectly configured. " + ballastSizeMibKey +
-			" must be set equal to ballast size set in ballast extension config.")
+		ml.logger.Warn(ballastSizeMibKey + " in ballast extension is likely incorrectly configured.")
 	}
 
 	return ms
@@ -343,19 +331,4 @@ func newPercentageMemUsageChecker(totalMemory uint64, percentageLimit, percentag
 		return nil, errPercentageLimitOutOfRange
 	}
 	return newFixedMemUsageChecker(percentageLimit*totalMemory/100, percentageSpike*totalMemory/100)
-}
-
-func calculateBallastSize(cfg *Config) (uint64, error) {
-	var ballastSizeBytes uint64
-	if cfg.BallastSizeMiB > 0 {
-		ballastSizeBytes = uint64(cfg.BallastSizeMiB * mibBytes)
-	} else {
-		totalMemory, err := getMemoryFn()
-		if err != nil {
-			return ballastSizeBytes, err
-		}
-		ballastPercentage := cfg.BallastSizePercentage
-		ballastSizeBytes = uint64(ballastPercentage) * totalMemory / 100
-	}
-	return ballastSizeBytes, nil
 }

--- a/service/defaultcomponents/default_extensions_test.go
+++ b/service/defaultcomponents/default_extensions_test.go
@@ -24,6 +24,7 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/extension/ballastextension"
 	"go.opentelemetry.io/collector/extension/bearertokenauthextension"
 	"go.opentelemetry.io/collector/extension/healthcheckextension"
 	"go.opentelemetry.io/collector/extension/pprofextension"
@@ -71,6 +72,13 @@ func TestDefaultExtensions(t *testing.T) {
 			getConfigFn: func() config.Extension {
 				cfg := extFactories["bearertokenauth"].CreateDefaultConfig().(*bearertokenauthextension.Config)
 				cfg.BearerToken = "sometoken"
+				return cfg
+			},
+		},
+		{
+			extension: "memory_ballast",
+			getConfigFn: func() config.Extension {
+				cfg := extFactories["memory_ballast"].CreateDefaultConfig().(*ballastextension.Config)
 				return cfg
 			},
 		},

--- a/service/defaultcomponents/defaults.go
+++ b/service/defaultcomponents/defaults.go
@@ -28,6 +28,7 @@ import (
 	"go.opentelemetry.io/collector/exporter/prometheusexporter"
 	"go.opentelemetry.io/collector/exporter/prometheusremotewriteexporter"
 	"go.opentelemetry.io/collector/exporter/zipkinexporter"
+	"go.opentelemetry.io/collector/extension/ballastextension"
 	"go.opentelemetry.io/collector/extension/bearertokenauthextension"
 	"go.opentelemetry.io/collector/extension/healthcheckextension"
 	"go.opentelemetry.io/collector/extension/oidcauthextension"
@@ -63,6 +64,7 @@ func Components() (
 		oidcauthextension.NewFactory(),
 		pprofextension.NewFactory(),
 		zpagesextension.NewFactory(),
+		ballastextension.NewFactory(),
 	)
 	if err != nil {
 		errs = append(errs, err)


### PR DESCRIPTION
**Description:** <Describe what has changed. 

1. enable `ballastextension` component 
2. Make memory limiter uses the ballast size value from ballast extension if it is enabled.

**Link to tracking Issue:** <Issue number if applicable>
https://github.com/open-telemetry/opentelemetry-collector/issues/2516

**Testing:** 
make all