### PR TITLE
[confighttp] Allow CORS requests with configured auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 - Transform configmapprovider.Retrieved interface to a struct (#4789)
 - Added feature gate summary to zpages extension (#4834)
 
+### 🧰 Bug fixes 🧰
+
+- `confighttp`: Allow CORS requests with configured auth (#4869)
+
 ### 🚩 Deprecations 🚩
 
 - Deprecate `pdata.NumberDataPoint.Type()` and `pdata.Exemplar.Type()` in favor of `NumberDataPoint.ValueType()` and


### PR DESCRIPTION
**Description:** 

If authenticator is configured it will deny CORS requests which do not carry auth. This change reorders auth and CORS middlewares so CORS takes precedence.

**Testing:**

There is a test which ensures that auth will be skipped for CORS requests.
