### PR TITLE
use component.Host rather than map of extensions in ToServer

### DIFF
--- a/component/componenttest/nop_host.go
+++ b/component/componenttest/nop_host.go
@@ -20,7 +20,7 @@ import (
 )
 
 // nopHost mocks a receiver.ReceiverHost for test purposes.
-type nopHost struct {}
+type nopHost struct{}
 
 var nopHostInstance component.Host = &nopHost{}
 

--- a/component/componenttest/nop_host.go
+++ b/component/componenttest/nop_host.go
@@ -21,7 +21,6 @@ import (
 
 // nopHost mocks a receiver.ReceiverHost for test purposes.
 type nopHost struct {
-	ext map[config.ComponentID]component.Extension
 }
 
 var nopHostInstance component.Host = &nopHost{}
@@ -31,13 +30,6 @@ func NewNopHost() component.Host {
 	return nopHostInstance
 }
 
-// NewNopHost returns a new instance of nopHost with proper defaults for most tests.
-func NewNopHostWithExtensions(ext map[config.ComponentID]component.Extension) component.Host {
-	return &nopHost{
-		ext: ext,
-	}
-}
-
 func (nh *nopHost) ReportFatalError(_ error) {}
 
 func (nh *nopHost) GetFactory(_ component.Kind, _ config.Type) component.Factory {
@@ -45,7 +37,7 @@ func (nh *nopHost) GetFactory(_ component.Kind, _ config.Type) component.Factory
 }
 
 func (nh *nopHost) GetExtensions() map[config.ComponentID]component.Extension {
-	return nh.ext
+	return nil
 }
 
 func (nh *nopHost) GetExporters() map[config.DataType]map[config.ComponentID]component.Exporter {

--- a/component/componenttest/nop_host.go
+++ b/component/componenttest/nop_host.go
@@ -20,13 +20,22 @@ import (
 )
 
 // nopHost mocks a receiver.ReceiverHost for test purposes.
-type nopHost struct{}
+type nopHost struct {
+	ext map[config.ComponentID]component.Extension
+}
 
 var nopHostInstance component.Host = &nopHost{}
 
 // NewNopHost returns a new instance of nopHost with proper defaults for most tests.
 func NewNopHost() component.Host {
 	return nopHostInstance
+}
+
+// NewNopHost returns a new instance of nopHost with proper defaults for most tests.
+func NewNopHostWithExtensions(ext map[config.ComponentID]component.Extension) component.Host {
+	return &nopHost{
+		ext: ext,
+	}
 }
 
 func (nh *nopHost) ReportFatalError(_ error) {}
@@ -36,7 +45,7 @@ func (nh *nopHost) GetFactory(_ component.Kind, _ config.Type) component.Factory
 }
 
 func (nh *nopHost) GetExtensions() map[config.ComponentID]component.Extension {
-	return nil
+	return nh.ext
 }
 
 func (nh *nopHost) GetExporters() map[config.DataType]map[config.ComponentID]component.Exporter {

--- a/component/componenttest/nop_host.go
+++ b/component/componenttest/nop_host.go
@@ -20,8 +20,7 @@ import (
 )
 
 // nopHost mocks a receiver.ReceiverHost for test purposes.
-type nopHost struct {
-}
+type nopHost struct {}
 
 var nopHostInstance component.Host = &nopHost{}
 

--- a/config/configgrpc/configgrpc.go
+++ b/config/configgrpc/configgrpc.go
@@ -179,7 +179,7 @@ func (gcs *GRPCClientSettings) isSchemeHTTPS() bool {
 }
 
 // ToDialOptions maps configgrpc.GRPCClientSettings to a slice of dial options for gRPC.
-func (gcs *GRPCClientSettings) ToDialOptions(ext map[config.ComponentID]component.Extension) ([]grpc.DialOption, error) {
+func (gcs *GRPCClientSettings) ToDialOptions(host component.Host) ([]grpc.DialOption, error) {
 	var opts []grpc.DialOption
 	if gcs.Compression != "" {
 		if compressionKey := GetGRPCCompressionKey(gcs.Compression); compressionKey != CompressionUnsupported {
@@ -219,7 +219,7 @@ func (gcs *GRPCClientSettings) ToDialOptions(ext map[config.ComponentID]componen
 	}
 
 	if gcs.Auth != nil {
-		if ext == nil {
+		if host.GetExtensions() == nil {
 			return nil, fmt.Errorf("no extensions configuration available")
 		}
 
@@ -228,7 +228,7 @@ func (gcs *GRPCClientSettings) ToDialOptions(ext map[config.ComponentID]componen
 			return nil, cperr
 		}
 
-		grpcAuthenticator, cerr := configauth.GetGRPCClientAuthenticator(ext, componentID)
+		grpcAuthenticator, cerr := configauth.GetGRPCClientAuthenticator(host.GetExtensions(), componentID)
 		if cerr != nil {
 			return nil, cerr
 		}
@@ -270,7 +270,7 @@ func (gss *GRPCServerSettings) ToListener() (net.Listener, error) {
 }
 
 // ToServerOption maps configgrpc.GRPCServerSettings to a slice of server options for gRPC.
-func (gss *GRPCServerSettings) ToServerOption(ext map[config.ComponentID]component.Extension, settings component.TelemetrySettings) ([]grpc.ServerOption, error) {
+func (gss *GRPCServerSettings) ToServerOption(host component.Host, settings component.TelemetrySettings) ([]grpc.ServerOption, error) {
 	var opts []grpc.ServerOption
 
 	if gss.TLSSetting != nil {
@@ -334,7 +334,7 @@ func (gss *GRPCServerSettings) ToServerOption(ext map[config.ComponentID]compone
 			return nil, cperr
 		}
 
-		authenticator, err := configauth.GetServerAuthenticator(ext, componentID)
+		authenticator, err := configauth.GetServerAuthenticator(host.GetExtensions(), componentID)
 		if err != nil {
 			return nil, err
 		}

--- a/config/configgrpc/configgrpc_test.go
+++ b/config/configgrpc/configgrpc_test.go
@@ -43,7 +43,7 @@ func TestDefaultGrpcClientSettings(t *testing.T) {
 			Insecure: true,
 		},
 	}
-	opts, err := gcs.ToDialOptions(map[config.ComponentID]component.Extension{})
+	opts, err := gcs.ToDialOptions(componenttest.NewNopHost())
 	assert.NoError(t, err)
 	assert.Len(t, opts, 3)
 }
@@ -70,18 +70,18 @@ func TestAllGrpcClientSettings(t *testing.T) {
 		Auth:            &configauth.Authentication{AuthenticatorName: "testauth"},
 	}
 
-	ext := map[config.ComponentID]component.Extension{
+	host := componenttest.NewNopHostWithExtensions(map[config.ComponentID]component.Extension{
 		config.NewID("testauth"): &configauth.MockClientAuthenticator{},
-	}
+	})
 
-	opts, err := gcs.ToDialOptions(ext)
+	opts, err := gcs.ToDialOptions(host)
 	assert.NoError(t, err)
 	assert.Len(t, opts, 9)
 }
 
 func TestDefaultGrpcServerSettings(t *testing.T) {
 	gss := &GRPCServerSettings{}
-	opts, err := gss.ToServerOption(map[config.ComponentID]component.Extension{}, componenttest.NewNopTelemetrySettings())
+	opts, err := gss.ToServerOption(componenttest.NewNopHost(), componenttest.NewNopTelemetrySettings())
 	_ = grpc.NewServer(opts...)
 
 	assert.NoError(t, err)
@@ -116,7 +116,7 @@ func TestAllGrpcServerSettingsExceptAuth(t *testing.T) {
 			},
 		},
 	}
-	opts, err := gss.ToServerOption(map[config.ComponentID]component.Extension{}, componenttest.NewNopTelemetrySettings())
+	opts, err := gss.ToServerOption(componenttest.NewNopHost(), componenttest.NewNopTelemetrySettings())
 	_ = grpc.NewServer(opts...)
 
 	assert.NoError(t, err)
@@ -127,17 +127,17 @@ func TestGrpcServerAuthSettings(t *testing.T) {
 	gss := &GRPCServerSettings{}
 
 	// sanity check
-	_, err := gss.ToServerOption(map[config.ComponentID]component.Extension{}, componenttest.NewNopTelemetrySettings())
+	_, err := gss.ToServerOption(componenttest.NewNopHost(), componenttest.NewNopTelemetrySettings())
 	require.NoError(t, err)
 
 	// test
 	gss.Auth = &configauth.Authentication{
 		AuthenticatorName: "mock",
 	}
-	ext := map[config.ComponentID]component.Extension{
+	host := componenttest.NewNopHostWithExtensions(map[config.ComponentID]component.Extension{
 		config.NewID("mock"): &configauth.MockAuthenticator{},
-	}
-	opts, err := gss.ToServerOption(ext, componenttest.NewNopTelemetrySettings())
+	})
+	opts, err := gss.ToServerOption(host, componenttest.NewNopTelemetrySettings())
 	_ = grpc.NewServer(opts...)
 
 	// verify
@@ -149,7 +149,7 @@ func TestGRPCClientSettingsError(t *testing.T) {
 	tests := []struct {
 		settings GRPCClientSettings
 		err      string
-		ext      map[config.ComponentID]component.Extension
+		host     component.Host
 	}{
 		{
 			err: "^failed to load TLS config: failed to load CA CertPool: failed to load CA /doesnt/exist:",
@@ -211,9 +211,9 @@ func TestGRPCClientSettingsError(t *testing.T) {
 				Endpoint: "localhost:1234",
 				Auth:     &configauth.Authentication{},
 			},
-			ext: map[config.ComponentID]component.Extension{
+			host: componenttest.NewNopHostWithExtensions(map[config.ComponentID]component.Extension{
 				config.NewID("mock"): &configauth.MockClientAuthenticator{},
-			},
+			}),
 		},
 		{
 			err: "failed to resolve authenticator \"doesntexist\": authenticator not found",
@@ -221,7 +221,7 @@ func TestGRPCClientSettingsError(t *testing.T) {
 				Endpoint: "localhost:1234",
 				Auth:     &configauth.Authentication{AuthenticatorName: "doesntexist"},
 			},
-			ext: map[config.ComponentID]component.Extension{},
+			host: componenttest.NewNopHostWithExtensions(map[config.ComponentID]component.Extension{}),
 		},
 		{
 			err: "no extensions configuration available",
@@ -229,12 +229,12 @@ func TestGRPCClientSettingsError(t *testing.T) {
 				Endpoint: "localhost:1234",
 				Auth:     &configauth.Authentication{AuthenticatorName: "doesntexist"},
 			},
-			ext: nil,
+			host: componenttest.NewNopHostWithExtensions(nil),
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.err, func(t *testing.T) {
-			opts, err := test.settings.ToDialOptions(test.ext)
+			opts, err := test.settings.ToDialOptions(test.host)
 			assert.Nil(t, opts)
 			assert.Error(t, err)
 			assert.Regexp(t, test.err, err)
@@ -250,7 +250,7 @@ func TestUseSecure(t *testing.T) {
 		TLSSetting:  configtls.TLSClientSetting{},
 		Keepalive:   nil,
 	}
-	dialOpts, err := gcs.ToDialOptions(map[config.ComponentID]component.Extension{})
+	dialOpts, err := gcs.ToDialOptions(componenttest.NewNopHost())
 	assert.NoError(t, err)
 	assert.Len(t, dialOpts, 3)
 }
@@ -303,7 +303,7 @@ func TestGRPCServerSettingsError(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.err, func(t *testing.T) {
-			opts, err := test.settings.ToServerOption(map[config.ComponentID]component.Extension{}, componenttest.NewNopTelemetrySettings())
+			opts, err := test.settings.ToServerOption(componenttest.NewNopHost(), componenttest.NewNopTelemetrySettings())
 			_ = grpc.NewServer(opts...)
 
 			assert.Regexp(t, test.err, err)
@@ -458,7 +458,7 @@ func TestHttpReception(t *testing.T) {
 			}
 			ln, err := gss.ToListener()
 			assert.NoError(t, err)
-			opts, err := gss.ToServerOption(map[config.ComponentID]component.Extension{}, componenttest.NewNopTelemetrySettings())
+			opts, err := gss.ToServerOption(componenttest.NewNopHost(), componenttest.NewNopTelemetrySettings())
 			assert.NoError(t, err)
 			s := grpc.NewServer(opts...)
 			otlpgrpc.RegisterTracesServer(s, &grpcTraceServer{})
@@ -471,7 +471,7 @@ func TestHttpReception(t *testing.T) {
 				Endpoint:   ln.Addr().String(),
 				TLSSetting: *tt.tlsClientCreds,
 			}
-			clientOpts, errClient := gcs.ToDialOptions(map[config.ComponentID]component.Extension{})
+			clientOpts, errClient := gcs.ToDialOptions(componenttest.NewNopHost())
 			assert.NoError(t, errClient)
 			grpcClientConn, errDial := grpc.Dial(gcs.Endpoint, clientOpts...)
 			assert.NoError(t, errDial)
@@ -503,7 +503,7 @@ func TestReceiveOnUnixDomainSocket(t *testing.T) {
 	}
 	ln, err := gss.ToListener()
 	assert.NoError(t, err)
-	opts, err := gss.ToServerOption(map[config.ComponentID]component.Extension{}, componenttest.NewNopTelemetrySettings())
+	opts, err := gss.ToServerOption(componenttest.NewNopHost(), componenttest.NewNopTelemetrySettings())
 	assert.NoError(t, err)
 	s := grpc.NewServer(opts...)
 	otlpgrpc.RegisterTracesServer(s, &grpcTraceServer{})
@@ -518,7 +518,7 @@ func TestReceiveOnUnixDomainSocket(t *testing.T) {
 			Insecure: true,
 		},
 	}
-	clientOpts, errClient := gcs.ToDialOptions(map[config.ComponentID]component.Extension{})
+	clientOpts, errClient := gcs.ToDialOptions(componenttest.NewNopHost())
 	assert.NoError(t, errClient)
 	grpcClientConn, errDial := grpc.Dial(gcs.Endpoint, clientOpts...)
 	assert.NoError(t, errDial)

--- a/exporter/otlpexporter/otlp.go
+++ b/exporter/otlpexporter/otlp.go
@@ -55,7 +55,7 @@ func newExporter(cfg config.Exporter) (*exporter, error) {
 // start actually creates the gRPC connection. The client construction is deferred till this point as this
 // is the only place we get hold of Extensions which are required to construct auth round tripper.
 func (e *exporter) start(_ context.Context, host component.Host) (err error) {
-	e.w, err = newGrpcSender(e.config, host.GetExtensions())
+	e.w, err = newGrpcSender(e.config, host)
 	return
 }
 
@@ -94,8 +94,8 @@ type grpcSender struct {
 	callOptions    []grpc.CallOption
 }
 
-func newGrpcSender(config *Config, ext map[config.ComponentID]component.Extension) (*grpcSender, error) {
-	dialOpts, err := config.GRPCClientSettings.ToDialOptions(ext)
+func newGrpcSender(config *Config, host component.Host) (*grpcSender, error) {
+	dialOpts, err := config.GRPCClientSettings.ToDialOptions(host)
 	if err != nil {
 		return nil, err
 	}

--- a/receiver/otlpreceiver/otlp.go
+++ b/receiver/otlpreceiver/otlp.go
@@ -110,7 +110,7 @@ func (r *otlpReceiver) startProtocolServers(host component.Host) error {
 	var err error
 	if r.cfg.GRPC != nil {
 		var opts []grpc.ServerOption
-		opts, err = r.cfg.GRPC.ToServerOption(host.GetExtensions(), r.settings.TelemetrySettings)
+		opts, err = r.cfg.GRPC.ToServerOption(host, r.settings.TelemetrySettings)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
**Description:** <Describe what has changed. 
Follow up to https://github.com/open-telemetry/opentelemetry-collector/issues/4012, this changes the method signature for `ToServerOption` and `ToDialOption` to receive a `component.Host` which contains the extensions previously passed in.

**Link to tracking Issue:** Fixes https://github.com/open-telemetry/opentelemetry-collector/issues/4012

