### PR TITLE
add support for exporting internal metrics via OpenTelemetry library.

### DIFF
--- a/config/configtelemetry/configtelemetry.go
+++ b/config/configtelemetry/configtelemetry.go
@@ -38,6 +38,8 @@ const (
 	metricsLevelCfg = "metrics-level"
 )
 
+const UseOpenTelemetryForInternalMetrics = false
+
 var metricsLevelPtr = new(Level)
 
 // Flags is a helper function to add telemetry config flags to the service that exposes

--- a/go.mod
+++ b/go.mod
@@ -23,8 +23,11 @@ require (
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.23.0
 	go.opentelemetry.io/contrib/zpages v0.23.0
 	go.opentelemetry.io/otel v1.0.0
+	go.opentelemetry.io/otel/exporters/prometheus v0.23.0
 	go.opentelemetry.io/otel/metric v0.23.0
 	go.opentelemetry.io/otel/sdk v1.0.0
+	go.opentelemetry.io/otel/sdk/export/metric v0.23.0
+	go.opentelemetry.io/otel/sdk/metric v0.23.0
 	go.opentelemetry.io/otel/trace v1.0.0
 	go.uber.org/atomic v1.9.0
 	go.uber.org/zap v1.19.1

--- a/go.sum
+++ b/go.sum
@@ -408,6 +408,8 @@ go.opentelemetry.io/contrib/zpages v0.23.0/go.mod h1:i5BVZTRftVMBmYLP/T++in2G5MA
 go.opentelemetry.io/otel v1.0.0-RC3/go.mod h1:Ka5j3ua8tZs4Rkq4Ex3hwgBgOchyPVq5S6P2lz//nKQ=
 go.opentelemetry.io/otel v1.0.0 h1:qTTn6x71GVBvoafHK/yaRUmFzI4LcONZD0/kXxl5PHI=
 go.opentelemetry.io/otel v1.0.0/go.mod h1:AjRVh9A5/5DE7S+mZtTR6t8vpKKryam+0lREnfmS4cg=
+go.opentelemetry.io/otel/exporters/prometheus v0.23.0 h1:ZFx1kUjUSBF7H1mTPHHOqglEDQsxYBrDnYZ8i41v3iE=
+go.opentelemetry.io/otel/exporters/prometheus v0.23.0/go.mod h1:kjCXbxQnnEm5l3HrUw4IPyuALu7Uqb/bEK7vWQnbd8s=
 go.opentelemetry.io/otel/internal/metric v0.23.0 h1:mPfzm9Iqhw7G2nDBmUAjFTfPqLZPbOW2k7QI57ITbaI=
 go.opentelemetry.io/otel/internal/metric v0.23.0/go.mod h1:z+RPiDJe30YnCrOhFGivwBS+DU1JU/PiLKkk4re2DNY=
 go.opentelemetry.io/otel/metric v0.23.0 h1:mYCcDxi60P4T27/0jchIDFa1WHEfQeU3zH9UEMpnj2c=
@@ -415,6 +417,10 @@ go.opentelemetry.io/otel/metric v0.23.0/go.mod h1:G/Nn9InyNnIv7J6YVkQfpc0JCfKBNJ
 go.opentelemetry.io/otel/sdk v1.0.0-RC3/go.mod h1:78H6hyg2fka0NYT9fqGuFLvly2yCxiBXDJAgLKo/2Us=
 go.opentelemetry.io/otel/sdk v1.0.0 h1:BNPMYUONPNbLneMttKSjQhOTlFLOD9U22HNG1KrIN2Y=
 go.opentelemetry.io/otel/sdk v1.0.0/go.mod h1:PCrDHlSy5x1kjezSdL37PhbFUMjrsLRshJ2zCzeXwbM=
+go.opentelemetry.io/otel/sdk/export/metric v0.23.0 h1:7NeoKPPx6NdZBVHLEp/LY5Lq85Ff1WNZnuJkuRy+azw=
+go.opentelemetry.io/otel/sdk/export/metric v0.23.0/go.mod h1:SuMiREmKVRIwFKq73zvGTvwFpxb/ZAYkMfyqMoOtDqs=
+go.opentelemetry.io/otel/sdk/metric v0.23.0 h1:xlZhPbiue1+jjSFEth94q9QCmX8Q24mOtue9IAmlVyI=
+go.opentelemetry.io/otel/sdk/metric v0.23.0/go.mod h1:wa0sKK13eeIFW+0OFjcC3S1i7FTRRiLAXe1kjBVbhwg=
 go.opentelemetry.io/otel/trace v1.0.0-RC3/go.mod h1:VUt2TUYd8S2/ZRX09ZDFZQwn2RqfMB5MzO17jBojGxo=
 go.opentelemetry.io/otel/trace v1.0.0 h1:TSBr8GTEtKevYMG/2d21M989r5WJYVimhTHBKVEZuh4=
 go.opentelemetry.io/otel/trace v1.0.0/go.mod h1:PXTWqayeFUlJV1YDNhsJYB184+IvAH814St6o6ajzIs=

--- a/service/telemetry.go
+++ b/service/telemetry.go
@@ -24,6 +24,13 @@ import (
 	"contrib.go.opencensus.io/exporter/prometheus"
 	"github.com/google/uuid"
 	"go.opencensus.io/stats/view"
+	otelprometheus "go.opentelemetry.io/otel/exporters/prometheus"
+	"go.opentelemetry.io/otel/metric/global"
+	export "go.opentelemetry.io/otel/sdk/export/metric"
+	"go.opentelemetry.io/otel/sdk/metric/aggregator/histogram"
+	controller "go.opentelemetry.io/otel/sdk/metric/controller/basic"
+	processor "go.opentelemetry.io/otel/sdk/metric/processor/basic"
+	selector "go.opentelemetry.io/otel/sdk/metric/selector/simple"
 	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/config/configtelemetry"
@@ -71,44 +78,26 @@ func (tel *colTelemetry) initOnce(asyncErrorChannel chan<- error, ballastSizeByt
 		return nil
 	}
 
-	processMetricsViews, err := telemetry2.NewProcessMetricsViews(ballastSizeBytes)
-	if err != nil {
-		return err
-	}
-
-	var views []*view.View
-	obsMetrics := obsreportconfig.Configure(level)
-	views = append(views, batchprocessor.MetricViews()...)
-	views = append(views, obsMetrics.Views...)
-	views = append(views, processMetricsViews.Views()...)
-
-	tel.views = views
-	if err = view.Register(views...); err != nil {
-		return err
-	}
-
-	processMetricsViews.StartCollection()
-
-	// Until we can use a generic metrics exporter, default to Prometheus.
-	opts := prometheus.Options{
-		Namespace: telemetry.GetMetricsPrefix(),
-	}
-
 	var instanceID string
 	if telemetry.GetAddInstanceID() {
 		instanceUUID, _ := uuid.NewRandom()
 		instanceID = instanceUUID.String()
-		opts.ConstLabels = map[string]string{
-			sanitizePrometheusKey(semconv.AttributeServiceInstanceID): instanceID,
+	}
+
+	var pe http.Handler
+	if configtelemetry.UseOpenTelemetryForInternalMetrics {
+		otelHandler, err := tel.initOpenTelemetry()
+		if err != nil {
+			return err
 		}
+		pe = otelHandler
+	} else {
+		ocHandler, err := tel.initOpenCensus(level, instanceID, ballastSizeBytes)
+		if err != nil {
+			return err
+		}
+		pe = ocHandler
 	}
-
-	pe, err := prometheus.NewExporter(opts)
-	if err != nil {
-		return err
-	}
-
-	view.RegisterExporter(pe)
 
 	logger.Info(
 		"Serving Prometheus metrics",
@@ -133,6 +122,66 @@ func (tel *colTelemetry) initOnce(asyncErrorChannel chan<- error, ballastSizeByt
 	}()
 
 	return nil
+}
+
+func (tel *colTelemetry) initOpenCensus(level configtelemetry.Level, instanceID string, ballastSizeBytes uint64) (http.Handler, error) {
+	processMetricsViews, err := telemetry2.NewProcessMetricsViews(ballastSizeBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	var views []*view.View
+	obsMetrics := obsreportconfig.Configure(level)
+	views = append(views, batchprocessor.MetricViews()...)
+	views = append(views, obsMetrics.Views...)
+	views = append(views, processMetricsViews.Views()...)
+
+	tel.views = views
+	if err = view.Register(views...); err != nil {
+		return nil, err
+	}
+
+	processMetricsViews.StartCollection()
+
+	// Until we can use a generic metrics exporter, default to Prometheus.
+	opts := prometheus.Options{
+		Namespace: telemetry.GetMetricsPrefix(),
+	}
+
+	if telemetry.GetAddInstanceID() {
+		opts.ConstLabels = map[string]string{
+			sanitizePrometheusKey(semconv.AttributeServiceInstanceID): instanceID,
+		}
+	}
+
+	pe, err := prometheus.NewExporter(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	view.RegisterExporter(pe)
+	return pe, nil
+}
+
+func (tel *colTelemetry) initOpenTelemetry() (http.Handler, error) {
+	config := otelprometheus.Config{}
+	c := controller.New(
+		processor.New(
+			selector.NewWithHistogramDistribution(
+				histogram.WithExplicitBoundaries(config.DefaultHistogramBoundaries),
+			),
+			export.CumulativeExportKindSelector(),
+			processor.WithMemory(true),
+		),
+	)
+
+	pe, err := otelprometheus.New(config, c)
+	if err != nil {
+		return nil, err
+	}
+
+	global.SetMeterProvider(pe.MeterProvider())
+	return pe, err
 }
 
 func (tel *colTelemetry) shutdown() error {


### PR DESCRIPTION
**Description:** add support for exporting internal metrics via OpenTelemetry library.

This change adds a new flag `--metrics-backend` which can be set to `opentelemetry` to use the [OpenTelemetry Prometheus exporter](https://github.com/open-telemetry/opentelemetry-go/tree/main/exporters/prometheus) for internal metrics instead of the current OpenCensus implementation. The flag defaults to `opencensus`, preserving the current functionality. There will be follow up PRs that actually set up the existing internal metrics to be exported via the OpenTelemetry library (currently, the exporter will start but will not expose any metrics).

**Link to tracking Issue:** Updates #816 

**Testing:** Added unit tests for the new flag and manually tested to make sure the current internal metrics are still exported correctly using OpenCensus when `--metrics-backend` isn't set.

/cc @odeke-em 