### PR TITLE
Fix json trace/metrics unmarshaling for numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@
 ### 🧰 Bug fixes 🧰
 
 - Fix bug in setting the correct collector state after a configuration change event. (#5830)
+- Fix json trace unmarshalling for numbers (#5924):
+  - Accept both string and number for int32/uint32.
+  - Read uint64 numbers without converting from int64.
 
 ## v0.58.0 Beta
 

--- a/pdata/internal/json/number.go
+++ b/pdata/internal/json/number.go
@@ -15,10 +15,83 @@
 package json // import "go.opentelemetry.io/collector/pdata/internal/json"
 
 import (
+	"strconv"
+
 	jsoniter "github.com/json-iterator/go"
 )
 
-// ReadInt64  Unmarshal JSON data and return int64
+// ReadInt32 unmarshalls JSON data into an int32. Accepts both numbers and strings decimal.
+// See https://developers.google.com/protocol-buffers/docs/proto3#json.
+func ReadInt32(iter *jsoniter.Iterator) int32 {
+	switch iter.WhatIsNext() {
+	case jsoniter.NumberValue:
+		return iter.ReadInt32()
+	case jsoniter.StringValue:
+		val, err := strconv.ParseInt(iter.ReadString(), 10, 32)
+		if err != nil {
+			iter.ReportError("ReadInt32", err.Error())
+			return 0
+		}
+		return int32(val)
+	default:
+		iter.ReportError("ReadInt32", "unsupported value type")
+		return 0
+	}
+}
+
+// ReadUint32 unmarshalls JSON data into an uint32. Accepts both numbers and strings decimal.
+// See https://developers.google.com/protocol-buffers/docs/proto3#json.
+func ReadUint32(iter *jsoniter.Iterator) uint32 {
+	switch iter.WhatIsNext() {
+	case jsoniter.NumberValue:
+		return iter.ReadUint32()
+	case jsoniter.StringValue:
+		val, err := strconv.ParseUint(iter.ReadString(), 10, 32)
+		if err != nil {
+			iter.ReportError("ReadUint32", err.Error())
+			return 0
+		}
+		return uint32(val)
+	default:
+		iter.ReportError("ReadUint32", "unsupported value type")
+		return 0
+	}
+}
+
+// ReadInt64 unmarshalls JSON data into an int64. Accepts both numbers and strings decimal.
+// See https://developers.google.com/protocol-buffers/docs/proto3#json.
 func ReadInt64(iter *jsoniter.Iterator) int64 {
-	return iter.ReadAny().ToInt64()
+	switch iter.WhatIsNext() {
+	case jsoniter.NumberValue:
+		return iter.ReadInt64()
+	case jsoniter.StringValue:
+		val, err := strconv.ParseInt(iter.ReadString(), 10, 64)
+		if err != nil {
+			iter.ReportError("ReadInt64", err.Error())
+			return 0
+		}
+		return val
+	default:
+		iter.ReportError("ReadInt64", "unsupported value type")
+		return 0
+	}
+}
+
+// ReadUint64 unmarshalls JSON data into an uint64. Accepts both numbers and strings decimal.
+// See https://developers.google.com/protocol-buffers/docs/proto3#json.
+func ReadUint64(iter *jsoniter.Iterator) uint64 {
+	switch iter.WhatIsNext() {
+	case jsoniter.NumberValue:
+		return iter.ReadUint64()
+	case jsoniter.StringValue:
+		val, err := strconv.ParseUint(iter.ReadString(), 10, 64)
+		if err != nil {
+			iter.ReportError("ReadUint64", err.Error())
+			return 0
+		}
+		return val
+	default:
+		iter.ReportError("ReadUint64", "unsupported value type")
+		return 0
+	}
 }

--- a/pdata/internal/json/number_test.go
+++ b/pdata/internal/json/number_test.go
@@ -21,11 +21,12 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestReadInt64(t *testing.T) {
+func TestReadInt32(t *testing.T) {
 	tests := []struct {
 		name    string
 		jsonStr string
-		want    int64
+		want    int32
+		wantErr bool
 	}{
 		{
 			name:    "number",
@@ -37,12 +38,195 @@ func TestReadInt64(t *testing.T) {
 			jsonStr: `"1"`,
 			want:    1,
 		},
+		{
+			name:    "negative number",
+			jsonStr: `-1 `,
+			want:    -1,
+		},
+		{
+			name:    "negative string",
+			jsonStr: `"-1"`,
+			want:    -1,
+		},
+		{
+			name:    "wrong string",
+			jsonStr: `"3.f14"`,
+			wantErr: true,
+		},
+		{
+			name:    "wrong type",
+			jsonStr: `true`,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			iter := jsoniter.ConfigFastest.BorrowIterator([]byte(tt.jsonStr))
+			defer jsoniter.ConfigFastest.ReturnIterator(iter)
+			val := ReadInt32(iter)
+			if tt.wantErr {
+				assert.Error(t, iter.Error)
+				return
+			}
+			assert.NoError(t, iter.Error)
+			assert.Equal(t, tt.want, val)
+		})
+	}
+}
+
+func TestReadUint32(t *testing.T) {
+	tests := []struct {
+		name    string
+		jsonStr string
+		want    uint32
+		wantErr bool
+	}{
+		{
+			name:    "number",
+			jsonStr: `1 `,
+			want:    1,
+		},
+		{
+			name:    "string",
+			jsonStr: `"1"`,
+			want:    1,
+		},
+		{
+			name:    "negative number",
+			jsonStr: `-1 `,
+			wantErr: true,
+		},
+		{
+			name:    "negative string",
+			jsonStr: `"-1"`,
+			wantErr: true,
+		},
+		{
+			name:    "wrong string",
+			jsonStr: `"3.f14"`,
+			wantErr: true,
+		},
+		{
+			name:    "wrong type",
+			jsonStr: `true`,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			iter := jsoniter.ConfigFastest.BorrowIterator([]byte(tt.jsonStr))
+			defer jsoniter.ConfigFastest.ReturnIterator(iter)
+			val := ReadUint32(iter)
+			if tt.wantErr {
+				assert.Error(t, iter.Error)
+				return
+			}
+			assert.NoError(t, iter.Error)
+			assert.Equal(t, tt.want, val)
+		})
+	}
+}
+
+func TestReadInt64(t *testing.T) {
+	tests := []struct {
+		name    string
+		jsonStr string
+		want    int64
+		wantErr bool
+	}{
+		{
+			name:    "number",
+			jsonStr: `1 `,
+			want:    1,
+		},
+		{
+			name:    "string",
+			jsonStr: `"1"`,
+			want:    1,
+		},
+		{
+			name:    "negative number",
+			jsonStr: `-1 `,
+			want:    -1,
+		},
+		{
+			name:    "negative string",
+			jsonStr: `"-1"`,
+			want:    -1,
+		},
+		{
+			name:    "wrong string",
+			jsonStr: `"3.f14"`,
+			wantErr: true,
+		},
+		{
+			name:    "wrong type",
+			jsonStr: `true`,
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			iter := jsoniter.ConfigFastest.BorrowIterator([]byte(tt.jsonStr))
 			defer jsoniter.ConfigFastest.ReturnIterator(iter)
 			val := ReadInt64(iter)
+			if tt.wantErr {
+				assert.Error(t, iter.Error)
+				return
+			}
+			assert.NoError(t, iter.Error)
+			assert.Equal(t, tt.want, val)
+		})
+	}
+}
+
+func TestReadUint64(t *testing.T) {
+	tests := []struct {
+		name    string
+		jsonStr string
+		want    uint64
+		wantErr bool
+	}{
+		{
+			name:    "number",
+			jsonStr: `1 `,
+			want:    1,
+		},
+		{
+			name:    "string",
+			jsonStr: `"1"`,
+			want:    1,
+		},
+		{
+			name:    "negative number",
+			jsonStr: `-1 `,
+			wantErr: true,
+		},
+		{
+			name:    "negative string",
+			jsonStr: `"-1"`,
+			wantErr: true,
+		},
+		{
+			name:    "wrong string",
+			jsonStr: `"3.f14"`,
+			wantErr: true,
+		},
+		{
+			name:    "wrong type",
+			jsonStr: `true`,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			iter := jsoniter.ConfigFastest.BorrowIterator([]byte(tt.jsonStr))
+			defer jsoniter.ConfigFastest.ReturnIterator(iter)
+			val := ReadUint64(iter)
+			if tt.wantErr {
+				assert.Error(t, iter.Error)
+				return
+			}
 			assert.NoError(t, iter.Error)
 			assert.Equal(t, tt.want, val)
 		})

--- a/pdata/pmetric/json.go
+++ b/pdata/pmetric/json.go
@@ -23,7 +23,7 @@ import (
 
 	"go.opentelemetry.io/collector/pdata/internal"
 	otlpmetrics "go.opentelemetry.io/collector/pdata/internal/data/protogen/metrics/v1"
-	commonjson "go.opentelemetry.io/collector/pdata/internal/json"
+	"go.opentelemetry.io/collector/pdata/internal/json"
 	"go.opentelemetry.io/collector/pdata/internal/otlp"
 )
 
@@ -91,11 +91,11 @@ func (d *jsonUnmarshaler) readResourceMetrics(iter *jsoniter.Iterator) *otlpmetr
 				switch f {
 				case "attributes":
 					iter.ReadArrayCB(func(iter *jsoniter.Iterator) bool {
-						rs.Resource.Attributes = append(rs.Resource.Attributes, commonjson.ReadAttribute(iter))
+						rs.Resource.Attributes = append(rs.Resource.Attributes, json.ReadAttribute(iter))
 						return true
 					})
 				case "droppedAttributesCount", "dropped_attributes_count":
-					rs.Resource.DroppedAttributesCount = iter.ReadUint32()
+					rs.Resource.DroppedAttributesCount = json.ReadUint32(iter)
 				default:
 					iter.Skip()
 				}
@@ -131,11 +131,11 @@ func (d *jsonUnmarshaler) readScopeMetrics(iter *jsoniter.Iterator) *otlpmetrics
 				case "attributes":
 					iter.ReadArrayCB(func(iter *jsoniter.Iterator) bool {
 						ils.Scope.Attributes = append(ils.Scope.Attributes,
-							commonjson.ReadAttribute(iter))
+							json.ReadAttribute(iter))
 						return true
 					})
 				case "droppedAttributesCount", "dropped_attributes_count":
-					ils.Scope.DroppedAttributesCount = iter.ReadUint32()
+					ils.Scope.DroppedAttributesCount = json.ReadUint32(iter)
 				default:
 					iter.Skip()
 				}
