### PR TITLE
Move builder/cmd/root to internal, no need to be public

### DIFF
--- a/cmd/builder/internal/root.go
+++ b/cmd/builder/internal/root.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package internal // import "go.opentelemetry.io/collector/cmd/builder/cmd"
+package internal // import "go.opentelemetry.io/collector/cmd/builder/internal"
 
 import (
 	"fmt"

--- a/cmd/builder/internal/root.go
+++ b/cmd/builder/internal/root.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package cmd // import "go.opentelemetry.io/collector/cmd/builder/cmd"
+package internal // import "go.opentelemetry.io/collector/cmd/builder/cmd"
 
 import (
 	"fmt"

--- a/cmd/builder/main.go
+++ b/cmd/builder/main.go
@@ -18,11 +18,11 @@ import (
 	"fmt"
 	"os"
 
-	"go.opentelemetry.io/collector/cmd/builder/cmd"
+	"go.opentelemetry.io/collector/cmd/builder/internal"
 )
 
 func main() {
-	if err := cmd.Execute(); err != nil {
+	if err := internal.Execute(); err != nil {
 		fmt.Println(err.Error())
 		os.Exit(1)
 	}


### PR DESCRIPTION
Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
