### PR TITLE
Cleanup extension builder, avoid exposing private members

### DIFF
--- a/service/host.go
+++ b/service/host.go
@@ -31,7 +31,7 @@ type serviceHost struct {
 	builtExporters  builder.Exporters
 	builtReceivers  builder.Receivers
 	builtPipelines  builder.BuiltPipelines
-	builtExtensions extensions.Extensions
+	builtExtensions *extensions.BuiltExtensions
 }
 
 // ReportFatalError is used to report to the host that the receiver encountered

--- a/service/service.go
+++ b/service/service.go
@@ -64,7 +64,7 @@ func newService(set *settings) (*service, error) {
 		return nil, fmt.Errorf("failed to get logger: %w", err)
 	}
 
-	if srv.host.builtExtensions, err = extensions.Build(srv.telemetry, srv.buildInfo, srv.config, srv.host.factories.Extensions); err != nil {
+	if srv.host.builtExtensions, err = extensions.Build(context.Background(), srv.telemetry, srv.buildInfo, srv.config.Extensions, srv.config.Service.Extensions, srv.host.factories.Extensions); err != nil {
 		return nil, fmt.Errorf("cannot build extensions: %w", err)
 	}
 


### PR DESCRIPTION
This PR also remove the use of the deprecated `config.Config` in the extension builder package.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
