### PR TITLE
Builder skip Go binary validation if not used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 ### 💡 Enhancements 💡
 
 - Add `skip-get-modules` builder flag to support isolated environment executions (#6009)
+  - Skip unnecessary Go binary path validation when the builder is used with `skip-compilation` and `skip-get-modules` flags (#6026)
 
 ## v0.59.0 Beta
 

--- a/cmd/builder/internal/builder/config.go
+++ b/cmd/builder/internal/builder/config.go
@@ -89,16 +89,18 @@ func NewDefaultConfig() Config {
 
 // Validate checks whether the current configuration is valid
 func (c *Config) Validate() error {
-	// #nosec G204
-	if _, err := exec.Command(c.Distribution.Go, "env").CombinedOutput(); err != nil {
-		path, err := exec.LookPath("go")
-		if err != nil {
-			return ErrGoNotFound
+	if !c.SkipCompilation || !c.SkipGetModules {
+		// #nosec G204
+		if _, err := exec.Command(c.Distribution.Go, "env").CombinedOutput(); err != nil {
+			path, err := exec.LookPath("go")
+			if err != nil {
+				return ErrGoNotFound
+			}
+			c.Distribution.Go = path
 		}
-		c.Distribution.Go = path
-	}
 
-	c.Logger.Info("Using go", zap.String("go-executable", c.Distribution.Go))
+		c.Logger.Info("Using go", zap.String("go-executable", c.Distribution.Go))
+	}
 
 	return nil
 }

--- a/cmd/builder/internal/builder/config_test.go
+++ b/cmd/builder/internal/builder/config_test.go
@@ -135,3 +135,14 @@ func TestNewDefaultConfig(t *testing.T) {
 	require.NoError(t, cfg.ParseModules())
 	require.NoError(t, cfg.Validate())
 }
+
+func TestSkipGoValidation(t *testing.T) {
+	cfg := Config{
+		Distribution: Distribution{
+			Go: "invalid/go/binary/path",
+		},
+		SkipCompilation: true,
+		SkipGetModules:  true,
+	}
+	require.NoError(t, cfg.Validate())
+}

--- a/cmd/builder/internal/builder/config_test.go
+++ b/cmd/builder/internal/builder/config_test.go
@@ -144,5 +144,15 @@ func TestSkipGoValidation(t *testing.T) {
 		SkipCompilation: true,
 		SkipGetModules:  true,
 	}
-	require.NoError(t, cfg.Validate())
+	assert.NoError(t, cfg.Validate())
 }
+
+func TestSkipGoInitialization(t *testing.T) {
+	cfg := Config{
+		SkipCompilation: true,
+		SkipGetModules:  true,
+	}
+	assert.NoError(t, cfg.Validate())
+	assert.Zero(t, cfg.Distribution.Go)
+}
+

--- a/cmd/builder/internal/builder/config_test.go
+++ b/cmd/builder/internal/builder/config_test.go
@@ -155,4 +155,3 @@ func TestSkipGoInitialization(t *testing.T) {
 	assert.NoError(t, cfg.Validate())
 	assert.Zero(t, cfg.Distribution.Go)
 }
-


### PR DESCRIPTION
**Description:** Builder skip Go binary validation if not used

As a follow-up on (#6009), when the builder is used with `-skip-compilation` and `-skip-get-modules` flags, it only generates distribution go codes. So there is no need for Go binary.
Isolated build environments like [Bazel](https://bazel.build/) or some CIs can skip passing Go binary to the builder.