### PR TITLE
Revert breaking change to [Trace|Span]ID.HexString()

### DIFF
--- a/pdata/pcommon/spanid.go
+++ b/pdata/pcommon/spanid.go
@@ -44,6 +44,9 @@ func (ms SpanID) Bytes() [8]byte {
 
 // HexString returns hex representation of the SpanID.
 func (ms SpanID) HexString() string {
+	if ms.IsEmpty() {
+		return ""
+	}
 	return hex.EncodeToString(ms.orig[:])
 }
 

--- a/pdata/pcommon/spanid_test.go
+++ b/pdata/pcommon/spanid_test.go
@@ -34,7 +34,7 @@ func TestNewSpanID(t *testing.T) {
 
 func TestSpanIDHexString(t *testing.T) {
 	sid := NewSpanID([8]byte{})
-	assert.Equal(t, "0000000000000000", sid.HexString())
+	assert.Equal(t, "", sid.HexString())
 
 	sid = NewSpanID([8]byte{0x12, 0x23, 0xAD, 0x12, 0x23, 0xAD, 0x12, 0x23})
 	assert.Equal(t, "1223ad1223ad1223", sid.HexString())

--- a/pdata/pcommon/traceid.go
+++ b/pdata/pcommon/traceid.go
@@ -45,6 +45,9 @@ func (ms TraceID) Bytes() [16]byte {
 
 // HexString returns hex representation of the TraceID.
 func (ms TraceID) HexString() string {
+	if ms.IsEmpty() {
+		return ""
+	}
 	return hex.EncodeToString(ms.orig[:])
 }
 

--- a/pdata/pcommon/traceid_test.go
+++ b/pdata/pcommon/traceid_test.go
@@ -35,7 +35,7 @@ func TestNewTraceID(t *testing.T) {
 
 func TestTraceIDHexString(t *testing.T) {
 	tid := NewTraceID([16]byte{})
-	assert.Equal(t, "00000000000000000000000000000000", tid.HexString())
+	assert.Equal(t, "", tid.HexString())
 
 	tid = NewTraceID([16]byte{0x12, 0x34, 0x56, 0x78, 0x12, 0x34, 0x56, 0x78, 0x12, 0x34, 0x56, 0x78, 0x12, 0x34, 0x56, 0x78})
 	assert.Equal(t, "12345678123456781234567812345678", tid.HexString())


### PR DESCRIPTION
The breaking change was added, unintentionally in https://github.com/open-telemetry/opentelemetry-collector/pull/5968 

Signed-off-by: Bogdan <bogdandrutu@gmail.com>
