### PR TITLE
github actions: mount docker sock for contrib tests

### DIFF
--- a/.github/workflows/contrib-tests.yml
+++ b/.github/workflows/contrib-tests.yml
@@ -11,6 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: cimg/go:1.17
+      # required for docker_stats receiver startup
+      volumes:
+        - /var/run/docker.sock:/var/run/docker.sock
     steps:
       - name: Setup Permissions
         run: sudo chmod -R 777 $GITHUB_WORKSPACE /github /__w/_temp


### PR DESCRIPTION
**Description:**
Fixing a bug - Adding a docker daemon domain socket volume to the contrib tests container to prevent a failure uncovered by https://github.com/open-telemetry/opentelemetry-collector-contrib/commit/3dfb70944f06a6c8c4ca886b2b9c1256b0e56141.

Example failure: https://github.com/open-telemetry/opentelemetry-collector/runs/4719103326?check_suite_focus=true

**Link to tracking Issue:**
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/7023