### PR TITLE
[pdata] add Move function (#5431)

### DIFF
--- a/pdata/internal/cmd/pdatagen/internal/base_slices.go
+++ b/pdata/internal/cmd/pdatagen/internal/base_slices.go
@@ -20,6 +20,14 @@ import (
 )
 
 const commonSliceTemplate = `
+// Move moves all elements from the current slice and replaces the dest.
+// The current slice will be cleared.
+func (es ${structName}) Move(dest ${structName}) {
+	// We can simply move the entire vector and avoid any allocations.
+	*dest.orig = *es.orig
+	*es.orig = nil
+}
+
 // MoveAndAppendTo moves all elements from the current slice and appends them to the dest.
 // The current slice will be cleared.
 func (es ${structName}) MoveAndAppendTo(dest ${structName}) {
@@ -53,6 +61,33 @@ func (es ${structName}) RemoveIf(f func(${elementName}) bool) {
 }`
 
 const commonSliceTestTemplate = `
+
+func Test${structName}_Move(t *testing.T) {
+	// assert.EqualValues(t, 1, 2)
+
+	// Test Move to empty
+	expectedSlice := generateTest${structName}()
+	dest := New${structName}()
+	src := generateTest${structName}()
+	assert.EqualValues(t, 7, src.Len())
+	src.Move(dest)
+	assert.EqualValues(t, generateTest${structName}(), dest)
+	assert.EqualValues(t, 0, src.Len())
+	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
+
+	// Test Move empty slice
+	src.Move(dest)
+	assert.EqualValues(t, src, dest)
+	assert.EqualValues(t, 0, src.Len())
+	assert.EqualValues(t, 0, dest.Len())
+
+	// Test Move not empty slice
+	generateTest${structName}().Move(dest)
+	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
+	for i := 0; i < expectedSlice.Len(); i++ {
+		assert.EqualValues(t, expectedSlice.At(i), dest.At(i))
+	}
+}
 
 func Test${structName}_MoveAndAppendTo(t *testing.T) {
 	// Test MoveAndAppendTo to empty

--- a/pdata/internal/generated_common.go
+++ b/pdata/internal/generated_common.go
@@ -162,6 +162,13 @@ func (es Slice) AppendEmpty() Value {
 	*es.orig = append(*es.orig, otlpcommon.AnyValue{})
 	return es.At(es.Len() - 1)
 }
+// Move moves all elements from the current slice and replaces the dest.
+// The current slice will be cleared.
+func (es Slice) Move(dest Slice) {
+	// We can simply move the entire vector and avoid any allocations.
+	*dest.orig = *es.orig
+	*es.orig = nil
+}
 
 // MoveAndAppendTo moves all elements from the current slice and appends them to the dest.
 // The current slice will be cleared.

--- a/pdata/internal/generated_common_test.go
+++ b/pdata/internal/generated_common_test.go
@@ -25,6 +25,7 @@ import (
 	otlpcommon "go.opentelemetry.io/collector/pdata/internal/data/protogen/common/v1"
 )
 
+
 func TestInstrumentationScope_MoveTo(t *testing.T) {
 	ms := generateTestInstrumentationScope()
 	dest := NewInstrumentationScope()
@@ -115,6 +116,33 @@ func TestSlice_EnsureCapacity(t *testing.T) {
 	assert.Equal(t, oldLen, len(expectedEs))
 	es.EnsureCapacity(ensureLargeLen)
 	assert.Equal(t, ensureLargeLen, cap(*es.orig))
+}
+
+func TestSlice_Move(t *testing.T) {
+	// assert.EqualValues(t, 1, 2)
+
+	// Test Move to empty
+	expectedSlice := generateTestSlice()
+	dest := NewSlice()
+	src := generateTestSlice()
+	assert.EqualValues(t, 7, src.Len())
+	src.Move(dest)
+	assert.EqualValues(t, generateTestSlice(), dest)
+	assert.EqualValues(t, 0, src.Len())
+	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
+
+	// Test Move empty slice
+	src.Move(dest)
+	assert.EqualValues(t, src, dest)
+	assert.EqualValues(t, 0, src.Len())
+	assert.EqualValues(t, 0, dest.Len())
+
+	// Test Move not empty slice
+	generateTestSlice().Move(dest)
+	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
+	for i := 0; i < expectedSlice.Len(); i++ {
+		assert.EqualValues(t, expectedSlice.At(i), dest.At(i))
+	}
 }
 
 func TestSlice_MoveAndAppendTo(t *testing.T) {

--- a/pdata/internal/generated_plog.go
+++ b/pdata/internal/generated_plog.go
@@ -128,6 +128,14 @@ func (es ResourceLogsSlice) Sort(less func(a, b ResourceLogs) bool) ResourceLogs
 	return es
 }
 
+// Move moves all elements from the current slice and replaces the dest.
+// The current slice will be cleared.
+func (es ResourceLogsSlice) Move(dest ResourceLogsSlice) {
+	// We can simply move the entire vector and avoid any allocations.
+	*dest.orig = *es.orig
+	*es.orig = nil
+}
+
 // MoveAndAppendTo moves all elements from the current slice and appends them to the dest.
 // The current slice will be cleared.
 func (es ResourceLogsSlice) MoveAndAppendTo(dest ResourceLogsSlice) {
@@ -322,6 +330,14 @@ func (es ScopeLogsSlice) Sort(less func(a, b ScopeLogs) bool) ScopeLogsSlice {
 	return es
 }
 
+// Move moves all elements from the current slice and replaces the dest.
+// The current slice will be cleared.
+func (es ScopeLogsSlice) Move(dest ScopeLogsSlice) {
+	// We can simply move the entire vector and avoid any allocations.
+	*dest.orig = *es.orig
+	*es.orig = nil
+}
+
 // MoveAndAppendTo moves all elements from the current slice and appends them to the dest.
 // The current slice will be cleared.
 func (es ScopeLogsSlice) MoveAndAppendTo(dest ScopeLogsSlice) {
@@ -514,6 +530,14 @@ func (es LogRecordSlice) AppendEmpty() LogRecord {
 func (es LogRecordSlice) Sort(less func(a, b LogRecord) bool) LogRecordSlice {
 	sort.SliceStable(*es.orig, func(i, j int) bool { return less(es.At(i), es.At(j)) })
 	return es
+}
+
+// Move moves all elements from the current slice and replaces the dest.
+// The current slice will be cleared.
+func (es LogRecordSlice) Move(dest LogRecordSlice) {
+	// We can simply move the entire vector and avoid any allocations.
+	*dest.orig = *es.orig
+	*es.orig = nil
 }
 
 // MoveAndAppendTo moves all elements from the current slice and appends them to the dest.

--- a/pdata/internal/generated_plog_test.go
+++ b/pdata/internal/generated_plog_test.go
@@ -92,6 +92,33 @@ func TestResourceLogsSlice_EnsureCapacity(t *testing.T) {
 	assert.EqualValues(t, expectedEs, foundEs)
 }
 
+func TestResourceLogsSlice_Move(t *testing.T) {
+	// assert.EqualValues(t, 1, 2)
+
+	// Test Move to empty
+	expectedSlice := generateTestResourceLogsSlice()
+	dest := NewResourceLogsSlice()
+	src := generateTestResourceLogsSlice()
+	assert.EqualValues(t, 7, src.Len())
+	src.Move(dest)
+	assert.EqualValues(t, generateTestResourceLogsSlice(), dest)
+	assert.EqualValues(t, 0, src.Len())
+	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
+
+	// Test Move empty slice
+	src.Move(dest)
+	assert.EqualValues(t, src, dest)
+	assert.EqualValues(t, 0, src.Len())
+	assert.EqualValues(t, 0, dest.Len())
+
+	// Test Move not empty slice
+	generateTestResourceLogsSlice().Move(dest)
+	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
+	for i := 0; i < expectedSlice.Len(); i++ {
+		assert.EqualValues(t, expectedSlice.At(i), dest.At(i))
+	}
+}
+
 func TestResourceLogsSlice_MoveAndAppendTo(t *testing.T) {
 	// Test MoveAndAppendTo to empty
 	expectedSlice := generateTestResourceLogsSlice()
@@ -134,6 +161,7 @@ func TestResourceLogsSlice_RemoveIf(t *testing.T) {
 	})
 	assert.Equal(t, 5, filtered.Len())
 }
+
 
 func TestResourceLogs_MoveTo(t *testing.T) {
 	ms := generateTestResourceLogs()
@@ -242,6 +270,33 @@ func TestScopeLogsSlice_EnsureCapacity(t *testing.T) {
 	assert.EqualValues(t, expectedEs, foundEs)
 }
 
+func TestScopeLogsSlice_Move(t *testing.T) {
+	// assert.EqualValues(t, 1, 2)
+
+	// Test Move to empty
+	expectedSlice := generateTestScopeLogsSlice()
+	dest := NewScopeLogsSlice()
+	src := generateTestScopeLogsSlice()
+	assert.EqualValues(t, 7, src.Len())
+	src.Move(dest)
+	assert.EqualValues(t, generateTestScopeLogsSlice(), dest)
+	assert.EqualValues(t, 0, src.Len())
+	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
+
+	// Test Move empty slice
+	src.Move(dest)
+	assert.EqualValues(t, src, dest)
+	assert.EqualValues(t, 0, src.Len())
+	assert.EqualValues(t, 0, dest.Len())
+
+	// Test Move not empty slice
+	generateTestScopeLogsSlice().Move(dest)
+	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
+	for i := 0; i < expectedSlice.Len(); i++ {
+		assert.EqualValues(t, expectedSlice.At(i), dest.At(i))
+	}
+}
+
 func TestScopeLogsSlice_MoveAndAppendTo(t *testing.T) {
 	// Test MoveAndAppendTo to empty
 	expectedSlice := generateTestScopeLogsSlice()
@@ -284,6 +339,7 @@ func TestScopeLogsSlice_RemoveIf(t *testing.T) {
 	})
 	assert.Equal(t, 5, filtered.Len())
 }
+
 
 func TestScopeLogs_MoveTo(t *testing.T) {
 	ms := generateTestScopeLogs()
@@ -392,6 +448,33 @@ func TestLogRecordSlice_EnsureCapacity(t *testing.T) {
 	assert.EqualValues(t, expectedEs, foundEs)
 }
 
+func TestLogRecordSlice_Move(t *testing.T) {
+	// assert.EqualValues(t, 1, 2)
+
+	// Test Move to empty
+	expectedSlice := generateTestLogRecordSlice()
+	dest := NewLogRecordSlice()
+	src := generateTestLogRecordSlice()
+	assert.EqualValues(t, 7, src.Len())
+	src.Move(dest)
+	assert.EqualValues(t, generateTestLogRecordSlice(), dest)
+	assert.EqualValues(t, 0, src.Len())
+	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
+
+	// Test Move empty slice
+	src.Move(dest)
+	assert.EqualValues(t, src, dest)
+	assert.EqualValues(t, 0, src.Len())
+	assert.EqualValues(t, 0, dest.Len())
+
+	// Test Move not empty slice
+	generateTestLogRecordSlice().Move(dest)
+	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
+	for i := 0; i < expectedSlice.Len(); i++ {
+		assert.EqualValues(t, expectedSlice.At(i), dest.At(i))
+	}
+}
+
 func TestLogRecordSlice_MoveAndAppendTo(t *testing.T) {
 	// Test MoveAndAppendTo to empty
 	expectedSlice := generateTestLogRecordSlice()
@@ -434,6 +517,7 @@ func TestLogRecordSlice_RemoveIf(t *testing.T) {
 	})
 	assert.Equal(t, 5, filtered.Len())
 }
+
 
 func TestLogRecord_MoveTo(t *testing.T) {
 	ms := generateTestLogRecord()

--- a/pdata/internal/generated_pmetric.go
+++ b/pdata/internal/generated_pmetric.go
@@ -128,6 +128,14 @@ func (es ResourceMetricsSlice) Sort(less func(a, b ResourceMetrics) bool) Resour
 	return es
 }
 
+// Move moves all elements from the current slice and replaces the dest.
+// The current slice will be cleared.
+func (es ResourceMetricsSlice) Move(dest ResourceMetricsSlice) {
+	// We can simply move the entire vector and avoid any allocations.
+	*dest.orig = *es.orig
+	*es.orig = nil
+}
+
 // MoveAndAppendTo moves all elements from the current slice and appends them to the dest.
 // The current slice will be cleared.
 func (es ResourceMetricsSlice) MoveAndAppendTo(dest ResourceMetricsSlice) {
@@ -320,6 +328,14 @@ func (es ScopeMetricsSlice) AppendEmpty() ScopeMetrics {
 func (es ScopeMetricsSlice) Sort(less func(a, b ScopeMetrics) bool) ScopeMetricsSlice {
 	sort.SliceStable(*es.orig, func(i, j int) bool { return less(es.At(i), es.At(j)) })
 	return es
+}
+
+// Move moves all elements from the current slice and replaces the dest.
+// The current slice will be cleared.
+func (es ScopeMetricsSlice) Move(dest ScopeMetricsSlice) {
+	// We can simply move the entire vector and avoid any allocations.
+	*dest.orig = *es.orig
+	*es.orig = nil
 }
 
 // MoveAndAppendTo moves all elements from the current slice and appends them to the dest.
@@ -516,6 +532,14 @@ func (es MetricSlice) Sort(less func(a, b Metric) bool) MetricSlice {
 	return es
 }
 
+// Move moves all elements from the current slice and replaces the dest.
+// The current slice will be cleared.
+func (es MetricSlice) Move(dest MetricSlice) {
+	// We can simply move the entire vector and avoid any allocations.
+	*dest.orig = *es.orig
+	*es.orig = nil
+}
+
 // MoveAndAppendTo moves all elements from the current slice and appends them to the dest.
 // The current slice will be cleared.
 func (es MetricSlice) MoveAndAppendTo(dest MetricSlice) {
@@ -629,7 +653,7 @@ func (ms Metric) DataType() MetricDataType {
 
 // Gauge returns the gauge associated with this Metric.
 //
-// Calling this function when DataType() != MetricDataTypeGauge returns an invalid
+// Calling this function when DataType() != MetricDataTypeGauge returns an invalid 
 // zero-initialized instance of Gauge. Note that using such Gauge instance can cause panic.
 //
 // Calling this function on zero-initialized Metric will cause a panic.
@@ -643,7 +667,7 @@ func (ms Metric) Gauge() Gauge {
 
 // Sum returns the sum associated with this Metric.
 //
-// Calling this function when DataType() != MetricDataTypeSum returns an invalid
+// Calling this function when DataType() != MetricDataTypeSum returns an invalid 
 // zero-initialized instance of Sum. Note that using such Sum instance can cause panic.
 //
 // Calling this function on zero-initialized Metric will cause a panic.
@@ -657,7 +681,7 @@ func (ms Metric) Sum() Sum {
 
 // Histogram returns the histogram associated with this Metric.
 //
-// Calling this function when DataType() != MetricDataTypeHistogram returns an invalid
+// Calling this function when DataType() != MetricDataTypeHistogram returns an invalid 
 // zero-initialized instance of Histogram. Note that using such Histogram instance can cause panic.
 //
 // Calling this function on zero-initialized Metric will cause a panic.
@@ -671,7 +695,7 @@ func (ms Metric) Histogram() Histogram {
 
 // ExponentialHistogram returns the exponentialhistogram associated with this Metric.
 //
-// Calling this function when DataType() != MetricDataTypeExponentialHistogram returns an invalid
+// Calling this function when DataType() != MetricDataTypeExponentialHistogram returns an invalid 
 // zero-initialized instance of ExponentialHistogram. Note that using such ExponentialHistogram instance can cause panic.
 //
 // Calling this function on zero-initialized Metric will cause a panic.
@@ -685,7 +709,7 @@ func (ms Metric) ExponentialHistogram() ExponentialHistogram {
 
 // Summary returns the summary associated with this Metric.
 //
-// Calling this function when DataType() != MetricDataTypeSummary returns an invalid
+// Calling this function when DataType() != MetricDataTypeSummary returns an invalid 
 // zero-initialized instance of Summary. Note that using such Summary instance can cause panic.
 //
 // Calling this function on zero-initialized Metric will cause a panic.
@@ -696,6 +720,8 @@ func (ms Metric) Summary() Summary {
 	}
 	return newSummary(v.Summary)
 }
+
+
 
 // CopyTo copies all properties from the current struct to the dest.
 func (ms Metric) CopyTo(dest Metric) {
@@ -876,7 +902,7 @@ func (ms Histogram) CopyTo(dest Histogram) {
 }
 
 // ExponentialHistogram represents the type of a metric that is calculated by aggregating
-// as a ExponentialHistogram of all reported double measurements over a time interval.
+	// as a ExponentialHistogram of all reported double measurements over a time interval.
 //
 // This is a reference type, if passed by value and callee modifies it the
 // caller will see the modification.
@@ -1072,6 +1098,14 @@ func (es NumberDataPointSlice) Sort(less func(a, b NumberDataPoint) bool) Number
 	return es
 }
 
+// Move moves all elements from the current slice and replaces the dest.
+// The current slice will be cleared.
+func (es NumberDataPointSlice) Move(dest NumberDataPointSlice) {
+	// We can simply move the entire vector and avoid any allocations.
+	*dest.orig = *es.orig
+	*es.orig = nil
+}
+
 // MoveAndAppendTo moves all elements from the current slice and appends them to the dest.
 // The current slice will be cleared.
 func (es NumberDataPointSlice) MoveAndAppendTo(dest NumberDataPointSlice) {
@@ -1195,6 +1229,8 @@ func (ms NumberDataPoint) SetIntVal(v int64) {
 	}
 }
 
+
+
 // Exemplars returns the Exemplars associated with this NumberDataPoint.
 func (ms NumberDataPoint) Exemplars() ExemplarSlice {
 	return newExemplarSlice(&(*ms.orig).Exemplars)
@@ -1217,9 +1253,9 @@ func (ms NumberDataPoint) CopyTo(dest NumberDataPoint) {
 	dest.SetTimestamp(ms.Timestamp())
 	switch ms.ValueType() {
 	case NumberDataPointValueTypeDouble:
-		dest.SetDoubleVal(ms.DoubleVal())
+	 dest.SetDoubleVal(ms.DoubleVal())
 	case NumberDataPointValueTypeInt:
-		dest.SetIntVal(ms.IntVal())
+	 dest.SetIntVal(ms.IntVal())
 	}
 
 	ms.Exemplars().CopyTo(dest.Exemplars())
@@ -1331,6 +1367,14 @@ func (es HistogramDataPointSlice) Sort(less func(a, b HistogramDataPoint) bool) 
 	return es
 }
 
+// Move moves all elements from the current slice and replaces the dest.
+// The current slice will be cleared.
+func (es HistogramDataPointSlice) Move(dest HistogramDataPointSlice) {
+	// We can simply move the entire vector and avoid any allocations.
+	*dest.orig = *es.orig
+	*es.orig = nil
+}
+
 // MoveAndAppendTo moves all elements from the current slice and appends them to the dest.
 // The current slice will be cleared.
 func (es HistogramDataPointSlice) MoveAndAppendTo(dest HistogramDataPointSlice) {
@@ -1432,17 +1476,16 @@ func (ms HistogramDataPoint) SetCount(v uint64) {
 func (ms HistogramDataPoint) Sum() float64 {
 	return (*ms.orig).GetSum()
 }
-
 // HasSum returns true if the HistogramDataPoint contains a
 // Sum value, false otherwise.
 func (ms HistogramDataPoint) HasSum() bool {
 	return ms.orig.Sum_ != nil
 }
-
 // SetSum replaces the sum associated with this HistogramDataPoint.
 func (ms HistogramDataPoint) SetSum(v float64) {
 	(*ms.orig).Sum_ = &otlpmetrics.HistogramDataPoint_Sum{Sum: v}
 }
+
 
 // MBucketCounts returns the mbucketcounts associated with this HistogramDataPoint.
 func (ms HistogramDataPoint) MBucketCounts() []uint64 {
@@ -1483,33 +1526,31 @@ func (ms HistogramDataPoint) SetFlags(v MetricDataPointFlags) {
 func (ms HistogramDataPoint) Min() float64 {
 	return (*ms.orig).GetMin()
 }
-
 // HasMin returns true if the HistogramDataPoint contains a
 // Min value, false otherwise.
 func (ms HistogramDataPoint) HasMin() bool {
 	return ms.orig.Min_ != nil
 }
-
 // SetMin replaces the min associated with this HistogramDataPoint.
 func (ms HistogramDataPoint) SetMin(v float64) {
 	(*ms.orig).Min_ = &otlpmetrics.HistogramDataPoint_Min{Min: v}
 }
 
+
 // Max returns the max associated with this HistogramDataPoint.
 func (ms HistogramDataPoint) Max() float64 {
 	return (*ms.orig).GetMax()
 }
-
 // HasMax returns true if the HistogramDataPoint contains a
 // Max value, false otherwise.
 func (ms HistogramDataPoint) HasMax() bool {
 	return ms.orig.Max_ != nil
 }
-
 // SetMax replaces the max associated with this HistogramDataPoint.
 func (ms HistogramDataPoint) SetMax(v float64) {
 	(*ms.orig).Max_ = &otlpmetrics.HistogramDataPoint_Max{Max: v}
 }
+
 
 // CopyTo copies all properties from the current struct to the dest.
 func (ms HistogramDataPoint) CopyTo(dest HistogramDataPoint) {
@@ -1517,18 +1558,18 @@ func (ms HistogramDataPoint) CopyTo(dest HistogramDataPoint) {
 	dest.SetStartTimestamp(ms.StartTimestamp())
 	dest.SetTimestamp(ms.Timestamp())
 	dest.SetCount(ms.Count())
-	if ms.HasSum() {
-		dest.SetSum(ms.Sum())
-	}
+if ms.HasSum(){
+	dest.SetSum(ms.Sum())
+}
 
-	if len(ms.orig.BucketCounts) == 0 {
+	if len(ms.orig.BucketCounts) == 0 {	
 		dest.orig.BucketCounts = nil
 	} else {
 		dest.orig.BucketCounts = make([]uint64, len(ms.orig.BucketCounts))
 		copy(dest.orig.BucketCounts, ms.orig.BucketCounts)
 	}
 
-	if len(ms.orig.ExplicitBounds) == 0 {
+	if len(ms.orig.ExplicitBounds) == 0 {	
 		dest.orig.ExplicitBounds = nil
 	} else {
 		dest.orig.ExplicitBounds = make([]float64, len(ms.orig.ExplicitBounds))
@@ -1537,13 +1578,13 @@ func (ms HistogramDataPoint) CopyTo(dest HistogramDataPoint) {
 
 	ms.Exemplars().CopyTo(dest.Exemplars())
 	dest.SetFlags(ms.Flags())
-	if ms.HasMin() {
-		dest.SetMin(ms.Min())
-	}
+if ms.HasMin(){
+	dest.SetMin(ms.Min())
+}
 
-	if ms.HasMax() {
-		dest.SetMax(ms.Max())
-	}
+if ms.HasMax(){
+	dest.SetMax(ms.Max())
+}
 
 }
 
@@ -1652,6 +1693,14 @@ func (es ExponentialHistogramDataPointSlice) Sort(less func(a, b ExponentialHist
 	return es
 }
 
+// Move moves all elements from the current slice and replaces the dest.
+// The current slice will be cleared.
+func (es ExponentialHistogramDataPointSlice) Move(dest ExponentialHistogramDataPointSlice) {
+	// We can simply move the entire vector and avoid any allocations.
+	*dest.orig = *es.orig
+	*es.orig = nil
+}
+
 // MoveAndAppendTo moves all elements from the current slice and appends them to the dest.
 // The current slice will be cleared.
 func (es ExponentialHistogramDataPointSlice) MoveAndAppendTo(dest ExponentialHistogramDataPointSlice) {
@@ -1685,9 +1734,9 @@ func (es ExponentialHistogramDataPointSlice) RemoveIf(f func(ExponentialHistogra
 }
 
 // ExponentialHistogramDataPoint is a single data point in a timeseries that describes the
-// time-varying values of a ExponentialHistogram of double values. A ExponentialHistogram contains
-// summary statistics for a population of values, it may optionally contain the
-// distribution of those values across a set of buckets.
+	// time-varying values of a ExponentialHistogram of double values. A ExponentialHistogram contains
+	// summary statistics for a population of values, it may optionally contain the
+	// distribution of those values across a set of buckets.
 //
 // This is a reference type, if passed by value and callee modifies it the
 // caller will see the modification.
@@ -1811,33 +1860,31 @@ func (ms ExponentialHistogramDataPoint) SetFlags(v MetricDataPointFlags) {
 func (ms ExponentialHistogramDataPoint) Min() float64 {
 	return (*ms.orig).GetMin()
 }
-
 // HasMin returns true if the ExponentialHistogramDataPoint contains a
 // Min value, false otherwise.
 func (ms ExponentialHistogramDataPoint) HasMin() bool {
 	return ms.orig.Min_ != nil
 }
-
 // SetMin replaces the min associated with this ExponentialHistogramDataPoint.
 func (ms ExponentialHistogramDataPoint) SetMin(v float64) {
 	(*ms.orig).Min_ = &otlpmetrics.ExponentialHistogramDataPoint_Min{Min: v}
 }
 
+
 // Max returns the max associated with this ExponentialHistogramDataPoint.
 func (ms ExponentialHistogramDataPoint) Max() float64 {
 	return (*ms.orig).GetMax()
 }
-
 // HasMax returns true if the ExponentialHistogramDataPoint contains a
 // Max value, false otherwise.
 func (ms ExponentialHistogramDataPoint) HasMax() bool {
 	return ms.orig.Max_ != nil
 }
-
 // SetMax replaces the max associated with this ExponentialHistogramDataPoint.
 func (ms ExponentialHistogramDataPoint) SetMax(v float64) {
 	(*ms.orig).Max_ = &otlpmetrics.ExponentialHistogramDataPoint_Max{Max: v}
 }
+
 
 // CopyTo copies all properties from the current struct to the dest.
 func (ms ExponentialHistogramDataPoint) CopyTo(dest ExponentialHistogramDataPoint) {
@@ -1852,13 +1899,13 @@ func (ms ExponentialHistogramDataPoint) CopyTo(dest ExponentialHistogramDataPoin
 	ms.Negative().CopyTo(dest.Negative())
 	ms.Exemplars().CopyTo(dest.Exemplars())
 	dest.SetFlags(ms.Flags())
-	if ms.HasMin() {
-		dest.SetMin(ms.Min())
-	}
+if ms.HasMin(){
+	dest.SetMin(ms.Min())
+}
 
-	if ms.HasMax() {
-		dest.SetMax(ms.Max())
-	}
+if ms.HasMax(){
+	dest.SetMax(ms.Max())
+}
 
 }
 
@@ -1915,7 +1962,7 @@ func (ms Buckets) SetMBucketCounts(v []uint64) {
 // CopyTo copies all properties from the current struct to the dest.
 func (ms Buckets) CopyTo(dest Buckets) {
 	dest.SetOffset(ms.Offset())
-	if len(ms.orig.BucketCounts) == 0 {
+	if len(ms.orig.BucketCounts) == 0 {	
 		dest.orig.BucketCounts = nil
 	} else {
 		dest.orig.BucketCounts = make([]uint64, len(ms.orig.BucketCounts))
@@ -2027,6 +2074,14 @@ func (es SummaryDataPointSlice) AppendEmpty() SummaryDataPoint {
 func (es SummaryDataPointSlice) Sort(less func(a, b SummaryDataPoint) bool) SummaryDataPointSlice {
 	sort.SliceStable(*es.orig, func(i, j int) bool { return less(es.At(i), es.At(j)) })
 	return es
+}
+
+// Move moves all elements from the current slice and replaces the dest.
+// The current slice will be cleared.
+func (es SummaryDataPointSlice) Move(dest SummaryDataPointSlice) {
+	// We can simply move the entire vector and avoid any allocations.
+	*dest.orig = *es.orig
+	*es.orig = nil
 }
 
 // MoveAndAppendTo moves all elements from the current slice and appends them to the dest.
@@ -2267,6 +2322,14 @@ func (es ValueAtQuantileSlice) Sort(less func(a, b ValueAtQuantile) bool) ValueA
 	return es
 }
 
+// Move moves all elements from the current slice and replaces the dest.
+// The current slice will be cleared.
+func (es ValueAtQuantileSlice) Move(dest ValueAtQuantileSlice) {
+	// We can simply move the entire vector and avoid any allocations.
+	*dest.orig = *es.orig
+	*es.orig = nil
+}
+
 // MoveAndAppendTo moves all elements from the current slice and appends them to the dest.
 // The current slice will be cleared.
 func (es ValueAtQuantileSlice) MoveAndAppendTo(dest ValueAtQuantileSlice) {
@@ -2440,6 +2503,13 @@ func (es ExemplarSlice) AppendEmpty() Exemplar {
 	*es.orig = append(*es.orig, otlpmetrics.Exemplar{})
 	return es.At(es.Len() - 1)
 }
+// Move moves all elements from the current slice and replaces the dest.
+// The current slice will be cleared.
+func (es ExemplarSlice) Move(dest ExemplarSlice) {
+	// We can simply move the entire vector and avoid any allocations.
+	*dest.orig = *es.orig
+	*es.orig = nil
+}
 
 // MoveAndAppendTo moves all elements from the current slice and appends them to the dest.
 // The current slice will be cleared.
@@ -2552,6 +2622,8 @@ func (ms Exemplar) SetIntVal(v int64) {
 	}
 }
 
+
+
 // FilteredAttributes returns the FilteredAttributes associated with this Exemplar.
 func (ms Exemplar) FilteredAttributes() Map {
 	return newMap(&(*ms.orig).FilteredAttributes)
@@ -2582,9 +2654,9 @@ func (ms Exemplar) CopyTo(dest Exemplar) {
 	dest.SetTimestamp(ms.Timestamp())
 	switch ms.ValueType() {
 	case ExemplarValueTypeDouble:
-		dest.SetDoubleVal(ms.DoubleVal())
+	 dest.SetDoubleVal(ms.DoubleVal())
 	case ExemplarValueTypeInt:
-		dest.SetIntVal(ms.IntVal())
+	 dest.SetIntVal(ms.IntVal())
 	}
 
 	ms.FilteredAttributes().CopyTo(dest.FilteredAttributes())

--- a/pdata/internal/generated_pmetric_test.go
+++ b/pdata/internal/generated_pmetric_test.go
@@ -92,6 +92,33 @@ func TestResourceMetricsSlice_EnsureCapacity(t *testing.T) {
 	assert.EqualValues(t, expectedEs, foundEs)
 }
 
+func TestResourceMetricsSlice_Move(t *testing.T) {
+	// assert.EqualValues(t, 1, 2)
+
+	// Test Move to empty
+	expectedSlice := generateTestResourceMetricsSlice()
+	dest := NewResourceMetricsSlice()
+	src := generateTestResourceMetricsSlice()
+	assert.EqualValues(t, 7, src.Len())
+	src.Move(dest)
+	assert.EqualValues(t, generateTestResourceMetricsSlice(), dest)
+	assert.EqualValues(t, 0, src.Len())
+	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
+
+	// Test Move empty slice
+	src.Move(dest)
+	assert.EqualValues(t, src, dest)
+	assert.EqualValues(t, 0, src.Len())
+	assert.EqualValues(t, 0, dest.Len())
+
+	// Test Move not empty slice
+	generateTestResourceMetricsSlice().Move(dest)
+	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
+	for i := 0; i < expectedSlice.Len(); i++ {
+		assert.EqualValues(t, expectedSlice.At(i), dest.At(i))
+	}
+}
+
 func TestResourceMetricsSlice_MoveAndAppendTo(t *testing.T) {
 	// Test MoveAndAppendTo to empty
 	expectedSlice := generateTestResourceMetricsSlice()
@@ -134,6 +161,7 @@ func TestResourceMetricsSlice_RemoveIf(t *testing.T) {
 	})
 	assert.Equal(t, 5, filtered.Len())
 }
+
 
 func TestResourceMetrics_MoveTo(t *testing.T) {
 	ms := generateTestResourceMetrics()
@@ -242,6 +270,33 @@ func TestScopeMetricsSlice_EnsureCapacity(t *testing.T) {
 	assert.EqualValues(t, expectedEs, foundEs)
 }
 
+func TestScopeMetricsSlice_Move(t *testing.T) {
+	// assert.EqualValues(t, 1, 2)
+
+	// Test Move to empty
+	expectedSlice := generateTestScopeMetricsSlice()
+	dest := NewScopeMetricsSlice()
+	src := generateTestScopeMetricsSlice()
+	assert.EqualValues(t, 7, src.Len())
+	src.Move(dest)
+	assert.EqualValues(t, generateTestScopeMetricsSlice(), dest)
+	assert.EqualValues(t, 0, src.Len())
+	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
+
+	// Test Move empty slice
+	src.Move(dest)
+	assert.EqualValues(t, src, dest)
+	assert.EqualValues(t, 0, src.Len())
+	assert.EqualValues(t, 0, dest.Len())
+
+	// Test Move not empty slice
+	generateTestScopeMetricsSlice().Move(dest)
+	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
+	for i := 0; i < expectedSlice.Len(); i++ {
+		assert.EqualValues(t, expectedSlice.At(i), dest.At(i))
+	}
+}
+
 func TestScopeMetricsSlice_MoveAndAppendTo(t *testing.T) {
 	// Test MoveAndAppendTo to empty
 	expectedSlice := generateTestScopeMetricsSlice()
@@ -284,6 +339,7 @@ func TestScopeMetricsSlice_RemoveIf(t *testing.T) {
 	})
 	assert.Equal(t, 5, filtered.Len())
 }
+
 
 func TestScopeMetrics_MoveTo(t *testing.T) {
 	ms := generateTestScopeMetrics()
@@ -392,6 +448,33 @@ func TestMetricSlice_EnsureCapacity(t *testing.T) {
 	assert.EqualValues(t, expectedEs, foundEs)
 }
 
+func TestMetricSlice_Move(t *testing.T) {
+	// assert.EqualValues(t, 1, 2)
+
+	// Test Move to empty
+	expectedSlice := generateTestMetricSlice()
+	dest := NewMetricSlice()
+	src := generateTestMetricSlice()
+	assert.EqualValues(t, 7, src.Len())
+	src.Move(dest)
+	assert.EqualValues(t, generateTestMetricSlice(), dest)
+	assert.EqualValues(t, 0, src.Len())
+	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
+
+	// Test Move empty slice
+	src.Move(dest)
+	assert.EqualValues(t, src, dest)
+	assert.EqualValues(t, 0, src.Len())
+	assert.EqualValues(t, 0, dest.Len())
+
+	// Test Move not empty slice
+	generateTestMetricSlice().Move(dest)
+	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
+	for i := 0; i < expectedSlice.Len(); i++ {
+		assert.EqualValues(t, expectedSlice.At(i), dest.At(i))
+	}
+}
+
 func TestMetricSlice_MoveAndAppendTo(t *testing.T) {
 	// Test MoveAndAppendTo to empty
 	expectedSlice := generateTestMetricSlice()
@@ -434,6 +517,7 @@ func TestMetricSlice_RemoveIf(t *testing.T) {
 	})
 	assert.Equal(t, 5, filtered.Len())
 }
+
 
 func TestMetric_MoveTo(t *testing.T) {
 	ms := generateTestMetric()
@@ -486,20 +570,20 @@ func TestMetricDataType(t *testing.T) {
 	assert.Equal(t, Histogram{}, tv.Histogram())
 	assert.Equal(t, ExponentialHistogram{}, tv.ExponentialHistogram())
 	assert.Equal(t, Summary{}, tv.Summary())
-	tv.SetDataType(MetricDataTypeGauge)
-	fillTestGauge(tv.Gauge())
+tv.SetDataType(MetricDataTypeGauge)
+fillTestGauge(tv.Gauge())
 	assert.Equal(t, MetricDataTypeGauge, tv.DataType())
-	tv.SetDataType(MetricDataTypeSum)
-	fillTestSum(tv.Sum())
+tv.SetDataType(MetricDataTypeSum)
+fillTestSum(tv.Sum())
 	assert.Equal(t, MetricDataTypeSum, tv.DataType())
-	tv.SetDataType(MetricDataTypeHistogram)
-	fillTestHistogram(tv.Histogram())
+tv.SetDataType(MetricDataTypeHistogram)
+fillTestHistogram(tv.Histogram())
 	assert.Equal(t, MetricDataTypeHistogram, tv.DataType())
-	tv.SetDataType(MetricDataTypeExponentialHistogram)
-	fillTestExponentialHistogram(tv.ExponentialHistogram())
+tv.SetDataType(MetricDataTypeExponentialHistogram)
+fillTestExponentialHistogram(tv.ExponentialHistogram())
 	assert.Equal(t, MetricDataTypeExponentialHistogram, tv.DataType())
-	tv.SetDataType(MetricDataTypeSummary)
-	fillTestSummary(tv.Summary())
+tv.SetDataType(MetricDataTypeSummary)
+fillTestSummary(tv.Summary())
 	assert.Equal(t, MetricDataTypeSummary, tv.DataType())
 }
 
@@ -583,6 +667,9 @@ func TestMetric_CopyTo_Summary(t *testing.T) {
 	assert.EqualValues(t, ms, dest)
 }
 
+
+
+
 func TestGauge_MoveTo(t *testing.T) {
 	ms := generateTestGauge()
 	dest := NewGauge()
@@ -608,6 +695,7 @@ func TestGauge_DataPoints(t *testing.T) {
 	testValDataPoints := generateTestNumberDataPointSlice()
 	assert.EqualValues(t, testValDataPoints, ms.DataPoints())
 }
+
 
 func TestSum_MoveTo(t *testing.T) {
 	ms := generateTestSum()
@@ -651,6 +739,7 @@ func TestSum_DataPoints(t *testing.T) {
 	assert.EqualValues(t, testValDataPoints, ms.DataPoints())
 }
 
+
 func TestHistogram_MoveTo(t *testing.T) {
 	ms := generateTestHistogram()
 	dest := NewHistogram()
@@ -685,6 +774,7 @@ func TestHistogram_DataPoints(t *testing.T) {
 	assert.EqualValues(t, testValDataPoints, ms.DataPoints())
 }
 
+
 func TestExponentialHistogram_MoveTo(t *testing.T) {
 	ms := generateTestExponentialHistogram()
 	dest := NewExponentialHistogram()
@@ -718,6 +808,7 @@ func TestExponentialHistogram_DataPoints(t *testing.T) {
 	testValDataPoints := generateTestExponentialHistogramDataPointSlice()
 	assert.EqualValues(t, testValDataPoints, ms.DataPoints())
 }
+
 
 func TestSummary_MoveTo(t *testing.T) {
 	ms := generateTestSummary()
@@ -812,6 +903,33 @@ func TestNumberDataPointSlice_EnsureCapacity(t *testing.T) {
 	assert.EqualValues(t, expectedEs, foundEs)
 }
 
+func TestNumberDataPointSlice_Move(t *testing.T) {
+	// assert.EqualValues(t, 1, 2)
+
+	// Test Move to empty
+	expectedSlice := generateTestNumberDataPointSlice()
+	dest := NewNumberDataPointSlice()
+	src := generateTestNumberDataPointSlice()
+	assert.EqualValues(t, 7, src.Len())
+	src.Move(dest)
+	assert.EqualValues(t, generateTestNumberDataPointSlice(), dest)
+	assert.EqualValues(t, 0, src.Len())
+	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
+
+	// Test Move empty slice
+	src.Move(dest)
+	assert.EqualValues(t, src, dest)
+	assert.EqualValues(t, 0, src.Len())
+	assert.EqualValues(t, 0, dest.Len())
+
+	// Test Move not empty slice
+	generateTestNumberDataPointSlice().Move(dest)
+	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
+	for i := 0; i < expectedSlice.Len(); i++ {
+		assert.EqualValues(t, expectedSlice.At(i), dest.At(i))
+	}
+}
+
 func TestNumberDataPointSlice_MoveAndAppendTo(t *testing.T) {
 	// Test MoveAndAppendTo to empty
 	expectedSlice := generateTestNumberDataPointSlice()
@@ -854,6 +972,7 @@ func TestNumberDataPointSlice_RemoveIf(t *testing.T) {
 	})
 	assert.Equal(t, 5, filtered.Len())
 }
+
 
 func TestNumberDataPoint_MoveTo(t *testing.T) {
 	ms := generateTestNumberDataPoint()
@@ -901,9 +1020,9 @@ func TestNumberDataPointValueType(t *testing.T) {
 	tv := NewNumberDataPoint()
 	assert.Equal(t, NumberDataPointValueTypeNone, tv.ValueType())
 	assert.Equal(t, "", NumberDataPointValueType(1000).String())
-	tv.SetDoubleVal(float64(17.13))
+	 tv.SetDoubleVal(float64(17.13))
 	assert.Equal(t, NumberDataPointValueTypeDouble, tv.ValueType())
-	tv.SetIntVal(int64(17))
+	 tv.SetIntVal(int64(17))
 	assert.Equal(t, NumberDataPointValueTypeInt, tv.ValueType())
 }
 
@@ -922,6 +1041,8 @@ func TestNumberDataPoint_IntVal(t *testing.T) {
 	ms.SetIntVal(testValIntVal)
 	assert.EqualValues(t, testValIntVal, ms.IntVal())
 }
+
+
 
 func TestNumberDataPoint_Exemplars(t *testing.T) {
 	ms := NewNumberDataPoint()
@@ -1006,6 +1127,33 @@ func TestHistogramDataPointSlice_EnsureCapacity(t *testing.T) {
 	assert.EqualValues(t, expectedEs, foundEs)
 }
 
+func TestHistogramDataPointSlice_Move(t *testing.T) {
+	// assert.EqualValues(t, 1, 2)
+
+	// Test Move to empty
+	expectedSlice := generateTestHistogramDataPointSlice()
+	dest := NewHistogramDataPointSlice()
+	src := generateTestHistogramDataPointSlice()
+	assert.EqualValues(t, 7, src.Len())
+	src.Move(dest)
+	assert.EqualValues(t, generateTestHistogramDataPointSlice(), dest)
+	assert.EqualValues(t, 0, src.Len())
+	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
+
+	// Test Move empty slice
+	src.Move(dest)
+	assert.EqualValues(t, src, dest)
+	assert.EqualValues(t, 0, src.Len())
+	assert.EqualValues(t, 0, dest.Len())
+
+	// Test Move not empty slice
+	generateTestHistogramDataPointSlice().Move(dest)
+	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
+	for i := 0; i < expectedSlice.Len(); i++ {
+		assert.EqualValues(t, expectedSlice.At(i), dest.At(i))
+	}
+}
+
 func TestHistogramDataPointSlice_MoveAndAppendTo(t *testing.T) {
 	// Test MoveAndAppendTo to empty
 	expectedSlice := generateTestHistogramDataPointSlice()
@@ -1048,6 +1196,7 @@ func TestHistogramDataPointSlice_RemoveIf(t *testing.T) {
 	})
 	assert.Equal(t, 5, filtered.Len())
 }
+
 
 func TestHistogramDataPoint_MoveTo(t *testing.T) {
 	ms := generateTestHistogramDataPoint()
@@ -1115,6 +1264,7 @@ func TestHistogramDataPoint_Sum(t *testing.T) {
 	assert.EqualValues(t, testValSum, ms.Sum())
 }
 
+
 func TestHistogramDataPoint_MBucketCounts(t *testing.T) {
 	ms := NewHistogramDataPoint()
 	assert.EqualValues(t, []uint64(nil), ms.MBucketCounts())
@@ -1155,6 +1305,7 @@ func TestHistogramDataPoint_Min(t *testing.T) {
 	assert.EqualValues(t, testValMin, ms.Min())
 }
 
+
 func TestHistogramDataPoint_Max(t *testing.T) {
 	ms := NewHistogramDataPoint()
 	assert.EqualValues(t, float64(0.0), ms.Max())
@@ -1162,6 +1313,7 @@ func TestHistogramDataPoint_Max(t *testing.T) {
 	ms.SetMax(testValMax)
 	assert.EqualValues(t, testValMax, ms.Max())
 }
+
 
 func TestExponentialHistogramDataPointSlice(t *testing.T) {
 	es := NewExponentialHistogramDataPointSlice()
@@ -1230,6 +1382,33 @@ func TestExponentialHistogramDataPointSlice_EnsureCapacity(t *testing.T) {
 	assert.EqualValues(t, expectedEs, foundEs)
 }
 
+func TestExponentialHistogramDataPointSlice_Move(t *testing.T) {
+	// assert.EqualValues(t, 1, 2)
+
+	// Test Move to empty
+	expectedSlice := generateTestExponentialHistogramDataPointSlice()
+	dest := NewExponentialHistogramDataPointSlice()
+	src := generateTestExponentialHistogramDataPointSlice()
+	assert.EqualValues(t, 7, src.Len())
+	src.Move(dest)
+	assert.EqualValues(t, generateTestExponentialHistogramDataPointSlice(), dest)
+	assert.EqualValues(t, 0, src.Len())
+	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
+
+	// Test Move empty slice
+	src.Move(dest)
+	assert.EqualValues(t, src, dest)
+	assert.EqualValues(t, 0, src.Len())
+	assert.EqualValues(t, 0, dest.Len())
+
+	// Test Move not empty slice
+	generateTestExponentialHistogramDataPointSlice().Move(dest)
+	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
+	for i := 0; i < expectedSlice.Len(); i++ {
+		assert.EqualValues(t, expectedSlice.At(i), dest.At(i))
+	}
+}
+
 func TestExponentialHistogramDataPointSlice_MoveAndAppendTo(t *testing.T) {
 	// Test MoveAndAppendTo to empty
 	expectedSlice := generateTestExponentialHistogramDataPointSlice()
@@ -1272,6 +1451,7 @@ func TestExponentialHistogramDataPointSlice_RemoveIf(t *testing.T) {
 	})
 	assert.Equal(t, 5, filtered.Len())
 }
+
 
 func TestExponentialHistogramDataPoint_MoveTo(t *testing.T) {
 	ms := generateTestExponentialHistogramDataPoint()
@@ -1383,6 +1563,7 @@ func TestExponentialHistogramDataPoint_Min(t *testing.T) {
 	assert.EqualValues(t, testValMin, ms.Min())
 }
 
+
 func TestExponentialHistogramDataPoint_Max(t *testing.T) {
 	ms := NewExponentialHistogramDataPoint()
 	assert.EqualValues(t, float64(0.0), ms.Max())
@@ -1390,6 +1571,8 @@ func TestExponentialHistogramDataPoint_Max(t *testing.T) {
 	ms.SetMax(testValMax)
 	assert.EqualValues(t, testValMax, ms.Max())
 }
+
+
 
 func TestBuckets_MoveTo(t *testing.T) {
 	ms := generateTestBuckets()
@@ -1496,6 +1679,33 @@ func TestSummaryDataPointSlice_EnsureCapacity(t *testing.T) {
 	assert.EqualValues(t, expectedEs, foundEs)
 }
 
+func TestSummaryDataPointSlice_Move(t *testing.T) {
+	// assert.EqualValues(t, 1, 2)
+
+	// Test Move to empty
+	expectedSlice := generateTestSummaryDataPointSlice()
+	dest := NewSummaryDataPointSlice()
+	src := generateTestSummaryDataPointSlice()
+	assert.EqualValues(t, 7, src.Len())
+	src.Move(dest)
+	assert.EqualValues(t, generateTestSummaryDataPointSlice(), dest)
+	assert.EqualValues(t, 0, src.Len())
+	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
+
+	// Test Move empty slice
+	src.Move(dest)
+	assert.EqualValues(t, src, dest)
+	assert.EqualValues(t, 0, src.Len())
+	assert.EqualValues(t, 0, dest.Len())
+
+	// Test Move not empty slice
+	generateTestSummaryDataPointSlice().Move(dest)
+	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
+	for i := 0; i < expectedSlice.Len(); i++ {
+		assert.EqualValues(t, expectedSlice.At(i), dest.At(i))
+	}
+}
+
 func TestSummaryDataPointSlice_MoveAndAppendTo(t *testing.T) {
 	// Test MoveAndAppendTo to empty
 	expectedSlice := generateTestSummaryDataPointSlice()
@@ -1538,6 +1748,7 @@ func TestSummaryDataPointSlice_RemoveIf(t *testing.T) {
 	})
 	assert.Equal(t, 5, filtered.Len())
 }
+
 
 func TestSummaryDataPoint_MoveTo(t *testing.T) {
 	ms := generateTestSummaryDataPoint()
@@ -1680,6 +1891,33 @@ func TestValueAtQuantileSlice_EnsureCapacity(t *testing.T) {
 	assert.EqualValues(t, expectedEs, foundEs)
 }
 
+func TestValueAtQuantileSlice_Move(t *testing.T) {
+	// assert.EqualValues(t, 1, 2)
+
+	// Test Move to empty
+	expectedSlice := generateTestValueAtQuantileSlice()
+	dest := NewValueAtQuantileSlice()
+	src := generateTestValueAtQuantileSlice()
+	assert.EqualValues(t, 7, src.Len())
+	src.Move(dest)
+	assert.EqualValues(t, generateTestValueAtQuantileSlice(), dest)
+	assert.EqualValues(t, 0, src.Len())
+	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
+
+	// Test Move empty slice
+	src.Move(dest)
+	assert.EqualValues(t, src, dest)
+	assert.EqualValues(t, 0, src.Len())
+	assert.EqualValues(t, 0, dest.Len())
+
+	// Test Move not empty slice
+	generateTestValueAtQuantileSlice().Move(dest)
+	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
+	for i := 0; i < expectedSlice.Len(); i++ {
+		assert.EqualValues(t, expectedSlice.At(i), dest.At(i))
+	}
+}
+
 func TestValueAtQuantileSlice_MoveAndAppendTo(t *testing.T) {
 	// Test MoveAndAppendTo to empty
 	expectedSlice := generateTestValueAtQuantileSlice()
@@ -1722,6 +1960,7 @@ func TestValueAtQuantileSlice_RemoveIf(t *testing.T) {
 	})
 	assert.Equal(t, 5, filtered.Len())
 }
+
 
 func TestValueAtQuantile_MoveTo(t *testing.T) {
 	ms := generateTestValueAtQuantile()
@@ -1815,6 +2054,33 @@ func TestExemplarSlice_EnsureCapacity(t *testing.T) {
 	assert.Equal(t, ensureLargeLen, cap(*es.orig))
 }
 
+func TestExemplarSlice_Move(t *testing.T) {
+	// assert.EqualValues(t, 1, 2)
+
+	// Test Move to empty
+	expectedSlice := generateTestExemplarSlice()
+	dest := NewExemplarSlice()
+	src := generateTestExemplarSlice()
+	assert.EqualValues(t, 7, src.Len())
+	src.Move(dest)
+	assert.EqualValues(t, generateTestExemplarSlice(), dest)
+	assert.EqualValues(t, 0, src.Len())
+	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
+
+	// Test Move empty slice
+	src.Move(dest)
+	assert.EqualValues(t, src, dest)
+	assert.EqualValues(t, 0, src.Len())
+	assert.EqualValues(t, 0, dest.Len())
+
+	// Test Move not empty slice
+	generateTestExemplarSlice().Move(dest)
+	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
+	for i := 0; i < expectedSlice.Len(); i++ {
+		assert.EqualValues(t, expectedSlice.At(i), dest.At(i))
+	}
+}
+
 func TestExemplarSlice_MoveAndAppendTo(t *testing.T) {
 	// Test MoveAndAppendTo to empty
 	expectedSlice := generateTestExemplarSlice()
@@ -1858,6 +2124,7 @@ func TestExemplarSlice_RemoveIf(t *testing.T) {
 	assert.Equal(t, 5, filtered.Len())
 }
 
+
 func TestExemplar_MoveTo(t *testing.T) {
 	ms := generateTestExemplar()
 	dest := NewExemplar()
@@ -1888,9 +2155,9 @@ func TestExemplarValueType(t *testing.T) {
 	tv := NewExemplar()
 	assert.Equal(t, ExemplarValueTypeNone, tv.ValueType())
 	assert.Equal(t, "", ExemplarValueType(1000).String())
-	tv.SetDoubleVal(float64(17.13))
+	 tv.SetDoubleVal(float64(17.13))
 	assert.Equal(t, ExemplarValueTypeDouble, tv.ValueType())
-	tv.SetIntVal(int64(17))
+	 tv.SetIntVal(int64(17))
 	assert.Equal(t, ExemplarValueTypeInt, tv.ValueType())
 }
 
@@ -1909,6 +2176,8 @@ func TestExemplar_IntVal(t *testing.T) {
 	ms.SetIntVal(testValIntVal)
 	assert.EqualValues(t, testValIntVal, ms.IntVal())
 }
+
+
 
 func TestExemplar_FilteredAttributes(t *testing.T) {
 	ms := NewExemplar()
@@ -2010,8 +2279,8 @@ func fillTestMetric(tv Metric) {
 	tv.SetName("test_name")
 	tv.SetDescription("test_description")
 	tv.SetUnit("1")
-	tv.SetDataType(MetricDataTypeSum)
-	fillTestSum(tv.Sum())
+tv.SetDataType(MetricDataTypeSum)
+fillTestSum(tv.Sum())
 }
 
 func generateTestGauge() Gauge {
@@ -2092,7 +2361,7 @@ func fillTestNumberDataPoint(tv NumberDataPoint) {
 	fillTestMap(tv.Attributes())
 	tv.SetStartTimestamp(Timestamp(1234567890))
 	tv.SetTimestamp(Timestamp(1234567890))
-	tv.SetDoubleVal(float64(17.13))
+	 tv.SetDoubleVal(float64(17.13))
 	fillTestExemplarSlice(tv.Exemplars())
 	tv.SetFlags(MetricDataPointFlagsNone)
 }
@@ -2122,13 +2391,13 @@ func fillTestHistogramDataPoint(tv HistogramDataPoint) {
 	tv.SetStartTimestamp(Timestamp(1234567890))
 	tv.SetTimestamp(Timestamp(1234567890))
 	tv.SetCount(uint64(17))
-	tv.SetSum(float64(17.13))
+	 tv.SetSum(float64(17.13))
 	tv.SetMBucketCounts([]uint64{1, 2, 3})
 	tv.SetMExplicitBounds([]float64{1, 2, 3})
 	fillTestExemplarSlice(tv.Exemplars())
 	tv.SetFlags(MetricDataPointFlagsNone)
-	tv.SetMin(float64(9.23))
-	tv.SetMax(float64(182.55))
+	 tv.SetMin(float64(9.23))
+	 tv.SetMax(float64(182.55))
 }
 
 func generateTestExponentialHistogramDataPointSlice() ExponentialHistogramDataPointSlice {
@@ -2163,8 +2432,8 @@ func fillTestExponentialHistogramDataPoint(tv ExponentialHistogramDataPoint) {
 	fillTestBuckets(tv.Negative())
 	fillTestExemplarSlice(tv.Exemplars())
 	tv.SetFlags(MetricDataPointFlagsNone)
-	tv.SetMin(float64(9.23))
-	tv.SetMax(float64(182.55))
+	 tv.SetMin(float64(9.23))
+	 tv.SetMax(float64(182.55))
 }
 
 func generateTestBuckets() Buckets {
@@ -2255,7 +2524,7 @@ func generateTestExemplar() Exemplar {
 
 func fillTestExemplar(tv Exemplar) {
 	tv.SetTimestamp(Timestamp(1234567890))
-	tv.SetIntVal(int64(17))
+	 tv.SetIntVal(int64(17))
 	fillTestMap(tv.FilteredAttributes())
 	tv.SetTraceID(NewTraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 8, 7, 6, 5, 4, 3, 2, 1}))
 	tv.SetSpanID(NewSpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8}))

--- a/pdata/internal/generated_ptrace.go
+++ b/pdata/internal/generated_ptrace.go
@@ -128,6 +128,14 @@ func (es ResourceSpansSlice) Sort(less func(a, b ResourceSpans) bool) ResourceSp
 	return es
 }
 
+// Move moves all elements from the current slice and replaces the dest.
+// The current slice will be cleared.
+func (es ResourceSpansSlice) Move(dest ResourceSpansSlice) {
+	// We can simply move the entire vector and avoid any allocations.
+	*dest.orig = *es.orig
+	*es.orig = nil
+}
+
 // MoveAndAppendTo moves all elements from the current slice and appends them to the dest.
 // The current slice will be cleared.
 func (es ResourceSpansSlice) MoveAndAppendTo(dest ResourceSpansSlice) {
@@ -322,6 +330,14 @@ func (es ScopeSpansSlice) Sort(less func(a, b ScopeSpans) bool) ScopeSpansSlice 
 	return es
 }
 
+// Move moves all elements from the current slice and replaces the dest.
+// The current slice will be cleared.
+func (es ScopeSpansSlice) Move(dest ScopeSpansSlice) {
+	// We can simply move the entire vector and avoid any allocations.
+	*dest.orig = *es.orig
+	*es.orig = nil
+}
+
 // MoveAndAppendTo moves all elements from the current slice and appends them to the dest.
 // The current slice will be cleared.
 func (es ScopeSpansSlice) MoveAndAppendTo(dest ScopeSpansSlice) {
@@ -514,6 +530,14 @@ func (es SpanSlice) AppendEmpty() Span {
 func (es SpanSlice) Sort(less func(a, b Span) bool) SpanSlice {
 	sort.SliceStable(*es.orig, func(i, j int) bool { return less(es.At(i), es.At(j)) })
 	return es
+}
+
+// Move moves all elements from the current slice and replaces the dest.
+// The current slice will be cleared.
+func (es SpanSlice) Move(dest SpanSlice) {
+	// We can simply move the entire vector and avoid any allocations.
+	*dest.orig = *es.orig
+	*es.orig = nil
 }
 
 // MoveAndAppendTo moves all elements from the current slice and appends them to the dest.
@@ -833,6 +857,14 @@ func (es SpanEventSlice) Sort(less func(a, b SpanEvent) bool) SpanEventSlice {
 	return es
 }
 
+// Move moves all elements from the current slice and replaces the dest.
+// The current slice will be cleared.
+func (es SpanEventSlice) Move(dest SpanEventSlice) {
+	// We can simply move the entire vector and avoid any allocations.
+	*dest.orig = *es.orig
+	*es.orig = nil
+}
+
 // MoveAndAppendTo moves all elements from the current slice and appends them to the dest.
 // The current slice will be cleared.
 func (es SpanEventSlice) MoveAndAppendTo(dest SpanEventSlice) {
@@ -1042,6 +1074,14 @@ func (es SpanLinkSlice) AppendEmpty() SpanLink {
 func (es SpanLinkSlice) Sort(less func(a, b SpanLink) bool) SpanLinkSlice {
 	sort.SliceStable(*es.orig, func(i, j int) bool { return less(es.At(i), es.At(j)) })
 	return es
+}
+
+// Move moves all elements from the current slice and replaces the dest.
+// The current slice will be cleared.
+func (es SpanLinkSlice) Move(dest SpanLinkSlice) {
+	// We can simply move the entire vector and avoid any allocations.
+	*dest.orig = *es.orig
+	*es.orig = nil
 }
 
 // MoveAndAppendTo moves all elements from the current slice and appends them to the dest.

--- a/pdata/internal/generated_ptrace_test.go
+++ b/pdata/internal/generated_ptrace_test.go
@@ -92,6 +92,33 @@ func TestResourceSpansSlice_EnsureCapacity(t *testing.T) {
 	assert.EqualValues(t, expectedEs, foundEs)
 }
 
+func TestResourceSpansSlice_Move(t *testing.T) {
+	// assert.EqualValues(t, 1, 2)
+
+	// Test Move to empty
+	expectedSlice := generateTestResourceSpansSlice()
+	dest := NewResourceSpansSlice()
+	src := generateTestResourceSpansSlice()
+	assert.EqualValues(t, 7, src.Len())
+	src.Move(dest)
+	assert.EqualValues(t, generateTestResourceSpansSlice(), dest)
+	assert.EqualValues(t, 0, src.Len())
+	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
+
+	// Test Move empty slice
+	src.Move(dest)
+	assert.EqualValues(t, src, dest)
+	assert.EqualValues(t, 0, src.Len())
+	assert.EqualValues(t, 0, dest.Len())
+
+	// Test Move not empty slice
+	generateTestResourceSpansSlice().Move(dest)
+	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
+	for i := 0; i < expectedSlice.Len(); i++ {
+		assert.EqualValues(t, expectedSlice.At(i), dest.At(i))
+	}
+}
+
 func TestResourceSpansSlice_MoveAndAppendTo(t *testing.T) {
 	// Test MoveAndAppendTo to empty
 	expectedSlice := generateTestResourceSpansSlice()
@@ -134,6 +161,7 @@ func TestResourceSpansSlice_RemoveIf(t *testing.T) {
 	})
 	assert.Equal(t, 5, filtered.Len())
 }
+
 
 func TestResourceSpans_MoveTo(t *testing.T) {
 	ms := generateTestResourceSpans()
@@ -242,6 +270,33 @@ func TestScopeSpansSlice_EnsureCapacity(t *testing.T) {
 	assert.EqualValues(t, expectedEs, foundEs)
 }
 
+func TestScopeSpansSlice_Move(t *testing.T) {
+	// assert.EqualValues(t, 1, 2)
+
+	// Test Move to empty
+	expectedSlice := generateTestScopeSpansSlice()
+	dest := NewScopeSpansSlice()
+	src := generateTestScopeSpansSlice()
+	assert.EqualValues(t, 7, src.Len())
+	src.Move(dest)
+	assert.EqualValues(t, generateTestScopeSpansSlice(), dest)
+	assert.EqualValues(t, 0, src.Len())
+	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
+
+	// Test Move empty slice
+	src.Move(dest)
+	assert.EqualValues(t, src, dest)
+	assert.EqualValues(t, 0, src.Len())
+	assert.EqualValues(t, 0, dest.Len())
+
+	// Test Move not empty slice
+	generateTestScopeSpansSlice().Move(dest)
+	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
+	for i := 0; i < expectedSlice.Len(); i++ {
+		assert.EqualValues(t, expectedSlice.At(i), dest.At(i))
+	}
+}
+
 func TestScopeSpansSlice_MoveAndAppendTo(t *testing.T) {
 	// Test MoveAndAppendTo to empty
 	expectedSlice := generateTestScopeSpansSlice()
@@ -284,6 +339,7 @@ func TestScopeSpansSlice_RemoveIf(t *testing.T) {
 	})
 	assert.Equal(t, 5, filtered.Len())
 }
+
 
 func TestScopeSpans_MoveTo(t *testing.T) {
 	ms := generateTestScopeSpans()
@@ -392,6 +448,33 @@ func TestSpanSlice_EnsureCapacity(t *testing.T) {
 	assert.EqualValues(t, expectedEs, foundEs)
 }
 
+func TestSpanSlice_Move(t *testing.T) {
+	// assert.EqualValues(t, 1, 2)
+
+	// Test Move to empty
+	expectedSlice := generateTestSpanSlice()
+	dest := NewSpanSlice()
+	src := generateTestSpanSlice()
+	assert.EqualValues(t, 7, src.Len())
+	src.Move(dest)
+	assert.EqualValues(t, generateTestSpanSlice(), dest)
+	assert.EqualValues(t, 0, src.Len())
+	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
+
+	// Test Move empty slice
+	src.Move(dest)
+	assert.EqualValues(t, src, dest)
+	assert.EqualValues(t, 0, src.Len())
+	assert.EqualValues(t, 0, dest.Len())
+
+	// Test Move not empty slice
+	generateTestSpanSlice().Move(dest)
+	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
+	for i := 0; i < expectedSlice.Len(); i++ {
+		assert.EqualValues(t, expectedSlice.At(i), dest.At(i))
+	}
+}
+
 func TestSpanSlice_MoveAndAppendTo(t *testing.T) {
 	// Test MoveAndAppendTo to empty
 	expectedSlice := generateTestSpanSlice()
@@ -434,6 +517,7 @@ func TestSpanSlice_RemoveIf(t *testing.T) {
 	})
 	assert.Equal(t, 5, filtered.Len())
 }
+
 
 func TestSpan_MoveTo(t *testing.T) {
 	ms := generateTestSpan()
@@ -638,6 +722,33 @@ func TestSpanEventSlice_EnsureCapacity(t *testing.T) {
 	assert.EqualValues(t, expectedEs, foundEs)
 }
 
+func TestSpanEventSlice_Move(t *testing.T) {
+	// assert.EqualValues(t, 1, 2)
+
+	// Test Move to empty
+	expectedSlice := generateTestSpanEventSlice()
+	dest := NewSpanEventSlice()
+	src := generateTestSpanEventSlice()
+	assert.EqualValues(t, 7, src.Len())
+	src.Move(dest)
+	assert.EqualValues(t, generateTestSpanEventSlice(), dest)
+	assert.EqualValues(t, 0, src.Len())
+	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
+
+	// Test Move empty slice
+	src.Move(dest)
+	assert.EqualValues(t, src, dest)
+	assert.EqualValues(t, 0, src.Len())
+	assert.EqualValues(t, 0, dest.Len())
+
+	// Test Move not empty slice
+	generateTestSpanEventSlice().Move(dest)
+	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
+	for i := 0; i < expectedSlice.Len(); i++ {
+		assert.EqualValues(t, expectedSlice.At(i), dest.At(i))
+	}
+}
+
 func TestSpanEventSlice_MoveAndAppendTo(t *testing.T) {
 	// Test MoveAndAppendTo to empty
 	expectedSlice := generateTestSpanEventSlice()
@@ -680,6 +791,7 @@ func TestSpanEventSlice_RemoveIf(t *testing.T) {
 	})
 	assert.Equal(t, 5, filtered.Len())
 }
+
 
 func TestSpanEvent_MoveTo(t *testing.T) {
 	ms := generateTestSpanEvent()
@@ -798,6 +910,33 @@ func TestSpanLinkSlice_EnsureCapacity(t *testing.T) {
 	assert.EqualValues(t, expectedEs, foundEs)
 }
 
+func TestSpanLinkSlice_Move(t *testing.T) {
+	// assert.EqualValues(t, 1, 2)
+
+	// Test Move to empty
+	expectedSlice := generateTestSpanLinkSlice()
+	dest := NewSpanLinkSlice()
+	src := generateTestSpanLinkSlice()
+	assert.EqualValues(t, 7, src.Len())
+	src.Move(dest)
+	assert.EqualValues(t, generateTestSpanLinkSlice(), dest)
+	assert.EqualValues(t, 0, src.Len())
+	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
+
+	// Test Move empty slice
+	src.Move(dest)
+	assert.EqualValues(t, src, dest)
+	assert.EqualValues(t, 0, src.Len())
+	assert.EqualValues(t, 0, dest.Len())
+
+	// Test Move not empty slice
+	generateTestSpanLinkSlice().Move(dest)
+	assert.EqualValues(t, expectedSlice.Len(), dest.Len())
+	for i := 0; i < expectedSlice.Len(); i++ {
+		assert.EqualValues(t, expectedSlice.At(i), dest.At(i))
+	}
+}
+
 func TestSpanLinkSlice_MoveAndAppendTo(t *testing.T) {
 	// Test MoveAndAppendTo to empty
 	expectedSlice := generateTestSpanLinkSlice()
@@ -840,6 +979,7 @@ func TestSpanLinkSlice_RemoveIf(t *testing.T) {
 	})
 	assert.Equal(t, 5, filtered.Len())
 }
+
 
 func TestSpanLink_MoveTo(t *testing.T) {
 	ms := generateTestSpanLink()
@@ -898,6 +1038,7 @@ func TestSpanLink_DroppedAttributesCount(t *testing.T) {
 	ms.SetDroppedAttributesCount(testValDroppedAttributesCount)
 	assert.EqualValues(t, testValDroppedAttributesCount, ms.DroppedAttributesCount())
 }
+
 
 func TestSpanStatus_MoveTo(t *testing.T) {
 	ms := generateTestSpanStatus()

--- a/pdata/internal/generated_resource_test.go
+++ b/pdata/internal/generated_resource_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+
 func TestResource_MoveTo(t *testing.T) {
 	ms := generateTestResource()
 	dest := NewResource()

--- a/pdata/pcommon/generated_common_alias.go
+++ b/pdata/pcommon/generated_common_alias.go
@@ -26,7 +26,7 @@ import "go.opentelemetry.io/collector/pdata/internal"
 //
 // Must use NewInstrumentationScope function to create new instances.
 // Important: zero-initialized instance is not valid for use.
-type InstrumentationScope = internal.InstrumentationScope
+type InstrumentationScope = internal.InstrumentationScope 
 
 // NewInstrumentationScope is an alias for a function to create a new empty InstrumentationScope.
 var NewInstrumentationScope = internal.NewInstrumentationScope
@@ -43,3 +43,5 @@ type Slice = internal.Slice
 // NewSlice creates a Slice with 0 elements.
 // Can use "EnsureCapacity" to initialize with a given capacity.
 var NewSlice = internal.NewSlice
+
+

--- a/pdata/pcommon/generated_resource_alias.go
+++ b/pdata/pcommon/generated_resource_alias.go
@@ -26,7 +26,9 @@ import "go.opentelemetry.io/collector/pdata/internal"
 //
 // Must use NewResource function to create new instances.
 // Important: zero-initialized instance is not valid for use.
-type Resource = internal.Resource
+type Resource = internal.Resource 
 
 // NewResource is an alias for a function to create a new empty Resource.
 var NewResource = internal.NewResource
+
+

--- a/pdata/plog/generated_alias.go
+++ b/pdata/plog/generated_alias.go
@@ -39,7 +39,7 @@ var NewResourceLogsSlice = internal.NewResourceLogsSlice
 //
 // Must use NewResourceLogs function to create new instances.
 // Important: zero-initialized instance is not valid for use.
-type ResourceLogs = internal.ResourceLogs
+type ResourceLogs = internal.ResourceLogs 
 
 // NewResourceLogs is an alias for a function to create a new empty ResourceLogs.
 var NewResourceLogs = internal.NewResourceLogs
@@ -64,7 +64,7 @@ var NewScopeLogsSlice = internal.NewScopeLogsSlice
 //
 // Must use NewScopeLogs function to create new instances.
 // Important: zero-initialized instance is not valid for use.
-type ScopeLogs = internal.ScopeLogs
+type ScopeLogs = internal.ScopeLogs 
 
 // NewScopeLogs is an alias for a function to create a new empty ScopeLogs.
 var NewScopeLogs = internal.NewScopeLogs
@@ -90,7 +90,9 @@ var NewLogRecordSlice = internal.NewLogRecordSlice
 //
 // Must use NewLogRecord function to create new instances.
 // Important: zero-initialized instance is not valid for use.
-type LogRecord = internal.LogRecord
+type LogRecord = internal.LogRecord 
 
 // NewLogRecord is an alias for a function to create a new empty LogRecord.
 var NewLogRecord = internal.NewLogRecord
+
+

--- a/pdata/pmetric/generated_alias.go
+++ b/pdata/pmetric/generated_alias.go
@@ -39,7 +39,7 @@ var NewResourceMetricsSlice = internal.NewResourceMetricsSlice
 //
 // Must use NewResourceMetrics function to create new instances.
 // Important: zero-initialized instance is not valid for use.
-type ResourceMetrics = internal.ResourceMetrics
+type ResourceMetrics = internal.ResourceMetrics 
 
 // NewResourceMetrics is an alias for a function to create a new empty ResourceMetrics.
 var NewResourceMetrics = internal.NewResourceMetrics
@@ -64,7 +64,7 @@ var NewScopeMetricsSlice = internal.NewScopeMetricsSlice
 //
 // Must use NewScopeMetrics function to create new instances.
 // Important: zero-initialized instance is not valid for use.
-type ScopeMetrics = internal.ScopeMetrics
+type ScopeMetrics = internal.ScopeMetrics 
 
 // NewScopeMetrics is an alias for a function to create a new empty ScopeMetrics.
 var NewScopeMetrics = internal.NewScopeMetrics
@@ -90,7 +90,7 @@ var NewMetricSlice = internal.NewMetricSlice
 //
 // Must use NewMetric function to create new instances.
 // Important: zero-initialized instance is not valid for use.
-type Metric = internal.Metric
+type Metric = internal.Metric 
 
 // NewMetric is an alias for a function to create a new empty Metric.
 var NewMetric = internal.NewMetric
@@ -102,7 +102,7 @@ var NewMetric = internal.NewMetric
 //
 // Must use NewGauge function to create new instances.
 // Important: zero-initialized instance is not valid for use.
-type Gauge = internal.Gauge
+type Gauge = internal.Gauge 
 
 // NewGauge is an alias for a function to create a new empty Gauge.
 var NewGauge = internal.NewGauge
@@ -114,7 +114,7 @@ var NewGauge = internal.NewGauge
 //
 // Must use NewSum function to create new instances.
 // Important: zero-initialized instance is not valid for use.
-type Sum = internal.Sum
+type Sum = internal.Sum 
 
 // NewSum is an alias for a function to create a new empty Sum.
 var NewSum = internal.NewSum
@@ -126,20 +126,20 @@ var NewSum = internal.NewSum
 //
 // Must use NewHistogram function to create new instances.
 // Important: zero-initialized instance is not valid for use.
-type Histogram = internal.Histogram
+type Histogram = internal.Histogram 
 
 // NewHistogram is an alias for a function to create a new empty Histogram.
 var NewHistogram = internal.NewHistogram
 
 // ExponentialHistogram represents the type of a metric that is calculated by aggregating
-// as a ExponentialHistogram of all reported double measurements over a time interval.
+	// as a ExponentialHistogram of all reported double measurements over a time interval.
 //
 // This is a reference type, if passed by value and callee modifies it the
 // caller will see the modification.
 //
 // Must use NewExponentialHistogram function to create new instances.
 // Important: zero-initialized instance is not valid for use.
-type ExponentialHistogram = internal.ExponentialHistogram
+type ExponentialHistogram = internal.ExponentialHistogram 
 
 // NewExponentialHistogram is an alias for a function to create a new empty ExponentialHistogram.
 var NewExponentialHistogram = internal.NewExponentialHistogram
@@ -151,7 +151,7 @@ var NewExponentialHistogram = internal.NewExponentialHistogram
 //
 // Must use NewSummary function to create new instances.
 // Important: zero-initialized instance is not valid for use.
-type Summary = internal.Summary
+type Summary = internal.Summary 
 
 // NewSummary is an alias for a function to create a new empty Summary.
 var NewSummary = internal.NewSummary
@@ -176,7 +176,7 @@ var NewNumberDataPointSlice = internal.NewNumberDataPointSlice
 //
 // Must use NewNumberDataPoint function to create new instances.
 // Important: zero-initialized instance is not valid for use.
-type NumberDataPoint = internal.NumberDataPoint
+type NumberDataPoint = internal.NumberDataPoint 
 
 // NewNumberDataPoint is an alias for a function to create a new empty NumberDataPoint.
 var NewNumberDataPoint = internal.NewNumberDataPoint
@@ -201,7 +201,7 @@ var NewHistogramDataPointSlice = internal.NewHistogramDataPointSlice
 //
 // Must use NewHistogramDataPoint function to create new instances.
 // Important: zero-initialized instance is not valid for use.
-type HistogramDataPoint = internal.HistogramDataPoint
+type HistogramDataPoint = internal.HistogramDataPoint 
 
 // NewHistogramDataPoint is an alias for a function to create a new empty HistogramDataPoint.
 var NewHistogramDataPoint = internal.NewHistogramDataPoint
@@ -220,16 +220,16 @@ type ExponentialHistogramDataPointSlice = internal.ExponentialHistogramDataPoint
 var NewExponentialHistogramDataPointSlice = internal.NewExponentialHistogramDataPointSlice
 
 // ExponentialHistogramDataPoint is a single data point in a timeseries that describes the
-// time-varying values of a ExponentialHistogram of double values. A ExponentialHistogram contains
-// summary statistics for a population of values, it may optionally contain the
-// distribution of those values across a set of buckets.
+	// time-varying values of a ExponentialHistogram of double values. A ExponentialHistogram contains
+	// summary statistics for a population of values, it may optionally contain the
+	// distribution of those values across a set of buckets.
 //
 // This is a reference type, if passed by value and callee modifies it the
 // caller will see the modification.
 //
 // Must use NewExponentialHistogramDataPoint function to create new instances.
 // Important: zero-initialized instance is not valid for use.
-type ExponentialHistogramDataPoint = internal.ExponentialHistogramDataPoint
+type ExponentialHistogramDataPoint = internal.ExponentialHistogramDataPoint 
 
 // NewExponentialHistogramDataPoint is an alias for a function to create a new empty ExponentialHistogramDataPoint.
 var NewExponentialHistogramDataPoint = internal.NewExponentialHistogramDataPoint
@@ -241,7 +241,7 @@ var NewExponentialHistogramDataPoint = internal.NewExponentialHistogramDataPoint
 //
 // Must use NewBuckets function to create new instances.
 // Important: zero-initialized instance is not valid for use.
-type Buckets = internal.Buckets
+type Buckets = internal.Buckets 
 
 // NewBuckets is an alias for a function to create a new empty Buckets.
 var NewBuckets = internal.NewBuckets
@@ -266,7 +266,7 @@ var NewSummaryDataPointSlice = internal.NewSummaryDataPointSlice
 //
 // Must use NewSummaryDataPoint function to create new instances.
 // Important: zero-initialized instance is not valid for use.
-type SummaryDataPoint = internal.SummaryDataPoint
+type SummaryDataPoint = internal.SummaryDataPoint 
 
 // NewSummaryDataPoint is an alias for a function to create a new empty SummaryDataPoint.
 var NewSummaryDataPoint = internal.NewSummaryDataPoint
@@ -291,7 +291,7 @@ var NewValueAtQuantileSlice = internal.NewValueAtQuantileSlice
 //
 // Must use NewValueAtQuantile function to create new instances.
 // Important: zero-initialized instance is not valid for use.
-type ValueAtQuantile = internal.ValueAtQuantile
+type ValueAtQuantile = internal.ValueAtQuantile 
 
 // NewValueAtQuantile is an alias for a function to create a new empty ValueAtQuantile.
 var NewValueAtQuantile = internal.NewValueAtQuantile
@@ -319,7 +319,9 @@ var NewExemplarSlice = internal.NewExemplarSlice
 //
 // Must use NewExemplar function to create new instances.
 // Important: zero-initialized instance is not valid for use.
-type Exemplar = internal.Exemplar
+type Exemplar = internal.Exemplar 
 
 // NewExemplar is an alias for a function to create a new empty Exemplar.
 var NewExemplar = internal.NewExemplar
+
+

--- a/pdata/ptrace/generated_alias.go
+++ b/pdata/ptrace/generated_alias.go
@@ -39,7 +39,7 @@ var NewResourceSpansSlice = internal.NewResourceSpansSlice
 //
 // Must use NewResourceSpans function to create new instances.
 // Important: zero-initialized instance is not valid for use.
-type ResourceSpans = internal.ResourceSpans
+type ResourceSpans = internal.ResourceSpans 
 
 // NewResourceSpans is an alias for a function to create a new empty ResourceSpans.
 var NewResourceSpans = internal.NewResourceSpans
@@ -64,7 +64,7 @@ var NewScopeSpansSlice = internal.NewScopeSpansSlice
 //
 // Must use NewScopeSpans function to create new instances.
 // Important: zero-initialized instance is not valid for use.
-type ScopeSpans = internal.ScopeSpans
+type ScopeSpans = internal.ScopeSpans 
 
 // NewScopeSpans is an alias for a function to create a new empty ScopeSpans.
 var NewScopeSpans = internal.NewScopeSpans
@@ -90,7 +90,7 @@ var NewSpanSlice = internal.NewSpanSlice
 //
 // Must use NewSpan function to create new instances.
 // Important: zero-initialized instance is not valid for use.
-type Span = internal.Span
+type Span = internal.Span 
 
 // NewSpan is an alias for a function to create a new empty Span.
 var NewSpan = internal.NewSpan
@@ -116,7 +116,7 @@ var NewSpanEventSlice = internal.NewSpanEventSlice
 //
 // Must use NewSpanEvent function to create new instances.
 // Important: zero-initialized instance is not valid for use.
-type SpanEvent = internal.SpanEvent
+type SpanEvent = internal.SpanEvent 
 
 // NewSpanEvent is an alias for a function to create a new empty SpanEvent.
 var NewSpanEvent = internal.NewSpanEvent
@@ -143,7 +143,7 @@ var NewSpanLinkSlice = internal.NewSpanLinkSlice
 //
 // Must use NewSpanLink function to create new instances.
 // Important: zero-initialized instance is not valid for use.
-type SpanLink = internal.SpanLink
+type SpanLink = internal.SpanLink 
 
 // NewSpanLink is an alias for a function to create a new empty SpanLink.
 var NewSpanLink = internal.NewSpanLink
@@ -156,7 +156,9 @@ var NewSpanLink = internal.NewSpanLink
 //
 // Must use NewSpanStatus function to create new instances.
 // Important: zero-initialized instance is not valid for use.
-type SpanStatus = internal.SpanStatus
+type SpanStatus = internal.SpanStatus 
 
 // NewSpanStatus is an alias for a function to create a new empty SpanStatus.
 var NewSpanStatus = internal.NewSpanStatus
+
+


### PR DESCRIPTION
**Description:**
Add `Move` function for slices in pdata so that we can replace span events in a span. This is useful to make a filter processor.
Please refer to #5431 for more detailed usage example.

**Link to tracking Issue:**
#5431 

**Testing:**
Unit tests added in pdata/internal/cmd/pdatagen/internal/base_slices.go -> Test${structtName}_Move.
Tested in all slices generated by `go run pdata/internal/cmd/pdagtagen/main.go` -> `make test`
