### PR TITLE
Small cleanup in tests, use t.Setenv instead of os, avoids manual cleanup

### DIFF
--- a/config/configmapprovider/env_test.go
+++ b/config/configmapprovider/env_test.go
@@ -36,10 +36,7 @@ func TestEnv_InvalidYaml(t *testing.T) {
 	bytes, err := os.ReadFile(path.Join("testdata", "invalid-yaml.yaml"))
 	require.NoError(t, err)
 	const envName = "invalid-yaml"
-	require.NoError(t, os.Setenv(envName, string(bytes)))
-	t.Cleanup(func() {
-		require.NoError(t, os.Unsetenv(envName))
-	})
+	t.Setenv(envName, string(bytes))
 	env := NewEnv(envName)
 	_, err = env.Retrieve(context.Background(), nil)
 	assert.Error(t, err)
@@ -49,10 +46,7 @@ func TestEnv(t *testing.T) {
 	bytes, err := os.ReadFile(path.Join("testdata", "default-config.yaml"))
 	require.NoError(t, err)
 	const envName = "default-config"
-	require.NoError(t, os.Setenv(envName, string(bytes)))
-	t.Cleanup(func() {
-		require.NoError(t, os.Unsetenv(envName))
-	})
+	t.Setenv(envName, string(bytes))
 	env := NewEnv(envName)
 	ret, err := env.Retrieve(context.Background(), nil)
 	assert.NoError(t, err)

--- a/config/internal/configsource/manager_test.go
+++ b/config/internal/configsource/manager_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"path"
 	"testing"
 
@@ -359,10 +358,7 @@ func TestConfigSourceManager_MultipleWatchForUpdate(t *testing.T) {
 }
 
 func TestConfigSourceManager_EnvVarHandling(t *testing.T) {
-	require.NoError(t, os.Setenv("envvar", "envvar_value"))
-	defer func() {
-		assert.NoError(t, os.Unsetenv("envvar"))
-	}()
+	t.Setenv("envvar", "envvar_value")
 
 	ctx := context.Background()
 	tstCfgSrc := testConfigSource{
@@ -414,14 +410,8 @@ func TestManager_parseStringValue(t *testing.T) {
 		},
 	})
 
-	require.NoError(t, os.Setenv("envvar", "envvar_value"))
-	defer func() {
-		assert.NoError(t, os.Unsetenv("envvar"))
-	}()
-	require.NoError(t, os.Setenv("envvar_str_key", "str_key"))
-	defer func() {
-		assert.NoError(t, os.Unsetenv("envvar_str_key"))
-	}()
+	t.Setenv("envvar", "envvar_value")
+	t.Setenv("envvar_str_key", "str_key")
 
 	tests := []struct {
 		want    interface{}


### PR DESCRIPTION
Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>

Thanks @mx-psi for this.