### PR TITLE
Implement Equal() for map-valued AttributeValues

### DIFF
--- a/model/pdata/common.go
+++ b/model/pdata/common.go
@@ -287,14 +287,14 @@ func (a AttributeValue) Equal(av AttributeValue) bool {
 
 		for i, val := range avv {
 			val := val
-			av := newAttributeValue(&vv[i])
+			newAv := newAttributeValue(&vv[i])
 
 			// According to the specification, array values must be scalar.
-			if avType := av.Type(); avType == AttributeValueTypeArray || avType == AttributeValueTypeMap {
+			if avType := newAv.Type(); avType == AttributeValueTypeArray || avType == AttributeValueTypeMap {
 				return false
 			}
 
-			if !av.Equal(newAttributeValue(&val)) {
+			if !newAv.Equal(newAttributeValue(&val)) {
 				return false
 			}
 		}
@@ -309,12 +309,12 @@ func (a AttributeValue) Equal(av AttributeValue) bool {
 		am := newAttributeMap(&avv)
 
 		for _, val := range cc {
-			av, ok := am.Get(val.Key)
+			newAv, ok := am.Get(val.Key)
 			if !ok {
 				return false
 			}
 
-			if !av.Equal(newAttributeValue(&val.Value)) {
+			if !newAv.Equal(newAttributeValue(&val.Value)) {
 				return false
 			}
 		}

--- a/model/pdata/common.go
+++ b/model/pdata/common.go
@@ -299,9 +299,28 @@ func (a AttributeValue) Equal(av AttributeValue) bool {
 			}
 		}
 		return true
+	case *otlpcommon.AnyValue_KvlistValue:
+		cc := v.KvlistValue.GetValues()
+		avv := av.orig.GetKvlistValue().GetValues()
+		if len(cc) != len(avv) {
+			return false
+		}
+
+		am := newAttributeMap(&avv)
+
+		for _, val := range cc {
+			av, ok := am.Get(val.Key)
+			if !ok {
+				return false
+			}
+
+			if !av.Equal(newAttributeValue(&val.Value)) {
+				return false
+			}
+		}
+		return true
 	}
 
-	// TODO: handle MAP data type
 	return false
 }
 

--- a/model/pdata/common_test.go
+++ b/model/pdata/common_test.go
@@ -226,6 +226,26 @@ func TestAttributeValueEqual(t *testing.T) {
 	av1.CopyTo(av2.ArrayVal().AppendEmpty())
 	assert.False(t, av1.Equal(av2))
 	assert.True(t, av1.Equal(av1))
+
+	av1 = NewAttributeValueMap()
+	av1.MapVal().InitFromMap(map[string]AttributeValue{
+		"foo": NewAttributeValueString("bar"),
+	})
+	assert.False(t, av1.Equal(av2))
+	assert.False(t, av2.Equal(av1))
+
+	av2 = NewAttributeValueMap()
+	av2.MapVal().InitFromMap(map[string]AttributeValue{
+		"foo": NewAttributeValueString("bar"),
+	})
+	assert.True(t, av1.Equal(av2))
+
+	fooVal, ok := av2.MapVal().Get("foo")
+	if !ok {
+		assert.Fail(t, "expected to find value with key foo")
+	}
+	fooVal.SetStringVal("not-bar")
+	assert.False(t, av1.Equal(av2))
 }
 
 func TestNilAttributeMap(t *testing.T) {


### PR DESCRIPTION
### Description

The implementation AttributeValue.Equals() was incomplete, because it didn't handle values that were of map (kvlist) type. This PR handles that case.

### Link to tracking Issue

Possibly #2488.

**Testing:**

Added to the existing unit test.