### PR TITLE
Create new AWS ECS health check extension.

### DIFF
--- a/examples/local/otel-config.yaml
+++ b/examples/local/otel-config.yaml
@@ -1,5 +1,9 @@
 extensions:
   health_check:
+  aws_ecs_health_check:
+    endpoint: 0.0.0.0:13134
+    interval: "5m"
+    exporter_error_limit: 5
   pprof:
     endpoint: 0.0.0.0:1777
   zpages:

--- a/extension/awsecshealthcheckextension/config.go
+++ b/extension/awsecshealthcheckextension/config.go
@@ -1,0 +1,52 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package awsecshealthcheckextension
+
+import (
+	"errors"
+	"time"
+
+	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/config/confignet"
+)
+
+type Config struct {
+	config.ExtensionSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
+
+	// TCPAddr represents a tcp endpoint address that is to publish the health check status.
+	// The default endpoint is "127.0.0.1:13134".
+	TCPAddr confignet.TCPAddr `mapstructure:",squash"`
+
+	// Interval is the time error kept, and error limit is the threshold of number of error happened during the interval
+	Interval string `mapstructure:"interval"`
+
+	// current scope will be focus on exporter failures
+	// TODO receiver/processor failures
+	ExporterErrorLimit int `mapstructure:"exporter_error_limit"`
+}
+
+var _ config.Extension = (*Config)(nil)
+
+// Validate checks if the extension configuration is valid
+func (cfg *Config) Validate() error {
+	_, err := time.ParseDuration(cfg.Interval)
+	if err != nil {
+		return err
+	}
+	if cfg.ExporterErrorLimit < 0 {
+		return errors.New("math: error limit is a negative number")
+	}
+	return nil
+}

--- a/extension/awsecshealthcheckextension/config.go
+++ b/extension/awsecshealthcheckextension/config.go
@@ -45,8 +45,10 @@ func (cfg *Config) Validate() error {
 	if err != nil {
 		return err
 	}
+
 	if cfg.ExporterErrorLimit < 0 {
-		return errors.New("math: error limit is a negative number")
+		return errors.New("error limit is a negative number")
 	}
+
 	return nil
 }

--- a/extension/awsecshealthcheckextension/config_test.go
+++ b/extension/awsecshealthcheckextension/config_test.go
@@ -1,0 +1,58 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package awsecshealthcheckextension
+
+import (
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/config/confignet"
+	"go.opentelemetry.io/collector/config/configtest"
+)
+
+func TestLoadConfig(t *testing.T) {
+	factories, err := componenttest.NopFactories()
+	assert.NoError(t, err)
+
+	factory := NewFactory()
+	factories.Extensions[typeStr] = factory
+	cfg, err := configtest.LoadConfigAndValidate(path.Join(".", "testdata", "config.yaml"), factories)
+
+	require.Nil(t, err)
+	require.NotNil(t, cfg)
+
+	ext0 := cfg.Extensions[config.NewID(typeStr)]
+	assert.Equal(t, factory.CreateDefaultConfig(), ext0)
+
+	ext1 := cfg.Extensions[config.NewIDWithName(typeStr, "1")]
+	assert.Equal(t,
+		&Config{
+			ExtensionSettings: config.NewExtensionSettings(config.NewIDWithName(typeStr, "1")),
+			TCPAddr: confignet.TCPAddr{
+				Endpoint: "localhost:13134",
+			},
+			Interval:           "5m",
+			ExporterErrorLimit: 5,
+		},
+		ext1)
+
+	assert.Equal(t, 1, len(cfg.Service.Extensions))
+	assert.Equal(t, config.NewIDWithName(typeStr, "1"), cfg.Service.Extensions[0])
+}

