### PR TITLE
Replace service.ConfigMapConverterFunc with config.MapConverter interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Change Properties Provider to be a Converter (#4666)
 - Define a type `WatcherFunc` for onChange func instead of func pointer (#4656)
 - Remove deprecated `configtest.LoadConfig` and `configtest.LoadConfigAndValidate` (#4659)
+- Replace service.ConfigMapConverterFunc with config.MapConverter interface (#4668)
 
 ## 💡 Enhancements 💡
 

--- a/config/configmapconverter.go
+++ b/config/configmapconverter.go
@@ -1,0 +1,52 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config // import "go.opentelemetry.io/collector/config"
+
+import (
+	"context"
+)
+
+// MapConverter interface to convert a config.Map. This allows distributions
+// (or components) to build backwards compatible config converters.
+type MapConverter interface {
+	Convert(ctx context.Context, cfgMap *Map) error
+
+	// privateMapConverter is an unexported func to disallow direct implementation.
+	privateMapConverter()
+}
+
+// ConvertFunc specifies the function invoked when the MapConverter.Convert is being called.
+type ConvertFunc func(context.Context, *Map) error
+
+// Convert implements the MapConverter.Convert.
+func (f ConvertFunc) Convert(ctx context.Context, cfgMap *Map) error {
+	if f == nil {
+		return nil
+	}
+	return f(ctx, cfgMap)
+}
+
+type converter struct {
+	ConvertFunc
+}
+
+func (converter) privateMapConverter() {}
+
+// NewMapConverter returns a MapConverter configured with the provided options.
+func NewMapConverter(convertFunc ConvertFunc) MapConverter {
+	return &converter{
+		ConvertFunc: convertFunc,
+	}
+}

--- a/config/configmapconverter_test.go
+++ b/config/configmapconverter_test.go
@@ -1,0 +1,38 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config // import "go.opentelemetry.io/collector/config"
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewRetrieved_NilConvertFunc(t *testing.T) {
+	mc := NewMapConverter(nil)
+	cfgMap := NewMapFromStringMap(map[string]interface{}{"foo": "bar"})
+	assert.NoError(t, mc.Convert(context.Background(), cfgMap))
+	assert.Equal(t, map[string]interface{}{"foo": "bar"}, cfgMap.ToStringMap())
+}
+
+func TestNewConverter_ReturnError(t *testing.T) {
+	expectedErr := errors.New("my error")
+	mc := NewMapConverter(func(ctx context.Context, m *Map) error {
+		return expectedErr
+	})
+	assert.ErrorIs(t, mc.Convert(context.Background(), NewMap()), expectedErr)
+}

--- a/config/configmapprovider/properties.go
+++ b/config/configmapprovider/properties.go
@@ -16,6 +16,7 @@ package configmapprovider // import "go.opentelemetry.io/collector/config/config
 
 import (
 	"bytes"
+	"context"
 	"strings"
 
 	"github.com/knadh/koanf/maps"
@@ -24,17 +25,15 @@ import (
 	"go.opentelemetry.io/collector/config"
 )
 
-// NewOverwritePropertiesConverter returns a service.ConfigMapConverterFunc, that overrides all the given properties into the
-// input map.
+// NewOverwritePropertiesConverter returns a config.MapConverter, that overrides all the properties into the input map.
 //
 // Properties must follow the Java properties format, key-value list separated by equal sign with a "."
 // as key delimiter.
 //  ["processors.batch.timeout=2s", "processors.batch/foo.timeout=3s"]
-// TODO: Find the right place for service.ConfigMapConverterFunc and return that. Currently this will cause circular dependency.
-func NewOverwritePropertiesConverter(properties []string) func(*config.Map) error {
-	return func(cfgMap *config.Map) error {
+func NewOverwritePropertiesConverter(properties []string) config.MapConverter {
+	return config.NewMapConverter(func(_ context.Context, cfgMap *config.Map) error {
 		return convert(properties, cfgMap)
-	}
+	})
 }
 
 func convert(propsStr []string, cfgMap *config.Map) error {

--- a/config/configmapprovider/properties_test.go
+++ b/config/configmapprovider/properties_test.go
@@ -15,6 +15,7 @@
 package configmapprovider
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -24,9 +25,9 @@ import (
 )
 
 func TestOverwritePropertiesConverter_Empty(t *testing.T) {
-	pmp := NewOverwritePropertiesConverter(nil)
+	pc := NewOverwritePropertiesConverter(nil)
 	cfgMap := config.NewMapFromStringMap(map[string]interface{}{"foo": "bar"})
-	assert.NoError(t, pmp(cfgMap))
+	assert.NoError(t, pc.Convert(context.Background(), cfgMap))
 	assert.Equal(t, map[string]interface{}{"foo": "bar"}, cfgMap.ToStringMap())
 }
 
@@ -38,9 +39,9 @@ func TestOverwritePropertiesConverter(t *testing.T) {
 		"exporters.kafka.brokers=foo:9200,foo2:9200",
 	}
 
-	pmp := NewOverwritePropertiesConverter(props)
+	pc := NewOverwritePropertiesConverter(props)
 	cfgMap := config.NewMap()
-	require.NoError(t, pmp(cfgMap))
+	require.NoError(t, pc.Convert(context.Background(), cfgMap))
 	keys := cfgMap.AllKeys()
 	assert.Len(t, keys, 4)
 	assert.Equal(t, "2s", cfgMap.Get("processors::batch::timeout"))
@@ -50,7 +51,7 @@ func TestOverwritePropertiesConverter(t *testing.T) {
 }
 
 func TestOverwritePropertiesConverter_InvalidProperty(t *testing.T) {
-	pmp := NewOverwritePropertiesConverter([]string{"=2s"})
+	pc := NewOverwritePropertiesConverter([]string{"=2s"})
 	cfgMap := config.NewMap()
-	assert.Error(t, pmp(cfgMap))
+	assert.Error(t, pc.Convert(context.Background(), cfgMap))
 }

--- a/service/config_provider.go
+++ b/service/config_provider.go
@@ -67,7 +67,7 @@ type ConfigProvider interface {
 type configProvider struct {
 	locations          []string
 	configMapProviders map[string]configmapprovider.Provider
-	cfgMapConverters   []ConfigMapConverterFunc
+	cfgMapConverters   []config.MapConverter
 	configUnmarshaler  configunmarshaler.ConfigUnmarshaler
 
 	sync.Mutex
@@ -86,7 +86,7 @@ type configProvider struct {
 func NewConfigProvider(
 	locations []string,
 	configMapProviders map[string]configmapprovider.Provider,
-	cfgMapConverters []ConfigMapConverterFunc,
+	cfgMapConverters []config.MapConverter,
 	configUnmarshaler configunmarshaler.ConfigUnmarshaler) ConfigProvider {
 	return &configProvider{
 		locations:          locations,
@@ -97,10 +97,6 @@ func NewConfigProvider(
 	}
 }
 
-// ConfigMapConverterFunc is a converter function for the config.Map that allows distributions
-// (in the future components as well) to build backwards compatible config converters.
-type ConfigMapConverterFunc func(*config.Map) error
-
 // NewDefaultConfigProvider returns the default ConfigProvider, and it creates configuration from a file
 // defined by the given configFile and overwrites fields using properties.
 func NewDefaultConfigProvider(configFileName string, properties []string) ConfigProvider {
@@ -110,7 +106,7 @@ func NewDefaultConfigProvider(configFileName string, properties []string) Config
 			"file": configmapprovider.NewFile(),
 			"env":  configmapprovider.NewEnv(),
 		},
-		[]ConfigMapConverterFunc{
+		[]config.MapConverter{
 			configmapprovider.NewOverwritePropertiesConverter(properties),
 			configprovider.NewExpandConverter(),
 		},
@@ -139,7 +135,7 @@ func (cm *configProvider) Get(ctx context.Context, factories component.Factories
 
 	// Apply all converters.
 	for _, cfgMapConv := range cm.cfgMapConverters {
-		if err = cfgMapConv(cfgMap); err != nil {
+		if err = cfgMapConv.Convert(ctx, cfgMap); err != nil {
 			return nil, fmt.Errorf("cannot convert the config.Map: %w", err)
 		}
 	}

--- a/service/config_provider_test.go
+++ b/service/config_provider_test.go
@@ -100,7 +100,7 @@ func TestConfigProvider_Errors(t *testing.T) {
 		name              string
 		locations         []string
 		parserProvider    map[string]configmapprovider.Provider
-		cfgMapConverters  []ConfigMapConverterFunc
+		cfgMapConverters  []config.MapConverter
 		configUnmarshaler configunmarshaler.ConfigUnmarshaler
 		expectNewErr      bool
 		expectWatchErr    bool
@@ -142,7 +142,9 @@ func TestConfigProvider_Errors(t *testing.T) {
 				"mock": &mockProvider{},
 				"file": configmapprovider.NewFile(),
 			},
-			cfgMapConverters:  []ConfigMapConverterFunc{func(c *config.Map) error { return errors.New("converter_err") }},
+			cfgMapConverters: []config.MapConverter{
+				config.NewMapConverter(func(context.Context, *config.Map) error { return errors.New("converter_err") }),
+			},
 			configUnmarshaler: configunmarshaler.NewDefault(),
 			expectNewErr:      true,
 		},

--- a/service/internal/configprovider/expand.go
+++ b/service/internal/configprovider/expand.go
@@ -15,21 +15,20 @@
 package configprovider // import "go.opentelemetry.io/collector/service/internal/configprovider"
 
 import (
+	"context"
 	"os"
 
 	"go.opentelemetry.io/collector/config"
 )
 
-// NewExpandConverter returns a service.ConfigMapConverterFunc, that expands all environment variables for a given config.Map.
-//
-// This does not directly return service.ConfigMapConverterFunc to avoid circular dependencies, not a problem since it is internal.
-func NewExpandConverter() func(*config.Map) error {
-	return func(cfgMap *config.Map) error {
+// NewExpandConverter returns a config.MapConverter, that expands all environment variables for a given config.Map.
+func NewExpandConverter() config.MapConverter {
+	return config.NewMapConverter(func(_ context.Context, cfgMap *config.Map) error {
 		for _, k := range cfgMap.AllKeys() {
 			cfgMap.Set(k, expandStringValues(cfgMap.Get(k)))
 		}
 		return nil
-	}
+	})
 }
 
 func expandStringValues(value interface{}) interface{} {

--- a/service/internal/configprovider/expand_test.go
+++ b/service/internal/configprovider/expand_test.go
@@ -15,6 +15,7 @@
 package configprovider
 
 import (
+	"context"
 	"path"
 	"testing"
 
@@ -52,7 +53,7 @@ func TestNewExpandConverter(t *testing.T) {
 			require.NoError(t, err, "Unable to get config")
 
 			// Test that expanded configs are the same with the simple config with no env vars.
-			require.NoError(t, NewExpandConverter()(cfgMap))
+			require.NoError(t, NewExpandConverter().Convert(context.Background(), cfgMap))
 			assert.Equal(t, expectedCfgMap.ToStringMap(), cfgMap.ToStringMap())
 		})
 	}
@@ -71,7 +72,7 @@ func TestNewExpandConverter_EscapedMaps(t *testing.T) {
 				"recv": "$MAP_VALUE",
 			}},
 	)
-	require.NoError(t, NewExpandConverter()(cfgMap))
+	require.NoError(t, NewExpandConverter().Convert(context.Background(), cfgMap))
 
 	expectedMap := map[string]interface{}{
 		"test_string_map": map[string]interface{}{
@@ -108,6 +109,6 @@ func TestNewExpandConverter_EscapedEnvVars(t *testing.T) {
 			// escaped $ alone
 			"recv.7": "$",
 		}}
-	require.NoError(t, NewExpandConverter()(cfgMap))
+	require.NoError(t, NewExpandConverter().Convert(context.Background(), cfgMap))
 	assert.Equal(t, expectedMap, cfgMap.ToStringMap())
 }


### PR DESCRIPTION
This PR tries to solve 2 "todos" from the code, where the current `service.ConfigMapConverterFunc` cannot be used as return type because of circular deps.