### PR TITLE
Remove expand cases that cannot happen with config.Map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Define a type `WatcherFunc` for onChange func instead of func pointer (#4656)
 
+## 💡 Enhancements 💡
+
+- Remove expand cases that cannot happen with config.Map (#4649)
+
 ## v0.42.0 Beta
 
 ## 🛑 Breaking changes 🛑

--- a/service/internal/configprovider/expand.go
+++ b/service/internal/configprovider/expand.go
@@ -34,8 +34,6 @@ func NewExpandConverter() func(*config.Map) error {
 
 func expandStringValues(value interface{}) interface{} {
 	switch v := value.(type) {
-	default:
-		return v
 	case string:
 		return expandEnv(v)
 	case []interface{}:
@@ -44,18 +42,8 @@ func expandStringValues(value interface{}) interface{} {
 			nslice = append(nslice, expandStringValues(vint))
 		}
 		return nslice
-	case map[string]interface{}:
-		nmap := make(map[interface{}]interface{}, len(v))
-		for k, vint := range v {
-			nmap[k] = expandStringValues(vint)
-		}
-		return nmap
-	case map[interface{}]interface{}:
-		nmap := make(map[interface{}]interface{}, len(v))
-		for k, vint := range v {
-			nmap[k] = expandStringValues(vint)
-		}
-		return nmap
+	default:
+		return v
 	}
 }
 


### PR DESCRIPTION
Using Koanf fixed the issue with AllKeys that did not correctly flatten the input map.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>

## Important (read before submitting)
We are currently preparing for the upcoming 1.0 GA release. Pull requests that are not aligned with
the current roadmap https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/roadmap.md
and are not aimed at stabilizing and preparing the Collector for the release will not be accepted.

_Delete this paragraph before submitting._

**Description:** <Describe what has changed. 
Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.>

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** < Describe what testing was performed and which tests were added.>

**Documentation:** < Describe the documentation added.>

_Please delete paragraphs that you did not use before submitting._
