### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/api-compatibility.yml
+++ b/.github/workflows/api-compatibility.yml
@@ -12,6 +12,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   Check-Compatibility:
     runs-on: macos-latest

--- a/.github/workflows/build-and-test-windows.yaml
+++ b/.github/workflows/build-and-test-windows.yaml
@@ -6,6 +6,9 @@ on:
       - 'v[0-9]+.[0-9]+.[0-9]+*'
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   windows-unittest:
     runs-on: windows-latest

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -6,6 +6,9 @@ on:
       - "v[0-9]+.[0-9]+.[0-9]+*"
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   setup-environment:
     runs-on: ubuntu-latest

--- a/.github/workflows/builder-integration-test.yaml
+++ b/.github/workflows/builder-integration-test.yaml
@@ -20,6 +20,9 @@ on:
   # manual execution
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   integration-test:
     name: Integration test

--- a/.github/workflows/builder-release.yaml
+++ b/.github/workflows/builder-release.yaml
@@ -5,8 +5,13 @@ on:
     tags:
       - 'cmd/builder/v*'
 
+permissions:
+  contents: read
+
 jobs:
   goreleaser:
+    permissions:
+      contents: write  # for goreleaser/goreleaser-action to create a GitHub release
     runs-on: ubuntu-20.04
     steps:
       -

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -9,6 +9,9 @@ on:
     types: [opened, synchronize, reopened, labeled, unlabeled]
     branches:
       - main
+permissions:
+  contents: read
+
 jobs:
   changelog:
     runs-on: ubuntu-latest

--- a/.github/workflows/check-links.yaml
+++ b/.github/workflows/check-links.yaml
@@ -8,6 +8,9 @@ on:
     paths-ignore:
       - 'cmd/builder/**'
 
+permissions:
+  contents: read
+
 jobs:
   changedfiles:
     name: changed files

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -4,8 +4,15 @@ on:
     branches: [ main ]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   CodeQL-Build:
+    permissions:
+      actions: read  # for github/codeql-action/init to get workflow details
+      contents: read  # for actions/checkout to fetch code
+      security-events: write  # for github/codeql-action/autobuild to send a status report
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/contrib-tests.yml
+++ b/.github/workflows/contrib-tests.yml
@@ -6,6 +6,9 @@ on:
       - v[0-9]+.[0-9]+.[0-9]+.*
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   contrib_tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/stale-pr.yaml
+++ b/.github/workflows/stale-pr.yaml
@@ -3,8 +3,14 @@ on:
   schedule:
     - cron: "12 3 * * *" # arbitrary time not to DDOS GitHub
 
+permissions:
+  contents: read
+
 jobs:
   stale:
+    permissions:
+      issues: write  # for actions/stale to close stale issues
+      pull-requests: write  # for actions/stale to close stale PRs
     runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@v5


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
