### PR TITLE
Make InstrumentationLibrary<signal>ToScope functions unexported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Remove deprecated funcs from otlpgrpc (#5144)
 - Add Scheme to MapProvider interface (#5068)
 - Do not set MeterProvider to global otel (#5146)
+- Make `InstrumentationLibrary<signal>ToScope` helper functions unexported (#5164)
 
 ### 🚩 Deprecations 🚩
 

--- a/model/internal/otlp/logs.go
+++ b/model/internal/otlp/logs.go
@@ -1,0 +1,46 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package otlp // import "go.opentelemetry.io/collector/model/internal/otlp"
+
+import (
+	otlpcommon "go.opentelemetry.io/collector/model/internal/data/protogen/common/v1"
+	otlplogs "go.opentelemetry.io/collector/model/internal/data/protogen/logs/v1"
+)
+
+// InstrumentationLibraryLogsToScope implements the translation of resource logs data
+// following the v0.15.0 upgrade:
+//      receivers SHOULD check if instrumentation_library_logs is set
+//      and scope_logs is not set then the value in instrumentation_library_logs
+//      SHOULD be used instead by converting InstrumentationLibraryLogs into ScopeLogs.
+//      If scope_logs is set then instrumentation_library_logs SHOULD be ignored.
+// https://github.com/open-telemetry/opentelemetry-proto/blob/3c2915c01a9fb37abfc0415ec71247c4978386b0/opentelemetry/proto/logs/v1/logs.proto#L58
+func InstrumentationLibraryLogsToScope(rls []*otlplogs.ResourceLogs) {
+	for _, rl := range rls {
+		if len(rl.ScopeLogs) == 0 {
+			for _, ill := range rl.InstrumentationLibraryLogs {
+				scopeLogs := otlplogs.ScopeLogs{
+					Scope: otlpcommon.InstrumentationScope{
+						Name:    ill.InstrumentationLibrary.Name,
+						Version: ill.InstrumentationLibrary.Version,
+					},
+					LogRecords: ill.LogRecords,
+					SchemaUrl:  ill.SchemaUrl,
+				}
+				rl.ScopeLogs = append(rl.ScopeLogs, &scopeLogs)
+			}
+		}
+		rl.InstrumentationLibraryLogs = nil
+	}
+}

--- a/model/internal/otlp/metrics.go
+++ b/model/internal/otlp/metrics.go
@@ -1,0 +1,46 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package otlp // import "go.opentelemetry.io/collector/model/internal/otlp"
+
+import (
+	otlpcommon "go.opentelemetry.io/collector/model/internal/data/protogen/common/v1"
+	otlpmetrics "go.opentelemetry.io/collector/model/internal/data/protogen/metrics/v1"
+)
+
+// InstrumentationLibraryMetricsToScope implements the translation of resource metrics data
+// following the v0.15.0 upgrade:
+//      receivers SHOULD check if instrumentation_library_metrics is set
+//      and scope_metrics is not set then the value in instrumentation_library_metrics
+//      SHOULD be used instead by converting InstrumentationLibraryMetrics into ScopeMetrics.
+//      If scope_metrics is set then instrumentation_library_metrics SHOULD be ignored.
+// https://github.com/open-telemetry/opentelemetry-proto/blob/3c2915c01a9fb37abfc0415ec71247c4978386b0/opentelemetry/proto/metrics/v1/metrics.proto#L58
+func InstrumentationLibraryMetricsToScope(rms []*otlpmetrics.ResourceMetrics) {
+	for _, rm := range rms {
+		if len(rm.ScopeMetrics) == 0 {
+			for _, ilm := range rm.InstrumentationLibraryMetrics {
+				scopeMetrics := otlpmetrics.ScopeMetrics{
+					Scope: otlpcommon.InstrumentationScope{
+						Name:    ilm.InstrumentationLibrary.Name,
+						Version: ilm.InstrumentationLibrary.Version,
+					},
+					Metrics:   ilm.Metrics,
+					SchemaUrl: ilm.SchemaUrl,
+				}
+				rm.ScopeMetrics = append(rm.ScopeMetrics, &scopeMetrics)
+			}
+		}
+		rm.InstrumentationLibraryMetrics = nil
+	}
+}

--- a/model/internal/otlp/traces.go
+++ b/model/internal/otlp/traces.go
@@ -1,0 +1,46 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package otlp // import "go.opentelemetry.io/collector/model/internal/otlp"
+
+import (
+	otlpcommon "go.opentelemetry.io/collector/model/internal/data/protogen/common/v1"
+	otlptrace "go.opentelemetry.io/collector/model/internal/data/protogen/trace/v1"
+)
+
+// InstrumentationLibraryToScope implements the translation of resource span data
+// following the v0.15.0 upgrade:
+//      receivers SHOULD check if instrumentation_library_spans is set
+//      and scope_spans is not set then the value in instrumentation_library_spans
+//      SHOULD be used instead by converting InstrumentationLibrarySpans into ScopeSpans.
+//      If scope_spans is set then instrumentation_library_spans SHOULD be ignored.
+// https://github.com/open-telemetry/opentelemetry-proto/blob/3c2915c01a9fb37abfc0415ec71247c4978386b0/opentelemetry/proto/trace/v1/trace.proto#L58
+func InstrumentationLibrarySpansToScope(rss []*otlptrace.ResourceSpans) {
+	for _, rs := range rss {
+		if len(rs.ScopeSpans) == 0 {
+			for _, ils := range rs.InstrumentationLibrarySpans {
+				scopeSpans := otlptrace.ScopeSpans{
+					Scope: otlpcommon.InstrumentationScope{
+						Name:    ils.InstrumentationLibrary.Name,
+						Version: ils.InstrumentationLibrary.Version,
+					},
+					Spans:     ils.Spans,
+					SchemaUrl: ils.SchemaUrl,
+				}
+				rs.ScopeSpans = append(rs.ScopeSpans, &scopeSpans)
+			}
+		}
+		rs.InstrumentationLibrarySpans = nil
+	}
+}

--- a/model/otlp/json_unmarshaler.go
+++ b/model/otlp/json_unmarshaler.go
@@ -23,7 +23,7 @@ import (
 	otlplogs "go.opentelemetry.io/collector/model/internal/data/protogen/logs/v1"
 	otlpmetrics "go.opentelemetry.io/collector/model/internal/data/protogen/metrics/v1"
 	otlptrace "go.opentelemetry.io/collector/model/internal/data/protogen/trace/v1"
-	"go.opentelemetry.io/collector/model/otlpgrpc"
+	"go.opentelemetry.io/collector/model/internal/otlp"
 	"go.opentelemetry.io/collector/model/pdata"
 )
 
@@ -55,7 +55,7 @@ func (d *jsonUnmarshaler) UnmarshalLogs(buf []byte) (pdata.Logs, error) {
 	if err := d.delegate.Unmarshal(bytes.NewReader(buf), ld); err != nil {
 		return pdata.Logs{}, err
 	}
-	otlpgrpc.InstrumentationLibraryLogsToScope(ld.ResourceLogs)
+	otlp.InstrumentationLibraryLogsToScope(ld.ResourceLogs)
 	return ipdata.LogsFromOtlp(ld), nil
 }
 
@@ -64,7 +64,7 @@ func (d *jsonUnmarshaler) UnmarshalMetrics(buf []byte) (pdata.Metrics, error) {
 	if err := d.delegate.Unmarshal(bytes.NewReader(buf), md); err != nil {
 		return pdata.Metrics{}, err
 	}
-	otlpgrpc.InstrumentationLibraryMetricsToScope(md.ResourceMetrics)
+	otlp.InstrumentationLibraryMetricsToScope(md.ResourceMetrics)
 	return ipdata.MetricsFromOtlp(md), nil
 }
 
@@ -73,6 +73,6 @@ func (d *jsonUnmarshaler) UnmarshalTraces(buf []byte) (pdata.Traces, error) {
 	if err := d.delegate.Unmarshal(bytes.NewReader(buf), td); err != nil {
 		return pdata.Traces{}, err
 	}
-	otlpgrpc.InstrumentationLibrarySpansToScope(td.ResourceSpans)
+	otlp.InstrumentationLibrarySpansToScope(td.ResourceSpans)
 	return ipdata.TracesFromOtlp(td), nil
 }

--- a/model/otlpgrpc/logs.go
+++ b/model/otlpgrpc/logs.go
@@ -23,8 +23,8 @@ import (
 
 	ipdata "go.opentelemetry.io/collector/model/internal"
 	otlpcollectorlog "go.opentelemetry.io/collector/model/internal/data/protogen/collector/logs/v1"
-	v1 "go.opentelemetry.io/collector/model/internal/data/protogen/common/v1"
 	otlplogs "go.opentelemetry.io/collector/model/internal/data/protogen/logs/v1"
+	"go.opentelemetry.io/collector/model/internal/otlp"
 	"go.opentelemetry.io/collector/model/pdata"
 )
 
@@ -85,7 +85,7 @@ func (lr LogsRequest) UnmarshalProto(data []byte) error {
 	if err := lr.orig.Unmarshal(data); err != nil {
 		return err
 	}
-	InstrumentationLibraryLogsToScope(lr.orig.ResourceLogs)
+	otlp.InstrumentationLibraryLogsToScope(lr.orig.ResourceLogs)
 	return nil
 }
 
@@ -103,7 +103,7 @@ func (lr LogsRequest) UnmarshalJSON(data []byte) error {
 	if err := jsonUnmarshaler.Unmarshal(bytes.NewReader(data), lr.orig); err != nil {
 		return err
 	}
-	InstrumentationLibraryLogsToScope(lr.orig.ResourceLogs)
+	otlp.InstrumentationLibraryLogsToScope(lr.orig.ResourceLogs)
 	return nil
 }
 
@@ -161,30 +161,4 @@ type rawLogsServer struct {
 func (s rawLogsServer) Export(ctx context.Context, request *otlpcollectorlog.ExportLogsServiceRequest) (*otlpcollectorlog.ExportLogsServiceResponse, error) {
 	rsp, err := s.srv.Export(ctx, LogsRequest{orig: request})
 	return rsp.orig, err
-}
-
-// InstrumentationLibraryLogsToScope implements the translation of resource logs data
-// following the v0.15.0 upgrade:
-//      receivers SHOULD check if instrumentation_library_logs is set
-//      and scope_logs is not set then the value in instrumentation_library_logs
-//      SHOULD be used instead by converting InstrumentationLibraryLogs into ScopeLogs.
-//      If scope_logs is set then instrumentation_library_logs SHOULD be ignored.
-// https://github.com/open-telemetry/opentelemetry-proto/blob/3c2915c01a9fb37abfc0415ec71247c4978386b0/opentelemetry/proto/logs/v1/logs.proto#L58
-func InstrumentationLibraryLogsToScope(rls []*otlplogs.ResourceLogs) {
-	for _, rl := range rls {
-		if len(rl.ScopeLogs) == 0 {
-			for _, ill := range rl.InstrumentationLibraryLogs {
-				scopeLogs := otlplogs.ScopeLogs{
-					Scope: v1.InstrumentationScope{
-						Name:    ill.InstrumentationLibrary.Name,
-						Version: ill.InstrumentationLibrary.Version,
-					},
-					LogRecords: ill.LogRecords,
-					SchemaUrl:  ill.SchemaUrl,
-				}
-				rl.ScopeLogs = append(rl.ScopeLogs, &scopeLogs)
-			}
-		}
-		rl.InstrumentationLibraryLogs = nil
-	}
 }

--- a/model/otlpgrpc/logs_test.go
+++ b/model/otlpgrpc/logs_test.go
@@ -32,6 +32,7 @@ import (
 	"google.golang.org/grpc/test/bufconn"
 
 	v1 "go.opentelemetry.io/collector/model/internal/data/protogen/logs/v1"
+	"go.opentelemetry.io/collector/model/internal/otlp"
 	"go.opentelemetry.io/collector/model/pdata"
 )
 
@@ -209,7 +210,7 @@ func TestLogsGrpcTransition(t *testing.T) {
 	logClient := NewLogsClient(cc)
 
 	req := generateLogsRequestWithInstrumentationLibrary()
-	InstrumentationLibraryLogsToScope(req.orig.ResourceLogs)
+	otlp.InstrumentationLibraryLogsToScope(req.orig.ResourceLogs)
 	resp, err := logClient.Export(context.Background(), req)
 	assert.NoError(t, err)
 	assert.Equal(t, NewLogsResponse(), resp)

--- a/model/otlpgrpc/metrics.go
+++ b/model/otlpgrpc/metrics.go
@@ -22,8 +22,8 @@ import (
 
 	ipdata "go.opentelemetry.io/collector/model/internal"
 	otlpcollectormetrics "go.opentelemetry.io/collector/model/internal/data/protogen/collector/metrics/v1"
-	v1 "go.opentelemetry.io/collector/model/internal/data/protogen/common/v1"
 	otlpmetrics "go.opentelemetry.io/collector/model/internal/data/protogen/metrics/v1"
+	"go.opentelemetry.io/collector/model/internal/otlp"
 	"go.opentelemetry.io/collector/model/pdata"
 )
 
@@ -95,7 +95,7 @@ func (mr MetricsRequest) UnmarshalJSON(data []byte) error {
 	if err := jsonUnmarshaler.Unmarshal(bytes.NewReader(data), mr.orig); err != nil {
 		return err
 	}
-	InstrumentationLibraryMetricsToScope(mr.orig.ResourceMetrics)
+	otlp.InstrumentationLibraryMetricsToScope(mr.orig.ResourceMetrics)
 	return nil
 }
 
@@ -153,30 +153,4 @@ type rawMetricsServer struct {
 func (s rawMetricsServer) Export(ctx context.Context, request *otlpcollectormetrics.ExportMetricsServiceRequest) (*otlpcollectormetrics.ExportMetricsServiceResponse, error) {
 	rsp, err := s.srv.Export(ctx, MetricsRequest{orig: request})
 	return rsp.orig, err
-}
-
-// InstrumentationLibraryMetricsToScope implements the translation of resource metrics data
-// following the v0.15.0 upgrade:
-//      receivers SHOULD check if instrumentation_library_metrics is set
-//      and scope_metrics is not set then the value in instrumentation_library_metrics
-//      SHOULD be used instead by converting InstrumentationLibraryMetrics into ScopeMetrics.
-//      If scope_metrics is set then instrumentation_library_metrics SHOULD be ignored.
-// https://github.com/open-telemetry/opentelemetry-proto/blob/3c2915c01a9fb37abfc0415ec71247c4978386b0/opentelemetry/proto/metrics/v1/metrics.proto#L58
-func InstrumentationLibraryMetricsToScope(rms []*otlpmetrics.ResourceMetrics) {
-	for _, rm := range rms {
-		if len(rm.ScopeMetrics) == 0 {
-			for _, ilm := range rm.InstrumentationLibraryMetrics {
-				scopeMetrics := otlpmetrics.ScopeMetrics{
-					Scope: v1.InstrumentationScope{
-						Name:    ilm.InstrumentationLibrary.Name,
-						Version: ilm.InstrumentationLibrary.Version,
-					},
-					Metrics:   ilm.Metrics,
-					SchemaUrl: ilm.SchemaUrl,
-				}
-				rm.ScopeMetrics = append(rm.ScopeMetrics, &scopeMetrics)
-			}
-		}
-		rm.InstrumentationLibraryMetrics = nil
-	}
 }

--- a/model/otlpgrpc/metrics_test.go
+++ b/model/otlpgrpc/metrics_test.go
@@ -32,6 +32,7 @@ import (
 	"google.golang.org/grpc/test/bufconn"
 
 	v1 "go.opentelemetry.io/collector/model/internal/data/protogen/metrics/v1"
+	"go.opentelemetry.io/collector/model/internal/otlp"
 	"go.opentelemetry.io/collector/model/pdata"
 )
 
@@ -193,7 +194,7 @@ func TestMetricsGrpcTransition(t *testing.T) {
 	logClient := NewMetricsClient(cc)
 
 	req := generateMetricsRequestWithInstrumentationLibrary()
-	InstrumentationLibraryMetricsToScope(req.orig.ResourceMetrics)
+	otlp.InstrumentationLibraryMetricsToScope(req.orig.ResourceMetrics)
 	resp, err := logClient.Export(context.Background(), req)
 	assert.NoError(t, err)
 	assert.Equal(t, NewMetricsResponse(), resp)

--- a/model/otlpgrpc/traces.go
+++ b/model/otlpgrpc/traces.go
@@ -22,8 +22,8 @@ import (
 
 	ipdata "go.opentelemetry.io/collector/model/internal"
 	otlpcollectortrace "go.opentelemetry.io/collector/model/internal/data/protogen/collector/trace/v1"
-	v1 "go.opentelemetry.io/collector/model/internal/data/protogen/common/v1"
 	otlptrace "go.opentelemetry.io/collector/model/internal/data/protogen/trace/v1"
+	"go.opentelemetry.io/collector/model/internal/otlp"
 	"go.opentelemetry.io/collector/model/pdata"
 )
 
@@ -81,7 +81,7 @@ func (tr TracesRequest) UnmarshalProto(data []byte) error {
 	if err := tr.orig.Unmarshal(data); err != nil {
 		return err
 	}
-	InstrumentationLibrarySpansToScope(tr.orig.ResourceSpans)
+	otlp.InstrumentationLibrarySpansToScope(tr.orig.ResourceSpans)
 	return nil
 }
 
@@ -99,7 +99,7 @@ func (tr TracesRequest) UnmarshalJSON(data []byte) error {
 	if err := jsonUnmarshaler.Unmarshal(bytes.NewReader(data), tr.orig); err != nil {
 		return err
 	}
-	InstrumentationLibrarySpansToScope(tr.orig.ResourceSpans)
+	otlp.InstrumentationLibrarySpansToScope(tr.orig.ResourceSpans)
 	return nil
 }
 
@@ -158,30 +158,4 @@ type rawTracesServer struct {
 func (s rawTracesServer) Export(ctx context.Context, request *otlpcollectortrace.ExportTraceServiceRequest) (*otlpcollectortrace.ExportTraceServiceResponse, error) {
 	rsp, err := s.srv.Export(ctx, TracesRequest{orig: request})
 	return rsp.orig, err
-}
-
-// InstrumentationLibraryToScope implements the translation of resource span data
-// following the v0.15.0 upgrade:
-//      receivers SHOULD check if instrumentation_library_spans is set
-//      and scope_spans is not set then the value in instrumentation_library_spans
-//      SHOULD be used instead by converting InstrumentationLibrarySpans into ScopeSpans.
-//      If scope_spans is set then instrumentation_library_spans SHOULD be ignored.
-// https://github.com/open-telemetry/opentelemetry-proto/blob/3c2915c01a9fb37abfc0415ec71247c4978386b0/opentelemetry/proto/trace/v1/trace.proto#L58
-func InstrumentationLibrarySpansToScope(rss []*otlptrace.ResourceSpans) {
-	for _, rs := range rss {
-		if len(rs.ScopeSpans) == 0 {
-			for _, ils := range rs.InstrumentationLibrarySpans {
-				scopeSpans := otlptrace.ScopeSpans{
-					Scope: v1.InstrumentationScope{
-						Name:    ils.InstrumentationLibrary.Name,
-						Version: ils.InstrumentationLibrary.Version,
-					},
-					Spans:     ils.Spans,
-					SchemaUrl: ils.SchemaUrl,
-				}
-				rs.ScopeSpans = append(rs.ScopeSpans, &scopeSpans)
-			}
-		}
-		rs.InstrumentationLibrarySpans = nil
-	}
 }

--- a/model/otlpgrpc/traces_test.go
+++ b/model/otlpgrpc/traces_test.go
@@ -32,6 +32,7 @@ import (
 	"google.golang.org/grpc/test/bufconn"
 
 	v1 "go.opentelemetry.io/collector/model/internal/data/protogen/trace/v1"
+	"go.opentelemetry.io/collector/model/internal/otlp"
 	"go.opentelemetry.io/collector/model/pdata"
 )
 
@@ -209,7 +210,7 @@ func TestTracesGrpcTransition(t *testing.T) {
 	logClient := NewTracesClient(cc)
 
 	req := generateTracesRequestWithInstrumentationLibrary()
-	InstrumentationLibrarySpansToScope(req.orig.ResourceSpans)
+	otlp.InstrumentationLibrarySpansToScope(req.orig.ResourceSpans)
 	resp, err := logClient.Export(context.Background(), req)
 	assert.NoError(t, err)
 	assert.Equal(t, NewTracesResponse(), resp)


### PR DESCRIPTION
The functions were added in the the latest release. They are intended for the internal use only and shouldn't be exported.

This change is applied without backward compatibility because the functions accept an argument of internal type and cannot be used outside of `collector/model`. If we keep backward compatibility here, we would also have to export these functions additionally in the new structure defined in https://github.com/open-telemetry/opentelemetry-collector/pull/5087.

Closes: https://github.com/open-telemetry/opentelemetry-collector/issues/5163