### PR TITLE
ExtensionDefaultConfigFunc should be ExtensionCreateDefaultConfigFunc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
   - Package `expandmapconverter` -> `expandconverter`
   - Package `filemapprovider` -> `fileprovider`
   - Package `overwritepropertiesmapconverter` -> `overwritepropertiesconverter`
+- Deprecate `component.ExtensionDefaultConfigFunc` in favor of `component.ExtensionCreateDefaultConfigFunc` (#5451)
 
 ### 💡 Enhancements 💡
 

--- a/component/extension.go
+++ b/component/extension.go
@@ -52,6 +52,9 @@ type ExtensionCreateSettings struct {
 	BuildInfo BuildInfo
 }
 
+// Deprecated: [v0.53.0] use ExtensionCreateDefaultConfigFunc.
+type ExtensionDefaultConfigFunc = ExtensionCreateDefaultConfigFunc
+
 // ExtensionCreateDefaultConfigFunc is the equivalent of component.ExtensionFactory.CreateDefaultConfig()
 type ExtensionCreateDefaultConfigFunc func() config.Extension
 


### PR DESCRIPTION
This resolved the issue#5437, and better align with the names of following types from package **component** : 

ExporterCreateDefaultConfigFunc
ProcessorCreateDefaultConfigFunc
ReceiverCreateDefaultConfigFunc
ExtensionDefaultConfigFunc