### PR TITLE
Add a collector flag to list available components.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Add the Collector flag `--list-components` to show the available components (#5709)
 
 ## v0.60.0 Beta
 

--- a/service/command.go
+++ b/service/command.go
@@ -16,13 +16,70 @@ package service // import "go.opentelemetry.io/collector/service"
 
 import (
 	"errors"
+	"fmt"
+	"io"
+	"strings"
 
 	"github.com/spf13/cobra"
 
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/confmap/converter/overwritepropertiesconverter"
 	"go.opentelemetry.io/collector/service/featuregate"
 )
+
+func printComponentSet(out io.Writer, factories component.Factories) {
+	stabilityString := func(
+		traces component.StabilityLevel,
+		metrics component.StabilityLevel,
+		logs component.StabilityLevel,
+	) string {
+		var stability []string
+
+		if traces != component.StabilityLevelUndefined {
+			stability = append(stability, fmt.Sprintf("traces: %s", traces))
+		}
+
+		if metrics != component.StabilityLevelUndefined {
+			stability = append(stability, fmt.Sprintf("metrics: %s", metrics))
+		}
+
+		if logs != component.StabilityLevelUndefined {
+			stability = append(stability, fmt.Sprintf("logs: %s", logs))
+		}
+
+		return strings.Join(stability, ", ")
+	}
+
+	fmt.Fprintf(out, "exporters:\n")
+	for _, e := range factories.Exporters {
+		fmt.Fprintf(out, "\t%s (%s)\n",
+			e.Type(),
+			stabilityString(e.TracesExporterStability(), e.MetricsExporterStability(), e.LogsExporterStability()),
+		)
+	}
+
+	fmt.Fprintf(out, "receivers:\n")
+	for _, r := range factories.Receivers {
+		fmt.Fprintf(out, "\t%s (%s)\n",
+			r.Type(),
+			stabilityString(r.TracesReceiverStability(), r.MetricsReceiverStability(), r.LogsReceiverStability()),
+		)
+	}
+
+	fmt.Fprintf(out, "processors:\n")
+	for _, p := range factories.Processors {
+		fmt.Fprintf(out, "\t%s (%s)\n",
+			p.Type(),
+			stabilityString(p.TracesProcessorStability(), p.MetricsProcessorStability(), p.LogsProcessorStability()),
+		)
+	}
+
+	fmt.Fprintf(out, "extensions:\n")
+	for _, e := range factories.Extensions {
+		fmt.Fprintf(out, "\t%s (%s)\n", e.Type(), e.ExtensionStability())
+	}
+}
 
 // NewCommand constructs a new cobra.Command using the given CollectorSettings.
 func NewCommand(set CollectorSettings) *cobra.Command {
@@ -32,6 +89,10 @@ func NewCommand(set CollectorSettings) *cobra.Command {
 		Version:      set.BuildInfo.Version,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if getListComponentsFlag(flagSet) {
+				printComponentSet(cmd.OutOrStdout(), set.Factories)
+				return nil
+			}
 			if err := featuregate.GetRegistry().Apply(gatesList); err != nil {
 				return err
 			}

--- a/service/command_test.go
+++ b/service/command_test.go
@@ -15,6 +15,7 @@
 package service
 
 import (
+	"bytes"
 	"path/filepath"
 	"testing"
 
@@ -47,4 +48,27 @@ func TestNewCommandInvalidComponent(t *testing.T) {
 
 	cmd := NewCommand(CollectorSettings{Factories: factories, ConfigProvider: cfgProvider})
 	require.Error(t, cmd.Execute())
+}
+
+func TestNewCommandListComponents(t *testing.T) {
+	factories, err := componenttest.NopFactories()
+	require.NoError(t, err)
+
+	stdout := bytes.Buffer{}
+
+	cmd := NewCommand(CollectorSettings{Factories: factories})
+	cmd.SetOut(&stdout)
+	require.NoError(t, cmd.Flags().Set("list-components", "true"))
+	require.NoError(t, cmd.Execute())
+
+	const expected = `exporters:
+	nop (traces: stable, metrics: stable, logs: stable)
+receivers:
+	nop (traces: stable, metrics: stable, logs: stable)
+processors:
+	nop (traces: stable, metrics: stable, logs: stable)
+extensions:
+	nop (stable)
+`
+	assert.Equal(t, expected, stdout.String())
 }

--- a/service/flags.go
+++ b/service/flags.go
@@ -60,6 +60,9 @@ func flags() *flag.FlagSet {
 		"feature-gates",
 		"Comma-delimited list of feature gate identifiers. Prefix with '-' to disable the feature. '+' or no prefix will enable the feature.")
 
+	flagSet.Bool("list-components", false,
+		"List the available components and exit.")
+
 	return flagSet
 }
 
@@ -69,4 +72,8 @@ func getConfigFlag(flagSet *flag.FlagSet) []string {
 
 func getSetFlag(flagSet *flag.FlagSet) []string {
 	return flagSet.Lookup(setFlag).Value.(*stringArrayValue).values
+}
+
+func getListComponentsFlag(flagSet *flag.FlagSet) bool {
+	return flagSet.Lookup("list-components").Value.String() == "true"
 }


### PR DESCRIPTION
**Description:**

Add a `--list-components` flag to the collector service. This currently
show all the available components, their types and their signal stability
levels. In future, we could also show the Go module and version, but
that would require changes to the builder, so it's omitted for now.

**Link to tracking Issue:** 

This fixes #5709.

**Testing:** 

Just manual.

```
otelcorecol jpeach$ go build . && ./otelcorecol --list-components
exporters:
	logging (traces: in development, metrics: in development, logs: in development)
	otlp (traces: stable, metrics: stable, logs: beta)
	otlphttp (traces: stable, metrics: stable, logs: beta)
receivers:
	otlp (traces: stable, metrics: stable, logs: beta)
processors:
	batch (traces: stable, metrics: stable, logs: stable)
	memory_limiter (traces: beta, metrics: beta, logs: beta)
extensions:
	memory_ballast
	zpages
```

**Documentation:**

None. Visible in usage output.
