### PR TITLE
[ci] disable G112 to unblock CI

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -134,6 +134,10 @@ issues:
     - text: "G402:"
       linters:
         - gosec
+    # https://github.com/open-telemetry/opentelemetry-collector/issues/5699
+    - text: "G112:"
+      linters:
+        - gosec
 
   # The list of ids of default excludes to include or disable. By default it's empty.
   # See the list of default excludes here https://golangci-lint.run/usage/configuration.


### PR DESCRIPTION
Disabling G112 until https://github.com/open-telemetry/opentelemetry-collector/issues/5699 has been addressed.
