### PR TITLE
Deprecate NewWindowsService, add NewSvcHandler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,7 @@
   in 0.11.0 are no longer converted to the messages and fields that replaced the deprecated ones.
   Received deprecated messages and fields will be now ignored. In OTLP/JSON in the
   instrumentationLibraryLogs object the "logs" field is now named "logRecords" (#4724)
+- Deprecate `service.NewWindowsService`, add `service.NewSvcHandler` (#4783).
 
 ### 🚩 Deprecations 🚩
 

--- a/cmd/builder/internal/builder/templates/main_windows.go.tmpl
+++ b/cmd/builder/internal/builder/templates/main_windows.go.tmpl
@@ -42,7 +42,7 @@ func checkUseInteractiveMode() (bool, error) {
 
 func runService(params service.CollectorSettings) error {
 	// do not need to supply service name when startup is invoked through Service Control Manager directly
-	if err := svc.Run("", service.NewWindowsService(params)); err != nil {
+	if err := svc.Run("", service.NewSvcHandler(params)); err != nil {
 		return fmt.Errorf("failed to start collector server: %w", err)
 	}
 

--- a/cmd/otelcorecol/main_windows.go
+++ b/cmd/otelcorecol/main_windows.go
@@ -42,7 +42,7 @@ func checkUseInteractiveMode() (bool, error) {
 
 func runService(params service.CollectorSettings) error {
 	// do not need to supply service name when startup is invoked through Service Control Manager directly
-	if err := svc.Run("", service.NewWindowsService(params)); err != nil {
+	if err := svc.Run("", service.NewSvcHandler(params)); err != nil {
 		return fmt.Errorf("failed to start collector server: %w", err)
 	}
 

--- a/service/collector_windows.go
+++ b/service/collector_windows.go
@@ -30,12 +30,19 @@ import (
 	"golang.org/x/sys/windows/svc/eventlog"
 )
 
+// Deprecated: [v0.48.0] will be made private soon.
 type WindowsService struct {
 	settings CollectorSettings
 	col      *Collector
 }
 
+// Deprecated: [v0.48.0] use NewSvcHandler.
 func NewWindowsService(set CollectorSettings) *WindowsService {
+	return &WindowsService{settings: set}
+}
+
+// NewSvcHandler constructs a new svc.Handler using the given CollectorSettings.
+func NewSvcHandler(set CollectorSettings) svc.Handler {
 	return &WindowsService{settings: set}
 }
 

--- a/service/collector_windows_test.go
+++ b/service/collector_windows_test.go
@@ -30,13 +30,13 @@ import (
 	"go.opentelemetry.io/collector/internal/testcomponents"
 )
 
-func TestWindowsService_Execute(t *testing.T) {
+func TestNewSvcHandler(t *testing.T) {
 	os.Args = []string{"otelcol", "--config", filepath.Join("testdata", "otelcol-config.yaml")}
 
 	factories, err := testcomponents.NewDefaultFactories()
 	require.NoError(t, err)
 
-	s := NewWindowsService(CollectorSettings{BuildInfo: component.NewDefaultBuildInfo(), Factories: factories})
+	s := NewSvcHandler(CollectorSettings{BuildInfo: component.NewDefaultBuildInfo(), Factories: factories})
 
 	colDone := make(chan struct{})
 	requests := make(chan svc.ChangeRequest)


### PR DESCRIPTION
Currently the WindowsService type in the service package is unnecessary public, and always used as a svc.Handler.

Avoid exposing this public type by returning an `svc.Handler` instead.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>