### PR TITLE
Access Ballast extension in Memory Limiter via Host.GetExtensions

### DIFF
--- a/extension/ballastextension/memory_ballast.go
+++ b/extension/ballastextension/memory_ballast.go
@@ -24,44 +24,43 @@ import (
 
 const megaBytes = 1024 * 1024
 
-var ballastSizeBytes uint64
-
-type memoryBallast struct {
-	cfg         *Config
-	logger      *zap.Logger
-	ballast     []byte
-	getTotalMem func() (uint64, error)
+type MemoryBallast struct {
+	cfg              *Config
+	logger           *zap.Logger
+	ballast          []byte
+	ballastSizeBytes uint64
+	getTotalMem      func() (uint64, error)
 }
 
-func (m *memoryBallast) Start(_ context.Context, _ component.Host) error {
+func (m *MemoryBallast) Start(_ context.Context, _ component.Host) error {
 	// absolute value supersedes percentage setting
 	if m.cfg.SizeMiB > 0 {
-		ballastSizeBytes = m.cfg.SizeMiB * megaBytes
+		m.ballastSizeBytes = m.cfg.SizeMiB * megaBytes
 	} else {
 		totalMemory, err := m.getTotalMem()
 		if err != nil {
 			return err
 		}
 		ballastPercentage := m.cfg.SizeInPercentage
-		ballastSizeBytes = ballastPercentage * totalMemory / 100
+		m.ballastSizeBytes = ballastPercentage * totalMemory / 100
 	}
 
-	if ballastSizeBytes > 0 {
-		m.ballast = make([]byte, ballastSizeBytes)
+	if m.ballastSizeBytes > 0 {
+		m.ballast = make([]byte, m.ballastSizeBytes)
 	}
 
-	m.logger.Info("Setting memory ballast", zap.Uint32("MiBs", uint32(ballastSizeBytes/megaBytes)))
+	m.logger.Info("Setting memory ballast", zap.Uint32("MiBs", uint32(m.ballastSizeBytes/megaBytes)))
 
 	return nil
 }
 
-func (m *memoryBallast) Shutdown(_ context.Context) error {
+func (m *MemoryBallast) Shutdown(_ context.Context) error {
 	m.ballast = nil
 	return nil
 }
 
-func newMemoryBallast(cfg *Config, logger *zap.Logger, getTotalMem func() (uint64, error)) *memoryBallast {
-	return &memoryBallast{
+func newMemoryBallast(cfg *Config, logger *zap.Logger, getTotalMem func() (uint64, error)) *MemoryBallast {
+	return &MemoryBallast{
 		cfg:         cfg,
 		logger:      logger,
 		getTotalMem: getTotalMem,
@@ -69,6 +68,6 @@ func newMemoryBallast(cfg *Config, logger *zap.Logger, getTotalMem func() (uint6
 }
 
 // GetBallastSize returns the current ballast memory setting in bytes
-func GetBallastSize() uint64 {
-	return ballastSizeBytes
+func (m *MemoryBallast) GetBallastSize() uint64 {
+	return m.ballastSizeBytes
 }

--- a/processor/memorylimiter/factory.go
+++ b/processor/memorylimiter/factory.go
@@ -63,6 +63,7 @@ func createTracesProcessor(
 		nextConsumer,
 		ml.processTraces,
 		processorhelper.WithCapabilities(processorCapabilities),
+		processorhelper.WithStart(ml.start),
 		processorhelper.WithShutdown(ml.shutdown))
 }
 

--- a/processor/memorylimiter/memorylimiter_test.go
+++ b/processor/memorylimiter/memorylimiter_test.go
@@ -444,7 +444,7 @@ func TestBallastSizeMiB(t *testing.T) {
 			ballastExtCfg.SizeMiB = tt.ballastExtBallastSizeSetting
 			ballastExt, _ := ballastExtFactory.CreateExtension(ctx, extCreateSet, ballastExtCfg)
 			ballastExt.Start(ctx, nil)
-			assert.Equal(t, tt.expectResult, tt.expectedMemLimiterBallastSize*mibBytes == ballastextension.GetBallastSize())
+			assert.Equal(t, tt.expectResult, tt.expectedMemLimiterBallastSize*mibBytes == ballastExt.(*ballastextension.MemoryBallast).GetBallastSize())
 		})
 	}
 }


### PR DESCRIPTION
**Description:** <Describe what has changed. 
* Remove the global ballast size variable in ballast extension
* Access Ballast extension in Memory Limiter processor via Host.GetExtensions 

**Link to tracking Issue:** 
#2516

