### PR TITLE
Change configmapprovider.Provider to accept an location for retrieve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## 🛑 Breaking changes 🛑
 
+- Change configmapprovider.Provider to accept a location for retrieve (#4657)
 - Define a type `WatcherFunc` for onChange func instead of func pointer (#4656)
 - Remove deprecated `configtest.LoadConfig` and `configtest.LoadConfigAndValidate` (#4659)
 

--- a/config/configmapprovider/env.go
+++ b/config/configmapprovider/env.go
@@ -16,33 +16,33 @@ package configmapprovider // import "go.opentelemetry.io/collector/config/config
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	"gopkg.in/yaml.v2"
 
 	"go.opentelemetry.io/collector/config"
 )
 
-type envMapProvider struct {
-	envName string
-}
+const envSchemeName = "env"
+
+type envMapProvider struct{}
 
 // NewEnv returns a new Provider that reads the configuration from the given environment variable.
-func NewEnv(envName string) Provider {
-	return &envMapProvider{
-		envName: envName,
-	}
+//
+// This Provider supports "env" scheme, and can be called with a selector:
+// `env:NAME_OF_ENVIRONMENT_VARIABLE`
+func NewEnv() Provider {
+	return &envMapProvider{}
 }
 
-func (emp *envMapProvider) Retrieve(context.Context, WatcherFunc) (Retrieved, error) {
-	if emp.envName == "" {
-		return nil, errors.New("config environment not specified")
+func (emp *envMapProvider) Retrieve(_ context.Context, location string, _ WatcherFunc) (Retrieved, error) {
+	if !strings.HasPrefix(location, envSchemeName+":") {
+		return nil, fmt.Errorf("%v location is not supported by %v provider", location, envSchemeName)
 	}
 
-	content := os.Getenv(emp.envName)
-
+	content := os.Getenv(location[len(envSchemeName)+1:])
 	var data map[string]interface{}
 	if err := yaml.Unmarshal([]byte(content), &data); err != nil {
 		return nil, fmt.Errorf("unable to parse yaml: %w", err)

--- a/config/configmapprovider/file.go
+++ b/config/configmapprovider/file.go
@@ -16,34 +16,46 @@ package configmapprovider // import "go.opentelemetry.io/collector/config/config
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io/ioutil"
+	"path"
+	"strings"
 
 	"gopkg.in/yaml.v2"
 
 	"go.opentelemetry.io/collector/config"
 )
 
-type fileMapProvider struct {
-	fileName string
+const fileSchemeName = "file"
+
+type fileMapProvider struct{}
+
+// NewFile returns a new Provider that reads the configuration from a file.
+//
+// This Provider supports "file" scheme, and can be called with a "location" that follows:
+//   file-location = "file:" local-path
+//   local-path    = [ drive-letter ] file-path
+//   drive-letter  = ALPHA ":"
+// The "file-path" can be relative or absolute, and it can be any OS supported format.
+//
+// Examples:
+// `file:path/to/file` - relative path (unix, windows)
+// `file:/path/to/file` - absolute path (unix, windows)
+// `file:c:/path/to/file` - absolute path including drive-letter (windows)
+// `file:c:\path\to\file` - absolute path including drive-letter (windows)
+func NewFile() Provider {
+	return &fileMapProvider{}
 }
 
-// NewFile returns a new Provider that reads the configuration from the given file.
-func NewFile(fileName string) Provider {
-	return &fileMapProvider{
-		fileName: fileName,
-	}
-}
-
-func (fmp *fileMapProvider) Retrieve(context.Context, WatcherFunc) (Retrieved, error) {
-	if fmp.fileName == "" {
-		return nil, errors.New("config file not specified")
+func (fmp *fileMapProvider) Retrieve(_ context.Context, location string, _ WatcherFunc) (Retrieved, error) {
+	if !strings.HasPrefix(location, fileSchemeName+":") {
+		return nil, fmt.Errorf("%v location is not supported by %v provider", location, fileSchemeName)
 	}
 
-	content, err := ioutil.ReadFile(fmp.fileName)
+	// Clean the path before using it.
+	content, err := ioutil.ReadFile(path.Clean(location[len(fileSchemeName)+1:]))
 	if err != nil {
-		return nil, fmt.Errorf("unable to read the file %v: %w", fmp.fileName, err)
+		return nil, fmt.Errorf("unable to read the file %v: %w", location, err)
 	}
 
 	var data map[string]interface{}

--- a/config/configmapprovider/properties.go
+++ b/config/configmapprovider/properties.go
@@ -34,13 +34,14 @@ type propertiesMapProvider struct {
 // Properties must follow the Java properties format, key-value list separated by equal sign with a "."
 // as key delimiter.
 //  ["processors.batch.timeout=2s", "processors.batch/foo.timeout=3s"]
+// TODO: Change this to be a service.ConfigMapConverterFunc.
 func NewProperties(properties []string) Provider {
 	return &propertiesMapProvider{
 		properties: properties,
 	}
 }
 
-func (pmp *propertiesMapProvider) Retrieve(context.Context, WatcherFunc) (Retrieved, error) {
+func (pmp *propertiesMapProvider) Retrieve(context.Context, string, WatcherFunc) (Retrieved, error) {
 	if len(pmp.properties) == 0 {
 		return NewRetrieved(func(ctx context.Context) (*config.Map, error) {
 			return config.NewMap(), nil

--- a/config/configmapprovider/properties_test.go
+++ b/config/configmapprovider/properties_test.go
@@ -22,6 +22,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestPropertiesProvider_Empty(t *testing.T) {
+	pmp := NewProperties(nil)
+	retr, err := pmp.Retrieve(context.Background(), "", nil)
+	require.NoError(t, err)
+	cfgMap, err := retr.Get(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(cfgMap.AllKeys()))
+	require.NoError(t, pmp.Shutdown(context.Background()))
+}
+
 func TestPropertiesProvider(t *testing.T) {
 	setFlagStr := []string{
 		"processors.batch.timeout=2s",
@@ -31,7 +41,7 @@ func TestPropertiesProvider(t *testing.T) {
 	}
 
 	pmp := NewProperties(setFlagStr)
-	retr, err := pmp.Retrieve(context.Background(), nil)
+	retr, err := pmp.Retrieve(context.Background(), "", nil)
 	require.NoError(t, err)
 	cfgMap, err := retr.Get(context.Background())
 	require.NoError(t, err)
@@ -41,15 +51,5 @@ func TestPropertiesProvider(t *testing.T) {
 	assert.Equal(t, "3s", cfgMap.Get("processors::batch/foo::timeout"))
 	assert.Equal(t, "foo:9200,foo2:9200", cfgMap.Get("exporters::kafka::brokers"))
 	assert.Equal(t, "localhost:1818", cfgMap.Get("receivers::otlp::protocols::grpc::endpoint"))
-	require.NoError(t, pmp.Shutdown(context.Background()))
-}
-
-func TestPropertiesProvider_empty(t *testing.T) {
-	pmp := NewProperties(nil)
-	retr, err := pmp.Retrieve(context.Background(), nil)
-	require.NoError(t, err)
-	cfgMap, err := retr.Get(context.Background())
-	require.NoError(t, err)
-	assert.Equal(t, 0, len(cfgMap.AllKeys()))
 	require.NoError(t, pmp.Shutdown(context.Background()))
 }

--- a/config/configmapprovider/provider.go
+++ b/config/configmapprovider/provider.go
@@ -24,11 +24,11 @@ import (
 //
 // The typical usage is the following:
 //
-//		r := mapProvider.Retrieve()
+//		r := mapProvider.Retrieve("file:/path/to/config")
 //		r.Get()
 //		// wait for onChange() to be called.
 //		r.Close()
-//		r = mapProvider.Retrieve()
+//		r = mapProvider.Retrieve("file:/path/to/config")
 //		r.Get()
 //		// wait for onChange() to be called.
 //		r.Close()
@@ -40,7 +40,11 @@ type Provider interface {
 	// contains the value to be injected in the configuration and the corresponding watcher that
 	// will be used to monitor for updates of the retrieved value.
 	//
-	// watcher callback is called when the config changes. watcher may be called from
+	// `location` must follow the "<scheme>:<opaque_data>" format. This format is compatible
+	// with the URI definition (see https://datatracker.ietf.org/doc/html/rfc3986). The "<scheme>"
+	// must be always included in the `location`.
+	//
+	// `watcher` callback is called when the config changes. watcher may be called from
 	// a different go routine. After watcher is called Retrieved.Get should be called
 	// to get the new config. See description of Retrieved for more details.
 	// watcher may be nil, which indicates that the caller is not interested in
@@ -48,7 +52,7 @@ type Provider interface {
 	//
 	// If ctx is cancelled should return immediately with an error.
 	// Should never be called concurrently with itself or with Shutdown.
-	Retrieve(ctx context.Context, watcher WatcherFunc) (Retrieved, error)
+	Retrieve(ctx context.Context, location string, watcher WatcherFunc) (Retrieved, error)
 
 	// Shutdown signals that the configuration for which this Provider was used to
 	// retrieve values is no longer in use and the Provider should close and release

--- a/config/configtest/configtest.go
+++ b/config/configtest/configtest.go
@@ -32,7 +32,7 @@ var configFieldTagRegExp = regexp.MustCompile("^[a-z0-9][a-z0-9_]*$")
 
 // LoadConfigMap loads a config.Map from file, and does NOT validate the configuration.
 func LoadConfigMap(fileName string) (*config.Map, error) {
-	ret, err := configmapprovider.NewFile(fileName).Retrieve(context.Background(), nil)
+	ret, err := configmapprovider.NewFile().Retrieve(context.Background(), "file:"+fileName, nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This is a preliminary change in order to support single/multiple local/remote config sources.
This PR changes the Provider to accept an URI as the resource identifier.

1. The current way is still fully supported and will continue to be supported, but there are more ways to specify the file:

Command line(currently supported): `./otelcol --config=local.yaml`
Command line(currently supported): `./otelcol --config=/path/to/local.yaml`
Command line(new support): `./otelcol --config=file:/path/to/local.yaml`

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
