### PR TITLE
Update Kubernetes example to latest version

### DIFF
--- a/examples/k8s/otel-config.yaml
+++ b/examples/k8s/otel-config.yaml
@@ -65,9 +65,7 @@ spec:
       - command:
           - "/otelcol"
           - "--config=/conf/otel-agent-config.yaml"
-          # Memory Ballast size should be max 1/3 to 1/2 of memory.
-          - "--mem-ballast-size-mib=165"
-        image: otel/opentelemetry-collector-dev:latest
+        image: otel/opentelemetry-collector:0.38.0
         name: otel-agent
         resources:
           limits:
@@ -177,9 +175,7 @@ spec:
       - command:
           - "/otelcol"
           - "--config=/conf/otel-collector-config.yaml"
-#           Memory Ballast size should be max 1/3 to 1/2 of memory.
-          - "--mem-ballast-size-mib=683"
-        image: otel/opentelemetry-collector-dev:latest
+        image: otel/opentelemetry-collector:0.38.0
         name: otel-collector
         resources:
           limits:
@@ -214,3 +210,4 @@ spec:
 #                path: cert.pem
 #              - key: key.pem
 #                path: key.pem
+


### PR DESCRIPTION
Description:
The k8s example [here](https://raw.githubusercontent.com/open-telemetry/opentelemetry-collector/main/examples/k8s/otel-config.yaml) has old otel collector image which does not had the new tls config implementation so replacing with new one and command line flag --mem-ballast-size-mib has been deprecated so removed that flag as well.

Link to tracking Issue:
[4247](https://github.com/open-telemetry/opentelemetry-collector/issues/4247)

Testing:
I performed following steps in minikube k8s
$ kubectl apply -f otel-config.yaml

$ kubectl get pod

and checked all pod were up and there were no TLS error

Documentation:
Once it gets merged I will update the docs.


Since Easycla is not being triggered for my account which is https://github.com/shree007 so I am trying with another account. I have created the Linux foundation account and connect the my current github account.