### PR TITLE
add stability level to component factory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@
 ### 🚩 Deprecations 🚩
 
 - Deprecate `service.ConfigServiceTelemetry`, `service.ConfigServiceTelemetryLogs`, and `service.ConfigServiceTelemetryMetrics` (#5565)
+- Deprecate the following component functions to ensure a stability level is set (#5580): 
+  - `component.WithTracesExporter` -> `component.WithTracesExporterAndStabilityLevel`
+  - `component.WithMetricsExporter` -> `component.WithMetricsExporterAndStabilityLevel`
+  - `component.WithLogsExporter` -> `component.WithLogsExporterAndStabilityLevel`
+
+### 💡 Enhancements 💡
+
+- Components stability levels are now logged. By default components which haven't defined their stability levels, or which are
+  unmaintained, deprecated or in development will log a message. (#5580)
 
 ### 🧰 Bug fixes 🧰
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,16 @@
 ### 🚩 Deprecations 🚩
 
 - Deprecate `service.ConfigServiceTelemetry`, `service.ConfigServiceTelemetryLogs`, and `service.ConfigServiceTelemetryMetrics` (#5565)
-- Deprecate the following component functions to ensure a stability level is set (#5580): 
+- Deprecate the following component functions to ensure a stability level is set (#5580):
   - `component.WithTracesExporter` -> `component.WithTracesExporterAndStabilityLevel`
   - `component.WithMetricsExporter` -> `component.WithMetricsExporterAndStabilityLevel`
   - `component.WithLogsExporter` -> `component.WithLogsExporterAndStabilityLevel`
+  - `component.WithTracesReceiver` -> `component.WithTracesReceiverAndStabilityLevel`
+  - `component.WithMetricsReceiver` -> `component.WithMetricsReceiverAndStabilityLevel`
+  - `component.WithLogsReceiver` -> `component.WithLogsReceiverAndStabilityLevel`
+  - `component.WithTracesProcessor` -> `component.WithTracesProcessorAndStabilityLevel`
+  - `component.WithMetricsProcessor` -> `component.WithMetricsProcessorAndStabilityLevel`
+  - `component.WithLogsProcessor` -> `component.WithLogsProcessorAndStabilityLevel`
 
 ### 💡 Enhancements 💡
 

--- a/component/component.go
+++ b/component/component.go
@@ -105,6 +105,9 @@ const (
 )
 
 // StabilityLevel represents the stability level of the component created by the factory.
+// The stability level is used to determine if the component should be used in production
+// or not. For more details see:
+// https://github.com/open-telemetry/opentelemetry-collector#stability-levels
 type StabilityLevel int
 
 const (

--- a/component/component.go
+++ b/component/component.go
@@ -104,6 +104,37 @@ const (
 	KindExtension
 )
 
+// StabilityLevel represents the stability level of the component created by the factory.
+type StabilityLevel int
+
+const (
+	_ StabilityLevel = iota // skip 0, start types from 1.
+	StabilityLevelUnmaintained
+	StabilityLevelDeprecated
+	StabilityLevelInDevelopment
+	StabilityLevelAlpha
+	StabilityLevelBeta
+	StabilityLevelStable
+)
+
+func (sl StabilityLevel) String() string {
+	switch sl {
+	case StabilityLevelUnmaintained:
+		return "unmaintained"
+	case StabilityLevelDeprecated:
+		return "deprecated"
+	case StabilityLevelInDevelopment:
+		return "in development"
+	case StabilityLevelAlpha:
+		return "alpha"
+	case StabilityLevelBeta:
+		return "beta"
+	case StabilityLevelStable:
+		return "stable"
+	}
+	return "undefined"
+}
+
 // Factory is implemented by all component factories.
 //
 // This interface cannot be directly implemented. Implementations must
@@ -116,11 +147,16 @@ type Factory interface {
 }
 
 type baseFactory struct {
-	cfgType config.Type
+	cfgType   config.Type
+	stability StabilityLevel
 }
 
 func (baseFactory) unexportedFactoryFunc() {}
 
 func (bf baseFactory) Type() config.Type {
 	return bf.cfgType
+}
+
+func (bf baseFactory) StabilityLevel() StabilityLevel {
+	return bf.stability
 }

--- a/component/component.go
+++ b/component/component.go
@@ -147,7 +147,7 @@ type Factory interface {
 	Type() config.Type
 
 	// StabilityLevel gets the stability level of the component.
-	StabilityLevel(config.Type) StabilityLevel
+	StabilityLevel(config.DataType) StabilityLevel
 
 	unexportedFactoryFunc()
 }
@@ -163,8 +163,8 @@ func (bf baseFactory) Type() config.Type {
 	return bf.cfgType
 }
 
-func (bf baseFactory) StabilityLevel(cfgType config.Type) StabilityLevel {
-	if val, ok := bf.stability[cfgType]; ok {
+func (bf baseFactory) StabilityLevel(dt config.DataType) StabilityLevel {
+	if val, ok := bf.stability[dt]; ok {
 		return val
 	}
 	return StabilityLevelUndefined

--- a/component/component.go
+++ b/component/component.go
@@ -111,7 +111,7 @@ const (
 type StabilityLevel int
 
 const (
-	_ StabilityLevel = iota // skip 0, start types from 1.
+	StabilityLevelUndefined = iota // skip 0, start types from 1.
 	StabilityLevelUnmaintained
 	StabilityLevelDeprecated
 	StabilityLevelInDevelopment
@@ -146,12 +146,15 @@ type Factory interface {
 	// Type gets the type of the component created by this factory.
 	Type() config.Type
 
+	// StabilityLevel gets the stability level of the component.
+	StabilityLevel(config.Type) StabilityLevel
+
 	unexportedFactoryFunc()
 }
 
 type baseFactory struct {
 	cfgType   config.Type
-	stability StabilityLevel
+	stability map[config.Type]StabilityLevel
 }
 
 func (baseFactory) unexportedFactoryFunc() {}
@@ -160,6 +163,9 @@ func (bf baseFactory) Type() config.Type {
 	return bf.cfgType
 }
 
-func (bf baseFactory) StabilityLevel() StabilityLevel {
-	return bf.stability
+func (bf baseFactory) StabilityLevel(cfgType config.Type) StabilityLevel {
+	if val, ok := bf.stability[cfgType]; ok {
+		return val
+	}
+	return StabilityLevelUndefined
 }

--- a/component/componenttest/nop_exporter.go
+++ b/component/componenttest/nop_exporter.go
@@ -45,7 +45,8 @@ func NewNopExporterFactory() component.ExporterFactory {
 		},
 		component.WithTracesExporter(createTracesExporter),
 		component.WithMetricsExporter(createMetricsExporter),
-		component.WithLogsExporter(createLogsExporter))
+		component.WithLogsExporter(createLogsExporter),
+		component.WithExporterStabilityLevel(component.StabilityLevelInDevelopment))
 }
 
 func createTracesExporter(context.Context, component.ExporterCreateSettings, config.Exporter) (component.TracesExporter, error) {

--- a/component/componenttest/nop_exporter.go
+++ b/component/componenttest/nop_exporter.go
@@ -46,7 +46,12 @@ func NewNopExporterFactory() component.ExporterFactory {
 		component.WithTracesExporter(createTracesExporter),
 		component.WithMetricsExporter(createMetricsExporter),
 		component.WithLogsExporter(createLogsExporter),
-		component.WithExporterStabilityLevel(component.StabilityLevelInDevelopment))
+		component.WithExporterStabilityLevel(map[config.Type]component.StabilityLevel{
+			config.LogsDataType:    component.StabilityLevelInDevelopment,
+			config.TracesDataType:  component.StabilityLevelInDevelopment,
+			config.MetricsDataType: component.StabilityLevelInDevelopment,
+		}),
+	)
 }
 
 func createTracesExporter(context.Context, component.ExporterCreateSettings, config.Exporter) (component.TracesExporter, error) {

--- a/component/componenttest/nop_exporter.go
+++ b/component/componenttest/nop_exporter.go
@@ -43,9 +43,9 @@ func NewNopExporterFactory() component.ExporterFactory {
 				ExporterSettings: config.NewExporterSettings(config.NewComponentID("nop")),
 			}
 		},
-		component.WithTracesExporterAndStabilityLevel(createTracesExporter, component.StabilityLevelInDevelopment),
-		component.WithMetricsExporterAndStabilityLevel(createMetricsExporter, component.StabilityLevelInDevelopment),
-		component.WithLogsExporterAndStabilityLevel(createLogsExporter, component.StabilityLevelInDevelopment),
+		component.WithTracesExporterAndStabilityLevel(createTracesExporter, component.StabilityLevelStable),
+		component.WithMetricsExporterAndStabilityLevel(createMetricsExporter, component.StabilityLevelStable),
+		component.WithLogsExporterAndStabilityLevel(createLogsExporter, component.StabilityLevelStable),
 	)
 }
 

--- a/component/componenttest/nop_exporter.go
+++ b/component/componenttest/nop_exporter.go
@@ -43,14 +43,9 @@ func NewNopExporterFactory() component.ExporterFactory {
 				ExporterSettings: config.NewExporterSettings(config.NewComponentID("nop")),
 			}
 		},
-		component.WithTracesExporter(createTracesExporter),
-		component.WithMetricsExporter(createMetricsExporter),
-		component.WithLogsExporter(createLogsExporter),
-		component.WithExporterStabilityLevel(map[config.Type]component.StabilityLevel{
-			config.LogsDataType:    component.StabilityLevelInDevelopment,
-			config.TracesDataType:  component.StabilityLevelInDevelopment,
-			config.MetricsDataType: component.StabilityLevelInDevelopment,
-		}),
+		component.WithTracesExporterAndStabilityLevel(createTracesExporter, component.StabilityLevelInDevelopment),
+		component.WithMetricsExporterAndStabilityLevel(createMetricsExporter, component.StabilityLevelInDevelopment),
+		component.WithLogsExporterAndStabilityLevel(createLogsExporter, component.StabilityLevelInDevelopment),
 	)
 }
 

--- a/component/componenttest/nop_processor.go
+++ b/component/componenttest/nop_processor.go
@@ -44,9 +44,9 @@ func NewNopProcessorFactory() component.ProcessorFactory {
 				ProcessorSettings: config.NewProcessorSettings(config.NewComponentID("nop")),
 			}
 		},
-		component.WithTracesProcessor(createTracesProcessor),
-		component.WithMetricsProcessor(createMetricsProcessor),
-		component.WithLogsProcessor(createLogsProcessor),
+		component.WithTracesProcessorAndStabilityLevel(createTracesProcessor, component.StabilityLevelInDevelopment),
+		component.WithMetricsProcessorAndStabilityLevel(createMetricsProcessor, component.StabilityLevelInDevelopment),
+		component.WithLogsProcessorAndStabilityLevel(createLogsProcessor, component.StabilityLevelInDevelopment),
 	)
 }
 

--- a/component/componenttest/nop_processor.go
+++ b/component/componenttest/nop_processor.go
@@ -44,9 +44,9 @@ func NewNopProcessorFactory() component.ProcessorFactory {
 				ProcessorSettings: config.NewProcessorSettings(config.NewComponentID("nop")),
 			}
 		},
