### PR TITLE
add NewAttributeMapFromMap, mark InitFromMap deprecated

### DIFF
--- a/internal/testdata/common.go
+++ b/internal/testdata/common.go
@@ -38,41 +38,41 @@ const (
 )
 
 func initResourceAttributes1(dest pdata.AttributeMap) {
-	dest.InitFromMap(resourceAttributes1)
+	pdata.NewAttributeMapFromMap(resourceAttributes1).CopyTo(dest)
 }
 
 func initResourceAttributes2(dest pdata.AttributeMap) {
-	dest.InitFromMap(resourceAttributes2)
+	pdata.NewAttributeMapFromMap(resourceAttributes2).CopyTo(dest)
 }
 
 func initSpanAttributes(dest pdata.AttributeMap) {
-	dest.InitFromMap(spanAttributes)
+	pdata.NewAttributeMapFromMap(spanAttributes).CopyTo(dest)
 }
 
 func initSpanEventAttributes(dest pdata.AttributeMap) {
-	dest.InitFromMap(spanEventAttributes)
+	pdata.NewAttributeMapFromMap(spanEventAttributes).CopyTo(dest)
 }
 
 func initSpanLinkAttributes(dest pdata.AttributeMap) {
-	dest.InitFromMap(spanLinkAttributes)
+	pdata.NewAttributeMapFromMap(spanLinkAttributes).CopyTo(dest)
 }
 
 func initMetricAttachment(dest pdata.AttributeMap) {
-	dest.InitFromMap(map[string]pdata.AttributeValue{TestAttachmentKey: pdata.NewAttributeValueString(TestAttachmentValue)})
+	pdata.NewAttributeMapFromMap(map[string]pdata.AttributeValue{TestAttachmentKey: pdata.NewAttributeValueString(TestAttachmentValue)}).CopyTo(dest)
 }
 
 func initMetricAttributes1(dest pdata.AttributeMap) {
-	dest.InitFromMap(map[string]pdata.AttributeValue{TestLabelKey1: pdata.NewAttributeValueString(TestLabelValue1)})
+	pdata.NewAttributeMapFromMap(map[string]pdata.AttributeValue{TestLabelKey1: pdata.NewAttributeValueString(TestLabelValue1)}).CopyTo(dest)
 }
 
 func initMetricAttributes12(dest pdata.AttributeMap) {
-	dest.InitFromMap(map[string]pdata.AttributeValue{TestLabelKey1: pdata.NewAttributeValueString(TestLabelValue1), TestLabelKey2: pdata.NewAttributeValueString(TestLabelValue2)}).Sort()
+	pdata.NewAttributeMapFromMap(map[string]pdata.AttributeValue{TestLabelKey1: pdata.NewAttributeValueString(TestLabelValue1), TestLabelKey2: pdata.NewAttributeValueString(TestLabelValue2)}).Sort().CopyTo(dest)
 }
 
 func initMetricAttributes13(dest pdata.AttributeMap) {
-	dest.InitFromMap(map[string]pdata.AttributeValue{TestLabelKey1: pdata.NewAttributeValueString(TestLabelValue1), TestLabelKey3: pdata.NewAttributeValueString(TestLabelValue3)}).Sort()
+	pdata.NewAttributeMapFromMap(map[string]pdata.AttributeValue{TestLabelKey1: pdata.NewAttributeValueString(TestLabelValue1), TestLabelKey3: pdata.NewAttributeValueString(TestLabelValue3)}).Sort().CopyTo(dest)
 }
 
 func initMetricAttributes2(dest pdata.AttributeMap) {
-	dest.InitFromMap(map[string]pdata.AttributeValue{TestLabelKey2: pdata.NewAttributeValueString(TestLabelValue2)})
+	pdata.NewAttributeMapFromMap(map[string]pdata.AttributeValue{TestLabelKey2: pdata.NewAttributeValueString(TestLabelValue2)}).CopyTo(dest)
 }

