### PR TITLE
Use chained interceptors in the gRPC server

### DIFF
--- a/config/configgrpc/configgrpc.go
+++ b/config/configgrpc/configgrpc.go
@@ -325,6 +325,9 @@ func (gss *GRPCServerSettings) ToServerOption(ext map[config.ComponentID]compone
 		}
 	}
 
+	uInterceptors := []grpc.UnaryServerInterceptor{}
+	sInterceptors := []grpc.StreamServerInterceptor{}
+
 	if gss.Auth != nil {
 		componentID, cperr := config.NewIDFromString(gss.Auth.AuthenticatorName)
 		if cperr != nil {
@@ -336,24 +339,22 @@ func (gss *GRPCServerSettings) ToServerOption(ext map[config.ComponentID]compone
 			return nil, err
 		}
 
-		opts = append(opts,
-			grpc.UnaryInterceptor(authenticator.GRPCUnaryServerInterceptor),
-			grpc.StreamInterceptor(authenticator.GRPCStreamServerInterceptor),
-		)
+		uInterceptors = append(uInterceptors, authenticator.GRPCUnaryServerInterceptor)
+		sInterceptors = append(sInterceptors, authenticator.GRPCStreamServerInterceptor)
 	}
 
 	// Enable OpenTelemetry observability plugin.
 	// TODO: Pass construct settings to have access to Tracer.
-	opts = append(opts, grpc.UnaryInterceptor(
-		otelgrpc.UnaryServerInterceptor(
-			otelgrpc.WithTracerProvider(otel.GetTracerProvider()),
-			otelgrpc.WithPropagators(otel.GetTextMapPropagator()),
-		)))
-	opts = append(opts, grpc.StreamInterceptor(
-		otelgrpc.StreamServerInterceptor(
-			otelgrpc.WithTracerProvider(otel.GetTracerProvider()),
-			otelgrpc.WithPropagators(otel.GetTextMapPropagator()),
-		)))
+	uInterceptors = append(uInterceptors, otelgrpc.UnaryServerInterceptor(
+		otelgrpc.WithTracerProvider(otel.GetTracerProvider()),
+		otelgrpc.WithPropagators(otel.GetTextMapPropagator()),
+	))
+	sInterceptors = append(sInterceptors, otelgrpc.StreamServerInterceptor(
+		otelgrpc.WithTracerProvider(otel.GetTracerProvider()),
+		otelgrpc.WithPropagators(otel.GetTextMapPropagator()),
+	))
+
+	opts = append(opts, grpc.ChainUnaryInterceptor(uInterceptors...), grpc.ChainStreamInterceptor(sInterceptors...))
 
 	return opts, nil
 }

--- a/config/configgrpc/configgrpc_test.go
+++ b/config/configgrpc/configgrpc_test.go
@@ -81,6 +81,8 @@ func TestAllGrpcClientSettings(t *testing.T) {
 func TestDefaultGrpcServerSettings(t *testing.T) {
 	gss := &GRPCServerSettings{}
 	opts, err := gss.ToServerOption(map[config.ComponentID]component.Extension{})
+	_ = grpc.NewServer(opts...)
+
 	assert.NoError(t, err)
 	assert.Len(t, opts, 2)
 }
@@ -114,6 +116,8 @@ func TestAllGrpcServerSettingsExceptAuth(t *testing.T) {
 		},
 	}
 	opts, err := gss.ToServerOption(map[config.ComponentID]component.Extension{})
+	_ = grpc.NewServer(opts...)
+
 	assert.NoError(t, err)
 	assert.Len(t, opts, 9)
 }
@@ -133,6 +137,7 @@ func TestGrpcServerAuthSettings(t *testing.T) {
 		config.NewID("mock"): &configauth.MockAuthenticator{},
 	}
 	opts, err := gss.ToServerOption(ext)
+	_ = grpc.NewServer(opts...)
 
 	// verify
 	assert.NoError(t, err)
@@ -297,7 +302,9 @@ func TestGRPCServerSettingsError(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.err, func(t *testing.T) {
-			_, err := test.settings.ToServerOption(map[config.ComponentID]component.Extension{})
+			opts, err := test.settings.ToServerOption(map[config.ComponentID]component.Extension{})
+			_ = grpc.NewServer(opts...)
+
 			assert.Regexp(t, test.err, err)
 		})
 	}


### PR DESCRIPTION
Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>

Fixes #3734 by using chained interceptors for the gRPC servers. The tests making use of ToServerOptions were also changed to call grpc.NewServer with the obtained options, ensuring that they are valid.

The test TestGrpcServerAuthSettings now calling grpc.NewServer, executed against the configgrpc without the chained interceptors confirms the bug:

```
$ go test ./config/configgrpc/
--- FAIL: TestGrpcServerAuthSettings (0.00s)
panic: The unary server interceptor was already set and may not be reset. [recovered]
	panic: The unary server interceptor was already set and may not be reset.

goroutine 23 [running]:
testing.tRunner.func1.2(0xa6c2a0, 0xc0b8a0)
	/home/jpkroehling/bin/go/src/testing/testing.go:1144 +0x332
testing.tRunner.func1(0xc000103b00)
	/home/jpkroehling/bin/go/src/testing/testing.go:1147 +0x4b6
panic(0xa6c2a0, 0xc0b8a0)
	/home/jpkroehling/bin/go/src/runtime/panic.go:965 +0x1b9
google.golang.org/grpc.UnaryInterceptor.func1(0xc000374500)
	/home/jpkroehling/go/pkg/mod/google.golang.org/grpc@v1.39.0/server.go:382 +0x6b
google.golang.org/grpc.(*funcServerOption).apply(0xc0001243f0, 0xc000374500)
	/home/jpkroehling/go/pkg/mod/google.golang.org/grpc@v1.39.0/server.go:201 +0x33
google.golang.org/grpc.NewServer(0xc000129900, 0x4, 0x4, 0x4)
	/home/jpkroehling/go/pkg/mod/google.golang.org/grpc@v1.39.0/server.go:564 +0xeb
go.opentelemetry.io/collector/config/configgrpc.TestGrpcServerAuthSettings(0xc000103b00)
	/home/jpkroehling/Projects/src/github.com/open-telemetry/opentelemetry-collector/config/configgrpc/configgrpc_test.go:140 +0x2aa
testing.tRunner(0xc000103b00, 0xb85528)
	/home/jpkroehling/bin/go/src/testing/testing.go:1194 +0xef
created by testing.(*T).Run
	/home/jpkroehling/bin/go/src/testing/testing.go:1239 +0x2b3
FAIL	go.opentelemetry.io/collector/config/configgrpc	0.006s
FAIL
```


