### PR TITLE
Copy AggregationTemporality and IsMonotonic to new metric batches

### DIFF
--- a/processor/batchprocessor/splitmetrics.go
+++ b/processor/batchprocessor/splitmetrics.go
@@ -133,8 +133,11 @@ func splitMetric(ms, dest pdata.Metric, size int) (int, bool) {
 	case pdata.MetricDataTypeGauge:
 		return splitNumberDataPoints(ms.Gauge().DataPoints(), dest.Gauge().DataPoints(), size)
 	case pdata.MetricDataTypeSum:
+		dest.Sum().SetAggregationTemporality(ms.Sum().AggregationTemporality())
+		dest.Sum().SetIsMonotonic(ms.Sum().IsMonotonic())
 		return splitNumberDataPoints(ms.Sum().DataPoints(), dest.Sum().DataPoints(), size)
 	case pdata.MetricDataTypeHistogram:
+		dest.Histogram().SetAggregationTemporality(ms.Histogram().AggregationTemporality())
 		return splitHistogramDataPoints(ms.Histogram().DataPoints(), dest.Histogram().DataPoints(), size)
 	case pdata.MetricDataTypeSummary:
 		return splitSummaryDataPoints(ms.Summary().DataPoints(), dest.Summary().DataPoints(), size)

--- a/processor/batchprocessor/splitmetrics_test.go
+++ b/processor/batchprocessor/splitmetrics_test.go
@@ -174,24 +174,36 @@ func TestSplitMetricsBatchSizeSmallerThanDataPointCount(t *testing.T) {
 
 	splitSize := 1
 	split := splitMetrics(splitSize, md)
+	splitMetric := split.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(0)
 	assert.Equal(t, 1, split.MetricCount())
 	assert.Equal(t, 2, md.MetricCount())
-	assert.Equal(t, "test-metric-int-0-0", split.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(0).Name())
+	assert.Equal(t, pdata.MetricAggregationTemporalityCumulative, splitMetric.Sum().AggregationTemporality())
+	assert.Equal(t, true, splitMetric.Sum().IsMonotonic())
+	assert.Equal(t, "test-metric-int-0-0", splitMetric.Name())
 
 	split = splitMetrics(splitSize, md)
+	splitMetric = split.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(0)
 	assert.Equal(t, 1, split.MetricCount())
 	assert.Equal(t, 1, md.MetricCount())
-	assert.Equal(t, "test-metric-int-0-0", split.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(0).Name())
+	assert.Equal(t, pdata.MetricAggregationTemporalityCumulative, splitMetric.Sum().AggregationTemporality())
+	assert.Equal(t, true, splitMetric.Sum().IsMonotonic())
+	assert.Equal(t, "test-metric-int-0-0", splitMetric.Name())
 
 	split = splitMetrics(splitSize, md)
+	splitMetric = split.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(0)
 	assert.Equal(t, 1, split.MetricCount())
 	assert.Equal(t, 1, md.MetricCount())
-	assert.Equal(t, "test-metric-int-0-1", split.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(0).Name())
+	assert.Equal(t, pdata.MetricAggregationTemporalityCumulative, splitMetric.Sum().AggregationTemporality())
+	assert.Equal(t, true, splitMetric.Sum().IsMonotonic())
+	assert.Equal(t, "test-metric-int-0-1", splitMetric.Name())
 
 	split = splitMetrics(splitSize, md)
+	splitMetric = split.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(0)
 	assert.Equal(t, 1, split.MetricCount())
 	assert.Equal(t, 1, md.MetricCount())
-	assert.Equal(t, "test-metric-int-0-1", split.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(0).Name())
+	assert.Equal(t, pdata.MetricAggregationTemporalityCumulative, splitMetric.Sum().AggregationTemporality())
+	assert.Equal(t, true, splitMetric.Sum().IsMonotonic())
+	assert.Equal(t, "test-metric-int-0-1", splitMetric.Name())
 }
 
 func TestSplitMetricsMultipleILM(t *testing.T) {


### PR DESCRIPTION
**Description:**
Fix a regression in which metric batches do not have aggregation temporality and IsMonotonic set for cumulative metrics.  The issue was introduced in #3573, where we changed to having to copy each field from the old metric to the new one.  These fields were missed, and thus get their default value when new batches of metrics were created.

I looked at the implementation of [CopyTo](https://github.com/open-telemetry/opentelemetry-collector/blob/main/model/pdata/generated_metrics.go#L716) that is used for copying metrics elsewhere to make sure I fix all issues of this type.  For Sum, we are missing AggregationTemporality and IsMonotonic.  We were also missing [AggregationTemporality](https://github.com/open-telemetry/opentelemetry-collector/blob/main/model/pdata/generated_metrics.go#L768) for histograms, so I added that as well.  Both summary and gauges only copy data points, so the status quo is correct.

**Link to tracking Issue:**
Fixes #4388

**Testing:**

Unit testing.  The test changes I made fail without the corresponding changes to metric splitting.  I haven't had a chance to e2e test it yet to show that it fixes the issue I was seeing, but it seems fairly obvious that this is the correct fix for my problems.

cc @Aneurysm9 

