### PR TITLE
Use atomic.Bool when int was used as a bool variable

### DIFF
--- a/exporter/exporterhelper/internal/bounded_memory_queue.go
+++ b/exporter/exporterhelper/internal/bounded_memory_queue.go
@@ -19,7 +19,7 @@ package internal // import "go.opentelemetry.io/collector/exporter/exporterhelpe
 import (
 	"sync"
 
-	uatomic "go.uber.org/atomic"
+	"go.uber.org/atomic"
 )
 
 // boundedMemoryQueue implements a producer-consumer exchange similar to a ring buffer queue,
@@ -29,8 +29,8 @@ import (
 // the items from the top of the queue until its size drops back to maxSize
 type boundedMemoryQueue struct {
 	stopWG        sync.WaitGroup
-	size          *uatomic.Uint32
-	stopped       *uatomic.Uint32
+	size          *atomic.Uint32
+	stopped       *atomic.Bool
 	items         chan interface{}
 	onDroppedItem func(item interface{})
 	factory       func() consumer
@@ -45,8 +45,8 @@ func NewBoundedMemoryQueue(capacity int, onDroppedItem func(item interface{})) P
 		onDroppedItem: onDroppedItem,
 		items:         make(chan interface{}, capacity),
 		stopCh:        make(chan struct{}),
-		stopped:       uatomic.NewUint32(0),
-		size:          uatomic.NewUint32(0),
+		stopped:       atomic.NewBool(false),
+		size:          atomic.NewUint32(0),
 		capacity:      uint32(capacity),
 	}
 }
@@ -97,7 +97,7 @@ func (c consumerFunc) consume(item interface{}) {
 
 // Produce is used by the producer to submit new item to the queue. Returns false in case of queue overflow.
 func (q *boundedMemoryQueue) Produce(item interface{}) bool {
-	if q.stopped.Load() != 0 {
+	if q.stopped.Load() {
 		q.onDroppedItem(item)
 		return false
 	}
@@ -128,7 +128,7 @@ func (q *boundedMemoryQueue) Produce(item interface{}) bool {
 // Stop stops all consumers, as well as the length reporter if started,
 // and releases the items channel. It blocks until all consumers have stopped.
 func (q *boundedMemoryQueue) Stop() {
-	q.stopped.Store(1) // disable producer
+	q.stopped.Store(true) // disable producer
 	close(q.stopCh)
 	q.stopWG.Wait()
 	close(q.items)

--- a/processor/memorylimiterprocessor/memorylimiter_test.go
+++ b/processor/memorylimiterprocessor/memorylimiter_test.go
@@ -113,7 +113,7 @@ func TestMetricsMemoryPressureResponse(t *testing.T) {
 		usageChecker: memUsageChecker{
 			memAllocLimit: 1024,
 		},
-		forceDrop: atomic.NewInt64(0),
+		forceDrop: atomic.NewBool(false),
 		readMemStatsFn: func(ms *runtime.MemStats) {
 			ms.Alloc = currentMemAlloc
 		},
@@ -186,7 +186,7 @@ func TestTraceMemoryPressureResponse(t *testing.T) {
 		usageChecker: memUsageChecker{
 			memAllocLimit: 1024,
 		},
-		forceDrop: atomic.NewInt64(0),
+		forceDrop: atomic.NewBool(false),
 		readMemStatsFn: func(ms *runtime.MemStats) {
 			ms.Alloc = currentMemAlloc
 		},
@@ -258,7 +258,7 @@ func TestLogMemoryPressureResponse(t *testing.T) {
 		usageChecker: memUsageChecker{
 			memAllocLimit: 1024,
 		},
-		forceDrop: atomic.NewInt64(0),
+		forceDrop: atomic.NewBool(false),
 		readMemStatsFn: func(ms *runtime.MemStats) {
 			ms.Alloc = currentMemAlloc
 		},


### PR DESCRIPTION
Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
