### PR TITLE
Rename CustomUnmarshable to Unmarshallable, typo in the initial name

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -169,9 +169,9 @@ type validatable interface {
 	Validate() error
 }
 
-// CustomUnmarshable defines an optional interface for custom configuration unmarshaling.
+// Unmarshallable defines an optional interface for custom configuration unmarshaling.
 // A configuration struct can implement this interface to override the default unmarshaling.
-type CustomUnmarshable interface {
+type Unmarshallable interface {
 	// Unmarshal is a function that un-marshals a Parser into the unmarshable struct in a custom way.
 	// componentSection *Parser
 	//   The config for this specific component. May be nil or empty if no config available.

--- a/config/configloader/config.go
+++ b/config/configloader/config.go
@@ -526,7 +526,7 @@ func expandEnv(s string) string {
 }
 
 func unmarshal(componentSection *configparser.Parser, intoCfg interface{}) error {
-	if cu, ok := intoCfg.(config.CustomUnmarshable); ok {
+	if cu, ok := intoCfg.(config.Unmarshallable); ok {
 		return cu.Unmarshal(componentSection)
 	}
 

--- a/internal/testcomponents/example_exporter.go
+++ b/internal/testcomponents/example_exporter.go
@@ -25,7 +25,7 @@ import (
 	"go.opentelemetry.io/collector/model/pdata"
 )
 
-var _ config.CustomUnmarshable = (*ExampleExporter)(nil)
+var _ config.Unmarshallable = (*ExampleExporter)(nil)
 
 // ExampleExporter is for testing purposes. We are defining an example config and factory
 // for "exampleexporter" exporter type.

--- a/receiver/hostmetricsreceiver/config.go
+++ b/receiver/hostmetricsreceiver/config.go
@@ -37,7 +37,7 @@ type Config struct {
 }
 
 var _ config.Receiver = (*Config)(nil)
-var _ config.CustomUnmarshable = (*Config)(nil)
+var _ config.Unmarshallable = (*Config)(nil)
 
 // Validate checks the receiver configuration is valid
 func (cfg *Config) Validate() error {

--- a/receiver/jaegerreceiver/config.go
+++ b/receiver/jaegerreceiver/config.go
@@ -81,7 +81,7 @@ type Config struct {
 }
 
 var _ config.Receiver = (*Config)(nil)
-var _ config.CustomUnmarshable = (*Config)(nil)
+var _ config.Unmarshallable = (*Config)(nil)
 
 // Validate checks the receiver configuration is valid
 func (cfg *Config) Validate() error {

--- a/receiver/otlpreceiver/config.go
+++ b/receiver/otlpreceiver/config.go
@@ -44,7 +44,7 @@ type Config struct {
 }
 
 var _ config.Receiver = (*Config)(nil)
-var _ config.CustomUnmarshable = (*Config)(nil)
+var _ config.Unmarshallable = (*Config)(nil)
 
 // Validate checks the receiver configuration is valid
 func (cfg *Config) Validate() error {

--- a/receiver/prometheusreceiver/config.go
+++ b/receiver/prometheusreceiver/config.go
@@ -48,7 +48,7 @@ type Config struct {
 }
 
 var _ config.Receiver = (*Config)(nil)
-var _ config.CustomUnmarshable = (*Config)(nil)
+var _ config.Unmarshallable = (*Config)(nil)
 
 // Validate checks the receiver configuration is valid.
 func (cfg *Config) Validate() error {


### PR DESCRIPTION
Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
