### PR TITLE
Support CORS Max-Age on OTLP/HTTP receiver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,14 +20,14 @@
 - Remove `pdata.AttributeMap.InitFromMap` (#4429)
 - Updated configgrpc `ToDialOptions` to support passing providers to instrumentation library (#4451)
 - Make state information propagation non-blocking on the collector (#4460)
-- CORS configuration for OLTP/HTTP receivers has been moved into a `cors:` block, instead of individual `cors_allowed_origins` and `cors_allowed_headers` settings (#4492)
+- CORS configuration for OTLP/HTTP receivers has been moved into a `cors:` block, instead of individual `cors_allowed_origins` and `cors_allowed_headers` settings (#4492)
 
 ## 💡 Enhancements 💡
 
 - Add semconv 1.7.0 and 1.8.0 (#4452)
 - Added `feature-gates` CLI flag for controlling feature gate state. (#4368)
 - Add a default user-agent header to the OTLP/gRPC and OTLP/HTTP exporters containing collector build information (#3970)
-- OLTP/HTTP receivers now support setting the `Access-Control-Max-Age` header for CORS caching. (#4492)
+- OTLP/HTTP receivers now support setting the `Access-Control-Max-Age` header for CORS caching. (#4492)
 
 ## v0.39.0 Beta
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,12 +20,14 @@
 - Remove `pdata.AttributeMap.InitFromMap` (#4429)
 - Updated configgrpc `ToDialOptions` to support passing providers to instrumentation library (#4451)
 - Make state information propagation non-blocking on the collector (#4460)
+- CORS configuration for OLTP/HTTP receivers has been moved into a `cors:` block, instead of individual `cors_allowed_origins` and `cors_allowed_headers` settings (#4492)
 
 ## 💡 Enhancements 💡
 
 - Add semconv 1.7.0 and 1.8.0 (#4452)
 - Added `feature-gates` CLI flag for controlling feature gate state. (#4368)
 - Add a default user-agent header to the OTLP/gRPC and OTLP/HTTP exporters containing collector build information (#3970)
+- OLTP/HTTP receivers now support setting the `Access-Control-Max-Age` header for CORS caching. (#4492)
 
 ## v0.39.0 Beta
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 - Remove `config.NewConfigMapFrom[File|Buffer]`, add testonly version (#4502)
 - `configtls`: TLS 1.2 is the new default mininum version (#4503)
 - `confighttp`: `ToServer` now accepts a `component.Host`, in line with gRPC's counterpart (#4514)
+- CORS configuration for OTLP/HTTP receivers has been moved into a `cors:` block, instead of individual `cors_allowed_origins` and `cors_allowed_headers` settings (#4492)
+
+## 💡 Enhancements 💡
+
+- OTLP/HTTP receivers now support setting the `Access-Control-Max-Age` header for CORS caching. (#4492)
 
 ## 🧰 Bug fixes 🧰
 
@@ -20,14 +25,12 @@
 - Remove `pdata.AttributeMap.InitFromMap` (#4429)
 - Updated configgrpc `ToDialOptions` to support passing providers to instrumentation library (#4451)
 - Make state information propagation non-blocking on the collector (#4460)
-- CORS configuration for OTLP/HTTP receivers has been moved into a `cors:` block, instead of individual `cors_allowed_origins` and `cors_allowed_headers` settings (#4492)
 
 ## 💡 Enhancements 💡
 
 - Add semconv 1.7.0 and 1.8.0 (#4452)
 - Added `feature-gates` CLI flag for controlling feature gate state. (#4368)
 - Add a default user-agent header to the OTLP/gRPC and OTLP/HTTP exporters containing collector build information (#3970)
-- OTLP/HTTP receivers now support setting the `Access-Control-Max-Age` header for CORS caching. (#4492)
 
 ## v0.39.0 Beta
 

--- a/config/confighttp/README.md
+++ b/config/confighttp/README.md
@@ -45,30 +45,39 @@ exporter:
 [Receivers](https://github.com/open-telemetry/opentelemetry-collector/blob/main/receiver/README.md)
 leverage server configuration.
 
-- [`cors_allowed_origins`](https://github.com/rs/cors): An empty list means
-  that CORS is not enabled at all. A wildcard can be used to match any origin
-  or one or more characters of an origin.
-- [`cors_allowed_headers`](https://github.com/rs/cors): When CORS is enabled,
-  can be used to specify an optional list of allowed headers. By default, it includes `Accept`, 
-  `Content-Type`, `X-Requested-With`. `Origin` is also always
-  added to the list. A wildcard (`*`) can be used to match any header.
-- [`cors_max_age`](https://github.com/rs/cors): When CORS is enabled,
-  sets the value of the `Access-Control-Max-Age` header, allowing clients to
-  cache the response to CORS preflight requests.
+- [`cors`](https://github.com/rs/cors#parameters): Configure [CORS][cors],
+allowing the receiver to accept traces from web browsers, even if the receiver
+is hosted at a different [origin][origin]. If left blank or set to `null`, CORS
+will not be enabled.
+  - `allowed_origins`: A list of [origins][origin] allowed to send requests to
+  the receiver. An origin may contain a wildcard (`*`) to replace 0 or more
+  characters (e.g., `https://*.example.com`). To allow any origin, set to
+  `['*']`. If no origins are listed, CORS will not be enabled.
+  - `allowed_headers`: Allow CORS requests to include headers outside the
+  [default safelist][cors-headers]. By default, safelist headers and
+  `X-Requested-With` will be allowed. To allow any request header, set to
+  `['*']`.
+  - `max_age`: Sets the value of the `Access-Control-Max-Age` header, allowing
+  clients to cache the response to CORS preflight requests.
 - `endpoint`: Valid value syntax available [here](https://github.com/grpc/grpc/blob/master/doc/naming.md)
 - [`tls`](../configtls/README.md)
+
+[cors]: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS
+[cors-headers]: https://developer.mozilla.org/en-US/docs/Glossary/CORS-safelisted_request_header
+[origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin
 
 Example:
 
 ```yaml
 receivers:
   otlp:
-    cors_allowed_origins:
-    - https://foo.bar.com
-    - https://*.test.com
-    cors_allowed_headers:
-    - ExampleHeader
-    cors_max_age: 7200
+    cors:
+      allowed_origins:
+        - https://foo.bar.com
+        - https://*.test.com
+      allowed_headers:
+        - ExampleHeader
+      max_age: 7200
     endpoint: 0.0.0.0:55690
     protocols:
       http:

--- a/config/confighttp/README.md
+++ b/config/confighttp/README.md
@@ -52,6 +52,9 @@ leverage server configuration.
   can be used to specify an optional list of allowed headers. By default, it includes `Accept`, 
   `Content-Type`, `X-Requested-With`. `Origin` is also always
   added to the list. A wildcard (`*`) can be used to match any header.
+- [`cors_max_age`](https://github.com/rs/cors): When CORS is enabled,
+  sets the value of the `Access-Control-Max-Age` header, allowing clients to
+  cache the response to CORS preflight requests.
 - `endpoint`: Valid value syntax available [here](https://github.com/grpc/grpc/blob/master/doc/naming.md)
 - [`tls`](../configtls/README.md)
 
@@ -65,6 +68,7 @@ receivers:
     - https://*.test.com
     cors_allowed_headers:
     - ExampleHeader
+    cors_max_age: 7200
     endpoint: 0.0.0.0:55690
     protocols:
       http:

--- a/config/confighttp/README.md
+++ b/config/confighttp/README.md
@@ -57,13 +57,15 @@ will not be enabled.
   [default safelist][cors-headers]. By default, safelist headers and
   `X-Requested-With` will be allowed. To allow any request header, set to
   `["*"]`.
-  - `max_age`: Sets the value of the `Access-Control-Max-Age` header, allowing
-  clients to cache the response to CORS preflight requests.
+  - `max_age`: Sets the value of the [`Access-Control-Max-Age`][cors-cache]
+  header, allowing clients to cache the response to CORS preflight requests. If
+  not set, browsers use a default of 5 seconds.
 - `endpoint`: Valid value syntax available [here](https://github.com/grpc/grpc/blob/master/doc/naming.md)
 - [`tls`](../configtls/README.md)
 
 [cors]: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS
 [cors-headers]: https://developer.mozilla.org/en-US/docs/Glossary/CORS-safelisted_request_header
+[cors-cache]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Max-Age
 [origin]: https://developer.mozilla.org/en-US/docs/Glossary/Origin
 
 Example:

--- a/config/confighttp/README.md
+++ b/config/confighttp/README.md
@@ -52,11 +52,11 @@ will not be enabled.
   - `allowed_origins`: A list of [origins][origin] allowed to send requests to
   the receiver. An origin may contain a wildcard (`*`) to replace 0 or more
   characters (e.g., `https://*.example.com`). To allow any origin, set to
-  `['*']`. If no origins are listed, CORS will not be enabled.
+  `["*"]`. If no origins are listed, CORS will not be enabled.
   - `allowed_headers`: Allow CORS requests to include headers outside the
   [default safelist][cors-headers]. By default, safelist headers and
   `X-Requested-With` will be allowed. To allow any request header, set to
-  `['*']`.
+  `["*"]`.
   - `max_age`: Sets the value of the `Access-Control-Max-Age` header, allowing
   clients to cache the response to CORS preflight requests.
 - `endpoint`: Valid value syntax available [here](https://github.com/grpc/grpc/blob/master/doc/naming.md)
@@ -76,7 +76,7 @@ receivers:
         - https://foo.bar.com
         - https://*.test.com
       allowed_headers:
-        - ExampleHeader
+        - Example-Header
       max_age: 7200
     endpoint: 0.0.0.0:55690
     protocols:

--- a/config/confighttp/confighttp.go
+++ b/config/confighttp/confighttp.go
@@ -185,22 +185,8 @@ type HTTPServerSettings struct {
 	// TLSSetting struct exposes TLS client configuration.
 	TLSSetting *configtls.TLSServerSetting `mapstructure:"tls, omitempty"`
 
-	// CorsOrigins are the allowed CORS origins for HTTP/JSON requests to grpc-gateway adapter
-	// for the OTLP receiver. See github.com/rs/cors
-	// An empty list means that CORS is not enabled at all. A wildcard (*) can be
-	// used to match any origin or one or more characters of an origin.
-	CorsOrigins []string `mapstructure:"cors_allowed_origins"`
-
-	// CorsHeaders are the allowed CORS headers for HTTP/JSON requests to grpc-gateway adapter
-	// for the OTLP receiver. See github.com/rs/cors
-	// CORS needs to be enabled first by providing a non-empty list in CorsOrigins
-	// A wildcard (*) can be used to match any header.
-	CorsHeaders []string `mapstructure:"cors_allowed_headers"`
-
-	// CorsMaxAge allows browsers to cache CORS preflight responses. It sets
-	// the Access-Control-Max-Age header. See github.com/rs/cors
-	// CORS needs to be enabled first by providing a non-empty list in CorsOrigins.
-	CorsMaxAge int `mapstructure:"cors_max_age"`
+	// CORS configures the server for HTTP cross-origin request sharing (CORS).
+	CORS *CORSSettings `mapstructure:"cors,omitempty"`
 }
 
 // ToListener creates a net.Listener.
@@ -251,12 +237,12 @@ func (hss *HTTPServerSettings) ToServer(_ component.Host, settings component.Tel
 		middleware.WithErrorHandler(serverOpts.errorHandler),
 	)
 
-	if len(hss.CorsOrigins) > 0 {
+	if hss.CORS != nil && len(hss.CORS.AllowedOrigins) > 0 {
 		co := cors.Options{
-			AllowedOrigins:   hss.CorsOrigins,
+			AllowedOrigins:   hss.CORS.AllowedOrigins,
 			AllowCredentials: true,
-			AllowedHeaders:   hss.CorsHeaders,
-			MaxAge:           hss.CorsMaxAge,
+			AllowedHeaders:   hss.CORS.AllowedHeaders,
+			MaxAge:           hss.CORS.MaxAge,
 		}
 		handler = cors.New(co).Handler(handler)
 	}
@@ -278,4 +264,24 @@ func (hss *HTTPServerSettings) ToServer(_ component.Host, settings component.Tel
 	return &http.Server{
 		Handler: handler,
 	}, nil
+}
+
+// CORSSettings configures a receiver for HTTP cross-origin request sharing (CORS).
+// See the underlying https://github.com/rs/cors package for details.
+type CORSSettings struct {
+	// AllowedOrigins sets the allowed values of the Origin header for
+	// HTTP/JSON requests to an OTLP receiver. An origin may contain a
+	// wildcard (*) to replace 0 or more characters (e.g.,
+	// "http://*.domain.com", or "*" to allow any origin).
+	AllowedOrigins []string `mapstructure:"allowed_origins"`
+
+	// AllowedHeaders sets the value of the Access-Control-Allow-Headers
+	// response header. If not specified or blank, no such header will be
+	// sent in response to CORS requests.
+	AllowedHeaders []string `mapstructure:"allowed_headers,omitempty"`
+
+	// MaxAge sets the value of the Access-Control-Max-Age response header.
+	// Set it to the number of seconds that browsers should cache a CORS
+	// preflight response for.
+	MaxAge int `mapstructure:"max_age,omitempty"`
 }

--- a/config/confighttp/confighttp.go
+++ b/config/confighttp/confighttp.go
@@ -196,6 +196,11 @@ type HTTPServerSettings struct {
 	// CORS needs to be enabled first by providing a non-empty list in CorsOrigins
 	// A wildcard (*) can be used to match any header.
 	CorsHeaders []string `mapstructure:"cors_allowed_headers"`
+
+	// CorsMaxAge allows browsers to cache CORS preflight responses. It sets
+	// the Access-Control-Max-Age header. See github.com/rs/cors
+	// CORS needs to be enabled first by providing a non-empty list in CorsOrigins.
+	CorsMaxAge int `mapstructure:"cors_max_age"`
 }
 
 // ToListener creates a net.Listener.
@@ -251,6 +256,7 @@ func (hss *HTTPServerSettings) ToServer(_ component.Host, settings component.Tel
 			AllowedOrigins:   hss.CorsOrigins,
 			AllowCredentials: true,
 			AllowedHeaders:   hss.CorsHeaders,
+			MaxAge:           hss.CorsMaxAge,
 		}
 		handler = cors.New(co).Handler(handler)
 	}

--- a/config/confighttp/confighttp.go
+++ b/config/confighttp/confighttp.go
@@ -185,7 +185,7 @@ type HTTPServerSettings struct {
 	// TLSSetting struct exposes TLS client configuration.
 	TLSSetting *configtls.TLSServerSetting `mapstructure:"tls, omitempty"`
 
-	// CORS configures the server for HTTP cross-origin request sharing (CORS).
+	// CORS configures the server for HTTP cross-origin resource sharing (CORS).
 	CORS *CORSSettings `mapstructure:"cors,omitempty"`
 }
 
@@ -266,7 +266,7 @@ func (hss *HTTPServerSettings) ToServer(_ component.Host, settings component.Tel
 	}, nil
 }
 
-// CORSSettings configures a receiver for HTTP cross-origin request sharing (CORS).
+// CORSSettings configures a receiver for HTTP cross-origin resource sharing (CORS).
 // See the underlying https://github.com/rs/cors package for details.
 type CORSSettings struct {
 	// AllowedOrigins sets the allowed values of the Origin header for
@@ -275,9 +275,11 @@ type CORSSettings struct {
 	// "http://*.domain.com", or "*" to allow any origin).
 	AllowedOrigins []string `mapstructure:"allowed_origins"`
 
-	// AllowedHeaders sets the value of the Access-Control-Allow-Headers
-	// response header. If not specified or blank, no such header will be
-	// sent in response to CORS requests.
+	// AllowedHeaders sets what headers will be allowed in CORS requests.
+	// The Accept, Accept-Language, Content-Type, and Content-Language
+	// headers are implicitly allowed. If no headers are listed,
+	// X-Requested-With will also be accepted by default. Include "*" to
+	// allow any request header.
 	AllowedHeaders []string `mapstructure:"allowed_headers,omitempty"`
 
 	// MaxAge sets the value of the Access-Control-Max-Age response header.

--- a/config/confighttp/confighttp_test.go
+++ b/config/confighttp/confighttp_test.go
@@ -529,10 +529,12 @@ func TestHttpCors(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			hss := &HTTPServerSettings{
-				Endpoint:    "localhost:0",
-				CorsOrigins: tt.CorsOrigins,
-				CorsHeaders: tt.CorsHeaders,
-				CorsMaxAge:  tt.CorsMaxAge,
+				Endpoint: "localhost:0",
+				CORS: &CORSSettings{
+					AllowedOrigins: tt.CorsOrigins,
+					AllowedHeaders: tt.CorsHeaders,
+					MaxAge:         tt.CorsMaxAge,
+				},
 			}
 
 			ln, err := hss.ToListener()
@@ -576,8 +578,8 @@ func TestHttpCors(t *testing.T) {
 
 func TestHttpCorsInvalidSettings(t *testing.T) {
 	hss := &HTTPServerSettings{
-		Endpoint:    "localhost:0",
-		CorsHeaders: []string{"some-header"},
+		Endpoint: "localhost:0",
+		CORS:     &CORSSettings{AllowedHeaders: []string{"some-header"}},
 	}
 
 	// This effectively does not enable CORS but should also not cause an error

--- a/receiver/otlpreceiver/README.md
+++ b/receiver/otlpreceiver/README.md
@@ -65,4 +65,5 @@ receivers:
         - https://*.example.com
         cors_allowed_headers:
         - TestHeader
+        cors_max_age: 7200
 ```

--- a/receiver/otlpreceiver/README.md
+++ b/receiver/otlpreceiver/README.md
@@ -48,10 +48,17 @@ To write traces with HTTP/JSON, `POST` to `[address]/v1/traces` for traces,
 to `[address]/v1/metrics` for metrics, to `[address]/v1/logs` for logs. The default
 port is `4318`.
 
-The HTTP/JSON endpoint can also optionally configure
-[CORS](https://fetch.spec.whatwg.org/#cors-protocol), which is enabled by
-specifying a list of allowed CORS origins in the `cors_allowed_origins`
-and optionally headers in `cors_allowed_headers`:
+### CORS (Cross-origin resource sharing)
+
+The HTTP/JSON endpoint can also optionally configure [CORS][cors] under `cors:`.
+Specify what origins (or wildcard patterns) to allow requests from as
+`allowed_origins`. To allow additional request headers outside of the [default
+safelist][cors-headers], set `allowed_headers`. Browsers can be instructed to
+[cache][cors-max-age] responses to preflight requests by setting `max_age`.
+
+[cors]: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS
+[cors-headers]: https://developer.mozilla.org/en-US/docs/Glossary/CORS-safelisted_request_header
+[cors-max-age]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Max-Age
 
 ```yaml
 receivers:
@@ -59,11 +66,12 @@ receivers:
     protocols:
       http:
         endpoint: "localhost:4318"
-        cors_allowed_origins:
-        - http://test.com
-        # Origins can have wildcards with *, use * by itself to match any origin.
-        - https://*.example.com
-        cors_allowed_headers:
-        - TestHeader
-        cors_max_age: 7200
+        cors:
+          allowed_origins:
+            - http://test.com
+            # Origins can have wildcards with *, use * by itself to match any origin.
+            - https://*.example.com
+          allowed_headers:
+            - Example-Header
+          max_age: 7200
 ```

--- a/receiver/otlpreceiver/config.md
+++ b/receiver/otlpreceiver/config.md
@@ -75,14 +75,14 @@ Config defines configuration for OTLP receiver.
 | ---- | ---- | ------- | ---- |
 | endpoint |string| 0.0.0.0:4318 | Endpoint configures the listening address for the server.  |
 | tls |[configtls-TLSServerSetting](#configtls-TLSServerSetting)| <no value> | TLSSetting struct exposes TLS client configuration.  |
-| cors |[confighttp-CORSSettings](#confighttp-CORSSettings)| <no value> | CORSSettings configures a receiver for HTTP cross-origin request sharing (CORS). |
+| cors |[confighttp-CORSSettings](#confighttp-CORSSettings)| <no value> | CORSSettings configures a receiver for HTTP cross-origin resource sharing (CORS). |
 
-### confighttp-HTTPServerSettings
+### confighttp-CORSSettings
 
 | Name | Type | Default | Docs |
 | ---- | ---- | ------- | ---- |
 | allowed_origins |[]string| <no value> | AllowedOrigins sets the allowed values of the Origin header for HTTP/JSON requests to an OTLP receiver. An origin may contain a wildcard (`*`) to replace 0 or more characters (e.g., `"https://*.example.com"`, or `"*"` to allow any origin). |
-| allowed_headers |[]string| <no value> | AllowedHeaders sets the value of the Access-Control-Allow-Headers response header. If not specified or blank, no such header will be sent in response to CORS requests. Include `"*"` to allow any request header. |
+| allowed_headers |[]string| <no value> | AllowedHeaders sets what headers will be allowed in CORS requests. The Accept, Accept-Language, Content-Type, and Content-Language headers are implicitly allowed. If no headers are listed, X-Requested-With will also be accepted by default. Include `"*"` to allow any request header. |
 | max_age |int| <no value> | MaxAge sets the value of the Access-Control-Max-Age response header.  Set it to the number of seconds that browsers should cache a CORS preflight response for. |
 
 ### configtls-TLSServerSetting

--- a/receiver/otlpreceiver/config.md
+++ b/receiver/otlpreceiver/config.md
@@ -77,6 +77,7 @@ Config defines configuration for OTLP receiver.
 | tls |[configtls-TLSServerSetting](#configtls-TLSServerSetting)| <no value> | TLSSetting struct exposes TLS client configuration.  |
 | cors_allowed_origins |[]string| <no value> | CorsOrigins are the allowed CORS origins for HTTP/JSON requests to grpc-gateway adapter for the OTLP receiver. See github.com/rs/cors An empty list means that CORS is not enabled at all. A wildcard (*) can be used to match any origin or one or more characters of an origin.  |
 | cors_allowed_headers |[]string| <no value> | CorsHeaders are the allowed CORS headers for HTTP/JSON requests to grpc-gateway adapter for the OTLP receiver. See github.com/rs/cors CORS needs to be enabled first by providing a non-empty list in CorsOrigins A wildcard (*) can be used to match any header.  |
+| cors_max_age |int| <no value> | CorsMaxAge allows browsers to cache CORS preflight responses. It sets the Access-Control-Max-Age header. See github.com/rs/cors CORS needs to be enabled first by providing a non-empty list in CorsOrigins. |
 
 ### configtls-TLSServerSetting
 

--- a/receiver/otlpreceiver/config.md
+++ b/receiver/otlpreceiver/config.md
@@ -75,9 +75,15 @@ Config defines configuration for OTLP receiver.
 | ---- | ---- | ------- | ---- |
 | endpoint |string| 0.0.0.0:4318 | Endpoint configures the listening address for the server.  |
 | tls |[configtls-TLSServerSetting](#configtls-TLSServerSetting)| <no value> | TLSSetting struct exposes TLS client configuration.  |
-| cors_allowed_origins |[]string| <no value> | CorsOrigins are the allowed CORS origins for HTTP/JSON requests to grpc-gateway adapter for the OTLP receiver. See github.com/rs/cors An empty list means that CORS is not enabled at all. A wildcard (*) can be used to match any origin or one or more characters of an origin.  |
-| cors_allowed_headers |[]string| <no value> | CorsHeaders are the allowed CORS headers for HTTP/JSON requests to grpc-gateway adapter for the OTLP receiver. See github.com/rs/cors CORS needs to be enabled first by providing a non-empty list in CorsOrigins A wildcard (*) can be used to match any header.  |
-| cors_max_age |int| <no value> | CorsMaxAge allows browsers to cache CORS preflight responses. It sets the Access-Control-Max-Age header. See github.com/rs/cors CORS needs to be enabled first by providing a non-empty list in CorsOrigins. |
+| cors |[confighttp-CORSSettings](#confighttp-CORSSettings)| <no value> | CORSSettings configures a receiver for HTTP cross-origin request sharing (CORS). |
+
+### confighttp-HTTPServerSettings
+
+| Name | Type | Default | Docs |
+| ---- | ---- | ------- | ---- |
+| allowed_origins |[]string| <no value> | AllowedOrigins sets the allowed values of the Origin header for HTTP/JSON requests to an OTLP receiver. An origin may contain a wildcard (`*`) to replace 0 or more characters (e.g., `"https://*.example.com"`, or `"*"` to allow any origin). |
+| allowed_headers |[]string| <no value> | AllowedHeaders sets the value of the Access-Control-Allow-Headers response header. If not specified or blank, no such header will be sent in response to CORS requests. Include `"*"` to allow any request header. |
+| max_age |int| <no value> | MaxAge sets the value of the Access-Control-Max-Age response header.  Set it to the number of seconds that browsers should cache a CORS preflight response for. |
 
 ### configtls-TLSServerSetting
 

--- a/receiver/otlpreceiver/config_test.go
+++ b/receiver/otlpreceiver/config_test.go
@@ -157,6 +157,7 @@ func TestLoadConfig(t *testing.T) {
 				HTTP: &confighttp.HTTPServerSettings{
 					Endpoint:    "0.0.0.0:4318",
 					CorsOrigins: []string{"https://*.test.com", "https://test.com"},
+					CorsMaxAge:  7200,
 				},
 			},
 		})

--- a/receiver/otlpreceiver/config_test.go
+++ b/receiver/otlpreceiver/config_test.go
@@ -155,9 +155,11 @@ func TestLoadConfig(t *testing.T) {
 			ReceiverSettings: config.NewReceiverSettings(config.NewComponentIDWithName(typeStr, "cors")),
 			Protocols: Protocols{
 				HTTP: &confighttp.HTTPServerSettings{
-					Endpoint:    "0.0.0.0:4318",
-					CorsOrigins: []string{"https://*.test.com", "https://test.com"},
-					CorsMaxAge:  7200,
+					Endpoint: "0.0.0.0:4318",
+					CORS: &confighttp.CORSSettings{
+						AllowedOrigins: []string{"https://*.test.com", "https://test.com"},
+						MaxAge:         7200,
+					},
 				},
 			},
 		})
@@ -167,9 +169,11 @@ func TestLoadConfig(t *testing.T) {
 			ReceiverSettings: config.NewReceiverSettings(config.NewComponentIDWithName(typeStr, "corsheader")),
 			Protocols: Protocols{
 				HTTP: &confighttp.HTTPServerSettings{
-					Endpoint:    "0.0.0.0:4318",
-					CorsOrigins: []string{"https://*.test.com", "https://test.com"},
-					CorsHeaders: []string{"ExampleHeader"},
+					Endpoint: "0.0.0.0:4318",
+					CORS: &confighttp.CORSSettings{
+						AllowedOrigins: []string{"https://*.test.com", "https://test.com"},
+						AllowedHeaders: []string{"ExampleHeader"},
+					},
 				},
 			},
 		})

--- a/receiver/otlpreceiver/testdata/config.yaml
+++ b/receiver/otlpreceiver/testdata/config.yaml
@@ -76,8 +76,9 @@ receivers:
     protocols:
       http:
         cors_allowed_origins:
-        - https://*.test.com # Wildcard subdomain. Allows domains like https://www.test.com and https://foo.test.com but not https://wwwtest.com.
-        - https://test.com # Fully qualified domain name. Allows https://test.com only.
+          - https://*.test.com # Wildcard subdomain. Allows domains like https://www.test.com and https://foo.test.com but not https://wwwtest.com.
+          - https://test.com # Fully qualified domain name. Allows https://test.com only.
+        cors_max_age: 7200
   # The following entry demonstrates how to use CORS Header configuration.
   otlp/corsheader:
     protocols:

--- a/receiver/otlpreceiver/testdata/config.yaml
+++ b/receiver/otlpreceiver/testdata/config.yaml
@@ -75,19 +75,21 @@ receivers:
   otlp/cors:
     protocols:
       http:
-        cors_allowed_origins:
-          - https://*.test.com # Wildcard subdomain. Allows domains like https://www.test.com and https://foo.test.com but not https://wwwtest.com.
-          - https://test.com # Fully qualified domain name. Allows https://test.com only.
-        cors_max_age: 7200
+        cors:
+          allowed_origins:
+            - https://*.test.com # Wildcard subdomain. Allows domains like https://www.test.com and https://foo.test.com but not https://wwwtest.com.
+            - https://test.com # Fully qualified domain name. Allows https://test.com only.
+          max_age: 7200
   # The following entry demonstrates how to use CORS Header configuration.
   otlp/corsheader:
     protocols:
       http:
-        cors_allowed_origins:
-          - https://*.test.com # Wildcard subdomain. Allows domains like https://www.test.com and https://foo.test.com but not https://wwwtest.com.
-          - https://test.com # Fully qualified domain name. Allows https://test.com only.
-        cors_allowed_headers:
-          - ExampleHeader
+        cors:
+          allowed_origins:
+            - https://*.test.com # Wildcard subdomain. Allows domains like https://www.test.com and https://foo.test.com but not https://wwwtest.com.
+            - https://test.com # Fully qualified domain name. Allows https://test.com only.
+          allowed_headers:
+            - ExampleHeader
 processors:
   nop:
 


### PR DESCRIPTION
**Description:** Add support for sending `Access-Control-Max-Age` along with CORS preflight responses.

I have OpenTelemetry Collector deployed, with an OLTP HTTP endpoint configured to accept traces directly from browser clients. I noticed there was no `Access-Control-Max-Age` sent in CORS preflight responses from the collector, meaning the browser needs to send a new preflight request every time the client submits traces to the collector.

**Testing:** I found existing CORS tests, and updated them to exercise the new `cors_max_age` property and check for a `Access-Control-Max-Age` response header.

**Documentation:** I found documentation for the existing CORS receiver properties and added entries for the new `cors_max_age` property.
