### PR TITLE
Add `max_request_body_size` to confighttp.HTTPServerSettings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ## 💡 Enhancements 💡
 
 - Remove expand cases that cannot happen with config.Map (#4649)
+- Add `max_recv_size` to otlpreceiver's http settings (#4677)
 
 ## v0.42.0 Beta
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 ## 💡 Enhancements 💡
 
 - Remove expand cases that cannot happen with config.Map (#4649)
-- Add `max_recv_size` to otlpreceiver's http settings (#4677)
+- Add `max_request_body_size` to otlpreceiver's http settings (#4677)
 
 ## v0.42.0 Beta
 

--- a/config/confighttp/confighttp.go
+++ b/config/confighttp/confighttp.go
@@ -232,7 +232,6 @@ func (hss *HTTPServerSettings) ToListener() (net.Listener, error) {
 // returned by HTTPServerSettings.ToServer().
 type toServerOptions struct {
 	errorHandler
-	maxRequestBodySize int64
 }
 
 // ToServerOption is an option to change the behavior of the HTTP server
@@ -244,15 +243,6 @@ type ToServerOption func(opts *toServerOptions)
 func WithErrorHandler(e errorHandler) ToServerOption {
 	return func(opts *toServerOptions) {
 		opts.errorHandler = e
-	}
-}
-
-// WithMaxRequestBodySize introduce a request body size upper bound for the HTTP handler.
-// This uses http.MaxBytesReader under the hood and when the client sends a request body
-// that exceeds this limit, 400 will be returned.
-func WithMaxRequestBodySize(maxRequestBodySize int64) ToServerOption {
-	return func(opts *toServerOptions) {
-		opts.maxRequestBodySize = maxRequestBodySize
 	}
 }
 
@@ -268,8 +258,8 @@ func (hss *HTTPServerSettings) ToServer(host component.Host, settings component.
 		withErrorHandlerForDecompressor(serverOpts.errorHandler),
 	)
 
-	if serverOpts.maxRequestBodySize > 0 {
-		handler = maxRequestBodySizeInterceptor(handler, serverOpts.maxRequestBodySize)
+	if hss.MaxRequestBodySize > 0 {
+		handler = maxRequestBodySizeInterceptor(handler, hss.MaxRequestBodySize)
 	}
 
 	if hss.CORS != nil && len(hss.CORS.AllowedOrigins) > 0 {

--- a/config/confighttp/confighttp.go
+++ b/config/confighttp/confighttp.go
@@ -226,7 +226,7 @@ func (hss *HTTPServerSettings) ToListener() (net.Listener, error) {
 // returned by HTTPServerSettings.ToServer().
 type toServerOptions struct {
 	errorHandler middleware.ErrorHandler
-	maxRecvSize int64
+	maxRecvSize  int64
 }
 
 // ToServerOption is an option to change the behavior of the HTTP server

--- a/config/confighttp/confighttp.go
+++ b/config/confighttp/confighttp.go
@@ -200,8 +200,8 @@ type HTTPServerSettings struct {
 	// Auth for this receiver
 	Auth *configauth.Authentication `mapstructure:"auth,omitempty"`
 
-	// MaxRecvSize sets the maximum request body size
-	MaxRecvSize int64 `mapstructure:"max_recv_size,omitempty"`
+	// MaxRequestBodySize sets the maximum request body size in bytes
+	MaxRequestBodySize int64 `mapstructure:"max_request_body_size,omitempty"`
 }
 
 // ToListener creates a net.Listener.

--- a/receiver/otlpreceiver/config.md
+++ b/receiver/otlpreceiver/config.md
@@ -71,12 +71,12 @@ Config defines configuration for OTLP receiver.
 
 ### confighttp-HTTPServerSettings
 
-| Name                  | Type                                                      | Default      | Docs                                                                                       |
-| ----                  | ----                                                      | -------      | ----                                                                                       |
-| endpoint              | string                                                    | 0.0.0.0:4318 | Endpoint configures the listening address for the server.                                  |
-| tls                   | [configtls-TLSServerSetting](#configtls-TLSServerSetting) | <no value>   | TLSSetting struct exposes TLS client configuration.                                        |
-| cors                  | [confighttp-CORSSettings](#confighttp-CORSSettings)       | <no value>   | CORSSettings configures a receiver for HTTP cross-origin resource sharing (CORS).          |
-| max_request_body_size | int                                                       | 0            | MaxRequestBodySize configures the maximum allowed body size in bytes for a single request. |
+| Name                  | Type                                                      | Default      | Docs                                                                                                                                    |
+| ----                  | ----                                                      | -------      | ----                                                                                                                                    |
+| endpoint              | string                                                    | 0.0.0.0:4318 | Endpoint configures the listening address for the server.                                                                               |
+| tls                   | [configtls-TLSServerSetting](#configtls-TLSServerSetting) | <no value>   | TLSSetting struct exposes TLS client configuration.                                                                                     |
+| cors                  | [confighttp-CORSSettings](#confighttp-CORSSettings)       | <no value>   | CORSSettings configures a receiver for HTTP cross-origin resource sharing (CORS).                                                       |
+| max_request_body_size | int                                                       | 0            | MaxRequestBodySize configures the maximum allowed body size in bytes for a single request. The default `0` means there's no restriction |
 
 ### confighttp-CORSSettings
 

--- a/receiver/otlpreceiver/config.md
+++ b/receiver/otlpreceiver/config.md
@@ -71,12 +71,12 @@ Config defines configuration for OTLP receiver.
 
 ### confighttp-HTTPServerSettings
 
-| Name          | Type                                                      | Default      | Docs                                                                               |
-| ----          | ----                                                      | -------      | ----                                                                               |
-| endpoint      | string                                                    | 0.0.0.0:4318 | Endpoint configures the listening address for the server.                          |
-| tls           | [configtls-TLSServerSetting](#configtls-TLSServerSetting) | <no value>   | TLSSetting struct exposes TLS client configuration.                                |
-| cors          | [confighttp-CORSSettings](#confighttp-CORSSettings)       | <no value>   | CORSSettings configures a receiver for HTTP cross-origin resource sharing (CORS).  |
-| max_recv_size | int                                                       | 0            | MaxRecvSize configures the maximum allowed body size for a single request.         |
+| Name                  | Type                                                      | Default      | Docs                                                                                       |
+| ----                  | ----                                                      | -------      | ----                                                                                       |
+| endpoint              | string                                                    | 0.0.0.0:4318 | Endpoint configures the listening address for the server.                                  |
+| tls                   | [configtls-TLSServerSetting](#configtls-TLSServerSetting) | <no value>   | TLSSetting struct exposes TLS client configuration.                                        |
+| cors                  | [confighttp-CORSSettings](#confighttp-CORSSettings)       | <no value>   | CORSSettings configures a receiver for HTTP cross-origin resource sharing (CORS).          |
+| max_request_body_size | int                                                       | 0            | MaxRequestBodySize configures the maximum allowed body size in bytes for a single request. |
 
 ### confighttp-CORSSettings
 

--- a/receiver/otlpreceiver/config.md
+++ b/receiver/otlpreceiver/config.md
@@ -71,11 +71,12 @@ Config defines configuration for OTLP receiver.
 
 ### confighttp-HTTPServerSettings
 
-| Name | Type | Default | Docs |
-| ---- | ---- | ------- | ---- |
-| endpoint |string| 0.0.0.0:4318 | Endpoint configures the listening address for the server.  |
-| tls |[configtls-TLSServerSetting](#configtls-TLSServerSetting)| <no value> | TLSSetting struct exposes TLS client configuration.  |
-| cors |[confighttp-CORSSettings](#confighttp-CORSSettings)| <no value> | CORSSettings configures a receiver for HTTP cross-origin resource sharing (CORS). |
+| Name          | Type                                                      | Default      | Docs                                                                               |
+| ----          | ----                                                      | -------      | ----                                                                               |
+| endpoint      | string                                                    | 0.0.0.0:4318 | Endpoint configures the listening address for the server.                          |
+| tls           | [configtls-TLSServerSetting](#configtls-TLSServerSetting) | <no value>   | TLSSetting struct exposes TLS client configuration.                                |
+| cors          | [confighttp-CORSSettings](#confighttp-CORSSettings)       | <no value>   | CORSSettings configures a receiver for HTTP cross-origin resource sharing (CORS).  |
+| max_recv_size | int                                                       | 0            | MaxRecvSize configures the maximum allowed body size for a single request.         |
 
 ### confighttp-CORSSettings
 

--- a/receiver/otlpreceiver/otlp.go
+++ b/receiver/otlpreceiver/otlp.go
@@ -134,6 +134,7 @@ func (r *otlpReceiver) startProtocolServers(host component.Host) error {
 			r.settings.TelemetrySettings,
 			r.httpMux,
 			confighttp.WithErrorHandler(errorHandler),
+			confighttp.WithMaxRecvSize(r.cfg.HTTP.MaxRecvSize),
 		)
 		if err != nil {
 			return err

--- a/receiver/otlpreceiver/otlp.go
+++ b/receiver/otlpreceiver/otlp.go
@@ -134,7 +134,7 @@ func (r *otlpReceiver) startProtocolServers(host component.Host) error {
 			r.settings.TelemetrySettings,
 			r.httpMux,
 			confighttp.WithErrorHandler(errorHandler),
-			confighttp.WithMaxRecvSize(r.cfg.HTTP.MaxRequestBodySize),
+			confighttp.WithMaxRequestBodySize(r.cfg.HTTP.MaxRequestBodySize),
 		)
 		if err != nil {
 			return err

--- a/receiver/otlpreceiver/otlp.go
+++ b/receiver/otlpreceiver/otlp.go
@@ -134,7 +134,7 @@ func (r *otlpReceiver) startProtocolServers(host component.Host) error {
 			r.settings.TelemetrySettings,
 			r.httpMux,
 			confighttp.WithErrorHandler(errorHandler),
-			confighttp.WithMaxRecvSize(r.cfg.HTTP.MaxRecvSize),
+			confighttp.WithMaxRecvSize(r.cfg.HTTP.MaxRequestBodySize),
 		)
 		if err != nil {
 			return err

--- a/receiver/otlpreceiver/otlp.go
+++ b/receiver/otlpreceiver/otlp.go
@@ -134,7 +134,6 @@ func (r *otlpReceiver) startProtocolServers(host component.Host) error {
 			r.settings.TelemetrySettings,
 			r.httpMux,
 			confighttp.WithErrorHandler(errorHandler),
-			confighttp.WithMaxRequestBodySize(r.cfg.HTTP.MaxRequestBodySize),
 		)
 		if err != nil {
 			return err

--- a/receiver/otlpreceiver/otlp_test.go
+++ b/receiver/otlpreceiver/otlp_test.go
@@ -668,7 +668,7 @@ func TestHTTPUseLegacyPortWhenUsingDefaultEndpoint(t *testing.T) {
 	require.Equal(t, defaultHTTPEndpoint, metric.cfg.HTTP.Endpoint)
 }
 
-func TestHTTPMaxRecvSize(t *testing.T) {
+func TestHTTPMaxRequestBodySize(t *testing.T) {
 	jsonDataLength := len(traceJSON)
 	endpoint := testutil.GetAvailableLocalAddress(t)
 	url := fmt.Sprintf("http://%s/v1/traces", endpoint)

--- a/receiver/otlpreceiver/otlp_test.go
+++ b/receiver/otlpreceiver/otlp_test.go
@@ -676,7 +676,7 @@ func TestHTTPMaxRecvSize(t *testing.T) {
 		ReceiverSettings: config.NewReceiverSettings(config.NewComponentID(typeStr)),
 		Protocols: Protocols{
 			HTTP: &confighttp.HTTPServerSettings{
-				Endpoint: endpoint,
+				Endpoint:    endpoint,
 				MaxRecvSize: int64(jsonDataLength),
 			},
 		},
@@ -693,14 +693,14 @@ func TestHTTPMaxRecvSize(t *testing.T) {
 
 	resp, err := http.Post(url, "application/json", bytes.NewReader(traceJSON))
 	require.NoError(t, err)
-	body, err := ioutil.ReadAll(resp.Body)
+	_, err = ioutil.ReadAll(resp.Body)
 	require.NoError(t, err)
 	require.Equal(t, 200, resp.StatusCode)
 
 	err = r.Shutdown(context.Background())
 	require.NoError(t, err)
 
-	cfg.Protocols.HTTP.MaxRecvSize -= 1
+	cfg.Protocols.HTTP.MaxRecvSize--
 	r, err = NewFactory().CreateTracesReceiver(
 		context.Background(),
 		componenttest.NewNopReceiverCreateSettings(),
@@ -713,7 +713,7 @@ func TestHTTPMaxRecvSize(t *testing.T) {
 	resp, err = http.Post(url, "application/json", bytes.NewReader(traceJSON))
 	require.NoError(t, err)
 	require.Equal(t, 400, resp.StatusCode)
-	body, err = ioutil.ReadAll(resp.Body)
+	body, err := ioutil.ReadAll(resp.Body)
 	require.NoError(t, err)
 	require.Contains(t, string(body), "request body too large")
 }

--- a/receiver/otlpreceiver/otlp_test.go
+++ b/receiver/otlpreceiver/otlp_test.go
@@ -676,8 +676,8 @@ func TestHTTPMaxRecvSize(t *testing.T) {
 		ReceiverSettings: config.NewReceiverSettings(config.NewComponentID(typeStr)),
 		Protocols: Protocols{
 			HTTP: &confighttp.HTTPServerSettings{
-				Endpoint:    endpoint,
-				MaxRecvSize: int64(jsonDataLength),
+				Endpoint:           endpoint,
+				MaxRequestBodySize: int64(jsonDataLength),
 			},
 		},
 	}
@@ -704,7 +704,7 @@ func TestHTTPMaxRecvSize(t *testing.T) {
 	err = r.Shutdown(context.Background())
 	require.NoError(t, err)
 
-	cfg.Protocols.HTTP.MaxRecvSize--
+	cfg.Protocols.HTTP.MaxRequestBodySize--
 	r, err = NewFactory().CreateTracesReceiver(
 		context.Background(),
 		componenttest.NewNopReceiverCreateSettings(),

--- a/receiver/otlpreceiver/otlp_test.go
+++ b/receiver/otlpreceiver/otlp_test.go
@@ -691,7 +691,11 @@ func TestHTTPMaxRecvSize(t *testing.T) {
 	assert.NotNil(t, r)
 	require.NoError(t, r.Start(context.Background(), componenttest.NewNopHost()))
 
-	resp, err := http.Post(url, "application/json", bytes.NewReader(traceJSON))
+	req, err := http.NewRequest("POST", url, bytes.NewReader(traceJSON))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	client := &http.Client{}
+	resp, err := client.Do(req)
 	require.NoError(t, err)
 	_, err = ioutil.ReadAll(resp.Body)
 	require.NoError(t, err)
@@ -710,7 +714,10 @@ func TestHTTPMaxRecvSize(t *testing.T) {
 	assert.NotNil(t, r)
 	require.NoError(t, r.Start(context.Background(), componenttest.NewNopHost()))
 
-	resp, err = http.Post(url, "application/json", bytes.NewReader(traceJSON))
+	req, err = http.NewRequest("POST", url, bytes.NewReader(traceJSON))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err = client.Do(req)
 	require.NoError(t, err)
 	require.Equal(t, 400, resp.StatusCode)
 	body, err := ioutil.ReadAll(resp.Body)


### PR DESCRIPTION
**Description:**
Add a max_recv_size option to otlpreceiver's http endpoint.
When not specified it is the default zero value 0, in which case will not introduce the size limit.

**Link to tracking Issue:** #4669

**Testing:**
- a new `TestHTTPMaxRecvSize` test is added in **otlp_test.go** (this uses the existing global json data to test)
- also manually tested

screenshot of a packet capture session for **x-protobuf** content-type
setting `max_recv_size` to 74 for a size 75 message:
![image](https://user-images.githubusercontent.com/7122156/149290899-7b1b11b4-d267-4e20-8ef7-e847778aea62.png)
![image](https://user-images.githubusercontent.com/7122156/149290960-595ff1c2-1f7d-4de6-992f-1c337a49aabb.png)


**Documentation:**
update README for otlpreceiver and CHANGELOG
