### PR TITLE
Watch for config file changes in fileprovider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 - Remove unnecessary duplicate code and allocations for reading enums in JSON. (#5928)
 - Add "dist.build_tags" configuration option to support passing go build flags to builder. (#5659)
 - Add an AsRaw func on the flags, lots of places to encode these flags. (#5934)
+- Watch for config file changes in fileprovider (#5945)
 
 ### 🧰 Bug fixes 🧰
 

--- a/confmap/provider/fileprovider/filewatcher.go
+++ b/confmap/provider/fileprovider/filewatcher.go
@@ -1,0 +1,175 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fileprovider // import "go.opentelemetry.io/collector/confmap/provider/fileprovider"
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"os"
+	"sync"
+	"time"
+
+	"go.uber.org/atomic"
+
+	"go.opentelemetry.io/collector/confmap"
+)
+
+// pollingFileWatcher watches for changes to a file and delivers change events for each one
+// It keeps track of the state of the watched file in a simple polling loop
+//
+// The implementation intentionally doesn't use notification mechanisms provided by the OS
+// such as inotify. The reasons for this choice are:
+//
+//   - Reliability
+//     Inotify and similar mechanisms don't work in some circumstances, and require hacky workarounds
+//     in others. Problematic cases include Kubernetes ConfigMaps and network filesystems in general.
+//   - Simplicity
+//     A poll is easy to understand and only uses very basic OS filesystem features.
+//   - The advantages of inotify, like performance and the ability to watch whole folders for changes,
+//     are irrelevant here. We're only watching a single small file, and we don't need high update
+//     frequency.
+
+type pollingFileWatcher struct {
+	Events          chan *confmap.ChangeEvent
+	pollInterval    time.Duration
+	filePath        string
+	fileFingerprint []byte
+	fileInfo        os.FileInfo
+	running         atomic.Bool // this is here to make Close() idempotent and safe to call multiple times
+	closeCh         chan struct{}
+	wg              sync.WaitGroup
+}
+
+func newPollingFileWatcher(filePath string, pollInterval time.Duration) *pollingFileWatcher {
+	return &pollingFileWatcher{
+		filePath:     filePath,
+		pollInterval: pollInterval,
+	}
+}
+
+// Start starts the watcher. It's safe to call multiple times - it's a noop if the watcher is already
+// running. It is, however, not thread-safe.
+func (fw *pollingFileWatcher) Start() error {
+	var err error
+
+	if fw.running.Load() {
+		return nil
+	}
+
+	fw.fileInfo, err = os.Stat(fw.filePath)
+	if err != nil {
+		return err
+	}
+
+	fileContent, err := os.ReadFile(fw.filePath)
+	if err != nil {
+		return err
+	}
+
+	fw.fileFingerprint = calculateFingerprint(fileContent)
+
+	fw.closeCh = make(chan struct{})
+	fw.Events = make(chan *confmap.ChangeEvent)
+
+	fw.wg.Add(1)
+	go func() {
+		defer fw.wg.Done()
+		fw.startWatchLoop()
+	}()
+
+	fw.running.Store(true)
+
+	return nil
+}
+
+// startWatchLoop starts the watch loop, which checks for changes to the file every poll interval
+// and emits events if needed
+// returns after closeCh is closed or after the context is cancelled
+func (fw *pollingFileWatcher) startWatchLoop() {
+	ticker := time.NewTicker(fw.pollInterval)
+	for {
+		select {
+		case <-ticker.C:
+			changeEvent := fw.checkFileForChanges()
+			if changeEvent != nil {
+				fw.sendEvent(changeEvent)
+			}
+		case _, ok := <-fw.closeCh:
+			if !ok {
+				return
+			}
+		}
+
+	}
+}
+
+func (fw *pollingFileWatcher) sendEvent(event *confmap.ChangeEvent) {
+	select {
+	case fw.Events <- event:
+	case _, ok := <-fw.closeCh:
+		if !ok {
+			return
+		}
+	}
+}
+
+// checkFileForChanges checks if the watched file changed since the previous check and returns an appropriate
+// ChangeEvent if it did, and nil if no changes were detected
+func (fw *pollingFileWatcher) checkFileForChanges() *confmap.ChangeEvent {
+	// check fileinfo first, it's cheaper than reading the content
+	fileInfo, err := os.Stat(fw.filePath)
+	if err != nil {
+		return &confmap.ChangeEvent{Error: err}
+	}
+	if metadataEqual(fileInfo, fw.fileInfo) {
+		return nil
+	}
+	fw.fileInfo = fileInfo
+
+	fileContent, err := os.ReadFile(fw.filePath)
+	if err != nil {
+		return &confmap.ChangeEvent{Error: err}
+	}
+
+	// check fingerprints
+	currentFingerprint := calculateFingerprint(fileContent)
+	if bytes.Equal(fw.fileFingerprint, currentFingerprint) {
+		return nil
+	}
+	fw.fileFingerprint = currentFingerprint
+
+	return &confmap.ChangeEvent{}
+}
+
+// Close stops the watcher. It's thread-safe and can be safely called multiple times.
+func (fw *pollingFileWatcher) Close() {
+	if !fw.running.CompareAndSwap(true, false) { // this is here to make it safe to call Close multiple times
+		return
+	}
+	close(fw.closeCh)
+	fw.wg.Wait()
+	close(fw.Events)
+}
+
+// calculateFingerprint calculates the fingerprint used to check for file changes
+func calculateFingerprint(content []byte) []byte {
+	hash := sha256.New()
+	hash.Write(content)
+	return hash.Sum(nil)
+}
+
+func metadataEqual(first os.FileInfo, second os.FileInfo) bool {
+	return first.Size() == second.Size() && first.ModTime() == second.ModTime()
+}

--- a/confmap/provider/fileprovider/filewatcher_test.go
+++ b/confmap/provider/fileprovider/filewatcher_test.go
@@ -1,0 +1,188 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fileprovider
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/collector/confmap"
+)
+
+func TestStartClose(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "*")
+	require.NoError(t, err)
+	defer f.Close()
+	watcher := newPollingFileWatcher(f.Name(), time.Second)
+
+	// start and then close
+	assert.NoError(t, watcher.Start())
+	watcher.Close()
+
+	// start again twice
+	assert.NoError(t, watcher.Start())
+	assert.NoError(t, watcher.Start())
+
+	// and then close again twice
+	watcher.Close()
+	watcher.Close()
+}
+
+func TestCloseEvenIfBlockedOnEventChannel(t *testing.T) {
+	pollInterval := time.Millisecond
+	fileContent := "content"
+	f, err := os.CreateTemp(t.TempDir(), "*")
+	require.NoError(t, err)
+	defer f.Close()
+	_, err = f.WriteString(fileContent)
+	require.NoError(t, err)
+
+	watcher := newPollingFileWatcher(f.Name(), pollInterval)
+	require.NoError(t, watcher.Start())
+
+	// write to the file, we should get an event, but we don't receive it, and just close the watcher
+	_, err = f.WriteString("\n")
+	require.NoError(t, err)
+	time.Sleep(pollInterval * 2)
+	watcher.Close()
+}
+
+func TestNoFile(t *testing.T) {
+	watcher := newPollingFileWatcher(filepath.Join(t.TempDir(), "nonexistent"), time.Second)
+
+	// start returns an error
+	assert.Error(t, watcher.Start())
+}
+
+func TestNoEventsIfNoChanges(t *testing.T) {
+	pollInterval := time.Millisecond
+	fileContent := "content"
+	f, err := os.CreateTemp(t.TempDir(), "*")
+	require.NoError(t, err)
+	defer f.Close()
+	_, err = f.WriteString(fileContent)
+	require.NoError(t, err)
+
+	watcher := newPollingFileWatcher(f.Name(), pollInterval)
+	require.NoError(t, watcher.Start())
+	defer watcher.Close()
+	assert.Nil(t, getEventWithTimeout(watcher.Events, pollInterval*2))
+
+	// change the access times, this doesn't change the content, but does change the metadata
+	require.NoError(t, os.Chtimes(f.Name(), time.Now(), time.Now()))
+	assert.Nil(t, getEventWithTimeout(watcher.Events, pollInterval*2))
+}
+
+func TestEventIfFileContentChanged(t *testing.T) {
+	pollInterval := time.Millisecond
+	fileContent := "content"
+	f, err := os.CreateTemp(t.TempDir(), "*")
+	require.NoError(t, err)
+	defer f.Close()
+	_, err = f.WriteString(fileContent)
+	require.NoError(t, err)
+
+	watcher := newPollingFileWatcher(f.Name(), pollInterval)
+	require.NoError(t, watcher.Start())
+	defer watcher.Close()
+	assert.Nil(t, getEventWithTimeout(watcher.Events, pollInterval*100))
+
+	// write to the file, we should get an event
+	_, err = f.WriteString("\n")
+	require.NoError(t, err)
+	event := getEventWithTimeout(watcher.Events, pollInterval*100)
+	require.NotNil(t, event)
+	require.Nil(t, event.Error)
+}
+
+func TestEventIfFileRemoved(t *testing.T) {
+	pollInterval := time.Millisecond
+	fileContent := "content"
+	f, err := os.CreateTemp(t.TempDir(), "*")
+	require.NoError(t, err)
+	defer f.Close()
+	_, err = f.WriteString(fileContent)
+	require.NoError(t, err)
+
+	watcher := newPollingFileWatcher(f.Name(), pollInterval)
+	require.NoError(t, watcher.Start())
+	defer watcher.Close()
+	assert.Nil(t, getEventWithTimeout(watcher.Events, pollInterval*100))
+
+	// remove the file, we should get an error event
+	err = f.Close()
+	require.NoError(t, err)
+	err = os.Remove(f.Name())
+	require.NoError(t, err)
+	event := getEventWithTimeout(watcher.Events, pollInterval*100)
+	require.NotNil(t, event)
+	require.NotNil(t, event.Error)
+}
+
+func BenchmarkCheckFileForChangesNoChange(b *testing.B) {
+	fileContent := "content"
+	f, err := os.CreateTemp(b.TempDir(), "*")
+	require.NoError(b, err)
+	defer f.Close()
+	_, err = f.WriteString(fileContent)
+	require.NoError(b, err)
+
+	watcher := newPollingFileWatcher(f.Name(), time.Hour)
+	require.NoError(b, watcher.Start())
+	defer watcher.Close()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		watcher.checkFileForChanges()
+	}
+}
+
+func BenchmarkCheckFileForChangesMetadataChanged(b *testing.B) {
+	fileContent := make([]byte, 1024)
+	f, err := os.CreateTemp(b.TempDir(), "*")
+	require.NoError(b, err)
+	defer f.Close()
+	_, err = f.Write(fileContent)
+	require.NoError(b, err)
+
+	watcher := newPollingFileWatcher(f.Name(), time.Hour)
+	require.NoError(b, watcher.Start())
+	defer watcher.Close()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		require.NoError(b, os.Chtimes(f.Name(), time.Now(), time.Now()))
+		b.StartTimer()
+		watcher.checkFileForChanges()
+	}
+}
+
+func getEventWithTimeout(events chan *confmap.ChangeEvent, waitTime time.Duration) *confmap.ChangeEvent {
+	select {
+	case event, ok := <-events:
+		if !ok {
+			return nil
+		}
+		return event
+	case <-time.After(waitTime):
+		return nil
+	}
+}

