### PR TITLE
`confighttp`: add component.Host parameter to ToServer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Remove `config.NewConfigMapFrom[File|Buffer]`, add testonly version (#4502)
 - `configtls`: TLS 1.2 is the new default mininum version (#4503)
+- `confighttp`: `ToServer` how accepts a `component.Host`, in line with gRPC's counterpart (#4514)
 
 ## 🧰 Bug fixes 🧰
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Remove `config.NewConfigMapFrom[File|Buffer]`, add testonly version (#4502)
 - `configtls`: TLS 1.2 is the new default mininum version (#4503)
-- `confighttp`: `ToServer` how accepts a `component.Host`, in line with gRPC's counterpart (#4514)
+- `confighttp`: `ToServer` now accepts a `component.Host`, in line with gRPC's counterpart (#4514)
 
 ## 🧰 Bug fixes 🧰
 

--- a/config/confighttp/confighttp.go
+++ b/config/confighttp/confighttp.go
@@ -187,7 +187,7 @@ func WithErrorHandler(e middleware.ErrorHandler) ToServerOption {
 }
 
 // ToServer creates an http.Server from settings object.
-func (hss *HTTPServerSettings) ToServer(handler http.Handler, settings component.TelemetrySettings, opts ...ToServerOption) *http.Server {
+func (hss *HTTPServerSettings) ToServer(_ component.Host, settings component.TelemetrySettings, handler http.Handler, opts ...ToServerOption) (*http.Server, error) {
 	serverOpts := &toServerOptions{}
 	for _, o := range opts {
 		o(serverOpts)
@@ -223,5 +223,5 @@ func (hss *HTTPServerSettings) ToServer(handler http.Handler, settings component
 
 	return &http.Server{
 		Handler: handler,
-	}
+	}, nil
 }

--- a/config/confighttp/confighttp_test.go
+++ b/config/confighttp/confighttp_test.go
@@ -380,7 +380,8 @@ func TestHttpReception(t *testing.T) {
 				TLSSetting: tt.tlsServerCreds,
 			}
 			ln, err := hss.ToListener()
-			assert.NoError(t, err)
+			require.NoError(t, err)
+
 			s, err := hss.ToServer(
 				componenttest.NewNopHost(),
 				componenttest.NewNopTelemetrySettings(),
@@ -388,7 +389,7 @@ func TestHttpReception(t *testing.T) {
 					_, errWrite := fmt.Fprint(w, "test")
 					assert.NoError(t, errWrite)
 				}))
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			go func() {
 				_ = s.Serve(ln)
@@ -407,7 +408,8 @@ func TestHttpReception(t *testing.T) {
 				TLSSetting: *tt.tlsClientCreds,
 			}
 			client, errClient := hcs.ToClient(map[config.ComponentID]component.Extension{})
-			assert.NoError(t, errClient)
+			require.NoError(t, errClient)
+
 			resp, errResp := client.Get(hcs.Endpoint)
 			if tt.hasError {
 				assert.Error(t, errResp)
@@ -464,14 +466,15 @@ func TestHttpCors(t *testing.T) {
 			}
 
 			ln, err := hss.ToListener()
-			assert.NoError(t, err)
+			require.NoError(t, err)
+
 			s, err := hss.ToServer(
 				componenttest.NewNopHost(),
 				componenttest.NewNopTelemetrySettings(),
 				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					w.WriteHeader(http.StatusOK)
 				}))
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			go func() {
 				_ = s.Serve(ln)

--- a/config/confighttp/confighttp_test.go
+++ b/config/confighttp/confighttp_test.go
@@ -381,10 +381,14 @@ func TestHttpReception(t *testing.T) {
 			}
 			ln, err := hss.ToListener()
 			assert.NoError(t, err)
-			s := hss.ToServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				_, errWrite := fmt.Fprint(w, "test")
-				assert.NoError(t, errWrite)
-			}), componenttest.NewNopTelemetrySettings())
+			s, err := hss.ToServer(
+				componenttest.NewNopHost(),
+				componenttest.NewNopTelemetrySettings(),
+				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					_, errWrite := fmt.Fprint(w, "test")
+					assert.NoError(t, errWrite)
+				}))
+			assert.NoError(t, err)
 
 			go func() {
 				_ = s.Serve(ln)
@@ -461,9 +465,14 @@ func TestHttpCors(t *testing.T) {
 
 			ln, err := hss.ToListener()
 			assert.NoError(t, err)
-			s := hss.ToServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.WriteHeader(http.StatusOK)
-			}), componenttest.NewNopTelemetrySettings())
+			s, err := hss.ToServer(
+				componenttest.NewNopHost(),
+				componenttest.NewNopTelemetrySettings(),
+				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusOK)
+				}))
+			assert.NoError(t, err)
+
 			go func() {
 				_ = s.Serve(ln)
 			}()
@@ -499,7 +508,11 @@ func TestHttpCorsInvalidSettings(t *testing.T) {
 	}
 
 	// This effectively does not enable CORS but should also not cause an error
-	s := hss.ToServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}), componenttest.NewNopTelemetrySettings())
+	s, err := hss.ToServer(
+		componenttest.NewNopHost(),
+		componenttest.NewNopTelemetrySettings(),
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	require.NoError(t, err)
 	require.NotNil(t, s)
 	require.NoError(t, s.Close())
 }
@@ -541,7 +554,14 @@ func ExampleHTTPServerSettings() {
 	settings := HTTPServerSettings{
 		Endpoint: ":443",
 	}
-	s := settings.ToServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}), componenttest.NewNopTelemetrySettings())
+	s, err := settings.ToServer(
+		componenttest.NewNopHost(),
+		componenttest.NewNopTelemetrySettings(),
+		http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	if err != nil {
+		panic(err)
+	}
+
 	l, err := settings.ToListener()
 	if err != nil {
 		panic(err)

--- a/receiver/otlpreceiver/otlp.go
+++ b/receiver/otlpreceiver/otlp.go
@@ -128,11 +128,16 @@ func (r *otlpReceiver) startProtocolServers(host component.Host) error {
 		}
 	}
 	if r.cfg.HTTP != nil {
-		r.serverHTTP = r.cfg.HTTP.ToServer(
-			r.httpMux,
+		r.serverHTTP, err = r.cfg.HTTP.ToServer(
+			host,
 			r.settings.TelemetrySettings,
+			r.httpMux,
 			confighttp.WithErrorHandler(errorHandler),
 		)
+		if err != nil {
+			return err
+		}
+
 		err = r.startHTTPServer(r.cfg.HTTP, host)
 		if err != nil {
 			return err


### PR DESCRIPTION
Closes #4512 by adding the component.Host parameter to the confighttp.ToServer function, in preparation for the changes related to configauth. This also changes the order of arguments, to make it consistent with configgrpc.

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>