### PR TITLE
Update builder integration tests, enable daily/manual builds

### DIFF
--- a/.github/workflows/builder-integration-test.yaml
+++ b/.github/workflows/builder-integration-test.yaml
@@ -1,14 +1,24 @@
 name: Builder - Integration tests
 
 on:
+  # on changes to the main branch touching the builder
   push:
     branches: [ main ]
     paths:
       - 'cmd/builder/**'
+
+  # on PRs touching the builder
   pull_request:
     branches: [ main ]
     paths:
       - 'cmd/builder/**'
+  
+  # once a day at 6:17 AM UTC
+  schedule:
+    - cron: '17 6 * * *'
+
+  # manual execution
+  workflow_dispatch:
 
 jobs:
   integration-test:

--- a/cmd/builder/test/core.builder.yaml
+++ b/cmd/builder/test/core.builder.yaml
@@ -1,15 +1,15 @@
 dist:
   module: go.opentelemetry.io/collector/builder/test/nocore
-  otelcol_version: 0.41.0
+  otelcol_version: 0.43.0
 
 extensions:
   - import: go.opentelemetry.io/collector/extension/zpagesextension
-    gomod: go.opentelemetry.io/collector v0.41.0
+    gomod: go.opentelemetry.io/collector v0.43.0
 
 receivers:
   - import: go.opentelemetry.io/collector/receiver/otlpreceiver
-    gomod: go.opentelemetry.io/collector v0.41.0
+    gomod: go.opentelemetry.io/collector v0.43.0
 
 exporters:
   - import: go.opentelemetry.io/collector/exporter/loggingexporter
-    gomod: go.opentelemetry.io/collector v0.41.0
+    gomod: go.opentelemetry.io/collector v0.43.0

--- a/cmd/builder/test/core.builder.yaml
+++ b/cmd/builder/test/core.builder.yaml
@@ -4,12 +4,12 @@ dist:
 
 extensions:
   - import: go.opentelemetry.io/collector/extension/zpagesextension
-    gomod: go.opentelemetry.io/collector v0.43.0
+    gomod: go.opentelemetry.io/collector v0.43.1
 
 receivers:
   - import: go.opentelemetry.io/collector/receiver/otlpreceiver
-    gomod: go.opentelemetry.io/collector v0.43.0
+    gomod: go.opentelemetry.io/collector v0.43.1
 
 exporters:
   - import: go.opentelemetry.io/collector/exporter/loggingexporter
-    gomod: go.opentelemetry.io/collector v0.43.0
+    gomod: go.opentelemetry.io/collector v0.43.1

--- a/cmd/builder/test/replaces.builder.yaml
+++ b/cmd/builder/test/replaces.builder.yaml
@@ -4,11 +4,11 @@ dist:
 
 extensions:
   - import: go.opentelemetry.io/collector/extension/zpagesextension
-    gomod: go.opentelemetry.io/collector v0.43.0
+    gomod: go.opentelemetry.io/collector v0.43.1
 
 receivers:
   - import: go.opentelemetry.io/collector/receiver/otlpreceiver
-    gomod: go.opentelemetry.io/collector v0.43.0
+    gomod: go.opentelemetry.io/collector v0.43.1
 
 processors:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/routingprocessor v0.43.0
@@ -16,7 +16,7 @@ processors:
 
 exporters:
   - import: go.opentelemetry.io/collector/exporter/loggingexporter
-    gomod: go.opentelemetry.io/collector v0.43.0
+    gomod: go.opentelemetry.io/collector v0.43.1
 
 replaces:
   - github.com/open-telemetry/opentelemetry-collector-contrib/internal/common => github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.43.0

--- a/cmd/builder/test/replaces.builder.yaml
+++ b/cmd/builder/test/replaces.builder.yaml
@@ -1,22 +1,22 @@
 dist:
   module: go.opentelemetry.io/collector/builder/test/replaces
-  otelcol_version: 0.41.0
+  otelcol_version: 0.43.0
 
 extensions:
   - import: go.opentelemetry.io/collector/extension/zpagesextension
-    gomod: go.opentelemetry.io/collector v0.41.0
+    gomod: go.opentelemetry.io/collector v0.43.0
 
 receivers:
   - import: go.opentelemetry.io/collector/receiver/otlpreceiver
-    gomod: go.opentelemetry.io/collector v0.41.0
+    gomod: go.opentelemetry.io/collector v0.43.0
 
 processors:
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/routingprocessor v0.41.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.41.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/routingprocessor v0.43.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.43.0
 
 exporters:
   - import: go.opentelemetry.io/collector/exporter/loggingexporter
-    gomod: go.opentelemetry.io/collector v0.41.0
+    gomod: go.opentelemetry.io/collector v0.43.0
 
 replaces:
-  - github.com/open-telemetry/opentelemetry-collector-contrib/internal/common => github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.40.0
+  - github.com/open-telemetry/opentelemetry-collector-contrib/internal/common => github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.43.0


### PR DESCRIPTION
This PR bumps the integration tests to use the latest released version of the collector when building a distribution. It also enables a daily build running the integration tests, as well as their manual execution.

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>
