### PR TITLE
Refactor configmapprovider.Provider and Retrieved interfaces

### DIFF
--- a/config/configmapprovider/expand.go
+++ b/config/configmapprovider/expand.go
@@ -31,20 +31,23 @@ func NewExpand(base Provider) Provider {
 	}
 }
 
-func (emp *expandMapProvider) Retrieve(ctx context.Context) (Retrieved, error) {
-	retr, err := emp.base.Retrieve(ctx)
+func (emp *expandMapProvider) Retrieve(ctx context.Context, onChange func(*ChangeEvent)) (Retrieved, error) {
+	retr, err := emp.base.Retrieve(ctx, onChange)
 	if err != nil {
 		return nil, err
 	}
-	cfgMap := retr.Get()
+	cfgMap, err := retr.Get(ctx)
+	if err != nil {
+		return nil, err
+	}
 	for _, k := range cfgMap.AllKeys() {
 		cfgMap.Set(k, expandStringValues(cfgMap.Get(k)))
 	}
 	return &simpleRetrieved{confMap: cfgMap}, nil
 }
 
-func (emp *expandMapProvider) Close(ctx context.Context) error {
-	return emp.base.Close(ctx)
+func (emp *expandMapProvider) Shutdown(ctx context.Context) error {
+	return emp.base.Shutdown(ctx)
 }
 
 func expandStringValues(value interface{}) interface{} {

--- a/config/configmapprovider/expand_test.go
+++ b/config/configmapprovider/expand_test.go
@@ -57,11 +57,13 @@ func TestExpand(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			// Retrieve the config
 			emp := NewExpand(NewFile(path.Join("testdata", test.name)))
-			cp, err := emp.Retrieve(context.Background())
+			cp, err := emp.Retrieve(context.Background(), nil)
 			require.NoError(t, err, "Unable to get config")
 
 			// Test that expanded configs are the same with the simple config with no env vars.
-			assert.Equal(t, expectedCfgMap.ToStringMap(), cp.Get().ToStringMap())
+			m, err := cp.Get(context.Background())
+			require.NoError(t, err)
+			assert.Equal(t, expectedCfgMap.ToStringMap(), m.ToStringMap())
 		})
 	}
 }
@@ -75,7 +77,7 @@ func TestExpand_EscapedEnvVars(t *testing.T) {
 
 	// Retrieve the config
 	emp := NewExpand(NewFile(path.Join("testdata", "expand-escaped-env.yaml")))
-	cp, err := emp.Retrieve(context.Background())
+	cp, err := emp.Retrieve(context.Background(), nil)
 	require.NoError(t, err, "Unable to get config")
 
 	expectedMap := map[string]interface{}{
@@ -95,5 +97,7 @@ func TestExpand_EscapedEnvVars(t *testing.T) {
 			// escaped $ alone
 			"recv.7": "$",
 		}}
-	assert.Equal(t, expectedMap, cp.Get().ToStringMap())
+	m, err := cp.Get(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, expectedMap, m.ToStringMap())
 }

--- a/config/configmapprovider/file.go
+++ b/config/configmapprovider/file.go
@@ -33,7 +33,7 @@ func NewFile(fileName string) Provider {
 	}
 }
 
