### PR TITLE
[test] fixing flaky TestBatchMetricsProcessor_Timeout

### DIFF
--- a/processor/batchprocessor/batch_processor_test.go
+++ b/processor/batchprocessor/batch_processor_test.go
@@ -395,7 +395,7 @@ func TestBatchMetricsProcessor_Timeout(t *testing.T) {
 	cfg := Config{
 		ProcessorSettings: config.NewProcessorSettings(config.NewComponentID(typeStr)),
 		Timeout:           100 * time.Millisecond,
-		SendBatchSize:     100,
+		SendBatchSize:     101,
 	}
 	requestCount := 5
 	metricsPerRequest := 10


### PR DESCRIPTION
**Description:**

The batch size was 100 and the number of datapoints being generated was also 100 so at times, the batch processor would be sending the data before the timeout was reached, which is what this particular test is trying to test. To fix this, I'm increasing the batch send size to 101.

**Link to tracking Issue:** Fixes #4322