--- a/extension/awsecshealthcheckextension/ecshealthcheckextension.go
+++ b/extension/awsecshealthcheckextension/ecshealthcheckextension.go
@@ -1,0 +1,141 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package awsecshealthcheckextension
+
+import (
+	"context"
+	"log"
+	"net"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/jaegertracing/jaeger/pkg/healthcheck"
+	"go.uber.org/zap"
+
+	"go.opencensus.io/stats/view"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/internal/obsreportconfig/obsmetrics"
+)
+
+type ECSHealthCheckExtension struct {
+	config   Config
+	logger   *zap.Logger
+	state    *healthcheck.HealthCheck
+	server   http.Server
+	stopCh   chan struct{}
+	exporter *ECSHealthCheckExporter
+}
+
+// initViews function could register the "failed to send" view and the customized exporter
+func (hc *ECSHealthCheckExtension) initViews() error {
+	if err := view.Register(&view.View{
+		Name:        "AOC/ECSHealthCheckExporterFailedToSendSpans",
+		Description: "number of errors in exporters over span",
+		Measure:     obsmetrics.ExporterFailedToSendSpans,
+		Aggregation: view.Count(),
+	}); err != nil {
+		log.Fatalf("Failed to register view: %v", err)
+		return err
+	}
+
+	hc.exporter = newECSHealthCheckExporter()
+	view.RegisterExporter(hc.exporter)
+	return nil
+}
+
+func (hc *ECSHealthCheckExtension) Start(_ context.Context, host component.Host) error {
+	hc.logger.Info("Starting ECS health check extension", zap.Any("config", hc.config))
+
+	// Initialize listener
+	var (
+		ln  net.Listener
+		err error
+	)
+
+	err = hc.initViews()
+	if err != nil {
+		return err
+	}
+
+	err = hc.config.Validate()
+	if err != nil {
+		return err
+	}
+
+	if hc.config.TCPAddr.Endpoint == "" || hc.config.TCPAddr.Endpoint == defaultEndpoint {
+		ln, err = net.Listen("tcp", defaultEndpoint)
+	} else {
+		ln, err = hc.config.TCPAddr.Listen()
+	}
+	if err != nil {
+		return err
+	}
+
+	hc.server.Handler = hc.handler()
+	hc.stopCh = make(chan struct{})
+	go func() {
+		defer close(hc.stopCh)
+
+		if err := hc.server.Serve(ln); err != http.ErrServerClosed && err != nil {
+			host.ReportFatalError(err)
+		}
+	}()
+	return nil
+}
+
+func (hc *ECSHealthCheckExtension) check() bool {
+	hc.exporter.mu.Lock()
+	defer hc.exporter.mu.Unlock()
+
+	interval, _ := time.ParseDuration(hc.config.Interval)
+	hc.exporter.rotate(interval)
+
+	return hc.config.ExporterErrorLimit >= len(hc.exporter.exporterErrorQueue)
+}
+
+func (hc *ECSHealthCheckExtension) handler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if hc.check() {
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(strconv.Itoa(len(hc.exporter.exporterErrorQueue))))
+		} else {
+			w.WriteHeader(500)
+			_, _ = w.Write([]byte(strconv.Itoa(len(hc.exporter.exporterErrorQueue))))
+		}
+	})
+}
+
+func (hc *ECSHealthCheckExtension) Shutdown(context.Context) error {
+	err := hc.server.Close()
+	if hc.stopCh != nil {
+		<-hc.stopCh
+	}
+	return err
+}
+
+func newServer(config Config, logger *zap.Logger) *ECSHealthCheckExtension {
+	hc := &ECSHealthCheckExtension{
+		config:   config,
+		logger:   logger,
+		state:    healthcheck.New(),
+		server:   http.Server{},
+		exporter: newECSHealthCheckExporter(),
+	}
+
+	hc.state.SetLogger(logger)
+
+	return hc
+}

