### PR TITLE
Breaking Change: Change confmap.Provider to return pointer to Retrieved.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - ABI breaking change: `featuregate.Registry.Apply` returns error now.
 - Update minimum go version to 1.18 (#5795)
 - Remove deprecated `Flags` API from pdata (#5814)
+- Change `confmap.Provider` to return pointer to `Retrieved` (#5839)
 
 ### 🚩 Deprecations 🚩
 

--- a/confmap/provider.go
+++ b/confmap/provider.go
@@ -53,7 +53,7 @@ type Provider interface {
 	//
 	// If ctx is cancelled should return immediately with an error.
 	// Should never be called concurrently with itself or with Shutdown.
-	Retrieve(ctx context.Context, uri string, watcher WatcherFunc) (Retrieved, error)
+	Retrieve(ctx context.Context, uri string, watcher WatcherFunc) (*Retrieved, error)
 
 	// Scheme returns the location scheme used by Retrieve.
 	Scheme() string
@@ -106,15 +106,15 @@ func WithRetrievedClose(closeFunc CloseFunc) RetrievedOption {
 //   - Primitives: int, int32, int64, float32, float64, bool, string;
 //   - []interface{};
 //   - map[string]interface{};
-func NewRetrieved(rawConf interface{}, opts ...RetrievedOption) (Retrieved, error) {
+func NewRetrieved(rawConf interface{}, opts ...RetrievedOption) (*Retrieved, error) {
 	if err := checkRawConfType(rawConf); err != nil {
-		return Retrieved{}, err
+		return nil, err
 	}
 	set := retrievedSettings{}
 	for _, opt := range opts {
 		opt(&set)
 	}
-	return Retrieved{rawConf: rawConf, closeFunc: set.closeFunc}, nil
+	return &Retrieved{rawConf: rawConf, closeFunc: set.closeFunc}, nil
 }
 
 // AsConf returns the retrieved configuration parsed as a Conf.

--- a/confmap/provider/envprovider/provider.go
+++ b/confmap/provider/envprovider/provider.go
@@ -36,9 +36,9 @@ func New() confmap.Provider {
 	return &provider{}
 }
 
-func (emp *provider) Retrieve(_ context.Context, uri string, _ confmap.WatcherFunc) (confmap.Retrieved, error) {
+func (emp *provider) Retrieve(_ context.Context, uri string, _ confmap.WatcherFunc) (*confmap.Retrieved, error) {
 	if !strings.HasPrefix(uri, schemeName+":") {
-		return confmap.Retrieved{}, fmt.Errorf("%q uri is not supported by %q provider", uri, schemeName)
+		return nil, fmt.Errorf("%q uri is not supported by %q provider", uri, schemeName)
 	}
 
 	return internal.NewRetrievedFromYAML([]byte(os.Getenv(uri[len(schemeName)+1:])))

--- a/confmap/provider/fileprovider/provider.go
+++ b/confmap/provider/fileprovider/provider.go
@@ -48,15 +48,15 @@ func New() confmap.Provider {
 	return &provider{}
 }
 
-func (fmp *provider) Retrieve(_ context.Context, uri string, _ confmap.WatcherFunc) (confmap.Retrieved, error) {
+func (fmp *provider) Retrieve(_ context.Context, uri string, _ confmap.WatcherFunc) (*confmap.Retrieved, error) {
 	if !strings.HasPrefix(uri, schemeName+":") {
-		return confmap.Retrieved{}, fmt.Errorf("%q uri is not supported by %q provider", uri, schemeName)
+		return nil, fmt.Errorf("%q uri is not supported by %q provider", uri, schemeName)
 	}
 
 	// Clean the path before using it.
 	content, err := ioutil.ReadFile(filepath.Clean(uri[len(schemeName)+1:]))
 	if err != nil {
-		return confmap.Retrieved{}, fmt.Errorf("unable to read the file %v: %w", uri, err)
+		return nil, fmt.Errorf("unable to read the file %v: %w", uri, err)
 	}
 
 	return internal.NewRetrievedFromYAML(content)

--- a/confmap/provider/internal/provider.go
+++ b/confmap/provider/internal/provider.go
@@ -23,10 +23,10 @@ import (
 // NewRetrievedFromYAML returns a new Retrieved instance that contains the deserialized data from the yaml bytes.
 // * yamlBytes the yaml bytes that will be deserialized.
 // * opts specifies options associated with this Retrieved value, such as CloseFunc.
-func NewRetrievedFromYAML(yamlBytes []byte, opts ...confmap.RetrievedOption) (confmap.Retrieved, error) {
+func NewRetrievedFromYAML(yamlBytes []byte, opts ...confmap.RetrievedOption) (*confmap.Retrieved, error) {
 	var rawConf interface{}
 	if err := yaml.Unmarshal(yamlBytes, &rawConf); err != nil {
-		return confmap.Retrieved{}, err
+		return nil, err
 	}
 	return confmap.NewRetrieved(rawConf, opts...)
 }

--- a/confmap/provider/yamlprovider/provider.go
+++ b/confmap/provider/yamlprovider/provider.go
@@ -40,9 +40,9 @@ func New() confmap.Provider {
 	return &provider{}
 }
 
-func (s *provider) Retrieve(_ context.Context, uri string, _ confmap.WatcherFunc) (confmap.Retrieved, error) {
+func (s *provider) Retrieve(_ context.Context, uri string, _ confmap.WatcherFunc) (*confmap.Retrieved, error) {
 	if !strings.HasPrefix(uri, schemeName+":") {
-		return confmap.Retrieved{}, fmt.Errorf("%q uri is not supported by %q provider", uri, schemeName)
+		return nil, fmt.Errorf("%q uri is not supported by %q provider", uri, schemeName)
 	}
 
 	return internal.NewRetrievedFromYAML([]byte(uri[len(schemeName)+1:]))

--- a/confmap/resolver.go
+++ b/confmap/resolver.go
@@ -259,7 +259,7 @@ type location struct {
 	defaultScheme string
 }
 
-func (mr *Resolver) retrieveValue(ctx context.Context, l location) (Retrieved, error) {
+func (mr *Resolver) retrieveValue(ctx context.Context, l location) (*Retrieved, error) {
 	uri := l.uri
 	scheme := l.defaultScheme
 	if idx := strings.Index(uri, ":"); idx != -1 {
@@ -269,7 +269,7 @@ func (mr *Resolver) retrieveValue(ctx context.Context, l location) (Retrieved, e
 	}
 	p, ok := mr.providers[scheme]
 	if !ok {
-		return Retrieved{}, fmt.Errorf("scheme %q is not supported for uri %q", scheme, uri)
+		return nil, fmt.Errorf("scheme %q is not supported for uri %q", scheme, uri)
 	}
 	return p.Retrieve(ctx, uri, mr.onChange)
 }


### PR DESCRIPTION
This change makes implementations cleaner, since they can return `nil, err` in case of an error instead of a zero initialized Retrieved.

This is a breaking change, but there are very very few implementation of the Provider, so it should be safe to just break it.

Signed-off-by: Bogdan <bogdandrutu@gmail.com>
