### PR TITLE
add prepare-release make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ TOOLS_MOD_DIR := ./internal/tools
 
 GOOS=$(shell $(GOCMD) env GOOS)
 GOARCH=$(shell $(GOCMD) env GOARCH)
+GH := $(shell which gh)
 
 # TODO: Find a way to configure this in the generated code, currently no effect.
 BUILD_INFO_IMPORT_PATH=go.opentelemetry.io/collector/internal/version
@@ -406,4 +407,9 @@ endif
 	git add .
 	git commit -m "add multimod changes" || (echo "no multimod changes to commit")
 	git push fork opentelemetry-collector-bot/release-$(RELEASE_CANDIDATE)
+	@if [ -z "$(GH)" ]; then \
+		echo "'gh' command not found, can't submit the PR on your behalf."; \
+		exit 1; \
+	fi
 	gh pr create --title "[chore] prepare release $(RELEASE_CANDIDATE)"
+

--- a/Makefile
+++ b/Makefile
@@ -369,3 +369,41 @@ multimod-verify: install-tools
 multimod-prerelease: install-tools
 	multimod prerelease -v ./versions.yaml -m collector-core
 	$(MAKE) gotidy
+
+.PHONY: prepare-release
+prepare-release:
+ifdef PREVIOUS_VERSION
+	@echo "Previous version $(PREVIOUS_VERSION)"
+else
+	@echo "PREVIOUS_VERSION not defined"
+	@echo "usage: make prepare-release RELEASE_CANDIDATE=<version eg 0.53.0> PREVIOUS_VERSION=<version eg 0.52.0>"
+	exit 1
+endif
+ifdef RELEASE_CANDIDATE
+	@echo "Preparing release $(RELEASE_CANDIDATE)"
+else
+	@echo "RELEASE_CANDIDATE not defined"
+	@echo "usage: make prepare-release RELEASE_CANDIDATE=<version eg 0.53.0> PREVIOUS_VERSION=<version eg 0.52.0>"
+	exit 1
+endif
+	# ensure a clean branch
+	git diff -s --exit-code || (echo "local repository not clean"; exit 1)
+	# TODO: update changelog
+	# update versions.yaml config.go builder-config.yaml
+	sed -i.bak 's/$(PREVIOUS_VERSION)/$(RELEASE_CANDIDATE)/g' versions.yaml
+	sed -i.bak 's/$(PREVIOUS_VERSION)/$(RELEASE_CANDIDATE)/g' ./cmd/builder/internal/builder/config.go
+	sed -i.bak 's/$(PREVIOUS_VERSION)/$(RELEASE_CANDIDATE)/g' ./cmd/otelcorecol/builder-config.yaml
+	sed -i.bak 's/$(PREVIOUS_VERSION)/$(RELEASE_CANDIDATE)/g' examples/k8s/otel-config.yaml
+	find . -name "*.bak" -type f -delete
+	# regenerate files
+	$(MAKE) genotelcorecol
+	# commit changes before running multimod
+	git checkout -b opentelemetry-collector-bot/release-$(RELEASE_CANDIDATE)
+	git add .
+	git commit -m "prepare release $(RELEASE_CANDIDATE)"
+	$(MAKE) multimod-prerelease
+	# commit multimod changes
+	git add .
+	git commit -m "add multimod changes" || (echo "no multimod changes to commit")
+	git push fork opentelemetry-collector-bot/release-$(RELEASE_CANDIDATE)
+	gh pr create --title "[chore] prepare release $(RELEASE_CANDIDATE)"

--- a/docs/release.md
+++ b/docs/release.md
@@ -39,17 +39,7 @@ It is possible that a core approver isn't a contrib approver. In that case, the 
 
     * Update CHANGELOG.md file and rename the Unreleased section to the new release name. Add a new unreleased section at top. Use commit history feature to get the list of commits since the last release to help understand what should be in the release notes, e.g.: https://github.com/open-telemetry/opentelemetry-collector/compare/v0.44.0...main.
 
-    * Use multimod to update the version of the collector package
-      * Update [versions.yaml](https://github.com/open-telemetry/opentelemetry-collector/blob/main/versions.yaml) and commit it locally
-      * Run `make multimod-prerelease` (it might fail if you didn't commit the change above)
-
-    * Update the collector version in the collector builder to the new release in `./cmd/builder/internal/builder/config.go`.
-
-    * Update the collector version in the manifest used by `make run` to the new release in `./cmd/otelcorecol/builder-config.yaml` and run `make genotelcorecol`.
-
-    * Update the collector version in the `examples/k8s/otel-config.yaml` 
-
-    * Submit a PR with the changes and get the PR approved and merged.
+    * Run `make prepare-release PREVIOUS_VERSION=0.52.0 RELEASE_CANDIDATE=0.53.0`
 
     * Ensure the `main` branch builds successfully.
 


### PR DESCRIPTION
make prepare-release does the following:
- checks the local repository is clean
- search/replace PREVIOUS_VERSION with RELEASE_CANDIDATE
- runs make genotelcorecol
- creates a commit on a new branch
- runs make multimod-prerelease
- commits the changes to the branch
- creates a PR
