### PR TITLE
fix: skip nil metrics

### DIFF
--- a/model/internal/otlp_wrapper.go
+++ b/model/internal/otlp_wrapper.go
@@ -50,6 +50,9 @@ func MetricsCompatibilityChanges(req *otlpcollectormetrics.ExportMetricsServiceR
 	for _, rsm := range req.ResourceMetrics {
 		for _, ilm := range rsm.InstrumentationLibraryMetrics {
 			for _, metric := range ilm.Metrics {
+				if metric == nil {
+					continue
+				}
 				switch m := metric.Data.(type) {
 				case *otlpmetrics.Metric_IntHistogram:
 					metric.Data = intHistogramToHistogram(m)

--- a/model/internal/otlp_wrappers_test.go
+++ b/model/internal/otlp_wrappers_test.go
@@ -752,3 +752,32 @@ func TestAttributesAndLabels(t *testing.T) {
 		})
 	}
 }
+
+func TestNilMetric(t *testing.T) {
+	tests := []struct {
+		inputMetrics  []*otlpmetrics.Metric
+		outputMetrics []*otlpmetrics.Metric
+	}{
+		{
+			inputMetrics:  nil,
+			outputMetrics: nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run("nil input metric", func(t *testing.T) {
+			req := &otlpcollectormetrics.ExportMetricsServiceRequest{
+				ResourceMetrics: []*otlpmetrics.ResourceMetrics{
+					{
+						InstrumentationLibraryMetrics: []*otlpmetrics.InstrumentationLibraryMetrics{
+							{
+								Metrics: test.inputMetrics,
+							},
+						}},
+				},
+			}
+			MetricsCompatibilityChanges(req)
+			assert.EqualValues(t, test.outputMetrics, req.ResourceMetrics[0].InstrumentationLibraryMetrics[0].Metrics)
+		})
+	}
+}


### PR DESCRIPTION
**Description:**
Some versions of OTLP in JSON over HTTP causes nil values to be inserted into the Metrics slice. This PR checks for that condition and avoids the panic. This does not address the underlying issue of why that metric was `nil` in the first place.

**Link to tracking Issue:** Fixes #3978 

**Testing:** Reproduce the case described in the original issue with the otel-js sdk. Added a unit test as well.