### PR TITLE
[pdata] Rename MetricValueType to NumberType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,11 @@
 - Rename `Array` type of `pdata.Value` to `Slice` (#5067)
   - Deprecate `pdata.AttributeValueTypeArray` type in favor of `pdata.ValueTypeSlice`
   - Deprecate `pdata.NewAttributeValueArray` func in favor of `pdata.NewValueSlice`
+- Rename `pdata.MetricValueType` to `pdata.NumberType` (#5004)
+  - Deprecate `pdata.MetricValueType` type in favor of `pdata.NumberType`
+  - Deprecate `pdata.MetricValueTypeNone` const in favor of `pdata.NumberTypeNone`
+  - Deprecate `pdata.MetricValueTypeInt` const in favor of `pdata.NumberTypeInt`
+  - Deprecate `pdata.MetricValueTypeDouble` const in favor of `pdata.NumberTypeDouble`
 - Deprecate global flag in `featuregates` (#5060)
 - Deprecate last funcs/structs in componenthelper (#5069)
 - Change structs in otlpgrpc to follow standard go encoding interfaces (#5062)

--- a/internal/otlptext/databuffer.go
+++ b/internal/otlptext/databuffer.go
@@ -98,9 +98,9 @@ func (b *dataBuffer) logNumberDataPoints(ps pdata.NumberDataPointSlice) {
 		b.logEntry("StartTimestamp: %s", p.StartTimestamp())
 		b.logEntry("Timestamp: %s", p.Timestamp())
 		switch p.ValueType() {
-		case pdata.MetricValueTypeInt:
+		case pdata.NumberTypeInt:
 			b.logEntry("Value: %d", p.IntVal())
-		case pdata.MetricValueTypeDouble:
+		case pdata.NumberTypeDouble:
 			b.logEntry("Value: %f", p.DoubleVal())
 		}
 	}

--- a/model/internal/cmd/pdatagen/internal/metrics_structs.go
+++ b/model/internal/cmd/pdatagen/internal/metrics_structs.go
@@ -242,7 +242,7 @@ var numberDataPoint = &messageValueStruct{
 		startTimeField,
 		timeField,
 		&oneOfField{
-			typeName:         "MetricValueType",
+			typeName:         "NumberType",
 			originFieldName:  "Value",
 			originTypePrefix: "otlpmetrics.NumberDataPoint_",
 			testValueIdx:     0, // Double
@@ -412,7 +412,7 @@ var exemplar = &messageValueStruct{
 	fields: []baseField{
 		timeField,
 		&oneOfField{
-			typeName:         "MetricValueType",
+			typeName:         "NumberType",
 			originFieldName:  "Value",
 			originTypePrefix: "otlpmetrics.Exemplar_",
 			testValueIdx:     1, // Int

--- a/model/internal/pdata/generated_metrics.go
+++ b/model/internal/pdata/generated_metrics.go
@@ -1161,14 +1161,14 @@ func (ms NumberDataPoint) SetTimestamp(v Timestamp) {
 
 // ValueType returns the type of the value for this NumberDataPoint.
 // Calling this function on zero-initialized NumberDataPoint will cause a panic.
-func (ms NumberDataPoint) ValueType() MetricValueType {
+func (ms NumberDataPoint) ValueType() NumberType {
 	switch ms.orig.Value.(type) {
 	case *otlpmetrics.NumberDataPoint_AsDouble:
-		return MetricValueTypeDouble
+		return NumberTypeDouble
 	case *otlpmetrics.NumberDataPoint_AsInt:
-		return MetricValueTypeInt
+		return NumberTypeInt
 	}
-	return MetricValueTypeNone
+	return NumberTypeNone
 }
 
 // DoubleVal returns the doubleval associated with this NumberDataPoint.
@@ -1216,9 +1216,9 @@ func (ms NumberDataPoint) CopyTo(dest NumberDataPoint) {
 	dest.SetStartTimestamp(ms.StartTimestamp())
 	dest.SetTimestamp(ms.Timestamp())
 	switch ms.ValueType() {
-	case MetricValueTypeDouble:
+	case NumberTypeDouble:
 		dest.SetDoubleVal(ms.DoubleVal())
-	case MetricValueTypeInt:
+	case NumberTypeInt:
 		dest.SetIntVal(ms.IntVal())
 	}
 
@@ -2418,14 +2418,14 @@ func (ms Exemplar) SetTimestamp(v Timestamp) {
 
 // ValueType returns the type of the value for this Exemplar.
 // Calling this function on zero-initialized Exemplar will cause a panic.
-func (ms Exemplar) ValueType() MetricValueType {
+func (ms Exemplar) ValueType() NumberType {
 	switch ms.orig.Value.(type) {
 	case *otlpmetrics.Exemplar_AsDouble:
-		return MetricValueTypeDouble
+		return NumberTypeDouble
 	case *otlpmetrics.Exemplar_AsInt:
-		return MetricValueTypeInt
+		return NumberTypeInt
 	}
-	return MetricValueTypeNone
+	return NumberTypeNone
 }
 
 // DoubleVal returns the doubleval associated with this Exemplar.
@@ -2481,9 +2481,9 @@ func (ms Exemplar) SetSpanID(v SpanID) {
 func (ms Exemplar) CopyTo(dest Exemplar) {
 	dest.SetTimestamp(ms.Timestamp())
 	switch ms.ValueType() {
-	case MetricValueTypeDouble:
+	case NumberTypeDouble:
 		dest.SetDoubleVal(ms.DoubleVal())
-	case MetricValueTypeInt:
+	case NumberTypeInt:
 		dest.SetIntVal(ms.IntVal())
 	}
 

--- a/model/internal/pdata/generated_metrics_test.go
+++ b/model/internal/pdata/generated_metrics_test.go
@@ -863,12 +863,12 @@ func TestNumberDataPoint_Timestamp(t *testing.T) {
 
 func TestNumberDataPointValueType(t *testing.T) {
 	tv := NewNumberDataPoint()
-	assert.Equal(t, MetricValueTypeNone, tv.ValueType())
-	assert.Equal(t, "", MetricValueType(1000).String())
+	assert.Equal(t, NumberTypeNone, tv.ValueType())
+	assert.Equal(t, "", NumberType(1000).String())
 	tv.SetDoubleVal(float64(17.13))
-	assert.Equal(t, MetricValueTypeDouble, tv.ValueType())
+	assert.Equal(t, NumberTypeDouble, tv.ValueType())
 	tv.SetIntVal(int64(17))
-	assert.Equal(t, MetricValueTypeInt, tv.ValueType())
+	assert.Equal(t, NumberTypeInt, tv.ValueType())
 }
 
 func TestNumberDataPoint_DoubleVal(t *testing.T) {
@@ -1782,12 +1782,12 @@ func TestExemplar_Timestamp(t *testing.T) {
 
 func TestExemplarValueType(t *testing.T) {
 	tv := NewExemplar()
-	assert.Equal(t, MetricValueTypeNone, tv.ValueType())
-	assert.Equal(t, "", MetricValueType(1000).String())
+	assert.Equal(t, NumberTypeNone, tv.ValueType())
+	assert.Equal(t, "", NumberType(1000).String())
 	tv.SetDoubleVal(float64(17.13))
-	assert.Equal(t, MetricValueTypeDouble, tv.ValueType())
+	assert.Equal(t, NumberTypeDouble, tv.ValueType())
 	tv.SetIntVal(int64(17))
-	assert.Equal(t, MetricValueTypeInt, tv.ValueType())
+	assert.Equal(t, NumberTypeInt, tv.ValueType())
 }
 
 func TestExemplar_DoubleVal(t *testing.T) {

--- a/model/internal/pdata/metrics.go
+++ b/model/internal/pdata/metrics.go
@@ -218,23 +218,23 @@ const (
 	MetricDataPointFlagNoRecordedValue = MetricDataPointFlag(otlpmetrics.DataPointFlags_FLAG_NO_RECORDED_VALUE)
 )
 
-// MetricValueType specifies the type of NumberDataPoint.
-type MetricValueType int32
+// NumberType specifies the type of NumberDataPoint.
+type NumberType int32
 
 const (
-	MetricValueTypeNone MetricValueType = iota
-	MetricValueTypeInt
-	MetricValueTypeDouble
+	NumberTypeNone NumberType = iota
+	NumberTypeInt
+	NumberTypeDouble
 )
 
-// String returns the string representation of the MetricValueType.
-func (mdt MetricValueType) String() string {
-	switch mdt {
-	case MetricValueTypeNone:
+// String returns the string representation of the NumberType.
+func (nt NumberType) String() string {
+	switch nt {
+	case NumberTypeNone:
 		return "None"
-	case MetricValueTypeInt:
+	case NumberTypeInt:
 		return "Int"
-	case MetricValueTypeDouble:
+	case NumberTypeDouble:
 		return "Double"
 	}
 	return ""

--- a/model/internal/pdata/metrics_test.go
+++ b/model/internal/pdata/metrics_test.go
@@ -42,11 +42,11 @@ func TestMetricDataTypeString(t *testing.T) {
 	assert.Equal(t, "", (MetricDataTypeSummary + 1).String())
 }
 
-func TestPointMetricValueTypeString(t *testing.T) {
-	assert.Equal(t, "None", MetricValueTypeNone.String())
-	assert.Equal(t, "Int", MetricValueTypeInt.String())
-	assert.Equal(t, "Double", MetricValueTypeDouble.String())
-	assert.Equal(t, "", (MetricValueTypeDouble + 1).String())
+func TestPointNumberTypeString(t *testing.T) {
+	assert.Equal(t, "None", NumberTypeNone.String())
+	assert.Equal(t, "Int", NumberTypeInt.String())
+	assert.Equal(t, "Double", NumberTypeDouble.String())
+	assert.Equal(t, "", (NumberTypeDouble + 1).String())
 }
 
 func TestResourceMetricsWireCompatibility(t *testing.T) {

--- a/model/pdata/metrics_alias.go
+++ b/model/pdata/metrics_alias.go
@@ -73,11 +73,23 @@ const (
 	MetricDataPointFlagNoRecordedValue = pdata.MetricDataPointFlagNoRecordedValue
 )
 
-// MetricValueType is an alias for pdata.MetricValueType type.
-type MetricValueType = pdata.MetricValueType
+// NumberType is an alias for pdata.NumberType type.
+type NumberType = pdata.NumberType
 
 const (
-	MetricValueTypeNone   = pdata.MetricValueTypeNone
-	MetricValueTypeInt    = pdata.MetricValueTypeInt
-	MetricValueTypeDouble = pdata.MetricValueTypeDouble
+	NumberTypeNone   = pdata.NumberTypeNone
+	NumberTypeInt    = pdata.NumberTypeInt
+	NumberTypeDouble = pdata.NumberTypeDouble
 )
+
+// Deprecated: [v0.48.0] Use NumberType instead.
+type MetricValueType = pdata.NumberType
+
+// Deprecated: [v0.48.0] Use NumberTypeNone instead.
+const MetricValueTypeNone = pdata.NumberTypeNone
+
+// Deprecated: [v0.48.0] Use NumberTypeInt instead.
+const MetricValueTypeInt = pdata.NumberTypeInt
+
+// Deprecated: [v0.48.0] Use NumberTypeDouble instead.
+const MetricValueTypeDouble = pdata.NumberTypeDouble


### PR DESCRIPTION
`MetricValueType` name is confusing. It's not a type of any metric value, it's applicable to numeric values only.

This change proposes renaming of `pdata.MetricValueType` to `pdata.NumberType`.

Closes: https://github.com/open-telemetry/opentelemetry-collector/issues/4819