### PR TITLE
Use directly the consumer helper funcs in the other helpers packages.

### DIFF
--- a/component/componenttest/nop_exporter.go
+++ b/component/componenttest/nop_exporter.go
@@ -88,12 +88,12 @@ func (f *nopExporterFactory) CreateLogsExporter(
 }
 
 var nopExporterInstance = &nopExporter{
-	Component: componenthelper.New(),
-	Consumer:  consumertest.NewNop(),
+	Consumer: consumertest.NewNop(),
 }
 
 // nopExporter stores consumed traces and metrics for testing purposes.
 type nopExporter struct {
-	component.Component
+	componenthelper.StartFunc
+	componenthelper.ShutdownFunc
 	consumertest.Consumer
 }

--- a/component/componenttest/nop_extension.go
+++ b/component/componenttest/nop_extension.go
@@ -68,11 +68,10 @@ func (f *nopExtensionFactory) CreateExtension(
 	return nopExtensionInstance, nil
 }
 
-var nopExtensionInstance = &nopExtension{
-	Component: componenthelper.New(),
-}
+var nopExtensionInstance = &nopExtension{}
 
 // nopExtension stores consumed traces and metrics for testing purposes.
 type nopExtension struct {
-	component.Component
+	componenthelper.StartFunc
+	componenthelper.ShutdownFunc
 }

--- a/component/componenttest/nop_processor.go
+++ b/component/componenttest/nop_processor.go
@@ -92,12 +92,12 @@ func (f *nopProcessorFactory) CreateLogsProcessor(
 }
 
 var nopProcessorInstance = &nopProcessor{
-	Component: componenthelper.New(),
-	Consumer:  consumertest.NewNop(),
+	Consumer: consumertest.NewNop(),
 }
 
 // nopProcessor stores consumed traces and metrics for testing purposes.
 type nopProcessor struct {
-	component.Component
+	componenthelper.StartFunc
+	componenthelper.ShutdownFunc
 	consumertest.Consumer
 }

--- a/component/componenttest/nop_receiver.go
+++ b/component/componenttest/nop_receiver.go
@@ -90,11 +90,10 @@ func (f *nopReceiverFactory) CreateLogsReceiver(
 	return nopReceiverInstance, nil
 }
 
-var nopReceiverInstance = &nopReceiver{
-	Component: componenthelper.New(),
-}
+var nopReceiverInstance = &nopReceiver{}
 
 // nopReceiver stores consumed traces and metrics for testing purposes.
 type nopReceiver struct {
-	component.Component
+	componenthelper.StartFunc
+	componenthelper.ShutdownFunc
 }

--- a/processor/processorhelper/logs.go
+++ b/processor/processorhelper/logs.go
@@ -34,7 +34,8 @@ import (
 type ProcessLogsFunc func(context.Context, pdata.Logs) (pdata.Logs, error)
 
 type logProcessor struct {
-	component.Component
+	componenthelper.StartFunc
+	componenthelper.ShutdownFunc
 	consumer.Logs
 }
 
@@ -75,7 +76,8 @@ func NewLogsProcessor(
 	}
 
 	return &logProcessor{
-		Component: componenthelper.New(bs.componentOptions...),
-		Logs:      logsConsumer,
+		StartFunc:    bs.StartFunc,
+		ShutdownFunc: bs.ShutdownFunc,
+		Logs:         logsConsumer,
 	}, nil
 }

--- a/processor/processorhelper/metrics.go
+++ b/processor/processorhelper/metrics.go
@@ -34,7 +34,8 @@ import (
 type ProcessMetricsFunc func(context.Context, pdata.Metrics) (pdata.Metrics, error)
 
 type metricsProcessor struct {
-	component.Component
+	componenthelper.StartFunc
+	componenthelper.ShutdownFunc
 	consumer.Metrics
 }
 
@@ -75,7 +76,8 @@ func NewMetricsProcessor(
 	}
 
 	return &metricsProcessor{
-		Component: componenthelper.New(bs.componentOptions...),
-		Metrics:   metricsConsumer,
+		StartFunc:    bs.StartFunc,
+		ShutdownFunc: bs.ShutdownFunc,
+		Metrics:      metricsConsumer,
 	}, nil
 }

--- a/processor/processorhelper/processor.go
+++ b/processor/processorhelper/processor.go
@@ -39,7 +39,7 @@ type Option func(*baseSettings)
 // The default shutdown function does nothing and always returns nil.
 func WithStart(start componenthelper.StartFunc) Option {
 	return func(o *baseSettings) {
-		o.componentOptions = append(o.componentOptions, componenthelper.WithStart(start))
+		o.StartFunc = start
 	}
 }
 
@@ -47,7 +47,7 @@ func WithStart(start componenthelper.StartFunc) Option {
 // The default shutdown function does nothing and always returns nil.
 func WithShutdown(shutdown componenthelper.ShutdownFunc) Option {
 	return func(o *baseSettings) {
-		o.componentOptions = append(o.componentOptions, componenthelper.WithShutdown(shutdown))
+		o.ShutdownFunc = shutdown
 	}
 }
 
@@ -60,8 +60,9 @@ func WithCapabilities(capabilities consumer.Capabilities) Option {
 }
 
 type baseSettings struct {
-	componentOptions []componenthelper.Option
-	consumerOptions  []consumerhelper.Option
+	componenthelper.StartFunc
+	componenthelper.ShutdownFunc
+	consumerOptions []consumerhelper.Option
 }
 
 // fromOptions returns the internal settings starting from the default and applying all options.

--- a/processor/processorhelper/traces.go
+++ b/processor/processorhelper/traces.go
@@ -34,7 +34,8 @@ import (
 type ProcessTracesFunc func(context.Context, pdata.Traces) (pdata.Traces, error)
 
 type tracesProcessor struct {
-	component.Component
+	componenthelper.StartFunc
+	componenthelper.ShutdownFunc
 	consumer.Traces
 }
 
@@ -76,7 +77,8 @@ func NewTracesProcessor(
 	}
 
 	return &tracesProcessor{
-		Component: componenthelper.New(bs.componentOptions...),
-		Traces:    traceConsumer,
+		StartFunc:    bs.StartFunc,
+		ShutdownFunc: bs.ShutdownFunc,
+		Traces:       traceConsumer,
 	}, nil
 }


### PR DESCRIPTION
Try to understand if the Component helper is necessary, or only having the helper funcs is enough.

Updates https://github.com/open-telemetry/opentelemetry-collector/issues/4681

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
