### PR TITLE
set grpc logger to collectors logger 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/gogo/protobuf v1.3.2
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/mux v1.8.0
+	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/knadh/koanf v1.3.3
 	github.com/magiconair/properties v1.8.5
 	github.com/mitchellh/mapstructure v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -214,6 +214,8 @@ github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5m
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
+github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 h1:+9834+KizmvFV7pXQGSXQTsaWhq2GjuNUt0aUU0YBYw=
+github.com/grpc-ecosystem/go-grpc-middleware v1.3.0/go.mod h1:z0ButlSOZa5vEBq9m2m2hlwIgKw+rp3sdCBRoJY+30Y=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=
 github.com/hashicorp/consul/sdk v0.1.1/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
@@ -329,6 +331,7 @@ github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQ
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.8.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
+github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.7.0/go.mod h1:vwGMzjaWMwyfHwgIBhI2YUM4fB6nL6lVAvS1LBMMhTE=
@@ -454,14 +457,17 @@ go.opentelemetry.io/otel/sdk/metric v0.25.0/go.mod h1:G4xzj4LvC6xDDSsVXpvRVclQCb
 go.opentelemetry.io/otel/trace v1.2.0 h1:Ys3iqbqZhcf28hHzrm5WAquMkDHNZTUkw7KHbuNjej0=
 go.opentelemetry.io/otel/trace v1.2.0/go.mod h1:N5FLswTubnxKxOJHM7XZC074qpeEdLy3CgAVsdMucK0=
 go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=
+go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/atomic v1.9.0 h1:ECmE8Bn/WFTYwEW/bpKD3M8VtR/zQVbavAoalC1PYyE=
 go.uber.org/atomic v1.9.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/goleak v1.1.11-0.20210813005559-691160354723 h1:sHOAIxRGBp443oHZIPB+HsUGaksVCXVQENPxwTfQdH4=
 go.uber.org/goleak v1.1.11-0.20210813005559-691160354723/go.mod h1:cwTWslyiVhfpKIDGSZEM2HlOvcqm+tG4zioyIeLoqMQ=
+go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/multierr v1.6.0/go.mod h1:cdWPpRnG4AhwMwsgIHip0KRBQjJy5kYEpYjJxpXp9iU=
 go.uber.org/multierr v1.7.0 h1:zaiO/rmgFjbmCXdSYJWQcdvOCsthmdaHfr3Gm2Kx4Ec=
 go.uber.org/multierr v1.7.0/go.mod h1:7EAYxJLBy9rStEaz58O2t4Uvip6FSURkq8/ppBp95ak=
+go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 go.uber.org/zap v1.17.0/go.mod h1:MXVU+bhUf/A7Xi2HNOnopQOrmycQ5Ih87HtOu4q5SSo=
 go.uber.org/zap v1.19.1 h1:ue41HOKd1vGURxrmeKIgELGb3jPW9DMUDGtsinblHwI=
 go.uber.org/zap v1.19.1/go.mod h1:j3DNczoxDZroyBnOT1L/Q79cfUMGZxlv/9dzN7SM1rI=
@@ -759,6 +765,7 @@ google.golang.org/genproto v0.0.0-20200228133532-8c2c7df3a383/go.mod h1:55QSHmfG
 google.golang.org/genproto v0.0.0-20200305110556-506484158171/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
 google.golang.org/genproto v0.0.0-20200312145019-da6875a35672/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
 google.golang.org/genproto v0.0.0-20200331122359-1ee6d9798940/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
+google.golang.org/genproto v0.0.0-20200423170343-7949de9c1215/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
 google.golang.org/genproto v0.0.0-20200430143042-b979b6f78d84/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
 google.golang.org/genproto v0.0.0-20200511104702-f5ebc3bea380/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
 google.golang.org/genproto v0.0.0-20200513103714-09dca8ec2884/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=

--- a/service/collector.go
+++ b/service/collector.go
@@ -26,6 +26,11 @@ import (
 	"sync/atomic"
 	"syscall"
 
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config/configunmarshaler"
+	"go.opentelemetry.io/collector/extension/ballastextension"
+	"go.opentelemetry.io/collector/service/internal"
+	"go.opentelemetry.io/collector/service/internal/telemetrylogs"
 	"go.opentelemetry.io/contrib/zpages"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/metric"
@@ -33,13 +38,6 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/multierr"
 	"go.uber.org/zap"
-	"google.golang.org/grpc/grpclog"
-
-	"go.opentelemetry.io/collector/component"
-	"go.opentelemetry.io/collector/config/configunmarshaler"
-	"go.opentelemetry.io/collector/extension/ballastextension"
-	"go.opentelemetry.io/collector/service/internal"
-	"go.opentelemetry.io/collector/service/internal/telemetrylogs"
 )
 
 // State defines Collector's state.
