### PR TITLE
Move Persistent Queue to exporthelper/internal [Part 1/3]

### DIFF
--- a/exporter/exporterhelper/internal/bounded_memory_queue_test.go
+++ b/exporter/exporterhelper/internal/bounded_memory_queue_test.go
@@ -6,7 +6,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+//       http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,7 +17,6 @@
 package internal
 
 import (
-	"fmt"
 	"reflect"
 	"sync"
 	"sync/atomic"
@@ -26,7 +25,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	uatomic "go.uber.org/atomic"
 )
 
 // In this test we run a queue with capacity 1 and a single consumer.
@@ -97,12 +95,6 @@ func TestBoundedQueue(t *testing.T) {
 	})
 }
 
-func TestBoundedQueueWithFactory(t *testing.T) {
-	helper(t, func(q ProducerConsumerQueue, consumerFn func(item interface{})) {
-		q.StartConsumersWithFactory(1, func() Consumer { return ConsumerFunc(consumerFn) })
-	})
-}
-
 type consumerState struct {
 	sync.Mutex
 	t            *testing.T
@@ -152,154 +144,6 @@ func (s *consumerState) assertConsumed(expected map[string]bool) {
 	assert.Equal(s.t, expected, s.snapshot())
 }
 
-func TestResizeUp(t *testing.T) {
-	q := NewBoundedMemoryQueue(2, func(item interface{}) {
-		fmt.Printf("dropped: %v\n", item)
-	})
-
-	var firstConsumer, secondConsumer, releaseConsumers sync.WaitGroup
-	firstConsumer.Add(1)
-	secondConsumer.Add(1)
-	releaseConsumers.Add(1)
-
-	released, resized := false, false
-	q.StartConsumers(1, func(item interface{}) {
-		if !resized { // we'll have a second consumer once the queue is resized
-			// signal that the worker is processing
-			firstConsumer.Done()
-		} else if !released {
-			// once we release the lock, we might end up with multiple calls to reach this
-			secondConsumer.Done()
-		}
-
-		// wait until we are signaled that we can finish
-		releaseConsumers.Wait()
-	})
-
-	assert.True(t, q.Produce("a")) // in process
-	firstConsumer.Wait()
-
-	assert.True(t, q.Produce("b"))  // in queue
-	assert.True(t, q.Produce("c"))  // in queue
-	assert.False(t, q.Produce("d")) // dropped
-	assert.EqualValues(t, 2, q.Capacity())
-	assert.EqualValues(t, q.Capacity(), q.Size())
-	assert.EqualValues(t, q.Capacity(), len(*q.(*boundedMemoryQueue).items))
-
-	resized = true
-	assert.True(t, q.Resize(4))
-	assert.True(t, q.Produce("e")) // in process by the second consumer
-	secondConsumer.Wait()
-
-	assert.True(t, q.Produce("f"))  // in the new queue
-	assert.True(t, q.Produce("g"))  // in the new queue
-	assert.False(t, q.Produce("h")) // the new queue has the capacity, but the sum of queues doesn't
-
-	assert.EqualValues(t, 4, q.Capacity())
-	assert.EqualValues(t, q.Capacity(), q.Size())                 // the combined queues are at the capacity right now
-	assert.EqualValues(t, 2, len(*q.(*boundedMemoryQueue).items)) // the new internal queue should have two items only
-
-	released = true
-	releaseConsumers.Done()
-}
-
-func TestResizeDown(t *testing.T) {
-	q := NewBoundedMemoryQueue(4, func(item interface{}) {
-		fmt.Printf("dropped: %v\n", item)
-	})
-
-	var consumer, releaseConsumers sync.WaitGroup
-	consumer.Add(1)
-	releaseConsumers.Add(1)
-
-	released := false
-	q.StartConsumers(1, func(item interface{}) {
-		// once we release the lock, we might end up with multiple calls to reach this
-		if !released {
-			// signal that the worker is processing
-			consumer.Done()
-		}
-
-		// wait until we are signaled that we can finish
-		releaseConsumers.Wait()
-	})
-
-	assert.True(t, q.Produce("a")) // in process
-	consumer.Wait()
-
-	assert.True(t, q.Produce("b")) // in queue
-	assert.True(t, q.Produce("c")) // in queue
-	assert.True(t, q.Produce("d")) // in queue
-	assert.True(t, q.Produce("e")) // dropped
-	assert.EqualValues(t, 4, q.Capacity())
-	assert.EqualValues(t, q.Capacity(), q.Size())
-	assert.EqualValues(t, q.Capacity(), len(*q.(*boundedMemoryQueue).items))
-
-	assert.True(t, q.Resize(2))
-	assert.False(t, q.Produce("f")) // dropped
-
-	assert.EqualValues(t, 2, q.Capacity())
-	assert.EqualValues(t, 4, q.Size())                            // the queue will eventually drain, but it will live for a while over capacity
-	assert.EqualValues(t, 0, len(*q.(*boundedMemoryQueue).items)) // the new queue is empty, as the old queue is still full and over capacity
-
-	released = true
-	releaseConsumers.Done()
-}
-
-func TestResizeOldQueueIsDrained(t *testing.T) {
-	q := NewBoundedMemoryQueue(2, func(item interface{}) {
-		fmt.Printf("dropped: %v\n", item)
-	})
-
-	var consumerReady, expected, readyToConsume sync.WaitGroup
-	consumerReady.Add(1)
-	readyToConsume.Add(1)
-	expected.Add(5) // we expect 5 items to be processed
-
-	consumed := uatomic.NewInt32(5)
-
-	first := true
-	q.StartConsumers(1, func(item interface{}) {
-		// first run only
-		if first {
-			first = false
-			consumerReady.Done()
-		}
-
-		readyToConsume.Wait()
-
-		if consumed.Sub(1) >= 0 {
-			// we mark only the first 5 items as done
-			// we *might* get one item more in the queue given the right conditions
-			// but this small difference is OK -- making sure we are processing *exactly* N items
-			// is costlier than just accept that there's a couple more items in the queue than expected
-			expected.Done()
-		}
-	})
-
-	assert.True(t, q.Produce("a"))
-	consumerReady.Wait()
-
-	assert.True(t, q.Produce("b"))
-	assert.True(t, q.Produce("c"))
-	assert.False(t, q.Produce("d"))
-
-	q.Resize(4)
-
-	assert.True(t, q.Produce("e"))
-	assert.True(t, q.Produce("f"))
-
-	readyToConsume.Done()
-	expected.Wait() // once this returns, we've consumed all items, meaning that both queues are drained
-}
-
-func TestNoopResize(t *testing.T) {
-	q := NewBoundedMemoryQueue(2, func(item interface{}) {
-	})
-
-	assert.False(t, q.Resize(2))
-}
-
 func TestZeroSize(t *testing.T) {
 	q := NewBoundedMemoryQueue(0, func(item interface{}) {
 	})
@@ -326,9 +170,7 @@ func BenchmarkBoundedQueueWithFactory(b *testing.B) {
 	q := NewBoundedMemoryQueue(1000, func(item interface{}) {
 	})
 
-	q.StartConsumersWithFactory(10, func() Consumer {
-		return ConsumerFunc(func(item interface{}) {})
-	})
+	q.StartConsumers(10, func(item interface{}) {})
 
 	for n := 0; n < b.N; n++ {
 		q.Produce(n)

--- a/exporter/exporterhelper/internal/producer_consumer_queue.go
+++ b/exporter/exporterhelper/internal/producer_consumer_queue.go
@@ -6,7 +6,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+//       http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -27,9 +27,6 @@ type ProducerConsumerQueue interface {
 	// StartConsumers starts a given number of goroutines consuming items from the queue
 	// and passing them into the consumer callback.
 	StartConsumers(num int, callback func(item interface{}))
-	// StartConsumersWithFactory creates a given number of consumers consuming items
-	// from the queue in separate goroutines.
-	StartConsumersWithFactory(num int, factory func() Consumer)
 	// Produce is used by the producer to submit new item to the queue. Returns false if the item wasn't added
 	// to the queue due to queue overflow.
 	Produce(item interface{}) bool
@@ -37,8 +34,6 @@ type ProducerConsumerQueue interface {
 	Size() int
 	// Capacity returns capacity of the queue
 	Capacity() int
-	// Resize changes the capacity of the queue, returning whether the action was successful
-	Resize(capacity int) bool
 	// Stop stops all consumers, as well as the length reporter if started,
 	// and releases the items channel. It blocks until all consumers have stopped.
 	Stop()

--- a/exporter/exporterhelper/internal/producer_consumer_queue.go
+++ b/exporter/exporterhelper/internal/producer_consumer_queue.go
@@ -1,10 +1,12 @@
 // Copyright The OpenTelemetry Authors
+// Copyright (c) 2019 The Jaeger Authors.
+// Copyright (c) 2017 Uber Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+// http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -12,21 +14,32 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package exporterhelper
+package internal
 
-// consumersQueue is largely based on queue.BoundedQueue and matches the subset used in the collector
-// It describes a producer-consumer exchange which can be backed by e.g. the memory-based ring buffer queue
-// (queue.BoundedQueue) or via disk-based queue (persistentQueue)
-type consumersQueue interface {
+// Consumer consumes data from a bounded queue
+type Consumer interface {
+	Consume(item interface{})
+}
+
+// ProducerConsumerQueue defines a producer-consumer exchange which can be backed by e.g. the memory-based ring buffer queue
+// (boundedMemoryQueue) or via a disk-based queue (persistentQueue)
+type ProducerConsumerQueue interface {
 	// StartConsumers starts a given number of goroutines consuming items from the queue
 	// and passing them into the consumer callback.
 	StartConsumers(num int, callback func(item interface{}))
+	// StartConsumersWithFactory creates a given number of consumers consuming items
+	// from the queue in separate goroutines.
+	StartConsumersWithFactory(num int, factory func() Consumer)
 	// Produce is used by the producer to submit new item to the queue. Returns false if the item wasn't added
 	// to the queue due to queue overflow.
 	Produce(item interface{}) bool
+	// Size returns the current Size of the queue
+	Size() int
+	// Capacity returns capacity of the queue
+	Capacity() int
+	// Resize changes the capacity of the queue, returning whether the action was successful
+	Resize(capacity int) bool
 	// Stop stops all consumers, as well as the length reporter if started,
 	// and releases the items channel. It blocks until all consumers have stopped.
 	Stop()
-	// Size returns the current Size of the queue
-	Size() int
 }

--- a/exporter/exporterhelper/persistent_queue.go
+++ b/exporter/exporterhelper/persistent_queue.go
@@ -48,14 +48,9 @@ func newPersistentQueue(ctx context.Context, name string, capacity int, logger *
 
 // StartConsumers starts the given number of consumers which will be consuming items
 func (pq *persistentQueue) StartConsumers(num int, callback func(item interface{})) {
-	pq.StartConsumersWithFactory(num, func() internal.Consumer {
+	factory := func() internal.Consumer {
 		return internal.ConsumerFunc(callback)
-	})
-}
-
-// StartConsumersWithFactory creates a given number of consumers consuming items
-// from the queue in separate goroutines.
-func (pq *persistentQueue) StartConsumersWithFactory(num int, factory func() internal.Consumer) {
+	}
 	pq.numWorkers = num
 
 	for i := 0; i < pq.numWorkers; i++ {
@@ -100,9 +95,4 @@ func (pq *persistentQueue) Size() int {
 // Currently, it is unlimited but in the future it can take into account available storage space or configured limits
 func (pq *persistentQueue) Capacity() int {
 	return pq.Size() + 1
-}
-
-// Resize changes the size of the queue. It has no effect in case of the Persistent Queue
-func (pq *persistentQueue) Resize(_ int) bool {
-	return true
 }

--- a/exporter/exporterhelper/persistent_queue.go
+++ b/exporter/exporterhelper/persistent_queue.go
@@ -38,7 +38,7 @@ type persistentQueue struct {
 }
 
 // newPersistentQueue creates a new queue backed by file storage; name parameter must be a unique value that identifies the queue
-func newPersistentQueue(ctx context.Context, name string, capacity int, logger *zap.Logger, client storage.Client, unmarshaler requestUnmarshaler) *persistentQueue {
+func newPersistentQueue(ctx context.Context, name string, capacity int, logger *zap.Logger, client storage.Client, unmarshaler requestUnmarshaler) internal.ProducerConsumerQueue {
 	return &persistentQueue{
 		logger:   logger,
 		stopChan: make(chan struct{}),
@@ -48,11 +48,15 @@ func newPersistentQueue(ctx context.Context, name string, capacity int, logger *
 
 // StartConsumers starts the given number of consumers which will be consuming items
 func (pq *persistentQueue) StartConsumers(num int, callback func(item interface{})) {
-	pq.numWorkers = num
-
-	factory := func() internal.Consumer {
+	pq.StartConsumersWithFactory(num, func() internal.Consumer {
 		return internal.ConsumerFunc(callback)
-	}
+	})
+}
+
+// StartConsumersWithFactory creates a given number of consumers consuming items
+// from the queue in separate goroutines.
+func (pq *persistentQueue) StartConsumersWithFactory(num int, factory func() internal.Consumer) {
+	pq.numWorkers = num
 
 	for i := 0; i < pq.numWorkers; i++ {
 		pq.stopWG.Add(1)
@@ -90,4 +94,15 @@ func (pq *persistentQueue) Stop() {
 // Size returns the current depth of the queue, excluding the item already in the storage channel (if any)
 func (pq *persistentQueue) Size() int {
 	return int(pq.storage.size())
+}
+
+// Capacity returns the current capacity of persistent queue.
+// Currently, it is unlimited but in the future it can take into account available storage space or configured limits
+func (pq *persistentQueue) Capacity() int {
+	return pq.Size() + 1
+}
+
+// Resize changes the size of the queue. It has no effect in case of the Persistent Queue
+func (pq *persistentQueue) Resize(_ int) bool {
+	return true
 }

--- a/exporter/exporterhelper/persistent_queue_test.go
+++ b/exporter/exporterhelper/persistent_queue_test.go
@@ -43,7 +43,7 @@ func createTestQueue(extension storage.Extension, capacity int) *persistentQueue
 	}
 
 	wq := newPersistentQueue(context.Background(), "foo", capacity, logger, client, newTraceRequestUnmarshalerFunc(nopTracePusher()))
-	return wq
+	return wq.(*persistentQueue)
 }
 
 func TestPersistentQueue_Capacity(t *testing.T) {

--- a/exporter/exporterhelper/queued_retry_experimental.go
+++ b/exporter/exporterhelper/queued_retry_experimental.go
@@ -79,7 +79,7 @@ type queuedRetrySender struct {
 	signal             config.DataType
 	cfg                QueueSettings
 	consumerSender     requestSender
-	queue              consumersQueue
+	queue              internal.ProducerConsumerQueue
 	retryStopCh        chan struct{}
 	traceAttributes    []attribute.KeyValue
 	logger             *zap.Logger
@@ -120,7 +120,7 @@ func newQueuedRetrySender(id config.ComponentID, signal config.DataType, qCfg Qu
 	}
 
 	if !qCfg.PersistentStorageEnabled {
-		qrs.queue = internal.NewBoundedQueue(qrs.cfg.QueueSize, func(item interface{}) {})
+		qrs.queue = internal.NewBoundedMemoryQueue(qrs.cfg.QueueSize, func(item interface{}) {})
 	}
 	// The Persistent Queue is initialized separately as it needs extra information about the component
 

--- a/exporter/exporterhelper/queued_retry_inmemory.go
+++ b/exporter/exporterhelper/queued_retry_inmemory.go
@@ -61,7 +61,7 @@ type queuedRetrySender struct {
 	fullName        string
 	cfg             QueueSettings
 	consumerSender  requestSender
-	queue           consumersQueue
+	queue           internal.ProducerConsumerQueue
 	retryStopCh     chan struct{}
 	traceAttributes []attribute.KeyValue
 	logger          *zap.Logger
@@ -82,7 +82,7 @@ func newQueuedRetrySender(id config.ComponentID, _ config.DataType, qCfg QueueSe
 			logger:             sampledLogger,
 			onTemporaryFailure: onTemporaryFailure,
 		},
-		queue:           internal.NewBoundedQueue(qCfg.QueueSize, func(item interface{}) {}),
+		queue:           internal.NewBoundedMemoryQueue(qCfg.QueueSize, func(item interface{}) {}),
 		retryStopCh:     retryStopCh,
 		traceAttributes: []attribute.KeyValue{traceAttr},
 		logger:          sampledLogger,


### PR DESCRIPTION
This addresses one of the items raised in #4025 (move persistent_queue to internal). The overall refactor is broken into three parts:

* **Part 1**: extracting ProducerConsumerQueue interface out of BoundedQueue (so it could be later used for both memory-based and disk-based queues, preparing ground for Part 2) 👈    (this PR)
* **Part 2**: actual moving Persistent Queue into exporthelper/internal (this also requires exporting `internal.RequestUnmarshaller` and `internal.PersistentRequest`) [(link to draft PR)](https://github.com/open-telemetry/opentelemetry-collector/pull/4116)
* **Part 3**: including metrics on number of batches handled through persistent queue [(link to draft PR)](https://github.com/open-telemetry/opentelemetry-collector/pull/4117)

Link to tracking Issue: #4025

Testing: Unit tests updated, manual tests to follow