### PR TITLE
[PROTOTYPE] Combine gRPC and HTTP servers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -52,6 +52,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.0.0-RC2
 	go.uber.org/atomic v1.9.0
 	go.uber.org/zap v1.18.1
+	golang.org/x/net v0.0.0-20210614182718-04defd469f4e
 	golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1
 	golang.org/x/text v0.3.6
 	google.golang.org/genproto v0.0.0-20210604141403-392c879c8b08

--- a/receiver/otlpreceiver/config.go
+++ b/receiver/otlpreceiver/config.go
@@ -54,7 +54,8 @@ var _ config.Unmarshallable = (*Config)(nil)
 
 // Validate checks the receiver configuration is valid
 func (cfg *Config) Validate() error {
-	if cfg.GRPC == nil &&
+	if cfg.ExperimentalServer == nil &&
+		cfg.GRPC == nil &&
 		cfg.HTTP == nil {
 		return fmt.Errorf("must specify at least one protocol when using the OTLP receiver")
 	}
@@ -74,6 +75,13 @@ func (cfg *Config) Unmarshal(componentParser *configparser.Parser) error {
 
 	// If the experimental field is loaded, zero out the config for any other protocol fields
 	if componentParser.IsSet(experimentalField) {
+		if cfg.ExperimentalServer == nil {
+			cfg.ExperimentalServer = &confighttp.HTTPServerSettings{
+				Endpoint: defaultCombinedEndpoint,
+			}
+		} else if cfg.ExperimentalServer.Endpoint == "" {
+			cfg.ExperimentalServer.Endpoint = defaultCombinedEndpoint
+		}
 		cfg.GRPC = nil
 		cfg.HTTP = nil
 		return nil

--- a/receiver/otlpreceiver/config_test.go
+++ b/receiver/otlpreceiver/config_test.go
@@ -196,13 +196,13 @@ func TestLoadConfig(t *testing.T) {
 			ReceiverSettings: config.NewReceiverSettings(config.NewIDWithName(typeStr, "experimental")),
 			Protocols: Protocols{
 				GRPC: nil,
-				HTTP: nil,
+				HTTP: &confighttp.HTTPServerSettings{
+					Endpoint:    "0.0.0.0:4317",
+					CorsOrigins: []string{"https://*.test.com", "https://test.com"},
+					CorsHeaders: []string{"ExampleHeader"},
+				},
 			},
-			ExperimentalServer: &confighttp.HTTPServerSettings{
-				Endpoint:    "0.0.0.0:4317",
-				CorsOrigins: []string{"https://*.test.com", "https://test.com"},
-				CorsHeaders: []string{"ExampleHeader"},
-			},
+			ExperimentalServerEnabled: true,
 		})
 }
 

--- a/receiver/otlpreceiver/config_test.go
+++ b/receiver/otlpreceiver/config_test.go
@@ -42,7 +42,7 @@ func TestLoadConfig(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, cfg)
 
-	assert.Equal(t, len(cfg.Receivers), 10)
+	assert.Equal(t, len(cfg.Receivers), 11)
 
 	assert.Equal(t, cfg.Receivers[config.NewID(typeStr)], factory.CreateDefaultConfig())
 
@@ -188,6 +188,20 @@ func TestLoadConfig(t *testing.T) {
 					Endpoint: "/tmp/http_otlp.sock",
 					// Transport: "unix",
 				},
+			},
+		})
+
+	assert.Equal(t, cfg.Receivers[config.NewIDWithName(typeStr, "experimental")],
+		&Config{
+			ReceiverSettings: config.NewReceiverSettings(config.NewIDWithName(typeStr, "experimental")),
+			Protocols: Protocols{
+				GRPC: nil,
+				HTTP: nil,
+			},
+			ExperimentalServer: &confighttp.HTTPServerSettings{
+				Endpoint:    "0.0.0.0:4317",
+				CorsOrigins: []string{"https://*.test.com", "https://test.com"},
+				CorsHeaders: []string{"ExampleHeader"},
 			},
 		})
 }

