### PR TITLE
Add config marshaler.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Deprecate `p[metric|log|trace]otlp.RegiserServer` in favor of `p[metric|log|trace]otlp.RegiserGRPCServer` (#6180)
 
+### 💡 Enhancements 💡
+
+- Add config marshaler (#5566)
+
 ## v0.61.0 Beta
 
 ### 🛑 Breaking changes 🛑

--- a/config/configtelemetry/configtelemetry.go
+++ b/config/configtelemetry/configtelemetry.go
@@ -41,6 +41,7 @@ const (
 // that every component should generate.
 type Level int32
 
+var _ encoding.TextMarshaler = (*Level)(nil)
 var _ encoding.TextUnmarshaler = (*Level)(nil)
 
 func (l Level) String() string {
@@ -55,6 +56,11 @@ func (l Level) String() string {
 		return levelDetailedStr
 	}
 	return "unknown"
+}
+
+// MarshalText marshals Level to text.
+func (l Level) MarshalText() (text []byte, err error) {
+	return []byte(l.String()), nil
 }
 
 // UnmarshalText unmarshalls text to a Level.

--- a/config/configtelemetry/configtelemetry_test.go
+++ b/config/configtelemetry/configtelemetry_test.go
@@ -103,6 +103,9 @@ func TestLevelString(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.str, func(t *testing.T) {
 			assert.Equal(t, test.str, test.level.String())
+			got, err := test.level.MarshalText()
+			assert.NoError(t, err)
+			assert.Equal(t, test.str, string(got))
 		})
 	}
 }

--- a/config/identifiable.go
+++ b/config/identifiable.go
@@ -69,6 +69,12 @@ func (id ComponentID) Name() string {
 	return id.nameVal
 }
 
+// MarshalText implements the encoding.TextMarshaler interface.
+// This marshals the type and name as one string in the config.
+func (id ComponentID) MarshalText() (text []byte, err error) {
+	return []byte(id.String()), nil
+}
+
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (id *ComponentID) UnmarshalText(text []byte) error {
 	idStr := string(text)

--- a/config/identifiable_test.go
+++ b/config/identifiable_test.go
@@ -76,3 +76,10 @@ func TestIDFromString(t *testing.T) {
 		})
 	}
 }
+
+func TestMarshalText(t *testing.T) {
+	id := NewComponentIDWithName("test", "name")
+	got, err := id.MarshalText()
+	assert.NoError(t, err)
+	assert.Equal(t, id.String(), string(got))
+}

