### PR TITLE
Change TLSClient config to pointer type

### DIFF
--- a/config/configgrpc/configgrpc.go
+++ b/config/configgrpc/configgrpc.go
@@ -73,7 +73,7 @@ type GRPCClientSettings struct {
 	Compression string `mapstructure:"compression"`
 
 	// TLSSetting struct exposes TLS client configuration.
-	TLSSetting configtls.TLSClientSetting `mapstructure:"tls,omitempty"`
+	TLSSetting *configtls.TLSClientSetting `mapstructure:"tls,omitempty"`
 
 	// The keepalive parameters for gRPC client. See grpc.WithKeepaliveParams.
 	// (https://godoc.org/google.golang.org/grpc#WithKeepaliveParams).
@@ -181,6 +181,8 @@ func (gcs *GRPCClientSettings) isSchemeHTTPS() bool {
 // ToDialOptions maps configgrpc.GRPCClientSettings to a slice of dial options for gRPC.
 func (gcs *GRPCClientSettings) ToDialOptions(host component.Host) ([]grpc.DialOption, error) {
 	var opts []grpc.DialOption
+	var tlsCfg *tls.Config
+	var err error
 	if gcs.Compression != "" {
 		if compressionKey := GetGRPCCompressionKey(gcs.Compression); compressionKey != CompressionUnsupported {
 			opts = append(opts, grpc.WithDefaultCallOptions(grpc.UseCompressor(compressionKey)))
@@ -188,17 +190,19 @@ func (gcs *GRPCClientSettings) ToDialOptions(host component.Host) ([]grpc.DialOp
 			return nil, fmt.Errorf("unsupported compression type %q", gcs.Compression)
 		}
 	}
-
-	tlsCfg, err := gcs.TLSSetting.LoadTLSConfig()
-	if err != nil {
-		return nil, err
-	}
 	tlsDialOption := grpc.WithInsecure()
+	if gcs.TLSSetting != nil {
+		tlsCfg, err = gcs.TLSSetting.LoadTLSConfig()
+		if err != nil {
+			return nil, err
+		}
+	}
 	if tlsCfg != nil {
 		tlsDialOption = grpc.WithTransportCredentials(credentials.NewTLS(tlsCfg))
 	} else if gcs.isSchemeHTTPS() {
 		tlsDialOption = grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{}))
 	}
+
 	opts = append(opts, tlsDialOption)
 
 	if gcs.ReadBufferSize > 0 {
@@ -235,7 +239,7 @@ func (gcs *GRPCClientSettings) ToDialOptions(host component.Host) ([]grpc.DialOp
 
 		perRPCCredentials, perr := grpcAuthenticator.PerRPCCredentials()
 		if perr != nil {
-			return nil, err
+			return nil, perr
 		}
 		opts = append(opts, grpc.WithPerRPCCredentials(perRPCCredentials))
 	}

--- a/config/configgrpc/configgrpc_test.go
+++ b/config/configgrpc/configgrpc_test.go
@@ -38,7 +38,7 @@ import (
 
 func TestDefaultGrpcClientSettings(t *testing.T) {
 	gcs := &GRPCClientSettings{
-		TLSSetting: configtls.TLSClientSetting{
+		TLSSetting: &configtls.TLSClientSetting{
 			Insecure: true,
 		},
 	}
@@ -54,7 +54,7 @@ func TestAllGrpcClientSettings(t *testing.T) {
 		},
 		Endpoint:    "localhost:1234",
 		Compression: "gzip",
-		TLSSetting: configtls.TLSClientSetting{
+		TLSSetting: &configtls.TLSClientSetting{
 			Insecure: false,
 		},
 		Keepalive: &KeepaliveClientConfig{
@@ -160,7 +160,7 @@ func TestGRPCClientSettingsError(t *testing.T) {
 				Headers:     nil,
 				Endpoint:    "",
 				Compression: "",
-				TLSSetting: configtls.TLSClientSetting{
+				TLSSetting: &configtls.TLSClientSetting{
 					TLSSetting: configtls.TLSSetting{
 						CAFile: "/doesnt/exist",
 					},
@@ -176,7 +176,7 @@ func TestGRPCClientSettingsError(t *testing.T) {
 				Headers:     nil,
 				Endpoint:    "",
 				Compression: "",
-				TLSSetting: configtls.TLSClientSetting{
+				TLSSetting: &configtls.TLSClientSetting{
 					TLSSetting: configtls.TLSSetting{
 						CertFile: "/doesnt/exist",
 					},
@@ -194,7 +194,7 @@ func TestGRPCClientSettingsError(t *testing.T) {
 				},
 				Endpoint:    "localhost:1234",
 				Compression: "gzip",
-				TLSSetting: configtls.TLSClientSetting{
+				TLSSetting: &configtls.TLSClientSetting{
 					Insecure: false,
 				},
 				Keepalive: &KeepaliveClientConfig{
@@ -250,7 +250,7 @@ func TestUseSecure(t *testing.T) {
 		Headers:     nil,
 		Endpoint:    "",
 		Compression: "",
-		TLSSetting:  configtls.TLSClientSetting{},
+		TLSSetting:  &configtls.TLSClientSetting{},
 		Keepalive:   nil,
 	}
 	dialOpts, err := gcs.ToDialOptions(componenttest.NewNopHost())
@@ -472,7 +472,7 @@ func TestHttpReception(t *testing.T) {
 
 			gcs := &GRPCClientSettings{
 				Endpoint:   ln.Addr().String(),
-				TLSSetting: *tt.tlsClientCreds,
+				TLSSetting: tt.tlsClientCreds,
 			}
 			clientOpts, errClient := gcs.ToDialOptions(componenttest.NewNopHost())
 			assert.NoError(t, errClient)
@@ -517,7 +517,7 @@ func TestReceiveOnUnixDomainSocket(t *testing.T) {
 
 	gcs := &GRPCClientSettings{
 		Endpoint: "unix://" + ln.Addr().String(),
-		TLSSetting: configtls.TLSClientSetting{
+		TLSSetting: &configtls.TLSClientSetting{
 			Insecure: true,
 		},
 	}

--- a/config/confighttp/confighttp.go
+++ b/config/confighttp/confighttp.go
@@ -38,7 +38,7 @@ type HTTPClientSettings struct {
 	Endpoint string `mapstructure:"endpoint"`
 
 	// TLSSetting struct exposes TLS client configuration.
-	TLSSetting configtls.TLSClientSetting `mapstructure:"tls,omitempty"`
+	TLSSetting *configtls.TLSClientSetting `mapstructure:"tls,omitempty"`
 
 	// ReadBufferSize for HTTP client. See http.Transport.ReadBufferSize.
 	ReadBufferSize int `mapstructure:"read_buffer_size"`
@@ -62,14 +62,19 @@ type HTTPClientSettings struct {
 
 // ToClient creates an HTTP client.
 func (hcs *HTTPClientSettings) ToClient(ext map[config.ComponentID]component.Extension) (*http.Client, error) {
-	tlsCfg, err := hcs.TLSSetting.LoadTLSConfig()
-	if err != nil {
-		return nil, err
-	}
+	var err error
 	transport := http.DefaultTransport.(*http.Transport).Clone()
-	if tlsCfg != nil {
-		transport.TLSClientConfig = tlsCfg
+
+	if hcs.TLSSetting != nil {
+		tlsCfg, terr := hcs.TLSSetting.LoadTLSConfig()
+		if terr != nil {
+			return nil, terr
+		}
+		if tlsCfg != nil {
+			transport.TLSClientConfig = tlsCfg
+		}
 	}
+
 	if hcs.ReadBufferSize > 0 {
 		transport.ReadBufferSize = hcs.ReadBufferSize
 	}

--- a/config/confighttp/confighttp_test.go
+++ b/config/confighttp/confighttp_test.go
@@ -57,7 +57,7 @@ func TestAllHTTPClientSettings(t *testing.T) {
 			name: "all_valid_settings",
 			settings: HTTPClientSettings{
 				Endpoint: "localhost:1234",
-				TLSSetting: configtls.TLSClientSetting{
+				TLSSetting: &configtls.TLSClientSetting{
 					Insecure: false,
 				},
 				ReadBufferSize:     1024,
@@ -70,7 +70,7 @@ func TestAllHTTPClientSettings(t *testing.T) {
 			name: "error_round_tripper_returned",
 			settings: HTTPClientSettings{
 				Endpoint: "localhost:1234",
-				TLSSetting: configtls.TLSClientSetting{
+				TLSSetting: &configtls.TLSClientSetting{
 					Insecure: false,
 				},
 				ReadBufferSize:     1024,
@@ -105,7 +105,7 @@ func TestHTTPClientSettingsError(t *testing.T) {
 			err: "^failed to load TLS config: failed to load CA CertPool: failed to load CA /doesnt/exist:",
 			settings: HTTPClientSettings{
 				Endpoint: "",
-				TLSSetting: configtls.TLSClientSetting{
+				TLSSetting: &configtls.TLSClientSetting{
 					TLSSetting: configtls.TLSSetting{
 						CAFile: "/doesnt/exist",
 					},
@@ -118,7 +118,7 @@ func TestHTTPClientSettingsError(t *testing.T) {
 			err: "^failed to load TLS config: for auth via TLS, either both certificate and key must be supplied, or neither",
 			settings: HTTPClientSettings{
 				Endpoint: "",
-				TLSSetting: configtls.TLSClientSetting{
+				TLSSetting: &configtls.TLSClientSetting{
 					TLSSetting: configtls.TLSSetting{
 						CertFile: "/doesnt/exist",
 					},
@@ -407,7 +407,7 @@ func TestHttpReception(t *testing.T) {
 
 			hcs := &HTTPClientSettings{
 				Endpoint:   prefix + ln.Addr().String(),
-				TLSSetting: *tt.tlsClientCreds,
+				TLSSetting: tt.tlsClientCreds,
 			}
 			client, errClient := hcs.ToClient(map[config.ComponentID]component.Extension{})
 			assert.NoError(t, errClient)
@@ -582,7 +582,7 @@ func TestHttpHeaders(t *testing.T) {
 			serverURL, _ := url.Parse(server.URL)
 			setting := HTTPClientSettings{
 				Endpoint:        serverURL.String(),
-				TLSSetting:      configtls.TLSClientSetting{},
+				TLSSetting:      &configtls.TLSClientSetting{},
 				ReadBufferSize:  0,
 				WriteBufferSize: 0,
 				Timeout:         0,

--- a/exporter/otlpexporter/config_test.go
+++ b/exporter/otlpexporter/config_test.go
@@ -72,7 +72,7 @@ func TestLoadConfig(t *testing.T) {
 				},
 				Endpoint:    "1.2.3.4:1234",
 				Compression: "on",
-				TLSSetting: configtls.TLSClientSetting{
+				TLSSetting: &configtls.TLSClientSetting{
 					TLSSetting: configtls.TLSSetting{
 						CAFile: "/var/lib/mycert.pem",
 					},

--- a/exporter/otlpexporter/factory_test.go
+++ b/exporter/otlpexporter/factory_test.go
@@ -78,7 +78,7 @@ func TestCreateTracesExporter(t *testing.T) {
 				ExporterSettings: config.NewExporterSettings(config.NewID(typeStr)),
 				GRPCClientSettings: configgrpc.GRPCClientSettings{
 					Endpoint: endpoint,
-					TLSSetting: configtls.TLSClientSetting{
+					TLSSetting: &configtls.TLSClientSetting{
 						Insecure: false,
 					},
 				},
@@ -147,7 +147,7 @@ func TestCreateTracesExporter(t *testing.T) {
 				ExporterSettings: config.NewExporterSettings(config.NewID(typeStr)),
 				GRPCClientSettings: configgrpc.GRPCClientSettings{
 					Endpoint: endpoint,
-					TLSSetting: configtls.TLSClientSetting{
+					TLSSetting: &configtls.TLSClientSetting{
 						TLSSetting: configtls.TLSSetting{
 							CAFile: "testdata/test_cert.pem",
 						},
@@ -161,7 +161,7 @@ func TestCreateTracesExporter(t *testing.T) {
 				ExporterSettings: config.NewExporterSettings(config.NewID(typeStr)),
 				GRPCClientSettings: configgrpc.GRPCClientSettings{
 					Endpoint: endpoint,
-					TLSSetting: configtls.TLSClientSetting{
+					TLSSetting: &configtls.TLSClientSetting{
 						TLSSetting: configtls.TLSSetting{
 							CAFile: "nosuchfile",
 						},

--- a/exporter/otlpexporter/otlp_test.go
+++ b/exporter/otlpexporter/otlp_test.go
@@ -195,7 +195,7 @@ func TestSendTraces(t *testing.T) {
 	cfg := factory.CreateDefaultConfig().(*Config)
 	cfg.GRPCClientSettings = configgrpc.GRPCClientSettings{
 		Endpoint: ln.Addr().String(),
-		TLSSetting: configtls.TLSClientSetting{
+		TLSSetting: &configtls.TLSClientSetting{
 			Insecure: true,
 		},
 		Headers: map[string]string{
@@ -258,17 +258,19 @@ func TestSendTracesWhenEndpointHasHttpScheme(t *testing.T) {
 		gRPCClientSettings configgrpc.GRPCClientSettings
 	}{
 		{
-			name:               "Use https scheme",
-			useTLS:             true,
-			scheme:             "https://",
-			gRPCClientSettings: configgrpc.GRPCClientSettings{},
+			name:   "Use https scheme",
+			useTLS: true,
+			scheme: "https://",
+			gRPCClientSettings: configgrpc.GRPCClientSettings{
+				TLSSetting: &configtls.TLSClientSetting{},
+			},
 		},
 		{
 			name:   "Use http scheme",
 			useTLS: false,
 			scheme: "http://",
 			gRPCClientSettings: configgrpc.GRPCClientSettings{
-				TLSSetting: configtls.TLSClientSetting{
+				TLSSetting: &configtls.TLSClientSetting{
 					Insecure: true,
 				},
 			},
@@ -336,7 +338,7 @@ func TestSendMetrics(t *testing.T) {
 	cfg := factory.CreateDefaultConfig().(*Config)
 	cfg.GRPCClientSettings = configgrpc.GRPCClientSettings{
 		Endpoint: ln.Addr().String(),
-		TLSSetting: configtls.TLSClientSetting{
+		TLSSetting: &configtls.TLSClientSetting{
 			Insecure: true,
 		},
 		Headers: map[string]string{
@@ -404,7 +406,7 @@ func TestSendTraceDataServerDownAndUp(t *testing.T) {
 	cfg.QueueSettings.Enabled = false
 	cfg.GRPCClientSettings = configgrpc.GRPCClientSettings{
 		Endpoint: ln.Addr().String(),
-		TLSSetting: configtls.TLSClientSetting{
+		TLSSetting: &configtls.TLSClientSetting{
 			Insecure: true,
 		},
 		// Need to wait for every request blocking until either request timeouts or succeed.
@@ -464,7 +466,7 @@ func TestSendTraceDataServerStartWhileRequest(t *testing.T) {
 	cfg := factory.CreateDefaultConfig().(*Config)
 	cfg.GRPCClientSettings = configgrpc.GRPCClientSettings{
 		Endpoint: ln.Addr().String(),
-		TLSSetting: configtls.TLSClientSetting{
+		TLSSetting: &configtls.TLSClientSetting{
 			Insecure: true,
 		},
 	}
@@ -540,7 +542,7 @@ func TestSendLogData(t *testing.T) {
 	cfg := factory.CreateDefaultConfig().(*Config)
 	cfg.GRPCClientSettings = configgrpc.GRPCClientSettings{
 		Endpoint: ln.Addr().String(),
-		TLSSetting: configtls.TLSClientSetting{
+		TLSSetting: &configtls.TLSClientSetting{
 			Insecure: true,
 		},
 	}

--- a/exporter/otlphttpexporter/config_test.go
+++ b/exporter/otlphttpexporter/config_test.go
@@ -66,7 +66,7 @@ func TestLoadConfig(t *testing.T) {
 					"another":                "somevalue",
 				},
 				Endpoint: "https://1.2.3.4:1234",
-				TLSSetting: configtls.TLSClientSetting{
+				TLSSetting: &configtls.TLSClientSetting{
 					TLSSetting: configtls.TLSSetting{
 						CAFile:   "/var/lib/mycert.pem",
 						CertFile: "certfile",

--- a/exporter/otlphttpexporter/factory_test.go
+++ b/exporter/otlphttpexporter/factory_test.go
@@ -82,7 +82,7 @@ func TestCreateTracesExporter(t *testing.T) {
 				ExporterSettings: config.NewExporterSettings(config.NewID(typeStr)),
 				HTTPClientSettings: confighttp.HTTPClientSettings{
 					Endpoint: endpoint,
-					TLSSetting: configtls.TLSClientSetting{
+					TLSSetting: &configtls.TLSClientSetting{
 						Insecure: false,
 					},
 				},
@@ -107,7 +107,7 @@ func TestCreateTracesExporter(t *testing.T) {
 				ExporterSettings: config.NewExporterSettings(config.NewID(typeStr)),
 				HTTPClientSettings: confighttp.HTTPClientSettings{
 					Endpoint: endpoint,
-					TLSSetting: configtls.TLSClientSetting{
+					TLSSetting: &configtls.TLSClientSetting{
 						TLSSetting: configtls.TLSSetting{
 							CAFile: "testdata/test_cert.pem",
 						},
@@ -121,7 +121,7 @@ func TestCreateTracesExporter(t *testing.T) {
 				ExporterSettings: config.NewExporterSettings(config.NewID(typeStr)),
 				HTTPClientSettings: confighttp.HTTPClientSettings{
 					Endpoint: endpoint,
-					TLSSetting: configtls.TLSClientSetting{
+					TLSSetting: &configtls.TLSClientSetting{
 						TLSSetting: configtls.TLSSetting{
 							CAFile: "nosuchfile",
 						},


### PR DESCRIPTION
**Description:** <Describe what has changed. 
Change TLSClient config to pointer type in `confighttp` and `configgrpc` config

**Related Issue**
https://github.com/open-telemetry/opentelemetry-collector/issues/4028
https://github.com/open-telemetry/opentelemetry-collector/pull/4063#discussion_r711974463