### PR TITLE
Define a new API for components stability level to match extensions as well

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@
 
 ### 🚩 Deprecations 🚩
 
+- Deprecate the `component.Factory.StabilityLevel(config.DataType)` in favor of Stability per component (#5762):
+  - `component.ExporterFactory.TracesExporterStability`
+  - `component.ExporterFactory.MetricsExporterStability`
+  - `component.ExporterFactory.LogsExporterStability`
+  - `component.ProcessorFactory.TracesProcessorStability`
+  - `component.ProcessorFactory.MetricsProcessorStability`
+  - `component.ProcessorFactory.LogsProcessorStability`
+  - `component.ReceiverFactory.TracesReceiverStability`
+  - `component.ReceiverFactory.MetricsReceiverStability`
+  - `component.ReceiverFactory.LogsReceiverStability`
+
 ### 💡 Enhancements 💡
 
 ### 🧰 Bug fixes 🧰

--- a/component/component.go
+++ b/component/component.go
@@ -164,7 +164,7 @@ type Factory interface {
 	// Type gets the type of the component created by this factory.
 	Type() config.Type
 
-	// StabilityLevel gets the stability level of the component.
+	// Deprecated: [v0.58.0] replaced by the more specific versions in each Factory type.
 	StabilityLevel(config.DataType) StabilityLevel
 
 	unexportedFactoryFunc()
@@ -182,6 +182,10 @@ func (bf baseFactory) Type() config.Type {
 }
 
 func (bf baseFactory) StabilityLevel(dt config.DataType) StabilityLevel {
+	return bf.getStabilityLevel(dt)
+}
+
+func (bf baseFactory) getStabilityLevel(dt config.DataType) StabilityLevel {
 	if val, ok := bf.stability[dt]; ok {
 		return val
 	}

--- a/component/componenttest/nop_extension.go
+++ b/component/componenttest/nop_extension.go
@@ -35,7 +35,7 @@ type nopExtensionConfig struct {
 
 // NewNopExtensionFactory returns a component.ExtensionFactory that constructs nop extensions.
 func NewNopExtensionFactory() component.ExtensionFactory {
-	return component.NewExtensionFactory(
+	return component.NewExtensionFactoryWithStabilityLevel(
 		"nop",
 		func() config.Extension {
 			return &nopExtensionConfig{
@@ -44,7 +44,8 @@ func NewNopExtensionFactory() component.ExtensionFactory {
 		},
 		func(context.Context, component.ExtensionCreateSettings, config.Extension) (component.Extension, error) {
 			return nopExtensionInstance, nil
-		})
+		},
+		component.StabilityLevelStable)
 }
 
 var nopExtensionInstance = &nopExtension{}

--- a/component/exporter.go
+++ b/component/exporter.go
@@ -68,20 +68,29 @@ type ExporterFactory interface {
 	// tests of any implementation of the Factory interface.
 	CreateDefaultConfig() config.Exporter
 
-	// CreateTracesExporter creates a trace exporter based on this config.
+	// CreateTracesExporter creates a TracesExporter based on this config.
 	// If the exporter type does not support tracing or if the config is not valid,
 	// an error will be returned instead.
 	CreateTracesExporter(ctx context.Context, set ExporterCreateSettings, cfg config.Exporter) (TracesExporter, error)
 
-	// CreateMetricsExporter creates a metrics exporter based on this config.
+	// TracesExporterStability gets the stability level of the TracesExporter.
+	TracesExporterStability() StabilityLevel
+
+	// CreateMetricsExporter creates a MetricsExporter based on this config.
 	// If the exporter type does not support metrics or if the config is not valid,
 	// an error will be returned instead.
 	CreateMetricsExporter(ctx context.Context, set ExporterCreateSettings, cfg config.Exporter) (MetricsExporter, error)
 
-	// CreateLogsExporter creates an exporter based on the config.
+	// MetricsExporterStability gets the stability level of the MetricsExporter.
+	MetricsExporterStability() StabilityLevel
+
+	// CreateLogsExporter creates a LogsExporter based on the config.
 	// If the exporter type does not support logs or if the config is not valid,
 	// an error will be returned instead.
 	CreateLogsExporter(ctx context.Context, set ExporterCreateSettings, cfg config.Exporter) (LogsExporter, error)
+
+	// LogsExporterStability gets the stability level of the LogsExporter.
+	LogsExporterStability() StabilityLevel
 }
 
 // ExporterFactoryOption apply changes to ExporterOptions.
@@ -146,6 +155,18 @@ type exporterFactory struct {
 	CreateTracesExporterFunc
 	CreateMetricsExporterFunc
 	CreateLogsExporterFunc
+}
+
+func (e exporterFactory) TracesExporterStability() StabilityLevel {
+	return e.getStabilityLevel(config.TracesDataType)
+}
+
+func (e exporterFactory) MetricsExporterStability() StabilityLevel {
+	return e.getStabilityLevel(config.MetricsDataType)
+}
+
+func (e exporterFactory) LogsExporterStability() StabilityLevel {
+	return e.getStabilityLevel(config.LogsDataType)
 }
 
 // WithTracesExporter overrides the default "error not supported" implementation for CreateTracesExporter and the default "undefined" stability level.

--- a/component/exporter_test.go
+++ b/component/exporter_test.go
@@ -51,15 +51,15 @@ func TestNewExporterFactory_WithOptions(t *testing.T) {
 	assert.EqualValues(t, typeStr, factory.Type())
 	assert.EqualValues(t, &defaultCfg, factory.CreateDefaultConfig())
 
-	assert.Equal(t, StabilityLevelInDevelopment, factory.StabilityLevel(config.TracesDataType))
+	assert.Equal(t, StabilityLevelInDevelopment, factory.TracesExporterStability())
 	_, err := factory.CreateTracesExporter(context.Background(), ExporterCreateSettings{}, &defaultCfg)
 	assert.NoError(t, err)
 
-	assert.Equal(t, StabilityLevelAlpha, factory.StabilityLevel(config.MetricsDataType))
+	assert.Equal(t, StabilityLevelAlpha, factory.MetricsExporterStability())
 	_, err = factory.CreateMetricsExporter(context.Background(), ExporterCreateSettings{}, &defaultCfg)
 	assert.NoError(t, err)
 
-	assert.Equal(t, StabilityLevelDeprecated, factory.StabilityLevel(config.LogsDataType))
+	assert.Equal(t, StabilityLevelDeprecated, factory.LogsExporterStability())
 	_, err = factory.CreateLogsExporter(context.Background(), ExporterCreateSettings{}, &defaultCfg)
 	assert.NoError(t, err)
 }

--- a/component/extension.go
+++ b/component/extension.go
@@ -83,21 +83,40 @@ type ExtensionFactory interface {
 
 	// CreateExtension creates an extension based on the given config.
 	CreateExtension(ctx context.Context, set ExtensionCreateSettings, cfg config.Extension) (Extension, error)
+
+	// ExtensionStability gets the stability level of the Extension.
+	ExtensionStability() StabilityLevel
 }
 
 type extensionFactory struct {
 	baseFactory
 	ExtensionCreateDefaultConfigFunc
 	CreateExtensionFunc
+	extensionStability StabilityLevel
 }
 
+func (ef *extensionFactory) ExtensionStability() StabilityLevel {
+	return ef.extensionStability
+}
+
+// Deprecated: [v0.58.0] use NewExtensionFactoryWithStabilityLevel.
 func NewExtensionFactory(
 	cfgType config.Type,
 	createDefaultConfig ExtensionCreateDefaultConfigFunc,
 	createServiceExtension CreateExtensionFunc) ExtensionFactory {
+	return NewExtensionFactoryWithStabilityLevel(cfgType, createDefaultConfig, createServiceExtension, StabilityLevelUndefined)
+}
+
+// NewExtensionFactoryWithStabilityLevel returns a new ExtensionFactory  based on this configuration.
+func NewExtensionFactoryWithStabilityLevel(
+	cfgType config.Type,
+	createDefaultConfig ExtensionCreateDefaultConfigFunc,
+	createServiceExtension CreateExtensionFunc,
+	sl StabilityLevel) ExtensionFactory {
 	return &extensionFactory{
 		baseFactory:                      baseFactory{cfgType: cfgType},
 		ExtensionCreateDefaultConfigFunc: createDefaultConfig,
 		CreateExtensionFunc:              createServiceExtension,
+		extensionStability:               sl,
 	}
 }

--- a/component/extension_test.go
+++ b/component/extension_test.go
@@ -33,14 +33,17 @@ func TestNewExtensionFactory(t *testing.T) {
 	defaultCfg := config.NewExtensionSettings(config.NewComponentID(typeStr))
 	nopExtensionInstance := new(nopExtension)
 
-	factory := NewExtensionFactory(
+	factory := NewExtensionFactoryWithStabilityLevel(
 		typeStr,
 		func() config.Extension { return &defaultCfg },
 		func(ctx context.Context, settings ExtensionCreateSettings, extension config.Extension) (Extension, error) {
 			return nopExtensionInstance, nil
-		})
+		},
+		StabilityLevelInDevelopment)
 	assert.EqualValues(t, typeStr, factory.Type())
 	assert.EqualValues(t, &defaultCfg, factory.CreateDefaultConfig())
+
+	assert.Equal(t, StabilityLevelInDevelopment, factory.ExtensionStability())
 	ext, err := factory.CreateExtension(context.Background(), ExtensionCreateSettings{}, &defaultCfg)
 	assert.NoError(t, err)
 	assert.Same(t, nopExtensionInstance, ext)

--- a/component/factories_test.go
+++ b/component/factories_test.go
@@ -29,8 +29,8 @@ func TestMakeExtensionFactoryMap(t *testing.T) {
 		out  map[config.Type]ExtensionFactory
 	}
 
-	p1 := NewExtensionFactory("p1", nil, nil)
-	p2 := NewExtensionFactory("p2", nil, nil)
+	p1 := NewExtensionFactoryWithStabilityLevel("p1", nil, nil, StabilityLevelAlpha)
+	p2 := NewExtensionFactoryWithStabilityLevel("p2", nil, nil, StabilityLevelAlpha)
 	testCases := []testCase{
 		{
 			name: "different names",
@@ -42,7 +42,7 @@ func TestMakeExtensionFactoryMap(t *testing.T) {
 		},
 		{
 			name: "same name",
-			in:   []ExtensionFactory{p1, p2, NewExtensionFactory("p1", nil, nil)},
+			in:   []ExtensionFactory{p1, p2, NewExtensionFactoryWithStabilityLevel("p1", nil, nil, StabilityLevelAlpha)},
 		},
 	}
 	for i := range testCases {

--- a/component/processor.go
+++ b/component/processor.go
@@ -69,35 +69,29 @@ type ProcessorFactory interface {
 	// tests of any implementation of the Factory interface.
 	CreateDefaultConfig() config.Processor
 
-	// CreateTracesProcessor creates a trace processor based on this config.
+	// CreateTracesProcessor creates a TracesProcessor based on this config.
 	// If the processor type does not support tracing or if the config is not valid,
 	// an error will be returned instead.
-	CreateTracesProcessor(
-		ctx context.Context,
-		set ProcessorCreateSettings,
-		cfg config.Processor,
-		nextConsumer consumer.Traces,
-	) (TracesProcessor, error)
+	CreateTracesProcessor(ctx context.Context, set ProcessorCreateSettings, cfg config.Processor, nextConsumer consumer.Traces) (TracesProcessor, error)
 
-	// CreateMetricsProcessor creates a metrics processor based on this config.
+	// TracesProcessorStability gets the stability level of the TracesProcessor.
+	TracesProcessorStability() StabilityLevel
+
+	// CreateMetricsProcessor creates a MetricsProcessor based on this config.
 	// If the processor type does not support metrics or if the config is not valid,
 	// an error will be returned instead.
-	CreateMetricsProcessor(
-		ctx context.Context,
-		set ProcessorCreateSettings,
-		cfg config.Processor,
-		nextConsumer consumer.Metrics,
-	) (MetricsProcessor, error)
+	CreateMetricsProcessor(ctx context.Context, set ProcessorCreateSettings, cfg config.Processor, nextConsumer consumer.Metrics) (MetricsProcessor, error)
 
-	// CreateLogsProcessor creates a processor based on the config.
+	// MetricsProcessorStability gets the stability level of the MetricsProcessor.
+	MetricsProcessorStability() StabilityLevel
+
+	// CreateLogsProcessor creates a LogsProcessor based on the config.
 	// If the processor type does not support logs or if the config is not valid,
 	// an error will be returned instead.
-	CreateLogsProcessor(
-		ctx context.Context,
-		set ProcessorCreateSettings,
-		cfg config.Processor,
-		nextConsumer consumer.Logs,
-	) (LogsProcessor, error)
+	CreateLogsProcessor(ctx context.Context, set ProcessorCreateSettings, cfg config.Processor, nextConsumer consumer.Logs) (LogsProcessor, error)
+
+	// LogsProcessorStability gets the stability level of the LogsProcessor.
+	LogsProcessorStability() StabilityLevel
 }
 
 // ProcessorCreateDefaultConfigFunc is the equivalent of ProcessorFactory.CreateDefaultConfig().
@@ -176,6 +170,18 @@ type processorFactory struct {
 	CreateTracesProcessorFunc
 	CreateMetricsProcessorFunc
 	CreateLogsProcessorFunc
+}
+
+func (p processorFactory) TracesProcessorStability() StabilityLevel {
+	return p.getStabilityLevel(config.TracesDataType)
+}
+
+func (p processorFactory) MetricsProcessorStability() StabilityLevel {
+	return p.getStabilityLevel(config.MetricsDataType)
+}
+
+func (p processorFactory) LogsProcessorStability() StabilityLevel {
+	return p.getStabilityLevel(config.LogsDataType)
 }
 
 // WithTracesProcessor overrides the default "error not supported" implementation for CreateTracesProcessor and the default "undefined" stability level.

--- a/component/processor_test.go
+++ b/component/processor_test.go
@@ -52,15 +52,15 @@ func TestNewProcessorFactory_WithOptions(t *testing.T) {
 	assert.EqualValues(t, typeStr, factory.Type())
 	assert.EqualValues(t, &defaultCfg, factory.CreateDefaultConfig())
 
-	assert.Equal(t, StabilityLevelAlpha, factory.StabilityLevel(config.TracesDataType))
+	assert.Equal(t, StabilityLevelAlpha, factory.TracesProcessorStability())
 	_, err := factory.CreateTracesProcessor(context.Background(), ProcessorCreateSettings{}, &defaultCfg, nil)
 	assert.NoError(t, err)
 
-	assert.Equal(t, StabilityLevelBeta, factory.StabilityLevel(config.MetricsDataType))
+	assert.Equal(t, StabilityLevelBeta, factory.MetricsProcessorStability())
 	_, err = factory.CreateMetricsProcessor(context.Background(), ProcessorCreateSettings{}, &defaultCfg, nil)
 	assert.NoError(t, err)
 
-	assert.Equal(t, StabilityLevelUnmaintained, factory.StabilityLevel(config.LogsDataType))
+	assert.Equal(t, StabilityLevelUnmaintained, factory.LogsProcessorStability())
 	_, err = factory.CreateLogsProcessor(context.Background(), ProcessorCreateSettings{}, &defaultCfg, nil)
 	assert.NoError(t, err)
 }

--- a/component/receiver.go
+++ b/component/receiver.go
@@ -113,23 +113,29 @@ type ReceiverFactory interface {
 	// tests of any implementation of the Factory interface.
 	CreateDefaultConfig() config.Receiver
 
-	// CreateTracesReceiver creates a trace receiver based on this config.
+	// CreateTracesReceiver creates a TracesReceiver based on this config.
 	// If the receiver type does not support tracing or if the config is not valid
 	// an error will be returned instead.
-	CreateTracesReceiver(ctx context.Context, set ReceiverCreateSettings,
-		cfg config.Receiver, nextConsumer consumer.Traces) (TracesReceiver, error)
+	CreateTracesReceiver(ctx context.Context, set ReceiverCreateSettings, cfg config.Receiver, nextConsumer consumer.Traces) (TracesReceiver, error)
 
-	// CreateMetricsReceiver creates a metrics receiver based on this config.
+	// TracesReceiverStability gets the stability level of the TracesReceiver.
+	TracesReceiverStability() StabilityLevel
+
+	// CreateMetricsReceiver creates a MetricsReceiver based on this config.
 	// If the receiver type does not support metrics or if the config is not valid
 	// an error will be returned instead.
-	CreateMetricsReceiver(ctx context.Context, set ReceiverCreateSettings,
-		cfg config.Receiver, nextConsumer consumer.Metrics) (MetricsReceiver, error)
+	CreateMetricsReceiver(ctx context.Context, set ReceiverCreateSettings, cfg config.Receiver, nextConsumer consumer.Metrics) (MetricsReceiver, error)
 
-	// CreateLogsReceiver creates a log receiver based on this config.
+	// MetricsReceiverStability gets the stability level of the MetricsReceiver.
+	MetricsReceiverStability() StabilityLevel
+
+	// CreateLogsReceiver creates a LogsReceiver based on this config.
 	// If the receiver type does not support the data type or if the config is not valid
 	// an error will be returned instead.
-	CreateLogsReceiver(ctx context.Context, set ReceiverCreateSettings,
-		cfg config.Receiver, nextConsumer consumer.Logs) (LogsReceiver, error)
+	CreateLogsReceiver(ctx context.Context, set ReceiverCreateSettings, cfg config.Receiver, nextConsumer consumer.Logs) (LogsReceiver, error)
+
+	// LogsReceiverStability gets the stability level of the LogsReceiver.
+	LogsReceiverStability() StabilityLevel
 }
 
 // ReceiverFactoryOption apply changes to ReceiverOptions.
@@ -208,6 +214,18 @@ type receiverFactory struct {
 	CreateTracesReceiverFunc
 	CreateMetricsReceiverFunc
 	CreateLogsReceiverFunc
+}
+
+func (r receiverFactory) TracesReceiverStability() StabilityLevel {
+	return r.getStabilityLevel(config.TracesDataType)
+}
+
+func (r receiverFactory) MetricsReceiverStability() StabilityLevel {
+	return r.getStabilityLevel(config.MetricsDataType)
+}
+
+func (r receiverFactory) LogsReceiverStability() StabilityLevel {
+	return r.getStabilityLevel(config.LogsDataType)
 }
 
 // WithTracesReceiver overrides the default "error not supported" implementation for CreateTracesReceiver and the default "undefined" stability level.

--- a/component/receiver_test.go
+++ b/component/receiver_test.go
@@ -52,15 +52,15 @@ func TestNewReceiverFactory_WithOptions(t *testing.T) {
 	assert.EqualValues(t, typeStr, factory.Type())
 	assert.EqualValues(t, &defaultCfg, factory.CreateDefaultConfig())
 
-	assert.Equal(t, StabilityLevelDeprecated, factory.StabilityLevel(config.TracesDataType))
+	assert.Equal(t, StabilityLevelDeprecated, factory.TracesReceiverStability())
 	_, err := factory.CreateTracesReceiver(context.Background(), ReceiverCreateSettings{}, &defaultCfg, nil)
 	assert.NoError(t, err)
 
-	assert.Equal(t, StabilityLevelAlpha, factory.StabilityLevel(config.MetricsDataType))
+	assert.Equal(t, StabilityLevelAlpha, factory.MetricsReceiverStability())
 	_, err = factory.CreateMetricsReceiver(context.Background(), ReceiverCreateSettings{}, &defaultCfg, nil)
 	assert.NoError(t, err)
 
-	assert.Equal(t, StabilityLevelStable, factory.StabilityLevel(config.LogsDataType))
+	assert.Equal(t, StabilityLevelStable, factory.LogsReceiverStability())
 	_, err = factory.CreateLogsReceiver(context.Background(), ReceiverCreateSettings{}, &defaultCfg, nil)
 	assert.NoError(t, err)
 }

--- a/extension/ballastextension/factory.go
+++ b/extension/ballastextension/factory.go
@@ -32,7 +32,7 @@ var memHandler = iruntime.TotalMemory
 
 // NewFactory creates a factory for FluentBit extension.
 func NewFactory() component.ExtensionFactory {
-	return component.NewExtensionFactory(typeStr, createDefaultConfig, createExtension)
+	return component.NewExtensionFactoryWithStabilityLevel(typeStr, createDefaultConfig, createExtension, component.StabilityLevelBeta)
 }
 
 func createDefaultConfig() config.Extension {

--- a/extension/zpagesextension/factory.go
+++ b/extension/zpagesextension/factory.go
@@ -31,7 +31,7 @@ const (
 
 // NewFactory creates a factory for Z-Pages extension.
 func NewFactory() component.ExtensionFactory {
-	return component.NewExtensionFactory(typeStr, createDefaultConfig, createExtension)
+	return component.NewExtensionFactoryWithStabilityLevel(typeStr, createDefaultConfig, createExtension, component.StabilityLevelBeta)
 }
 
 func createDefaultConfig() config.Extension {

--- a/service/extensions/extensions_test.go
+++ b/service/extensions/extensions_test.go
@@ -106,7 +106,7 @@ func TestBuildExtensions(t *testing.T) {
 }
 
 func newBadExtensionFactory() component.ExtensionFactory {
-	return component.NewExtensionFactory(
+	return component.NewExtensionFactoryWithStabilityLevel(
 		"bf",
 		func() config.Extension {
 			return &struct {
@@ -118,11 +118,12 @@ func newBadExtensionFactory() component.ExtensionFactory {
 		func(ctx context.Context, set component.ExtensionCreateSettings, extension config.Extension) (component.Extension, error) {
 			return nil, nil
 		},
+		component.StabilityLevelInDevelopment,
 	)
 }
 
 func newCreateErrorExtensionFactory() component.ExtensionFactory {
-	return component.NewExtensionFactory(
+	return component.NewExtensionFactoryWithStabilityLevel(
 		"err",
 		func() config.Extension {
 			return &struct {
@@ -134,5 +135,6 @@ func newCreateErrorExtensionFactory() component.ExtensionFactory {
 		func(ctx context.Context, set component.ExtensionCreateSettings, extension config.Extension) (component.Extension, error) {
 			return nil, errors.New("cannot create \"err\" extension type")
 		},
+		component.StabilityLevelInDevelopment,
 	)
 }

--- a/service/internal/pipelines/pipelines.go
+++ b/service/internal/pipelines/pipelines.go
@@ -355,7 +355,7 @@ func buildExporter(
 		BuildInfo:         buildInfo,
 	}
 	set.TelemetrySettings.Logger = exporterLogger(settings.Logger, id, pipelineID.Type())
-	components.LogStabilityLevel(set.TelemetrySettings.Logger, factory.StabilityLevel(pipelineID.Type()))
+	components.LogStabilityLevel(set.TelemetrySettings.Logger, getExporterStabilityLevel(factory, pipelineID.Type()))
 
 	exp, err := createExporter(ctx, set, cfg, id, pipelineID, factory)
 	if err != nil {
@@ -413,6 +413,18 @@ func exporterLogger(logger *zap.Logger, id config.ComponentID, dt config.DataTyp
 		zap.String(components.ZapNameKey, id.String()))
 }
 
+func getExporterStabilityLevel(factory component.ExporterFactory, dt config.DataType) component.StabilityLevel {
+	switch dt {
+	case config.TracesDataType:
+		return factory.TracesExporterStability()
+	case config.MetricsDataType:
+		return factory.MetricsExporterStability()
+	case config.LogsDataType:
+		return factory.LogsExporterStability()
+	}
+	return component.StabilityLevelUndefined
+}
+
 func buildProcessor(ctx context.Context,
 	settings component.TelemetrySettings,
 	buildInfo component.BuildInfo,
@@ -437,7 +449,7 @@ func buildProcessor(ctx context.Context,
 		BuildInfo:         buildInfo,
 	}
 	set.TelemetrySettings.Logger = processorLogger(settings.Logger, id, pipelineID)
-	components.LogStabilityLevel(set.TelemetrySettings.Logger, factory.StabilityLevel(pipelineID.Type()))
+	components.LogStabilityLevel(set.TelemetrySettings.Logger, getProcessorStabilityLevel(factory, pipelineID.Type()))
 
 	proc, err := createProcessor(ctx, set, procCfg, id, pipelineID, next, factory)
 	if err != nil {
@@ -467,6 +479,18 @@ func processorLogger(logger *zap.Logger, procID config.ComponentID, pipelineID c
 		zap.String(components.ZapKindPipeline, pipelineID.String()))
 }
 
+func getProcessorStabilityLevel(factory component.ProcessorFactory, dt config.DataType) component.StabilityLevel {
+	switch dt {
+	case config.TracesDataType:
+		return factory.TracesProcessorStability()
+	case config.MetricsDataType:
+		return factory.MetricsProcessorStability()
+	case config.LogsDataType:
+		return factory.LogsProcessorStability()
+	}
+	return component.StabilityLevelUndefined
+}
+
 func buildReceiver(ctx context.Context,
 	settings component.TelemetrySettings,
 	buildInfo component.BuildInfo,
@@ -491,7 +515,7 @@ func buildReceiver(ctx context.Context,
 		BuildInfo:         buildInfo,
 	}
 	set.TelemetrySettings.Logger = receiverLogger(settings.Logger, id, pipelineID.Type())
-	components.LogStabilityLevel(set.TelemetrySettings.Logger, factory.StabilityLevel(pipelineID.Type()))
+	components.LogStabilityLevel(set.TelemetrySettings.Logger, getReceiverStabilityLevel(factory, pipelineID.Type()))
 
 	recv, err := createReceiver(ctx, set, cfg, id, pipelineID, nexts, factory)
 	if err != nil {
@@ -530,6 +554,18 @@ func receiverLogger(logger *zap.Logger, id config.ComponentID, dt config.DataTyp
 		zap.String(components.ZapKindKey, components.ZapKindReceiver),
 		zap.String(components.ZapNameKey, id.String()),
 		zap.String(components.ZapKindPipeline, string(dt)))
+}
+
+func getReceiverStabilityLevel(factory component.ReceiverFactory, dt config.DataType) component.StabilityLevel {
+	switch dt {
+	case config.TracesDataType:
+		return factory.TracesReceiverStability()
+	case config.MetricsDataType:
+		return factory.MetricsReceiverStability()
+	case config.LogsDataType:
+		return factory.LogsReceiverStability()
+	}
+	return component.StabilityLevelUndefined
 }
 
 func (bps *Pipelines) getPipelinesSummaryTableData() zpages.SummaryPipelinesTableData {


### PR DESCRIPTION
* Deprecates current `StabilityLevel(config.DataType)` function from the base `Factory` which is not well suited for Extension. 
* Add new specific for each component `Stability` functions.

Signed-off-by: Bogdan <bogdandrutu@gmail.com>
