### PR TITLE
Revert "Use action/checkout fetch-depth instead of manually fetch (#4535)"

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -16,14 +16,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-        with:
-          # Only the latest commit of the feature branch is available
-          # automatically. To diff with the base branch, we need to
-          # fetch that too (and we only need its latest commit).
-          fetch-depth: 1
 
       - name: Check for CHANGELOG changes
         run: |
+          # Only the latest commit of the feature branch is available
+          # automatically. To diff with the base branch, we need to
+          # fetch that too (and we only need its latest commit).
+          git fetch origin ${{ github.base_ref }} --depth=1
           if [[ $(git diff --name-only FETCH_HEAD | grep CHANGELOG) ]]
           then
             echo "A CHANGELOG was modified. Looks good!"


### PR DESCRIPTION
This reverts commit 5405247048e4e22416d14236ad7be006f4e609a6.

The problem is happening because there's a mismatch between references: previously, the changelog was obtaining the latest commit from `github.base_ref`, which is typically `main`. The referenced commit uses the GitHub Action, which will get the latest commit from the PR itself. Running a diff between the PR against itself yields no results at all:

```console
$ git fetch origin jpkrohling/issue4556 --depth=1
remote: Total 0 (delta 0), reused 0 (delta 0), pack-reused 0
From github.com:jpkrohling/opentelemetry-collector
 * branch              jpkrohling/issue4556 -> FETCH_HEAD

$ git diff --name-only FETCH_HEAD
$
```

Whereas running the same command using `main` in the FETCH_HEAD yields

```console
$ git fetch origin main --depth=1
remote: Total 0 (delta 0), reused 0 (delta 0), pack-reused 0
From github.com:jpkrohling/opentelemetry-collector
 * branch              main       -> FETCH_HEAD

$ git diff --name-only FETCH_HEAD
CHANGELOG.md
config/configauth/configauth_test.go
config/configauth/default_serverauthenticator.go
config/configauth/default_serverauthenticator_test.go
config/configauth/mock_serverauth.go
config/configauth/mock_serverauth_test.go
config/configgrpc/configgrpc_test.go
config/confighttp/confighttp_test.go
```

Fixes #4559
