### PR TITLE
stop build if config file not exist

### DIFF
--- a/cmd/builder/cmd/root.go
+++ b/cmd/builder/cmd/root.go
@@ -116,6 +116,8 @@ func initConfig() {
 	// load the config file
 	if err := vp.ReadInConfig(); err == nil {
 		cfg.Logger.Info("Using config file", zap.String("path", vp.ConfigFileUsed()))
+	} else {
+		cobra.CheckErr(err)
 	}
 
 	// convert Viper's internal state into our configuration object

--- a/cmd/builder/cmd/root.go
+++ b/cmd/builder/cmd/root.go
@@ -114,11 +114,10 @@ func initConfig() {
 	}
 
 	// load the config file
-	if err := vp.ReadInConfig(); err == nil {
-		cfg.Logger.Info("Using config file", zap.String("path", vp.ConfigFileUsed()))
-	} else {
+	if err := vp.ReadInConfig(); err != nil {
 		cobra.CheckErr(err)
 	}
+	cfg.Logger.Info("Using config file", zap.String("path", vp.ConfigFileUsed()))
 
 	// convert Viper's internal state into our configuration object
 	if err := vp.Unmarshal(&cfg); err != nil {


### PR DESCRIPTION
Adding a feature: stop build if config file in `--config` is set but not exist

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector/issues/4308

