### PR TITLE
Add skip-get-modules flag to support isolated envs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
   - `processorhelper.New[Traces|Metrics|Logs]ProcessorWithCreateSettings`
   - `component.NewExtensionFactoryWithStabilityLevel`
 
+### 💡 Enhancements 💡
+
+- Add `skip-get-modules` builder flag to support isolated environment executions (#6009)
+
 ## v0.59.0 Beta
 
 ### 🛑 Breaking changes 🛑

--- a/cmd/builder/internal/builder/config.go
+++ b/cmd/builder/internal/builder/config.go
@@ -34,6 +34,7 @@ var ErrInvalidGoMod = errors.New("invalid gomod specification for module")
 type Config struct {
 	Logger          *zap.Logger
 	SkipCompilation bool `mapstructure:"-"`
+	SkipGetModules  bool `mapstructure:"-"`
 
 	Distribution Distribution `mapstructure:"dist"`
 	Exporters    []Module     `mapstructure:"exporters"`

--- a/cmd/builder/internal/builder/main.go
+++ b/cmd/builder/internal/builder/main.go
@@ -103,6 +103,11 @@ func Compile(cfg Config) error {
 
 // GetModules retrieves the go modules, updating go.mod and go.sum in the process
 func GetModules(cfg Config) error {
+	if cfg.SkipGetModules {
+		cfg.Logger.Info("Generating source codes only, will not update go.mod and retrieve Go modules.")
+		return nil
+	}
+
 	// #nosec G204
 	cmd := exec.Command(cfg.Distribution.Go, "mod", "tidy", "-compat=1.18")
 	cmd.Dir = cfg.Distribution.OutputPath

--- a/cmd/builder/internal/command.go
+++ b/cmd/builder/internal/command.go
@@ -31,6 +31,7 @@ import (
 
 const (
 	skipCompilationFlag            = "skip-compilation"
+	skipGetModulesFlag             = "skip-get-modules"
 	distributionNameFlag           = "name"
 	distributionDescriptionFlag    = "description"
 	distributionVersionFlag        = "version"
@@ -85,6 +86,7 @@ build configuration given by the "--config" argument.
 
 	// the distribution parameters, which we accept as CLI flags as well
 	cmd.Flags().BoolVar(&cfg.SkipCompilation, skipCompilationFlag, false, "Whether builder should only generate go code with no compile of the collector (default false)")
+	cmd.Flags().BoolVar(&cfg.SkipGetModules, skipGetModulesFlag, false, "Whether builder should skip updating go.mod and retrieve Go module list (default false)")
 	cmd.Flags().StringVar(&cfg.Distribution.Name, distributionNameFlag, "otelcol-custom", "The executable name for the OpenTelemetry Collector distribution")
 	if err := cmd.Flags().MarkDeprecated(distributionNameFlag, "use config distribution::name"); err != nil {
 		return nil, err
@@ -157,6 +159,9 @@ func applyCfgFromFile(flags *flag.FlagSet, cfgFromFile builder.Config) {
 
 	if !flags.Changed(skipCompilationFlag) && cfgFromFile.SkipCompilation {
 		cfg.SkipCompilation = cfgFromFile.SkipCompilation
+	}
+	if !flags.Changed(skipGetModulesFlag) && cfgFromFile.SkipGetModules {
+		cfg.SkipGetModules = cfgFromFile.SkipGetModules
 	}
 	if !flags.Changed(distributionNameFlag) && cfgFromFile.Distribution.Name != "" {
 		cfg.Distribution.Name = cfgFromFile.Distribution.Name


### PR DESCRIPTION
**Description:** Add `skip-get-modules` flag to the builder.

Isolated build environments like [Bazel](https://bazel.build/) or some CIs might not have access to the public internet.
These environments have different ways to inject dependencies, and there is no need to get them directly from the internet during the builder execution time.
~~Also, if we skip compilation (an existing feature) and downloading modules (this feature), there is no need for Go binary anymore.~~ Move to a separate PR.