### PR TITLE
update OTLP to v0.8.0

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -134,6 +134,14 @@ issues:
     - text: "or a comment on this block"
       linters:
         - revive
+    # disabling to suppress deprecation warnings when updating OTLP to v0.8.0
+    # in support of breaking up the work into more manageable PRs
+    - path: pdata/metrics.go
+      linters:
+        - staticcheck
+    - path: pdata/metrics_test.go
+      linters:
+        - staticcheck
 
   # The list of ids of default excludes to include or disable. By default it's empty.
   # See the list of default excludes here https://golangci-lint.run/usage/configuration.

--- a/cmd/pdatagen/internal/metrics_structs.go
+++ b/cmd/pdatagen/internal/metrics_structs.go
@@ -255,7 +255,14 @@ var doubleDataPoint = &messageValueStruct{
 		labelsField,
 		startTimeField,
 		timeField,
-		valueFloat64Field,
+		&primitiveAsDoubleField{
+			originFullName:  "otlpmetrics.NumberDataPoint",
+			fieldName:       "Value",
+			originFieldName: "Value",
+			returnType:      "float64",
+			defaultVal:      "float64(0.0)",
+			testVal:         "float64(17.13)",
+		},
 		exemplarsField,
 	},
 }
@@ -363,7 +370,7 @@ var intExemplar = &messageValueStruct{
 	},
 }
 
