### PR TITLE
[exporter/otlpexporter]: remove stale comment

### DIFF
--- a/exporter/otlpexporter/otlp.go
+++ b/exporter/otlpexporter/otlp.go
@@ -125,9 +125,6 @@ func (e *exporter) enhanceContext(ctx context.Context) context.Context {
 	return ctx
 }
 
-// Send a trace or metrics request to the server. "perform" function is expected to make
-// the actual gRPC unary call that sends the request. This function implements the
-// common OTLP logic around request handling such as retries and throttling.
 func processError(err error) error {
 	if err == nil {
 		// Request is successful, we are done.


### PR DESCRIPTION
This comment ended up on the wrong function over time, and it generally doesn't apply.

## Important (read before submitting)
We are currently preparing for the upcoming 1.0 GA release. Pull requests that are not aligned with
the current roadmap https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/roadmap.md
and are not aimed at stabilizing and preparing the Collector for the release will not be accepted.

_Delete this paragraph before submitting._

**Description:** <Describe what has changed. 
Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.>

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** < Describe what testing was performed and which tests were added.>

**Documentation:** < Describe the documentation added.>

_Please delete paragraphs that you did not use before submitting._
