### PR TITLE
[receiver/otlp] Add tests for YAML edge cases

### DIFF
--- a/receiver/otlpreceiver/config_test.go
+++ b/receiver/otlpreceiver/config_test.go
@@ -42,7 +42,7 @@ func TestLoadConfig(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, cfg)
 
-	assert.Equal(t, len(cfg.Receivers), 10)
+	assert.Equal(t, len(cfg.Receivers), 12)
 
 	assert.Equal(t, cfg.Receivers[config.NewComponentID(typeStr)], factory.CreateDefaultConfig())
 
@@ -55,6 +55,16 @@ func TestLoadConfig(t *testing.T) {
 	defaultOnlyHTTP.SetIDName("only_http")
 	defaultOnlyHTTP.GRPC = nil
 	assert.Equal(t, cfg.Receivers[config.NewComponentIDWithName(typeStr, "only_http")], defaultOnlyHTTP)
+
+	defaultOnlyHTTPNull := factory.CreateDefaultConfig().(*Config)
+	defaultOnlyHTTPNull.SetIDName("only_http_null")
+	defaultOnlyHTTPNull.GRPC = nil
+	assert.Equal(t, cfg.Receivers[config.NewComponentIDWithName(typeStr, "only_http_null")], defaultOnlyHTTPNull)
+
+	defaultOnlyHTTPEmptyMap := factory.CreateDefaultConfig().(*Config)
+	defaultOnlyHTTPEmptyMap.SetIDName("only_http_empty_map")
+	defaultOnlyHTTPEmptyMap.GRPC = nil
+	assert.Equal(t, cfg.Receivers[config.NewComponentIDWithName(typeStr, "only_http_empty_map")], defaultOnlyHTTPEmptyMap)
 
 	assert.Equal(t, cfg.Receivers[config.NewComponentIDWithName(typeStr, "customname")],
 		&Config{

--- a/receiver/otlpreceiver/testdata/config.yaml
+++ b/receiver/otlpreceiver/testdata/config.yaml
@@ -13,6 +13,14 @@ receivers:
   otlp/only_http:
     protocols:
       http:
+  # The following entry initializes the default OTLP receiver with only http support by setting it explicitly to null.
+  otlp/only_http_null:
+    protocols:
+      http: null
+  # The following entry initializes the default OTLP receiver with only http support by setting it explicitly to an empty map.
+  otlp/only_http_empty_map:
+    protocols:
+      http: {}
   # The following entry demonstrates configuring the common receiver settings:
   # - endpoint
   # This configuration is of type 'otlp' and has the name 'customname' with a full name of 'otlp/customname'


### PR DESCRIPTION
**Description:** 

Add two test cases for edge cases in writing the OTLP receiver YAML:

- A protocol key is explicitly set as `null`.
- A protocol key is explicitly set to an empty object, `{}`.

In both cases the protocol will be enabled.

These test cases would usually not be set by end-users but they can happen if there is some processing of YAML (e.g. by something like Helm). I think it's important to have them here to avoid regressions if we ever change the underlying code for configuration loading
