### PR TITLE
Deprecate global flag in featuregates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,12 +27,17 @@
   - Deprecate `pdata.AttributeValueSlice` struct in favor of `pdata.Slice`
   - Deprecate `pdata.NewAttributeValueSlice` func in favor of `pdata.NewSlice`
 - Deprecate LogRecord.Name(), it was deprecated in the data model (#5054)
+- Deprecate global flag in `featuregates` (#5060)
 
 ### 💡 Enhancements 💡
 
 - Change outcome of `pdata.Metric.<Gauge|Sum|Histogram|ExponentialHistogram>()` functions misuse.
   In case of type mismatch, they don't panic right away but return an invalid zero-initialized
   instance for consistency with other OneOf field accessors (#5034)
+
+### 🧰 Bug fixes 🧰
+
+- The `featuregates` were not configured from the "--feature-gates" flag on windows service (#5060)
 
 ## v0.47.0 Beta
 

--- a/service/collector_windows.go
+++ b/service/collector_windows.go
@@ -28,6 +28,8 @@ import (
 	"go.uber.org/zap/zapcore"
 	"golang.org/x/sys/windows/svc"
 	"golang.org/x/sys/windows/svc/eventlog"
+
+	"go.opentelemetry.io/collector/service/featuregate"
 )
 
 type WindowsService struct {
@@ -88,6 +90,7 @@ func (s *WindowsService) start(elog *eventlog.Log, colErrorChannel chan error) e
 	if err := flags().Parse(os.Args[1:]); err != nil {
 		return err
 	}
+	featuregate.Apply(gatesList)
 	var err error
 	s.col, err = newWithWindowsEventLogCore(s.settings, elog)
 	if err != nil {

--- a/service/command.go
+++ b/service/command.go
@@ -27,7 +27,7 @@ func NewCommand(set CollectorSettings) *cobra.Command {
 		Version:      set.BuildInfo.Version,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			featuregate.Apply(featuregate.GetFlags())
+			featuregate.Apply(gatesList)
 			if set.ConfigProvider == nil {
 				set.ConfigProvider = MustNewDefaultConfigProvider(getConfigFlag(), getSetFlag())
 			}

--- a/service/featuregate/flags.go
+++ b/service/featuregate/flags.go
@@ -24,9 +24,7 @@ const gatesListCfg = "feature-gates"
 
 var gatesList = FlagValue{}
 
-// Flags adds CLI flags for managing feature gates to the provided FlagSet
-// Feature gates can be configured with `--feature-gates=foo,-bar`.  This would
-// enable the `foo` feature gate and disable the `bar` feature gate.
+// Deprecated: [v0.48.0] declare distribution flag if needed.
 func Flags(flags *flag.FlagSet) {
 	flags.Var(
 		gatesList,
@@ -34,7 +32,7 @@ func Flags(flags *flag.FlagSet) {
 		"Comma-delimited list of feature gate identifiers. Prefix with '-' to disable the feature.  '+' or no prefix will enable the feature.")
 }
 
-// GetFlags returns the FlagValue used with Flags()
+// Deprecated: [v0.48.0] declare distribution flag if needed.
 func GetFlags() FlagValue {
 	return gatesList
 }

--- a/service/flags.go
+++ b/service/flags.go
@@ -25,6 +25,7 @@ var (
 	// Command-line flag that control the configuration file.
 	configFlag = new(stringArrayValue)
 	setFlag    = new(stringArrayValue)
+	gatesList  = featuregate.FlagValue{}
 )
 
 type stringArrayValue struct {
@@ -42,7 +43,6 @@ func (s *stringArrayValue) String() string {
 
 func flags() *flag.FlagSet {
 	flagSet := new(flag.FlagSet)
-	featuregate.Flags(flagSet)
 
 	flagSet.Var(configFlag, "config", "Locations to the config file(s), note that only a"+
 		" single location can be set per flag entry e.g. `-config=file:/path/to/first --config=file:path/to/second`.")
@@ -51,6 +51,11 @@ func flags() *flag.FlagSet {
 		"Set arbitrary component config property. The component has to be defined in the config file and the flag"+
 			" has a higher precedence. Array config properties are overridden and maps are joined, note that only a single"+
 			" (first) array property can be set e.g. -set=processors.attributes.actions.key=some_key. Example --set=processors.batch.timeout=2s")
+
+	flagSet.Var(
+		gatesList,
+		"feature-gates",
+		"Comma-delimited list of feature gate identifiers. Prefix with '-' to disable the feature.  '+' or no prefix will enable the feature.")
 
 	return flagSet
 }


### PR DESCRIPTION
Distributions that build without the builder will need to declare it as they do for "config" and "set".

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
