### PR TITLE
pdata: deprecate funcs working with InternalRep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### 🛑 Breaking changes 🛑
 
 - Remove `Type` funcs in pdata (#4933)
+- pdata: deprecate funcs working with InternalRep (#4957)
 
 ## 🧰 Bug fixes 🧰
 

--- a/model/internal/otlp_wrapper.go
+++ b/model/internal/otlp_wrapper.go
@@ -14,59 +14,11 @@
 
 package internal // import "go.opentelemetry.io/collector/model/internal"
 
-import (
-	otlplogs "go.opentelemetry.io/collector/model/internal/data/protogen/logs/v1"
-	otlpmetrics "go.opentelemetry.io/collector/model/internal/data/protogen/metrics/v1"
-	otlptrace "go.opentelemetry.io/collector/model/internal/data/protogen/trace/v1"
-)
+// Deprecated: [v0.47.0] will be removed soon, only used internally.
+type MetricsWrapper struct{}
 
-// MetricsWrapper is an intermediary struct that is declared in an internal package
-// as a way to prevent certain functions of pdata.Metrics data type to be callable by
-// any code outside of this module.
-type MetricsWrapper struct {
-	req *otlpmetrics.MetricsData
-}
+// Deprecated: [v0.47.0] will be removed soon, only used internally.
+type TracesWrapper struct{}
 
-// MetricsToOtlp internal helper to convert MetricsWrapper to protobuf representation.
-func MetricsToOtlp(mw MetricsWrapper) *otlpmetrics.MetricsData {
-	return mw.req
-}
-
-// MetricsFromOtlp internal helper to convert protobuf representation to MetricsWrapper.
-func MetricsFromOtlp(req *otlpmetrics.MetricsData) MetricsWrapper {
-	return MetricsWrapper{req: req}
-}
-
-// TracesWrapper is an intermediary struct that is declared in an internal package
-// as a way to prevent certain functions of pdata.Traces data type to be callable by
-// any code outside of this module.
-type TracesWrapper struct {
-	req *otlptrace.TracesData
-}
-
-// TracesToOtlp internal helper to convert TracesWrapper to protobuf representation.
-func TracesToOtlp(mw TracesWrapper) *otlptrace.TracesData {
-	return mw.req
-}
-
-// TracesFromOtlp internal helper to convert protobuf representation to TracesWrapper.
-func TracesFromOtlp(req *otlptrace.TracesData) TracesWrapper {
-	return TracesWrapper{req: req}
-}
-
-// LogsWrapper is an intermediary struct that is declared in an internal package
-// as a way to prevent certain functions of pdata.Logs data type to be callable by
-// any code outside of this module.
-type LogsWrapper struct {
-	req *otlplogs.LogsData
-}
-
-// LogsToOtlp internal helper to convert LogsWrapper to protobuf representation.
-func LogsToOtlp(l LogsWrapper) *otlplogs.LogsData {
-	return l.req
-}
-
-// LogsFromOtlp internal helper to convert protobuf representation to LogsWrapper.
-func LogsFromOtlp(req *otlplogs.LogsData) LogsWrapper {
-	return LogsWrapper{req: req}
-}
+// Deprecated: [v0.47.0] will be removed soon, only used internally.
+type LogsWrapper struct{}

--- a/model/internal/pdata/logs.go
+++ b/model/internal/pdata/logs.go
@@ -51,18 +51,9 @@ func NewLogs() Logs {
 	return Logs{orig: &otlplogs.LogsData{}}
 }
 
-// LogsFromInternalRep creates the internal Logs representation from the ProtoBuf. Should
-// not be used outside this module. This is intended to be used only by OTLP exporter and
-// File exporter, which legitimately need to work with OTLP Protobuf structs.
-func LogsFromInternalRep(logs internal.LogsWrapper) Logs {
-	return Logs{orig: internal.LogsToOtlp(logs)}
-}
-
-// InternalRep returns internal representation of the logs. Should not be used outside
-// this module. This is intended to be used only by OTLP exporter and File exporter,
-// which legitimately need to work with OTLP Protobuf structs.
+// Deprecated: [v0.47.0] will be removed soon, only used internally.
 func (ld Logs) InternalRep() internal.LogsWrapper {
-	return internal.LogsFromOtlp(ld.orig)
+	return internal.LogsWrapper{}
 }
 
 // MoveTo moves all properties from the current struct to dest

--- a/model/internal/pdata/logs_test.go
+++ b/model/internal/pdata/logs_test.go
@@ -22,7 +22,6 @@ import (
 	goproto "google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/emptypb"
 
-	"go.opentelemetry.io/collector/model/internal"
 	otlplogs "go.opentelemetry.io/collector/model/internal/data/protogen/logs/v1"
 )
 
@@ -76,8 +75,7 @@ func TestLogRecordCountWithEmpty(t *testing.T) {
 }
 
 func TestToFromLogProto(t *testing.T) {
-	wrapper := internal.LogsFromOtlp(&otlplogs.LogsData{})
-	logs := LogsFromInternalRep(wrapper)
+	logs := LogsFromOtlp(&otlplogs.LogsData{})
 	assert.EqualValues(t, NewLogs(), logs)
 	assert.EqualValues(t, &otlplogs.LogsData{}, logs.orig)
 }

--- a/model/internal/pdata/metrics.go
+++ b/model/internal/pdata/metrics.go
@@ -51,16 +51,9 @@ func NewMetrics() Metrics {
 	return Metrics{orig: &otlpmetrics.MetricsData{}}
 }
 
-// MetricsFromInternalRep creates Metrics from the internal representation.
-// Should not be used outside this module.
-func MetricsFromInternalRep(wrapper internal.MetricsWrapper) Metrics {
-	return Metrics{orig: internal.MetricsToOtlp(wrapper)}
-}
-
-// InternalRep returns internal representation of the Metrics.
-// Should not be used outside this module.
+// Deprecated: [v0.47.0] will be removed soon, only used internally.
 func (md Metrics) InternalRep() internal.MetricsWrapper {
-	return internal.MetricsFromOtlp(md.orig)
+	return internal.MetricsWrapper{}
 }
 
 // Clone returns a copy of MetricData.

--- a/model/internal/pdata/metrics_test.go
+++ b/model/internal/pdata/metrics_test.go
@@ -22,7 +22,6 @@ import (
 	goproto "google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/emptypb"
 
-	"go.opentelemetry.io/collector/model/internal"
 	otlpcommon "go.opentelemetry.io/collector/model/internal/data/protogen/common/v1"
 	otlpmetrics "go.opentelemetry.io/collector/model/internal/data/protogen/metrics/v1"
 	otlpresource "go.opentelemetry.io/collector/model/internal/data/protogen/resource/v1"
@@ -290,7 +289,7 @@ func TestOtlpToInternalReadOnly(t *testing.T) {
 }
 
 func TestOtlpToFromInternalReadOnly(t *testing.T) {
-	md := MetricsFromInternalRep(internal.MetricsFromOtlp(&otlpmetrics.MetricsData{
+	md := MetricsFromOtlp(&otlpmetrics.MetricsData{
 		ResourceMetrics: []*otlpmetrics.ResourceMetrics{
 			{
 				Resource: generateTestProtoResource(),
@@ -302,7 +301,7 @@ func TestOtlpToFromInternalReadOnly(t *testing.T) {
 				},
 			},
 		},
-	}))
+	})
 	// Test that nothing changed
 	assert.EqualValues(t, &otlpmetrics.MetricsData{
 		ResourceMetrics: []*otlpmetrics.ResourceMetrics{
@@ -316,13 +315,13 @@ func TestOtlpToFromInternalReadOnly(t *testing.T) {
 				},
 			},
 		},
-	}, internal.MetricsToOtlp(md.InternalRep()))
+	}, MetricsToOtlp(md))
 }
 
 func TestOtlpToFromInternalGaugeMutating(t *testing.T) {
 	newAttributes := NewAttributeMapFromMap(map[string]AttributeValue{"k": NewAttributeValueString("v")})
 
-	md := MetricsFromInternalRep(internal.MetricsFromOtlp(&otlpmetrics.MetricsData{
+	md := MetricsFromOtlp(&otlpmetrics.MetricsData{
 		ResourceMetrics: []*otlpmetrics.ResourceMetrics{
 			{
 				Resource: generateTestProtoResource(),
@@ -334,7 +333,7 @@ func TestOtlpToFromInternalGaugeMutating(t *testing.T) {
 				},
 			},
 		},
-	}))
+	})
 	resourceMetrics := md.ResourceMetrics()
 	metric := resourceMetrics.At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(0)
 	// Mutate MetricDescriptor
@@ -399,13 +398,13 @@ func TestOtlpToFromInternalGaugeMutating(t *testing.T) {
 				},
 			},
 		},
