### PR TITLE
Update otel-config.yaml - modify comment about Jaeger endpoint type

### DIFF
--- a/examples/k8s/otel-config.yaml
+++ b/examples/k8s/otel-config.yaml
@@ -189,7 +189,7 @@ spec:
         ports:
         - containerPort: 55679 # Default endpoint for ZPages.
         - containerPort: 4317 # Default endpoint for OpenTelemetry receiver.
-        - containerPort: 14250 # Default endpoint for Jaeger HTTP receiver.
+        - containerPort: 14250 # Default endpoint for Jaeger gRPC receiver.
         - containerPort: 14268 # Default endpoint for Jaeger HTTP receiver.
         - containerPort: 9411 # Default endpoint for Zipkin receiver.
         - containerPort: 8888  # Default endpoint for querying metrics.


### PR DESCRIPTION
**Description:** <Describe what has changed. 
Adjust comment to differentiate between Jaeger http (rest-ish) vs grpc endpoints
