### PR TITLE
Deprecate obsreport.[Processor|Exporter]Settings.Level and use MetricsLevel from CreateSettings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
   - `component.ReceiverFactory.TracesReceiverStability`
   - `component.ReceiverFactory.MetricsReceiverStability`
   - `component.ReceiverFactory.LogsReceiverStability`
+- Deprecate `obsreport.ProcessorSettings.Level` and `obsreport.ExporterSettings.Level`, use MetricsLevel from CreateSettings (#5824)
 
 ### 💡 Enhancements 💡
 

--- a/exporter/exporterhelper/common.go
+++ b/exporter/exporterhelper/common.go
@@ -176,11 +176,7 @@ type baseExporter struct {
 func newBaseExporter(cfg config.Exporter, set component.ExporterCreateSettings, bs *baseSettings, signal config.DataType, reqUnmarshaler internal.RequestUnmarshaler) *baseExporter {
 	be := &baseExporter{}
 
-	be.obsrep = newObsExporter(obsreport.ExporterSettings{
-		Level:                  set.MetricsLevel,
-		ExporterID:             cfg.ID(),
-		ExporterCreateSettings: set,
-	}, globalInstruments)
+	be.obsrep = newObsExporter(obsreport.ExporterSettings{ExporterID: cfg.ID(), ExporterCreateSettings: set}, globalInstruments)
 	be.qrSender = newQueuedRetrySender(cfg.ID(), signal, bs.QueueSettings, bs.RetrySettings, reqUnmarshaler, &timeoutSender{cfg: bs.TimeoutSettings}, set.Logger)
 	be.sender = be.qrSender
 	be.StartFunc = func(ctx context.Context, host component.Host) error {

--- a/exporter/exporterhelper/obsreport_test.go
+++ b/exporter/exporterhelper/obsreport_test.go
@@ -23,7 +23,6 @@ import (
 	"go.opencensus.io/tag"
 
 	"go.opentelemetry.io/collector/config"
-	"go.opentelemetry.io/collector/config/configtelemetry"
 	"go.opentelemetry.io/collector/obsreport"
 	"go.opentelemetry.io/collector/obsreport/obsreporttest"
 )
@@ -37,7 +36,6 @@ func TestExportEnqueueFailure(t *testing.T) {
 
 	insts := newInstruments(metric.NewRegistry())
 	obsrep := newObsExporter(obsreport.ExporterSettings{
-		Level:                  configtelemetry.LevelNormal,
 		ExporterID:             exporter,
 		ExporterCreateSettings: tt.ToExporterCreateSettings(),
 	}, insts)

--- a/obsreport/obsreport_exporter.go
+++ b/obsreport/obsreport_exporter.go
@@ -31,7 +31,6 @@ import (
 
 // Exporter is a helper to add observability to a component.Exporter.
 type Exporter struct {
-	level          configtelemetry.Level
 	spanNamePrefix string
 	mutators       []tag.Mutator
 	tracer         trace.Tracer
@@ -39,6 +38,7 @@ type Exporter struct {
 
 // ExporterSettings are settings for creating an Exporter.
 type ExporterSettings struct {
+	// Deprecated: set the level in the ExporterSettings.ExporterCreateSettings.
 	Level                  configtelemetry.Level
 	ExporterID             config.ComponentID
 	ExporterCreateSettings component.ExporterCreateSettings
@@ -47,7 +47,6 @@ type ExporterSettings struct {
 // NewExporter creates a new Exporter.
 func NewExporter(cfg ExporterSettings) *Exporter {
 	return &Exporter{
-		level:          cfg.Level,
 		spanNamePrefix: obsmetrics.ExporterPrefix + cfg.ExporterID.String(),
 		mutators:       []tag.Mutator{tag.Upsert(obsmetrics.TagKeyExporter, cfg.ExporterID.String(), tag.WithTTL(tag.TTLNoPropagation))},
 		tracer:         cfg.ExporterCreateSettings.TracerProvider.Tracer(cfg.ExporterID.String()),

--- a/obsreport/obsreport_processor.go
+++ b/obsreport/obsreport_processor.go
@@ -49,6 +49,7 @@ type Processor struct {
 
 // ProcessorSettings are settings for creating a Processor.
 type ProcessorSettings struct {
+	// Deprecated: [v0.58.0] set the level in the ProcessorSettings.ProcessorCreateSettings.
 	Level                   configtelemetry.Level
 	ProcessorID             config.ComponentID
 	ProcessorCreateSettings component.ProcessorCreateSettings
@@ -57,7 +58,7 @@ type ProcessorSettings struct {
 // NewProcessor creates a new Processor.
 func NewProcessor(cfg ProcessorSettings) *Processor {
 	return &Processor{
-		level:    cfg.Level,
+		level:    cfg.ProcessorCreateSettings.MetricsLevel,
 		mutators: []tag.Mutator{tag.Upsert(obsmetrics.TagKeyProcessor, cfg.ProcessorID.String(), tag.WithTTL(tag.TTLNoPropagation))},
 	}
 }

--- a/obsreport/obsreport_test.go
+++ b/obsreport/obsreport_test.go
@@ -25,7 +25,6 @@ import (
 	"go.opentelemetry.io/otel/codes"
 
 	"go.opentelemetry.io/collector/config"
-	"go.opentelemetry.io/collector/config/configtelemetry"
 	"go.opentelemetry.io/collector/internal/obsreportconfig/obsmetrics"
 	"go.opentelemetry.io/collector/obsreport/obsreporttest"
 	"go.opentelemetry.io/collector/receiver/scrapererror"
@@ -263,7 +262,6 @@ func TestExportTraceDataOp(t *testing.T) {
 	defer parentSpan.End()
 
 	obsrep := NewExporter(ExporterSettings{
-		Level:                  configtelemetry.LevelNormal,
 		ExporterID:             exporter,
 		ExporterCreateSettings: tt.ToExporterCreateSettings(),
 	})
@@ -313,7 +311,6 @@ func TestExportMetricsOp(t *testing.T) {
 	defer parentSpan.End()
 
 	obsrep := NewExporter(ExporterSettings{
-		Level:                  configtelemetry.LevelNormal,
 		ExporterID:             exporter,
 		ExporterCreateSettings: tt.ToExporterCreateSettings(),
 	})
@@ -364,7 +361,6 @@ func TestExportLogsOp(t *testing.T) {
 	defer parentSpan.End()
 
 	obsrep := NewExporter(ExporterSettings{
-		Level:                  configtelemetry.LevelNormal,
 		ExporterID:             exporter,
 		ExporterCreateSettings: tt.ToExporterCreateSettings(),
 	})
@@ -469,7 +465,6 @@ func TestProcessorTraceData(t *testing.T) {
 	const droppedSpans = 13
 
 	obsrep := NewProcessor(ProcessorSettings{
-		Level:                   configtelemetry.LevelNormal,
 		ProcessorID:             processor,
 		ProcessorCreateSettings: tt.ToProcessorCreateSettings(),
 	})
@@ -490,7 +485,6 @@ func TestProcessorMetricsData(t *testing.T) {
 	const droppedPoints = 17
 
 	obsrep := NewProcessor(ProcessorSettings{
-		Level:                   configtelemetry.LevelNormal,
 		ProcessorID:             processor,
 		ProcessorCreateSettings: tt.ToProcessorCreateSettings(),
 	})
@@ -533,7 +527,6 @@ func TestProcessorLogRecords(t *testing.T) {
 	const droppedRecords = 17
 
 	obsrep := NewProcessor(ProcessorSettings{
-		Level:                   configtelemetry.LevelNormal,
 		ProcessorID:             processor,
 		ProcessorCreateSettings: tt.ToProcessorCreateSettings(),
 	})

--- a/obsreport/obsreporttest/obsreporttest.go
+++ b/obsreport/obsreporttest/obsreporttest.go
@@ -90,7 +90,8 @@ func SetupTelemetry() (TestTelemetry, error) {
 		TelemetrySettings: componenttest.NewNopTelemetrySettings(),
 		SpanRecorder:      sr,
 	}
-	settings.TracerProvider = tp
+	settings.TelemetrySettings.TracerProvider = tp
+	settings.TelemetrySettings.MetricsLevel = configtelemetry.LevelNormal
 	obsMetrics := obsreportconfig.Configure(configtelemetry.LevelNormal)
 	settings.views = obsMetrics.Views
 	err := view.Register(settings.views...)

--- a/obsreport/obsreporttest/obsreporttest_test.go
+++ b/obsreport/obsreporttest/obsreporttest_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/collector/config"
-	"go.opentelemetry.io/collector/config/configtelemetry"
 	"go.opentelemetry.io/collector/obsreport"
 	"go.opentelemetry.io/collector/obsreport/obsreporttest"
 )
@@ -103,7 +102,6 @@ func TestCheckExporterTracesViews(t *testing.T) {
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
 	obsrep := obsreport.NewExporter(obsreport.ExporterSettings{
-		Level:                  configtelemetry.LevelNormal,
 		ExporterID:             exporter,
 		ExporterCreateSettings: tt.ToExporterCreateSettings(),
 	})
@@ -123,7 +121,6 @@ func TestCheckExporterMetricsViews(t *testing.T) {
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
 	obsrep := obsreport.NewExporter(obsreport.ExporterSettings{
-		Level:                  configtelemetry.LevelNormal,
 		ExporterID:             exporter,
 		ExporterCreateSettings: tt.ToExporterCreateSettings(),
 	})
@@ -143,7 +140,6 @@ func TestCheckExporterLogsViews(t *testing.T) {
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
 	obsrep := obsreport.NewExporter(obsreport.ExporterSettings{
-		Level:                  configtelemetry.LevelNormal,
 		ExporterID:             exporter,
 		ExporterCreateSettings: tt.ToExporterCreateSettings(),
 	})

--- a/processor/memorylimiterprocessor/memorylimiter.go
+++ b/processor/memorylimiterprocessor/memorylimiter.go
@@ -123,7 +123,6 @@ func newMemoryLimiter(set component.ProcessorCreateSettings, cfg *Config) (*memo
 		logger:         logger,
 		forceDrop:      atomic.NewBool(false),
 		obsrep: obsreport.NewProcessor(obsreport.ProcessorSettings{
-			Level:                   set.MetricsLevel,
 			ProcessorID:             cfg.ID(),
 			ProcessorCreateSettings: set,
 		}),

--- a/processor/memorylimiterprocessor/memorylimiter_test.go
+++ b/processor/memorylimiterprocessor/memorylimiter_test.go
@@ -116,11 +116,7 @@ func TestMetricsMemoryPressureResponse(t *testing.T) {
 		readMemStatsFn: func(ms *runtime.MemStats) {
 			ms.Alloc = currentMemAlloc
 		},
-		obsrep: obsreport.NewProcessor(obsreport.ProcessorSettings{
-			Level:       configtelemetry.LevelNone,
-			ProcessorID: config.NewComponentID(typeStr),
-		}),
-
+		obsrep: newObsReport(),
 		logger: zap.NewNop(),
 	}
 	mp, err := processorhelper.NewMetricsProcessor(
@@ -189,10 +185,7 @@ func TestTraceMemoryPressureResponse(t *testing.T) {
 		readMemStatsFn: func(ms *runtime.MemStats) {
 			ms.Alloc = currentMemAlloc
 		},
-		obsrep: obsreport.NewProcessor(obsreport.ProcessorSettings{
-			Level:       configtelemetry.LevelNone,
-			ProcessorID: config.NewComponentID(typeStr),
-		}),
+		obsrep: newObsReport(),
 		logger: zap.NewNop(),
 	}
 	tp, err := processorhelper.NewTracesProcessor(
@@ -261,10 +254,7 @@ func TestLogMemoryPressureResponse(t *testing.T) {
 		readMemStatsFn: func(ms *runtime.MemStats) {
 			ms.Alloc = currentMemAlloc
 		},
-		obsrep: obsreport.NewProcessor(obsreport.ProcessorSettings{
-			Level:       configtelemetry.LevelNone,
-			ProcessorID: config.NewComponentID(typeStr),
-		}),
+		obsrep: newObsReport(),
 		logger: zap.NewNop(),
 	}
 	lp, err := processorhelper.NewLogsProcessor(
@@ -453,4 +443,14 @@ func TestBallastSizeMiB(t *testing.T) {
 			assert.Equal(t, tt.expectResult, tt.expectedMemLimiterBallastSize*mibBytes == ballastExt.(*ballastextension.MemoryBallast).GetBallastSize())
 		})
 	}
+}
+
+func newObsReport() *obsreport.Processor {
+	set := obsreport.ProcessorSettings{
+		ProcessorID:             config.NewComponentID(typeStr),
+		ProcessorCreateSettings: componenttest.NewNopProcessorCreateSettings(),
+	}
+	set.ProcessorCreateSettings.MetricsLevel = configtelemetry.LevelNone
+
+	return obsreport.NewProcessor(set)
 }


### PR DESCRIPTION
Signed-off-by: Bogdan <bogdandrutu@gmail.com>
