### PR TITLE
Remove NewConfigMapFrom[File|Buffer], add testonly version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 🛑 Breaking changes 🛑
+
+- Remove `config.NewConfigMapFrom[File|Buffer]`, add testonly version (#4502)
+
 ## 🧰 Bug fixes 🧰
 
 - Fix handling of corrupted records by persistent buffer (experimental) (#4475)

--- a/config/configmap.go
+++ b/config/configmap.go
@@ -16,16 +16,11 @@ package config // import "go.opentelemetry.io/collector/config"
 
 import (
 	"fmt"
-	"io"
-	"io/ioutil"
 	"reflect"
 
 	"github.com/knadh/koanf"
 	"github.com/knadh/koanf/maps"
-	"github.com/knadh/koanf/parsers/yaml"
 	"github.com/knadh/koanf/providers/confmap"
-	"github.com/knadh/koanf/providers/file"
-	"github.com/knadh/koanf/providers/rawbytes"
 	"github.com/mitchellh/mapstructure"
 	"github.com/spf13/cast"
 )
@@ -38,31 +33,6 @@ const (
 // NewMap creates a new empty config.Map instance.
 func NewMap() *Map {
 	return &Map{k: koanf.New(KeyDelimiter)}
-}
-
-// NewMapFromFile creates a new config.Map by reading the given file.
-func NewMapFromFile(fileName string) (*Map, error) {
-	// Read yaml config from file.
-	p := NewMap()
-	if err := p.k.Load(file.Provider(fileName), yaml.Parser()); err != nil {
-		return nil, fmt.Errorf("unable to read the file %v: %w", fileName, err)
-	}
-	return p, nil
-}
-
-// NewMapFromBuffer creates a new config.Map by reading the given yaml buffer.
-func NewMapFromBuffer(buf io.Reader) (*Map, error) {
-	content, err := ioutil.ReadAll(buf)
-	if err != nil {
-		return nil, err
-	}
-
-	p := NewMap()
-	if err := p.k.Load(rawbytes.Provider(content), yaml.Parser()); err != nil {
-		return nil, err
-	}
-
-	return p, nil
 }
 
 // NewMapFromStringMap creates a config.Map from a map[string]interface{}.

--- a/config/configmap_test.go
+++ b/config/configmap_test.go
@@ -15,10 +15,14 @@
 package config
 
 import (
+	"fmt"
+	"io/ioutil"
+	"path"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
 )
 
 func TestToStringMap_WithSet(t *testing.T) {
@@ -98,9 +102,24 @@ func TestToStringMap(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			parser, err := NewMapFromFile(test.fileName)
-			require.NoError(t, err, "Unable to read configuration file '%s'", test.fileName)
+			parser, err := newMapFromFile(test.fileName)
+			require.NoError(t, err)
 			assert.Equal(t, test.stringMap, parser.ToStringMap())
 		})
 	}
+}
+
+// newMapFromFile creates a new config.Map by reading the given file.
+func newMapFromFile(fileName string) (*Map, error) {
+	content, err := ioutil.ReadFile(path.Clean(fileName))
+	if err != nil {
+		return nil, fmt.Errorf("unable to read the file %v: %w", fileName, err)
+	}
+
+	var data map[string]interface{}
+	if err = yaml.Unmarshal(content, &data); err != nil {
+		return nil, fmt.Errorf("unable to parse yaml: %w", err)
+	}
+
+	return NewMapFromStringMap(data), nil
 }

--- a/config/configmapprovider/default_test.go
+++ b/config/configmapprovider/default_test.go
@@ -16,7 +16,6 @@ package configmapprovider
 
 import (
 	"context"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -30,13 +29,10 @@ func TestDefaultMapProvider(t *testing.T) {
 	retr, err := mp.Retrieve(context.Background(), nil)
 	require.NoError(t, err)
 
-	expectedMap, err := config.NewMapFromBuffer(strings.NewReader(`
-processors:
-  batch:
-exporters:
-  otlp:
-    endpoint: "localhost:4317"`))
-	require.NoError(t, err)
+	expectedMap := config.NewMapFromStringMap(map[string]interface{}{
+		"processors::batch":         nil,
+		"exporters::otlp::endpoint": "localhost:4317",
+	})
 	m, err := retr.Get(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, expectedMap, m)
@@ -49,14 +45,10 @@ func TestDefaultMapProvider_AddNewConfig(t *testing.T) {
 	cp, err := mp.Retrieve(context.Background(), nil)
 	require.NoError(t, err)
 
-	expectedMap, err := config.NewMapFromBuffer(strings.NewReader(`
-processors:
-  batch:
-    timeout: 2s
-exporters:
-  otlp:
-    endpoint: "localhost:4317"`))
-	require.NoError(t, err)
+	expectedMap := config.NewMapFromStringMap(map[string]interface{}{
+		"processors::batch::timeout": "2s",
+		"exporters::otlp::endpoint":  "localhost:4317",
+	})
 	m, err := cp.Get(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, expectedMap, m)
@@ -71,14 +63,10 @@ func TestDefaultMapProvider_OverwriteConfig(t *testing.T) {
 	cp, err := mp.Retrieve(context.Background(), nil)
 	require.NoError(t, err)
 
-	expectedMap, err := config.NewMapFromBuffer(strings.NewReader(`
-processors:
-  batch:
-    timeout: 2s
-exporters:
-  otlp:
-    endpoint: "localhost:1234"`))
-	require.NoError(t, err)
+	expectedMap := config.NewMapFromStringMap(map[string]interface{}{
+		"processors::batch::timeout": "2s",
+		"exporters::otlp::endpoint":  "localhost:1234",
+	})
 	m, err := cp.Get(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, expectedMap, m)

--- a/config/configmapprovider/expand_test.go
+++ b/config/configmapprovider/expand_test.go
@@ -23,8 +23,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"go.opentelemetry.io/collector/config"
 )
 
 func TestBaseRetrieveFailsOnRetrieve(t *testing.T) {
@@ -69,7 +67,10 @@ func TestExpand(t *testing.T) {
 		assert.NoError(t, os.Unsetenv("EXTRA_LIST_VALUE_1"))
 	}()
 
-	expectedCfgMap, errExpected := config.NewMapFromFile(path.Join("testdata", "expand-with-no-env.yaml"))
+	// Cannot use configtest.LoadConfigMap because of circular deps.
+	ret, errRet := NewFile(path.Join("testdata", "expand-with-no-env.yaml")).Retrieve(context.Background(), nil)
+	require.NoError(t, errRet, "Unable to get expected config")
+	expectedCfgMap, errExpected := ret.Get(context.Background())
 	require.NoError(t, errExpected, "Unable to get expected config")
 
 	for _, test := range testCases {

--- a/config/configtest/configtest.go
+++ b/config/configtest/configtest.go
@@ -32,7 +32,7 @@ import (
 // The regular expression for valid config field tag.
 var configFieldTagRegExp = regexp.MustCompile("^[a-z0-9][a-z0-9_]*$")
 
-// LoadConfig loads a config from file, and does NOT validate the configuration.
+// LoadConfig loads a config.Config  from file, and does NOT validate the configuration.
 func LoadConfig(fileName string, factories component.Factories) (*config.Config, error) {
 	// Read yaml config from file
 	cp, err := configmapprovider.NewExpand(configmapprovider.NewFile(fileName)).Retrieve(context.Background(), nil)
@@ -54,6 +54,16 @@ func LoadConfigAndValidate(fileName string, factories component.Factories) (*con
 		return nil, err
 	}
 	return cfg, cfg.Validate()
+}
+
+// LoadConfigMap loads a config.Map from file, and does NOT validate the configuration.
+func LoadConfigMap(fileName string) (*config.Map, error) {
+	ret, err := configmapprovider.NewFile(fileName).Retrieve(context.Background(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return ret.Get(context.Background())
 }
 
 // CheckConfigStruct enforces that given configuration object is following the patterns

--- a/config/configunmarshaler/defaultunmarshaler_test.go
+++ b/config/configunmarshaler/defaultunmarshaler_test.go
@@ -15,6 +15,7 @@
 package configunmarshaler
 
 import (
+	"context"
 	"path"
 	"testing"
 
@@ -24,6 +25,7 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/config/configmapprovider"
 	"go.opentelemetry.io/collector/config/confignet"
 	"go.opentelemetry.io/collector/internal/testcomponents"
 )
@@ -206,9 +208,11 @@ func TestLoadEmptyAllSections(t *testing.T) {
 }
 
 func loadConfigFile(t *testing.T, fileName string, factories component.Factories) (*config.Config, error) {
-	v, err := config.NewMapFromFile(fileName)
+	v, err := configmapprovider.NewFile(fileName).Retrieve(context.Background(), nil)
+	require.NoError(t, err)
+	cm, err := v.Get(context.Background())
 	require.NoError(t, err)
 
 	// Unmarshal the config from the config.Map using the given factories.
-	return NewDefault().Unmarshal(v, factories)
+	return NewDefault().Unmarshal(cm, factories)
 }

--- a/config/internal/configsource/manager.go
+++ b/config/internal/configsource/manager.go
@@ -15,7 +15,6 @@
 package configsource // import "go.opentelemetry.io/collector/config/internal/configsource"
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -531,12 +530,11 @@ func parseCfgSrcInvocation(s string) (cfgSrcName, selector string, paramsConfigM
 		selector = strings.Trim(parts[0], " ")
 
 		if len(parts) > 1 && len(parts[1]) > 0 {
-			var cp *config.Map
-			cp, err = config.NewMapFromBuffer(bytes.NewReader([]byte(parts[1])))
-			if err != nil {
+			var data map[string]interface{}
+			if err = yaml.Unmarshal([]byte(parts[1]), &data); err != nil {
 				return
 			}
-			paramsConfigMap = cp
+			paramsConfigMap = config.NewMapFromStringMap(data)
 		}
 
 	default:

--- a/config/internal/configsource/manager_test.go
+++ b/config/internal/configsource/manager_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/config/configtest"
 	"go.opentelemetry.io/collector/config/experimental/configsource"
 )
 
@@ -161,11 +162,11 @@ map:
 	})
 
 	file := path.Join("testdata", "yaml_injection.yaml")
-	cp, err := config.NewMapFromFile(file)
+	cp, err := configtest.LoadConfigMap(file)
 	require.NoError(t, err)
 
 	expectedFile := path.Join("testdata", "yaml_injection_expected.yaml")
-	expectedConfigMap, err := config.NewMapFromFile(expectedFile)
+	expectedConfigMap, err := configtest.LoadConfigMap(expectedFile)
 	require.NoError(t, err)
 	expectedCfg := expectedConfigMap.ToStringMap()
 
@@ -190,11 +191,11 @@ func TestConfigSourceManager_ArraysAndMaps(t *testing.T) {
 	})
 
 	file := path.Join("testdata", "arrays_and_maps.yaml")
-	cp, err := config.NewMapFromFile(file)
+	cp, err := configtest.LoadConfigMap(file)
 	require.NoError(t, err)
 
 	expectedFile := path.Join("testdata", "arrays_and_maps_expected.yaml")
-	expectedConfigMap, err := config.NewMapFromFile(expectedFile)
+	expectedConfigMap, err := configtest.LoadConfigMap(expectedFile)
 	require.NoError(t, err)
 
 	res, err := manager.Resolve(ctx, cp)
@@ -244,11 +245,11 @@ func TestConfigSourceManager_ParamsHandling(t *testing.T) {
 	})
 
 	file := path.Join("testdata", "params_handling.yaml")
-	cp, err := config.NewMapFromFile(file)
+	cp, err := configtest.LoadConfigMap(file)
 	require.NoError(t, err)
 
 	expectedFile := path.Join("testdata", "params_handling_expected.yaml")
-	expectedConfigMap, err := config.NewMapFromFile(expectedFile)
+	expectedConfigMap, err := configtest.LoadConfigMap(expectedFile)
 	require.NoError(t, err)
 
 	res, err := manager.Resolve(ctx, cp)
@@ -383,11 +384,11 @@ func TestConfigSourceManager_EnvVarHandling(t *testing.T) {
 	})
 
 	file := path.Join("testdata", "envvar_cfgsrc_mix.yaml")
-	cp, err := config.NewMapFromFile(file)
+	cp, err := configtest.LoadConfigMap(file)
 	require.NoError(t, err)
 
 	expectedFile := path.Join("testdata", "envvar_cfgsrc_mix_expected.yaml")
-	expectedConfigMap, err := config.NewMapFromFile(expectedFile)
+	expectedConfigMap, err := configtest.LoadConfigMap(expectedFile)
 	require.NoError(t, err)
 
 	res, err := manager.Resolve(ctx, cp)


### PR DESCRIPTION
The benefit of this is that we remove from the public API the assumption that configuration needs to be yaml.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
