### PR TITLE
Remove IntGauge/IntSum

### DIFF
--- a/cmd/pdatagen/internal/metrics_structs.go
+++ b/cmd/pdatagen/internal/metrics_structs.go
@@ -425,6 +425,6 @@ var aggregationTemporalityField = &primitiveTypedField{
 var oneofDataField = &oneofField{
 	copyFuncName:    "copyData",
 	originFieldName: "Data",
-	testVal:         "&otlpmetrics.Metric_IntGauge{IntGauge: &otlpmetrics.IntGauge{}}",
-	fillTestName:    "IntGauge",
+	testVal:         "&otlpmetrics.Metric_Gauge{Gauge: &otlpmetrics.Gauge{}}",
+	fillTestName:    "Gauge",
 }

--- a/cmd/pdatagen/internal/metrics_structs.go
+++ b/cmd/pdatagen/internal/metrics_structs.go
@@ -35,9 +35,7 @@ var metricsFile = &File{
 		instrumentationLibraryMetrics,
 		metricSlice,
 		metric,
-		intGauge,
 		doubleGauge,
-		intSum,
 		doubleSum,
 		histogram,
 		summary,
@@ -124,20 +122,6 @@ var metric = &messageValueStruct{
 	},
 }
 
-var intGauge = &messageValueStruct{
-	structName:     "IntGauge",
-	description:    "// IntGauge represents the type of a int scalar metric that always exports the \"current value\" for every data point.",
-	originFullName: "otlpmetrics.IntGauge",
-	deprecated:     "Deprecated: Use Gauge instead.",
-	fields: []baseField{
-		&sliceField{
-			fieldName:       "DataPoints",
-			originFieldName: "DataPoints",
-			returnSlice:     intDataPointSlice,
-		},
-	},
-}
-
 var doubleGauge = &messageValueStruct{
 	structName:     "Gauge",
 	description:    "// Gauge represents the type of a double scalar metric that always exports the \"current value\" for every data point.",
@@ -147,22 +131,6 @@ var doubleGauge = &messageValueStruct{
 			fieldName:       "DataPoints",
 			originFieldName: "DataPoints",
 			returnSlice:     numberDataPointSlice,
-		},
-	},
-}
-
-var intSum = &messageValueStruct{
-	structName:     "IntSum",
-	description:    "// IntSum represents the type of a numeric int scalar metric that is calculated as a sum of all reported measurements over a time interval.",
-	originFullName: "otlpmetrics.IntSum",
-	deprecated:     "Deprecated: Use Sum instead.",
-	fields: []baseField{
-		aggregationTemporalityField,
-		isMonotonicField,
-		&sliceField{
-			fieldName:       "DataPoints",
-			originFieldName: "DataPoints",
-			returnSlice:     intDataPointSlice,
 		},
 	},
 }

--- a/model/pdata/generated_metrics.go
+++ b/model/pdata/generated_metrics.go
@@ -574,39 +574,6 @@ func (ms Metric) CopyTo(dest Metric) {
 	copyData(ms.orig, dest.orig)
 }
 
-// IntGauge represents the type of a int scalar metric that always exports the "current value" for every data point.
-//
-// This is a reference type, if passed by value and callee modifies it the
-// caller will see the modification.
-//
-// Must use NewIntGauge function to create new instances.
-// Important: zero-initialized instance is not valid for use.
-// Deprecated: Use Gauge instead.
-type IntGauge struct {
-	orig *otlpmetrics.IntGauge
-}
-
-func newIntGauge(orig *otlpmetrics.IntGauge) IntGauge {
-	return IntGauge{orig: orig}
-}
-
-// NewIntGauge creates a new empty IntGauge.
-//
-// This must be used only in testing code since no "Set" method available.
-func NewIntGauge() IntGauge {
-	return newIntGauge(&otlpmetrics.IntGauge{})
-}
-
-// DataPoints returns the DataPoints associated with this IntGauge.
-func (ms IntGauge) DataPoints() IntDataPointSlice {
-	return newIntDataPointSlice(&(*ms.orig).DataPoints)
-}
-
-// CopyTo copies all properties from the current struct to the dest.
-func (ms IntGauge) CopyTo(dest IntGauge) {
-	ms.DataPoints().CopyTo(dest.DataPoints())
-}
-
 // Gauge represents the type of a double scalar metric that always exports the "current value" for every data point.
 //
 // This is a reference type, if passed by value and callee modifies it the
