### PR TITLE
Remove usage of unnecessary omitempty

### DIFF
--- a/config/configgrpc/configgrpc.go
+++ b/config/configgrpc/configgrpc.go
@@ -54,9 +54,9 @@ var allowedBalancerNames = []string{roundrobin.Name, grpc.PickFirstBalancerName}
 // Refer to the original data-structure for the meaning of each parameter:
 // https://godoc.org/google.golang.org/grpc/keepalive#ClientParameters
 type KeepaliveClientConfig struct {
-	Time                time.Duration `mapstructure:"time,omitempty"`
-	Timeout             time.Duration `mapstructure:"timeout,omitempty"`
-	PermitWithoutStream bool          `mapstructure:"permit_without_stream,omitempty"`
+	Time                time.Duration `mapstructure:"time"`
+	Timeout             time.Duration `mapstructure:"timeout"`
+	PermitWithoutStream bool          `mapstructure:"permit_without_stream"`
 }
 
 // GRPCClientSettings defines common settings for a gRPC client configuration.
@@ -70,7 +70,7 @@ type GRPCClientSettings struct {
 	Compression configcompression.CompressionType `mapstructure:"compression"`
 
 	// TLSSetting struct exposes TLS client configuration.
-	TLSSetting configtls.TLSClientSetting `mapstructure:"tls,omitempty"`
+	TLSSetting configtls.TLSClientSetting `mapstructure:"tls"`
 
 	// The keepalive parameters for gRPC client. See grpc.WithKeepaliveParams.
 	// (https://godoc.org/google.golang.org/grpc#WithKeepaliveParams).
@@ -96,32 +96,32 @@ type GRPCClientSettings struct {
 	BalancerName string `mapstructure:"balancer_name"`
 
 	// Auth configuration for outgoing RPCs.
-	Auth *configauth.Authentication `mapstructure:"auth,omitempty"`
+	Auth *configauth.Authentication `mapstructure:"auth"`
 }
 
 // KeepaliveServerConfig is the configuration for keepalive.
 type KeepaliveServerConfig struct {
-	ServerParameters  *KeepaliveServerParameters  `mapstructure:"server_parameters,omitempty"`
-	EnforcementPolicy *KeepaliveEnforcementPolicy `mapstructure:"enforcement_policy,omitempty"`
+	ServerParameters  *KeepaliveServerParameters  `mapstructure:"server_parameters"`
+	EnforcementPolicy *KeepaliveEnforcementPolicy `mapstructure:"enforcement_policy"`
 }
 
 // KeepaliveServerParameters allow configuration of the keepalive.ServerParameters.
 // The same default values as keepalive.ServerParameters are applicable and get applied by the server.
 // See https://godoc.org/google.golang.org/grpc/keepalive#ServerParameters for details.
 type KeepaliveServerParameters struct {
-	MaxConnectionIdle     time.Duration `mapstructure:"max_connection_idle,omitempty"`
-	MaxConnectionAge      time.Duration `mapstructure:"max_connection_age,omitempty"`
-	MaxConnectionAgeGrace time.Duration `mapstructure:"max_connection_age_grace,omitempty"`
-	Time                  time.Duration `mapstructure:"time,omitempty"`
-	Timeout               time.Duration `mapstructure:"timeout,omitempty"`
+	MaxConnectionIdle     time.Duration `mapstructure:"max_connection_idle"`
+	MaxConnectionAge      time.Duration `mapstructure:"max_connection_age"`
+	MaxConnectionAgeGrace time.Duration `mapstructure:"max_connection_age_grace"`
+	Time                  time.Duration `mapstructure:"time"`
+	Timeout               time.Duration `mapstructure:"timeout"`
 }
 
 // KeepaliveEnforcementPolicy allow configuration of the keepalive.EnforcementPolicy.
 // The same default values as keepalive.EnforcementPolicy are applicable and get applied by the server.
 // See https://godoc.org/google.golang.org/grpc/keepalive#EnforcementPolicy for details.
 type KeepaliveEnforcementPolicy struct {
-	MinTime             time.Duration `mapstructure:"min_time,omitempty"`
-	PermitWithoutStream bool          `mapstructure:"permit_without_stream,omitempty"`
+	MinTime             time.Duration `mapstructure:"min_time"`
+	PermitWithoutStream bool          `mapstructure:"permit_without_stream"`
 }
 
 // GRPCServerSettings defines common settings for a gRPC server configuration.
@@ -131,7 +131,7 @@ type GRPCServerSettings struct {
 
 	// Configures the protocol to use TLS.
 	// The default value is nil, which will cause the protocol to not use TLS.
-	TLSSetting *configtls.TLSServerSetting `mapstructure:"tls,omitempty"`
+	TLSSetting *configtls.TLSServerSetting `mapstructure:"tls"`
 
 	// MaxRecvMsgSizeMiB sets the maximum size (in MiB) of messages accepted by the server.
 	MaxRecvMsgSizeMiB uint64 `mapstructure:"max_recv_msg_size_mib"`
@@ -149,14 +149,14 @@ type GRPCServerSettings struct {
 	WriteBufferSize int `mapstructure:"write_buffer_size"`
 
 	// Keepalive anchor for all the settings related to keepalive.
-	Keepalive *KeepaliveServerConfig `mapstructure:"keepalive,omitempty"`
+	Keepalive *KeepaliveServerConfig `mapstructure:"keepalive"`
 
 	// Auth for this receiver
-	Auth *configauth.Authentication `mapstructure:"auth,omitempty"`
+	Auth *configauth.Authentication `mapstructure:"auth"`
 
 	// Include propagates the incoming connection's metadata to downstream consumers.
 	// Experimental: *NOTE* this option is subject to change or removal in the future.
-	IncludeMetadata bool `mapstructure:"include_metadata,omitempty"`
+	IncludeMetadata bool `mapstructure:"include_metadata"`
 }
 
 // SanitizedEndpoint strips the prefix of either http:// or https:// from configgrpc.GRPCClientSettings.Endpoint.

--- a/config/confighttp/confighttp.go
+++ b/config/confighttp/confighttp.go
@@ -41,7 +41,7 @@ type HTTPClientSettings struct {
 	Endpoint string `mapstructure:"endpoint"`
 
 	// TLSSetting struct exposes TLS client configuration.
-	TLSSetting configtls.TLSClientSetting `mapstructure:"tls,omitempty"`
+	TLSSetting configtls.TLSClientSetting `mapstructure:"tls"`
 
 	// ReadBufferSize for HTTP client. See http.Transport.ReadBufferSize.
 	ReadBufferSize int `mapstructure:"read_buffer_size"`
@@ -50,17 +50,17 @@ type HTTPClientSettings struct {
 	WriteBufferSize int `mapstructure:"write_buffer_size"`
 
 	// Timeout parameter configures `http.Client.Timeout`.
-	Timeout time.Duration `mapstructure:"timeout,omitempty"`
+	Timeout time.Duration `mapstructure:"timeout"`
 
 	// Additional headers attached to each HTTP request sent by the client.
 	// Existing header values are overwritten if collision happens.
-	Headers map[string]string `mapstructure:"headers,omitempty"`
+	Headers map[string]string `mapstructure:"headers"`
 
 	// Custom Round Tripper to allow for individual components to intercept HTTP requests
 	CustomRoundTripper func(next http.RoundTripper) (http.RoundTripper, error)
 
 	// Auth configuration for outgoing HTTP calls.
-	Auth *configauth.Authentication `mapstructure:"auth,omitempty"`
+	Auth *configauth.Authentication `mapstructure:"auth"`
 
 	// The compression key for supported compression types within collector.
 	Compression configcompression.CompressionType `mapstructure:"compression"`
@@ -204,20 +204,20 @@ type HTTPServerSettings struct {
 	Endpoint string `mapstructure:"endpoint"`
 
 	// TLSSetting struct exposes TLS client configuration.
-	TLSSetting *configtls.TLSServerSetting `mapstructure:"tls, omitempty"`
+	TLSSetting *configtls.TLSServerSetting `mapstructure:"tls"`
 
 	// CORS configures the server for HTTP cross-origin resource sharing (CORS).
-	CORS *CORSSettings `mapstructure:"cors,omitempty"`
+	CORS *CORSSettings `mapstructure:"cors"`
 
 	// Auth for this receiver
-	Auth *configauth.Authentication `mapstructure:"auth,omitempty"`
+	Auth *configauth.Authentication `mapstructure:"auth"`
 
 	// MaxRequestBodySize sets the maximum request body size in bytes
-	MaxRequestBodySize int64 `mapstructure:"max_request_body_size,omitempty"`
+	MaxRequestBodySize int64 `mapstructure:"max_request_body_size"`
 
 	// IncludeMetadata propagates the client metadata from the incoming requests to the downstream consumers
 	// Experimental: *NOTE* this option is subject to change or removal in the future.
-	IncludeMetadata bool `mapstructure:"include_metadata,omitempty"`
+	IncludeMetadata bool `mapstructure:"include_metadata"`
 }
 
 // ToListener creates a net.Listener.
@@ -331,12 +331,12 @@ type CORSSettings struct {
 	// headers are implicitly allowed. If no headers are listed,
 	// X-Requested-With will also be accepted by default. Include "*" to
 	// allow any request header.
-	AllowedHeaders []string `mapstructure:"allowed_headers,omitempty"`
+	AllowedHeaders []string `mapstructure:"allowed_headers"`
 
 	// MaxAge sets the value of the Access-Control-Max-Age response header.
 	// Set it to the number of seconds that browsers should cache a CORS
 	// preflight response for.
-	MaxAge int `mapstructure:"max_age,omitempty"`
+	MaxAge int `mapstructure:"max_age"`
 }
 
 func authInterceptor(next http.Handler, authenticate configauth.AuthenticateFunc) http.Handler {

--- a/processor/batchprocessor/config.go
+++ b/processor/batchprocessor/config.go
@@ -26,15 +26,15 @@ type Config struct {
 	config.ProcessorSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
 
 	// Timeout sets the time after which a batch will be sent regardless of size.
-	Timeout time.Duration `mapstructure:"timeout,omitempty"`
+	Timeout time.Duration `mapstructure:"timeout"`
 
 	// SendBatchSize is the size of a batch which after hit, will trigger it to be sent.
-	SendBatchSize uint32 `mapstructure:"send_batch_size,omitempty"`
+	SendBatchSize uint32 `mapstructure:"send_batch_size"`
 
 	// SendBatchMaxSize is the maximum size of a batch. It must be larger than SendBatchSize.
 	// Larger batches are split into smaller units.
 	// Default value is 0, that means no maximum size.
-	SendBatchMaxSize uint32 `mapstructure:"send_batch_max_size,omitempty"`
+	SendBatchMaxSize uint32 `mapstructure:"send_batch_max_size"`
 }
 
 var _ config.Processor = (*Config)(nil)


### PR DESCRIPTION
`omitempty` has effect only if the config is used as a source to encode/decode from, but the config is always the destination in our case, so it has no effect.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
