### PR TITLE
[pdata] Rename `Value.NewValueBytes ` to `Value.NewValueBytes`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 
 - Deprecate `config.Config` and `config.Service`, use `service.Config*` (#4608)
 - Deprecate `componenterror` package, move everything to `component` (#5383)
+- `pcommon.Value.NewValueBytes` is deprecated in favor of `Value.NewValueMBytes` in preparation of migration to 
+  immutable slices (#5367)
 
 ### 💡 Enhancements 💡
 

--- a/pdata/internal/common.go
+++ b/pdata/internal/common.go
@@ -125,10 +125,10 @@ func NewValueSlice() Value {
 	return Value{orig: &otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_ArrayValue{ArrayValue: &otlpcommon.ArrayValue{}}}}
 }
 
-// NewValueBytes creates a new Value with the given []byte value.
+// NewValueMBytes creates a new Value with the given []byte value.
 // The caller must ensure the []byte passed in is not modified after the call is made, sharing the data
 // across multiple attributes is forbidden.
-func NewValueBytes(v []byte) Value {
+func NewValueMBytes(v []byte) Value {
 	return Value{orig: &otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_BytesValue{BytesValue: v}}}
 }
 
@@ -165,7 +165,7 @@ func newValueFromRaw(iv interface{}) Value {
 	case bool:
 		return NewValueBool(tv)
 	case []byte:
-		return NewValueBytes(tv)
+		return NewValueMBytes(tv)
 	case map[string]interface{}:
 		mv := NewValueMap()
 		NewMapFromRaw(tv).CopyTo(mv.MapVal())

--- a/pdata/internal/common_test.go
+++ b/pdata/internal/common_test.go
@@ -64,7 +64,7 @@ func TestAttributeValue(t *testing.T) {
 	assert.True(t, v.BoolVal())
 
 	bytesValue := []byte{1, 2, 3, 4}
-	v = NewValueBytes(bytesValue)
+	v = NewValueMBytes(bytesValue)
 	assert.EqualValues(t, ValueTypeBytes, v.Type())
 	assert.EqualValues(t, bytesValue, v.MBytesVal())
 }
@@ -224,14 +224,14 @@ func TestAttributeValueEqual(t *testing.T) {
 	av1 = NewValueBool(false)
 	assert.True(t, av1.Equal(av2))
 
-	av2 = NewValueBytes([]byte{1, 2, 3})
+	av2 = NewValueMBytes([]byte{1, 2, 3})
 	assert.False(t, av1.Equal(av2))
 	assert.False(t, av2.Equal(av1))
 
-	av1 = NewValueBytes([]byte{1, 2, 4})
+	av1 = NewValueMBytes([]byte{1, 2, 4})
 	assert.False(t, av1.Equal(av2))
 
-	av1 = NewValueBytes([]byte{1, 2, 3})
+	av1 = NewValueMBytes([]byte{1, 2, 3})
 	assert.True(t, av1.Equal(av2))
 
 	av1 = NewValueSlice()
@@ -664,7 +664,7 @@ func TestAttributeValue_copyTo(t *testing.T) {
 }
 
 func TestValueBytes_CopyTo(t *testing.T) {
-	orig := NewValueBytes([]byte{1, 2, 3})
+	orig := NewValueMBytes([]byte{1, 2, 3})
 	dest := NewValueEmpty()
 	orig.CopyTo(dest)
 	assert.Equal(t, orig, dest)
@@ -1087,7 +1087,7 @@ func TestAsString(t *testing.T) {
 		},
 		{
 			name:     "bytes",
-			input:    NewValueBytes([]byte("String bytes")),
+			input:    NewValueMBytes([]byte("String bytes")),
 			expected: base64.StdEncoding.EncodeToString([]byte("String bytes")),
 		},
 	}
@@ -1122,12 +1122,12 @@ func TestValueAsRaw(t *testing.T) {
 		},
 		{
 			name:     "bytes",
-			input:    NewValueBytes([]byte("bytes")),
+			input:    NewValueMBytes([]byte("bytes")),
 			expected: []byte("bytes"),
 		},
 		{
 			name:     "bytes",
-			input:    NewValueBytes([]byte("bytes")),
+			input:    NewValueMBytes([]byte("bytes")),
 			expected: []byte("bytes"),
 		},
 		{
@@ -1286,7 +1286,7 @@ func TestNewValueFromRaw(t *testing.T) {
 		{
 			name:     "bytes",
 			input:    []byte{1, 2, 3},
-			expected: NewValueBytes([]byte{1, 2, 3}),
+			expected: NewValueMBytes([]byte{1, 2, 3}),
 		},
 		{
 			name: "map",

--- a/pdata/pcommon/alias.go
+++ b/pdata/pcommon/alias.go
@@ -76,7 +76,13 @@ var (
 	// NewValueBytes creates a new Value with the given []byte value.
 	// The caller must ensure the []byte passed in is not modified after the call is made, sharing the data
 	// across multiple attributes is forbidden.
-	NewValueBytes = internal.NewValueBytes
+	// Deprecated: [0.52.0] Use NewValueMBytes instead. Signature of this func will be changed to accept new immutable slice type in 0.53.0.
+	NewValueBytes = internal.NewValueMBytes
+
+	// NewValueMBytes creates a new Value with the given []byte value.
+	// The caller must ensure the []byte passed in is not modified after the call is made, sharing the data
+	// across multiple attributes is forbidden.
+	NewValueMBytes = internal.NewValueMBytes
 )
 
 // Map stores a map of string keys to elements of Value type.


### PR DESCRIPTION
Deprecate `pcommon.Value.NewValueBytes` in favor of `Value.NewValueMBytes` in preparation of migration to the new immutable slices.

This constructor was missed in https://github.com/open-telemetry/opentelemetry-collector/pull/5344. We will still stick to the schedule defined in https://github.com/open-telemetry/opentelemetry-collector/issues/5263. The deprecated function will be just replaced without removal in 0.53.0.