### PR TITLE
Fix JSON serialization tests

### DIFF
--- a/model/otlpgrpc/logs_test.go
+++ b/model/otlpgrpc/logs_test.go
@@ -33,9 +33,9 @@ var logsRequestJSON = []byte(`
 	  "resourceLogs": [
 		{
           "resource": {},
-		  "instrumentationLibraryLogs": [
+		  "scopeLogs": [
 			{
-              "instrumentationLibrary": {},
+              "scope": {},
 			  "logRecords": [
 				{
 				  "body": {

--- a/model/otlpgrpc/metrics_test.go
+++ b/model/otlpgrpc/metrics_test.go
@@ -33,9 +33,9 @@ var metricsRequestJSON = []byte(`
 	  "resourceMetrics": [
 		{
           "resource": {},
-		  "instrumentationLibraryMetrics": [
+		  "scopeMetrics": [
 			{
-              "instrumentationLibrary": {},
+              "scope": {},
 			  "metrics": [
 				{
 				  "name": "test_metric"

--- a/model/otlpgrpc/traces_test.go
+++ b/model/otlpgrpc/traces_test.go
@@ -33,9 +33,9 @@ var tracesRequestJSON = []byte(`
 	  "resourceSpans": [
 		{
           "resource": {},
-		  "instrumentationLibrarySpans": [
+		  "scopeSpans": [
 			{
-              "instrumentationLibrary": {},
+              "scope": {},
 			  "spans": [
 				{
                   "traceId": "",


### PR DESCRIPTION
This happened because the upgrade to otlp 0.15.0 is not fully implemented to deal with backwards compatibility.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
