### PR TITLE
receiver/prometheus: add `_total` to list of trimmable metric name suffixes

### DIFF
--- a/receiver/prometheusreceiver/internal/metricsbuilder.go
+++ b/receiver/prometheusreceiver/internal/metricsbuilder.go
@@ -35,12 +35,13 @@ const (
 	metricsSuffixCount  = "_count"
 	metricsSuffixBucket = "_bucket"
 	metricsSuffixSum    = "_sum"
+	metricSuffixTotal   = "_total"
 	startTimeMetricName = "process_start_time_seconds"
 	scrapeUpMetricName  = "up"
 )
 
 var (
-	trimmableSuffixes     = []string{metricsSuffixBucket, metricsSuffixCount, metricsSuffixSum}
+	trimmableSuffixes     = []string{metricsSuffixBucket, metricsSuffixCount, metricsSuffixSum, metricSuffixTotal}
 	errNoDataToBuild      = errors.New("there's no data to build")
 	errNoBoundaryLabel    = errors.New("given metricType has no BucketLabel or QuantileLabel")
 	errEmptyBoundaryLabel = errors.New("BucketLabel or QuantileLabel is empty")

--- a/receiver/prometheusreceiver/internal/metricsbuilder_test.go
+++ b/receiver/prometheusreceiver/internal/metricsbuilder_test.go
@@ -1319,6 +1319,7 @@ func Test_normalizeMetricName(t *testing.T) {
 		{"count", "foo_count", "foo"},
 		{"bucket", "foo_bucket", "foo"},
 		{"sum", "foo_sum", "foo"},
+		{"total", "foo_total", "foo"},
 		{"no_prefix", "_sum", "_sum"},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
**Description:** attempts to ensure that the prometheus receiver correctly ingests counter metrics, regardless whether the producing system includes a `_total` suffix on the counter metric name.

**Fixes:** #3557 
