### PR TITLE
Add a NewConfigProvider that uses options for settings, and does input validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,6 @@
 
 - Deprecate configmapprovider package, replace with mapconverter (#5167)
 - Deprecate `service.MustNewConfigProvider` and `service.MustNewDefaultConfigProvider`in favor of `service.NewConfigProvider` (#4762)
-  - There is no equivalent to provide custom ConfigUnmarshaler, if you need to apply changes to the parsed config wrap the default ConfigProvider.
->>>>>>> 2daa6ab9 (Change deprecated NewConfigProvider to use options and do input validation)
 
 ### 💡 Enhancements 💡
 
@@ -50,7 +48,6 @@
 
 - Move MapProvider to config, split providers in their own package (#5030)
 - API related to `pdata.AttributeValue` is deprecated in favor of `pdata.Value` (#4978)
-- API related to `pdata.AttributeValue` is deprecated in favor of `pdata.Value` (#4975)
   - `pdata.AttributeValue` struct is deprecated in favor of `pdata.Value`
   - `pdata.AttributeValueType` type is deprecated in favor of `pdata.ValueType`
   - `pdata.AttributeValueType...` constants are deprecated in favor of `pdata.ValueType...`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
 ### 🚩 Deprecations 🚩
 
 - Deprecate configmapprovider package, replace with mapconverter (#5167)
+- Deprecate `service.MustNewConfigProvider` and `service.MustNewDefaultConfigProvider`in favor of `service.NewConfigProvider` (#4762)
+  - There is no equivalent to provide custom ConfigUnmarshaler, if you need to apply changes to the parsed config wrap the default ConfigProvider.
+>>>>>>> 2daa6ab9 (Change deprecated NewConfigProvider to use options and do input validation)
 
 ### 💡 Enhancements 💡
 
@@ -47,6 +50,7 @@
 
 - Move MapProvider to config, split providers in their own package (#5030)
 - API related to `pdata.AttributeValue` is deprecated in favor of `pdata.Value` (#4978)
+- API related to `pdata.AttributeValue` is deprecated in favor of `pdata.Value` (#4975)
   - `pdata.AttributeValue` struct is deprecated in favor of `pdata.Value`
   - `pdata.AttributeValueType` type is deprecated in favor of `pdata.ValueType`
   - `pdata.AttributeValueType...` constants are deprecated in favor of `pdata.ValueType...`

--- a/service/collector_windows.go
+++ b/service/collector_windows.go
@@ -30,7 +30,7 @@ import (
 	"golang.org/x/sys/windows/svc/eventlog"
 
 	"go.opentelemetry.io/collector/config"
-	"go.opentelemetry.io/collector/config/configmapprovider"
+	"go.opentelemetry.io/collector/config/mapconverter/overwritepropertiesmapconverter"
 	"go.opentelemetry.io/collector/service/featuregate"
 )
 
@@ -147,11 +147,13 @@ func openEventLog(serviceName string) (*eventlog.Log, error) {
 func newWithWindowsEventLogCore(set CollectorSettings, elog *eventlog.Log) (*Collector, error) {
 	if set.ConfigProvider == nil {
 		var err error
-		set.ConfigProvider, err = NewConfigProvider(
-			getConfigFlag(),
-			WithConfigMapConverters([]config.MapConverterFunc{
-				configmapprovider.NewOverwritePropertiesConverter(getSetFlag()),
-				configmapprovider.NewExpandConverter()}))
+		cfgSet := newDefaultConfigProviderSettings()
+		cfgSet.Locations = getConfigFlag()
+		// Append the "overwrite properties converter" as the first converter.
+		cfgSet.MapConverters = append(
+			[]config.MapConverterFunc{overwritepropertiesmapconverter.New(getSetFlag())},
+			cfgSet.MapConverters...)
+		set.ConfigProvider, err = NewConfigProvider(cfgSet)
 		if err != nil {
 			return nil, err
 		}

--- a/service/command.go
+++ b/service/command.go
@@ -16,10 +16,10 @@ package service // import "go.opentelemetry.io/collector/service"
 
 import (
 	"github.com/spf13/cobra"
-	"go.opentelemetry.io/collector/config/mapconverter/overwritepropertiesmapconverter"
 
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/mapconverter/expandmapconverter"
+	"go.opentelemetry.io/collector/config/mapconverter/overwritepropertiesmapconverter"
 	"go.opentelemetry.io/collector/service/featuregate"
 )
 

--- a/service/config_provider.go
+++ b/service/config_provider.go
@@ -93,7 +93,7 @@ type ConfigProviderSettings struct {
 	MapConverters []config.MapConverterFunc
 
 	// The configunmarshaler.ConfigUnmarshaler to be used to unmarshal the config.Map into config.Config.
-	// It is required to not be nit, use configunmarshaler.NewDefault() by default.
+	// It is required to not be nil, use configunmarshaler.NewDefault() by default.
 	Unmarshaler configunmarshaler.ConfigUnmarshaler
 }
 

--- a/service/config_provider.go
+++ b/service/config_provider.go
@@ -99,9 +99,6 @@ func WithConfigMapConverters(c []config.MapConverterFunc) ConfigProviderOption {
 }
 
 // WithConfigUnmarshaler overwrites the default unmarshaler.
-// Deprecated: [v0.49.0] because providing custom ConfigUnmarshaler is not necessary since users can wrap/implement
-// ConfigProvider if needed to change the resulted config. This functionality will be kept for at least 2 minor versions,
-// and if nobody express a need for it will be removed.
 func WithConfigUnmarshaler(c configunmarshaler.ConfigUnmarshaler) ConfigProviderOption {
 	return func(opts *configProvider) {
 		opts.configUnmarshaler = c

--- a/service/config_provider.go
+++ b/service/config_provider.go
@@ -25,10 +25,10 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/config/configmapprovider"
 	"go.opentelemetry.io/collector/config/configunmarshaler"
 	"go.opentelemetry.io/collector/config/experimental/configsource"
 	"go.opentelemetry.io/collector/config/mapconverter/expandmapconverter"
-	"go.opentelemetry.io/collector/config/mapconverter/overwritepropertiesmapconverter"
 	"go.opentelemetry.io/collector/config/mapprovider/envmapprovider"
 	"go.opentelemetry.io/collector/config/mapprovider/filemapprovider"
 	"go.opentelemetry.io/collector/config/mapprovider/yamlmapprovider"
@@ -69,50 +69,113 @@ type ConfigProvider interface {
 }
 
 type configProvider struct {
-	locations          []string
-	configMapProviders map[string]config.MapProvider
-	cfgMapConverters   []config.MapConverterFunc
-	configUnmarshaler  configunmarshaler.ConfigUnmarshaler
+	locations           []string
+	configMapProviders  map[string]config.MapProvider
+	configMapConverters []config.MapConverterFunc
+	configUnmarshaler   configunmarshaler.ConfigUnmarshaler
 
 	sync.Mutex
 	closer  config.CloseFunc
 	watcher chan error
 }
 
-// MustNewConfigProvider returns a new ConfigProvider that provides the configuration:
-// * Retrieve the config.Map by merging all retrieved maps from all the config.MapProvider in order.
-// * Then applies all the ConfigMapConverterFunc in the given order.
-// * Then unmarshalls the final config.Config using the given configunmarshaler.ConfigUnmarshaler.
-//
-// The `configMapProviders` is a map of pairs <scheme,Provider>.
+// ConfigProviderOption is an option to change the behavior of ConfigProvider
+// returned by NewConfigProvider()
+type ConfigProviderOption func(opts *configProvider)
+
+// WithConfigMapProvider appends to the default available providers.
+// This provider overwrites any existing provider with the same scheme.
+func WithConfigMapProvider(mp config.MapProvider) ConfigProviderOption {
+	return func(opts *configProvider) {
+		opts.configMapProviders[mp.Scheme()] = mp
+	}
+}
+
+// WithConfigMapConverters overwrites the default converters.
+func WithConfigMapConverters(c []config.MapConverterFunc) ConfigProviderOption {
+	return func(opts *configProvider) {
+		opts.configMapConverters = c
+	}
+}
+
+// WithConfigUnmarshaler overwrites the default unmarshaler.
+// Deprecated: [v0.49.0] because providing custom ConfigUnmarshaler is not necessary since users can wrap/implement
+// ConfigProvider if needed to change the resulted config. This functionality will be kept for at least 2 minor versions,
+// and if nobody express a need for it will be removed.
+func WithConfigUnmarshaler(c configunmarshaler.ConfigUnmarshaler) ConfigProviderOption {
+	return func(opts *configProvider) {
+		opts.configUnmarshaler = c
+	}
+}
+
+// Deprecated: [v0.49.0] use NewConfigProvider instead.
 func MustNewConfigProvider(
 	locations []string,
 	configMapProviders map[string]config.MapProvider,
 	cfgMapConverters []config.MapConverterFunc,
 	configUnmarshaler configunmarshaler.ConfigUnmarshaler) ConfigProvider {
+	opts := []ConfigProviderOption{
+		WithConfigMapConverters(cfgMapConverters),
+		WithConfigUnmarshaler(configUnmarshaler),
+	}
+	for _, c := range configMapProviders {
+		opts = append(opts, WithConfigMapProvider(c))
+	}
+	cfgProvider, err := NewConfigProvider(locations, opts...)
+	if err != nil {
+		panic(err)
+	}
+	return cfgProvider
+}
+
+// NewConfigProvider returns a new ConfigProvider that provides the configuration:
+// * Retrieve the config.Map by merging all retrieved maps from the given `locations` in order.
+// * Then applies all the config.MapConverterFunc in the given order.
+// * Then unmarshals the config.Map into the service Config.
+func NewConfigProvider(locations []string, opts ...ConfigProviderOption) (ConfigProvider, error) {
+	if len(locations) == 0 {
+		return nil, fmt.Errorf("cannot create ConfigProvider: no locations provided")
+	}
 	// Safe copy, ensures the slice cannot be changed from the caller.
 	locationsCopy := make([]string, len(locations))
 	copy(locationsCopy, locations)
-	return &configProvider{
-		locations:          locationsCopy,
-		configMapProviders: configMapProviders,
-		cfgMapConverters:   cfgMapConverters,
-		configUnmarshaler:  configUnmarshaler,
-		watcher:            make(chan error, 1),
-	}
-}
 
-// MustNewDefaultConfigProvider returns the default ConfigProvider from slice of location strings
-// (e.g. file:/path/to/config.yaml) and property overrides (e.g. service.telemetry.metrics.address=localhost:8888).
-func MustNewDefaultConfigProvider(configLocations []string, properties []string) ConfigProvider {
-	return MustNewConfigProvider(
-		configLocations,
-		makeConfigMapProviderMap(filemapprovider.New(), envmapprovider.New(), yamlmapprovider.New()),
-		[]config.MapConverterFunc{
-			overwritepropertiesmapconverter.New(properties),
+	opts = append([]ConfigProviderOption{
+		WithConfigMapProvider(filemapprovider.New()),
+		WithConfigMapProvider(envmapprovider.New()),
+		WithConfigMapProvider(yamlmapprovider.New()),
+	}, opts...)
+
+	provider := configProvider{
+		locations:          locationsCopy,
+		configMapProviders: make(map[string]config.MapProvider),
+		configMapConverters: []config.MapConverterFunc{
 			expandmapconverter.New(),
 		},
-		configunmarshaler.NewDefault())
+		configUnmarshaler: configunmarshaler.NewDefault(),
+		watcher:           make(chan error, 1),
+	}
+
+	// Override default values with user options
+	for _, o := range opts {
+		o(&provider)
+	}
+
+	return &provider, nil
+}
+
+// Deprecated: [v0.49.0] use NewConfigProvider instead.
+func MustNewDefaultConfigProvider(configLocations []string, properties []string) ConfigProvider {
+	cfgProvider, err := NewConfigProvider(
+		configLocations,
+		WithConfigMapConverters([]config.MapConverterFunc{
+			configmapprovider.NewOverwritePropertiesConverter(properties),
+			configmapprovider.NewExpandConverter(),
+		}))
+	if err != nil {
+		panic(err)
+	}
+	return cfgProvider
 }
 
 func (cm *configProvider) Get(ctx context.Context, factories component.Factories) (*config.Config, error) {
@@ -128,7 +191,7 @@ func (cm *configProvider) Get(ctx context.Context, factories component.Factories
 	cm.closer = ret.CloseFunc
 
 	// Apply all converters.
-	for _, cfgMapConv := range cm.cfgMapConverters {
+	for _, cfgMapConv := range cm.configMapConverters {
 		if err = cfgMapConv(ctx, ret.Map); err != nil {
 			return nil, fmt.Errorf("cannot convert the config.Map: %w", err)
 		}
@@ -218,12 +281,4 @@ func (cm *configProvider) mergeRetrieve(ctx context.Context) (*config.Retrieved,
 			return err
 		},
 	}, nil
-}
-
-func makeConfigMapProviderMap(providers ...config.MapProvider) map[string]config.MapProvider {
-	ret := make(map[string]config.MapProvider, len(providers))
-	for _, provider := range providers {
-		ret[provider.Scheme()] = provider
-	}
-	return ret
 }

--- a/service/config_provider_test.go
+++ b/service/config_provider_test.go
@@ -34,7 +34,7 @@ import (
 )
 
 type mockProvider struct {
-	shceme string
+	scheme string
 	retM   *config.Map
 	errR   error
 	errS   error
@@ -56,10 +56,10 @@ func (m *mockProvider) Retrieve(_ context.Context, _ string, watcher config.Watc
 }
 
 func (m *mockProvider) Scheme() string {
-	if m.shceme == "" {
+	if m.scheme == "" {
 		return "mock"
 	}
-	return m.shceme
+	return m.scheme
 }
 
 func (m *mockProvider) Shutdown(context.Context) error {
@@ -100,7 +100,7 @@ func TestConfigProvider_Errors(t *testing.T) {
 			locations: []string{"mock:", "err:"},
 			parserProvider: []config.MapProvider{
 				&mockProvider{},
-				&mockProvider{shceme: "err", errR: errors.New("retrieve_err")},
+				&mockProvider{scheme: "err", errR: errors.New("retrieve_err")},
 			},
 			configUnmarshaler: configunmarshaler.NewDefault(),
 			expectNewErr:      true,
@@ -133,7 +133,7 @@ func TestConfigProvider_Errors(t *testing.T) {
 			parserProvider: func() []config.MapProvider {
 				cfgMap, err := configtest.LoadConfigMap(filepath.Join("testdata", "otelcol-nop.yaml"))
 				require.NoError(t, err)
-				return []config.MapProvider{&mockProvider{}, &mockProvider{shceme: "err", retM: cfgMap, errW: errors.New("watch_err")}}
+				return []config.MapProvider{&mockProvider{}, &mockProvider{scheme: "err", retM: cfgMap, errW: errors.New("watch_err")}}
 			}(),
 			configUnmarshaler: configunmarshaler.NewDefault(),
 			expectWatchErr:    true,
@@ -146,7 +146,7 @@ func TestConfigProvider_Errors(t *testing.T) {
 				require.NoError(t, err)
 				return []config.MapProvider{
 					&mockProvider{},
-					&mockProvider{shceme: "err", retM: cfgMap, errC: errors.New("close_err")},
+					&mockProvider{scheme: "err", retM: cfgMap, errC: errors.New("close_err")},
 				}
 			}(),
 			configUnmarshaler: configunmarshaler.NewDefault(),


### PR DESCRIPTION
This is a fork of https://github.com/open-telemetry/opentelemetry-collector/pull/4762

Also, deprecates `service.MustNewConfigProvider` and `service.MustNewDefaultConfigProvider`in favor of `service.NewConfigProvider`.


Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
