### PR TITLE
Fix changelog related to Go 1.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
   - `component.WithTracesProcessorAndStabilityLevel`
   - `component.WithMetricsProcessorAndStabilityLevel`
   - `component.WithLogsProcessorAndStabilityLevel`
+- Update minimum go version to 1.18 (#5795)
 
 ### 🚩 Deprecations 🚩
 
@@ -59,7 +60,6 @@ There isn't a valid core binary for this release. Use v0.57.2 instead.
   - `component.WithTracesProcessor`
   - `component.WithMetricsProcessor`
   - `component.WithLogsProcessor`
-- Update minimum go version to 1.18 (#5795)
 
 ### 🚩 Deprecations 🚩
 


### PR DESCRIPTION
**Description:** Move Go 1.18 changelog entry to unreleased, since this is not included in the 0.57 release

Follow up to #5795