### PR TITLE
Fix for NPE when no trace provider is set

### DIFF
--- a/obsreport/obsreport_exporter.go
+++ b/obsreport/obsreport_exporter.go
@@ -46,11 +46,16 @@ type ExporterSettings struct {
 
 // NewExporter creates a new Exporter.
 func NewExporter(cfg ExporterSettings) *Exporter {
+	tracerProvider := cfg.ExporterCreateSettings.TracerProvider
+	if tracerProvider == nil {
+		tracerProvider = trace.NewNoopTracerProvider()
+	}
+
 	return &Exporter{
 		level:          cfg.Level,
 		spanNamePrefix: obsmetrics.ExporterPrefix + cfg.ExporterID.String(),
 		mutators:       []tag.Mutator{tag.Upsert(obsmetrics.TagKeyExporter, cfg.ExporterID.String(), tag.WithTTL(tag.TTLNoPropagation))},
-		tracer:         cfg.ExporterCreateSettings.TracerProvider.Tracer(cfg.ExporterID.String()),
+		tracer:         tracerProvider.Tracer(cfg.ExporterID.String()),
 	}
 }
 


### PR DESCRIPTION
**Description:*
Fix a bug: NPE if tracer-provider is not set in ExporterCreateSettings

See behaviour of otel.GetTracerProvider:
https://github.com/open-telemetry/opentelemetry-go/blob/v0.20.0/trace.go#L31


Regression was introduced by this change: https://github.com/open-telemetry/opentelemetry-collector/commit/bb9569f896aa3ab1ff552e8058b00da926f52e0c#diff-1293b9f0774eaa2598506c1afb02c81402731067400dd0273386f425aaadfba2