### PR TITLE
State set to closing when Collector Run encounters startup failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 - Collector `Run` will now exit when a context cancels (#4954)
 - Add missing droppedAttributesCount to pdata generated resource (#4979)
+- Collector `Run` will now set state to `Closed` if startup fails (#4974)
 
 ## v0.46.0 Beta
 

--- a/service/collector.go
+++ b/service/collector.go
@@ -239,10 +239,12 @@ func (col *Collector) Run(ctx context.Context) error {
 	col.asyncErrorChannel = make(chan error)
 
 	if err := col.setupConfigurationComponents(ctx); err != nil {
+		col.setCollectorState(Closed)
 		return err
 	}
 
 	if err := collectorTelemetry.init(col); err != nil {
+		col.setCollectorState(Closed)
 		return err
 	}
 


### PR DESCRIPTION
**Description:**
Fixes: #4826

If the `Run` exited due to an error during startup the state would stay as `Starting` changed this to be set to `Closed` when any startup error occurs.

There might need to be a larger discussion on if `Closed` is the correct state or if we should introduce a `Failed` or `Error` state that would be more appropriate here.?

**Link to tracking Issue:** #4826

**Testing:** Added unit tests to valid state change

