### PR TITLE
Run unit tests on go 1.18 in addition to 1.17

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -124,6 +124,9 @@ jobs:
       - name: Multimod verify
         run: make multimod-verify
   unittest:
+    strategy:
+      matrix:
+        go-version: [1.18, 1.17]
     runs-on: ubuntu-latest
     needs: [setup-environment]
     steps:
@@ -132,7 +135,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: ${{ matrix.go-version }}
       - name: Setup Go Environment
         run: |
           echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-collector/issues/5032.

In order to merge this PR, an admin for the repo will need to change the branch protection rules for `main` to require the `build-and-test / unittest (1.18)` and `build-and-test / unittest (1.17)`  checks instead of the `unittest` check.

I don't think this needs a changelog entry.