### PR TITLE
Add linux-arm architecture to cross build tests in CI

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -184,6 +184,8 @@ jobs:
             goarch: amd64
           - goos: linux
             goarch: arm64
+          - goos: linux
+            goarch: arm
           - goos: windows
             goarch: 386
           - goos: windows

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 ### 💡 Enhancements 💡
 
 - Move `service.mapResolver` to `confmap.Resolver` (#5444)
+- Add `linux-arm` architecture to cross build tests in CI (#5472)
 
 ### 🧰 Bug fixes 🧰
 


### PR DESCRIPTION

**Description:** 
Added linux arm to "cross-build-collector" matrix in `build-ant-test.yml` action for CI.
This will allow adding release for armv7 to dockerhub so the collector can run on raspberry pi.
This architecture is already tested [in contrib CI](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/6297dffe6a7728d33715e8189bbc75e82a48ddc4/.github/workflows/build-and-test.yml#L288).

**Link to tracking Issue:**
See full discussion [here](https://github.com/open-telemetry/opentelemetry-collector-releases/issues/105). Thank you @mx-psi for the help with this :)

**Testing:**
This PR invokes more tests in CI

