### PR TITLE
Add support in the confmap.Resolver to expand embedded config URIs inside configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -192,6 +192,7 @@ There isn't a valid core binary for this release. Use v0.57.2 instead.
 - Use OpenCensus `metric` package for process metrics instead of `stats` package (#5486)
 - Update OTLP to v0.18.0 (#5530)
 - Log histogram min/max fields with `logging` exporter (#5520)
+- Add support in the `confmap.Resolver` to expand embedded config URIs inside configuration (#4742)
 
 ### 🧰 Bug fixes 🧰
 

--- a/confmap/README.md
+++ b/confmap/README.md
@@ -33,23 +33,35 @@ The `Resolver` receives as input a set of `Providers`, a list of `Converters`, a
 `configURI` that will be used to generate the resulting, or effective, configuration in the form of a `Conf`,
 that can be used by code that is oblivious to the usage of `Providers` and `Converters`.
 
+`Providers` are used to provide an entire configuration when the `configURI` is given directly to the `Resolver`,
+or an individual value (partial configuration) when the `configURI` is embedded into the `Conf` as a values using
+the syntax `${configURI}`.
+
 ```terminal
               Resolver                   Provider
-                 │                          │
    Resolve       │                          │
 ────────────────►│                          │
                  │                          │
               ┌─ │        Retrieve          │
               │  ├─────────────────────────►│
-              │  │                          │
+              │  │          Conf            │
               │  │◄─────────────────────────┤
-   foreach    │  │                          │
+  foreach     │  │                          │
   configURI   │  ├───┐                      │
               │  │   │Merge                 │
               │  │◄──┘                      │
               └─ │                          │
+              ┌─ │        Retrieve          │
+              │  ├─────────────────────────►│
+              │  │    Partial Conf Value    │
+              │  │◄─────────────────────────┤
+  foreach     │  │                          │
+  embedded    │  │                          │
+  configURI   │  ├───┐                      │
+              │  │   │Replace               │
+              │  │◄──┘                      │
+              └─ │                          │
                  │            Converter     │
-                 │                │         │
               ┌─ │     Convert    │         │
               │  ├───────────────►│         │
     foreach   │  │                │         │
@@ -57,15 +69,15 @@ that can be used by code that is oblivious to the usage of `Providers` and `Conv
               └─ │                          │
                  │                          │
 ◄────────────────┤                          │
-                 │                          │
 ```
 
 The `Resolve` method proceeds in the following steps:
 
 1. Start with an empty "result" of `Conf` type.
 2. For each config URI retrieves individual configurations, and merges it into the "result".
-2. For each "Converter", call "Convert" for the "result".
-4. Return the "result", aka effective, configuration.
+3. For each embedded config URI retrieves individual value, and replaces it into the "result".
+4. For each "Converter", call "Convert" for the "result".
+5. Return the "result", aka effective, configuration.
 
 ### Watching for Updates
 After the configuration was processed, the `Resolver` can be used as a single point to watch for updates in the

--- a/confmap/provider/internal/provider.go
+++ b/confmap/provider/internal/provider.go
@@ -24,7 +24,7 @@ import (
 // * yamlBytes the yaml bytes that will be deserialized.
 // * opts specifies options associated with this Retrieved value, such as CloseFunc.
 func NewRetrievedFromYAML(yamlBytes []byte, opts ...confmap.RetrievedOption) (confmap.Retrieved, error) {
-	var rawConf map[string]interface{}
+	var rawConf interface{}
 	if err := yaml.Unmarshal(yamlBytes, &rawConf); err != nil {
 		return confmap.Retrieved{}, err
 	}

--- a/confmap/provider/internal/provider_test.go
+++ b/confmap/provider/internal/provider_test.go
@@ -46,10 +46,13 @@ func TestNewRetrievedFromYAMLWithOptions(t *testing.T) {
 
 func TestNewRetrievedFromYAMLInvalidYAMLBytes(t *testing.T) {
 	_, err := NewRetrievedFromYAML([]byte("[invalid:,"))
-	require.Error(t, err)
+	assert.Error(t, err)
 }
 
 func TestNewRetrievedFromYAMLInvalidAsMap(t *testing.T) {
-	_, err := NewRetrievedFromYAML([]byte("string"))
-	require.Error(t, err)
+	ret, err := NewRetrievedFromYAML([]byte("string"))
+	require.NoError(t, err)
+
+	_, err = ret.AsConf()
+	assert.Error(t, err)
 }

--- a/confmap/resolver.go
+++ b/confmap/resolver.go
@@ -38,6 +38,8 @@ type Resolver struct {
 	sync.Mutex
 	closers []CloseFunc
 	watcher chan error
+
+	enableExpand bool
 }
 
 // ResolverSettings are the settings to configure the behavior of the Resolver.
@@ -115,20 +117,14 @@ func (mr *Resolver) Resolve(ctx context.Context) (*Conf, error) {
 		// For backwards compatibility:
 		// - empty url scheme means "file".
 		// - "^[A-z]:" also means "file"
-		scheme := "file"
-		if idx := strings.Index(uri, ":"); idx != -1 && !driverLetterRegexp.MatchString(uri) {
-			scheme = uri[:idx]
-		} else {
-			uri = scheme + ":" + uri
+		if driverLetterRegexp.MatchString(uri) {
+			uri = "file:" + uri
 		}
-		p, ok := mr.providers[scheme]
-		if !ok {
-			return nil, fmt.Errorf("scheme %q is not supported for uri %q", scheme, uri)
-		}
-		ret, err := p.Retrieve(ctx, uri, mr.onChange)
+		ret, err := mr.retrieveValue(ctx, location{uri: uri, defaultScheme: "file"})
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("cannot retrieve the configuration: %w", err)
 		}
+		mr.closers = append(mr.closers, ret.Close)
 		retCfgMap, err := ret.AsConf()
 		if err != nil {
 			return nil, err
@@ -136,7 +132,18 @@ func (mr *Resolver) Resolve(ctx context.Context) (*Conf, error) {
 		if err = retMap.Merge(retCfgMap); err != nil {
 			return nil, err
 		}
-		mr.closers = append(mr.closers, ret.Close)
+	}
+
+	if mr.enableExpand {
+		cfgMap := make(map[string]interface{})
+		for _, k := range retMap.AllKeys() {
+			val, err := mr.expandValueRecursively(ctx, retMap.Get(k))
+			if err != nil {
+				return nil, err
+			}
+			cfgMap[k] = val
+		}
+		retMap = NewFromStringMap(cfgMap)
 	}
 
 	// Apply the converters in the given order.
@@ -186,4 +193,83 @@ func (mr *Resolver) closeIfNeeded(ctx context.Context) error {
 		err = multierr.Append(err, ret(ctx))
 	}
 	return err
+}
+
+func (mr *Resolver) expandValueRecursively(ctx context.Context, value interface{}) (interface{}, error) {
+	for i := 0; i < 100; i++ {
+		val, changed, err := mr.expandValue(ctx, value)
+		if err != nil {
+			return nil, err
+		}
+		if !changed {
+			return val, nil
+		}
+		value = val
+	}
+	return nil, errors.New("too many recursive expansions")
+}
+
+func (mr *Resolver) expandValue(ctx context.Context, value interface{}) (interface{}, bool, error) {
+	switch v := value.(type) {
+	case string:
+		// If it doesn't have the format "${scheme:opaque}" no need to expand.
+		if !strings.HasPrefix(v, "${") || !strings.HasSuffix(v, "}") {
+			return value, false, nil
+		}
+		uri := v[2 : len(v)-1]
+		// For backwards compatibility:
+		// - empty scheme means "env".
+		ret, err := mr.retrieveValue(ctx, location{uri: uri, defaultScheme: "env"})
+		if err != nil {
+			return nil, false, err
+		}
+		mr.closers = append(mr.closers, ret.Close)
+		val, err := ret.AsRaw()
+		return val, true, err
+	case []interface{}:
+		nslice := make([]interface{}, 0, len(v))
+		nchanged := false
+		for _, vint := range v {
+			val, changed, err := mr.expandValue(ctx, vint)
+			if err != nil {
+				return nil, false, err
+			}
+			nslice = append(nslice, val)
+			nchanged = nchanged || changed
+		}
+		return nslice, nchanged, nil
+	case map[string]interface{}:
+		nmap := map[string]interface{}{}
+		nchanged := false
+		for mk, mv := range v {
+			val, changed, err := mr.expandValue(ctx, mv)
+			if err != nil {
+				return nil, false, err
+			}
+			nmap[mk] = val
+			nchanged = nchanged || changed
+		}
+		return nmap, nchanged, nil
+	}
+	return value, false, nil
+}
+
+type location struct {
+	uri           string
+	defaultScheme string
+}
+
+func (mr *Resolver) retrieveValue(ctx context.Context, l location) (Retrieved, error) {
+	uri := l.uri
+	scheme := l.defaultScheme
+	if idx := strings.Index(uri, ":"); idx != -1 {
+		scheme = uri[:idx]
+	} else {
+		uri = scheme + ":" + uri
+	}
+	p, ok := mr.providers[scheme]
+	if !ok {
+		return Retrieved{}, fmt.Errorf("scheme %q is not supported for uri %q", scheme, uri)
+	}
+	return p.Retrieve(ctx, uri, mr.onChange)
 }

--- a/confmap/testdata/expand-with-all-env-with-source.yaml
+++ b/confmap/testdata/expand-with-all-env-with-source.yaml
@@ -1,0 +1,11 @@
+test_map:
+  extra: "${env:EXTRA}"
+  extra_map:
+    recv.1: "${env:EXTRA_MAP_VALUE_1}"
+    recv.2: "${env:EXTRA_MAP_VALUE_2}"
+  extra_list_map:
+    - { recv.1: "${env:EXTRA_LIST_MAP_VALUE_1}",recv.2: "${env:EXTRA_LIST_MAP_VALUE_2}" }
+  extra_list:
+    - "${env:EXTRA_LIST_VALUE_1}"
+    - "${env:EXTRA_LIST_VALUE_2}"
+    

--- a/confmap/testdata/expand-with-all-env.yaml
+++ b/confmap/testdata/expand-with-all-env.yaml
@@ -1,0 +1,11 @@
+test_map:
+  extra: "${EXTRA}"
+  extra_map:
+    recv.1: "${EXTRA_MAP_VALUE_1}"
+    recv.2: "${EXTRA_MAP_VALUE_2}"
+  extra_list_map:
+    - { recv.1: "${EXTRA_LIST_MAP_VALUE_1}",recv.2: "${EXTRA_LIST_MAP_VALUE_2}" }
+  extra_list:
+    - "${EXTRA_LIST_VALUE_1}"
+    - "${EXTRA_LIST_VALUE_2}"
+    

--- a/confmap/testdata/expand-with-no-env.yaml
+++ b/confmap/testdata/expand-with-no-env.yaml
@@ -1,0 +1,10 @@
+test_map:
+  extra: "some string"
+  extra_map:
+    recv.1: "some map value_1"
+    recv.2: "some map value_2"
+  extra_list_map:
+    - { recv.1: "some list map value_1",recv.2: "some list map value_2" }
+  extra_list:
+    - "some list value_1"
+    - "some list value_2"

--- a/confmap/testdata/expand-with-partial-env.yaml
+++ b/confmap/testdata/expand-with-partial-env.yaml
@@ -1,0 +1,10 @@
+test_map:
+  extra: "${EXTRA}"
+  extra_map:
+    recv.1: "${EXTRA_MAP_VALUE_1}"
+    recv.2: "some map value_2"
+  extra_list_map:
+    - { recv.1: "some list map value_1",recv.2: "${EXTRA_LIST_MAP_VALUE_2}" }
+  extra_list:
+    - "some list value_1"
+    - "${EXTRA_LIST_VALUE_2}"


### PR DESCRIPTION
Proposal on how we can extend our current config provider to support expanding (including) config "parts". This will fix https://github.com/open-telemetry/opentelemetry-collector/issues/4231 and will fully implement same capabilities as proposed in https://github.com/open-telemetry/opentelemetry-collector/pull/4468.

This design is based on the https://docs.google.com/document/d/1XlDpS8-a4Ds6uoe6C6WgO8mCpDaQNufcHSEmBpiCdI0/edit format which we already support for the "--config" flag.

## `confmap.Provider` changes

Extend the capability of a `confmap.Provider` to return a `Provided` value that can encapsulate a `confmap.Conf` or any partial config value (float64/int64/bool/string/map[string]interface{}/[]interface{} where map values or slice values have the same restrictions). The current design allows `recursive` expansions, so values returned by expanding one embedded config URI will be searched for expanding again.

## Known caveats

1. The proposed mechanism does not allow expanding values within other values, for example this case `${http://example.com/get_config?os=${env:OSNAME}}` will NOT expand first the OSNAME env var.

## Examples of usages

**Retrieving token from zookeeper (scheme not yet defined)**

```yaml
exporters:
  signalfx:
    # this will read the access_token value from "zk" config provider.
    access_token: ${zk:zk1,zk2,zk2/path/to/data}
```

**Retrieving an entire exporter config from a file**

```yaml
exporters:
  # this will read the entire config for the otlp/file exporter from the given file
  otlp/file_config: ${file:path/to/config/file/for/the/exporter.yaml}
```

**Expanding env vars**

```yaml
exporters:
  otlp:
    endpoint: ${env:MY_ENV}

  otlp/backwards_compatible:
    endpoint: ${MY_ENV}
```

## Expand `Converter` vs `embedded` config

The current proposal to support `embedding` config URIs, does not support the following cases that are supported by the expand envvar `Converter`:

1. Using `$` without brackets:

```yaml
exporters:
  otlp/another_way_to_use_env_vars:
    endpoint: $MY_ENV
```

2. Expanding values within a string value and concatenate:

```yaml
exporters:
  otlp/localhost_enpoint:
    endpoint: "localhost:${OTLP_PORT_ENV}"
```

Because of these missing features the Expand `Converter` will be maintain for a period of time until a final decision between supporting or not the 2 missing features is made. If we decide to not support any of these features we can start at least by logging errors and disable the functionality behind a featuregate until we know if this is needed or not.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
