### PR TITLE
Otel-4467 Return an error on config.Map.Set

### DIFF
--- a/config/configmap.go
+++ b/config/configmap.go
@@ -82,12 +82,15 @@ func (l *Map) Get(key string) interface{} {
 }
 
 // Set sets the value for the key.
-func (l *Map) Set(key string, value interface{}) {
+func (l *Map) Set(key string, value interface{}) error {
 	// koanf doesn't offer a direct setting mechanism so merging is required.
 	merged := koanf.New(KeyDelimiter)
-	_ = merged.Load(confmap.Provider(map[string]interface{}{key: value}, KeyDelimiter), nil)
+	_, err = merged.Load(confmap.Provider(map[string]interface{}{key: value}, KeyDelimiter), nil)
 	// TODO (issue 4467): return this error on `Set`.
-	_ = l.k.Merge(merged)
+	if err !=nil {
+		return err
+	}
+	return l.k.Merge(merged)
 }
 
 // IsSet checks to see if the key has been set in any of the data locations.

--- a/config/configmap.go
+++ b/config/configmap.go
@@ -85,7 +85,7 @@ func (l *Map) Get(key string) interface{} {
 func (l *Map) Set(key string, value interface{}) error {
 	// koanf doesn't offer a direct setting mechanism so merging is required.
 	merged := koanf.New(KeyDelimiter)
-	_, err = merged.Load(confmap.Provider(map[string]interface{}{key: value}, KeyDelimiter), nil)
+	_, err := merged.Load(confmap.Provider(map[string]interface{}{key: value}, KeyDelimiter), nil)
 	// TODO (issue 4467): return this error on `Set`.
 	if err !=nil {
 		return err


### PR DESCRIPTION
## Important (read before submitting)
We are currently preparing for the upcoming 1.0 GA release. Pull requests that are not aligned with
the current roadmap https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/roadmap.md
and are not aimed at stabilizing and preparing the Collector for the release will not be accepted.


**Description:**  Implemented the return error on config map set function. 
Ex. Fixing a bug - Describe the bug and how this fixes the issue.

According to comment in issue #4467
seems there's at least a couple of calls that could trigger an error in this func with Load at line https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/configmap.go#L88.

**Link to tracking Issue:** 
 #4467
**Testing:** Need to discuss..

