### PR TITLE
Restore "Shutdown complete" log

### DIFF
--- a/service/collector.go
+++ b/service/collector.go
@@ -243,6 +243,7 @@ func (col *Collector) shutdown(ctx context.Context) error {
 		errs = multierr.Append(errs, fmt.Errorf("failed to shutdown collector telemetry: %w", err))
 	}
 
+	col.service.telemetrySettings.Logger.Info("Shutdown complete.")
 	col.setCollectorState(Closed)
 
 	return errs


### PR DESCRIPTION
Fixes #5625 

**Testing:** 

I have run:

```console
make install-tools
make
make otelcorecol
```

After the otelcorecol binary was built, I ran it with a simple config:

```yaml
exporters:
  logging:

receivers:
  otlp:
    protocols:
      http:

service:
  pipelines:
    traces:
      receivers:
      - otlp
      exporters:
      - logging
```

and got the following log output, including the "Shutdown complete" log:

```console
2022-07-04T12:58:21.506+0200    info    service/telemetry.go:103        Setting up own telemetry...
2022-07-04T12:58:21.507+0200    info    service/telemetry.go:138        Serving Prometheus metrics      {"address": ":8888", "level": "basic"}
2022-07-04T12:58:21.507+0200    info    extensions/extensions.go:42     Starting extensions...
2022-07-04T12:58:21.507+0200    info    pipelines/pipelines.go:74       Starting exporters...
2022-07-04T12:58:21.507+0200    info    pipelines/pipelines.go:78       Exporter is starting... {"kind": "exporter", "data_type": "traces", "name": "logging"}
2022-07-04T12:58:21.507+0200    info    pipelines/pipelines.go:82       Exporter started.       {"kind": "exporter", "data_type": "traces", "name": "logging"}
2022-07-04T12:58:21.507+0200    info    pipelines/pipelines.go:86       Starting processors...
2022-07-04T12:58:21.507+0200    info    pipelines/pipelines.go:98       Starting receivers...
2022-07-04T12:58:21.507+0200    info    pipelines/pipelines.go:102      Receiver is starting... {"kind": "receiver", "name": "otlp", "pipeline": "traces"}
2022-07-04T12:58:21.507+0200    info    otlpreceiver/otlp.go:88 Starting HTTP server on endpoint 0.0.0.0:4318   {"kind": "receiver", "name": "otlp", "pipeline": "traces"}
2022-07-04T12:58:21.507+0200    info    pipelines/pipelines.go:106      Receiver started.       {"kind": "receiver", "name": "otlp", "pipeline": "traces"}
2022-07-04T12:58:21.507+0200    info    service/collector.go:215        Starting otelcorecol... {"Version": "0.54.0-dev", "NumCPU": 16}
2022-07-04T12:58:21.507+0200    info    service/collector.go:128        Everything is ready. Begin running and processing data.

^C2022-07-04T12:58:24.650+0200  info    service/collector.go:159        Received signal from OS {"signal": "interrupt"}
2022-07-04T12:58:24.650+0200    info    service/collector.go:231        Starting shutdown...
2022-07-04T12:58:24.650+0200    info    pipelines/pipelines.go:118      Stopping receivers...
2022-07-04T12:58:24.651+0200    info    pipelines/pipelines.go:125      Stopping processors...
2022-07-04T12:58:24.651+0200    info    pipelines/pipelines.go:132      Stopping exporters...
2022-07-04T12:58:24.651+0200    info    extensions/extensions.go:56     Stopping extensions...
2022-07-04T12:58:24.651+0200    info    service/collector.go:246        Shutdown complete.
```