### PR TITLE
[loggingexporter] Rename labels to attributes

### DIFF
--- a/exporter/loggingexporter/internal/otlptext/databuffer.go
+++ b/exporter/loggingexporter/internal/otlptext/databuffer.go
@@ -35,16 +35,16 @@ func (b *dataBuffer) logEntry(format string, a ...interface{}) {
 	b.buf.WriteString("\n")
 }
 
-func (b *dataBuffer) logAttr(label string, value string) {
-	b.logEntry("    %-15s: %s", label, value)
+func (b *dataBuffer) logAttr(attr string, value string) {
+	b.logEntry("    %-15s: %s", attr, value)
 }
 
-func (b *dataBuffer) logAttributes(label string, m pcommon.Map) {
+func (b *dataBuffer) logAttributes(attr string, m pcommon.Map) {
 	if m.Len() == 0 {
 		return
 	}
 
-	b.logEntry("%s:", label)
+	b.logEntry("%s:", attr)
 	m.Range(func(k string, v pcommon.Value) bool {
 		b.logEntry("     -> %s: %s(%s)", k, v.Type().String(), attributeValueToString(v))
 		return true
@@ -216,8 +216,8 @@ func (b *dataBuffer) logDoubleSummaryDataPoints(ps pmetric.SummaryDataPointSlice
 	}
 }
 
-func (b *dataBuffer) logDataPointAttributes(labels pcommon.Map) {
-	b.logAttributes("Data point attributes", labels)
+func (b *dataBuffer) logDataPointAttributes(attributes pcommon.Map) {
+	b.logAttributes("Data point attributes", attributes)
 }
 
 func (b *dataBuffer) logEvents(description string, se ptrace.SpanEventSlice) {

--- a/exporter/loggingexporter/internal/otlptext/logs.go
+++ b/exporter/loggingexporter/internal/otlptext/logs.go
@@ -33,7 +33,7 @@ func (textLogsMarshaler) MarshalLogs(ld plog.Logs) ([]byte, error) {
 		buf.logEntry("ResourceLog #%d", i)
 		rl := rls.At(i)
 		buf.logEntry("Resource SchemaURL: %s", rl.SchemaUrl())
-		buf.logAttributes("Resource labels", rl.Resource().Attributes())
+		buf.logAttributes("Resource attributes", rl.Resource().Attributes())
 		ills := rl.ScopeLogs()
 		for j := 0; j < ills.Len(); j++ {
 			buf.logEntry("ScopeLogs #%d", j)

--- a/exporter/loggingexporter/internal/otlptext/metrics.go
+++ b/exporter/loggingexporter/internal/otlptext/metrics.go
@@ -31,7 +31,7 @@ func (textMetricsMarshaler) MarshalMetrics(md pmetric.Metrics) ([]byte, error) {
 		buf.logEntry("ResourceMetrics #%d", i)
 		rm := rms.At(i)
 		buf.logEntry("Resource SchemaURL: %s", rm.SchemaUrl())
-		buf.logAttributes("Resource labels", rm.Resource().Attributes())
+		buf.logAttributes("Resource attributes", rm.Resource().Attributes())
 		ilms := rm.ScopeMetrics()
 		for j := 0; j < ilms.Len(); j++ {
 			buf.logEntry("ScopeMetrics #%d", j)

--- a/exporter/loggingexporter/internal/otlptext/traces.go
+++ b/exporter/loggingexporter/internal/otlptext/traces.go
@@ -33,7 +33,7 @@ func (textTracesMarshaler) MarshalTraces(td ptrace.Traces) ([]byte, error) {
 		buf.logEntry("ResourceSpans #%d", i)
 		rs := rss.At(i)
 		buf.logEntry("Resource SchemaURL: %s", rs.SchemaUrl())
-		buf.logAttributes("Resource labels", rs.Resource().Attributes())
+		buf.logAttributes("Resource attributes", rs.Resource().Attributes())
 		ilss := rs.ScopeSpans()
 		for j := 0; j < ilss.Len(); j++ {
 			buf.logEntry("ScopeSpans #%d", j)


### PR DESCRIPTION
**Description:**
While working on #5976, I realized that there are some leftover mentions of `labels` in the logging exporter code, and replaced them with `attributes`.