### PR TITLE
Deprecate for good the FlagsStruct types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@
 - Deprecate `exporterhelper.New[Traces|Metrics|Logs]ExporterWithContext` in favor of `exporterhelper.New[Traces|Metrics|Logs]Exporter` (#5914)
 - Deprecate `component.NewExtensionFactoryWithStabilityLevel` in favor of `component.NewExtensionFactory` (#5917)
 - Deprecate `plog.SeverityNumber[UPPERCASE]` constants (#5927)
+- Deprecate FlagsStruct types (#5933):
+  - `MetricDataPointFlagsStruct` -> `MetricDataPointFlags`
+  - `NewMetricDataPointFlagsStruct` -> `NewMetricDataPointFlags`
 
 ### 💡 Enhancements 💡
 
@@ -82,8 +85,6 @@
 - Deprecate `processorhelper.New[Traces|Metrics|Logs]Processor` in favor of `processorhelper.New[Traces|Metrics|Logs]ProcessorWithCreateSettings` (#5833)
 - Deprecate MetricDataPointFlags.String(), no other pdata flags have this method (#5868)
 - Deprecates `FlagsStruct` in favor of `Flags` (#5842)
-  - `MetricDataPointFlagsStruct` -> `MetricDataPointFlags`
-  - `NewMetricDataPointFlagsStruct` -> `NewMetricDataPointFlags`
   - `FlagsStruct` -> `Flags`
 - Deprecate `exporterhelper.New[Traces|Metrics|Logs]Exporter` in favor of `exporterhelper.New[Traces|Metrics|Logs]ExporterWithContext` (#5834)
 

--- a/pdata/pmetric/alias.go
+++ b/pdata/pmetric/alias.go
@@ -50,13 +50,10 @@ const (
 	MetricAggregationTemporalityCumulative = internal.MetricAggregationTemporalityCumulative
 )
 
-// MetricDataPointFlagsStruct defines how a metric aggregator reports aggregated values.
-// It describes how those values relate to the time interval over which they are aggregated.
-// Deprecated [0.58.0] Use MetricDataPointFlags instead
+// Deprecated: [0.59.0] Use MetricDataPointFlags instead
 type MetricDataPointFlagsStruct = MetricDataPointFlags
 
-// NewMetricDataPointFlagsStruct returns a new empty MetricDataPointFlagsStruct.
-// Deprecated [0.58.0] Use NewMetricDataPointFlags instead
+// Deprecated: [0.59.0] Use NewMetricDataPointFlags instead
 var NewMetricDataPointFlagsStruct = NewMetricDataPointFlags
 
 // MetricDataPointFlags defines how a metric aggregator reports aggregated values.


### PR DESCRIPTION
They cannot be removed, unless we apply an exception, since the Deprecation was not correctly marked in golang/godoc because of the missing ":".

Updates https://github.com/open-telemetry/opentelemetry-collector/issues/5443

Signed-off-by: Bogdan <bogdandrutu@gmail.com>
