### PR TITLE
Return an error in `service.NewConfigProvider` if there is no configLocations (v0.45)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@
 
 - Deprecate `pdata.NumberDataPoint.Type()` and `pdata.Exemplar.Type()` in favor of `NumberDataPoint.ValueType()` and
   `Exemplar.ValueType()` (#4850)
+- Deprecate `service.MustNewConfigProvider` and `service.MustNewDefaultConfigProvider`in favor of `service.NewConfigProvider` and
+  `service.NewDefaultConfigProvider` (#4762)
 
 ## v0.44.0 Beta
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,8 +44,7 @@
 
 - Deprecate `pdata.NumberDataPoint.Type()` and `pdata.Exemplar.Type()` in favor of `NumberDataPoint.ValueType()` and
   `Exemplar.ValueType()` (#4850)
-- Deprecate `service.MustNewConfigProvider` and `service.MustNewDefaultConfigProvider`in favor of `service.NewConfigProvider` and
-  `service.NewDefaultConfigProvider` (#4762)
+- Deprecate `service.MustNewConfigProvider` and `service.MustNewDefaultConfigProvider`in favor of `service.NewConfigProvider` (#4762)
 
 ## v0.44.0 Beta
 

--- a/service/collector_test.go
+++ b/service/collector_test.go
@@ -51,10 +51,13 @@ func TestCollector_StartAsGoRoutine(t *testing.T) {
 	factories, err := testcomponents.NewDefaultFactories()
 	require.NoError(t, err)
 
+	configProvider, err := NewDefaultConfigProvider([]string{filepath.Join("testdata", "otelcol-config.yaml")}, nil)
+	require.NoError(t, err)
+
 	set := CollectorSettings{
 		BuildInfo:      component.NewDefaultBuildInfo(),
 		Factories:      factories,
-		ConfigProvider: MustNewDefaultConfigProvider([]string{filepath.Join("testdata", "otelcol-config.yaml")}, nil),
+		ConfigProvider: configProvider,
 	}
 	col, err := New(set)
 	require.NoError(t, err)
@@ -93,12 +96,16 @@ func TestCollector_Start(t *testing.T) {
 	}
 
 	metricsPort := testutil.GetAvailablePort(t)
+	configProvider, err := NewDefaultConfigProvider(
+		[]string{filepath.Join("testdata", "otelcol-config.yaml")},
+		[]string{"service.telemetry.metrics.address=localhost:" + strconv.FormatUint(uint64(metricsPort), 10)})
+
+	require.NoError(t, err)
+
 	col, err := New(CollectorSettings{
-		BuildInfo: component.NewDefaultBuildInfo(),
-		Factories: factories,
-		ConfigProvider: MustNewDefaultConfigProvider(
-			[]string{filepath.Join("testdata", "otelcol-config.yaml")},
-			[]string{"service.telemetry.metrics.address=localhost:" + strconv.FormatUint(uint64(metricsPort), 10)}),
+		BuildInfo:      component.NewDefaultBuildInfo(),
+		Factories:      factories,
+		ConfigProvider: configProvider,
 		LoggingOptions: []zap.Option{zap.Hooks(hook)},
 	})
 	require.NoError(t, err)
@@ -172,10 +179,13 @@ func TestCollector_ReportError(t *testing.T) {
 	factories, err := testcomponents.NewDefaultFactories()
 	require.NoError(t, err)
 
+	configProvider, err := NewDefaultConfigProvider([]string{filepath.Join("testdata", "otelcol-config.yaml")}, nil)
+	require.NoError(t, err)
+
 	col, err := New(CollectorSettings{
 		BuildInfo:      component.NewDefaultBuildInfo(),
 		Factories:      factories,
-		ConfigProvider: MustNewDefaultConfigProvider([]string{filepath.Join("testdata", "otelcol-config.yaml")}, nil),
+		ConfigProvider: configProvider,
 	})
 	require.NoError(t, err)
 

--- a/service/command.go
+++ b/service/command.go
@@ -17,6 +17,8 @@ package service // import "go.opentelemetry.io/collector/service"
 import (
 	"github.com/spf13/cobra"
 
+	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/config/configmapprovider"
 	"go.opentelemetry.io/collector/service/featuregate"
 )
 
@@ -30,7 +32,10 @@ func NewCommand(set CollectorSettings) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			featuregate.Apply(featuregate.GetFlags())
 			if set.ConfigProvider == nil {
-				configProvider, err := NewDefaultConfigProvider(getConfigFlag(), getSetFlag())
+				cfgMapConverter := []config.MapConverterFunc{
+					configmapprovider.NewOverwritePropertiesConverter(getSetFlag()),
+				}
+				configProvider, err := NewConfigProvider(getConfigFlag(), WithCfgMapConverters(cfgMapConverter))
 				if err != nil {
 					return err
 				}

--- a/service/command.go
+++ b/service/command.go
@@ -30,7 +30,11 @@ func NewCommand(set CollectorSettings) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			featuregate.Apply(featuregate.GetFlags())
 			if set.ConfigProvider == nil {
-				set.ConfigProvider = MustNewDefaultConfigProvider(getConfigFlag(), getSetFlag())
+				configProvider, err := NewDefaultConfigProvider(getConfigFlag(), getSetFlag())
+				if err != nil {
+					return err
+				}
+				set.ConfigProvider = configProvider
 			}
 			col, err := New(set)
 			if err != nil {

--- a/service/config_provider_test.go
+++ b/service/config_provider_test.go
@@ -165,7 +165,9 @@ func TestConfigProvider_Errors(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cfgW := MustNewConfigProvider(tt.locations, tt.parserProvider, tt.cfgMapConverters, tt.configUnmarshaler)
+			cfgW, err := NewConfigProvider(tt.locations, tt.parserProvider, tt.cfgMapConverters, tt.configUnmarshaler)
+			assert.NoError(t, err)
+
 			_, errN := cfgW.Get(context.Background(), factories)
 			if tt.expectNewErr {
 				assert.Error(t, errN)
@@ -200,11 +202,12 @@ func TestConfigProvider(t *testing.T) {
 		return &mockProvider{retM: cfgMap}
 	}()
 
-	cfgW := MustNewConfigProvider(
+	cfgW, err := NewConfigProvider(
 		[]string{"watcher:"},
 		map[string]configmapprovider.Provider{"watcher": configMapProvider},
 		nil,
 		configunmarshaler.NewDefault())
+	require.NoError(t, err)
 	_, errN := cfgW.Get(context.Background(), factories)
 	assert.NoError(t, errN)
 
@@ -228,11 +231,12 @@ func TestConfigProviderNoWatcher(t *testing.T) {
 	require.NoError(t, errF)
 
 	watcherWG := sync.WaitGroup{}
-	cfgW := MustNewConfigProvider(
+	cfgW, err := NewConfigProvider(
 		[]string{filepath.Join("testdata", "otelcol-nop.yaml")},
 		map[string]configmapprovider.Provider{"file": configmapprovider.NewFile()},
 		nil,
 		configunmarshaler.NewDefault())
+	require.NoError(t, err)
 	_, errN := cfgW.Get(context.Background(), factories)
 	assert.NoError(t, errN)
 
@@ -260,12 +264,14 @@ func TestConfigProvider_ShutdownClosesWatch(t *testing.T) {
 	}()
 
 	watcherWG := sync.WaitGroup{}
-	cfgW := MustNewConfigProvider(
+	cfgW, err := NewConfigProvider(
 		[]string{"watcher:"},
 		map[string]configmapprovider.Provider{"watcher": configMapProvider},
 		nil,
 		configunmarshaler.NewDefault())
 	_, errN := cfgW.Get(context.Background(), factories)
+	require.NoError(t, err)
+
 	assert.NoError(t, errN)
 
 	watcherWG.Add(1)
@@ -322,8 +328,9 @@ func TestBackwardsCompatibilityForFilePath(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		provider := MustNewDefaultConfigProvider([]string{tt.location}, []string{})
-		_, err := provider.Get(context.Background(), factories)
+		provider, err := NewDefaultConfigProvider([]string{tt.location}, []string{})
+		assert.NoError(t, err)
+		_, err = provider.Get(context.Background(), factories)
 		assert.Contains(t, err.Error(), tt.errMessage, tt.name)
 	}
 

--- a/service/config_provider_test.go
+++ b/service/config_provider_test.go
@@ -325,7 +325,7 @@ func TestBackwardsCompatibilityForFilePath(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		provider, err := NewDefaultConfigProvider([]string{tt.location}, []string{})
+		provider, err := NewConfigProvider([]string{tt.location})
 		assert.NoError(t, err)
 		_, err = provider.Get(context.Background(), factories)
 		assert.Contains(t, err.Error(), tt.errMessage, tt.name)

--- a/service/config_provider_test.go
+++ b/service/config_provider_test.go
@@ -165,7 +165,7 @@ func TestConfigProvider_Errors(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cfgW, err := NewConfigProvider(tt.locations, tt.parserProvider, tt.cfgMapConverters, tt.configUnmarshaler)
+			cfgW, err := NewConfigProvider(tt.locations, WithConfigMapProviders(tt.parserProvider), WithCfgMapConverters(tt.cfgMapConverters), WithConfigUnmarshaler(tt.configUnmarshaler))
 			assert.NoError(t, err)
 
 			_, errN := cfgW.Get(context.Background(), factories)
@@ -204,9 +204,8 @@ func TestConfigProvider(t *testing.T) {
 
 	cfgW, err := NewConfigProvider(
 		[]string{"watcher:"},
-		map[string]configmapprovider.Provider{"watcher": configMapProvider},
-		nil,
-		configunmarshaler.NewDefault())
+		WithConfigMapProviders(map[string]configmapprovider.Provider{"watcher": configMapProvider}),
+		WithConfigUnmarshaler(configunmarshaler.NewDefault()))
 	require.NoError(t, err)
 	_, errN := cfgW.Get(context.Background(), factories)
 	assert.NoError(t, errN)
@@ -233,9 +232,8 @@ func TestConfigProviderNoWatcher(t *testing.T) {
 	watcherWG := sync.WaitGroup{}
 	cfgW, err := NewConfigProvider(
 		[]string{filepath.Join("testdata", "otelcol-nop.yaml")},
-		map[string]configmapprovider.Provider{"file": configmapprovider.NewFile()},
-		nil,
-		configunmarshaler.NewDefault())
+		WithConfigMapProviders(map[string]configmapprovider.Provider{"file": configmapprovider.NewFile()}),
+		WithConfigUnmarshaler(configunmarshaler.NewDefault()))
 	require.NoError(t, err)
 	_, errN := cfgW.Get(context.Background(), factories)
 	assert.NoError(t, errN)
@@ -266,9 +264,8 @@ func TestConfigProvider_ShutdownClosesWatch(t *testing.T) {
 	watcherWG := sync.WaitGroup{}
 	cfgW, err := NewConfigProvider(
 		[]string{"watcher:"},
-		map[string]configmapprovider.Provider{"watcher": configMapProvider},
-		nil,
-		configunmarshaler.NewDefault())
+		WithConfigMapProviders(map[string]configmapprovider.Provider{"watcher": configMapProvider}),
+		WithConfigUnmarshaler(configunmarshaler.NewDefault()))
 	_, errN := cfgW.Get(context.Background(), factories)
 	require.NoError(t, err)
 


### PR DESCRIPTION
**Description:** 
As was said in #4734, this commit:  

- changes `service.NewConfigProvider` to return an error when provided `configLocations` length is equals to 0,
- deprecates `service.MustNewConfigProvider` and makes it `panic` under the same condition as above,
- changes back all references in code from "Must" version to normal and handles error.

When the version 0.44 will come out I will undraft this PR.
Also I'm not sure is it possible to apply only third commit (the previous 2 are from my last PR) but I will remove them when my last PR will be merged.

**Link to tracking Issue:** #4730 

**Testing:** `make all`
