### PR TITLE
Setup the correct meter provider if telemetry.useOtelForInternalMetrics featuregate enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Do not set TraceProvider to global otel (#5138)
 - Remove deprecated funcs from otlpgrpc (#5144)
 - Add Scheme to MapProvider interface (#5068)
+- Do not set MeterProvider to global otel (#5146)
 
 ### 🚩 Deprecations 🚩
 
@@ -16,6 +17,8 @@
 - OTLP HTTP receiver will use HTTP/2 over TLS if client supports it (#5190) 
 
 ### 🧰 Bug fixes 🧰
+
+- Setup the correct meter provider if telemetry.useOtelForInternalMetrics featuregate enabled (#5146)
 
 ## v0.48.0 Beta
 

--- a/service/telemetry.go
+++ b/service/telemetry.go
@@ -25,7 +25,6 @@ import (
 	"github.com/google/uuid"
 	"go.opencensus.io/stats/view"
 	otelprometheus "go.opentelemetry.io/otel/exporters/prometheus"
-	"go.opentelemetry.io/otel/metric/global"
 	"go.opentelemetry.io/otel/sdk/metric/aggregator/histogram"
 	controller "go.opentelemetry.io/otel/sdk/metric/controller/basic"
 	"go.opentelemetry.io/otel/sdk/metric/export/aggregation"
@@ -113,7 +112,7 @@ func (tel *colTelemetry) initOnce(col *Collector) error {
 
 	var pe http.Handler
 	if featuregate.IsEnabled(useOtelForInternalMetricsfeatureGateID) {
-		otelHandler, err := tel.initOpenTelemetry()
+		otelHandler, err := tel.initOpenTelemetry(col)
 		if err != nil {
 			return err
 		}
@@ -193,7 +192,7 @@ func (tel *colTelemetry) initOpenCensus(col *Collector, instanceID string) (http
 	return pe, nil
 }
 
-func (tel *colTelemetry) initOpenTelemetry() (http.Handler, error) {
+func (tel *colTelemetry) initOpenTelemetry(col *Collector) (http.Handler, error) {
 	config := otelprometheus.Config{}
 	c := controller.New(
 		processor.NewFactory(
@@ -210,7 +209,7 @@ func (tel *colTelemetry) initOpenTelemetry() (http.Handler, error) {
 		return nil, err
 	}
 
-	global.SetMeterProvider(pe.MeterProvider())
+	col.meterProvider = pe.MeterProvider()
 	return pe, err
 }
 


### PR DESCRIPTION
This PR also removes the set of the global MeterProvider, similarly with #5138.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
