### PR TITLE
Refactor configgrpc for compression methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
   - `service.telemetry.metrics.level` and `service.telemetry.metrics.address`
     should be used to configure collector self-metrics.
 - `configauth`: add helpers to create new server authenticators. (#4558)
+- Refactor `configgrpc` for compression methods (#4624)
 
 ## 🧰 Bug fixes 🧰
 

--- a/config/configgrpc/configgrpc.go
+++ b/config/configgrpc/configgrpc.go
@@ -44,24 +44,7 @@ import (
 	"go.opentelemetry.io/collector/internal/middleware"
 )
 
-// Compression gRPC keys for supported compression types within collector.
-const (
-	CompressionUnsupported = ""
-	CompressionGzip        = "gzip"
-	CompressionSnappy      = "snappy"
-	CompressionZstd        = "zstd"
-)
-
-var (
-	// Map of opentelemetry compression types to grpc registered compression types.
-	gRPCCompressionKeyMap = map[string]string{
-		CompressionGzip:   gzip.Name,
-		CompressionSnappy: snappy.Name,
-		CompressionZstd:   zstd.Name,
-	}
-
-	errMetadataNotFound = errors.New("no request metadata found")
-)
+var errMetadataNotFound = errors.New("no request metadata found")
 
 // Allowed balancer names to be set in grpclb_policy to discover the servers.
 var allowedBalancerNames = []string{roundrobin.Name, grpc.PickFirstBalancerName}
@@ -83,7 +66,7 @@ type GRPCClientSettings struct {
 	Endpoint string `mapstructure:"endpoint"`
 
 	// The compression key for supported compression types within collector.
-	Compression string `mapstructure:"compression"`
+	Compression middleware.CompressionType `mapstructure:"compression"`
 
 	// TLSSetting struct exposes TLS client configuration.
 	TLSSetting configtls.TLSClientSetting `mapstructure:"tls,omitempty"`
@@ -194,12 +177,9 @@ func (gcs *GRPCClientSettings) isSchemeHTTPS() bool {
 // ToDialOptions maps configgrpc.GRPCClientSettings to a slice of dial options for gRPC.
 func (gcs *GRPCClientSettings) ToDialOptions(host component.Host, settings component.TelemetrySettings) ([]grpc.DialOption, error) {
 	var opts []grpc.DialOption
-	if gcs.Compression != "" {
-		if compressionKey := GetGRPCCompressionKey(gcs.Compression); compressionKey != CompressionUnsupported {
-			opts = append(opts, grpc.WithDefaultCallOptions(grpc.UseCompressor(compressionKey)))
-		} else {
-			return nil, fmt.Errorf("unsupported compression type %q", gcs.Compression)
-		}
+	if gcs.Compression != middleware.CompressionEmpty && gcs.Compression != middleware.CompressionNone {
+		cp := GetGRPCCompressionName(gcs.Compression)
+		opts = append(opts, grpc.WithDefaultCallOptions(grpc.UseCompressor(cp)))
 	}
 
 	tlsCfg, err := gcs.TLSSetting.LoadTLSConfig()
@@ -373,14 +353,17 @@ func (gss *GRPCServerSettings) ToServerOption(host component.Host, settings comp
 	return opts, nil
 }
 
-// GetGRPCCompressionKey returns the grpc registered compression key if the
-// passed in compression key is supported, and CompressionUnsupported otherwise.
-func GetGRPCCompressionKey(compressionType string) string {
-	compressionKey := strings.ToLower(compressionType)
-	if encodingKey, ok := gRPCCompressionKeyMap[compressionKey]; ok {
-		return encodingKey
+// GetGRPCCompressionName returns compression name registered in grpc.
+func GetGRPCCompressionName(compressionType middleware.CompressionType) string {
+	switch compressionType {
+	case middleware.CompressionGzip:
+		return gzip.Name
+	case middleware.CompressionSnappy:
+		return snappy.Name
+	case middleware.CompressionZstd:
+		return zstd.Name
 	}
-	return CompressionUnsupported
+	return ""
 }
 
 // enhanceWithClientInformation intercepts the incoming RPC, replacing the incoming context with one that includes

--- a/config/configgrpc/configgrpc.go
+++ b/config/configgrpc/configgrpc.go
@@ -178,7 +178,7 @@ func (gcs *GRPCClientSettings) isSchemeHTTPS() bool {
 func (gcs *GRPCClientSettings) ToDialOptions(host component.Host, settings component.TelemetrySettings) ([]grpc.DialOption, error) {
 	var opts []grpc.DialOption
 	if gcs.Compression != middleware.CompressionEmpty && gcs.Compression != middleware.CompressionNone {
-		cp, err := GetGRPCCompressionName(gcs.Compression)
+		cp, err := getGRPCCompressionName(gcs.Compression)
 		if err != nil {
 			return nil, err
 		}
@@ -356,8 +356,8 @@ func (gss *GRPCServerSettings) ToServerOption(host component.Host, settings comp
 	return opts, nil
 }
 
-// GetGRPCCompressionName returns compression name registered in grpc.
-func GetGRPCCompressionName(compressionType middleware.CompressionType) (string, error) {
+// getGRPCCompressionName returns compression name registered in grpc.
+func getGRPCCompressionName(compressionType middleware.CompressionType) (string, error) {
 	switch compressionType {
 	case middleware.CompressionGzip:
 		return gzip.Name, nil

--- a/config/configgrpc/configgrpc_test.go
+++ b/config/configgrpc/configgrpc_test.go
@@ -63,36 +63,103 @@ func TestAllGrpcClientSettings(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
-	gcs := &GRPCClientSettings{
-		Headers: map[string]string{
-			"test": "test",
+	tests := []struct {
+		settings GRPCClientSettings
+		name     string
+		host     component.Host
+	}{
+		{
+			name: "test all with gzip compression",
+			settings: GRPCClientSettings{
+				Headers: map[string]string{
+					"test": "test",
+				},
+				Endpoint:    "localhost:1234",
+				Compression: middleware.CompressionGzip,
+				TLSSetting: configtls.TLSClientSetting{
+					Insecure: false,
+				},
+				Keepalive: &KeepaliveClientConfig{
+					Time:                time.Second,
+					Timeout:             time.Second,
+					PermitWithoutStream: true,
+				},
+				ReadBufferSize:  1024,
+				WriteBufferSize: 1024,
+				WaitForReady:    true,
+				BalancerName:    "round_robin",
+				Auth:            &configauth.Authentication{AuthenticatorID: config.NewComponentID("testauth")},
+			},
+			host: &mockHost{
+				ext: map[config.ComponentID]component.Extension{
+					config.NewComponentID("testauth"): &configauth.MockClientAuthenticator{},
+				},
+			},
 		},
-		Endpoint:    "localhost:1234",
-		Compression: middleware.CompressionGzip,
-		TLSSetting: configtls.TLSClientSetting{
-			Insecure: false,
+		{
+			name: "test all with snappy compression",
+			settings: GRPCClientSettings{
+				Headers: map[string]string{
+					"test": "test",
+				},
+				Endpoint:    "localhost:1234",
+				Compression: middleware.CompressionSnappy,
+				TLSSetting: configtls.TLSClientSetting{
+					Insecure: false,
+				},
+				Keepalive: &KeepaliveClientConfig{
+					Time:                time.Second,
+					Timeout:             time.Second,
+					PermitWithoutStream: true,
+				},
+				ReadBufferSize:  1024,
+				WriteBufferSize: 1024,
+				WaitForReady:    true,
+				BalancerName:    "round_robin",
+				Auth:            &configauth.Authentication{AuthenticatorID: config.NewComponentID("testauth")},
+			},
+			host: &mockHost{
+				ext: map[config.ComponentID]component.Extension{
+					config.NewComponentID("testauth"): &configauth.MockClientAuthenticator{},
+				},
+			},
 		},
-		Keepalive: &KeepaliveClientConfig{
-			Time:                time.Second,
-			Timeout:             time.Second,
-			PermitWithoutStream: true,
+		{
+			name: "test all with zstd compression",
+			settings: GRPCClientSettings{
+				Headers: map[string]string{
+					"test": "test",
+				},
+				Endpoint:    "localhost:1234",
+				Compression: middleware.CompressionZstd,
+				TLSSetting: configtls.TLSClientSetting{
+					Insecure: false,
+				},
+				Keepalive: &KeepaliveClientConfig{
+					Time:                time.Second,
+					Timeout:             time.Second,
+					PermitWithoutStream: true,
+				},
+				ReadBufferSize:  1024,
+				WriteBufferSize: 1024,
+				WaitForReady:    true,
+				BalancerName:    "round_robin",
+				Auth:            &configauth.Authentication{AuthenticatorID: config.NewComponentID("testauth")},
+			},
+			host: &mockHost{
+				ext: map[config.ComponentID]component.Extension{
+					config.NewComponentID("testauth"): &configauth.MockClientAuthenticator{},
+				},
+			},
 		},
-		ReadBufferSize:  1024,
-		WriteBufferSize: 1024,
-		WaitForReady:    true,
-		BalancerName:    "round_robin",
-		Auth:            &configauth.Authentication{AuthenticatorID: config.NewComponentID("testauth")},
 	}
-
-	host := &mockHost{
-		ext: map[config.ComponentID]component.Extension{
-			config.NewComponentID("testauth"): &configauth.MockClientAuthenticator{},
-		},
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			opts, err := test.settings.ToDialOptions(test.host, tt.TelemetrySettings)
+			assert.NoError(t, err)
+			assert.Len(t, opts, 9)
+		})
 	}
-
-	opts, err := gcs.ToDialOptions(host, tt.TelemetrySettings)
-	assert.NoError(t, err)
-	assert.Len(t, opts, 9)
 }
 
 func TestDefaultGrpcServerSettings(t *testing.T) {
@@ -240,6 +307,39 @@ func TestGRPCClientSettingsError(t *testing.T) {
 			settings: GRPCClientSettings{
 				Endpoint: "localhost:1234",
 				Auth:     &configauth.Authentication{AuthenticatorID: config.NewComponentID("doesntexist")},
+			},
+			host: &mockHost{},
+		},
+		{
+			err: "unsupported compression type \"zlib\"",
+			settings: GRPCClientSettings{
+				Endpoint: "localhost:1234",
+				TLSSetting: configtls.TLSClientSetting{
+					Insecure: true,
+				},
+				Compression: "zlib",
+			},
+			host: &mockHost{},
+		},
+		{
+			err: "unsupported compression type \"deflate\"",
+			settings: GRPCClientSettings{
+				Endpoint: "localhost:1234",
+				TLSSetting: configtls.TLSClientSetting{
+					Insecure: true,
+				},
+				Compression: "deflate",
+			},
+			host: &mockHost{},
+		},
+		{
+			err: "unsupported compression type \"bad\"",
+			settings: GRPCClientSettings{
+				Endpoint: "localhost:1234",
+				TLSSetting: configtls.TLSClientSetting{
+					Insecure: true,
+				},
+				Compression: "bad",
 			},
 			host: &mockHost{},
 		},

--- a/config/configgrpc/configgrpc_test.go
+++ b/config/configgrpc/configgrpc_test.go
@@ -38,6 +38,7 @@ import (
 	"go.opentelemetry.io/collector/config/configauth"
 	"go.opentelemetry.io/collector/config/confignet"
 	"go.opentelemetry.io/collector/config/configtls"
+	"go.opentelemetry.io/collector/internal/middleware"
 	"go.opentelemetry.io/collector/model/otlpgrpc"
 	"go.opentelemetry.io/collector/obsreport/obsreporttest"
 )
@@ -67,7 +68,7 @@ func TestAllGrpcClientSettings(t *testing.T) {
 			"test": "test",
 		},
 		Endpoint:    "localhost:1234",
-		Compression: "gzip",
+		Compression: middleware.CompressionGzip,
 		TLSSetting: configtls.TLSClientSetting{
 			Insecure: false,
 		},
@@ -341,36 +342,6 @@ func TestGRPCServerSettings_ToListener_Error(t *testing.T) {
 	}
 	_, err := settings.ToListener()
 	assert.Error(t, err)
-}
-
-func TestGetGRPCCompressionKey(t *testing.T) {
-	if GetGRPCCompressionKey("gzip") != CompressionGzip {
-		t.Error("gzip is marked as supported but returned unsupported")
-	}
-
-	if GetGRPCCompressionKey("Gzip") != CompressionGzip {
-		t.Error("Capitalization of CompressionGzip should not matter")
-	}
-
-	if GetGRPCCompressionKey("snappy") != CompressionSnappy {
-		t.Error("snappy is marked as supported but returned unsupported")
-	}
-
-	if GetGRPCCompressionKey("Snappy") != CompressionSnappy {
-		t.Error("Capitalization of CompressionSnappy should not matter")
-	}
-
-	if GetGRPCCompressionKey("zstd") != CompressionZstd {
-		t.Error("zstd is marked as supported but returned unsupported")
-	}
-
-	if GetGRPCCompressionKey("Zstd") != CompressionZstd {
-		t.Error("Capitalization of CompressionZstd should not matter")
-	}
-
-	if GetGRPCCompressionKey("badType") != CompressionUnsupported {
-		t.Error("badType is not supported but was returned as supported")
-	}
 }
 
 func TestHttpReception(t *testing.T) {

--- a/exporter/otlpexporter/config_test.go
+++ b/exporter/otlpexporter/config_test.go
@@ -71,7 +71,7 @@ func TestLoadConfig(t *testing.T) {
 					"another":                "somevalue",
 				},
 				Endpoint:    "1.2.3.4:1234",
-				Compression: "on",
+				Compression: "gzip",
 				TLSSetting: configtls.TLSClientSetting{
 					TLSSetting: configtls.TLSSetting{
 						CAFile: "/var/lib/mycert.pem",

--- a/exporter/otlpexporter/factory_test.go
+++ b/exporter/otlpexporter/factory_test.go
@@ -29,6 +29,7 @@ import (
 	"go.opentelemetry.io/collector/config/configtest"
 	"go.opentelemetry.io/collector/config/configtls"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
+	"go.opentelemetry.io/collector/internal/middleware"
 	"go.opentelemetry.io/collector/internal/testutil"
 )
 
@@ -105,7 +106,7 @@ func TestCreateTracesExporter(t *testing.T) {
 				ExporterSettings: config.NewExporterSettings(config.NewComponentID(typeStr)),
 				GRPCClientSettings: configgrpc.GRPCClientSettings{
 					Endpoint:    endpoint,
-					Compression: configgrpc.CompressionGzip,
+					Compression: middleware.CompressionGzip,
 				},
 			},
 		},
@@ -114,7 +115,7 @@ func TestCreateTracesExporter(t *testing.T) {
 			config: Config{
 				GRPCClientSettings: configgrpc.GRPCClientSettings{
 					Endpoint:    endpoint,
-					Compression: configgrpc.CompressionSnappy,
+					Compression: middleware.CompressionSnappy,
 				},
 			},
 		},
@@ -123,7 +124,7 @@ func TestCreateTracesExporter(t *testing.T) {
 			config: Config{
 				GRPCClientSettings: configgrpc.GRPCClientSettings{
 					Endpoint:    endpoint,
-					Compression: configgrpc.CompressionZstd,
+					Compression: middleware.CompressionZstd,
 				},
 			},
 		},
@@ -148,17 +149,6 @@ func TestCreateTracesExporter(t *testing.T) {
 					Endpoint: endpoint,
 				},
 			},
-		},
-		{
-			name: "CompressionError",
-			config: Config{
-				ExporterSettings: config.NewExporterSettings(config.NewComponentID(typeStr)),
-				GRPCClientSettings: configgrpc.GRPCClientSettings{
-					Endpoint:    endpoint,
-					Compression: "unknown compression",
-				},
-			},
-			mustFailOnStart: true,
 		},
 		{
 			name: "CaCert",

--- a/exporter/otlpexporter/testdata/config.yaml
+++ b/exporter/otlpexporter/testdata/config.yaml
@@ -11,7 +11,7 @@ exporters:
   otlp:
   otlp/2:
     endpoint: "1.2.3.4:1234"
-    compression: "on"
+    compression: "gzip"
     tls:
       ca_file: /var/lib/mycert.pem
     timeout: 10s


### PR DESCRIPTION
**Description:**
- use `middleware.CompressionType` instead of grpc's own constants.
- Not to use a map to validate compression keys.
- added tests for each compression methods.
- throw an error for zlib and deflate, which only be supported in confighttp

**Link to tracking Issue:**
#4623 