### PR TITLE
Handle unsupported requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## 🛑 Breaking changes 🛑
 
+- Invalid requests now return an appropriate unsupported (`405`) or method not allowed (`415`) response (#4735)
 - Updated to OTLP 0.12.0. Deprecated traces and metrics messages that existed
   in 0.11.0 are no longer converted to the messages and fields that replaced the deprecated ones.
   Received deprecated messages and fields will be now ignored. In OTLP/JSON in the

--- a/receiver/otlpreceiver/otlp.go
+++ b/receiver/otlpreceiver/otlp.go
@@ -244,14 +244,14 @@ func (r *otlpReceiver) registerLogsConsumer(lc consumer.Logs) error {
 }
 
 func handleUnmatchedRequests(resp http.ResponseWriter, req *http.Request) {
-	if req.Method == http.MethodPatch {
+	if req.Method != http.MethodPost {
 		status := http.StatusMethodNotAllowed
-		writeResponse(resp, "text/plain", status, []byte(fmt.Sprintf("%v method not allowed, supported: [GET, POST]", status)))
+		writeResponse(resp, "text/plain", status, []byte(fmt.Sprintf("%v method not allowed, supported: [POST]", status)))
 		return
 	}
 	if req.Header.Get("Content-Type") == "" {
 		status := http.StatusUnsupportedMediaType
-		writeResponse(resp, "text/plain", status, []byte(fmt.Sprintf("%v unsupported media type, supported: [application/json]", status)))
+		writeResponse(resp, "text/plain", status, []byte(fmt.Sprintf("%v unsupported media type, supported: [%s, %s]", status, jsonContentType, pbContentType)))
 		return
 	}
 }

--- a/receiver/otlpreceiver/otlp.go
+++ b/receiver/otlpreceiver/otlp.go
@@ -217,6 +217,9 @@ func (r *otlpReceiver) registerMetricsConsumer(mc consumer.Metrics) error {
 		r.httpMux.HandleFunc("/v1/metrics", func(resp http.ResponseWriter, req *http.Request) {
 			handleMetrics(resp, req, r.metricsReceiver, jsEncoder)
 		}).Methods(http.MethodPost).Headers("Content-Type", jsonContentType)
+		r.httpMux.HandleFunc("/v1/metrics", func(resp http.ResponseWriter, req *http.Request) {
+			handleUnmatchedRequests(resp, req)
+		})
 	}
 	return nil
 }
@@ -233,6 +236,9 @@ func (r *otlpReceiver) registerLogsConsumer(lc consumer.Logs) error {
 		r.httpMux.HandleFunc("/v1/logs", func(w http.ResponseWriter, req *http.Request) {
 			handleLogs(w, req, r.logReceiver, jsEncoder)
 		}).Methods(http.MethodPost).Headers("Content-Type", jsonContentType)
+		r.httpMux.HandleFunc("/v1/logs", func(resp http.ResponseWriter, req *http.Request) {
+			handleUnmatchedRequests(resp, req)
+		})
 	}
 	return nil
 }

--- a/receiver/otlpreceiver/otlp.go
+++ b/receiver/otlpreceiver/otlp.go
@@ -246,14 +246,12 @@ func (r *otlpReceiver) registerLogsConsumer(lc consumer.Logs) error {
 func handleUnmatchedRequests(resp http.ResponseWriter, req *http.Request) {
 	if req.Method == http.MethodPatch {
 		status := http.StatusMethodNotAllowed
-		resp.WriteHeader(status)
-		resp.Write([]byte(fmt.Sprintf("%v method not allowed, supported: [GET, POST]", status)))
+		writeResponse(resp, "text/plain", status, []byte(fmt.Sprintf("%v method not allowed, supported: [GET, POST]", status)))
 		return
 	}
 	if req.Header.Get("Content-Type") == "" {
 		status := http.StatusUnsupportedMediaType
-		resp.WriteHeader(status)
-		resp.Write([]byte(fmt.Sprintf("%v unsupported media type, supported: [application/json]", status)))
+		writeResponse(resp, "text/plain", status, []byte(fmt.Sprintf("%v unsupported media type, supported: [application/json]", status)))
 		return
 	}
 }

--- a/receiver/otlpreceiver/otlp.go
+++ b/receiver/otlpreceiver/otlp.go
@@ -198,6 +198,9 @@ func (r *otlpReceiver) registerTraceConsumer(tc consumer.Traces) error {
 		r.httpMux.HandleFunc("/v1/traces", func(resp http.ResponseWriter, req *http.Request) {
 			handleTraces(resp, req, r.traceReceiver, jsEncoder)
 		}).Methods(http.MethodPost).Headers("Content-Type", jsonContentType)
+		r.httpMux.HandleFunc("/v1/traces", func(resp http.ResponseWriter, req *http.Request) {
+			handleUnmatchedRequests(resp, req)
+		})
 	}
 	return nil
 }
