### PR TITLE
model/pdata: Change AttributeValue NULL->EMPTY

### DIFF
--- a/model/pdata/common.go
+++ b/model/pdata/common.go
@@ -31,7 +31,7 @@ import (
 type AttributeValueType int32
 
 const (
-	AttributeValueTypeNull AttributeValueType = iota
+	AttributeValueTypeEmpty AttributeValueType = iota
 	AttributeValueTypeString
 	AttributeValueTypeInt
 	AttributeValueTypeDouble
@@ -44,8 +44,8 @@ const (
 // String returns the string representation of the AttributeValueType.
 func (avt AttributeValueType) String() string {
 	switch avt {
-	case AttributeValueTypeNull:
-		return "NULL"
+	case AttributeValueTypeEmpty:
+		return "EMPTY"
 	case AttributeValueTypeString:
 		return "STRING"
 	case AttributeValueTypeBool:
@@ -88,8 +88,8 @@ func newAttributeValue(orig *otlpcommon.AnyValue) AttributeValue {
 	return AttributeValue{orig}
 }
 
-// NewAttributeValueNull creates a new AttributeValue with a null value.
-func NewAttributeValueNull() AttributeValue {
+// NewAttributeValueEmpty creates a new AttributeValue with an empty value.
+func NewAttributeValueEmpty() AttributeValue {
 	return AttributeValue{orig: &otlpcommon.AnyValue{}}
 }
 
@@ -134,7 +134,7 @@ func NewAttributeValueBytes(v []byte) AttributeValue {
 // Calling this function on zero-initialized AttributeValue will cause a panic.
 func (a AttributeValue) Type() AttributeValueType {
 	if a.orig.Value == nil {
-		return AttributeValueTypeNull
+		return AttributeValueTypeEmpty
 	}
 	switch a.orig.Value.(type) {
 	case *otlpcommon.AnyValue_StringValue:
@@ -152,7 +152,7 @@ func (a AttributeValue) Type() AttributeValueType {
 	case *otlpcommon.AnyValue_BytesValue:
 		return AttributeValueTypeBytes
 	}
-	return AttributeValueTypeNull
+	return AttributeValueTypeEmpty
 }
 
 // StringVal returns the string value associated with this AttributeValue.
@@ -252,6 +252,20 @@ func (a AttributeValue) SetBoolVal(v bool) {
 // across multiple attributes is forbidden.
 func (a AttributeValue) SetBytesVal(v []byte) {
 	a.orig.Value = &otlpcommon.AnyValue_BytesValue{BytesValue: v}
+}
+
+// SetMapVal replaces the AttributeMap value associated with this AttributeValue,
+// it also changes the type to be AttributeValueTypeMap.
+// Calling this function on zero-initialized AttributeValue will cause a panic.
+func (a AttributeValue) SetMapVal(v AttributeMap) {
+	a.orig.Value = &otlpcommon.AnyValue_KvlistValue{KvlistValue: &otlpcommon.KeyValueList{Values: *v.orig}}
+}
+
+// SetArrayVal replaces the AnyValueArray value associated with this AttributeValue,
+// it also changes the type to be AttributeValueTypeArray.
+// Calling this function on zero-initialized AttributeValue will cause a panic.
+func (a AttributeValue) SetArrayVal(v AnyValueArray) {
+	a.orig.Value = &otlpcommon.AnyValue_ArrayValue{ArrayValue: &otlpcommon.ArrayValue{Values: *v.orig}}
 }
 
 // copyTo copies the value to AnyValue. Will panic if dest is nil.
@@ -368,7 +382,7 @@ func (a AttributeValue) Equal(av AttributeValue) bool {
 // if the AttributeValueType is AttributeValueTypeString.
 func (a AttributeValue) AsString() string {
 	switch a.Type() {
-	case AttributeValueTypeNull:
+	case AttributeValueTypeEmpty:
 		return ""
 
 	case AttributeValueTypeString:
@@ -808,7 +822,7 @@ func AttributeMapToMap(attrMap AttributeMap) map[string]interface{} {
 			rawMap[k] = v.DoubleVal()
 		case AttributeValueTypeBool:
 			rawMap[k] = v.BoolVal()
-		case AttributeValueTypeNull:
+		case AttributeValueTypeEmpty:
 			rawMap[k] = nil
 		case AttributeValueTypeMap:
 			rawMap[k] = AttributeMapToMap(v.MapVal())
@@ -834,7 +848,7 @@ func attributeArrayToSlice(attrArray AnyValueArray) []interface{} {
 			rawSlice = append(rawSlice, v.DoubleVal())
 		case AttributeValueTypeBool:
 			rawSlice = append(rawSlice, v.BoolVal())
-		case AttributeValueTypeNull:
+		case AttributeValueTypeEmpty:
 			rawSlice = append(rawSlice, nil)
 		default:
 			rawSlice = append(rawSlice, "<Invalid array value>")

--- a/model/pdata/common_test.go
+++ b/model/pdata/common_test.go
@@ -41,8 +41,8 @@ func TestAttributeValue(t *testing.T) {
 	assert.EqualValues(t, AttributeValueTypeBool, v.Type())
 	assert.True(t, v.BoolVal())
 
-	v = NewAttributeValueNull()
-	assert.EqualValues(t, AttributeValueTypeNull, v.Type())
+	v = NewAttributeValueEmpty()
+	assert.EqualValues(t, AttributeValueTypeEmpty, v.Type())
 
 	v.SetStringVal("abc")
 	assert.EqualValues(t, AttributeValueTypeString, v.Type())
@@ -67,7 +67,7 @@ func TestAttributeValue(t *testing.T) {
 }
 
 func TestAttributeValueType(t *testing.T) {
-	assert.EqualValues(t, "NULL", AttributeValueTypeNull.String())
+	assert.EqualValues(t, "EMPTY", AttributeValueTypeEmpty.String())
 	assert.EqualValues(t, "STRING", AttributeValueTypeString.String())
 	assert.EqualValues(t, "BOOL", AttributeValueTypeBool.String())
 	assert.EqualValues(t, "INT", AttributeValueTypeInt.String())
@@ -155,30 +155,30 @@ func TestAttributeValueMap(t *testing.T) {
 }
 
 func TestNilOrigSetAttributeValue(t *testing.T) {
-	av := NewAttributeValueNull()
+	av := NewAttributeValueEmpty()
 	av.SetStringVal("abc")
 	assert.EqualValues(t, "abc", av.StringVal())
 
-	av = NewAttributeValueNull()
+	av = NewAttributeValueEmpty()
 	av.SetIntVal(123)
 	assert.EqualValues(t, 123, av.IntVal())
 
-	av = NewAttributeValueNull()
+	av = NewAttributeValueEmpty()
 	av.SetBoolVal(true)
 	assert.True(t, av.BoolVal())
 
-	av = NewAttributeValueNull()
+	av = NewAttributeValueEmpty()
 	av.SetDoubleVal(1.23)
 	assert.EqualValues(t, 1.23, av.DoubleVal())
 
-	av = NewAttributeValueNull()
+	av = NewAttributeValueEmpty()
 	av.SetBytesVal([]byte{1, 2, 3})
 	assert.Equal(t, []byte{1, 2, 3}, av.BytesVal())
 }
 
 func TestAttributeValueEqual(t *testing.T) {
-	av1 := NewAttributeValueNull()
-	av2 := NewAttributeValueNull()
+	av1 := NewAttributeValueEmpty()
+	av2 := NewAttributeValueEmpty()
 	assert.True(t, av1.Equal(av2))
 
 	av2 = NewAttributeValueString("abc")
@@ -285,7 +285,7 @@ func TestNilAttributeMap(t *testing.T) {
 
 	insertMapNull := NewAttributeMap()
 	insertMapNull.InsertNull("k")
-	assert.EqualValues(t, generateTestNullAttributeMap(), insertMapNull)
+	assert.EqualValues(t, generateTestEmptyAttributeMap(), insertMapNull)
 
 	insertMapInt := NewAttributeMap()
 	insertMapInt.InsertInt("k", 123)
@@ -381,7 +381,7 @@ func TestAttributeMapWithEmpty(t *testing.T) {
 
 	val, exist = sm.Get("test_key2")
 	assert.True(t, exist)
-	assert.EqualValues(t, AttributeValueTypeNull, val.Type())
+	assert.EqualValues(t, AttributeValueTypeEmpty, val.Type())
 	assert.EqualValues(t, "", val.StringVal())
 
 	sm.Insert("other_key", NewAttributeValueString("other_value"))
@@ -551,7 +551,7 @@ func TestAttributeMapWithEmpty(t *testing.T) {
 
 	val, exist = sm.Get("test_key2")
 	assert.True(t, exist)
-	assert.EqualValues(t, AttributeValueTypeNull, val.Type())
+	assert.EqualValues(t, AttributeValueTypeEmpty, val.Type())
 	assert.EqualValues(t, "", val.StringVal())
 
 	_, exist = sm.Get("test_key3")
@@ -575,7 +575,7 @@ func TestAttributeMap_Range(t *testing.T) {
 		"k_int":    NewAttributeValueInt(123),
 		"k_double": NewAttributeValueDouble(1.23),
 		"k_bool":   NewAttributeValueBool(true),
-		"k_null":   NewAttributeValueNull(),
+		"k_empty":  NewAttributeValueEmpty(),
 		"k_bytes":  NewAttributeValueBytes([]byte{}),
 	}
 	am := NewAttributeMapFromMap(rawMap)
@@ -605,7 +605,7 @@ func TestAttributeMap_InitFromMap(t *testing.T) {
 		"k_int":    NewAttributeValueInt(123),
 		"k_double": NewAttributeValueDouble(1.23),
 		"k_bool":   NewAttributeValueBool(true),
-		"k_null":   NewAttributeValueNull(),
+		"k_null":   NewAttributeValueEmpty(),
 		"k_bytes":  NewAttributeValueBytes([]byte{1, 2, 3}),
 	}
 	rawOrig := []otlpcommon.KeyValue{
@@ -622,13 +622,13 @@ func TestAttributeMap_InitFromMap(t *testing.T) {
 
 func TestAttributeValue_CopyTo(t *testing.T) {
 	// Test nil KvlistValue case for MapVal() func.
-	dest := NewAttributeValueNull()
+	dest := NewAttributeValueEmpty()
 	orig := &otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_KvlistValue{KvlistValue: nil}}
 	AttributeValue{orig: orig}.CopyTo(dest)
 	assert.Nil(t, dest.orig.Value.(*otlpcommon.AnyValue_KvlistValue).KvlistValue)
 
 	// Test nil ArrayValue case for ArrayVal() func.
-	dest = NewAttributeValueNull()
+	dest = NewAttributeValueEmpty()
 	orig = &otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_ArrayValue{ArrayValue: nil}}
 	AttributeValue{orig: orig}.CopyTo(dest)
 	assert.Nil(t, dest.orig.Value.(*otlpcommon.AnyValue_ArrayValue).ArrayValue)
@@ -659,7 +659,7 @@ func TestAttributeMap_CopyTo(t *testing.T) {
 }
 
 func TestAttributeValue_copyTo(t *testing.T) {
-	av := NewAttributeValueNull()
+	av := NewAttributeValueEmpty()
 	destVal := otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_IntValue{}}
 	av.copyTo(&destVal)
 	assert.EqualValues(t, nil, destVal.Value)
@@ -693,7 +693,7 @@ func TestAttributeMap_Update(t *testing.T) {
 
 	av, exists = sm.Get("test_key2")
 	assert.True(t, exists)
-	assert.EqualValues(t, AttributeValueTypeNull, av.Type())
+	assert.EqualValues(t, AttributeValueTypeEmpty, av.Type())
 	assert.EqualValues(t, "", av.StringVal())
 	av.SetIntVal(123)
 
@@ -834,7 +834,7 @@ func fillTestAttributeValue(dest AttributeValue) {
 }
 
 func generateTestAttributeValue() AttributeValue {
-	av := NewAttributeValueNull()
+	av := NewAttributeValueEmpty()
 	fillTestAttributeValue(av)
 	return av
 }
@@ -851,9 +851,9 @@ func fillTestAttributeMap(dest AttributeMap) {
 	}).CopyTo(dest)
 }
 
-func generateTestNullAttributeMap() AttributeMap {
+func generateTestEmptyAttributeMap() AttributeMap {
 	return NewAttributeMapFromMap(map[string]AttributeValue{
-		"k": NewAttributeValueNull(),
+		"k": NewAttributeValueEmpty(),
 	})
 }
 func generateTestIntAttributeMap() AttributeMap {
@@ -886,8 +886,7 @@ func TestAttributeValueArray(t *testing.T) {
 	assert.EqualValues(t, NewAnyValueArray(), a1.ArrayVal())
 	assert.EqualValues(t, 0, a1.ArrayVal().Len())
 
-	v := a1.ArrayVal().AppendEmpty()
-	v.SetDoubleVal(123)
+	a1.ArrayVal().AppendEmpty().SetDoubleVal(123)
 	assert.EqualValues(t, 1, a1.ArrayVal().Len())
 	assert.EqualValues(t, NewAttributeValueDouble(123), a1.ArrayVal().At(0))
 	// Create a second array.
@@ -899,7 +898,7 @@ func TestAttributeValueArray(t *testing.T) {
 	assert.EqualValues(t, NewAttributeValueString("somestr"), a2.ArrayVal().At(0))
 
 	// Insert the second array as a child.
-	a2.CopyTo(a1.ArrayVal().AppendEmpty())
+	a1.ArrayVal().AppendEmpty().SetArrayVal(a2.ArrayVal())
 	assert.EqualValues(t, 2, a1.ArrayVal().Len())
 	assert.EqualValues(t, NewAttributeValueDouble(123), a1.ArrayVal().At(0))
 	assert.EqualValues(t, a2, a1.ArrayVal().At(1))
@@ -909,7 +908,7 @@ func TestAttributeValueArray(t *testing.T) {
 	assert.EqualValues(t, AttributeValueTypeArray, childArray.Type())
 	assert.EqualValues(t, 1, childArray.ArrayVal().Len())
 
-	v = childArray.ArrayVal().At(0)
+	v := childArray.ArrayVal().At(0)
 	assert.EqualValues(t, AttributeValueTypeString, v.Type())
 	assert.EqualValues(t, "somestr", v.StringVal())
 
@@ -928,7 +927,7 @@ func TestAnyValueArrayWithNilValues(t *testing.T) {
 	}
 
 	val := sm.At(0)
-	assert.EqualValues(t, AttributeValueTypeNull, val.Type())
+	assert.EqualValues(t, AttributeValueTypeEmpty, val.Type())
 	assert.EqualValues(t, "", val.StringVal())
 
 	val = sm.At(1)
@@ -988,8 +987,8 @@ func TestAsString(t *testing.T) {
 			expected: "[\"strVal\",7,18.6,false,null]",
 		},
 		{
-			name:     "null",
-			input:    NewAttributeValueNull(),
+			name:     "empty",
+			input:    NewAttributeValueEmpty(),
 			expected: "",
 		},
 	}
@@ -1008,7 +1007,7 @@ func simpleAttributeValueMap() AttributeValue {
 	attrMap.UpsertInt("intKey", 7)
 	attrMap.UpsertDouble("floatKey", 18.6)
 	attrMap.UpsertBool("boolKey", false)
-	attrMap.Upsert("nullKey", NewAttributeValueNull())
+	attrMap.Upsert("nullKey", NewAttributeValueEmpty())
 	attrMap.Upsert("mapKey", constructTestAttributeSubmap())
 	attrMap.Upsert("arrKey", constructTestAttributeSubarray())
 	return ret


### PR DESCRIPTION
Signed-off-by: Anthony J Mirabella <a9@aneurysm9.com>

**Description:** Takes the second alternative outlined in #3930.  Renames the `NULL` attribute value to `EMPTY` to maintain parity with other collection types that use `AppendEmpty()`.  Added `SetMapVal()` and `SetArrayVal()` to the `AttributeValue` type to simplify converting the entry to those types.  We can later add typed `Append*` methods on the `AnyValueArray` type if this indirection proves too cumbersome.

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector/issues/3930