### PR TITLE
Make sure otlphttp exporter tests include TraceID and SpanID

### DIFF
--- a/internal/testdata/trace.go
+++ b/internal/testdata/trace.go
@@ -101,6 +101,8 @@ func fillSpanOne(span pdata.Span) {
 	span.SetStartTimestamp(TestSpanStartTimestamp)
 	span.SetEndTimestamp(TestSpanEndTimestamp)
 	span.SetDroppedAttributesCount(1)
+	span.SetTraceID(pdata.NewTraceID([16]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10}))
+	span.SetSpanID(pdata.NewSpanID([8]byte{0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18}))
 	evs := span.Events()
 	ev0 := evs.AppendEmpty()
 	ev0.SetTimestamp(TestSpanEventTimestamp)


### PR DESCRIPTION
Related to https://github.com/open-telemetry/opentelemetry-collector/issues/4221

There was a report that TraceID and SpanID are correupted by otlphttp exporter.
I added to TraceID and SpanID to try to reproduce the bug. The bug is not reproduced
but keeping these in the test is useful.
