### PR TITLE
[pdatagen] Remove deprecated field from messageValueStruct

### DIFF
--- a/model/internal/cmd/pdatagen/internal/base_structs.go
+++ b/model/internal/cmd/pdatagen/internal/base_structs.go
@@ -26,7 +26,6 @@ const messageValueTemplate = `${description}
 //
 // Must use New${structName} function to create new instances.
 // Important: zero-initialized instance is not valid for use.
-// ${deprecated}
 type ${structName} struct {
 	orig *${originName}
 }
@@ -95,7 +94,6 @@ type messageValueStruct struct {
 	structName     string
 	description    string
 	originFullName string
-	deprecated     string
 	fields         []baseField
 }
 
@@ -112,8 +110,6 @@ func (ms *messageValueStruct) generateStruct(sb *strings.Builder) {
 			return ms.originFullName
 		case "description":
 			return ms.description
-		case "deprecated":
-			return ms.deprecated
 		default:
 			panic(name)
 		}

--- a/model/pdata/generated_common.go
+++ b/model/pdata/generated_common.go
@@ -28,7 +28,6 @@ import (
 //
 // Must use NewInstrumentationLibrary function to create new instances.
 // Important: zero-initialized instance is not valid for use.
-//
 type InstrumentationLibrary struct {
 	orig *otlpcommon.InstrumentationLibrary
 }

--- a/model/pdata/generated_log.go
+++ b/model/pdata/generated_log.go
@@ -167,7 +167,6 @@ func (es ResourceLogsSlice) RemoveIf(f func(ResourceLogs) bool) {
 //
 // Must use NewResourceLogs function to create new instances.
 // Important: zero-initialized instance is not valid for use.
-//
 type ResourceLogs struct {
 	orig *otlplogs.ResourceLogs
 }
@@ -362,7 +361,6 @@ func (es InstrumentationLibraryLogsSlice) RemoveIf(f func(InstrumentationLibrary
 //
 // Must use NewInstrumentationLibraryLogs function to create new instances.
 // Important: zero-initialized instance is not valid for use.
-//
 type InstrumentationLibraryLogs struct {
 	orig *otlplogs.InstrumentationLibraryLogs
 }
@@ -558,7 +556,6 @@ func (es LogRecordSlice) RemoveIf(f func(LogRecord) bool) {
 //
 // Must use NewLogRecord function to create new instances.
 // Important: zero-initialized instance is not valid for use.
-//
 type LogRecord struct {
 	orig *otlplogs.LogRecord
 }

--- a/model/pdata/generated_metrics.go
+++ b/model/pdata/generated_metrics.go
@@ -167,7 +167,6 @@ func (es ResourceMetricsSlice) RemoveIf(f func(ResourceMetrics) bool) {
 //
 // Must use NewResourceMetrics function to create new instances.
 // Important: zero-initialized instance is not valid for use.
-//
 type ResourceMetrics struct {
 	orig *otlpmetrics.ResourceMetrics
 }
@@ -362,7 +361,6 @@ func (es InstrumentationLibraryMetricsSlice) RemoveIf(f func(InstrumentationLibr
 //
 // Must use NewInstrumentationLibraryMetrics function to create new instances.
 // Important: zero-initialized instance is not valid for use.
-//
 type InstrumentationLibraryMetrics struct {
 	orig *otlpmetrics.InstrumentationLibraryMetrics
 }
@@ -558,7 +556,6 @@ func (es MetricSlice) RemoveIf(f func(Metric) bool) {
 //
 // Must use NewMetric function to create new instances.
 // Important: zero-initialized instance is not valid for use.
-//
 type Metric struct {
 	orig *otlpmetrics.Metric
 }
@@ -679,7 +676,6 @@ func (ms Metric) CopyTo(dest Metric) {
 //
 // Must use NewGauge function to create new instances.
 // Important: zero-initialized instance is not valid for use.
-//
 type Gauge struct {
 	orig *otlpmetrics.Gauge
 }
@@ -720,7 +716,6 @@ func (ms Gauge) CopyTo(dest Gauge) {
 //
 // Must use NewSum function to create new instances.
 // Important: zero-initialized instance is not valid for use.
-//
 type Sum struct {
 	orig *otlpmetrics.Sum
 }
@@ -783,7 +778,6 @@ func (ms Sum) CopyTo(dest Sum) {
 //
 // Must use NewHistogram function to create new instances.
 // Important: zero-initialized instance is not valid for use.
-//
 type Histogram struct {
 	orig *otlpmetrics.Histogram
 }
@@ -836,7 +830,6 @@ func (ms Histogram) CopyTo(dest Histogram) {
 //
 // Must use NewExponentialHistogram function to create new instances.
 // Important: zero-initialized instance is not valid for use.
-//
 type ExponentialHistogram struct {
 	orig *otlpmetrics.ExponentialHistogram
 }
@@ -888,7 +881,6 @@ func (ms ExponentialHistogram) CopyTo(dest ExponentialHistogram) {
 //
 // Must use NewSummary function to create new instances.
 // Important: zero-initialized instance is not valid for use.
-//
 type Summary struct {
 	orig *otlpmetrics.Summary
 }
@@ -1066,7 +1058,6 @@ func (es NumberDataPointSlice) RemoveIf(f func(NumberDataPoint) bool) {
 //
 // Must use NewNumberDataPoint function to create new instances.
 // Important: zero-initialized instance is not valid for use.
-//
 type NumberDataPoint struct {
 	orig *otlpmetrics.NumberDataPoint
 }
@@ -1314,7 +1305,6 @@ func (es HistogramDataPointSlice) RemoveIf(f func(HistogramDataPoint) bool) {
 //
 // Must use NewHistogramDataPoint function to create new instances.
 // Important: zero-initialized instance is not valid for use.
-//
 type HistogramDataPoint struct {
 	orig *otlpmetrics.HistogramDataPoint
 }
@@ -1578,7 +1568,6 @@ func (es ExponentialHistogramDataPointSlice) RemoveIf(f func(ExponentialHistogra
 //
 // Must use NewExponentialHistogramDataPoint function to create new instances.
 // Important: zero-initialized instance is not valid for use.
-//
 type ExponentialHistogramDataPoint struct {
 	orig *otlpmetrics.ExponentialHistogramDataPoint
 }
@@ -1714,7 +1703,6 @@ func (ms ExponentialHistogramDataPoint) CopyTo(dest ExponentialHistogramDataPoin
 //
 // Must use NewBuckets function to create new instances.
 // Important: zero-initialized instance is not valid for use.
-//
 type Buckets struct {
 	orig *otlpmetrics.ExponentialHistogramDataPoint_Buckets
 }
@@ -1908,7 +1896,6 @@ func (es SummaryDataPointSlice) RemoveIf(f func(SummaryDataPoint) bool) {
 //
 // Must use NewSummaryDataPoint function to create new instances.
 // Important: zero-initialized instance is not valid for use.
-//
 type SummaryDataPoint struct {
 	orig *otlpmetrics.SummaryDataPoint
 }
@@ -2147,7 +2134,6 @@ func (es ValueAtQuantileSlice) RemoveIf(f func(ValueAtQuantile) bool) {
 //
 // Must use NewValueAtQuantile function to create new instances.
 // Important: zero-initialized instance is not valid for use.
-//
 type ValueAtQuantile struct {
 	orig *otlpmetrics.SummaryDataPoint_ValueAtQuantile
 }
@@ -2325,7 +2311,6 @@ func (es ExemplarSlice) RemoveIf(f func(Exemplar) bool) {
 //
 // Must use NewExemplar function to create new instances.
 // Important: zero-initialized instance is not valid for use.
-//
 type Exemplar struct {
 	orig *otlpmetrics.Exemplar
 }

--- a/model/pdata/generated_resource.go
+++ b/model/pdata/generated_resource.go
@@ -28,7 +28,6 @@ import (
 //
 // Must use NewResource function to create new instances.
 // Important: zero-initialized instance is not valid for use.
-//
 type Resource struct {
 	orig *otlpresource.Resource
 }

--- a/model/pdata/generated_trace.go
+++ b/model/pdata/generated_trace.go
@@ -167,7 +167,6 @@ func (es ResourceSpansSlice) RemoveIf(f func(ResourceSpans) bool) {
 //
 // Must use NewResourceSpans function to create new instances.
 // Important: zero-initialized instance is not valid for use.
-//
 type ResourceSpans struct {
 	orig *otlptrace.ResourceSpans
 }
@@ -362,7 +361,6 @@ func (es InstrumentationLibrarySpansSlice) RemoveIf(f func(InstrumentationLibrar
 //
 // Must use NewInstrumentationLibrarySpans function to create new instances.
 // Important: zero-initialized instance is not valid for use.
-//
 type InstrumentationLibrarySpans struct {
 	orig *otlptrace.InstrumentationLibrarySpans
 }
@@ -558,7 +556,6 @@ func (es SpanSlice) RemoveIf(f func(Span) bool) {
 //
 // Must use NewSpan function to create new instances.
 // Important: zero-initialized instance is not valid for use.
-//
 type Span struct {
 	orig *otlptrace.Span
 }
@@ -876,7 +873,6 @@ func (es SpanEventSlice) RemoveIf(f func(SpanEvent) bool) {
 //
 // Must use NewSpanEvent function to create new instances.
 // Important: zero-initialized instance is not valid for use.
-//
 type SpanEvent struct {
 	orig *otlptrace.Span_Event
 }
@@ -1089,7 +1085,6 @@ func (es SpanLinkSlice) RemoveIf(f func(SpanLink) bool) {
 //
 // Must use NewSpanLink function to create new instances.
 // Important: zero-initialized instance is not valid for use.
-//
 type SpanLink struct {
 	orig *otlptrace.Span_Link
 }
@@ -1175,7 +1170,6 @@ func (ms SpanLink) CopyTo(dest SpanLink) {
 //
 // Must use NewSpanStatus function to create new instances.
 // Important: zero-initialized instance is not valid for use.
-//
 type SpanStatus struct {
 	orig *otlptrace.Status
 }


### PR DESCRIPTION
The field is not being used anymore.

The build will be fixed once https://github.com/open-telemetry/opentelemetry-collector/pull/4791 is merged