### PR TITLE
Add file watch to support config reload on file change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 - Add semconv 1.7.0 and 1.8.0 (#4452)
 - Added `feature-gates` CLI flag for controlling feature gate state. (#4368)
+- Add file watch to support config reload on file change (#4454) 
 
 ## v0.39.0 Beta
 

--- a/config/configmapprovider/file_test.go
+++ b/config/configmapprovider/file_test.go
@@ -1,0 +1,64 @@
+package configmapprovider
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWatchFile(t *testing.T) {
+	// Create a temporary file.
+	file, err := ioutil.TempFile("", "file_watcher_test")
+	require.NoError(t, err)
+	defer func() {
+		file.Close()
+		os.Remove(file.Name())
+	}()
+
+	received := false
+
+	// Write some initial content.
+	_, err = file.WriteString("hello")
+	require.NoError(t, err)
+	require.NoError(t, file.Sync())
+
+	// Setup the watch.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	watchFile(ctx, file.Name(), testingOnChange(t, &received))
+	time.Sleep(time.Second * 2)
+
+	// Update the file and verify we see the updated content.
+	_, err = file.WriteString(" world")
+	require.NoError(t, err)
+	require.NoError(t, file.Sync())
+
+	require.Eventually(t, func() bool {
+		return received
+	}, time.Second*10, time.Second)
+
+	// Cancel the context.
+	cancel()
+}
+
+func TestWatchFile_ReloadError(t *testing.T) {
+	// Create then delete a temporary file so we have a filename that we know can't be opened.
+	file, err := ioutil.TempFile("", "file_watcher_test")
+	require.NoError(t, err)
+	require.NoError(t, os.Remove(file.Name()))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	watchFile(ctx, file.Name(), func(event *ChangeEvent) {})
+}
+
+func testingOnChange(t *testing.T, r *bool) func(c *ChangeEvent) {
+	return func(c *ChangeEvent) {
+		require.Nil(t, c.Error)
+		*r = true
+	}
+}

--- a/config/configmapprovider/file_test.go
+++ b/config/configmapprovider/file_test.go
@@ -1,9 +1,24 @@
+// Copyright  The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package configmapprovider
 
 import (
 	"context"
 	"io/ioutil"
 	"os"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -19,7 +34,8 @@ func TestWatchFile(t *testing.T) {
 		os.Remove(file.Name())
 	}()
 
-	received := false
+	received := atomic.Value{}
+	received.Store(false)
 
 	// Write some initial content.
 	_, err = file.WriteString("hello")
@@ -38,7 +54,7 @@ func TestWatchFile(t *testing.T) {
 	require.NoError(t, file.Sync())
 
 	require.Eventually(t, func() bool {
-		return received
+		return received.Load().(bool)
 	}, time.Second*10, time.Second)
 
 	// Cancel the context.
@@ -49,6 +65,7 @@ func TestWatchFile_ReloadError(t *testing.T) {
 	// Create then delete a temporary file so we have a filename that we know can't be opened.
 	file, err := ioutil.TempFile("", "file_watcher_test")
 	require.NoError(t, err)
+	_ = file.Close()
 	require.NoError(t, os.Remove(file.Name()))
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -56,9 +73,9 @@ func TestWatchFile_ReloadError(t *testing.T) {
 	watchFile(ctx, file.Name(), func(event *ChangeEvent) {})
 }
 
-func testingOnChange(t *testing.T, r *bool) func(c *ChangeEvent) {
+func testingOnChange(t *testing.T, r *atomic.Value) func(c *ChangeEvent) {
 	return func(c *ChangeEvent) {
 		require.Nil(t, c.Error)
-		*r = true
+		r.Store(true)
 	}
 }

--- a/config/configmapprovider/properties.go
+++ b/config/configmapprovider/properties.go
@@ -40,7 +40,7 @@ func NewProperties(properties []string) Provider {
 	}
 }
 
-func (pmp *propertiesMapProvider) Retrieve(_ context.Context, onChange func(*ChangeEvent)) (Retrieved, error) {
+func (pmp *propertiesMapProvider) Retrieve(_ context.Context, _ func(*ChangeEvent)) (Retrieved, error) {
 	if len(pmp.properties) == 0 {
 		return &simpleRetrieved{confMap: config.NewMap()}, nil
 	}

--- a/service/collector.go
+++ b/service/collector.go
@@ -233,11 +233,7 @@ func (col *Collector) Run(ctx context.Context) error {
 	col.asyncErrorChannel = make(chan error)
 
 	// set up config watcher
-	var err error
-	if col.cfgW, err = newConfigWatcher(ctx, col.set); err != nil {
-		return err
-	}
-
+	col.cfgW = newConfigWatcher(ctx, col.set)
 	cfg, err := col.cfgW.get()
 	if err != nil {
 		return fmt.Errorf("unable to get config: %w", err)

--- a/service/config_watcher.go
+++ b/service/config_watcher.go
@@ -30,14 +30,14 @@ type configWatcher struct {
 	ret     configmapprovider.Retrieved
 }
 
-func newConfigWatcher(ctx context.Context, set CollectorSettings) (*configWatcher, error) {
+func newConfigWatcher(ctx context.Context, set CollectorSettings) *configWatcher {
 	cm := &configWatcher{
 		ctx:     ctx,
 		watcher: make(chan error, 1),
 		set:     set,
 	}
 
-	return cm, nil
+	return cm
 }
 
 func (cm *configWatcher) get() (*config.Config, error) {

--- a/service/config_watcher_test.go
+++ b/service/config_watcher_test.go
@@ -147,7 +147,7 @@ func TestConfigWatcher(t *testing.T) {
 				Factories:         factories,
 			}
 
-			cfgW, _ := newConfigWatcher(context.Background(), set)
+			cfgW := newConfigWatcher(context.Background(), set)
 			_, errN := cfgW.get()
 
 			if tt.expectNewErr {
@@ -177,8 +177,7 @@ func TestConfigWatcherNoWatcher(t *testing.T) {
 	}
 
 	watcherWG := sync.WaitGroup{}
-	cfgW, errN := newConfigWatcher(context.Background(), set)
-	assert.NoError(t, errN)
+	cfgW := newConfigWatcher(context.Background(), set)
 
 	watcherWG.Add(1)
 	go func() {
@@ -210,9 +209,7 @@ func TestConfigWatcherWhenClosed(t *testing.T) {
 	}
 
 	watcherWG := sync.WaitGroup{}
-	cfgW, errN := newConfigWatcher(context.Background(), set)
-	assert.NoError(t, errN)
-
+	cfgW := newConfigWatcher(context.Background(), set)
 	cfg, err := cfgW.get()
 	assert.NotNil(t, cfg)
 	assert.Nil(t, err)


### PR DESCRIPTION
**Description:**
Fixes: https://github.com/open-telemetry/opentelemetry-collector/issues/4397

This PR allows the main config.yml to be reloaded each time the config file changes. The entire pipeline gets reloaded.

This PR doesn't use an FS notify/inotify style watcher as we have seen that Kubernetes doesnt support such watches when a config is mounted as a config file. os.Stat given that it is cheap can be run every second to trigger a reload. 