### PR TITLE
[model/semconv] Add missing files for semconv v1.7.0 and v1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 
 ### 🧰 Bug fixes 🧰
 
+- Add missing files for semconv definitions v1.7.0 and v1.8.0 (#5091)
 - The `featuregates` were not configured from the "--feature-gates" flag on windows service (#5060)
 
 ## v0.47.0 Beta

--- a/model/semconv/v1.7.0/nonstandard.go
+++ b/model/semconv/v1.7.0/nonstandard.go
@@ -1,0 +1,22 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package semconv // import "go.opentelemetry.io/collector/model/semconv/v1.7.0"
+
+const (
+	OtelLibraryName       = "otel.library.name"
+	OtelLibraryVersion    = "otel.library.version"
+	OtelStatusCode        = "otel.status_code"
+	OtelStatusDescription = "otel.status_description"
+)

--- a/model/semconv/v1.7.0/schema.go
+++ b/model/semconv/v1.7.0/schema.go
@@ -1,0 +1,20 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package semconv // import "go.opentelemetry.io/collector/model/semconv/v1.7.0"
+
+// SchemaURL is the schema URL that matches the version of the semantic conventions
+// that this package defines. Conventions packages starting from v1.4.0 must declare
+// non-empty schema URL in the form https://opentelemetry.io/schemas/<version>
+const SchemaURL = "https://opentelemetry.io/schemas/1.7.0"

--- a/model/semconv/v1.8.0/nonstandard.go
+++ b/model/semconv/v1.8.0/nonstandard.go
@@ -1,0 +1,22 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package semconv // import "go.opentelemetry.io/collector/model/semconv/v1.8.0"
+
+const (
+	OtelLibraryName       = "otel.library.name"
+	OtelLibraryVersion    = "otel.library.version"
+	OtelStatusCode        = "otel.status_code"
+	OtelStatusDescription = "otel.status_description"
+)

--- a/model/semconv/v1.8.0/schema.go
+++ b/model/semconv/v1.8.0/schema.go
@@ -1,0 +1,20 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package semconv // import "go.opentelemetry.io/collector/model/semconv/v1.8.0"
+
+// SchemaURL is the schema URL that matches the version of the semantic conventions
+// that this package defines. Conventions packages starting from v1.4.0 must declare
+// non-empty schema URL in the form https://opentelemetry.io/schemas/<version>
+const SchemaURL = "https://opentelemetry.io/schemas/1.8.0"


### PR DESCRIPTION
Some files that are supposed to be created manually were missed in semconv v1.7.0 and v1.8.0
