### PR TITLE
Add missing package docs to exporters

### DIFF
--- a/exporter/exporterhelper/doc.go
+++ b/exporter/exporterhelper/doc.go
@@ -12,5 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package jaegerexporter sends trace data to a Jaeger Collector gRPC endpoint.
-package jaegerexporter
+// Package exporterhelper provides helper functions for exporters.
+package exporterhelper

--- a/exporter/fileexporter/doc.go
+++ b/exporter/fileexporter/doc.go
@@ -12,5 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package jaegerexporter sends trace data to a Jaeger Collector gRPC endpoint.
-package jaegerexporter
+// Package fileexporter exports data to files.
+package fileexporter

--- a/exporter/kafkaexporter/doc.go
+++ b/exporter/kafkaexporter/doc.go
@@ -12,5 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package jaegerexporter sends trace data to a Jaeger Collector gRPC endpoint.
-package jaegerexporter
+// Package kafkaexporter exports trace data to Kafka.
+package kafkaexporter

--- a/exporter/loggingexporter/doc.go
+++ b/exporter/loggingexporter/doc.go
@@ -12,5 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package jaegerexporter sends trace data to a Jaeger Collector gRPC endpoint.
-package jaegerexporter
+// Package loggingexporter exports data to console as logs.
+package loggingexporter

--- a/exporter/opencensusexporter/doc.go
+++ b/exporter/opencensusexporter/doc.go
@@ -12,5 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package jaegerexporter sends trace data to a Jaeger Collector gRPC endpoint.
-package jaegerexporter
+// Package opencensusexporter exports data to an OpenCensus agent.
+package opencensusexporter

--- a/exporter/otlpexporter/doc.go
+++ b/exporter/otlpexporter/doc.go
@@ -12,5 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package jaegerexporter sends trace data to a Jaeger Collector gRPC endpoint.
-package jaegerexporter
+// Package otlpexporter exports data by using OTLP format to a gPRC endpoint.
+package otlpexporter

--- a/exporter/otlpexporter/doc.go
+++ b/exporter/otlpexporter/doc.go
@@ -12,5 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package otlpexporter exports data by using OTLP format to a gPRC endpoint.
+// Package otlpexporter exports data by using the OTLP format to a gPRC endpoint.
 package otlpexporter

--- a/exporter/otlphttpexporter/doc.go
+++ b/exporter/otlphttpexporter/doc.go
@@ -12,5 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package jaegerexporter sends trace data to a Jaeger Collector gRPC endpoint.
-package jaegerexporter
+// Package otlphttpexporter exports data by using OTLP format to an HTTP endpoint.
+package otlphttpexporter

--- a/exporter/otlphttpexporter/doc.go
+++ b/exporter/otlphttpexporter/doc.go
@@ -12,5 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package otlphttpexporter exports data by using OTLP format to an HTTP endpoint.
+// Package otlphttpexporter exports data by using the OTLP format to an HTTP endpoint.
 package otlphttpexporter

--- a/exporter/prometheusexporter/doc.go
+++ b/exporter/prometheusexporter/doc.go
@@ -12,5 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package jaegerexporter sends trace data to a Jaeger Collector gRPC endpoint.
-package jaegerexporter
+// Package prometheusexporter exports metrics data as a Prometheus pull handler.
+package prometheusexporter

--- a/exporter/prometheusremotewriteexporter/doc.go
+++ b/exporter/prometheusremotewriteexporter/doc.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//      http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -12,5 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package jaegerexporter sends trace data to a Jaeger Collector gRPC endpoint.
-package jaegerexporter
+// Package prometheusremotewriteexporter sends metrics data to Prometheus Remote Write (PRW) endpoints.
+package prometheusremotewriteexporter

--- a/exporter/prometheusremotewriteexporter/exporter.go
+++ b/exporter/prometheusremotewriteexporter/exporter.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package prometheusremotewriteexporter implements an exporter that sends Prometheus remote write requests.
 package prometheusremotewriteexporter
 
 import (

--- a/exporter/zipkinexporter/doc.go
+++ b/exporter/zipkinexporter/doc.go
@@ -12,5 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package jaegerexporter sends trace data to a Jaeger Collector gRPC endpoint.
-package jaegerexporter
+// Package zipkinexporter exports trace data to Zipkin.
+package zipkinexporter


### PR DESCRIPTION
Some exporters have package godocs and some doesn't. It gives an impression that the package with godocs are not mature. I'll follow up with godoc additions to receivers and processors.