### PR TITLE
Remove deprecated configtest.LoadConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## 🛑 Breaking changes 🛑
 
 - Define a type `WatcherFunc` for onChange func instead of func pointer (#4656)
+- Remove deprecated `configtest.LoadConfig` and `configtest.LoadConfigAndValidate` (#4659)
 
 ## 💡 Enhancements 💡
 

--- a/config/configtest/configtest.go
+++ b/config/configtest/configtest.go
@@ -23,24 +23,12 @@ import (
 
 	"go.uber.org/multierr"
 
-	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/configmapprovider"
-	"go.opentelemetry.io/collector/service/servicetest"
 )
 
 // The regular expression for valid config field tag.
 var configFieldTagRegExp = regexp.MustCompile("^[a-z0-9][a-z0-9_]*$")
-
-// Deprecated: use servicetest.LoadConfig
-func LoadConfig(fileName string, factories component.Factories) (*config.Config, error) {
-	return servicetest.LoadConfig(fileName, factories)
-}
-
-// Deprecated: use servicetest.LoadConfigAndValidate
-func LoadConfigAndValidate(fileName string, factories component.Factories) (*config.Config, error) {
-	return servicetest.LoadConfigAndValidate(fileName, factories)
-}
 
 // LoadConfigMap loads a config.Map from file, and does NOT validate the configuration.
 func LoadConfigMap(fileName string) (*config.Map, error) {

--- a/config/configunmarshaler/defaultunmarshaler_test.go
+++ b/config/configunmarshaler/defaultunmarshaler_test.go
@@ -15,7 +15,6 @@
 package configunmarshaler
 
 import (
-	"context"
 	"path/filepath"
 	"testing"
 
@@ -26,9 +25,9 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config"
-	"go.opentelemetry.io/collector/config/configmapprovider"
 	"go.opentelemetry.io/collector/config/confignet"
 	"go.opentelemetry.io/collector/config/configtelemetry"
+	"go.opentelemetry.io/collector/config/configtest"
 	"go.opentelemetry.io/collector/internal/testcomponents"
 )
 
@@ -227,9 +226,7 @@ func TestLoadEmptyAllSections(t *testing.T) {
 }
 
 func loadConfigFile(t *testing.T, fileName string, factories component.Factories) (*config.Config, error) {
-	v, err := configmapprovider.NewFile(fileName).Retrieve(context.Background(), nil)
-	require.NoError(t, err)
-	cm, err := v.Get(context.Background())
+	cm, err := configtest.LoadConfigMap(fileName)
 	require.NoError(t, err)
 
 	// Unmarshal the config from the config.Map using the given factories.

--- a/service/internal/configprovider/expand_test.go
+++ b/service/internal/configprovider/expand_test.go
@@ -15,7 +15,6 @@
 package configprovider
 
 import (
-	"context"
 	"path"
 	"testing"
 
@@ -23,7 +22,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/collector/config"
-	"go.opentelemetry.io/collector/config/configmapprovider"
 	"go.opentelemetry.io/collector/config/configtest"
 )
 
@@ -45,10 +43,7 @@ func TestNewExpandConverter(t *testing.T) {
 	t.Setenv("EXTRA_LIST_VALUE_1", valueExtraListElement+"_1")
 	t.Setenv("EXTRA_LIST_VALUE_2", valueExtraListElement+"_2")
 
-	// Cannot use configtest.LoadConfigMap because of circular deps.
-	ret, errRet := configmapprovider.NewFile(path.Join("testdata", "expand-with-no-env.yaml")).Retrieve(context.Background(), nil)
-	require.NoError(t, errRet, "Unable to get expected config")
-	expectedCfgMap, errExpected := ret.Get(context.Background())
+	expectedCfgMap, errExpected := configtest.LoadConfigMap(path.Join("testdata", "expand-with-no-env.yaml"))
 	require.NoError(t, errExpected, "Unable to get expected config")
 
 	for _, test := range testCases {

--- a/service/servicetest/configprovider.go
+++ b/service/servicetest/configprovider.go
@@ -15,27 +15,20 @@
 package servicetest // import "go.opentelemetry.io/collector/service/servicetest"
 
 import (
-	"context"
-
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config"
-	"go.opentelemetry.io/collector/config/configmapprovider"
+	"go.opentelemetry.io/collector/config/configtest"
 	"go.opentelemetry.io/collector/config/configunmarshaler"
 )
 
 // LoadConfig loads a config.Config  from file, and does NOT validate the configuration.
 func LoadConfig(fileName string, factories component.Factories) (*config.Config, error) {
 	// Read yaml config from file
-	cp, err := configmapprovider.NewFile(fileName).Retrieve(context.Background(), nil)
+	cfgMap, err := configtest.LoadConfigMap(fileName)
 	if err != nil {
 		return nil, err
 	}
-	// Unmarshal the config using the given factories.
-	m, err := cp.Get(context.Background())
-	if err != nil {
-		return nil, err
-	}
-	return configunmarshaler.NewDefault().Unmarshal(m, factories)
+	return configunmarshaler.NewDefault().Unmarshal(cfgMap, factories)
 }
 
 // LoadConfigAndValidate loads a config from the file, and validates the configuration.


### PR DESCRIPTION
Updates https://github.com/open-telemetry/opentelemetry-collector/issues/4605

Fix bunch of places in tests where we had duplicate code to avoid circular dependencies.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
