### PR TITLE
Handle corrupted persistent storage data gracefully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@
 - Add semconv 1.7.0 and 1.8.0 (#4452)
 - Added `feature-gates` CLI flag for controlling feature gate state. (#4368)
 
+## 🧰 Bug fixes 🧰
+
+- Fix handling of corrupted records by persistent buffer (experimental) (#4475)
+
 ## v0.39.0 Beta
 
 ## 🛑 Breaking changes 🛑

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 🧰 Bug fixes 🧰
+
+- Fix handling of corrupted records by persistent buffer (experimental) (#4475)
+
 ## v0.40.0 Beta
 
 ## 🛑 Breaking changes 🛑
@@ -15,10 +19,6 @@
 
 - Add semconv 1.7.0 and 1.8.0 (#4452)
 - Added `feature-gates` CLI flag for controlling feature gate state. (#4368)
-
-## 🧰 Bug fixes 🧰
-
-- Fix handling of corrupted records by persistent buffer (experimental) (#4475)
 
 ## v0.39.0 Beta
 

--- a/exporter/exporterhelper/internal/persistent_storage_batch.go
+++ b/exporter/exporterhelper/internal/persistent_storage_batch.go
@@ -111,6 +111,9 @@ func (bof *batchStruct) getRequestResult(key string) (PersistentRequest, error) 
 	if err != nil {
 		return nil, err
 	}
+	if reqIf == nil {
+		return nil, errValueNotSet
+	}
 
 	return reqIf.(PersistentRequest), nil
 }

--- a/exporter/exporterhelper/internal/persistent_storage_batch.go
+++ b/exporter/exporterhelper/internal/persistent_storage_batch.go
@@ -91,7 +91,7 @@ func (bof *batchStruct) delete(keys ...string) *batchStruct {
 }
 
 // getResult returns the result of a Get operation for a given key using the provided unmarshal function.
-// It should be called after execute
+// It should be called after execute. It may return nil value
 func (bof *batchStruct) getResult(key string, unmarshal func([]byte) (interface{}, error)) (interface{}, error) {
 	op := bof.getOperations[key]
 	if op == nil {
@@ -106,6 +106,7 @@ func (bof *batchStruct) getResult(key string, unmarshal func([]byte) (interface{
 }
 
 // getRequestResult returns the result of a Get operation as a request
+// If the value cannot be retrieved, it returns an error
 func (bof *batchStruct) getRequestResult(key string) (PersistentRequest, error) {
 	reqIf, err := bof.getResult(key, bof.bytesToRequest)
 	if err != nil {
@@ -119,6 +120,7 @@ func (bof *batchStruct) getRequestResult(key string) (PersistentRequest, error) 
 }
 
 // getItemIndexResult returns the result of a Get operation as an itemIndex
+// If the value cannot be retrieved, it returns an error
 func (bof *batchStruct) getItemIndexResult(key string) (itemIndex, error) {
 	itemIndexIf, err := bof.getResult(key, bytesToItemIndex)
 	if err != nil {
@@ -133,6 +135,7 @@ func (bof *batchStruct) getItemIndexResult(key string) (itemIndex, error) {
 }
 
 // getItemIndexArrayResult returns the result of a Get operation as a itemIndexArray
+// It may return nil value
 func (bof *batchStruct) getItemIndexArrayResult(key string) ([]itemIndex, error) {
 	itemIndexArrIf, err := bof.getResult(key, bytesToItemIndexArray)
 	if err != nil {

--- a/exporter/exporterhelper/internal/persistent_storage_test.go
+++ b/exporter/exporterhelper/internal/persistent_storage_test.go
@@ -104,6 +104,124 @@ func newFakeTracesRequestUnmarshalerFunc() RequestUnmarshaler {
 	}
 }
 
+func TestPersistentStorage_CorruptedData(t *testing.T) {
+	path := createTemporaryDirectory()
+	defer os.RemoveAll(path)
+
+	traces := newTraces(5, 10)
+	req := newFakeTracesRequest(traces)
+
+	ext := createStorageExtension(path)
+
+	cases := []struct {
+		name                               string
+		corruptAllData                     bool
+		corruptSomeData                    bool
+		corruptCurrentlyDispatchedItemsKey bool
+		corruptReadIndex                   bool
+		corruptWriteIndex                  bool
+		desiredQueueSize                   uint64
+		desiredNumberOfDispatchedItems     int
+	}{
+		{
+			name:                           "corrupted no items",
+			corruptAllData:                 false,
+			desiredQueueSize:               2,
+			desiredNumberOfDispatchedItems: 1,
+		},
+		{
+			name:                           "corrupted all items",
+			corruptAllData:                 true,
+			desiredQueueSize:               0,
+			desiredNumberOfDispatchedItems: 0,
+		},
+		{
+			name:                           "corrupted some items",
+			corruptSomeData:                true,
+			desiredQueueSize:               1,
+			desiredNumberOfDispatchedItems: 1,
+		},
+		{
+			name:                               "corrupted dispatched items key",
+			corruptCurrentlyDispatchedItemsKey: true,
+			desiredQueueSize:                   1,
+			desiredNumberOfDispatchedItems:     1,
+		},
+		{
+			name:                           "corrupted read index",
+			corruptReadIndex:               true,
+			desiredQueueSize:               0,
+			desiredNumberOfDispatchedItems: 1,
+		},
+		{
+			name:                           "corrupted write index",
+			corruptWriteIndex:              true,
+			desiredQueueSize:               0,
+			desiredNumberOfDispatchedItems: 1,
+		},
+		{
+			name:                               "corrupted everything",
+			corruptAllData:                     true,
+			corruptCurrentlyDispatchedItemsKey: true,
+			corruptReadIndex:                   true,
+			corruptWriteIndex:                  true,
+			desiredQueueSize:                   0,
+			desiredNumberOfDispatchedItems:     0,
+		},
+	}
+
+	badBytes := []byte{0, 1, 2}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			client := createTestClient(ext)
+			ps := createTestPersistentStorage(client)
+
+			ctx := context.Background()
+
+			// Put some items, make sure they are loaded and shutdown the storage...
+			for i := 0; i < 3; i++ {
+				err := ps.put(req)
+				require.NoError(t, err)
+			}
+			require.Eventually(t, func() bool {
+				return ps.size() == 2
+			}, 500*time.Millisecond, 10*time.Millisecond)
+			ps.stop()
+
+			// ... so now we can corrupt data (in several ways)
+			if c.corruptAllData || c.corruptSomeData {
+				_ = client.Set(ctx, "0", badBytes)
+			}
+			if c.corruptAllData {
+				_ = client.Set(ctx, "1", badBytes)
+				_ = client.Set(ctx, "2", badBytes)
+			}
+
+			if c.corruptCurrentlyDispatchedItemsKey {
+				_ = client.Set(ctx, currentlyDispatchedItemsKey, badBytes)
+			}
+
+			if c.corruptReadIndex {
+				_ = client.Set(ctx, readIndexKey, badBytes)
+			}
+
+			if c.corruptWriteIndex {
+				_ = client.Set(ctx, writeIndexKey, badBytes)
+			}
+
+			// Reload
+			newPs := createTestPersistentStorage(client)
+
+			require.Eventually(t, func() bool {
+				newPs.mu.Lock()
+				defer newPs.mu.Unlock()
+				return newPs.size() == c.desiredQueueSize && len(newPs.currentlyDispatchedItems) == c.desiredNumberOfDispatchedItems
+			}, 500*time.Millisecond, 10*time.Millisecond)
+		})
+	}
+}
+
 func TestPersistentStorage_CurrentlyProcessedItems(t *testing.T) {
 	path := createTemporaryDirectory()
 	defer os.RemoveAll(path)


### PR DESCRIPTION
**Description:** 
This fixes a bug with handling corrupted data by persistent buffer. In principle, when corrupted data is encountered, it should be handled gracefully. This fix makes sure this happens for several scenarios. Also, the change adds several test cases

The original bug was found by @pmalek-sumo and was expressed by following:

```
2021-11-24T11:53:33.753Z    info    internal/persistent_storage.go:309    Fetching items left for dispatch by consumers    {"kind": "exporter", "name": "otlphttp/containers", "queueName": "otlphttp/containers-logs", "numberOfItems": 2}
panic: interface conversion: interface is nil, not internal.PersistentRequest

goroutine 1 [running]:
go.opentelemetry.io/collector/exporter/exporterhelper/internal.(*batchStruct).getRequestResult(0xc001653038, {0x4e937b8, 0x1})
    go.opentelemetry.io/collector@v0.38.0/exporter/exporterhelper/internal/persistent_storage_batch.go:115 +0x65
go.opentelemetry.io/collector/exporter/exporterhelper/internal.(*persistentContiguousStorage).retrieveNotDispatchedReqs(0xc001068140, {0x567dda0, 0xc000078030})
    go.opentelemetry.io/collector@v0.38.0/exporter/exporterhelper/internal/persistent_storage.go:341 +0xf6d
go.opentelemetry.io/collector/exporter/exporterhelper/internal.newPersistentContiguousStorage({0x567dda0, 0xc000078030}, {0xc000fde040, 0x19}, 0x1388, 0xc001006960, {0x56aedf8, 0xc00000ebf0}, 0xc00100e630)
    go.opentelemetry.io/collector@v0.38.0/exporter/exporterhelper/internal/persistent_storage.go:124 +0x1e5
go.opentelemetry.io/collector/exporter/exporterhelper/internal.NewPersistentQueue(...)
    go.opentelemetry.io/collector@v0.38.0/exporter/exporterhelper/internal/persistent_queue.go:44
go.opentelemetry.io/collector/exporter/exporterhelper.
```

**Link to tracking Issue:** N/A

**Testing:** Unit tests added

**Documentation:** N/A

