### PR TITLE
Add changelog entry for removing AttributeHTTPStatusText

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## 🛑 Breaking changes 🛑
 
 - Remove `mem-ballast-size-mib`, already deprecated and no-op (#4005).
+- Remove `AttributeHTTPStatusText` const, replaced with `"http.status_text"` (#4015, contrib/#5182).
 
 ## v0.35.0 Beta
 


### PR DESCRIPTION
**Description:** 
This PR adds a changelog entry for the changes made in #4015 and [contrib/5182](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/5182).

**Link to tracking Issue:** 
#3999, addressed by the PRs mentioned above

**Documentation:**
One line addition to `CHANGELOG.md`.