### PR TITLE
Require the storage to be explicitly set for persistent queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 🛑 Breaking changes 🛑
 
+- Require the storage to be explicitly set for the (experimental) persistent queue (#5784)
 - Remove deprecated component stability helpers (#5802):
   - `component.WithTracesExporterAndStabilityLevel`
   - `component.WithMetricsExporterAndStabilityLevel`

--- a/exporter/exporterhelper/README.md
+++ b/exporter/exporterhelper/README.md
@@ -36,16 +36,13 @@ The following configuration options can be modified:
 With this build tag set, additional configuration option can be enabled:
 
 - `sending_queue`
-  - `persistent_storage_enabled` (default = false): When set, enables persistence via a file storage extension
+  - `storage` (default = none): When set, enables persistence and uses the component specified as a storage extension for the persistent queue
     (note, `enable_unstable` build tag needs to be enabled first, see below for more details)
 
 The maximum number of batches stored to disk can be controlled using `sending_queue.queue_size` parameter (which,
 similarly as for in-memory buffering, defaults to 5000 batches).
 
-When `persistent_storage_enabled` is set to true, the queue is being buffered to disk using 
-[file storage extension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/storage/filestorage).
-If collector instance is killed while having some items in the persistent queue, on restart the items are being picked and
-the exporting is continued.
+When persistent queue is enabled, the batches are being buffered using the provided storage extension - [filestorage] is a popular and safe choice. If the collector instance is killed while having some items in the persistent queue, on restart the items will be be picked and the exporting is continued.
 
 ```
                                                               ┌─Consumer #1─┐
@@ -93,9 +90,9 @@ exporters:
   otlp:
     endpoint: <ENDPOINT>
     sending_queue:
-      persistent_storage_enabled: true
+      storage: file_storage/otc
 extensions:
-  file_storage:
+  file_storage/otc:
     directory: /var/lib/storage/otc
     timeout: 10s
 service:
@@ -112,3 +109,5 @@ service:
       exporters: [otlp]
 
 ```
+
+[filestorage]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/storage/filestorage


### PR DESCRIPTION
**Description:**

The persistent queue needs a storage client to run. Currently, this simply takes the one storage extension defined, and errors if there are multiple available. This is both restrictive and arbitrary, and mostly works because it's currently unusual for users to define multiple storage extensions.

This change forces the users to explicitly set the storage extension in queue config if they want to use the persistent queue. This setting doubles as both choosing the storage and enabling the persistent queue - when `storage: nil` (the default), we use the in-memory queue, otherwise, we use the persistent queue with the set storage extension.

This was originally discussed in #5711, and it's part of that change. As it's a breaking change, I'd like to do it before we enable the persistent queue by default in the build.

**Link to tracking Issue:** Related to https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/10915

**Testing:**
Updated the unit tests.

**Documentation:**
Updated the queue readme.
