### PR TITLE
Add a warning message for usage legacy OTLP HTTP endpoint

### DIFF
--- a/examples/local/otel-config.yaml
+++ b/examples/local/otel-config.yaml
@@ -9,6 +9,7 @@ receivers:
     protocols:
       grpc:
       http:
+        endpoint: 0.0.0.0:55681
 
 processors:
   batch:

--- a/receiver/otlpreceiver/otlp.go
+++ b/receiver/otlpreceiver/otlp.go
@@ -16,6 +16,7 @@ package otlpreceiver // import "go.opentelemetry.io/collector/receiver/otlprecei
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"net/http"
 	"sync"
@@ -153,6 +154,10 @@ func (r *otlpReceiver) startProtocolServers(host component.Host) error {
 			if err != nil {
 				return err
 			}
+		}
+		if r.cfg.HTTP.Endpoint == legacyHTTPEndpoint {
+			r.settings.Logger.Warn(fmt.Sprintf("Legacy HTTP endpoint %v is configured, please use %v instead.",
+				legacyHTTPEndpoint, defaultHTTPEndpoint))
 		}
 	}
 


### PR DESCRIPTION
Default OTLP HTTP endpoint 0.0.0.0:4318 enables legacy endpoint as well. It makes the migration painless, so we need to encourage users to update their configuration. This change adds a warning message in case if user has the legacy endpoint configured explicitly.
