### PR TITLE
Add a default build configuration to ocb.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 - Fix reading resource attributes for trace JSON, remove duplicate code. (#6023)
 - Add support to unmarshalls bytes into plogs.Logs with `jsoniter` in jsonUnmarshaler(#5935)
+- Instead of exiting, `ocb` now generates a default Collector when no build configuration is supplied (#5752)
 
 
 ### 🛑 Breaking changes 🛑

--- a/Makefile
+++ b/Makefile
@@ -205,6 +205,7 @@ genotelcorecol:
 
 .PHONY: ocb
 ocb:
+	$(MAKE) -C cmd/builder config
 	$(MAKE) -C cmd/builder ocb
 
 DEPENDABOT_PATH=".github/dependabot.yml"
@@ -397,6 +398,7 @@ endif
 	sed -i.bak 's/$(PREVIOUS_VERSION)/$(RELEASE_CANDIDATE)/g' examples/k8s/otel-config.yaml
 	find . -name "*.bak" -type f -delete
 	# regenerate files
+	$(MAKE) -C cmd/builder config
 	$(MAKE) genotelcorecol
 	# commit changes before running multimod
 	git checkout -b opentelemetry-collector-bot/release-$(RELEASE_CANDIDATE)

--- a/cmd/builder/Makefile
+++ b/cmd/builder/Makefile
@@ -3,3 +3,12 @@ include ../../Makefile.Common
 .PHONY: ocb
 ocb:
 	GO111MODULE=on CGO_ENABLED=0 $(GOCMD) build -trimpath -o ../../bin/ocb_$(GOOS)_$(GOARCH) .
+
+# Generate the default build config from otelcorecol, by removing the
+# "replaces" stanza, which is assumed to be at the end of the file.
+#
+# The default config file is checked in so that `go install` will work
+# and so that non-unix builds don't need sed to be installed.
+.PHONY: config
+config: internal/config/default.yaml
+	sed '-e/replaces:/,$$d' <../otelcorecol/builder-config.yaml > internal/config/default.yaml

--- a/cmd/builder/internal/config/default.go
+++ b/cmd/builder/internal/config/default.go
@@ -1,0 +1,32 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config // import "go.opentelemetry.io/collector/cmd/builder/internal/config"
+
+import (
+	"embed"
+
+	"github.com/knadh/koanf"
+	"github.com/knadh/koanf/providers/fs"
+)
+
+//go:embed *.yaml
+var configs embed.FS
+
+// DefaultProvider returns a koanf.Provider that provides the default build
+// configuration file. This is the same configuration that otelcorecol is
+// built with.
+func DefaultProvider() koanf.Provider {
+	return fs.Provider(configs, "default.yaml")
+}

--- a/cmd/builder/internal/config/default.yaml
+++ b/cmd/builder/internal/config/default.yaml
@@ -1,0 +1,28 @@
+dist:
+  module: go.opentelemetry.io/collector/cmd/otelcorecol
+  name: otelcorecol
+  description: Local OpenTelemetry Collector binary, testing only.
+  version: 0.59.0-dev
+  otelcol_version: 0.59.0
+
+receivers:
+  - import: go.opentelemetry.io/collector/receiver/otlpreceiver
+    gomod: go.opentelemetry.io/collector v0.59.0
+exporters:
+  - import: go.opentelemetry.io/collector/exporter/loggingexporter
+    gomod: go.opentelemetry.io/collector v0.59.0
+  - import: go.opentelemetry.io/collector/exporter/otlpexporter
+    gomod: go.opentelemetry.io/collector v0.59.0
+  - import: go.opentelemetry.io/collector/exporter/otlphttpexporter
+    gomod: go.opentelemetry.io/collector v0.59.0
+extensions:
+  - import: go.opentelemetry.io/collector/extension/ballastextension
+    gomod: go.opentelemetry.io/collector v0.59.0
+  - import: go.opentelemetry.io/collector/extension/zpagesextension
+    gomod: go.opentelemetry.io/collector v0.59.0
+processors:
+  - import: go.opentelemetry.io/collector/processor/batchprocessor
+    gomod: go.opentelemetry.io/collector v0.59.0
+  - import: go.opentelemetry.io/collector/processor/memorylimiterprocessor
+    gomod: go.opentelemetry.io/collector v0.59.0
+

--- a/cmd/builder/test/default.otel.yaml
+++ b/cmd/builder/test/default.otel.yaml
@@ -1,0 +1,22 @@
+extensions:
+  zpages:
+
+receivers:
+  otlp:
+    protocols:
+      grpc:
+
+processors:
+
+exporters:
+  logging:
+
+service:
+  extensions: [zpages]
+  pipelines:
+    traces:
+      receivers:
+        - otlp
+      processors: []
+      exporters:
+        - logging


### PR DESCRIPTION
**Description:** 

Embed the build configuration that is used to build otelcorecol into ocb
so that end users can easily generate a useful collector. This makes the
`--config` flag optional again.

**Link to tracking Issue:**

None.

**Testing:**
```
$ make ocb
/Library/Developer/CommandLineTools/usr/bin/make -C cmd/builder config
sed '-e/replaces:/,$d' <../otelcorecol/builder-config.yaml > internal/config/default.yaml
/Library/Developer/CommandLineTools/usr/bin/make -C cmd/builder ocb
GO111MODULE=on CGO_ENABLED=0 go build -trimpath -o ../../bin/ocb_darwin_arm64 .
$ ./bin/ocb_darwin_arm64
2022-07-26T16:05:06.722+1000	INFO	internal/command.go:91	OpenTelemetry Collector Builder	{"version": "dev", "date": "unknown"}
2022-07-26T16:05:06.722+1000	INFO	internal/command.go:102	Using default build configuration
2022-07-26T16:05:06.723+1000	INFO	builder/config.go:99	Using go	{"go-executable": "/opt/homebrew/bin/go"}
2022-07-26T16:05:06.724+1000	INFO	builder/main.go:76	Sources created	{"path": "/var/folders/hf/8frlwk6s40j0wj3jpgbq94z00000gp/T/otelcol-distribution1809706932"}
2022-07-26T16:05:06.913+1000	INFO	builder/main.go:108	Getting go modules
2022-07-26T16:05:06.942+1000	INFO	builder/main.go:87	Compiling
2022-07-26T16:05:07.948+1000	INFO	builder/main.go:94	Compiled	{"binary": "/var/folders/hf/8frlwk6s40j0wj3jpgbq94z00000gp/T/otelcol-distribution1809706932/otelcorecol"}
```

**Documentation:** 

None.
