### PR TITLE
Remove hostmetricsreceiver from docs

### DIFF
--- a/receiver/README.md
+++ b/receiver/README.md
@@ -12,7 +12,6 @@ Available trace receivers (sorted alphabetically):
 
 Available metric receivers (sorted alphabetically):
 
-- [Host Metrics Receiver](hostmetricsreceiver/README.md)
 - [OTLP Receiver](otlpreceiver/README.md)
 
 Available log receivers (sorted alphabetically):


### PR DESCRIPTION
It was moved to contrib (https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/hostmetricsreceiver).