### PR TITLE
[chore] Update config for docs.github.com urls

### DIFF
--- a/.github/workflows/check_links_config.json
+++ b/.github/workflows/check_links_config.json
@@ -10,5 +10,13 @@
             "pattern": "http(s)?://example.com"
         }
     ],
-    "aliveStatusCodes": [429, 200]
+    "aliveStatusCodes": [429, 200],
+    "httpHeaders": [
+        {
+            "urls": ["https://docs.github.com/"],
+            "headers": {
+                "Accept-Encoding": "zstd, br, gzip, deflate"
+            }
+        }
+    ]
 }


### PR DESCRIPTION
**Description:** 
Updates markdown-link-check config so that is can correctly check `docs.github.com` urls.  See https://github.com/tcort/markdown-link-check/issues/201 for more details on this workaround.

**Testing:**

ran markdown-link-check locally.

```
markdown-link-check ./docs/release.md -c ./.github/workflows/check_links_config.json   

FILE: ./docs/release.md
  [✓] #releasing-opentelemetry-collector
  [✓] #releasing-opentelemetry-collector-contrib
  [✓] #producing-the-artifacts
  [✓] https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
  [✓] https://github.com/open-telemetry/opentelemetry-collector
  [✓] https://github.com/open-telemetry/opentelemetry-collector-contrib
  [✓] https://github.com/open-telemetry/opentelemetry-collector-releases
  [✓] #release-schedule
  [✓] https://github.com/open-telemetry/opentelemetry-collector/labels/release%3Ablocker
  [✓] https://github.com/open-telemetry/opentelemetry-collector-contrib/labels/release%3Ablocker
  [✓] https://github.com/open-telemetry/opentelemetry-collector/actions/workflows/build-and-test.yml?query=branch%3Amain
  [✓] https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/workflows/build-and-test.yml?query=branch%3Amain
  [✓] https://github.com/open-telemetry/opentelemetry-collector/issues/new?assignees=&labels=release&template=release.md&title=Release+vX.X.X
  [✓] https://github.com/open-telemetry/opentelemetry-collector/issues/4870
  [✓] https://github.com/open-telemetry/opentelemetry-collector/compare/v0.44.0...main
  [✓] https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/versions.yaml
  [✓] https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.55.0
  [✓] https://github.com/open-telemetry/opentelemetry-collector-releases/pull/71
  [✓] https://hub.docker.com/repository/docker/otel/opentelemetry-collector
  [✓] https://github.com/open-telemetry/opentelemetry-collector-releases/actions/runs/1346637081

  20 links checked.

```
