### PR TITLE
configHttp: Ability to pass telemetry settings to http instrument library that instruments the otlphttp exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Remove deprecate flags --metrics-level and --metrics-addr (#4695)
   - Usages of `--metrics-level={VALUE}` can be replaced by `--set=service.telemetry.metrics.level={VALUE}`;
   - Usages of `--metrics-addr={VALUE}` can be replaced by `--set=service.telemetry.metrics.address={VALUE}`;
+- Updated confighttp `ToClient` to support passing telemetry settings for instrumenting otlphttp exporter(#4449)
 
 ## 💡 Enhancements 💡
 

--- a/config/confighttp/confighttp_test.go
+++ b/config/confighttp/confighttp_test.go
@@ -131,7 +131,9 @@ func TestAllHTTPClientSettings(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			client, err := test.settings.ToClient(ext)
+			tt := componenttest.NewNopTelemetrySettings()
+			tt.TracerProvider = nil
+			client, err := test.settings.ToClient(ext, tt)
 			if test.shouldError {
 				assert.Error(t, err)
 				return
@@ -178,7 +180,9 @@ func TestPartialHTTPClientSettings(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			client, err := test.settings.ToClient(ext)
+			tt := componenttest.NewNopTelemetrySettings()
+			tt.TracerProvider = nil
+			client, err := test.settings.ToClient(ext, tt)
 			assert.NoError(t, err)
 			transport := client.Transport.(*http.Transport)
 			assert.EqualValues(t, 1024, transport.ReadBufferSize)
@@ -239,7 +243,7 @@ func TestHTTPClientSettingsError(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.err, func(t *testing.T) {
-			_, err := test.settings.ToClient(map[config.ComponentID]component.Extension{})
+			_, err := test.settings.ToClient(map[config.ComponentID]component.Extension{}, componenttest.NewNopTelemetrySettings())
 			assert.Regexp(t, test.err, err)
 		})
 	}
@@ -310,7 +314,7 @@ func TestHTTPClientSettingWithAuthConfig(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			client, err := test.settings.ToClient(test.extensionMap)
+			client, err := test.settings.ToClient(test.extensionMap, componenttest.NewNopTelemetrySettings())
 			if test.shouldErr {
 				assert.Error(t, err)
 				return
@@ -509,7 +513,7 @@ func TestHttpReception(t *testing.T) {
 				Endpoint:   prefix + ln.Addr().String(),
 				TLSSetting: *tt.tlsClientCreds,
 			}
-			client, errClient := hcs.ToClient(map[config.ComponentID]component.Extension{})
+			client, errClient := hcs.ToClient(map[config.ComponentID]component.Extension{}, componenttest.NewNopTelemetrySettings())
 			require.NoError(t, errClient)
 
 			resp, errResp := client.Get(hcs.Endpoint)
@@ -726,7 +730,7 @@ func TestHttpHeaders(t *testing.T) {
 					"header1": "value1",
 				},
 			}
-			client, _ := setting.ToClient(map[config.ComponentID]component.Extension{})
+			client, _ := setting.ToClient(map[config.ComponentID]component.Extension{}, componenttest.NewNopTelemetrySettings())
 			req, err := http.NewRequest("GET", setting.Endpoint, nil)
 			assert.NoError(t, err)
 			_, err = client.Do(req)

--- a/exporter/otlphttpexporter/factory.go
+++ b/exporter/otlphttpexporter/factory.go
@@ -77,7 +77,7 @@ func createTracesExporter(
 	set component.ExporterCreateSettings,
 	cfg config.Exporter,
 ) (component.TracesExporter, error) {
-	oce, err := newExporter(cfg, set.Logger, set.BuildInfo)
+	oce, err := newExporter(cfg, set)
 	if err != nil {
 		return nil, err
 	}
@@ -105,7 +105,7 @@ func createMetricsExporter(
 	set component.ExporterCreateSettings,
 	cfg config.Exporter,
 ) (component.MetricsExporter, error) {
-	oce, err := newExporter(cfg, set.Logger, set.BuildInfo)
+	oce, err := newExporter(cfg, set)
 	if err != nil {
 		return nil, err
 	}
@@ -133,7 +133,7 @@ func createLogsExporter(
 	set component.ExporterCreateSettings,
 	cfg config.Exporter,
 ) (component.LogsExporter, error) {
-	oce, err := newExporter(cfg, set.Logger, set.BuildInfo)
+	oce, err := newExporter(cfg, set)
 	if err != nil {
 		return nil, err
 	}

--- a/exporter/otlphttpexporter/otlp.go
+++ b/exporter/otlphttpexporter/otlp.go
@@ -47,7 +47,7 @@ type exporter struct {
 	metricsURL string
 	logsURL    string
 	logger     *zap.Logger
-
+	settings   component.TelemetrySettings
 	// Default user-agent header.
 	userAgent string
 }
@@ -58,7 +58,7 @@ const (
 )
 
 // Crete new exporter.
-func newExporter(cfg config.Exporter, logger *zap.Logger, buildInfo component.BuildInfo) (*exporter, error) {
+func newExporter(cfg config.Exporter, set component.ExporterCreateSettings) (*exporter, error) {
 	oCfg := cfg.(*Config)
 
 	if oCfg.Endpoint != "" {
@@ -69,13 +69,14 @@ func newExporter(cfg config.Exporter, logger *zap.Logger, buildInfo component.Bu
 	}
 
 	userAgent := fmt.Sprintf("%s/%s (%s/%s)",
-		buildInfo.Description, buildInfo.Version, runtime.GOOS, runtime.GOARCH)
+		set.BuildInfo.Description, set.BuildInfo.Version, runtime.GOOS, runtime.GOARCH)
 
 	// client construction is deferred to start
 	return &exporter{
 		config:    oCfg,
-		logger:    logger,
+		logger:    set.Logger,
 		userAgent: userAgent,
+		settings:  set.TelemetrySettings,
 	}, nil
 }
 

--- a/exporter/otlphttpexporter/otlp.go
+++ b/exporter/otlphttpexporter/otlp.go
@@ -83,7 +83,7 @@ func newExporter(cfg config.Exporter, set component.ExporterCreateSettings) (*ex
 // start actually creates the HTTP client. The client construction is deferred till this point as this
 // is the only place we get hold of Extensions which are required to construct auth round tripper.
 func (e *exporter) start(_ context.Context, host component.Host) error {
-	client, err := e.config.HTTPClientSettings.ToClient(host.GetExtensions())
+	client, err := e.config.HTTPClientSettings.ToClient(host.GetExtensions(), e.settings)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**Description:**
1. Made changes to pass telemetry settings to configHttp Toclient to configure the instrumentation library
2. Instrumented the otlphttp exporter using otel instrumentation library to enable observability.
**Link to tracking Issue:** 
Fixes: #4449 
