### PR TITLE
Added MarshalerSizer Interface to facilitate creation of Sizer implementations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@
 
 ### 💡 Enhancements 💡
 
-- Added `NewProtoSizer` method to `ptrace`, `plog`, and `pmetric` packages to directly create a `Sizer` implementation ()
+- Added `NewProtoSizer` method to `ptrace`, `plog`, and `pmetric` packages to directly create a `Sizer` implementation (#5929)
 - Add support to unmarshalls bytes into pmetric.Metrics with `jsoniter` in jsonUnmarshaler(#5433)
 - Add httpprovider to allow loading config files stored in HTTP (#5810)
 - Added `service.telemetry.traces.propagators` configuration to set propagators for collector's internal spans. (#5572)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@
 
 ### 💡 Enhancements 💡
 
-- Added `NewProtoSizer` method to `ptrace`, `plog`, and `pmetric` packages to directly create a `Sizer` implementation (#5929)
+- Added `MarshalSizer` interface to `ptrace`, `plog`, and `pmetric` packages. `NewProtoMarshaler` now returns a `MarshalSizer` (#5929)
 - Add support to unmarshalls bytes into pmetric.Metrics with `jsoniter` in jsonUnmarshaler(#5433)
 - Add httpprovider to allow loading config files stored in HTTP (#5810)
 - Added `service.telemetry.traces.propagators` configuration to set propagators for collector's internal spans. (#5572)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@
 
 ### 💡 Enhancements 💡
 
-- Added `MarshalSizer` interface to `ptrace`, `plog`, and `pmetric` packages. `NewProtoMarshaler` now returns a `MarshalSizer` (#5929)
+- Added `MarshalerSizer` interface to `ptrace`, `plog`, and `pmetric` packages. `NewProtoMarshaler` now returns a `MarshalerSizer` (#5929)
 - Add support to unmarshalls bytes into pmetric.Metrics with `jsoniter` in jsonUnmarshaler(#5433)
 - Add httpprovider to allow loading config files stored in HTTP (#5810)
 - Added `service.telemetry.traces.propagators` configuration to set propagators for collector's internal spans. (#5572)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 
 ### 💡 Enhancements 💡
 
+- Added `NewProtoSizer` method to `ptrace`, `plog`, and `pmetric` packages to directly create a `Sizer` implementation ()
 - Add support to unmarshalls bytes into pmetric.Metrics with `jsoniter` in jsonUnmarshaler(#5433)
 - Add httpprovider to allow loading config files stored in HTTP (#5810)
 - Added `service.telemetry.traces.propagators` configuration to set propagators for collector's internal spans. (#5572)

--- a/pdata/plog/encoding.go
+++ b/pdata/plog/encoding.go
@@ -14,6 +14,12 @@
 
 package plog // import "go.opentelemetry.io/collector/pdata/plog"
 
+// MarshalSizer is the interface that groups the basic Marshal and Size methods
+type MarshalSizer interface {
+	Marshaler
+	Sizer
+}
+
 // Marshaler marshals pdata.Logs into bytes.
 type Marshaler interface {
 	// MarshalLogs the given pdata.Logs into bytes.

--- a/pdata/plog/encoding.go
+++ b/pdata/plog/encoding.go
@@ -14,8 +14,8 @@
 
 package plog // import "go.opentelemetry.io/collector/pdata/plog"
 
-// MarshalSizer is the interface that groups the basic Marshal and Size methods
-type MarshalSizer interface {
+// MarshalerSizer is the interface that groups the basic Marshal and Size methods
+type MarshalerSizer interface {
 	Marshaler
 	Sizer
 }

--- a/pdata/plog/pb.go
+++ b/pdata/plog/pb.go
@@ -19,13 +19,9 @@ import (
 	otlplogs "go.opentelemetry.io/collector/pdata/internal/data/protogen/logs/v1"
 )
 
-// NewProtoMarshaler returns a Marshaler. Marshals to OTLP binary protobuf bytes.
-func NewProtoMarshaler() Marshaler {
-	return newPbMarshaler()
-}
-
-// NewProtoSizer returns a Sizer. Calculates the size of a marshaled Logs.
-func NewProtoSizer() Sizer {
+// NewProtoMarshaler returns a Marshaler.
+// Marshals to OTLP binary protobuf bytes and calculates the size of the marshaled Logs.
+func NewProtoMarshaler() MarshalSizer {
 	return newPbMarshaler()
 }
 

--- a/pdata/plog/pb.go
+++ b/pdata/plog/pb.go
@@ -19,9 +19,9 @@ import (
 	otlplogs "go.opentelemetry.io/collector/pdata/internal/data/protogen/logs/v1"
 )
 
-// NewProtoMarshaler returns a MarshalSizer.
+// NewProtoMarshaler returns a MarshalerSizer.
 // Marshals to OTLP binary protobuf bytes and calculates the size of the marshaled Logs.
-func NewProtoMarshaler() MarshalSizer {
+func NewProtoMarshaler() MarshalerSizer {
 	return newPbMarshaler()
 }
 

--- a/pdata/plog/pb.go
+++ b/pdata/plog/pb.go
@@ -19,7 +19,7 @@ import (
 	otlplogs "go.opentelemetry.io/collector/pdata/internal/data/protogen/logs/v1"
 )
 
-// NewProtoMarshaler returns a Marshaler.
+// NewProtoMarshaler returns a MarshalSizer.
 // Marshals to OTLP binary protobuf bytes and calculates the size of the marshaled Logs.
 func NewProtoMarshaler() MarshalSizer {
 	return newPbMarshaler()

--- a/pdata/plog/pb.go
+++ b/pdata/plog/pb.go
@@ -24,7 +24,11 @@ func NewProtoMarshaler() Marshaler {
 	return newPbMarshaler()
 }
 
-// TODO(#3842): Figure out how we want to represent/return *Sizers.
+// NewProtoSizer returns a Sizer. Calculates the size of a marshaled Logs.
+func NewProtoSizer() Sizer {
+	return newPbMarshaler()
+}
+
 type pbMarshaler struct{}
 
 func newPbMarshaler() *pbMarshaler {

--- a/pdata/plog/pb_test.go
+++ b/pdata/plog/pb_test.go
@@ -31,7 +31,7 @@ func TestProtoLogsUnmarshaler_error(t *testing.T) {
 }
 
 func TestProtoSizer(t *testing.T) {
-	sizer := NewProtoMarshaler().(Sizer)
+	sizer := NewProtoSizer()
 	marshaler := NewProtoMarshaler()
 	ld := NewLogs()
 	ld.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords().AppendEmpty().SetSeverityText("error")

--- a/pdata/plog/pb_test.go
+++ b/pdata/plog/pb_test.go
@@ -31,12 +31,11 @@ func TestProtoLogsUnmarshaler_error(t *testing.T) {
 }
 
 func TestProtoSizer(t *testing.T) {
-	sizer := NewProtoSizer()
 	marshaler := NewProtoMarshaler()
 	ld := NewLogs()
 	ld.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords().AppendEmpty().SetSeverityText("error")
 
-	size := sizer.LogsSize(ld)
+	size := marshaler.LogsSize(ld)
 
 	bytes, err := marshaler.MarshalLogs(ld)
 	require.NoError(t, err)

--- a/pdata/pmetric/encoding.go
+++ b/pdata/pmetric/encoding.go
@@ -14,6 +14,12 @@
 
 package pmetric // import "go.opentelemetry.io/collector/pdata/pmetric"
 
+// MarshalSizer is the interface that groups the basic Marshal and Size methods
+type MarshalSizer interface {
+	Marshaler
+	Sizer
+}
+
 // Marshaler marshals pmetric.Metrics into bytes.
 type Marshaler interface {
 	// MarshalMetrics the given pmetric.Metrics into bytes.

--- a/pdata/pmetric/encoding.go
+++ b/pdata/pmetric/encoding.go
@@ -14,8 +14,8 @@
 
 package pmetric // import "go.opentelemetry.io/collector/pdata/pmetric"
 
-// MarshalSizer is the interface that groups the basic Marshal and Size methods
-type MarshalSizer interface {
+// MarshalerSizer is the interface that groups the basic Marshal and Size methods
+type MarshalerSizer interface {
 	Marshaler
 	Sizer
 }

--- a/pdata/pmetric/pb.go
+++ b/pdata/pmetric/pb.go
@@ -19,9 +19,9 @@ import (
 	otlpmetrics "go.opentelemetry.io/collector/pdata/internal/data/protogen/metrics/v1"
 )
 
-// NewProtoMarshaler returns a MarshalSizer.
+// NewProtoMarshaler returns a MarshalerSizer.
 // Marshals to OTLP binary protobuf bytes and calculates the size of the marshaled Metrics.
-func NewProtoMarshaler() MarshalSizer {
+func NewProtoMarshaler() MarshalerSizer {
 	return newPbMarshaler()
 }
 

--- a/pdata/pmetric/pb.go
+++ b/pdata/pmetric/pb.go
@@ -24,7 +24,11 @@ func NewProtoMarshaler() Marshaler {
 	return newPbMarshaler()
 }
 
-// TODO(#3842): Figure out how we want to represent/return *Sizers.
+// NewProtoSizer returns a Sizer. Calculates the size of a marshaled metrics.
+func NewProtoSizer() Sizer {
+	return newPbMarshaler()
+}
+
 type pbMarshaler struct{}
 
 func newPbMarshaler() *pbMarshaler {

--- a/pdata/pmetric/pb.go
+++ b/pdata/pmetric/pb.go
@@ -19,13 +19,9 @@ import (
 	otlpmetrics "go.opentelemetry.io/collector/pdata/internal/data/protogen/metrics/v1"
 )
 
-// NewProtoMarshaler returns a Marshaler. Marshals to OTLP binary protobuf bytes.
-func NewProtoMarshaler() Marshaler {
-	return newPbMarshaler()
-}
-
-// NewProtoSizer returns a Sizer. Calculates the size of a marshaled metrics.
-func NewProtoSizer() Sizer {
+// NewProtoMarshaler returns a Marshaler.
+// Marshals to OTLP binary protobuf bytes and calculates the size of the marshaled Metrics.
+func NewProtoMarshaler() MarshalSizer {
 	return newPbMarshaler()
 }
 

--- a/pdata/pmetric/pb.go
+++ b/pdata/pmetric/pb.go
@@ -19,7 +19,7 @@ import (
 	otlpmetrics "go.opentelemetry.io/collector/pdata/internal/data/protogen/metrics/v1"
 )
 
-// NewProtoMarshaler returns a Marshaler.
+// NewProtoMarshaler returns a MarshalSizer.
 // Marshals to OTLP binary protobuf bytes and calculates the size of the marshaled Metrics.
 func NewProtoMarshaler() MarshalSizer {
 	return newPbMarshaler()

--- a/pdata/pmetric/pb_test.go
+++ b/pdata/pmetric/pb_test.go
@@ -31,7 +31,7 @@ func TestProtoMetricsUnmarshaler_error(t *testing.T) {
 }
 
 func TestProtoSizer(t *testing.T) {
-	sizer := NewProtoMarshaler().(Sizer)
+	sizer := NewProtoSizer()
 	marshaler := NewProtoMarshaler()
 	md := NewMetrics()
 	md.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty().SetName("foo")

--- a/pdata/pmetric/pb_test.go
+++ b/pdata/pmetric/pb_test.go
@@ -31,12 +31,11 @@ func TestProtoMetricsUnmarshaler_error(t *testing.T) {
 }
 
 func TestProtoSizer(t *testing.T) {
-	sizer := NewProtoSizer()
 	marshaler := NewProtoMarshaler()
 	md := NewMetrics()
 	md.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty().SetName("foo")
 
-	size := sizer.MetricsSize(md)
+	size := marshaler.MetricsSize(md)
 
 	bytes, err := marshaler.MarshalMetrics(md)
 	require.NoError(t, err)

--- a/pdata/ptrace/encoding.go
+++ b/pdata/ptrace/encoding.go
@@ -14,6 +14,12 @@
 
 package ptrace // import "go.opentelemetry.io/collector/pdata/ptrace"
 
+// MarshalSizer is the interface that groups the basic Marshal and Size methods
+type MarshalSizer interface {
+	Marshaler
+	Sizer
+}
+
 // Marshaler marshals pdata.Traces into bytes.
 type Marshaler interface {
 	// MarshalTraces the given pdata.Traces into bytes.

--- a/pdata/ptrace/encoding.go
+++ b/pdata/ptrace/encoding.go
@@ -14,8 +14,8 @@
 
 package ptrace // import "go.opentelemetry.io/collector/pdata/ptrace"
 
-// MarshalSizer is the interface that groups the basic Marshal and Size methods
-type MarshalSizer interface {
+// MarshalerSizer is the interface that groups the basic Marshal and Size methods
+type MarshalerSizer interface {
 	Marshaler
 	Sizer
 }

--- a/pdata/ptrace/pb.go
+++ b/pdata/ptrace/pb.go
@@ -19,9 +19,9 @@ import (
 	otlptrace "go.opentelemetry.io/collector/pdata/internal/data/protogen/trace/v1"
 )
 
-// NewProtoMarshaler returns a MarshalSizer.
+// NewProtoMarshaler returns a MarshalerSizer.
 // Marshals to OTLP binary protobuf bytes and calculates the size of the marshaled Traces.
-func NewProtoMarshaler() MarshalSizer {
+func NewProtoMarshaler() MarshalerSizer {
 	return newPbMarshaler()
 }
 

--- a/pdata/ptrace/pb.go
+++ b/pdata/ptrace/pb.go
@@ -19,13 +19,9 @@ import (
 	otlptrace "go.opentelemetry.io/collector/pdata/internal/data/protogen/trace/v1"
 )
 
-// NewProtoMarshaler returns a Marshaler. Marshals to OTLP binary protobuf bytes.
-func NewProtoMarshaler() Marshaler {
-	return newPbMarshaler()
-}
-
-// NewProtoSizer returns a Sizer. Calculates the size of a marshaled Traces.
-func NewProtoSizer() Sizer {
+// NewProtoMarshaler returns a MarshalSizer.
+// Marshals to OTLP binary protobuf bytes and calculates the size of the marshaled Traces.
+func NewProtoMarshaler() MarshalSizer {
 	return newPbMarshaler()
 }
 

--- a/pdata/ptrace/pb.go
+++ b/pdata/ptrace/pb.go
@@ -24,7 +24,11 @@ func NewProtoMarshaler() Marshaler {
 	return newPbMarshaler()
 }
 
-// TODO(#3842): Figure out how we want to represent/return *Sizers.
+// NewProtoSizer returns a Sizer. Calculates the size of a marshaled Traces.
+func NewProtoSizer() Sizer {
+	return newPbMarshaler()
+}
+
 type pbMarshaler struct{}
 
 func newPbMarshaler() *pbMarshaler {

--- a/pdata/ptrace/pb_test.go
+++ b/pdata/ptrace/pb_test.go
@@ -31,13 +31,12 @@ func TestProtoTracesUnmarshaler_error(t *testing.T) {
 }
 
 func TestProtoSizer(t *testing.T) {
-	sizer := NewProtoSizer()
 	marshaler := NewProtoMarshaler()
 	td := NewTraces()
 	rms := td.ResourceSpans()
 	rms.AppendEmpty().ScopeSpans().AppendEmpty().Spans().AppendEmpty().SetName("foo")
 
-	size := sizer.TracesSize(td)
+	size := marshaler.TracesSize(td)
 
 	bytes, err := marshaler.MarshalTraces(td)
 	require.NoError(t, err)

--- a/pdata/ptrace/pb_test.go
+++ b/pdata/ptrace/pb_test.go
@@ -31,7 +31,7 @@ func TestProtoTracesUnmarshaler_error(t *testing.T) {
 }
 
 func TestProtoSizer(t *testing.T) {
-	sizer := NewProtoMarshaler().(Sizer)
+	sizer := NewProtoSizer()
 	marshaler := NewProtoMarshaler()
 	td := NewTraces()
 	rms := td.ResourceSpans()


### PR DESCRIPTION
**Description:**
Proposing adding a new `MarshalerSizer` interface to `ptrace`, `plog`, and `pmetric` packages and alter `NewProtoMarshaler` to return this interface. This allows easy creation of a `Sizer` implementation. Currently the only way to create a sizer for the `pdata` packages is to call `NewProtoMarshaler` function then cast to a `Sizer`. This is not intuitive from an API standpoint that it should be safe to cast a `Marshaler` as a `Sizer`. 

The `MarshalerSizer` interface is a combination of the `Marshaler` and `Sizer` interfaces.

If this is merged I will create a follow up PR to update the Batch Processor to use this rather than casting from a `Marshaler`.

**Link to tracking Issue:** #5920

**Testing:** Updated tests to use the `MarshalSizer` instead of casting.
