### PR TITLE
Change to comment for some description in pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,14 +5,12 @@ and are not aimed at stabilizing and preparing the Collector for the release wil
 
 _Delete this paragraph before submitting._
 
-**Description:** <Describe what has changed. 
-Ex. Fixing a bug - Describe the bug and how this fixes the issue.
-Ex. Adding a feature - Explain what this achieves.>
+**Description:** <Describe what has changed.>
+<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
+Ex. Adding a feature - Explain what this achieves.-->
 
 **Link to tracking Issue:** <Issue number if applicable>
 
-**Testing:** < Describe what testing was performed and which tests were added.>
+**Testing:** <Describe what testing was performed and which tests were added.>
 
-**Documentation:** < Describe the documentation added.>
-
-_Please delete paragraphs that you did not use before submitting._
+**Documentation:** <Describe the documentation added.>


### PR DESCRIPTION
**Description:** 
Instead of manually deleting the description paragraph, it would be better for developers to see those as comments and only needs to review as less as possible before creating the PR. Therefore, it will decrease the time for them to open a PR.

**Link to tracking Issue:** 
N/A

**Testing:** 
Capture a picture with the final pull request template that is attached below.

**Documentation:** 
N/A

**Atteched Image:**
![image](https://user-images.githubusercontent.com/91758108/149429942-07266ee0-2b04-45f4-92c0-1606859e0331.png)

