### PR TITLE
Add guidelines for breaking changes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -359,6 +359,8 @@ version (`vM.N+1`).
 - when renaming types, functions, or attributes, we MUST create the new name and MUST deprecate the old one in one
   version (step 1), and MAY remove it in a subsequent version (step 2). For simple renames, the old name SHALL call the
   new one.
+- when a feature is being replaced in favor of an existing one, we MUST mark a feature as deprecated in one version, and
+  MAY remove it in the next one
 
 When deprecating a feature affecting end-users, consider first deprecating the feature in one version, then hiding it
 behind a [feature
@@ -383,9 +385,19 @@ that each of the following steps is done in a separate version:
 1. Current version `v0.N` has `func GetFoo() Foo`
 1. We now need to also return an error. We do it by creating a new function that will be equivalent to the existing one,
    so that current users can easily migrate to that: `func MustGetFoo() Foo`, which panics on errors. We release this in
-   `v0.N+1`, deprecating the existing `func GetFoo() Foo` with it, perhaps adding a log entry with a warning and an
-   entry to the changelog.
+   `v0.N+1`, deprecating the existing `func GetFoo() Foo` with it, adding an entry to the changelog and perhaps a log
+   entry with a warning.
 1. On `v0.N+2`, we change `func GetFoo() Foo` to `func GetFoo() (Foo, error)`.
+
+#### Example #3 - Changing the arguments of a function
+
+1. Current version `v0.N` has `func GetFoo() Foo`
+1. We now decided to do something that might be blocking as part of `func GetFoo() Foo`, so, we start accepting a
+   context: `func GetFooWithContext(context.Context) Foo`. We release this in `v0.N+1`, deprecating the existing `func
+   GetFoo() Foo` with it, adding an entry to the changelog and perhaps a log entry with a warning. The existing `func
+   GetFoo() Foo` is changed to call `func GetFooWithContext(context.Background()) Foo`.
+1. On `v0.N+2`, we change `func GetFoo() Foo` to `func GetFoo(context.Context) Foo` if desired or remove it entirely if
+   needed.
 
 #### Exceptions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -403,7 +403,9 @@ that each of the following steps is done in a separate version:
 
 While the above is what we strive to follow, we acknowledge that some changes might be unfeasible to achieve in a
 non-breaking manner. Exceptions to the outlined rules are acceptable if consensus can be obtained from approvers in the
-pull request they are proposed. A reason for requesting the exception MUST be given in the pull request.
+pull request they are proposed. A reason for requesting the exception MUST be given in the pull request. Until unanimity
+is obtained, approvers and maintainers are encouraged to discuss the issue at hand. If a consensus (unanimity) cannot be
+obtained, the maintainers are then tasked in getting a decision using its regular means (voting, TC help, ...).
 
 ## Updating Changelog
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -358,8 +358,8 @@ We also strive to perform breaking changes in two stages:
 version, and MAY remove it in the next version. For simple renames, the old name SHALL call the new one.
 
 When deprecating a feature affecting end-users, consider first deprecating the feature in one version, then hiding it behind
-a [feature flag](https://github.com/open-telemetry/opentelemetry-collector/blob/6b5a3d08a96bfb41a5e121b34f592a1d5c6e0435/service/featuregate/) in the next version,
-and eventually removing it after yet another version.
+a [feature flag](https://github.com/open-telemetry/opentelemetry-collector/blob/6b5a3d08a96bfb41a5e121b34f592a1d5c6e0435/service/featuregate/)
+in a subsequent version, and eventually removing it after yet another version.
 
 #### Example #1 - Renaming a function
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -351,12 +351,19 @@ Whenever possible, we adhere to semver as our minimum standards. Even before v1,
 without a good reason. Hence, when a change is known to cause a breaking change, it should be clearly marked in the
 changelog, possibly with a line instructing users how to move forward.
 
-We also strive to perform breaking changes in two stages, or using feature flags: 
+We also strive to perform breaking changes in two stages: 
 
 - when we need to remove something, we mark a feature as deprecated in one version, and remove it in the next one
 - when renaming types, functions, or attributes, we create the new name first, deprecating the old one in one
 version, removing it in the next version
-- when creating new interfaces, provide helpers so that consumers can be forward compatible without much effort
+- when creating new interfaces, provide helpers so that consumers can be forward compatible without much effort. One
+example can be found in the `configauth` package, where a [`ServerAuthenticator`](https://github.com/open-telemetry/opentelemetry-collector/blob/6b5a3d08a96bfb41a5e121b34f592a1d5c6e0435/config/configauth/serverauth.go#L28-L40)
+interface exists, we as well as a [helper](https://github.com/open-telemetry/opentelemetry-collector/blob/6b5a3d08a96bfb41a5e121b34f592a1d5c6e0435/config/configauth/default_serverauthenticator.go#L59-L71)
+that most implementations should use.
+
+When deprecating a feature affecting end-users, consider first deprecating the feature, then hiding it behind
+a [feature flag](https://github.com/open-telemetry/opentelemetry-collector/blob/6b5a3d08a96bfb41a5e121b34f592a1d5c6e0435/service/featuregate/),
+and eventually removing it. 
 
 ## Updating Changelog
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -356,9 +356,9 @@ version (`vM.N+1`).
 
 - when we need to remove something, we MUST mark a feature as deprecated in one version, and MAY remove it in the next
   one
-- when renaming types, functions, or attributes, we MUST create the new name and MUST deprecate the old one in one
-  version (step 1), and MAY remove it in a subsequent version (step 2). For simple renames, the old name SHALL call the
-  new one.
+- when renaming or refactoring types, functions, or attributes, we MUST create the new name and MUST deprecate the old
+  one in one version (step 1), and MAY remove it in a subsequent version (step 2). For simple renames, the old name
+  SHALL call the new one.
 - when a feature is being replaced in favor of an existing one, we MUST mark a feature as deprecated in one version, and
   MAY remove it in the next one
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -353,29 +353,32 @@ changelog, and SHOULD include a line instructing users how to move forward.
 
 We also strive to perform breaking changes in two stages: 
 
-- when we need to remove something, we MUST mark a feature as deprecated in one version, and MAY remove it in the next one
-- when renaming types, functions, or attributes, we MUST create the new name first and MUST deprecate the old one in one
-version, and MAY remove it in the next version. For simple renames, the old name SHALL call the new one.
+- when we need to remove something, we MUST mark a feature as deprecated in one version, and MAY remove it in the next
+  one
+- when renaming types, functions, or attributes, we MUST create the new name and MUST deprecate the old one in one
+  version (step 1), and MAY remove it in a subsequent version (step 2). For simple renames, the old name SHALL call the
+  new one.
 
-When deprecating a feature affecting end-users, consider first deprecating the feature in one version, then hiding it behind
-a [feature flag](https://github.com/open-telemetry/opentelemetry-collector/blob/6b5a3d08a96bfb41a5e121b34f592a1d5c6e0435/service/featuregate/)
+When deprecating a feature affecting end-users, consider first deprecating the feature in one version, then hiding it
+behind a [feature
+flag](https://github.com/open-telemetry/opentelemetry-collector/blob/6b5a3d08a96bfb41a5e121b34f592a1d5c6e0435/service/featuregate/)
 in a subsequent version, and eventually removing it after yet another version.
 
 #### Example #1 - Renaming a function
 
 1. Current version `v0.N` has `func GetFoo() Bar`
 1. We now decided that `GetBar` is a better name. As such, on `v0.N+1` we add a new `func GetBar() Bar` function,
-changing the existing `func GetFoo() Bar` to be an alias of the new function. Additionally, a log entry with a warning
-is added to the old function, along with an entry to the changelog.
+   changing the existing `func GetFoo() Bar` to be an alias of the new function. Additionally, a log entry with a
+   warning is added to the old function, along with an entry to the changelog.
 1. On `v0.N+2`, we MAY remove `func GetFoo() Bar`.
 
 #### Example #2 - Changing the return values of a function
 
 1. Current version `v0.N` has `func GetFoo() Foo`
-1. We now need to also return an error. We do it by creating a new function that will be equivalent to the existing
-one, so that current users can easily migrate to that: `func MustGetFoo() Foo`, which panics on errors. We release
-this in `v0.N+1`, deprecating the existing `func GetFoo() Foo` with it, adding a log entry with a warning and an
-entry to the changelog.
+1. We now need to also return an error. We do it by creating a new function that will be equivalent to the existing one,
+   so that current users can easily migrate to that: `func MustGetFoo() Foo`, which panics on errors. We release this in
+   `v0.N+1`, deprecating the existing `func GetFoo() Foo` with it, perhaps adding a log entry with a warning and an
+   entry to the changelog.
 1. On `v0.N+2`, we change `func GetFoo() Foo` to `func GetFoo() (Foo, error)`.
 
 ## Updating Changelog

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -351,7 +351,8 @@ Whenever possible, we adhere to semver as our minimum standards. Even before v1,
 without a good reason. Hence, when a change is known to cause a breaking change, it MUST be clearly marked in the
 changelog, and SHOULD include a line instructing users how to move forward.
 
-We also strive to perform breaking changes in two stages: 
+We also strive to perform breaking changes in two stages, deprecating it first (`vM.N`) and breaking it in a subsequent
+version (`vM.N+1`).
 
 - when we need to remove something, we MUST mark a feature as deprecated in one version, and MAY remove it in the next
   one
@@ -362,7 +363,12 @@ We also strive to perform breaking changes in two stages:
 When deprecating a feature affecting end-users, consider first deprecating the feature in one version, then hiding it
 behind a [feature
 flag](https://github.com/open-telemetry/opentelemetry-collector/blob/6b5a3d08a96bfb41a5e121b34f592a1d5c6e0435/service/featuregate/)
-in a subsequent version, and eventually removing it after yet another version.
+in a subsequent version, and eventually removing it after yet another version. This is how it would look like, considering
+that each of the following steps is done in a separate version:
+
+1. Mark the feature as deprecated, add a short lived feature flag with the feature enabled by default
+1. Change the feature flag to disable the feature by default, deprecating the flag at the same time
+1. Remove the feature and the flag
 
 #### Example #1 - Renaming a function
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -356,10 +356,6 @@ We also strive to perform breaking changes in two stages:
 - when we need to remove something, we MUST mark a feature as deprecated in one version, and MAY remove it in the next one
 - when renaming types, functions, or attributes, we MUST create the new name first and MUST deprecate the old one in one
 version, and MAY remove it in the next version. For simple renames, the old name SHALL call the new one.
-- when creating new interfaces, helpers MUST be provided so that consumers can be forward compatible without much effort. One
-example can be found in the `configauth` package, where a [`ServerAuthenticator`](https://github.com/open-telemetry/opentelemetry-collector/blob/6b5a3d08a96bfb41a5e121b34f592a1d5c6e0435/config/configauth/serverauth.go#L28-L40)
-interface exists, we as well as a [helper](https://github.com/open-telemetry/opentelemetry-collector/blob/6b5a3d08a96bfb41a5e121b34f592a1d5c6e0435/config/configauth/default_serverauthenticator.go#L59-L71)
-that most implementations should use.
 
 When deprecating a feature affecting end-users, consider first deprecating the feature in one version, then hiding it behind
 a [feature flag](https://github.com/open-telemetry/opentelemetry-collector/blob/6b5a3d08a96bfb41a5e121b34f592a1d5c6e0435/service/featuregate/) in the next version,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -345,6 +345,18 @@ with clear instructions on how to install the required libraries.
 Furthermore, if your package requires CGO, it MUST be able to compile and operate in a no op mode
 or report a warning back to the collector with a clear error saying CGO is required to work.
 
+### Doing breaking changes
+
+Whenever possible, we adhere to semver as our minimum standards. Even before v1, we strive to not break compatibility
+without a good reason. Hence, when a change is known to cause a breaking change, it should be clearly marked in the
+changelog, possibly with a line instructing users how to move forward.
+
+We also strive to perform breaking changes in two stages, or using feature flags: 
+
+- when we need to remove something, we mark a feature as deprecated in one version, and remove it in the next one
+- when renaming types, functions, or attributes, we create the new name first, deprecating the old one in one
+version, removing it in the next version
+- when creating new interfaces, provide helpers so that consumers can be forward compatible without much effort
 
 ## Updating Changelog
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -387,6 +387,12 @@ that each of the following steps is done in a separate version:
    entry to the changelog.
 1. On `v0.N+2`, we change `func GetFoo() Foo` to `func GetFoo() (Foo, error)`.
 
+#### Exceptions
+
+While the above is what we strive to follow, we acknowledge that some changes might be unfeasible to achieve in a
+non-breaking manner. Exceptions to the outlined rules are acceptable if consensus can be obtained from approvers in the
+pull request they are proposed. A reason for requesting the exception MUST be given in the pull request.
+
 ## Updating Changelog
 
 An entry into the [Changelog](./CHANGELOG.md) is required for the following reasons:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -354,13 +354,13 @@ changelog, and SHOULD include a line instructing users how to move forward.
 We also strive to perform breaking changes in two stages, deprecating it first (`vM.N`) and breaking it in a subsequent
 version (`vM.N+1`).
 
-- when we need to remove something, we MUST mark a feature as deprecated in one version, and MAY remove it in the next
-  one
+- when we need to remove something, we MUST mark a feature as deprecated in one version, and MAY remove it in a
+  subsequent one
 - when renaming or refactoring types, functions, or attributes, we MUST create the new name and MUST deprecate the old
   one in one version (step 1), and MAY remove it in a subsequent version (step 2). For simple renames, the old name
   SHALL call the new one.
 - when a feature is being replaced in favor of an existing one, we MUST mark a feature as deprecated in one version, and
-  MAY remove it in the next one
+  MAY remove it in a subsequent one.
 
 When deprecating a feature affecting end-users, consider first deprecating the feature in one version, then hiding it
 behind a [feature

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -345,7 +345,7 @@ with clear instructions on how to install the required libraries.
 Furthermore, if your package requires CGO, it MUST be able to compile and operate in a no op mode
 or report a warning back to the collector with a clear error saying CGO is required to work.
 
-### Doing breaking changes
+### Breaking changes
 
 Whenever possible, we adhere to semver as our minimum standards. Even before v1, we strive to not break compatibility
 without a good reason. Hence, when a change is known to cause a breaking change, it should be clearly marked in the


### PR DESCRIPTION
As a result of the discussion involving #4672, we agreed during the SIG Collector meeting that we'd start recommending and enforcing breaking changes to be performed in two steps.

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>
