### PR TITLE
Make graceful shutdown optional

### DIFF
--- a/service/settings.go
+++ b/service/settings.go
@@ -51,7 +51,7 @@ type CollectorSettings struct {
 	// DisableGracefulShutdown disables the automatic graceful shutdown
 	// of the collector on SIGINT or SIGTERM.
 	// Users who want to handle signals themselves can disable this behavior
-	// and manaully handle the signals to shutdown the collector.
+	// and manually handle the signals to shutdown the collector.
 	DisableGracefulShutdown bool
 
 	// ParserProvider provides the configuration's Parser.

--- a/service/settings.go
+++ b/service/settings.go
@@ -48,6 +48,12 @@ type CollectorSettings struct {
 	// BuildInfo provides collector start information.
 	BuildInfo component.BuildInfo
 
+	// DisableGracefulShutdown disables the automatic graceful shutdown
+	// of the collector on SIGINT or SIGTERM.
+	// Users who want to handle signals themselves can disable this behavior
+	// and manaully handle the signals to shutdown the collector.
+	DisableGracefulShutdown bool
+
 	// ParserProvider provides the configuration's Parser.
 	// If it is not provided a default provider is used. The default provider loads the configuration
 	// from a config file define by the --config command line flag and overrides component's configuration


### PR DESCRIPTION
service.Collector is handling the signal management and implementing a graceful shutdown. This is a problem for collectors that want to wire their own signal handling in cases they want to add custom logic and/or have resources other than the service.Collector to shutdown. Moving the graceful shutdown out of the service package to let the main programs do the wiring themselves.

Fixes #3490
