### PR TITLE
fix: lint error not having a return value of `exp.Shutdown`

### DIFF
--- a/config/configmapprovider/expand_test.go
+++ b/config/configmapprovider/expand_test.go
@@ -30,7 +30,9 @@ import (
 func TestBaseRetrieveFailsOnRetrieve(t *testing.T) {
 	retErr := errors.New("test error")
 	exp := NewExpand(&mockProvider{retrieveErr: retErr})
-	defer exp.Shutdown(context.Background())
+	defer func() {
+		assert.NoError(t, exp.Shutdown(context.Background()))
+	}()
 	_, err := exp.Retrieve(context.Background(), nil)
 	require.Error(t, err)
 	require.ErrorIs(t, err, retErr)
@@ -39,7 +41,9 @@ func TestBaseRetrieveFailsOnRetrieve(t *testing.T) {
 func TestBaseRetrieveFailsOnGet(t *testing.T) {
 	getErr := errors.New("test error")
 	exp := NewExpand(&mockProvider{retrieved: &mockRetrieved{getErr: getErr}})
-	defer exp.Shutdown(context.Background())
+	defer func() {
+		assert.NoError(t, exp.Shutdown(context.Background()))
+	}()
 	_, err := exp.Retrieve(context.Background(), nil)
 	require.Error(t, err)
 	require.ErrorIs(t, err, getErr)

--- a/config/configmapprovider/expand_test.go
+++ b/config/configmapprovider/expand_test.go
@@ -30,9 +30,7 @@ import (
 func TestBaseRetrieveFailsOnRetrieve(t *testing.T) {
 	retErr := errors.New("test error")
 	exp := NewExpand(&mockProvider{retrieveErr: retErr})
-	defer func() {
-		assert.NoError(t, exp.Shutdown(context.Background()))
-	}()
+	t.Cleanup(func() { require.NoError(t, exp.Shutdown(context.Background())) })
 	_, err := exp.Retrieve(context.Background(), nil)
 	require.Error(t, err)
 	require.ErrorIs(t, err, retErr)
@@ -41,9 +39,7 @@ func TestBaseRetrieveFailsOnRetrieve(t *testing.T) {
 func TestBaseRetrieveFailsOnGet(t *testing.T) {
 	getErr := errors.New("test error")
 	exp := NewExpand(&mockProvider{retrieved: &mockRetrieved{getErr: getErr}})
-	defer func() {
-		assert.NoError(t, exp.Shutdown(context.Background()))
-	}()
+	t.Cleanup(func() { require.NoError(t, exp.Shutdown(context.Background())) })
 	_, err := exp.Retrieve(context.Background(), nil)
 	require.Error(t, err)
 	require.ErrorIs(t, err, getErr)


### PR DESCRIPTION
**Description:**
This PR solves linting error after #4450  was merged. 
I found a solution at [expoter/otlpexporter/otlp_test.go](https://github.com/open-telemetry/opentelemetry-collector/blob/main/exporter/otlpexporter/otlp_test.go#L210-L212)

**Link to tracking Issue:**
#4470 
