### PR TITLE
Add external process execution guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -260,6 +260,24 @@ the event happens.
 Make log message human readable and also include data that is needed for easier
 understanding of what happened and in what context.
 
+### Executing External Processes
+
+The components should avoid executing arbitrary external processes with arbitrary command
+line arguments based on user input, including input received from the network or input
+read from the configuration file. Failure to follow this rule can result in arbitrary
+remote code execution, compelled by malicious actors that can craft the input.
+
+The following limitations are recommended:
+- If an external process needs to be executed limit and hard-code the location where
+  the executable file may be located, instead of allowing the input to dictate the
+  full path to the executable.
+- If possible limit the name of the executable file to be one from a hard-coded
+  list defined at compile time.
+- If command line arguments need to be passed to the process do not take the arguments
+  from the user input directly. Instead, compose the command line arguments indirectly,
+  if necessary, deriving the value from the user input. Limit as much as possible the
+  possible space of values for command line arguments.
+
 ### Observability
 
 Out of the box, your users should be able to observe the state of your component. 


### PR DESCRIPTION
The guidelines are necessary to explain how we want to generally approach external process execution. This was recently brought up in https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/6512

If we accept these guidelines the following should happen:
- The prometheusexecreceiver should be modified to allow only a hard-coded list of exporters.
- The fluentbitextension should be either removed or significantly
  limited in terms of what locations and what executable file names it can allow.
- https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/6512
  will be rejected, possibly substituted by a plugin system that @zenmoto
  referred to in https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/6512#issuecomment-996922645
  if we find useful to have such plugin system.
