### PR TITLE
Deprecate `plog.LogRecord.SetName()` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
   - `pmetric.MetricValueTypeNone` is deprecated in favor of `NumberDataPointValueTypeNone`
   - `pmetric.MetricValueTypeInt` is deprecated in favor of `NumberDataPointValueTypeInt`
   - `pmetric.MetricValueTypeDouble` is deprecated in favor of `NumberDataPointValueTypeDouble`
+- Deprecate `plog.LogRecord.SetName()` function (#5230)
 
 ### 💡 Enhancements 💡
 

--- a/pdata/internal/cmd/pdatagen/internal/base_fields.go
+++ b/pdata/internal/cmd/pdatagen/internal/base_fields.go
@@ -49,7 +49,7 @@ ${extraComment}func (ms ${structName}) ${fieldName}() ${returnType} {
 }
 
 // Set${fieldName} replaces the ${lowerFieldName} associated with this ${structName}.
-func (ms ${structName}) Set${fieldName}(v ${returnType}) {
+${extraComment}func (ms ${structName}) Set${fieldName}(v ${returnType}) {
 	(*ms.orig).${originFieldName} = v
 }`
 

--- a/pdata/internal/cmd/pdatagen/internal/log_structs.go
+++ b/pdata/internal/cmd/pdatagen/internal/log_structs.go
@@ -130,7 +130,7 @@ var logRecord = &messageValueStruct{
 			testVal:         `SeverityNumberINFO`,
 		},
 		&primitiveField{
-			extraComment:    "Deprecated: [v0.48.0] it was removed from the data model.",
+			extraComment:    "Deprecated: [v0.50.0] it was removed from the data model.",
 			fieldName:       "Name",
 			originFieldName: "Name",
 			returnType:      "string",

--- a/pdata/internal/generated_plog.go
+++ b/pdata/internal/generated_plog.go
@@ -651,12 +651,14 @@ func (ms LogRecord) SetSeverityNumber(v SeverityNumber) {
 
 // Name returns the name associated with this LogRecord.
 //
-// Deprecated: [v0.48.0] it was removed from the data model.
+// Deprecated: [v0.50.0] it was removed from the data model.
 func (ms LogRecord) Name() string {
 	return (*ms.orig).Name
 }
 
 // SetName replaces the name associated with this LogRecord.
+//
+// Deprecated: [v0.50.0] it was removed from the data model.
 func (ms LogRecord) SetName(v string) {
 	(*ms.orig).Name = v
 }


### PR DESCRIPTION
The field is going to be removed but the setter is still not deprecated
