### PR TITLE
Prepare v0.41.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 ## Unreleased
 
-- Remove reference to `defaultcomponents` in core and deprecate `include_core` flag (#4087)
+## v0.41.0 Beta
 
 ## 🛑 Breaking changes 🛑
 
+- Remove reference to `defaultcomponents` in core and deprecate `include_core` flag (#4087)
 - Remove `config.NewConfigMapFrom[File|Buffer]`, add testonly version (#4502)
 - `configtls`: TLS 1.2 is the new default mininum version (#4503)
 - `confighttp`: `ToServer` now accepts a `component.Host`, in line with gRPC's counterpart (#4514)
@@ -14,14 +15,11 @@
 ## 💡 Enhancements 💡
 
 - OTLP/HTTP receivers now support setting the `Access-Control-Max-Age` header for CORS caching. (#4492)
+- `client.Info` pre-populated for all receivers using common helpers like `confighttp` and `configgrpc` (#4423)
 
 ## 🧰 Bug fixes 🧰
 
 - Fix handling of corrupted records by persistent buffer (experimental) (#4475)
-
-## 💡 Enhancements 💡
-
-- `client.Info` pre-populated for all receivers using common helpers like `confighttp` and `configgrpc` (#4423)
 
 ## v0.40.0 Beta
 

--- a/cmd/builder/internal/builder/config.go
+++ b/cmd/builder/internal/builder/config.go
@@ -25,7 +25,7 @@ import (
 	"go.uber.org/zap"
 )
 
-const defaultOtelColVersion = "0.40.0"
+const defaultOtelColVersion = "0.41.0"
 
 // ErrInvalidGoMod indicates an invalid gomod
 var ErrInvalidGoMod = errors.New("invalid gomod specification for module")

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/spf13/cobra v1.2.1
 	github.com/stretchr/testify v1.7.0
 	go.opencensus.io v0.23.0
-	go.opentelemetry.io/collector/model v0.40.0
+	go.opentelemetry.io/collector/model v0.41.0
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.27.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.27.0
 	go.opentelemetry.io/contrib/zpages v0.27.0

--- a/internal/buildscripts/builder-config.yaml
+++ b/internal/buildscripts/builder-config.yaml
@@ -2,8 +2,8 @@ dist:
   module: github.com/open-telemetry/opentelemetry-collector-releases/core
   name: cmd-otelcol
   description: OpenTelemetry Collector Replacing cmd/otelcol
-  version: 0.40.0-dev
-  otelcol_version: 0.40.0
+  version: 0.41.0-dev
+  otelcol_version: 0.41.0
 
 replaces:
   - go.opentelemetry.io/collector => ../

--- a/versions.yaml
+++ b/versions.yaml
@@ -14,7 +14,7 @@
 
 module-sets:
   collector-base:
-    version: v0.40.0
+    version: v0.41.0
     modules:
       - go.opentelemetry.io/collector
       - go.opentelemetry.io/collector/cmd/builder


### PR DESCRIPTION
Closes #4524

The current state of the collector seems to be compatible with contrib: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/6642

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>