### PR TITLE
Change key cache to use hash go sum only

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /home/runner/go/pkg/mod
-          key: go-pkg-mod-${{ runner.os }}-${{ hashFiles('**/go.mod', '**/go.sum') }}
+          key: go-pkg-mod-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
       - name: Install dependencies
         if: steps.module-cache.outputs.cache-hit != 'true'
         run: make gomoddownload
@@ -57,7 +57,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /home/runner/go/pkg/mod
-          key: go-pkg-mod-${{ runner.os }}-${{ hashFiles('**/go.mod', '**/go.sum') }}
+          key: go-pkg-mod-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
       - name: Cache Tools
         id: tool-cache
         uses: actions/cache@v2
@@ -103,7 +103,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /home/runner/go/pkg/mod
-          key: go-pkg-mod-${{ runner.os }}-${{ hashFiles('**/go.mod', '**/go.sum') }}
+          key: go-pkg-mod-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
       - name: Cache Tools
         id: tool-cache
         uses: actions/cache@v2
@@ -114,7 +114,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /home/runner/.cache/go-build
-          key: go-build-unittest-${{ runner.os }}-${{ hashFiles('**/go.mod', '**/go.sum') }}
+          key: go-build-unittest-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
       - name: Run Unit Tests
         run: make gotest
   test-coverage:
@@ -136,7 +136,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /home/runner/go/pkg/mod
-          key: go-pkg-mod-${{ runner.os }}-${{ hashFiles('**/go.mod', '**/go.sum') }}
+          key: go-pkg-mod-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
       - name: Cache Tools
         id: tool-cache
         uses: actions/cache@v2
@@ -147,7 +147,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /home/runner/.cache/go-build
-          key: go-build-coverage-${{ runner.os }}-${{ hashFiles('**/go.mod', '**/go.sum') }}
+          key: go-build-coverage-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
       - name: Run Unit Tests With Coverage
         run: make gotest-with-cover
       - name: Upload coverage report


### PR DESCRIPTION
**Description:** 
Currently, the key used for cache is based on all hash go.mod and go.sum files. However, go.sum is enough unique to become a hash key for the cache. As a result, it would decrease the time to hash the files and execute the workflow more faster.

**Link to tracking Issue:** <Issue number if applicable>
N/A

**Testing:** < Describe what testing was performed and which tests were added.>
We can test it on the ```buid-and-test``` workflow which will be tested with a Pull Request.

**Documentation:** < Describe the documentation added.>
N/A
