### PR TITLE
Cleanup collector, remove duplicate fields with settings, restructure code

### DIFF
--- a/service/collector.go
+++ b/service/collector.go
@@ -68,7 +68,8 @@ const (
 
 // Collector represents a server providing the OpenTelemetry Collector service.
 type Collector struct {
-	info    component.BuildInfo
+	set CollectorSettings
+
 	rootCmd *cobra.Command
 	logger  *zap.Logger
 
@@ -78,18 +79,11 @@ type Collector struct {
 	service      *service
 	stateChannel chan State
 
-	factories component.Factories
-
-	parserProvider    parserprovider.ParserProvider
-	configUnmarshaler configunmarshaler.ConfigUnmarshaler
-
 	// shutdownChan is used to terminate the collector.
 	shutdownChan chan struct{}
 
 	// signalsChannel is used to receive termination signals from the OS.
 	signalsChannel chan os.Signal
-
-	allowGracefulShutodwn bool
 
 	// asyncErrorChannel is used to signal a fatal error from any component.
 	asyncErrorChannel chan error
@@ -101,45 +95,25 @@ func New(set CollectorSettings) (*Collector, error) {
 		return nil, err
 	}
 
+	if set.ParserProvider == nil {
+		// use default provider.
+		set.ParserProvider = parserprovider.Default()
+	}
+
+	if set.ConfigUnmarshaler == nil {
+		// use default unmarshaler.
+		set.ConfigUnmarshaler = configunmarshaler.NewDefault()
+	}
+
 	col := &Collector{
-		info:              set.BuildInfo,
-		factories:         set.Factories,
-		stateChannel:      make(chan State, Closed+1),
-		parserProvider:    set.ParserProvider,
-		configUnmarshaler: set.ConfigUnmarshaler,
-		// We use a negative in the settings not to break the existing
-		// behavior. Internally, allowGracefulShutodwn is more readable.
-		allowGracefulShutodwn: !set.DisableGracefulShutdown,
-	}
-
-	if col.parserProvider == nil {
-		// use default provider.
-		col.parserProvider = parserprovider.Default()
-	}
-
-	if col.configUnmarshaler == nil {
-		// use default provider.
-		col.configUnmarshaler = configunmarshaler.NewDefault()
+		set:          set,
+		stateChannel: make(chan State, Closed+1),
 	}
 
 	rootCmd := &cobra.Command{
 		Use:     set.BuildInfo.Command,
 		Version: set.BuildInfo.Version,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			var err error
-			if col.logger, err = newLogger(set.LoggingOptions); err != nil {
-				return fmt.Errorf("failed to get logger: %w", err)
-			}
-
-			col.zPagesSpanProcessor = zpages.NewSpanProcessor()
-			col.tracerProvider = sdktrace.NewTracerProvider(
-				sdktrace.WithSampler(internal.AlwaysRecord()),
-				sdktrace.WithSpanProcessor(col.zPagesSpanProcessor))
-
-			// Set the constructed tracer provider as Global, in case any component uses the
-			// global TracerProvider.
-			otel.SetTracerProvider(col.tracerProvider)
-
 			return col.execute(cmd.Context())
 		},
 	}
@@ -190,8 +164,6 @@ func (col *Collector) GetLogger() *zap.Logger {
 
 // Shutdown shuts down the collector server.
 func (col *Collector) Shutdown() {
-	// TODO: Implement a proper shutdown with graceful draining of the pipeline.
-	// See https://github.com/open-telemetry/opentelemetry-collector/issues/483.
 	defer func() {
 		if r := recover(); r != nil {
 			col.logger.Info("shutdownChan already closed")
@@ -200,24 +172,13 @@ func (col *Collector) Shutdown() {
 	close(col.shutdownChan)
 }
 
-func (col *Collector) setupTelemetry(ballastSizeBytes uint64) error {
-	col.logger.Info("Setting up own telemetry...")
-
-	err := collectorTelemetry.init(col.asyncErrorChannel, ballastSizeBytes, col.logger)
-	if err != nil {
-		return fmt.Errorf("failed to initialize telemetry: %w", err)
-	}
-
-	return nil
-}
-
 // runAndWaitForShutdownEvent waits for one of the shutdown events that can happen.
 func (col *Collector) runAndWaitForShutdownEvent() {
 	col.logger.Info("Everything is ready. Begin running and processing data.")
 
 	col.signalsChannel = make(chan os.Signal, 1)
 	// Only notify with SIGTERM and SIGINT if graceful shutdown is enabled.
-	if col.allowGracefulShutodwn {
+	if !col.set.DisableGracefulShutdown {
 		signal.Notify(col.signalsChannel, os.Interrupt, syscall.SIGTERM)
 	}
 
@@ -237,14 +198,12 @@ func (col *Collector) runAndWaitForShutdownEvent() {
 // setupConfigurationComponents loads the config and starts the components. If all the steps succeeds it
 // sets the col.service with the service currently running.
 func (col *Collector) setupConfigurationComponents(ctx context.Context) error {
-	col.logger.Info("Loading configuration...")
-
-	cp, err := col.parserProvider.Get(ctx)
+	cp, err := col.set.ParserProvider.Get(ctx)
 	if err != nil {
 		return fmt.Errorf("cannot load configuration's parser: %w", err)
 	}
 
-	cfg, err := col.configUnmarshaler.Unmarshal(cp, col.factories)
+	cfg, err := col.set.ConfigUnmarshaler.Unmarshal(cp, col.set.Factories)
 	if err != nil {
 		return fmt.Errorf("cannot load configuration: %w", err)
 	}
@@ -253,11 +212,9 @@ func (col *Collector) setupConfigurationComponents(ctx context.Context) error {
 		return fmt.Errorf("invalid configuration: %w", err)
 	}
 
-	col.logger.Info("Applying configuration...")
-
-	service, err := newService(&svcSettings{
-		BuildInfo:           col.info,
-		Factories:           col.factories,
+	col.service, err = newService(&svcSettings{
+		BuildInfo:           col.set.BuildInfo,
+		Factories:           col.set.Factories,
 		Config:              cfg,
 		Logger:              col.logger,
 		TracerProvider:      col.tracerProvider,
@@ -268,52 +225,46 @@ func (col *Collector) setupConfigurationComponents(ctx context.Context) error {
 		return err
 	}
 
-	err = service.Start(ctx)
-	if err != nil {
+	if err = col.service.Start(ctx); err != nil {
 		return err
 	}
 
-	col.service = service
-
 	// If provider is watchable start a goroutine watching for updates.
-	if watchable, ok := col.parserProvider.(parserprovider.Watchable); ok {
-		go func() {
-			err := watchable.WatchForUpdate()
-			switch {
-			// TODO: Move configsource.ErrSessionClosed to providerparser package to avoid depending on configsource.
-			case errors.Is(err, configsource.ErrSessionClosed):
-				// This is the case of shutdown of the whole collector server, nothing to do.
-				col.logger.Info("Config WatchForUpdate closed", zap.Error(err))
-				return
-			default:
-				col.logger.Warn("Config WatchForUpdated exited", zap.Error(err))
-				if err := col.reloadService(context.Background()); err != nil {
-					col.asyncErrorChannel <- err
-				}
-			}
-		}()
+	if watchable, ok := col.set.ParserProvider.(parserprovider.Watchable); ok {
+		go col.watchForConfigUpdates(watchable)
 	}
 
 	return nil
 }
 
 func (col *Collector) execute(ctx context.Context) error {
-	col.logger.Info("Starting "+col.info.Command+"...",
-		zap.String("Version", col.info.Version),
+	var err error
+	if col.logger, err = newLogger(col.set.LoggingOptions); err != nil {
+		return fmt.Errorf("failed to get logger: %w", err)
+	}
+
+	col.zPagesSpanProcessor = zpages.NewSpanProcessor()
+	col.tracerProvider = sdktrace.NewTracerProvider(
+		sdktrace.WithSampler(internal.AlwaysRecord()),
+		sdktrace.WithSpanProcessor(col.zPagesSpanProcessor))
+
+	// Set the constructed tracer provider as Global, in case any component uses the
+	// global TracerProvider.
+	otel.SetTracerProvider(col.tracerProvider)
+
+	col.logger.Info("Starting "+col.set.BuildInfo.Command+"...",
+		zap.String("Version", col.set.BuildInfo.Version),
 		zap.Int("NumCPU", runtime.NumCPU()),
 	)
 	col.stateChannel <- Starting
 
 	col.asyncErrorChannel = make(chan error)
 
-	err := col.setupConfigurationComponents(ctx)
-	if err != nil {
+	if err = col.setupConfigurationComponents(ctx); err != nil {
 		return err
 	}
 
-	// Get ballastSizeBytes if ballast extension is enabled and setup Telemetry.
-	err = col.setupTelemetry(col.getBallastSize())
-	if err != nil {
+	if err = collectorTelemetry.init(col.asyncErrorChannel, getBallastSize(col.service), col.logger); err != nil {
 		return err
 	}
 
@@ -326,12 +277,12 @@ func (col *Collector) execute(ctx context.Context) error {
 	// Begin shutdown sequence.
 	col.logger.Info("Starting shutdown...")
 
-	if err = col.parserProvider.Close(ctx); err != nil {
+	if err = col.set.ParserProvider.Close(ctx); err != nil {
 		errs = append(errs, fmt.Errorf("failed to close config: %w", err))
 	}
 
 	if col.service != nil {
-		if err := col.service.Shutdown(ctx); err != nil {
+		if err = col.service.Shutdown(ctx); err != nil {
 			errs = append(errs, fmt.Errorf("failed to shutdown service: %w", err))
 		}
 	}
@@ -351,7 +302,7 @@ func (col *Collector) execute(ctx context.Context) error {
 // to the latest configuration. It requires that col.parserProvider and col.factories
 // are properly populated to finish successfully.
 func (col *Collector) reloadService(ctx context.Context) error {
-	if err := col.parserProvider.Close(ctx); err != nil {
+	if err := col.set.ParserProvider.Close(ctx); err != nil {
 		return fmt.Errorf("failed close current config provider: %w", err)
 	}
 
@@ -370,9 +321,22 @@ func (col *Collector) reloadService(ctx context.Context) error {
 	return nil
 }
 
-func (col *Collector) getBallastSize() uint64 {
+func (col *Collector) watchForConfigUpdates(watchable parserprovider.Watchable) {
+	err := watchable.WatchForUpdate()
+	if errors.Is(err, configsource.ErrSessionClosed) {
+		// This is the case of shutdown of the whole collector server, nothing to do.
+		col.logger.Info("Config WatchForUpdate closed", zap.Error(err))
+		return
+	}
+	col.logger.Warn("Config WatchForUpdated exited", zap.Error(err))
+	if err = col.reloadService(context.Background()); err != nil {
+		col.asyncErrorChannel <- err
+	}
+}
+
+func getBallastSize(host component.Host) uint64 {
 	var ballastSize uint64
-	extensions := col.service.GetExtensions()
+	extensions := host.GetExtensions()
 	for _, extension := range extensions {
 		if ext, ok := extension.(*ballastextension.MemoryBallast); ok {
 			ballastSize = ext.GetBallastSize()

--- a/service/collector_test.go
+++ b/service/collector_test.go
@@ -318,12 +318,14 @@ func TestCollector_reloadService(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			col := Collector{
-				logger:            zap.NewNop(),
-				tracerProvider:    trace.NewNoopTracerProvider(),
-				parserProvider:    tt.parserProvider,
-				configUnmarshaler: configunmarshaler.NewDefault(),
-				factories:         factories,
-				service:           tt.service,
+				set: CollectorSettings{
+					ParserProvider:    tt.parserProvider,
+					ConfigUnmarshaler: configunmarshaler.NewDefault(),
+					Factories:         factories,
+				},
+				logger:         zap.NewNop(),
+				tracerProvider: trace.NewNoopTracerProvider(),
+				service:        tt.service,
 			}
 
 			err := col.reloadService(ctx)


### PR DESCRIPTION
Updates: https://github.com/open-telemetry/opentelemetry-collector/issues/3957

Need these cleanups to allow separation between flags parsing and usage, this will happen in a separate PR.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
