### PR TITLE
Remove reference to `--new-metrics` in the docs

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -1,9 +1,7 @@
 # Monitoring
 
 Many metrics are provided by the Collector for its monitoring. Below some
-key recommendations for alerting and monitoring are listed. All metrics
-referenced below are using the `--new-metrics` option that is enabled by
-default.
+key recommendations for alerting and monitoring are listed.
 
 ## Critical Monitoring
 


### PR DESCRIPTION
Removes reference to inexistent flag `--new-metrics` as it's default and
this flag doesn't exist anymore. It was removed here:
https://github.com/open-telemetry/opentelemetry-collector/pull/2105

Resolves: https://github.com/open-telemetry/opentelemetry-collector/issues/4815