### PR TITLE
Fix wmi error on contrib-tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,8 @@ go 1.16
 require (
 	contrib.go.opencensus.io/exporter/prometheus v0.3.0
 	github.com/Shopify/sarama v1.29.1
+	github.com/StackExchange/wmi v1.2.1 // indirect
+    github.com/pquerna/cachecontrol v0.1.0 // indirect
 	github.com/antonmedv/expr v1.9.0
 	github.com/apache/thrift v0.14.2
 	github.com/cenkalti/backoff/v4 v4.1.1

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	contrib.go.opencensus.io/exporter/prometheus v0.3.0
 	github.com/Shopify/sarama v1.29.1
 	github.com/StackExchange/wmi v1.2.1 // indirect
-    github.com/pquerna/cachecontrol v0.1.0 // indirect
+	github.com/pquerna/cachecontrol v0.1.0 // indirect
 	github.com/antonmedv/expr v1.9.0
 	github.com/apache/thrift v0.14.2
 	github.com/cenkalti/backoff/v4 v4.1.1

--- a/go.sum
+++ b/go.sum
@@ -124,8 +124,9 @@ github.com/Shopify/sarama v1.29.1 h1:wBAacXbYVLmWieEA/0X/JagDdCZ8NVFOfS6l6+2u5S0
 github.com/Shopify/sarama v1.29.1/go.mod h1:mdtqvCSg8JOxk8PmpTNGyo6wzd4BMm4QXSfDnTXmgkE=
 github.com/Shopify/toxiproxy v2.1.4+incompatible h1:TKdv8HiTLgE5wdJuEML90aBgNWsokNbMijUGhmcoBJc=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
-github.com/StackExchange/wmi v0.0.0-20210224194228-fe8f1750fd46 h1:5sXbqlSomvdjlRbWyNqkPsJ3Fg+tQZCbgeX1VGljbQY=
 github.com/StackExchange/wmi v0.0.0-20210224194228-fe8f1750fd46/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
+github.com/StackExchange/wmi v1.2.1 h1:VIkavFPXSjcnS+O8yTq7NI32k0R5Aj+v39y29VYDOSA=
+github.com/StackExchange/wmi v1.2.1/go.mod h1:rcmrprowKIVzvc+NUiLncP2uuArMWLCbu9SBzvHz7e8=
 github.com/VividCortex/gohistogram v1.0.0 h1:6+hBz+qvs0JOrrNhhmR7lFxo5sINxBCGXrdtl/UvroE=
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=


### PR DESCRIPTION
**Description:** 

Fix wmi error on contrib tests by requiring the latest version. 
This error was probably introduced by #3802.
This uncovers a different, unrelated error:
```
go test -race -timeout 30s ./...
# github.com/influxdata/influxdb-observability/common
/home/circleci/go/pkg/mod/github.com/influxdata/influxdb-observability/common@v0.2.4/metrics_sort.go:20:35: m.Gauge().DataPoints().At(l).LabelsMap undefined (type pdata.NumberDataPoint has no field or method LabelsMap)
/home/circleci/go/pkg/mod/github.com/influxdata/influxdb-observability/common@v0.2.4/metrics_sort.go:24:33: m.Sum().DataPoints().At(l).LabelsMap undefined (type pdata.NumberDataPoint has no field or method LabelsMap)
/home/circleci/go/pkg/mod/github.com/influxdata/influxdb-observability/common@v0.2.4/metrics_sort.go:29:39: m.Histogram().DataPoints().At(l).LabelsMap undefined (type pdata.HistogramDataPoint has no field or method LabelsMap)
/home/circleci/go/pkg/mod/github.com/influxdata/influxdb-observability/common@v0.2.4/metrics_sort.go:33:37: m.Summary().DataPoints().At(l).LabelsMap undefined (type pdata.SummaryDataPoint has no field or method LabelsMap)
FAIL	github.com/open-telemetry/opentelemetry-collector-contrib/cmd/otelcontribcol [build failed]
ok  	github.com/open-telemetry/opentelemetry-collector-contrib/internal/version	0.021s [no tests to run]
FAIL
```

**Link to tracking Issue:** relates to discussion on open-telemetry/opentelemetry-collector-contrib#4433.