### PR TITLE
Remove deprecated legacy path support for otlp http receiver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Updated confighttp `ToClient` to support passing telemetry settings for instrumenting otlphttp exporter(#4449)
 - Deprecate `configtelemetry.Level.Set()` (#4700)
 - Remove support to some arches and platforms from `ocb` (opentelemetry-collector-builder) (#4710)
+- Remove deprecated legacy path ("v1/trace") support for otlp http receiver (#4720)
 
 ## 💡 Enhancements 💡
 

--- a/receiver/otlpreceiver/otlp.go
+++ b/receiver/otlpreceiver/otlp.go
@@ -195,15 +195,7 @@ func (r *otlpReceiver) registerTraceConsumer(tc consumer.Traces) error {
 		r.httpMux.HandleFunc("/v1/traces", func(resp http.ResponseWriter, req *http.Request) {
 			handleTraces(resp, req, r.traceReceiver, pbEncoder)
 		}).Methods(http.MethodPost).Headers("Content-Type", pbContentType)
-		// For backwards compatibility see https://github.com/open-telemetry/opentelemetry-collector/issues/1968
-		r.httpMux.HandleFunc("/v1/trace", func(resp http.ResponseWriter, req *http.Request) {
-			handleTraces(resp, req, r.traceReceiver, pbEncoder)
-		}).Methods(http.MethodPost).Headers("Content-Type", pbContentType)
 		r.httpMux.HandleFunc("/v1/traces", func(resp http.ResponseWriter, req *http.Request) {
-			handleTraces(resp, req, r.traceReceiver, jsEncoder)
-		}).Methods(http.MethodPost).Headers("Content-Type", jsonContentType)
-		// For backwards compatibility see https://github.com/open-telemetry/opentelemetry-collector/issues/1968
-		r.httpMux.HandleFunc("/v1/trace", func(resp http.ResponseWriter, req *http.Request) {
 			handleTraces(resp, req, r.traceReceiver, jsEncoder)
 		}).Methods(http.MethodPost).Headers("Content-Type", jsonContentType)
 	}

--- a/receiver/otlpreceiver/otlp_test.go
+++ b/receiver/otlpreceiver/otlp_test.go
@@ -148,20 +148,12 @@ func TestJsonHttp(t *testing.T) {
 	// Wait for the servers to start
 	<-time.After(10 * time.Millisecond)
 
-	// Previously we used /v1/trace as the path. The correct path according to OTLP spec
-	// is /v1/traces. We currently support both on the receiving side to give graceful
-	// period for senders to roll out a fix, so we test for both paths to make sure
-	// the receiver works correctly.
-	targetURLPaths := []string{"/v1/trace", "/v1/traces"}
-
 	for _, test := range tests {
-		for _, targetURLPath := range targetURLPaths {
-			t.Run(test.name+targetURLPath, func(t *testing.T) {
-				url := fmt.Sprintf("http://%s%s", addr, targetURLPath)
-				sink.Reset()
-				testHTTPJSONRequest(t, url, sink, test.encoding, test.err)
-			})
-		}
+		t.Run(test.name, func(t *testing.T) {
+			url := fmt.Sprintf("http://%s/v1/traces", addr)
+			sink.Reset()
+			testHTTPJSONRequest(t, url, sink, test.encoding, test.err)
+		})
 	}
 }
 
@@ -260,20 +252,12 @@ func TestProtoHttp(t *testing.T) {
 		t.Errorf("Error marshaling protobuf: %v", err)
 	}
 
-	// Previously we used /v1/trace as the path. The correct path according to OTLP spec
-	// is /v1/traces. We currently support both on the receiving side to give graceful
-	// period for senders to roll out a fix, so we test for both paths to make sure
-	// the receiver works correctly.
-	targetURLPaths := []string{"/v1/trace", "/v1/traces"}
-
 	for _, test := range tests {
-		for _, targetURLPath := range targetURLPaths {
-			t.Run(test.name+targetURLPath, func(t *testing.T) {
-				url := fmt.Sprintf("http://%s%s", addr, targetURLPath)
-				tSink.Reset()
-				testHTTPProtobufRequest(t, url, tSink, test.encoding, traceBytes, test.err, td)
-			})
-		}
+		t.Run(test.name, func(t *testing.T) {
+			url := fmt.Sprintf("http://%s/v1/traces", addr)
+			tSink.Reset()
+			testHTTPProtobufRequest(t, url, tSink, test.encoding, traceBytes, test.err, td)
+		})
 	}
 }
 


### PR DESCRIPTION
This was changed 1y ago, and it is probably safe to remove it now.

Updates https://github.com/open-telemetry/opentelemetry-collector/issues/1968

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
