### PR TITLE
Update Check* functions to support TestTelemetry

### DIFF
--- a/exporter/exporterhelper/logs_test.go
+++ b/exporter/exporterhelper/logs_test.go
@@ -217,9 +217,9 @@ func checkRecordedMetricsForLogsExporter(t *testing.T, le component.LogsExporter
 
 	// TODO: When the new metrics correctly count partial dropped fix this.
 	if wantError != nil {
-		require.NoError(t, obsreporttest.CheckExporterLogs(fakeLogsExporterName, 0, int64(numBatches*ld.LogRecordCount())))
+		require.NoError(t, obsreporttest.CheckExporterLogs(tt, fakeLogsExporterName, 0, int64(numBatches*ld.LogRecordCount())))
 	} else {
-		require.NoError(t, obsreporttest.CheckExporterLogs(fakeLogsExporterName, int64(numBatches*ld.LogRecordCount()), 0))
+		require.NoError(t, obsreporttest.CheckExporterLogs(tt, fakeLogsExporterName, int64(numBatches*ld.LogRecordCount()), 0))
 	}
 }
 

--- a/exporter/exporterhelper/metrics_test.go
+++ b/exporter/exporterhelper/metrics_test.go
@@ -219,9 +219,9 @@ func checkRecordedMetricsForMetricsExporter(t *testing.T, me component.MetricsEx
 	// TODO: When the new metrics correctly count partial dropped fix this.
 	numPoints := int64(numBatches * md.MetricCount() * 2) /* 2 points per metric*/
 	if wantError != nil {
-		require.NoError(t, obsreporttest.CheckExporterMetrics(fakeMetricsExporterName, 0, numPoints))
+		require.NoError(t, obsreporttest.CheckExporterMetrics(tt, fakeMetricsExporterName, 0, numPoints))
 	} else {
-		require.NoError(t, obsreporttest.CheckExporterMetrics(fakeMetricsExporterName, numPoints, 0))
+		require.NoError(t, obsreporttest.CheckExporterMetrics(tt, fakeMetricsExporterName, numPoints, 0))
 	}
 }
 

--- a/exporter/exporterhelper/traces_test.go
+++ b/exporter/exporterhelper/traces_test.go
@@ -218,9 +218,9 @@ func checkRecordedMetricsForTracesExporter(t *testing.T, te component.TracesExpo
 
 	// TODO: When the new metrics correctly count partial dropped fix this.
 	if wantError != nil {
-		require.NoError(t, obsreporttest.CheckExporterTraces(fakeTracesExporterName, 0, int64(numBatches*td.SpanCount())))
+		require.NoError(t, obsreporttest.CheckExporterTraces(tt, fakeTracesExporterName, 0, int64(numBatches*td.SpanCount())))
 	} else {
-		require.NoError(t, obsreporttest.CheckExporterTraces(fakeTracesExporterName, int64(numBatches*td.SpanCount()), 0))
+		require.NoError(t, obsreporttest.CheckExporterTraces(tt, fakeTracesExporterName, int64(numBatches*td.SpanCount()), 0))
 	}
 }
 

--- a/obsreport/obsreport_test.go
+++ b/obsreport/obsreport_test.go
@@ -96,7 +96,7 @@ func TestReceiveTraceDataOp(t *testing.T) {
 			t.Fatalf("unexpected param: %v", params[i])
 		}
 	}
-	require.NoError(t, obsreporttest.CheckReceiverTraces(receiver, transport, int64(acceptedSpans), int64(refusedSpans)))
+	require.NoError(t, obsreporttest.CheckReceiverTraces(tt, receiver, transport, int64(acceptedSpans), int64(refusedSpans)))
 }
 
 func TestReceiveLogsOp(t *testing.T) {
@@ -144,7 +144,7 @@ func TestReceiveLogsOp(t *testing.T) {
 			t.Fatalf("unexpected param: %v", params[i])
 		}
 	}
