### PR TITLE
Small nits in logging exporter

### DIFF
--- a/exporter/loggingexporter/config.go
+++ b/exporter/loggingexporter/config.go
@@ -15,6 +15,8 @@
 package loggingexporter // import "go.opentelemetry.io/collector/exporter/loggingexporter"
 
 import (
+	"go.uber.org/zap/zapcore"
+
 	"go.opentelemetry.io/collector/config"
 )
 
@@ -23,7 +25,7 @@ type Config struct {
 	config.ExporterSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
 
 	// LogLevel defines log level of the logging exporter; options are debug, info, warn, error.
-	LogLevel string `mapstructure:"loglevel"`
+	LogLevel zapcore.Level `mapstructure:"loglevel"`
 
 	// SamplingInitial defines how many samples are initially logged during each second.
 	SamplingInitial int `mapstructure:"sampling_initial"`

--- a/exporter/loggingexporter/config_test.go
+++ b/exporter/loggingexporter/config_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
 
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config"
@@ -44,7 +45,7 @@ func TestLoadConfig(t *testing.T) {
 	assert.Equal(t, e1,
 		&Config{
 			ExporterSettings:   config.NewExporterSettings(config.NewComponentIDWithName(typeStr, "2")),
-			LogLevel:           "debug",
+			LogLevel:           zapcore.DebugLevel,
 			SamplingInitial:    10,
 			SamplingThereafter: 50,
 		})

--- a/exporter/loggingexporter/factory.go
+++ b/exporter/loggingexporter/factory.go
@@ -45,7 +45,7 @@ func NewFactory() component.ExporterFactory {
 func createDefaultConfig() config.Exporter {
 	return &Config{
 		ExporterSettings:   config.NewExporterSettings(config.NewComponentID(typeStr)),
-		LogLevel:           "info",
+		LogLevel:           zapcore.InfoLevel,
 		SamplingInitial:    defaultSamplingInitial,
 		SamplingThereafter: defaultSamplingThereafter,
 	}
@@ -59,7 +59,7 @@ func createTracesExporter(_ context.Context, set component.ExporterCreateSetting
 		return nil, err
 	}
 
-	return newTracesExporter(config, cfg.LogLevel, exporterLogger, set)
+	return newTracesExporter(config, exporterLogger, set)
 }
 
 func createMetricsExporter(_ context.Context, set component.ExporterCreateSettings, config config.Exporter) (component.MetricsExporter, error) {
@@ -70,7 +70,7 @@ func createMetricsExporter(_ context.Context, set component.ExporterCreateSettin
 		return nil, err
 	}
 
-	return newMetricsExporter(config, cfg.LogLevel, exporterLogger, set)
+	return newMetricsExporter(config, exporterLogger, set)
 }
 
 func createLogsExporter(_ context.Context, set component.ExporterCreateSettings, config config.Exporter) (component.LogsExporter, error) {
@@ -81,20 +81,14 @@ func createLogsExporter(_ context.Context, set component.ExporterCreateSettings,
 		return nil, err
 	}
 
-	return newLogsExporter(config, cfg.LogLevel, exporterLogger, set)
+	return newLogsExporter(config, exporterLogger, set)
 }
 
 func createLogger(cfg *Config) (*zap.Logger, error) {
-	var level zapcore.Level
-	err := (&level).UnmarshalText([]byte(cfg.LogLevel))
-	if err != nil {
-		return nil, err
-	}
-
 	// We take development config as the base since it matches the purpose
 	// of logging exporter being used for debugging reasons (so e.g. console encoder)
 	conf := zap.NewDevelopmentConfig()
-	conf.Level = zap.NewAtomicLevelAt(level)
+	conf.Level = zap.NewAtomicLevelAt(cfg.LogLevel)
 	conf.Sampling = &zap.SamplingConfig{
 		Initial:    cfg.SamplingInitial,
 		Thereafter: cfg.SamplingThereafter,

--- a/exporter/loggingexporter/logging_exporter_test.go
+++ b/exporter/loggingexporter/logging_exporter_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
 
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config"
@@ -29,7 +30,7 @@ import (
 )
 
 func TestLoggingTracesExporterNoErrors(t *testing.T) {
-	lte, err := newTracesExporter(&config.ExporterSettings{}, "Debug", zap.NewNop(), componenttest.NewNopExporterCreateSettings())
+	lte, err := newTracesExporter(&config.ExporterSettings{}, zap.NewNop(), componenttest.NewNopExporterCreateSettings())
 	require.NotNil(t, lte)
 	assert.NoError(t, err)
 
@@ -40,7 +41,7 @@ func TestLoggingTracesExporterNoErrors(t *testing.T) {
 }
 
 func TestLoggingMetricsExporterNoErrors(t *testing.T) {
-	lme, err := newMetricsExporter(&config.ExporterSettings{}, "DEBUG", zap.NewNop(), componenttest.NewNopExporterCreateSettings())
+	lme, err := newMetricsExporter(&config.ExporterSettings{}, zap.NewNop(), componenttest.NewNopExporterCreateSettings())
 	require.NotNil(t, lme)
 	assert.NoError(t, err)
 
@@ -53,7 +54,7 @@ func TestLoggingMetricsExporterNoErrors(t *testing.T) {
 }
 
 func TestLoggingLogsExporterNoErrors(t *testing.T) {
-	lle, err := newLogsExporter(&config.ExporterSettings{}, "debug", zap.NewNop(), componenttest.NewNopExporterCreateSettings())
+	lle, err := newLogsExporter(&config.ExporterSettings{}, zap.NewNop(), componenttest.NewNopExporterCreateSettings())
 	require.NotNil(t, lle)
 	assert.NoError(t, err)
 
@@ -66,7 +67,7 @@ func TestLoggingLogsExporterNoErrors(t *testing.T) {
 }
 
 func TestLoggingExporterErrors(t *testing.T) {
-	le := newLoggingExporter("Debug", zap.NewNop())
+	le := newLoggingExporter(zaptest.NewLogger(t))
 	require.NotNil(t, le)
 
 	errWant := errors.New("my error")


### PR DESCRIPTION
* Use zapcore.Level in config to avoid manual parsing.
* Use logger.Core to determine if debug is enabled.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
