### PR TITLE
Ensure extensions are only shut down once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 ### 🧰 Bug fixes 🧰
 
 - Update sum field of exponential histograms to make it optional (#5530)
+- Remove redundant extension shutdown call (#5532)
 
 ## v0.53.0 Beta
 

--- a/service/service.go
+++ b/service/service.go
@@ -145,11 +145,6 @@ func (srv *service) Shutdown(ctx context.Context) error {
 		errs = multierr.Append(errs, fmt.Errorf("failed to shutdown extensions: %w", err))
 	}
 
-	srv.telemetry.Logger.Info("Stopping extensions...")
-	if err := srv.host.builtExtensions.ShutdownAll(ctx); err != nil {
-		errs = multierr.Append(errs, fmt.Errorf("failed to shutdown extensions: %w", err))
-	}
-
 	// TODO: Shutdown TracerProvider, MeterProvider, and Sync Logger.
 	return errs
 }


### PR DESCRIPTION
**Description:**
Fixing a bug - Removes a repeated call to shut down extensions introduced in 1aa0e5ab3667721f282b557346779cb4ebec4903