-	require.NoError(t, obsreporttest.CheckReceiverLogs(receiver, transport, int64(acceptedLogRecords), int64(refusedLogRecords)))
+	require.NoError(t, obsreporttest.CheckReceiverLogs(tt, receiver, transport, int64(acceptedLogRecords), int64(refusedLogRecords)))
 }
 
 func TestReceiveMetricsOp(t *testing.T) {
@@ -193,7 +193,7 @@ func TestReceiveMetricsOp(t *testing.T) {
 		}
 	}
 
-	require.NoError(t, obsreporttest.CheckReceiverMetrics(receiver, transport, int64(acceptedMetricPoints), int64(refusedMetricPoints)))
+	require.NoError(t, obsreporttest.CheckReceiverMetrics(tt, receiver, transport, int64(acceptedMetricPoints), int64(refusedMetricPoints)))
 }
 
 func TestScrapeMetricsDataOp(t *testing.T) {
@@ -251,7 +251,7 @@ func TestScrapeMetricsDataOp(t *testing.T) {
 		}
 	}
 
-	require.NoError(t, obsreporttest.CheckScraperMetrics(receiver, scraper, int64(scrapedMetricPoints), int64(erroredMetricPoints)))
+	require.NoError(t, obsreporttest.CheckScraperMetrics(tt, receiver, scraper, int64(scrapedMetricPoints), int64(erroredMetricPoints)))
 }
 
 func TestExportTraceDataOp(t *testing.T) {
@@ -301,7 +301,7 @@ func TestExportTraceDataOp(t *testing.T) {
 		}
 	}
 
-	require.NoError(t, obsreporttest.CheckExporterTraces(exporter, int64(sentSpans), int64(failedToSendSpans)))
+	require.NoError(t, obsreporttest.CheckExporterTraces(tt, exporter, int64(sentSpans), int64(failedToSendSpans)))
 }
 
 func TestExportMetricsOp(t *testing.T) {
@@ -352,7 +352,7 @@ func TestExportMetricsOp(t *testing.T) {
 		}
 	}
 
-	require.NoError(t, obsreporttest.CheckExporterMetrics(exporter, int64(sentMetricPoints), int64(failedToSendMetricPoints)))
+	require.NoError(t, obsreporttest.CheckExporterMetrics(tt, exporter, int64(sentMetricPoints), int64(failedToSendMetricPoints)))
 }
 
 func TestExportLogsOp(t *testing.T) {
@@ -403,7 +403,7 @@ func TestExportLogsOp(t *testing.T) {
 		}
 	}
 
