### PR TITLE
docs: migrate extension links to opentelemetry-collector-contrib repo…

### DIFF
--- a/config/configgrpc/README.md
+++ b/config/configgrpc/README.md
@@ -26,7 +26,7 @@ README](../configtls/README.md).
 - [`read_buffer_size`](https://godoc.org/google.golang.org/grpc#ReadBufferSize)
 - [`write_buffer_size`](https://godoc.org/google.golang.org/grpc#WriteBufferSize)
 
-Please note that [`per_rpc_auth`](https://pkg.go.dev/google.golang.org/grpc#PerRPCCredentials) which allows the credentials to send for every RPC is now moved to become an [extension](https://github.com/open-telemetry/opentelemetry-collector/tree/main/extension/bearertokenauthextension). Note that this feature isn't about sending the headers only during the initial connection as an `authorization` header under the `headers` would do: this is sent for every RPC performed during an established connection.
+Please note that [`per_rpc_auth`](https://pkg.go.dev/google.golang.org/grpc#PerRPCCredentials) which allows the credentials to send for every RPC is now moved to become an [extension](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/extension/bearertokenauthextension). Note that this feature isn't about sending the headers only during the initial connection as an `authorization` header under the `headers` would do: this is sent for every RPC performed during an established connection.
 
 Example:
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -168,7 +168,7 @@ Attributes:
 ### Health Check
 
 The
-[health_check](https://github.com/open-telemetry/opentelemetry-collector/tree/main/extension/healthcheckextension/README.md)
+[health_check](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/extension/healthcheckextension/README.md)
 extension, which by default is available on all interfaces on port `13133`, can
 be used to ensure the Collector is functioning properly.
 
@@ -182,13 +182,17 @@ service:
 It returns a response like the following:
 
 ```json
-{"status":"Server available","upSince":"2020-11-11T04:12:31.6847174Z","uptime":"49.0132518s"}
+{
+  "status": "Server available",
+  "upSince": "2020-11-11T04:12:31.6847174Z",
+  "uptime": "49.0132518s"
+}
 ```
 
 ### pprof
 
 The
-[pprof](https://github.com/open-telemetry/opentelemetry-collector/tree/main/extension/pprofextension/README.md)
+[pprof](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/extension/pprofextension/README.md)
 extension, which by default is available locally on port `1777`, allows you to profile the
 Collector as it runs. This is an advanced use-case that should not be needed in most circumstances.
 


### PR DESCRIPTION
This PR corrects invalid links for `bearertokenauthextension`, `healthcheckextension`, and `pprofextension` that have been migrated to the [opentelemetry-collector-config](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension).