### PR TITLE
reverted link check action to 1.0.13

### DIFF
--- a/.github/workflows/check-links.yaml
+++ b/.github/workflows/check-links.yaml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: gaurav-nelson/github-action-markdown-link-check@1.0.14
+      - uses: gaurav-nelson/github-action-markdown-link-check@1.0.13
         with:
           base-branch: 'main'
           use-quiet-mode: 'yes'


### PR DESCRIPTION
**Description:**
Reverted github-action-markdown-link-check action in the check-links workflow to version 1.0.13 due to [issues with version 1.0.14 ](https://github.com/gaurav-nelson/github-action-markdown-link-check/issues/127)

**Link to tracking Issue:**
Fixes #5118 

**Testing:**
Reverted version, updated release.md in a test branch, and triggered the action.  [Passing results here.](https://github.com/TylerHelmuth/opentelemetry-collector/runs/5979608772?check_suite_focus=true)

