### PR TITLE
Add tests for signal closing shutdown

### DIFF
--- a/service/collector_test.go
+++ b/service/collector_test.go
@@ -132,6 +132,33 @@ func TestCollectorReportError(t *testing.T) {
 	assert.Equal(t, Closed, col.GetState())
 }
 
+func TestCollectorSendSignal(t *testing.T) {
+	factories, err := componenttest.NopFactories()
+	require.NoError(t, err)
+
+	cfgProvider, err := NewConfigProvider(newDefaultConfigProviderSettings([]string{filepath.Join("testdata", "otelcol-nop.yaml")}))
+	require.NoError(t, err)
+
+	col, err := New(CollectorSettings{
+		BuildInfo:      component.NewDefaultBuildInfo(),
+		Factories:      factories,
+		ConfigProvider: cfgProvider,
+		telemetry:      newColTelemetry(featuregate.NewRegistry()),
+	})
+	require.NoError(t, err)
+
+	wg := startCollector(context.Background(), t, col)
+
+	assert.Eventually(t, func() bool {
+		return Running == col.GetState()
+	}, 2*time.Second, 200*time.Millisecond)
+
+	col.signalsChannel <- syscall.SIGTERM
+
+	wg.Wait()
+	assert.Equal(t, Closed, col.GetState())
+}
+
 func TestCollectorFailedShutdown(t *testing.T) {
 	t.Skip("This test was using telemetry shutdown failure, switch to use a component that errors on shutdown.")
 	factories, err := componenttest.NopFactories()
@@ -321,7 +348,7 @@ func testCollectorStartHelper(t *testing.T, telemetry *telemetryInitializer, tc 
 	assertMetrics(t, metricsAddr, tc.expectedLabels)
 
 	assertZPages(t)
-	col.signalsChannel <- syscall.SIGTERM
+	col.Shutdown()
 
 	wg.Wait()
 	assert.Equal(t, Closed, col.GetState())

--- a/service/collector_windows.go
+++ b/service/collector_windows.go
@@ -22,7 +22,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"syscall"
 	"time"
 
 	"go.uber.org/zap"
@@ -127,8 +126,7 @@ func (s *windowsService) start(elog *eventlog.Log, colErrorChannel chan error) e
 }
 
 func (s *windowsService) stop(colErrorChannel chan error) error {
-	// simulate a SIGTERM signal to terminate the collector server
-	s.col.signalsChannel <- syscall.SIGTERM
+	s.col.Shutdown()
 	// return the response of col.Start
 	return <-colErrorChannel
 }


### PR DESCRIPTION
Avoid using directly the signal channel outside of the test and struct itself.

Signed-off-by: Bogdan <bogdandrutu@gmail.com>
