### PR TITLE
[chore] Add missing dashes to descriptions of flags

### DIFF
--- a/service/flags.go
+++ b/service/flags.go
@@ -48,12 +48,12 @@ func flags() *flag.FlagSet {
 	flagSet := new(flag.FlagSet)
 
 	flagSet.Var(new(stringArrayValue), configFlag, "Locations to the config file(s), note that only a"+
-		" single location can be set per flag entry e.g. `-config=file:/path/to/first --config=file:path/to/second`.")
+		" single location can be set per flag entry e.g. `--config=file:/path/to/first --config=file:path/to/second`.")
 
 	flagSet.Var(new(stringArrayValue), setFlag,
 		"Set arbitrary component config property. The component has to be defined in the config file and the flag"+
 			" has a higher precedence. Array config properties are overridden and maps are joined, note that only a single"+
-			" (first) array property can be set e.g. -set=processors.attributes.actions.key=some_key. Example --set=processors.batch.timeout=2s")
+			" (first) array property can be set e.g. --set=processors.attributes.actions.key=some_key. Example --set=processors.batch.timeout=2s")
 
 	flagSet.Var(
 		gatesList,


### PR DESCRIPTION
**Description:** 
A small fix to the descriptions of flags. In their descriptions, `config` and `set` flags had examples that used only one dash before the flag instead of two, which was a bit misleading.

