### PR TITLE
Update name of `k8sattributes` processor on documentation

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -13,7 +13,7 @@ Metrics correctness tests|In progress|[#652](https://github.com/open-telemetry/o
 | |
 **New Formats**|
 Complete OTLP/HTTP support| |[#882](https://github.com/open-telemetry/opentelemetry-collector/issues/882)
-Add logs support for all primary core processors (attributes, batch, k8s_tagger, etc)|In progress|
+Add logs support for all primary core processors (attributes, batch, k8sattributes, etc)|In progress|
 | |
 **5 Min to Value**|
 Distribution packages for most common targets (e.g. Docker, RPM, Windows, etc)|

--- a/processor/README.md
+++ b/processor/README.md
@@ -31,14 +31,14 @@ processor documentation for more information.
 
 1. [memory_limiter](memorylimiterprocessor/README.md)
 2. *any sampling processors*
-3. Any processor relying on sending source from `Context` (e.g. `k8s_tagger`)
+3. Any processor relying on sending source from `Context` (e.g. `k8sattributes`)
 3. [batch](batchprocessor/README.md)
 4. *any other processors*
 
 ### Metrics
 
 1. [memory_limiter](memorylimiterprocessor/README.md)
-2. Any processor relying on sending source from `Context` (e.g. `k8s_tagger`)
+2. Any processor relying on sending source from `Context` (e.g. `k8sattributes`)
 3. [batch](batchprocessor/README.md)
 4. *any other processors*
 


### PR DESCRIPTION
**Description:**

Replace references of `k8s_tagger` by `k8sattributes` after open-telemetry/opentelemetry-collector-contrib#5384.
