### PR TITLE
mark IntGauge/IntSum/IntDataPoint as deprecated

### DIFF
--- a/cmd/pdatagen/internal/base_structs.go
+++ b/cmd/pdatagen/internal/base_structs.go
@@ -26,6 +26,7 @@ const messageValueTemplate = `${description}
 //
 // Must use New${structName} function to create new instances.
 // Important: zero-initialized instance is not valid for use.
+// ${deprecated}
 type ${structName} struct {
 	orig *${originName}
 }
@@ -78,6 +79,7 @@ type messageValueStruct struct {
 	structName     string
 	description    string
 	originFullName string
+	deprecated     string
 	fields         []baseField
 }
 
@@ -94,6 +96,8 @@ func (ms *messageValueStruct) generateStruct(sb *strings.Builder) {
 			return ms.originFullName
 		case "description":
 			return ms.description
+		case "deprecated":
+			return ms.deprecated
 		default:
 			panic(name)
 		}

--- a/cmd/pdatagen/internal/metrics_structs.go
+++ b/cmd/pdatagen/internal/metrics_structs.go
@@ -130,6 +130,7 @@ var intGauge = &messageValueStruct{
 	structName:     "IntGauge",
 	description:    "// IntGauge represents the type of a int scalar metric that always exports the \"current value\" for every data point.",
 	originFullName: "otlpmetrics.IntGauge",
+	deprecated:     "Deprecated: Use Gauge instead.",
 	fields: []baseField{
 		&sliceField{
 			fieldName:       "DataPoints",
@@ -156,6 +157,7 @@ var intSum = &messageValueStruct{
 	structName:     "IntSum",
 	description:    "// IntSum represents the type of a numeric int scalar metric that is calculated as a sum of all reported measurements over a time interval.",
 	originFullName: "otlpmetrics.IntSum",
+	deprecated:     "Deprecated: Use Sum instead.",
 	fields: []baseField{
 		aggregationTemporalityField,
 		isMonotonicField,
@@ -218,6 +220,7 @@ var intDataPoint = &messageValueStruct{
 	structName:     "IntDataPoint",
 	description:    "// IntDataPoint is a single data point in a timeseries that describes the time-varying values of a scalar int metric.",
 	originFullName: "otlpmetrics.IntDataPoint",
+	deprecated:     "Deprecated: Use NumberDataPoint instead.",
 	fields: []baseField{
 		labelsField,
 		startTimeField,

--- a/model/pdata/generated_common.go
+++ b/model/pdata/generated_common.go
@@ -28,6 +28,7 @@ import (
 //
 // Must use NewInstrumentationLibrary function to create new instances.
 // Important: zero-initialized instance is not valid for use.
+//
 type InstrumentationLibrary struct {
 	orig *otlpcommon.InstrumentationLibrary
 }

--- a/model/pdata/generated_log.go
+++ b/model/pdata/generated_log.go
@@ -167,6 +167,7 @@ func (es ResourceLogsSlice) RemoveIf(f func(ResourceLogs) bool) {
 //
 // Must use NewResourceLogs function to create new instances.
 // Important: zero-initialized instance is not valid for use.
+//
 type ResourceLogs struct {
 	orig *otlplogs.ResourceLogs
 }
@@ -342,6 +343,7 @@ func (es InstrumentationLibraryLogsSlice) RemoveIf(f func(InstrumentationLibrary
 //
 // Must use NewInstrumentationLibraryLogs function to create new instances.
 // Important: zero-initialized instance is not valid for use.
+//
 type InstrumentationLibraryLogs struct {
 	orig *otlplogs.InstrumentationLibraryLogs
 }
@@ -518,6 +520,7 @@ func (es LogSlice) RemoveIf(f func(LogRecord) bool) {
 //
 // Must use NewLogRecord function to create new instances.
 // Important: zero-initialized instance is not valid for use.
+//
 type LogRecord struct {
 	orig *otlplogs.LogRecord
 }

--- a/model/pdata/generated_metrics.go
+++ b/model/pdata/generated_metrics.go
@@ -167,6 +167,7 @@ func (es ResourceMetricsSlice) RemoveIf(f func(ResourceMetrics) bool) {
 //
 // Must use NewResourceMetrics function to create new instances.
 // Important: zero-initialized instance is not valid for use.
+//
 type ResourceMetrics struct {
 	orig *otlpmetrics.ResourceMetrics
 }
@@ -342,6 +343,7 @@ func (es InstrumentationLibraryMetricsSlice) RemoveIf(f func(InstrumentationLibr
 //
 // Must use NewInstrumentationLibraryMetrics function to create new instances.
 // Important: zero-initialized instance is not valid for use.
+//
 type InstrumentationLibraryMetrics struct {
 	orig *otlpmetrics.InstrumentationLibraryMetrics
 }
@@ -518,6 +520,7 @@ func (es MetricSlice) RemoveIf(f func(Metric) bool) {
 //
 // Must use NewMetric function to create new instances.
 // Important: zero-initialized instance is not valid for use.
+//
 type Metric struct {
 	orig *otlpmetrics.Metric
 }
@@ -578,6 +581,7 @@ func (ms Metric) CopyTo(dest Metric) {
 //
 // Must use NewIntGauge function to create new instances.
 // Important: zero-initialized instance is not valid for use.
+// Deprecated: Use Gauge instead.
 type IntGauge struct {
 	orig *otlpmetrics.IntGauge
 }
@@ -610,6 +614,7 @@ func (ms IntGauge) CopyTo(dest IntGauge) {
 //
 // Must use NewGauge function to create new instances.
 // Important: zero-initialized instance is not valid for use.
+//
 type Gauge struct {
 	orig *otlpmetrics.Gauge
 }
@@ -642,6 +647,7 @@ func (ms Gauge) CopyTo(dest Gauge) {
 //
 // Must use NewIntSum function to create new instances.
 // Important: zero-initialized instance is not valid for use.
+// Deprecated: Use Sum instead.
 type IntSum struct {
 	orig *otlpmetrics.IntSum
 }
@@ -696,6 +702,7 @@ func (ms IntSum) CopyTo(dest IntSum) {
 //
 // Must use NewSum function to create new instances.
 // Important: zero-initialized instance is not valid for use.
+//
 type Sum struct {
 	orig *otlpmetrics.Sum
 }
@@ -750,6 +757,7 @@ func (ms Sum) CopyTo(dest Sum) {
 //
 // Must use NewHistogram function to create new instances.
 // Important: zero-initialized instance is not valid for use.
+//
 type Histogram struct {
 	orig *otlpmetrics.Histogram
 }
@@ -793,6 +801,7 @@ func (ms Histogram) CopyTo(dest Histogram) {
 //
 // Must use NewSummary function to create new instances.
 // Important: zero-initialized instance is not valid for use.
+//
 type Summary struct {
 	orig *otlpmetrics.Summary
 }
@@ -962,6 +971,7 @@ func (es IntDataPointSlice) RemoveIf(f func(IntDataPoint) bool) {
 //
 // Must use NewIntDataPoint function to create new instances.
 // Important: zero-initialized instance is not valid for use.
+// Deprecated: Use NumberDataPoint instead.
 type IntDataPoint struct {
 	orig *otlpmetrics.IntDataPoint
 }
@@ -1170,6 +1180,7 @@ func (es NumberDataPointSlice) RemoveIf(f func(NumberDataPoint) bool) {
 //
 // Must use NewNumberDataPoint function to create new instances.
 // Important: zero-initialized instance is not valid for use.
+//
 type NumberDataPoint struct {
 	orig *otlpmetrics.NumberDataPoint
 }
@@ -1398,6 +1409,7 @@ func (es HistogramDataPointSlice) RemoveIf(f func(HistogramDataPoint) bool) {
 //
 // Must use NewHistogramDataPoint function to create new instances.
 // Important: zero-initialized instance is not valid for use.
+//
 type HistogramDataPoint struct {
 	orig *otlpmetrics.HistogramDataPoint
 }
@@ -1639,6 +1651,7 @@ func (es SummaryDataPointSlice) RemoveIf(f func(SummaryDataPoint) bool) {
 //
 // Must use NewSummaryDataPoint function to create new instances.
 // Important: zero-initialized instance is not valid for use.
+//
 type SummaryDataPoint struct {
 	orig *otlpmetrics.SummaryDataPoint
 }
@@ -1858,6 +1871,7 @@ func (es ValueAtQuantileSlice) RemoveIf(f func(ValueAtQuantile) bool) {
 //
 // Must use NewValueAtQuantile function to create new instances.
 // Important: zero-initialized instance is not valid for use.
+//
 type ValueAtQuantile struct {
 	orig *otlpmetrics.SummaryDataPoint_ValueAtQuantile
 }
@@ -2027,6 +2041,7 @@ func (es IntExemplarSlice) RemoveIf(f func(IntExemplar) bool) {
 //
 // Must use NewIntExemplar function to create new instances.
 // Important: zero-initialized instance is not valid for use.
+//
 type IntExemplar struct {
 	orig *otlpmetrics.IntExemplar
 }
@@ -2202,6 +2217,7 @@ func (es ExemplarSlice) RemoveIf(f func(Exemplar) bool) {
 //
 // Must use NewExemplar function to create new instances.
 // Important: zero-initialized instance is not valid for use.
+//
 type Exemplar struct {
 	orig *otlpmetrics.Exemplar
 }

--- a/model/pdata/generated_resource.go
+++ b/model/pdata/generated_resource.go
@@ -28,6 +28,7 @@ import (
 //
 // Must use NewResource function to create new instances.
 // Important: zero-initialized instance is not valid for use.
+//
 type Resource struct {
 	orig *otlpresource.Resource
 }

--- a/model/pdata/generated_trace.go
+++ b/model/pdata/generated_trace.go
@@ -167,6 +167,7 @@ func (es ResourceSpansSlice) RemoveIf(f func(ResourceSpans) bool) {
 //
 // Must use NewResourceSpans function to create new instances.
 // Important: zero-initialized instance is not valid for use.
+//
 type ResourceSpans struct {
 	orig *otlptrace.ResourceSpans
 }
@@ -342,6 +343,7 @@ func (es InstrumentationLibrarySpansSlice) RemoveIf(f func(InstrumentationLibrar
 //
 // Must use NewInstrumentationLibrarySpans function to create new instances.
 // Important: zero-initialized instance is not valid for use.
+//
 type InstrumentationLibrarySpans struct {
 	orig *otlptrace.InstrumentationLibrarySpans
 }
@@ -518,6 +520,7 @@ func (es SpanSlice) RemoveIf(f func(Span) bool) {
 //
 // Must use NewSpan function to create new instances.
 // Important: zero-initialized instance is not valid for use.
+//
 type Span struct {
 	orig *otlptrace.Span
 }
@@ -827,6 +830,7 @@ func (es SpanEventSlice) RemoveIf(f func(SpanEvent) bool) {
 //
 // Must use NewSpanEvent function to create new instances.
 // Important: zero-initialized instance is not valid for use.
+//
 type SpanEvent struct {
 	orig *otlptrace.Span_Event
 }
@@ -1031,6 +1035,7 @@ func (es SpanLinkSlice) RemoveIf(f func(SpanLink) bool) {
 //
 // Must use NewSpanLink function to create new instances.
 // Important: zero-initialized instance is not valid for use.
+//
 type SpanLink struct {
 	orig *otlptrace.Span_Link
 }
@@ -1108,6 +1113,7 @@ func (ms SpanLink) CopyTo(dest SpanLink) {
 //
 // Must use NewSpanStatus function to create new instances.
 // Important: zero-initialized instance is not valid for use.
+//
 type SpanStatus struct {
 	orig *otlptrace.Status
 }


### PR DESCRIPTION
**Description:** In preparation to remove `IntSum`/`IntGauge`/`IntDataPoint`, marking them as deprecated

**Link to tracking Issue:** Part of #3534

