### PR TITLE
Allow user to pass in metrics namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 - `ocb` now exits with an error if it fails to load the build configuration. (#5731)
 - Deprecate `HTTPClientSettings.ToClientWithHost` (#5737)
-- Add a new field `namespace` in `service.telemetry.metrics.namespace` to allow user to customize metric namespace (#5692)
+- Add a new field `service.telemetry.metrics.namespace` to allow users to customize the collector's metric namespace (#5692)
 
 ### 🧰 Bug fixes 🧰
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - `ocb` now exits with an error if it fails to load the build configuration. (#5731)
 - Deprecate `HTTPClientSettings.ToClientWithHost` (#5737)
+- Add a new field `namespace` in `service.telemetry.metrics.namespace` to allow user to customize metric namespace (#5692)
 
 ### 🧰 Bug fixes 🧰
 

--- a/service/telemetry.go
+++ b/service/telemetry.go
@@ -54,6 +54,7 @@ const (
 	// useOtelForInternalMetricsfeatureGateID is the feature gate ID that controls whether the collector uses open
 	// telemetrySettings for internal metrics.
 	useOtelForInternalMetricsfeatureGateID = "telemetry.useOtelForInternalMetrics"
+	defaultNameSpace                       = "otelcol"
 )
 
 type telemetryInitializer struct {
@@ -173,8 +174,12 @@ func (tel *telemetryInitializer) initOpenCensus(cfg telemetry.Config, telAttrs m
 	}
 
 	// Until we can use a generic metrics exporter, default to Prometheus.
+	namespace := defaultNameSpace
+	if cfg.Metrics.NameSpace != "" {
+		namespace = cfg.Metrics.NameSpace
+	}
 	opts := prometheus.Options{
-		Namespace: "otelcol",
+		Namespace: namespace,
 	}
 
 	opts.ConstLabels = make(map[string]string)

--- a/service/telemetry.go
+++ b/service/telemetry.go
@@ -175,8 +175,8 @@ func (tel *telemetryInitializer) initOpenCensus(cfg telemetry.Config, telAttrs m
 
 	// Until we can use a generic metrics exporter, default to Prometheus.
 	namespace := defaultNameSpace
-	if cfg.Metrics.NameSpace != "" {
-		namespace = cfg.Metrics.NameSpace
+	if cfg.Metrics.Namespace != nil {
+		namespace = *cfg.Metrics.Namespace
 	}
 	opts := prometheus.Options{
 		Namespace: namespace,

--- a/service/telemetry/config.go
+++ b/service/telemetry/config.go
@@ -103,6 +103,10 @@ type MetricsConfig struct {
 	// Address is the [address]:port that metrics exposition should be bound to.
 	Address string `mapstructure:"address"`
 
-	// Namespace indicates the telemetry namespace the service will set. If nil, a default value is assigned.
+	// Namespace indicates the telemetry namespace the service will set. If nil, a default value 'otelcol' is assigned.
+	// An example of how the value of Namespace would affect metrics name:
+	// - if Namespace not set: "otelcol_process_cpu_seconds"
+	// - if Namespace set to empty string: "process_cpu_seconds"
+	// - if Namespace set to other string(e.g: "custom_namespace"): "custom_namespace_process_cpu_seconds"
 	Namespace *string `mapstructure:"namespace"`
 }

--- a/service/telemetry/config.go
+++ b/service/telemetry/config.go
@@ -102,4 +102,7 @@ type MetricsConfig struct {
 
 	// Address is the [address]:port that metrics exposition should be bound to.
 	Address string `mapstructure:"address"`
+
+	// NameSpace indicates the telemetry namespace the service will set.
+	NameSpace string `mapstructure:"namespace"`
 }

--- a/service/telemetry/config.go
+++ b/service/telemetry/config.go
@@ -103,6 +103,6 @@ type MetricsConfig struct {
 	// Address is the [address]:port that metrics exposition should be bound to.
 	Address string `mapstructure:"address"`
 
-	// NameSpace indicates the telemetry namespace the service will set.
-	NameSpace string `mapstructure:"namespace"`
+	// Namespace indicates the telemetry namespace the service will set. If nil, a default value is assigned.
+	Namespace *string `mapstructure:"namespace"`
 }

--- a/service/testdata/otelcol-metricnamespace.yaml
+++ b/service/testdata/otelcol-metricnamespace.yaml
@@ -1,0 +1,30 @@
+receivers:
+  nop:
+
+processors:
+  nop:
+
+exporters:
+  nop:
+
+extensions:
+  nop:
+
+service:
+  telemetry:
+    metrics:
+      namespace: customNamespace
+  extensions: [nop]
+  pipelines:
+    traces:
+      receivers: [nop]
+      processors: [nop]
+      exporters: [nop]
+    metrics:
+      receivers: [nop]
+      processors: [nop]
+      exporters: [nop]
+    logs:
+      receivers: [nop]
+      processors: [nop]
+      exporters: [nop]


### PR DESCRIPTION
**Description:**  
Adding a configuration that allows user to configure their metrics namespace

**Link to tracking Issue:** 
https://github.com/open-telemetry/opentelemetry-collector/issues/5692

**Testing:**
Added a unit test to verify namespace can be customized

**Documentation:**
Added godoc on the new `namespace` field