### PR TITLE
Unit test and changelog follow up to batch processor descriptor fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@
 ## 💡 Enhancements 💡
 - Supports more compression methods(`snappy` and `zstd`) for configgrpc, in addition to current `gzip` (#4088)
 
+## 🧰 Bug fixes 🧰
+
+- Fix AggregationTemporality and IsMonotonic when metric descriptors are split in the batch processor (#4389)
+
 ## v0.38.0 Beta
 
 ## 🛑 Breaking changes 🛑


### PR DESCRIPTION
This makes sure we have full test coverage for all data types in the batch processor, and adds a changelog entry for the fix in #4389, as requested by reviewers.