### PR TITLE
Deprecate config.Unmarshallable in favor of confmap.Unmarshallable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Deprecate `MetricDataPointFlagsImmutable` type. (#6017)
 - Deprecate `*DataPoint.[Set]FlagsImmutable()` funcs in favor of `*DataPoint.[Set]Flags()`. (#6017)
 - Deprecate `LogRecord.FlagsStruct()` and `LogRecord.SetFlagsStruct()` in favor of `LogRecord.Flags()` and `LogRecord.SetFlags()`. (#6007)
+- Deprecate `config.Unmarshallable` in favor of `confmap.Unmarshaler`. (#6031)
 
 ### 💡 Enhancements 💡
 

--- a/config/common.go
+++ b/config/common.go
@@ -26,13 +26,8 @@ type validatable interface {
 	Validate() error
 }
 
-// Unmarshallable defines an optional interface for custom configuration unmarshalling.
-// A configuration struct can implement this interface to override the default unmarshalling.
-type Unmarshallable interface {
-	// Unmarshal is a function that unmarshalls a confmap.Conf into the unmarshable struct in a custom way.
-	// The confmap.Conf for this specific component may be nil or empty if no config available.
-	Unmarshal(component *confmap.Conf) error
-}
+// Deprecated: [v0.60.0] use confmap.Unmarshaler.
+type Unmarshallable = confmap.Unmarshaler
 
 // DataType is a special Type that represents the data types supported by the collector. We currently support
 // collecting metrics, traces and logs, this can expand in the future.
@@ -51,7 +46,7 @@ const (
 )
 
 func unmarshal(componentSection *confmap.Conf, intoCfg interface{}) error {
-	if cu, ok := intoCfg.(Unmarshallable); ok {
+	if cu, ok := intoCfg.(confmap.Unmarshaler); ok {
 		return cu.Unmarshal(componentSection)
 	}
 

--- a/config/exporter.go
+++ b/config/exporter.go
@@ -27,7 +27,7 @@ type Exporter interface {
 }
 
 // UnmarshalExporter helper function to unmarshal an Exporter config.
-// It checks if the config implements Unmarshallable and uses that if available,
+// It checks if the config implements confmap.Unmarshaler and uses that if available,
 // otherwise uses Map.UnmarshalExact, erroring if a field is nonexistent.
 func UnmarshalExporter(conf *confmap.Conf, cfg Exporter) error {
 	return unmarshal(conf, cfg)

--- a/config/extension.go
+++ b/config/extension.go
@@ -27,7 +27,7 @@ type Extension interface {
 }
 
 // UnmarshalExtension helper function to unmarshal an Extension config.
-// It checks if the config implements Unmarshallable and uses that if available,
+// It checks if the config implements confmap.Unmarshaler and uses that if available,
 // otherwise uses Map.UnmarshalExact, erroring if a field is nonexistent.
 func UnmarshalExtension(conf *confmap.Conf, cfg Extension) error {
 	return unmarshal(conf, cfg)

--- a/config/processor.go
+++ b/config/processor.go
@@ -27,7 +27,7 @@ type Processor interface {
 }
 
 // UnmarshalProcessor helper function to unmarshal a Processor config.
-// It checks if the config implements Unmarshallable and uses that if available,
+// It checks if the config implements confmap.Unmarshaler and uses that if available,
 // otherwise uses Map.UnmarshalExact, erroring if a field is nonexistent.
 func UnmarshalProcessor(conf *confmap.Conf, cfg Processor) error {
 	return unmarshal(conf, cfg)

--- a/config/receiver.go
+++ b/config/receiver.go
@@ -27,7 +27,7 @@ type Receiver interface {
 }
 
 // UnmarshalReceiver helper function to unmarshal a Receiver config.
-// It checks if the config implements Unmarshallable and uses that if available,
+// It checks if the config implements confmap.Unmarshaler and uses that if available,
 // otherwise uses Map.UnmarshalExact, erroring if a field is nonexistent.
 func UnmarshalReceiver(conf *confmap.Conf, cfg Receiver) error {
 	return unmarshal(conf, cfg)

--- a/confmap/confmap.go
+++ b/confmap/confmap.go
@@ -209,3 +209,10 @@ func mapKeyStringToMapKeyTextUnmarshalerHookFunc() mapstructure.DecodeHookFuncTy
 		return data, nil
 	}
 }
+
+// Unmarshaler interface may be implemented by types to customize their behavior when being unmarshaled from a Conf.
+type Unmarshaler interface {
+	// Unmarshal a Conf into the struct in a custom way.
+	// The Conf for this specific component may be nil or empty if no config available.
+	Unmarshal(component *Conf) error
+}

--- a/receiver/otlpreceiver/config.go
+++ b/receiver/otlpreceiver/config.go
@@ -44,7 +44,7 @@ type Config struct {
 }
 
 var _ config.Receiver = (*Config)(nil)
-var _ config.Unmarshallable = (*Config)(nil)
+var _ confmap.Unmarshaler = (*Config)(nil)
 
 // Validate checks the receiver configuration is valid
 func (cfg *Config) Validate() error {


### PR DESCRIPTION
This interface is concerned with unmarshalling a `confmap.Conf`, so is arguably more appropriate
in the `confmap` package. More concretely, moving this is necessary to avoid an import cycle as
would be introduced by #6029.