### PR TITLE
added option to enable server reflection on the otlp receiver

### DIFF
--- a/config/configgrpc/configgrpc.go
+++ b/config/configgrpc/configgrpc.go
@@ -157,6 +157,9 @@ type GRPCServerSettings struct {
 	// Include propagates the incoming connection's metadata to downstream consumers.
 	// Experimental: *NOTE* this option is subject to change or removal in the future.
 	IncludeMetadata bool `mapstructure:"include_metadata,omitempty"`
+
+	// EnableReflection will add grpc reflection apis to the receiver
+	EnableReflection bool `mapstructure:"enable_reflection,omitempty"`
 }
 
 // SanitizedEndpoint strips the prefix of either http:// or https:// from configgrpc.GRPCClientSettings.Endpoint.

--- a/receiver/otlpreceiver/otlp.go
+++ b/receiver/otlpreceiver/otlp.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/gorilla/mux"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/reflection"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenterror"
@@ -121,6 +122,10 @@ func (r *otlpReceiver) startProtocolServers(host component.Host) error {
 
 		if r.logReceiver != nil {
 			otlpgrpc.RegisterLogsServer(r.serverGRPC, r.logReceiver)
+		}
+
+		if r.cfg.GRPC.EnableReflection {
+			reflection.Register(r.serverGRPC)
 		}
 
 		err = r.startGRPCServer(r.cfg.GRPC, host)


### PR DESCRIPTION
**Description:** Adding a feature - added option to enable grpc reflection on the otlp receiver
**Link to tracking Issue:** #4951
**Testing:** no additional testing
**Documentation:** no additional documentation