--- a/confmap/provider/fileprovider/provider.go
+++ b/confmap/provider/fileprovider/provider.go
@@ -20,14 +20,23 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
+	"time"
 
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/confmap/provider/internal"
 )
 
-const schemeName = "file"
+const (
+	schemeName       = "file"
+	filePollInterval = time.Second
+)
 
-type provider struct{}
+type provider struct {
+	eventHandlers    sync.WaitGroup
+	eventCloseCh     chan struct{}
+	filePollInterval time.Duration
+}
 
 // New returns a new confmap.Provider that reads the configuration from a file.
 //
@@ -45,27 +54,93 @@ type provider struct{}
 // `file:c:/path/to/file` - absolute path including drive-letter (windows)
 // `file:c:\path\to\file` - absolute path including drive-letter (windows)
 func New() confmap.Provider {
-	return &provider{}
+	return &provider{
+		filePollInterval: filePollInterval,
+		eventCloseCh:     make(chan struct{}),
+	}
 }
 
-func (fmp *provider) Retrieve(_ context.Context, uri string, _ confmap.WatcherFunc) (*confmap.Retrieved, error) {
+func (fmp *provider) Retrieve(_ context.Context, uri string, watcherFunc confmap.WatcherFunc) (*confmap.Retrieved, error) {
 	if !strings.HasPrefix(uri, schemeName+":") {
 		return nil, fmt.Errorf("%q uri is not supported by %q provider", uri, schemeName)
 	}
 
 	// Clean the path before using it.
-	content, err := os.ReadFile(filepath.Clean(uri[len(schemeName)+1:]))
+	cleanedPath := filepath.Clean(uri[len(schemeName)+1:])
+
+	// set up the file watcher if the caller asked for watch updates
+	// do this before reading the file to avoid a race condition where the file is changed after
+	// reading the contents but before the watch is started
+	opts := []confmap.RetrievedOption{}
+	if watcherFunc != nil {
+		closeFunc, err := fmp.startFileWatcher(cleanedPath, watcherFunc)
+		if err != nil {
+			return &confmap.Retrieved{}, fmt.Errorf("unable to start file watcher %v: %w", uri, err)
+		}
+
+		opts = append(opts, confmap.WithRetrievedClose(closeFunc))
+	}
+
+	content, err := os.ReadFile(cleanedPath)
 	if err != nil {
 		return nil, fmt.Errorf("unable to read the file %v: %w", uri, err)
 	}
 
-	return internal.NewRetrievedFromYAML(content)
+	return internal.NewRetrievedFromYAML(content, opts...)
+}
+
+// startFileWatcher creates and starts the watcher for the provided file
+func (fmp *provider) startFileWatcher(path string, watcherFunc confmap.WatcherFunc) (confmap.CloseFunc, error) {
+	fileWatcher := newPollingFileWatcher(path, fmp.filePollInterval)
+	err := fileWatcher.Start()
+	if err != nil {
+		return nil, err
+	}
+
+	closeFunc := func(_ context.Context) error {
+		// this is idempotent and safe to call multiple times
+		fileWatcher.Close()
+		return nil
+	}
+	// handle events coming in from the watcher
+	fmp.eventHandlers.Add(1)
+	go func() {
+		defer fmp.eventHandlers.Done()
+		fmp.handleEventsFromWatcher(fileWatcher, watcherFunc)
+	}()
+
+	return closeFunc, nil
+}
+
+// handleEventsFromWatcher reads change events from the file watcher's event channel and calls
+// the watchFunc on each event
+func (fmp *provider) handleEventsFromWatcher(fileWatcher *pollingFileWatcher, watchFunc confmap.WatcherFunc) {
+	for { // this loop ends when either the fileWatcher or closeCh is closed
+		select {
+		case changeEvent, ok := <-fileWatcher.Events:
+			if !ok {
+				return
+			}
+			go watchFunc(changeEvent)
+		case _, ok := <-fmp.eventCloseCh:
+			if !ok {
+				// caller called Shutdown before all the closeFuncs, clean up anyway
+				fileWatcher.Close()
+				return
+			}
+		}
+	}
 }
 
 func (*provider) Scheme() string {
 	return schemeName
 }
 
-func (*provider) Shutdown(context.Context) error {
+func (fmp *provider) Shutdown(context.Context) error {
+	// according to the spec, the caller should call the closeFunc for all values returned by Retrieve before
+	// calling Shutdown, so no handlers should be running at this point
+	// just in case, we close this channel to stop any remaining ones
+	close(fmp.eventCloseCh)
+	fmp.eventHandlers.Wait()
 	return nil
 }

--- a/confmap/provider/fileprovider/provider_test.go
+++ b/confmap/provider/fileprovider/provider_test.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -52,6 +53,9 @@ func TestNonExistent(t *testing.T) {
 	_, err := fp.Retrieve(context.Background(), fileSchemePrefix+filepath.Join("testdata", "non-existent.yaml"), nil)
 	assert.Error(t, err)
 	_, err = fp.Retrieve(context.Background(), fileSchemePrefix+absolutePath(t, filepath.Join("testdata", "non-existent.yaml")), nil)
+	assert.Error(t, err)
+	watchFunc := func(_ *confmap.ChangeEvent) {}
+	_, err = fp.Retrieve(context.Background(), fileSchemePrefix+filepath.Join("testdata", "non-existent.yaml"), watchFunc)
 	assert.Error(t, err)
 	require.NoError(t, fp.Shutdown(context.Background()))
 }
@@ -93,8 +97,79 @@ func TestAbsolutePath(t *testing.T) {
 	assert.NoError(t, fp.Shutdown(context.Background()))
 }
 
+func TestWatcherStartAndShutdown(t *testing.T) {
+	fp := New()
+	watchFunc := func(_ *confmap.ChangeEvent) {}
+	ret, err := fp.Retrieve(context.Background(), fileSchemePrefix+absolutePath(t, filepath.Join("testdata", "default-config.yaml")), watchFunc)
+	require.NoError(t, err)
+	retMap, err := ret.AsConf()
+	assert.NoError(t, err)
+	expectedMap := confmap.NewFromStringMap(map[string]interface{}{
+		"processors::batch":         nil,
+		"exporters::otlp::endpoint": "localhost:4317",
+	})
+	assert.Equal(t, expectedMap, retMap)
+	assert.NoError(t, ret.Close(context.Background()))
+	assert.NoError(t, fp.Shutdown(context.Background()))
+}
+
+func TestWatcherShutdownBeforeClose(t *testing.T) {
+	fp := New()
+	watchFunc := func(_ *confmap.ChangeEvent) {}
+	ret, err := fp.Retrieve(context.Background(), fileSchemePrefix+absolutePath(t, filepath.Join("testdata", "default-config.yaml")), watchFunc)
+	require.NoError(t, err)
+	assert.NoError(t, fp.Shutdown(context.Background()))
+	assert.NoError(t, ret.Close(context.Background()))
+}
+
+func TestWatcherConfigChange(t *testing.T) {
+	fp := New().(*provider)
+	fp.filePollInterval = time.Millisecond
+
+	events := make(chan *confmap.ChangeEvent)
+	watchFunc := func(event *confmap.ChangeEvent) {
+		events <- event
+	}
+
+	absolutePath := absolutePath(t, filepath.Join("testdata", "default-config.yaml"))
+	testFile := copyTestFile(t, absolutePath)
+
+	ret, err := fp.Retrieve(context.Background(), fileSchemePrefix+testFile.Name(), watchFunc)
+	require.NoError(t, err)
+
+	// change the file, we should get an update event
+	_, err = testFile.WriteString("\n")
+	require.NoError(t, err)
+	event := getEventWithTimeout(events, fp.filePollInterval*100)
+	require.NotNil(t, event)
+	assert.Nil(t, event.Error)
+
+	// delete the file, we should get an error
+	err = testFile.Close()
+	require.NoError(t, err)
+	err = os.Remove(testFile.Name())
+	require.NoError(t, err)
+	event = getEventWithTimeout(events, fp.filePollInterval*100)
+	require.NotNil(t, event)
+	assert.Error(t, event.Error)
+
+	assert.NoError(t, ret.Close(context.Background()))
+	require.NoError(t, fp.Shutdown(context.Background()))
+}
+
 func absolutePath(t *testing.T, relativePath string) string {
 	dir, err := os.Getwd()
 	require.NoError(t, err)
 	return filepath.Join(dir, relativePath)
+}
+
+func copyTestFile(t *testing.T, path string) *os.File {
+	cleanPath := filepath.Clean(path)
+	data, err := os.ReadFile(cleanPath)
+	require.NoError(t, err)
+	tempFile, err := os.CreateTemp(t.TempDir(), "*")
+	require.NoError(t, err)
+	_, err = tempFile.Write(data)
+	require.NoError(t, err)
+	return tempFile
 }


### PR DESCRIPTION
**Description:**
Make the file config provider watch for changes to the config file.

This is done via polling the file every second, with an additional grace period of two seconds for actually delivering updates to the collector. We're not using notification mechanisms provided by the OS because they're unreliable or annoyingly complex to make work for some popular use cases - most notably Kubernetes ConfigMaps. As we don't need frequent updates and our watched files are small, polling is both performant and easier to understand than, say, inotify.

This change is more complex than it technically needs to be because it tries to reasonably deal with misbehaving users. For example, it'll quietly accept a user calling `.Shutdown` before `.Close`:

```go
r, err := provider.Retrieve("file:/path/to/config")
provider.Shutdown()
r.Close()
```

and `r.Close()` is even thread-safe. If we're ok with the above resulting in a panic or a deadlock, I can make both the provider and the filewatcher simpler.

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector/issues/273

**Testing:**
Added additional tests for the provider and separate unit tests for the filewatcher. I also did a couple manual e2e tests of the more interesting edge cases, like network filesystems and deep symlink chains.
