### PR TITLE
Allow specifying Collector's own Resource in the config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,12 @@
 ### 💡 Enhancements 💡
 
 - Update OTLP to v0.17.0 (#5335)
-  - Add optional min/max fields to histograms (#5399)
+- Add optional min/max fields to histograms (#5399)
+- User-defined Resource attributes can be specified under `service.telemetry.resource`
+  configuration key and will be included as metric lables for own telemetry.
+  If `service.instance.id` is not specified it will be auto-generated. Previously
+  `service.instance.id` was always auto-generated, so the default of the new
+  behavior matches the old behavior. (#5402)
 
 ### 🧰 Bug fixes 🧰
 

--- a/config/moved_service.go
+++ b/config/moved_service.go
@@ -38,6 +38,13 @@ type Service struct {
 type ServiceTelemetry struct {
 	Logs    ServiceTelemetryLogs    `mapstructure:"logs"`
 	Metrics ServiceTelemetryMetrics `mapstructure:"metrics"`
+
+	// Resource specifies user-defined attributes to include with all emitted telemetry.
+	// For metrics the attributes become Prometheus labels.
+	// Note that some attributes are added automatically (e.g. service.version) even
+	// if they are not specified here. In order to suppress such attributes the
+	// attribute must be specified in this map with null YAML value (nil string pointer).
+	Resource map[string]*string `mapstructure:"resource"`
 }
 
 // ServiceTelemetryLogs defines the configurable settings for service telemetry logs.


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-collector/issues/5398

This adds a sub-section in the `service.telemetry` config section where any Resource attributes can be specified. All specified attributes will included as own metrics labels.

If `service.instance.id` is not specified it will be auto-generated. Previously `service.instance.id` was always auto-generated, so the default of the new behavior matches the old behavior.

For example we can have the following in the config:

```yaml
service:
  telemetry:
    resource:
      service.instance.id: 01G3EN4NW306AFVGQT5ZYC0GEK
      service.namespace: onlineshop
      deployment.environment: production
```