### PR TITLE
[pdata] Rename `NumberDataPoint/Exemplar.Type` methods to `ValueType`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@
 - Reject invalid queue size exporterhelper (#4799)
 - Transform configmapprovider.Retrieved interface to a struct (#4789)
 
+## 🚩 Deprecations 🚩
+
+- Deprecate `pdata.NumberDataPoint.Type()` and `pdata.Exemplar.Type()` in favor of `NumberDataPoint.ValueType()` and
+  `Exemplar.ValueType()` (#4850)
+
 ## v0.44.0 Beta
 
 ## 🛑 Breaking changes 🛑

--- a/internal/otlptext/databuffer.go
+++ b/internal/otlptext/databuffer.go
@@ -97,7 +97,7 @@ func (b *dataBuffer) logNumberDataPoints(ps pdata.NumberDataPointSlice) {
 
 		b.logEntry("StartTimestamp: %s", p.StartTimestamp())
 		b.logEntry("Timestamp: %s", p.Timestamp())
-		switch p.Type() {
+		switch p.ValueType() {
 		case pdata.MetricValueTypeInt:
 			b.logEntry("Value: %d", p.IntVal())
 		case pdata.MetricValueTypeDouble:

--- a/model/internal/cmd/pdatagen/internal/metrics_structs.go
+++ b/model/internal/cmd/pdatagen/internal/metrics_structs.go
@@ -123,7 +123,6 @@ var metric = &messageValueStruct{
 			testVal:         `"1"`,
 		},
 		&oneOfField{
-			typeAccessor:     "DataType",
 			typeName:         "MetricDataType",
 			originFieldName:  "Data",
 			originTypePrefix: "otlpmetrics.Metric_",
@@ -243,7 +242,6 @@ var numberDataPoint = &messageValueStruct{
 		startTimeField,
 		timeField,
 		&oneOfField{
-			typeAccessor:     "Type",
 			typeName:         "MetricValueType",
 			originFieldName:  "Value",
 			originTypePrefix: "otlpmetrics.NumberDataPoint_",
@@ -414,7 +412,6 @@ var exemplar = &messageValueStruct{
 	fields: []baseField{
 		timeField,
 		&oneOfField{
-			typeAccessor:     "Type",
 			typeName:         "MetricValueType",
 			originFieldName:  "Value",
 			originTypePrefix: "otlpmetrics.Exemplar_",

--- a/model/pdata/generated_metrics.go
+++ b/model/pdata/generated_metrics.go
@@ -1124,9 +1124,9 @@ func (ms NumberDataPoint) SetTimestamp(v Timestamp) {
 	(*ms.orig).TimeUnixNano = uint64(v)
 }
 
-// Type returns the type of the value for this NumberDataPoint.
+// ValueType returns the type of the value for this NumberDataPoint.
 // Calling this function on zero-initialized NumberDataPoint will cause a panic.
-func (ms NumberDataPoint) Type() MetricValueType {
+func (ms NumberDataPoint) ValueType() MetricValueType {
 	switch ms.orig.Value.(type) {
 	case *otlpmetrics.NumberDataPoint_AsDouble:
 		return MetricValueTypeDouble
@@ -1180,7 +1180,7 @@ func (ms NumberDataPoint) CopyTo(dest NumberDataPoint) {
 	ms.Attributes().CopyTo(dest.Attributes())
 	dest.SetStartTimestamp(ms.StartTimestamp())
 	dest.SetTimestamp(ms.Timestamp())
-	switch ms.Type() {
+	switch ms.ValueType() {
 	case MetricValueTypeDouble:
 		dest.SetDoubleVal(ms.DoubleVal())
 	case MetricValueTypeInt:
@@ -2374,9 +2374,9 @@ func (ms Exemplar) SetTimestamp(v Timestamp) {
 	(*ms.orig).TimeUnixNano = uint64(v)
 }
 
-// Type returns the type of the value for this Exemplar.
+// ValueType returns the type of the value for this Exemplar.
 // Calling this function on zero-initialized Exemplar will cause a panic.
-func (ms Exemplar) Type() MetricValueType {
+func (ms Exemplar) ValueType() MetricValueType {
 	switch ms.orig.Value.(type) {
 	case *otlpmetrics.Exemplar_AsDouble:
 		return MetricValueTypeDouble
@@ -2438,7 +2438,7 @@ func (ms Exemplar) SetSpanID(v SpanID) {
 // CopyTo copies all properties from the current struct to the dest.
 func (ms Exemplar) CopyTo(dest Exemplar) {
 	dest.SetTimestamp(ms.Timestamp())
-	switch ms.Type() {
+	switch ms.ValueType() {
 	case MetricValueTypeDouble:
 		dest.SetDoubleVal(ms.DoubleVal())
 	case MetricValueTypeInt:

--- a/model/pdata/generated_metrics_test.go
+++ b/model/pdata/generated_metrics_test.go
@@ -856,14 +856,14 @@ func TestNumberDataPoint_Timestamp(t *testing.T) {
 	assert.EqualValues(t, testValTimestamp, ms.Timestamp())
 }
 
-func TestNumberDataPointType(t *testing.T) {
+func TestNumberDataPointValueType(t *testing.T) {
 	tv := NewNumberDataPoint()
-	assert.Equal(t, MetricValueTypeNone, tv.Type())
+	assert.Equal(t, MetricValueTypeNone, tv.ValueType())
 	assert.Equal(t, "", MetricValueType(1000).String())
 	tv.SetDoubleVal(float64(17.13))
-	assert.Equal(t, MetricValueTypeDouble, tv.Type())
+	assert.Equal(t, MetricValueTypeDouble, tv.ValueType())
 	tv.SetIntVal(int64(17))
-	assert.Equal(t, MetricValueTypeInt, tv.Type())
+	assert.Equal(t, MetricValueTypeInt, tv.ValueType())
 }
 
 func TestNumberDataPoint_DoubleVal(t *testing.T) {
@@ -1775,14 +1775,14 @@ func TestExemplar_Timestamp(t *testing.T) {
 	assert.EqualValues(t, testValTimestamp, ms.Timestamp())
 }
 
-func TestExemplarType(t *testing.T) {
+func TestExemplarValueType(t *testing.T) {
 	tv := NewExemplar()
-	assert.Equal(t, MetricValueTypeNone, tv.Type())
+	assert.Equal(t, MetricValueTypeNone, tv.ValueType())
 	assert.Equal(t, "", MetricValueType(1000).String())
 	tv.SetDoubleVal(float64(17.13))
-	assert.Equal(t, MetricValueTypeDouble, tv.Type())
+	assert.Equal(t, MetricValueTypeDouble, tv.ValueType())
 	tv.SetIntVal(int64(17))
-	assert.Equal(t, MetricValueTypeInt, tv.Type())
+	assert.Equal(t, MetricValueTypeInt, tv.ValueType())
 }
 
 func TestExemplar_DoubleVal(t *testing.T) {

--- a/model/pdata/metrics.go
+++ b/model/pdata/metrics.go
@@ -245,3 +245,13 @@ func (mdt MetricValueType) String() string {
 	}
 	return ""
 }
+
+// Deprecated: [v0.45.0] Use ValueType instead.
+func (ms NumberDataPoint) Type() MetricValueType {
+	return ms.ValueType()
+}
+
+// Deprecated: [v0.45.0] Use ValueType instead.
+func (ms Exemplar) Type() MetricValueType {
+	return ms.ValueType()
+}

--- a/model/pdata/metrics_test.go
+++ b/model/pdata/metrics_test.go
@@ -661,6 +661,18 @@ func TestMetricsDataPointFlags(t *testing.T) {
 	assert.Equal(t, "FLAG_NO_RECORDED_VALUE", gauge.DataPoints().At(0).Flags().String())
 }
 
+// TestNumberDataPointType tests deprecated NumberDataPoint.Type
+func TestNumberDataPointType(t *testing.T) {
+	tv := NewNumberDataPoint()
+	assert.Equal(t, tv.ValueType(), tv.Type())
+}
+
+// TestExemplarType tests deprecated Exemplar.Type
+func TestExemplarType(t *testing.T) {
+	tv := NewExemplar()
+	assert.Equal(t, tv.ValueType(), tv.Type())
+}
+
 func BenchmarkMetricsClone(b *testing.B) {
 	metrics := NewMetrics()
 	fillTestResourceMetricsSlice(metrics.ResourceMetrics())


### PR DESCRIPTION
Add new `NumberDataPoint.ValueType()` and `Exemplar.ValueType()` instead. Do not use `accessorType` in the pdatagen, always rely on proto field type for consistency.


Resolves https://github.com/open-telemetry/opentelemetry-collector/issues/4781