### PR TITLE
remove no longer needed test functions

### DIFF
--- a/exporter/exporterhelper/resource_to_label_test.go
+++ b/exporter/exporterhelper/resource_to_label_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestConvertResourceToLabels(t *testing.T) {
-	md := testdata.GenerateMetricsOneSumMetric()
+	md := testdata.GenerateMetricsOneMetric()
 	assert.NotNil(t, md)
 
 	// Before converting resource to labels

--- a/exporter/otlpexporter/otlp_test.go
+++ b/exporter/otlpexporter/otlp_test.go
@@ -368,7 +368,7 @@ func TestSendMetrics(t *testing.T) {
 	assert.EqualValues(t, 0, atomic.LoadInt32(&rcv.totalItems))
 
 	// Send two metrics.
-	md = testdata.GenerateMetricsTwoSumMetrics()
+	md = testdata.GenerateMetricsTwoMetrics()
 
 	err = exp.ConsumeMetrics(context.Background(), md)
 	assert.NoError(t, err)

--- a/exporter/otlphttpexporter/otlp_test.go
+++ b/exporter/otlphttpexporter/otlp_test.go
@@ -227,7 +227,7 @@ func TestMetricsRoundTrip(t *testing.T) {
 			startMetricsReceiver(t, addr, sink)
 			exp := startMetricsExporter(t, test.baseURL, test.overrideURL)
 
-			md := testdata.GenerateMetricsOneSumMetric()
+			md := testdata.GenerateMetricsOneMetric()
 			assert.NoError(t, exp.ConsumeMetrics(context.Background(), md))
 			require.Eventually(t, func() bool {
 				return sink.DataPointCount() > 0

--- a/exporter/prometheusexporter/prometheus_test.go
+++ b/exporter/prometheusexporter/prometheus_test.go
@@ -278,7 +278,7 @@ func TestPrometheusExporter_endToEndWithResource(t *testing.T) {
 	assert.NotNil(t, exp)
 	require.NoError(t, exp.Start(context.Background(), componenttest.NewNopHost()))
 
-	md := testdata.GenerateMetricsOneSumMetric()
+	md := testdata.GenerateMetricsOneMetric()
 	assert.NotNil(t, md)
 
 	assert.NoError(t, exp.ConsumeMetrics(context.Background(), md))

--- a/internal/testdata/metric.go
+++ b/internal/testdata/metric.go
@@ -74,34 +74,11 @@ func GenerateMetricsOneMetric() pdata.Metrics {
 	return md
 }
 
-func GenerateMetricsOneSumMetric() pdata.Metrics {
-	// TODO: this is currently used in place of GenerateMetricsOneMetric
-	// because the OTLP receiver converts IntSum to Sum types and causes a
-	// failure in TestSendMetrics. Once Sum supports setting either Int
-	// or Double, this function can be removed.
-	md := GenerateMetricsOneEmptyInstrumentationLibrary()
-	rm0ils0 := md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0)
-	initSumMetric(rm0ils0.Metrics().AppendEmpty())
-	return md
-}
-
 func GenerateMetricsTwoMetrics() pdata.Metrics {
 	md := GenerateMetricsOneEmptyInstrumentationLibrary()
 	rm0ils0 := md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0)
 	initSumIntMetric(rm0ils0.Metrics().AppendEmpty())
 	initSumIntMetric(rm0ils0.Metrics().AppendEmpty())
-	return md
-}
-
-func GenerateMetricsTwoSumMetrics() pdata.Metrics {
-	// TODO: this is currently used in place of GenerateMetricsTwoMetrics
-	// because the OTLP receiver converts IntSum to Sum types and causes a
-	// failure in TestSendMetrics. Once Sum supports setting either Int
-	// or Double, this function can be removed.
-	md := GenerateMetricsOneEmptyInstrumentationLibrary()
-	rm0ils0 := md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0)
-	initSumMetric(rm0ils0.Metrics().AppendEmpty())
-	initSumMetric(rm0ils0.Metrics().AppendEmpty())
 	return md
 }
 
@@ -180,22 +157,6 @@ func GeneratMetricsAllTypesWithSampleDatapoints() pdata.Metrics {
 	initDoubleSummaryMetric(ms.AppendEmpty())
 
 	return md
-}
-
-func initSumMetric(im pdata.Metric) {
-	initMetric(im, TestSumIntMetricName, pdata.MetricDataTypeSum)
-
-	idps := im.Sum().DataPoints()
-	idp0 := idps.AppendEmpty()
-	initMetricLabels1(idp0.LabelsMap())
-	idp0.SetStartTimestamp(TestMetricStartTimestamp)
-	idp0.SetTimestamp(TestMetricTimestamp)
-	idp0.SetDoubleVal(123)
-	idp1 := idps.AppendEmpty()
-	initMetricLabels2(idp1.LabelsMap())
-	idp1.SetStartTimestamp(TestMetricStartTimestamp)
-	idp1.SetTimestamp(TestMetricTimestamp)
-	idp1.SetDoubleVal(456)
 }
 
 func initGaugeIntMetric(im pdata.Metric) {

--- a/receiver/otlpreceiver/internal/metrics/otlp_test.go
+++ b/receiver/otlpreceiver/internal/metrics/otlp_test.go
@@ -46,7 +46,7 @@ func TestExport(t *testing.T) {
 
 	// when
 
-	req := testdata.GenerateMetricsOneSumMetric()
+	req := testdata.GenerateMetricsOneMetric()
 
 	// Keep metric data to compare the test result against it
 	// Clone needed because OTLP proto XXX_ fields are altered in the GRPC downstream


### PR DESCRIPTION
**Description:** This change removes temporary test functions that were added as part of the transition to OTLP v0.8.0, they are no longer needed.

**Link to tracking Issue:** Part of #3534 
