### PR TITLE
Remove the legacy gRPC port 55680 in OTLP receiver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## Unreleased
+## 🛑 Breaking changes 🛑
+
+- Remove the legacy gRPC port(`55680`) support in OTLP receiver 
 
 ## v0.34.0 Beta
 

--- a/receiver/otlpreceiver/factory.go
+++ b/receiver/otlpreceiver/factory.go
@@ -32,7 +32,6 @@ const (
 
 	defaultGRPCEndpoint = "0.0.0.0:4317"
 	defaultHTTPEndpoint = "0.0.0.0:4318"
-	legacyGRPCEndpoint  = "0.0.0.0:55680"
 	legacyHTTPEndpoint  = "0.0.0.0:55681"
 )
 

--- a/receiver/otlpreceiver/otlp.go
+++ b/receiver/otlpreceiver/otlp.go
@@ -133,18 +133,6 @@ func (r *otlpReceiver) startProtocolServers(host component.Host) error {
 		if err != nil {
 			return err
 		}
-		if r.cfg.GRPC.NetAddr.Endpoint == defaultGRPCEndpoint {
-			r.logger.Info("Setting up a second GRPC listener on legacy endpoint " + legacyGRPCEndpoint)
-
-			// Copy the config.
-			cfgLegacyGRPC := r.cfg.GRPC
-			// And use the legacy endpoint.
-			cfgLegacyGRPC.NetAddr.Endpoint = legacyGRPCEndpoint
-			err = r.startGRPCServer(cfgLegacyGRPC, host)
-			if err != nil {
-				return err
-			}
-		}
 	}
 	if r.cfg.HTTP != nil {
 		r.serverHTTP = r.cfg.HTTP.ToServer(


### PR DESCRIPTION
**Description:** <Describe what has changed. 
Remove the legacy gRPC port `55680` in OTLP receiver

**Note** - will remove the legacy http port `55681` in a separate PR once we're ready.

**Link**
https://github.com/open-telemetry/opentelemetry-collector/issues/3368

