### PR TITLE
Deprecate consumererror.As[Traces|Metrics|Logs], use standard errors.As

### DIFF
--- a/consumer/consumererror/signalerrors.go
+++ b/consumer/consumererror/signalerrors.go
@@ -37,6 +37,7 @@ func NewTraces(err error, failed pdata.Traces) error {
 
 // AsTraces finds the first error in err's chain that can be assigned to target. If such an error is found,
 // it is assigned to target and true is returned, otherwise false is returned.
+// Deprecated: Use `errors.As(err, target)` instead.
 func AsTraces(err error, target *Traces) bool {
 	if err == nil {
 		return false
@@ -71,6 +72,7 @@ func NewLogs(err error, failed pdata.Logs) error {
 
 // AsLogs finds the first error in err's chain that can be assigned to target. If such an error is found,
 // it is assigned to target and true is returned, otherwise false is returned.
+// Deprecated: Use `errors.As(err, target)` instead.
 func AsLogs(err error, target *Logs) bool {
 	if err == nil {
 		return false
@@ -105,6 +107,7 @@ func NewMetrics(err error, failed pdata.Metrics) error {
 
 // AsMetrics finds the first error in err's chain that can be assigned to target. If such an error is found,
 // it is assigned to target and true is returned, otherwise false is returned.
+// Deprecated: Use `errors.As(err, target)` instead.
 func AsMetrics(err error, target *Metrics) bool {
 	if err == nil {
 		return false

--- a/consumer/consumererror/signalerrors_test.go
+++ b/consumer/consumererror/signalerrors_test.go
@@ -31,9 +31,9 @@ func TestTraces(t *testing.T) {
 	traceErr := NewTraces(err, td)
 	assert.Equal(t, err.Error(), traceErr.Error())
 	var target Traces
-	assert.False(t, AsTraces(nil, &target))
-	assert.False(t, AsTraces(err, &target))
-	assert.True(t, AsTraces(traceErr, &target))
+	assert.False(t, errors.As(nil, &target))
+	assert.False(t, errors.As(err, &target))
+	assert.True(t, errors.As(traceErr, &target))
 	assert.Equal(t, td, target.GetTraces())
 }
 
@@ -55,9 +55,9 @@ func TestLogs(t *testing.T) {
 	logsErr := NewLogs(err, td)
 	assert.Equal(t, err.Error(), logsErr.Error())
 	var target Logs
-	assert.False(t, AsLogs(nil, &target))
-	assert.False(t, AsLogs(err, &target))
-	assert.True(t, AsLogs(logsErr, &target))
+	assert.False(t, errors.As(nil, &target))
+	assert.False(t, errors.As(err, &target))
+	assert.True(t, errors.As(logsErr, &target))
 	assert.Equal(t, td, target.GetLogs())
 }
 
@@ -79,9 +79,9 @@ func TestMetrics(t *testing.T) {
 	metricErr := NewMetrics(err, td)
 	assert.Equal(t, err.Error(), metricErr.Error())
 	var target Metrics
-	assert.False(t, AsMetrics(nil, &target))
-	assert.False(t, AsMetrics(err, &target))
-	assert.True(t, AsMetrics(metricErr, &target))
+	assert.False(t, errors.As(nil, &target))
+	assert.False(t, errors.As(err, &target))
+	assert.True(t, errors.As(metricErr, &target))
 	assert.Equal(t, td, target.GetMetrics())
 }
 

--- a/exporter/exporterhelper/logs.go
+++ b/exporter/exporterhelper/logs.go
@@ -56,7 +56,7 @@ func newLogsRequestUnmarshalerFunc(pusher consumerhelper.ConsumeLogsFunc) reques
 
 func (req *logsRequest) onError(err error) request {
 	var logError consumererror.Logs
-	if consumererror.AsLogs(err, &logError) {
+	if errors.As(err, &logError) {
 		return newLogsRequest(req.ctx, logError.GetLogs(), req.pusher)
 	}
 	return req

--- a/exporter/exporterhelper/metrics.go
+++ b/exporter/exporterhelper/metrics.go
@@ -56,7 +56,7 @@ func newMetricsRequestUnmarshalerFunc(pusher consumerhelper.ConsumeMetricsFunc) 
 
 func (req *metricsRequest) onError(err error) request {
 	var metricsError consumererror.Metrics
-	if consumererror.AsMetrics(err, &metricsError) {
+	if errors.As(err, &metricsError) {
 		return newMetricsRequest(req.ctx, metricsError.GetMetrics(), req.pusher)
 	}
 	return req

--- a/exporter/exporterhelper/traces.go
+++ b/exporter/exporterhelper/traces.go
@@ -60,7 +60,7 @@ func (req *tracesRequest) marshal() ([]byte, error) {
 
 func (req *tracesRequest) onError(err error) request {
 	var traceError consumererror.Traces
-	if consumererror.AsTraces(err, &traceError) {
+	if errors.As(err, &traceError) {
 		return newTracesRequest(req.ctx, traceError.GetTraces(), req.pusher)
 	}
 	return req


### PR DESCRIPTION
Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
