### PR TITLE
Remove workdir from builder release workflow, restrict to builder tags

### DIFF
--- a/.github/workflows/builder-release.yaml
+++ b/.github/workflows/builder-release.yaml
@@ -3,7 +3,7 @@ name: Builder - Release
 on:
   push:
     tags:
-      - 'v*'
+      - 'cmd/builder/v*'
 
 jobs:
   goreleaser:
@@ -26,7 +26,6 @@ jobs:
           distribution: goreleaser-pro
           version: latest
           args: release --rm-dist
-          workdir: cmd/builder
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The release of the collector builder for 0.39.0 failed due to:

```
   ⨯ release failed after 10.40s error=failed to get module path: chdir cmd/builder: no such file or directory: 
```
https://github.com/open-telemetry/opentelemetry-collector/runs/4195118833?check_suite_focus=true

Running it locally from the root of the repository did work:

```
$ goreleaser release -f ./cmd/builder/.goreleaser.yml
   • running goreleaser v0.184.0-pro
   • licensed to juraci.kroehling@grafana.com
   • releasing...     
   • loading config file       file=./cmd/builder/.goreleaser.yml
   • loading environment variables
   • getting and validating git state
      • building...               commit=57ecd4ff8dc5a37c6f353c7d6f72f49e5dec18c2 latest tag=cmd/builder/v0.39.0
   • parsing tag      
   • running before hooks
      • running hook              hook=go mod download
   • setting defaults 
      • snapshotting     
      • nightly          
      • github/gitlab/gitea releases
      • project name     
      • loading go mod information
      • building binaries
      • universal binaries
      • creating source archive
      • archives         
      • linux packages   
      • snapcraft packages
      • calculating checksums
      • signing artifacts
      • signing docker images
      • docker images    
      • docker manifests 
      • artifactory      
      • fury             
      • blobs            
      • homebrew tap formula
      • gofish fish food cookbook
      • scoop manifests  
      • discord          
      • reddit           
      • slack            
      • teams            
      • twitter          
      • smtp             
      • mattermost       
      • milestones       
      • telegram         
   • checking ./dist  
   • loading go mod information
   • writing effective config file
      • writing                   config=dist/config.yaml
   • building binaries
      • building                  binary=/home/jpkroehling/Projects/src/github.com/open-telemetry/opentelemetry-collector/dist/opentelemetry-collector_linux_arm_6/opentelemetry-collector
      • building                  binary=/home/jpkroehling/Projects/src/github.com/open-telemetry/opentelemetry-collector/dist/opentelemetry-collector_linux_arm64/opentelemetry-collector
      • building                  binary=/home/jpkroehling/Projects/src/github.com/open-telemetry/opentelemetry-collector/dist/opentelemetry-collector_darwin_arm64/opentelemetry-collector
      • building                  binary=/home/jpkroehling/Projects/src/github.com/open-telemetry/opentelemetry-collector/dist/opentelemetry-collector_linux_amd64/opentelemetry-collector
      • building                  binary=/home/jpkroehling/Projects/src/github.com/open-telemetry/opentelemetry-collector/dist/opentelemetry-collector_darwin_amd64/opentelemetry-collector
      • building                  binary=/home/jpkroehling/Projects/src/github.com/open-telemetry/opentelemetry-collector/dist/opentelemetry-collector_linux_arm_7/opentelemetry-collector
      • building                  binary=/home/jpkroehling/Projects/src/github.com/open-telemetry/opentelemetry-collector/dist/opentelemetry-collector_windows_arm_6/opentelemetry-collector.exe
      • building                  binary=/home/jpkroehling/Projects/src/github.com/open-telemetry/opentelemetry-collector/dist/opentelemetry-collector_windows_arm64/opentelemetry-collector.exe
      • building                  binary=/home/jpkroehling/Projects/src/github.com/open-telemetry/opentelemetry-collector/dist/opentelemetry-collector_windows_arm_7/opentelemetry-collector.exe
      • building                  binary=/home/jpkroehling/Projects/src/github.com/open-telemetry/opentelemetry-collector/dist/opentelemetry-collector_windows_amd64/opentelemetry-collector.exe
   • archives         
      • skip archiving            binary=opentelemetry-collector name=opentelemetry-collector_0.39.0_darwin_amd64
      • skip archiving            binary=opentelemetry-collector name=opentelemetry-collector_0.39.0_linux_amd64
      • skip archiving            binary=opentelemetry-collector name=opentelemetry-collector_0.39.0_linux_armv7
      • skip archiving            binary=opentelemetry-collector.exe name=opentelemetry-collector_0.39.0_windows_armv6.exe
      • skip archiving            binary=opentelemetry-collector.exe name=opentelemetry-collector_0.39.0_windows_amd64.exe
      • skip archiving            binary=opentelemetry-collector name=opentelemetry-collector_0.39.0_darwin_arm64
      • skip archiving            binary=opentelemetry-collector name=opentelemetry-collector_0.39.0_linux_armv6
      • skip archiving            binary=opentelemetry-collector.exe name=opentelemetry-collector_0.39.0_windows_armv7.exe
      • skip archiving            binary=opentelemetry-collector.exe name=opentelemetry-collector_0.39.0_windows_arm64.exe
      • skip archiving            binary=opentelemetry-collector name=opentelemetry-collector_0.39.0_linux_arm64
   • calculating checksums
      • checksumming              file=opentelemetry-collector_0.39.0_darwin_amd64
      • checksumming              file=opentelemetry-collector_0.39.0_linux_amd64
      • checksumming              file=opentelemetry-collector_0.39.0_linux_armv7
      • checksumming              file=opentelemetry-collector_0.39.0_windows_amd64.exe
      • checksumming              file=opentelemetry-collector_0.39.0_linux_arm64
      • checksumming              file=opentelemetry-collector_0.39.0_darwin_arm64
      • checksumming              file=opentelemetry-collector_0.39.0_windows_armv7.exe
      • checksumming              file=opentelemetry-collector_0.39.0_windows_armv6.exe
      • checksumming              file=opentelemetry-collector_0.39.0_linux_armv6
      • checksumming              file=opentelemetry-collector_0.39.0_windows_arm64.exe
   • publishing       
      • github/gitlab/gitea releases
         • creating or updating release repo=jpkrohling/opentelemetry-collector tag=cmd/builder/v0.39.0
         • release updated           url=https://github.com/jpkrohling/opentelemetry-collector/releases/tag/cmd/builder/v0.39.0
         • uploading to release      file=dist/checksums.txt name=checksums.txt
         • uploading to release      file=/home/jpkroehling/Projects/src/github.com/open-telemetry/opentelemetry-collector/dist/opentelemetry-collector_windows_amd64/opentelemetry-collector.exe name=opentelemetry-collector_0.39.0_windows_amd64.exe
         • uploading to release      file=/home/jpkroehling/Projects/src/github.com/open-telemetry/opentelemetry-collector/dist/opentelemetry-collector_darwin_amd64/opentelemetry-collector name=opentelemetry-collector_0.39.0_darwin_amd64
         • uploading to release      file=/home/jpkroehling/Projects/src/github.com/open-telemetry/opentelemetry-collector/dist/opentelemetry-collector_linux_amd64/opentelemetry-collector name=opentelemetry-collector_0.39.0_linux_amd64
         • uploading to release      file=/home/jpkroehling/Projects/src/github.com/open-telemetry/opentelemetry-collector/dist/opentelemetry-collector_windows_arm_6/opentelemetry-collector.exe name=opentelemetry-collector_0.39.0_windows_armv6.exe
         • uploading to release      file=/home/jpkroehling/Projects/src/github.com/open-telemetry/opentelemetry-collector/dist/opentelemetry-collector_linux_arm_7/opentelemetry-collector name=opentelemetry-collector_0.39.0_linux_armv7
         • uploading to release      file=/home/jpkroehling/Projects/src/github.com/open-telemetry/opentelemetry-collector/dist/opentelemetry-collector_windows_arm64/opentelemetry-collector.exe name=opentelemetry-collector_0.39.0_windows_arm64.exe
         • uploading to release      file=/home/jpkroehling/Projects/src/github.com/open-telemetry/opentelemetry-collector/dist/opentelemetry-collector_windows_arm_7/opentelemetry-collector.exe name=opentelemetry-collector_0.39.0_windows_armv7.exe
         • uploading to release      file=/home/jpkroehling/Projects/src/github.com/open-telemetry/opentelemetry-collector/dist/opentelemetry-collector_linux_arm_6/opentelemetry-collector name=opentelemetry-collector_0.39.0_linux_armv6
         • uploading to release      file=/home/jpkroehling/Projects/src/github.com/open-telemetry/opentelemetry-collector/dist/opentelemetry-collector_darwin_arm64/opentelemetry-collector name=opentelemetry-collector_0.39.0_darwin_arm64
         • uploading to release      file=/home/jpkroehling/Projects/src/github.com/open-telemetry/opentelemetry-collector/dist/opentelemetry-collector_linux_arm64/opentelemetry-collector name=opentelemetry-collector_0.39.0_linux_arm64
   • announcing       
   • release succeeded after 15.12s
   • thanks for using goreleaser-pro!
```

This PR removes the workdir entry from the release workflow, meaning that it should now run goreleaser from the main directory.

This PR also changes the tags to which this workflow reacts. Originally, this would react to "v*", but I tried locally with "cmd/builder/v0.39.0" and got a separate release for it, which I believe to be better. Example:
https://github.com/jpkrohling/opentelemetry-collector/releases/tag/cmd/builder/v0.39.0

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>
