### PR TITLE
[obsreport] Replace Prometheus namespace with metrics prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### 🛑 Breaking changes 🛑
 
+- "otelcol" part of the exposed metrics that is set as Prometheus namespace is replaced the same explicit metrics prefix (#5939)
+  - This is potentially a breaking change for custom distributions that expose additional OpenCensus metrics. The
+    "otelcol/" prefix must be explicitly added to those metrics to get the same names as before this change.
 - Remove deprecated fields/funcs from `service` (#5907)
   - Remove `ConfigProviderSettings.Location`
   - Remove `ConfigProviderSettings.MapProviders`

--- a/exporter/exporterhelper/obsreport.go
+++ b/exporter/exporterhelper/obsreport.go
@@ -51,31 +51,31 @@ func newInstruments(registry *metric.Registry) *instruments {
 		registry: registry,
 	}
 	insts.queueSize, _ = registry.AddInt64DerivedGauge(
-		obsmetrics.ExporterKey+"/queue_size",
+		obsmetrics.ExporterPrefix+"queue_size",
 		metric.WithDescription("Current size of the retry queue (in batches)"),
 		metric.WithLabelKeys(obsmetrics.ExporterKey),
 		metric.WithUnit(metricdata.UnitDimensionless))
 
 	insts.queueCapacity, _ = registry.AddInt64DerivedGauge(
-		obsmetrics.ExporterKey+"/queue_capacity",
+		obsmetrics.ExporterPrefix+"queue_capacity",
 		metric.WithDescription("Fixed capacity of the retry queue (in batches)"),
 		metric.WithLabelKeys(obsmetrics.ExporterKey),
 		metric.WithUnit(metricdata.UnitDimensionless))
 
 	insts.failedToEnqueueTraceSpans, _ = registry.AddInt64Cumulative(
-		obsmetrics.ExporterKey+"/enqueue_failed_spans",
+		obsmetrics.ExporterPrefix+"enqueue_failed_spans",
 		metric.WithDescription("Number of spans failed to be added to the sending queue."),
 		metric.WithLabelKeys(obsmetrics.ExporterKey),
 		metric.WithUnit(metricdata.UnitDimensionless))
 
 	insts.failedToEnqueueMetricPoints, _ = registry.AddInt64Cumulative(
-		obsmetrics.ExporterKey+"/enqueue_failed_metric_points",
+		obsmetrics.ExporterPrefix+"enqueue_failed_metric_points",
 		metric.WithDescription("Number of metric points failed to be added to the sending queue."),
 		metric.WithLabelKeys(obsmetrics.ExporterKey),
 		metric.WithUnit(metricdata.UnitDimensionless))
 
 	insts.failedToEnqueueLogRecords, _ = registry.AddInt64Cumulative(
-		obsmetrics.ExporterKey+"/enqueue_failed_log_records",
+		obsmetrics.ExporterPrefix+"enqueue_failed_log_records",
 		metric.WithDescription("Number of log records failed to be added to the sending queue."),
 		metric.WithLabelKeys(obsmetrics.ExporterKey),
 		metric.WithUnit(metricdata.UnitDimensionless))

--- a/exporter/exporterhelper/queued_retry_test.go
+++ b/exporter/exporterhelper/queued_retry_test.go
@@ -346,14 +346,14 @@ func TestQueuedRetry_QueueMetricsReported(t *testing.T) {
 	be := newBaseExporter(&defaultExporterCfg, componenttest.NewNopExporterCreateSettings(), fromOptions(WithRetry(rCfg), WithQueue(qCfg)), "", nopRequestUnmarshaler())
 	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
 
-	checkValueForGlobalManager(t, defaultExporterTags, int64(5000), "exporter/queue_capacity")
+	checkValueForGlobalManager(t, defaultExporterTags, int64(5000), "otelcol/exporter/queue_capacity")
 	for i := 0; i < 7; i++ {
 		require.NoError(t, be.sender.send(newErrorRequest(context.Background())))
 	}
-	checkValueForGlobalManager(t, defaultExporterTags, int64(7), "exporter/queue_size")
+	checkValueForGlobalManager(t, defaultExporterTags, int64(7), "otelcol/exporter/queue_size")
 
 	assert.NoError(t, be.Shutdown(context.Background()))
-	checkValueForGlobalManager(t, defaultExporterTags, int64(0), "exporter/queue_size")
+	checkValueForGlobalManager(t, defaultExporterTags, int64(0), "otelcol/exporter/queue_size")
 }
 
 func TestNoCancellationContext(t *testing.T) {

--- a/internal/obsreportconfig/obsmetrics/obs_exporter.go
+++ b/internal/obsreportconfig/obsmetrics/obs_exporter.go
@@ -42,7 +42,7 @@ const (
 var (
 	TagKeyExporter, _ = tag.NewKey(ExporterKey)
 
-	ExporterPrefix                 = ExporterKey + NameSep
+	ExporterPrefix                 = Prefix + ExporterKey + NameSep
 	ExportTraceDataOperationSuffix = NameSep + "traces"
 	ExportMetricsOperationSuffix   = NameSep + "metrics"
 	ExportLogsOperationSuffix      = NameSep + "logs"

--- a/internal/obsreportconfig/obsmetrics/obs_processor.go
+++ b/internal/obsreportconfig/obsmetrics/obs_processor.go
@@ -36,7 +36,7 @@ const (
 var (
 	TagKeyProcessor, _ = tag.NewKey(ProcessorKey)
 
-	ProcessorPrefix = ProcessorKey + NameSep
+	ProcessorPrefix = Prefix + ProcessorKey + NameSep
 
 	// Processor metrics. Any count of data items below is in the internal format
 	// of the collector since processors only deal with internal format.

--- a/internal/obsreportconfig/obsmetrics/obs_receiver.go
+++ b/internal/obsreportconfig/obsmetrics/obs_receiver.go
@@ -49,7 +49,7 @@ var (
 	TagKeyReceiver, _  = tag.NewKey(ReceiverKey)
 	TagKeyTransport, _ = tag.NewKey(TransportKey)
 
-	ReceiverPrefix                  = ReceiverKey + NameSep
+	ReceiverPrefix                  = Prefix + ReceiverKey + NameSep
 	ReceiveTraceDataOperationSuffix = NameSep + "TraceDataReceived"
 	ReceiverMetricsOperationSuffix  = NameSep + "MetricsReceived"
 	ReceiverLogsOperationSuffix     = NameSep + "LogsReceived"

--- a/internal/obsreportconfig/obsmetrics/obs_scraper.go
+++ b/internal/obsreportconfig/obsmetrics/obs_scraper.go
@@ -32,7 +32,7 @@ const (
 )
 
 const (
-	ScraperPrefix                 = ScraperKey + NameSep
+	ScraperPrefix                 = Prefix + ScraperKey + NameSep
 	ScraperMetricsOperationSuffix = NameSep + "MetricsScraped"
 )
 

--- a/internal/obsreportconfig/obsmetrics/obsmetrics.go
+++ b/internal/obsreportconfig/obsmetrics/obsmetrics.go
@@ -19,4 +19,5 @@ package obsmetrics // import "go.opentelemetry.io/collector/internal/obsreportco
 
 const (
 	NameSep = "/"
+	Prefix  = "otelcol" + NameSep
 )

--- a/obsreport/obsreport_exporter.go
+++ b/obsreport/obsreport_exporter.go
@@ -46,7 +46,7 @@ type ExporterSettings struct {
 func NewExporter(cfg ExporterSettings) *Exporter {
 	return &Exporter{
 		level:          cfg.ExporterCreateSettings.TelemetrySettings.MetricsLevel,
-		spanNamePrefix: obsmetrics.ExporterPrefix + cfg.ExporterID.String(),
+		spanNamePrefix: obsmetrics.ExporterKey + obsmetrics.NameSep + cfg.ExporterID.String(),
 		mutators:       []tag.Mutator{tag.Upsert(obsmetrics.TagKeyExporter, cfg.ExporterID.String(), tag.WithTTL(tag.TTLNoPropagation))},
 		tracer:         cfg.ExporterCreateSettings.TracerProvider.Tracer(cfg.ExporterID.String()),
 	}

--- a/obsreport/obsreport_receiver.go
+++ b/obsreport/obsreport_receiver.go
@@ -55,7 +55,7 @@ type ReceiverSettings struct {
 func NewReceiver(cfg ReceiverSettings) *Receiver {
 	return &Receiver{
 		level:          cfg.ReceiverCreateSettings.TelemetrySettings.MetricsLevel,
-		spanNamePrefix: obsmetrics.ReceiverPrefix + cfg.ReceiverID.String(),
+		spanNamePrefix: obsmetrics.ReceiverKey + obsmetrics.NameSep + cfg.ReceiverID.String(),
 		transport:      cfg.Transport,
 		longLivedCtx:   cfg.LongLivedCtx,
 		mutators: []tag.Mutator{

--- a/obsreport/obsreport_scraper.go
+++ b/obsreport/obsreport_scraper.go
@@ -65,7 +65,7 @@ func NewScraper(cfg ScraperSettings) *Scraper {
 func (s *Scraper) StartMetricsOp(ctx context.Context) context.Context {
 	ctx, _ = tag.New(ctx, s.mutators...)
 
-	spanName := obsmetrics.ScraperPrefix + s.receiverID.String() + obsmetrics.NameSep + s.scraper.String() + obsmetrics.ScraperMetricsOperationSuffix
+	spanName := obsmetrics.ScraperKey + obsmetrics.NameSep + s.receiverID.String() + obsmetrics.NameSep + s.scraper.String() + obsmetrics.ScraperMetricsOperationSuffix
 	ctx, _ = s.tracer.Start(ctx, spanName)
 	return ctx
 }

--- a/obsreport/obsreport_test.go
+++ b/obsreport/obsreport_test.go
@@ -502,11 +502,11 @@ func TestBuildProcessorCustomMetricName(t *testing.T) {
 	}{
 		{
 			name: "firstMeasure",
-			want: "processor/test_type/firstMeasure",
+			want: "otelcol/processor/test_type/firstMeasure",
 		},
 		{
 			name: "secondMeasure",
-			want: "processor/test_type/secondMeasure",
+			want: "otelcol/processor/test_type/secondMeasure",
 		},
 	}
 	for _, tt := range tests {

--- a/obsreport/obsreporttest/obsreporttest.go
+++ b/obsreport/obsreporttest/obsreporttest.go
@@ -108,10 +108,10 @@ func CheckExporterTraces(_ TestTelemetry, exporter config.ComponentID, sentSpans
 	exporterTags := tagsForExporterView(exporter)
 	if sendFailedSpans > 0 {
 		return multierr.Combine(
-			checkValueForView(exporterTags, sentSpans, "exporter/sent_spans"),
-			checkValueForView(exporterTags, sendFailedSpans, "exporter/send_failed_spans"))
+			checkValueForView(exporterTags, sentSpans, "otelcol/exporter/sent_spans"),
+			checkValueForView(exporterTags, sendFailedSpans, "otelcol/exporter/send_failed_spans"))
 	}
-	return checkValueForView(exporterTags, sentSpans, "exporter/sent_spans")
+	return checkValueForView(exporterTags, sentSpans, "otelcol/exporter/sent_spans")
 }
 
 // CheckExporterMetrics checks that for the current exported values for metrics exporter metrics match given values.
@@ -120,10 +120,10 @@ func CheckExporterMetrics(_ TestTelemetry, exporter config.ComponentID, sentMetr
 	exporterTags := tagsForExporterView(exporter)
 	if sendFailedMetricsPoints > 0 {
 		return multierr.Combine(
-			checkValueForView(exporterTags, sentMetricsPoints, "exporter/sent_metric_points"),
-			checkValueForView(exporterTags, sendFailedMetricsPoints, "exporter/send_failed_metric_points"))
+			checkValueForView(exporterTags, sentMetricsPoints, "otelcol/exporter/sent_metric_points"),
+			checkValueForView(exporterTags, sendFailedMetricsPoints, "otelcol/exporter/send_failed_metric_points"))
 	}
-	return checkValueForView(exporterTags, sentMetricsPoints, "exporter/sent_metric_points")
+	return checkValueForView(exporterTags, sentMetricsPoints, "otelcol/exporter/sent_metric_points")
 }
 
 // CheckExporterLogs checks that for the current exported values for logs exporter metrics match given values.
@@ -132,10 +132,10 @@ func CheckExporterLogs(_ TestTelemetry, exporter config.ComponentID, sentLogReco
 	exporterTags := tagsForExporterView(exporter)
 	if sendFailedLogRecords > 0 {
 		return multierr.Combine(
-			checkValueForView(exporterTags, sentLogRecords, "exporter/sent_log_records"),
-			checkValueForView(exporterTags, sendFailedLogRecords, "exporter/send_failed_log_records"))
+			checkValueForView(exporterTags, sentLogRecords, "otelcol/exporter/sent_log_records"),
+			checkValueForView(exporterTags, sendFailedLogRecords, "otelcol/exporter/send_failed_log_records"))
 	}
-	return checkValueForView(exporterTags, sentLogRecords, "exporter/sent_log_records")
+	return checkValueForView(exporterTags, sentLogRecords, "otelcol/exporter/sent_log_records")
 }
 
 // CheckProcessorTraces checks that for the current exported values for trace exporter metrics match given values.
@@ -143,9 +143,9 @@ func CheckExporterLogs(_ TestTelemetry, exporter config.ComponentID, sentLogReco
 func CheckProcessorTraces(_ TestTelemetry, processor config.ComponentID, acceptedSpans, refusedSpans, droppedSpans int64) error {
 	processorTags := tagsForProcessorView(processor)
 	return multierr.Combine(
-		checkValueForView(processorTags, acceptedSpans, "processor/accepted_spans"),
-		checkValueForView(processorTags, refusedSpans, "processor/refused_spans"),
-		checkValueForView(processorTags, droppedSpans, "processor/dropped_spans"))
+		checkValueForView(processorTags, acceptedSpans, "otelcol/processor/accepted_spans"),
+		checkValueForView(processorTags, refusedSpans, "otelcol/processor/refused_spans"),
+		checkValueForView(processorTags, droppedSpans, "otelcol/processor/dropped_spans"))
 }
 
 // CheckProcessorMetrics checks that for the current exported values for metrics exporter metrics match given values.
@@ -153,9 +153,9 @@ func CheckProcessorTraces(_ TestTelemetry, processor config.ComponentID, accepte
 func CheckProcessorMetrics(_ TestTelemetry, processor config.ComponentID, acceptedMetricPoints, refusedMetricPoints, droppedMetricPoints int64) error {
 	processorTags := tagsForProcessorView(processor)
 	return multierr.Combine(
-		checkValueForView(processorTags, acceptedMetricPoints, "processor/accepted_metric_points"),
-		checkValueForView(processorTags, refusedMetricPoints, "processor/refused_metric_points"),
-		checkValueForView(processorTags, droppedMetricPoints, "processor/dropped_metric_points"))
+		checkValueForView(processorTags, acceptedMetricPoints, "otelcol/processor/accepted_metric_points"),
+		checkValueForView(processorTags, refusedMetricPoints, "otelcol/processor/refused_metric_points"),
+		checkValueForView(processorTags, droppedMetricPoints, "otelcol/processor/dropped_metric_points"))
 }
 
 // CheckProcessorLogs checks that for the current exported values for logs exporter metrics match given values.
@@ -163,9 +163,9 @@ func CheckProcessorMetrics(_ TestTelemetry, processor config.ComponentID, accept
 func CheckProcessorLogs(_ TestTelemetry, processor config.ComponentID, acceptedLogRecords, refusedLogRecords, droppedLogRecords int64) error {
 	processorTags := tagsForProcessorView(processor)
 	return multierr.Combine(
-		checkValueForView(processorTags, acceptedLogRecords, "processor/accepted_log_records"),
-		checkValueForView(processorTags, refusedLogRecords, "processor/refused_log_records"),
-		checkValueForView(processorTags, droppedLogRecords, "processor/dropped_log_records"))
+		checkValueForView(processorTags, acceptedLogRecords, "otelcol/processor/accepted_log_records"),
+		checkValueForView(processorTags, refusedLogRecords, "otelcol/processor/refused_log_records"),
+		checkValueForView(processorTags, droppedLogRecords, "otelcol/processor/dropped_log_records"))
 }
 
 // CheckReceiverTraces checks that for the current exported values for trace receiver metrics match given values.
@@ -173,8 +173,8 @@ func CheckProcessorLogs(_ TestTelemetry, processor config.ComponentID, acceptedL
 func CheckReceiverTraces(_ TestTelemetry, receiver config.ComponentID, protocol string, acceptedSpans, droppedSpans int64) error {
 	receiverTags := tagsForReceiverView(receiver, protocol)
 	return multierr.Combine(
-		checkValueForView(receiverTags, acceptedSpans, "receiver/accepted_spans"),
-		checkValueForView(receiverTags, droppedSpans, "receiver/refused_spans"))
+		checkValueForView(receiverTags, acceptedSpans, "otelcol/receiver/accepted_spans"),
+		checkValueForView(receiverTags, droppedSpans, "otelcol/receiver/refused_spans"))
 }
 
 // CheckReceiverLogs checks that for the current exported values for logs receiver metrics match given values.
@@ -182,8 +182,8 @@ func CheckReceiverTraces(_ TestTelemetry, receiver config.ComponentID, protocol 
 func CheckReceiverLogs(_ TestTelemetry, receiver config.ComponentID, protocol string, acceptedLogRecords, droppedLogRecords int64) error {
 	receiverTags := tagsForReceiverView(receiver, protocol)
 	return multierr.Combine(
-		checkValueForView(receiverTags, acceptedLogRecords, "receiver/accepted_log_records"),
-		checkValueForView(receiverTags, droppedLogRecords, "receiver/refused_log_records"))
+		checkValueForView(receiverTags, acceptedLogRecords, "otelcol/receiver/accepted_log_records"),
+		checkValueForView(receiverTags, droppedLogRecords, "otelcol/receiver/refused_log_records"))
 }
 
 // CheckReceiverMetrics checks that for the current exported values for metrics receiver metrics match given values.
@@ -191,8 +191,8 @@ func CheckReceiverLogs(_ TestTelemetry, receiver config.ComponentID, protocol st
 func CheckReceiverMetrics(_ TestTelemetry, receiver config.ComponentID, protocol string, acceptedMetricPoints, droppedMetricPoints int64) error {
 	receiverTags := tagsForReceiverView(receiver, protocol)
 	return multierr.Combine(
-		checkValueForView(receiverTags, acceptedMetricPoints, "receiver/accepted_metric_points"),
-		checkValueForView(receiverTags, droppedMetricPoints, "receiver/refused_metric_points"))
+		checkValueForView(receiverTags, acceptedMetricPoints, "otelcol/receiver/accepted_metric_points"),
+		checkValueForView(receiverTags, droppedMetricPoints, "otelcol/receiver/refused_metric_points"))
 }
 
 // CheckScraperMetrics checks that for the current exported values for metrics scraper metrics match given values.
@@ -200,8 +200,8 @@ func CheckReceiverMetrics(_ TestTelemetry, receiver config.ComponentID, protocol
 func CheckScraperMetrics(_ TestTelemetry, receiver config.ComponentID, scraper config.ComponentID, scrapedMetricPoints, erroredMetricPoints int64) error {
 	scraperTags := tagsForScraperView(receiver, scraper)
 	return multierr.Combine(
-		checkValueForView(scraperTags, scrapedMetricPoints, "scraper/scraped_metric_points"),
-		checkValueForView(scraperTags, erroredMetricPoints, "scraper/errored_metric_points"))
+		checkValueForView(scraperTags, scrapedMetricPoints, "otelcol/scraper/scraped_metric_points"),
+		checkValueForView(scraperTags, erroredMetricPoints, "otelcol/scraper/errored_metric_points"))
 }
 
 // checkValueForView checks that for the current exported value in the view with the given name

--- a/processor/batchprocessor/batch_processor_test.go
+++ b/processor/batchprocessor/batch_processor_test.go
@@ -167,7 +167,7 @@ func TestBatchProcessorSentBySize(t *testing.T) {
 		}
 	}
 
-	viewData, err := view.RetrieveData("processor/batch/" + statBatchSendSize.Name())
+	viewData, err := view.RetrieveData("otelcol/processor/batch/" + statBatchSendSize.Name())
 	require.NoError(t, err)
 	assert.Equal(t, 1, len(viewData))
 	distData := viewData[0].Data.(*view.DistributionData)
@@ -176,7 +176,7 @@ func TestBatchProcessorSentBySize(t *testing.T) {
 	assert.Equal(t, sendBatchSize, int(distData.Min))
 	assert.Equal(t, sendBatchSize, int(distData.Max))
 
-	viewData, err = view.RetrieveData("processor/batch/" + statBatchSendSizeBytes.Name())
+	viewData, err = view.RetrieveData("otelcol/processor/batch/" + statBatchSendSizeBytes.Name())
 	require.NoError(t, err)
 	assert.Equal(t, 1, len(viewData))
 	distData = viewData[0].Data.(*view.DistributionData)
@@ -223,7 +223,7 @@ func TestBatchProcessorSentBySize_withMaxSize(t *testing.T) {
 	receivedTraces := sink.AllTraces()
 	require.EqualValues(t, expectedBatchesNum, len(receivedTraces))
 
-	viewData, err := view.RetrieveData("processor/batch/" + statBatchSendSize.Name())
+	viewData, err := view.RetrieveData("otelcol/processor/batch/" + statBatchSendSize.Name())
 	require.NoError(t, err)
 	assert.Equal(t, 1, len(viewData))
 	distData := viewData[0].Data.(*view.DistributionData)
@@ -408,7 +408,7 @@ func TestBatchMetricProcessor_BatchSize(t *testing.T) {
 		}
 	}
 
-	viewData, err := view.RetrieveData("processor/batch/" + statBatchSendSize.Name())
+	viewData, err := view.RetrieveData("otelcol/processor/batch/" + statBatchSendSize.Name())
 	require.NoError(t, err)
 	assert.Equal(t, 1, len(viewData))
 	distData := viewData[0].Data.(*view.DistributionData)
@@ -417,7 +417,7 @@ func TestBatchMetricProcessor_BatchSize(t *testing.T) {
 	assert.Equal(t, cfg.SendBatchSize, uint32(distData.Min))
 	assert.Equal(t, cfg.SendBatchSize, uint32(distData.Max))
 
-	viewData, err = view.RetrieveData("processor/batch/" + statBatchSendSizeBytes.Name())
+	viewData, err = view.RetrieveData("otelcol/processor/batch/" + statBatchSendSizeBytes.Name())
 	require.NoError(t, err)
 	assert.Equal(t, 1, len(viewData))
 	distData = viewData[0].Data.(*view.DistributionData)
@@ -724,7 +724,7 @@ func TestBatchLogProcessor_BatchSize(t *testing.T) {
 		}
 	}
 
-	viewData, err := view.RetrieveData("processor/batch/" + statBatchSendSize.Name())
+	viewData, err := view.RetrieveData("otelcol/processor/batch/" + statBatchSendSize.Name())
 	require.NoError(t, err)
 	assert.Equal(t, 1, len(viewData))
 	distData := viewData[0].Data.(*view.DistributionData)
@@ -733,7 +733,7 @@ func TestBatchLogProcessor_BatchSize(t *testing.T) {
 	assert.Equal(t, cfg.SendBatchSize, uint32(distData.Min))
 	assert.Equal(t, cfg.SendBatchSize, uint32(distData.Max))
 
-	viewData, err = view.RetrieveData("processor/batch/" + statBatchSendSizeBytes.Name())
+	viewData, err = view.RetrieveData("otelcol/processor/batch/" + statBatchSendSizeBytes.Name())
 	require.NoError(t, err)
 	assert.Equal(t, 1, len(viewData))
 	distData = viewData[0].Data.(*view.DistributionData)

--- a/processor/batchprocessor/metrics_test.go
+++ b/processor/batchprocessor/metrics_test.go
@@ -29,6 +29,6 @@ func TestBatchProcessorMetrics(t *testing.T) {
 	}
 	views := MetricViews()
 	for i, viewName := range viewNames {
-		assert.Equal(t, "processor/batch/"+viewName, views[i].Name)
+		assert.Equal(t, "otelcol/processor/batch/"+viewName, views[i].Name)
 	}
 }

--- a/service/internal/telemetry/process_telemetry.go
+++ b/service/internal/telemetry/process_telemetry.go
@@ -23,7 +23,11 @@ import (
 	"github.com/shirou/gopsutil/v3/process"
 	"go.opencensus.io/metric"
 	"go.opencensus.io/stats"
+
+	"go.opentelemetry.io/collector/internal/obsreportconfig/obsmetrics"
 )
+
+const processMetricsPrefix = obsmetrics.Prefix + "process" + obsmetrics.NameSep
 
 // processMetrics is a struct that contains views related to process metrics (cpu, mem, etc)
 type processMetrics struct {
@@ -59,7 +63,7 @@ func RegisterProcessMetrics(registry *metric.Registry, ballastSizeBytes uint64) 
 	}
 
 	pm.processUptime, err = registry.AddFloat64DerivedCumulative(
-		"process/uptime",
+		processMetricsPrefix+"uptime",
 		metric.WithDescription("Uptime of the process"),
 		metric.WithUnit(stats.UnitSeconds))
 	if err != nil {
@@ -70,7 +74,7 @@ func RegisterProcessMetrics(registry *metric.Registry, ballastSizeBytes uint64) 
 	}
 
 	pm.allocMem, err = registry.AddInt64DerivedGauge(
-		"process/runtime/heap_alloc_bytes",
+		processMetricsPrefix+"runtime/heap_alloc_bytes",
 		metric.WithDescription("Bytes of allocated heap objects (see 'go doc runtime.MemStats.HeapAlloc')"),
 		metric.WithUnit(stats.UnitBytes))
 	if err != nil {
@@ -81,7 +85,7 @@ func RegisterProcessMetrics(registry *metric.Registry, ballastSizeBytes uint64) 
 	}
 
 	pm.totalAllocMem, err = registry.AddInt64DerivedCumulative(
-		"process/runtime/total_alloc_bytes",
+		processMetricsPrefix+"runtime/total_alloc_bytes",
 		metric.WithDescription("Cumulative bytes allocated for heap objects (see 'go doc runtime.MemStats.TotalAlloc')"),
 		metric.WithUnit(stats.UnitBytes))
 	if err != nil {
@@ -92,7 +96,7 @@ func RegisterProcessMetrics(registry *metric.Registry, ballastSizeBytes uint64) 
 	}
 
 	pm.sysMem, err = registry.AddInt64DerivedGauge(
-		"process/runtime/total_sys_memory_bytes",
+		processMetricsPrefix+"runtime/total_sys_memory_bytes",
 		metric.WithDescription("Total bytes of memory obtained from the OS (see 'go doc runtime.MemStats.Sys')"),
 		metric.WithUnit(stats.UnitBytes))
 	if err != nil {
@@ -103,7 +107,7 @@ func RegisterProcessMetrics(registry *metric.Registry, ballastSizeBytes uint64) 
 	}
 
 	pm.cpuSeconds, err = registry.AddFloat64DerivedCumulative(
-		"process/cpu_seconds",
+		processMetricsPrefix+"cpu_seconds",
 		metric.WithDescription("Total CPU user and system time in seconds"),
 		metric.WithUnit(stats.UnitSeconds))
 	if err != nil {
@@ -114,7 +118,7 @@ func RegisterProcessMetrics(registry *metric.Registry, ballastSizeBytes uint64) 
 	}
 
 	pm.rssMemory, err = registry.AddInt64DerivedGauge(
-		"process/memory/rss",
+		processMetricsPrefix+"memory/rss",
 		metric.WithDescription("Total physical memory (resident set size)"),
 		metric.WithUnit(stats.UnitBytes))
 	if err != nil {

--- a/service/internal/telemetry/process_telemetry_test.go
+++ b/service/internal/telemetry/process_telemetry_test.go
@@ -28,12 +28,12 @@ var expectedMetrics = []string{
 	// Changing a metric name is a breaking change.
 	// Adding new metrics is ok as long it follows the conventions described at
 	// https://pkg.go.dev/go.opentelemetry.io/collector/obsreport?tab=doc#hdr-Naming_Convention_for_New_Metrics
-	"process/uptime",
-	"process/runtime/heap_alloc_bytes",
-	"process/runtime/total_alloc_bytes",
-	"process/runtime/total_sys_memory_bytes",
-	"process/cpu_seconds",
-	"process/memory/rss",
+	"otelcol/process/uptime",
+	"otelcol/process/runtime/heap_alloc_bytes",
+	"otelcol/process/runtime/total_alloc_bytes",
+	"otelcol/process/runtime/total_sys_memory_bytes",
+	"otelcol/process/cpu_seconds",
+	"otelcol/process/memory/rss",
 }
 
 func TestProcessTelemetry(t *testing.T) {
@@ -54,13 +54,13 @@ func TestProcessTelemetry(t *testing.T) {
 		require.Len(t, ts.Points, 1)
 
 		var value float64
-		if metricName == "process/uptime" || metricName == "process/cpu_seconds" {
+		if metricName == "otelcol/process/uptime" || metricName == "otelcol/process/cpu_seconds" {
 			value = ts.Points[0].Value.(float64)
 		} else {
 			value = float64(ts.Points[0].Value.(int64))
 		}
 
-		if metricName == "process/uptime" || metricName == "process/cpu_seconds" {
+		if metricName == "otelcol/process/uptime" || metricName == "otelcol/process/cpu_seconds" {
 			// This likely will still be zero when running the test.
 			assert.True(t, value >= 0, metricName)
 			continue

--- a/service/telemetry.go
+++ b/service/telemetry.go
@@ -191,9 +191,7 @@ func (tel *telemetryInitializer) initOpenCensus(cfg telemetry.Config, telAttrs m
 	}
 
 	// Until we can use a generic metrics exporter, default to Prometheus.
-	opts := prometheus.Options{
-		Namespace: "otelcol",
-	}
+	opts := prometheus.Options{}
 
 	opts.ConstLabels = make(map[string]string)
 


### PR DESCRIPTION
"otelcol" part of the exposed metrics that is set as Prometheus namespace is replaced the same explicit metrics prefix. This change brings names consistency between metrics that can be reported with enabled or disabled "telemetry.useOtelForInternalMetrics" feature gate.

Resolves https://github.com/open-telemetry/opentelemetry-collector/issues/5882