@@ -232,4 +235,10 @@ func (r *otlpReceiver) registerLogsConsumer(lc consumer.Logs) error {
 		}).Methods(http.MethodPost).Headers("Content-Type", jsonContentType)
 	}
 	return nil
+}
+
+func handleUnmatchedRequests(resp http.ResponseWriter, req *http.Request) {
+	if req.Header.Get("Content-Type") == "" {
+		resp.WriteHeader(http.StatusUnsupportedMediaType)
+	}
 }

--- a/receiver/otlpreceiver/otlp.go
+++ b/receiver/otlpreceiver/otlp.go
@@ -244,7 +244,16 @@ func (r *otlpReceiver) registerLogsConsumer(lc consumer.Logs) error {
 }
 
 func handleUnmatchedRequests(resp http.ResponseWriter, req *http.Request) {
+	if req.Method == http.MethodPatch {
+		status := http.StatusMethodNotAllowed
+		resp.WriteHeader(status)
+		resp.Write([]byte(fmt.Sprintf("%v method not allowed, supported: [GET, POST]", status)))
+		return
+	}
 	if req.Header.Get("Content-Type") == "" {
-		resp.WriteHeader(http.StatusUnsupportedMediaType)
+		status := http.StatusUnsupportedMediaType
+		resp.WriteHeader(status)
+		resp.Write([]byte(fmt.Sprintf("%v unsupported media type, supported: [application/json]", status)))
+		return
 	}
 }

