### PR TITLE
[pdatagen] Remove redundant switch case in messageValueField.generateAccessors

### DIFF
--- a/model/internal/cmd/pdatagen/internal/base_fields.go
+++ b/model/internal/cmd/pdatagen/internal/base_fields.go
@@ -168,8 +168,6 @@ func (mf *messageValueField) generateAccessors(ms baseStruct, sb *strings.Builde
 			return strings.ToLower(mf.fieldName)
 		case "returnType":
 			return mf.returnMessage.structName
-		case "structOriginFullName":
-			return mf.returnMessage.originFullName
 		case "originFieldName":
 			return mf.originFieldName
 		default:


### PR DESCRIPTION
The env var `structOriginFullName` is not used in `accessorsMessageValueTemplate`, removing the redundant switch case.