### PR TITLE
Remove usage of deprecated LogRecord.Flags

### DIFF
--- a/exporter/loggingexporter/internal/otlptext/logs.go
+++ b/exporter/loggingexporter/internal/otlptext/logs.go
@@ -52,7 +52,7 @@ func (textLogsMarshaler) MarshalLogs(ld plog.Logs) ([]byte, error) {
 				buf.logAttributes("Attributes", lr.Attributes())
 				buf.logEntry("Trace ID: %s", lr.TraceID().HexString())
 				buf.logEntry("Span ID: %s", lr.SpanID().HexString())
-				buf.logEntry("Flags: %d", lr.Flags())
+				buf.logEntry("Flags: %d", lr.FlagsStruct().AsRaw())
 			}
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Bogdan <bogdandrutu@gmail.com>
