### PR TITLE
Remove wrong limitation on pcommon.Value.Equal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 - Enable persistent queue in the build by default (#5828)
 - Bump to opentelemetry-proto v0.19.0. (#5823)
 - Expose `Scope.Attributes` in pdata (#5826)
+- Remove unnecessary limitation on `pcommon.Value.Equal` that slices have only primitive values. (#5865)
 - Add support to handle 404, 405 http error code as permanent errors in OTLP exporter (#5827)
 
 ### 🧰 Bug fixes 🧰

--- a/pdata/internal/common.go
+++ b/pdata/internal/common.go
@@ -371,16 +371,8 @@ func (v Value) Equal(av Value) bool {
 			return false
 		}
 
-		for i, val := range avv {
-			val := val
-			newAv := newValue(&vv[i])
-
-			// According to the specification, array values must be scalar.
-			if avType := newAv.Type(); avType == ValueTypeSlice || avType == ValueTypeMap {
-				return false
-			}
-
-			if !newAv.Equal(newValue(&val)) {
+		for i := range avv {
+			if !newValue(&vv[i]).Equal(newValue(&avv[i])) {
 				return false
 			}
 		}
@@ -394,13 +386,13 @@ func (v Value) Equal(av Value) bool {
 
 		m := newMap(&avv)
 
-		for _, val := range cc {
-			newAv, ok := m.Get(val.Key)
+		for i := range cc {
+			newAv, ok := m.Get(cc[i].Key)
 			if !ok {
 				return false
 			}
 
-			if !newAv.Equal(newValue(&val.Value)) {
+			if !newAv.Equal(newValue(&cc[i].Value)) {
 				return false
 			}
 		}


### PR DESCRIPTION
The limitation that the pcommon.Slice can have only primitives is indeed in the specs, but cannot be enforced in Equal, it has to be enforced in the constructor if anywhere. Logs need this to support any value, so for the moment remove this artificial limitation from Equal func.

Signed-off-by: Bogdan <bogdandrutu@gmail.com>
