### PR TITLE
exporter/prometheusremotewrite: add a WAL implementation without wiring up

### DIFF
--- a/exporter/prometheusremotewriteexporter/wal.go
+++ b/exporter/prometheusremotewriteexporter/wal.go
@@ -1,0 +1,192 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package prometheusremotewriteexporter
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/gogo/protobuf/proto"
+	"github.com/prometheus/prometheus/prompb"
+	"github.com/tidwall/wal"
+)
+
+type prweWAL struct {
+	mu        sync.Mutex // mu protects the fields below.
+	wal       *wal.Log
+	walConfig *walConfig
+	walPath   string
+
+	exportSink func(ctx context.Context, reqL []*prompb.WriteRequest) []error
+
+	stopOnce  sync.Once
+	stopChan  chan struct{}
+	rWALIndex uint64
+	wWALIndex uint64
+}
+
+func newWAL(walConfig *walConfig, exportSink func(context.Context, []*prompb.WriteRequest) []error) (*prweWAL, error) {
+	if walConfig == nil {
+		// There are cases for which the WAL can be disabled.
+		// TODO: Perhaps log that the WAL wasn't enabled.
+		return nil, errNilConfig
+	}
+
+	return &prweWAL{
+		exportSink: exportSink,
+		walConfig:  walConfig,
+		stopChan:   make(chan struct{}),
+	}, nil
+}
+
+func (wc *walConfig) createWAL() (*wal.Log, string, error) {
+	walPath := filepath.Join(wc.Directory, "prom_remotewrite")
+	wal, err := wal.Open(walPath, &wal.Options{
+		SegmentCacheSize: wc.nBeforeTruncation(),
+		NoCopy:           true,
+	})
+	if err != nil {
+		return nil, "", fmt.Errorf("prometheusremotewriteexporter: failed to open WAL: %w", err)
+	}
+	return wal, walPath, nil
+}
+
+type walConfig struct {
+	// Note: These variable names are meant to closely mirror what Prometheus' WAL uses for field names per
+	// https://docs.google.com/document/d/1cCcoFgjDFwU2n823tKuMvrIhzHty4UDyn0IcfUHiyyI/edit#heading=h.mlf37ibqjgov
+	// but also we are using underscores "_" instead of dashes "-".
+	Directory         string        `mapstructure:"directory"`
+	NBeforeTruncation int           `mapstructure:"n_before_truncation"`
+	TruncateFrequency time.Duration `mapstructure:"truncate_frequency"`
+}
+
+func (wc *walConfig) nBeforeTruncation() int {
+	if wc.NBeforeTruncation <= 0 {
+		return 300
+	}
+	return wc.NBeforeTruncation
+}
+
+var (
+	errAlreadyClosed = errors.New("already closed")
+	errNilConfig     = errors.New("expecting a non-nil configuration")
+)
+
+// retrieveWALIndices queries the WriteAheadLog for its current first and last indices.
+func (prwe *prweWAL) retrieveWALIndices(context.Context) (err error) {
+	prwe.mu.Lock()
+	defer prwe.mu.Unlock()
+
+	prwe.closeWAL()
+	wal, walPath, err := prwe.walConfig.createWAL()
+	if err != nil {
+		return err
+	}
+	prwe.wal = wal
+	prwe.walPath = walPath
+
+	prwe.rWALIndex, err = prwe.wal.FirstIndex()
+	if err != nil {
+		return fmt.Errorf("prometheusremotewriteexporter: failed to retrieve the last WAL index: %w", err)
+	}
+
+	prwe.wWALIndex, err = prwe.wal.LastIndex()
+	if err != nil {
+		return fmt.Errorf("prometheusremotewriteexporter: failed to retrieve the first WAL index: %w", err)
+	}
+	return nil
+}
+
+func (prwe *prweWAL) stop() error {
+	err := errAlreadyClosed
+	prwe.stopOnce.Do(func() {
+		close(prwe.stopChan)
+		prwe.closeWAL()
+		err = nil
+	})
+	return err
+}
+
+// start begins reading from the WAL until prwe.stopChan is closed.
+func (prwe *prweWAL) start(ctx context.Context) error {
+	shutdownCtx, cancel := context.WithCancel(ctx)
+	if err := prwe.retrieveWALIndices(shutdownCtx); err != nil {
+		cancel()
+		return err
+	}
+
+	go func() {
+		<-prwe.stopChan
+		cancel()
+	}()
+
+	return nil
+}
+
+func (prwe *prweWAL) closeWAL() {
+	if prwe.wal != nil {
+		prwe.wal.Close()
+		prwe.wal = nil
+	}
+}
+
+// persistToWAL is the routine that'll be hooked into the exporter's receiving side and it'll
+// write them to the Write-Ahead-Log so that shutdowns won't lose data, and that the routine that
+// reads from the WAL can then process the previously serialized requests.
+func (prwe *prweWAL) persistToWAL(requests []*prompb.WriteRequest) error {
+	// Write all the requests to the WAL in a batch.
+	batch := new(wal.Batch)
+	for _, req := range requests {
+		protoBlob, err := proto.Marshal(req)
+		if err != nil {
+			return err
+		}
+		prwe.wWALIndex++
+		batch.Write(prwe.wWALIndex, protoBlob)
+	}
+
+	prwe.mu.Lock()
+	defer prwe.mu.Unlock()
+
+	return prwe.wal.WriteBatch(batch)
+}
+
+func (prwe *prweWAL) readPrompbFromWAL(_ context.Context, index uint64) (wreq *prompb.WriteRequest, err error) {
+	var protoBlob []byte
+	for i := 0; i < 12; i++ {
+		if index <= 0 {
+			index = 1
+		}
+		protoBlob, err = prwe.wal.Read(index)
+		if errors.Is(err, wal.ErrNotFound) {
+			time.Sleep(time.Duration(1<<i) * time.Millisecond)
+			continue
+		}
+		if err != nil {
+			return nil, err
+		}
+
+		req := new(prompb.WriteRequest)
+		if err = proto.Unmarshal(protoBlob, req); err != nil {
+			return nil, err
+		}
+		return req, nil
+	}
+	return nil, err
+}

