### PR TITLE
Making access atomic to the collector's level

### DIFF
--- a/config/configtelemetry/configtelemetry.go
+++ b/config/configtelemetry/configtelemetry.go
@@ -53,7 +53,7 @@ func Flags(flags *flag.FlagSet) {
 
 // Level is the level of internal telemetry (metrics, logs, traces about the component itself)
 // that every component should generate.
-type Level int8
+type Level int32
 
 var _ flag.Value = (*Level)(nil)
 

--- a/internal/obsreportconfig/obsreportconfig.go
+++ b/internal/obsreportconfig/obsreportconfig.go
@@ -15,6 +15,8 @@
 package obsreportconfig // import "go.opentelemetry.io/collector/internal/obsreportconfig"
 
 import (
+	"sync/atomic"
+
 	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
@@ -24,7 +26,7 @@ import (
 )
 
 var (
-	Level = configtelemetry.LevelBasic
+	globalLevel = int32(configtelemetry.LevelBasic)
 )
 
 // ObsMetrics wraps OpenCensus View for Collector observability metrics
@@ -35,10 +37,11 @@ type ObsMetrics struct {
 // Configure is used to control the settings that will be used by the obsreport
 // package.
 func Configure(level configtelemetry.Level) *ObsMetrics {
-	Level = level
+	atomic.StoreInt32(&globalLevel, int32(level))
+
 	var views []*view.View
 
-	if Level != configtelemetry.LevelNone {
+	if Level() != configtelemetry.LevelNone {
 		obsMetricViews := allViews()
 		views = append(views, obsMetricViews.Views...)
 	}
@@ -46,6 +49,10 @@ func Configure(level configtelemetry.Level) *ObsMetrics {
 	return &ObsMetrics{
 		Views: views,
 	}
+}
+
+func Level() configtelemetry.Level {
+	return configtelemetry.Level(atomic.LoadInt32(&globalLevel))
 }
 
 // allViews return the list of all views that needs to be configured.

--- a/obsreport/obsreport_exporter.go
+++ b/obsreport/obsreport_exporter.go
@@ -106,7 +106,7 @@ func (exp *Exporter) startOp(ctx context.Context, operationSuffix string) contex
 }
 
 func (exp *Exporter) recordMetrics(ctx context.Context, numSent, numFailedToSend int64, sentMeasure, failedToSendMeasure *stats.Int64Measure) {
-	if obsreportconfig.Level == configtelemetry.LevelNone {
+	if obsreportconfig.Level() == configtelemetry.LevelNone {
 		return
 	}
 	// Ignore the error for now. This should not happen.

--- a/obsreport/obsreport_receiver.go
+++ b/obsreport/obsreport_receiver.go
@@ -161,7 +161,7 @@ func (rec *Receiver) endOp(
 
 	span := trace.SpanFromContext(receiverCtx)
 
-	if obsreportconfig.Level != configtelemetry.LevelNone {
+	if obsreportconfig.Level() != configtelemetry.LevelNone {
 		var acceptedMeasure, refusedMeasure *stats.Int64Measure
 		switch dataType {
 		case config.TracesDataType:

--- a/obsreport/obsreport_scraper.go
+++ b/obsreport/obsreport_scraper.go
@@ -87,7 +87,7 @@ func (s *Scraper) EndMetricsOp(
 
 	span := trace.SpanFromContext(scraperCtx)
 
-	if obsreportconfig.Level != configtelemetry.LevelNone {
+	if obsreportconfig.Level() != configtelemetry.LevelNone {
 		stats.Record(
 			scraperCtx,
 			obsmetrics.ScraperScrapedMetricPoints.M(int64(numScrapedMetrics)),

--- a/obsreport/obsreport_test.go
+++ b/obsreport/obsreport_test.go
@@ -52,6 +52,8 @@ type testParams struct {
 }
 
 func TestReceiveTraceDataOp(t *testing.T) {
+	t.Parallel()
+
 	tt, err := obsreporttest.SetupTelemetry()
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })

--- a/obsreport/obsreport_test.go
+++ b/obsreport/obsreport_test.go
@@ -52,8 +52,6 @@ type testParams struct {
 }
 
 func TestReceiveTraceDataOp(t *testing.T) {
-	t.Parallel()
-
 	tt, err := obsreporttest.SetupTelemetry()
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })


### PR DESCRIPTION
**Description:** 
In order to allow for more tests to run concurrently without triggering
the race detector, Level needs to be guarded by some atomic method.
This change makes access to the collector's Level managable via sync
method which may lead to eventual consistent.

**Link to tracking Issue:** 
[#4543](https://github.com/open-telemetry/opentelemetry-collector/pull/4542#:~:text=I%20had%20raised-,%234543,-to%20help%20track)

**Testing:** 
Nothing at the moment, not exactly sure how best to effectively change made.
