### PR TITLE
fix: remove AttributeMessageType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## 🛑 Breaking changes 🛑
 
+- Remove AttributeMessageType (#4020)
 - Remove `mem-ballast-size-mib`, already deprecated and no-op (#4005).
 
 ## v0.35.0 Beta

--- a/model/semconv/v1.5.0/nonstandard.go
+++ b/model/semconv/v1.5.0/nonstandard.go
@@ -23,4 +23,3 @@ const (
 	OtelStatusCode        = "otel.status_code"
 	OtelStatusDescription = "otel.status_description"
 )
-

--- a/model/semconv/v1.5.0/nonstandard.go
+++ b/model/semconv/v1.5.0/nonstandard.go
@@ -25,6 +25,5 @@ const (
 )
 
 const (
-	AttributeMessageType    = "message.type"
 	AttributeHTTPStatusText = "http.status_text"
 )


### PR DESCRIPTION
**Description:**
Removes `AttributeMessageType` from `/model/semconv/v1.5.0/nonstandard.go`

**Link to tracking Issue:**
This PR and PR in [contrib/5186](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/5186) addresses #3998  in the collector repository.