### PR TITLE
Document that (*Collector).Run shouldn't be called after shutdown

### DIFF
--- a/service/collector.go
+++ b/service/collector.go
@@ -142,6 +142,8 @@ func New(set CollectorSettings) (*Collector, error) {
 
 // Run starts the collector according to the command and configuration
 // given by the user, and waits for it to complete.
+// Consecutive calls to Run are not allowed, Run shouldn't be called
+// once a collector is shut down.
 func (col *Collector) Run() error {
 	// From this point on do not show usage in case of error.
 	col.rootCmd.SilenceUsage = true


### PR DESCRIPTION
Currently, the behavior allows collector to be shutdown and restarted by Run. But we shouldn't promise this behavior given it may complicate the Collector implementation over time even though it doesn't present a significant advantage to the alternative: reconstructing a collector and running it. We can always flex this behavior if Shutdown -> Run -> Shutdown becomes a critical to support.
