### PR TITLE
Add otlptext support for exponential histogram

### DIFF
--- a/internal/otlptext/databuffer.go
+++ b/internal/otlptext/databuffer.go
@@ -146,6 +146,14 @@ func (b *dataBuffer) logExponentialHistogramDataPoints(ps pdata.ExponentialHisto
 
 		scale := int(p.Scale())
 		factor := math.Ldexp(math.Ln2, -scale)
+		// Note: the equation used here, which is
+		//   math.Exp(index * factor)
+		// reports +Inf as the _lower_ boundary of the bucket nearest
+		// infinity, which is incorrect and can be addressed in various
+		// ways.  The OTel-Go implementation of this histogram pending
+		// in https://github.com/open-telemetry/opentelemetry-go/pull/2393
+		// uses a lookup table for the last finite boundary, which can be
+		// easily computed using `math/big` (for scales up to 20).
 
 		negB := p.Negative().BucketCounts()
 		posB := p.Positive().BucketCounts()

--- a/internal/testdata/metric.go
+++ b/internal/testdata/metric.go
@@ -258,17 +258,43 @@ func initExponentialHistogramMetric(hm pdata.Metric) {
 	initMetricAttributes13(hdp0.Attributes())
 	hdp0.SetStartTimestamp(TestMetricStartTimestamp)
 	hdp0.SetTimestamp(TestMetricTimestamp)
-	hdp0.SetCount(2)
-	hdp0.SetSum(15)
+	hdp0.SetCount(5)
+	hdp0.SetSum(0.15)
 	hdp0.SetZeroCount(1)
-	hdp1 := hdps.AppendEmpty()
+	hdp0.SetScale(1)
 
+	// positive index 1 and 2 are values sqrt(2), 2 at scale 1
+	hdp0.Positive().SetOffset(1)
+	hdp0.Positive().SetBucketCounts([]uint64{1, 1})
+	// negative index -1 and 0 are values -1/sqrt(2), -1 at scale 1
+	hdp0.Negative().SetOffset(-1)
+	hdp0.Negative().SetBucketCounts([]uint64{1, 1})
+
+	// The above will print:
+	// Bucket (-1.414214, -1.000000], Count: 1
+	// Bucket (-1.000000, -0.707107], Count: 1
+	// Bucket [0, 0], Count: 1
+	// Bucket [0.707107, 1.000000), Count: 1
+	// Bucket [1.000000, 1.414214), Count: 1
+
+	hdp1 := hdps.AppendEmpty()
 	initMetricAttributes2(hdp1.Attributes())
 	hdp1.SetStartTimestamp(TestMetricStartTimestamp)
 	hdp1.SetTimestamp(TestMetricTimestamp)
-	hdp1.SetCount(2)
-	hdp1.SetSum(15)
+	hdp1.SetCount(3)
+	hdp1.SetSum(1.25)
 	hdp1.SetZeroCount(1)
+	hdp1.SetScale(-1)
+
+	// index -1 and 0 are values 0.25, 1 at scale -1
+	hdp1.Positive().SetOffset(-1)
+	hdp1.Positive().SetBucketCounts([]uint64{1, 1})
+
+	// The above will print:
+	// Bucket [0, 0], Count: 1
+	// Bucket [0.250000, 1.000000), Count: 1
+	// Bucket [1.000000, 4.000000), Count: 1
+
 	exemplar := hdp1.Exemplars().AppendEmpty()
 	exemplar.SetTimestamp(TestMetricExemplarTimestamp)
 	exemplar.SetDoubleVal(15)


### PR DESCRIPTION
**Description:** 
Add support for printing OTLP exponential histograms

**Link to tracking Issue:** 
Fixes #4641 

**Testing:**

I ran `go test -v` with a modified test to verify that the printed format (which the test does not actually validate for any data point) is correct. 

The math equations used here are copied from https://github.com/open-telemetry/opentelemetry-go/pull/2393 where they have been extensively tested. 