### PR TITLE
Duplicate testdata inside consumer to remove the additional from the consumer package

### DIFF
--- a/consumer/consumererror/signalerrors_test.go
+++ b/consumer/consumererror/signalerrors_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"go.opentelemetry.io/collector/internal/testdata"
+	"go.opentelemetry.io/collector/consumer/internal/testdata"
 )
 
 func TestTraces(t *testing.T) {

--- a/consumer/consumertest/sink_test.go
+++ b/consumer/consumertest/sink_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"go.opentelemetry.io/collector/internal/testdata"
+	"go.opentelemetry.io/collector/consumer/internal/testdata"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/ptrace"

--- a/consumer/internal/testdata/common.go
+++ b/consumer/internal/testdata/common.go
@@ -1,0 +1,87 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testdata
+
+import (
+	"go.opentelemetry.io/collector/pdata/pcommon"
+)
+
+var (
+	resourceAttributes1 = pcommon.NewMapFromRaw(map[string]interface{}{"resource-attr": "resource-attr-val-1"})
+	resourceAttributes2 = pcommon.NewMapFromRaw(map[string]interface{}{"resource-attr": "resource-attr-val-2"})
+	spanEventAttributes = pcommon.NewMapFromRaw(map[string]interface{}{"span-event-attr": "span-event-attr-val"})
+	spanLinkAttributes  = pcommon.NewMapFromRaw(map[string]interface{}{"span-link-attr": "span-link-attr-val"})
+	spanAttributes      = pcommon.NewMapFromRaw(map[string]interface{}{"span-attr": "span-attr-val"})
+	metricAttachment    = pcommon.NewMapFromRaw(map[string]interface{}{"exemplar-attachment": "exemplar-attachment-value"})
+)
+
+const (
+	TestLabelKey1   = "label-1"
+	TestLabelValue1 = "label-value-1"
+	TestLabelKey2   = "label-2"
+	TestLabelValue2 = "label-value-2"
+	TestLabelKey3   = "label-3"
+	TestLabelValue3 = "label-value-3"
+)
+
+func initResourceAttributes1(dest pcommon.Map) {
+	dest.Clear()
+	resourceAttributes1.CopyTo(dest)
+}
+
+func initResourceAttributes2(dest pcommon.Map) {
+	dest.Clear()
+	resourceAttributes2.CopyTo(dest)
+}
+
+func initSpanAttributes(dest pcommon.Map) {
+	dest.Clear()
+	spanAttributes.CopyTo(dest)
+}
+
+func initSpanEventAttributes(dest pcommon.Map) {
+	dest.Clear()
+	spanEventAttributes.CopyTo(dest)
+}
+
+func initSpanLinkAttributes(dest pcommon.Map) {
+	dest.Clear()
+	spanLinkAttributes.CopyTo(dest)
+}
+
+func initMetricAttachment(dest pcommon.Map) {
+	dest.Clear()
+	metricAttachment.CopyTo(dest)
+}
+
+func initMetricAttributes1(dest pcommon.Map) {
+	dest.Clear()
+	dest.InsertString(TestLabelKey1, TestLabelValue1)
+}
+
+func initMetricAttributes12(dest pcommon.Map) {
+	initMetricAttributes1(dest)
+	dest.InsertString(TestLabelKey2, TestLabelValue2)
+}
+
+func initMetricAttributes13(dest pcommon.Map) {
+	initMetricAttributes1(dest)
+	dest.InsertString(TestLabelKey3, TestLabelValue3)
+}
+
+func initMetricAttributes2(dest pcommon.Map) {
+	dest.Clear()
+	dest.InsertString(TestLabelKey2, TestLabelValue2)
+}

--- a/consumer/internal/testdata/log.go
+++ b/consumer/internal/testdata/log.go
@@ -1,0 +1,130 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testdata
+
+import (
+	"time"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
+)
+
+var (
+	TestLogTime      = time.Date(2020, 2, 11, 20, 26, 13, 789, time.UTC)
+	TestLogTimestamp = pcommon.NewTimestampFromTime(TestLogTime)
+)
+
+func GenerateLogsOneEmptyResourceLogs() plog.Logs {
+	ld := plog.NewLogs()
+	ld.ResourceLogs().AppendEmpty()
+	return ld
+}
+
+func GenerateLogsNoLogRecords() plog.Logs {
+	ld := GenerateLogsOneEmptyResourceLogs()
+	initResource1(ld.ResourceLogs().At(0).Resource())
+	return ld
+}
+
+func GenerateLogsOneEmptyLogRecord() plog.Logs {
+	ld := GenerateLogsNoLogRecords()
+	rs0 := ld.ResourceLogs().At(0)
+	rs0.ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
+	return ld
+}
+
+func GenerateLogsOneLogRecord() plog.Logs {
+	ld := GenerateLogsOneEmptyLogRecord()
+	fillLogOne(ld.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0))
+	return ld
+}
+
+func GenerateLogsTwoLogRecordsSameResource() plog.Logs {
+	ld := GenerateLogsOneEmptyLogRecord()
+	logs := ld.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords()
+	fillLogOne(logs.At(0))
+	fillLogTwo(logs.AppendEmpty())
+	return ld
+}
+
+func GenerateLogsTwoLogRecordsSameResourceOneDifferent() plog.Logs {
+	ld := plog.NewLogs()
+	rl0 := ld.ResourceLogs().AppendEmpty()
+	initResource1(rl0.Resource())
+	logs := rl0.ScopeLogs().AppendEmpty().LogRecords()
+	fillLogOne(logs.AppendEmpty())
+	fillLogTwo(logs.AppendEmpty())
+	rl1 := ld.ResourceLogs().AppendEmpty()
+	initResource2(rl1.Resource())
+	fillLogThree(rl1.ScopeLogs().AppendEmpty().LogRecords().AppendEmpty())
+	return ld
+}
+func fillLogOne(log plog.LogRecord) {
+	log.SetTimestamp(TestLogTimestamp)
+	log.SetDroppedAttributesCount(1)
+	log.SetSeverityNumber(plog.SeverityNumberINFO)
+	log.SetSeverityText("Info")
+	log.SetSpanID(pcommon.NewSpanID([8]byte{0x01, 0x02, 0x04, 0x08}))
+	log.SetTraceID(pcommon.NewTraceID([16]byte{0x08, 0x04, 0x02, 0x01}))
+
+	attrs := log.Attributes()
+	attrs.InsertString("app", "server")
+	attrs.InsertInt("instance_num", 1)
+
+	log.Body().SetStringVal("This is a log message")
+}
+
+func fillLogTwo(log plog.LogRecord) {
+	log.SetTimestamp(TestLogTimestamp)
+	log.SetDroppedAttributesCount(1)
+	log.SetSeverityNumber(plog.SeverityNumberINFO)
+	log.SetSeverityText("Info")
+
+	attrs := log.Attributes()
+	attrs.InsertString("customer", "acme")
+	attrs.InsertString("env", "dev")
+
+	log.Body().SetStringVal("something happened")
+}
+
+func fillLogThree(log plog.LogRecord) {
+	log.SetTimestamp(TestLogTimestamp)
+	log.SetDroppedAttributesCount(1)
+	log.SetSeverityNumber(plog.SeverityNumberWARN)
+	log.SetSeverityText("Warning")
+
+	log.Body().SetStringVal("something else happened")
+}
+
+func GenerateLogsManyLogRecordsSameResource(count int) plog.Logs {
+	ld := GenerateLogsOneEmptyLogRecord()
+	logs := ld.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords()
+	logs.EnsureCapacity(count)
+	for i := 0; i < count; i++ {
+		var l plog.LogRecord
+		if i < logs.Len() {
+			l = logs.At(i)
+		} else {
+			l = logs.AppendEmpty()
+		}
+
+		if i%2 == 0 {
+			fillLogOne(l)
+		} else {
+			fillLogTwo(l)
+		}
+	}
+	return ld
+}

