### PR TITLE
adding SchemaUrl field

### DIFF
--- a/cmd/pdatagen/internal/common_structs.go
+++ b/cmd/pdatagen/internal/common_structs.go
@@ -122,3 +122,11 @@ var anyValueArray = &sliceOfValues{
 	structName: "AnyValueArray",
 	element:    anyValue,
 }
+
+var schemaURLField = &primitiveField{
+	fieldName:       "SchemaUrl",
+	originFieldName: "SchemaUrl",
+	returnType:      "string",
+	defaultVal:      `""`,
+	testVal:         `"https://opentelemetry.io/schemas/1.5.0"`,
+}

--- a/cmd/pdatagen/internal/log_structs.go
+++ b/cmd/pdatagen/internal/log_structs.go
@@ -49,6 +49,7 @@ var resourceLogs = &messageValueStruct{
 	originFullName: "otlplogs.ResourceLogs",
 	fields: []baseField{
 		resourceField,
+		schemaURLField,
 		&sliceField{
 			fieldName:       "InstrumentationLibraryLogs",
 			originFieldName: "InstrumentationLibraryLogs",
@@ -68,6 +69,7 @@ var instrumentationLibraryLogs = &messageValueStruct{
 	originFullName: "otlplogs.InstrumentationLibraryLogs",
 	fields: []baseField{
 		instrumentationLibraryField,
+		schemaURLField,
 		&sliceField{
 			fieldName:       "Logs",
 			originFieldName: "Logs",

--- a/cmd/pdatagen/internal/metrics_structs.go
+++ b/cmd/pdatagen/internal/metrics_structs.go
@@ -63,6 +63,7 @@ var resourceMetrics = &messageValueStruct{
 	originFullName: "otlpmetrics.ResourceMetrics",
 	fields: []baseField{
 		resourceField,
+		schemaURLField,
 		&sliceField{
 			fieldName:       "InstrumentationLibraryMetrics",
 			originFieldName: "InstrumentationLibraryMetrics",
@@ -82,6 +83,7 @@ var instrumentationLibraryMetrics = &messageValueStruct{
 	originFullName: "otlpmetrics.InstrumentationLibraryMetrics",
 	fields: []baseField{
 		instrumentationLibraryField,
+		schemaURLField,
 		&sliceField{
 			fieldName:       "Metrics",
 			originFieldName: "Metrics",

--- a/cmd/pdatagen/internal/trace_structs.go
+++ b/cmd/pdatagen/internal/trace_structs.go
@@ -54,6 +54,7 @@ var resourceSpans = &messageValueStruct{
 	originFullName: "otlptrace.ResourceSpans",
 	fields: []baseField{
 		resourceField,
+		schemaURLField,
 		&sliceField{
 			fieldName:       "InstrumentationLibrarySpans",
 			originFieldName: "InstrumentationLibrarySpans",
@@ -73,6 +74,7 @@ var instrumentationLibrarySpans = &messageValueStruct{
 	originFullName: "otlptrace.InstrumentationLibrarySpans",
 	fields: []baseField{
 		instrumentationLibraryField,
+		schemaURLField,
 		&sliceField{
 			fieldName:       "Spans",
 			originFieldName: "Spans",

--- a/model/pdata/generated_log.go
+++ b/model/pdata/generated_log.go
@@ -188,6 +188,16 @@ func (ms ResourceLogs) Resource() Resource {
 	return newResource(&(*ms.orig).Resource)
 }
 
+// SchemaUrl returns the schemaurl associated with this ResourceLogs.
+func (ms ResourceLogs) SchemaUrl() string {
+	return (*ms.orig).SchemaUrl
+}
+
+// SetSchemaUrl replaces the schemaurl associated with this ResourceLogs.
+func (ms ResourceLogs) SetSchemaUrl(v string) {
+	(*ms.orig).SchemaUrl = v
+}
+
 // InstrumentationLibraryLogs returns the InstrumentationLibraryLogs associated with this ResourceLogs.
 func (ms ResourceLogs) InstrumentationLibraryLogs() InstrumentationLibraryLogsSlice {
 	return newInstrumentationLibraryLogsSlice(&(*ms.orig).InstrumentationLibraryLogs)
@@ -196,6 +206,7 @@ func (ms ResourceLogs) InstrumentationLibraryLogs() InstrumentationLibraryLogsSl
 // CopyTo copies all properties from the current struct to the dest.
 func (ms ResourceLogs) CopyTo(dest ResourceLogs) {
 	ms.Resource().CopyTo(dest.Resource())
+	dest.SetSchemaUrl(ms.SchemaUrl())
 	ms.InstrumentationLibraryLogs().CopyTo(dest.InstrumentationLibraryLogs())
 }
 
@@ -364,6 +375,16 @@ func (ms InstrumentationLibraryLogs) InstrumentationLibrary() InstrumentationLib
 	return newInstrumentationLibrary(&(*ms.orig).InstrumentationLibrary)
 }
 
+// SchemaUrl returns the schemaurl associated with this InstrumentationLibraryLogs.
+func (ms InstrumentationLibraryLogs) SchemaUrl() string {
+	return (*ms.orig).SchemaUrl
+}
+
+// SetSchemaUrl replaces the schemaurl associated with this InstrumentationLibraryLogs.
+func (ms InstrumentationLibraryLogs) SetSchemaUrl(v string) {
+	(*ms.orig).SchemaUrl = v
+}
+
 // Logs returns the Logs associated with this InstrumentationLibraryLogs.
 func (ms InstrumentationLibraryLogs) Logs() LogSlice {
 	return newLogSlice(&(*ms.orig).Logs)
@@ -372,6 +393,7 @@ func (ms InstrumentationLibraryLogs) Logs() LogSlice {
 // CopyTo copies all properties from the current struct to the dest.
 func (ms InstrumentationLibraryLogs) CopyTo(dest InstrumentationLibraryLogs) {
 	ms.InstrumentationLibrary().CopyTo(dest.InstrumentationLibrary())
+	dest.SetSchemaUrl(ms.SchemaUrl())
 	ms.Logs().CopyTo(dest.Logs())
 }
 

--- a/model/pdata/generated_log_test.go
+++ b/model/pdata/generated_log_test.go
@@ -147,6 +147,14 @@ func TestResourceLogs_Resource(t *testing.T) {
 	assert.EqualValues(t, generateTestResource(), ms.Resource())
 }
 
+func TestResourceLogs_SchemaUrl(t *testing.T) {
+	ms := NewResourceLogs()
+	assert.EqualValues(t, "", ms.SchemaUrl())
+	testValSchemaUrl := "https://opentelemetry.io/schemas/1.5.0"
+	ms.SetSchemaUrl(testValSchemaUrl)
+	assert.EqualValues(t, testValSchemaUrl, ms.SchemaUrl())
+}
+
 func TestResourceLogs_InstrumentationLibraryLogs(t *testing.T) {
 	ms := NewResourceLogs()
 	assert.EqualValues(t, NewInstrumentationLibraryLogsSlice(), ms.InstrumentationLibraryLogs())
@@ -275,6 +283,14 @@ func TestInstrumentationLibraryLogs_InstrumentationLibrary(t *testing.T) {
 	ms := NewInstrumentationLibraryLogs()
 	fillTestInstrumentationLibrary(ms.InstrumentationLibrary())
 	assert.EqualValues(t, generateTestInstrumentationLibrary(), ms.InstrumentationLibrary())
+}
+
+func TestInstrumentationLibraryLogs_SchemaUrl(t *testing.T) {
+	ms := NewInstrumentationLibraryLogs()
+	assert.EqualValues(t, "", ms.SchemaUrl())
+	testValSchemaUrl := "https://opentelemetry.io/schemas/1.5.0"
+	ms.SetSchemaUrl(testValSchemaUrl)
+	assert.EqualValues(t, testValSchemaUrl, ms.SchemaUrl())
 }
 
 func TestInstrumentationLibraryLogs_Logs(t *testing.T) {
@@ -501,6 +517,7 @@ func generateTestResourceLogs() ResourceLogs {
 
 func fillTestResourceLogs(tv ResourceLogs) {
 	fillTestResource(tv.Resource())
+	tv.SetSchemaUrl("https://opentelemetry.io/schemas/1.5.0")
 	fillTestInstrumentationLibraryLogsSlice(tv.InstrumentationLibraryLogs())
 }
 
@@ -526,6 +543,7 @@ func generateTestInstrumentationLibraryLogs() InstrumentationLibraryLogs {
 
 func fillTestInstrumentationLibraryLogs(tv InstrumentationLibraryLogs) {
 	fillTestInstrumentationLibrary(tv.InstrumentationLibrary())
+	tv.SetSchemaUrl("https://opentelemetry.io/schemas/1.5.0")
 	fillTestLogSlice(tv.Logs())
 }
 

--- a/model/pdata/generated_metrics.go
+++ b/model/pdata/generated_metrics.go
@@ -188,6 +188,16 @@ func (ms ResourceMetrics) Resource() Resource {
 	return newResource(&(*ms.orig).Resource)
 }
 
+// SchemaUrl returns the schemaurl associated with this ResourceMetrics.
+func (ms ResourceMetrics) SchemaUrl() string {
+	return (*ms.orig).SchemaUrl
+}
+
+// SetSchemaUrl replaces the schemaurl associated with this ResourceMetrics.
+func (ms ResourceMetrics) SetSchemaUrl(v string) {
+	(*ms.orig).SchemaUrl = v
+}
+
 // InstrumentationLibraryMetrics returns the InstrumentationLibraryMetrics associated with this ResourceMetrics.
 func (ms ResourceMetrics) InstrumentationLibraryMetrics() InstrumentationLibraryMetricsSlice {
 	return newInstrumentationLibraryMetricsSlice(&(*ms.orig).InstrumentationLibraryMetrics)
@@ -196,6 +206,7 @@ func (ms ResourceMetrics) InstrumentationLibraryMetrics() InstrumentationLibrary
 // CopyTo copies all properties from the current struct to the dest.
 func (ms ResourceMetrics) CopyTo(dest ResourceMetrics) {
 	ms.Resource().CopyTo(dest.Resource())
+	dest.SetSchemaUrl(ms.SchemaUrl())
 	ms.InstrumentationLibraryMetrics().CopyTo(dest.InstrumentationLibraryMetrics())
 }
 
@@ -364,6 +375,16 @@ func (ms InstrumentationLibraryMetrics) InstrumentationLibrary() Instrumentation
 	return newInstrumentationLibrary(&(*ms.orig).InstrumentationLibrary)
 }
 
+// SchemaUrl returns the schemaurl associated with this InstrumentationLibraryMetrics.
+func (ms InstrumentationLibraryMetrics) SchemaUrl() string {
+	return (*ms.orig).SchemaUrl
+}
+
+// SetSchemaUrl replaces the schemaurl associated with this InstrumentationLibraryMetrics.
+func (ms InstrumentationLibraryMetrics) SetSchemaUrl(v string) {
+	(*ms.orig).SchemaUrl = v
+}
+
 // Metrics returns the Metrics associated with this InstrumentationLibraryMetrics.
 func (ms InstrumentationLibraryMetrics) Metrics() MetricSlice {
 	return newMetricSlice(&(*ms.orig).Metrics)
@@ -372,6 +393,7 @@ func (ms InstrumentationLibraryMetrics) Metrics() MetricSlice {
 // CopyTo copies all properties from the current struct to the dest.
 func (ms InstrumentationLibraryMetrics) CopyTo(dest InstrumentationLibraryMetrics) {
 	ms.InstrumentationLibrary().CopyTo(dest.InstrumentationLibrary())
+	dest.SetSchemaUrl(ms.SchemaUrl())
 	ms.Metrics().CopyTo(dest.Metrics())
 }
 

--- a/model/pdata/generated_metrics_test.go
+++ b/model/pdata/generated_metrics_test.go
@@ -147,6 +147,14 @@ func TestResourceMetrics_Resource(t *testing.T) {
 	assert.EqualValues(t, generateTestResource(), ms.Resource())
 }
 
+func TestResourceMetrics_SchemaUrl(t *testing.T) {
+	ms := NewResourceMetrics()
+	assert.EqualValues(t, "", ms.SchemaUrl())
+	testValSchemaUrl := "https://opentelemetry.io/schemas/1.5.0"
+	ms.SetSchemaUrl(testValSchemaUrl)
+	assert.EqualValues(t, testValSchemaUrl, ms.SchemaUrl())
+}
+
 func TestResourceMetrics_InstrumentationLibraryMetrics(t *testing.T) {
 	ms := NewResourceMetrics()
 	assert.EqualValues(t, NewInstrumentationLibraryMetricsSlice(), ms.InstrumentationLibraryMetrics())
@@ -275,6 +283,14 @@ func TestInstrumentationLibraryMetrics_InstrumentationLibrary(t *testing.T) {
 	ms := NewInstrumentationLibraryMetrics()
 	fillTestInstrumentationLibrary(ms.InstrumentationLibrary())
 	assert.EqualValues(t, generateTestInstrumentationLibrary(), ms.InstrumentationLibrary())
+}
+
+func TestInstrumentationLibraryMetrics_SchemaUrl(t *testing.T) {
+	ms := NewInstrumentationLibraryMetrics()
+	assert.EqualValues(t, "", ms.SchemaUrl())
+	testValSchemaUrl := "https://opentelemetry.io/schemas/1.5.0"
+	ms.SetSchemaUrl(testValSchemaUrl)
+	assert.EqualValues(t, testValSchemaUrl, ms.SchemaUrl())
 }
 
 func TestInstrumentationLibraryMetrics_Metrics(t *testing.T) {
@@ -1304,6 +1320,7 @@ func generateTestResourceMetrics() ResourceMetrics {
 
 func fillTestResourceMetrics(tv ResourceMetrics) {
 	fillTestResource(tv.Resource())
+	tv.SetSchemaUrl("https://opentelemetry.io/schemas/1.5.0")
 	fillTestInstrumentationLibraryMetricsSlice(tv.InstrumentationLibraryMetrics())
 }
 
@@ -1329,6 +1346,7 @@ func generateTestInstrumentationLibraryMetrics() InstrumentationLibraryMetrics {
 
 func fillTestInstrumentationLibraryMetrics(tv InstrumentationLibraryMetrics) {
 	fillTestInstrumentationLibrary(tv.InstrumentationLibrary())
+	tv.SetSchemaUrl("https://opentelemetry.io/schemas/1.5.0")
 	fillTestMetricSlice(tv.Metrics())
 }
 

--- a/model/pdata/generated_trace.go
+++ b/model/pdata/generated_trace.go
@@ -188,6 +188,16 @@ func (ms ResourceSpans) Resource() Resource {
 	return newResource(&(*ms.orig).Resource)
 }
 
+// SchemaUrl returns the schemaurl associated with this ResourceSpans.
+func (ms ResourceSpans) SchemaUrl() string {
+	return (*ms.orig).SchemaUrl
+}
+
+// SetSchemaUrl replaces the schemaurl associated with this ResourceSpans.
+func (ms ResourceSpans) SetSchemaUrl(v string) {
+	(*ms.orig).SchemaUrl = v
+}
+
 // InstrumentationLibrarySpans returns the InstrumentationLibrarySpans associated with this ResourceSpans.
 func (ms ResourceSpans) InstrumentationLibrarySpans() InstrumentationLibrarySpansSlice {
 	return newInstrumentationLibrarySpansSlice(&(*ms.orig).InstrumentationLibrarySpans)
@@ -196,6 +206,7 @@ func (ms ResourceSpans) InstrumentationLibrarySpans() InstrumentationLibrarySpan
 // CopyTo copies all properties from the current struct to the dest.
 func (ms ResourceSpans) CopyTo(dest ResourceSpans) {
 	ms.Resource().CopyTo(dest.Resource())
+	dest.SetSchemaUrl(ms.SchemaUrl())
 	ms.InstrumentationLibrarySpans().CopyTo(dest.InstrumentationLibrarySpans())
 }
 
@@ -364,6 +375,16 @@ func (ms InstrumentationLibrarySpans) InstrumentationLibrary() InstrumentationLi
 	return newInstrumentationLibrary(&(*ms.orig).InstrumentationLibrary)
 }
 
+// SchemaUrl returns the schemaurl associated with this InstrumentationLibrarySpans.
+func (ms InstrumentationLibrarySpans) SchemaUrl() string {
+	return (*ms.orig).SchemaUrl
+}
+
+// SetSchemaUrl replaces the schemaurl associated with this InstrumentationLibrarySpans.
+func (ms InstrumentationLibrarySpans) SetSchemaUrl(v string) {
+	(*ms.orig).SchemaUrl = v
+}
+
 // Spans returns the Spans associated with this InstrumentationLibrarySpans.
 func (ms InstrumentationLibrarySpans) Spans() SpanSlice {
 	return newSpanSlice(&(*ms.orig).Spans)
@@ -372,6 +393,7 @@ func (ms InstrumentationLibrarySpans) Spans() SpanSlice {
 // CopyTo copies all properties from the current struct to the dest.
 func (ms InstrumentationLibrarySpans) CopyTo(dest InstrumentationLibrarySpans) {
 	ms.InstrumentationLibrary().CopyTo(dest.InstrumentationLibrary())
+	dest.SetSchemaUrl(ms.SchemaUrl())
 	ms.Spans().CopyTo(dest.Spans())
 }
 

--- a/model/pdata/generated_trace_test.go
+++ b/model/pdata/generated_trace_test.go
@@ -147,6 +147,14 @@ func TestResourceSpans_Resource(t *testing.T) {
 	assert.EqualValues(t, generateTestResource(), ms.Resource())
 }
 
+func TestResourceSpans_SchemaUrl(t *testing.T) {
+	ms := NewResourceSpans()
+	assert.EqualValues(t, "", ms.SchemaUrl())
+	testValSchemaUrl := "https://opentelemetry.io/schemas/1.5.0"
+	ms.SetSchemaUrl(testValSchemaUrl)
+	assert.EqualValues(t, testValSchemaUrl, ms.SchemaUrl())
+}
+
 func TestResourceSpans_InstrumentationLibrarySpans(t *testing.T) {
 	ms := NewResourceSpans()
 	assert.EqualValues(t, NewInstrumentationLibrarySpansSlice(), ms.InstrumentationLibrarySpans())
@@ -275,6 +283,14 @@ func TestInstrumentationLibrarySpans_InstrumentationLibrary(t *testing.T) {
 	ms := NewInstrumentationLibrarySpans()
 	fillTestInstrumentationLibrary(ms.InstrumentationLibrary())
 	assert.EqualValues(t, generateTestInstrumentationLibrary(), ms.InstrumentationLibrary())
+}
+
+func TestInstrumentationLibrarySpans_SchemaUrl(t *testing.T) {
+	ms := NewInstrumentationLibrarySpans()
+	assert.EqualValues(t, "", ms.SchemaUrl())
+	testValSchemaUrl := "https://opentelemetry.io/schemas/1.5.0"
+	ms.SetSchemaUrl(testValSchemaUrl)
+	assert.EqualValues(t, testValSchemaUrl, ms.SchemaUrl())
 }
 
 func TestInstrumentationLibrarySpans_Spans(t *testing.T) {
@@ -867,6 +883,7 @@ func generateTestResourceSpans() ResourceSpans {
 
 func fillTestResourceSpans(tv ResourceSpans) {
 	fillTestResource(tv.Resource())
+	tv.SetSchemaUrl("https://opentelemetry.io/schemas/1.5.0")
 	fillTestInstrumentationLibrarySpansSlice(tv.InstrumentationLibrarySpans())
 }
 
@@ -892,6 +909,7 @@ func generateTestInstrumentationLibrarySpans() InstrumentationLibrarySpans {
 
 func fillTestInstrumentationLibrarySpans(tv InstrumentationLibrarySpans) {
 	fillTestInstrumentationLibrary(tv.InstrumentationLibrary())
+	tv.SetSchemaUrl("https://opentelemetry.io/schemas/1.5.0")
 	fillTestSpanSlice(tv.Spans())
 }
 


### PR DESCRIPTION
**Description:** Adding SchemaUrl field to:
- `ResourceLogs`
- `ResourceMetrics`
- `ResourceSpans`
- `InstrumentationLibraryLogs`
- `InstrumentationLibraryMetrics`
- `InstrumentationLibrarySpans`

**Link to tracking Issue:** Part of #3535 

Followup to https://github.com/open-telemetry/opentelemetry-collector/pull/3756
