### PR TITLE
Include SchemaURL in OTLP text

### DIFF
--- a/internal/otlptext/logs.go
+++ b/internal/otlptext/logs.go
@@ -32,11 +32,13 @@ func (textLogsMarshaler) MarshalLogs(ld pdata.Logs) ([]byte, error) {
 	for i := 0; i < rls.Len(); i++ {
 		buf.logEntry("ResourceLog #%d", i)
 		rl := rls.At(i)
+		buf.logEntry("Resource SchemaURL: %s", rl.SchemaUrl())
 		buf.logAttributeMap("Resource labels", rl.Resource().Attributes())
 		ills := rl.InstrumentationLibraryLogs()
 		for j := 0; j < ills.Len(); j++ {
 			buf.logEntry("InstrumentationLibraryLogs #%d", j)
 			ils := ills.At(j)
+			buf.logEntry("InstrumentationLibraryMetrics SchemaURL: %s", ils.SchemaUrl())
 			buf.logInstrumentationLibrary(ils.InstrumentationLibrary())
 
 			logs := ils.Logs()

--- a/internal/otlptext/metrics.go
+++ b/internal/otlptext/metrics.go
@@ -32,11 +32,13 @@ func (textMetricsMarshaler) MarshalMetrics(md pdata.Metrics) ([]byte, error) {
 	for i := 0; i < rms.Len(); i++ {
 		buf.logEntry("ResourceMetrics #%d", i)
 		rm := rms.At(i)
+		buf.logEntry("Resource SchemaURL: %s", rm.SchemaUrl())
 		buf.logAttributeMap("Resource labels", rm.Resource().Attributes())
 		ilms := rm.InstrumentationLibraryMetrics()
 		for j := 0; j < ilms.Len(); j++ {
 			buf.logEntry("InstrumentationLibraryMetrics #%d", j)
 			ilm := ilms.At(j)
+			buf.logEntry("InstrumentationLibraryMetrics SchemaURL: %s", ilm.SchemaUrl())
 			buf.logInstrumentationLibrary(ilm.InstrumentationLibrary())
 			metrics := ilm.Metrics()
 			for k := 0; k < metrics.Len(); k++ {

--- a/internal/otlptext/traces.go
+++ b/internal/otlptext/traces.go
@@ -32,11 +32,13 @@ func (textTracesMarshaler) MarshalTraces(td pdata.Traces) ([]byte, error) {
 	for i := 0; i < rss.Len(); i++ {
 		buf.logEntry("ResourceSpans #%d", i)
 		rs := rss.At(i)
+		buf.logEntry("Resource SchemaURL: %s", rs.SchemaUrl())
 		buf.logAttributeMap("Resource labels", rs.Resource().Attributes())
 		ilss := rs.InstrumentationLibrarySpans()
 		for j := 0; j < ilss.Len(); j++ {
 			buf.logEntry("InstrumentationLibrarySpans #%d", j)
 			ils := ilss.At(j)
+			buf.logEntry("InstrumentationLibraryMetrics SchemaURL: %s", ils.SchemaUrl())
 			buf.logInstrumentationLibrary(ils.InstrumentationLibrary())
 
 			spans := ils.Spans()


### PR DESCRIPTION
This enables printing SchemaURL in logging exporter.
