### PR TITLE
Remove Owais Lone from the approvers' list

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,6 @@ Approvers ([@open-telemetry/collector-approvers](https://github.com/orgs/open-te
 - [Anthony Mirabella](https://github.com/Aneurysm9), AWS
 - [Dmitrii Anoshin](https://github.com/dmitryax), Splunk
 - [Juraci Paixão Kröhling](https://github.com/jpkrohling), Grafana Labs
-- [Owais Lone](https://github.com/owais), Splunk
 
 Maintainers ([@open-telemetry/collector-maintainers](https://github.com/orgs/open-telemetry/teams/collector-maintainers)):
 


### PR DESCRIPTION
Owais is currently not able to allocate much time to the Collector.

Thank you for your contributions, Owais. I hope to see you back when you have more time!
