### PR TITLE
exporter/prometheusremotewrite: glue up and use Write-Ahead-Log

### DIFF
--- a/exporter/prometheusremotewriteexporter/README.md
+++ b/exporter/prometheusremotewriteexporter/README.md
@@ -48,6 +48,10 @@ Example:
 exporters:
   prometheusremotewrite:
     endpoint: "https://my-cortex:7900/api/v1/push"
+    wal: # Enabling the Write-Ahead-Log for the exporter.
+        directory: ./prom_rw # The directory to store the WAL in
+        buffer_size: 100 # Optional count of elements to be read from the WAL before truncating; default of 300
+        truncate_frequency: 45s # Optional frequency for how often the WAL should be truncated. It is a time.ParseDuration; default of 1m
 ```
 
 ## Advanced Configuration

--- a/exporter/prometheusremotewriteexporter/config.go
+++ b/exporter/prometheusremotewriteexporter/config.go
@@ -45,6 +45,8 @@ type Config struct {
 	// "Enabled" - A boolean field to enable/disable this option. Default is `false`.
 	// If enabled, all the resource attributes will be converted to metric labels by default.
 	exporterhelper.ResourceToTelemetrySettings `mapstructure:"resource_to_telemetry_conversion"`
+
+	WAL *walConfig `mapstructure:"wal"`
 }
 
 // RemoteWriteQueue allows to configure the remote write queue.

--- a/exporter/prometheusremotewriteexporter/wal_test.go
+++ b/exporter/prometheusremotewriteexporter/wal_test.go
@@ -75,6 +75,13 @@ func orderByLabelValue(wreq *prompb.WriteRequest) {
 			timeSeries.Samples[i] = *bMsgs[i].sample
 		}
 	}
+
+	// Now finally sort stably by timeseries value for
+	// which just .String() is good enough for comparison.
+	sort.Slice(wreq.Timeseries, func(i, j int) bool {
+		ti, tj := wreq.Timeseries[i], wreq.Timeseries[j]
+		return ti.String() < tj.String()
+	})
 }
 
 func TestWALStopManyTimes(t *testing.T) {
@@ -82,7 +89,7 @@ func TestWALStopManyTimes(t *testing.T) {
 	config := &walConfig{
 		Directory:         tempDir,
 		TruncateFrequency: 60 * time.Microsecond,
-		NBeforeTruncation: 1,
+		BufferSize:        1,
 	}
 	pwal, err := newWAL(config, doNothingExportSink)
 	require.Nil(t, err)

--- a/go.mod
+++ b/go.mod
@@ -6,13 +6,13 @@ require (
 	contrib.go.opencensus.io/exporter/prometheus v0.3.0
 	github.com/Shopify/sarama v1.29.1
 	github.com/StackExchange/wmi v1.2.1 // indirect
-	github.com/pquerna/cachecontrol v0.1.0 // indirect
 	github.com/antonmedv/expr v1.9.0
 	github.com/apache/thrift v0.14.2
 	github.com/cenkalti/backoff/v4 v4.1.1
 	github.com/census-instrumentation/opencensus-proto v0.3.0
 	github.com/coreos/go-oidc v2.2.1+incompatible
 	github.com/fatih/structtag v1.2.0
+	github.com/fsnotify/fsnotify v1.4.9 // indirect
 	github.com/go-kit/kit v0.11.0
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da
@@ -29,6 +29,7 @@ require (
 	github.com/magiconair/properties v1.8.5
 	github.com/mitchellh/mapstructure v1.4.1
 	github.com/openzipkin/zipkin-go v0.2.5
+	github.com/pquerna/cachecontrol v0.1.0 // indirect
 	github.com/prometheus/client_golang v1.11.0
 	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.30.0

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/mux v1.8.0
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0
+	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/jaegertracing/jaeger v1.25.0
 	github.com/knadh/koanf v1.2.1
 	github.com/leoluk/perflib_exporter v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -673,6 +673,8 @@ github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iP
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/go-multierror v1.1.0 h1:B9UzwGQJehnUY1yNrnwREHc3fGbC2xefo8g4TbElacI=
 github.com/hashicorp/go-multierror v1.1.0/go.mod h1:spPvp8C1qA32ftKqdAHm4hHTbPw+vmowP0z+KUhOZdA=
+github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
+github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/go-plugin v1.0.1/go.mod h1:++UyYGoz3o5w9ZzAdZxtQKrWWP+iqPBn3cQptSMzBuY=
 github.com/hashicorp/go-plugin v1.4.2/go.mod h1:5fGEH17QVwTTcR0zV7yhDPLLmFX9YSZ38b18Udy6vYQ=
 github.com/hashicorp/go-retryablehttp v0.5.3/go.mod h1:9B5zBasrRhHXnJnui7y6sL7es7NDiJgTc6Er0maI1Xs=


### PR DESCRIPTION
This change completes the WAL capability for the Prometheus Remote-Write exporter
that allows recovery of data if the prior write requests weren't yet exported.

This wires up a Write-Ahead-Log (WAL) that was implemented in PR #3597, which
was split off from PR #3017.

Note: there is very rare condition for which we can perhaps send the
same data many times and it can happen if we haven't yet truncated the
WAL, the RemoteWrite endpoint received the prior data but the process
received a Ctrl+C, kill signal. However, this will be very rare and
would have to be timed so fast and precisely.

Replaces PR #3017
Updates PR #3597
Fixes #3727
Fixes open-telemetry/wg-prometheus#9
