### PR TITLE
Copy slice argument, disallow changes from caller to the input slice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ## 💡 Enhancements 💡
 
+- `service.NewConfigProvider`: copy slice argument, disallow changes from caller to the input slice (#4729)
 - `confighttp` and `configgrpc`: New config option `include_metadata` to persist request metadata/headers in `client.Info.Metadata` (experimental) (#4547)
 - Remove expand cases that cannot happen with config.Map (#4649)
 - Add `max_request_body_size` to confighttp.HTTPServerSettings (#4677)

--- a/service/config_provider.go
+++ b/service/config_provider.go
@@ -88,8 +88,11 @@ func NewConfigProvider(
 	configMapProviders map[string]configmapprovider.Provider,
 	cfgMapConverters []config.MapConverterFunc,
 	configUnmarshaler configunmarshaler.ConfigUnmarshaler) ConfigProvider {
+	// Safe copy, ensures the slice cannot be changed from the caller.
+	locationsCopy := make([]string, len(locations))
+	copy(locationsCopy, locations)
 	return &configProvider{
-		locations:          locations,
+		locations:          locationsCopy,
 		configMapProviders: configMapProviders,
 		cfgMapConverters:   cfgMapConverters,
 		configUnmarshaler:  configUnmarshaler,


### PR DESCRIPTION
Split from https://github.com/open-telemetry/opentelemetry-collector/pull/4727

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
