### PR TITLE
receiver/prometheus: make Config.Validate reject unsupported Prometheus advanced features

### DIFF
--- a/receiver/prometheusreceiver/README.md
+++ b/receiver/prometheusreceiver/README.md
@@ -18,6 +18,18 @@ and please don't use it if the following limitations is a concern:
   if they want to manually shard the scraping.
 * The Prometheus receiver is a stateful component.
 
+## Unsupported features
+The Prometheus receiver is meant to minimally be a drop-in replacement for Prometheus. However,
+there are advanced features of Prometheus that we don't support and thus explicitly will return
+an error for if the receiver's configuration YAML/code contains any of the following
+
+- [x] alert_config.alertmanagers
+- [x] alert_config.relabel_configs
+- [x] remote_read
+- [x] remote_write
+- [x] rule_files
+
+
 ## Getting Started
 
 This receiver is a drop-in replacement for getting Prometheus to scrape your

--- a/receiver/prometheusreceiver/testdata/invalid-config-prometheus-unsupported-features.yaml
+++ b/receiver/prometheusreceiver/testdata/invalid-config-prometheus-unsupported-features.yaml
@@ -1,0 +1,43 @@
+receivers:
+  prometheus:
+    buffer_period: 234
+    buffer_count: 45
+    use_start_time_metric: true
+    start_time_metric_regex: '^(.+_)*process_start_time_seconds$'
+    config:
+      scrape_configs:
+        - job_name: 'demo'
+          scrape_interval: 5s
+      remote_write:
+        - url: "https://example.org/write"
+
+      remote_read:
+        - url: "https://example.org/read"
+
+      rule_files: ["a", "b"]
+
+      alerting:
+        alert_relabel_configs:
+          - separator: ","
+            target_label: "fix"
+
+          - separator: "|"
+            target_label: "gotham"
+
+        alertmanagers:
+          - scheme: "http"
+            path_prefix: "/prefix1"
+            timeout: 1s
+
+processors:
+  nop:
+
+exporters:
+  nop:
+
+service:
+  pipelines:
+    traces:
+      receivers: [prometheus]
+      processors: [nop]
+      exporters: [nop]


### PR DESCRIPTION
With this change, we reject advanced Prometheus features that the
collector won't support. This way users will be cognizant of what isn't
supported. This way, anyone who adds this configuration to their
Prometheus receiver section

```yaml
receivers:
  prometheus:
    buffer_period: 234
    buffer_count: 45
    use_start_time_metric: true
    start_time_metric_regex: '^(.+_)*process_start_time_seconds$'
    config:
      scrape_configs:
        - job_name: 'demo'
          scrape_interval: 5s
      remote_write:
        - url: "https://example.org/write"

      remote_read:
        - url: "https://example.org/read"

      rule_files: ["a", "b"]

      alerting:
        alert_relabel_configs:
          - separator: ","
            target_label: "fix"

          - separator: "|"
            target_label: "gotham"

        alertmanagers:
          - scheme: "http"
            path_prefix: "/prefix1"
            timeout: 1s
```

will be shown what we don't support these features with this error
message:

```shell
receiver "prometheus" has invalid configuration: unsupported features:
        alert_config.alertmanagers
        alert_config.relabel_configs
        remote_read
        remote_write
        rule_files
```

Fixes #3864
Fixes https://github.com/open-telemetry/wg-prometheus/issues/3