### PR TITLE
Remove `mem-ballast-size-mib` from command line options

### DIFF
--- a/examples/k8s/otel-config.yaml
+++ b/examples/k8s/otel-config.yaml
@@ -25,8 +25,6 @@ data:
     processors:
       batch:
       memory_limiter:
-        # Same as --mem-ballast-size-mib CLI argument
-        ballast_size_mib: 165
         # 80% of maximum memory up to 2G
         limit_mib: 400
         # 25% of limit up to 2G
@@ -35,8 +33,10 @@ data:
     extensions:
       health_check: {}
       zpages: {}
+      memory_ballast:
+        size_mib: 165
     service:
-      extensions: [health_check, zpages]
+      extensions: [health_check, zpages, memory_ballast]
       pipelines:
         traces:
           receivers: [otlp]
@@ -65,8 +65,6 @@ spec:
       - command:
           - "/otelcol"
           - "--config=/conf/otel-agent-config.yaml"
-          # Memory Ballast size should be max 1/3 to 1/2 of memory.
-          - "--mem-ballast-size-mib=165"
         image: otel/opentelemetry-collector-dev:latest
         name: otel-agent
         resources:
@@ -121,8 +119,6 @@ data:
     processors:
       batch:
       memory_limiter:
-        # Same as --mem-ballast-size-mib CLI argument
-        ballast_size_mib: 683
         # 80% of maximum memory up to 2G
         limit_mib: 1500
         # 25% of limit up to 2G
@@ -131,6 +127,9 @@ data:
     extensions:
       health_check: {}
       zpages: {}
+      memory_ballast:
+        # Memory Ballast size should be max 1/3 to 1/2 of memory.
+        size_mib: 683
     exporters:
       zipkin:
         endpoint: "http://somezipkin.target.com:9411/api/v2/spans" # Replace with a real endpoint.
@@ -138,7 +137,7 @@ data:
         endpoint: "somejaegergrpc.target.com:14250" # Replace with a real endpoint.
         insecure: true
     service:
-      extensions: [health_check, zpages]
+      extensions: [health_check, zpages, memory_ballast]
       pipelines:
         traces/1:
           receivers: [otlp, zipkin]
@@ -198,8 +197,6 @@ spec:
       - command:
           - "/otelcol"
           - "--config=/conf/otel-collector-config.yaml"
-#           Memory Ballast size should be max 1/3 to 1/2 of memory.
-          - "--mem-ballast-size-mib=683"
         image: otel/opentelemetry-collector-dev:latest
         name: otel-collector
         resources:

