### PR TITLE
Add guidelines about commit messages and merging/squashing commits

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -196,9 +196,9 @@ so it is a useful habit to write good commit messages before the PR is created.
 Also, unless you actually want to tell a story with multiple commits make sure to squash
 into a single commit before creating the PR.
 
-When merging PRs with multiple commits, they will be squashed and GitHub will
+When maintainers merge PRs with multiple commits, they will be squashed and GitHub will
 concatenate all commit messages right before you hit the "Confirm squash and merge"
-button. Make sure to edit this concatenated message to make it right before merging.
+button. Maintainers must make sure to edit this concatenated message to make it right before merging.
 In some cases, if the commit messages are lacking the easiest approach to have at
 least something useful is copy/pasting the PR description into the commit message box
 before merging (but see above paragraph about writing good commit messages in the first place).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -187,6 +187,22 @@ $ git commit
 $ git push fork feature
 ```
 
+### Commit Messages
+
+Use descriptive commit messages. Here are [some recommendations](https://cbea.ms/git-commit/)
+on how to write good commit messages.
+When creating PRs GitHub will automatically copy commit messages into the PR description,
+so it is a useful habit to write good commit messages before the PR is created.
+Also, unless you actually want to tell a story with multiple commits make sure to squash
+into a single commit before creating the PR.
+
+When merging PRs with multiple commits, they will be squashed and GitHub will
+concatenate all commit messages right before you hit the "Confirm squash and merge"
+button. Make sure to edit this concatenated message to make it right before merging.
+In some cases, if the commit messages are lacking the easiest approach to have at
+least something useful is copy/pasting the PR description into the commit message box
+before merging (but see above paragraph about writing good commit messages in the first place).
+
 ## General Notes
 
 This project uses Go 1.17.* and [Github Actions.](https://github.com/features/actions)


### PR DESCRIPTION
Our commit messages often are quite lacking. A typical approach is writing single line commit
messages and pushing multiple such commits to a PR. When commits are squashed the commit
messages are concatenated, and we end up with useless commit messages.

Here is an example of a commit message body (I am omitting the first line and the commit hash
to avoid blaming anyone in particular - we are all guilty):

```
    * add docstring

    * fix typo

    * fix impi

    * apply review feedback
```

This is a useless commit message, in fact, it is worse than an empty one.

I tried to keep the added paragraph in the CONTRIBUTING.md short. If you think more details and
convincing is necessary I can make it more elaborate. Note that the text I added doesn't just
call for good commit messages but has some hints about the commit and PR creation, squashing and
merging processes that make it easier to end up with better commit messages.
