### PR TITLE
add validation for empty telemetry metric address when level not none

### DIFF
--- a/.chloggen/valiation-for-empty-metric-address.yaml
+++ b/.chloggen/valiation-for-empty-metric-address.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: config
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add validation for empty address [telemetry::metrics::address]
+
+# One or more tracking issues or pull requests related to the change
+issues: [5661]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/service/config.go
+++ b/service/config.go
@@ -148,6 +148,10 @@ func (cfg *Config) validateService() error {
 				return fmt.Errorf("pipeline %q references exporter %q which does not exist", pipelineID, ref)
 			}
 		}
+
+		if err := cfg.Service.Telemetry.Validate(); err != nil {
+			fmt.Printf("telemetry config validation failed, %v\n", err)
+		}
 	}
 	return nil
 }

--- a/service/config_test.go
+++ b/service/config_test.go
@@ -85,7 +85,7 @@ func TestConfigValidate(t *testing.T) {
 			name: "custom-service-telemetrySettings-encoding",
 			cfgFn: func() *Config {
 				cfg := generateConfig()
-				cfg.Service.Telemetry.Logs.Encoding = "test_encoding"
+				cfg.Service.Telemetry.Logs.Encoding = "json"
 				return cfg
 			},
 			expected: nil,
@@ -236,6 +236,16 @@ func TestConfigValidate(t *testing.T) {
 				return cfg
 			},
 			expected: errors.New(`unknown pipeline datatype "wrongtype" for wrongtype`),
+		},
+		{
+			name: "invalid-telemetry-metric-config",
+			cfgFn: func() *Config {
+				cfg := generateConfig()
+				cfg.Service.Telemetry.Metrics.Level = configtelemetry.LevelBasic
+				cfg.Service.Telemetry.Metrics.Address = ""
+				return cfg
+			},
+			expected: nil,
 		},
 	}
 

--- a/service/telemetry/config.go
+++ b/service/telemetry/config.go
@@ -15,6 +15,8 @@
 package telemetry // import "go.opentelemetry.io/collector/service/telemetry"
 
 import (
+	"fmt"
+
 	"go.uber.org/zap/zapcore"
 
 	"go.opentelemetry.io/collector/config/configtelemetry"
@@ -112,4 +114,15 @@ type TracesConfig struct {
 	// tracecontext and  b3 are supported. By default, the value is set to empty list and
 	// context propagation is disabled.
 	Propagators []string `mapstructure:"propagators"`
+}
+
+// Validate checks whether the current configuration is valid
+func (c *Config) Validate() error {
+
+	// Check when service telemetry metric level is not none, the metrics address should not be empty
+	if c.Metrics.Level != configtelemetry.LevelNone && c.Metrics.Address == "" {
+		return fmt.Errorf("collector telemetry metric address should exist when metric level is not none")
+	}
+
+	return nil
 }

--- a/service/telemetry/config_test.go
+++ b/service/telemetry/config_test.go
@@ -1,0 +1,63 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package telemetry
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"go.opentelemetry.io/collector/config/configtelemetry"
+)
+
+func TestLoadConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     *Config
+		success bool
+	}{
+		{
+			name: "basic metric telemetry",
+			cfg: &Config{
+				Metrics: MetricsConfig{
+					Level:   configtelemetry.LevelBasic,
+					Address: "127.0.0.1:3333",
+				},
+			},
+			success: true,
+		},
+		{
+			name: "invalid metric telemetry",
+			cfg: &Config{
+				Metrics: MetricsConfig{
+					Level:   configtelemetry.LevelBasic,
+					Address: "",
+				},
+			},
+			success: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.cfg.Validate()
+			if tt.success {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: Ziqi Zhao <zhaoziqi9146@gmail.com>

**Description:** 
Fix #5655