### PR TITLE
[service] nit: move all telemetry fields into TelemetrySettings.

### DIFF
--- a/service/collector.go
+++ b/service/collector.go
@@ -26,7 +26,6 @@ import (
 	"syscall"
 
 	"go.opentelemetry.io/contrib/zpages"
-	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/metric/nonrecording"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/trace"
@@ -77,11 +76,8 @@ func (s State) String() string {
 
 // Collector represents a server providing the OpenTelemetry Collector service.
 type Collector struct {
-	set    CollectorSettings
-	logger *zap.Logger
-
-	tracerProvider      trace.TracerProvider
-	meterProvider       metric.MeterProvider
+	set                 CollectorSettings
+	telemetry           component.TelemetrySettings
 	zPagesSpanProcessor *zpages.SpanProcessor
 
 	service *service
@@ -108,10 +104,11 @@ func New(set CollectorSettings) (*Collector, error) {
 	}
 
 	return &Collector{
-		logger: zap.NewNop(), // Set a Nop logger as a place holder until a logger is created based on configuration
-
-		tracerProvider:    trace.NewNoopTracerProvider(),
-		meterProvider:     nonrecording.NewNoopMeterProvider(),
+		telemetry: component.TelemetrySettings{
+			Logger:         zap.NewNop(), // Set a Nop logger as a place holder until a logger is created based on configuration
+			TracerProvider: trace.NewNoopTracerProvider(),
+			MeterProvider:  nonrecording.NewNoopMeterProvider(),
+		},
 		asyncErrorChannel: make(chan error),
 
 		set:          set,
@@ -129,7 +126,7 @@ func (col *Collector) GetState() State {
 // GetLogger returns logger used by the Collector.
 // The logger is initialized after collector server start.
 func (col *Collector) GetLogger() *zap.Logger {
-	return col.logger
+	return col.telemetry.Logger
 }
 
 // Shutdown shuts down the collector server.
@@ -146,7 +143,7 @@ func (col *Collector) Shutdown() {
 
 // runAndWaitForShutdownEvent waits for one of the shutdown events that can happen.
 func (col *Collector) runAndWaitForShutdownEvent(ctx context.Context) error {
-	col.logger.Info("Everything is ready. Begin running and processing data.")
+	col.telemetry.Logger.Info("Everything is ready. Begin running and processing data.")
 
 	col.signalsChannel = make(chan os.Signal, 1)
 	// Only notify with SIGTERM and SIGINT if graceful shutdown is enabled.
@@ -160,11 +157,11 @@ LOOP:
 		select {
 		case err := <-col.set.ConfigProvider.Watch():
 			if err != nil {
-				col.logger.Error("Config watch failed", zap.Error(err))
+				col.telemetry.Logger.Error("Config watch failed", zap.Error(err))
 				break LOOP
 			}
 
-			col.logger.Warn("Config updated, restart service")
+			col.telemetry.Logger.Warn("Config updated, restart service")
 			col.setCollectorState(Closing)
 
 			if err = col.service.Shutdown(ctx); err != nil {
@@ -174,16 +171,16 @@ LOOP:
 				return fmt.Errorf("failed to setup configuration components: %w", err)
 			}
 		case err := <-col.asyncErrorChannel:
-			col.logger.Error("Asynchronous error received, terminating process", zap.Error(err))
+			col.telemetry.Logger.Error("Asynchronous error received, terminating process", zap.Error(err))
 			break LOOP
 		case s := <-col.signalsChannel:
-			col.logger.Info("Received signal from OS", zap.String("signal", s.String()))
+			col.telemetry.Logger.Info("Received signal from OS", zap.String("signal", s.String()))
 			break LOOP
 		case <-col.shutdownChan:
-			col.logger.Info("Received shutdown request")
+			col.telemetry.Logger.Info("Received shutdown request")
 			break LOOP
 		case <-ctx.Done():
-			col.logger.Info("Context done, terminating process", zap.Error(ctx.Err()))
+			col.telemetry.Logger.Info("Context done, terminating process", zap.Error(ctx.Err()))
 
 			// Call shutdown with background context as the passed in context has been canceled
 			return col.shutdown(context.Background())
@@ -202,24 +199,21 @@ func (col *Collector) setupConfigurationComponents(ctx context.Context) error {
 		return fmt.Errorf("failed to get config: %w", err)
 	}
 
-	if col.logger, err = telemetrylogs.NewLogger(cfg.Service.Telemetry.Logs, col.set.LoggingOptions); err != nil {
+	col.telemetry.MetricsLevel = cfg.Telemetry.Metrics.Level
+
+	if col.telemetry.Logger, err = telemetrylogs.NewLogger(cfg.Service.Telemetry.Logs, col.set.LoggingOptions); err != nil {
 		return fmt.Errorf("failed to get logger: %w", err)
 	}
 
 	if !col.set.SkipSettingGRPCLogger {
-		telemetrylogs.SetColGRPCLogger(col.logger, cfg.Service.Telemetry.Logs.Level)
+		telemetrylogs.SetColGRPCLogger(col.telemetry.Logger, cfg.Service.Telemetry.Logs.Level)
 	}
 
 	col.service, err = newService(&svcSettings{
-		BuildInfo: col.set.BuildInfo,
-		Factories: col.set.Factories,
-		Config:    cfg,
-		Telemetry: component.TelemetrySettings{
-			Logger:         col.logger,
-			TracerProvider: col.tracerProvider,
-			MeterProvider:  col.meterProvider,
-			MetricsLevel:   cfg.Telemetry.Metrics.Level,
-		},
+		BuildInfo:           col.set.BuildInfo,
+		Factories:           col.set.Factories,
+		Config:              cfg,
+		Telemetry:           col.telemetry,
 		ZPagesSpanProcessor: col.zPagesSpanProcessor,
 		AsyncErrorChannel:   col.asyncErrorChannel,
 	})
@@ -245,7 +239,7 @@ func (col *Collector) setupConfigurationComponents(ctx context.Context) error {
 // Consecutive calls to Run are not allowed, Run shouldn't be called once a collector is shut down.
 func (col *Collector) Run(ctx context.Context) error {
 	col.zPagesSpanProcessor = zpages.NewSpanProcessor()
-	col.tracerProvider = sdktrace.NewTracerProvider(
+	col.telemetry.TracerProvider = sdktrace.NewTracerProvider(
 		sdktrace.WithSampler(internal.AlwaysRecord()),
 		sdktrace.WithSpanProcessor(col.zPagesSpanProcessor))
 
@@ -254,7 +248,7 @@ func (col *Collector) Run(ctx context.Context) error {
 		return err
 	}
 
-	col.logger.Info("Starting "+col.set.BuildInfo.Command+"...",
+	col.telemetry.Logger.Info("Starting "+col.set.BuildInfo.Command+"...",
 		zap.String("Version", col.set.BuildInfo.Version),
 		zap.Int("NumCPU", runtime.NumCPU()),
 	)
@@ -270,7 +264,7 @@ func (col *Collector) shutdown(ctx context.Context) error {
 	var errs error
 
 	// Begin shutdown sequence.
-	col.logger.Info("Starting shutdown...")
+	col.telemetry.Logger.Info("Starting shutdown...")
 
 	if err := col.set.ConfigProvider.Shutdown(ctx); err != nil {
 		errs = multierr.Append(errs, fmt.Errorf("failed to shutdown config provider: %w", err))
@@ -284,7 +278,7 @@ func (col *Collector) shutdown(ctx context.Context) error {
 		errs = multierr.Append(errs, fmt.Errorf("failed to shutdown collector telemetry: %w", err))
 	}
 
-	col.logger.Info("Shutdown complete.")
+	col.telemetry.Logger.Info("Shutdown complete.")
 	col.setCollectorState(Closed)
 
 	return errs

--- a/service/collector_test.go
+++ b/service/collector_test.go
@@ -217,7 +217,7 @@ func testCollectorStartHelper(t *testing.T, telemetry collectorTelemetryExporter
 	assert.Eventually(t, func() bool {
 		return Running == col.GetState()
 	}, 2*time.Second, 200*time.Millisecond)
-	assert.Equal(t, col.logger, col.GetLogger())
+	assert.Equal(t, col.telemetry.Logger, col.GetLogger())
 	assert.True(t, loggingHookCalled)
 
 	// All labels added to all collector metrics by default are listed below.

--- a/service/telemetry.go
+++ b/service/telemetry.go
@@ -91,7 +91,7 @@ func (tel *colTelemetry) init(col *Collector) error {
 }
 
 func (tel *colTelemetry) initOnce(col *Collector) error {
-	logger := col.logger
+	logger := col.telemetry.Logger
 	cfg := col.service.config.Telemetry
 
 	level := cfg.Metrics.Level
@@ -210,7 +210,7 @@ func (tel *colTelemetry) initOpenTelemetry(col *Collector) (http.Handler, error)
 		return nil, err
 	}
 
-	col.meterProvider = pe.MeterProvider()
+	col.telemetry.MeterProvider = pe.MeterProvider()
 	return pe, err
 }
 


### PR DESCRIPTION
**Description:** 

Just a small nit to make `Collector` and `service` more consistent by moving every telemetry-related struct into a `component.TelemetrySettings`.

The only thing I don't like is that the field name conflicts with the one from #5160, better name ideas are accepted :)
