### PR TITLE
fix format error of config file for otel local example

### DIFF
--- a/examples/local/otel-config.yaml
+++ b/examples/local/otel-config.yaml
@@ -21,7 +21,7 @@ processors:
 
 exporters:
   logging:
-    logLevel: debug
+    loglevel: debug
 
 service:
   pipelines:


### PR DESCRIPTION
Signed-off-by: Ziqi Zhao <zhaoziqi9146@gmail.com>

**Description:** 
Fix the format error of configuration file in local examples, the right format can be saw in https://github.com/open-telemetry/opentelemetry-collector/blob/main/exporter/loggingexporter/README.md. 


