### PR TITLE
Website: support GH page links to canonical src

### DIFF
--- a/website_docs/_index.md
+++ b/website_docs/_index.md
@@ -1,10 +1,14 @@
 ---
-title: "Collector"
-linkTitle: "Collector"
+title: Collector
 weight: 10
-description: >
+description: >-
   <img width="35" src="https://raw.github.com/open-telemetry/opentelemetry.io/main/iconography/32x32/Collector.svg" alt="Collector logo"></img>
-  Vendor-agnostic way to receive, process and export telemetry data
+  Vendor-agnostic way to receive, process and export telemetry data.
+cascade:
+  github_repo: &repo https://github.com/open-telemetry/opentelemetry-collector
+  github_subdir: website_docs
+  path_base_for_github_subdir: content/en/docs/collector/
+  github_project_repo: *repo
 ---
 
 <img src="https://raw.github.com/open-telemetry/opentelemetry.io/main/iconography/Otel_Collector.svg" alt="Otel-Collector diagram with Jaeger, OTLP and Prometheus integration"></img>


### PR DESCRIPTION
Contributes to https://github.com/open-telemetry/opentelemetry.io/issues/542

/cc @carlosalberto @mtwo @shelbyspees @austinlparker 

While I can't (currently) show you a preview of this PR, you can see the corresponding change for OTel Java (https://github.com/open-telemetry/opentelemetry-java/pull/3501) in action by trying the **Edit this page** and related links, from https://opentelemetry.io/docs/java/ and it's subpages.

@tigrannajaryan @bogdandrutu: if/once this is approved and merged, could you then trigger the [docs-update workflow](https://github.com/open-telemetry/opentelemetry-collector/actions/workflows/docs-update.yml)? Thanks