### PR TITLE
all: remove OtlpProtoSize in favor of Sizer interface

### DIFF
--- a/model/otlp/pb_marshaler.go
+++ b/model/otlp/pb_marshaler.go
@@ -19,29 +19,32 @@ import (
 	"go.opentelemetry.io/collector/model/pdata"
 )
 
-// NewProtobufTracesMarshaler returns a model.TracesMarshaler. Marshals to OTLP binary protobuf bytes.
+// NewProtobufTracesMarshaler returns a pdata.TracesMarshaler. Marshals to OTLP binary protobuf bytes.
 func NewProtobufTracesMarshaler() pdata.TracesMarshaler {
 	return newPbMarshaler()
 }
 
-// NewProtobufMetricsMarshaler returns a model.MetricsMarshaler. Marshals to OTLP binary protobuf bytes.
+// NewProtobufMetricsMarshaler returns a pdata.MetricsMarshaler. Marshals to OTLP binary protobuf bytes.
 func NewProtobufMetricsMarshaler() pdata.MetricsMarshaler {
 	return newPbMarshaler()
 }
 
-// NewProtobufLogsMarshaler returns a model.LogsMarshaler. Marshals to OTLP binary protobuf bytes.
+// NewProtobufLogsMarshaler returns a pdata.LogsMarshaler. Marshals to OTLP binary protobuf bytes.
 func NewProtobufLogsMarshaler() pdata.LogsMarshaler {
 	return newPbMarshaler()
 }
 
+// NewProtobufTracesSizer returns a pdata.TracesSizer. Returns the size of the a pdata.Traces when converted to a binary protobuf.
 func NewProtobufTracesSizer() pdata.TracesSizer {
 	return newPbMarshaler()
 }
 
+// NewProtobufMetricsSizer returns a pdata.MetricsSizer. Returns the size of the a pdata.Metrics when converted to a binary protobuf.
 func NewProtobufMetricsSizer() pdata.MetricsSizer {
 	return newPbMarshaler()
 }
 
+// NewProtobufLogsSizer returns a pdata.LogsSizer. Returns the size of the a pdata.Logs when converted to a binary protobuf.
 func NewProtobufLogsSizer() pdata.LogsSizer {
 	return newPbMarshaler()
 }

--- a/model/otlp/pb_marshaler.go
+++ b/model/otlp/pb_marshaler.go
@@ -15,8 +15,6 @@
 package otlp
 
 import (
-	"fmt"
-
 	"go.opentelemetry.io/collector/model/internal"
 	"go.opentelemetry.io/collector/model/pdata"
 )
@@ -36,7 +34,15 @@ func NewProtobufLogsMarshaler() pdata.LogsMarshaler {
 	return newPbMarshaler()
 }
 
