### PR TITLE
[docs] add status information for OTLP exporter

### DIFF
--- a/exporter/otlpexporter/README.md
+++ b/exporter/otlpexporter/README.md
@@ -1,13 +1,14 @@
 # OTLP gRPC Exporter
 
+| Status                   |                       |
+| ------------------------ | --------------------- |
+| Stability                | [beta]                |
+| Supported pipeline types | traces, metrics, logs |
+| Distributions            | [core], [contrib]     |
+
 Exports data via gRPC using [OTLP](
 https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/otlp.md)
 format. By default, this exporter requires TLS and offers queued retry capabilities.
-
-Supported pipeline types: traces, metrics, logs
-
-:warning: OTLP logs format is currently marked as "Beta" and may change in
-incompatible ways.
 
 ## Getting Started
 
@@ -50,3 +51,7 @@ Several helper files are leveraged to provide additional capabilities automatica
 - [gRPC settings](https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/configgrpc/README.md)
 - [TLS and mTLS settings](https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/configtls/README.md)
 - [Queuing, retry and timeout settings](https://github.com/open-telemetry/opentelemetry-collector/blob/main/exporter/exporterhelper/README.md)
+
+[beta]: https://github.com/open-telemetry/opentelemetry-collector-contrib#beta
+[contrib]: https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib
+[core]: https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol

--- a/exporter/otlpexporter/README.md
+++ b/exporter/otlpexporter/README.md
@@ -2,7 +2,9 @@
 
 | Status                   |                       |
 | ------------------------ | --------------------- |
-| Stability                | [beta]                |
+| Stability                | traces [stable]       |
+|                          | metrics [stable]      |
+|                          | logs [beta]           |
 | Supported pipeline types | traces, metrics, logs |
 | Distributions            | [core], [contrib]     |
 
@@ -55,3 +57,4 @@ Several helper files are leveraged to provide additional capabilities automatica
 [beta]: https://github.com/open-telemetry/opentelemetry-collector-contrib#beta
 [contrib]: https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib
 [core]: https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol
+[stable]: https://github.com/open-telemetry/opentelemetry-collector-contrib#stable

--- a/exporter/otlpexporter/README.md
+++ b/exporter/otlpexporter/README.md
@@ -54,7 +54,7 @@ Several helper files are leveraged to provide additional capabilities automatica
 - [TLS and mTLS settings](https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/configtls/README.md)
 - [Queuing, retry and timeout settings](https://github.com/open-telemetry/opentelemetry-collector/blob/main/exporter/exporterhelper/README.md)
 
-[beta]: https://github.com/open-telemetry/opentelemetry-collector-contrib#beta
+[beta]: https://github.com/open-telemetry/opentelemetry-collector#beta
 [contrib]: https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib
 [core]: https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol
-[stable]: https://github.com/open-telemetry/opentelemetry-collector-contrib#stable
+[stable]: https://github.com/open-telemetry/opentelemetry-collector#stable


### PR DESCRIPTION
Adds the status header for the OTLP exporter.
