### PR TITLE
Transform component.ExtensionFactory into a struct. 

### DIFF
--- a/component/componenttest/nop_extension.go
+++ b/component/componenttest/nop_extension.go
@@ -19,7 +19,6 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config"
-	"go.opentelemetry.io/collector/internal/internalinterface"
 )
 
 // NewNopExtensionCreateSettings returns a new nop settings for Create*Extension functions.
@@ -34,37 +33,19 @@ type nopExtensionConfig struct {
 	config.ExtensionSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
 }
 
-// nopExtensionFactory is factory for nopExtension.
-type nopExtensionFactory struct {
-	internalinterface.BaseInternal
-}
-
-var nopExtensionFactoryInstance = &nopExtensionFactory{}
-
 // NewNopExtensionFactory returns a component.ExtensionFactory that constructs nop extensions.
 func NewNopExtensionFactory() component.ExtensionFactory {
-	return nopExtensionFactoryInstance
-}
-
-// Type gets the type of the Extension config created by this factory.
-func (f *nopExtensionFactory) Type() config.Type {
-	return "nop"
-}
-
-// CreateDefaultConfig creates the default configuration for the Extension.
-func (f *nopExtensionFactory) CreateDefaultConfig() config.Extension {
-	return &nopExtensionConfig{
-		ExtensionSettings: config.NewExtensionSettings(config.NewComponentID("nop")),
+	return component.ExtensionFactory{
+		CfgType: "nop",
+		ExtensionCreateDefaultConfigFunc: func() config.Extension {
+			return &nopExtensionConfig{
+				ExtensionSettings: config.NewExtensionSettings(config.NewComponentID("nop")),
+			}
+		},
+		CreateExtensionFunc: func(context.Context, component.ExtensionCreateSettings, config.Extension) (component.Extension, error) {
+			return nopExtensionInstance, nil
+		},
 	}
-}
-
-// CreateExtension implements component.ExtensionFactory interface.
-func (f *nopExtensionFactory) CreateExtension(
-	_ context.Context,
-	_ component.ExtensionCreateSettings,
-	_ config.Extension,
-) (component.Extension, error) {
-	return nopExtensionInstance, nil
 }
 
 var nopExtensionInstance = &nopExtension{}

--- a/config/configunmarshaler/defaultunmarshaler.go
+++ b/config/configunmarshaler/defaultunmarshaler.go
@@ -143,8 +143,8 @@ func unmarshalExtensions(exts map[config.ComponentID]map[string]interface{}, fac
 	// Iterate over extensions and create a config for each.
 	for id, value := range exts {
 		// Find extension factory based on "type" that we read from config source.
-		factory := factories[id.Type()]
-		if factory == nil {
+		factory, ok := factories[id.Type()]
+		if !ok {
 			return nil, errorUnknownType(extensionsKeyName, id, reflect.ValueOf(factories).MapKeys())
 		}
 

--- a/extension/extensionhelper/factory.go
+++ b/extension/extensionhelper/factory.go
@@ -15,60 +15,29 @@
 package extensionhelper // import "go.opentelemetry.io/collector/extension/extensionhelper"
 
 import (
-	"context"
-
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config"
-	"go.opentelemetry.io/collector/internal/internalinterface"
 )
 
-// FactoryOption apply changes to ExporterOptions.
-type FactoryOption func(o *factory)
+// Deprecated: not needed, will be removed soon.
+type FactoryOption struct{}
 
-// CreateDefaultConfig is the equivalent of component.ExtensionFactory.CreateDefaultConfig()
-type CreateDefaultConfig func() config.Extension
+// Deprecated: use component.ExtensionCreateDefaultConfigFunc.
+type CreateDefaultConfig = component.ExtensionCreateDefaultConfigFunc
 
-// CreateServiceExtension is the equivalent of component.ExtensionFactory.CreateExtension()
-type CreateServiceExtension func(context.Context, component.ExtensionCreateSettings, config.Extension) (component.Extension, error)
+// Deprecated: use component.CreateExtensionFunc.
+type CreateServiceExtension = component.CreateExtensionFunc
 
-type factory struct {
-	internalinterface.BaseInternal
-	cfgType                config.Type
-	createDefaultConfig    CreateDefaultConfig
-	createServiceExtension CreateServiceExtension
-}
-
-// NewFactory returns a component.ExtensionFactory.
+// Deprecated: use component.ExtensionFactory directly.
 func NewFactory(
 	cfgType config.Type,
-	createDefaultConfig CreateDefaultConfig,
-	createServiceExtension CreateServiceExtension,
+	createDefaultConfig component.ExtensionCreateDefaultConfigFunc,
+	createServiceExtension component.CreateExtensionFunc,
 	options ...FactoryOption) component.ExtensionFactory {
-	f := &factory{
-		cfgType:                cfgType,
-		createDefaultConfig:    createDefaultConfig,
-		createServiceExtension: createServiceExtension,
-	}
-	for _, opt := range options {
-		opt(f)
+	f := component.ExtensionFactory{
+		CfgType:                          cfgType,
+		ExtensionCreateDefaultConfigFunc: createDefaultConfig,
+		CreateExtensionFunc:              createServiceExtension,
 	}
 	return f
-}
-
-// Type gets the type of the Extension config created by this factory.
-func (f *factory) Type() config.Type {
-	return f.cfgType
-}
-
-// CreateDefaultConfig creates the default configuration for processor.
-func (f *factory) CreateDefaultConfig() config.Extension {
-	return f.createDefaultConfig()
-}
-
-// CreateExtension creates a component.TraceExtension based on this config.
-func (f *factory) CreateExtension(
-	ctx context.Context,
-	set component.ExtensionCreateSettings,
-	cfg config.Extension) (component.Extension, error) {
-	return f.createServiceExtension(ctx, set, cfg)
 }

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -55,7 +55,7 @@ func TestService_GetFactory(t *testing.T) {
 	assert.EqualValues(t, nil, factory)
 
 	factory = srv.GetFactory(component.KindExtension, "nop")
-	assert.EqualValues(t, factories.Extensions["nop"], factory)
+	assert.Equal(t, factories.Extensions["nop"], factory)
 	factory = srv.GetFactory(component.KindExtension, "wrongtype")
 	assert.EqualValues(t, nil, factory)
 


### PR DESCRIPTION
Other benefits/things discovered
* No need to have the helper packages, we can remove all "helper" packages to component (independent of this PR).
* Remove the internalinterface, and dependency between packages (component, internal, helpers). May help in the future with splitting into different packages.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