--- a/consumer/internal/testdata/metric.go
+++ b/consumer/internal/testdata/metric.go
@@ -1,0 +1,322 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testdata
+
+import (
+	"time"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+)
+
+var (
+	TestMetricStartTime      = time.Date(2020, 2, 11, 20, 26, 12, 321, time.UTC)
+	TestMetricStartTimestamp = pcommon.NewTimestampFromTime(TestMetricStartTime)
+
+	TestMetricExemplarTime      = time.Date(2020, 2, 11, 20, 26, 13, 123, time.UTC)
+	TestMetricExemplarTimestamp = pcommon.NewTimestampFromTime(TestMetricExemplarTime)
+
+	TestMetricTime      = time.Date(2020, 2, 11, 20, 26, 13, 789, time.UTC)
+	TestMetricTimestamp = pcommon.NewTimestampFromTime(TestMetricTime)
+)
+
+const (
+	TestGaugeDoubleMetricName          = "gauge-double"
+	TestGaugeIntMetricName             = "gauge-int"
+	TestSumDoubleMetricName            = "sum-double"
+	TestSumIntMetricName               = "sum-int"
+	TestHistogramMetricName            = "histogram"
+	TestExponentialHistogramMetricName = "exponential-histogram"
+	TestSummaryMetricName              = "summary"
+)
+
+func GenerateMetricsOneEmptyResourceMetrics() pmetric.Metrics {
+	md := pmetric.NewMetrics()
+	md.ResourceMetrics().AppendEmpty()
+	return md
+}
+
+func GenerateMetricsNoLibraries() pmetric.Metrics {
+	md := GenerateMetricsOneEmptyResourceMetrics()
+	ms0 := md.ResourceMetrics().At(0)
+	initResource1(ms0.Resource())
+	return md
+}
+
+func GenerateMetricsOneEmptyInstrumentationScope() pmetric.Metrics {
+	md := GenerateMetricsNoLibraries()
+	md.ResourceMetrics().At(0).ScopeMetrics().AppendEmpty()
+	return md
+}
+
+func GenerateMetricsOneMetric() pmetric.Metrics {
+	md := GenerateMetricsOneEmptyInstrumentationScope()
+	rm0ils0 := md.ResourceMetrics().At(0).ScopeMetrics().At(0)
+	initSumIntMetric(rm0ils0.Metrics().AppendEmpty())
+	return md
+}
+
+func GenerateMetricsTwoMetrics() pmetric.Metrics {
+	md := GenerateMetricsOneEmptyInstrumentationScope()
+	rm0ils0 := md.ResourceMetrics().At(0).ScopeMetrics().At(0)
+	initSumIntMetric(rm0ils0.Metrics().AppendEmpty())
+	initSumIntMetric(rm0ils0.Metrics().AppendEmpty())
+	return md
+}
+
+func GenerateMetricsAllTypesEmptyDataPoint() pmetric.Metrics {
+	md := GenerateMetricsOneEmptyInstrumentationScope()
+	ilm0 := md.ResourceMetrics().At(0).ScopeMetrics().At(0)
+	ms := ilm0.Metrics()
+
+	doubleGauge := ms.AppendEmpty()
+	initMetric(doubleGauge, TestGaugeDoubleMetricName, pmetric.MetricDataTypeGauge)
+	doubleGauge.Gauge().DataPoints().AppendEmpty()
+	intGauge := ms.AppendEmpty()
+	initMetric(intGauge, TestGaugeIntMetricName, pmetric.MetricDataTypeGauge)
+	intGauge.Gauge().DataPoints().AppendEmpty()
+	doubleSum := ms.AppendEmpty()
+	initMetric(doubleSum, TestSumDoubleMetricName, pmetric.MetricDataTypeSum)
+	doubleSum.Sum().DataPoints().AppendEmpty()
+	intSum := ms.AppendEmpty()
+	initMetric(intSum, TestSumIntMetricName, pmetric.MetricDataTypeSum)
+	intSum.Sum().DataPoints().AppendEmpty()
+	histogram := ms.AppendEmpty()
+	initMetric(histogram, TestHistogramMetricName, pmetric.MetricDataTypeHistogram)
+	histogram.Histogram().DataPoints().AppendEmpty()
+	summary := ms.AppendEmpty()
+	initMetric(summary, TestSummaryMetricName, pmetric.MetricDataTypeSummary)
+	summary.Summary().DataPoints().AppendEmpty()
+	return md
+}
+
+func GenerateMetricsMetricTypeInvalid() pmetric.Metrics {
+	md := GenerateMetricsOneEmptyInstrumentationScope()
+	ilm0 := md.ResourceMetrics().At(0).ScopeMetrics().At(0)
+	initMetric(ilm0.Metrics().AppendEmpty(), TestSumIntMetricName, pmetric.MetricDataTypeNone)
+	return md
+}
+
+func GeneratMetricsAllTypesWithSampleDatapoints() pmetric.Metrics {
+	md := GenerateMetricsOneEmptyInstrumentationScope()
+
+	ilm := md.ResourceMetrics().At(0).ScopeMetrics().At(0)
+	ms := ilm.Metrics()
+	initGaugeIntMetric(ms.AppendEmpty())
+	initGaugeDoubleMetric(ms.AppendEmpty())
+	initSumIntMetric(ms.AppendEmpty())
+	initSumDoubleMetric(ms.AppendEmpty())
+	initHistogramMetric(ms.AppendEmpty())
+	initExponentialHistogramMetric(ms.AppendEmpty())
+	initSummaryMetric(ms.AppendEmpty())
+	return md
+}
+
+func initGaugeIntMetric(im pmetric.Metric) {
+	initMetric(im, TestGaugeIntMetricName, pmetric.MetricDataTypeGauge)
+
+	idps := im.Gauge().DataPoints()
+	idp0 := idps.AppendEmpty()
+	initMetricAttributes1(idp0.Attributes())
+	idp0.SetStartTimestamp(TestMetricStartTimestamp)
+	idp0.SetTimestamp(TestMetricTimestamp)
+	idp0.SetIntVal(123)
+	idp1 := idps.AppendEmpty()
+	initMetricAttributes2(idp1.Attributes())
+	idp1.SetStartTimestamp(TestMetricStartTimestamp)
+	idp1.SetTimestamp(TestMetricTimestamp)
+	idp1.SetIntVal(456)
+}
+
+func initGaugeDoubleMetric(im pmetric.Metric) {
+	initMetric(im, TestGaugeDoubleMetricName, pmetric.MetricDataTypeGauge)
+
+	idps := im.Gauge().DataPoints()
+	idp0 := idps.AppendEmpty()
+	initMetricAttributes12(idp0.Attributes())
+	idp0.SetStartTimestamp(TestMetricStartTimestamp)
+	idp0.SetTimestamp(TestMetricTimestamp)
+	idp0.SetDoubleVal(1.23)
+	idp1 := idps.AppendEmpty()
+	initMetricAttributes13(idp1.Attributes())
+	idp1.SetStartTimestamp(TestMetricStartTimestamp)
+	idp1.SetTimestamp(TestMetricTimestamp)
+	idp1.SetDoubleVal(4.56)
+}
+
+func initSumIntMetric(im pmetric.Metric) {
+	initMetric(im, TestSumIntMetricName, pmetric.MetricDataTypeSum)
+
+	idps := im.Sum().DataPoints()
+	idp0 := idps.AppendEmpty()
+	initMetricAttributes1(idp0.Attributes())
+	idp0.SetStartTimestamp(TestMetricStartTimestamp)
+	idp0.SetTimestamp(TestMetricTimestamp)
+	idp0.SetIntVal(123)
+	idp1 := idps.AppendEmpty()
+	initMetricAttributes2(idp1.Attributes())
+	idp1.SetStartTimestamp(TestMetricStartTimestamp)
+	idp1.SetTimestamp(TestMetricTimestamp)
+	idp1.SetIntVal(456)
+}
+
+func initSumDoubleMetric(dm pmetric.Metric) {
+	initMetric(dm, TestSumDoubleMetricName, pmetric.MetricDataTypeSum)
+
+	ddps := dm.Sum().DataPoints()
+	ddp0 := ddps.AppendEmpty()
+	initMetricAttributes12(ddp0.Attributes())
+	ddp0.SetStartTimestamp(TestMetricStartTimestamp)
+	ddp0.SetTimestamp(TestMetricTimestamp)
+	ddp0.SetDoubleVal(1.23)
+
+	ddp1 := ddps.AppendEmpty()
+	initMetricAttributes13(ddp1.Attributes())
+	ddp1.SetStartTimestamp(TestMetricStartTimestamp)
+	ddp1.SetTimestamp(TestMetricTimestamp)
+	ddp1.SetDoubleVal(4.56)
+}
+
+func initHistogramMetric(hm pmetric.Metric) {
+	initMetric(hm, TestHistogramMetricName, pmetric.MetricDataTypeHistogram)
+
+	hdps := hm.Histogram().DataPoints()
+	hdp0 := hdps.AppendEmpty()
+	initMetricAttributes13(hdp0.Attributes())
+	hdp0.SetStartTimestamp(TestMetricStartTimestamp)
+	hdp0.SetTimestamp(TestMetricTimestamp)
+	hdp0.SetCount(1)
+	hdp0.SetSum(15)
+
+	hdp1 := hdps.AppendEmpty()
+	initMetricAttributes2(hdp1.Attributes())
+	hdp1.SetStartTimestamp(TestMetricStartTimestamp)
+	hdp1.SetTimestamp(TestMetricTimestamp)
+	hdp1.SetCount(1)
+	hdp1.SetSum(15)
+	hdp1.SetMin(15)
+	hdp1.SetMax(15)
+	hdp1.SetBucketCounts(pcommon.NewImmutableUInt64Slice([]uint64{0, 1}))
+	exemplar := hdp1.Exemplars().AppendEmpty()
+	exemplar.SetTimestamp(TestMetricExemplarTimestamp)
+	exemplar.SetDoubleVal(15)
+	initMetricAttachment(exemplar.FilteredAttributes())
+	hdp1.SetExplicitBounds(pcommon.NewImmutableFloat64Slice([]float64{1}))
+}
+
+func initExponentialHistogramMetric(hm pmetric.Metric) {
+	initMetric(hm, TestExponentialHistogramMetricName, pmetric.MetricDataTypeExponentialHistogram)
+
+	hdps := hm.ExponentialHistogram().DataPoints()
+	hdp0 := hdps.AppendEmpty()
+	initMetricAttributes13(hdp0.Attributes())
+	hdp0.SetStartTimestamp(TestMetricStartTimestamp)
+	hdp0.SetTimestamp(TestMetricTimestamp)
+	hdp0.SetCount(5)
+	hdp0.SetSum(0.15)
+	hdp0.SetZeroCount(1)
+	hdp0.SetScale(1)
+
+	// positive index 1 and 2 are values sqrt(2), 2 at scale 1
+	hdp0.Positive().SetOffset(1)
+	hdp0.Positive().SetBucketCounts(pcommon.NewImmutableUInt64Slice([]uint64{1, 1}))
+	// negative index -1 and 0 are values -1/sqrt(2), -1 at scale 1
+	hdp0.Negative().SetOffset(-1)
+	hdp0.Negative().SetBucketCounts(pcommon.NewImmutableUInt64Slice([]uint64{1, 1}))
+
+	// The above will print:
+	// Bucket (-1.414214, -1.000000], Count: 1
+	// Bucket (-1.000000, -0.707107], Count: 1
+	// Bucket [0, 0], Count: 1
+	// Bucket [0.707107, 1.000000), Count: 1
+	// Bucket [1.000000, 1.414214), Count: 1
+
+	hdp1 := hdps.AppendEmpty()
+	initMetricAttributes2(hdp1.Attributes())
+	hdp1.SetStartTimestamp(TestMetricStartTimestamp)
+	hdp1.SetTimestamp(TestMetricTimestamp)
+	hdp1.SetCount(3)
+	hdp1.SetSum(1.25)
+	hdp1.SetMin(0)
+	hdp1.SetMax(1)
+	hdp1.SetZeroCount(1)
+	hdp1.SetScale(-1)
+
+	// index -1 and 0 are values 0.25, 1 at scale -1
+	hdp1.Positive().SetOffset(-1)
+	hdp1.Positive().SetBucketCounts(pcommon.NewImmutableUInt64Slice([]uint64{1, 1}))
+
+	// The above will print:
+	// Bucket [0, 0], Count: 1
+	// Bucket [0.250000, 1.000000), Count: 1
+	// Bucket [1.000000, 4.000000), Count: 1
+
+	exemplar := hdp1.Exemplars().AppendEmpty()
+	exemplar.SetTimestamp(TestMetricExemplarTimestamp)
+	exemplar.SetDoubleVal(15)
+	initMetricAttachment(exemplar.FilteredAttributes())
+}
+
+func initSummaryMetric(sm pmetric.Metric) {
+	initMetric(sm, TestSummaryMetricName, pmetric.MetricDataTypeSummary)
+
+	sdps := sm.Summary().DataPoints()
+	sdp0 := sdps.AppendEmpty()
+	initMetricAttributes13(sdp0.Attributes())
+	sdp0.SetStartTimestamp(TestMetricStartTimestamp)
+	sdp0.SetTimestamp(TestMetricTimestamp)
+	sdp0.SetCount(1)
+	sdp0.SetSum(15)
+
+	sdp1 := sdps.AppendEmpty()
+	initMetricAttributes2(sdp1.Attributes())
+	sdp1.SetStartTimestamp(TestMetricStartTimestamp)
+	sdp1.SetTimestamp(TestMetricTimestamp)
+	sdp1.SetCount(1)
+	sdp1.SetSum(15)
+
+	quantile := sdp1.QuantileValues().AppendEmpty()
+	quantile.SetQuantile(0.01)
+	quantile.SetValue(15)
+}
+
+func initMetric(m pmetric.Metric, name string, ty pmetric.MetricDataType) {
+	m.SetName(name)
+	m.SetDescription("")
+	m.SetUnit("1")
+	m.SetDataType(ty)
+	switch ty {
+	case pmetric.MetricDataTypeSum:
+		sum := m.Sum()
+		sum.SetIsMonotonic(true)
+		sum.SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
+	case pmetric.MetricDataTypeHistogram:
+		histo := m.Histogram()
+		histo.SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
+	case pmetric.MetricDataTypeExponentialHistogram:
+		histo := m.ExponentialHistogram()
+		histo.SetAggregationTemporality(pmetric.MetricAggregationTemporalityDelta)
+	}
+}
+
+func GenerateMetricsManyMetricsSameResource(metricsCount int) pmetric.Metrics {
+	md := GenerateMetricsOneEmptyInstrumentationScope()
+	rs0ilm0 := md.ResourceMetrics().At(0).ScopeMetrics().At(0)
+	rs0ilm0.Metrics().EnsureCapacity(metricsCount)
+	for i := 0; i < metricsCount; i++ {
+		initSumIntMetric(rs0ilm0.Metrics().AppendEmpty())
+	}
+	return md
+}

