### PR TITLE
Support env substitution in configuration file if variable not set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Remove `pdata.AttributeMap.InitFromMap` (#4429)
 
 ## 💡 Enhancements 💡
-- Support Env substitution if variable is unset (#4458)
+- Support shell-like syntax for environment variable substitution defaults (`${ENV:-default}`) (#4458)
 ## v0.39.0 Beta
 
 ## 🛑 Breaking changes 🛑

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Remove `pdata.AttributeMap.InitFromMap` (#4429)
 
+## 💡 Enhancements 💡
+- Support Env substitution if variable is unset (#4458)
 ## v0.39.0 Beta
 
 ## 🛑 Breaking changes 🛑

--- a/config/configmapprovider/expand.go
+++ b/config/configmapprovider/expand.go
@@ -88,7 +88,7 @@ func expandEnv(s string) string {
 			return "$"
 		}
 		pair := strings.Split(str, ":")
-		if envValue := os.Getenv(pair[0]); envValue != "" || len(pair) == 1 {
+		if envValue, ok := os.LookupEnv(pair[0]); ok || len(pair) == 1 {
 			return envValue
 		}
 		return pair[1]

--- a/config/configmapprovider/expand.go
+++ b/config/configmapprovider/expand.go
@@ -87,7 +87,7 @@ func expandEnv(s string) string {
 		if str == "$" {
 			return "$"
 		}
-		pair := strings.Split(str, ":")
+		pair := strings.SplitN(str, ":-", 2)
 		if envValue, ok := os.LookupEnv(pair[0]); ok || len(pair) == 1 {
 			return envValue
 		}

--- a/config/configmapprovider/expand.go
+++ b/config/configmapprovider/expand.go
@@ -17,6 +17,7 @@ package configmapprovider // import "go.opentelemetry.io/collector/config/config
 import (
 	"context"
 	"os"
+	"strings"
 )
 
 type expandMapProvider struct {
@@ -86,6 +87,10 @@ func expandEnv(s string) string {
 		if str == "$" {
 			return "$"
 		}
-		return os.Getenv(str)
+		pair := strings.Split(str, ":")
+		if envValue := os.Getenv(pair[0]); envValue != "" || len(pair) == 1 {
+			return envValue
+		}
+		return pair[1]
 	})
 }

--- a/config/configmapprovider/expand_test.go
+++ b/config/configmapprovider/expand_test.go
@@ -111,7 +111,7 @@ func TestExpand_EscapedEnvVars(t *testing.T) {
 			// escaped $ alone
 			"recv.7": "$",
 			// $$ -> escaped $
-			"recv.8": "${THREE:DEFAULT_THREE}",
+			"recv.8": "${THREE:-DEFAULT_THREE}",
 			// $$$ -> escaped $ + substituted env var (not expanded)
 			"recv.9": "$" + receiverEnvValueNotExpanded,
 			// $$$ -> escaped $ + substituted env var (expanded)

--- a/config/configmapprovider/expand_test.go
+++ b/config/configmapprovider/expand_test.go
@@ -39,6 +39,7 @@ func TestExpand(t *testing.T) {
 	const valueExtraMapValue = "some map value"
 	const valueExtraListElement = "some list value"
 	const valueEnv = "some env value"
+	const emptyValue = ""
 	assert.NoError(t, os.Setenv("EXTRA", valueExtra))
 	assert.NoError(t, os.Setenv("EXTRA_MAP_VALUE_1", valueExtraMapValue+"_1"))
 	assert.NoError(t, os.Setenv("EXTRA_MAP_VALUE_2", valueExtraMapValue+"_2"))
@@ -46,6 +47,7 @@ func TestExpand(t *testing.T) {
 	assert.NoError(t, os.Setenv("EXTRA_LIST_VALUE_2", valueExtraListElement+"_2"))
 	assert.NoError(t, os.Setenv("ENV_VALUE_1", valueEnv+"_1"))
 	assert.NoError(t, os.Setenv("ENV_VALUE_2", valueEnv+"_2"))
+	assert.NoError(t, os.Setenv("ENV_VALUE_6", emptyValue))
 
 	defer func() {
 		assert.NoError(t, os.Unsetenv("EXTRA"))
@@ -55,6 +57,7 @@ func TestExpand(t *testing.T) {
 		assert.NoError(t, os.Unsetenv("EXTRA_LIST_VALUE_2"))
 		assert.NoError(t, os.Unsetenv("ENV_VALUE_1"))
 		assert.NoError(t, os.Unsetenv("ENV_VALUE_2"))
+		assert.NoError(t, os.Unsetenv("ENV_VALUE_6"))
 	}()
 
 	expectedCfgMap, errExpected := config.NewMapFromFile(path.Join("testdata", "expand-with-no-env.yaml"))
@@ -108,7 +111,7 @@ func TestExpand_EscapedEnvVars(t *testing.T) {
 			// escaped $ alone
 			"recv.7": "$",
 			// $$ -> escaped $
-  			"recv.8": "${THREE:DEFAULT_THREE}",
+			"recv.8": "${THREE:DEFAULT_THREE}",
 			// $$$ -> escaped $ + substituted env var (not expanded)
 			"recv.9": "$" + receiverEnvValueNotExpanded,
 			// $$$ -> escaped $ + substituted env var (expanded)

--- a/config/configmapprovider/testdata/expand-escaped-env.yaml
+++ b/config/configmapprovider/testdata/expand-escaped-env.yaml
@@ -13,3 +13,9 @@ test_map:
   recv.6: "text$$"
   # escaped $ alone
   recv.7: "$$"
+  # $$ -> escaped $
+  recv.8: "$${THREE:DEFAULT_THREE}"
+  # $$$ -> escaped $ + substituted env var (not expanded)
+  recv.9: "$$${FOUR:some map value for env FOUR}"
+  # $$$ -> escaped $ + substituted env var (expanded)
+  recv.10: "$$${FIVE:DEFAULT_FIVE}"

--- a/config/configmapprovider/testdata/expand-escaped-env.yaml
+++ b/config/configmapprovider/testdata/expand-escaped-env.yaml
@@ -14,8 +14,8 @@ test_map:
   # escaped $ alone
   recv.7: "$$"
   # $$ -> escaped $
-  recv.8: "$${THREE:DEFAULT_THREE}"
+  recv.8: "$${THREE:-DEFAULT_THREE}"
   # $$$ -> escaped $ + substituted env var (not expanded)
-  recv.9: "$$${FOUR:some map value for env FOUR}"
+  recv.9: "$$${FOUR:-some map value for env FOUR}"
   # $$$ -> escaped $ + substituted env var (expanded)
-  recv.10: "$$${FIVE:DEFAULT_FIVE}"
+  recv.10: "$$${FIVE:-DEFAULT_FIVE}"

--- a/config/configmapprovider/testdata/expand-with-all-env.yaml
+++ b/config/configmapprovider/testdata/expand-with-all-env.yaml
@@ -1,5 +1,11 @@
 test_map:
   extra: "$EXTRA"
+  env:
+    recv.1: "$ENV_VALUE_1"
+    recv.2: "${ENV_VALUE_2:default value for 2 not substituted}"
+    recv.3: "${ENV_VALUE_3:default value for 3 substituted}"
+    recv.4: "${ENV_VALUE_4:}"
+    recv.5: "$ENV_VALUE_5"
   extra_map:
     recv.1: "$EXTRA_MAP_VALUE_1"
     recv.2: "${EXTRA_MAP_VALUE_2}"

--- a/config/configmapprovider/testdata/expand-with-all-env.yaml
+++ b/config/configmapprovider/testdata/expand-with-all-env.yaml
@@ -6,6 +6,7 @@ test_map:
     recv.3: "${ENV_VALUE_3:default value for 3 substituted}"
     recv.4: "${ENV_VALUE_4:}"
     recv.5: "$ENV_VALUE_5"
+    recv.6: "${ENV_VALUE_6}"
   extra_map:
     recv.1: "$EXTRA_MAP_VALUE_1"
     recv.2: "${EXTRA_MAP_VALUE_2}"

--- a/config/configmapprovider/testdata/expand-with-all-env.yaml
+++ b/config/configmapprovider/testdata/expand-with-all-env.yaml
@@ -2,11 +2,13 @@ test_map:
   extra: "$EXTRA"
   env:
     recv.1: "$ENV_VALUE_1"
-    recv.2: "${ENV_VALUE_2:default value for 2 not substituted}"
-    recv.3: "${ENV_VALUE_3:default value for 3 substituted}"
-    recv.4: "${ENV_VALUE_4:}"
+    recv.2: "${ENV_VALUE_2:-default value for 2 not substituted}"
+    recv.3: "${ENV_VALUE_3:-default value for 3 substituted}"
+    recv.4: "${ENV_VALUE_4:-}"
     recv.5: "$ENV_VALUE_5"
     recv.6: "${ENV_VALUE_6}"
+    recv.7: "${ENV_VALUE_7:-default value containing :- multiple :-}"
+    recv.8: "${ENV_VALUE_8:-special \"double-quotes\" :- 'single-quotes' !@#%^&*()$}"
   extra_map:
     recv.1: "$EXTRA_MAP_VALUE_1"
     recv.2: "${EXTRA_MAP_VALUE_2}"

--- a/config/configmapprovider/testdata/expand-with-no-env.yaml
+++ b/config/configmapprovider/testdata/expand-with-no-env.yaml
@@ -7,6 +7,8 @@ test_map:
     recv.4: ""
     recv.5: ""
     recv.6: ""
+    recv.7: "default value containing :- multiple :-"
+    recv.8: special "double-quotes" :- 'single-quotes' !@#%^&*()$
   extra_map:
     recv.1: "some map value_1"
     recv.2: "some map value_2"

--- a/config/configmapprovider/testdata/expand-with-no-env.yaml
+++ b/config/configmapprovider/testdata/expand-with-no-env.yaml
@@ -6,6 +6,7 @@ test_map:
     recv.3: "default value for 3 substituted"
     recv.4: ""
     recv.5: ""
+    recv.6: ""
   extra_map:
     recv.1: "some map value_1"
     recv.2: "some map value_2"

--- a/config/configmapprovider/testdata/expand-with-no-env.yaml
+++ b/config/configmapprovider/testdata/expand-with-no-env.yaml
@@ -1,5 +1,11 @@
 test_map:
   extra: "some string"
+  env:
+    recv.1: "some env value_1"
+    recv.2: "some env value_2"
+    recv.3: "default value for 3 substituted"
+    recv.4: ""
+    recv.5: ""
   extra_map:
     recv.1: "some map value_1"
     recv.2: "some map value_2"

--- a/config/configmapprovider/testdata/expand-with-partial-env.yaml
+++ b/config/configmapprovider/testdata/expand-with-partial-env.yaml
@@ -2,11 +2,13 @@ test_map:
   extra: "${EXTRA}"
   env:
     recv.1: "some env value_1"
-    recv.2: "${ENV_VALUE_2:default value for 2 not substituted}"
-    recv.3: "${ENV_VALUE_3:default value for 3 substituted}"
-    recv.4: "${ENV_VALUE_4:}"
+    recv.2: "${ENV_VALUE_2:-default value for 2 not substituted}"
+    recv.3: "${ENV_VALUE_3:-default value for 3 substituted}"
+    recv.4: "${ENV_VALUE_4:-}"
     recv.5: ""
     recv.6: "${ENV_VALUE_6}"
+    recv.7: "${ENV_VALUE_7:-default value containing :- multiple :-}"
+    recv.8: "${ENV_VALUE_8:-special \"double-quotes\" :- 'single-quotes' !@#%^&*()$}"
   extra_map:
     recv.1: "${EXTRA_MAP_VALUE_1}"
     recv.2: "some map value_2"

--- a/config/configmapprovider/testdata/expand-with-partial-env.yaml
+++ b/config/configmapprovider/testdata/expand-with-partial-env.yaml
@@ -6,6 +6,7 @@ test_map:
     recv.3: "${ENV_VALUE_3:default value for 3 substituted}"
     recv.4: "${ENV_VALUE_4:}"
     recv.5: ""
+    recv.6: "${ENV_VALUE_6}"
   extra_map:
     recv.1: "${EXTRA_MAP_VALUE_1}"
     recv.2: "some map value_2"

--- a/config/configmapprovider/testdata/expand-with-partial-env.yaml
+++ b/config/configmapprovider/testdata/expand-with-partial-env.yaml
@@ -1,5 +1,11 @@
 test_map:
   extra: "${EXTRA}"
+  env:
+    recv.1: "some env value_1"
+    recv.2: "${ENV_VALUE_2:default value for 2 not substituted}"
+    recv.3: "${ENV_VALUE_3:default value for 3 substituted}"
+    recv.4: "${ENV_VALUE_4:}"
+    recv.5: ""
   extra_map:
     recv.1: "${EXTRA_MAP_VALUE_1}"
     recv.2: "some map value_2"


### PR DESCRIPTION
**Description:**
FEAT: Support for expanding environment variable in case it is not set. 
The basic syntax is:
`${ENV_VAR:-DEFAULT_VALUE}`

**Link to tracking Issue:** #4384 

**Testing:**  Unit Tests
This PR is similar to #4387, instead this doesn't use extra dependencies. 

I think this is a relatively common ask especially when configuration is allowed via environment variables. A fallback is expected in case the variable is not set.