### PR TITLE
exporter/exporthelper: extend trace submission timeout

### DIFF
--- a/exporter/exporterhelper/common.go
+++ b/exporter/exporterhelper/common.go
@@ -36,7 +36,7 @@ type TimeoutSettings struct {
 // DefaultTimeoutSettings returns the default settings for TimeoutSettings.
 func DefaultTimeoutSettings() TimeoutSettings {
 	return TimeoutSettings{
-		Timeout: 5 * time.Second,
+		Timeout: 10 * time.Second,
 	}
 }
 


### PR DESCRIPTION
The 5 second timeout is too low and is resulting in timeouts on trace
submission. This commit extends that timeout to 10 seconds.

Fixes #2353