### PR TITLE
[pdata] Split `pmetric.MetricValueType` into two more specific types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Remove pdata deprecated funcs from 2 versions (v0.48.0) ago. (#5219)
 - Remove non pdata deprecated funcs/structs (#5220)
+- Split `pmetric.MetricValueType` into `NumberDataPointValueType` and `ExemplarValueType` (#5004)
 
 ### 🚩 Deprecations 🚩
 

--- a/internal/otlptext/databuffer.go
+++ b/internal/otlptext/databuffer.go
@@ -100,9 +100,9 @@ func (b *dataBuffer) logNumberDataPoints(ps pmetric.NumberDataPointSlice) {
 		b.logEntry("StartTimestamp: %s", p.StartTimestamp())
 		b.logEntry("Timestamp: %s", p.Timestamp())
 		switch p.ValueType() {
-		case pmetric.MetricValueTypeInt:
+		case pmetric.NumberDataPointValueTypeInt:
 			b.logEntry("Value: %d", p.IntVal())
-		case pmetric.MetricValueTypeDouble:
+		case pmetric.NumberDataPointValueTypeDouble:
 			b.logEntry("Value: %f", p.DoubleVal())
 		}
 	}

--- a/model/pdata/metrics_alias.go
+++ b/model/pdata/metrics_alias.go
@@ -100,19 +100,3 @@ const (
 	// Deprecated: [v0.49.0] Use pmetric.MetricDataPointFlagNoRecordedValue instead.
 	MetricDataPointFlagNoRecordedValue = pmetric.MetricDataPointFlagNoRecordedValue
 )
-
-// MetricValueType is an alias for pmetric.MetricValueType type.
-// Deprecated: [v0.49.0] Use pmetric.MetricValueType instead.
-type MetricValueType = pmetric.MetricValueType
-
-const (
-
-	// Deprecated: [v0.49.0] Use pmetric.MetricValueTypeNone instead.
-	MetricValueTypeNone = pmetric.MetricValueTypeNone
-
-	// Deprecated: [v0.49.0] Use pmetric.MetricValueTypeInt instead.
-	MetricValueTypeInt = pmetric.MetricValueTypeInt
-
-	// Deprecated: [v0.49.0] Use pmetric.MetricValueTypeDouble instead.
-	MetricValueTypeDouble = pmetric.MetricValueTypeDouble
-)

--- a/pdata/internal/cmd/pdatagen/internal/metrics_structs.go
+++ b/pdata/internal/cmd/pdatagen/internal/metrics_structs.go
@@ -242,7 +242,7 @@ var numberDataPoint = &messageValueStruct{
 		startTimeField,
 		timeField,
 		&oneOfField{
-			typeName:         "MetricValueType",
+			typeName:         "NumberDataPointValueType",
 			originFieldName:  "Value",
 			originTypePrefix: "otlpmetrics.NumberDataPoint_",
 			testValueIdx:     0, // Double
@@ -412,7 +412,7 @@ var exemplar = &messageValueStruct{
 	fields: []baseField{
 		timeField,
 		&oneOfField{
-			typeName:         "MetricValueType",
+			typeName:         "ExemplarValueType",
 			originFieldName:  "Value",
 			originTypePrefix: "otlpmetrics.Exemplar_",
 			testValueIdx:     1, // Int

--- a/pdata/internal/generated_pmetric.go
+++ b/pdata/internal/generated_pmetric.go
@@ -1161,14 +1161,14 @@ func (ms NumberDataPoint) SetTimestamp(v Timestamp) {
 
 // ValueType returns the type of the value for this NumberDataPoint.
 // Calling this function on zero-initialized NumberDataPoint will cause a panic.
-func (ms NumberDataPoint) ValueType() MetricValueType {
+func (ms NumberDataPoint) ValueType() NumberDataPointValueType {
 	switch ms.orig.Value.(type) {
 	case *otlpmetrics.NumberDataPoint_AsDouble:
-		return MetricValueTypeDouble
+		return NumberDataPointValueTypeDouble
 	case *otlpmetrics.NumberDataPoint_AsInt:
-		return MetricValueTypeInt
+		return NumberDataPointValueTypeInt
 	}
-	return MetricValueTypeNone
+	return NumberDataPointValueTypeNone
 }
 
 // DoubleVal returns the doubleval associated with this NumberDataPoint.
@@ -1216,9 +1216,9 @@ func (ms NumberDataPoint) CopyTo(dest NumberDataPoint) {
 	dest.SetStartTimestamp(ms.StartTimestamp())
 	dest.SetTimestamp(ms.Timestamp())
 	switch ms.ValueType() {
-	case MetricValueTypeDouble:
+	case NumberDataPointValueTypeDouble:
 		dest.SetDoubleVal(ms.DoubleVal())
-	case MetricValueTypeInt:
+	case NumberDataPointValueTypeInt:
 		dest.SetIntVal(ms.IntVal())
 	}
 
@@ -2420,14 +2420,14 @@ func (ms Exemplar) SetTimestamp(v Timestamp) {
 
 // ValueType returns the type of the value for this Exemplar.
 // Calling this function on zero-initialized Exemplar will cause a panic.
-func (ms Exemplar) ValueType() MetricValueType {
+func (ms Exemplar) ValueType() ExemplarValueType {
 	switch ms.orig.Value.(type) {
 	case *otlpmetrics.Exemplar_AsDouble:
-		return MetricValueTypeDouble
+		return ExemplarValueTypeDouble
 	case *otlpmetrics.Exemplar_AsInt:
-		return MetricValueTypeInt
+		return ExemplarValueTypeInt
 	}
-	return MetricValueTypeNone
+	return ExemplarValueTypeNone
 }
 
 // DoubleVal returns the doubleval associated with this Exemplar.
@@ -2483,9 +2483,9 @@ func (ms Exemplar) SetSpanID(v SpanID) {
 func (ms Exemplar) CopyTo(dest Exemplar) {
 	dest.SetTimestamp(ms.Timestamp())
 	switch ms.ValueType() {
-	case MetricValueTypeDouble:
+	case ExemplarValueTypeDouble:
 		dest.SetDoubleVal(ms.DoubleVal())
-	case MetricValueTypeInt:
+	case ExemplarValueTypeInt:
 		dest.SetIntVal(ms.IntVal())
 	}
 

--- a/pdata/internal/generated_pmetric_test.go
+++ b/pdata/internal/generated_pmetric_test.go
@@ -863,12 +863,12 @@ func TestNumberDataPoint_Timestamp(t *testing.T) {
 
 func TestNumberDataPointValueType(t *testing.T) {
 	tv := NewNumberDataPoint()
-	assert.Equal(t, MetricValueTypeNone, tv.ValueType())
-	assert.Equal(t, "", MetricValueType(1000).String())
+	assert.Equal(t, NumberDataPointValueTypeNone, tv.ValueType())
+	assert.Equal(t, "", NumberDataPointValueType(1000).String())
 	tv.SetDoubleVal(float64(17.13))
-	assert.Equal(t, MetricValueTypeDouble, tv.ValueType())
+	assert.Equal(t, NumberDataPointValueTypeDouble, tv.ValueType())
 	tv.SetIntVal(int64(17))
-	assert.Equal(t, MetricValueTypeInt, tv.ValueType())
+	assert.Equal(t, NumberDataPointValueTypeInt, tv.ValueType())
 }
 
 func TestNumberDataPoint_DoubleVal(t *testing.T) {
@@ -1782,12 +1782,12 @@ func TestExemplar_Timestamp(t *testing.T) {
 
 func TestExemplarValueType(t *testing.T) {
 	tv := NewExemplar()
-	assert.Equal(t, MetricValueTypeNone, tv.ValueType())
-	assert.Equal(t, "", MetricValueType(1000).String())
+	assert.Equal(t, ExemplarValueTypeNone, tv.ValueType())
+	assert.Equal(t, "", ExemplarValueType(1000).String())
 	tv.SetDoubleVal(float64(17.13))
-	assert.Equal(t, MetricValueTypeDouble, tv.ValueType())
+	assert.Equal(t, ExemplarValueTypeDouble, tv.ValueType())
 	tv.SetIntVal(int64(17))
-	assert.Equal(t, MetricValueTypeInt, tv.ValueType())
+	assert.Equal(t, ExemplarValueTypeInt, tv.ValueType())
 }
 
 func TestExemplar_DoubleVal(t *testing.T) {

--- a/pdata/internal/metrics.go
+++ b/pdata/internal/metrics.go
@@ -222,23 +222,45 @@ const (
 	MetricDataPointFlagNoRecordedValue = MetricDataPointFlag(otlpmetrics.DataPointFlags_FLAG_NO_RECORDED_VALUE)
 )
 
-// MetricValueType specifies the type of NumberDataPoint.
-type MetricValueType int32
+// NumberDataPointValueType specifies the type of NumberDataPoint value.
+type NumberDataPointValueType int32
 
 const (
-	MetricValueTypeNone MetricValueType = iota
-	MetricValueTypeInt
-	MetricValueTypeDouble
+	NumberDataPointValueTypeNone NumberDataPointValueType = iota
+	NumberDataPointValueTypeInt
+	NumberDataPointValueTypeDouble
 )
 
-// String returns the string representation of the MetricValueType.
-func (mdt MetricValueType) String() string {
-	switch mdt {
-	case MetricValueTypeNone:
+// String returns the string representation of the NumberDataPointValueType.
+func (nt NumberDataPointValueType) String() string {
+	switch nt {
+	case NumberDataPointValueTypeNone:
 		return "None"
-	case MetricValueTypeInt:
+	case NumberDataPointValueTypeInt:
 		return "Int"
-	case MetricValueTypeDouble:
+	case NumberDataPointValueTypeDouble:
+		return "Double"
+	}
+	return ""
+}
+
+// ExemplarValueType specifies the type of Exemplar measurement value.
+type ExemplarValueType int32
+
+const (
+	ExemplarValueTypeNone ExemplarValueType = iota
+	ExemplarValueTypeInt
+	ExemplarValueTypeDouble
+)
+
+// String returns the string representation of the ExemplarValueType.
+func (nt ExemplarValueType) String() string {
+	switch nt {
+	case ExemplarValueTypeNone:
+		return "None"
+	case ExemplarValueTypeInt:
+		return "Int"
+	case ExemplarValueTypeDouble:
 		return "Double"
 	}
 	return ""

--- a/pdata/internal/metrics_test.go
+++ b/pdata/internal/metrics_test.go
@@ -43,11 +43,18 @@ func TestMetricDataTypeString(t *testing.T) {
 	assert.Equal(t, "", (MetricDataTypeSummary + 1).String())
 }
 
-func TestPointMetricValueTypeString(t *testing.T) {
-	assert.Equal(t, "None", MetricValueTypeNone.String())
-	assert.Equal(t, "Int", MetricValueTypeInt.String())
-	assert.Equal(t, "Double", MetricValueTypeDouble.String())
-	assert.Equal(t, "", (MetricValueTypeDouble + 1).String())
+func TestNumberDataPointValueTypeString(t *testing.T) {
+	assert.Equal(t, "None", NumberDataPointValueTypeNone.String())
+	assert.Equal(t, "Int", NumberDataPointValueTypeInt.String())
+	assert.Equal(t, "Double", NumberDataPointValueTypeDouble.String())
+	assert.Equal(t, "", (NumberDataPointValueTypeDouble + 1).String())
+}
+
+func TestExemplarValueTypeString(t *testing.T) {
+	assert.Equal(t, "None", ExemplarValueTypeNone.String())
+	assert.Equal(t, "Int", ExemplarValueTypeInt.String())
+	assert.Equal(t, "Double", ExemplarValueTypeDouble.String())
+	assert.Equal(t, "", (ExemplarValueTypeDouble + 1).String())
 }
 
 func TestResourceMetricsWireCompatibility(t *testing.T) {

--- a/pdata/pmetric/alias.go
+++ b/pdata/pmetric/alias.go
@@ -73,11 +73,20 @@ const (
 	MetricDataPointFlagNoRecordedValue = internal.MetricDataPointFlagNoRecordedValue
 )
 
-// MetricValueType specifies the type of NumberDataPoint.
-type MetricValueType = internal.MetricValueType
+// NumberDataPointValueType specifies the type of NumberDataPoint value.
+type NumberDataPointValueType = internal.NumberDataPointValueType
 
 const (
-	MetricValueTypeNone   = internal.MetricValueTypeNone
-	MetricValueTypeInt    = internal.MetricValueTypeInt
-	MetricValueTypeDouble = internal.MetricValueTypeDouble
+	NumberDataPointValueTypeNone   = internal.NumberDataPointValueTypeNone
+	NumberDataPointValueTypeInt    = internal.NumberDataPointValueTypeInt
+	NumberDataPointValueTypeDouble = internal.NumberDataPointValueTypeDouble
+)
+
+// ExemplarValueType specifies the type of Exemplar measurement value.
+type ExemplarValueType = internal.ExemplarValueType
+
+const (
+	ExemplarValueTypeNone   = internal.ExemplarValueTypeNone
+	ExemplarValueTypeInt    = internal.ExemplarValueTypeInt
+	ExemplarValueTypeDouble = internal.ExemplarValueTypeDouble
 )


### PR DESCRIPTION
Split `pmetric.MetricValueType` into `NumberDataPointValueType` and `ExemplarValueType`

- `NumberDataPoint.ValueType()` now returns a `NumberDataPointValueType` that can be `NumberDataPointValueTypeInt` or `NumberDataPointValueTypeDouble`.

- `ExemplarValueType` now returns a `ExemplarValueType` that can be `ExemplarValueInt` or `ExemplarValueDouble`.

This change doesn't provide backward compatibility. All usage of the old types has to be replaced with the upgrade.

Closes: https://github.com/open-telemetry/opentelemetry-collector/issues/4819

Updated PR from https://github.com/open-telemetry/opentelemetry-collector/pull/5104