### PR TITLE
rename NewParser* -> NewConfigMap*

### DIFF
--- a/config/configparser/parser.go
+++ b/config/configparser/parser.go
@@ -35,29 +35,29 @@ const (
 	KeyDelimiter = "::"
 )
 
-// NewParser creates a new empty Parser instance.
-func NewParser() *ConfigMap {
+// NewConfigMap creates a new empty ConfigMap instance.
+func NewConfigMap() *ConfigMap {
 	return &ConfigMap{k: koanf.New(KeyDelimiter)}
 }
 
-// NewParserFromFile creates a new Parser by reading the given file.
-func NewParserFromFile(fileName string) (*ConfigMap, error) {
+// NewConfigMapFromFile creates a new ConfigMap by reading the given file.
+func NewConfigMapFromFile(fileName string) (*ConfigMap, error) {
 	// Read yaml config from file.
-	p := NewParser()
+	p := NewConfigMap()
 	if err := p.k.Load(file.Provider(fileName), yaml.Parser()); err != nil {
 		return nil, fmt.Errorf("unable to read the file %v: %w", fileName, err)
 	}
 	return p, nil
 }
 
-// NewParserFromBuffer creates a new Parser by reading the given yaml buffer.
-func NewParserFromBuffer(buf io.Reader) (*ConfigMap, error) {
+// NewConfigMapFromBuffer creates a new ConfigMap by reading the given yaml buffer.
+func NewConfigMapFromBuffer(buf io.Reader) (*ConfigMap, error) {
 	content, err := ioutil.ReadAll(buf)
 	if err != nil {
 		return nil, err
 	}
 
-	p := NewParser()
+	p := NewConfigMap()
 	if err := p.k.Load(rawbytes.Provider(content), yaml.Parser()); err != nil {
 		return nil, err
 	}
@@ -65,9 +65,9 @@ func NewParserFromBuffer(buf io.Reader) (*ConfigMap, error) {
 	return p, nil
 }
 
-// NewParserFromStringMap creates a parser from a map[string]interface{}.
-func NewParserFromStringMap(data map[string]interface{}) *ConfigMap {
-	p := NewParser()
+// NewConfigMapFromStringMap creates a ConfigMap from a map[string]interface{}.
+func NewConfigMapFromStringMap(data map[string]interface{}) *ConfigMap {
+	p := NewConfigMap()
 	// Cannot return error because the koanf instance is empty.
 	_ = p.k.Load(confmap.Provider(data, KeyDelimiter), nil)
 	return p
@@ -138,11 +138,11 @@ func (l *ConfigMap) MergeStringMap(cfg map[string]interface{}) error {
 func (l *ConfigMap) Sub(key string) (*ConfigMap, error) {
 	data := l.Get(key)
 	if data == nil {
-		return NewParser(), nil
+		return NewConfigMap(), nil
 	}
 
 	if reflect.TypeOf(data).Kind() == reflect.Map {
-		subParser := NewParser()
+		subParser := NewConfigMap()
 		// Cannot return error because the subv is empty.
 		_ = subParser.MergeStringMap(cast.ToStringMap(data))
 		return subParser, nil

--- a/config/configparser/parser_test.go
+++ b/config/configparser/parser_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestToStringMap_WithSet(t *testing.T) {
-	parser := NewParser()
+	parser := NewConfigMap()
 	parser.Set("key::embedded", int64(123))
 	assert.Equal(t, map[string]interface{}{"key": map[string]interface{}{"embedded": int64(123)}}, parser.ToStringMap())
 }
@@ -98,7 +98,7 @@ func TestToStringMap(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			parser, err := NewParserFromFile(test.fileName)
+			parser, err := NewConfigMapFromFile(test.fileName)
 			require.NoError(t, err, "Unable to read configuration file '%s'", test.fileName)
 			assert.Equal(t, test.stringMap, parser.ToStringMap())
 		})

--- a/config/configtest/configtest.go
+++ b/config/configtest/configtest.go
@@ -24,7 +24,7 @@ import (
 // LoadConfig loads a config from file, and does NOT validate the configuration.
 func LoadConfig(fileName string, factories component.Factories) (*config.Config, error) {
 	// Read yaml config from file
-	cp, err := configparser.NewParserFromFile(fileName)
+	cp, err := configparser.NewConfigMapFromFile(fileName)
 	if err != nil {
 		return nil, err
 	}

--- a/config/configunmarshaler/defaultunmarshaler.go
+++ b/config/configunmarshaler/defaultunmarshaler.go
@@ -183,7 +183,7 @@ func unmarshalExtensions(exts map[string]map[string]interface{}, factories map[c
 
 	// Iterate over extensions and create a config for each.
 	for key, value := range exts {
-		componentConfig := configparser.NewParserFromStringMap(value)
+		componentConfig := configparser.NewConfigMapFromStringMap(value)
 		expandEnvConfig(componentConfig)
 
 		// Decode the key into type and fullName components.
@@ -260,7 +260,7 @@ func unmarshalReceivers(recvs map[string]map[string]interface{}, factories map[c
 
 	// Iterate over input map and create a config for each.
 	for key, value := range recvs {
-		componentConfig := configparser.NewParserFromStringMap(value)
+		componentConfig := configparser.NewConfigMapFromStringMap(value)
 		expandEnvConfig(componentConfig)
 
 		// Decode the key into type and fullName components.
@@ -297,7 +297,7 @@ func unmarshalExporters(exps map[string]map[string]interface{}, factories map[co
 
 	// Iterate over Exporters and create a config for each.
 	for key, value := range exps {
-		componentConfig := configparser.NewParserFromStringMap(value)
+		componentConfig := configparser.NewConfigMapFromStringMap(value)
 		expandEnvConfig(componentConfig)
 
 		// Decode the key into type and fullName components.
@@ -339,7 +339,7 @@ func unmarshalProcessors(procs map[string]map[string]interface{}, factories map[
 
 	// Iterate over processors and create a config for each.
 	for key, value := range procs {
-		componentConfig := configparser.NewParserFromStringMap(value)
+		componentConfig := configparser.NewConfigMapFromStringMap(value)
 		expandEnvConfig(componentConfig)
 
 		// Decode the key into type and fullName components.

--- a/config/configunmarshaler/defaultunmarshaler_test.go
+++ b/config/configunmarshaler/defaultunmarshaler_test.go
@@ -456,7 +456,7 @@ func TestLoadEmptyAllSections(t *testing.T) {
 }
 
 func loadConfigFile(t *testing.T, fileName string, factories component.Factories) (*config.Config, error) {
-	v, err := configparser.NewParserFromFile(fileName)
+	v, err := configparser.NewConfigMapFromFile(fileName)
 	require.NoError(t, err)
 
 	// Unmarshal the config from the configparser.ConfigMap using the given factories.

--- a/config/internal/configsource/manager.go
+++ b/config/internal/configsource/manager.go
@@ -186,7 +186,7 @@ func NewManager(_ *configparser.ConfigMap) (*Manager, error) {
 // in the configuration, returning a config.Parser fully resolved. This must be called only
 // once per lifetime of a Manager object.
 func (m *Manager) Resolve(ctx context.Context, parser *configparser.ConfigMap) (*configparser.ConfigMap, error) {
-	res := configparser.NewParser()
+	res := configparser.NewConfigMap()
 	allKeys := parser.AllKeys()
 	for _, k := range allKeys {
 		value, err := m.expandStringValues(ctx, parser.Get(k))
@@ -484,7 +484,7 @@ func parseCfgSrc(s string) (cfgSrcName, selector string, params interface{}, err
 
 		if len(parts) > 1 && len(parts[1]) > 0 {
 			var cp *configparser.ConfigMap
-			cp, err = configparser.NewParserFromBuffer(bytes.NewReader([]byte(parts[1])))
+			cp, err = configparser.NewConfigMapFromBuffer(bytes.NewReader([]byte(parts[1])))
 			if err != nil {
 				return
 			}

--- a/config/internal/configsource/manager_test.go
+++ b/config/internal/configsource/manager_test.go
@@ -54,7 +54,7 @@ func TestConfigSourceManager_Simple(t *testing.T) {
 		},
 	}
 
-	cp := configparser.NewParserFromStringMap(originalCfg)
+	cp := configparser.NewConfigMapFromStringMap(originalCfg)
 
 	actualParser, err := manager.Resolve(ctx, cp)
 	require.NoError(t, err)
@@ -121,7 +121,7 @@ func TestConfigSourceManager_ResolveErrors(t *testing.T) {
 			require.NoError(t, err)
 			manager.configSources = tt.configSourceMap
 
-			res, err := manager.Resolve(ctx, configparser.NewParserFromStringMap(tt.config))
+			res, err := manager.Resolve(ctx, configparser.NewConfigMapFromStringMap(tt.config))
 			require.Error(t, err)
 			require.Nil(t, res)
 			require.NoError(t, manager.Close(ctx))
@@ -145,11 +145,11 @@ func TestConfigSourceManager_ArraysAndMaps(t *testing.T) {
 	}
 
 	file := path.Join("testdata", "arrays_and_maps.yaml")
-	cp, err := configparser.NewParserFromFile(file)
+	cp, err := configparser.NewConfigMapFromFile(file)
 	require.NoError(t, err)
 
 	expectedFile := path.Join("testdata", "arrays_and_maps_expected.yaml")
-	expectedParser, err := configparser.NewParserFromFile(expectedFile)
+	expectedParser, err := configparser.NewConfigMapFromFile(expectedFile)
 	require.NoError(t, err)
 
 	actualParser, err := manager.Resolve(ctx, cp)
@@ -197,11 +197,11 @@ func TestConfigSourceManager_ParamsHandling(t *testing.T) {
 	}
 
 	file := path.Join("testdata", "params_handling.yaml")
-	cp, err := configparser.NewParserFromFile(file)
+	cp, err := configparser.NewConfigMapFromFile(file)
 	require.NoError(t, err)
 
 	expectedFile := path.Join("testdata", "params_handling_expected.yaml")
-	expectedParser, err := configparser.NewParserFromFile(expectedFile)
+	expectedParser, err := configparser.NewConfigMapFromFile(expectedFile)
 	require.NoError(t, err)
 
 	actualParser, err := manager.Resolve(ctx, cp)
@@ -235,7 +235,7 @@ func TestConfigSourceManager_WatchForUpdate(t *testing.T) {
 		},
 	}
 
-	cp := configparser.NewParserFromStringMap(originalCfg)
+	cp := configparser.NewConfigMapFromStringMap(originalCfg)
 	_, err = manager.Resolve(ctx, cp)
 	require.NoError(t, err)
 
@@ -291,7 +291,7 @@ func TestConfigSourceManager_MultipleWatchForUpdate(t *testing.T) {
 		},
 	}
 
-	cp := configparser.NewParserFromStringMap(originalCfg)
+	cp := configparser.NewConfigMapFromStringMap(originalCfg)
 	_, err = manager.Resolve(ctx, cp)
 	require.NoError(t, err)
 
@@ -342,11 +342,11 @@ func TestConfigSourceManager_EnvVarHandling(t *testing.T) {
 	}
 
 	file := path.Join("testdata", "envvar_cfgsrc_mix.yaml")
-	cp, err := configparser.NewParserFromFile(file)
+	cp, err := configparser.NewConfigMapFromFile(file)
 	require.NoError(t, err)
 
 	expectedFile := path.Join("testdata", "envvar_cfgsrc_mix_expected.yaml")
-	expectedParser, err := configparser.NewParserFromFile(expectedFile)
+	expectedParser, err := configparser.NewConfigMapFromFile(expectedFile)
 	require.NoError(t, err)
 
 	actualParser, err := manager.Resolve(ctx, cp)

--- a/service/collector_test.go
+++ b/service/collector_test.go
@@ -258,7 +258,7 @@ service:
       processors: [batch]
       exporters: [otlp]
 `
-	return configparser.NewParserFromBuffer(strings.NewReader(configStr))
+	return configparser.NewConfigMapFromBuffer(strings.NewReader(configStr))
 }
 
 func (*minimalParserLoader) Close(context.Context) error {

--- a/service/parserprovider/file.go
+++ b/service/parserprovider/file.go
@@ -36,7 +36,7 @@ func (fl *fileProvider) Get(context.Context) (*configparser.ConfigMap, error) {
 		return nil, errors.New("config file not specified")
 	}
 
-	cp, err := configparser.NewParserFromFile(fileName)
+	cp, err := configparser.NewConfigMapFromFile(fileName)
 	if err != nil {
 		return nil, fmt.Errorf("error loading config file %q: %v", fileName, err)
 	}

--- a/service/parserprovider/inmemory.go
+++ b/service/parserprovider/inmemory.go
@@ -31,7 +31,7 @@ func NewInMemory(buf io.Reader) ParserProvider {
 }
 
 func (inp *inMemoryProvider) Get(context.Context) (*configparser.ConfigMap, error) {
-	return configparser.NewParserFromBuffer(inp.buf)
+	return configparser.NewConfigMapFromBuffer(inp.buf)
 }
 
 func (inp *inMemoryProvider) Close(context.Context) error {

--- a/service/parserprovider/setflag_test.go
+++ b/service/parserprovider/setflag_test.go
@@ -61,7 +61,7 @@ func TestSetFlags_empty(t *testing.T) {
 type emptyProvider struct{}
 
 func (el *emptyProvider) Get(context.Context) (*configparser.ConfigMap, error) {
-	return configparser.NewParser(), nil
+	return configparser.NewConfigMap(), nil
 }
 
 func (el *emptyProvider) Close(context.Context) error {


### PR DESCRIPTION
**Description:** 
Clean up constructors for `ConfigMap` which were left after the rename from `Parser`

**Link to tracking Issue:** Fix https://github.com/open-telemetry/opentelemetry-collector/issues/4026

