### PR TITLE
rename SetupRecordedMetricsTest -> SetupTelemetry

### DIFF
--- a/exporter/exporterhelper/logs_test.go
+++ b/exporter/exporterhelper/logs_test.go
@@ -125,7 +125,7 @@ func TestLogsExporter_WithRecordLogs_ReturnError(t *testing.T) {
 }
 
 func TestLogsExporter_WithRecordEnqueueFailedMetrics(t *testing.T) {
-	set, err := obsreporttest.SetupRecordedMetricsTest()
+	set, err := obsreporttest.SetupTelemetry()
 	require.NoError(t, err)
 	defer set.Shutdown(context.Background())
 
@@ -205,7 +205,7 @@ func newPushLogsData(retError error) consumerhelper.ConsumeLogsFunc {
 }
 
 func checkRecordedMetricsForLogsExporter(t *testing.T, le component.LogsExporter, wantError error) {
-	set, err := obsreporttest.SetupRecordedMetricsTest()
+	set, err := obsreporttest.SetupTelemetry()
 	require.NoError(t, err)
 	defer set.Shutdown(context.Background())
 

--- a/exporter/exporterhelper/metrics_test.go
+++ b/exporter/exporterhelper/metrics_test.go
@@ -124,7 +124,7 @@ func TestMetricsExporter_WithRecordMetrics_ReturnError(t *testing.T) {
 }
 
 func TestMetricsExporter_WithRecordEnqueueFailedMetrics(t *testing.T) {
-	set, err := obsreporttest.SetupRecordedMetricsTest()
+	set, err := obsreporttest.SetupTelemetry()
 	require.NoError(t, err)
 	defer set.Shutdown(context.Background())
 
@@ -206,7 +206,7 @@ func newPushMetricsData(retError error) consumerhelper.ConsumeMetricsFunc {
 }
 
 func checkRecordedMetricsForMetricsExporter(t *testing.T, me component.MetricsExporter, wantError error) {
-	set, err := obsreporttest.SetupRecordedMetricsTest()
+	set, err := obsreporttest.SetupTelemetry()
 	require.NoError(t, err)
 	defer set.Shutdown(context.Background())
 

--- a/exporter/exporterhelper/obsreport_test.go
+++ b/exporter/exporterhelper/obsreport_test.go
@@ -31,7 +31,7 @@ import (
 )
 
 func TestExportEnqueueFailure(t *testing.T) {
-	set, err := obsreporttest.SetupRecordedMetricsTest()
+	set, err := obsreporttest.SetupTelemetry()
 	require.NoError(t, err)
 	defer set.Shutdown(context.Background())
 
@@ -57,21 +57,21 @@ func TestExportEnqueueFailure(t *testing.T) {
 }
 
 // checkExporterEnqueueFailedTracesStats checks that reported number of spans failed to enqueue match given values.
-// When this function is called it is required to also call SetupRecordedMetricsTest as first thing.
+// When this function is called it is required to also call SetupTelemetry as first thing.
 func checkExporterEnqueueFailedTracesStats(t *testing.T, exporter config.ComponentID, spans int64) {
 	exporterTags := tagsForExporterView(exporter)
 	checkValueForView(t, exporterTags, spans, "exporter/enqueue_failed_spans")
 }
 
 // checkExporterEnqueueFailedMetricsStats checks that reported number of metric points failed to enqueue match given values.
-// When this function is called it is required to also call SetupRecordedMetricsTest as first thing.
+// When this function is called it is required to also call SetupTelemetry as first thing.
 func checkExporterEnqueueFailedMetricsStats(t *testing.T, exporter config.ComponentID, metricPoints int64) {
 	exporterTags := tagsForExporterView(exporter)
 	checkValueForView(t, exporterTags, metricPoints, "exporter/enqueue_failed_metric_points")
 }
 
 // checkExporterEnqueueFailedLogsStats checks that reported number of log records failed to enqueue match given values.
-// When this function is called it is required to also call SetupRecordedMetricsTest as first thing.
+// When this function is called it is required to also call SetupTelemetry as first thing.
 func checkExporterEnqueueFailedLogsStats(t *testing.T, exporter config.ComponentID, logRecords int64) {
 	exporterTags := tagsForExporterView(exporter)
 	checkValueForView(t, exporterTags, logRecords, "exporter/enqueue_failed_log_records")

--- a/exporter/exporterhelper/queued_retry_test.go
+++ b/exporter/exporterhelper/queued_retry_test.go
@@ -300,7 +300,7 @@ func TestQueuedRetry_DropOnFull(t *testing.T) {
 }
 
 func TestQueuedRetryHappyPath(t *testing.T) {
-	set, err := obsreporttest.SetupRecordedMetricsTest()
+	set, err := obsreporttest.SetupTelemetry()
 	require.NoError(t, err)
 	defer set.Shutdown(context.Background())
 

--- a/exporter/exporterhelper/traces_test.go
+++ b/exporter/exporterhelper/traces_test.go
@@ -122,7 +122,7 @@ func TestTracesExporter_WithRecordMetrics_ReturnError(t *testing.T) {
 }
 
 func TestTracesExporter_WithRecordEnqueueFailedMetrics(t *testing.T) {
-	set, err := obsreporttest.SetupRecordedMetricsTest()
+	set, err := obsreporttest.SetupTelemetry()
 	require.NoError(t, err)
 	defer set.Shutdown(context.Background())
 
@@ -206,7 +206,7 @@ func newTraceDataPusher(retError error) consumerhelper.ConsumeTracesFunc {
 }
 
 func checkRecordedMetricsForTracesExporter(t *testing.T, te component.TracesExporter, wantError error) {
-	set, err := obsreporttest.SetupRecordedMetricsTest()
+	set, err := obsreporttest.SetupTelemetry()
 	require.NoError(t, err)
 	defer set.Shutdown(context.Background())
 

--- a/obsreport/obsreport_test.go
+++ b/obsreport/obsreport_test.go
@@ -54,7 +54,7 @@ type testParams struct {
 }
 
 func TestReceiveTraceDataOp(t *testing.T) {
-	set, err := obsreporttest.SetupRecordedMetricsTest()
+	set, err := obsreporttest.SetupTelemetry()
 	require.NoError(t, err)
 	defer set.Shutdown(context.Background())
 
@@ -101,7 +101,7 @@ func TestReceiveTraceDataOp(t *testing.T) {
 }
 
 func TestReceiveLogsOp(t *testing.T) {
-	set, err := obsreporttest.SetupRecordedMetricsTest()
+	set, err := obsreporttest.SetupTelemetry()
 	require.NoError(t, err)
 	defer set.Shutdown(context.Background())
 
@@ -148,7 +148,7 @@ func TestReceiveLogsOp(t *testing.T) {
 }
 
 func TestReceiveMetricsOp(t *testing.T) {
-	set, err := obsreporttest.SetupRecordedMetricsTest()
+	set, err := obsreporttest.SetupTelemetry()
 	require.NoError(t, err)
 	defer set.Shutdown(context.Background())
 
@@ -196,7 +196,7 @@ func TestReceiveMetricsOp(t *testing.T) {
 }
 
 func TestScrapeMetricsDataOp(t *testing.T) {
-	set, err := obsreporttest.SetupRecordedMetricsTest()
+	set, err := obsreporttest.SetupTelemetry()
 	require.NoError(t, err)
 	defer set.Shutdown(context.Background())
 
@@ -253,7 +253,7 @@ func TestScrapeMetricsDataOp(t *testing.T) {
 }
 
 func TestExportTraceDataOp(t *testing.T) {
-	set, err := obsreporttest.SetupRecordedMetricsTest()
+	set, err := obsreporttest.SetupTelemetry()
 	require.NoError(t, err)
 	defer set.Shutdown(context.Background())
 
@@ -303,7 +303,7 @@ func TestExportTraceDataOp(t *testing.T) {
 }
 
 func TestExportMetricsOp(t *testing.T) {
-	set, err := obsreporttest.SetupRecordedMetricsTest()
+	set, err := obsreporttest.SetupTelemetry()
 	require.NoError(t, err)
 	defer set.Shutdown(context.Background())
 
@@ -354,7 +354,7 @@ func TestExportMetricsOp(t *testing.T) {
 }
 
 func TestExportLogsOp(t *testing.T) {
-	set, err := obsreporttest.SetupRecordedMetricsTest()
+	set, err := obsreporttest.SetupTelemetry()
 	require.NoError(t, err)
 	defer set.Shutdown(context.Background())
 
@@ -405,7 +405,7 @@ func TestExportLogsOp(t *testing.T) {
 }
 
 func TestReceiveWithLongLivedCtx(t *testing.T) {
-	set, err := obsreporttest.SetupRecordedMetricsTest()
+	set, err := obsreporttest.SetupTelemetry()
 	require.NoError(t, err)
 	defer set.Shutdown(context.Background())
 
@@ -456,7 +456,7 @@ func TestReceiveWithLongLivedCtx(t *testing.T) {
 }
 
 func TestProcessorTraceData(t *testing.T) {
-	set, err := obsreporttest.SetupRecordedMetricsTest()
+	set, err := obsreporttest.SetupTelemetry()
 	require.NoError(t, err)
 	defer set.Shutdown(context.Background())
 
@@ -477,7 +477,7 @@ func TestProcessorTraceData(t *testing.T) {
 }
 
 func TestProcessorMetricsData(t *testing.T) {
-	set, err := obsreporttest.SetupRecordedMetricsTest()
+	set, err := obsreporttest.SetupTelemetry()
 	require.NoError(t, err)
 	defer set.Shutdown(context.Background())
 
@@ -520,7 +520,7 @@ func TestBuildProcessorCustomMetricName(t *testing.T) {
 }
 
 func TestProcessorLogRecords(t *testing.T) {
-	set, err := obsreporttest.SetupRecordedMetricsTest()
+	set, err := obsreporttest.SetupTelemetry()
 	require.NoError(t, err)
 	defer set.Shutdown(context.Background())
 

--- a/obsreport/obsreporttest/obsreporttest.go
+++ b/obsreport/obsreporttest/obsreporttest.go
@@ -46,46 +46,46 @@ var (
 	processorTag, _ = tag.NewKey("processor")
 )
 
-type TestTelemetrySettings struct {
+type TestTelemetry struct {
 	component.TelemetrySettings
 	SpanRecorder *tracetest.SpanRecorder
 	views        []*view.View
 }
 
 // ToExporterCreateSettings returns ExporterCreateSettings with configured TelemetrySettings
-func (tts *TestTelemetrySettings) ToExporterCreateSettings() component.ExporterCreateSettings {
+func (tts *TestTelemetry) ToExporterCreateSettings() component.ExporterCreateSettings {
 	exporterSettings := componenttest.NewNopExporterCreateSettings()
 	exporterSettings.TelemetrySettings = tts.TelemetrySettings
 	return exporterSettings
 }
 
 // ToProcessorCreateSettings returns ProcessorCreateSettings with configured TelemetrySettings
-func (tts *TestTelemetrySettings) ToProcessorCreateSettings() component.ProcessorCreateSettings {
+func (tts *TestTelemetry) ToProcessorCreateSettings() component.ProcessorCreateSettings {
 	processorSettings := componenttest.NewNopProcessorCreateSettings()
 	processorSettings.TelemetrySettings = tts.TelemetrySettings
 	return processorSettings
 }
 
 // ToReceiverCreateSettings returns ReceiverCreateSettings with configured TelemetrySettings
-func (tts *TestTelemetrySettings) ToReceiverCreateSettings() component.ReceiverCreateSettings {
+func (tts *TestTelemetry) ToReceiverCreateSettings() component.ReceiverCreateSettings {
 	receiverSettings := componenttest.NewNopReceiverCreateSettings()
 	receiverSettings.TelemetrySettings = tts.TelemetrySettings
 	return receiverSettings
 }
 
 // Shutdown unregisters any views and shuts down the SpanRecorder
-func (tts *TestTelemetrySettings) Shutdown(ctx context.Context) error {
+func (tts *TestTelemetry) Shutdown(ctx context.Context) error {
 	view.Unregister(tts.views...)
 	return tts.SpanRecorder.Shutdown(ctx)
 }
 
 // SetupTelemetry does setup the testing environment to check the metrics recorded by receivers, producers or exporters.
-// The caller should defer a call to Shutdown the returned TestTelemetrySettings.
-func SetupTelemetry() (TestTelemetrySettings, error) {
+// The caller should defer a call to Shutdown the returned TestTelemetry.
+func SetupTelemetry() (TestTelemetry, error) {
 	sr := new(tracetest.SpanRecorder)
 	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
 
-	settings := TestTelemetrySettings{
+	settings := TestTelemetry{
 		TelemetrySettings: componenttest.NewNopTelemetrySettings(),
 		SpanRecorder:      sr,
 	}

--- a/obsreport/obsreporttest/obsreporttest.go
+++ b/obsreport/obsreporttest/obsreporttest.go
@@ -79,9 +79,9 @@ func (tts *TestTelemetrySettings) Shutdown(ctx context.Context) error {
 	return tts.SpanRecorder.Shutdown(ctx)
 }
 
-// SetupRecordedMetricsTest does setup the testing environment to check the metrics recorded by receivers, producers or exporters.
+// SetupTelemetry does setup the testing environment to check the metrics recorded by receivers, producers or exporters.
 // The caller should defer a call to Shutdown the returned TestTelemetrySettings.
-func SetupRecordedMetricsTest() (TestTelemetrySettings, error) {
+func SetupTelemetry() (TestTelemetrySettings, error) {
 	sr := new(tracetest.SpanRecorder)
 	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
 
@@ -101,7 +101,7 @@ func SetupRecordedMetricsTest() (TestTelemetrySettings, error) {
 }
 
 // CheckExporterTraces checks that for the current exported values for trace exporter metrics match given values.
-// When this function is called it is required to also call SetupRecordedMetricsTest as first thing.
+// When this function is called it is required to also call SetupTelemetry as first thing.
 func CheckExporterTraces(exporter config.ComponentID, acceptedSpans, droppedSpans int64) error {
 	exporterTags := tagsForExporterView(exporter)
 	if err := checkValueForView(exporterTags, acceptedSpans, "exporter/sent_spans"); err != nil {
@@ -111,7 +111,7 @@ func CheckExporterTraces(exporter config.ComponentID, acceptedSpans, droppedSpan
 }
 
 // CheckExporterMetrics checks that for the current exported values for metrics exporter metrics match given values.
-// When this function is called it is required to also call SetupRecordedMetricsTest as first thing.
+// When this function is called it is required to also call SetupTelemetry as first thing.
 func CheckExporterMetrics(exporter config.ComponentID, acceptedMetricsPoints, droppedMetricsPoints int64) error {
 	exporterTags := tagsForExporterView(exporter)
 	if err := checkValueForView(exporterTags, acceptedMetricsPoints, "exporter/sent_metric_points"); err != nil {
@@ -121,7 +121,7 @@ func CheckExporterMetrics(exporter config.ComponentID, acceptedMetricsPoints, dr
 }
 
 // CheckExporterLogs checks that for the current exported values for logs exporter metrics match given values.
-// When this function is called it is required to also call SetupRecordedMetricsTest as first thing.
+// When this function is called it is required to also call SetupTelemetry as first thing.
 func CheckExporterLogs(exporter config.ComponentID, acceptedLogRecords, droppedLogRecords int64) error {
 	exporterTags := tagsForExporterView(exporter)
 	if err := checkValueForView(exporterTags, acceptedLogRecords, "exporter/sent_log_records"); err != nil {
@@ -131,7 +131,7 @@ func CheckExporterLogs(exporter config.ComponentID, acceptedLogRecords, droppedL
 }
 
 // CheckProcessorTraces checks that for the current exported values for trace exporter metrics match given values.
-// When this function is called it is required to also call SetupRecordedMetricsTest as first thing.
+// When this function is called it is required to also call SetupTelemetry as first thing.
 func CheckProcessorTraces(processor config.ComponentID, acceptedSpans, refusedSpans, droppedSpans int64) error {
 	processorTags := tagsForProcessorView(processor)
 	if err := checkValueForView(processorTags, acceptedSpans, "processor/accepted_spans"); err != nil {
@@ -144,7 +144,7 @@ func CheckProcessorTraces(processor config.ComponentID, acceptedSpans, refusedSp
 }
 
 // CheckProcessorMetrics checks that for the current exported values for metrics exporter metrics match given values.
-// When this function is called it is required to also call SetupRecordedMetricsTest as first thing.
+// When this function is called it is required to also call SetupTelemetry as first thing.
 func CheckProcessorMetrics(processor config.ComponentID, acceptedMetricPoints, refusedMetricPoints, droppedMetricPoints int64) error {
 	processorTags := tagsForProcessorView(processor)
 	if err := checkValueForView(processorTags, acceptedMetricPoints, "processor/accepted_metric_points"); err != nil {
@@ -157,7 +157,7 @@ func CheckProcessorMetrics(processor config.ComponentID, acceptedMetricPoints, r
 }
 
 // CheckProcessorLogs checks that for the current exported values for logs exporter metrics match given values.
-// When this function is called it is required to also call SetupRecordedMetricsTest as first thing.
+// When this function is called it is required to also call SetupTelemetry as first thing.
 func CheckProcessorLogs(processor config.ComponentID, acceptedLogRecords, refusedLogRecords, droppedLogRecords int64) error {
 	processorTags := tagsForProcessorView(processor)
 	if err := checkValueForView(processorTags, acceptedLogRecords, "processor/accepted_log_records"); err != nil {
@@ -170,7 +170,7 @@ func CheckProcessorLogs(processor config.ComponentID, acceptedLogRecords, refuse
 }
 
 // CheckReceiverTraces checks that for the current exported values for trace receiver metrics match given values.
-// When this function is called it is required to also call SetupRecordedMetricsTest as first thing.
+// When this function is called it is required to also call SetupTelemetry as first thing.
 func CheckReceiverTraces(receiver config.ComponentID, protocol string, acceptedSpans, droppedSpans int64) error {
 	receiverTags := tagsForReceiverView(receiver, protocol)
 	if err := checkValueForView(receiverTags, acceptedSpans, "receiver/accepted_spans"); err != nil {
@@ -180,7 +180,7 @@ func CheckReceiverTraces(receiver config.ComponentID, protocol string, acceptedS
 }
 
 // CheckReceiverLogs checks that for the current exported values for logs receiver metrics match given values.
-// When this function is called it is required to also call SetupRecordedMetricsTest as first thing.
+// When this function is called it is required to also call SetupTelemetry as first thing.
 func CheckReceiverLogs(receiver config.ComponentID, protocol string, acceptedLogRecords, droppedLogRecords int64) error {
 	receiverTags := tagsForReceiverView(receiver, protocol)
 	if err := checkValueForView(receiverTags, acceptedLogRecords, "receiver/accepted_log_records"); err != nil {
@@ -190,7 +190,7 @@ func CheckReceiverLogs(receiver config.ComponentID, protocol string, acceptedLog
 }
 
 // CheckReceiverMetrics checks that for the current exported values for metrics receiver metrics match given values.
-// When this function is called it is required to also call SetupRecordedMetricsTest as first thing.
+// When this function is called it is required to also call SetupTelemetry as first thing.
 func CheckReceiverMetrics(receiver config.ComponentID, protocol string, acceptedMetricPoints, droppedMetricPoints int64) error {
 	receiverTags := tagsForReceiverView(receiver, protocol)
 	if err := checkValueForView(receiverTags, acceptedMetricPoints, "receiver/accepted_metric_points"); err != nil {
@@ -200,7 +200,7 @@ func CheckReceiverMetrics(receiver config.ComponentID, protocol string, accepted
 }
 
 // CheckScraperMetrics checks that for the current exported values for metrics scraper metrics match given values.
-// When this function is called it is required to also call SetupRecordedMetricsTest as first thing.
+// When this function is called it is required to also call SetupTelemetry as first thing.
 func CheckScraperMetrics(receiver config.ComponentID, scraper config.ComponentID, scrapedMetricPoints, erroredMetricPoints int64) error {
 	scraperTags := tagsForScraperView(receiver, scraper)
 	if err := checkValueForView(scraperTags, scrapedMetricPoints, "scraper/scraped_metric_points"); err != nil {

--- a/obsreport/obsreporttest/obsreporttest_test.go
+++ b/obsreport/obsreporttest/obsreporttest_test.go
@@ -38,7 +38,7 @@ var (
 )
 
 func TestCheckReceiverTracesViews(t *testing.T) {
-	set, err := obsreporttest.SetupRecordedMetricsTest()
+	set, err := obsreporttest.SetupTelemetry()
 	require.NoError(t, err)
 	defer set.Shutdown(context.Background())
 
@@ -55,7 +55,7 @@ func TestCheckReceiverTracesViews(t *testing.T) {
 }
 
 func TestCheckReceiverMetricsViews(t *testing.T) {
-	set, err := obsreporttest.SetupRecordedMetricsTest()
+	set, err := obsreporttest.SetupTelemetry()
 	require.NoError(t, err)
 	defer set.Shutdown(context.Background())
 
@@ -68,7 +68,7 @@ func TestCheckReceiverMetricsViews(t *testing.T) {
 }
 
 func TestCheckReceiverLogsViews(t *testing.T) {
-	set, err := obsreporttest.SetupRecordedMetricsTest()
+	set, err := obsreporttest.SetupTelemetry()
 	require.NoError(t, err)
 	defer set.Shutdown(context.Background())
 
@@ -81,7 +81,7 @@ func TestCheckReceiverLogsViews(t *testing.T) {
 }
 
 func TestCheckExporterTracesViews(t *testing.T) {
-	set, err := obsreporttest.SetupRecordedMetricsTest()
+	set, err := obsreporttest.SetupTelemetry()
 	require.NoError(t, err)
 	defer set.Shutdown(context.Background())
 
@@ -99,7 +99,7 @@ func TestCheckExporterTracesViews(t *testing.T) {
 }
 
 func TestCheckExporterMetricsViews(t *testing.T) {
-	set, err := obsreporttest.SetupRecordedMetricsTest()
+	set, err := obsreporttest.SetupTelemetry()
 	require.NoError(t, err)
 	defer set.Shutdown(context.Background())
 
@@ -117,7 +117,7 @@ func TestCheckExporterMetricsViews(t *testing.T) {
 }
 
 func TestCheckExporterLogsViews(t *testing.T) {
-	set, err := obsreporttest.SetupRecordedMetricsTest()
+	set, err := obsreporttest.SetupTelemetry()
 	require.NoError(t, err)
 	defer set.Shutdown(context.Background())
 

--- a/receiver/otlpreceiver/otlp_test.go
+++ b/receiver/otlpreceiver/otlp_test.go
@@ -506,7 +506,7 @@ func TestOTLPReceiverTrace_HandleNextConsumerResponse(t *testing.T) {
 	for _, exporter := range exporters {
 		for _, tt := range tests {
 			t.Run(tt.name+"/"+exporter.receiverTag, func(t *testing.T) {
-				set, err := obsreporttest.SetupRecordedMetricsTest()
+				set, err := obsreporttest.SetupTelemetry()
 				require.NoError(t, err)
 				defer set.Shutdown(context.Background())
 

--- a/receiver/scraperhelper/scrapercontroller_test.go
+++ b/receiver/scraperhelper/scrapercontroller_test.go
@@ -191,7 +191,7 @@ func TestScrapeController(t *testing.T) {
 			otel.SetTracerProvider(tp)
 			defer otel.SetTracerProvider(trace.NewNoopTracerProvider())
 
-			set, err := obsreporttest.SetupRecordedMetricsTest()
+			set, err := obsreporttest.SetupTelemetry()
 			require.NoError(t, err)
 			defer set.Shutdown(context.Background())
 


### PR DESCRIPTION
**Description:**
Updating a test method and struct:
* `SetupRecordedMetricsTest` -> `SetupTelemetry`
* `TestTelemetrySettings` -> `TestTelemetry`

Follow up to https://github.com/open-telemetry/opentelemetry-collector/pull/4093#discussion_r718770901
