### PR TITLE
Change config.Retrieved to be an interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Remove deprecated pdata funcs/structs from v0.50.0 (#5345)
 - Remove derecated featuregate funcs/structs from v0.50.0 (#5346)
 - Remove access to deprecated members of the config.Retrieved struct (#5363)
+- Change config.Retrieved to be an interface (#5305)
 
 ### 🚩 Deprecations 🚩
 

--- a/config/mapprovider/envmapprovider/mapprovider.go
+++ b/config/mapprovider/envmapprovider/mapprovider.go
@@ -39,13 +39,13 @@ func New() config.MapProvider {
 
 func (emp *mapProvider) Retrieve(_ context.Context, uri string, _ config.WatcherFunc) (config.Retrieved, error) {
 	if !strings.HasPrefix(uri, schemeName+":") {
-		return config.Retrieved{}, fmt.Errorf("%v uri is not supported by %v provider", uri, schemeName)
+		return nil, fmt.Errorf("%v uri is not supported by %v provider", uri, schemeName)
 	}
 
 	content := os.Getenv(uri[len(schemeName)+1:])
 	var data map[string]interface{}
 	if err := yaml.Unmarshal([]byte(content), &data); err != nil {
-		return config.Retrieved{}, fmt.Errorf("unable to parse yaml: %w", err)
+		return nil, fmt.Errorf("unable to parse yaml: %w", err)
 	}
 
 	return config.NewRetrievedFromMap(config.NewMapFromStringMap(data)), nil

--- a/config/mapprovider/filemapprovider/mapprovider.go
+++ b/config/mapprovider/filemapprovider/mapprovider.go
@@ -49,18 +49,18 @@ func New() config.MapProvider {
 
 func (fmp *mapProvider) Retrieve(_ context.Context, uri string, _ config.WatcherFunc) (config.Retrieved, error) {
 	if !strings.HasPrefix(uri, schemeName+":") {
-		return config.Retrieved{}, fmt.Errorf("%v uri is not supported by %v provider", uri, schemeName)
+		return nil, fmt.Errorf("%v uri is not supported by %v provider", uri, schemeName)
 	}
 
 	// Clean the path before using it.
 	content, err := ioutil.ReadFile(filepath.Clean(uri[len(schemeName)+1:]))
 	if err != nil {
-		return config.Retrieved{}, fmt.Errorf("unable to read the file %v: %w", uri, err)
+		return nil, fmt.Errorf("unable to read the file %v: %w", uri, err)
 	}
 
 	var data map[string]interface{}
 	if err = yaml.Unmarshal(content, &data); err != nil {
-		return config.Retrieved{}, fmt.Errorf("unable to parse yaml: %w", err)
+		return nil, fmt.Errorf("unable to parse yaml: %w", err)
 	}
 
 	return config.NewRetrievedFromMap(config.NewMapFromStringMap(data)), nil

--- a/config/mapprovider/yamlmapprovider/mapprovider.go
+++ b/config/mapprovider/yamlmapprovider/mapprovider.go
@@ -42,12 +42,12 @@ func New() config.MapProvider {
 
 func (s *mapProvider) Retrieve(_ context.Context, uri string, _ config.WatcherFunc) (config.Retrieved, error) {
 	if !strings.HasPrefix(uri, schemeName+":") {
-		return config.Retrieved{}, fmt.Errorf("%v uri is not supported by %v provider", uri, schemeName)
+		return nil, fmt.Errorf("%v uri is not supported by %v provider", uri, schemeName)
 	}
 
 	var data map[string]interface{}
 	if err := yaml.Unmarshal([]byte(uri[len(schemeName)+1:]), &data); err != nil {
-		return config.Retrieved{}, fmt.Errorf("unable to parse yaml: %w", err)
+		return nil, fmt.Errorf("unable to parse yaml: %w", err)
 	}
 
 	return config.NewRetrievedFromMap(config.NewMapFromStringMap(data)), nil

--- a/config/mapprovider_test.go
+++ b/config/mapprovider_test.go
@@ -24,20 +24,20 @@ import (
 )
 
 func TestNewRetrievedFromMap(t *testing.T) {
-	cfgMap := NewMap()
+	cfgMap := NewMapFromStringMap(map[string]interface{}{"test": "value"})
 	ret := NewRetrievedFromMap(cfgMap)
 	retMap, err := ret.AsMap()
 	require.NoError(t, err)
-	assert.Same(t, cfgMap, retMap)
+	assert.Equal(t, cfgMap, retMap)
 	assert.NoError(t, ret.Close(context.Background()))
 }
 
 func TestNewRetrievedFromMapWithOptions(t *testing.T) {
 	want := errors.New("my error")
-	cfgMap := NewMap()
+	cfgMap := NewMapFromStringMap(map[string]interface{}{"test": "value"})
 	ret := NewRetrievedFromMap(cfgMap, WithRetrievedClose(func(context.Context) error { return want }))
 	retMap, err := ret.AsMap()
 	require.NoError(t, err)
-	assert.Same(t, cfgMap, retMap)
+	assert.Equal(t, cfgMap, retMap)
 	assert.Equal(t, want, ret.Close(context.Background()))
 }

--- a/service/mapresolver_test.go
+++ b/service/mapresolver_test.go
@@ -41,7 +41,7 @@ type mockProvider struct {
 
 func (m *mockProvider) Retrieve(_ context.Context, _ string, watcher config.WatcherFunc) (config.Retrieved, error) {
 	if m.errR != nil {
-		return config.Retrieved{}, m.errR
+		return nil, m.errR
 	}
 	if m.retM == nil {
 		return config.NewRetrievedFromMap(config.NewMap()), nil


### PR DESCRIPTION
This change will allow to implement support for "retrieving" any type of values, since we can offer implementations of the retrieved for string/etc.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
