### PR TITLE
[chore] Set PR workflows concurrency

### DIFF
--- a/.github/workflows/build-and-test-windows.yaml
+++ b/.github/workflows/build-and-test-windows.yaml
@@ -6,6 +6,10 @@ on:
       - 'v[0-9]+.[0-9]+.[0-9]+*'
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   windows-unittest:
     runs-on: windows-latest

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -6,6 +6,10 @@ on:
       - "v[0-9]+.[0-9]+.[0-9]+*"
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   setup-environment:
     runs-on: ubuntu-latest

--- a/.github/workflows/builder-integration-test.yaml
+++ b/.github/workflows/builder-integration-test.yaml
@@ -20,6 +20,10 @@ on:
   # manual execution
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   integration-test:
     name: Integration test

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -9,6 +9,11 @@ on:
     types: [opened, synchronize, reopened, labeled, unlabeled]
     branches:
       - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   changelog:
     runs-on: ubuntu-latest

--- a/.github/workflows/check-links.yaml
+++ b/.github/workflows/check-links.yaml
@@ -8,6 +8,10 @@ on:
     paths-ignore:
       - 'cmd/builder/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   changedfiles:
     name: changed files

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -4,6 +4,10 @@ on:
     branches: [ main ]
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   CodeQL-Build:
     runs-on: ubuntu-latest

--- a/.github/workflows/contrib-tests.yml
+++ b/.github/workflows/contrib-tests.yml
@@ -6,6 +6,10 @@ on:
       - v[0-9]+.[0-9]+.[0-9]+.*
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   contrib_tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Description:
This PR uses [workflow concurrency](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency) to cancel in-progress builds if a new, higher priority workflow is scheduled. This will happen when new code is pushed to a PR.

Some of our workflows trigger on PR and main, and this setting would affect workflows in both situations. If a set of workflows is running on main and another PR is merged and triggers a new set, the original workflows will be canceled. 

Corresponding PR in Contrib: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/12564