-		component.WithTracesProcessorAndStabilityLevel(createTracesProcessor, component.StabilityLevelInDevelopment),
-		component.WithMetricsProcessorAndStabilityLevel(createMetricsProcessor, component.StabilityLevelInDevelopment),
-		component.WithLogsProcessorAndStabilityLevel(createLogsProcessor, component.StabilityLevelInDevelopment),
+		component.WithTracesProcessorAndStabilityLevel(createTracesProcessor, component.StabilityLevelStable),
+		component.WithMetricsProcessorAndStabilityLevel(createMetricsProcessor, component.StabilityLevelStable),
+		component.WithLogsProcessorAndStabilityLevel(createLogsProcessor, component.StabilityLevelStable),
 	)
 }
 

--- a/component/componenttest/nop_receiver.go
+++ b/component/componenttest/nop_receiver.go
@@ -43,9 +43,9 @@ func NewNopReceiverFactory() component.ReceiverFactory {
 				ReceiverSettings: config.NewReceiverSettings(config.NewComponentID("nop")),
 			}
 		},
-		component.WithTracesReceiver(createTracesReceiver),
-		component.WithMetricsReceiver(createMetricsReceiver),
-		component.WithLogsReceiver(createLogsReceiver))
+		component.WithTracesReceiverAndStabilityLevel(createTracesReceiver, component.StabilityLevelInDevelopment),
+		component.WithMetricsReceiverAndStabilityLevel(createMetricsReceiver, component.StabilityLevelInDevelopment),
+		component.WithLogsReceiverAndStabilityLevel(createLogsReceiver, component.StabilityLevelInDevelopment))
 }
 
 func createTracesReceiver(context.Context, component.ReceiverCreateSettings, config.Receiver, consumer.Traces) (component.TracesReceiver, error) {

--- a/component/componenttest/nop_receiver.go
+++ b/component/componenttest/nop_receiver.go
@@ -43,9 +43,9 @@ func NewNopReceiverFactory() component.ReceiverFactory {
 				ReceiverSettings: config.NewReceiverSettings(config.NewComponentID("nop")),
 			}
 		},
-		component.WithTracesReceiverAndStabilityLevel(createTracesReceiver, component.StabilityLevelInDevelopment),
-		component.WithMetricsReceiverAndStabilityLevel(createMetricsReceiver, component.StabilityLevelInDevelopment),
-		component.WithLogsReceiverAndStabilityLevel(createLogsReceiver, component.StabilityLevelInDevelopment))
+		component.WithTracesReceiverAndStabilityLevel(createTracesReceiver, component.StabilityLevelStable),
+		component.WithMetricsReceiverAndStabilityLevel(createMetricsReceiver, component.StabilityLevelStable),
+		component.WithLogsReceiverAndStabilityLevel(createLogsReceiver, component.StabilityLevelStable))
 }
 
 func createTracesReceiver(context.Context, component.ReceiverCreateSettings, config.Receiver, consumer.Traces) (component.TracesReceiver, error) {

--- a/component/exporter.go
+++ b/component/exporter.go
@@ -169,6 +169,13 @@ func WithLogsExporter(createLogsExporter CreateLogsExporterFunc) ExporterFactory
 	})
 }
 