--- a/internal/testdata/metric.go
+++ b/internal/testdata/metric.go
@@ -93,8 +93,8 @@ func GenerateMetricsOneCounterOneSummaryMetrics() pdata.Metrics {
 func GenerateMetricsOneMetricNoAttributes() pdata.Metrics {
 	md := GenerateMetricsOneMetric()
 	dps := md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(0).Sum().DataPoints()
-	dps.At(0).Attributes().InitFromMap(map[string]pdata.AttributeValue{})
-	dps.At(1).Attributes().InitFromMap(map[string]pdata.AttributeValue{})
+	pdata.NewAttributeMap().CopyTo(dps.At(0).Attributes())
+	pdata.NewAttributeMap().CopyTo(dps.At(1).Attributes())
 	return md
 }
 

--- a/model/pdata/common.go
+++ b/model/pdata/common.go
@@ -420,15 +420,33 @@ func NewAttributeMap() AttributeMap {
 	return AttributeMap{&orig}
 }
 
+// NewAttributeMapFromMap creates a AttributeMap with values
+// from the given map[string]AttributeValue.
+func NewAttributeMapFromMap(attrMap map[string]AttributeValue) AttributeMap {
+	if len(attrMap) == 0 {
+		kv := []otlpcommon.KeyValue(nil)
+		return AttributeMap{&kv}
+	}
+	origs := make([]otlpcommon.KeyValue, len(attrMap))
+	ix := 0
+	for k, v := range attrMap {
+		origs[ix].Key = k
+		v.copyTo(&origs[ix].Value)
+		ix++
+	}
+	return AttributeMap{&origs}
+}
+
 func newAttributeMap(orig *[]otlpcommon.KeyValue) AttributeMap {
 	return AttributeMap{orig}
 }
 
 // InitFromMap overwrites the entire AttributeMap and reconstructs the AttributeMap
-// with values from the given map[string]string.
+// with values from the given map[string]AttributeValue.
 //
 // Returns the same instance to allow nicer code like:
 //   assert.EqualValues(t, NewAttributeMap().InitFromMap(map[string]AttributeValue{...}), actual)
+// Deprecated: use NewAttributeMapFromMap instead.
 func (am AttributeMap) InitFromMap(attrMap map[string]AttributeValue) AttributeMap {
 	if len(attrMap) == 0 {
 		*am.orig = []otlpcommon.KeyValue(nil)

--- a/model/pdata/common_test.go
+++ b/model/pdata/common_test.go
@@ -578,7 +578,7 @@ func TestAttributeMap_Range(t *testing.T) {
 		"k_null":   NewAttributeValueNull(),
 		"k_bytes":  NewAttributeValueBytes([]byte{}),
 	}
-	am := NewAttributeMap().InitFromMap(rawMap)
+	am := NewAttributeMapFromMap(rawMap)
 	assert.Equal(t, 6, am.Len())
 
 	calls := 0
@@ -597,7 +597,7 @@ func TestAttributeMap_Range(t *testing.T) {
 }
 
 func TestAttributeMap_InitFromMap(t *testing.T) {
-	am := NewAttributeMap().InitFromMap(map[string]AttributeValue(nil))
+	am := NewAttributeMapFromMap(map[string]AttributeValue(nil))
 	assert.EqualValues(t, NewAttributeMap(), am)
 
 	rawMap := map[string]AttributeValue{
@@ -616,7 +616,7 @@ func TestAttributeMap_InitFromMap(t *testing.T) {
 		newAttributeKeyValueNull("k_null"),
 		newAttributeKeyValueBytes("k_bytes", []byte{1, 2, 3}),
 	}
-	am = NewAttributeMap().InitFromMap(rawMap)
+	am = NewAttributeMapFromMap(rawMap)
 	assert.EqualValues(t, AttributeMap{orig: &rawOrig}.Sort(), am.Sort())
 }
 
@@ -846,48 +846,38 @@ func generateTestAttributeMap() AttributeMap {
 }
 
 func fillTestAttributeMap(dest AttributeMap) {
-	dest.InitFromMap(map[string]AttributeValue{
+	NewAttributeMapFromMap(map[string]AttributeValue{
 		"k": NewAttributeValueString("v"),
-	})
+	}).CopyTo(dest)
 }
 
 func generateTestNullAttributeMap() AttributeMap {
-	am := NewAttributeMap()
-	am.InitFromMap(map[string]AttributeValue{
+	return NewAttributeMapFromMap(map[string]AttributeValue{
 		"k": NewAttributeValueNull(),
 	})
-	return am
 }
 func generateTestIntAttributeMap() AttributeMap {
-	am := NewAttributeMap()
-	am.InitFromMap(map[string]AttributeValue{
+	return NewAttributeMapFromMap(map[string]AttributeValue{
 		"k": NewAttributeValueInt(123),
 	})
-	return am
 }
 
 func generateTestDoubleAttributeMap() AttributeMap {
-	am := NewAttributeMap()
-	am.InitFromMap(map[string]AttributeValue{
+	return NewAttributeMapFromMap(map[string]AttributeValue{
 		"k": NewAttributeValueDouble(12.3),
 	})
-	return am
 }
 
 func generateTestBoolAttributeMap() AttributeMap {
-	am := NewAttributeMap()
-	am.InitFromMap(map[string]AttributeValue{
+	return NewAttributeMapFromMap(map[string]AttributeValue{
 		"k": NewAttributeValueBool(true),
 	})
-	return am
 }
 
 func generateTestBytesAttributeMap() AttributeMap {
-	am := NewAttributeMap()
-	am.InitFromMap(map[string]AttributeValue{
+	return NewAttributeMapFromMap(map[string]AttributeValue{
 		"k": NewAttributeValueBytes([]byte{1, 2, 3, 4, 5}),
 	})
-	return am
 }
 
 func TestAttributeValueArray(t *testing.T) {

--- a/model/pdata/metrics_test.go
+++ b/model/pdata/metrics_test.go
@@ -233,7 +233,7 @@ func TestOtlpToInternalReadOnly(t *testing.T) {
 	assert.EqualValues(t, 1, resourceMetrics.Len())
 
 	resourceMetric := resourceMetrics.At(0)
-	assert.EqualValues(t, NewAttributeMap().InitFromMap(map[string]AttributeValue{
+	assert.EqualValues(t, NewAttributeMapFromMap(map[string]AttributeValue{
 		"string": NewAttributeValueString("string-resource"),
 	}), resourceMetric.Resource().Attributes())
 	metrics := resourceMetric.InstrumentationLibraryMetrics().At(0).Metrics()
@@ -251,12 +251,12 @@ func TestOtlpToInternalReadOnly(t *testing.T) {
 	assert.EqualValues(t, startTime, gaugeDataPoints.At(0).StartTimestamp())
 	assert.EqualValues(t, endTime, gaugeDataPoints.At(0).Timestamp())
 	assert.EqualValues(t, 123.1, gaugeDataPoints.At(0).DoubleVal())
-	assert.EqualValues(t, NewAttributeMap().InitFromMap(map[string]AttributeValue{"key0": NewAttributeValueString("value0")}), gaugeDataPoints.At(0).Attributes())
+	assert.EqualValues(t, NewAttributeMapFromMap(map[string]AttributeValue{"key0": NewAttributeValueString("value0")}), gaugeDataPoints.At(0).Attributes())
 	// Second point
 	assert.EqualValues(t, startTime, gaugeDataPoints.At(1).StartTimestamp())
 	assert.EqualValues(t, endTime, gaugeDataPoints.At(1).Timestamp())
 	assert.EqualValues(t, 456.1, gaugeDataPoints.At(1).DoubleVal())
-	assert.EqualValues(t, NewAttributeMap().InitFromMap(map[string]AttributeValue{"key1": NewAttributeValueString("value1")}), gaugeDataPoints.At(1).Attributes())
+	assert.EqualValues(t, NewAttributeMapFromMap(map[string]AttributeValue{"key1": NewAttributeValueString("value1")}), gaugeDataPoints.At(1).Attributes())
 
 	// Check double metric
 	metricDouble := metrics.At(1)
@@ -272,12 +272,12 @@ func TestOtlpToInternalReadOnly(t *testing.T) {
 	assert.EqualValues(t, startTime, sumDataPoints.At(0).StartTimestamp())
 	assert.EqualValues(t, endTime, sumDataPoints.At(0).Timestamp())
 	assert.EqualValues(t, 123.1, sumDataPoints.At(0).DoubleVal())
-	assert.EqualValues(t, NewAttributeMap().InitFromMap(map[string]AttributeValue{"key0": NewAttributeValueString("value0")}), sumDataPoints.At(0).Attributes())
+	assert.EqualValues(t, NewAttributeMapFromMap(map[string]AttributeValue{"key0": NewAttributeValueString("value0")}), sumDataPoints.At(0).Attributes())
 	// Second point
 	assert.EqualValues(t, startTime, sumDataPoints.At(1).StartTimestamp())
 	assert.EqualValues(t, endTime, sumDataPoints.At(1).Timestamp())
 	assert.EqualValues(t, 456.1, sumDataPoints.At(1).DoubleVal())
-	assert.EqualValues(t, NewAttributeMap().InitFromMap(map[string]AttributeValue{"key1": NewAttributeValueString("value1")}), sumDataPoints.At(1).Attributes())
+	assert.EqualValues(t, NewAttributeMapFromMap(map[string]AttributeValue{"key1": NewAttributeValueString("value1")}), sumDataPoints.At(1).Attributes())
 
 	// Check histogram metric
 	metricHistogram := metrics.At(2)
@@ -293,13 +293,13 @@ func TestOtlpToInternalReadOnly(t *testing.T) {
 	assert.EqualValues(t, startTime, histogramDataPoints.At(0).StartTimestamp())
 	assert.EqualValues(t, endTime, histogramDataPoints.At(0).Timestamp())
 	assert.EqualValues(t, []float64{1, 2}, histogramDataPoints.At(0).ExplicitBounds())
-	assert.EqualValues(t, NewAttributeMap().InitFromMap(map[string]AttributeValue{"key0": NewAttributeValueString("value0")}), histogramDataPoints.At(0).Attributes())
+	assert.EqualValues(t, NewAttributeMapFromMap(map[string]AttributeValue{"key0": NewAttributeValueString("value0")}), histogramDataPoints.At(0).Attributes())
 	assert.EqualValues(t, []uint64{10, 15, 1}, histogramDataPoints.At(0).BucketCounts())
 	// Second point
 	assert.EqualValues(t, startTime, histogramDataPoints.At(1).StartTimestamp())
 	assert.EqualValues(t, endTime, histogramDataPoints.At(1).Timestamp())
 	assert.EqualValues(t, []float64{1}, histogramDataPoints.At(1).ExplicitBounds())
-	assert.EqualValues(t, NewAttributeMap().InitFromMap(map[string]AttributeValue{"key1": NewAttributeValueString("value1")}), histogramDataPoints.At(1).Attributes())
+	assert.EqualValues(t, NewAttributeMapFromMap(map[string]AttributeValue{"key1": NewAttributeValueString("value1")}), histogramDataPoints.At(1).Attributes())
 	assert.EqualValues(t, []uint64{10, 1}, histogramDataPoints.At(1).BucketCounts())
 }
 
@@ -334,7 +334,7 @@ func TestOtlpToFromInternalReadOnly(t *testing.T) {
 }
 
 func TestOtlpToFromInternalGaugeMutating(t *testing.T) {
-	newAttributes := NewAttributeMap().InitFromMap(map[string]AttributeValue{"k": NewAttributeValueString("v")})
+	newAttributes := NewAttributeMapFromMap(map[string]AttributeValue{"k": NewAttributeValueString("v")})
 
 	md := MetricsFromInternalRep(internal.MetricsFromOtlp(&otlpcollectormetrics.ExportMetricsServiceRequest{
 		ResourceMetrics: []*otlpmetrics.ResourceMetrics{
@@ -417,7 +417,7 @@ func TestOtlpToFromInternalGaugeMutating(t *testing.T) {
 }
 
 func TestOtlpToFromInternalSumMutating(t *testing.T) {
-	newAttributes := NewAttributeMap().InitFromMap(map[string]AttributeValue{"k": NewAttributeValueString("v")})
+	newAttributes := NewAttributeMapFromMap(map[string]AttributeValue{"k": NewAttributeValueString("v")})
 
 	md := MetricsFromInternalRep(internal.MetricsFromOtlp(&otlpcollectormetrics.ExportMetricsServiceRequest{
 		ResourceMetrics: []*otlpmetrics.ResourceMetrics{
@@ -502,7 +502,7 @@ func TestOtlpToFromInternalSumMutating(t *testing.T) {
 }
 
 func TestOtlpToFromInternalHistogramMutating(t *testing.T) {
-	newAttributes := NewAttributeMap().InitFromMap(map[string]AttributeValue{"k": NewAttributeValueString("v")})
+	newAttributes := NewAttributeMapFromMap(map[string]AttributeValue{"k": NewAttributeValueString("v")})
 
 	md := MetricsFromInternalRep(internal.MetricsFromOtlp(&otlpcollectormetrics.ExportMetricsServiceRequest{
 		ResourceMetrics: []*otlpmetrics.ResourceMetrics{


### PR DESCRIPTION
**Description:**
As per issue #3926, adding `NewAttributeMapFromMap` for consistency. As part of this also deprecating the existing `InitFromMap` will will be removed once the contrib repo is updated.

**Link to tracking Issue:** part of #3926 

**Testing:** Updated existing tests

