### PR TITLE
[pdatagen] Generate oneOf field

### DIFF
--- a/model/internal/cmd/pdatagen/internal/base_fields.go
+++ b/model/internal/cmd/pdatagen/internal/base_fields.go
@@ -53,15 +53,34 @@ func (ms ${structName}) Set${fieldName}(v ${returnType}) {
 	(*ms.orig).${originFieldName} = v
 }`
 
-const accessorsOneofPrimitiveTemplate = `// ${fieldName} returns the ${lowerFieldName} associated with this ${structName}.
+const accessorsOneOfMessageTemplate = `// ${fieldName} returns the ${lowerFieldName} associated with this ${structName}.
+// Calling this function when ${typeAccessor}() != ${typeName} will cause a panic.
+// Calling this function on zero-initialized ${structName} will cause a panic.
 func (ms ${structName}) ${fieldName}() ${returnType} {
-	return (*ms.orig).GetAs${fieldType}()
+	return new${returnType}((*ms.orig).${originOneOfFieldName}.(*${originStructType}).${originFieldName})
+}`
+
+const accessorsOneOfMessageTestTemplate = `func Test${structName}_${fieldName}(t *testing.T) {
+	ms := New${structName}()
+	ms.Set${typeAccessor}(${typeName})
+	fillTest${returnType}(ms.${fieldName}())
+	assert.EqualValues(t, generateTest${returnType}(), ms.${fieldName}())
+}`
+
+const copyToValueOneOfMessageTemplate = `	case ${typeName}:
+		dest.Set${typeAccessor}(${typeName})
+		ms.${fieldName}().CopyTo(dest.${fieldName}())
+`
+
+const accessorsOneOfPrimitiveTemplate = `// ${fieldName} returns the ${lowerFieldName} associated with this ${structName}.
+func (ms ${structName}) ${fieldName}() ${returnType} {
+	return (*ms.orig).Get${originFieldName}()
 }
 
 // Set${fieldName} replaces the ${lowerFieldName} associated with this ${structName}.
 func (ms ${structName}) Set${fieldName}(v ${returnType}) {
-	(*ms.orig).${originFieldName} = &${originFullName}_As${fieldType}{
-		As${fieldType}: v,
+	(*ms.orig).${originOneOfFieldName} = &${originStructType}{
+		${originFieldName}: v,
 	}
 }`
 
