### PR TITLE
Move TraceState to pcommon, expect usages similar with ids

### DIFF
--- a/pdata/internal/cmd/pdatagen/internal/common_structs.go
+++ b/pdata/internal/cmd/pdatagen/internal/common_structs.go
@@ -80,6 +80,14 @@ var timestampType = &primitiveType{
 	testVal:     "1234567890",
 }
 
+var traceStateType = &primitiveType{
+	structName:  "TraceState",
+	packageName: "pcommon",
+	rawType:     "string",
+	defaultVal:  `""`,
+	testVal:     `"congo=congos"`,
+}
+
 var startTimeField = &primitiveTypedField{
 	fieldName:       "StartTimestamp",
 	originFieldName: "StartTimeUnixNano",

--- a/pdata/internal/cmd/pdatagen/internal/trace_structs.go
+++ b/pdata/internal/cmd/pdatagen/internal/trace_structs.go
@@ -216,12 +216,7 @@ var spanStatus = &messageValueStruct{
 var traceStateField = &primitiveTypedField{
 	fieldName:       "TraceState",
 	originFieldName: "TraceState",
-	returnType: &primitiveType{
-		structName: "TraceState",
-		rawType:    "string",
-		defaultVal: `""`,
-		testVal:    `"congo=congos"`,
-	},
+	returnType:      traceStateType,
 }
 
 var droppedAttributesCount = &primitiveField{

--- a/pdata/pcommon/trace_state.go
+++ b/pdata/pcommon/trace_state.go
@@ -1,0 +1,23 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pcommon // import "go.opentelemetry.io/collector/pdata/pcommon"
+
+const (
+	// TraceStateEmpty represents the empty TraceState.
+	TraceStateEmpty TraceState = ""
+)
+
+// TraceState is a string representing the tracestate in w3c-trace-context format: https://www.w3.org/TR/trace-context/#tracestate-header
+type TraceState string

--- a/pdata/ptrace/generated_traces.go
+++ b/pdata/ptrace/generated_traces.go
@@ -621,12 +621,12 @@ func (ms Span) SetSpanID(v pcommon.SpanID) {
 }
 
 // TraceState returns the tracestate associated with this Span.
-func (ms Span) TraceState() TraceState {
-	return TraceState(ms.getOrig().TraceState)
+func (ms Span) TraceState() pcommon.TraceState {
+	return pcommon.TraceState(ms.getOrig().TraceState)
 }
 
 // SetTraceState replaces the tracestate associated with this Span.
-func (ms Span) SetTraceState(v TraceState) {
+func (ms Span) SetTraceState(v pcommon.TraceState) {
 	ms.getOrig().TraceState = string(v)
 }
 
@@ -1162,12 +1162,12 @@ func (ms SpanLink) SetSpanID(v pcommon.SpanID) {
 }
 
 // TraceState returns the tracestate associated with this SpanLink.
-func (ms SpanLink) TraceState() TraceState {
-	return TraceState(ms.getOrig().TraceState)
+func (ms SpanLink) TraceState() pcommon.TraceState {
+	return pcommon.TraceState(ms.getOrig().TraceState)
 }
 
 // SetTraceState replaces the tracestate associated with this SpanLink.
-func (ms SpanLink) SetTraceState(v TraceState) {
+func (ms SpanLink) SetTraceState(v pcommon.TraceState) {
 	ms.getOrig().TraceState = string(v)
 }
 

--- a/pdata/ptrace/generated_traces_test.go
+++ b/pdata/ptrace/generated_traces_test.go
@@ -470,8 +470,8 @@ func TestSpan_SpanID(t *testing.T) {
 
 func TestSpan_TraceState(t *testing.T) {
 	ms := NewSpan()
-	assert.Equal(t, TraceState(""), ms.TraceState())
-	testValTraceState := TraceState("congo=congos")
+	assert.Equal(t, pcommon.TraceState(""), ms.TraceState())
+	testValTraceState := pcommon.TraceState("congo=congos")
 	ms.SetTraceState(testValTraceState)
 	assert.Equal(t, testValTraceState, ms.TraceState())
 }
@@ -866,8 +866,8 @@ func TestSpanLink_SpanID(t *testing.T) {
 
 func TestSpanLink_TraceState(t *testing.T) {
 	ms := NewSpanLink()
-	assert.Equal(t, TraceState(""), ms.TraceState())
-	testValTraceState := TraceState("congo=congos")
+	assert.Equal(t, pcommon.TraceState(""), ms.TraceState())
+	testValTraceState := pcommon.TraceState("congo=congos")
 	ms.SetTraceState(testValTraceState)
 	assert.Equal(t, testValTraceState, ms.TraceState())
 }

--- a/pdata/ptrace/traces.go
+++ b/pdata/ptrace/traces.go
@@ -18,6 +18,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/internal"
 	otlpcollectortrace "go.opentelemetry.io/collector/pdata/internal/data/protogen/collector/trace/v1"
 	otlptrace "go.opentelemetry.io/collector/pdata/internal/data/protogen/trace/v1"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 )
 
 // Traces is the top-level struct that is propagated through the traces pipeline.
@@ -70,12 +71,12 @@ func (ms Traces) ResourceSpans() ResourceSpansSlice {
 	return newResourceSpansSlice(&ms.getOrig().ResourceSpans)
 }
 
-// TraceState is a string representing the tracestate in w3c-trace-context format: https://www.w3.org/TR/trace-context/#tracestate-header
-type TraceState string
+// Deprecated: [v0.60.0] use pcommon.TraceState.
+type TraceState = pcommon.TraceState
 
 const (
-	// TraceStateEmpty represents the empty TraceState.
-	TraceStateEmpty TraceState = ""
+	// Deprecated: [v0.60.0] use pcommon.TraceStateEmpty.
+	TraceStateEmpty = pcommon.TraceStateEmpty
 )
 
 // SpanKind is the type of span. Can be used to specify additional relationships between spans


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-collector/issues/6022

Will keep the type immutable and will offer mutatore similar with Flags "WithEntry" which will return a new TraceState.

Signed-off-by: Bogdan <bogdandrutu@gmail.com>
