### PR TITLE
add String method to AttributeValue to replace AttributeValueToString

### DIFF
--- a/internal/otlptext/databuffer.go
+++ b/internal/otlptext/databuffer.go
@@ -247,7 +247,7 @@ func attributeMapToString(av pdata.AttributeMap) string {
 	b.WriteString("{\n")
 
 	av.Sort().Range(func(k string, v pdata.AttributeValue) bool {
-		fmt.Fprintf(&b, "     -> %s: %s(%s)\n", k, v.Type(), pdata.AttributeValueToString(v))
+		fmt.Fprintf(&b, "     -> %s: %s(%s)\n", k, v.Type(), v.AsString())
 		return true
 	})
 	b.WriteByte('}')

--- a/model/pdata/common.go
+++ b/model/pdata/common.go
@@ -363,6 +363,39 @@ func (a AttributeValue) Equal(av AttributeValue) bool {
 	return false
 }
 
+// String converts an OTLP AttributeValue object of any type to its equivalent string
+// representation. This differs from StringVal which only returns a non-empty value
+// if the AttributeValueType is AttributeValueTypeString.
+func (a AttributeValue) AsString() string {
+	switch a.Type() {
+	case AttributeValueTypeNull:
+		return ""
+
+	case AttributeValueTypeString:
+		return a.StringVal()
+
+	case AttributeValueTypeBool:
+		return strconv.FormatBool(a.BoolVal())
+
+	case AttributeValueTypeDouble:
+		return strconv.FormatFloat(a.DoubleVal(), 'f', -1, 64)
+
+	case AttributeValueTypeInt:
+		return strconv.FormatInt(a.IntVal(), 10)
+
+	case AttributeValueTypeMap:
+		jsonStr, _ := json.Marshal(AttributeMapToMap(a.MapVal()))
+		return string(jsonStr)
+
+	case AttributeValueTypeArray:
+		jsonStr, _ := json.Marshal(attributeArrayToSlice(a.ArrayVal()))
+		return string(jsonStr)
+
+	default:
+		return fmt.Sprintf("<Unknown OpenTelemetry attribute value type %q>", a.Type())
+	}
+}
+
 func newAttributeKeyValueString(k string, v string) otlpcommon.KeyValue {
 	orig := otlpcommon.KeyValue{Key: k}
 	akv := AttributeValue{&orig.Value}
@@ -745,34 +778,9 @@ func (am AttributeMap) CopyTo(dest AttributeMap) {
 }
 
 // AttributeValueToString converts an OTLP AttributeValue object to its equivalent string representation
+// Deprecated: use AttributeValue's String method instead.
 func AttributeValueToString(attr AttributeValue) string {
-	switch attr.Type() {
-	case AttributeValueTypeNull:
-		return ""
-
-	case AttributeValueTypeString:
-		return attr.StringVal()
-
-	case AttributeValueTypeBool:
-		return strconv.FormatBool(attr.BoolVal())
-
-	case AttributeValueTypeDouble:
-		return strconv.FormatFloat(attr.DoubleVal(), 'f', -1, 64)
-
-	case AttributeValueTypeInt:
-		return strconv.FormatInt(attr.IntVal(), 10)
-
-	case AttributeValueTypeMap:
-		jsonStr, _ := json.Marshal(AttributeMapToMap(attr.MapVal()))
-		return string(jsonStr)
-
-	case AttributeValueTypeArray:
-		jsonStr, _ := json.Marshal(attributeArrayToSlice(attr.ArrayVal()))
-		return string(jsonStr)
-
-	default:
-		return fmt.Sprintf("<Unknown OpenTelemetry attribute value type %q>", attr.Type())
-	}
+	return attr.AsString()
 }
 
 // AttributeMapToMap converts an OTLP AttributeMap to a standard go map

--- a/model/pdata/common_test.go
+++ b/model/pdata/common_test.go
@@ -951,7 +951,7 @@ func TestAnyValueArrayWithNilValues(t *testing.T) {
 	assert.EqualValues(t, "other_value", val.StringVal())
 }
 
-func TestAttributeValueToString(t *testing.T) {
+func TestAsString(t *testing.T) {
 	tests := []struct {
 		name     string
 		input    AttributeValue
@@ -1005,7 +1005,7 @@ func TestAttributeValueToString(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			actual := AttributeValueToString(test.input)
+			actual := test.input.AsString()
 			assert.Equal(t, test.expected, actual)
 		})
 	}


### PR DESCRIPTION
**Description:** 
Deprecating `AttributeValueToString` in favour of `attribute.AsString()`. 

**Link to tracking Issue:** Part of #3926 