--- a/confmap/internal/mapstructure/encoder.go
+++ b/confmap/internal/mapstructure/encoder.go
@@ -1,0 +1,234 @@
+// Copyright  The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mapstructure // import "go.opentelemetry.io/collector/confmap/internal/mapstructure"
+
+import (
+	"encoding"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/mitchellh/mapstructure"
+)
+
+const (
+	tagNameMapStructure = "mapstructure"
+	optionSeparator     = ","
+	optionOmitEmpty     = "omitempty"
+	optionSquash        = "squash"
+	optionRemain        = "remain"
+	optionSkip          = "-"
+)
+
+var (
+	errNonStringEncodedKey = errors.New("non string-encoded key")
+)
+
+// tagInfo stores the mapstructure tag details.
+type tagInfo struct {
+	name      string
+	omitEmpty bool
+	squash    bool
+}
+
+// An Encoder takes structured data and converts it into an
+// interface following the mapstructure tags.
+type Encoder struct {
+	config *EncoderConfig
+}
+
+// EncoderConfig is the configuration used to create a new encoder.
+type EncoderConfig struct {
+	// EncodeHook, if set, is a way to provide custom encoding. It
+	// will be called before structs and primitive types.
+	EncodeHook mapstructure.DecodeHookFunc
+}
+
+// New returns a new encoder for the configuration.
+func New(cfg *EncoderConfig) *Encoder {
+	return &Encoder{config: cfg}
+}
+
+// Encode takes the input and uses reflection to encode it to
+// an interface based on the mapstructure spec.
+func (e *Encoder) Encode(input interface{}) (interface{}, error) {
+	return e.encode(reflect.ValueOf(input))
+}
+
+// encode processes the value based on the reflect.Kind.
+func (e *Encoder) encode(value reflect.Value) (interface{}, error) {
+	if value.IsValid() {
+		switch value.Kind() {
+		case reflect.Interface, reflect.Ptr:
+			return e.encode(value.Elem())
+		case reflect.Map:
+			return e.encodeMap(value)
+		case reflect.Slice:
+			return e.encodeSlice(value)
+		case reflect.Struct:
+			return e.encodeStruct(value)
+		default:
+			return e.encodeHook(value)
+		}
+	}
+	return nil, nil
+}
+
+// encodeHook calls the EncodeHook in the EncoderConfig with the value passed in.
+// This is called before processing structs and for primitive data types.
+func (e *Encoder) encodeHook(value reflect.Value) (interface{}, error) {
+	if e.config != nil && e.config.EncodeHook != nil {
+		out, err := mapstructure.DecodeHookExec(e.config.EncodeHook, value, value)
+		if err != nil {
+			return nil, fmt.Errorf("error running encode hook: %w", err)
+		}
+		return out, nil
+	}
+	return value.Interface(), nil
+}
+
+// encodeStruct encodes the struct by iterating over the fields, getting the
+// mapstructure tagInfo for each exported field, and encoding the value.
+func (e *Encoder) encodeStruct(value reflect.Value) (interface{}, error) {
+	if value.Kind() != reflect.Struct {
+		return nil, &reflect.ValueError{
+			Method: "encodeStruct",
+			Kind:   value.Kind(),
+		}
+	}
+	out, err := e.encodeHook(value)
+	if err != nil {
+		return nil, err
+	}
+	value = reflect.ValueOf(out)
+	// if the output of encodeHook is no longer a struct,
+	// call encode against it.
+	if value.Kind() != reflect.Struct {
+		return e.encode(value)
+	}
+	result := make(map[string]interface{})
+	for i := 0; i < value.NumField(); i++ {
+		field := value.Field(i)
+		if field.CanInterface() {
+			info := getTagInfo(value.Type().Field(i))
+			if (info.omitEmpty && field.IsZero()) || info.name == optionSkip {
+				continue
+			}
+			encoded, err := e.encode(field)
+			if err != nil {
+				return nil, fmt.Errorf("error encoding field %q: %w", info.name, err)
+			}
+			if info.squash {
+				if m, ok := encoded.(map[string]interface{}); ok {
+					for k, v := range m {
+						result[k] = v
+					}
+				}
+			} else {
+				result[info.name] = encoded
+			}
+		}
+	}
+	return result, nil
+}
+
+// encodeSlice iterates over the slice and encodes each of the elements.
+func (e *Encoder) encodeSlice(value reflect.Value) (interface{}, error) {
+	if value.Kind() != reflect.Slice {
+		return nil, &reflect.ValueError{
+			Method: "encodeSlice",
+			Kind:   value.Kind(),
+		}
+	}
+	result := make([]interface{}, value.Len())
+	for i := 0; i < value.Len(); i++ {
+		var err error
+		if result[i], err = e.encode(value.Index(i)); err != nil {
+			return nil, fmt.Errorf("error encoding element in slice at index %d: %w", i, err)
+		}
+	}
+	return result, nil
+}
+
+// encodeMap encodes a map by encoding the key and value. Returns errNonStringEncodedKey
+// if the key is not encoded into a string.
+func (e *Encoder) encodeMap(value reflect.Value) (interface{}, error) {
+	if value.Kind() != reflect.Map {
+		return nil, &reflect.ValueError{
+			Method: "encodeMap",
+			Kind:   value.Kind(),
+		}
+	}
+	result := make(map[string]interface{})
+	iterator := value.MapRange()
+	for iterator.Next() {
+		encoded, err := e.encode(iterator.Key())
+		if err != nil {
+			return nil, fmt.Errorf("error encoding key: %w", err)
+		}
+		key, ok := encoded.(string)
+		if !ok {
+			return nil, fmt.Errorf("%w key %q, kind: %v", errNonStringEncodedKey, iterator.Key().Interface(), iterator.Key().Kind())
+		}
+		if _, ok = result[key]; ok {
+			return nil, fmt.Errorf("duplicate key %q while encoding", key)
+		}
+		if result[key], err = e.encode(iterator.Value()); err != nil {
+			return nil, fmt.Errorf("error encoding map value for key %q: %w", key, err)
+		}
+	}
+	return result, nil
+}
+
+// getTagInfo looks up the mapstructure tag and uses that if available.
+// Uses the lowercase field if not found. Checks for omitempty and squash.
+func getTagInfo(field reflect.StructField) *tagInfo {
+	info := tagInfo{}
+	if tag, ok := field.Tag.Lookup(tagNameMapStructure); ok {
+		options := strings.Split(tag, optionSeparator)
+		info.name = options[0]
+		if len(options) > 1 {
+			for _, option := range options[1:] {
+				switch option {
+				case optionOmitEmpty:
+					info.omitEmpty = true
+				case optionSquash, optionRemain:
+					info.squash = true
+				}
+			}
+		}
+	} else {
+		info.name = strings.ToLower(field.Name)
+	}
+	return &info
+}
+
+// TextMarshalerHookFunc returns a DecodeHookFuncValue that checks
+// for the encoding.TextMarshaler interface and calls the MarshalText
+// function if found.
+func TextMarshalerHookFunc() mapstructure.DecodeHookFuncValue {
+	return func(from reflect.Value, _ reflect.Value) (interface{}, error) {
+		marshaler, ok := from.Interface().(encoding.TextMarshaler)
+		if !ok {
+			return from.Interface(), nil
+		}
+		out, err := marshaler.MarshalText()
+		if err != nil {
+			return nil, err
+		}
+		return string(out), nil
+	}
+}

