### PR TITLE
rename configparser.Parser to configparser.ConfigMap

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -175,7 +175,7 @@ type Unmarshallable interface {
 	// Unmarshal is a function that un-marshals a Parser into the unmarshable struct in a custom way.
 	// componentSection *Parser
 	//   The config for this specific component. May be nil or empty if no config available.
-	Unmarshal(componentSection *configparser.Parser) error
+	Unmarshal(componentSection *configparser.ConfigMap) error
 }
 
 // DataType is the data type that is supported for collection. We currently support

--- a/config/configparser/parser.go
+++ b/config/configparser/parser.go
@@ -36,12 +36,12 @@ const (
 )
 
 // NewParser creates a new empty Parser instance.
-func NewParser() *Parser {
-	return &Parser{k: koanf.New(KeyDelimiter)}
+func NewParser() *ConfigMap {
+	return &ConfigMap{k: koanf.New(KeyDelimiter)}
 }
 
 // NewParserFromFile creates a new Parser by reading the given file.
-func NewParserFromFile(fileName string) (*Parser, error) {
+func NewParserFromFile(fileName string) (*ConfigMap, error) {
 	// Read yaml config from file.
 	p := NewParser()
 	if err := p.k.Load(file.Provider(fileName), yaml.Parser()); err != nil {
@@ -51,7 +51,7 @@ func NewParserFromFile(fileName string) (*Parser, error) {
 }
 
 // NewParserFromBuffer creates a new Parser by reading the given yaml buffer.
-func NewParserFromBuffer(buf io.Reader) (*Parser, error) {
+func NewParserFromBuffer(buf io.Reader) (*ConfigMap, error) {
 	content, err := ioutil.ReadAll(buf)
 	if err != nil {
 		return nil, err
@@ -66,27 +66,27 @@ func NewParserFromBuffer(buf io.Reader) (*Parser, error) {
 }
 
 // NewParserFromStringMap creates a parser from a map[string]interface{}.
-func NewParserFromStringMap(data map[string]interface{}) *Parser {
+func NewParserFromStringMap(data map[string]interface{}) *ConfigMap {
 	p := NewParser()
 	// Cannot return error because the koanf instance is empty.
 	_ = p.k.Load(confmap.Provider(data, KeyDelimiter), nil)
 	return p
 }
 
-// Parser loads configuration.
-type Parser struct {
+// ConfigMap loads configuration.
+type ConfigMap struct {
 	k *koanf.Koanf
 }
 
 // AllKeys returns all keys holding a value, regardless of where they are set.
 // Nested keys are returned with a KeyDelimiter separator.
-func (l *Parser) AllKeys() []string {
+func (l *ConfigMap) AllKeys() []string {
 	return l.k.Keys()
 }
 
 // Unmarshal unmarshalls the config into a struct.
 // Tags on the fields of the structure must be properly set.
-func (l *Parser) Unmarshal(rawVal interface{}) error {
+func (l *ConfigMap) Unmarshal(rawVal interface{}) error {
 	decoder, err := mapstructure.NewDecoder(decoderConfig(rawVal))
 	if err != nil {
 		return err
@@ -95,7 +95,7 @@ func (l *Parser) Unmarshal(rawVal interface{}) error {
 }
 
 // UnmarshalExact unmarshalls the config into a struct, erroring if a field is nonexistent.
-func (l *Parser) UnmarshalExact(intoCfg interface{}) error {
+func (l *ConfigMap) UnmarshalExact(intoCfg interface{}) error {
 	dc := decoderConfig(intoCfg)
 	dc.ErrorUnused = true
 	decoder, err := mapstructure.NewDecoder(dc)
@@ -106,12 +106,12 @@ func (l *Parser) UnmarshalExact(intoCfg interface{}) error {
 }
 
 // Get can retrieve any value given the key to use.
-func (l *Parser) Get(key string) interface{} {
+func (l *ConfigMap) Get(key string) interface{} {
 	return l.k.Get(key)
 }
 
 // Set sets the value for the key.
-func (l *Parser) Set(key string, value interface{}) {
+func (l *ConfigMap) Set(key string, value interface{}) {
 	// koanf doesn't offer a direct setting mechanism so merging is required.
 	merged := koanf.New(KeyDelimiter)
 	merged.Load(confmap.Provider(map[string]interface{}{key: value}, KeyDelimiter), nil)
@@ -120,13 +120,13 @@ func (l *Parser) Set(key string, value interface{}) {
 
 // IsSet checks to see if the key has been set in any of the data locations.
 // IsSet is case-insensitive for a key.
-func (l *Parser) IsSet(key string) bool {
+func (l *ConfigMap) IsSet(key string) bool {
 	return l.k.Exists(key)
 }
 
 // MergeStringMap merges the configuration from the given map with the existing config.
 // Note that the given map may be modified.
-func (l *Parser) MergeStringMap(cfg map[string]interface{}) error {
+func (l *ConfigMap) MergeStringMap(cfg map[string]interface{}) error {
 	toMerge := koanf.New(KeyDelimiter)
 	toMerge.Load(confmap.Provider(cfg, KeyDelimiter), nil)
 	return l.k.Merge(toMerge)
@@ -135,7 +135,7 @@ func (l *Parser) MergeStringMap(cfg map[string]interface{}) error {
 // Sub returns new Parser instance representing a sub-config of this instance.
 // It returns an error is the sub-config is not a map (use Get()) and an empty Parser if
 // none exists.
-func (l *Parser) Sub(key string) (*Parser, error) {
+func (l *ConfigMap) Sub(key string) (*ConfigMap, error) {
 	data := l.Get(key)
 	if data == nil {
 		return NewParser(), nil
@@ -152,7 +152,7 @@ func (l *Parser) Sub(key string) (*Parser, error) {
 }
 
 // ToStringMap creates a map[string]interface{} from a Parser.
-func (l *Parser) ToStringMap() map[string]interface{} {
+func (l *ConfigMap) ToStringMap() map[string]interface{} {
 	return maps.Unflatten(l.k.All(), KeyDelimiter)
 }
 

--- a/config/configunmarshaler/defaultunmarshaler.go
+++ b/config/configunmarshaler/defaultunmarshaler.go
@@ -97,7 +97,7 @@ func NewDefault() ConfigUnmarshaler {
 
 // Unmarshal the Config from a Parser.
 // After the config is unmarshalled, `Validate()` must be called to validate.
-func (*defaultUnmarshaler) Unmarshal(v *configparser.Parser, factories component.Factories) (*config.Config, error) {
+func (*defaultUnmarshaler) Unmarshal(v *configparser.ConfigMap, factories component.Factories) (*config.Config, error) {
 	var cfg config.Config
 
 	// Unmarshal the config.
@@ -239,7 +239,7 @@ func unmarshalService(rawService serviceSettings) (config.Service, error) {
 }
 
 // LoadReceiver loads a receiver config from componentConfig using the provided factories.
-func LoadReceiver(componentConfig *configparser.Parser, id config.ComponentID, factory component.ReceiverFactory) (config.Receiver, error) {
+func LoadReceiver(componentConfig *configparser.ConfigMap, id config.ComponentID, factory component.ReceiverFactory) (config.Receiver, error) {
 	// Create the default config for this receiver.
 	receiverCfg := factory.CreateDefaultConfig()
 	receiverCfg.SetIDName(id.Name())
@@ -434,9 +434,9 @@ func parseIDNames(pipelineID config.ComponentID, componentType string, names []s
 	return ret, nil
 }
 
-// expandEnvConfig updates a configparser.Parser with expanded values for all the values (simple, list or map value).
+// expandEnvConfig updates a configparser.ConfigMap with expanded values for all the values (simple, list or map value).
 // It does not expand the keys.
-func expandEnvConfig(v *configparser.Parser) {
+func expandEnvConfig(v *configparser.ConfigMap) {
 	for _, k := range v.AllKeys() {
 		v.Set(k, expandStringValues(v.Get(k)))
 	}
@@ -527,7 +527,7 @@ func expandEnv(s string) string {
 	})
 }
 
-func unmarshal(componentSection *configparser.Parser, intoCfg interface{}) error {
+func unmarshal(componentSection *configparser.ConfigMap, intoCfg interface{}) error {
 	if cu, ok := intoCfg.(config.Unmarshallable); ok {
 		return cu.Unmarshal(componentSection)
 	}

--- a/config/configunmarshaler/defaultunmarshaler_test.go
+++ b/config/configunmarshaler/defaultunmarshaler_test.go
@@ -459,7 +459,7 @@ func loadConfigFile(t *testing.T, fileName string, factories component.Factories
 	v, err := configparser.NewParserFromFile(fileName)
 	require.NoError(t, err)
 
-	// Unmarshal the config from the configparser.Parser using the given factories.
+	// Unmarshal the config from the configparser.ConfigMap using the given factories.
 	return NewDefault().Unmarshal(v, factories)
 }
 

--- a/config/configunmarshaler/unmarshaler.go
+++ b/config/configunmarshaler/unmarshaler.go
@@ -20,8 +20,8 @@ import (
 	"go.opentelemetry.io/collector/config/configparser"
 )
 
-// ConfigUnmarshaler is the interface that unmarshalls the collector configuration from the configparser.Parser.
+// ConfigUnmarshaler is the interface that unmarshalls the collector configuration from the configparser.ConfigMap.
 type ConfigUnmarshaler interface {
 	// Unmarshal the configuration from the given parser and factories.
-	Unmarshal(v *configparser.Parser, factories component.Factories) (*config.Config, error)
+	Unmarshal(v *configparser.ConfigMap, factories component.Factories) (*config.Config, error)
 }

--- a/config/internal/configsource/manager.go
+++ b/config/internal/configsource/manager.go
@@ -173,7 +173,7 @@ type Manager struct {
 // NewManager creates a new instance of a Manager to be used to inject data from
 // ConfigSource objects into a configuration and watch for updates on the injected
 // data.
-func NewManager(_ *configparser.Parser) (*Manager, error) {
+func NewManager(_ *configparser.ConfigMap) (*Manager, error) {
 	// TODO: Config sources should be extracted for the config itself, need Factories for that.
 
 	return &Manager{
@@ -185,7 +185,7 @@ func NewManager(_ *configparser.Parser) (*Manager, error) {
 // Resolve inspects the given config.Parser and resolves all config sources referenced
 // in the configuration, returning a config.Parser fully resolved. This must be called only
 // once per lifetime of a Manager object.
-func (m *Manager) Resolve(ctx context.Context, parser *configparser.Parser) (*configparser.Parser, error) {
+func (m *Manager) Resolve(ctx context.Context, parser *configparser.ConfigMap) (*configparser.ConfigMap, error) {
 	res := configparser.NewParser()
 	allKeys := parser.AllKeys()
 	for _, k := range allKeys {
@@ -483,7 +483,7 @@ func parseCfgSrc(s string) (cfgSrcName, selector string, params interface{}, err
 		selector = strings.Trim(parts[0], " ")
 
 		if len(parts) > 1 && len(parts[1]) > 0 {
-			var cp *configparser.Parser
+			var cp *configparser.ConfigMap
 			cp, err = configparser.NewParserFromBuffer(bytes.NewReader([]byte(parts[1])))
 			if err != nil {
 				return

--- a/internal/testcomponents/example_exporter.go
+++ b/internal/testcomponents/example_exporter.go
@@ -38,7 +38,7 @@ type ExampleExporter struct {
 }
 
 // Unmarshal a viper data into the config struct
-func (cfg *ExampleExporter) Unmarshal(componentParser *configparser.Parser) error {
+func (cfg *ExampleExporter) Unmarshal(componentParser *configparser.ConfigMap) error {
 	return componentParser.UnmarshalExact(cfg)
 }
 

--- a/receiver/otlpreceiver/config.go
+++ b/receiver/otlpreceiver/config.go
@@ -56,7 +56,7 @@ func (cfg *Config) Validate() error {
 }
 
 // Unmarshal a config.Parser into the config struct.
-func (cfg *Config) Unmarshal(componentParser *configparser.Parser) error {
+func (cfg *Config) Unmarshal(componentParser *configparser.ConfigMap) error {
 	if componentParser == nil || len(componentParser.AllKeys()) == 0 {
 		return fmt.Errorf("empty config for OTLP receiver")
 	}
@@ -66,7 +66,7 @@ func (cfg *Config) Unmarshal(componentParser *configparser.Parser) error {
 		return err
 	}
 
-	// next manually search for protocols in the configparser.Parser, if a protocol is not present it means it is disable.
+	// next manually search for protocols in the configparser.ConfigMap, if a protocol is not present it means it is disable.
 	protocols, err := componentParser.Sub(protocolsFieldName)
 	if err != nil {
 		return err

--- a/service/collector_test.go
+++ b/service/collector_test.go
@@ -234,7 +234,7 @@ func assertZPages(t *testing.T) {
 
 type minimalParserLoader struct{}
 
-func (*minimalParserLoader) Get() (*configparser.Parser, error) {
+func (*minimalParserLoader) Get() (*configparser.ConfigMap, error) {
 	configStr := `
 receivers:
   otlp:
@@ -265,7 +265,7 @@ type errParserLoader struct {
 	err error
 }
 
-func (epl *errParserLoader) Get() (*configparser.Parser, error) {
+func (epl *errParserLoader) Get() (*configparser.ConfigMap, error) {
 	return nil, epl.err
 }
 

--- a/service/parserprovider/default_test.go
+++ b/service/parserprovider/default_test.go
@@ -44,7 +44,7 @@ func TestDefault(t *testing.T) {
 		require.NoError(t, err)
 		pl := Default()
 		require.NotNil(t, pl)
-		var cp *configparser.Parser
+		var cp *configparser.ConfigMap
 		cp, err = pl.Get()
 		require.NoError(t, err)
 		require.NotNil(t, cp)
@@ -64,7 +64,7 @@ func TestDefault(t *testing.T) {
 		require.NoError(t, err)
 		pl := Default()
 		require.NotNil(t, pl)
-		var cp *configparser.Parser
+		var cp *configparser.ConfigMap
 		cp, err = pl.Get()
 		require.NoError(t, err)
 		require.NotNil(t, cp)
@@ -95,7 +95,7 @@ func TestDefault(t *testing.T) {
 		require.NoError(t, err)
 		pl := Default()
 		require.NotNil(t, pl)
-		var cp *configparser.Parser
+		var cp *configparser.ConfigMap
 		cp, err = pl.Get()
 		require.NoError(t, err)
 		require.NotNil(t, cp)

--- a/service/parserprovider/file.go
+++ b/service/parserprovider/file.go
@@ -29,7 +29,7 @@ func NewFile() ParserProvider {
 	return &fileProvider{}
 }
 
-func (fl *fileProvider) Get() (*configparser.Parser, error) {
+func (fl *fileProvider) Get() (*configparser.ConfigMap, error) {
 	fileName := getConfigFlag()
 	if fileName == "" {
 		return nil, errors.New("config file not specified")

--- a/service/parserprovider/inmemory.go
+++ b/service/parserprovider/inmemory.go
@@ -29,6 +29,6 @@ func NewInMemory(buf io.Reader) ParserProvider {
 	return &inMemoryProvider{buf: buf}
 }
 
-func (inp *inMemoryProvider) Get() (*configparser.Parser, error) {
+func (inp *inMemoryProvider) Get() (*configparser.ConfigMap, error) {
 	return configparser.NewParserFromBuffer(inp.buf)
 }

--- a/service/parserprovider/provider.go
+++ b/service/parserprovider/provider.go
@@ -24,7 +24,7 @@ import (
 // Implementations may load the parser from a file, a database or any other source.
 type ParserProvider interface {
 	// Get returns the config.Parser if succeed or error otherwise.
-	Get() (*configparser.Parser, error)
+	Get() (*configparser.ConfigMap, error)
 }
 
 // Watchable is an extension for ParserProvider that is implemented if the given provider

--- a/service/parserprovider/setflag.go
+++ b/service/parserprovider/setflag.go
@@ -40,7 +40,7 @@ func NewSetFlag(base ParserProvider) ParserProvider {
 	}
 }
 
-func (sfl *setFlagProvider) Get() (*configparser.Parser, error) {
+func (sfl *setFlagProvider) Get() (*configparser.ConfigMap, error) {
 	flagProperties := getSetFlag()
 	if len(flagProperties) == 0 {
 		return sfl.base.Get()
@@ -61,7 +61,7 @@ func (sfl *setFlagProvider) Get() (*configparser.Parser, error) {
 	}
 
 	// Create a map manually instead of using props.Map() to allow env var expansion
-	// as used by original Viper-based configparser.Parser.
+	// as used by original Viper-based configparser.ConfigMap.
 	parsed := make(map[string]interface{}, props.Len())
 	for _, key := range props.Keys() {
 		value, _ := props.Get(key)
@@ -69,7 +69,7 @@ func (sfl *setFlagProvider) Get() (*configparser.Parser, error) {
 	}
 	prop := maps.Unflatten(parsed, ".")
 
-	var cp *configparser.Parser
+	var cp *configparser.ConfigMap
 	if cp, err = sfl.base.Get(); err != nil {
 		return nil, err
 	}

--- a/service/parserprovider/setflag_test.go
+++ b/service/parserprovider/setflag_test.go
@@ -59,6 +59,6 @@ func TestSetFlags_empty(t *testing.T) {
 
 type emptyProvider struct{}
 
-func (el *emptyProvider) Get() (*configparser.Parser, error) {
+func (el *emptyProvider) Get() (*configparser.ConfigMap, error) {
 	return configparser.NewParser(), nil
 }


### PR DESCRIPTION
**Description:**
As per issue https://github.com/open-telemetry/opentelemetry-collector/issues/3923, renaming Parser to ConfigMap

**Link to tracking Issue:** Fix https://github.com/open-telemetry/opentelemetry-collector/issues/3923