### PR TITLE
Replace NewRetrievedFromMap with NewRetrieved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
   - `config.Map` -> `confmap.ConfMap`
   - `config.MapProvider` -> `confmap.Provider`
   - `config.Received` -> `confmap.Received`
+  - `config.NewReceivedFromMap` -> `confmap.NewReceived`
   - `config.CloseFunc` -> `confmap.CloseFunc`
   - `config.ChangeEvent` -> `confmap.ChangeEvent`
   - `config.MapConverter` -> `confmap.Converter`

--- a/config/moved_configmap.go
+++ b/config/moved_configmap.go
@@ -47,8 +47,11 @@ type RetrievedOption = confmap.RetrievedOption
 // Deprecated: [v0.53.0] use confmap.WithRetrievedClose
 var WithRetrievedClose = confmap.WithRetrievedClose
 
-// Deprecated: [v0.53.0] use confmap.NewRetrievedFromMap
-var NewRetrievedFromMap = confmap.NewRetrievedFromMap
+// Deprecated: [v0.53.0] use confmap.NewRetrieved
+func NewRetrievedFromMap(conf *confmap.Conf, opts ...confmap.RetrievedOption) confmap.Retrieved {
+	ret, _ := confmap.NewRetrieved(conf.ToStringMap(), opts...)
+	return ret
+}
 
 // Deprecated: [v0.53.0] use confmap.WatcherFunc
 type WatcherFunc = confmap.WatcherFunc

--- a/confmap/confmap_test.go
+++ b/confmap/confmap_test.go
@@ -104,7 +104,7 @@ func TestToStringMap(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			conf := newConfFromFile(t, test.fileName)
-			assert.Equal(t, test.stringMap, conf.ToStringMap())
+			assert.Equal(t, test.stringMap, conf)
 		})
 	}
 }
@@ -221,12 +221,12 @@ func TestMapKeyStringToMapKeyTextUnmarshalerHookFuncErrorUnmarshal(t *testing.T)
 }
 
 // newConfFromFile creates a new Conf by reading the given file.
-func newConfFromFile(t *testing.T, fileName string) *Conf {
+func newConfFromFile(t *testing.T, fileName string) map[string]interface{} {
 	content, err := ioutil.ReadFile(filepath.Clean(fileName))
 	require.NoErrorf(t, err, "unable to read the file %v", fileName)
 
 	var data map[string]interface{}
 	require.NoError(t, yaml.Unmarshal(content, &data), "unable to parse yaml")
 
-	return NewFromStringMap(data)
+	return NewFromStringMap(data).ToStringMap()
 }

--- a/confmap/provider.go
+++ b/confmap/provider.go
@@ -100,17 +100,13 @@ func WithRetrievedClose(closeFunc CloseFunc) RetrievedOption {
 	}
 }
 
-// NewRetrievedFromMap returns a new Retrieved instance that contains a Map data.
-// * conf the Map that will be merged to the given map in the MergeTo.
-// * CloseFunc specifies a function to be invoked when the configuration for which it was
-//   used to retrieve values is no longer in use and should close and release any watchers
-//	 that it may have created.
-func NewRetrievedFromMap(conf *Conf, opts ...RetrievedOption) Retrieved {
+// NewRetrieved returns a new Retrieved instance that contains the data from the raw deserialized config.
+func NewRetrieved(rawConf map[string]interface{}, opts ...RetrievedOption) (Retrieved, error) {
 	set := retrievedSettings{}
 	for _, opt := range opts {
 		opt(&set)
 	}
-	return Retrieved{conf: conf, closeFunc: set.closeFunc}
+	return Retrieved{conf: NewFromStringMap(rawConf), closeFunc: set.closeFunc}, nil
 }
 
 // AsMap returns the retrieved configuration parsed as a Map.

--- a/confmap/provider/envprovider/provider.go
+++ b/confmap/provider/envprovider/provider.go
@@ -40,6 +40,7 @@ func (emp *provider) Retrieve(_ context.Context, uri string, _ confmap.WatcherFu
 	if !strings.HasPrefix(uri, schemeName+":") {
 		return confmap.Retrieved{}, fmt.Errorf("%q uri is not supported by %q provider", uri, schemeName)
 	}
+
 	return internal.NewRetrievedFromYAML([]byte(os.Getenv(uri[len(schemeName)+1:])))
 }
 

--- a/confmap/provider/internal/provider.go
+++ b/confmap/provider/internal/provider.go
@@ -28,5 +28,5 @@ func NewRetrievedFromYAML(yamlBytes []byte, opts ...confmap.RetrievedOption) (co
 	if err := yaml.Unmarshal(yamlBytes, &rawConf); err != nil {
 		return confmap.Retrieved{}, err
 	}
-	return confmap.NewRetrievedFromMap(confmap.NewFromStringMap(rawConf), opts...), nil
+	return confmap.NewRetrieved(rawConf, opts...)
 }

--- a/confmap/provider_test.go
+++ b/confmap/provider_test.go
@@ -23,21 +23,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestNewRetrievedFromMap(t *testing.T) {
-	conf := New()
-	ret := NewRetrievedFromMap(conf)
+func TestNewRetrieved(t *testing.T) {
+	ret, err := NewRetrieved(nil)
+	require.NoError(t, err)
 	retMap, err := ret.AsMap()
 	require.NoError(t, err)
-	assert.Same(t, conf, retMap)
+	assert.Equal(t, New(), retMap)
 	assert.NoError(t, ret.Close(context.Background()))
 }
 
-func TestNewRetrievedFromMapWithOptions(t *testing.T) {
+func TestNewRetrievedWithOptions(t *testing.T) {
 	want := errors.New("my error")
-	conf := New()
-	ret := NewRetrievedFromMap(conf, WithRetrievedClose(func(context.Context) error { return want }))
+	ret, err := NewRetrieved(nil, WithRetrievedClose(func(context.Context) error { return want }))
+	require.NoError(t, err)
 	retMap, err := ret.AsMap()
 	require.NoError(t, err)
-	assert.Same(t, conf, retMap)
+	assert.Equal(t, New(), retMap)
 	assert.Equal(t, want, ret.Close(context.Background()))
 }


### PR DESCRIPTION
It is ok to change NewRetrievedFromMap to NewRetrieved since it was just moved, not yet released. This is a step towards supporting providing any value type.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
