### PR TITLE
Move ID from Config to CreateSettings for Exporter

### DIFF
--- a/component/componenttest/nop_exporter.go
+++ b/component/componenttest/nop_exporter.go
@@ -27,8 +27,9 @@ import (
 )
 
 // NewNopExporterCreateSettings returns a new nop settings for Create*Exporter functions.
-func NewNopExporterCreateSettings() component.ExporterCreateSettings {
+func NewNopExporterCreateSettings(id config.ComponentID) component.ExporterCreateSettings {
 	return component.ExporterCreateSettings{
+		ID:             id,
 		Logger:         zap.NewNop(),
 		TracerProvider: trace.NewNoopTracerProvider(),
 		BuildInfo:      component.DefaultBuildInfo(),
@@ -57,7 +58,7 @@ func (f *nopExporterFactory) Type() config.Type {
 // CreateDefaultConfig creates the default configuration for the Exporter.
 func (f *nopExporterFactory) CreateDefaultConfig() config.Exporter {
 	return &nopExporterConfig{
-		ExporterSettings: config.NewExporterSettings(config.NewID("nop")),
+		ExporterSettings: config.NewExporterSettings(),
 	}
 }
 

--- a/component/componenttest/nop_exporter_test.go
+++ b/component/componenttest/nop_exporter_test.go
@@ -25,26 +25,28 @@ import (
 	"go.opentelemetry.io/collector/model/pdata"
 )
 
+var exporterID = config.NewID("nop")
+
 func TestNewNopExporterFactory(t *testing.T) {
 	factory := NewNopExporterFactory()
 	require.NotNil(t, factory)
 	assert.Equal(t, config.Type("nop"), factory.Type())
 	cfg := factory.CreateDefaultConfig()
-	assert.Equal(t, &nopExporterConfig{ExporterSettings: config.NewExporterSettings(config.NewID("nop"))}, cfg)
+	assert.Equal(t, &nopExporterConfig{ExporterSettings: config.NewExporterSettings()}, cfg)
 
-	traces, err := factory.CreateTracesExporter(context.Background(), NewNopExporterCreateSettings(), cfg)
+	traces, err := factory.CreateTracesExporter(context.Background(), NewNopExporterCreateSettings(exporterID), cfg)
 	require.NoError(t, err)
 	assert.NoError(t, traces.Start(context.Background(), NewNopHost()))
 	assert.NoError(t, traces.ConsumeTraces(context.Background(), pdata.NewTraces()))
 	assert.NoError(t, traces.Shutdown(context.Background()))
 
-	metrics, err := factory.CreateMetricsExporter(context.Background(), NewNopExporterCreateSettings(), cfg)
+	metrics, err := factory.CreateMetricsExporter(context.Background(), NewNopExporterCreateSettings(exporterID), cfg)
 	require.NoError(t, err)
 	assert.NoError(t, metrics.Start(context.Background(), NewNopHost()))
 	assert.NoError(t, metrics.ConsumeMetrics(context.Background(), pdata.NewMetrics()))
 	assert.NoError(t, metrics.Shutdown(context.Background()))
 
-	logs, err := factory.CreateLogsExporter(context.Background(), NewNopExporterCreateSettings(), cfg)
+	logs, err := factory.CreateLogsExporter(context.Background(), NewNopExporterCreateSettings(exporterID), cfg)
 	require.NoError(t, err)
 	assert.NoError(t, logs.Start(context.Background(), NewNopHost()))
 	assert.NoError(t, logs.ConsumeLogs(context.Background(), pdata.NewLogs()))

--- a/component/exporter.go
+++ b/component/exporter.go
@@ -49,6 +49,9 @@ type LogsExporter interface {
 
 // ExporterCreateSettings configures Exporter creators.
 type ExporterCreateSettings struct {
+	// ID is the id of the exporter component to be created.
+	ID config.ComponentID
+
 	// Logger that the factory can use during creation and can pass to the created
 	// component to be used later as well.
 	Logger *zap.Logger

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -40,13 +40,11 @@ func (nc *nopRecvConfig) Validate() error {
 
 type nopExpConfig struct {
 	ExporterSettings
+	err error
 }
 
 func (nc *nopExpConfig) Validate() error {
-	if nc.ID() != NewID("nop") {
-		return errInvalidExpConfig
-	}
-	return nil
+	return nc.err
 }
 
 type nopProcConfig struct {
@@ -184,7 +182,7 @@ func TestConfigValidate(t *testing.T) {
 			cfgFn: func() *Config {
 				cfg := generateConfig()
 				cfg.Exporters[NewID("nop")] = &nopExpConfig{
-					ExporterSettings: NewExporterSettings(NewID("invalid_rec_type")),
+					err: errInvalidExpConfig,
 				}
 				return cfg
 			},
@@ -231,7 +229,7 @@ func generateConfig() *Config {
 		},
 		Exporters: map[ComponentID]Exporter{
 			NewID("nop"): &nopExpConfig{
-				ExporterSettings: NewExporterSettings(NewID("nop")),
+				ExporterSettings: NewExporterSettings(),
 			},
 		},
 		Processors: map[ComponentID]Processor{

--- a/config/configunmarshaler/defaultunmarshaler.go
+++ b/config/configunmarshaler/defaultunmarshaler.go
@@ -320,7 +320,6 @@ func unmarshalExporters(exps map[string]interface{}, factories map[config.Type]c
 
 		// Create the default config for this exporter.
 		exporterCfg := factory.CreateDefaultConfig()
-		exporterCfg.SetIDName(id.Name())
 		expandEnvLoadedConfig(exporterCfg)
 
 		// Now that the default config struct is created we can Unmarshal into it

--- a/config/configunmarshaler/defaultunmarshaler_test.go
+++ b/config/configunmarshaler/defaultunmarshaler_test.go
@@ -76,7 +76,7 @@ func TestDecodeConfig(t *testing.T) {
 
 	assert.Equal(t,
 		&testcomponents.ExampleExporter{
-			ExporterSettings: config.NewExporterSettings(config.NewID("exampleexporter")),
+			ExporterSettings: config.NewExporterSettings(),
 			ExtraSetting:     "some export string",
 		},
 		cfg.Exporters[config.NewID("exampleexporter")],
@@ -84,7 +84,7 @@ func TestDecodeConfig(t *testing.T) {
 
 	assert.Equal(t,
 		&testcomponents.ExampleExporter{
-			ExporterSettings: config.NewExporterSettings(config.NewIDWithName("exampleexporter", "myexporter")),
+			ExporterSettings: config.NewExporterSettings(),
 			ExtraSetting:     "some export string 2",
 		},
 		cfg.Exporters[config.NewIDWithName("exampleexporter", "myexporter")],
@@ -227,7 +227,7 @@ func TestSimpleConfig(t *testing.T) {
 
 			assert.Equalf(t,
 				&testcomponents.ExampleExporter{
-					ExporterSettings: config.NewExporterSettings(config.NewID("exampleexporter")),
+					ExporterSettings: config.NewExporterSettings(),
 					ExtraInt:         65,
 					ExtraSetting:     exporterExtra,
 					ExtraMapSetting:  map[string]string{"exp_1": exporterExtraMapValue + "_1", "exp_2": exporterExtraMapValue + "_2"},
@@ -332,7 +332,7 @@ func TestEscapedEnvVars(t *testing.T) {
 
 	assert.Equal(t,
 		&testcomponents.ExampleExporter{
-			ExporterSettings: config.NewExporterSettings(config.NewID("exampleexporter")),
+			ExporterSettings: config.NewExporterSettings(),
 			ExtraSetting:     "${EXPORTERS_EXAMPLEEXPORTER_EXTRA}",
 			ExtraMapSetting:  map[string]string{"exp_1": "${EXPORTERS_EXAMPLEEXPORTER_EXTRA_MAP_EXP_VALUE_1}", "exp_2": "${EXPORTERS_EXAMPLEEXPORTER_EXTRA_MAP_EXP_VALUE_2}"},
 			ExtraListSetting: []string{"${EXPORTERS_EXAMPLEEXPORTER_EXTRA_LIST_VALUE_1}", "${EXPORTERS_EXAMPLEEXPORTER_EXTRA_LIST_VALUE_2}"},
@@ -492,7 +492,7 @@ func TestExpandEnvLoadedConfig(t *testing.T) {
 	testString := "$PTR_VALUE"
 
 	cfg := &testConfig{
-		ExporterSettings: config.NewExporterSettings(config.NewID("test")),
+		ExporterSettings: config.NewExporterSettings(),
 		NestedConfigPtr: &nestedConfig{
 			NestedStringValue: "$NESTED_VALUE",
 			NestedIntValue:    1,
@@ -511,7 +511,7 @@ func TestExpandEnvLoadedConfig(t *testing.T) {
 	replacedTestString := "replaced_ptr_value"
 
 	assert.Equal(t, &testConfig{
-		ExporterSettings: config.NewExporterSettings(config.NewID("test")),
+		ExporterSettings: config.NewExporterSettings(),
 		NestedConfigPtr: &nestedConfig{
 			NestedStringValue: "replaced_nested_value",
 			NestedIntValue:    1,
@@ -540,7 +540,7 @@ func TestExpandEnvLoadedConfigEscapedEnv(t *testing.T) {
 	testString := "$$ESCAPED_PTR_VALUE"
 
 	cfg := &testConfig{
-		ExporterSettings: config.NewExporterSettings(config.NewID("test")),
+		ExporterSettings: config.NewExporterSettings(),
 		NestedConfigPtr: &nestedConfig{
 			NestedStringValue: "$NESTED_VALUE",
 			NestedIntValue:    1,
@@ -559,7 +559,7 @@ func TestExpandEnvLoadedConfigEscapedEnv(t *testing.T) {
 	replacedTestString := "$ESCAPED_PTR_VALUE"
 
 	assert.Equal(t, &testConfig{
-		ExporterSettings: config.NewExporterSettings(config.NewID("test")),
+		ExporterSettings: config.NewExporterSettings(),
 		NestedConfigPtr: &nestedConfig{
 			NestedStringValue: "replaced_nested_value",
 			NestedIntValue:    1,
@@ -584,7 +584,7 @@ func TestExpandEnvLoadedConfigMissingEnv(t *testing.T) {
 	testString := "$PTR_VALUE"
 
 	cfg := &testConfig{
-		ExporterSettings: config.NewExporterSettings(config.NewID("test")),
+		ExporterSettings: config.NewExporterSettings(),
 		NestedConfigPtr: &nestedConfig{
 			NestedStringValue: "$NESTED_VALUE",
 			NestedIntValue:    1,
@@ -603,7 +603,7 @@ func TestExpandEnvLoadedConfigMissingEnv(t *testing.T) {
 	replacedTestString := ""
 
 	assert.Equal(t, &testConfig{
-		ExporterSettings: config.NewExporterSettings(config.NewID("test")),
+		ExporterSettings: config.NewExporterSettings(),
 		NestedConfigPtr: &nestedConfig{
 			NestedStringValue: "replaced_nested_value",
 			NestedIntValue:    1,

--- a/config/exporter.go
+++ b/config/exporter.go
@@ -17,7 +17,6 @@ package config
 // Exporter is the configuration of a component.Exporter. Specific extensions must implement
 // this interface and must embed ExporterSettings struct or a struct that extends it.
 type Exporter interface {
-	identifiable
 	validatable
 
 	privateConfigExporter()
@@ -32,25 +31,13 @@ type Exporters map[ComponentID]Exporter
 // It is highly recommended to "override" the Validate() function.
 //
 // When embedded in the exporter config, it must be with `mapstructure:",squash"` tag.
-type ExporterSettings struct {
-	id ComponentID `mapstructure:"-"`
-}
-
-// NewExporterSettings return a new ExporterSettings with the given ComponentID.
-func NewExporterSettings(id ComponentID) ExporterSettings {
-	return ExporterSettings{id: ComponentID{typeVal: id.Type(), nameVal: id.Name()}}
-}
+type ExporterSettings struct{}
 
 var _ Exporter = (*ExporterSettings)(nil)
 
-// ID returns the receiver ComponentID.
-func (rs *ExporterSettings) ID() ComponentID {
-	return rs.id
-}
-
-// SetIDName sets the receiver name.
-func (rs *ExporterSettings) SetIDName(idName string) {
-	rs.id.nameVal = idName
+// NewExporterSettings return a new ExporterSettings with the given ComponentID.
+func NewExporterSettings() ExporterSettings {
+	return ExporterSettings{}
 }
 
 func (rs *ExporterSettings) Validate() error {

--- a/exporter/exporterhelper/common.go
+++ b/exporter/exporterhelper/common.go
@@ -20,7 +20,6 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenthelper"
-	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/configtelemetry"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumerhelper"
@@ -169,17 +168,16 @@ type baseExporter struct {
 	qrSender *queuedRetrySender
 }
 
-func newBaseExporter(cfg config.Exporter, set component.ExporterCreateSettings, bs *baseSettings) *baseExporter {
+func newBaseExporter(set component.ExporterCreateSettings, bs *baseSettings) *baseExporter {
 	be := &baseExporter{
 		Component: componenthelper.New(bs.componentOptions...),
 	}
 
 	be.obsrep = newObsExporter(obsreport.ExporterSettings{
 		Level:                  configtelemetry.GetMetricsLevelFlagValue(),
-		ExporterID:             cfg.ID(),
 		ExporterCreateSettings: set,
 	})
-	be.qrSender = newQueuedRetrySender(cfg.ID().String(), bs.QueueSettings, bs.RetrySettings, &timeoutSender{cfg: bs.TimeoutSettings}, set.Logger)
+	be.qrSender = newQueuedRetrySender(set.ID.String(), bs.QueueSettings, bs.RetrySettings, &timeoutSender{cfg: bs.TimeoutSettings}, set.Logger)
 	be.sender = be.qrSender
 
 	return be

--- a/exporter/exporterhelper/common_test.go
+++ b/exporter/exporterhelper/common_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 var (
-	defaultExporterCfg  = config.NewExporterSettings(config.NewID(typeStr))
+	exporterID          = config.NewID(typeStr)
 	exporterTag, _      = tag.NewKey("exporter")
 	defaultExporterTags = []tag.Tag{
 		{Key: exporterTag, Value: "test"},
@@ -37,7 +37,7 @@ var (
 )
 
 func TestBaseExporter(t *testing.T) {
-	be := newBaseExporter(&defaultExporterCfg, componenttest.NewNopExporterCreateSettings(), fromOptions())
+	be := newBaseExporter(componenttest.NewNopExporterCreateSettings(exporterID), fromOptions())
 	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
 	require.NoError(t, be.Shutdown(context.Background()))
 }
@@ -45,8 +45,7 @@ func TestBaseExporter(t *testing.T) {
 func TestBaseExporterWithOptions(t *testing.T) {
 	want := errors.New("my error")
 	be := newBaseExporter(
-		&defaultExporterCfg,
-		componenttest.NewNopExporterCreateSettings(),
+		componenttest.NewNopExporterCreateSettings(exporterID),
 		fromOptions(
 			WithStart(func(ctx context.Context, host component.Host) error { return want }),
 			WithShutdown(func(ctx context.Context) error { return want }),

--- a/exporter/exporterhelper/factory_test.go
+++ b/exporter/exporterhelper/factory_test.go
@@ -30,14 +30,15 @@ import (
 const typeStr = "test"
 
 var (
-	defaultCfg           = config.NewExporterSettings(config.NewID(typeStr))
-	nopTracesExporter, _ = NewTracesExporter(&defaultCfg, componenttest.NewNopExporterCreateSettings(), func(ctx context.Context, td pdata.Traces) error {
+	defaultID            = config.NewID(typeStr)
+	defaultCfg           = config.NewExporterSettings()
+	nopTracesExporter, _ = NewTracesExporter(&defaultCfg, componenttest.NewNopExporterCreateSettings(defaultID), func(ctx context.Context, td pdata.Traces) error {
 		return nil
 	})
-	nopMetricsExporter, _ = NewMetricsExporter(&defaultCfg, componenttest.NewNopExporterCreateSettings(), func(ctx context.Context, md pdata.Metrics) error {
+	nopMetricsExporter, _ = NewMetricsExporter(&defaultCfg, componenttest.NewNopExporterCreateSettings(defaultID), func(ctx context.Context, md pdata.Metrics) error {
 		return nil
 	})
-	nopLogsExporter, _ = NewLogsExporter(&defaultCfg, componenttest.NewNopExporterCreateSettings(), func(ctx context.Context, md pdata.Logs) error {
+	nopLogsExporter, _ = NewLogsExporter(&defaultCfg, componenttest.NewNopExporterCreateSettings(defaultID), func(ctx context.Context, md pdata.Logs) error {
 		return nil
 	})
 )
@@ -48,11 +49,11 @@ func TestNewFactory(t *testing.T) {
 		defaultConfig)
 	assert.EqualValues(t, typeStr, factory.Type())
 	assert.EqualValues(t, &defaultCfg, factory.CreateDefaultConfig())
-	_, err := factory.CreateTracesExporter(context.Background(), componenttest.NewNopExporterCreateSettings(), &defaultCfg)
+	_, err := factory.CreateTracesExporter(context.Background(), componenttest.NewNopExporterCreateSettings(defaultID), &defaultCfg)
 	assert.Equal(t, componenterror.ErrDataTypeIsNotSupported, err)
-	_, err = factory.CreateMetricsExporter(context.Background(), componenttest.NewNopExporterCreateSettings(), &defaultCfg)
+	_, err = factory.CreateMetricsExporter(context.Background(), componenttest.NewNopExporterCreateSettings(defaultID), &defaultCfg)
 	assert.Equal(t, componenterror.ErrDataTypeIsNotSupported, err)
-	_, err = factory.CreateLogsExporter(context.Background(), componenttest.NewNopExporterCreateSettings(), &defaultCfg)
+	_, err = factory.CreateLogsExporter(context.Background(), componenttest.NewNopExporterCreateSettings(defaultID), &defaultCfg)
 	assert.Equal(t, componenterror.ErrDataTypeIsNotSupported, err)
 }
 
@@ -66,15 +67,15 @@ func TestNewFactory_WithConstructors(t *testing.T) {
 	assert.EqualValues(t, typeStr, factory.Type())
 	assert.EqualValues(t, &defaultCfg, factory.CreateDefaultConfig())
 
-	te, err := factory.CreateTracesExporter(context.Background(), componenttest.NewNopExporterCreateSettings(), &defaultCfg)
+	te, err := factory.CreateTracesExporter(context.Background(), componenttest.NewNopExporterCreateSettings(defaultID), &defaultCfg)
 	assert.NoError(t, err)
 	assert.Same(t, nopTracesExporter, te)
 
-	me, err := factory.CreateMetricsExporter(context.Background(), componenttest.NewNopExporterCreateSettings(), &defaultCfg)
+	me, err := factory.CreateMetricsExporter(context.Background(), componenttest.NewNopExporterCreateSettings(defaultID), &defaultCfg)
 	assert.NoError(t, err)
 	assert.Same(t, nopMetricsExporter, me)
 
-	le, err := factory.CreateLogsExporter(context.Background(), componenttest.NewNopExporterCreateSettings(), &defaultCfg)
+	le, err := factory.CreateLogsExporter(context.Background(), componenttest.NewNopExporterCreateSettings(defaultID), &defaultCfg)
 	assert.NoError(t, err)
 	assert.Same(t, nopLogsExporter, le)
 }

--- a/exporter/exporterhelper/logs.go
+++ b/exporter/exporterhelper/logs.go
@@ -63,15 +63,11 @@ type logsExporter struct {
 
 // NewLogsExporter creates an LogsExporter that records observability metrics and wraps every request with a Span.
 func NewLogsExporter(
-	cfg config.Exporter,
+	_ config.Exporter,
 	set component.ExporterCreateSettings,
 	pusher consumerhelper.ConsumeLogsFunc,
 	options ...Option,
 ) (component.LogsExporter, error) {
-	if cfg == nil {
-		return nil, errNilConfig
-	}
-
 	if set.Logger == nil {
 		return nil, errNilLogger
 	}
@@ -81,7 +77,7 @@ func NewLogsExporter(
 	}
 
 	bs := fromOptions(options...)
-	be := newBaseExporter(cfg, set, bs)
+	be := newBaseExporter(set, bs)
 	be.wrapConsumerSender(func(nextSender requestSender) requestSender {
 		return &logsExporterWithObservability{
 			obsrep:     be.obsrep,

--- a/exporter/exporterhelper/metrics.go
+++ b/exporter/exporterhelper/metrics.go
@@ -63,15 +63,11 @@ type metricsExporter struct {
 
 // NewMetricsExporter creates an MetricsExporter that records observability metrics and wraps every request with a Span.
 func NewMetricsExporter(
-	cfg config.Exporter,
+	_ config.Exporter,
 	set component.ExporterCreateSettings,
 	pusher consumerhelper.ConsumeMetricsFunc,
 	options ...Option,
 ) (component.MetricsExporter, error) {
-	if cfg == nil {
-		return nil, errNilConfig
-	}
-
 	if set.Logger == nil {
 		return nil, errNilLogger
 	}
@@ -81,7 +77,7 @@ func NewMetricsExporter(
 	}
 
 	bs := fromOptions(options...)
-	be := newBaseExporter(cfg, set, bs)
+	be := newBaseExporter(set, bs)
 	be.wrapConsumerSender(func(nextSender requestSender) requestSender {
 		return &metricsSenderWithObservability{
 			obsrep:     be.obsrep,

--- a/exporter/exporterhelper/obsreport.go
+++ b/exporter/exporterhelper/obsreport.go
@@ -38,7 +38,7 @@ type obsExporter struct {
 func newObsExporter(cfg obsreport.ExporterSettings) *obsExporter {
 	return &obsExporter{
 		obsreport.NewExporter(cfg),
-		[]tag.Mutator{tag.Upsert(obsmetrics.TagKeyExporter, cfg.ExporterID.String(), tag.WithTTL(tag.TTLNoPropagation))},
+		[]tag.Mutator{tag.Upsert(obsmetrics.TagKeyExporter, cfg.ExporterCreateSettings.ID.String(), tag.WithTTL(tag.TTLNoPropagation))},
 	}
 }
 

--- a/exporter/exporterhelper/obsreport_test.go
+++ b/exporter/exporterhelper/obsreport_test.go
@@ -40,8 +40,7 @@ func TestExportEnqueueFailure(t *testing.T) {
 
 	obsrep := newObsExporter(obsreport.ExporterSettings{
 		Level:                  configtelemetry.LevelNormal,
-		ExporterID:             exporter,
-		ExporterCreateSettings: componenttest.NewNopExporterCreateSettings()})
+		ExporterCreateSettings: componenttest.NewNopExporterCreateSettings(exporter)})
 
 	logRecords := 7
 	obsrep.recordLogsEnqueueFailure(context.Background(), logRecords)

--- a/exporter/exporterhelper/queued_retry_test.go
+++ b/exporter/exporterhelper/queued_retry_test.go
@@ -38,7 +38,7 @@ import (
 func TestQueuedRetry_DropOnPermanentError(t *testing.T) {
 	qCfg := DefaultQueueSettings()
 	rCfg := DefaultRetrySettings()
-	be := newBaseExporter(&defaultExporterCfg, componenttest.NewNopExporterCreateSettings(), fromOptions(WithRetry(rCfg), WithQueue(qCfg)))
+	be := newBaseExporter(componenttest.NewNopExporterCreateSettings(exporterID), fromOptions(WithRetry(rCfg), WithQueue(qCfg)))
 	ocs := newObservabilityConsumerSender(be.qrSender.consumerSender)
 	be.qrSender.consumerSender = ocs
 	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
@@ -62,7 +62,7 @@ func TestQueuedRetry_DropOnNoRetry(t *testing.T) {
 	qCfg := DefaultQueueSettings()
 	rCfg := DefaultRetrySettings()
 	rCfg.Enabled = false
-	be := newBaseExporter(&defaultExporterCfg, componenttest.NewNopExporterCreateSettings(), fromOptions(WithRetry(rCfg), WithQueue(qCfg)))
+	be := newBaseExporter(componenttest.NewNopExporterCreateSettings(exporterID), fromOptions(WithRetry(rCfg), WithQueue(qCfg)))
 	ocs := newObservabilityConsumerSender(be.qrSender.consumerSender)
 	be.qrSender.consumerSender = ocs
 	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
@@ -87,7 +87,7 @@ func TestQueuedRetry_OnError(t *testing.T) {
 	qCfg.NumConsumers = 1
 	rCfg := DefaultRetrySettings()
 	rCfg.InitialInterval = 0
-	be := newBaseExporter(&defaultExporterCfg, componenttest.NewNopExporterCreateSettings(), fromOptions(WithRetry(rCfg), WithQueue(qCfg)))
+	be := newBaseExporter(componenttest.NewNopExporterCreateSettings(exporterID), fromOptions(WithRetry(rCfg), WithQueue(qCfg)))
 	ocs := newObservabilityConsumerSender(be.qrSender.consumerSender)
 	be.qrSender.consumerSender = ocs
 	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
@@ -113,7 +113,7 @@ func TestQueuedRetry_StopWhileWaiting(t *testing.T) {
 	qCfg := DefaultQueueSettings()
 	qCfg.NumConsumers = 1
 	rCfg := DefaultRetrySettings()
-	be := newBaseExporter(&defaultExporterCfg, componenttest.NewNopExporterCreateSettings(), fromOptions(WithRetry(rCfg), WithQueue(qCfg)))
+	be := newBaseExporter(componenttest.NewNopExporterCreateSettings(exporterID), fromOptions(WithRetry(rCfg), WithQueue(qCfg)))
 	ocs := newObservabilityConsumerSender(be.qrSender.consumerSender)
 	be.qrSender.consumerSender = ocs
 	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
@@ -146,7 +146,7 @@ func TestQueuedRetry_DoNotPreserveCancellation(t *testing.T) {
 	qCfg := DefaultQueueSettings()
 	qCfg.NumConsumers = 1
 	rCfg := DefaultRetrySettings()
-	be := newBaseExporter(&defaultExporterCfg, componenttest.NewNopExporterCreateSettings(), fromOptions(WithRetry(rCfg), WithQueue(qCfg)))
+	be := newBaseExporter(componenttest.NewNopExporterCreateSettings(exporterID), fromOptions(WithRetry(rCfg), WithQueue(qCfg)))
 	ocs := newObservabilityConsumerSender(be.qrSender.consumerSender)
 	be.qrSender.consumerSender = ocs
 	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
@@ -175,7 +175,7 @@ func TestQueuedRetry_MaxElapsedTime(t *testing.T) {
 	rCfg := DefaultRetrySettings()
 	rCfg.InitialInterval = time.Millisecond
 	rCfg.MaxElapsedTime = 100 * time.Millisecond
-	be := newBaseExporter(&defaultExporterCfg, componenttest.NewNopExporterCreateSettings(), fromOptions(WithRetry(rCfg), WithQueue(qCfg)))
+	be := newBaseExporter(componenttest.NewNopExporterCreateSettings(exporterID), fromOptions(WithRetry(rCfg), WithQueue(qCfg)))
 	ocs := newObservabilityConsumerSender(be.qrSender.consumerSender)
 	be.qrSender.consumerSender = ocs
 	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
@@ -221,7 +221,7 @@ func TestQueuedRetry_ThrottleError(t *testing.T) {
 	qCfg.NumConsumers = 1
 	rCfg := DefaultRetrySettings()
 	rCfg.InitialInterval = 10 * time.Millisecond
-	be := newBaseExporter(&defaultExporterCfg, componenttest.NewNopExporterCreateSettings(), fromOptions(WithRetry(rCfg), WithQueue(qCfg)))
+	be := newBaseExporter(componenttest.NewNopExporterCreateSettings(exporterID), fromOptions(WithRetry(rCfg), WithQueue(qCfg)))
 	ocs := newObservabilityConsumerSender(be.qrSender.consumerSender)
 	be.qrSender.consumerSender = ocs
 	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
@@ -253,7 +253,7 @@ func TestQueuedRetry_RetryOnError(t *testing.T) {
 	qCfg.QueueSize = 1
 	rCfg := DefaultRetrySettings()
 	rCfg.InitialInterval = 0
-	be := newBaseExporter(&defaultExporterCfg, componenttest.NewNopExporterCreateSettings(), fromOptions(WithRetry(rCfg), WithQueue(qCfg)))
+	be := newBaseExporter(componenttest.NewNopExporterCreateSettings(exporterID), fromOptions(WithRetry(rCfg), WithQueue(qCfg)))
 	ocs := newObservabilityConsumerSender(be.qrSender.consumerSender)
 	be.qrSender.consumerSender = ocs
 	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
@@ -279,7 +279,7 @@ func TestQueuedRetry_DropOnFull(t *testing.T) {
 	qCfg := DefaultQueueSettings()
 	qCfg.QueueSize = 0
 	rCfg := DefaultRetrySettings()
-	be := newBaseExporter(&defaultExporterCfg, componenttest.NewNopExporterCreateSettings(), fromOptions(WithRetry(rCfg), WithQueue(qCfg)))
+	be := newBaseExporter(componenttest.NewNopExporterCreateSettings(exporterID), fromOptions(WithRetry(rCfg), WithQueue(qCfg)))
 	ocs := newObservabilityConsumerSender(be.qrSender.consumerSender)
 	be.qrSender.consumerSender = ocs
 	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
@@ -297,7 +297,7 @@ func TestQueuedRetryHappyPath(t *testing.T) {
 
 	qCfg := DefaultQueueSettings()
 	rCfg := DefaultRetrySettings()
-	be := newBaseExporter(&defaultExporterCfg, componenttest.NewNopExporterCreateSettings(), fromOptions(WithRetry(rCfg), WithQueue(qCfg)))
+	be := newBaseExporter(componenttest.NewNopExporterCreateSettings(exporterID), fromOptions(WithRetry(rCfg), WithQueue(qCfg)))
 	ocs := newObservabilityConsumerSender(be.qrSender.consumerSender)
 	be.qrSender.consumerSender = ocs
 	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
@@ -331,7 +331,7 @@ func TestQueuedRetry_QueueMetricsReported(t *testing.T) {
 	qCfg := DefaultQueueSettings()
 	qCfg.NumConsumers = 0 // to make every request go straight to the queue
 	rCfg := DefaultRetrySettings()
-	be := newBaseExporter(&defaultExporterCfg, componenttest.NewNopExporterCreateSettings(), fromOptions(WithRetry(rCfg), WithQueue(qCfg)))
+	be := newBaseExporter(componenttest.NewNopExporterCreateSettings(exporterID), fromOptions(WithRetry(rCfg), WithQueue(qCfg)))
 	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
 
 	for i := 0; i < 7; i++ {

--- a/exporter/exporterhelper/traces.go
+++ b/exporter/exporterhelper/traces.go
@@ -63,16 +63,11 @@ type traceExporter struct {
 
 // NewTracesExporter creates a TracesExporter that records observability metrics and wraps every request with a Span.
 func NewTracesExporter(
-	cfg config.Exporter,
+	_ config.Exporter,
 	set component.ExporterCreateSettings,
 	pusher consumerhelper.ConsumeTracesFunc,
 	options ...Option,
 ) (component.TracesExporter, error) {
-
-	if cfg == nil {
-		return nil, errNilConfig
-	}
-
 	if set.Logger == nil {
 		return nil, errNilLogger
 	}
@@ -82,7 +77,7 @@ func NewTracesExporter(
 	}
 
 	bs := fromOptions(options...)
-	be := newBaseExporter(cfg, set, bs)
+	be := newBaseExporter(set, bs)
 	be.wrapConsumerSender(func(nextSender requestSender) requestSender {
 		return &tracesExporterWithObservability{
 			obsrep:     be.obsrep,

--- a/exporter/fileexporter/config_test.go
+++ b/exporter/fileexporter/config_test.go
@@ -42,7 +42,7 @@ func TestLoadConfig(t *testing.T) {
 	e1 := cfg.Exporters[config.NewIDWithName(typeStr, "2")]
 	assert.Equal(t, e1,
 		&Config{
-			ExporterSettings: config.NewExporterSettings(config.NewIDWithName(typeStr, "2")),
+			ExporterSettings: config.NewExporterSettings(),
 			Path:             "./filename.json",
 		})
 }

--- a/exporter/fileexporter/factory.go
+++ b/exporter/fileexporter/factory.go
@@ -23,10 +23,8 @@ import (
 	"go.opentelemetry.io/collector/internal/sharedcomponent"
 )
 
-const (
-	// The value of "type" key in configuration.
-	typeStr = "file"
-)
+// The value of "type" key in configuration.
+const typeStr = "file"
 
 // NewFactory creates a factory for OTLP exporter.
 func NewFactory() component.ExporterFactory {
@@ -40,7 +38,7 @@ func NewFactory() component.ExporterFactory {
 
 func createDefaultConfig() config.Exporter {
 	return &Config{
-		ExporterSettings: config.NewExporterSettings(config.NewID(typeStr)),
+		ExporterSettings: config.NewExporterSettings(),
 	}
 }
 

--- a/exporter/fileexporter/factory_test.go
+++ b/exporter/fileexporter/factory_test.go
@@ -22,8 +22,11 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/configcheck"
 )
+
+var defaultID = config.NewID(typeStr)
 
 func TestCreateDefaultConfig(t *testing.T) {
 	cfg := createDefaultConfig()
@@ -35,7 +38,7 @@ func TestCreateMetricsExporter(t *testing.T) {
 	cfg := createDefaultConfig()
 	exp, err := createMetricsExporter(
 		context.Background(),
-		componenttest.NewNopExporterCreateSettings(),
+		componenttest.NewNopExporterCreateSettings(defaultID),
 		cfg)
 	assert.NoError(t, err)
 	require.NotNil(t, exp)
@@ -45,7 +48,7 @@ func TestCreateTracesExporter(t *testing.T) {
 	cfg := createDefaultConfig()
 	exp, err := createTracesExporter(
 		context.Background(),
-		componenttest.NewNopExporterCreateSettings(),
+		componenttest.NewNopExporterCreateSettings(defaultID),
 		cfg)
 	assert.NoError(t, err)
 	require.NotNil(t, exp)
@@ -55,7 +58,7 @@ func TestCreateLogsExporter(t *testing.T) {
 	cfg := createDefaultConfig()
 	exp, err := createLogsExporter(
 		context.Background(),
-		componenttest.NewNopExporterCreateSettings(),
+		componenttest.NewNopExporterCreateSettings(defaultID),
 		cfg)
 	assert.NoError(t, err)
 	require.NotNil(t, exp)

--- a/exporter/jaegerexporter/config_test.go
+++ b/exporter/jaegerexporter/config_test.go
@@ -47,7 +47,7 @@ func TestLoadConfig(t *testing.T) {
 	e1 := cfg.Exporters[config.NewIDWithName(typeStr, "2")]
 	assert.Equal(t, e1,
 		&Config{
-			ExporterSettings: config.NewExporterSettings(config.NewIDWithName(typeStr, "2")),
+			ExporterSettings: config.NewExporterSettings(),
 			TimeoutSettings: exporterhelper.TimeoutSettings{
 				Timeout: 10 * time.Second,
 			},
@@ -69,7 +69,7 @@ func TestLoadConfig(t *testing.T) {
 			},
 		})
 
-	set := componenttest.NewNopExporterCreateSettings()
+	set := componenttest.NewNopExporterCreateSettings(config.NewIDWithName(typeStr, "2"))
 	te, err := factory.CreateTracesExporter(context.Background(), set, e1)
 	require.NoError(t, err)
 	require.NotNil(t, te)

--- a/exporter/jaegerexporter/exporter.go
+++ b/exporter/jaegerexporter/exporter.go
@@ -41,7 +41,7 @@ import (
 // The exporter name is the name to be used in the observability of the exporter.
 // The collectorEndpoint should be of the form "hostname:14250" (a gRPC target).
 func newTracesExporter(cfg *Config, set component.ExporterCreateSettings) (component.TracesExporter, error) {
-	s := newProtoGRPCSender(cfg, set.Logger)
+	s := newProtoGRPCSender(cfg, set)
 	return exporterhelper.NewTracesExporter(
 		cfg, set, s.pushTraces,
 		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
@@ -72,10 +72,10 @@ type protoGRPCSender struct {
 	clientSettings *configgrpc.GRPCClientSettings
 }
 
-func newProtoGRPCSender(cfg *Config, logger *zap.Logger) *protoGRPCSender {
+func newProtoGRPCSender(cfg *Config, set component.ExporterCreateSettings) *protoGRPCSender {
 	s := &protoGRPCSender{
-		name:                      cfg.ID().String(),
-		logger:                    logger,
+		name:                      set.ID.String(),
+		logger:                    set.Logger,
 		metadata:                  metadata.New(cfg.GRPCClientSettings.Headers),
 		waitForReady:              cfg.WaitForReady,
 		connStateReporterInterval: time.Second,

--- a/exporter/jaegerexporter/exporter_test.go
+++ b/exporter/jaegerexporter/exporter_test.go
@@ -48,7 +48,7 @@ func TestNew(t *testing.T) {
 		{
 			name: "createExporter",
 			config: Config{
-				ExporterSettings: config.NewExporterSettings(config.NewID(typeStr)),
+				ExporterSettings: config.NewExporterSettings(),
 				GRPCClientSettings: configgrpc.GRPCClientSettings{
 					Headers:     nil,
 					Endpoint:    "foo.bar",
@@ -63,7 +63,7 @@ func TestNew(t *testing.T) {
 		{
 			name: "createExporterWithHeaders",
 			config: Config{
-				ExporterSettings: config.NewExporterSettings(config.NewID(typeStr)),
+				ExporterSettings: config.NewExporterSettings(),
 				GRPCClientSettings: configgrpc.GRPCClientSettings{
 					Headers:     map[string]string{"extra-header": "header-value"},
 					Endpoint:    "foo.bar",
@@ -75,7 +75,7 @@ func TestNew(t *testing.T) {
 		{
 			name: "createBasicSecureExporter",
 			config: Config{
-				ExporterSettings: config.NewExporterSettings(config.NewID(typeStr)),
+				ExporterSettings: config.NewExporterSettings(),
 				GRPCClientSettings: configgrpc.GRPCClientSettings{
 					Headers:     nil,
 					Endpoint:    "foo.bar",
@@ -87,7 +87,7 @@ func TestNew(t *testing.T) {
 		{
 			name: "createSecureExporterWithClientTLS",
 			config: Config{
-				ExporterSettings: config.NewExporterSettings(config.NewID(typeStr)),
+				ExporterSettings: config.NewExporterSettings(),
 				GRPCClientSettings: configgrpc.GRPCClientSettings{
 					Headers:     nil,
 					Endpoint:    "foo.bar",
@@ -105,7 +105,7 @@ func TestNew(t *testing.T) {
 		{
 			name: "createSecureExporterWithKeepAlive",
 			config: Config{
-				ExporterSettings: config.NewExporterSettings(config.NewID(typeStr)),
+				ExporterSettings: config.NewExporterSettings(),
 				GRPCClientSettings: configgrpc.GRPCClientSettings{
 					Headers:     nil,
 					Endpoint:    "foo.bar",
@@ -128,7 +128,7 @@ func TestNew(t *testing.T) {
 		{
 			name: "createSecureExporterWithMissingFile",
 			config: Config{
-				ExporterSettings: config.NewExporterSettings(config.NewID(typeStr)),
+				ExporterSettings: config.NewExporterSettings(),
 				GRPCClientSettings: configgrpc.GRPCClientSettings{
 					Headers:     nil,
 					Endpoint:    "foo.bar",
@@ -147,7 +147,7 @@ func TestNew(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := newTracesExporter(&tt.config, componenttest.NewNopExporterCreateSettings())
+			got, err := newTracesExporter(&tt.config, componenttest.NewNopExporterCreateSettings(defaultID))
 			assert.NoError(t, err)
 			assert.NotNil(t, got)
 			t.Cleanup(func() {
@@ -222,7 +222,7 @@ func TestMutualTLS(t *testing.T) {
 			ServerName: "localhost",
 		},
 	}
-	exporter, err := factory.CreateTracesExporter(context.Background(), componenttest.NewNopExporterCreateSettings(), cfg)
+	exporter, err := factory.CreateTracesExporter(context.Background(), componenttest.NewNopExporterCreateSettings(defaultID), cfg)
 	require.NoError(t, err)
 	err = exporter.Start(context.Background(), componenttest.NewNopHost())
 	require.NoError(t, err)

--- a/exporter/jaegerexporter/factory.go
+++ b/exporter/jaegerexporter/factory.go
@@ -39,7 +39,7 @@ func NewFactory() component.ExporterFactory {
 
 func createDefaultConfig() config.Exporter {
 	return &Config{
-		ExporterSettings: config.NewExporterSettings(config.NewID(typeStr)),
+		ExporterSettings: config.NewExporterSettings(),
 		TimeoutSettings:  exporterhelper.DefaultTimeoutSettings(),
 		RetrySettings:    exporterhelper.DefaultRetrySettings(),
 		QueueSettings:    exporterhelper.DefaultQueueSettings(),
@@ -59,9 +59,7 @@ func createTracesExporter(
 	expCfg := config.(*Config)
 	if expCfg.Endpoint == "" {
 		// TODO: Improve error message, see #215
-		return nil, fmt.Errorf(
-			"%q config requires a non-empty \"endpoint\"",
-			expCfg.ID().String())
+		return nil, fmt.Errorf("%q config requires a non-empty \"endpoint\"", set.ID.String())
 	}
 
 	return newTracesExporter(expCfg, set)

--- a/exporter/jaegerexporter/factory_test.go
+++ b/exporter/jaegerexporter/factory_test.go
@@ -22,8 +22,11 @@ import (
 
 	"go.opentelemetry.io/collector/component/componenterror"
 	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/configcheck"
 )
+
+var defaultID = config.NewID(typeStr)
 
 func TestCreateDefaultConfig(t *testing.T) {
 	factory := NewFactory()
@@ -36,7 +39,7 @@ func TestCreateMetricsExporter(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
 
-	set := componenttest.NewNopExporterCreateSettings()
+	set := componenttest.NewNopExporterCreateSettings(defaultID)
 	_, err := factory.CreateMetricsExporter(context.Background(), set, cfg)
 	assert.Error(t, err, componenterror.ErrDataTypeIsNotSupported)
 }
@@ -48,7 +51,7 @@ func TestCreateInstanceViaFactory(t *testing.T) {
 
 	// Default config doesn't have default endpoint so creating from it should
 	// fail.
-	set := componenttest.NewNopExporterCreateSettings()
+	set := componenttest.NewNopExporterCreateSettings(defaultID)
 	exp, err := factory.CreateTracesExporter(context.Background(), set, cfg)
 	assert.NotNil(t, err)
 	assert.Equal(t, "\"jaeger\" config requires a non-empty \"endpoint\"", err.Error())

--- a/exporter/kafkaexporter/config_test.go
+++ b/exporter/kafkaexporter/config_test.go
@@ -40,7 +40,7 @@ func TestLoadConfig(t *testing.T) {
 
 	c := cfg.Exporters[config.NewID(typeStr)].(*Config)
 	assert.Equal(t, &Config{
-		ExporterSettings: config.NewExporterSettings(config.NewID(typeStr)),
+		ExporterSettings: config.NewExporterSettings(),
 		TimeoutSettings: exporterhelper.TimeoutSettings{
 			Timeout: 10 * time.Second,
 		},

--- a/exporter/kafkaexporter/factory.go
+++ b/exporter/kafkaexporter/factory.go
@@ -72,7 +72,7 @@ func NewFactory(options ...FactoryOption) component.ExporterFactory {
 
 func createDefaultConfig() config.Exporter {
 	return &Config{
-		ExporterSettings: config.NewExporterSettings(config.NewID(typeStr)),
+		ExporterSettings: config.NewExporterSettings(),
 		TimeoutSettings:  exporterhelper.DefaultTimeoutSettings(),
 		RetrySettings:    exporterhelper.DefaultRetrySettings(),
 		QueueSettings:    exporterhelper.DefaultQueueSettings(),

--- a/exporter/kafkaexporter/factory_test.go
+++ b/exporter/kafkaexporter/factory_test.go
@@ -23,9 +23,12 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/configcheck"
 	"go.opentelemetry.io/collector/model/pdata"
 )
+
+var defaultID = config.NewID(typeStr)
 
 func TestCreateDefaultConfig(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)
@@ -42,7 +45,7 @@ func TestCreateTracesExporter(t *testing.T) {
 	// this disables contacting the broker so we can successfully create the exporter
 	cfg.Metadata.Full = false
 	f := kafkaExporterFactory{tracesMarshalers: tracesMarshalers()}
-	r, err := f.createTracesExporter(context.Background(), componenttest.NewNopExporterCreateSettings(), cfg)
+	r, err := f.createTracesExporter(context.Background(), componenttest.NewNopExporterCreateSettings(defaultID), cfg)
 	require.NoError(t, err)
 	assert.NotNil(t, r)
 }
@@ -54,7 +57,7 @@ func TestCreateMetricsExport(t *testing.T) {
 	// this disables contacting the broker so we can successfully create the exporter
 	cfg.Metadata.Full = false
 	mf := kafkaExporterFactory{metricsMarshalers: metricsMarshalers()}
-	mr, err := mf.createMetricsExporter(context.Background(), componenttest.NewNopExporterCreateSettings(), cfg)
+	mr, err := mf.createMetricsExporter(context.Background(), componenttest.NewNopExporterCreateSettings(defaultID), cfg)
 	require.NoError(t, err)
 	assert.NotNil(t, mr)
 }
@@ -66,7 +69,7 @@ func TestCreateLogsExport(t *testing.T) {
 	// this disables contacting the broker so we can successfully create the exporter
 	cfg.Metadata.Full = false
 	mf := kafkaExporterFactory{logsMarshalers: logsMarshalers()}
-	mr, err := mf.createLogsExporter(context.Background(), componenttest.NewNopExporterCreateSettings(), cfg)
+	mr, err := mf.createLogsExporter(context.Background(), componenttest.NewNopExporterCreateSettings(defaultID), cfg)
 	require.NoError(t, err)
 	assert.NotNil(t, mr)
 }
@@ -76,7 +79,7 @@ func TestCreateTracesExporter_err(t *testing.T) {
 	cfg.Brokers = []string{"invalid:9092"}
 	cfg.ProtocolVersion = "2.0.0"
 	f := kafkaExporterFactory{tracesMarshalers: tracesMarshalers()}
-	r, err := f.createTracesExporter(context.Background(), componenttest.NewNopExporterCreateSettings(), cfg)
+	r, err := f.createTracesExporter(context.Background(), componenttest.NewNopExporterCreateSettings(defaultID), cfg)
 	// no available broker
 	require.Error(t, err)
 	assert.Nil(t, r)
@@ -87,7 +90,7 @@ func TestCreateMetricsExporter_err(t *testing.T) {
 	cfg.Brokers = []string{"invalid:9092"}
 	cfg.ProtocolVersion = "2.0.0"
 	mf := kafkaExporterFactory{metricsMarshalers: metricsMarshalers()}
-	mr, err := mf.createMetricsExporter(context.Background(), componenttest.NewNopExporterCreateSettings(), cfg)
+	mr, err := mf.createMetricsExporter(context.Background(), componenttest.NewNopExporterCreateSettings(defaultID), cfg)
 	require.Error(t, err)
 	assert.Nil(t, mr)
 }
@@ -97,7 +100,7 @@ func TestCreateLogsExporter_err(t *testing.T) {
 	cfg.Brokers = []string{"invalid:9092"}
 	cfg.ProtocolVersion = "2.0.0"
 	mf := kafkaExporterFactory{logsMarshalers: logsMarshalers()}
-	mr, err := mf.createLogsExporter(context.Background(), componenttest.NewNopExporterCreateSettings(), cfg)
+	mr, err := mf.createLogsExporter(context.Background(), componenttest.NewNopExporterCreateSettings(defaultID), cfg)
 	require.Error(t, err)
 	assert.Nil(t, mr)
 }
@@ -111,13 +114,13 @@ func TestWithMarshalers(t *testing.T) {
 
 	t.Run("custom_encoding", func(t *testing.T) {
 		cfg.Encoding = cm.Encoding()
-		exporter, err := f.CreateTracesExporter(context.Background(), componenttest.NewNopExporterCreateSettings(), cfg)
+		exporter, err := f.CreateTracesExporter(context.Background(), componenttest.NewNopExporterCreateSettings(defaultID), cfg)
 		require.NoError(t, err)
 		require.NotNil(t, exporter)
 	})
 	t.Run("default_encoding", func(t *testing.T) {
 		cfg.Encoding = defaultEncoding
-		exporter, err := f.CreateTracesExporter(context.Background(), componenttest.NewNopExporterCreateSettings(), cfg)
+		exporter, err := f.CreateTracesExporter(context.Background(), componenttest.NewNopExporterCreateSettings(defaultID), cfg)
 		require.NoError(t, err)
 		assert.NotNil(t, exporter)
 	})

--- a/exporter/kafkaexporter/kafka_exporter_test.go
+++ b/exporter/kafkaexporter/kafka_exporter_test.go
@@ -34,56 +34,56 @@ import (
 
 func TestNewExporter_err_version(t *testing.T) {
 	c := Config{ProtocolVersion: "0.0.0", Encoding: defaultEncoding}
-	texp, err := newTracesExporter(c, componenttest.NewNopExporterCreateSettings(), tracesMarshalers())
+	texp, err := newTracesExporter(c, componenttest.NewNopExporterCreateSettings(defaultID), tracesMarshalers())
 	assert.Error(t, err)
 	assert.Nil(t, texp)
 }
 
 func TestNewExporter_err_encoding(t *testing.T) {
 	c := Config{Encoding: "foo"}
-	texp, err := newTracesExporter(c, componenttest.NewNopExporterCreateSettings(), tracesMarshalers())
+	texp, err := newTracesExporter(c, componenttest.NewNopExporterCreateSettings(defaultID), tracesMarshalers())
 	assert.EqualError(t, err, errUnrecognizedEncoding.Error())
 	assert.Nil(t, texp)
 }
 
 func TestNewMetricsExporter_err_version(t *testing.T) {
 	c := Config{ProtocolVersion: "0.0.0", Encoding: defaultEncoding}
-	mexp, err := newMetricsExporter(c, componenttest.NewNopExporterCreateSettings(), metricsMarshalers())
+	mexp, err := newMetricsExporter(c, componenttest.NewNopExporterCreateSettings(defaultID), metricsMarshalers())
 	assert.Error(t, err)
 	assert.Nil(t, mexp)
 }
 
 func TestNewMetricsExporter_err_encoding(t *testing.T) {
 	c := Config{Encoding: "bar"}
-	mexp, err := newMetricsExporter(c, componenttest.NewNopExporterCreateSettings(), metricsMarshalers())
+	mexp, err := newMetricsExporter(c, componenttest.NewNopExporterCreateSettings(defaultID), metricsMarshalers())
 	assert.EqualError(t, err, errUnrecognizedEncoding.Error())
 	assert.Nil(t, mexp)
 }
 
 func TestNewMetricsExporter_err_traces_encoding(t *testing.T) {
 	c := Config{Encoding: "jaeger_proto"}
-	mexp, err := newMetricsExporter(c, componenttest.NewNopExporterCreateSettings(), metricsMarshalers())
+	mexp, err := newMetricsExporter(c, componenttest.NewNopExporterCreateSettings(defaultID), metricsMarshalers())
 	assert.EqualError(t, err, errUnrecognizedEncoding.Error())
 	assert.Nil(t, mexp)
 }
 
 func TestNewLogsExporter_err_version(t *testing.T) {
 	c := Config{ProtocolVersion: "0.0.0", Encoding: defaultEncoding}
-	mexp, err := newLogsExporter(c, componenttest.NewNopExporterCreateSettings(), logsMarshalers())
+	mexp, err := newLogsExporter(c, componenttest.NewNopExporterCreateSettings(defaultID), logsMarshalers())
 	assert.Error(t, err)
 	assert.Nil(t, mexp)
 }
 
 func TestNewLogsExporter_err_encoding(t *testing.T) {
 	c := Config{Encoding: "bar"}
-	mexp, err := newLogsExporter(c, componenttest.NewNopExporterCreateSettings(), logsMarshalers())
+	mexp, err := newLogsExporter(c, componenttest.NewNopExporterCreateSettings(defaultID), logsMarshalers())
 	assert.EqualError(t, err, errUnrecognizedEncoding.Error())
 	assert.Nil(t, mexp)
 }
 
 func TestNewLogsExporter_err_traces_encoding(t *testing.T) {
 	c := Config{Encoding: "jaeger_proto"}
-	mexp, err := newLogsExporter(c, componenttest.NewNopExporterCreateSettings(), logsMarshalers())
+	mexp, err := newLogsExporter(c, componenttest.NewNopExporterCreateSettings(defaultID), logsMarshalers())
 	assert.EqualError(t, err, errUnrecognizedEncoding.Error())
 	assert.Nil(t, mexp)
 }
@@ -103,15 +103,15 @@ func TestNewExporter_err_auth_type(t *testing.T) {
 			Full: false,
 		},
 	}
-	texp, err := newTracesExporter(c, componenttest.NewNopExporterCreateSettings(), tracesMarshalers())
+	texp, err := newTracesExporter(c, componenttest.NewNopExporterCreateSettings(defaultID), tracesMarshalers())
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to load TLS config")
 	assert.Nil(t, texp)
-	mexp, err := newMetricsExporter(c, componenttest.NewNopExporterCreateSettings(), metricsMarshalers())
+	mexp, err := newMetricsExporter(c, componenttest.NewNopExporterCreateSettings(defaultID), metricsMarshalers())
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to load TLS config")
 	assert.Nil(t, mexp)
-	lexp, err := newLogsExporter(c, componenttest.NewNopExporterCreateSettings(), logsMarshalers())
+	lexp, err := newLogsExporter(c, componenttest.NewNopExporterCreateSettings(defaultID), logsMarshalers())
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to load TLS config")
 	assert.Nil(t, lexp)

--- a/exporter/loggingexporter/config_test.go
+++ b/exporter/loggingexporter/config_test.go
@@ -43,7 +43,7 @@ func TestLoadConfig(t *testing.T) {
 	e1 := cfg.Exporters[config.NewIDWithName(typeStr, "2")]
 	assert.Equal(t, e1,
 		&Config{
-			ExporterSettings:   config.NewExporterSettings(config.NewIDWithName(typeStr, "2")),
+			ExporterSettings:   config.NewExporterSettings(),
 			LogLevel:           "debug",
 			SamplingInitial:    10,
 			SamplingThereafter: 50,

--- a/exporter/loggingexporter/factory.go
+++ b/exporter/loggingexporter/factory.go
@@ -44,7 +44,7 @@ func NewFactory() component.ExporterFactory {
 
 func createDefaultConfig() config.Exporter {
 	return &Config{
-		ExporterSettings:   config.NewExporterSettings(config.NewID(typeStr)),
+		ExporterSettings:   config.NewExporterSettings(),
 		LogLevel:           "info",
 		SamplingInitial:    defaultSamplingInitial,
 		SamplingThereafter: defaultSamplingThereafter,

--- a/exporter/loggingexporter/factory_test.go
+++ b/exporter/loggingexporter/factory_test.go
@@ -21,8 +21,11 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/configcheck"
 )
+
+var defaultID = config.NewID(typeStr)
 
 func TestCreateDefaultConfig(t *testing.T) {
 	factory := NewFactory()
@@ -35,7 +38,7 @@ func TestCreateMetricsExporter(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
 
-	me, err := factory.CreateMetricsExporter(context.Background(), componenttest.NewNopExporterCreateSettings(), cfg)
+	me, err := factory.CreateMetricsExporter(context.Background(), componenttest.NewNopExporterCreateSettings(defaultID), cfg)
 	assert.NoError(t, err)
 	assert.NotNil(t, me)
 }
@@ -44,7 +47,7 @@ func TestCreateTracesExporter(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
 
-	te, err := factory.CreateTracesExporter(context.Background(), componenttest.NewNopExporterCreateSettings(), cfg)
+	te, err := factory.CreateTracesExporter(context.Background(), componenttest.NewNopExporterCreateSettings(defaultID), cfg)
 	assert.NoError(t, err)
 	assert.NotNil(t, te)
 }
@@ -53,7 +56,7 @@ func TestCreateLogsExporter(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
 
-	te, err := factory.CreateLogsExporter(context.Background(), componenttest.NewNopExporterCreateSettings(), cfg)
+	te, err := factory.CreateLogsExporter(context.Background(), componenttest.NewNopExporterCreateSettings(defaultID), cfg)
 	assert.NoError(t, err)
 	assert.NotNil(t, te)
 }

--- a/exporter/loggingexporter/logging_exporter_test.go
+++ b/exporter/loggingexporter/logging_exporter_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 func TestLoggingTracesExporterNoErrors(t *testing.T) {
-	lte, err := newTracesExporter(&config.ExporterSettings{}, "Debug", zap.NewNop(), componenttest.NewNopExporterCreateSettings())
+	lte, err := newTracesExporter(&config.ExporterSettings{}, "Debug", zap.NewNop(), componenttest.NewNopExporterCreateSettings(defaultID))
 	require.NotNil(t, lte)
 	assert.NoError(t, err)
 
@@ -40,7 +40,7 @@ func TestLoggingTracesExporterNoErrors(t *testing.T) {
 }
 
 func TestLoggingMetricsExporterNoErrors(t *testing.T) {
-	lme, err := newMetricsExporter(&config.ExporterSettings{}, "DEBUG", zap.NewNop(), componenttest.NewNopExporterCreateSettings())
+	lme, err := newMetricsExporter(&config.ExporterSettings{}, "DEBUG", zap.NewNop(), componenttest.NewNopExporterCreateSettings(defaultID))
 	require.NotNil(t, lme)
 	assert.NoError(t, err)
 
@@ -53,7 +53,7 @@ func TestLoggingMetricsExporterNoErrors(t *testing.T) {
 }
 
 func TestLoggingLogsExporterNoErrors(t *testing.T) {
-	lle, err := newLogsExporter(&config.ExporterSettings{}, "debug", zap.NewNop(), componenttest.NewNopExporterCreateSettings())
+	lle, err := newLogsExporter(&config.ExporterSettings{}, "debug", zap.NewNop(), componenttest.NewNopExporterCreateSettings(defaultID))
 	require.NotNil(t, lle)
 	assert.NoError(t, err)
 

--- a/exporter/opencensusexporter/config_test.go
+++ b/exporter/opencensusexporter/config_test.go
@@ -47,7 +47,7 @@ func TestLoadConfig(t *testing.T) {
 	e1 := cfg.Exporters[config.NewIDWithName(typeStr, "2")]
 	assert.Equal(t, e1,
 		&Config{
-			ExporterSettings: config.NewExporterSettings(config.NewIDWithName(typeStr, "2")),
+			ExporterSettings: config.NewExporterSettings(),
 			RetrySettings: exporterhelper.RetrySettings{
 				Enabled:         true,
 				InitialInterval: 10 * time.Second,

--- a/exporter/opencensusexporter/factory.go
+++ b/exporter/opencensusexporter/factory.go
@@ -24,10 +24,8 @@ import (
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 )
 
-const (
-	// The value of "type" key in configuration.
-	typeStr = "opencensus"
-)
+// The value of "type" key in configuration.
+const typeStr = "opencensus"
 
 // NewFactory creates a factory for OTLP exporter.
 func NewFactory() component.ExporterFactory {
@@ -40,7 +38,7 @@ func NewFactory() component.ExporterFactory {
 
 func createDefaultConfig() config.Exporter {
 	return &Config{
-		ExporterSettings: config.NewExporterSettings(config.NewID(typeStr)),
+		ExporterSettings: config.NewExporterSettings(),
 		GRPCClientSettings: configgrpc.GRPCClientSettings{
 			Headers: map[string]string{},
 			// We almost read 0 bytes, so no need to tune ReadBufferSize.

--- a/exporter/opencensusexporter/factory_test.go
+++ b/exporter/opencensusexporter/factory_test.go
@@ -31,6 +31,8 @@ import (
 	"go.opentelemetry.io/collector/testutil"
 )
 
+var defaultID = config.NewID(typeStr)
+
 func TestCreateDefaultConfig(t *testing.T) {
 	cfg := createDefaultConfig()
 	assert.NotNil(t, cfg, "failed to create default config")
@@ -48,7 +50,7 @@ func TestCreateTracesExporter(t *testing.T) {
 		{
 			name: "NoEndpoint",
 			config: Config{
-				ExporterSettings: config.NewExporterSettings(config.NewID(typeStr)),
+				ExporterSettings: config.NewExporterSettings(),
 				GRPCClientSettings: configgrpc.GRPCClientSettings{
 					Endpoint: "",
 				},
@@ -59,7 +61,7 @@ func TestCreateTracesExporter(t *testing.T) {
 		{
 			name: "ZeroNumWorkers",
 			config: Config{
-				ExporterSettings: config.NewExporterSettings(config.NewID(typeStr)),
+				ExporterSettings: config.NewExporterSettings(),
 				GRPCClientSettings: configgrpc.GRPCClientSettings{
 					Endpoint: endpoint,
 					TLSSetting: configtls.TLSClientSetting{
@@ -73,7 +75,7 @@ func TestCreateTracesExporter(t *testing.T) {
 		{
 			name: "UseSecure",
 			config: Config{
-				ExporterSettings: config.NewExporterSettings(config.NewID(typeStr)),
+				ExporterSettings: config.NewExporterSettings(),
 				GRPCClientSettings: configgrpc.GRPCClientSettings{
 					Endpoint: endpoint,
 					TLSSetting: configtls.TLSClientSetting{
@@ -86,7 +88,7 @@ func TestCreateTracesExporter(t *testing.T) {
 		{
 			name: "Keepalive",
 			config: Config{
-				ExporterSettings: config.NewExporterSettings(config.NewID(typeStr)),
+				ExporterSettings: config.NewExporterSettings(),
 				GRPCClientSettings: configgrpc.GRPCClientSettings{
 					Endpoint: endpoint,
 					Keepalive: &configgrpc.KeepaliveClientConfig{
@@ -101,7 +103,7 @@ func TestCreateTracesExporter(t *testing.T) {
 		{
 			name: "Compression",
 			config: Config{
-				ExporterSettings: config.NewExporterSettings(config.NewID(typeStr)),
+				ExporterSettings: config.NewExporterSettings(),
 				GRPCClientSettings: configgrpc.GRPCClientSettings{
 					Endpoint:    endpoint,
 					Compression: configgrpc.CompressionGzip,
@@ -112,7 +114,7 @@ func TestCreateTracesExporter(t *testing.T) {
 		{
 			name: "Headers",
 			config: Config{
-				ExporterSettings: config.NewExporterSettings(config.NewID(typeStr)),
+				ExporterSettings: config.NewExporterSettings(),
 				GRPCClientSettings: configgrpc.GRPCClientSettings{
 					Endpoint: endpoint,
 					Headers: map[string]string{
@@ -126,7 +128,7 @@ func TestCreateTracesExporter(t *testing.T) {
 		{
 			name: "CompressionError",
 			config: Config{
-				ExporterSettings: config.NewExporterSettings(config.NewID(typeStr)),
+				ExporterSettings: config.NewExporterSettings(),
 				GRPCClientSettings: configgrpc.GRPCClientSettings{
 					Endpoint:    endpoint,
 					Compression: "unknown compression",
@@ -139,7 +141,7 @@ func TestCreateTracesExporter(t *testing.T) {
 		{
 			name: "CaCert",
 			config: Config{
-				ExporterSettings: config.NewExporterSettings(config.NewID(typeStr)),
+				ExporterSettings: config.NewExporterSettings(),
 				GRPCClientSettings: configgrpc.GRPCClientSettings{
 					Endpoint: endpoint,
 					TLSSetting: configtls.TLSClientSetting{
@@ -154,7 +156,7 @@ func TestCreateTracesExporter(t *testing.T) {
 		{
 			name: "CertPemFileError",
 			config: Config{
-				ExporterSettings: config.NewExporterSettings(config.NewID(typeStr)),
+				ExporterSettings: config.NewExporterSettings(),
 				GRPCClientSettings: configgrpc.GRPCClientSettings{
 					Endpoint: endpoint,
 					TLSSetting: configtls.TLSClientSetting{
@@ -172,7 +174,7 @@ func TestCreateTracesExporter(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			set := componenttest.NewNopExporterCreateSettings()
+			set := componenttest.NewNopExporterCreateSettings(defaultID)
 			tExporter, tErr := createTracesExporter(context.Background(), set, &tt.config)
 			checkErrorsAndStartAndShutdown(t, tExporter, tErr, tt.mustFailOnCreate, tt.mustFailOnStart)
 			mExporter, mErr := createMetricsExporter(context.Background(), set, &tt.config)

--- a/exporter/opencensusexporter/opencensus_test.go
+++ b/exporter/opencensusexporter/opencensus_test.go
@@ -54,7 +54,7 @@ func TestSendTraces(t *testing.T) {
 		},
 	}
 	cfg.NumWorkers = 1
-	exp, err := factory.CreateTracesExporter(context.Background(), componenttest.NewNopExporterCreateSettings(), cfg)
+	exp, err := factory.CreateTracesExporter(context.Background(), componenttest.NewNopExporterCreateSettings(defaultID), cfg)
 	require.NoError(t, err)
 	require.NotNil(t, exp)
 	host := componenttest.NewNopHost()
@@ -94,7 +94,7 @@ func TestSendTraces_NoBackend(t *testing.T) {
 			Insecure: true,
 		},
 	}
-	exp, err := factory.CreateTracesExporter(context.Background(), componenttest.NewNopExporterCreateSettings(), cfg)
+	exp, err := factory.CreateTracesExporter(context.Background(), componenttest.NewNopExporterCreateSettings(defaultID), cfg)
 	require.NoError(t, err)
 	require.NotNil(t, exp)
 	host := componenttest.NewNopHost()
@@ -118,7 +118,7 @@ func TestSendTraces_AfterStop(t *testing.T) {
 			Insecure: true,
 		},
 	}
-	exp, err := factory.CreateTracesExporter(context.Background(), componenttest.NewNopExporterCreateSettings(), cfg)
+	exp, err := factory.CreateTracesExporter(context.Background(), componenttest.NewNopExporterCreateSettings(defaultID), cfg)
 	require.NoError(t, err)
 	require.NotNil(t, exp)
 	host := componenttest.NewNopHost()
@@ -152,7 +152,7 @@ func TestSendMetrics(t *testing.T) {
 		},
 	}
 	cfg.NumWorkers = 1
-	exp, err := factory.CreateMetricsExporter(context.Background(), componenttest.NewNopExporterCreateSettings(), cfg)
+	exp, err := factory.CreateMetricsExporter(context.Background(), componenttest.NewNopExporterCreateSettings(defaultID), cfg)
 	require.NoError(t, err)
 	require.NotNil(t, exp)
 	host := componenttest.NewNopHost()
@@ -191,7 +191,7 @@ func TestSendMetrics_NoBackend(t *testing.T) {
 			Insecure: true,
 		},
 	}
-	exp, err := factory.CreateMetricsExporter(context.Background(), componenttest.NewNopExporterCreateSettings(), cfg)
+	exp, err := factory.CreateMetricsExporter(context.Background(), componenttest.NewNopExporterCreateSettings(defaultID), cfg)
 	require.NoError(t, err)
 	require.NotNil(t, exp)
 	host := componenttest.NewNopHost()
@@ -215,7 +215,7 @@ func TestSendMetrics_AfterStop(t *testing.T) {
 			Insecure: true,
 		},
 	}
-	exp, err := factory.CreateMetricsExporter(context.Background(), componenttest.NewNopExporterCreateSettings(), cfg)
+	exp, err := factory.CreateMetricsExporter(context.Background(), componenttest.NewNopExporterCreateSettings(defaultID), cfg)
 	require.NoError(t, err)
 	require.NotNil(t, exp)
 	host := componenttest.NewNopHost()

--- a/exporter/otlpexporter/config_test.go
+++ b/exporter/otlpexporter/config_test.go
@@ -54,7 +54,7 @@ func TestLoadConfig(t *testing.T) {
 	e1 := cfg.Exporters[config.NewIDWithName(typeStr, "2")]
 	assert.Equal(t, e1,
 		&Config{
-			ExporterSettings: config.NewExporterSettings(config.NewIDWithName(typeStr, "2")),
+			ExporterSettings: config.NewExporterSettings(),
 			TimeoutSettings: exporterhelper.TimeoutSettings{
 				Timeout: 10 * time.Second,
 			},

--- a/exporter/otlpexporter/factory.go
+++ b/exporter/otlpexporter/factory.go
@@ -41,7 +41,7 @@ func NewFactory() component.ExporterFactory {
 
 func createDefaultConfig() config.Exporter {
 	return &Config{
-		ExporterSettings: config.NewExporterSettings(config.NewID(typeStr)),
+		ExporterSettings: config.NewExporterSettings(),
 		TimeoutSettings:  exporterhelper.DefaultTimeoutSettings(),
 		RetrySettings:    exporterhelper.DefaultRetrySettings(),
 		QueueSettings:    exporterhelper.DefaultQueueSettings(),

--- a/exporter/otlpexporter/factory_test.go
+++ b/exporter/otlpexporter/factory_test.go
@@ -31,6 +31,8 @@ import (
 	"go.opentelemetry.io/collector/testutil"
 )
 
+var defaultID = config.NewID(typeStr)
+
 func TestCreateDefaultConfig(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
@@ -48,7 +50,7 @@ func TestCreateMetricsExporter(t *testing.T) {
 	cfg := factory.CreateDefaultConfig().(*Config)
 	cfg.GRPCClientSettings.Endpoint = testutil.GetAvailableLocalAddress(t)
 
-	set := componenttest.NewNopExporterCreateSettings()
+	set := componenttest.NewNopExporterCreateSettings(defaultID)
 	oexp, err := factory.CreateMetricsExporter(context.Background(), set, cfg)
 	require.Nil(t, err)
 	require.NotNil(t, oexp)
@@ -65,7 +67,7 @@ func TestCreateTracesExporter(t *testing.T) {
 		{
 			name: "NoEndpoint",
 			config: Config{
-				ExporterSettings: config.NewExporterSettings(config.NewID(typeStr)),
+				ExporterSettings: config.NewExporterSettings(),
 				GRPCClientSettings: configgrpc.GRPCClientSettings{
 					Endpoint: "",
 				},
@@ -75,7 +77,7 @@ func TestCreateTracesExporter(t *testing.T) {
 		{
 			name: "UseSecure",
 			config: Config{
-				ExporterSettings: config.NewExporterSettings(config.NewID(typeStr)),
+				ExporterSettings: config.NewExporterSettings(),
 				GRPCClientSettings: configgrpc.GRPCClientSettings{
 					Endpoint: endpoint,
 					TLSSetting: configtls.TLSClientSetting{
@@ -87,7 +89,7 @@ func TestCreateTracesExporter(t *testing.T) {
 		{
 			name: "Keepalive",
 			config: Config{
-				ExporterSettings: config.NewExporterSettings(config.NewID(typeStr)),
+				ExporterSettings: config.NewExporterSettings(),
 				GRPCClientSettings: configgrpc.GRPCClientSettings{
 					Endpoint: endpoint,
 					Keepalive: &configgrpc.KeepaliveClientConfig{
@@ -101,7 +103,7 @@ func TestCreateTracesExporter(t *testing.T) {
 		{
 			name: "Compression",
 			config: Config{
-				ExporterSettings: config.NewExporterSettings(config.NewID(typeStr)),
+				ExporterSettings: config.NewExporterSettings(),
 				GRPCClientSettings: configgrpc.GRPCClientSettings{
 					Endpoint:    endpoint,
 					Compression: configgrpc.CompressionGzip,
@@ -111,7 +113,7 @@ func TestCreateTracesExporter(t *testing.T) {
 		{
 			name: "Headers",
 			config: Config{
-				ExporterSettings: config.NewExporterSettings(config.NewID(typeStr)),
+				ExporterSettings: config.NewExporterSettings(),
 				GRPCClientSettings: configgrpc.GRPCClientSettings{
 					Endpoint: endpoint,
 					Headers: map[string]string{
@@ -124,7 +126,7 @@ func TestCreateTracesExporter(t *testing.T) {
 		{
 			name: "NumConsumers",
 			config: Config{
-				ExporterSettings: config.NewExporterSettings(config.NewID(typeStr)),
+				ExporterSettings: config.NewExporterSettings(),
 				GRPCClientSettings: configgrpc.GRPCClientSettings{
 					Endpoint: endpoint,
 				},
@@ -133,7 +135,7 @@ func TestCreateTracesExporter(t *testing.T) {
 		{
 			name: "CompressionError",
 			config: Config{
-				ExporterSettings: config.NewExporterSettings(config.NewID(typeStr)),
+				ExporterSettings: config.NewExporterSettings(),
 				GRPCClientSettings: configgrpc.GRPCClientSettings{
 					Endpoint:    endpoint,
 					Compression: "unknown compression",
@@ -144,7 +146,7 @@ func TestCreateTracesExporter(t *testing.T) {
 		{
 			name: "CaCert",
 			config: Config{
-				ExporterSettings: config.NewExporterSettings(config.NewID(typeStr)),
+				ExporterSettings: config.NewExporterSettings(),
 				GRPCClientSettings: configgrpc.GRPCClientSettings{
 					Endpoint: endpoint,
 					TLSSetting: configtls.TLSClientSetting{
@@ -158,7 +160,7 @@ func TestCreateTracesExporter(t *testing.T) {
 		{
 			name: "CertPemFileError",
 			config: Config{
-				ExporterSettings: config.NewExporterSettings(config.NewID(typeStr)),
+				ExporterSettings: config.NewExporterSettings(),
 				GRPCClientSettings: configgrpc.GRPCClientSettings{
 					Endpoint: endpoint,
 					TLSSetting: configtls.TLSClientSetting{
@@ -175,7 +177,7 @@ func TestCreateTracesExporter(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			factory := NewFactory()
-			set := componenttest.NewNopExporterCreateSettings()
+			set := componenttest.NewNopExporterCreateSettings(defaultID)
 			consumer, err := factory.CreateTracesExporter(context.Background(), set, &tt.config)
 			if tt.mustFailOnCreate {
 				assert.NotNil(t, err)
@@ -204,7 +206,7 @@ func TestCreateLogsExporter(t *testing.T) {
 	cfg := factory.CreateDefaultConfig().(*Config)
 	cfg.GRPCClientSettings.Endpoint = testutil.GetAvailableLocalAddress(t)
 
-	set := componenttest.NewNopExporterCreateSettings()
+	set := componenttest.NewNopExporterCreateSettings(defaultID)
 	oexp, err := factory.CreateLogsExporter(context.Background(), set, cfg)
 	require.Nil(t, err)
 	require.NotNil(t, oexp)

--- a/exporter/otlpexporter/otlp_test.go
+++ b/exporter/otlpexporter/otlp_test.go
@@ -199,7 +199,7 @@ func TestSendTraces(t *testing.T) {
 			"header": "header-value",
 		},
 	}
-	set := componenttest.NewNopExporterCreateSettings()
+	set := componenttest.NewNopExporterCreateSettings(defaultID)
 	exp, err := factory.CreateTracesExporter(context.Background(), set, cfg)
 	require.NoError(t, err)
 	require.NotNil(t, exp)
@@ -290,7 +290,7 @@ func TestSendTracesWhenEndpointHasHttpScheme(t *testing.T) {
 			if test.useTLS {
 				cfg.GRPCClientSettings.TLSSetting.InsecureSkipVerify = true
 			}
-			set := componenttest.NewNopExporterCreateSettings()
+			set := componenttest.NewNopExporterCreateSettings(defaultID)
 			exp, err := factory.CreateTracesExporter(context.Background(), set, cfg)
 			require.NoError(t, err)
 			require.NotNil(t, exp)
@@ -340,7 +340,7 @@ func TestSendMetrics(t *testing.T) {
 			"header": "header-value",
 		},
 	}
-	set := componenttest.NewNopExporterCreateSettings()
+	set := componenttest.NewNopExporterCreateSettings(defaultID)
 	exp, err := factory.CreateMetricsExporter(context.Background(), set, cfg)
 	require.NoError(t, err)
 	require.NotNil(t, exp)
@@ -408,7 +408,7 @@ func TestSendTraceDataServerDownAndUp(t *testing.T) {
 		// Do not rely on external retry logic here, if that is intended set InitialInterval to 100ms.
 		WaitForReady: true,
 	}
-	set := componenttest.NewNopExporterCreateSettings()
+	set := componenttest.NewNopExporterCreateSettings(defaultID)
 	exp, err := factory.CreateTracesExporter(context.Background(), set, cfg)
 	require.NoError(t, err)
 	require.NotNil(t, exp)
@@ -465,7 +465,7 @@ func TestSendTraceDataServerStartWhileRequest(t *testing.T) {
 			Insecure: true,
 		},
 	}
-	set := componenttest.NewNopExporterCreateSettings()
+	set := componenttest.NewNopExporterCreateSettings(defaultID)
 	exp, err := factory.CreateTracesExporter(context.Background(), set, cfg)
 	require.NoError(t, err)
 	require.NotNil(t, exp)
@@ -541,7 +541,7 @@ func TestSendLogData(t *testing.T) {
 			Insecure: true,
 		},
 	}
-	set := componenttest.NewNopExporterCreateSettings()
+	set := componenttest.NewNopExporterCreateSettings(defaultID)
 	exp, err := factory.CreateLogsExporter(context.Background(), set, cfg)
 	require.NoError(t, err)
 	require.NotNil(t, exp)

--- a/exporter/otlphttpexporter/config_test.go
+++ b/exporter/otlphttpexporter/config_test.go
@@ -47,7 +47,7 @@ func TestLoadConfig(t *testing.T) {
 	e1 := cfg.Exporters[config.NewIDWithName(typeStr, "2")]
 	assert.Equal(t, e1,
 		&Config{
-			ExporterSettings: config.NewExporterSettings(config.NewIDWithName(typeStr, "2")),
+			ExporterSettings: config.NewExporterSettings(),
 			RetrySettings: exporterhelper.RetrySettings{
 				Enabled:         true,
 				InitialInterval: 10 * time.Second,

--- a/exporter/otlphttpexporter/factory.go
+++ b/exporter/otlphttpexporter/factory.go
@@ -44,7 +44,7 @@ func NewFactory() component.ExporterFactory {
 
 func createDefaultConfig() config.Exporter {
 	return &Config{
-		ExporterSettings: config.NewExporterSettings(config.NewID(typeStr)),
+		ExporterSettings: config.NewExporterSettings(),
 		RetrySettings:    exporterhelper.DefaultRetrySettings(),
 		QueueSettings:    exporterhelper.DefaultQueueSettings(),
 		HTTPClientSettings: confighttp.HTTPClientSettings{

--- a/exporter/otlphttpexporter/factory_test.go
+++ b/exporter/otlphttpexporter/factory_test.go
@@ -30,6 +30,8 @@ import (
 	"go.opentelemetry.io/collector/testutil"
 )
 
+var defaultID = config.NewID(typeStr)
+
 func TestCreateDefaultConfig(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
@@ -51,7 +53,7 @@ func TestCreateMetricsExporter(t *testing.T) {
 	cfg := factory.CreateDefaultConfig().(*Config)
 	cfg.HTTPClientSettings.Endpoint = "http://" + testutil.GetAvailableLocalAddress(t)
 
-	set := componenttest.NewNopExporterCreateSettings()
+	set := componenttest.NewNopExporterCreateSettings(defaultID)
 	oexp, err := factory.CreateMetricsExporter(context.Background(), set, cfg)
 	require.Nil(t, err)
 	require.NotNil(t, oexp)
@@ -69,7 +71,7 @@ func TestCreateTracesExporter(t *testing.T) {
 		{
 			name: "NoEndpoint",
 			config: Config{
-				ExporterSettings: config.NewExporterSettings(config.NewID(typeStr)),
+				ExporterSettings: config.NewExporterSettings(),
 				HTTPClientSettings: confighttp.HTTPClientSettings{
 					Endpoint: "",
 				},
@@ -79,7 +81,7 @@ func TestCreateTracesExporter(t *testing.T) {
 		{
 			name: "UseSecure",
 			config: Config{
-				ExporterSettings: config.NewExporterSettings(config.NewID(typeStr)),
+				ExporterSettings: config.NewExporterSettings(),
 				HTTPClientSettings: confighttp.HTTPClientSettings{
 					Endpoint: endpoint,
 					TLSSetting: configtls.TLSClientSetting{
@@ -91,7 +93,7 @@ func TestCreateTracesExporter(t *testing.T) {
 		{
 			name: "Headers",
 			config: Config{
-				ExporterSettings: config.NewExporterSettings(config.NewID(typeStr)),
+				ExporterSettings: config.NewExporterSettings(),
 				HTTPClientSettings: confighttp.HTTPClientSettings{
 					Endpoint: endpoint,
 					Headers: map[string]string{
@@ -104,7 +106,7 @@ func TestCreateTracesExporter(t *testing.T) {
 		{
 			name: "CaCert",
 			config: Config{
-				ExporterSettings: config.NewExporterSettings(config.NewID(typeStr)),
+				ExporterSettings: config.NewExporterSettings(),
 				HTTPClientSettings: confighttp.HTTPClientSettings{
 					Endpoint: endpoint,
 					TLSSetting: configtls.TLSClientSetting{
@@ -118,7 +120,7 @@ func TestCreateTracesExporter(t *testing.T) {
 		{
 			name: "CertPemFileError",
 			config: Config{
-				ExporterSettings: config.NewExporterSettings(config.NewID(typeStr)),
+				ExporterSettings: config.NewExporterSettings(),
 				HTTPClientSettings: confighttp.HTTPClientSettings{
 					Endpoint: endpoint,
 					TLSSetting: configtls.TLSClientSetting{
@@ -136,7 +138,7 @@ func TestCreateTracesExporter(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			factory := NewFactory()
-			set := componenttest.NewNopExporterCreateSettings()
+			set := componenttest.NewNopExporterCreateSettings(defaultID)
 			consumer, err := factory.CreateTracesExporter(context.Background(), set, &tt.config)
 
 			if tt.mustFailOnCreate {
@@ -165,7 +167,7 @@ func TestCreateLogsExporter(t *testing.T) {
 	cfg := factory.CreateDefaultConfig().(*Config)
 	cfg.HTTPClientSettings.Endpoint = "http://" + testutil.GetAvailableLocalAddress(t)
 
-	set := componenttest.NewNopExporterCreateSettings()
+	set := componenttest.NewNopExporterCreateSettings(defaultID)
 	oexp, err := factory.CreateLogsExporter(context.Background(), set, cfg)
 	require.Nil(t, err)
 	require.NotNil(t, oexp)

--- a/exporter/otlphttpexporter/otlp_test.go
+++ b/exporter/otlphttpexporter/otlp_test.go
@@ -50,7 +50,7 @@ func TestInvalidConfig(t *testing.T) {
 		},
 	}
 	f := NewFactory()
-	set := componenttest.NewNopExporterCreateSettings()
+	set := componenttest.NewNopExporterCreateSettings(defaultID)
 	_, err := f.CreateTracesExporter(context.Background(), set, config)
 	require.Error(t, err)
 	_, err = f.CreateMetricsExporter(context.Background(), set, config)
@@ -164,7 +164,7 @@ func TestCompressionOptions(t *testing.T) {
 			factory := NewFactory()
 			cfg := createExporterConfig(test.baseURL, factory.CreateDefaultConfig())
 			cfg.Compression = test.compression
-			exp, _ := factory.CreateTracesExporter(context.Background(), componenttest.NewNopExporterCreateSettings(), cfg)
+			exp, _ := factory.CreateTracesExporter(context.Background(), componenttest.NewNopExporterCreateSettings(defaultID), cfg)
 			err := exp.Start(context.Background(), componenttest.NewNopHost())
 			t.Cleanup(func() {
 				require.NoError(t, exp.Shutdown(context.Background()))
@@ -296,7 +296,7 @@ func startTracesExporter(t *testing.T, baseURL string, overrideURL string) compo
 	factory := NewFactory()
 	cfg := createExporterConfig(baseURL, factory.CreateDefaultConfig())
 	cfg.TracesEndpoint = overrideURL
-	exp, err := factory.CreateTracesExporter(context.Background(), componenttest.NewNopExporterCreateSettings(), cfg)
+	exp, err := factory.CreateTracesExporter(context.Background(), componenttest.NewNopExporterCreateSettings(defaultID), cfg)
 	require.NoError(t, err)
 	startAndCleanup(t, exp)
 	return exp
@@ -306,7 +306,7 @@ func startMetricsExporter(t *testing.T, baseURL string, overrideURL string) comp
 	factory := NewFactory()
 	cfg := createExporterConfig(baseURL, factory.CreateDefaultConfig())
 	cfg.MetricsEndpoint = overrideURL
-	exp, err := factory.CreateMetricsExporter(context.Background(), componenttest.NewNopExporterCreateSettings(), cfg)
+	exp, err := factory.CreateMetricsExporter(context.Background(), componenttest.NewNopExporterCreateSettings(defaultID), cfg)
 	require.NoError(t, err)
 	startAndCleanup(t, exp)
 	return exp
@@ -316,7 +316,7 @@ func startLogsExporter(t *testing.T, baseURL string, overrideURL string) compone
 	factory := NewFactory()
 	cfg := createExporterConfig(baseURL, factory.CreateDefaultConfig())
 	cfg.LogsEndpoint = overrideURL
-	exp, err := factory.CreateLogsExporter(context.Background(), componenttest.NewNopExporterCreateSettings(), cfg)
+	exp, err := factory.CreateLogsExporter(context.Background(), componenttest.NewNopExporterCreateSettings(defaultID), cfg)
 	require.NoError(t, err)
 	startAndCleanup(t, exp)
 	return exp
@@ -444,12 +444,12 @@ func TestErrorResponses(t *testing.T) {
 			}()
 
 			cfg := &Config{
-				ExporterSettings: config.NewExporterSettings(config.NewID(typeStr)),
+				ExporterSettings: config.NewExporterSettings(),
 				TracesEndpoint:   fmt.Sprintf("http://%s/v1/traces", addr),
 				// Create without QueueSettings and RetrySettings so that ConsumeTraces
 				// returns the errors that we want to check immediately.
 			}
-			exp, err := createTracesExporter(context.Background(), componenttest.NewNopExporterCreateSettings(), cfg)
+			exp, err := createTracesExporter(context.Background(), componenttest.NewNopExporterCreateSettings(defaultID), cfg)
 			require.NoError(t, err)
 
 			// start the exporter

--- a/exporter/prometheusexporter/config_test.go
+++ b/exporter/prometheusexporter/config_test.go
@@ -44,7 +44,7 @@ func TestLoadConfig(t *testing.T) {
 	e1 := cfg.Exporters[config.NewIDWithName(typeStr, "2")]
 	assert.Equal(t, e1,
 		&Config{
-			ExporterSettings: config.NewExporterSettings(config.NewIDWithName(typeStr, "2")),
+			ExporterSettings: config.NewExporterSettings(),
 			Endpoint:         "1.2.3.4:1234",
 			Namespace:        "test-space",
 			ConstLabels: map[string]string{

--- a/exporter/prometheusexporter/end_to_end_test.go
+++ b/exporter/prometheusexporter/end_to_end_test.go
@@ -66,14 +66,14 @@ func TestEndToEndSummarySupport(t *testing.T) {
 
 	// 2. Create the Prometheus metrics exporter that'll receive and verify the metrics produced.
 	exporterCfg := &Config{
-		ExporterSettings: config.NewExporterSettings(config.NewID(typeStr)),
+		ExporterSettings: config.NewExporterSettings(),
 		Namespace:        "test",
 		Endpoint:         ":8787",
 		SendTimestamps:   true,
 		MetricExpiration: 2 * time.Hour,
 	}
 	exporterFactory := NewFactory()
-	set := componenttest.NewNopExporterCreateSettings()
+	set := componenttest.NewNopExporterCreateSettings(defaultID)
 	exporter, err := exporterFactory.CreateMetricsExporter(ctx, set, exporterCfg)
 	if err != nil {
 		t.Fatal(err)

--- a/exporter/prometheusexporter/factory.go
+++ b/exporter/prometheusexporter/factory.go
@@ -39,7 +39,7 @@ func NewFactory() component.ExporterFactory {
 
 func createDefaultConfig() config.Exporter {
 	return &Config{
-		ExporterSettings: config.NewExporterSettings(config.NewID(typeStr)),
+		ExporterSettings: config.NewExporterSettings(),
 		ConstLabels:      map[string]string{},
 		SendTimestamps:   false,
 		MetricExpiration: time.Minute * 5,

--- a/exporter/prometheusexporter/factory_test.go
+++ b/exporter/prometheusexporter/factory_test.go
@@ -22,8 +22,11 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/configcheck"
 )
+
+var defaultID = config.NewID(typeStr)
 
 func TestCreateDefaultConfig(t *testing.T) {
 	cfg := createDefaultConfig()
@@ -37,7 +40,7 @@ func TestCreateMetricsExporter(t *testing.T) {
 	oCfg.Endpoint = ""
 	exp, err := createMetricsExporter(
 		context.Background(),
-		componenttest.NewNopExporterCreateSettings(),
+		componenttest.NewNopExporterCreateSettings(defaultID),
 		cfg)
 	require.Equal(t, errBlankPrometheusAddress, err)
 	require.Nil(t, exp)
@@ -49,7 +52,7 @@ func TestCreateMetricsExporterExportHelperError(t *testing.T) {
 
 	cfg.Endpoint = "http://localhost:8889"
 
-	set := componenttest.NewNopExporterCreateSettings()
+	set := componenttest.NewNopExporterCreateSettings(defaultID)
 	set.Logger = nil
 
 	// Should give us an exporterhelper.errNilLogger

--- a/exporter/prometheusexporter/prometheus.go
+++ b/exporter/prometheusexporter/prometheus.go
@@ -31,7 +31,6 @@ import (
 )
 
 type prometheusExporter struct {
-	name         string
 	endpoint     string
 	shutdownFunc func() error
 	handler      http.Handler
@@ -50,7 +49,6 @@ func newPrometheusExporter(config *Config, set component.ExporterCreateSettings)
 
 	obsrep := obsreport.NewExporter(obsreport.ExporterSettings{
 		Level:                  configtelemetry.GetMetricsLevelFlagValue(),
-		ExporterID:             config.ID(),
 		ExporterCreateSettings: set,
 	})
 
@@ -59,7 +57,6 @@ func newPrometheusExporter(config *Config, set component.ExporterCreateSettings)
 	_ = registry.Register(collector)
 
 	return &prometheusExporter{
-		name:         config.ID().String(),
 		endpoint:     addr,
 		collector:    collector,
 		registry:     registry,

--- a/exporter/prometheusexporter/prometheus_test.go
+++ b/exporter/prometheusexporter/prometheus_test.go
@@ -41,7 +41,7 @@ func TestPrometheusExporter(t *testing.T) {
 	}{
 		{
 			config: &Config{
-				ExporterSettings: config.NewExporterSettings(config.NewID(typeStr)),
+				ExporterSettings: config.NewExporterSettings(),
 				Namespace:        "test",
 				ConstLabels: map[string]string{
 					"foo0":  "bar0",
@@ -54,21 +54,21 @@ func TestPrometheusExporter(t *testing.T) {
 		},
 		{
 			config: &Config{
-				ExporterSettings: config.NewExporterSettings(config.NewID(typeStr)),
+				ExporterSettings: config.NewExporterSettings(),
 				Endpoint:         ":88999",
 			},
 			wantStartErr: "listen tcp: address 88999: invalid port",
 		},
 		{
 			config: &Config{
-				ExporterSettings: config.NewExporterSettings(config.NewID(typeStr)),
+				ExporterSettings: config.NewExporterSettings(),
 			},
 			wantErr: "expecting a non-blank address to run the Prometheus metrics handler",
 		},
 	}
 
 	factory := NewFactory()
-	set := componenttest.NewNopExporterCreateSettings()
+	set := componenttest.NewNopExporterCreateSettings(defaultID)
 	for _, tt := range tests {
 		// Run it a few times to ensure that shutdowns exit cleanly.
 		for j := 0; j < 3; j++ {
@@ -99,7 +99,7 @@ func TestPrometheusExporter(t *testing.T) {
 
 func TestPrometheusExporter_endToEnd(t *testing.T) {
 	cfg := &Config{
-		ExporterSettings: config.NewExporterSettings(config.NewID(typeStr)),
+		ExporterSettings: config.NewExporterSettings(),
 		Namespace:        "test",
 		ConstLabels: map[string]string{
 			"foo1":  "bar1",
@@ -110,7 +110,7 @@ func TestPrometheusExporter_endToEnd(t *testing.T) {
 	}
 
 	factory := NewFactory()
-	set := componenttest.NewNopExporterCreateSettings()
+	set := componenttest.NewNopExporterCreateSettings(defaultID)
 	exp, err := factory.CreateMetricsExporter(context.Background(), set, cfg)
 	assert.NoError(t, err)
 
@@ -174,7 +174,7 @@ func TestPrometheusExporter_endToEnd(t *testing.T) {
 
 func TestPrometheusExporter_endToEndWithTimestamps(t *testing.T) {
 	cfg := &Config{
-		ExporterSettings: config.NewExporterSettings(config.NewID(typeStr)),
+		ExporterSettings: config.NewExporterSettings(),
 		Namespace:        "test",
 		ConstLabels: map[string]string{
 			"foo2":  "bar2",
@@ -186,7 +186,7 @@ func TestPrometheusExporter_endToEndWithTimestamps(t *testing.T) {
 	}
 
 	factory := NewFactory()
-	set := componenttest.NewNopExporterCreateSettings()
+	set := componenttest.NewNopExporterCreateSettings(defaultID)
 	exp, err := factory.CreateMetricsExporter(context.Background(), set, cfg)
 	assert.NoError(t, err)
 
@@ -250,7 +250,7 @@ func TestPrometheusExporter_endToEndWithTimestamps(t *testing.T) {
 
 func TestPrometheusExporter_endToEndWithResource(t *testing.T) {
 	cfg := &Config{
-		ExporterSettings: config.NewExporterSettings(config.NewID(typeStr)),
+		ExporterSettings: config.NewExporterSettings(),
 		Namespace:        "test",
 		ConstLabels: map[string]string{
 			"foo2":  "bar2",
@@ -265,7 +265,7 @@ func TestPrometheusExporter_endToEndWithResource(t *testing.T) {
 	}
 
 	factory := NewFactory()
-	set := componenttest.NewNopExporterCreateSettings()
+	set := componenttest.NewNopExporterCreateSettings(defaultID)
 	exp, err := factory.CreateMetricsExporter(context.Background(), set, cfg)
 	assert.NoError(t, err)
 

--- a/exporter/prometheusremotewriteexporter/config_test.go
+++ b/exporter/prometheusremotewriteexporter/config_test.go
@@ -50,7 +50,7 @@ func Test_loadConfig(t *testing.T) {
 	e1 := cfg.Exporters[config.NewIDWithName(typeStr, "2")]
 	assert.Equal(t, e1,
 		&Config{
-			ExporterSettings: config.NewExporterSettings(config.NewIDWithName(typeStr, "2")),
+			ExporterSettings: config.NewExporterSettings(),
 			TimeoutSettings:  exporterhelper.DefaultTimeoutSettings(),
 			RetrySettings: exporterhelper.RetrySettings{
 				Enabled:         true,

--- a/exporter/prometheusremotewriteexporter/exporter_test.go
+++ b/exporter/prometheusremotewriteexporter/exporter_test.go
@@ -42,7 +42,7 @@ import (
 // Test_NewPRWExporter checks that a new exporter instance with non-nil fields is initialized
 func Test_NewPRWExporter(t *testing.T) {
 	cfg := &Config{
-		ExporterSettings:   config.NewExporterSettings(config.NewID(typeStr)),
+		ExporterSettings:   config.NewExporterSettings(),
 		TimeoutSettings:    exporterhelper.TimeoutSettings{},
 		RetrySettings:      exporterhelper.RetrySettings{},
 		Namespace:          "",
@@ -132,7 +132,7 @@ func Test_NewPRWExporter(t *testing.T) {
 // Test_Start checks if the client is properly created as expected.
 func Test_Start(t *testing.T) {
 	cfg := &Config{
-		ExporterSettings: config.NewExporterSettings(config.NewID(typeStr)),
+		ExporterSettings: config.NewExporterSettings(),
 		TimeoutSettings:  exporterhelper.TimeoutSettings{},
 		RetrySettings:    exporterhelper.RetrySettings{},
 		Namespace:        "",
@@ -525,7 +525,7 @@ func Test_PushMetrics(t *testing.T) {
 			defer server.Close()
 
 			cfg := &Config{
-				ExporterSettings: config.NewExporterSettings(config.NewID(typeStr)),
+				ExporterSettings: config.NewExporterSettings(),
 				Namespace:        "",
 				HTTPClientSettings: confighttp.HTTPClientSettings{
 					Endpoint: server.URL,

--- a/exporter/prometheusremotewriteexporter/factory.go
+++ b/exporter/prometheusremotewriteexporter/factory.go
@@ -76,7 +76,7 @@ func createMetricsExporter(_ context.Context, set component.ExporterCreateSettin
 
 func createDefaultConfig() config.Exporter {
 	return &Config{
-		ExporterSettings: config.NewExporterSettings(config.NewID(typeStr)),
+		ExporterSettings: config.NewExporterSettings(),
 		Namespace:        "",
 		ExternalLabels:   map[string]string{},
 		TimeoutSettings:  exporterhelper.DefaultTimeoutSettings(),

--- a/exporter/prometheusremotewriteexporter/factory_test.go
+++ b/exporter/prometheusremotewriteexporter/factory_test.go
@@ -28,6 +28,8 @@ import (
 	"go.opentelemetry.io/collector/config/configtls"
 )
 
+var defaultID = config.NewID(typeStr)
+
 // Tests whether or not the default Exporter factory can instantiate a properly interfaced Exporter with default conditions
 func Test_createDefaultConfig(t *testing.T) {
 	cfg := createDefaultConfig()
@@ -59,25 +61,25 @@ func Test_createMetricsExporter(t *testing.T) {
 	}{
 		{"success_case",
 			createDefaultConfig(),
-			componenttest.NewNopExporterCreateSettings(),
+			componenttest.NewNopExporterCreateSettings(defaultID),
 			false,
 			false,
 		},
 		{"fail_case",
 			nil,
-			componenttest.NewNopExporterCreateSettings(),
+			componenttest.NewNopExporterCreateSettings(defaultID),
 			true,
 			false,
 		},
 		{"invalid_config_case",
 			invalidConfig,
-			componenttest.NewNopExporterCreateSettings(),
+			componenttest.NewNopExporterCreateSettings(defaultID),
 			true,
 			false,
 		},
 		{"invalid_tls_config_case",
 			invalidTLSConfig,
-			componenttest.NewNopExporterCreateSettings(),
+			componenttest.NewNopExporterCreateSettings(defaultID),
 			false,
 			true,
 		},

--- a/exporter/zipkinexporter/config_test.go
+++ b/exporter/zipkinexporter/config_test.go
@@ -51,7 +51,7 @@ func TestLoadConfig(t *testing.T) {
 
 	e1 := cfg.Exporters[config.NewIDWithName(typeStr, "2")]
 	assert.Equal(t, &Config{
-		ExporterSettings: config.NewExporterSettings(config.NewIDWithName(typeStr, "2")),
+		ExporterSettings: config.NewExporterSettings(),
 		RetrySettings: exporterhelper.RetrySettings{
 			Enabled:         true,
 			InitialInterval: 10 * time.Second,
@@ -71,7 +71,7 @@ func TestLoadConfig(t *testing.T) {
 		Format:             "proto",
 		DefaultServiceName: "test_name",
 	}, e1)
-	set := componenttest.NewNopExporterCreateSettings()
+	set := componenttest.NewNopExporterCreateSettings(config.NewIDWithName(typeStr, "2"))
 	_, err = factory.CreateTracesExporter(context.Background(), set, e1)
 	require.NoError(t, err)
 }

--- a/exporter/zipkinexporter/factory.go
+++ b/exporter/zipkinexporter/factory.go
@@ -46,7 +46,7 @@ func NewFactory() component.ExporterFactory {
 
 func createDefaultConfig() config.Exporter {
 	return &Config{
-		ExporterSettings: config.NewExporterSettings(config.NewID(typeStr)),
+		ExporterSettings: config.NewExporterSettings(),
 		RetrySettings:    exporterhelper.DefaultRetrySettings(),
 		QueueSettings:    exporterhelper.DefaultQueueSettings(),
 		HTTPClientSettings: confighttp.HTTPClientSettings{

--- a/exporter/zipkinexporter/factory_test.go
+++ b/exporter/zipkinexporter/factory_test.go
@@ -21,8 +21,11 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/configcheck"
 )
+
+var defaultID = config.NewID(typeStr)
 
 func TestCreateDefaultConfig(t *testing.T) {
 	cfg := createDefaultConfig()
@@ -35,14 +38,14 @@ func TestCreateInstanceViaFactory(t *testing.T) {
 
 	// Default config doesn't have default endpoint so creating from it should
 	// fail.
-	ze, err := createTracesExporter(context.Background(), componenttest.NewNopExporterCreateSettings(), cfg)
+	ze, err := createTracesExporter(context.Background(), componenttest.NewNopExporterCreateSettings(defaultID), cfg)
 	assert.Error(t, err)
 	assert.Nil(t, ze)
 
 	// URL doesn't have a default value so set it directly.
 	zeCfg := cfg.(*Config)
 	zeCfg.Endpoint = "http://some.location.org:9411/api/v2/spans"
-	ze, err = createTracesExporter(context.Background(), componenttest.NewNopExporterCreateSettings(), cfg)
+	ze, err = createTracesExporter(context.Background(), componenttest.NewNopExporterCreateSettings(defaultID), cfg)
 	assert.NoError(t, err)
 	assert.NotNil(t, ze)
 }

--- a/exporter/zipkinexporter/zipkin_test.go
+++ b/exporter/zipkinexporter/zipkin_test.go
@@ -63,7 +63,7 @@ func TestZipkinExporter_roundtripJSON(t *testing.T) {
 		},
 		Format: "json",
 	}
-	zexp, err := NewFactory().CreateTracesExporter(context.Background(), componenttest.NewNopExporterCreateSettings(), cfg)
+	zexp, err := NewFactory().CreateTracesExporter(context.Background(), componenttest.NewNopExporterCreateSettings(defaultID), cfg)
 	assert.NoError(t, err)
 	require.NotNil(t, zexp)
 
@@ -289,7 +289,7 @@ func TestZipkinExporter_invalidFormat(t *testing.T) {
 		Format: "foobar",
 	}
 	f := NewFactory()
-	set := componenttest.NewNopExporterCreateSettings()
+	set := componenttest.NewNopExporterCreateSettings(defaultID)
 	_, err := f.CreateTracesExporter(context.Background(), set, config)
 	require.Error(t, err)
 }
@@ -311,7 +311,7 @@ func TestZipkinExporter_roundtripProto(t *testing.T) {
 		},
 		Format: "proto",
 	}
-	zexp, err := NewFactory().CreateTracesExporter(context.Background(), componenttest.NewNopExporterCreateSettings(), cfg)
+	zexp, err := NewFactory().CreateTracesExporter(context.Background(), componenttest.NewNopExporterCreateSettings(defaultID), cfg)
 	require.NoError(t, err)
 
 	require.NoError(t, zexp.Start(context.Background(), componenttest.NewNopHost()))

--- a/internal/testcomponents/example_exporter.go
+++ b/internal/testcomponents/example_exporter.go
@@ -55,7 +55,7 @@ var ExampleExporterFactory = exporterhelper.NewFactory(
 // CreateDefaultConfig creates the default configuration for the Exporter.
 func createExporterDefaultConfig() config.Exporter {
 	return &ExampleExporter{
-		ExporterSettings: config.NewExporterSettings(config.NewID(expType)),
+		ExporterSettings: config.NewExporterSettings(),
 		ExtraSetting:     "some export string",
 		ExtraMapSetting:  nil,
 		ExtraListSetting: nil,

--- a/obsreport/obsreport_exporter.go
+++ b/obsreport/obsreport_exporter.go
@@ -23,7 +23,6 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"go.opentelemetry.io/collector/component"
-	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/configtelemetry"
 	"go.opentelemetry.io/collector/internal/obsreportconfig"
 	"go.opentelemetry.io/collector/internal/obsreportconfig/obsmetrics"
@@ -40,7 +39,6 @@ type Exporter struct {
 // ExporterSettings are settings for creating an Exporter.
 type ExporterSettings struct {
 	Level                  configtelemetry.Level
-	ExporterID             config.ComponentID
 	ExporterCreateSettings component.ExporterCreateSettings
 }
 
@@ -48,9 +46,9 @@ type ExporterSettings struct {
 func NewExporter(cfg ExporterSettings) *Exporter {
 	return &Exporter{
 		level:          cfg.Level,
-		spanNamePrefix: obsmetrics.ExporterPrefix + cfg.ExporterID.String(),
-		mutators:       []tag.Mutator{tag.Upsert(obsmetrics.TagKeyExporter, cfg.ExporterID.String(), tag.WithTTL(tag.TTLNoPropagation))},
-		tracer:         cfg.ExporterCreateSettings.TracerProvider.Tracer(cfg.ExporterID.String()),
+		spanNamePrefix: obsmetrics.ExporterPrefix + cfg.ExporterCreateSettings.ID.String(),
+		mutators:       []tag.Mutator{tag.Upsert(obsmetrics.TagKeyExporter, cfg.ExporterCreateSettings.ID.String(), tag.WithTTL(tag.TTLNoPropagation))},
+		tracer:         cfg.ExporterCreateSettings.TracerProvider.Tracer(cfg.ExporterCreateSettings.ID.String()),
 	}
 }
 

--- a/obsreport/obsreport_test.go
+++ b/obsreport/obsreport_test.go
@@ -269,7 +269,7 @@ func TestExportTraceDataOp(t *testing.T) {
 	require.NoError(t, err)
 	defer doneFn()
 
-	set := componenttest.NewNopExporterCreateSettings()
+	set := componenttest.NewNopExporterCreateSettings(exporter)
 	sr := new(oteltest.SpanRecorder)
 	set.TracerProvider = oteltest.NewTracerProvider(oteltest.WithSpanRecorder(sr))
 
@@ -278,7 +278,6 @@ func TestExportTraceDataOp(t *testing.T) {
 
 	obsrep := NewExporter(ExporterSettings{
 		Level:                  configtelemetry.LevelNormal,
-		ExporterID:             exporter,
 		ExporterCreateSettings: set,
 	})
 
@@ -323,7 +322,7 @@ func TestExportMetricsOp(t *testing.T) {
 	require.NoError(t, err)
 	defer doneFn()
 
-	set := componenttest.NewNopExporterCreateSettings()
+	set := componenttest.NewNopExporterCreateSettings(exporter)
 	sr := new(oteltest.SpanRecorder)
 	set.TracerProvider = oteltest.NewTracerProvider(oteltest.WithSpanRecorder(sr))
 
@@ -332,7 +331,6 @@ func TestExportMetricsOp(t *testing.T) {
 
 	obsrep := NewExporter(ExporterSettings{
 		Level:                  configtelemetry.LevelNormal,
-		ExporterID:             exporter,
 		ExporterCreateSettings: set,
 	})
 
@@ -378,7 +376,7 @@ func TestExportLogsOp(t *testing.T) {
 	require.NoError(t, err)
 	defer doneFn()
 
-	set := componenttest.NewNopExporterCreateSettings()
+	set := componenttest.NewNopExporterCreateSettings(exporter)
 	sr := new(oteltest.SpanRecorder)
 	set.TracerProvider = oteltest.NewTracerProvider(oteltest.WithSpanRecorder(sr))
 
@@ -387,7 +385,6 @@ func TestExportLogsOp(t *testing.T) {
 
 	obsrep := NewExporter(ExporterSettings{
 		Level:                  configtelemetry.LevelNormal,
-		ExporterID:             exporter,
 		ExporterCreateSettings: set,
 	})
 

--- a/obsreport/obsreporttest/obsreporttest_test.go
+++ b/obsreport/obsreporttest/obsreporttest_test.go
@@ -88,8 +88,7 @@ func TestCheckExporterTracesViews(t *testing.T) {
 
 	obsrep := obsreport.NewExporter(obsreport.ExporterSettings{
 		Level:                  configtelemetry.LevelNormal,
-		ExporterID:             exporter,
-		ExporterCreateSettings: componenttest.NewNopExporterCreateSettings(),
+		ExporterCreateSettings: componenttest.NewNopExporterCreateSettings(exporter),
 	})
 	ctx := obsrep.StartTracesOp(context.Background())
 	assert.NotNil(t, ctx)
@@ -106,8 +105,7 @@ func TestCheckExporterMetricsViews(t *testing.T) {
 
 	obsrep := obsreport.NewExporter(obsreport.ExporterSettings{
 		Level:                  configtelemetry.LevelNormal,
-		ExporterID:             exporter,
-		ExporterCreateSettings: componenttest.NewNopExporterCreateSettings(),
+		ExporterCreateSettings: componenttest.NewNopExporterCreateSettings(exporter),
 	})
 	ctx := obsrep.StartMetricsOp(context.Background())
 	assert.NotNil(t, ctx)
@@ -124,8 +122,7 @@ func TestCheckExporterLogsViews(t *testing.T) {
 
 	obsrep := obsreport.NewExporter(obsreport.ExporterSettings{
 		Level:                  configtelemetry.LevelNormal,
-		ExporterID:             exporter,
-		ExporterCreateSettings: componenttest.NewNopExporterCreateSettings(),
+		ExporterCreateSettings: componenttest.NewNopExporterCreateSettings(exporter),
 	})
 	ctx := obsrep.StartLogsOp(context.Background())
 	assert.NotNil(t, ctx)

--- a/receiver/opencensusreceiver/internal/ocmetrics/opencensus_test.go
+++ b/receiver/opencensusreceiver/internal/ocmetrics/opencensus_test.go
@@ -55,7 +55,7 @@ func TestReceiver_endToEnd(t *testing.T) {
 	expCfg.GRPCClientSettings.TLSSetting.Insecure = true
 	expCfg.Endpoint = addr.String()
 	expCfg.WaitForReady = true
-	oce, err := expFactory.CreateMetricsExporter(context.Background(), componenttest.NewNopExporterCreateSettings(), expCfg)
+	oce, err := expFactory.CreateMetricsExporter(context.Background(), componenttest.NewNopExporterCreateSettings(config.NewID(expFactory.Type())), expCfg)
 	require.NoError(t, err)
 	err = oce.Start(context.Background(), componenttest.NewNopHost())
 	require.NoError(t, err)

--- a/receiver/opencensusreceiver/internal/octrace/opencensus_test.go
+++ b/receiver/opencensusreceiver/internal/octrace/opencensus_test.go
@@ -53,7 +53,7 @@ func TestReceiver_endToEnd(t *testing.T) {
 	expCfg.GRPCClientSettings.TLSSetting.Insecure = true
 	expCfg.Endpoint = addr.String()
 	expCfg.WaitForReady = true
-	oce, err := expFactory.CreateTracesExporter(context.Background(), componenttest.NewNopExporterCreateSettings(), expCfg)
+	oce, err := expFactory.CreateTracesExporter(context.Background(), componenttest.NewNopExporterCreateSettings(config.NewID(expFactory.Type())), expCfg)
 	require.NoError(t, err)
 	err = oce.Start(context.Background(), componenttest.NewNopHost())
 	require.NoError(t, err)

--- a/receiver/zipkinreceiver/trace_receiver_test.go
+++ b/receiver/zipkinreceiver/trace_receiver_test.go
@@ -227,10 +227,10 @@ func TestConversionRoundtrip(t *testing.T) {
 	defer backend.Close()
 
 	factory := zipkinexporter.NewFactory()
-	config := factory.CreateDefaultConfig().(*zipkinexporter.Config)
-	config.Endpoint = backend.URL
-	set := componenttest.NewNopExporterCreateSettings()
-	ze, err := factory.CreateTracesExporter(context.Background(), set, config)
+	cfg := factory.CreateDefaultConfig().(*zipkinexporter.Config)
+	cfg.Endpoint = backend.URL
+	set := componenttest.NewNopExporterCreateSettings(config.NewID("zipkin"))
+	ze, err := factory.CreateTracesExporter(context.Background(), set, cfg)
 	require.NoError(t, err)
 	require.NotNil(t, ze)
 	require.NoError(t, ze.Start(context.Background(), componenttest.NewNopHost()))

--- a/service/defaultcomponents/default_exporters_test.go
+++ b/service/defaultcomponents/default_exporters_test.go
@@ -140,7 +140,6 @@ func TestDefaultExporters(t *testing.T) {
 			factory, ok := expFactories[tt.exporter]
 			require.True(t, ok)
 			assert.Equal(t, tt.exporter, factory.Type())
-			assert.Equal(t, config.NewID(tt.exporter), factory.CreateDefaultConfig().ID())
 
 			if tt.skipLifecycle {
 				t.Log("Skipping lifecycle test", tt.exporter)
@@ -163,7 +162,7 @@ type getExporterConfigFn func() config.Exporter
 func verifyExporterLifecycle(t *testing.T, factory component.ExporterFactory, getConfigFn getExporterConfigFn) {
 	ctx := context.Background()
 	host := newAssertNoErrorHost(t)
-	expCreateSettings := componenttest.NewNopExporterCreateSettings()
+	expCreateSettings := componenttest.NewNopExporterCreateSettings(config.NewID(factory.Type()))
 
 	cfg := factory.CreateDefaultConfig()
 	if getConfigFn != nil {

--- a/service/internal/builder/exporters_builder_test.go
+++ b/service/internal/builder/exporters_builder_test.go
@@ -42,7 +42,7 @@ func TestBuildExporters(t *testing.T) {
 	cfg := &config.Config{
 		Exporters: map[config.ComponentID]config.Exporter{
 			config.NewID("opencensus"): &opencensusexporter.Config{
-				ExporterSettings: config.NewExporterSettings(config.NewID("opencensus")),
+				ExporterSettings: config.NewExporterSettings(),
 				GRPCClientSettings: configgrpc.GRPCClientSettings{
 					Endpoint: "0.0.0.0:12345",
 				},
@@ -113,7 +113,7 @@ func TestBuildExporters_BuildLogs(t *testing.T) {
 	cfg := &config.Config{
 		Exporters: map[config.ComponentID]config.Exporter{
 			config.NewID("exampleexporter"): &testcomponents.ExampleExporter{
-				ExporterSettings: config.NewExporterSettings(config.NewID("exampleexporter")),
+				ExporterSettings: config.NewExporterSettings(),
 			},
 		},
 

--- a/service/internal/builder/factories_test.go
+++ b/service/internal/builder/factories_test.go
@@ -81,7 +81,7 @@ func newBadExporterFactory() component.ExporterFactory {
 		return &struct {
 			config.ExporterSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
 		}{
-			ExporterSettings: config.NewExporterSettings(config.NewID("bf")),
+			ExporterSettings: config.NewExporterSettings(),
 		}
 	})
 }


### PR DESCRIPTION
Pros:
* The config.Exporter becomes now immutable;
* The obsreport needs only settings
* The exporter helper does not need config (will be removed in followup). Since config is opaque anyway.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
