### PR TITLE
Add RemoveIf to attribute map, and rename Delete to Remove

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,13 @@
 ### 🛑 Breaking changes 🛑
 
 - Remove `Type` funcs in pdata (#4933)
+- Rename `pdata.AttributeMap.Delete` to `pdata.AttributeMap.Remove` (#4914)
 
-## 🧰 Bug fixes 🧰
+### 💡 Enhancements 💡
+
+- Add `pdata.AttributeMap.RemoveIf`, which is a more performant way to remove multiple keys (#4914)
+
+### 🧰 Bug fixes 🧰
 
 - Collector `Run` will now exit when a context cancels (#4954)
 

--- a/model/internal/pdata/common.go
+++ b/model/internal/pdata/common.go
@@ -513,7 +513,7 @@ func (am AttributeMap) Get(key string) (AttributeValue, bool) {
 
 // Delete deletes the entry associated with the key and returns true if the key
 // was present in the map, otherwise returns false.
-// Deprecated: Use Remove instead.
+// Deprecated: [v0.46.0] Use Remove instead.
 func (am AttributeMap) Delete(key string) bool {
 	return am.Remove(key)
 }

--- a/model/internal/pdata/common.go
+++ b/model/internal/pdata/common.go
@@ -525,6 +525,26 @@ func (am AttributeMap) Delete(key string) bool {
 	return false
 }
 
+// DeleteIf deletes the entries for which the function in question returns true
+func (am AttributeMap) DeleteIf(f func(string, AttributeValue) bool) {
+	newLen := 0
+	for i := 0; i < len(*am.orig); i++ {
+		akv := &(*am.orig)[i]
+		if f(akv.Key, AttributeValue{&akv.Value}) {
+			continue
+		}
+		if newLen == i {
+			// Nothing to move, element is at the right place.
+			newLen++
+			continue
+		}
+		(*am.orig)[newLen] = (*am.orig)[i]
+		newLen++
+	}
+	// TODO: Prevent memory leak by erasing truncated values.
+	*am.orig = (*am.orig)[:newLen]
+}
+
 // Insert adds the AttributeValue to the map when the key does not exist.
 // No action is applied to the map where the key already exists.
 //

--- a/model/internal/pdata/common.go
+++ b/model/internal/pdata/common.go
@@ -513,7 +513,14 @@ func (am AttributeMap) Get(key string) (AttributeValue, bool) {
 
 // Delete deletes the entry associated with the key and returns true if the key
 // was present in the map, otherwise returns false.
+// Deprecated: Use Remove instead.
 func (am AttributeMap) Delete(key string) bool {
+	return am.Remove(key)
+}
+
+// Remove removes the entry associated with the key and returns true if the key
+// was present in the map, otherwise returns false.
+func (am AttributeMap) Remove(key string) bool {
 	for i := range *am.orig {
 		akv := &(*am.orig)[i]
 		if akv.Key == key {
@@ -525,8 +532,8 @@ func (am AttributeMap) Delete(key string) bool {
 	return false
 }
 
-// DeleteIf deletes the entries for which the function in question returns true
-func (am AttributeMap) DeleteIf(f func(string, AttributeValue) bool) {
+// RemoveIf removes the entries for which the function in question returns true
+func (am AttributeMap) RemoveIf(f func(string, AttributeValue) bool) {
 	newLen := 0
 	for i := 0; i < len(*am.orig); i++ {
 		akv := &(*am.orig)[i]

--- a/model/internal/pdata/common.go
+++ b/model/internal/pdata/common.go
@@ -548,7 +548,6 @@ func (am AttributeMap) RemoveIf(f func(string, AttributeValue) bool) {
 		(*am.orig)[newLen] = (*am.orig)[i]
 		newLen++
 	}
-	// TODO: Prevent memory leak by erasing truncated values.
 	*am.orig = (*am.orig)[:newLen]
 }
 

--- a/model/internal/pdata/common_test.go
+++ b/model/internal/pdata/common_test.go
@@ -138,14 +138,14 @@ func TestAttributeValueMap(t *testing.T) {
 	require.True(t, exists)
 	assert.Equal(t, NewAttributeValueString("somestr2"), got)
 
-	deleted := m1.MapVal().Delete("double_key")
-	assert.True(t, deleted)
+	removed := m1.MapVal().Remove("double_key")
+	assert.True(t, removed)
 	assert.EqualValues(t, 1, m1.MapVal().Len())
 	_, exists = m1.MapVal().Get("double_key")
 	assert.False(t, exists)
 
-	deleted = m1.MapVal().Delete("child_map")
-	assert.True(t, deleted)
+	removed = m1.MapVal().Remove("child_map")
+	assert.True(t, removed)
 	assert.EqualValues(t, 0, m1.MapVal().Len())
 	_, exists = m1.MapVal().Get("child_map")
 	assert.False(t, exists)
@@ -348,9 +348,9 @@ func TestNilAttributeMap(t *testing.T) {
 	upsertMapBytes.UpsertBytes("k", []byte{1, 2, 3, 4, 5})
 	assert.EqualValues(t, generateTestBytesAttributeMap(), upsertMapBytes)
 
-	deleteMap := NewAttributeMap()
-	assert.False(t, deleteMap.Delete("k"))
-	assert.EqualValues(t, NewAttributeMap(), deleteMap)
+	removeMap := NewAttributeMap()
+	assert.False(t, removeMap.Remove("k"))
+	assert.EqualValues(t, NewAttributeMap(), removeMap)
 
 	// Test Sort
 	assert.EqualValues(t, NewAttributeMap(), NewAttributeMap().Sort())
@@ -525,20 +525,20 @@ func TestAttributeMapWithEmpty(t *testing.T) {
 	assert.EqualValues(t, AttributeValueTypeBytes, val.Type())
 	assert.EqualValues(t, []byte{1}, val.BytesVal())
 
-	assert.True(t, sm.Delete("other_key"))
-	assert.True(t, sm.Delete("other_key_string"))
-	assert.True(t, sm.Delete("other_key_int"))
-	assert.True(t, sm.Delete("other_key_double"))
-	assert.True(t, sm.Delete("other_key_bool"))
-	assert.True(t, sm.Delete("other_key_bytes"))
-	assert.True(t, sm.Delete("yet_another_key"))
-	assert.True(t, sm.Delete("yet_another_key_string"))
-	assert.True(t, sm.Delete("yet_another_key_int"))
-	assert.True(t, sm.Delete("yet_another_key_double"))
-	assert.True(t, sm.Delete("yet_another_key_bool"))
-	assert.True(t, sm.Delete("yet_another_key_bytes"))
-	assert.False(t, sm.Delete("other_key"))
-	assert.False(t, sm.Delete("yet_another_key"))
+	assert.True(t, sm.Remove("other_key"))
+	assert.True(t, sm.Remove("other_key_string"))
+	assert.True(t, sm.Remove("other_key_int"))
+	assert.True(t, sm.Remove("other_key_double"))
+	assert.True(t, sm.Remove("other_key_bool"))
+	assert.True(t, sm.Remove("other_key_bytes"))
+	assert.True(t, sm.Remove("yet_another_key"))
+	assert.True(t, sm.Remove("yet_another_key_string"))
+	assert.True(t, sm.Remove("yet_another_key_int"))
+	assert.True(t, sm.Remove("yet_another_key_double"))
+	assert.True(t, sm.Remove("yet_another_key_bool"))
+	assert.True(t, sm.Remove("yet_another_key_bytes"))
+	assert.False(t, sm.Remove("other_key"))
+	assert.False(t, sm.Remove("yet_another_key"))
 
 	// Test that the initial key is still there.
 	val, exist = sm.Get("test_key")
@@ -731,7 +731,7 @@ func TestAttributeMap_Clear(t *testing.T) {
 	assert.Nil(t, *am.orig)
 }
 
-func TestAttributeMap_DeleteIf(t *testing.T) {
+func TestAttributeMap_RemoveIf(t *testing.T) {
 	rawMap := map[string]AttributeValue{
 		"k_string": NewAttributeValueString("123"),
 		"k_int":    NewAttributeValueInt(123),
@@ -743,7 +743,7 @@ func TestAttributeMap_DeleteIf(t *testing.T) {
 	am := NewAttributeMapFromMap(rawMap)
 	assert.Equal(t, 6, am.Len())
 
-	am.DeleteIf(func(key string, val AttributeValue) bool {
+	am.RemoveIf(func(key string, val AttributeValue) bool {
 		return key == "k_int" || val.Type() == AttributeValueTypeBool
 	})
 	assert.Equal(t, 4, am.Len())
@@ -827,12 +827,12 @@ func BenchmarkAttributeMap_RangeOverMap(b *testing.B) {
 	}
 }
 
-func BenchmarkAttributeMap_Delete(b *testing.B) {
+func BenchmarkAttributeMap_Remove(b *testing.B) {
 	b.StopTimer()
-	// Delete all of the even keys
-	keysToDelete := map[string]struct{}{}
+	// Remove all of the even keys
+	keysToRemove := map[string]struct{}{}
 	for j := 0; j < 50; j++ {
-		keysToDelete[fmt.Sprintf("%d", j*2)] = struct{}{}
+		keysToRemove[fmt.Sprintf("%d", j*2)] = struct{}{}
 	}
 	for i := 0; i < b.N; i++ {
 		m := NewAttributeMap()
@@ -840,19 +840,19 @@ func BenchmarkAttributeMap_Delete(b *testing.B) {
 			m.InsertString(fmt.Sprintf("%d", j), "string value")
 		}
 		b.StartTimer()
-		for k := range keysToDelete {
-			m.Delete(k)
+		for k := range keysToRemove {
+			m.Remove(k)
 		}
 		b.StopTimer()
 	}
 }
 
-func BenchmarkAttributeMap_DeleteIf(b *testing.B) {
+func BenchmarkAttributeMap_RemoveIf(b *testing.B) {
 	b.StopTimer()
-	// Delete all of the even keys
-	keysToDelete := map[string]struct{}{}
+	// Remove all of the even keys
+	keysToRemove := map[string]struct{}{}
 	for j := 0; j < 50; j++ {
-		keysToDelete[fmt.Sprintf("%d", j*2)] = struct{}{}
+		keysToRemove[fmt.Sprintf("%d", j*2)] = struct{}{}
 	}
 	for i := 0; i < b.N; i++ {
 		m := NewAttributeMap()
@@ -860,9 +860,9 @@ func BenchmarkAttributeMap_DeleteIf(b *testing.B) {
 			m.InsertString(fmt.Sprintf("%d", j), "string value")
 		}
 		b.StartTimer()
-		m.DeleteIf(func(key string, _ AttributeValue) bool {
-			_, delete := keysToDelete[key]
-			return delete
+		m.RemoveIf(func(key string, _ AttributeValue) bool {
+			_, remove := keysToRemove[key]
+			return remove
 		})
 		b.StopTimer()
 	}

--- a/model/internal/pdata/metrics_test.go
+++ b/model/internal/pdata/metrics_test.go
@@ -357,7 +357,7 @@ func TestOtlpToFromInternalGaugeMutating(t *testing.T) {
 	assert.EqualValues(t, endTime+1, gaugeDataPoints.At(0).Timestamp())
 	gaugeDataPoints.At(0).SetDoubleVal(124.1)
 	assert.EqualValues(t, 124.1, gaugeDataPoints.At(0).DoubleVal())
-	gaugeDataPoints.At(0).Attributes().Delete("key0")
+	gaugeDataPoints.At(0).Attributes().Remove("key0")
 	gaugeDataPoints.At(0).Attributes().UpsertString("k", "v")
 	assert.EqualValues(t, newAttributes, gaugeDataPoints.At(0).Attributes())
 
@@ -441,7 +441,7 @@ func TestOtlpToFromInternalSumMutating(t *testing.T) {
 	assert.EqualValues(t, endTime+1, doubleDataPoints.At(0).Timestamp())
 	doubleDataPoints.At(0).SetDoubleVal(124.1)
 	assert.EqualValues(t, 124.1, doubleDataPoints.At(0).DoubleVal())
-	doubleDataPoints.At(0).Attributes().Delete("key0")
+	doubleDataPoints.At(0).Attributes().Remove("key0")
 	doubleDataPoints.At(0).Attributes().UpsertString("k", "v")
 	assert.EqualValues(t, newAttributes, doubleDataPoints.At(0).Attributes())
 
@@ -524,7 +524,7 @@ func TestOtlpToFromInternalHistogramMutating(t *testing.T) {
 	assert.EqualValues(t, startTime+1, histogramDataPoints.At(0).StartTimestamp())
 	histogramDataPoints.At(0).SetTimestamp(Timestamp(endTime + 1))
 	assert.EqualValues(t, endTime+1, histogramDataPoints.At(0).Timestamp())
-	histogramDataPoints.At(0).Attributes().Delete("key0")
+	histogramDataPoints.At(0).Attributes().Remove("key0")
 	histogramDataPoints.At(0).Attributes().UpsertString("k", "v")
 	assert.EqualValues(t, newAttributes, histogramDataPoints.At(0).Attributes())
 	histogramDataPoints.At(0).SetExplicitBounds([]float64{1})
@@ -608,7 +608,7 @@ func TestOtlpToFromInternalExponentialHistogramMutating(t *testing.T) {
 	assert.EqualValues(t, startTime+1, histogramDataPoints.At(0).StartTimestamp())
 	histogramDataPoints.At(0).SetTimestamp(Timestamp(endTime + 1))
 	assert.EqualValues(t, endTime+1, histogramDataPoints.At(0).Timestamp())
-	histogramDataPoints.At(0).Attributes().Delete("key0")
+	histogramDataPoints.At(0).Attributes().Remove("key0")
 	histogramDataPoints.At(0).Attributes().UpsertString("k", "v")
 	assert.EqualValues(t, newAttributes, histogramDataPoints.At(0).Attributes())
 	// Test that everything is updated.


### PR DESCRIPTION
**Description:**

Fixes https://github.com/open-telemetry/opentelemetry-collector/issues/4756 by adding RemoveIf for AttributeMap.  The implementation (and TODO) are based on the RemoveIf for AttributeValueSlice: https://github.com/open-telemetry/opentelemetry-collector/blob/model/v0.43.1/model/pdata/generated_common.go#L181

**Testing:**
Unit tests added.

Benchmark added to compare performance of Remove to RemoveIf when deleting a large number of elements.

```
$ go test -bench=.
goos: linux
goarch: amd64
pkg: go.opentelemetry.io/collector/model/pdata
cpu: Intel(R) Xeon(R) CPU @ 2.20GHz
...
BenchmarkAttributeMap_Remove-16                                  	   94230	     12897 ns/op
BenchmarkAttributeMap_RemoveIf-16                                	  374329	      3345 ns/op
...
```