+// WithExporterStabiityLevel overrides the default "unmaintained" stability level.
+func WithExporterStabilityLevel(sl StabilityLevel) ExporterFactoryOption {
+	return func(o *exporterFactory) {
+		o.stability = sl
+	}
+}
+
 // NewExporterFactory returns a ExporterFactory.
 func NewExporterFactory(cfgType config.Type, createDefaultConfig ExporterCreateDefaultConfigFunc, options ...ExporterFactoryOption) ExporterFactory {
 	f := &exporterFactory{

--- a/component/exporter.go
+++ b/component/exporter.go
@@ -151,9 +151,7 @@ type exporterFactory struct {
 // WithTracesExporter overrides the default "error not supported" implementation for CreateTracesExporter.
 // Deprecated: [v0.55.0] Use WithTracesExporterAndStabilityLevel instead.
 func WithTracesExporter(createTracesExporter CreateTracesExporterFunc) ExporterFactoryOption {
-	return exporterFactoryOptionFunc(func(o *exporterFactory) {
-		o.CreateTracesExporterFunc = createTracesExporter
-	})
+	return WithTracesExporterAndStabilityLevel(createTracesExporter, StabilityLevelUndefined)
 }
 
 // WithTracesExporterAndStabilityLevel overrides the default "error not supported" implementation for CreateTracesExporter and the default "undefined" stability level.
@@ -167,9 +165,7 @@ func WithTracesExporterAndStabilityLevel(createTracesExporter CreateTracesExport
 // WithMetricsExporter overrides the default "error not supported" implementation for CreateMetricsExporter.
 // Deprecated: [v0.55.0] Use WithMetricsExporterAndStabilityLevel instead.
 func WithMetricsExporter(createMetricsExporter CreateMetricsExporterFunc) ExporterFactoryOption {
-	return exporterFactoryOptionFunc(func(o *exporterFactory) {
-		o.CreateMetricsExporterFunc = createMetricsExporter
-	})
+	return WithMetricsExporterAndStabilityLevel(createMetricsExporter, StabilityLevelUndefined)
 }
 
 // WithMetricsExporterAndStabilityLevel overrides the default "error not supported" implementation for CreateMetricsExporter and the default "undefined" stability level.
@@ -183,9 +179,7 @@ func WithMetricsExporterAndStabilityLevel(createMetricsExporter CreateMetricsExp
 // WithLogsExporter overrides the default "error not supported" implementation for CreateLogsExporter.
 // Deprecated: [v0.55.0] Use WithLogsExporterAndStabilityLevel instead.
 func WithLogsExporter(createLogsExporter CreateLogsExporterFunc) ExporterFactoryOption {
-	return exporterFactoryOptionFunc(func(o *exporterFactory) {
-		o.CreateLogsExporterFunc = createLogsExporter
-	})
+	return WithLogsExporterAndStabilityLevel(createLogsExporter, StabilityLevelUndefined)
 }
 
 // WithLogsExporterAndStabilityLevel overrides the default "error not supported" implementation for CreateLogsExporter and the default "undefined" stability level.

--- a/component/exporter.go
+++ b/component/exporter.go
@@ -149,37 +149,57 @@ type exporterFactory struct {
 }
 
 // WithTracesExporter overrides the default "error not supported" implementation for CreateTracesExporter.
+// Deprecated: [v0.55.0] Use WithTracesExporterAndStabilityLevel instead.
 func WithTracesExporter(createTracesExporter CreateTracesExporterFunc) ExporterFactoryOption {
 	return exporterFactoryOptionFunc(func(o *exporterFactory) {
 		o.CreateTracesExporterFunc = createTracesExporter
 	})
 }
 
+// WithTracesExporterAndStabilityLevel overrides the default "error not supported" implementation for CreateTracesExporter and the default "undefined" stability level.
+func WithTracesExporterAndStabilityLevel(createTracesExporter CreateTracesExporterFunc, sl StabilityLevel) ExporterFactoryOption {
+	return exporterFactoryOptionFunc(func(o *exporterFactory) {
+		o.stability[config.TracesDataType] = sl
+		o.CreateTracesExporterFunc = createTracesExporter
+	})
+}
+
 // WithMetricsExporter overrides the default "error not supported" implementation for CreateMetricsExporter.
+// Deprecated: [v0.55.0] Use WithMetricsExporterAndStabilityLevel instead.
 func WithMetricsExporter(createMetricsExporter CreateMetricsExporterFunc) ExporterFactoryOption {
 	return exporterFactoryOptionFunc(func(o *exporterFactory) {
 		o.CreateMetricsExporterFunc = createMetricsExporter
 	})
 }
 
+// WithMetricsExporterAndStabilityLevel overrides the default "error not supported" implementation for CreateMetricsExporter and the default "undefined" stability level.
+func WithMetricsExporterAndStabilityLevel(createMetricsExporter CreateMetricsExporterFunc, sl StabilityLevel) ExporterFactoryOption {
+	return exporterFactoryOptionFunc(func(o *exporterFactory) {
+		o.stability[config.MetricsDataType] = sl
+		o.CreateMetricsExporterFunc = createMetricsExporter
+	})
+}
+
 // WithLogsExporter overrides the default "error not supported" implementation for CreateLogsExporter.
+// Deprecated: [v0.55.0] Use WithLogsExporterAndStabilityLevel instead.
 func WithLogsExporter(createLogsExporter CreateLogsExporterFunc) ExporterFactoryOption {
 	return exporterFactoryOptionFunc(func(o *exporterFactory) {
 		o.CreateLogsExporterFunc = createLogsExporter
 	})
 }
 
-// WithExporterStabiityLevel overrides the default "unmaintained" stability level.
-func WithExporterStabilityLevel(sl map[config.Type]StabilityLevel) ExporterFactoryOption {
-	return func(o *exporterFactory) {
-		o.stability = sl
-	}
+// WithLogsExporterAndStabilityLevel overrides the default "error not supported" implementation for CreateLogsExporter and the default "undefined" stability level.
+func WithLogsExporterAndStabilityLevel(createLogsExporter CreateLogsExporterFunc, sl StabilityLevel) ExporterFactoryOption {
+	return exporterFactoryOptionFunc(func(o *exporterFactory) {
+		o.stability[config.LogsDataType] = sl
+		o.CreateLogsExporterFunc = createLogsExporter
+	})
 }
 
 // NewExporterFactory returns a ExporterFactory.
 func NewExporterFactory(cfgType config.Type, createDefaultConfig ExporterCreateDefaultConfigFunc, options ...ExporterFactoryOption) ExporterFactory {
 	f := &exporterFactory{
-		baseFactory:                     baseFactory{cfgType: cfgType},
+		baseFactory:                     baseFactory{cfgType: cfgType, stability: map[config.Type]StabilityLevel{}},
 		ExporterCreateDefaultConfigFunc: createDefaultConfig,
 	}
 	for _, opt := range options {

--- a/component/exporter.go
+++ b/component/exporter.go
@@ -199,7 +199,7 @@ func WithLogsExporterAndStabilityLevel(createLogsExporter CreateLogsExporterFunc
 // NewExporterFactory returns a ExporterFactory.
 func NewExporterFactory(cfgType config.Type, createDefaultConfig ExporterCreateDefaultConfigFunc, options ...ExporterFactoryOption) ExporterFactory {
 	f := &exporterFactory{
-		baseFactory:                     baseFactory{cfgType: cfgType, stability: map[config.Type]StabilityLevel{}},
+		baseFactory:                     baseFactory{cfgType: cfgType, stability: make(map[config.DataType]StabilityLevel)},
 		ExporterCreateDefaultConfigFunc: createDefaultConfig,
 	}
 	for _, opt := range options {

--- a/component/exporter.go
+++ b/component/exporter.go
@@ -170,7 +170,7 @@ func WithLogsExporter(createLogsExporter CreateLogsExporterFunc) ExporterFactory
 }
 
 // WithExporterStabiityLevel overrides the default "unmaintained" stability level.
-func WithExporterStabilityLevel(sl StabilityLevel) ExporterFactoryOption {
+func WithExporterStabilityLevel(sl map[config.Type]StabilityLevel) ExporterFactoryOption {
 	return func(o *exporterFactory) {
 		o.stability = sl
 	}

--- a/component/processor.go
+++ b/component/processor.go
@@ -179,22 +179,49 @@ type processorFactory struct {
 }
 
 // WithTracesProcessor overrides the default "error not supported" implementation for CreateTracesProcessor.
+// Deprecated: [v0.55.0] Use WithTracesProcessorAndStabilityLevel instead.
 func WithTracesProcessor(createTracesProcessor CreateTracesProcessorFunc) ProcessorFactoryOption {
 	return processorFactoryOptionFunc(func(o *processorFactory) {
 		o.CreateTracesProcessorFunc = createTracesProcessor
 	})
 }
 
+// WithTracesProcessorAndStabilityLevel overrides the default "error not supported" implementation for CreateTracesProcessor and the default "undefined" stability level.
+func WithTracesProcessorAndStabilityLevel(createTracesProcessor CreateTracesProcessorFunc, sl StabilityLevel) ProcessorFactoryOption {
+	return processorFactoryOptionFunc(func(o *processorFactory) {
+		o.stability[config.TracesDataType] = sl
+		o.CreateTracesProcessorFunc = createTracesProcessor
+	})
+}
+
 // WithMetricsProcessor overrides the default "error not supported" implementation for CreateMetricsProcessor.
+// Deprecated: [v0.55.0] Use WithMetricsProcessorAndStabilityLevel instead.
 func WithMetricsProcessor(createMetricsProcessor CreateMetricsProcessorFunc) ProcessorFactoryOption {
 	return processorFactoryOptionFunc(func(o *processorFactory) {
 		o.CreateMetricsProcessorFunc = createMetricsProcessor
 	})
 }
 
+// WithMetricsProcessorAndStabilityLevel overrides the default "error not supported" implementation for CreateMetricsProcessor and the default "undefined" stability level.
+func WithMetricsProcessorAndStabilityLevel(createMetricsProcessor CreateMetricsProcessorFunc, sl StabilityLevel) ProcessorFactoryOption {
+	return processorFactoryOptionFunc(func(o *processorFactory) {
+		o.stability[config.MetricsDataType] = sl
+		o.CreateMetricsProcessorFunc = createMetricsProcessor
+	})
+}
+
 // WithLogsProcessor overrides the default "error not supported" implementation for CreateLogsProcessor.
+// Deprecated: [v0.55.0] Use WithLogsProcessorAndStabilityLevel instead.
 func WithLogsProcessor(createLogsProcessor CreateLogsProcessorFunc) ProcessorFactoryOption {
 	return processorFactoryOptionFunc(func(o *processorFactory) {
+		o.CreateLogsProcessorFunc = createLogsProcessor
+	})
+}
+
+// WithLogsProcessorAndStabilityLevel overrides the default "error not supported" implementation for CreateLogsProcessor and the default "undefined" stability level.
+func WithLogsProcessorAndStabilityLevel(createLogsProcessor CreateLogsProcessorFunc, sl StabilityLevel) ProcessorFactoryOption {
+	return processorFactoryOptionFunc(func(o *processorFactory) {
+		o.stability[config.LogsDataType] = sl
 		o.CreateLogsProcessorFunc = createLogsProcessor
 	})
 }
@@ -202,7 +229,7 @@ func WithLogsProcessor(createLogsProcessor CreateLogsProcessorFunc) ProcessorFac
 // NewProcessorFactory returns a ProcessorFactory.
 func NewProcessorFactory(cfgType config.Type, createDefaultConfig ProcessorCreateDefaultConfigFunc, options ...ProcessorFactoryOption) ProcessorFactory {
 	f := &processorFactory{
-		baseFactory:                      baseFactory{cfgType: cfgType},
+		baseFactory:                      baseFactory{cfgType: cfgType, stability: make(map[config.DataType]StabilityLevel)},
 		ProcessorCreateDefaultConfigFunc: createDefaultConfig,
 	}
 	for _, opt := range options {

--- a/component/processor.go
+++ b/component/processor.go
@@ -181,9 +181,7 @@ type processorFactory struct {
 // WithTracesProcessor overrides the default "error not supported" implementation for CreateTracesProcessor.
 // Deprecated: [v0.55.0] Use WithTracesProcessorAndStabilityLevel instead.
 func WithTracesProcessor(createTracesProcessor CreateTracesProcessorFunc) ProcessorFactoryOption {
-	return processorFactoryOptionFunc(func(o *processorFactory) {
-		o.CreateTracesProcessorFunc = createTracesProcessor
-	})
+	return WithTracesProcessorAndStabilityLevel(createTracesProcessor, StabilityLevelUndefined)
 }
 
 // WithTracesProcessorAndStabilityLevel overrides the default "error not supported" implementation for CreateTracesProcessor and the default "undefined" stability level.
@@ -197,9 +195,7 @@ func WithTracesProcessorAndStabilityLevel(createTracesProcessor CreateTracesProc
 // WithMetricsProcessor overrides the default "error not supported" implementation for CreateMetricsProcessor.
 // Deprecated: [v0.55.0] Use WithMetricsProcessorAndStabilityLevel instead.
 func WithMetricsProcessor(createMetricsProcessor CreateMetricsProcessorFunc) ProcessorFactoryOption {
-	return processorFactoryOptionFunc(func(o *processorFactory) {
-		o.CreateMetricsProcessorFunc = createMetricsProcessor
-	})
+	return WithMetricsProcessorAndStabilityLevel(createMetricsProcessor, StabilityLevelUndefined)
 }
 
 // WithMetricsProcessorAndStabilityLevel overrides the default "error not supported" implementation for CreateMetricsProcessor and the default "undefined" stability level.
@@ -213,9 +209,7 @@ func WithMetricsProcessorAndStabilityLevel(createMetricsProcessor CreateMetricsP
 // WithLogsProcessor overrides the default "error not supported" implementation for CreateLogsProcessor.
 // Deprecated: [v0.55.0] Use WithLogsProcessorAndStabilityLevel instead.
 func WithLogsProcessor(createLogsProcessor CreateLogsProcessorFunc) ProcessorFactoryOption {
-	return processorFactoryOptionFunc(func(o *processorFactory) {
-		o.CreateLogsProcessorFunc = createLogsProcessor
-	})
+	return WithLogsProcessorAndStabilityLevel(createLogsProcessor, StabilityLevelUndefined)
 }
 
 // WithLogsProcessorAndStabilityLevel overrides the default "error not supported" implementation for CreateLogsProcessor and the default "undefined" stability level.

--- a/component/receiver.go
+++ b/component/receiver.go
@@ -211,22 +211,49 @@ type receiverFactory struct {
 }
 
 // WithTracesReceiver overrides the default "error not supported" implementation for CreateTracesReceiver.
+// Deprecated: [v0.55.0] Use WithTracesReceiverAndStabilityLevel instead.
 func WithTracesReceiver(createTracesReceiver CreateTracesReceiverFunc) ReceiverFactoryOption {
 	return receiverFactoryOptionFunc(func(o *receiverFactory) {
 		o.CreateTracesReceiverFunc = createTracesReceiver
 	})
 }
 
+// WithTracesReceiverAndStabilityLevel overrides the default "error not supported" implementation for CreateTracesReceiver and the default "undefined" stability level.
+func WithTracesReceiverAndStabilityLevel(createTracesReceiver CreateTracesReceiverFunc, sl StabilityLevel) ReceiverFactoryOption {
+	return receiverFactoryOptionFunc(func(o *receiverFactory) {
+		o.stability[config.TracesDataType] = sl
+		o.CreateTracesReceiverFunc = createTracesReceiver
+	})
+}
+
 // WithMetricsReceiver overrides the default "error not supported" implementation for CreateMetricsReceiver.
+// Deprecated: [v0.55.0] Use WithMetricsReceiverAndStabilityLevel instead.
 func WithMetricsReceiver(createMetricsReceiver CreateMetricsReceiverFunc) ReceiverFactoryOption {
 	return receiverFactoryOptionFunc(func(o *receiverFactory) {
 		o.CreateMetricsReceiverFunc = createMetricsReceiver
 	})
 }
 
+// WithMetricsReceiverAndStabilityLevel overrides the default "error not supported" implementation for CreateMetricsReceiver and the default "undefined" stability level.
+func WithMetricsReceiverAndStabilityLevel(createMetricsReceiver CreateMetricsReceiverFunc, sl StabilityLevel) ReceiverFactoryOption {
+	return receiverFactoryOptionFunc(func(o *receiverFactory) {
+		o.stability[config.MetricsDataType] = sl
+		o.CreateMetricsReceiverFunc = createMetricsReceiver
+	})
+}
+
 // WithLogsReceiver overrides the default "error not supported" implementation for CreateLogsReceiver.
+// Deprecated: [v0.55.0] Use WithLogsReceiverAndStabilityLevel instead.
 func WithLogsReceiver(createLogsReceiver CreateLogsReceiverFunc) ReceiverFactoryOption {
 	return receiverFactoryOptionFunc(func(o *receiverFactory) {
+		o.CreateLogsReceiverFunc = createLogsReceiver
+	})
+}
+
+// WithLogsReceiverAndStabilityLevel overrides the default "error not supported" implementation for CreateLogsReceiver and the default "undefined" stability level.
+func WithLogsReceiverAndStabilityLevel(createLogsReceiver CreateLogsReceiverFunc, sl StabilityLevel) ReceiverFactoryOption {
+	return receiverFactoryOptionFunc(func(o *receiverFactory) {
+		o.stability[config.LogsDataType] = sl
 		o.CreateLogsReceiverFunc = createLogsReceiver
 	})
 }
@@ -234,7 +261,7 @@ func WithLogsReceiver(createLogsReceiver CreateLogsReceiverFunc) ReceiverFactory
 // NewReceiverFactory returns a ReceiverFactory.
 func NewReceiverFactory(cfgType config.Type, createDefaultConfig ReceiverCreateDefaultConfigFunc, options ...ReceiverFactoryOption) ReceiverFactory {
 	f := &receiverFactory{
-		baseFactory:                     baseFactory{cfgType: cfgType},
+		baseFactory:                     baseFactory{cfgType: cfgType, stability: make(map[config.DataType]StabilityLevel)},
 		ReceiverCreateDefaultConfigFunc: createDefaultConfig,
 	}
 	for _, opt := range options {

--- a/component/receiver.go
+++ b/component/receiver.go
@@ -213,9 +213,7 @@ type receiverFactory struct {
 // WithTracesReceiver overrides the default "error not supported" implementation for CreateTracesReceiver.
 // Deprecated: [v0.55.0] Use WithTracesReceiverAndStabilityLevel instead.
 func WithTracesReceiver(createTracesReceiver CreateTracesReceiverFunc) ReceiverFactoryOption {
-	return receiverFactoryOptionFunc(func(o *receiverFactory) {
-		o.CreateTracesReceiverFunc = createTracesReceiver
-	})
+	return WithTracesReceiverAndStabilityLevel(createTracesReceiver, StabilityLevelUndefined)
 }
 
 // WithTracesReceiverAndStabilityLevel overrides the default "error not supported" implementation for CreateTracesReceiver and the default "undefined" stability level.
@@ -229,9 +227,7 @@ func WithTracesReceiverAndStabilityLevel(createTracesReceiver CreateTracesReceiv
 // WithMetricsReceiver overrides the default "error not supported" implementation for CreateMetricsReceiver.
 // Deprecated: [v0.55.0] Use WithMetricsReceiverAndStabilityLevel instead.
 func WithMetricsReceiver(createMetricsReceiver CreateMetricsReceiverFunc) ReceiverFactoryOption {
-	return receiverFactoryOptionFunc(func(o *receiverFactory) {
-		o.CreateMetricsReceiverFunc = createMetricsReceiver
-	})
+	return WithMetricsReceiverAndStabilityLevel(createMetricsReceiver, StabilityLevelUndefined)
 }
 
 // WithMetricsReceiverAndStabilityLevel overrides the default "error not supported" implementation for CreateMetricsReceiver and the default "undefined" stability level.
@@ -245,9 +241,7 @@ func WithMetricsReceiverAndStabilityLevel(createMetricsReceiver CreateMetricsRec
 // WithLogsReceiver overrides the default "error not supported" implementation for CreateLogsReceiver.
 // Deprecated: [v0.55.0] Use WithLogsReceiverAndStabilityLevel instead.
 func WithLogsReceiver(createLogsReceiver CreateLogsReceiverFunc) ReceiverFactoryOption {
-	return receiverFactoryOptionFunc(func(o *receiverFactory) {
-		o.CreateLogsReceiverFunc = createLogsReceiver
-	})
+	return WithLogsReceiverAndStabilityLevel(createLogsReceiver, StabilityLevelUndefined)
 }
 
 // WithLogsReceiverAndStabilityLevel overrides the default "error not supported" implementation for CreateLogsReceiver and the default "undefined" stability level.

--- a/component/receiver_test.go
+++ b/component/receiver_test.go
@@ -62,6 +62,31 @@ func TestNewReceiverFactory_WithOptions(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestNewReceiverFactory_WithStabilityLevels(t *testing.T) {
+	const typeStr = "test"
+	defaultCfg := config.NewReceiverSettings(config.NewComponentID(typeStr))
+	factory := NewReceiverFactory(
+		typeStr,
+		func() config.Receiver { return &defaultCfg },
+		WithTracesReceiverAndStabilityLevel(createTracesReceiver, StabilityLevelDeprecated),
+		WithMetricsReceiverAndStabilityLevel(createMetricsReceiver, StabilityLevelAlpha),
+		WithLogsReceiverAndStabilityLevel(createLogsReceiver, StabilityLevelStable))
+	assert.EqualValues(t, typeStr, factory.Type())
+	assert.EqualValues(t, &defaultCfg, factory.CreateDefaultConfig())
+
+	assert.EqualValues(t, StabilityLevelDeprecated, factory.StabilityLevel(config.TracesDataType))
+	_, err := factory.CreateTracesReceiver(context.Background(), ReceiverCreateSettings{}, &defaultCfg, nil)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, StabilityLevelAlpha, factory.StabilityLevel(config.MetricsDataType))
+	_, err = factory.CreateMetricsReceiver(context.Background(), ReceiverCreateSettings{}, &defaultCfg, nil)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, StabilityLevelStable, factory.StabilityLevel(config.LogsDataType))
+	_, err = factory.CreateLogsReceiver(context.Background(), ReceiverCreateSettings{}, &defaultCfg, nil)
+	assert.NoError(t, err)
+}
+
 func createTracesReceiver(context.Context, ReceiverCreateSettings, config.Receiver, consumer.Traces) (TracesReceiver, error) {
 	return nil, nil
 }

--- a/exporter/loggingexporter/factory.go
+++ b/exporter/loggingexporter/factory.go
@@ -36,14 +36,10 @@ func NewFactory() component.ExporterFactory {
 	return component.NewExporterFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithTracesExporter(createTracesExporter),
-		component.WithMetricsExporter(createMetricsExporter),
-		component.WithLogsExporter(createLogsExporter),
-		component.WithExporterStabilityLevel(map[config.Type]component.StabilityLevel{
-			config.LogsDataType:    component.StabilityLevelInDevelopment,
-			config.TracesDataType:  component.StabilityLevelInDevelopment,
-			config.MetricsDataType: component.StabilityLevelInDevelopment,
-		}))
+		component.WithTracesExporterAndStabilityLevel(createTracesExporter, component.StabilityLevelInDevelopment),
+		component.WithMetricsExporterAndStabilityLevel(createMetricsExporter, component.StabilityLevelInDevelopment),
+		component.WithLogsExporterAndStabilityLevel(createLogsExporter, component.StabilityLevelInDevelopment),
+	)
 }
 
 func createDefaultConfig() config.Exporter {

--- a/exporter/loggingexporter/factory.go
+++ b/exporter/loggingexporter/factory.go
@@ -27,6 +27,7 @@ import (
 const (
 	// The value of "type" key in configuration.
 	typeStr                   = "logging"
+	stability                 = component.StabilityLevelInDevelopment
 	defaultSamplingInitial    = 2
 	defaultSamplingThereafter = 500
 )
@@ -38,7 +39,8 @@ func NewFactory() component.ExporterFactory {
 		createDefaultConfig,
 		component.WithTracesExporter(createTracesExporter),
 		component.WithMetricsExporter(createMetricsExporter),
-		component.WithLogsExporter(createLogsExporter))
+		component.WithLogsExporter(createLogsExporter),
+		component.WithExporterStabilityLevel(stability))
 }
 
 func createDefaultConfig() config.Exporter {

--- a/exporter/loggingexporter/factory.go
+++ b/exporter/loggingexporter/factory.go
@@ -27,7 +27,6 @@ import (
 const (
 	// The value of "type" key in configuration.
 	typeStr                   = "logging"
-	stability                 = component.StabilityLevelInDevelopment
 	defaultSamplingInitial    = 2
 	defaultSamplingThereafter = 500
 )
@@ -40,7 +39,11 @@ func NewFactory() component.ExporterFactory {
 		component.WithTracesExporter(createTracesExporter),
 		component.WithMetricsExporter(createMetricsExporter),
 		component.WithLogsExporter(createLogsExporter),
-		component.WithExporterStabilityLevel(stability))
+		component.WithExporterStabilityLevel(map[config.Type]component.StabilityLevel{
+			config.LogsDataType:    component.StabilityLevelInDevelopment,
+			config.TracesDataType:  component.StabilityLevelInDevelopment,
+			config.MetricsDataType: component.StabilityLevelInDevelopment,
+		}))
 }
 
 func createDefaultConfig() config.Exporter {

--- a/exporter/otlpexporter/factory.go
+++ b/exporter/otlpexporter/factory.go
@@ -27,8 +27,7 @@ import (
 
 const (
 	// The value of "type" key in configuration.
-	typeStr   = "otlp"
-	stability = component.StabilityLevelBeta
+	typeStr = "otlp"
 )
 
 // NewFactory creates a factory for OTLP exporter.
@@ -36,14 +35,10 @@ func NewFactory() component.ExporterFactory {
 	return component.NewExporterFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithTracesExporter(createTracesExporter),
-		component.WithMetricsExporter(createMetricsExporter),
-		component.WithLogsExporter(createLogsExporter),
-		component.WithExporterStabilityLevel(map[config.Type]component.StabilityLevel{
-			config.LogsDataType:    component.StabilityLevelBeta,
-			config.TracesDataType:  component.StabilityLevelStable,
-			config.MetricsDataType: component.StabilityLevelStable,
-		}))
+		component.WithTracesExporterAndStabilityLevel(createTracesExporter, component.StabilityLevelStable),
+		component.WithMetricsExporterAndStabilityLevel(createMetricsExporter, component.StabilityLevelStable),
+		component.WithLogsExporterAndStabilityLevel(createLogsExporter, component.StabilityLevelBeta),
+	)
 }
 
 func createDefaultConfig() config.Exporter {

--- a/exporter/otlpexporter/factory.go
+++ b/exporter/otlpexporter/factory.go
@@ -27,7 +27,8 @@ import (
 
 const (
 	// The value of "type" key in configuration.
-	typeStr = "otlp"
+	typeStr   = "otlp"
+	stability = component.StabilityLevelBeta
 )
 
 // NewFactory creates a factory for OTLP exporter.
@@ -37,7 +38,8 @@ func NewFactory() component.ExporterFactory {
 		createDefaultConfig,
 		component.WithTracesExporter(createTracesExporter),
 		component.WithMetricsExporter(createMetricsExporter),
-		component.WithLogsExporter(createLogsExporter))
+		component.WithLogsExporter(createLogsExporter),
+		component.WithExporterStabilityLevel(stability))
 }
 
 func createDefaultConfig() config.Exporter {

--- a/exporter/otlpexporter/factory.go
+++ b/exporter/otlpexporter/factory.go
@@ -39,7 +39,11 @@ func NewFactory() component.ExporterFactory {
 		component.WithTracesExporter(createTracesExporter),
 		component.WithMetricsExporter(createMetricsExporter),
 		component.WithLogsExporter(createLogsExporter),
-		component.WithExporterStabilityLevel(stability))
+		component.WithExporterStabilityLevel(map[config.Type]component.StabilityLevel{
+			config.LogsDataType:    component.StabilityLevelBeta,
+			config.TracesDataType:  component.StabilityLevelStable,
+			config.MetricsDataType: component.StabilityLevelStable,
+		}))
 }
 
 func createDefaultConfig() config.Exporter {

--- a/exporter/otlphttpexporter/factory.go
+++ b/exporter/otlphttpexporter/factory.go
@@ -42,7 +42,11 @@ func NewFactory() component.ExporterFactory {
 		component.WithTracesExporter(createTracesExporter),
 		component.WithMetricsExporter(createMetricsExporter),
 		component.WithLogsExporter(createLogsExporter),
-		component.WithExporterStabilityLevel(stability))
+		component.WithExporterStabilityLevel(map[config.Type]component.StabilityLevel{
+			config.LogsDataType:    component.StabilityLevelBeta,
+			config.TracesDataType:  component.StabilityLevelStable,
+			config.MetricsDataType: component.StabilityLevelStable,
+		}))
 }
 
 func createDefaultConfig() config.Exporter {

--- a/exporter/otlphttpexporter/factory.go
+++ b/exporter/otlphttpexporter/factory.go
@@ -30,7 +30,8 @@ import (
 
 const (
 	// The value of "type" key in configuration.
-	typeStr = "otlphttp"
+	typeStr   = "otlphttp"
+	stability = component.StabilityLevelBeta
 )
 
 // NewFactory creates a factory for OTLP exporter.
@@ -40,7 +41,8 @@ func NewFactory() component.ExporterFactory {
 		createDefaultConfig,
 		component.WithTracesExporter(createTracesExporter),
 		component.WithMetricsExporter(createMetricsExporter),
-		component.WithLogsExporter(createLogsExporter))
+		component.WithLogsExporter(createLogsExporter),
+		component.WithExporterStabilityLevel(stability))
 }
 
 func createDefaultConfig() config.Exporter {

--- a/exporter/otlphttpexporter/factory.go
+++ b/exporter/otlphttpexporter/factory.go
@@ -30,8 +30,7 @@ import (
 
 const (
 	// The value of "type" key in configuration.
-	typeStr   = "otlphttp"
-	stability = component.StabilityLevelBeta
+	typeStr = "otlphttp"
 )
 
 // NewFactory creates a factory for OTLP exporter.
@@ -39,14 +38,10 @@ func NewFactory() component.ExporterFactory {
 	return component.NewExporterFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithTracesExporter(createTracesExporter),
-		component.WithMetricsExporter(createMetricsExporter),
-		component.WithLogsExporter(createLogsExporter),
-		component.WithExporterStabilityLevel(map[config.Type]component.StabilityLevel{
-			config.LogsDataType:    component.StabilityLevelBeta,
-			config.TracesDataType:  component.StabilityLevelStable,
-			config.MetricsDataType: component.StabilityLevelStable,
-		}))
+		component.WithTracesExporterAndStabilityLevel(createTracesExporter, component.StabilityLevelStable),
+		component.WithMetricsExporterAndStabilityLevel(createMetricsExporter, component.StabilityLevelStable),
+		component.WithLogsExporterAndStabilityLevel(createLogsExporter, component.StabilityLevelBeta),
+	)
 }
 
 func createDefaultConfig() config.Exporter {

--- a/internal/testcomponents/example_exporter.go
+++ b/internal/testcomponents/example_exporter.go
@@ -42,7 +42,11 @@ var ExampleExporterFactory = component.NewExporterFactory(
 	component.WithTracesExporter(createTracesExporter),
 	component.WithMetricsExporter(createMetricsExporter),
 	component.WithLogsExporter(createLogsExporter),
-	component.WithExporterStabilityLevel(stability))
+	component.WithExporterStabilityLevel(map[config.Type]component.StabilityLevel{
+		config.LogsDataType:    component.StabilityLevelInDevelopment,
+		config.TracesDataType:  component.StabilityLevelInDevelopment,
+		config.MetricsDataType: component.StabilityLevelInDevelopment,
+	}))
 
 func createExporterDefaultConfig() config.Exporter {
 	return &ExampleExporterConfig{

--- a/internal/testcomponents/example_exporter.go
+++ b/internal/testcomponents/example_exporter.go
@@ -25,7 +25,10 @@ import (
 	"go.opentelemetry.io/collector/pdata/ptrace"
 )
 
-const expType = "exampleexporter"
+const (
+	typeStr   = "exampleexporter"
+	stability = component.StabilityLevelInDevelopment
+)
 
 // ExampleExporterConfig config for ExampleExporter.
 type ExampleExporterConfig struct {
@@ -34,15 +37,16 @@ type ExampleExporterConfig struct {
 
 // ExampleExporterFactory is factory for ExampleExporter.
 var ExampleExporterFactory = component.NewExporterFactory(
-	expType,
+	typeStr,
 	createExporterDefaultConfig,
 	component.WithTracesExporter(createTracesExporter),
 	component.WithMetricsExporter(createMetricsExporter),
-	component.WithLogsExporter(createLogsExporter))
+	component.WithLogsExporter(createLogsExporter),
+	component.WithExporterStabilityLevel(stability))
 
 func createExporterDefaultConfig() config.Exporter {
 	return &ExampleExporterConfig{
-		ExporterSettings: config.NewExporterSettings(config.NewComponentID(expType)),
+		ExporterSettings: config.NewExporterSettings(config.NewComponentID(typeStr)),
 	}
 }
 

--- a/internal/testcomponents/example_exporter.go
+++ b/internal/testcomponents/example_exporter.go
@@ -39,14 +39,10 @@ type ExampleExporterConfig struct {
 var ExampleExporterFactory = component.NewExporterFactory(
 	typeStr,
 	createExporterDefaultConfig,
-	component.WithTracesExporter(createTracesExporter),
-	component.WithMetricsExporter(createMetricsExporter),
-	component.WithLogsExporter(createLogsExporter),
-	component.WithExporterStabilityLevel(map[config.Type]component.StabilityLevel{
-		config.LogsDataType:    component.StabilityLevelInDevelopment,
-		config.TracesDataType:  component.StabilityLevelInDevelopment,
-		config.MetricsDataType: component.StabilityLevelInDevelopment,
-	}))
+	component.WithTracesExporterAndStabilityLevel(createTracesExporter, stability),
+	component.WithMetricsExporterAndStabilityLevel(createMetricsExporter, stability),
+	component.WithLogsExporterAndStabilityLevel(createLogsExporter, stability),
+)
 
 func createExporterDefaultConfig() config.Exporter {
 	return &ExampleExporterConfig{

--- a/internal/testcomponents/example_processor.go
+++ b/internal/testcomponents/example_processor.go
@@ -33,9 +33,9 @@ type ExampleProcessorConfig struct {
 var ExampleProcessorFactory = component.NewProcessorFactory(
 	procType,
 	createDefaultConfig,
-	component.WithTracesProcessor(createTracesProcessor),
-	component.WithMetricsProcessor(createMetricsProcessor),
-	component.WithLogsProcessor(createLogsProcessor))
+	component.WithTracesProcessorAndStabilityLevel(createTracesProcessor, component.StabilityLevelInDevelopment),
+	component.WithMetricsProcessorAndStabilityLevel(createMetricsProcessor, component.StabilityLevelInDevelopment),
+	component.WithLogsProcessorAndStabilityLevel(createLogsProcessor, component.StabilityLevelInDevelopment))
 
 // CreateDefaultConfig creates the default configuration for the Processor.
 func createDefaultConfig() config.Processor {

--- a/internal/testcomponents/example_receiver.go
+++ b/internal/testcomponents/example_receiver.go
@@ -33,9 +33,9 @@ type ExampleReceiverConfig struct {
 var ExampleReceiverFactory = component.NewReceiverFactory(
 	receiverType,
 	createReceiverDefaultConfig,
-	component.WithTracesReceiver(createTracesReceiver),
-	component.WithMetricsReceiver(createMetricsReceiver),
-	component.WithLogsReceiver(createLogsReceiver))
+	component.WithTracesReceiverAndStabilityLevel(createTracesReceiver, component.StabilityLevelInDevelopment),
+	component.WithMetricsReceiverAndStabilityLevel(createMetricsReceiver, component.StabilityLevelInDevelopment),
+	component.WithLogsReceiverAndStabilityLevel(createLogsReceiver, component.StabilityLevelInDevelopment))
 
 func createReceiverDefaultConfig() config.Receiver {
 	return &ExampleReceiverConfig{

--- a/processor/batchprocessor/factory.go
+++ b/processor/batchprocessor/factory.go
@@ -36,9 +36,9 @@ func NewFactory() component.ProcessorFactory {
 	return component.NewProcessorFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithTracesProcessor(createTracesProcessor),
-		component.WithMetricsProcessor(createMetricsProcessor),
-		component.WithLogsProcessor(createLogsProcessor))
+		component.WithTracesProcessorAndStabilityLevel(createTracesProcessor, component.StabilityLevelStable),
+		component.WithMetricsProcessorAndStabilityLevel(createMetricsProcessor, component.StabilityLevelStable),
+		component.WithLogsProcessorAndStabilityLevel(createLogsProcessor, component.StabilityLevelStable))
 }
 
 func createDefaultConfig() config.Processor {

--- a/processor/memorylimiterprocessor/factory.go
+++ b/processor/memorylimiterprocessor/factory.go
@@ -46,9 +46,9 @@ func NewFactory() component.ProcessorFactory {
 	return component.NewProcessorFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithTracesProcessor(f.createTracesProcessor),
-		component.WithMetricsProcessor(f.createMetricsProcessor),
-		component.WithLogsProcessor(f.createLogsProcessor))
+		component.WithTracesProcessorAndStabilityLevel(f.createTracesProcessor, component.StabilityLevelBeta),
+		component.WithMetricsProcessorAndStabilityLevel(f.createMetricsProcessor, component.StabilityLevelBeta),
+		component.WithLogsProcessorAndStabilityLevel(f.createLogsProcessor, component.StabilityLevelBeta))
 }
 
 // CreateDefaultConfig creates the default configuration for processor. Notice

--- a/receiver/otlpreceiver/factory.go
+++ b/receiver/otlpreceiver/factory.go
@@ -38,9 +38,9 @@ func NewFactory() component.ReceiverFactory {
 	return component.NewReceiverFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithTracesReceiver(createTracesReceiver),
-		component.WithMetricsReceiver(createMetricsReceiver),
-		component.WithLogsReceiver(createLogReceiver))
+		component.WithTracesReceiverAndStabilityLevel(createTracesReceiver, component.StabilityLevelStable),
+		component.WithMetricsReceiverAndStabilityLevel(createMetricsReceiver, component.StabilityLevelStable),
+		component.WithLogsReceiverAndStabilityLevel(createLogReceiver, component.StabilityLevelBeta))
 }
 
 // createDefaultConfig creates the default configuration for receiver.

--- a/service/internal/components/constants.go
+++ b/service/internal/components/constants.go
@@ -23,4 +23,5 @@ const (
 	ZapKindPipeline  = "pipeline"
 	ZapNameKey       = "name"
 	ZapDataTypeKey   = "data_type"
+	ZapStabilityKey  = "stability"
 )

--- a/service/internal/pipelines/pipelines.go
+++ b/service/internal/pipelines/pipelines.go
@@ -312,11 +312,7 @@ func logStabilityMessage(logger *zap.Logger, sl component.StabilityLevel) {
 		logger.Info("Component is unmaintained and actively looking for contributors. This component will become deprecated after 6 months of remaining unmaintained", zap.String(components.ZapStabilityKey, sl.String()))
 	case component.StabilityLevelInDevelopment:
 		logger.Info("Component is under development.", zap.String(components.ZapStabilityKey, sl.String()))
-	case component.StabilityLevelAlpha:
-		fallthrough
-	case component.StabilityLevelBeta:
-		fallthrough
-	case component.StabilityLevelStable:
+	case component.StabilityLevelAlpha, component.StabilityLevelBeta, component.StabilityLevelStable:
 		logger.Debug("Stability level", zap.String(components.ZapStabilityKey, sl.String()))
 	default:
 		logger.Info("Stability level of component undefined", zap.String(components.ZapStabilityKey, sl.String()))

--- a/service/internal/pipelines/pipelines.go
+++ b/service/internal/pipelines/pipelines.go
@@ -309,11 +309,13 @@ func logStabilityMessage(logger *zap.Logger, sl component.StabilityLevel) {
 	case component.StabilityLevelDeprecated:
 		logger.Info("Component has been deprecated and will be removed in future releases.", zap.String(components.ZapStabilityKey, sl.String()))
 	case component.StabilityLevelUnmaintained:
-		logger.Info("Component is unmaintained and actively looking for contributors.", zap.String(components.ZapStabilityKey, sl.String()))
+		logger.Info("Component is unmaintained and actively looking for contributors. This component will become deprecated after 6 months of remaining unmaintained", zap.String(components.ZapStabilityKey, sl.String()))
 	case component.StabilityLevelInDevelopment:
 		logger.Info("Component is under development.", zap.String(components.ZapStabilityKey, sl.String()))
 	case component.StabilityLevelAlpha:
+		fallthrough
 	case component.StabilityLevelBeta:
+		fallthrough
 	case component.StabilityLevelStable:
 		logger.Debug("Stability level", zap.String(components.ZapStabilityKey, sl.String()))
 	default:

--- a/service/internal/pipelines/pipelines.go
+++ b/service/internal/pipelines/pipelines.go
@@ -425,6 +425,7 @@ func buildProcessor(ctx context.Context,
 		BuildInfo:         buildInfo,
 	}
 	set.TelemetrySettings.Logger = processorLogger(settings.Logger, id, pipelineID)
+	logStabilityMessage(set.TelemetrySettings.Logger, factory.StabilityLevel(pipelineID.Type()))
 
 	proc, err := createProcessor(ctx, set, procCfg, id, pipelineID, next, factory)
 	if err != nil {
@@ -478,6 +479,7 @@ func buildReceiver(ctx context.Context,
 		BuildInfo:         buildInfo,
 	}
 	set.TelemetrySettings.Logger = receiverLogger(settings.Logger, id, pipelineID.Type())
+	logStabilityMessage(set.TelemetrySettings.Logger, factory.StabilityLevel(pipelineID.Type()))
 
 	recv, err := createReceiver(ctx, set, cfg, id, pipelineID, nexts, factory)
 	if err != nil {

--- a/service/internal/pipelines/pipelines_test.go
+++ b/service/internal/pipelines/pipelines_test.go
@@ -20,11 +20,10 @@ import (
 	"path/filepath"
 	"testing"
 
-	"go.uber.org/zap/zapcore"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"
 
 	"go.opentelemetry.io/collector/component"


### PR DESCRIPTION
The following allows the setting of a stability level on the factory. This will let us consolidate warnings across all components to notify users of deprecated, unmaintained components.
