### PR TITLE
Adding max_message_bytes for producer configuration to kafkaexporter

### DIFF
--- a/exporter/kafkaexporter/config.go
+++ b/exporter/kafkaexporter/config.go
@@ -42,6 +42,9 @@ type Config struct {
 	// Client, and shared by the Producer/Consumer.
 	Metadata Metadata `mapstructure:"metadata"`
 
+	// Producer is the namespaces for producer properties used only by the Producer
+	Producer Producer `mapstructure:"producer"`
+
 	// Authentication defines used authentication mechanism.
 	Authentication Authentication `mapstructure:"auth"`
 }
@@ -58,6 +61,12 @@ type Metadata struct {
 	// This configuration is useful to avoid race conditions when broker
 	// is starting at the same time as collector.
 	Retry MetadataRetry `mapstructure:"retry"`
+}
+
+// Producer defines configuration for producer
+type Producer struct {
+	// Maximum message bytes the producer will accept to produce.
+	MaxMessageBytes int `mapstructure:"max_message_bytes"`
 }
 
 // MetadataRetry defines retry configuration for Metadata.

--- a/exporter/kafkaexporter/config_test.go
+++ b/exporter/kafkaexporter/config_test.go
@@ -71,5 +71,8 @@ func TestLoadConfig(t *testing.T) {
 				Backoff: defaultMetadataRetryBackoff,
 			},
 		},
+		Producer: Producer{
+			MaxMessageBytes: 10000000,
+		},
 	}, c)
 }

--- a/exporter/kafkaexporter/factory.go
+++ b/exporter/kafkaexporter/factory.go
@@ -37,6 +37,8 @@ const (
 	defaultMetadataRetryBackoff = time.Millisecond * 250
 	// default from sarama.NewConfig()
 	defaultMetadataFull = true
+	// default max.message.bytes for the producer
+	defaultProducerMaxMessageBytes = 1000000
 )
 
 // FactoryOption applies changes to kafkaExporterFactory.
@@ -86,6 +88,9 @@ func createDefaultConfig() config.Exporter {
 				Max:     defaultMetadataRetryMax,
 				Backoff: defaultMetadataRetryBackoff,
 			},
+		},
+		Producer: Producer{
+			MaxMessageBytes: defaultProducerMaxMessageBytes,
 		},
 	}
 }

--- a/exporter/kafkaexporter/kafka_exporter.go
+++ b/exporter/kafkaexporter/kafka_exporter.go
@@ -112,6 +112,7 @@ func newSaramaProducer(config Config) (sarama.SyncProducer, error) {
 	c.Metadata.Full = config.Metadata.Full
 	c.Metadata.Retry.Max = config.Metadata.Retry.Max
 	c.Metadata.Retry.Backoff = config.Metadata.Retry.Backoff
+	c.Producer.MaxMessageBytes = config.Producer.MaxMessageBytes
 	if config.ProtocolVersion != "" {
 		version, err := sarama.ParseKafkaVersion(config.ProtocolVersion)
 		if err != nil {

--- a/exporter/kafkaexporter/testdata/config.yaml
+++ b/exporter/kafkaexporter/testdata/config.yaml
@@ -8,6 +8,8 @@ exporters:
       full: false
       retry:
         max: 15
+    producer:
+      max_message_bytes: 10000000
     timeout: 10s
     auth:
       plain_text:


### PR DESCRIPTION
**Description:** 

A new `kafkaexporter` setting `max_message_bytes` has been added, under `producer` section.

**Link to tracking Issue:**

https://github.com/open-telemetry/opentelemetry-collector/issues/3579

**Testing:**

A test was added to validate that configuration is parsed correctly.
Tested for messages bigger than default allowed.
