### PR TITLE
[golangci-lint] Remove unused exclude rules

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -125,15 +125,6 @@ issues:
     - text: "G402:"
       linters:
         - gosec
-    # Exclude internal package for now.
-    - path: ".*internal.*"
-      text: "should have comment|should be of the form"
-      linters:
-        - revive
-    # Exclude documenting constant blocks.
-    - text: "or a comment on this block"
-      linters:
-        - revive
 
   # The list of ids of default excludes to include or disable. By default it's empty.
   # See the list of default excludes here https://golangci-lint.run/usage/configuration.


### PR DESCRIPTION
**Description:** 

Removed unused `.golangci.yml` rules, they were used when many components lived here.
