### PR TITLE
Run Windows unit tests for all modules and fix them

### DIFF
--- a/.github/workflows/build-and-test-windows.yaml
+++ b/.github/workflows/build-and-test-windows.yaml
@@ -25,5 +25,5 @@ jobs:
             ~\go\pkg\mod
             ~\AppData\Local\go-build
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-      - name: Run Unit tests
-        run: go test ./...
+      - name: Run Unit Tests
+        run: make gotest

--- a/Makefile
+++ b/Makefile
@@ -146,13 +146,18 @@ install-tools:
 run: otelcorecol
 	./bin/otelcorecol_$(GOOS)_$(GOARCH) --config ${RUN_CONFIG} ${RUN_ARGS}
 
+# Append root module to all modules
 GOMODULES = $(ALL_MODULES) $(PWD)
+
+# Define a delegation target for each module
 .PHONY: $(GOMODULES)
-MODULEDIRS = $(GOMODULES:%=for-all-target-%)
+$(GOMODULES):
+	@echo "Running target '$(TARGET)' in module '$@'"
+	$(MAKE) -C $@ $(TARGET)
+
+# Triggers each module's delegation target
 .PHONY: for-all-target
-for-all-target: $(MODULEDIRS)
-$(MODULEDIRS):
-	$(MAKE) -C $(@:for-all-target-%=%) $(TARGET)
+for-all-target: $(GOMODULES)
 
 .PHONY: check-component
 check-component:

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -3,7 +3,7 @@ ALL_PKGS := $(sort $(shell go list ./...))
 
 # Use a single process (-p 1) on go test to avoid tests clashing on machine
 # wide resources, e.g. ports.
-GOTEST_OPT?= -v -p 1 -race -timeout 60s
+GOTEST_OPT?= -v -p 1 -race -timeout 120s
 GOCMD?= go
 GOTEST=$(GOCMD) test
 GO_ACC=go-acc

--- a/cmd/builder/internal/builder/config_test.go
+++ b/cmd/builder/internal/builder/config_test.go
@@ -58,7 +58,6 @@ func TestRelativePath(t *testing.T) {
 	// verify
 	cwd, err := os.Getwd()
 	require.NoError(t, err)
-	assert.True(t, strings.HasPrefix(cfg.Extensions[0].Path, "/"))
 	assert.True(t, strings.HasPrefix(cfg.Extensions[0].Path, cwd))
 }
 

--- a/cmd/builder/internal/builder/main_test.go
+++ b/cmd/builder/internal/builder/main_test.go
@@ -18,6 +18,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -37,14 +38,17 @@ func TestGenerateInvalidCollectorVersion(t *testing.T) {
 
 func TestGenerateInvalidOutputPath(t *testing.T) {
 	cfg := NewDefaultConfig()
-	cfg.Distribution.OutputPath = "/invalid"
+	cfg.Distribution.OutputPath = "/:invalid"
 	err := Generate(cfg)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failed to create output path")
 }
 
 func TestGenerateAndCompileDefault(t *testing.T) {
-	dir, err := ioutil.TempDir("/tmp", "default")
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping the test on Windows, see https://github.com/open-telemetry/opentelemetry-collector/issues/5403")
+	}
+	dir, err := ioutil.TempDir("", "default")
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Enable running unit test on Windows for all modules and fix those that are failing except for one issue reported separately:
https://github.com/open-telemetry/opentelemetry-collector/issues/5403