### PR TITLE
[chore] Update check-links workflow to match contrib logic

### DIFF
--- a/.github/workflows/check-links.yaml
+++ b/.github/workflows/check-links.yaml
@@ -22,8 +22,7 @@ jobs:
       - name: Get changed files
         id: changes
         run: |
-          echo "::set-output name=md::$(git diff --name-only --diff-filter=ACMRTUXB origin/${{ github.event.pull_request.base.ref }} ${{ github.event.pull_request.head.sha }} | grep .md$ | xargs)"
-
+          echo "::set-output name=md::$(git diff --name-only --diff-filter=ACMRTUXB $(git merge-base origin/main ${{ github.event.pull_request.head.sha }}) ${{ github.event.pull_request.head.sha }} | grep .md$ | xargs)"
   check-links:
     runs-on: ubuntu-latest
     needs: changedfiles
@@ -42,4 +41,5 @@ jobs:
           markdown-link-check \
             --verbose \
             --config .github/workflows/check_links_config.json \
-            ${{needs.changedfiles.outputs.md}}
+            ${{needs.changedfiles.outputs.md}} \
+            || { echo "Check that anchor links are lowercase"; exit 1; }


### PR DESCRIPTION
**Description:** 
Quick PR to closer align Core's checklink workflow with Contribs.  I am hoping it fixes issues like this: https://github.com/open-telemetry/opentelemetry-collector/runs/7452564621?check_suite_focus=true.
