### PR TITLE
Add support to handle 402, 413, 414, 431 http error code as permanent errors in OTLP exporter #5674

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - `loggingexporter`: Decouple `loglevel` field from level of logged messages (#5678)
 - Expose `pcommon.NewSliceFromRaw` function (#5679)
 - `loggingexporter`: create the exporter's logger from the service's logger (#5677)
-- Add support to handle 402 and 413 http error code in Otlp exporter (#5685)
+- Add support to handle 402 and 413 http error code in OTLP exporter (#5685)
 
 ### 🧰 Bug fixes 🧰
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add `linux-ppc64le` architecture to cross build tests in CI
 - `client`: perform case insensitive lookups in case the requested metadata value isn't found (#5646)
 - `loggingexporter`: Decouple `loglevel` field from level of logged messages (#5678)
+- Add support to handle 402 and 413 http error code in Otlp exporter (#5685)
 
 ### 🧰 Bug fixes 🧰
 

--- a/exporter/otlphttpexporter/otlp.go
+++ b/exporter/otlphttpexporter/otlp.go
@@ -188,32 +188,29 @@ func (e *exporter) export(ctx context.Context, url string, request []byte) error
 }
 
 func isPermanentClientFailure(code int) bool {
-	// 400 - bad request
-	if code == http.StatusBadRequest {
-		return true
+	var isPermanentError bool
+
+	switch code {
+	case http.StatusBadRequest:
+		// 400 - bad request
+		isPermanentError = true
+	case http.StatusPaymentRequired:
+		// 402 - payment required typically means that an auth token isn't valid anymore and as such, we deem it as permanent
+		isPermanentError = true
+	case http.StatusRequestEntityTooLarge:
+		// 413 - request size is too large
+		isPermanentError = true
+	case http.StatusRequestURITooLong:
+		// 414 - uri is too long
+		isPermanentError = true
+	case http.StatusRequestHeaderFieldsTooLarge:
+		// 431 - headers too large
+		isPermanentError = true
+	default:
+		isPermanentError = false
 	}
 
-	// 402 - payment required typically means that an auth token isn't valid anymore and as such, we deem it as permanent
-	if code == http.StatusPaymentRequired {
-		return true
-	}
-
-	// 413 - request size is too large
-	if code == http.StatusRequestEntityTooLarge {
-		return true
-	}
-
-	// 414 - uri is too long
-	if code == http.StatusRequestURITooLong {
-		return true
-	}
-
-	// 431 - headers too large
-	if code == http.StatusRequestHeaderFieldsTooLarge {
-		return true
-	}
-
-	return false
+	return isPermanentError
 }
 
 // Read the response and decode the status.Status from the body.

--- a/exporter/otlphttpexporter/otlp.go
+++ b/exporter/otlphttpexporter/otlp.go
@@ -203,6 +203,16 @@ func isPermanentClientFailure(code int) bool {
 		return true
 	}
 
+	// 414 - uri is too long
+	if code == http.StatusRequestURITooLong {
+		return true
+	}
+
+	// 431 - headers too large
+	if code == http.StatusRequestHeaderFieldsTooLarge {
+		return true
+	}
+
 	return false
 }
 

--- a/exporter/otlphttpexporter/otlp.go
+++ b/exporter/otlphttpexporter/otlp.go
@@ -188,29 +188,23 @@ func (e *exporter) export(ctx context.Context, url string, request []byte) error
 }
 
 func isPermanentClientFailure(code int) bool {
-	var isPermanentError bool
-
 	switch code {
 	case http.StatusBadRequest:
-		// 400 - bad request
-		isPermanentError = true
+		return true
 	case http.StatusPaymentRequired:
 		// 402 - payment required typically means that an auth token isn't valid anymore and as such, we deem it as permanent
-		isPermanentError = true
+		return true
 	case http.StatusRequestEntityTooLarge:
-		// 413 - request size is too large
-		isPermanentError = true
+		return true
 	case http.StatusRequestURITooLong:
-		// 414 - uri is too long
-		isPermanentError = true
+		return true
 	case http.StatusRequestHeaderFieldsTooLarge:
-		// 431 - headers too large
-		isPermanentError = true
+		return true
 	default:
-		isPermanentError = false
+		return false
 	}
 
-	return isPermanentError
+	return false
 }
 
 // Read the response and decode the status.Status from the body.

--- a/exporter/otlphttpexporter/otlp.go
+++ b/exporter/otlphttpexporter/otlp.go
@@ -203,8 +203,6 @@ func isPermanentClientFailure(code int) bool {
 	default:
 		return false
 	}
-
-	return false
 }
 
 // Read the response and decode the status.Status from the body.

--- a/exporter/otlphttpexporter/otlp.go
+++ b/exporter/otlphttpexporter/otlp.go
@@ -178,7 +178,9 @@ func (e *exporter) export(ctx context.Context, url string, request []byte) error
 		return exporterhelper.NewThrottleRetry(formattedErr, time.Duration(retryAfter)*time.Second)
 	}
 
-	if resp.StatusCode == http.StatusBadRequest {
+	// do not retry these errors
+	if resp.StatusCode == http.StatusBadRequest || resp.StatusCode == http.StatusRequestEntityTooLarge ||
+		resp.StatusCode == http.StatusPaymentRequired {
 		// Report the failure as permanent if the server thinks the request is malformed.
 		return consumererror.NewPermanent(formattedErr)
 	}

--- a/exporter/otlphttpexporter/otlp.go
+++ b/exporter/otlphttpexporter/otlp.go
@@ -187,6 +187,7 @@ func (e *exporter) export(ctx context.Context, url string, request []byte) error
 	return formattedErr
 }
 
+// Does the 'code' indicate a permanent error
 func isPermanentClientFailure(code int) bool {
 	switch code {
 	case http.StatusBadRequest:

--- a/exporter/otlphttpexporter/otlp_test.go
+++ b/exporter/otlphttpexporter/otlp_test.go
@@ -411,6 +411,18 @@ func TestErrorResponses(t *testing.T) {
 			isPermErr:      true,
 		},
 		{
+			name:           "414",
+			responseStatus: http.StatusRequestURITooLong,
+			responseBody:   status.New(codes.InvalidArgument, "Bad field"),
+			isPermErr:      true,
+		},
+		{
+			name:           "431",
+			responseStatus: http.StatusRequestHeaderFieldsTooLarge,
+			responseBody:   status.New(codes.InvalidArgument, "Bad field"),
+			isPermErr:      true,
+		},
+		{
 			name:           "419",
 			responseStatus: http.StatusTooManyRequests,
 			responseBody:   status.New(codes.InvalidArgument, "Quota exceeded"),

--- a/exporter/otlphttpexporter/otlp_test.go
+++ b/exporter/otlphttpexporter/otlp_test.go
@@ -394,9 +394,21 @@ func TestErrorResponses(t *testing.T) {
 			isPermErr:      true,
 		},
 		{
+			name:           "402",
+			responseStatus: http.StatusPaymentRequired,
+			responseBody:   status.New(codes.InvalidArgument, "Bad field"),
+			isPermErr:      true,
+		},
+		{
 			name:           "404",
 			responseStatus: http.StatusNotFound,
 			err:            errors.New(errMsgPrefix + "404"),
+		},
+		{
+			name:           "413",
+			responseStatus: http.StatusRequestEntityTooLarge,
+			responseBody:   status.New(codes.InvalidArgument, "Bad field"),
+			isPermErr:      true,
 		},
 		{
 			name:           "419",


### PR DESCRIPTION
**Description:** 
Collector currently does retries 402 and 413 error code. 413 is the error code for PAYLOAD TOO LARGE
and 402 is for PAYMENT REQUIRED which a user case of this would be when license token is exhausted.
These error code should be treated as permanent error in the Collector so that they won't get retried.

**Link to tracking Issue:** 
https://github.com/open-telemetry/opentelemetry-collector/issues/5674

**Testing:** 
oltp_test.go

**Documentation:** 
if we currently document http error code behavior, then treating 402 and 413 as permanent failure can be documented

