### PR TITLE
Fix collector tests on windows. The locations gets set in a different test.

### DIFF
--- a/service/collector_windows.go
+++ b/service/collector_windows.go
@@ -19,6 +19,7 @@ package service // import "go.opentelemetry.io/collector/service"
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"os"
 	"syscall"
@@ -37,11 +38,12 @@ import (
 type windowsService struct {
 	settings CollectorSettings
 	col      *Collector
+	flags    *flag.FlagSet
 }
 
 // NewSvcHandler constructs a new svc.Handler using the given CollectorSettings.
 func NewSvcHandler(set CollectorSettings) svc.Handler {
-	return &windowsService{settings: set}
+	return &windowsService{settings: set, flags: flags()}
 }
 
 // Execute implements https://godoc.org/golang.org/x/sys/windows/svc#Handler
@@ -90,12 +92,12 @@ func (s *windowsService) Execute(args []string, requests <-chan svc.ChangeReques
 
 func (s *windowsService) start(elog *eventlog.Log, colErrorChannel chan error) error {
 	// Parse all the flags manually.
-	if err := flags().Parse(os.Args[1:]); err != nil {
+	if err := s.flags.Parse(os.Args[1:]); err != nil {
 		return err
 	}
 	featuregate.GetRegistry().Apply(gatesList)
 	var err error
-	s.col, err = newWithWindowsEventLogCore(s.settings, elog)
+	s.col, err = newWithWindowsEventLogCore(s.settings, s.flags, elog)
 	if err != nil {
 		return err
 	}
@@ -138,13 +140,13 @@ func openEventLog(serviceName string) (*eventlog.Log, error) {
 	return elog, nil
 }
 
-func newWithWindowsEventLogCore(set CollectorSettings, elog *eventlog.Log) (*Collector, error) {
+func newWithWindowsEventLogCore(set CollectorSettings, flags *flag.FlagSet, elog *eventlog.Log) (*Collector, error) {
 	if set.ConfigProvider == nil {
 		var err error
-		cfgSet := newDefaultConfigProviderSettings(getConfigFlag())
+		cfgSet := newDefaultConfigProviderSettings(getConfigFlag(flags))
 		// Append the "overwrite properties converter" as the first converter.
 		cfgSet.MapConverters = append(
-			[]confmap.Converter{overwritepropertiesconverter.New(getSetFlag())},
+			[]confmap.Converter{overwritepropertiesconverter.New(getSetFlag(flags))},
 			cfgSet.MapConverters...)
 		set.ConfigProvider, err = NewConfigProvider(cfgSet)
 		if err != nil {

--- a/service/collector_windows_test.go
+++ b/service/collector_windows_test.go
@@ -31,6 +31,8 @@ import (
 )
 
 func TestNewSvcHandler(t *testing.T) {
+	oldArgs := os.Args
+	defer func() { os.Args = oldArgs }()
 	os.Args = []string{"otelcol", "--config", filepath.Join("testdata", "otelcol-nop.yaml")}
 
 	factories, err := componenttest.NopFactories()

--- a/service/command.go
+++ b/service/command.go
@@ -24,6 +24,7 @@ import (
 
 // NewCommand constructs a new cobra.Command using the given CollectorSettings.
 func NewCommand(set CollectorSettings) *cobra.Command {
+	flagSet := flags()
 	rootCmd := &cobra.Command{
 		Use:          set.BuildInfo.Command,
 		Version:      set.BuildInfo.Version,
@@ -32,10 +33,10 @@ func NewCommand(set CollectorSettings) *cobra.Command {
 			featuregate.GetRegistry().Apply(gatesList)
 			if set.ConfigProvider == nil {
 				var err error
-				cfgSet := newDefaultConfigProviderSettings(getConfigFlag())
+				cfgSet := newDefaultConfigProviderSettings(getConfigFlag(flagSet))
 				// Append the "overwrite properties converter" as the first converter.
 				cfgSet.MapConverters = append(
-					[]confmap.Converter{overwritepropertiesconverter.New(getSetFlag())},
+					[]confmap.Converter{overwritepropertiesconverter.New(getSetFlag(flagSet))},
 					cfgSet.MapConverters...)
 				set.ConfigProvider, err = NewConfigProvider(cfgSet)
 				if err != nil {
@@ -50,6 +51,6 @@ func NewCommand(set CollectorSettings) *cobra.Command {
 		},
 	}
 
-	rootCmd.Flags().AddGoFlagSet(flags())
+	rootCmd.Flags().AddGoFlagSet(flagSet)
 	return rootCmd
 }

--- a/service/flags.go
+++ b/service/flags.go
@@ -21,11 +21,14 @@ import (
 	"go.opentelemetry.io/collector/service/featuregate"
 )
 
+const (
+	configFlag = "config"
+	setFlag    = "set"
+)
+
 var (
 	// Command-line flag that control the configuration file.
-	configFlag = new(stringArrayValue)
-	setFlag    = new(stringArrayValue)
-	gatesList  = featuregate.FlagValue{}
+	gatesList = featuregate.FlagValue{}
 )
 
 type stringArrayValue struct {
@@ -44,10 +47,10 @@ func (s *stringArrayValue) String() string {
 func flags() *flag.FlagSet {
 	flagSet := new(flag.FlagSet)
 
-	flagSet.Var(configFlag, "config", "Locations to the config file(s), note that only a"+
+	flagSet.Var(new(stringArrayValue), configFlag, "Locations to the config file(s), note that only a"+
 		" single location can be set per flag entry e.g. `-config=file:/path/to/first --config=file:path/to/second`.")
 
-	flagSet.Var(setFlag, "set",
+	flagSet.Var(new(stringArrayValue), setFlag,
 		"Set arbitrary component config property. The component has to be defined in the config file and the flag"+
 			" has a higher precedence. Array config properties are overridden and maps are joined, note that only a single"+
 			" (first) array property can be set e.g. -set=processors.attributes.actions.key=some_key. Example --set=processors.batch.timeout=2s")
@@ -60,10 +63,10 @@ func flags() *flag.FlagSet {
 	return flagSet
 }
 
-func getConfigFlag() []string {
-	return configFlag.values
+func getConfigFlag(flagSet *flag.FlagSet) []string {
+	return flagSet.Lookup(configFlag).Value.(*stringArrayValue).values
 }
 
-func getSetFlag() []string {
-	return setFlag.values
+func getSetFlag(flagSet *flag.FlagSet) []string {
+	return flagSet.Lookup(setFlag).Value.(*stringArrayValue).values
 }


### PR DESCRIPTION
Because we are not cleaning up the os.Args the NewCommand tests which are also parsing the flags (via os.Args) set the config flag even if that was not expected.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
