### PR TITLE
Remove AttributeHTTPStatusText const from nonstandard.go

### DIFF
--- a/model/semconv/v1.5.0/nonstandard.go
+++ b/model/semconv/v1.5.0/nonstandard.go
@@ -26,5 +26,4 @@ const (
 
 const (
 	AttributeMessageType    = "message.type"
-	AttributeHTTPStatusText = "http.status_text"
 )

--- a/model/semconv/v1.5.0/nonstandard.go
+++ b/model/semconv/v1.5.0/nonstandard.go
@@ -25,5 +25,5 @@ const (
 )
 
 const (
-	AttributeMessageType    = "message.type"
+	AttributeMessageType = "message.type"
 )


### PR DESCRIPTION
**Description:**
This PR removes the `AttributeHTTPStatusText` const from `/model/semconv/v1.5.0/nonstandard.go`.

**Link to tracking Issue:**
This PR, along with PR [5182](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/5182) in the collector-contrib repository, address issue #3999 
