### PR TITLE
Make AttributeValue accessors to return error in case of type mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@
 - Rename `pdata.AttributeMap.Delete` to `pdata.AttributeMap.Remove` (#4914)
 - pdata: deprecate funcs working with InternalRep (#4957)
 
+### 🚩 Deprecations 🚩
+
+- Change behavior of pdata.AttributeValue oneof value field accessors (#4909)
+  - Deprecated `AttributeValue.StringVal` in favor of `AttributeValue.StringValue`
+  - Deprecated `AttributeValue.IntVal` in favor of `AttributeValue.IntValue`
+  - Deprecated `AttributeValue.DoubleVal` in favor of `AttributeValue.DoubleValue`
+  - Deprecated `AttributeValue.BoolVal` in favor of `AttributeValue.BoolValue`
+  - Deprecated `AttributeValue.MapVal` in favor of `AttributeValue.MapValue`
+  - Deprecated `AttributeValue.SliceVal` in favor of `AttributeValue.SliceValue`
+  - Deprecated `AttributeValue.BytesVal` in favor of `AttributeValue.BytesValue`
+  - Deprecated `AttributeValue.SetStringVal` in favor of `AttributeValue.SetStringValue`
+  - Deprecated `AttributeValue.SetIntVal` in favor of `AttributeValue.SetIntValue`
+  - Deprecated `AttributeValue.SetDoubleVal` in favor of `AttributeValue.SetDoubleValue`
+  - Deprecated `AttributeValue.SetBoolVal` in favor of `AttributeValue.SetBoolValue`
+  - Deprecated `AttributeValue.SetBytesVal` in favor of `AttributeValue.SetBytesValue`
+
 ### 💡 Enhancements 💡
 
 - Add `pdata.AttributeMap.RemoveIf`, which is a more performant way to remove multiple keys (#4914)

--- a/internal/otlptext/databuffer.go
+++ b/internal/otlptext/databuffer.go
@@ -256,17 +256,23 @@ func (b *dataBuffer) logLinks(description string, sl pdata.SpanLinkSlice) {
 func attributeValueToString(av pdata.AttributeValue) string {
 	switch av.Type() {
 	case pdata.AttributeValueTypeString:
-		return av.StringVal()
+		val, _ := av.StringValue()
+		return val
 	case pdata.AttributeValueTypeBool:
-		return strconv.FormatBool(av.BoolVal())
+		val, _ := av.BoolValue()
+		return strconv.FormatBool(val)
 	case pdata.AttributeValueTypeDouble:
-		return strconv.FormatFloat(av.DoubleVal(), 'f', -1, 64)
+		val, _ := av.DoubleValue()
+		return strconv.FormatFloat(val, 'f', -1, 64)
 	case pdata.AttributeValueTypeInt:
-		return strconv.FormatInt(av.IntVal(), 10)
+		val, _ := av.IntValue()
+		return strconv.FormatInt(val, 10)
 	case pdata.AttributeValueTypeArray:
-		return attributeValueSliceToString(av.SliceVal())
+		val, _ := av.SliceValue()
+		return attributeValueSliceToString(val)
 	case pdata.AttributeValueTypeMap:
-		return attributeMapToString(av.MapVal())
+		val, _ := av.MapValue()
+		return attributeMapToString(val)
 	default:
 		return fmt.Sprintf("<Unknown OpenTelemetry attribute value type %q>", av.Type())
 	}

--- a/internal/otlptext/databuffer_test.go
+++ b/internal/otlptext/databuffer_test.go
@@ -24,6 +24,26 @@ import (
 
 func TestNestedArraySerializesCorrectly(t *testing.T) {
 	ava := pdata.NewAttributeValueArray()
+	avaVal, err := ava.SliceValue()
+	assert.NoError(t, err)
+	avaVal.AppendEmpty().SetStringValue("foo")
+	avaVal.AppendEmpty().SetIntValue(42)
+
+	ava2 := pdata.NewAttributeValueArray()
+	ava2Val, err := ava2.SliceValue()
+	assert.NoError(t, err)
+	ava2Val.AppendEmpty().SetStringValue("bar")
+	ava2.CopyTo(avaVal.AppendEmpty())
+
+	avaVal.AppendEmpty().SetBoolValue(true)
+	avaVal.AppendEmpty().SetDoubleValue(5.5)
+
+	assert.Equal(t, 5, avaVal.Len())
+	assert.Equal(t, "[foo, 42, [bar], true, 5.5]", attributeValueToString(ava))
+}
+
+func TestNestedArraySerializesCorrectlyDeprecated(t *testing.T) {
+	ava := pdata.NewAttributeValueArray()
 	ava.SliceVal().AppendEmpty().SetStringVal("foo")
 	ava.SliceVal().AppendEmpty().SetIntVal(42)
 
@@ -40,11 +60,13 @@ func TestNestedArraySerializesCorrectly(t *testing.T) {
 
 func TestNestedMapSerializesCorrectly(t *testing.T) {
 	ava := pdata.NewAttributeValueMap()
-	av := ava.MapVal()
+	av, err := ava.MapValue()
+	assert.NoError(t, err)
 	av.Insert("foo", pdata.NewAttributeValueString("test"))
 
 	ava2 := pdata.NewAttributeValueMap()
-	av2 := ava2.MapVal()
+	av2, err := ava2.MapValue()
+	assert.NoError(t, err)
 	av2.InsertInt("bar", 13)
 	av.Insert("zoo", ava2)
 
@@ -53,6 +75,6 @@ func TestNestedMapSerializesCorrectly(t *testing.T) {
      -> zoo: MAP({"bar":13})
 }`
 
-	assert.Equal(t, 2, ava.MapVal().Len())
+	assert.Equal(t, 2, av.Len())
 	assert.Equal(t, expected, attributeValueToString(ava))
 }

--- a/internal/testdata/log.go
+++ b/internal/testdata/log.go
@@ -82,7 +82,7 @@ func fillLogOne(log pdata.LogRecord) {
 	attrs.InsertString("app", "server")
 	attrs.InsertInt("instance_num", 1)
 
-	log.Body().SetStringVal("This is a log message")
+	log.Body().SetStringValue("This is a log message")
 }
 
 func fillLogTwo(log pdata.LogRecord) {
@@ -95,7 +95,7 @@ func fillLogTwo(log pdata.LogRecord) {
 	attrs.InsertString("customer", "acme")
 	attrs.InsertString("env", "dev")
 
-	log.Body().SetStringVal("something happened")
+	log.Body().SetStringValue("something happened")
 }
 
 func fillLogThree(log pdata.LogRecord) {
@@ -104,7 +104,7 @@ func fillLogThree(log pdata.LogRecord) {
 	log.SetSeverityNumber(pdata.SeverityNumberWARN)
 	log.SetSeverityText("Warning")
 
-	log.Body().SetStringVal("something else happened")
+	log.Body().SetStringValue("something else happened")
 }
 
 func GenerateLogsManyLogRecordsSameResource(count int) pdata.Logs {

--- a/model/internal/pdata/common.go
+++ b/model/internal/pdata/common.go
@@ -28,6 +28,15 @@ import (
 	otlpcommon "go.opentelemetry.io/collector/model/internal/data/protogen/common/v1"
 )
 
+type AttributeValueTypeMismatchError struct {
+	actualType    AttributeValueType
+	requestedType AttributeValueType
+}
+
+func (err AttributeValueTypeMismatchError) Error() string {
+	return fmt.Sprintf("type of the attibute value is %s, not %s", err.actualType, err.requestedType)
+}
+
 // AttributeValueType specifies the type of AttributeValue.
 type AttributeValueType int32
 
@@ -72,7 +81,7 @@ func (avt AttributeValueType) String() string {
 // value representation. For the same reason passing by value and calling setters
 // will modify the original, e.g.:
 //
-//   func f1(val AttributeValue) { val.SetIntVal(234) }
+//   func f1(val AttributeValue) { val.SetIntValue(234) }
 //   func f2() {
 //       v := NewAttributeValueString("a string")
 //       f1(v)
@@ -159,29 +168,77 @@ func (a AttributeValue) Type() AttributeValueType {
 // StringVal returns the string value associated with this AttributeValue.
 // If the Type() is not AttributeValueTypeString then returns empty string.
 // Calling this function on zero-initialized AttributeValue will cause a panic.
+// Deprecated: [v0.47.0] Use StringValue instead.
 func (a AttributeValue) StringVal() string {
 	return a.orig.GetStringValue()
+}
+
+// StringValue returns the string value associated with this AttributeValue.
+// Calling this function on zero-initialized AttributeValue will cause a panic.
+// The error is returned only if Type() != AttributeValueTypeString,
+// it can be ignored if the type is checked prior to the call.
+func (a AttributeValue) StringValue() (string, error) {
+	if a.Type() == AttributeValueTypeString {
+		return a.orig.Value.(*otlpcommon.AnyValue_StringValue).StringValue, nil
+	}
+	return "", AttributeValueTypeMismatchError{a.Type(), AttributeValueTypeString}
 }
 
 // IntVal returns the int64 value associated with this AttributeValue.
 // If the Type() is not AttributeValueTypeInt then returns int64(0).
 // Calling this function on zero-initialized AttributeValue will cause a panic.
+// Deprecated: [v0.47.0] Use IntValue instead.
 func (a AttributeValue) IntVal() int64 {
 	return a.orig.GetIntValue()
+}
+
+// IntValue returns the int64 value associated with this AttributeValue.
+// Calling this function on zero-initialized AttributeValue will cause a panic.
+// The error is returned only if Type() != AttributeValueTypeInt,
+// it can be ignored if the type is checked prior to the call.
+func (a AttributeValue) IntValue() (int64, error) {
+	if a.Type() == AttributeValueTypeInt {
+		return a.orig.Value.(*otlpcommon.AnyValue_IntValue).IntValue, nil
+	}
+	return 0, AttributeValueTypeMismatchError{a.Type(), AttributeValueTypeInt}
 }
 
 // DoubleVal returns the float64 value associated with this AttributeValue.
 // If the Type() is not AttributeValueTypeDouble then returns float64(0).
 // Calling this function on zero-initialized AttributeValue will cause a panic.
+// Deprecated: [v0.47.0] Use DoubleValue instead.
 func (a AttributeValue) DoubleVal() float64 {
 	return a.orig.GetDoubleValue()
+}
+
+// DoubleValue returns the float64 value associated with this AttributeValue.
+// Calling this function on zero-initialized AttributeValue will cause a panic.
+// The error is returned only if Type() != AttributeValueTypeDouble,
+// it can be ignored if the type is checked prior to the call.
+func (a AttributeValue) DoubleValue() (float64, error) {
+	if a.Type() == AttributeValueTypeDouble {
+		return a.orig.Value.(*otlpcommon.AnyValue_DoubleValue).DoubleValue, nil
+	}
+	return 0, AttributeValueTypeMismatchError{a.Type(), AttributeValueTypeDouble}
 }
 
 // BoolVal returns the bool value associated with this AttributeValue.
 // If the Type() is not AttributeValueTypeBool then returns false.
 // Calling this function on zero-initialized AttributeValue will cause a panic.
+// Deprecated: [v0.47.0] Use BoolValue instead.
 func (a AttributeValue) BoolVal() bool {
 	return a.orig.GetBoolValue()
+}
+
+// BoolValue returns the bool value associated with this AttributeValue.
+// Calling this function on zero-initialized AttributeValue will cause a panic.
+// The error is returned only if Type() != AttributeValueTypeBool,
+// it can be ignored if the type is checked prior to the call.
+func (a AttributeValue) BoolValue() (bool, error) {
+	if a.Type() == AttributeValueTypeBool {
+		return a.orig.Value.(*otlpcommon.AnyValue_BoolValue).BoolValue, nil
+	}
+	return false, AttributeValueTypeMismatchError{a.Type(), AttributeValueTypeBool}
 }
 
 // MapVal returns the map value associated with this AttributeValue.
@@ -189,6 +246,7 @@ func (a AttributeValue) BoolVal() bool {
 // such empty map has no effect on this AttributeValue.
 //
 // Calling this function on zero-initialized AttributeValue will cause a panic.
+// Deprecated: [v0.47.0] Use MapValue instead.
 func (a AttributeValue) MapVal() AttributeMap {
 	kvlist := a.orig.GetKvlistValue()
 	if kvlist == nil {
@@ -197,11 +255,23 @@ func (a AttributeValue) MapVal() AttributeMap {
 	return newAttributeMap(&kvlist.Values)
 }
 
+// MapValue returns the map value associated with this AttributeValue.
+// Calling this function on zero-initialized AttributeValue will cause a panic.
+// The error is returned only if Type() != AttributeValueTypeMap,
+// it can be ignored if the type is checked prior to the call.
+func (a AttributeValue) MapValue() (AttributeMap, error) {
+	if a.Type() == AttributeValueTypeMap {
+		return newAttributeMap(&a.orig.Value.(*otlpcommon.AnyValue_KvlistValue).KvlistValue.Values), nil
+	}
+	return NewAttributeMap(), AttributeValueTypeMismatchError{a.Type(), AttributeValueTypeMap}
+}
+
 // SliceVal returns the slice value associated with this AttributeValue.
 // If the Type() is not AttributeValueTypeArray then returns an empty slice. Note that modifying
 // such empty slice has no effect on this AttributeValue.
 //
 // Calling this function on zero-initialized AttributeValue will cause a panic.
+// Deprecated: [v0.47.0] Use SliceValue instead.
 func (a AttributeValue) SliceVal() AttributeValueSlice {
 	arr := a.orig.GetArrayValue()
 	if arr == nil {
@@ -210,39 +280,94 @@ func (a AttributeValue) SliceVal() AttributeValueSlice {
 	return newAttributeValueSlice(&arr.Values)
 }
 
+// SliceValue returns the slice value associated with this AttributeValue.
+// Calling this function on zero-initialized AttributeValue will cause a panic.
+// The error is returned only if Type() != AttributeValueTypeArray,
+// it can be ignored if the type is checked prior to the call.
+func (a AttributeValue) SliceValue() (AttributeValueSlice, error) {
+	if a.Type() == AttributeValueTypeArray {
+		return newAttributeValueSlice(&a.orig.Value.(*otlpcommon.AnyValue_ArrayValue).ArrayValue.Values), nil
+	}
+	return NewAttributeValueSlice(), AttributeValueTypeMismatchError{a.Type(), AttributeValueTypeArray}
+}
+
 // BytesVal returns the []byte value associated with this AttributeValue.
 // If the Type() is not AttributeValueTypeBytes then returns false.
 // Calling this function on zero-initialized AttributeValue will cause a panic.
 // Modifying the returned []byte in-place is forbidden.
+// Deprecated: [v0.47.0] Use BytesValue instead.
 func (a AttributeValue) BytesVal() []byte {
 	return a.orig.GetBytesValue()
+}
+
+// BytesValue returns the []byte value associated with this AttributeValue.
+// Calling this function on zero-initialized AttributeValue will cause a panic.
+// The error is returned only if Type() != AttributeValueTypeBytes,
+// it can be ignored if the type is checked prior to the call.
+func (a AttributeValue) BytesValue() ([]byte, error) {
+	if a.Type() == AttributeValueTypeBytes {
+		return a.orig.Value.(*otlpcommon.AnyValue_BytesValue).BytesValue, nil
+	}
+	return nil, AttributeValueTypeMismatchError{a.Type(), AttributeValueTypeBytes}
 }
 
 // SetStringVal replaces the string value associated with this AttributeValue,
 // it also changes the type to be AttributeValueTypeString.
 // Calling this function on zero-initialized AttributeValue will cause a panic.
+// Deprecated: [v0.47.0] Use SetStringValue instead.
 func (a AttributeValue) SetStringVal(v string) {
+	a.SetStringValue(v)
+}
+
+// SetStringValue replaces the string value associated with this AttributeValue,
+// it also changes the type to be AttributeValueTypeString.
+// Calling this function on zero-initialized AttributeValue will cause a panic.
+func (a AttributeValue) SetStringValue(v string) {
 	a.orig.Value = &otlpcommon.AnyValue_StringValue{StringValue: v}
 }
 
 // SetIntVal replaces the int64 value associated with this AttributeValue,
 // it also changes the type to be AttributeValueTypeInt.
 // Calling this function on zero-initialized AttributeValue will cause a panic.
+// Deprecated: [v0.47.0] Use SetIntValue instead.
 func (a AttributeValue) SetIntVal(v int64) {
+	a.SetIntValue(v)
+}
+
+// SetIntValue replaces the int64 value associated with this AttributeValue,
+// it also changes the type to be AttributeValueTypeInt.
+// Calling this function on zero-initialized AttributeValue will cause a panic.
+func (a AttributeValue) SetIntValue(v int64) {
 	a.orig.Value = &otlpcommon.AnyValue_IntValue{IntValue: v}
 }
 
 // SetDoubleVal replaces the float64 value associated with this AttributeValue,
 // it also changes the type to be AttributeValueTypeDouble.
 // Calling this function on zero-initialized AttributeValue will cause a panic.
+// Deprecated: [v0.47.0] Use SetDoubleValue instead.
 func (a AttributeValue) SetDoubleVal(v float64) {
+	a.SetDoubleValue(v)
+}
+
+// SetDoubleValue replaces the float64 value associated with this AttributeValue,
+// it also changes the type to be AttributeValueTypeDouble.
+// Calling this function on zero-initialized AttributeValue will cause a panic.
+func (a AttributeValue) SetDoubleValue(v float64) {
 	a.orig.Value = &otlpcommon.AnyValue_DoubleValue{DoubleValue: v}
 }
 
 // SetBoolVal replaces the bool value associated with this AttributeValue,
 // it also changes the type to be AttributeValueTypeBool.
 // Calling this function on zero-initialized AttributeValue will cause a panic.
+// Deprecated: [v0.47.0] Use SetBoolValue instead.
 func (a AttributeValue) SetBoolVal(v bool) {
+	a.SetBoolValue(v)
+}
+
+// SetBoolValue replaces the bool value associated with this AttributeValue,
+// it also changes the type to be AttributeValueTypeBool.
+// Calling this function on zero-initialized AttributeValue will cause a panic.
+func (a AttributeValue) SetBoolValue(v bool) {
 	a.orig.Value = &otlpcommon.AnyValue_BoolValue{BoolValue: v}
 }
 
@@ -251,7 +376,17 @@ func (a AttributeValue) SetBoolVal(v bool) {
 // Calling this function on zero-initialized AttributeValue will cause a panic.
 // The caller must ensure the []byte passed in is not modified after the call is made, sharing the data
 // across multiple attributes is forbidden.
+// Deprecated: [v0.47.0] Use SetBytesValue instead.
 func (a AttributeValue) SetBytesVal(v []byte) {
+	a.SetBytesValue(v)
+}
+
+// SetBytesValue replaces the []byte value associated with this AttributeValue,
+// it also changes the type to be AttributeValueTypeBytes.
+// Calling this function on zero-initialized AttributeValue will cause a panic.
+// The caller must ensure the []byte passed in is not modified after the call is made, sharing the data
+// across multiple attributes is forbidden.
+func (a AttributeValue) SetBytesValue(v []byte) {
 	a.orig.Value = &otlpcommon.AnyValue_BytesValue{BytesValue: v}
 }
 
@@ -365,7 +500,7 @@ func (a AttributeValue) Equal(av AttributeValue) bool {
 }
 
 // AsString converts an OTLP AttributeValue object of any type to its equivalent string
-// representation. This differs from StringVal which only returns a non-empty value
+// representation. This differs from StringValue which only returns a value
 // if the AttributeValueType is AttributeValueTypeString.
 func (a AttributeValue) AsString() string {
 	switch a.Type() {
@@ -373,26 +508,33 @@ func (a AttributeValue) AsString() string {
 		return ""
 
 	case AttributeValueTypeString:
-		return a.StringVal()
+		val, _ := a.StringValue()
+		return val
 
 	case AttributeValueTypeBool:
-		return strconv.FormatBool(a.BoolVal())
+		val, _ := a.BoolValue()
+		return strconv.FormatBool(val)
 
 	case AttributeValueTypeDouble:
-		return strconv.FormatFloat(a.DoubleVal(), 'f', -1, 64)
+		val, _ := a.DoubleValue()
+		return strconv.FormatFloat(val, 'f', -1, 64)
 
 	case AttributeValueTypeInt:
-		return strconv.FormatInt(a.IntVal(), 10)
+		val, _ := a.IntValue()
+		return strconv.FormatInt(val, 10)
 
 	case AttributeValueTypeMap:
-		jsonStr, _ := json.Marshal(a.MapVal().AsRaw())
+		val, _ := a.MapValue()
+		jsonStr, _ := json.Marshal(val.AsRaw())
 		return string(jsonStr)
 
 	case AttributeValueTypeBytes:
-		return base64.StdEncoding.EncodeToString(a.BytesVal())
+		val, _ := a.BytesValue()
+		return base64.StdEncoding.EncodeToString(val)
 
 	case AttributeValueTypeArray:
-		jsonStr, _ := json.Marshal(a.SliceVal().asRaw())
+		val, _ := a.SliceValue()
+		jsonStr, _ := json.Marshal(val.asRaw())
 		return string(jsonStr)
 
 	default:
@@ -403,14 +545,14 @@ func (a AttributeValue) AsString() string {
 func newAttributeKeyValueString(k string, v string) otlpcommon.KeyValue {
 	orig := otlpcommon.KeyValue{Key: k}
 	akv := AttributeValue{&orig.Value}
-	akv.SetStringVal(v)
+	akv.SetStringValue(v)
 	return orig
 }
 
 func newAttributeKeyValueInt(k string, v int64) otlpcommon.KeyValue {
 	orig := otlpcommon.KeyValue{Key: k}
 	akv := AttributeValue{&orig.Value}
-	akv.SetIntVal(v)
+	akv.SetIntValue(v)
 	return orig
 }
 
@@ -424,7 +566,7 @@ func newAttributeKeyValueDouble(k string, v float64) otlpcommon.KeyValue {
 func newAttributeKeyValueBool(k string, v bool) otlpcommon.KeyValue {
 	orig := otlpcommon.KeyValue{Key: k}
 	akv := AttributeValue{&orig.Value}
-	akv.SetBoolVal(v)
+	akv.SetBoolValue(v)
 	return orig
 }
 
@@ -442,7 +584,7 @@ func newAttributeKeyValue(k string, av AttributeValue) otlpcommon.KeyValue {
 func newAttributeKeyValueBytes(k string, v []byte) otlpcommon.KeyValue {
 	orig := otlpcommon.KeyValue{Key: k}
 	akv := AttributeValue{&orig.Value}
-	akv.SetBytesVal(v)
+	akv.SetBytesValue(v)
 	return orig
 }
 
@@ -631,7 +773,7 @@ func (am AttributeMap) Update(k string, v AttributeValue) {
 // No action is applied to the map where the key does not exist.
 func (am AttributeMap) UpdateString(k string, v string) {
 	if av, existing := am.Get(k); existing {
-		av.SetStringVal(v)
+		av.SetStringValue(v)
 	}
 }
 
@@ -639,7 +781,7 @@ func (am AttributeMap) UpdateString(k string, v string) {
 // No action is applied to the map where the key does not exist.
 func (am AttributeMap) UpdateInt(k string, v int64) {
 	if av, existing := am.Get(k); existing {
-		av.SetIntVal(v)
+		av.SetIntValue(v)
 	}
 }
 
@@ -647,7 +789,7 @@ func (am AttributeMap) UpdateInt(k string, v int64) {
 // No action is applied to the map where the key does not exist.
 func (am AttributeMap) UpdateDouble(k string, v float64) {
 	if av, existing := am.Get(k); existing {
-		av.SetDoubleVal(v)
+		av.SetDoubleValue(v)
 	}
 }
 
@@ -655,7 +797,7 @@ func (am AttributeMap) UpdateDouble(k string, v float64) {
 // No action is applied to the map where the key does not exist.
 func (am AttributeMap) UpdateBool(k string, v bool) {
 	if av, existing := am.Get(k); existing {
-		av.SetBoolVal(v)
+		av.SetBoolValue(v)
 	}
 }
 
@@ -665,7 +807,7 @@ func (am AttributeMap) UpdateBool(k string, v bool) {
 // across multiple attributes is forbidden.
 func (am AttributeMap) UpdateBytes(k string, v []byte) {
 	if av, existing := am.Get(k); existing {
-		av.SetBytesVal(v)
+		av.SetBytesValue(v)
 	}
 }
 
@@ -690,7 +832,7 @@ func (am AttributeMap) Upsert(k string, v AttributeValue) {
 // updated to the map where the key already existed.
 func (am AttributeMap) UpsertString(k string, v string) {
 	if av, existing := am.Get(k); existing {
-		av.SetStringVal(v)
+		av.SetStringValue(v)
 	} else {
 		*am.orig = append(*am.orig, newAttributeKeyValueString(k, v))
 	}
@@ -701,7 +843,7 @@ func (am AttributeMap) UpsertString(k string, v string) {
 // updated to the map where the key already existed.
 func (am AttributeMap) UpsertInt(k string, v int64) {
 	if av, existing := am.Get(k); existing {
-		av.SetIntVal(v)
+		av.SetIntValue(v)
 	} else {
 		*am.orig = append(*am.orig, newAttributeKeyValueInt(k, v))
 	}
@@ -712,7 +854,7 @@ func (am AttributeMap) UpsertInt(k string, v int64) {
 // updated to the map where the key already existed.
 func (am AttributeMap) UpsertDouble(k string, v float64) {
 	if av, existing := am.Get(k); existing {
-		av.SetDoubleVal(v)
+		av.SetDoubleValue(v)
 	} else {
 		*am.orig = append(*am.orig, newAttributeKeyValueDouble(k, v))
 	}
@@ -723,7 +865,7 @@ func (am AttributeMap) UpsertDouble(k string, v float64) {
 // updated to the map where the key already existed.
 func (am AttributeMap) UpsertBool(k string, v bool) {
 	if av, existing := am.Get(k); existing {
-		av.SetBoolVal(v)
+		av.SetBoolValue(v)
 	} else {
 		*am.orig = append(*am.orig, newAttributeKeyValueBool(k, v))
 	}
@@ -736,7 +878,7 @@ func (am AttributeMap) UpsertBool(k string, v bool) {
 // across multiple attributes is forbidden.
 func (am AttributeMap) UpsertBytes(k string, v []byte) {
 	if av, existing := am.Get(k); existing {
-		av.SetBytesVal(v)
+		av.SetBytesValue(v)
 	} else {
 		*am.orig = append(*am.orig, newAttributeKeyValueBytes(k, v))
 	}
@@ -809,21 +951,28 @@ func (am AttributeMap) AsRaw() map[string]interface{} {
 	am.Range(func(k string, v AttributeValue) bool {
 		switch v.Type() {
 		case AttributeValueTypeString:
-			rawMap[k] = v.StringVal()
+			val, _ := v.StringValue()
+			rawMap[k] = val
 		case AttributeValueTypeInt:
-			rawMap[k] = v.IntVal()
+			val, _ := v.IntValue()
+			rawMap[k] = val
 		case AttributeValueTypeDouble:
-			rawMap[k] = v.DoubleVal()
+			val, _ := v.DoubleValue()
+			rawMap[k] = val
 		case AttributeValueTypeBool:
-			rawMap[k] = v.BoolVal()
+			val, _ := v.BoolValue()
+			rawMap[k] = val
 		case AttributeValueTypeBytes:
-			rawMap[k] = v.BytesVal()
+			val, _ := v.BytesValue()
+			rawMap[k] = val
 		case AttributeValueTypeEmpty:
 			rawMap[k] = nil
 		case AttributeValueTypeMap:
-			rawMap[k] = v.MapVal().AsRaw()
+			val, _ := v.MapValue()
+			rawMap[k] = val.AsRaw()
 		case AttributeValueTypeArray:
-			rawMap[k] = v.SliceVal().asRaw()
+			val, _ := v.SliceValue()
+			rawMap[k] = val.asRaw()
 		}
 		return true
 	})
@@ -837,15 +986,20 @@ func (es AttributeValueSlice) asRaw() []interface{} {
 		v := es.At(i)
 		switch v.Type() {
 		case AttributeValueTypeString:
-			rawSlice = append(rawSlice, v.StringVal())
+			val, _ := v.StringValue()
+			rawSlice = append(rawSlice, val)
 		case AttributeValueTypeInt:
-			rawSlice = append(rawSlice, v.IntVal())
+			val, _ := v.IntValue()
+			rawSlice = append(rawSlice, val)
 		case AttributeValueTypeDouble:
-			rawSlice = append(rawSlice, v.DoubleVal())
+			val, _ := v.DoubleValue()
+			rawSlice = append(rawSlice, val)
 		case AttributeValueTypeBool:
-			rawSlice = append(rawSlice, v.BoolVal())
+			val, _ := v.BoolValue()
+			rawSlice = append(rawSlice, val)
 		case AttributeValueTypeBytes:
-			rawSlice = append(rawSlice, v.BytesVal())
+			val, _ := v.BytesValue()
+			rawSlice = append(rawSlice, val)
 		case AttributeValueTypeEmpty:
 			rawSlice = append(rawSlice, nil)
 		default:


### PR DESCRIPTION
This is an alternative solution to https://github.com/open-telemetry/opentelemetry-collector/pull/4909 proposed by @Aneurysm9

The following methods are deprecated in favor of the new accessors:
- StringVal -> StringValue
- IntVal -> IntValue
- DoubleVal -> DoubleValue
- BoolVal -> BoolValue
- MapVal -> MapValue
- SliceVal -> SliceValue
- BytesVal -> BytesValue

The new accessors return additional error. The error is raised if accessor is called for a wrong type, e.g. `IntValue()` is called on `AttributeValue` of `AttributeValueTypeString` type.

Corresponding setter methods are also renamed for consistency without changing its logic:
- SetStringVal -> SetStringValue
- SetIntVal -> SetIntValue
- SetDoubleVal -> SetDoubleValue
- SetBoolVal -> SetBoolValue
- SetBytesVal -> SetBytesValue

## Benchmarks

goos: darwin
goarch: amd64
pkg: go.opentelemetry.io/collector/model/internal/pdata
cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz

### Before

```
BenchmarkAttributeValueStringDeprecatedAccessor-16                  1000000000           0.6064 ns/op          0 B/op          0 allocs/op
BenchmarkAttributeValueIntDeprecatedAccessor-16                     1000000000           0.6103 ns/op          0 B/op          0 allocs/op
BenchmarkAttributeValueDoubleDeprecatedAccessor-16                  1000000000           0.6048 ns/op          0 B/op          0 allocs/op
BenchmarkAttributeValueBoolDeprecatedAccessor-16                    1000000000           0.6933 ns/op          0 B/op          0 allocs/op
BenchmarkAttributeValueBytesDeprecatedAccessor-16                   1000000000           0.6501 ns/op          0 B/op          0 allocs/op
BenchmarkAttributeValueMapDeprecatedAccessor-16                     556089897            2.182 ns/op           0 B/op          0 allocs/op
BenchmarkAttributeValueArrayDeprecatedAccessor-16                   541185199            2.179 ns/op           0 B/op          0 allocs/op

```

### After

```
BenchmarkAttributeValueStringAccessor-16                            353806957            3.464 ns/op           0 B/op          0 allocs/op
BenchmarkAttributeValueIntAccessor-16                               346630108            3.479 ns/op           0 B/op          0 allocs/op
BenchmarkAttributeValueDoubleAccessor-16                            356147574            3.358 ns/op           0 B/op          0 allocs/op
BenchmarkAttributeValueBoolAccessor-16                              350702415            3.472 ns/op           0 B/op          0 allocs/op
BenchmarkAttributeValueBytesAccessor-16                             331781389            3.677 ns/op           0 B/op          0 allocs/op
BenchmarkAttributeValueMapAccessor-16                               341309820            3.559 ns/op           0 B/op          0 allocs/op
BenchmarkAttributeValueArrayAccessor-16                             346380688            3.493 ns/op           0 B/op          0 allocs/op
```