### PR TITLE
Fix wrong name suggestion made by bogdandrutu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### 🚩 Deprecations 🚩
 
+- Deprecate `p[metric|log|trace].MarshalerSizer` in favor of `p[metric|log|trace].MarshalSizer`. (#6033)
 - Deprecate `pcommon.Map.Update+` in favor of `pcommon.Map.Get` + `pcommon.Value.Set+` (#6013)
 - Deprecate `pcommon.Empty[Trace|Span]ID` in favor of `pcommon.New[Trace|Span]IDEmpty` (#6008)
 - Deprecate `pcommon.[Trace|Span]ID.Bytes` in favor direct conversion. (#6008)

--- a/pdata/plog/encoding.go
+++ b/pdata/plog/encoding.go
@@ -14,8 +14,11 @@
 
 package plog // import "go.opentelemetry.io/collector/pdata/plog"
 
-// MarshalerSizer is the interface that groups the basic Marshal and Size methods
-type MarshalerSizer interface {
+// Deprecated: [v0.60.0] use MarshalSizer.
+type MarshalerSizer = MarshalSizer
+
+// MarshalSizer is the interface that groups the basic Marshal and Size methods
+type MarshalSizer interface {
 	Marshaler
 	Sizer
 }

--- a/pdata/plog/pb.go
+++ b/pdata/plog/pb.go
@@ -19,9 +19,9 @@ import (
 	otlplogs "go.opentelemetry.io/collector/pdata/internal/data/protogen/logs/v1"
 )
 
-// NewProtoMarshaler returns a MarshalerSizer.
+// NewProtoMarshaler returns a MarshalSizer.
 // Marshals to OTLP binary protobuf bytes and calculates the size of the marshaled Logs.
-func NewProtoMarshaler() MarshalerSizer {
+func NewProtoMarshaler() MarshalSizer {
 	return newPbMarshaler()
 }
 

--- a/pdata/pmetric/encoding.go
+++ b/pdata/pmetric/encoding.go
@@ -14,8 +14,11 @@
 
 package pmetric // import "go.opentelemetry.io/collector/pdata/pmetric"
 
-// MarshalerSizer is the interface that groups the basic Marshal and Size methods
-type MarshalerSizer interface {
+// Deprecated: [v0.60.0] use MarshalSizer.
+type MarshalerSizer = MarshalSizer
+
+// MarshalSizer is the interface that groups the basic Marshal and Size methods
+type MarshalSizer interface {
 	Marshaler
 	Sizer
 }

--- a/pdata/pmetric/pb.go
+++ b/pdata/pmetric/pb.go
@@ -19,9 +19,9 @@ import (
 	otlpmetrics "go.opentelemetry.io/collector/pdata/internal/data/protogen/metrics/v1"
 )
 
-// NewProtoMarshaler returns a MarshalerSizer.
+// NewProtoMarshaler returns a MarshalSizer.
 // Marshals to OTLP binary protobuf bytes and calculates the size of the marshaled Metrics.
-func NewProtoMarshaler() MarshalerSizer {
+func NewProtoMarshaler() MarshalSizer {
 	return newPbMarshaler()
 }
 

--- a/pdata/ptrace/encoding.go
+++ b/pdata/ptrace/encoding.go
@@ -14,8 +14,11 @@
 
 package ptrace // import "go.opentelemetry.io/collector/pdata/ptrace"
 
-// MarshalerSizer is the interface that groups the basic Marshal and Size methods
-type MarshalerSizer interface {
+// Deprecated: [v0.60.0] use MarshalSizer.
+type MarshalerSizer = MarshalSizer
+
+// MarshalSizer is the interface that groups the basic Marshal and Size methods
+type MarshalSizer interface {
 	Marshaler
 	Sizer
 }

--- a/pdata/ptrace/pb.go
+++ b/pdata/ptrace/pb.go
@@ -19,9 +19,9 @@ import (
 	otlptrace "go.opentelemetry.io/collector/pdata/internal/data/protogen/trace/v1"
 )
 
-// NewProtoMarshaler returns a MarshalerSizer.
+// NewProtoMarshaler returns a MarshalSizer.
 // Marshals to OTLP binary protobuf bytes and calculates the size of the marshaled Traces.
-func NewProtoMarshaler() MarshalerSizer {
+func NewProtoMarshaler() MarshalSizer {
 	return newPbMarshaler()
 }
 


### PR DESCRIPTION
In https://github.com/open-telemetry/opentelemetry-collector/pull/5929, the suggestion to have the combined name as "MarshalerSizer" was wrong.

Even the comment https://github.com/open-telemetry/opentelemetry-collector/pull/5929#discussion_r948230586 was wrong since the link is `WriteSeeker`.

Signed-off-by: Bogdan <bogdandrutu@gmail.com>
