### PR TITLE
Handle errors when reloading service

### DIFF
--- a/service/collector.go
+++ b/service/collector.go
@@ -269,7 +269,10 @@ func (col *Collector) setupConfigurationComponents(ctx context.Context) error {
 				return
 			default:
 				col.logger.Warn("Config WatchForUpdated exited", zap.Error(err))
-				col.reloadService(context.Background())
+				err := col.reloadService(context.Background())
+				if err != nil {
+					col.asyncErrorChannel <- err
+				}
 			}
 		}()
 	}

--- a/service/collector.go
+++ b/service/collector.go
@@ -269,8 +269,7 @@ func (col *Collector) setupConfigurationComponents(ctx context.Context) error {
 				return
 			default:
 				col.logger.Warn("Config WatchForUpdated exited", zap.Error(err))
-				err := col.reloadService(context.Background())
-				if err != nil {
+				if err := col.reloadService(context.Background()); err != nil {
 					col.asyncErrorChannel <- err
 				}
 			}


### PR DESCRIPTION
**Description**
Fix bug: The collector hangs when reloading the service fails. This change will cause the collector fail with a fatal error if it can't be reloaded.

**Example**
* Load the collector with a valid config
* Config changed to an invalid config
* Reload the collector using parseprovider.Watchable
* [Current behaviour] Collector hangs in a stopped state
* [New behaviour] Collector exits with fatal error

**Testing**
Manually tested only