--- a/receiver/otlpreceiver/factory.go
+++ b/receiver/otlpreceiver/factory.go
@@ -30,11 +30,10 @@ import (
 const (
 	typeStr = "otlp"
 
-	defaultCombinedEndpoint = "0.0.0.0:4317"
-	defaultGRPCEndpoint     = "0.0.0.0:4317"
-	defaultHTTPEndpoint     = "0.0.0.0:4318"
-	legacyGRPCEndpoint      = "0.0.0.0:55680"
-	legacyHTTPEndpoint      = "0.0.0.0:55681"
+	defaultGRPCEndpoint = "0.0.0.0:4317"
+	defaultHTTPEndpoint = "0.0.0.0:4318"
+	legacyGRPCEndpoint  = "0.0.0.0:55680"
+	legacyHTTPEndpoint  = "0.0.0.0:55681"
 )
 
 // NewFactory creates a new OTLP receiver factory.

--- a/receiver/otlpreceiver/factory.go
+++ b/receiver/otlpreceiver/factory.go
@@ -30,10 +30,11 @@ import (
 const (
 	typeStr = "otlp"
 
-	defaultGRPCEndpoint = "0.0.0.0:4317"
-	defaultHTTPEndpoint = "0.0.0.0:4318"
-	legacyGRPCEndpoint  = "0.0.0.0:55680"
-	legacyHTTPEndpoint  = "0.0.0.0:55681"
+	defaultCombinedEndpoint = "0.0.0.0:4317"
+	defaultGRPCEndpoint     = "0.0.0.0:4317"
+	defaultHTTPEndpoint     = "0.0.0.0:4318"
+	legacyGRPCEndpoint      = "0.0.0.0:55680"
+	legacyHTTPEndpoint      = "0.0.0.0:55681"
 )
 
 // NewFactory creates a new OTLP receiver factory.

--- a/receiver/otlpreceiver/otlp.go
+++ b/receiver/otlpreceiver/otlp.go
@@ -207,6 +207,11 @@ func (r *otlpReceiver) registerTraceConsumer(tc consumer.Traces) error {
 		return componenterror.ErrNilNextConsumer
 	}
 	r.traceReceiver = trace.New(r.cfg.ID(), tc)
+	if r.cfg.ExperimentalServer != nil {
+		r.httpMux.HandleFunc("/opentelemetry.proto.collector.trace.v1.TraceService/Export", func(resp http.ResponseWriter, req *http.Request) {
+			handleTraces(resp, req, grpcContentType, r.traceReceiver, tracesPbUnmarshaler)
+		}).Methods(http.MethodPost).Headers("Content-Type", grpcContentType)
+	}
 	if r.httpMux != nil {
 		r.httpMux.HandleFunc("/v1/traces", func(resp http.ResponseWriter, req *http.Request) {
 			handleTraces(resp, req, pbContentType, r.traceReceiver, tracesPbUnmarshaler)
@@ -234,6 +239,11 @@ func (r *otlpReceiver) registerMetricsConsumer(mc consumer.Metrics) error {
 		return componenterror.ErrNilNextConsumer
 	}
 	r.metricsReceiver = metrics.New(r.cfg.ID(), mc)
+	if r.cfg.ExperimentalServer != nil {
+		r.httpMux.HandleFunc("/opentelemetry.proto.collector.metrics.v1.MetricsService/Export", func(resp http.ResponseWriter, req *http.Request) {
+			handleMetrics(resp, req, grpcContentType, r.metricsReceiver, metricsPbUnmarshaler)
+		}).Methods(http.MethodPost).Headers("Content-Type", grpcContentType)
+	}
 	if r.httpMux != nil {
 		r.httpMux.HandleFunc("/v1/metrics", func(resp http.ResponseWriter, req *http.Request) {
 			handleMetrics(resp, req, pbContentType, r.metricsReceiver, metricsPbUnmarshaler)
@@ -253,6 +263,11 @@ func (r *otlpReceiver) registerLogsConsumer(lc consumer.Logs) error {
 		return componenterror.ErrNilNextConsumer
 	}
 	r.logReceiver = logs.New(r.cfg.ID(), lc)
+	if r.cfg.ExperimentalServer != nil {
+		r.httpMux.HandleFunc("/opentelemetry.proto.collector.logs.v1.LogsService/Export", func(w http.ResponseWriter, req *http.Request) {
+			handleLogs(w, req, grpcContentType, r.logReceiver, logsPbUnmarshaler)
+		}).Methods(http.MethodPost).Headers("Content-Type", grpcContentType)
+	}
 	if r.httpMux != nil {
 		r.httpMux.HandleFunc("/v1/logs", func(w http.ResponseWriter, req *http.Request) {
 			handleLogs(w, req, pbContentType, r.logReceiver, logsPbUnmarshaler)

--- a/receiver/otlpreceiver/otlp.go
+++ b/receiver/otlpreceiver/otlp.go
@@ -37,6 +37,7 @@ import (
 )
 
 const (
+	grpcContentType = "application/grpc"
 	pbContentType   = "application/x-protobuf"
 	jsonContentType = "application/json"
 )

--- a/receiver/otlpreceiver/otlpgrpc.go
+++ b/receiver/otlpreceiver/otlpgrpc.go
@@ -1,0 +1,60 @@
+package otlpreceiver
+
+import (
+	"encoding/binary"
+	"errors"
+	"io"
+	"net/http"
+	"strconv"
+
+	"google.golang.org/grpc/codes"
+)
+
+const grpcStatus = "grpc-status"
+const grpcMessage = "grpc-message"
+
+var errTooLong = errors.New("response payload is too long to encode into gRPC")
+
+type grpcResponseWriter struct {
+	innerRw       http.ResponseWriter
+	headerWritten bool
+}
+
+func (rw grpcResponseWriter) Header() http.Header {
+	return rw.innerRw.Header()
+}
+
+func (rw grpcResponseWriter) Write(b []byte) (int, error) {
+	if !rw.headerWritten {
+		rw.WriteHeader(int(codes.OK))
+	}
+	lengthPrefix := make([]byte, 5)
+	payloadLen := uint32(len(b))
+	if int(payloadLen) != len(b) {
+		return 0, errTooLong
+	}
+	binary.BigEndian.PutUint32(lengthPrefix[1:], payloadLen)
+	_, err := rw.innerRw.Write(lengthPrefix)
+	if err != nil {
+		return 0, err
+	}
+	return rw.innerRw.Write(b)
+}
+
+func (rw *grpcResponseWriter) WriteHeader(statusCode int) {
+	if !rw.headerWritten {
+		rw.headerWritten = true
+		rw.Header()["Date"] = nil
+		rw.Header()["Trailer"] = []string{grpcStatus, grpcMessage}
+		rw.Header().Set("Content-Type", grpcContentType)
+		rw.innerRw.WriteHeader(200)
+	}
+	rw.Header().Set(grpcStatus, strconv.FormatInt(int64(statusCode), 10))
+}
+
+func unwrapProtoFromGrpc(reader io.Reader) (compressed bool, errout error) {
+	b := make([]byte, 5)
+	_, err := io.ReadFull(reader, b)
+	// compressed := b[0] == 1
+	return b[0] == 1, err
+}

--- a/receiver/otlpreceiver/testdata/config.yaml
+++ b/receiver/otlpreceiver/testdata/config.yaml
@@ -89,12 +89,15 @@ receivers:
           - ExampleHeader
   # The following demonstrates the experimental server which can serve both gRPC and HTTP from the same endpoint
   otlp/experimental:
-    experimental_server:
-      cors_allowed_origins:
-        - https://*.test.com # Wildcard subdomain. Allows domains like https://www.test.com and https://foo.test.com but not https://wwwtest.com.
-        - https://test.com # Fully qualified domain name. Allows https://test.com only.
-      cors_allowed_headers:
-        - ExampleHeader
+    experimental_server_enabled: true
+    protocols:
+      http:
+        endpoint: 0.0.0.0:4317
+        cors_allowed_origins:
+          - https://*.test.com # Wildcard subdomain. Allows domains like https://www.test.com and https://foo.test.com but not https://wwwtest.com.
+          - https://test.com # Fully qualified domain name. Allows https://test.com only.
+        cors_allowed_headers:
+          - ExampleHeader
 processors:
   nop:
 

--- a/receiver/otlpreceiver/testdata/config.yaml
+++ b/receiver/otlpreceiver/testdata/config.yaml
@@ -76,8 +76,8 @@ receivers:
     protocols:
       http:
         cors_allowed_origins:
-        - https://*.test.com # Wildcard subdomain. Allows domains like https://www.test.com and https://foo.test.com but not https://wwwtest.com.
-        - https://test.com # Fully qualified domain name. Allows https://test.com only.
+          - https://*.test.com # Wildcard subdomain. Allows domains like https://www.test.com and https://foo.test.com but not https://wwwtest.com.
+          - https://test.com # Fully qualified domain name. Allows https://test.com only.
   # The following entry demonstrates how to use CORS Header configuration.
   otlp/corsheader:
     protocols:
@@ -87,6 +87,14 @@ receivers:
           - https://test.com # Fully qualified domain name. Allows https://test.com only.
         cors_allowed_headers:
           - ExampleHeader
+  # The following demonstrates the experimental server which can serve both gRPC and HTTP from the same endpoint
+  otlp/experimental:
+    experimental_server:
+      cors_allowed_origins:
+        - https://*.test.com # Wildcard subdomain. Allows domains like https://www.test.com and https://foo.test.com but not https://wwwtest.com.
+        - https://test.com # Fully qualified domain name. Allows https://test.com only.
+      cors_allowed_headers:
+        - ExampleHeader
 processors:
   nop:
 


### PR DESCRIPTION
# gRPC / HTTP server consolidation 🚧  [PROTOTYPE] 🚧 

This PR consolidates the gRPC server and HTTP servers into 1 centralized server. The architecture of this solution enables:
* A consolidated 4317 port for both gRPC and HTTP traffic
* More configurable transports given that the official h2 / h2c golang servers are used rather than the gRPC implementation
* A smaller footprint for the binary given that the gRPC library is no longer compiled into the receiver

## Notes

* We should probably discuss direction on how to transport headers into the processors / exporters. There are valid reasons for wanting to access the headers - one example being the implementation of a multi-tenant solution where API keys may change.