### PR TITLE
Fix Semantic Convention Schema URL definition for 1.5.0 and 1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 ### 🧰 Bug fixes 🧰
 
 - The `featuregates` were not configured from the "--feature-gates" flag on windows service (#5060)
+- Fix Semantic Convention Schema URL definition for 1.5.0 and 1.6.1 versions (#5103)
 
 ## v0.47.0 Beta
 

--- a/model/semconv/v1.5.0/schema.go
+++ b/model/semconv/v1.5.0/schema.go
@@ -17,4 +17,4 @@ package semconv // import "go.opentelemetry.io/collector/model/semconv/v1.5.0"
 // SchemaURL is the schema URL that matches the version of the semantic conventions
 // that this package defines. Conventions packages starting from v1.4.0 must declare
 // non-empty schema URL in the form https://opentelemetry.io/schemas/<version>
-const SchemaURL = "https://opentelemetry.io/schemas/v1.5.0"
+const SchemaURL = "https://opentelemetry.io/schemas/1.5.0"

--- a/model/semconv/v1.6.1/schema.go
+++ b/model/semconv/v1.6.1/schema.go
@@ -17,4 +17,4 @@ package semconv // import "go.opentelemetry.io/collector/model/semconv/v1.6.1"
 // SchemaURL is the schema URL that matches the version of the semantic conventions
 // that this package defines. Conventions packages starting from v1.4.0 must declare
 // non-empty schema URL in the form https://opentelemetry.io/schemas/<version>
-const SchemaURL = "https://opentelemetry.io/schemas/v1.6.1"
+const SchemaURL = "https://opentelemetry.io/schemas/1.6.1"


### PR DESCRIPTION
This change fixes the sem conv SchemaURL values, as reported in https://github.com/open-telemetry/opentelemetry-collector/pull/5090#discussion_r835926493