-var exemplarSlice = &sliceOfValues{
+var exemplarSlice = &sliceOfPtrs{
 	structName: "ExemplarSlice",
 	element:    exemplar,
 }
@@ -377,7 +384,14 @@ var exemplar = &messageValueStruct{
 	originFullName: "otlpmetrics.Exemplar",
 	fields: []baseField{
 		timeField,
-		valueFloat64Field,
+		&primitiveAsDoubleField{
+			originFullName:  "otlpmetrics.Exemplar",
+			fieldName:       "Value",
+			originFieldName: "Value",
+			returnType:      "float64",
+			defaultVal:      "float64(0.0)",
+			testVal:         "float64(17.13)",
+		},
 		&sliceField{
 			fieldName:       "FilteredLabels",
 			originFieldName: "FilteredLabels",

--- a/cmd/pdatagen/internal/metrics_structs.go
+++ b/cmd/pdatagen/internal/metrics_structs.go
@@ -143,7 +143,7 @@ var intGauge = &messageValueStruct{
 var doubleGauge = &messageValueStruct{
 	structName:     "DoubleGauge",
 	description:    "// DoubleGauge represents the type of a double scalar metric that always exports the \"current value\" for every data point.",
-	originFullName: "otlpmetrics.DoubleGauge",
+	originFullName: "otlpmetrics.Gauge",
 	fields: []baseField{
 		&sliceField{
 			fieldName:       "DataPoints",
@@ -171,7 +171,7 @@ var intSum = &messageValueStruct{
 var doubleSum = &messageValueStruct{
 	structName:     "DoubleSum",
 	description:    "// DoubleSum represents the type of a numeric double scalar metric that is calculated as a sum of all reported measurements over a time interval.",
-	originFullName: "otlpmetrics.DoubleSum",
+	originFullName: "otlpmetrics.Sum",
 	fields: []baseField{
 		aggregationTemporalityField,
 		isMonotonicField,
@@ -200,7 +200,7 @@ var intHistogram = &messageValueStruct{
 var histogram = &messageValueStruct{
 	structName:     "Histogram",
 	description:    "// Histogram represents the type of a metric that is calculated by aggregating as a Histogram of all reported measurements over a time interval.",
-	originFullName: "otlpmetrics.DoubleHistogram",
+	originFullName: "otlpmetrics.Histogram",
 	fields: []baseField{
 		aggregationTemporalityField,
 		&sliceField{
@@ -214,7 +214,7 @@ var histogram = &messageValueStruct{
 var summary = &messageValueStruct{
 	structName:     "Summary",
 	description:    "// Summary represents the type of a metric that is calculated by aggregating as a Summary of all reported double measurements over a time interval.",
-	originFullName: "otlpmetrics.DoubleSummary",
+	originFullName: "otlpmetrics.Summary",
 	fields: []baseField{
 		&sliceField{
 			fieldName:       "DataPoints",
@@ -250,7 +250,7 @@ var doubleDataPointSlice = &sliceOfPtrs{
 var doubleDataPoint = &messageValueStruct{
 	structName:     "DoubleDataPoint",
 	description:    "// DoubleDataPoint is a single data point in a timeseries that describes the time-varying value of a double metric.",
-	originFullName: "otlpmetrics.DoubleDataPoint",
+	originFullName: "otlpmetrics.NumberDataPoint",
 	fields: []baseField{
 		labelsField,
 		startTimeField,
@@ -289,7 +289,7 @@ var histogramDataPointSlice = &sliceOfPtrs{
 var histogramDataPoint = &messageValueStruct{
 	structName:     "HistogramDataPoint",
 	description:    "// HistogramDataPoint is a single data point in a timeseries that describes the time-varying values of a Histogram of values.",
-	originFullName: "otlpmetrics.DoubleHistogramDataPoint",
+	originFullName: "otlpmetrics.HistogramDataPoint",
 	fields: []baseField{
 		labelsField,
 		startTimeField,
@@ -310,7 +310,7 @@ var summaryDataPointSlice = &sliceOfPtrs{
 var summaryDataPoint = &messageValueStruct{
 	structName:     "SummaryDataPoint",
 	description:    "// SummaryDataPoint is a single data point in a timeseries that describes the time-varying values of a Summary of double values.",
-	originFullName: "otlpmetrics.DoubleSummaryDataPoint",
+	originFullName: "otlpmetrics.SummaryDataPoint",
 	fields: []baseField{
 		labelsField,
 		startTimeField,
@@ -333,7 +333,7 @@ var quantileValuesSlice = &sliceOfPtrs{
 var quantileValues = &messageValueStruct{
 	structName:     "ValueAtQuantile",
 	description:    "// ValueAtQuantile is a quantile value within a Summary data point.",
-	originFullName: "otlpmetrics.DoubleSummaryDataPoint_ValueAtQuantile",
+	originFullName: "otlpmetrics.SummaryDataPoint_ValueAtQuantile",
 	fields: []baseField{
 		quantileField,
 		valueFloat64Field,
@@ -374,7 +374,7 @@ var exemplar = &messageValueStruct{
 		"// Exemplars also hold information about the environment when the measurement was recorded,\n" +
 		"// for example the span and trace ID of the active span when the exemplar was recorded.",
 
-	originFullName: "otlpmetrics.DoubleExemplar",
+	originFullName: "otlpmetrics.Exemplar",
 	fields: []baseField{
 		timeField,
 		valueFloat64Field,

--- a/model/internal/data/protogen/common/v1/common.pb.go
+++ b/model/internal/data/protogen/common/v1/common.pb.go
@@ -377,6 +377,7 @@ func (m *StringKeyValue) GetValue() string {
 // InstrumentationLibrary is a message representing the instrumentation library information
 // such as the fully qualified name and version.
 type InstrumentationLibrary struct {
+	// An empty instrumentation library name means the name is unknown.
 	Name    string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
 	Version string `protobuf:"bytes,2,opt,name=version,proto3" json:"version,omitempty"`
 }

--- a/model/internal/data/protogen/logs/v1/logs.pb.go
+++ b/model/internal/data/protogen/logs/v1/logs.pb.go
@@ -33,7 +33,7 @@ const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 type SeverityNumber int32
 
 const (
-	// UNSPECIFIED is the default SeverityNumber, it MUST not be used.
+	// UNSPECIFIED is the default SeverityNumber, it MUST NOT be used.
 	SeverityNumber_SEVERITY_NUMBER_UNSPECIFIED SeverityNumber = 0
 	SeverityNumber_SEVERITY_NUMBER_TRACE       SeverityNumber = 1
 	SeverityNumber_SEVERITY_NUMBER_TRACE2      SeverityNumber = 2
@@ -154,7 +154,7 @@ func (LogRecordFlags) EnumDescriptor() ([]byte, []int) {
 // A collection of InstrumentationLibraryLogs from a Resource.
 type ResourceLogs struct {
 	// The resource for the logs in this message.
-	// If this field is not set then no resource info is known.
+	// If this field is not set then resource info is unknown.
 	Resource v1.Resource `protobuf:"bytes,1,opt,name=resource,proto3" json:"resource"`
 	// A list of InstrumentationLibraryLogs that originate from a resource.
 	InstrumentationLibraryLogs []*InstrumentationLibraryLogs `protobuf:"bytes,2,rep,name=instrumentation_library_logs,json=instrumentationLibraryLogs,proto3" json:"instrumentation_library_logs,omitempty"`
@@ -210,7 +210,8 @@ func (m *ResourceLogs) GetInstrumentationLibraryLogs() []*InstrumentationLibrary
 // A collection of Logs produced by an InstrumentationLibrary.
 type InstrumentationLibraryLogs struct {
 	// The instrumentation library information for the logs in this message.
-	// If this field is not set then no library info is known.
+	// Semantically when InstrumentationLibrary isn't set, it is equivalent with
+	// an empty instrumentation library name (unknown).
 	InstrumentationLibrary v11.InstrumentationLibrary `protobuf:"bytes,1,opt,name=instrumentation_library,json=instrumentationLibrary,proto3" json:"instrumentation_library"`
 	// A list of log records.
 	Logs []*LogRecord `protobuf:"bytes,2,rep,name=logs,proto3" json:"logs,omitempty"`
@@ -264,7 +265,7 @@ func (m *InstrumentationLibraryLogs) GetLogs() []*LogRecord {
 }
 
 // A log record according to OpenTelemetry Log Data Model:
-// https://github.com/open-telemetry/oteps/blob/master/text/logs/0097-log-data-model.md
+// https://github.com/open-telemetry/oteps/blob/main/text/logs/0097-log-data-model.md
 type LogRecord struct {
 	// time_unix_nano is the time when the event occurred.
 	// Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.

--- a/model/internal/data/protogen/trace/v1/trace.pb.go
+++ b/model/internal/data/protogen/trace/v1/trace.pb.go
@@ -38,7 +38,7 @@ const (
 	// Implementations MAY assume SpanKind to be INTERNAL when receiving UNSPECIFIED.
 	Span_SPAN_KIND_UNSPECIFIED Span_SpanKind = 0
 	// Indicates that the span represents an internal operation within an application,
-	// as opposed to an operations happening at the boundaries. Default value.
+	// as opposed to an operation happening at the boundaries. Default value.
 	Span_SPAN_KIND_INTERNAL Span_SpanKind = 1
 	// Indicates that the span covers server-side handling of an RPC or other
 	// remote network request.
@@ -153,7 +153,7 @@ func (Status_DeprecatedStatusCode) EnumDescriptor() ([]byte, []int) {
 }
 
 // For the semantics of status codes see
-// https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#set-status
+// https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#set-status
 type Status_StatusCode int32
 
 const (
@@ -245,7 +245,8 @@ func (m *ResourceSpans) GetInstrumentationLibrarySpans() []*InstrumentationLibra
 // A collection of Spans produced by an InstrumentationLibrary.
 type InstrumentationLibrarySpans struct {
 	// The instrumentation library information for the spans in this message.
-	// If this field is not set then no library info is known.
+	// Semantically when InstrumentationLibrary isn't set, it is equivalent with
+	// an empty instrumentation library name (unknown).
 	InstrumentationLibrary v11.InstrumentationLibrary `protobuf:"bytes,1,opt,name=instrumentation_library,json=instrumentationLibrary,proto3" json:"instrumentation_library"`
 	// A list of Spans that originate from an instrumentation library.
 	Spans []*Span `protobuf:"bytes,2,rep,name=spans,proto3" json:"spans,omitempty"`

--- a/model/pdata/generated_metrics.go
+++ b/model/pdata/generated_metrics.go
@@ -597,10 +597,10 @@ func (ms IntGauge) CopyTo(dest IntGauge) {
 // Must use NewDoubleGauge function to create new instances.
 // Important: zero-initialized instance is not valid for use.
 type DoubleGauge struct {
-	orig *otlpmetrics.DoubleGauge
+	orig *otlpmetrics.Gauge
 }
 
-func newDoubleGauge(orig *otlpmetrics.DoubleGauge) DoubleGauge {
+func newDoubleGauge(orig *otlpmetrics.Gauge) DoubleGauge {
 	return DoubleGauge{orig: orig}
 }
 
@@ -608,7 +608,7 @@ func newDoubleGauge(orig *otlpmetrics.DoubleGauge) DoubleGauge {
 //
 // This must be used only in testing code since no "Set" method available.
 func NewDoubleGauge() DoubleGauge {
-	return newDoubleGauge(&otlpmetrics.DoubleGauge{})
+	return newDoubleGauge(&otlpmetrics.Gauge{})
 }
 
 // DataPoints returns the DataPoints associated with this DoubleGauge.
@@ -683,10 +683,10 @@ func (ms IntSum) CopyTo(dest IntSum) {
 // Must use NewDoubleSum function to create new instances.
 // Important: zero-initialized instance is not valid for use.
 type DoubleSum struct {
-	orig *otlpmetrics.DoubleSum
+	orig *otlpmetrics.Sum
 }
 
-func newDoubleSum(orig *otlpmetrics.DoubleSum) DoubleSum {
+func newDoubleSum(orig *otlpmetrics.Sum) DoubleSum {
 	return DoubleSum{orig: orig}
 }
 
@@ -694,7 +694,7 @@ func newDoubleSum(orig *otlpmetrics.DoubleSum) DoubleSum {
 //
 // This must be used only in testing code since no "Set" method available.
 func NewDoubleSum() DoubleSum {
-	return newDoubleSum(&otlpmetrics.DoubleSum{})
+	return newDoubleSum(&otlpmetrics.Sum{})
 }
 
 // AggregationTemporality returns the aggregationtemporality associated with this DoubleSum.
@@ -780,10 +780,10 @@ func (ms IntHistogram) CopyTo(dest IntHistogram) {
 // Must use NewHistogram function to create new instances.
 // Important: zero-initialized instance is not valid for use.
 type Histogram struct {
-	orig *otlpmetrics.DoubleHistogram
+	orig *otlpmetrics.Histogram
 }
 
-func newHistogram(orig *otlpmetrics.DoubleHistogram) Histogram {
+func newHistogram(orig *otlpmetrics.Histogram) Histogram {
 	return Histogram{orig: orig}
 }
 
@@ -791,7 +791,7 @@ func newHistogram(orig *otlpmetrics.DoubleHistogram) Histogram {
 //
 // This must be used only in testing code since no "Set" method available.
 func NewHistogram() Histogram {
-	return newHistogram(&otlpmetrics.DoubleHistogram{})
+	return newHistogram(&otlpmetrics.Histogram{})
 }
 
 // AggregationTemporality returns the aggregationtemporality associated with this Histogram.
@@ -823,10 +823,10 @@ func (ms Histogram) CopyTo(dest Histogram) {
 // Must use NewSummary function to create new instances.
 // Important: zero-initialized instance is not valid for use.
 type Summary struct {
-	orig *otlpmetrics.DoubleSummary
+	orig *otlpmetrics.Summary
 }
 
-func newSummary(orig *otlpmetrics.DoubleSummary) Summary {
+func newSummary(orig *otlpmetrics.Summary) Summary {
 	return Summary{orig: orig}
 }
 
@@ -834,7 +834,7 @@ func newSummary(orig *otlpmetrics.DoubleSummary) Summary {
 //
 // This must be used only in testing code since no "Set" method available.
 func NewSummary() Summary {
-	return newSummary(&otlpmetrics.DoubleSummary{})
+	return newSummary(&otlpmetrics.Summary{})
 }
 
 // DataPoints returns the DataPoints associated with this Summary.
@@ -1059,19 +1059,19 @@ func (ms IntDataPoint) CopyTo(dest IntDataPoint) {
 // Must use NewDoubleDataPointSlice function to create new instances.
 // Important: zero-initialized instance is not valid for use.
 type DoubleDataPointSlice struct {
-	// orig points to the slice otlpmetrics.DoubleDataPoint field contained somewhere else.
+	// orig points to the slice otlpmetrics.NumberDataPoint field contained somewhere else.
 	// We use pointer-to-slice to be able to modify it in functions like Resize.
-	orig *[]*otlpmetrics.DoubleDataPoint
+	orig *[]*otlpmetrics.NumberDataPoint
 }
 
-func newDoubleDataPointSlice(orig *[]*otlpmetrics.DoubleDataPoint) DoubleDataPointSlice {
+func newDoubleDataPointSlice(orig *[]*otlpmetrics.NumberDataPoint) DoubleDataPointSlice {
 	return DoubleDataPointSlice{orig}
 }
 
 // NewDoubleDataPointSlice creates a DoubleDataPointSlice with 0 elements.
 // Can use "Resize" to initialize with a given length.
 func NewDoubleDataPointSlice() DoubleDataPointSlice {
-	orig := []*otlpmetrics.DoubleDataPoint(nil)
+	orig := []*otlpmetrics.NumberDataPoint(nil)
 	return DoubleDataPointSlice{&orig}
 }
 
@@ -1104,8 +1104,8 @@ func (es DoubleDataPointSlice) CopyTo(dest DoubleDataPointSlice) {
 		}
 		return
 	}
-	origs := make([]otlpmetrics.DoubleDataPoint, srcLen)
-	wrappers := make([]*otlpmetrics.DoubleDataPoint, srcLen)
+	origs := make([]otlpmetrics.NumberDataPoint, srcLen)
+	wrappers := make([]*otlpmetrics.NumberDataPoint, srcLen)
 	for i := range *es.orig {
 		wrappers[i] = &origs[i]
 		newDoubleDataPoint((*es.orig)[i]).CopyTo(newDoubleDataPoint(wrappers[i]))
@@ -1133,13 +1133,13 @@ func (es DoubleDataPointSlice) Resize(newLen int) {
 	}
 
 	if newLen > oldCap {
-		newOrig := make([]*otlpmetrics.DoubleDataPoint, oldLen, newLen)
+		newOrig := make([]*otlpmetrics.NumberDataPoint, oldLen, newLen)
 		copy(newOrig, *es.orig)
 		*es.orig = newOrig
 	}
 
 	// Add extra empty elements to the array.
-	extraOrigs := make([]otlpmetrics.DoubleDataPoint, newLen-oldLen)
+	extraOrigs := make([]otlpmetrics.NumberDataPoint, newLen-oldLen)
 	for i := range extraOrigs {
 		*es.orig = append(*es.orig, &extraOrigs[i])
 	}
@@ -1148,7 +1148,7 @@ func (es DoubleDataPointSlice) Resize(newLen int) {
 // AppendEmpty will append to the end of the slice an empty DoubleDataPoint.
 // It returns the newly added DoubleDataPoint.
 func (es DoubleDataPointSlice) AppendEmpty() DoubleDataPoint {
-	*es.orig = append(*es.orig, &otlpmetrics.DoubleDataPoint{})
+	*es.orig = append(*es.orig, &otlpmetrics.NumberDataPoint{})
 	return es.At(es.Len() - 1)
 }
 
@@ -1192,10 +1192,10 @@ func (es DoubleDataPointSlice) RemoveIf(f func(DoubleDataPoint) bool) {
 // Must use NewDoubleDataPoint function to create new instances.
 // Important: zero-initialized instance is not valid for use.
 type DoubleDataPoint struct {
-	orig *otlpmetrics.DoubleDataPoint
+	orig *otlpmetrics.NumberDataPoint
 }
 
-func newDoubleDataPoint(orig *otlpmetrics.DoubleDataPoint) DoubleDataPoint {
+func newDoubleDataPoint(orig *otlpmetrics.NumberDataPoint) DoubleDataPoint {
 	return DoubleDataPoint{orig: orig}
 }
 
@@ -1203,7 +1203,7 @@ func newDoubleDataPoint(orig *otlpmetrics.DoubleDataPoint) DoubleDataPoint {
 //
 // This must be used only in testing code since no "Set" method available.
 func NewDoubleDataPoint() DoubleDataPoint {
-	return newDoubleDataPoint(&otlpmetrics.DoubleDataPoint{})
+	return newDoubleDataPoint(&otlpmetrics.NumberDataPoint{})
 }
 
 // LabelsMap returns the Labels associated with this DoubleDataPoint.
@@ -1233,12 +1233,14 @@ func (ms DoubleDataPoint) SetTimestamp(v Timestamp) {
 
 // Value returns the value associated with this DoubleDataPoint.
 func (ms DoubleDataPoint) Value() float64 {
-	return (*ms.orig).Value
+	return (*ms.orig).GetAsDouble()
 }
 
 // SetValue replaces the value associated with this DoubleDataPoint.
 func (ms DoubleDataPoint) SetValue(v float64) {
-	(*ms.orig).Value = v
+	(*ms.orig).Value = &otlpmetrics.NumberDataPoint_AsDouble{
+		AsDouble: v,
+	}
 }
 
 // Exemplars returns the Exemplars associated with this DoubleDataPoint.
@@ -1500,19 +1502,19 @@ func (ms IntHistogramDataPoint) CopyTo(dest IntHistogramDataPoint) {
 // Must use NewHistogramDataPointSlice function to create new instances.
 // Important: zero-initialized instance is not valid for use.
 type HistogramDataPointSlice struct {
-	// orig points to the slice otlpmetrics.DoubleHistogramDataPoint field contained somewhere else.
+	// orig points to the slice otlpmetrics.HistogramDataPoint field contained somewhere else.
 	// We use pointer-to-slice to be able to modify it in functions like Resize.
-	orig *[]*otlpmetrics.DoubleHistogramDataPoint
+	orig *[]*otlpmetrics.HistogramDataPoint
 }
 
-func newHistogramDataPointSlice(orig *[]*otlpmetrics.DoubleHistogramDataPoint) HistogramDataPointSlice {
+func newHistogramDataPointSlice(orig *[]*otlpmetrics.HistogramDataPoint) HistogramDataPointSlice {
 	return HistogramDataPointSlice{orig}
 }
 
 // NewHistogramDataPointSlice creates a HistogramDataPointSlice with 0 elements.
 // Can use "Resize" to initialize with a given length.
 func NewHistogramDataPointSlice() HistogramDataPointSlice {
-	orig := []*otlpmetrics.DoubleHistogramDataPoint(nil)
+	orig := []*otlpmetrics.HistogramDataPoint(nil)
 	return HistogramDataPointSlice{&orig}
 }
 
@@ -1545,8 +1547,8 @@ func (es HistogramDataPointSlice) CopyTo(dest HistogramDataPointSlice) {
 		}
 		return
 	}
-	origs := make([]otlpmetrics.DoubleHistogramDataPoint, srcLen)
-	wrappers := make([]*otlpmetrics.DoubleHistogramDataPoint, srcLen)
+	origs := make([]otlpmetrics.HistogramDataPoint, srcLen)
+	wrappers := make([]*otlpmetrics.HistogramDataPoint, srcLen)
 	for i := range *es.orig {
 		wrappers[i] = &origs[i]
 		newHistogramDataPoint((*es.orig)[i]).CopyTo(newHistogramDataPoint(wrappers[i]))
@@ -1574,13 +1576,13 @@ func (es HistogramDataPointSlice) Resize(newLen int) {
 	}
 
 	if newLen > oldCap {
-		newOrig := make([]*otlpmetrics.DoubleHistogramDataPoint, oldLen, newLen)
+		newOrig := make([]*otlpmetrics.HistogramDataPoint, oldLen, newLen)
 		copy(newOrig, *es.orig)
 		*es.orig = newOrig
 	}
 
 	// Add extra empty elements to the array.
-	extraOrigs := make([]otlpmetrics.DoubleHistogramDataPoint, newLen-oldLen)
+	extraOrigs := make([]otlpmetrics.HistogramDataPoint, newLen-oldLen)
 	for i := range extraOrigs {
 		*es.orig = append(*es.orig, &extraOrigs[i])
 	}
@@ -1589,7 +1591,7 @@ func (es HistogramDataPointSlice) Resize(newLen int) {
 // AppendEmpty will append to the end of the slice an empty HistogramDataPoint.
 // It returns the newly added HistogramDataPoint.
 func (es HistogramDataPointSlice) AppendEmpty() HistogramDataPoint {
-	*es.orig = append(*es.orig, &otlpmetrics.DoubleHistogramDataPoint{})
+	*es.orig = append(*es.orig, &otlpmetrics.HistogramDataPoint{})
 	return es.At(es.Len() - 1)
 }
 
@@ -1633,10 +1635,10 @@ func (es HistogramDataPointSlice) RemoveIf(f func(HistogramDataPoint) bool) {
 // Must use NewHistogramDataPoint function to create new instances.
 // Important: zero-initialized instance is not valid for use.
 type HistogramDataPoint struct {
-	orig *otlpmetrics.DoubleHistogramDataPoint
+	orig *otlpmetrics.HistogramDataPoint
 }
 
-func newHistogramDataPoint(orig *otlpmetrics.DoubleHistogramDataPoint) HistogramDataPoint {
+func newHistogramDataPoint(orig *otlpmetrics.HistogramDataPoint) HistogramDataPoint {
 	return HistogramDataPoint{orig: orig}
 }
 
@@ -1644,7 +1646,7 @@ func newHistogramDataPoint(orig *otlpmetrics.DoubleHistogramDataPoint) Histogram
 //
 // This must be used only in testing code since no "Set" method available.
 func NewHistogramDataPoint() HistogramDataPoint {
-	return newHistogramDataPoint(&otlpmetrics.DoubleHistogramDataPoint{})
+	return newHistogramDataPoint(&otlpmetrics.HistogramDataPoint{})
 }
 
 // LabelsMap returns the Labels associated with this HistogramDataPoint.
@@ -1737,19 +1739,19 @@ func (ms HistogramDataPoint) CopyTo(dest HistogramDataPoint) {
 // Must use NewSummaryDataPointSlice function to create new instances.
 // Important: zero-initialized instance is not valid for use.
 type SummaryDataPointSlice struct {
-	// orig points to the slice otlpmetrics.DoubleSummaryDataPoint field contained somewhere else.
+	// orig points to the slice otlpmetrics.SummaryDataPoint field contained somewhere else.
 	// We use pointer-to-slice to be able to modify it in functions like Resize.
-	orig *[]*otlpmetrics.DoubleSummaryDataPoint
+	orig *[]*otlpmetrics.SummaryDataPoint
 }
 
-func newSummaryDataPointSlice(orig *[]*otlpmetrics.DoubleSummaryDataPoint) SummaryDataPointSlice {
+func newSummaryDataPointSlice(orig *[]*otlpmetrics.SummaryDataPoint) SummaryDataPointSlice {
 	return SummaryDataPointSlice{orig}
 }
 
 // NewSummaryDataPointSlice creates a SummaryDataPointSlice with 0 elements.
 // Can use "Resize" to initialize with a given length.
 func NewSummaryDataPointSlice() SummaryDataPointSlice {
-	orig := []*otlpmetrics.DoubleSummaryDataPoint(nil)
+	orig := []*otlpmetrics.SummaryDataPoint(nil)
 	return SummaryDataPointSlice{&orig}
 }
 
@@ -1782,8 +1784,8 @@ func (es SummaryDataPointSlice) CopyTo(dest SummaryDataPointSlice) {
 		}
 		return
 	}
-	origs := make([]otlpmetrics.DoubleSummaryDataPoint, srcLen)
-	wrappers := make([]*otlpmetrics.DoubleSummaryDataPoint, srcLen)
+	origs := make([]otlpmetrics.SummaryDataPoint, srcLen)
+	wrappers := make([]*otlpmetrics.SummaryDataPoint, srcLen)
 	for i := range *es.orig {
 		wrappers[i] = &origs[i]
 		newSummaryDataPoint((*es.orig)[i]).CopyTo(newSummaryDataPoint(wrappers[i]))
@@ -1811,13 +1813,13 @@ func (es SummaryDataPointSlice) Resize(newLen int) {
 	}
 
 	if newLen > oldCap {
-		newOrig := make([]*otlpmetrics.DoubleSummaryDataPoint, oldLen, newLen)
+		newOrig := make([]*otlpmetrics.SummaryDataPoint, oldLen, newLen)
 		copy(newOrig, *es.orig)
 		*es.orig = newOrig
 	}
 
 	// Add extra empty elements to the array.
-	extraOrigs := make([]otlpmetrics.DoubleSummaryDataPoint, newLen-oldLen)
+	extraOrigs := make([]otlpmetrics.SummaryDataPoint, newLen-oldLen)
 	for i := range extraOrigs {
 		*es.orig = append(*es.orig, &extraOrigs[i])
 	}
@@ -1826,7 +1828,7 @@ func (es SummaryDataPointSlice) Resize(newLen int) {
 // AppendEmpty will append to the end of the slice an empty SummaryDataPoint.
 // It returns the newly added SummaryDataPoint.
 func (es SummaryDataPointSlice) AppendEmpty() SummaryDataPoint {
-	*es.orig = append(*es.orig, &otlpmetrics.DoubleSummaryDataPoint{})
+	*es.orig = append(*es.orig, &otlpmetrics.SummaryDataPoint{})
 	return es.At(es.Len() - 1)
 }
 
@@ -1870,10 +1872,10 @@ func (es SummaryDataPointSlice) RemoveIf(f func(SummaryDataPoint) bool) {
 // Must use NewSummaryDataPoint function to create new instances.
 // Important: zero-initialized instance is not valid for use.
 type SummaryDataPoint struct {
-	orig *otlpmetrics.DoubleSummaryDataPoint
+	orig *otlpmetrics.SummaryDataPoint
 }
 
-func newSummaryDataPoint(orig *otlpmetrics.DoubleSummaryDataPoint) SummaryDataPoint {
+func newSummaryDataPoint(orig *otlpmetrics.SummaryDataPoint) SummaryDataPoint {
 	return SummaryDataPoint{orig: orig}
 }
 
@@ -1881,7 +1883,7 @@ func newSummaryDataPoint(orig *otlpmetrics.DoubleSummaryDataPoint) SummaryDataPo
 //
 // This must be used only in testing code since no "Set" method available.
 func NewSummaryDataPoint() SummaryDataPoint {
-	return newSummaryDataPoint(&otlpmetrics.DoubleSummaryDataPoint{})
+	return newSummaryDataPoint(&otlpmetrics.SummaryDataPoint{})
 }
 
 // LabelsMap returns the Labels associated with this SummaryDataPoint.
@@ -1952,19 +1954,19 @@ func (ms SummaryDataPoint) CopyTo(dest SummaryDataPoint) {
 // Must use NewValueAtQuantileSlice function to create new instances.
 // Important: zero-initialized instance is not valid for use.
 type ValueAtQuantileSlice struct {
-	// orig points to the slice otlpmetrics.DoubleSummaryDataPoint_ValueAtQuantile field contained somewhere else.
+	// orig points to the slice otlpmetrics.SummaryDataPoint_ValueAtQuantile field contained somewhere else.
 	// We use pointer-to-slice to be able to modify it in functions like Resize.
-	orig *[]*otlpmetrics.DoubleSummaryDataPoint_ValueAtQuantile
+	orig *[]*otlpmetrics.SummaryDataPoint_ValueAtQuantile
 }
 
-func newValueAtQuantileSlice(orig *[]*otlpmetrics.DoubleSummaryDataPoint_ValueAtQuantile) ValueAtQuantileSlice {
+func newValueAtQuantileSlice(orig *[]*otlpmetrics.SummaryDataPoint_ValueAtQuantile) ValueAtQuantileSlice {
 	return ValueAtQuantileSlice{orig}
 }
 
 // NewValueAtQuantileSlice creates a ValueAtQuantileSlice with 0 elements.
 // Can use "Resize" to initialize with a given length.
 func NewValueAtQuantileSlice() ValueAtQuantileSlice {
-	orig := []*otlpmetrics.DoubleSummaryDataPoint_ValueAtQuantile(nil)
+	orig := []*otlpmetrics.SummaryDataPoint_ValueAtQuantile(nil)
 	return ValueAtQuantileSlice{&orig}
 }
 
@@ -1997,8 +1999,8 @@ func (es ValueAtQuantileSlice) CopyTo(dest ValueAtQuantileSlice) {
 		}
 		return
 	}
-	origs := make([]otlpmetrics.DoubleSummaryDataPoint_ValueAtQuantile, srcLen)
-	wrappers := make([]*otlpmetrics.DoubleSummaryDataPoint_ValueAtQuantile, srcLen)
+	origs := make([]otlpmetrics.SummaryDataPoint_ValueAtQuantile, srcLen)
+	wrappers := make([]*otlpmetrics.SummaryDataPoint_ValueAtQuantile, srcLen)
 	for i := range *es.orig {
 		wrappers[i] = &origs[i]
 		newValueAtQuantile((*es.orig)[i]).CopyTo(newValueAtQuantile(wrappers[i]))
@@ -2026,13 +2028,13 @@ func (es ValueAtQuantileSlice) Resize(newLen int) {
 	}
 
 	if newLen > oldCap {
-		newOrig := make([]*otlpmetrics.DoubleSummaryDataPoint_ValueAtQuantile, oldLen, newLen)
+		newOrig := make([]*otlpmetrics.SummaryDataPoint_ValueAtQuantile, oldLen, newLen)
 		copy(newOrig, *es.orig)
 		*es.orig = newOrig
 	}
 
 	// Add extra empty elements to the array.
-	extraOrigs := make([]otlpmetrics.DoubleSummaryDataPoint_ValueAtQuantile, newLen-oldLen)
+	extraOrigs := make([]otlpmetrics.SummaryDataPoint_ValueAtQuantile, newLen-oldLen)
 	for i := range extraOrigs {
 		*es.orig = append(*es.orig, &extraOrigs[i])
 	}
@@ -2041,7 +2043,7 @@ func (es ValueAtQuantileSlice) Resize(newLen int) {
 // AppendEmpty will append to the end of the slice an empty ValueAtQuantile.
 // It returns the newly added ValueAtQuantile.
 func (es ValueAtQuantileSlice) AppendEmpty() ValueAtQuantile {
-	*es.orig = append(*es.orig, &otlpmetrics.DoubleSummaryDataPoint_ValueAtQuantile{})
+	*es.orig = append(*es.orig, &otlpmetrics.SummaryDataPoint_ValueAtQuantile{})
 	return es.At(es.Len() - 1)
 }
 
@@ -2085,10 +2087,10 @@ func (es ValueAtQuantileSlice) RemoveIf(f func(ValueAtQuantile) bool) {
 // Must use NewValueAtQuantile function to create new instances.
 // Important: zero-initialized instance is not valid for use.
 type ValueAtQuantile struct {
-	orig *otlpmetrics.DoubleSummaryDataPoint_ValueAtQuantile
+	orig *otlpmetrics.SummaryDataPoint_ValueAtQuantile
 }
 
-func newValueAtQuantile(orig *otlpmetrics.DoubleSummaryDataPoint_ValueAtQuantile) ValueAtQuantile {
+func newValueAtQuantile(orig *otlpmetrics.SummaryDataPoint_ValueAtQuantile) ValueAtQuantile {
 	return ValueAtQuantile{orig: orig}
 }
 
@@ -2096,7 +2098,7 @@ func newValueAtQuantile(orig *otlpmetrics.DoubleSummaryDataPoint_ValueAtQuantile
 //
 // This must be used only in testing code since no "Set" method available.
 func NewValueAtQuantile() ValueAtQuantile {
-	return newValueAtQuantile(&otlpmetrics.DoubleSummaryDataPoint_ValueAtQuantile{})
+	return newValueAtQuantile(&otlpmetrics.SummaryDataPoint_ValueAtQuantile{})
 }
 
 // Quantile returns the quantile associated with this ValueAtQuantile.
@@ -2318,19 +2320,19 @@ func (ms IntExemplar) CopyTo(dest IntExemplar) {
 // Must use NewExemplarSlice function to create new instances.
 // Important: zero-initialized instance is not valid for use.
 type ExemplarSlice struct {
-	// orig points to the slice otlpmetrics.DoubleExemplar field contained somewhere else.
+	// orig points to the slice otlpmetrics.Exemplar field contained somewhere else.
 	// We use pointer-to-slice to be able to modify it in functions like Resize.
-	orig *[]otlpmetrics.DoubleExemplar
+	orig *[]otlpmetrics.Exemplar
 }
 
-func newExemplarSlice(orig *[]otlpmetrics.DoubleExemplar) ExemplarSlice {
+func newExemplarSlice(orig *[]otlpmetrics.Exemplar) ExemplarSlice {
 	return ExemplarSlice{orig}
 }
 
 // NewExemplarSlice creates a ExemplarSlice with 0 elements.
 // Can use "Resize" to initialize with a given length.
 func NewExemplarSlice() ExemplarSlice {
-	orig := []otlpmetrics.DoubleExemplar(nil)
+	orig := []otlpmetrics.Exemplar(nil)
 	return ExemplarSlice{&orig}
 }
 
@@ -2359,7 +2361,7 @@ func (es ExemplarSlice) CopyTo(dest ExemplarSlice) {
 	if srcLen <= destCap {
 		(*dest.orig) = (*dest.orig)[:srcLen:destCap]
 	} else {
-		(*dest.orig) = make([]otlpmetrics.DoubleExemplar, srcLen)
+		(*dest.orig) = make([]otlpmetrics.Exemplar, srcLen)
 	}
 
 	for i := range *es.orig {
@@ -2387,13 +2389,13 @@ func (es ExemplarSlice) Resize(newLen int) {
 	}
 
 	if newLen > oldCap {
-		newOrig := make([]otlpmetrics.DoubleExemplar, oldLen, newLen)
+		newOrig := make([]otlpmetrics.Exemplar, oldLen, newLen)
 		copy(newOrig, *es.orig)
 		*es.orig = newOrig
 	}
 
 	// Add extra empty elements to the array.
-	empty := otlpmetrics.DoubleExemplar{}
+	empty := otlpmetrics.Exemplar{}
 	for i := oldLen; i < newLen; i++ {
 		*es.orig = append(*es.orig, empty)
 	}
@@ -2402,7 +2404,7 @@ func (es ExemplarSlice) Resize(newLen int) {
 // AppendEmpty will append to the end of the slice an empty Exemplar.
 // It returns the newly added Exemplar.
 func (es ExemplarSlice) AppendEmpty() Exemplar {
-	*es.orig = append(*es.orig, otlpmetrics.DoubleExemplar{})
+	*es.orig = append(*es.orig, otlpmetrics.Exemplar{})
 	return es.At(es.Len() - 1)
 }
 
@@ -2449,10 +2451,10 @@ func (es ExemplarSlice) RemoveIf(f func(Exemplar) bool) {
 // Must use NewExemplar function to create new instances.
 // Important: zero-initialized instance is not valid for use.
 type Exemplar struct {
-	orig *otlpmetrics.DoubleExemplar
+	orig *otlpmetrics.Exemplar
 }
 
-func newExemplar(orig *otlpmetrics.DoubleExemplar) Exemplar {
+func newExemplar(orig *otlpmetrics.Exemplar) Exemplar {
 	return Exemplar{orig: orig}
 }
 
@@ -2460,7 +2462,7 @@ func newExemplar(orig *otlpmetrics.DoubleExemplar) Exemplar {
 //
 // This must be used only in testing code since no "Set" method available.
 func NewExemplar() Exemplar {
-	return newExemplar(&otlpmetrics.DoubleExemplar{})
+	return newExemplar(&otlpmetrics.Exemplar{})
 }
 
 // Timestamp returns the timestamp associated with this Exemplar.
@@ -2475,12 +2477,14 @@ func (ms Exemplar) SetTimestamp(v Timestamp) {
 
 // Value returns the value associated with this Exemplar.
 func (ms Exemplar) Value() float64 {
-	return (*ms.orig).Value
+	return (*ms.orig).GetAsDouble()
 }
 
 // SetValue replaces the value associated with this Exemplar.
 func (ms Exemplar) SetValue(v float64) {
-	(*ms.orig).Value = v
+	(*ms.orig).Value = &otlpmetrics.Exemplar_AsDouble{
+		AsDouble: v,
+	}
 }
 
 // FilteredLabels returns the FilteredLabels associated with this Exemplar.

--- a/model/pdata/generated_metrics.go
+++ b/model/pdata/generated_metrics.go
@@ -2371,7 +2371,6 @@ func (es ExemplarSlice) CopyTo(dest ExemplarSlice) {
 		wrappers[i] = &origs[i]
 		newExemplar((*es.orig)[i]).CopyTo(newExemplar(wrappers[i]))
 	}
-
 	*dest.orig = wrappers
 }
 

--- a/model/pdata/generated_metrics_test.go
+++ b/model/pdata/generated_metrics_test.go
@@ -1752,7 +1752,7 @@ func TestIntExemplar_FilteredLabels(t *testing.T) {
 func TestExemplarSlice(t *testing.T) {
 	es := NewExemplarSlice()
 	assert.EqualValues(t, 0, es.Len())
-	es = newExemplarSlice(&[]otlpmetrics.Exemplar{})
+	es = newExemplarSlice(&[]*otlpmetrics.Exemplar{})
 	assert.EqualValues(t, 0, es.Len())
 
 	es.Resize(7)

--- a/model/pdata/generated_metrics_test.go
+++ b/model/pdata/generated_metrics_test.go
@@ -758,11 +758,11 @@ func TestIntDataPoint_Exemplars(t *testing.T) {
 func TestDoubleDataPointSlice(t *testing.T) {
 	es := NewDoubleDataPointSlice()
 	assert.EqualValues(t, 0, es.Len())
-	es = newDoubleDataPointSlice(&[]*otlpmetrics.DoubleDataPoint{})
+	es = newDoubleDataPointSlice(&[]*otlpmetrics.NumberDataPoint{})
 	assert.EqualValues(t, 0, es.Len())
 
 	es.Resize(7)
-	emptyVal := newDoubleDataPoint(&otlpmetrics.DoubleDataPoint{})
+	emptyVal := newDoubleDataPoint(&otlpmetrics.NumberDataPoint{})
 	testVal := generateTestDoubleDataPoint()
 	assert.EqualValues(t, 7, es.Len())
 	for i := 0; i < es.Len(); i++ {
@@ -789,17 +789,17 @@ func TestDoubleDataPointSlice_CopyTo(t *testing.T) {
 
 func TestDoubleDataPointSlice_Resize(t *testing.T) {
 	es := generateTestDoubleDataPointSlice()
-	emptyVal := newDoubleDataPoint(&otlpmetrics.DoubleDataPoint{})
+	emptyVal := newDoubleDataPoint(&otlpmetrics.NumberDataPoint{})
 	// Test Resize less elements.
 	const resizeSmallLen = 4
-	expectedEs := make(map[*otlpmetrics.DoubleDataPoint]bool, resizeSmallLen)
+	expectedEs := make(map[*otlpmetrics.NumberDataPoint]bool, resizeSmallLen)
 	for i := 0; i < resizeSmallLen; i++ {
 		expectedEs[es.At(i).orig] = true
 	}
 	assert.Equal(t, resizeSmallLen, len(expectedEs))
 	es.Resize(resizeSmallLen)
 	assert.Equal(t, resizeSmallLen, es.Len())
-	foundEs := make(map[*otlpmetrics.DoubleDataPoint]bool, resizeSmallLen)
+	foundEs := make(map[*otlpmetrics.NumberDataPoint]bool, resizeSmallLen)
 	for i := 0; i < es.Len(); i++ {
 		foundEs[es.At(i).orig] = true
 	}
@@ -808,14 +808,14 @@ func TestDoubleDataPointSlice_Resize(t *testing.T) {
 	// Test Resize more elements.
 	const resizeLargeLen = 7
 	oldLen := es.Len()
-	expectedEs = make(map[*otlpmetrics.DoubleDataPoint]bool, oldLen)
+	expectedEs = make(map[*otlpmetrics.NumberDataPoint]bool, oldLen)
 	for i := 0; i < oldLen; i++ {
 		expectedEs[es.At(i).orig] = true
 	}
 	assert.Equal(t, oldLen, len(expectedEs))
 	es.Resize(resizeLargeLen)
 	assert.Equal(t, resizeLargeLen, es.Len())
-	foundEs = make(map[*otlpmetrics.DoubleDataPoint]bool, oldLen)
+	foundEs = make(map[*otlpmetrics.NumberDataPoint]bool, oldLen)
 	for i := 0; i < oldLen; i++ {
 		foundEs[es.At(i).orig] = true
 	}
@@ -1108,11 +1108,11 @@ func TestIntHistogramDataPoint_Exemplars(t *testing.T) {
 func TestHistogramDataPointSlice(t *testing.T) {
 	es := NewHistogramDataPointSlice()
 	assert.EqualValues(t, 0, es.Len())
-	es = newHistogramDataPointSlice(&[]*otlpmetrics.DoubleHistogramDataPoint{})
+	es = newHistogramDataPointSlice(&[]*otlpmetrics.HistogramDataPoint{})
 	assert.EqualValues(t, 0, es.Len())
 
 	es.Resize(7)
-	emptyVal := newHistogramDataPoint(&otlpmetrics.DoubleHistogramDataPoint{})
+	emptyVal := newHistogramDataPoint(&otlpmetrics.HistogramDataPoint{})
 	testVal := generateTestHistogramDataPoint()
 	assert.EqualValues(t, 7, es.Len())
 	for i := 0; i < es.Len(); i++ {
@@ -1139,17 +1139,17 @@ func TestHistogramDataPointSlice_CopyTo(t *testing.T) {
 
 func TestHistogramDataPointSlice_Resize(t *testing.T) {
 	es := generateTestHistogramDataPointSlice()
-	emptyVal := newHistogramDataPoint(&otlpmetrics.DoubleHistogramDataPoint{})
+	emptyVal := newHistogramDataPoint(&otlpmetrics.HistogramDataPoint{})
 	// Test Resize less elements.
 	const resizeSmallLen = 4
-	expectedEs := make(map[*otlpmetrics.DoubleHistogramDataPoint]bool, resizeSmallLen)
+	expectedEs := make(map[*otlpmetrics.HistogramDataPoint]bool, resizeSmallLen)
 	for i := 0; i < resizeSmallLen; i++ {
 		expectedEs[es.At(i).orig] = true
 	}
 	assert.Equal(t, resizeSmallLen, len(expectedEs))
 	es.Resize(resizeSmallLen)
 	assert.Equal(t, resizeSmallLen, es.Len())
-	foundEs := make(map[*otlpmetrics.DoubleHistogramDataPoint]bool, resizeSmallLen)
+	foundEs := make(map[*otlpmetrics.HistogramDataPoint]bool, resizeSmallLen)
 	for i := 0; i < es.Len(); i++ {
 		foundEs[es.At(i).orig] = true
 	}
@@ -1158,14 +1158,14 @@ func TestHistogramDataPointSlice_Resize(t *testing.T) {
 	// Test Resize more elements.
 	const resizeLargeLen = 7
 	oldLen := es.Len()
-	expectedEs = make(map[*otlpmetrics.DoubleHistogramDataPoint]bool, oldLen)
+	expectedEs = make(map[*otlpmetrics.HistogramDataPoint]bool, oldLen)
 	for i := 0; i < oldLen; i++ {
 		expectedEs[es.At(i).orig] = true
 	}
 	assert.Equal(t, oldLen, len(expectedEs))
 	es.Resize(resizeLargeLen)
 	assert.Equal(t, resizeLargeLen, es.Len())
-	foundEs = make(map[*otlpmetrics.DoubleHistogramDataPoint]bool, oldLen)
+	foundEs = make(map[*otlpmetrics.HistogramDataPoint]bool, oldLen)
 	for i := 0; i < oldLen; i++ {
 		foundEs[es.At(i).orig] = true
 	}
@@ -1295,11 +1295,11 @@ func TestHistogramDataPoint_Exemplars(t *testing.T) {
 func TestSummaryDataPointSlice(t *testing.T) {
 	es := NewSummaryDataPointSlice()
 	assert.EqualValues(t, 0, es.Len())
-	es = newSummaryDataPointSlice(&[]*otlpmetrics.DoubleSummaryDataPoint{})
+	es = newSummaryDataPointSlice(&[]*otlpmetrics.SummaryDataPoint{})
 	assert.EqualValues(t, 0, es.Len())
 
 	es.Resize(7)
-	emptyVal := newSummaryDataPoint(&otlpmetrics.DoubleSummaryDataPoint{})
+	emptyVal := newSummaryDataPoint(&otlpmetrics.SummaryDataPoint{})
 	testVal := generateTestSummaryDataPoint()
 	assert.EqualValues(t, 7, es.Len())
 	for i := 0; i < es.Len(); i++ {
@@ -1326,17 +1326,17 @@ func TestSummaryDataPointSlice_CopyTo(t *testing.T) {
 
 func TestSummaryDataPointSlice_Resize(t *testing.T) {
 	es := generateTestSummaryDataPointSlice()
-	emptyVal := newSummaryDataPoint(&otlpmetrics.DoubleSummaryDataPoint{})
+	emptyVal := newSummaryDataPoint(&otlpmetrics.SummaryDataPoint{})
 	// Test Resize less elements.
 	const resizeSmallLen = 4
-	expectedEs := make(map[*otlpmetrics.DoubleSummaryDataPoint]bool, resizeSmallLen)
+	expectedEs := make(map[*otlpmetrics.SummaryDataPoint]bool, resizeSmallLen)
 	for i := 0; i < resizeSmallLen; i++ {
 		expectedEs[es.At(i).orig] = true
 	}
 	assert.Equal(t, resizeSmallLen, len(expectedEs))
 	es.Resize(resizeSmallLen)
 	assert.Equal(t, resizeSmallLen, es.Len())
-	foundEs := make(map[*otlpmetrics.DoubleSummaryDataPoint]bool, resizeSmallLen)
+	foundEs := make(map[*otlpmetrics.SummaryDataPoint]bool, resizeSmallLen)
 	for i := 0; i < es.Len(); i++ {
 		foundEs[es.At(i).orig] = true
 	}
@@ -1345,14 +1345,14 @@ func TestSummaryDataPointSlice_Resize(t *testing.T) {
 	// Test Resize more elements.
 	const resizeLargeLen = 7
 	oldLen := es.Len()
-	expectedEs = make(map[*otlpmetrics.DoubleSummaryDataPoint]bool, oldLen)
+	expectedEs = make(map[*otlpmetrics.SummaryDataPoint]bool, oldLen)
 	for i := 0; i < oldLen; i++ {
 		expectedEs[es.At(i).orig] = true
 	}
 	assert.Equal(t, oldLen, len(expectedEs))
 	es.Resize(resizeLargeLen)
 	assert.Equal(t, resizeLargeLen, es.Len())
-	foundEs = make(map[*otlpmetrics.DoubleSummaryDataPoint]bool, oldLen)
+	foundEs = make(map[*otlpmetrics.SummaryDataPoint]bool, oldLen)
 	for i := 0; i < oldLen; i++ {
 		foundEs[es.At(i).orig] = true
 	}
@@ -1466,11 +1466,11 @@ func TestSummaryDataPoint_QuantileValues(t *testing.T) {
 func TestValueAtQuantileSlice(t *testing.T) {
 	es := NewValueAtQuantileSlice()
 	assert.EqualValues(t, 0, es.Len())
-	es = newValueAtQuantileSlice(&[]*otlpmetrics.DoubleSummaryDataPoint_ValueAtQuantile{})
+	es = newValueAtQuantileSlice(&[]*otlpmetrics.SummaryDataPoint_ValueAtQuantile{})
 	assert.EqualValues(t, 0, es.Len())
 
 	es.Resize(7)
-	emptyVal := newValueAtQuantile(&otlpmetrics.DoubleSummaryDataPoint_ValueAtQuantile{})
+	emptyVal := newValueAtQuantile(&otlpmetrics.SummaryDataPoint_ValueAtQuantile{})
 	testVal := generateTestValueAtQuantile()
 	assert.EqualValues(t, 7, es.Len())
 	for i := 0; i < es.Len(); i++ {
@@ -1497,17 +1497,17 @@ func TestValueAtQuantileSlice_CopyTo(t *testing.T) {
 
 func TestValueAtQuantileSlice_Resize(t *testing.T) {
 	es := generateTestValueAtQuantileSlice()
-	emptyVal := newValueAtQuantile(&otlpmetrics.DoubleSummaryDataPoint_ValueAtQuantile{})
+	emptyVal := newValueAtQuantile(&otlpmetrics.SummaryDataPoint_ValueAtQuantile{})
 	// Test Resize less elements.
 	const resizeSmallLen = 4
-	expectedEs := make(map[*otlpmetrics.DoubleSummaryDataPoint_ValueAtQuantile]bool, resizeSmallLen)
+	expectedEs := make(map[*otlpmetrics.SummaryDataPoint_ValueAtQuantile]bool, resizeSmallLen)
 	for i := 0; i < resizeSmallLen; i++ {
 		expectedEs[es.At(i).orig] = true
 	}
 	assert.Equal(t, resizeSmallLen, len(expectedEs))
 	es.Resize(resizeSmallLen)
 	assert.Equal(t, resizeSmallLen, es.Len())
-	foundEs := make(map[*otlpmetrics.DoubleSummaryDataPoint_ValueAtQuantile]bool, resizeSmallLen)
+	foundEs := make(map[*otlpmetrics.SummaryDataPoint_ValueAtQuantile]bool, resizeSmallLen)
 	for i := 0; i < es.Len(); i++ {
 		foundEs[es.At(i).orig] = true
 	}
@@ -1516,14 +1516,14 @@ func TestValueAtQuantileSlice_Resize(t *testing.T) {
 	// Test Resize more elements.
 	const resizeLargeLen = 7
 	oldLen := es.Len()
-	expectedEs = make(map[*otlpmetrics.DoubleSummaryDataPoint_ValueAtQuantile]bool, oldLen)
+	expectedEs = make(map[*otlpmetrics.SummaryDataPoint_ValueAtQuantile]bool, oldLen)
 	for i := 0; i < oldLen; i++ {
 		expectedEs[es.At(i).orig] = true
 	}
 	assert.Equal(t, oldLen, len(expectedEs))
 	es.Resize(resizeLargeLen)
 	assert.Equal(t, resizeLargeLen, es.Len())
-	foundEs = make(map[*otlpmetrics.DoubleSummaryDataPoint_ValueAtQuantile]bool, oldLen)
+	foundEs = make(map[*otlpmetrics.SummaryDataPoint_ValueAtQuantile]bool, oldLen)
 	for i := 0; i < oldLen; i++ {
 		foundEs[es.At(i).orig] = true
 	}
@@ -1752,11 +1752,11 @@ func TestIntExemplar_FilteredLabels(t *testing.T) {
 func TestExemplarSlice(t *testing.T) {
 	es := NewExemplarSlice()
 	assert.EqualValues(t, 0, es.Len())
-	es = newExemplarSlice(&[]otlpmetrics.DoubleExemplar{})
+	es = newExemplarSlice(&[]otlpmetrics.Exemplar{})
 	assert.EqualValues(t, 0, es.Len())
 
 	es.Resize(7)
-	emptyVal := newExemplar(&otlpmetrics.DoubleExemplar{})
+	emptyVal := newExemplar(&otlpmetrics.Exemplar{})
 	testVal := generateTestExemplar()
 	assert.EqualValues(t, 7, es.Len())
 	for i := 0; i < es.Len(); i++ {
@@ -1783,17 +1783,17 @@ func TestExemplarSlice_CopyTo(t *testing.T) {
 
 func TestExemplarSlice_Resize(t *testing.T) {
 	es := generateTestExemplarSlice()
-	emptyVal := newExemplar(&otlpmetrics.DoubleExemplar{})
+	emptyVal := newExemplar(&otlpmetrics.Exemplar{})
 	// Test Resize less elements.
 	const resizeSmallLen = 4
-	expectedEs := make(map[*otlpmetrics.DoubleExemplar]bool, resizeSmallLen)
+	expectedEs := make(map[*otlpmetrics.Exemplar]bool, resizeSmallLen)
 	for i := 0; i < resizeSmallLen; i++ {
 		expectedEs[es.At(i).orig] = true
 	}
 	assert.Equal(t, resizeSmallLen, len(expectedEs))
 	es.Resize(resizeSmallLen)
 	assert.Equal(t, resizeSmallLen, es.Len())
-	foundEs := make(map[*otlpmetrics.DoubleExemplar]bool, resizeSmallLen)
+	foundEs := make(map[*otlpmetrics.Exemplar]bool, resizeSmallLen)
 	for i := 0; i < es.Len(); i++ {
 		foundEs[es.At(i).orig] = true
 	}
@@ -1802,14 +1802,14 @@ func TestExemplarSlice_Resize(t *testing.T) {
 	// Test Resize more elements.
 	const resizeLargeLen = 7
 	oldLen := es.Len()
-	expectedEs = make(map[*otlpmetrics.DoubleExemplar]bool, oldLen)
+	expectedEs = make(map[*otlpmetrics.Exemplar]bool, oldLen)
 	for i := 0; i < oldLen; i++ {
 		expectedEs[es.At(i).orig] = true
 	}
 	assert.Equal(t, oldLen, len(expectedEs))
 	es.Resize(resizeLargeLen)
 	assert.Equal(t, resizeLargeLen, es.Len())
-	foundEs = make(map[*otlpmetrics.DoubleExemplar]bool, oldLen)
+	foundEs = make(map[*otlpmetrics.Exemplar]bool, oldLen)
 	for i := 0; i < oldLen; i++ {
 		foundEs[es.At(i).orig] = true
 	}

--- a/model/pdata/metrics.go
+++ b/model/pdata/metrics.go
@@ -169,17 +169,17 @@ func (ms Metric) DataType() MetricDataType {
 	switch ms.orig.Data.(type) {
 	case *otlpmetrics.Metric_IntGauge:
 		return MetricDataTypeIntGauge
-	case *otlpmetrics.Metric_DoubleGauge:
+	case *otlpmetrics.Metric_Gauge:
 		return MetricDataTypeDoubleGauge
 	case *otlpmetrics.Metric_IntSum:
 		return MetricDataTypeIntSum
-	case *otlpmetrics.Metric_DoubleSum:
+	case *otlpmetrics.Metric_Sum:
 		return MetricDataTypeDoubleSum
 	case *otlpmetrics.Metric_IntHistogram:
 		return MetricDataTypeIntHistogram
-	case *otlpmetrics.Metric_DoubleHistogram:
+	case *otlpmetrics.Metric_Histogram:
 		return MetricDataTypeHistogram
-	case *otlpmetrics.Metric_DoubleSummary:
+	case *otlpmetrics.Metric_Summary:
 		return MetricDataTypeSummary
 	}
 	return MetricDataTypeNone
@@ -192,17 +192,17 @@ func (ms Metric) SetDataType(ty MetricDataType) {
 	case MetricDataTypeIntGauge:
 		ms.orig.Data = &otlpmetrics.Metric_IntGauge{IntGauge: &otlpmetrics.IntGauge{}}
 	case MetricDataTypeDoubleGauge:
-		ms.orig.Data = &otlpmetrics.Metric_DoubleGauge{DoubleGauge: &otlpmetrics.DoubleGauge{}}
+		ms.orig.Data = &otlpmetrics.Metric_Gauge{Gauge: &otlpmetrics.Gauge{}}
 	case MetricDataTypeIntSum:
 		ms.orig.Data = &otlpmetrics.Metric_IntSum{IntSum: &otlpmetrics.IntSum{}}
 	case MetricDataTypeDoubleSum:
-		ms.orig.Data = &otlpmetrics.Metric_DoubleSum{DoubleSum: &otlpmetrics.DoubleSum{}}
+		ms.orig.Data = &otlpmetrics.Metric_Sum{Sum: &otlpmetrics.Sum{}}
 	case MetricDataTypeIntHistogram:
 		ms.orig.Data = &otlpmetrics.Metric_IntHistogram{IntHistogram: &otlpmetrics.IntHistogram{}}
 	case MetricDataTypeHistogram:
-		ms.orig.Data = &otlpmetrics.Metric_DoubleHistogram{DoubleHistogram: &otlpmetrics.DoubleHistogram{}}
+		ms.orig.Data = &otlpmetrics.Metric_Histogram{Histogram: &otlpmetrics.Histogram{}}
 	case MetricDataTypeSummary:
-		ms.orig.Data = &otlpmetrics.Metric_DoubleSummary{DoubleSummary: &otlpmetrics.DoubleSummary{}}
+		ms.orig.Data = &otlpmetrics.Metric_Summary{Summary: &otlpmetrics.Summary{}}
 	}
 }
 
@@ -217,7 +217,7 @@ func (ms Metric) IntGauge() IntGauge {
 // Calling this function when DataType() != MetricDataTypeDoubleGauge will cause a panic.
 // Calling this function on zero-initialized Metric will cause a panic.
 func (ms Metric) DoubleGauge() DoubleGauge {
-	return newDoubleGauge(ms.orig.Data.(*otlpmetrics.Metric_DoubleGauge).DoubleGauge)
+	return newDoubleGauge(ms.orig.Data.(*otlpmetrics.Metric_Gauge).Gauge)
 }
 
 // IntSum returns the data as IntSum.
@@ -231,7 +231,7 @@ func (ms Metric) IntSum() IntSum {
 // Calling this function when DataType() != MetricDataTypeDoubleSum will cause a panic.
 // Calling this function on zero-initialized Metric will cause a panic.
 func (ms Metric) DoubleSum() DoubleSum {
-	return newDoubleSum(ms.orig.Data.(*otlpmetrics.Metric_DoubleSum).DoubleSum)
+	return newDoubleSum(ms.orig.Data.(*otlpmetrics.Metric_Sum).Sum)
 }
 
 // IntHistogram returns the data as IntHistogram.
@@ -245,14 +245,14 @@ func (ms Metric) IntHistogram() IntHistogram {
 // Calling this function when DataType() != MetricDataTypeHistogram will cause a panic.
 // Calling this function on zero-initialized Metric will cause a panic.
 func (ms Metric) Histogram() Histogram {
-	return newHistogram(ms.orig.Data.(*otlpmetrics.Metric_DoubleHistogram).DoubleHistogram)
+	return newHistogram(ms.orig.Data.(*otlpmetrics.Metric_Histogram).Histogram)
 }
 
 // Summary returns the data as Summary.
 // Calling this function when DataType() != MetricDataTypeSummary will cause a panic.
 // Calling this function on zero-initialized Metric will cause a panic.
 func (ms Metric) Summary() Summary {
-	return newSummary(ms.orig.Data.(*otlpmetrics.Metric_DoubleSummary).DoubleSummary)
+	return newSummary(ms.orig.Data.(*otlpmetrics.Metric_Summary).Summary)
 }
 
 func copyData(src, dest *otlpmetrics.Metric) {
@@ -261,29 +261,29 @@ func copyData(src, dest *otlpmetrics.Metric) {
 		data := &otlpmetrics.Metric_IntGauge{IntGauge: &otlpmetrics.IntGauge{}}
 		newIntGauge(srcData.IntGauge).CopyTo(newIntGauge(data.IntGauge))
 		dest.Data = data
-	case *otlpmetrics.Metric_DoubleGauge:
-		data := &otlpmetrics.Metric_DoubleGauge{DoubleGauge: &otlpmetrics.DoubleGauge{}}
-		newDoubleGauge(srcData.DoubleGauge).CopyTo(newDoubleGauge(data.DoubleGauge))
+	case *otlpmetrics.Metric_Gauge:
+		data := &otlpmetrics.Metric_Gauge{Gauge: &otlpmetrics.Gauge{}}
+		newDoubleGauge(srcData.Gauge).CopyTo(newDoubleGauge(data.Gauge))
 		dest.Data = data
 	case *otlpmetrics.Metric_IntSum:
 		data := &otlpmetrics.Metric_IntSum{IntSum: &otlpmetrics.IntSum{}}
 		newIntSum(srcData.IntSum).CopyTo(newIntSum(data.IntSum))
 		dest.Data = data
-	case *otlpmetrics.Metric_DoubleSum:
-		data := &otlpmetrics.Metric_DoubleSum{DoubleSum: &otlpmetrics.DoubleSum{}}
-		newDoubleSum(srcData.DoubleSum).CopyTo(newDoubleSum(data.DoubleSum))
+	case *otlpmetrics.Metric_Sum:
+		data := &otlpmetrics.Metric_Sum{Sum: &otlpmetrics.Sum{}}
+		newDoubleSum(srcData.Sum).CopyTo(newDoubleSum(data.Sum))
 		dest.Data = data
 	case *otlpmetrics.Metric_IntHistogram:
 		data := &otlpmetrics.Metric_IntHistogram{IntHistogram: &otlpmetrics.IntHistogram{}}
 		newIntHistogram(srcData.IntHistogram).CopyTo(newIntHistogram(data.IntHistogram))
 		dest.Data = data
-	case *otlpmetrics.Metric_DoubleHistogram:
-		data := &otlpmetrics.Metric_DoubleHistogram{DoubleHistogram: &otlpmetrics.DoubleHistogram{}}
-		newHistogram(srcData.DoubleHistogram).CopyTo(newHistogram(data.DoubleHistogram))
+	case *otlpmetrics.Metric_Histogram:
+		data := &otlpmetrics.Metric_Histogram{Histogram: &otlpmetrics.Histogram{}}
+		newHistogram(srcData.Histogram).CopyTo(newHistogram(data.Histogram))
 		dest.Data = data
-	case *otlpmetrics.Metric_DoubleSummary:
-		data := &otlpmetrics.Metric_DoubleSummary{DoubleSummary: &otlpmetrics.DoubleSummary{}}
-		newSummary(srcData.DoubleSummary).CopyTo(newSummary(data.DoubleSummary))
+	case *otlpmetrics.Metric_Summary:
+		data := &otlpmetrics.Metric_Summary{Summary: &otlpmetrics.Summary{}}
+		newSummary(srcData.Summary).CopyTo(newSummary(data.Summary))
 		dest.Data = data
 	}
 }

--- a/model/pdata/metrics_test.go
+++ b/model/pdata/metrics_test.go
@@ -51,8 +51,8 @@ func TestCopyData(t *testing.T) {
 		{
 			name: "DoubleGauge",
 			src: &otlpmetrics.Metric{
-				Data: &otlpmetrics.Metric_DoubleGauge{
-					DoubleGauge: &otlpmetrics.DoubleGauge{},
+				Data: &otlpmetrics.Metric_Gauge{
+					Gauge: &otlpmetrics.Gauge{},
 				},
 			},
 		},
@@ -67,8 +67,8 @@ func TestCopyData(t *testing.T) {
 		{
 			name: "DoubleSum",
 			src: &otlpmetrics.Metric{
-				Data: &otlpmetrics.Metric_DoubleSum{
-					DoubleSum: &otlpmetrics.DoubleSum{},
+				Data: &otlpmetrics.Metric_Sum{
+					Sum: &otlpmetrics.Sum{},
 				},
 			},
 		},
@@ -83,8 +83,8 @@ func TestCopyData(t *testing.T) {
 		{
 			name: "Histogram",
 			src: &otlpmetrics.Metric{
-				Data: &otlpmetrics.Metric_DoubleHistogram{
-					DoubleHistogram: &otlpmetrics.DoubleHistogram{},
+				Data: &otlpmetrics.Metric_Histogram{
+					Histogram: &otlpmetrics.Histogram{},
 				},
 			},
 		},
@@ -516,10 +516,10 @@ func TestOtlpToFromInternalDoubleSumMutating(t *testing.T) {
 								Name:        "new_my_metric_double",
 								Description: "My new metric",
 								Unit:        "1",
-								Data: &otlpmetrics.Metric_DoubleSum{
-									DoubleSum: &otlpmetrics.DoubleSum{
+								Data: &otlpmetrics.Metric_Sum{
+									Sum: &otlpmetrics.Sum{
 										AggregationTemporality: otlpmetrics.AggregationTemporality_AGGREGATION_TEMPORALITY_CUMULATIVE,
-										DataPoints: []*otlpmetrics.DoubleDataPoint{
+										DataPoints: []*otlpmetrics.NumberDataPoint{
 											{
 												Labels: []otlpcommon.StringKeyValue{
 													{
@@ -529,7 +529,9 @@ func TestOtlpToFromInternalDoubleSumMutating(t *testing.T) {
 												},
 												StartTimeUnixNano: startTime + 1,
 												TimeUnixNano:      endTime + 1,
-												Value:             124.1,
+												Value: &otlpmetrics.NumberDataPoint_AsDouble{
+													AsDouble: 124.1,
+												},
 											},
 										},
 									},
@@ -597,10 +599,10 @@ func TestOtlpToFromInternalHistogramMutating(t *testing.T) {
 								Name:        "new_my_metric_histogram",
 								Description: "My new metric",
 								Unit:        "1",
-								Data: &otlpmetrics.Metric_DoubleHistogram{
-									DoubleHistogram: &otlpmetrics.DoubleHistogram{
+								Data: &otlpmetrics.Metric_Histogram{
+									Histogram: &otlpmetrics.Histogram{
 										AggregationTemporality: otlpmetrics.AggregationTemporality_AGGREGATION_TEMPORALITY_DELTA,
-										DataPoints: []*otlpmetrics.DoubleHistogramDataPoint{
+										DataPoints: []*otlpmetrics.HistogramDataPoint{
 											{
 												Labels: []otlpcommon.StringKeyValue{
 													{
@@ -804,10 +806,10 @@ func generateTestProtoDoubleSumMetric() *otlpmetrics.Metric {
 		Name:        "my_metric_double",
 		Description: "My metric",
 		Unit:        "ms",
-		Data: &otlpmetrics.Metric_DoubleSum{
-			DoubleSum: &otlpmetrics.DoubleSum{
+		Data: &otlpmetrics.Metric_Sum{
+			Sum: &otlpmetrics.Sum{
 				AggregationTemporality: otlpmetrics.AggregationTemporality_AGGREGATION_TEMPORALITY_CUMULATIVE,
-				DataPoints: []*otlpmetrics.DoubleDataPoint{
+				DataPoints: []*otlpmetrics.NumberDataPoint{
 					{
 						Labels: []otlpcommon.StringKeyValue{
 							{
@@ -817,7 +819,9 @@ func generateTestProtoDoubleSumMetric() *otlpmetrics.Metric {
 						},
 						StartTimeUnixNano: startTime,
 						TimeUnixNano:      endTime,
-						Value:             123.1,
+						Value: &otlpmetrics.NumberDataPoint_AsDouble{
+							AsDouble: 123.1,
+						},
 					},
 					{
 						Labels: []otlpcommon.StringKeyValue{
@@ -828,7 +832,9 @@ func generateTestProtoDoubleSumMetric() *otlpmetrics.Metric {
 						},
 						StartTimeUnixNano: startTime,
 						TimeUnixNano:      endTime,
-						Value:             456.1,
+						Value: &otlpmetrics.NumberDataPoint_AsDouble{
+							AsDouble: 456.1,
+						},
 					},
 				},
 			},
@@ -841,10 +847,10 @@ func generateTestProtoDoubleHistogramMetric() *otlpmetrics.Metric {
 		Name:        "my_metric_histogram",
 		Description: "My metric",
 		Unit:        "ms",
-		Data: &otlpmetrics.Metric_DoubleHistogram{
-			DoubleHistogram: &otlpmetrics.DoubleHistogram{
+		Data: &otlpmetrics.Metric_Histogram{
+			Histogram: &otlpmetrics.Histogram{
 				AggregationTemporality: otlpmetrics.AggregationTemporality_AGGREGATION_TEMPORALITY_DELTA,
-				DataPoints: []*otlpmetrics.DoubleHistogramDataPoint{
+				DataPoints: []*otlpmetrics.HistogramDataPoint{
 					{
 						Labels: []otlpcommon.StringKeyValue{
 							{
@@ -913,9 +919,9 @@ func generateMetricsEmptyDataPoints() Metrics {
 					{
 						Metrics: []*otlpmetrics.Metric{
 							{
-								Data: &otlpmetrics.Metric_DoubleGauge{
-									DoubleGauge: &otlpmetrics.DoubleGauge{
-										DataPoints: []*otlpmetrics.DoubleDataPoint{
+								Data: &otlpmetrics.Metric_Gauge{
+									Gauge: &otlpmetrics.Gauge{
+										DataPoints: []*otlpmetrics.NumberDataPoint{
 											{},
 										},
 									},


### PR DESCRIPTION
**Description:**
Updating OTLP to version 0.8.0. Here is a checklist of the progress so far:
- [x] bump submodule version
- [x] regenerate protos
- [x] update uses of `DoubleGauge`, `DoubleSum`, `DoubleHistogram`, `DoubleSummary`, `DoubleDataPoint`, `DoubleHistogramDataPoint`, `DoubleSummaryDataPoint`, and `DoubleExemplar`
- [x] update `ExemplarSlice` to use `[]*otlpmetrics.Exemplar`
- [ ] deprecate `IntSum`, `IntGauge` https://github.com/open-telemetry/opentelemetry-proto/blob/f3b0ee0861d304f8f3126686ba9b01c106069cb0/opentelemetry/proto/metrics/v1/metrics.proto#L156
- [ ] deprecate `IntDataPoint` https://github.com/open-telemetry/opentelemetry-proto/blob/f3b0ee0861d304f8f3126686ba9b01c106069cb0/opentelemetry/proto/metrics/v1/metrics.proto#L554
- [ ] deprecate `IntExemplar` https://github.com/open-telemetry/opentelemetry-proto/blob/f3b0ee0861d304f8f3126686ba9b01c106069cb0/opentelemetry/proto/metrics/v1/metrics.proto#L675
- [ ] deprecate `IntHistogram` https://github.com/open-telemetry/opentelemetry-proto/blob/f3b0ee0861d304f8f3126686ba9b01c106069cb0/opentelemetry/proto/metrics/v1/metrics.proto#L170
- [ ] deprecate filtered labels https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/metrics/v1/metrics.proto#L514

**Link to tracking Issue:** Part of #3534 
