### PR TITLE
Fix windows go cache path, per GA examples

### DIFF
--- a/.github/workflows/build-and-test-windows.yaml
+++ b/.github/workflows/build-and-test-windows.yaml
@@ -27,8 +27,8 @@ jobs:
           cache-name: cache-go-modules
         with:
           path: |
-            \Users\runneradmin\go\pkg\mod
-            %LocalAppData%\go-build
-          key: go-pkg-mod-${{ runner.os }}-${{ hashFiles('./go.mod', '**/go.sum') }}
+            ~\go\pkg\mod
+            ~\AppData\Local\go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
       - name: Run Unit tests
         run: go test ./...


### PR DESCRIPTION
See https://github.com/actions/cache/blob/main/examples.md#go---modules

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
