### PR TITLE
`configauth`: add ServerAuthenticator interfaces for HTTP receivers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@
 - OTLP/HTTP receivers now support setting the `Access-Control-Max-Age` header for CORS caching. (#4492)
 - `client.Info` pre-populated for all receivers using common helpers like `confighttp` and `configgrpc` (#4423)
 
+## 💡 Enhancements 💡
+
+- `configauth`: add ServerAuthenticator interfaces for HTTP receivers. (#4506)
+
 ## 🧰 Bug fixes 🧰
 
 - Fix handling of corrupted records by persistent buffer (experimental) (#4475)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## 💡 Enhancements 💡
 
 -  Allow more zap logger configs: `disable_caller`, `disable_stacktrace`, `output_paths`, `error_output_paths`, `initial_fields` (#1048)
+- `configauth`: add ServerAuthenticator interfaces for HTTP receivers. (#4506)
 
 ## v0.41.0 Beta
 
@@ -20,10 +21,6 @@
 
 - OTLP/HTTP receivers now support setting the `Access-Control-Max-Age` header for CORS caching. (#4492)
 - `client.Info` pre-populated for all receivers using common helpers like `confighttp` and `configgrpc` (#4423)
-
-## 💡 Enhancements 💡
-
-- `configauth`: add ServerAuthenticator interfaces for HTTP receivers. (#4506)
 
 ## 🧰 Bug fixes 🧰
 

--- a/config/configauth/mock_serverauth.go
+++ b/config/configauth/mock_serverauth.go
@@ -16,6 +16,7 @@ package configauth // import "go.opentelemetry.io/collector/config/configauth"
 
 import (
 	"context"
+	"net/http"
 
 	"google.golang.org/grpc"
 
@@ -31,6 +32,9 @@ var (
 type MockServerAuthenticator struct {
 	// AuthenticateFunc to use during the authentication phase of this mock. Optional.
 	AuthenticateFunc AuthenticateFunc
+
+	// HTTPInterceptor to use in the test
+	HTTPInterceptorFunc HTTPInterceptorFunc
 	// TODO: implement the other funcs
 }
 
@@ -50,6 +54,14 @@ func (m *MockServerAuthenticator) GRPCUnaryServerInterceptor(context.Context, in
 // GRPCStreamServerInterceptor isn't currently implemented and always returns nil.
 func (m *MockServerAuthenticator) GRPCStreamServerInterceptor(interface{}, grpc.ServerStream, *grpc.StreamServerInfo, grpc.StreamHandler) error {
 	return nil
+}
+
+// HTTPInterceptor isn't currently implemented and always returns nil.
+func (m *MockServerAuthenticator) HTTPInterceptor(next http.Handler) http.Handler {
+	if m.HTTPInterceptorFunc == nil {
+		return next
+	}
+	return m.HTTPInterceptorFunc(next, m.AuthenticateFunc)
 }
 
 // Start isn't currently implemented and always returns nil.


### PR DESCRIPTION
Fixes #4440 by specifying the interface for HTTP auth and implementing it for the OTLP receiver.

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>
