### PR TITLE
Freakynoblegas/reject invalid queue size exporterhelper

### DIFF
--- a/exporter/exporterhelper/queued_retry_experimental.go
+++ b/exporter/exporterhelper/queued_retry_experimental.go
@@ -62,6 +62,19 @@ func DefaultQueueSettings() QueueSettings {
 	}
 }
 
+// Validate checks if the QueueSettings configuration is valid
+func (qCfg *QueueSettings) Validate() error {
+	if !qCfg.Enabled {
+		return nil
+	}
+
+	if qCfg.QueueSize <= 0 {
+		return fmt.Errorf("queue size must be positive")
+	}
+
+	return nil
+}
+
 var (
 	errNoStorageClient        = errors.New("no storage client extension found")
 	errMultipleStorageClients = errors.New("multiple storage extensions found")

--- a/exporter/exporterhelper/queued_retry_inmemory.go
+++ b/exporter/exporterhelper/queued_retry_inmemory.go
@@ -57,6 +57,19 @@ func DefaultQueueSettings() QueueSettings {
 	}
 }
 
+// Validate checks if the QueueSettings configuration is valid
+func (qCfg *QueueSettings) Validate() error {
+	if !qCfg.Enabled {
+		return nil
+	}
+
+	if qCfg.QueueSize <= 0 {
+		return fmt.Errorf("queue size must be positive")
+	}
+
+	return nil
+}
+
 type queuedRetrySender struct {
 	fullName        string
 	cfg             QueueSettings

--- a/exporter/exporterhelper/queued_retry_test.go
+++ b/exporter/exporterhelper/queued_retry_test.go
@@ -368,6 +368,18 @@ func TestNoCancellationContext(t *testing.T) {
 	assert.True(t, d.IsZero())
 }
 
+func TestQueueSettings_Validate(t *testing.T) {
+	qCfg := DefaultQueueSettings()
+	assert.NoError(t, qCfg.Validate())
+
+	qCfg.QueueSize = 0
+	assert.EqualError(t, qCfg.Validate(), "queue size must be positive")
+
+	// Confirm Validate doesn't return error with invalid config when feature is disabled
+	qCfg.Enabled = false
+	assert.NoError(t, qCfg.Validate())
+}
+
 type mockErrorRequest struct {
 	baseRequest
 }

--- a/exporter/otlpexporter/config.go
+++ b/exporter/otlpexporter/config.go
@@ -37,7 +37,7 @@ var _ config.Exporter = (*Config)(nil)
 // Validate checks if the exporter configuration is valid
 func (cfg *Config) Validate() error {
 	if err := cfg.QueueSettings.Validate(); err != nil {
-		return fmt.Errorf("queue settings has invalid configuration %w", err)
+		return fmt.Errorf("queue settings has invalid configuration: %w", err)
 	}
 
 	return nil

--- a/exporter/otlpexporter/config.go
+++ b/exporter/otlpexporter/config.go
@@ -15,6 +15,8 @@
 package otlpexporter // import "go.opentelemetry.io/collector/exporter/otlpexporter"
 
 import (
+	"fmt"
+
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/configgrpc"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
@@ -34,5 +36,9 @@ var _ config.Exporter = (*Config)(nil)
 
 // Validate checks if the exporter configuration is valid
 func (cfg *Config) Validate() error {
+	if err := cfg.QueueSettings.Validate(); err != nil {
+		return fmt.Errorf("queue settings has invalid configuration %w", err)
+	}
+
 	return nil
 }


### PR DESCRIPTION
**Description:**
- Added Validation method to QueueSettings struct in ExporterHelper which checks for zero or negative values.
- Updated OTLP exporter config to validate QueueSettings struct.

**Link to tracking Issue:** [4584](https://github.com/open-telemetry/opentelemetry-collector/issues/4584)

**Testing:**
- Added test for QueueSetting's Validate function in queue_retry_test.go

**Documentation:**
- Added comments with code as appropriate. I am unsure if I should update changelog.
