### PR TITLE
[pdata] Remove deprecated pcommon.Map methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
   - `processorhelper.New[Traces|Metrics|Logs]ProcessorWithCreateSettings`
   - `component.NewExtensionFactoryWithStabilityLevel`
 - Remove deprecated `pcommon.InvalidTraceID` and `pcommon.InvalidSpanID` funcs (#6008)
+- Remove deprecated `pcommon.Map` methods: `Update`, `Upsert`, `InsertNull` (#6019)
 
 ### 🚩 Deprecations 🚩
 

--- a/pdata/pcommon/common.go
+++ b/pdata/pcommon/common.go
@@ -679,15 +679,6 @@ func (m Map) Insert(k string, v Value) {
 	}
 }
 
-// InsertNull adds a null Value to the map when the key does not exist.
-// No action is applied to the map where the key already exists.
-// Deprecated: [0.59.0] Use Get and UpsertEmpty instead.
-func (m Map) InsertNull(k string) {
-	if _, existing := m.Get(k); !existing {
-		*m.getOrig() = append(*m.getOrig(), newAttributeKeyValueNull(k))
-	}
-}
-
 // InsertString adds the string Value to the map when the key does not exist.
 // No action is applied to the map where the key already exists.
 func (m Map) InsertString(k string, v string) {
@@ -725,28 +716,6 @@ func (m Map) InsertBool(k string, v bool) {
 func (m Map) InsertBytes(k string, v ImmutableByteSlice) {
 	if _, existing := m.Get(k); !existing {
 		*m.getOrig() = append(*m.getOrig(), newAttributeKeyValueBytes(k, v))
-	}
-}
-
-// Update updates an existing Value with a value.
-// No action is applied to the map where the key does not exist.
-//
-// Calling this function with a zero-initialized Value struct will cause a panic.
-//
-// Important: this function should not be used if the caller has access to
-// the raw value to avoid an extra allocation.
-//
-// Deprecated: [0.59.0] Replace it with the following function calls:
-// For primitive types, use Update<Type> methods, e.g. UpdateString.
-// For complex and unknown types, use:
-//
-//	toVal, ok := m.Get(k)
-//	if ok {
-//		v.CopyTo(toVal) // or use m.UpsertEmpty<Type> for complex types.
-//	}
-func (m Map) Update(k string, v Value) {
-	if av, existing := m.Get(k); existing {
-		v.copyTo(av.getOrig())
 	}
 }
 
@@ -807,27 +776,6 @@ func (m Map) UpdateBool(k string, v bool) {
 func (m Map) UpdateBytes(k string, v ImmutableByteSlice) {
 	if av, existing := m.Get(k); existing {
 		av.SetBytesVal(v)
-	}
-}
-
-// Upsert performs the Insert or Update action. The Value is
-// inserted to the map that did not originally have the key. The key/value is
-// updated to the map where the key already existed.
-//
-// Calling this function with a zero-initialized Value struct will cause a panic.
-//
-// Important: this function should not be used if the caller has access to
-// the raw value to avoid an extra allocation.
-//
-// Deprecated: [0.59.0] Replace it with the following function calls:
-// For primitive types, use Upsert<Type> methods, e.g. UpsertString.
-// For complex types, use UpsertEmpty<Type> methods, e.g. UpsertEmptyMap, and fill it with the data.
-// If you don't know the value type, replace it with v.CopyTo(m.UpsertEmpty()).
-func (m Map) Upsert(k string, v Value) {
-	if av, existing := m.Get(k); existing {
-		v.copyTo(av.getOrig())
-	} else {
-		*m.getOrig() = append(*m.getOrig(), newAttributeKeyValue(k, v))
 	}
 }
 

--- a/pdata/pcommon/common_test.go
+++ b/pdata/pcommon/common_test.go
@@ -297,10 +297,6 @@ func TestMap(t *testing.T) {
 	insertMapBytes.InsertBytes("k", NewImmutableByteSlice([]byte{1, 2, 3, 4, 5}))
 	assert.EqualValues(t, generateTestBytesMap(), insertMapBytes)
 
-	updateMap := NewMap()
-	updateMap.Update("k", NewValueString("v"))
-	assert.EqualValues(t, NewMap(), updateMap)
-
 	updateMapString := NewMap()
 	updateMapString.UpdateString("k", "v")
 	assert.EqualValues(t, NewMap(), updateMapString)
@@ -320,10 +316,6 @@ func TestMap(t *testing.T) {
 	updateMapBytes := NewMap()
 	updateMapBytes.UpdateBytes("k", NewImmutableByteSlice([]byte{1, 2, 3}))
 	assert.EqualValues(t, NewMap(), updateMapBytes)
-
-	upsertMap := NewMap()
-	upsertMap.Upsert("k", NewValueString("v"))
-	assert.EqualValues(t, Map(internal.GenerateTestMap()), upsertMap)
 
 	upsertMapString := NewMap()
 	upsertMapString.UpsertString("k", "v")
@@ -475,12 +467,6 @@ func TestMapWithEmpty(t *testing.T) {
 	assert.EqualValues(t, ValueTypeBytes, val.Type())
 	assert.EqualValues(t, []byte{1, 2, 3}, val.BytesVal().AsRaw())
 
-	sm.Update("other_key", NewValueString("yet_another_value"))
-	val, exist = sm.Get("other_key")
-	assert.True(t, exist)
-	assert.EqualValues(t, ValueTypeString, val.Type())
-	assert.EqualValues(t, "yet_another_value", val.StringVal())
-
 	sm.UpdateString("other_key_string", "yet_another_value")
 	val, exist = sm.Get("other_key_string")
 	assert.True(t, exist)
@@ -511,12 +497,6 @@ func TestMapWithEmpty(t *testing.T) {
 	assert.EqualValues(t, ValueTypeBytes, val.Type())
 	assert.EqualValues(t, []byte{4, 5, 6}, val.BytesVal().AsRaw())
 
-	sm.Upsert("other_key", NewValueString("other_value"))
-	val, exist = sm.Get("other_key")
-	assert.True(t, exist)
-	assert.EqualValues(t, ValueTypeString, val.Type())
-	assert.EqualValues(t, "other_value", val.StringVal())
-
 	sm.UpsertString("other_key_string", "other_value")
 	val, exist = sm.Get("other_key")
 	assert.True(t, exist)
@@ -546,12 +526,6 @@ func TestMapWithEmpty(t *testing.T) {
 	assert.True(t, exist)
 	assert.EqualValues(t, ValueTypeBytes, val.Type())
 	assert.EqualValues(t, []byte{7, 8, 9}, val.BytesVal().AsRaw())
-
-	sm.Upsert("yet_another_key", NewValueString("yet_another_value"))
-	val, exist = sm.Get("yet_another_key")
-	assert.True(t, exist)
-	assert.EqualValues(t, ValueTypeString, val.Type())
-	assert.EqualValues(t, "yet_another_value", val.StringVal())
 
 	sm.UpsertString("yet_another_key_string", "yet_another_value")
 	val, exist = sm.Get("yet_another_key_string")
@@ -589,7 +563,6 @@ func TestMapWithEmpty(t *testing.T) {
 	assert.True(t, sm.Remove("other_key_double"))
 	assert.True(t, sm.Remove("other_key_bool"))
 	assert.True(t, sm.Remove("other_key_bytes"))
-	assert.True(t, sm.Remove("yet_another_key"))
 	assert.True(t, sm.Remove("yet_another_key_string"))
 	assert.True(t, sm.Remove("yet_another_key_int"))
 	assert.True(t, sm.Remove("yet_another_key_double"))
@@ -757,7 +730,7 @@ func TestMap_RemoveIf(t *testing.T) {
 	am.UpsertInt("k_int", int64(123))
 	am.UpsertDouble("k_double", float64(1.23))
 	am.UpsertBool("k_bool", true)
-	am.Upsert("k_empty", NewValueEmpty())
+	am.UpsertEmpty("k_empty")
 
 	assert.Equal(t, 5, am.Len())
 
@@ -1186,17 +1159,15 @@ func generateTestValueMap() Value {
 	attrMap.UpsertInt("intKey", 7)
 	attrMap.UpsertDouble("floatKey", 18.6)
 	attrMap.UpsertBool("boolKey", false)
-	attrMap.Upsert("nullKey", NewValueEmpty())
+	attrMap.UpsertEmpty("nullKey")
 
-	vm := NewValueMap()
-	vm.MapVal().UpsertString("keyOne", "valOne")
-	vm.MapVal().UpsertString("keyTwo", "valTwo")
-	attrMap.Upsert("mapKey", vm)
+	m := attrMap.UpsertEmptyMap("mapKey")
+	m.UpsertString("keyOne", "valOne")
+	m.UpsertString("keyTwo", "valTwo")
 
-	vs := NewValueSlice()
-	vs.SliceVal().AppendEmpty().SetStringVal("strOne")
-	vs.SliceVal().AppendEmpty().SetStringVal("strTwo")
-	attrMap.Upsert("arrKey", vs)
+	s := attrMap.UpsertEmptySlice("arrKey")
+	s.AppendEmpty().SetStringVal("strOne")
+	s.AppendEmpty().SetStringVal("strTwo")
 
 	return ret
 }


### PR DESCRIPTION
Remove deprecated `pcommon.Map` methods: `Update`, `Upsert`, `InsertNull`

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector/issues/5974
