### PR TITLE
Clarify that Watchable is not used for continuous watching

### DIFF
--- a/service/parserprovider/provider.go
+++ b/service/parserprovider/provider.go
@@ -28,9 +28,13 @@ type ParserProvider interface {
 }
 
 // Watchable is an extension for ParserProvider that is implemented if the given provider
-// supports monitoring for configuration updates.
+// supports monitoring of configuration updates.
 type Watchable interface {
-	// WatchForUpdate is used to monitor for updates on the retrieved value.
+	// WatchForUpdate waits for updates on any of the values retrieved from config sources.
+	// It blocks until configuration updates are recieved and can
+	// return an error if anything fails. WatchForUpdate is used once during the
+	// first evaluation of the configuration and is not used to watch configuration
+	// changes continously.
 	WatchForUpdate() error
 }
 

--- a/service/parserprovider/provider.go
+++ b/service/parserprovider/provider.go
@@ -34,7 +34,7 @@ type Watchable interface {
 	// It blocks until configuration updates are received and can
 	// return an error if anything fails. WatchForUpdate is used once during the
 	// first evaluation of the configuration and is not used to watch configuration
-	// changes continously.
+	// changes continuously.
 	WatchForUpdate() error
 }
 

--- a/service/parserprovider/provider.go
+++ b/service/parserprovider/provider.go
@@ -31,7 +31,7 @@ type ParserProvider interface {
 // supports monitoring of configuration updates.
 type Watchable interface {
 	// WatchForUpdate waits for updates on any of the values retrieved from config sources.
-	// It blocks until configuration updates are recieved and can
+	// It blocks until configuration updates are received and can
 	// return an error if anything fails. WatchForUpdate is used once during the
 	// first evaluation of the configuration and is not used to watch configuration
 	// changes continously.

--- a/service/settings.go
+++ b/service/settings.go
@@ -52,6 +52,8 @@ type CollectorSettings struct {
 	// If it is not provided a default provider is used. The default provider loads the configuration
 	// from a config file define by the --config command line flag and overrides component's configuration
 	// properties supplied via --set command line flag.
+	// If the provider is parserprovider.Watchable, collector
+	// may reload the configuration upon error.
 	ParserProvider parserprovider.ParserProvider
 
 	// LoggingOptions provides a way to change behavior of zap logging.


### PR DESCRIPTION
Watching is a loaded term and gives an impression that it's a mechanism that could be used to continuously report new configuration changes. We could have called this interface a Waiter, but it's too late to make changes, hence adding some comments to clarify it's not used for continuous config updates.