--- a/confmap/internal/mapstructure/encoder_test.go
+++ b/confmap/internal/mapstructure/encoder_test.go
@@ -1,0 +1,313 @@
+// Copyright  The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mapstructure
+
+import (
+	"encoding"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/mitchellh/mapstructure"
+	"github.com/stretchr/testify/require"
+)
+
+type TestComplexStruct struct {
+	Skipped   TestEmptyStruct             `mapstructure:",squash"`
+	Nested    TestSimpleStruct            `mapstructure:",squash"`
+	Slice     []TestSimpleStruct          `mapstructure:"slice,omitempty"`
+	Pointer   *TestSimpleStruct           `mapstructure:"ptr"`
+	Map       map[string]TestSimpleStruct `mapstructure:"map,omitempty"`
+	Remain    map[string]interface{}      `mapstructure:",remain"`
+	Interface encoding.TextMarshaler
+}
+
+type TestSimpleStruct struct {
+	Value   string `mapstructure:"value"`
+	skipped string
+	err     error
+}
+
+type TestEmptyStruct struct {
+	Value string `mapstructure:"-"`
+}
+
+type TestID string
+
+func (tID TestID) MarshalText() (text []byte, err error) {
+	out := string(tID)
+	if out == "error" {
+		return nil, errors.New("parsing error")
+	}
+	if !strings.HasSuffix(out, "_") {
+		out += "_"
+	}
+	return []byte(out), nil
+}
+
+func TestEncode(t *testing.T) {
+	enc := New(&EncoderConfig{
+		EncodeHook: TextMarshalerHookFunc(),
+	})
+	testCases := map[string]struct {
+		input interface{}
+		want  interface{}
+	}{
+		"WithString": {
+			input: "test",
+			want:  "test",
+		},
+		"WithTextMarshaler": {
+			input: TestID("type"),
+			want:  "type_",
+		},
+		"WithSlice": {
+			input: []TestID{
+				TestID("nop"),
+				TestID("type_"),
+			},
+			want: []interface{}{"nop_", "type_"},
+		},
+		"WithSimpleStruct": {
+			input: TestSimpleStruct{Value: "test", skipped: "skipped"},
+			want: map[string]interface{}{
+				"value": "test",
+			},
+		},
+		"WithComplexStruct": {
+			input: &TestComplexStruct{
+				Skipped: TestEmptyStruct{
+					Value: "omitted",
+				},
+				Nested: TestSimpleStruct{
+					Value: "nested",
+				},
+				Slice: []TestSimpleStruct{
+					{Value: "slice"},
+				},
+				Map: map[string]TestSimpleStruct{
+					"Key": {Value: "map"},
+				},
+				Pointer: &TestSimpleStruct{
+					Value: "pointer",
+				},
+				Remain: map[string]interface{}{
+					"remain1": 23,
+					"remain2": "value",
+				},
+				Interface: TestID("value"),
+			},
+			want: map[string]interface{}{
+				"value": "nested",
+				"slice": []interface{}{map[string]interface{}{"value": "slice"}},
+				"map": map[string]interface{}{
+					"Key": map[string]interface{}{"value": "map"},
+				},
+				"ptr":       map[string]interface{}{"value": "pointer"},
+				"interface": "value_",
+				"remain1":   23,
+				"remain2":   "value",
+			},
+		},
+	}
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			got, err := enc.Encode(testCase.input)
+			require.NoError(t, err)
+			require.Equal(t, testCase.want, got)
+		})
+	}
+	// without the TextMarshalerHookFunc
+	enc.config.EncodeHook = nil
+	testCase := TestID("test")
+	got, err := enc.Encode(testCase)
+	require.NoError(t, err)
+	require.Equal(t, testCase, got)
+}
+
+func TestGetTagInfo(t *testing.T) {
+	testCases := map[string]struct {
+		field      reflect.StructField
+		wantName   string
+		wantOmit   bool
+		wantSquash bool
+	}{
+		"WithoutTags": {
+			field: reflect.StructField{
+				Name: "Test",
+			},
+			wantName: "test",
+		},
+		"WithoutMapStructureTag": {
+			field: reflect.StructField{
+				Tag:  `yaml:"hello,inline"`,
+				Name: "YAML",
+			},
+			wantName: "yaml",
+		},
+		"WithRename": {
+			field: reflect.StructField{
+				Tag:  `mapstructure:"hello"`,
+				Name: "Test",
+			},
+			wantName: "hello",
+		},
+		"WithOmitEmpty": {
+			field: reflect.StructField{
+				Tag:  `mapstructure:"hello,omitempty"`,
+				Name: "Test",
+			},
+			wantName: "hello",
+			wantOmit: true,
+		},
+		"WithSquash": {
+			field: reflect.StructField{
+				Tag:  `mapstructure:",squash"`,
+				Name: "Test",
+			},
+			wantSquash: true,
+		},
+		"WithRemain": {
+			field: reflect.StructField{
+				Tag:  `mapstructure:",remain"`,
+				Name: "Test",
+			},
+			wantSquash: true,
+		},
+	}
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			got := getTagInfo(testCase.field)
+			require.Equal(t, testCase.wantName, got.name)
+			require.Equal(t, testCase.wantOmit, got.omitEmpty)
+			require.Equal(t, testCase.wantSquash, got.squash)
+		})
+	}
+}
+
+func TestEncodeValueError(t *testing.T) {
+	enc := New(nil)
+	testValue := reflect.ValueOf("")
+	testCases := []struct {
+		encodeFn func(value reflect.Value) (interface{}, error)
+		wantErr  error
+	}{
+		{encodeFn: enc.encodeMap, wantErr: &reflect.ValueError{Method: "encodeMap", Kind: reflect.String}},
+		{encodeFn: enc.encodeStruct, wantErr: &reflect.ValueError{Method: "encodeStruct", Kind: reflect.String}},
+		{encodeFn: enc.encodeSlice, wantErr: &reflect.ValueError{Method: "encodeSlice", Kind: reflect.String}},
+	}
+	for _, testCase := range testCases {
+		got, err := testCase.encodeFn(testValue)
+		require.Error(t, err)
+		require.Equal(t, testCase.wantErr, err)
+		require.Nil(t, got)
+	}
+}
+
+func TestEncodeNonStringEncodedKey(t *testing.T) {
+	enc := New(nil)
+	testCase := []struct {
+		Test map[string]interface{}
+	}{
+		{
+			Test: map[string]interface{}{
+				"test": map[TestEmptyStruct]TestSimpleStruct{
+					{Value: "key"}: {Value: "value"},
+				},
+			},
+		},
+	}
+	got, err := enc.Encode(testCase)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, errNonStringEncodedKey))
+	require.Nil(t, got)
+}
+
+func TestDuplicateKey(t *testing.T) {
+	enc := New(&EncoderConfig{
+		EncodeHook: TextMarshalerHookFunc(),
+	})
+	testCase := map[TestID]string{
+		"test":  "value",
+		"test_": "other value",
+	}
+	got, err := enc.Encode(testCase)
+	require.Error(t, err)
+	require.Nil(t, got)
+}
+
+func TestTextMarshalerError(t *testing.T) {
+	enc := New(&EncoderConfig{
+		EncodeHook: TextMarshalerHookFunc(),
+	})
+	testCase := map[TestID]string{
+		"error": "value",
+	}
+	got, err := enc.Encode(testCase)
+	require.Error(t, err)
+	require.Nil(t, got)
+}
+
+func TestEncodeStruct(t *testing.T) {
+	enc := New(&EncoderConfig{
+		EncodeHook: testHookFunc(),
+	})
+	testCase := TestSimpleStruct{
+		Value:   "original",
+		skipped: "final",
+	}
+	got, err := enc.Encode(testCase)
+	require.NoError(t, err)
+	require.Equal(t, "final", got)
+}
+
+func TestEncodeStructError(t *testing.T) {
+	enc := New(&EncoderConfig{
+		EncodeHook: testHookFunc(),
+	})
+	wantErr := errors.New("test")
+	testCase := map[TestSimpleStruct]string{
+		{err: wantErr}: "value",
+	}
+	got, err := enc.Encode(testCase)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, wantErr))
+	require.Nil(t, got)
+}
+
+func TestEncodeNil(t *testing.T) {
+	enc := New(nil)
+	got, err := enc.Encode(nil)
+	require.NoError(t, err)
+	require.Nil(t, got)
+}
+
+func testHookFunc() mapstructure.DecodeHookFuncValue {
+	return func(from reflect.Value, _ reflect.Value) (interface{}, error) {
+		if from.Kind() != reflect.Struct {
+			return from.Interface(), nil
+		}
+
+		got, ok := from.Interface().(TestSimpleStruct)
+		if !ok {
+			return from.Interface(), nil
+		}
+		if got.err != nil {
+			return nil, got.err
+		}
+		return got.skipped, nil
+	}
+}


### PR DESCRIPTION
**Description:**
Add `Marshal` function to `confmap`. Update types implementing `encoding.TextUnmarshaler` to implement `encoding.TextMarshaler` as well. Add a mapstructure encoder that encodes the config provided using the existing mapstructure tags.

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector/issues/5418

**Testing:** Added unit test to validate the unmarshal/marshal cycle.

