### PR TITLE
Use `go.uber.org/atomic` everywhere

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -95,8 +95,16 @@ linters-settings:
       - kilometre
       - kilometres
 
+  depguard:
+    list-type: denylist
+    include-go-root: true
+    packages-with-error-message:
+      # See https://github.com/open-telemetry/opentelemetry-collector/issues/5200 for rationale
+      - sync/atomic: "Use go.uber.org/atomic instead of sync/atomic"
+
 linters:
   enable:
+    - depguard
     - errcheck
     - exportloopref
     - gocritic

--- a/exporter/exporterhelper/queued_retry_test.go
+++ b/exporter/exporterhelper/queued_retry_test.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -28,6 +27,7 @@ import (
 	"go.opencensus.io/metric/metricdata"
 	"go.opencensus.io/metric/metricproducer"
 	"go.opencensus.io/tag"
+	"go.uber.org/atomic"
 
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/consumer/consumererror"
@@ -410,11 +410,11 @@ type mockRequest struct {
 	cnt          int
 	mu           sync.Mutex
 	consumeError error
-	requestCount *int64
+	requestCount *atomic.Int64
 }
 
 func (m *mockRequest) export(ctx context.Context) error {
-	atomic.AddInt64(m.requestCount, 1)
+	m.requestCount.Inc()
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	err := m.consumeError
@@ -441,7 +441,7 @@ func (m *mockRequest) onError(error) request {
 
 func (m *mockRequest) checkNumRequests(t *testing.T, want int) {
 	assert.Eventually(t, func() bool {
-		return int64(want) == atomic.LoadInt64(m.requestCount)
+		return int64(want) == m.requestCount.Load()
 	}, time.Second, 1*time.Millisecond)
 }
 
@@ -454,27 +454,32 @@ func newMockRequest(ctx context.Context, cnt int, consumeError error) *mockReque
 		baseRequest:  baseRequest{ctx: ctx},
 		cnt:          cnt,
 		consumeError: consumeError,
-		requestCount: new(int64),
+		requestCount: atomic.NewInt64(0),
 	}
 }
 
 type observabilityConsumerSender struct {
 	waitGroup         *sync.WaitGroup
-	sentItemsCount    int64
-	droppedItemsCount int64
+	sentItemsCount    *atomic.Int64
+	droppedItemsCount *atomic.Int64
 	nextSender        requestSender
 }
 
 func newObservabilityConsumerSender(nextSender requestSender) *observabilityConsumerSender {
-	return &observabilityConsumerSender{waitGroup: new(sync.WaitGroup), nextSender: nextSender}
+	return &observabilityConsumerSender{
+		waitGroup:         new(sync.WaitGroup),
+		nextSender:        nextSender,
+		droppedItemsCount: atomic.NewInt64(0),
+		sentItemsCount:    atomic.NewInt64(0),
+	}
 }
 
 func (ocs *observabilityConsumerSender) send(req request) error {
 	err := ocs.nextSender.send(req)
 	if err != nil {
-		atomic.AddInt64(&ocs.droppedItemsCount, int64(req.count()))
+		ocs.droppedItemsCount.Add(int64(req.count()))
 	} else {
-		atomic.AddInt64(&ocs.sentItemsCount, int64(req.count()))
+		ocs.sentItemsCount.Add(int64(req.count()))
 	}
 	ocs.waitGroup.Done()
 	return err
@@ -490,11 +495,11 @@ func (ocs *observabilityConsumerSender) awaitAsyncProcessing() {
 }
 
 func (ocs *observabilityConsumerSender) checkSendItemsCount(t *testing.T, want int) {
-	assert.EqualValues(t, want, atomic.LoadInt64(&ocs.sentItemsCount))
+	assert.EqualValues(t, want, ocs.sentItemsCount.Load())
 }
 
 func (ocs *observabilityConsumerSender) checkDroppedItemsCount(t *testing.T, want int) {
-	assert.EqualValues(t, want, atomic.LoadInt64(&ocs.droppedItemsCount))
+	assert.EqualValues(t, want, ocs.droppedItemsCount.Load())
 }
 
 // checkValueForGlobalManager checks that the given metrics with wantTags is reported by one of the

--- a/internal/obsreportconfig/obsreportconfig.go
+++ b/internal/obsreportconfig/obsreportconfig.go
@@ -15,18 +15,17 @@
 package obsreportconfig // import "go.opentelemetry.io/collector/internal/obsreportconfig"
 
 import (
-	"sync/atomic"
-
 	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
+	"go.uber.org/atomic"
 
 	"go.opentelemetry.io/collector/config/configtelemetry"
 	"go.opentelemetry.io/collector/internal/obsreportconfig/obsmetrics"
 )
 
 var (
-	globalLevel = int32(configtelemetry.LevelBasic)
+	globalLevel = atomic.NewInt32(int32(configtelemetry.LevelBasic))
 )
 
 // ObsMetrics wraps OpenCensus View for Collector observability metrics
@@ -37,7 +36,7 @@ type ObsMetrics struct {
 // Configure is used to control the settings that will be used by the obsreport
 // package.
 func Configure(level configtelemetry.Level) *ObsMetrics {
-	atomic.StoreInt32(&globalLevel, int32(level))
+	globalLevel.Store(int32(level))
 
 	var views []*view.View
 
@@ -52,7 +51,7 @@ func Configure(level configtelemetry.Level) *ObsMetrics {
 }
 
 func Level() configtelemetry.Level {
-	return configtelemetry.Level(atomic.LoadInt32(&globalLevel))
+	return configtelemetry.Level(globalLevel.Load())
 }
 
 // allViews return the list of all views that needs to be configured.

--- a/processor/memorylimiterprocessor/memorylimiter_test.go
+++ b/processor/memorylimiterprocessor/memorylimiter_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
 	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -112,6 +113,7 @@ func TestMetricsMemoryPressureResponse(t *testing.T) {
 		usageChecker: memUsageChecker{
 			memAllocLimit: 1024,
 		},
+		forceDrop: atomic.NewInt64(0),
 		readMemStatsFn: func(ms *runtime.MemStats) {
 			ms.Alloc = currentMemAlloc
 		},
@@ -184,6 +186,7 @@ func TestTraceMemoryPressureResponse(t *testing.T) {
 		usageChecker: memUsageChecker{
 			memAllocLimit: 1024,
 		},
+		forceDrop: atomic.NewInt64(0),
 		readMemStatsFn: func(ms *runtime.MemStats) {
 			ms.Alloc = currentMemAlloc
 		},
@@ -255,6 +258,7 @@ func TestLogMemoryPressureResponse(t *testing.T) {
 		usageChecker: memUsageChecker{
 			memAllocLimit: 1024,
 		},
+		forceDrop: atomic.NewInt64(0),
 		readMemStatsFn: func(ms *runtime.MemStats) {
 			ms.Alloc = currentMemAlloc
 		},


### PR DESCRIPTION
**Description:**

- Add depguard to enforce usage of `go.uber.org/atomic`
- Use `go.uber.org/atomic` everywhere (WIP, still need to fix some tests)

**Link to tracking Issue:** Fixes #5200
