### PR TITLE
[release process] add helm charts to release issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -9,11 +9,19 @@ assignees: ''
 
 Like #4522, but for vX.X.X
 
+**Performed by collector release manager**
+
 - [ ] Prepare core release vX.X.X
 - [ ] Tag and release core vX.X.X
 - [ ] Prepare contrib release vX.X.X
 - [ ] Tag and release contrib vX.X.X
 - [ ] Prepare otelcol-releases vX.X.X
 - [ ] Release binaries and container images vX.X.X
+
+**Performed by operator maintainers**
+
 - [ ] Release the operator vX.X.X
+
+**Performed by helm chart maintainers**
+
 - [ ] Update the opentelemetry-collector helm chart to use vX.X.X docker image


### PR DESCRIPTION
**Description:** 
Adds a new step to the release issue to track updating the opentelemetry-collector helm chart.  Process for completing this step will be similar to the operator release.