### PR TITLE
Rename consumererror.Permanent to consumererror.NewPermanent, consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Move configcheck.ValidateConfigFromFactories as internal function in service package (#3876)
 - Rename `configparser.Parser` as `config.Map` (#4075)
 - Rename `component.DefaultBuildInfo()` to `component.NewDefaultBuildInfo()` (#4129)
+- Rename consumererror.Permanent to consumererror.NewPermanent (#4118)
 
 ## 💡 Enhancements 💡
 

--- a/consumer/consumererror/combine_test.go
+++ b/consumer/consumererror/combine_test.go
@@ -53,7 +53,7 @@ func TestCombine(t *testing.T) {
 			errors: []error{
 				fmt.Errorf("foo"),
 				fmt.Errorf("bar"),
-				Permanent(fmt.Errorf("permanent"))},
+				NewPermanent(fmt.Errorf("permanent"))},
 			expected: "[foo; bar; Permanent error: permanent]",
 		},
 		{
@@ -99,7 +99,7 @@ func TestCombineContainsError(t *testing.T) {
 		err      error
 	}{
 		{contains: io.EOF, err: Combine([]error{errors.New("invalid entry"), io.EOF})},
-		{contains: io.EOF, err: Combine([]error{errors.New("invalid entry"), Permanent(io.EOF)})},
+		{contains: io.EOF, err: Combine([]error{errors.New("invalid entry"), NewPermanent(io.EOF)})},
 		{contains: io.EOF, err: Combine([]error{errors.New("foo"), errors.New("bar"), Combine([]error{errors.New("xyz"), io.EOF})})},
 	}
 

--- a/consumer/consumererror/permanent.go
+++ b/consumer/consumererror/permanent.go
@@ -22,9 +22,9 @@ type permanent struct {
 	err error
 }
 
-// Permanent wraps an error to indicate that it is a permanent error, i.e. an
+// NewPermanent wraps an error to indicate that it is a permanent error, i.e. an
 // error that will be always returned if its source receives the same inputs.
-func Permanent(err error) error {
+func NewPermanent(err error) error {
 	return permanent{err: err}
 }
 
@@ -37,7 +37,7 @@ func (p permanent) Unwrap() error {
 	return p.err
 }
 
-// IsPermanent checks if an error was wrapped with the Permanent function, which
+// IsPermanent checks if an error was wrapped with the NewPermanent function, which
 // is used to indicate that a given error will always be returned in the case
 // that its sources receives the same input.
 func IsPermanent(err error) bool {

--- a/consumer/consumererror/permanent_test.go
+++ b/consumer/consumererror/permanent_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -30,20 +31,18 @@ func (t testErrorType) Error() string {
 	return ""
 }
 
-func TestPermanent(t *testing.T) {
-	err := errors.New("testError")
-	require.False(t, IsPermanent(err))
+func TestIsPermanent(t *testing.T) {
+	var err error
+	assert.False(t, IsPermanent(err))
 
-	err = Permanent(err)
-	require.True(t, IsPermanent(err))
+	err = errors.New("testError")
+	assert.False(t, IsPermanent(err))
+
+	err = NewPermanent(err)
+	assert.True(t, IsPermanent(err))
 
 	err = fmt.Errorf("%w", err)
-	require.True(t, IsPermanent(err))
-}
-
-func TestIsPermanent_NilError(t *testing.T) {
-	var err error
-	require.False(t, IsPermanent(err))
+	assert.True(t, IsPermanent(err))
 }
 
 func TestPermanent_Unwrap(t *testing.T) {
@@ -51,7 +50,7 @@ func TestPermanent_Unwrap(t *testing.T) {
 	require.False(t, IsPermanent(err))
 
 	// Wrapping testErrorType err with permanent error.
-	permanentErr := Permanent(err)
+	permanentErr := NewPermanent(err)
 	require.True(t, IsPermanent(permanentErr))
 
 	target := testErrorType{}

--- a/exporter/exporterhelper/queued_retry_test.go
+++ b/exporter/exporterhelper/queued_retry_test.go
@@ -46,7 +46,7 @@ func mockRequestUnmarshaler(mr *mockRequest) requestUnmarshaler {
 func TestQueuedRetry_DropOnPermanentError(t *testing.T) {
 	qCfg := DefaultQueueSettings()
 	rCfg := DefaultRetrySettings()
-	mockR := newMockRequest(context.Background(), 2, consumererror.Permanent(errors.New("bad data")))
+	mockR := newMockRequest(context.Background(), 2, consumererror.NewPermanent(errors.New("bad data")))
 	be := newBaseExporter(&defaultExporterCfg, componenttest.NewNopExporterCreateSettings(), fromOptions(WithRetry(rCfg), WithQueue(qCfg)), "", mockRequestUnmarshaler(mockR))
 	ocs := newObservabilityConsumerSender(be.qrSender.consumerSender)
 	be.qrSender.consumerSender = ocs

--- a/exporter/otlpexporter/otlp.go
+++ b/exporter/otlpexporter/otlp.go
@@ -171,7 +171,7 @@ func processError(err error) error {
 
 	if !shouldRetry(st.Code()) {
 		// It is not a retryable error, we should not retry.
-		return consumererror.Permanent(err)
+		return consumererror.NewPermanent(err)
 	}
 
 	// Need to retry.

--- a/exporter/otlphttpexporter/otlp.go
+++ b/exporter/otlphttpexporter/otlp.go
@@ -98,7 +98,7 @@ func (e *exporter) pushTraces(ctx context.Context, td pdata.Traces) error {
 	tr.SetTraces(td)
 	request, err := tr.Marshal()
 	if err != nil {
-		return consumererror.Permanent(err)
+		return consumererror.NewPermanent(err)
 	}
 
 	return e.export(ctx, e.tracesURL, request)
@@ -109,7 +109,7 @@ func (e *exporter) pushMetrics(ctx context.Context, md pdata.Metrics) error {
 	tr.SetMetrics(md)
 	request, err := tr.Marshal()
 	if err != nil {
-		return consumererror.Permanent(err)
+		return consumererror.NewPermanent(err)
 	}
 	return e.export(ctx, e.metricsURL, request)
 }
@@ -119,7 +119,7 @@ func (e *exporter) pushLogs(ctx context.Context, ld pdata.Logs) error {
 	tr.SetLogs(ld)
 	request, err := tr.Marshal()
 	if err != nil {
-		return consumererror.Permanent(err)
+		return consumererror.NewPermanent(err)
 	}
 
 	return e.export(ctx, e.logsURL, request)
@@ -129,7 +129,7 @@ func (e *exporter) export(ctx context.Context, url string, request []byte) error
 	e.logger.Debug("Preparing to make HTTP request", zap.String("url", url))
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(request))
 	if err != nil {
-		return consumererror.Permanent(err)
+		return consumererror.NewPermanent(err)
 	}
 	req.Header.Set("Content-Type", "application/x-protobuf")
 
@@ -180,10 +180,10 @@ func (e *exporter) export(ctx context.Context, url string, request []byte) error
 
 	if resp.StatusCode == http.StatusBadRequest {
 		// Report the failure as permanent if the server thinks the request is malformed.
-		return consumererror.Permanent(formattedErr)
+		return consumererror.NewPermanent(formattedErr)
 	}
 
-	// All other errors are retryable, so don't wrap them in consumererror.Permanent().
+	// All other errors are retryable, so don't wrap them in consumererror.NewPermanent().
 	return formattedErr
 }
 


### PR DESCRIPTION
This also will allow us to expose the "permanent" type in the future if needed.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
