### PR TITLE
Fix: correct the value of otelcol_exporter_send_failed_requests

### DIFF
--- a/obsreport/obsreport_exporter.go
+++ b/obsreport/obsreport_exporter.go
@@ -110,7 +110,11 @@ func (exp *Exporter) recordMetrics(ctx context.Context, numSent, numFailedToSend
 		return
 	}
 	// Ignore the error for now. This should not happen.
-	_ = stats.RecordWithTags(ctx, exp.mutators, sentMeasure.M(numSent), failedToSendMeasure.M(numFailedToSend))
+	if numFailedToSend > 0 {
+		_ = stats.RecordWithTags(ctx, exp.mutators, sentMeasure.M(numSent), failedToSendMeasure.M(numFailedToSend))
+	} else {
+		_ = stats.RecordWithTags(ctx, exp.mutators, sentMeasure.M(numSent))
+	}
 }
 
 func endSpan(ctx context.Context, err error, numSent, numFailedToSend int64, sentItemsKey, failedToSendItemsKey string) {


### PR DESCRIPTION
The metric of `otelcol_exporter_send_failed_requests` defined in [obsreportconfig.go](https://github.com/open-telemetry/opentelemetry-collector/blob/main/internal/obsreportconfig/obsreportconfig.go#L95) used `view.Count()` as the aggregation. 
```go
	errorNumberView := &view.View{
		Name:        obsmetrics.ExporterPrefix + "send_failed_requests",
		Description: "number of times exporters failed to send requests to the destination",
		Measure:     obsmetrics.ExporterFailedToSendSpans,
		Aggregation: view.Count(),
	}
```
In [obsreport_exporter.go](https://github.com/open-telemetry/opentelemetry-collector/blob/main/obsreport/obsreport_exporter.go#L108), while `numFailedToSend`(`obsmetrics.ExporterFailedToSendSpans`) equals 0, it will also increase count of the metric. The actual meaning of `otelcol_exporter_send_failed_requests` is the total count of requests that sent to destination but not the failed requests.
```go
func (exp *Exporter) recordMetrics(ctx context.Context, numSent, numFailedToSend int64, sentMeasure, failedToSendMeasure *stats.Int64Measure) {
	if obsreportconfig.Level() == configtelemetry.LevelNone {
		return
	}
	// Ignore the error for now. This should not happen.
	_ = stats.RecordWithTags(ctx, exp.mutators, sentMeasure.M(numSent), failedToSendMeasure.M(numFailedToSend))
}
```