### PR TITLE
[chore] rename internal funcs which still refer to double histogram

### DIFF
--- a/exporter/loggingexporter/internal/otlptext/databuffer.go
+++ b/exporter/loggingexporter/internal/otlptext/databuffer.go
@@ -80,7 +80,7 @@ func (b *dataBuffer) logMetricDataPoints(m pmetric.Metric) {
 	case pmetric.MetricDataTypeHistogram:
 		data := m.Histogram()
 		b.logEntry("     -> AggregationTemporality: %s", data.AggregationTemporality().String())
-		b.logDoubleHistogramDataPoints(data.DataPoints())
+		b.logHistogramDataPoints(data.DataPoints())
 	case pmetric.MetricDataTypeExponentialHistogram:
 		data := m.ExponentialHistogram()
 		b.logEntry("     -> AggregationTemporality: %s", data.AggregationTemporality().String())
@@ -108,7 +108,7 @@ func (b *dataBuffer) logNumberDataPoints(ps pmetric.NumberDataPointSlice) {
 	}
 }
 
-func (b *dataBuffer) logDoubleHistogramDataPoints(ps pmetric.HistogramDataPointSlice) {
+func (b *dataBuffer) logHistogramDataPoints(ps pmetric.HistogramDataPointSlice) {
 	for i := 0; i < ps.Len(); i++ {
 		p := ps.At(i)
 		b.logEntry("HistogramDataPoints #%d", i)

--- a/pdata/internal/metrics_test.go
+++ b/pdata/internal/metrics_test.go
@@ -241,7 +241,7 @@ func TestOtlpToInternalReadOnly(t *testing.T) {
 				ScopeMetrics: []*otlpmetrics.ScopeMetrics{
 					{
 						Scope:   generateTestProtoInstrumentationScope(),
-						Metrics: []*otlpmetrics.Metric{generateTestProtoGaugeMetric(), generateTestProtoSumMetric(), generateTestProtoDoubleHistogramMetric()},
+						Metrics: []*otlpmetrics.Metric{generateTestProtoGaugeMetric(), generateTestProtoSumMetric(), generateTestProtoHistogramMetric()},
 					},
 				},
 			},
@@ -329,7 +329,7 @@ func TestOtlpToFromInternalReadOnly(t *testing.T) {
 				ScopeMetrics: []*otlpmetrics.ScopeMetrics{
 					{
 						Scope:   generateTestProtoInstrumentationScope(),
-						Metrics: []*otlpmetrics.Metric{generateTestProtoGaugeMetric(), generateTestProtoSumMetric(), generateTestProtoDoubleHistogramMetric()},
+						Metrics: []*otlpmetrics.Metric{generateTestProtoGaugeMetric(), generateTestProtoSumMetric(), generateTestProtoHistogramMetric()},
 					},
 				},
 			},
@@ -343,7 +343,7 @@ func TestOtlpToFromInternalReadOnly(t *testing.T) {
 				ScopeMetrics: []*otlpmetrics.ScopeMetrics{
 					{
 						Scope:   generateTestProtoInstrumentationScope(),
-						Metrics: []*otlpmetrics.Metric{generateTestProtoGaugeMetric(), generateTestProtoSumMetric(), generateTestProtoDoubleHistogramMetric()},
+						Metrics: []*otlpmetrics.Metric{generateTestProtoGaugeMetric(), generateTestProtoSumMetric(), generateTestProtoHistogramMetric()},
 					},
 				},
 			},
@@ -529,7 +529,7 @@ func TestOtlpToFromInternalHistogramMutating(t *testing.T) {
 				ScopeMetrics: []*otlpmetrics.ScopeMetrics{
 					{
 						Scope:   generateTestProtoInstrumentationScope(),
-						Metrics: []*otlpmetrics.Metric{generateTestProtoDoubleHistogramMetric()},
+						Metrics: []*otlpmetrics.Metric{generateTestProtoHistogramMetric()},
 					},
 				},
 			},
@@ -613,7 +613,7 @@ func TestOtlpToFromInternalExponentialHistogramMutating(t *testing.T) {
 				ScopeMetrics: []*otlpmetrics.ScopeMetrics{
 					{
 						Scope:   generateTestProtoInstrumentationScope(),
-						Metrics: []*otlpmetrics.Metric{generateTestProtoDoubleHistogramMetric()},
+						Metrics: []*otlpmetrics.Metric{generateTestProtoHistogramMetric()},
 					},
 				},
 			},
@@ -730,7 +730,7 @@ func BenchmarkOtlpToFromInternal_PassThrough(b *testing.B) {
 				ScopeMetrics: []*otlpmetrics.ScopeMetrics{
 					{
 						Scope:   generateTestProtoInstrumentationScope(),
-						Metrics: []*otlpmetrics.Metric{generateTestProtoGaugeMetric(), generateTestProtoSumMetric(), generateTestProtoDoubleHistogramMetric()},
+						Metrics: []*otlpmetrics.Metric{generateTestProtoGaugeMetric(), generateTestProtoSumMetric(), generateTestProtoHistogramMetric()},
 					},
 				},
 			},
@@ -807,7 +807,7 @@ func BenchmarkOtlpToFromInternal_HistogramPoints_MutateOneLabel(b *testing.B) {
 				ScopeMetrics: []*otlpmetrics.ScopeMetrics{
 					{
 						Scope:   generateTestProtoInstrumentationScope(),
-						Metrics: []*otlpmetrics.Metric{generateTestProtoDoubleHistogramMetric()},
+						Metrics: []*otlpmetrics.Metric{generateTestProtoHistogramMetric()},
 					},
 				},
 			},
@@ -923,7 +923,7 @@ func generateTestProtoSumMetric() *otlpmetrics.Metric {
 	}
 }
 
-func generateTestProtoDoubleHistogramMetric() *otlpmetrics.Metric {
+func generateTestProtoHistogramMetric() *otlpmetrics.Metric {
 	return &otlpmetrics.Metric{
 		Name:        "my_metric_histogram",
 		Description: "My metric",


### PR DESCRIPTION
Signed-off-by: Bogdan <bogdandrutu@gmail.com>
