### PR TITLE
Extract client IP address and store it into context for OTLP/HTTP

### DIFF
--- a/receiver/otlpreceiver/otlphttp.go
+++ b/receiver/otlpreceiver/otlphttp.go
@@ -22,6 +22,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"go.opentelemetry.io/collector/client"
 	"go.opentelemetry.io/collector/receiver/otlpreceiver/internal/logs"
 	"go.opentelemetry.io/collector/receiver/otlpreceiver/internal/metrics"
 	"go.opentelemetry.io/collector/receiver/otlpreceiver/internal/trace"
@@ -44,7 +45,12 @@ func handleTraces(resp http.ResponseWriter, req *http.Request, tracesReceiver *t
 		return
 	}
 
-	otlpResp, err := tracesReceiver.Export(req.Context(), otlpReq)
+	ctx := req.Context()
+	if c, ok := client.FromHTTP(req); ok {
+		ctx = client.NewContext(ctx, c)
+	}
+
+	otlpResp, err := tracesReceiver.Export(ctx, otlpReq)
 	if err != nil {
 		writeError(resp, encoder, err, http.StatusInternalServerError)
 		return
@@ -70,7 +76,12 @@ func handleMetrics(resp http.ResponseWriter, req *http.Request, metricsReceiver 
 		return
 	}
 
-	otlpResp, err := metricsReceiver.Export(req.Context(), otlpReq)
+	ctx := req.Context()
+	if c, ok := client.FromHTTP(req); ok {
+		ctx = client.NewContext(ctx, c)
+	}
+
+	otlpResp, err := metricsReceiver.Export(ctx, otlpReq)
 	if err != nil {
 		writeError(resp, encoder, err, http.StatusInternalServerError)
 		return
@@ -96,7 +107,12 @@ func handleLogs(resp http.ResponseWriter, req *http.Request, logsReceiver *logs.
 		return
 	}
 
-	otlpResp, err := logsReceiver.Export(req.Context(), otlpReq)
+	ctx := req.Context()
+	if c, ok := client.FromHTTP(req); ok {
+		ctx = client.NewContext(ctx, c)
+	}
+
+	otlpResp, err := logsReceiver.Export(ctx, otlpReq)
 	if err != nil {
 		writeError(resp, encoder, err, http.StatusInternalServerError)
 		return


### PR DESCRIPTION
**Description:** 

Fixes otlphttp receiver so it adds information about the source IP into the context

*Context:* For [k8sattributesprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/k8sattributesprocessor) the source IP is frequently required to [associate](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/8e6ad2e54b52d5d3b061483589eb5e8256155469/processor/k8sattributesprocessor/pod_association.go#L37) the source with a given pod. This bug is emphasised now since SDK's are now encouraged to switch from gRPC to HTTP

**Link to tracking Issue:** #4256 

**Testing:** Tested manually. I considered extending unit tests to cover this case, though I believe it would required including Context (as an array or the last one) in `consumertest.TracesSink` and I wasn't sure if it's a right thing to do.

**Documentation:** Not changed