### PR TITLE
if the config is invalid, list the factories

### DIFF
--- a/service/collector.go
+++ b/service/collector.go
@@ -202,17 +202,11 @@ func printFactories(factories component.Factories) {
 func (col *Collector) setupConfigurationComponents(ctx context.Context) error {
 	col.setCollectorState(Starting)
 
-<<<<<<< HEAD
 	cfg, err := col.set.ConfigProvider.Get(ctx, col.set.Factories)
 	if err != nil {
-		return fmt.Errorf("failed to get config: %w", err)
-=======
-	var err error
-	if col.cfgW, err = newConfigWatcher(ctx, col.set); err != nil {
 		printFactories(col.set.Factories)
 
-		return err
->>>>>>> af98b610 (if the config is invalid, list the factories)
+		return fmt.Errorf("failed to get config: %w", err)
 	}
 	if col.logger, err = telemetrylogs.NewLogger(cfg.Service.Telemetry.Logs, col.set.LoggingOptions); err != nil {
 		return fmt.Errorf("failed to get logger: %w", err)

--- a/service/collector.go
+++ b/service/collector.go
@@ -163,14 +163,56 @@ LOOP:
 	return col.shutdown(ctx)
 }
 
+func printFactories(factories component.Factories) {
+	ids := make([]string, len(factories.Extensions))
+	i := 0
+	for id := range factories.Extensions {
+		ids[i] = string(id)
+		i++
+	}
+	fmt.Printf("Extensions are: %v\n", ids)
+
+	ids = make([]string, len(factories.Receivers))
+	i = 0
+	for id := range factories.Receivers {
+		ids[i] = string(id)
+		i++
+	}
+	fmt.Printf("Receivers are: %v\n", ids)
+
+	ids = make([]string, len(factories.Processors))
+	i = 0
+	for id := range factories.Processors {
+		ids[i] = string(id)
+		i++
+	}
+	fmt.Printf("Processors are: %v\n", ids)
+
+	ids = make([]string, len(factories.Exporters))
+	i = 0
+	for id := range factories.Exporters {
+		ids[i] = string(id)
+		i++
+	}
+	fmt.Printf("Exporters are: %v\n", ids)
+}
+
 // setupConfigurationComponents loads the config and starts the components. If all the steps succeeds it
 // sets the col.service with the service currently running.
 func (col *Collector) setupConfigurationComponents(ctx context.Context) error {
 	col.setCollectorState(Starting)
 
+<<<<<<< HEAD
 	cfg, err := col.set.ConfigProvider.Get(ctx, col.set.Factories)
 	if err != nil {
 		return fmt.Errorf("failed to get config: %w", err)
+=======
+	var err error
+	if col.cfgW, err = newConfigWatcher(ctx, col.set); err != nil {
+		printFactories(col.set.Factories)
+
+		return err
+>>>>>>> af98b610 (if the config is invalid, list the factories)
 	}
 	if col.logger, err = telemetrylogs.NewLogger(cfg.Service.Telemetry.Logs, col.set.LoggingOptions); err != nil {
 		return fmt.Errorf("failed to get logger: %w", err)

--- a/service/collector.go
+++ b/service/collector.go
@@ -170,7 +170,7 @@ func printFactories(factories component.Factories) {
 		ids[i] = string(id)
 		i++
 	}
-	fmt.Printf("Extensions are: %v\n", ids)
+	fmt.Printf("Available extensions are: %v\n", ids)
 
 	ids = make([]string, len(factories.Receivers))
 	i = 0
@@ -178,7 +178,7 @@ func printFactories(factories component.Factories) {
 		ids[i] = string(id)
 		i++
 	}
-	fmt.Printf("Receivers are: %v\n", ids)
+	fmt.Printf("Available receivers are: %v\n", ids)
 
 	ids = make([]string, len(factories.Processors))
 	i = 0
@@ -186,7 +186,7 @@ func printFactories(factories component.Factories) {
 		ids[i] = string(id)
 		i++
 	}
-	fmt.Printf("Processors are: %v\n", ids)
+	fmt.Printf("Available processors are: %v\n", ids)
 
 	ids = make([]string, len(factories.Exporters))
 	i = 0
@@ -194,7 +194,7 @@ func printFactories(factories component.Factories) {
 		ids[i] = string(id)
 		i++
 	}
-	fmt.Printf("Exporters are: %v\n", ids)
+	fmt.Printf("Available exporters are: %v\n", ids)
 }
 
 // setupConfigurationComponents loads the config and starts the components. If all the steps succeeds it


### PR DESCRIPTION
Signed-off-by: Ed Snible <snible@us.ibm.com>

**Description:**

Enhancement: List the factories if the config cannot be read.  This solves a problem where an agent is being configured and we don't know the extensions that were built into the binary.  The goal is for logs to have enough information to know if the config file can be fixed.

**Testing:**

No tests were added.  If tests are needed, please advise.

**Documentation:**

None.  If documentation is needed, please advise.
