### PR TITLE
Warn on unknown environment variable; add feature gate to error out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ### 💡 Enhancements 💡
 
+- Warn when expanding unknown environment variable (#5734)
+  - The `confmap.expandconverter.RaiseErrorOnUnknownEnvVar` feature gate will turn this into an error.
+
 ### 🧰 Bug fixes 🧰
 
 ## v0.56.0 Beta

--- a/internal/nonfatalerror/nonfatal.go
+++ b/internal/nonfatalerror/nonfatal.go
@@ -1,0 +1,48 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nonfatalerror // import "go.opentelemetry.io/collector/internal/nonfatalerror"
+
+import "errors"
+
+// nonFatal is an error that will be always returned if its source
+// receives the same inputs.
+type nonFatal struct {
+	err error
+}
+
+// New wraps an error to indicate that it is a non fatal error, i.e. an
+// error that needs to be reported but will not make the Collector fail.
+func New(err error) error {
+	return nonFatal{err: err}
+}
+
+func (p nonFatal) Error() string {
+	return "Non fatal error: " + p.err.Error()
+}
+
+// Unwrap returns the wrapped error for functions Is and As in standard package errors.
+func (p nonFatal) Unwrap() error {
+	return p.err
+}
+
+// IsNonFatal checks if an error was wrapped with the New function, which
+// is used to indicate that a given error needs to be reported but will not make
+// the Collector fail.
+func IsNonFatal(err error) bool {
+	if err == nil {
+		return false
+	}
+	return errors.As(err, &nonFatal{})
+}

--- a/internal/nonfatalerror/nonfatal_test.go
+++ b/internal/nonfatalerror/nonfatal_test.go
@@ -1,0 +1,63 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nonfatalerror
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testErrorType struct {
+	s string
+}
+
+func (t testErrorType) Error() string {
+	return ""
+}
+
+func TestIsNonFatal(t *testing.T) {
+	var err error
+	assert.False(t, IsNonFatal(err))
+
+	err = errors.New("testError")
+	assert.False(t, IsNonFatal(err))
+
+	err = New(err)
+	assert.True(t, IsNonFatal(err))
+
+	err = fmt.Errorf("%w", err)
+	assert.True(t, IsNonFatal(err))
+}
+
+func TestNonFatal_Unwrap(t *testing.T) {
+	var err error = testErrorType{"testError"}
+	require.False(t, IsNonFatal(err))
+
+	// Wrapping testErrorType err with non fatal error.
+	nonFatalErr := New(err)
+	require.True(t, IsNonFatal(nonFatalErr))
+
+	target := testErrorType{}
+	require.NotEqual(t, err, target)
+
+	isTestErrorTypeWrapped := errors.As(nonFatalErr, &target)
+	require.True(t, isTestErrorTypeWrapped)
+
+	require.Equal(t, err, target)
+}


### PR DESCRIPTION
**Description:**

- Add warning when expanding unknown environment variable.
- Add `confmap.expandconverter.RaiseErrorOnUnknownEnvVar` feature gate to turn this warning into an error

**Link to tracking Issue:** Fixes  #5615

**Testing:** Added unit tests