### PR TITLE
fix DoubleHistogram in pict input data

### DIFF
--- a/internal/goldendataset/testdata/pict_input_metrics.txt
+++ b/internal/goldendataset/testdata/pict_input_metrics.txt
@@ -1,4 +1,4 @@
 NumPtsPerMetric: OnePt, ManyPts
-MetricType: DoubleGauge, MonotonicDoubleSum, NonMonotonicDoubleSum, IntGauge, MonotonicIntSum, NonMonotonicIntSum, IntHistogram, DoubleHistogram
+MetricType: DoubleGauge, MonotonicDoubleSum, NonMonotonicDoubleSum, IntGauge, MonotonicIntSum, NonMonotonicIntSum, IntHistogram, Histogram
 NumLabels: NoLabels, OneLabel, ManyLabels
 NumResourceAttrs: NoAttrs, OneAttr, TwoAttrs


### PR DESCRIPTION
I used the following command to regenerate pict pairs and found that the data didn't match what was currently there, looking at the input data, it looks like`DoubleHistogram` should have been renamed along w/ the generated data.

```
pict ./testdata/pict_input_metrics.txt > testdata/generated_pict_pairs_metrics.txt
```

I don't have a good sense for how to get `pict` generation as part of the build. The hard problem seems to be getting a binary for it built. I just ran the command I installed w/ brew on my machine.