--- a/extension/awsecshealthcheckextension/ecshealthcheckextension_test.go
+++ b/extension/awsecshealthcheckextension/ecshealthcheckextension_test.go
@@ -1,0 +1,167 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package awsecshealthcheckextension
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"go.opencensus.io/stats/view"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/config/confignet"
+)
+
+func TestHealthCheckExtensionUsage(t *testing.T) {
+	testEndpoint := "localhost:13134"
+	config := Config{
+		TCPAddr: confignet.TCPAddr{
+			Endpoint: testEndpoint,
+		},
+		Interval:           "5m",
+		ExporterErrorLimit: 1,
+	}
+
+	hcExt := newServer(config, zap.NewNop())
+	require.NotNil(t, hcExt)
+
+	require.NoError(t, hcExt.Start(context.Background(), componenttest.NewNopHost()))
+	t.Cleanup(func() { require.NoError(t, hcExt.Shutdown(context.Background())) })
+
+	// Give a chance for the server goroutine to run.
+	runtime.Gosched()
+
+	currentTime := time.Now()
+	vd1 := &view.Data{
+		View:  nil,
+		Start: currentTime.Add(-2 * time.Minute),
+		End:   currentTime,
+		Rows:  nil,
+	}
+	vd2 := &view.Data{
+		View:  nil,
+		Start: currentTime.Add(-1 * time.Minute),
+		End:   currentTime,
+		Rows:  nil,
+	}
+
+	hcExt.exporter.exporterErrorQueue = append(hcExt.exporter.exporterErrorQueue, vd1)
+	req1, err := http.NewRequest("GET", testEndpoint, nil)
+	require.Nil(t, err)
+	responseRecorder1 := httptest.NewRecorder()
+	hcExt.handler().ServeHTTP(responseRecorder1, req1)
+	require.Equal(t, http.StatusOK, responseRecorder1.Code)
+
+	hcExt.exporter.exporterErrorQueue = append(hcExt.exporter.exporterErrorQueue, vd2)
+	req2, err := http.NewRequest("GET", testEndpoint, nil)
+	require.Nil(t, err)
+	responseRecorder2 := httptest.NewRecorder()
+	hcExt.handler().ServeHTTP(responseRecorder2, req2)
+	require.Equal(t, http.StatusInternalServerError, responseRecorder2.Code)
+}
+
+func TestHealthCheckExtensionPortAlreadyInUse(t *testing.T) {
+	endpoint := "localhost:13134"
+
+	ln, err := net.Listen("tcp", endpoint)
+	require.NoError(t, err)
+	defer ln.Close()
+
+	config := Config{
+		TCPAddr: confignet.TCPAddr{
+			Endpoint: "localhost:13134",
+		},
+		Interval:           "5m",
+		ExporterErrorLimit: 5,
+	}
+	hcExt := newServer(config, zap.NewNop())
+	require.NotNil(t, hcExt)
+
+	mh := newAssertNoErrorHost(t)
+	require.Error(t, hcExt.Start(context.Background(), mh))
+}
+
+func TestHealthCheckMultipleStarts(t *testing.T) {
+	config := Config{
+		TCPAddr: confignet.TCPAddr{
+			Endpoint: "localhost:13134",
+		},
+		Interval:           "5m",
+		ExporterErrorLimit: 5,
+	}
+
+	hcExt := newServer(config, zap.NewNop())
+	require.NotNil(t, hcExt)
+
+	mh := newAssertNoErrorHost(t)
+	require.NoError(t, hcExt.Start(context.Background(), mh))
+	t.Cleanup(func() { require.NoError(t, hcExt.Shutdown(context.Background())) })
+
+	require.Error(t, hcExt.Start(context.Background(), mh))
+}
+
+func TestHealthCheckMultipleShutdowns(t *testing.T) {
+	config := Config{
+		TCPAddr: confignet.TCPAddr{
+			Endpoint: "localhost:13134",
+		},
+		Interval:           "5m",
+		ExporterErrorLimit: 5,
+	}
+
+	hcExt := newServer(config, zap.NewNop())
+	require.NotNil(t, hcExt)
+
+	require.NoError(t, hcExt.Start(context.Background(), componenttest.NewNopHost()))
+	require.NoError(t, hcExt.Shutdown(context.Background()))
+	require.NoError(t, hcExt.Shutdown(context.Background()))
+}
+
+func TestHealthCheckShutdownWithoutStart(t *testing.T) {
+	config := Config{
+		TCPAddr: confignet.TCPAddr{
+			Endpoint: "localhost:13134",
+		},
+		Interval:           "5m",
+		ExporterErrorLimit: 5,
+	}
+
+	hcExt := newServer(config, zap.NewNop())
+	require.NotNil(t, hcExt)
+
+	require.NoError(t, hcExt.Shutdown(context.Background()))
+}
+
+// assertNoErrorHost implements a component.Host that asserts that there were no errors.
+type assertNoErrorHost struct {
+	component.Host
+	*testing.T
+}
+
+// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
+func newAssertNoErrorHost(t *testing.T) component.Host {
+	return &assertNoErrorHost{
+		Host: componenttest.NewNopHost(),
+		T:    t,
+	}
+}

