### PR TITLE
cleanup exporterhelper readme

### DIFF
--- a/exporter/exporterhelper/README.md
+++ b/exporter/exporterhelper/README.md
@@ -21,11 +21,7 @@ The following configuration options can be modified:
   User should calculate this as `num_seconds * requests_per_second` where:
     - `num_seconds` is the number of seconds to buffer in case of a backend outage
     - `requests_per_second` is the average number of requests per seconds.
-- `resource_to_telemetry_conversion`
-  - `enabled` (default = false): If `enabled` is `true`, all the resource attributes will be converted to metric labels by default.
 - `timeout` (default = 5s): Time to wait per individual attempt to send data to a backend.
-
-The full list of settings exposed for this helper exporter are documented [here](factory.go).
 
 ### Persistent Queue
 


### PR DESCRIPTION
The `resource_to_telemetry_conversion` setting was listed in the readme, but it doesn't correspond to a setting for this exporter. It looks like individual exporters in the contrib repo have it.

The readme also had a dangling link for more settings. I've removed the link altogether since, as far as I can tell, there are no longer any settings not listed in the readme. Please kindly verify that this is true.