### PR TITLE
Remove expand cases that cannot happen with config.Map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Define a type `WatcherFunc` for onChange func instead of func pointer (#4656)
 
+## 💡 Enhancements 💡
+
+- Remove expand cases that cannot happen with config.Map (#4649)
+
 ## v0.42.0 Beta
 
 ## 🛑 Breaking changes 🛑

--- a/service/internal/configprovider/expand.go
+++ b/service/internal/configprovider/expand.go
@@ -34,8 +34,6 @@ func NewExpandConverter() func(*config.Map) error {
 
 func expandStringValues(value interface{}) interface{} {
 	switch v := value.(type) {
-	default:
-		return v
 	case string:
 		return expandEnv(v)
 	case []interface{}:
@@ -44,18 +42,8 @@ func expandStringValues(value interface{}) interface{} {
 			nslice = append(nslice, expandStringValues(vint))
 		}
 		return nslice
-	case map[string]interface{}:
-		nmap := make(map[interface{}]interface{}, len(v))
-		for k, vint := range v {
-			nmap[k] = expandStringValues(vint)
-		}
-		return nmap
-	case map[interface{}]interface{}:
-		nmap := make(map[interface{}]interface{}, len(v))
-		for k, vint := range v {
-			nmap[k] = expandStringValues(vint)
-		}
-		return nmap
+	default:
+		return v
 	}
 }
 


### PR DESCRIPTION
Using Koanf fixed the issue with AllKeys that did not correctly flatten the input map.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
