### PR TITLE
[exporterhelper] Remove unused function from the internal interface ProducerConsumerQueue

### DIFF
--- a/exporter/exporterhelper/internal/bounded_memory_queue.go
+++ b/exporter/exporterhelper/internal/bounded_memory_queue.go
@@ -92,7 +92,7 @@ func (q *boundedMemoryQueue) Produce(item interface{}) bool {
 	// we might have two concurrent backing queues at the moment
 	// their combined size is stored in q.size, and their combined capacity
 	// should match the capacity of the new queue
-	if q.Size() >= q.Capacity() {
+	if q.size.Load() >= q.capacity {
 		// note that all items will be dropped if the capacity is 0
 		q.onDroppedItem(item)
 		return false
@@ -123,9 +123,4 @@ func (q *boundedMemoryQueue) Stop() {
 // Size returns the current size of the queue
 func (q *boundedMemoryQueue) Size() int {
 	return int(q.size.Load())
-}
-
-// Capacity returns capacity of the queue
-func (q *boundedMemoryQueue) Capacity() int {
-	return int(q.capacity)
 }

--- a/exporter/exporterhelper/internal/bounded_memory_queue_test.go
+++ b/exporter/exporterhelper/internal/bounded_memory_queue_test.go
@@ -32,7 +32,6 @@ import (
 // by holding a startLock before submitting items to the queue.
 func helper(t *testing.T, startConsumers func(q ProducerConsumerQueue, consumerFn func(item interface{}))) {
 	q := NewBoundedMemoryQueue(1, func(item interface{}) {})
-	assert.Equal(t, 1, q.Capacity())
 
 	var startLock sync.Mutex
 

--- a/exporter/exporterhelper/internal/persistent_queue.go
+++ b/exporter/exporterhelper/internal/persistent_queue.go
@@ -89,9 +89,3 @@ func (pq *persistentQueue) Stop() {
 func (pq *persistentQueue) Size() int {
 	return int(pq.storage.size())
 }
-
-// Capacity returns the current capacity of persistent queue.
-// Currently, it is unlimited but in the future it can take into account available storage space or configured limits
-func (pq *persistentQueue) Capacity() int {
-	return pq.Size() + 1
-}

--- a/exporter/exporterhelper/internal/producer_consumer_queue.go
+++ b/exporter/exporterhelper/internal/producer_consumer_queue.go
@@ -32,8 +32,6 @@ type ProducerConsumerQueue interface {
 	Produce(item interface{}) bool
 	// Size returns the current Size of the queue
 	Size() int
-	// Capacity returns capacity of the queue
-	Capacity() int
 	// Stop stops all consumers, as well as the length reporter if started,
 	// and releases the items channel. It blocks until all consumers have stopped.
 	Stop()


### PR DESCRIPTION
Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
