### PR TITLE
Collector Run will listen for context done

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Remove `Type` funcs in pdata (#4933)
 
+## 🧰 Bug fixes 🧰
+
+- Collector `Run` will now exit when a context cancels ()
+
 ## v0.46.0 Beta
 
 ### 🛑 Breaking changes 🛑

--- a/service/collector.go
+++ b/service/collector.go
@@ -174,6 +174,10 @@ LOOP:
 		case <-col.shutdownChan:
 			col.logger.Info("Received shutdown request")
 			break LOOP
+		case <-ctx.Done():
+			col.logger.Error("Context done, terminating process", zap.Error(ctx.Err()))
+			// Call shutdown with background context as the passed in context has been canceled
+			return col.shutdown(context.Background())
 		}
 	}
 	return col.shutdown(ctx)


### PR DESCRIPTION
**Description:** <Describe what has changed. 
Fixes #4842 

Added listening for `<-ctx.Done()` in `Run` select so if the passed in context cancels the collector will too.

There was a weird pattern though where internal `shutdown` takes a context and currently it's the passed in one. For the case of context cancelling I called the `shutdown` function with background context. Wondering if we want to put a timer on this or if we want to always use background context on `shutdown`. I could see a scenario where the collector is shutting down and the passed in context is canceled and interrupts the graceful shutdown.

**Link to tracking Issue:** #4842 

**Testing:** Added unit test