--- a/extension/awsecshealthcheckextension/exporter.go
+++ b/extension/awsecshealthcheckextension/exporter.go
@@ -1,0 +1,53 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package awsecshealthcheckextension
+
+import (
+	"sync"
+	"time"
+
+	"go.opencensus.io/stats/view"
+)
+
+// ECSHealthCheckExporter is a struct implement the exporter interface in open census that could export metrics
+type ECSHealthCheckExporter struct {
+	mu                 sync.Mutex
+	exporterErrorQueue []*view.Data
+}
+
+func newECSHealthCheckExporter() *ECSHealthCheckExporter {
+	return &ECSHealthCheckExporter{}
+}
+
+// ExportView function could export the view to the queue
+func (e *ECSHealthCheckExporter) ExportView(vd *view.Data) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	e.exporterErrorQueue = append(e.exporterErrorQueue, vd)
+}
+
+// rotate function could rotate the error logs that expired the time interval
+func (e *ECSHealthCheckExporter) rotate(interval time.Duration) {
+	viewNum := len(e.exporterErrorQueue)
+	currentTime := time.Now()
+	for i := 0; i < viewNum; i++ {
+		vd := e.exporterErrorQueue[0]
+		if vd.Start.Add(interval).After(currentTime) {
+			e.exporterErrorQueue = append(e.exporterErrorQueue, vd)
+		}
+		e.exporterErrorQueue = e.exporterErrorQueue[1:]
+	}
+}

--- a/extension/awsecshealthcheckextension/exporter_test.go
+++ b/extension/awsecshealthcheckextension/exporter_test.go
@@ -1,0 +1,57 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package awsecshealthcheckextension
+
+import (
+	"go.opencensus.io/stats/view"
+	"gotest.tools/v3/assert"
+	"testing"
+	"time"
+)
+
+func TestECSHealthCheckExporter_ExportView(t *testing.T) {
+	exporter := &ECSHealthCheckExporter{}
+	vd := &view.Data{
+		View:  nil,
+		Start: time.Time{},
+		End:   time.Time{},
+		Rows:  nil,
+	}
+	exporter.ExportView(vd)
+	assert.Equal(t, 1, len(exporter.exporterErrorQueue))
+}
+
+func TestECSHealthCheckExporter_rotate(t *testing.T) {
+	exporter := &ECSHealthCheckExporter{}
+	currentTime := time.Now()
+	time1 := currentTime.Add(-10 * time.Minute)
+	time2 := currentTime.Add(-3 * time.Minute)
+	vd1 := &view.Data{
+		View:  nil,
+		Start: time1,
+		End:   currentTime,
+		Rows:  nil,
+	}
+	vd2 := &view.Data{
+		View:  nil,
+		Start: time2,
+		End:   currentTime,
+		Rows:  nil,
+	}
+	exporter.ExportView(vd1)
+	exporter.ExportView(vd2)
+	exporter.rotate(5 * time.Minute)
+	assert.Equal(t, 1, len(exporter.exporterErrorQueue))
+}

--- a/extension/awsecshealthcheckextension/factory.go
+++ b/extension/awsecshealthcheckextension/factory.go
@@ -1,0 +1,56 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package awsecshealthcheckextension
+
+import (
+	"context"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/config/confignet"
+	"go.opentelemetry.io/collector/extension/extensionhelper"
+)
+
+const (
+	// The value of extension "type" in configuration.
+	typeStr = "aws_ecs_health_check"
+
+	defaultEndpoint = "127.0.0.1:13134"
+)
+
+// NewFactory creates a factory for HealthCheck extension.
+func NewFactory() component.ExtensionFactory {
+	return extensionhelper.NewFactory(
+		typeStr,
+		createDefaultConfig,
+		createExtension)
+}
+
+func createDefaultConfig() config.Extension {
+	return &Config{
+		ExtensionSettings: config.NewExtensionSettings(config.NewID(typeStr)),
+		TCPAddr: confignet.TCPAddr{
+			Endpoint: defaultEndpoint,
+		},
+		Interval:           "5m",
+		ExporterErrorLimit: 5,
+	}
+}
+
+func createExtension(_ context.Context, set component.ExtensionCreateSettings, cfg config.Extension) (component.Extension, error) {
+	config := cfg.(*Config)
+
+	return newServer(*config, set.Logger), nil
+}

