### PR TITLE
Add version to the internal telemetry metrics

### DIFF
--- a/config/configtelemetry/configtelemetry.go
+++ b/config/configtelemetry/configtelemetry.go
@@ -40,6 +40,9 @@ const (
 
 const UseOpenTelemetryForInternalMetrics = false
 
+// indicates if the collector version tag should be added to all telemetry metrics
+const AddCollectorVersionTag = true
+
 var metricsLevelPtr = new(Level)
 
 // Flags is a helper function to add telemetry config flags to the service that exposes

--- a/config/configtelemetry/configtelemetry.go
+++ b/config/configtelemetry/configtelemetry.go
@@ -40,9 +40,6 @@ const (
 
 const UseOpenTelemetryForInternalMetrics = false
 
-// indicates if the collector version tag should be added to all telemetry metrics
-const AddCollectorVersionTag = true
-
 var metricsLevelPtr = new(Level)
 
 // Flags is a helper function to add telemetry config flags to the service that exposes


### PR DESCRIPTION
Added a version tag to the collector's own telemetry metrics because today when looking at those metrics there is no way to know the collector's version, this can also help to know what collector versions are running out there.
I based the "flag" to control this on [PR 3816](https://github.com/open-telemetry/opentelemetry-collector/pull/3816)