### PR TITLE
translate FilteredLabels to FilteredAttributes

### DIFF
--- a/cmd/pdatagen/internal/metrics_structs.go
+++ b/cmd/pdatagen/internal/metrics_structs.go
@@ -319,6 +319,11 @@ var exemplar = &messageValueStruct{
 			originFieldName: "FilteredLabels",
 			returnSlice:     stringMap,
 		},
+		&sliceField{
+			fieldName:       "FilteredAttributes",
+			originFieldName: "FilteredAttributes",
+			returnSlice:     attributeMap,
+		},
 	},
 }
 

--- a/internal/testdata/common.go
+++ b/internal/testdata/common.go
@@ -57,8 +57,8 @@ func initSpanLinkAttributes(dest pdata.AttributeMap) {
 	dest.InitFromMap(spanLinkAttributes)
 }
 
-func initMetricAttachment(dest pdata.StringMap) {
-	dest.InitFromMap(map[string]string{TestAttachmentKey: TestAttachmentValue})
+func initMetricAttachment(dest pdata.AttributeMap) {
+	dest.InitFromMap(map[string]pdata.AttributeValue{TestAttachmentKey: pdata.NewAttributeValueString(TestAttachmentValue)})
 }
 
 func initMetricAttributes1(dest pdata.AttributeMap) {

--- a/internal/testdata/metric.go
+++ b/internal/testdata/metric.go
@@ -244,7 +244,7 @@ func initDoubleHistogramMetric(hm pdata.Metric) {
 	exemplar := hdp1.Exemplars().AppendEmpty()
 	exemplar.SetTimestamp(TestMetricExemplarTimestamp)
 	exemplar.SetDoubleVal(15)
-	initMetricAttachment(exemplar.FilteredLabels())
+	initMetricAttachment(exemplar.FilteredAttributes())
 	hdp1.SetExplicitBounds([]float64{1})
 }
 

--- a/model/internal/otlp_wrapper.go
+++ b/model/internal/otlp_wrapper.go
@@ -146,6 +146,17 @@ func labelsToAttributes(labels []otlpcommon.StringKeyValue) []otlpcommon.KeyValu
 	return attrs
 }
 
+func addFilteredAttributesToExemplars(exemplars []otlpmetrics.Exemplar) {
+	for i := range exemplars {
+		if exemplars[i].FilteredLabels != nil && exemplars[i].FilteredAttributes != nil {
+			continue
+		}
+		if exemplars[i].FilteredLabels != nil {
+			exemplars[i].FilteredAttributes = labelsToAttributes(exemplars[i].FilteredLabels)
+		}
+	}
+}
+
 func intHistogramToHistogram(src *otlpmetrics.Metric_IntHistogram) *otlpmetrics.Metric_Histogram {
 	datapoints := []*otlpmetrics.HistogramDataPoint{}
 	for _, datapoint := range src.IntHistogram.DataPoints {
@@ -228,6 +239,7 @@ func intExemplarToExemplar(src []otlpmetrics.IntExemplar) []otlpmetrics.Exemplar
 
 func numberDataPointsLabelsToAttributes(dps []*otlpmetrics.NumberDataPoint) {
 	for i := range dps {
+		addFilteredAttributesToExemplars(dps[i].Exemplars)
 		if dps[i].Labels != nil && dps[i].Attributes != nil {
 			continue
 		}
@@ -250,6 +262,7 @@ func summaryDataPointsLabelsToAttributes(dps []*otlpmetrics.SummaryDataPoint) {
 
 func histogramDataPointsLabelsToAttributes(dps []*otlpmetrics.HistogramDataPoint) {
 	for i := range dps {
+		addFilteredAttributesToExemplars(dps[i].Exemplars)
 		if dps[i].Labels != nil && dps[i].Attributes != nil {
 			continue
 		}

--- a/model/internal/otlp_wrappers_test.go
+++ b/model/internal/otlp_wrappers_test.go
@@ -407,7 +407,13 @@ func TestDeprecatedIntSum(t *testing.T) {
 								StartTimeUnixNano: 20,
 								TimeUnixNano:      21,
 								Value:             &otlpmetrics.NumberDataPoint_AsInt{AsInt: 200},
-								Exemplars:         []otlpmetrics.Exemplar{},
+								Exemplars: []otlpmetrics.Exemplar{
+									{
+										FilteredLabels: []otlpcommon.StringKeyValue{ //nolint:staticcheck // SA1019 ignore this!
+											{Key: "FilteredLabelKey", Value: "FilteredLabelValue"},
+										},
+									},
+								},
 							},
 						},
 					},
@@ -426,7 +432,16 @@ func TestDeprecatedIntSum(t *testing.T) {
 								StartTimeUnixNano: 20,
 								TimeUnixNano:      21,
 								Value:             &otlpmetrics.NumberDataPoint_AsInt{AsInt: 200},
-								Exemplars:         []otlpmetrics.Exemplar{},
+								Exemplars: []otlpmetrics.Exemplar{
+									{
+										FilteredLabels: []otlpcommon.StringKeyValue{ //nolint:staticcheck // SA1019 ignore this!
+											{Key: "FilteredLabelKey", Value: "FilteredLabelValue"},
+										},
+										FilteredAttributes: []otlpcommon.KeyValue{ //nolint:staticcheck // SA1019 ignore this!
+											{Key: "FilteredLabelKey", Value: otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_StringValue{StringValue: "FilteredLabelValue"}}},
+										},
+									},
+								},
 								Attributes: []otlpcommon.KeyValue{
 									{Key: "SumKey", Value: otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_StringValue{StringValue: "SumValue"}}},
 								},
@@ -534,7 +549,13 @@ func TestDeprecatedIntSum(t *testing.T) {
 								StartTimeUnixNano: 22,
 								TimeUnixNano:      23,
 								Value:             201,
-								Exemplars:         []otlpmetrics.IntExemplar{}, //nolint:staticcheck // SA1019 ignore this!
+								Exemplars: []otlpmetrics.IntExemplar{ //nolint:staticcheck // SA1019 ignore this!
+									{
+										FilteredLabels: []otlpcommon.StringKeyValue{ //nolint:staticcheck // SA1019 ignore this!
+											{Key: "FilteredLabelKey", Value: "FilteredLabelValue"},
+										},
+									},
+								},
 							},
 						},
 					},
@@ -551,7 +572,19 @@ func TestDeprecatedIntSum(t *testing.T) {
 								StartTimeUnixNano: 22,
 								TimeUnixNano:      23,
 								Value:             &otlpmetrics.NumberDataPoint_AsInt{AsInt: 201},
-								Exemplars:         []otlpmetrics.Exemplar{},
+								Exemplars: []otlpmetrics.Exemplar{
+									{
+										Value: &otlpmetrics.Exemplar_AsInt{
+											AsInt: 0,
+										},
+										FilteredLabels: []otlpcommon.StringKeyValue{ //nolint:staticcheck // SA1019 ignore this!
+											{Key: "FilteredLabelKey", Value: "FilteredLabelValue"},
+										},
+										FilteredAttributes: []otlpcommon.KeyValue{ //nolint:staticcheck // SA1019 ignore this!
+											{Key: "FilteredLabelKey", Value: otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_StringValue{StringValue: "FilteredLabelValue"}}},
+										},
+									},
+								},
 								Attributes: []otlpcommon.KeyValue{
 									{Key: "IntSumKey", Value: otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_StringValue{StringValue: "IntSumValue"}}},
 								},

--- a/model/pdata/generated_metrics.go
+++ b/model/pdata/generated_metrics.go
@@ -1839,6 +1839,11 @@ func (ms Exemplar) FilteredLabels() StringMap {
 	return newStringMap(&(*ms.orig).FilteredLabels)
 }
 
+// FilteredAttributes returns the FilteredAttributes associated with this Exemplar.
+func (ms Exemplar) FilteredAttributes() AttributeMap {
+	return newAttributeMap(&(*ms.orig).FilteredAttributes)
+}
+
 // CopyTo copies all properties from the current struct to the dest.
 func (ms Exemplar) CopyTo(dest Exemplar) {
 	dest.SetTimestamp(ms.Timestamp())
@@ -1850,4 +1855,5 @@ func (ms Exemplar) CopyTo(dest Exemplar) {
 	}
 
 	ms.FilteredLabels().CopyTo(dest.FilteredLabels())
+	ms.FilteredAttributes().CopyTo(dest.FilteredAttributes())
 }

--- a/model/pdata/generated_metrics_test.go
+++ b/model/pdata/generated_metrics_test.go
@@ -1322,6 +1322,14 @@ func TestExemplar_FilteredLabels(t *testing.T) {
 	assert.EqualValues(t, testValFilteredLabels, ms.FilteredLabels())
 }
 
+func TestExemplar_FilteredAttributes(t *testing.T) {
+	ms := NewExemplar()
+	assert.EqualValues(t, NewAttributeMap(), ms.FilteredAttributes())
+	fillTestAttributeMap(ms.FilteredAttributes())
+	testValFilteredAttributes := generateTestAttributeMap()
+	assert.EqualValues(t, testValFilteredAttributes, ms.FilteredAttributes())
+}
+
 func generateTestResourceMetricsSlice() ResourceMetricsSlice {
 	tv := NewResourceMetricsSlice()
 	fillTestResourceMetricsSlice(tv)
@@ -1587,4 +1595,5 @@ func fillTestExemplar(tv Exemplar) {
 	tv.SetDoubleVal(float64(17.13))
 
 	fillTestStringMap(tv.FilteredLabels())
+	fillTestAttributeMap(tv.FilteredAttributes())
 }

--- a/receiver/prometheusreceiver/internal/otlp_metricfamily_test.go
+++ b/receiver/prometheusreceiver/internal/otlp_metricfamily_test.go
@@ -26,6 +26,7 @@ import (
 	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/model/pdata"
+	tracetranslator "go.opentelemetry.io/collector/translator/trace"
 )
 
 type byLookupMetadataCache map[string]scrape.MetricMetadata
@@ -234,8 +235,8 @@ func TestMetricGroupData_toDistributionPointEquivalence(t *testing.T) {
 				require.Equal(t, ocExemplar.Timestamp.AsTime(), pdataExemplar.Timestamp().AsTime(), msgPrefix+"timestamp mismatch")
 				require.Equal(t, ocExemplar.Value, pdataExemplar.DoubleVal(), msgPrefix+"value mismatch")
 				pdataExemplarAttachments := make(map[string]string)
-				pdataExemplar.FilteredLabels().Range(func(key, value string) bool {
-					pdataExemplarAttachments[key] = value
+				pdataExemplar.FilteredAttributes().Range(func(key string, value pdata.AttributeValue) bool {
+					pdataExemplarAttachments[key] = tracetranslator.AttributeValueToString(value)
 					return true
 				})
 				require.Equal(t, ocExemplar.Attachments, pdataExemplarAttachments, msgPrefix+"attachments mismatch")

--- a/translator/internaldata/metrics_to_oc.go
+++ b/translator/internaldata/metrics_to_oc.go
@@ -23,6 +23,7 @@ import (
 	"github.com/golang/protobuf/ptypes/wrappers"
 
 	"go.opentelemetry.io/collector/model/pdata"
+	tracetranslator "go.opentelemetry.io/collector/translator/trace"
 )
 
 type labelKeysAndType struct {
@@ -378,16 +379,16 @@ func exemplarsToOC(bounds []float64, ocBuckets []*ocmetrics.DistributionValue_Bu
 			}
 			break
 		}
-		ocBuckets[pos].Exemplar = exemplarToOC(exemplar.FilteredLabels(), val, exemplar.Timestamp())
+		ocBuckets[pos].Exemplar = exemplarToOC(exemplar.FilteredAttributes(), val, exemplar.Timestamp())
 	}
 }
 
-func exemplarToOC(filteredLabels pdata.StringMap, value float64, timestamp pdata.Timestamp) *ocmetrics.DistributionValue_Exemplar {
+func exemplarToOC(filteredLabels pdata.AttributeMap, value float64, timestamp pdata.Timestamp) *ocmetrics.DistributionValue_Exemplar {
 	var labels map[string]string
 	if filteredLabels.Len() != 0 {
 		labels = make(map[string]string, filteredLabels.Len())
-		filteredLabels.Range(func(k string, v string) bool {
-			labels[k] = v
+		filteredLabels.Range(func(k string, v pdata.AttributeValue) bool {
+			labels[k] = tracetranslator.AttributeValueToString(v)
 			return true
 		})
 	}

--- a/translator/internaldata/oc_to_metrics.go
+++ b/translator/internaldata/oc_to_metrics.go
@@ -347,11 +347,11 @@ func exemplarToMetrics(ocExemplar *ocmetrics.DistributionValue_Exemplar, exempla
 	}
 	ocAttachments := ocExemplar.GetAttachments()
 	exemplar.SetDoubleVal(ocExemplar.GetValue())
-	filteredLabels := exemplar.FilteredLabels()
-	filteredLabels.Clear()
-	filteredLabels.EnsureCapacity(len(ocAttachments))
+	filteredAttributes := exemplar.FilteredAttributes()
+	filteredAttributes.Clear()
+	filteredAttributes.EnsureCapacity(len(ocAttachments))
 	for k, v := range ocAttachments {
-		filteredLabels.Upsert(k, v)
+		filteredAttributes.UpsertString(k, v)
 	}
 }
 


### PR DESCRIPTION
**Description:**
`FilteredLabels` are being deprecated in favour of `FilteredAttributes`, this change adds the `FilteredAttributes` field to pdata and translates FilteredLabels to FilteredAttributes in the otlp wrapper. Note this change could be broken into multiple changes, but it's fairly small. If the reviewers feel otherwise, I'm happy to split it up. 

**Link to tracking Issue:** Part of #3535 

Note that this change isn't dependent on https://github.com/open-telemetry/opentelemetry-collector/pull/3805, but there will be some merge conflicts that arise from it. I will rebase this PR and mark it ready for review once 3805 is merged.