--- a/receiver/otlpreceiver/otlp_test.go
+++ b/receiver/otlpreceiver/otlp_test.go
@@ -289,16 +289,16 @@ func TestHandleInvalidRequests(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			url := fmt.Sprintf("http://%s%s", endpoint, test.uri)
-			req, err := http.NewRequest(test.method, url, bytes.NewReader([]byte(`{}`)))
-			require.NoError(t, err)
+			req, err2 := http.NewRequest(test.method, url, bytes.NewReader([]byte(`{}`)))
+			require.NoError(t, err2)
 			req.Header.Set("Content-Type", test.contentType)
 
 			client := &http.Client{}
-			resp, err := client.Do(req)
-			require.NoError(t, err)
+			resp, err2 := client.Do(req)
+			require.NoError(t, err2)
 
-			body, err := ioutil.ReadAll(resp.Body)
-			require.NoError(t, err)
+			body, err2 := ioutil.ReadAll(resp.Body)
+			require.NoError(t, err2)
 
 			require.Equal(t, resp.Header.Get("Content-Type"), "text/plain")
 			require.Equal(t, resp.StatusCode, test.expectedStatus)

--- a/receiver/otlpreceiver/otlp_test.go
+++ b/receiver/otlpreceiver/otlp_test.go
@@ -204,13 +204,13 @@ func TestHandleInvalidRequests(t *testing.T) {
 		expectedResponseBody string
 	}{
 		{
-			name:        "POST /v1/traces",
+			name:        "POST /v1/traces, no content type",
 			uri:         "/v1/traces",
 			method:      http.MethodPost,
 			contentType: "",
 
 			expectedStatus:       http.StatusUnsupportedMediaType,
-			expectedResponseBody: "415 unsupported media type, supported: [application/json]",
+			expectedResponseBody: "415 unsupported media type, supported: [application/json, application/x-protobuf]",
 		},
 		{
 			name:        "PATCH /v1/traces",
@@ -219,16 +219,25 @@ func TestHandleInvalidRequests(t *testing.T) {
 			contentType: "application/json",
 
 			expectedStatus:       http.StatusMethodNotAllowed,
-			expectedResponseBody: "405 method not allowed, supported: [GET, POST]",
+			expectedResponseBody: "405 method not allowed, supported: [POST]",
 		},
 		{
-			name:        "POST /v1/metrics",
+			name:        "GET /v1/traces",
+			uri:         "/v1/traces",
+			method:      http.MethodGet,
+			contentType: "application/json",
+
+			expectedStatus:       http.StatusMethodNotAllowed,
+			expectedResponseBody: "405 method not allowed, supported: [POST]",
+		},
+		{
+			name:        "POST /v1/metrics, no content type",
 			uri:         "/v1/metrics",
 			method:      http.MethodPost,
 			contentType: "",
 
 			expectedStatus:       http.StatusUnsupportedMediaType,
-			expectedResponseBody: "415 unsupported media type, supported: [application/json]",
+			expectedResponseBody: "415 unsupported media type, supported: [application/json, application/x-protobuf]",
 		},
 		{
 			name:        "PATCH /v1/metrics",
@@ -237,16 +246,25 @@ func TestHandleInvalidRequests(t *testing.T) {
 			contentType: "application/json",
 
 			expectedStatus:       http.StatusMethodNotAllowed,
-			expectedResponseBody: "405 method not allowed, supported: [GET, POST]",
+			expectedResponseBody: "405 method not allowed, supported: [POST]",
 		},
 		{
-			name:        "POST /v1/logs",
+			name:        "GET /v1/metrics",
+			uri:         "/v1/metrics",
+			method:      http.MethodGet,
+			contentType: "application/json",
+
+			expectedStatus:       http.StatusMethodNotAllowed,
+			expectedResponseBody: "405 method not allowed, supported: [POST]",
+		},
+		{
+			name:        "POST /v1/logs, no content type",
 			uri:         "/v1/logs",
 			method:      http.MethodPost,
 			contentType: "",
 
 			expectedStatus:       http.StatusUnsupportedMediaType,
-			expectedResponseBody: "415 unsupported media type, supported: [application/json]",
+			expectedResponseBody: "415 unsupported media type, supported: [application/json, application/x-protobuf]",
 		},
 		{
 			name:        "PATCH /v1/logs",
@@ -255,7 +273,16 @@ func TestHandleInvalidRequests(t *testing.T) {
 			contentType: "application/json",
 
 			expectedStatus:       http.StatusMethodNotAllowed,
-			expectedResponseBody: "405 method not allowed, supported: [GET, POST]",
+			expectedResponseBody: "405 method not allowed, supported: [POST]",
+		},
+		{
+			name:        "GET /v1/logs",
+			uri:         "/v1/logs",
+			method:      http.MethodGet,
+			contentType: "application/json",
+
+			expectedStatus:       http.StatusMethodNotAllowed,
+			expectedResponseBody: "405 method not allowed, supported: [POST]",
 		},
 	}
 

--- a/receiver/otlpreceiver/otlp_test.go
+++ b/receiver/otlpreceiver/otlp_test.go
@@ -272,6 +272,8 @@ func TestHandleInvalidRequests(t *testing.T) {
 
 			body, err := ioutil.ReadAll(resp.Body)
 			require.NoError(t, err)
+
+			require.Equal(t, resp.Header.Get("Content-Type"), "text/plain")
 			require.Equal(t, resp.StatusCode, test.expectedStatus)
 			require.EqualValues(t, body, test.expectedResponseBody)
 		})


### PR DESCRIPTION
**Description:** 

This change adds a fallback handler to handle responses to invalid requests for logs, metrics and traces.

Given the following requests, the following responses are returned:

```
POST http://localhost:4318/v1/(logs|metrics|traces)
Content-Type: 

HTTP/1.1 415 Unsupported Media Type
Content-Type: text/plain
Date: Thu, 27 Jan 2022 03:44:19 GMT
Content-Length: 57
Content-Type: text/plain; charset=utf-8
Connection: close

415 unsupported media type, supported: [application/json]
```
```
PATCH http://localhost:4318/v1/(logs|metrics|traces)
Content-Type: application/json

HTTP/1.1 405 Method Not Allowed
Content-Type: text/plain
Date: Thu, 27 Jan 2022 04:13:01 GMT
Content-Length: 46
Content-Type: text/plain; charset=utf-8
Connection: close

405 method not allowed, supported: [GET, POST]
```

**Link to tracking Issue:** #4661

**Testing:** Manual testing and automated tests added to the pull request.