### PR TITLE
Remove deprecated funcs from otlpgrpc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Remove deprecated structs/funcs from previous versions (#5131)
 - Do not set TraceProvider to global otel (#5138)
+- Remove deprecated funcs from otlpgrpc (#5144)
 
 ### 🚩 Deprecations 🚩
 

--- a/model/otlpgrpc/logs.go
+++ b/model/otlpgrpc/logs.go
@@ -41,25 +41,6 @@ func NewLogsResponse() LogsResponse {
 	return LogsResponse{orig: &otlpcollectorlog.ExportLogsServiceResponse{}}
 }
 
-// Deprecated: [v0.48.0] use LogsResponse.UnmarshalProto.
-func UnmarshalLogsResponse(data []byte) (LogsResponse, error) {
-	lr := NewLogsResponse()
-	err := lr.UnmarshalProto(data)
-	return lr, err
-}
-
-// Deprecated: [v0.48.0] use LogsResponse.UnmarshalJSON.
-func UnmarshalJSONLogsResponse(data []byte) (LogsResponse, error) {
-	lr := NewLogsResponse()
-	err := lr.UnmarshalJSON(data)
-	return lr, err
-}
-
-// Deprecated: [v0.48.0] use MarshalProto.
-func (lr LogsResponse) Marshal() ([]byte, error) {
-	return lr.MarshalProto()
-}
-
 // MarshalProto marshals LogsResponse into proto bytes.
 func (lr LogsResponse) MarshalProto() ([]byte, error) {
 	return lr.orig.Marshal()
@@ -92,25 +73,6 @@ type LogsRequest struct {
 // NewLogsRequest returns an empty LogsRequest.
 func NewLogsRequest() LogsRequest {
 	return LogsRequest{orig: &otlpcollectorlog.ExportLogsServiceRequest{}}
-}
-
-// Deprecated: [v0.48.0] use LogsRequest.UnmarshalProto.
-func UnmarshalLogsRequest(data []byte) (LogsRequest, error) {
-	lr := NewLogsRequest()
-	err := lr.UnmarshalProto(data)
-	return lr, err
-}
-
-// Deprecated: [v0.48.0] use LogsRequest.UnmarshalJSON.
-func UnmarshalJSONLogsRequest(data []byte) (LogsRequest, error) {
-	lr := NewLogsRequest()
-	err := lr.UnmarshalJSON(data)
-	return lr, err
-}
-
-// Deprecated: [v0.48.0] use MarshalProto.
-func (lr LogsRequest) Marshal() ([]byte, error) {
-	return lr.MarshalProto()
 }
 
 // MarshalProto marshals LogsRequest into proto bytes.

--- a/model/otlpgrpc/logs_test.go
+++ b/model/otlpgrpc/logs_test.go
@@ -147,16 +147,6 @@ func TestLogsRequestJSONTransition(t *testing.T) {
 	}
 }
 
-func TestLogsRequestJSON_Deprecated(t *testing.T) {
-	lr, err := UnmarshalJSONLogsRequest(logsRequestJSON)
-	assert.NoError(t, err)
-	assert.Equal(t, "test_log_record", lr.Logs().ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Body().AsString())
-
-	got, err := lr.MarshalJSON()
-	assert.NoError(t, err)
-	assert.Equal(t, strings.Join(strings.Fields(string(logsRequestJSON)), ""), string(got))
-}
-
 func TestLogsGrpc(t *testing.T) {
 	lis := bufconn.Listen(1024 * 1024)
 	s := grpc.NewServer()

--- a/model/otlpgrpc/metrics.go
+++ b/model/otlpgrpc/metrics.go
@@ -37,25 +37,6 @@ func NewMetricsResponse() MetricsResponse {
 	return MetricsResponse{orig: &otlpcollectormetrics.ExportMetricsServiceResponse{}}
 }
 
-// Deprecated: [v0.48.0] use MetricsResponse.UnmarshalProto.
-func UnmarshalMetricsResponse(data []byte) (MetricsResponse, error) {
-	mr := NewMetricsResponse()
-	err := mr.UnmarshalProto(data)
-	return mr, err
-}
-
-// Deprecated: [v0.48.0] use MetricsResponse.UnmarshalJSON.
-func UnmarshalJSONMetricsResponse(data []byte) (MetricsResponse, error) {
-	mr := NewMetricsResponse()
-	err := mr.UnmarshalJSON(data)
-	return mr, err
-}
-
-// Deprecated: [v0.48.0] use MarshalProto.
-func (mr MetricsResponse) Marshal() ([]byte, error) {
-	return mr.MarshalProto()
-}
-
 // MarshalProto marshals MetricsResponse into proto bytes.
 func (mr MetricsResponse) MarshalProto() ([]byte, error) {
 	return mr.orig.Marshal()
@@ -88,25 +69,6 @@ type MetricsRequest struct {
 // NewMetricsRequest returns an empty MetricsRequest.
 func NewMetricsRequest() MetricsRequest {
 	return MetricsRequest{orig: &otlpcollectormetrics.ExportMetricsServiceRequest{}}
-}
-
-// Deprecated: [v0.48.0] use MetricsRequest.UnmarshalProto.
-func UnmarshalMetricsRequest(data []byte) (MetricsRequest, error) {
-	mr := NewMetricsRequest()
-	err := mr.UnmarshalProto(data)
-	return mr, err
-}
-
-// Deprecated: [v0.48.0] use MetricsRequest.UnmarshalJSON.
-func UnmarshalJSONMetricsRequest(data []byte) (MetricsRequest, error) {
-	mr := NewMetricsRequest()
-	err := mr.UnmarshalJSON(data)
-	return mr, err
-}
-
-// Deprecated: [v0.48.0] use MarshalProto.
-func (mr MetricsRequest) Marshal() ([]byte, error) {
-	return mr.MarshalProto()
 }
 
 // MarshalProto marshals MetricsRequest into proto bytes.

--- a/model/otlpgrpc/metrics_test.go
+++ b/model/otlpgrpc/metrics_test.go
@@ -131,16 +131,6 @@ func TestMetricsRequestJSONTransition(t *testing.T) {
 	}
 }
 
-func TestMetricsRequestJSON_Deprecated(t *testing.T) {
-	mr, err := UnmarshalJSONMetricsRequest(metricsRequestJSON)
-	assert.NoError(t, err)
-	assert.Equal(t, "test_metric", mr.Metrics().ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Name())
-
-	got, err := mr.MarshalJSON()
-	assert.NoError(t, err)
-	assert.Equal(t, strings.Join(strings.Fields(string(metricsRequestJSON)), ""), string(got))
-}
-
 func TestMetricsGrpc(t *testing.T) {
 	lis := bufconn.Listen(1024 * 1024)
 	s := grpc.NewServer()

--- a/model/otlpgrpc/traces.go
+++ b/model/otlpgrpc/traces.go
@@ -37,25 +37,6 @@ func NewTracesResponse() TracesResponse {
 	return TracesResponse{orig: &otlpcollectortrace.ExportTraceServiceResponse{}}
 }
 
-// Deprecated: [v0.48.0] use TracesResponse.UnmarshalProto.
-func UnmarshalTracesResponse(data []byte) (TracesResponse, error) {
-	tr := NewTracesResponse()
-	err := tr.UnmarshalProto(data)
-	return tr, err
-}
-
-// Deprecated: [v0.48.0] use TracesResponse.UnmarshalJSON.
-func UnmarshalJSONTracesResponse(data []byte) (TracesResponse, error) {
-	tr := NewTracesResponse()
-	err := tr.UnmarshalJSON(data)
-	return tr, err
-}
-
-// Deprecated: [v0.48.0] use MarshalProto.
-func (tr TracesResponse) Marshal() ([]byte, error) {
-	return tr.MarshalProto()
-}
-
 // MarshalProto marshals TracesResponse into proto bytes.
 func (tr TracesResponse) MarshalProto() ([]byte, error) {
 	return tr.orig.Marshal()
@@ -88,25 +69,6 @@ type TracesRequest struct {
 // NewTracesRequest returns an empty TracesRequest.
 func NewTracesRequest() TracesRequest {
 	return TracesRequest{orig: &otlpcollectortrace.ExportTraceServiceRequest{}}
-}
-
-// Deprecated: [v0.48.0] use TracesRequest.UnmarshalProto.
-func UnmarshalTracesRequest(data []byte) (TracesRequest, error) {
-	tr := NewTracesRequest()
-	err := tr.UnmarshalProto(data)
-	return tr, err
-}
-
-// Deprecated: [v0.48.0] use TracesRequest.UnmarshalJSON.
-func UnmarshalJSONTracesRequest(data []byte) (TracesRequest, error) {
-	tr := NewTracesRequest()
-	err := tr.UnmarshalJSON(data)
-	return tr, err
-}
-
-// Deprecated: [v0.48.0] use MarshalProto.
-func (tr TracesRequest) Marshal() ([]byte, error) {
-	return tr.MarshalProto()
 }
 
 // MarshalProto marshals TracesRequest into proto bytes.

--- a/model/otlpgrpc/traces_test.go
+++ b/model/otlpgrpc/traces_test.go
@@ -147,16 +147,6 @@ func TestTracesRequestJSONTransition(t *testing.T) {
 	}
 }
 
-func TestTracesRequestJSON_Deprecated(t *testing.T) {
-	tr, err := UnmarshalJSONTracesRequest(tracesRequestJSON)
-	assert.NoError(t, err)
-	assert.Equal(t, "test_span", tr.Traces().ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0).Name())
-
-	got, err := tr.MarshalJSON()
-	assert.NoError(t, err)
-	assert.Equal(t, strings.Join(strings.Fields(string(tracesRequestJSON)), ""), string(got))
-}
-
 func TestTracesGrpc(t *testing.T) {
 	lis := bufconn.Listen(1024 * 1024)
 	s := grpc.NewServer()


### PR DESCRIPTION
Because, most likely for the moment only otlp exporter/receiver is using this package, we can remove this after just one version, no third-party deps.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
