### PR TITLE
add MeterProvider to TelemetrySettings

### DIFF
--- a/component/componenttest/nop_telemetry.go
+++ b/component/componenttest/nop_telemetry.go
@@ -15,6 +15,7 @@
 package componenttest
 
 import (
+	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
@@ -26,5 +27,6 @@ func NewNopTelemetrySettings() component.TelemetrySettings {
 	return component.TelemetrySettings{
 		Logger:         zap.NewNop(),
 		TracerProvider: trace.NewNoopTracerProvider(),
+		MeterProvider:  metric.NoopMeterProvider{},
 	}
 }

--- a/component/telemetry.go
+++ b/component/telemetry.go
@@ -15,6 +15,7 @@
 package component
 
 import (
+	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 )
@@ -26,4 +27,7 @@ type TelemetrySettings struct {
 
 	// TracerProvider that the factory can pass to other instrumented third-party libraries.
 	TracerProvider trace.TracerProvider
+
+	// MeterProvider that the factory can pass to other instrumented third-party libraries.
+	MeterProvider metric.MeterProvider
 }

--- a/config/configgrpc/configgrpc.go
+++ b/config/configgrpc/configgrpc.go
@@ -347,10 +347,14 @@ func (gss *GRPCServerSettings) ToServerOption(ext map[config.ComponentID]compone
 	// TODO: Pass construct settings to have access to Tracer.
 	uInterceptors = append(uInterceptors, otelgrpc.UnaryServerInterceptor(
 		otelgrpc.WithTracerProvider(settings.TracerProvider),
+		// TODO: https://github.com/open-telemetry/opentelemetry-collector/issues/4030
+		// otelgrpc.WithMeterProvider(settings.MeterProvider),
 		otelgrpc.WithPropagators(otel.GetTextMapPropagator()),
 	))
 	sInterceptors = append(sInterceptors, otelgrpc.StreamServerInterceptor(
 		otelgrpc.WithTracerProvider(settings.TracerProvider),
+		// TODO: https://github.com/open-telemetry/opentelemetry-collector/issues/4030
+		// otelgrpc.WithMeterProvider(settings.MeterProvider),
 		otelgrpc.WithPropagators(otel.GetTextMapPropagator()),
 	))
 

--- a/config/confighttp/confighttp.go
+++ b/config/confighttp/confighttp.go
@@ -219,6 +219,7 @@ func (hss *HTTPServerSettings) ToServer(handler http.Handler, settings component
 		handler,
 		"",
 		otelhttp.WithTracerProvider(settings.TracerProvider),
+		otelhttp.WithMeterProvider(settings.MeterProvider),
 		otelhttp.WithPropagators(otel.GetTextMapPropagator()),
 		otelhttp.WithSpanNameFormatter(func(operation string, r *http.Request) string {
 			return r.URL.Path


### PR DESCRIPTION
**Description:**
Add `MeterProvider` to `TelemetrySettings` for any component to use.

**Link to tracking Issue:** Last part of https://github.com/open-telemetry/opentelemetry-collector/issues/3931