--- a/consumer/internal/testdata/resource.go
+++ b/consumer/internal/testdata/resource.go
@@ -1,0 +1,25 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testdata
+
+import "go.opentelemetry.io/collector/pdata/pcommon"
+
+func initResource1(r pcommon.Resource) {
+	initResourceAttributes1(r.Attributes())
+}
+
+func initResource2(r pcommon.Resource) {
+	initResourceAttributes2(r.Attributes())
+}

--- a/consumer/internal/testdata/trace.go
+++ b/consumer/internal/testdata/trace.go
@@ -1,0 +1,134 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testdata
+
+import (
+	"time"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+)
+
+var (
+	TestSpanStartTime      = time.Date(2020, 2, 11, 20, 26, 12, 321, time.UTC)
+	TestSpanStartTimestamp = pcommon.NewTimestampFromTime(TestSpanStartTime)
+
+	TestSpanEventTime      = time.Date(2020, 2, 11, 20, 26, 13, 123, time.UTC)
+	TestSpanEventTimestamp = pcommon.NewTimestampFromTime(TestSpanEventTime)
+
+	TestSpanEndTime      = time.Date(2020, 2, 11, 20, 26, 13, 789, time.UTC)
+	TestSpanEndTimestamp = pcommon.NewTimestampFromTime(TestSpanEndTime)
+)
+
+func GenerateTracesOneEmptyResourceSpans() ptrace.Traces {
+	td := ptrace.NewTraces()
+	td.ResourceSpans().AppendEmpty()
+	return td
+}
+
+func GenerateTracesNoLibraries() ptrace.Traces {
+	td := GenerateTracesOneEmptyResourceSpans()
+	rs0 := td.ResourceSpans().At(0)
+	initResource1(rs0.Resource())
+	return td
+}
+
+func GenerateTracesOneEmptyInstrumentationScope() ptrace.Traces {
+	td := GenerateTracesNoLibraries()
+	td.ResourceSpans().At(0).ScopeSpans().AppendEmpty()
+	return td
+}
+
+func GenerateTracesOneSpan() ptrace.Traces {
+	td := GenerateTracesOneEmptyInstrumentationScope()
+	rs0ils0 := td.ResourceSpans().At(0).ScopeSpans().At(0)
+	fillSpanOne(rs0ils0.Spans().AppendEmpty())
+	return td
+}
+
+func GenerateTracesTwoSpansSameResource() ptrace.Traces {
+	td := GenerateTracesOneEmptyInstrumentationScope()
+	rs0ils0 := td.ResourceSpans().At(0).ScopeSpans().At(0)
+	fillSpanOne(rs0ils0.Spans().AppendEmpty())
+	fillSpanTwo(rs0ils0.Spans().AppendEmpty())
+	return td
+}
+
+func GenerateTracesTwoSpansSameResourceOneDifferent() ptrace.Traces {
+	td := ptrace.NewTraces()
+	rs0 := td.ResourceSpans().AppendEmpty()
+	initResource1(rs0.Resource())
+	rs0ils0 := rs0.ScopeSpans().AppendEmpty()
+	fillSpanOne(rs0ils0.Spans().AppendEmpty())
+	fillSpanTwo(rs0ils0.Spans().AppendEmpty())
+	rs1 := td.ResourceSpans().AppendEmpty()
+	initResource2(rs1.Resource())
+	rs1ils0 := rs1.ScopeSpans().AppendEmpty()
+	fillSpanThree(rs1ils0.Spans().AppendEmpty())
+	return td
+}
+
+func GenerateTracesManySpansSameResource(spanCount int) ptrace.Traces {
+	td := GenerateTracesOneEmptyInstrumentationScope()
+	rs0ils0 := td.ResourceSpans().At(0).ScopeSpans().At(0)
+	rs0ils0.Spans().EnsureCapacity(spanCount)
+	for i := 0; i < spanCount; i++ {
+		fillSpanOne(rs0ils0.Spans().AppendEmpty())
+	}
+	return td
+}
+
+func fillSpanOne(span ptrace.Span) {
+	span.SetName("operationA")
+	span.SetStartTimestamp(TestSpanStartTimestamp)
+	span.SetEndTimestamp(TestSpanEndTimestamp)
+	span.SetDroppedAttributesCount(1)
+	span.SetTraceID(pcommon.NewTraceID([16]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10}))
+	span.SetSpanID(pcommon.NewSpanID([8]byte{0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18}))
+	evs := span.Events()
+	ev0 := evs.AppendEmpty()
+	ev0.SetTimestamp(TestSpanEventTimestamp)
+	ev0.SetName("event-with-attr")
+	initSpanEventAttributes(ev0.Attributes())
+	ev0.SetDroppedAttributesCount(2)
+	ev1 := evs.AppendEmpty()
+	ev1.SetTimestamp(TestSpanEventTimestamp)
+	ev1.SetName("event")
+	ev1.SetDroppedAttributesCount(2)
+	span.SetDroppedEventsCount(1)
+	status := span.Status()
+	status.SetCode(ptrace.StatusCodeError)
+	status.SetMessage("status-cancelled")
+}
+
+func fillSpanTwo(span ptrace.Span) {
+	span.SetName("operationB")
+	span.SetStartTimestamp(TestSpanStartTimestamp)
+	span.SetEndTimestamp(TestSpanEndTimestamp)
+	link0 := span.Links().AppendEmpty()
+	initSpanLinkAttributes(link0.Attributes())
+	link0.SetDroppedAttributesCount(4)
+	link1 := span.Links().AppendEmpty()
+	link1.SetDroppedAttributesCount(4)
+	span.SetDroppedLinksCount(3)
+}
+
+func fillSpanThree(span ptrace.Span) {
+	span.SetName("operationC")
+	span.SetStartTimestamp(TestSpanStartTimestamp)
+	span.SetEndTimestamp(TestSpanEndTimestamp)
+	initSpanAttributes(span.Attributes())
+	span.SetDroppedAttributesCount(5)
+}


### PR DESCRIPTION
**Description:**

Part of https://github.com/open-telemetry/opentelemetry-collector/issues/5550.

This would remove the need to put internal/testdata in its own module to allow using consumer without depending on the rest of collector core.