### PR TITLE
fix nil error introduced in SetColGRPCLogger

### DIFF
--- a/service/internal/telemetrylogs/logger.go
+++ b/service/internal/telemetrylogs/logger.go
@@ -61,9 +61,14 @@ func SetColGRPCLogger(baseLogger *zap.Logger, loglevel zapcore.Level) *zapgrpc.L
 	logger := zapgrpc.NewLogger(baseLogger.WithOptions(zap.WrapCore(func(core zapcore.Core) zapcore.Core {
 		var c zapcore.Core
 		if loglevel == zap.InfoLevel {
+			var err error
 			// NewIncreaseLevelCore errors only if the new log level is less than the initial core level.
 			// In this case it never happens as WARN is always greater than INFO, therefore ignoring it.
-			c, _ = zapcore.NewIncreaseLevelCore(core, zap.WarnLevel)
+			c, err = zapcore.NewIncreaseLevelCore(core, zap.WarnLevel)
+			// In case of an error changing the level, move on, this happens when using the NopCore
+			if err != nil {
+				c = core
+			}
 		} else {
 			c = core
 		}


### PR DESCRIPTION
This was triggered by the Prometheus Staleness tests. Setting the core logger to a NopLogger can cause `NewIncreaseLevelCore` to cause the following error:
"invalid increase level, as level \"fatal\" is allowed by increased level, but not by existing core"

The change in this PR fixes that to ensure the logger is never nil.
