### PR TITLE
Change metadata lookup to be case insensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### 💡 Enhancements 💡
 
 - Add `linux-ppc64le` architecture to cross build tests in CI
+- `client`: perform case insensitive lookups in case the requested metadata value isn't found (#5646)
 
 ## v0.55.0 Beta
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -91,6 +91,7 @@ func TestMetadata(t *testing.T) {
 	source := map[string][]string{"test-key": {"test-val"}}
 	md := NewMetadata(source)
 	assert.Equal(t, []string{"test-val"}, md.Get("test-key"))
+	assert.Equal(t, []string{"test-val"}, md.Get("test-KEY")) // case insensitive lookup
 
 	// test if copy. In regular use, source cannot change
 	val := md.Get("test-key")


### PR DESCRIPTION
Before this change, users would make references to headers such as "authorization" and "X-CloudFront-Viewer-Latitude", which would potentially fail, as they would be stored in the context as "X-Cloudfront-Viewer-Latitude" or "Authorization".

This PR changes this behavior, to attempt a case insensitive lookup to the backing map in case the key wasn't found under the requested casing. Under the assumption that the lookup key specified by users won't change, on a subsequent lookup, we proactively copy the value to the looked up key, to make the next lookup faster.

Fixes #5610
Fixes open-telemetry/opentelemetry-collector-contrib#8994

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>
