### PR TITLE
[chore] update golang used by dependabot pr

### DIFF
--- a/.github/workflows/create-dependabot-pr.yml
+++ b/.github/workflows/create-dependabot-pr.yml
@@ -8,7 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.19
       - name: Run dependabot-pr.sh
         run: ./.github/workflows/scripts/dependabot-pr.sh
         env:


### PR DESCRIPTION
The action used the default go installed in the ubuntu container, that won't work moving forward.

This caused the failure here: https://github.com/open-telemetry/opentelemetry-collector/runs/7728159426?check_suite_focus=true#step:3:463