### PR TITLE
[exporter/exporterhelper] allow to specify max queue size in bytes

### DIFF
--- a/exporter/exporterhelper/README.md
+++ b/exporter/exporterhelper/README.md
@@ -17,7 +17,7 @@ The following configuration options can be modified:
 - `sending_queue`
   - `enabled` (default = true)
   - `num_consumers` (default = 10): Number of consumers that dequeue batches; ignored if `enabled` is `false`
-  - `queue_size` (default = 5000): Maximum number of batches kept in memory before dropping; ignored if `enabled` is `false`
+  - `queue_size_batches` (default = 5000): Maximum number of batches kept in memory before dropping; ignored if `enabled` is `false`
   User should calculate this as `num_seconds * requests_per_second / requests_per_batch` where:
     - `num_seconds` is the number of seconds to buffer in case of a backend outage
     - `requests_per_second` is the average number of requests per seconds
@@ -39,7 +39,7 @@ With this build tag set, additional configuration option can be enabled:
   - `persistent_storage_enabled` (default = false): When set, enables persistence via a file storage extension
     (note, `enable_unstable` build tag needs to be enabled first, see below for more details)
   - `queue_size_bytes` (default = 2^63 - 1): Maximum number of bytes available for batches in the storage before dropping;
-  It is a separate limit from `queue_size`, both limits are being checked when adding to the queue.
+  It is a separate limit from `queue_size_batches`, both limits are being checked when adding to the queue.
 
 The maximum number of batches stored to disk can be controlled using `sending_queue.queue_size` parameter (which,
 similarly as for in-memory buffering, defaults to 5000 batches).

--- a/exporter/exporterhelper/README.md
+++ b/exporter/exporterhelper/README.md
@@ -38,6 +38,8 @@ With this build tag set, additional configuration option can be enabled:
 - `sending_queue`
   - `persistent_storage_enabled` (default = false): When set, enables persistence via a file storage extension
     (note, `enable_unstable` build tag needs to be enabled first, see below for more details)
+  - `queue_size_bytes` (default = 2^63 - 1): Maximum number of bytes available for batches in the storage before dropping;
+  It is a separate limit from `queue_size`, both limits are being checked when adding to the queue.
 
 The maximum number of batches stored to disk can be controlled using `sending_queue.queue_size` parameter (which,
 similarly as for in-memory buffering, defaults to 5000 batches).

--- a/exporter/exporterhelper/internal/persistent_queue.go
+++ b/exporter/exporterhelper/internal/persistent_queue.go
@@ -37,11 +37,11 @@ type persistentQueue struct {
 }
 
 // NewPersistentQueue creates a new queue backed by file storage; name parameter must be a unique value that identifies the queue
