### PR TITLE
Add more config parameters to HTTPClientSettings to be used by multiple http-based exporters

### DIFF
--- a/config/confighttp/README.md
+++ b/config/confighttp/README.md
@@ -20,6 +20,9 @@ README](../configtls/README.md).
 - [`read_buffer_size`](https://golang.org/pkg/net/http/#Transport)
 - [`timeout`](https://golang.org/pkg/net/http/#Client)
 - [`write_buffer_size`](https://golang.org/pkg/net/http/#Transport)
+- [`max_idle_conns`](https://golang.org/pkg/net/http/#Transport)
+- [`max_idle_conns_per_host`](https://golang.org/pkg/net/http/#Transport)
+- [`idle_conn_timeout`](https://golang.org/pkg/net/http/#Transport)
 
 Example:
 

--- a/config/confighttp/README.md
+++ b/config/confighttp/README.md
@@ -22,6 +22,7 @@ README](../configtls/README.md).
 - [`write_buffer_size`](https://golang.org/pkg/net/http/#Transport)
 - [`max_idle_conns`](https://golang.org/pkg/net/http/#Transport)
 - [`max_idle_conns_per_host`](https://golang.org/pkg/net/http/#Transport)
+- [`max_conns_per_host`](https://golang.org/pkg/net/http/#Transport)
 - [`idle_conn_timeout`](https://golang.org/pkg/net/http/#Transport)
 
 Example:

--- a/config/confighttp/confighttp.go
+++ b/config/confighttp/confighttp.go
@@ -65,6 +65,10 @@ type HTTPClientSettings struct {
 	// MaxIdleConnsPerHost is used to set a limit to the maximum idle HTTP connection the host can keep open.
 	MaxIdleConnsPerHost int `mapstructure:"max_idle_conns_per_host"`
 
+	// MaxConnsPerHost limits the total number of connections per host, including connections in the dialing,
+	// active, and idle states.
+	MaxConnsPerHost int `mapstructure:"max_conns_per_host"`
+
 	// IdleConnTimeout is the maximum amount of time a connection will remain open before closing itself.
 	IdleConnTimeout time.Duration `mapstructure:"idle_conn_timeout"`
 }
@@ -91,6 +95,7 @@ func (hcs *HTTPClientSettings) ToClient(ext map[config.ComponentID]component.Ext
 	}
 
 	transport.MaxIdleConnsPerHost = hcs.MaxIdleConnsPerHost
+	transport.MaxConnsPerHost = hcs.MaxConnsPerHost
 
 	if hcs.IdleConnTimeout != 0 {
 		transport.IdleConnTimeout = hcs.IdleConnTimeout

--- a/config/confighttp/confighttp.go
+++ b/config/confighttp/confighttp.go
@@ -59,10 +59,10 @@ type HTTPClientSettings struct {
 	// Auth configuration for outgoing HTTP calls.
 	Auth *configauth.Authentication `mapstructure:"auth,omitempty"`
 
-	// MaxIdleConns is used to set a limit to the maximum idle HTTP connection the client can keep open.
+	// MaxIdleConns is used to set a limit to the maximum idle HTTP connections the client can keep open.
 	MaxIdleConns *int `mapstructure:"max_idle_conns"`
 
-	// MaxIdleConnsPerHost is used to set a limit to the maximum idle HTTP connection the host can keep open.
+	// MaxIdleConnsPerHost is used to set a limit to the maximum idle HTTP connections the host can keep open.
 	MaxIdleConnsPerHost int `mapstructure:"max_idle_conns_per_host"`
 
 	// MaxConnsPerHost limits the total number of connections per host, including connections in the dialing,

--- a/config/confighttp/confighttp.go
+++ b/config/confighttp/confighttp.go
@@ -60,18 +60,20 @@ type HTTPClientSettings struct {
 	Auth *configauth.Authentication `mapstructure:"auth,omitempty"`
 
 	// MaxIdleConns is used to set a limit to the maximum idle HTTP connections the client can keep open.
-	// Here pointer is used to differentiate `no input` from `zero value input`
+	// There's an already set value, and we want to override it only if an explicit value provided
 	MaxIdleConns *int `mapstructure:"max_idle_conns"`
 
 	// MaxIdleConnsPerHost is used to set a limit to the maximum idle HTTP connections the host can keep open.
-	MaxIdleConnsPerHost int `mapstructure:"max_idle_conns_per_host"`
+	// There's an already set value, and we want to override it only if an explicit value provided
+	MaxIdleConnsPerHost *int `mapstructure:"max_idle_conns_per_host"`
 
 	// MaxConnsPerHost limits the total number of connections per host, including connections in the dialing,
 	// active, and idle states.
-	MaxConnsPerHost int `mapstructure:"max_conns_per_host"`
+	// There's an already set value, and we want to override it only if an explicit value provided
+	MaxConnsPerHost *int `mapstructure:"max_conns_per_host"`
 
 	// IdleConnTimeout is the maximum amount of time a connection will remain open before closing itself.
-	// Here pointer is used to differentiate `no input` from `zero value input`
+	// There's an already set value, and we want to override it only if an explicit value provided
 	IdleConnTimeout *time.Duration `mapstructure:"idle_conn_timeout"`
 }
 
@@ -96,8 +98,13 @@ func (hcs *HTTPClientSettings) ToClient(ext map[config.ComponentID]component.Ext
 		transport.MaxIdleConns = *hcs.MaxIdleConns
 	}
 
-	transport.MaxIdleConnsPerHost = hcs.MaxIdleConnsPerHost
-	transport.MaxConnsPerHost = hcs.MaxConnsPerHost
+	if hcs.MaxIdleConnsPerHost != nil {
+		transport.MaxIdleConnsPerHost = *hcs.MaxIdleConnsPerHost
+	}
+
+	if hcs.MaxConnsPerHost != nil {
+		transport.MaxConnsPerHost = *hcs.MaxConnsPerHost
+	}
 
 	if hcs.IdleConnTimeout != nil {
 		transport.IdleConnTimeout = *hcs.IdleConnTimeout

--- a/config/confighttp/confighttp.go
+++ b/config/confighttp/confighttp.go
@@ -60,6 +60,7 @@ type HTTPClientSettings struct {
 	Auth *configauth.Authentication `mapstructure:"auth,omitempty"`
 
 	// MaxIdleConns is used to set a limit to the maximum idle HTTP connections the client can keep open.
+	// Here pointer is used to differentiate `no input` from `zero value input`
 	MaxIdleConns *int `mapstructure:"max_idle_conns"`
 
 	// MaxIdleConnsPerHost is used to set a limit to the maximum idle HTTP connections the host can keep open.
@@ -70,6 +71,7 @@ type HTTPClientSettings struct {
 	MaxConnsPerHost int `mapstructure:"max_conns_per_host"`
 
 	// IdleConnTimeout is the maximum amount of time a connection will remain open before closing itself.
+	// Here pointer is used to differentiate `no input` from `zero value input`
 	IdleConnTimeout *time.Duration `mapstructure:"idle_conn_timeout"`
 }
 

--- a/config/confighttp/confighttp.go
+++ b/config/confighttp/confighttp.go
@@ -60,7 +60,7 @@ type HTTPClientSettings struct {
 	Auth *configauth.Authentication `mapstructure:"auth,omitempty"`
 
 	// MaxIdleConns is used to set a limit to the maximum idle HTTP connection the client can keep open.
-	MaxIdleConns int `mapstructure:"max_idle_conns"`
+	MaxIdleConns *int `mapstructure:"max_idle_conns"`
 
 	// MaxIdleConnsPerHost is used to set a limit to the maximum idle HTTP connection the host can keep open.
 	MaxIdleConnsPerHost int `mapstructure:"max_idle_conns_per_host"`
@@ -70,7 +70,7 @@ type HTTPClientSettings struct {
 	MaxConnsPerHost int `mapstructure:"max_conns_per_host"`
 
 	// IdleConnTimeout is the maximum amount of time a connection will remain open before closing itself.
-	IdleConnTimeout time.Duration `mapstructure:"idle_conn_timeout"`
+	IdleConnTimeout *time.Duration `mapstructure:"idle_conn_timeout"`
 }
 
 // ToClient creates an HTTP client.
@@ -90,15 +90,15 @@ func (hcs *HTTPClientSettings) ToClient(ext map[config.ComponentID]component.Ext
 		transport.WriteBufferSize = hcs.WriteBufferSize
 	}
 
-	if hcs.MaxIdleConns != 0 {
-		transport.MaxIdleConns = hcs.MaxIdleConns
+	if hcs.MaxIdleConns != nil {
+		transport.MaxIdleConns = *hcs.MaxIdleConns
 	}
 
 	transport.MaxIdleConnsPerHost = hcs.MaxIdleConnsPerHost
 	transport.MaxConnsPerHost = hcs.MaxConnsPerHost
 
-	if hcs.IdleConnTimeout != 0 {
-		transport.IdleConnTimeout = hcs.IdleConnTimeout
+	if hcs.IdleConnTimeout != nil {
+		transport.IdleConnTimeout = *hcs.IdleConnTimeout
 	}
 
 	clientTransport := (http.RoundTripper)(transport)

--- a/config/confighttp/confighttp.go
+++ b/config/confighttp/confighttp.go
@@ -16,7 +16,6 @@ package confighttp // import "go.opentelemetry.io/collector/config/confighttp"
 
 import (
 	"crypto/tls"
-	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -87,24 +86,13 @@ func (hcs *HTTPClientSettings) ToClient(ext map[config.ComponentID]component.Ext
 		transport.WriteBufferSize = hcs.WriteBufferSize
 	}
 
-	if hcs.MaxIdleConns < 0 {
-		return nil, errors.New(`cannot have a negative "max_idle_conns"`)
-	} else if hcs.MaxIdleConns > 0 {
+	if hcs.MaxIdleConns != 0 {
 		transport.MaxIdleConns = hcs.MaxIdleConns
 	}
 
-	if hcs.MaxIdleConnsPerHost < 0 {
-		return nil, errors.New(`cannot have a negative "max_idle_conns_per_host"`)
-	} else if hcs.MaxIdleConnsPerHost > 0 {
-		if hcs.MaxIdleConnsPerHost > hcs.MaxIdleConns {
-			return nil, errors.New(`"max_idle_conns_per_host" cannot be greater than "max_idle_conns"`)
-		}
-		transport.MaxIdleConnsPerHost = hcs.MaxIdleConnsPerHost
-	}
+	transport.MaxIdleConnsPerHost = hcs.MaxIdleConnsPerHost
 
-	if hcs.IdleConnTimeout < 0 {
-		return nil, errors.New(`cannot have a negative "idle_conn_timeout"`)
-	} else if hcs.IdleConnTimeout > 0 {
+	if hcs.IdleConnTimeout != 0 {
 		transport.IdleConnTimeout = hcs.IdleConnTimeout
 	}
 

--- a/config/confighttp/confighttp.go
+++ b/config/confighttp/confighttp.go
@@ -77,6 +77,21 @@ type HTTPClientSettings struct {
 	IdleConnTimeout *time.Duration `mapstructure:"idle_conn_timeout"`
 }
 
+// DefaultHTTPClientSettings returns HTTPClientSettings type object with
+// the default values of 'MaxIdleConns' and 'IdleConnTimeout'.
+// Other config options are not added as they are initialized with 'zero value' by GoLang as default.
+// We encourage to use this function to create an object of HTTPClientSettings.
+func DefaultHTTPClientSettings() HTTPClientSettings {
+	// The default values are taken from the values of 'DefaultTransport' of 'http' package.
+	maxIdleConns := 100
+	idleConnTimeout := 90 * time.Second
+
+	return HTTPClientSettings{
+		MaxIdleConns:    &maxIdleConns,
+		IdleConnTimeout: &idleConnTimeout,
+	}
+}
+
 // ToClient creates an HTTP client.
 func (hcs *HTTPClientSettings) ToClient(ext map[config.ComponentID]component.Extension) (*http.Client, error) {
 	tlsCfg, err := hcs.TLSSetting.LoadTLSConfig()

--- a/config/confighttp/confighttp_test.go
+++ b/config/confighttp/confighttp_test.go
@@ -149,6 +149,12 @@ func TestPartialHTTPClientSettings(t *testing.T) {
 	}
 }
 
+func TestDefaultHTTPClientSettings(t *testing.T) {
+	httpClientSettings := DefaultHTTPClientSettings()
+	assert.EqualValues(t, 100, *httpClientSettings.MaxIdleConns)
+	assert.EqualValues(t, 90*time.Second, *httpClientSettings.IdleConnTimeout)
+}
+
 func TestHTTPClientSettingsError(t *testing.T) {
 	tests := []struct {
 		settings HTTPClientSettings

--- a/config/confighttp/confighttp_test.go
+++ b/config/confighttp/confighttp_test.go
@@ -64,6 +64,7 @@ func TestAllHTTPClientSettings(t *testing.T) {
 				WriteBufferSize:     512,
 				MaxIdleConns:        50,
 				MaxIdleConnsPerHost: 40,
+				MaxConnsPerHost:     45,
 				IdleConnTimeout:     30 * time.Second,
 				CustomRoundTripper:  func(next http.RoundTripper) (http.RoundTripper, error) { return next, nil },
 			},
@@ -97,6 +98,7 @@ func TestAllHTTPClientSettings(t *testing.T) {
 			assert.EqualValues(t, 512, transport.WriteBufferSize)
 			assert.EqualValues(t, 50, transport.MaxIdleConns)
 			assert.EqualValues(t, 40, transport.MaxIdleConnsPerHost)
+			assert.EqualValues(t, 45, transport.MaxConnsPerHost)
 			assert.EqualValues(t, 30*time.Second, transport.IdleConnTimeout)
 		})
 	}

--- a/config/confighttp/confighttp_test.go
+++ b/config/confighttp/confighttp_test.go
@@ -140,59 +140,6 @@ func TestHTTPClientSettingsError(t *testing.T) {
 				Auth:     &configauth.Authentication{AuthenticatorID: config.NewComponentID("dummy")},
 			},
 		},
-		{
-			err: "cannot have a negative \"max_idle_conns\"",
-			settings: HTTPClientSettings{
-				Endpoint: "localhost:1234",
-				TLSSetting: &configtls.TLSClientSetting{
-					Insecure: false,
-				},
-				ReadBufferSize:     1024,
-				WriteBufferSize:    512,
-				MaxIdleConns:       -10,
-				CustomRoundTripper: func(next http.RoundTripper) (http.RoundTripper, error) { return next, nil },
-			},
-		},
-		{
-			err: "cannot have a negative \"max_idle_conns_per_host\"",
-			settings: HTTPClientSettings{
-				Endpoint: "localhost:1234",
-				TLSSetting: &configtls.TLSClientSetting{
-					Insecure: false,
-				},
-				ReadBufferSize:      1024,
-				WriteBufferSize:     512,
-				MaxIdleConnsPerHost: -10,
-				CustomRoundTripper:  func(next http.RoundTripper) (http.RoundTripper, error) { return next, nil },
-			},
-		},
-		{
-			err: "\"max_idle_conns_per_host\" cannot be greater than \"max_idle_conns\"",
-			settings: HTTPClientSettings{
-				Endpoint: "localhost:1234",
-				TLSSetting: &configtls.TLSClientSetting{
-					Insecure: false,
-				},
-				ReadBufferSize:      1024,
-				WriteBufferSize:     512,
-				MaxIdleConns:        40,
-				MaxIdleConnsPerHost: 50,
-				CustomRoundTripper:  func(next http.RoundTripper) (http.RoundTripper, error) { return next, nil },
-			},
-		},
-		{
-			err: "cannot have a negative \"idle_conn_timeout\"",
-			settings: HTTPClientSettings{
-				Endpoint: "localhost:1234",
-				TLSSetting: &configtls.TLSClientSetting{
-					Insecure: false,
-				},
-				ReadBufferSize:     1024,
-				WriteBufferSize:    512,
-				IdleConnTimeout:    -2 * time.Second,
-				CustomRoundTripper: func(next http.RoundTripper) (http.RoundTripper, error) { return next, nil },
-			},
-		},
 	}
 	for _, test := range tests {
 		t.Run(test.err, func(t *testing.T) {

--- a/config/confighttp/confighttp_test.go
+++ b/config/confighttp/confighttp_test.go
@@ -76,7 +76,7 @@ func TestAllHTTPClientSettings(t *testing.T) {
 			name: "error_round_tripper_returned",
 			settings: HTTPClientSettings{
 				Endpoint: "localhost:1234",
-				TLSSetting: &configtls.TLSClientSetting{
+				TLSSetting: configtls.TLSClientSetting{
 					Insecure: false,
 				},
 				ReadBufferSize:     1024,

--- a/config/confighttp/confighttp_test.go
+++ b/config/confighttp/confighttp_test.go
@@ -49,6 +49,8 @@ func TestAllHTTPClientSettings(t *testing.T) {
 		config.NewComponentID("testauth"): &configauth.MockClientAuthenticator{ResultRoundTripper: &customRoundTripper{}},
 	}
 	maxIdleConns := 50
+	maxIdleConnsPerHost := 40
+	maxConnsPerHost := 45
 	idleConnTimeout := 30 * time.Second
 	tests := []struct {
 		name        string
@@ -65,8 +67,8 @@ func TestAllHTTPClientSettings(t *testing.T) {
 				ReadBufferSize:      1024,
 				WriteBufferSize:     512,
 				MaxIdleConns:        &maxIdleConns,
-				MaxIdleConnsPerHost: 40,
-				MaxConnsPerHost:     45,
+				MaxIdleConnsPerHost: &maxIdleConnsPerHost,
+				MaxConnsPerHost:     &maxConnsPerHost,
 				IdleConnTimeout:     &idleConnTimeout,
 				CustomRoundTripper:  func(next http.RoundTripper) (http.RoundTripper, error) { return next, nil },
 			},


### PR DESCRIPTION
Add more config parameters to HTTPClientSettings to be used by multiple http-based exporters

**Description:** Added  3 more config parameters MaxIdleConns, MaxIdleConnsPerHost and IdleConnTimeout in HTTPClientSettings

**Link to tracking Issue:**  https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/5432#discussion_r716774048

**Testing:** All test cases are passing
