### PR TITLE
Add nonstandard "ExceptionEventName" constant to v1.5.0 semantic conventions

### DIFF
--- a/model/semconv/v1.5.0/nonstandard.go
+++ b/model/semconv/v1.5.0/nonstandard.go
@@ -28,3 +28,7 @@ const (
 	AttributeMessageType    = "message.type"
 	AttributeHTTPStatusText = "http.status_text"
 )
+
+const (
+	ExceptionEventName = "exception"
+)


### PR DESCRIPTION
Signed-off-by: Anthony J Mirabella <a9@aneurysm9.com>

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector/issues/3787