### PR TITLE
[exporter/logging] Decouple `loglevel` field from level of logged messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### 💡 Enhancements 💡
 
 - Add `linux-ppc64le` architecture to cross build tests in CI
+- `loggingexporter`: Decouple `loglevel` field from level of logged messages (#TODO)
 
 ### 🧰 Bug fixes 🧰
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### 💡 Enhancements 💡
 
 - Add `linux-ppc64le` architecture to cross build tests in CI
-- `loggingexporter`: Decouple `loglevel` field from level of logged messages (#TODO)
+- `loggingexporter`: Decouple `loglevel` field from level of logged messages (#5678)
 
 ### 🧰 Bug fixes 🧰
 

--- a/exporter/loggingexporter/factory.go
+++ b/exporter/loggingexporter/factory.go
@@ -59,7 +59,7 @@ func createTracesExporter(_ context.Context, set component.ExporterCreateSetting
 		return nil, err
 	}
 
-	return newTracesExporter(config, exporterLogger, set)
+	return newTracesExporter(cfg, exporterLogger, set)
 }
 
 func createMetricsExporter(_ context.Context, set component.ExporterCreateSettings, config config.Exporter) (component.MetricsExporter, error) {
@@ -70,7 +70,7 @@ func createMetricsExporter(_ context.Context, set component.ExporterCreateSettin
 		return nil, err
 	}
 
-	return newMetricsExporter(config, exporterLogger, set)
+	return newMetricsExporter(cfg, exporterLogger, set)
 }
 
 func createLogsExporter(_ context.Context, set component.ExporterCreateSettings, config config.Exporter) (component.LogsExporter, error) {
@@ -81,7 +81,7 @@ func createLogsExporter(_ context.Context, set component.ExporterCreateSettings,
 		return nil, err
 	}
 
-	return newLogsExporter(config, exporterLogger, set)
+	return newLogsExporter(cfg, exporterLogger, set)
 }
 
 func createLogger(cfg *Config) (*zap.Logger, error) {

--- a/exporter/loggingexporter/logging_exporter_test.go
+++ b/exporter/loggingexporter/logging_exporter_test.go
@@ -21,10 +21,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest"
 
 	"go.opentelemetry.io/collector/component/componenttest"
-	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/internal/testdata"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/pmetric"
@@ -32,7 +32,8 @@ import (
 )
 
 func TestLoggingTracesExporterNoErrors(t *testing.T) {
-	lte, err := newTracesExporter(&config.ExporterSettings{}, zap.NewNop(), componenttest.NewNopExporterCreateSettings())
+	f := NewFactory()
+	lte, err := newTracesExporter(f.CreateDefaultConfig().(*Config), zap.NewNop(), componenttest.NewNopExporterCreateSettings())
 	require.NotNil(t, lte)
 	assert.NoError(t, err)
 
@@ -43,7 +44,8 @@ func TestLoggingTracesExporterNoErrors(t *testing.T) {
 }
 
 func TestLoggingMetricsExporterNoErrors(t *testing.T) {
-	lme, err := newMetricsExporter(&config.ExporterSettings{}, zap.NewNop(), componenttest.NewNopExporterCreateSettings())
+	f := NewFactory()
+	lme, err := newMetricsExporter(f.CreateDefaultConfig().(*Config), zap.NewNop(), componenttest.NewNopExporterCreateSettings())
 	require.NotNil(t, lme)
 	assert.NoError(t, err)
 
@@ -57,7 +59,8 @@ func TestLoggingMetricsExporterNoErrors(t *testing.T) {
 }
 
 func TestLoggingLogsExporterNoErrors(t *testing.T) {
-	lle, err := newLogsExporter(&config.ExporterSettings{}, zap.NewNop(), componenttest.NewNopExporterCreateSettings())
+	f := NewFactory()
+	lle, err := newLogsExporter(f.CreateDefaultConfig().(*Config), zap.NewNop(), componenttest.NewNopExporterCreateSettings())
 	require.NotNil(t, lle)
 	assert.NoError(t, err)
 
@@ -68,7 +71,7 @@ func TestLoggingLogsExporterNoErrors(t *testing.T) {
 }
 
 func TestLoggingExporterErrors(t *testing.T) {
-	le := newLoggingExporter(zaptest.NewLogger(t))
+	le := newLoggingExporter(zaptest.NewLogger(t), zapcore.DebugLevel)
 	require.NotNil(t, le)
 
 	errWant := errors.New("my error")


### PR DESCRIPTION
**Description:** Make all messages from logging exporter report at info level.

**Link to tracking Issue:**  https://github.com/open-telemetry/opentelemetry-collector/pull/5677#pullrequestreview-1036046290

cc @tigrannajaryan
