### PR TITLE
[pdata] Fix Value.asRaw to correctly return Slice and Map elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 ### 🧰 Bug fixes 🧰
 
 - Setup the correct meter provider if telemetry.useOtelForInternalMetrics featuregate enabled (#5146)
+- Fix pdata.Value.asRaw() to correctly return elements of Slice and Map type (#5153)
 
 ## v0.48.0 Beta
 

--- a/model/internal/pdata/common.go
+++ b/model/internal/pdata/common.go
@@ -494,9 +494,9 @@ func (v Value) asRaw() interface{} {
 	case ValueTypeBytes:
 		return v.BytesVal()
 	case ValueTypeMap:
-		v.MapVal().AsRaw()
+		return v.MapVal().AsRaw()
 	case ValueTypeSlice:
-		v.SliceVal().asRaw()
+		return v.SliceVal().asRaw()
 	}
 	return fmt.Sprintf("<Unknown OpenTelemetry value type %q>", v.Type())
 }

--- a/model/internal/pdata/common_test.go
+++ b/model/internal/pdata/common_test.go
@@ -1111,7 +1111,70 @@ func TestAsString(t *testing.T) {
 	}
 }
 
-func TestAsRaw(t *testing.T) {
+func TestValueAsRaw(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    Value
+		expected interface{}
+	}{
+		{
+			name:     "string",
+			input:    NewValueString("value"),
+			expected: "value",
+		},
+		{
+			name:     "int",
+			input:    NewValueInt(11),
+			expected: int64(11),
+		},
+		{
+			name:     "double",
+			input:    NewValueDouble(1.2),
+			expected: 1.2,
+		},
+		{
+			name:     "bytes",
+			input:    NewValueBytes([]byte("bytes")),
+			expected: []byte("bytes"),
+		},
+		{
+			name:     "bytes",
+			input:    NewValueBytes([]byte("bytes")),
+			expected: []byte("bytes"),
+		},
+		{
+			name:     "empty",
+			input:    NewValueEmpty(),
+			expected: nil,
+		},
+		{
+			name:     "slice",
+			input:    simpleValueSlice(),
+			expected: []interface{}{"strVal", int64(7), 18.6, false, nil},
+		},
+		{
+			name:  "map",
+			input: simpleValueMap(),
+			expected: map[string]interface{}{
+				"mapKey":   map[string]interface{}{"keyOne": "valOne", "keyTwo": "valTwo"},
+				"nullKey":  nil,
+				"strKey":   "strVal",
+				"arrKey":   []interface{}{"strOne", "strTwo"},
+				"boolKey":  false,
+				"floatKey": 18.6,
+				"intKey":   int64(7),
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := test.input.asRaw()
+			assert.Equal(t, test.expected, actual)
+		})
+	}
+}
+
+func TestMapAsRaw(t *testing.T) {
 	tests := []struct {
 		name     string
 		input    Map


### PR DESCRIPTION
`return` statements were missed in the Value.asRaw function for Slice and Map elements.