### PR TITLE
Move Persistent Queue to exporterhelper/internal

### DIFF
--- a/exporter/exporterhelper/README.md
+++ b/exporter/exporterhelper/README.md
@@ -17,7 +17,7 @@ The following configuration options can be modified:
 - `sending_queue`
   - `enabled` (default = true)
   - `num_consumers` (default = 10): Number of consumers that dequeue batches; ignored if `enabled` is `false`
-  - `queue_size` (default = 5000): Maximum number of batches kept in memory or on disk (for persistent storage) before dropping; ignored if `enabled` is `false`
+  - `queue_size` (default = 5000): Maximum number of batches kept in memory before dropping; ignored if `enabled` is `false`
   User should calculate this as `num_seconds * requests_per_second` where:
     - `num_seconds` is the number of seconds to buffer in case of a backend outage
     - `requests_per_second` is the average number of requests per seconds.
@@ -35,6 +35,15 @@ The full list of settings exposed for this helper exporter are documented [here]
 
 > :warning: The capability is under development and currently can be enabled only in OpenTelemetry
 > Collector Contrib with `enable_unstable` build tag set. 
+
+With this build tag set, additional configuration option can be enabled:
+
+- `sending_queue`
+  - `persistent_storage_enabled` (default = false): When set, enables persistence via a file storage extension
+    (note, `enable_unstable` build tag needs to be enabled first, see below for more details)
+
+The maximum number of batches stored to disk can be controlled using `sending_queue.queue_size` parameter (which,
+similarly as for in-memory buffering, defaults to 5000 batches).
 
 When `persistent_storage_enabled` is set to true, the queue is being buffered to disk using 
 [file storage extension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/storage/filestorage).

--- a/exporter/exporterhelper/common_test.go
+++ b/exporter/exporterhelper/common_test.go
@@ -27,6 +27,7 @@ import (
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/consumer/consumerhelper"
+	"go.opentelemetry.io/collector/exporter/exporterhelper/internal"
 	"go.opentelemetry.io/collector/model/pdata"
 )
 
@@ -75,6 +76,6 @@ func nopTracePusher() consumerhelper.ConsumeTracesFunc {
 	}
 }
 
