### PR TITLE
Replace mem-ballast-size-mib by ballast extension in testbed

### DIFF
--- a/internal/goldendataset/resource_generator.go
+++ b/internal/goldendataset/resource_generator.go
@@ -120,7 +120,6 @@ func appendExecAttributes(attrMap pdata.AttributeMap) {
 	parts := pdata.NewAttributeValueArray()
 	parts.ArrayVal().AppendEmpty().SetStringVal("otelcol")
 	parts.ArrayVal().AppendEmpty().SetStringVal("--config=/etc/otel-collector-config.yaml")
-	parts.ArrayVal().AppendEmpty().SetStringVal("--mem-ballast-size-mib=683")
 	attrMap.Upsert(conventions.AttributeProcessCommandLine, parts)
 	attrMap.UpsertString(conventions.AttributeProcessExecutablePath, "/usr/local/bin/otelcol")
 	attrMap.UpsertInt(conventions.AttributeProcessID, 2020)

--- a/testbed/tests/scenarios.go
+++ b/testbed/tests/scenarios.go
@@ -209,7 +209,7 @@ func genRandByteString(len int) string {
 
 // Scenario1kSPSWithAttrs runs a performance test at 1k sps with specified span attributes
 // and test options.
-func Scenario1kSPSWithAttrs(t *testing.T, args []string, tests []TestCase, processors map[string]string) {
+func Scenario1kSPSWithAttrs(t *testing.T, args []string, tests []TestCase, processors map[string]string, extensions map[string]string) {
 	for i := range tests {
 		test := tests[i]
 
@@ -228,7 +228,7 @@ func Scenario1kSPSWithAttrs(t *testing.T, args []string, tests []TestCase, proce
 			receiver := testbed.NewOCDataReceiver(testbed.GetAvailablePort(t))
 
 			// Prepare config.
-			configStr := createConfigYaml(t, sender, receiver, resultDir, processors, nil)
+			configStr := createConfigYaml(t, sender, receiver, resultDir, processors, extensions)
 			configCleanup, err := agentProc.PrepareConfig(configStr)
 			require.NoError(t, err)
 			defer configCleanup()

--- a/testbed/tests/testdata/ballast_extension.yaml
+++ b/testbed/tests/testdata/ballast_extension.yaml
@@ -1,0 +1,28 @@
+extensions:
+  memory_ballast:
+    size_mib: %d
+
+receivers:
+  jaeger:
+    protocols:
+      grpc:
+        endpoint: "localhost:14250"
+  opencensus:
+    endpoint: "localhost:55678"
+
+exporters:
+  opencensus:
+    endpoint: "localhost:56565"
+    insecure: true
+  logging:
+    loglevel: info
+
+service:
+  extensions: [memory_ballast]
+  pipelines:
+    traces:
+      receivers: [jaeger]
+      exporters: [opencensus,logging]
+    metrics:
+      receivers: [opencensus]
+      exporters: [opencensus,logging]

--- a/testbed/tests/trace_test.go
+++ b/testbed/tests/trace_test.go
@@ -213,12 +213,14 @@ func TestTrace1kSPSWithAttrs(t *testing.T) {
 			expectedMaxRAM: 100,
 			resultsSummary: performanceResultsSummary,
 		},
-	}, nil)
+	}, nil, nil)
 }
 
 func TestTraceBallast1kSPSWithAttrs(t *testing.T) {
-	args := []string{"--mem-ballast-size-mib", "1000"}
-	Scenario1kSPSWithAttrs(t, args, []TestCase{
+	ballastExtCfg := `
+  memory_ballast:
+    size_mib: 1000`
+	Scenario1kSPSWithAttrs(t, []string{}, []TestCase{
 		// No attributes.
 		{
 			attrCount:      0,
@@ -248,11 +250,13 @@ func TestTraceBallast1kSPSWithAttrs(t *testing.T) {
 			expectedMaxRAM: 2000,
 			resultsSummary: performanceResultsSummary,
 		},
-	}, nil)
+	}, nil, map[string]string{"memory_ballast": ballastExtCfg})
 }
 
 func TestTraceBallast1kSPSAddAttrs(t *testing.T) {
-	args := []string{"--mem-ballast-size-mib", "1000"}
+	ballastExtCfg := `
+  memory_ballast:
+    size_mib: 1000`
 
 	attrProcCfg := `
   attributes:
@@ -275,7 +279,7 @@ func TestTraceBallast1kSPSAddAttrs(t *testing.T) {
 
 	Scenario1kSPSWithAttrs(
 		t,
-		args,
+		[]string{},
 		[]TestCase{
 			{
 				attrCount:      0,
@@ -307,6 +311,7 @@ func TestTraceBallast1kSPSAddAttrs(t *testing.T) {
 			},
 		},
 		map[string]string{"attributes": attrProcCfg},
+		map[string]string{"memory_ballast": ballastExtCfg},
 	)
 }
 


### PR DESCRIPTION
**Description:** <Describe what has changed. 
* Replace `mem-ballast-size-mib` by `ballast extension` in testbed

**Link to tracking Issue:** <Issue number if applicable>
#2516
