### PR TITLE
Disable `mem-ballast-size-mib` from command line option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,10 @@
 ## Unreleased
 
 ## 🛑 Breaking changes 🛑
-
 - Remove Resize() from pdata slice APIs (#3675)
-
+- Remove the ballast allocation when `mem-ballast-size-mib` is set in command line (#3626)
+  - Use [`ballast extension`](./extension/ballastextension/README.md) to set memory ballast instead.
+  
 ## v0.30.0 Beta
 
 ## 🛑 Breaking changes 🛑

--- a/service/internal/builder/builder.go
+++ b/service/internal/builder/builder.go
@@ -36,6 +36,7 @@ var (
 )
 
 // Flags adds flags related to basic building of the collector server to the given flagset.
+// Deprecated: keep this flag for preventing the breaking change. Use `ballast extension` instead.
 func Flags(flags *flag.FlagSet) {
 	memBallastSize = flags.Uint(memBallastFlag, 0,
 		fmt.Sprintf("Flag to specify size of memory (MiB) ballast to set. Ballast is not used when this is not specified. "+

--- a/service/internal/telemetry/process_telemetry.go
+++ b/service/internal/telemetry/process_telemetry.go
@@ -111,8 +111,8 @@ var viewRSSMemory = &view.View{
 func NewProcessMetricsViews(ballastSizeBytes uint64) (*ProcessMetricsViews, error) {
 	pmv := &ProcessMetricsViews{
 		prevTimeUnixNano: time.Now().UnixNano(),
-		ballastSizeBytes: ballastSizeBytes,
 		views:            []*view.View{viewProcessUptime, viewAllocMem, viewTotalAllocMem, viewSysMem, viewCPUSeconds, viewRSSMemory},
+		ballastSizeBytes: ballastSizeBytes,
 		done:             make(chan struct{}),
 	}
 
@@ -176,8 +176,10 @@ func (pmv *ProcessMetricsViews) updateViews() {
 
 func (pmv *ProcessMetricsViews) readMemStats(ms *runtime.MemStats) {
 	runtime.ReadMemStats(ms)
-	ms.Alloc -= pmv.ballastSizeBytes
-	ms.HeapAlloc -= pmv.ballastSizeBytes
-	ms.HeapSys -= pmv.ballastSizeBytes
-	ms.HeapInuse -= pmv.ballastSizeBytes
+	if pmv.ballastSizeBytes > 0 {
+		ms.Alloc -= pmv.ballastSizeBytes
+		ms.HeapAlloc -= pmv.ballastSizeBytes
+		ms.HeapSys -= pmv.ballastSizeBytes
+		ms.HeapInuse -= pmv.ballastSizeBytes
+	}
 }

--- a/service/internal/telemetry/process_telemetry_test.go
+++ b/service/internal/telemetry/process_telemetry_test.go
@@ -25,7 +25,6 @@ import (
 
 func TestProcessTelemetry(t *testing.T) {
 	const ballastSizeBytes uint64 = 0
-
 	pmv, err := NewProcessMetricsViews(ballastSizeBytes)
 	require.NoError(t, err)
 	assert.NotNil(t, pmv)


### PR DESCRIPTION
**Description:** <Describe what has changed. 
* Disable `mem-ballast-size-mib` command line option for setting memory ballast

**Link to tracking Issue:** <Issue number if applicable>
#2516

