### PR TITLE
Ensure hostmetricsreceiver sets SchemaURL

### DIFF
--- a/receiver/hostmetricsreceiver/hostmetrics_receiver_test.go
+++ b/receiver/hostmetricsreceiver/hostmetrics_receiver_test.go
@@ -43,6 +43,7 @@ import (
 	"go.opentelemetry.io/collector/receiver/hostmetricsreceiver/internal/scraper/processesscraper"
 	"go.opentelemetry.io/collector/receiver/hostmetricsreceiver/internal/scraper/processscraper"
 	"go.opentelemetry.io/collector/receiver/scraperhelper"
+	conventions "go.opentelemetry.io/collector/translator/conventions/v1.5.0"
 )
 
 var standardMetrics = []string{
@@ -157,6 +158,8 @@ func assertIncludesExpectedMetrics(t *testing.T, got pdata.Metrics) {
 		rm := rms.At(i)
 		metrics := getMetricSlice(t, rm)
 		returnedMetricNames := getReturnedMetricNames(metrics)
+		assert.EqualValues(t, conventions.SchemaURL, rm.SchemaUrl(),
+			"SchemaURL is incorrect for metrics: %v", returnedMetricNames)
 		if rm.Resource().Attributes().Len() == 0 {
 			appendMapInto(returnedMetrics, returnedMetricNames)
 		} else {

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper.go
@@ -28,6 +28,7 @@ import (
 	"go.opentelemetry.io/collector/model/pdata"
 	"go.opentelemetry.io/collector/receiver/hostmetricsreceiver/internal/metadata"
 	"go.opentelemetry.io/collector/receiver/scrapererror"
+	conventions "go.opentelemetry.io/collector/translator/conventions/v1.5.0"
 )
 
 const (
@@ -101,6 +102,7 @@ func (s *scraper) scrape(_ context.Context) (pdata.ResourceMetricsSlice, error) 
 	rms.EnsureCapacity(len(metadata))
 	for _, md := range metadata {
 		rm := rms.AppendEmpty()
+		rm.SetSchemaUrl(conventions.SchemaURL)
 		md.initializeResource(rm.Resource())
 		metrics := rm.InstrumentationLibraryMetrics().AppendEmpty().Metrics()
 

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_test.go
@@ -70,12 +70,20 @@ func TestScrape(t *testing.T) {
 	}
 
 	require.Greater(t, resourceMetrics.Len(), 1)
+	assertSchemaIsSet(t, resourceMetrics)
 	assertProcessResourceAttributesExist(t, resourceMetrics)
 	assertCPUTimeMetricValid(t, resourceMetrics, expectedStartTime)
 	assertMemoryUsageMetricValid(t, metadata.Metrics.ProcessMemoryPhysicalUsage.New(), resourceMetrics)
 	assertMemoryUsageMetricValid(t, metadata.Metrics.ProcessMemoryVirtualUsage.New(), resourceMetrics)
 	assertDiskIOMetricValid(t, resourceMetrics, expectedStartTime)
 	assertSameTimeStampForAllMetricsWithinResource(t, resourceMetrics)
+}
+
+func assertSchemaIsSet(t *testing.T, resourceMetrics pdata.ResourceMetricsSlice) {
+	for i := 0; i < resourceMetrics.Len(); i++ {
+		rm := resourceMetrics.At(0)
+		assert.EqualValues(t, conventions.SchemaURL, rm.SchemaUrl())
+	}
 }
 
 func assertProcessResourceAttributesExist(t *testing.T, resourceMetrics pdata.ResourceMetricsSlice) {


### PR DESCRIPTION
This changes ensures that all metrics produced by hostmetricsreceiver
set the SchemaURL.

If no specific SchemaURL is set we assume all collected host metrics
confirm to our default SchemaURL. The assumption is that the code that
produces these metrics uses semantic conventions defined in
package "conventions".
