### PR TITLE
[pdata] Deprecate pcommon.Map.InsertNull method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Deprecate `exporterhelper.New[Traces|Metrics|Logs]ExporterWithContext` in favor of `exporterhelper.New[Traces|Metrics|Logs]Exporter` (#5914)
 - Deprecate `component.NewExtensionFactoryWithStabilityLevel` in favor of `component.NewExtensionFactory` (#5917)
 - Deprecate `plog.SeverityNumber[UPPERCASE]` constants (#5927)
+- Deprecate `pcommon.Map.InsertNull` method (#5955)
 - Deprecate FlagsStruct types (#5933):
   - `MetricDataPointFlagsStruct` -> `MetricDataPointFlags`
   - `NewMetricDataPointFlagsStruct` -> `NewMetricDataPointFlags`

--- a/pdata/internal/common.go
+++ b/pdata/internal/common.go
@@ -651,6 +651,7 @@ func (m Map) Insert(k string, v Value) {
 
 // InsertNull adds a null Value to the map when the key does not exist.
 // No action is applied to the map where the key already exists.
+// Deprecated: [0.59.0] Use Insert(key, NewValueEmpty()) instead.
 func (m Map) InsertNull(k string) {
 	if _, existing := m.Get(k); !existing {
 		*m.orig = append(*m.orig, newAttributeKeyValueNull(k))


### PR DESCRIPTION
The method is inconsistent with other Map methods. It's not very useful and can be easily replaced by `Map.Insert(<key>, NewValueEmpty())`. 

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector/issues/5953