### PR TITLE
Deprecate consumererror.Combine, use go.uber.org/multierr

### DIFF
--- a/config/configtest/configtest.go
+++ b/config/configtest/configtest.go
@@ -20,10 +20,11 @@ import (
 	"regexp"
 	"strings"
 
+	"go.uber.org/multierr"
+
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/configunmarshaler"
-	"go.opentelemetry.io/collector/consumer/consumererror"
 )
 
 // The regular expression for valid config field tag.
@@ -71,21 +72,17 @@ func CheckConfigStruct(config interface{}) error {
 // If the type is a struct it goes to each of its fields to check for the proper
 // tags.
 func validateConfigDataType(t reflect.Type) error {
-	var errs []error
+	var errs error
 
 	switch t.Kind() {
 	case reflect.Ptr:
-		if err := validateConfigDataType(t.Elem()); err != nil {
-			errs = append(errs, err)
-		}
+		errs = multierr.Append(errs, validateConfigDataType(t.Elem()))
 	case reflect.Struct:
 		// Reflect on the pointed data and check each of its fields.
 		nf := t.NumField()
 		for i := 0; i < nf; i++ {
 			f := t.Field(i)
-			if err := checkStructFieldTags(f); err != nil {
-				errs = append(errs, err)
-			}
+			errs = multierr.Append(errs, checkStructFieldTags(f))
 		}
 	default:
 		// The config object can carry other types but they are not used when
@@ -94,12 +91,8 @@ func validateConfigDataType(t reflect.Type) error {
 		// reflect.UnsafePointer.
 	}
 
-	if err := consumererror.Combine(errs); err != nil {
-		return fmt.Errorf(
-			"type %q from package %q has invalid config settings: %v",
-			t.Name(),
-			t.PkgPath(),
-			err)
+	if errs != nil {
+		return fmt.Errorf("type %q from package %q has invalid config settings: %w", t.Name(), t.PkgPath(), errs)
 	}
 
 	return nil

--- a/consumer/consumererror/combine.go
+++ b/consumer/consumererror/combine.go
@@ -21,18 +21,19 @@ import (
 
 type combined []error
 
-var _ error = (*combined)(nil)
-
 func (c combined) Error() string {
-	var sb strings.Builder
-	length := len(c)
-	for i, err := range c {
-		sb.WriteString(err.Error())
-		if i != length-1 {
-			sb.WriteString("; ")
-		}
+	if len(c) == 0 {
+		return "[]"
 	}
-	return "[" + sb.String() + "]"
+	var sb strings.Builder
+	sb.WriteString("[")
+	sb.WriteString(c[0].Error())
+	for _, err := range c[1:] {
+		sb.WriteString("; ")
+		sb.WriteString(err.Error())
+	}
+	sb.WriteString("]")
+	return sb.String()
 }
 
 func (c combined) Is(target error) bool {
@@ -55,8 +56,7 @@ func (c combined) As(target interface{}) bool {
 
 // Combine converts a list of errors into one error.
 //
-// If any of the errors in errs are Permanent then the returned
-// error will also be Permanent.
+// Deprecated: Use alternative modules like "go.uber.org/multierr"
 func Combine(errs []error) error {
 	switch len(errs) {
 	case 0:

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v0.23.0
 	go.opentelemetry.io/otel/trace v1.0.0
 	go.uber.org/atomic v1.9.0
+	go.uber.org/multierr v1.6.0
 	go.uber.org/zap v1.19.1
 	golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1
 	google.golang.org/genproto v0.0.0-20210604141403-392c879c8b08
@@ -64,7 +65,6 @@ require (
 	github.com/tklauser/go-sysconf v0.3.5 // indirect
 	github.com/tklauser/numcpus v0.2.2 // indirect
 	go.opentelemetry.io/otel/internal/metric v0.23.0 // indirect
-	go.uber.org/multierr v1.6.0 // indirect
 	golang.org/x/net v0.0.0-20210614182718-04defd469f4e // indirect
 	golang.org/x/text v0.3.6 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect

--- a/receiver/scrapererror/scrapeerror.go
+++ b/receiver/scrapererror/scrapeerror.go
@@ -15,7 +15,7 @@
 package scrapererror
 
 import (
-	"go.opentelemetry.io/collector/consumer/consumererror"
+	"go.uber.org/multierr"
 )
 
 // ScrapeErrors contains multiple PartialScrapeErrors and can also contain generic errors.
@@ -45,9 +45,10 @@ func (s *ScrapeErrors) Combine() error {
 		}
 	}
 
+	combined := multierr.Combine(s.errs...)
 	if !partialScrapeErr {
-		return consumererror.Combine(s.errs)
+		return combined
 	}
 
-	return NewPartialScrapeError(consumererror.Combine(s.errs), s.failedScrapeCount)
+	return NewPartialScrapeError(combined, s.failedScrapeCount)
 }

--- a/receiver/scraperhelper/scrapercontroller.go
+++ b/receiver/scraperhelper/scrapercontroller.go
@@ -19,13 +19,13 @@ import (
 	"errors"
 	"time"
 
+	"go.uber.org/multierr"
 	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenterror"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/consumer"
-	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/model/pdata"
 	"go.opentelemetry.io/collector/obsreport"
 	"go.opentelemetry.io/collector/receiver/scrapererror"
@@ -142,14 +142,12 @@ func (sc *controller) Shutdown(ctx context.Context) error {
 		<-sc.terminated
 	}
 
-	var errs []error
+	var errs error
 	for _, scraper := range sc.scrapers {
-		if err := scraper.Shutdown(ctx); err != nil {
-			errs = append(errs, err)
-		}
+		errs = multierr.Append(errs, scraper.Shutdown(ctx))
 	}
 
-	return consumererror.Combine(errs)
+	return errs
 }
 
 // startScraping initiates a ticker that calls Scrape based on the configured

--- a/receiver/scraperhelper/scrapercontroller_test.go
+++ b/receiver/scraperhelper/scrapercontroller_test.go
@@ -27,13 +27,13 @@ import (
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"go.opentelemetry.io/otel/trace"
+	"go.uber.org/multierr"
 	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/consumer"
-	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/model/pdata"
 	"go.opentelemetry.io/collector/obsreport/obsreporttest"
@@ -321,15 +321,15 @@ func getExpectedStartErr(test metricsTestCase) error {
 }
 
 func getExpectedShutdownErr(test metricsTestCase) error {
-	var errs []error
+	var errs error
 
 	if test.closeErr != nil {
 		for i := 0; i < test.scrapers; i++ {
-			errs = append(errs, test.closeErr)
+			errs = multierr.Append(errs, test.closeErr)
 		}
 	}
 
-	return consumererror.Combine(errs)
+	return errs
 }
 
 func assertChannelsCalled(t *testing.T, chs []chan bool, message string) {

--- a/service/collector.go
+++ b/service/collector.go
@@ -30,12 +30,12 @@ import (
 	"go.opentelemetry.io/otel/metric"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/trace"
+	"go.uber.org/multierr"
 	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configunmarshaler"
 	"go.opentelemetry.io/collector/config/experimental/configsource"
-	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/extension/ballastextension"
 	"go.opentelemetry.io/collector/service/internal"
 	"go.opentelemetry.io/collector/service/internal/telemetrylogs"
@@ -237,30 +237,30 @@ func (col *Collector) Run(ctx context.Context) error {
 	col.runAndWaitForShutdownEvent()
 
 	// Accumulate errors and proceed with shutting down remaining components.
-	var errs []error
+	var errs error
 
 	// Begin shutdown sequence.
 	col.logger.Info("Starting shutdown...")
 
 	if err := col.set.ConfigMapProvider.Close(ctx); err != nil {
-		errs = append(errs, fmt.Errorf("failed to close config: %w", err))
+		errs = multierr.Append(errs, fmt.Errorf("failed to close config: %w", err))
 	}
 
 	if col.service != nil {
 		if err := col.service.Shutdown(ctx); err != nil {
-			errs = append(errs, fmt.Errorf("failed to shutdown service: %w", err))
+			errs = multierr.Append(errs, fmt.Errorf("failed to shutdown service: %w", err))
 		}
 	}
 
 	if err := collectorTelemetry.shutdown(); err != nil {
-		errs = append(errs, fmt.Errorf("failed to shutdown collector telemetry: %w", err))
+		errs = multierr.Append(errs, fmt.Errorf("failed to shutdown collector telemetry: %w", err))
 	}
 
 	col.logger.Info("Shutdown complete.")
 	col.stateChannel <- Closed
 	close(col.stateChannel)
 
-	return consumererror.Combine(errs)
+	return errs
 }
 
 // reloadService shutdowns the current col.service and setups a new one according

--- a/service/configcheck.go
+++ b/service/configcheck.go
@@ -15,36 +15,29 @@
 package service
 
 import (
+	"go.uber.org/multierr"
+
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configtest"
-	"go.opentelemetry.io/collector/consumer/consumererror"
 )
 
 // validateConfigFromFactories checks if all configurations for the given factories
 // are satisfying the patterns used by the collector.
 func validateConfigFromFactories(factories component.Factories) error {
-	var errs []error
+	var errs error
 
 	for _, factory := range factories.Receivers {
-		if err := configtest.CheckConfigStruct(factory.CreateDefaultConfig()); err != nil {
-			errs = append(errs, err)
-		}
+		errs = multierr.Append(errs, configtest.CheckConfigStruct(factory.CreateDefaultConfig()))
 	}
 	for _, factory := range factories.Processors {
-		if err := configtest.CheckConfigStruct(factory.CreateDefaultConfig()); err != nil {
-			errs = append(errs, err)
-		}
+		errs = multierr.Append(errs, configtest.CheckConfigStruct(factory.CreateDefaultConfig()))
 	}
 	for _, factory := range factories.Exporters {
-		if err := configtest.CheckConfigStruct(factory.CreateDefaultConfig()); err != nil {
-			errs = append(errs, err)
-		}
+		errs = multierr.Append(errs, configtest.CheckConfigStruct(factory.CreateDefaultConfig()))
 	}
 	for _, factory := range factories.Extensions {
-		if err := configtest.CheckConfigStruct(factory.CreateDefaultConfig()); err != nil {
-			errs = append(errs, err)
-		}
+		errs = multierr.Append(errs, configtest.CheckConfigStruct(factory.CreateDefaultConfig()))
 	}
 
-	return consumererror.Combine(errs)
+	return errs
 }

--- a/service/defaultcomponents/defaults.go
+++ b/service/defaultcomponents/defaults.go
@@ -16,8 +16,9 @@
 package defaultcomponents
 
 import (
+	"go.uber.org/multierr"
+
 	"go.opentelemetry.io/collector/component"
-	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/exporter/loggingexporter"
 	"go.opentelemetry.io/collector/exporter/otlpexporter"
 	"go.opentelemetry.io/collector/exporter/otlphttpexporter"
@@ -34,39 +35,31 @@ func Components() (
 	component.Factories,
 	error,
 ) {
-	var errs []error
+	var errs error
 
 	extensions, err := component.MakeExtensionFactoryMap(
 		zpagesextension.NewFactory(),
 		ballastextension.NewFactory(),
 	)
-	if err != nil {
-		errs = append(errs, err)
-	}
+	errs = multierr.Append(errs, err)
 
 	receivers, err := component.MakeReceiverFactoryMap(
 		otlpreceiver.NewFactory(),
 	)
-	if err != nil {
-		errs = append(errs, err)
-	}
+	errs = multierr.Append(errs, err)
 
 	exporters, err := component.MakeExporterFactoryMap(
 		loggingexporter.NewFactory(),
 		otlpexporter.NewFactory(),
 		otlphttpexporter.NewFactory(),
 	)
-	if err != nil {
-		errs = append(errs, err)
-	}
+	errs = multierr.Append(errs, err)
 
 	processors, err := component.MakeProcessorFactoryMap(
 		batchprocessor.NewFactory(),
 		memorylimiterprocessor.NewFactory(),
 	)
-	if err != nil {
-		errs = append(errs, err)
-	}
+	errs = multierr.Append(errs, err)
 
 	factories := component.Factories{
 		Extensions: extensions,
@@ -75,5 +68,5 @@ func Components() (
 		Exporters:  exporters,
 	}
 
-	return factories, consumererror.Combine(errs)
+	return factories, errs
 }

--- a/service/internal/builder/exporters_builder.go
+++ b/service/internal/builder/exporters_builder.go
@@ -18,12 +18,12 @@ import (
 	"context"
 	"fmt"
 
+	"go.uber.org/multierr"
 	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenterror"
 	"go.opentelemetry.io/collector/config"
-	"go.opentelemetry.io/collector/consumer/consumererror"
 )
 
 // builtExporter is an exporter that is built based on a config. It can have
@@ -35,28 +35,22 @@ type builtExporter struct {
 
 // Start the exporter.
 func (bexp *builtExporter) Start(ctx context.Context, host component.Host) error {
-	var errors []error
+	var errs error
 	for _, exporter := range bexp.expByDataType {
-		err := exporter.Start(ctx, host)
-		if err != nil {
-			errors = append(errors, err)
-		}
+		errs = multierr.Append(errs, exporter.Start(ctx, host))
 	}
 
-	return consumererror.Combine(errors)
+	return errs
 }
 
 // Shutdown the trace component and the metrics component of an exporter.
 func (bexp *builtExporter) Shutdown(ctx context.Context) error {
-	var errors []error
+	var errs error
 	for _, exporter := range bexp.expByDataType {
-		err := exporter.Shutdown(ctx)
-		if err != nil {
-			errors = append(errors, err)
-		}
+		errs = multierr.Append(errs, exporter.Shutdown(ctx))
 	}
 
-	return consumererror.Combine(errors)
+	return errs
 }
 
 func (bexp *builtExporter) getTracesExporter() component.TracesExporter {
@@ -101,15 +95,12 @@ func (exps Exporters) StartAll(ctx context.Context, host component.Host) error {
 
 // ShutdownAll stops all exporters.
 func (exps Exporters) ShutdownAll(ctx context.Context) error {
-	var errs []error
+	var errs error
 	for _, exp := range exps {
-		err := exp.Shutdown(ctx)
-		if err != nil {
-			errs = append(errs, err)
-		}
+		errs = multierr.Append(errs, exp.Shutdown(ctx))
 	}
 
-	return consumererror.Combine(errs)
+	return errs
 }
 
 func (exps Exporters) ToMapByDataType() map[config.DataType]map[config.ComponentID]component.Exporter {

--- a/service/internal/builder/receivers_builder.go
+++ b/service/internal/builder/receivers_builder.go
@@ -19,13 +19,13 @@ import (
 	"errors"
 	"fmt"
 
+	"go.uber.org/multierr"
 	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenterror"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/consumer"
-	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/service/internal/fanoutconsumer"
 )
 
@@ -53,15 +53,12 @@ type Receivers map[config.ComponentID]*builtReceiver
 
 // ShutdownAll stops all receivers.
 func (rcvs Receivers) ShutdownAll(ctx context.Context) error {
-	var errs []error
+	var err error
 	for _, rcv := range rcvs {
-		err := rcv.Shutdown(ctx)
-		if err != nil {
-			errs = append(errs, err)
-		}
+		err = multierr.Append(err, rcv.Shutdown(ctx))
 	}
 
-	return consumererror.Combine(errs)
+	return err
 }
 
 // StartAll starts all receivers.

--- a/service/parserprovider/merge.go
+++ b/service/parserprovider/merge.go
@@ -17,8 +17,9 @@ package parserprovider
 import (
 	"context"
 
+	"go.uber.org/multierr"
+
 	"go.opentelemetry.io/collector/config"
-	"go.opentelemetry.io/collector/consumer/consumererror"
 )
 
 // TODO: Add support to "merge" watchable interface.
@@ -49,12 +50,10 @@ func (mp *mergeMapProvider) Get(ctx context.Context) (*config.Map, error) {
 }
 
 func (mp *mergeMapProvider) Close(ctx context.Context) error {
-	var errs []error
+	var errs error
 	for _, p := range mp.providers {
-		if err := p.Close(ctx); err != nil {
-			errs = append(errs, err)
-		}
+		errs = multierr.Append(errs, p.Close(ctx))
 	}
 
-	return consumererror.Combine(errs)
+	return errs
 }


### PR DESCRIPTION
The functionality was added before the support for errors.Is/As was added to golang,
right now this is no longer needed and generic packages like go.uber.org/multierr are more user friendly.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
