### PR TITLE
Update README.md

### DIFF
--- a/exporter/exporterhelper/README.md
+++ b/exporter/exporterhelper/README.md
@@ -13,7 +13,7 @@ The following configuration options can be modified:
   - `enabled` (default = true)
   - `initial_interval` (default = 5s): Time to wait after the first failure before retrying; ignored if `enabled` is `false`
   - `max_interval` (default = 30s): Is the upper bound on backoff; ignored if `enabled` is `false`
-  - `max_elapsed_time` (default = 120s): Is the maximum amount of time spent trying to send a batch; ignored if `enabled` is `false`
+  - `max_elapsed_time` (default = 300s): Is the maximum amount of time spent trying to send a batch; ignored if `enabled` is `false`
 - `sending_queue`
   - `enabled` (default = true)
   - `num_consumers` (default = 10): Number of consumers that dequeue batches; ignored if `enabled` is `false`


### PR DESCRIPTION
max_elapsed_time is set to a default of 5 minutes in queued_retry.go, but was listed as 120s in this readme.

**Testing:** I ran a collector instance and exported to an empty IP address with the default retry settings. The retries continued for more than 120s and less than 300s. So I concluded that of these two numbers, 300s must be correct.
