### PR TITLE
Update confighttp readme

### DIFF
--- a/config/confighttp/README.md
+++ b/config/confighttp/README.md
@@ -77,14 +77,14 @@ Example:
 ```yaml
 receivers:
   otlp:
-    cors:
-      allowed_origins:
-        - https://foo.bar.com
-        - https://*.test.com
-      allowed_headers:
-        - Example-Header
-      max_age: 7200
-    endpoint: 0.0.0.0:55690
     protocols:
       http:
+        cors:
+          allowed_origins:
+            - https://foo.bar.com
+            - https://*.test.com
+          allowed_headers:
+            - Example-Header
+          max_age: 7200
+        endpoint: 0.0.0.0:55690
 ```


### PR DESCRIPTION
Update confighttp readme to reflect correct placement of the cors and endpoint configuration

The example provided in confighttp resulted in configuration errors. The example has now been updated to reflect the documentation provided at [otlpreceiver / confighttp / HTTPServerSettings](https://github.com/open-telemetry/opentelemetry-collector/blob/main/receiver/otlpreceiver/config.md#confighttp-HTTPServerSettings)