### PR TITLE
ensure windows file path is respected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@
   - Add context to config.MapConverterFunc (#4678)
 - Builder: the skip compilation should only be supplied as a CLI flag. Previously, it was possible to specify that in the YAML file, contrary to the original intention (#4645)
 
+## 🧰 Bug fixes 🧰
+
+- Ensure Windows path (e.g: C:) is recognized as a file path (#4726)
+
 ## 💡 Enhancements 💡
 
 - Remove expand cases that cannot happen with config.Map (#4649)

--- a/service/config_provider.go
+++ b/service/config_provider.go
@@ -17,6 +17,7 @@ package service // import "go.opentelemetry.io/collector/service"
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 	"sync"
 
@@ -182,16 +183,18 @@ func (cm *configProvider) Shutdown(ctx context.Context) error {
 	return errs
 }
 
+var fileRegexp = regexp.MustCompile("^[A-z]:")
+
 func (cm *configProvider) mergeRetrieve(ctx context.Context) (configmapprovider.Retrieved, error) {
 	var retrs []configmapprovider.Retrieved
 	retCfgMap := config.NewMap()
 	for _, location := range cm.locations {
 		// For backwards compatibility:
 		// - empty url scheme means "file".
-		// - "C:" also means "file"
+		// - "^[A-z]:" also means "file"
 		scheme := "file"
 		if idx := strings.Index(location, ":"); idx != -1 {
-			if strings.HasPrefix(location, "C:") {
+			if fileRegexp.MatchString(location) {
 				location = scheme + ":" + location
 			} else {
 				scheme = location[:idx]

--- a/service/config_provider.go
+++ b/service/config_provider.go
@@ -186,10 +186,16 @@ func (cm *configProvider) mergeRetrieve(ctx context.Context) (configmapprovider.
 	var retrs []configmapprovider.Retrieved
 	retCfgMap := config.NewMap()
 	for _, location := range cm.locations {
-		// For backwards compatibility, empty url scheme means "file".
+		// For backwards compatibility:
+		// - empty url scheme means "file".
+		// - "C:" also means "file"
 		scheme := "file"
 		if idx := strings.Index(location, ":"); idx != -1 {
-			scheme = location[:idx]
+			if strings.HasPrefix(location, "C:") {
+				location = scheme + ":" + location
+			} else {
+				scheme = location[:idx]
+			}
 		} else {
 			location = scheme + ":" + location
 		}

--- a/service/config_provider.go
+++ b/service/config_provider.go
@@ -183,7 +183,9 @@ func (cm *configProvider) Shutdown(ctx context.Context) error {
 	return errs
 }
 
-var fileRegexp = regexp.MustCompile("^[A-z]:")
+// follows drive-letter specification:
+// https://tools.ietf.org/id/draft-kerwin-file-scheme-07.html#syntax
+var driverLetterRegexp = regexp.MustCompile("^[A-z]:")
 
 func (cm *configProvider) mergeRetrieve(ctx context.Context) (configmapprovider.Retrieved, error) {
 	var retrs []configmapprovider.Retrieved
@@ -193,12 +195,8 @@ func (cm *configProvider) mergeRetrieve(ctx context.Context) (configmapprovider.
 		// - empty url scheme means "file".
 		// - "^[A-z]:" also means "file"
 		scheme := "file"
-		if idx := strings.Index(location, ":"); idx != -1 {
-			if fileRegexp.MatchString(location) {
-				location = scheme + ":" + location
-			} else {
-				scheme = location[:idx]
-			}
+		if idx := strings.Index(location, ":"); idx != -1 && !driverLetterRegexp.MatchString(location) {
+			scheme = location[:idx]
 		} else {
 			location = scheme + ":" + location
 		}

--- a/service/config_provider_test.go
+++ b/service/config_provider_test.go
@@ -312,3 +312,37 @@ func TestConfigProvider_ShutdownClosesWatch(t *testing.T) {
 	assert.NoError(t, cfgW.Shutdown(context.Background()))
 	watcherWG.Wait()
 }
+
+func TestBackwardsCompatibilityForFilePath(t *testing.T) {
+	factories, errF := componenttest.NopFactories()
+	require.NoError(t, errF)
+
+	tests := []struct {
+		name     string
+		location string
+		err      error
+	}{
+		{
+			name:     "unix",
+			location: `/test`,
+		},
+		{
+			name:     "file_unix",
+			location: `file:/test`,
+		},
+		{
+			name:     "windows",
+			location: `C:\test`,
+		},
+		{
+			name:     "file_windows",
+			location: `file:C:\test`,
+		},
+	}
+	for _, tt := range tests {
+		provider := NewDefaultConfigProvider(tt.location, []string{})
+		_, err := provider.Get(context.Background(), factories)
+		assert.Contains(t, err.Error(), "no such file or directory")
+	}
+
+}

--- a/service/config_provider_test.go
+++ b/service/config_provider_test.go
@@ -325,27 +325,27 @@ func TestBackwardsCompatibilityForFilePath(t *testing.T) {
 		{
 			name:       "unix",
 			location:   `/test`,
-			errMessage: "open /test: no such file or directory",
+			errMessage: "unable to read the file file:/test",
 		},
 		{
 			name:       "file_unix",
 			location:   `file:/test`,
-			errMessage: "open /test: no such file or directory",
+			errMessage: "unable to read the file file:/test",
 		},
 		{
 			name:       "windows_C",
 			location:   `C:\test`,
-			errMessage: "open C:\\test: no such file or directory",
+			errMessage: "unable to read the file file:C:\\test",
 		},
 		{
 			name:       "windows_z",
 			location:   `z:\test`,
-			errMessage: "open z:\\test: no such file or directory",
+			errMessage: "unable to read the file file:z:\\test",
 		},
 		{
 			name:       "file_windows",
 			location:   `file:C:\test`,
-			errMessage: "open C:\\test: no such file or directory",
+			errMessage: "unable to read the file file:C:\\test",
 		},
 		{
 			name:       "invalid_scheme",

--- a/service/config_provider_test.go
+++ b/service/config_provider_test.go
@@ -318,31 +318,45 @@ func TestBackwardsCompatibilityForFilePath(t *testing.T) {
 	require.NoError(t, errF)
 
 	tests := []struct {
-		name     string
-		location string
-		err      error
+		name       string
+		location   string
+		errMessage string
 	}{
 		{
-			name:     "unix",
-			location: `/test`,
+			name:       "unix",
+			location:   `/test`,
+			errMessage: "open /test: no such file or directory",
 		},
 		{
-			name:     "file_unix",
-			location: `file:/test`,
+			name:       "file_unix",
+			location:   `file:/test`,
+			errMessage: "open /test: no such file or directory",
 		},
 		{
-			name:     "windows",
-			location: `C:\test`,
+			name:       "windows_C",
+			location:   `C:\test`,
+			errMessage: "open C:\\test: no such file or directory",
 		},
 		{
-			name:     "file_windows",
-			location: `file:C:\test`,
+			name:       "windows_z",
+			location:   `z:\test`,
+			errMessage: "open z:\\test: no such file or directory",
+		},
+		{
+			name:       "file_windows",
+			location:   `file:C:\test`,
+			errMessage: "open C:\\test: no such file or directory",
+		},
+		{
+			name:       "invalid_scheme",
+			location:   `LL:\test`,
+			errMessage: "scheme LL is not supported for location",
 		},
 	}
 	for _, tt := range tests {
 		provider := NewDefaultConfigProvider(tt.location, []string{})
 		_, err := provider.Get(context.Background(), factories)
-		assert.Contains(t, err.Error(), "no such file or directory")
+		assert.Contains(t, err.Error(), tt.errMessage, tt.name)
 	}
 
 }


### PR DESCRIPTION
**Description:**
The current --config flag breaks backwards compatibility for Windows users as a common path is to use is C: as is used in the collector-contrib MSI for example.

**Link to tracking Issue:** #4725

**Testing:** Added unit test, confirmed with command line manual test.

