### PR TITLE
record telemetry dropped by exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Enhancements 💡
 
+- Record dropped telemetry.
+
 ### 🧰 Bug fixes 🧰
 
 ## v0.52.0 Beta

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Enhancements 💡
 
-- Record dropped telemetry.
+- Record dropped telemetry. (#5427)
 
 ### 🧰 Bug fixes 🧰
 

--- a/exporter/exporterhelper/logs.go
+++ b/exporter/exporterhelper/logs.go
@@ -129,6 +129,9 @@ type logsExporterWithObservability struct {
 func (lewo *logsExporterWithObservability) send(req request) error {
 	req.setContext(lewo.obsrep.StartLogsOp(req.context()))
 	err := lewo.nextSender.send(req)
+	if consumererror.IsPermanent(err) {
+		lewo.obsrep.recordLogsDropped(req.context(), int64(req.count()))
+	}
 	lewo.obsrep.EndLogsOp(req.context(), req.count(), err)
 	return err
 }

--- a/exporter/exporterhelper/logs_test.go
+++ b/exporter/exporterhelper/logs_test.go
@@ -159,8 +159,8 @@ func TestLogsExporter_WithPermanentError(t *testing.T) {
 	require.NotNil(t, te)
 
 	// errors are checked in the checkExporterDroppedLogsStats function below.
-	_ = te.ConsumeLogs(context.Background(), testdata.GenerateLogsTwoLogRecordsSameResourceOneDifferent())
-	checkExporterDroppedLogsStats(t, globalInstruments, fakeLogsExporterName, 2)
+	_ = te.ConsumeLogs(context.Background(), testdata.GenerateLogsOneLogRecord())
+	checkExporterDroppedLogsStats(t, globalInstruments, fakeLogsExporterName, 1)
 }
 
 func TestLogsExporter_WithSpan(t *testing.T) {

--- a/exporter/exporterhelper/logs_test.go
+++ b/exporter/exporterhelper/logs_test.go
@@ -154,7 +154,7 @@ func TestLogsExporter_WithPermanentError(t *testing.T) {
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
 	wantErr := consumererror.NewPermanent(errors.New("really permanent error"))
-	te, err := NewLogsExporter(&fakeMetricsExporterConfig, tt.ToExporterCreateSettings(), newPushLogsData(wantErr))
+	te, err := NewLogsExporter(&fakeLogsExporterConfig, tt.ToExporterCreateSettings(), newPushLogsData(wantErr))
 	require.NoError(t, err)
 	require.NotNil(t, te)
 

--- a/exporter/exporterhelper/metrics.go
+++ b/exporter/exporterhelper/metrics.go
@@ -130,6 +130,9 @@ type metricsSenderWithObservability struct {
 func (mewo *metricsSenderWithObservability) send(req request) error {
 	req.setContext(mewo.obsrep.StartMetricsOp(req.context()))
 	err := mewo.nextSender.send(req)
+	if consumererror.IsPermanent(err) {
+		mewo.obsrep.recordMetricsDropped(req.context(), int64(req.count()))
+	}
 	mewo.obsrep.EndMetricsOp(req.context(), req.count(), err)
 	return err
 }

--- a/exporter/exporterhelper/obsreport_test.go
+++ b/exporter/exporterhelper/obsreport_test.go
@@ -73,6 +73,24 @@ func checkExporterEnqueueFailedLogsStats(t *testing.T, insts *instruments, expor
 	checkValueForProducer(t, insts.registry, tagsForExporterView(exporter), logRecords, "exporter/enqueue_failed_log_records")
 }
 
+// checkExporterDroppedTracesStats checks that reported number of spans dropped match given values.
+// When this function is called it is required to also call SetupTelemetry as first thing.
+func checkExporterDroppedTracesStats(t *testing.T, insts *instruments, exporter config.ComponentID, spans int64) {
+	checkValueForProducer(t, insts.registry, tagsForExporterView(exporter), spans, "exporter/dropped_spans")
+}
+
+// checkExporterDroppedMetricsStats checks that reported number of metric points dropped match given values.
+// When this function is called it is required to also call SetupTelemetry as first thing.
+func checkExporterDroppedMetricsStats(t *testing.T, insts *instruments, exporter config.ComponentID, metricPoints int64) {
+	checkValueForProducer(t, insts.registry, tagsForExporterView(exporter), metricPoints, "exporter/dropped_metric_points")
+}
+
+// checkExporterDroppedLogsStats checks that reported number of log records dropped match given values.
+// When this function is called it is required to also call SetupTelemetry as first thing.
+func checkExporterDroppedLogsStats(t *testing.T, insts *instruments, exporter config.ComponentID, logRecords int64) {
+	checkValueForProducer(t, insts.registry, tagsForExporterView(exporter), logRecords, "exporter/dropped_log_records")
+}
+
 // tagsForExporterView returns the tags that are needed for the exporter views.
 func tagsForExporterView(exporter config.ComponentID) []tag.Tag {
 	return []tag.Tag{

--- a/exporter/exporterhelper/traces.go
+++ b/exporter/exporterhelper/traces.go
@@ -132,6 +132,9 @@ func (tewo *tracesExporterWithObservability) send(req request) error {
 	req.setContext(tewo.obsrep.StartTracesOp(req.context()))
 	// Forward the data to the next consumer (this pusher is the next).
 	err := tewo.nextSender.send(req)
+	if consumererror.IsPermanent(err) {
+		tewo.obsrep.recordTracesDropped(req.context(), int64(req.count()))
+	}
 	tewo.obsrep.EndTracesOp(req.context(), req.count(), err)
 	return err
 }

--- a/exporter/exporterhelper/traces_test.go
+++ b/exporter/exporterhelper/traces_test.go
@@ -151,7 +151,7 @@ func TestTracesExporter_WithPermanentError(t *testing.T) {
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
 	wantErr := consumererror.NewPermanent(errors.New("really permanent error"))
-	te, err := NewTracesExporter(&fakeMetricsExporterConfig, tt.ToExporterCreateSettings(), newTraceDataPusher(wantErr))
+	te, err := NewTracesExporter(&fakeTracesExporterConfig, tt.ToExporterCreateSettings(), newTraceDataPusher(wantErr))
 	require.NoError(t, err)
 	require.NotNil(t, te)
 


### PR DESCRIPTION
The following change adds a metric to record dropped spans/metrics/logs as a metric in the observability report for exporters.

Here's a sample output from the `/metrics` endpoint with these metrics:
```
# HELP otelcol_exporter_dropped_log_records Number of log records failed that were dropped.
# TYPE otelcol_exporter_dropped_log_records counter
otelcol_exporter_dropped_log_records{exporter="logging",service_instance_id="d455132f-8e4d-44a5-ac4d-63d15818302b",service_version="v0.52.0-2-g42fb93c6"} 0
otelcol_exporter_dropped_log_records{exporter="otlp",service_instance_id="d455132f-8e4d-44a5-ac4d-63d15818302b",service_version="v0.52.0-2-g42fb93c6"} 0
# HELP otelcol_exporter_dropped_metric_points Number of metrics points that were dropped.
# TYPE otelcol_exporter_dropped_metric_points counter
otelcol_exporter_dropped_metric_points{exporter="logging",service_instance_id="d455132f-8e4d-44a5-ac4d-63d15818302b",service_version="v0.52.0-2-g42fb93c6"} 0
otelcol_exporter_dropped_metric_points{exporter="otlp",service_instance_id="d455132f-8e4d-44a5-ac4d-63d15818302b",service_version="v0.52.0-2-g42fb93c6"} 26
# HELP otelcol_exporter_dropped_spans Number of spans that were dropped.
# TYPE otelcol_exporter_dropped_spans counter
otelcol_exporter_dropped_spans{exporter="logging",service_instance_id="d455132f-8e4d-44a5-ac4d-63d15818302b",service_version="v0.52.0-2-g42fb93c6"} 0
otelcol_exporter_dropped_spans{exporter="otlp",service_instance_id="d455132f-8e4d-44a5-ac4d-63d15818302b",service_version="v0.52.0-2-g42fb93c6"} 4
```
