### PR TITLE
Deprecate config.[Receiver|Processor|Exporter|Extension].ID() and SetName()

### DIFF
--- a/.chloggen/deprecateid.yaml
+++ b/.chloggen/deprecateid.yaml
@@ -1,0 +1,19 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: component
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Change Config to be opaque for otel collector core.
+
+# One or more tracking issues or pull requests related to the change
+issues: [4714]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  - Deprecate `component.Config.ID()` in favor of `component.[*]CreateSettings.ID`.
+  - Deprecate `component.Config.SetIDName()`, no replacement needed since ID in settings is public member.
+  - Deprecate `obsreporttest.SetupTelemetry` in favor of `obsreporttest.SetupTelemetryWithID`.

--- a/component/config.go
+++ b/component/config.go
@@ -23,7 +23,11 @@ import (
 )
 
 type Config interface {
-	identifiable
+	// Deprecated: [v0.67.0] use Settings.ID.
+	ID() ID
+
+	// Deprecated: [v0.67.0] use Settings.ID.
+	SetIDName(idName string)
 
 	privateConfig()
 }

--- a/component/exporter.go
+++ b/component/exporter.go
@@ -46,6 +46,9 @@ type LogsExporter interface {
 
 // ExporterCreateSettings configures Exporter creators.
 type ExporterCreateSettings struct {
+	// ID returns the ID of the component that will be created.
+	ID ID
+
 	TelemetrySettings
 
 	// BuildInfo can be used by components for informational purposes

--- a/component/extension.go
+++ b/component/extension.go
@@ -48,6 +48,9 @@ type PipelineWatcher interface {
 
 // ExtensionCreateSettings is passed to ExtensionFactory.Create* functions.
 type ExtensionCreateSettings struct {
+	// ID returns the ID of the component that will be created.
+	ID ID
+
 	TelemetrySettings
 
 	// BuildInfo can be used by components for informational purposes

--- a/component/identifiable.go
+++ b/component/identifiable.go
@@ -23,14 +23,6 @@ import (
 // typeAndNameSeparator is the separator that is used between type and name in type/name composite keys.
 const typeAndNameSeparator = "/"
 
-// identifiable is an interface that all components configurations MUST embed.
-type identifiable interface {
-	// ID returns the ID of the component that this configuration belongs to.
-	ID() ID
-	// SetIDName updates the name part of the ID for the component that this configuration belongs to.
-	SetIDName(idName string)
-}
-
 // ID represents the identity for a component. It combines two values:
 // * type - the Type of the component.
 // * name - the name of that component.

--- a/component/processor.go
+++ b/component/processor.go
@@ -46,6 +46,9 @@ type LogsProcessor interface {
 
 // ProcessorCreateSettings is passed to Create* functions in ProcessorFactory.
 type ProcessorCreateSettings struct {
+	// ID returns the ID of the component that will be created.
+	ID ID
+
 	TelemetrySettings
 
 	// BuildInfo can be used by components for informational purposes

--- a/component/receiver.go
+++ b/component/receiver.go
@@ -55,6 +55,9 @@ type LogsReceiver interface {
 
 // ReceiverCreateSettings configures Receiver creators.
 type ReceiverCreateSettings struct {
+	// ID returns the ID of the component that will be created.
+	ID ID
+
 	TelemetrySettings
 
 	// BuildInfo can be used by components for informational purposes.

--- a/config/configgrpc/configgrpc_test.go
+++ b/config/configgrpc/configgrpc_test.go
@@ -44,7 +44,7 @@ import (
 )
 
 func TestDefaultGrpcClientSettings(t *testing.T) {
-	tt, err := obsreporttest.SetupTelemetry()
+	tt, err := obsreporttest.SetupTelemetryWithID(component.NewID("component"))
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
@@ -59,7 +59,7 @@ func TestDefaultGrpcClientSettings(t *testing.T) {
 }
 
 func TestAllGrpcClientSettings(t *testing.T) {
-	tt, err := obsreporttest.SetupTelemetry()
+	tt, err := obsreporttest.SetupTelemetryWithID(component.NewID("component"))
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
@@ -226,7 +226,7 @@ func TestGrpcServerAuthSettings(t *testing.T) {
 }
 
 func TestGRPCClientSettingsError(t *testing.T) {
-	tt, err := obsreporttest.SetupTelemetry()
+	tt, err := obsreporttest.SetupTelemetryWithID(component.NewID("component"))
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
@@ -349,7 +349,7 @@ func TestGRPCClientSettingsError(t *testing.T) {
 }
 
 func TestUseSecure(t *testing.T) {
-	tt, err := obsreporttest.SetupTelemetry()
+	tt, err := obsreporttest.SetupTelemetryWithID(component.NewID("component"))
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
@@ -488,7 +488,7 @@ func TestGRPCServerSettings_ToListener_Error(t *testing.T) {
 }
 
 func TestHttpReception(t *testing.T) {
-	tt, err := obsreporttest.SetupTelemetry()
+	tt, err := obsreporttest.SetupTelemetryWithID(component.NewID("component"))
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
@@ -640,7 +640,7 @@ func TestReceiveOnUnixDomainSocket(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("skipping test on windows")
 	}
-	tt, err := obsreporttest.SetupTelemetry()
+	tt, err := obsreporttest.SetupTelemetryWithID(component.NewID("component"))
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
@@ -869,7 +869,7 @@ func TestClientInfoInterceptors(t *testing.T) {
 					},
 				}
 
-				tt, err := obsreporttest.SetupTelemetry()
+				tt, err := obsreporttest.SetupTelemetryWithID(component.NewID("component"))
 				require.NoError(t, err)
 				defer func() {
 					require.NoError(t, tt.Shutdown(context.Background()))

--- a/config/settings.go
+++ b/config/settings.go
@@ -29,12 +29,12 @@ func newSettings(id component.ID) settings {
 
 var _ component.Config = (*settings)(nil)
 
-// ID returns the receiver component.ID.
+// Deprecated: [v0.67.0] use Settings.ID.
 func (es *settings) ID() component.ID {
 	return es.id
 }
 
-// SetIDName sets the receiver name.
+// Deprecated: [v0.67.0] use Settings.ID.
 func (es *settings) SetIDName(idName string) {
 	es.id = component.NewIDWithName(es.id.Type(), idName)
 }

--- a/exporter/exporterhelper/common.go
+++ b/exporter/exporterhelper/common.go
@@ -155,16 +155,16 @@ type baseExporter struct {
 	qrSender *queuedRetrySender
 }
 
-func newBaseExporter(cfg component.Config, set component.ExporterCreateSettings, bs *baseSettings, signal component.DataType, reqUnmarshaler internal.RequestUnmarshaler) (*baseExporter, error) {
+func newBaseExporter(set component.ExporterCreateSettings, bs *baseSettings, signal component.DataType, reqUnmarshaler internal.RequestUnmarshaler) (*baseExporter, error) {
 	be := &baseExporter{}
 
 	var err error
-	be.obsrep, err = newObsExporter(obsreport.ExporterSettings{ExporterID: cfg.ID(), ExporterCreateSettings: set}, globalInstruments)
+	be.obsrep, err = newObsExporter(obsreport.ExporterSettings{ExporterID: set.ID, ExporterCreateSettings: set}, globalInstruments)
 	if err != nil {
 		return nil, err
 	}
 
-	be.qrSender = newQueuedRetrySender(cfg.ID(), signal, bs.QueueSettings, bs.RetrySettings, reqUnmarshaler, &timeoutSender{cfg: bs.TimeoutSettings}, set.Logger)
+	be.qrSender = newQueuedRetrySender(set.ID, signal, bs.QueueSettings, bs.RetrySettings, reqUnmarshaler, &timeoutSender{cfg: bs.TimeoutSettings}, set.Logger)
 	be.sender = be.qrSender
 	be.StartFunc = func(ctx context.Context, host component.Host) error {
 		// First start the wrapped exporter.

--- a/exporter/exporterhelper/common_test.go
+++ b/exporter/exporterhelper/common_test.go
@@ -25,14 +25,18 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
-	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/exporter/exporterhelper/internal"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 )
 
 var (
-	defaultExporterCfg  = config.NewExporterSettings(component.NewID("test"))
+	defaultID       = component.NewID("test")
+	defaultSettings = func() component.ExporterCreateSettings {
+		set := componenttest.NewNopExporterCreateSettings()
+		set.ID = defaultID
+		return set
+	}()
 	exporterTag, _      = tag.NewKey("exporter")
 	defaultExporterTags = []tag.Tag{
 		{Key: exporterTag, Value: "test"},
@@ -40,7 +44,7 @@ var (
 )
 
 func TestBaseExporter(t *testing.T) {
-	be, err := newBaseExporter(&defaultExporterCfg, componenttest.NewNopExporterCreateSettings(), fromOptions(), "", nopRequestUnmarshaler())
+	be, err := newBaseExporter(defaultSettings, fromOptions(), "", nopRequestUnmarshaler())
 	require.NoError(t, err)
 	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
 	require.NoError(t, be.Shutdown(context.Background()))
@@ -49,8 +53,7 @@ func TestBaseExporter(t *testing.T) {
 func TestBaseExporterWithOptions(t *testing.T) {
 	want := errors.New("my error")
 	be, err := newBaseExporter(
-		&defaultExporterCfg,
-		componenttest.NewNopExporterCreateSettings(),
+		defaultSettings,
 		fromOptions(
 			WithStart(func(ctx context.Context, host component.Host) error { return want }),
 			WithShutdown(func(ctx context.Context) error { return want }),

--- a/exporter/exporterhelper/logs.go
+++ b/exporter/exporterhelper/logs.go
@@ -98,7 +98,7 @@ func NewLogsExporter(
 	}
 
 	bs := fromOptions(options...)
-	be, err := newBaseExporter(cfg, set, bs, component.DataTypeLogs, newLogsRequestUnmarshalerFunc(pusher))
+	be, err := newBaseExporter(set, bs, component.DataTypeLogs, newLogsRequestUnmarshalerFunc(pusher))
 	if err != nil {
 		return nil, err
 	}

--- a/exporter/exporterhelper/logs_test.go
+++ b/exporter/exporterhelper/logs_test.go
@@ -107,7 +107,7 @@ func TestLogsExporter_Default_ReturnError(t *testing.T) {
 }
 
 func TestLogsExporter_WithRecordLogs(t *testing.T) {
-	tt, err := obsreporttest.SetupTelemetry()
+	tt, err := obsreporttest.SetupTelemetryWithID(fakeLogsExporterName)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
@@ -120,7 +120,7 @@ func TestLogsExporter_WithRecordLogs(t *testing.T) {
 
 func TestLogsExporter_WithRecordLogs_ReturnError(t *testing.T) {
 	want := errors.New("my_error")
-	tt, err := obsreporttest.SetupTelemetry()
+	tt, err := obsreporttest.SetupTelemetryWithID(fakeLogsExporterName)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
@@ -132,7 +132,7 @@ func TestLogsExporter_WithRecordLogs_ReturnError(t *testing.T) {
 }
 
 func TestLogsExporter_WithRecordEnqueueFailedMetrics(t *testing.T) {
-	tt, err := obsreporttest.SetupTelemetry()
+	tt, err := obsreporttest.SetupTelemetryWithID(fakeLogsExporterName)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 

--- a/exporter/exporterhelper/metrics.go
+++ b/exporter/exporterhelper/metrics.go
@@ -99,7 +99,7 @@ func NewMetricsExporter(
 	}
 
 	bs := fromOptions(options...)
-	be, err := newBaseExporter(cfg, set, bs, component.DataTypeMetrics, newMetricsRequestUnmarshalerFunc(pusher))
+	be, err := newBaseExporter(set, bs, component.DataTypeMetrics, newMetricsRequestUnmarshalerFunc(pusher))
 	if err != nil {
 		return nil, err
 	}

--- a/exporter/exporterhelper/metrics_test.go
+++ b/exporter/exporterhelper/metrics_test.go
@@ -106,7 +106,7 @@ func TestMetricsExporter_Default_ReturnError(t *testing.T) {
 }
 
 func TestMetricsExporter_WithRecordMetrics(t *testing.T) {
-	tt, err := obsreporttest.SetupTelemetry()
+	tt, err := obsreporttest.SetupTelemetryWithID(fakeMetricsExporterName)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
@@ -119,7 +119,7 @@ func TestMetricsExporter_WithRecordMetrics(t *testing.T) {
 
 func TestMetricsExporter_WithRecordMetrics_ReturnError(t *testing.T) {
 	want := errors.New("my_error")
-	tt, err := obsreporttest.SetupTelemetry()
+	tt, err := obsreporttest.SetupTelemetryWithID(fakeMetricsExporterName)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
@@ -131,7 +131,7 @@ func TestMetricsExporter_WithRecordMetrics_ReturnError(t *testing.T) {
 }
 
 func TestMetricsExporter_WithRecordEnqueueFailedMetrics(t *testing.T) {
-	tt, err := obsreporttest.SetupTelemetry()
+	tt, err := obsreporttest.SetupTelemetryWithID(fakeMetricsExporterName)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 

--- a/exporter/exporterhelper/obsreport_test.go
+++ b/exporter/exporterhelper/obsreport_test.go
@@ -28,11 +28,10 @@ import (
 )
 
 func TestExportEnqueueFailure(t *testing.T) {
-	tt, err := obsreporttest.SetupTelemetry()
+	exporter := component.NewID("fakeExporter")
+	tt, err := obsreporttest.SetupTelemetryWithID(exporter)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
-
-	exporter := component.NewID("fakeExporter")
 
 	insts := newInstruments(metric.NewRegistry())
 	obsrep, err := newObsExporter(obsreport.ExporterSettings{

--- a/exporter/exporterhelper/queued_retry_test.go
+++ b/exporter/exporterhelper/queued_retry_test.go
@@ -50,7 +50,7 @@ func TestQueuedRetry_DropOnPermanentError(t *testing.T) {
 	qCfg := NewDefaultQueueSettings()
 	rCfg := NewDefaultRetrySettings()
 	mockR := newMockRequest(context.Background(), 2, consumererror.NewPermanent(errors.New("bad data")))
-	be, err := newBaseExporter(&defaultExporterCfg, componenttest.NewNopExporterCreateSettings(), fromOptions(WithRetry(rCfg), WithQueue(qCfg)), "", mockRequestUnmarshaler(mockR))
+	be, err := newBaseExporter(defaultSettings, fromOptions(WithRetry(rCfg), WithQueue(qCfg)), "", mockRequestUnmarshaler(mockR))
 	require.NoError(t, err)
 	ocs := newObservabilityConsumerSender(be.qrSender.consumerSender)
 	be.qrSender.consumerSender = ocs
@@ -74,7 +74,7 @@ func TestQueuedRetry_DropOnNoRetry(t *testing.T) {
 	qCfg := NewDefaultQueueSettings()
 	rCfg := NewDefaultRetrySettings()
 	rCfg.Enabled = false
-	be, err := newBaseExporter(&defaultExporterCfg, componenttest.NewNopExporterCreateSettings(), fromOptions(WithRetry(rCfg), WithQueue(qCfg)), "", nopRequestUnmarshaler())
+	be, err := newBaseExporter(defaultSettings, fromOptions(WithRetry(rCfg), WithQueue(qCfg)), "", nopRequestUnmarshaler())
 	require.NoError(t, err)
 	ocs := newObservabilityConsumerSender(be.qrSender.consumerSender)
 	be.qrSender.consumerSender = ocs
@@ -100,7 +100,7 @@ func TestQueuedRetry_OnError(t *testing.T) {
 	qCfg.NumConsumers = 1
 	rCfg := NewDefaultRetrySettings()
 	rCfg.InitialInterval = 0
-	be, err := newBaseExporter(&defaultExporterCfg, componenttest.NewNopExporterCreateSettings(), fromOptions(WithRetry(rCfg), WithQueue(qCfg)), "", nopRequestUnmarshaler())
+	be, err := newBaseExporter(defaultSettings, fromOptions(WithRetry(rCfg), WithQueue(qCfg)), "", nopRequestUnmarshaler())
 	require.NoError(t, err)
 	ocs := newObservabilityConsumerSender(be.qrSender.consumerSender)
 	be.qrSender.consumerSender = ocs
@@ -127,7 +127,7 @@ func TestQueuedRetry_StopWhileWaiting(t *testing.T) {
 	qCfg := NewDefaultQueueSettings()
 	qCfg.NumConsumers = 1
 	rCfg := NewDefaultRetrySettings()
-	be, err := newBaseExporter(&defaultExporterCfg, componenttest.NewNopExporterCreateSettings(), fromOptions(WithRetry(rCfg), WithQueue(qCfg)), "", nopRequestUnmarshaler())
+	be, err := newBaseExporter(defaultSettings, fromOptions(WithRetry(rCfg), WithQueue(qCfg)), "", nopRequestUnmarshaler())
 	require.NoError(t, err)
 	ocs := newObservabilityConsumerSender(be.qrSender.consumerSender)
 	be.qrSender.consumerSender = ocs
@@ -161,7 +161,7 @@ func TestQueuedRetry_DoNotPreserveCancellation(t *testing.T) {
 	qCfg := NewDefaultQueueSettings()
 	qCfg.NumConsumers = 1
 	rCfg := NewDefaultRetrySettings()
-	be, err := newBaseExporter(&defaultExporterCfg, componenttest.NewNopExporterCreateSettings(), fromOptions(WithRetry(rCfg), WithQueue(qCfg)), "", nopRequestUnmarshaler())
+	be, err := newBaseExporter(defaultSettings, fromOptions(WithRetry(rCfg), WithQueue(qCfg)), "", nopRequestUnmarshaler())
 	require.NoError(t, err)
 	ocs := newObservabilityConsumerSender(be.qrSender.consumerSender)
 	be.qrSender.consumerSender = ocs
@@ -191,7 +191,7 @@ func TestQueuedRetry_MaxElapsedTime(t *testing.T) {
 	rCfg := NewDefaultRetrySettings()
 	rCfg.InitialInterval = time.Millisecond
 	rCfg.MaxElapsedTime = 100 * time.Millisecond
-	be, err := newBaseExporter(&defaultExporterCfg, componenttest.NewNopExporterCreateSettings(), fromOptions(WithRetry(rCfg), WithQueue(qCfg)), "", nopRequestUnmarshaler())
+	be, err := newBaseExporter(defaultSettings, fromOptions(WithRetry(rCfg), WithQueue(qCfg)), "", nopRequestUnmarshaler())
 	require.NoError(t, err)
 	ocs := newObservabilityConsumerSender(be.qrSender.consumerSender)
 	be.qrSender.consumerSender = ocs
@@ -238,7 +238,7 @@ func TestQueuedRetry_ThrottleError(t *testing.T) {
 	qCfg.NumConsumers = 1
 	rCfg := NewDefaultRetrySettings()
 	rCfg.InitialInterval = 10 * time.Millisecond
-	be, err := newBaseExporter(&defaultExporterCfg, componenttest.NewNopExporterCreateSettings(), fromOptions(WithRetry(rCfg), WithQueue(qCfg)), "", nopRequestUnmarshaler())
+	be, err := newBaseExporter(defaultSettings, fromOptions(WithRetry(rCfg), WithQueue(qCfg)), "", nopRequestUnmarshaler())
 	require.NoError(t, err)
 	ocs := newObservabilityConsumerSender(be.qrSender.consumerSender)
 	be.qrSender.consumerSender = ocs
@@ -271,7 +271,7 @@ func TestQueuedRetry_RetryOnError(t *testing.T) {
 	qCfg.QueueSize = 1
 	rCfg := NewDefaultRetrySettings()
 	rCfg.InitialInterval = 0
-	be, err := newBaseExporter(&defaultExporterCfg, componenttest.NewNopExporterCreateSettings(), fromOptions(WithRetry(rCfg), WithQueue(qCfg)), "", nopRequestUnmarshaler())
+	be, err := newBaseExporter(defaultSettings, fromOptions(WithRetry(rCfg), WithQueue(qCfg)), "", nopRequestUnmarshaler())
 	require.NoError(t, err)
 	ocs := newObservabilityConsumerSender(be.qrSender.consumerSender)
 	be.qrSender.consumerSender = ocs
@@ -298,7 +298,7 @@ func TestQueuedRetry_DropOnFull(t *testing.T) {
 	qCfg := NewDefaultQueueSettings()
 	qCfg.QueueSize = 0
 	rCfg := NewDefaultRetrySettings()
-	be, err := newBaseExporter(&defaultExporterCfg, componenttest.NewNopExporterCreateSettings(), fromOptions(WithRetry(rCfg), WithQueue(qCfg)), "", nopRequestUnmarshaler())
+	be, err := newBaseExporter(defaultSettings, fromOptions(WithRetry(rCfg), WithQueue(qCfg)), "", nopRequestUnmarshaler())
 	require.NoError(t, err)
 	ocs := newObservabilityConsumerSender(be.qrSender.consumerSender)
 	be.qrSender.consumerSender = ocs
@@ -311,13 +311,14 @@ func TestQueuedRetry_DropOnFull(t *testing.T) {
 }
 
 func TestQueuedRetryHappyPath(t *testing.T) {
-	tt, err := obsreporttest.SetupTelemetry()
+	tt, err := obsreporttest.SetupTelemetryWithID(defaultID)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
 	qCfg := NewDefaultQueueSettings()
 	rCfg := NewDefaultRetrySettings()
-	be, err := newBaseExporter(&defaultExporterCfg, tt.ToExporterCreateSettings(), fromOptions(WithRetry(rCfg), WithQueue(qCfg)), "", nopRequestUnmarshaler())
+	set := tt.ToExporterCreateSettings()
+	be, err := newBaseExporter(set, fromOptions(WithRetry(rCfg), WithQueue(qCfg)), "", nopRequestUnmarshaler())
 	require.NoError(t, err)
 	ocs := newObservabilityConsumerSender(be.qrSender.consumerSender)
 	be.qrSender.consumerSender = ocs
@@ -352,7 +353,7 @@ func TestQueuedRetry_QueueMetricsReported(t *testing.T) {
 	qCfg := NewDefaultQueueSettings()
 	qCfg.NumConsumers = 0 // to make every request go straight to the queue
 	rCfg := NewDefaultRetrySettings()
-	be, err := newBaseExporter(&defaultExporterCfg, componenttest.NewNopExporterCreateSettings(), fromOptions(WithRetry(rCfg), WithQueue(qCfg)), "", nopRequestUnmarshaler())
+	be, err := newBaseExporter(defaultSettings, fromOptions(WithRetry(rCfg), WithQueue(qCfg)), "", nopRequestUnmarshaler())
 	require.NoError(t, err)
 	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
 
@@ -486,7 +487,7 @@ func TestQueuedRetry_RequeuingEnabled(t *testing.T) {
 	qCfg.NumConsumers = 1
 	rCfg := NewDefaultRetrySettings()
 	rCfg.MaxElapsedTime = time.Nanosecond // we don't want to retry at all, but requeue instead
-	be, err := newBaseExporter(&defaultExporterCfg, componenttest.NewNopExporterCreateSettings(), fromOptions(WithRetry(rCfg), WithQueue(qCfg)), "", nopRequestUnmarshaler())
+	be, err := newBaseExporter(defaultSettings, fromOptions(WithRetry(rCfg), WithQueue(qCfg)), "", nopRequestUnmarshaler())
 	require.NoError(t, err)
 	ocs := newObservabilityConsumerSender(be.qrSender.consumerSender)
 	be.qrSender.consumerSender = ocs
@@ -518,7 +519,7 @@ func TestQueuedRetry_RequeuingEnabledQueueFull(t *testing.T) {
 	qCfg.QueueSize = 0
 	rCfg := NewDefaultRetrySettings()
 	rCfg.MaxElapsedTime = time.Nanosecond // we don't want to retry at all, but requeue instead
-	be, err := newBaseExporter(&defaultExporterCfg, componenttest.NewNopExporterCreateSettings(), fromOptions(WithRetry(rCfg), WithQueue(qCfg)), "", nopRequestUnmarshaler())
+	be, err := newBaseExporter(defaultSettings, fromOptions(WithRetry(rCfg), WithQueue(qCfg)), "", nopRequestUnmarshaler())
 	require.NoError(t, err)
 	be.qrSender.requeuingEnabled = true
 	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
@@ -534,7 +535,7 @@ func TestQueuedRetry_RequeuingEnabledQueueFull(t *testing.T) {
 }
 
 func TestQueuedRetryPersistenceEnabled(t *testing.T) {
-	tt, err := obsreporttest.SetupTelemetry()
+	tt, err := obsreporttest.SetupTelemetryWithID(defaultID)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
@@ -542,7 +543,8 @@ func TestQueuedRetryPersistenceEnabled(t *testing.T) {
 	storageID := component.NewIDWithName("file_storage", "storage")
 	qCfg.StorageID = &storageID // enable persistence
 	rCfg := NewDefaultRetrySettings()
-	be, err := newBaseExporter(&defaultExporterCfg, tt.ToExporterCreateSettings(), fromOptions(WithRetry(rCfg), WithQueue(qCfg)), "", nopRequestUnmarshaler())
+	set := tt.ToExporterCreateSettings()
+	be, err := newBaseExporter(set, fromOptions(WithRetry(rCfg), WithQueue(qCfg)), "", nopRequestUnmarshaler())
 	require.NoError(t, err)
 
 	var extensions = map[component.ID]component.Component{
@@ -557,7 +559,7 @@ func TestQueuedRetryPersistenceEnabled(t *testing.T) {
 
 func TestQueuedRetryPersistenceEnabledStorageError(t *testing.T) {
 	storageError := errors.New("could not get storage client")
-	tt, err := obsreporttest.SetupTelemetry()
+	tt, err := obsreporttest.SetupTelemetryWithID(defaultID)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
@@ -565,7 +567,8 @@ func TestQueuedRetryPersistenceEnabledStorageError(t *testing.T) {
 	storageID := component.NewIDWithName("file_storage", "storage")
 	qCfg.StorageID = &storageID // enable persistence
 	rCfg := NewDefaultRetrySettings()
-	be, err := newBaseExporter(&defaultExporterCfg, tt.ToExporterCreateSettings(), fromOptions(WithRetry(rCfg), WithQueue(qCfg)), "", nopRequestUnmarshaler())
+	set := tt.ToExporterCreateSettings()
+	be, err := newBaseExporter(set, fromOptions(WithRetry(rCfg), WithQueue(qCfg)), "", nopRequestUnmarshaler())
 	require.NoError(t, err)
 
 	var extensions = map[component.ID]component.Component{

--- a/exporter/exporterhelper/traces.go
+++ b/exporter/exporterhelper/traces.go
@@ -99,7 +99,7 @@ func NewTracesExporter(
 	}
 
 	bs := fromOptions(options...)
-	be, err := newBaseExporter(cfg, set, bs, component.DataTypeTraces, newTraceRequestUnmarshalerFunc(pusher))
+	be, err := newBaseExporter(set, bs, component.DataTypeTraces, newTraceRequestUnmarshalerFunc(pusher))
 	if err != nil {
 		return nil, err
 	}

--- a/exporter/exporterhelper/traces_test.go
+++ b/exporter/exporterhelper/traces_test.go
@@ -104,7 +104,7 @@ func TestTracesExporter_Default_ReturnError(t *testing.T) {
 }
 
 func TestTracesExporter_WithRecordMetrics(t *testing.T) {
-	tt, err := obsreporttest.SetupTelemetry()
+	tt, err := obsreporttest.SetupTelemetryWithID(fakeTracesExporterName)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
@@ -117,7 +117,7 @@ func TestTracesExporter_WithRecordMetrics(t *testing.T) {
 
 func TestTracesExporter_WithRecordMetrics_ReturnError(t *testing.T) {
 	want := errors.New("my_error")
-	tt, err := obsreporttest.SetupTelemetry()
+	tt, err := obsreporttest.SetupTelemetryWithID(fakeTracesExporterName)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
@@ -129,7 +129,7 @@ func TestTracesExporter_WithRecordMetrics_ReturnError(t *testing.T) {
 }
 
 func TestTracesExporter_WithRecordEnqueueFailedMetrics(t *testing.T) {
-	tt, err := obsreporttest.SetupTelemetry()
+	tt, err := obsreporttest.SetupTelemetryWithID(fakeTracesExporterName)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 

--- a/obsreport/obsreport_test.go
+++ b/obsreport/obsreport_test.go
@@ -52,9 +52,9 @@ type testParams struct {
 	err   error
 }
 
-func testTelemetry(t *testing.T, testFunc func(t *testing.T, tt obsreporttest.TestTelemetry, registry *featuregate.Registry)) {
+func testTelemetry(t *testing.T, id component.ID, testFunc func(t *testing.T, tt obsreporttest.TestTelemetry, registry *featuregate.Registry)) {
 	t.Run("WithOC", func(t *testing.T) {
-		tt, err := obsreporttest.SetupTelemetry()
+		tt, err := obsreporttest.SetupTelemetryWithID(id)
 		require.NoError(t, err)
 		t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
@@ -66,7 +66,7 @@ func testTelemetry(t *testing.T, testFunc func(t *testing.T, tt obsreporttest.Te
 		obsreportconfig.RegisterInternalMetricFeatureGate(registry)
 		require.NoError(t, registry.Apply(map[string]bool{obsreportconfig.UseOtelForInternalMetricsfeatureGateID: true}))
 
-		tt, err := obsreporttest.SetupTelemetry()
+		tt, err := obsreporttest.SetupTelemetryWithID(id)
 		require.NoError(t, err)
 		t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
@@ -75,7 +75,7 @@ func testTelemetry(t *testing.T, testFunc func(t *testing.T, tt obsreporttest.Te
 }
 
 func TestReceiveTraceDataOp(t *testing.T) {
-	testTelemetry(t, func(t *testing.T, tt obsreporttest.TestTelemetry, registry *featuregate.Registry) {
+	testTelemetry(t, receiver, func(t *testing.T, tt obsreporttest.TestTelemetry, registry *featuregate.Registry) {
 		parentCtx, parentSpan := tt.TracerProvider.Tracer("test").Start(context.Background(), t.Name())
 		defer parentSpan.End()
 
@@ -122,7 +122,7 @@ func TestReceiveTraceDataOp(t *testing.T) {
 }
 
 func TestReceiveLogsOp(t *testing.T) {
-	testTelemetry(t, func(t *testing.T, tt obsreporttest.TestTelemetry, registry *featuregate.Registry) {
+	testTelemetry(t, receiver, func(t *testing.T, tt obsreporttest.TestTelemetry, registry *featuregate.Registry) {
 		parentCtx, parentSpan := tt.TracerProvider.Tracer("test").Start(context.Background(), t.Name())
 		defer parentSpan.End()
 
@@ -170,7 +170,7 @@ func TestReceiveLogsOp(t *testing.T) {
 }
 
 func TestReceiveMetricsOp(t *testing.T) {
-	testTelemetry(t, func(t *testing.T, tt obsreporttest.TestTelemetry, registry *featuregate.Registry) {
+	testTelemetry(t, receiver, func(t *testing.T, tt obsreporttest.TestTelemetry, registry *featuregate.Registry) {
 		parentCtx, parentSpan := tt.TracerProvider.Tracer("test").Start(context.Background(), t.Name())
 		defer parentSpan.End()
 
@@ -219,7 +219,7 @@ func TestReceiveMetricsOp(t *testing.T) {
 }
 
 func TestScrapeMetricsDataOp(t *testing.T) {
-	testTelemetry(t, testScrapeMetricsDataOp)
+	testTelemetry(t, receiver, testScrapeMetricsDataOp)
 }
 
 func testScrapeMetricsDataOp(t *testing.T, tt obsreporttest.TestTelemetry, registry *featuregate.Registry) {
@@ -278,7 +278,7 @@ func testScrapeMetricsDataOp(t *testing.T, tt obsreporttest.TestTelemetry, regis
 }
 
 func TestExportTraceDataOp(t *testing.T) {
-	testTelemetry(t, func(t *testing.T, tt obsreporttest.TestTelemetry, registry *featuregate.Registry) {
+	testTelemetry(t, exporter, func(t *testing.T, tt obsreporttest.TestTelemetry, registry *featuregate.Registry) {
 		parentCtx, parentSpan := tt.TracerProvider.Tracer("test").Start(context.Background(), t.Name())
 		defer parentSpan.End()
 
@@ -327,7 +327,7 @@ func TestExportTraceDataOp(t *testing.T) {
 }
 
 func TestExportMetricsOp(t *testing.T) {
-	testTelemetry(t, func(t *testing.T, tt obsreporttest.TestTelemetry, registry *featuregate.Registry) {
+	testTelemetry(t, exporter, func(t *testing.T, tt obsreporttest.TestTelemetry, registry *featuregate.Registry) {
 		parentCtx, parentSpan := tt.TracerProvider.Tracer("test").Start(context.Background(), t.Name())
 		defer parentSpan.End()
 
@@ -376,7 +376,7 @@ func TestExportMetricsOp(t *testing.T) {
 }
 
 func TestExportLogsOp(t *testing.T) {
-	testTelemetry(t, func(t *testing.T, tt obsreporttest.TestTelemetry, registry *featuregate.Registry) {
+	testTelemetry(t, exporter, func(t *testing.T, tt obsreporttest.TestTelemetry, registry *featuregate.Registry) {
 		parentCtx, parentSpan := tt.TracerProvider.Tracer("test").Start(context.Background(), t.Name())
 		defer parentSpan.End()
 
@@ -425,7 +425,7 @@ func TestExportLogsOp(t *testing.T) {
 }
 
 func TestReceiveWithLongLivedCtx(t *testing.T) {
-	tt, err := obsreporttest.SetupTelemetry()
+	tt, err := obsreporttest.SetupTelemetryWithID(receiver)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
@@ -479,7 +479,7 @@ func TestReceiveWithLongLivedCtx(t *testing.T) {
 }
 
 func TestProcessorTraceData(t *testing.T) {
-	testTelemetry(t, testProcessorTraceData)
+	testTelemetry(t, processor, testProcessorTraceData)
 }
 
 func testProcessorTraceData(t *testing.T, tt obsreporttest.TestTelemetry, registry *featuregate.Registry) {
@@ -499,7 +499,7 @@ func testProcessorTraceData(t *testing.T, tt obsreporttest.TestTelemetry, regist
 }
 
 func TestProcessorMetricsData(t *testing.T) {
-	testTelemetry(t, testProcessorMetricsData)
+	testTelemetry(t, processor, testProcessorMetricsData)
 }
 
 func testProcessorMetricsData(t *testing.T, tt obsreporttest.TestTelemetry, registry *featuregate.Registry) {
@@ -542,7 +542,7 @@ func TestBuildProcessorCustomMetricName(t *testing.T) {
 }
 
 func TestProcessorLogRecords(t *testing.T) {
-	testTelemetry(t, testProcessorLogRecords)
+	testTelemetry(t, processor, testProcessorLogRecords)
 }
 
 func testProcessorLogRecords(t *testing.T, tt obsreporttest.TestTelemetry, registry *featuregate.Registry) {

--- a/obsreport/obsreporttest/obsreporttest_test.go
+++ b/obsreport/obsreporttest/obsreporttest_test.go
@@ -39,7 +39,7 @@ var (
 )
 
 func TestCheckScraperMetricsViews(t *testing.T) {
-	tt, err := obsreporttest.SetupTelemetry()
+	tt, err := obsreporttest.SetupTelemetryWithID(receiver)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
@@ -60,7 +60,7 @@ func TestCheckScraperMetricsViews(t *testing.T) {
 }
 
 func TestCheckReceiverTracesViews(t *testing.T) {
-	tt, err := obsreporttest.SetupTelemetry()
+	tt, err := obsreporttest.SetupTelemetryWithID(receiver)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
@@ -81,7 +81,7 @@ func TestCheckReceiverTracesViews(t *testing.T) {
 }
 
 func TestCheckReceiverMetricsViews(t *testing.T) {
-	tt, err := obsreporttest.SetupTelemetry()
+	tt, err := obsreporttest.SetupTelemetryWithID(receiver)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
@@ -102,7 +102,7 @@ func TestCheckReceiverMetricsViews(t *testing.T) {
 }
 
 func TestCheckReceiverLogsViews(t *testing.T) {
-	tt, err := obsreporttest.SetupTelemetry()
+	tt, err := obsreporttest.SetupTelemetryWithID(receiver)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
@@ -198,7 +198,7 @@ func TestCheckProcessorLogViews(t *testing.T) {
 }
 
 func TestCheckExporterTracesViews(t *testing.T) {
-	tt, err := obsreporttest.SetupTelemetry()
+	tt, err := obsreporttest.SetupTelemetryWithID(exporter)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
@@ -218,7 +218,7 @@ func TestCheckExporterTracesViews(t *testing.T) {
 }
 
 func TestCheckExporterMetricsViews(t *testing.T) {
-	tt, err := obsreporttest.SetupTelemetry()
+	tt, err := obsreporttest.SetupTelemetryWithID(exporter)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
@@ -238,7 +238,7 @@ func TestCheckExporterMetricsViews(t *testing.T) {
 }
 
 func TestCheckExporterLogsViews(t *testing.T) {
-	tt, err := obsreporttest.SetupTelemetry()
+	tt, err := obsreporttest.SetupTelemetryWithID(exporter)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 

--- a/processor/batchprocessor/batch_processor.go
+++ b/processor/batchprocessor/batch_processor.go
@@ -24,7 +24,6 @@ import (
 	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/component"
-	"go.opentelemetry.io/collector/config/configtelemetry"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/featuregate"
 	"go.opentelemetry.io/collector/pdata/plog"
@@ -72,8 +71,8 @@ var _ consumer.Traces = (*batchProcessor)(nil)
 var _ consumer.Metrics = (*batchProcessor)(nil)
 var _ consumer.Logs = (*batchProcessor)(nil)
 
-func newBatchProcessor(set component.ProcessorCreateSettings, cfg *Config, batch batch, telemetryLevel configtelemetry.Level, registry *featuregate.Registry) (*batchProcessor, error) {
-	bpt, err := newBatchProcessorTelemetry(set.MeterProvider, cfg, telemetryLevel, registry)
+func newBatchProcessor(set component.ProcessorCreateSettings, cfg *Config, batch batch, registry *featuregate.Registry) (*batchProcessor, error) {
+	bpt, err := newBatchProcessorTelemetry(set, registry)
 	if err != nil {
 		return nil, fmt.Errorf("error to create batch processor telemetry %w", err)
 	}
@@ -201,18 +200,18 @@ func (bp *batchProcessor) ConsumeLogs(_ context.Context, ld plog.Logs) error {
 }
 
 // newBatchTracesProcessor creates a new batch processor that batches traces by size or with timeout
-func newBatchTracesProcessor(set component.ProcessorCreateSettings, next consumer.Traces, cfg *Config, telemetryLevel configtelemetry.Level, registry *featuregate.Registry) (*batchProcessor, error) {
-	return newBatchProcessor(set, cfg, newBatchTraces(next), telemetryLevel, registry)
+func newBatchTracesProcessor(set component.ProcessorCreateSettings, next consumer.Traces, cfg *Config, registry *featuregate.Registry) (*batchProcessor, error) {
+	return newBatchProcessor(set, cfg, newBatchTraces(next), registry)
 }
 
 // newBatchMetricsProcessor creates a new batch processor that batches metrics by size or with timeout
-func newBatchMetricsProcessor(set component.ProcessorCreateSettings, next consumer.Metrics, cfg *Config, telemetryLevel configtelemetry.Level, registry *featuregate.Registry) (*batchProcessor, error) {
-	return newBatchProcessor(set, cfg, newBatchMetrics(next), telemetryLevel, registry)
+func newBatchMetricsProcessor(set component.ProcessorCreateSettings, next consumer.Metrics, cfg *Config, registry *featuregate.Registry) (*batchProcessor, error) {
+	return newBatchProcessor(set, cfg, newBatchMetrics(next), registry)
 }
 
 // newBatchLogsProcessor creates a new batch processor that batches logs by size or with timeout
-func newBatchLogsProcessor(set component.ProcessorCreateSettings, next consumer.Logs, cfg *Config, telemetryLevel configtelemetry.Level, registry *featuregate.Registry) (*batchProcessor, error) {
-	return newBatchProcessor(set, cfg, newBatchLogs(next), telemetryLevel, registry)
+func newBatchLogsProcessor(set component.ProcessorCreateSettings, next consumer.Logs, cfg *Config, registry *featuregate.Registry) (*batchProcessor, error) {
+	return newBatchProcessor(set, cfg, newBatchLogs(next), registry)
 }
 
 type batchTraces struct {

--- a/processor/batchprocessor/batch_processor_test.go
+++ b/processor/batchprocessor/batch_processor_test.go
@@ -43,7 +43,8 @@ func TestBatchProcessorSpansDelivered(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)
 	cfg.SendBatchSize = 128
 	creationSet := componenttest.NewNopProcessorCreateSettings()
-	batcher, err := newBatchTracesProcessor(creationSet, sink, cfg, configtelemetry.LevelDetailed, featuregate.GetRegistry())
+	creationSet.MetricsLevel = configtelemetry.LevelDetailed
+	batcher, err := newBatchTracesProcessor(creationSet, sink, cfg, featuregate.GetRegistry())
 	require.NoError(t, err)
 	require.NoError(t, batcher.Start(context.Background(), componenttest.NewNopHost()))
 
@@ -85,7 +86,8 @@ func TestBatchProcessorSpansDeliveredEnforceBatchSize(t *testing.T) {
 	cfg.SendBatchSize = 128
 	cfg.SendBatchMaxSize = 130
 	creationSet := componenttest.NewNopProcessorCreateSettings()
-	batcher, err := newBatchTracesProcessor(creationSet, sink, cfg, configtelemetry.LevelBasic, featuregate.GetRegistry())
+	creationSet.MetricsLevel = configtelemetry.LevelDetailed
+	batcher, err := newBatchTracesProcessor(creationSet, sink, cfg, featuregate.GetRegistry())
 	require.NoError(t, err)
 	require.NoError(t, batcher.Start(context.Background(), componenttest.NewNopHost()))
 
@@ -134,7 +136,8 @@ func testBatchProcessorSentBySize(t *testing.T, tel testTelemetry, registry *fea
 	cfg.SendBatchSize = uint32(sendBatchSize)
 	cfg.Timeout = 500 * time.Millisecond
 	creationSet := tel.NewProcessorCreateSettings()
-	batcher, err := newBatchTracesProcessor(creationSet, sink, cfg, configtelemetry.LevelDetailed, registry)
+	creationSet.MetricsLevel = configtelemetry.LevelDetailed
+	batcher, err := newBatchTracesProcessor(creationSet, sink, cfg, registry)
 	require.NoError(t, err)
 	require.NoError(t, batcher.Start(context.Background(), componenttest.NewNopHost()))
 
@@ -189,7 +192,8 @@ func testBatchProcessorSentBySizeWithMaxSize(t *testing.T, tel testTelemetry, re
 	cfg.SendBatchMaxSize = uint32(sendBatchMaxSize)
 	cfg.Timeout = 500 * time.Millisecond
 	creationSet := tel.NewProcessorCreateSettings()
-	batcher, err := newBatchTracesProcessor(creationSet, sink, cfg, configtelemetry.LevelDetailed, registry)
+	creationSet.MetricsLevel = configtelemetry.LevelDetailed
+	batcher, err := newBatchTracesProcessor(creationSet, sink, cfg, registry)
 	require.NoError(t, err)
 	require.NoError(t, batcher.Start(context.Background(), componenttest.NewNopHost()))
 
@@ -229,13 +233,14 @@ func TestBatchProcessorSentByTimeout(t *testing.T) {
 	sendBatchSize := 100
 	cfg.SendBatchSize = uint32(sendBatchSize)
 	cfg.Timeout = 100 * time.Millisecond
-	creationSet := componenttest.NewNopProcessorCreateSettings()
 
 	requestCount := 5
 	spansPerRequest := 10
 	start := time.Now()
 
-	batcher, err := newBatchTracesProcessor(creationSet, sink, cfg, configtelemetry.LevelDetailed, featuregate.GetRegistry())
+	creationSet := componenttest.NewNopProcessorCreateSettings()
+	creationSet.MetricsLevel = configtelemetry.LevelDetailed
+	batcher, err := newBatchTracesProcessor(creationSet, sink, cfg, featuregate.GetRegistry())
 	require.NoError(t, err)
 	require.NoError(t, batcher.Start(context.Background(), componenttest.NewNopHost()))
 
@@ -282,7 +287,8 @@ func TestBatchProcessorTraceSendWhenClosing(t *testing.T) {
 	sink := new(consumertest.TracesSink)
 
 	creationSet := componenttest.NewNopProcessorCreateSettings()
-	batcher, err := newBatchTracesProcessor(creationSet, sink, &cfg, configtelemetry.LevelDetailed, featuregate.GetRegistry())
+	creationSet.MetricsLevel = configtelemetry.LevelDetailed
+	batcher, err := newBatchTracesProcessor(creationSet, sink, &cfg, featuregate.GetRegistry())
 	require.NoError(t, err)
 	require.NoError(t, batcher.Start(context.Background(), componenttest.NewNopHost()))
 
@@ -313,7 +319,8 @@ func TestBatchMetricProcessor_ReceivingData(t *testing.T) {
 	sink := new(consumertest.MetricsSink)
 
 	creationSet := componenttest.NewNopProcessorCreateSettings()
-	batcher, err := newBatchMetricsProcessor(creationSet, sink, &cfg, configtelemetry.LevelDetailed, featuregate.GetRegistry())
+	creationSet.MetricsLevel = configtelemetry.LevelDetailed
+	batcher, err := newBatchMetricsProcessor(creationSet, sink, &cfg, featuregate.GetRegistry())
 	require.NoError(t, err)
 	require.NoError(t, batcher.Start(context.Background(), componenttest.NewNopHost()))
 
@@ -370,7 +377,8 @@ func testBatchMetricProcessorBatchSize(t *testing.T, tel testTelemetry, registry
 	sink := new(consumertest.MetricsSink)
 
 	creationSet := tel.NewProcessorCreateSettings()
-	batcher, err := newBatchMetricsProcessor(creationSet, sink, &cfg, configtelemetry.LevelDetailed, registry)
+	creationSet.MetricsLevel = configtelemetry.LevelDetailed
+	batcher, err := newBatchMetricsProcessor(creationSet, sink, &cfg, registry)
 	require.NoError(t, err)
 	require.NoError(t, batcher.Start(context.Background(), componenttest.NewNopHost()))
 
@@ -437,7 +445,8 @@ func TestBatchMetricsProcessor_Timeout(t *testing.T) {
 	sink := new(consumertest.MetricsSink)
 
 	creationSet := componenttest.NewNopProcessorCreateSettings()
-	batcher, err := newBatchMetricsProcessor(creationSet, sink, &cfg, configtelemetry.LevelDetailed, featuregate.GetRegistry())
+	creationSet.MetricsLevel = configtelemetry.LevelDetailed
+	batcher, err := newBatchMetricsProcessor(creationSet, sink, &cfg, featuregate.GetRegistry())
 	require.NoError(t, err)
 	require.NoError(t, batcher.Start(context.Background(), componenttest.NewNopHost()))
 
@@ -486,7 +495,8 @@ func TestBatchMetricProcessor_Shutdown(t *testing.T) {
 	sink := new(consumertest.MetricsSink)
 
 	creationSet := componenttest.NewNopProcessorCreateSettings()
-	batcher, err := newBatchMetricsProcessor(creationSet, sink, &cfg, configtelemetry.LevelDetailed, featuregate.GetRegistry())
+	creationSet.MetricsLevel = configtelemetry.LevelDetailed
+	batcher, err := newBatchMetricsProcessor(creationSet, sink, &cfg, featuregate.GetRegistry())
 	require.NoError(t, err)
 	require.NoError(t, batcher.Start(context.Background(), componenttest.NewNopHost()))
 
@@ -570,9 +580,9 @@ func BenchmarkBatchMetricProcessor(b *testing.B) {
 	ctx := context.Background()
 	sink := new(metricsSink)
 	creationSet := componenttest.NewNopProcessorCreateSettings()
+	creationSet.MetricsLevel = configtelemetry.LevelDetailed
 	metricsPerRequest := 1000
-
-	batcher, err := newBatchMetricsProcessor(creationSet, sink, &cfg, configtelemetry.LevelDetailed, featuregate.GetRegistry())
+	batcher, err := newBatchMetricsProcessor(creationSet, sink, &cfg, featuregate.GetRegistry())
 	require.NoError(b, err)
 	require.NoError(b, batcher.Start(ctx, componenttest.NewNopHost()))
 
@@ -623,7 +633,8 @@ func TestBatchLogProcessor_ReceivingData(t *testing.T) {
 	sink := new(consumertest.LogsSink)
 
 	creationSet := componenttest.NewNopProcessorCreateSettings()
-	batcher, err := newBatchLogsProcessor(creationSet, sink, &cfg, configtelemetry.LevelDetailed, featuregate.GetRegistry())
+	creationSet.MetricsLevel = configtelemetry.LevelDetailed
+	batcher, err := newBatchLogsProcessor(creationSet, sink, &cfg, featuregate.GetRegistry())
 	require.NoError(t, err)
 	require.NoError(t, batcher.Start(context.Background(), componenttest.NewNopHost()))
 
@@ -678,7 +689,8 @@ func testBatchLogProcessorBatchSize(t *testing.T, tel testTelemetry, registry *f
 	sink := new(consumertest.LogsSink)
 
 	creationSet := tel.NewProcessorCreateSettings()
-	batcher, err := newBatchLogsProcessor(creationSet, sink, &cfg, configtelemetry.LevelDetailed, registry)
+	creationSet.MetricsLevel = configtelemetry.LevelDetailed
+	batcher, err := newBatchLogsProcessor(creationSet, sink, &cfg, registry)
 	require.NoError(t, err)
 	require.NoError(t, batcher.Start(context.Background(), componenttest.NewNopHost()))
 
@@ -726,7 +738,8 @@ func TestBatchLogsProcessor_Timeout(t *testing.T) {
 	sink := new(consumertest.LogsSink)
 
 	creationSet := componenttest.NewNopProcessorCreateSettings()
-	batcher, err := newBatchLogsProcessor(creationSet, sink, &cfg, configtelemetry.LevelDetailed, featuregate.GetRegistry())
+	creationSet.MetricsLevel = configtelemetry.LevelDetailed
+	batcher, err := newBatchLogsProcessor(creationSet, sink, &cfg, featuregate.GetRegistry())
 	require.NoError(t, err)
 	require.NoError(t, batcher.Start(context.Background(), componenttest.NewNopHost()))
 
@@ -775,7 +788,8 @@ func TestBatchLogProcessor_Shutdown(t *testing.T) {
 	sink := new(consumertest.LogsSink)
 
 	creationSet := componenttest.NewNopProcessorCreateSettings()
-	batcher, err := newBatchLogsProcessor(creationSet, sink, &cfg, configtelemetry.LevelDetailed, featuregate.GetRegistry())
+	creationSet.MetricsLevel = configtelemetry.LevelDetailed
+	batcher, err := newBatchLogsProcessor(creationSet, sink, &cfg, featuregate.GetRegistry())
 	require.NoError(t, err)
 	require.NoError(t, batcher.Start(context.Background(), componenttest.NewNopHost()))
 

--- a/processor/batchprocessor/factory.go
+++ b/processor/batchprocessor/factory.go
@@ -56,8 +56,7 @@ func createTracesProcessor(
 	cfg component.Config,
 	nextConsumer consumer.Traces,
 ) (component.TracesProcessor, error) {
-	level := set.MetricsLevel
-	return newBatchTracesProcessor(set, nextConsumer, cfg.(*Config), level, featuregate.GetRegistry())
+	return newBatchTracesProcessor(set, nextConsumer, cfg.(*Config), featuregate.GetRegistry())
 }
 
 func createMetricsProcessor(
@@ -66,8 +65,7 @@ func createMetricsProcessor(
 	cfg component.Config,
 	nextConsumer consumer.Metrics,
 ) (component.MetricsProcessor, error) {
-	level := set.MetricsLevel
-	return newBatchMetricsProcessor(set, nextConsumer, cfg.(*Config), level, featuregate.GetRegistry())
+	return newBatchMetricsProcessor(set, nextConsumer, cfg.(*Config), featuregate.GetRegistry())
 }
 
 func createLogsProcessor(
@@ -76,6 +74,5 @@ func createLogsProcessor(
 	cfg component.Config,
 	nextConsumer consumer.Logs,
 ) (component.LogsProcessor, error) {
-	level := set.MetricsLevel
-	return newBatchLogsProcessor(set, nextConsumer, cfg.(*Config), level, featuregate.GetRegistry())
+	return newBatchLogsProcessor(set, nextConsumer, cfg.(*Config), featuregate.GetRegistry())
 }

--- a/processor/batchprocessor/metrics_test.go
+++ b/processor/batchprocessor/metrics_test.go
@@ -130,6 +130,7 @@ func setupTelemetry(t *testing.T, useOtel bool) testTelemetry {
 func (tt *testTelemetry) NewProcessorCreateSettings() component.ProcessorCreateSettings {
 	settings := componenttest.NewNopProcessorCreateSettings()
 	settings.MeterProvider = tt.meterProvider
+	settings.ID = component.NewID(typeStr)
 
 	return settings
 }

--- a/processor/memorylimiterprocessor/memorylimiter.go
+++ b/processor/memorylimiterprocessor/memorylimiter.go
@@ -115,7 +115,7 @@ func newMemoryLimiter(set component.ProcessorCreateSettings, cfg *Config) (*memo
 		zap.Duration("check_interval", cfg.CheckInterval))
 
 	obsrep, err := obsreport.NewProcessor(obsreport.ProcessorSettings{
-		ProcessorID:             cfg.ID(),
+		ProcessorID:             set.ID,
 		ProcessorCreateSettings: set,
 	})
 	if err != nil {

--- a/processor/processorhelper/logs.go
+++ b/processor/processorhelper/logs.go
@@ -38,8 +38,8 @@ type logProcessor struct {
 // NewLogsProcessor creates a component.LogsProcessor that ensure context propagation and the right tags are set.
 func NewLogsProcessor(
 	_ context.Context,
-	_ component.ProcessorCreateSettings,
-	cfg component.Config,
+	set component.ProcessorCreateSettings,
+	_ component.Config,
 	nextConsumer consumer.Logs,
 	logsFunc ProcessLogsFunc,
 	options ...Option,
@@ -53,7 +53,7 @@ func NewLogsProcessor(
 		return nil, component.ErrNilNextConsumer
 	}
 
-	eventOptions := spanAttributes(cfg.ID())
+	eventOptions := spanAttributes(set.ID)
 	bs := fromOptions(options)
 	logsConsumer, err := consumer.NewLogs(func(ctx context.Context, ld plog.Logs) error {
 		span := trace.SpanFromContext(ctx)

--- a/processor/processorhelper/metrics.go
+++ b/processor/processorhelper/metrics.go
@@ -38,8 +38,8 @@ type metricsProcessor struct {
 // NewMetricsProcessor creates a component.MetricsProcessor that ensure context propagation and the right tags are set.
 func NewMetricsProcessor(
 	_ context.Context,
-	_ component.ProcessorCreateSettings,
-	cfg component.Config,
+	set component.ProcessorCreateSettings,
+	_ component.Config,
 	nextConsumer consumer.Metrics,
 	metricsFunc ProcessMetricsFunc,
 	options ...Option,
@@ -53,7 +53,7 @@ func NewMetricsProcessor(
 		return nil, component.ErrNilNextConsumer
 	}
 
-	eventOptions := spanAttributes(cfg.ID())
+	eventOptions := spanAttributes(set.ID)
 	bs := fromOptions(options)
 	metricsConsumer, err := consumer.NewMetrics(func(ctx context.Context, md pmetric.Metrics) error {
 		span := trace.SpanFromContext(ctx)

--- a/processor/processorhelper/traces.go
+++ b/processor/processorhelper/traces.go
@@ -38,8 +38,8 @@ type tracesProcessor struct {
 // NewTracesProcessor creates a component.TracesProcessor that ensure context propagation and the right tags are set.
 func NewTracesProcessor(
 	_ context.Context,
-	_ component.ProcessorCreateSettings,
-	cfg component.Config,
+	set component.ProcessorCreateSettings,
+	_ component.Config,
 	nextConsumer consumer.Traces,
 	tracesFunc ProcessTracesFunc,
 	options ...Option,
@@ -53,7 +53,7 @@ func NewTracesProcessor(
 		return nil, component.ErrNilNextConsumer
 	}
 
-	eventOptions := spanAttributes(cfg.ID())
+	eventOptions := spanAttributes(set.ID)
 	bs := fromOptions(options)
 	traceConsumer, err := consumer.NewTraces(func(ctx context.Context, td ptrace.Traces) error {
 		span := trace.SpanFromContext(ctx)

--- a/receiver/otlpreceiver/internal/logs/otlp.go
+++ b/receiver/otlpreceiver/internal/logs/otlp.go
@@ -35,9 +35,9 @@ type Receiver struct {
 }
 
 // New creates a new Receiver reference.
-func New(id component.ID, nextConsumer consumer.Logs, set component.ReceiverCreateSettings) (*Receiver, error) {
+func New(nextConsumer consumer.Logs, set component.ReceiverCreateSettings) (*Receiver, error) {
 	obsrecv, err := obsreport.NewReceiver(obsreport.ReceiverSettings{
-		ReceiverID:             id,
+		ReceiverID:             set.ID,
 		Transport:              receiverTransport,
 		ReceiverCreateSettings: set,
 	})

--- a/receiver/otlpreceiver/internal/logs/otlp_test.go
+++ b/receiver/otlpreceiver/internal/logs/otlp_test.go
@@ -86,7 +86,9 @@ func otlpReceiverOnGRPCServer(t *testing.T, lc consumer.Logs) net.Addr {
 		require.NoError(t, ln.Close())
 	})
 
-	r, err := New(component.NewIDWithName("otlp", "log"), lc, componenttest.NewNopReceiverCreateSettings())
+	set := componenttest.NewNopReceiverCreateSettings()
+	set.ID = component.NewIDWithName("otlp", "log")
+	r, err := New(lc, set)
 	require.NoError(t, err)
 	// Now run it as a gRPC server
 	srv := grpc.NewServer()

--- a/receiver/otlpreceiver/internal/metrics/otlp.go
+++ b/receiver/otlpreceiver/internal/metrics/otlp.go
@@ -35,9 +35,9 @@ type Receiver struct {
 }
 
 // New creates a new Receiver reference.
-func New(id component.ID, nextConsumer consumer.Metrics, set component.ReceiverCreateSettings) (*Receiver, error) {
+func New(nextConsumer consumer.Metrics, set component.ReceiverCreateSettings) (*Receiver, error) {
 	obsrecv, err := obsreport.NewReceiver(obsreport.ReceiverSettings{
-		ReceiverID:             id,
+		ReceiverID:             set.ID,
 		Transport:              receiverTransport,
 		ReceiverCreateSettings: set,
 	})

--- a/receiver/otlpreceiver/internal/metrics/otlp_test.go
+++ b/receiver/otlpreceiver/internal/metrics/otlp_test.go
@@ -87,7 +87,9 @@ func otlpReceiverOnGRPCServer(t *testing.T, mc consumer.Metrics) net.Addr {
 		require.NoError(t, ln.Close())
 	})
 
-	r, err := New(component.NewIDWithName("otlp", "metrics"), mc, componenttest.NewNopReceiverCreateSettings())
+	set := componenttest.NewNopReceiverCreateSettings()
+	set.ID = component.NewIDWithName("otlp", "metrics")
+	r, err := New(mc, set)
 	require.NoError(t, err)
 	// Now run it as a gRPC server
 	srv := grpc.NewServer()

--- a/receiver/otlpreceiver/internal/trace/otlp.go
+++ b/receiver/otlpreceiver/internal/trace/otlp.go
@@ -35,9 +35,9 @@ type Receiver struct {
 }
 
 // New creates a new Receiver reference.
-func New(id component.ID, nextConsumer consumer.Traces, set component.ReceiverCreateSettings) (*Receiver, error) {
+func New(nextConsumer consumer.Traces, set component.ReceiverCreateSettings) (*Receiver, error) {
 	obsrecv, err := obsreport.NewReceiver(obsreport.ReceiverSettings{
-		ReceiverID:             id,
+		ReceiverID:             set.ID,
 		Transport:              receiverTransport,
 		ReceiverCreateSettings: set,
 	})

--- a/receiver/otlpreceiver/internal/trace/otlp_test.go
+++ b/receiver/otlpreceiver/internal/trace/otlp_test.go
@@ -84,7 +84,9 @@ func otlpReceiverOnGRPCServer(t *testing.T, tc consumer.Traces) net.Addr {
 		require.NoError(t, ln.Close())
 	})
 
-	r, err := New(component.NewIDWithName("otlp", "trace"), tc, componenttest.NewNopReceiverCreateSettings())
+	set := componenttest.NewNopReceiverCreateSettings()
+	set.ID = component.NewIDWithName("otlp", "trace")
+	r, err := New(tc, set)
 	require.NoError(t, err)
 	// Now run it as a gRPC server
 	srv := grpc.NewServer()

--- a/receiver/otlpreceiver/otlp.go
+++ b/receiver/otlpreceiver/otlp.go
@@ -175,7 +175,7 @@ func (r *otlpReceiver) registerTraceConsumer(tc consumer.Traces) error {
 		return component.ErrNilNextConsumer
 	}
 	var err error
-	r.traceReceiver, err = trace.New(r.cfg.ID(), tc, r.settings)
+	r.traceReceiver, err = trace.New(tc, r.settings)
 	if err != nil {
 		return err
 	}
@@ -203,7 +203,7 @@ func (r *otlpReceiver) registerMetricsConsumer(mc consumer.Metrics) error {
 		return component.ErrNilNextConsumer
 	}
 	var err error
-	r.metricsReceiver, err = metrics.New(r.cfg.ID(), mc, r.settings)
+	r.metricsReceiver, err = metrics.New(mc, r.settings)
 	if err != nil {
 		return err
 	}
@@ -232,7 +232,7 @@ func (r *otlpReceiver) registerLogsConsumer(lc consumer.Logs) error {
 		return component.ErrNilNextConsumer
 	}
 	var err error
-	r.logReceiver, err = logs.New(r.cfg.ID(), lc, r.settings)
+	r.logReceiver, err = logs.New(lc, r.settings)
 	if err != nil {
 		return err
 	}

--- a/receiver/scraperhelper/scrapercontroller.go
+++ b/receiver/scraperhelper/scrapercontroller.go
@@ -105,7 +105,7 @@ func NewScraperControllerReceiver(
 	}
 
 	obsrecv, err := obsreport.NewReceiver(obsreport.ReceiverSettings{
-		ReceiverID:             cfg.ID(),
+		ReceiverID:             set.ID,
 		Transport:              "",
 		ReceiverCreateSettings: set,
 	})
@@ -114,7 +114,7 @@ func NewScraperControllerReceiver(
 	}
 
 	sc := &controller{
-		id:                 cfg.ID(),
+		id:                 set.ID,
 		logger:             set.Logger,
 		collectionInterval: cfg.CollectionInterval,
 		nextConsumer:       nextConsumer,

--- a/receiver/scraperhelper/scrapercontroller_test.go
+++ b/receiver/scraperhelper/scrapercontroller_test.go
@@ -135,7 +135,7 @@ func TestScrapeController(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
-			tt, err := obsreporttest.SetupTelemetry()
+			tt, err := obsreporttest.SetupTelemetryWithID(component.NewID("receiver"))
 			require.NoError(t, err)
 			t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 

--- a/service/extensions/extensions.go
+++ b/service/extensions/extensions.go
@@ -147,6 +147,7 @@ func New(ctx context.Context, set Settings, cfg Config) (*Extensions, error) {
 		}
 
 		extSet := component.ExtensionCreateSettings{
+			ID:                extID,
 			TelemetrySettings: set.Telemetry,
 			BuildInfo:         set.BuildInfo,
 		}

--- a/service/internal/configunmarshaler/exporters.go
+++ b/service/internal/configunmarshaler/exporters.go
@@ -53,7 +53,7 @@ func (e *Exporters) Unmarshal(conf *confmap.Conf) error {
 
 		// Create the default config for this exporter.
 		exporterCfg := factory.CreateDefaultConfig()
-		exporterCfg.SetIDName(id.Name())
+		exporterCfg.SetIDName(id.Name()) //nolint:staticcheck
 
 		// Now that the default config struct is created we can Unmarshal into it,
 		// and it will apply user-defined config on top of the default.

--- a/service/internal/configunmarshaler/exporters_test.go
+++ b/service/internal/configunmarshaler/exporters_test.go
@@ -37,7 +37,7 @@ func TestExportersUnmarshal(t *testing.T) {
 	require.NoError(t, exps.Unmarshal(conf))
 
 	cfgWithName := factories.Exporters["nop"].CreateDefaultConfig()
-	cfgWithName.SetIDName("myexporter")
+	cfgWithName.SetIDName("myexporter") //nolint:staticcheck
 	assert.Equal(t, map[component.ID]component.Config{
 		component.NewID("nop"):                       factories.Exporters["nop"].CreateDefaultConfig(),
 		component.NewIDWithName("nop", "myexporter"): cfgWithName,

--- a/service/internal/configunmarshaler/extensions.go
+++ b/service/internal/configunmarshaler/extensions.go
@@ -53,7 +53,7 @@ func (e *Extensions) Unmarshal(conf *confmap.Conf) error {
 
 		// Create the default config for this extension.
 		extensionCfg := factory.CreateDefaultConfig()
-		extensionCfg.SetIDName(id.Name())
+		extensionCfg.SetIDName(id.Name()) //nolint:staticcheck
 
 		// Now that the default config struct is created we can Unmarshal into it,
 		// and it will apply user-defined config on top of the default.

--- a/service/internal/configunmarshaler/extensions_test.go
+++ b/service/internal/configunmarshaler/extensions_test.go
@@ -37,7 +37,7 @@ func TestExtensionsUnmarshal(t *testing.T) {
 	require.NoError(t, exts.Unmarshal(conf))
 
 	cfgWithName := factories.Extensions["nop"].CreateDefaultConfig()
-	cfgWithName.SetIDName("myextension")
+	cfgWithName.SetIDName("myextension") //nolint:staticcheck
 	assert.Equal(t, map[component.ID]component.Config{
 		component.NewID("nop"):                        factories.Extensions["nop"].CreateDefaultConfig(),
 		component.NewIDWithName("nop", "myextension"): cfgWithName,

--- a/service/internal/configunmarshaler/processors.go
+++ b/service/internal/configunmarshaler/processors.go
@@ -52,7 +52,7 @@ func (p *Processors) Unmarshal(conf *confmap.Conf) error {
 
 		// Create the default config for this processor.
 		processorCfg := factory.CreateDefaultConfig()
-		processorCfg.SetIDName(id.Name())
+		processorCfg.SetIDName(id.Name()) //nolint:staticcheck
 
 		// Now that the default config struct is created we can Unmarshal into it,
 		// and it will apply user-defined config on top of the default.

--- a/service/internal/configunmarshaler/processors_test.go
+++ b/service/internal/configunmarshaler/processors_test.go
@@ -37,7 +37,7 @@ func TestProcessorsUnmarshal(t *testing.T) {
 	require.NoError(t, procs.Unmarshal(conf))
 
 	cfgWithName := factories.Processors["nop"].CreateDefaultConfig()
-	cfgWithName.SetIDName("myprocessor")
+	cfgWithName.SetIDName("myprocessor") //nolint:staticcheck
 	assert.Equal(t, map[component.ID]component.Config{
 		component.NewID("nop"):                        factories.Processors["nop"].CreateDefaultConfig(),
 		component.NewIDWithName("nop", "myprocessor"): cfgWithName,

--- a/service/internal/configunmarshaler/receivers.go
+++ b/service/internal/configunmarshaler/receivers.go
@@ -53,7 +53,7 @@ func (r *Receivers) Unmarshal(conf *confmap.Conf) error {
 
 		// Create the default config for this receiver.
 		receiverCfg := factory.CreateDefaultConfig()
-		receiverCfg.SetIDName(id.Name())
+		receiverCfg.SetIDName(id.Name()) //nolint:staticcheck
 
 		// Now that the default config struct is created we can Unmarshal into it,
 		// and it will apply user-defined config on top of the default.

--- a/service/internal/configunmarshaler/receivers_test.go
+++ b/service/internal/configunmarshaler/receivers_test.go
@@ -37,7 +37,7 @@ func TestReceiversUnmarshal(t *testing.T) {
 	require.NoError(t, recvs.Unmarshal(conf))
 
 	cfgWithName := factories.Receivers["nop"].CreateDefaultConfig()
-	cfgWithName.SetIDName("myreceiver")
+	cfgWithName.SetIDName("myreceiver") //nolint:staticcheck
 	assert.Equal(t, map[component.ID]component.Config{
 		component.NewID("nop"):                       factories.Receivers["nop"].CreateDefaultConfig(),
 		component.NewIDWithName("nop", "myreceiver"): cfgWithName,

--- a/service/internal/pipelines/pipelines.go
+++ b/service/internal/pipelines/pipelines.go
@@ -351,6 +351,7 @@ func buildExporter(
 	}
 
 	set := component.ExporterCreateSettings{
+		ID:                id,
 		TelemetrySettings: settings,
 		BuildInfo:         buildInfo,
 	}
@@ -445,6 +446,7 @@ func buildProcessor(ctx context.Context,
 	}
 
 	set := component.ProcessorCreateSettings{
+		ID:                id,
 		TelemetrySettings: settings,
 		BuildInfo:         buildInfo,
 	}
@@ -511,6 +513,7 @@ func buildReceiver(ctx context.Context,
 	}
 
 	set := component.ReceiverCreateSettings{
+		ID:                id,
 		TelemetrySettings: settings,
 		BuildInfo:         buildInfo,
 	}


### PR DESCRIPTION
Updates https://github.com/open-telemetry/opentelemetry-collector/issues/4714

Signed-off-by: Bogdan <bogdandrutu@gmail.com>

