### PR TITLE
[Documentation] fixes for configauth module's README

### DIFF
--- a/config/configauth/README.md
+++ b/config/configauth/README.md
@@ -1,10 +1,18 @@
-# Authentication configuration for receivers
+# Authentication configuration
 
-This module allows server types, such as gRPC and HTTP, to be configured to perform authentication for requests and/or RPCs. Each server type is responsible for getting the request/RPC metadata and passing down to the authenticator.
+This module defines necessary interfaces to implement 
 
-The currently known authenticators:
+- Server type authenticators for gRPC and HTTP receivers to perform authentication for requests and/or RPCs. Each server type is responsible for getting the request/RPC metadata and passing down to the authenticator.
+- Client type authenticators such as gRPC and HTTP exporters to perform client side authentication. 
 
-- [oidc](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/oidcauthextension)
+Few such authenticators that are implemented currently:
+
+- Server Authenticators
+  - [oidc](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/oidcauthextension)
+
+- Client Authenticators
+  - [oauth2](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/oauth2clientauthextension)
+  - [BearerToken](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/bearertokenauthextension)
 
 Examples:
 ```yaml
@@ -17,6 +25,20 @@ extensions:
     issuer_url: http://localhost:8080/auth/realms/opentelemetry
     audience: account
 
+  oauth2client:
+    client_id: someclientid
+    client_secret: someclientsecret
+    token_url: https://example.com/oauth2/default/v1/token
+    scopes: ["api.metrics"]
+    # tls settings for the token client
+    tls:
+      insecure: true
+      ca_file: /var/lib/mycert.pem
+      cert_file: certfile
+      key_file: keyfile
+    # timeout for the token client
+    timeout: 2s
+
 receivers:
   otlp/with_auth:
     protocols:
@@ -28,10 +50,16 @@ receivers:
         auth:
           ## oidc is the extension name to use as the authenticator for this receiver
           authenticator: oidc
+
+  otlphttp/withauth:
+    endpoint: http://localhost:9000
+    auth:
+      authenticator: oauth2client
+
 ```
 
 ## Creating an authenticator
 
-New authenticators can be added by creating a new extension that also implements the `configauth.ServerAuthenticator` extension. Generic authenticators that may be used by a good number of users might be accepted as part of the core distribution, or as part of the contrib distribution. If you have interest in contributing one authenticator, open an issue with your proposal.
+New server side authenticators can be added by creating a new extension that also implements the `configauth.ServerAuthenticator` extension and similarly a client side authenticator can be added by implementing `configauth.ClientAuthenticator` interface.
 
-For other cases, you'll need to include your custom authenticator as part of your custom OpenTelemetry Collector, perhaps being built using the [OpenTelemetry Collector Builder](https://github.com/open-telemetry/opentelemetry-collector-builder).
+Generic authenticators that may be used by a good number of users might be accepted as part of the core distribution, or as part of the contrib distribution. If you have interest in contributing one authenticator, open an issue with your proposal. For other cases, you'll need to include your custom authenticator as part of your custom OpenTelemetry Collector, perhaps being built using the [OpenTelemetry Collector Builder](https://github.com/open-telemetry/opentelemetry-collector-builder).

--- a/config/configauth/README.md
+++ b/config/configauth/README.md
@@ -3,7 +3,7 @@
 This module defines necessary interfaces to implement 
 
 - Server type authenticators for gRPC and HTTP receivers to perform authentication for requests and/or RPCs. Each server type is responsible for getting the request/RPC metadata and passing down to the authenticator.
-- Client type authenticators such as gRPC and HTTP exporters to perform client side authentication. 
+- Client type authenticators for gRPC and HTTP exporters to perform client side authentication. 
 
 Few such authenticators that are implemented currently:
 

--- a/config/configauth/README.md
+++ b/config/configauth/README.md
@@ -1,11 +1,11 @@
 # Authentication configuration
 
-This module defines necessary interfaces to implement 
+This module defines necessary interfaces to implement server and client type authenticators:
 
-- Server type authenticators for gRPC and HTTP receivers to perform authentication for requests and/or RPCs. Each server type is responsible for getting the request/RPC metadata and passing down to the authenticator.
-- Client type authenticators for gRPC and HTTP exporters to perform client side authentication. 
+- Server type authenticators perform authentication for incoming HTTP/gRPC requests and are typically used in receivers.
+- Client type authenticators perform client-side authentication for outgoing HTTP/gRPC requests and are typically used in exporters.
 
-Few such authenticators that are implemented currently:
+The currently known authenticators are:
 
 - Server Authenticators
   - [oidc](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/oidcauthextension)
@@ -60,6 +60,6 @@ receivers:
 
 ## Creating an authenticator
 
-New server side authenticators can be added by creating a new extension that also implements the `configauth.ServerAuthenticator` extension and similarly a client side authenticator can be added by implementing `configauth.ClientAuthenticator` interface.
+New authenticators can be added by creating a new extension that also implements the appropriate interface (`configauth.ServerAuthenticator` or `configauth.ClientAuthenticator`).
 
-Generic authenticators that may be used by a good number of users might be accepted as part of the core distribution, or as part of the contrib distribution. If you have interest in contributing one authenticator, open an issue with your proposal. For other cases, you'll need to include your custom authenticator as part of your custom OpenTelemetry Collector, perhaps being built using the [OpenTelemetry Collector Builder](https://github.com/open-telemetry/opentelemetry-collector-builder).
+Generic authenticators that may be used by a good number of users might be accepted as part of the contrib distribution. If you have an interest in contributing an authenticator, open an issue with your proposal. For other cases, you'll need to include your custom authenticator as part of your custom OpenTelemetry Collector, perhaps being built using the [OpenTelemetry Collector Builder](https://github.com/open-telemetry/opentelemetry-collector/tree/main/cmd/builder).


### PR DESCRIPTION
 Fixing a bug - Current documentation in configauth module's README misses client side authenticators documentation. 

This PR adds client authenticators details and link existing client authenticators.
