### PR TITLE
Remove RetrieveEnd from ConfigSource, proved not used in splunk implementations

### DIFF
--- a/config/experimental/configsource/component.go
+++ b/config/experimental/configsource/component.go
@@ -54,11 +54,6 @@ type ConfigSource interface {
 	// implementation handles the generic params according to their requirements.
 	Retrieve(ctx context.Context, selector string, params interface{}) (Retrieved, error)
 
-	// RetrieveEnd signals that the Session must not be used to retrieve any new values from the
-	// source, ie.: all values from this source were retrieved for the configuration. It should
-	// be used to release resources that are only needed to retrieve configuration data.
-	RetrieveEnd(ctx context.Context) error
-
 	// Close signals that the configuration for which it was used to retrieve values is no longer in use
 	// and the object should close and release any watchers that it may have created.
 	// This method must be called when the configuration session ends, either in case of success or error.
@@ -86,8 +81,5 @@ type Watchable interface {
 	// 3. An error happens while watching for updates. The method should not return
 	//    on first instances of transient errors, optionally there should be
 	//    configurable thresholds to control for how long such errors can be ignored.
-	//
-	// This method must only be called when the RetrieveEnd method of the Session that
-	// retrieved the value was successfully completed.
 	WatchForUpdate() error
 }

--- a/config/internal/configsource/manager.go
+++ b/config/internal/configsource/manager.go
@@ -191,15 +191,9 @@ func (m *Manager) Resolve(ctx context.Context, parser *configparser.ConfigMap) (
 	for _, k := range allKeys {
 		value, err := m.expandStringValues(ctx, parser.Get(k))
 		if err != nil {
-			// Call RetrieveEnd for all sources used so far but don't record any errors.
-			_ = m.retrieveEnd(ctx)
 			return nil, err
 		}
 		res.Set(k, value)
-	}
-
-	if errs := m.retrieveEnd(ctx); len(errs) > 0 {
-		return nil, consumererror.Combine(errs)
 	}
 
 	return res, nil
@@ -273,16 +267,6 @@ func (m *Manager) Close(ctx context.Context) error {
 	m.watchersWG.Wait()
 
 	return consumererror.Combine(errs)
-}
-
-func (m *Manager) retrieveEnd(ctx context.Context) []error {
-	var errs []error
-	for _, source := range m.configSources {
-		if err := source.RetrieveEnd(ctx); err != nil {
-			errs = append(errs, err)
-		}
-	}
-	return errs
 }
 
 func (m *Manager) expandStringValues(ctx context.Context, value interface{}) (interface{}, error) {

--- a/config/internal/configsource/manager_test.go
+++ b/config/internal/configsource/manager_test.go
@@ -100,20 +100,6 @@ func TestConfigSourceManager_ResolveErrors(t *testing.T) {
 				"tstcfgsrc": &testConfigSource{ErrOnRetrieve: testErr},
 			},
 		},
-		{
-			name: "error_on_retrieve_end",
-			config: map[string]interface{}{
-				"cfgsrc": "$tstcfgsrc:selector",
-			},
-			configSourceMap: map[string]configsource.ConfigSource{
-				"tstcfgsrc": &testConfigSource{
-					ErrOnRetrieveEnd: testErr,
-					ValueMap: map[string]valueEntry{
-						"selector": {Value: "test_value"},
-					},
-				},
-			},
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -554,9 +540,8 @@ func Test_parseCfgSrc(t *testing.T) {
 type testConfigSource struct {
 	ValueMap map[string]valueEntry
 
-	ErrOnRetrieve    error
-	ErrOnRetrieveEnd error
-	ErrOnClose       error
+	ErrOnRetrieve error
+	ErrOnClose    error
 
 	OnRetrieve func(ctx context.Context, selector string, params interface{}) error
 }
@@ -596,10 +581,6 @@ func (t *testConfigSource) Retrieve(ctx context.Context, selector string, params
 	return &retrieved{
 		value: entry.Value,
 	}, nil
-}
-
-func (t *testConfigSource) RetrieveEnd(context.Context) error {
-	return t.ErrOnRetrieveEnd
 }
 
 func (t *testConfigSource) Close(context.Context) error {


### PR DESCRIPTION
Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
