### PR TITLE
Paging metric -- add device label

### DIFF
--- a/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/pagefile.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/pagefile.go
@@ -1,0 +1,22 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pagingscraper
+
+type pageFileStats struct {
+	deviceName  string // Optional
+	usedBytes   uint64
+	freeBytes   uint64
+	cachedBytes *uint64 // Optional
+}

--- a/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/pagefile_linux.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/pagefile_linux.go
@@ -1,0 +1,102 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build linux
+
+package pagingscraper
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+)
+
+const swapsFilePath = "/proc/swaps"
+
+const (
+	filenameCol = 0
+	// typeCol     = 1
+	sizeCol = 2
+	usedCol = 3
+	// priorityCol = 4
+)
+
+func getPageFileStats() ([]*pageFileStats, error) {
+	f, err := os.Open(swapsFilePath)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	return getPageFileStatsFromFile(f)
+}
+
+func getPageFileStatsFromFile(r io.Reader) ([]*pageFileStats, error) {
+	scanner := bufio.NewScanner(r)
+	if !scanner.Scan() {
+		if err := scanner.Err(); err != nil {
+			return nil, fmt.Errorf("couldn't read file %q: %w", swapsFilePath, err)
+		}
+		return nil, fmt.Errorf("unexpected end-of-file in %q", swapsFilePath)
+
+	}
+
+	// Check header headerFields are as expected
+	headerFields := strings.Fields(scanner.Text())
+	if len(headerFields) < usedCol {
+		return nil, fmt.Errorf("couldn't parse %q: too few fields in header", swapsFilePath)
+	}
+	if headerFields[filenameCol] != "Filename" {
+		return nil, fmt.Errorf("couldn't parse %q: expected %q to be %q", swapsFilePath, headerFields[filenameCol], "Filename")
+	}
+	if headerFields[sizeCol] != "Size" {
+		return nil, fmt.Errorf("couldn't parse %q: expected %q to be %q", swapsFilePath, headerFields[sizeCol], "Size")
+	}
+	if headerFields[usedCol] != "Used" {
+		return nil, fmt.Errorf("couldn't parse %q: expected %q to be %q", swapsFilePath, headerFields[usedCol], "Used")
+	}
+
+	var pages []*pageFileStats
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) < usedCol {
+			return nil, fmt.Errorf("couldn't parse %q: too few fields", swapsFilePath)
+		}
+
+		sizeKB, err := strconv.ParseUint(fields[sizeCol], 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("couldn't parse 'Size' column in %q: %w", swapsFilePath, err)
+		}
+
+		usedKB, err := strconv.ParseUint(fields[usedCol], 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("couldn't parse 'Used' column in %q: %w", swapsFilePath, err)
+		}
+
+		pages = append(pages, &pageFileStats{
+			deviceName: fields[filenameCol],
+			usedBytes:  usedKB * 1024,
+			freeBytes:  (sizeKB - usedKB) * 1024,
+		})
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("couldn't read file %q: %w", swapsFilePath, err)
+	}
+
+	return pages, nil
+}

--- a/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/pagefile_linux_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/pagefile_linux_test.go
@@ -1,0 +1,62 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build linux
+
+package pagingscraper
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const validFile = `Filename				Type		Size		Used		Priority
+/dev/dm-2                               partition	67022844	490788		-2
+/swapfile                               file		2		1		-3
+`
+
+const invalidFile = `INVALID				Type		Size		Used		Priority
+/dev/dm-2                               partition	67022844	490788		-2
+/swapfile                               file		1048572		0		-3
+`
+
+func TestGetPageFileStats_ValidFile(t *testing.T) {
+	assert := assert.New(t)
+	stats, err := getPageFileStatsFromFile(strings.NewReader(validFile))
+	assert.NoError(err)
+
+	assert.Equal(*stats[0], pageFileStats{
+		deviceName: "/dev/dm-2",
+		usedBytes:  502566912,
+		freeBytes:  68128825344,
+	})
+
+	assert.Equal(*stats[1], pageFileStats{
+		deviceName: "/swapfile",
+		usedBytes:  1024,
+		freeBytes:  1024,
+	})
+}
+
+func TestGetPageFileStats_InvalidFile(t *testing.T) {
+	_, err := getPageFileStatsFromFile(strings.NewReader(invalidFile))
+	assert.Error(t, err)
+}
+
+func TestGetPageFileStats_EmptyFile(t *testing.T) {
+	_, err := getPageFileStatsFromFile(strings.NewReader(""))
+	assert.Error(t, err)
+}