-	}, internal.MetricsToOtlp(md.InternalRep()))
+	}, MetricsToOtlp(md))
 }
 
 func TestOtlpToFromInternalSumMutating(t *testing.T) {
 	newAttributes := NewAttributeMapFromMap(map[string]AttributeValue{"k": NewAttributeValueString("v")})
 
-	md := MetricsFromInternalRep(internal.MetricsFromOtlp(&otlpmetrics.MetricsData{
+	md := MetricsFromOtlp(&otlpmetrics.MetricsData{
 		ResourceMetrics: []*otlpmetrics.ResourceMetrics{
 			{
 				Resource: generateTestProtoResource(),
@@ -417,7 +416,7 @@ func TestOtlpToFromInternalSumMutating(t *testing.T) {
 				},
 			},
 		},
-	}))
+	})
 	resourceMetrics := md.ResourceMetrics()
 	metric := resourceMetrics.At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(0)
 	// Mutate MetricDescriptor
@@ -484,13 +483,13 @@ func TestOtlpToFromInternalSumMutating(t *testing.T) {
 				},
 			},
 		},
-	}, internal.MetricsToOtlp(md.InternalRep()))
+	}, MetricsToOtlp(md))
 }
 
 func TestOtlpToFromInternalHistogramMutating(t *testing.T) {
 	newAttributes := NewAttributeMapFromMap(map[string]AttributeValue{"k": NewAttributeValueString("v")})
 
-	md := MetricsFromInternalRep(internal.MetricsFromOtlp(&otlpmetrics.MetricsData{
+	md := MetricsFromOtlp(&otlpmetrics.MetricsData{
 		ResourceMetrics: []*otlpmetrics.ResourceMetrics{
 			{
 				Resource: generateTestProtoResource(),
@@ -502,7 +501,7 @@ func TestOtlpToFromInternalHistogramMutating(t *testing.T) {
 				},
 			},
 		},
-	}))
+	})
 	resourceMetrics := md.ResourceMetrics()
 	metric := resourceMetrics.At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(0)
 	// Mutate MetricDescriptor
@@ -568,13 +567,13 @@ func TestOtlpToFromInternalHistogramMutating(t *testing.T) {
 				},
 			},
 		},