-func NewPersistentQueue(ctx context.Context, name string, capacity int, logger *zap.Logger, client storage.Client, unmarshaler RequestUnmarshaler) ProducerConsumerQueue {
+func NewPersistentQueue(ctx context.Context, name string, capacityBatches int, capacityBytes int, logger *zap.Logger, client storage.Client, unmarshaler RequestUnmarshaler) ProducerConsumerQueue {
 	return &persistentQueue{
 		logger:   logger,
 		stopChan: make(chan struct{}),
-		storage:  newPersistentContiguousStorage(ctx, name, uint64(capacity), logger, client, unmarshaler),
+		storage:  newPersistentContiguousStorage(ctx, name, uint64(capacityBatches), uint64(capacityBytes), logger, client, unmarshaler),
 	}
 }
 
@@ -88,4 +88,9 @@ func (pq *persistentQueue) Stop() {
 // Size returns the current depth of the queue, excluding the item already in the storage channel (if any)
 func (pq *persistentQueue) Size() int {
 	return int(pq.storage.size())
+}
+
+// SizeBytes returns the current sum of sizes of elements in the queue in bytes, excluding the item already in the storage channel (if any)
+func (pq *persistentQueue) SizeBytes() int {
+	return int(pq.storage.sizeBytes())
 }

--- a/exporter/exporterhelper/internal/persistent_storage_batch_test.go
+++ b/exporter/exporterhelper/internal/persistent_storage_batch_test.go
@@ -33,16 +33,18 @@ func TestPersistentStorageBatch_Operations(t *testing.T) {
 
 	itemIndexValue := itemIndex(123)
 	itemIndexArrayValue := []itemIndex{itemIndex(1), itemIndex(2)}
+	uint64Value := uint64(42)
 
 	_, err := newBatch(ps).
 		setItemIndex("index", itemIndexValue).
 		setItemIndexArray("arr", itemIndexArrayValue).
+		setUint64("num", uint64Value).
 		execute(context.Background())
 
 	require.NoError(t, err)
 
 	batch, err := newBatch(ps).
-		get("index", "arr").
+		get("index", "arr", "num").
 		execute(context.Background())
 	require.NoError(t, err)
 
@@ -54,18 +56,26 @@ func TestPersistentStorageBatch_Operations(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, itemIndexArrayValue, retrievedItemIndexArrayValue)
 
-	_, err = newBatch(ps).delete("index", "arr").execute(context.Background())
+	retrievedUint64Value, err := batch.getUint64Result("num")
+	require.NoError(t, err)
+	require.Equal(t, uint64Value, retrievedUint64Value)
+
+	_, err = newBatch(ps).delete("index", "arr", "num").execute(context.Background())
 	require.NoError(t, err)
 
 	batch, err = newBatch(ps).
-		get("index", "arr").
+		get("index", "arr", "num").
 		execute(context.Background())
 	require.NoError(t, err)
 
 	_, err = batch.getItemIndexResult("index")
 	require.Error(t, err, errValueNotSet)
 
+	_, err = batch.getUint64Result("num")
+	require.Error(t, err, errValueNotSet)
+
 	retrievedItemIndexArrayValue, err = batch.getItemIndexArrayResult("arr")
 	require.NoError(t, err)
 	require.Nil(t, retrievedItemIndexArrayValue)
+
 }

--- a/exporter/exporterhelper/obsreport.go
+++ b/exporter/exporterhelper/obsreport.go
@@ -41,6 +41,7 @@ type instruments struct {
 	registry                    *metric.Registry
 	queueSize                   *metric.Int64DerivedGauge
 	queueCapacity               *metric.Int64DerivedGauge
+	queueCapacityBytes          *metric.Int64DerivedGauge
 	failedToEnqueueTraceSpans   *metric.Int64Cumulative
 	failedToEnqueueMetricPoints *metric.Int64Cumulative
 	failedToEnqueueLogRecords   *metric.Int64Cumulative
@@ -59,6 +60,12 @@ func newInstruments(registry *metric.Registry) *instruments {
 	insts.queueCapacity, _ = registry.AddInt64DerivedGauge(
 		obsmetrics.ExporterKey+"/queue_capacity",
 		metric.WithDescription("Fixed capacity of the retry queue (in batches)"),
+		metric.WithLabelKeys(obsmetrics.ExporterKey),
+		metric.WithUnit(metricdata.UnitDimensionless))
+
+	insts.queueCapacityBytes, _ = registry.AddInt64DerivedGauge(
+		obsmetrics.ExporterKey+"/queue_capacity_bytes",
+		metric.WithDescription("Fixed capacity of the retry queue (in bytes)"),
 		metric.WithLabelKeys(obsmetrics.ExporterKey),
 		metric.WithUnit(metricdata.UnitDimensionless))
 

--- a/exporter/exporterhelper/queued_retry_test.go
+++ b/exporter/exporterhelper/queued_retry_test.go
@@ -258,7 +258,7 @@ func TestQueuedRetry_ThrottleError(t *testing.T) {
 func TestQueuedRetry_RetryOnError(t *testing.T) {
 	qCfg := NewDefaultQueueSettings()
 	qCfg.NumConsumers = 1
-	qCfg.QueueSize = 1
+	qCfg.QueueSizeBatches = 1
 	rCfg := NewDefaultRetrySettings()
 	rCfg.InitialInterval = 0
 	be := newBaseExporter(&defaultExporterCfg, componenttest.NewNopExporterCreateSettings(), fromOptions(WithRetry(rCfg), WithQueue(qCfg)), "", nopRequestUnmarshaler())
@@ -285,7 +285,7 @@ func TestQueuedRetry_RetryOnError(t *testing.T) {
 
 func TestQueuedRetry_DropOnFull(t *testing.T) {
 	qCfg := NewDefaultQueueSettings()
-	qCfg.QueueSize = 0
+	qCfg.QueueSizeBatches = 0
 	rCfg := NewDefaultRetrySettings()
 	be := newBaseExporter(&defaultExporterCfg, componenttest.NewNopExporterCreateSettings(), fromOptions(WithRetry(rCfg), WithQueue(qCfg)), "", nopRequestUnmarshaler())
 	ocs := newObservabilityConsumerSender(be.qrSender.consumerSender)
@@ -372,7 +372,7 @@ func TestQueueSettings_Validate(t *testing.T) {
 	qCfg := NewDefaultQueueSettings()
 	assert.NoError(t, qCfg.Validate())
 
-	qCfg.QueueSize = 0
+	qCfg.QueueSizeBatches = 0
 	assert.EqualError(t, qCfg.Validate(), "queue size must be positive")
 
 	// Confirm Validate doesn't return error with invalid config when feature is disabled


### PR DESCRIPTION
**Description:** 
This PR resolves a problem described more precisely in the linked issue. 
TL;DR: The persistent queue now supports specifying an upper limit for the queue capacity in bytes. The `queue_size` parameter is now deprecated and serves as an alias for `queue_size_batches`. 

**Link to tracking Issue:** 
Resolves #5213 

**Testing:** 
Some of the old tests have been modified insignificantly, by adding a bonus parameter to some functions etc. 
The main functionality added in this PR has been tested with a test very similar to the test for the capacity specified in batches. 