### PR TITLE
Add configuration to setup collector logs via config file.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -161,7 +161,7 @@ type Service struct {
 
 // ServiceTelemetry defines the configurable settings for service telemetry.
 type ServiceTelemetry struct {
-	Logs ServiceTelemetryLogs `mapstructure:"logs"`
+	Logs ServiceTelemetryLogs
 }
 
 func (srvT *ServiceTelemetry) validate() error {
@@ -173,24 +173,18 @@ func (srvT *ServiceTelemetry) validate() error {
 // the collector uses mapstructure and not yaml tags.
 type ServiceTelemetryLogs struct {
 	// Level is the minimum enabled logging level.
-	// Valid values are "DEBUG", "INFO", "WARN", "ERROR", "DPANIC", "PANIC", "FATAL".
-	Level string `mapstructure:"level"`
+	Level zapcore.Level
 
 	// Development puts the logger in development mode, which changes the
 	// behavior of DPanicLevel and takes stacktraces more liberally.
-	Development bool `mapstructure:"development"`
+	Development bool
 
 	// Encoding sets the logger's encoding.
 	// Valid values are "json" and "console".
-	Encoding string `mapstructure:"encoding"`
+	Encoding string
 }
 
 func (srvTL *ServiceTelemetryLogs) validate() error {
-	var lvl zapcore.Level
-	if err := lvl.UnmarshalText([]byte(srvTL.Level)); err != nil {
-		return fmt.Errorf(`service telemetry logs invalid level: %q, valid values are "DEBUG", "INFO", "WARN", "ERROR", "DPANIC", "PANIC", "FATAL"`, srvTL.Level)
-	}
-
 	if srvTL.Encoding != "json" && srvTL.Encoding != "console" {
 		return fmt.Errorf(`service telemetry logs invalid encoding: %q, valid values are "json" and "console"`, srvTL.Encoding)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -18,6 +18,8 @@ import (
 	"errors"
 	"fmt"
 
+	"go.uber.org/zap/zapcore"
+
 	"go.opentelemetry.io/collector/config/configparser"
 )
 
@@ -84,18 +86,16 @@ func (cfg *Config) Validate() error {
 		}
 	}
 
-	// Check that all enabled extensions in the service are configured.
-	if err := cfg.validateServiceExtensions(); err != nil {
+	return cfg.validateService()
+}
+
+func (cfg *Config) validateService() error {
+	// Validate Telemetry
+	if err := cfg.Service.Telemetry.validate(); err != nil {
 		return err
 	}
 
-	// Check that all pipelines have at least one receiver and one exporter, and they reference
-	// only configured components.
-	return cfg.validateServicePipelines()
-}
-
-func (cfg *Config) validateServiceExtensions() error {
-	// Validate extensions.
+	// Check that all enabled extensions in the service are configured.
 	for _, ref := range cfg.Service.Extensions {
 		// Check that the name referenced in the Service extensions exists in the top-level extensions.
 		if cfg.Extensions[ref] == nil {
@@ -103,16 +103,13 @@ func (cfg *Config) validateServiceExtensions() error {
 		}
 	}
 
-	return nil
-}
-
-func (cfg *Config) validateServicePipelines() error {
 	// Must have at least one pipeline.
 	if len(cfg.Service.Pipelines) == 0 {
 		return errMissingServicePipelines
 	}
 
-	// Validate pipelines.
+	// Check that all pipelines have at least one receiver and one exporter, and they reference
+	// only configured components.
 	for _, pipeline := range cfg.Service.Pipelines {
 		// Validate pipeline has at least one receiver.
 		if len(pipeline.Receivers) == 0 {
@@ -153,11 +150,51 @@ func (cfg *Config) validateServicePipelines() error {
 
 // Service defines the configurable components of the service.
 type Service struct {
+	Telemetry ServiceTelemetry
+
 	// Extensions are the ordered list of extensions configured for the service.
 	Extensions []ComponentID
 
 	// Pipelines are the set of data pipelines configured for the service.
 	Pipelines Pipelines
+}
+
+// ServiceTelemetry defines the configurable settings for service telemetry.
+type ServiceTelemetry struct {
+	Logs ServiceTelemetryLogs `mapstructure:"logs"`
+}
+
+func (srvT *ServiceTelemetry) validate() error {
+	return srvT.Logs.validate()
+}
+
+// ServiceTelemetryLogs defines the configurable settings for service telemetry logs.
+// This MUST be compatible with zap.Config. Cannot use directly zap.Config because
+// the collector uses mapstructure and not yaml tags.
+type ServiceTelemetryLogs struct {
+	// Level is the minimum enabled logging level.
+	// Valid values are "DEBUG", "INFO", "WARN", "ERROR", "DPANIC", "PANIC", "FATAL".
+	Level string `mapstructure:"level"`
+
+	// Development puts the logger in development mode, which changes the
+	// behavior of DPanicLevel and takes stacktraces more liberally.
+	Development bool `mapstructure:"development"`
+
+	// Encoding sets the logger's encoding.
+	// Valid values are "json" and "console".
+	Encoding string `mapstructure:"encoding"`
+}
+
+func (srvTL *ServiceTelemetryLogs) validate() error {
+	var lvl zapcore.Level
+	if err := lvl.UnmarshalText([]byte(srvTL.Level)); err != nil {
+		return fmt.Errorf(`service telemetry logs invalid level: %q, valid values are "DEBUG", "INFO", "WARN", "ERROR", "DPANIC", "PANIC", "FATAL"`, srvTL.Level)
+	}
+
+	if srvTL.Encoding != "json" && srvTL.Encoding != "console" {
+		return fmt.Errorf(`service telemetry logs invalid encoding: %q, valid values are "json" and "console"`, srvTL.Encoding)
+	}
+	return nil
 }
 
 // Type is the component type as it is used in the config.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -212,6 +212,24 @@ func TestConfigValidate(t *testing.T) {
 			},
 			expected: fmt.Errorf(`extension "nop" has invalid configuration: %w`, errInvalidExtConfig),
 		},
+		{
+			name: "invalid-service-telemetry-level",
+			cfgFn: func() *Config {
+				cfg := generateConfig()
+				cfg.Service.Telemetry.Logs.Level = "unknown"
+				return cfg
+			},
+			expected: errors.New(`service telemetry logs invalid level: "unknown", valid values are "DEBUG", "INFO", "WARN", "ERROR", "DPANIC", "PANIC", "FATAL"`),
+		},
+		{
+			name: "invalid-service-telemetry-encoding",
+			cfgFn: func() *Config {
+				cfg := generateConfig()
+				cfg.Service.Telemetry.Logs.Encoding = "unknown"
+				return cfg
+			},
+			expected: errors.New(`service telemetry logs invalid encoding: "unknown", valid values are "json" and "console"`),
+		},
 	}
 
 	for _, test := range testCases {
@@ -245,6 +263,7 @@ func generateConfig() *Config {
 			},
 		},
 		Service: Service{
+			Telemetry:  ServiceTelemetry{Logs: ServiceTelemetryLogs{Level: "DEBUG", Development: true, Encoding: "console"}},
 			Extensions: []ComponentID{NewID("nop")},
 			Pipelines: map[string]*Pipeline{
 				"traces": {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap/zapcore"
 )
 
 var errInvalidRecvConfig = errors.New("invalid receiver config")
@@ -213,15 +214,6 @@ func TestConfigValidate(t *testing.T) {
 			expected: fmt.Errorf(`extension "nop" has invalid configuration: %w`, errInvalidExtConfig),
 		},
 		{
-			name: "invalid-service-telemetry-level",
-			cfgFn: func() *Config {
-				cfg := generateConfig()
-				cfg.Service.Telemetry.Logs.Level = "unknown"
-				return cfg
-			},
-			expected: errors.New(`service telemetry logs invalid level: "unknown", valid values are "DEBUG", "INFO", "WARN", "ERROR", "DPANIC", "PANIC", "FATAL"`),
-		},
-		{
 			name: "invalid-service-telemetry-encoding",
 			cfgFn: func() *Config {
 				cfg := generateConfig()
@@ -263,7 +255,7 @@ func generateConfig() *Config {
 			},
 		},
 		Service: Service{
-			Telemetry:  ServiceTelemetry{Logs: ServiceTelemetryLogs{Level: "DEBUG", Development: true, Encoding: "console"}},
+			Telemetry:  ServiceTelemetry{Logs: ServiceTelemetryLogs{Level: zapcore.DebugLevel, Development: true, Encoding: "console"}},
 			Extensions: []ComponentID{NewID("nop")},
 			Pipelines: map[string]*Pipeline{
 				"traces": {

--- a/config/configunmarshaler/defaultunmarshaler_test.go
+++ b/config/configunmarshaler/defaultunmarshaler_test.go
@@ -41,11 +41,6 @@ func TestDecodeConfig(t *testing.T) {
 	assert.Equal(t, 3, len(cfg.Extensions))
 	assert.Equal(t, "some string", cfg.Extensions[config.NewIDWithName("exampleextension", "1")].(*testcomponents.ExampleExtensionCfg).ExtraSetting)
 
-	// Verify service.
-	assert.Equal(t, 2, len(cfg.Service.Extensions))
-	assert.Equal(t, config.NewIDWithName("exampleextension", "0"), cfg.Service.Extensions[0])
-	assert.Equal(t, config.NewIDWithName("exampleextension", "1"), cfg.Service.Extensions[1])
-
 	// Verify receivers
 	assert.Equal(t, 2, len(cfg.Receivers), "Incorrect receivers count")
 
@@ -101,7 +96,15 @@ func TestDecodeConfig(t *testing.T) {
 		cfg.Processors[config.NewID("exampleprocessor")],
 		"Did not load processor config correctly")
 
-	// Verify Pipelines
+	// Verify Service Telemetry
+	assert.Equal(t, config.ServiceTelemetry{Logs: config.ServiceTelemetryLogs{Level: "DEBUG", Development: true, Encoding: "console"}}, cfg.Service.Telemetry)
+
+	// Verify Service Extensions
+	assert.Equal(t, 2, len(cfg.Service.Extensions))
+	assert.Equal(t, config.NewIDWithName("exampleextension", "0"), cfg.Service.Extensions[0])
+	assert.Equal(t, config.NewIDWithName("exampleextension", "1"), cfg.Service.Extensions[1])
+
+	// Verify Service Pipelines
 	assert.Equal(t, 1, len(cfg.Service.Pipelines), "Incorrect pipelines count")
 
 	assert.Equal(t,

--- a/config/configunmarshaler/defaultunmarshaler_test.go
+++ b/config/configunmarshaler/defaultunmarshaler_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config"
@@ -97,7 +98,7 @@ func TestDecodeConfig(t *testing.T) {
 		"Did not load processor config correctly")
 
 	// Verify Service Telemetry
-	assert.Equal(t, config.ServiceTelemetry{Logs: config.ServiceTelemetryLogs{Level: "DEBUG", Development: true, Encoding: "console"}}, cfg.Service.Telemetry)
+	assert.Equal(t, config.ServiceTelemetry{Logs: config.ServiceTelemetryLogs{Level: zapcore.DebugLevel, Development: true, Encoding: "console"}}, cfg.Service.Telemetry)
 
 	// Verify Service Extensions
 	assert.Equal(t, 2, len(cfg.Service.Extensions))
@@ -417,6 +418,8 @@ func TestDecodeConfig_Invalid(t *testing.T) {
 		{name: "invalid-processor-sub-config", expected: errUnmarshalTopLevelStructureError},
 		{name: "invalid-receiver-sub-config", expected: errUnmarshalTopLevelStructureError},
 		{name: "invalid-pipeline-sub-config", expected: errUnmarshalTopLevelStructureError},
+
+		{name: "invalid-logs-level", expected: errInvalidLogsLevel},
 	}
 
 	factories, err := testcomponents.ExampleComponents()

--- a/config/configunmarshaler/testdata/invalid-logs-level.yaml
+++ b/config/configunmarshaler/testdata/invalid-logs-level.yaml
@@ -1,0 +1,19 @@
+receivers:
+  examplereceiver:
+processors:
+  exampleprocessor:
+exporters:
+  exampleexporter:
+extensions:
+  exampleextension:
+service:
+  telemetry:
+    logs:
+      level: "UNKNOWN"
+  extensions: [exampleextension]
+  pipelines:
+    traces:
+      receivers: [examplereceiver]
+      processors: [exampleprocessor]
+      exporters: [exampleexporter]
+

--- a/config/configunmarshaler/testdata/valid-config.yaml
+++ b/config/configunmarshaler/testdata/valid-config.yaml
@@ -20,6 +20,11 @@ extensions:
     extra: "some string"
 
 service:
+  telemetry:
+    logs:
+      level: "DEBUG"
+      development: true
+      encoding: "console"
   extensions: [exampleextension/0, exampleextension/1]
   pipelines:
     traces:


### PR DESCRIPTION
Updates: https://github.com/open-telemetry/opentelemetry-collector/issues/3957

Next PRs will use this configuration and it will deprecate/remove the flags.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