-	}, internal.MetricsToOtlp(md.InternalRep()))
+	}, MetricsToOtlp(md))
 }
 
 func TestOtlpToFromInternalExponentialHistogramMutating(t *testing.T) {
 	newAttributes := NewAttributeMapFromMap(map[string]AttributeValue{"k": NewAttributeValueString("v")})
 
-	md := MetricsFromInternalRep(internal.MetricsFromOtlp(&otlpmetrics.MetricsData{
+	md := MetricsFromOtlp(&otlpmetrics.MetricsData{
 		ResourceMetrics: []*otlpmetrics.ResourceMetrics{
 			{
 				Resource: generateTestProtoResource(),
@@ -586,7 +585,7 @@ func TestOtlpToFromInternalExponentialHistogramMutating(t *testing.T) {
 				},
 			},
 		},
-	}))
+	})
 	resourceMetrics := md.ResourceMetrics()
 	metric := resourceMetrics.At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(0)
 	// Mutate MetricDescriptor
@@ -647,7 +646,7 @@ func TestOtlpToFromInternalExponentialHistogramMutating(t *testing.T) {
 				},
 			},
 		},
-	}, internal.MetricsToOtlp(md.InternalRep()))
+	}, MetricsToOtlp(md))
 }
 
 func TestMetricsClone(t *testing.T) {
@@ -699,8 +698,8 @@ func BenchmarkOtlpToFromInternal_PassThrough(b *testing.B) {
 
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		md := MetricsFromInternalRep(internal.MetricsFromOtlp(req))
-		newReq := internal.MetricsToOtlp(md.InternalRep())
+		md := MetricsFromOtlp(req)
+		newReq := MetricsToOtlp(md)
 		if len(req.ResourceMetrics) != len(newReq.ResourceMetrics) {
 			b.Fail()
 		}
@@ -724,9 +723,9 @@ func BenchmarkOtlpToFromInternal_Gauge_MutateOneLabel(b *testing.B) {
 
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		md := MetricsFromInternalRep(internal.MetricsFromOtlp(req))
+		md := MetricsFromOtlp(req)
 		md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(0).Gauge().DataPoints().At(0).Attributes().UpsertString("key0", "value2")
-		newReq := internal.MetricsToOtlp(md.InternalRep())
+		newReq := MetricsToOtlp(md)
 		if len(req.ResourceMetrics) != len(newReq.ResourceMetrics) {
 			b.Fail()
 		}
@@ -750,9 +749,9 @@ func BenchmarkOtlpToFromInternal_Sum_MutateOneLabel(b *testing.B) {
 
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		md := MetricsFromInternalRep(internal.MetricsFromOtlp(req))
+		md := MetricsFromOtlp(req)
 		md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(0).Sum().DataPoints().At(0).Attributes().UpsertString("key0", "value2")
-		newReq := internal.MetricsToOtlp(md.InternalRep())
+		newReq := MetricsToOtlp(md)
 		if len(req.ResourceMetrics) != len(newReq.ResourceMetrics) {
 			b.Fail()
 		}
@@ -776,9 +775,9 @@ func BenchmarkOtlpToFromInternal_HistogramPoints_MutateOneLabel(b *testing.B) {
 
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		md := MetricsFromInternalRep(internal.MetricsFromOtlp(req))
+		md := MetricsFromOtlp(req)
 		md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(0).Histogram().DataPoints().At(0).Attributes().UpsertString("key0", "value2")
-		newReq := internal.MetricsToOtlp(md.InternalRep())
+		newReq := MetricsToOtlp(md)
 		if len(req.ResourceMetrics) != len(newReq.ResourceMetrics) {
 			b.Fail()
 		}

--- a/model/internal/pdata/otlp_wrapper.go
+++ b/model/internal/pdata/otlp_wrapper.go
@@ -1,0 +1,51 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pdata // import "go.opentelemetry.io/collector/model/internal/pdata"
+
+import (
+	otlplogs "go.opentelemetry.io/collector/model/internal/data/protogen/logs/v1"
+	otlpmetrics "go.opentelemetry.io/collector/model/internal/data/protogen/metrics/v1"
+	otlptrace "go.opentelemetry.io/collector/model/internal/data/protogen/trace/v1"
+)
+
+// MetricsToOtlp internal helper to convert Metrics to protobuf representation.
+func MetricsToOtlp(mw Metrics) *otlpmetrics.MetricsData {
+	return mw.orig
+}
+
+// MetricsFromOtlp internal helper to convert protobuf representation to Metrics.
+func MetricsFromOtlp(orig *otlpmetrics.MetricsData) Metrics {
+	return Metrics{orig: orig}
+}
+
+// TracesToOtlp internal helper to convert Traces to protobuf representation.
+func TracesToOtlp(mw Traces) *otlptrace.TracesData {
+	return mw.orig
+}
+
+// TracesFromOtlp internal helper to convert protobuf representation to Traces.
+func TracesFromOtlp(orig *otlptrace.TracesData) Traces {
+	return Traces{orig: orig}
+}
+
+// LogsToOtlp internal helper to convert Logs to protobuf representation.
+func LogsToOtlp(l Logs) *otlplogs.LogsData {
+	return l.orig
+}
+
+// LogsFromOtlp internal helper to convert protobuf representation to Logs.
+func LogsFromOtlp(orig *otlplogs.LogsData) Logs {
+	return Logs{orig: orig}
+}

--- a/model/internal/pdata/traces.go
+++ b/model/internal/pdata/traces.go
@@ -51,16 +51,9 @@ func NewTraces() Traces {
 	return Traces{orig: &otlptrace.TracesData{}}
 }
 
-// TracesFromInternalRep creates Traces from the internal representation.
-// Should not be used outside this module.
-func TracesFromInternalRep(wrapper internal.TracesWrapper) Traces {
-	return Traces{orig: internal.TracesToOtlp(wrapper)}
-}
-
-// InternalRep returns internal representation of the Traces.
-// Should not be used outside this module.
+// Deprecated: [v0.47.0] will be removed soon, only used internally.
 func (td Traces) InternalRep() internal.TracesWrapper {
-	return internal.TracesFromOtlp(td.orig)
+	return internal.TracesWrapper{}
 }
 
 // MoveTo moves all properties from the current struct to dest

--- a/model/internal/pdata/traces_test.go
+++ b/model/internal/pdata/traces_test.go
@@ -22,7 +22,6 @@ import (
 	goproto "google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/emptypb"
 
-	"go.opentelemetry.io/collector/model/internal"
 	otlptrace "go.opentelemetry.io/collector/model/internal/data/protogen/trace/v1"
 )
 
@@ -76,9 +75,9 @@ func TestSpanCountWithEmpty(t *testing.T) {
 
 func TestToFromOtlp(t *testing.T) {
 	otlp := &otlptrace.TracesData{}
-	traces := TracesFromInternalRep(internal.TracesFromOtlp(otlp))
+	traces := TracesFromOtlp(otlp)
 	assert.EqualValues(t, NewTraces(), traces)
-	assert.EqualValues(t, otlp, internal.TracesToOtlp(traces.InternalRep()))
+	assert.EqualValues(t, otlp, TracesToOtlp(traces))
 	// More tests in ./tracedata/traces_test.go. Cannot have them here because of
 	// circular dependency.
 }

--- a/model/otlp/json_marshaler.go
+++ b/model/otlp/json_marshaler.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/gogo/protobuf/jsonpb"
 
-	"go.opentelemetry.io/collector/model/internal"
+	ipdata "go.opentelemetry.io/collector/model/internal/pdata"
 	"go.opentelemetry.io/collector/model/pdata"
 )
 
@@ -48,18 +48,18 @@ func newJSONMarshaler() *jsonMarshaler {
 
 func (e *jsonMarshaler) MarshalLogs(ld pdata.Logs) ([]byte, error) {
 	buf := bytes.Buffer{}
-	err := e.delegate.Marshal(&buf, internal.LogsToOtlp(ld.InternalRep()))
+	err := e.delegate.Marshal(&buf, ipdata.LogsToOtlp(ld))
 	return buf.Bytes(), err
 }
 
 func (e *jsonMarshaler) MarshalMetrics(md pdata.Metrics) ([]byte, error) {
 	buf := bytes.Buffer{}
-	err := e.delegate.Marshal(&buf, internal.MetricsToOtlp(md.InternalRep()))
+	err := e.delegate.Marshal(&buf, ipdata.MetricsToOtlp(md))
 	return buf.Bytes(), err
 }
 
 func (e *jsonMarshaler) MarshalTraces(td pdata.Traces) ([]byte, error) {
 	buf := bytes.Buffer{}
-	err := e.delegate.Marshal(&buf, internal.TracesToOtlp(td.InternalRep()))
+	err := e.delegate.Marshal(&buf, ipdata.TracesToOtlp(td))
 	return buf.Bytes(), err
 }

--- a/model/otlp/json_unmarshaler.go
+++ b/model/otlp/json_unmarshaler.go
@@ -19,10 +19,10 @@ import (
 
 	"github.com/gogo/protobuf/jsonpb"
 
-	"go.opentelemetry.io/collector/model/internal"
 	otlplogs "go.opentelemetry.io/collector/model/internal/data/protogen/logs/v1"
 	otlpmetrics "go.opentelemetry.io/collector/model/internal/data/protogen/metrics/v1"
 	otlptrace "go.opentelemetry.io/collector/model/internal/data/protogen/trace/v1"
+	ipdata "go.opentelemetry.io/collector/model/internal/pdata"
 	"go.opentelemetry.io/collector/model/pdata"
 )
 
@@ -54,7 +54,7 @@ func (d *jsonUnmarshaler) UnmarshalLogs(buf []byte) (pdata.Logs, error) {
 	if err := d.delegate.Unmarshal(bytes.NewReader(buf), ld); err != nil {
 		return pdata.Logs{}, err
 	}
-	return pdata.LogsFromInternalRep(internal.LogsFromOtlp(ld)), nil
+	return ipdata.LogsFromOtlp(ld), nil
 }
 
 func (d *jsonUnmarshaler) UnmarshalMetrics(buf []byte) (pdata.Metrics, error) {
@@ -62,7 +62,7 @@ func (d *jsonUnmarshaler) UnmarshalMetrics(buf []byte) (pdata.Metrics, error) {
 	if err := d.delegate.Unmarshal(bytes.NewReader(buf), md); err != nil {
 		return pdata.Metrics{}, err
 	}
-	return pdata.MetricsFromInternalRep(internal.MetricsFromOtlp(md)), nil
+	return ipdata.MetricsFromOtlp(md), nil
 }
 
 func (d *jsonUnmarshaler) UnmarshalTraces(buf []byte) (pdata.Traces, error) {
@@ -70,5 +70,5 @@ func (d *jsonUnmarshaler) UnmarshalTraces(buf []byte) (pdata.Traces, error) {
 	if err := d.delegate.Unmarshal(bytes.NewReader(buf), td); err != nil {
 		return pdata.Traces{}, err
 	}
-	return pdata.TracesFromInternalRep(internal.TracesFromOtlp(td)), nil
+	return ipdata.TracesFromOtlp(td), nil
 }

--- a/model/otlp/pb_marshaler.go
+++ b/model/otlp/pb_marshaler.go
@@ -15,7 +15,7 @@
 package otlp // import "go.opentelemetry.io/collector/model/otlp"
 
 import (
-	"go.opentelemetry.io/collector/model/internal"
+	ipdata "go.opentelemetry.io/collector/model/internal/pdata"
 	"go.opentelemetry.io/collector/model/pdata"
 )
 
@@ -46,25 +46,25 @@ var _ pdata.MetricsSizer = (*pbMarshaler)(nil)
 var _ pdata.LogsSizer = (*pbMarshaler)(nil)
 
 func (e *pbMarshaler) MarshalLogs(ld pdata.Logs) ([]byte, error) {
-	return internal.LogsToOtlp(ld.InternalRep()).Marshal()
+	return ipdata.LogsToOtlp(ld).Marshal()
 }
 
 func (e *pbMarshaler) MarshalMetrics(md pdata.Metrics) ([]byte, error) {
-	return internal.MetricsToOtlp(md.InternalRep()).Marshal()
+	return ipdata.MetricsToOtlp(md).Marshal()
 }
 
 func (e *pbMarshaler) MarshalTraces(td pdata.Traces) ([]byte, error) {
-	return internal.TracesToOtlp(td.InternalRep()).Marshal()
+	return ipdata.TracesToOtlp(td).Marshal()
 }
 
 func (e *pbMarshaler) TracesSize(td pdata.Traces) int {
-	return internal.TracesToOtlp(td.InternalRep()).Size()
+	return ipdata.TracesToOtlp(td).Size()
 }
 
 func (e *pbMarshaler) MetricsSize(md pdata.Metrics) int {
-	return internal.MetricsToOtlp(md.InternalRep()).Size()
+	return ipdata.MetricsToOtlp(md).Size()
 }
 
 func (e *pbMarshaler) LogsSize(ld pdata.Logs) int {
-	return internal.LogsToOtlp(ld.InternalRep()).Size()
+	return ipdata.LogsToOtlp(ld).Size()
 }

--- a/model/otlp/pb_unmarshaler.go
+++ b/model/otlp/pb_unmarshaler.go
@@ -15,10 +15,10 @@
 package otlp // import "go.opentelemetry.io/collector/model/otlp"
 
 import (
-	"go.opentelemetry.io/collector/model/internal"
 	otlplogs "go.opentelemetry.io/collector/model/internal/data/protogen/logs/v1"
 	otlpmetrics "go.opentelemetry.io/collector/model/internal/data/protogen/metrics/v1"
 	otlptrace "go.opentelemetry.io/collector/model/internal/data/protogen/trace/v1"
+	ipdata "go.opentelemetry.io/collector/model/internal/pdata"
 	"go.opentelemetry.io/collector/model/pdata"
 )
 
@@ -46,17 +46,17 @@ func newPbUnmarshaler() *pbUnmarshaler {
 func (d *pbUnmarshaler) UnmarshalLogs(buf []byte) (pdata.Logs, error) {
 	ld := &otlplogs.LogsData{}
 	err := ld.Unmarshal(buf)
-	return pdata.LogsFromInternalRep(internal.LogsFromOtlp(ld)), err
+	return ipdata.LogsFromOtlp(ld), err
 }
 
 func (d *pbUnmarshaler) UnmarshalMetrics(buf []byte) (pdata.Metrics, error) {
 	md := &otlpmetrics.MetricsData{}
 	err := md.Unmarshal(buf)
-	return pdata.MetricsFromInternalRep(internal.MetricsFromOtlp(md)), err
+	return ipdata.MetricsFromOtlp(md), err
 }
 
 func (d *pbUnmarshaler) UnmarshalTraces(buf []byte) (pdata.Traces, error) {
 	td := &otlptrace.TracesData{}
 	err := td.Unmarshal(buf)
-	return pdata.TracesFromInternalRep(internal.TracesFromOtlp(td)), err
+	return ipdata.TracesFromOtlp(td), err
 }

--- a/model/otlpgrpc/logs.go
+++ b/model/otlpgrpc/logs.go
@@ -21,9 +21,9 @@ import (
 	"github.com/gogo/protobuf/jsonpb"
 	"google.golang.org/grpc"
 
-	"go.opentelemetry.io/collector/model/internal"
 	otlpcollectorlog "go.opentelemetry.io/collector/model/internal/data/protogen/collector/logs/v1"
 	otlplogs "go.opentelemetry.io/collector/model/internal/data/protogen/logs/v1"
+	ipdata "go.opentelemetry.io/collector/model/internal/pdata"
 	"go.opentelemetry.io/collector/model/pdata"
 )
 
@@ -115,11 +115,11 @@ func (lr LogsRequest) MarshalJSON() ([]byte, error) {
 }
 
 func (lr LogsRequest) SetLogs(ld pdata.Logs) {
-	lr.orig.ResourceLogs = internal.LogsToOtlp(ld.InternalRep()).ResourceLogs
+	lr.orig.ResourceLogs = ipdata.LogsToOtlp(ld).ResourceLogs
 }
 
 func (lr LogsRequest) Logs() pdata.Logs {
-	return pdata.LogsFromInternalRep(internal.LogsFromOtlp(&otlplogs.LogsData{ResourceLogs: lr.orig.ResourceLogs}))
+	return ipdata.LogsFromOtlp(&otlplogs.LogsData{ResourceLogs: lr.orig.ResourceLogs})
 }
 
 // LogsClient is the client API for OTLP-GRPC Logs service.

--- a/model/otlpgrpc/metrics.go
+++ b/model/otlpgrpc/metrics.go
@@ -20,9 +20,9 @@ import (
 
 	"google.golang.org/grpc"
 
-	"go.opentelemetry.io/collector/model/internal"
 	otlpcollectormetrics "go.opentelemetry.io/collector/model/internal/data/protogen/collector/metrics/v1"
 	otlpmetrics "go.opentelemetry.io/collector/model/internal/data/protogen/metrics/v1"
+	ipdata "go.opentelemetry.io/collector/model/internal/pdata"
 	"go.opentelemetry.io/collector/model/pdata"
 )
 
@@ -111,11 +111,11 @@ func (mr MetricsRequest) MarshalJSON() ([]byte, error) {
 }
 
 func (mr MetricsRequest) SetMetrics(ld pdata.Metrics) {
-	mr.orig.ResourceMetrics = internal.MetricsToOtlp(ld.InternalRep()).ResourceMetrics
+	mr.orig.ResourceMetrics = ipdata.MetricsToOtlp(ld).ResourceMetrics
 }
 
 func (mr MetricsRequest) Metrics() pdata.Metrics {
-	return pdata.MetricsFromInternalRep(internal.MetricsFromOtlp(&otlpmetrics.MetricsData{ResourceMetrics: mr.orig.ResourceMetrics}))
+	return ipdata.MetricsFromOtlp(&otlpmetrics.MetricsData{ResourceMetrics: mr.orig.ResourceMetrics})
 }
 
 // MetricsClient is the client API for OTLP-GRPC Metrics service.

--- a/model/otlpgrpc/traces.go
+++ b/model/otlpgrpc/traces.go
@@ -20,9 +20,9 @@ import (
 
 	"google.golang.org/grpc"
 
-	"go.opentelemetry.io/collector/model/internal"
 	otlpcollectortrace "go.opentelemetry.io/collector/model/internal/data/protogen/collector/trace/v1"
 	otlptrace "go.opentelemetry.io/collector/model/internal/data/protogen/trace/v1"
+	ipdata "go.opentelemetry.io/collector/model/internal/pdata"
 	"go.opentelemetry.io/collector/model/pdata"
 )
 
@@ -111,11 +111,11 @@ func (tr TracesRequest) MarshalJSON() ([]byte, error) {
 }
 
 func (tr TracesRequest) SetTraces(td pdata.Traces) {
-	tr.orig.ResourceSpans = internal.TracesToOtlp(td.InternalRep()).ResourceSpans
+	tr.orig.ResourceSpans = ipdata.TracesToOtlp(td).ResourceSpans
 }
 
 func (tr TracesRequest) Traces() pdata.Traces {
-	return pdata.TracesFromInternalRep(internal.TracesFromOtlp(&otlptrace.TracesData{ResourceSpans: tr.orig.ResourceSpans}))
+	return ipdata.TracesFromOtlp(&otlptrace.TracesData{ResourceSpans: tr.orig.ResourceSpans})
 }
 
 // TracesClient is the client API for OTLP-GRPC Traces service.

--- a/model/pdata/logs_alias.go
+++ b/model/pdata/logs_alias.go
@@ -16,7 +16,10 @@ package pdata // import "go.opentelemetry.io/collector/model/pdata"
 
 // This file contains aliases for log data structures.
 
-import "go.opentelemetry.io/collector/model/internal/pdata"
+import (
+	"go.opentelemetry.io/collector/model/internal"
+	"go.opentelemetry.io/collector/model/internal/pdata"
+)
 
 // LogsMarshaler is an alias for pdata.LogsMarshaler interface.
 type LogsMarshaler = pdata.LogsMarshaler
@@ -33,9 +36,10 @@ type Logs = pdata.Logs
 // NewLogs is an alias for a function to create new Logs.
 var NewLogs = pdata.NewLogs
 
-// LogsFromInternalRep is an alias for pdata.LogsFromInternalRep function.
-// TODO: Can be removed, internal pdata.LogsFromInternalRep should be used instead.
-var LogsFromInternalRep = pdata.LogsFromInternalRep
+// Deprecated: [v0.47.0] will be removed soon, only used internally.
+func LogsFromInternalRep(internal.LogsWrapper) Logs {
+	return Logs{}
+}
 
 // SeverityNumber is an alias for pdata.SeverityNumber type.
 type SeverityNumber = pdata.SeverityNumber

--- a/model/pdata/metrics_alias.go
+++ b/model/pdata/metrics_alias.go
@@ -16,7 +16,10 @@ package pdata // import "go.opentelemetry.io/collector/model/pdata"
 
 // This file contains aliases for metric data structures.
 
-import "go.opentelemetry.io/collector/model/internal/pdata"
+import (
+	"go.opentelemetry.io/collector/model/internal"
+	"go.opentelemetry.io/collector/model/internal/pdata"
+)
 
 // MetricsMarshaler is an alias for pdata.MetricsMarshaler interface.
 type MetricsMarshaler = pdata.MetricsMarshaler
@@ -33,9 +36,10 @@ type Metrics = pdata.Metrics
 // NewMetrics is an alias for a function to create new Metrics.
 var NewMetrics = pdata.NewMetrics
 
-// MetricsFromInternalRep is an alias for MetricsFromInternalRep.
-// TODO: Can be removed, internal pdata.MetricsFromInternalRep should be used instead.
-var MetricsFromInternalRep = pdata.MetricsFromInternalRep
+// Deprecated: [v0.47.0] will be removed soon, only used internally.
+func MetricsFromInternalRep(internal.MetricsWrapper) Metrics {
+	return Metrics{}
+}
 
 // MetricDataType is an alias for pdata.MetricDataType type.
 type MetricDataType = pdata.MetricDataType

--- a/model/pdata/traces_alias.go
+++ b/model/pdata/traces_alias.go
@@ -16,7 +16,10 @@ package pdata // import "go.opentelemetry.io/collector/model/pdata"
 
 // This file contains aliases for trace data structures.
 
-import "go.opentelemetry.io/collector/model/internal/pdata"
+import (
+	"go.opentelemetry.io/collector/model/internal"
+	"go.opentelemetry.io/collector/model/internal/pdata"
+)
 
 // TracesMarshaler is an alias for pdata.TracesMarshaler interface.
 type TracesMarshaler = pdata.TracesMarshaler
@@ -33,9 +36,10 @@ type Traces = pdata.Traces
 // NewTraces is an alias for a function to create new Traces.
 var NewTraces = pdata.NewTraces
 
-// TracesFromInternalRep is an alias for pdata.TracesFromInternalRep.
-// TODO: Can be removed, internal pdata.TracesFromInternalRep should be used instead.
-var TracesFromInternalRep = pdata.TracesFromInternalRep
+// Deprecated: [v0.47.0] will be removed soon, only used internally.
+func TracesFromInternalRep(internal.TracesWrapper) Traces {
+	return Traces{}
+}
 
 // TraceState is an alias for pdata.TraceState type.
 type TraceState = pdata.TraceState


### PR DESCRIPTION
This PR tries to respect the rules 100%, but the need to keep the deprecated public funcs is unclear since they should not/ cannot be used externally.

Updates: https://github.com/open-telemetry/opentelemetry-collector/issues/4706

Issue will be fixed when removing the deprecated funcs.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
