### PR TITLE
[backport][release/v0.55.x] Fix panic when telemetry metrics are disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### 🧰 Bug fixes 🧰
+
+- Fix Collector panic when disabling telemetry metrics (#5642)
+
 ## v0.55.0 Beta
 
 ### 🛑 Breaking changes 🛑

--- a/service/service.go
+++ b/service/service.go
@@ -24,6 +24,7 @@ import (
 	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config/configtelemetry"
 	"go.opentelemetry.io/collector/service/internal"
 	"go.opentelemetry.io/collector/service/internal/extensions"
 	"go.opentelemetry.io/collector/service/internal/pipelines"
@@ -97,9 +98,11 @@ func newService(set *settings) (*service, error) {
 		return nil, fmt.Errorf("cannot build pipelines: %w", err)
 	}
 
-	// The process telemetry initialization requires the ballast size, which is available after the extensions are initialized.
-	if err = telemetry.RegisterProcessMetrics(srv.telemetryInitializer.ocRegistry, getBallastSize(srv.host)); err != nil {
-		return nil, fmt.Errorf("failed to register process metrics: %w", err)
+	if set.Config.Telemetry.Metrics.Level != configtelemetry.LevelNone && set.Config.Telemetry.Metrics.Address != "" {
+		// The process telemetry initialization requires the ballast size, which is available after the extensions are initialized.
+		if err = telemetry.RegisterProcessMetrics(srv.telemetryInitializer.ocRegistry, getBallastSize(srv.host)); err != nil {
+			return nil, fmt.Errorf("failed to register process metrics: %w", err)
+		}
 	}
 
 	return srv, nil

--- a/service/testdata/otelcol-nometrics.yaml
+++ b/service/testdata/otelcol-nometrics.yaml
@@ -1,0 +1,14 @@
+receivers:
+  nop:
+
+exporters:
+  nop:
+
+service:
+  telemetry:
+    metrics:
+      level: none
+  pipelines:
+    metrics:
+      receivers: [nop]
+      exporters: [nop]


### PR DESCRIPTION
Backport of #5642 to `release/v0.55.x`.