@@ -637,61 +604,6 @@ func (ms Gauge) DataPoints() NumberDataPointSlice {
 
 // CopyTo copies all properties from the current struct to the dest.
 func (ms Gauge) CopyTo(dest Gauge) {
-	ms.DataPoints().CopyTo(dest.DataPoints())
-}
-
-// IntSum represents the type of a numeric int scalar metric that is calculated as a sum of all reported measurements over a time interval.
-//
-// This is a reference type, if passed by value and callee modifies it the
-// caller will see the modification.
-//
-// Must use NewIntSum function to create new instances.
-// Important: zero-initialized instance is not valid for use.
-// Deprecated: Use Sum instead.
-type IntSum struct {
-	orig *otlpmetrics.IntSum
-}
-
-func newIntSum(orig *otlpmetrics.IntSum) IntSum {
-	return IntSum{orig: orig}
-}
-
-// NewIntSum creates a new empty IntSum.
-//
-// This must be used only in testing code since no "Set" method available.
-func NewIntSum() IntSum {
-	return newIntSum(&otlpmetrics.IntSum{})
-}
-
-// AggregationTemporality returns the aggregationtemporality associated with this IntSum.
-func (ms IntSum) AggregationTemporality() AggregationTemporality {
-	return AggregationTemporality((*ms.orig).AggregationTemporality)
-}
-
-// SetAggregationTemporality replaces the aggregationtemporality associated with this IntSum.
-func (ms IntSum) SetAggregationTemporality(v AggregationTemporality) {
-	(*ms.orig).AggregationTemporality = otlpmetrics.AggregationTemporality(v)
-}
-
-// IsMonotonic returns the ismonotonic associated with this IntSum.
-func (ms IntSum) IsMonotonic() bool {
-	return (*ms.orig).IsMonotonic
-}
-
-// SetIsMonotonic replaces the ismonotonic associated with this IntSum.
-func (ms IntSum) SetIsMonotonic(v bool) {
-	(*ms.orig).IsMonotonic = v
-}
-
-// DataPoints returns the DataPoints associated with this IntSum.
-func (ms IntSum) DataPoints() IntDataPointSlice {
-	return newIntDataPointSlice(&(*ms.orig).DataPoints)
-}
-
-// CopyTo copies all properties from the current struct to the dest.
-func (ms IntSum) CopyTo(dest IntSum) {
-	dest.SetAggregationTemporality(ms.AggregationTemporality())
-	dest.SetIsMonotonic(ms.IsMonotonic())
 	ms.DataPoints().CopyTo(dest.DataPoints())
 }
 

--- a/model/pdata/generated_metrics_test.go
+++ b/model/pdata/generated_metrics_test.go
@@ -425,20 +425,6 @@ func TestMetric_Unit(t *testing.T) {
 	assert.EqualValues(t, testValUnit, ms.Unit())
 }
 
-func TestIntGauge_CopyTo(t *testing.T) {
-	ms := NewIntGauge()
-	generateTestIntGauge().CopyTo(ms)
-	assert.EqualValues(t, generateTestIntGauge(), ms)
-}
-
-func TestIntGauge_DataPoints(t *testing.T) {
-	ms := NewIntGauge()
-	assert.EqualValues(t, NewIntDataPointSlice(), ms.DataPoints())
-	fillTestIntDataPointSlice(ms.DataPoints())
-	testValDataPoints := generateTestIntDataPointSlice()
-	assert.EqualValues(t, testValDataPoints, ms.DataPoints())
-}
-
 func TestGauge_CopyTo(t *testing.T) {
 	ms := NewGauge()
 	generateTestGauge().CopyTo(ms)
@@ -450,36 +436,6 @@ func TestGauge_DataPoints(t *testing.T) {
 	assert.EqualValues(t, NewNumberDataPointSlice(), ms.DataPoints())
 	fillTestNumberDataPointSlice(ms.DataPoints())
 	testValDataPoints := generateTestNumberDataPointSlice()
-	assert.EqualValues(t, testValDataPoints, ms.DataPoints())
-}
-
-func TestIntSum_CopyTo(t *testing.T) {
-	ms := NewIntSum()
-	generateTestIntSum().CopyTo(ms)
-	assert.EqualValues(t, generateTestIntSum(), ms)
-}
-
-func TestIntSum_AggregationTemporality(t *testing.T) {
-	ms := NewIntSum()
-	assert.EqualValues(t, AggregationTemporalityUnspecified, ms.AggregationTemporality())
-	testValAggregationTemporality := AggregationTemporalityCumulative
-	ms.SetAggregationTemporality(testValAggregationTemporality)
-	assert.EqualValues(t, testValAggregationTemporality, ms.AggregationTemporality())
-}
-
-func TestIntSum_IsMonotonic(t *testing.T) {
-	ms := NewIntSum()
-	assert.EqualValues(t, false, ms.IsMonotonic())
-	testValIsMonotonic := true
-	ms.SetIsMonotonic(testValIsMonotonic)
-	assert.EqualValues(t, testValIsMonotonic, ms.IsMonotonic())
-}
-
-func TestIntSum_DataPoints(t *testing.T) {
-	ms := NewIntSum()
-	assert.EqualValues(t, NewIntDataPointSlice(), ms.DataPoints())
-	fillTestIntDataPointSlice(ms.DataPoints())
-	testValDataPoints := generateTestIntDataPointSlice()
 	assert.EqualValues(t, testValDataPoints, ms.DataPoints())
 }
 
@@ -1552,16 +1508,6 @@ func fillTestMetric(tv Metric) {
 	fillTestIntGauge(tv.IntGauge())
 }
 
-func generateTestIntGauge() IntGauge {
-	tv := NewIntGauge()
-	fillTestIntGauge(tv)
-	return tv
-}
-
-func fillTestIntGauge(tv IntGauge) {
-	fillTestIntDataPointSlice(tv.DataPoints())
-}
-
 func generateTestGauge() Gauge {
 	tv := NewGauge()
 	fillTestGauge(tv)
@@ -1570,18 +1516,6 @@ func generateTestGauge() Gauge {
 
 func fillTestGauge(tv Gauge) {
 	fillTestNumberDataPointSlice(tv.DataPoints())
-}
-
-func generateTestIntSum() IntSum {
-	tv := NewIntSum()
-	fillTestIntSum(tv)
-	return tv
-}
-
-func fillTestIntSum(tv IntSum) {
-	tv.SetAggregationTemporality(AggregationTemporalityCumulative)
-	tv.SetIsMonotonic(true)
-	fillTestIntDataPointSlice(tv.DataPoints())
 }
 
 func generateTestSum() Sum {

--- a/model/pdata/generated_metrics_test.go
+++ b/model/pdata/generated_metrics_test.go
@@ -1504,8 +1504,8 @@ func fillTestMetric(tv Metric) {
 	tv.SetName("test_name")
 	tv.SetDescription("test_description")
 	tv.SetUnit("1")
-	(*tv.orig).Data = &otlpmetrics.Metric_IntGauge{IntGauge: &otlpmetrics.IntGauge{}}
-	fillTestIntGauge(tv.IntGauge())
+	(*tv.orig).Data = &otlpmetrics.Metric_Gauge{Gauge: &otlpmetrics.Gauge{}}
+	fillTestGauge(tv.Gauge())
 }
 
 func generateTestGauge() Gauge {

--- a/model/pdata/metrics.go
+++ b/model/pdata/metrics.go
@@ -105,12 +105,8 @@ func (md Metrics) DataPointCount() (dataPointCount int) {
 			for k := 0; k < ms.Len(); k++ {
 				m := ms.At(k)
 				switch m.DataType() {
-				case MetricDataTypeIntGauge:
-					dataPointCount += m.IntGauge().DataPoints().Len()
 				case MetricDataTypeGauge:
 					dataPointCount += m.Gauge().DataPoints().Len()
-				case MetricDataTypeIntSum:
-					dataPointCount += m.IntSum().DataPoints().Len()
 				case MetricDataTypeSum:
 					dataPointCount += m.Sum().DataPoints().Len()
 				case MetricDataTypeHistogram:
@@ -129,9 +125,7 @@ type MetricDataType int32
 
 const (
 	MetricDataTypeNone MetricDataType = iota
-	MetricDataTypeIntGauge
 	MetricDataTypeGauge
-	MetricDataTypeIntSum
 	MetricDataTypeSum
 	MetricDataTypeHistogram
 	MetricDataTypeSummary
@@ -142,12 +136,8 @@ func (mdt MetricDataType) String() string {
 	switch mdt {
 	case MetricDataTypeNone:
 		return "None"
-	case MetricDataTypeIntGauge:
-		return "IntGauge"
 	case MetricDataTypeGauge:
 		return "Gauge"
-	case MetricDataTypeIntSum:
-		return "IntSum"
 	case MetricDataTypeSum:
 		return "Sum"
 	case MetricDataTypeHistogram:
@@ -162,12 +152,8 @@ func (mdt MetricDataType) String() string {
 // Calling this function on zero-initialized Metric will cause a panic.
 func (ms Metric) DataType() MetricDataType {
 	switch ms.orig.Data.(type) {
-	case *otlpmetrics.Metric_IntGauge:
-		return MetricDataTypeIntGauge
 	case *otlpmetrics.Metric_Gauge:
 		return MetricDataTypeGauge
-	case *otlpmetrics.Metric_IntSum:
-		return MetricDataTypeIntSum
 	case *otlpmetrics.Metric_Sum:
 		return MetricDataTypeSum
 	case *otlpmetrics.Metric_Histogram:
@@ -182,12 +168,8 @@ func (ms Metric) DataType() MetricDataType {
 // Calling this function on zero-initialized Metric will cause a panic.
 func (ms Metric) SetDataType(ty MetricDataType) {
 	switch ty {
-	case MetricDataTypeIntGauge:
-		ms.orig.Data = &otlpmetrics.Metric_IntGauge{IntGauge: &otlpmetrics.IntGauge{}}
 	case MetricDataTypeGauge:
 		ms.orig.Data = &otlpmetrics.Metric_Gauge{Gauge: &otlpmetrics.Gauge{}}
-	case MetricDataTypeIntSum:
-		ms.orig.Data = &otlpmetrics.Metric_IntSum{IntSum: &otlpmetrics.IntSum{}}
 	case MetricDataTypeSum:
 		ms.orig.Data = &otlpmetrics.Metric_Sum{Sum: &otlpmetrics.Sum{}}
 	case MetricDataTypeHistogram:
@@ -197,25 +179,11 @@ func (ms Metric) SetDataType(ty MetricDataType) {
 	}
 }
 
-// IntGauge returns the data as IntGauge.
-// Calling this function when DataType() != MetricDataTypeIntGauge will cause a panic.
-// Calling this function on zero-initialized Metric will cause a panic.
-func (ms Metric) IntGauge() IntGauge {
-	return newIntGauge(ms.orig.Data.(*otlpmetrics.Metric_IntGauge).IntGauge)
-}
-
 // Gauge returns the data as Gauge.
 // Calling this function when DataType() != MetricDataTypeGauge will cause a panic.
 // Calling this function on zero-initialized Metric will cause a panic.
 func (ms Metric) Gauge() Gauge {
 	return newGauge(ms.orig.Data.(*otlpmetrics.Metric_Gauge).Gauge)
-}
-
-// IntSum returns the data as IntSum.
-// Calling this function when DataType() != MetricDataTypeIntSum  will cause a panic.
-// Calling this function on zero-initialized Metric will cause a panic.
-func (ms Metric) IntSum() IntSum {
-	return newIntSum(ms.orig.Data.(*otlpmetrics.Metric_IntSum).IntSum)
 }
 
 // Sum returns the data as Sum.
@@ -241,17 +209,9 @@ func (ms Metric) Summary() Summary {
 
 func copyData(src, dest *otlpmetrics.Metric) {
 	switch srcData := (src).Data.(type) {
-	case *otlpmetrics.Metric_IntGauge:
-		data := &otlpmetrics.Metric_IntGauge{IntGauge: &otlpmetrics.IntGauge{}}
-		newIntGauge(srcData.IntGauge).CopyTo(newIntGauge(data.IntGauge))
-		dest.Data = data
 	case *otlpmetrics.Metric_Gauge:
 		data := &otlpmetrics.Metric_Gauge{Gauge: &otlpmetrics.Gauge{}}
 		newGauge(srcData.Gauge).CopyTo(newGauge(data.Gauge))
-		dest.Data = data
-	case *otlpmetrics.Metric_IntSum:
-		data := &otlpmetrics.Metric_IntSum{IntSum: &otlpmetrics.IntSum{}}
-		newIntSum(srcData.IntSum).CopyTo(newIntSum(data.IntSum))
 		dest.Data = data
 	case *otlpmetrics.Metric_Sum:
 		data := &otlpmetrics.Metric_Sum{Sum: &otlpmetrics.Sum{}}


### PR DESCRIPTION
**Description:** Follow up to https://github.com/open-telemetry/opentelemetry-collector/pull/3730, removing `IntGauge` and `IntSum`.

**Link to tracking Issue:** Part of #3534 

Will rebase once #3730 is merged.