### PR TITLE
`semconv`: adding semconv 1.7.0 and 1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Remove `pdata.AttributeMap.InitFromMap` (#4429)
 
+## 💡 Enhancements 💡
+
+- Add semconv 1.7.0 and 1.8.0 (#4452)
+
 ## v0.39.0 Beta
 
 ## 🛑 Breaking changes 🛑

--- a/model/semconv/v1.7.0/resource.go
+++ b/model/semconv/v1.7.0/resource.go
@@ -1,0 +1,1002 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Code generated from semantic convention specification. DO NOT EDIT.
+
+package semconv
+
+// A cloud environment (e.g. GCP, Azure, AWS)
+const (
+	// Name of the cloud provider.
+	//
+	// Type: Enum
+	// Required: No
+	// Stability: stable
+	AttributeCloudProvider = "cloud.provider"
+	// The cloud account ID the resource is assigned to.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '111111111111', 'opentelemetry'
+	AttributeCloudAccountID = "cloud.account.id"
+	// The geographical region the resource is running. Refer to your provider's docs
+	// to see the available regions, for example Alibaba Cloud regions, AWS regions,
+	// Azure regions, or Google Cloud regions.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'us-central1', 'us-east-1'
+	AttributeCloudRegion = "cloud.region"
+	// Cloud regions often have multiple, isolated locations known as zones to
+	// increase availability. Availability zone represents the zone where the resource
+	// is running.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'us-east-1c'
+	// Note: Availability zones are called &quot;zones&quot; on Alibaba Cloud and
+	// Google Cloud.
+	AttributeCloudAvailabilityZone = "cloud.availability_zone"
+	// The cloud platform in use.
+	//
+	// Type: Enum
+	// Required: No
+	// Stability: stable
+	// Note: The prefix of the service SHOULD match the one specified in
+	// cloud.provider.
+	AttributeCloudPlatform = "cloud.platform"
+)
+
+const (
+	// Alibaba Cloud
+	AttributeCloudProviderAlibabaCloud = "alibaba_cloud"
+	// Amazon Web Services
+	AttributeCloudProviderAWS = "aws"
+	// Microsoft Azure
+	AttributeCloudProviderAzure = "azure"
+	// Google Cloud Platform
+	AttributeCloudProviderGCP = "gcp"
+)
+
+const (
+	// Alibaba Cloud Elastic Compute Service
+	AttributeCloudPlatformAlibabaCloudECS = "alibaba_cloud_ecs"
+	// Alibaba Cloud Function Compute
+	AttributeCloudPlatformAlibabaCloudFc = "alibaba_cloud_fc"
+	// AWS Elastic Compute Cloud
+	AttributeCloudPlatformAWSEC2 = "aws_ec2"
+	// AWS Elastic Container Service
+	AttributeCloudPlatformAWSECS = "aws_ecs"
+	// AWS Elastic Kubernetes Service
+	AttributeCloudPlatformAWSEKS = "aws_eks"
+	// AWS Lambda
+	AttributeCloudPlatformAWSLambda = "aws_lambda"
+	// AWS Elastic Beanstalk
+	AttributeCloudPlatformAWSElasticBeanstalk = "aws_elastic_beanstalk"
+	// Azure Virtual Machines
+	AttributeCloudPlatformAzureVM = "azure_vm"
+	// Azure Container Instances
+	AttributeCloudPlatformAzureContainerInstances = "azure_container_instances"
+	// Azure Kubernetes Service
+	AttributeCloudPlatformAzureAKS = "azure_aks"
+	// Azure Functions
+	AttributeCloudPlatformAzureFunctions = "azure_functions"
+	// Azure App Service
+	AttributeCloudPlatformAzureAppService = "azure_app_service"
+	// Google Cloud Compute Engine (GCE)
+	AttributeCloudPlatformGCPComputeEngine = "gcp_compute_engine"
+	// Google Cloud Run
+	AttributeCloudPlatformGCPCloudRun = "gcp_cloud_run"
+	// Google Cloud Kubernetes Engine (GKE)
+	AttributeCloudPlatformGCPKubernetesEngine = "gcp_kubernetes_engine"
+	// Google Cloud Functions (GCF)
+	AttributeCloudPlatformGCPCloudFunctions = "gcp_cloud_functions"
+	// Google Cloud App Engine (GAE)
+	AttributeCloudPlatformGCPAppEngine = "gcp_app_engine"
+)
+
+// Resources used by AWS Elastic Container Service (ECS).
+const (
+	// The Amazon Resource Name (ARN) of an ECS container instance.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'arn:aws:ecs:us-
+	// west-1:123456789123:container/32624152-9086-4f0e-acae-1a75b14fe4d9'
+	AttributeAWSECSContainerARN = "aws.ecs.container.arn"
+	// The ARN of an ECS cluster.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'arn:aws:ecs:us-west-2:123456789123:cluster/my-cluster'
+	AttributeAWSECSClusterARN = "aws.ecs.cluster.arn"
+	// The launch type for an ECS task.
+	//
+	// Type: Enum
+	// Required: No
+	// Stability: stable
+	AttributeAWSECSLaunchtype = "aws.ecs.launchtype"
+	// The ARN of an ECS task definition.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'arn:aws:ecs:us-
+	// west-1:123456789123:task/10838bed-421f-43ef-870a-f43feacbbb5b'
+	AttributeAWSECSTaskARN = "aws.ecs.task.arn"
+	// The task definition family this task definition is a member of.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'opentelemetry-family'
+	AttributeAWSECSTaskFamily = "aws.ecs.task.family"
+	// The revision for this task definition.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '8', '26'
+	AttributeAWSECSTaskRevision = "aws.ecs.task.revision"
+)
+
+const (
+	// ec2
+	AttributeAWSECSLaunchtypeEC2 = "ec2"
+	// fargate
+	AttributeAWSECSLaunchtypeFargate = "fargate"
+)
+
+// Resources used by AWS Elastic Kubernetes Service (EKS).
+const (
+	// The ARN of an EKS cluster.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'arn:aws:ecs:us-west-2:123456789123:cluster/my-cluster'
+	AttributeAWSEKSClusterARN = "aws.eks.cluster.arn"
+)
+
+// Resources specific to Amazon Web Services.
+const (
+	// The name(s) of the AWS log group(s) an application is writing to.
+	//
+	// Type: string[]
+	// Required: No
+	// Stability: stable
+	// Examples: '/aws/lambda/my-function', 'opentelemetry-service'
+	// Note: Multiple log groups must be supported for cases like multi-container
+	// applications, where a single application has sidecar containers, and each write
+	// to their own log group.
+	AttributeAWSLogGroupNames = "aws.log.group.names"
+	// The Amazon Resource Name(s) (ARN) of the AWS log group(s).
+	//
+	// Type: string[]
+	// Required: No
+	// Stability: stable
+	// Examples: 'arn:aws:logs:us-west-1:123456789012:log-group:/aws/my/group:*'
+	// Note: See the log group ARN format documentation.
+	AttributeAWSLogGroupARNs = "aws.log.group.arns"
+	// The name(s) of the AWS log stream(s) an application is writing to.
+	//
+	// Type: string[]
+	// Required: No
+	// Stability: stable
+	// Examples: 'logs/main/10838bed-421f-43ef-870a-f43feacbbb5b'
+	AttributeAWSLogStreamNames = "aws.log.stream.names"
+	// The ARN(s) of the AWS log stream(s).
+	//
+	// Type: string[]
+	// Required: No
+	// Stability: stable
+	// Examples: 'arn:aws:logs:us-west-1:123456789012:log-group:/aws/my/group:log-
+	// stream:logs/main/10838bed-421f-43ef-870a-f43feacbbb5b'
+	// Note: See the log stream ARN format documentation. One log group can contain
+	// several log streams, so these ARNs necessarily identify both a log group and a
+	// log stream.
+	AttributeAWSLogStreamARNs = "aws.log.stream.arns"
+)
+
+// A container instance.
+const (
+	// Container name.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'opentelemetry-autoconf'
+	AttributeContainerName = "container.name"
+	// Container ID. Usually a UUID, as for example used to identify Docker
+	// containers. The UUID might be abbreviated.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'a3bf90e006b2'
+	AttributeContainerID = "container.id"
+	// The container runtime managing this container.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'docker', 'containerd', 'rkt'
+	AttributeContainerRuntime = "container.runtime"
+	// Name of the image the container was built on.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'gcr.io/opentelemetry/operator'
+	AttributeContainerImageName = "container.image.name"
+	// Container image tag.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '0.1'
+	AttributeContainerImageTag = "container.image.tag"
+)
+
+// The software deployment.
+const (
+	// Name of the deployment environment (aka deployment tier).
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'staging', 'production'
+	AttributeDeploymentEnvironment = "deployment.environment"
+)
+
+// The device on which the process represented by this resource is running.
+const (
+	// A unique identifier representing the device
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '2ab2916d-a51f-4ac8-80ee-45ac31a28092'
+	// Note: The device identifier MUST only be defined using the values outlined
+	// below. This value is not an advertising identifier and MUST NOT be used as
+	// such. On iOS (Swift or Objective-C), this value MUST be equal to the vendor
+	// identifier. On Android (Java or Kotlin), this value MUST be equal to the
+	// Firebase Installation ID or a globally unique UUID which is persisted across
+	// sessions in your application. More information can be found here on best
+	// practices and exact implementation details. Caution should be taken when
+	// storing personal data or anything which can identify a user. GDPR and data
+	// protection laws may apply, ensure you do your own due diligence.
+	AttributeDeviceID = "device.id"
+	// The model identifier for the device
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'iPhone3,4', 'SM-G920F'
+	// Note: It's recommended this value represents a machine readable version of the
+	// model identifier rather than the market or consumer-friendly name of the
+	// device.
+	AttributeDeviceModelIdentifier = "device.model.identifier"
+	// The marketing name for the device model
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'iPhone 6s Plus', 'Samsung Galaxy S6'
+	// Note: It's recommended this value represents a human readable version of the
+	// device model rather than a machine readable alternative.
+	AttributeDeviceModelName = "device.model.name"
+)
+
+// A serverless instance.
+const (
+	// The name of the single function that this runtime instance executes.
+	//
+	// Type: string
+	// Required: Always
+	// Stability: stable
+	// Examples: 'my-function'
+	// Note: This is the name of the function as configured/deployed on the FaaS
+	// platform and is usually different from the name of the callback function (which
+	// may be stored in the code.namespace/code.function span attributes).
+	AttributeFaaSName = "faas.name"
+	// The unique ID of the single function that this runtime instance executes.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'arn:aws:lambda:us-west-2:123456789012:function:my-function'
+	// Note: Depending on the cloud provider, use:<ul>
+	// <li>AWS Lambda: The function ARN.</li>
+	// </ul>
+	// Take care not to use the &quot;invoked ARN&quot; directly but replace any
+	// alias suffix with the resolved function version, as the same runtime instance
+	// may be invokable with multiple
+	// different aliases.<ul>
+	// <li>GCP: The URI of the resource</li>
+	// <li>Azure: The Fully Qualified Resource ID.</li>
+	// </ul>
+	// On some providers, it may not be possible to determine the full ID at startup,
+	// which is why this field cannot be made required. For example, on AWS the
+	// account ID
+	// part of the ARN is not available without calling another AWS API
+	// which may be deemed too slow for a short-running lambda function.
+	// As an alternative, consider setting faas.id as a span attribute instead.
+	AttributeFaaSID = "faas.id"
+	// The immutable version of the function being executed.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '26', 'pinkfroid-00002'
+	// Note: Depending on the cloud provider and platform, use:<ul>
+	// <li>AWS Lambda: The function version
+	// (an integer represented as a decimal string).</li>
+	// <li>Google Cloud Run: The revision
+	// (i.e., the function name plus the revision suffix).</li>
+	// <li>Google Cloud Functions: The value of the
+	// K_REVISION environment variable.</li>
+	// <li>Azure Functions: Not applicable. Do not set this attribute.</li>
+	// </ul>
+	AttributeFaaSVersion = "faas.version"
+	// The execution environment ID as a string, that will be potentially reused for
+	// other invocations to the same function/function version.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '2021/06/28/[$LATEST]2f399eb14537447da05ab2a2e39309de'
+	// Note: <ul>
+	// <li>AWS Lambda: Use the (full) log stream name.</li>
+	// </ul>
+	AttributeFaaSInstance = "faas.instance"
+	// The amount of memory available to the serverless function in MiB.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 128
+	// Note: It's recommended to set this attribute since e.g. too little memory can
+	// easily stop a Java AWS Lambda function from working correctly. On AWS Lambda,
+	// the environment variable AWS_LAMBDA_FUNCTION_MEMORY_SIZE provides this
+	// information.
+	AttributeFaaSMaxMemory = "faas.max_memory"
+)
+
+// A host is defined as a general computing instance.
+const (
+	// Unique host ID. For Cloud, this must be the instance_id assigned by the cloud
+	// provider.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'opentelemetry-test'
+	AttributeHostID = "host.id"
+	// Name of the host. On Unix systems, it may contain what the hostname command
+	// returns, or the fully qualified hostname, or another name specified by the
+	// user.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'opentelemetry-test'
+	AttributeHostName = "host.name"
+	// Type of host. For Cloud, this must be the machine type.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'n1-standard-1'
+	AttributeHostType = "host.type"
+	// The CPU architecture the host system is running on.
+	//
+	// Type: Enum
+	// Required: No
+	// Stability: stable
+	AttributeHostArch = "host.arch"
+	// Name of the VM image or OS install the host was instantiated from.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'infra-ami-eks-worker-node-7d4ec78312', 'CentOS-8-x86_64-1905'
+	AttributeHostImageName = "host.image.name"
+	// VM image ID. For Cloud, this value is from the provider.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'ami-07b06b442921831e5'
+	AttributeHostImageID = "host.image.id"
+	// The version string of the VM image as defined in Version Attributes.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '0.1'
+	AttributeHostImageVersion = "host.image.version"
+)
+
+const (
+	// AMD64
+	AttributeHostArchAMD64 = "amd64"
+	// ARM32
+	AttributeHostArchARM32 = "arm32"
+	// ARM64
+	AttributeHostArchARM64 = "arm64"
+	// Itanium
+	AttributeHostArchIA64 = "ia64"
+	// 32-bit PowerPC
+	AttributeHostArchPPC32 = "ppc32"
+	// 64-bit PowerPC
+	AttributeHostArchPPC64 = "ppc64"
+	// 32-bit x86
+	AttributeHostArchX86 = "x86"
+)
+
+// A Kubernetes Cluster.
+const (
+	// The name of the cluster.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'opentelemetry-cluster'
+	AttributeK8SClusterName = "k8s.cluster.name"
+)
+
+// A Kubernetes Node object.
+const (
+	// The name of the Node.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'node-1'
+	AttributeK8SNodeName = "k8s.node.name"
+	// The UID of the Node.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '1eb3a0c6-0477-4080-a9cb-0cb7db65c6a2'
+	AttributeK8SNodeUID = "k8s.node.uid"
+)
+
+// A Kubernetes Namespace.
+const (
+	// The name of the namespace that the pod is running in.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'default'
+	AttributeK8SNamespaceName = "k8s.namespace.name"
+)
+
+// A Kubernetes Pod object.
+const (
+	// The UID of the Pod.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '275ecb36-5aa8-4c2a-9c47-d8bb681b9aff'
+	AttributeK8SPodUID = "k8s.pod.uid"
+	// The name of the Pod.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'opentelemetry-pod-autoconf'
+	AttributeK8SPodName = "k8s.pod.name"
+)
+
+// A container in a [PodTemplate](https://kubernetes.io/docs/concepts/workloads/pods/#pod-templates).
+const (
+	// The name of the Container in a Pod template.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'redis'
+	AttributeK8SContainerName = "k8s.container.name"
+)
+
+// A Kubernetes ReplicaSet object.
+const (
+	// The UID of the ReplicaSet.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '275ecb36-5aa8-4c2a-9c47-d8bb681b9aff'
+	AttributeK8SReplicaSetUID = "k8s.replicaset.uid"
+	// The name of the ReplicaSet.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'opentelemetry'
+	AttributeK8SReplicaSetName = "k8s.replicaset.name"
+)
+
+// A Kubernetes Deployment object.
+const (
+	// The UID of the Deployment.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '275ecb36-5aa8-4c2a-9c47-d8bb681b9aff'
+	AttributeK8SDeploymentUID = "k8s.deployment.uid"
+	// The name of the Deployment.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'opentelemetry'
+	AttributeK8SDeploymentName = "k8s.deployment.name"
+)
+
+// A Kubernetes StatefulSet object.
+const (
+	// The UID of the StatefulSet.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '275ecb36-5aa8-4c2a-9c47-d8bb681b9aff'
+	AttributeK8SStatefulSetUID = "k8s.statefulset.uid"
+	// The name of the StatefulSet.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'opentelemetry'
+	AttributeK8SStatefulSetName = "k8s.statefulset.name"
+)
+
+// A Kubernetes DaemonSet object.
+const (
+	// The UID of the DaemonSet.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '275ecb36-5aa8-4c2a-9c47-d8bb681b9aff'
+	AttributeK8SDaemonSetUID = "k8s.daemonset.uid"
+	// The name of the DaemonSet.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'opentelemetry'
+	AttributeK8SDaemonSetName = "k8s.daemonset.name"
+)
+
+// A Kubernetes Job object.
+const (
+	// The UID of the Job.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '275ecb36-5aa8-4c2a-9c47-d8bb681b9aff'
+	AttributeK8SJobUID = "k8s.job.uid"
+	// The name of the Job.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'opentelemetry'
+	AttributeK8SJobName = "k8s.job.name"
+)
+
+// A Kubernetes CronJob object.
+const (
+	// The UID of the CronJob.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '275ecb36-5aa8-4c2a-9c47-d8bb681b9aff'
+	AttributeK8SCronJobUID = "k8s.cronjob.uid"
+	// The name of the CronJob.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'opentelemetry'
+	AttributeK8SCronJobName = "k8s.cronjob.name"
+)
+
+// The operating system (OS) on which the process represented by this resource is running.
+const (
+	// The operating system type.
+	//
+	// Type: Enum
+	// Required: Always
+	// Stability: stable
+	AttributeOSType = "os.type"
+	// Human readable (not intended to be parsed) OS version information, like e.g.
+	// reported by ver or lsb_release -a commands.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'Microsoft Windows [Version 10.0.18363.778]', 'Ubuntu 18.04.1 LTS'
+	AttributeOSDescription = "os.description"
+	// Human readable operating system name.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'iOS', 'Android', 'Ubuntu'
+	AttributeOSName = "os.name"
+	// The version string of the operating system as defined in Version Attributes.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '14.2.1', '18.04.1'
+	AttributeOSVersion = "os.version"
+)
+
+const (
+	// Microsoft Windows
+	AttributeOSTypeWindows = "windows"
+	// Linux
+	AttributeOSTypeLinux = "linux"
+	// Apple Darwin
+	AttributeOSTypeDarwin = "darwin"
+	// FreeBSD
+	AttributeOSTypeFreeBSD = "freebsd"
+	// NetBSD
+	AttributeOSTypeNetBSD = "netbsd"
+	// OpenBSD
+	AttributeOSTypeOpenBSD = "openbsd"
+	// DragonFly BSD
+	AttributeOSTypeDragonflyBSD = "dragonflybsd"
+	// HP-UX (Hewlett Packard Unix)
+	AttributeOSTypeHPUX = "hpux"
+	// AIX (Advanced Interactive eXecutive)
+	AttributeOSTypeAIX = "aix"
+	// Oracle Solaris
+	AttributeOSTypeSolaris = "solaris"
+	// IBM z/OS
+	AttributeOSTypeZOS = "z_os"
+)
+
+// An operating system process.
+const (
+	// Process identifier (PID).
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 1234
+	AttributeProcessPID = "process.pid"
+	// The name of the process executable. On Linux based systems, can be set to the
+	// Name in proc/[pid]/status. On Windows, can be set to the base name of
+	// GetProcessImageFileNameW.
+	//
+	// Type: string
+	// Required: See below
+	// Stability: stable
+	// Examples: 'otelcol'
+	AttributeProcessExecutableName = "process.executable.name"
+	// The full path to the process executable. On Linux based systems, can be set to
+	// the target of proc/[pid]/exe. On Windows, can be set to the result of
+	// GetProcessImageFileNameW.
+	//
+	// Type: string
+	// Required: See below
+	// Stability: stable
+	// Examples: '/usr/bin/cmd/otelcol'
+	AttributeProcessExecutablePath = "process.executable.path"
+	// The command used to launch the process (i.e. the command name). On Linux based
+	// systems, can be set to the zeroth string in proc/[pid]/cmdline. On Windows, can
+	// be set to the first parameter extracted from GetCommandLineW.
+	//
+	// Type: string
+	// Required: See below
+	// Stability: stable
+	// Examples: 'cmd/otelcol'
+	AttributeProcessCommand = "process.command"
+	// The full command used to launch the process as a single string representing the
+	// full command. On Windows, can be set to the result of GetCommandLineW. Do not
+	// set this if you have to assemble it just for monitoring; use
+	// process.command_args instead.
+	//
+	// Type: string
+	// Required: See below
+	// Stability: stable
+	// Examples: 'C:\\cmd\\otecol --config="my directory\\config.yaml"'
+	AttributeProcessCommandLine = "process.command_line"
+	// All the command arguments (including the command/executable itself) as received
+	// by the process. On Linux-based systems (and some other Unixoid systems
+	// supporting procfs), can be set according to the list of null-delimited strings
+	// extracted from proc/[pid]/cmdline. For libc-based executables, this would be
+	// the full argv vector passed to main.
+	//
+	// Type: string[]
+	// Required: See below
+	// Stability: stable
+	// Examples: 'cmd/otecol', '--config=config.yaml'
+	AttributeProcessCommandArgs = "process.command_args"
+	// The username of the user that owns the process.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'root'
+	AttributeProcessOwner = "process.owner"
+)
+
+// The single (language) runtime instance which is monitored.
+const (
+	// The name of the runtime of this process. For compiled native binaries, this
+	// SHOULD be the name of the compiler.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'OpenJDK Runtime Environment'
+	AttributeProcessRuntimeName = "process.runtime.name"
+	// The version of the runtime of this process, as returned by the runtime without
+	// modification.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '14.0.2'
+	AttributeProcessRuntimeVersion = "process.runtime.version"
+	// An additional description about the runtime of the process, for example a
+	// specific vendor customization of the runtime environment.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'Eclipse OpenJ9 Eclipse OpenJ9 VM openj9-0.21.0'
+	AttributeProcessRuntimeDescription = "process.runtime.description"
+)
+
+// A service instance.
+const (
+	// Logical name of the service.
+	//
+	// Type: string
+	// Required: Always
+	// Stability: stable
+	// Examples: 'shoppingcart'
+	// Note: MUST be the same for all instances of horizontally scaled services. If
+	// the value was not specified, SDKs MUST fallback to unknown_service:
+	// concatenated with process.executable.name, e.g. unknown_service:bash. If
+	// process.executable.name is not available, the value MUST be set to
+	// unknown_service.
+	AttributeServiceName = "service.name"
+	// A namespace for service.name.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'Shop'
+	// Note: A string value having a meaning that helps to distinguish a group of
+	// services, for example the team name that owns a group of services. service.name
+	// is expected to be unique within the same namespace. If service.namespace is not
+	// specified in the Resource then service.name is expected to be unique for all
+	// services that have no explicit namespace defined (so the empty/unspecified
+	// namespace is simply one more valid namespace). Zero-length namespace string is
+	// assumed equal to unspecified namespace.
+	AttributeServiceNamespace = "service.namespace"
+	// The string ID of the service instance.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '627cc493-f310-47de-96bd-71410b7dec09'
+	// Note: MUST be unique for each instance of the same
+	// service.namespace,service.name pair (in other words
+	// service.namespace,service.name,service.instance.id triplet MUST be globally
+	// unique). The ID helps to distinguish instances of the same service that exist
+	// at the same time (e.g. instances of a horizontally scaled service). It is
+	// preferable for the ID to be persistent and stay the same for the lifetime of
+	// the service instance, however it is acceptable that the ID is ephemeral and
+	// changes during important lifetime events for the service (e.g. service
+	// restarts). If the service has no inherent unique ID that can be used as the
+	// value of this attribute it is recommended to generate a random Version 1 or
+	// Version 4 RFC 4122 UUID (services aiming for reproducible UUIDs may also use
+	// Version 5, see RFC 4122 for more recommendations).
+	AttributeServiceInstanceID = "service.instance.id"
+	// The version string of the service API or implementation.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '2.0.0'
+	AttributeServiceVersion = "service.version"
+)
+
+// The telemetry SDK used to capture data recorded by the instrumentation libraries.
+const (
+	// The name of the telemetry SDK as defined above.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'opentelemetry'
+	AttributeTelemetrySDKName = "telemetry.sdk.name"
+	// The language of the telemetry SDK.
+	//
+	// Type: Enum
+	// Required: No
+	// Stability: stable
+	AttributeTelemetrySDKLanguage = "telemetry.sdk.language"
+	// The version string of the telemetry SDK.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '1.2.3'
+	AttributeTelemetrySDKVersion = "telemetry.sdk.version"
+	// The version string of the auto instrumentation agent, if used.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '1.2.3'
+	AttributeTelemetryAutoVersion = "telemetry.auto.version"
+)
+
+const (
+	// cpp
+	AttributeTelemetrySDKLanguageCPP = "cpp"
+	// dotnet
+	AttributeTelemetrySDKLanguageDotnet = "dotnet"
+	// erlang
+	AttributeTelemetrySDKLanguageErlang = "erlang"
+	// go
+	AttributeTelemetrySDKLanguageGo = "go"
+	// java
+	AttributeTelemetrySDKLanguageJava = "java"
+	// nodejs
+	AttributeTelemetrySDKLanguageNodejs = "nodejs"
+	// php
+	AttributeTelemetrySDKLanguagePHP = "php"
+	// python
+	AttributeTelemetrySDKLanguagePython = "python"
+	// ruby
+	AttributeTelemetrySDKLanguageRuby = "ruby"
+	// webjs
+	AttributeTelemetrySDKLanguageWebjs = "webjs"
+)
+
+// Resource describing the packaged software running the application code. Web engines are typically executed using process.runtime.
+const (
+	// The name of the web engine.
+	//
+	// Type: string
+	// Required: Always
+	// Stability: stable
+	// Examples: 'WildFly'
+	AttributeWebEngineName = "webengine.name"
+	// The version of the web engine.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '21.0.0'
+	AttributeWebEngineVersion = "webengine.version"
+	// Additional description of the web engine (e.g. detailed version and edition
+	// information).
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'WildFly Full 21.0.0.Final (WildFly Core 13.0.1.Final) - 2.2.2.Final'
+	AttributeWebEngineDescription = "webengine.description"
+)
+
+func GetResourceSemanticConventionAttributeNames() []string {
+	return []string{
+		AttributeCloudProvider,
+		AttributeCloudAccountID,
+		AttributeCloudRegion,
+		AttributeCloudAvailabilityZone,
+		AttributeCloudPlatform,
+		AttributeAWSECSContainerARN,
+		AttributeAWSECSClusterARN,
+		AttributeAWSECSLaunchtype,
+		AttributeAWSECSTaskARN,
+		AttributeAWSECSTaskFamily,
+		AttributeAWSECSTaskRevision,
+		AttributeAWSEKSClusterARN,
+		AttributeAWSLogGroupNames,
+		AttributeAWSLogGroupARNs,
+		AttributeAWSLogStreamNames,
+		AttributeAWSLogStreamARNs,
+		AttributeContainerName,
+		AttributeContainerID,
+		AttributeContainerRuntime,
+		AttributeContainerImageName,
+		AttributeContainerImageTag,
+		AttributeDeploymentEnvironment,
+		AttributeDeviceID,
+		AttributeDeviceModelIdentifier,
+		AttributeDeviceModelName,
+		AttributeFaaSName,
+		AttributeFaaSID,
+		AttributeFaaSVersion,
+		AttributeFaaSInstance,
+		AttributeFaaSMaxMemory,
+		AttributeHostID,
+		AttributeHostName,
+		AttributeHostType,
+		AttributeHostArch,
+		AttributeHostImageName,
+		AttributeHostImageID,
+		AttributeHostImageVersion,
+		AttributeK8SClusterName,
+		AttributeK8SNodeName,
+		AttributeK8SNodeUID,
+		AttributeK8SNamespaceName,
+		AttributeK8SPodUID,
+		AttributeK8SPodName,
+		AttributeK8SContainerName,
+		AttributeK8SReplicaSetUID,
+		AttributeK8SReplicaSetName,
+		AttributeK8SDeploymentUID,
+		AttributeK8SDeploymentName,
+		AttributeK8SStatefulSetUID,
+		AttributeK8SStatefulSetName,
+		AttributeK8SDaemonSetUID,
+		AttributeK8SDaemonSetName,
+		AttributeK8SJobUID,
+		AttributeK8SJobName,
+		AttributeK8SCronJobUID,
+		AttributeK8SCronJobName,
+		AttributeOSType,
+		AttributeOSDescription,
+		AttributeOSName,
+		AttributeOSVersion,
+		AttributeProcessPID,
+		AttributeProcessExecutableName,
+		AttributeProcessExecutablePath,
+		AttributeProcessCommand,
+		AttributeProcessCommandLine,
+		AttributeProcessCommandArgs,
+		AttributeProcessOwner,
+		AttributeProcessRuntimeName,
+		AttributeProcessRuntimeVersion,
+		AttributeProcessRuntimeDescription,
+		AttributeServiceName,
+		AttributeServiceNamespace,
+		AttributeServiceInstanceID,
+		AttributeServiceVersion,
+		AttributeTelemetrySDKName,
+		AttributeTelemetrySDKLanguage,
+		AttributeTelemetrySDKVersion,
+		AttributeTelemetryAutoVersion,
+		AttributeWebEngineName,
+		AttributeWebEngineVersion,
+		AttributeWebEngineDescription,
+	}
+}

--- a/model/semconv/v1.7.0/trace.go
+++ b/model/semconv/v1.7.0/trace.go
@@ -1,0 +1,1663 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Code generated from semantic convention specification. DO NOT EDIT.
+
+package semconv
+
+// Span attributes used by AWS Lambda (in addition to general `faas` attributes).
+const (
+	// The full invoked ARN as provided on the Context passed to the function (Lambda-
+	// Runtime-Invoked-Function-ARN header on the /runtime/invocation/next
+	// applicable).
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'arn:aws:lambda:us-east-1:123456:function:myfunction:myalias'
+	// Note: This may be different from faas.id if an alias is involved.
+	AttributeAWSLambdaInvokedARN = "aws.lambda.invoked_arn"
+)
+
+// This document defines the attributes used to perform database client calls.
+const (
+	// An identifier for the database management system (DBMS) product being used. See
+	// below for a list of well-known identifiers.
+	//
+	// Type: Enum
+	// Required: Always
+	// Stability: stable
+	AttributeDBSystem = "db.system"
+	// The connection string used to connect to the database. It is recommended to
+	// remove embedded credentials.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'Server=(localdb)\\v11.0;Integrated Security=true;'
+	AttributeDBConnectionString = "db.connection_string"
+	// Username for accessing the database.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'readonly_user', 'reporting_user'
+	AttributeDBUser = "db.user"
+	// The fully-qualified class name of the Java Database Connectivity (JDBC) driver
+	// used to connect.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'org.postgresql.Driver',
+	// 'com.microsoft.sqlserver.jdbc.SQLServerDriver'
+	AttributeDBJDBCDriverClassname = "db.jdbc.driver_classname"
+	// If no tech-specific attribute is defined, this attribute is used to report the
+	// name of the database being accessed. For commands that switch the database,
+	// this should be set to the target database (even if the command fails).
+	//
+	// Type: string
+	// Required: Required, if applicable and no more-specific attribute is defined.
+	// Stability: stable
+	// Examples: 'customers', 'main'
+	// Note: In some SQL databases, the database name to be used is called
+	// &quot;schema name&quot;.
+	AttributeDBName = "db.name"
+	// The database statement being executed.
+	//
+	// Type: string
+	// Required: Required if applicable and not explicitly disabled via
+	// instrumentation configuration.
+	// Stability: stable
+	// Examples: 'SELECT * FROM wuser_table', 'SET mykey "WuValue"'
+	// Note: The value may be sanitized to exclude sensitive information.
+	AttributeDBStatement = "db.statement"
+	// The name of the operation being executed, e.g. the MongoDB command name such as
+	// findAndModify, or the SQL keyword.
+	//
+	// Type: string
+	// Required: Required, if `db.statement` is not applicable.
+	// Stability: stable
+	// Examples: 'findAndModify', 'HMSET', 'SELECT'
+	// Note: When setting this to an SQL keyword, it is not recommended to attempt any
+	// client-side parsing of db.statement just to get this property, but it should be
+	// set if the operation name is provided by the library being instrumented. If the
+	// SQL statement has an ambiguous operation, or performs more than one operation,
+	// this value may be omitted.
+	AttributeDBOperation = "db.operation"
+)
+
+const (
+	// Some other SQL database. Fallback only. See notes
+	AttributeDBSystemOtherSQL = "other_sql"
+	// Microsoft SQL Server
+	AttributeDBSystemMSSQL = "mssql"
+	// MySQL
+	AttributeDBSystemMySQL = "mysql"
+	// Oracle Database
+	AttributeDBSystemOracle = "oracle"
+	// IBM DB2
+	AttributeDBSystemDB2 = "db2"
+	// PostgreSQL
+	AttributeDBSystemPostgreSQL = "postgresql"
+	// Amazon Redshift
+	AttributeDBSystemRedshift = "redshift"
+	// Apache Hive
+	AttributeDBSystemHive = "hive"
+	// Cloudscape
+	AttributeDBSystemCloudscape = "cloudscape"
+	// HyperSQL DataBase
+	AttributeDBSystemHSQLDB = "hsqldb"
+	// Progress Database
+	AttributeDBSystemProgress = "progress"
+	// SAP MaxDB
+	AttributeDBSystemMaxDB = "maxdb"
+	// SAP HANA
+	AttributeDBSystemHanaDB = "hanadb"
+	// Ingres
+	AttributeDBSystemIngres = "ingres"
+	// FirstSQL
+	AttributeDBSystemFirstSQL = "firstsql"
+	// EnterpriseDB
+	AttributeDBSystemEDB = "edb"
+	// InterSystems Caché
+	AttributeDBSystemCache = "cache"
+	// Adabas (Adaptable Database System)
+	AttributeDBSystemAdabas = "adabas"
+	// Firebird
+	AttributeDBSystemFirebird = "firebird"
+	// Apache Derby
+	AttributeDBSystemDerby = "derby"
+	// FileMaker
+	AttributeDBSystemFilemaker = "filemaker"
+	// Informix
+	AttributeDBSystemInformix = "informix"
+	// InstantDB
+	AttributeDBSystemInstantDB = "instantdb"
+	// InterBase
+	AttributeDBSystemInterbase = "interbase"
+	// MariaDB
+	AttributeDBSystemMariaDB = "mariadb"
+	// Netezza
+	AttributeDBSystemNetezza = "netezza"
+	// Pervasive PSQL
+	AttributeDBSystemPervasive = "pervasive"
+	// PointBase
+	AttributeDBSystemPointbase = "pointbase"
+	// SQLite
+	AttributeDBSystemSqlite = "sqlite"
+	// Sybase
+	AttributeDBSystemSybase = "sybase"
+	// Teradata
+	AttributeDBSystemTeradata = "teradata"
+	// Vertica
+	AttributeDBSystemVertica = "vertica"
+	// H2
+	AttributeDBSystemH2 = "h2"
+	// ColdFusion IMQ
+	AttributeDBSystemColdfusion = "coldfusion"
+	// Apache Cassandra
+	AttributeDBSystemCassandra = "cassandra"
+	// Apache HBase
+	AttributeDBSystemHBase = "hbase"
+	// MongoDB
+	AttributeDBSystemMongoDB = "mongodb"
+	// Redis
+	AttributeDBSystemRedis = "redis"
+	// Couchbase
+	AttributeDBSystemCouchbase = "couchbase"
+	// CouchDB
+	AttributeDBSystemCouchDB = "couchdb"
+	// Microsoft Azure Cosmos DB
+	AttributeDBSystemCosmosDB = "cosmosdb"
+	// Amazon DynamoDB
+	AttributeDBSystemDynamoDB = "dynamodb"
+	// Neo4j
+	AttributeDBSystemNeo4j = "neo4j"
+	// Apache Geode
+	AttributeDBSystemGeode = "geode"
+	// Elasticsearch
+	AttributeDBSystemElasticsearch = "elasticsearch"
+	// Memcached
+	AttributeDBSystemMemcached = "memcached"
+	// CockroachDB
+	AttributeDBSystemCockroachdb = "cockroachdb"
+)
+
+// Connection-level attributes for Microsoft SQL Server
+const (
+	// The Microsoft SQL Server instance name connecting to. This name is used to
+	// determine the port of a named instance.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'MSSQLSERVER'
+	// Note: If setting a db.mssql.instance_name, net.peer.port is no longer required
+	// (but still recommended if non-standard).
+	AttributeDBMSSQLInstanceName = "db.mssql.instance_name"
+)
+
+// Call-level attributes for Cassandra
+const (
+	// The name of the keyspace being accessed. To be used instead of the generic
+	// db.name attribute.
+	//
+	// Type: string
+	// Required: Always
+	// Stability: stable
+	// Examples: 'mykeyspace'
+	AttributeDBCassandraKeyspace = "db.cassandra.keyspace"
+	// The fetch size used for paging, i.e. how many rows will be returned at once.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 5000
+	AttributeDBCassandraPageSize = "db.cassandra.page_size"
+	// The consistency level of the query. Based on consistency values from CQL.
+	//
+	// Type: Enum
+	// Required: No
+	// Stability: stable
+	AttributeDBCassandraConsistencyLevel = "db.cassandra.consistency_level"
+	// The name of the primary table that the operation is acting upon, including the
+	// schema name (if applicable).
+	//
+	// Type: string
+	// Required: Recommended if available.
+	// Stability: stable
+	// Examples: 'mytable'
+	// Note: This mirrors the db.sql.table attribute but references cassandra rather
+	// than sql. It is not recommended to attempt any client-side parsing of
+	// db.statement just to get this property, but it should be set if it is provided
+	// by the library being instrumented. If the operation is acting upon an anonymous
+	// table, or more than one table, this value MUST NOT be set.
+	AttributeDBCassandraTable = "db.cassandra.table"
+	// Whether or not the query is idempotent.
+	//
+	// Type: boolean
+	// Required: No
+	// Stability: stable
+	AttributeDBCassandraIdempotence = "db.cassandra.idempotence"
+	// The number of times a query was speculatively executed. Not set or 0 if the
+	// query was not executed speculatively.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 0, 2
+	AttributeDBCassandraSpeculativeExecutionCount = "db.cassandra.speculative_execution_count"
+	// The ID of the coordinating node for a query.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'be13faa2-8574-4d71-926d-27f16cf8a7af'
+	AttributeDBCassandraCoordinatorID = "db.cassandra.coordinator.id"
+	// The data center of the coordinating node for a query.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'us-west-2'
+	AttributeDBCassandraCoordinatorDC = "db.cassandra.coordinator.dc"
+)
+
+const (
+	// all
+	AttributeDBCassandraConsistencyLevelAll = "all"
+	// each_quorum
+	AttributeDBCassandraConsistencyLevelEachQuorum = "each_quorum"
+	// quorum
+	AttributeDBCassandraConsistencyLevelQuorum = "quorum"
+	// local_quorum
+	AttributeDBCassandraConsistencyLevelLocalQuorum = "local_quorum"
+	// one
+	AttributeDBCassandraConsistencyLevelOne = "one"
+	// two
+	AttributeDBCassandraConsistencyLevelTwo = "two"
+	// three
+	AttributeDBCassandraConsistencyLevelThree = "three"
+	// local_one
+	AttributeDBCassandraConsistencyLevelLocalOne = "local_one"
+	// any
+	AttributeDBCassandraConsistencyLevelAny = "any"
+	// serial
+	AttributeDBCassandraConsistencyLevelSerial = "serial"
+	// local_serial
+	AttributeDBCassandraConsistencyLevelLocalSerial = "local_serial"
+)
+
+// Call-level attributes for Apache HBase
+const (
+	// The HBase namespace being accessed. To be used instead of the generic db.name
+	// attribute.
+	//
+	// Type: string
+	// Required: Always
+	// Stability: stable
+	// Examples: 'default'
+	AttributeDBHBaseNamespace = "db.hbase.namespace"
+)
+
+// Call-level attributes for Redis
+const (
+	// The index of the database being accessed as used in the SELECT command,
+	// provided as an integer. To be used instead of the generic db.name attribute.
+	//
+	// Type: int
+	// Required: Required, if other than the default database (`0`).
+	// Stability: stable
+	// Examples: 0, 1, 15
+	AttributeDBRedisDBIndex = "db.redis.database_index"
+)
+
+// Call-level attributes for MongoDB
+const (
+	// The collection being accessed within the database stated in db.name.
+	//
+	// Type: string
+	// Required: Always
+	// Stability: stable
+	// Examples: 'customers', 'products'
+	AttributeDBMongoDBCollection = "db.mongodb.collection"
+)
+
+// Call-level attrbiutes for SQL databases
+const (
+	// The name of the primary table that the operation is acting upon, including the
+	// schema name (if applicable).
+	//
+	// Type: string
+	// Required: Recommended if available.
+	// Stability: stable
+	// Examples: 'public.users', 'customers'
+	// Note: It is not recommended to attempt any client-side parsing of db.statement
+	// just to get this property, but it should be set if it is provided by the
+	// library being instrumented. If the operation is acting upon an anonymous table,
+	// or more than one table, this value MUST NOT be set.
+	AttributeDBSQLTable = "db.sql.table"
+)
+
+// This document defines the attributes used to report a single exception associated with a span.
+const (
+	// The type of the exception (its fully-qualified class name, if applicable). The
+	// dynamic type of the exception should be preferred over the static type in
+	// languages that support it.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'java.net.ConnectException', 'OSError'
+	AttributeExceptionType = "exception.type"
+	// The exception message.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'Division by zero', "Can't convert 'int' object to str implicitly"
+	AttributeExceptionMessage = "exception.message"
+	// A stacktrace as a string in the natural representation for the language
+	// runtime. The representation is to be determined and documented by each language
+	// SIG.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'Exception in thread "main" java.lang.RuntimeException: Test
+	// exception\\n at '
+	//  'com.example.GenerateTrace.methodB(GenerateTrace.java:13)\\n at '
+	//  'com.example.GenerateTrace.methodA(GenerateTrace.java:9)\\n at '
+	//  'com.example.GenerateTrace.main(GenerateTrace.java:5)'
+	AttributeExceptionStacktrace = "exception.stacktrace"
+	// SHOULD be set to true if the exception event is recorded at a point where it is
+	// known that the exception is escaping the scope of the span.
+	//
+	// Type: boolean
+	// Required: No
+	// Stability: stable
+	// Note: An exception is considered to have escaped (or left) the scope of a span,
+	// if that span is ended while the exception is still logically &quot;in
+	// flight&quot;.
+	// This may be actually &quot;in flight&quot; in some languages (e.g. if the
+	// exception
+	// is passed to a Context manager's __exit__ method in Python) but will
+	// usually be caught at the point of recording the exception in most languages.It
+	// is usually not possible to determine at the point where an exception is thrown
+	// whether it will escape the scope of a span.
+	// However, it is trivial to know that an exception
+	// will escape, if one checks for an active exception just before ending the span,
+	// as done in the example above.It follows that an exception may still escape the
+	// scope of the span
+	// even if the exception.escaped attribute was not set or set to false,
+	// since the event might have been recorded at a time where it was not
+	// clear whether the exception will escape.
+	AttributeExceptionEscaped = "exception.escaped"
+)
+
+// This semantic convention describes an instance of a function that runs without provisioning or managing of servers (also known as serverless functions or Function as a Service (FaaS)) with spans.
+const (
+	// Type of the trigger on which the function is executed.
+	//
+	// Type: Enum
+	// Required: On FaaS instances, faas.trigger MUST be set on incoming invocations.
+	// Clients invoking FaaS instances MUST set `faas.trigger` on outgoing
+	// invocations, if it is known to the client. This is, for example, not the case,
+	// when the transport layer is abstracted in a FaaS client framework without
+	// access to its configuration.
+	// Stability: stable
+	AttributeFaaSTrigger = "faas.trigger"
+	// The execution ID of the current function execution.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'af9d5aa4-a685-4c5f-a22b-444f80b3cc28'
+	AttributeFaaSExecution = "faas.execution"
+)
+
+const (
+	// A response to some data source operation such as a database or filesystem read/write
+	AttributeFaaSTriggerDatasource = "datasource"
+	// To provide an answer to an inbound HTTP request
+	AttributeFaaSTriggerHTTP = "http"
+	// A function is set to be executed when messages are sent to a messaging system
+	AttributeFaaSTriggerPubsub = "pubsub"
+	// A function is scheduled to be executed regularly
+	AttributeFaaSTriggerTimer = "timer"
+	// If none of the others apply
+	AttributeFaaSTriggerOther = "other"
+)
+
+// Semantic Convention for FaaS triggered as a response to some data source operation such as a database or filesystem read/write.
+const (
+	// The name of the source on which the triggering operation was performed. For
+	// example, in Cloud Storage or S3 corresponds to the bucket name, and in Cosmos
+	// DB to the database name.
+	//
+	// Type: string
+	// Required: Always
+	// Stability: stable
+	// Examples: 'myBucketName', 'myDBName'
+	AttributeFaaSDocumentCollection = "faas.document.collection"
+	// Describes the type of the operation that was performed on the data.
+	//
+	// Type: Enum
+	// Required: Always
+	// Stability: stable
+	AttributeFaaSDocumentOperation = "faas.document.operation"
+	// A string containing the time when the data was accessed in the ISO 8601 format
+	// expressed in UTC.
+	//
+	// Type: string
+	// Required: Always
+	// Stability: stable
+	// Examples: '2020-01-23T13:47:06Z'
+	AttributeFaaSDocumentTime = "faas.document.time"
+	// The document name/table subjected to the operation. For example, in Cloud
+	// Storage or S3 is the name of the file, and in Cosmos DB the table name.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'myFile.txt', 'myTableName'
+	AttributeFaaSDocumentName = "faas.document.name"
+)
+
+const (
+	// When a new object is created
+	AttributeFaaSDocumentOperationInsert = "insert"
+	// When an object is modified
+	AttributeFaaSDocumentOperationEdit = "edit"
+	// When an object is deleted
+	AttributeFaaSDocumentOperationDelete = "delete"
+)
+
+// Semantic Convention for FaaS scheduled to be executed regularly.
+const (
+	// A string containing the function invocation time in the ISO 8601 format
+	// expressed in UTC.
+	//
+	// Type: string
+	// Required: Always
+	// Stability: stable
+	// Examples: '2020-01-23T13:47:06Z'
+	AttributeFaaSTime = "faas.time"
+	// A string containing the schedule period as Cron Expression.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '0/5 * * * ? *'
+	AttributeFaaSCron = "faas.cron"
+)
+
+// Contains additional attributes for incoming FaaS spans.
+const (
+	// A boolean that is true if the serverless function is executed for the first
+	// time (aka cold-start).
+	//
+	// Type: boolean
+	// Required: No
+	// Stability: stable
+	AttributeFaaSColdstart = "faas.coldstart"
+)
+
+// Contains additional attributes for outgoing FaaS spans.
+const (
+	// The name of the invoked function.
+	//
+	// Type: string
+	// Required: Always
+	// Stability: stable
+	// Examples: 'my-function'
+	// Note: SHOULD be equal to the faas.name resource attribute of the invoked
+	// function.
+	AttributeFaaSInvokedName = "faas.invoked_name"
+	// The cloud provider of the invoked function.
+	//
+	// Type: Enum
+	// Required: Always
+	// Stability: stable
+	// Note: SHOULD be equal to the cloud.provider resource attribute of the invoked
+	// function.
+	AttributeFaaSInvokedProvider = "faas.invoked_provider"
+	// The cloud region of the invoked function.
+	//
+	// Type: string
+	// Required: For some cloud providers, like AWS or GCP, the region in which a
+	// function is hosted is essential to uniquely identify the function and also part
+	// of its endpoint. Since it's part of the endpoint being called, the region is
+	// always known to clients. In these cases, `faas.invoked_region` MUST be set
+	// accordingly. If the region is unknown to the client or not required for
+	// identifying the invoked function, setting `faas.invoked_region` is optional.
+	// Stability: stable
+	// Examples: 'eu-central-1'
+	// Note: SHOULD be equal to the cloud.region resource attribute of the invoked
+	// function.
+	AttributeFaaSInvokedRegion = "faas.invoked_region"
+)
+
+const (
+	// Alibaba Cloud
+	AttributeFaaSInvokedProviderAlibabaCloud = "alibaba_cloud"
+	// Amazon Web Services
+	AttributeFaaSInvokedProviderAWS = "aws"
+	// Microsoft Azure
+	AttributeFaaSInvokedProviderAzure = "azure"
+	// Google Cloud Platform
+	AttributeFaaSInvokedProviderGCP = "gcp"
+)
+
+// These attributes may be used for any network related operation.
+const (
+	// Transport protocol used. See note below.
+	//
+	// Type: Enum
+	// Required: No
+	// Stability: stable
+	AttributeNetTransport = "net.transport"
+	// Remote address of the peer (dotted decimal for IPv4 or RFC5952 for IPv6)
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '127.0.0.1'
+	AttributeNetPeerIP = "net.peer.ip"
+	// Remote port number.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 80, 8080, 443
+	AttributeNetPeerPort = "net.peer.port"
+	// Remote hostname or similar, see note below.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'example.com'
+	AttributeNetPeerName = "net.peer.name"
+	// Like net.peer.ip but for the host IP. Useful in case of a multi-IP host.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '192.168.0.1'
+	AttributeNetHostIP = "net.host.ip"
+	// Like net.peer.port but for the host port.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 35555
+	AttributeNetHostPort = "net.host.port"
+	// Local hostname or similar, see note below.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'localhost'
+	AttributeNetHostName = "net.host.name"
+	// The internet connection type currently being used by the host.
+	//
+	// Type: Enum
+	// Required: No
+	// Stability: stable
+	// Examples: 'wifi'
+	AttributeNetHostConnectionType = "net.host.connection.type"
+	// This describes more details regarding the connection.type. It may be the type
+	// of cell technology connection, but it could be used for describing details
+	// about a wifi connection.
+	//
+	// Type: Enum
+	// Required: No
+	// Stability: stable
+	// Examples: 'LTE'
+	AttributeNetHostConnectionSubtype = "net.host.connection.subtype"
+	// The name of the mobile carrier.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'sprint'
+	AttributeNetHostCarrierName = "net.host.carrier.name"
+	// The mobile carrier country code.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '310'
+	AttributeNetHostCarrierMcc = "net.host.carrier.mcc"
+	// The mobile carrier network code.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '001'
+	AttributeNetHostCarrierMnc = "net.host.carrier.mnc"
+	// The ISO 3166-1 alpha-2 2-character country code associated with the mobile
+	// carrier network.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'DE'
+	AttributeNetHostCarrierIcc = "net.host.carrier.icc"
+)
+
+const (
+	// ip_tcp
+	AttributeNetTransportTCP = "ip_tcp"
+	// ip_udp
+	AttributeNetTransportUDP = "ip_udp"
+	// Another IP-based protocol
+	AttributeNetTransportIP = "ip"
+	// Unix Domain socket. See below
+	AttributeNetTransportUnix = "unix"
+	// Named or anonymous pipe. See note below
+	AttributeNetTransportPipe = "pipe"
+	// In-process communication
+	AttributeNetTransportInProc = "inproc"
+	// Something else (non IP-based)
+	AttributeNetTransportOther = "other"
+)
+
+const (
+	// wifi
+	AttributeNetHostConnectionTypeWifi = "wifi"
+	// wired
+	AttributeNetHostConnectionTypeWired = "wired"
+	// cell
+	AttributeNetHostConnectionTypeCell = "cell"
+	// unavailable
+	AttributeNetHostConnectionTypeUnavailable = "unavailable"
+	// unknown
+	AttributeNetHostConnectionTypeUnknown = "unknown"
+)
+
+const (
+	// GPRS
+	AttributeNetHostConnectionSubtypeGprs = "gprs"
+	// EDGE
+	AttributeNetHostConnectionSubtypeEdge = "edge"
+	// UMTS
+	AttributeNetHostConnectionSubtypeUmts = "umts"
+	// CDMA
+	AttributeNetHostConnectionSubtypeCdma = "cdma"
+	// EVDO Rel. 0
+	AttributeNetHostConnectionSubtypeEvdo0 = "evdo_0"
+	// EVDO Rev. A
+	AttributeNetHostConnectionSubtypeEvdoA = "evdo_a"
+	// CDMA2000 1XRTT
+	AttributeNetHostConnectionSubtypeCdma20001xrtt = "cdma2000_1xrtt"
+	// HSDPA
+	AttributeNetHostConnectionSubtypeHsdpa = "hsdpa"
+	// HSUPA
+	AttributeNetHostConnectionSubtypeHsupa = "hsupa"
+	// HSPA
+	AttributeNetHostConnectionSubtypeHspa = "hspa"
+	// IDEN
+	AttributeNetHostConnectionSubtypeIden = "iden"
+	// EVDO Rev. B
+	AttributeNetHostConnectionSubtypeEvdoB = "evdo_b"
+	// LTE
+	AttributeNetHostConnectionSubtypeLte = "lte"
+	// EHRPD
+	AttributeNetHostConnectionSubtypeEhrpd = "ehrpd"
+	// HSPAP
+	AttributeNetHostConnectionSubtypeHspap = "hspap"
+	// GSM
+	AttributeNetHostConnectionSubtypeGsm = "gsm"
+	// TD-SCDMA
+	AttributeNetHostConnectionSubtypeTdScdma = "td_scdma"
+	// IWLAN
+	AttributeNetHostConnectionSubtypeIwlan = "iwlan"
+	// 5G NR (New Radio)
+	AttributeNetHostConnectionSubtypeNr = "nr"
+	// 5G NRNSA (New Radio Non-Standalone)
+	AttributeNetHostConnectionSubtypeNrnsa = "nrnsa"
+	// LTE CA
+	AttributeNetHostConnectionSubtypeLteCa = "lte_ca"
+)
+
+// Operations that access some remote service.
+const (
+	// The service.name of the remote service. SHOULD be equal to the actual
+	// service.name resource attribute of the remote service if any.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'AuthTokenCache'
+	AttributePeerService = "peer.service"
+)
+
+// These attributes may be used for any operation with an authenticated and/or authorized enduser.
+const (
+	// Username or client_id extracted from the access token or Authorization header
+	// in the inbound request from outside the system.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'username'
+	AttributeEnduserID = "enduser.id"
+	// Actual/assumed role the client is making the request under extracted from token
+	// or application security context.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'admin'
+	AttributeEnduserRole = "enduser.role"
+	// Scopes or granted authorities the client currently possesses extracted from
+	// token or application security context. The value would come from the scope
+	// associated with an OAuth 2.0 Access Token or an attribute value in a SAML 2.0
+	// Assertion.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'read:message, write:files'
+	AttributeEnduserScope = "enduser.scope"
+)
+
+// These attributes may be used for any operation to store information about a thread that started a span.
+const (
+	// Current &quot;managed&quot; thread ID (as opposed to OS thread ID).
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 42
+	AttributeThreadID = "thread.id"
+	// Current thread name.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'main'
+	AttributeThreadName = "thread.name"
+)
+
+// These attributes allow to report this unit of code and therefore to provide more context about the span.
+const (
+	// The method or function name, or equivalent (usually rightmost part of the code
+	// unit's name).
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'serveRequest'
+	AttributeCodeFunction = "code.function"
+	// The &quot;namespace&quot; within which code.function is defined. Usually the
+	// qualified class or module name, such that code.namespace + some separator +
+	// code.function form a unique identifier for the code unit.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'com.example.MyHTTPService'
+	AttributeCodeNamespace = "code.namespace"
+	// The source code file name that identifies the code unit as uniquely as possible
+	// (preferably an absolute file path).
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '/usr/local/MyApplication/content_root/app/index.php'
+	AttributeCodeFilepath = "code.filepath"
+	// The line number in code.filepath best representing the operation. It SHOULD
+	// point within the code unit named in code.function.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 42
+	AttributeCodeLineNumber = "code.lineno"
+)
+
+// This document defines semantic conventions for HTTP client and server Spans.
+const (
+	// HTTP request method.
+	//
+	// Type: string
+	// Required: Always
+	// Stability: stable
+	// Examples: 'GET', 'POST', 'HEAD'
+	AttributeHTTPMethod = "http.method"
+	// Full HTTP request URL in the form scheme://host[:port]/path?query[#fragment].
+	// Usually the fragment is not transmitted over HTTP, but if it is known, it
+	// should be included nevertheless.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'https://www.foo.bar/search?q=OpenTelemetry#SemConv'
+	// Note: http.url MUST NOT contain credentials passed via URL in form of
+	// https://username:password@www.example.com/. In such case the attribute's value
+	// should be https://www.example.com/.
+	AttributeHTTPURL = "http.url"
+	// The full request target as passed in a HTTP request line or equivalent.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '/path/12314/?q=ddds#123'
+	AttributeHTTPTarget = "http.target"
+	// The value of the HTTP host header. An empty Host header should also be
+	// reported, see note.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'www.example.org'
+	// Note: When the header is present but empty the attribute SHOULD be set to the
+	// empty string. Note that this is a valid situation that is expected in certain
+	// cases, according the aforementioned section of RFC 7230. When the header is not
+	// set the attribute MUST NOT be set.
+	AttributeHTTPHost = "http.host"
+	// The URI scheme identifying the used protocol.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'http', 'https'
+	AttributeHTTPScheme = "http.scheme"
+	// HTTP response status code.
+	//
+	// Type: int
+	// Required: If and only if one was received/sent.
+	// Stability: stable
+	// Examples: 200
+	AttributeHTTPStatusCode = "http.status_code"
+	// Kind of HTTP protocol used.
+	//
+	// Type: Enum
+	// Required: No
+	// Stability: stable
+	// Note: If net.transport is not specified, it can be assumed to be IP.TCP except
+	// if http.flavor is QUIC, in which case IP.UDP is assumed.
+	AttributeHTTPFlavor = "http.flavor"
+	// Value of the HTTP User-Agent header sent by the client.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'CERN-LineMode/2.15 libwww/2.17b3'
+	AttributeHTTPUserAgent = "http.user_agent"
+	// The size of the request payload body in bytes. This is the number of bytes
+	// transferred excluding headers and is often, but not always, present as the
+	// Content-Length header. For requests using transport encoding, this should be
+	// the compressed size.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 3495
+	AttributeHTTPRequestContentLength = "http.request_content_length"
+	// The size of the uncompressed request payload body after transport decoding. Not
+	// set if transport encoding not used.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 5493
+	AttributeHTTPRequestContentLengthUncompressed = "http.request_content_length_uncompressed"
+	// The size of the response payload body in bytes. This is the number of bytes
+	// transferred excluding headers and is often, but not always, present as the
+	// Content-Length header. For requests using transport encoding, this should be
+	// the compressed size.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 3495
+	AttributeHTTPResponseContentLength = "http.response_content_length"
+	// The size of the uncompressed response payload body after transport decoding.
+	// Not set if transport encoding not used.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 5493
+	AttributeHTTPResponseContentLengthUncompressed = "http.response_content_length_uncompressed"
+)
+
+const (
+	// HTTP 1.0
+	AttributeHTTPFlavorHTTP10 = "1.0"
+	// HTTP 1.1
+	AttributeHTTPFlavorHTTP11 = "1.1"
+	// HTTP 2
+	AttributeHTTPFlavorHTTP20 = "2.0"
+	// SPDY protocol
+	AttributeHTTPFlavorSPDY = "SPDY"
+	// QUIC protocol
+	AttributeHTTPFlavorQUIC = "QUIC"
+)
+
+// Semantic Convention for HTTP Server
+const (
+	// The primary server name of the matched virtual host. This should be obtained
+	// via configuration. If no such configuration can be obtained, this attribute
+	// MUST NOT be set ( net.host.name should be used instead).
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'example.com'
+	// Note: http.url is usually not readily available on the server side but would
+	// have to be assembled in a cumbersome and sometimes lossy process from other
+	// information (see e.g. open-telemetry/opentelemetry-python/pull/148). It is thus
+	// preferred to supply the raw data that is available.
+	AttributeHTTPServerName = "http.server_name"
+	// The matched route (path template).
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '/users/:userID?'
+	AttributeHTTPRoute = "http.route"
+	// The IP address of the original client behind all proxies, if known (e.g. from
+	// X-Forwarded-For).
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '83.164.160.102'
+	// Note: This is not necessarily the same as net.peer.ip, which would
+	// identify the network-level peer, which may be a proxy.This attribute should be
+	// set when a source of information different
+	// from the one used for net.peer.ip, is available even if that other
+	// source just confirms the same value as net.peer.ip.
+	// Rationale: For net.peer.ip, one typically does not know if it
+	// comes from a proxy, reverse proxy, or the actual client. Setting
+	// http.client_ip when it's the same as net.peer.ip means that
+	// one is at least somewhat confident that the address is not that of
+	// the closest proxy.
+	AttributeHTTPClientIP = "http.client_ip"
+)
+
+// Attributes that exist for multiple DynamoDB request types.
+const (
+	// The keys in the RequestItems object field.
+	//
+	// Type: string[]
+	// Required: No
+	// Stability: stable
+	// Examples: 'Users', 'Cats'
+	AttributeAWSDynamoDBTableNames = "aws.dynamodb.table_names"
+	// The JSON-serialized value of each item in the ConsumedCapacity response field.
+	//
+	// Type: string[]
+	// Required: No
+	// Stability: stable
+	// Examples: '{ "CapacityUnits": number, "GlobalSecondaryIndexes": { "string" : {
+	// "CapacityUnits": number, "ReadCapacityUnits": number, "WriteCapacityUnits":
+	// number } }, "LocalSecondaryIndexes": { "string" : { "CapacityUnits": number,
+	// "ReadCapacityUnits": number, "WriteCapacityUnits": number } },
+	// "ReadCapacityUnits": number, "Table": { "CapacityUnits": number,
+	// "ReadCapacityUnits": number, "WriteCapacityUnits": number }, "TableName":
+	// "string", "WriteCapacityUnits": number }'
+	AttributeAWSDynamoDBConsumedCapacity = "aws.dynamodb.consumed_capacity"
+	// The JSON-serialized value of the ItemCollectionMetrics response field.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '{ "string" : [ { "ItemCollectionKey": { "string" : { "B": blob,
+	// "BOOL": boolean, "BS": [ blob ], "L": [ "AttributeValue" ], "M": { "string" :
+	// "AttributeValue" }, "N": "string", "NS": [ "string" ], "NULL": boolean, "S":
+	// "string", "SS": [ "string" ] } }, "SizeEstimateRangeGB": [ number ] } ] }'
+	AttributeAWSDynamoDBItemCollectionMetrics = "aws.dynamodb.item_collection_metrics"
+	// The value of the ProvisionedThroughput.ReadCapacityUnits request parameter.
+	//
+	// Type: double
+	// Required: No
+	// Stability: stable
+	// Examples: 1.0, 2.0
+	AttributeAWSDynamoDBProvisionedReadCapacity = "aws.dynamodb.provisioned_read_capacity"
+	// The value of the ProvisionedThroughput.WriteCapacityUnits request parameter.
+	//
+	// Type: double
+	// Required: No
+	// Stability: stable
+	// Examples: 1.0, 2.0
+	AttributeAWSDynamoDBProvisionedWriteCapacity = "aws.dynamodb.provisioned_write_capacity"
+	// The value of the ConsistentRead request parameter.
+	//
+	// Type: boolean
+	// Required: No
+	// Stability: stable
+	AttributeAWSDynamoDBConsistentRead = "aws.dynamodb.consistent_read"
+	// The value of the ProjectionExpression request parameter.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'Title', 'Title, Price, Color', 'Title, Description, RelatedItems,
+	// ProductReviews'
+	AttributeAWSDynamoDBProjection = "aws.dynamodb.projection"
+	// The value of the Limit request parameter.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 10
+	AttributeAWSDynamoDBLimit = "aws.dynamodb.limit"
+	// The value of the AttributesToGet request parameter.
+	//
+	// Type: string[]
+	// Required: No
+	// Stability: stable
+	// Examples: 'lives', 'id'
+	AttributeAWSDynamoDBAttributesToGet = "aws.dynamodb.attributes_to_get"
+	// The value of the IndexName request parameter.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'name_to_group'
+	AttributeAWSDynamoDBIndexName = "aws.dynamodb.index_name"
+	// The value of the Select request parameter.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'ALL_ATTRIBUTES', 'COUNT'
+	AttributeAWSDynamoDBSelect = "aws.dynamodb.select"
+)
+
+// DynamoDB.CreateTable
+const (
+	// The JSON-serialized value of each item of the GlobalSecondaryIndexes request
+	// field
+	//
+	// Type: string[]
+	// Required: No
+	// Stability: stable
+	// Examples: '{ "IndexName": "string", "KeySchema": [ { "AttributeName": "string",
+	// "KeyType": "string" } ], "Projection": { "NonKeyAttributes": [ "string" ],
+	// "ProjectionType": "string" }, "ProvisionedThroughput": { "ReadCapacityUnits":
+	// number, "WriteCapacityUnits": number } }'
+	AttributeAWSDynamoDBGlobalSecondaryIndexes = "aws.dynamodb.global_secondary_indexes"
+	// The JSON-serialized value of each item of the LocalSecondaryIndexes request
+	// field.
+	//
+	// Type: string[]
+	// Required: No
+	// Stability: stable
+	// Examples: '{ "IndexARN": "string", "IndexName": "string", "IndexSizeBytes":
+	// number, "ItemCount": number, "KeySchema": [ { "AttributeName": "string",
+	// "KeyType": "string" } ], "Projection": { "NonKeyAttributes": [ "string" ],
+	// "ProjectionType": "string" } }'
+	AttributeAWSDynamoDBLocalSecondaryIndexes = "aws.dynamodb.local_secondary_indexes"
+)
+
+// DynamoDB.ListTables
+const (
+	// The value of the ExclusiveStartTableName request parameter.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'Users', 'CatsTable'
+	AttributeAWSDynamoDBExclusiveStartTable = "aws.dynamodb.exclusive_start_table"
+	// The the number of items in the TableNames response parameter.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 20
+	AttributeAWSDynamoDBTableCount = "aws.dynamodb.table_count"
+)
+
+// DynamoDB.Query
+const (
+	// The value of the ScanIndexForward request parameter.
+	//
+	// Type: boolean
+	// Required: No
+	// Stability: stable
+	AttributeAWSDynamoDBScanForward = "aws.dynamodb.scan_forward"
+)
+
+// DynamoDB.Scan
+const (
+	// The value of the Segment request parameter.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 10
+	AttributeAWSDynamoDBSegment = "aws.dynamodb.segment"
+	// The value of the TotalSegments request parameter.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 100
+	AttributeAWSDynamoDBTotalSegments = "aws.dynamodb.total_segments"
+	// The value of the Count response parameter.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 10
+	AttributeAWSDynamoDBCount = "aws.dynamodb.count"
+	// The value of the ScannedCount response parameter.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 50
+	AttributeAWSDynamoDBScannedCount = "aws.dynamodb.scanned_count"
+)
+
+// DynamoDB.UpdateTable
+const (
+	// The JSON-serialized value of each item in the AttributeDefinitions request
+	// field.
+	//
+	// Type: string[]
+	// Required: No
+	// Stability: stable
+	// Examples: '{ "AttributeName": "string", "AttributeType": "string" }'
+	AttributeAWSDynamoDBAttributeDefinitions = "aws.dynamodb.attribute_definitions"
+	// The JSON-serialized value of each item in the the GlobalSecondaryIndexUpdates
+	// request field.
+	//
+	// Type: string[]
+	// Required: No
+	// Stability: stable
+	// Examples: '{ "Create": { "IndexName": "string", "KeySchema": [ {
+	// "AttributeName": "string", "KeyType": "string" } ], "Projection": {
+	// "NonKeyAttributes": [ "string" ], "ProjectionType": "string" },
+	// "ProvisionedThroughput": { "ReadCapacityUnits": number, "WriteCapacityUnits":
+	// number } }'
+	AttributeAWSDynamoDBGlobalSecondaryIndexUpdates = "aws.dynamodb.global_secondary_index_updates"
+)
+
+// This document defines the attributes used in messaging systems.
+const (
+	// A string identifying the messaging system.
+	//
+	// Type: string
+	// Required: Always
+	// Stability: stable
+	// Examples: 'kafka', 'rabbitmq', 'activemq', 'AmazonSQS'
+	AttributeMessagingSystem = "messaging.system"
+	// The message destination name. This might be equal to the span name but is
+	// required nevertheless.
+	//
+	// Type: string
+	// Required: Always
+	// Stability: stable
+	// Examples: 'MyQueue', 'MyTopic'
+	AttributeMessagingDestination = "messaging.destination"
+	// The kind of message destination
+	//
+	// Type: Enum
+	// Required: Required only if the message destination is either a `queue` or
+	// `topic`.
+	// Stability: stable
+	AttributeMessagingDestinationKind = "messaging.destination_kind"
+	// A boolean that is true if the message destination is temporary.
+	//
+	// Type: boolean
+	// Required: If missing, it is assumed to be false.
+	// Stability: stable
+	AttributeMessagingTempDestination = "messaging.temp_destination"
+	// The name of the transport protocol.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'AMQP', 'MQTT'
+	AttributeMessagingProtocol = "messaging.protocol"
+	// The version of the transport protocol.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '0.9.1'
+	AttributeMessagingProtocolVersion = "messaging.protocol_version"
+	// Connection string.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'tibjmsnaming://localhost:7222',
+	// 'https://queue.amazonaws.com/80398EXAMPLE/MyQueue'
+	AttributeMessagingURL = "messaging.url"
+	// A value used by the messaging system as an identifier for the message,
+	// represented as a string.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '452a7c7c7c7048c2f887f61572b18fc2'
+	AttributeMessagingMessageID = "messaging.message_id"
+	// The conversation ID identifying the conversation to which the message belongs,
+	// represented as a string. Sometimes called &quot;Correlation ID&quot;.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'MyConversationID'
+	AttributeMessagingConversationID = "messaging.conversation_id"
+	// The (uncompressed) size of the message payload in bytes. Also use this
+	// attribute if it is unknown whether the compressed or uncompressed payload size
+	// is reported.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 2738
+	AttributeMessagingMessagePayloadSizeBytes = "messaging.message_payload_size_bytes"
+	// The compressed size of the message payload in bytes.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 2048
+	AttributeMessagingMessagePayloadCompressedSizeBytes = "messaging.message_payload_compressed_size_bytes"
+)
+
+const (
+	// A message sent to a queue
+	AttributeMessagingDestinationKindQueue = "queue"
+	// A message sent to a topic
+	AttributeMessagingDestinationKindTopic = "topic"
+)
+
+// Semantic convention for a consumer of messages received from a messaging system
+const (
+	// A string identifying the kind of message consumption as defined in the
+	// Operation names section above. If the operation is &quot;send&quot;, this
+	// attribute MUST NOT be set, since the operation can be inferred from the span
+	// kind in that case.
+	//
+	// Type: Enum
+	// Required: No
+	// Stability: stable
+	AttributeMessagingOperation = "messaging.operation"
+	// The identifier for the consumer receiving a message. For Kafka, set it to
+	// {messaging.kafka.consumer_group} - {messaging.kafka.client_id}, if both are
+	// present, or only messaging.kafka.consumer_group. For brokers, such as RabbitMQ
+	// and Artemis, set it to the client_id of the client consuming the message.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'mygroup - client-6'
+	AttributeMessagingConsumerID = "messaging.consumer_id"
+)
+
+const (
+	// receive
+	AttributeMessagingOperationReceive = "receive"
+	// process
+	AttributeMessagingOperationProcess = "process"
+)
+
+// Attributes for RabbitMQ
+const (
+	// RabbitMQ message routing key.
+	//
+	// Type: string
+	// Required: Unless it is empty.
+	// Stability: stable
+	// Examples: 'myKey'
+	AttributeMessagingRabbitmqRoutingKey = "messaging.rabbitmq.routing_key"
+)
+
+// Attributes for Apache Kafka
+const (
+	// Message keys in Kafka are used for grouping alike messages to ensure they're
+	// processed on the same partition. They differ from messaging.message_id in that
+	// they're not unique. If the key is null, the attribute MUST NOT be set.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'myKey'
+	// Note: If the key type is not string, it's string representation has to be
+	// supplied for the attribute. If the key has no unambiguous, canonical string
+	// form, don't include its value.
+	AttributeMessagingKafkaMessageKey = "messaging.kafka.message_key"
+	// Name of the Kafka Consumer Group that is handling the message. Only applies to
+	// consumers, not producers.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'my-group'
+	AttributeMessagingKafkaConsumerGroup = "messaging.kafka.consumer_group"
+	// Client ID for the Consumer or Producer that is handling the message.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'client-5'
+	AttributeMessagingKafkaClientID = "messaging.kafka.client_id"
+	// Partition the message is sent to.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 2
+	AttributeMessagingKafkaPartition = "messaging.kafka.partition"
+	// A boolean that is true if the message is a tombstone.
+	//
+	// Type: boolean
+	// Required: If missing, it is assumed to be false.
+	// Stability: stable
+	AttributeMessagingKafkaTombstone = "messaging.kafka.tombstone"
+)
+
+// This document defines semantic conventions for remote procedure calls.
+const (
+	// A string identifying the remoting system.
+	//
+	// Type: string
+	// Required: Always
+	// Stability: stable
+	// Examples: 'grpc', 'java_rmi', 'wcf'
+	AttributeRPCSystem = "rpc.system"
+	// The full (logical) name of the service being called, including its package
+	// name, if applicable.
+	//
+	// Type: string
+	// Required: No, but recommended
+	// Stability: stable
+	// Examples: 'myservice.EchoService'
+	// Note: This is the logical name of the service from the RPC interface
+	// perspective, which can be different from the name of any implementing class.
+	// The code.namespace attribute may be used to store the latter (despite the
+	// attribute name, it may include a class name; e.g., class with method actually
+	// executing the call on the server side, RPC client stub class on the client
+	// side).
+	AttributeRPCService = "rpc.service"
+	// The name of the (logical) method being called, must be equal to the $method
+	// part in the span name.
+	//
+	// Type: string
+	// Required: No, but recommended
+	// Stability: stable
+	// Examples: 'exampleMethod'
+	// Note: This is the logical name of the method from the RPC interface
+	// perspective, which can be different from the name of any implementing
+	// method/function. The code.function attribute may be used to store the latter
+	// (e.g., method actually executing the call on the server side, RPC client stub
+	// method on the client side).
+	AttributeRPCMethod = "rpc.method"
+)
+
+// Tech-specific attributes for gRPC.
+const (
+	// The numeric status code of the gRPC request.
+	//
+	// Type: Enum
+	// Required: Always
+	// Stability: stable
+	AttributeRPCGRPCStatusCode = "rpc.grpc.status_code"
+)
+
+const (
+	// OK
+	AttributeRPCGRPCStatusCodeOk = "0"
+	// CANCELLED
+	AttributeRPCGRPCStatusCodeCancelled = "1"
+	// UNKNOWN
+	AttributeRPCGRPCStatusCodeUnknown = "2"
+	// INVALID_ARGUMENT
+	AttributeRPCGRPCStatusCodeInvalidArgument = "3"
+	// DEADLINE_EXCEEDED
+	AttributeRPCGRPCStatusCodeDeadlineExceeded = "4"
+	// NOT_FOUND
+	AttributeRPCGRPCStatusCodeNotFound = "5"
+	// ALREADY_EXISTS
+	AttributeRPCGRPCStatusCodeAlreadyExists = "6"
+	// PERMISSION_DENIED
+	AttributeRPCGRPCStatusCodePermissionDenied = "7"
+	// RESOURCE_EXHAUSTED
+	AttributeRPCGRPCStatusCodeResourceExhausted = "8"
+	// FAILED_PRECONDITION
+	AttributeRPCGRPCStatusCodeFailedPrecondition = "9"
+	// ABORTED
+	AttributeRPCGRPCStatusCodeAborted = "10"
+	// OUT_OF_RANGE
+	AttributeRPCGRPCStatusCodeOutOfRange = "11"
+	// UNIMPLEMENTED
+	AttributeRPCGRPCStatusCodeUnimplemented = "12"
+	// INTERNAL
+	AttributeRPCGRPCStatusCodeInternal = "13"
+	// UNAVAILABLE
+	AttributeRPCGRPCStatusCodeUnavailable = "14"
+	// DATA_LOSS
+	AttributeRPCGRPCStatusCodeDataLoss = "15"
+	// UNAUTHENTICATED
+	AttributeRPCGRPCStatusCodeUnauthenticated = "16"
+)
+
+// Tech-specific attributes for [JSON RPC](https://www.jsonrpc.org/).
+const (
+	// Protocol version as in jsonrpc property of request/response. Since JSON-RPC 1.0
+	// does not specify this, the value can be omitted.
+	//
+	// Type: string
+	// Required: If missing, it is assumed to be "1.0".
+	// Stability: stable
+	// Examples: '2.0', '1.0'
+	AttributeRPCJsonrpcVersion = "rpc.jsonrpc.version"
+	// id property of request or response. Since protocol allows id to be int, string,
+	// null or missing (for notifications), value is expected to be cast to string for
+	// simplicity. Use empty string in case of null value. Omit entirely if this is a
+	// notification.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '10', 'request-7', ''
+	AttributeRPCJsonrpcRequestID = "rpc.jsonrpc.request_id"
+	// error.code property of response if it is an error response.
+	//
+	// Type: int
+	// Required: If missing, response is assumed to be successful.
+	// Stability: stable
+	// Examples: -32700, 100
+	AttributeRPCJsonrpcErrorCode = "rpc.jsonrpc.error_code"
+	// error.message property of response if it is an error response.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'Parse error', 'User already exists'
+	AttributeRPCJsonrpcErrorMessage = "rpc.jsonrpc.error_message"
+)
+
+// RPC received/sent message.
+const (
+	// Whether this is a received or sent message.
+	//
+	// Type: Enum
+	// Required: No
+	// Stability: stable
+	AttributeMessageType = "message.type"
+	// MUST be calculated as two different counters starting from 1 one for sent
+	// messages and one for received message.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Note: This way we guarantee that the values will be consistent between
+	// different implementations.
+	AttributeMessageID = "message.id"
+	// Compressed size of the message in bytes.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	AttributeMessageCompressedSize = "message.compressed_size"
+	// Uncompressed size of the message in bytes.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	AttributeMessageUncompressedSize = "message.uncompressed_size"
+)
+
+const (
+	// sent
+	AttributeMessageTypeSent = "SENT"
+	// received
+	AttributeMessageTypeReceived = "RECEIVED"
+)
+
+func GetTraceSemanticConventionAttributeNames() []string {
+	return []string{
+		AttributeAWSLambdaInvokedARN,
+		AttributeDBSystem,
+		AttributeDBConnectionString,
+		AttributeDBUser,
+		AttributeDBJDBCDriverClassname,
+		AttributeDBName,
+		AttributeDBStatement,
+		AttributeDBOperation,
+		AttributeDBMSSQLInstanceName,
+		AttributeDBCassandraKeyspace,
+		AttributeDBCassandraPageSize,
+		AttributeDBCassandraConsistencyLevel,
+		AttributeDBCassandraTable,
+		AttributeDBCassandraIdempotence,
+		AttributeDBCassandraSpeculativeExecutionCount,
+		AttributeDBCassandraCoordinatorID,
+		AttributeDBCassandraCoordinatorDC,
+		AttributeDBHBaseNamespace,
+		AttributeDBRedisDBIndex,
+		AttributeDBMongoDBCollection,
+		AttributeDBSQLTable,
+		AttributeExceptionType,
+		AttributeExceptionMessage,
+		AttributeExceptionStacktrace,
+		AttributeExceptionEscaped,
+		AttributeFaaSTrigger,
+		AttributeFaaSExecution,
+		AttributeFaaSDocumentCollection,
+		AttributeFaaSDocumentOperation,
+		AttributeFaaSDocumentTime,
+		AttributeFaaSDocumentName,
+		AttributeFaaSTime,
+		AttributeFaaSCron,
+		AttributeFaaSColdstart,
+		AttributeFaaSInvokedName,
+		AttributeFaaSInvokedProvider,
+		AttributeFaaSInvokedRegion,
+		AttributeNetTransport,
+		AttributeNetPeerIP,
+		AttributeNetPeerPort,
+		AttributeNetPeerName,
+		AttributeNetHostIP,
+		AttributeNetHostPort,
+		AttributeNetHostName,
+		AttributeNetHostConnectionType,
+		AttributeNetHostConnectionSubtype,
+		AttributeNetHostCarrierName,
+		AttributeNetHostCarrierMcc,
+		AttributeNetHostCarrierMnc,
+		AttributeNetHostCarrierIcc,
+		AttributePeerService,
+		AttributeEnduserID,
+		AttributeEnduserRole,
+		AttributeEnduserScope,
+		AttributeThreadID,
+		AttributeThreadName,
+		AttributeCodeFunction,
+		AttributeCodeNamespace,
+		AttributeCodeFilepath,
+		AttributeCodeLineNumber,
+		AttributeHTTPMethod,
+		AttributeHTTPURL,
+		AttributeHTTPTarget,
+		AttributeHTTPHost,
+		AttributeHTTPScheme,
+		AttributeHTTPStatusCode,
+		AttributeHTTPFlavor,
+		AttributeHTTPUserAgent,
+		AttributeHTTPRequestContentLength,
+		AttributeHTTPRequestContentLengthUncompressed,
+		AttributeHTTPResponseContentLength,
+		AttributeHTTPResponseContentLengthUncompressed,
+		AttributeHTTPServerName,
+		AttributeHTTPRoute,
+		AttributeHTTPClientIP,
+		AttributeAWSDynamoDBTableNames,
+		AttributeAWSDynamoDBConsumedCapacity,
+		AttributeAWSDynamoDBItemCollectionMetrics,
+		AttributeAWSDynamoDBProvisionedReadCapacity,
+		AttributeAWSDynamoDBProvisionedWriteCapacity,
+		AttributeAWSDynamoDBConsistentRead,
+		AttributeAWSDynamoDBProjection,
+		AttributeAWSDynamoDBLimit,
+		AttributeAWSDynamoDBAttributesToGet,
+		AttributeAWSDynamoDBIndexName,
+		AttributeAWSDynamoDBSelect,
+		AttributeAWSDynamoDBGlobalSecondaryIndexes,
+		AttributeAWSDynamoDBLocalSecondaryIndexes,
+		AttributeAWSDynamoDBExclusiveStartTable,
+		AttributeAWSDynamoDBTableCount,
+		AttributeAWSDynamoDBScanForward,
+		AttributeAWSDynamoDBSegment,
+		AttributeAWSDynamoDBTotalSegments,
+		AttributeAWSDynamoDBCount,
+		AttributeAWSDynamoDBScannedCount,
+		AttributeAWSDynamoDBAttributeDefinitions,
+		AttributeAWSDynamoDBGlobalSecondaryIndexUpdates,
+		AttributeMessagingSystem,
+		AttributeMessagingDestination,
+		AttributeMessagingDestinationKind,
+		AttributeMessagingTempDestination,
+		AttributeMessagingProtocol,
+		AttributeMessagingProtocolVersion,
+		AttributeMessagingURL,
+		AttributeMessagingMessageID,
+		AttributeMessagingConversationID,
+		AttributeMessagingMessagePayloadSizeBytes,
+		AttributeMessagingMessagePayloadCompressedSizeBytes,
+		AttributeMessagingOperation,
+		AttributeMessagingConsumerID,
+		AttributeMessagingRabbitmqRoutingKey,
+		AttributeMessagingKafkaMessageKey,
+		AttributeMessagingKafkaConsumerGroup,
+		AttributeMessagingKafkaClientID,
+		AttributeMessagingKafkaPartition,
+		AttributeMessagingKafkaTombstone,
+		AttributeRPCSystem,
+		AttributeRPCService,
+		AttributeRPCMethod,
+		AttributeRPCGRPCStatusCode,
+		AttributeRPCJsonrpcVersion,
+		AttributeRPCJsonrpcRequestID,
+		AttributeRPCJsonrpcErrorCode,
+		AttributeRPCJsonrpcErrorMessage,
+		AttributeMessageType,
+		AttributeMessageID,
+		AttributeMessageCompressedSize,
+		AttributeMessageUncompressedSize,
+	}
+}

--- a/model/semconv/v1.8.0/resource.go
+++ b/model/semconv/v1.8.0/resource.go
@@ -1,0 +1,1027 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Code generated from semantic convention specification. DO NOT EDIT.
+
+package semconv
+
+// A cloud environment (e.g. GCP, Azure, AWS)
+const (
+	// Name of the cloud provider.
+	//
+	// Type: Enum
+	// Required: No
+	// Stability: stable
+	AttributeCloudProvider = "cloud.provider"
+	// The cloud account ID the resource is assigned to.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '111111111111', 'opentelemetry'
+	AttributeCloudAccountID = "cloud.account.id"
+	// The geographical region the resource is running.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'us-central1', 'us-east-1'
+	// Note: Refer to your provider's docs to see the available regions, for example
+	// Alibaba Cloud regions, AWS regions, Azure regions, Google Cloud regions, or
+	// Tencent Cloud regions.
+	AttributeCloudRegion = "cloud.region"
+	// Cloud regions often have multiple, isolated locations known as zones to
+	// increase availability. Availability zone represents the zone where the resource
+	// is running.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'us-east-1c'
+	// Note: Availability zones are called &quot;zones&quot; on Alibaba Cloud and
+	// Google Cloud.
+	AttributeCloudAvailabilityZone = "cloud.availability_zone"
+	// The cloud platform in use.
+	//
+	// Type: Enum
+	// Required: No
+	// Stability: stable
+	// Note: The prefix of the service SHOULD match the one specified in
+	// cloud.provider.
+	AttributeCloudPlatform = "cloud.platform"
+)
+
+const (
+	// Alibaba Cloud
+	AttributeCloudProviderAlibabaCloud = "alibaba_cloud"
+	// Amazon Web Services
+	AttributeCloudProviderAWS = "aws"
+	// Microsoft Azure
+	AttributeCloudProviderAzure = "azure"
+	// Google Cloud Platform
+	AttributeCloudProviderGCP = "gcp"
+	// Tencent Cloud
+	AttributeCloudProviderTencentCloud = "tencent_cloud"
+)
+
+const (
+	// Alibaba Cloud Elastic Compute Service
+	AttributeCloudPlatformAlibabaCloudECS = "alibaba_cloud_ecs"
+	// Alibaba Cloud Function Compute
+	AttributeCloudPlatformAlibabaCloudFc = "alibaba_cloud_fc"
+	// AWS Elastic Compute Cloud
+	AttributeCloudPlatformAWSEC2 = "aws_ec2"
+	// AWS Elastic Container Service
+	AttributeCloudPlatformAWSECS = "aws_ecs"
+	// AWS Elastic Kubernetes Service
+	AttributeCloudPlatformAWSEKS = "aws_eks"
+	// AWS Lambda
+	AttributeCloudPlatformAWSLambda = "aws_lambda"
+	// AWS Elastic Beanstalk
+	AttributeCloudPlatformAWSElasticBeanstalk = "aws_elastic_beanstalk"
+	// AWS App Runner
+	AttributeCloudPlatformAWSAppRunner = "aws_app_runner"
+	// Azure Virtual Machines
+	AttributeCloudPlatformAzureVM = "azure_vm"
+	// Azure Container Instances
+	AttributeCloudPlatformAzureContainerInstances = "azure_container_instances"
+	// Azure Kubernetes Service
+	AttributeCloudPlatformAzureAKS = "azure_aks"
+	// Azure Functions
+	AttributeCloudPlatformAzureFunctions = "azure_functions"
+	// Azure App Service
+	AttributeCloudPlatformAzureAppService = "azure_app_service"
+	// Google Cloud Compute Engine (GCE)
+	AttributeCloudPlatformGCPComputeEngine = "gcp_compute_engine"
+	// Google Cloud Run
+	AttributeCloudPlatformGCPCloudRun = "gcp_cloud_run"
+	// Google Cloud Kubernetes Engine (GKE)
+	AttributeCloudPlatformGCPKubernetesEngine = "gcp_kubernetes_engine"
+	// Google Cloud Functions (GCF)
+	AttributeCloudPlatformGCPCloudFunctions = "gcp_cloud_functions"
+	// Google Cloud App Engine (GAE)
+	AttributeCloudPlatformGCPAppEngine = "gcp_app_engine"
+	// Tencent Cloud Cloud Virtual Machine (CVM)
+	AttributeCloudPlatformTencentCloudCvm = "tencent_cloud_cvm"
+	// Tencent Cloud Elastic Kubernetes Service (EKS)
+	AttributeCloudPlatformTencentCloudEKS = "tencent_cloud_eks"
+	// Tencent Cloud Serverless Cloud Function (SCF)
+	AttributeCloudPlatformTencentCloudScf = "tencent_cloud_scf"
+)
+
+// Resources used by AWS Elastic Container Service (ECS).
+const (
+	// The Amazon Resource Name (ARN) of an ECS container instance.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'arn:aws:ecs:us-
+	// west-1:123456789123:container/32624152-9086-4f0e-acae-1a75b14fe4d9'
+	AttributeAWSECSContainerARN = "aws.ecs.container.arn"
+	// The ARN of an ECS cluster.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'arn:aws:ecs:us-west-2:123456789123:cluster/my-cluster'
+	AttributeAWSECSClusterARN = "aws.ecs.cluster.arn"
+	// The launch type for an ECS task.
+	//
+	// Type: Enum
+	// Required: No
+	// Stability: stable
+	AttributeAWSECSLaunchtype = "aws.ecs.launchtype"
+	// The ARN of an ECS task definition.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'arn:aws:ecs:us-
+	// west-1:123456789123:task/10838bed-421f-43ef-870a-f43feacbbb5b'
+	AttributeAWSECSTaskARN = "aws.ecs.task.arn"
+	// The task definition family this task definition is a member of.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'opentelemetry-family'
+	AttributeAWSECSTaskFamily = "aws.ecs.task.family"
+	// The revision for this task definition.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '8', '26'
+	AttributeAWSECSTaskRevision = "aws.ecs.task.revision"
+)
+
+const (
+	// ec2
+	AttributeAWSECSLaunchtypeEC2 = "ec2"
+	// fargate
+	AttributeAWSECSLaunchtypeFargate = "fargate"
+)
+
+// Resources used by AWS Elastic Kubernetes Service (EKS).
+const (
+	// The ARN of an EKS cluster.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'arn:aws:ecs:us-west-2:123456789123:cluster/my-cluster'
+	AttributeAWSEKSClusterARN = "aws.eks.cluster.arn"
+)
+
+// Resources specific to Amazon Web Services.
+const (
+	// The name(s) of the AWS log group(s) an application is writing to.
+	//
+	// Type: string[]
+	// Required: No
+	// Stability: stable
+	// Examples: '/aws/lambda/my-function', 'opentelemetry-service'
+	// Note: Multiple log groups must be supported for cases like multi-container
+	// applications, where a single application has sidecar containers, and each write
+	// to their own log group.
+	AttributeAWSLogGroupNames = "aws.log.group.names"
+	// The Amazon Resource Name(s) (ARN) of the AWS log group(s).
+	//
+	// Type: string[]
+	// Required: No
+	// Stability: stable
+	// Examples: 'arn:aws:logs:us-west-1:123456789012:log-group:/aws/my/group:*'
+	// Note: See the log group ARN format documentation.
+	AttributeAWSLogGroupARNs = "aws.log.group.arns"
+	// The name(s) of the AWS log stream(s) an application is writing to.
+	//
+	// Type: string[]
+	// Required: No
+	// Stability: stable
+	// Examples: 'logs/main/10838bed-421f-43ef-870a-f43feacbbb5b'
+	AttributeAWSLogStreamNames = "aws.log.stream.names"
+	// The ARN(s) of the AWS log stream(s).
+	//
+	// Type: string[]
+	// Required: No
+	// Stability: stable
+	// Examples: 'arn:aws:logs:us-west-1:123456789012:log-group:/aws/my/group:log-
+	// stream:logs/main/10838bed-421f-43ef-870a-f43feacbbb5b'
+	// Note: See the log stream ARN format documentation. One log group can contain
+	// several log streams, so these ARNs necessarily identify both a log group and a
+	// log stream.
+	AttributeAWSLogStreamARNs = "aws.log.stream.arns"
+)
+
+// A container instance.
+const (
+	// Container name used by container runtime.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'opentelemetry-autoconf'
+	AttributeContainerName = "container.name"
+	// Container ID. Usually a UUID, as for example used to identify Docker
+	// containers. The UUID might be abbreviated.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'a3bf90e006b2'
+	AttributeContainerID = "container.id"
+	// The container runtime managing this container.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'docker', 'containerd', 'rkt'
+	AttributeContainerRuntime = "container.runtime"
+	// Name of the image the container was built on.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'gcr.io/opentelemetry/operator'
+	AttributeContainerImageName = "container.image.name"
+	// Container image tag.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '0.1'
+	AttributeContainerImageTag = "container.image.tag"
+)
+
+// The software deployment.
+const (
+	// Name of the deployment environment (aka deployment tier).
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'staging', 'production'
+	AttributeDeploymentEnvironment = "deployment.environment"
+)
+
+// The device on which the process represented by this resource is running.
+const (
+	// A unique identifier representing the device
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '2ab2916d-a51f-4ac8-80ee-45ac31a28092'
+	// Note: The device identifier MUST only be defined using the values outlined
+	// below. This value is not an advertising identifier and MUST NOT be used as
+	// such. On iOS (Swift or Objective-C), this value MUST be equal to the vendor
+	// identifier. On Android (Java or Kotlin), this value MUST be equal to the
+	// Firebase Installation ID or a globally unique UUID which is persisted across
+	// sessions in your application. More information can be found here on best
+	// practices and exact implementation details. Caution should be taken when
+	// storing personal data or anything which can identify a user. GDPR and data
+	// protection laws may apply, ensure you do your own due diligence.
+	AttributeDeviceID = "device.id"
+	// The model identifier for the device
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'iPhone3,4', 'SM-G920F'
+	// Note: It's recommended this value represents a machine readable version of the
+	// model identifier rather than the market or consumer-friendly name of the
+	// device.
+	AttributeDeviceModelIdentifier = "device.model.identifier"
+	// The marketing name for the device model
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'iPhone 6s Plus', 'Samsung Galaxy S6'
+	// Note: It's recommended this value represents a human readable version of the
+	// device model rather than a machine readable alternative.
+	AttributeDeviceModelName = "device.model.name"
+)
+
+// A serverless instance.
+const (
+	// The name of the single function that this runtime instance executes.
+	//
+	// Type: string
+	// Required: Always
+	// Stability: stable
+	// Examples: 'my-function'
+	// Note: This is the name of the function as configured/deployed on the FaaS
+	// platform and is usually different from the name of the callback function (which
+	// may be stored in the code.namespace/code.function span attributes).
+	AttributeFaaSName = "faas.name"
+	// The unique ID of the single function that this runtime instance executes.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'arn:aws:lambda:us-west-2:123456789012:function:my-function'
+	// Note: Depending on the cloud provider, use:<ul>
+	// <li>AWS Lambda: The function ARN.</li>
+	// </ul>
+	// Take care not to use the &quot;invoked ARN&quot; directly but replace any
+	// alias suffix with the resolved function version, as the same runtime instance
+	// may be invokable with multiple
+	// different aliases.<ul>
+	// <li>GCP: The URI of the resource</li>
+	// <li>Azure: The Fully Qualified Resource ID.</li>
+	// </ul>
+	// On some providers, it may not be possible to determine the full ID at startup,
+	// which is why this field cannot be made required. For example, on AWS the
+	// account ID
+	// part of the ARN is not available without calling another AWS API
+	// which may be deemed too slow for a short-running lambda function.
+	// As an alternative, consider setting faas.id as a span attribute instead.
+	AttributeFaaSID = "faas.id"
+	// The immutable version of the function being executed.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '26', 'pinkfroid-00002'
+	// Note: Depending on the cloud provider and platform, use:<ul>
+	// <li>AWS Lambda: The function version
+	// (an integer represented as a decimal string).</li>
+	// <li>Google Cloud Run: The revision
+	// (i.e., the function name plus the revision suffix).</li>
+	// <li>Google Cloud Functions: The value of the
+	// K_REVISION environment variable.</li>
+	// <li>Azure Functions: Not applicable. Do not set this attribute.</li>
+	// </ul>
+	AttributeFaaSVersion = "faas.version"
+	// The execution environment ID as a string, that will be potentially reused for
+	// other invocations to the same function/function version.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '2021/06/28/[$LATEST]2f399eb14537447da05ab2a2e39309de'
+	// Note: <ul>
+	// <li>AWS Lambda: Use the (full) log stream name.</li>
+	// </ul>
+	AttributeFaaSInstance = "faas.instance"
+	// The amount of memory available to the serverless function in MiB.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 128
+	// Note: It's recommended to set this attribute since e.g. too little memory can
+	// easily stop a Java AWS Lambda function from working correctly. On AWS Lambda,
+	// the environment variable AWS_LAMBDA_FUNCTION_MEMORY_SIZE provides this
+	// information.
+	AttributeFaaSMaxMemory = "faas.max_memory"
+)
+
+// A host is defined as a general computing instance.
+const (
+	// Unique host ID. For Cloud, this must be the instance_id assigned by the cloud
+	// provider.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'opentelemetry-test'
+	AttributeHostID = "host.id"
+	// Name of the host. On Unix systems, it may contain what the hostname command
+	// returns, or the fully qualified hostname, or another name specified by the
+	// user.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'opentelemetry-test'
+	AttributeHostName = "host.name"
+	// Type of host. For Cloud, this must be the machine type.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'n1-standard-1'
+	AttributeHostType = "host.type"
+	// The CPU architecture the host system is running on.
+	//
+	// Type: Enum
+	// Required: No
+	// Stability: stable
+	AttributeHostArch = "host.arch"
+	// Name of the VM image or OS install the host was instantiated from.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'infra-ami-eks-worker-node-7d4ec78312', 'CentOS-8-x86_64-1905'
+	AttributeHostImageName = "host.image.name"
+	// VM image ID. For Cloud, this value is from the provider.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'ami-07b06b442921831e5'
+	AttributeHostImageID = "host.image.id"
+	// The version string of the VM image as defined in Version Attributes.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '0.1'
+	AttributeHostImageVersion = "host.image.version"
+)
+
+const (
+	// AMD64
+	AttributeHostArchAMD64 = "amd64"
+	// ARM32
+	AttributeHostArchARM32 = "arm32"
+	// ARM64
+	AttributeHostArchARM64 = "arm64"
+	// Itanium
+	AttributeHostArchIA64 = "ia64"
+	// 32-bit PowerPC
+	AttributeHostArchPPC32 = "ppc32"
+	// 64-bit PowerPC
+	AttributeHostArchPPC64 = "ppc64"
+	// IBM z/Architecture
+	AttributeHostArchS390x = "s390x"
+	// 32-bit x86
+	AttributeHostArchX86 = "x86"
+)
+
+// A Kubernetes Cluster.
+const (
+	// The name of the cluster.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'opentelemetry-cluster'
+	AttributeK8SClusterName = "k8s.cluster.name"
+)
+
+// A Kubernetes Node object.
+const (
+	// The name of the Node.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'node-1'
+	AttributeK8SNodeName = "k8s.node.name"
+	// The UID of the Node.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '1eb3a0c6-0477-4080-a9cb-0cb7db65c6a2'
+	AttributeK8SNodeUID = "k8s.node.uid"
+)
+
+// A Kubernetes Namespace.
+const (
+	// The name of the namespace that the pod is running in.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'default'
+	AttributeK8SNamespaceName = "k8s.namespace.name"
+)
+
+// A Kubernetes Pod object.
+const (
+	// The UID of the Pod.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '275ecb36-5aa8-4c2a-9c47-d8bb681b9aff'
+	AttributeK8SPodUID = "k8s.pod.uid"
+	// The name of the Pod.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'opentelemetry-pod-autoconf'
+	AttributeK8SPodName = "k8s.pod.name"
+)
+
+// A container in a [PodTemplate](https://kubernetes.io/docs/concepts/workloads/pods/#pod-templates).
+const (
+	// The name of the Container from Pod specification, must be unique within a Pod.
+	// Container runtime usually uses different globally unique name (container.name).
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'redis'
+	AttributeK8SContainerName = "k8s.container.name"
+	// Number of times the container was restarted. This attribute can be used to
+	// identify a particular container (running or stopped) within a container spec.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 0, 2
+	AttributeK8SContainerRestartCount = "k8s.container.restart_count"
+)
+
+// A Kubernetes ReplicaSet object.
+const (
+	// The UID of the ReplicaSet.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '275ecb36-5aa8-4c2a-9c47-d8bb681b9aff'
+	AttributeK8SReplicaSetUID = "k8s.replicaset.uid"
+	// The name of the ReplicaSet.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'opentelemetry'
+	AttributeK8SReplicaSetName = "k8s.replicaset.name"
+)
+
+// A Kubernetes Deployment object.
+const (
+	// The UID of the Deployment.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '275ecb36-5aa8-4c2a-9c47-d8bb681b9aff'
+	AttributeK8SDeploymentUID = "k8s.deployment.uid"
+	// The name of the Deployment.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'opentelemetry'
+	AttributeK8SDeploymentName = "k8s.deployment.name"
+)
+
+// A Kubernetes StatefulSet object.
+const (
+	// The UID of the StatefulSet.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '275ecb36-5aa8-4c2a-9c47-d8bb681b9aff'
+	AttributeK8SStatefulSetUID = "k8s.statefulset.uid"
+	// The name of the StatefulSet.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'opentelemetry'
+	AttributeK8SStatefulSetName = "k8s.statefulset.name"
+)
+
+// A Kubernetes DaemonSet object.
+const (
+	// The UID of the DaemonSet.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '275ecb36-5aa8-4c2a-9c47-d8bb681b9aff'
+	AttributeK8SDaemonSetUID = "k8s.daemonset.uid"
+	// The name of the DaemonSet.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'opentelemetry'
+	AttributeK8SDaemonSetName = "k8s.daemonset.name"
+)
+
+// A Kubernetes Job object.
+const (
+	// The UID of the Job.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '275ecb36-5aa8-4c2a-9c47-d8bb681b9aff'
+	AttributeK8SJobUID = "k8s.job.uid"
+	// The name of the Job.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'opentelemetry'
+	AttributeK8SJobName = "k8s.job.name"
+)
+
+// A Kubernetes CronJob object.
+const (
+	// The UID of the CronJob.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '275ecb36-5aa8-4c2a-9c47-d8bb681b9aff'
+	AttributeK8SCronJobUID = "k8s.cronjob.uid"
+	// The name of the CronJob.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'opentelemetry'
+	AttributeK8SCronJobName = "k8s.cronjob.name"
+)
+
+// The operating system (OS) on which the process represented by this resource is running.
+const (
+	// The operating system type.
+	//
+	// Type: Enum
+	// Required: Always
+	// Stability: stable
+	AttributeOSType = "os.type"
+	// Human readable (not intended to be parsed) OS version information, like e.g.
+	// reported by ver or lsb_release -a commands.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'Microsoft Windows [Version 10.0.18363.778]', 'Ubuntu 18.04.1 LTS'
+	AttributeOSDescription = "os.description"
+	// Human readable operating system name.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'iOS', 'Android', 'Ubuntu'
+	AttributeOSName = "os.name"
+	// The version string of the operating system as defined in Version Attributes.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '14.2.1', '18.04.1'
+	AttributeOSVersion = "os.version"
+)
+
+const (
+	// Microsoft Windows
+	AttributeOSTypeWindows = "windows"
+	// Linux
+	AttributeOSTypeLinux = "linux"
+	// Apple Darwin
+	AttributeOSTypeDarwin = "darwin"
+	// FreeBSD
+	AttributeOSTypeFreeBSD = "freebsd"
+	// NetBSD
+	AttributeOSTypeNetBSD = "netbsd"
+	// OpenBSD
+	AttributeOSTypeOpenBSD = "openbsd"
+	// DragonFly BSD
+	AttributeOSTypeDragonflyBSD = "dragonflybsd"
+	// HP-UX (Hewlett Packard Unix)
+	AttributeOSTypeHPUX = "hpux"
+	// AIX (Advanced Interactive eXecutive)
+	AttributeOSTypeAIX = "aix"
+	// Oracle Solaris
+	AttributeOSTypeSolaris = "solaris"
+	// IBM z/OS
+	AttributeOSTypeZOS = "z_os"
+)
+
+// An operating system process.
+const (
+	// Process identifier (PID).
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 1234
+	AttributeProcessPID = "process.pid"
+	// The name of the process executable. On Linux based systems, can be set to the
+	// Name in proc/[pid]/status. On Windows, can be set to the base name of
+	// GetProcessImageFileNameW.
+	//
+	// Type: string
+	// Required: See below
+	// Stability: stable
+	// Examples: 'otelcol'
+	AttributeProcessExecutableName = "process.executable.name"
+	// The full path to the process executable. On Linux based systems, can be set to
+	// the target of proc/[pid]/exe. On Windows, can be set to the result of
+	// GetProcessImageFileNameW.
+	//
+	// Type: string
+	// Required: See below
+	// Stability: stable
+	// Examples: '/usr/bin/cmd/otelcol'
+	AttributeProcessExecutablePath = "process.executable.path"
+	// The command used to launch the process (i.e. the command name). On Linux based
+	// systems, can be set to the zeroth string in proc/[pid]/cmdline. On Windows, can
+	// be set to the first parameter extracted from GetCommandLineW.
+	//
+	// Type: string
+	// Required: See below
+	// Stability: stable
+	// Examples: 'cmd/otelcol'
+	AttributeProcessCommand = "process.command"
+	// The full command used to launch the process as a single string representing the
+	// full command. On Windows, can be set to the result of GetCommandLineW. Do not
+	// set this if you have to assemble it just for monitoring; use
+	// process.command_args instead.
+	//
+	// Type: string
+	// Required: See below
+	// Stability: stable
+	// Examples: 'C:\\cmd\\otecol --config="my directory\\config.yaml"'
+	AttributeProcessCommandLine = "process.command_line"
+	// All the command arguments (including the command/executable itself) as received
+	// by the process. On Linux-based systems (and some other Unixoid systems
+	// supporting procfs), can be set according to the list of null-delimited strings
+	// extracted from proc/[pid]/cmdline. For libc-based executables, this would be
+	// the full argv vector passed to main.
+	//
+	// Type: string[]
+	// Required: See below
+	// Stability: stable
+	// Examples: 'cmd/otecol', '--config=config.yaml'
+	AttributeProcessCommandArgs = "process.command_args"
+	// The username of the user that owns the process.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'root'
+	AttributeProcessOwner = "process.owner"
+)
+
+// The single (language) runtime instance which is monitored.
+const (
+	// The name of the runtime of this process. For compiled native binaries, this
+	// SHOULD be the name of the compiler.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'OpenJDK Runtime Environment'
+	AttributeProcessRuntimeName = "process.runtime.name"
+	// The version of the runtime of this process, as returned by the runtime without
+	// modification.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '14.0.2'
+	AttributeProcessRuntimeVersion = "process.runtime.version"
+	// An additional description about the runtime of the process, for example a
+	// specific vendor customization of the runtime environment.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'Eclipse OpenJ9 Eclipse OpenJ9 VM openj9-0.21.0'
+	AttributeProcessRuntimeDescription = "process.runtime.description"
+)
+
+// A service instance.
+const (
+	// Logical name of the service.
+	//
+	// Type: string
+	// Required: Always
+	// Stability: stable
+	// Examples: 'shoppingcart'
+	// Note: MUST be the same for all instances of horizontally scaled services. If
+	// the value was not specified, SDKs MUST fallback to unknown_service:
+	// concatenated with process.executable.name, e.g. unknown_service:bash. If
+	// process.executable.name is not available, the value MUST be set to
+	// unknown_service.
+	AttributeServiceName = "service.name"
+	// A namespace for service.name.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'Shop'
+	// Note: A string value having a meaning that helps to distinguish a group of
+	// services, for example the team name that owns a group of services. service.name
+	// is expected to be unique within the same namespace. If service.namespace is not
+	// specified in the Resource then service.name is expected to be unique for all
+	// services that have no explicit namespace defined (so the empty/unspecified
+	// namespace is simply one more valid namespace). Zero-length namespace string is
+	// assumed equal to unspecified namespace.
+	AttributeServiceNamespace = "service.namespace"
+	// The string ID of the service instance.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '627cc493-f310-47de-96bd-71410b7dec09'
+	// Note: MUST be unique for each instance of the same
+	// service.namespace,service.name pair (in other words
+	// service.namespace,service.name,service.instance.id triplet MUST be globally
+	// unique). The ID helps to distinguish instances of the same service that exist
+	// at the same time (e.g. instances of a horizontally scaled service). It is
+	// preferable for the ID to be persistent and stay the same for the lifetime of
+	// the service instance, however it is acceptable that the ID is ephemeral and
+	// changes during important lifetime events for the service (e.g. service
+	// restarts). If the service has no inherent unique ID that can be used as the
+	// value of this attribute it is recommended to generate a random Version 1 or
+	// Version 4 RFC 4122 UUID (services aiming for reproducible UUIDs may also use
+	// Version 5, see RFC 4122 for more recommendations).
+	AttributeServiceInstanceID = "service.instance.id"
+	// The version string of the service API or implementation.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '2.0.0'
+	AttributeServiceVersion = "service.version"
+)
+
+// The telemetry SDK used to capture data recorded by the instrumentation libraries.
+const (
+	// The name of the telemetry SDK as defined above.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'opentelemetry'
+	AttributeTelemetrySDKName = "telemetry.sdk.name"
+	// The language of the telemetry SDK.
+	//
+	// Type: Enum
+	// Required: No
+	// Stability: stable
+	AttributeTelemetrySDKLanguage = "telemetry.sdk.language"
+	// The version string of the telemetry SDK.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '1.2.3'
+	AttributeTelemetrySDKVersion = "telemetry.sdk.version"
+	// The version string of the auto instrumentation agent, if used.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '1.2.3'
+	AttributeTelemetryAutoVersion = "telemetry.auto.version"
+)
+
+const (
+	// cpp
+	AttributeTelemetrySDKLanguageCPP = "cpp"
+	// dotnet
+	AttributeTelemetrySDKLanguageDotnet = "dotnet"
+	// erlang
+	AttributeTelemetrySDKLanguageErlang = "erlang"
+	// go
+	AttributeTelemetrySDKLanguageGo = "go"
+	// java
+	AttributeTelemetrySDKLanguageJava = "java"
+	// nodejs
+	AttributeTelemetrySDKLanguageNodejs = "nodejs"
+	// php
+	AttributeTelemetrySDKLanguagePHP = "php"
+	// python
+	AttributeTelemetrySDKLanguagePython = "python"
+	// ruby
+	AttributeTelemetrySDKLanguageRuby = "ruby"
+	// webjs
+	AttributeTelemetrySDKLanguageWebjs = "webjs"
+	// swift
+	AttributeTelemetrySDKLanguageSwift = "swift"
+)
+
+// Resource describing the packaged software running the application code. Web engines are typically executed using process.runtime.
+const (
+	// The name of the web engine.
+	//
+	// Type: string
+	// Required: Always
+	// Stability: stable
+	// Examples: 'WildFly'
+	AttributeWebEngineName = "webengine.name"
+	// The version of the web engine.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '21.0.0'
+	AttributeWebEngineVersion = "webengine.version"
+	// Additional description of the web engine (e.g. detailed version and edition
+	// information).
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'WildFly Full 21.0.0.Final (WildFly Core 13.0.1.Final) - 2.2.2.Final'
+	AttributeWebEngineDescription = "webengine.description"
+)
+
+func GetResourceSemanticConventionAttributeNames() []string {
+	return []string{
+		AttributeCloudProvider,
+		AttributeCloudAccountID,
+		AttributeCloudRegion,
+		AttributeCloudAvailabilityZone,
+		AttributeCloudPlatform,
+		AttributeAWSECSContainerARN,
+		AttributeAWSECSClusterARN,
+		AttributeAWSECSLaunchtype,
+		AttributeAWSECSTaskARN,
+		AttributeAWSECSTaskFamily,
+		AttributeAWSECSTaskRevision,
+		AttributeAWSEKSClusterARN,
+		AttributeAWSLogGroupNames,
+		AttributeAWSLogGroupARNs,
+		AttributeAWSLogStreamNames,
+		AttributeAWSLogStreamARNs,
+		AttributeContainerName,
+		AttributeContainerID,
+		AttributeContainerRuntime,
+		AttributeContainerImageName,
+		AttributeContainerImageTag,
+		AttributeDeploymentEnvironment,
+		AttributeDeviceID,
+		AttributeDeviceModelIdentifier,
+		AttributeDeviceModelName,
+		AttributeFaaSName,
+		AttributeFaaSID,
+		AttributeFaaSVersion,
+		AttributeFaaSInstance,
+		AttributeFaaSMaxMemory,
+		AttributeHostID,
+		AttributeHostName,
+		AttributeHostType,
+		AttributeHostArch,
+		AttributeHostImageName,
+		AttributeHostImageID,
+		AttributeHostImageVersion,
+		AttributeK8SClusterName,
+		AttributeK8SNodeName,
+		AttributeK8SNodeUID,
+		AttributeK8SNamespaceName,
+		AttributeK8SPodUID,
+		AttributeK8SPodName,
+		AttributeK8SContainerName,
+		AttributeK8SContainerRestartCount,
+		AttributeK8SReplicaSetUID,
+		AttributeK8SReplicaSetName,
+		AttributeK8SDeploymentUID,
+		AttributeK8SDeploymentName,
+		AttributeK8SStatefulSetUID,
+		AttributeK8SStatefulSetName,
+		AttributeK8SDaemonSetUID,
+		AttributeK8SDaemonSetName,
+		AttributeK8SJobUID,
+		AttributeK8SJobName,
+		AttributeK8SCronJobUID,
+		AttributeK8SCronJobName,
+		AttributeOSType,
+		AttributeOSDescription,
+		AttributeOSName,
+		AttributeOSVersion,
+		AttributeProcessPID,
+		AttributeProcessExecutableName,
+		AttributeProcessExecutablePath,
+		AttributeProcessCommand,
+		AttributeProcessCommandLine,
+		AttributeProcessCommandArgs,
+		AttributeProcessOwner,
+		AttributeProcessRuntimeName,
+		AttributeProcessRuntimeVersion,
+		AttributeProcessRuntimeDescription,
+		AttributeServiceName,
+		AttributeServiceNamespace,
+		AttributeServiceInstanceID,
+		AttributeServiceVersion,
+		AttributeTelemetrySDKName,
+		AttributeTelemetrySDKLanguage,
+		AttributeTelemetrySDKVersion,
+		AttributeTelemetryAutoVersion,
+		AttributeWebEngineName,
+		AttributeWebEngineVersion,
+		AttributeWebEngineDescription,
+	}
+}

--- a/model/semconv/v1.8.0/trace.go
+++ b/model/semconv/v1.8.0/trace.go
@@ -1,0 +1,1727 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Code generated from semantic convention specification. DO NOT EDIT.
+
+package semconv
+
+// Span attributes used by AWS Lambda (in addition to general `faas` attributes).
+const (
+	// The full invoked ARN as provided on the Context passed to the function (Lambda-
+	// Runtime-Invoked-Function-ARN header on the /runtime/invocation/next
+	// applicable).
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'arn:aws:lambda:us-east-1:123456:function:myfunction:myalias'
+	// Note: This may be different from faas.id if an alias is involved.
+	AttributeAWSLambdaInvokedARN = "aws.lambda.invoked_arn"
+)
+
+// This document defines the attributes used to perform database client calls.
+const (
+	// An identifier for the database management system (DBMS) product being used. See
+	// below for a list of well-known identifiers.
+	//
+	// Type: Enum
+	// Required: Always
+	// Stability: stable
+	AttributeDBSystem = "db.system"
+	// The connection string used to connect to the database. It is recommended to
+	// remove embedded credentials.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'Server=(localdb)\\v11.0;Integrated Security=true;'
+	AttributeDBConnectionString = "db.connection_string"
+	// Username for accessing the database.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'readonly_user', 'reporting_user'
+	AttributeDBUser = "db.user"
+	// The fully-qualified class name of the Java Database Connectivity (JDBC) driver
+	// used to connect.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'org.postgresql.Driver',
+	// 'com.microsoft.sqlserver.jdbc.SQLServerDriver'
+	AttributeDBJDBCDriverClassname = "db.jdbc.driver_classname"
+	// This attribute is used to report the name of the database being accessed. For
+	// commands that switch the database, this should be set to the target database
+	// (even if the command fails).
+	//
+	// Type: string
+	// Required: Required, if applicable.
+	// Stability: stable
+	// Examples: 'customers', 'main'
+	// Note: In some SQL databases, the database name to be used is called
+	// &quot;schema name&quot;. In case there are multiple layers that could be
+	// considered for database name (e.g. Oracle instance name and schema name), the
+	// database name to be used is the more specific layer (e.g. Oracle schema name).
+	AttributeDBName = "db.name"
+	// The database statement being executed.
+	//
+	// Type: string
+	// Required: Required if applicable and not explicitly disabled via
+	// instrumentation configuration.
+	// Stability: stable
+	// Examples: 'SELECT * FROM wuser_table', 'SET mykey "WuValue"'
+	// Note: The value may be sanitized to exclude sensitive information.
+	AttributeDBStatement = "db.statement"
+	// The name of the operation being executed, e.g. the MongoDB command name such as
+	// findAndModify, or the SQL keyword.
+	//
+	// Type: string
+	// Required: Required, if `db.statement` is not applicable.
+	// Stability: stable
+	// Examples: 'findAndModify', 'HMSET', 'SELECT'
+	// Note: When setting this to an SQL keyword, it is not recommended to attempt any
+	// client-side parsing of db.statement just to get this property, but it should be
+	// set if the operation name is provided by the library being instrumented. If the
+	// SQL statement has an ambiguous operation, or performs more than one operation,
+	// this value may be omitted.
+	AttributeDBOperation = "db.operation"
+)
+
+const (
+	// Some other SQL database. Fallback only. See notes
+	AttributeDBSystemOtherSQL = "other_sql"
+	// Microsoft SQL Server
+	AttributeDBSystemMSSQL = "mssql"
+	// MySQL
+	AttributeDBSystemMySQL = "mysql"
+	// Oracle Database
+	AttributeDBSystemOracle = "oracle"
+	// IBM DB2
+	AttributeDBSystemDB2 = "db2"
+	// PostgreSQL
+	AttributeDBSystemPostgreSQL = "postgresql"
+	// Amazon Redshift
+	AttributeDBSystemRedshift = "redshift"
+	// Apache Hive
+	AttributeDBSystemHive = "hive"
+	// Cloudscape
+	AttributeDBSystemCloudscape = "cloudscape"
+	// HyperSQL DataBase
+	AttributeDBSystemHSQLDB = "hsqldb"
+	// Progress Database
+	AttributeDBSystemProgress = "progress"
+	// SAP MaxDB
+	AttributeDBSystemMaxDB = "maxdb"
+	// SAP HANA
+	AttributeDBSystemHanaDB = "hanadb"
+	// Ingres
+	AttributeDBSystemIngres = "ingres"
+	// FirstSQL
+	AttributeDBSystemFirstSQL = "firstsql"
+	// EnterpriseDB
+	AttributeDBSystemEDB = "edb"
+	// InterSystems Caché
+	AttributeDBSystemCache = "cache"
+	// Adabas (Adaptable Database System)
+	AttributeDBSystemAdabas = "adabas"
+	// Firebird
+	AttributeDBSystemFirebird = "firebird"
+	// Apache Derby
+	AttributeDBSystemDerby = "derby"
+	// FileMaker
+	AttributeDBSystemFilemaker = "filemaker"
+	// Informix
+	AttributeDBSystemInformix = "informix"
+	// InstantDB
+	AttributeDBSystemInstantDB = "instantdb"
+	// InterBase
+	AttributeDBSystemInterbase = "interbase"
+	// MariaDB
+	AttributeDBSystemMariaDB = "mariadb"
+	// Netezza
+	AttributeDBSystemNetezza = "netezza"
+	// Pervasive PSQL
+	AttributeDBSystemPervasive = "pervasive"
+	// PointBase
+	AttributeDBSystemPointbase = "pointbase"
+	// SQLite
+	AttributeDBSystemSqlite = "sqlite"
+	// Sybase
+	AttributeDBSystemSybase = "sybase"
+	// Teradata
+	AttributeDBSystemTeradata = "teradata"
+	// Vertica
+	AttributeDBSystemVertica = "vertica"
+	// H2
+	AttributeDBSystemH2 = "h2"
+	// ColdFusion IMQ
+	AttributeDBSystemColdfusion = "coldfusion"
+	// Apache Cassandra
+	AttributeDBSystemCassandra = "cassandra"
+	// Apache HBase
+	AttributeDBSystemHBase = "hbase"
+	// MongoDB
+	AttributeDBSystemMongoDB = "mongodb"
+	// Redis
+	AttributeDBSystemRedis = "redis"
+	// Couchbase
+	AttributeDBSystemCouchbase = "couchbase"
+	// CouchDB
+	AttributeDBSystemCouchDB = "couchdb"
+	// Microsoft Azure Cosmos DB
+	AttributeDBSystemCosmosDB = "cosmosdb"
+	// Amazon DynamoDB
+	AttributeDBSystemDynamoDB = "dynamodb"
+	// Neo4j
+	AttributeDBSystemNeo4j = "neo4j"
+	// Apache Geode
+	AttributeDBSystemGeode = "geode"
+	// Elasticsearch
+	AttributeDBSystemElasticsearch = "elasticsearch"
+	// Memcached
+	AttributeDBSystemMemcached = "memcached"
+	// CockroachDB
+	AttributeDBSystemCockroachdb = "cockroachdb"
+)
+
+// Connection-level attributes for Microsoft SQL Server
+const (
+	// The Microsoft SQL Server instance name connecting to. This name is used to
+	// determine the port of a named instance.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'MSSQLSERVER'
+	// Note: If setting a db.mssql.instance_name, net.peer.port is no longer required
+	// (but still recommended if non-standard).
+	AttributeDBMSSQLInstanceName = "db.mssql.instance_name"
+)
+
+// Call-level attributes for Cassandra
+const (
+	// The fetch size used for paging, i.e. how many rows will be returned at once.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 5000
+	AttributeDBCassandraPageSize = "db.cassandra.page_size"
+	// The consistency level of the query. Based on consistency values from CQL.
+	//
+	// Type: Enum
+	// Required: No
+	// Stability: stable
+	AttributeDBCassandraConsistencyLevel = "db.cassandra.consistency_level"
+	// The name of the primary table that the operation is acting upon, including the
+	// keyspace name (if applicable).
+	//
+	// Type: string
+	// Required: Recommended if available.
+	// Stability: stable
+	// Examples: 'mytable'
+	// Note: This mirrors the db.sql.table attribute but references cassandra rather
+	// than sql. It is not recommended to attempt any client-side parsing of
+	// db.statement just to get this property, but it should be set if it is provided
+	// by the library being instrumented. If the operation is acting upon an anonymous
+	// table, or more than one table, this value MUST NOT be set.
+	AttributeDBCassandraTable = "db.cassandra.table"
+	// Whether or not the query is idempotent.
+	//
+	// Type: boolean
+	// Required: No
+	// Stability: stable
+	AttributeDBCassandraIdempotence = "db.cassandra.idempotence"
+	// The number of times a query was speculatively executed. Not set or 0 if the
+	// query was not executed speculatively.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 0, 2
+	AttributeDBCassandraSpeculativeExecutionCount = "db.cassandra.speculative_execution_count"
+	// The ID of the coordinating node for a query.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'be13faa2-8574-4d71-926d-27f16cf8a7af'
+	AttributeDBCassandraCoordinatorID = "db.cassandra.coordinator.id"
+	// The data center of the coordinating node for a query.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'us-west-2'
+	AttributeDBCassandraCoordinatorDC = "db.cassandra.coordinator.dc"
+)
+
+const (
+	// all
+	AttributeDBCassandraConsistencyLevelAll = "all"
+	// each_quorum
+	AttributeDBCassandraConsistencyLevelEachQuorum = "each_quorum"
+	// quorum
+	AttributeDBCassandraConsistencyLevelQuorum = "quorum"
+	// local_quorum
+	AttributeDBCassandraConsistencyLevelLocalQuorum = "local_quorum"
+	// one
+	AttributeDBCassandraConsistencyLevelOne = "one"
+	// two
+	AttributeDBCassandraConsistencyLevelTwo = "two"
+	// three
+	AttributeDBCassandraConsistencyLevelThree = "three"
+	// local_one
+	AttributeDBCassandraConsistencyLevelLocalOne = "local_one"
+	// any
+	AttributeDBCassandraConsistencyLevelAny = "any"
+	// serial
+	AttributeDBCassandraConsistencyLevelSerial = "serial"
+	// local_serial
+	AttributeDBCassandraConsistencyLevelLocalSerial = "local_serial"
+)
+
+// Call-level attributes for Redis
+const (
+	// The index of the database being accessed as used in the SELECT command,
+	// provided as an integer. To be used instead of the generic db.name attribute.
+	//
+	// Type: int
+	// Required: Required, if other than the default database (`0`).
+	// Stability: stable
+	// Examples: 0, 1, 15
+	AttributeDBRedisDBIndex = "db.redis.database_index"
+)
+
+// Call-level attributes for MongoDB
+const (
+	// The collection being accessed within the database stated in db.name.
+	//
+	// Type: string
+	// Required: Always
+	// Stability: stable
+	// Examples: 'customers', 'products'
+	AttributeDBMongoDBCollection = "db.mongodb.collection"
+)
+
+// Call-level attributes for SQL databases
+const (
+	// The name of the primary table that the operation is acting upon, including the
+	// database name (if applicable).
+	//
+	// Type: string
+	// Required: Recommended if available.
+	// Stability: stable
+	// Examples: 'public.users', 'customers'
+	// Note: It is not recommended to attempt any client-side parsing of db.statement
+	// just to get this property, but it should be set if it is provided by the
+	// library being instrumented. If the operation is acting upon an anonymous table,
+	// or more than one table, this value MUST NOT be set.
+	AttributeDBSQLTable = "db.sql.table"
+)
+
+// This document defines the attributes used to report a single exception associated with a span.
+const (
+	// The type of the exception (its fully-qualified class name, if applicable). The
+	// dynamic type of the exception should be preferred over the static type in
+	// languages that support it.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'java.net.ConnectException', 'OSError'
+	AttributeExceptionType = "exception.type"
+	// The exception message.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'Division by zero', "Can't convert 'int' object to str implicitly"
+	AttributeExceptionMessage = "exception.message"
+	// A stacktrace as a string in the natural representation for the language
+	// runtime. The representation is to be determined and documented by each language
+	// SIG.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'Exception in thread "main" java.lang.RuntimeException: Test
+	// exception\\n at '
+	//  'com.example.GenerateTrace.methodB(GenerateTrace.java:13)\\n at '
+	//  'com.example.GenerateTrace.methodA(GenerateTrace.java:9)\\n at '
+	//  'com.example.GenerateTrace.main(GenerateTrace.java:5)'
+	AttributeExceptionStacktrace = "exception.stacktrace"
+	// SHOULD be set to true if the exception event is recorded at a point where it is
+	// known that the exception is escaping the scope of the span.
+	//
+	// Type: boolean
+	// Required: No
+	// Stability: stable
+	// Note: An exception is considered to have escaped (or left) the scope of a span,
+	// if that span is ended while the exception is still logically &quot;in
+	// flight&quot;.
+	// This may be actually &quot;in flight&quot; in some languages (e.g. if the
+	// exception
+	// is passed to a Context manager's __exit__ method in Python) but will
+	// usually be caught at the point of recording the exception in most languages.It
+	// is usually not possible to determine at the point where an exception is thrown
+	// whether it will escape the scope of a span.
+	// However, it is trivial to know that an exception
+	// will escape, if one checks for an active exception just before ending the span,
+	// as done in the example above.It follows that an exception may still escape the
+	// scope of the span
+	// even if the exception.escaped attribute was not set or set to false,
+	// since the event might have been recorded at a time where it was not
+	// clear whether the exception will escape.
+	AttributeExceptionEscaped = "exception.escaped"
+)
+
+// This semantic convention describes an instance of a function that runs without provisioning or managing of servers (also known as serverless functions or Function as a Service (FaaS)) with spans.
+const (
+	// Type of the trigger which caused this function execution.
+	//
+	// Type: Enum
+	// Required: No
+	// Stability: stable
+	// Note: For the server/consumer span on the incoming side,
+	// faas.trigger MUST be set.Clients invoking FaaS instances usually cannot set
+	// faas.trigger,
+	// since they would typically need to look in the payload to determine
+	// the event type. If clients set it, it should be the same as the
+	// trigger that corresponding incoming would have (i.e., this has
+	// nothing to do with the underlying transport used to make the API
+	// call to invoke the lambda, which is often HTTP).
+	AttributeFaaSTrigger = "faas.trigger"
+	// The execution ID of the current function execution.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'af9d5aa4-a685-4c5f-a22b-444f80b3cc28'
+	AttributeFaaSExecution = "faas.execution"
+)
+
+const (
+	// A response to some data source operation such as a database or filesystem read/write
+	AttributeFaaSTriggerDatasource = "datasource"
+	// To provide an answer to an inbound HTTP request
+	AttributeFaaSTriggerHTTP = "http"
+	// A function is set to be executed when messages are sent to a messaging system
+	AttributeFaaSTriggerPubsub = "pubsub"
+	// A function is scheduled to be executed regularly
+	AttributeFaaSTriggerTimer = "timer"
+	// If none of the others apply
+	AttributeFaaSTriggerOther = "other"
+)
+
+// Semantic Convention for FaaS triggered as a response to some data source operation such as a database or filesystem read/write.
+const (
+	// The name of the source on which the triggering operation was performed. For
+	// example, in Cloud Storage or S3 corresponds to the bucket name, and in Cosmos
+	// DB to the database name.
+	//
+	// Type: string
+	// Required: Always
+	// Stability: stable
+	// Examples: 'myBucketName', 'myDBName'
+	AttributeFaaSDocumentCollection = "faas.document.collection"
+	// Describes the type of the operation that was performed on the data.
+	//
+	// Type: Enum
+	// Required: Always
+	// Stability: stable
+	AttributeFaaSDocumentOperation = "faas.document.operation"
+	// A string containing the time when the data was accessed in the ISO 8601 format
+	// expressed in UTC.
+	//
+	// Type: string
+	// Required: Always
+	// Stability: stable
+	// Examples: '2020-01-23T13:47:06Z'
+	AttributeFaaSDocumentTime = "faas.document.time"
+	// The document name/table subjected to the operation. For example, in Cloud
+	// Storage or S3 is the name of the file, and in Cosmos DB the table name.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'myFile.txt', 'myTableName'
+	AttributeFaaSDocumentName = "faas.document.name"
+)
+
+const (
+	// When a new object is created
+	AttributeFaaSDocumentOperationInsert = "insert"
+	// When an object is modified
+	AttributeFaaSDocumentOperationEdit = "edit"
+	// When an object is deleted
+	AttributeFaaSDocumentOperationDelete = "delete"
+)
+
+// Semantic Convention for FaaS scheduled to be executed regularly.
+const (
+	// A string containing the function invocation time in the ISO 8601 format
+	// expressed in UTC.
+	//
+	// Type: string
+	// Required: Always
+	// Stability: stable
+	// Examples: '2020-01-23T13:47:06Z'
+	AttributeFaaSTime = "faas.time"
+	// A string containing the schedule period as Cron Expression.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '0/5 * * * ? *'
+	AttributeFaaSCron = "faas.cron"
+)
+
+// Contains additional attributes for incoming FaaS spans.
+const (
+	// A boolean that is true if the serverless function is executed for the first
+	// time (aka cold-start).
+	//
+	// Type: boolean
+	// Required: No
+	// Stability: stable
+	AttributeFaaSColdstart = "faas.coldstart"
+)
+
+// Contains additional attributes for outgoing FaaS spans.
+const (
+	// The name of the invoked function.
+	//
+	// Type: string
+	// Required: Always
+	// Stability: stable
+	// Examples: 'my-function'
+	// Note: SHOULD be equal to the faas.name resource attribute of the invoked
+	// function.
+	AttributeFaaSInvokedName = "faas.invoked_name"
+	// The cloud provider of the invoked function.
+	//
+	// Type: Enum
+	// Required: Always
+	// Stability: stable
+	// Note: SHOULD be equal to the cloud.provider resource attribute of the invoked
+	// function.
+	AttributeFaaSInvokedProvider = "faas.invoked_provider"
+	// The cloud region of the invoked function.
+	//
+	// Type: string
+	// Required: For some cloud providers, like AWS or GCP, the region in which a
+	// function is hosted is essential to uniquely identify the function and also part
+	// of its endpoint. Since it's part of the endpoint being called, the region is
+	// always known to clients. In these cases, `faas.invoked_region` MUST be set
+	// accordingly. If the region is unknown to the client or not required for
+	// identifying the invoked function, setting `faas.invoked_region` is optional.
+	// Stability: stable
+	// Examples: 'eu-central-1'
+	// Note: SHOULD be equal to the cloud.region resource attribute of the invoked
+	// function.
+	AttributeFaaSInvokedRegion = "faas.invoked_region"
+)
+
+const (
+	// Alibaba Cloud
+	AttributeFaaSInvokedProviderAlibabaCloud = "alibaba_cloud"
+	// Amazon Web Services
+	AttributeFaaSInvokedProviderAWS = "aws"
+	// Microsoft Azure
+	AttributeFaaSInvokedProviderAzure = "azure"
+	// Google Cloud Platform
+	AttributeFaaSInvokedProviderGCP = "gcp"
+	// Tencent Cloud
+	AttributeFaaSInvokedProviderTencentCloud = "tencent_cloud"
+)
+
+// These attributes may be used for any network related operation.
+const (
+	// Transport protocol used. See note below.
+	//
+	// Type: Enum
+	// Required: No
+	// Stability: stable
+	AttributeNetTransport = "net.transport"
+	// Remote address of the peer (dotted decimal for IPv4 or RFC5952 for IPv6)
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '127.0.0.1'
+	AttributeNetPeerIP = "net.peer.ip"
+	// Remote port number.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 80, 8080, 443
+	AttributeNetPeerPort = "net.peer.port"
+	// Remote hostname or similar, see note below.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'example.com'
+	AttributeNetPeerName = "net.peer.name"
+	// Like net.peer.ip but for the host IP. Useful in case of a multi-IP host.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '192.168.0.1'
+	AttributeNetHostIP = "net.host.ip"
+	// Like net.peer.port but for the host port.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 35555
+	AttributeNetHostPort = "net.host.port"
+	// Local hostname or similar, see note below.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'localhost'
+	AttributeNetHostName = "net.host.name"
+	// The internet connection type currently being used by the host.
+	//
+	// Type: Enum
+	// Required: No
+	// Stability: stable
+	// Examples: 'wifi'
+	AttributeNetHostConnectionType = "net.host.connection.type"
+	// This describes more details regarding the connection.type. It may be the type
+	// of cell technology connection, but it could be used for describing details
+	// about a wifi connection.
+	//
+	// Type: Enum
+	// Required: No
+	// Stability: stable
+	// Examples: 'LTE'
+	AttributeNetHostConnectionSubtype = "net.host.connection.subtype"
+	// The name of the mobile carrier.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'sprint'
+	AttributeNetHostCarrierName = "net.host.carrier.name"
+	// The mobile carrier country code.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '310'
+	AttributeNetHostCarrierMcc = "net.host.carrier.mcc"
+	// The mobile carrier network code.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '001'
+	AttributeNetHostCarrierMnc = "net.host.carrier.mnc"
+	// The ISO 3166-1 alpha-2 2-character country code associated with the mobile
+	// carrier network.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'DE'
+	AttributeNetHostCarrierIcc = "net.host.carrier.icc"
+)
+
+const (
+	// ip_tcp
+	AttributeNetTransportTCP = "ip_tcp"
+	// ip_udp
+	AttributeNetTransportUDP = "ip_udp"
+	// Another IP-based protocol
+	AttributeNetTransportIP = "ip"
+	// Unix Domain socket. See below
+	AttributeNetTransportUnix = "unix"
+	// Named or anonymous pipe. See note below
+	AttributeNetTransportPipe = "pipe"
+	// In-process communication
+	AttributeNetTransportInProc = "inproc"
+	// Something else (non IP-based)
+	AttributeNetTransportOther = "other"
+)
+
+const (
+	// wifi
+	AttributeNetHostConnectionTypeWifi = "wifi"
+	// wired
+	AttributeNetHostConnectionTypeWired = "wired"
+	// cell
+	AttributeNetHostConnectionTypeCell = "cell"
+	// unavailable
+	AttributeNetHostConnectionTypeUnavailable = "unavailable"
+	// unknown
+	AttributeNetHostConnectionTypeUnknown = "unknown"
+)
+
+const (
+	// GPRS
+	AttributeNetHostConnectionSubtypeGprs = "gprs"
+	// EDGE
+	AttributeNetHostConnectionSubtypeEdge = "edge"
+	// UMTS
+	AttributeNetHostConnectionSubtypeUmts = "umts"
+	// CDMA
+	AttributeNetHostConnectionSubtypeCdma = "cdma"
+	// EVDO Rel. 0
+	AttributeNetHostConnectionSubtypeEvdo0 = "evdo_0"
+	// EVDO Rev. A
+	AttributeNetHostConnectionSubtypeEvdoA = "evdo_a"
+	// CDMA2000 1XRTT
+	AttributeNetHostConnectionSubtypeCdma20001xrtt = "cdma2000_1xrtt"
+	// HSDPA
+	AttributeNetHostConnectionSubtypeHsdpa = "hsdpa"
+	// HSUPA
+	AttributeNetHostConnectionSubtypeHsupa = "hsupa"
+	// HSPA
+	AttributeNetHostConnectionSubtypeHspa = "hspa"
+	// IDEN
+	AttributeNetHostConnectionSubtypeIden = "iden"
+	// EVDO Rev. B
+	AttributeNetHostConnectionSubtypeEvdoB = "evdo_b"
+	// LTE
+	AttributeNetHostConnectionSubtypeLte = "lte"
+	// EHRPD
+	AttributeNetHostConnectionSubtypeEhrpd = "ehrpd"
+	// HSPAP
+	AttributeNetHostConnectionSubtypeHspap = "hspap"
+	// GSM
+	AttributeNetHostConnectionSubtypeGsm = "gsm"
+	// TD-SCDMA
+	AttributeNetHostConnectionSubtypeTdScdma = "td_scdma"
+	// IWLAN
+	AttributeNetHostConnectionSubtypeIwlan = "iwlan"
+	// 5G NR (New Radio)
+	AttributeNetHostConnectionSubtypeNr = "nr"
+	// 5G NRNSA (New Radio Non-Standalone)
+	AttributeNetHostConnectionSubtypeNrnsa = "nrnsa"
+	// LTE CA
+	AttributeNetHostConnectionSubtypeLteCa = "lte_ca"
+)
+
+// Operations that access some remote service.
+const (
+	// The service.name of the remote service. SHOULD be equal to the actual
+	// service.name resource attribute of the remote service if any.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'AuthTokenCache'
+	AttributePeerService = "peer.service"
+)
+
+// These attributes may be used for any operation with an authenticated and/or authorized enduser.
+const (
+	// Username or client_id extracted from the access token or Authorization header
+	// in the inbound request from outside the system.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'username'
+	AttributeEnduserID = "enduser.id"
+	// Actual/assumed role the client is making the request under extracted from token
+	// or application security context.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'admin'
+	AttributeEnduserRole = "enduser.role"
+	// Scopes or granted authorities the client currently possesses extracted from
+	// token or application security context. The value would come from the scope
+	// associated with an OAuth 2.0 Access Token or an attribute value in a SAML 2.0
+	// Assertion.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'read:message, write:files'
+	AttributeEnduserScope = "enduser.scope"
+)
+
+// These attributes may be used for any operation to store information about a thread that started a span.
+const (
+	// Current &quot;managed&quot; thread ID (as opposed to OS thread ID).
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 42
+	AttributeThreadID = "thread.id"
+	// Current thread name.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'main'
+	AttributeThreadName = "thread.name"
+)
+
+// These attributes allow to report this unit of code and therefore to provide more context about the span.
+const (
+	// The method or function name, or equivalent (usually rightmost part of the code
+	// unit's name).
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'serveRequest'
+	AttributeCodeFunction = "code.function"
+	// The &quot;namespace&quot; within which code.function is defined. Usually the
+	// qualified class or module name, such that code.namespace + some separator +
+	// code.function form a unique identifier for the code unit.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'com.example.MyHTTPService'
+	AttributeCodeNamespace = "code.namespace"
+	// The source code file name that identifies the code unit as uniquely as possible
+	// (preferably an absolute file path).
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '/usr/local/MyApplication/content_root/app/index.php'
+	AttributeCodeFilepath = "code.filepath"
+	// The line number in code.filepath best representing the operation. It SHOULD
+	// point within the code unit named in code.function.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 42
+	AttributeCodeLineNumber = "code.lineno"
+)
+
+// This document defines semantic conventions for HTTP client and server Spans.
+const (
+	// HTTP request method.
+	//
+	// Type: string
+	// Required: Always
+	// Stability: stable
+	// Examples: 'GET', 'POST', 'HEAD'
+	AttributeHTTPMethod = "http.method"
+	// Full HTTP request URL in the form scheme://host[:port]/path?query[#fragment].
+	// Usually the fragment is not transmitted over HTTP, but if it is known, it
+	// should be included nevertheless.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'https://www.foo.bar/search?q=OpenTelemetry#SemConv'
+	// Note: http.url MUST NOT contain credentials passed via URL in form of
+	// https://username:password@www.example.com/. In such case the attribute's value
+	// should be https://www.example.com/.
+	AttributeHTTPURL = "http.url"
+	// The full request target as passed in a HTTP request line or equivalent.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '/path/12314/?q=ddds#123'
+	AttributeHTTPTarget = "http.target"
+	// The value of the HTTP host header. An empty Host header should also be
+	// reported, see note.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'www.example.org'
+	// Note: When the header is present but empty the attribute SHOULD be set to the
+	// empty string. Note that this is a valid situation that is expected in certain
+	// cases, according the aforementioned section of RFC 7230. When the header is not
+	// set the attribute MUST NOT be set.
+	AttributeHTTPHost = "http.host"
+	// The URI scheme identifying the used protocol.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'http', 'https'
+	AttributeHTTPScheme = "http.scheme"
+	// HTTP response status code.
+	//
+	// Type: int
+	// Required: If and only if one was received/sent.
+	// Stability: stable
+	// Examples: 200
+	AttributeHTTPStatusCode = "http.status_code"
+	// Kind of HTTP protocol used.
+	//
+	// Type: Enum
+	// Required: No
+	// Stability: stable
+	// Note: If net.transport is not specified, it can be assumed to be IP.TCP except
+	// if http.flavor is QUIC, in which case IP.UDP is assumed.
+	AttributeHTTPFlavor = "http.flavor"
+	// Value of the HTTP User-Agent header sent by the client.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'CERN-LineMode/2.15 libwww/2.17b3'
+	AttributeHTTPUserAgent = "http.user_agent"
+	// The size of the request payload body in bytes. This is the number of bytes
+	// transferred excluding headers and is often, but not always, present as the
+	// Content-Length header. For requests using transport encoding, this should be
+	// the compressed size.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 3495
+	AttributeHTTPRequestContentLength = "http.request_content_length"
+	// The size of the uncompressed request payload body after transport decoding. Not
+	// set if transport encoding not used.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 5493
+	AttributeHTTPRequestContentLengthUncompressed = "http.request_content_length_uncompressed"
+	// The size of the response payload body in bytes. This is the number of bytes
+	// transferred excluding headers and is often, but not always, present as the
+	// Content-Length header. For requests using transport encoding, this should be
+	// the compressed size.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 3495
+	AttributeHTTPResponseContentLength = "http.response_content_length"
+	// The size of the uncompressed response payload body after transport decoding.
+	// Not set if transport encoding not used.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 5493
+	AttributeHTTPResponseContentLengthUncompressed = "http.response_content_length_uncompressed"
+)
+
+const (
+	// HTTP 1.0
+	AttributeHTTPFlavorHTTP10 = "1.0"
+	// HTTP 1.1
+	AttributeHTTPFlavorHTTP11 = "1.1"
+	// HTTP 2
+	AttributeHTTPFlavorHTTP20 = "2.0"
+	// SPDY protocol
+	AttributeHTTPFlavorSPDY = "SPDY"
+	// QUIC protocol
+	AttributeHTTPFlavorQUIC = "QUIC"
+)
+
+// Semantic Convention for HTTP Server
+const (
+	// The primary server name of the matched virtual host. This should be obtained
+	// via configuration. If no such configuration can be obtained, this attribute
+	// MUST NOT be set ( net.host.name should be used instead).
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'example.com'
+	// Note: http.url is usually not readily available on the server side but would
+	// have to be assembled in a cumbersome and sometimes lossy process from other
+	// information (see e.g. open-telemetry/opentelemetry-python/pull/148). It is thus
+	// preferred to supply the raw data that is available.
+	AttributeHTTPServerName = "http.server_name"
+	// The matched route (path template).
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '/users/:userID?'
+	AttributeHTTPRoute = "http.route"
+	// The IP address of the original client behind all proxies, if known (e.g. from
+	// X-Forwarded-For).
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '83.164.160.102'
+	// Note: This is not necessarily the same as net.peer.ip, which would
+	// identify the network-level peer, which may be a proxy.This attribute should be
+	// set when a source of information different
+	// from the one used for net.peer.ip, is available even if that other
+	// source just confirms the same value as net.peer.ip.
+	// Rationale: For net.peer.ip, one typically does not know if it
+	// comes from a proxy, reverse proxy, or the actual client. Setting
+	// http.client_ip when it's the same as net.peer.ip means that
+	// one is at least somewhat confident that the address is not that of
+	// the closest proxy.
+	AttributeHTTPClientIP = "http.client_ip"
+)
+
+// Attributes that exist for multiple DynamoDB request types.
+const (
+	// The keys in the RequestItems object field.
+	//
+	// Type: string[]
+	// Required: No
+	// Stability: stable
+	// Examples: 'Users', 'Cats'
+	AttributeAWSDynamoDBTableNames = "aws.dynamodb.table_names"
+	// The JSON-serialized value of each item in the ConsumedCapacity response field.
+	//
+	// Type: string[]
+	// Required: No
+	// Stability: stable
+	// Examples: '{ "CapacityUnits": number, "GlobalSecondaryIndexes": { "string" : {
+	// "CapacityUnits": number, "ReadCapacityUnits": number, "WriteCapacityUnits":
+	// number } }, "LocalSecondaryIndexes": { "string" : { "CapacityUnits": number,
+	// "ReadCapacityUnits": number, "WriteCapacityUnits": number } },
+	// "ReadCapacityUnits": number, "Table": { "CapacityUnits": number,
+	// "ReadCapacityUnits": number, "WriteCapacityUnits": number }, "TableName":
+	// "string", "WriteCapacityUnits": number }'
+	AttributeAWSDynamoDBConsumedCapacity = "aws.dynamodb.consumed_capacity"
+	// The JSON-serialized value of the ItemCollectionMetrics response field.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '{ "string" : [ { "ItemCollectionKey": { "string" : { "B": blob,
+	// "BOOL": boolean, "BS": [ blob ], "L": [ "AttributeValue" ], "M": { "string" :
+	// "AttributeValue" }, "N": "string", "NS": [ "string" ], "NULL": boolean, "S":
+	// "string", "SS": [ "string" ] } }, "SizeEstimateRangeGB": [ number ] } ] }'
+	AttributeAWSDynamoDBItemCollectionMetrics = "aws.dynamodb.item_collection_metrics"
+	// The value of the ProvisionedThroughput.ReadCapacityUnits request parameter.
+	//
+	// Type: double
+	// Required: No
+	// Stability: stable
+	// Examples: 1.0, 2.0
+	AttributeAWSDynamoDBProvisionedReadCapacity = "aws.dynamodb.provisioned_read_capacity"
+	// The value of the ProvisionedThroughput.WriteCapacityUnits request parameter.
+	//
+	// Type: double
+	// Required: No
+	// Stability: stable
+	// Examples: 1.0, 2.0
+	AttributeAWSDynamoDBProvisionedWriteCapacity = "aws.dynamodb.provisioned_write_capacity"
+	// The value of the ConsistentRead request parameter.
+	//
+	// Type: boolean
+	// Required: No
+	// Stability: stable
+	AttributeAWSDynamoDBConsistentRead = "aws.dynamodb.consistent_read"
+	// The value of the ProjectionExpression request parameter.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'Title', 'Title, Price, Color', 'Title, Description, RelatedItems,
+	// ProductReviews'
+	AttributeAWSDynamoDBProjection = "aws.dynamodb.projection"
+	// The value of the Limit request parameter.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 10
+	AttributeAWSDynamoDBLimit = "aws.dynamodb.limit"
+	// The value of the AttributesToGet request parameter.
+	//
+	// Type: string[]
+	// Required: No
+	// Stability: stable
+	// Examples: 'lives', 'id'
+	AttributeAWSDynamoDBAttributesToGet = "aws.dynamodb.attributes_to_get"
+	// The value of the IndexName request parameter.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'name_to_group'
+	AttributeAWSDynamoDBIndexName = "aws.dynamodb.index_name"
+	// The value of the Select request parameter.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'ALL_ATTRIBUTES', 'COUNT'
+	AttributeAWSDynamoDBSelect = "aws.dynamodb.select"
+)
+
+// DynamoDB.CreateTable
+const (
+	// The JSON-serialized value of each item of the GlobalSecondaryIndexes request
+	// field
+	//
+	// Type: string[]
+	// Required: No
+	// Stability: stable
+	// Examples: '{ "IndexName": "string", "KeySchema": [ { "AttributeName": "string",
+	// "KeyType": "string" } ], "Projection": { "NonKeyAttributes": [ "string" ],
+	// "ProjectionType": "string" }, "ProvisionedThroughput": { "ReadCapacityUnits":
+	// number, "WriteCapacityUnits": number } }'
+	AttributeAWSDynamoDBGlobalSecondaryIndexes = "aws.dynamodb.global_secondary_indexes"
+	// The JSON-serialized value of each item of the LocalSecondaryIndexes request
+	// field.
+	//
+	// Type: string[]
+	// Required: No
+	// Stability: stable
+	// Examples: '{ "IndexARN": "string", "IndexName": "string", "IndexSizeBytes":
+	// number, "ItemCount": number, "KeySchema": [ { "AttributeName": "string",
+	// "KeyType": "string" } ], "Projection": { "NonKeyAttributes": [ "string" ],
+	// "ProjectionType": "string" } }'
+	AttributeAWSDynamoDBLocalSecondaryIndexes = "aws.dynamodb.local_secondary_indexes"
+)
+
+// DynamoDB.ListTables
+const (
+	// The value of the ExclusiveStartTableName request parameter.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'Users', 'CatsTable'
+	AttributeAWSDynamoDBExclusiveStartTable = "aws.dynamodb.exclusive_start_table"
+	// The the number of items in the TableNames response parameter.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 20
+	AttributeAWSDynamoDBTableCount = "aws.dynamodb.table_count"
+)
+
+// DynamoDB.Query
+const (
+	// The value of the ScanIndexForward request parameter.
+	//
+	// Type: boolean
+	// Required: No
+	// Stability: stable
+	AttributeAWSDynamoDBScanForward = "aws.dynamodb.scan_forward"
+)
+
+// DynamoDB.Scan
+const (
+	// The value of the Segment request parameter.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 10
+	AttributeAWSDynamoDBSegment = "aws.dynamodb.segment"
+	// The value of the TotalSegments request parameter.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 100
+	AttributeAWSDynamoDBTotalSegments = "aws.dynamodb.total_segments"
+	// The value of the Count response parameter.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 10
+	AttributeAWSDynamoDBCount = "aws.dynamodb.count"
+	// The value of the ScannedCount response parameter.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 50
+	AttributeAWSDynamoDBScannedCount = "aws.dynamodb.scanned_count"
+)
+
+// DynamoDB.UpdateTable
+const (
+	// The JSON-serialized value of each item in the AttributeDefinitions request
+	// field.
+	//
+	// Type: string[]
+	// Required: No
+	// Stability: stable
+	// Examples: '{ "AttributeName": "string", "AttributeType": "string" }'
+	AttributeAWSDynamoDBAttributeDefinitions = "aws.dynamodb.attribute_definitions"
+	// The JSON-serialized value of each item in the the GlobalSecondaryIndexUpdates
+	// request field.
+	//
+	// Type: string[]
+	// Required: No
+	// Stability: stable
+	// Examples: '{ "Create": { "IndexName": "string", "KeySchema": [ {
+	// "AttributeName": "string", "KeyType": "string" } ], "Projection": {
+	// "NonKeyAttributes": [ "string" ], "ProjectionType": "string" },
+	// "ProvisionedThroughput": { "ReadCapacityUnits": number, "WriteCapacityUnits":
+	// number } }'
+	AttributeAWSDynamoDBGlobalSecondaryIndexUpdates = "aws.dynamodb.global_secondary_index_updates"
+)
+
+// This document defines the attributes used in messaging systems.
+const (
+	// A string identifying the messaging system.
+	//
+	// Type: string
+	// Required: Always
+	// Stability: stable
+	// Examples: 'kafka', 'rabbitmq', 'rocketmq', 'activemq', 'AmazonSQS'
+	AttributeMessagingSystem = "messaging.system"
+	// The message destination name. This might be equal to the span name but is
+	// required nevertheless.
+	//
+	// Type: string
+	// Required: Always
+	// Stability: stable
+	// Examples: 'MyQueue', 'MyTopic'
+	AttributeMessagingDestination = "messaging.destination"
+	// The kind of message destination
+	//
+	// Type: Enum
+	// Required: Required only if the message destination is either a `queue` or
+	// `topic`.
+	// Stability: stable
+	AttributeMessagingDestinationKind = "messaging.destination_kind"
+	// A boolean that is true if the message destination is temporary.
+	//
+	// Type: boolean
+	// Required: If missing, it is assumed to be false.
+	// Stability: stable
+	AttributeMessagingTempDestination = "messaging.temp_destination"
+	// The name of the transport protocol.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'AMQP', 'MQTT'
+	AttributeMessagingProtocol = "messaging.protocol"
+	// The version of the transport protocol.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '0.9.1'
+	AttributeMessagingProtocolVersion = "messaging.protocol_version"
+	// Connection string.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'tibjmsnaming://localhost:7222',
+	// 'https://queue.amazonaws.com/80398EXAMPLE/MyQueue'
+	AttributeMessagingURL = "messaging.url"
+	// A value used by the messaging system as an identifier for the message,
+	// represented as a string.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '452a7c7c7c7048c2f887f61572b18fc2'
+	AttributeMessagingMessageID = "messaging.message_id"
+	// The conversation ID identifying the conversation to which the message belongs,
+	// represented as a string. Sometimes called &quot;Correlation ID&quot;.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'MyConversationID'
+	AttributeMessagingConversationID = "messaging.conversation_id"
+	// The (uncompressed) size of the message payload in bytes. Also use this
+	// attribute if it is unknown whether the compressed or uncompressed payload size
+	// is reported.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 2738
+	AttributeMessagingMessagePayloadSizeBytes = "messaging.message_payload_size_bytes"
+	// The compressed size of the message payload in bytes.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 2048
+	AttributeMessagingMessagePayloadCompressedSizeBytes = "messaging.message_payload_compressed_size_bytes"
+)
+
+const (
+	// A message sent to a queue
+	AttributeMessagingDestinationKindQueue = "queue"
+	// A message sent to a topic
+	AttributeMessagingDestinationKindTopic = "topic"
+)
+
+// Semantic convention for a consumer of messages received from a messaging system
+const (
+	// A string identifying the kind of message consumption as defined in the
+	// Operation names section above. If the operation is &quot;send&quot;, this
+	// attribute MUST NOT be set, since the operation can be inferred from the span
+	// kind in that case.
+	//
+	// Type: Enum
+	// Required: No
+	// Stability: stable
+	AttributeMessagingOperation = "messaging.operation"
+	// The identifier for the consumer receiving a message. For Kafka, set it to
+	// {messaging.kafka.consumer_group} - {messaging.kafka.client_id}, if both are
+	// present, or only messaging.kafka.consumer_group. For brokers, such as RabbitMQ
+	// and Artemis, set it to the client_id of the client consuming the message.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'mygroup - client-6'
+	AttributeMessagingConsumerID = "messaging.consumer_id"
+)
+
+const (
+	// receive
+	AttributeMessagingOperationReceive = "receive"
+	// process
+	AttributeMessagingOperationProcess = "process"
+)
+
+// Attributes for RabbitMQ
+const (
+	// RabbitMQ message routing key.
+	//
+	// Type: string
+	// Required: Unless it is empty.
+	// Stability: stable
+	// Examples: 'myKey'
+	AttributeMessagingRabbitmqRoutingKey = "messaging.rabbitmq.routing_key"
+)
+
+// Attributes for Apache Kafka
+const (
+	// Message keys in Kafka are used for grouping alike messages to ensure they're
+	// processed on the same partition. They differ from messaging.message_id in that
+	// they're not unique. If the key is null, the attribute MUST NOT be set.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'myKey'
+	// Note: If the key type is not string, it's string representation has to be
+	// supplied for the attribute. If the key has no unambiguous, canonical string
+	// form, don't include its value.
+	AttributeMessagingKafkaMessageKey = "messaging.kafka.message_key"
+	// Name of the Kafka Consumer Group that is handling the message. Only applies to
+	// consumers, not producers.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'my-group'
+	AttributeMessagingKafkaConsumerGroup = "messaging.kafka.consumer_group"
+	// Client ID for the Consumer or Producer that is handling the message.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'client-5'
+	AttributeMessagingKafkaClientID = "messaging.kafka.client_id"
+	// Partition the message is sent to.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Examples: 2
+	AttributeMessagingKafkaPartition = "messaging.kafka.partition"
+	// A boolean that is true if the message is a tombstone.
+	//
+	// Type: boolean
+	// Required: If missing, it is assumed to be false.
+	// Stability: stable
+	AttributeMessagingKafkaTombstone = "messaging.kafka.tombstone"
+)
+
+// Attributes for Apache RocketMQ
+const (
+	// Namespace of RocketMQ resources, resources in different namespaces are
+	// individual.
+	//
+	// Type: string
+	// Required: Always
+	// Stability: stable
+	// Examples: 'myNamespace'
+	AttributeMessagingRocketmqNamespace = "messaging.rocketmq.namespace"
+	// Name of the RocketMQ producer/consumer group that is handling the message. The
+	// client type is identified by the SpanKind.
+	//
+	// Type: string
+	// Required: Always
+	// Stability: stable
+	// Examples: 'myConsumerGroup'
+	AttributeMessagingRocketmqClientGroup = "messaging.rocketmq.client_group"
+	// The unique identifier for each client.
+	//
+	// Type: string
+	// Required: Always
+	// Stability: stable
+	// Examples: 'myhost@8742@s8083jm'
+	AttributeMessagingRocketmqClientID = "messaging.rocketmq.client_id"
+	// Type of message.
+	//
+	// Type: Enum
+	// Required: No
+	// Stability: stable
+	AttributeMessagingRocketmqMessageType = "messaging.rocketmq.message_type"
+	// The secondary classifier of message besides topic.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'tagA'
+	AttributeMessagingRocketmqMessageTag = "messaging.rocketmq.message_tag"
+	// Key(s) of message, another way to mark message besides message id.
+	//
+	// Type: string[]
+	// Required: No
+	// Stability: stable
+	// Examples: 'keyA', 'keyB'
+	AttributeMessagingRocketmqMessageKeys = "messaging.rocketmq.message_keys"
+	// Model of message consumption. This only applies to consumer spans.
+	//
+	// Type: Enum
+	// Required: No
+	// Stability: stable
+	AttributeMessagingRocketmqConsumptionModel = "messaging.rocketmq.consumption_model"
+)
+
+const (
+	// Normal message
+	AttributeMessagingRocketmqMessageTypeNormal = "normal"
+	// FIFO message
+	AttributeMessagingRocketmqMessageTypeFifo = "fifo"
+	// Delay message
+	AttributeMessagingRocketmqMessageTypeDelay = "delay"
+	// Transaction message
+	AttributeMessagingRocketmqMessageTypeTransaction = "transaction"
+)
+
+const (
+	// Clustering consumption model
+	AttributeMessagingRocketmqConsumptionModelClustering = "clustering"
+	// Broadcasting consumption model
+	AttributeMessagingRocketmqConsumptionModelBroadcasting = "broadcasting"
+)
+
+// This document defines semantic conventions for remote procedure calls.
+const (
+	// A string identifying the remoting system.
+	//
+	// Type: string
+	// Required: Always
+	// Stability: stable
+	// Examples: 'grpc', 'java_rmi', 'wcf'
+	AttributeRPCSystem = "rpc.system"
+	// The full (logical) name of the service being called, including its package
+	// name, if applicable.
+	//
+	// Type: string
+	// Required: No, but recommended
+	// Stability: stable
+	// Examples: 'myservice.EchoService'
+	// Note: This is the logical name of the service from the RPC interface
+	// perspective, which can be different from the name of any implementing class.
+	// The code.namespace attribute may be used to store the latter (despite the
+	// attribute name, it may include a class name; e.g., class with method actually
+	// executing the call on the server side, RPC client stub class on the client
+	// side).
+	AttributeRPCService = "rpc.service"
+	// The name of the (logical) method being called, must be equal to the $method
+	// part in the span name.
+	//
+	// Type: string
+	// Required: No, but recommended
+	// Stability: stable
+	// Examples: 'exampleMethod'
+	// Note: This is the logical name of the method from the RPC interface
+	// perspective, which can be different from the name of any implementing
+	// method/function. The code.function attribute may be used to store the latter
+	// (e.g., method actually executing the call on the server side, RPC client stub
+	// method on the client side).
+	AttributeRPCMethod = "rpc.method"
+)
+
+// Tech-specific attributes for gRPC.
+const (
+	// The numeric status code of the gRPC request.
+	//
+	// Type: Enum
+	// Required: Always
+	// Stability: stable
+	AttributeRPCGRPCStatusCode = "rpc.grpc.status_code"
+)
+
+const (
+	// OK
+	AttributeRPCGRPCStatusCodeOk = "0"
+	// CANCELLED
+	AttributeRPCGRPCStatusCodeCancelled = "1"
+	// UNKNOWN
+	AttributeRPCGRPCStatusCodeUnknown = "2"
+	// INVALID_ARGUMENT
+	AttributeRPCGRPCStatusCodeInvalidArgument = "3"
+	// DEADLINE_EXCEEDED
+	AttributeRPCGRPCStatusCodeDeadlineExceeded = "4"
+	// NOT_FOUND
+	AttributeRPCGRPCStatusCodeNotFound = "5"
+	// ALREADY_EXISTS
+	AttributeRPCGRPCStatusCodeAlreadyExists = "6"
+	// PERMISSION_DENIED
+	AttributeRPCGRPCStatusCodePermissionDenied = "7"
+	// RESOURCE_EXHAUSTED
+	AttributeRPCGRPCStatusCodeResourceExhausted = "8"
+	// FAILED_PRECONDITION
+	AttributeRPCGRPCStatusCodeFailedPrecondition = "9"
+	// ABORTED
+	AttributeRPCGRPCStatusCodeAborted = "10"
+	// OUT_OF_RANGE
+	AttributeRPCGRPCStatusCodeOutOfRange = "11"
+	// UNIMPLEMENTED
+	AttributeRPCGRPCStatusCodeUnimplemented = "12"
+	// INTERNAL
+	AttributeRPCGRPCStatusCodeInternal = "13"
+	// UNAVAILABLE
+	AttributeRPCGRPCStatusCodeUnavailable = "14"
+	// DATA_LOSS
+	AttributeRPCGRPCStatusCodeDataLoss = "15"
+	// UNAUTHENTICATED
+	AttributeRPCGRPCStatusCodeUnauthenticated = "16"
+)
+
+// Tech-specific attributes for [JSON RPC](https://www.jsonrpc.org/).
+const (
+	// Protocol version as in jsonrpc property of request/response. Since JSON-RPC 1.0
+	// does not specify this, the value can be omitted.
+	//
+	// Type: string
+	// Required: If missing, it is assumed to be "1.0".
+	// Stability: stable
+	// Examples: '2.0', '1.0'
+	AttributeRPCJsonrpcVersion = "rpc.jsonrpc.version"
+	// id property of request or response. Since protocol allows id to be int, string,
+	// null or missing (for notifications), value is expected to be cast to string for
+	// simplicity. Use empty string in case of null value. Omit entirely if this is a
+	// notification.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: '10', 'request-7', ''
+	AttributeRPCJsonrpcRequestID = "rpc.jsonrpc.request_id"
+	// error.code property of response if it is an error response.
+	//
+	// Type: int
+	// Required: If missing, response is assumed to be successful.
+	// Stability: stable
+	// Examples: -32700, 100
+	AttributeRPCJsonrpcErrorCode = "rpc.jsonrpc.error_code"
+	// error.message property of response if it is an error response.
+	//
+	// Type: string
+	// Required: No
+	// Stability: stable
+	// Examples: 'Parse error', 'User already exists'
+	AttributeRPCJsonrpcErrorMessage = "rpc.jsonrpc.error_message"
+)
+
+// RPC received/sent message.
+const (
+	// Whether this is a received or sent message.
+	//
+	// Type: Enum
+	// Required: No
+	// Stability: stable
+	AttributeMessageType = "message.type"
+	// MUST be calculated as two different counters starting from 1 one for sent
+	// messages and one for received message.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	// Note: This way we guarantee that the values will be consistent between
+	// different implementations.
+	AttributeMessageID = "message.id"
+	// Compressed size of the message in bytes.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	AttributeMessageCompressedSize = "message.compressed_size"
+	// Uncompressed size of the message in bytes.
+	//
+	// Type: int
+	// Required: No
+	// Stability: stable
+	AttributeMessageUncompressedSize = "message.uncompressed_size"
+)
+
+const (
+	// sent
+	AttributeMessageTypeSent = "SENT"
+	// received
+	AttributeMessageTypeReceived = "RECEIVED"
+)
+
+func GetTraceSemanticConventionAttributeNames() []string {
+	return []string{
+		AttributeAWSLambdaInvokedARN,
+		AttributeDBSystem,
+		AttributeDBConnectionString,
+		AttributeDBUser,
+		AttributeDBJDBCDriverClassname,
+		AttributeDBName,
+		AttributeDBStatement,
+		AttributeDBOperation,
+		AttributeDBMSSQLInstanceName,
+		AttributeDBCassandraPageSize,
+		AttributeDBCassandraConsistencyLevel,
+		AttributeDBCassandraTable,
+		AttributeDBCassandraIdempotence,
+		AttributeDBCassandraSpeculativeExecutionCount,
+		AttributeDBCassandraCoordinatorID,
+		AttributeDBCassandraCoordinatorDC,
+		AttributeDBRedisDBIndex,
+		AttributeDBMongoDBCollection,
+		AttributeDBSQLTable,
+		AttributeExceptionType,
+		AttributeExceptionMessage,
+		AttributeExceptionStacktrace,
+		AttributeExceptionEscaped,
+		AttributeFaaSTrigger,
+		AttributeFaaSExecution,
+		AttributeFaaSDocumentCollection,
+		AttributeFaaSDocumentOperation,
+		AttributeFaaSDocumentTime,
+		AttributeFaaSDocumentName,
+		AttributeFaaSTime,
+		AttributeFaaSCron,
+		AttributeFaaSColdstart,
+		AttributeFaaSInvokedName,
+		AttributeFaaSInvokedProvider,
+		AttributeFaaSInvokedRegion,
+		AttributeNetTransport,
+		AttributeNetPeerIP,
+		AttributeNetPeerPort,
+		AttributeNetPeerName,
+		AttributeNetHostIP,
+		AttributeNetHostPort,
+		AttributeNetHostName,
+		AttributeNetHostConnectionType,
+		AttributeNetHostConnectionSubtype,
+		AttributeNetHostCarrierName,
+		AttributeNetHostCarrierMcc,
+		AttributeNetHostCarrierMnc,
+		AttributeNetHostCarrierIcc,
+		AttributePeerService,
+		AttributeEnduserID,
+		AttributeEnduserRole,
+		AttributeEnduserScope,
+		AttributeThreadID,
+		AttributeThreadName,
+		AttributeCodeFunction,
+		AttributeCodeNamespace,
+		AttributeCodeFilepath,
+		AttributeCodeLineNumber,
+		AttributeHTTPMethod,
+		AttributeHTTPURL,
+		AttributeHTTPTarget,
+		AttributeHTTPHost,
+		AttributeHTTPScheme,
+		AttributeHTTPStatusCode,
+		AttributeHTTPFlavor,
+		AttributeHTTPUserAgent,
+		AttributeHTTPRequestContentLength,
+		AttributeHTTPRequestContentLengthUncompressed,
+		AttributeHTTPResponseContentLength,
+		AttributeHTTPResponseContentLengthUncompressed,
+		AttributeHTTPServerName,
+		AttributeHTTPRoute,
+		AttributeHTTPClientIP,
+		AttributeAWSDynamoDBTableNames,
+		AttributeAWSDynamoDBConsumedCapacity,
+		AttributeAWSDynamoDBItemCollectionMetrics,
+		AttributeAWSDynamoDBProvisionedReadCapacity,
+		AttributeAWSDynamoDBProvisionedWriteCapacity,
+		AttributeAWSDynamoDBConsistentRead,
+		AttributeAWSDynamoDBProjection,
+		AttributeAWSDynamoDBLimit,
+		AttributeAWSDynamoDBAttributesToGet,
+		AttributeAWSDynamoDBIndexName,
+		AttributeAWSDynamoDBSelect,
+		AttributeAWSDynamoDBGlobalSecondaryIndexes,
+		AttributeAWSDynamoDBLocalSecondaryIndexes,
+		AttributeAWSDynamoDBExclusiveStartTable,
+		AttributeAWSDynamoDBTableCount,
+		AttributeAWSDynamoDBScanForward,
+		AttributeAWSDynamoDBSegment,
+		AttributeAWSDynamoDBTotalSegments,
+		AttributeAWSDynamoDBCount,
+		AttributeAWSDynamoDBScannedCount,
+		AttributeAWSDynamoDBAttributeDefinitions,
+		AttributeAWSDynamoDBGlobalSecondaryIndexUpdates,
+		AttributeMessagingSystem,
+		AttributeMessagingDestination,
+		AttributeMessagingDestinationKind,
+		AttributeMessagingTempDestination,
+		AttributeMessagingProtocol,
+		AttributeMessagingProtocolVersion,
+		AttributeMessagingURL,
+		AttributeMessagingMessageID,
+		AttributeMessagingConversationID,
+		AttributeMessagingMessagePayloadSizeBytes,
+		AttributeMessagingMessagePayloadCompressedSizeBytes,
+		AttributeMessagingOperation,
+		AttributeMessagingConsumerID,
+		AttributeMessagingRabbitmqRoutingKey,
+		AttributeMessagingKafkaMessageKey,
+		AttributeMessagingKafkaConsumerGroup,
+		AttributeMessagingKafkaClientID,
+		AttributeMessagingKafkaPartition,
+		AttributeMessagingKafkaTombstone,
+		AttributeMessagingRocketmqNamespace,
+		AttributeMessagingRocketmqClientGroup,
+		AttributeMessagingRocketmqClientID,
+		AttributeMessagingRocketmqMessageType,
+		AttributeMessagingRocketmqMessageTag,
+		AttributeMessagingRocketmqMessageKeys,
+		AttributeMessagingRocketmqConsumptionModel,
+		AttributeRPCSystem,
+		AttributeRPCService,
+		AttributeRPCMethod,
+		AttributeRPCGRPCStatusCode,
+		AttributeRPCJsonrpcVersion,
+		AttributeRPCJsonrpcRequestID,
+		AttributeRPCJsonrpcErrorCode,
+		AttributeRPCJsonrpcErrorMessage,
+		AttributeMessageType,
+		AttributeMessageID,
+		AttributeMessageCompressedSize,
+		AttributeMessageUncompressedSize,
+	}
+}


### PR DESCRIPTION
A couple of versions of the spec have been released since semconv was last generated, this brings the collector up to date.
