### PR TITLE
[exporter/logging] Build exporter's logger from service's logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add `linux-ppc64le` architecture to cross build tests in CI
 - `client`: perform case insensitive lookups in case the requested metadata value isn't found (#5646)
 - `loggingexporter`: Decouple `loglevel` field from level of logged messages (#5678)
+- `loggingexporter`: create the exporter's logger from the service's logger (#5677)
 
 ### 🧰 Bug fixes 🧰
 


### PR DESCRIPTION
**Description:**

Build the logger on the logging exporter's logger from the one on `TelemetrySettings`, so that the logger honors the configuration settings on `telemetry::logs` and the configuration options on `CollectorSettings.LoggingOptions`.

Depends on #5678

**Link to tracking Issue:** Fixes #5652

**Documentation:** Documented the feature gate.
