### PR TITLE
Remove deprecate flags --metrics-level and --metrics-addr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@
   - Add context to config.MapConverterFunc (#4678)
 - Builder: the skip compilation should only be supplied as a CLI flag. Previously, it was possible to specify that in the YAML file, contrary to the original intention (#4645)
 - Builder: Remove deprecated config option module::core (#4693)
+- Remove deprecate flags --metrics-level and --metrics-addr (#4695)
+  - Usages of `--metrics-level={VALUE}` can be replaced by `--set=service.telemetry.metrics.level={VALUE}`;
+  - Usages of `--metrics-addr={VALUE}` can be replaced by `--set=service.telemetry.metrics.address={VALUE}`;
 
 ## 💡 Enhancements 💡
 

--- a/config/configtelemetry/configtelemetry.go
+++ b/config/configtelemetry/configtelemetry.go
@@ -34,33 +34,14 @@ const (
 	levelBasicStr    = "basic"
 	levelNormalStr   = "normal"
 	levelDetailedStr = "detailed"
-
-	metricsLevelCfg = "metrics-level"
-	metricsAddrCfg  = "metrics-addr"
 )
 
 const UseOpenTelemetryForInternalMetrics = false
 
-var (
-	metricsLevelPtr = new(Level)
-	metricsAddrPtr  = new(string)
-)
-
 // Flags is a helper function to add telemetry config flags to the service that exposes
 // the application flags.
-func Flags(flags *flag.FlagSet) {
-	flags.Var(
-		metricsLevelPtr,
-		metricsLevelCfg,
-		"Deprecated. Define the metrics configuration as part of the configuration file, under the 'service' section.")
-
-	// At least until we can use a generic, i.e.: OpenCensus, metrics exporter
-	// we default to Prometheus at port 8888, if not otherwise specified.
-	metricsAddrPtr = flags.String(
-		metricsAddrCfg,
-		GetMetricsAddrDefault(),
-		"Deprecated. Define the metrics configuration as part of the configuration file, under the 'service' section.")
-}
+// Deprecated: No-op, kept for backwards compatibility until next release
+func Flags(*flag.FlagSet) {}
 
 // Level is the level of internal telemetry (metrics, logs, traces about the component itself)
 // that every component should generate.
@@ -118,23 +99,4 @@ func parseLevel(str string) (Level, error) {
 		return LevelDetailed, nil
 	}
 	return LevelNone, fmt.Errorf("unknown metrics level %q", str)
-}
-
-// GetMetricsAddrDefault returns the default metrics bind address and port depending on
-// the current build type.
-// Deprecated: This function will be removed in the future.
-func GetMetricsAddrDefault() string {
-	return ":8888"
-}
-
-// Deprecated: This function will be removed in the future.
-func GetMetricsAddr() string {
-	return *metricsAddrPtr
-}
-
-// GetMetricsLevelFlagValue returns the value of the "--metrics-level" flag.
-// IMPORTANT: This must be used only in the core collector code for the moment.
-// Deprecated: This function will be removed in the future.
-func GetMetricsLevelFlagValue() Level {
-	return *metricsLevelPtr
 }

--- a/config/configunmarshaler/defaultunmarshaler.go
+++ b/config/configunmarshaler/defaultunmarshaler.go
@@ -195,17 +195,9 @@ func unmarshalService(srvRaw map[string]interface{}) (config.Service, error) {
 }
 
 func defaultServiceTelemetryMetricsSettings() config.ServiceTelemetryMetrics {
-	// These deprecated functions are still needed here so that the values provided through the CLI flags
-	// can be used as a baseline if no values are provided in configuration.  This will eventually return
-	// a static default configuration when the CLI flags are removed.
-	addr := configtelemetry.GetMetricsAddr() //nolint:staticcheck
-	if addr == "" {
-		addr = configtelemetry.GetMetricsAddrDefault() //nolint:staticcheck
-	}
-
 	return config.ServiceTelemetryMetrics{
-		Level:   configtelemetry.GetMetricsLevelFlagValue(), //nolint:staticcheck
-		Address: addr,
+		Level:   configtelemetry.LevelBasic, //nolint:staticcheck
+		Address: ":8888",
 	}
 }
 

--- a/service/collector_test.go
+++ b/service/collector_test.go
@@ -92,18 +92,16 @@ func TestCollector_Start(t *testing.T) {
 		return nil
 	}
 
+	metricsPort := testutil.GetAvailablePort(t)
 	col, err := New(CollectorSettings{
-		BuildInfo:      component.NewDefaultBuildInfo(),
-		Factories:      factories,
-		ConfigProvider: NewDefaultConfigProvider(path.Join("testdata", "otelcol-config.yaml"), nil),
+		BuildInfo: component.NewDefaultBuildInfo(),
+		Factories: factories,
+		ConfigProvider: NewDefaultConfigProvider(
+			path.Join("testdata", "otelcol-config.yaml"),
+			[]string{"service.telemetry.metrics.address=localhost:" + strconv.FormatUint(uint64(metricsPort), 10)}),
 		LoggingOptions: []zap.Option{zap.Hooks(hook)},
 	})
 	require.NoError(t, err)
-
-	metricsPort := testutil.GetAvailablePort(t)
-	require.NoError(t, flags().Parse([]string{
-		"--metrics-addr=localhost:" + strconv.FormatUint(uint64(metricsPort), 10),
-	}))
 
 	colDone := make(chan struct{})
 	go func() {

--- a/service/flags.go
+++ b/service/flags.go
@@ -18,7 +18,6 @@ import (
 	"flag"
 	"strings"
 
-	"go.opentelemetry.io/collector/config/configtelemetry"
 	"go.opentelemetry.io/collector/service/featuregate"
 )
 
@@ -45,7 +44,6 @@ func (s *stringArrayValue) String() string {
 
 func flags() *flag.FlagSet {
 	flagSet := new(flag.FlagSet)
-	configtelemetry.Flags(flagSet)
 	featuregate.Flags(flagSet)
 
 	configFlag = flagSet.String("config", defaultConfig, "Path to the config file")


### PR DESCRIPTION
* Usages of `--metrics-level={VALUE}` can be replaced by `--set=service.telemetry.metrics.level={VALUE}`;
* Usages of `--metrics-addr={VALUE}` can be replaced by `--set=service.telemetry.metrics.address={VALUE}`;

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
