### PR TITLE
Enable errorlint and fix all warnings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -110,6 +110,7 @@ linters:
   enable:
     - depguard
     - errcheck
+    - errorlint
     - exportloopref
     - gocritic
     - gofmt

--- a/cmd/builder/internal/builder/config.go
+++ b/cmd/builder/internal/builder/config.go
@@ -147,7 +147,7 @@ func parseModules(mods []Module) ([]Module, error) {
 		if strings.HasPrefix(mod.Path, "./") {
 			path, err := os.Getwd()
 			if err != nil {
-				return mods, fmt.Errorf("module has a relative Path element, but we couldn't get the current working dir: %v", err)
+				return mods, fmt.Errorf("module has a relative Path element, but we couldn't get the current working dir: %w", err)
 			}
 
 			mod.Path = fmt.Sprintf("%s/%s", path, mod.Path[2:])

--- a/component/componenttest/shutdown_verifier.go
+++ b/component/componenttest/shutdown_verifier.go
@@ -16,6 +16,7 @@ package componenttest // import "go.opentelemetry.io/collector/component/compone
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -38,7 +39,7 @@ func verifyTracesProcessorDoesntProduceAfterShutdown(t *testing.T, factory compo
 		nextSink,
 	)
 	if err != nil {
-		if err == componenterror.ErrDataTypeIsNotSupported {
+		if errors.Is(err, componenterror.ErrDataTypeIsNotSupported) {
 			return
 		}
 		require.NoError(t, err)

--- a/config/configgrpc/configgrpc.go
+++ b/config/configgrpc/configgrpc.go
@@ -221,7 +221,7 @@ func (gcs *GRPCClientSettings) ToDialOptions(host component.Host, settings compo
 
 	if gcs.Auth != nil {
 		if host.GetExtensions() == nil {
-			return nil, fmt.Errorf("no extensions configuration available")
+			return nil, errors.New("no extensions configuration available")
 		}
 
 		grpcAuthenticator, cerr := gcs.Auth.GetClientAuthenticator(host.GetExtensions())

--- a/config/configgrpc/configgrpc_test.go
+++ b/config/configgrpc/configgrpc_test.go
@@ -16,7 +16,7 @@ package configgrpc
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"io/ioutil"
 	"net"
 	"os"
@@ -895,7 +895,7 @@ func TestDefaultUnaryInterceptorAuthSucceeded(t *testing.T) {
 func TestDefaultUnaryInterceptorAuthFailure(t *testing.T) {
 	// prepare
 	authCalled := false
-	expectedErr := fmt.Errorf("not authenticated")
+	expectedErr := errors.New("not authenticated")
 	authFunc := func(context.Context, map[string][]string) (context.Context, error) {
 		authCalled = true
 		return context.Background(), expectedErr
@@ -969,7 +969,7 @@ func TestDefaultStreamInterceptorAuthSucceeded(t *testing.T) {
 func TestDefaultStreamInterceptorAuthFailure(t *testing.T) {
 	// prepare
 	authCalled := false
-	expectedErr := fmt.Errorf("not authenticated")
+	expectedErr := errors.New("not authenticated")
 	authFunc := func(context.Context, map[string][]string) (context.Context, error) {
 		authCalled = true
 		return context.Background(), expectedErr

--- a/config/confighttp/confighttp.go
+++ b/config/confighttp/confighttp.go
@@ -16,7 +16,7 @@ package confighttp // import "go.opentelemetry.io/collector/config/confighttp"
 
 import (
 	"crypto/tls"
-	"fmt"
+	"errors"
 	"net"
 	"net/http"
 	"time"
@@ -156,7 +156,7 @@ func (hcs *HTTPClientSettings) ToClient(ext map[config.ComponentID]component.Ext
 
 	if hcs.Auth != nil {
 		if ext == nil {
-			return nil, fmt.Errorf("extensions configuration not found")
+			return nil, errors.New("extensions configuration not found")
 		}
 
 		httpCustomAuthRoundTripper, aerr := hcs.Auth.GetClientAuthenticator(ext)

--- a/config/confighttp/confighttp_test.go
+++ b/config/confighttp/confighttp_test.go
@@ -681,7 +681,7 @@ func TestHttpCorsWithAuthentication(t *testing.T) {
 		ext: map[config.ComponentID]component.Extension{
 			config.NewComponentID("mock"): configauth.NewServerAuthenticator(
 				configauth.WithAuthenticate(func(ctx context.Context, headers map[string][]string) (context.Context, error) {
-					return ctx, fmt.Errorf("authentication failed")
+					return ctx, errors.New("authentication failed")
 				}),
 			),
 		},
@@ -921,7 +921,7 @@ func TestFailedServerAuth(t *testing.T) {
 		ext: map[config.ComponentID]component.Extension{
 			config.NewComponentID("mock"): configauth.NewServerAuthenticator(
 				configauth.WithAuthenticate(func(ctx context.Context, headers map[string][]string) (context.Context, error) {
-					return ctx, fmt.Errorf("authentication failed")
+					return ctx, errors.New("authentication failed")
 				}),
 			),
 		},

--- a/config/configtelemetry/configtelemetry.go
+++ b/config/configtelemetry/configtelemetry.go
@@ -16,6 +16,7 @@ package configtelemetry // import "go.opentelemetry.io/collector/config/configte
 
 import (
 	"encoding"
+	"errors"
 	"fmt"
 	"strings"
 )
@@ -59,7 +60,7 @@ func (l Level) String() string {
 // UnmarshalText unmarshalls text to a Level.
 func (l *Level) UnmarshalText(text []byte) error {
 	if l == nil {
-		return fmt.Errorf("cannot unmarshal to a nil *Level")
+		return errors.New("cannot unmarshal to a nil *Level")
 	}
 
 	str := strings.ToLower(string(text))

--- a/config/configtls/configtls.go
+++ b/config/configtls/configtls.go
@@ -17,6 +17,7 @@ package configtls // import "go.opentelemetry.io/collector/config/configtls"
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
@@ -160,7 +161,7 @@ func (c TLSSetting) loadTLSConfig() (*tls.Config, error) {
 	}
 
 	if (c.CertFile == "" && c.KeyFile != "") || (c.CertFile != "" && c.KeyFile == "") {
-		return nil, fmt.Errorf("for auth via TLS, either both certificate and key must be supplied, or neither")
+		return nil, errors.New("for auth via TLS, either both certificate and key must be supplied, or neither")
 	}
 
 	var getCertificate func(*tls.ClientHelloInfo) (*tls.Certificate, error)

--- a/consumer/consumererror/signalerrors_test.go
+++ b/consumer/consumererror/signalerrors_test.go
@@ -16,7 +16,6 @@ package consumererror
 
 import (
 	"errors"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -27,7 +26,7 @@ import (
 
 func TestTraces(t *testing.T) {
 	td := testdata.GenerateTracesOneSpan()
-	err := fmt.Errorf("some error")
+	err := errors.New("some error")
 	traceErr := NewTraces(err, td)
 	assert.Equal(t, err.Error(), traceErr.Error())
 	var target Traces
@@ -51,7 +50,7 @@ func TestTraces_Unwrap(t *testing.T) {
 
 func TestLogs(t *testing.T) {
 	td := testdata.GenerateLogsOneLogRecord()
-	err := fmt.Errorf("some error")
+	err := errors.New("some error")
 	logsErr := NewLogs(err, td)
 	assert.Equal(t, err.Error(), logsErr.Error())
 	var target Logs
@@ -75,7 +74,7 @@ func TestLogs_Unwrap(t *testing.T) {
 
 func TestMetrics(t *testing.T) {
 	td := testdata.GenerateMetricsOneMetric()
-	err := fmt.Errorf("some error")
+	err := errors.New("some error")
 	metricErr := NewMetrics(err, td)
 	assert.Equal(t, err.Error(), metricErr.Error())
 	var target Metrics

--- a/exporter/exporterhelper/internal/persistent_storage.go
+++ b/exporter/exporterhelper/internal/persistent_storage.go
@@ -153,7 +153,7 @@ func initPersistentContiguousStorage(ctx context.Context, pcs *persistentContigu
 	}
 
 	if err != nil {
-		if err == errValueNotSet {
+		if errors.Is(err, errValueNotSet) {
 			pcs.logger.Info("Initializing new persistent queue", zap.String(zapQueueNameKey, pcs.queueName))
 		} else {
 			pcs.logger.Error("Failed getting read/write index, starting with new ones",

--- a/exporter/exporterhelper/queued_retry_experimental.go
+++ b/exporter/exporterhelper/queued_retry_experimental.go
@@ -69,7 +69,7 @@ func (qCfg *QueueSettings) Validate() error {
 	}
 
 	if qCfg.QueueSize <= 0 {
-		return fmt.Errorf("queue size must be positive")
+		return errors.New("queue size must be positive")
 	}
 
 	return nil
@@ -217,7 +217,7 @@ func (qrs *queuedRetrySender) start(ctx context.Context, host component.Host) er
 			return int64(qrs.queue.Size())
 		}, metricdata.NewLabelValue(qrs.fullName()))
 		if err != nil {
-			return fmt.Errorf("failed to create retry queue size metric: %v", err)
+			return fmt.Errorf("failed to create retry queue size metric: %w", err)
 		}
 	}
 

--- a/exporter/exporterhelper/queued_retry_inmemory.go
+++ b/exporter/exporterhelper/queued_retry_inmemory.go
@@ -19,6 +19,7 @@ package exporterhelper // import "go.opentelemetry.io/collector/exporter/exporte
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"go.opencensus.io/metric/metricdata"
@@ -64,7 +65,7 @@ func (qCfg *QueueSettings) Validate() error {
 	}
 
 	if qCfg.QueueSize <= 0 {
-		return fmt.Errorf("queue size must be positive")
+		return errors.New("queue size must be positive")
 	}
 
 	return nil
@@ -125,7 +126,7 @@ func (qrs *queuedRetrySender) start(context.Context, component.Host) error {
 			return int64(qrs.queue.Size())
 		}, metricdata.NewLabelValue(qrs.fullName))
 		if err != nil {
-			return fmt.Errorf("failed to create retry queue size metric: %v", err)
+			return fmt.Errorf("failed to create retry queue size metric: %w", err)
 		}
 	}
 

--- a/exporter/loggingexporter/known_sync_error.go
+++ b/exporter/loggingexporter/known_sync_error.go
@@ -18,6 +18,7 @@
 package loggingexporter // import "go.opentelemetry.io/collector/exporter/loggingexporter"
 
 import (
+	"errors"
 	"syscall"
 )
 
@@ -31,9 +32,5 @@ import (
 // - sync /dev/stdout: inappropriate ioctl for device
 //
 func knownSyncError(err error) bool {
-	switch err {
-	case syscall.EINVAL, syscall.ENOTSUP, syscall.ENOTTY:
-		return true
-	}
-	return false
+	return errors.Is(err, syscall.EINVAL) || errors.Is(err, syscall.ENOTSUP) || errors.Is(err, syscall.ENOTTY)
 }

--- a/exporter/loggingexporter/logging_exporter.go
+++ b/exporter/loggingexporter/logging_exporter.go
@@ -16,6 +16,7 @@ package loggingexporter // import "go.opentelemetry.io/collector/exporter/loggin
 
 import (
 	"context"
+	"errors"
 	"os"
 
 	"go.uber.org/zap"
@@ -147,7 +148,8 @@ func loggerSync(logger *zap.Logger) func(context.Context) error {
 		// Currently Sync() return a different error depending on the OS.
 		// Since these are not actionable ignore them.
 		err := logger.Sync()
-		if osErr, ok := err.(*os.PathError); ok {
+		osErr := &os.PathError{}
+		if errors.As(err, &osErr) {
 			wrappedErr := osErr.Unwrap()
 			if knownSyncError(wrappedErr) {
 				err = nil

--- a/exporter/otlphttpexporter/config.go
+++ b/exporter/otlphttpexporter/config.go
@@ -15,7 +15,7 @@
 package otlphttpexporter // import "go.opentelemetry.io/collector/exporter/otlphttpexporter"
 
 import (
-	"fmt"
+	"errors"
 
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/confighttp"
@@ -44,7 +44,7 @@ var _ config.Exporter = (*Config)(nil)
 // Validate checks if the exporter configuration is valid
 func (cfg *Config) Validate() error {
 	if cfg.Endpoint == "" && cfg.TracesEndpoint == "" && cfg.MetricsEndpoint == "" && cfg.LogsEndpoint == "" {
-		return fmt.Errorf("at least one endpoint must be specified")
+		return errors.New("at least one endpoint must be specified")
 	}
 	return nil
 }

--- a/exporter/otlphttpexporter/otlp_test.go
+++ b/exporter/otlphttpexporter/otlp_test.go
@@ -396,14 +396,14 @@ func TestErrorResponses(t *testing.T) {
 		{
 			name:           "404",
 			responseStatus: http.StatusNotFound,
-			err:            fmt.Errorf(errMsgPrefix + "404"),
+			err:            errors.New(errMsgPrefix + "404"),
 		},
 		{
 			name:           "419",
 			responseStatus: http.StatusTooManyRequests,
 			responseBody:   status.New(codes.InvalidArgument, "Quota exceeded"),
 			err: exporterhelper.NewThrottleRetry(
-				fmt.Errorf(errMsgPrefix+"429, Message=Quota exceeded, Details=[]"),
+				errors.New(errMsgPrefix+"429, Message=Quota exceeded, Details=[]"),
 				time.Duration(0)*time.Second),
 		},
 		{
@@ -411,7 +411,7 @@ func TestErrorResponses(t *testing.T) {
 			responseStatus: http.StatusServiceUnavailable,
 			responseBody:   status.New(codes.InvalidArgument, "Server overloaded"),
 			err: exporterhelper.NewThrottleRetry(
-				fmt.Errorf(errMsgPrefix+"503, Message=Server overloaded, Details=[]"),
+				errors.New(errMsgPrefix+"503, Message=Server overloaded, Details=[]"),
 				time.Duration(0)*time.Second),
 		},
 		{
@@ -420,7 +420,7 @@ func TestErrorResponses(t *testing.T) {
 			responseBody:   status.New(codes.InvalidArgument, "Server overloaded"),
 			headers:        map[string]string{"Retry-After": "30"},
 			err: exporterhelper.NewThrottleRetry(
-				fmt.Errorf(errMsgPrefix+"503, Message=Server overloaded, Details=[]"),
+				errors.New(errMsgPrefix+"503, Message=Server overloaded, Details=[]"),
 				time.Duration(30)*time.Second),
 		},
 	}

--- a/extension/ballastextension/config.go
+++ b/extension/ballastextension/config.go
@@ -15,7 +15,7 @@
 package ballastextension // import "go.opentelemetry.io/collector/extension/ballastextension"
 
 import (
-	"fmt"
+	"errors"
 
 	"go.opentelemetry.io/collector/config"
 )
@@ -37,7 +37,7 @@ type Config struct {
 func (cfg *Config) Validate() error {
 	// no need to validate less than 0 case for uint64
 	if cfg.SizeInPercentage > 100 {
-		return fmt.Errorf("size_in_percentage is not in range 0 to 100")
+		return errors.New("size_in_percentage is not in range 0 to 100")
 	}
 	return nil
 }

--- a/extension/zpagesextension/zpagesextension.go
+++ b/extension/zpagesextension/zpagesextension.go
@@ -16,6 +16,7 @@ package zpagesextension // import "go.opentelemetry.io/collector/extension/zpage
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"path"
 
@@ -88,8 +89,8 @@ func (zpe *zpagesExtension) Start(_ context.Context, host component.Host) error 
 	go func() {
 		defer close(zpe.stopCh)
 
-		if err := zpe.server.Serve(ln); err != nil && err != http.ErrServerClosed {
-			host.ReportFatalError(err)
+		if errHTTP := zpe.server.Serve(ln); errHTTP != nil && !errors.Is(errHTTP, http.ErrServerClosed) {
+			host.ReportFatalError(errHTTP)
 		}
 	}()
 

--- a/obsreport/obsreport_scraper.go
+++ b/obsreport/obsreport_scraper.go
@@ -16,6 +16,7 @@ package obsreport // import "go.opentelemetry.io/collector/obsreport"
 
 import (
 	"context"
+	"errors"
 
 	"go.opencensus.io/stats"
 	"go.opencensus.io/tag"
@@ -77,7 +78,8 @@ func (s *Scraper) EndMetricsOp(
 ) {
 	numErroredMetrics := 0
 	if err != nil {
-		if partialErr, isPartial := err.(scrapererror.PartialScrapeError); isPartial {
+		var partialErr scrapererror.PartialScrapeError
+		if errors.As(err, &partialErr) {
 			numErroredMetrics = partialErr.Failed
 		} else {
 			numErroredMetrics = numScrapedMetrics

--- a/obsreport/obsreport_test.go
+++ b/obsreport/obsreport_test.go
@@ -80,13 +80,13 @@ func TestReceiveTraceDataOp(t *testing.T) {
 	var acceptedSpans, refusedSpans int
 	for i, span := range spans {
 		assert.Equal(t, "receiver/"+receiver.String()+"/TraceDataReceived", span.Name())
-		switch params[i].err {
-		case nil:
+		switch {
+		case params[i].err == nil:
 			acceptedSpans += params[i].items
 			require.Contains(t, span.Attributes(), attribute.KeyValue{Key: obsmetrics.AcceptedSpansKey, Value: attribute.Int64Value(int64(params[i].items))})
 			require.Contains(t, span.Attributes(), attribute.KeyValue{Key: obsmetrics.RefusedSpansKey, Value: attribute.Int64Value(0)})
 			assert.Equal(t, codes.Unset, span.Status().Code)
-		case errFake:
+		case errors.Is(params[i].err, errFake):
 			refusedSpans += params[i].items
 			require.Contains(t, span.Attributes(), attribute.KeyValue{Key: obsmetrics.AcceptedSpansKey, Value: attribute.Int64Value(0)})
 			require.Contains(t, span.Attributes(), attribute.KeyValue{Key: obsmetrics.RefusedSpansKey, Value: attribute.Int64Value(int64(params[i].items))})
@@ -128,13 +128,13 @@ func TestReceiveLogsOp(t *testing.T) {
 	var acceptedLogRecords, refusedLogRecords int
 	for i, span := range spans {
 		assert.Equal(t, "receiver/"+receiver.String()+"/LogsReceived", span.Name())
-		switch params[i].err {
-		case nil:
+		switch {
+		case params[i].err == nil:
 			acceptedLogRecords += params[i].items
 			require.Contains(t, span.Attributes(), attribute.KeyValue{Key: obsmetrics.AcceptedLogRecordsKey, Value: attribute.Int64Value(int64(params[i].items))})
 			require.Contains(t, span.Attributes(), attribute.KeyValue{Key: obsmetrics.RefusedLogRecordsKey, Value: attribute.Int64Value(0)})
 			assert.Equal(t, codes.Unset, span.Status().Code)
-		case errFake:
+		case errors.Is(params[i].err, errFake):
 			refusedLogRecords += params[i].items
 			require.Contains(t, span.Attributes(), attribute.KeyValue{Key: obsmetrics.AcceptedLogRecordsKey, Value: attribute.Int64Value(0)})
 			require.Contains(t, span.Attributes(), attribute.KeyValue{Key: obsmetrics.RefusedLogRecordsKey, Value: attribute.Int64Value(int64(params[i].items))})
@@ -176,13 +176,13 @@ func TestReceiveMetricsOp(t *testing.T) {
 	var acceptedMetricPoints, refusedMetricPoints int
 	for i, span := range spans {
 		assert.Equal(t, "receiver/"+receiver.String()+"/MetricsReceived", span.Name())
-		switch params[i].err {
-		case nil:
+		switch {
+		case params[i].err == nil:
 			acceptedMetricPoints += params[i].items
 			require.Contains(t, span.Attributes(), attribute.KeyValue{Key: obsmetrics.AcceptedMetricPointsKey, Value: attribute.Int64Value(int64(params[i].items))})
 			require.Contains(t, span.Attributes(), attribute.KeyValue{Key: obsmetrics.RefusedMetricPointsKey, Value: attribute.Int64Value(0)})
 			assert.Equal(t, codes.Unset, span.Status().Code)
-		case errFake:
+		case errors.Is(params[i].err, errFake):
 			refusedMetricPoints += params[i].items
 			require.Contains(t, span.Attributes(), attribute.KeyValue{Key: obsmetrics.AcceptedMetricPointsKey, Value: attribute.Int64Value(0)})
 			require.Contains(t, span.Attributes(), attribute.KeyValue{Key: obsmetrics.RefusedMetricPointsKey, Value: attribute.Int64Value(int64(params[i].items))})
@@ -226,20 +226,20 @@ func TestScrapeMetricsDataOp(t *testing.T) {
 	var scrapedMetricPoints, erroredMetricPoints int
 	for i, span := range spans {
 		assert.Equal(t, "scraper/"+receiver.String()+"/"+scraper.String()+"/MetricsScraped", span.Name())
-		switch params[i].err {
-		case nil:
+		switch {
+		case params[i].err == nil:
 			scrapedMetricPoints += params[i].items
 			require.Contains(t, span.Attributes(), attribute.KeyValue{Key: obsmetrics.ScrapedMetricPointsKey, Value: attribute.Int64Value(int64(params[i].items))})
 			require.Contains(t, span.Attributes(), attribute.KeyValue{Key: obsmetrics.ErroredMetricPointsKey, Value: attribute.Int64Value(0)})
 			assert.Equal(t, codes.Unset, span.Status().Code)
-		case errFake:
+		case errors.Is(params[i].err, errFake):
 			erroredMetricPoints += params[i].items
 			require.Contains(t, span.Attributes(), attribute.KeyValue{Key: obsmetrics.ScrapedMetricPointsKey, Value: attribute.Int64Value(0)})
 			require.Contains(t, span.Attributes(), attribute.KeyValue{Key: obsmetrics.ErroredMetricPointsKey, Value: attribute.Int64Value(int64(params[i].items))})
 			assert.Equal(t, codes.Error, span.Status().Code)
 			assert.Equal(t, params[i].err.Error(), span.Status().Description)
 
-		case partialErrFake:
+		case errors.Is(params[i].err, partialErrFake):
 			scrapedMetricPoints += params[i].items
 			erroredMetricPoints++
 			require.Contains(t, span.Attributes(), attribute.KeyValue{Key: obsmetrics.ScrapedMetricPointsKey, Value: attribute.Int64Value(int64(params[i].items))})
@@ -284,13 +284,13 @@ func TestExportTraceDataOp(t *testing.T) {
 	var sentSpans, failedToSendSpans int
 	for i, span := range spans {
 		assert.Equal(t, "exporter/"+exporter.String()+"/traces", span.Name())
-		switch params[i].err {
-		case nil:
+		switch {
+		case params[i].err == nil:
 			sentSpans += params[i].items
 			require.Contains(t, span.Attributes(), attribute.KeyValue{Key: obsmetrics.SentSpansKey, Value: attribute.Int64Value(int64(params[i].items))})
 			require.Contains(t, span.Attributes(), attribute.KeyValue{Key: obsmetrics.FailedToSendSpansKey, Value: attribute.Int64Value(0)})
 			assert.Equal(t, codes.Unset, span.Status().Code)
-		case errFake:
+		case errors.Is(params[i].err, errFake):
 			failedToSendSpans += params[i].items
 			require.Contains(t, span.Attributes(), attribute.KeyValue{Key: obsmetrics.SentSpansKey, Value: attribute.Int64Value(0)})
 			require.Contains(t, span.Attributes(), attribute.KeyValue{Key: obsmetrics.FailedToSendSpansKey, Value: attribute.Int64Value(int64(params[i].items))})
@@ -335,13 +335,13 @@ func TestExportMetricsOp(t *testing.T) {
 	var sentMetricPoints, failedToSendMetricPoints int
 	for i, span := range spans {
 		assert.Equal(t, "exporter/"+exporter.String()+"/metrics", span.Name())
-		switch params[i].err {
-		case nil:
+		switch {
+		case params[i].err == nil:
 			sentMetricPoints += params[i].items
 			require.Contains(t, span.Attributes(), attribute.KeyValue{Key: obsmetrics.SentMetricPointsKey, Value: attribute.Int64Value(int64(params[i].items))})
 			require.Contains(t, span.Attributes(), attribute.KeyValue{Key: obsmetrics.FailedToSendMetricPointsKey, Value: attribute.Int64Value(0)})
 			assert.Equal(t, codes.Unset, span.Status().Code)
-		case errFake:
+		case errors.Is(params[i].err, errFake):
 			failedToSendMetricPoints += params[i].items
 			require.Contains(t, span.Attributes(), attribute.KeyValue{Key: obsmetrics.SentMetricPointsKey, Value: attribute.Int64Value(0)})
 			require.Contains(t, span.Attributes(), attribute.KeyValue{Key: obsmetrics.FailedToSendMetricPointsKey, Value: attribute.Int64Value(int64(params[i].items))})
@@ -386,13 +386,13 @@ func TestExportLogsOp(t *testing.T) {
 	var sentLogRecords, failedToSendLogRecords int
 	for i, span := range spans {
 		assert.Equal(t, "exporter/"+exporter.String()+"/logs", span.Name())
-		switch params[i].err {
-		case nil:
+		switch {
+		case params[i].err == nil:
 			sentLogRecords += params[i].items
 			require.Contains(t, span.Attributes(), attribute.KeyValue{Key: obsmetrics.SentLogRecordsKey, Value: attribute.Int64Value(int64(params[i].items))})
 			require.Contains(t, span.Attributes(), attribute.KeyValue{Key: obsmetrics.FailedToSendLogRecordsKey, Value: attribute.Int64Value(0)})
 			assert.Equal(t, codes.Unset, span.Status().Code)
-		case errFake:
+		case errors.Is(params[i].err, errFake):
 			failedToSendLogRecords += params[i].items
 			require.Contains(t, span.Attributes(), attribute.KeyValue{Key: obsmetrics.SentLogRecordsKey, Value: attribute.Int64Value(0)})
 			require.Contains(t, span.Attributes(), attribute.KeyValue{Key: obsmetrics.FailedToSendLogRecordsKey, Value: attribute.Int64Value(int64(params[i].items))})
@@ -443,12 +443,12 @@ func TestReceiveWithLongLivedCtx(t *testing.T) {
 		assert.Equal(t, parentSpan.SpanContext().SpanID(), link.SpanContext.SpanID())
 		assert.Equal(t, "receiver/"+receiver.String()+"/TraceDataReceived", span.Name())
 		require.Contains(t, span.Attributes(), attribute.KeyValue{Key: obsmetrics.TransportKey, Value: attribute.StringValue(transport)})
-		switch params[i].err {
-		case nil:
+		switch {
+		case params[i].err == nil:
 			require.Contains(t, span.Attributes(), attribute.KeyValue{Key: obsmetrics.AcceptedSpansKey, Value: attribute.Int64Value(int64(params[i].items))})
 			require.Contains(t, span.Attributes(), attribute.KeyValue{Key: obsmetrics.RefusedSpansKey, Value: attribute.Int64Value(0)})
 			assert.Equal(t, codes.Unset, span.Status().Code)
-		case errFake:
+		case errors.Is(params[i].err, errFake):
 			require.Contains(t, span.Attributes(), attribute.KeyValue{Key: obsmetrics.AcceptedSpansKey, Value: attribute.Int64Value(0)})
 			require.Contains(t, span.Attributes(), attribute.KeyValue{Key: obsmetrics.RefusedSpansKey, Value: attribute.Int64Value(int64(params[i].items))})
 			assert.Equal(t, codes.Error, span.Status().Code)

--- a/processor/memorylimiterprocessor/factory_test.go
+++ b/processor/memorylimiterprocessor/factory_test.go
@@ -16,7 +16,6 @@ package memorylimiterprocessor
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -62,12 +61,11 @@ func TestCreateProcessor(t *testing.T) {
 	pCfg.MemorySpikeLimitMiB = 1907
 	pCfg.CheckInterval = 100 * time.Millisecond
 
-	errorCheck := fmt.Errorf("no existing monitoring routine is running")
 	tp, err = factory.CreateTracesProcessor(context.Background(), componenttest.NewNopProcessorCreateSettings(), cfg, consumertest.NewNop())
 	assert.NoError(t, err)
 	assert.NotNil(t, tp)
 	// test if we can shutdown a monitoring routine that has not started
-	assert.Error(t, errorCheck, tp.Shutdown(context.Background()))
+	assert.ErrorIs(t, tp.Shutdown(context.Background()), errShutdownNotStarted)
 	assert.NoError(t, tp.Start(context.Background(), componenttest.NewNopHost()))
 
 	mp, err = factory.CreateMetricsProcessor(context.Background(), componenttest.NewNopProcessorCreateSettings(), cfg, consumertest.NewNop())
@@ -84,11 +82,11 @@ func TestCreateProcessor(t *testing.T) {
 	assert.NoError(t, tp.Shutdown(context.Background()))
 	assert.NoError(t, mp.Shutdown(context.Background()))
 	// verify that no monitoring routine is running
-	assert.Error(t, errorCheck, tp.Shutdown(context.Background()))
+	assert.Error(t, tp.Shutdown(context.Background()))
 
 	// start and shutdown a new monitoring routine
 	assert.NoError(t, lp.Start(context.Background(), componenttest.NewNopHost()))
 	assert.NoError(t, lp.Shutdown(context.Background()))
 	// calling it again should throw an error
-	assert.Error(t, errorCheck, lp.Shutdown(context.Background()))
+	assert.ErrorIs(t, lp.Shutdown(context.Background()), errShutdownNotStarted)
 }

--- a/processor/memorylimiterprocessor/memorylimiter.go
+++ b/processor/memorylimiterprocessor/memorylimiter.go
@@ -57,6 +57,8 @@ var (
 	errPercentageLimitOutOfRange = errors.New(
 		"memoryLimitPercentage and memorySpikePercentage must be greater than zero and less than or equal to hundred",
 	)
+
+	errShutdownNotStarted = errors.New("no existing monitoring routine is running")
 )
 
 // make it overridable by tests
@@ -164,7 +166,7 @@ func (ml *memoryLimiter) shutdown(context.Context) error {
 	defer ml.refCounterLock.Unlock()
 
 	if ml.refCounter == 0 {
-		return fmt.Errorf("no existing monitoring routine is running")
+		return errShutdownNotStarted
 	} else if ml.refCounter == 1 {
 		ml.ticker.Stop()
 	}

--- a/processor/memorylimiterprocessor/memorylimiter_test.go
+++ b/processor/memorylimiterprocessor/memorylimiter_test.go
@@ -93,14 +93,13 @@ func TestNew(t *testing.T) {
 			cfg.MemoryLimitMiB = tt.args.memoryLimitMiB
 			cfg.MemorySpikeLimitMiB = tt.args.memorySpikeLimitMiB
 			got, err := newMemoryLimiter(componenttest.NewNopProcessorCreateSettings(), cfg)
-			if err != tt.wantErr {
-				t.Errorf("newMemoryLimiter() error = %v, wantErr %v", err, tt.wantErr)
+			if tt.wantErr != nil {
+				assert.ErrorIs(t, err, tt.wantErr)
 				return
 			}
-			if got != nil {
-				assert.NoError(t, got.start(context.Background(), componenttest.NewNopHost()))
-				assert.NoError(t, got.shutdown(context.Background()))
-			}
+			assert.NoError(t, err)
+			assert.NoError(t, got.start(context.Background(), componenttest.NewNopHost()))
+			assert.NoError(t, got.shutdown(context.Background()))
 		})
 	}
 }

--- a/receiver/otlpreceiver/config.go
+++ b/receiver/otlpreceiver/config.go
@@ -15,7 +15,7 @@
 package otlpreceiver // import "go.opentelemetry.io/collector/receiver/otlpreceiver"
 
 import (
-	"fmt"
+	"errors"
 
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/configgrpc"
@@ -49,7 +49,7 @@ var _ config.Unmarshallable = (*Config)(nil)
 func (cfg *Config) Validate() error {
 	if cfg.GRPC == nil &&
 		cfg.HTTP == nil {
-		return fmt.Errorf("must specify at least one protocol when using the OTLP receiver")
+		return errors.New("must specify at least one protocol when using the OTLP receiver")
 	}
 	return nil
 }
@@ -57,7 +57,7 @@ func (cfg *Config) Validate() error {
 // Unmarshal a config.Map into the config struct.
 func (cfg *Config) Unmarshal(componentParser *config.Map) error {
 	if componentParser == nil || len(componentParser.AllKeys()) == 0 {
-		return fmt.Errorf("empty config for OTLP receiver")
+		return errors.New("empty config for OTLP receiver")
 	}
 	// first load the config normally
 	err := componentParser.UnmarshalExact(cfg)

--- a/receiver/otlpreceiver/otlp.go
+++ b/receiver/otlpreceiver/otlp.go
@@ -16,6 +16,7 @@ package otlpreceiver // import "go.opentelemetry.io/collector/receiver/otlprecei
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -77,7 +78,7 @@ func (r *otlpReceiver) startGRPCServer(cfg *configgrpc.GRPCServerSettings, host 
 	go func() {
 		defer r.shutdownWG.Done()
 
-		if errGrpc := r.serverGRPC.Serve(gln); errGrpc != nil && errGrpc != grpc.ErrServerStopped {
+		if errGrpc := r.serverGRPC.Serve(gln); errGrpc != nil && !errors.Is(errGrpc, grpc.ErrServerStopped) {
 			host.ReportFatalError(errGrpc)
 		}
 	}()
@@ -95,7 +96,7 @@ func (r *otlpReceiver) startHTTPServer(cfg *confighttp.HTTPServerSettings, host 
 	go func() {
 		defer r.shutdownWG.Done()
 
-		if errHTTP := r.serverHTTP.Serve(hln); errHTTP != http.ErrServerClosed {
+		if errHTTP := r.serverHTTP.Serve(hln); errHTTP != nil && !errors.Is(errHTTP, http.ErrServerClosed) {
 			host.ReportFatalError(errHTTP)
 		}
 	}()

--- a/receiver/scrapererror/partialscrapeerror_test.go
+++ b/receiver/scrapererror/partialscrapeerror_test.go
@@ -16,7 +16,6 @@ package scrapererror
 
 import (
 	"errors"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -25,7 +24,7 @@ import (
 
 func TestPartialScrapeError(t *testing.T) {
 	failed := 2
-	err := fmt.Errorf("some error")
+	err := errors.New("some error")
 	partialErr := NewPartialScrapeError(err, failed)
 	assert.Equal(t, err.Error(), partialErr.Error())
 	assert.Equal(t, failed, partialErr.Failed)

--- a/receiver/scraperhelper/scrapercontroller_test.go
+++ b/receiver/scraperhelper/scrapercontroller_test.go
@@ -317,7 +317,8 @@ func assertScraperViews(t *testing.T, tt obsreporttest.TestTelemetry, expectedEr
 	expectedScraped := int64(sink.DataPointCount())
 	expectedErrored := int64(0)
 	if expectedErr != nil {
-		if partialError, isPartial := expectedErr.(scrapererror.PartialScrapeError); isPartial {
+		var partialError scrapererror.PartialScrapeError
+		if errors.As(expectedErr, &partialError) {
 			expectedErrored = int64(partialError.Failed)
 		} else {
 			expectedScraped = int64(0)

--- a/service/internal/builder/exporters_builder.go
+++ b/service/internal/builder/exporters_builder.go
@@ -16,6 +16,7 @@ package builder // import "go.opentelemetry.io/collector/service/internal/builde
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"go.uber.org/multierr"
@@ -237,7 +238,7 @@ func buildExporter(
 		}
 
 		if err != nil {
-			if err == componenterror.ErrDataTypeIsNotSupported {
+			if errors.Is(err, componenterror.ErrDataTypeIsNotSupported) {
 				// Could not create because this exporter does not support this data type.
 				return nil, exporterTypeMismatchErr(cfg, pipelineID, dataType)
 			}

--- a/service/internal/builder/receivers_builder.go
+++ b/service/internal/builder/receivers_builder.go
@@ -108,7 +108,7 @@ func BuildReceivers(
 
 		rcv, err := rb.buildReceiver(context.Background(), set, recvID, recvCfg)
 		if err != nil {
-			if err == errUnusedReceiver {
+			if errors.Is(err, errUnusedReceiver) {
 				set.Logger.Info("Ignoring receiver as it is not used by any pipeline")
 				continue
 			}
@@ -195,7 +195,7 @@ func attachReceiverToPipelines(
 	}
 
 	if err != nil {
-		if err == componenterror.ErrDataTypeIsNotSupported {
+		if errors.Is(err, componenterror.ErrDataTypeIsNotSupported) {
 			return fmt.Errorf(
 				"receiver %v does not support %s but it was used in a %s pipeline",
 				id, dataType, dataType)

--- a/service/internal/configunmarshaler/defaultunmarshaler.go
+++ b/service/internal/configunmarshaler/defaultunmarshaler.go
@@ -91,7 +91,7 @@ func (ConfigUnmarshaler) Unmarshal(v *config.Map, factories component.Factories)
 	// Unmarshal top level sections and validate.
 	rawCfg := configSettings{}
 	if err := v.UnmarshalExact(&rawCfg); err != nil {
-		return nil, &configError{
+		return nil, configError{
 			error: fmt.Errorf("error reading top level configuration sections: %w", err),
 			code:  errUnmarshalTopLevelStructure,
 		}
@@ -99,35 +99,35 @@ func (ConfigUnmarshaler) Unmarshal(v *config.Map, factories component.Factories)
 
 	var err error
 	if cfg.Extensions, err = unmarshalExtensions(rawCfg.Extensions, factories.Extensions); err != nil {
-		return nil, &configError{
+		return nil, configError{
 			error: err,
 			code:  errUnmarshalExtension,
 		}
 	}
 
 	if cfg.Receivers, err = unmarshalReceivers(rawCfg.Receivers, factories.Receivers); err != nil {
-		return nil, &configError{
+		return nil, configError{
 			error: err,
 			code:  errUnmarshalReceiver,
 		}
 	}
 
 	if cfg.Processors, err = unmarshalProcessors(rawCfg.Processors, factories.Processors); err != nil {
-		return nil, &configError{
+		return nil, configError{
 			error: err,
 			code:  errUnmarshalProcessor,
 		}
 	}
 
 	if cfg.Exporters, err = unmarshalExporters(rawCfg.Exporters, factories.Exporters); err != nil {
-		return nil, &configError{
+		return nil, configError{
 			error: err,
 			code:  errUnmarshalExporter,
 		}
 	}
 
 	if cfg.Service, err = unmarshalService(rawCfg.Service); err != nil {
-		return nil, &configError{
+		return nil, configError{
 			error: err,
 			code:  errUnmarshalService,
 		}

--- a/service/internal/configunmarshaler/defaultunmarshaler_test.go
+++ b/service/internal/configunmarshaler/defaultunmarshaler_test.go
@@ -15,6 +15,7 @@
 package configunmarshaler
 
 import (
+	"errors"
 	"path/filepath"
 	"testing"
 
@@ -194,8 +195,8 @@ func TestDecodeConfig_Invalid(t *testing.T) {
 			_, err := loadConfigFile(t, filepath.Join("testdata", test.name+".yaml"), factories)
 			require.Error(t, err)
 			if test.expected != 0 {
-				cfgErr, ok := err.(*configError)
-				if !ok {
+				var cfgErr configError
+				if !errors.As(err, &cfgErr) {
 					t.Errorf("expected config error code %v but got a different error '%v'", test.expected, err)
 				} else {
 					assert.Equal(t, test.expected, cfgErr.code, err)

--- a/service/internal/extensions/extensions_test.go
+++ b/service/internal/extensions/extensions_test.go
@@ -16,7 +16,7 @@ package extensions
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -34,7 +34,7 @@ func TestService_setupExtensions(t *testing.T) {
 			return &cfg
 		},
 		func(ctx context.Context, set component.ExtensionCreateSettings, extension config.Extension) (component.Extension, error) {
-			return nil, fmt.Errorf("cannot create \"err\" extension type")
+			return nil, errors.New("cannot create \"err\" extension type")
 		},
 	)
 	errExtensionConfig := errExtensionFactory.CreateDefaultConfig()

--- a/service/mapresolver.go
+++ b/service/mapresolver.go
@@ -16,6 +16,7 @@ package service // import "go.opentelemetry.io/collector/service"
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -63,11 +64,11 @@ type mapResolver struct {
 // (see https://datatracker.ietf.org/doc/html/rfc3986). An empty "<scheme>" defaults to "file" schema.
 func newMapResolver(uris []string, mapProviders map[string]config.MapProvider, mapConverters []config.MapConverterFunc) (*mapResolver, error) {
 	if len(uris) == 0 {
-		return nil, fmt.Errorf("invalid map resolver config: no URIs")
+		return nil, errors.New("invalid map resolver config: no URIs")
 	}
 
 	if len(mapProviders) == 0 {
-		return nil, fmt.Errorf("invalid map resolver config: no map providers")
+		return nil, errors.New("invalid map resolver config: no map providers")
 	}
 
 	// Safe copy, ensures the slices and maps cannot be changed from the caller.
@@ -166,7 +167,7 @@ func (mr *mapResolver) Shutdown(ctx context.Context) error {
 
 func (mr *mapResolver) onChange(event *config.ChangeEvent) {
 	// TODO: Remove check for configsource.ErrSessionClosed when providers updated to not call onChange when closed.
-	if event.Error != configsource.ErrSessionClosed {
+	if !errors.Is(event.Error, configsource.ErrSessionClosed) {
 		mr.watcher <- event.Error
 	}
 }

--- a/service/telemetry.go
+++ b/service/telemetry.go
@@ -15,6 +15,7 @@
 package service // import "go.opentelemetry.io/collector/service"
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -143,8 +144,7 @@ func (tel *colTelemetry) initOnce(col *Collector) error {
 	}
 
 	go func() {
-		serveErr := tel.server.ListenAndServe()
-		if serveErr != nil && serveErr != http.ErrServerClosed {
+		if serveErr := tel.server.ListenAndServe(); serveErr != nil && !errors.Is(serveErr, http.ErrServerClosed) {
 			col.asyncErrorChannel <- serveErr
 		}
 	}()


### PR DESCRIPTION
On top of the errorlint errors, also changes `fmt.Errorf("string literal")` with `errors.New("string literal")`.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
