### PR TITLE
Restore deprecated funcs still in use in third-party dependencies

### DIFF
--- a/pdata/internal/metrics.go
+++ b/pdata/internal/metrics.go
@@ -340,3 +340,33 @@ func (ot OptionalType) String() string {
 	}
 	return ""
 }
+
+// Deprecated: [0.54.0] Use BucketCounts instead.
+func (ms HistogramDataPoint) MBucketCounts() []uint64 {
+	return ms.BucketCounts().AsRaw()
+}
+
+// Deprecated: [0.54.0] Use SetBucketCounts instead.
+func (ms HistogramDataPoint) SetMBucketCounts(v []uint64) {
+	ms.SetBucketCounts(NewImmutableUInt64Slice(v))
+}
+
+// Deprecated: [0.54.0] Use ExplicitBounds instead.
+func (ms HistogramDataPoint) MExplicitBounds() []float64 {
+	return ms.ExplicitBounds().AsRaw()
+}
+
+// Deprecated: [0.54.0] Use SetExplicitBounds instead.
+func (ms HistogramDataPoint) SetMExplicitBounds(v []float64) {
+	ms.SetExplicitBounds(NewImmutableFloat64Slice(v))
+}
+
+// Deprecated: [0.54.0] Use BucketCounts instead.
+func (ms Buckets) MBucketCounts() []uint64 {
+	return ms.BucketCounts().AsRaw()
+}
+
+// Deprecated: [0.54.0] Use SetBucketCounts instead.
+func (ms Buckets) SetMBucketCounts(v []uint64) {
+	ms.SetBucketCounts(NewImmutableUInt64Slice(v))
+}


### PR DESCRIPTION
Temporary restore deprecated funcs until https://github.com/influxdata/influxdb-observability/pull/107 is merged, to not block the release.

Fixes https://github.com/open-telemetry/opentelemetry-collector/issues/5770

Signed-off-by: Bogdan <bogdandrutu@gmail.com>
