### PR TITLE
Prepare auth API to return a context

### DIFF
--- a/config/configauth/mock_serverauth.go
+++ b/config/configauth/mock_serverauth.go
@@ -35,9 +35,9 @@ type MockAuthenticator struct {
 }
 
 // Authenticate executes the mock's AuthenticateFunc, if provided, or just returns the given context unchanged.
-func (m *MockAuthenticator) Authenticate(ctx context.Context, headers map[string][]string) error {
+func (m *MockAuthenticator) Authenticate(ctx context.Context, headers map[string][]string) (context.Context, error) {
 	if m.AuthenticateFunc == nil {
-		return nil
+		return context.Background(), nil
 	}
 	return m.AuthenticateFunc(ctx, headers)
 }

--- a/config/configauth/mock_serverauth_test.go
+++ b/config/configauth/mock_serverauth_test.go
@@ -25,17 +25,18 @@ func TestAuthenticateFunc(t *testing.T) {
 	// prepare
 	m := &MockAuthenticator{}
 	called := false
-	m.AuthenticateFunc = func(c context.Context, m map[string][]string) error {
+	m.AuthenticateFunc = func(c context.Context, m map[string][]string) (context.Context, error) {
 		called = true
-		return nil
+		return context.Background(), nil
 	}
 
 	// test
-	err := m.Authenticate(context.Background(), nil)
+	ctx, err := m.Authenticate(context.Background(), nil)
 
 	// verify
 	assert.NoError(t, err)
 	assert.True(t, called)
+	assert.NotNil(t, ctx)
 }
 
 func TestNilOperations(t *testing.T) {
@@ -46,8 +47,9 @@ func TestNilOperations(t *testing.T) {
 	origCtx := context.Background()
 
 	{
-		err := m.Authenticate(origCtx, nil)
+		ctx, err := m.Authenticate(origCtx, nil)
 		assert.NoError(t, err)
+		assert.NotNil(t, ctx)
 	}
 
 	{

--- a/config/configauth/serverauth.go
+++ b/config/configauth/serverauth.go
@@ -40,7 +40,7 @@ type ServerAuthenticator interface {
 	// When the authentication fails, an error must be returned and the caller must not retry. This function is typically called from interceptors,
 	// on behalf of receivers, but receivers can still call this directly if the usage of interceptors isn't suitable.
 	// The deadline and cancellation given to this function must be respected, but note that authentication data has to be part of the map, not context.
-	Authenticate(ctx context.Context, headers map[string][]string) error
+	Authenticate(ctx context.Context, headers map[string][]string) (context.Context, error)
 
 	// GRPCUnaryServerInterceptor is a helper method to provide a gRPC-compatible UnaryServerInterceptor, typically calling the authenticator's Authenticate method.
 	// While the context is the typical source of authentication data, the interceptor is free to determine where the auth data should come from. For instance, some
@@ -59,7 +59,7 @@ type ServerAuthenticator interface {
 
 // AuthenticateFunc defines the signature for the function responsible for performing the authentication based on the given headers map.
 // See ServerAuthenticator.Authenticate.
-type AuthenticateFunc func(ctx context.Context, headers map[string][]string) error
+type AuthenticateFunc func(ctx context.Context, headers map[string][]string) (context.Context, error)
 
 // GRPCUnaryInterceptorFunc defines the signature for the function intercepting unary gRPC calls, useful for authenticators to use as
 // types for internal structs, making it easier to mock them in tests.
@@ -79,7 +79,8 @@ func DefaultGRPCUnaryServerInterceptor(ctx context.Context, req interface{}, _ *
 		return nil, errMetadataNotFound
 	}
 
-	if err := authenticate(ctx, headers); err != nil {
+	ctx, err := authenticate(ctx, headers)
+	if err != nil {
 		return nil, err
 	}
 
@@ -95,7 +96,9 @@ func DefaultGRPCStreamServerInterceptor(srv interface{}, stream grpc.ServerStrea
 		return errMetadataNotFound
 	}
 
-	if err := authenticate(ctx, headers); err != nil {
+	// TODO: propagate the context down the stream
+	_, err := authenticate(ctx, headers)
+	if err != nil {
 		return err
 	}
 

--- a/config/configauth/serverauth.go
+++ b/config/configauth/serverauth.go
@@ -40,6 +40,10 @@ type ServerAuthenticator interface {
 	// When the authentication fails, an error must be returned and the caller must not retry. This function is typically called from interceptors,
 	// on behalf of receivers, but receivers can still call this directly if the usage of interceptors isn't suitable.
 	// The deadline and cancellation given to this function must be respected, but note that authentication data has to be part of the map, not context.
+	// The resulting context should contain the authentication data, such as the principal/username, group membership (if available), and the raw
+	// authentication data (if possible). This will allow other components in the pipeline to make decisions based on that data, such as routing based
+	// on tenancy as determined by the group membership, or passing through the authentication data to the next collector/backend.
+	// The context keys to be used are not defined yet.
 	Authenticate(ctx context.Context, headers map[string][]string) (context.Context, error)
 
 	// GRPCUnaryServerInterceptor is a helper method to provide a gRPC-compatible UnaryServerInterceptor, typically calling the authenticator's Authenticate method.

--- a/config/configauth/serverauth_test.go
+++ b/config/configauth/serverauth_test.go
@@ -28,9 +28,9 @@ func TestDefaultUnaryInterceptorAuthSucceeded(t *testing.T) {
 	// prepare
 	handlerCalled := false
 	authCalled := false
-	authFunc := func(context.Context, map[string][]string) error {
+	authFunc := func(context.Context, map[string][]string) (context.Context, error) {
 		authCalled = true
-		return nil
+		return context.Background(), nil
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		handlerCalled = true
@@ -52,9 +52,9 @@ func TestDefaultUnaryInterceptorAuthFailure(t *testing.T) {
 	// prepare
 	authCalled := false
 	expectedErr := fmt.Errorf("not authenticated")
-	authFunc := func(context.Context, map[string][]string) error {
+	authFunc := func(context.Context, map[string][]string) (context.Context, error) {
 		authCalled = true
-		return expectedErr
+		return context.Background(), expectedErr
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		assert.FailNow(t, "the handler should not have been called on auth failure!")
@@ -73,9 +73,9 @@ func TestDefaultUnaryInterceptorAuthFailure(t *testing.T) {
 
 func TestDefaultUnaryInterceptorMissingMetadata(t *testing.T) {
 	// prepare
-	authFunc := func(context.Context, map[string][]string) error {
+	authFunc := func(context.Context, map[string][]string) (context.Context, error) {
 		assert.FailNow(t, "the auth func should not have been called!")
-		return nil
+		return context.Background(), nil
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		assert.FailNow(t, "the handler should not have been called!")
@@ -94,9 +94,9 @@ func TestDefaultStreamInterceptorAuthSucceeded(t *testing.T) {
 	// prepare
 	handlerCalled := false
 	authCalled := false
-	authFunc := func(context.Context, map[string][]string) error {
+	authFunc := func(context.Context, map[string][]string) (context.Context, error) {
 		authCalled = true
-		return nil
+		return context.Background(), nil
 	}
 	handler := func(srv interface{}, stream grpc.ServerStream) error {
 		handlerCalled = true
@@ -120,9 +120,9 @@ func TestDefaultStreamInterceptorAuthFailure(t *testing.T) {
 	// prepare
 	authCalled := false
 	expectedErr := fmt.Errorf("not authenticated")
-	authFunc := func(context.Context, map[string][]string) error {
+	authFunc := func(context.Context, map[string][]string) (context.Context, error) {
 		authCalled = true
-		return expectedErr
+		return context.Background(), expectedErr
 	}
 	handler := func(srv interface{}, stream grpc.ServerStream) error {
 		assert.FailNow(t, "the handler should not have been called on auth failure!")
@@ -143,9 +143,9 @@ func TestDefaultStreamInterceptorAuthFailure(t *testing.T) {
 
 func TestDefaultStreamInterceptorMissingMetadata(t *testing.T) {
 	// prepare
-	authFunc := func(context.Context, map[string][]string) error {
+	authFunc := func(context.Context, map[string][]string) (context.Context, error) {
 		assert.FailNow(t, "the auth func should not have been called!")
-		return nil
+		return context.Background(), nil
 	}
 	handler := func(srv interface{}, stream grpc.ServerStream) error {
 		assert.FailNow(t, "the handler should not have been called!")

--- a/extension/oidcauthextension/extension.go
+++ b/extension/oidcauthextension/extension.go
@@ -100,21 +100,21 @@ func (e *oidcExtension) Shutdown(context.Context) error {
 }
 
 // Authenticate checks whether the given context contains valid auth data. Successfully authenticated calls will always return a nil error and a context with the auth data.
-func (e *oidcExtension) Authenticate(ctx context.Context, headers map[string][]string) error {
+func (e *oidcExtension) Authenticate(ctx context.Context, headers map[string][]string) (context.Context, error) {
 	authHeaders := headers[e.cfg.Attribute]
 	if len(authHeaders) == 0 {
-		return errNotAuthenticated
+		return ctx, errNotAuthenticated
 	}
 
 	// we only use the first header, if multiple values exist
 	parts := strings.Split(authHeaders[0], " ")
 	if len(parts) != 2 {
-		return errInvalidAuthenticationHeaderFormat
+		return ctx, errInvalidAuthenticationHeaderFormat
 	}
 
 	idToken, err := e.verifier.Verify(ctx, parts[1])
 	if err != nil {
-		return fmt.Errorf("failed to verify token: %w", err)
+		return ctx, fmt.Errorf("failed to verify token: %w", err)
 	}
 
 	claims := map[string]interface{}{}
@@ -125,20 +125,22 @@ func (e *oidcExtension) Authenticate(ctx context.Context, headers map[string][]s
 		// to read the claims. It could fail if we were using a custom struct. Instead of
 		// swalling the error, it's better to make this future-proof, in case the underlying
 		// code changes
-		return errFailedToObtainClaimsFromToken
+		return ctx, errFailedToObtainClaimsFromToken
 	}
 
 	_, err = getSubjectFromClaims(claims, e.cfg.UsernameClaim, idToken.Subject)
 	if err != nil {
-		return fmt.Errorf("failed to get subject from claims in the token: %w", err)
+		return ctx, fmt.Errorf("failed to get subject from claims in the token: %w", err)
 	}
 
 	_, err = getGroupsFromClaims(claims, e.cfg.GroupsClaim)
 	if err != nil {
-		return fmt.Errorf("failed to get groups from claims in the token: %w", err)
+		return ctx, fmt.Errorf("failed to get groups from claims in the token: %w", err)
 	}
 
-	return nil
+	// TODO: once the design for #2734 is determined, we will probably need to add the auth data to the context
+	// https://github.com/open-telemetry/opentelemetry-collector/issues/2734
+	return ctx, nil
 }
 
 // GRPCUnaryServerInterceptor is a helper method to provide a gRPC-compatible UnaryInterceptor, typically calling the authenticator's Authenticate method.

--- a/extension/oidcauthextension/extension_test.go
+++ b/extension/oidcauthextension/extension_test.go
@@ -69,10 +69,11 @@ func TestOIDCAuthenticationSucceeded(t *testing.T) {
 	require.NoError(t, err)
 
 	// test
-	err = p.Authenticate(context.Background(), map[string][]string{"authorization": {fmt.Sprintf("Bearer %s", token)}})
+	ctx, err := p.Authenticate(context.Background(), map[string][]string{"authorization": {fmt.Sprintf("Bearer %s", token)}})
 
 	// verify
 	assert.NoError(t, err)
+	assert.NotNil(t, ctx)
 
 	// TODO(jpkroehling): assert that the authentication routine set the subject/membership to the resource
 }
@@ -209,10 +210,11 @@ func TestOIDCInvalidAuthHeader(t *testing.T) {
 	require.NoError(t, err)
 
 	// test
-	err = p.Authenticate(context.Background(), map[string][]string{"authorization": {"some-value"}})
+	ctx, err := p.Authenticate(context.Background(), map[string][]string{"authorization": {"some-value"}})
 
 	// verify
 	assert.Equal(t, errInvalidAuthenticationHeaderFormat, err)
+	assert.NotNil(t, ctx)
 }
 
 func TestOIDCNotAuthenticated(t *testing.T) {
@@ -224,10 +226,11 @@ func TestOIDCNotAuthenticated(t *testing.T) {
 	require.NoError(t, err)
 
 	// test
-	err = p.Authenticate(context.Background(), make(map[string][]string))
+	ctx, err := p.Authenticate(context.Background(), make(map[string][]string))
 
 	// verify
 	assert.Equal(t, errNotAuthenticated, err)
+	assert.NotNil(t, ctx)
 }
 
 func TestProviderNotReacheable(t *testing.T) {
@@ -262,10 +265,11 @@ func TestFailedToVerifyToken(t *testing.T) {
 	require.NoError(t, err)
 
 	// test
-	err = p.Authenticate(context.Background(), map[string][]string{"authorization": {"Bearer some-token"}})
+	ctx, err := p.Authenticate(context.Background(), map[string][]string{"authorization": {"Bearer some-token"}})
 
 	// verify
 	assert.Error(t, err)
+	assert.NotNil(t, ctx)
 }
 
 func TestFailedToGetGroupsClaimFromToken(t *testing.T) {
@@ -325,10 +329,11 @@ func TestFailedToGetGroupsClaimFromToken(t *testing.T) {
 			require.NoError(t, err)
 
 			// test
-			err = p.Authenticate(context.Background(), map[string][]string{"authorization": {fmt.Sprintf("Bearer %s", token)}})
+			ctx, err := p.Authenticate(context.Background(), map[string][]string{"authorization": {fmt.Sprintf("Bearer %s", token)}})
 
 			// verify
 			assert.ErrorIs(t, err, tt.expectedError)
+			assert.NotNil(t, ctx)
 		})
 	}
 }


### PR DESCRIPTION
This PR is split from #3552 and contains only the first commits from that, as discussed during today's SIG Collector call. 

﻿Signed-off-by: Juraci Paixão Kröhling juraci@kroehling.de