### PR TITLE
Implement composite watchable config map provider

### DIFF
--- a/config/configmapprovider/composite.go
+++ b/config/configmapprovider/composite.go
@@ -1,0 +1,294 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package configmapprovider // import "go.opentelemetry.io/collector/config/configmapprovider"
+
+import (
+	"context"
+
+	"go.uber.org/multierr"
+
+	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/config/experimental/configsource"
+)
+
+// configComposeFunc combines a current config "orig" with another config "add".
+// The resulting config is stored in "orig".
+type configComposeFunc func(orig *config.Map, add *config.Map) error
+
+// compositeMapProvider creates a map provider that is a composite of other map providers.
+// The composition function that combines the config maps returned by the providers
+// must be provided externally.
+type compositeMapProvider struct {
+	composeFunc  configComposeFunc
+	subProviders []Provider
+	retrieved    *compositeRetrieved
+}
+
+// NewComposite returns a Provider, that combines multiple
+// Providers.
+//
+// The resulting config.Map is created by composing the config.Maps returned
+// by each subprovider in the specified order into an initially empty config.Map
+// using the composeFunc.
+//
+// The returned map provider's Retrieved object also implements a WatchableRetrieved
+// interface which is triggered when a WatchableRetrieved of any subprovider is triggered.
+//
+// TODO: pass logger to compositeMapProvider for debug logging and to pass to
+// subproviders such as fileMapProvider to print when the file is changed.
+func NewComposite(composeFunc configComposeFunc, subProviders ...Provider) Provider {
+	return &compositeMapProvider{composeFunc: composeFunc, subProviders: subProviders}
+}
+
+// A list of Retrieved objects.
+type retrievedList []Retrieved
+
+// getAllAndCompose calls Get() of each subprovider, then uses the composeFunc to combine
+// each returned config.Map into one config.Map and return the resulting map.
+func (rl retrievedList) getAllAndCompose(composeFunc configComposeFunc) (*config.Map, error) {
+	// We start with an empty map.
+	retCfgMap := config.NewMap()
+	for _, retrieved := range rl {
+		// Get a map from subprovider.
+		configMap := retrieved.Get()
+
+		// And compose it on top of the current map.
+		if err := composeFunc(retCfgMap, configMap); err != nil {
+			return nil, err
+		}
+	}
+
+	return retCfgMap, nil
+}
+
+func (mp *compositeMapProvider) Retrieve(ctx context.Context) (Retrieved, error) {
+	rList := retrievedList{}
+
+	// Call Retrieve() of every subprovider and remember the resulting Retrieved.
+	for _, p := range mp.subProviders {
+		retr, err := p.Retrieve(ctx)
+		if err != nil {
+			return nil, err
+		}
+		rList = append(rList, retr)
+	}
+
+	// Create a Retrieved object that has the list of subprovider's Retrieved objects.
+	var err error
+	mp.retrieved, err = newCompositeRetrieved(ctx, mp.composeFunc, rList)
+	return mp.retrieved, err
+}
+
+func (mp *compositeMapProvider) Close(ctx context.Context) error {
+	var errs error
+
+	// If Retrieved() was called close it.
+	if mp.retrieved != nil {
+		err := mp.retrieved.Close(ctx)
+		errs = multierr.Append(errs, err)
+	}
+
+	// Close all subproviders.
+	for _, sub := range mp.subProviders {
+		err := sub.Close(ctx)
+		errs = multierr.Append(errs, err)
+	}
+
+	return errs
+}
+
+// compositeRetrieved tracks a list of subproviders' Retrieved objects and watches
+// for WatchForUpdate() of these Retrieved to return.
+// ┌────────────────────┐
+// │ compositeRetrieved │
+// └─────────┬──────────┘
+//           │
+//           │   ┌─────────┬─────────┬─────────┬───┐
+//           └──►│Retrieved│Retrieved│Retrieved│...│
+//               └─────────┴─────────┴─────────┴───┘
+type compositeRetrieved struct {
+	// The current config map composed from subprovider's config maps. Will be returned
+	// by Get() func.
+	composedMap *config.Map
+
+	composeFunc configComposeFunc
+
+	// List of retrieved subproviders.
+	subRetrieved retrievedList
+
+	// A cancellable context that is used for long-running operations in WatchForUpdate().
+	watchContext       context.Context
+	cancelWatchContext func()
+}
+
+// A Watchable of which WaitForUpdate() returned and that is ready for Get() call.
+type readyWatchable struct {
+	// The Watchable that is ready.
+	watchable WatchableRetrieved
+
+	// The value that was returned by WaitForUpdate().
+	returnedError error
+}
+
+// Create a new composite Retrieved object from a list of Retrieved objects returned
+// by subproviders' Retrieve() calls.
+func newCompositeRetrieved(
+	ctx context.Context,
+	composeFunc configComposeFunc,
+	subRetrieved retrievedList,
+) (*compositeRetrieved, error) {
+	// Unfortunately Retrieved.Get() cannot return an error, but it is
+	// possible that composeFunc returns an error. Because of that we cannot
+	// do the composition using composeFunc in our Get() implementation and
+	// have to do it here so that we can return an error.
+	// TODO: change Retrieved.Get() to allow returning an error and move
+	// the following code to our Get().
+
+	// Call Get() on all sub-retrieved and combine the results using the composeFunc.
+	composedMap, err := subRetrieved.getAllAndCompose(composeFunc)
+	if err != nil {
+		// Didn't work. Close every WatchableRetrieved that may be on our list.
+		for _, retr := range subRetrieved {
+			if watchable, ok := retr.(WatchableRetrieved); ok {
+				err2 := watchable.Close(ctx)
+				err = multierr.Append(err, err2)
+			}
+		}
+		return nil, err
+	}
+
+	// Create a new cancellable context for long-running operations.
+	ctx, cancelFunc := context.WithCancel(context.Background())
+
+	m := &compositeRetrieved{
+		composedMap:        composedMap,
+		composeFunc:        composeFunc,
+		subRetrieved:       subRetrieved,
+		watchContext:       ctx,
+		cancelWatchContext: cancelFunc,
+	}
+
+	return m, nil
+}
+
+func (cr *compositeRetrieved) Get() *config.Map {
+	// WatchableRetrieved requires that Get() is never called concurrently
+	// with WatchForUpdate() which means a race on cr.composedMap is not possible
+	// since the only place where we modify it is in WatchForUpdate(), so there
+	// is no need to protect cr.composedMap from races.
+	return cr.composedMap
+}
+
+func (cr *compositeRetrieved) WatchForUpdate() error {
+	// Create one go routine per sub-retrieved and start waiting for WatchForUpdate()
+	// of any Watchable sub-retrieved to return.
+
+	// Channel used to signal that sub-retrieved WaitForUpdate() returned.
+	readyWatchableCh := make(chan readyWatchable)
+
+	// Count how many of the sub-retrieved are watchable.
+	watchableCount := 0
+	for _, subRetrieved := range cr.subRetrieved {
+		if watchable, ok := subRetrieved.(WatchableRetrieved); ok {
+			// This is a Watchable sub-retrieved.
+			// Start watching for updates from this WatchableRetrieved.
+			watchableCount++
+			go func() {
+				err := watchable.WatchForUpdate()
+				select {
+				case readyWatchableCh <- readyWatchable{watchable, err}:
+					// We have an update, signal it to the outer func.
+				case <-cr.watchContext.Done():
+					// We are instructed to terminate. Just return.
+				}
+			}()
+		}
+	}
+
+	select {
+	case readyWatchable := <-readyWatchableCh:
+
+		// At least one watcher fired. Close all sub-Retrieved. We don't need
+		// to close the one that fired the signal (readyWatchable.watchable),
+		// so provide it as an exception to closeAllExcept().
+		if err := cr.closeAllExcept(cr.watchContext, readyWatchable.watchable); err != nil {
+			return err
+		}
+
+		// Wait for all sub-retrieved WatchForUpdate() to return. They either will return
+		// because there is an update or because we closed them via closeAllExcept()
+		// call above.
+		err := readyWatchable.returnedError
+		for i := 0; i < watchableCount-1; i++ {
+			select {
+			case watchable := <-readyWatchableCh:
+				// One more sub-retrieved's WatchForUpdate() returned.
+				// ErrSessionClosed is expected because we called Close. If it is
+				// any other error then it is unexpected so return the error to the caller.
+				if watchable.returnedError != nil && watchable.returnedError != configsource.ErrSessionClosed {
+					err = multierr.Append(err, watchable.returnedError)
+				}
+				continue
+			case <-cr.watchContext.Done():
+				// We are instructed to terminate.
+				return configsource.ErrSessionClosed
+			}
+		}
+
+		if err == nil {
+			// All Watchables returned without error, which means they are ready for
+			// another Get() call. Call Get() for all subproviders again and combine
+			// the results.
+			configMap, err2 := cr.subRetrieved.getAllAndCompose(cr.composeFunc)
+			if err2 != nil {
+				return err2
+			}
+
+			// Remember the result.
+			cr.composedMap = configMap
+		}
+
+		// Propagate the result to our caller.
+		return err
+
+	case <-cr.watchContext.Done():
+		// We are instructed to terminate.
+		return configsource.ErrSessionClosed
+	}
+}
+
+// Close all watchable subproviders' Retrieved, except the one that is provided as
+// and "except" parameter.
+func (cr *compositeRetrieved) closeAllExcept(ctx context.Context, except WatchableRetrieved) error {
+	var errs error
+	for _, retr := range cr.subRetrieved {
+		if watchable, ok := retr.(WatchableRetrieved); ok {
+			if watchable != except {
+				if err := watchable.Close(ctx); err != nil {
+					errs = multierr.Append(errs, err)
+				}
+			}
+		}
+	}
+	return errs
+}
+
+func (cr *compositeRetrieved) Close(ctx context.Context) error {
+	// Cancel any long-running operations in WatchForUpdate().
+	cr.cancelWatchContext()
+
+	// Close all sub-retrieved.
+	return cr.closeAllExcept(ctx, nil)
+}