@@ -187,9 +185,6 @@ func (col *Collector) setupConfigurationComponents(ctx context.Context) error {
 	if col.logger, err = telemetrylogs.NewLogger(col.cfgW.cfg.Service.Telemetry.Logs, col.set.LoggingOptions); err != nil {
 		return fmt.Errorf("failed to get logger: %w", err)
 	}
-
-	// replace grpc logger with zap logger
-	grpclog.SetLoggerV2(telemetrylogs.NewGRPCLogger(col.logger, col.cfgW.cfg.Service.Telemetry.Logs.Level))
 
 	col.logger.Info("Applying configuration...")
 

--- a/service/collector.go
+++ b/service/collector.go
@@ -26,6 +26,7 @@ import (
 	"sync/atomic"
 	"syscall"
 
+	grpc_zap "github.com/grpc-ecosystem/go-grpc-middleware/logging/zap"
 	"go.opentelemetry.io/contrib/zpages"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/metric"
@@ -186,6 +187,9 @@ func (col *Collector) setupConfigurationComponents(ctx context.Context) error {
 	if col.logger, err = telemetrylogs.NewLogger(col.cfgW.cfg.Service.Telemetry.Logs, col.set.LoggingOptions); err != nil {
 		return fmt.Errorf("failed to get logger: %w", err)
 	}
+
+	grpcLogger := telemetrylogs.NewGRPCLogger(col.logger, col.cfgW.cfg.Service.Telemetry.Logs.Level)
+	grpc_zap.ReplaceGrpcLoggerV2(grpcLogger)
 
 	col.logger.Info("Applying configuration...")
 

--- a/service/collector.go
+++ b/service/collector.go
@@ -26,7 +26,6 @@ import (
 	"sync/atomic"
 	"syscall"
 
-	grpcZap "github.com/grpc-ecosystem/go-grpc-middleware/logging/zap"
 	"go.opentelemetry.io/contrib/zpages"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/metric"
@@ -34,6 +33,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/multierr"
 	"go.uber.org/zap"
+	"google.golang.org/grpc/grpclog"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configunmarshaler"
@@ -188,8 +188,8 @@ func (col *Collector) setupConfigurationComponents(ctx context.Context) error {
 		return fmt.Errorf("failed to get logger: %w", err)
 	}
 
-	// replace grpc logger with collector logger
-	grpcZap.ReplaceGrpcLoggerV2(col.logger)
+	// replace grpc logger with zap logger
+	grpclog.SetLoggerV2(telemetrylogs.NewGRPCLogger(col.logger, col.cfgW.cfg.Service.Telemetry.Logs.Level))
 
 	col.logger.Info("Applying configuration...")
 

--- a/service/collector.go
+++ b/service/collector.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"go.uber.org/zap/zapgrpc"
 	"os"
 	"os/signal"
 	"runtime"
@@ -35,6 +34,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/multierr"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapgrpc"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configunmarshaler"
@@ -194,7 +194,7 @@ func (col *Collector) setupConfigurationComponents(ctx context.Context) error {
 
 	grpcLogger := telemetrylogs.NewGRPCLogger(col.logger, col.cfgW.cfg.Service.Telemetry.Logs.Level)
 	gsettable.Set(zapgrpc.NewLogger(grpcLogger))
-	
+
 	col.logger.Info("Applying configuration...")
 
 	col.service, err = newService(&svcSettings{

--- a/service/collector.go
+++ b/service/collector.go
@@ -26,11 +26,6 @@ import (
 	"sync/atomic"
 	"syscall"
 
-	"go.opentelemetry.io/collector/component"
-	"go.opentelemetry.io/collector/config/configunmarshaler"
-	"go.opentelemetry.io/collector/extension/ballastextension"
-	"go.opentelemetry.io/collector/service/internal"
-	"go.opentelemetry.io/collector/service/internal/telemetrylogs"
 	"go.opentelemetry.io/contrib/zpages"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/metric"
@@ -38,6 +33,12 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/multierr"
 	"go.uber.org/zap"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config/configunmarshaler"
+	"go.opentelemetry.io/collector/extension/ballastextension"
+	"go.opentelemetry.io/collector/service/internal"
+	"go.opentelemetry.io/collector/service/internal/telemetrylogs"
 )
 
 // State defines Collector's state.

--- a/service/collector.go
+++ b/service/collector.go
@@ -26,6 +26,7 @@ import (
 	"sync/atomic"
 	"syscall"
 
+	grpcZap "github.com/grpc-ecosystem/go-grpc-middleware/logging/zap"
 	"go.opentelemetry.io/contrib/zpages"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/metric"
@@ -186,6 +187,9 @@ func (col *Collector) setupConfigurationComponents(ctx context.Context) error {
 	if col.logger, err = telemetrylogs.NewLogger(col.cfgW.cfg.Service.Telemetry.Logs, col.set.LoggingOptions); err != nil {
 		return fmt.Errorf("failed to get logger: %w", err)
 	}
+
+	// replace grpc logger with collector logger
+	grpcZap.ReplaceGrpcLoggerV2(col.logger)
 
 	col.logger.Info("Applying configuration...")
 

--- a/service/collector_test.go
+++ b/service/collector_test.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"testing"
 	"time"
@@ -103,8 +104,12 @@ func TestCollector_Start(t *testing.T) {
 	factories, err := defaultcomponents.Components()
 	require.NoError(t, err)
 
+	var mu sync.Mutex
+
 	loggingHookCalled := false
 	hook := func(entry zapcore.Entry) error {
+		mu.Lock()
+		defer mu.Unlock()
 		loggingHookCalled = true
 		return nil
 	}

--- a/service/collector_test.go
+++ b/service/collector_test.go
@@ -23,7 +23,6 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
-	"sync"
 	"syscall"
 	"testing"
 	"time"
@@ -103,13 +102,9 @@ func TestCollector_StartAsGoRoutine(t *testing.T) {
 func TestCollector_Start(t *testing.T) {
 	factories, err := defaultcomponents.Components()
 	require.NoError(t, err)
-
-	var mu sync.Mutex
-
+	
 	loggingHookCalled := false
 	hook := func(entry zapcore.Entry) error {
-		mu.Lock()
-		defer mu.Unlock()
 		loggingHookCalled = true
 		return nil
 	}

--- a/service/internal/telemetrylogs/logger.go
+++ b/service/internal/telemetrylogs/logger.go
@@ -15,12 +15,10 @@
 package telemetrylogs // import "go.opentelemetry.io/collector/service/internal/telemetrylogs"
 
 import (
+	grpc_zap "github.com/grpc-ecosystem/go-grpc-middleware/logging/zap"
+	"go.opentelemetry.io/collector/config"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
-	"go.uber.org/zap/zapgrpc"
-	"google.golang.org/grpc/grpclog"
-
-	"go.opentelemetry.io/collector/config"
 )
 
 func NewLogger(cfg config.ServiceTelemetryLogs, options []zap.Option) (*zap.Logger, error) {
@@ -48,10 +46,11 @@ func NewLogger(cfg config.ServiceTelemetryLogs, options []zap.Option) (*zap.Logg
 		return nil, err
 	}
 
+	grpc_zap.ReplaceGrpcLoggerV2(newGRPCLogger(logger, cfg.Level))
 	return logger, nil
 }
 
-func NewGRPCLogger(logger *zap.Logger, loglevel zapcore.Level) grpclog.LoggerV2 {
+func newGRPCLogger(logger *zap.Logger, loglevel zapcore.Level) *zap.Logger {
 	glogger := logger.WithOptions(zap.WrapCore(func(core zapcore.Core) zapcore.Core {
 		if loglevel == zap.InfoLevel {
 			c, _ := zapcore.NewIncreaseLevelCore(core, loglevel+1)
@@ -59,5 +58,5 @@ func NewGRPCLogger(logger *zap.Logger, loglevel zapcore.Level) grpclog.LoggerV2 
 		}
 		return core
 	}))
-	return zapgrpc.NewLogger(glogger)
+	return glogger
 }

--- a/service/internal/telemetrylogs/logger.go
+++ b/service/internal/telemetrylogs/logger.go
@@ -16,9 +16,10 @@ package telemetrylogs // import "go.opentelemetry.io/collector/service/internal/
 
 import (
 	grpc_zap "github.com/grpc-ecosystem/go-grpc-middleware/logging/zap"
-	"go.opentelemetry.io/collector/config"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+
+	"go.opentelemetry.io/collector/config"
 )
 
 func NewLogger(cfg config.ServiceTelemetryLogs, options []zap.Option) (*zap.Logger, error) {

--- a/service/internal/telemetrylogs/logger.go
+++ b/service/internal/telemetrylogs/logger.go
@@ -15,7 +15,6 @@
 package telemetrylogs // import "go.opentelemetry.io/collector/service/internal/telemetrylogs"
 
 import (
-	grpc_zap "github.com/grpc-ecosystem/go-grpc-middleware/logging/zap"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
@@ -47,7 +46,6 @@ func NewLogger(cfg config.ServiceTelemetryLogs, options []zap.Option) (*zap.Logg
 		return nil, err
 	}
 
-	grpc_zap.ReplaceGrpcLoggerV2(newGRPCLogger(logger, cfg.Level))
 	return logger, nil
 }
 

--- a/service/internal/telemetrylogs/logger.go
+++ b/service/internal/telemetrylogs/logger.go
@@ -49,7 +49,7 @@ func NewLogger(cfg config.ServiceTelemetryLogs, options []zap.Option) (*zap.Logg
 	return logger, nil
 }
 
-func newGRPCLogger(logger *zap.Logger, loglevel zapcore.Level) *zap.Logger {
+func NewGRPCLogger(logger *zap.Logger, loglevel zapcore.Level) *zap.Logger {
 	glogger := logger.WithOptions(zap.WrapCore(func(core zapcore.Core) zapcore.Core {
 		if loglevel == zap.InfoLevel {
 			c, _ := zapcore.NewIncreaseLevelCore(core, loglevel+1)

--- a/service/internal/telemetrylogs/logger.go
+++ b/service/internal/telemetrylogs/logger.go
@@ -17,6 +17,8 @@ package telemetrylogs // import "go.opentelemetry.io/collector/service/internal/
 import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zapgrpc"
+	"google.golang.org/grpc/grpclog"
 
 	"go.opentelemetry.io/collector/config"
 )
@@ -45,5 +47,17 @@ func NewLogger(cfg config.ServiceTelemetryLogs, options []zap.Option) (*zap.Logg
 	if err != nil {
 		return nil, err
 	}
+
 	return logger, nil
+}
+
+func NewGRPCLogger(logger *zap.Logger, loglevel zapcore.Level) grpclog.LoggerV2 {
+	glogger := logger.WithOptions(zap.WrapCore(func(core zapcore.Core) zapcore.Core {
+		if loglevel == zap.InfoLevel {
+			c, _ := zapcore.NewIncreaseLevelCore(core, loglevel+1)
+			return c
+		}
+		return core
+	}))
+	return zapgrpc.NewLogger(glogger)
 }

--- a/service/internal/telemetrylogs/logger_test.go
+++ b/service/internal/telemetrylogs/logger_test.go
@@ -80,6 +80,16 @@ func TestGRPCLogger(t *testing.T) {
 			logger, err := NewLogger(test.cfg, []zap.Option{hook})
 			assert.NoError(t, err)
 
+			t.Cleanup(func() {
+				defaultLogger, _ := NewLogger(config.ServiceTelemetryLogs{
+					Level:       zapcore.InfoLevel,
+					Development: false,
+					Encoding:    "console",
+				}, nil)
+
+				grpc_zap.ReplaceGrpcLoggerV2(newGRPCLogger(defaultLogger, zapcore.InfoLevel))
+			})
+
 			glogger := newGRPCLogger(logger, test.cfg.Level)
 			grpc_zap.ReplaceGrpcLoggerV2(glogger)
 			// write a grpc log

--- a/service/internal/telemetrylogs/logger_test.go
+++ b/service/internal/telemetrylogs/logger_test.go
@@ -76,12 +76,9 @@ func TestGRPCLogger(t *testing.T) {
 			})
 
 			// create new collector logger
-			logger, err := NewLogger(test.cfg, []zap.Option{hook})
+			_, err := NewLogger(test.cfg, []zap.Option{hook})
 			assert.NoError(t, err)
 
-			// create new grpc logger from collector logger
-			glogger := NewGRPCLogger(logger, test.cfg.Level)
-			grpclog.SetLoggerV2(glogger)
 
 			// write a grpc log
 			grpclog.Info(test.name)

--- a/service/internal/telemetrylogs/logger_test.go
+++ b/service/internal/telemetrylogs/logger_test.go
@@ -1,0 +1,95 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package telemetrylogs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"google.golang.org/grpc/grpclog"
+
+	"go.opentelemetry.io/collector/config"
+)
+
+func TestGRPCLogger(t *testing.T) {
+	tests := []struct {
+		name       string
+		cfg        config.ServiceTelemetryLogs
+		infoLogged bool
+		warnLogged bool
+	}{
+		{
+			"collector_info_level_grpc_log_warn",
+			config.ServiceTelemetryLogs{
+				Level:    zapcore.InfoLevel,
+				Encoding: "console",
+			},
+			false,
+			true,
+		},
+		{
+			"collector_debug_level_grpc_log_debug",
+			config.ServiceTelemetryLogs{
+				Level:    zapcore.DebugLevel,
+				Encoding: "console",
+			},
+			true,
+			true,
+		},
+		{
+			"collector_warn_level_grpc_log_warn",
+			config.ServiceTelemetryLogs{
+				Development: false, // this must set the grpc logger to logger
+				Level:       zapcore.WarnLevel,
+				Encoding:    "console",
+			},
+			false,
+			true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			expectedInfo, expectedWarn := false, false
+
+			hook := zap.Hooks(func(entry zapcore.Entry) error {
+				switch entry.Level {
+				case zapcore.InfoLevel:
+					expectedInfo = true
+				case zapcore.WarnLevel:
+					expectedWarn = true
+				}
+				return nil
+			})
+
+			// create new collector logger
+			logger, err := NewLogger(test.cfg, []zap.Option{hook})
+			assert.NoError(t, err)
+
+			// create new grpc logger from collector logger
+			glogger := NewGRPCLogger(logger, test.cfg.Level)
+			grpclog.SetLoggerV2(glogger)
+
+			// write a grpc log
+			grpclog.Info(test.name)
+			grpclog.Warning(test.name)
+
+			// test whether the grpc log has been recorded from collector logger
+			assert.Equal(t, expectedInfo, test.infoLogged)
+			assert.Equal(t, expectedWarn, test.warnLogged)
+		})
+	}
+}

--- a/service/internal/telemetrylogs/logger_test.go
+++ b/service/internal/telemetrylogs/logger_test.go
@@ -87,10 +87,10 @@ func TestGRPCLogger(t *testing.T) {
 					Encoding:    "console",
 				}, nil)
 
-				grpc_zap.ReplaceGrpcLoggerV2(newGRPCLogger(defaultLogger, zapcore.InfoLevel))
+				grpc_zap.ReplaceGrpcLoggerV2(NewGRPCLogger(defaultLogger, zapcore.InfoLevel))
 			})
 
-			glogger := newGRPCLogger(logger, test.cfg.Level)
+			glogger := NewGRPCLogger(logger, test.cfg.Level)
 			grpc_zap.ReplaceGrpcLoggerV2(glogger)
 			// write a grpc log
 			grpclog.Info(test.name)

--- a/service/internal/telemetrylogs/logger_test.go
+++ b/service/internal/telemetrylogs/logger_test.go
@@ -79,7 +79,6 @@ func TestGRPCLogger(t *testing.T) {
 			_, err := NewLogger(test.cfg, []zap.Option{hook})
 			assert.NoError(t, err)
 
-
 			// write a grpc log
 			grpclog.Info(test.name)
 			grpclog.Warning(test.name)


### PR DESCRIPTION
**Description:** 

 Adding a feature - This feature sets the grpc logger to one derived from collector logger configuration and enables users to control grpc logs. 


- In the case of collector default log level (INFO) gRPC logs min level is set to WARN (to reduce the log traffic) sharing rest of collector's logger configuration 

```bash
$ ./bin/cmd-otelcol --config ./bin/config.yaml
2021-11-30T16:47:38.293-0800	info	service/collector.go:201	Applying configuration...
2021-11-30T16:47:38.294-0800	info	builder/exporters_builder.go:254	Exporter was built.	{"kind": "exporter", "name": "otlp"}
2021-11-30T16:47:38.294-0800	info	builder/exporters_builder.go:254	Exporter was built.	{"kind": "exporter", "name": "logging"}
2021-11-30T16:47:38.295-0800	info	builder/pipelines_builder.go:222	Pipeline was built.	{"name": "pipeline", "name": "metrics"}
2021-11-30T16:47:38.295-0800	info	builder/pipelines_builder.go:222	Pipeline was built.	{"name": "pipeline", "name": "traces"}
2021-11-30T16:47:38.295-0800	info	builder/receivers_builder.go:224	Receiver was built.	{"kind": "receiver", "name": "otlp", "datatype": "traces"}
2021-11-30T16:47:38.295-0800	info	builder/receivers_builder.go:224	Receiver was built.	{"kind": "receiver", "name": "otlp", "datatype": "metrics"}
2021-11-30T16:47:38.295-0800	info	service/service.go:86	Starting extensions...
2021-11-30T16:47:38.295-0800	info	service/service.go:91	Starting exporters...
2021-11-30T16:47:38.295-0800	info	builder/exporters_builder.go:40	Exporter is starting...	{"kind": "exporter", "name": "logging"}
2021-11-30T16:47:38.295-0800	info	builder/exporters_builder.go:48	Exporter started.	{"kind": "exporter", "name": "logging"}
2021-11-30T16:47:38.295-0800	info	builder/exporters_builder.go:40	Exporter is starting...	{"kind": "exporter", "name": "otlp"}
2021-11-30T16:47:38.295-0800	info	builder/exporters_builder.go:48	Exporter started.	{"kind": "exporter", "name": "otlp"}
2021-11-30T16:47:38.295-0800	info	service/service.go:96	Starting processors...
2021-11-30T16:47:38.295-0800	info	builder/pipelines_builder.go:54	Pipeline is starting...	{"name": "pipeline", "name": "metrics"}
2021-11-30T16:47:38.295-0800	info	builder/pipelines_builder.go:65	Pipeline is started.	{"name": "pipeline", "name": "metrics"}
2021-11-30T16:47:38.295-0800	info	builder/pipelines_builder.go:54	Pipeline is starting...	{"name": "pipeline", "name": "traces"}
2021-11-30T16:47:38.295-0800	info	builder/pipelines_builder.go:65	Pipeline is started.	{"name": "pipeline", "name": "traces"}
2021-11-30T16:47:38.295-0800	info	service/service.go:101	Starting receivers...
2021-11-30T16:47:38.295-0800	info	builder/receivers_builder.go:68	Receiver is starting...	{"kind": "receiver", "name": "otlp"}
2021-11-30T16:47:38.295-0800	info	otlpreceiver/otlp.go:68	Starting GRPC server on endpoint 0.0.0.0:4317	{"kind": "receiver", "name": "otlp"}
2021-11-30T16:47:38.302-0800	info	builder/receivers_builder.go:73	Receiver started.	{"kind": "receiver", "name": "otlp"}
2021-11-30T16:47:38.302-0800	info	service/telemetry.go:92	Setting up own telemetry...
2021-11-30T16:47:38.310-0800	info	service/telemetry.go:116	Serving Prometheus metrics	{"address": ":8888", "level": "basic", "service.instance.id": "a8caf36a-00df-407e-b356-23569252e525", "service.version": "latest"}
2021-11-30T16:47:38.310-0800	info	service/collector.go:250	Starting cmd-otelcol...	{"Version": "0.40.0-dev", "NumCPU": 12}
2021-11-30T16:47:38.310-0800	info	service/collector.go:138	Everything is ready. Begin running and processing data.
2021-11-30T16:47:38.384-0800	warn	zapgrpc/zapgrpc.go:191	[core] grpc: addrConn.createTransport failed to connect to {otelcol:4317 otelcol:4317 <nil> <nil> 0 <nil>}. Err: connection error: desc = "transport: Error while dialing dial tcp: lookup otelcol: no such host"
2021-11-30T16:47:42.912-0800	INFO	loggingexporter/logging_exporter.go:40	TracesExporter	{"#spans": 200}
```


- for all other levels - gRPC logs min log level takes whatever is set for collector log sharing rest of collector's logger configuration.   for example

```yaml
service:
  telemetry:
    logs:
      level: "DEBUG"
      encoding: "console"
  pipelines:
    traces:
      receivers: [otlp]
      processors: [batch]
      exporters: [logging, otlp]
```

in non development made

```bash 

$ ./bin/cmd-otelcol --config ./bin/config.yaml
2021-11-30T17:35:09.442-0800	info	builder/exporters_builder.go:40	Exporter is starting...	{"kind": "exporter", "name": "otlp"}
2021-11-30T17:35:09.442-0800	info	zapgrpc/zapgrpc.go:174	[core] original dial target is: "otelcol:4317"
2021-11-30T17:35:09.443-0800	info	zapgrpc/zapgrpc.go:174	[core] parsed dial target is: {Scheme:otelcol Authority: Endpoint:4317 URL:{Scheme:otelcol Opaque:4317 User: Host: Path: RawPath: ForceQuery:false RawQuery: Fragment: RawFragment:}}
2021-11-30T17:35:09.443-0800	info	zapgrpc/zapgrpc.go:174	[core] fallback to scheme "passthrough"
2021-11-30T17:35:09.443-0800	info	zapgrpc/zapgrpc.go:174	[core] parsed dial target is: {Scheme:passthrough Authority: Endpoint:otelcol:4317 URL:{Scheme:passthrough Opaque: User: Host: Path:/otelcol:4317 RawPath: ForceQuery:false RawQuery: Fragment: RawFragment:}}
2021-11-30T17:35:09.443-0800	info	zapgrpc/zapgrpc.go:174	[core] Channel authority set to "otelcol:4317"
2021-11-30T17:35:09.443-0800	info	zapgrpc/zapgrpc.go:174	[core] ccResolverWrapper: sending update to cc: {[{otelcol:4317  <nil> <nil> 0 <nil>}] <nil> <nil>}
2021-11-30T17:35:09.443-0800	info	zapgrpc/zapgrpc.go:174	[core] ClientConn switching balancer to "pick_first"
2021-11-30T17:35:09.443-0800	info	zapgrpc/zapgrpc.go:174	[core] Channel switches to new LB policy "pick_first"
2021-11-30T17:35:09.443-0800	info	builder/exporters_builder.go:48	Exporter started.	{"kind": "exporter", "name": "otlp"}
2021-11-30T17:35:09.443-0800	info	zapgrpc/zapgrpc.go:174	[core] Subchannel Connectivity change to CONNECTING
2021-11-30T17:35:09.443-0800	info	builder/exporters_builder.go:40	Exporter is starting...	{"kind": "exporter", "name": "logging"}
2021-11-30T17:35:09.443-0800	info	builder/exporters_builder.go:48	Exporter started.	{"kind": "exporter", "name": "logging"}
2021-11-30T17:35:09.443-0800	info	service/service.go:96	Starting processors...
2021-11-30T17:35:09.443-0800	info	builder/pipelines_builder.go:54	Pipeline is starting...	{"name": "pipeline", "name": "traces"}
2021-11-30T17:35:09.443-0800	info	zapgrpc/zapgrpc.go:174	[core] Subchannel picks a new address "otelcol:4317" to connect
2021-11-30T17:35:09.443-0800	info	builder/pipelines_builder.go:65	Pipeline is started.	{"name": "pipeline", "name": "traces"}
2021-11-30T17:35:09.443-0800	info	zapgrpc/zapgrpc.go:174	[core] pickfirstBalancer: UpdateSubConnState: 0xc0000f4440, {CONNECTING <nil>}
2021-11-30T17:35:09.443-0800	info	builder/pipelines_builder.go:54	Pipeline is starting...	{"name": "pipeline", "name": "metrics"}
2021-11-30T17:35:09.443-0800	info	zapgrpc/zapgrpc.go:174	[core] Channel Connectivity change to CONNECTING
2021-11-30T17:35:09.443-0800	info	builder/pipelines_builder.go:65	Pipeline is started.	{"name": "pipeline", "name": "metrics"}
2021-11-30T17:35:09.443-0800	info	service/service.go:101	Starting receivers...
2021-11-30T17:35:09.444-0800	info	builder/receivers_builder.go:68	Receiver is starting...	{"kind": "receiver", "name": "otlp"}
2021-11-30T17:35:09.444-0800	info	otlpreceiver/otlp.go:68	Starting GRPC server on endpoint 0.0.0.0:4317	{"kind": "receiver", "name": "otlp"}
2021-11-30T17:35:09.445-0800	info	builder/receivers_builder.go:73	Receiver started.	{"kind": "receiver", "name": "otlp"}
2021-11-30T17:35:09.445-0800	info	service/telemetry.go:92	Setting up own telemetry...
2021-11-30T17:35:09.449-0800	warn	zapgrpc/zapgrpc.go:191	[core] grpc: addrConn.createTransport failed to connect to {otelcol:4317 otelcol:4317 <nil> <nil> 0 <nil>}. Err: connection error: desc = "transport: Error while dialing dial tcp: lookup otelcol: no such host"
2021-11-30T17:35:09.449-0800	info	zapgrpc/zapgrpc.go:174	[core] Subchannel Connectivity change to TRANSIENT_FAILURE
2021-11-30T17:35:09.449-0800	info	zapgrpc/zapgrpc.go:174	[core] pickfirstBalancer: UpdateSubConnState: 0xc0000f4440, {TRANSIENT_FAILURE connection error: desc = "transport: Error while dialing dial tcp: lookup otelcol: no such host"}
2021-11-30T17:35:09.449-0800	info	zapgrpc/zapgrpc.go:174	[core] Channel Connectivity change to TRANSIENT_FAILURE
2021-11-30T17:35:09.455-0800	info	service/telemetry.go:116	Serving Prometheus metrics	{"address": ":8888", "level": "basic", "service.instance.id": "a579c69f-edb3-4fca-8911-e6fd9a5f5344", "service.version": "latest"}
2021-11-30T17:35:09.456-0800	info	service/collector.go:243	Starting cmd-otelcol...	{"Version": "0.40.0-dev", "NumCPU": 12}
2021-11-30T17:35:09.456-0800	info	service/collector.go:136	Everything is ready. Begin running and processing data.
2021-11-30T17:35:10.449-0800	info	zapgrpc/zapgrpc.go:174	[core] Subchannel Connectivity change to IDLE
2021-11-30T17:35:10.449-0800	info	zapgrpc/zapgrpc.go:174	[core] pickfirstBalancer: UpdateSubConnState: 0xc0000f4440, {IDLE connection error: desc = "transport: Error while dialing dial tcp: lookup otelcol: no such host"}
2021-11-30T17:35:10.449-0800	info	zapgrpc/zapgrpc.go:174	[core] Channel Connectivity change to IDLE
2021-11-30T17:35:12.072-0800	info	zapgrpc/zapgrpc.go:174	[transport] transport: loopyWriter.run returning. connection error: desc = "transport is closing"
2021-11-30T17:35:12.255-0800	INFO	loggingexporter/logging_exporter.go:40	TracesExporter	{"#spans": 2}
2021-11-30T17:35:28.595-0800	info	zapgrpc/zapgrpc.go:174	[core] Subchannel Connectivity change to TRANSIENT_FAILURE
2021-11-30T17:35:28.595-0800	info	zapgrpc/zapgrpc.go:174	[core] pickfirstBalancer: UpdateSubConnState: 0xc0000f4440, {TRANSIENT_FAILURE connection error: desc = "transport: Error while dialing dial tcp: lookup otelcol: no such host"}
2021-11-30T17:35:28.595-0800	info	zapgrpc/zapgrpc.go:174	[core] Channel Connectivity change to TRANSIENT_FAILURE
2021-11-30T17:35:28.595-0800	info	exporterhelper/queued_retry.go:215	Exporting failed. Will retry the request after interval.	{"kind": "exporter", "name": "otlp", "error": "rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing dial tcp: lookup otelcol: no such host\"", "interval": "13.101300599s"}
2021-11-30T17:35:32.049-0800	info	zapgrpc/zapgrpc.go:174	[core] Subchannel Connectivity change to IDLE
2021-11-30T17:35:32.049-0800	info	zapgrpc/zapgrpc.go:174	[core] pickfirstBalancer: UpdateSubConnState: 0xc0000f4440, {IDLE connection error: desc = "transport: Error while dialing dial tcp: lookup otelcol: no such host"}
2021-11-30T17:35:32.049-0800	info	zapgrpc/zapgrpc.go:174	[core] Channel Connectivity change to IDLE

```

DEBUG in development mode

```yaml
service:
  telemetry:
    logs:
      level: "DEBUG"
      development: true
      encoding: "console"
  pipelines:
    traces:
      receivers: [otlp]
      processors: [batch]
      exporters: [logging, otlp]
```

produces

```bash
2021-11-30T17:30:55.091-0800	info	builder/pipelines_builder.go:65	Pipeline is started.	{"name": "pipeline", "name": "metrics"}
2021-11-30T17:30:55.091-0800	info	builder/pipelines_builder.go:54	Pipeline is starting...	{"name": "pipeline", "name": "traces"}
2021-11-30T17:30:55.091-0800	info	zapgrpc/zapgrpc.go:174	[core] Subchannel picks a new address "otelcol:4317" to connect
2021-11-30T17:30:55.091-0800	info	builder/pipelines_builder.go:65	Pipeline is started.	{"name": "pipeline", "name": "traces"}
2021-11-30T17:30:55.091-0800	info	zapgrpc/zapgrpc.go:174	[core] pickfirstBalancer: UpdateSubConnState: 0xc00011c8f0, {CONNECTING <nil>}
2021-11-30T17:30:55.091-0800	info	service/service.go:101	Starting receivers...
2021-11-30T17:30:55.091-0800	info	zapgrpc/zapgrpc.go:174	[core] Channel Connectivity change to CONNECTING
2021-11-30T17:30:55.091-0800	info	builder/receivers_builder.go:68	Receiver is starting...	{"kind": "receiver", "name": "otlp"}
2021-11-30T17:30:55.091-0800	info	otlpreceiver/otlp.go:68	Starting GRPC server on endpoint 0.0.0.0:4317	{"kind": "receiver", "name": "otlp"}
2021-11-30T17:30:55.091-0800	info	builder/receivers_builder.go:73	Receiver started.	{"kind": "receiver", "name": "otlp"}
2021-11-30T17:30:55.091-0800	info	service/telemetry.go:92	Setting up own telemetry...
2021-11-30T17:30:55.101-0800	info	service/telemetry.go:116	Serving Prometheus metrics	{"address": ":8888", "level": "basic", "service.instance.id": "38ece474-2cdc-42a3-b442-46477936c2b7", "service.version": "latest"}
2021-11-30T17:30:55.101-0800	info	service/collector.go:243	Starting cmd-otelcol...	{"Version": "0.40.0-dev", "NumCPU": 12}
2021-11-30T17:30:55.101-0800	info	service/collector.go:136	Everything is ready. Begin running and processing data.
2021-11-30T17:30:55.236-0800	warn	zapgrpc/zapgrpc.go:191	[core] grpc: addrConn.createTransport failed to connect to {otelcol:4317 otelcol:4317 <nil> <nil> 0 <nil>}. Err: connection error: desc = "transport: Error while dialing dial tcp: lookup otelcol: no such host"
go.uber.org/zap/zapgrpc.(*Logger).Warningln
	go.uber.org/zap@v1.19.1/zapgrpc/zapgrpc.go:191
google.golang.org/grpc/internal/grpclog.WarningDepth
	google.golang.org/grpc@v1.42.0/internal/grpclog/grpclog.go:46
google.golang.org/grpc/grpclog.(*componentData).WarningDepth
	google.golang.org/grpc@v1.42.0/grpclog/component.go:41
google.golang.org/grpc/internal/channelz.Warningf
	google.golang.org/grpc@v1.42.0/internal/channelz/logging.go:75
google.golang.org/grpc.(*addrConn).createTransport
	google.golang.org/grpc@v1.42.0/clientconn.go:1315
google.golang.org/grpc.(*addrConn).tryAllAddrs
	google.golang.org/grpc@v1.42.0/clientconn.go:1249
google.golang.org/grpc.(*addrConn).resetTransport
	google.golang.org/grpc@v1.42.0/clientconn.go:1184
google.golang.org/grpc.(*addrConn).connect
	google.golang.org/grpc@v1.42.0/clientconn.go:845
2021-11-30T17:30:55.237-0800	info	zapgrpc/zapgrpc.go:174	[core] Subchannel Connectivity change to TRANSIENT_FAILURE
2021-11-30T17:30:55.237-0800	info	zapgrpc/zapgrpc.go:174	[core] pickfirstBalancer: UpdateSubConnState: 0xc00011c8f0, {TRANSIENT_FAILURE connection error: desc = "transport: Error while dialing dial tcp: lookup otelcol: no such host"}
2021-11-30T17:30:55.237-0800	info	zapgrpc/zapgrpc.go:174	[core] Channel Connectivity change to TRANSIENT_FAILURE
2021-11-30T17:30:56.238-0800	info	zapgrpc/zapgrpc.go:174	[core] Subchannel Connectivity change to IDLE
2021-11-30T17:30:56.238-0800	info	zapgrpc/zapgrpc.go:174	[core] pickfirstBalancer: UpdateSubConnState: 0xc00011c8f0, {IDLE connection error: desc = "transport: Error while dialing dial tcp: lookup otelcol: no such host"}
2021-11-30T17:30:56.238-0800	info	zapgrpc/zapgrpc.go:174	[core] Channel Connectivity change to IDLE
^C2021-11-30T17:30:58.448-0800	info	service/collector.go:167	Received signal from OS	{"signal": "interrupt"}
2021-11-30T17:30:58.448-0800	info	service/collector.go:259	Starting shutdown...
2021-11-30
```

**Link to tracking Issue:** #2237

**Testing:** Added unit tests and manual testing 
