### PR TITLE
Reduced logging level for collector shutdown due to context cancel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@
 ### 💡 Enhancements 💡
 
 - Extend config.Map.Unmarshal hook to check map key string to any TextUnmarshaler not only ComponentID (#5244)
-- Collector will no longer print error with stack trace when the collector is shutdown due to a context cancel. ()
+- Collector will no longer print error with stack trace when the collector is shutdown due to a context cancel. (#5258)
 
 ### 🧰 Bug fixes 🧰
 - Fix translation from otlp.Request to pdata representation, changes to the returned pdata not all reflected to the otlp.Request (#5197)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 ### 💡 Enhancements 💡
 
 - Extend config.Map.Unmarshal hook to check map key string to any TextUnmarshaler not only ComponentID (#5244)
+- Collector will no longer print error with stack trace when the collector is shutdown due to a context cancel. ()
 
 ### 🧰 Bug fixes 🧰
 - Fix translation from otlp.Request to pdata representation, changes to the returned pdata not all reflected to the otlp.Request (#5197)

--- a/service/collector.go
+++ b/service/collector.go
@@ -183,15 +183,9 @@ LOOP:
 			col.logger.Info("Received shutdown request")
 			break LOOP
 		case <-ctx.Done():
-			col.logger.Info("Context done, terminating process")
+			// Log the error for the context as a string or else zap.Error prints a stack trace.
+			col.logger.Info("Context done, terminating process", zap.String("Context Error", ctx.Err().Error()))
 
-			// Log error for when a context has timed out.
-			// A context that is canceled could be do to intercepted signals or intentional
-			// and we don't want to log an error with a stack trace to the user.
-			err := ctx.Err()
-			if errors.Is(err, context.DeadlineExceeded) {
-				col.logger.Error("Context deadline exceeded", zap.Error(err))
-			}
 			// Call shutdown with background context as the passed in context has been canceled
 			return col.shutdown(context.Background())
 		}

--- a/service/collector.go
+++ b/service/collector.go
@@ -183,8 +183,7 @@ LOOP:
 			col.logger.Info("Received shutdown request")
 			break LOOP
 		case <-ctx.Done():
-			// Log the error for the context as a string or else zap.Error prints a stack trace.
-			col.logger.Info("Context done, terminating process", zap.String("Context Error", ctx.Err().Error()))
+			col.logger.Info("Context done, terminating process", zap.Error(ctx.Err()))
 
 			// Call shutdown with background context as the passed in context has been canceled
 			return col.shutdown(context.Background())


### PR DESCRIPTION
**Description:** <Describe what has changed. 
Resolves #5242

Reduced the logging level when the collector exits due to a context cancel. When the collector is exited with a canceled context it would print an error with a stack trace. This lead to confusing logs when the collector correctly shut down due to a context that was closed by signal intercepts.

~~Kept the context error log if the error is `context.DeadlineExceeded` as it's much more likely if the collector exceeded some deadline the user should be notified of such.~~

**Link to tracking Issue:** #5242 

**Testing:** Tested locally with signal intercepts. Current unit tests are valid.
