### PR TITLE
configtls: TLS 1.2 is the new default min version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 💡 Enhancements 💡
+
+- `configtls`: TLS 1.2 is the new default mininum version (#4503)
+
 ## 🧰 Bug fixes 🧰
 
 - Fix handling of corrupted records by persistent buffer (experimental) (#4475)

--- a/config/configtls/README.md
+++ b/config/configtls/README.md
@@ -36,7 +36,8 @@ won't use TLS at all.
 
 Minimum and maximum TLS version can be set:
 
-- `min_version` (default = "1.0"): Minimum acceptable TLS version.
+- `min_version` (default = "1.2"): Minimum acceptable TLS version.
+It's recommended to use at least 1.2 as the minimum version.
 
 - `max_version` (default = "1.3"): Maximum acceptable TLS version.
 

--- a/config/configtls/configtls.go
+++ b/config/configtls/configtls.go
@@ -178,7 +178,7 @@ func (c TLSServerSetting) LoadTLSConfig() (*tls.Config, error) {
 
 func convertVersion(v string) (uint16, error) {
 	if v == "" {
-		return 0, nil // default
+		return tls.VersionTLS12, nil // default
 	}
 	val, ok := tlsVersions[v]
 	if !ok {


### PR DESCRIPTION
Addresses ﻿CWE-327 by setting the minimum TLS version to 1.2. Lower versions can still be set for backwards compatibility with older network appliances, although I don't think any of them are that old to still not have 1.2 available.

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>
