### PR TITLE
Pass a TracerProvider via construct settings to all the components

### DIFF
--- a/component/componenttest/nop_exporter.go
+++ b/component/componenttest/nop_exporter.go
@@ -17,6 +17,7 @@ package componenttest
 import (
 	"context"
 
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/component"
@@ -28,8 +29,9 @@ import (
 // NewNopExporterCreateSettings returns a new nop settings for Create*Exporter functions.
 func NewNopExporterCreateSettings() component.ExporterCreateSettings {
 	return component.ExporterCreateSettings{
-		Logger:    zap.NewNop(),
-		BuildInfo: component.DefaultBuildInfo(),
+		Logger:         zap.NewNop(),
+		TracerProvider: trace.NewNoopTracerProvider(),
+		BuildInfo:      component.DefaultBuildInfo(),
 	}
 }
 

--- a/component/componenttest/nop_extension.go
+++ b/component/componenttest/nop_extension.go
@@ -17,6 +17,7 @@ package componenttest
 import (
 	"context"
 
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/component"
@@ -27,8 +28,9 @@ import (
 // NewNopExtensionCreateSettings returns a new nop settings for Create*Extension functions.
 func NewNopExtensionCreateSettings() component.ExtensionCreateSettings {
 	return component.ExtensionCreateSettings{
-		Logger:    zap.NewNop(),
-		BuildInfo: component.DefaultBuildInfo(),
+		Logger:         zap.NewNop(),
+		TracerProvider: trace.NewNoopTracerProvider(),
+		BuildInfo:      component.DefaultBuildInfo(),
 	}
 }
 

--- a/component/componenttest/nop_processor.go
+++ b/component/componenttest/nop_processor.go
@@ -17,6 +17,7 @@ package componenttest
 import (
 	"context"
 
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/component"
@@ -29,8 +30,9 @@ import (
 // NewNopProcessorCreateSettings returns a new nop settings for Create*Processor functions.
 func NewNopProcessorCreateSettings() component.ProcessorCreateSettings {
 	return component.ProcessorCreateSettings{
-		Logger:    zap.NewNop(),
-		BuildInfo: component.DefaultBuildInfo(),
+		Logger:         zap.NewNop(),
+		TracerProvider: trace.NewNoopTracerProvider(),
+		BuildInfo:      component.DefaultBuildInfo(),
 	}
 }
 

--- a/component/componenttest/nop_receiver.go
+++ b/component/componenttest/nop_receiver.go
@@ -17,6 +17,7 @@ package componenttest
 import (
 	"context"
 
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/component"
@@ -28,8 +29,9 @@ import (
 // NewNopReceiverCreateSettings returns a new nop settings for Create*Receiver functions.
 func NewNopReceiverCreateSettings() component.ReceiverCreateSettings {
 	return component.ReceiverCreateSettings{
-		Logger:    zap.NewNop(),
-		BuildInfo: component.DefaultBuildInfo(),
+		Logger:         zap.NewNop(),
+		TracerProvider: trace.NewNoopTracerProvider(),
+		BuildInfo:      component.DefaultBuildInfo(),
 	}
 }
 

--- a/component/exporter.go
+++ b/component/exporter.go
@@ -17,6 +17,7 @@ package component
 import (
 	"context"
 
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/config"
@@ -51,6 +52,9 @@ type ExporterCreateSettings struct {
 	// Logger that the factory can use during creation and can pass to the created
 	// component to be used later as well.
 	Logger *zap.Logger
+
+	// TracerProvider that the factory can pass to other instrumented third-party libraries.
+	TracerProvider trace.TracerProvider
 
 	// BuildInfo can be used by components for informational purposes
 	BuildInfo BuildInfo

--- a/component/extension.go
+++ b/component/extension.go
@@ -17,6 +17,7 @@ package component
 import (
 	"context"
 
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/config"
@@ -51,6 +52,9 @@ type ExtensionCreateSettings struct {
 	// Logger that the factory can use during creation and can pass to the created
 	// component to be used later as well.
 	Logger *zap.Logger
+
+	// TracerProvider that the factory can pass to other instrumented third-party libraries.
+	TracerProvider trace.TracerProvider
 
 	// BuildInfo can be used by components for informational purposes
 	BuildInfo BuildInfo

--- a/component/processor.go
+++ b/component/processor.go
@@ -17,6 +17,7 @@ package component
 import (
 	"context"
 
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/component/componenterror"
@@ -53,6 +54,9 @@ type ProcessorCreateSettings struct {
 	// Logger that the factory can use during creation and can pass to the created
 	// component to be used later as well.
 	Logger *zap.Logger
+
+	// TracerProvider that the factory can pass to other instrumented third-party libraries.
+	TracerProvider trace.TracerProvider
 
 	// BuildInfo can be used by components for informational purposes
 	BuildInfo BuildInfo

--- a/component/receiver.go
+++ b/component/receiver.go
@@ -17,6 +17,7 @@ package component
 import (
 	"context"
 
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/config"
@@ -60,6 +61,9 @@ type ReceiverCreateSettings struct {
 	// Logger that the factory can use during creation and can pass to the created
 	// component to be used later as well.
 	Logger *zap.Logger
+
+	// TracerProvider that the factory can pass to other instrumented third-party libraries.
+	TracerProvider trace.TracerProvider
 
 	// BuildInfo can be used by components for informational purposes.
 	BuildInfo BuildInfo

--- a/service/internal/builder/exporters_builder_test.go
+++ b/service/internal/builder/exporters_builder_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/component"
@@ -60,7 +61,7 @@ func TestBuildExporters(t *testing.T) {
 		},
 	}
 
-	exporters, err := BuildExporters(zap.NewNop(), component.DefaultBuildInfo(), cfg, factories.Exporters)
+	exporters, err := BuildExporters(zap.NewNop(), trace.NewNoopTracerProvider(), component.DefaultBuildInfo(), cfg, factories.Exporters)
 
 	assert.NoError(t, err)
 	require.NotNil(t, exporters)
@@ -89,7 +90,7 @@ func TestBuildExporters(t *testing.T) {
 	// This should result in creating an exporter that has none of consumption
 	// functions set.
 	delete(cfg.Service.Pipelines, "trace")
-	exporters, err = BuildExporters(zap.NewNop(), component.DefaultBuildInfo(), cfg, factories.Exporters)
+	exporters, err = BuildExporters(zap.NewNop(), trace.NewNoopTracerProvider(), component.DefaultBuildInfo(), cfg, factories.Exporters)
 	assert.NotNil(t, exporters)
 	assert.NoError(t, err)
 
@@ -127,7 +128,7 @@ func TestBuildExporters_BuildLogs(t *testing.T) {
 		},
 	}
 
-	exporters, err := BuildExporters(zap.NewNop(), component.DefaultBuildInfo(), cfg, factories.Exporters)
+	exporters, err := BuildExporters(zap.NewNop(), trace.NewNoopTracerProvider(), component.DefaultBuildInfo(), cfg, factories.Exporters)
 
 	assert.NoError(t, err)
 	require.NotNil(t, exporters)
@@ -152,7 +153,7 @@ func TestBuildExporters_BuildLogs(t *testing.T) {
 	// This should result in creating an exporter that has none of consumption
 	// functions set.
 	delete(cfg.Service.Pipelines, "logs")
-	exporters, err = BuildExporters(zap.NewNop(), component.DefaultBuildInfo(), cfg, factories.Exporters)
+	exporters, err = BuildExporters(zap.NewNop(), trace.NewNoopTracerProvider(), component.DefaultBuildInfo(), cfg, factories.Exporters)
 	assert.NotNil(t, exporters)
 	assert.Nil(t, err)
 
@@ -238,7 +239,7 @@ func TestBuildExporters_NotSupportedDataType(t *testing.T) {
 			cfg, err := configtest.LoadConfigAndValidate(path.Join("testdata", test.configFile), factories)
 			require.Nil(t, err)
 
-			exporters, err := BuildExporters(zap.NewNop(), component.DefaultBuildInfo(), cfg, factories.Exporters)
+			exporters, err := BuildExporters(zap.NewNop(), trace.NewNoopTracerProvider(), component.DefaultBuildInfo(), cfg, factories.Exporters)
 			assert.Error(t, err)
 			assert.Zero(t, len(exporters))
 		})

--- a/service/internal/builder/extensions_builder.go
+++ b/service/internal/builder/extensions_builder.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/component"
@@ -113,6 +114,7 @@ func (exts Extensions) ToMap() map[config.ComponentID]component.Extension {
 // BuildExtensions builds Extensions from config.
 func BuildExtensions(
 	logger *zap.Logger,
+	tracerProvider trace.TracerProvider,
 	buildInfo component.BuildInfo,
 	config *config.Config,
 	factories map[config.Type]component.ExtensionFactory,
@@ -126,8 +128,9 @@ func BuildExtensions(
 		}
 
 		set := component.ExtensionCreateSettings{
-			Logger:    logger.With(zap.Stringer(zapNameKey, extCfg.ID())),
-			BuildInfo: buildInfo,
+			Logger:         logger.With(zap.Stringer(zapNameKey, extCfg.ID())),
+			TracerProvider: tracerProvider,
+			BuildInfo:      buildInfo,
 		}
 		ext, err := buildExtension(context.Background(), factories, set, extCfg)
 		if err != nil {

--- a/service/internal/builder/extensions_builder_test.go
+++ b/service/internal/builder/extensions_builder_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/component"
@@ -115,7 +116,7 @@ func TestService_setupExtensions(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ext, err := BuildExtensions(zap.NewNop(), component.DefaultBuildInfo(), tt.config, tt.factories.Extensions)
+			ext, err := BuildExtensions(zap.NewNop(), trace.NewNoopTracerProvider(), component.DefaultBuildInfo(), tt.config, tt.factories.Extensions)
 
 			assert.Error(t, err)
 			assert.Equal(t, tt.wantErrMsg, err.Error())

--- a/service/internal/builder/pipelines_builder_test.go
+++ b/service/internal/builder/pipelines_builder_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/component"
@@ -112,7 +113,7 @@ func TestBuildPipelines_BuildVarious(t *testing.T) {
 			cfg := createExampleConfig(dataType)
 
 			// BuildProcessors the pipeline
-			allExporters, err := BuildExporters(zap.NewNop(), component.DefaultBuildInfo(), cfg, factories.Exporters)
+			allExporters, err := BuildExporters(zap.NewNop(), trace.NewNoopTracerProvider(), component.DefaultBuildInfo(), cfg, factories.Exporters)
 			if test.shouldFail {
 				assert.Error(t, err)
 				return
@@ -120,7 +121,7 @@ func TestBuildPipelines_BuildVarious(t *testing.T) {
 
 			require.NoError(t, err)
 			require.EqualValues(t, 1, len(allExporters))
-			pipelineProcessors, err := BuildPipelines(zap.NewNop(), component.DefaultBuildInfo(), cfg, allExporters, factories.Processors)
+			pipelineProcessors, err := BuildPipelines(zap.NewNop(), trace.NewNoopTracerProvider(), component.DefaultBuildInfo(), cfg, allExporters, factories.Processors)
 
 			assert.NoError(t, err)
 			require.NotNil(t, pipelineProcessors)
@@ -184,9 +185,9 @@ func testPipeline(t *testing.T, pipelineName string, exporterIDs []config.Compon
 	require.Nil(t, err)
 
 	// BuildProcessors the pipeline
-	allExporters, err := BuildExporters(zap.NewNop(), component.DefaultBuildInfo(), cfg, factories.Exporters)
+	allExporters, err := BuildExporters(zap.NewNop(), trace.NewNoopTracerProvider(), component.DefaultBuildInfo(), cfg, factories.Exporters)
 	assert.NoError(t, err)
-	pipelineProcessors, err := BuildPipelines(zap.NewNop(), component.DefaultBuildInfo(), cfg, allExporters, factories.Processors)
+	pipelineProcessors, err := BuildPipelines(zap.NewNop(), trace.NewNoopTracerProvider(), component.DefaultBuildInfo(), cfg, allExporters, factories.Processors)
 
 	assert.NoError(t, err)
 	require.NotNil(t, pipelineProcessors)
@@ -258,10 +259,10 @@ func TestBuildPipelines_NotSupportedDataType(t *testing.T) {
 			cfg, err := configtest.LoadConfigAndValidate(path.Join("testdata", test.configFile), factories)
 			require.Nil(t, err)
 
-			allExporters, err := BuildExporters(zap.NewNop(), component.DefaultBuildInfo(), cfg, factories.Exporters)
+			allExporters, err := BuildExporters(zap.NewNop(), trace.NewNoopTracerProvider(), component.DefaultBuildInfo(), cfg, factories.Exporters)
 			assert.NoError(t, err)
 
-			pipelineProcessors, err := BuildPipelines(zap.NewNop(), component.DefaultBuildInfo(), cfg, allExporters, factories.Processors)
+			pipelineProcessors, err := BuildPipelines(zap.NewNop(), trace.NewNoopTracerProvider(), component.DefaultBuildInfo(), cfg, allExporters, factories.Processors)
 			assert.Error(t, err)
 			assert.Zero(t, len(pipelineProcessors))
 		})

--- a/service/internal/builder/receivers_builder_test.go
+++ b/service/internal/builder/receivers_builder_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/component"
@@ -100,11 +101,11 @@ func testReceivers(
 	require.NoError(t, err)
 
 	// Build the pipeline
-	allExporters, err := BuildExporters(zap.NewNop(), component.DefaultBuildInfo(), cfg, factories.Exporters)
+	allExporters, err := BuildExporters(zap.NewNop(), trace.NewNoopTracerProvider(), component.DefaultBuildInfo(), cfg, factories.Exporters)
 	assert.NoError(t, err)
-	pipelineProcessors, err := BuildPipelines(zap.NewNop(), component.DefaultBuildInfo(), cfg, allExporters, factories.Processors)
+	pipelineProcessors, err := BuildPipelines(zap.NewNop(), trace.NewNoopTracerProvider(), component.DefaultBuildInfo(), cfg, allExporters, factories.Processors)
 	assert.NoError(t, err)
-	receivers, err := BuildReceivers(zap.NewNop(), component.DefaultBuildInfo(), cfg, pipelineProcessors, factories.Receivers)
+	receivers, err := BuildReceivers(zap.NewNop(), trace.NewNoopTracerProvider(), component.DefaultBuildInfo(), cfg, pipelineProcessors, factories.Receivers)
 
 	assert.NoError(t, err)
 	require.NotNil(t, receivers)
@@ -201,16 +202,16 @@ func TestBuildReceivers_BuildCustom(t *testing.T) {
 			cfg := createExampleConfig(dataType)
 
 			// Build the pipeline
-			allExporters, err := BuildExporters(zap.NewNop(), component.DefaultBuildInfo(), cfg, factories.Exporters)
+			allExporters, err := BuildExporters(zap.NewNop(), trace.NewNoopTracerProvider(), component.DefaultBuildInfo(), cfg, factories.Exporters)
 			if test.shouldFail {
 				assert.Error(t, err)
 				return
 			}
 
 			assert.NoError(t, err)
-			pipelineProcessors, err := BuildPipelines(zap.NewNop(), component.DefaultBuildInfo(), cfg, allExporters, factories.Processors)
+			pipelineProcessors, err := BuildPipelines(zap.NewNop(), trace.NewNoopTracerProvider(), component.DefaultBuildInfo(), cfg, allExporters, factories.Processors)
 			assert.NoError(t, err)
-			receivers, err := BuildReceivers(zap.NewNop(), component.DefaultBuildInfo(), cfg, pipelineProcessors, factories.Receivers)
+			receivers, err := BuildReceivers(zap.NewNop(), trace.NewNoopTracerProvider(), component.DefaultBuildInfo(), cfg, pipelineProcessors, factories.Receivers)
 
 			assert.NoError(t, err)
 			require.NotNil(t, receivers)
@@ -302,11 +303,11 @@ func TestBuildReceivers_Unused(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Build the pipeline
-	allExporters, err := BuildExporters(zap.NewNop(), component.DefaultBuildInfo(), cfg, factories.Exporters)
+	allExporters, err := BuildExporters(zap.NewNop(), trace.NewNoopTracerProvider(), component.DefaultBuildInfo(), cfg, factories.Exporters)
 	assert.NoError(t, err)
-	pipelineProcessors, err := BuildPipelines(zap.NewNop(), component.DefaultBuildInfo(), cfg, allExporters, factories.Processors)
+	pipelineProcessors, err := BuildPipelines(zap.NewNop(), trace.NewNoopTracerProvider(), component.DefaultBuildInfo(), cfg, allExporters, factories.Processors)
 	assert.NoError(t, err)
-	receivers, err := BuildReceivers(zap.NewNop(), component.DefaultBuildInfo(), cfg, pipelineProcessors, factories.Receivers)
+	receivers, err := BuildReceivers(zap.NewNop(), trace.NewNoopTracerProvider(), component.DefaultBuildInfo(), cfg, pipelineProcessors, factories.Receivers)
 	assert.NoError(t, err)
 	assert.NotNil(t, receivers)
 
@@ -338,13 +339,13 @@ func TestBuildReceivers_NotSupportedDataType(t *testing.T) {
 			assert.NoError(t, err)
 			require.NotNil(t, cfg)
 
-			allExporters, err := BuildExporters(zap.NewNop(), component.DefaultBuildInfo(), cfg, factories.Exporters)
+			allExporters, err := BuildExporters(zap.NewNop(), trace.NewNoopTracerProvider(), component.DefaultBuildInfo(), cfg, factories.Exporters)
 			assert.NoError(t, err)
 
-			pipelineProcessors, err := BuildPipelines(zap.NewNop(), component.DefaultBuildInfo(), cfg, allExporters, factories.Processors)
+			pipelineProcessors, err := BuildPipelines(zap.NewNop(), trace.NewNoopTracerProvider(), component.DefaultBuildInfo(), cfg, allExporters, factories.Processors)
 			assert.NoError(t, err)
 
-			receivers, err := BuildReceivers(zap.NewNop(), component.DefaultBuildInfo(), cfg, pipelineProcessors, factories.Receivers)
+			receivers, err := BuildReceivers(zap.NewNop(), trace.NewNoopTracerProvider(), component.DefaultBuildInfo(), cfg, pipelineProcessors, factories.Receivers)
 			assert.Error(t, err)
 			assert.Zero(t, len(receivers))
 		})


### PR DESCRIPTION
Followup PR will use the passed tracer to construct obsreport.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
