### PR TITLE
Implement gRPC deframing directly on HTTP receiver port.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM alpine:latest as prep
+RUN apk --update add ca-certificates
+
+RUN mkdir -p /tmp
+
+FROM scratch
+
+ARG USER_UID=10001
+USER ${USER_UID}
+
+COPY --from=prep /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY bin/otelcorecol_linux_amd64 /otelcorecol
+EXPOSE 4317 55680 55679
+ENTRYPOINT ["/otelcorecol"]
+CMD ["--config", "/etc/otel/config.yaml"]

--- a/config/confighttp/confighttp.go
+++ b/config/confighttp/confighttp.go
@@ -17,6 +17,8 @@ package confighttp // import "go.opentelemetry.io/collector/config/confighttp"
 import (
 	"crypto/tls"
 	"fmt"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c"
 	"net"
 	"net/http"
 	"time"
@@ -309,6 +311,9 @@ func (hss *HTTPServerSettings) ToServer(host component.Host, settings component.
 		next:            handler,
 		includeMetadata: hss.IncludeMetadata,
 	}
+
+	// support H2C
+	handler = h2c.NewHandler(handler, &http2.Server{})
 
 	return &http.Server{
 		Handler: handler,

--- a/config/confighttp/confighttp.go
+++ b/config/confighttp/confighttp.go
@@ -234,6 +234,7 @@ func (hss *HTTPServerSettings) ToListener() (net.Listener, error) {
 		if err != nil {
 			return nil, err
 		}
+		tlsCfg.NextProtos = []string{http2.NextProtoTLS}
 		listener = tls.NewListener(listener, tlsCfg)
 	}
 	return listener, nil


### PR DESCRIPTION
This is basically the opposite of the Java exporter work detailed in https://github.com/open-telemetry/opentelemetry-specification/discussions/1996. Notably, implementing unary gRPC is fairly simple with off-the-shelf HTTP frameworks. 

This isn't complete but I can finish it up if there is interest in this approach. IMO it's the best way to achieve gRPC and HTTP receivers on the same port.

Verified it basically works with the Java integration tests in https://github.com/open-telemetry/opentelemetry-java/compare/main...anuraaga:otlp-unify?expand=1

Notable functionality improvements (?) with this approach

- Only have to implement server auth extension once for HTTP and gRPC as this would just use the HTTP extensions
- Can use HTTP 1.1 with gRPC if someone wants to (only client I know of that supports this is Armeria Java but maybe there are more, but no official ones)