### PR TITLE
Fix Parser.ToStringMap to split the loaded keys by delim

### DIFF
--- a/config/configparser/parser.go
+++ b/config/configparser/parser.go
@@ -21,6 +21,7 @@ import (
 	"reflect"
 
 	"github.com/knadh/koanf"
+	"github.com/knadh/koanf/maps"
 	"github.com/knadh/koanf/parsers/yaml"
 	"github.com/knadh/koanf/providers/confmap"
 	"github.com/knadh/koanf/providers/file"
@@ -152,7 +153,7 @@ func (l *Parser) Sub(key string) (*Parser, error) {
 
 // ToStringMap creates a map[string]interface{} from a Parser.
 func (l *Parser) ToStringMap() map[string]interface{} {
-	return l.k.Raw()
+	return maps.Unflatten(l.k.All(), KeyDelimiter)
 }
 
 // decoderConfig returns a default mapstructure.DecoderConfig capable of parsing time.Duration

--- a/config/configparser/parser_test.go
+++ b/config/configparser/parser_test.go
@@ -21,6 +21,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestToStringMap_WithSet(t *testing.T) {
+	parser := NewParser()
+	parser.Set("key::embedded", int64(123))
+	assert.Equal(t, map[string]interface{}{"key": map[string]interface{}{"embedded": int64(123)}}, parser.ToStringMap())
+}
+
 func TestToStringMap(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -72,7 +78,21 @@ func TestToStringMap(t *testing.T) {
 					"integer.example":        1234,
 					"bool.example":           false,
 					"string.example":         "this is a string",
+					"nil.example":            nil,
 				},
+			},
+		},
+		{
+			name:     "Embedded keys",
+			fileName: "testdata/embedded_keys.yaml",
+			stringMap: map[string]interface{}{
+				"typed": map[string]interface{}{"options": map[string]interface{}{
+					"floating": map[string]interface{}{"point": map[string]interface{}{"example": 3.14}},
+					"integer":  map[string]interface{}{"example": 1234},
+					"bool":     map[string]interface{}{"example": false},
+					"string":   map[string]interface{}{"example": "this is a string"},
+					"nil":      map[string]interface{}{"example": nil},
+				}},
 			},
 		},
 	}

--- a/config/configparser/testdata/basic_types.yaml
+++ b/config/configparser/testdata/basic_types.yaml
@@ -1,5 +1,6 @@
 typed.options:
   floating.point.example:  3.14
   integer.example: 1234
-  bool.example: no
+  bool.example: false
   string.example: this is a string
+  nil.example:

--- a/config/configparser/testdata/embedded_keys.yaml
+++ b/config/configparser/testdata/embedded_keys.yaml
@@ -1,0 +1,6 @@
+typed::options:
+  floating::point::example:  3.14
+  integer::example: 1234
+  bool::example: false
+  string::example: this is a string
+  nil::example:


### PR DESCRIPTION
Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
