### PR TITLE
Add support to handle 402 and 413 http error code in Otlp exporter #5674

### DIFF
--- a/exporter/otlphttpexporter/otlp.go
+++ b/exporter/otlphttpexporter/otlp.go
@@ -178,7 +178,9 @@ func (e *exporter) export(ctx context.Context, url string, request []byte) error
 		return exporterhelper.NewThrottleRetry(formattedErr, time.Duration(retryAfter)*time.Second)
 	}
 
-	if resp.StatusCode == http.StatusBadRequest {
+	// do not retry these errors
+	if resp.StatusCode == http.StatusBadRequest || resp.StatusCode == http.StatusRequestEntityTooLarge ||
+		resp.StatusCode == http.StatusPaymentRequired {
 		// Report the failure as permanent if the server thinks the request is malformed.
 		return consumererror.NewPermanent(formattedErr)
 	}


### PR DESCRIPTION
 **Description:** 
Collector currently does retries 402 and 413 error code. 413 is the error code for PAYLOAD TOO LARGE
and 402 is for PAYMENT REQUIRED which a user case of this would be when license token is exhausted.
These error code should be treated as permanent error in the Collector so that they won't get retried.

**Link to tracking Issue:**  
https://github.com/open-telemetry/opentelemetry-collector/issues/5674

**Testing:** 
otlp_test.go

**Documentation:**  
if we currently document http error code behavior, then treating 402 and 413 as permanent failure can be documented