-func NewProtobufSizer() pdata.Sizer {
+func NewProtobufTracesSizer() pdata.TracesSizer {
+	return newPbMarshaler()
+}
+
+func NewProtobufMetricsSizer() pdata.MetricsSizer {
+	return newPbMarshaler()
+}
+
+func NewProtobufLogsSizer() pdata.LogsSizer {
 	return newPbMarshaler()
 }
 
@@ -45,6 +51,10 @@ type pbMarshaler struct{}
 func newPbMarshaler() *pbMarshaler {
 	return &pbMarshaler{}
 }
+
+var _ pdata.TracesSizer = (*pbMarshaler)(nil)
+var _ pdata.MetricsSizer = (*pbMarshaler)(nil)
+var _ pdata.LogsSizer = (*pbMarshaler)(nil)
 
 func (e *pbMarshaler) MarshalLogs(ld pdata.Logs) ([]byte, error) {
 	return internal.LogsToOtlp(ld.InternalRep()).Marshal()
@@ -58,23 +68,14 @@ func (e *pbMarshaler) MarshalTraces(td pdata.Traces) ([]byte, error) {
 	return internal.TracesToOtlp(td.InternalRep()).Marshal()
 }
 
-// Size returns the size in bytes of a pdata.Traces, pdata.Metrics or pdata.Logs.
-// If the type is not known, an error will be returned.
-func (e *pbMarshaler) Size(v interface{}) (int, error) {
-	switch conv := v.(type) {
-	case pdata.Traces:
-		return internal.TracesToOtlp(conv.InternalRep()).Size(), nil
-	case *pdata.Traces:
-		return internal.TracesToOtlp(conv.InternalRep()).Size(), nil
-	case pdata.Metrics:
-		return internal.MetricsToOtlp(conv.InternalRep()).Size(), nil
-	case *pdata.Metrics:
-		return internal.MetricsToOtlp(conv.InternalRep()).Size(), nil
-	case pdata.Logs:
-		return internal.LogsToOtlp(conv.InternalRep()).Size(), nil
-	case *pdata.Logs:
-		return internal.LogsToOtlp(conv.InternalRep()).Size(), nil
-	default:
-		return 0, fmt.Errorf("unknown type: %T", v)
-	}
+func (e *pbMarshaler) TracesSize(td pdata.Traces) int {
+	return internal.TracesToOtlp(td.InternalRep()).Size()
+}
+
+func (e *pbMarshaler) MetricsSize(td pdata.Metrics) int {
+	return internal.MetricsToOtlp(td.InternalRep()).Size()
+}
+
+func (e *pbMarshaler) LogsSize(td pdata.Logs) int {
+	return internal.LogsToOtlp(td.InternalRep()).Size()
 }

--- a/model/otlp/pb_marshaler.go
+++ b/model/otlp/pb_marshaler.go
@@ -34,21 +34,7 @@ func NewProtobufLogsMarshaler() pdata.LogsMarshaler {
 	return newPbMarshaler()
 }
 
-// NewProtobufTracesSizer returns a pdata.TracesSizer. Returns the size of the a pdata.Traces when converted to a binary protobuf.
-func NewProtobufTracesSizer() pdata.TracesSizer {
-	return newPbMarshaler()
-}
-
-// NewProtobufMetricsSizer returns a pdata.MetricsSizer. Returns the size of the a pdata.Metrics when converted to a binary protobuf.
-func NewProtobufMetricsSizer() pdata.MetricsSizer {
-	return newPbMarshaler()
-}
-
-// NewProtobufLogsSizer returns a pdata.LogsSizer. Returns the size of the a pdata.Logs when converted to a binary protobuf.
-func NewProtobufLogsSizer() pdata.LogsSizer {
-	return newPbMarshaler()
-}
-
+// TODO(#3842): Figure out how we want to represent/return *Sizers.
 type pbMarshaler struct{}
 
 func newPbMarshaler() *pbMarshaler {

--- a/model/otlp/pb_marshaler.go
+++ b/model/otlp/pb_marshaler.go
@@ -72,10 +72,10 @@ func (e *pbMarshaler) TracesSize(td pdata.Traces) int {
 	return internal.TracesToOtlp(td.InternalRep()).Size()
 }
 
-func (e *pbMarshaler) MetricsSize(td pdata.Metrics) int {
-	return internal.MetricsToOtlp(td.InternalRep()).Size()
+func (e *pbMarshaler) MetricsSize(md pdata.Metrics) int {
+	return internal.MetricsToOtlp(md.InternalRep()).Size()
 }
 
-func (e *pbMarshaler) LogsSize(td pdata.Logs) int {
-	return internal.LogsToOtlp(td.InternalRep()).Size()
+func (e *pbMarshaler) LogsSize(ld pdata.Logs) int {
+	return internal.LogsToOtlp(ld.InternalRep()).Size()
 }

--- a/model/otlp/pb_test.go
+++ b/model/otlp/pb_test.go
@@ -43,7 +43,7 @@ func TestProtobufTracesUnmarshaler_error(t *testing.T) {
 }
 
 func TestProtobufTracesSizer(t *testing.T) {
-	sizer := NewProtobufTracesSizer()
+	sizer := NewProtobufTracesMarshaler().(pdata.TracesSizer)
 	marshaler := NewProtobufTracesMarshaler()
 	td := pdata.NewTraces()
 	rms := td.ResourceSpans()
@@ -57,13 +57,13 @@ func TestProtobufTracesSizer(t *testing.T) {
 }
 
 func TestProtobufTracesSizer_withNil(t *testing.T) {
-	sizer := NewProtobufTracesSizer()
+	sizer := NewProtobufTracesMarshaler().(pdata.TracesSizer)
 
 	assert.Equal(t, 0, sizer.TracesSize(pdata.NewTraces()))
 }
 
 func TestProtobufMetricsSizer(t *testing.T) {
-	sizer := NewProtobufMetricsSizer()
+	sizer := NewProtobufMetricsMarshaler().(pdata.MetricsSizer)
 	marshaler := NewProtobufMetricsMarshaler()
 	md := pdata.NewMetrics()
 	md.ResourceMetrics().AppendEmpty().InstrumentationLibraryMetrics().AppendEmpty().Metrics().AppendEmpty().SetName("foo")
@@ -76,13 +76,13 @@ func TestProtobufMetricsSizer(t *testing.T) {
 }
 
 func TestProtobufMetricsSizer_withNil(t *testing.T) {
-	sizer := NewProtobufMetricsSizer()
+	sizer := NewProtobufMetricsMarshaler().(pdata.MetricsSizer)
 
 	assert.Equal(t, 0, sizer.MetricsSize(pdata.NewMetrics()))
 }
 
 func TestProtobufLogsSizer(t *testing.T) {
-	sizer := NewProtobufLogsSizer()
+	sizer := NewProtobufLogsMarshaler().(pdata.LogsSizer)
 	marshaler := NewProtobufLogsMarshaler()
 	ld := pdata.NewLogs()
 	ld.ResourceLogs().AppendEmpty().InstrumentationLibraryLogs().AppendEmpty().Logs().AppendEmpty().SetName("foo")
@@ -96,7 +96,7 @@ func TestProtobufLogsSizer(t *testing.T) {
 }
 
 func TestProtobufLogsSizer_withNil(t *testing.T) {
-	sizer := NewProtobufLogsSizer()
+	sizer := NewProtobufLogsMarshaler().(pdata.LogsSizer)
 
 	assert.Equal(t, 0, sizer.LogsSize(pdata.NewLogs()))
 }

--- a/model/otlp/pb_test.go
+++ b/model/otlp/pb_test.go
@@ -42,6 +42,65 @@ func TestProtobufTracesUnmarshaler_error(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestProtobufTracesSizer(t *testing.T) {
+	sizer := NewProtobufTracesSizer()
+	marshaler := NewProtobufTracesMarshaler()
+	td := pdata.NewTraces()
+	rms := td.ResourceSpans()
+	rms.AppendEmpty().InstrumentationLibrarySpans().AppendEmpty().Spans().AppendEmpty().SetName("foo")
+
+	size := sizer.TracesSize(td)
+
+	bytes, err := marshaler.MarshalTraces(td)
+	require.NoError(t, err)
+	assert.Equal(t, len(bytes), size)
+}
+
+func TestProtobufTracesSizer_withNil(t *testing.T) {
+	sizer := NewProtobufTracesSizer()
+
+	assert.Equal(t, 0, sizer.TracesSize(pdata.NewTraces()))
+}
+
+func TestProtobufMetricsSizer(t *testing.T) {
+	sizer := NewProtobufMetricsSizer()
+	marshaler := NewProtobufMetricsMarshaler()
+	md := pdata.NewMetrics()
+	md.ResourceMetrics().AppendEmpty().InstrumentationLibraryMetrics().AppendEmpty().Metrics().AppendEmpty().SetName("foo")
+
+	size := sizer.MetricsSize(md)
+
+	bytes, err := marshaler.MarshalMetrics(md)
+	require.NoError(t, err)
+	assert.Equal(t, len(bytes), size)
+}
+
+func TestProtobufMetricsSizer_withNil(t *testing.T) {
+	sizer := NewProtobufMetricsSizer()
+
+	assert.Equal(t, 0, sizer.MetricsSize(pdata.NewMetrics()))
+}
+
+func TestProtobufLogsSizer(t *testing.T) {
+	sizer := NewProtobufLogsSizer()
+	marshaler := NewProtobufLogsMarshaler()
+	ld := pdata.NewLogs()
+	ld.ResourceLogs().AppendEmpty().InstrumentationLibraryLogs().AppendEmpty().Logs().AppendEmpty().SetName("foo")
+
+	size := sizer.LogsSize(ld)
+
+	bytes, err := marshaler.MarshalLogs(ld)
+	require.NoError(t, err)
+	assert.Equal(t, len(bytes), size)
+
+}
+
+func TestProtobufLogsSizer_withNil(t *testing.T) {
+	sizer := NewProtobufLogsSizer()
+
+	assert.Equal(t, 0, sizer.LogsSize(pdata.NewLogs()))
+}
+
 func BenchmarkLogsToProtobuf(b *testing.B) {
 	marshaler := NewProtobufLogsMarshaler()
 	logs := generateBenchmarkLogs(128)

--- a/model/pdata/common.go
+++ b/model/pdata/common.go
@@ -908,10 +908,3 @@ func (sm StringMap) Sort() StringMap {
 func newStringKeyValue(k, v string) otlpcommon.StringKeyValue { //nolint:staticcheck // SA1019 ignore this!
 	return otlpcommon.StringKeyValue{Key: k, Value: v} //nolint:staticcheck // SA1019 ignore this!
 }
-
-// Sizer returns the size of a Traces, Metrics, or Logs.
-type Sizer interface {
-	// Size returns the size in bytes of a Traces, Metrics or Logs.
-	// If the type is not known, an error will be returned.
-	Size(v interface{}) (int, error)
-}

--- a/model/pdata/common.go
+++ b/model/pdata/common.go
@@ -908,3 +908,10 @@ func (sm StringMap) Sort() StringMap {
 func newStringKeyValue(k, v string) otlpcommon.StringKeyValue { //nolint:staticcheck // SA1019 ignore this!
 	return otlpcommon.StringKeyValue{Key: k, Value: v} //nolint:staticcheck // SA1019 ignore this!
 }
+
+// Sizer returns the size of a Traces, Metrics, or Logs.
+type Sizer interface {
+	// Size returns the size in bytes of a Traces, Metrics or Logs.
+	// If the type is not known, an error will be returned.
+	Size(v interface{}) (int, error)
+}

--- a/model/pdata/logs.go
+++ b/model/pdata/logs.go
@@ -34,6 +34,12 @@ type LogsUnmarshaler interface {
 	UnmarshalLogs(buf []byte) (Logs, error)
 }
 
+// LogsSizer returns the size of a Logs.
+type LogsSizer interface {
+	// LogsSize returns the size in bytes of a Logs.
+	LogsSize(td Logs) int
+}
+
 // Logs is the top-level struct that is propagated through the logs pipeline.
 //
 // This is a reference type (like builtin map).

--- a/model/pdata/logs.go
+++ b/model/pdata/logs.go
@@ -85,12 +85,6 @@ func (ld Logs) LogRecordCount() int {
 	return logCount
 }
 
-// OtlpProtoSize returns the size in bytes of this Logs encoded as OTLP Collector
-// ExportLogsServiceRequest ProtoBuf bytes.
-func (ld Logs) OtlpProtoSize() int {
-	return ld.orig.Size()
-}
-
 // ResourceLogs returns the ResourceLogsSlice associated with this Logs.
 func (ld Logs) ResourceLogs() ResourceLogsSlice {
 	return newResourceLogsSlice(&ld.orig.ResourceLogs)

--- a/model/pdata/logs.go
+++ b/model/pdata/logs.go
@@ -24,7 +24,7 @@ import (
 type LogsMarshaler interface {
 	// MarshalLogs the given pdata.Logs into bytes.
 	// If the error is not nil, the returned bytes slice cannot be used.
-	MarshalLogs(td Logs) ([]byte, error)
+	MarshalLogs(ld Logs) ([]byte, error)
 }
 
 // LogsUnmarshaler unmarshalls bytes into pdata.Logs.
@@ -37,7 +37,7 @@ type LogsUnmarshaler interface {
 // LogsSizer returns the size of a Logs.
 type LogsSizer interface {
 	// LogsSize returns the size in bytes of a Logs.
-	LogsSize(td Logs) int
+	LogsSize(ld Logs) int
 }
 
 // Logs is the top-level struct that is propagated through the logs pipeline.

--- a/model/pdata/metrics.go
+++ b/model/pdata/metrics.go
@@ -24,7 +24,7 @@ import (
 type MetricsMarshaler interface {
 	// MarshalMetrics the given pdata.Metrics into bytes.
 	// If the error is not nil, the returned bytes slice cannot be used.
-	MarshalMetrics(td Metrics) ([]byte, error)
+	MarshalMetrics(md Metrics) ([]byte, error)
 }
 
 // MetricsUnmarshaler unmarshalls bytes into pdata.Metrics.
@@ -37,7 +37,7 @@ type MetricsUnmarshaler interface {
 // MetricsSizer returns the size of a Metrics.
 type MetricsSizer interface {
 	// LogsSize returns the size in bytes of a Metrics.
-	MetricsSize(td Metrics) int
+	MetricsSize(md Metrics) int
 }
 
 // Metrics is an opaque interface that allows transition to the new internal Metrics data, but also facilitates the

--- a/model/pdata/metrics.go
+++ b/model/pdata/metrics.go
@@ -34,6 +34,12 @@ type MetricsUnmarshaler interface {
 	UnmarshalMetrics(buf []byte) (Metrics, error)
 }
 
+// MetricsSizer returns the size of a Metrics.
+type MetricsSizer interface {
+	// LogsSize returns the size in bytes of a Metrics.
+	MetricsSize(td Metrics) int
+}
+
 // Metrics is an opaque interface that allows transition to the new internal Metrics data, but also facilitates the
 // transition to the new components, especially for traces.
 //

--- a/model/pdata/metrics.go
+++ b/model/pdata/metrics.go
@@ -87,12 +87,6 @@ func (md Metrics) MetricCount() int {
 	return metricCount
 }
 
-// OtlpProtoSize returns the size in bytes of this Metrics encoded as OTLP Collector
-// ExportMetricsServiceRequest ProtoBuf bytes.
-func (md Metrics) OtlpProtoSize() int {
-	return md.orig.Size()
-}
-
 // DataPointCount calculates the total number of data points.
 func (md Metrics) DataPointCount() (dataPointCount int) {
 	rms := md.ResourceMetrics()

--- a/model/pdata/metrics_test.go
+++ b/model/pdata/metrics_test.go
@@ -147,22 +147,6 @@ func TestMetricCount(t *testing.T) {
 	assert.EqualValues(t, 6, md.MetricCount())
 }
 
-// func TestMetricsSize(t *testing.T) {
-// 	assert.Equal(t, 0, NewMetrics().OtlpProtoSize())
-
-// 	md := generateMetricsEmptyDataPoints()
-// 	orig := md.orig
-// 	size := orig.Size()
-// 	bytes, err := orig.Marshal()
-// 	require.NoError(t, err)
-// 	assert.Equal(t, size, md.OtlpProtoSize())
-// 	assert.Equal(t, len(bytes), md.OtlpProtoSize())
-// }
-
-// func TestMetricsSizeWithNil(t *testing.T) {
-// 	assert.Equal(t, 0, NewMetrics().OtlpProtoSize())
-// }
-
 func TestMetricCountWithEmpty(t *testing.T) {
 	assert.EqualValues(t, 0, generateMetricsEmptyResource().MetricCount())
 	assert.EqualValues(t, 0, generateMetricsEmptyInstrumentation().MetricCount())

--- a/model/pdata/metrics_test.go
+++ b/model/pdata/metrics_test.go
@@ -19,7 +19,6 @@ import (
 
 	gogoproto "github.com/gogo/protobuf/proto"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	goproto "google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/emptypb"
 
@@ -148,21 +147,21 @@ func TestMetricCount(t *testing.T) {
 	assert.EqualValues(t, 6, md.MetricCount())
 }
 
-func TestMetricsSize(t *testing.T) {
-	assert.Equal(t, 0, NewMetrics().OtlpProtoSize())
+// func TestMetricsSize(t *testing.T) {
+// 	assert.Equal(t, 0, NewMetrics().OtlpProtoSize())
 
-	md := generateMetricsEmptyDataPoints()
-	orig := md.orig
-	size := orig.Size()
-	bytes, err := orig.Marshal()
-	require.NoError(t, err)
-	assert.Equal(t, size, md.OtlpProtoSize())
-	assert.Equal(t, len(bytes), md.OtlpProtoSize())
-}
+// 	md := generateMetricsEmptyDataPoints()
+// 	orig := md.orig
+// 	size := orig.Size()
+// 	bytes, err := orig.Marshal()
+// 	require.NoError(t, err)
+// 	assert.Equal(t, size, md.OtlpProtoSize())
+// 	assert.Equal(t, len(bytes), md.OtlpProtoSize())
+// }
 
-func TestMetricsSizeWithNil(t *testing.T) {
-	assert.Equal(t, 0, NewMetrics().OtlpProtoSize())
-}
+// func TestMetricsSizeWithNil(t *testing.T) {
+// 	assert.Equal(t, 0, NewMetrics().OtlpProtoSize())
+// }
 
 func TestMetricCountWithEmpty(t *testing.T) {
 	assert.EqualValues(t, 0, generateMetricsEmptyResource().MetricCount())

--- a/model/pdata/traces.go
+++ b/model/pdata/traces.go
@@ -34,6 +34,12 @@ type TracesUnmarshaler interface {
 	UnmarshalTraces(buf []byte) (Traces, error)
 }
 
+// TracesSizer returns the size of a Traces.
+type TracesSizer interface {
+	// TracesSize returns the size in bytes of a Traces.
+	TracesSize(td Traces) int
+}
+
 // Traces is the top-level struct that is propagated through the traces pipeline.
 type Traces struct {
 	orig *otlpcollectortrace.ExportTraceServiceRequest

--- a/model/pdata/traces.go
+++ b/model/pdata/traces.go
@@ -77,12 +77,6 @@ func (td Traces) SpanCount() int {
 	return spanCount
 }
 
-// OtlpProtoSize returns the size in bytes of this Traces encoded as OTLP Collector
-// ExportTraceServiceRequest ProtoBuf bytes.
-func (td Traces) OtlpProtoSize() int {
-	return td.orig.Size()
-}
-
 // ResourceSpans returns the ResourceSpansSlice associated with this Metrics.
 func (td Traces) ResourceSpans() ResourceSpansSlice {
 	return newResourceSpansSlice(&td.orig.ResourceSpans)

--- a/model/pdata/traces_test.go
+++ b/model/pdata/traces_test.go
@@ -51,23 +51,6 @@ func TestSpanCount(t *testing.T) {
 	assert.EqualValues(t, 6, md.SpanCount())
 }
 
-// func TestTracesSize(t *testing.T) {
-// 	assert.Equal(t, 0, NewTraces().OtlpProtoSize())
-// 	td := NewTraces()
-// 	rms := td.ResourceSpans()
-// 	rms.AppendEmpty().InstrumentationLibrarySpans().AppendEmpty().Spans().AppendEmpty().SetName("foo")
-// 	orig := td.orig
-// 	size := orig.Size()
-// 	bytes, err := orig.Marshal()
-// 	require.NoError(t, err)
-// 	assert.Equal(t, size, td.OtlpProtoSize())
-// 	assert.Equal(t, len(bytes), td.OtlpProtoSize())
-// }
-
-// func TestTracesSizeWithNil(t *testing.T) {
-// 	assert.Equal(t, 0, NewTraces().OtlpProtoSize())
-// }
-
 func TestSpanCountWithEmpty(t *testing.T) {
 	assert.EqualValues(t, 0, Traces{orig: &otlpcollectortrace.ExportTraceServiceRequest{
 		ResourceSpans: []*otlptrace.ResourceSpans{{}},

--- a/model/pdata/traces_test.go
+++ b/model/pdata/traces_test.go
@@ -19,7 +19,6 @@ import (
 
 	gogoproto "github.com/gogo/protobuf/proto"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	goproto "google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/emptypb"
 
@@ -28,46 +27,46 @@ import (
 	otlptrace "go.opentelemetry.io/collector/model/internal/data/protogen/trace/v1"
 )
 
-func TestSpanCount(t *testing.T) {
-	md := NewTraces()
-	assert.EqualValues(t, 0, md.SpanCount())
+// func TestSpanCount(t *testing.T) {
+// 	md := NewTraces()
+// 	assert.EqualValues(t, 0, md.SpanCount())
 
-	rs := md.ResourceSpans().AppendEmpty()
-	assert.EqualValues(t, 0, md.SpanCount())
+// 	rs := md.ResourceSpans().AppendEmpty()
+// 	assert.EqualValues(t, 0, md.SpanCount())
 
-	ils := rs.InstrumentationLibrarySpans().AppendEmpty()
-	assert.EqualValues(t, 0, md.SpanCount())
+// 	ils := rs.InstrumentationLibrarySpans().AppendEmpty()
+// 	assert.EqualValues(t, 0, md.SpanCount())
 
-	ils.Spans().AppendEmpty()
-	assert.EqualValues(t, 1, md.SpanCount())
+// 	ils.Spans().AppendEmpty()
+// 	assert.EqualValues(t, 1, md.SpanCount())
 
-	rms := md.ResourceSpans()
-	rms.EnsureCapacity(3)
-	rms.AppendEmpty().InstrumentationLibrarySpans().AppendEmpty()
-	ilss := rms.AppendEmpty().InstrumentationLibrarySpans().AppendEmpty().Spans()
-	for i := 0; i < 5; i++ {
-		ilss.AppendEmpty()
-	}
-	// 5 + 1 (from rms.At(0) initialized first)
-	assert.EqualValues(t, 6, md.SpanCount())
-}
+// 	rms := md.ResourceSpans()
+// 	rms.EnsureCapacity(3)
+// 	rms.AppendEmpty().InstrumentationLibrarySpans().AppendEmpty()
+// 	ilss := rms.AppendEmpty().InstrumentationLibrarySpans().AppendEmpty().Spans()
+// 	for i := 0; i < 5; i++ {
+// 		ilss.AppendEmpty()
+// 	}
+// 	// 5 + 1 (from rms.At(0) initialized first)
+// 	assert.EqualValues(t, 6, md.SpanCount())
+// }
 
-func TestTracesSize(t *testing.T) {
-	assert.Equal(t, 0, NewTraces().OtlpProtoSize())
-	td := NewTraces()
-	rms := td.ResourceSpans()
-	rms.AppendEmpty().InstrumentationLibrarySpans().AppendEmpty().Spans().AppendEmpty().SetName("foo")
-	orig := td.orig
-	size := orig.Size()
-	bytes, err := orig.Marshal()
-	require.NoError(t, err)
-	assert.Equal(t, size, td.OtlpProtoSize())
-	assert.Equal(t, len(bytes), td.OtlpProtoSize())
-}
+// func TestTracesSize(t *testing.T) {
+// 	assert.Equal(t, 0, NewTraces().OtlpProtoSize())
+// 	td := NewTraces()
+// 	rms := td.ResourceSpans()
+// 	rms.AppendEmpty().InstrumentationLibrarySpans().AppendEmpty().Spans().AppendEmpty().SetName("foo")
+// 	orig := td.orig
+// 	size := orig.Size()
+// 	bytes, err := orig.Marshal()
+// 	require.NoError(t, err)
+// 	assert.Equal(t, size, td.OtlpProtoSize())
+// 	assert.Equal(t, len(bytes), td.OtlpProtoSize())
+// }
 
-func TestTracesSizeWithNil(t *testing.T) {
-	assert.Equal(t, 0, NewTraces().OtlpProtoSize())
-}
+// func TestTracesSizeWithNil(t *testing.T) {
+// 	assert.Equal(t, 0, NewTraces().OtlpProtoSize())
+// }
 
 func TestSpanCountWithEmpty(t *testing.T) {
 	assert.EqualValues(t, 0, Traces{orig: &otlpcollectortrace.ExportTraceServiceRequest{

--- a/model/pdata/traces_test.go
+++ b/model/pdata/traces_test.go
@@ -27,29 +27,29 @@ import (
 	otlptrace "go.opentelemetry.io/collector/model/internal/data/protogen/trace/v1"
 )
 
-// func TestSpanCount(t *testing.T) {
-// 	md := NewTraces()
-// 	assert.EqualValues(t, 0, md.SpanCount())
+func TestSpanCount(t *testing.T) {
+	md := NewTraces()
+	assert.EqualValues(t, 0, md.SpanCount())
 
-// 	rs := md.ResourceSpans().AppendEmpty()
-// 	assert.EqualValues(t, 0, md.SpanCount())
+	rs := md.ResourceSpans().AppendEmpty()
+	assert.EqualValues(t, 0, md.SpanCount())
 
-// 	ils := rs.InstrumentationLibrarySpans().AppendEmpty()
-// 	assert.EqualValues(t, 0, md.SpanCount())
+	ils := rs.InstrumentationLibrarySpans().AppendEmpty()
+	assert.EqualValues(t, 0, md.SpanCount())
 
-// 	ils.Spans().AppendEmpty()
-// 	assert.EqualValues(t, 1, md.SpanCount())
+	ils.Spans().AppendEmpty()
+	assert.EqualValues(t, 1, md.SpanCount())
 
-// 	rms := md.ResourceSpans()
-// 	rms.EnsureCapacity(3)
-// 	rms.AppendEmpty().InstrumentationLibrarySpans().AppendEmpty()
-// 	ilss := rms.AppendEmpty().InstrumentationLibrarySpans().AppendEmpty().Spans()
-// 	for i := 0; i < 5; i++ {
-// 		ilss.AppendEmpty()
-// 	}
-// 	// 5 + 1 (from rms.At(0) initialized first)
-// 	assert.EqualValues(t, 6, md.SpanCount())
-// }
+	rms := md.ResourceSpans()
+	rms.EnsureCapacity(3)
+	rms.AppendEmpty().InstrumentationLibrarySpans().AppendEmpty()
+	ilss := rms.AppendEmpty().InstrumentationLibrarySpans().AppendEmpty().Spans()
+	for i := 0; i < 5; i++ {
+		ilss.AppendEmpty()
+	}
+	// 5 + 1 (from rms.At(0) initialized first)
+	assert.EqualValues(t, 6, md.SpanCount())
+}
 
 // func TestTracesSize(t *testing.T) {
 // 	assert.Equal(t, 0, NewTraces().OtlpProtoSize())

--- a/processor/batchprocessor/batch_processor.go
+++ b/processor/batchprocessor/batch_processor.go
@@ -228,7 +228,7 @@ type batchTraces struct {
 }
 
 func newBatchTraces(nextConsumer consumer.Traces) *batchTraces {
-	return &batchTraces{nextConsumer: nextConsumer, traceData: pdata.NewTraces(), sizer: otlp.NewProtobufTracesSizer()}
+	return &batchTraces{nextConsumer: nextConsumer, traceData: pdata.NewTraces(), sizer: otlp.NewProtobufTracesMarshaler().(pdata.TracesSizer)}
 }
 
 // add updates current batchTraces by adding new TraceData object
@@ -272,7 +272,7 @@ type batchMetrics struct {
 }
 
 func newBatchMetrics(nextConsumer consumer.Metrics) *batchMetrics {
-	return &batchMetrics{nextConsumer: nextConsumer, metricData: pdata.NewMetrics(), sizer: otlp.NewProtobufMetricsSizer()}
+	return &batchMetrics{nextConsumer: nextConsumer, metricData: pdata.NewMetrics(), sizer: otlp.NewProtobufMetricsMarshaler().(pdata.MetricsSizer)}
 }
 
 func (bm *batchMetrics) export(ctx context.Context, sendBatchMaxSize int) error {
@@ -315,7 +315,7 @@ type batchLogs struct {
 }
 
 func newBatchLogs(nextConsumer consumer.Logs) *batchLogs {
-	return &batchLogs{nextConsumer: nextConsumer, logData: pdata.NewLogs(), sizer: otlp.NewProtobufLogsSizer()}
+	return &batchLogs{nextConsumer: nextConsumer, logData: pdata.NewLogs(), sizer: otlp.NewProtobufLogsMarshaler().(pdata.LogsSizer)}
 }
 
 func (bl *batchLogs) export(ctx context.Context, sendBatchMaxSize int) error {

--- a/processor/batchprocessor/batch_processor_test.go
+++ b/processor/batchprocessor/batch_processor_test.go
@@ -510,12 +510,13 @@ func getTestMetricName(requestNum, index int) string {
 	return fmt.Sprintf("test-metric-int-%d-%d", requestNum, index)
 }
 
-// func BenchmarkTraceSizeBytes(b *testing.B) {
-// 	td := testdata.GenerateTracesManySpansSameResource(8192)
-// 	for n := 0; n < b.N; n++ {
-// 		fmt.Println(td.OtlpProtoSize())
-// 	}
-// }
+func BenchmarkTraceSizeBytes(b *testing.B) {
+	sizer := otlp.NewProtobufTracesSizer()
+	td := testdata.GenerateTracesManySpansSameResource(8192)
+	for n := 0; n < b.N; n++ {
+		fmt.Println(sizer.TracesSize(td))
+	}
+}
 
 func BenchmarkTraceSizeSpanCount(b *testing.B) {
 	td := testdata.GenerateTracesManySpansSameResource(8192)

--- a/processor/batchprocessor/batch_processor_test.go
+++ b/processor/batchprocessor/batch_processor_test.go
@@ -120,7 +120,7 @@ func TestBatchProcessorSpansDeliveredEnforceBatchSize(t *testing.T) {
 }
 
 func TestBatchProcessorSentBySize(t *testing.T) {
-	sizer := otlp.NewProtobufTracesSizer()
+	sizer := otlp.NewProtobufTracesMarshaler().(pdata.TracesSizer)
 	views := MetricViews()
 	require.NoError(t, view.Register(views...))
 	defer view.Unregister(views...)
@@ -308,7 +308,7 @@ func TestBatchMetricProcessor_ReceivingData(t *testing.T) {
 }
 
 func TestBatchMetricProcessor_BatchSize(t *testing.T) {
-	sizer := otlp.NewProtobufMetricsSizer()
+	sizer := otlp.NewProtobufMetricsMarshaler().(pdata.MetricsSizer)
 	views := MetricViews()
 	require.NoError(t, view.Register(views...))
 	defer view.Unregister(views...)
@@ -511,7 +511,7 @@ func getTestMetricName(requestNum, index int) string {
 }
 
 func BenchmarkTraceSizeBytes(b *testing.B) {
-	sizer := otlp.NewProtobufTracesSizer()
+	sizer := otlp.NewProtobufTracesMarshaler().(pdata.TracesSizer)
 	td := testdata.GenerateTracesManySpansSameResource(8192)
 	for n := 0; n < b.N; n++ {
 		fmt.Println(sizer.TracesSize(td))
@@ -624,7 +624,7 @@ func TestBatchLogProcessor_ReceivingData(t *testing.T) {
 }
 
 func TestBatchLogProcessor_BatchSize(t *testing.T) {
-	sizer := otlp.NewProtobufLogsSizer()
+	sizer := otlp.NewProtobufLogsMarshaler().(pdata.LogsSizer)
 	views := MetricViews()
 	require.NoError(t, view.Register(views...))
 	defer view.Unregister(views...)

--- a/processor/batchprocessor/batch_processor_test.go
+++ b/processor/batchprocessor/batch_processor_test.go
@@ -118,67 +118,67 @@ func TestBatchProcessorSpansDeliveredEnforceBatchSize(t *testing.T) {
 	assert.Equal(t, (requestCount*spansPerRequest)%int(cfg.SendBatchMaxSize), sink.AllTraces()[len(sink.AllTraces())-1].SpanCount())
 }
 
-func TestBatchProcessorSentBySize(t *testing.T) {
-	views := MetricViews()
-	require.NoError(t, view.Register(views...))
-	defer view.Unregister(views...)
+// func TestBatchProcessorSentBySize(t *testing.T) {
+// 	views := MetricViews()
+// 	require.NoError(t, view.Register(views...))
+// 	defer view.Unregister(views...)
 
-	sink := new(consumertest.TracesSink)
-	cfg := createDefaultConfig().(*Config)
-	sendBatchSize := 20
-	cfg.SendBatchSize = uint32(sendBatchSize)
-	cfg.Timeout = 500 * time.Millisecond
-	creationSet := componenttest.NewNopProcessorCreateSettings()
-	batcher, err := newBatchTracesProcessor(creationSet, sink, cfg, configtelemetry.LevelDetailed)
-	require.NoError(t, err)
-	require.NoError(t, batcher.Start(context.Background(), componenttest.NewNopHost()))
+// 	sink := new(consumertest.TracesSink)
+// 	cfg := createDefaultConfig().(*Config)
+// 	sendBatchSize := 20
+// 	cfg.SendBatchSize = uint32(sendBatchSize)
+// 	cfg.Timeout = 500 * time.Millisecond
+// 	creationSet := componenttest.NewNopProcessorCreateSettings()
+// 	batcher, err := newBatchTracesProcessor(creationSet, sink, cfg, configtelemetry.LevelDetailed)
+// 	require.NoError(t, err)
+// 	require.NoError(t, batcher.Start(context.Background(), componenttest.NewNopHost()))
 
-	requestCount := 100
-	spansPerRequest := 5
+// 	requestCount := 100
+// 	spansPerRequest := 5
 
-	start := time.Now()
-	sizeSum := 0
-	for requestNum := 0; requestNum < requestCount; requestNum++ {
-		td := testdata.GenerateTracesManySpansSameResource(spansPerRequest)
-		sizeSum += td.OtlpProtoSize()
-		assert.NoError(t, batcher.ConsumeTraces(context.Background(), td))
-	}
+// 	start := time.Now()
+// 	sizeSum := 0
+// 	for requestNum := 0; requestNum < requestCount; requestNum++ {
+// 		td := testdata.GenerateTracesManySpansSameResource(spansPerRequest)
+// 		sizeSum += td.OtlpProtoSize()
+// 		assert.NoError(t, batcher.ConsumeTraces(context.Background(), td))
+// 	}
 
-	require.NoError(t, batcher.Shutdown(context.Background()))
+// 	require.NoError(t, batcher.Shutdown(context.Background()))
 
-	elapsed := time.Since(start)
-	require.LessOrEqual(t, elapsed.Nanoseconds(), cfg.Timeout.Nanoseconds())
+// 	elapsed := time.Since(start)
+// 	require.LessOrEqual(t, elapsed.Nanoseconds(), cfg.Timeout.Nanoseconds())
 
-	expectedBatchesNum := requestCount * spansPerRequest / sendBatchSize
-	expectedBatchingFactor := sendBatchSize / spansPerRequest
+// 	expectedBatchesNum := requestCount * spansPerRequest / sendBatchSize
+// 	expectedBatchingFactor := sendBatchSize / spansPerRequest
 
-	require.Equal(t, requestCount*spansPerRequest, sink.SpanCount())
-	receivedTraces := sink.AllTraces()
-	require.EqualValues(t, expectedBatchesNum, len(receivedTraces))
-	for _, td := range receivedTraces {
-		rss := td.ResourceSpans()
-		require.Equal(t, expectedBatchingFactor, rss.Len())
-		for i := 0; i < expectedBatchingFactor; i++ {
-			require.Equal(t, spansPerRequest, rss.At(i).InstrumentationLibrarySpans().At(0).Spans().Len())
-		}
-	}
+// 	require.Equal(t, requestCount*spansPerRequest, sink.SpanCount())
+// 	receivedTraces := sink.AllTraces()
+// 	require.EqualValues(t, expectedBatchesNum, len(receivedTraces))
+// 	for _, td := range receivedTraces {
+// 		rss := td.ResourceSpans()
+// 		require.Equal(t, expectedBatchingFactor, rss.Len())
+// 		for i := 0; i < expectedBatchingFactor; i++ {
+// 			require.Equal(t, spansPerRequest, rss.At(i).InstrumentationLibrarySpans().At(0).Spans().Len())
+// 		}
+// 	}
 
-	viewData, err := view.RetrieveData("processor/batch/" + statBatchSendSize.Name())
-	require.NoError(t, err)
-	assert.Equal(t, 1, len(viewData))
-	distData := viewData[0].Data.(*view.DistributionData)
-	assert.Equal(t, int64(expectedBatchesNum), distData.Count)
-	assert.Equal(t, sink.SpanCount(), int(distData.Sum()))
-	assert.Equal(t, sendBatchSize, int(distData.Min))
-	assert.Equal(t, sendBatchSize, int(distData.Max))
+// 	viewData, err := view.RetrieveData("processor/batch/" + statBatchSendSize.Name())
+// 	require.NoError(t, err)
+// 	assert.Equal(t, 1, len(viewData))
+// 	distData := viewData[0].Data.(*view.DistributionData)
+// 	assert.Equal(t, int64(expectedBatchesNum), distData.Count)
+// 	assert.Equal(t, sink.SpanCount(), int(distData.Sum()))
+// 	assert.Equal(t, sendBatchSize, int(distData.Min))
+// 	assert.Equal(t, sendBatchSize, int(distData.Max))
 
-	viewData, err = view.RetrieveData("processor/batch/" + statBatchSendSizeBytes.Name())
-	require.NoError(t, err)
-	assert.Equal(t, 1, len(viewData))
-	distData = viewData[0].Data.(*view.DistributionData)
-	assert.Equal(t, int64(expectedBatchesNum), distData.Count)
-	assert.Equal(t, sizeSum, int(distData.Sum()))
-}
+// 	viewData, err = view.RetrieveData("processor/batch/" + statBatchSendSizeBytes.Name())
+// 	require.NoError(t, err)
+// 	assert.Equal(t, 1, len(viewData))
+// 	distData = viewData[0].Data.(*view.DistributionData)
+// 	assert.Equal(t, int64(expectedBatchesNum), distData.Count)
+// 	assert.Equal(t, sizeSum, int(distData.Sum()))
+// }
 
 func TestBatchProcessorSentByTimeout(t *testing.T) {
 	sink := new(consumertest.TracesSink)
@@ -333,7 +333,7 @@ func TestBatchMetricProcessor_BatchSize(t *testing.T) {
 	size := 0
 	for requestNum := 0; requestNum < requestCount; requestNum++ {
 		md := testdata.GenerateMetricsManyMetricsSameResource(metricsPerRequest)
-		size += md.OtlpProtoSize()
+		// size += md.OtlpProtoSize()
 		assert.NoError(t, batcher.ConsumeMetrics(context.Background(), md))
 	}
 	require.NoError(t, batcher.Shutdown(context.Background()))
@@ -507,12 +507,12 @@ func getTestMetricName(requestNum, index int) string {
 	return fmt.Sprintf("test-metric-int-%d-%d", requestNum, index)
 }
 
-func BenchmarkTraceSizeBytes(b *testing.B) {
-	td := testdata.GenerateTracesManySpansSameResource(8192)
-	for n := 0; n < b.N; n++ {
-		fmt.Println(td.OtlpProtoSize())
-	}
-}
+// func BenchmarkTraceSizeBytes(b *testing.B) {
+// 	td := testdata.GenerateTracesManySpansSameResource(8192)
+// 	for n := 0; n < b.N; n++ {
+// 		fmt.Println(td.OtlpProtoSize())
+// 	}
+// }
 
 func BenchmarkTraceSizeSpanCount(b *testing.B) {
 	td := testdata.GenerateTracesManySpansSameResource(8192)
@@ -619,69 +619,69 @@ func TestBatchLogProcessor_ReceivingData(t *testing.T) {
 	}
 }
 
-func TestBatchLogProcessor_BatchSize(t *testing.T) {
-	views := MetricViews()
-	require.NoError(t, view.Register(views...))
-	defer view.Unregister(views...)
+// func TestBatchLogProcessor_BatchSize(t *testing.T) {
+// 	views := MetricViews()
+// 	require.NoError(t, view.Register(views...))
+// 	defer view.Unregister(views...)
 
-	// Instantiate the batch processor with low config values to test data
-	// gets sent through the processor.
-	cfg := Config{
-		ProcessorSettings: config.NewProcessorSettings(config.NewID(typeStr)),
-		Timeout:           100 * time.Millisecond,
-		SendBatchSize:     50,
-	}
+// 	// Instantiate the batch processor with low config values to test data
+// 	// gets sent through the processor.
+// 	cfg := Config{
+// 		ProcessorSettings: config.NewProcessorSettings(config.NewID(typeStr)),
+// 		Timeout:           100 * time.Millisecond,
+// 		SendBatchSize:     50,
+// 	}
 
-	requestCount := 100
-	logsPerRequest := 5
-	sink := new(consumertest.LogsSink)
+// 	requestCount := 100
+// 	logsPerRequest := 5
+// 	sink := new(consumertest.LogsSink)
 
-	creationSet := componenttest.NewNopProcessorCreateSettings()
-	batcher, err := newBatchLogsProcessor(creationSet, sink, &cfg, configtelemetry.LevelDetailed)
-	require.NoError(t, err)
-	require.NoError(t, batcher.Start(context.Background(), componenttest.NewNopHost()))
+// 	creationSet := componenttest.NewNopProcessorCreateSettings()
+// 	batcher, err := newBatchLogsProcessor(creationSet, sink, &cfg, configtelemetry.LevelDetailed)
+// 	require.NoError(t, err)
+// 	require.NoError(t, batcher.Start(context.Background(), componenttest.NewNopHost()))
 
-	start := time.Now()
-	size := 0
-	for requestNum := 0; requestNum < requestCount; requestNum++ {
-		ld := testdata.GenerateLogsManyLogRecordsSameResource(logsPerRequest)
-		size += ld.OtlpProtoSize()
-		assert.NoError(t, batcher.ConsumeLogs(context.Background(), ld))
-	}
-	require.NoError(t, batcher.Shutdown(context.Background()))
+// 	start := time.Now()
+// 	size := 0
+// 	for requestNum := 0; requestNum < requestCount; requestNum++ {
+// 		ld := testdata.GenerateLogsManyLogRecordsSameResource(logsPerRequest)
+// 		size += ld.OtlpProtoSize()
+// 		assert.NoError(t, batcher.ConsumeLogs(context.Background(), ld))
+// 	}
+// 	require.NoError(t, batcher.Shutdown(context.Background()))
 
-	elapsed := time.Since(start)
-	require.LessOrEqual(t, elapsed.Nanoseconds(), cfg.Timeout.Nanoseconds())
+// 	elapsed := time.Since(start)
+// 	require.LessOrEqual(t, elapsed.Nanoseconds(), cfg.Timeout.Nanoseconds())
 
-	expectedBatchesNum := requestCount * logsPerRequest / int(cfg.SendBatchSize)
-	expectedBatchingFactor := int(cfg.SendBatchSize) / logsPerRequest
+// 	expectedBatchesNum := requestCount * logsPerRequest / int(cfg.SendBatchSize)
+// 	expectedBatchingFactor := int(cfg.SendBatchSize) / logsPerRequest
 
-	require.Equal(t, requestCount*logsPerRequest, sink.LogRecordCount())
-	receivedMds := sink.AllLogs()
-	require.Equal(t, expectedBatchesNum, len(receivedMds))
-	for _, ld := range receivedMds {
-		require.Equal(t, expectedBatchingFactor, ld.ResourceLogs().Len())
-		for i := 0; i < expectedBatchingFactor; i++ {
-			require.Equal(t, logsPerRequest, ld.ResourceLogs().At(i).InstrumentationLibraryLogs().At(0).Logs().Len())
-		}
-	}
+// 	require.Equal(t, requestCount*logsPerRequest, sink.LogRecordCount())
+// 	receivedMds := sink.AllLogs()
+// 	require.Equal(t, expectedBatchesNum, len(receivedMds))
+// 	for _, ld := range receivedMds {
+// 		require.Equal(t, expectedBatchingFactor, ld.ResourceLogs().Len())
+// 		for i := 0; i < expectedBatchingFactor; i++ {
+// 			require.Equal(t, logsPerRequest, ld.ResourceLogs().At(i).InstrumentationLibraryLogs().At(0).Logs().Len())
+// 		}
+// 	}
 
-	viewData, err := view.RetrieveData("processor/batch/" + statBatchSendSize.Name())
-	require.NoError(t, err)
-	assert.Equal(t, 1, len(viewData))
-	distData := viewData[0].Data.(*view.DistributionData)
-	assert.Equal(t, int64(expectedBatchesNum), distData.Count)
-	assert.Equal(t, sink.LogRecordCount(), int(distData.Sum()))
-	assert.Equal(t, cfg.SendBatchSize, uint32(distData.Min))
-	assert.Equal(t, cfg.SendBatchSize, uint32(distData.Max))
+// 	viewData, err := view.RetrieveData("processor/batch/" + statBatchSendSize.Name())
+// 	require.NoError(t, err)
+// 	assert.Equal(t, 1, len(viewData))
+// 	distData := viewData[0].Data.(*view.DistributionData)
+// 	assert.Equal(t, int64(expectedBatchesNum), distData.Count)
+// 	assert.Equal(t, sink.LogRecordCount(), int(distData.Sum()))
+// 	assert.Equal(t, cfg.SendBatchSize, uint32(distData.Min))
+// 	assert.Equal(t, cfg.SendBatchSize, uint32(distData.Max))
 
-	viewData, err = view.RetrieveData("processor/batch/" + statBatchSendSizeBytes.Name())
-	require.NoError(t, err)
-	assert.Equal(t, 1, len(viewData))
-	distData = viewData[0].Data.(*view.DistributionData)
-	assert.Equal(t, int64(expectedBatchesNum), distData.Count)
-	assert.Equal(t, size, int(distData.Sum()))
-}
+// 	viewData, err = view.RetrieveData("processor/batch/" + statBatchSendSizeBytes.Name())
+// 	require.NoError(t, err)
+// 	assert.Equal(t, 1, len(viewData))
+// 	distData = viewData[0].Data.(*view.DistributionData)
+// 	assert.Equal(t, int64(expectedBatchesNum), distData.Count)
+// 	assert.Equal(t, size, int(distData.Sum()))
+// }
 
 func TestBatchLogsProcessor_Timeout(t *testing.T) {
 	cfg := Config{

--- a/processor/batchprocessor/batch_processor_test.go
+++ b/processor/batchprocessor/batch_processor_test.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.opencensus.io/stats/view"
 
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config"
@@ -305,71 +304,71 @@ func TestBatchMetricProcessor_ReceivingData(t *testing.T) {
 	}
 }
 
-func TestBatchMetricProcessor_BatchSize(t *testing.T) {
-	views := MetricViews()
-	require.NoError(t, view.Register(views...))
-	defer view.Unregister(views...)
+// func TestBatchMetricProcessor_BatchSize(t *testing.T) {
+// 	views := MetricViews()
+// 	require.NoError(t, view.Register(views...))
+// 	defer view.Unregister(views...)
 
-	// Instantiate the batch processor with low config values to test data
-	// gets sent through the processor.
-	cfg := Config{
-		ProcessorSettings: config.NewProcessorSettings(config.NewID(typeStr)),
-		Timeout:           100 * time.Millisecond,
-		SendBatchSize:     50,
-	}
+// 	// Instantiate the batch processor with low config values to test data
+// 	// gets sent through the processor.
+// 	cfg := Config{
+// 		ProcessorSettings: config.NewProcessorSettings(config.NewID(typeStr)),
+// 		Timeout:           100 * time.Millisecond,
+// 		SendBatchSize:     50,
+// 	}
 
-	requestCount := 100
-	metricsPerRequest := 5
-	dataPointsPerMetric := 2 // Since the int counter uses two datapoints.
-	dataPointsPerRequest := metricsPerRequest * dataPointsPerMetric
-	sink := new(consumertest.MetricsSink)
+// 	requestCount := 100
+// 	metricsPerRequest := 5
+// 	dataPointsPerMetric := 2 // Since the int counter uses two datapoints.
+// 	dataPointsPerRequest := metricsPerRequest * dataPointsPerMetric
+// 	sink := new(consumertest.MetricsSink)
 
-	creationSet := componenttest.NewNopProcessorCreateSettings()
-	batcher, err := newBatchMetricsProcessor(creationSet, sink, &cfg, configtelemetry.LevelDetailed)
-	require.NoError(t, err)
-	require.NoError(t, batcher.Start(context.Background(), componenttest.NewNopHost()))
+// 	creationSet := componenttest.NewNopProcessorCreateSettings()
+// 	batcher, err := newBatchMetricsProcessor(creationSet, sink, &cfg, configtelemetry.LevelDetailed)
+// 	require.NoError(t, err)
+// 	require.NoError(t, batcher.Start(context.Background(), componenttest.NewNopHost()))
 
-	start := time.Now()
-	size := 0
-	for requestNum := 0; requestNum < requestCount; requestNum++ {
-		md := testdata.GenerateMetricsManyMetricsSameResource(metricsPerRequest)
-		// size += md.OtlpProtoSize()
-		assert.NoError(t, batcher.ConsumeMetrics(context.Background(), md))
-	}
-	require.NoError(t, batcher.Shutdown(context.Background()))
+// 	start := time.Now()
+// 	size := 0
+// 	for requestNum := 0; requestNum < requestCount; requestNum++ {
+// 		md := testdata.GenerateMetricsManyMetricsSameResource(metricsPerRequest)
+// 		size += md.OtlpProtoSize()
+// 		assert.NoError(t, batcher.ConsumeMetrics(context.Background(), md))
+// 	}
+// 	require.NoError(t, batcher.Shutdown(context.Background()))
 
-	elapsed := time.Since(start)
-	require.LessOrEqual(t, elapsed.Nanoseconds(), cfg.Timeout.Nanoseconds())
+// 	elapsed := time.Since(start)
+// 	require.LessOrEqual(t, elapsed.Nanoseconds(), cfg.Timeout.Nanoseconds())
 
-	expectedBatchesNum := requestCount * dataPointsPerRequest / int(cfg.SendBatchSize)
-	expectedBatchingFactor := int(cfg.SendBatchSize) / dataPointsPerRequest
+// 	expectedBatchesNum := requestCount * dataPointsPerRequest / int(cfg.SendBatchSize)
+// 	expectedBatchingFactor := int(cfg.SendBatchSize) / dataPointsPerRequest
 
-	require.Equal(t, requestCount*2*metricsPerRequest, sink.DataPointCount())
-	receivedMds := sink.AllMetrics()
-	require.Equal(t, expectedBatchesNum, len(receivedMds))
-	for _, md := range receivedMds {
-		require.Equal(t, expectedBatchingFactor, md.ResourceMetrics().Len())
-		for i := 0; i < expectedBatchingFactor; i++ {
-			require.Equal(t, metricsPerRequest, md.ResourceMetrics().At(i).InstrumentationLibraryMetrics().At(0).Metrics().Len())
-		}
-	}
+// 	require.Equal(t, requestCount*2*metricsPerRequest, sink.DataPointCount())
+// 	receivedMds := sink.AllMetrics()
+// 	require.Equal(t, expectedBatchesNum, len(receivedMds))
+// 	for _, md := range receivedMds {
+// 		require.Equal(t, expectedBatchingFactor, md.ResourceMetrics().Len())
+// 		for i := 0; i < expectedBatchingFactor; i++ {
+// 			require.Equal(t, metricsPerRequest, md.ResourceMetrics().At(i).InstrumentationLibraryMetrics().At(0).Metrics().Len())
+// 		}
+// 	}
 
-	viewData, err := view.RetrieveData("processor/batch/" + statBatchSendSize.Name())
-	require.NoError(t, err)
-	assert.Equal(t, 1, len(viewData))
-	distData := viewData[0].Data.(*view.DistributionData)
-	assert.Equal(t, int64(expectedBatchesNum), distData.Count)
-	assert.Equal(t, sink.DataPointCount(), int(distData.Sum()))
-	assert.Equal(t, cfg.SendBatchSize, uint32(distData.Min))
-	assert.Equal(t, cfg.SendBatchSize, uint32(distData.Max))
+// 	viewData, err := view.RetrieveData("processor/batch/" + statBatchSendSize.Name())
+// 	require.NoError(t, err)
+// 	assert.Equal(t, 1, len(viewData))
+// 	distData := viewData[0].Data.(*view.DistributionData)
+// 	assert.Equal(t, int64(expectedBatchesNum), distData.Count)
+// 	assert.Equal(t, sink.DataPointCount(), int(distData.Sum()))
+// 	assert.Equal(t, cfg.SendBatchSize, uint32(distData.Min))
+// 	assert.Equal(t, cfg.SendBatchSize, uint32(distData.Max))
 
-	viewData, err = view.RetrieveData("processor/batch/" + statBatchSendSizeBytes.Name())
-	require.NoError(t, err)
-	assert.Equal(t, 1, len(viewData))
-	distData = viewData[0].Data.(*view.DistributionData)
-	assert.Equal(t, int64(expectedBatchesNum), distData.Count)
-	assert.Equal(t, size, int(distData.Sum()))
-}
+// 	viewData, err = view.RetrieveData("processor/batch/" + statBatchSendSizeBytes.Name())
+// 	require.NoError(t, err)
+// 	assert.Equal(t, 1, len(viewData))
+// 	distData = viewData[0].Data.(*view.DistributionData)
+// 	assert.Equal(t, int64(expectedBatchesNum), distData.Count)
+// 	assert.Equal(t, size, int(distData.Sum()))
+// }
 
 func TestBatchMetrics_UnevenBatchMaxSize(t *testing.T) {
 	ctx := context.Background()


### PR DESCRIPTION
**Description:** remove OtlpProtoSize in favor of Sizer interface.

This change adds a `Sizer` interface + an implementation for `pb_marshaler` as per the discussion in #3531. This allows us to remove `OtlpProtoSize()` from traces/metrics/logs and will allow different marshalers to implement `Size()` themselves.

**Link to tracking Issue:** Fixes #3531

**Testing:** Moved size tests for traces/metrics/logs to `pb_marshaler` and converted `batch_processor_test` to use the *Sizers from `pb_marshaler`
