### PR TITLE
Remove deprecated log name from text marshaler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Add Scheme to MapProvider interface (#5068)
 - Do not set MeterProvider to global otel (#5146)
 - Make `InstrumentationLibrary<signal>ToScope` helper functions unexported (#5164)
+- Remove Log's "ShortName" from logging exporter output (#5172)
 
 ### 🚩 Deprecations 🚩
 

--- a/internal/otlptext/logs.go
+++ b/internal/otlptext/logs.go
@@ -47,7 +47,6 @@ func (textLogsMarshaler) MarshalLogs(ld pdata.Logs) ([]byte, error) {
 				lr := logs.At(k)
 				buf.logEntry("Timestamp: %s", lr.Timestamp())
 				buf.logEntry("Severity: %s", lr.SeverityText())
-				buf.logEntry("ShortName: %s", lr.Name())
 				buf.logEntry("Body: %s", attributeValueToString(lr.Body()))
 				buf.logAttributes("Attributes", lr.Attributes())
 				buf.logEntry("Trace ID: %s", lr.TraceID().HexString())


### PR DESCRIPTION
LogRecord.Name has been deprecated, but there is still a reference to it in the logging exporter. This change removes the name from the logging exporter output.