### PR TITLE
Fail when the builder can't load its configuration.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 💡 Enhancements 💡
 
+- `ocb` now exits with an error if it fails to load the build configuration. (#5731)
+
 ### 🧰 Bug fixes 🧰
 
 ## v0.56.0 Beta

--- a/cmd/builder/internal/command.go
+++ b/cmd/builder/internal/command.go
@@ -38,7 +38,9 @@ var (
 // Command is the main entrypoint for this application
 func Command() (*cobra.Command, error) {
 	cmd := &cobra.Command{
-		Use: "ocb",
+		SilenceUsage:  true, // Don't print usage on Run error.
+		SilenceErrors: true, // Don't print errors; main does it.
+		Use:           "ocb",
 		Long: fmt.Sprintf("OpenTelemetry Collector Builder (%s)", version) + `
 
 ocb generates a custom OpenTelemetry Collector binary using the
@@ -50,13 +52,11 @@ build configuration given by the "--config" argument.
 				return err
 			}
 			if err := cfg.Validate(); err != nil {
-				cfg.Logger.Error("invalid configuration", zap.Error(err))
-				return err
+				return fmt.Errorf("invalid configuration: %w", err)
 			}
 
 			if err := cfg.ParseModules(); err != nil {
-				cfg.Logger.Error("invalid module configuration", zap.Error(err))
-				return err
+				return fmt.Errorf("invalid module configuration: %w", err)
 			}
 
 			return builder.GenerateAndCompile(cfg)
@@ -86,30 +86,30 @@ build configuration given by the "--config" argument.
 	cmd.AddCommand(versionCommand())
 
 	if err := k.Load(posflag.Provider(cmd.Flags(), ".", k), nil); err != nil {
-		cfg.Logger.Error("failed to load command line arguments", zap.Error(err))
+		return nil, fmt.Errorf("failed to load command line arguments: %w", err)
 	}
 
 	return cmd, nil
 }
 
 func initConfig() error {
-	cfg.Logger.Info("OpenTelemetry Collector Builder", zap.String("version", version), zap.String("date", date))
+	cfg.Logger.Info("OpenTelemetry Collector Builder",
+		zap.String("version", version), zap.String("date", date))
 
 	// load the config file
 	if err := k.Load(file.Provider(cfgFile), yaml.Parser()); err != nil {
-		cfg.Logger.Error("failed to load config file", zap.String("config-file", cfgFile), zap.Error(err))
+		return fmt.Errorf("failed to load configuration file: %w", err)
 	}
 
 	// handle env variables
 	if err := k.Load(env.Provider("", ".", func(s string) string {
 		return strings.ReplaceAll(s, ".", "_")
 	}), nil); err != nil {
-		cfg.Logger.Error("failed to load env var", zap.Error(err))
+		return fmt.Errorf("failed to load environment variables: %w", err)
 	}
 
 	if err := k.UnmarshalWithConf("", &cfg, koanf.UnmarshalConf{Tag: "mapstructure"}); err != nil {
-		cfg.Logger.Error("failed to unmarshal config", zap.Error(err))
-		return err
+		return fmt.Errorf("failed to unmarshal configuration: %w", err)
 	}
 
 	cfg.Logger.Info("Using config file", zap.String("path", cfgFile))


### PR DESCRIPTION
**Description:** 

If the builder can't load its build configuration file, it logs an error
and continues. This results in building a collector that is not the one
the user specified. Exit with a fatal error instead.

**Link to tracking Issue:** 

None.

**Testing:** 

```
$ ./builder
2022-07-22T11:32:21.845+1000	INFO	internal/command.go:85	OpenTelemetry Collector distribution builder	{"version": "dev", "date": "unknown"}
2022-07-22T11:32:21.845+1000	FATAL	internal/command.go:93	failed to load config file	{"config-file": "$HOME/.otelcol-builder.yaml", "error": "open $HOME/.otelcol-builder.yaml: no such file or directory"}
go.opentelemetry.io/collector/cmd/builder/internal.initConfig
	/Users/jpeach/upstream/opentelemetry/opentelemetry-collector/cmd/builder/internal/command.go:93
go.opentelemetry.io/collector/cmd/builder/internal.Command.func1
	/Users/jpeach/upstream/opentelemetry/opentelemetry-collector/cmd/builder/internal/command.go:44
github.com/spf13/cobra.(*Command).execute
	/Users/jpeach/go/pkg/mod/github.com/spf13/cobra@v1.5.0/command.go:872
github.com/spf13/cobra.(*Command).ExecuteC
	/Users/jpeach/go/pkg/mod/github.com/spf13/cobra@v1.5.0/command.go:990
github.com/spf13/cobra.(*Command).Execute
	/Users/jpeach/go/pkg/mod/github.com/spf13/cobra@v1.5.0/command.go:918
main.main
	/Users/jpeach/upstream/opentelemetry/opentelemetry-collector/cmd/builder/main.go:26
runtime.main
	/opt/homebrew/Cellar/go/1.18.4/libexec/src/runtime/proc.go:250
$ echo $?
1
```
