### PR TITLE
fix(builder): fixes ldflags module path for version and date in builder goreleaser

### DIFF
--- a/cmd/builder/.goreleaser.yml
+++ b/cmd/builder/.goreleaser.yml
@@ -5,7 +5,7 @@ builds:
   - flags:
       - -trimpath
     ldflags:
-      - -s -w -X go.opentelemetry.io/collector/builder/cmd.version={{.Version}} -X go.opentelemetry.io/collector/builder/cmd.date={{.Date}}
+      - -s -w -X go.opentelemetry.io/collector/cmd/builder/internal.version={{.Version}} -X go.opentelemetry.io/collector/cmd/builder/internal.date={{.Date}}
     env:
       - CGO_ENABLED=0
     goos:


### PR DESCRIPTION
**Description:** Fixing a ldflags bug in the builder. Currently it does not get to replace either version or date.

**Testing:**
Before:
```
goreleaser release --snapshot --rm-dist
./dist/opentelemetry-collector_darwin_amd64/opentelemetry-collector version
2021-11-08T14:41:22.701-0600	INFO	internal/root.go:100	OpenTelemetry Collector distribution builder	{"version": "dev", "date": "unknown"}
2021-11-08T14:41:22.702-0600	INFO	internal/root.go:120	Using config file	{"path": "/Users/isantos/.otelcol-builder.yaml"}
builder version dev
```

After:
```
./dist/opentelemetry-collector_darwin_amd64/opentelemetry-collector version
2021-11-08T14:46:36.713-0600	INFO	internal/root.go:100	OpenTelemetry Collector distribution builder	{"version": "v0.39.0-next", "date": "2021-11-08T20:46:26Z"}
2021-11-08T14:46:36.714-0600	INFO	internal/root.go:120	Using config file	{"path": "/Users/isantos/.otelcol-builder.yaml"}
builder version v0.39.0-next
```
**Documentation:** 
Context: https://github.com/open-telemetry/opentelemetry-collector/issues/4380
