### PR TITLE
Enable end users to provide multiple files for config location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Deprecate `configtelemetry.Level.Set()` (#4700)
 - Remove support to some arches and platforms from `ocb` (opentelemetry-collector-builder) (#4710)
 - Remove deprecated legacy path ("v1/trace") support for otlp http receiver (#4720)
+- Change the `service.NewDefaultConfigProvider` to accept a slice of strings (#4727).
 
 ## 💡 Enhancements 💡
 
@@ -29,6 +30,7 @@
 - Move `compression.go` into `confighttp.go` to internalize functions in `compression.go` file. (#4651)
   - create `configcompression` package to manage compression methods in `confighttp` and `configgrpc`
 - Add support for cgroupv2 memory limit (#4654)
+- Enable end users to provide multiple files for config location (#4727)
 
 ## 🧰 Bug fixes 🧰
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 - Deprecate `configtelemetry.Level.Set()` (#4700)
 - Remove support to some arches and platforms from `ocb` (opentelemetry-collector-builder) (#4710)
 - Remove deprecated legacy path ("v1/trace") support for otlp http receiver (#4720)
-- Change the `service.NewDefaultConfigProvider` to accept a slice of strings (#4727).
+- Change the `service.NewDefaultConfigProvider` to accept a slice of location strings (#4727).
 
 ## 💡 Enhancements 💡
 

--- a/service/collector_test.go
+++ b/service/collector_test.go
@@ -54,7 +54,7 @@ func TestCollector_StartAsGoRoutine(t *testing.T) {
 	set := CollectorSettings{
 		BuildInfo:      component.NewDefaultBuildInfo(),
 		Factories:      factories,
-		ConfigProvider: NewDefaultConfigProvider(path.Join("testdata", "otelcol-config.yaml"), nil),
+		ConfigProvider: NewDefaultConfigProvider([]string{path.Join("testdata", "otelcol-config.yaml")}, nil),
 	}
 	col, err := New(set)
 	require.NoError(t, err)
@@ -97,7 +97,7 @@ func TestCollector_Start(t *testing.T) {
 		BuildInfo: component.NewDefaultBuildInfo(),
 		Factories: factories,
 		ConfigProvider: NewDefaultConfigProvider(
-			path.Join("testdata", "otelcol-config.yaml"),
+			[]string{path.Join("testdata", "otelcol-config.yaml")},
 			[]string{"service.telemetry.metrics.address=localhost:" + strconv.FormatUint(uint64(metricsPort), 10)}),
 		LoggingOptions: []zap.Option{zap.Hooks(hook)},
 	})
@@ -157,7 +157,7 @@ func TestCollector_ReportError(t *testing.T) {
 	col, err := New(CollectorSettings{
 		BuildInfo:      component.NewDefaultBuildInfo(),
 		Factories:      factories,
-		ConfigProvider: NewDefaultConfigProvider(path.Join("testdata", "otelcol-config.yaml"), nil),
+		ConfigProvider: NewDefaultConfigProvider([]string{path.Join("testdata", "otelcol-config.yaml")}, nil),
 	})
 	require.NoError(t, err)
 

--- a/service/config_provider.go
+++ b/service/config_provider.go
@@ -102,9 +102,9 @@ func NewConfigProvider(
 
 // NewDefaultConfigProvider returns the default ConfigProvider, and it creates configuration from a file
 // defined by the given configFile and overwrites fields using properties.
-func NewDefaultConfigProvider(configFileName string, properties []string) ConfigProvider {
+func NewDefaultConfigProvider(configLocations []string, properties []string) ConfigProvider {
 	return NewConfigProvider(
-		[]string{configFileName},
+		configLocations,
 		map[string]configmapprovider.Provider{
 			"file": configmapprovider.NewFile(),
 			"env":  configmapprovider.NewEnv(),

--- a/service/flags.go
+++ b/service/flags.go
@@ -45,7 +45,7 @@ func flags() *flag.FlagSet {
 	featuregate.Flags(flagSet)
 
 	flagSet.Var(configFlag, "config", "Locations to the config file(s), note that only a"+
-		" single (first) location can be set per flag entry e.g. `-config=file:/path/to/first --config=file:path/to/second`.")
+		" single location can be set per flag entry e.g. `-config=file:/path/to/first --config=file:path/to/second`.")
 
 	flagSet.Var(setFlag, "set",
 		"Set arbitrary component config property. The component has to be defined in the config file and the flag"+

--- a/service/flags.go
+++ b/service/flags.go
@@ -22,10 +22,8 @@ import (
 )
 
 var (
-	defaultConfig = ""
-
 	// Command-line flag that control the configuration file.
-	configFlag = &defaultConfig
+	configFlag = new(stringArrayValue)
 	setFlag    = new(stringArrayValue)
 )
 
@@ -39,14 +37,15 @@ func (s *stringArrayValue) Set(val string) error {
 }
 
 func (s *stringArrayValue) String() string {
-	return "[" + strings.Join(s.values, ",") + "]"
+	return "[" + strings.Join(s.values, ", ") + "]"
 }
 
 func flags() *flag.FlagSet {
 	flagSet := new(flag.FlagSet)
 	featuregate.Flags(flagSet)
 
-	configFlag = flagSet.String("config", defaultConfig, "Path to the config file")
+	flagSet.Var(configFlag, "config", "Locations to the config file(s), note that only a"+
+		" single (first) location can be set per flag entry e.g. `-config=file:/path/to/first --config=file:path/to/second`.")
 
 	flagSet.Var(setFlag, "set",
 		"Set arbitrary component config property. The component has to be defined in the config file and the flag"+
@@ -56,8 +55,8 @@ func flags() *flag.FlagSet {
 	return flagSet
 }
 
-func getConfigFlag() string {
-	return *configFlag
+func getConfigFlag() []string {
+	return configFlag.values
 }
 
 func getSetFlag() []string {


### PR DESCRIPTION
Restriction (compatible with `--set`): Per flag entry can be defined only one location, to define multiple locations use multiple flag entries (which will be merged in the given order):

```bash
./otelcol --cofig=file:/path/to/first/file --config=file:/path/to/second/file
```

Fixes: https://github.com/open-telemetry/opentelemetry-collector/issues/2701

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
