### PR TITLE
Rename `logging` exporter to `debug` exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Rename `pdata.DoubleSum` to `pdata.Sum` (#3583)
 - Rename `pdata.DoubleGauge` to `pdata.Gauge` (#3599)
+- Rename `logging` exporter to `debug` (#3609)
 
 ## 🧰 Bug fixes 🧰
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Rename `pdata.DoubleSum` to `pdata.Sum` (#3583)
 - Rename `pdata.DoubleGauge` to `pdata.Gauge` (#3599)
-- Rename `logging` exporter to `debug` (#3609)
+- Rename `logging` exporter to `debug` exporter (#3609)
 
 ## 🧰 Bug fixes 🧰
 

--- a/cmd/otelcol/config.yaml
+++ b/cmd/otelcol/config.yaml
@@ -35,7 +35,7 @@ processors:
   batch:
 
 exporters:
-  logging:
+  debug:
     logLevel: debug
 
 service:
@@ -45,11 +45,11 @@ service:
     traces:
       receivers: [otlp, opencensus, jaeger, zipkin]
       processors: [batch]
-      exporters: [logging]
+      exporters: [debug]
 
     metrics:
       receivers: [otlp, opencensus, prometheus]
       processors: [batch]
-      exporters: [logging]
+      exporters: [debug]
 
   extensions: [health_check, pprof, zpages]

--- a/docs/design.md
+++ b/docs/design.md
@@ -70,7 +70,7 @@ Important: when the same receiver is referenced in more than one pipeline the Co
 
 ### Exporters
 
-Exporters typically forward the data they get to a destination on a network (but they can also send it elsewhere, e.g “logging” exporter writes the telemetry data to a local file).
+Exporters typically forward the data they get to a destination on a network (but they can also send it elsewhere, e.g “debug” exporter writes the telemetry data to a local file).
 
 The configuration allows to have multiple exporters of the same type, even in the same pipeline. For example one can have 2 “opencensus” exporters defined each one sending to a different opencensus endpoint, e.g.:
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -50,13 +50,13 @@ receivers:
             regex: '.*grpc_io.*'
             action: drop
 exporters:
-  logging:
+  debug:
 service:
   pipelines:
     metrics:
       receivers: [prometheus]
       processors: []
-      exporters: [logging]
+      exporters: [debug]
 ```
 
 ### zPages
@@ -83,7 +83,7 @@ extensions:
 exporters](https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter#general-information)
 can be configured to inspect the data being processed by the Collector.
 
-For live troubleshooting purposes consider leveraging the `logging` exporter,
+For live troubleshooting purposes consider leveraging the `debug` exporter,
 which can be used to confirm that data is being received, processed and
 exported by the Collector.
 
@@ -91,13 +91,13 @@ exported by the Collector.
 receivers:
   zipkin:
 exporters:
-  logging:
+  debug:
 service:
   pipelines:
     traces:
       receivers: [zipkin]
       processors: []
-      exporters: [logging]
+      exporters: [debug]
 ```
 
 Get a Zipkin payload to test. For example create a file called `trace.json`
@@ -135,21 +135,21 @@ $ curl -X POST localhost:9411/api/v2/spans -H'Content-Type: application/json' -d
 You should see a log entry like the following from the Collector:
 
 ```json
-2020-11-11T04:12:33.089Z	INFO	loggingexporter/logging_exporter.go:296	TraceExporter	{"#spans": 1}
+2020-11-11T04:12:33.089Z	INFO	debugexporter/debug_exporter.go:296	TraceExporter	{"#spans": 1}
 ```
 
-You can also configure the `logging` exporter so the entire payload is printed:
+You can also configure the `debug` exporter so the entire payload is printed:
 
 ```yaml
 exporters:
-  logging:
+  debug:
     loglevel: debug
 ```
 
 With the modified configuration if you re-run the test above the log output should look like:
 
 ```json
-2020-11-11T04:08:17.344Z	DEBUG	loggingexporter/logging_exporter.go:353	ResourceSpans #0
+2020-11-11T04:08:17.344Z	DEBUG	debugexporter/debug_exporter.go:353	ResourceSpans #0
 Resource labels:
      -> service.name: STRING(api)
 InstrumentationLibrarySpans #0

--- a/examples/demo/otel-agent-config.yaml
+++ b/examples/demo/otel-agent-config.yaml
@@ -13,7 +13,7 @@ exporters:
   otlp:
     endpoint: "otel-collector:4317"
     insecure: true
-  logging:
+  debug:
     loglevel: debug
 
 processors:
@@ -32,8 +32,8 @@ service:
     traces:
       receivers: [otlp, opencensus, jaeger, zipkin]
       processors: [batch]
-      exporters: [otlp, logging]
+      exporters: [otlp, debug]
     metrics:
       receivers: [otlp, opencensus]
       processors: [batch]
-      exporters: [otlp, logging]
+      exporters: [otlp, debug]

--- a/examples/demo/otel-collector-config.yaml
+++ b/examples/demo/otel-collector-config.yaml
@@ -9,7 +9,7 @@ exporters:
     namespace: promexample
     const_labels:
       label1: value1
-  logging:
+  debug:
 
   zipkin:
     endpoint: "http://zipkin-all-in-one:9411/api/v2/spans"
@@ -35,8 +35,8 @@ service:
     traces:
       receivers: [otlp]
       processors: [batch]
-      exporters: [logging, zipkin, jaeger]
+      exporters: [debug, zipkin, jaeger]
     metrics:
       receivers: [otlp]
       processors: [batch]
-      exporters: [logging, prometheus]
+      exporters: [debug, prometheus]

--- a/examples/local/otel-config.yaml
+++ b/examples/local/otel-config.yaml
@@ -32,7 +32,7 @@ processors:
   batch:
 
 exporters:
-  logging:
+  debug:
     logLevel: debug
 
 service:
@@ -40,10 +40,10 @@ service:
     traces:
       receivers: [otlp, opencensus, jaeger, zipkin]
       processors: [batch]
-      exporters: [logging]
+      exporters: [debug]
     metrics:
       receivers: [otlp, opencensus, prometheus]
       processors: [batch]
-      exporters: [logging]
+      exporters: [debug]
 
   extensions: [health_check, pprof, zpages]

--- a/exporter/README.md
+++ b/exporter/README.md
@@ -29,7 +29,7 @@ Available log exporters (sorted alphabetically):
 Available local exporters (sorted alphabetically):
 
 - [File](fileexporter/README.md)
-- [Logging](loggingexporter/README.md)
+- [Debug](debugexporter/README.md)
 
 The [contrib
 repository](https://github.com/open-telemetry/opentelemetry-collector-contrib)

--- a/exporter/debugexporter/README.md
+++ b/exporter/debugexporter/README.md
@@ -1,4 +1,4 @@
-# Logging Exporter
+# Debug Exporter
 
 Exports data to the console via zap.Logger.
 
@@ -8,7 +8,7 @@ Supported pipeline types: traces, metrics, logs
 
 The following settings are optional:
 
-- `loglevel` (default = `info`): the log level of the logging export
+- `loglevel` (default = `info`): the log level of the debug export
   (debug|info|warn|error). When set to `debug`, pipeline data is verbosely
   logged.
 - `sampling_initial` (default = `2`): number of messages initially logged each
@@ -22,7 +22,7 @@ Example:
 
 ```yaml
 exporters:
-  logging:
+  debug:
     loglevel: debug
     sampling_initial: 5
     sampling_thereafter: 200

--- a/exporter/debugexporter/config.go
+++ b/exporter/debugexporter/config.go
@@ -12,17 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package loggingexporter
+package debugexporter
 
 import (
 	"go.opentelemetry.io/collector/config"
 )
 
-// Config defines configuration for logging exporter.
+// Config defines configuration for debug exporter.
 type Config struct {
 	config.ExporterSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
 
-	// LogLevel defines log level of the logging exporter; options are debug, info, warn, error.
+	// LogLevel defines log level of the debug exporter; options are debug, info, warn, error.
 	LogLevel string `mapstructure:"loglevel"`
 
 	// SamplingInitial defines how many samples are initially logged during each second.

--- a/exporter/debugexporter/config_test.go
+++ b/exporter/debugexporter/config_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package loggingexporter
+package debugexporter
 
 import (
 	"path"

--- a/exporter/debugexporter/debug_exporter.go
+++ b/exporter/debugexporter/debug_exporter.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package loggingexporter
+package debugexporter
 
 import (
 	"context"
@@ -29,7 +29,7 @@ import (
 	"go.opentelemetry.io/collector/model/pdata"
 )
 
-type loggingExporter struct {
+type debugExporter struct {
 	logger           *zap.Logger
 	debug            bool
 	logsMarshaler    pdata.LogsMarshaler
@@ -37,7 +37,7 @@ type loggingExporter struct {
 	tracesMarshaler  pdata.TracesMarshaler
 }
 
-func (s *loggingExporter) pushTraces(_ context.Context, td pdata.Traces) error {
+func (s *debugExporter) pushTraces(_ context.Context, td pdata.Traces) error {
 	s.logger.Info("TracesExporter", zap.Int("#spans", td.SpanCount()))
 
 	if !s.debug {
@@ -52,7 +52,7 @@ func (s *loggingExporter) pushTraces(_ context.Context, td pdata.Traces) error {
 	return nil
 }
 
-func (s *loggingExporter) pushMetrics(_ context.Context, md pdata.Metrics) error {
+func (s *debugExporter) pushMetrics(_ context.Context, md pdata.Metrics) error {
 	s.logger.Info("MetricsExporter", zap.Int("#metrics", md.MetricCount()))
 
 	if !s.debug {
@@ -67,7 +67,7 @@ func (s *loggingExporter) pushMetrics(_ context.Context, md pdata.Metrics) error
 	return nil
 }
 
-func (s *loggingExporter) pushLogs(_ context.Context, ld pdata.Logs) error {
+func (s *debugExporter) pushLogs(_ context.Context, ld pdata.Logs) error {
 	s.logger.Info("LogsExporter", zap.Int("#logs", ld.LogRecordCount()))
 
 	if !s.debug {
@@ -82,8 +82,8 @@ func (s *loggingExporter) pushLogs(_ context.Context, ld pdata.Logs) error {
 	return nil
 }
 
-func newLoggingExporter(level string, logger *zap.Logger) *loggingExporter {
-	return &loggingExporter{
+func newDebugExporter(level string, logger *zap.Logger) *debugExporter {
+	return &debugExporter{
 		debug:            strings.ToLower(level) == "debug",
 		logger:           logger,
 		logsMarshaler:    otlptext.NewTextLogsMarshaler(),
@@ -95,7 +95,7 @@ func newLoggingExporter(level string, logger *zap.Logger) *loggingExporter {
 // newTracesExporter creates an exporter.TracesExporter that just drops the
 // received data and logs debugging messages.
 func newTracesExporter(config config.Exporter, level string, logger *zap.Logger, set component.ExporterCreateSettings) (component.TracesExporter, error) {
-	s := newLoggingExporter(level, logger)
+	s := newDebugExporter(level, logger)
 	return exporterhelper.NewTracesExporter(
 		config,
 		set,
@@ -112,7 +112,7 @@ func newTracesExporter(config config.Exporter, level string, logger *zap.Logger,
 // newMetricsExporter creates an exporter.MetricsExporter that just drops the
 // received data and logs debugging messages.
 func newMetricsExporter(config config.Exporter, level string, logger *zap.Logger, set component.ExporterCreateSettings) (component.MetricsExporter, error) {
-	s := newLoggingExporter(level, logger)
+	s := newDebugExporter(level, logger)
 	return exporterhelper.NewMetricsExporter(
 		config,
 		set,
@@ -129,7 +129,7 @@ func newMetricsExporter(config config.Exporter, level string, logger *zap.Logger
 // newLogsExporter creates an exporter.LogsExporter that just drops the
 // received data and logs debugging messages.
 func newLogsExporter(config config.Exporter, level string, logger *zap.Logger, set component.ExporterCreateSettings) (component.LogsExporter, error) {
-	s := newLoggingExporter(level, logger)
+	s := newDebugExporter(level, logger)
 	return exporterhelper.NewLogsExporter(
 		config,
 		set,

--- a/exporter/debugexporter/debug_exporter_test.go
+++ b/exporter/debugexporter/debug_exporter_test.go
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-package loggingexporter
+package debugexporter
 
 import (
 	"context"
@@ -28,7 +28,7 @@ import (
 	"go.opentelemetry.io/collector/model/pdata"
 )
 
-func TestLoggingTracesExporterNoErrors(t *testing.T) {
+func TestDebugTracesExporterNoErrors(t *testing.T) {
 	lte, err := newTracesExporter(&config.ExporterSettings{}, "Debug", zap.NewNop(), componenttest.NewNopExporterCreateSettings())
 	require.NotNil(t, lte)
 	assert.NoError(t, err)
@@ -39,7 +39,7 @@ func TestLoggingTracesExporterNoErrors(t *testing.T) {
 	assert.NoError(t, lte.Shutdown(context.Background()))
 }
 
-func TestLoggingMetricsExporterNoErrors(t *testing.T) {
+func TestDebugMetricsExporterNoErrors(t *testing.T) {
 	lme, err := newMetricsExporter(&config.ExporterSettings{}, "DEBUG", zap.NewNop(), componenttest.NewNopExporterCreateSettings())
 	require.NotNil(t, lme)
 	assert.NoError(t, err)
@@ -52,7 +52,7 @@ func TestLoggingMetricsExporterNoErrors(t *testing.T) {
 	assert.NoError(t, lme.Shutdown(context.Background()))
 }
 
-func TestLoggingLogsExporterNoErrors(t *testing.T) {
+func TestDebugLogsExporterNoErrors(t *testing.T) {
 	lle, err := newLogsExporter(&config.ExporterSettings{}, "debug", zap.NewNop(), componenttest.NewNopExporterCreateSettings())
 	require.NotNil(t, lle)
 	assert.NoError(t, err)
@@ -65,8 +65,8 @@ func TestLoggingLogsExporterNoErrors(t *testing.T) {
 	assert.NoError(t, lle.Shutdown(context.Background()))
 }
 
-func TestLoggingExporterErrors(t *testing.T) {
-	le := newLoggingExporter("Debug", zap.NewNop())
+func TestDebugExporterErrors(t *testing.T) {
+	le := newDebugExporter("Debug", zap.NewNop())
 	require.NotNil(t, le)
 
 	errWant := errors.New("my error")

--- a/exporter/debugexporter/factory.go
+++ b/exporter/debugexporter/factory.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package loggingexporter
+package debugexporter
 
 import (
 	"context"
@@ -27,12 +27,12 @@ import (
 
 const (
 	// The value of "type" key in configuration.
-	typeStr                   = "logging"
+	typeStr                   = "debug"
 	defaultSamplingInitial    = 2
 	defaultSamplingThereafter = 500
 )
 
-// NewFactory creates a factory for Logging exporter
+// NewFactory creates a factory for Debug exporter
 func NewFactory() component.ExporterFactory {
 	return exporterhelper.NewFactory(
 		typeStr,
@@ -92,7 +92,7 @@ func createLogger(cfg *Config) (*zap.Logger, error) {
 	}
 
 	// We take development config as the base since it matches the purpose
-	// of logging exporter being used for debugging reasons (so e.g. console encoder)
+	// of debug exporter being used for debugging reasons (so e.g. console encoder)
 	conf := zap.NewDevelopmentConfig()
 	conf.Level = zap.NewAtomicLevelAt(level)
 	conf.Sampling = &zap.SamplingConfig{
@@ -100,9 +100,9 @@ func createLogger(cfg *Config) (*zap.Logger, error) {
 		Thereafter: cfg.SamplingThereafter,
 	}
 
-	logginglogger, err := conf.Build()
+	debuglogger, err := conf.Build()
 	if err != nil {
 		return nil, err
 	}
-	return logginglogger, nil
+	return debuglogger, nil
 }

--- a/exporter/debugexporter/factory_test.go
+++ b/exporter/debugexporter/factory_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package loggingexporter
+package debugexporter
 
 import (
 	"context"

--- a/exporter/debugexporter/known_sync_error.go
+++ b/exporter/debugexporter/known_sync_error.go
@@ -12,17 +12,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build windows
+// +build !windows
 
-package loggingexporter
+package debugexporter
 
-import "golang.org/x/sys/windows"
+import (
+	"syscall"
+)
 
 // knownSyncError returns true if the given error is one of the known
-// non-actionable errors returned by Sync on Windows:
+// non-actionable errors returned by Sync on Linux and macOS:
 //
-// - sync /dev/stderr: The handle is invalid.
+// Linux:
+// - sync /dev/stdout: invalid argument
+//
+// macOS:
+// - sync /dev/stdout: inappropriate ioctl for device
 //
 func knownSyncError(err error) bool {
-	return err == windows.ERROR_INVALID_HANDLE
+	switch err {
+	case syscall.EINVAL, syscall.ENOTSUP, syscall.ENOTTY:
+		return true
+	}
+	return false
 }

--- a/exporter/debugexporter/known_sync_error_windows.go
+++ b/exporter/debugexporter/known_sync_error_windows.go
@@ -12,27 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build !windows
+// +build windows
 
-package loggingexporter
+package debugexporter
 
-import (
-	"syscall"
-)
+import "golang.org/x/sys/windows"
 
 // knownSyncError returns true if the given error is one of the known
-// non-actionable errors returned by Sync on Linux and macOS:
+// non-actionable errors returned by Sync on Windows:
 //
-// Linux:
-// - sync /dev/stdout: invalid argument
-//
-// macOS:
-// - sync /dev/stdout: inappropriate ioctl for device
+// - sync /dev/stderr: The handle is invalid.
 //
 func knownSyncError(err error) bool {
-	switch err {
-	case syscall.EINVAL, syscall.ENOTSUP, syscall.ENOTTY:
-		return true
-	}
-	return false
+	return err == windows.ERROR_INVALID_HANDLE
 }

--- a/exporter/debugexporter/testdata/config.yaml
+++ b/exporter/debugexporter/testdata/config.yaml
@@ -5,8 +5,8 @@ processors:
   nop:
 
 exporters:
-  logging:
-  logging/2:
+  debug:
+  debug/2:
     loglevel: debug
     sampling_initial: 10
     sampling_thereafter: 50
@@ -16,7 +16,7 @@ service:
     traces:
       receivers: [nop]
       processors: [nop]
-      exporters: [logging]
+      exporters: [debug]
     metrics:
       receivers: [nop]
-      exporters: [logging,logging/2]
+      exporters: [debug,debug/2]

--- a/extension/oidcauthextension/README.md
+++ b/extension/oidcauthextension/README.md
@@ -22,7 +22,7 @@ receivers:
 processors:
 
 exporters:
-  logging:
+  debug:
     logLevel: debug
 
 service:
@@ -31,5 +31,5 @@ service:
     traces:
       receivers: [otlp]
       processors: []
-      exporters: [logging]
+      exporters: [debug]
 ```

--- a/receiver/hostmetricsreceiver/example_config.yaml
+++ b/receiver/hostmetricsreceiver/example_config.yaml
@@ -16,7 +16,7 @@ receivers:
       processes:
 
 exporters:
-  logging:
+  debug:
   prometheus:
     endpoint: 0.0.0.0:8889
 
@@ -24,6 +24,6 @@ service:
   pipelines:
     metrics:
       receivers: [hostmetrics]
-      exporters: [prometheus, logging]
+      exporters: [prometheus, debug]
 
   extensions: [zpages]

--- a/service/collector_test.go
+++ b/service/collector_test.go
@@ -254,7 +254,7 @@ receivers:
     protocols:
       grpc:
 exporters:
-  logging:
+  debug:
 processors:
   batch:
 
@@ -266,7 +266,7 @@ service:
     traces:
       receivers: [otlp]
       processors: [batch]
-      exporters: [logging]
+      exporters: [debug]
 `
 	return configparser.NewParserFromBuffer(strings.NewReader(configStr))
 }

--- a/service/defaultcomponents/default_exporters_test.go
+++ b/service/defaultcomponents/default_exporters_test.go
@@ -82,7 +82,7 @@ func TestDefaultExporters(t *testing.T) {
 			},
 		},
 		{
-			exporter:      "logging",
+			exporter:      "debug",
 			skipLifecycle: runtime.GOOS == "darwin", // TODO: investigate why this fails on darwin.
 		},
 		{

--- a/service/defaultcomponents/defaults.go
+++ b/service/defaultcomponents/defaults.go
@@ -18,10 +18,10 @@ package defaultcomponents
 import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer/consumererror"
+	"go.opentelemetry.io/collector/exporter/debugexporter"
 	"go.opentelemetry.io/collector/exporter/fileexporter"
 	"go.opentelemetry.io/collector/exporter/jaegerexporter"
 	"go.opentelemetry.io/collector/exporter/kafkaexporter"
-	"go.opentelemetry.io/collector/exporter/loggingexporter"
 	"go.opentelemetry.io/collector/exporter/opencensusexporter"
 	"go.opentelemetry.io/collector/exporter/otlpexporter"
 	"go.opentelemetry.io/collector/exporter/otlphttpexporter"
@@ -85,7 +85,7 @@ func Components() (
 		opencensusexporter.NewFactory(),
 		prometheusexporter.NewFactory(),
 		prometheusremotewriteexporter.NewFactory(),
-		loggingexporter.NewFactory(),
+		debugexporter.NewFactory(),
 		zipkinexporter.NewFactory(),
 		jaegerexporter.NewFactory(),
 		fileexporter.NewFactory(),

--- a/testbed/tests/testdata/agent-config.yaml
+++ b/testbed/tests/testdata/agent-config.yaml
@@ -10,7 +10,7 @@ exporters:
   opencensus:
     endpoint: "localhost:56565"
     insecure: true
-  logging:
+  debug:
     loglevel: info
 
 processors:
@@ -21,8 +21,8 @@ service:
     traces:
       receivers: [jaeger]
       processors: [batch]
-      exporters: [opencensus,logging]
+      exporters: [opencensus,debug]
     metrics:
       receivers: [opencensus]
       processors: [batch]
-      exporters: [opencensus,logging]
+      exporters: [opencensus,debug]

--- a/testbed/tests/testdata/memory-limiter.yaml
+++ b/testbed/tests/testdata/memory-limiter.yaml
@@ -10,7 +10,7 @@ exporters:
   opencensus:
     endpoint: "localhost:56565"
     insecure: true
-  logging:
+  debug:
     loglevel: info
 
 processors:
@@ -23,7 +23,7 @@ service:
     traces:
       receivers: [jaeger]
       processors: [memory_limiter]
-      exporters: [opencensus,logging]
+      exporters: [opencensus,debug]
     metrics:
       receivers: [opencensus]
-      exporters: [opencensus,logging]
+      exporters: [opencensus,debug]

--- a/website_docs/configuration.md
+++ b/website_docs/configuration.md
@@ -316,7 +316,7 @@ exporters:
     protocol_version: 2.0.0
 
   # Data sources: traces, metrics, logs
-  logging:
+  debug:
     loglevel: debug
 
   # Data sources: traces, metrics


### PR DESCRIPTION
**Description:**
This PR renamed `logging` exporter to `debug` exporter.

**Link to tracking Issue:**
Closes #3524 

**Testing:**
Verified locally.

**Documentation:**
Also modified all the `logging` exporter usage in the documentations and example configs.