### PR TITLE
correct traceid error log

### DIFF
--- a/model/internal/data/traceid.go
+++ b/model/internal/data/traceid.go
@@ -21,7 +21,7 @@ import (
 
 const traceIDSize = 16
 
-var errInvalidTraceIDSize = errors.New("invalid length for SpanID")
+var errInvalidTraceIDSize = errors.New("invalid length for TraceID")
 
 // TraceID is a custom data type that is used for all trace_id fields in OTLP
 // Protobuf messages.


### PR DESCRIPTION
**Description:**
Fixing a bug - Correct TraceID error log

from
`var errInvalidTraceIDSize = errors.New("invalid length for SpanID")`
to
`var errInvalidTraceIDSize = errors.New("invalid length for TraceID")`