-	require.NoError(t, obsreporttest.CheckExporterLogs(exporter, int64(sentLogRecords), int64(failedToSendLogRecords)))
+	require.NoError(t, obsreporttest.CheckExporterLogs(tt, exporter, int64(sentLogRecords), int64(failedToSendLogRecords)))
 }
 
 func TestReceiveWithLongLivedCtx(t *testing.T) {
@@ -477,7 +477,7 @@ func TestProcessorTraceData(t *testing.T) {
 	obsrep.TracesRefused(context.Background(), refusedSpans)
 	obsrep.TracesDropped(context.Background(), droppedSpans)
 
-	require.NoError(t, obsreporttest.CheckProcessorTraces(processor, acceptedSpans, refusedSpans, droppedSpans))
+	require.NoError(t, obsreporttest.CheckProcessorTraces(tt, processor, acceptedSpans, refusedSpans, droppedSpans))
 }
 
 func TestProcessorMetricsData(t *testing.T) {
@@ -498,7 +498,7 @@ func TestProcessorMetricsData(t *testing.T) {
 	obsrep.MetricsRefused(context.Background(), refusedPoints)
 	obsrep.MetricsDropped(context.Background(), droppedPoints)
 
-	require.NoError(t, obsreporttest.CheckProcessorMetrics(processor, acceptedPoints, refusedPoints, droppedPoints))
+	require.NoError(t, obsreporttest.CheckProcessorMetrics(tt, processor, acceptedPoints, refusedPoints, droppedPoints))
 }
 
 func TestBuildProcessorCustomMetricName(t *testing.T) {
@@ -541,5 +541,5 @@ func TestProcessorLogRecords(t *testing.T) {
 	obsrep.LogsRefused(context.Background(), refusedRecords)
 	obsrep.LogsDropped(context.Background(), droppedRecords)
 
-	require.NoError(t, obsreporttest.CheckProcessorLogs(processor, acceptedRecords, refusedRecords, droppedRecords))
+	require.NoError(t, obsreporttest.CheckProcessorLogs(tt, processor, acceptedRecords, refusedRecords, droppedRecords))
 }

--- a/obsreport/obsreporttest/obsreporttest.go
+++ b/obsreport/obsreporttest/obsreporttest.go
@@ -102,7 +102,7 @@ func SetupTelemetry() (TestTelemetry, error) {
 
 // CheckExporterTraces checks that for the current exported values for trace exporter metrics match given values.
 // When this function is called it is required to also call SetupTelemetry as first thing.
-func CheckExporterTraces(exporter config.ComponentID, acceptedSpans, droppedSpans int64) error {
+func CheckExporterTraces(_ TestTelemetry, exporter config.ComponentID, acceptedSpans, droppedSpans int64) error {
 	exporterTags := tagsForExporterView(exporter)
 	if err := checkValueForView(exporterTags, acceptedSpans, "exporter/sent_spans"); err != nil {
 		return err
@@ -112,7 +112,7 @@ func CheckExporterTraces(exporter config.ComponentID, acceptedSpans, droppedSpan
 
 // CheckExporterMetrics checks that for the current exported values for metrics exporter metrics match given values.
 // When this function is called it is required to also call SetupTelemetry as first thing.
-func CheckExporterMetrics(exporter config.ComponentID, acceptedMetricsPoints, droppedMetricsPoints int64) error {
+func CheckExporterMetrics(_ TestTelemetry, exporter config.ComponentID, acceptedMetricsPoints, droppedMetricsPoints int64) error {
 	exporterTags := tagsForExporterView(exporter)
 	if err := checkValueForView(exporterTags, acceptedMetricsPoints, "exporter/sent_metric_points"); err != nil {
 		return err
@@ -122,7 +122,7 @@ func CheckExporterMetrics(exporter config.ComponentID, acceptedMetricsPoints, dr
 
 // CheckExporterLogs checks that for the current exported values for logs exporter metrics match given values.
 // When this function is called it is required to also call SetupTelemetry as first thing.
-func CheckExporterLogs(exporter config.ComponentID, acceptedLogRecords, droppedLogRecords int64) error {
+func CheckExporterLogs(_ TestTelemetry, exporter config.ComponentID, acceptedLogRecords, droppedLogRecords int64) error {
 	exporterTags := tagsForExporterView(exporter)
 	if err := checkValueForView(exporterTags, acceptedLogRecords, "exporter/sent_log_records"); err != nil {
 		return err
@@ -132,7 +132,7 @@ func CheckExporterLogs(exporter config.ComponentID, acceptedLogRecords, droppedL
 
 // CheckProcessorTraces checks that for the current exported values for trace exporter metrics match given values.
 // When this function is called it is required to also call SetupTelemetry as first thing.
-func CheckProcessorTraces(processor config.ComponentID, acceptedSpans, refusedSpans, droppedSpans int64) error {
+func CheckProcessorTraces(_ TestTelemetry, processor config.ComponentID, acceptedSpans, refusedSpans, droppedSpans int64) error {
 	processorTags := tagsForProcessorView(processor)
 	if err := checkValueForView(processorTags, acceptedSpans, "processor/accepted_spans"); err != nil {
 		return err
@@ -145,7 +145,7 @@ func CheckProcessorTraces(processor config.ComponentID, acceptedSpans, refusedSp
 
 // CheckProcessorMetrics checks that for the current exported values for metrics exporter metrics match given values.
 // When this function is called it is required to also call SetupTelemetry as first thing.
-func CheckProcessorMetrics(processor config.ComponentID, acceptedMetricPoints, refusedMetricPoints, droppedMetricPoints int64) error {
+func CheckProcessorMetrics(_ TestTelemetry, processor config.ComponentID, acceptedMetricPoints, refusedMetricPoints, droppedMetricPoints int64) error {
 	processorTags := tagsForProcessorView(processor)
 	if err := checkValueForView(processorTags, acceptedMetricPoints, "processor/accepted_metric_points"); err != nil {
 		return err
@@ -158,7 +158,7 @@ func CheckProcessorMetrics(processor config.ComponentID, acceptedMetricPoints, r
 
 // CheckProcessorLogs checks that for the current exported values for logs exporter metrics match given values.
 // When this function is called it is required to also call SetupTelemetry as first thing.
-func CheckProcessorLogs(processor config.ComponentID, acceptedLogRecords, refusedLogRecords, droppedLogRecords int64) error {
+func CheckProcessorLogs(_ TestTelemetry, processor config.ComponentID, acceptedLogRecords, refusedLogRecords, droppedLogRecords int64) error {
 	processorTags := tagsForProcessorView(processor)
 	if err := checkValueForView(processorTags, acceptedLogRecords, "processor/accepted_log_records"); err != nil {
 		return err
@@ -171,7 +171,7 @@ func CheckProcessorLogs(processor config.ComponentID, acceptedLogRecords, refuse
 
 // CheckReceiverTraces checks that for the current exported values for trace receiver metrics match given values.
 // When this function is called it is required to also call SetupTelemetry as first thing.
-func CheckReceiverTraces(receiver config.ComponentID, protocol string, acceptedSpans, droppedSpans int64) error {
+func CheckReceiverTraces(_ TestTelemetry, receiver config.ComponentID, protocol string, acceptedSpans, droppedSpans int64) error {
 	receiverTags := tagsForReceiverView(receiver, protocol)
 	if err := checkValueForView(receiverTags, acceptedSpans, "receiver/accepted_spans"); err != nil {
 		return err
@@ -181,7 +181,7 @@ func CheckReceiverTraces(receiver config.ComponentID, protocol string, acceptedS
 
 // CheckReceiverLogs checks that for the current exported values for logs receiver metrics match given values.
 // When this function is called it is required to also call SetupTelemetry as first thing.
-func CheckReceiverLogs(receiver config.ComponentID, protocol string, acceptedLogRecords, droppedLogRecords int64) error {
+func CheckReceiverLogs(_ TestTelemetry, receiver config.ComponentID, protocol string, acceptedLogRecords, droppedLogRecords int64) error {
 	receiverTags := tagsForReceiverView(receiver, protocol)
 	if err := checkValueForView(receiverTags, acceptedLogRecords, "receiver/accepted_log_records"); err != nil {
 		return err
@@ -191,7 +191,7 @@ func CheckReceiverLogs(receiver config.ComponentID, protocol string, acceptedLog
 
 // CheckReceiverMetrics checks that for the current exported values for metrics receiver metrics match given values.
 // When this function is called it is required to also call SetupTelemetry as first thing.
-func CheckReceiverMetrics(receiver config.ComponentID, protocol string, acceptedMetricPoints, droppedMetricPoints int64) error {
+func CheckReceiverMetrics(_ TestTelemetry, receiver config.ComponentID, protocol string, acceptedMetricPoints, droppedMetricPoints int64) error {
 	receiverTags := tagsForReceiverView(receiver, protocol)
 	if err := checkValueForView(receiverTags, acceptedMetricPoints, "receiver/accepted_metric_points"); err != nil {
 		return err
@@ -201,7 +201,7 @@ func CheckReceiverMetrics(receiver config.ComponentID, protocol string, accepted
 
 // CheckScraperMetrics checks that for the current exported values for metrics scraper metrics match given values.
 // When this function is called it is required to also call SetupTelemetry as first thing.
-func CheckScraperMetrics(receiver config.ComponentID, scraper config.ComponentID, scrapedMetricPoints, erroredMetricPoints int64) error {
+func CheckScraperMetrics(_ TestTelemetry, receiver config.ComponentID, scraper config.ComponentID, scrapedMetricPoints, erroredMetricPoints int64) error {
 	scraperTags := tagsForScraperView(receiver, scraper)
 	if err := checkValueForView(scraperTags, scrapedMetricPoints, "scraper/scraped_metric_points"); err != nil {
 		return err

--- a/obsreport/obsreporttest/obsreporttest_test.go
+++ b/obsreport/obsreporttest/obsreporttest_test.go
@@ -55,7 +55,7 @@ func TestCheckReceiverTracesViews(t *testing.T) {
 		7,
 		nil)
 
-	require.NoError(t, obsreporttest.CheckReceiverTraces(receiver, transport, 7, 0))
+	require.NoError(t, obsreporttest.CheckReceiverTraces(tt, receiver, transport, 7, 0))
 }
 
 func TestCheckReceiverMetricsViews(t *testing.T) {
@@ -72,7 +72,7 @@ func TestCheckReceiverMetricsViews(t *testing.T) {
 	assert.NotNil(t, ctx)
 	rec.EndMetricsOp(ctx, format, 7, nil)
 
-	require.NoError(t, obsreporttest.CheckReceiverMetrics(receiver, transport, 7, 0))
+	require.NoError(t, obsreporttest.CheckReceiverMetrics(tt, receiver, transport, 7, 0))
 }
 
 func TestCheckReceiverLogsViews(t *testing.T) {
@@ -89,7 +89,7 @@ func TestCheckReceiverLogsViews(t *testing.T) {
 	assert.NotNil(t, ctx)
 	rec.EndLogsOp(ctx, format, 7, nil)
 
-	require.NoError(t, obsreporttest.CheckReceiverLogs(receiver, transport, 7, 0))
+	require.NoError(t, obsreporttest.CheckReceiverLogs(tt, receiver, transport, 7, 0))
 }
 
 func TestCheckExporterTracesViews(t *testing.T) {
@@ -107,7 +107,7 @@ func TestCheckExporterTracesViews(t *testing.T) {
 
 	obsrep.EndTracesOp(ctx, 7, nil)
 
-	require.NoError(t, obsreporttest.CheckExporterTraces(exporter, 7, 0))
+	require.NoError(t, obsreporttest.CheckExporterTraces(tt, exporter, 7, 0))
 }
 
 func TestCheckExporterMetricsViews(t *testing.T) {
@@ -125,7 +125,7 @@ func TestCheckExporterMetricsViews(t *testing.T) {
 
 	obsrep.EndMetricsOp(ctx, 7, nil)
 
-	require.NoError(t, obsreporttest.CheckExporterMetrics(exporter, 7, 0))
+	require.NoError(t, obsreporttest.CheckExporterMetrics(tt, exporter, 7, 0))
 }
 
 func TestCheckExporterLogsViews(t *testing.T) {
@@ -142,5 +142,5 @@ func TestCheckExporterLogsViews(t *testing.T) {
 	assert.NotNil(t, ctx)
 	obsrep.EndLogsOp(ctx, 7, nil)
 
-	require.NoError(t, obsreporttest.CheckExporterLogs(exporter, 7, 0))
+	require.NoError(t, obsreporttest.CheckExporterLogs(tt, exporter, 7, 0))
 }

--- a/receiver/otlpreceiver/otlp_test.go
+++ b/receiver/otlpreceiver/otlp_test.go
@@ -530,7 +530,7 @@ func TestOTLPReceiverTrace_HandleNextConsumerResponse(t *testing.T) {
 
 				require.Equal(t, test.expectedReceivedBatches, len(sink.AllTraces()))
 
-				require.NoError(t, obsreporttest.CheckReceiverTraces(config.NewComponentIDWithName(typeStr, exporter.receiverTag), "grpc", int64(test.expectedReceivedBatches), int64(test.expectedIngestionBlockedRPCs)))
+				require.NoError(t, obsreporttest.CheckReceiverTraces(tt, config.NewComponentIDWithName(typeStr, exporter.receiverTag), "grpc", int64(test.expectedReceivedBatches), int64(test.expectedIngestionBlockedRPCs)))
 			})
 		}
 	}

--- a/receiver/scraperhelper/scrapercontroller_test.go
+++ b/receiver/scraperhelper/scrapercontroller_test.go
@@ -201,9 +201,9 @@ func TestScrapeController(t *testing.T) {
 
 				spans := tt.SpanRecorder.Ended()
 				assertReceiverSpan(t, spans)
-				assertReceiverViews(t, sink)
+				assertReceiverViews(t, tt, sink)
 				assertScraperSpan(t, test.scrapeErr, spans)
-				assertScraperViews(t, test.scrapeErr, sink)
+				assertScraperViews(t, tt, test.scrapeErr, sink)
 			}
 
 			err = mr.Shutdown(context.Background())
@@ -285,12 +285,12 @@ func assertReceiverSpan(t *testing.T, spans []sdktrace.ReadOnlySpan) {
 	assert.True(t, receiverSpan)
 }
 
-func assertReceiverViews(t *testing.T, sink *consumertest.MetricsSink) {
+func assertReceiverViews(t *testing.T, tt obsreporttest.TestTelemetry, sink *consumertest.MetricsSink) {
 	dataPointCount := 0
 	for _, md := range sink.AllMetrics() {
 		dataPointCount += md.DataPointCount()
 	}
-	require.NoError(t, obsreporttest.CheckReceiverMetrics(config.NewComponentID("receiver"), "", int64(dataPointCount), 0))
+	require.NoError(t, obsreporttest.CheckReceiverMetrics(tt, config.NewComponentID("receiver"), "", int64(dataPointCount), 0))
 }
 
 func assertScraperSpan(t *testing.T, expectedErr error, spans []sdktrace.ReadOnlySpan) {
@@ -313,7 +313,7 @@ func assertScraperSpan(t *testing.T, expectedErr error, spans []sdktrace.ReadOnl
 	assert.True(t, scraperSpan)
 }
 
-func assertScraperViews(t *testing.T, expectedErr error, sink *consumertest.MetricsSink) {
+func assertScraperViews(t *testing.T, tt obsreporttest.TestTelemetry, expectedErr error, sink *consumertest.MetricsSink) {
 	expectedScraped := int64(sink.DataPointCount())
 	expectedErrored := int64(0)
 	if expectedErr != nil {
@@ -325,7 +325,7 @@ func assertScraperViews(t *testing.T, expectedErr error, sink *consumertest.Metr
 		}
 	}
 
-	require.NoError(t, obsreporttest.CheckScraperMetrics(config.NewComponentID("receiver"), config.NewComponentID("scraper"), expectedScraped, expectedErrored))
+	require.NoError(t, obsreporttest.CheckScraperMetrics(tt, config.NewComponentID("receiver"), config.NewComponentID("scraper"), expectedScraped, expectedErrored))
 }
 
 func TestSingleScrapePerTick(t *testing.T) {


### PR DESCRIPTION
The following change updates various obsreporttest methods to support TestTelemetry:
* CheckExporterMetrics, CheckExporterTraces, CheckExporterLogs
* CheckProcessorTraces, CheckProcessorMetrics, CheckProcessorLogs
* CheckReceiverLogs, CheckReceiverTraces, CheckReceiverMetrics
* CheckScraperMetrics

Fixes https://github.com/open-telemetry/opentelemetry-collector/issues/4038

This is built on top of https://github.com/open-telemetry/opentelemetry-collector/pull/4281