### PR TITLE
Move NewThrottleRetry from exporterhelper to consumererror

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -378,6 +378,7 @@ There isn't a valid core binary for this release. Use v0.57.2 instead.
     that takes `pcommon.ImmutableFloat64Slice` instead of []float64.
   - `HistogramDataPoint.MExplicitBounds` func func is deprecated in favor of `HistogramDataPoint.ExplicitBounds`
     returns `pcommon.ImmutableFloat64Slice` instead of []float64.
+- Deprecate `exporterhelper.NewThrottleRetry` in favor of `consumererror.NewThrottleRetry` (#5551)
 
 ### 💡 Enhancements 💡
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -378,7 +378,7 @@ There isn't a valid core binary for this release. Use v0.57.2 instead.
     that takes `pcommon.ImmutableFloat64Slice` instead of []float64.
   - `HistogramDataPoint.MExplicitBounds` func func is deprecated in favor of `HistogramDataPoint.ExplicitBounds`
     returns `pcommon.ImmutableFloat64Slice` instead of []float64.
-- Deprecate `exporterhelper.NewThrottleRetry` in favor of `consumererror.NewThrottleRetry` (#5551)
+- Deprecate `exporterhelper.NewThrottleRetry` in favor of `consumererror.NewThrottleRetry` (#5569)
 
 ### 💡 Enhancements 💡
 

--- a/consumer/consumererror/throttle.go
+++ b/consumer/consumererror/throttle.go
@@ -1,0 +1,38 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package consumererror // import "go.opentelemetry.io/collector/consumer/consumererror"
+
+import (
+	"time"
+)
+
+type Throttle struct {
+	delay time.Duration
+}
+
+func (t Throttle) Error() string {
+	return "Throttle (" + t.delay.String() + ")"
+}
+
+func (t Throttle) RetryDelay() time.Duration {
+	return t.delay
+}
+
+// NewThrottleRetry creates a new throttle retry error.
+func NewThrottleRetry(delay time.Duration) error {
+	return Throttle{
+		delay: delay,
+	}
+}

--- a/consumer/consumererror/throttle_test.go
+++ b/consumer/consumererror/throttle_test.go
@@ -1,0 +1,36 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package consumererror
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestThrottleDelay(t *testing.T) {
+	err := NewThrottleRetry(time.Minute)
+	throttleErr := Throttle{}
+	assert.True(t, errors.As(err, &throttleErr))
+	assert.Equal(t, throttleErr.RetryDelay(), time.Minute)
+
+	err = fmt.Errorf("%w", err)
+	throttleErr = Throttle{}
+	assert.True(t, errors.As(err, &throttleErr))
+	assert.Equal(t, throttleErr.RetryDelay(), time.Minute)
+}

--- a/exporter/exporterhelper/queued_retry_test.go
+++ b/exporter/exporterhelper/queued_retry_test.go
@@ -241,7 +241,7 @@ func TestQueuedRetry_ThrottleError(t *testing.T) {
 		assert.NoError(t, be.Shutdown(context.Background()))
 	})
 
-	retry := NewThrottleRetry(errors.New("throttle error"), 100*time.Millisecond)
+	retry := consumererror.NewThrottleRetry(100 * time.Millisecond)
 	mockR := newMockRequest(context.Background(), 2, wrappedError{retry})
 	start := time.Now()
 	ocs.run(func() {

--- a/exporter/otlpexporter/otlp.go
+++ b/exporter/otlpexporter/otlp.go
@@ -21,6 +21,7 @@ import (
 	"runtime"
 	"time"
 
+	"go.uber.org/multierr"
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -30,7 +31,6 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/consumer/consumererror"
-	"go.opentelemetry.io/collector/exporter/exporterhelper"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/plog/plogotlp"
 	"go.opentelemetry.io/collector/pdata/pmetric"
@@ -152,7 +152,7 @@ func processError(err error) error {
 	throttleDuration := getThrottleDuration(retryInfo)
 	if throttleDuration != 0 {
 		// We are throttled. Wait before retrying as requested by the server.
-		return exporterhelper.NewThrottleRetry(err, throttleDuration)
+		return multierr.Combine(err, consumererror.NewThrottleRetry(throttleDuration))
 	}
 
 	// Need to retry.

--- a/exporter/otlphttpexporter/otlp.go
+++ b/exporter/otlphttpexporter/otlp.go
@@ -26,6 +26,7 @@ import (
 	"strconv"
 	"time"
 
+	"go.uber.org/multierr"
 	"go.uber.org/zap"
 	"google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/protobuf/proto"
@@ -33,7 +34,6 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/consumer/consumererror"
-	"go.opentelemetry.io/collector/exporter/exporterhelper"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/plog/plogotlp"
 	"go.opentelemetry.io/collector/pdata/pmetric"
@@ -174,7 +174,7 @@ func (e *exporter) export(ctx context.Context, url string, request []byte) error
 			}
 		}
 		// Indicate to our caller to pause for the specified number of seconds.
-		return exporterhelper.NewThrottleRetry(formattedErr, time.Duration(retryAfter)*time.Second)
+		return multierr.Combine(formattedErr, consumererror.NewThrottleRetry(time.Duration(retryAfter)*time.Second))
 	}
 
 	if isPermanentClientFailure(resp.StatusCode) {


### PR DESCRIPTION
**Description:**

Part of https://github.com/open-telemetry/opentelemetry-collector/issues/5550.

NewThrottleRetry is an error that is similar in kind to a permanent error: it informs callers how to deal with retries. I think it makes the most sense for the two to live in the same package, since users of NewPermanent will likely also need NewThrottleRetry.

This also makes getting the duration of the throttle retry error cleaner.

It deprecates the previous NewThrottleRetry function.

**Testing:**

Added unit tests