--- a/config/configmapprovider/composite_test.go
+++ b/config/configmapprovider/composite_test.go
@@ -1,0 +1,381 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package configmapprovider
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/config/experimental/configsource"
+)
+
+func TestComposite_Watchable_Update(t *testing.T) {
+	// Create a composite provider from 2 subproviders.
+
+	// This is our compose func. It just returns a predictable config that is different
+	// every time so that we can verify that Get() method returns what we expect.
+	composeCounter := 0
+	composeFunc := func(orig *config.Map, add *config.Map) error {
+		composeCounter++
+		orig.Set("counter", composeCounter)
+		return nil
+	}
+
+	subProvider1 := newMockWatchableProvider(t)
+	subProvider2 := newMockWatchableProvider(t)
+
+	composite := NewComposite(composeFunc, subProvider1, subProvider2)
+	require.NotNil(t, composite)
+
+	// Retrieve the initial config from composite.
+	retrieved, err := composite.Retrieve(context.Background())
+	assert.NoError(t, err)
+	assert.NotNil(t, retrieved)
+
+	cfg := retrieved.Get()
+	assert.NotNil(t, cfg)
+
+	// composeFunc should be called twice, so "counter" should be equal to 2.
+	assert.EqualValues(t, 2, cfg.Get("counter"))
+
+	// Now we are going to loop through [WatchForUpdate(), signal from subprovider
+	// that there is an update, Get()] sequence a few times. We want to verify that:
+	// - WatchForUpdate() of composite provider returns as expected.
+	// - Get() returns the expected composed config.
+	// - WatchForUpdate() can be restarted after it fires.
+	for i := 0; i < 10; i++ {
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func(i int) {
+			// This should block until SignalUpdateAvailable() is called.
+			err := retrieved.(WatchableRetrieved).WatchForUpdate()
+			assert.Nil(t, err)
+
+			// We have an updated config, get it.
+			cfg := retrieved.Get()
+			assert.NotNil(t, cfg)
+
+			// Did we get the expected composed config? This should match the
+			// "counter" value populated by composeFunc above. The "counter"
+			// increases by 2 on every run.
+			assert.EqualValues(t, (i+2)*2, cfg.Get("counter"))
+
+			wg.Done()
+		}(i)
+
+		// SignalUpdateAvailable() should terminate WatchForUpdate().
+		subProvider1.SignalUpdateAvailable(nil)
+
+		// Wait for WatchForUpdate() to be terminated.
+		wg.Wait()
+	}
+
+	assert.EqualValues(t, 0, subProvider1.GetCloseCallCounter())
+	assert.EqualValues(t, 0, subProvider2.GetCloseCallCounter())
+
+	// Close the composite provider. This should result in closing of subproviders.
+	composite.Close(context.Background())
+
+	// Verify that Close() of the subproviders was also called.
+	assert.EqualValues(t, 1, subProvider1.GetCloseCallCounter())
+	assert.EqualValues(t, 1, subProvider2.GetCloseCallCounter())
+}
+
+func TestComposite_Watchable_Close(t *testing.T) {
+	// Create a composite provider from 1 subprovider.
+	composeFunc := func(orig *config.Map, add *config.Map) error {
+		return nil
+	}
+
+	subProvider := newMockWatchableProvider(t)
+
+	composite := NewComposite(composeFunc, subProvider)
+	require.NotNil(t, composite)
+
+	// Retrieve the initial config.
+	retrieved, err := composite.Retrieve(context.Background())
+	assert.NoError(t, err)
+	assert.NotNil(t, retrieved)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		cfg := retrieved.Get()
+		assert.NotNil(t, cfg)
+
+		// This should block until Close() is called.
+		err := retrieved.(WatchableRetrieved).WatchForUpdate()
+
+		// Verify that the correct error is returned as a result of Close().
+		assert.ErrorIs(t, err, configsource.ErrSessionClosed)
+
+		wg.Done()
+	}()
+
+	// Close the composite provider. Close() should terminate WatchForUpdate().
+	composite.Close(context.Background())
+
+	// Wait for WatchForUpdate() to be terminated.
+	wg.Wait()
+
+	// Verify that Close() of the subprovider was also called.
+	assert.EqualValues(t, 1, subProvider.GetCloseCallCounter())
+}
+
+func TestComposite_Watchable_Subprovider_Terminate(t *testing.T) {
+	// Create a composite provider from 2 subproviders.
+	composeFunc := func(orig *config.Map, add *config.Map) error {
+		return nil
+	}
+
+	subProvider := newMockWatchableProvider(t)
+
+	composite := NewComposite(composeFunc, subProvider)
+	require.NotNil(t, composite)
+
+	// Retrieve the initial config.
+	retrieved, err := composite.Retrieve(context.Background())
+	assert.NoError(t, err)
+	assert.NotNil(t, retrieved)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		cfg := retrieved.Get()
+		assert.NotNil(t, cfg)
+
+		// This should block until subprovider's WatchForUpdate() is terminated.
+		err := retrieved.(WatchableRetrieved).WatchForUpdate()
+
+		// Verify that the correct error is returned as a result of subprovider's
+		// termination.
+		assert.ErrorIs(t, err, configsource.ErrSessionClosed)
+		wg.Done()
+	}()
+
+	// SignalUpdateAvailable() will terminate the subprovider's WatchForUpdate()
+	// permanently and make it return ErrSessionClosed.
+	// This should propagate the termination to WatchForUpdate() of composite's
+	// retrieved that we wait for in the go routine above.
+	subProvider.SignalUpdateAvailable(configsource.ErrSessionClosed)
+
+	wg.Wait()
+
+	// Verify that Close() of the subprovider was not yet called.
+	assert.EqualValues(t, 0, subProvider.GetCloseCallCounter())
+
+	composite.Close(context.Background())
+
+	// Verify that Close() of the subprovider was now called.
+	assert.EqualValues(t, 1, subProvider.GetCloseCallCounter())
+}
+
+func TestComposite_Watchable_FailCompose(t *testing.T) {
+	composeFunc := func(orig *config.Map, add *config.Map) error {
+		return errors.New("cannot compose configs")
+	}
+
+	subProvider := newMockWatchableProvider(t)
+
+	composite := NewComposite(composeFunc, subProvider)
+	require.NotNil(t, composite)
+	retrieved, err := composite.Retrieve(context.Background())
+	assert.Error(t, err)
+	assert.Nil(t, retrieved)
+
+	// Verify that Close() of the subprovider was not yet called.
+	assert.EqualValues(t, 0, subProvider.GetCloseCallCounter())
+
+	composite.Close(context.Background())
+
+	// Verify that Close() of the subprovider was now called.
+	assert.EqualValues(t, 1, subProvider.GetCloseCallCounter())
+}
+
+func TestComposite_Watchable_FailCompose_AfterUpdate(t *testing.T) {
+	var composeError error
+	composeFunc := func(orig *config.Map, add *config.Map) error {
+		return composeError
+	}
+
+	subProvider := newMockWatchableProvider(t)
+
+	composite := NewComposite(composeFunc, subProvider)
+	require.NotNil(t, composite)
+	retrieved, err := composite.Retrieve(context.Background())
+	assert.NoError(t, err)
+	assert.NotNil(t, retrieved)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		cfg := retrieved.Get()
+		assert.NotNil(t, cfg)
+
+		// This should block until subprovider's WatchForUpdate() is terminated.
+		err := retrieved.(WatchableRetrieved).WatchForUpdate()
+
+		// Verify that the correct error is returned. Become composeFunc failed, its
+		// returned error should be propagated to WatchForUpdate().
+		assert.ErrorIs(t, err, composeError)
+		wg.Done()
+	}()
+
+	// Next composeFunc call should return an error.
+	composeError = errors.New("cannot compose configs")
+
+	// Signal WatchForUpdate() to return. This will begin a new retrieving session
+	// and the composite will call Get() of subproviders and will then call composeFunc.
+	// composeFunc should fail this time and the composite's WatchForUpdate() should
+	// fail too and sohuld return an error.
+	subProvider.SignalUpdateAvailable(nil)
+
+	wg.Wait()
+}
+
+func TestComposite_Subprovider_Close_Fail(t *testing.T) {
+	// Create a composite provider from 2 subproviders.
+	composeFunc := func(orig *config.Map, add *config.Map) error {
+		return nil
+	}
+
+	subProvider1 := newMockWatchableProvider(t)
+	subProvider2 := newMockWatchableProvider(t)
+
+	composite := NewComposite(composeFunc, subProvider1, subProvider2)
+	require.NotNil(t, composite)
+
+	// Retrieve the initial config from composite.
+	retrieved, err := composite.Retrieve(context.Background())
+	assert.NoError(t, err)
+	assert.NotNil(t, retrieved)
+
+	subErr := errors.New("bad failure")
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		cfg := retrieved.Get()
+		assert.NotNil(t, cfg)
+
+		// This should block until subprovider's WatchForUpdate() is terminated.
+		err = retrieved.(WatchableRetrieved).WatchForUpdate()
+
+		// Verify that the correct error is returned as a result of subprovider's
+		// termination.
+		assert.ErrorIs(t, err, subErr)
+		wg.Done()
+	}()
+
+	// Prepare the first subprovider to return an error on close.
+	subProvider1.SetCloseReturnError(subErr)
+
+	// Signal that the second subprovider has a regular update. This should trigger
+	// the call to Close() of the first subprovider which should return an error.
+	// This in turn should result in WatchForUpdate() of the composite
+	// to return that same error, which we check above in the go routine.
+	subProvider2.SignalUpdateAvailable(nil)
+
+	wg.Wait()
+
+	// Close the composite provider. This should result in closing of subproviders.
+	err = composite.Close(context.Background())
+
+	// We should also get the same subprovider's error here.
+	assert.ErrorIs(t, err, subErr)
+
+	// Verify that Close() of the subproviders was called.
+	assert.EqualValues(t, 1, subProvider1.GetCloseCallCounter())
+	assert.EqualValues(t, 1, subProvider2.GetCloseCallCounter())
+}
+
+// A map provider which is watchable and can be forces to return from WatchForUpdate.
+type mockWatchableProvider struct {
+	watchSignal      chan error
+	closeCallCounter uint64
+	closeReturnError error
+	retrieved        *mockWatchableRetrieved
+	t                *testing.T
+}
+
+func newMockWatchableProvider(t *testing.T) *mockWatchableProvider {
+	return &mockWatchableProvider{
+		watchSignal: make(chan error, 1),
+		t:           t,
+	}
+}
+
+func (p *mockWatchableProvider) Retrieve(context.Context) (Retrieved, error) {
+	p.retrieved = &mockWatchableRetrieved{watchSignal: p.watchSignal, t: p.t}
+	return p.retrieved, nil
+}
+
+func (p *mockWatchableProvider) Close(context.Context) error {
+	atomic.AddUint64(&p.closeCallCounter, 1)
+	return p.closeReturnError
+}
+
+func (p *mockWatchableProvider) GetCloseCallCounter() uint64 {
+	return atomic.LoadUint64(&p.closeCallCounter)
+}
+
+func (p *mockWatchableProvider) SetCloseReturnError(err error) {
+	p.closeReturnError = err
+	if p.retrieved != nil {
+		p.retrieved.closeReturnError = err
+	}
+}
+
+func (p *mockWatchableProvider) SignalUpdateAvailable(withErr error) {
+	// Signal to WatchForUpdate to terminate and return.
+	p.watchSignal <- withErr
+}
+
+type mockWatchableRetrieved struct {
+	watchSignal           chan error
+	closeReturnError      error
+	watchForUpdateCounter int64
+	t                     *testing.T
+}
+
+func (r mockWatchableRetrieved) Get() *config.Map {
+	return config.NewMapFromStringMap(map[string]interface{}{})
+}
+
+func (r *mockWatchableRetrieved) WatchForUpdate() error {
+	watchEntranceCounter := atomic.AddInt64(&r.watchForUpdateCounter, 1)
+	defer atomic.AddInt64(&r.watchForUpdateCounter, -1)
+	assert.EqualValues(r.t, 1, watchEntranceCounter)
+
+	// Wait until signaled by SignalUpdateAvailable().
+	err := <-r.watchSignal
+	return err
+}
+
+func (r *mockWatchableRetrieved) Close(ctx context.Context) error {
+	// Signal to WatchForUpdate to terminate and return.
+	select {
+	case r.watchSignal <- configsource.ErrSessionClosed:
+	default:
+	}
+	return r.closeReturnError
+}

