### PR TITLE
Empty featuregate values will happen to be a panic

### DIFF
--- a/service/featuregate/flags.go
+++ b/service/featuregate/flags.go
@@ -44,6 +44,10 @@ func (f FlagValue) String() string {
 
 // Set applies the FlagValue encoded in the input string
 func (f FlagValue) Set(s string) error {
+	if s == "" {
+		return nil
+	}
+
 	return f.setSlice(strings.Split(s, ","))
 }
 

--- a/service/featuregate/flags_test.go
+++ b/service/featuregate/flags_test.go
@@ -28,6 +28,11 @@ func TestFlagValue_basic(t *testing.T) {
 		skipString bool
 	}{
 		{
+			name:   "empty item",
+			input:  "",
+			output: FlagValue{},
+		},
+		{
 			name:   "single item",
 			input:  "foo",
 			output: FlagValue{"foo": true},


### PR DESCRIPTION
**Description:** 
Fixing a bug - Empty featuregate values will happen to be a panic

`FlagValue.Set("")` 

```go
panic: runtime error: index out of range [0] with length 0

goroutine 1 [running]:
go.opentelemetry.io/collector/service/featuregate.FlagValue.setSlice(...)
	/xxx/go/pkg/mod/go.opentelemetry.io/collector@v0.55.0/service/featuregate/flags.go:54
go.opentelemetry.io/collector/service/featuregate.FlagValue.Set(0x105f26828?, {0x0?, 0x0?})
	/xxx/go/pkg/mod/go.opentelemetry.io/collector@v0.55.0/service/featuregate/flags.go:47 +0x14c
```

**Testing:**

Add an empty flag test

**Documentation:** 

Just check if the input string is empty, and return directly.


