### PR TITLE
Finish removal of health_check extension from k8s example configuration

### DIFF
--- a/examples/k8s/otel-config.yaml
+++ b/examples/k8s/otel-config.yaml
@@ -82,14 +82,6 @@ spec:
         volumeMounts:
         - name: otel-agent-config-vol
           mountPath: /conf
-        livenessProbe:
-          httpGet:
-            path: /
-            port: 13133 # Health Check extension default port.
-        readinessProbe:
-          httpGet:
-            path: /
-            port: 13133 # Health Check extension default port.
       volumes:
         - configMap:
             name: otel-agent-conf
@@ -206,14 +198,6 @@ spec:
           mountPath: /conf
 #        - name: otel-collector-secrets
 #          mountPath: /secrets
-        livenessProbe:
-          httpGet:
-            path: /
-            port: 13133 # Health Check extension default port.
-        readinessProbe:
-          httpGet:
-            path: /
-            port: 13133 # Health Check extension default port.
       volumes:
         - configMap:
             name: otel-collector-conf


### PR DESCRIPTION
**Description:** Finish removal of health_check extension from k8s example, will lead to confusing output otherwise.

**Link to tracking Issue:** The removal was started in #3903

**Testing:** kubectl reports the pod as ready which it did not before.
