### PR TITLE
fix bool attribute equality

### DIFF
--- a/model/pdata/common.go
+++ b/model/pdata/common.go
@@ -269,6 +269,10 @@ func (a AttributeValue) Equal(av AttributeValue) bool {
 		return a.orig.Value == av.orig.Value
 	}
 
+	if a.Type() != av.Type() {
+		return false
+	}
+
 	switch v := a.orig.Value.(type) {
 	case *otlpcommon.AnyValue_StringValue:
 		return v.StringValue == av.orig.GetStringValue()

--- a/model/pdata/common_test.go
+++ b/model/pdata/common_test.go
@@ -201,15 +201,15 @@ func TestAttributeValueEqual(t *testing.T) {
 	av1 = NewAttributeValueDouble(123)
 	assert.True(t, av1.Equal(av2))
 
-	av2 = NewAttributeValueBool(true)
+	av2 = NewAttributeValueBool(false)
 	assert.False(t, av1.Equal(av2))
 	assert.False(t, av2.Equal(av1))
 
 	av1 = NewAttributeValueBool(true)
-	assert.True(t, av1.Equal(av2))
+	assert.False(t, av1.Equal(av2))
 
 	av1 = NewAttributeValueBool(false)
-	assert.False(t, av1.Equal(av2))
+	assert.True(t, av1.Equal(av2))
 
 	av1 = NewAttributeValueArray()
 	av1.ArrayVal().AppendEmpty().SetIntVal(123)


### PR DESCRIPTION
**Description:**

Fix a bug - Getting the bool value of a non-bool attribute returns false; therefore, equality of a false bool attribute and any non-bool attribute returned true. To fix this issue, the equality of attributes should assert the two attributes share a type.

**Testing:**

The respective unit test was updated to ensure this edge case was hit.
