### PR TITLE
update Exemplar to use oneOfPrimitiveValue

### DIFF
--- a/cmd/pdatagen/internal/base_fields.go
+++ b/cmd/pdatagen/internal/base_fields.go
@@ -65,18 +65,6 @@ func (ms ${structName}) Set${fieldName}(v ${returnType}) {
 	}
 }`
 
-const accessorsPrimitiveAsDoubleTemplate = `// ${fieldName} returns the ${lowerFieldName} associated with this ${structName}.
-func (ms ${structName}) ${fieldName}() ${returnType} {
-	return (*ms.orig).GetAsDouble()
-}
-
-// Set${fieldName} replaces the ${lowerFieldName} associated with this ${structName}.
-func (ms ${structName}) Set${fieldName}(v ${returnType}) {
-	(*ms.orig).${originFieldName} = &${originFullName}_AsDouble{
-		AsDouble: v,
-	}
-}`
-
 const accessorsPrimitiveTestTemplate = `func Test${structName}_${fieldName}(t *testing.T) {
 	ms := New${structName}()
 	assert.EqualValues(t, ${defaultVal}, ms.${fieldName}())
@@ -417,63 +405,6 @@ func (one oneofField) generateCopyToValue(sb *strings.Builder) {
 }
 
 var _ baseField = (*oneofField)(nil)
-
-type primitiveAsDoubleField struct {
-	originFullName  string
-	fieldName       string
-	originFieldName string
-	returnType      string
-	defaultVal      string
-	testVal         string
-}
-
-func (pf *primitiveAsDoubleField) generateAccessors(ms baseStruct, sb *strings.Builder) {
-	sb.WriteString(os.Expand(accessorsPrimitiveAsDoubleTemplate, func(name string) string {
-		switch name {
-		case "structName":
-			return ms.getName()
-		case "fieldName":
-			return pf.fieldName
-		case "lowerFieldName":
-			return strings.ToLower(pf.fieldName)
-		case "returnType":
-			return pf.returnType
-		case "originFieldName":
-			return pf.originFieldName
-		case "originFullName":
-			return pf.originFullName
-		default:
-			panic(name)
-		}
-	}))
-}
-
-func (pf *primitiveAsDoubleField) generateAccessorsTest(ms baseStruct, sb *strings.Builder) {
-	sb.WriteString(os.Expand(accessorsPrimitiveTestTemplate, func(name string) string {
-		switch name {
-		case "structName":
-			return ms.getName()
-		case "defaultVal":
-			return pf.defaultVal
-		case "fieldName":
-			return pf.fieldName
-		case "testValue":
-			return pf.testVal
-		default:
-			panic(name)
-		}
-	}))
-}
-
-func (pf *primitiveAsDoubleField) generateSetWithTestValue(sb *strings.Builder) {
-	sb.WriteString("\ttv.Set" + pf.fieldName + "(" + pf.testVal + ")")
-}
-
-func (pf *primitiveAsDoubleField) generateCopyToValue(sb *strings.Builder) {
-	sb.WriteString("\tdest.Set" + pf.fieldName + "(ms." + pf.fieldName + "())")
-}
-
-var _ baseField = (*primitiveField)(nil)
 
 type oneOfPrimitiveValue struct {
 	name            string

--- a/cmd/pdatagen/internal/metrics_structs.go
+++ b/cmd/pdatagen/internal/metrics_structs.go
@@ -362,13 +362,27 @@ var exemplar = &messageValueStruct{
 	originFullName: "otlpmetrics.Exemplar",
 	fields: []baseField{
 		timeField,
-		&primitiveAsDoubleField{
-			originFullName:  "otlpmetrics.Exemplar",
-			fieldName:       "Value",
-			originFieldName: "Value",
-			returnType:      "float64",
-			defaultVal:      "float64(0.0)",
-			testVal:         "float64(17.13)",
+		&numberField{
+			fields: []*oneOfPrimitiveValue{
+				{
+					originFullName:  "otlpmetrics.Exemplar",
+					name:            "DoubleVal",
+					originFieldName: "Value",
+					returnType:      "float64",
+					defaultVal:      "float64(0.0)",
+					testVal:         "float64(17.13)",
+					fieldType:       "Double",
+				},
+				{
+					originFullName:  "otlpmetrics.Exemplar",
+					name:            "IntVal",
+					originFieldName: "Value",
+					returnType:      "int64",
+					defaultVal:      "int64(0)",
+					testVal:         "int64(17)",
+					fieldType:       "Int",
+				},
+			},
 		},
 		&sliceField{
 			fieldName:       "FilteredLabels",

--- a/internal/testdata/metric.go
+++ b/internal/testdata/metric.go
@@ -282,7 +282,7 @@ func initDoubleHistogramMetric(hm pdata.Metric) {
 	hdp1.SetBucketCounts([]uint64{0, 1})
 	exemplar := hdp1.Exemplars().AppendEmpty()
 	exemplar.SetTimestamp(TestMetricExemplarTimestamp)
-	exemplar.SetValue(15)
+	exemplar.SetDoubleVal(15)
 	initMetricAttachment(exemplar.FilteredLabels())
 	hdp1.SetExplicitBounds([]float64{1})
 }

--- a/model/pdata/generated_metrics.go
+++ b/model/pdata/generated_metrics.go
@@ -2227,15 +2227,27 @@ func (ms Exemplar) SetTimestamp(v Timestamp) {
 	(*ms.orig).TimeUnixNano = uint64(v)
 }
 
-// Value returns the value associated with this Exemplar.
-func (ms Exemplar) Value() float64 {
+// DoubleVal returns the doubleval associated with this Exemplar.
+func (ms Exemplar) DoubleVal() float64 {
 	return (*ms.orig).GetAsDouble()
 }
 
-// SetValue replaces the value associated with this Exemplar.
-func (ms Exemplar) SetValue(v float64) {
+// SetDoubleVal replaces the doubleval associated with this Exemplar.
+func (ms Exemplar) SetDoubleVal(v float64) {
 	(*ms.orig).Value = &otlpmetrics.Exemplar_AsDouble{
 		AsDouble: v,
+	}
+}
+
+// IntVal returns the intval associated with this Exemplar.
+func (ms Exemplar) IntVal() int64 {
+	return (*ms.orig).GetAsInt()
+}
+
+// SetIntVal replaces the intval associated with this Exemplar.
+func (ms Exemplar) SetIntVal(v int64) {
+	(*ms.orig).Value = &otlpmetrics.Exemplar_AsInt{
+		AsInt: v,
 	}
 }
 
@@ -2247,6 +2259,12 @@ func (ms Exemplar) FilteredLabels() StringMap {
 // CopyTo copies all properties from the current struct to the dest.
 func (ms Exemplar) CopyTo(dest Exemplar) {
 	dest.SetTimestamp(ms.Timestamp())
-	dest.SetValue(ms.Value())
+	switch ms.Type() {
+	case NumberDataPointTypeDouble:
+		dest.SetDoubleVal(ms.DoubleVal())
+	case NumberDataPointTypeInt:
+		dest.SetIntVal(ms.IntVal())
+	}
+
 	ms.FilteredLabels().CopyTo(dest.FilteredLabels())
 }

--- a/model/pdata/generated_metrics_test.go
+++ b/model/pdata/generated_metrics_test.go
@@ -1590,12 +1590,19 @@ func TestExemplar_Timestamp(t *testing.T) {
 	assert.EqualValues(t, testValTimestamp, ms.Timestamp())
 }
 
-func TestExemplar_Value(t *testing.T) {
+func TestExemplar_DoubleVal(t *testing.T) {
 	ms := NewExemplar()
-	assert.EqualValues(t, float64(0.0), ms.Value())
-	testValValue := float64(17.13)
-	ms.SetValue(testValValue)
-	assert.EqualValues(t, testValValue, ms.Value())
+	assert.EqualValues(t, float64(0.0), ms.DoubleVal())
+	testValDoubleVal := float64(17.13)
+	ms.SetDoubleVal(testValDoubleVal)
+	assert.EqualValues(t, testValDoubleVal, ms.DoubleVal())
+}
+func TestExemplar_IntVal(t *testing.T) {
+	ms := NewExemplar()
+	assert.EqualValues(t, int64(0), ms.IntVal())
+	testValIntVal := int64(17)
+	ms.SetIntVal(testValIntVal)
+	assert.EqualValues(t, testValIntVal, ms.IntVal())
 }
 
 func TestExemplar_FilteredLabels(t *testing.T) {
@@ -1939,6 +1946,7 @@ func generateTestExemplar() Exemplar {
 
 func fillTestExemplar(tv Exemplar) {
 	tv.SetTimestamp(Timestamp(1234567890))
-	tv.SetValue(float64(17.13))
+	tv.SetDoubleVal(float64(17.13))
+
 	fillTestStringMap(tv.FilteredLabels())
 }

--- a/model/pdata/metrics.go
+++ b/model/pdata/metrics.go
@@ -321,3 +321,30 @@ func (ms NumberDataPoint) Value() float64 {
 func (ms NumberDataPoint) SetValue(v float64) {
 	ms.SetDoubleVal(v)
 }
+
+// Type returns the type of the value for this Exemplar.
+// Calling this function on zero-initialized Exemplar will cause a panic.
+func (ms Exemplar) Type() NumberDataPointType {
+	if ms.orig.Value == nil {
+		return NumberDataPointTypeNone
+	}
+	switch ms.orig.Value.(type) {
+	case *otlpmetrics.Exemplar_AsDouble:
+		return NumberDataPointTypeDouble
+	case *otlpmetrics.Exemplar_AsInt:
+		return NumberDataPointTypeInt
+	}
+	return NumberDataPointTypeNone
+}
+
+// Value returns the value associated with this Exemplar.
+// Deprecated: Use DoubleVal instead.
+func (ms Exemplar) Value() float64 {
+	return ms.DoubleVal()
+}
+
+// SetValue replaces the value associated with this Exemplar.
+// Deprecated: Use SetDoubleVal instead.
+func (ms Exemplar) SetValue(v float64) {
+	ms.SetDoubleVal(v)
+}

--- a/receiver/prometheusreceiver/internal/otlp_metricfamily_test.go
+++ b/receiver/prometheusreceiver/internal/otlp_metricfamily_test.go
@@ -227,7 +227,7 @@ func TestMetricGroupData_toDistributionPointEquivalence(t *testing.T) {
 				pdataExemplar := pdataPoint.Exemplars().At(i)
 				msgPrefix := fmt.Sprintf("Exemplar #%d:: ", i)
 				require.Equal(t, ocExemplar.Timestamp.AsTime(), pdataExemplar.Timestamp().AsTime(), msgPrefix+"timestamp mismatch")
-				require.Equal(t, ocExemplar.Value, pdataExemplar.Value(), msgPrefix+"value mismatch")
+				require.Equal(t, ocExemplar.Value, pdataExemplar.DoubleVal(), msgPrefix+"value mismatch")
 				pdataExemplarAttachments := make(map[string]string)
 				pdataExemplar.FilteredLabels().Range(func(key, value string) bool {
 					pdataExemplarAttachments[key] = value

--- a/testbed/correctness/metrics/metric_diff.go
+++ b/testbed/correctness/metrics/metric_diff.go
@@ -199,7 +199,7 @@ func diffDoubleExemplars(
 		return diffs
 	}
 	for i := 0; i < expected.Len(); i++ {
-		diffs = diff(diffs, expected.At(i).Value(), actual.At(i).Value(), "Exemplar Value")
+		diffs = diff(diffs, expected.At(i).DoubleVal(), actual.At(i).DoubleVal(), "Exemplar Value")
 	}
 	return diffs
 }

--- a/translator/internaldata/metrics_to_oc.go
+++ b/translator/internaldata/metrics_to_oc.go
@@ -386,7 +386,7 @@ func doubleExemplarsToOC(bounds []float64, ocBuckets []*ocmetrics.DistributionVa
 
 	for i := 0; i < exemplars.Len(); i++ {
 		exemplar := exemplars.At(i)
-		val := exemplar.Value()
+		val := exemplar.DoubleVal()
 		pos := 0
 		for ; pos < len(bounds); pos++ {
 			if val > bounds[pos] {

--- a/translator/internaldata/oc_to_metrics.go
+++ b/translator/internaldata/oc_to_metrics.go
@@ -369,7 +369,7 @@ func exemplarToMetrics(ocExemplar *ocmetrics.DistributionValue_Exemplar, exempla
 		exemplar.SetTimestamp(pdata.TimestampFromTime(ocExemplar.GetTimestamp().AsTime()))
 	}
 	ocAttachments := ocExemplar.GetAttachments()
-	exemplar.SetValue(ocExemplar.GetValue())
+	exemplar.SetDoubleVal(ocExemplar.GetValue())
 	filteredLabels := exemplar.FilteredLabels()
 	filteredLabels.Clear()
 	filteredLabels.EnsureCapacity(len(ocAttachments))


### PR DESCRIPTION
**Description:** Updates Exemplar to use oneOfPrimitiveValue, this means we'll be able to move away from IntDataPoint in the next change.

**Link to tracking Issue:** Part fo #3534 