### PR TITLE
Remove Set[Map|Slice]Val. They were added in a PR focused on other change

### DIFF
--- a/model/pdata/common.go
+++ b/model/pdata/common.go
@@ -255,20 +255,6 @@ func (a AttributeValue) SetBytesVal(v []byte) {
 	a.orig.Value = &otlpcommon.AnyValue_BytesValue{BytesValue: v}
 }
 
-// SetMapVal replaces the AttributeMap value associated with this AttributeValue,
-// it also changes the type to be AttributeValueTypeMap.
-// Calling this function on zero-initialized AttributeValue will cause a panic.
-func (a AttributeValue) SetMapVal(v AttributeMap) {
-	a.orig.Value = &otlpcommon.AnyValue_KvlistValue{KvlistValue: &otlpcommon.KeyValueList{Values: *v.orig}}
-}
-
-// SetSliceVal replaces the AttributeValueSlice value associated with this AttributeValue,
-// it also changes the type to be AttributeValueTypeArray.
-// Calling this function on zero-initialized AttributeValue will cause a panic.
-func (a AttributeValue) SetSliceVal(v AttributeValueSlice) {
-	a.orig.Value = &otlpcommon.AnyValue_ArrayValue{ArrayValue: &otlpcommon.ArrayValue{Values: *v.orig}}
-}
-
 // copyTo copies the value to AnyValue. Will panic if dest is nil.
 func (a AttributeValue) copyTo(dest *otlpcommon.AnyValue) {
 	switch v := a.orig.Value.(type) {

--- a/model/pdata/common_test.go
+++ b/model/pdata/common_test.go
@@ -899,7 +899,7 @@ func TestAttributeValueArray(t *testing.T) {
 	assert.EqualValues(t, NewAttributeValueString("somestr"), a2.SliceVal().At(0))
 
 	// Insert the second array as a child.
-	a1.SliceVal().AppendEmpty().SetSliceVal(a2.SliceVal())
+	a2.CopyTo(a1.SliceVal().AppendEmpty())
 	assert.EqualValues(t, 2, a1.SliceVal().Len())
 	assert.EqualValues(t, NewAttributeValueDouble(123), a1.SliceVal().At(0))
 	assert.EqualValues(t, a2, a1.SliceVal().At(1))


### PR DESCRIPTION
Unfortunately during the code review of the https://github.com/open-telemetry/opentelemetry-collector/pull/3980 I missed this because was kind of "hiden" in a PR that was supposed to just do a rename of NULL -> Empty.
This is yet another example why collector maintainers MUST always ask for small focused PRs and never allow other different changes.

The reason to not allow this is because user need to either "CopyTo" or "MoveTo", right now the way how Set was implemented would share the same memory and is not thread safe since changes in the copied value will be reflected in the destination.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
