### PR TITLE
Deprecate MetricDataPointFlags.String(), no other pdata has this

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
   - `component.ReceiverFactory.MetricsReceiverStability`
   - `component.ReceiverFactory.LogsReceiverStability`
 - Deprecate `obsreport.ProcessorSettings.Level` and `obsreport.ExporterSettings.Level`, use MetricsLevel from CreateSettings (#5824)
+- Deprecate MetricDataPointFlags.String(), no other pdata has this (#5868)
 - Deprecates `FlagsStruct` in favor of `Flags` (#5842)
   - `MetricDataPointFlagsStruct` -> `MetricDataPointFlags`
   - `NewMetricDataPointFlagsStruct` -> `NewMetricDataPointFlags`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@
   - `component.ReceiverFactory.MetricsReceiverStability`
   - `component.ReceiverFactory.LogsReceiverStability`
 - Deprecate `obsreport.ProcessorSettings.Level` and `obsreport.ExporterSettings.Level`, use MetricsLevel from CreateSettings (#5824)
-- Deprecate MetricDataPointFlags.String(), no other pdata has this (#5868)
+- Deprecate MetricDataPointFlags.String(), no other pdata flags have this method (#5868)
 - Deprecates `FlagsStruct` in favor of `Flags` (#5842)
   - `MetricDataPointFlagsStruct` -> `MetricDataPointFlags`
   - `NewMetricDataPointFlagsStruct` -> `NewMetricDataPointFlags`

--- a/pdata/internal/metrics.go
+++ b/pdata/internal/metrics.go
@@ -258,7 +258,7 @@ func (ms MetricDataPointFlags) SetNoRecordedValue(b bool) {
 	}
 }
 
-// String returns the string representation of the MetricDataPointFlags.
+// Deprecated: [v0.58.0] will be soon removed, no String() on any other pdata.
 func (ms MetricDataPointFlags) String() string {
 	return otlpmetrics.DataPointFlags(*ms.orig).String()
 }

--- a/pdata/internal/metrics_test.go
+++ b/pdata/internal/metrics_test.go
@@ -690,13 +690,10 @@ func TestMetricsClone(t *testing.T) {
 
 func TestMetricsDataPointFlags(t *testing.T) {
 	gauge := generateTestGauge()
-
 	assert.False(t, gauge.DataPoints().At(0).Flags().NoRecordedValue())
-	assert.Equal(t, "FLAG_NONE", gauge.DataPoints().At(0).Flags().String())
 
 	gauge.DataPoints().At(1).Flags().SetNoRecordedValue(true)
 	assert.True(t, gauge.DataPoints().At(1).Flags().NoRecordedValue())
-	assert.Equal(t, "FLAG_NO_RECORDED_VALUE", gauge.DataPoints().At(1).Flags().String())
 	gauge.DataPoints().At(1).Flags().SetNoRecordedValue(false)
 	assert.False(t, gauge.DataPoints().At(1).Flags().NoRecordedValue())
 


### PR DESCRIPTION
If offering String() on pdata we should do it from the pdata generator not as ad-hoc for some of the hand written structs.

Signed-off-by: Bogdan <bogdandrutu@gmail.com>
