### PR TITLE
Improving usability of combined errors throughout the collector

### DIFF
--- a/consumer/consumererror/combine.go
+++ b/consumer/consumererror/combine.go
@@ -15,39 +15,76 @@
 package consumererror
 
 import (
-	"fmt"
+	"errors"
 	"strings"
 )
+
+type combined []error
+
+var (
+	_ error                                    = (*combined)(nil)
+	_ interface{ Is(target error) bool }       = (*combined)(nil)
+	_ interface{ As(target interface{}) bool } = (*combined)(nil)
+)
+
+func (c combined) Error() string {
+	var sb strings.Builder
+	length := len(c)
+	for i, err := range c {
+		sb.WriteString(err.Error())
+		if i != length-1 {
+			sb.WriteString("; ")
+		}
+	}
+	return "[" + sb.String() + "]"
+}
+
+// Range iterates over the slice and all subslices of errors
+// and will apply the passed function on each.
+// The method will return once a the passed function returns true
+// or there is no items in the slice.
+func (c combined) Range(fn func(error) bool) bool {
+	for _, err := range c {
+		if target, ok := err.(combined); ok {
+			if target.Range(fn) {
+				return true
+			}
+		}
+		if fn(err) {
+			return true
+		}
+	}
+	return false
+}
+
+func (c combined) Is(target error) bool {
+	return c.Range(func(err error) bool {
+		return errors.Is(err, target)
+	})
+}
+
+func (c combined) As(target interface{}) bool {
+	return c.Range(func(err error) bool {
+		return errors.As(err, target)
+	})
+}
 
 // Combine converts a list of errors into one error.
 //
 // If any of the errors in errs are Permanent then the returned
 // error will also be Permanent.
-//
-// Any signal data associated with an error from this package
-// will be discarded.
 func Combine(errs []error) error {
-	numErrors := len(errs)
-	if numErrors == 0 {
-		// No errors
+	switch len(errs) {
+	case 0:
 		return nil
-	}
-
-	if numErrors == 1 {
+	case 1:
 		return errs[0]
 	}
-
-	errMsgs := make([]string, 0, numErrors)
-	permanent := false
+	result := make([]error, 0, len(errs))
 	for _, err := range errs {
-		if !permanent && IsPermanent(err) {
-			permanent = true
+		if err != nil {
+			result = append(result, err)
 		}
-		errMsgs = append(errMsgs, err.Error())
 	}
-	err := fmt.Errorf("[%s]", strings.Join(errMsgs, "; "))
-	if permanent {
-		err = Permanent(err)
-	}
-	return err
+	return combined(result)
 }

--- a/consumer/consumererror/combine.go
+++ b/consumer/consumererror/combine.go
@@ -35,25 +35,22 @@ func (c combined) Error() string {
 	return "[" + sb.String() + "]"
 }
 
-func (c combined) iterate(fn func(error) bool) bool {
+func (c combined) Is(target error) bool {
 	for _, err := range c {
-		if fn(err) {
+		if errors.Is(err, target) {
 			return true
 		}
 	}
 	return false
 }
 
-func (c combined) Is(target error) bool {
-	return c.iterate(func(err error) bool {
-		return errors.Is(err, target)
-	})
-}
-
 func (c combined) As(target interface{}) bool {
-	return c.iterate(func(err error) bool {
-		return errors.As(err, target)
-	})
+	for _, err := range c {
+		if errors.As(err, target) {
+			return true
+		}
+	}
+	return false
 }
 
 // Combine converts a list of errors into one error.


### PR DESCRIPTION


**Description:** 
This change preserves the original errors used in `consumererrors.Combine` which enables using go 1.13+ errors package to assert the error types.

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector/issues/4056

**Testing:** 
Added further unit tests to the existing test suite for it.