--- a/exporter/prometheusremotewriteexporter/wal_test.go
+++ b/exporter/prometheusremotewriteexporter/wal_test.go
@@ -1,0 +1,160 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package prometheusremotewriteexporter
+
+import (
+	"context"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/prompb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func doNothingExportSink(_ context.Context, reqL []*prompb.WriteRequest) []error {
+	_ = reqL
+	return nil
+}
+
+func TestWALCreation_nilConfig(t *testing.T) {
+	config := (*walConfig)(nil)
+	pwal, err := newWAL(config, doNothingExportSink)
+	require.Equal(t, err, errNilConfig)
+	require.Nil(t, pwal)
+}
+
+func TestWALCreation_nonNilConfig(t *testing.T) {
+	config := &walConfig{Directory: t.TempDir()}
+	pwal, err := newWAL(config, doNothingExportSink)
+	require.NotNil(t, pwal)
+	assert.Nil(t, err)
+	pwal.stop()
+}
+
+func orderByLabelValueForEach(reqL []*prompb.WriteRequest) {
+	for _, req := range reqL {
+		orderByLabelValue(req)
+	}
+}
+
+func orderByLabelValue(wreq *prompb.WriteRequest) {
+	// Sort the timeSeries by their labels.
+	type byLabelMessage struct {
+		label  *prompb.Label
+		sample *prompb.Sample
+	}
+
+	for _, timeSeries := range wreq.Timeseries {
+		bMsgs := make([]*byLabelMessage, 0, len(wreq.Timeseries)*10)
+		for i := range timeSeries.Labels {
+			bMsgs = append(bMsgs, &byLabelMessage{
+				label:  &timeSeries.Labels[i],
+				sample: &timeSeries.Samples[i],
+			})
+		}
+		sort.Slice(bMsgs, func(i, j int) bool {
+			return bMsgs[i].label.Value < bMsgs[j].label.Value
+		})
+
+		for i := range bMsgs {
+			timeSeries.Labels[i] = *bMsgs[i].label
+			timeSeries.Samples[i] = *bMsgs[i].sample
+		}
+	}
+}
+
+func TestWALStopManyTimes(t *testing.T) {
+	tempDir := t.TempDir()
+	config := &walConfig{
+		Directory:         tempDir,
+		TruncateFrequency: 60 * time.Microsecond,
+		NBeforeTruncation: 1,
+	}
+	pwal, err := newWAL(config, doNothingExportSink)
+	require.Nil(t, err)
+	require.NotNil(t, pwal)
+
+	// Ensure that invoking .stop() multiple times doesn't cause a panic, but actually
+	// First close should NOT return an error.
+	err = pwal.stop()
+	require.Nil(t, err)
+	for i := 0; i < 4; i++ {
+		// Every invocation to .stop() should return an errAlreadyClosed.
+		err = pwal.stop()
+		require.Equal(t, err, errAlreadyClosed)
+	}
+}
+
+func TestWAL_persist(t *testing.T) {
+	// Unit tests that requests written to the WAL persist.
+	config := &walConfig{Directory: t.TempDir()}
+
+	pwal, err := newWAL(config, doNothingExportSink)
+	require.Nil(t, err)
+
+	// 1. Write out all the entries.
+	reqL := []*prompb.WriteRequest{
+		{
+			Timeseries: []prompb.TimeSeries{
+				{
+					Labels:  []prompb.Label{{Name: "ts1l1", Value: "ts1k1"}},
+					Samples: []prompb.Sample{{Value: 1, Timestamp: 100}},
+				},
+			},
+		},
+		{
+			Timeseries: []prompb.TimeSeries{
+				{
+					Labels:  []prompb.Label{{Name: "ts2l1", Value: "ts2k1"}},
+					Samples: []prompb.Sample{{Value: 2, Timestamp: 200}},
+				},
+				{
+					Labels:  []prompb.Label{{Name: "ts1l1", Value: "ts1k1"}},
+					Samples: []prompb.Sample{{Value: 1, Timestamp: 100}},
+				},
+			},
+		},
+	}
+
+	ctx := context.Background()
+	err = pwal.start(ctx)
+	require.Nil(t, err)
+	defer pwal.stop()
+
+	err = pwal.persistToWAL(reqL)
+	require.Nil(t, err)
+
+	// 2. Read all the entries from the WAL itself, guided by the indices available,
+	// and ensure that they are exactly in order as we'd expect them.
+	wal := pwal.wal
+	start, err := wal.FirstIndex()
+	require.Nil(t, err)
+	end, err := wal.LastIndex()
+	require.Nil(t, err)
+
+	var reqLFromWAL []*prompb.WriteRequest
+	for i := start; i <= end; i++ {
+		req, err := pwal.readPrompbFromWAL(ctx, i)
+		require.Nil(t, err)
+		reqLFromWAL = append(reqLFromWAL, req)
+	}
+
+	orderByLabelValueForEach(reqL)
+	orderByLabelValueForEach(reqLFromWAL)
+	require.Equal(t, reqLFromWAL[0], reqL[0])
+	require.Equal(t, reqLFromWAL[1], reqL[1])
+}

--- a/go.mod
+++ b/go.mod
@@ -41,6 +41,7 @@ require (
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/viper v1.8.1
 	github.com/stretchr/testify v1.7.0
+	github.com/tidwall/wal v0.1.4
 	github.com/tklauser/go-sysconf v0.3.6 // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible
 	github.com/xdg-go/scram v1.0.2

--- a/go.sum
+++ b/go.sum
@@ -1153,7 +1153,17 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
+github.com/tidwall/gjson v1.6.1 h1:LRbvNuNuvAiISWg6gxLEFuCe72UKy5hDqhxW/8183ws=
+github.com/tidwall/gjson v1.6.1/go.mod h1:BaHyNc5bjzYkPqgLq7mdVzeiRtULKULXLgZFKsxEHI0=
+github.com/tidwall/match v1.0.1 h1:PnKP62LPNxHKTwvHHZZzdOAOCtsJTjo6dZLCwpKm5xc=
+github.com/tidwall/match v1.0.1/go.mod h1:LujAq0jyVjBy028G1WhWfIzbpQfMO8bBZ6Tyb0+pL9E=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
+github.com/tidwall/pretty v1.0.2 h1:Z7S3cePv9Jwm1KwS0513MRaoUe3S01WPbLNV40pwWZU=
+github.com/tidwall/pretty v1.0.2/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
+github.com/tidwall/tinylru v1.0.2 h1:W4mp7iUz4cnVMqAvWy2zbzC35ASv5sqdyyEjoQKKBFg=
+github.com/tidwall/tinylru v1.0.2/go.mod h1:HDVL7TsWeezQ4g44Um84TOVBMFcq7Xa9giqNc805KJ8=
+github.com/tidwall/wal v0.1.4 h1:YDUbo2ShwiaGoEu74tC2oQlQFj4iDw+iA9qkkanSKC4=
+github.com/tidwall/wal v0.1.4/go.mod h1:ww7Pd44/KnyETODJPUPKrzLlYjI72GZWlucNKt7pOt0=
 github.com/tinylib/msgp v1.0.2/go.mod h1:+d+yLhGm8mzTaHzB+wgMYrodPfmZrzkirds8fDWklFE=
 github.com/tinylib/msgp v1.1.0/go.mod h1:+d+yLhGm8mzTaHzB+wgMYrodPfmZrzkirds8fDWklFE=
 github.com/tklauser/go-sysconf v0.3.6 h1:oc1sJWvKkmvIxhDHeKWvZS4f6AW+YcoguSfRF2/Hmo4=


### PR DESCRIPTION
Split off from PR #3017, as requested to firstly add the implementation
unwired to the exporter itself to help the reviewers easily understand

Uses an off the shelf WAL implementation to add capabilities
to the Prometheus remote exporter using github.com/tidwall/wal.

By default the WAL will be on and to configure the WAL location,
please use this prometheusremotewrite exporter YAML configuration:

```yaml
exporters:
  prometheusremotewrite:
    endpoint: "http://some.url:9411/api/prom/push"
    wal:
        directory: ./waldir/wal_directory
        truncate_frequency: 200s
        cache_size: 300
```

whose fields are quite similar to Prometheus' WAL fields per

    https://docs.google.com/document/d/1cCcoFgjDFwU2n823tKuMvrIhzHty4UDyn0IcfUHiyyI/edit#heading=h.mlf37ibqjgov

We are using an off-the-shelf WAL because:
By the time that we get OTLP metrics, we can convert to Prometheus proto,
but trying to implement the Prometheus storage interfaces would involve
either by-passing to-Prometheus-Proto and then save to Prometheus raw Go,
then retrieve Prometheus raw Go and then convert to Prometheus Proto.
It is much easier to get an off the shelf WAL implementation and add
it to the Prometheus implementation.

The next PR after this one will involve hooking it into the actual
Prometheus Remote Write exporter.

Updates open-telemetry/wg-prometheus#9