### PR TITLE
Change semantic conventions for status (code, msg) as per specifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 🛑 Breaking changes 🛑
+
+- Change semantic conventions for status (code, msg) as per specifications (#3872)
+
 ## v0.33.0 Beta
 
 ## 🛑 Breaking changes 🛑

--- a/receiver/jaegerreceiver/trace_receiver_test.go
+++ b/receiver/jaegerreceiver/trace_receiver_test.go
@@ -53,7 +53,6 @@ import (
 	"go.opentelemetry.io/collector/obsreport"
 	"go.opentelemetry.io/collector/testutil"
 	conventions "go.opentelemetry.io/collector/translator/conventions/v1.5.0"
-	tracetranslator "go.opentelemetry.io/collector/translator/trace"
 	"go.opentelemetry.io/collector/translator/trace/jaeger"
 )
 
@@ -355,8 +354,8 @@ func grpcFixture(t1 time.Time, d1, d2 time.Duration) *api_v2.PostSpansRequest {
 					StartTime:     t1,
 					Duration:      d1,
 					Tags: []model.KeyValue{
-						model.String(tracetranslator.TagStatusMsg, "Stale indices"),
-						model.Int64(tracetranslator.TagStatusCode, int64(pdata.StatusCodeError)),
+						model.String(conventions.OtelStatusDescription, "Stale indices"),
+						model.Int64(conventions.OtelStatusCode, int64(pdata.StatusCodeError)),
 						model.Bool("error", true),
 					},
 					References: []model.SpanRef{
@@ -374,8 +373,8 @@ func grpcFixture(t1 time.Time, d1, d2 time.Duration) *api_v2.PostSpansRequest {
 					StartTime:     t1.Add(d1),
 					Duration:      d2,
 					Tags: []model.KeyValue{
-						model.String(tracetranslator.TagStatusMsg, "Frontend crash"),
-						model.Int64(tracetranslator.TagStatusCode, int64(pdata.StatusCodeError)),
+						model.String(conventions.OtelStatusDescription, "Frontend crash"),
+						model.Int64(conventions.OtelStatusCode, int64(pdata.StatusCodeError)),
 						model.Bool("error", true),
 					},
 				},

--- a/receiver/zipkinreceiver/trace_receiver_test.go
+++ b/receiver/zipkinreceiver/trace_receiver_test.go
@@ -170,7 +170,7 @@ func TestConversionRoundtrip(t *testing.T) {
   "tags": {
     "http.path": "/api",
     "clnt/finagle.version": "6.45.0",
-	"status.code": "STATUS_CODE_UNSET"
+	"otel.status_code": "STATUS_CODE_UNSET"
   }
 },
 {
@@ -203,7 +203,7 @@ func TestConversionRoundtrip(t *testing.T) {
   "tags": {
     "http.path": "/api",
     "clnt/finagle.version": "6.45.0",
-	"status.code": "STATUS_CODE_UNSET"
+	"otel.status_code": "STATUS_CODE_UNSET"
   }
 }]`)
 

--- a/translator/conventions/v1.5.0/nonstandard.go
+++ b/translator/conventions/v1.5.0/nonstandard.go
@@ -20,6 +20,11 @@ const (
 )
 
 const (
+	OtelStatusCode        = "otel.status_code"
+	OtelStatusDescription = "otel.status_description"
+)
+
+const (
 	AttributeMessageType    = "message.type"
 	AttributeHTTPStatusText = "http.status_text"
 )

--- a/translator/internaldata/oc_to_traces.go
+++ b/translator/internaldata/oc_to_traces.go
@@ -175,11 +175,11 @@ func ocStatusToInternal(ocStatus *octrace.Status, ocAttrs *octrace.Span_Attribut
 	}
 
 	if ocAttrs != nil {
-		// tracetranslator.TagStatusCode is set it must override the status code value.
+		// If conventions.OtelStatusCode is set, it must override the status code value.
 		// See the reverse translation in traces_to_oc.go:statusToOC().
-		if attr, ok := ocAttrs.AttributeMap[tracetranslator.TagStatusCode]; ok {
+		if attr, ok := ocAttrs.AttributeMap[conventions.OtelStatusCode]; ok {
 			code = pdata.StatusCode(attr.GetIntValue())
-			delete(ocAttrs.AttributeMap, tracetranslator.TagStatusCode)
+			delete(ocAttrs.AttributeMap, conventions.OtelStatusCode)
 		}
 	}
 

--- a/translator/internaldata/traces_to_oc.go
+++ b/translator/internaldata/traces_to_oc.go
@@ -78,7 +78,7 @@ func spanToOC(span pdata.Span) *octrace.Span {
 				DroppedAttributesCount: 0,
 			}
 		}
-		attributes.AttributeMap[tracetranslator.TagStatusCode] = statusAttr
+		attributes.AttributeMap[conventions.OtelStatusCode] = statusAttr
 	}
 
 	return &octrace.Span{

--- a/translator/trace/jaeger/jaegerproto_to_traces.go
+++ b/translator/trace/jaeger/jaegerproto_to_traces.go
@@ -223,15 +223,15 @@ func setInternalSpanStatus(attrs pdata.AttributeMap, dest pdata.SpanStatus) {
 		}
 	}
 
-	if codeAttr, ok := attrs.Get(tracetranslator.TagStatusCode); ok {
+	if codeAttr, ok := attrs.Get(conventions.OtelStatusCode); ok {
 		statusExists = true
 		if code, err := getStatusCodeValFromAttr(codeAttr); err == nil {
 			statusCode = pdata.StatusCode(code)
-			attrs.Delete(tracetranslator.TagStatusCode)
+			attrs.Delete(conventions.OtelStatusCode)
 		}
-		if msgAttr, ok := attrs.Get(tracetranslator.TagStatusMsg); ok {
+		if msgAttr, ok := attrs.Get(conventions.OtelStatusDescription); ok {
 			statusMessage = msgAttr.StringVal()
-			attrs.Delete(tracetranslator.TagStatusMsg)
+			attrs.Delete(conventions.OtelStatusDescription)
 		}
 	} else if httpCodeAttr, ok := attrs.Get(conventions.AttributeHTTPStatusCode); ok {
 		statusExists = true

--- a/translator/trace/jaeger/jaegerproto_to_traces_test.go
+++ b/translator/trace/jaeger/jaegerproto_to_traces_test.go
@@ -365,7 +365,7 @@ func TestSetInternalSpanStatus(t *testing.T) {
 		{
 			name: "status.code is set as int",
 			attrs: pdata.NewAttributeMap().InitFromMap(map[string]pdata.AttributeValue{
-				tracetranslator.TagStatusCode: pdata.NewAttributeValueInt(1),
+				conventions.OtelStatusCode: pdata.NewAttributeValueInt(1),
 			}),
 			status:           okStatus,
 			attrsModifiedLen: 0,
@@ -373,9 +373,9 @@ func TestSetInternalSpanStatus(t *testing.T) {
 		{
 			name: "status.code, status.message and error tags are set",
 			attrs: pdata.NewAttributeMap().InitFromMap(map[string]pdata.AttributeValue{
-				tracetranslator.TagError:      pdata.NewAttributeValueBool(true),
-				tracetranslator.TagStatusCode: pdata.NewAttributeValueInt(int64(pdata.StatusCodeError)),
-				tracetranslator.TagStatusMsg:  pdata.NewAttributeValueString("Error: Invalid argument"),
+				tracetranslator.TagError:          pdata.NewAttributeValueBool(true),
+				conventions.OtelStatusCode:        pdata.NewAttributeValueInt(int64(pdata.StatusCodeError)),
+				conventions.OtelStatusDescription: pdata.NewAttributeValueString("Error: Invalid argument"),
 			}),
 			status:           errorStatusWithMessage,
 			attrsModifiedLen: 0,
@@ -401,7 +401,7 @@ func TestSetInternalSpanStatus(t *testing.T) {
 		{
 			name: "status.code has precedence over http.status_code.",
 			attrs: pdata.NewAttributeMap().InitFromMap(map[string]pdata.AttributeValue{
-				tracetranslator.TagStatusCode:       pdata.NewAttributeValueInt(1),
+				conventions.OtelStatusCode:          pdata.NewAttributeValueInt(1),
 				conventions.AttributeHTTPStatusCode: pdata.NewAttributeValueInt(500),
 				tracetranslator.TagHTTPStatusMsg:    pdata.NewAttributeValueString("Server Error"),
 			}),
@@ -606,7 +606,7 @@ func generateProtoSpan() *model.Span {
 				VStr:  string(tracetranslator.OpenTracingSpanKindClient),
 			},
 			{
-				Key:    tracetranslator.TagStatusCode,
+				Key:    conventions.OtelStatusCode,
 				VType:  model.ValueType_INT64,
 				VInt64: int64(pdata.StatusCodeError),
 			},
@@ -616,7 +616,7 @@ func generateProtoSpan() *model.Span {
 				VType: model.ValueType_BOOL,
 			},
 			{
-				Key:   tracetranslator.TagStatusMsg,
+				Key:   conventions.OtelStatusDescription,
 				VType: model.ValueType_STRING,
 				VStr:  "status-cancelled",
 			},
@@ -684,7 +684,7 @@ func generateProtoSpanWithTraceState() *model.Span {
 				VStr:  string(tracetranslator.OpenTracingSpanKindClient),
 			},
 			{
-				Key:    tracetranslator.TagStatusCode,
+				Key:    conventions.OtelStatusCode,
 				VType:  model.ValueType_INT64,
 				VInt64: int64(pdata.StatusCodeError),
 			},
@@ -694,7 +694,7 @@ func generateProtoSpanWithTraceState() *model.Span {
 				VType: model.ValueType_BOOL,
 			},
 			{
-				Key:   tracetranslator.TagStatusMsg,
+				Key:   conventions.OtelStatusDescription,
 				VType: model.ValueType_STRING,
 				VStr:  "status-cancelled",
 			},
@@ -797,12 +797,12 @@ func generateProtoFollowerSpan() *model.Span {
 				VStr:  string(tracetranslator.OpenTracingSpanKindConsumer),
 			},
 			{
-				Key:    tracetranslator.TagStatusCode,
+				Key:    conventions.OtelStatusCode,
 				VType:  model.ValueType_INT64,
 				VInt64: int64(pdata.StatusCodeOk),
 			},
 			{
-				Key:   tracetranslator.TagStatusMsg,
+				Key:   conventions.OtelStatusDescription,
 				VType: model.ValueType_STRING,
 				VStr:  "status-ok",
 			},

--- a/translator/trace/jaeger/jaegerthrift_to_traces_test.go
+++ b/translator/trace/jaeger/jaegerthrift_to_traces_test.go
@@ -195,12 +195,12 @@ func generateThriftSpan() *jaeger.Span {
 		},
 		Tags: []*jaeger.Tag{
 			{
-				Key:   tracetranslator.TagStatusCode,
+				Key:   conventions.OtelStatusCode,
 				VType: jaeger.TagType_LONG,
 				VLong: &statusCode,
 			},
 			{
-				Key:   tracetranslator.TagStatusMsg,
+				Key:   conventions.OtelStatusDescription,
 				VType: jaeger.TagType_STRING,
 				VStr:  &statusMsg,
 			},
@@ -256,12 +256,12 @@ func generateThriftFollowerSpan() *jaeger.Span {
 		Duration:      1000,
 		Tags: []*jaeger.Tag{
 			{
-				Key:   tracetranslator.TagStatusCode,
+				Key:   conventions.OtelStatusCode,
 				VType: jaeger.TagType_LONG,
 				VLong: &statusCode,
 			},
 			{
-				Key:   tracetranslator.TagStatusMsg,
+				Key:   conventions.OtelStatusDescription,
 				VType: jaeger.TagType_STRING,
 				VStr:  &statusMsg,
 			},

--- a/translator/trace/jaeger/traces_to_jaegerproto.go
+++ b/translator/trace/jaeger/traces_to_jaegerproto.go
@@ -382,7 +382,7 @@ func getTagFromSpanKind(spanKind pdata.SpanKind) (model.KeyValue, bool) {
 
 func getTagFromStatusCode(statusCode pdata.StatusCode) (model.KeyValue, bool) {
 	return model.KeyValue{
-		Key:    tracetranslator.TagStatusCode,
+		Key:    conventions.OtelStatusCode,
 		VInt64: int64(statusCode),
 		VType:  model.ValueType_INT64,
 	}, true
@@ -405,7 +405,7 @@ func getTagFromStatusMsg(statusMsg string) (model.KeyValue, bool) {
 		return model.KeyValue{}, false
 	}
 	return model.KeyValue{
-		Key:   tracetranslator.TagStatusMsg,
+		Key:   conventions.OtelStatusDescription,
 		VStr:  statusMsg,
 		VType: model.ValueType_STRING,
 	}, true

--- a/translator/trace/jaeger/traces_to_jaegerproto_test.go
+++ b/translator/trace/jaeger/traces_to_jaegerproto_test.go
@@ -37,7 +37,7 @@ func TestGetTagFromStatusCode(t *testing.T) {
 			name: "ok",
 			code: pdata.StatusCodeOk,
 			tag: model.KeyValue{
-				Key:    tracetranslator.TagStatusCode,
+				Key:    conventions.OtelStatusCode,
 				VInt64: int64(pdata.StatusCodeOk),
 				VType:  model.ValueType_INT64,
 			},
@@ -47,7 +47,7 @@ func TestGetTagFromStatusCode(t *testing.T) {
 			name: "error",
 			code: pdata.StatusCodeError,
 			tag: model.KeyValue{
-				Key:    tracetranslator.TagStatusCode,
+				Key:    conventions.OtelStatusCode,
 				VInt64: int64(pdata.StatusCodeError),
 				VType:  model.ValueType_INT64,
 			},
@@ -88,7 +88,7 @@ func TestGetTagFromStatusMsg(t *testing.T) {
 	got, ok := getTagFromStatusMsg("test-error")
 	assert.True(t, ok)
 	assert.EqualValues(t, model.KeyValue{
-		Key:   tracetranslator.TagStatusMsg,
+		Key:   conventions.OtelStatusDescription,
 		VStr:  "test-error",
 		VType: model.ValueType_STRING,
 	}, got)
@@ -339,7 +339,7 @@ func TestInternalTracesToJaegerProtoBatchesAndBack(t *testing.T) {
 func generateProtoChildSpanWithErrorTags() *model.Span {
 	span := generateProtoChildSpan()
 	span.Tags = append(span.Tags, model.KeyValue{
-		Key:    tracetranslator.TagStatusCode,
+		Key:    conventions.OtelStatusCode,
 		VType:  model.ValueType_INT64,
 		VInt64: int64(pdata.StatusCodeError),
 	})

--- a/translator/trace/protospan_translation.go
+++ b/translator/trace/protospan_translation.go
@@ -16,6 +16,7 @@ package tracetranslator
 
 import (
 	"go.opentelemetry.io/collector/model/pdata"
+	conventions "go.opentelemetry.io/collector/translator/conventions/v1.5.0"
 )
 
 // Some of the keys used to represent OTLP constructs as tags or annotations in other formats.
@@ -24,12 +25,17 @@ const (
 
 	TagSpanKind = "span.kind"
 
-	TagStatusCode    = "status.code"
-	TagStatusMsg     = "status.message"
 	TagError         = "error"
 	TagHTTPStatusMsg = "http.status_message"
 
 	TagW3CTraceState = "w3c.tracestate"
+)
+
+const (
+	// Deprecated: Use conventions.OtelStatusCode
+	TagStatusCode = conventions.OtelStatusCode
+	// Deprecated: Use conventions.OtelStatusDescription
+	TagStatusMsg = conventions.OtelStatusDescription
 )
 
 // Constants used for signifying batch-level attribute values where not supplied by OTLP data but required

--- a/translator/trace/zipkinv1/json_test.go
+++ b/translator/trace/zipkinv1/json_test.go
@@ -231,9 +231,9 @@ func TestZipkinAnnotationsToOCStatus(t *testing.T) {
 
 	cases := []test{
 		{
-			name: "only status.code tag",
+			name: "only otel.status_code tag",
 			haveTags: []*binaryAnnotation{{
-				Key:   "status.code",
+				Key:   conventions.OtelStatusCode,
 				Value: "13",
 			}},
 			wantAttributes: nil,
@@ -243,9 +243,9 @@ func TestZipkinAnnotationsToOCStatus(t *testing.T) {
 		},
 
 		{
-			name: "only status.message tag",
+			name: "only otel.status_description tag",
 			haveTags: []*binaryAnnotation{{
-				Key:   "status.message",
+				Key:   conventions.OtelStatusDescription,
 				Value: "Forbidden",
 			}},
 			wantAttributes: nil,
@@ -253,14 +253,14 @@ func TestZipkinAnnotationsToOCStatus(t *testing.T) {
 		},
 
 		{
-			name: "both status.code and status.message",
+			name: "both otel.status_code and otel.status_description",
 			haveTags: []*binaryAnnotation{
 				{
-					Key:   "status.code",
+					Key:   conventions.OtelStatusCode,
 					Value: "13",
 				},
 				{
-					Key:   "status.message",
+					Key:   conventions.OtelStatusDescription,
 					Value: "Forbidden",
 				},
 			},
@@ -272,7 +272,7 @@ func TestZipkinAnnotationsToOCStatus(t *testing.T) {
 		},
 
 		{
-			name: "http status.code",
+			name: "http otel.status_code",
 			haveTags: []*binaryAnnotation{
 				{
 					Key:   "http.status_code",
@@ -315,11 +315,11 @@ func TestZipkinAnnotationsToOCStatus(t *testing.T) {
 					Value: "NotFound",
 				},
 				{
-					Key:   "status.code",
+					Key:   conventions.OtelStatusCode,
 					Value: "13",
 				},
 				{
-					Key:   "status.message",
+					Key:   conventions.OtelStatusDescription,
 					Value: "Forbidden",
 				},
 			},
@@ -355,7 +355,7 @@ func TestZipkinAnnotationsToOCStatus(t *testing.T) {
 					Value: "NotFound",
 				},
 				{
-					Key:   "status.code",
+					Key:   conventions.OtelStatusCode,
 					Value: "14",
 				},
 			},
@@ -390,7 +390,7 @@ func TestZipkinAnnotationsToOCStatus(t *testing.T) {
 					Value: "NotFound",
 				},
 				{
-					Key:   "status.message",
+					Key:   conventions.OtelStatusDescription,
 					Value: "Forbidden",
 				},
 			},
@@ -453,11 +453,11 @@ func TestZipkinAnnotationsToOCStatus(t *testing.T) {
 					Value: "NotFound",
 				},
 				{
-					Key:   "status.message",
+					Key:   conventions.OtelStatusDescription,
 					Value: "Forbidden",
 				},
 				{
-					Key:   "status.code",
+					Key:   conventions.OtelStatusCode,
 					Value: "7",
 				},
 			},

--- a/translator/trace/zipkinv1/status_code.go
+++ b/translator/trace/zipkinv1/status_code.go
@@ -101,14 +101,14 @@ func (m *statusMapper) fromAttribute(key string, attrib *tracepb.AttributeValue)
 		m.fromCensus.message = attrib.GetStringValue().GetValue()
 		return true
 
-	case tracetranslator.TagStatusCode:
+	case conventions.OtelStatusCode:
 		code, err := attribToStatusCode(attrib)
 		if err == nil {
 			m.fromStatus.codePtr = &code
 		}
 		return true
 
-	case tracetranslator.TagStatusMsg:
+	case conventions.OtelStatusDescription:
 		m.fromStatus.message = attrib.GetStringValue().GetValue()
 		return true
 

--- a/translator/trace/zipkinv1/thrift_test.go
+++ b/translator/trace/zipkinv1/thrift_test.go
@@ -120,7 +120,7 @@ func TestZipkinThriftAnnotationsToOCStatus(t *testing.T) {
 		// too large code for OC
 		{
 			haveTags: []*zipkincore.BinaryAnnotation{{
-				Key:            "status.code",
+				Key:            conventions.OtelStatusCode,
 				Value:          uint64ToBytes(math.MaxInt64),
 				AnnotationType: zipkincore.AnnotationType_I64,
 			}},
@@ -130,7 +130,7 @@ func TestZipkinThriftAnnotationsToOCStatus(t *testing.T) {
 		// only status.code tag
 		{
 			haveTags: []*zipkincore.BinaryAnnotation{{
-				Key:            "status.code",
+				Key:            conventions.OtelStatusCode,
 				Value:          uint64ToBytes(5),
 				AnnotationType: zipkincore.AnnotationType_I64,
 			}},
@@ -141,7 +141,7 @@ func TestZipkinThriftAnnotationsToOCStatus(t *testing.T) {
 		},
 		{
 			haveTags: []*zipkincore.BinaryAnnotation{{
-				Key:            "status.code",
+				Key:            conventions.OtelStatusCode,
 				Value:          uint32ToBytes(6),
 				AnnotationType: zipkincore.AnnotationType_I32,
 			}},
@@ -152,7 +152,7 @@ func TestZipkinThriftAnnotationsToOCStatus(t *testing.T) {
 		},
 		{
 			haveTags: []*zipkincore.BinaryAnnotation{{
-				Key:            "status.code",
+				Key:            conventions.OtelStatusCode,
 				Value:          uint16ToBytes(7),
 				AnnotationType: zipkincore.AnnotationType_I16,
 			}},
@@ -164,7 +164,7 @@ func TestZipkinThriftAnnotationsToOCStatus(t *testing.T) {
 		// only status.message tag
 		{
 			haveTags: []*zipkincore.BinaryAnnotation{{
-				Key:            "status.message",
+				Key:            conventions.OtelStatusDescription,
 				Value:          []byte("Forbidden"),
 				AnnotationType: zipkincore.AnnotationType_STRING,
 			}},
@@ -175,12 +175,12 @@ func TestZipkinThriftAnnotationsToOCStatus(t *testing.T) {
 		{
 			haveTags: []*zipkincore.BinaryAnnotation{
 				{
-					Key:            "status.code",
+					Key:            conventions.OtelStatusCode,
 					Value:          uint32ToBytes(13),
 					AnnotationType: zipkincore.AnnotationType_I32,
 				},
 				{
-					Key:            "status.message",
+					Key:            conventions.OtelStatusDescription,
 					Value:          []byte("Forbidden"),
 					AnnotationType: zipkincore.AnnotationType_STRING,
 				},
@@ -240,12 +240,12 @@ func TestZipkinThriftAnnotationsToOCStatus(t *testing.T) {
 					AnnotationType: zipkincore.AnnotationType_STRING,
 				},
 				{
-					Key:            "status.code",
+					Key:            conventions.OtelStatusCode,
 					Value:          uint32ToBytes(13),
 					AnnotationType: zipkincore.AnnotationType_I32,
 				},
 				{
-					Key:            "status.message",
+					Key:            conventions.OtelStatusDescription,
 					Value:          []byte("Forbidden"),
 					AnnotationType: zipkincore.AnnotationType_STRING,
 				},
@@ -284,7 +284,7 @@ func TestZipkinThriftAnnotationsToOCStatus(t *testing.T) {
 					AnnotationType: zipkincore.AnnotationType_STRING,
 				},
 				{
-					Key:            "status.code",
+					Key:            conventions.OtelStatusCode,
 					Value:          uint32ToBytes(14),
 					AnnotationType: zipkincore.AnnotationType_I32,
 				},
@@ -321,7 +321,7 @@ func TestZipkinThriftAnnotationsToOCStatus(t *testing.T) {
 					AnnotationType: zipkincore.AnnotationType_STRING,
 				},
 				{
-					Key:            "status.message",
+					Key:            conventions.OtelStatusDescription,
 					Value:          []byte("Forbidden"),
 					AnnotationType: zipkincore.AnnotationType_STRING,
 				},
@@ -391,12 +391,12 @@ func TestZipkinThriftAnnotationsToOCStatus(t *testing.T) {
 					AnnotationType: zipkincore.AnnotationType_STRING,
 				},
 				{
-					Key:            "status.message",
+					Key:            conventions.OtelStatusDescription,
 					Value:          []byte("Forbidden"),
 					AnnotationType: zipkincore.AnnotationType_STRING,
 				},
 				{
-					Key:            "status.code",
+					Key:            conventions.OtelStatusCode,
 					Value:          uint32ToBytes(1),
 					AnnotationType: zipkincore.AnnotationType_I32,
 				},

--- a/translator/trace/zipkinv2/from_translator.go
+++ b/translator/trace/zipkinv2/from_translator.go
@@ -158,9 +158,9 @@ func spanToZipkinSpan(
 	removeRedundentTags(redundantKeys, tags)
 
 	status := span.Status()
-	tags[tracetranslator.TagStatusCode] = status.Code().String()
+	tags[conventions.OtelStatusCode] = status.Code().String()
 	if status.Message() != "" {
-		tags[tracetranslator.TagStatusMsg] = status.Message()
+		tags[conventions.OtelStatusDescription] = status.Message()
 		if int32(status.Code()) > 0 {
 			zs.Err = fmt.Errorf("%s", status.Message())
 		}

--- a/translator/trace/zipkinv2/from_translator_test.go
+++ b/translator/trace/zipkinv2/from_translator_test.go
@@ -24,6 +24,7 @@ import (
 	"go.opentelemetry.io/collector/internal/goldendataset"
 	"go.opentelemetry.io/collector/internal/testdata"
 	"go.opentelemetry.io/collector/model/pdata"
+	conventions "go.opentelemetry.io/collector/translator/conventions/v1.5.0"
 )
 
 func TestInternalTracesToZipkinSpans(t *testing.T) {
@@ -167,9 +168,9 @@ func zipkinOneSpan() *zipkinmodel.SpanModel {
 			},
 		},
 		Tags: map[string]string{
-			"resource-attr":  "resource-attr-val-1",
-			"status.code":    "STATUS_CODE_ERROR",
-			"status.message": "status-cancelled",
+			"resource-attr":                   "resource-attr-val-1",
+			conventions.OtelStatusCode:        "STATUS_CODE_ERROR",
+			conventions.OtelStatusDescription: "status-cancelled",
 		},
 		Name:      "operationA",
 		Timestamp: testdata.TestSpanStartTime,

--- a/translator/trace/zipkinv2/to_translator.go
+++ b/translator/trace/zipkinv2/to_translator.go
@@ -156,12 +156,12 @@ func zSpanToInternal(zspan *zipkinmodel.SpanModel, tags map[string]string, dest 
 }
 
 func populateSpanStatus(tags map[string]string, status pdata.SpanStatus) {
-	if value, ok := tags[tracetranslator.TagStatusCode]; ok {
+	if value, ok := tags[conventions.OtelStatusCode]; ok {
 		status.SetCode(pdata.StatusCode(statusCodeValue[value]))
-		delete(tags, tracetranslator.TagStatusCode)
-		if value, ok := tags[tracetranslator.TagStatusMsg]; ok {
+		delete(tags, conventions.OtelStatusCode)
+		if value, ok := tags[conventions.OtelStatusDescription]; ok {
 			status.SetMessage(value)
-			delete(tags, tracetranslator.TagStatusMsg)
+			delete(tags, conventions.OtelStatusDescription)
 		}
 	}
 


### PR DESCRIPTION
Deprecate the old values and replace with the new value defined by the specification.
This may be a breaking change for backends that expect this value.

See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk_exporters/non-otlp.md

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