--- a/config/configmapprovider/provider.go
+++ b/config/configmapprovider/provider.go
@@ -26,36 +26,72 @@ type Provider interface {
 	// Retrieve goes to the configuration source and retrieves the selected data which
 	// contains the value to be injected in the configuration and the corresponding watcher that
 	// will be used to monitor for updates of the retrieved value.
+	// Should never be called concurrently with itself.
 	Retrieve(ctx context.Context) (Retrieved, error)
 
 	// Close signals that the configuration for which it was used to retrieve values is no longer in use
 	// and the object should close and release any watchers that it may have created.
 	// This method must be called when the service ends, either in case of success or error.
+	// Should never be called concurrently with itself.
 	Close(ctx context.Context) error
+
+	// Note that Retrieve() and Close() should never be called concurrently. Close()
+	// should be called only after Retrieve() returns.
 }
 
 // Retrieved holds the result of a call to the Retrieve method of a Session object.
 type Retrieved interface {
 	// Get returns the Map.
+	// Should never be called concurrently with itself.
 	Get() *config.Map
 }
 
 // WatchableRetrieved is an extension for Retrieved that if implemented,
 // the Retrieved value supports monitoring for updates.
+//
+// The typical usage is the following:
+//
+//	goroutine 1                                        | go routine 2
+//	                                                   |
+//	r := mapProvider.Retrieve()                        |
+//	r.Get()                                            |
+//	r.WatchForUpdate() blocks until there are updates  |
+//	...                                                |
+//	r.Get()                                            |
+//	r.WatchForUpdate()                                 | Close() can be called anytime after Retrieve() returns
+//  WatchForUpdate() returns when Close() is called.   |
 type WatchableRetrieved interface {
 	Retrieved
 
 	// WatchForUpdate waits for updates on any of the values retrieved from config sources.
-	// It blocks until configuration updates are received and can
-	// return an error if anything fails. WatchForUpdate is used once during the
-	// first evaluation of the configuration and is not used to watch configuration
-	// changes continuously.
+	// It blocks until the configuration updates.
+	//
+	// If the update is successful then the returned error will be nil.
+	// If Close() was called while WatchForUpdate() is in progress then the returned
+	// error will be configsource.ErrSessionClosed.
+	// If anything else fails during watching some other error may be returned.
+	//
+	// WatchForUpdate can be used to watch configuration changes continuously.
+	//
+	// Should never be called concurrently with itself.
+	// Should never be called concurrently with Get().
 	WatchForUpdate() error
 
-	// Close signals that the configuration for which it was used to retrieve values is no longer in use
-	// and the object should close and release any watchers that it may have created.
+	// Close signals that the configuration for which it was used to retrieve values is
+	// no longer in use and the object should close and release any watchers that it
+	// may have created.
+	//
 	// This method must be called when the service ends, either in case of success or error.
+	//
 	// The method may be called while WatchForUpdate() class is in progress and is blocked.
-	// In that case WatchForUpdate() method must abort as soon as possible and return ErrSessionClosed.
+	// In that case WatchForUpdate() method must abort as soon as possible and
+	// return ErrSessionClosed.
+	//
+	// Should never be called concurrently with itself.
+	// May be called before, after or concurrently with WatchForUpdate().
+	// May be called before, after or concurrently with Get().
+	//
+	// Calling Close() on an object that is already closed because WatchForUpdate()
+	// has already returned should not block and should return nil.
 	Close(ctx context.Context) error
 }


### PR DESCRIPTION
The new compositeMapProvider implements a generic map provider
that can be composed of subproviders and also implements a
watchable interface that can be triggered by any subprovider.

The ExpandMapProvider and MergeMapProvider are rewritten using
the compositeMapProvider with custom compose function.

This is necessary to implement file watching in fileMapProvider.
I have that part ready as well, but it won't work until the
providers that contain it are watchable (which this change adds).

There is a fair but of concurrent code in this change, it would
be great to have another pair of eyes to check I don't have
races and other bugs here.