-func (fmp *fileMapProvider) Retrieve(context.Context) (Retrieved, error) {
+func (fmp *fileMapProvider) Retrieve(_ context.Context, _ func(*ChangeEvent)) (Retrieved, error) {
 	if fmp.fileName == "" {
 		return nil, errors.New("config file not specified")
 	}
@@ -46,6 +46,6 @@ func (fmp *fileMapProvider) Retrieve(context.Context) (Retrieved, error) {
 	return &simpleRetrieved{confMap: cp}, nil
 }
 
-func (*fileMapProvider) Close(context.Context) error {
+func (*fileMapProvider) Shutdown(context.Context) error {
 	return nil
 }

--- a/config/configmapprovider/inmemory.go
+++ b/config/configmapprovider/inmemory.go
@@ -30,7 +30,7 @@ func NewInMemory(buf io.Reader) Provider {
 	return &inMemoryMapProvider{buf: buf}
 }
 
-func (inp *inMemoryMapProvider) Retrieve(context.Context) (Retrieved, error) {
+func (inp *inMemoryMapProvider) Retrieve(_ context.Context, onChange func(*ChangeEvent)) (Retrieved, error) {
 	cfg, err := config.NewMapFromBuffer(inp.buf)
 	if err != nil {
 		return nil, err
@@ -38,6 +38,6 @@ func (inp *inMemoryMapProvider) Retrieve(context.Context) (Retrieved, error) {
 	return &simpleRetrieved{confMap: cfg}, nil
 }
 
-func (inp *inMemoryMapProvider) Close(context.Context) error {
+func (inp *inMemoryMapProvider) Shutdown(context.Context) error {
 	return nil
 }

--- a/config/configmapprovider/merge_test.go
+++ b/config/configmapprovider/merge_test.go
@@ -28,7 +28,7 @@ import (
 func TestMerge_GetError(t *testing.T) {
 	pl := NewMerge(&errProvider{err: nil}, &errProvider{errors.New("my error")})
 	require.NotNil(t, pl)
-	cp, err := pl.Retrieve(context.Background())
+	cp, err := pl.Retrieve(context.Background(), nil)
 	assert.Error(t, err)
 	assert.Nil(t, cp)
 }
@@ -36,20 +36,20 @@ func TestMerge_GetError(t *testing.T) {
 func TestMerge_CloseError(t *testing.T) {
 	pl := NewMerge(&errProvider{err: nil}, &errProvider{errors.New("my error")})
 	require.NotNil(t, pl)
-	assert.Error(t, pl.Close(context.Background()))
+	assert.Error(t, pl.Shutdown(context.Background()))
 }
 
 type errProvider struct {
 	err error
 }
 
-func (epl *errProvider) Retrieve(context.Context) (Retrieved, error) {
+func (epl *errProvider) Retrieve(context.Context, func(*ChangeEvent)) (Retrieved, error) {
 	if epl.err == nil {
 		return &simpleRetrieved{confMap: config.NewMap()}, nil
 	}
 	return nil, epl.err
 }
 
-func (epl *errProvider) Close(context.Context) error {
+func (epl *errProvider) Shutdown(context.Context) error {
 	return epl.err
 }

--- a/config/configmapprovider/properties.go
+++ b/config/configmapprovider/properties.go
@@ -40,7 +40,7 @@ func NewProperties(properties []string) Provider {
 	}
 }
 
-func (pmp *propertiesMapProvider) Retrieve(context.Context) (Retrieved, error) {
+func (pmp *propertiesMapProvider) Retrieve(_ context.Context, onChange func(*ChangeEvent)) (Retrieved, error) {
 	if len(pmp.properties) == 0 {
 		return &simpleRetrieved{confMap: config.NewMap()}, nil
 	}
@@ -70,6 +70,6 @@ func (pmp *propertiesMapProvider) Retrieve(context.Context) (Retrieved, error) {
 	return &simpleRetrieved{confMap: config.NewMapFromStringMap(prop)}, nil
 }
 
-func (*propertiesMapProvider) Close(context.Context) error {
+func (*propertiesMapProvider) Shutdown(context.Context) error {
 	return nil
 }

--- a/config/configmapprovider/properties_test.go
+++ b/config/configmapprovider/properties_test.go
@@ -31,23 +31,25 @@ func TestPropertiesProvider(t *testing.T) {
 	}
 
 	pmp := NewProperties(setFlagStr)
-	retr, err := pmp.Retrieve(context.Background())
+	retr, err := pmp.Retrieve(context.Background(), nil)
 	require.NoError(t, err)
-	cfgMap := retr.Get()
+	cfgMap, err := retr.Get(context.Background())
+	require.NoError(t, err)
 	keys := cfgMap.AllKeys()
 	assert.Len(t, keys, 4)
 	assert.Equal(t, "2s", cfgMap.Get("processors::batch::timeout"))
 	assert.Equal(t, "3s", cfgMap.Get("processors::batch/foo::timeout"))
 	assert.Equal(t, "foo:9200,foo2:9200", cfgMap.Get("exporters::kafka::brokers"))
 	assert.Equal(t, "localhost:1818", cfgMap.Get("receivers::otlp::protocols::grpc::endpoint"))
-	require.NoError(t, pmp.Close(context.Background()))
+	require.NoError(t, pmp.Shutdown(context.Background()))
 }
 
 func TestPropertiesProvider_empty(t *testing.T) {
 	pmp := NewProperties(nil)
-	retr, err := pmp.Retrieve(context.Background())
+	retr, err := pmp.Retrieve(context.Background(), nil)
 	require.NoError(t, err)
-	cfgMap := retr.Get()
+	cfgMap, err := retr.Get(context.Background())
+	require.NoError(t, err)
 	assert.Equal(t, 0, len(cfgMap.AllKeys()))
-	require.NoError(t, pmp.Close(context.Background()))
+	require.NoError(t, pmp.Shutdown(context.Background()))
 }

--- a/config/configmapprovider/simple.go
+++ b/config/configmapprovider/simple.go
@@ -15,6 +15,8 @@
 package configmapprovider // import "go.opentelemetry.io/collector/config/configmapprovider"
 
 import (
+	"context"
+
 	"go.opentelemetry.io/collector/config"
 )
 
@@ -23,6 +25,10 @@ type simpleRetrieved struct {
 	confMap *config.Map
 }
 
-func (sr *simpleRetrieved) Get() *config.Map {
-	return sr.confMap
+func (sr *simpleRetrieved) Get(ctx context.Context) (*config.Map, error) {
+	return sr.confMap, nil
+}
+
+func (sr *simpleRetrieved) Close(ctx context.Context) error {
+	return nil
 }

--- a/config/configtest/configtest.go
+++ b/config/configtest/configtest.go
@@ -35,12 +35,16 @@ var configFieldTagRegExp = regexp.MustCompile("^[a-z0-9][a-z0-9_]*$")
 // LoadConfig loads a config from file, and does NOT validate the configuration.
 func LoadConfig(fileName string, factories component.Factories) (*config.Config, error) {
 	// Read yaml config from file
-	cp, err := configmapprovider.NewExpand(configmapprovider.NewFile(fileName)).Retrieve(context.Background())
+	cp, err := configmapprovider.NewExpand(configmapprovider.NewFile(fileName)).Retrieve(context.Background(), nil)
 	if err != nil {
 		return nil, err
 	}
 	// Unmarshal the config using the given factories.
-	return configunmarshaler.NewDefault().Unmarshal(cp.Get(), factories)
+	m, err := cp.Get(context.Background())
+	if err != nil {
+		return nil, err
+	}
+	return configunmarshaler.NewDefault().Unmarshal(m, factories)
 }
 
 // LoadConfigAndValidate loads a config from the file, and validates the configuration.

--- a/service/collector.go
+++ b/service/collector.go
@@ -254,7 +254,7 @@ func (col *Collector) shutdown(ctx context.Context) error {
 		errs = multierr.Append(errs, fmt.Errorf("failed to close config provider watcher: %w", err))
 	}
 
-	if err := col.set.ConfigMapProvider.Close(ctx); err != nil {
+	if err := col.set.ConfigMapProvider.Shutdown(ctx); err != nil {
 		errs = multierr.Append(errs, fmt.Errorf("failed to shutdown config provider: %w", err))
 	}
 


### PR DESCRIPTION
This uses a callback instead of a blocking WaitForUpdate function
to notify about config changes.

This simplifies the usage of the Provider, especially when watching
for changes is required.

A follow up PR will add watching capabilities to existing Provider
implementations.
