### PR TITLE
pdata.Exemplar: add function to get/set traceID and spanID

### DIFF
--- a/cmd/pdatagen/internal/metrics_structs.go
+++ b/cmd/pdatagen/internal/metrics_structs.go
@@ -316,6 +316,8 @@ var exemplar = &messageValueStruct{
 			originFieldName: "FilteredAttributes",
 			returnSlice:     attributeMap,
 		},
+		traceIDField,
+		spanIDField,
 	},
 }
 

--- a/model/pdata/generated_metrics.go
+++ b/model/pdata/generated_metrics.go
@@ -1821,6 +1821,26 @@ func (ms Exemplar) FilteredAttributes() AttributeMap {
 	return newAttributeMap(&(*ms.orig).FilteredAttributes)
 }
 
+// TraceID returns the traceid associated with this Exemplar.
+func (ms Exemplar) TraceID() TraceID {
+	return TraceID{orig: ((*ms.orig).TraceId)}
+}
+
+// SetTraceID replaces the traceid associated with this Exemplar.
+func (ms Exemplar) SetTraceID(v TraceID) {
+	(*ms.orig).TraceId = v.orig
+}
+
+// SpanID returns the spanid associated with this Exemplar.
+func (ms Exemplar) SpanID() SpanID {
+	return SpanID{orig: ((*ms.orig).SpanId)}
+}
+
+// SetSpanID replaces the spanid associated with this Exemplar.
+func (ms Exemplar) SetSpanID(v SpanID) {
+	(*ms.orig).SpanId = v.orig
+}
+
 // CopyTo copies all properties from the current struct to the dest.
 func (ms Exemplar) CopyTo(dest Exemplar) {
 	dest.SetTimestamp(ms.Timestamp())
@@ -1832,4 +1852,6 @@ func (ms Exemplar) CopyTo(dest Exemplar) {
 	}
 
 	ms.FilteredAttributes().CopyTo(dest.FilteredAttributes())
+	dest.SetTraceID(ms.TraceID())
+	dest.SetSpanID(ms.SpanID())
 }

--- a/model/pdata/generated_metrics_test.go
+++ b/model/pdata/generated_metrics_test.go
@@ -1298,6 +1298,22 @@ func TestExemplar_FilteredAttributes(t *testing.T) {
 	assert.EqualValues(t, testValFilteredAttributes, ms.FilteredAttributes())
 }
 
+func TestExemplar_TraceID(t *testing.T) {
+	ms := NewExemplar()
+	assert.EqualValues(t, NewTraceID([16]byte{}), ms.TraceID())
+	testValTraceID := NewTraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 8, 7, 6, 5, 4, 3, 2, 1})
+	ms.SetTraceID(testValTraceID)
+	assert.EqualValues(t, testValTraceID, ms.TraceID())
+}
+
+func TestExemplar_SpanID(t *testing.T) {
+	ms := NewExemplar()
+	assert.EqualValues(t, NewSpanID([8]byte{}), ms.SpanID())
+	testValSpanID := NewSpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8})
+	ms.SetSpanID(testValSpanID)
+	assert.EqualValues(t, testValSpanID, ms.SpanID())
+}
+
 func generateTestResourceMetricsSlice() ResourceMetricsSlice {
 	tv := NewResourceMetricsSlice()
 	fillTestResourceMetricsSlice(tv)
@@ -1560,4 +1576,6 @@ func fillTestExemplar(tv Exemplar) {
 	tv.SetDoubleVal(float64(17.13))
 
 	fillTestAttributeMap(tv.FilteredAttributes())
+	tv.SetTraceID(NewTraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 8, 7, 6, 5, 4, 3, 2, 1}))
+	tv.SetSpanID(NewSpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8}))
 }


### PR DESCRIPTION
**Description:**
Currently `otlpmetrics.Exemplar` (protogen/metrics/v1/metrics.pb.go) has a `TraceId` field and a `SpanId` field, but `pdata.Exemplar` does not provide any function to query/modify these values. This PR expose that by simply adding fields declaration to `cmd/pdatagen/internal/metrics_structs.go`

**Testing:**
- `go test ./...`-ed inside cmd/pdata/internal