### PR TITLE
skip changelog for [chore] prs

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -28,6 +28,6 @@ jobs:
             echo "A CHANGELOG was modified. Looks good!"
           else
             echo "No CHANGELOG was modified."
-            echo "Please add a CHANGELOG entry, or add \"[chore]\" to the title of the pull request if not required."
+            echo "Please add a CHANGELOG entry, or add either \"[chore]\" to the title of the pull request or add the \"Skip Changelog\" label if not required."
             false
           fi

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   changelog:
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'dependencies') && !contains(github.event.pull_request.labels.*.name, 'Skip Changelog')}}
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'dependencies') && !contains(github.event.pull_request.labels.*.name, 'Skip Changelog') && !contains(github.event.pull_request.title, '[chore]')}}
 
     steps:
       - uses: actions/checkout@v3
@@ -28,6 +28,6 @@ jobs:
             echo "A CHANGELOG was modified. Looks good!"
           else
             echo "No CHANGELOG was modified."
-            echo "Please add a CHANGELOG entry, or add the \"Skip Changelog\" label if not required."
+            echo "Please add a CHANGELOG entry, or add \"[chore]\" to the title of the pull request if not required."
             false
           fi

--- a/.github/workflows/scripts/dependabot-pr.sh
+++ b/.github/workflows/scripts/dependabot-pr.sh
@@ -41,4 +41,4 @@ git commit -m "dependabot updates `date`
 $message"
 git push origin $PR_NAME
 
-gh pr create --title "dependabot updates `date`" --body "$message" -l "Skip Changelog"
+gh pr create --title "[chore] dependabot updates `date`" --body "$message" -l "Skip Changelog"


### PR DESCRIPTION
Add a check in the changelog job to skip the job if the title of the PR contains [chore]. This makes it possible for a user who's change doesn't require a changelog entry and doesn't have write access to the repository to skip this check.

For now I've left the check for the "Skip Changelog" label as well, in the future, this should be removed and the label can be removed altogether.
