### PR TITLE
[bugfix] temporary fix around grpclogger

### DIFF
--- a/service/collector.go
+++ b/service/collector.go
@@ -202,18 +202,11 @@ func (col *Collector) setupConfigurationComponents(ctx context.Context) error {
 		return fmt.Errorf("failed to get config: %w", err)
 	}
 
-	// TODO: hacky workaround to unblock v0.50.0
-	configureGRPCLogging := false
-	if col.logger == nil {
-		configureGRPCLogging = true
-	}
 	if col.logger, err = telemetrylogs.NewLogger(cfg.Service.Telemetry.Logs, col.set.LoggingOptions); err != nil {
 		return fmt.Errorf("failed to get logger: %w", err)
 	}
 
-	// setting the grpc logger multiple times causes
-	// a race condition
-	if configureGRPCLogging {
+	if !col.set.SkipSettingGRPCLogger {
 		telemetrylogs.SetColGRPCLogger(col.logger, cfg.Service.Telemetry.Logs.Level)
 	}
 

--- a/service/settings.go
+++ b/service/settings.go
@@ -64,6 +64,9 @@ type CollectorSettings struct {
 	// LoggingOptions provides a way to change behavior of zap logging.
 	LoggingOptions []zap.Option
 
+	// SkipSettingGRPCLogger avoids setting the grpc logger
+	SkipSettingGRPCLogger bool
+
 	// For testing purpose only.
 	telemetry collectorTelemetryExporter
 }


### PR DESCRIPTION
Calling SetLoggerV2 isn't thread safe and should only be called `before any grpc functions`. See more details: https://pkg.go.dev/github.com/grpc-ecosystem/go-grpc-middleware@v1.3.0/logging/settable#pkg-overview

This hacky workaround checks if the collector's logger has been set, if so, don't bother updating the grpc logger. Looking for alternative implementations here.