--- a/extension/ballastextension/memory_ballast_test.go
+++ b/extension/ballastextension/memory_ballast_test.go
@@ -73,6 +73,7 @@ func TestMemoryBallast(t *testing.T) {
 			assert.Nil(t, mbExt.ballast)
 
 			assert.NoError(t, mbExt.Start(context.Background(), componenttest.NewNopHost()))
+			assert.Equal(t, tt.expect, int(GetBallastSize()))
 			assert.Equal(t, tt.expect, len(mbExt.ballast))
 
 			assert.NoError(t, mbExt.Shutdown(context.Background()))

--- a/internal/goldendataset/resource_generator.go
+++ b/internal/goldendataset/resource_generator.go
@@ -120,7 +120,6 @@ func appendExecAttributes(attrMap pdata.AttributeMap) {
 	parts := pdata.NewAttributeValueArray()
 	parts.ArrayVal().AppendEmpty().SetStringVal("otelcol")
 	parts.ArrayVal().AppendEmpty().SetStringVal("--config=/etc/otel-collector-config.yaml")
-	parts.ArrayVal().AppendEmpty().SetStringVal("--mem-ballast-size-mib=683")
 	attrMap.Upsert(conventions.AttributeProcessCommandLine, parts)
 	attrMap.UpsertString(conventions.AttributeProcessExecutablePath, "/usr/local/bin/otelcol")
 	attrMap.UpsertInt(conventions.AttributeProcessID, 2020)

--- a/processor/memorylimiter/memorylimiter.go
+++ b/processor/memorylimiter/memorylimiter.go
@@ -105,8 +105,8 @@ func newMemoryLimiter(logger *zap.Logger, cfg *Config) (*memoryLimiter, error) {
 	}
 
 	logger.Info("Memory limiter configured",
-		zap.Uint64("limit_mib", usageChecker.memAllocLimit),
-		zap.Uint64("spike_limit_mib", usageChecker.memSpikeLimit),
+		zap.Uint64("limit_mib", usageChecker.memAllocLimit/mibBytes),
+		zap.Uint64("spike_limit_mib", usageChecker.memSpikeLimit/mibBytes),
 		zap.Duration("check_interval", cfg.CheckInterval))
 
 	ml := &memoryLimiter{
@@ -138,7 +138,7 @@ func getMemUsageChecker(cfg *Config, logger *zap.Logger) (*memUsageChecker, erro
 		return nil, fmt.Errorf("failed to get total memory, use fixed memory settings (limit_mib): %w", err)
 	}
 	logger.Info("Using percentage memory limiter",
-		zap.Uint64("total_memory", totalMemory),
+		zap.Uint64("total_memory_mib", totalMemory/mibBytes),
 		zap.Uint32("limit_percentage", cfg.MemoryLimitPercentage),
 		zap.Uint32("spike_limit_percentage", cfg.MemorySpikePercentage))
 	return newPercentageMemUsageChecker(totalMemory, uint64(cfg.MemoryLimitPercentage), uint64(cfg.MemorySpikePercentage))
@@ -245,7 +245,7 @@ func (ml *memoryLimiter) setForcingDrop(b bool) {
 }
 
 func memstatToZapField(ms *runtime.MemStats) zap.Field {
-	return zap.Uint64("cur_mem_mib", ms.Alloc/1024/1024)
+	return zap.Uint64("cur_mem_mib", ms.Alloc/mibBytes)
 }
 
 func (ml *memoryLimiter) doGCandReadMemStats() *runtime.MemStats {

--- a/service/collector_test.go
+++ b/service/collector_test.go
@@ -106,7 +106,7 @@ func TestCollector_Start(t *testing.T) {
 
 type mockColTelemetry struct{}
 
-func (tel *mockColTelemetry) init(chan<- error, uint64, *zap.Logger) error {
+func (tel *mockColTelemetry) init(chan<- error, *zap.Logger) error {
 	return nil
 }
 

--- a/service/internal/builder/builder.go
+++ b/service/internal/builder/builder.go
@@ -14,15 +14,7 @@
 
 package builder
 
-import (
-	"flag"
-	"fmt"
-)
-
 const (
-	// flags
-	memBallastFlag = "mem-ballast-size-mib"
-
 	zapKindKey         = "kind"
 	zapKindReceiver    = "receiver"
 	zapKindProcessor   = "processor"
@@ -30,19 +22,3 @@ const (
 	zapKindExtension   = "extension"
 	zapNameKey         = "name"
 )
-
-var (
-	memBallastSize *uint
-)
-
-// Flags adds flags related to basic building of the collector server to the given flagset.
-func Flags(flags *flag.FlagSet) {
-	memBallastSize = flags.Uint(memBallastFlag, 0,
-		fmt.Sprintf("Flag to specify size of memory (MiB) ballast to set. Ballast is not used when this is not specified. "+
-			"default settings: 0"))
-}
-
-// MemBallastSize returns the size of memory ballast to use in MBs
-func MemBallastSize() int {
-	return int(*memBallastSize)
-}

--- a/service/internal/telemetry/process_telemetry_test.go
+++ b/service/internal/telemetry/process_telemetry_test.go
@@ -24,9 +24,7 @@ import (
 )
 
 func TestProcessTelemetry(t *testing.T) {
-	const ballastSizeBytes uint64 = 0
-
-	pmv, err := NewProcessMetricsViews(ballastSizeBytes)
+	pmv, err := NewProcessMetricsViews()
 	require.NoError(t, err)
 	assert.NotNil(t, pmv)
 

--- a/service/telemetry.go
+++ b/service/telemetry.go
@@ -38,7 +38,7 @@ import (
 var collectorTelemetry collectorTelemetryExporter = &colTelemetry{}
 
 type collectorTelemetryExporter interface {
-	init(asyncErrorChannel chan<- error, ballastSizeBytes uint64, logger *zap.Logger) error
+	init(asyncErrorChannel chan<- error, logger *zap.Logger) error
 	shutdown() error
 }
 
@@ -47,7 +47,7 @@ type colTelemetry struct {
 	server *http.Server
 }
 
-func (tel *colTelemetry) init(asyncErrorChannel chan<- error, ballastSizeBytes uint64, logger *zap.Logger) error {
+func (tel *colTelemetry) init(asyncErrorChannel chan<- error, logger *zap.Logger) error {
 	level := configtelemetry.GetMetricsLevelFlagValue()
 	metricsAddr := telemetry.GetMetricsAddr()
 
@@ -55,7 +55,7 @@ func (tel *colTelemetry) init(asyncErrorChannel chan<- error, ballastSizeBytes u
 		return nil
 	}
 
-	processMetricsViews, err := telemetry2.NewProcessMetricsViews(ballastSizeBytes)
+	processMetricsViews, err := telemetry2.NewProcessMetricsViews()
 	if err != nil {
 		return err
 	}

--- a/testbed/tests/scenarios.go
+++ b/testbed/tests/scenarios.go
@@ -209,7 +209,7 @@ func genRandByteString(len int) string {
 
 // Scenario1kSPSWithAttrs runs a performance test at 1k sps with specified span attributes
 // and test options.
-func Scenario1kSPSWithAttrs(t *testing.T, args []string, tests []TestCase, processors map[string]string) {
+func Scenario1kSPSWithAttrs(t *testing.T, args []string, tests []TestCase, processors map[string]string, extensions map[string]string) {
 	for i := range tests {
 		test := tests[i]
 
@@ -228,7 +228,7 @@ func Scenario1kSPSWithAttrs(t *testing.T, args []string, tests []TestCase, proce
 			receiver := testbed.NewOCDataReceiver(testbed.GetAvailablePort(t))
 
 			// Prepare config.
-			configStr := createConfigYaml(t, sender, receiver, resultDir, processors, nil)
+			configStr := createConfigYaml(t, sender, receiver, resultDir, processors, extensions)
 			configCleanup, err := agentProc.PrepareConfig(configStr)
 			require.NoError(t, err)
 			defer configCleanup()

--- a/testbed/tests/testdata/ballast_extension.yaml
+++ b/testbed/tests/testdata/ballast_extension.yaml
@@ -1,0 +1,28 @@
+extensions:
+  memory_ballast:
+    size_mib: %d
+
+receivers:
+  jaeger:
+    protocols:
+      grpc:
+        endpoint: "localhost:14250"
+  opencensus:
+    endpoint: "localhost:55678"
+
+exporters:
+  opencensus:
+    endpoint: "localhost:56565"
+    insecure: true
+  logging:
+    loglevel: info
+
+service:
+  extensions: [memory_ballast]
+  pipelines:
+    traces:
+      receivers: [jaeger]
+      exporters: [opencensus,logging]
+    metrics:
+      receivers: [opencensus]
+      exporters: [opencensus,logging]

--- a/testbed/tests/trace_test.go
+++ b/testbed/tests/trace_test.go
@@ -213,12 +213,14 @@ func TestTrace1kSPSWithAttrs(t *testing.T) {
 			expectedMaxRAM: 100,
 			resultsSummary: performanceResultsSummary,
 		},
-	}, nil)
+	}, nil, nil)
 }
 
 func TestTraceBallast1kSPSWithAttrs(t *testing.T) {
-	args := []string{"--mem-ballast-size-mib", "1000"}
-	Scenario1kSPSWithAttrs(t, args, []TestCase{
+	ballastExtCfg := `
+  memory_ballast:
+    size_mib: 1000`
+	Scenario1kSPSWithAttrs(t, []string{}, []TestCase{
 		// No attributes.
 		{
 			attrCount:      0,
@@ -248,11 +250,13 @@ func TestTraceBallast1kSPSWithAttrs(t *testing.T) {
 			expectedMaxRAM: 2000,
 			resultsSummary: performanceResultsSummary,
 		},
-	}, nil)
+	}, nil, map[string]string{"memory_ballast": ballastExtCfg})
 }
 
 func TestTraceBallast1kSPSAddAttrs(t *testing.T) {
-	args := []string{"--mem-ballast-size-mib", "1000"}
+	ballastExtCfg := `
+  memory_ballast:
+    size_mib: 1000`
 
 	attrProcCfg := `
   attributes:
@@ -275,7 +279,7 @@ func TestTraceBallast1kSPSAddAttrs(t *testing.T) {
 
 	Scenario1kSPSWithAttrs(
 		t,
-		args,
+		[]string{},
 		[]TestCase{
 			{
 				attrCount:      0,
@@ -307,6 +311,7 @@ func TestTraceBallast1kSPSAddAttrs(t *testing.T) {
 			},
 		},
 		map[string]string{"attributes": attrProcCfg},
+		map[string]string{"memory_ballast": ballastExtCfg},
 	)
 }
 


### PR DESCRIPTION
**Description:** <Describe what has changed. 
* Remove `mem-ballast-size-mib` from command line options
* Replace `mem-ballast-size-mib` setting by `ballast extension` in testings


**Link to tracking Issue:** 
https://github.com/open-telemetry/opentelemetry-collector/issues/2516

