### PR TITLE
Include valid factories in error when unknown type in config

### DIFF
--- a/config/configunmarshaler/defaultunmarshaler.go
+++ b/config/configunmarshaler/defaultunmarshaler.go
@@ -145,7 +145,7 @@ func unmarshalExtensions(exts map[config.ComponentID]map[string]interface{}, fac
 		// Find extension factory based on "type" that we read from config source.
 		factory := factories[id.Type()]
 		if factory == nil {
-			return nil, errorUnknownType(extensionsKeyName, id, factories)
+			return nil, errorUnknownType(extensionsKeyName, id, reflect.ValueOf(factories).MapKeys())
 		}
 
 		// Create the default config for this extension.
@@ -234,7 +234,7 @@ func unmarshalReceivers(recvs map[config.ComponentID]map[string]interface{}, fac
 		// Find receiver factory based on "type" that we read from config source.
 		factory := factories[id.Type()]
 		if factory == nil {
-			return nil, errorUnknownType(receiversKeyName, id, factories)
+			return nil, errorUnknownType(receiversKeyName, id, reflect.ValueOf(factories).MapKeys())
 		}
 
 		receiverCfg, err := LoadReceiver(config.NewMapFromStringMap(value), id, factory)
@@ -258,7 +258,7 @@ func unmarshalExporters(exps map[config.ComponentID]map[string]interface{}, fact
 		// Find exporter factory based on "type" that we read from config source.
 		factory := factories[id.Type()]
 		if factory == nil {
-			return nil, errorUnknownType(exportersKeyName, id, factories)
+			return nil, errorUnknownType(exportersKeyName, id, reflect.ValueOf(factories).MapKeys())
 		}
 
 		// Create the default config for this exporter.
@@ -286,7 +286,7 @@ func unmarshalProcessors(procs map[config.ComponentID]map[string]interface{}, fa
 		// Find processor factory based on "type" that we read from config source.
 		factory := factories[id.Type()]
 		if factory == nil {
-			return nil, errorUnknownType(processorsKeyName, id, factories)
+			return nil, errorUnknownType(processorsKeyName, id, reflect.ValueOf(factories).MapKeys())
 		}
 
 		// Create the default config for this processor.
@@ -313,15 +313,8 @@ func unmarshal(componentSection *config.Map, intoCfg interface{}) error {
 	return componentSection.UnmarshalExact(intoCfg)
 }
 
-func errorUnknownType(component string, id config.ComponentID, extensions interface{}) error {
-	// 'extensions' SHOULD be a map[config.Type]component.<x>Factory
-	v := reflect.ValueOf(extensions)
-	if v.Kind() != reflect.Map {
-		return fmt.Errorf("unknown %s type %q for %q (internal error: extension map is a %T)", component, id.Type(), id, extensions)
-	}
-
-	validValues := v.MapKeys()
-	return fmt.Errorf("unknown %s type %q for %q (valid values: %v)", component, id.Type(), id, validValues)
+func errorUnknownType(component string, id config.ComponentID, factories []reflect.Value) error {
+	return fmt.Errorf("unknown %s type %q for %q (valid values: %v)", component, id.Type(), id, factories)
 }
 
 func errorUnmarshalError(component string, id config.ComponentID, err error) error {

--- a/config/configunmarshaler/defaultunmarshaler_test.go
+++ b/config/configunmarshaler/defaultunmarshaler_test.go
@@ -253,3 +253,8 @@ func TestDefaultLoggerConfig(t *testing.T) {
 			InitialFields:     zapProdCfg.InitialFields,
 		}, cfg.Service.Telemetry.Logs)
 }
+
+func TestErrorUnknownTypeNoMap(t *testing.T) {
+	err := errorUnknownType("pinepple", config.NewComponentID("pineapple"), -1)
+	assert.Error(t, err)
+}

--- a/config/configunmarshaler/defaultunmarshaler_test.go
+++ b/config/configunmarshaler/defaultunmarshaler_test.go
@@ -253,8 +253,3 @@ func TestDefaultLoggerConfig(t *testing.T) {
 			InitialFields:     zapProdCfg.InitialFields,
 		}, cfg.Service.Telemetry.Logs)
 }
-
-func TestErrorUnknownTypeNoMap(t *testing.T) {
-	err := errorUnknownType("pinepple", config.NewComponentID("pineapple"), -1)
-	assert.Error(t, err)
-}


### PR DESCRIPTION
**Description:** <Describe what has changed. 
Better error message when config is invalid

**Link to tracking Issue:** <Issue number if applicable>
This is a replacement for PR https://github.com/open-telemetry/opentelemetry-collector/pull/4517 which seems to be going nowhere.

**Testing:**
I added a simple test for code coverage.  I mostly tested manually with 
```
receivers:
  otlp:
    protocols:
      http:

exporters:
  pineapple:
    logLevel: debug

service:
  pipelines:
    traces:
      receivers: [otlp]
      exporters: [pineapple]
```
which causes the output to become `collector server run finished with error: failed to get config: cannot unmarshal the configuration: unknown exporters type "pineapple" for "pineapple" (valid values: [otlp otlphttp logging])`.  (The valid values the new part of the `error`)

cc @jpkrohling 