### PR TITLE
change feature registry as a prototype to make test friendly

### DIFF
--- a/service/collector_test.go
+++ b/service/collector_test.go
@@ -151,13 +151,14 @@ func TestCollector_Start(t *testing.T) {
 
 func TestCollector_StartWithOtelInternalMetrics(t *testing.T) {
 	resetCollectorTelemetry()
-	originalFlag := featuregate.IsEnabled(useOtelForInternalMetricsfeatureGateID)
+	reg := featuregate.NewRegistry()
+	originalFlag := reg.IsEnabled(useOtelForInternalMetricsfeatureGateID)
 	defer func() {
-		featuregate.Apply(map[string]bool{
+		reg.Apply(map[string]bool{
 			useOtelForInternalMetricsfeatureGateID: originalFlag,
 		})
 	}()
-	featuregate.Apply(map[string]bool{
+	reg.Apply(map[string]bool{
 		useOtelForInternalMetricsfeatureGateID: true,
 	})
 	testCollectorStartHelper(t)

--- a/service/command.go
+++ b/service/command.go
@@ -28,7 +28,7 @@ func NewCommand(set CollectorSettings) *cobra.Command {
 		Version:      set.BuildInfo.Version,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			featuregate.Apply(featuregate.GetFlags())
+			featuregate.GetRegistry().Apply(featuregate.GetFlags())
 			if set.ConfigProvider == nil {
 				set.ConfigProvider = MustNewDefaultConfigProvider(getConfigFlag(), getSetFlag())
 			}

--- a/service/featuregate/gates.go
+++ b/service/featuregate/gates.go
@@ -27,38 +27,32 @@ type Gate struct {
 	Enabled     bool
 }
 
-var reg = &registry{gates: make(map[string]Gate)}
+var reg = &Registry{gates: make(map[string]Gate)}
 
-// IsEnabled returns true if a registered feature gate is enabled and false otherwise.
-func IsEnabled(id string) bool {
-	return reg.isEnabled(id)
+func GetRegistry() *Registry {
+	return reg
 }
 
-// List returns a slice of copies of all registered Gates.
-func List() []Gate {
-	return reg.list()
+func NewRegistry() Registry {
+	return Registry{gates: make(map[string]Gate)}
 }
 
 // Register a Gate. May only be called in an init() function.
 // Will panic() if a Gate with the same ID is already registered.
-func Register(g Gate) {
-	if err := reg.add(g); err != nil {
+func (r *Registry) Register(g Gate) {
+	if err := r.add(g); err != nil {
 		panic(err)
 	}
 }
 
-// Apply a configuration in the form of a map of Gate identifiers to boolean values.
-// Sets only those values provided in the map, other gate values are not changed.
-func Apply(cfg map[string]bool) {
-	reg.apply(cfg)
-}
-
-type registry struct {
+type Registry struct {
 	sync.RWMutex
 	gates map[string]Gate
 }
 
-func (r *registry) apply(cfg map[string]bool) {
+// Apply a configuration in the form of a map of Gate identifiers to boolean values.
+// Sets only those values provided in the map, other gate values are not changed.
+func (r *Registry) Apply(cfg map[string]bool) {
 	r.Lock()
 	defer r.Unlock()
 	for id, val := range cfg {
@@ -69,7 +63,7 @@ func (r *registry) apply(cfg map[string]bool) {
 	}
 }
 
-func (r *registry) add(g Gate) error {
+func (r *Registry) add(g Gate) error {
 	r.Lock()
 	defer r.Unlock()
 	if _, ok := r.gates[g.ID]; ok {
@@ -80,14 +74,16 @@ func (r *registry) add(g Gate) error {
 	return nil
 }
 
-func (r *registry) isEnabled(id string) bool {
+// IsEnabled returns true if a registered feature gate is enabled and false otherwise.
+func (r *Registry) IsEnabled(id string) bool {
 	r.RLock()
 	defer r.RUnlock()
 	g, ok := r.gates[id]
 	return ok && g.Enabled
 }
 
-func (r *registry) list() []Gate {
+// List returns a slice of copies of all registered Gates.
+func (r *Registry) List() []Gate {
 	r.RLock()
 	defer r.RUnlock()
 	ret := make([]Gate, len(r.gates))

--- a/service/featuregate/gates_test.go
+++ b/service/featuregate/gates_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestRegistry(t *testing.T) {
-	r := registry{gates: map[string]Gate{}}
+	r := Registry{gates: map[string]Gate{}}
 
 	gate := Gate{
 		ID:          "foo",
@@ -29,15 +29,15 @@ func TestRegistry(t *testing.T) {
 		Enabled:     true,
 	}
 
-	assert.Empty(t, r.list())
-	assert.False(t, r.isEnabled(gate.ID))
+	assert.Empty(t, r.List())
+	assert.False(t, r.IsEnabled(gate.ID))
 
 	assert.NoError(t, r.add(gate))
-	assert.Len(t, r.list(), 1)
-	assert.True(t, r.isEnabled(gate.ID))
+	assert.Len(t, r.List(), 1)
+	assert.True(t, r.IsEnabled(gate.ID))
 
-	r.apply(map[string]bool{gate.ID: false})
-	assert.False(t, r.isEnabled(gate.ID))
+	r.Apply(map[string]bool{gate.ID: false})
+	assert.False(t, r.IsEnabled(gate.ID))
 
 	assert.Error(t, r.add(gate))
 }
@@ -49,17 +49,19 @@ func TestGlobalRegistry(t *testing.T) {
 		Enabled:     true,
 	}
 
-	assert.NotContains(t, List(), gate)
-	assert.False(t, IsEnabled(gate.ID))
+	registry := NewRegistry()
 
-	assert.NotPanics(t, func() { Register(gate) })
-	assert.Contains(t, List(), gate)
-	assert.True(t, IsEnabled(gate.ID))
+	assert.NotContains(t, registry.List(), gate)
+	assert.False(t, registry.IsEnabled(gate.ID))
 
-	Apply(map[string]bool{gate.ID: false})
-	assert.False(t, IsEnabled(gate.ID))
+	assert.NotPanics(t, func() { registry.Register(gate) })
+	assert.Contains(t, registry.List(), gate)
+	assert.True(t, registry.IsEnabled(gate.ID))
 
-	assert.Panics(t, func() { Register(gate) })
+	registry.Apply(map[string]bool{gate.ID: false})
+	assert.False(t, registry.IsEnabled(gate.ID))
+
+	assert.Panics(t, func() { registry.Register(gate) })
 	reg.Lock()
 	delete(reg.gates, gate.ID)
 	reg.Unlock()

--- a/service/telemetry.go
+++ b/service/telemetry.go
@@ -58,8 +58,12 @@ const (
 )
 
 func init() {
+	initWithRegistry(featuregate.GetRegistry())
+}
+
+func initWithRegistry(registry *featuregate.Registry) {
 	//nolint:staticcheck
-	featuregate.Register(featuregate.Gate{
+	registry.Register(featuregate.Gate{
 		ID:          useOtelForInternalMetricsfeatureGateID,
 		Description: "controls whether the collector to uses open telemetry for internal metrics",
 		Enabled:     configtelemetry.UseOpenTelemetryForInternalMetrics,
@@ -112,7 +116,7 @@ func (tel *colTelemetry) initOnce(col *Collector) error {
 	instanceID := instanceUUID.String()
 
 	var pe http.Handler
-	if featuregate.IsEnabled(useOtelForInternalMetricsfeatureGateID) {
+	if featuregate.GetRegistry().IsEnabled(useOtelForInternalMetricsfeatureGateID) {
 		otelHandler, err := tel.initOpenTelemetry()
 		if err != nil {
 			return err

--- a/service/telemetry_test.go
+++ b/service/telemetry_test.go
@@ -1,0 +1,40 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"go.opentelemetry.io/collector/config/configtelemetry"
+	"go.opentelemetry.io/collector/service/featuregate"
+)
+
+func TestInitWithRegistry(t *testing.T) {
+	//nolint:staticcheck
+	gate := featuregate.Gate{
+		ID:          useOtelForInternalMetricsfeatureGateID,
+		Description: "controls whether the collector to uses open telemetry for internal metrics",
+		Enabled:     configtelemetry.UseOpenTelemetryForInternalMetrics,
+	}
+
+	registry := featuregate.NewRegistry()
+	initWithRegistry(&registry)
+	assert.Contains(t, registry.List(), gate)
+	//nolint:staticcheck
+	assert.False(t, registry.IsEnabled(useOtelForInternalMetricsfeatureGateID))
+
+}

--- a/service/zpages.go
+++ b/service/zpages.go
@@ -169,7 +169,7 @@ func handleFeaturezRequest(w http.ResponseWriter, r *http.Request) {
 
 func getFeaturesTableData() zpages.FeatureGateTableData {
 	data := zpages.FeatureGateTableData{}
-	for _, g := range featuregate.List() {
+	for _, g := range featuregate.GetRegistry().List() {
 		data.Rows = append(data.Rows, zpages.FeatureGateTableRowData{
 			ID:          g.ID,
 			Enabled:     g.Enabled,


### PR DESCRIPTION
change feature registry as a prototype to make test friendly.
* change  type registry to public
* create a public func "GetRegistry" to return the prototype
* remove the golbal function: List, IsEnabled, Apply
* change the unit test

**Link to tracking Issue:**  https://github.com/open-telemetry/opentelemetry-collector/issues/4917

Signed-off-by: Kay Yan <kay.yan@daocloud.io>