### PR TITLE
[Minor] Fixed receiverbuilder error log statement to include CreateLogsReceiver 

### DIFF
--- a/service/internal/builder/receivers_builder.go
+++ b/service/internal/builder/receivers_builder.go
@@ -214,8 +214,8 @@ func attachReceiverToPipelines(
 		if rcv.receiver != createdReceiver {
 			return fmt.Errorf(
 				"factory for %v is implemented incorrectly: "+
-					"CreateTracesReceiver and CreateMetricsReceiver must return the same "+
-					"receiver pointer when creating receivers of different data types",
+					"CreateTracesReceiver, CreateMetricsReceiver and CreateLogsReceiver must return " +
+					"the same receiver pointer when creating receivers of different data types",
 				cfg.ID(),
 			)
 		}


### PR DESCRIPTION
**Description:** Fixed the error log statement to include CreateLogsReceiver also needs to return the same receiver pointer

The current message only refers to CreateTracesReceiver, CreateMetricsReceiver and kind of got us bit confused when we we were (incorrectly) implementing a receiver that supports only logs and metrics.
 

**Testing:** 

Compilation is fine.
Ran the local tests/linting/gochecks