### PR TITLE
[pdata] Replace `Request.Set<Signals>` with NewRequestFrom<Signals>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 
 - Deprecate `configunmarshaler` package, move it to internal (#5151)
 - Deprecate all API in `model/semconv`. The package is moved to a new `semcomv` module (#5196)
+- Deprecate `p<signal>otlp.Request.Set<Logs|Metrics|Traces>` (#5234)
+  - `plogotlp.Request.SetLogs` func is deprecated in favor of `plogotlp.NewRequestFromLogs`
+  - `pmetricotlp.Request.SetMetrics` func is deprecated in favor of `pmetricotlp.NewRequestFromMetrics`
+  - `ptraceotlp.Request.SetTraces` func is deprecated in favor of `ptraceotlp.NewRequestFromTraces`
 
 ### 💡 Enhancements 💡
 

--- a/exporter/otlpexporter/otlp.go
+++ b/exporter/otlpexporter/otlp.go
@@ -101,22 +101,19 @@ func (e *exporter) shutdown(context.Context) error {
 }
 
 func (e *exporter) pushTraces(ctx context.Context, td ptrace.Traces) error {
-	req := ptraceotlp.NewRequest()
-	req.SetTraces(td)
+	req := ptraceotlp.NewRequestFromTraces(td)
 	_, err := e.traceExporter.Export(e.enhanceContext(ctx), req, e.callOptions...)
 	return processError(err)
 }
 
 func (e *exporter) pushMetrics(ctx context.Context, md pmetric.Metrics) error {
-	req := pmetricotlp.NewRequest()
-	req.SetMetrics(md)
+	req := pmetricotlp.NewRequestFromMetrics(md)
 	_, err := e.metricExporter.Export(e.enhanceContext(ctx), req, e.callOptions...)
 	return processError(err)
 }
 
 func (e *exporter) pushLogs(ctx context.Context, ld plog.Logs) error {
-	req := plogotlp.NewRequest()
-	req.SetLogs(ld)
+	req := plogotlp.NewRequestFromLogs(ld)
 	_, err := e.logExporter.Export(e.enhanceContext(ctx), req, e.callOptions...)
 	return processError(err)
 }

--- a/exporter/otlphttpexporter/otlp.go
+++ b/exporter/otlphttpexporter/otlp.go
@@ -96,8 +96,7 @@ func (e *exporter) start(_ context.Context, host component.Host) error {
 }
 
 func (e *exporter) pushTraces(ctx context.Context, td ptrace.Traces) error {
-	tr := ptraceotlp.NewRequest()
-	tr.SetTraces(td)
+	tr := ptraceotlp.NewRequestFromTraces(td)
 	request, err := tr.MarshalProto()
 	if err != nil {
 		return consumererror.NewPermanent(err)
@@ -107,8 +106,7 @@ func (e *exporter) pushTraces(ctx context.Context, td ptrace.Traces) error {
 }
 
 func (e *exporter) pushMetrics(ctx context.Context, md pmetric.Metrics) error {
-	tr := pmetricotlp.NewRequest()
-	tr.SetMetrics(md)
+	tr := pmetricotlp.NewRequestFromMetrics(md)
 	request, err := tr.MarshalProto()
 	if err != nil {
 		return consumererror.NewPermanent(err)
@@ -117,8 +115,7 @@ func (e *exporter) pushMetrics(ctx context.Context, md pmetric.Metrics) error {
 }
 
 func (e *exporter) pushLogs(ctx context.Context, ld plog.Logs) error {
-	tr := plogotlp.NewRequest()
-	tr.SetLogs(ld)
+	tr := plogotlp.NewRequestFromLogs(ld)
 	request, err := tr.MarshalProto()
 	if err != nil {
 		return consumererror.NewPermanent(err)

--- a/pdata/plog/plogotlp/logs.go
+++ b/pdata/plog/plogotlp/logs.go
@@ -65,6 +65,7 @@ func (lr Response) UnmarshalJSON(data []byte) error {
 }
 
 // Request represents the request for gRPC/HTTP client/server.
+// It's a wrapper for plog.Logs data.
 type Request struct {
 	orig *otlpcollectorlog.ExportLogsServiceRequest
 }
@@ -72,6 +73,13 @@ type Request struct {
 // NewRequest returns an empty Request.
 func NewRequest() Request {
 	return Request{orig: &otlpcollectorlog.ExportLogsServiceRequest{}}
+}
+
+// NewRequestFromLogs returns a Request from plog.Logs.
+// Because Request is a wrapper for plog.Logs,
+// any changes to the provided Logs struct will be reflected in the Request and vise versa.
+func NewRequestFromLogs(l plog.Logs) Request {
+	return Request{orig: internal.LogsToOtlp(l)}
 }
 
 // MarshalProto marshals Request into proto bytes.
@@ -106,6 +114,7 @@ func (lr Request) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// Deprecated: [v0.50.0] Use NewRequestFromLogs instead.
 func (lr Request) SetLogs(ld plog.Logs) {
 	*lr.orig = *internal.LogsToOtlp(ld)
 }

--- a/pdata/plog/plogotlp/logs.go
+++ b/pdata/plog/plogotlp/logs.go
@@ -77,7 +77,7 @@ func NewRequest() Request {
 
 // NewRequestFromLogs returns a Request from plog.Logs.
 // Because Request is a wrapper for plog.Logs,
-// any changes to the provided Logs struct will be reflected in the Request and vise versa.
+// any changes to the provided Logs struct will be reflected in the Request and vice versa.
 func NewRequestFromLogs(l plog.Logs) Request {
 	return Request{orig: internal.LogsToOtlp(l)}
 }

--- a/pdata/plog/plogotlp/logs_test.go
+++ b/pdata/plog/plogotlp/logs_test.go
@@ -314,10 +314,7 @@ func (f fakeLogsServer) Export(_ context.Context, request Request) (Response, er
 func generateLogsRequest() Request {
 	ld := plog.NewLogs()
 	ld.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords().AppendEmpty().Body().SetStringVal("test_log_record")
-
-	lr := NewRequest()
-	lr.SetLogs(ld)
-	return lr
+	return NewRequestFromLogs(ld)
 }
 
 func generateLogsRequestWithInstrumentationLibrary() Request {

--- a/pdata/pmetric/pmetricotlp/metrics.go
+++ b/pdata/pmetric/pmetricotlp/metrics.go
@@ -77,7 +77,7 @@ func NewRequest() Request {
 
 // NewRequestFromMetrics returns a Request from pmetric.Metrics.
 // Because Request is a wrapper for pmetric.Metrics,
-// any changes to the provided Metrics struct will be reflected in the Request and vise versa.
+// any changes to the provided Metrics struct will be reflected in the Request and vice versa.
 func NewRequestFromMetrics(m pmetric.Metrics) Request {
 	return Request{orig: internal.MetricsToOtlp(m)}
 }

--- a/pdata/pmetric/pmetricotlp/metrics.go
+++ b/pdata/pmetric/pmetricotlp/metrics.go
@@ -65,6 +65,7 @@ func (mr Response) UnmarshalJSON(data []byte) error {
 }
 
 // Request represents the request for gRPC/HTTP client/server.
+// It's a wrapper for pmetric.Metrics data.
 type Request struct {
 	orig *otlpcollectormetrics.ExportMetricsServiceRequest
 }
@@ -72,6 +73,13 @@ type Request struct {
 // NewRequest returns an empty Request.
 func NewRequest() Request {
 	return Request{orig: &otlpcollectormetrics.ExportMetricsServiceRequest{}}
+}
+
+// NewRequestFromMetrics returns a Request from pmetric.Metrics.
+// Because Request is a wrapper for pmetric.Metrics,
+// any changes to the provided Metrics struct will be reflected in the Request and vise versa.
+func NewRequestFromMetrics(m pmetric.Metrics) Request {
+	return Request{orig: internal.MetricsToOtlp(m)}
 }
 
 // MarshalProto marshals Request into proto bytes.
@@ -102,6 +110,7 @@ func (mr Request) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// Deprecated: [v0.50.0] Use NewRequestFromMetrics instead.
 func (mr Request) SetMetrics(ld pmetric.Metrics) {
 	*mr.orig = *internal.MetricsToOtlp(ld)
 }

--- a/pdata/pmetric/pmetricotlp/metrics_test.go
+++ b/pdata/pmetric/pmetricotlp/metrics_test.go
@@ -301,10 +301,7 @@ func generateMetricsRequest() Request {
 	m.SetName("test_metric")
 	m.SetDataType(pmetric.MetricDataTypeGauge)
 	m.Gauge().DataPoints().AppendEmpty()
-
-	mr := NewRequest()
-	mr.SetMetrics(md)
-	return mr
+	return NewRequestFromMetrics(md)
 }
 
 func generateMetricsRequestWithInstrumentationLibrary() Request {

--- a/pdata/ptrace/ptraceotlp/traces.go
+++ b/pdata/ptrace/ptraceotlp/traces.go
@@ -77,7 +77,7 @@ func NewRequest() Request {
 
 // NewRequestFromTraces returns a Request from ptrace.Traces.
 // Because Request is a wrapper for ptrace.Traces,
-// any changes to the provided Traces struct will be reflected in the Request and vise versa.
+// any changes to the provided Traces struct will be reflected in the Request and vice versa.
 func NewRequestFromTraces(t ptrace.Traces) Request {
 	return Request{orig: internal.TracesToOtlp(t)}
 }

--- a/pdata/ptrace/ptraceotlp/traces.go
+++ b/pdata/ptrace/ptraceotlp/traces.go
@@ -65,6 +65,7 @@ func (tr Response) UnmarshalJSON(data []byte) error {
 }
 
 // Request represents the request for gRPC/HTTP client/server.
+// It's a wrapper for ptrace.Traces data.
 type Request struct {
 	orig *otlpcollectortrace.ExportTraceServiceRequest
 }
@@ -72,6 +73,13 @@ type Request struct {
 // NewRequest returns an empty Request.
 func NewRequest() Request {
 	return Request{orig: &otlpcollectortrace.ExportTraceServiceRequest{}}
+}
+
+// NewRequestFromTraces returns a Request from ptrace.Traces.
+// Because Request is a wrapper for ptrace.Traces,
+// any changes to the provided Traces struct will be reflected in the Request and vise versa.
+func NewRequestFromTraces(t ptrace.Traces) Request {
+	return Request{orig: internal.TracesToOtlp(t)}
 }
 
 // MarshalProto marshals Request into proto bytes.
@@ -106,6 +114,7 @@ func (tr Request) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// Deprecated: [v0.50.0] Use NewRequestFromTraces instead.
 func (tr Request) SetTraces(td ptrace.Traces) {
 	*tr.orig = *internal.TracesToOtlp(td)
 }

--- a/pdata/ptrace/ptraceotlp/traces_test.go
+++ b/pdata/ptrace/ptraceotlp/traces_test.go
@@ -315,10 +315,7 @@ func (f fakeTracesServer) Export(_ context.Context, request Request) (Response, 
 func generateTracesRequest() Request {
 	td := ptrace.NewTraces()
 	td.ResourceSpans().AppendEmpty().ScopeSpans().AppendEmpty().Spans().AppendEmpty().SetName("test_span")
-
-	tr := NewRequest()
-	tr.SetTraces(td)
-	return tr
+	return NewRequestFromTraces(td)
 }
 
 func generateTracesRequestWithInstrumentationLibrary() Request {

--- a/receiver/otlpreceiver/internal/logs/otlp_test.go
+++ b/receiver/otlpreceiver/internal/logs/otlp_test.go
@@ -47,8 +47,7 @@ func TestExport(t *testing.T) {
 	// Keep log data to compare the test result against it
 	// Clone needed because OTLP proto XXX_ fields are altered in the GRPC downstream
 	logData := ld.Clone()
-	req := plogotlp.NewRequest()
-	req.SetLogs(ld)
+	req := plogotlp.NewRequestFromLogs(ld)
 
 	resp, err := traceClient.Export(context.Background(), req)
 	require.NoError(t, err, "Failed to export trace: %v", err)
@@ -83,8 +82,7 @@ func TestExport_ErrorConsumer(t *testing.T) {
 	defer logClientDoneFn()
 
 	ld := testdata.GenerateLogsOneLogRecord()
-	req := plogotlp.NewRequest()
-	req.SetLogs(ld)
+	req := plogotlp.NewRequestFromLogs(ld)
 
 	resp, err := logClient.Export(context.Background(), req)
 	assert.EqualError(t, err, "rpc error: code = Unknown desc = my error")

--- a/receiver/otlpreceiver/internal/metrics/otlp_test.go
+++ b/receiver/otlpreceiver/internal/metrics/otlp_test.go
@@ -49,8 +49,7 @@ func TestExport(t *testing.T) {
 	// Clone needed because OTLP proto XXX_ fields are altered in the GRPC downstream
 	metricData := md.Clone()
 
-	req := pmetricotlp.NewRequest()
-	req.SetMetrics(md)
+	req := pmetricotlp.NewRequestFromMetrics(md)
 	resp, err := metricsClient.Export(context.Background(), req)
 
 	require.NoError(t, err, "Failed to export metrics: %v", err)
@@ -85,8 +84,7 @@ func TestExport_ErrorConsumer(t *testing.T) {
 	defer metricsClientDoneFn()
 
 	md := testdata.GenerateMetricsOneMetric()
-	req := pmetricotlp.NewRequest()
-	req.SetMetrics(md)
+	req := pmetricotlp.NewRequestFromMetrics(md)
 
 	resp, err := metricsClient.Export(context.Background(), req)
 	assert.EqualError(t, err, "rpc error: code = Unknown desc = my error")

--- a/receiver/otlpreceiver/internal/trace/otlp_test.go
+++ b/receiver/otlpreceiver/internal/trace/otlp_test.go
@@ -48,8 +48,7 @@ func TestExport(t *testing.T) {
 	// Keep trace data to compare the test result against it
 	// Clone needed because OTLP proto XXX_ fields are altered in the GRPC downstream
 	traceData := td.Clone()
-	req := ptraceotlp.NewRequest()
-	req.SetTraces(td)
+	req := ptraceotlp.NewRequestFromTraces(td)
 
 	resp, err := traceClient.Export(context.Background(), req)
 	require.NoError(t, err, "Failed to export trace: %v", err)
@@ -83,8 +82,7 @@ func TestExport_ErrorConsumer(t *testing.T) {
 	defer traceClientDoneFn()
 
 	td := testdata.GenerateTracesOneSpan()
-	req := ptraceotlp.NewRequest()
-	req.SetTraces(td)
+	req := ptraceotlp.NewRequestFromTraces(td)
 	resp, err := traceClient.Export(context.Background(), req)
 	assert.EqualError(t, err, "rpc error: code = Unknown desc = my error")
 	assert.Equal(t, ptraceotlp.Response{}, resp)

--- a/receiver/otlpreceiver/otlp_test.go
+++ b/receiver/otlpreceiver/otlp_test.go
@@ -991,8 +991,7 @@ loop:
 
 func exportTraces(cc *grpc.ClientConn, td ptrace.Traces) error {
 	acc := ptraceotlp.NewClient(cc)
-	req := ptraceotlp.NewRequest()
-	req.SetTraces(td)
+	req := ptraceotlp.NewRequestFromTraces(td)
 	_, err := acc.Export(context.Background(), req)
 
 	return err


### PR DESCRIPTION
- `plogotlp.Request.SetLogs` func is deprecated in favor of `plogotlp.NewRequestFromLogs`
- `pmetricotlp.Request.SetMetrics` func is deprecated in favor of `pmetricotlp.NewRequestFromMetrics`
- `ptraceotlp.Request.SetTraces` func is deprecated in favor of `ptraceotlp.NewRequestFromTraces`

Closes https://github.com/open-telemetry/opentelemetry-collector/issues/5230
