### PR TITLE
Close persistent storage client on stop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@
   - Accept both string and number for float64.
   - Accept both string and number for int32/uint32.
   - Read uint64 numbers without converting from int64.
+- Fix persistent storage client not closing when shutting down (#6003)
 
 ## v0.58.0 Beta
 

--- a/exporter/exporterhelper/internal/persistent_storage.go
+++ b/exporter/exporterhelper/internal/persistent_storage.go
@@ -204,6 +204,9 @@ func (pcs *persistentContiguousStorage) stop() {
 	pcs.logger.Debug("Stopping persistentContiguousStorage", zap.String(zapQueueNameKey, pcs.queueName))
 	pcs.stopOnce.Do(func() {
 		close(pcs.stopChan)
+		if err := pcs.client.Close(context.Background()); err != nil {
+			pcs.logger.Warn("failed to close client", zap.Error(err))
+		}
 	})
 }
 


### PR DESCRIPTION
**Description:**
The client passed into `persistentContiguousStorage` was never closed prior. This would caused the underneath file locked forever and collector failing to restart when settings are updated.

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector/issues/6003

**Testing:** Added unit test on stop

**Documentation:** None needed as fixing bug