--- a/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/pagefile_others.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/pagefile_others.go
@@ -1,0 +1,32 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !windows,!linux
+
+package pagingscraper
+
+import "github.com/shirou/gopsutil/mem"
+
+func getPageFileStats() ([]*pageFileStats, error) {
+	vmem, err := mem.VirtualMemory()
+	if err != nil {
+		return nil, err
+	}
+	return []*pageFileStats{{
+		deviceName:  "", // We do not support per-device swap
+		usedBytes:   vmem.SwapTotal - vmem.SwapFree - vmem.SwapCached,
+		freeBytes:   vmem.SwapFree,
+		cachedBytes: &vmem.SwapCached,
+	}}, nil
+}

--- a/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/paging_scraper_others_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/paging_scraper_others_test.go
@@ -32,7 +32,7 @@ import (
 func TestScrape_Errors(t *testing.T) {
 	type testCase struct {
 		name              string
-		virtualMemoryFunc func() (*mem.VirtualMemoryStat, error)
+		virtualMemoryFunc func() ([]*pageFileStats, error)
 		swapMemoryFunc    func() (*mem.SwapMemoryStat, error)
 		expectedError     string
 		expectedErrCount  int
@@ -41,7 +41,7 @@ func TestScrape_Errors(t *testing.T) {
 	testCases := []testCase{
 		{
 			name:              "virtualMemoryError",
-			virtualMemoryFunc: func() (*mem.VirtualMemoryStat, error) { return nil, errors.New("err1") },
+			virtualMemoryFunc: func() ([]*pageFileStats, error) { return nil, errors.New("err1") },
 			expectedError:     "err1",
 			expectedErrCount:  pagingUsageMetricsLen,
 		},
@@ -53,7 +53,7 @@ func TestScrape_Errors(t *testing.T) {
 		},
 		{
 			name:              "multipleErrors",
-			virtualMemoryFunc: func() (*mem.VirtualMemoryStat, error) { return nil, errors.New("err1") },
+			virtualMemoryFunc: func() ([]*pageFileStats, error) { return nil, errors.New("err1") },
 			swapMemoryFunc:    func() (*mem.SwapMemoryStat, error) { return nil, errors.New("err2") },
 			expectedError:     "[err1; err2]",
 			expectedErrCount:  pagingUsageMetricsLen + pagingMetricsLen,
@@ -64,7 +64,7 @@ func TestScrape_Errors(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			scraper := newPagingScraper(context.Background(), &Config{})
 			if test.virtualMemoryFunc != nil {
-				scraper.virtualMemory = test.virtualMemoryFunc
+				scraper.getPageFileStats = test.virtualMemoryFunc
 			}
 			if test.swapMemoryFunc != nil {
 				scraper.swapMemory = test.swapMemoryFunc

--- a/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/paging_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/paging_scraper_test.go
@@ -100,19 +100,20 @@ func assertPagingUsageMetricValid(t *testing.T, hostPagingUsageMetric pdata.Metr
 	// expect at least used, free & cached datapoint
 	expectedDataPoints := 3
 	// windows does not return a cached datapoint
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == "windows" || runtime.GOOS == "linux" {
 		expectedDataPoints = 2
 	}
 
 	assert.GreaterOrEqual(t, hostPagingUsageMetric.Sum().DataPoints().Len(), expectedDataPoints)
 	internal.AssertSumMetricHasAttributeValue(t, hostPagingUsageMetric, 0, "state", pdata.NewAttributeValueString(metadata.LabelState.Used))
 	internal.AssertSumMetricHasAttributeValue(t, hostPagingUsageMetric, 1, "state", pdata.NewAttributeValueString(metadata.LabelState.Free))
-	// on non-windows, also expect a cached state label
-	if runtime.GOOS != "windows" {
+	// Windows and Linux do not support cached state label
+	if runtime.GOOS != "windows" && runtime.GOOS != "linux" {
 		internal.AssertSumMetricHasAttributeValue(t, hostPagingUsageMetric, 2, "state", pdata.NewAttributeValueString(metadata.LabelState.Cached))
 	}
-	// on windows, also expect the page file device name label
-	if runtime.GOOS == "windows" {
+
+	// on Windows and Linux, also expect the page file device name label
+	if runtime.GOOS == "windows" || runtime.GOOS == "linux" {
 		internal.AssertSumMetricHasAttribute(t, hostPagingUsageMetric, 0, "device")
 		internal.AssertSumMetricHasAttribute(t, hostPagingUsageMetric, 1, "device")
 	}

--- a/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/paging_scraper_windows_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/paging_scraper_windows_test.go
@@ -33,7 +33,7 @@ func TestScrape_Errors(t *testing.T) {
 	type testCase struct {
 		name              string
 		pageSize          uint64
-		getPageFileStats  func() ([]*pageFileData, error)
+		getPageFileStats  func() ([]*pageFileStats, error)
 		scrapeErr         error
 		getObjectErr      error
 		getValuesErr      error
@@ -44,21 +44,21 @@ func TestScrape_Errors(t *testing.T) {
 	}
 
 	testPageSize := uint64(4096)
-	testPageFileData := &pageFileData{usedPages: 100, totalPages: 300}
+	testPageFileData := &pageFileStats{usedBytes: 100, freeBytes: 200}
 
 	testCases := []testCase{
 		{
 			name:     "standard",
 			pageSize: testPageSize,
-			getPageFileStats: func() ([]*pageFileData, error) {
-				return []*pageFileData{testPageFileData}, nil
+			getPageFileStats: func() ([]*pageFileStats, error) {
+				return []*pageFileStats{testPageFileData}, nil
 			},
-			expectedUsedValue: int64(testPageFileData.usedPages * testPageSize),
-			expectedFreeValue: int64((testPageFileData.totalPages - testPageFileData.usedPages) * testPageSize),
+			expectedUsedValue: int64(testPageFileData.usedBytes),
+			expectedFreeValue: int64(testPageFileData.freeBytes),
 		},
 		{
 			name:             "pageFileError",
-			getPageFileStats: func() ([]*pageFileData, error) { return nil, errors.New("err1") },
+			getPageFileStats: func() ([]*pageFileStats, error) { return nil, errors.New("err1") },
 			expectedErr:      "err1",
 			expectedErrCount: pagingUsageMetricsLen,
 		},
@@ -82,7 +82,7 @@ func TestScrape_Errors(t *testing.T) {
 		},
 		{
 			name:             "multipleErrors",
-			getPageFileStats: func() ([]*pageFileData, error) { return nil, errors.New("err1") },
+			getPageFileStats: func() ([]*pageFileStats, error) { return nil, errors.New("err1") },
 			getObjectErr:     errors.New("err2"),
 			expectedErr:      "[err1; err2]",
 			expectedErrCount: pagingUsageMetricsLen + pagingMetricsLen,
@@ -95,12 +95,16 @@ func TestScrape_Errors(t *testing.T) {
 			if test.getPageFileStats != nil {
 				scraper.pageFileStats = test.getPageFileStats
 			}
+
+			pageSizeOnce.Do(func() {}) // Run this now so what we set pageSize to here is not overridden
 			if test.pageSize > 0 {
-				scraper.pageSize = test.pageSize
+				pageSize = test.pageSize
 			} else {
+				pageSize = getPageSize()
 				assert.Greater(t, pageSize, uint64(0))
 				assert.Zero(t, pageSize%4096) // page size on Windows should always be a multiple of 4KB
 			}
+
 			scraper.perfCounterScraper = perfcounters.NewMockPerfCounterScraperError(test.scrapeErr, test.getObjectErr, test.getValuesErr)
 
 			err := scraper.start(context.Background(), componenttest.NewNopHost())
@@ -118,6 +122,8 @@ func TestScrape_Errors(t *testing.T) {
 
 				return
 			}
+
+			assert.NoError(t, err)
 
 			pagingUsageMetric := metrics.At(0)
 			assert.Equal(t, test.expectedUsedValue, pagingUsageMetric.Sum().DataPoints().At(0).IntVal())


### PR DESCRIPTION
**Description:**
Extend paging scraper to collect per-device paging stats on Linux -- this will match the behavior for Windows. See tracking issue for more details.

**Link to tracking Issue:**  #3447

**Testing:** Unit tests extended for this case.