### PR TITLE
[docs] move current triagers to emeritus

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,13 +110,15 @@ See the [Contributing Guide](CONTRIBUTING.md) for details.
 Here is a list of community roles with current and previous members:
 
 - Triagers ([@open-telemetry/collector-triagers](https://github.com/orgs/open-telemetry/teams/collector-triagers)):
-   - [Alolita Sharma](https://github.com/alolita), AWS
-   - [Punya Biswal](https://github.com/punya), Google
-   - [Steve Flanders](https://github.com/flands), Splunk
+
+  - Actively seeking contributors to triage issues
 
 - Emeritus Triagers:
 
    - [Andrew Hsu](https://github.com/andrewhsu), Lightstep
+   - [Alolita Sharma](https://github.com/alolita), AWS
+   - [Punya Biswal](https://github.com/punya), Google
+   - [Steve Flanders](https://github.com/flands), Splunk
 
 - Approvers ([@open-telemetry/collector-approvers](https://github.com/orgs/open-telemetry/teams/collector-approvers)):
 


### PR DESCRIPTION
Thanks for your contributions @alolita @punya @flands!

Please provide feedback here if you have bandwidth to continue triaging for the collector/collector-contrib repositories.