### PR TITLE
Remove changelog entry since feature is not yet available, also wrong version 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -205,7 +205,6 @@ There isn't a valid core binary for this release. Use v0.57.2 instead.
 - Use OpenCensus `metric` package for process metrics instead of `stats` package (#5486)
 - Update OTLP to v0.18.0 (#5530)
 - Log histogram min/max fields with `logging` exporter (#5520)
-- Add support in the `confmap.Resolver` to expand embedded config URIs inside configuration (#4742)
 
 ### 🧰 Bug fixes 🧰
 


### PR DESCRIPTION
This feature is for the moment protected by a private variable that cannot be enabled from outside tests, see https://github.com/open-telemetry/opentelemetry-collector/blob/main/confmap/resolver.go#L42

When will allow this feature to be enabled, then will add the changelog entry in the right version.

Signed-off-by: Bogdan <bogdandrutu@gmail.com>
