### PR TITLE
fix call to NewDefaultConfigProvider

### DIFF
--- a/service/config_provider_test.go
+++ b/service/config_provider_test.go
@@ -354,7 +354,7 @@ func TestBackwardsCompatibilityForFilePath(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		provider := NewDefaultConfigProvider(tt.location, []string{})
+		provider := NewDefaultConfigProvider([]string{tt.location}, []string{})
 		_, err := provider.Get(context.Background(), factories)
 		assert.Contains(t, err.Error(), tt.errMessage, tt.name)
 	}


### PR DESCRIPTION
Still unclear how this didn't fail CI before 🤔 

The call in the test was still passing in a `string` instead of `[]string`
