### PR TITLE
[pdata] Add CopyTo and MoveTo methods to primitive slices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 - Add `skip-get-modules` builder flag to support isolated environment executions (#6009)
   - Skip unnecessary Go binary path validation when the builder is used with `skip-compilation` and `skip-get-modules` flags (#6026)
 - Add mapstructure hook function for confmap.Unmarshaler interface (#6029)
+- Add CopyTo and MoveTo methods to primitive slices (#6044)
 
 ### 🧰 Bug fixes 🧰
 

--- a/pdata/internal/cmd/pdatagen/internal/base_fields.go
+++ b/pdata/internal/cmd/pdatagen/internal/base_fields.go
@@ -52,14 +52,6 @@ func (ms ${structName}) Set${fieldName}(v ${returnType}) {
 	ms.getOrig().${originFieldName} = v
 }`
 
-const copyToPrimitiveSliceTestTemplate = `	if len(ms.getOrig().${originFieldName}) == 0 {	
-		dest.getOrig().${originFieldName} = nil
-	} else {
-		dest.getOrig().${originFieldName} = make(${rawType}, len(ms.getOrig().${originFieldName}))
-		copy(dest.getOrig().${originFieldName}, ms.getOrig().${originFieldName})
-	}
-`
-
 const accessorsPrimitiveSliceTemplate = `// ${fieldName} returns the ${lowerFieldName} associated with this ${structName}.
 func (ms ${structName}) ${fieldName}() ${packageName}${returnType} {
 	return ${packageName}${returnType}(internal.New${returnType}(&ms.getOrig().${originFieldName}))
@@ -516,20 +508,7 @@ func (psf *primitiveSliceField) generateSetWithTestValue(sb *strings.Builder) {
 }
 
 func (psf *primitiveSliceField) generateCopyToValue(ms baseStruct, sb *strings.Builder) {
-	sb.WriteString(os.Expand(copyToPrimitiveSliceTestTemplate, func(name string) string {
-		switch name {
-		case "structName":
-			return ms.getName()
-		case "originFieldName":
-			return psf.originFieldName
-		case "rawType":
-			return psf.rawType
-		case "returnType":
-			return psf.returnType
-		default:
-			panic(name)
-		}
-	}))
+	sb.WriteString("\tms." + psf.fieldName + "().CopyTo(dest." + psf.fieldName + "())")
 }
 
 var _ baseField = (*primitiveSliceField)(nil)

--- a/pdata/internal/cmd/pdatagen/internal/primitive_slice_structs.go
+++ b/pdata/internal/cmd/pdatagen/internal/primitive_slice_structs.go
@@ -61,6 +61,17 @@ func (ms ${structName}) SetAt(i int, val ${itemType}) {
 	(*ms.getOrig())[i] = val
 }
 
+// MoveTo moves ${structName} to another instance.
+func (ms ${structName}) MoveTo(dest ${structName}) {
+	*dest.getOrig() = *ms.getOrig()
+	*ms.getOrig() = nil
+}
+
+// CopyTo copies ${structName} to another instance.
+func (ms ${structName}) CopyTo(dest ${structName}) {
+	*dest.getOrig() = copy${structName}(*ms.getOrig())
+}
+
 func copy${structName}(from []${itemType}) []${itemType} {
 	if len(from) == 0 {
 		return nil
@@ -84,6 +95,24 @@ const immutableSliceTestTemplate = `func TestNew${structName}(t *testing.T) {
 	ms.FromRaw([]${itemType}{3})
 	assert.Equal(t, 1, ms.Len())
 	assert.Equal(t, ${itemType}(3), ms.At(0))
+	
+	cp := New${structName}()
+	ms.CopyTo(cp)
+	ms.SetAt(0, ${itemType}(2))
+	assert.Equal(t, ${itemType}(2), ms.At(0))
+	assert.Equal(t, ${itemType}(3), cp.At(0))
+	ms.CopyTo(cp)
+	assert.Equal(t, ${itemType}(2), cp.At(0))
+	
+	mv := New${structName}()
+	ms.MoveTo(mv)
+	assert.Equal(t, 0, ms.Len())
+	assert.Equal(t, 1, mv.Len())
+	assert.Equal(t, ${itemType}(2), mv.At(0))
+	ms.FromRaw([]${itemType}{1, 2, 3})
+	ms.MoveTo(mv)
+	assert.Equal(t, 3, mv.Len())
+	assert.Equal(t, ${itemType}(1), mv.At(0))
 }`
 
 const primitiveSliceInternalTemplate = `

--- a/pdata/pcommon/generated_primitive_slice.go
+++ b/pdata/pcommon/generated_primitive_slice.go
@@ -61,6 +61,17 @@ func (ms ByteSlice) SetAt(i int, val byte) {
 	(*ms.getOrig())[i] = val
 }
 
+// MoveTo moves ByteSlice to another instance.
+func (ms ByteSlice) MoveTo(dest ByteSlice) {
+	*dest.getOrig() = *ms.getOrig()
+	*ms.getOrig() = nil
+}
+
+// CopyTo copies ByteSlice to another instance.
+func (ms ByteSlice) CopyTo(dest ByteSlice) {
+	*dest.getOrig() = copyByteSlice(*ms.getOrig())
+}
+
 func copyByteSlice(from []byte) []byte {
 	if len(from) == 0 {
 		return nil
@@ -115,6 +126,17 @@ func (ms Float64Slice) SetAt(i int, val float64) {
 	(*ms.getOrig())[i] = val
 }
 
+// MoveTo moves Float64Slice to another instance.
+func (ms Float64Slice) MoveTo(dest Float64Slice) {
+	*dest.getOrig() = *ms.getOrig()
+	*ms.getOrig() = nil
+}
+
+// CopyTo copies Float64Slice to another instance.
+func (ms Float64Slice) CopyTo(dest Float64Slice) {
+	*dest.getOrig() = copyFloat64Slice(*ms.getOrig())
+}
+
 func copyFloat64Slice(from []float64) []float64 {
 	if len(from) == 0 {
 		return nil
@@ -167,6 +189,17 @@ func (ms UInt64Slice) At(i int) uint64 {
 // SetAt sets uint64 item at particular index.
 func (ms UInt64Slice) SetAt(i int, val uint64) {
 	(*ms.getOrig())[i] = val
+}
+
+// MoveTo moves UInt64Slice to another instance.
+func (ms UInt64Slice) MoveTo(dest UInt64Slice) {
+	*dest.getOrig() = *ms.getOrig()
+	*ms.getOrig() = nil
+}
+
+// CopyTo copies UInt64Slice to another instance.
+func (ms UInt64Slice) CopyTo(dest UInt64Slice) {
+	*dest.getOrig() = copyUInt64Slice(*ms.getOrig())
 }
 
 func copyUInt64Slice(from []uint64) []uint64 {

--- a/pdata/pcommon/generated_primitive_slice_test.go
+++ b/pdata/pcommon/generated_primitive_slice_test.go
@@ -34,6 +34,24 @@ func TestNewByteSlice(t *testing.T) {
 	ms.FromRaw([]byte{3})
 	assert.Equal(t, 1, ms.Len())
 	assert.Equal(t, byte(3), ms.At(0))
+
+	cp := NewByteSlice()
+	ms.CopyTo(cp)
+	ms.SetAt(0, byte(2))
+	assert.Equal(t, byte(2), ms.At(0))
+	assert.Equal(t, byte(3), cp.At(0))
+	ms.CopyTo(cp)
+	assert.Equal(t, byte(2), cp.At(0))
+
+	mv := NewByteSlice()
+	ms.MoveTo(mv)
+	assert.Equal(t, 0, ms.Len())
+	assert.Equal(t, 1, mv.Len())
+	assert.Equal(t, byte(2), mv.At(0))
+	ms.FromRaw([]byte{1, 2, 3})
+	ms.MoveTo(mv)
+	assert.Equal(t, 3, mv.Len())
+	assert.Equal(t, byte(1), mv.At(0))
 }
 
 func TestNewFloat64Slice(t *testing.T) {
@@ -47,6 +65,24 @@ func TestNewFloat64Slice(t *testing.T) {
 	ms.FromRaw([]float64{3})
 	assert.Equal(t, 1, ms.Len())
 	assert.Equal(t, float64(3), ms.At(0))
+
+	cp := NewFloat64Slice()
+	ms.CopyTo(cp)
+	ms.SetAt(0, float64(2))
+	assert.Equal(t, float64(2), ms.At(0))
+	assert.Equal(t, float64(3), cp.At(0))
+	ms.CopyTo(cp)
+	assert.Equal(t, float64(2), cp.At(0))
+
+	mv := NewFloat64Slice()
+	ms.MoveTo(mv)
+	assert.Equal(t, 0, ms.Len())
+	assert.Equal(t, 1, mv.Len())
+	assert.Equal(t, float64(2), mv.At(0))
+	ms.FromRaw([]float64{1, 2, 3})
+	ms.MoveTo(mv)
+	assert.Equal(t, 3, mv.Len())
+	assert.Equal(t, float64(1), mv.At(0))
 }
 
 func TestNewUInt64Slice(t *testing.T) {
@@ -60,4 +96,22 @@ func TestNewUInt64Slice(t *testing.T) {
 	ms.FromRaw([]uint64{3})
 	assert.Equal(t, 1, ms.Len())
 	assert.Equal(t, uint64(3), ms.At(0))
+
+	cp := NewUInt64Slice()
+	ms.CopyTo(cp)
+	ms.SetAt(0, uint64(2))
+	assert.Equal(t, uint64(2), ms.At(0))
+	assert.Equal(t, uint64(3), cp.At(0))
+	ms.CopyTo(cp)
+	assert.Equal(t, uint64(2), cp.At(0))
+
+	mv := NewUInt64Slice()
+	ms.MoveTo(mv)
+	assert.Equal(t, 0, ms.Len())
+	assert.Equal(t, 1, mv.Len())
+	assert.Equal(t, uint64(2), mv.At(0))
+	ms.FromRaw([]uint64{1, 2, 3})
+	ms.MoveTo(mv)
+	assert.Equal(t, 3, mv.Len())
+	assert.Equal(t, uint64(1), mv.At(0))
 }

--- a/pdata/pmetric/generated_metrics.go
+++ b/pdata/pmetric/generated_metrics.go
@@ -1621,20 +1621,8 @@ func (ms HistogramDataPoint) CopyTo(dest HistogramDataPoint) {
 		dest.SetSum(ms.Sum())
 	}
 
-	if len(ms.getOrig().BucketCounts) == 0 {
-		dest.getOrig().BucketCounts = nil
-	} else {
-		dest.getOrig().BucketCounts = make([]uint64, len(ms.getOrig().BucketCounts))
-		copy(dest.getOrig().BucketCounts, ms.getOrig().BucketCounts)
-	}
-
-	if len(ms.getOrig().ExplicitBounds) == 0 {
-		dest.getOrig().ExplicitBounds = nil
-	} else {
-		dest.getOrig().ExplicitBounds = make([]float64, len(ms.getOrig().ExplicitBounds))
-		copy(dest.getOrig().ExplicitBounds, ms.getOrig().ExplicitBounds)
-	}
-
+	ms.BucketCounts().CopyTo(dest.BucketCounts())
+	ms.ExplicitBounds().CopyTo(dest.ExplicitBounds())
 	ms.Exemplars().CopyTo(dest.Exemplars())
 	dest.SetFlags(ms.Flags())
 	if ms.HasMin() {
@@ -2034,13 +2022,7 @@ func (ms Buckets) SetBucketCounts(v pcommon.UInt64Slice) {
 // CopyTo copies all properties from the current struct to the dest.
 func (ms Buckets) CopyTo(dest Buckets) {
 	dest.SetOffset(ms.Offset())
-	if len(ms.getOrig().BucketCounts) == 0 {
-		dest.getOrig().BucketCounts = nil
-	} else {
-		dest.getOrig().BucketCounts = make([]uint64, len(ms.getOrig().BucketCounts))
-		copy(dest.getOrig().BucketCounts, ms.getOrig().BucketCounts)
-	}
-
+	ms.BucketCounts().CopyTo(dest.BucketCounts())
 }
 
 // SummaryDataPointSlice logically represents a slice of SummaryDataPoint.


### PR DESCRIPTION
Follow-up item 3 to https://github.com/open-telemetry/opentelemetry-collector/pull/5971

> Add CopyTo/MoveTo and remove the copy logic from the parent's CopyTo.