### PR TITLE
[docs] add stability documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,37 +63,35 @@ Objectives:
 - Extensible: Customizable without touching the core code.
 - Unified: Single codebase, deployable as an agent or collector with support for traces, metrics and logs.
 
-## Status
+## Stability levels
 
 The collector components and implementation are in different stages of stability, and usually split between
-functionality and configuration:
+functionality and configuration. The status for each component is available in the README file for the component. While
+we intend to provide high-quality components as part of this repository, we acknowledge that not all of them are ready
+for prime time. As such, each component should list its current stability level for each telemetry signal, according to
+the following definitions:
 
-| Signal | Component | Status |
-|--------|-----------|--------|
-|Traces  | OTLP protocol | Stable |
-|| OTLP receiver functionality | Stable |
-|| OTLP receiver configuration | Stable |
-|| OTLP exporter functionality | Stable |
-|| OTLP exporter configuration | Stable |
-|Metrics | OTLP protocol | Stable |
-|| OTLP receiver functionality | Stable |
-|| OTLP receiver configuration | Stable |
-|| OTLP exporter functionality | Stable |
-|| OTLP exporter configuration | Stable |
-|Logs    | OTLP protocol | Beta |
-|| OTLP receiver functionality | Beta |
-|| OTLP receiver configuration | Beta |
-|| OTLP exporter functionality | Beta |
-|| OTLP exporter configuration | Beta |
-|Common| Logging exporter | Unstable |
-|| Batch processor functionality | Beta |
-|| Batch processor configuration | Beta |
-|| MemoryLimiter processor functionality | Beta |
-|| MemoryLimiter processor configuration | Beta |
+### In development
 
-We follow the production maturity level defined [here](https://github.com/open-telemetry/community/blob/47813530864b9fe5a5146f466a58bd2bb94edc72/maturity-matrix.yaml#L31).
+Not all pieces of the component are in place yet and it might not be available as part of any distributions yet. Bugs and performance issues should be reported, but it is likely that the component owners might not give them much attention. Your feedback is still desired, especially when it comes to the user-experience (configuration options, component observability, technical implementation details, ...). Configuration options might break often depending on how things evolve. The component should not be used in production.
 
-### Compatibility
+### Alpha
+
+The component is ready to be used for limited non-critical workloads and the authors of this component would welcome your feedback. Bugs and performance problems should be reported, but component owners might not work on them right away. The configuration options might change often without backwards compatibility guarantees.
+
+### Beta
+
+Same as Alpha, but the configuration options are deemed stable. While there might be breaking changes between releases, component owners should try to minimize them. A component at this stage is expected to have had exposure to non-critical production workloads already during its **Alpha** phase, making it suitable for broader usage.
+
+### Stable
+
+The component is ready for general availability. Bugs and performance problems should be reported and there's an expectation that the component owners will work on them. Breaking changes, including configuration options and the component's output are not expected to happen without prior notice, unless under special circumstances.
+
+### Deprecated
+
+The component is planned to be removed in a future version and no further support will be provided. Note that new issues will likely not be worked on. When a component enters "deprecated" mode, it is expected to exist for at least two minor releases. See the component's readme file for more details on when a component will cease to exist.
+
+## Compatibility
 
 When used as a library, the OpenTelemetry Collector attempts to track the currently supported versions of Go, as [defined by the Go team](https://go.dev/doc/devel/release#policy).
 Removing support for an unsupported Go version is not considered a breaking change.


### PR DESCRIPTION
This moves the stability level documentation from the contrib repo to the core repo.