@@ -373,56 +392,78 @@ func (ptf *primitiveStructField) generateCopyToValue(sb *strings.Builder) {
 
 var _ baseField = (*primitiveStructField)(nil)
 
-// oneofField is used in case where the proto defines an "oneof".
-type oneofField struct {
-	copyFuncName    string
-	originFieldName string
-	testVal         string
-	fillTestName    string
+type oneOfField struct {
+	originTypePrefix string
+	originFieldName  string
+	// TODO: See if we can use a unified type accessor name.
+	// TODO: Generate type accessors.
+	typeAccessor string
+	typeName     string
+	testValueIdx int
+	values       []oneOfValue
 }
 
-func (one oneofField) generateAccessors(baseStruct, *strings.Builder) {}
-
-func (one oneofField) generateAccessorsTest(baseStruct, *strings.Builder) {}
-
-func (one oneofField) generateSetWithTestValue(sb *strings.Builder) {
-	sb.WriteString("\t(*tv.orig)." + one.originFieldName + " = " + one.testVal + "\n")
-	sb.WriteString("\tfillTest" + one.fillTestName + "(tv." + one.fillTestName + "())")
+func (of *oneOfField) generateAccessors(ms baseStruct, sb *strings.Builder) {
+	for _, v := range of.values {
+		v.generateAccessors(ms, of, sb)
+		sb.WriteString("\n")
+	}
 }
 
-func (one oneofField) generateCopyToValue(sb *strings.Builder) {
-	sb.WriteString("\t" + one.copyFuncName + "(ms.orig, dest.orig)")
+func (of *oneOfField) generateAccessorsTest(ms baseStruct, sb *strings.Builder) {
+	for _, v := range of.values {
+		v.generateAccessorsTest(ms.(*messageValueStruct), of, sb)
+		sb.WriteString("\n")
+	}
 }
 
-var _ baseField = (*oneofField)(nil)
+func (of *oneOfField) generateSetWithTestValue(sb *strings.Builder) {
+	of.values[of.testValueIdx].generateSetWithTestValue(of, sb)
+}
+
+func (of *oneOfField) generateCopyToValue(sb *strings.Builder) {
+	sb.WriteString("\tswitch ms." + of.typeAccessor + "() {\n")
+	for _, v := range of.values {
+		v.generateCopyToValue(of, sb)
+	}
+	sb.WriteString("\t}\n")
+}
+
+var _ baseField = (*oneOfField)(nil)
+
+type oneOfValue interface {
+	generateAccessors(ms baseStruct, of *oneOfField, sb *strings.Builder)
+	generateAccessorsTest(ms baseStruct, of *oneOfField, sb *strings.Builder)
+	generateSetWithTestValue(of *oneOfField, sb *strings.Builder)
+	generateCopyToValue(of *oneOfField, sb *strings.Builder)
+}
 
 type oneOfPrimitiveValue struct {
-	name            string
+	fieldName       string
+	fieldType       string
 	defaultVal      string
 	testVal         string
 	returnType      string
 	originFieldName string
-	originFullName  string
-	fieldType       string
 }
 
-func (opv *oneOfPrimitiveValue) generateAccessors(ms baseStruct, sb *strings.Builder) {
-	sb.WriteString(os.Expand(accessorsOneofPrimitiveTemplate, func(name string) string {
+func (opv *oneOfPrimitiveValue) generateAccessors(ms baseStruct, of *oneOfField, sb *strings.Builder) {
+	sb.WriteString(os.Expand(accessorsOneOfPrimitiveTemplate, func(name string) string {
 		switch name {
 		case "structName":
 			return ms.getName()
 		case "fieldName":
-			return opv.name
+			return opv.fieldName
 		case "lowerFieldName":
-			return strings.ToLower(opv.name)
+			return strings.ToLower(opv.fieldName)
 		case "returnType":
 			return opv.returnType
 		case "originFieldName":
 			return opv.originFieldName
-		case "originFullName":
-			return opv.originFullName
-		case "fieldType":
-			return opv.fieldType
+		case "originOneOfFieldName":
+			return of.originFieldName
+		case "originStructType":
+			return of.originTypePrefix + opv.originFieldName
 		default:
 			panic(name)
 		}
@@ -430,7 +471,7 @@ func (opv *oneOfPrimitiveValue) generateAccessors(ms baseStruct, sb *strings.Bui
 	sb.WriteString("\n")
 }
 
-func (opv *oneOfPrimitiveValue) generateAccessorsTest(ms baseStruct, sb *strings.Builder) {
+func (opv *oneOfPrimitiveValue) generateAccessorsTest(ms baseStruct, of *oneOfField, sb *strings.Builder) {
 	sb.WriteString(os.Expand(accessorsPrimitiveTestTemplate, func(name string) string {
 		switch name {
 		case "structName":
@@ -438,7 +479,7 @@ func (opv *oneOfPrimitiveValue) generateAccessorsTest(ms baseStruct, sb *strings
 		case "defaultVal":
 			return opv.defaultVal
 		case "fieldName":
-			return opv.name
+			return opv.fieldName
 		case "testValue":
 			return opv.testVal
 		default:
@@ -448,48 +489,91 @@ func (opv *oneOfPrimitiveValue) generateAccessorsTest(ms baseStruct, sb *strings
 	sb.WriteString("\n")
 }
 
-func (opv *oneOfPrimitiveValue) generateSetWithTestValue(sb *strings.Builder) {
-	sb.WriteString("\t tv.Set" + opv.name + "(" + opv.testVal + ")\n")
+func (opv *oneOfPrimitiveValue) generateSetWithTestValue(_ *oneOfField, sb *strings.Builder) {
+	sb.WriteString("\t tv.Set" + opv.fieldName + "(" + opv.testVal + ")")
 }
 
-func (opv *oneOfPrimitiveValue) generateCopyToValue(sb *strings.Builder) {
-	sb.WriteString("\tcase MetricValueType" + opv.fieldType + ":\n")
-	sb.WriteString("\t dest.Set" + opv.name + "(ms." + opv.name + "())\n")
+func (opv *oneOfPrimitiveValue) generateCopyToValue(of *oneOfField, sb *strings.Builder) {
+	sb.WriteString("\tcase " + of.typeName + opv.fieldType + ":\n")
+	sb.WriteString("\t dest.Set" + opv.fieldName + "(ms." + opv.fieldName + "())\n")
 }
 
-var _ baseField = (*oneOfPrimitiveValue)(nil)
+var _ oneOfValue = (*oneOfPrimitiveValue)(nil)
 
-type numberField struct {
-	fields []*oneOfPrimitiveValue
+type oneOfMessageValue struct {
+	fieldName       string
+	fieldType       string
+	originFieldName string
+	originFieldType string
+	returnMessage   *messageValueStruct
 }
 
-func (nf *numberField) generateAccessors(ms baseStruct, sb *strings.Builder) {
-	for _, field := range nf.fields {
-		field.generateAccessors(ms, sb)
-	}
+func (omv *oneOfMessageValue) generateAccessors(ms baseStruct, of *oneOfField, sb *strings.Builder) {
+	sb.WriteString(os.Expand(accessorsOneOfMessageTemplate, func(name string) string {
+		switch name {
+		case "fieldName":
+			return omv.fieldName
+		case "lowerFieldName":
+			return strings.ToLower(omv.fieldName)
+		case "originFieldName":
+			return omv.originFieldName
+		case "originOneOfFieldName":
+			return of.originFieldName
+		case "originStructType":
+			return of.originTypePrefix + omv.originFieldName
+		case "returnType":
+			return omv.returnMessage.structName
+		case "structName":
+			return ms.getName()
+		case "typeAccessor":
+			return of.typeAccessor
+		case "typeName":
+			return of.typeName + omv.fieldType
+		default:
+			panic(name)
+		}
+	}))
+	sb.WriteString("\n")
 }
 
-func (nf *numberField) generateAccessorsTest(ms baseStruct, sb *strings.Builder) {
-	for _, field := range nf.fields {
-		field.generateAccessorsTest(ms, sb)
-	}
+func (omv *oneOfMessageValue) generateAccessorsTest(ms baseStruct, of *oneOfField, sb *strings.Builder) {
+	sb.WriteString(os.Expand(accessorsOneOfMessageTestTemplate, func(name string) string {
+		switch name {
+		case "structName":
+			return ms.getName()
+		case "fieldName":
+			return omv.fieldName
+		case "returnType":
+			return omv.returnMessage.structName
+		case "typeAccessor":
+			return of.typeAccessor
+		case "typeName":
+			return of.typeName + omv.fieldName
+		default:
+			panic(name)
+		}
+	}))
+	sb.WriteString("\n")
 }
 
-func (nf *numberField) generateSetWithTestValue(sb *strings.Builder) {
-	for _, field := range nf.fields {
-		field.generateSetWithTestValue(sb)
-		// TODO: this test should be generated for all number values,
-		//       for now, it's ok to only set one value
-		return
-	}
+func (omv *oneOfMessageValue) generateSetWithTestValue(of *oneOfField, sb *strings.Builder) {
+	sb.WriteString("tv.Set" + of.typeAccessor + "(" + of.typeName + omv.fieldType + ")\n")
+	sb.WriteString("fillTest" + omv.returnMessage.structName + "(tv." + omv.fieldName + "())")
 }
 
-func (nf *numberField) generateCopyToValue(sb *strings.Builder) {
-	sb.WriteString("\tswitch ms.Type() {\n")
-	for _, field := range nf.fields {
-		field.generateCopyToValue(sb)
-	}
-	sb.WriteString("\t}\n")
+func (omv *oneOfMessageValue) generateCopyToValue(of *oneOfField, sb *strings.Builder) {
+	sb.WriteString(os.Expand(copyToValueOneOfMessageTemplate, func(name string) string {
+		switch name {
+		case "fieldName":
+			return omv.fieldName
+		case "typeAccessor":
+			return of.typeAccessor
+		case "typeName":
+			return of.typeName + omv.fieldName
+		default:
+			panic(name)
+		}
+	}))
 }
 
-var _ baseField = (*numberField)(nil)
+var _ oneOfValue = (*oneOfMessageValue)(nil)

--- a/model/internal/cmd/pdatagen/internal/metrics_structs.go
+++ b/model/internal/cmd/pdatagen/internal/metrics_structs.go
@@ -122,7 +122,50 @@ var metric = &messageValueStruct{
 			defaultVal:      `""`,
 			testVal:         `"1"`,
 		},
-		oneofDataField,
+		&oneOfField{
+			typeAccessor:     "DataType",
+			typeName:         "MetricDataType",
+			originFieldName:  "Data",
+			originTypePrefix: "otlpmetrics.Metric_",
+			testValueIdx:     1, // Sum
+			values: []oneOfValue{
+				&oneOfMessageValue{
+					fieldName:       "Gauge",
+					fieldType:       "Gauge",
+					originFieldName: "Gauge",
+					originFieldType: "otlpmetrics.Gauge",
+					returnMessage:   doubleGauge,
+				},
+				&oneOfMessageValue{
+					fieldName:       "Sum",
+					fieldType:       "Sum",
+					originFieldName: "Sum",
+					originFieldType: "otlpmetrics.Sum",
+					returnMessage:   doubleSum,
+				},
+				&oneOfMessageValue{
+					fieldName:       "Histogram",
+					fieldType:       "Histogram",
+					originFieldName: "Histogram",
+					originFieldType: "otlpmetrics.Histogram",
+					returnMessage:   histogram,
+				},
+				&oneOfMessageValue{
+					fieldName:       "ExponentialHistogram",
+					fieldType:       "ExponentialHistogram",
+					originFieldName: "ExponentialHistogram",
+					originFieldType: "otlpmetrics.ExponentialHistogram",
+					returnMessage:   exponentialHistogram,
+				},
+				&oneOfMessageValue{
+					fieldName:       "Summary",
+					fieldType:       "Summary",
+					originFieldName: "Summary",
+					originFieldType: "otlpmetrics.Summary",
+					returnMessage:   summary,
+				},
+			},
+		},
 	},
 }
 
@@ -209,25 +252,28 @@ var numberDataPoint = &messageValueStruct{
 		attributes,
 		startTimeField,
 		timeField,
-		&numberField{
-			fields: []*oneOfPrimitiveValue{
-				{
-					originFullName:  "otlpmetrics.NumberDataPoint",
-					name:            "DoubleVal",
-					originFieldName: "Value",
+		&oneOfField{
+			typeAccessor:     "Type",
+			typeName:         "MetricValueType",
+			originFieldName:  "Value",
+			originTypePrefix: "otlpmetrics.NumberDataPoint_",
+			testValueIdx:     0, // Double
+			values: []oneOfValue{
+				&oneOfPrimitiveValue{
+					fieldName:       "DoubleVal",
+					fieldType:       "Double",
+					originFieldName: "AsDouble",
 					returnType:      "float64",
 					defaultVal:      "float64(0.0)",
 					testVal:         "float64(17.13)",
-					fieldType:       "Double",
 				},
-				{
-					originFullName:  "otlpmetrics.NumberDataPoint",
-					name:            "IntVal",
-					originFieldName: "Value",
+				&oneOfPrimitiveValue{
+					fieldName:       "IntVal",
+					fieldType:       "Int",
+					originFieldName: "AsInt",
 					returnType:      "int64",
 					defaultVal:      "int64(0)",
 					testVal:         "int64(17)",
-					fieldType:       "Int",
 				},
 			},
 		},
@@ -377,21 +423,24 @@ var exemplar = &messageValueStruct{
 	originFullName: "otlpmetrics.Exemplar",
 	fields: []baseField{
 		timeField,
-		&numberField{
-			fields: []*oneOfPrimitiveValue{
-				{
-					originFullName:  "otlpmetrics.Exemplar",
-					name:            "DoubleVal",
-					originFieldName: "Value",
+		&oneOfField{
+			typeAccessor:     "Type",
+			typeName:         "MetricValueType",
+			originFieldName:  "Value",
+			originTypePrefix: "otlpmetrics.Exemplar_",
+			testValueIdx:     1, // Int
+			values: []oneOfValue{
+				&oneOfPrimitiveValue{
+					fieldName:       "DoubleVal",
+					originFieldName: "AsDouble",
 					returnType:      "float64",
 					defaultVal:      "float64(0.0)",
 					testVal:         "float64(17.13)",
 					fieldType:       "Double",
 				},
-				{
-					originFullName:  "otlpmetrics.Exemplar",
-					name:            "IntVal",
-					originFieldName: "Value",
+				&oneOfPrimitiveValue{
+					fieldName:       "IntVal",
+					originFieldName: "AsInt",
 					returnType:      "int64",
 					defaultVal:      "int64(0)",
 					testVal:         "int64(17)",
@@ -478,13 +527,6 @@ var aggregationTemporalityField = &primitiveTypedField{
 	rawType:         "otlpmetrics.AggregationTemporality",
 	defaultVal:      "MetricAggregationTemporalityUnspecified",
 	testVal:         "MetricAggregationTemporalityCumulative",
-}
-
-var oneofDataField = &oneofField{
-	copyFuncName:    "copyData",
-	originFieldName: "Data",
-	testVal:         "&otlpmetrics.Metric_Gauge{Gauge: &otlpmetrics.Gauge{}}",
-	fillTestName:    "Gauge",
 }
 
 var dataPointFlagsField = &primitiveTypedField{

--- a/model/pdata/generated_metrics.go
+++ b/model/pdata/generated_metrics.go
@@ -612,12 +612,64 @@ func (ms Metric) SetUnit(v string) {
 	(*ms.orig).Unit = v
 }
 
+// Gauge returns the gauge associated with this Metric.
+// Calling this function when DataType() != MetricDataTypeGauge will cause a panic.
+// Calling this function on zero-initialized Metric will cause a panic.
+func (ms Metric) Gauge() Gauge {
+	return newGauge((*ms.orig).Data.(*otlpmetrics.Metric_Gauge).Gauge)
+}
+
+// Sum returns the sum associated with this Metric.
+// Calling this function when DataType() != MetricDataTypeSum will cause a panic.
+// Calling this function on zero-initialized Metric will cause a panic.
+func (ms Metric) Sum() Sum {
+	return newSum((*ms.orig).Data.(*otlpmetrics.Metric_Sum).Sum)
+}
+
+// Histogram returns the histogram associated with this Metric.
+// Calling this function when DataType() != MetricDataTypeHistogram will cause a panic.
+// Calling this function on zero-initialized Metric will cause a panic.
+func (ms Metric) Histogram() Histogram {
+	return newHistogram((*ms.orig).Data.(*otlpmetrics.Metric_Histogram).Histogram)
+}
+
+// ExponentialHistogram returns the exponentialhistogram associated with this Metric.
+// Calling this function when DataType() != MetricDataTypeExponentialHistogram will cause a panic.
+// Calling this function on zero-initialized Metric will cause a panic.
+func (ms Metric) ExponentialHistogram() ExponentialHistogram {
+	return newExponentialHistogram((*ms.orig).Data.(*otlpmetrics.Metric_ExponentialHistogram).ExponentialHistogram)
+}
+
+// Summary returns the summary associated with this Metric.
+// Calling this function when DataType() != MetricDataTypeSummary will cause a panic.
+// Calling this function on zero-initialized Metric will cause a panic.
+func (ms Metric) Summary() Summary {
+	return newSummary((*ms.orig).Data.(*otlpmetrics.Metric_Summary).Summary)
+}
+
 // CopyTo copies all properties from the current struct to the dest.
 func (ms Metric) CopyTo(dest Metric) {
 	dest.SetName(ms.Name())
 	dest.SetDescription(ms.Description())
 	dest.SetUnit(ms.Unit())
-	copyData(ms.orig, dest.orig)
+	switch ms.DataType() {
+	case MetricDataTypeGauge:
+		dest.SetDataType(MetricDataTypeGauge)
+		ms.Gauge().CopyTo(dest.Gauge())
+	case MetricDataTypeSum:
+		dest.SetDataType(MetricDataTypeSum)
+		ms.Sum().CopyTo(dest.Sum())
+	case MetricDataTypeHistogram:
+		dest.SetDataType(MetricDataTypeHistogram)
+		ms.Histogram().CopyTo(dest.Histogram())
+	case MetricDataTypeExponentialHistogram:
+		dest.SetDataType(MetricDataTypeExponentialHistogram)
+		ms.ExponentialHistogram().CopyTo(dest.ExponentialHistogram())
+	case MetricDataTypeSummary:
+		dest.SetDataType(MetricDataTypeSummary)
+		ms.Summary().CopyTo(dest.Summary())
+	}
+
 }
 
 // Gauge represents the type of a double scalar metric that always exports the "current value" for every data point.

--- a/model/pdata/generated_metrics_test.go
+++ b/model/pdata/generated_metrics_test.go
@@ -465,6 +465,41 @@ func TestMetric_Unit(t *testing.T) {
 	assert.EqualValues(t, testValUnit, ms.Unit())
 }
 
+func TestMetric_Gauge(t *testing.T) {
+	ms := NewMetric()
+	ms.SetDataType(MetricDataTypeGauge)
+	fillTestGauge(ms.Gauge())
+	assert.EqualValues(t, generateTestGauge(), ms.Gauge())
+}
+
+func TestMetric_Sum(t *testing.T) {
+	ms := NewMetric()
+	ms.SetDataType(MetricDataTypeSum)
+	fillTestSum(ms.Sum())
+	assert.EqualValues(t, generateTestSum(), ms.Sum())
+}
+
+func TestMetric_Histogram(t *testing.T) {
+	ms := NewMetric()
+	ms.SetDataType(MetricDataTypeHistogram)
+	fillTestHistogram(ms.Histogram())
+	assert.EqualValues(t, generateTestHistogram(), ms.Histogram())
+}
+
+func TestMetric_ExponentialHistogram(t *testing.T) {
+	ms := NewMetric()
+	ms.SetDataType(MetricDataTypeExponentialHistogram)
+	fillTestExponentialHistogram(ms.ExponentialHistogram())
+	assert.EqualValues(t, generateTestExponentialHistogram(), ms.ExponentialHistogram())
+}
+
+func TestMetric_Summary(t *testing.T) {
+	ms := NewMetric()
+	ms.SetDataType(MetricDataTypeSummary)
+	fillTestSummary(ms.Summary())
+	assert.EqualValues(t, generateTestSummary(), ms.Summary())
+}
+
 func TestGauge_MoveTo(t *testing.T) {
 	ms := generateTestGauge()
 	dest := NewGauge()
@@ -762,6 +797,7 @@ func TestNumberDataPoint_DoubleVal(t *testing.T) {
 	ms.SetDoubleVal(testValDoubleVal)
 	assert.EqualValues(t, testValDoubleVal, ms.DoubleVal())
 }
+
 func TestNumberDataPoint_IntVal(t *testing.T) {
 	ms := NewNumberDataPoint()
 	assert.EqualValues(t, int64(0), ms.IntVal())
@@ -1670,6 +1706,7 @@ func TestExemplar_DoubleVal(t *testing.T) {
 	ms.SetDoubleVal(testValDoubleVal)
 	assert.EqualValues(t, testValDoubleVal, ms.DoubleVal())
 }
+
 func TestExemplar_IntVal(t *testing.T) {
 	ms := NewExemplar()
 	assert.EqualValues(t, int64(0), ms.IntVal())
@@ -1778,8 +1815,8 @@ func fillTestMetric(tv Metric) {
 	tv.SetName("test_name")
 	tv.SetDescription("test_description")
 	tv.SetUnit("1")
-	(*tv.orig).Data = &otlpmetrics.Metric_Gauge{Gauge: &otlpmetrics.Gauge{}}
-	fillTestGauge(tv.Gauge())
+	tv.SetDataType(MetricDataTypeSum)
+	fillTestSum(tv.Sum())
 }
 
 func generateTestGauge() Gauge {
@@ -1861,7 +1898,6 @@ func fillTestNumberDataPoint(tv NumberDataPoint) {
 	tv.SetStartTimestamp(Timestamp(1234567890))
 	tv.SetTimestamp(Timestamp(1234567890))
 	tv.SetDoubleVal(float64(17.13))
-
 	fillTestExemplarSlice(tv.Exemplars())
 	tv.SetFlags(MetricDataPointFlagsNone)
 }
@@ -2020,8 +2056,7 @@ func generateTestExemplar() Exemplar {
 
 func fillTestExemplar(tv Exemplar) {
 	tv.SetTimestamp(Timestamp(1234567890))
-	tv.SetDoubleVal(float64(17.13))
-
+	tv.SetIntVal(int64(17))
 	fillTestAttributeMap(tv.FilteredAttributes())
 	tv.SetTraceID(NewTraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 8, 7, 6, 5, 4, 3, 2, 1}))
 	tv.SetSpanID(NewSpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8}))

--- a/model/pdata/metrics.go
+++ b/model/pdata/metrics.go
@@ -188,66 +188,6 @@ func (ms Metric) SetDataType(ty MetricDataType) {
 	}
 }
 
-// Gauge returns the data as Gauge.
-// Calling this function when DataType() != MetricDataTypeGauge will cause a panic.
-// Calling this function on zero-initialized Metric will cause a panic.
-func (ms Metric) Gauge() Gauge {
-	return newGauge(ms.orig.Data.(*otlpmetrics.Metric_Gauge).Gauge)
-}
-
-// Sum returns the data as Sum.
-// Calling this function when DataType() != MetricDataTypeSum will cause a panic.
-// Calling this function on zero-initialized Metric will cause a panic.
-func (ms Metric) Sum() Sum {
-	return newSum(ms.orig.Data.(*otlpmetrics.Metric_Sum).Sum)
-}
-
-// Histogram returns the data as Histogram.
-// Calling this function when DataType() != MetricDataTypeHistogram will cause a panic.
-// Calling this function on zero-initialized Metric will cause a panic.
-func (ms Metric) Histogram() Histogram {
-	return newHistogram(ms.orig.Data.(*otlpmetrics.Metric_Histogram).Histogram)
-}
-
-// ExponentialHistogram returns the data as ExponentialHistogram.
-// Calling this function when DataType() != MetricDataTypeExponentialHistogram will cause a panic.
-// Calling this function on zero-initialized Metric will cause a panic.
-func (ms Metric) ExponentialHistogram() ExponentialHistogram {
-	return newExponentialHistogram(ms.orig.Data.(*otlpmetrics.Metric_ExponentialHistogram).ExponentialHistogram)
-}
-
-// Summary returns the data as Summary.
-// Calling this function when DataType() != MetricDataTypeSummary will cause a panic.
-// Calling this function on zero-initialized Metric will cause a panic.
-func (ms Metric) Summary() Summary {
-	return newSummary(ms.orig.Data.(*otlpmetrics.Metric_Summary).Summary)
-}
-
-func copyData(src, dest *otlpmetrics.Metric) {
-	switch srcData := (src).Data.(type) {
-	case *otlpmetrics.Metric_Gauge:
-		data := &otlpmetrics.Metric_Gauge{Gauge: &otlpmetrics.Gauge{}}
-		newGauge(srcData.Gauge).CopyTo(newGauge(data.Gauge))
-		dest.Data = data
-	case *otlpmetrics.Metric_Sum:
-		data := &otlpmetrics.Metric_Sum{Sum: &otlpmetrics.Sum{}}
-		newSum(srcData.Sum).CopyTo(newSum(data.Sum))
-		dest.Data = data
-	case *otlpmetrics.Metric_Histogram:
-		data := &otlpmetrics.Metric_Histogram{Histogram: &otlpmetrics.Histogram{}}
-		newHistogram(srcData.Histogram).CopyTo(newHistogram(data.Histogram))
-		dest.Data = data
-	case *otlpmetrics.Metric_ExponentialHistogram:
-		data := &otlpmetrics.Metric_ExponentialHistogram{ExponentialHistogram: &otlpmetrics.ExponentialHistogram{}}
-		newExponentialHistogram(srcData.ExponentialHistogram).CopyTo(newExponentialHistogram(data.ExponentialHistogram))
-		dest.Data = data
-	case *otlpmetrics.Metric_Summary:
-		data := &otlpmetrics.Metric_Summary{Summary: &otlpmetrics.Summary{}}
-		newSummary(srcData.Summary).CopyTo(newSummary(data.Summary))
-		dest.Data = data
-	}
-}
-
 // MetricAggregationTemporality defines how a metric aggregator reports aggregated values.
 // It describes how those values relate to the time interval over which they are aggregated.
 type MetricAggregationTemporality int32

--- a/model/pdata/metrics_test.go
+++ b/model/pdata/metrics_test.go
@@ -33,64 +33,6 @@ const (
 	endTime   = uint64(12578940000000054321)
 )
 
-func TestCopyData(t *testing.T) {
-	tests := []struct {
-		name string
-		src  *otlpmetrics.Metric
-	}{
-		{
-			name: "Gauge",
-			src: &otlpmetrics.Metric{
-				Data: &otlpmetrics.Metric_Gauge{
-					Gauge: &otlpmetrics.Gauge{},
-				},
-			},
-		},
-		{
-			name: "Sum",
-			src: &otlpmetrics.Metric{
-				Data: &otlpmetrics.Metric_Sum{
-					Sum: &otlpmetrics.Sum{},
-				},
-			},
-		},
-		{
-			name: "Histogram",
-			src: &otlpmetrics.Metric{
-				Data: &otlpmetrics.Metric_Histogram{
-					Histogram: &otlpmetrics.Histogram{},
-				},
-			},
-		},
-		{
-			name: "ExponentialHistogram",
-			src: &otlpmetrics.Metric{
-				Data: &otlpmetrics.Metric_ExponentialHistogram{
-					ExponentialHistogram: &otlpmetrics.ExponentialHistogram{},
-				},
-			},
-		},
-		{
-			name: "Summary",
-			src: &otlpmetrics.Metric{
-				Data: &otlpmetrics.Metric_Summary{
-					Summary: &otlpmetrics.Summary{},
-				},
-			},
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			dest := &otlpmetrics.Metric{}
-			assert.Nil(t, dest.Data)
-			assert.NotNil(t, test.src.Data)
-			copyData(test.src, dest)
-			assert.EqualValues(t, test.src, dest)
-		})
-	}
-}
-
 func TestMetricDataTypeString(t *testing.T) {
 	assert.Equal(t, "None", MetricDataTypeNone.String())
 	assert.Equal(t, "Gauge", MetricDataTypeGauge.String())


### PR DESCRIPTION
Define new pdatagen field `oneOfField` to represent `oneof` proto field. Migrate hardcoded Metric Data related functions and pdatagen numberField to use the new pdatagen field.

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector/issues/4704