### PR TITLE
Rename parserprovider.Default to parserprovider.NewDefaultMapProvider

### DIFF
--- a/service/collector.go
+++ b/service/collector.go
@@ -93,7 +93,7 @@ func New(set CollectorSettings) (*Collector, error) {
 
 	if set.ConfigMapProvider == nil {
 		// use default provider.
-		set.ConfigMapProvider = parserprovider.Default()
+		set.ConfigMapProvider = parserprovider.NewDefaultMapProvider()
 	}
 
 	if set.ConfigUnmarshaler == nil {

--- a/service/parserprovider/default.go
+++ b/service/parserprovider/default.go
@@ -14,9 +14,9 @@
 
 package parserprovider
 
-// Default is the default MapProvider and it creates configuration from a file
+// NewDefaultMapProvider is the default MapProvider and it creates configuration from a file
 // defined by the --config command line flag and overwrites properties from --set
 // command line flag (if the flag is present).
-func Default() MapProvider {
+func NewDefaultMapProvider() MapProvider {
 	return NewMergeMapProvider(NewFileMapProvider(), NewPropertiesMapProvider())
 }

--- a/service/parserprovider/default_test.go
+++ b/service/parserprovider/default_test.go
@@ -42,7 +42,7 @@ func TestDefault(t *testing.T) {
 			"--set=processors.doesnotexist.timeout=2s",
 		})
 		require.NoError(t, err)
-		pl := Default()
+		pl := NewDefaultMapProvider()
 		require.NotNil(t, pl)
 		var cp *config.Map
 		cp, err = pl.Get(context.Background())
@@ -62,7 +62,7 @@ func TestDefault(t *testing.T) {
 			"--set=processors.batch/foo.timeout=2s",
 		})
 		require.NoError(t, err)
-		pl := Default()
+		pl := NewDefaultMapProvider()
 		require.NotNil(t, pl)
 		var cp *config.Map
 		cp, err = pl.Get(context.Background())
@@ -93,7 +93,7 @@ func TestDefault(t *testing.T) {
 			"--set=receivers.otlp.protocols.grpc.endpoint=localhost:12345",
 		})
 		require.NoError(t, err)
-		pl := Default()
+		pl := NewDefaultMapProvider()
 		require.NotNil(t, pl)
 		var cp *config.Map
 		cp, err = pl.Get(context.Background())
@@ -128,7 +128,7 @@ func TestDefault_ComponentDoesNotExist(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	pl := Default()
+	pl := NewDefaultMapProvider()
 	require.NotNil(t, pl)
 	cp, err := pl.Get(context.Background())
 	require.NoError(t, err)


### PR DESCRIPTION
Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
