### PR TITLE
Add an option to allow config.Map conversion in the service.ConfigProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
     should be used to configure collector self-metrics.
 - `configauth`: add helpers to create new server authenticators. (#4558)
 - Refactor `configgrpc` for compression methods (#4624)
+- Add an option to allow `config.Map` conversion in the `service.ConfigProvider` (#4634)
 
 ## 🧰 Bug fixes 🧰
 


### PR DESCRIPTION
This is to allow backwards compatible "converters" to be implemented and still benefit of the default ConfigProvider implementation, as well as helping previous implementations which had a custom "config.MapProvider" to still use that + the new service.NewDefaultConfigProvider.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
