### PR TITLE
Add an AsRaw func on the flags, lots of places to encode these flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - Add httpprovider to allow loading config files stored in HTTP (#5810)
 - Added `service.telemetry.traces.propagators` configuration to set propagators for collector's internal spans. (#5572)
 - Remove unnecessary duplicate code and allocations for reading enums in JSON. (#5928)
+- Add an AsRaw func on the flags, lots of places to encode these flags. (#5934)
 
 ### 🧰 Bug fixes 🧰
 

--- a/pdata/internal/logs.go
+++ b/pdata/internal/logs.go
@@ -185,3 +185,8 @@ func (ms LogRecordFlags) SetIsSampled(b bool) {
 		*ms.orig &^= isSampledMask
 	}
 }
+
+// AsRaw converts LogRecordFlags to the OTLP uint32 representation.
+func (ms LogRecordFlags) AsRaw() uint32 {
+	return *ms.orig
+}

--- a/pdata/internal/logs_test.go
+++ b/pdata/internal/logs_test.go
@@ -133,14 +133,17 @@ func TestLogsClone(t *testing.T) {
 func TestLogRecordFlags(t *testing.T) {
 	flags := generateTestLogRecordFlags()
 	assert.True(t, flags.IsSampled())
+	assert.Equal(t, uint32(1), flags.AsRaw())
 
 	flags.SetIsSampled(false)
 	flags.SetIsSampled(false)
 	assert.False(t, flags.IsSampled())
+	assert.Equal(t, uint32(0), flags.AsRaw())
 
 	flags.SetIsSampled(true)
 	flags.SetIsSampled(true)
 	assert.True(t, flags.IsSampled())
+	assert.Equal(t, uint32(1), flags.AsRaw())
 
 	moveFlags := NewLogRecordFlags()
 	assert.False(t, moveFlags.IsSampled())

--- a/pdata/internal/metrics.go
+++ b/pdata/internal/metrics.go
@@ -234,6 +234,11 @@ func (ms MetricDataPointFlags) SetNoRecordedValue(b bool) {
 	}
 }
 
+// AsRaw converts MetricDataPointFlags to the OTLP uint32 representation.
+func (ms MetricDataPointFlags) AsRaw() uint32 {
+	return *ms.orig
+}
+
 // NumberDataPointValueType specifies the type of NumberDataPoint value.
 type NumberDataPointValueType int32
 

--- a/pdata/internal/metrics_test.go
+++ b/pdata/internal/metrics_test.go
@@ -688,23 +688,34 @@ func TestMetricsClone(t *testing.T) {
 	assert.EqualValues(t, metrics, metrics.Clone())
 }
 
-func TestMetricsDataPointFlags(t *testing.T) {
-	gauge := generateTestGauge()
-	assert.False(t, gauge.DataPoints().At(0).Flags().NoRecordedValue())
+func TestMetricDataPointFlags(t *testing.T) {
+	flags := generateTestMetricDataPointFlags()
+	assert.False(t, flags.NoRecordedValue())
+	assert.Equal(t, uint32(0), flags.AsRaw())
+	flags.SetNoRecordedValue(true)
+	assert.True(t, flags.NoRecordedValue())
+	assert.Equal(t, uint32(1), flags.AsRaw())
 
-	gauge.DataPoints().At(1).Flags().SetNoRecordedValue(true)
-	assert.True(t, gauge.DataPoints().At(1).Flags().NoRecordedValue())
-	gauge.DataPoints().At(1).Flags().SetNoRecordedValue(false)
-	assert.False(t, gauge.DataPoints().At(1).Flags().NoRecordedValue())
+	flags.SetNoRecordedValue(false)
+	flags.SetNoRecordedValue(false)
+	assert.False(t, flags.NoRecordedValue())
+	assert.Equal(t, uint32(0), flags.AsRaw())
 
-	gauge.DataPoints().At(1).Flags().SetNoRecordedValue(true)
-	gauge.DataPoints().At(1).Flags().SetNoRecordedValue(true)
-	assert.True(t, gauge.DataPoints().At(1).Flags().NoRecordedValue())
+	flags.SetNoRecordedValue(true)
+	flags.SetNoRecordedValue(true)
+	assert.True(t, flags.NoRecordedValue())
+	assert.Equal(t, uint32(1), flags.AsRaw())
 
-	gauge.DataPoints().At(0).Flags().SetNoRecordedValue(true)
-	gauge.DataPoints().At(0).Flags().MoveTo(gauge.DataPoints().At(1).Flags())
-	assert.False(t, gauge.DataPoints().At(0).Flags().NoRecordedValue())
-	assert.True(t, gauge.DataPoints().At(1).Flags().NoRecordedValue())
+	moveFlags := NewMetricDataPointFlags()
+	assert.False(t, moveFlags.NoRecordedValue())
+
+	flags.MoveTo(moveFlags)
+	assert.False(t, flags.NoRecordedValue())
+	assert.True(t, moveFlags.NoRecordedValue())
+
+	moveFlags.CopyTo(flags)
+	assert.True(t, flags.NoRecordedValue())
+	assert.True(t, moveFlags.NoRecordedValue())
 }
 
 func BenchmarkMetricsClone(b *testing.B) {


### PR DESCRIPTION
- https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/pkg/telemetryquerylanguage/contexts/tqlmetrics/metrics.go#L614
- https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/metricstransformprocessor/operation_aggregate_labels.go#L196
- https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/pkg/stanza/adapter/frompdataconverter.go#L220
- https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/alibabacloudlogserviceexporter/logsdata_to_logservice.go#L174
- https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/tencentcloudlogserviceexporter/logsdata_to_logservice.go#L172

Signed-off-by: Bogdan <bogdandrutu@gmail.com>
