### PR TITLE
Add back deprecated funcs/types deleted by mistake.

### DIFF
--- a/pdata/pmetric/metrics.go
+++ b/pdata/pmetric/metrics.go
@@ -286,3 +286,9 @@ func (ot OptionalType) String() string {
 	}
 	return ""
 }
+
+// Deprecated: [0.59.0] Use MetricDataPointFlagsImmutable.
+type MetricDataPointFlagsStruct = MetricDataPointFlags
+
+// Deprecated: [0.59.0] Use MetricDataPointFlagsImmutable.
+var NewMetricDataPointFlagsStruct = NewMetricDataPointFlags


### PR DESCRIPTION
The mistake happened in https://github.com/open-telemetry/opentelemetry-collector/pull/5936

Signed-off-by: Bogdan <bogdandrutu@gmail.com>
