### PR TITLE
Revert separate settings for map provider and unmarshaler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Remove `configmapprovider.NewInMemory()` (#4507)
 - Disallow direct implementation of `configmapprovider.Retrieved` (#4577)
 - `configauth`: remove interceptor functions from the ServerAuthenticator interface (#4583)
+- Replace ConfigMapProvider and ConfigUnmarshaler in collector settings by one simpler ConfigProvider (#4590)
 
 ## 💡 Enhancements 💡
 

--- a/service/collector_test.go
+++ b/service/collector_test.go
@@ -37,6 +37,7 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configmapprovider"
+	"go.opentelemetry.io/collector/config/configunmarshaler"
 	"go.opentelemetry.io/collector/internal/testcomponents"
 	"go.opentelemetry.io/collector/internal/testutil"
 )
@@ -53,9 +54,9 @@ func TestCollector_StartAsGoRoutine(t *testing.T) {
 	require.NoError(t, err)
 
 	set := CollectorSettings{
-		BuildInfo:         component.NewDefaultBuildInfo(),
-		Factories:         factories,
-		ConfigMapProvider: configmapprovider.NewFile(path.Join("testdata", "otelcol-config.yaml")),
+		BuildInfo:      component.NewDefaultBuildInfo(),
+		Factories:      factories,
+		ConfigProvider: NewConfigProvider(configmapprovider.NewFile(path.Join("testdata", "otelcol-config.yaml")), configunmarshaler.NewDefault()),
 	}
 	col, err := New(set)
 	require.NoError(t, err)
@@ -94,10 +95,10 @@ func TestCollector_Start(t *testing.T) {
 	}
 
 	col, err := New(CollectorSettings{
-		BuildInfo:         component.NewDefaultBuildInfo(),
-		Factories:         factories,
-		ConfigMapProvider: configmapprovider.NewFile(path.Join("testdata", "otelcol-config.yaml")),
-		LoggingOptions:    []zap.Option{zap.Hooks(hook)},
+		BuildInfo:      component.NewDefaultBuildInfo(),
+		Factories:      factories,
+		ConfigProvider: NewConfigProvider(configmapprovider.NewFile(path.Join("testdata", "otelcol-config.yaml")), configunmarshaler.NewDefault()),
+		LoggingOptions: []zap.Option{zap.Hooks(hook)},
 	})
 	require.NoError(t, err)
 
@@ -158,9 +159,9 @@ func TestCollector_ReportError(t *testing.T) {
 	require.NoError(t, err)
 
 	col, err := New(CollectorSettings{
-		BuildInfo:         component.NewDefaultBuildInfo(),
-		Factories:         factories,
-		ConfigMapProvider: configmapprovider.NewFile(path.Join("testdata", "otelcol-config.yaml")),
+		BuildInfo:      component.NewDefaultBuildInfo(),
+		Factories:      factories,
+		ConfigProvider: NewConfigProvider(configmapprovider.NewFile(path.Join("testdata", "otelcol-config.yaml")), configunmarshaler.NewDefault()),
 	})
 	require.NoError(t, err)
 

--- a/service/collector_windows.go
+++ b/service/collector_windows.go
@@ -30,6 +30,7 @@ import (
 	"golang.org/x/sys/windows/svc/eventlog"
 
 	"go.opentelemetry.io/collector/config/configmapprovider"
+	"go.opentelemetry.io/collector/config/configunmarshaler"
 )
 
 type WindowsService struct {
@@ -135,8 +136,8 @@ func openEventLog(serviceName string) (*eventlog.Log, error) {
 }
 
 func newWithWindowsEventLogCore(set CollectorSettings, elog *eventlog.Log) (*Collector, error) {
-	if set.ConfigMapProvider == nil {
-		set.ConfigMapProvider = configmapprovider.NewDefault(getConfigFlag(), getSetFlag())
+	if set.ConfigProvider == nil {
+		set.ConfigProvider = NewConfigProvider(configmapprovider.NewDefault(getConfigFlag(), getSetFlag()), configunmarshaler.NewDefault())
 	}
 	set.LoggingOptions = append(
 		set.LoggingOptions,

--- a/service/command.go
+++ b/service/command.go
@@ -18,6 +18,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"go.opentelemetry.io/collector/config/configmapprovider"
+	"go.opentelemetry.io/collector/config/configunmarshaler"
 	"go.opentelemetry.io/collector/service/featuregate"
 )
 
@@ -30,8 +31,8 @@ func NewCommand(set CollectorSettings) *cobra.Command {
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			featuregate.Apply(featuregate.GetFlags())
-			if set.ConfigMapProvider == nil {
-				set.ConfigMapProvider = configmapprovider.NewDefault(getConfigFlag(), getSetFlag())
+			if set.ConfigProvider == nil {
+				set.ConfigProvider = NewConfigProvider(configmapprovider.NewDefault(getConfigFlag(), getSetFlag()), configunmarshaler.NewDefault())
 			}
 			col, err := New(set)
 			if err != nil {

--- a/service/command_test.go
+++ b/service/command_test.go
@@ -33,7 +33,7 @@ func TestNewCommand(t *testing.T) {
 
 func TestNewCommandMapProviderIsNil(t *testing.T) {
 	settings := CollectorSettings{}
-	settings.ConfigMapProvider = nil
+	settings.ConfigProvider = nil
 	cmd := NewCommand(settings)
 	err := cmd.Execute()
 	require.Error(t, err)

--- a/service/config_provider.go
+++ b/service/config_provider.go
@@ -71,7 +71,9 @@ type configProvider struct {
 	watcher chan error
 }
 
-func newConfigProvider(configMapProvider configmapprovider.Provider, configUnmarshaler configunmarshaler.ConfigUnmarshaler) ConfigProvider {
+// NewConfigProvider returns a new ConfigProvider that provides the configuration using the given
+// `configMapProvider` and the given `configUnmarshaler`.
+func NewConfigProvider(configMapProvider configmapprovider.Provider, configUnmarshaler configunmarshaler.ConfigUnmarshaler) ConfigProvider {
 	return &configProvider{
 		configMapProvider: configMapProvider,
 		configUnmarshaler: configUnmarshaler,

--- a/service/config_provider_test.go
+++ b/service/config_provider_test.go
@@ -130,7 +130,7 @@ func TestConfigProvider_Errors(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cfgW := newConfigProvider(tt.parserProvider, tt.configUnmarshaler)
+			cfgW := NewConfigProvider(tt.parserProvider, tt.configUnmarshaler)
 			_, errN := cfgW.Get(context.Background(), factories)
 			if tt.expectNewErr {
 				assert.Error(t, errN)
@@ -167,7 +167,7 @@ func TestConfigProvider(t *testing.T) {
 		return &errConfigMapProvider{ret: &fakeRetrieved{retM: m}}
 	}()
 
-	cfgW := newConfigProvider(parserProvider, configunmarshaler.NewDefault())
+	cfgW := NewConfigProvider(parserProvider, configunmarshaler.NewDefault())
 	_, errN := cfgW.Get(context.Background(), factories)
 	assert.NoError(t, errN)
 
@@ -191,7 +191,7 @@ func TestConfigProviderNoWatcher(t *testing.T) {
 	require.NoError(t, errF)
 
 	watcherWG := sync.WaitGroup{}
-	cfgW := newConfigProvider(configmapprovider.NewFile(path.Join("testdata", "otelcol-nop.yaml")), configunmarshaler.NewDefault())
+	cfgW := NewConfigProvider(configmapprovider.NewFile(path.Join("testdata", "otelcol-nop.yaml")), configunmarshaler.NewDefault())
 	_, errN := cfgW.Get(context.Background(), factories)
 	assert.NoError(t, errN)
 
@@ -221,7 +221,7 @@ func TestConfigProvider_ShutdownClosesWatch(t *testing.T) {
 	}()
 
 	watcherWG := sync.WaitGroup{}
-	cfgW := newConfigProvider(configMapProvider, configunmarshaler.NewDefault())
+	cfgW := NewConfigProvider(configMapProvider, configunmarshaler.NewDefault())
 	_, errN := cfgW.Get(context.Background(), factories)
 	assert.NoError(t, errN)
 

--- a/service/settings.go
+++ b/service/settings.go
@@ -20,8 +20,6 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config"
-	"go.opentelemetry.io/collector/config/configmapprovider"
-	"go.opentelemetry.io/collector/config/configunmarshaler"
 )
 
 // svcSettings holds configuration for building a new service.
@@ -59,16 +57,9 @@ type CollectorSettings struct {
 	// and manually handle the signals to shutdown the collector.
 	DisableGracefulShutdown bool
 
-	// ConfigMapProvider provides the configuration's config.Map.
-	// If it is not provided a default provider is used. The default provider loads the configuration
-	// from a config file define by the --config command line flag and overrides component's configuration
-	// properties supplied via --set command line flag.
-	// If the provider is configmapprovider.WatchableRetrieved, collector may reload the configuration upon error.
-	ConfigMapProvider configmapprovider.Provider
-
-	// ConfigUnmarshaler unmarshalls the configuration's Parser into the service configuration.
-	// If it is not provided a default unmarshaler is used.
-	ConfigUnmarshaler configunmarshaler.ConfigUnmarshaler
+	// ConfigProvider provides the service configuration.
+	// If the provider watches for configuration change, collector may reload the new configuration upon changes.
+	ConfigProvider ConfigProvider
 
 	// LoggingOptions provides a way to change behavior of zap logging.
 	LoggingOptions []zap.Option


### PR DESCRIPTION
This change was added new too long ago, but we got clear feedback that it is
unclear how the separation work and how to replace one component or the other.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
