### PR TITLE
Move initialization of component factories after flag parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,10 @@
 - The `featuregates` were not configured from the "--feature-gates" flag on windows service (#5060)
 - Fix Semantic Convention Schema URL definition for 1.5.0 and 1.6.1 versions (#5103)
 
+### 🧰 Bug fixes 🧰
+
+- Fix the use of feature gates within factory initialization. (#4977)
+
 ## v0.47.0 Beta
 
 ### 🛑 Breaking changes 🛑

--- a/cmd/builder/internal/builder/templates/main.go.tmpl
+++ b/cmd/builder/internal/builder/templates/main.go.tmpl
@@ -8,32 +8,47 @@ package main
 import (
 	"log"
 
+	"github.com/spf13/cobra"
+
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/service"
+	"go.opentelemetry.io/collector/service/featuregate"
 )
 
 func main() {
-	factories, err := components()
-	if err != nil {
-		log.Fatalf("failed to build components: %v", err)
-	}
-
 	info := component.BuildInfo{
 		Command:     "{{ .Distribution.Name }}",
 		Description: "{{ .Distribution.Description }}",
 		Version:     "{{ .Distribution.Version }}",
 	}
 
-	if err := run(service.CollectorSettings{BuildInfo: info, Factories: factories}); err != nil {
-		log.Fatal(err)
+	if err := run(service.CollectorSettings{BuildInfo: info}); err != nil {
+		log.Fatalf("collector server run finished with error: %v", err)
 	}
 }
 
 func runInteractive(params service.CollectorSettings) error {
-	cmd := service.NewCommand(params)
-	if err := cmd.Execute(); err != nil {
-		log.Fatalf("collector server run finished with error: %v", err)
+	cmd := &cobra.Command{
+		Use:          params.BuildInfo.Command,
+		Version:      params.BuildInfo.Version,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			service.ApplyFeatureGateFlags()
+			if params.ConfigProvider == nil {
+				params.ConfigProvider = service.MustNewDefaultConfigProvider(service.GetConfigFlag(), service.GetSetFlag())
+			}
+			var err error
+			params.Factories, err = components()
+			if err != nil {
+				return err
+			}
+			col, err := service.New(params)
+			if err != nil {
+				return err
+			}
+			return col.Run(cmd.Context())
+		},
 	}
-
-	return nil
+	cmd.Flags().AddGoFlagSet(service.Flags())
+	return cmd.Execute()
 }

--- a/cmd/builder/internal/builder/templates/main_others.go.tmpl
+++ b/cmd/builder/internal/builder/templates/main_others.go.tmpl
@@ -8,5 +8,5 @@ package main
 import "go.opentelemetry.io/collector/service"
 
 func run(params service.CollectorSettings) error {
-	return runInteractive(params)
+	runInteractive(params)
 }

--- a/cmd/builder/internal/builder/templates/main_windows.go.tmpl
+++ b/cmd/builder/internal/builder/templates/main_windows.go.tmpl
@@ -41,6 +41,11 @@ func checkUseInteractiveMode() (bool, error) {
 }
 
 func runService(params service.CollectorSettings) error {
+	// Parse all the flags manually.
+	if err := service.Flags().Parse(os.Args[1:]); err != nil {
+		return err
+	}
+	service.ApplyFeatureGateFlags()
 	// do not need to supply service name when startup is invoked through Service Control Manager directly
 	if err := svc.Run("", service.NewSvcHandler(params)); err != nil {
 		return fmt.Errorf("failed to start collector server: %w", err)

--- a/cmd/otelcorecol/go.mod
+++ b/cmd/otelcorecol/go.mod
@@ -5,6 +5,7 @@ module go.opentelemetry.io/collector/cmd/otelcorecol
 go 1.17
 
 require (
+	github.com/spf13/cobra v1.4.0
 	github.com/stretchr/testify v1.7.1
 	go.opentelemetry.io/collector v0.48.0
 	golang.org/x/sys v0.0.0-20220114195835-da31bd327af9
@@ -48,7 +49,6 @@ require (
 	github.com/rs/cors v1.8.2 // indirect
 	github.com/shirou/gopsutil/v3 v3.22.2 // indirect
 	github.com/spf13/cast v1.4.1 // indirect
-	github.com/spf13/cobra v1.4.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/tklauser/go-sysconf v0.3.9 // indirect
 	github.com/tklauser/numcpus v0.3.0 // indirect

--- a/service/collector_windows.go
+++ b/service/collector_windows.go
@@ -93,11 +93,6 @@ func (s *WindowsService) Execute(args []string, requests <-chan svc.ChangeReques
 }
 
 func (s *WindowsService) start(elog *eventlog.Log, colErrorChannel chan error) error {
-	// Parse all the flags manually.
-	if err := flags().Parse(os.Args[1:]); err != nil {
-		return err
-	}
-	featuregate.Apply(gatesList)
 	var err error
 	s.col, err = newWithWindowsEventLogCore(s.settings, elog)
 	if err != nil {
@@ -144,7 +139,7 @@ func openEventLog(serviceName string) (*eventlog.Log, error) {
 
 func newWithWindowsEventLogCore(set CollectorSettings, elog *eventlog.Log) (*Collector, error) {
 	if set.ConfigProvider == nil {
-		set.ConfigProvider = MustNewDefaultConfigProvider(getConfigFlag(), getSetFlag())
+		set.ConfigProvider = MustNewDefaultConfigProvider(GetConfigFlag(), GetSetFlag())
 	}
 	set.LoggingOptions = append(
 		set.LoggingOptions,

--- a/service/command.go
+++ b/service/command.go
@@ -29,7 +29,7 @@ func NewCommand(set CollectorSettings) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			featuregate.Apply(gatesList)
 			if set.ConfigProvider == nil {
-				set.ConfigProvider = MustNewDefaultConfigProvider(getConfigFlag(), getSetFlag())
+				set.ConfigProvider = MustNewDefaultConfigProvider(GetConfigFlag(), GetSetFlag())
 			}
 			col, err := New(set)
 			if err != nil {
@@ -39,6 +39,6 @@ func NewCommand(set CollectorSettings) *cobra.Command {
 		},
 	}
 
-	rootCmd.Flags().AddGoFlagSet(flags())
+	rootCmd.Flags().AddGoFlagSet(Flags())
 	return rootCmd
 }

--- a/service/flags.go
+++ b/service/flags.go
@@ -41,7 +41,7 @@ func (s *stringArrayValue) String() string {
 	return "[" + strings.Join(s.values, ", ") + "]"
 }
 
-func flags() *flag.FlagSet {
+func Flags() *flag.FlagSet {
 	flagSet := new(flag.FlagSet)
 
 	flagSet.Var(configFlag, "config", "Locations to the config file(s), note that only a"+
@@ -60,10 +60,16 @@ func flags() *flag.FlagSet {
 	return flagSet
 }
 
-func getConfigFlag() []string {
+// ApplyFeatureGateFlags applies feature gates based on the content of the
+// --feature-gate flag.
+func ApplyFeatureGateFlags() {
+	featuregate.Apply(gatesList)
+}
+
+func GetConfigFlag() []string {
 	return configFlag.values
 }
 
-func getSetFlag() []string {
+func GetSetFlag() []string {
 	return setFlag.values
 }


### PR DESCRIPTION
**Description:**

Fixes https://github.com/open-telemetry/opentelemetry-collector/issues/4967

Instead of assembling factories before creating and executing the cobra service, construct factories within the cobra run command so it happens after feature flag parsing.

**Testing:**

Manually tested by adding a feature gate to the OTLP receiver, and checking its value during the NewFactory() call.
