### PR TITLE
Release ocb to a Homebrew tap.

### DIFF
--- a/cmd/builder/.goreleaser.yml
+++ b/cmd/builder/.goreleaser.yml
@@ -8,7 +8,10 @@ builds:
   - flags:
       - -trimpath
     ldflags:
-      - -s -w -X go.opentelemetry.io/collector/cmd/builder/internal.version={{.Version}} -X go.opentelemetry.io/collector/cmd/builder/internal.date={{.Date}}
+      - -s
+      - -w
+      - -X go.opentelemetry.io/collector/cmd/builder/internal.version={{.Version}}
+      - -X go.opentelemetry.io/collector/cmd/builder/internal.date={{.Date}}
     env:
       - CGO_ENABLED=0
     goos:
@@ -23,6 +26,20 @@ builds:
       - goos: windows
         goarch: arm64
     binary: ocb
+brews:
+  - name: ocb
+    tap:
+      owner: open-telemetry
+      name: homebrew-tap
+    homepage: https://opentelemetry.io/docs/collector/custom-collector/
+    description: This program generates a custom OpenTelemetry Collector from a given configuration.
+    license: Apache-2.0
+    folder: Formula
+    dependencies:
+      - name: go
+        type: optional
+    test: |
+      system "#{bin}/ocb version"
 release:
   github:
     owner: open-telemetry


### PR DESCRIPTION
**Description:**

Update the goreleaser configuration so that ocb releases will
automatically update the OpenTelementry Homebrew tap.

**Link to tracking Issue:**

This fixes #5680.


**Testing:**

Tested with a private tap at https://github.com/jpeach/homebrew-tap.

```
$ brew info ocb
jpeach/tap/ocb: stable 1.2
This program generates a custom OpenTelemetry Collector from a given configuration.
https://opentelemetry.io/docs/collector/custom-collector/
/opt/homebrew/Cellar/ocb/1.2 (3 files, 6.4MB) *
  Built from source on 2022-07-15 at 15:40:03
From: https://github.com/jpeach/homebrew-tap/blob/HEAD/Formula/ocb.rb
License: Apache-2.0
==> Dependencies
Optional: go ✘
==> Options
--with-go
	Build with go support
``` 
```
$ brew install ocb
==> Downloading https://github.com/jpeach/homebrew-tap/releases/download/v1.2/ocb_1.2_darwin_arm64
==> Downloading from https://objects.githubusercontent.com/github-production-release-asset-2e65be/514126043/14de5f50-8d99-4003-ac7e-522bf5510e37?X-Amz
######################################################################## 100.0%
==> Installing ocb from jpeach/tap
🍺  /opt/homebrew/Cellar/ocb/1.2: 3 files, 6.4MB, built in 1 second
==> Running `brew cleanup ocb`...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
```
```
$ which ocb
/opt/homebrew/bin/ocb
$ ocb version
builder version 1.2
```


**Documentation:** 

None. If we land this, I can go update the docs in a separate PR.
