### PR TITLE
Add a new type of provider that can merge multiple config providers

### DIFF
--- a/service/parserprovider/default.go
+++ b/service/parserprovider/default.go
@@ -18,5 +18,5 @@ package parserprovider
 // defined by the --config command line flag and overwrites properties from --set
 // command line flag (if the flag is present).
 func Default() ParserProvider {
-	return NewSetFlag(NewFile())
+	return NewMergeProvider(NewFile(), NewSetFlag())
 }

--- a/service/parserprovider/merge.go
+++ b/service/parserprovider/merge.go
@@ -1,0 +1,60 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parserprovider
+
+import (
+	"context"
+
+	"go.opentelemetry.io/collector/config/configparser"
+	"go.opentelemetry.io/collector/consumer/consumererror"
+)
+
+// TODO: Add support to "merge" watchable interface.
+
+type mergeProvider struct {
+	providers []ParserProvider
+}
+
+// NewMergeProvider returns a config.ParserProvider, that merges the result from multiple ParserProvider.
+//
+// The ConfigMaps are merged in the given order, by merging all of them in order into an initial empty map.
+func NewMergeProvider(ps ...ParserProvider) ParserProvider {
+	return &mergeProvider{providers: ps}
+}
+
+func (mp *mergeProvider) Get(ctx context.Context) (*configparser.ConfigMap, error) {
+	ret := configparser.NewConfigMap()
+	for _, p := range mp.providers {
+		cfgMap, err := p.Get(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if err = ret.Merge(cfgMap); err != nil {
+			return nil, err
+		}
+	}
+	return ret, nil
+}
+
+func (mp *mergeProvider) Close(ctx context.Context) error {
+	var errs []error
+	for _, p := range mp.providers {
+		if err := p.Close(ctx); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	return consumererror.Combine(errs)
+}

--- a/service/parserprovider/merge_test.go
+++ b/service/parserprovider/merge_test.go
@@ -1,0 +1,55 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parserprovider
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/collector/config/configparser"
+)
+
+func TestMerge_GetError(t *testing.T) {
+	pl := NewMergeProvider(&errProvider{err: nil}, &errProvider{errors.New("my error")})
+	require.NotNil(t, pl)
+	cp, err := pl.Get(context.Background())
+	assert.Error(t, err)
+	assert.Nil(t, cp)
+}
+
+func TestMerge_CloseError(t *testing.T) {
+	pl := NewMergeProvider(&errProvider{err: nil}, &errProvider{errors.New("my error")})
+	require.NotNil(t, pl)
+	assert.Error(t, pl.Close(context.Background()))
+}
+
+type errProvider struct {
+	err error
+}
+
+func (epl *errProvider) Get(context.Context) (*configparser.ConfigMap, error) {
+	if epl.err == nil {
+		return configparser.NewConfigMap(), nil
+	}
+	return nil, epl.err
+}
+
+func (epl *errProvider) Close(context.Context) error {
+	return epl.err
+}

--- a/service/parserprovider/setflag_test.go
+++ b/service/parserprovider/setflag_test.go
@@ -21,8 +21,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"go.opentelemetry.io/collector/config/configparser"
 )
 
 func TestSetFlags(t *testing.T) {
@@ -36,34 +34,25 @@ func TestSetFlags(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	sfl := NewSetFlag(new(emptyProvider))
+	sfl := NewSetFlag()
 	cp, err := sfl.Get(context.Background())
 	require.NoError(t, err)
-
 	keys := cp.AllKeys()
 	assert.Len(t, keys, 4)
 	assert.Equal(t, "2s", cp.Get("processors::batch::timeout"))
 	assert.Equal(t, "3s", cp.Get("processors::batch/foo::timeout"))
 	assert.Equal(t, "foo:9200,foo2:9200", cp.Get("exporters::kafka::brokers"))
 	assert.Equal(t, "localhost:1818", cp.Get("receivers::otlp::protocols::grpc::endpoint"))
+	require.NoError(t, sfl.Close(context.Background()))
 }
 
 func TestSetFlags_empty(t *testing.T) {
 	flags := new(flag.FlagSet)
 	Flags(flags)
 
-	sfl := NewSetFlag(new(emptyProvider))
+	sfl := NewSetFlag()
 	cp, err := sfl.Get(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, 0, len(cp.AllKeys()))
-}
-
-type emptyProvider struct{}
-
-func (el *emptyProvider) Get(context.Context) (*configparser.ConfigMap, error) {
-	return configparser.NewConfigMap(), nil
-}
-
-func (el *emptyProvider) Close(context.Context) error {
-	return nil
+	require.NoError(t, sfl.Close(context.Background()))
 }


### PR DESCRIPTION
Fixes a bug where the provider passed to SetFlag provider was not closed.

Followup will add support to merge multiple whatchable providers.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
