### PR TITLE
Update builder README instructions to include required modules

### DIFF
--- a/cmd/builder/README.md
+++ b/cmd/builder/README.md
@@ -10,6 +10,16 @@ $ GO111MODULE=on go install go.opentelemetry.io/collector/cmd/builder@latest
 $ cat > ~/.otelcol-builder.yaml <<EOF
 exporters:
   - gomod: "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/alibabacloudlogserviceexporter v0.40.0"
+  - import: go.opentelemetry.io/collector/exporter/loggingexporter
+    gomod: go.opentelemetry.io/collector v0.40.0
+
+receivers:
+  - import: go.opentelemetry.io/collector/receiver/otlpreceiver
+    gomod: go.opentelemetry.io/collector v0.40.0
+
+processors:
+  - import: go.opentelemetry.io/collector/processor/batchprocessor
+    gomod: go.opentelemetry.io/collector v0.40.0
 EOF
 $ builder --output-path=/tmp/dist
 $ cat > /tmp/otelcol.yaml <<EOF


### PR DESCRIPTION
**Description:**

Per [this Slack thread](https://cloud-native.slack.com/archives/CJFCJHG4Q/p1641843690036300?thread_ts=1641835604.031700&cid=CJFCJHG4Q), the builder was recently updated not to include any components by default.

This PR updates the README's TL;DR example to explicitly include the required core collector modules (OTLP receiver, batch processor, and logging exporter). Without them, the collector you build following those instructions fails to run.

**Link to tracking issue:**

n/a (I just went ahead and opened this PR)

**Testing:**

To reproduce the failure:
- Clone open-telemetry/opentelemetry-collector at https://github.com/open-telemetry/opentelemetry-collector/commit/bed95f1d1c648a8c538ec2698b9f60a2d913ba3b
- Navigate into cmd/builder
- Follow TL;DR instructions, creating `~/.otelcol-builder.yaml` that only includes `alibabacloudlogserviceexporter` and no other modules
- Build the collector
- Run the collector using the provided `/tmp/otelcol.yaml` in the instructions
- You should get the following error: `unknown receivers type "otlp" for "otlp"`

After rebuilding the collector with the updated `~/.otelcol-builder.yaml` listing all the required modules, it will run successfully.