### PR TITLE
Make `component.Factory` inherit `internalinterface.InternalInterface`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@
 ## 🛑 Breaking changes 🛑
 
 - Remove `component.BaseProcessorFactory`, use `processorhelper.NewFactory` instead (#4175)
-- Force usage of `exporterhelper.NewFactory` to implement `component.ExporterFactory` (#TODO)
+- Force usage of `exporterhelper.NewFactory` to implement `component.ExporterFactory` (#4338)
+- Force usage of `receiverhelper.NewFactory` to implement `component.ReceiverFactory` (#4338)
+- Force usage of `extensionhelper.NewFactory` to implement `component.ExtensionFactory` (#4338)
 - Move `service/parserprovider` package to `config/configmapprovider` (#4206)
 
 ## v0.38.0 Beta

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## 🛑 Breaking changes 🛑
 
 - Remove `component.BaseProcessorFactory`, use `processorhelper.NewFactory` instead (#4175)
+- Force usage of `exporterhelper.NewFactory` to implement `component.ExporterFactory` (#TODO)
 - Move `service/parserprovider` package to `config/configmapprovider` (#4206)
 
 ## v0.38.0 Beta

--- a/component/component.go
+++ b/component/component.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/internal/internalinterface"
 )
 
 // Component is either a receiver, exporter, processor, or an extension.
@@ -73,6 +74,7 @@ const (
 
 // Factory is implemented by all component factories.
 type Factory interface {
+	internalinterface.InternalInterface
 	// Type gets the type of the component created by this factory.
 	Type() config.Type
 }

--- a/component/component.go
+++ b/component/component.go
@@ -73,6 +73,9 @@ const (
 )
 
 // Factory is implemented by all component factories.
+//
+// This interface cannot be directly implemented. Implementations must
+// use the factory helpers for the appropriate component type.
 type Factory interface {
 	internalinterface.InternalInterface
 	// Type gets the type of the component created by this factory.

--- a/component/componenttest/nop_exporter.go
+++ b/component/componenttest/nop_exporter.go
@@ -21,6 +21,7 @@ import (
 	"go.opentelemetry.io/collector/component/componenthelper"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/internal/internalinterface"
 )
 
 // NewNopExporterCreateSettings returns a new nop settings for Create*Exporter functions.
@@ -36,7 +37,9 @@ type nopExporterConfig struct {
 }
 
 // nopExporterFactory is factory for nopExporter.
-type nopExporterFactory struct{}
+type nopExporterFactory struct {
+	internalinterface.BaseInternal
+}
 
 var nopExporterFactoryInstance = &nopExporterFactory{}
 

--- a/component/componenttest/nop_extension.go
+++ b/component/componenttest/nop_extension.go
@@ -20,6 +20,7 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenthelper"
 	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/internal/internalinterface"
 )
 
 // NewNopExtensionCreateSettings returns a new nop settings for Create*Extension functions.
@@ -35,7 +36,9 @@ type nopExtensionConfig struct {
 }
 
 // nopExtensionFactory is factory for nopExtension.
-type nopExtensionFactory struct{}
+type nopExtensionFactory struct {
+	internalinterface.BaseInternal
+}
 
 var nopExtensionFactoryInstance = &nopExtensionFactory{}
 

--- a/component/componenttest/nop_receiver.go
+++ b/component/componenttest/nop_receiver.go
@@ -21,6 +21,7 @@ import (
 	"go.opentelemetry.io/collector/component/componenthelper"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/internal/internalinterface"
 )
 
 // NewNopReceiverCreateSettings returns a new nop settings for Create*Receiver functions.
@@ -36,7 +37,9 @@ type nopReceiverConfig struct {
 }
 
 // nopReceiverFactory is factory for nopReceiver.
-type nopReceiverFactory struct{}
+type nopReceiverFactory struct {
+	internalinterface.BaseInternal
+}
 
 var nopReceiverFactoryInstance = &nopReceiverFactory{}
 

--- a/component/exporter.go
+++ b/component/exporter.go
@@ -54,6 +54,9 @@ type ExporterCreateSettings struct {
 
 // ExporterFactory can create MetricsExporter, TracesExporter and
 // LogsExporter. This is the new preferred factory type to create exporters.
+//
+// This interface cannot be directly implemented. Implementations must
+// use the exporterhelper.NewFactory to implement it.
 type ExporterFactory interface {
 	Factory
 

--- a/component/exporter_test.go
+++ b/component/exporter_test.go
@@ -15,42 +15,21 @@
 package component
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
-	"go.opentelemetry.io/collector/component/componenterror"
 	"go.opentelemetry.io/collector/config"
 )
 
 type TestExporterFactory struct {
+	ExporterFactory
 	name string
 }
 
 // Type gets the type of the Exporter config created by this factory.
 func (f *TestExporterFactory) Type() config.Type {
 	return config.Type(f.name)
-}
-
-// CreateDefaultConfig creates the default configuration for the Exporter.
-func (f *TestExporterFactory) CreateDefaultConfig() config.Exporter {
-	return nil
-}
-
-// CreateTracesExporter creates a trace exporter based on this config.
-func (f *TestExporterFactory) CreateTracesExporter(context.Context, ExporterCreateSettings, config.Exporter) (TracesExporter, error) {
-	return nil, componenterror.ErrDataTypeIsNotSupported
-}
-
-// CreateMetricsExporter creates a metrics exporter based on this config.
-func (f *TestExporterFactory) CreateMetricsExporter(context.Context, ExporterCreateSettings, config.Exporter) (MetricsExporter, error) {
-	return nil, componenterror.ErrDataTypeIsNotSupported
-}
-
-// CreateLogsExporter creates a logs exporter based on this config.
-func (f *TestExporterFactory) CreateLogsExporter(context.Context, ExporterCreateSettings, config.Exporter) (LogsExporter, error) {
-	return nil, componenterror.ErrDataTypeIsNotSupported
 }
 
 func TestBuildExporters(t *testing.T) {
@@ -62,18 +41,18 @@ func TestBuildExporters(t *testing.T) {
 	testCases := []testCase{
 		{
 			in: []ExporterFactory{
-				&TestExporterFactory{"exp1"},
-				&TestExporterFactory{"exp2"},
+				&TestExporterFactory{name: "exp1"},
+				&TestExporterFactory{name: "exp2"},
 			},
 			out: map[config.Type]ExporterFactory{
-				"exp1": &TestExporterFactory{"exp1"},
-				"exp2": &TestExporterFactory{"exp2"},
+				"exp1": &TestExporterFactory{name: "exp1"},
+				"exp2": &TestExporterFactory{name: "exp2"},
 			},
 		},
 		{
 			in: []ExporterFactory{
-				&TestExporterFactory{"exp1"},
-				&TestExporterFactory{"exp1"},
+				&TestExporterFactory{name: "exp1"},
+				&TestExporterFactory{name: "exp1"},
 			},
 		},
 	}

--- a/component/extension.go
+++ b/component/extension.go
@@ -53,6 +53,9 @@ type ExtensionCreateSettings struct {
 }
 
 // ExtensionFactory is a factory interface for extensions to the service.
+//
+// This interface cannot be directly implemented. Implementations must
+// use the extensionhelper.NewFactory to implement it.
 type ExtensionFactory interface {
 	Factory
 

--- a/component/receiver.go
+++ b/component/receiver.go
@@ -99,6 +99,9 @@ type ReceiverCreateSettings struct {
 
 // ReceiverFactory can create TracesReceiver, MetricsReceiver and
 // and LogsReceiver. This is the new preferred factory type to create receivers.
+//
+// This interface cannot be directly implemented. Implementations must
+// use the receiverhelper.NewFactory to implement it.
 type ReceiverFactory interface {
 	Factory
 

--- a/component/receiver_test.go
+++ b/component/receiver_test.go
@@ -15,43 +15,21 @@
 package component
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
-	"go.opentelemetry.io/collector/component/componenterror"
 	"go.opentelemetry.io/collector/config"
-	"go.opentelemetry.io/collector/consumer"
 )
 
 type TestReceiverFactory struct {
+	ReceiverFactory
 	name config.Type
 }
 
 // Type gets the type of the Receiver config created by this factory.
 func (f *TestReceiverFactory) Type() config.Type {
 	return f.name
-}
-
-// CreateDefaultConfig creates the default configuration for the Receiver.
-func (f *TestReceiverFactory) CreateDefaultConfig() config.Receiver {
-	return nil
-}
-
-// CreateTracesReceiver creates a trace receiver based on this config.
-func (f *TestReceiverFactory) CreateTracesReceiver(context.Context, ReceiverCreateSettings, config.Receiver, consumer.Traces) (TracesReceiver, error) {
-	return nil, componenterror.ErrDataTypeIsNotSupported
-}
-
-// CreateMetricsReceiver creates a metrics receiver based on this config.
-func (f *TestReceiverFactory) CreateMetricsReceiver(context.Context, ReceiverCreateSettings, config.Receiver, consumer.Metrics) (MetricsReceiver, error) {
-	return nil, componenterror.ErrDataTypeIsNotSupported
-}
-
-// CreateMetricsReceiver creates a metrics receiver based on this config.
-func (f *TestReceiverFactory) CreateLogsReceiver(context.Context, ReceiverCreateSettings, config.Receiver, consumer.Logs) (LogsReceiver, error) {
-	return nil, componenterror.ErrDataTypeIsNotSupported
 }
 
 func TestBuildReceivers(t *testing.T) {
@@ -63,18 +41,18 @@ func TestBuildReceivers(t *testing.T) {
 	testCases := []testCase{
 		{
 			in: []ReceiverFactory{
-				&TestReceiverFactory{"e1"},
-				&TestReceiverFactory{"e2"},
+				&TestReceiverFactory{name: "e1"},
+				&TestReceiverFactory{name: "e2"},
 			},
 			out: map[config.Type]ReceiverFactory{
-				"e1": &TestReceiverFactory{"e1"},
-				"e2": &TestReceiverFactory{"e2"},
+				"e1": &TestReceiverFactory{name: "e1"},
+				"e2": &TestReceiverFactory{name: "e2"},
 			},
 		},
 		{
 			in: []ReceiverFactory{
-				&TestReceiverFactory{"e1"},
-				&TestReceiverFactory{"e1"},
+				&TestReceiverFactory{name: "e1"},
+				&TestReceiverFactory{name: "e1"},
 			},
 		},
 	}

--- a/exporter/exporterhelper/factory.go
+++ b/exporter/exporterhelper/factory.go
@@ -20,6 +20,7 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenterror"
 	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/internal/internalinterface"
 )
 
 // FactoryOption apply changes to ExporterOptions.
@@ -38,6 +39,7 @@ type CreateMetricsExporter func(context.Context, component.ExporterCreateSetting
 type CreateLogsExporter func(context.Context, component.ExporterCreateSettings, config.Exporter) (component.LogsExporter, error)
 
 type factory struct {
+	internalinterface.BaseInternal
 	cfgType               config.Type
 	createDefaultConfig   CreateDefaultConfig
 	createTracesExporter  CreateTracesExporter

--- a/extension/extensionhelper/factory.go
+++ b/extension/extensionhelper/factory.go
@@ -19,6 +19,7 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/internal/internalinterface"
 )
 
 // FactoryOption apply changes to ExporterOptions.
@@ -31,6 +32,7 @@ type CreateDefaultConfig func() config.Extension
 type CreateServiceExtension func(context.Context, component.ExtensionCreateSettings, config.Extension) (component.Extension, error)
 
 type factory struct {
+	internalinterface.BaseInternal
 	cfgType                config.Type
 	createDefaultConfig    CreateDefaultConfig
 	createServiceExtension CreateServiceExtension

--- a/receiver/receiverhelper/factory.go
+++ b/receiver/receiverhelper/factory.go
@@ -21,6 +21,7 @@ import (
 	"go.opentelemetry.io/collector/component/componenterror"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/internal/internalinterface"
 )
 
 // FactoryOption apply changes to ReceiverOptions.
@@ -60,6 +61,7 @@ type CreateMetricsReceiver func(context.Context, component.ReceiverCreateSetting
 type CreateLogsReceiver func(context.Context, component.ReceiverCreateSettings, config.Receiver, consumer.Logs) (component.LogsReceiver, error)
 
 type factory struct {
+	internalinterface.BaseInternal
 	cfgType               config.Type
 	createDefaultConfig   CreateDefaultConfig
 	createTracesReceiver  CreateTracesReceiver

--- a/service/configcheck_test.go
+++ b/service/configcheck_test.go
@@ -22,6 +22,7 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/internal/internalinterface"
 	"go.opentelemetry.io/collector/service/defaultcomponents"
 )
 
@@ -47,7 +48,9 @@ func TestValidateConfigFromFactories_Failure(t *testing.T) {
 
 // badConfigExtensionFactory was created to force error path from factory returning
 // a config not satisfying the validation.
-type badConfigExtensionFactory struct{}
+type badConfigExtensionFactory struct {
+	internalinterface.BaseInternal
+}
 
 func (b badConfigExtensionFactory) Type() config.Type {
 	return "bad_config"


### PR DESCRIPTION
**Description:** 

Make `component.Factory` embed `internalinterface.InternalInterface`, so that the component factories must be implemented using the helpers.

This also includes extensions (which are not part of the focus of #3921, since extensions don't have per-signal methods), but I think for consistency it's better to add them (moving the internalinterface dependency to individual interfaces wouldn't be a breaking change if we find this is too restrictive).

This is a follow up to #4175.

**Link to tracking Issue:** fixes #3921
