### PR TITLE
fix bug with nil Sum

### DIFF
--- a/model/internal/cmd/pdatagen/internal/base_fields.go
+++ b/model/internal/cmd/pdatagen/internal/base_fields.go
@@ -745,7 +745,9 @@ func (opv *optionalPrimitiveValue) generateSetWithTestValue(sb *strings.Builder)
 }
 
 func (opv *optionalPrimitiveValue) generateCopyToValue(sb *strings.Builder) {
-	sb.WriteString("dest.Set" + opv.fieldName + "(ms." + opv.fieldName + "())\n")
+	sb.WriteString("if ms.Has" + opv.fieldName + "(){\n")
+	sb.WriteString("\tdest.Set" + opv.fieldName + "(ms." + opv.fieldName + "())\n")
+	sb.WriteString("}\n")
 }
 
 var _ baseField = (*optionalPrimitiveValue)(nil)

--- a/model/internal/pdata/generated_metrics.go
+++ b/model/internal/pdata/generated_metrics.go
@@ -1485,7 +1485,9 @@ func (ms HistogramDataPoint) CopyTo(dest HistogramDataPoint) {
 	dest.SetStartTimestamp(ms.StartTimestamp())
 	dest.SetTimestamp(ms.Timestamp())
 	dest.SetCount(ms.Count())
-	dest.SetSum(ms.Sum())
+	if ms.HasSum() {
+		dest.SetSum(ms.Sum())
+	}
 
 	dest.SetBucketCounts(ms.BucketCounts())
 	dest.SetExplicitBounds(ms.ExplicitBounds())

--- a/model/internal/pdata/metrics_test.go
+++ b/model/internal/pdata/metrics_test.go
@@ -191,6 +191,31 @@ func TestDataPointCountWithNilDataPoints(t *testing.T) {
 	assert.EqualValues(t, 0, metrics.DataPointCount())
 }
 
+func TestHistogramWithNilSum(t *testing.T) {
+	metrics := NewMetrics()
+	ilm := metrics.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty()
+	histo := ilm.Metrics().AppendEmpty()
+	histo.SetDataType(MetricDataTypeHistogram)
+	histogramDataPoints := histo.Histogram().DataPoints()
+	histogramDataPoints.AppendEmpty()
+	dest := ilm.Metrics().AppendEmpty()
+	histo.CopyTo(dest)
+	assert.EqualValues(t, histo, dest)
+}
+
+func TestHistogramWithValidSum(t *testing.T) {
+	metrics := NewMetrics()
+	ilm := metrics.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty()
+	histo := ilm.Metrics().AppendEmpty()
+	histo.SetDataType(MetricDataTypeHistogram)
+	histogramDataPoints := histo.Histogram().DataPoints()
+	histogramDataPoints.AppendEmpty()
+	histogramDataPoints.At(0).SetSum(10)
+	dest := ilm.Metrics().AppendEmpty()
+	histo.CopyTo(dest)
+	assert.EqualValues(t, histo, dest)
+}
+
 func TestMetricsMoveTo(t *testing.T) {
 	metrics := NewMetrics()
 	fillTestResourceMetricsSlice(metrics.ResourceMetrics())


### PR DESCRIPTION
A bug was caught in the prometheus tests in the contrib repository where a histogram datapoint that contained a nil sum was copied into a new datapoint, resulting in the sum being initialized to 0.

Added a test to validate the issue is fixed. I will add another issue to add this test to the generated tests for future use.
