### PR TITLE
Set log level for `undefined` stability level to debug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 ### 🧰 Bug fixes 🧰
 
 - Fix initialization of the OpenTelemetry MetricProvider. (#5571)
+- Set log level for `undefined` stability level to debug. (#5635)
 
 ## v0.54.0 Beta
 

--- a/service/internal/pipelines/pipelines.go
+++ b/service/internal/pipelines/pipelines.go
@@ -342,7 +342,7 @@ func logStabilityMessage(logger *zap.Logger, sl component.StabilityLevel) {
 	case component.StabilityLevelAlpha, component.StabilityLevelBeta, component.StabilityLevelStable:
 		logger.Debug("Stability level", zap.String(components.ZapStabilityKey, sl.String()))
 	default:
-		logger.Info("Stability level of component undefined", zap.String(components.ZapStabilityKey, sl.String()))
+		logger.Debug("Stability level of component undefined", zap.String(components.ZapStabilityKey, sl.String()))
 	}
 }
 

--- a/service/internal/pipelines/pipelines_test.go
+++ b/service/internal/pipelines/pipelines_test.go
@@ -359,7 +359,7 @@ func TestLogStabilityLevle(t *testing.T) {
 		},
 		{
 			level:        zapcore.InfoLevel,
-			expectedLogs: 4,
+			expectedLogs: 3,
 		},
 	}
 


### PR DESCRIPTION
This is option 1 of https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/12104

This gives component owners more time to set the stability level of the components.
