### PR TITLE
builder: bump otelColVersion version to 0.44.0

### DIFF
--- a/cmd/builder/internal/builder/config.go
+++ b/cmd/builder/internal/builder/config.go
@@ -25,7 +25,7 @@ import (
 	"go.uber.org/zap"
 )
 
-const defaultOtelColVersion = "0.43.0"
+const defaultOtelColVersion = "0.44.0"
 
 // ErrInvalidGoMod indicates an invalid gomod
 var ErrInvalidGoMod = errors.New("invalid gomod specification for module")

--- a/cmd/builder/test/core.builder.yaml
+++ b/cmd/builder/test/core.builder.yaml
@@ -1,15 +1,15 @@
 dist:
   module: go.opentelemetry.io/collector/builder/test/core
-  otelcol_version: 0.43.0
+  otelcol_version: 0.44.0
 
 extensions:
   - import: go.opentelemetry.io/collector/extension/zpagesextension
-    gomod: go.opentelemetry.io/collector v0.43.1
+    gomod: go.opentelemetry.io/collector v0.44.0
 
 receivers:
   - import: go.opentelemetry.io/collector/receiver/otlpreceiver
-    gomod: go.opentelemetry.io/collector v0.43.1
+    gomod: go.opentelemetry.io/collector v0.44.0
 
 exporters:
   - import: go.opentelemetry.io/collector/exporter/loggingexporter
-    gomod: go.opentelemetry.io/collector v0.43.1
+    gomod: go.opentelemetry.io/collector v0.44.0

--- a/cmd/builder/test/replaces.builder.yaml
+++ b/cmd/builder/test/replaces.builder.yaml
@@ -1,22 +1,22 @@
 dist:
   module: go.opentelemetry.io/collector/builder/test/replaces
-  otelcol_version: 0.43.0
+  otelcol_version: 0.44.0
 
 extensions:
   - import: go.opentelemetry.io/collector/extension/zpagesextension
-    gomod: go.opentelemetry.io/collector v0.43.1
+    gomod: go.opentelemetry.io/collector v0.44.0
 
 receivers:
   - import: go.opentelemetry.io/collector/receiver/otlpreceiver
-    gomod: go.opentelemetry.io/collector v0.43.1
+    gomod: go.opentelemetry.io/collector v0.44.0
 
 processors:
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/routingprocessor v0.43.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.43.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/routingprocessor v0.44.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.44.0
 
 exporters:
   - import: go.opentelemetry.io/collector/exporter/loggingexporter
-    gomod: go.opentelemetry.io/collector v0.43.1
+    gomod: go.opentelemetry.io/collector v0.44.0
 
 replaces:
-  - github.com/open-telemetry/opentelemetry-collector-contrib/internal/common => github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.43.0
+  - github.com/open-telemetry/opentelemetry-collector-contrib/internal/common => github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.44.0


### PR DESCRIPTION
**Description:** bump otel version to 0.44.0

This is to prevent:

```
2022-02-11T14:53:02.762+0100    INFO    builder/main.go:52      You're building a distribution with non-aligned version of the builder. Compilation may fail due to API changes. Please upgrade your builder or API     {"builder-version": "0.43.0"}
```

**Testing:** Ran `go test -count 1 ./...` in `./cmd/builder` dir
