### PR TITLE
Remove fileexporter from exporter docs (moved to contrib)

### DIFF
--- a/exporter/README.md
+++ b/exporter/README.md
@@ -20,7 +20,6 @@ Available log exporters (sorted alphabetically):
 
 Available local exporters (sorted alphabetically):
 
-- [File](fileexporter/README.md)
 - [Logging](loggingexporter/README.md)
 
 The [contrib


### PR DESCRIPTION
**Description:**
Fix exporter readme

**Documentation:**
Removed reference to fileexporter, since that is in contrib

