### PR TITLE
[receiver/otlp] fix otlp <0.15.0 receiver bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Setup the correct meter provider if telemetry.useOtelForInternalMetrics featuregate enabled (#5146)
 - Fix pdata.Value.asRaw() to correctly return elements of Slice and Map type (#5153)
 - Update pdata.Slice.asRaw() to return raw representation of Slice and Map elements (#5157)
+- The codepath through the OTLP receiver for gRPC was not translating the InstrumentationLibrary* to Scope* (#5189)
 
 ## v0.48.0 Beta
 

--- a/pdata/plog/plogotlp/logs.go
+++ b/pdata/plog/plogotlp/logs.go
@@ -159,6 +159,7 @@ type rawLogsServer struct {
 }
 
 func (s rawLogsServer) Export(ctx context.Context, request *otlpcollectorlog.ExportLogsServiceRequest) (*otlpcollectorlog.ExportLogsServiceResponse, error) {
+	otlp.InstrumentationLibraryLogsToScope(request.ResourceLogs)
 	rsp, err := s.srv.Export(ctx, Request{orig: request})
 	return rsp.orig, err
 }

--- a/pdata/plog/plogotlp/logs_test.go
+++ b/pdata/plog/plogotlp/logs_test.go
@@ -216,11 +216,11 @@ func TestGrpcTransition(t *testing.T) {
 	assert.Equal(t, NewResponse(), resp)
 }
 
-type fakeRawLogsServer struct {
+type fakeRawServer struct {
 	t *testing.T
 }
 
-func (s fakeRawLogsServer) Export(_ context.Context, req Request) (Response, error) {
+func (s fakeRawServer) Export(_ context.Context, req Request) (Response, error) {
 	assert.Equal(s.t, 1, req.Logs().LogRecordCount())
 	return NewResponse(), nil
 }
@@ -228,7 +228,7 @@ func (s fakeRawLogsServer) Export(_ context.Context, req Request) (Response, err
 func TestGrpcExport(t *testing.T) {
 	lis := bufconn.Listen(1024 * 1024)
 	s := grpc.NewServer()
-	RegisterServer(s, &fakeRawLogsServer{t: t})
+	RegisterServer(s, &fakeRawServer{t: t})
 	wg := sync.WaitGroup{}
 	wg.Add(1)
 	go func() {

--- a/pdata/pmetric/pmetricotlp/metrics.go
+++ b/pdata/pmetric/pmetricotlp/metrics.go
@@ -155,6 +155,7 @@ type rawMetricsServer struct {
 }
 
 func (s rawMetricsServer) Export(ctx context.Context, request *otlpcollectormetrics.ExportMetricsServiceRequest) (*otlpcollectormetrics.ExportMetricsServiceResponse, error) {
+	otlp.InstrumentationLibraryMetricsToScope(request.ResourceMetrics)
 	rsp, err := s.srv.Export(ctx, Request{orig: request})
 	return rsp.orig, err
 }

--- a/pdata/pmetric/pmetricotlp/metrics_test.go
+++ b/pdata/pmetric/pmetricotlp/metrics_test.go
@@ -200,11 +200,11 @@ func TestGrpcTransition(t *testing.T) {
 	assert.Equal(t, NewResponse(), resp)
 }
 
-type fakeRawMetricsServer struct {
+type fakeRawServer struct {
 	t *testing.T
 }
 
-func (s fakeRawMetricsServer) Export(_ context.Context, req Request) (Response, error) {
+func (s fakeRawServer) Export(_ context.Context, req Request) (Response, error) {
 	assert.Equal(s.t, 1, req.Metrics().DataPointCount())
 	return NewResponse(), nil
 }
@@ -212,7 +212,7 @@ func (s fakeRawMetricsServer) Export(_ context.Context, req Request) (Response, 
 func TestGrpcExport(t *testing.T) {
 	lis := bufconn.Listen(1024 * 1024)
 	s := grpc.NewServer()
-	RegisterServer(s, &fakeRawMetricsServer{t: t})
+	RegisterServer(s, &fakeRawServer{t: t})
 	wg := sync.WaitGroup{}
 	wg.Add(1)
 	go func() {

--- a/pdata/ptrace/ptraceotlp/traces.go
+++ b/pdata/ptrace/ptraceotlp/traces.go
@@ -160,6 +160,7 @@ type rawTracesServer struct {
 }
 
 func (s rawTracesServer) Export(ctx context.Context, request *otlpcollectortrace.ExportTraceServiceRequest) (*otlpcollectortrace.ExportTraceServiceResponse, error) {
+	otlp.InstrumentationLibrarySpansToScope(request.ResourceSpans)
 	rsp, err := s.srv.Export(ctx, Request{orig: request})
 	return rsp.orig, err
 }

--- a/pdata/ptrace/ptraceotlp/traces_test.go
+++ b/pdata/ptrace/ptraceotlp/traces_test.go
@@ -216,6 +216,49 @@ func TestGrpcTransition(t *testing.T) {
 	assert.Equal(t, NewResponse(), resp)
 }
 
+type fakeRawServer struct {
+	t *testing.T
+}
+
+func (s fakeRawServer) Export(_ context.Context, req Request) (Response, error) {
+	assert.Equal(s.t, 1, req.Traces().SpanCount())
+	return NewResponse(), nil
+}
+
+func TestGrpcExport(t *testing.T) {
+	lis := bufconn.Listen(1024 * 1024)
+	s := grpc.NewServer()
+
+	RegisterServer(s, &fakeRawServer{t: t})
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		assert.NoError(t, s.Serve(lis))
+	}()
+	t.Cleanup(func() {
+		s.Stop()
+		wg.Wait()
+	})
+
+	cc, err := grpc.Dial("bufnet",
+		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+			return lis.Dial()
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithBlock())
+	assert.NoError(t, err)
+	t.Cleanup(func() {
+		assert.NoError(t, cc.Close())
+	})
+	traceClient := NewClient(cc)
+
+	req := generateTracesRequestWithInstrumentationLibrary()
+	resp, err := traceClient.Export(context.Background(), req)
+	assert.NoError(t, err)
+	assert.Equal(t, NewResponse(), resp)
+}
+
 func TestGrpcError(t *testing.T) {
 	lis := bufconn.Listen(1024 * 1024)
 	s := grpc.NewServer()
@@ -278,5 +321,6 @@ func generateTracesRequestWithInstrumentationLibrary() Request {
 			Spans: tr.orig.ResourceSpans[0].ScopeSpans[0].Spans,
 		},
 	}
+	tr.orig.ResourceSpans[0].ScopeSpans = []*v1.ScopeSpans{}
 	return tr
 }


### PR DESCRIPTION
The codepath through the OTLP receiver for gRPC was not translating the `InstrumentationLibrary*` to `Scope*`.

Fixes #5188