### PR TITLE
Remove unnecessary aliases for Marshaler/Unmarshaler/Sizer in pdata

### DIFF
--- a/pdata/internal/logs.go
+++ b/pdata/internal/logs.go
@@ -18,27 +18,6 @@ import (
 	otlplogs "go.opentelemetry.io/collector/pdata/internal/data/protogen/logs/v1"
 )
 
-// LogsMarshaler marshals pdata.Logs into bytes.
-type LogsMarshaler interface {
-	// MarshalLogs the given pdata.Logs into bytes.
-	// If the error is not nil, the returned bytes slice cannot be used.
-	MarshalLogs(ld Logs) ([]byte, error)
-}
-
-// LogsUnmarshaler unmarshalls bytes into pdata.Logs.
-type LogsUnmarshaler interface {
-	// UnmarshalLogs the given bytes into pdata.Logs.
-	// If the error is not nil, the returned pdata.Logs cannot be used.
-	UnmarshalLogs(buf []byte) (Logs, error)
-}
-
-// LogsSizer is an optional interface implemented by the LogsMarshaler,
-// that calculates the size of a marshaled Logs.
-type LogsSizer interface {
-	// LogsSize returns the size in bytes of a marshaled Logs.
-	LogsSize(ld Logs) int
-}
-
 // Logs is the top-level struct that is propagated through the logs pipeline.
 // Use NewLogs to create new instance, zero-initialized instance is not valid for use.
 type Logs struct {

--- a/pdata/internal/metrics.go
+++ b/pdata/internal/metrics.go
@@ -18,27 +18,6 @@ import (
 	otlpmetrics "go.opentelemetry.io/collector/pdata/internal/data/protogen/metrics/v1"
 )
 
-// MetricsMarshaler marshals pmetric.Metrics into bytes.
-type MetricsMarshaler interface {
-	// MarshalMetrics the given pmetric.Metrics into bytes.
-	// If the error is not nil, the returned bytes slice cannot be used.
-	MarshalMetrics(md Metrics) ([]byte, error)
-}
-
-// MetricsUnmarshaler unmarshalls bytes into pmetric.Metrics.
-type MetricsUnmarshaler interface {
-	// UnmarshalMetrics the given bytes into pmetric.Metrics.
-	// If the error is not nil, the returned pmetric.Metrics cannot be used.
-	UnmarshalMetrics(buf []byte) (Metrics, error)
-}
-
-// MetricsSizer is an optional interface implemented by the MetricsMarshaler,
-// that calculates the size of a marshaled Metrics.
-type MetricsSizer interface {
-	// MetricsSize returns the size in bytes of a marshaled Metrics.
-	MetricsSize(md Metrics) int
-}
-
 // Metrics is the top-level struct that is propagated through the metrics pipeline.
 // Use NewMetrics to create new instance, zero-initialized instance is not valid for use.
 type Metrics struct {

--- a/pdata/internal/traces.go
+++ b/pdata/internal/traces.go
@@ -18,27 +18,6 @@ import (
 	otlptrace "go.opentelemetry.io/collector/pdata/internal/data/protogen/trace/v1"
 )
 
-// TracesMarshaler marshals pdata.Traces into bytes.
-type TracesMarshaler interface {
-	// MarshalTraces the given pdata.Traces into bytes.
-	// If the error is not nil, the returned bytes slice cannot be used.
-	MarshalTraces(td Traces) ([]byte, error)
-}
-
-// TracesUnmarshaler unmarshalls bytes into pdata.Traces.
-type TracesUnmarshaler interface {
-	// UnmarshalTraces the given bytes into pdata.Traces.
-	// If the error is not nil, the returned pdata.Traces cannot be used.
-	UnmarshalTraces(buf []byte) (Traces, error)
-}
-
-// TracesSizer is an optional interface implemented by the TracesMarshaler,
-// that calculates the size of a marshaled Traces.
-type TracesSizer interface {
-	// TracesSize returns the size in bytes of a marshaled Traces.
-	TracesSize(td Traces) int
-}
-
 // Traces is the top-level struct that is propagated through the traces pipeline.
 // Use NewTraces to create new instance, zero-initialized instance is not valid for use.
 type Traces struct {

--- a/pdata/plog/alias.go
+++ b/pdata/plog/alias.go
@@ -18,19 +18,10 @@ package plog // import "go.opentelemetry.io/collector/pdata/plog"
 
 import "go.opentelemetry.io/collector/pdata/internal"
 
-// Marshaler is an alias for internal.LogsMarshaler interface.
-type Marshaler = internal.LogsMarshaler
-
-// Unmarshaler is an alias for internal.LogsUnmarshaler interface.
-type Unmarshaler = internal.LogsUnmarshaler
-
-// Sizer is an alias for internal.LogsSizer interface.
-type Sizer = internal.LogsSizer
-
 // Logs is an alias for internal.Logs struct.
 type Logs = internal.Logs
 
-// New is an alias for a function to create new Logs.
+// NewLogs is an alias for a function to create new Logs.
 var NewLogs = internal.NewLogs
 
 // SeverityNumber is an alias for internal.SeverityNumber type.

--- a/pdata/plog/encoding.go
+++ b/pdata/plog/encoding.go
@@ -1,0 +1,36 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plog // import "go.opentelemetry.io/collector/pdata/plog"
+
+// Marshaler marshals pdata.Logs into bytes.
+type Marshaler interface {
+	// MarshalLogs the given pdata.Logs into bytes.
+	// If the error is not nil, the returned bytes slice cannot be used.
+	MarshalLogs(ld Logs) ([]byte, error)
+}
+
+// Unmarshaler unmarshalls bytes into pdata.Logs.
+type Unmarshaler interface {
+	// UnmarshalLogs the given bytes into pdata.Logs.
+	// If the error is not nil, the returned pdata.Logs cannot be used.
+	UnmarshalLogs(buf []byte) (Logs, error)
+}
+
+// Sizer is an optional interface implemented by the Marshaler,
+// that calculates the size of a marshaled Logs.
+type Sizer interface {
+	// LogsSize returns the size in bytes of a marshaled Logs.
+	LogsSize(ld Logs) int
+}

--- a/pdata/pmetric/alias.go
+++ b/pdata/pmetric/alias.go
@@ -16,15 +16,6 @@ package pmetric // import "go.opentelemetry.io/collector/pdata/pmetric"
 
 import "go.opentelemetry.io/collector/pdata/internal" // This file contains aliases for metric data structures.
 
-// Marshaler is an alias for internal.MetricsMarshaler interface.
-type Marshaler = internal.MetricsMarshaler
-
-// Unmarshaler is an alias for internal.MetricsUnmarshaler interface.
-type Unmarshaler = internal.MetricsUnmarshaler
-
-// Sizer is an alias for internal.MetricsSizer interface.
-type Sizer = internal.MetricsSizer
-
 // Metrics is an alias for internal.Metrics structure.
 type Metrics = internal.Metrics
 

--- a/pdata/pmetric/encoding.go
+++ b/pdata/pmetric/encoding.go
@@ -1,0 +1,35 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pmetric // import "go.opentelemetry.io/collector/pdata/pmetric"
+
+// Marshaler marshals pmetric.Metrics into bytes.
+type Marshaler interface {
+	// MarshalMetrics the given pmetric.Metrics into bytes.
+	// If the error is not nil, the returned bytes slice cannot be used.
+	MarshalMetrics(md Metrics) ([]byte, error)
+}
+
+// Unmarshaler unmarshalls bytes into pmetric.Metrics.
+type Unmarshaler interface {
+	// UnmarshalMetrics the given bytes into pmetric.Metrics.
+	// If the error is not nil, the returned pmetric.Metrics cannot be used.
+	UnmarshalMetrics(buf []byte) (Metrics, error)
+}
+
+// Sizer is an optional interface implemented by the Marshaler, that calculates the size of a marshaled Metrics.
+type Sizer interface {
+	// MetricsSize returns the size in bytes of a marshaled Metrics.
+	MetricsSize(md Metrics) int
+}

--- a/pdata/ptrace/alias.go
+++ b/pdata/ptrace/alias.go
@@ -18,15 +18,6 @@ import "go.opentelemetry.io/collector/pdata/internal"
 
 // This file contains aliases for trace data structures.
 
-// Marshaler is an alias for internal.TracesMarshaler interface.
-type Marshaler = internal.TracesMarshaler
-
-// Unmarshaler is an alias for internal.TracesUnmarshaler interface.
-type Unmarshaler = internal.TracesUnmarshaler
-
-// Sizer is an alias for internal.TracesSizer interface.
-type Sizer = internal.TracesSizer
-
 // Traces is an alias for internal.Traces struct.
 type Traces = internal.Traces
 

--- a/pdata/ptrace/encoding.go
+++ b/pdata/ptrace/encoding.go
@@ -1,0 +1,36 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ptrace // import "go.opentelemetry.io/collector/pdata/ptrace"
+
+// Marshaler marshals pdata.Traces into bytes.
+type Marshaler interface {
+	// MarshalTraces the given pdata.Traces into bytes.
+	// If the error is not nil, the returned bytes slice cannot be used.
+	MarshalTraces(td Traces) ([]byte, error)
+}
+
+// Unmarshaler unmarshalls bytes into pdata.Traces.
+type Unmarshaler interface {
+	// UnmarshalTraces the given bytes into pdata.Traces.
+	// If the error is not nil, the returned pdata.Traces cannot be used.
+	UnmarshalTraces(buf []byte) (Traces, error)
+}
+
+// Sizer is an optional interface implemented by the Marshaler,
+// that calculates the size of a marshaled Traces.
+type Sizer interface {
+	// TracesSize returns the size in bytes of a marshaled Traces.
+	TracesSize(td Traces) int
+}


### PR DESCRIPTION
Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
