### PR TITLE
Deprecate LogRecord.Name(), it was deprecated in the data model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
   - `pdata.AttributeValueType` type is deprecated in favor of `pdata.ValueType`
   - `pdata.AttributeValueType...` constants are deprecated in favor of `pdata.ValueType...`
   - `pdata.NewAttributeValue...` funcs are deprecated in favor of `pdata.NewValue...`
+- Deprecate LogRecord.Name(), it was deprecated in the data model (#5054)
 
 ## v0.47.0 Beta
 

--- a/model/internal/cmd/pdatagen/internal/base_fields.go
+++ b/model/internal/cmd/pdatagen/internal/base_fields.go
@@ -44,7 +44,7 @@ const accessorsMessageValueTestTemplate = `func Test${structName}_${fieldName}(t
 }`
 
 const accessorsPrimitiveTemplate = `// ${fieldName} returns the ${lowerFieldName} associated with this ${structName}.
-func (ms ${structName}) ${fieldName}() ${returnType} {
+${extraComment}func (ms ${structName}) ${fieldName}() ${returnType} {
 	return (*ms.orig).${originFieldName}
 }
 
@@ -239,6 +239,7 @@ func (mf *messageValueField) generateCopyToValue(sb *strings.Builder) {
 var _ baseField = (*messageValueField)(nil)
 
 type primitiveField struct {
+	extraComment    string
 	fieldName       string
 	originFieldName string
 	returnType      string
@@ -251,6 +252,11 @@ func (pf *primitiveField) generateAccessors(ms baseStruct, sb *strings.Builder) 
 		switch name {
 		case "structName":
 			return ms.getName()
+		case "extraComment":
+			if pf.extraComment != "" {
+				return "//\n// " + pf.extraComment + "\n"
+			}
+			return ""
 		case "fieldName":
 			return pf.fieldName
 		case "lowerFieldName":

--- a/model/internal/cmd/pdatagen/internal/log_structs.go
+++ b/model/internal/cmd/pdatagen/internal/log_structs.go
@@ -122,6 +122,7 @@ var logRecord = &messageValueStruct{
 			testVal:         `SeverityNumberINFO`,
 		},
 		&primitiveField{
+			extraComment:    "Deprecated: [v0.48.0] it was removed from the data model.",
 			fieldName:       "Name",
 			originFieldName: "Name",
 			returnType:      "string",

--- a/model/internal/pdata/generated_log.go
+++ b/model/internal/pdata/generated_log.go
@@ -640,6 +640,8 @@ func (ms LogRecord) SetSeverityNumber(v SeverityNumber) {
 }
 
 // Name returns the name associated with this LogRecord.
+//
+// Deprecated: [v0.48.0] it was removed from the data model.
 func (ms LogRecord) Name() string {
 	return (*ms.orig).Name
 }


### PR DESCRIPTION
Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
