### PR TITLE
Change behavior of AttributeValue oneof value field accessors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@
 - Rename `pdata.AttributeMap.Delete` to `pdata.AttributeMap.Remove` (#4914)
 - pdata: deprecate funcs working with InternalRep (#4957)
 
+### 🚩 Deprecations 🚩
+
+- Change behavior of pdata.AttributeValue oneof value field accessors (#4909)
+  - Deprecated `AttributeValue.StringVal` in favor of `AttributeValue.StringValue`
+  - Deprecated `AttributeValue.IntVal` in favor of `AttributeValue.IntValue`
+  - Deprecated `AttributeValue.DoubleVal` in favor of `AttributeValue.DoubleValue`
+  - Deprecated `AttributeValue.BoolVal` in favor of `AttributeValue.BoolValue`
+  - Deprecated `AttributeValue.MapVal` in favor of `AttributeValue.MapValue`
+  - Deprecated `AttributeValue.SliceVal` in favor of `AttributeValue.SliceValue`
+  - Deprecated `AttributeValue.BytesVal` in favor of `AttributeValue.BytesValue`
+  - Deprecated `AttributeValue.SetStringVal` in favor of `AttributeValue.SetStringValue`
+  - Deprecated `AttributeValue.SetIntVal` in favor of `AttributeValue.SetIntValue`
+  - Deprecated `AttributeValue.SetDoubleVal` in favor of `AttributeValue.SetDoubleValue`
+  - Deprecated `AttributeValue.SetBoolVal` in favor of `AttributeValue.SetBoolValue`
+  - Deprecated `AttributeValue.SetBytesVal` in favor of `AttributeValue.SetBytesValue`
+
 ### 💡 Enhancements 💡
 
 - Add `pdata.AttributeMap.RemoveIf`, which is a more performant way to remove multiple keys (#4914)

--- a/internal/otlptext/databuffer.go
+++ b/internal/otlptext/databuffer.go
@@ -256,17 +256,17 @@ func (b *dataBuffer) logLinks(description string, sl pdata.SpanLinkSlice) {
 func attributeValueToString(av pdata.AttributeValue) string {
 	switch av.Type() {
 	case pdata.AttributeValueTypeString:
-		return av.StringVal()
+		return av.StringValue()
 	case pdata.AttributeValueTypeBool:
-		return strconv.FormatBool(av.BoolVal())
+		return strconv.FormatBool(av.BoolValue())
 	case pdata.AttributeValueTypeDouble:
-		return strconv.FormatFloat(av.DoubleVal(), 'f', -1, 64)
+		return strconv.FormatFloat(av.DoubleValue(), 'f', -1, 64)
 	case pdata.AttributeValueTypeInt:
-		return strconv.FormatInt(av.IntVal(), 10)
+		return strconv.FormatInt(av.IntValue(), 10)
 	case pdata.AttributeValueTypeArray:
-		return attributeValueSliceToString(av.SliceVal())
+		return attributeValueSliceToString(av.SliceValue())
 	case pdata.AttributeValueTypeMap:
-		return attributeMapToString(av.MapVal())
+		return attributeMapToString(av.MapValue())
 	default:
 		return fmt.Sprintf("<Unknown OpenTelemetry attribute value type %q>", av.Type())
 	}

--- a/internal/otlptext/databuffer_test.go
+++ b/internal/otlptext/databuffer_test.go
@@ -24,6 +24,22 @@ import (
 
 func TestNestedArraySerializesCorrectly(t *testing.T) {
 	ava := pdata.NewAttributeValueArray()
+	ava.SliceValue().AppendEmpty().SetStringValue("foo")
+	ava.SliceValue().AppendEmpty().SetIntValue(42)
+
+	ava2 := pdata.NewAttributeValueArray()
+	ava2.SliceValue().AppendEmpty().SetStringValue("bar")
+	ava2.CopyTo(ava.SliceValue().AppendEmpty())
+
+	ava.SliceValue().AppendEmpty().SetBoolValue(true)
+	ava.SliceValue().AppendEmpty().SetDoubleValue(5.5)
+
+	assert.Equal(t, 5, ava.SliceValue().Len())
+	assert.Equal(t, "[foo, 42, [bar], true, 5.5]", attributeValueToString(ava))
+}
+
+func TestNestedArraySerializesCorrectlyDeprecated(t *testing.T) {
+	ava := pdata.NewAttributeValueArray()
 	ava.SliceVal().AppendEmpty().SetStringVal("foo")
 	ava.SliceVal().AppendEmpty().SetIntVal(42)
 
@@ -40,11 +56,11 @@ func TestNestedArraySerializesCorrectly(t *testing.T) {
 
 func TestNestedMapSerializesCorrectly(t *testing.T) {
 	ava := pdata.NewAttributeValueMap()
-	av := ava.MapVal()
+	av := ava.MapValue()
 	av.Insert("foo", pdata.NewAttributeValueString("test"))
 
 	ava2 := pdata.NewAttributeValueMap()
-	av2 := ava2.MapVal()
+	av2 := ava2.MapValue()
 	av2.InsertInt("bar", 13)
 	av.Insert("zoo", ava2)
 
@@ -53,6 +69,6 @@ func TestNestedMapSerializesCorrectly(t *testing.T) {
      -> zoo: MAP({"bar":13})
 }`
 
-	assert.Equal(t, 2, ava.MapVal().Len())
+	assert.Equal(t, 2, ava.MapValue().Len())
 	assert.Equal(t, expected, attributeValueToString(ava))
 }

--- a/internal/testdata/log.go
+++ b/internal/testdata/log.go
@@ -82,7 +82,7 @@ func fillLogOne(log pdata.LogRecord) {
 	attrs.InsertString("app", "server")
 	attrs.InsertInt("instance_num", 1)
 
-	log.Body().SetStringVal("This is a log message")
+	log.Body().SetStringValue("This is a log message")
 }
 
 func fillLogTwo(log pdata.LogRecord) {
@@ -95,7 +95,7 @@ func fillLogTwo(log pdata.LogRecord) {
 	attrs.InsertString("customer", "acme")
 	attrs.InsertString("env", "dev")
 
-	log.Body().SetStringVal("something happened")
+	log.Body().SetStringValue("something happened")
 }
 
 func fillLogThree(log pdata.LogRecord) {
@@ -104,7 +104,7 @@ func fillLogThree(log pdata.LogRecord) {
 	log.SetSeverityNumber(pdata.SeverityNumberWARN)
 	log.SetSeverityText("Warning")
 
-	log.Body().SetStringVal("something else happened")
+	log.Body().SetStringValue("something else happened")
 }
 
 func GenerateLogsManyLogRecordsSameResource(count int) pdata.Logs {

--- a/model/internal/pdata/common.go
+++ b/model/internal/pdata/common.go
@@ -72,7 +72,7 @@ func (avt AttributeValueType) String() string {
 // value representation. For the same reason passing by value and calling setters
 // will modify the original, e.g.:
 //
-//   func f1(val AttributeValue) { val.SetIntVal(234) }
+//   func f1(val AttributeValue) { val.SetIntValue(234) }
 //   func f2() {
 //       v := NewAttributeValueString("a string")
 //       f1(v)
@@ -159,29 +159,61 @@ func (a AttributeValue) Type() AttributeValueType {
 // StringVal returns the string value associated with this AttributeValue.
 // If the Type() is not AttributeValueTypeString then returns empty string.
 // Calling this function on zero-initialized AttributeValue will cause a panic.
+// Deprecated: [v0.47.0] Use StringValue instead.
 func (a AttributeValue) StringVal() string {
 	return a.orig.GetStringValue()
+}
+
+// StringValue returns the string value associated with this AttributeValue.
+// Calling this function on zero-initialized AttributeValue will cause a panic.
+// Calling this function when Type() != AttributeValueTypeString will cause a panic.
+func (a AttributeValue) StringValue() string {
+	return a.orig.Value.(*otlpcommon.AnyValue_StringValue).StringValue
 }
 
 // IntVal returns the int64 value associated with this AttributeValue.
 // If the Type() is not AttributeValueTypeInt then returns int64(0).
 // Calling this function on zero-initialized AttributeValue will cause a panic.
+// Deprecated: [v0.47.0] Use IntValue instead.
 func (a AttributeValue) IntVal() int64 {
 	return a.orig.GetIntValue()
+}
+
+// IntValue returns the int64 value associated with this AttributeValue.
+// Calling this function on zero-initialized AttributeValue will cause a panic.
+// Calling this function when Type() != AttributeValueTypeInt will cause a panic.
+func (a AttributeValue) IntValue() int64 {
+	return a.orig.Value.(*otlpcommon.AnyValue_IntValue).IntValue
 }
 
 // DoubleVal returns the float64 value associated with this AttributeValue.
 // If the Type() is not AttributeValueTypeDouble then returns float64(0).
 // Calling this function on zero-initialized AttributeValue will cause a panic.
+// Deprecated: [v0.47.0] Use DoubleValue instead.
 func (a AttributeValue) DoubleVal() float64 {
 	return a.orig.GetDoubleValue()
+}
+
+// DoubleValue returns the float64 value associated with this AttributeValue.
+// Calling this function on zero-initialized AttributeValue will cause a panic.
+// Calling this function when Type() != AttributeValueTypeDouble will cause a panic.
+func (a AttributeValue) DoubleValue() float64 {
+	return a.orig.Value.(*otlpcommon.AnyValue_DoubleValue).DoubleValue
 }
 
 // BoolVal returns the bool value associated with this AttributeValue.
 // If the Type() is not AttributeValueTypeBool then returns false.
 // Calling this function on zero-initialized AttributeValue will cause a panic.
+// Deprecated: [v0.47.0] Use BoolValue instead.
 func (a AttributeValue) BoolVal() bool {
 	return a.orig.GetBoolValue()
+}
+
+// BoolValue returns the bool value associated with this AttributeValue.
+// Calling this function on zero-initialized AttributeValue will cause a panic.
+// Calling this function when Type() != AttributeValueTypeBool will cause a panic.
+func (a AttributeValue) BoolValue() bool {
+	return a.orig.Value.(*otlpcommon.AnyValue_BoolValue).BoolValue
 }
 
 // MapVal returns the map value associated with this AttributeValue.
@@ -189,6 +221,7 @@ func (a AttributeValue) BoolVal() bool {
 // such empty map has no effect on this AttributeValue.
 //
 // Calling this function on zero-initialized AttributeValue will cause a panic.
+// Deprecated: [v0.47.0] Use MapValue instead.
 func (a AttributeValue) MapVal() AttributeMap {
 	kvlist := a.orig.GetKvlistValue()
 	if kvlist == nil {
@@ -197,11 +230,19 @@ func (a AttributeValue) MapVal() AttributeMap {
 	return newAttributeMap(&kvlist.Values)
 }
 
+// MapValue returns the map value associated with this AttributeValue.
+// Calling this function on zero-initialized AttributeValue will cause a panic.
+// Calling this function when Type() != AttributeValueTypeMap will cause a panic.
+func (a AttributeValue) MapValue() AttributeMap {
+	return newAttributeMap(&a.orig.Value.(*otlpcommon.AnyValue_KvlistValue).KvlistValue.Values)
+}
+
 // SliceVal returns the slice value associated with this AttributeValue.
 // If the Type() is not AttributeValueTypeArray then returns an empty slice. Note that modifying
 // such empty slice has no effect on this AttributeValue.
 //
 // Calling this function on zero-initialized AttributeValue will cause a panic.
+// Deprecated: [v0.47.0] Use SliceValue instead.
 func (a AttributeValue) SliceVal() AttributeValueSlice {
 	arr := a.orig.GetArrayValue()
 	if arr == nil {
@@ -210,39 +251,86 @@ func (a AttributeValue) SliceVal() AttributeValueSlice {
 	return newAttributeValueSlice(&arr.Values)
 }
 
+// SliceValue returns the slice value associated with this AttributeValue.
+// Calling this function on zero-initialized AttributeValue will cause a panic.
+// Calling this function when Type() != AttributeValueTypeArray will cause a panic.
+func (a AttributeValue) SliceValue() AttributeValueSlice {
+	return newAttributeValueSlice(&a.orig.Value.(*otlpcommon.AnyValue_ArrayValue).ArrayValue.Values)
+}
+
 // BytesVal returns the []byte value associated with this AttributeValue.
 // If the Type() is not AttributeValueTypeBytes then returns false.
 // Calling this function on zero-initialized AttributeValue will cause a panic.
 // Modifying the returned []byte in-place is forbidden.
+// Deprecated: [v0.47.0] Use BytesValue instead.
 func (a AttributeValue) BytesVal() []byte {
 	return a.orig.GetBytesValue()
+}
+
+// BytesValue returns the []byte value associated with this AttributeValue.
+// Calling this function on zero-initialized AttributeValue will cause a panic.
+// Calling this function when Type() != AttributeValueTypeBytes will cause a panic.
+func (a AttributeValue) BytesValue() []byte {
+	return a.orig.Value.(*otlpcommon.AnyValue_BytesValue).BytesValue
 }
 
 // SetStringVal replaces the string value associated with this AttributeValue,
 // it also changes the type to be AttributeValueTypeString.
 // Calling this function on zero-initialized AttributeValue will cause a panic.
+// Deprecated: [v0.47.0] Use SetStringValue instead.
 func (a AttributeValue) SetStringVal(v string) {
+	a.SetStringValue(v)
+}
+
+// SetStringValue replaces the string value associated with this AttributeValue,
+// it also changes the type to be AttributeValueTypeString.
+// Calling this function on zero-initialized AttributeValue will cause a panic.
+func (a AttributeValue) SetStringValue(v string) {
 	a.orig.Value = &otlpcommon.AnyValue_StringValue{StringValue: v}
 }
 
 // SetIntVal replaces the int64 value associated with this AttributeValue,
 // it also changes the type to be AttributeValueTypeInt.
 // Calling this function on zero-initialized AttributeValue will cause a panic.
+// Deprecated: [v0.47.0] Use SetIntValue instead.
 func (a AttributeValue) SetIntVal(v int64) {
+	a.SetIntValue(v)
+}
+
+// SetIntValue replaces the int64 value associated with this AttributeValue,
+// it also changes the type to be AttributeValueTypeInt.
+// Calling this function on zero-initialized AttributeValue will cause a panic.
+func (a AttributeValue) SetIntValue(v int64) {
 	a.orig.Value = &otlpcommon.AnyValue_IntValue{IntValue: v}
 }
 
 // SetDoubleVal replaces the float64 value associated with this AttributeValue,
 // it also changes the type to be AttributeValueTypeDouble.
 // Calling this function on zero-initialized AttributeValue will cause a panic.
+// Deprecated: [v0.47.0] Use SetDoubleValue instead.
 func (a AttributeValue) SetDoubleVal(v float64) {
+	a.SetDoubleValue(v)
+}
+
+// SetDoubleValue replaces the float64 value associated with this AttributeValue,
+// it also changes the type to be AttributeValueTypeDouble.
+// Calling this function on zero-initialized AttributeValue will cause a panic.
+func (a AttributeValue) SetDoubleValue(v float64) {
 	a.orig.Value = &otlpcommon.AnyValue_DoubleValue{DoubleValue: v}
 }
 
 // SetBoolVal replaces the bool value associated with this AttributeValue,
 // it also changes the type to be AttributeValueTypeBool.
 // Calling this function on zero-initialized AttributeValue will cause a panic.
+// Deprecated: [v0.47.0] Use SetBoolValue instead.
 func (a AttributeValue) SetBoolVal(v bool) {
+	a.SetBoolValue(v)
+}
+
+// SetBoolValue replaces the bool value associated with this AttributeValue,
+// it also changes the type to be AttributeValueTypeBool.
+// Calling this function on zero-initialized AttributeValue will cause a panic.
+func (a AttributeValue) SetBoolValue(v bool) {
 	a.orig.Value = &otlpcommon.AnyValue_BoolValue{BoolValue: v}
 }
 
@@ -251,7 +339,17 @@ func (a AttributeValue) SetBoolVal(v bool) {
 // Calling this function on zero-initialized AttributeValue will cause a panic.
 // The caller must ensure the []byte passed in is not modified after the call is made, sharing the data
 // across multiple attributes is forbidden.
+// Deprecated: [v0.47.0] Use SetBytesValue instead.
 func (a AttributeValue) SetBytesVal(v []byte) {
+	a.SetBytesValue(v)
+}
+
+// SetBytesValue replaces the []byte value associated with this AttributeValue,
+// it also changes the type to be AttributeValueTypeBytes.
+// Calling this function on zero-initialized AttributeValue will cause a panic.
+// The caller must ensure the []byte passed in is not modified after the call is made, sharing the data
+// across multiple attributes is forbidden.
+func (a AttributeValue) SetBytesValue(v []byte) {
 	a.orig.Value = &otlpcommon.AnyValue_BytesValue{BytesValue: v}
 }
 
@@ -365,7 +463,7 @@ func (a AttributeValue) Equal(av AttributeValue) bool {
 }
 
 // AsString converts an OTLP AttributeValue object of any type to its equivalent string
-// representation. This differs from StringVal which only returns a non-empty value
+// representation. This differs from StringValue which only returns a value
 // if the AttributeValueType is AttributeValueTypeString.
 func (a AttributeValue) AsString() string {
 	switch a.Type() {
@@ -373,26 +471,26 @@ func (a AttributeValue) AsString() string {
 		return ""
 
 	case AttributeValueTypeString:
-		return a.StringVal()
+		return a.StringValue()
 
 	case AttributeValueTypeBool:
-		return strconv.FormatBool(a.BoolVal())
+		return strconv.FormatBool(a.BoolValue())
 
 	case AttributeValueTypeDouble:
-		return strconv.FormatFloat(a.DoubleVal(), 'f', -1, 64)
+		return strconv.FormatFloat(a.DoubleValue(), 'f', -1, 64)
 
 	case AttributeValueTypeInt:
-		return strconv.FormatInt(a.IntVal(), 10)
+		return strconv.FormatInt(a.IntValue(), 10)
 
 	case AttributeValueTypeMap:
-		jsonStr, _ := json.Marshal(a.MapVal().AsRaw())
+		jsonStr, _ := json.Marshal(a.MapValue().AsRaw())
 		return string(jsonStr)
 
 	case AttributeValueTypeBytes:
-		return base64.StdEncoding.EncodeToString(a.BytesVal())
+		return base64.StdEncoding.EncodeToString(a.BytesValue())
 
 	case AttributeValueTypeArray:
-		jsonStr, _ := json.Marshal(a.SliceVal().asRaw())
+		jsonStr, _ := json.Marshal(a.SliceValue().asRaw())
 		return string(jsonStr)
 
 	default:
@@ -403,14 +501,14 @@ func (a AttributeValue) AsString() string {
 func newAttributeKeyValueString(k string, v string) otlpcommon.KeyValue {
 	orig := otlpcommon.KeyValue{Key: k}
 	akv := AttributeValue{&orig.Value}
-	akv.SetStringVal(v)
+	akv.SetStringValue(v)
 	return orig
 }
 
 func newAttributeKeyValueInt(k string, v int64) otlpcommon.KeyValue {
 	orig := otlpcommon.KeyValue{Key: k}
 	akv := AttributeValue{&orig.Value}
-	akv.SetIntVal(v)
+	akv.SetIntValue(v)
 	return orig
 }
 
@@ -424,7 +522,7 @@ func newAttributeKeyValueDouble(k string, v float64) otlpcommon.KeyValue {
 func newAttributeKeyValueBool(k string, v bool) otlpcommon.KeyValue {
 	orig := otlpcommon.KeyValue{Key: k}
 	akv := AttributeValue{&orig.Value}
-	akv.SetBoolVal(v)
+	akv.SetBoolValue(v)
 	return orig
 }
 
@@ -442,7 +540,7 @@ func newAttributeKeyValue(k string, av AttributeValue) otlpcommon.KeyValue {
 func newAttributeKeyValueBytes(k string, v []byte) otlpcommon.KeyValue {
 	orig := otlpcommon.KeyValue{Key: k}
 	akv := AttributeValue{&orig.Value}
-	akv.SetBytesVal(v)
+	akv.SetBytesValue(v)
 	return orig
 }
 
@@ -631,7 +729,7 @@ func (am AttributeMap) Update(k string, v AttributeValue) {
 // No action is applied to the map where the key does not exist.
 func (am AttributeMap) UpdateString(k string, v string) {
 	if av, existing := am.Get(k); existing {
-		av.SetStringVal(v)
+		av.SetStringValue(v)
 	}
 }
 
@@ -639,7 +737,7 @@ func (am AttributeMap) UpdateString(k string, v string) {
 // No action is applied to the map where the key does not exist.
 func (am AttributeMap) UpdateInt(k string, v int64) {
 	if av, existing := am.Get(k); existing {
-		av.SetIntVal(v)
+		av.SetIntValue(v)
 	}
 }
 
@@ -647,7 +745,7 @@ func (am AttributeMap) UpdateInt(k string, v int64) {
 // No action is applied to the map where the key does not exist.
 func (am AttributeMap) UpdateDouble(k string, v float64) {
 	if av, existing := am.Get(k); existing {
-		av.SetDoubleVal(v)
+		av.SetDoubleValue(v)
 	}
 }
 
@@ -655,7 +753,7 @@ func (am AttributeMap) UpdateDouble(k string, v float64) {
 // No action is applied to the map where the key does not exist.
 func (am AttributeMap) UpdateBool(k string, v bool) {
 	if av, existing := am.Get(k); existing {
-		av.SetBoolVal(v)
+		av.SetBoolValue(v)
 	}
 }
 
@@ -665,7 +763,7 @@ func (am AttributeMap) UpdateBool(k string, v bool) {
 // across multiple attributes is forbidden.
 func (am AttributeMap) UpdateBytes(k string, v []byte) {
 	if av, existing := am.Get(k); existing {
-		av.SetBytesVal(v)
+		av.SetBytesValue(v)
 	}
 }
 
@@ -690,7 +788,7 @@ func (am AttributeMap) Upsert(k string, v AttributeValue) {
 // updated to the map where the key already existed.
 func (am AttributeMap) UpsertString(k string, v string) {
 	if av, existing := am.Get(k); existing {
-		av.SetStringVal(v)
+		av.SetStringValue(v)
 	} else {
 		*am.orig = append(*am.orig, newAttributeKeyValueString(k, v))
 	}
@@ -701,7 +799,7 @@ func (am AttributeMap) UpsertString(k string, v string) {
 // updated to the map where the key already existed.
 func (am AttributeMap) UpsertInt(k string, v int64) {
 	if av, existing := am.Get(k); existing {
-		av.SetIntVal(v)
+		av.SetIntValue(v)
 	} else {
 		*am.orig = append(*am.orig, newAttributeKeyValueInt(k, v))
 	}
@@ -712,7 +810,7 @@ func (am AttributeMap) UpsertInt(k string, v int64) {
 // updated to the map where the key already existed.
 func (am AttributeMap) UpsertDouble(k string, v float64) {
 	if av, existing := am.Get(k); existing {
-		av.SetDoubleVal(v)
+		av.SetDoubleValue(v)
 	} else {
 		*am.orig = append(*am.orig, newAttributeKeyValueDouble(k, v))
 	}
@@ -723,7 +821,7 @@ func (am AttributeMap) UpsertDouble(k string, v float64) {
 // updated to the map where the key already existed.
 func (am AttributeMap) UpsertBool(k string, v bool) {
 	if av, existing := am.Get(k); existing {
-		av.SetBoolVal(v)
+		av.SetBoolValue(v)
 	} else {
 		*am.orig = append(*am.orig, newAttributeKeyValueBool(k, v))
 	}
@@ -736,7 +834,7 @@ func (am AttributeMap) UpsertBool(k string, v bool) {
 // across multiple attributes is forbidden.
 func (am AttributeMap) UpsertBytes(k string, v []byte) {
 	if av, existing := am.Get(k); existing {
-		av.SetBytesVal(v)
+		av.SetBytesValue(v)
 	} else {
 		*am.orig = append(*am.orig, newAttributeKeyValueBytes(k, v))
 	}
@@ -809,21 +907,21 @@ func (am AttributeMap) AsRaw() map[string]interface{} {
 	am.Range(func(k string, v AttributeValue) bool {
 		switch v.Type() {
 		case AttributeValueTypeString:
-			rawMap[k] = v.StringVal()
+			rawMap[k] = v.StringValue()
 		case AttributeValueTypeInt:
-			rawMap[k] = v.IntVal()
+			rawMap[k] = v.IntValue()
 		case AttributeValueTypeDouble:
-			rawMap[k] = v.DoubleVal()
+			rawMap[k] = v.DoubleValue()
 		case AttributeValueTypeBool:
-			rawMap[k] = v.BoolVal()
+			rawMap[k] = v.BoolValue()
 		case AttributeValueTypeBytes:
-			rawMap[k] = v.BytesVal()
+			rawMap[k] = v.BytesValue()
 		case AttributeValueTypeEmpty:
 			rawMap[k] = nil
 		case AttributeValueTypeMap:
-			rawMap[k] = v.MapVal().AsRaw()
+			rawMap[k] = v.MapValue().AsRaw()
 		case AttributeValueTypeArray:
-			rawMap[k] = v.SliceVal().asRaw()
+			rawMap[k] = v.SliceValue().asRaw()
 		}
 		return true
 	})
@@ -837,15 +935,15 @@ func (es AttributeValueSlice) asRaw() []interface{} {
 		v := es.At(i)
 		switch v.Type() {
 		case AttributeValueTypeString:
-			rawSlice = append(rawSlice, v.StringVal())
+			rawSlice = append(rawSlice, v.StringValue())
 		case AttributeValueTypeInt:
-			rawSlice = append(rawSlice, v.IntVal())
+			rawSlice = append(rawSlice, v.IntValue())
 		case AttributeValueTypeDouble:
-			rawSlice = append(rawSlice, v.DoubleVal())
+			rawSlice = append(rawSlice, v.DoubleValue())
 		case AttributeValueTypeBool:
-			rawSlice = append(rawSlice, v.BoolVal())
+			rawSlice = append(rawSlice, v.BoolValue())
 		case AttributeValueTypeBytes:
-			rawSlice = append(rawSlice, v.BytesVal())
+			rawSlice = append(rawSlice, v.BytesValue())
 		case AttributeValueTypeEmpty:
 			rawSlice = append(rawSlice, nil)
 		default:

--- a/model/internal/pdata/common_test.go
+++ b/model/internal/pdata/common_test.go
@@ -1297,3 +1297,129 @@ func constructTestAttributeSubarray() AttributeValue {
 	value.SliceValue().AppendEmpty().SetStringValue("strTwo")
 	return value
 }
+
+func BenchmarkAttributeValueStringAccessor(b *testing.B) {
+	val := NewAttributeValueString("string value")
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		val.StringValue()
+	}
+}
+
+func BenchmarkAttributeValueIntAccessor(b *testing.B) {
+	val := NewAttributeValueInt(11)
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		val.IntValue()
+	}
+}
+
+func BenchmarkAttributeValueDoubleAccessor(b *testing.B) {
+	val := NewAttributeValueDouble(1.1)
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		val.DoubleValue()
+	}
+}
+
+func BenchmarkAttributeValueBoolAccessor(b *testing.B) {
+	val := NewAttributeValueBool(true)
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		val.BoolValue()
+	}
+}
+
+func BenchmarkAttributeValueBytesAccessor(b *testing.B) {
+	val := NewAttributeValueBytes([]byte{1, 2, 3, 4})
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		val.BytesValue()
+	}
+}
+
+func BenchmarkAttributeValueMapAccessor(b *testing.B) {
+	val := simpleAttributeValueMap()
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		val.MapValue()
+	}
+}
+
+func BenchmarkAttributeValueArrayAccessor(b *testing.B) {
+	val := simpleAttributeValueArray()
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		val.SliceValue()
+	}
+}
+
+func BenchmarkAttributeValueStringDeprecatedAccessor(b *testing.B) {
+	val := NewAttributeValueString("string value")
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		val.StringVal()
+	}
+}
+
+func BenchmarkAttributeValueIntDeprecatedAccessor(b *testing.B) {
+	val := NewAttributeValueInt(11)
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		val.IntVal()
+	}
+}
+
+func BenchmarkAttributeValueDoubleDeprecatedAccessor(b *testing.B) {
+	val := NewAttributeValueDouble(1.1)
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		val.DoubleVal()
+	}
+}
+
+func BenchmarkAttributeValueBoolDeprecatedAccessor(b *testing.B) {
+	val := NewAttributeValueBool(true)
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		val.BoolVal()
+	}
+}
+
+func BenchmarkAttributeValueBytesDeprecatedAccessor(b *testing.B) {
+	val := NewAttributeValueBytes([]byte{1, 2, 3, 4})
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		val.BytesVal()
+	}
+}
+
+func BenchmarkAttributeValueMapDeprecatedAccessor(b *testing.B) {
+	val := simpleAttributeValueMap()
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		val.MapVal()
+	}
+}
+
+func BenchmarkAttributeValueArrayDeprecatedAccessor(b *testing.B) {
+	val := simpleAttributeValueArray()
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		val.SliceVal()
+	}
+}


### PR DESCRIPTION
Make it consistent with Metric oneof data field: raise panic in case of type mismatch instead of returning a zero value.

The following methods are deprecated in favor of the new accessors:
- StringVal -> StringValue
- IntVal -> IntValue
- DoubleVal -> DoubleValue
- BoolVal -> BoolValue
- MapVal -> MapValue
- SliceVal -> SliceValue
- BytesVal -> BytesValue

Corresponding setter methods are also renamed for consistency without changing its logic:
- SetStringVal -> SetStringValue
- SetIntVal -> SetIntValue
- SetDoubleVal -> SetDoubleValue
- SetBoolVal -> SetBoolValue
- SetBytesVal -> SetBytesValue

Updates: https://github.com/open-telemetry/opentelemetry-collector/issues/4775

## Benchmarks

goos: darwin
goarch: amd64
pkg: go.opentelemetry.io/collector/model/internal/pdata
cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz

### Before

```
BenchmarkAttributeValueStringDeprecatedAccessor-16               	1000000000	         0.6580 ns/op	       0 B/op	       0 allocs/op
BenchmarkAttributeValueIntDeprecatedAccessor-16                  	1000000000	         0.6568 ns/op	       0 B/op	       0 allocs/op
BenchmarkAttributeValueDoubleDeprecatedAccessor-16               	1000000000	         0.6514 ns/op	       0 B/op	       0 allocs/op
BenchmarkAttributeValueBoolDeprecatedAccessor-16                 	1000000000	         0.7169 ns/op	       0 B/op	       0 allocs/op
BenchmarkAttributeValueBytesDeprecatedAccessor-16                	1000000000	         0.6539 ns/op	       0 B/op	       0 allocs/op
BenchmarkAttributeValueMapDeprecatedAccessor-16                  	487263888	         2.425 ns/op	       0 B/op	       0 allocs/op
BenchmarkAttributeValueArrayDeprecatedAccessor-16                	508004030	         2.372 ns/op	       0 B/op	       0 allocs/op
```

### After

```
BenchmarkAttributeValueStringAccessor-16                         	1000000000	         0.6713 ns/op	       0 B/op	       0 allocs/op
BenchmarkAttributeValueIntAccessor-16                            	1000000000	         0.6626 ns/op	       0 B/op	       0 allocs/op
BenchmarkAttributeValueDoubleAccessor-16                         	1000000000	         0.6548 ns/op	       0 B/op	       0 allocs/op
BenchmarkAttributeValueBoolAccessor-16                           	1000000000	         0.7929 ns/op	       0 B/op	       0 allocs/op
BenchmarkAttributeValueBytesAccessor-16                          	1000000000	         0.6972 ns/op	       0 B/op	       0 allocs/op
BenchmarkAttributeValueMapAccessor-16                            	1000000000	         0.9166 ns/op	       0 B/op	       0 allocs/op
BenchmarkAttributeValueArrayAccessor-16                          	1000000000	         0.9209 ns/op	       0 B/op	       0 allocs/op
```