### PR TITLE
Remove unnecessary posflag provider load

### DIFF
--- a/cmd/builder/internal/command.go
+++ b/cmd/builder/internal/command.go
@@ -22,7 +22,6 @@ import (
 	"github.com/knadh/koanf/parsers/yaml"
 	"github.com/knadh/koanf/providers/env"
 	"github.com/knadh/koanf/providers/file"
-	"github.com/knadh/koanf/providers/posflag"
 	"github.com/spf13/cobra"
 	flag "github.com/spf13/pflag"
 	"go.uber.org/zap"
@@ -117,10 +116,6 @@ build configuration given by the "--config" argument.
 
 	// version of this binary
 	cmd.AddCommand(versionCommand())
-
-	if err := k.Load(posflag.Provider(cmd.Flags(), ".", k), nil); err != nil {
-		return nil, fmt.Errorf("failed to load command line arguments: %w", err)
-	}
 
 	return cmd, nil
 }


### PR DESCRIPTION
This is unnecessary because:
1. It happens before flags are loaded, so will initialize things with default values, which already happens during flags initialization. See flags.StringVar for example.
2. The load using posflag provider, as defined right now (with current flags name) produce this config:
```
k := map[string]interface{} {
	"config": ""
	"description": "Custom OpenTelemetry Collector distribution"
	"go": ""
	"module": "go.opentelemetry.io/collector/cmd/builder"
	"name": "otelcol-custom otelcol-version:0.58.0"
	"output-path": "/var/folders/5c/5p_3jmvd6qx0rsvmb9j7c_s00000gn/T/otelcol-distribution1155391158"
	"skip-compilation": false
	"version": "1.0.0"
}
```
As you can see, this will whole be ignored, since all the configs (except the config flag) are sub-configs under "dist" anyway.

Signed-off-by: Bogdan <bogdandrutu@gmail.com>
