### PR TITLE
remove SetValue/Value func for NumberDataPoint/Exemplar

### DIFF
--- a/model/pdata/metrics.go
+++ b/model/pdata/metrics.go
@@ -310,18 +310,6 @@ func (ms NumberDataPoint) Type() MetricValueType {
 	return MetricValueTypeNone
 }
 
-// Value returns the value associated with this NumberDataPoint.
-// Deprecated: Use DoubleVal instead.
-func (ms NumberDataPoint) Value() float64 {
-	return ms.DoubleVal()
-}
-
-// SetValue replaces the value associated with this NumberDataPoint.
-// Deprecated: Use SetDoubleVal instead.
-func (ms NumberDataPoint) SetValue(v float64) {
-	ms.SetDoubleVal(v)
-}
-
 // Type returns the type of the value for this Exemplar.
 // Calling this function on zero-initialized Exemplar will cause a panic.
 func (ms Exemplar) Type() MetricValueType {
@@ -335,16 +323,4 @@ func (ms Exemplar) Type() MetricValueType {
 		return MetricValueTypeInt
 	}
 	return MetricValueTypeNone
-}
-
-// Value returns the value associated with this Exemplar.
-// Deprecated: Use DoubleVal instead.
-func (ms Exemplar) Value() float64 {
-	return ms.DoubleVal()
-}
-
-// SetValue replaces the value associated with this Exemplar.
-// Deprecated: Use SetDoubleVal instead.
-func (ms Exemplar) SetValue(v float64) {
-	ms.SetDoubleVal(v)
 }

--- a/receiver/prometheusreceiver/internal/otlp_metricfamily_test.go
+++ b/receiver/prometheusreceiver/internal/otlp_metricfamily_test.go
@@ -466,7 +466,7 @@ func TestMetricGroupData_toNumberDataUnitTest(t *testing.T) {
 			},
 			want: func() pdata.NumberDataPoint {
 				point := pdata.NewNumberDataPoint()
-				point.SetValue(39.9)
+				point.SetDoubleVal(39.9)
 				point.SetTimestamp(38 * 1e6) // the time in milliseconds -> nanoseconds.
 				point.SetStartTimestamp(38 * 1e6)
 				labelsMap := point.LabelsMap()
@@ -539,7 +539,7 @@ func TestMetricGroupData_toNumberDataPointEquivalence(t *testing.T) {
 			// 1. Ensure that the startTimestamps are equal.
 			require.Equal(t, ocTimeseries.GetStartTimestamp().AsTime(), pdataPoint.Timestamp().AsTime(), "The timestamp must be equal")
 			// 2. Ensure that the value is equal.
-			require.Equal(t, ocPoint.GetDoubleValue(), pdataPoint.Value(), "Count must be equal")
+			require.Equal(t, ocPoint.GetDoubleValue(), pdataPoint.DoubleVal(), "Count must be equal")
 			// 4. Ensure that the point's timestamp is equal to that from the OpenCensusProto data point.
 			require.Equal(t, ocPoint.GetTimestamp().AsTime(), pdataPoint.Timestamp().AsTime(), "Point timestamps must be equal")
 			// 5. Ensure that the labels all match up.


### PR DESCRIPTION
**Description:** Removing `SetValue` and `Value` functions for `NumberDataPoint` and `Exemplar`. These have been replaced by `SetDoubleVal` and `DoubleVal` and updated in the contrib repo as well.

**Link to tracking Issue:** Part of #3534
