### PR TITLE
nit: clean up test variable names

### DIFF
--- a/exporter/exporterhelper/logs_test.go
+++ b/exporter/exporterhelper/logs_test.go
@@ -125,16 +125,16 @@ func TestLogsExporter_WithRecordLogs_ReturnError(t *testing.T) {
 }
 
 func TestLogsExporter_WithRecordEnqueueFailedMetrics(t *testing.T) {
-	set, err := obsreporttest.SetupTelemetry()
+	tt, err := obsreporttest.SetupTelemetry()
 	require.NoError(t, err)
-	defer set.Shutdown(context.Background())
+	defer tt.Shutdown(context.Background())
 
 	rCfg := DefaultRetrySettings()
 	qCfg := DefaultQueueSettings()
 	qCfg.NumConsumers = 1
 	qCfg.QueueSize = 2
 	wantErr := errors.New("some-error")
-	te, err := NewLogsExporter(&fakeLogsExporterConfig, set.ToExporterCreateSettings(), newPushLogsData(wantErr), WithRetry(rCfg), WithQueue(qCfg))
+	te, err := NewLogsExporter(&fakeLogsExporterConfig, tt.ToExporterCreateSettings(), newPushLogsData(wantErr), WithRetry(rCfg), WithQueue(qCfg))
 	require.NoError(t, err)
 	require.NotNil(t, te)
 
@@ -205,9 +205,9 @@ func newPushLogsData(retError error) consumerhelper.ConsumeLogsFunc {
 }
 
 func checkRecordedMetricsForLogsExporter(t *testing.T, le component.LogsExporter, wantError error) {
-	set, err := obsreporttest.SetupTelemetry()
+	tt, err := obsreporttest.SetupTelemetry()
 	require.NoError(t, err)
-	defer set.Shutdown(context.Background())
+	defer tt.Shutdown(context.Background())
 
 	ld := testdata.GenerateLogsTwoLogRecordsSameResource()
 	const numBatches = 7

--- a/exporter/exporterhelper/metrics_test.go
+++ b/exporter/exporterhelper/metrics_test.go
@@ -124,16 +124,16 @@ func TestMetricsExporter_WithRecordMetrics_ReturnError(t *testing.T) {
 }
 
 func TestMetricsExporter_WithRecordEnqueueFailedMetrics(t *testing.T) {
-	set, err := obsreporttest.SetupTelemetry()
+	tt, err := obsreporttest.SetupTelemetry()
 	require.NoError(t, err)
-	defer set.Shutdown(context.Background())
+	defer tt.Shutdown(context.Background())
 
 	rCfg := DefaultRetrySettings()
 	qCfg := DefaultQueueSettings()
 	qCfg.NumConsumers = 1
 	qCfg.QueueSize = 2
 	wantErr := errors.New("some-error")
-	te, err := NewMetricsExporter(&fakeMetricsExporterConfig, set.ToExporterCreateSettings(), newPushMetricsData(wantErr), WithRetry(rCfg), WithQueue(qCfg))
+	te, err := NewMetricsExporter(&fakeMetricsExporterConfig, tt.ToExporterCreateSettings(), newPushMetricsData(wantErr), WithRetry(rCfg), WithQueue(qCfg))
 	require.NoError(t, err)
 	require.NotNil(t, te)
 
@@ -206,9 +206,9 @@ func newPushMetricsData(retError error) consumerhelper.ConsumeMetricsFunc {
 }
 
 func checkRecordedMetricsForMetricsExporter(t *testing.T, me component.MetricsExporter, wantError error) {
-	set, err := obsreporttest.SetupTelemetry()
+	tt, err := obsreporttest.SetupTelemetry()
 	require.NoError(t, err)
-	defer set.Shutdown(context.Background())
+	defer tt.Shutdown(context.Background())
 
 	md := testdata.GenerateMetricsTwoMetrics()
 	const numBatches = 7

--- a/exporter/exporterhelper/obsreport_test.go
+++ b/exporter/exporterhelper/obsreport_test.go
@@ -29,9 +29,9 @@ import (
 )
 
 func TestExportEnqueueFailure(t *testing.T) {
-	set, err := obsreporttest.SetupTelemetry()
+	tt, err := obsreporttest.SetupTelemetry()
 	require.NoError(t, err)
-	defer set.Shutdown(context.Background())
+	defer tt.Shutdown(context.Background())
 
 	exporter := config.NewComponentID("fakeExporter")
 
@@ -39,7 +39,7 @@ func TestExportEnqueueFailure(t *testing.T) {
 	obsrep := newObsExporter(obsreport.ExporterSettings{
 		Level:                  configtelemetry.LevelNormal,
 		ExporterID:             exporter,
-		ExporterCreateSettings: set.ToExporterCreateSettings(),
+		ExporterCreateSettings: tt.ToExporterCreateSettings(),
 	}, insts)
 
 	logRecords := int64(7)

--- a/exporter/exporterhelper/queued_retry_test.go
+++ b/exporter/exporterhelper/queued_retry_test.go
@@ -300,13 +300,13 @@ func TestQueuedRetry_DropOnFull(t *testing.T) {
 }
 
 func TestQueuedRetryHappyPath(t *testing.T) {
-	set, err := obsreporttest.SetupTelemetry()
+	tt, err := obsreporttest.SetupTelemetry()
 	require.NoError(t, err)
-	defer set.Shutdown(context.Background())
+	defer tt.Shutdown(context.Background())
 
 	qCfg := DefaultQueueSettings()
 	rCfg := DefaultRetrySettings()
-	be := newBaseExporter(&defaultExporterCfg, set.ToExporterCreateSettings(), fromOptions(WithRetry(rCfg), WithQueue(qCfg)), "", nopRequestUnmarshaler())
+	be := newBaseExporter(&defaultExporterCfg, tt.ToExporterCreateSettings(), fromOptions(WithRetry(rCfg), WithQueue(qCfg)), "", nopRequestUnmarshaler())
 	ocs := newObservabilityConsumerSender(be.qrSender.consumerSender)
 	be.qrSender.consumerSender = ocs
 	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))

--- a/exporter/exporterhelper/traces_test.go
+++ b/exporter/exporterhelper/traces_test.go
@@ -122,16 +122,16 @@ func TestTracesExporter_WithRecordMetrics_ReturnError(t *testing.T) {
 }
 
 func TestTracesExporter_WithRecordEnqueueFailedMetrics(t *testing.T) {
-	set, err := obsreporttest.SetupTelemetry()
+	tt, err := obsreporttest.SetupTelemetry()
 	require.NoError(t, err)
-	defer set.Shutdown(context.Background())
+	defer tt.Shutdown(context.Background())
 
 	rCfg := DefaultRetrySettings()
 	qCfg := DefaultQueueSettings()
 	qCfg.NumConsumers = 1
 	qCfg.QueueSize = 2
 	wantErr := errors.New("some-error")
-	te, err := NewTracesExporter(&fakeTracesExporterConfig, set.ToExporterCreateSettings(), newTraceDataPusher(wantErr), WithRetry(rCfg), WithQueue(qCfg))
+	te, err := NewTracesExporter(&fakeTracesExporterConfig, tt.ToExporterCreateSettings(), newTraceDataPusher(wantErr), WithRetry(rCfg), WithQueue(qCfg))
 	require.NoError(t, err)
 	require.NotNil(t, te)
 
@@ -206,9 +206,9 @@ func newTraceDataPusher(retError error) consumerhelper.ConsumeTracesFunc {
 }
 
 func checkRecordedMetricsForTracesExporter(t *testing.T, te component.TracesExporter, wantError error) {
-	set, err := obsreporttest.SetupTelemetry()
+	tt, err := obsreporttest.SetupTelemetry()
 	require.NoError(t, err)
-	defer set.Shutdown(context.Background())
+	defer tt.Shutdown(context.Background())
 
 	td := testdata.GenerateTracesTwoSpansSameResource()
 	const numBatches = 7

--- a/obsreport/obsreport_test.go
+++ b/obsreport/obsreport_test.go
@@ -52,11 +52,11 @@ type testParams struct {
 }
 
 func TestReceiveTraceDataOp(t *testing.T) {
-	set, err := obsreporttest.SetupTelemetry()
+	tt, err := obsreporttest.SetupTelemetry()
 	require.NoError(t, err)
-	defer set.Shutdown(context.Background())
+	defer tt.Shutdown(context.Background())
 
-	parentCtx, parentSpan := set.TracerProvider.Tracer("test").Start(context.Background(), t.Name())
+	parentCtx, parentSpan := tt.TracerProvider.Tracer("test").Start(context.Background(), t.Name())
 	defer parentSpan.End()
 
 	params := []testParams{
@@ -67,14 +67,14 @@ func TestReceiveTraceDataOp(t *testing.T) {
 		rec := NewReceiver(ReceiverSettings{
 			ReceiverID:             receiver,
 			Transport:              transport,
-			ReceiverCreateSettings: set.ToReceiverCreateSettings(),
+			ReceiverCreateSettings: tt.ToReceiverCreateSettings(),
 		})
 		ctx := rec.StartTracesOp(parentCtx)
 		assert.NotNil(t, ctx)
 		rec.EndTracesOp(ctx, format, params[i].items, param.err)
 	}
 
-	spans := set.SpanRecorder.Ended()
+	spans := tt.SpanRecorder.Ended()
 	require.Equal(t, len(params), len(spans))
 
 	var acceptedSpans, refusedSpans int
@@ -100,11 +100,11 @@ func TestReceiveTraceDataOp(t *testing.T) {
 }
 
 func TestReceiveLogsOp(t *testing.T) {
-	set, err := obsreporttest.SetupTelemetry()
+	tt, err := obsreporttest.SetupTelemetry()
 	require.NoError(t, err)
-	defer set.Shutdown(context.Background())
+	defer tt.Shutdown(context.Background())
 
-	parentCtx, parentSpan := set.TracerProvider.Tracer("test").Start(context.Background(), t.Name())
+	parentCtx, parentSpan := tt.TracerProvider.Tracer("test").Start(context.Background(), t.Name())
 	defer parentSpan.End()
 
 	params := []testParams{
@@ -115,14 +115,14 @@ func TestReceiveLogsOp(t *testing.T) {
 		rec := NewReceiver(ReceiverSettings{
 			ReceiverID:             receiver,
 			Transport:              transport,
-			ReceiverCreateSettings: set.ToReceiverCreateSettings(),
+			ReceiverCreateSettings: tt.ToReceiverCreateSettings(),
 		})
 		ctx := rec.StartLogsOp(parentCtx)
 		assert.NotNil(t, ctx)
 		rec.EndLogsOp(ctx, format, params[i].items, param.err)
 	}
 
-	spans := set.SpanRecorder.Ended()
+	spans := tt.SpanRecorder.Ended()
 	require.Equal(t, len(params), len(spans))
 
 	var acceptedLogRecords, refusedLogRecords int
@@ -148,11 +148,11 @@ func TestReceiveLogsOp(t *testing.T) {
 }
 
 func TestReceiveMetricsOp(t *testing.T) {
-	set, err := obsreporttest.SetupTelemetry()
+	tt, err := obsreporttest.SetupTelemetry()
 	require.NoError(t, err)
-	defer set.Shutdown(context.Background())
+	defer tt.Shutdown(context.Background())
 
-	parentCtx, parentSpan := set.TracerProvider.Tracer("test").Start(context.Background(), t.Name())
+	parentCtx, parentSpan := tt.TracerProvider.Tracer("test").Start(context.Background(), t.Name())
 	defer parentSpan.End()
 
 	params := []testParams{
@@ -163,14 +163,14 @@ func TestReceiveMetricsOp(t *testing.T) {
 		rec := NewReceiver(ReceiverSettings{
 			ReceiverID:             receiver,
 			Transport:              transport,
-			ReceiverCreateSettings: set.ToReceiverCreateSettings(),
+			ReceiverCreateSettings: tt.ToReceiverCreateSettings(),
 		})
 		ctx := rec.StartMetricsOp(parentCtx)
 		assert.NotNil(t, ctx)
 		rec.EndMetricsOp(ctx, format, params[i].items, param.err)
 	}
 
-	spans := set.SpanRecorder.Ended()
+	spans := tt.SpanRecorder.Ended()
 	require.Equal(t, len(params), len(spans))
 
 	var acceptedMetricPoints, refusedMetricPoints int
@@ -197,11 +197,11 @@ func TestReceiveMetricsOp(t *testing.T) {
 }
 
 func TestScrapeMetricsDataOp(t *testing.T) {
-	set, err := obsreporttest.SetupTelemetry()
+	tt, err := obsreporttest.SetupTelemetry()
 	require.NoError(t, err)
-	defer set.Shutdown(context.Background())
+	defer tt.Shutdown(context.Background())
 
-	parentCtx, parentSpan := set.TracerProvider.Tracer("test").Start(context.Background(), t.Name())
+	parentCtx, parentSpan := tt.TracerProvider.Tracer("test").Start(context.Background(), t.Name())
 	defer parentSpan.End()
 
 	params := []testParams{
@@ -213,14 +213,14 @@ func TestScrapeMetricsDataOp(t *testing.T) {
 		scrp := NewScraper(ScraperSettings{
 			ReceiverID:             receiver,
 			Scraper:                scraper,
-			ReceiverCreateSettings: set.ToReceiverCreateSettings(),
+			ReceiverCreateSettings: tt.ToReceiverCreateSettings(),
 		})
 		ctx := scrp.StartMetricsOp(parentCtx)
 		assert.NotNil(t, ctx)
 		scrp.EndMetricsOp(ctx, params[i].items, params[i].err)
 	}
 
-	spans := set.SpanRecorder.Ended()
+	spans := tt.SpanRecorder.Ended()
 	require.Equal(t, len(params), len(spans))
 
 	var scrapedMetricPoints, erroredMetricPoints int
@@ -255,17 +255,17 @@ func TestScrapeMetricsDataOp(t *testing.T) {
 }
 
 func TestExportTraceDataOp(t *testing.T) {
-	set, err := obsreporttest.SetupTelemetry()
+	tt, err := obsreporttest.SetupTelemetry()
 	require.NoError(t, err)
-	defer set.Shutdown(context.Background())
+	defer tt.Shutdown(context.Background())
 
-	parentCtx, parentSpan := set.TracerProvider.Tracer("test").Start(context.Background(), t.Name())
+	parentCtx, parentSpan := tt.TracerProvider.Tracer("test").Start(context.Background(), t.Name())
 	defer parentSpan.End()
 
 	obsrep := NewExporter(ExporterSettings{
 		Level:                  configtelemetry.LevelNormal,
 		ExporterID:             exporter,
-		ExporterCreateSettings: set.ToExporterCreateSettings(),
+		ExporterCreateSettings: tt.ToExporterCreateSettings(),
 	})
 
 	params := []testParams{
@@ -278,7 +278,7 @@ func TestExportTraceDataOp(t *testing.T) {
 		obsrep.EndTracesOp(ctx, params[i].items, params[i].err)
 	}
 
-	spans := set.SpanRecorder.Ended()
+	spans := tt.SpanRecorder.Ended()
 	require.Equal(t, len(params), len(spans))
 
 	var sentSpans, failedToSendSpans int
@@ -305,17 +305,17 @@ func TestExportTraceDataOp(t *testing.T) {
 }
 
 func TestExportMetricsOp(t *testing.T) {
-	set, err := obsreporttest.SetupTelemetry()
+	tt, err := obsreporttest.SetupTelemetry()
 	require.NoError(t, err)
-	defer set.Shutdown(context.Background())
+	defer tt.Shutdown(context.Background())
 
-	parentCtx, parentSpan := set.TracerProvider.Tracer("test").Start(context.Background(), t.Name())
+	parentCtx, parentSpan := tt.TracerProvider.Tracer("test").Start(context.Background(), t.Name())
 	defer parentSpan.End()
 
 	obsrep := NewExporter(ExporterSettings{
 		Level:                  configtelemetry.LevelNormal,
 		ExporterID:             exporter,
-		ExporterCreateSettings: set.ToExporterCreateSettings(),
+		ExporterCreateSettings: tt.ToExporterCreateSettings(),
 	})
 
 	params := []testParams{
@@ -329,7 +329,7 @@ func TestExportMetricsOp(t *testing.T) {
 		obsrep.EndMetricsOp(ctx, params[i].items, params[i].err)
 	}
 
-	spans := set.SpanRecorder.Ended()
+	spans := tt.SpanRecorder.Ended()
 	require.Equal(t, len(params), len(spans))
 
 	var sentMetricPoints, failedToSendMetricPoints int
@@ -356,17 +356,17 @@ func TestExportMetricsOp(t *testing.T) {
 }
 
 func TestExportLogsOp(t *testing.T) {
-	set, err := obsreporttest.SetupTelemetry()
+	tt, err := obsreporttest.SetupTelemetry()
 	require.NoError(t, err)
-	defer set.Shutdown(context.Background())
+	defer tt.Shutdown(context.Background())
 
-	parentCtx, parentSpan := set.TracerProvider.Tracer("test").Start(context.Background(), t.Name())
+	parentCtx, parentSpan := tt.TracerProvider.Tracer("test").Start(context.Background(), t.Name())
 	defer parentSpan.End()
 
 	obsrep := NewExporter(ExporterSettings{
 		Level:                  configtelemetry.LevelNormal,
 		ExporterID:             exporter,
-		ExporterCreateSettings: set.ToExporterCreateSettings(),
+		ExporterCreateSettings: tt.ToExporterCreateSettings(),
 	})
 
 	params := []testParams{
@@ -380,7 +380,7 @@ func TestExportLogsOp(t *testing.T) {
 		obsrep.EndLogsOp(ctx, params[i].items, params[i].err)
 	}
 
-	spans := set.SpanRecorder.Ended()
+	spans := tt.SpanRecorder.Ended()
 	require.Equal(t, len(params), len(spans))
 
 	var sentLogRecords, failedToSendLogRecords int
@@ -407,11 +407,11 @@ func TestExportLogsOp(t *testing.T) {
 }
 
 func TestReceiveWithLongLivedCtx(t *testing.T) {
-	set, err := obsreporttest.SetupTelemetry()
+	tt, err := obsreporttest.SetupTelemetry()
 	require.NoError(t, err)
-	defer set.Shutdown(context.Background())
+	defer tt.Shutdown(context.Background())
 
-	longLivedCtx, parentSpan := set.TracerProvider.Tracer("test").Start(context.Background(), t.Name())
+	longLivedCtx, parentSpan := tt.TracerProvider.Tracer("test").Start(context.Background(), t.Name())
 	defer parentSpan.End()
 
 	params := []testParams{
@@ -425,14 +425,14 @@ func TestReceiveWithLongLivedCtx(t *testing.T) {
 			ReceiverID:             receiver,
 			Transport:              transport,
 			LongLivedCtx:           true,
-			ReceiverCreateSettings: set.ToReceiverCreateSettings(),
+			ReceiverCreateSettings: tt.ToReceiverCreateSettings(),
 		})
 		ctx := rec.StartTracesOp(longLivedCtx)
 		assert.NotNil(t, ctx)
 		rec.EndTracesOp(ctx, format, params[i].items, params[i].err)
 	}
 
-	spans := set.SpanRecorder.Ended()
+	spans := tt.SpanRecorder.Ended()
 	require.Equal(t, len(params), len(spans))
 
 	for i, span := range spans {
@@ -460,9 +460,9 @@ func TestReceiveWithLongLivedCtx(t *testing.T) {
 }
 
 func TestProcessorTraceData(t *testing.T) {
-	set, err := obsreporttest.SetupTelemetry()
+	tt, err := obsreporttest.SetupTelemetry()
 	require.NoError(t, err)
-	defer set.Shutdown(context.Background())
+	defer tt.Shutdown(context.Background())
 
 	const acceptedSpans = 27
 	const refusedSpans = 19
@@ -471,7 +471,7 @@ func TestProcessorTraceData(t *testing.T) {
 	obsrep := NewProcessor(ProcessorSettings{
 		Level:                   configtelemetry.LevelNormal,
 		ProcessorID:             processor,
-		ProcessorCreateSettings: set.ToProcessorCreateSettings(),
+		ProcessorCreateSettings: tt.ToProcessorCreateSettings(),
 	})
 	obsrep.TracesAccepted(context.Background(), acceptedSpans)
 	obsrep.TracesRefused(context.Background(), refusedSpans)
@@ -481,9 +481,9 @@ func TestProcessorTraceData(t *testing.T) {
 }
 
 func TestProcessorMetricsData(t *testing.T) {
-	set, err := obsreporttest.SetupTelemetry()
+	tt, err := obsreporttest.SetupTelemetry()
 	require.NoError(t, err)
-	defer set.Shutdown(context.Background())
+	defer tt.Shutdown(context.Background())
 
 	const acceptedPoints = 29
 	const refusedPoints = 11
@@ -492,7 +492,7 @@ func TestProcessorMetricsData(t *testing.T) {
 	obsrep := NewProcessor(ProcessorSettings{
 		Level:                   configtelemetry.LevelNormal,
 		ProcessorID:             processor,
-		ProcessorCreateSettings: set.ToProcessorCreateSettings(),
+		ProcessorCreateSettings: tt.ToProcessorCreateSettings(),
 	})
 	obsrep.MetricsAccepted(context.Background(), acceptedPoints)
 	obsrep.MetricsRefused(context.Background(), refusedPoints)
@@ -524,9 +524,9 @@ func TestBuildProcessorCustomMetricName(t *testing.T) {
 }
 
 func TestProcessorLogRecords(t *testing.T) {
-	set, err := obsreporttest.SetupTelemetry()
+	tt, err := obsreporttest.SetupTelemetry()
 	require.NoError(t, err)
-	defer set.Shutdown(context.Background())
+	defer tt.Shutdown(context.Background())
 
 	const acceptedRecords = 29
 	const refusedRecords = 11
@@ -535,7 +535,7 @@ func TestProcessorLogRecords(t *testing.T) {
 	obsrep := NewProcessor(ProcessorSettings{
 		Level:                   configtelemetry.LevelNormal,
 		ProcessorID:             processor,
-		ProcessorCreateSettings: set.ToProcessorCreateSettings(),
+		ProcessorCreateSettings: tt.ToProcessorCreateSettings(),
 	})
 	obsrep.LogsAccepted(context.Background(), acceptedRecords)
 	obsrep.LogsRefused(context.Background(), refusedRecords)

--- a/obsreport/obsreporttest/obsreporttest_test.go
+++ b/obsreport/obsreporttest/obsreporttest_test.go
@@ -38,14 +38,14 @@ var (
 )
 
 func TestCheckReceiverTracesViews(t *testing.T) {
-	set, err := obsreporttest.SetupTelemetry()
+	tt, err := obsreporttest.SetupTelemetry()
 	require.NoError(t, err)
-	defer set.Shutdown(context.Background())
+	defer tt.Shutdown(context.Background())
 
 	rec := obsreport.NewReceiver(obsreport.ReceiverSettings{
 		ReceiverID:             receiver,
 		Transport:              transport,
-		ReceiverCreateSettings: set.ToReceiverCreateSettings(),
+		ReceiverCreateSettings: tt.ToReceiverCreateSettings(),
 	})
 	ctx := rec.StartTracesOp(context.Background())
 	assert.NotNil(t, ctx)
@@ -59,14 +59,14 @@ func TestCheckReceiverTracesViews(t *testing.T) {
 }
 
 func TestCheckReceiverMetricsViews(t *testing.T) {
-	set, err := obsreporttest.SetupTelemetry()
+	tt, err := obsreporttest.SetupTelemetry()
 	require.NoError(t, err)
-	defer set.Shutdown(context.Background())
+	defer tt.Shutdown(context.Background())
 
 	rec := obsreport.NewReceiver(obsreport.ReceiverSettings{
 		ReceiverID:             receiver,
 		Transport:              transport,
-		ReceiverCreateSettings: set.ToReceiverCreateSettings(),
+		ReceiverCreateSettings: tt.ToReceiverCreateSettings(),
 	})
 	ctx := rec.StartMetricsOp(context.Background())
 	assert.NotNil(t, ctx)
@@ -76,14 +76,14 @@ func TestCheckReceiverMetricsViews(t *testing.T) {
 }
 
 func TestCheckReceiverLogsViews(t *testing.T) {
-	set, err := obsreporttest.SetupTelemetry()
+	tt, err := obsreporttest.SetupTelemetry()
 	require.NoError(t, err)
-	defer set.Shutdown(context.Background())
+	defer tt.Shutdown(context.Background())
 
 	rec := obsreport.NewReceiver(obsreport.ReceiverSettings{
 		ReceiverID:             receiver,
 		Transport:              transport,
-		ReceiverCreateSettings: set.ToReceiverCreateSettings(),
+		ReceiverCreateSettings: tt.ToReceiverCreateSettings(),
 	})
 	ctx := rec.StartLogsOp(context.Background())
 	assert.NotNil(t, ctx)
@@ -93,14 +93,14 @@ func TestCheckReceiverLogsViews(t *testing.T) {
 }
 
 func TestCheckExporterTracesViews(t *testing.T) {
-	set, err := obsreporttest.SetupTelemetry()
+	tt, err := obsreporttest.SetupTelemetry()
 	require.NoError(t, err)
-	defer set.Shutdown(context.Background())
+	defer tt.Shutdown(context.Background())
 
 	obsrep := obsreport.NewExporter(obsreport.ExporterSettings{
 		Level:                  configtelemetry.LevelNormal,
 		ExporterID:             exporter,
-		ExporterCreateSettings: set.ToExporterCreateSettings(),
+		ExporterCreateSettings: tt.ToExporterCreateSettings(),
 	})
 	ctx := obsrep.StartTracesOp(context.Background())
 	assert.NotNil(t, ctx)
@@ -111,14 +111,14 @@ func TestCheckExporterTracesViews(t *testing.T) {
 }
 
 func TestCheckExporterMetricsViews(t *testing.T) {
-	set, err := obsreporttest.SetupTelemetry()
+	tt, err := obsreporttest.SetupTelemetry()
 	require.NoError(t, err)
-	defer set.Shutdown(context.Background())
+	defer tt.Shutdown(context.Background())
 
 	obsrep := obsreport.NewExporter(obsreport.ExporterSettings{
 		Level:                  configtelemetry.LevelNormal,
 		ExporterID:             exporter,
-		ExporterCreateSettings: set.ToExporterCreateSettings(),
+		ExporterCreateSettings: tt.ToExporterCreateSettings(),
 	})
 	ctx := obsrep.StartMetricsOp(context.Background())
 	assert.NotNil(t, ctx)
@@ -129,14 +129,14 @@ func TestCheckExporterMetricsViews(t *testing.T) {
 }
 
 func TestCheckExporterLogsViews(t *testing.T) {
-	set, err := obsreporttest.SetupTelemetry()
+	tt, err := obsreporttest.SetupTelemetry()
 	require.NoError(t, err)
-	defer set.Shutdown(context.Background())
+	defer tt.Shutdown(context.Background())
 
 	obsrep := obsreport.NewExporter(obsreport.ExporterSettings{
 		Level:                  configtelemetry.LevelNormal,
 		ExporterID:             exporter,
-		ExporterCreateSettings: set.ToExporterCreateSettings(),
+		ExporterCreateSettings: tt.ToExporterCreateSettings(),
 	})
 	ctx := obsrep.StartLogsOp(context.Background())
 	assert.NotNil(t, ctx)

--- a/receiver/scraperhelper/scrapercontroller_test.go
+++ b/receiver/scraperhelper/scrapercontroller_test.go
@@ -138,9 +138,9 @@ func TestScrapeController(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
-			set, err := obsreporttest.SetupTelemetry()
+			tt, err := obsreporttest.SetupTelemetry()
 			require.NoError(t, err)
-			defer set.Shutdown(context.Background())
+			defer tt.Shutdown(context.Background())
 
 			initializeChs := make([]chan bool, test.scrapers)
 			scrapeMetricsChs := make([]chan int, test.scrapers)
@@ -161,7 +161,7 @@ func TestScrapeController(t *testing.T) {
 				cfg = test.scraperControllerSettings
 			}
 
-			mr, err := NewScraperControllerReceiver(cfg, set.ToReceiverCreateSettings(), nextConsumer, options...)
+			mr, err := NewScraperControllerReceiver(cfg, tt.ToReceiverCreateSettings(), nextConsumer, options...)
 			if test.expectedNewErr != "" {
 				assert.EqualError(t, err, test.expectedNewErr)
 				return
@@ -199,7 +199,7 @@ func TestScrapeController(t *testing.T) {
 					assert.GreaterOrEqual(t, sink.DataPointCount(), iterations)
 				}
 
-				spans := set.SpanRecorder.Ended()
+				spans := tt.SpanRecorder.Ended()
 				assertReceiverSpan(t, spans)
 				assertReceiverViews(t, sink)
 				assertScraperSpan(t, test.scrapeErr, spans)


### PR DESCRIPTION
SetupTelemetry returns TestTelemetry, the variable set didn't reflect this.
