### PR TITLE
[processor/memorylimiter] Only drops traces, not logs or metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,11 @@
 ## 🧰 Bug fixes 🧰
 
 - Initialized logger with collector to avoid potential race condition panic on `Shutdown` (#4827)
+- In addition to traces, now logs and metrics processors will start the memory limiter.
+  Added thread-safe logic so only the first processor can launch the `checkMemLimits` go-routine and the last processor
+  that calls shutdown to terminate it; this is done per memory limiter instance.
+  Added memory limiter factory to cache initiated object and be reused by similar config. This guarantees a single
+  running `checkMemLimits` per config (#4886)
 
 ## v0.45.0 Beta
 

--- a/processor/memorylimiterprocessor/factory_test.go
+++ b/processor/memorylimiterprocessor/factory_test.go
@@ -16,6 +16,7 @@ package memorylimiterprocessor
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -61,18 +62,33 @@ func TestCreateProcessor(t *testing.T) {
 	pCfg.MemorySpikeLimitMiB = 1907
 	pCfg.CheckInterval = 100 * time.Millisecond
 
+	errorCheck := fmt.Errorf("no existing monitoring routine is running")
 	tp, err = factory.CreateTracesProcessor(context.Background(), componenttest.NewNopProcessorCreateSettings(), cfg, consumertest.NewNop())
 	assert.NoError(t, err)
 	assert.NotNil(t, tp)
-	assert.NoError(t, tp.Shutdown(context.Background()))
+	// test if we can shutdown a monitoring routine that has not started
+	assert.Error(t, errorCheck, tp.Shutdown(context.Background()))
+	assert.NoError(t, tp.Start(context.Background(), componenttest.NewNopHost()))
 
 	mp, err = factory.CreateMetricsProcessor(context.Background(), componenttest.NewNopProcessorCreateSettings(), cfg, consumertest.NewNop())
 	assert.NoError(t, err)
 	assert.NotNil(t, mp)
-	assert.NoError(t, mp.Shutdown(context.Background()))
+	assert.NoError(t, mp.Start(context.Background(), componenttest.NewNopHost()))
 
 	lp, err = factory.CreateLogsProcessor(context.Background(), componenttest.NewNopProcessorCreateSettings(), cfg, consumertest.NewNop())
 	assert.NoError(t, err)
 	assert.NotNil(t, lp)
+	assert.NoError(t, lp.Start(context.Background(), componenttest.NewNopHost()))
+
 	assert.NoError(t, lp.Shutdown(context.Background()))
+	assert.NoError(t, tp.Shutdown(context.Background()))
+	assert.NoError(t, mp.Shutdown(context.Background()))
+	// verify that no monitoring routine is running
+	assert.Error(t, errorCheck, tp.Shutdown(context.Background()))
+
+	// start and shutdown a new monitoring routine
+	assert.NoError(t, lp.Start(context.Background(), componenttest.NewNopHost()))
+	assert.NoError(t, lp.Shutdown(context.Background()))
+	// calling it again should throw an error
+	assert.Error(t, errorCheck, lp.Shutdown(context.Background()))
 }

--- a/processor/memorylimiterprocessor/memorylimiter_test.go
+++ b/processor/memorylimiterprocessor/memorylimiter_test.go
@@ -95,6 +95,7 @@ func TestNew(t *testing.T) {
 				return
 			}
 			if got != nil {
+				assert.NoError(t, got.start(context.Background(), componenttest.NewNopHost()))
 				assert.NoError(t, got.shutdown(context.Background()))
 			}
 		})


### PR DESCRIPTION
Signed-off-by: Dani Louca <dlouca@splunk.com>

**Description:** 

This change https://github.com/open-telemetry/opentelemetry-collector/commit/062e64f1d7466400cbc5b0bd727ec94175a0e0de caused the memory limiter to "only" start the `checkMemLimits` routine for the ml instance used by the traces processor . 
In other words, metrics and logs processor will NOT [drop/refuse](https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/memorylimiterprocessor/memorylimiter.go#L206) data and will pass them down to the next consumer regardless of the current memory pressure as their instance of ml->forcingDrop will not be set.

The simplest solution, is to call start for each processor (metrics, logs, traces) , but this will not be efficient as we'll be running 3 instances of `checkMemLimits`, ie: multiple GC .
But at the same we need to allow multiple instances, with different configs, example: `memory_limiter/another` and `memory_limiter`

````
extensions:
  memory_ballast:
    size_mib: 4

receivers:
  otlp:
    protocols:
      grpc:
      http:
processors:
  memory_limiter:
    check_interval: 2s
    limit_mib: 10

  memory_limiter/another:
    check_interval: 1s
    limit_mib: 100
exporters:
  logging:
    logLevel: info

service:
  telemetry:
    logs:
      level: "info"
  pipelines:
    metrics:
      receivers: [otlp]
      processors: [memory_limiter]
      exporters: [logging]
    metrics/default:
      receivers: [otlp]
      processors: [memory_limiter]
      exporters: [logging]
    traces:
      receivers: [otlp]
      processors: [memory_limiter/another]
      exporters: [logging]
  extensions: [memory_ballast]
````

The fix adds a global map to keep track of the different instance and add ~~sync once~~ mutex for the start and shutdown call, so only the first processor can launch the `checkMemLimits` routine and the last one to call `shutdown` to take it down.
If shutdown was called and no `checkMemLimits` has started, then we'll return an error message; unit tests were updated to handle this.


**Testing:** 
Tested with above config and using splunk otel instance with valid data.
Made sure only a single `checkMemLimits` is running when there is a single config for memory-limiter and more than one when we have multiple.
I also verified that under memory pressure, when we pass the soft limit, all data types, traces, logs and metrics are getting dropped.

One we agree on this solution, I will look into adding more unit test to validate the change

