### PR TITLE
Fix typo in OTLP text

### DIFF
--- a/internal/otlptext/logs.go
+++ b/internal/otlptext/logs.go
@@ -38,7 +38,7 @@ func (textLogsMarshaler) MarshalLogs(ld pdata.Logs) ([]byte, error) {
 		for j := 0; j < ills.Len(); j++ {
 			buf.logEntry("InstrumentationLibraryLogs #%d", j)
 			ils := ills.At(j)
-			buf.logEntry("InstrumentationLibraryMetrics SchemaURL: %s", ils.SchemaUrl())
+			buf.logEntry("InstrumentationLibraryLogs SchemaURL: %s", ils.SchemaUrl())
 			buf.logInstrumentationLibrary(ils.InstrumentationLibrary())
 
 			logs := ils.LogRecords()

--- a/internal/otlptext/traces.go
+++ b/internal/otlptext/traces.go
@@ -38,7 +38,7 @@ func (textTracesMarshaler) MarshalTraces(td pdata.Traces) ([]byte, error) {
 		for j := 0; j < ilss.Len(); j++ {
 			buf.logEntry("InstrumentationLibrarySpans #%d", j)
 			ils := ilss.At(j)
-			buf.logEntry("InstrumentationLibraryMetrics SchemaURL: %s", ils.SchemaUrl())
+			buf.logEntry("InstrumentationLibrarySpans SchemaURL: %s", ils.SchemaUrl())
 			buf.logInstrumentationLibrary(ils.InstrumentationLibrary())
 
 			spans := ils.Spans()


### PR DESCRIPTION
I believe same line from metrics is copied but text is not changed.