### PR TITLE
fix: nil metrics being unmarshaled with invalid metrics

### DIFF
--- a/model/otlp/json_test.go
+++ b/model/otlp/json_test.go
@@ -120,3 +120,118 @@ func TestLogsJSON_Marshal(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, logsJSON, string(jsonBuf))
 }
+
+func TestMetricsNil(t *testing.T) {
+	jsonBuf := `{
+"resourceMetrics": [
+	{
+	"resource": {
+		"attributes": [
+		{
+			"key": "service.name",
+			"value": {
+			"stringValue": "unknown_service:node"
+			}
+		},
+		{
+			"key": "telemetry.sdk.language",
+			"value": {
+			"stringValue": "nodejs"
+			}
+		},
+		{
+			"key": "telemetry.sdk.name",
+			"value": {
+			"stringValue": "opentelemetry"
+			}
+		},
+		{
+			"key": "telemetry.sdk.version",
+			"value": {
+			"stringValue": "0.24.0"
+			}
+		}
+		],
+		"droppedAttributesCount": 0
+	},
+	"instrumentationLibraryMetrics": [
+		{
+		"metrics": [
+			{
+			"name": "metric_name",
+			"description": "Example of a UpDownCounter",
+			"unit": "1",
+			"doubleSum": {
+				"dataPoints": [
+				{
+					"labels": [
+					{
+						"key": "pid",
+						"value": "50712"
+					}
+					],
+					"value": 1,
+					"startTimeUnixNano": 1631056185376000000,
+					"timeUnixNano": 1631056185378763800
+				}
+				],
+				"isMonotonic": false,
+				"aggregationTemporality": 2
+			}
+			},
+			{
+			"name": "your_metric_name",
+			"description": "Example of a sync observer with callback",
+			"unit": "1",
+			"doubleGauge": {
+				"dataPoints": [
+				{
+					"labels": [
+					{
+						"key": "label",
+						"value": "1"
+					}
+					],
+					"value": 0.07604853280317792,
+					"startTimeUnixNano": 1631056185376000000,
+					"timeUnixNano": 1631056189394600700
+				}
+				]
+			}
+			},
+			{
+			"name": "your_metric_name",
+			"description": "Example of a sync observer with callback",
+			"unit": "1",
+			"doubleGauge": {
+				"dataPoints": [
+				{
+					"labels": [
+					{
+						"key": "label",
+						"value": "2"
+					}
+					],
+					"value": 0.9332005145656965,
+					"startTimeUnixNano": 1631056185376000000,
+					"timeUnixNano": 1631056189394630400
+				}
+				]
+			}
+			}
+		],
+		"instrumentationLibrary": {
+			"name": "example-meter"
+		}
+		}
+	]
+	}
+]
+}`
+	decoder := NewJSONMetricsUnmarshaler()
+	var got interface{}
+	got, err := decoder.UnmarshalMetrics([]byte(jsonBuf))
+	assert.Error(t, err)
+
+	assert.EqualValues(t, pdata.Metrics{}, got)
+}

--- a/model/otlp/json_unmarshaler.go
+++ b/model/otlp/json_unmarshaler.go
@@ -51,18 +51,26 @@ func newJSONUnmarshaler() *jsonUnmarshaler {
 
 func (d *jsonUnmarshaler) UnmarshalLogs(buf []byte) (pdata.Logs, error) {
 	ld := &otlpcollectorlog.ExportLogsServiceRequest{}
-	err := d.delegate.Unmarshal(bytes.NewReader(buf), ld)
-	return pdata.LogsFromInternalRep(internal.LogsFromOtlp(ld)), err
+
+	if err := d.delegate.Unmarshal(bytes.NewReader(buf), ld); err != nil {
+		return pdata.Logs{}, err
+	}
+	return pdata.LogsFromInternalRep(internal.LogsFromOtlp(ld)), nil
 }
 
 func (d *jsonUnmarshaler) UnmarshalMetrics(buf []byte) (pdata.Metrics, error) {
 	md := &otlpcollectormetrics.ExportMetricsServiceRequest{}
-	err := d.delegate.Unmarshal(bytes.NewReader(buf), md)
-	return pdata.MetricsFromInternalRep(internal.MetricsFromOtlp(md)), err
+
+	if err := d.delegate.Unmarshal(bytes.NewReader(buf), md); err != nil {
+		return pdata.Metrics{}, err
+	}
+	return pdata.MetricsFromInternalRep(internal.MetricsFromOtlp(md)), nil
 }
 
 func (d *jsonUnmarshaler) UnmarshalTraces(buf []byte) (pdata.Traces, error) {
 	td := &otlpcollectortrace.ExportTraceServiceRequest{}
-	err := d.delegate.Unmarshal(bytes.NewReader(buf), td)
-	return pdata.TracesFromInternalRep(internal.TracesFromOtlp(td)), err
+	if err := d.delegate.Unmarshal(bytes.NewReader(buf), td); err != nil {
+		return pdata.Traces{}, err
+	}
+	return pdata.TracesFromInternalRep(internal.TracesFromOtlp(td)), nil
 }


### PR DESCRIPTION
**Description:**
The underlying issue causing the panic and nil values to be injected was that the json parsing error was being raised but ignored and `MetricsFromInternalRep` was called anyways. The fix here checks that `err` is nil before calling additional methods on the returned data.

**Link to tracking Issue:** Fixes #3978

**Testing:** Added unit test to capture invalid metrics scenario.
