### PR TITLE
Add FromRaw to Flags struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@
 - Added `service.telemetry.traces.propagators` configuration to set propagators for collector's internal spans. (#5572)
 - Remove unnecessary duplicate code and allocations for reading enums in JSON. (#5928)
 - Add "dist.build_tags" configuration option to support passing go build flags to builder. (#5659)
-- Add an AsRaw func on the flags, lots of places to encode these flags. (#5934)
+- Add an AsRaw and FromRaw for Flags, lots of places to encode these flags. (#5934) (#5959)
 - Change pdata generated types to use type definition instead of aliases. (#5936)
   - Improves documentation, and makes code easier to read/understand.
 

--- a/pdata/plog/logs.go
+++ b/pdata/plog/logs.go
@@ -248,6 +248,11 @@ func (ms LogRecordFlags) SetIsSampled(b bool) {
 	}
 }
 
+// FromRaw converts from the OTLP uint32 representation into this LogRecordFlags.
+func (ms LogRecordFlags) FromRaw(val uint32) {
+	*ms.getOrig() = val
+}
+
 // AsRaw converts LogRecordFlags to the OTLP uint32 representation.
 func (ms LogRecordFlags) AsRaw() uint32 {
 	return *ms.getOrig()

--- a/pdata/plog/logs_test.go
+++ b/pdata/plog/logs_test.go
@@ -157,6 +157,10 @@ func TestLogRecordFlags(t *testing.T) {
 	moveFlags.CopyTo(flags)
 	assert.True(t, flags.IsSampled())
 	assert.True(t, moveFlags.IsSampled())
+
+	flags.FromRaw(127)
+	assert.True(t, flags.IsSampled())
+	assert.Equal(t, uint32(127), flags.AsRaw())
 }
 
 func BenchmarkLogsClone(b *testing.B) {

--- a/pdata/pmetric/metrics.go
+++ b/pdata/pmetric/metrics.go
@@ -219,6 +219,11 @@ func (ms MetricDataPointFlags) SetNoRecordedValue(b bool) {
 	}
 }
 
+// FromRaw converts from the OTLP uint32 representation into this LogRecordFlags.
+func (ms MetricDataPointFlags) FromRaw(val uint32) {
+	*ms.getOrig() = val
+}
+
 // AsRaw converts MetricDataPointFlags to the OTLP uint32 representation.
 func (ms MetricDataPointFlags) AsRaw() uint32 {
 	return *ms.getOrig()

--- a/pdata/pmetric/metrics_test.go
+++ b/pdata/pmetric/metrics_test.go
@@ -719,6 +719,10 @@ func TestMetricDataPointFlags(t *testing.T) {
 	moveFlags.CopyTo(flags)
 	assert.True(t, flags.NoRecordedValue())
 	assert.True(t, moveFlags.NoRecordedValue())
+
+	flags.FromRaw(127)
+	assert.True(t, flags.NoRecordedValue())
+	assert.Equal(t, uint32(127), flags.AsRaw())
 }
 
 func BenchmarkMetricsClone(b *testing.B) {


### PR DESCRIPTION
See usages in https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/13617 where we had to check for the sample bit to set the value instead of just setting the entire value.

Signed-off-by: Bogdan <bogdandrutu@gmail.com>
