### PR TITLE
guard against invalid settings

### DIFF
--- a/config/confighttp/confighttp.go
+++ b/config/confighttp/confighttp.go
@@ -24,6 +24,7 @@ import (
 	"github.com/rs/cors"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/metric/global"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config"
@@ -213,13 +214,21 @@ func (hss *HTTPServerSettings) ToServer(handler http.Handler, settings component
 	}
 	// TODO: emit a warning when non-empty CorsHeaders and empty CorsOrigins.
 
+	tp := settings.TracerProvider
+	if tp == nil {
+		tp = otel.GetTracerProvider()
+	}
+	mp := settings.MeterProvider
+	if mp == nil {
+		mp = global.GetMeterProvider()
+	}
 	// Enable OpenTelemetry observability plugin.
 	// TODO: Consider to use component ID string as prefix for all the operations.
 	handler = otelhttp.NewHandler(
 		handler,
 		"",
-		otelhttp.WithTracerProvider(settings.TracerProvider),
-		otelhttp.WithMeterProvider(settings.MeterProvider),
+		otelhttp.WithTracerProvider(tp),
+		otelhttp.WithMeterProvider(mp),
 		otelhttp.WithPropagators(otel.GetTextMapPropagator()),
 		otelhttp.WithSpanNameFormatter(func(operation string, r *http.Request) string {
 			return r.URL.Path

--- a/config/confighttp/confighttp_test.go
+++ b/config/confighttp/confighttp_test.go
@@ -511,6 +511,17 @@ func TestHttpCorsInvalidSettings(t *testing.T) {
 	require.NoError(t, s.Close())
 }
 
+func TestInvalidTelemetrySettings(t *testing.T) {
+	hss := &HTTPServerSettings{
+		Endpoint: "localhost:0",
+	}
+
+	// This includes non-initialized TelemetrySettings
+	s := hss.ToServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}), component.TelemetrySettings{})
+	require.NotNil(t, s)
+	require.NoError(t, s.Close())
+}
+
 func verifyCorsResp(t *testing.T, url string, origin string, extraHeader bool, wantStatus int, wantAllowed bool) {
 	req, err := http.NewRequest("OPTIONS", url, nil)
 	require.NoError(t, err, "Error creating trace OPTIONS request: %v", err)

--- a/service/collector.go
+++ b/service/collector.go
@@ -29,6 +29,8 @@ import (
 	"github.com/spf13/cobra"
 	"go.opentelemetry.io/contrib/zpages"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/global"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
@@ -74,6 +76,7 @@ type Collector struct {
 	logger  *zap.Logger
 
 	tracerProvider      trace.TracerProvider
+	meterProvider       metric.MeterProvider
 	zPagesSpanProcessor *zpages.SpanProcessor
 
 	service      *service
@@ -218,6 +221,7 @@ func (col *Collector) setupConfigurationComponents(ctx context.Context) error {
 		Config:              cfg,
 		Logger:              col.logger,
 		TracerProvider:      col.tracerProvider,
+		MeterProvider:       col.meterProvider,
 		ZPagesSpanProcessor: col.zPagesSpanProcessor,
 		AsyncErrorChannel:   col.asyncErrorChannel,
 	})
@@ -251,6 +255,8 @@ func (col *Collector) execute(ctx context.Context) error {
 	// Set the constructed tracer provider as Global, in case any component uses the
 	// global TracerProvider.
 	otel.SetTracerProvider(col.tracerProvider)
+
+	col.meterProvider = global.GetMeterProvider()
 
 	col.logger.Info("Starting "+col.set.BuildInfo.Command+"...",
 		zap.String("Version", col.set.BuildInfo.Version),

--- a/service/collector.go
+++ b/service/collector.go
@@ -30,7 +30,6 @@ import (
 	"go.opentelemetry.io/contrib/zpages"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/metric"
-	"go.opentelemetry.io/otel/metric/global"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
@@ -256,7 +255,7 @@ func (col *Collector) execute(ctx context.Context) error {
 	// global TracerProvider.
 	otel.SetTracerProvider(col.tracerProvider)
 
-	col.meterProvider = global.GetMeterProvider()
+	col.meterProvider = metric.NoopMeterProvider{}
 
 	col.logger.Info("Starting "+col.set.BuildInfo.Command+"...",
 		zap.String("Version", col.set.BuildInfo.Version),

--- a/service/internal/builder/exporters_builder.go
+++ b/service/internal/builder/exporters_builder.go
@@ -18,8 +18,6 @@ import (
 	"context"
 	"fmt"
 
-	"go.opentelemetry.io/otel/metric"
-	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/component"
@@ -144,14 +142,12 @@ type exportersRequiredDataTypes map[config.ComponentID]dataTypeRequirements
 
 // BuildExporters builds Exporters from config.
 func BuildExporters(
-	logger *zap.Logger,
-	tracerProvider trace.TracerProvider,
-	meterProvider metric.MeterProvider,
+	settings component.TelemetrySettings,
 	buildInfo component.BuildInfo,
 	cfg *config.Config,
 	factories map[config.Type]component.ExporterFactory,
 ) (Exporters, error) {
-	logger = logger.With(zap.String(zapKindKey, zapKindLogExporter))
+	logger := settings.Logger.With(zap.String(zapKindKey, zapKindLogExporter))
 
 	// We need to calculate required input data types for each exporter so that we know
 	// which data type must be started for each exporter.
@@ -164,8 +160,8 @@ func BuildExporters(
 		set := component.ExporterCreateSettings{
 			TelemetrySettings: component.TelemetrySettings{
 				Logger:         logger.With(zap.String(zapNameKey, expID.String())),
-				TracerProvider: tracerProvider,
-				MeterProvider:  meterProvider,
+				TracerProvider: settings.TracerProvider,
+				MeterProvider:  settings.MeterProvider,
 			},
 			BuildInfo: buildInfo,
 		}

--- a/service/internal/builder/exporters_builder.go
+++ b/service/internal/builder/exporters_builder.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 
+	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
@@ -145,6 +146,7 @@ type exportersRequiredDataTypes map[config.ComponentID]dataTypeRequirements
 func BuildExporters(
 	logger *zap.Logger,
 	tracerProvider trace.TracerProvider,
+	meterProvider metric.MeterProvider,
 	buildInfo component.BuildInfo,
 	cfg *config.Config,
 	factories map[config.Type]component.ExporterFactory,
@@ -163,6 +165,7 @@ func BuildExporters(
 			TelemetrySettings: component.TelemetrySettings{
 				Logger:         logger.With(zap.String(zapNameKey, expID.String())),
 				TracerProvider: tracerProvider,
+				MeterProvider:  meterProvider,
 			},
 			BuildInfo: buildInfo,
 		}

--- a/service/internal/builder/exporters_builder_test.go
+++ b/service/internal/builder/exporters_builder_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
@@ -60,7 +61,7 @@ func TestBuildExporters(t *testing.T) {
 		},
 	}
 
-	exporters, err := BuildExporters(zap.NewNop(), trace.NewNoopTracerProvider(), component.DefaultBuildInfo(), cfg, factories.Exporters)
+	exporters, err := BuildExporters(zap.NewNop(), trace.NewNoopTracerProvider(), metric.NoopMeterProvider{}, component.DefaultBuildInfo(), cfg, factories.Exporters)
 
 	assert.NoError(t, err)
 	require.NotNil(t, exporters)
@@ -89,7 +90,7 @@ func TestBuildExporters(t *testing.T) {
 	// This should result in creating an exporter that has none of consumption
 	// functions set.
 	delete(cfg.Service.Pipelines, "trace")
-	exporters, err = BuildExporters(zap.NewNop(), trace.NewNoopTracerProvider(), component.DefaultBuildInfo(), cfg, factories.Exporters)
+	exporters, err = BuildExporters(zap.NewNop(), trace.NewNoopTracerProvider(), metric.NoopMeterProvider{}, component.DefaultBuildInfo(), cfg, factories.Exporters)
 	assert.NotNil(t, exporters)
 	assert.NoError(t, err)
 
@@ -127,7 +128,7 @@ func TestBuildExporters_BuildLogs(t *testing.T) {
 		},
 	}
 
-	exporters, err := BuildExporters(zap.NewNop(), trace.NewNoopTracerProvider(), component.DefaultBuildInfo(), cfg, factories.Exporters)
+	exporters, err := BuildExporters(zap.NewNop(), trace.NewNoopTracerProvider(), metric.NoopMeterProvider{}, component.DefaultBuildInfo(), cfg, factories.Exporters)
 
 	assert.NoError(t, err)
 	require.NotNil(t, exporters)
@@ -152,7 +153,7 @@ func TestBuildExporters_BuildLogs(t *testing.T) {
 	// This should result in creating an exporter that has none of consumption
 	// functions set.
 	delete(cfg.Service.Pipelines, "logs")
-	exporters, err = BuildExporters(zap.NewNop(), trace.NewNoopTracerProvider(), component.DefaultBuildInfo(), cfg, factories.Exporters)
+	exporters, err = BuildExporters(zap.NewNop(), trace.NewNoopTracerProvider(), metric.NoopMeterProvider{}, component.DefaultBuildInfo(), cfg, factories.Exporters)
 	assert.NotNil(t, exporters)
 	assert.Nil(t, err)
 
@@ -217,7 +218,7 @@ func TestBuildExporters_NotSupportedDataType(t *testing.T) {
 			cfg, err := configtest.LoadConfigAndValidate(path.Join("testdata", test.configFile), factories)
 			require.Nil(t, err)
 
-			exporters, err := BuildExporters(zap.NewNop(), trace.NewNoopTracerProvider(), component.DefaultBuildInfo(), cfg, factories.Exporters)
+			exporters, err := BuildExporters(zap.NewNop(), trace.NewNoopTracerProvider(), metric.NoopMeterProvider{}, component.DefaultBuildInfo(), cfg, factories.Exporters)
 			assert.Error(t, err)
 			assert.Zero(t, len(exporters))
 		})

--- a/service/internal/builder/exporters_builder_test.go
+++ b/service/internal/builder/exporters_builder_test.go
@@ -21,8 +21,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/otel/metric"
-	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/component"
@@ -61,7 +59,7 @@ func TestBuildExporters(t *testing.T) {
 		},
 	}
 
-	exporters, err := BuildExporters(zap.NewNop(), trace.NewNoopTracerProvider(), metric.NoopMeterProvider{}, component.DefaultBuildInfo(), cfg, factories.Exporters)
+	exporters, err := BuildExporters(componenttest.NewNopTelemetrySettings(), component.DefaultBuildInfo(), cfg, factories.Exporters)
 
 	assert.NoError(t, err)
 	require.NotNil(t, exporters)
@@ -90,7 +88,7 @@ func TestBuildExporters(t *testing.T) {
 	// This should result in creating an exporter that has none of consumption
 	// functions set.
 	delete(cfg.Service.Pipelines, "trace")
-	exporters, err = BuildExporters(zap.NewNop(), trace.NewNoopTracerProvider(), metric.NoopMeterProvider{}, component.DefaultBuildInfo(), cfg, factories.Exporters)
+	exporters, err = BuildExporters(componenttest.NewNopTelemetrySettings(), component.DefaultBuildInfo(), cfg, factories.Exporters)
 	assert.NotNil(t, exporters)
 	assert.NoError(t, err)
 
@@ -128,7 +126,7 @@ func TestBuildExporters_BuildLogs(t *testing.T) {
 		},
 	}
 
-	exporters, err := BuildExporters(zap.NewNop(), trace.NewNoopTracerProvider(), metric.NoopMeterProvider{}, component.DefaultBuildInfo(), cfg, factories.Exporters)
+	exporters, err := BuildExporters(componenttest.NewNopTelemetrySettings(), component.DefaultBuildInfo(), cfg, factories.Exporters)
 
 	assert.NoError(t, err)
 	require.NotNil(t, exporters)
@@ -153,7 +151,7 @@ func TestBuildExporters_BuildLogs(t *testing.T) {
 	// This should result in creating an exporter that has none of consumption
 	// functions set.
 	delete(cfg.Service.Pipelines, "logs")
-	exporters, err = BuildExporters(zap.NewNop(), trace.NewNoopTracerProvider(), metric.NoopMeterProvider{}, component.DefaultBuildInfo(), cfg, factories.Exporters)
+	exporters, err = BuildExporters(componenttest.NewNopTelemetrySettings(), component.DefaultBuildInfo(), cfg, factories.Exporters)
 	assert.NotNil(t, exporters)
 	assert.Nil(t, err)
 
@@ -218,7 +216,7 @@ func TestBuildExporters_NotSupportedDataType(t *testing.T) {
 			cfg, err := configtest.LoadConfigAndValidate(path.Join("testdata", test.configFile), factories)
 			require.Nil(t, err)
 
-			exporters, err := BuildExporters(zap.NewNop(), trace.NewNoopTracerProvider(), metric.NoopMeterProvider{}, component.DefaultBuildInfo(), cfg, factories.Exporters)
+			exporters, err := BuildExporters(componenttest.NewNopTelemetrySettings(), component.DefaultBuildInfo(), cfg, factories.Exporters)
 			assert.Error(t, err)
 			assert.Zero(t, len(exporters))
 		})

--- a/service/internal/builder/extensions_builder.go
+++ b/service/internal/builder/extensions_builder.go
@@ -18,8 +18,6 @@ import (
 	"context"
 	"fmt"
 
-	"go.opentelemetry.io/otel/metric"
-	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/component"
@@ -114,9 +112,7 @@ func (exts Extensions) ToMap() map[config.ComponentID]component.Extension {
 
 // BuildExtensions builds Extensions from config.
 func BuildExtensions(
-	logger *zap.Logger,
-	tracerProvider trace.TracerProvider,
-	meterProvider metric.MeterProvider,
+	settings component.TelemetrySettings,
 	buildInfo component.BuildInfo,
 	config *config.Config,
 	factories map[config.Type]component.ExtensionFactory,
@@ -135,11 +131,11 @@ func BuildExtensions(
 
 		set := component.ExtensionCreateSettings{
 			TelemetrySettings: component.TelemetrySettings{
-				Logger: logger.With(
+				Logger: settings.Logger.With(
 					zap.String(zapKindKey, zapKindExtension),
 					zap.String(zapNameKey, extID.String())),
-				TracerProvider: tracerProvider,
-				MeterProvider:  meterProvider,
+				TracerProvider: settings.TracerProvider,
+				MeterProvider:  settings.MeterProvider,
 			},
 			BuildInfo: buildInfo,
 		}

--- a/service/internal/builder/extensions_builder.go
+++ b/service/internal/builder/extensions_builder.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 
+	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
@@ -115,6 +116,7 @@ func (exts Extensions) ToMap() map[config.ComponentID]component.Extension {
 func BuildExtensions(
 	logger *zap.Logger,
 	tracerProvider trace.TracerProvider,
+	meterProvider metric.MeterProvider,
 	buildInfo component.BuildInfo,
 	config *config.Config,
 	factories map[config.Type]component.ExtensionFactory,
@@ -137,6 +139,7 @@ func BuildExtensions(
 					zap.String(zapKindKey, zapKindExtension),
 					zap.String(zapNameKey, extID.String())),
 				TracerProvider: tracerProvider,
+				MeterProvider:  meterProvider,
 			},
 			BuildInfo: buildInfo,
 		}

--- a/service/internal/builder/extensions_builder_test.go
+++ b/service/internal/builder/extensions_builder_test.go
@@ -20,11 +20,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"go.opentelemetry.io/otel/metric"
-	"go.opentelemetry.io/otel/trace"
-	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/extension/extensionhelper"
 )
@@ -117,7 +115,7 @@ func TestService_setupExtensions(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ext, err := BuildExtensions(zap.NewNop(), trace.NewNoopTracerProvider(), metric.NoopMeterProvider{}, component.DefaultBuildInfo(), tt.config, tt.factories.Extensions)
+			ext, err := BuildExtensions(componenttest.NewNopTelemetrySettings(), component.DefaultBuildInfo(), tt.config, tt.factories.Extensions)
 
 			assert.Error(t, err)
 			assert.EqualError(t, err, tt.wantErrMsg)

--- a/service/internal/builder/extensions_builder_test.go
+++ b/service/internal/builder/extensions_builder_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
@@ -116,7 +117,7 @@ func TestService_setupExtensions(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ext, err := BuildExtensions(zap.NewNop(), trace.NewNoopTracerProvider(), component.DefaultBuildInfo(), tt.config, tt.factories.Extensions)
+			ext, err := BuildExtensions(zap.NewNop(), trace.NewNoopTracerProvider(), metric.NoopMeterProvider{}, component.DefaultBuildInfo(), tt.config, tt.factories.Extensions)
 
 			assert.Error(t, err)
 			assert.EqualError(t, err, tt.wantErrMsg)

--- a/service/internal/builder/pipelines_builder.go
+++ b/service/internal/builder/pipelines_builder.go
@@ -18,8 +18,6 @@ import (
 	"context"
 	"fmt"
 
-	"go.opentelemetry.io/otel/metric"
-	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/component"
@@ -83,27 +81,23 @@ func (bps BuiltPipelines) ShutdownProcessors(ctx context.Context) error {
 
 // pipelinesBuilder builds Pipelines from config.
 type pipelinesBuilder struct {
-	logger         *zap.Logger
-	tracerProvider trace.TracerProvider
-	meterProvider  metric.MeterProvider
-	buildInfo      component.BuildInfo
-	config         *config.Config
-	exporters      Exporters
-	factories      map[config.Type]component.ProcessorFactory
+	settings  component.TelemetrySettings
+	buildInfo component.BuildInfo
+	config    *config.Config
+	exporters Exporters
+	factories map[config.Type]component.ProcessorFactory
 }
 
 // BuildPipelines builds pipeline processors from config. Requires exporters to be already
 // built via BuildExporters.
 func BuildPipelines(
-	logger *zap.Logger,
-	tracerProvider trace.TracerProvider,
-	meterProvider metric.MeterProvider,
+	settings component.TelemetrySettings,
 	buildInfo component.BuildInfo,
 	config *config.Config,
 	exporters Exporters,
 	factories map[config.Type]component.ProcessorFactory,
 ) (BuiltPipelines, error) {
-	pb := &pipelinesBuilder{logger, tracerProvider, meterProvider, buildInfo, config, exporters, factories}
+	pb := &pipelinesBuilder{settings, buildInfo, config, exporters, factories}
 
 	pipelineProcessors := make(BuiltPipelines)
 	for _, pipeline := range pb.config.Service.Pipelines {
@@ -165,9 +159,9 @@ func (pb *pipelinesBuilder) buildPipeline(ctx context.Context, pipelineCfg *conf
 		var err error
 		set := component.ProcessorCreateSettings{
 			TelemetrySettings: component.TelemetrySettings{
-				Logger:         pb.logger.With(zap.String(zapKindKey, zapKindProcessor), zap.String(zapNameKey, procID.String())),
-				TracerProvider: pb.tracerProvider,
-				MeterProvider:  pb.meterProvider,
+				Logger:         pb.settings.Logger.With(zap.String(zapKindKey, zapKindProcessor), zap.String(zapNameKey, procID.String())),
+				TracerProvider: pb.settings.TracerProvider,
+				MeterProvider:  pb.settings.MeterProvider,
 			},
 			BuildInfo: pb.buildInfo,
 		}
@@ -215,7 +209,7 @@ func (pb *pipelinesBuilder) buildPipeline(ctx context.Context, pipelineCfg *conf
 		}
 	}
 
-	pipelineLogger := pb.logger.With(zap.String("pipeline_name", pipelineCfg.Name),
+	pipelineLogger := pb.settings.Logger.With(zap.String("pipeline_name", pipelineCfg.Name),
 		zap.String("pipeline_datatype", string(pipelineCfg.InputType)))
 	pipelineLogger.Info("Pipeline was built.")
 

--- a/service/internal/builder/pipelines_builder_test.go
+++ b/service/internal/builder/pipelines_builder_test.go
@@ -21,9 +21,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/otel/metric"
-	"go.opentelemetry.io/otel/trace"
-	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -114,7 +111,7 @@ func TestBuildPipelines_BuildVarious(t *testing.T) {
 			cfg := createExampleConfig(dataType)
 
 			// BuildProcessors the pipeline
-			allExporters, err := BuildExporters(zap.NewNop(), trace.NewNoopTracerProvider(), metric.NoopMeterProvider{}, component.DefaultBuildInfo(), cfg, factories.Exporters)
+			allExporters, err := BuildExporters(componenttest.NewNopTelemetrySettings(), component.DefaultBuildInfo(), cfg, factories.Exporters)
 			if test.shouldFail {
 				assert.Error(t, err)
 				return
@@ -122,7 +119,7 @@ func TestBuildPipelines_BuildVarious(t *testing.T) {
 
 			require.NoError(t, err)
 			require.EqualValues(t, 1, len(allExporters))
-			pipelineProcessors, err := BuildPipelines(zap.NewNop(), trace.NewNoopTracerProvider(), metric.NoopMeterProvider{}, component.DefaultBuildInfo(), cfg, allExporters, factories.Processors)
+			pipelineProcessors, err := BuildPipelines(componenttest.NewNopTelemetrySettings(), component.DefaultBuildInfo(), cfg, allExporters, factories.Processors)
 
 			assert.NoError(t, err)
 			require.NotNil(t, pipelineProcessors)
@@ -186,9 +183,9 @@ func testPipeline(t *testing.T, pipelineName string, exporterIDs []config.Compon
 	require.Nil(t, err)
 
 	// BuildProcessors the pipeline
-	allExporters, err := BuildExporters(zap.NewNop(), trace.NewNoopTracerProvider(), metric.NoopMeterProvider{}, component.DefaultBuildInfo(), cfg, factories.Exporters)
+	allExporters, err := BuildExporters(componenttest.NewNopTelemetrySettings(), component.DefaultBuildInfo(), cfg, factories.Exporters)
 	assert.NoError(t, err)
-	pipelineProcessors, err := BuildPipelines(zap.NewNop(), trace.NewNoopTracerProvider(), metric.NoopMeterProvider{}, component.DefaultBuildInfo(), cfg, allExporters, factories.Processors)
+	pipelineProcessors, err := BuildPipelines(componenttest.NewNopTelemetrySettings(), component.DefaultBuildInfo(), cfg, allExporters, factories.Processors)
 
 	assert.NoError(t, err)
 	require.NotNil(t, pipelineProcessors)
@@ -260,10 +257,10 @@ func TestBuildPipelines_NotSupportedDataType(t *testing.T) {
 			cfg, err := configtest.LoadConfigAndValidate(path.Join("testdata", test.configFile), factories)
 			require.Nil(t, err)
 
-			allExporters, err := BuildExporters(zap.NewNop(), trace.NewNoopTracerProvider(), metric.NoopMeterProvider{}, component.DefaultBuildInfo(), cfg, factories.Exporters)
+			allExporters, err := BuildExporters(componenttest.NewNopTelemetrySettings(), component.DefaultBuildInfo(), cfg, factories.Exporters)
 			assert.NoError(t, err)
 
-			pipelineProcessors, err := BuildPipelines(zap.NewNop(), trace.NewNoopTracerProvider(), metric.NoopMeterProvider{}, component.DefaultBuildInfo(), cfg, allExporters, factories.Processors)
+			pipelineProcessors, err := BuildPipelines(componenttest.NewNopTelemetrySettings(), component.DefaultBuildInfo(), cfg, allExporters, factories.Processors)
 			assert.Error(t, err)
 			assert.Zero(t, len(pipelineProcessors))
 		})

--- a/service/internal/builder/pipelines_builder_test.go
+++ b/service/internal/builder/pipelines_builder_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
@@ -113,7 +114,7 @@ func TestBuildPipelines_BuildVarious(t *testing.T) {
 			cfg := createExampleConfig(dataType)
 
 			// BuildProcessors the pipeline
-			allExporters, err := BuildExporters(zap.NewNop(), trace.NewNoopTracerProvider(), component.DefaultBuildInfo(), cfg, factories.Exporters)
+			allExporters, err := BuildExporters(zap.NewNop(), trace.NewNoopTracerProvider(), metric.NoopMeterProvider{}, component.DefaultBuildInfo(), cfg, factories.Exporters)
 			if test.shouldFail {
 				assert.Error(t, err)
 				return
@@ -121,7 +122,7 @@ func TestBuildPipelines_BuildVarious(t *testing.T) {
 
 			require.NoError(t, err)
 			require.EqualValues(t, 1, len(allExporters))
-			pipelineProcessors, err := BuildPipelines(zap.NewNop(), trace.NewNoopTracerProvider(), component.DefaultBuildInfo(), cfg, allExporters, factories.Processors)
+			pipelineProcessors, err := BuildPipelines(zap.NewNop(), trace.NewNoopTracerProvider(), metric.NoopMeterProvider{}, component.DefaultBuildInfo(), cfg, allExporters, factories.Processors)
 
 			assert.NoError(t, err)
 			require.NotNil(t, pipelineProcessors)
@@ -185,9 +186,9 @@ func testPipeline(t *testing.T, pipelineName string, exporterIDs []config.Compon
 	require.Nil(t, err)
 
 	// BuildProcessors the pipeline
-	allExporters, err := BuildExporters(zap.NewNop(), trace.NewNoopTracerProvider(), component.DefaultBuildInfo(), cfg, factories.Exporters)
+	allExporters, err := BuildExporters(zap.NewNop(), trace.NewNoopTracerProvider(), metric.NoopMeterProvider{}, component.DefaultBuildInfo(), cfg, factories.Exporters)
 	assert.NoError(t, err)
-	pipelineProcessors, err := BuildPipelines(zap.NewNop(), trace.NewNoopTracerProvider(), component.DefaultBuildInfo(), cfg, allExporters, factories.Processors)
+	pipelineProcessors, err := BuildPipelines(zap.NewNop(), trace.NewNoopTracerProvider(), metric.NoopMeterProvider{}, component.DefaultBuildInfo(), cfg, allExporters, factories.Processors)
 
 	assert.NoError(t, err)
 	require.NotNil(t, pipelineProcessors)
@@ -259,10 +260,10 @@ func TestBuildPipelines_NotSupportedDataType(t *testing.T) {
 			cfg, err := configtest.LoadConfigAndValidate(path.Join("testdata", test.configFile), factories)
 			require.Nil(t, err)
 
-			allExporters, err := BuildExporters(zap.NewNop(), trace.NewNoopTracerProvider(), component.DefaultBuildInfo(), cfg, factories.Exporters)
+			allExporters, err := BuildExporters(zap.NewNop(), trace.NewNoopTracerProvider(), metric.NoopMeterProvider{}, component.DefaultBuildInfo(), cfg, factories.Exporters)
 			assert.NoError(t, err)
 
-			pipelineProcessors, err := BuildPipelines(zap.NewNop(), trace.NewNoopTracerProvider(), component.DefaultBuildInfo(), cfg, allExporters, factories.Processors)
+			pipelineProcessors, err := BuildPipelines(zap.NewNop(), trace.NewNoopTracerProvider(), metric.NoopMeterProvider{}, component.DefaultBuildInfo(), cfg, allExporters, factories.Processors)
 			assert.Error(t, err)
 			assert.Zero(t, len(pipelineProcessors))
 		})

--- a/service/internal/builder/receivers_builder.go
+++ b/service/internal/builder/receivers_builder.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 
+	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
@@ -89,6 +90,7 @@ type receiversBuilder struct {
 func BuildReceivers(
 	logger *zap.Logger,
 	tracerProvider trace.TracerProvider,
+	meterProvider metric.MeterProvider,
 	buildInfo component.BuildInfo,
 	cfg *config.Config,
 	builtPipelines BuiltPipelines,
@@ -102,6 +104,7 @@ func BuildReceivers(
 			TelemetrySettings: component.TelemetrySettings{
 				Logger:         logger.With(zap.String(zapKindKey, zapKindReceiver), zap.String(zapNameKey, recvID.String())),
 				TracerProvider: tracerProvider,
+				MeterProvider:  meterProvider,
 			},
 			BuildInfo: buildInfo,
 		}

--- a/service/internal/builder/receivers_builder.go
+++ b/service/internal/builder/receivers_builder.go
@@ -19,8 +19,6 @@ import (
 	"errors"
 	"fmt"
 
-	"go.opentelemetry.io/otel/metric"
-	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/component"
@@ -88,9 +86,7 @@ type receiversBuilder struct {
 
 // BuildReceivers builds Receivers from config.
 func BuildReceivers(
-	logger *zap.Logger,
-	tracerProvider trace.TracerProvider,
-	meterProvider metric.MeterProvider,
+	settings component.TelemetrySettings,
 	buildInfo component.BuildInfo,
 	cfg *config.Config,
 	builtPipelines BuiltPipelines,
@@ -102,9 +98,9 @@ func BuildReceivers(
 	for recvID, recvCfg := range cfg.Receivers {
 		set := component.ReceiverCreateSettings{
 			TelemetrySettings: component.TelemetrySettings{
-				Logger:         logger.With(zap.String(zapKindKey, zapKindReceiver), zap.String(zapNameKey, recvID.String())),
-				TracerProvider: tracerProvider,
-				MeterProvider:  meterProvider,
+				Logger:         settings.Logger.With(zap.String(zapKindKey, zapKindReceiver), zap.String(zapNameKey, recvID.String())),
+				TracerProvider: settings.TracerProvider,
+				MeterProvider:  settings.MeterProvider,
 			},
 			BuildInfo: buildInfo,
 		}

--- a/service/internal/builder/receivers_builder_test.go
+++ b/service/internal/builder/receivers_builder_test.go
@@ -21,8 +21,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/otel/metric"
-	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/component"
@@ -96,11 +94,11 @@ func testReceivers(t *testing.T, test testCase) {
 	require.NoError(t, err)
 
 	// Build the pipeline
-	allExporters, err := BuildExporters(zap.NewNop(), trace.NewNoopTracerProvider(), metric.NoopMeterProvider{}, component.DefaultBuildInfo(), cfg, factories.Exporters)
+	allExporters, err := BuildExporters(componenttest.NewNopTelemetrySettings(), component.DefaultBuildInfo(), cfg, factories.Exporters)
 	assert.NoError(t, err)
-	pipelineProcessors, err := BuildPipelines(zap.NewNop(), trace.NewNoopTracerProvider(), metric.NoopMeterProvider{}, component.DefaultBuildInfo(), cfg, allExporters, factories.Processors)
+	pipelineProcessors, err := BuildPipelines(componenttest.NewNopTelemetrySettings(), component.DefaultBuildInfo(), cfg, allExporters, factories.Processors)
 	assert.NoError(t, err)
-	receivers, err := BuildReceivers(zap.NewNop(), trace.NewNoopTracerProvider(), metric.NoopMeterProvider{}, component.DefaultBuildInfo(), cfg, pipelineProcessors, factories.Receivers)
+	receivers, err := BuildReceivers(componenttest.NewNopTelemetrySettings(), component.DefaultBuildInfo(), cfg, pipelineProcessors, factories.Receivers)
 
 	assert.NoError(t, err)
 	require.NotNil(t, receivers)
@@ -197,16 +195,16 @@ func TestBuildReceivers_BuildCustom(t *testing.T) {
 			cfg := createExampleConfig(dataType)
 
 			// Build the pipeline
-			allExporters, err := BuildExporters(zap.NewNop(), trace.NewNoopTracerProvider(), metric.NoopMeterProvider{}, component.DefaultBuildInfo(), cfg, factories.Exporters)
+			allExporters, err := BuildExporters(componenttest.NewNopTelemetrySettings(), component.DefaultBuildInfo(), cfg, factories.Exporters)
 			if test.shouldFail {
 				assert.Error(t, err)
 				return
 			}
 
 			assert.NoError(t, err)
-			pipelineProcessors, err := BuildPipelines(zap.NewNop(), trace.NewNoopTracerProvider(), metric.NoopMeterProvider{}, component.DefaultBuildInfo(), cfg, allExporters, factories.Processors)
+			pipelineProcessors, err := BuildPipelines(componenttest.NewNopTelemetrySettings(), component.DefaultBuildInfo(), cfg, allExporters, factories.Processors)
 			assert.NoError(t, err)
-			receivers, err := BuildReceivers(zap.NewNop(), trace.NewNoopTracerProvider(), metric.NoopMeterProvider{}, component.DefaultBuildInfo(), cfg, pipelineProcessors, factories.Receivers)
+			receivers, err := BuildReceivers(componenttest.NewNopTelemetrySettings(), component.DefaultBuildInfo(), cfg, pipelineProcessors, factories.Receivers)
 
 			assert.NoError(t, err)
 			require.NotNil(t, receivers)
@@ -281,11 +279,11 @@ func TestBuildReceivers_Unused(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Build the pipeline
-	allExporters, err := BuildExporters(zap.NewNop(), trace.NewNoopTracerProvider(), metric.NoopMeterProvider{}, component.DefaultBuildInfo(), cfg, factories.Exporters)
+	allExporters, err := BuildExporters(componenttest.NewNopTelemetrySettings(), component.DefaultBuildInfo(), cfg, factories.Exporters)
 	assert.NoError(t, err)
-	pipelineProcessors, err := BuildPipelines(zap.NewNop(), trace.NewNoopTracerProvider(), metric.NoopMeterProvider{}, component.DefaultBuildInfo(), cfg, allExporters, factories.Processors)
+	pipelineProcessors, err := BuildPipelines(componenttest.NewNopTelemetrySettings(), component.DefaultBuildInfo(), cfg, allExporters, factories.Processors)
 	assert.NoError(t, err)
-	receivers, err := BuildReceivers(zap.NewNop(), trace.NewNoopTracerProvider(), metric.NoopMeterProvider{}, component.DefaultBuildInfo(), cfg, pipelineProcessors, factories.Receivers)
+	receivers, err := BuildReceivers(componenttest.NewNopTelemetrySettings(), component.DefaultBuildInfo(), cfg, pipelineProcessors, factories.Receivers)
 	assert.NoError(t, err)
 	assert.NotNil(t, receivers)
 
@@ -317,13 +315,13 @@ func TestBuildReceivers_NotSupportedDataType(t *testing.T) {
 			assert.NoError(t, err)
 			require.NotNil(t, cfg)
 
-			allExporters, err := BuildExporters(zap.NewNop(), trace.NewNoopTracerProvider(), metric.NoopMeterProvider{}, component.DefaultBuildInfo(), cfg, factories.Exporters)
+			allExporters, err := BuildExporters(componenttest.NewNopTelemetrySettings(), component.DefaultBuildInfo(), cfg, factories.Exporters)
 			assert.NoError(t, err)
 
-			pipelineProcessors, err := BuildPipelines(zap.NewNop(), trace.NewNoopTracerProvider(), metric.NoopMeterProvider{}, component.DefaultBuildInfo(), cfg, allExporters, factories.Processors)
+			pipelineProcessors, err := BuildPipelines(componenttest.NewNopTelemetrySettings(), component.DefaultBuildInfo(), cfg, allExporters, factories.Processors)
 			assert.NoError(t, err)
 
-			receivers, err := BuildReceivers(zap.NewNop(), trace.NewNoopTracerProvider(), metric.NoopMeterProvider{}, component.DefaultBuildInfo(), cfg, pipelineProcessors, factories.Receivers)
+			receivers, err := BuildReceivers(componenttest.NewNopTelemetrySettings(), component.DefaultBuildInfo(), cfg, pipelineProcessors, factories.Receivers)
 			assert.Error(t, err)
 			assert.Zero(t, len(receivers))
 		})

--- a/service/internal/builder/receivers_builder_test.go
+++ b/service/internal/builder/receivers_builder_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
@@ -95,11 +96,11 @@ func testReceivers(t *testing.T, test testCase) {
 	require.NoError(t, err)
 
 	// Build the pipeline
-	allExporters, err := BuildExporters(zap.NewNop(), trace.NewNoopTracerProvider(), component.DefaultBuildInfo(), cfg, factories.Exporters)
+	allExporters, err := BuildExporters(zap.NewNop(), trace.NewNoopTracerProvider(), metric.NoopMeterProvider{}, component.DefaultBuildInfo(), cfg, factories.Exporters)
 	assert.NoError(t, err)
-	pipelineProcessors, err := BuildPipelines(zap.NewNop(), trace.NewNoopTracerProvider(), component.DefaultBuildInfo(), cfg, allExporters, factories.Processors)
+	pipelineProcessors, err := BuildPipelines(zap.NewNop(), trace.NewNoopTracerProvider(), metric.NoopMeterProvider{}, component.DefaultBuildInfo(), cfg, allExporters, factories.Processors)
 	assert.NoError(t, err)
-	receivers, err := BuildReceivers(zap.NewNop(), trace.NewNoopTracerProvider(), component.DefaultBuildInfo(), cfg, pipelineProcessors, factories.Receivers)
+	receivers, err := BuildReceivers(zap.NewNop(), trace.NewNoopTracerProvider(), metric.NoopMeterProvider{}, component.DefaultBuildInfo(), cfg, pipelineProcessors, factories.Receivers)
 
 	assert.NoError(t, err)
 	require.NotNil(t, receivers)
@@ -196,16 +197,16 @@ func TestBuildReceivers_BuildCustom(t *testing.T) {
 			cfg := createExampleConfig(dataType)
 
 			// Build the pipeline
-			allExporters, err := BuildExporters(zap.NewNop(), trace.NewNoopTracerProvider(), component.DefaultBuildInfo(), cfg, factories.Exporters)
+			allExporters, err := BuildExporters(zap.NewNop(), trace.NewNoopTracerProvider(), metric.NoopMeterProvider{}, component.DefaultBuildInfo(), cfg, factories.Exporters)
 			if test.shouldFail {
 				assert.Error(t, err)
 				return
 			}
 
 			assert.NoError(t, err)
-			pipelineProcessors, err := BuildPipelines(zap.NewNop(), trace.NewNoopTracerProvider(), component.DefaultBuildInfo(), cfg, allExporters, factories.Processors)
+			pipelineProcessors, err := BuildPipelines(zap.NewNop(), trace.NewNoopTracerProvider(), metric.NoopMeterProvider{}, component.DefaultBuildInfo(), cfg, allExporters, factories.Processors)
 			assert.NoError(t, err)
-			receivers, err := BuildReceivers(zap.NewNop(), trace.NewNoopTracerProvider(), component.DefaultBuildInfo(), cfg, pipelineProcessors, factories.Receivers)
+			receivers, err := BuildReceivers(zap.NewNop(), trace.NewNoopTracerProvider(), metric.NoopMeterProvider{}, component.DefaultBuildInfo(), cfg, pipelineProcessors, factories.Receivers)
 
 			assert.NoError(t, err)
 			require.NotNil(t, receivers)
@@ -280,11 +281,11 @@ func TestBuildReceivers_Unused(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Build the pipeline
-	allExporters, err := BuildExporters(zap.NewNop(), trace.NewNoopTracerProvider(), component.DefaultBuildInfo(), cfg, factories.Exporters)
+	allExporters, err := BuildExporters(zap.NewNop(), trace.NewNoopTracerProvider(), metric.NoopMeterProvider{}, component.DefaultBuildInfo(), cfg, factories.Exporters)
 	assert.NoError(t, err)
-	pipelineProcessors, err := BuildPipelines(zap.NewNop(), trace.NewNoopTracerProvider(), component.DefaultBuildInfo(), cfg, allExporters, factories.Processors)
+	pipelineProcessors, err := BuildPipelines(zap.NewNop(), trace.NewNoopTracerProvider(), metric.NoopMeterProvider{}, component.DefaultBuildInfo(), cfg, allExporters, factories.Processors)
 	assert.NoError(t, err)
-	receivers, err := BuildReceivers(zap.NewNop(), trace.NewNoopTracerProvider(), component.DefaultBuildInfo(), cfg, pipelineProcessors, factories.Receivers)
+	receivers, err := BuildReceivers(zap.NewNop(), trace.NewNoopTracerProvider(), metric.NoopMeterProvider{}, component.DefaultBuildInfo(), cfg, pipelineProcessors, factories.Receivers)
 	assert.NoError(t, err)
 	assert.NotNil(t, receivers)
 
@@ -316,13 +317,13 @@ func TestBuildReceivers_NotSupportedDataType(t *testing.T) {
 			assert.NoError(t, err)
 			require.NotNil(t, cfg)
 
-			allExporters, err := BuildExporters(zap.NewNop(), trace.NewNoopTracerProvider(), component.DefaultBuildInfo(), cfg, factories.Exporters)
+			allExporters, err := BuildExporters(zap.NewNop(), trace.NewNoopTracerProvider(), metric.NoopMeterProvider{}, component.DefaultBuildInfo(), cfg, factories.Exporters)
 			assert.NoError(t, err)
 
-			pipelineProcessors, err := BuildPipelines(zap.NewNop(), trace.NewNoopTracerProvider(), component.DefaultBuildInfo(), cfg, allExporters, factories.Processors)
+			pipelineProcessors, err := BuildPipelines(zap.NewNop(), trace.NewNoopTracerProvider(), metric.NoopMeterProvider{}, component.DefaultBuildInfo(), cfg, allExporters, factories.Processors)
 			assert.NoError(t, err)
 
-			receivers, err := BuildReceivers(zap.NewNop(), trace.NewNoopTracerProvider(), component.DefaultBuildInfo(), cfg, pipelineProcessors, factories.Receivers)
+			receivers, err := BuildReceivers(zap.NewNop(), trace.NewNoopTracerProvider(), metric.NoopMeterProvider{}, component.DefaultBuildInfo(), cfg, pipelineProcessors, factories.Receivers)
 			assert.Error(t, err)
 			assert.Zero(t, len(receivers))
 		})

--- a/service/service.go
+++ b/service/service.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"go.opentelemetry.io/contrib/zpages"
+	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
@@ -35,6 +36,7 @@ type service struct {
 	config              *config.Config
 	logger              *zap.Logger
 	tracerProvider      trace.TracerProvider
+	meterProvider       metric.MeterProvider
 	zPagesSpanProcessor *zpages.SpanProcessor
 	asyncErrorChannel   chan error
 
@@ -51,6 +53,7 @@ func newService(set *svcSettings) (*service, error) {
 		config:              set.Config,
 		logger:              set.Logger,
 		tracerProvider:      set.TracerProvider,
+		meterProvider:       set.MeterProvider,
 		zPagesSpanProcessor: set.ZPagesSpanProcessor,
 		asyncErrorChannel:   set.AsyncErrorChannel,
 	}
@@ -60,7 +63,7 @@ func newService(set *svcSettings) (*service, error) {
 	}
 
 	var err error
-	srv.builtExtensions, err = builder.BuildExtensions(srv.logger, srv.tracerProvider, srv.buildInfo, srv.config, srv.factories.Extensions)
+	srv.builtExtensions, err = builder.BuildExtensions(srv.logger, srv.tracerProvider, srv.meterProvider, srv.buildInfo, srv.config, srv.factories.Extensions)
 	if err != nil {
 		return nil, fmt.Errorf("cannot build extensions: %w", err)
 	}
@@ -69,19 +72,19 @@ func newService(set *svcSettings) (*service, error) {
 	// which are referenced before objects which reference them.
 
 	// First create exporters.
-	srv.builtExporters, err = builder.BuildExporters(srv.logger, srv.tracerProvider, srv.buildInfo, srv.config, srv.factories.Exporters)
+	srv.builtExporters, err = builder.BuildExporters(srv.logger, srv.tracerProvider, srv.meterProvider, srv.buildInfo, srv.config, srv.factories.Exporters)
 	if err != nil {
 		return nil, fmt.Errorf("cannot build exporters: %w", err)
 	}
 
 	// Create pipelines and their processors and plug exporters to the end of the pipelines.
-	srv.builtPipelines, err = builder.BuildPipelines(srv.logger, srv.tracerProvider, srv.buildInfo, srv.config, srv.builtExporters, srv.factories.Processors)
+	srv.builtPipelines, err = builder.BuildPipelines(srv.logger, srv.tracerProvider, srv.meterProvider, srv.buildInfo, srv.config, srv.builtExporters, srv.factories.Processors)
 	if err != nil {
 		return nil, fmt.Errorf("cannot build pipelines: %w", err)
 	}
 
 	// Create receivers and plug them into the start of the pipelines.
-	srv.builtReceivers, err = builder.BuildReceivers(srv.logger, srv.tracerProvider, srv.buildInfo, srv.config, srv.builtPipelines, srv.factories.Receivers)
+	srv.builtReceivers, err = builder.BuildReceivers(srv.logger, srv.tracerProvider, srv.meterProvider, srv.buildInfo, srv.config, srv.builtPipelines, srv.factories.Receivers)
 	if err != nil {
 		return nil, fmt.Errorf("cannot build receivers: %w", err)
 	}

--- a/service/settings.go
+++ b/service/settings.go
@@ -16,6 +16,7 @@ package service
 
 import (
 	"go.opentelemetry.io/contrib/zpages"
+	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
@@ -41,6 +42,9 @@ type svcSettings struct {
 
 	// TracerProvider represents the TracerProvider used for all the components.
 	TracerProvider trace.TracerProvider
+
+	// MeterProvider represents the MeterProvider used for all the components.
+	MeterProvider metric.MeterProvider
 
 	// ZPagesSpanProcessor represents the SpanProcessor for tracez page.
 	ZPagesSpanProcessor *zpages.SpanProcessor


### PR DESCRIPTION
**Description:**
This is a followup to https://github.com/open-telemetry/opentelemetry-collector/pull/4044 and guards against invalid settings passed into `ToServer`

**Link to tracking Issue:** Follow up to #4043 

**Testing:** Added unit test 

If we want to move forward with this PR, I will rebase after #4044 is merged