### PR TITLE
add AttributeValueBytes support to AsString

### DIFF
--- a/model/pdata/common.go
+++ b/model/pdata/common.go
@@ -401,6 +401,9 @@ func (a AttributeValue) AsString() string {
 		jsonStr, _ := json.Marshal(a.MapVal().AsRaw())
 		return string(jsonStr)
 
+	case AttributeValueTypeBytes:
+		return string(a.BytesVal())
+
 	case AttributeValueTypeArray:
 		jsonStr, _ := json.Marshal(attributeArrayToSlice(a.ArrayVal()))
 		return string(jsonStr)

--- a/model/pdata/common.go
+++ b/model/pdata/common.go
@@ -19,6 +19,7 @@ package pdata
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"sort"
@@ -402,7 +403,7 @@ func (a AttributeValue) AsString() string {
 		return string(jsonStr)
 
 	case AttributeValueTypeBytes:
-		return string(a.BytesVal())
+		return base64.StdEncoding.EncodeToString(a.BytesVal())
 
 	case AttributeValueTypeArray:
 		jsonStr, _ := json.Marshal(attributeArrayToSlice(a.ArrayVal()))

--- a/model/pdata/common_test.go
+++ b/model/pdata/common_test.go
@@ -15,6 +15,7 @@
 package pdata
 
 import (
+	"encoding/base64"
 	"strconv"
 	"testing"
 
@@ -994,7 +995,7 @@ func TestAsString(t *testing.T) {
 		{
 			name:     "bytes",
 			input:    NewAttributeValueBytes([]byte("String bytes")),
-			expected: "String bytes",
+			expected: base64.StdEncoding.EncodeToString([]byte("String bytes")),
 		},
 	}
 	for _, test := range tests {

--- a/model/pdata/common_test.go
+++ b/model/pdata/common_test.go
@@ -991,6 +991,11 @@ func TestAsString(t *testing.T) {
 			input:    NewAttributeValueEmpty(),
 			expected: "",
 		},
+		{
+			name:     "bytes",
+			input:    NewAttributeValueBytes([]byte("String bytes")),
+			expected: "String bytes",
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
**Description:** 
Adding support for `AttributeValueBytes` type to `AsString` method.

**Link to tracking Issue:** Fixes #3996

**Testing:** Unit test added
