### PR TITLE
chore: adds fallback tracer provider to obsreport receiver.

### DIFF
--- a/obsreport/obsreport_exporter.go
+++ b/obsreport/obsreport_exporter.go
@@ -46,11 +46,16 @@ type ExporterSettings struct {
 
 // NewExporter creates a new Exporter.
 func NewExporter(cfg ExporterSettings) *Exporter {
+	traceProvider := cfg.ExporterCreateSettings.TracerProvider
+	if traceProvider == nil {
+		traceProvider = trace.NewNoopTracerProvider()
+	}
+
 	return &Exporter{
 		level:          cfg.Level,
 		spanNamePrefix: obsmetrics.ExporterPrefix + cfg.ExporterID.String(),
 		mutators:       []tag.Mutator{tag.Upsert(obsmetrics.TagKeyExporter, cfg.ExporterID.String(), tag.WithTTL(tag.TTLNoPropagation))},
-		tracer:         cfg.ExporterCreateSettings.TracerProvider.Tracer(cfg.ExporterID.String()),
+		tracer:         traceProvider.Tracer(cfg.ExporterID.String()),
 	}
 }
 

--- a/obsreport/obsreport_receiver.go
+++ b/obsreport/obsreport_receiver.go
@@ -53,6 +53,11 @@ type ReceiverSettings struct {
 
 // NewReceiver creates a new Receiver.
 func NewReceiver(cfg ReceiverSettings) *Receiver {
+	traceProvider := cfg.ReceiverCreateSettings.TracerProvider
+	if traceProvider == nil {
+		traceProvider = trace.NewNoopTracerProvider()
+	}
+
 	return &Receiver{
 		spanNamePrefix: obsmetrics.ReceiverPrefix + cfg.ReceiverID.String(),
 		transport:      cfg.Transport,
@@ -61,7 +66,7 @@ func NewReceiver(cfg ReceiverSettings) *Receiver {
 			tag.Upsert(obsmetrics.TagKeyReceiver, cfg.ReceiverID.String(), tag.WithTTL(tag.TTLNoPropagation)),
 			tag.Upsert(obsmetrics.TagKeyTransport, cfg.Transport, tag.WithTTL(tag.TTLNoPropagation)),
 		},
-		tracer: cfg.ReceiverCreateSettings.TracerProvider.Tracer(cfg.ReceiverID.String()),
+		tracer: traceProvider.Tracer(cfg.ReceiverID.String()),
 	}
 }
 

--- a/obsreport/obsreport_test.go
+++ b/obsreport/obsreport_test.go
@@ -262,6 +262,13 @@ func TestScrapeMetricsDataOp(t *testing.T) {
 	require.NoError(t, obsreporttest.CheckScraperMetrics(tt, receiver, scraper, int64(scrapedMetricPoints), int64(erroredMetricPoints)))
 }
 
+func TestNewExporterSuccess(t *testing.T) {
+	rec := NewExporter(ExporterSettings{
+		ExporterID: exporter,
+	})
+	require.NotNil(t, rec)
+}
+
 func TestExportTraceDataOp(t *testing.T) {
 	tt, err := obsreporttest.SetupTelemetry()
 	require.NoError(t, err)

--- a/obsreport/obsreport_test.go
+++ b/obsreport/obsreport_test.go
@@ -51,6 +51,14 @@ type testParams struct {
 	err   error
 }
 
+func TestNewReceiverSuccess(t *testing.T) {
+	rec := NewReceiver(ReceiverSettings{
+		ReceiverID: receiver,
+		Transport:  transport,
+	})
+	require.NotNil(t, rec)
+}
+
 func TestReceiveTraceDataOp(t *testing.T) {
 	tt, err := obsreporttest.SetupTelemetry()
 	require.NoError(t, err)


### PR DESCRIPTION
`ReceiverCreateSettings.TracerProvider` is required in the construction of the new receiver however due to the nature of the config object it can be also optional leading a nil pointer fatal error when user does not pass it.
