### PR TITLE
Adding new telemetry related config to the config file

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -161,11 +161,16 @@ type Service struct {
 
 // ServiceTelemetry defines the configurable settings for service telemetry.
 type ServiceTelemetry struct {
-	Logs ServiceTelemetryLogs
+	Logs    ServiceTelemetryLogs
+	Metrics ServiceTelemetryMetrics
 }
 
 func (srvT *ServiceTelemetry) validate() error {
-	return srvT.Logs.validate()
+	err := srvT.Logs.validate()
+	if err != nil {
+		return err
+	}
+	return srvT.Metrics.validate()
 }
 
 // ServiceTelemetryLogs defines the configurable settings for service telemetry logs.
@@ -184,10 +189,21 @@ type ServiceTelemetryLogs struct {
 	Encoding string
 }
 
+// ServiceTelemetryMetrics defines the configurable settings for service telemetry metrics.
+// the collector uses mapstructure and not yaml tags.
+type ServiceTelemetryMetrics struct {
+	// Add the collector version tag to the collector's telemetry metrics
+	AddVersionTag bool
+}
+
 func (srvTL *ServiceTelemetryLogs) validate() error {
 	if srvTL.Encoding != "json" && srvTL.Encoding != "console" {
 		return fmt.Errorf(`service telemetry logs invalid encoding: %q, valid values are "json" and "console"`, srvTL.Encoding)
 	}
+	return nil
+}
+
+func (srvTL *ServiceTelemetryMetrics) validate() error {
 	return nil
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -255,7 +255,8 @@ func generateConfig() *Config {
 			},
 		},
 		Service: Service{
-			Telemetry:  ServiceTelemetry{Logs: ServiceTelemetryLogs{Level: zapcore.DebugLevel, Development: true, Encoding: "console"}},
+			Telemetry: ServiceTelemetry{Logs: ServiceTelemetryLogs{Level: zapcore.DebugLevel, Development: true, Encoding: "console"},
+				Metrics: ServiceTelemetryMetrics{AddVersionTag: true}},
 			Extensions: []ComponentID{NewID("nop")},
 			Pipelines: map[string]*Pipeline{
 				"traces": {

--- a/config/configunmarshaler/defaultunmarshaler.go
+++ b/config/configunmarshaler/defaultunmarshaler.go
@@ -86,13 +86,18 @@ type serviceSettings struct {
 }
 
 type serviceTelemetrySettings struct {
-	Logs serviceTelemetryLogsSettings `mapstructure:"logs"`
+	Logs   serviceTelemetryLogsSettings    `mapstructure:"logs"`
+	Metric serviceTelemetryMetricsSettings `mapstructure:"metrics"`
 }
 
 type serviceTelemetryLogsSettings struct {
 	Level       string `mapstructure:"level"`
 	Development bool   `mapstructure:"development"`
 	Encoding    string `mapstructure:"encoding"`
+}
+
+type serviceTelemetryMetricsSettings struct {
+	AddVersionTag bool `mapstructure:"add_version_tag"`
 }
 
 type pipelineSettings struct {
@@ -126,6 +131,9 @@ func (*defaultUnmarshaler) Unmarshal(v *configparser.ConfigMap, factories compon
 					Level:       "INFO",
 					Development: false,
 					Encoding:    "console",
+				},
+				Metric: serviceTelemetryMetricsSettings{
+					AddVersionTag: true,
 				},
 			},
 		},
@@ -260,6 +268,10 @@ func unmarshalService(rawService serviceSettings) (config.Service, error) {
 		Level:       lvl,
 		Development: rawService.Telemetry.Logs.Development,
 		Encoding:    rawService.Telemetry.Logs.Encoding,
+	}
+
+	ret.Telemetry.Metrics = config.ServiceTelemetryMetrics{
+		AddVersionTag: rawService.Telemetry.Metric.AddVersionTag,
 	}
 
 	ret.Extensions = make([]config.ComponentID, 0, len(rawService.Extensions))

--- a/config/configunmarshaler/defaultunmarshaler_test.go
+++ b/config/configunmarshaler/defaultunmarshaler_test.go
@@ -98,7 +98,8 @@ func TestDecodeConfig(t *testing.T) {
 		"Did not load processor config correctly")
 
 	// Verify Service Telemetry
-	assert.Equal(t, config.ServiceTelemetry{Logs: config.ServiceTelemetryLogs{Level: zapcore.DebugLevel, Development: true, Encoding: "console"}}, cfg.Service.Telemetry)
+	assert.Equal(t, config.ServiceTelemetry{Logs: config.ServiceTelemetryLogs{Level: zapcore.DebugLevel, Development: true, Encoding: "console"},
+		Metrics: config.ServiceTelemetryMetrics{AddVersionTag: true}}, cfg.Service.Telemetry)
 
 	// Verify Service Extensions
 	assert.Equal(t, 2, len(cfg.Service.Extensions))

--- a/config/configunmarshaler/testdata/valid-config.yaml
+++ b/config/configunmarshaler/testdata/valid-config.yaml
@@ -25,6 +25,8 @@ service:
       level: "DEBUG"
       development: true
       encoding: "console"
+    metrics:
+      add_version_tag: true
   extensions: [exampleextension/0, exampleextension/1]
   pipelines:
     traces:

--- a/service/collector.go
+++ b/service/collector.go
@@ -269,7 +269,7 @@ func (col *Collector) execute(ctx context.Context) error {
 		return err
 	}
 
-	if err = collectorTelemetry.init(col.asyncErrorChannel, getBallastSize(col.service), col.logger); err != nil {
+	if err = collectorTelemetry.init(col.asyncErrorChannel, getBallastSize(col.service), col.logger, col.service.config.Telemetry); err != nil {
 		return err
 	}
 

--- a/service/collector_test.go
+++ b/service/collector_test.go
@@ -34,6 +34,7 @@ import (
 	"go.uber.org/zap/zapcore"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/configparser"
 	"go.opentelemetry.io/collector/config/configunmarshaler"
 	"go.opentelemetry.io/collector/internal/testutil"
@@ -103,7 +104,7 @@ func TestCollector_Start(t *testing.T) {
 
 type mockColTelemetry struct{}
 
-func (tel *mockColTelemetry) init(chan<- error, uint64, *zap.Logger) error {
+func (tel *mockColTelemetry) init(chan<- error, uint64, *zap.Logger, config.ServiceTelemetry) error {
 	return nil
 }
 


### PR DESCRIPTION
Added a version tag to the collector's own telemetry metrics because today when looking at those metrics there is no way to know the collector's version, this can also help to know what collector versions are running out there.
I added the new config option to the config file as suggested in https://github.com/open-telemetry/opentelemetry-collector/issues/3843 