--- a/extension/awsecshealthcheckextension/factory_test.go
+++ b/extension/awsecshealthcheckextension/factory_test.go
@@ -1,0 +1,54 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package awsecshealthcheckextension
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/config/configcheck"
+	"go.opentelemetry.io/collector/config/confignet"
+	"go.opentelemetry.io/collector/testutil"
+)
+
+func TestFactory_CreateDefaultConfig(t *testing.T) {
+	cfg := createDefaultConfig()
+	assert.Equal(t, &Config{
+		ExtensionSettings: config.NewExtensionSettings(config.NewID(typeStr)),
+		TCPAddr: confignet.TCPAddr{
+			Endpoint: defaultEndpoint,
+		},
+	}, cfg)
+
+	assert.NoError(t, configcheck.ValidateConfig(cfg))
+	ext, err := createExtension(context.Background(), component.ExtensionCreateSettings{Logger: zap.NewNop()}, cfg)
+	require.NoError(t, err)
+	require.NotNil(t, ext)
+}
+
+func TestFactory_CreateExtension(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	cfg.TCPAddr.Endpoint = testutil.GetAvailableLocalAddress(t)
+
+	ext, err := createExtension(context.Background(), component.ExtensionCreateSettings{Logger: zap.NewNop()}, cfg)
+	require.NoError(t, err)
+	require.NotNil(t, ext)
+}

--- a/extension/awsecshealthcheckextension/testdata/config.yaml
+++ b/extension/awsecshealthcheckextension/testdata/config.yaml
@@ -1,0 +1,22 @@
+extensions:
+  aws_ecs_health_check:
+  aws_ecs_health_check/1:
+    endpoint: 0.0.0.0:13134
+    interval: "5m"
+    exporter_error_limit: 5
+
+service:
+  extensions: [aws_ecs_health_check/1]
+  pipelines:
+    traces:
+      receivers: [nop]
+      processors: [nop]
+      exporters: [nop]
+
+# Data pipeline is required to load the config.
+receivers:
+  [nop]
+processors:
+  [nop]
+exporters:
+  [nop]

--- a/service/defaultcomponents/defaults.go
+++ b/service/defaultcomponents/defaults.go
@@ -28,6 +28,7 @@ import (
 	"go.opentelemetry.io/collector/exporter/prometheusexporter"
 	"go.opentelemetry.io/collector/exporter/prometheusremotewriteexporter"
 	"go.opentelemetry.io/collector/exporter/zipkinexporter"
+	"go.opentelemetry.io/collector/extension/awsecshealthcheckextension"
 	"go.opentelemetry.io/collector/extension/ballastextension"
 	"go.opentelemetry.io/collector/extension/bearertokenauthextension"
 	"go.opentelemetry.io/collector/extension/healthcheckextension"
@@ -65,6 +66,7 @@ func Components() (
 		pprofextension.NewFactory(),
 		zpagesextension.NewFactory(),
 		ballastextension.NewFactory(),
+		awsecshealthcheckextension.NewFactory(),
 	)
 	if err != nil {
 		errs = append(errs, err)

--- a/service/defaultcomponents/defaults.go
+++ b/service/defaultcomponents/defaults.go
@@ -28,6 +28,7 @@ import (
 	"go.opentelemetry.io/collector/exporter/prometheusexporter"
 	"go.opentelemetry.io/collector/exporter/prometheusremotewriteexporter"
 	"go.opentelemetry.io/collector/exporter/zipkinexporter"
+	"go.opentelemetry.io/collector/extension/awsecshealthcheckextension"
 	"go.opentelemetry.io/collector/extension/bearertokenauthextension"
 	"go.opentelemetry.io/collector/extension/healthcheckextension"
 	"go.opentelemetry.io/collector/extension/oidcauthextension"
@@ -59,6 +60,7 @@ func Components() (
 
 	extensions, err := component.MakeExtensionFactoryMap(
 		bearertokenauthextension.NewFactory(),
+		awsecshealthcheckextension.NewFactory(),
 		healthcheckextension.NewFactory(),
 		oidcauthextension.NewFactory(),
 		pprofextension.NewFactory(),


### PR DESCRIPTION
**Description:** 
This is a new health check extension feature for AWS/ECS, as we are going to monitor the OT collector health through the return status from endpoint of the new extension, detailed design in the design doc below, we will move this extension to opentelemetry-collector-contrib repo after we have can get the obsmetrics from internal folder in opentelemetry-collector.

**Link to tracking Issue:**
https://github.com/open-telemetry/opentelemetry-collector/issues/2573

**Testing:** 
`make otelcol`  
`./otelcol_darwin_amd64 --config /Users/tianduo/Documents/ot_healthcheck.yaml` 
run some script to connect to the endpoint, it will return 200/500 when the error number less/larger than the limit

**Documentation:** 
https://docs.google.com/document/d/1SpUMsWA2DeaoVazeQ8uEc1Wvu5LphmQU_TjzLmuJ4QM/edit#heading=h.rs1luwizct2w