@@ -301,14 +301,14 @@ func (d *jsonUnmarshaler) readExemplar(iter *jsoniter.Iterator) otlpmetrics.Exem
 		switch f {
 		case "filtered_attributes", "filteredAttributes":
 			iter.ReadArrayCB(func(iter *jsoniter.Iterator) bool {
-				exemplar.FilteredAttributes = append(exemplar.FilteredAttributes, commonjson.ReadAttribute(iter))
+				exemplar.FilteredAttributes = append(exemplar.FilteredAttributes, json.ReadAttribute(iter))
 				return true
 			})
 		case "timeUnixNano", "time_unix_nano":
-			exemplar.TimeUnixNano = uint64(commonjson.ReadInt64(iter))
+			exemplar.TimeUnixNano = json.ReadUint64(iter)
 		case "as_int", "asInt":
 			exemplar.Value = &otlpmetrics.Exemplar_AsInt{
-				AsInt: commonjson.ReadInt64(iter),
+				AsInt: json.ReadInt64(iter),
 			}
 		case "as_double", "asDouble":
 			exemplar.Value = &otlpmetrics.Exemplar_AsDouble{
@@ -335,12 +335,12 @@ func (d *jsonUnmarshaler) readNumberDataPoint(iter *jsoniter.Iterator) *otlpmetr
 	iter.ReadObjectCB(func(iter *jsoniter.Iterator, f string) bool {
 		switch f {
 		case "timeUnixNano", "time_unix_nano":
-			point.TimeUnixNano = uint64(commonjson.ReadInt64(iter))
+			point.TimeUnixNano = json.ReadUint64(iter)
 		case "start_time_unix_nano", "startTimeUnixNano":
-			point.StartTimeUnixNano = uint64(commonjson.ReadInt64(iter))
+			point.StartTimeUnixNano = json.ReadUint64(iter)
 		case "as_int", "asInt":
 			point.Value = &otlpmetrics.NumberDataPoint_AsInt{
-				AsInt: commonjson.ReadInt64(iter),
+				AsInt: json.ReadInt64(iter),
 			}
 		case "as_double", "asDouble":
 			point.Value = &otlpmetrics.NumberDataPoint_AsDouble{
@@ -348,7 +348,7 @@ func (d *jsonUnmarshaler) readNumberDataPoint(iter *jsoniter.Iterator) *otlpmetr
 			}
 		case "attributes":
 			iter.ReadArrayCB(func(iter *jsoniter.Iterator) bool {
-				point.Attributes = append(point.Attributes, commonjson.ReadAttribute(iter))
+				point.Attributes = append(point.Attributes, json.ReadAttribute(iter))
 				return true
 			})
 		case "exemplars":
@@ -357,7 +357,7 @@ func (d *jsonUnmarshaler) readNumberDataPoint(iter *jsoniter.Iterator) *otlpmetr
 				return true
 			})
 		case "flags":
-			point.Flags = iter.ReadUint32()
+			point.Flags = json.ReadUint32(iter)
 		default:
 			iter.Skip()
 		}
@@ -371,21 +371,21 @@ func (d *jsonUnmarshaler) readHistogramDataPoint(iter *jsoniter.Iterator) *otlpm
 	iter.ReadObjectCB(func(iter *jsoniter.Iterator, f string) bool {
 		switch f {
 		case "timeUnixNano", "time_unix_nano":
-			point.TimeUnixNano = uint64(commonjson.ReadInt64(iter))
+			point.TimeUnixNano = json.ReadUint64(iter)
 		case "start_time_unix_nano", "startTimeUnixNano":
-			point.StartTimeUnixNano = uint64(commonjson.ReadInt64(iter))
+			point.StartTimeUnixNano = json.ReadUint64(iter)
 		case "attributes":
 			iter.ReadArrayCB(func(iter *jsoniter.Iterator) bool {
-				point.Attributes = append(point.Attributes, commonjson.ReadAttribute(iter))
+				point.Attributes = append(point.Attributes, json.ReadAttribute(iter))
 				return true
 			})
 		case "count":
-			point.Count = uint64(commonjson.ReadInt64(iter))
+			point.Count = json.ReadUint64(iter)
 		case "sum":
 			point.Sum_ = &otlpmetrics.HistogramDataPoint_Sum{Sum: iter.ReadFloat64()}
 		case "bucket_counts", "bucketCounts":
 			iter.ReadArrayCB(func(iter *jsoniter.Iterator) bool {
-				point.BucketCounts = append(point.BucketCounts, uint64(commonjson.ReadInt64(iter)))
+				point.BucketCounts = append(point.BucketCounts, json.ReadUint64(iter))
 				return true
 			})
 		case "explicit_bounds", "explicitBounds":
@@ -399,7 +399,7 @@ func (d *jsonUnmarshaler) readHistogramDataPoint(iter *jsoniter.Iterator) *otlpm
 				return true
 			})
 		case "flags":
-			point.Flags = iter.ReadUint32()
+			point.Flags = json.ReadUint32(iter)
 		case "max":
 			point.Max_ = &otlpmetrics.HistogramDataPoint_Max{
 				Max: iter.ReadFloat64(),
@@ -421,16 +421,16 @@ func (d *jsonUnmarshaler) readExponentialHistogramDataPoint(iter *jsoniter.Itera
 	iter.ReadObjectCB(func(iter *jsoniter.Iterator, f string) bool {
 		switch f {
 		case "timeUnixNano", "time_unix_nano":
-			point.TimeUnixNano = uint64(commonjson.ReadInt64(iter))
+			point.TimeUnixNano = json.ReadUint64(iter)
 		case "start_time_unix_nano", "startTimeUnixNano":
-			point.StartTimeUnixNano = uint64(commonjson.ReadInt64(iter))
+			point.StartTimeUnixNano = json.ReadUint64(iter)
 		case "attributes":
 			iter.ReadArrayCB(func(iter *jsoniter.Iterator) bool {
-				point.Attributes = append(point.Attributes, commonjson.ReadAttribute(iter))
+				point.Attributes = append(point.Attributes, json.ReadAttribute(iter))
 				return true
 			})
 		case "count":
-			point.Count = uint64(commonjson.ReadInt64(iter))
+			point.Count = json.ReadUint64(iter)
 		case "sum":
 			point.Sum_ = &otlpmetrics.ExponentialHistogramDataPoint_Sum{
 				Sum: iter.ReadFloat64(),
@@ -438,14 +438,14 @@ func (d *jsonUnmarshaler) readExponentialHistogramDataPoint(iter *jsoniter.Itera
 		case "scale":
 			point.Scale = iter.ReadInt32()
 		case "zero_count", "zeroCount":
-			point.ZeroCount = uint64(commonjson.ReadInt64(iter))
+			point.ZeroCount = json.ReadUint64(iter)
 		case "positive":
 			positive := otlpmetrics.ExponentialHistogramDataPoint_Buckets{}
 			iter.ReadObjectCB(func(iter *jsoniter.Iterator, f string) bool {
 				switch f {
 				case "bucket_counts", "bucketCounts":
 					iter.ReadArrayCB(func(iter *jsoniter.Iterator) bool {
-						positive.BucketCounts = append(positive.BucketCounts, uint64(commonjson.ReadInt64(iter)))
+						positive.BucketCounts = append(positive.BucketCounts, json.ReadUint64(iter))
 						return true
 					})
 				case "offset":
@@ -462,7 +462,7 @@ func (d *jsonUnmarshaler) readExponentialHistogramDataPoint(iter *jsoniter.Itera
 				switch f {
 				case "bucket_counts", "bucketCounts":
 					iter.ReadArrayCB(func(iter *jsoniter.Iterator) bool {
-						negative.BucketCounts = append(negative.BucketCounts, uint64(commonjson.ReadInt64(iter)))
+						negative.BucketCounts = append(negative.BucketCounts, json.ReadUint64(iter))
 						return true
 					})
 				case "offset":
@@ -479,7 +479,7 @@ func (d *jsonUnmarshaler) readExponentialHistogramDataPoint(iter *jsoniter.Itera
 				return true
 			})
 		case "flags":
-			point.Flags = iter.ReadUint32()
+			point.Flags = json.ReadUint32(iter)
 		case "max":
 			point.Max_ = &otlpmetrics.ExponentialHistogramDataPoint_Max{
 				Max: iter.ReadFloat64(),
@@ -501,16 +501,16 @@ func (d *jsonUnmarshaler) readSummaryDataPoint(iter *jsoniter.Iterator) *otlpmet
 	iter.ReadObjectCB(func(iter *jsoniter.Iterator, f string) bool {
 		switch f {
 		case "timeUnixNano", "time_unix_nano":
-			point.TimeUnixNano = uint64(commonjson.ReadInt64(iter))
+			point.TimeUnixNano = json.ReadUint64(iter)
 		case "start_time_unix_nano", "startTimeUnixNano":
-			point.StartTimeUnixNano = uint64(commonjson.ReadInt64(iter))
+			point.StartTimeUnixNano = json.ReadUint64(iter)
 		case "attributes":
 			iter.ReadArrayCB(func(iter *jsoniter.Iterator) bool {
-				point.Attributes = append(point.Attributes, commonjson.ReadAttribute(iter))
+				point.Attributes = append(point.Attributes, json.ReadAttribute(iter))
 				return true
 			})
 		case "count":
-			point.Count = uint64(commonjson.ReadInt64(iter))
+			point.Count = json.ReadUint64(iter)
 		case "sum":
 			point.Sum = iter.ReadFloat64()
 		case "quantile_values", "quantileValues":
@@ -519,7 +519,7 @@ func (d *jsonUnmarshaler) readSummaryDataPoint(iter *jsoniter.Iterator) *otlpmet
 				return true
 			})
 		case "flags":
-			point.Flags = iter.ReadUint32()
+			point.Flags = json.ReadUint32(iter)
 		default:
 			iter.Skip()
 		}

--- a/pdata/ptrace/json.go
+++ b/pdata/ptrace/json.go
@@ -93,7 +93,7 @@ func readResourceSpans(iter *jsoniter.Iterator) *otlptrace.ResourceSpans {
 						return true
 					})
 				case "droppedAttributesCount", "dropped_attributes_count":
-					rs.Resource.DroppedAttributesCount = iter.ReadUint32()
+					rs.Resource.DroppedAttributesCount = json.ReadUint32(iter)
 				default:
 					iter.ReportError("readResourceSpans.resource", fmt.Sprintf("unknown field:%v", f))
 				}
@@ -171,30 +171,30 @@ func readSpan(iter *jsoniter.Iterator) *otlptrace.Span {
 		case "kind":
 			sp.Kind = readSpanKind(iter)
 		case "startTimeUnixNano", "start_time_unix_nano":
-			sp.StartTimeUnixNano = uint64(readInt64(iter))
+			sp.StartTimeUnixNano = json.ReadUint64(iter)
 		case "endTimeUnixNano", "end_time_unix_nano":
-			sp.EndTimeUnixNano = uint64(readInt64(iter))
+			sp.EndTimeUnixNano = json.ReadUint64(iter)
 		case "attributes":
 			iter.ReadArrayCB(func(iter *jsoniter.Iterator) bool {
 				sp.Attributes = append(sp.Attributes, json.ReadAttribute(iter))
 				return true
 			})
 		case "droppedAttributesCount", "dropped_attributes_count":
-			sp.DroppedAttributesCount = iter.ReadUint32()
+			sp.DroppedAttributesCount = json.ReadUint32(iter)
 		case "events":
 			iter.ReadArrayCB(func(iter *jsoniter.Iterator) bool {
 				sp.Events = append(sp.Events, readSpanEvent(iter))
 				return true
 			})
 		case "droppedEventsCount", "dropped_events_count":
-			sp.DroppedEventsCount = iter.ReadUint32()
+			sp.DroppedEventsCount = json.ReadUint32(iter)
 		case "links":
 			iter.ReadArrayCB(func(iter *jsoniter.Iterator) bool {
 				sp.Links = append(sp.Links, readSpanLink(iter))
 				return true
 			})
 		case "droppedLinksCount", "dropped_links_count":
-			sp.DroppedLinksCount = iter.ReadUint32()
+			sp.DroppedLinksCount = json.ReadUint32(iter)
 		case "status":
 			iter.ReadObjectCB(func(iter *jsoniter.Iterator, f string) bool {
 				switch f {
@@ -236,7 +236,7 @@ func readSpanLink(iter *jsoniter.Iterator) *otlptrace.Span_Link {
 				return true
 			})
 		case "droppedAttributesCount", "dropped_attributes_count":
-			link.DroppedAttributesCount = iter.ReadUint32()
+			link.DroppedAttributesCount = json.ReadUint32(iter)
 		default:
 			iter.ReportError("readSpanLink", fmt.Sprintf("unknown field:%v", f))
 		}
@@ -251,7 +251,7 @@ func readSpanEvent(iter *jsoniter.Iterator) *otlptrace.Span_Event {
 	iter.ReadObjectCB(func(iter *jsoniter.Iterator, f string) bool {
 		switch f {
 		case "timeUnixNano", "time_unix_nano":
-			event.TimeUnixNano = uint64(readInt64(iter))
+			event.TimeUnixNano = json.ReadUint64(iter)
 		case "name":
 			event.Name = iter.ReadString()
 		case "attributes":
@@ -260,17 +260,13 @@ func readSpanEvent(iter *jsoniter.Iterator) *otlptrace.Span_Event {
 				return true
 			})
 		case "droppedAttributesCount", "dropped_attributes_count":
-			event.DroppedAttributesCount = iter.ReadUint32()
+			event.DroppedAttributesCount = json.ReadUint32(iter)
 		default:
 			iter.ReportError("readSpanEvent", fmt.Sprintf("unknown field:%v", f))
 		}
 		return true
 	})
 	return event
-}
-
-func readInt64(iter *jsoniter.Iterator) int64 {
-	return iter.ReadAny().ToInt64()
 }
 
 func readSpanKind(iter *jsoniter.Iterator) otlptrace.Span_SpanKind {

--- a/pdata/ptrace/json_test.go
+++ b/pdata/ptrace/json_test.go
@@ -159,23 +159,6 @@ func BenchmarkJSONUnmarshal(b *testing.B) {
 	})
 }
 
-func TestReadInt64(t *testing.T) {
-	var data = `{"intAsNumber":1,"intAsString":"1"}`
-	iter := jsoniter.ConfigFastest.BorrowIterator([]byte(data))
-	iter.ReadObjectCB(func(iter *jsoniter.Iterator, f string) bool {
-		switch f {
-		case "intAsNumber":
-			v := readInt64(iter)
-			assert.Equal(t, int64(1), v)
-		case "intAsString":
-			v := readInt64(iter)
-			assert.Equal(t, int64(1), v)
-		}
-		return true
-	})
-	assert.NoError(t, iter.Error)
-}
-
 func TestReadTraceDataUnknownField(t *testing.T) {
 	jsonStr := `{"extra":""}`
 	iter := jsoniter.ConfigFastest.BorrowIterator([]byte(jsonStr))


### PR DESCRIPTION
Updates https://github.com/open-telemetry/opentelemetry-collector/issues/5312

Also this improves benchmarks since `ReadAny` was doing an allocation, see:

**Before:**
```
/private/var/folders/5c/5p_3jmvd6qx0rsvmb9j7c_s00000gn/T/GoLand/___BenchmarkJSONUnmarshal_in_go_opentelemetry_io_collector_pdata_ptrace.test -test.v -test.paniconexit0 -test.bench ^\QBenchmarkJSONUnmarshal\E$ -test.run ^$
goos: darwin
goarch: amd64
pkg: go.opentelemetry.io/collector/pdata/ptrace
cpu: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
BenchmarkJSONUnmarshal
BenchmarkJSONUnmarshal-16    	  334974	      3942 ns/op	    4669 B/op	     231 allocs/op
PASS
```

**After:**
```
/private/var/folders/5c/5p_3jmvd6qx0rsvmb9j7c_s00000gn/T/GoLand/___BenchmarkJSONUnmarshal_in_go_opentelemetry_io_collector_pdata_ptrace.test -test.v -test.paniconexit0 -test.bench ^\QBenchmarkJSONUnmarshal\E$ -test.run ^$
goos: darwin
goarch: amd64
pkg: go.opentelemetry.io/collector/pdata/ptrace
cpu: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
BenchmarkJSONUnmarshal
BenchmarkJSONUnmarshal-16    	  374025	      3642 ns/op	    4412 B/op	     219 allocs/op
PASS

Signed-off-by: Bogdan <bogdandrutu@gmail.com>
