### PR TITLE
updating release documentation

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -2,13 +2,17 @@
 
 Collector build and testing is currently fully automated. However there are still certain operations that need to be performed manually in order to make a release.
 
-We release both core and contrib collectors with the same versions where the contrib release uses the core release as a dependency. We’ve divided this process into two sections. A release engineer must first release the Core collector and then the Contrib collector.
+We release both core and contrib collectors with the same versions where the contrib release uses the core release as a dependency. We’ve divided this process into four sections. A release engineer must release:
+1. The [Core](#releasing-opentelemetry-collector) collector.
+1. The [Contrib](#releasing-opentelemetry-collector-contrib) collector.
+1. The collector [Builder](#releasing-opentelemetry-collector-builder).
+1. The [artifacts](#producing-the-artifacts)
 
-Important: Note that you’ll need to be able to sign git commits/tags in order to be able to release a collector version. Follow [this guide](https://docs.github.com/en/github/authenticating-to-github/signing-commits) to setup it up.
+**Important Note:** You’ll need to be able to sign git commits/tags in order to be able to release a collector version. Follow [this guide](https://docs.github.com/en/github/authenticating-to-github/signing-commits) to setup it up.
 
-Note: You’ll need to be an approver for both the repos in order to be able to make the release. This is required as you’ll need to push tags and commits directly to the upstream repo.
+**Important Note:** You’ll need to be an approver for both the repos in order to be able to make the release. This is required as you’ll need to push tags and commits directly to the upstream repo.
 
-## Releasing OpenTelemetry Core
+## Releasing opentelemetry-collector
 
 1. Update Contrib to use the latest in development version of Core. Run `make update-otel` in Contrib root directory and if it results in any changes, submit a PR. Get the PR approved and merged. This is to ensure that the latest core does not break contrib in any way. We’ll update it once more to the final release number later. Make sure contrib builds and end-to-end tests pass successfully after being merged and -dev docker images are published.
 
@@ -22,11 +26,11 @@ Note: You’ll need to be an approver for both the repos in order to be able to 
 
 1. Create a branch named release/<release-series> (e.g. release/v0.4.x) in Core from the changelog update commit and push to origin (not your fork). Wait for the release branch builds to pass successfully.
 
-1. Tag all the modules with the new release version by running the `make add-tag` command (e.g. `make add-tag TAG=v0.4.0`). Push them to origin (not your fork) with `git push --tags origin` (assuming origin refers to upstream open-telemetry project). Wait for the new tag build to pass successfully. This build will push new docker images to https://hub.docker.com/repository/docker/otel/opentelemetry-collector, create a Github release for the tag and push all the build artifacts to the Github release.
+1. Tag all the modules with the new release version by running the `make add-tag` command (e.g. `make add-tag TAG=v0.4.0`). Push them to origin (not your fork) with `git push --tags origin` (assuming origin refers to upstream open-telemetry project). Wait for the new tag build to pass successfully.
 
-1. Edit the newly auto-created Github release and copy release notes from the CHANGELOG.md file to the release. This step should be automated. CI can pull the release notes from the change log and use it as the body when creating the new release.
+1. Create a new Github release from the new version tag and copy release notes from the CHANGELOG.md file to the release. This step should be automated. CI can pull the release notes from the change log and use it as the body when creating the new release.
 
-## Releasing OpenTelemetry Contrib
+## Releasing opentelemetry-collector-contrib
 
 1. Prepare Contrib for release. Update CHANGELOG.md file and rename the Unreleased section to the new release name. Add a new unreleased section at top. Refer to Core release notes (assuming the previous release of Core and Contrib was also performed simultaneously), and in addition to that list changes that happened in the Contrib repo.
 
@@ -34,6 +38,26 @@ Note: You’ll need to be an approver for both the repos in order to be able to 
 
 1. Create a branch named release/<release-series> (e.g. release/v0.4.x) in Core from the changelog update commit and push to origin (not your fork). Wait for the release branch builds to pass successfully.
 
-1. Tag all the modules with the new release version by running the `make add-tag` command (e.g. `make add-tag TAG=v0.4.0`). Push them to origin (not your fork) with `git push --tags origin` (assuming origin refers to upstream open-telemetry project). Wait for the new tag build to pass successfully. This build will push new docker images to https://hub.docker.com/repository/docker/otel/opentelemetry-collector-contrib, create a Github release for the tag and push all the build artifacts to the Github release.
+1. Tag all the modules with the new release version by running the `make add-tag` command (e.g. `make add-tag TAG=v0.4.0`). Push them to origin (not your fork) with `git push --tags origin` (assuming origin refers to upstream open-telemetry project).
 
-1. Edit the newly auto-created Github release and copy release notes from the CHANGELOG.md file to the release. This step should be automated. CI can pull the release notes from the change log and use it as the body when creating the new release.
+1. Create a new Github release from the new version tag and copy release notes from the CHANGELOG.md file to the release. This step should be automated. CI can pull the release notes from the change log and use it as the body when creating the new release.
+
+## Releasing opentelemetry-collector-builder
+
+The collector release process uses the `opentelemetry-collector-builder` to produce the artifacts of the collector. This may require that the `opentelemetry-collector-builder` be updated to support new features. If so, follow these steps using the [opentelemetry-collector-builder](https://github.com/open-telemetry/opentelemetry-collector-builder) repo:
+
+1. Update the collector version to the new release in `./internal/builder/config.go`
+
+1. Create a pull request with the change and ensure the build completes successfully.
+
+## Producing the artifacts
+
+The last step of the release process creates artifacts for the new version of the collector and publishes images to Dockerhub. The steps in this portion of the release are done in the [opentelemetry-collector-releases](https://github.com/open-telemetry/opentelemetry-collector-releases) repo.
+
+1. Update `./distribution/otelcol/manifest.yaml` to include the new release version.
+
+1. If a new version of the builder has been created, update the builder version in `OTELCOL_BUILDER_VERSION` to the new release in the `Makefile`.
+
+1. Create a pull request with the change and ensure the build completes successfully. See [example](https://github.com/open-telemetry/opentelemetry-collector-releases/pull/17/files).
+
+1. Ensure the "Release" action passes, this will push new docker images to https://hub.docker.com/repository/docker/otel/opentelemetry-collector-contrib, create a Github release for the tag and push all the build artifacts to the Github release. See [example](https://github.com/open-telemetry/opentelemetry-collector-releases/actions/runs/1346637081).


### PR DESCRIPTION
Adding some of the missing steps in the release documentation specifically around the build and the release repositories. 

There's still some documentation around `multimod` missing. @Aneurysm9 suggested he may be interested in adding that.