### PR TITLE
Correctly clone windows logging encoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@
 - Move `compression.go` into `confighttp.go` to internalize functions in `compression.go` file. (#4651)
   - create `configcompression` package to manage compression methods in `confighttp` and `configgrpc`
 
+## 🧰 Bug fixes 🧰
+
+- Fix structured logging issue for windows service (#4686)
+
 ## v0.42.0 Beta
 
 ## 🛑 Breaking changes 🛑

--- a/service/collector_windows.go
+++ b/service/collector_windows.go
@@ -156,7 +156,15 @@ func (w windowsEventLogCore) Enabled(level zapcore.Level) bool {
 }
 
 func (w windowsEventLogCore) With(fields []zapcore.Field) zapcore.Core {
-	return withWindowsCore(w.elog)(w.core.With(fields))
+	enc := w.encoder.Clone()
+	for _, field := range fields {
+		field.AddTo(enc)
+	}
+	return windowsEventLogCore{
+		core:    w.core,
+		elog:    w.elog,
+		encoder: enc,
+	}
 }
 
 func (w windowsEventLogCore) Check(ent zapcore.Entry, ce *zapcore.CheckedEntry) *zapcore.CheckedEntry {


### PR DESCRIPTION
**Description:**
Fixes #4685. When `With` is called, clone the original encoder instead of creating a new one. Fields were being dropped because fields are apart of the encoder and each new call to `With` was creating a new encoder.

**Link to tracking issue:**
https://github.com/open-telemetry/opentelemetry-collector/issues/4685

**Testing:**
Tested manually with a windows service.