### PR TITLE
expandStringValues function support to map[string]interface{}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 🧰 Bug fixes 🧰
+
+- ExpandStringValues function support to map[string]interface{} (#4748) 
+
 ## v0.43.0 Beta
 
 ## 🛑 Breaking changes 🛑

--- a/config/configmapprovider/expand.go
+++ b/config/configmapprovider/expand.go
@@ -43,6 +43,12 @@ func expandStringValues(value interface{}) interface{} {
 			nslice = append(nslice, expandStringValues(vint))
 		}
 		return nslice
+	case map[string]interface{}:
+		nmap := map[string]interface{}{}
+		for mk, mv := range v {
+			nmap[mk] = expandStringValues(mv)
+		}
+		return nmap
 	default:
 		return v
 	}

--- a/config/configmapprovider/expand_test.go
+++ b/config/configmapprovider/expand_test.go
@@ -36,10 +36,13 @@ func TestNewExpandConverter(t *testing.T) {
 
 	const valueExtra = "some string"
 	const valueExtraMapValue = "some map value"
+	const valueExtraListMapValue = "some list map value"
 	const valueExtraListElement = "some list value"
 	t.Setenv("EXTRA", valueExtra)
 	t.Setenv("EXTRA_MAP_VALUE_1", valueExtraMapValue+"_1")
 	t.Setenv("EXTRA_MAP_VALUE_2", valueExtraMapValue+"_2")
+	t.Setenv("EXTRA_LIST_MAP_VALUE_1", valueExtraListMapValue+"_1")
+	t.Setenv("EXTRA_LIST_MAP_VALUE_2", valueExtraListMapValue+"_2")
 	t.Setenv("EXTRA_LIST_VALUE_1", valueExtraListElement+"_1")
 	t.Setenv("EXTRA_LIST_VALUE_2", valueExtraListElement+"_2")
 

--- a/config/configmapprovider/testdata/expand-with-all-env.yaml
+++ b/config/configmapprovider/testdata/expand-with-all-env.yaml
@@ -3,6 +3,8 @@ test_map:
   extra_map:
     recv.1: "$EXTRA_MAP_VALUE_1"
     recv.2: "${EXTRA_MAP_VALUE_2}"
+  extra_list_map:
+    - { recv.1: "$EXTRA_LIST_MAP_VALUE_1",recv.2: "${EXTRA_LIST_MAP_VALUE_2}" }
   extra_list:
     - "$EXTRA_LIST_VALUE_1"
     - "${EXTRA_LIST_VALUE_2}"

--- a/config/configmapprovider/testdata/expand-with-no-env.yaml
+++ b/config/configmapprovider/testdata/expand-with-no-env.yaml
@@ -3,6 +3,8 @@ test_map:
   extra_map:
     recv.1: "some map value_1"
     recv.2: "some map value_2"
+  extra_list_map:
+    - { recv.1: "some list map value_1",recv.2: "some list map value_2" }
   extra_list:
     - "some list value_1"
     - "some list value_2"

--- a/config/configmapprovider/testdata/expand-with-partial-env.yaml
+++ b/config/configmapprovider/testdata/expand-with-partial-env.yaml
@@ -3,6 +3,8 @@ test_map:
   extra_map:
     recv.1: "${EXTRA_MAP_VALUE_1}"
     recv.2: "some map value_2"
+  extra_list_map:
+    - { recv.1: "some list map value_1",recv.2: "${EXTRA_LIST_MAP_VALUE_2}" }
   extra_list:
     - "some list value_1"
     - "$EXTRA_LIST_VALUE_2"


### PR DESCRIPTION

**Description:** 

The use and expansion of environment variables is supported in the Collector configuration. For example:

```
processors:
  attributes/example:
    actions:
      - key: "${DB_KEY}"
        action: "${OPERATION}"
```