### PR TITLE
Contrib testing shouldn't be required for PR merge

### DIFF
--- a/.github/workflows/contrib-tests.yml
+++ b/.github/workflows/contrib-tests.yml
@@ -17,6 +17,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v2
       - name: Run Contrib Tests
+        continue-on-error: true
         run: |
           contrib_path=/tmp/opentelemetry-collector-contrib
           git clone https://github.com/open-telemetry/opentelemetry-collector-contrib.git $contrib_path

--- a/.github/workflows/contrib-tests.yml
+++ b/.github/workflows/contrib-tests.yml
@@ -22,3 +22,5 @@ jobs:
           contrib_path=/tmp/opentelemetry-collector-contrib
           git clone https://github.com/open-telemetry/opentelemetry-collector-contrib.git $contrib_path
           make CONTRIB_PATH=$contrib_path check-contrib
+      - name: Complete
+        run: echo "Tests are complete." # don't delete this, otherwise the previous step errors the entire job.


### PR DESCRIPTION
Contrib tests are run in an FYI fashion in this repo, yet they are set to fail the entire build. Because contrib tests are always failing, several contributors learned not to rely on the tests results under PRs. This causes them missing the actual failing tests. We should make the results something contributors can consistently rely on.
