### PR TITLE
Remove support to some arches and platforms from `ocb` (opentelemetry-collector-builder)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
   - Usages of `--metrics-addr={VALUE}` can be replaced by `--set=service.telemetry.metrics.address={VALUE}`;
 - Updated confighttp `ToClient` to support passing telemetry settings for instrumenting otlphttp exporter(#4449)
 - Deprecate `configtelemetry.Level.Set()` (#4700)
+- Remove support to some arches and platforms from `ocb` (opentelemetry-collector-builder) (#4710)
 
 ## 💡 Enhancements 💡
 

--- a/cmd/builder/.goreleaser.yml
+++ b/cmd/builder/.goreleaser.yml
@@ -17,11 +17,10 @@ builds:
       - darwin
     goarch:
       - amd64
-      - arm
       - arm64
-    goarm:
-      - 6
-      - 7
+    ignore:
+      - goos: windows
+        goarch: arm64
     binary: ocb
 release:
   github:


### PR DESCRIPTION
**Description:** 
drop some platforms for the builder release.

Fixes https://github.com/open-telemetry/opentelemetry-collector/issues/4655

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector/issues/4655

**Testing:** Ran goreleaser and check the outputs

This is the new list of arches/platforms:

- Linux arm64
- Linux amd64
- Darwin arm64
- Darwin amd64
- Windows amd64
