### PR TITLE
all: remove OtlpProtoSize in favour of .Size() helper

### DIFF
--- a/model/pdata/common.go
+++ b/model/pdata/common.go
@@ -18,6 +18,7 @@ package pdata
 // such as timestamps, attributes, etc.
 
 import (
+	"fmt"
 	"sort"
 
 	otlpcommon "go.opentelemetry.io/collector/model/internal/data/protogen/common/v1"
@@ -835,4 +836,25 @@ func (sm StringMap) Sort() StringMap {
 
 func newStringKeyValue(k, v string) otlpcommon.StringKeyValue {
 	return otlpcommon.StringKeyValue{Key: k, Value: v}
+}
+
+// ProtoSizeForKnownTypes returns the protobuf generated .Size() for any of Traces, Metrics, Logs.
+// If the type is not known, an error will be returned.
+func ProtoSizeForKnownTypes(v interface{}) (int, error) {
+	switch conv := v.(type) {
+	case Traces:
+		return conv.orig.Size(), nil
+	case *Traces:
+		return conv.orig.Size(), nil
+	case Metrics:
+		return conv.orig.Size(), nil
+	case *Metrics:
+		return conv.orig.Size(), nil
+	case Logs:
+		return conv.orig.Size(), nil
+	case *Logs:
+		return conv.orig.Size(), nil
+	default:
+		return 0, fmt.Errorf("unknown type: %T", v)
+	}
 }

--- a/model/pdata/logs.go
+++ b/model/pdata/logs.go
@@ -85,12 +85,6 @@ func (ld Logs) LogRecordCount() int {
 	return logCount
 }
 
-// OtlpProtoSize returns the size in bytes of this Logs encoded as OTLP Collector
-// ExportLogsServiceRequest ProtoBuf bytes.
-func (ld Logs) OtlpProtoSize() int {
-	return ld.orig.Size()
-}
-
 // ResourceLogs returns the ResourceLogsSlice associated with this Logs.
 func (ld Logs) ResourceLogs() ResourceLogsSlice {
 	return newResourceLogsSlice(&ld.orig.ResourceLogs)

--- a/model/pdata/metrics.go
+++ b/model/pdata/metrics.go
@@ -87,12 +87,6 @@ func (md Metrics) MetricCount() int {
 	return metricCount
 }
 
-// OtlpProtoSize returns the size in bytes of this Metrics encoded as OTLP Collector
-// ExportMetricsServiceRequest ProtoBuf bytes.
-func (md Metrics) OtlpProtoSize() int {
-	return md.orig.Size()
-}
-
 // DataPointCount calculates the total number of data points.
 func (md Metrics) DataPointCount() (dataPointCount int) {
 	rms := md.ResourceMetrics()

--- a/model/pdata/traces.go
+++ b/model/pdata/traces.go
@@ -77,12 +77,6 @@ func (td Traces) SpanCount() int {
 	return spanCount
 }
 
-// OtlpProtoSize returns the size in bytes of this Traces encoded as OTLP Collector
-// ExportTraceServiceRequest ProtoBuf bytes.
-func (td Traces) OtlpProtoSize() int {
-	return td.orig.Size()
-}
-
 // ResourceSpans returns the ResourceSpansSlice associated with this Metrics.
 func (td Traces) ResourceSpans() ResourceSpansSlice {
 	return newResourceSpansSlice(&td.orig.ResourceSpans)

--- a/processor/batchprocessor/batch_processor_test.go
+++ b/processor/batchprocessor/batch_processor_test.go
@@ -140,7 +140,9 @@ func TestBatchProcessorSentBySize(t *testing.T) {
 	sizeSum := 0
 	for requestNum := 0; requestNum < requestCount; requestNum++ {
 		td := testdata.GenerateTracesManySpansSameResource(spansPerRequest)
-		sizeSum += td.OtlpProtoSize()
+		size, err := pdata.ProtoSizeForKnownTypes(td)
+		assert.NoError(t, err)
+		sizeSum += size
 		assert.NoError(t, batcher.ConsumeTraces(context.Background(), td))
 	}
 
@@ -510,7 +512,8 @@ func getTestMetricName(requestNum, index int) string {
 func BenchmarkTraceSizeBytes(b *testing.B) {
 	td := testdata.GenerateTracesManySpansSameResource(8192)
 	for n := 0; n < b.N; n++ {
-		fmt.Println(td.OtlpProtoSize())
+		protoSize, _ := pdata.ProtoSizeForKnownTypes(td)
+		fmt.Println(protoSize)
 	}
 }
 


### PR DESCRIPTION
OtlpProtoSize on every type seemed unncessary given that
each of {Logs, Metrics, Traces} have underlying types that
already have a protobuf generated method .Size() that returns
the size in bytes of the data.

This change removes that method on all those types and instead
makes a helper function "ProtoSizeForKnownTypes" which returns

    (size int, err error)

with the size for the known 3 types, and an error for unknown
types.

Fixes #3531
