### PR TITLE
Change LogRecordFlags to use same struct concept as MetricDataPointFlags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🚩 Deprecations 🚩
 
+- Deprecates `LogRecord.Flags()` and `LogRecord.SetFlags()` in favor of `LogRecord.FlagsStruct()`. (#5866)
+
 ### 💡 Enhancements 💡
 
 ### 🧰 Bug fixes 🧰

--- a/pdata/internal/cmd/pdatagen/internal/log_structs.go
+++ b/pdata/internal/cmd/pdatagen/internal/log_structs.go
@@ -106,13 +106,13 @@ var logRecord = &messageValueStruct{
 		},
 		traceIDField,
 		spanIDField,
-		&primitiveTypedField{
-			fieldName:       "Flags",
+		&messageValueField{
+			fieldName:       "FlagsStruct",
 			originFieldName: "Flags",
-			returnType:      "uint32",
-			rawType:         "uint32",
-			defaultVal:      `uint32(0)`,
-			testVal:         `uint32(0x01)`,
+			returnMessage: &messageValueStruct{
+				structName:     "LogRecordFlags",
+				originFullName: "uint32",
+			},
 		},
 		&primitiveField{
 			fieldName:       "SeverityText",

--- a/pdata/internal/generated_plog.go
+++ b/pdata/internal/generated_plog.go
@@ -627,14 +627,9 @@ func (ms LogRecord) SetSpanID(v SpanID) {
 	(*ms.orig).SpanId = v.orig
 }
 
-// Flags returns the flags associated with this LogRecord.
-func (ms LogRecord) Flags() uint32 {
-	return uint32((*ms.orig).Flags)
-}
-
-// SetFlags replaces the flags associated with this LogRecord.
-func (ms LogRecord) SetFlags(v uint32) {
-	(*ms.orig).Flags = uint32(v)
+// FlagsStruct returns the flagsstruct associated with this LogRecord.
+func (ms LogRecord) FlagsStruct() LogRecordFlags {
+	return newLogRecordFlags(&(*ms.orig).Flags)
 }
 
 // SeverityText returns the severitytext associated with this LogRecord.
@@ -683,7 +678,7 @@ func (ms LogRecord) CopyTo(dest LogRecord) {
 	dest.SetTimestamp(ms.Timestamp())
 	dest.SetTraceID(ms.TraceID())
 	dest.SetSpanID(ms.SpanID())
-	dest.SetFlags(ms.Flags())
+	ms.FlagsStruct().CopyTo(dest.FlagsStruct())
 	dest.SetSeverityText(ms.SeverityText())
 	dest.SetSeverityNumber(ms.SeverityNumber())
 	ms.Body().CopyTo(dest.Body())

--- a/pdata/internal/generated_plog_test.go
+++ b/pdata/internal/generated_plog_test.go
@@ -485,12 +485,10 @@ func TestLogRecord_SpanID(t *testing.T) {
 	assert.EqualValues(t, testValSpanID, ms.SpanID())
 }
 
-func TestLogRecord_Flags(t *testing.T) {
+func TestLogRecord_FlagsStruct(t *testing.T) {
 	ms := NewLogRecord()
-	assert.EqualValues(t, uint32(0), ms.Flags())
-	testValFlags := uint32(0x01)
-	ms.SetFlags(testValFlags)
-	assert.EqualValues(t, testValFlags, ms.Flags())
+	fillTestLogRecordFlags(ms.FlagsStruct())
+	assert.EqualValues(t, generateTestLogRecordFlags(), ms.FlagsStruct())
 }
 
 func TestLogRecord_SeverityText(t *testing.T) {
@@ -608,7 +606,7 @@ func fillTestLogRecord(tv LogRecord) {
 	tv.SetTimestamp(Timestamp(1234567890))
 	tv.SetTraceID(NewTraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 8, 7, 6, 5, 4, 3, 2, 1}))
 	tv.SetSpanID(NewSpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8}))
-	tv.SetFlags(uint32(0x01))
+	fillTestLogRecordFlags(tv.FlagsStruct())
 	tv.SetSeverityText("INFO")
 	tv.SetSeverityNumber(SeverityNumberINFO)
 	fillTestValue(tv.Body())

--- a/pdata/internal/logs.go
+++ b/pdata/internal/logs.go
@@ -121,3 +121,67 @@ const (
 
 // String returns the string representation of the SeverityNumber.
 func (sn SeverityNumber) String() string { return otlplogs.SeverityNumber(sn).String() }
+
+// Deprecated: [v0.59.0] use FlagsStruct().
+func (ms LogRecord) Flags() uint32 {
+	return ms.orig.Flags
+}
+
+// Deprecated: [v0.59.0] use FlagsStruct().
+func (ms LogRecord) SetFlags(v uint32) {
+	ms.orig.Flags = v
+}
+
+const (
+	traceFlagsNone = uint32(0)
+	isSampledMask  = uint32(1)
+)
+
+// LogRecordFlags defines flags for the LogRecord. 8 least significant bits are the trace flags as
+// defined in W3C Trace Context specification. 24 most significant bits are reserved and must be set to 0.
+//
+// This is a reference type, if passed by value and callee modifies it the caller will see the modification.
+//
+// Must use NewLogRecordFlags function to create new instances.
+// Important: zero-initialized instance is not valid for use.
+type LogRecordFlags struct {
+	orig *uint32
+}
+
+func newLogRecordFlags(orig *uint32) LogRecordFlags {
+	return LogRecordFlags{orig: orig}
+}
+
+// NewLogRecordFlags creates a new empty LogRecordFlags.
+//
+// This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
+// OR directly access the member if this is embedded in another struct.
+func NewLogRecordFlags() LogRecordFlags {
+	return newLogRecordFlags(new(uint32))
+}
+
+// MoveTo moves all properties from the current struct to dest resetting the current instance to its zero value
+func (ms LogRecordFlags) MoveTo(dest LogRecordFlags) {
+	*dest.orig = *ms.orig
+	*ms.orig = traceFlagsNone
+}
+
+// CopyTo copies all properties from the current struct to the dest.
+func (ms LogRecordFlags) CopyTo(dest LogRecordFlags) {
+	*dest.orig = *ms.orig
+}
+
+// IsSampled returns true if the LogRecordFlags contains the IsSampled flag.
+func (ms LogRecordFlags) IsSampled() bool {
+	return *ms.orig&isSampledMask != 0
+}
+
+// SetIsSampled sets the IsSampled flag if true and removes it if false.
+// Setting this Flag when it is already set is a no-op.
+func (ms LogRecordFlags) SetIsSampled(b bool) {
+	if b {
+		*ms.orig |= isSampledMask
+	} else {
+		*ms.orig &^= isSampledMask
+	}
+}

--- a/pdata/internal/logs_test.go
+++ b/pdata/internal/logs_test.go
@@ -130,6 +130,30 @@ func TestLogsClone(t *testing.T) {
 	assert.EqualValues(t, logs, logs.Clone())
 }
 
+func TestLogRecordFlags(t *testing.T) {
+	flags := generateTestLogRecordFlags()
+	assert.True(t, flags.IsSampled())
+
+	flags.SetIsSampled(false)
+	flags.SetIsSampled(false)
+	assert.False(t, flags.IsSampled())
+
+	flags.SetIsSampled(true)
+	flags.SetIsSampled(true)
+	assert.True(t, flags.IsSampled())
+
+	moveFlags := NewLogRecordFlags()
+	assert.False(t, moveFlags.IsSampled())
+
+	flags.MoveTo(moveFlags)
+	assert.False(t, flags.IsSampled())
+	assert.True(t, moveFlags.IsSampled())
+
+	moveFlags.CopyTo(flags)
+	assert.True(t, flags.IsSampled())
+	assert.True(t, moveFlags.IsSampled())
+}
+
 func BenchmarkLogsClone(b *testing.B) {
 	logs := NewLogs()
 	fillTestResourceLogsSlice(logs.ResourceLogs())
@@ -140,4 +164,14 @@ func BenchmarkLogsClone(b *testing.B) {
 			b.Fail()
 		}
 	}
+}
+
+func fillTestLogRecordFlags(tv LogRecordFlags) {
+	tv.SetIsSampled(true)
+}
+
+func generateTestLogRecordFlags() LogRecordFlags {
+	tv := NewLogRecordFlags()
+	fillTestLogRecordFlags(tv)
+	return tv
 }


### PR DESCRIPTION
Deprecates LogRecord.Flags() and LogRecord.SetFlags() in favor of LogRecord.FlagsStruct()

Signed-off-by: Bogdan <bogdandrutu@gmail.com>
