### PR TITLE
Change parameter 'location' to a more relevant name

### DIFF
--- a/config/mapprovider.go
+++ b/config/mapprovider.go
@@ -38,9 +38,9 @@ type MapProvider interface {
 	// contains the value to be injected in the configuration and the corresponding watcher that
 	// will be used to monitor for updates of the retrieved value.
 	//
-	// `location` must follow the "<scheme>:<opaque_data>" format. This format is compatible
+	// `uri` must follow the "<scheme>:<opaque_data>" format. This format is compatible
 	// with the URI definition (see https://datatracker.ietf.org/doc/html/rfc3986). The "<scheme>"
-	// must be always included in the `location`. The scheme supported by any provider MUST be at
+	// must be always included in the `uri`. The scheme supported by any provider MUST be at
 	// least 2 characters long to avoid conflicting with a driver-letter identifier as specified
 	// in https://tools.ietf.org/id/draft-kerwin-file-scheme-07.html#syntax.
 	//
@@ -52,7 +52,7 @@ type MapProvider interface {
 	//
 	// If ctx is cancelled should return immediately with an error.
 	// Should never be called concurrently with itself or with Shutdown.
-	Retrieve(ctx context.Context, location string, watcher WatcherFunc) (Retrieved, error)
+	Retrieve(ctx context.Context, uri string, watcher WatcherFunc) (Retrieved, error)
 
 	// Shutdown signals that the configuration for which this Provider was used to
 	// retrieve values is no longer in use and the Provider should close and release

--- a/config/mapprovider/envmapprovider/mapprovider.go
+++ b/config/mapprovider/envmapprovider/mapprovider.go
@@ -37,12 +37,12 @@ func New() config.MapProvider {
 	return &mapProvider{}
 }
 
-func (emp *mapProvider) Retrieve(_ context.Context, location string, _ config.WatcherFunc) (config.Retrieved, error) {
-	if !strings.HasPrefix(location, schemeName+":") {
-		return config.Retrieved{}, fmt.Errorf("%v location is not supported by %v provider", location, schemeName)
+func (emp *mapProvider) Retrieve(_ context.Context, uri string, _ config.WatcherFunc) (config.Retrieved, error) {
+	if !strings.HasPrefix(uri, schemeName+":") {
+		return config.Retrieved{}, fmt.Errorf("%v uri is not supported by %v provider", uri, schemeName)
 	}
 
-	content := os.Getenv(location[len(schemeName)+1:])
+	content := os.Getenv(uri[len(schemeName)+1:])
 	var data map[string]interface{}
 	if err := yaml.Unmarshal([]byte(content), &data); err != nil {
 		return config.Retrieved{}, fmt.Errorf("unable to parse yaml: %w", err)

--- a/config/mapprovider/filemapprovider/mapprovider.go
+++ b/config/mapprovider/filemapprovider/mapprovider.go
@@ -32,10 +32,10 @@ type mapProvider struct{}
 
 // New returns a new config.MapProvider that reads the configuration from a file.
 //
-// This Provider supports "file" scheme, and can be called with a "location" that follows:
-//   file-location = "file:" local-path
-//   local-path    = [ drive-letter ] file-path
-//   drive-letter  = ALPHA ":"
+// This Provider supports "file" scheme, and can be called with a "uri" that follows:
+//   file-uri		= "file:" local-path
+//   local-path		= [ drive-letter ] file-path
+//   drive-letter	= ALPHA ":"
 // The "file-path" can be relative or absolute, and it can be any OS supported format.
 //
 // Examples:
@@ -47,15 +47,15 @@ func New() config.MapProvider {
 	return &mapProvider{}
 }
 
-func (fmp *mapProvider) Retrieve(_ context.Context, location string, _ config.WatcherFunc) (config.Retrieved, error) {
-	if !strings.HasPrefix(location, schemeName+":") {
-		return config.Retrieved{}, fmt.Errorf("%v location is not supported by %v provider", location, schemeName)
+func (fmp *mapProvider) Retrieve(_ context.Context, uri string, _ config.WatcherFunc) (config.Retrieved, error) {
+	if !strings.HasPrefix(uri, schemeName+":") {
+		return config.Retrieved{}, fmt.Errorf("%v uri is not supported by %v provider", uri, schemeName)
 	}
 
 	// Clean the path before using it.
-	content, err := ioutil.ReadFile(filepath.Clean(location[len(schemeName)+1:]))
+	content, err := ioutil.ReadFile(filepath.Clean(uri[len(schemeName)+1:]))
 	if err != nil {
-		return config.Retrieved{}, fmt.Errorf("unable to read the file %v: %w", location, err)
+		return config.Retrieved{}, fmt.Errorf("unable to read the file %v: %w", uri, err)
 	}
 
 	var data map[string]interface{}

--- a/config/mapprovider/yamlmapprovider/mapprovider.go
+++ b/config/mapprovider/yamlmapprovider/mapprovider.go
@@ -30,8 +30,8 @@ type mapProvider struct{}
 
 // New returns a new config.MapProvider that allows to provide yaml bytes.
 //
-// This Provider supports "yaml" scheme, and can be called with a "location" that follows:
-//   bytes-location   = "yaml:" yaml-bytes
+// This Provider supports "yaml" scheme, and can be called with a "uri" that follows:
+//   bytes-uri = "yaml:" yaml-bytes
 //
 // Examples:
 // `yaml:processors::batch::timeout: 2s`
@@ -40,13 +40,13 @@ func New() config.MapProvider {
 	return &mapProvider{}
 }
 
-func (s *mapProvider) Retrieve(_ context.Context, location string, _ config.WatcherFunc) (config.Retrieved, error) {
-	if !strings.HasPrefix(location, schemeName+":") {
-		return config.Retrieved{}, fmt.Errorf("%v location is not supported by %v provider", location, schemeName)
+func (s *mapProvider) Retrieve(_ context.Context, uri string, _ config.WatcherFunc) (config.Retrieved, error) {
+	if !strings.HasPrefix(uri, schemeName+":") {
+		return config.Retrieved{}, fmt.Errorf("%v uri is not supported by %v provider", uri, schemeName)
 	}
 
 	var data map[string]interface{}
-	if err := yaml.Unmarshal([]byte(location[len(schemeName)+1:]), &data); err != nil {
+	if err := yaml.Unmarshal([]byte(uri[len(schemeName)+1:]), &data); err != nil {
 		return config.Retrieved{}, fmt.Errorf("unable to parse yaml: %w", err)
 	}
 


### PR DESCRIPTION
The parameter `location` used in the [`Retrieve`](https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/configmapprovider/provider.go#L57) function of the `Provider` interface does not clearly define what it is.

This PR changes it to `uri` as it more clearly defines its value, which is a [data URI scheme](https://en.wikipedia.org/wiki/Data_URI_scheme).

Closes #5002.

Signed-off-by: Martin Hickey <martin.hickey@ie.ibm.com>