### PR TITLE
Use TLS 1.2 by default when min_version is not defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Replace `processorhelper.New[Traces|Metrics|Logs]Exporter` with `processorhelper.New[Traces|Metrics|Logs]ProcessorWithCreateSettings` definition (#5915)
 - Replace `exporterhelper.New[Traces|Metrics|Logs]Exporter` with `exporterhelper.New[Traces|Metrics|Logs]ExporterWithContext` definition (#5914)
 - Replace ``component.NewExtensionFactory`` with `component.NewExtensionFactoryWithStabilityLevel` definition (#5917)
+- Set TLS 1.2 as default for `min_version` for TLS configuration in clients and servers in case this property is not defined (#5956)
 
 ### 🚩 Deprecations 🚩
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 - Replace `processorhelper.New[Traces|Metrics|Logs]Exporter` with `processorhelper.New[Traces|Metrics|Logs]ProcessorWithCreateSettings` definition (#5915)
 - Replace `exporterhelper.New[Traces|Metrics|Logs]Exporter` with `exporterhelper.New[Traces|Metrics|Logs]ExporterWithContext` definition (#5914)
 - Replace ``component.NewExtensionFactory`` with `component.NewExtensionFactoryWithStabilityLevel` definition (#5917)
-- Set TLS 1.2 as default for `min_version` for TLS configuration in clients and servers in case this property is not defined (#5956)
+- Set TLS 1.2 as default for `min_version` for TLS configuration in case this property is not defined (affects servers). (#5956)
 
 ### 🚩 Deprecations 🚩
 

--- a/config/configtls/README.md
+++ b/config/configtls/README.md
@@ -36,7 +36,9 @@ won't use TLS at all.
 
 Minimum and maximum TLS version can be set:
 
-- `min_version` (default = "" handled by [crypto/tls](https://github.com/golang/go/blob/master/src/crypto/tls/common.go#L694)): Minimum acceptable TLS version.
+__IMPORTANT__: TLS 1.0 and 1.1 are deprecated and should be avoided.
+
+- `min_version` (default = "1.2"): Minimum acceptable TLS version.
   - options: ["1.0", "1.1", "1.2", "1.3"]
 
 - `max_version` (default = "" handled by [crypto/tls](https://github.com/golang/go/blob/master/src/crypto/tls/common.go#L700)): Maximum acceptable TLS version.

--- a/config/configtls/README.md
+++ b/config/configtls/README.md
@@ -36,12 +36,12 @@ won't use TLS at all.
 
 Minimum and maximum TLS version can be set:
 
-__IMPORTANT__: TLS 1.0 and 1.1 are deprecated and should be avoided.
+__IMPORTANT__: TLS 1.0 and 1.1 are deprecated due to known vulnerabilities and should be avoided.
 
 - `min_version` (default = "1.2"): Minimum acceptable TLS version.
   - options: ["1.0", "1.1", "1.2", "1.3"]
 
-- `max_version` (default = "" handled by [crypto/tls](https://github.com/golang/go/blob/master/src/crypto/tls/common.go#L700)): Maximum acceptable TLS version.
+- `max_version` (default = "" handled by [crypto/tls](https://github.com/golang/go/blob/master/src/crypto/tls/common.go#L700) - currently TLS 1.3): Maximum acceptable TLS version.
   - options: ["1.0", "1.1", "1.2", "1.3"]
 
 Additionally certifaces may be reloaded by setting the below configuration.

--- a/config/configtls/configtls_test.go
+++ b/config/configtls/configtls_test.go
@@ -361,8 +361,8 @@ func TestMinMaxTLSVersions(t *testing.T) {
 		outMaxVersion uint16
 		errorTxt      string
 	}{
-		{name: `TLS Config ["", ""] to give [0, 0]`, minVersion: "", maxVersion: "", outMinVersion: 0, outMaxVersion: 0},
-		{name: `TLS Config ["", "1.3"] to give [0, TLS1.3]`, minVersion: "", maxVersion: "1.3", outMinVersion: 0, outMaxVersion: tls.VersionTLS13},
+		{name: `TLS Config ["", ""] to give [TLS1.2, 0]`, minVersion: "", maxVersion: "", outMinVersion: tls.VersionTLS12, outMaxVersion: 0},
+		{name: `TLS Config ["", "1.3"] to give [TLS1.2, TLS1.3]`, minVersion: "", maxVersion: "1.3", outMinVersion: tls.VersionTLS12, outMaxVersion: tls.VersionTLS13},
 		{name: `TLS Config ["1.2", ""] to give [TLS1.2, 0]`, minVersion: "1.2", maxVersion: "", outMinVersion: tls.VersionTLS12, outMaxVersion: 0},
 		{name: `TLS Config ["1.3", "1.3"] to give [TLS1.3, TLS1.3]`, minVersion: "1.3", maxVersion: "1.3", outMinVersion: tls.VersionTLS13, outMaxVersion: tls.VersionTLS13},
 		{name: `TLS Config ["1.0", "1.1"] to give [TLS1.0, TLS1.1]`, minVersion: "1.0", maxVersion: "1.1", outMinVersion: tls.VersionTLS10, outMaxVersion: tls.VersionTLS11},


### PR DESCRIPTION
**Description:** 

Use TLS 1.2 by default when min_version is not defined. 

TLS 1.0 and 1.1 are widely deprecated. It does not make sense to offer users with an insecure default.

This PR changes the default TLS min_version for both server and client to 1.2. This is reverting part of a recent change: https://github.com/open-telemetry/opentelemetry-collector/pull/5480

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector/issues/5627

**Testing:** Unit tests were modified to account for this case.

**Documentation:** Documentation was updated describing the new default.

