### PR TITLE
Prepare v0.55.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.55.0 Beta
+
 ### 🛑 Breaking changes 🛑
 
 - Remove deprecated `config.ServiceTelemetry` (#5565)

--- a/cmd/builder/internal/builder/config.go
+++ b/cmd/builder/internal/builder/config.go
@@ -25,7 +25,7 @@ import (
 	"go.uber.org/zap"
 )
 
-const defaultOtelColVersion = "0.54.0"
+const defaultOtelColVersion = "0.55.0"
 
 // ErrInvalidGoMod indicates an invalid gomod
 var ErrInvalidGoMod = errors.New("invalid gomod specification for module")

--- a/cmd/otelcorecol/builder-config.yaml
+++ b/cmd/otelcorecol/builder-config.yaml
@@ -2,29 +2,29 @@ dist:
   module: go.opentelemetry.io/collector/cmd/otelcorecol
   name: otelcorecol
   description: Local OpenTelemetry Collector binary, testing only.
-  version: 0.54.0-dev
-  otelcol_version: 0.54.0
+  version: 0.55.0-dev
+  otelcol_version: 0.55.0
 
 receivers:
   - import: go.opentelemetry.io/collector/receiver/otlpreceiver
-    gomod: go.opentelemetry.io/collector v0.54.0
+    gomod: go.opentelemetry.io/collector v0.55.0
 exporters:
   - import: go.opentelemetry.io/collector/exporter/loggingexporter
-    gomod: go.opentelemetry.io/collector v0.54.0
+    gomod: go.opentelemetry.io/collector v0.55.0
   - import: go.opentelemetry.io/collector/exporter/otlpexporter
-    gomod: go.opentelemetry.io/collector v0.54.0
+    gomod: go.opentelemetry.io/collector v0.55.0
   - import: go.opentelemetry.io/collector/exporter/otlphttpexporter
-    gomod: go.opentelemetry.io/collector v0.54.0
+    gomod: go.opentelemetry.io/collector v0.55.0
 extensions:
   - import: go.opentelemetry.io/collector/extension/ballastextension
-    gomod: go.opentelemetry.io/collector v0.54.0
+    gomod: go.opentelemetry.io/collector v0.55.0
   - import: go.opentelemetry.io/collector/extension/zpagesextension
-    gomod: go.opentelemetry.io/collector v0.54.0
+    gomod: go.opentelemetry.io/collector v0.55.0
 processors:
   - import: go.opentelemetry.io/collector/processor/batchprocessor
-    gomod: go.opentelemetry.io/collector v0.54.0
+    gomod: go.opentelemetry.io/collector v0.55.0
   - import: go.opentelemetry.io/collector/processor/memorylimiterprocessor
-    gomod: go.opentelemetry.io/collector v0.54.0
+    gomod: go.opentelemetry.io/collector v0.55.0
 
 replaces:
   - go.opentelemetry.io/collector => ../../

--- a/cmd/otelcorecol/go.mod
+++ b/cmd/otelcorecol/go.mod
@@ -6,7 +6,7 @@ go 1.17
 
 require (
 	github.com/stretchr/testify v1.7.5
-	go.opentelemetry.io/collector v0.54.0
+	go.opentelemetry.io/collector v0.55.0
 	golang.org/x/sys v0.0.0-20220128215802-99c3d69c2c27
 )
 

--- a/cmd/otelcorecol/main.go
+++ b/cmd/otelcorecol/main.go
@@ -19,7 +19,7 @@ func main() {
 	info := component.BuildInfo{
 		Command:     "otelcorecol",
 		Description: "Local OpenTelemetry Collector binary, testing only.",
-		Version:     "0.54.0-dev",
+		Version:     "0.55.0-dev",
 	}
 
 	if err := run(service.CollectorSettings{BuildInfo: info, Factories: factories}); err != nil {

--- a/examples/k8s/otel-config.yaml
+++ b/examples/k8s/otel-config.yaml
@@ -66,7 +66,7 @@ spec:
       - command:
           - "/otelcol"
           - "--config=/conf/otel-agent-config.yaml"
-        image: otel/opentelemetry-collector:0.54.0
+        image: otel/opentelemetry-collector:0.55.0
         name: otel-agent
         resources:
           limits:
@@ -177,7 +177,7 @@ spec:
       - command:
           - "/otelcol"
           - "--config=/conf/otel-collector-config.yaml"
-        image: otel/opentelemetry-collector:0.54.0
+        image: otel/opentelemetry-collector:0.55.0
         name: otel-collector
         resources:
           limits:

--- a/versions.yaml
+++ b/versions.yaml
@@ -14,7 +14,7 @@
 
 module-sets:
   collector-core:
-    version: v0.54.0
+    version: v0.55.0
     modules:
       - go.opentelemetry.io/collector
       - go.opentelemetry.io/collector/cmd/builder


### PR DESCRIPTION
Steps performed:

 * Update CHANGELOG.md file and rename the Unreleased section to the new release name. Add a new unreleased section at top. Use commit history feature to get the list of commits since the last release to help understand what should be in the release notes, e.g.: https://github.com/open-telemetry/opentelemetry-collector/compare/v0.44.0...main.

    * Use multimod to update the version of the collector package
      * Update [versions.yaml](https://github.com/open-telemetry/opentelemetry-collector/blob/main/versions.yaml) and commit it locally
      * Run `make multimod-prerelease` (it might fail if you didn't commit the change above)

    * Update the collector version in the collector builder to the new release in `./cmd/builder/internal/builder/config.go`.

    * Update the collector version in the manifest used by `make run` to the new release in `./cmd/otelcorecol/builder-config.yaml` and run `make genotelcorecol`.

    * Update the collector version in the `examples/k8s/otel-config.yaml` 