### PR TITLE
Make state information propogation non blocking on the collector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Remove `pdata.AttributeMap.InitFromMap` (#4429)
 - Updated configgrpc `ToDialOptions` to support passing providers to instrumentation library (#4451)
+- Make state information propagation non-blocking on the collector (#4460)
 
 ## 💡 Enhancements 💡
 

--- a/service/collector_test.go
+++ b/service/collector_test.go
@@ -252,3 +252,16 @@ func assertZPages(t *testing.T) {
 		testZPagePathFn(t, path)
 	}
 }
+
+// TestStateChannelFull tests to ensure that a full state channel doesn't block code paths going forward.
+func TestStateChannelFull(t *testing.T) {
+	col := &Collector{stateChannel: make(chan State, Closed+1)}
+	col.setCollectorState(Starting)
+	col.setCollectorState(Running)
+	col.setCollectorState(Closing)
+	col.setCollectorState(Starting)
+	col.setCollectorState(Closing)
+	col.setCollectorState(Closed)
+
+	require.Len(t, col.stateChannel, 4)
+}

--- a/service/collector_test.go
+++ b/service/collector_test.go
@@ -89,14 +89,14 @@ func TestCollector_StartAsGoRoutine(t *testing.T) {
 
 	assert.Eventually(t, func() bool {
 		return Running == col.GetState()
-	}, time.Second*2, time.Second)
+	}, time.Second*2, time.Millisecond*200)
 
 	col.Shutdown()
 	col.Shutdown()
 	<-colDone
 	assert.Eventually(t, func() bool {
 		return Closed == col.GetState()
-	}, time.Second*2, time.Second)
+	}, time.Second*2, time.Millisecond*200)
 }
 
 func TestCollector_Start(t *testing.T) {
@@ -132,7 +132,7 @@ func TestCollector_Start(t *testing.T) {
 
 	assert.Eventually(t, func() bool {
 		return Running == col.GetState()
-	}, time.Second*2, time.Second)
+	}, time.Second*2, time.Millisecond*200)
 	assert.Equal(t, col.logger, col.GetLogger())
 	assert.True(t, loggingHookCalled)
 
@@ -153,7 +153,7 @@ func TestCollector_Start(t *testing.T) {
 	<-colDone
 	assert.Eventually(t, func() bool {
 		return Closed == col.GetState()
-	}, time.Second*2, time.Second)
+	}, time.Second*2, time.Millisecond*200)
 }
 
 type mockColTelemetry struct{}
@@ -190,12 +190,12 @@ func TestCollector_ReportError(t *testing.T) {
 
 	assert.Eventually(t, func() bool {
 		return Running == col.GetState()
-	}, time.Second*2, time.Second)
+	}, time.Second*2, time.Millisecond*200)
 	col.service.ReportFatalError(errors.New("err2"))
 	<-colDone
 	assert.Eventually(t, func() bool {
 		return Closed == col.GetState()
-	}, time.Second*2, time.Second)
+	}, time.Second*2, time.Millisecond*200)
 }
 
 func assertMetrics(t *testing.T, prefix string, metricsPort uint16, mandatoryLabels []string) {

--- a/service/collector_windows.go
+++ b/service/collector_windows.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"syscall"
+	"time"
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -103,11 +104,13 @@ func (s *WindowsService) start(elog *eventlog.Log, colErrorChannel chan error) e
 
 	// wait until the collector server is in the Running state
 	go func() {
-		for state := range s.col.GetStateChannel() {
+		for {
+			state := s.col.GetState()
 			if state == Running {
 				colErrorChannel <- nil
 				break
 			}
+			time.Sleep(time.Millisecond * 200)
 		}
 	}()
 


### PR DESCRIPTION
Currently, the state channel allows only 4 states to be stored at a given time. This is with the assumption that the configuration can't be reloaded dynamically. To be able to support the same we need to be able to not block if there are state changes that are periodically happening. ~This PR makes the state channel inserts non blocking.~

This PR ensures that state change information propagation is not blocking by removing the channel and replacing it with an atomic variable. 