### PR TITLE
Make collector flag functions public to allow collector builders to use them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 💡 Enhancements 💡
 
+- Make flag functions public so they can be used by collector builders (#5130)
+
 ### 🧰 Bug fixes 🧰
 
 ## v0.48.0 Beta

--- a/service/collector_windows.go
+++ b/service/collector_windows.go
@@ -94,7 +94,7 @@ func (s *WindowsService) Execute(args []string, requests <-chan svc.ChangeReques
 
 func (s *WindowsService) start(elog *eventlog.Log, colErrorChannel chan error) error {
 	// Parse all the flags manually.
-	if err := flags().Parse(os.Args[1:]); err != nil {
+	if err := Flags().Parse(os.Args[1:]); err != nil {
 		return err
 	}
 	featuregate.Apply(gatesList)
@@ -144,7 +144,7 @@ func openEventLog(serviceName string) (*eventlog.Log, error) {
 
 func newWithWindowsEventLogCore(set CollectorSettings, elog *eventlog.Log) (*Collector, error) {
 	if set.ConfigProvider == nil {
-		set.ConfigProvider = MustNewDefaultConfigProvider(getConfigFlag(), getSetFlag())
+		set.ConfigProvider = MustNewDefaultConfigProvider(GetConfigFlag(), GetSetFlag())
 	}
 	set.LoggingOptions = append(
 		set.LoggingOptions,

--- a/service/command.go
+++ b/service/command.go
@@ -29,7 +29,7 @@ func NewCommand(set CollectorSettings) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			featuregate.Apply(gatesList)
 			if set.ConfigProvider == nil {
-				set.ConfigProvider = MustNewDefaultConfigProvider(getConfigFlag(), getSetFlag())
+				set.ConfigProvider = MustNewDefaultConfigProvider(GetConfigFlag(), GetSetFlag())
 			}
 			col, err := New(set)
 			if err != nil {
@@ -39,6 +39,6 @@ func NewCommand(set CollectorSettings) *cobra.Command {
 		},
 	}
 
-	rootCmd.Flags().AddGoFlagSet(flags())
+	rootCmd.Flags().AddGoFlagSet(Flags())
 	return rootCmd
 }

--- a/service/flags.go
+++ b/service/flags.go
@@ -41,7 +41,7 @@ func (s *stringArrayValue) String() string {
 	return "[" + strings.Join(s.values, ", ") + "]"
 }
 
-func flags() *flag.FlagSet {
+func Flags() *flag.FlagSet {
 	flagSet := new(flag.FlagSet)
 
 	flagSet.Var(configFlag, "config", "Locations to the config file(s), note that only a"+
@@ -60,10 +60,20 @@ func flags() *flag.FlagSet {
 	return flagSet
 }
 
-func getConfigFlag() []string {
+// ApplyFeatureGateFlags applies feature gates based on the content of the
+// --feature-gate flag.
+func ApplyFeatureGateFlags() {
+	featuregate.Apply(gatesList)
+}
+
+// GetConfigFlag returns the locations of config files based on the content
+// of the --config flag.
+func GetConfigFlag() []string {
 	return configFlag.values
 }
 
-func getSetFlag() []string {
+// GetSetFlag returns the list of properties based on the content of the --set
+// flag.
+func GetSetFlag() []string {
 	return setFlag.values
 }


### PR DESCRIPTION
This is the set of public changes required for https://github.com/open-telemetry/opentelemetry-collector/pull/4977.  After that, we need to wait for a release before making changes in that PR.

Part of https://github.com/open-telemetry/opentelemetry-collector/issues/4967