### PR TITLE
configHttp: Ability to pass telemetry settings to http instrument  library that instruments the otlphttp exporter#4449

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## 🛑 Breaking changes 🛑
 
 - Define a type `WatcherFunc` for onChange func instead of func pointer (#4656)
+- Updated confighttp `ToClient` to support passing telemetry settings for instrumenting otlphttp exporter(#4449)
 
 ## v0.42.0 Beta
 

--- a/config/confighttp/confighttp_test.go
+++ b/config/confighttp/confighttp_test.go
@@ -194,7 +194,6 @@ func TestPartialHTTPClientSettings(t *testing.T) {
 	}
 }
 
-
 func TestDefaultHTTPClientSettings(t *testing.T) {
 	httpClientSettings := DefaultHTTPClientSettings()
 	assert.EqualValues(t, 100, *httpClientSettings.MaxIdleConns)

--- a/exporter/otlphttpexporter/factory.go
+++ b/exporter/otlphttpexporter/factory.go
@@ -77,7 +77,7 @@ func createTracesExporter(
 	set component.ExporterCreateSettings,
 	cfg config.Exporter,
 ) (component.TracesExporter, error) {
-	oce, err := newExporter(cfg, set.Logger, set.BuildInfo)
+	oce, err := newExporter(cfg, set.Logger, set.TelemetrySettings, set.BuildInfo)
 	if err != nil {
 		return nil, err
 	}
@@ -105,7 +105,7 @@ func createMetricsExporter(
 	set component.ExporterCreateSettings,
 	cfg config.Exporter,
 ) (component.MetricsExporter, error) {
-	oce, err := newExporter(cfg, set.Logger, set.BuildInfo)
+	oce, err := newExporter(cfg, set.Logger, set.TelemetrySettings, set.BuildInfo)
 	if err != nil {
 		return nil, err
 	}
@@ -133,7 +133,7 @@ func createLogsExporter(
 	set component.ExporterCreateSettings,
 	cfg config.Exporter,
 ) (component.LogsExporter, error) {
-	oce, err := newExporter(cfg, set.Logger, set.BuildInfo)
+	oce, err := newExporter(cfg, set.Logger, set.TelemetrySettings, set.BuildInfo)
 	if err != nil {
 		return nil, err
 	}

--- a/exporter/otlphttpexporter/otlp.go
+++ b/exporter/otlphttpexporter/otlp.go
@@ -83,7 +83,7 @@ func newExporter(cfg config.Exporter, logger *zap.Logger, settings component.Tel
 // start actually creates the HTTP client. The client construction is deferred till this point as this
 // is the only place we get hold of Extensions which are required to construct auth round tripper.
 func (e *exporter) start(_ context.Context, host component.Host) error {
-	client, err := e.config.HTTPClientSettings.ToClient(host.GetExtensions())
+	client, err := e.config.HTTPClientSettings.ToClient(host.GetExtensions(), e.settings)
 	if err != nil {
 		return err
 	}

--- a/exporter/otlphttpexporter/otlp.go
+++ b/exporter/otlphttpexporter/otlp.go
@@ -47,7 +47,7 @@ type exporter struct {
 	metricsURL string
 	logsURL    string
 	logger     *zap.Logger
-
+	settings   component.TelemetrySettings
 	// Default user-agent header.
 	userAgent string
 }
@@ -58,7 +58,7 @@ const (
 )
 
 // Crete new exporter.
-func newExporter(cfg config.Exporter, logger *zap.Logger, buildInfo component.BuildInfo) (*exporter, error) {
+func newExporter(cfg config.Exporter, logger *zap.Logger, settings component.TelemetrySettings, buildInfo component.BuildInfo) (*exporter, error) {
 	oCfg := cfg.(*Config)
 
 	if oCfg.Endpoint != "" {
@@ -76,6 +76,7 @@ func newExporter(cfg config.Exporter, logger *zap.Logger, buildInfo component.Bu
 		config:    oCfg,
 		logger:    logger,
 		userAgent: userAgent,
+		settings: settings,
 	}, nil
 }
 

--- a/exporter/otlphttpexporter/otlp.go
+++ b/exporter/otlphttpexporter/otlp.go
@@ -76,7 +76,7 @@ func newExporter(cfg config.Exporter, logger *zap.Logger, settings component.Tel
 		config:    oCfg,
 		logger:    logger,
 		userAgent: userAgent,
-		settings: settings,
+		settings:  settings,
 	}, nil
 }
 


### PR DESCRIPTION

**Description:**
1. Made changes to pass telemetry settings to configHttp Toclient to configure the instrumentation library
2. Instrumented the otlphttp exporter using otel instrumentation library to enable observability.
**Link to tracking Issue:** 
Fixes: #4449 
