### PR TITLE
memorylimiterprocessor: Remove deprecated config (already no-op) ballast_size_mib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## 🛑 Breaking changes 🛑
 
+- Remove deprecated config (already no-op) `ballast_size_mib` in memorylimiterprocessor (#4365)
 - Remove `config.Receivers`, `config.Exporters`, `config.Processors`, and `config.Extensions`. Use map directly (#4344)
 - Remove `component.BaseProcessorFactory`, use `processorhelper.NewFactory` instead (#4175)
 - Force usage of `exporterhelper.NewFactory` to implement `component.ExporterFactory` (#4338)

--- a/processor/memorylimiterprocessor/README.md
+++ b/processor/memorylimiterprocessor/README.md
@@ -32,11 +32,6 @@ value (otherwise memory usage may exceed the hard limit - even if temporarily).
 A good starting point for `spike_limit_mib` is 20% of the hard limit. Bigger
 `spike_limit_mib` values may be necessary for spiky traffic or for longer check intervals.
 
-In addition, if the ballast size is specified in [ballastextension](../../extension/ballastextension), 
-the same value that is provided via the `ballastextension` will be used in `memory_limitor` for
-calculating the total allocated memory for the collector. 
-The `memory_limiter.ballast_size_mib` config has been deprecated and will be removed soon.
-
 Note that while the processor can help mitigate out of memory situations,
 it is not a replacement for properly sizing and configuring the
 collector. Keep in mind that if the soft limit is crossed, the collector will

--- a/processor/memorylimiterprocessor/config.go
+++ b/processor/memorylimiterprocessor/config.go
@@ -40,14 +40,10 @@ type Config struct {
 	// measurements of memory usage.
 	MemorySpikeLimitMiB uint32 `mapstructure:"spike_limit_mib"`
 
-	// BallastSizeMiB is the size, in MiB, of the ballast size being used by the
-	// process.
-	// Deprecated: use the ballast size configuration in `ballastextension` component instead.
-	BallastSizeMiB uint32 `mapstructure:"ballast_size_mib"`
-
 	// MemoryLimitPercentage is the maximum amount of memory, in %, targeted to be
 	// allocated by the process. The fixed memory settings MemoryLimitMiB has a higher precedence.
 	MemoryLimitPercentage uint32 `mapstructure:"limit_percentage"`
+
 	// MemorySpikePercentage is the maximum, in percents against the total memory,
 	// spike expected between the measurements of memory usage.
 	MemorySpikePercentage uint32 `mapstructure:"spike_limit_percentage"`

--- a/processor/memorylimiterprocessor/config_test.go
+++ b/processor/memorylimiterprocessor/config_test.go
@@ -52,6 +52,5 @@ func TestLoadConfig(t *testing.T) {
 			CheckInterval:       5 * time.Second,
 			MemoryLimitMiB:      4000,
 			MemorySpikeLimitMiB: 500,
-			BallastSizeMiB:      2000,
 		})
 }

--- a/processor/memorylimiterprocessor/factory_test.go
+++ b/processor/memorylimiterprocessor/factory_test.go
@@ -59,7 +59,6 @@ func TestCreateProcessor(t *testing.T) {
 	pCfg := cfg.(*Config)
 	pCfg.MemoryLimitMiB = 5722
 	pCfg.MemorySpikeLimitMiB = 1907
-	pCfg.BallastSizeMiB = 2048
 	pCfg.CheckInterval = 100 * time.Millisecond
 
 	tp, err = factory.CreateTracesProcessor(context.Background(), componenttest.NewNopProcessorCreateSettings(), cfg, consumertest.NewNop())

--- a/processor/memorylimiterprocessor/testdata/config.yaml
+++ b/processor/memorylimiterprocessor/testdata/config.yaml
@@ -20,11 +20,6 @@ processors:
     # The maximum, in MiB, spike expected between the measurements of memory usage.
     spike_limit_mib: 500
 
-    # BallastSizeMiB is the size, in MiB, of the ballast size being used by the process.
-    # This must match the value of mem-ballast-size-mib command line option (if used)
-    # otherwise the memory limiter will not work correctly.
-    ballast_size_mib: 2000
-
 exporters:
   nop:
 


### PR DESCRIPTION
Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
