### PR TITLE
add droppedAttributesCount to resource_struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### 🧰 Bug fixes 🧰
 
 - Collector `Run` will now exit when a context cancels (#4954)
+- Add missing droppedAttributesCount to pdata generated resource (#4979)
 
 ## v0.46.0 Beta
 

--- a/model/internal/cmd/pdatagen/internal/resource_structs.go
+++ b/model/internal/cmd/pdatagen/internal/resource_structs.go
@@ -35,6 +35,7 @@ var resource = &messageValueStruct{
 	originFullName: "otlpresource.Resource",
 	fields: []baseField{
 		attributes,
+		droppedAttributesCount,
 	},
 }
 

--- a/model/internal/pdata/generated_resource.go
+++ b/model/internal/pdata/generated_resource.go
@@ -56,7 +56,18 @@ func (ms Resource) Attributes() AttributeMap {
 	return newAttributeMap(&(*ms.orig).Attributes)
 }
 
+// DroppedAttributesCount returns the droppedattributescount associated with this Resource.
+func (ms Resource) DroppedAttributesCount() uint32 {
+	return (*ms.orig).DroppedAttributesCount
+}
+
+// SetDroppedAttributesCount replaces the droppedattributescount associated with this Resource.
+func (ms Resource) SetDroppedAttributesCount(v uint32) {
+	(*ms.orig).DroppedAttributesCount = v
+}
+
 // CopyTo copies all properties from the current struct to the dest.
 func (ms Resource) CopyTo(dest Resource) {
 	ms.Attributes().CopyTo(dest.Attributes())
+	dest.SetDroppedAttributesCount(ms.DroppedAttributesCount())
 }

--- a/model/internal/pdata/generated_resource_test.go
+++ b/model/internal/pdata/generated_resource_test.go
@@ -45,6 +45,14 @@ func TestResource_Attributes(t *testing.T) {
 	assert.EqualValues(t, testValAttributes, ms.Attributes())
 }
 
+func TestResource_DroppedAttributesCount(t *testing.T) {
+	ms := NewResource()
+	assert.EqualValues(t, uint32(0), ms.DroppedAttributesCount())
+	testValDroppedAttributesCount := uint32(17)
+	ms.SetDroppedAttributesCount(testValDroppedAttributesCount)
+	assert.EqualValues(t, testValDroppedAttributesCount, ms.DroppedAttributesCount())
+}
+
 func generateTestResource() Resource {
 	tv := NewResource()
 	fillTestResource(tv)
@@ -53,4 +61,5 @@ func generateTestResource() Resource {
 
 func fillTestResource(tv Resource) {
 	fillTestAttributeMap(tv.Attributes())
+	tv.SetDroppedAttributesCount(uint32(17))
 }


### PR DESCRIPTION
**Description:** Added missing droppedAttributesCount

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector/issues/4788

**Testing:** No new tests where added, few test were autogenerated.

**Documentation:** No new documentation were added