-func nopRequestUnmarshaler() requestUnmarshaler {
+func nopRequestUnmarshaler() internal.RequestUnmarshaler {
 	return newTraceRequestUnmarshalerFunc(nopTracePusher())
 }

--- a/exporter/exporterhelper/consumers_queue.go
+++ b/exporter/exporterhelper/consumers_queue.go
@@ -14,10 +14,10 @@
 
 package exporterhelper
 
-// consumersQueue is largely based on queue.BoundedQueue and matches the subset used in the collector
+// ConsumersQueue is largely based on queue.BoundedQueue and matches the subset used in the collector
 // It describes a producer-consumer exchange which can be backed by e.g. the memory-based ring buffer queue
 // (queue.BoundedQueue) or via disk-based queue (persistentQueue)
-type consumersQueue interface {
+type ConsumersQueue interface {
 	// StartConsumers starts a given number of goroutines consuming items from the queue
 	// and passing them into the consumer callback.
 	StartConsumers(num int, callback func(item interface{}))

--- a/exporter/exporterhelper/factory.go
+++ b/exporter/exporterhelper/factory.go
@@ -20,6 +20,7 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenterror"
 	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/exporter/exporterhelper/internal"
 )
 
 // FactoryOption apply changes to ExporterOptions.
@@ -78,6 +79,7 @@ func NewFactory(
 	for _, opt := range options {
 		opt(f)
 	}
+	internal.RegisterMetrics()
 	return f
 }
 

--- a/exporter/exporterhelper/internal/bounded_memory_queue.go
+++ b/exporter/exporterhelper/internal/bounded_memory_queue.go
@@ -1,0 +1,183 @@
+// Copyright The OpenTelemetry Authors
+// Copyright (c) 2019 The Jaeger Authors.
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"sync"
+	"sync/atomic"
+	"unsafe"
+
+	uatomic "go.uber.org/atomic"
+)
+
+// boundedMemoryQueue implements a producer-consumer exchange similar to a ring buffer queue,
+// where the queue is bounded and if it fills up due to slow consumers, the new items written by
+// the producer force the earliest items to be dropped. The implementation is actually based on
+// channels, with a special Reaper goroutine that wakes up when the queue is full and consumers
+// the items from the top of the queue until its size drops back to maxSize
+type boundedMemoryQueue struct {
+	workers       int
+	stopWG        sync.WaitGroup
+	size          *uatomic.Uint32
+	capacity      *uatomic.Uint32
+	stopped       *uatomic.Uint32
+	items         *chan interface{}
+	onDroppedItem func(item interface{})
+	factory       func() Consumer
+	stopCh        chan struct{}
+}
+
+// NewBoundedMemoryQueue constructs the new queue of specified capacity, and with an optional
+// callback for dropped items (e.g. useful to emit metrics).
+func NewBoundedMemoryQueue(capacity int, onDroppedItem func(item interface{})) BoundedQueue {
+	queue := make(chan interface{}, capacity)
+	return &boundedMemoryQueue{
+		onDroppedItem: onDroppedItem,
+		items:         &queue,
+		stopCh:        make(chan struct{}),
+		capacity:      uatomic.NewUint32(uint32(capacity)),
+		stopped:       uatomic.NewUint32(0),
+		size:          uatomic.NewUint32(0),
+	}
+}
+
+// StartConsumersWithFactory creates a given number of consumers consuming items
+// from the queue in separate goroutines.
+func (q *boundedMemoryQueue) StartConsumersWithFactory(num int, factory func() Consumer) {
+	q.workers = num
+	q.factory = factory
+	var startWG sync.WaitGroup
+	for i := 0; i < q.workers; i++ {
+		q.stopWG.Add(1)
+		startWG.Add(1)
+		go func() {
+			startWG.Done()
+			defer q.stopWG.Done()
+			consumer := q.factory()
+			queue := *q.items
+			for {
+				select {
+				case item, ok := <-queue:
+					if ok {
+						q.size.Sub(1)
+						consumer.Consume(item)
+					} else {
+						// channel closed, finish worker
+						return
+					}
+				case <-q.stopCh:
+					// the whole queue is closing, finish worker
+					return
+				}
+			}
+		}()
+	}
+	startWG.Wait()
+}
+
+// ConsumerFunc is an adapter to allow the use of
+// a consume function callback as a Consumer.
+type ConsumerFunc func(item interface{})
+
+// Consume calls c(item)
+func (c ConsumerFunc) Consume(item interface{}) {
+	c(item)
+}
+
+// StartConsumers starts a given number of goroutines consuming items from the queue
+// and passing them into the consumer callback.
+func (q *boundedMemoryQueue) StartConsumers(num int, callback func(item interface{})) {
+	q.StartConsumersWithFactory(num, func() Consumer {
+		return ConsumerFunc(callback)
+	})
+}
+
+// Produce is used by the producer to submit new item to the queue. Returns false in case of queue overflow.
+func (q *boundedMemoryQueue) Produce(item interface{}) bool {
+	if q.stopped.Load() != 0 {
+		q.onDroppedItem(item)
+		return false
+	}
+
+	// we might have two concurrent backing queues at the moment
+	// their combined size is stored in q.size, and their combined capacity
+	// should match the capacity of the new queue
+	if q.Size() >= q.Capacity() {
+		// note that all items will be dropped if the capacity is 0
+		q.onDroppedItem(item)
+		return false
+	}
+
+	q.size.Add(1)
+	select {
+	case *q.items <- item:
+		return true
+	default:
+		// should not happen, as overflows should have been captured earlier
+		q.size.Sub(1)
+		if q.onDroppedItem != nil {
+			q.onDroppedItem(item)
+		}
+		return false
+	}
+}
+
+// Stop stops all consumers, as well as the length reporter if started,
+// and releases the items channel. It blocks until all consumers have stopped.
+func (q *boundedMemoryQueue) Stop() {
+	q.stopped.Store(1) // disable producer
+	close(q.stopCh)
+	q.stopWG.Wait()
+	close(*q.items)
+}
+
+// Size returns the current size of the queue
+func (q *boundedMemoryQueue) Size() int {
+	return int(q.size.Load())
+}
+
+// Capacity returns capacity of the queue
+func (q *boundedMemoryQueue) Capacity() int {
+	return int(q.capacity.Load())
+}
+
+// Resize changes the capacity of the queue, returning whether the action was successful
+func (q *boundedMemoryQueue) Resize(capacity int) bool {
+	if capacity == q.Capacity() {
+		// noop
+		return false
+	}
+
+	previous := *q.items
+	queue := make(chan interface{}, capacity)
+
+	// swap queues
+	// #nosec
+	swapped := atomic.CompareAndSwapPointer((*unsafe.Pointer)(unsafe.Pointer(&q.items)), unsafe.Pointer(q.items), unsafe.Pointer(&queue))
+	if swapped {
+		// start a new set of consumers, based on the information given previously
+		q.StartConsumersWithFactory(q.workers, q.factory)
+
+		// gracefully drain the existing queue
+		close(previous)
+
+		// update the capacity
+		q.capacity.Store(uint32(capacity))
+	}
+
+	return swapped
+}

--- a/exporter/exporterhelper/internal/bounded_queue.go
+++ b/exporter/exporterhelper/internal/bounded_queue.go
@@ -16,173 +16,30 @@
 
 package internal
 
-import (
-	"sync"
-	"sync/atomic"
-	"unsafe"
-
-	uatomic "go.uber.org/atomic"
-)
-
 // Consumer consumes data from a bounded queue
 type Consumer interface {
 	Consume(item interface{})
 }
 
-// BoundedQueue implements a producer-consumer exchange similar to a ring buffer queue,
-// where the queue is bounded and if it fills up due to slow consumers, the new items written by
-// the producer force the earliest items to be dropped. The implementation is actually based on
-// channels, with a special Reaper goroutine that wakes up when the queue is full and consumers
-// the items from the top of the queue until its size drops back to maxSize
-type BoundedQueue struct {
-	workers       int
-	stopWG        sync.WaitGroup
-	size          *uatomic.Uint32
-	capacity      *uatomic.Uint32
-	stopped       *uatomic.Uint32
-	items         *chan interface{}
-	onDroppedItem func(item interface{})
-	factory       func() Consumer
-	stopCh        chan struct{}
-}
-
-// NewBoundedQueue constructs the new queue of specified capacity, and with an optional
-// callback for dropped items (e.g. useful to emit metrics).
-func NewBoundedQueue(capacity int, onDroppedItem func(item interface{})) *BoundedQueue {
-	queue := make(chan interface{}, capacity)
-	return &BoundedQueue{
-		onDroppedItem: onDroppedItem,
-		items:         &queue,
-		stopCh:        make(chan struct{}),
-		capacity:      uatomic.NewUint32(uint32(capacity)),
-		stopped:       uatomic.NewUint32(0),
-		size:          uatomic.NewUint32(0),
-	}
-}
-
-// StartConsumersWithFactory creates a given number of consumers consuming items
-// from the queue in separate goroutines.
-func (q *BoundedQueue) StartConsumersWithFactory(num int, factory func() Consumer) {
-	q.workers = num
-	q.factory = factory
-	var startWG sync.WaitGroup
-	for i := 0; i < q.workers; i++ {
-		q.stopWG.Add(1)
-		startWG.Add(1)
-		go func() {
-			startWG.Done()
-			defer q.stopWG.Done()
-			consumer := q.factory()
-			queue := *q.items
-			for {
-				select {
-				case item, ok := <-queue:
-					if ok {
-						q.size.Sub(1)
-						consumer.Consume(item)
-					} else {
-						// channel closed, finish worker
-						return
-					}
-				case <-q.stopCh:
-					// the whole queue is closing, finish worker
-					return
-				}
-			}
-		}()
-	}
-	startWG.Wait()
-}
-
-// ConsumerFunc is an adapter to allow the use of
-// a consume function callback as a Consumer.
-type ConsumerFunc func(item interface{})
-
-// Consume calls c(item)
-func (c ConsumerFunc) Consume(item interface{}) {
-	c(item)
-}
-
-// StartConsumers starts a given number of goroutines consuming items from the queue
-// and passing them into the consumer callback.
-func (q *BoundedQueue) StartConsumers(num int, callback func(item interface{})) {
-	q.StartConsumersWithFactory(num, func() Consumer {
-		return ConsumerFunc(callback)
-	})
-}
-
-// Produce is used by the producer to submit new item to the queue. Returns false in case of queue overflow.
-func (q *BoundedQueue) Produce(item interface{}) bool {
-	if q.stopped.Load() != 0 {
-		q.onDroppedItem(item)
-		return false
-	}
-
-	// we might have two concurrent backing queues at the moment
-	// their combined size is stored in q.size, and their combined capacity
-	// should match the capacity of the new queue
-	if q.Size() >= q.Capacity() {
-		// note that all items will be dropped if the capacity is 0
-		q.onDroppedItem(item)
-		return false
-	}
-
-	q.size.Add(1)
-	select {
-	case *q.items <- item:
-		return true
-	default:
-		// should not happen, as overflows should have been captured earlier
-		q.size.Sub(1)
-		if q.onDroppedItem != nil {
-			q.onDroppedItem(item)
-		}
-		return false
-	}
-}
-
-// Stop stops all consumers, as well as the length reporter if started,
-// and releases the items channel. It blocks until all consumers have stopped.
-func (q *BoundedQueue) Stop() {
-	q.stopped.Store(1) // disable producer
-	close(q.stopCh)
-	q.stopWG.Wait()
-	close(*q.items)
-}
-
-// Size returns the current size of the queue
-func (q *BoundedQueue) Size() int {
-	return int(q.size.Load())
-}
-
-// Capacity returns capacity of the queue
-func (q *BoundedQueue) Capacity() int {
-	return int(q.capacity.Load())
-}
-
-// Resize changes the capacity of the queue, returning whether the action was successful
-func (q *BoundedQueue) Resize(capacity int) bool {
-	if capacity == q.Capacity() {
-		// noop
-		return false
-	}
-
-	previous := *q.items
-	queue := make(chan interface{}, capacity)
-
-	// swap queues
-	// #nosec
-	swapped := atomic.CompareAndSwapPointer((*unsafe.Pointer)(unsafe.Pointer(&q.items)), unsafe.Pointer(q.items), unsafe.Pointer(&queue))
-	if swapped {
-		// start a new set of consumers, based on the information given previously
-		q.StartConsumersWithFactory(q.workers, q.factory)
-
-		// gracefully drain the existing queue
-		close(previous)
-
-		// update the capacity
-		q.capacity.Store(uint32(capacity))
-	}
-
-	return swapped
+// BoundedQueue defines a producer-consumer exchange which can be backed by e.g. the memory-based ring buffer queue
+// (boundedMemoryQueue) or via a disk-based queue (persistentQueue)
+type BoundedQueue interface {
+	// StartConsumers starts a given number of goroutines consuming items from the queue
+	// and passing them into the consumer callback.
+	StartConsumers(num int, callback func(item interface{}))
+	// StartConsumersWithFactory creates a given number of consumers consuming items
+	// from the queue in separate goroutines.
+	StartConsumersWithFactory(num int, factory func() Consumer)
+	// Produce is used by the producer to submit new item to the queue. Returns false if the item wasn't added
+	// to the queue due to queue overflow.
+	Produce(item interface{}) bool
+	// Size returns the current Size of the queue
+	Size() int
+	// Capacity returns capacity of the queue
+	Capacity() int
+	// Resize changes the capacity of the queue, returning whether the action was successful
+	Resize(capacity int) bool
+	// Stop stops all consumers, as well as the length reporter if started,
+	// and releases the items channel. It blocks until all consumers have stopped.
+	Stop()
 }

--- a/exporter/exporterhelper/internal/observability_experimental.go
+++ b/exporter/exporterhelper/internal/observability_experimental.go
@@ -1,0 +1,89 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build enable_unstable
+// +build enable_unstable
+
+package internal
+
+import (
+	"context"
+	"sync"
+
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
+)
+
+var (
+	currentlyDispatchedBatches = stats.Int64(
+		"/currently_dispatched_batches",
+		"Number of batches that are currently being sent",
+		stats.UnitDimensionless)
+
+	totalDispatchedBatches = stats.Int64(
+		"/total_dispatched_batches",
+		"Total number of batches which were processed",
+		stats.UnitDimensionless)
+
+	queueNameKey = tag.MustNewKey("queue_name")
+)
+
+func recordCurrentlyDispatchedBatches(ctx context.Context, dispatchedBatches int, queueName string) {
+	ctx, err := tag.New(ctx, tag.Insert(queueNameKey, queueName))
+	if err != nil {
+		return
+	}
+
+	stats.Record(ctx, currentlyDispatchedBatches.M(int64(dispatchedBatches)))
+}
+
+func recordBatchDispatched(ctx context.Context, queueName string) {
+	ctx, err := tag.New(ctx, tag.Insert(queueNameKey, queueName))
+	if err != nil {
+		return
+	}
+
+	stats.Record(ctx, totalDispatchedBatches.M(int64(1)))
+}
+
+// ExporterHelperInternalViews return the metrics views according to given telemetry level.
+func ExporterHelperInternalViews() []*view.View {
+
+	return []*view.View{
+		{
+			Name:        currentlyDispatchedBatches.Name(),
+			Description: currentlyDispatchedBatches.Description(),
+			Measure:     currentlyDispatchedBatches,
+			Aggregation: view.Count(),
+			TagKeys:     []tag.Key{queueNameKey},
+		},
+		{
+			Name:        totalDispatchedBatches.Name(),
+			Description: totalDispatchedBatches.Description(),
+			Measure:     totalDispatchedBatches,
+			Aggregation: view.Sum(),
+			TagKeys:     []tag.Key{queueNameKey},
+		},
+	}
+}
+
+var onceMetrics sync.Once
+
+// RegisterMetrics registers a set of metric views used by the internal package
+func RegisterMetrics() {
+	onceMetrics.Do(func() {
+		_ = view.Register(ExporterHelperInternalViews()...)
+	})
+}

--- a/exporter/exporterhelper/internal/observability_stable.go
+++ b/exporter/exporterhelper/internal/observability_stable.go
@@ -1,0 +1,20 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !enable_unstable
+// +build !enable_unstable
+
+package internal
+
+func RegisterMetrics() {}

--- a/exporter/exporterhelper/internal/persistent_queue_test.go
+++ b/exporter/exporterhelper/internal/persistent_queue_test.go
@@ -15,7 +15,7 @@
 //go:build enable_unstable
 // +build enable_unstable
 
-package exporterhelper
+package internal
 
 import (
 	"context"
@@ -42,8 +42,8 @@ func createTestQueue(extension storage.Extension, capacity int) *persistentQueue
 		panic(err)
 	}
 
-	wq := newPersistentQueue(context.Background(), "foo", capacity, logger, client, newTraceRequestUnmarshalerFunc(nopTracePusher()))
-	return wq
+	pq := NewPersistentQueue(context.Background(), "foo", capacity, logger, client, newFakeTracesRequestUnmarshalerFunc())
+	return pq.(*persistentQueue)
 }
 
 func TestPersistentQueue_Capacity(t *testing.T) {
@@ -58,7 +58,7 @@ func TestPersistentQueue_Capacity(t *testing.T) {
 		require.Equal(t, 0, wq.Size())
 
 		traces := newTraces(1, 10)
-		req := newTracesRequest(context.Background(), traces, nopTracePusher())
+		req := newFakeTracesRequest(traces)
 
 		for i := 0; i < 10; i++ {
 			result := wq.Produce(req)
@@ -89,7 +89,7 @@ func TestPersistentQueue_Close(t *testing.T) {
 
 	wq := createTestQueue(ext, 1001)
 	traces := newTraces(1, 10)
-	req := newTracesRequest(context.Background(), traces, nopTracePusher())
+	req := newFakeTracesRequest(traces)
 
 	wq.StartConsumers(100, func(item interface{}) {})
 
@@ -140,7 +140,7 @@ func TestPersistentQueue_ConsumersProducers(t *testing.T) {
 			path := createTemporaryDirectory()
 
 			traces := newTraces(1, 10)
-			req := newTracesRequest(context.Background(), traces, nopTracePusher())
+			req := newFakeTracesRequest(traces)
 
 			ext := createStorageExtension(path)
 			tq := createTestQueue(ext, 5000)

--- a/exporter/exporterhelper/internal/persistent_request.go
+++ b/exporter/exporterhelper/internal/persistent_request.go
@@ -1,0 +1,28 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+// PersistentRequest defines capabilities required for persistent storage of a request
+type PersistentRequest interface {
+	// Marshal serializes the current request into a byte stream
+	Marshal() ([]byte, error)
+	// OnProcessingFinished calls the optional callback function to handle cleanup after all processing is finished
+	OnProcessingFinished()
+	// SetOnProcessingFinished allows to set an optional callback function to do the cleanup (e.g. remove the item from persistent queue)
+	SetOnProcessingFinished(callback func())
+}
+
+// RequestUnmarshaler defines a function which takes a byte slice and unmarshals it into a relevant request
+type RequestUnmarshaler func([]byte) (PersistentRequest, error)

--- a/exporter/exporterhelper/internal/persistent_storage.go
+++ b/exporter/exporterhelper/internal/persistent_storage.go
@@ -15,7 +15,7 @@
 //go:build enable_unstable
 // +build enable_unstable
 
-package exporterhelper
+package internal
 
 import (
 	"context"
@@ -24,7 +24,6 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"go.opencensus.io/metric/metricdata"
 	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/extension/storage"
@@ -33,16 +32,16 @@ import (
 // persistentStorage provides an interface for request storage operations
 type persistentStorage interface {
 	// put appends the request to the storage
-	put(req request) error
+	put(req PersistentRequest) error
 	// get returns the next available request; note that the channel is unbuffered
-	get() <-chan request
+	get() <-chan PersistentRequest
 	// size returns the current size of the persistent storage with items waiting for processing
 	size() uint64
 	// stop gracefully stops the storage
 	stop()
 }
 
-// persistentContiguousStorage provides a persistent queue implementation backed by file storage extension
+// persistentContiguousStorage provides a persistent queue implementation backed by a file storage extension
 //
 // Write index describes the position at which next item is going to be stored.
 // Read index describes which item needs to be read next.
@@ -70,14 +69,14 @@ type persistentContiguousStorage struct {
 	logger      *zap.Logger
 	queueName   string
 	client      storage.Client
-	unmarshaler requestUnmarshaler
+	unmarshaler RequestUnmarshaler
 
 	putChan  chan struct{}
 	stopChan chan struct{}
 	stopOnce sync.Once
 	capacity uint64
 
-	reqChan chan request
+	reqChan chan PersistentRequest
 
 	mu                       sync.Mutex
 	readIndex                itemIndex
@@ -109,7 +108,7 @@ var (
 // newPersistentContiguousStorage creates a new file-storage extension backed queue;
 // queueName parameter must be a unique value that identifies the queue.
 // The queue needs to be initialized separately using initPersistentContiguousStorage.
-func newPersistentContiguousStorage(ctx context.Context, queueName string, capacity uint64, logger *zap.Logger, client storage.Client, unmarshaler requestUnmarshaler) *persistentContiguousStorage {
+func newPersistentContiguousStorage(ctx context.Context, queueName string, capacity uint64, logger *zap.Logger, client storage.Client, unmarshaler RequestUnmarshaler) *persistentContiguousStorage {
 	pcs := &persistentContiguousStorage{
 		logger:      logger,
 		client:      client,
@@ -117,19 +116,12 @@ func newPersistentContiguousStorage(ctx context.Context, queueName string, capac
 		unmarshaler: unmarshaler,
 		capacity:    capacity,
 		putChan:     make(chan struct{}, capacity),
-		reqChan:     make(chan request),
+		reqChan:     make(chan PersistentRequest),
 		stopChan:    make(chan struct{}),
 	}
 
 	initPersistentContiguousStorage(ctx, pcs)
 	notDispatchedReqs := pcs.retrieveNotDispatchedReqs(context.Background())
-
-	err := currentlyDispatchedBatchesGauge.UpsertEntry(func() int64 {
-		return int64(pcs.numberOfCurrentlyDispatchedItems())
-	}, metricdata.NewLabelValue(pcs.queueName))
-	if err != nil {
-		logger.Error("failed to create number of currently dispatched items metric", zap.Error(err))
-	}
 
 	// We start the loop first so in case there are more elements in the persistent storage than the capacity,
 	// it does not get blocked on initialization
@@ -177,7 +169,7 @@ func initPersistentContiguousStorage(ctx context.Context, pcs *persistentContigu
 	atomic.StoreUint64(&pcs.itemsCount, uint64(pcs.writeIndex-pcs.readIndex))
 }
 
-func (pcs *persistentContiguousStorage) enqueueNotDispatchedReqs(reqs []request) {
+func (pcs *persistentContiguousStorage) enqueueNotDispatchedReqs(reqs []PersistentRequest) {
 	if len(reqs) > 0 {
 		errCount := 0
 		for _, req := range reqs {
@@ -215,7 +207,7 @@ func (pcs *persistentContiguousStorage) loop() {
 }
 
 // get returns the request channel that all the requests will be send on
-func (pcs *persistentContiguousStorage) get() <-chan request {
+func (pcs *persistentContiguousStorage) get() <-chan PersistentRequest {
 	return pcs.reqChan
 }
 
@@ -224,25 +216,15 @@ func (pcs *persistentContiguousStorage) size() uint64 {
 	return atomic.LoadUint64(&pcs.itemsCount)
 }
 
-// numberOfCurrentlyDispatchedItems returns the count of batches for which processing started but hasn't finished yet
-func (pcs *persistentContiguousStorage) numberOfCurrentlyDispatchedItems() int {
-	pcs.mu.Lock()
-	defer pcs.mu.Unlock()
-	return len(pcs.currentlyDispatchedItems)
-}
-
 func (pcs *persistentContiguousStorage) stop() {
 	pcs.logger.Debug("Stopping persistentContiguousStorage", zap.String(zapQueueNameKey, pcs.queueName))
 	pcs.stopOnce.Do(func() {
 		close(pcs.stopChan)
-		_ = currentlyDispatchedBatchesGauge.UpsertEntry(func() int64 {
-			return int64(pcs.numberOfCurrentlyDispatchedItems())
-		}, metricdata.NewLabelValue(pcs.queueName))
 	})
 }
 
 // put marshals the request and puts it into the persistent queue
-func (pcs *persistentContiguousStorage) put(req request) error {
+func (pcs *persistentContiguousStorage) put(req PersistentRequest) error {
 	// Nil requests are ignored
 	if req == nil {
 		return nil
@@ -265,12 +247,11 @@ func (pcs *persistentContiguousStorage) put(req request) error {
 
 	// Inform the loop that there's some data to process
 	pcs.putChan <- struct{}{}
-
 	return err
 }
 
 // getNextItem pulls the next available item from the persistent storage; if none is found, returns (nil, false)
-func (pcs *persistentContiguousStorage) getNextItem(ctx context.Context) (request, bool) {
+func (pcs *persistentContiguousStorage) getNextItem(ctx context.Context) (PersistentRequest, bool) {
 	pcs.mu.Lock()
 	defer pcs.mu.Unlock()
 
@@ -293,7 +274,7 @@ func (pcs *persistentContiguousStorage) getNextItem(ctx context.Context) (reques
 			return nil, false
 		}
 
-		req.setOnProcessingFinished(func() {
+		req.SetOnProcessingFinished(func() {
 			pcs.mu.Lock()
 			defer pcs.mu.Unlock()
 			pcs.itemDispatchingFinish(ctx, index)
@@ -306,8 +287,8 @@ func (pcs *persistentContiguousStorage) getNextItem(ctx context.Context) (reques
 
 // retrieveNotDispatchedReqs gets the items for which sending was not finished, cleans the storage
 // and moves the items back to the queue
-func (pcs *persistentContiguousStorage) retrieveNotDispatchedReqs(ctx context.Context) []request {
-	var reqs []request
+func (pcs *persistentContiguousStorage) retrieveNotDispatchedReqs(ctx context.Context) []PersistentRequest {
+	var reqs []PersistentRequest
 	var dispatchedItems []itemIndex
 
 	pcs.mu.Lock()
@@ -330,7 +311,7 @@ func (pcs *persistentContiguousStorage) retrieveNotDispatchedReqs(ctx context.Co
 		pcs.logger.Debug("No items left for dispatch by consumers")
 	}
 
-	reqs = make([]request, len(dispatchedItems))
+	reqs = make([]PersistentRequest, len(dispatchedItems))
 	keys := make([]string, len(dispatchedItems))
 	retrieveBatch := newBatch(pcs)
 	cleanupBatch := newBatch(pcs)
@@ -378,6 +359,8 @@ func (pcs *persistentContiguousStorage) itemDispatchingStart(ctx context.Context
 		pcs.logger.Debug("Failed updating currently dispatched items",
 			zap.String(zapQueueNameKey, pcs.queueName), zap.Error(err))
 	}
+
+	recordCurrentlyDispatchedBatches(ctx, len(pcs.currentlyDispatchedItems), pcs.queueName)
 }
 
 // itemDispatchingFinish removes the item from the list of currently dispatched items and deletes it from the persistent queue
@@ -398,6 +381,8 @@ func (pcs *persistentContiguousStorage) itemDispatchingFinish(ctx context.Contex
 		pcs.logger.Debug("Failed updating currently dispatched items",
 			zap.String(zapQueueNameKey, pcs.queueName), zap.Error(err))
 	}
+
+	recordBatchDispatched(ctx, pcs.queueName)
 }
 
 func (pcs *persistentContiguousStorage) updateReadIndex(ctx context.Context) {

--- a/exporter/exporterhelper/internal/persistent_storage_batch.go
+++ b/exporter/exporterhelper/internal/persistent_storage_batch.go
@@ -15,7 +15,7 @@
 //go:build enable_unstable
 // +build enable_unstable
 
-package exporterhelper
+package internal
 
 import (
 	"bytes"
@@ -106,13 +106,13 @@ func (bof *batchStruct) getResult(key string, unmarshal func([]byte) (interface{
 }
 
 // getRequestResult returns the result of a Get operation as a request
-func (bof *batchStruct) getRequestResult(key string) (request, error) {
+func (bof *batchStruct) getRequestResult(key string) (PersistentRequest, error) {
 	reqIf, err := bof.getResult(key, bof.bytesToRequest)
 	if err != nil {
 		return nil, err
 	}
 
-	return reqIf.(request), nil
+	return reqIf.(PersistentRequest), nil
 }
 
 // getItemIndexResult returns the result of a Get operation as an itemIndex
@@ -144,7 +144,7 @@ func (bof *batchStruct) getItemIndexArrayResult(key string) ([]itemIndex, error)
 }
 
 // setRequest adds Set operation over a given request to the batch
-func (bof *batchStruct) setRequest(key string, value request) *batchStruct {
+func (bof *batchStruct) setRequest(key string, value PersistentRequest) *batchStruct {
 	return bof.set(key, value, requestToBytes)
 }
 
@@ -215,7 +215,7 @@ func bytesToItemIndexArray(b []byte) (interface{}, error) {
 }
 
 func requestToBytes(req interface{}) ([]byte, error) {
-	return req.(request).marshal()
+	return req.(PersistentRequest).Marshal()
 }
 
 func (bof *batchStruct) bytesToRequest(b []byte) (interface{}, error) {

--- a/exporter/exporterhelper/internal/persistent_storage_batch_test.go
+++ b/exporter/exporterhelper/internal/persistent_storage_batch_test.go
@@ -15,7 +15,7 @@
 //go:build enable_unstable
 // +build enable_unstable
 
-package exporterhelper
+package internal
 
 import (
 	"context"

--- a/exporter/exporterhelper/internal/persistent_storage_test.go
+++ b/exporter/exporterhelper/internal/persistent_storage_test.go
@@ -15,7 +15,7 @@
 //go:build enable_unstable
 // +build enable_unstable
 
-package exporterhelper
+package internal
 
 import (
 	"context"
@@ -29,12 +29,15 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
 	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/extension/storage"
+	"go.opentelemetry.io/collector/model/otlp"
+	"go.opentelemetry.io/collector/model/pdata"
 )
 
 func createStorageExtension(_ string) storage.Extension {
@@ -51,7 +54,7 @@ func createTestClient(extension storage.Extension) storage.Client {
 }
 
 func createTestPersistentStorageWithLoggingAndCapacity(client storage.Client, logger *zap.Logger, capacity uint64) *persistentContiguousStorage {
-	return newPersistentContiguousStorage(context.Background(), "foo", capacity, logger, client, newTraceRequestUnmarshalerFunc(nopTracePusher()))
+	return newPersistentContiguousStorage(context.Background(), "foo", capacity, logger, client, newFakeTracesRequestUnmarshalerFunc())
 }
 
 func createTestPersistentStorage(client storage.Client) *persistentContiguousStorage {
@@ -67,12 +70,48 @@ func createTemporaryDirectory() string {
 	return directory
 }
 
+type fakeTracesRequest struct {
+	td                         pdata.Traces
+	processingFinishedCallback func()
+	PersistentRequest
+}
+
+func newFakeTracesRequest(td pdata.Traces) *fakeTracesRequest {
+	return &fakeTracesRequest{
+		td: td,
+	}
+}
+
+func (fd *fakeTracesRequest) Marshal() ([]byte, error) {
+	return otlp.NewProtobufTracesMarshaler().MarshalTraces(fd.td)
+}
+
+func (fd *fakeTracesRequest) OnProcessingFinished() {
+	if fd.processingFinishedCallback != nil {
+		fd.processingFinishedCallback()
+	}
+}
+
+func (fd *fakeTracesRequest) SetOnProcessingFinished(callback func()) {
+	fd.processingFinishedCallback = callback
+}
+
+func newFakeTracesRequestUnmarshalerFunc() RequestUnmarshaler {
+	return func(bytes []byte) (PersistentRequest, error) {
+		traces, err := otlp.NewProtobufTracesUnmarshaler().UnmarshalTraces(bytes)
+		if err != nil {
+			return nil, err
+		}
+		return newFakeTracesRequest(traces), nil
+	}
+}
+
 func TestPersistentStorage_CurrentlyProcessedItems(t *testing.T) {
 	path := createTemporaryDirectory()
 	defer os.RemoveAll(path)
 
 	traces := newTraces(5, 10)
-	req := newTracesRequest(context.Background(), traces, nopTracePusher())
+	req := newFakeTracesRequest(traces)
 
 	ext := createStorageExtension(path)
 	client := createTestClient(ext)
@@ -88,7 +127,7 @@ func TestPersistentStorage_CurrentlyProcessedItems(t *testing.T) {
 
 	// Now, this will take item 0 and pull item 1 into the unbuffered channel
 	readReq := getItemFromChannel(t, ps)
-	require.Equal(t, req.(*tracesRequest).td, readReq.(*tracesRequest).td)
+	require.Equal(t, req.td, readReq.(*fakeTracesRequest).td)
 	requireCurrentlyDispatchedItemsEqual(t, ps, []itemIndex{0, 1})
 
 	// This takes item 1 from channel and pulls another one (item 2) into the unbuffered channel
@@ -96,7 +135,7 @@ func TestPersistentStorage_CurrentlyProcessedItems(t *testing.T) {
 	requireCurrentlyDispatchedItemsEqual(t, ps, []itemIndex{0, 1, 2})
 
 	// Lets mark item 1 as finished, it will remove it from the currently dispatched items list
-	secondReadReq.onProcessingFinished()
+	secondReadReq.OnProcessingFinished()
 	requireCurrentlyDispatchedItemsEqual(t, ps, []itemIndex{0, 2})
 
 	// Reload the storage. Since items 0 and 2 were not finished, those should be requeued at the end.
@@ -112,7 +151,7 @@ func TestPersistentStorage_CurrentlyProcessedItems(t *testing.T) {
 	// We should be able to pull all remaining items now
 	for i := 0; i < 4; i++ {
 		req := getItemFromChannel(t, newPs)
-		req.onProcessingFinished()
+		req.OnProcessingFinished()
 	}
 
 	// The queue should be now empty
@@ -137,11 +176,13 @@ func TestPersistentStorage_MetricsReported(t *testing.T) {
 	defer os.RemoveAll(path)
 
 	traces := newTraces(5, 10)
-	req := newTracesRequest(context.Background(), traces, nopTracePusher())
+	req := newFakeTracesRequest(traces)
 
 	ext := createStorageExtension(path)
 	client := createTestClient(ext)
 	ps := createTestPersistentStorage(client)
+
+	RegisterMetrics()
 
 	for i := 0; i < 5; i++ {
 		err := ps.put(req)
@@ -150,10 +191,15 @@ func TestPersistentStorage_MetricsReported(t *testing.T) {
 
 	_ = getItemFromChannel(t, ps)
 	requireCurrentlyDispatchedItemsEqual(t, ps, []itemIndex{0, 1})
-	checkValueForProducer(t, []tag.Tag{{Key: exporterTag, Value: "foo"}}, int64(2), "exporter/currently_dispatched_batches")
+
+	dd, err := view.RetrieveData("/currently_dispatched_batches")
+	require.NoError(t, err)
+	require.Equal(t, 1, len(dd))
+	require.Equal(t, 1, len(dd[0].Tags))
+	require.Equal(t, tag.Tag{Key: queueNameKey, Value: "foo"}, dd[0].Tags[0])
+	require.Equal(t, int64(2), dd[0].Data.(*view.CountData).Value)
 
 	ps.stop()
-	checkValueForProducer(t, []tag.Tag{{Key: exporterTag, Value: "foo"}}, int64(2), "exporter/currently_dispatched_batches")
 }
 
 func TestPersistentStorage_RepeatPutCloseReadClose(t *testing.T) {
@@ -161,7 +207,7 @@ func TestPersistentStorage_RepeatPutCloseReadClose(t *testing.T) {
 	defer os.RemoveAll(path)
 
 	traces := newTraces(5, 10)
-	req := newTracesRequest(context.Background(), traces, nopTracePusher())
+	req := newFakeTracesRequest(traces)
 
 	for i := 0; i < 10; i++ {
 		ext := createStorageExtension(path)
@@ -189,10 +235,10 @@ func TestPersistentStorage_RepeatPutCloseReadClose(t *testing.T) {
 
 		// Lets read both of the elements we put
 		readReq := getItemFromChannel(t, ps)
-		require.Equal(t, req.(*tracesRequest).td, readReq.(*tracesRequest).td)
+		require.Equal(t, req.td, readReq.(*fakeTracesRequest).td)
 
 		readReq = getItemFromChannel(t, ps)
-		require.Equal(t, req.(*tracesRequest).td, readReq.(*tracesRequest).td)
+		require.Equal(t, req.td, readReq.(*fakeTracesRequest).td)
 		require.Equal(t, uint64(0), ps.size())
 
 		err = ext.Shutdown(context.Background())
@@ -253,7 +299,7 @@ func BenchmarkPersistentStorage_TraceSpans(b *testing.B) {
 			ps := createTestPersistentStorageWithLoggingAndCapacity(client, zap.NewNop(), 10000000)
 
 			traces := newTraces(c.numTraces, c.numSpansPerTrace)
-			req := newTracesRequest(context.Background(), traces, nopTracePusher())
+			req := newFakeTracesRequest(traces)
 
 			bb.ResetTimer()
 
@@ -305,8 +351,8 @@ func TestPersistentStorage_ItemIndexMarshaling(t *testing.T) {
 	}
 }
 
-func getItemFromChannel(t *testing.T, pcs *persistentContiguousStorage) request {
-	var readReq request
+func getItemFromChannel(t *testing.T, pcs *persistentContiguousStorage) PersistentRequest {
+	var readReq PersistentRequest
 	require.Eventually(t, func() bool {
 		readReq = <-pcs.get()
 		return true

--- a/exporter/exporterhelper/logs.go
+++ b/exporter/exporterhelper/logs.go
@@ -23,6 +23,7 @@ import (
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/consumer/consumerhelper"
+	"go.opentelemetry.io/collector/exporter/exporterhelper/internal"
 	"go.opentelemetry.io/collector/model/otlp"
 	"go.opentelemetry.io/collector/model/pdata"
 )
@@ -44,8 +45,8 @@ func newLogsRequest(ctx context.Context, ld pdata.Logs, pusher consumerhelper.Co
 	}
 }
 
-func newLogsRequestUnmarshalerFunc(pusher consumerhelper.ConsumeLogsFunc) requestUnmarshaler {
-	return func(bytes []byte) (request, error) {
+func newLogsRequestUnmarshalerFunc(pusher consumerhelper.ConsumeLogsFunc) internal.RequestUnmarshaler {
+	return func(bytes []byte) (internal.PersistentRequest, error) {
 		logs, err := logsUnmarshaler.UnmarshalLogs(bytes)
 		if err != nil {
 			return nil, err
@@ -66,7 +67,8 @@ func (req *logsRequest) export(ctx context.Context) error {
 	return req.pusher(ctx, req.ld)
 }
 
-func (req *logsRequest) marshal() ([]byte, error) {
+// Marshal provides serialization capabilities required by persistent queue
+func (req *logsRequest) Marshal() ([]byte, error) {
 	return logsMarshaler.MarshalLogs(req.ld)
 }
 

--- a/exporter/exporterhelper/metrics.go
+++ b/exporter/exporterhelper/metrics.go
@@ -23,6 +23,7 @@ import (
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/consumer/consumerhelper"
+	"go.opentelemetry.io/collector/exporter/exporterhelper/internal"
 	"go.opentelemetry.io/collector/model/otlp"
 	"go.opentelemetry.io/collector/model/pdata"
 )
@@ -44,8 +45,8 @@ func newMetricsRequest(ctx context.Context, md pdata.Metrics, pusher consumerhel
 	}
 }
 
-func newMetricsRequestUnmarshalerFunc(pusher consumerhelper.ConsumeMetricsFunc) requestUnmarshaler {
-	return func(bytes []byte) (request, error) {
+func newMetricsRequestUnmarshalerFunc(pusher consumerhelper.ConsumeMetricsFunc) internal.RequestUnmarshaler {
+	return func(bytes []byte) (internal.PersistentRequest, error) {
 		metrics, err := metricsUnmarshaler.UnmarshalMetrics(bytes)
 		if err != nil {
 			return nil, err
@@ -66,7 +67,8 @@ func (req *metricsRequest) export(ctx context.Context) error {
 	return req.pusher(ctx, req.md)
 }
 
-func (req *metricsRequest) marshal() ([]byte, error) {
+// Marshal provides serialization capabilities required by persistent queue
+func (req *metricsRequest) Marshal() ([]byte, error) {
 	return metricsMarshaler.MarshalMetrics(req.md)
 }
 

--- a/exporter/exporterhelper/queued_retry.go
+++ b/exporter/exporterhelper/queued_retry.go
@@ -49,32 +49,6 @@ func init() {
 	metricproducer.GlobalManager().AddProducer(r)
 }
 
-// QueueSettings defines configuration for queueing batches before sending to the consumerSender.
-type QueueSettings struct {
-	// Enabled indicates whether to not enqueue batches before sending to the consumerSender.
-	Enabled bool `mapstructure:"enabled"`
-	// NumConsumers is the number of consumers from the queue.
-	NumConsumers int `mapstructure:"num_consumers"`
-	// QueueSize is the maximum number of batches allowed in queue at a given time.
-	QueueSize int `mapstructure:"queue_size"`
-	// PersistentStorageEnabled describes whether persistence via a file storage extension is enabled
-	PersistentStorageEnabled bool `mapstructure:"persistent_storage_enabled"`
-}
-
-// DefaultQueueSettings returns the default settings for QueueSettings.
-func DefaultQueueSettings() QueueSettings {
-	return QueueSettings{
-		Enabled:      true,
-		NumConsumers: 10,
-		// For 5000 queue elements at 100 requests/sec gives about 50 sec of survival of destination outage.
-		// This is a pretty decent value for production.
-		// User should calculate this from the perspective of how many seconds to buffer in case of a backend outage,
-		// multiply that by the number of requests per seconds.
-		QueueSize:                5000,
-		PersistentStorageEnabled: false,
-	}
-}
-
 // RetrySettings defines configuration for retrying batches in case of export failure.
 // The current supported strategy is exponential backoff.
 type RetrySettings struct {

--- a/exporter/exporterhelper/queued_retry_experimental.go
+++ b/exporter/exporterhelper/queued_retry_experimental.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"fmt"
 
-	"go.opencensus.io/metric"
 	"go.opencensus.io/metric/metricdata"
 	"go.opentelemetry.io/otel/attribute"
 	"go.uber.org/zap"
@@ -37,13 +36,33 @@ import (
 // queued_retry_experimental includes the code for both memory-backed and persistent-storage backed queued retry helpers
 // enabled by setting "enable_unstable" build tag
 
-var (
-	currentlyDispatchedBatchesGauge, _ = r.AddInt64DerivedGauge(
-		obsmetrics.ExporterKey+"/currently_dispatched_batches",
-		metric.WithDescription("Number of batches that are currently being sent"),
-		metric.WithLabelKeys(obsmetrics.ExporterKey),
-		metric.WithUnit(metricdata.UnitDimensionless))
+// QueueSettings defines configuration for queueing batches before sending to the consumerSender.
+type QueueSettings struct {
+	// Enabled indicates whether to not enqueue batches before sending to the consumerSender.
+	Enabled bool `mapstructure:"enabled"`
+	// NumConsumers is the number of consumers from the queue.
+	NumConsumers int `mapstructure:"num_consumers"`
+	// QueueSize is the maximum number of batches allowed in queue at a given time.
+	QueueSize int `mapstructure:"queue_size"`
+	// PersistentStorageEnabled describes whether persistence via a file storage extension is enabled
+	PersistentStorageEnabled bool `mapstructure:"persistent_storage_enabled"`
+}
 
+// DefaultQueueSettings returns the default settings for QueueSettings.
+func DefaultQueueSettings() QueueSettings {
+	return QueueSettings{
+		Enabled:      true,
+		NumConsumers: 10,
+		// For 5000 queue elements at 100 requests/sec gives about 50 sec of survival of destination outage.
+		// This is a pretty decent value for production.
+		// User should calculate this from the perspective of how many seconds to buffer in case of a backend outage,
+		// multiply that by the number of requests per seconds.
+		QueueSize:                5000,
+		PersistentStorageEnabled: false,
+	}
+}
+
+var (
 	errNoStorageClient        = errors.New("no storage client extension found")
 	errMultipleStorageClients = errors.New("multiple storage extensions found")
 )
@@ -53,12 +72,12 @@ type queuedRetrySender struct {
 	signal             config.DataType
 	cfg                QueueSettings
 	consumerSender     requestSender
-	queue              consumersQueue
+	queue              internal.BoundedQueue
 	retryStopCh        chan struct{}
 	traceAttributes    []attribute.KeyValue
 	logger             *zap.Logger
 	requeuingEnabled   bool
-	requestUnmarshaler requestUnmarshaler
+	requestUnmarshaler internal.RequestUnmarshaler
 }
 
 func (qrs *queuedRetrySender) fullName() string {
@@ -68,7 +87,7 @@ func (qrs *queuedRetrySender) fullName() string {
 	return fmt.Sprintf("%s-%s", qrs.id.String(), qrs.signal)
 }
 
-func newQueuedRetrySender(id config.ComponentID, signal config.DataType, qCfg QueueSettings, rCfg RetrySettings, reqUnmarshaler requestUnmarshaler, nextSender requestSender, logger *zap.Logger) *queuedRetrySender {
+func newQueuedRetrySender(id config.ComponentID, signal config.DataType, bs *baseSettings, reqUnmarshaler internal.RequestUnmarshaler, nextSender requestSender, logger *zap.Logger) *queuedRetrySender {
 	retryStopCh := make(chan struct{})
 	sampledLogger := createSampledLogger(logger)
 	traceAttr := attribute.String(obsmetrics.ExporterKey, id.String())
@@ -76,7 +95,7 @@ func newQueuedRetrySender(id config.ComponentID, signal config.DataType, qCfg Qu
 	qrs := &queuedRetrySender{
 		id:                 id,
 		signal:             signal,
-		cfg:                qCfg,
+		cfg:                bs.QueueSettings,
 		retryStopCh:        retryStopCh,
 		traceAttributes:    []attribute.KeyValue{traceAttr},
 		logger:             sampledLogger,
@@ -85,7 +104,7 @@ func newQueuedRetrySender(id config.ComponentID, signal config.DataType, qCfg Qu
 
 	qrs.consumerSender = &retrySender{
 		traceAttribute: traceAttr,
-		cfg:            rCfg,
+		cfg:            bs.RetrySettings,
 		nextSender:     nextSender,
 		stopCh:         retryStopCh,
 		logger:         sampledLogger,
@@ -93,8 +112,8 @@ func newQueuedRetrySender(id config.ComponentID, signal config.DataType, qCfg Qu
 		onTemporaryFailure: qrs.onTemporaryFailure,
 	}
 
-	if !qCfg.PersistentStorageEnabled {
-		qrs.queue = internal.NewBoundedQueue(qrs.cfg.QueueSize, func(item interface{}) {})
+	if !bs.PersistentStorageEnabled {
+		qrs.queue = internal.NewBoundedMemoryQueue(qrs.cfg.QueueSize, func(item interface{}) {})
 	}
 	// The Persistent Queue is initialized separately as it needs extra information about the component
 
@@ -132,7 +151,7 @@ func (qrs *queuedRetrySender) initializePersistentQueue(ctx context.Context, hos
 			return err
 		}
 
-		qrs.queue = newPersistentQueue(ctx, qrs.fullName(), qrs.cfg.QueueSize, qrs.logger, *storageClient, qrs.requestUnmarshaler)
+		qrs.queue = internal.NewPersistentQueue(ctx, qrs.fullName(), qrs.cfg.QueueSize, qrs.logger, *storageClient, qrs.requestUnmarshaler)
 
 		// TODO: this can be further exposed as a config param rather than relying on a type of queue
 		qrs.requeuingEnabled = true
@@ -176,7 +195,7 @@ func (qrs *queuedRetrySender) start(ctx context.Context, host component.Host) er
 	qrs.queue.StartConsumers(qrs.cfg.NumConsumers, func(item interface{}) {
 		req := item.(request)
 		_ = qrs.consumerSender.send(req)
-		req.onProcessingFinished()
+		req.OnProcessingFinished()
 	})
 
 	// Start reporting queue length metric

--- a/exporter/exporterhelper/queued_retry_inmemory.go
+++ b/exporter/exporterhelper/queued_retry_inmemory.go
@@ -34,32 +34,55 @@ import (
 // queued_retry_inmemory includes the code for memory-backed (original) queued retry helper only
 // enabled when "enable_unstable" build tag is not set
 
+// QueueSettings defines configuration for queueing batches before sending to the consumerSender.
+type QueueSettings struct {
+	// Enabled indicates whether to not enqueue batches before sending to the consumerSender.
+	Enabled bool `mapstructure:"enabled"`
+	// NumConsumers is the number of consumers from the queue.
+	NumConsumers int `mapstructure:"num_consumers"`
+	// QueueSize is the maximum number of batches allowed in queue at a given time.
+	QueueSize int `mapstructure:"queue_size"`
+}
+
+// DefaultQueueSettings returns the default settings for QueueSettings.
+func DefaultQueueSettings() QueueSettings {
+	return QueueSettings{
+		Enabled:      true,
+		NumConsumers: 10,
+		// For 5000 queue elements at 100 requests/sec gives about 50 sec of survival of destination outage.
+		// This is a pretty decent value for production.
+		// User should calculate this from the perspective of how many seconds to buffer in case of a backend outage,
+		// multiply that by the number of requests per seconds.
+		QueueSize: 5000,
+	}
+}
+
 type queuedRetrySender struct {
 	fullName        string
 	cfg             QueueSettings
 	consumerSender  requestSender
-	queue           consumersQueue
+	queue           internal.BoundedQueue
 	retryStopCh     chan struct{}
 	traceAttributes []attribute.KeyValue
 	logger          *zap.Logger
 }
 
-func newQueuedRetrySender(id config.ComponentID, _ config.DataType, qCfg QueueSettings, rCfg RetrySettings, _ requestUnmarshaler, nextSender requestSender, logger *zap.Logger) *queuedRetrySender {
+func newQueuedRetrySender(id config.ComponentID, _ config.DataType, bs *baseSettings, _ internal.RequestUnmarshaler, nextSender requestSender, logger *zap.Logger) *queuedRetrySender {
 	retryStopCh := make(chan struct{})
 	sampledLogger := createSampledLogger(logger)
 	traceAttr := attribute.String(obsmetrics.ExporterKey, id.String())
 	return &queuedRetrySender{
 		fullName: id.String(),
-		cfg:      qCfg,
+		cfg:      bs.QueueSettings,
 		consumerSender: &retrySender{
 			traceAttribute:     traceAttr,
-			cfg:                rCfg,
+			cfg:                bs.RetrySettings,
 			nextSender:         nextSender,
 			stopCh:             retryStopCh,
 			logger:             sampledLogger,
 			onTemporaryFailure: onTemporaryFailure,
 		},
-		queue:           internal.NewBoundedQueue(qCfg.QueueSize, func(item interface{}) {}),
+		queue:           internal.NewBoundedMemoryQueue(bs.QueueSettings.QueueSize, func(item interface{}) {}),
 		retryStopCh:     retryStopCh,
 		traceAttributes: []attribute.KeyValue{traceAttr},
 		logger:          sampledLogger,
@@ -80,7 +103,7 @@ func (qrs *queuedRetrySender) start(ctx context.Context, host component.Host) er
 	qrs.queue.StartConsumers(qrs.cfg.NumConsumers, func(item interface{}) {
 		req := item.(request)
 		_ = qrs.consumerSender.send(req)
-		req.onProcessingFinished()
+		req.OnProcessingFinished()
 	})
 
 	// Start reporting queue length metric

--- a/exporter/exporterhelper/queued_retry_test.go
+++ b/exporter/exporterhelper/queued_retry_test.go
@@ -31,14 +31,15 @@ import (
 
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/consumer/consumererror"
+	"go.opentelemetry.io/collector/exporter/exporterhelper/internal"
 	"go.opentelemetry.io/collector/internal/testdata"
 	"go.opentelemetry.io/collector/model/otlp"
 	"go.opentelemetry.io/collector/model/pdata"
 	"go.opentelemetry.io/collector/obsreport/obsreporttest"
 )
 
-func mockRequestUnmarshaler(mr *mockRequest) requestUnmarshaler {
-	return func(bytes []byte) (request, error) {
+func mockRequestUnmarshaler(mr *mockRequest) internal.RequestUnmarshaler {
+	return func(bytes []byte) (internal.PersistentRequest, error) {
 		return mr, nil
 	}
 }
@@ -379,7 +380,7 @@ func (mer *mockErrorRequest) onError(error) request {
 	return mer
 }
 
-func (mer *mockErrorRequest) marshal() ([]byte, error) {
+func (mer *mockErrorRequest) Marshal() ([]byte, error) {
 	return nil, nil
 }
 
@@ -414,7 +415,7 @@ func (m *mockRequest) export(ctx context.Context) error {
 	return ctx.Err()
 }
 
-func (m *mockRequest) marshal() ([]byte, error) {
+func (m *mockRequest) Marshal() ([]byte, error) {
 	return otlp.NewProtobufTracesMarshaler().MarshalTraces(pdata.NewTraces())
 }
 

--- a/exporter/exporterhelper/request.go
+++ b/exporter/exporterhelper/request.go
@@ -1,0 +1,67 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exporterhelper
+
+import (
+	"context"
+
+	"go.opentelemetry.io/collector/exporter/exporterhelper/internal"
+)
+
+// request is an abstraction of an individual request (batch of data) independent of the type of the data (traces, metrics, logs).
+type request interface {
+	// context returns the Context of the requests.
+	context() context.Context
+	// setContext updates the Context of the requests.
+	setContext(context.Context)
+	export(ctx context.Context) error
+	// Returns a new request may contain the items left to be sent if some items failed to process and can be retried.
+	// Otherwise, it should return the original request.
+	onError(error) request
+	// Returns the count of spans/metric points or log records.
+	count() int
+
+	// PersistentRequest provides interface with additional capabilities required by persistent queue
+	internal.PersistentRequest
+}
+
+// requestSender is an abstraction of a sender for a request independent of the type of the data (traces, metrics, logs).
+type requestSender interface {
+	send(req request) error
+}
+
+// baseRequest is a base implementation for the request.
+type baseRequest struct {
+	ctx                        context.Context
+	processingFinishedCallback func()
+}
+
+func (req *baseRequest) context() context.Context {
+	return req.ctx
+}
+
+func (req *baseRequest) setContext(ctx context.Context) {
+	req.ctx = ctx
+}
+
+func (req *baseRequest) SetOnProcessingFinished(callback func()) {
+	req.processingFinishedCallback = callback
+}
+
+func (req *baseRequest) OnProcessingFinished() {
+	if req.processingFinishedCallback != nil {
+		req.processingFinishedCallback()
+	}
+}

--- a/exporter/exporterhelper/traces.go
+++ b/exporter/exporterhelper/traces.go
@@ -23,6 +23,7 @@ import (
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/consumer/consumerhelper"
+	"go.opentelemetry.io/collector/exporter/exporterhelper/internal"
 	"go.opentelemetry.io/collector/model/otlp"
 	"go.opentelemetry.io/collector/model/pdata"
 )
@@ -44,8 +45,8 @@ func newTracesRequest(ctx context.Context, td pdata.Traces, pusher consumerhelpe
 	}
 }
 
-func newTraceRequestUnmarshalerFunc(pusher consumerhelper.ConsumeTracesFunc) requestUnmarshaler {
-	return func(bytes []byte) (request, error) {
+func newTraceRequestUnmarshalerFunc(pusher consumerhelper.ConsumeTracesFunc) internal.RequestUnmarshaler {
+	return func(bytes []byte) (internal.PersistentRequest, error) {
 		traces, err := tracesUnmarshaler.UnmarshalTraces(bytes)
 		if err != nil {
 			return nil, err
@@ -54,7 +55,8 @@ func newTraceRequestUnmarshalerFunc(pusher consumerhelper.ConsumeTracesFunc) req
 	}
 }
 
-func (req *tracesRequest) marshal() ([]byte, error) {
+// Marshal provides serialization capabilities required by persistent queue
+func (req *tracesRequest) Marshal() ([]byte, error) {
 	return tracesMarshaler.MarshalTraces(req.td)
 }
 


### PR DESCRIPTION
**Description:**
This addresses the items raised in #4025 (move persistent_queue to internal and remove the config for persistent queue from stable build). I tried to keep the code clean and the refactor impacted several things:
* Some names had to be exported - e.g. `internal.RequestUnmarshaler` or `internal.PersistentRequest`
* I have extracted `BoundedQueue` as an interface. The memory-based implementation is now known as `boundedMemoryQueue`
* `QueueSettings` was duplicated. One struct has additional persistent-storage related config. Otherwise we are losing ability to reuse `exporterhelper.WithQueue`. Perhaps there's a more elegant way to handle that which would not include too much boilerplate?

**Link to tracking Issue:** #4025 

**Testing:** Unit tests updated, manual tests to follow

**Documentation:** README.md updated
