### PR TITLE
[pdata] Use copy instead of manual copying slices.

### DIFF
--- a/pdata/internal/cmd/pdatagen/internal/primitive_slice_structs.go
+++ b/pdata/internal/cmd/pdatagen/internal/primitive_slice_structs.go
@@ -67,9 +67,7 @@ func copy${structName}(from []${itemType}) []${itemType} {
 	}
 
 	to := make([]${itemType}, len(from))
-	for i := range from {
-		to[i] = from[i]
-	}
+	copy(to, from)
 	return to
 }`
 

--- a/pdata/pcommon/generated_primitive_slice.go
+++ b/pdata/pcommon/generated_primitive_slice.go
@@ -67,9 +67,7 @@ func copyByteSlice(from []byte) []byte {
 	}
 
 	to := make([]byte, len(from))
-	for i := range from {
-		to[i] = from[i]
-	}
+	copy(to, from)
 	return to
 }
 
@@ -121,9 +119,7 @@ func copyFloat64Slice(from []float64) []float64 {
 	}
 
 	to := make([]float64, len(from))
-	for i := range from {
-		to[i] = from[i]
-	}
+	copy(to, from)
 	return to
 }
 
@@ -175,8 +171,6 @@ func copyUInt64Slice(from []uint64) []uint64 {
 	}
 
 	to := make([]uint64, len(from))
-	for i := range from {
-		to[i] = from[i]
-	}
+	copy(to, from)
 	return to
 }


### PR DESCRIPTION
Follow-up to item 1 in https://github.com/open-telemetry/opentelemetry-collector/pull/5971

> Copying can be done in-place to save allocations.