### PR TITLE
Include Query Params in request map for configauth

### DIFF
--- a/config/configauth/default_serverauthenticator.go
+++ b/config/configauth/default_serverauthenticator.go
@@ -58,7 +58,7 @@ func WithShutdown(shutdownFunc componenthelper.ShutdownFunc) Option {
 // NewServerAuthenticator returns a ServerAuthenticator configured with the provided options.
 func NewServerAuthenticator(options ...Option) ServerAuthenticator {
 	bc := &defaultServerAuthenticator{
-		AuthenticateFunc: func(ctx context.Context, headers map[string][]string) (context.Context, error) { return ctx, nil },
+		AuthenticateFunc: func(ctx context.Context, requestMap map[string][]string) (context.Context, error) { return ctx, nil },
 		StartFunc:        func(ctx context.Context, host component.Host) error { return nil },
 		ShutdownFunc:     func(ctx context.Context) error { return nil },
 	}
@@ -71,8 +71,8 @@ func NewServerAuthenticator(options ...Option) ServerAuthenticator {
 }
 
 // Authenticate performs the authentication.
-func (a *defaultServerAuthenticator) Authenticate(ctx context.Context, headers map[string][]string) (context.Context, error) {
-	return a.AuthenticateFunc(ctx, headers)
+func (a *defaultServerAuthenticator) Authenticate(ctx context.Context, requestMap map[string][]string) (context.Context, error) {
+	return a.AuthenticateFunc(ctx, requestMap)
 }
 
 // Start the component.

--- a/config/configauth/serverauth.go
+++ b/config/configauth/serverauth.go
@@ -28,7 +28,8 @@ import (
 type ServerAuthenticator interface {
 	component.Extension
 
-	// Authenticate checks whether the given headers map contains valid auth data. Successfully authenticated calls will always return a nil error.
+	// Authenticate checks whether the given request map contains valid auth data. The request map includes query params along with the headers in a HTTP request.
+	// For gRPC requests, request map includes headers from the metadata. Successfully authenticated calls will always return a nil error.
 	// When the authentication fails, an error must be returned and the caller must not retry. This function is typically called from interceptors,
 	// on behalf of receivers, but receivers can still call this directly if the usage of interceptors isn't suitable.
 	// The deadline and cancellation given to this function must be respected, but note that authentication data has to be part of the map, not context.
@@ -36,9 +37,9 @@ type ServerAuthenticator interface {
 	// authentication data (if possible). This will allow other components in the pipeline to make decisions based on that data, such as routing based
 	// on tenancy as determined by the group membership, or passing through the authentication data to the next collector/backend.
 	// The context keys to be used are not defined yet.
-	Authenticate(ctx context.Context, headers map[string][]string) (context.Context, error)
+	Authenticate(ctx context.Context, requestMap map[string][]string) (context.Context, error)
 }
 
-// AuthenticateFunc defines the signature for the function responsible for performing the authentication based on the given headers map.
+// AuthenticateFunc defines the signature for the function responsible for performing the authentication based on the given request map.
 // See ServerAuthenticator.Authenticate.
-type AuthenticateFunc func(ctx context.Context, headers map[string][]string) (context.Context, error)
+type AuthenticateFunc func(ctx context.Context, requestMap map[string][]string) (context.Context, error)

--- a/config/confighttp/confighttp.go
+++ b/config/confighttp/confighttp.go
@@ -339,7 +339,14 @@ type CORSSettings struct {
 
 func authInterceptor(next http.Handler, authenticate configauth.AuthenticateFunc) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ctx, err := authenticate(r.Context(), r.Header)
+		requestMap := make(map[string][]string)
+		for k, v := range r.URL.Query() {
+			requestMap[k] = v
+		}
+		for k, v := range r.Header {
+			requestMap[k] = v
+		}
+		ctx, err := authenticate(r.Context(), requestMap)
 		if err != nil {
 			http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
 			return

--- a/config/confighttp/confighttp_test.go
+++ b/config/confighttp/confighttp_test.go
@@ -812,9 +812,9 @@ func TestServerAuth(t *testing.T) {
 	host := &mockHost{
 		ext: map[config.ComponentID]component.Extension{
 			config.NewComponentID("mock"): configauth.NewServerAuthenticator(
-				configauth.WithAuthenticate(func(ctx context.Context, headers map[string][]string) (context.Context, error) {
-					assert.ElementsMatch(t, headers["X-Test-Header"], []string{"test-value"})
-					assert.ElementsMatch(t, headers["query"], []string{"test"})
+				configauth.WithAuthenticate(func(ctx context.Context, requestMap map[string][]string) (context.Context, error) {
+					assert.ElementsMatch(t, requestMap["X-Test-Header"], []string{"test-value"})
+					assert.ElementsMatch(t, requestMap["query"], []string{"test"})
 					authCalled = true
 					return ctx, nil
 				}),
@@ -866,7 +866,7 @@ func TestFailedServerAuth(t *testing.T) {
 	host := &mockHost{
 		ext: map[config.ComponentID]component.Extension{
 			config.NewComponentID("mock"): configauth.NewServerAuthenticator(
-				configauth.WithAuthenticate(func(ctx context.Context, headers map[string][]string) (context.Context, error) {
+				configauth.WithAuthenticate(func(ctx context.Context, requestMap map[string][]string) (context.Context, error) {
 					return ctx, fmt.Errorf("authentication failed")
 				}),
 			),


### PR DESCRIPTION
**Description:**
Feature to include query params along with header in confighttp to pass to authenticator function.

**Link to tracking Issue:** NA

**Testing:** Unit

It would be good to have query params added to the "headers" map when considering http auth. The reason is for custom auth extensions could need data from query string(ex api_key, token) for authentication. This PR includes the query params in the headers itself which is renamed to a more generic `requestMap`. This allows non-breaking change for existing gRPC auth as well.