### PR TITLE
Update CONTRIBUTING.md to reference the correct CI platform

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -181,10 +181,9 @@ $ git push fork feature
 
 ## General Notes
 
-This project uses Go 1.17.* and CircleCI.
+This project uses Go 1.17.* and [Github Actions.](https://github.com/features/actions)
 
-CircleCI uses the Makefile with the `ci` target, it is recommended to
-run it before submitting your PR. It runs `gofmt -s` (simplify) and `golint`.
+It is recommended to run `make gofmt all` before submitting your PR
 
 The dependencies are managed with `go mod` if you work with the sources under your
 `$GOPATH` you need to set the environment variable `GO111MODULE=on`.


### PR DESCRIPTION
Signed-off-by: Kevin Earls <kearls@redhat.com>

**Description:** <Describe what has changed. 
This PR fixes #5314 by correcting CONTRIBUTING.md to use the correct CI platform and build targets.

**Link to tracking Issue:** #5314 

