### PR TITLE
Prometheus Receiver metric type fixes to match Prometheus functionality

### DIFF
--- a/receiver/prometheusreceiver/internal/metricsbuilder_test.go
+++ b/receiver/prometheusreceiver/internal/metricsbuilder_test.go
@@ -544,7 +544,7 @@ func Test_metricBuilder_untype(t *testing.T) {
 					{
 						MetricDescriptor: &metricspb.MetricDescriptor{
 							Name:      "something_not_exists",
-							Type:      metricspb.MetricDescriptor_UNSPECIFIED,
+							Type:      metricspb.MetricDescriptor_GAUGE_DOUBLE,
 							LabelKeys: []*metricspb.LabelKey{{Key: "foo"}}},
 						Timeseries: []*metricspb.TimeSeries{
 							{
@@ -558,7 +558,7 @@ func Test_metricBuilder_untype(t *testing.T) {
 					{
 						MetricDescriptor: &metricspb.MetricDescriptor{
 							Name:      "theother_not_exists",
-							Type:      metricspb.MetricDescriptor_UNSPECIFIED,
+							Type:      metricspb.MetricDescriptor_GAUGE_DOUBLE,
 							LabelKeys: []*metricspb.LabelKey{{Key: "bar"}, {Key: "foo"}}},
 						Timeseries: []*metricspb.TimeSeries{
 							{


### PR DESCRIPTION
**Description:** 
1. The prometheus receiver sets metrics without the `# TYPE` hint as UNSPECIFIED which converts to empty OTLP metrics: such as `{"metrics":[{},{},{}]}` in the OTLP json output and considers these metric invalid. Prometheus, however, will treat these metrics as a Gauge type and these metrics show up correctly in the Prometheus expression browser. With these changes, if the metadata type is not found, the type is set to `textparse.MetricTypeUnknown` so that in the function `convToOCAMetricType(metadata.Type)`, the type is converted to `metricspb.MetricDescriptor_GAUGE_DOUBLE`.
2. Issue #3557 was created since some counter metrics sent when using the python prometheus sdk were being considered invalid metrics. This is because in the Prometheus metadata lookup, their name excluded the _total, so their metadata couldn't be found. #3603 fixed the issue by checking the name without the _total suffix to lookup the metadata. However, the family name without the _total suffix is used as the metric name, so the metric `python_gc_objects_collected_total` is converted to the name `python_gc_objects_collected` whereas Prometheus still includes the _total suffix. This is because previously the metric family name only differed from metric names when the metric was a summary and histogram that have the metrics with _sum and _count, which are added back in later. There isn't this special logic for counters, so the family name needs to be set to the actual metric name when it is a counter and has the _total suffix.

**Link to tracking Issue:** #3852 #3557

**Testing:**
Tested out on a Kubernetes cluster with Prometheus scrape targets that have metrics without the `# TYPE` hint for (1) and metrics using the python sdk sending metrics such as below for testing (2):
```
python_gc_objects_collected_total
python_gc_objects_uncollectable_total 
python_gc_collections_total
process_cpu_seconds_total
```
Changed tests for metrics without the type hint to expect the gauge type.
