### PR TITLE
Small fixes in the new StabilityLevel feature

### DIFF
--- a/component/component.go
+++ b/component/component.go
@@ -111,7 +111,7 @@ const (
 type StabilityLevel int
 
 const (
-	StabilityLevelUndefined = iota // skip 0, start types from 1.
+	StabilityLevelUndefined StabilityLevel = iota // skip 0, start types from 1.
 	StabilityLevelUnmaintained
 	StabilityLevelDeprecated
 	StabilityLevelInDevelopment
@@ -172,7 +172,7 @@ type Factory interface {
 
 type baseFactory struct {
 	cfgType   config.Type
-	stability map[config.Type]StabilityLevel
+	stability map[config.DataType]StabilityLevel
 }
 
 func (baseFactory) unexportedFactoryFunc() {}

--- a/component/exporter_test.go
+++ b/component/exporter_test.go
@@ -51,15 +51,15 @@ func TestNewExporterFactory_WithOptions(t *testing.T) {
 	assert.EqualValues(t, typeStr, factory.Type())
 	assert.EqualValues(t, &defaultCfg, factory.CreateDefaultConfig())
 
-	assert.EqualValues(t, StabilityLevelInDevelopment, factory.StabilityLevel(config.TracesDataType))
+	assert.Equal(t, StabilityLevelInDevelopment, factory.StabilityLevel(config.TracesDataType))
 	_, err := factory.CreateTracesExporter(context.Background(), ExporterCreateSettings{}, &defaultCfg)
 	assert.NoError(t, err)
 
-	assert.EqualValues(t, StabilityLevelAlpha, factory.StabilityLevel(config.MetricsDataType))
+	assert.Equal(t, StabilityLevelAlpha, factory.StabilityLevel(config.MetricsDataType))
 	_, err = factory.CreateMetricsExporter(context.Background(), ExporterCreateSettings{}, &defaultCfg)
 	assert.NoError(t, err)
 
-	assert.EqualValues(t, StabilityLevelDeprecated, factory.StabilityLevel(config.LogsDataType))
+	assert.Equal(t, StabilityLevelDeprecated, factory.StabilityLevel(config.LogsDataType))
 	_, err = factory.CreateLogsExporter(context.Background(), ExporterCreateSettings{}, &defaultCfg)
 	assert.NoError(t, err)
 }

--- a/component/processor_test.go
+++ b/component/processor_test.go
@@ -52,15 +52,15 @@ func TestNewProcessorFactory_WithOptions(t *testing.T) {
 	assert.EqualValues(t, typeStr, factory.Type())
 	assert.EqualValues(t, &defaultCfg, factory.CreateDefaultConfig())
 
-	assert.EqualValues(t, StabilityLevelAlpha, factory.StabilityLevel(config.TracesDataType))
+	assert.Equal(t, StabilityLevelAlpha, factory.StabilityLevel(config.TracesDataType))
 	_, err := factory.CreateTracesProcessor(context.Background(), ProcessorCreateSettings{}, &defaultCfg, nil)
 	assert.NoError(t, err)
 
-	assert.EqualValues(t, StabilityLevelBeta, factory.StabilityLevel(config.MetricsDataType))
+	assert.Equal(t, StabilityLevelBeta, factory.StabilityLevel(config.MetricsDataType))
 	_, err = factory.CreateMetricsProcessor(context.Background(), ProcessorCreateSettings{}, &defaultCfg, nil)
 	assert.NoError(t, err)
 
-	assert.EqualValues(t, StabilityLevelUnmaintained, factory.StabilityLevel(config.LogsDataType))
+	assert.Equal(t, StabilityLevelUnmaintained, factory.StabilityLevel(config.LogsDataType))
 	_, err = factory.CreateLogsProcessor(context.Background(), ProcessorCreateSettings{}, &defaultCfg, nil)
 	assert.NoError(t, err)
 }

--- a/component/receiver_test.go
+++ b/component/receiver_test.go
@@ -52,15 +52,15 @@ func TestNewReceiverFactory_WithOptions(t *testing.T) {
 	assert.EqualValues(t, typeStr, factory.Type())
 	assert.EqualValues(t, &defaultCfg, factory.CreateDefaultConfig())
 
-	assert.EqualValues(t, StabilityLevelDeprecated, factory.StabilityLevel(config.TracesDataType))
+	assert.Equal(t, StabilityLevelDeprecated, factory.StabilityLevel(config.TracesDataType))
 	_, err := factory.CreateTracesReceiver(context.Background(), ReceiverCreateSettings{}, &defaultCfg, nil)
 	assert.NoError(t, err)
 
-	assert.EqualValues(t, StabilityLevelAlpha, factory.StabilityLevel(config.MetricsDataType))
+	assert.Equal(t, StabilityLevelAlpha, factory.StabilityLevel(config.MetricsDataType))
 	_, err = factory.CreateMetricsReceiver(context.Background(), ReceiverCreateSettings{}, &defaultCfg, nil)
 	assert.NoError(t, err)
 
-	assert.EqualValues(t, StabilityLevelStable, factory.StabilityLevel(config.LogsDataType))
+	assert.Equal(t, StabilityLevelStable, factory.StabilityLevel(config.LogsDataType))
 	_, err = factory.CreateLogsReceiver(context.Background(), ReceiverCreateSettings{}, &defaultCfg, nil)
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
* Make the enum values same type as the enum type
* Use config.DataType everywhere

These are non controversial fixes extracted from https://github.com/open-telemetry/opentelemetry-collector/pull/5762

Signed-off-by: Bogdan <bogdandrutu@gmail.com>