### PR TITLE
configtelemetry: remove unnecessary private func, add unittests for public funcs

### DIFF
--- a/config/configtelemetry/configtelemetry.go
+++ b/config/configtelemetry/configtelemetry.go
@@ -56,30 +56,26 @@ func (l Level) String() string {
 	return "unknown"
 }
 
-// UnmarshalText unmarshals text to a Level.
+// UnmarshalText unmarshalls text to a Level.
 func (l *Level) UnmarshalText(text []byte) error {
 	if l == nil {
 		return fmt.Errorf("cannot unmarshal to a nil *Level")
 	}
-	var err error
-	*l, err = parseLevel(string(text))
-	return err
-}
 
-// parseLevel returns the Level represented by the string. The parsing is case-insensitive
-// and it returns error if the string value is unknown.
-func parseLevel(str string) (Level, error) {
-	str = strings.ToLower(str)
-
+	str := strings.ToLower(string(text))
 	switch str {
 	case levelNoneStr:
-		return LevelNone, nil
+		*l = LevelNone
+		return nil
 	case levelBasicStr:
-		return LevelBasic, nil
+		*l = LevelBasic
+		return nil
 	case levelNormalStr:
-		return LevelNormal, nil
+		*l = LevelNormal
+		return nil
 	case levelDetailedStr:
-		return LevelDetailed, nil
+		*l = LevelDetailed
+		return nil
 	}
-	return LevelNone, fmt.Errorf("unknown metrics level %q", str)
+	return fmt.Errorf("unknown metrics level %q", str)
 }

--- a/config/configtelemetry/configtelemetry_test.go
+++ b/config/configtelemetry/configtelemetry_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestParseFrom(t *testing.T) {
+func TestUnmarshalText(t *testing.T) {
 	tests := []struct {
 		str   string
 		level Level
@@ -56,15 +56,21 @@ func TestParseFrom(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.str, func(t *testing.T) {
-			lvl, err := parseLevel(test.str)
+			var lvl Level
+			err := lvl.UnmarshalText([]byte(test.str))
 			if test.err {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
+				assert.Equal(t, test.level, lvl)
 			}
-			assert.Equal(t, test.level, lvl)
 		})
 	}
+}
+
+func TestUnmarshalTextNilLevel(t *testing.T) {
+	lvl := (*Level)(nil)
+	assert.Error(t, lvl.UnmarshalText([]byte(levelNormalStr)))
 }
 
 func TestLevelString(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
