### PR TITLE
[pdata] Add Append and EnsureCapacity methods to primitive slices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 - Delete deprecated `p[metric|log|trace].MarshalerSizer` interfaces (#6083)
 
+### 💡 Enhancements 💡
+
+- Add AppendEmpty and EnsureCapacity method to primitive pdata slices (#6060)
 
 ## v0.60.0 Beta
 

--- a/pdata/internal/cmd/pdatagen/internal/primitive_slice_structs.go
+++ b/pdata/internal/cmd/pdatagen/internal/primitive_slice_structs.go
@@ -61,6 +61,25 @@ func (ms ${structName}) SetAt(i int, val ${itemType}) {
 	(*ms.getOrig())[i] = val
 }
 
+// EnsureCapacity ensures ${structName} has at least the specified capacity.
+// 1. If the newCap <= cap, then is no change in capacity.
+// 2. If the newCap > cap, then the slice capacity will be expanded to the provided value.
+func (ms ${structName}) EnsureCapacity(newCap int) {
+	oldCap := cap(*ms.getOrig())
+	if newCap <= oldCap {
+		return
+	}
+
+	newOrig := make([]${itemType}, len(*ms.getOrig()), newCap)
+	copy(newOrig, *ms.getOrig())
+	*ms.getOrig() = newOrig
+}
+
+// Append appends extra elements to ${structName}.
+func (ms ${structName}) Append(elms ...${itemType}) {
+	*ms.getOrig() = append(*ms.getOrig(), elms...)
+}
+
 // MoveTo moves ${structName} to another instance.
 func (ms ${structName}) MoveTo(dest ${structName}) {
 	*dest.getOrig() = *ms.getOrig()
@@ -106,6 +125,22 @@ const immutableSliceTestTemplate = `func TestNew${structName}(t *testing.T) {
 	ms.MoveTo(mv)
 	assert.Equal(t, 3, mv.Len())
 	assert.Equal(t, ${itemType}(1), mv.At(0))
+}
+
+func Test${structName}Append(t *testing.T) {
+	ms := New${structName}()
+	ms.FromRaw([]${itemType}{1, 2, 3})
+	ms.Append(4, 5)
+	assert.Equal(t, 5, ms.Len())
+	assert.Equal(t, ${itemType}(5), ms.At(4))
+}
+
+func Test${structName}EnsureCapacity(t *testing.T) {
+	ms := New${structName}()
+	ms.EnsureCapacity(4)
+	assert.Equal(t, 4, cap(*ms.getOrig()))
+	ms.EnsureCapacity(2)
+	assert.Equal(t, 4, cap(*ms.getOrig()))
 }`
 
 const primitiveSliceInternalTemplate = `

--- a/pdata/pcommon/generated_primitive_slice.go
+++ b/pdata/pcommon/generated_primitive_slice.go
@@ -61,6 +61,25 @@ func (ms ByteSlice) SetAt(i int, val byte) {
 	(*ms.getOrig())[i] = val
 }
 
+// EnsureCapacity ensures ByteSlice has at least the specified capacity.
+// 1. If the newCap <= cap, then is no change in capacity.
+// 2. If the newCap > cap, then the slice capacity will be expanded to the provided value.
+func (ms ByteSlice) EnsureCapacity(newCap int) {
+	oldCap := cap(*ms.getOrig())
+	if newCap <= oldCap {
+		return
+	}
+
+	newOrig := make([]byte, len(*ms.getOrig()), newCap)
+	copy(newOrig, *ms.getOrig())
+	*ms.getOrig() = newOrig
+}
+
+// Append appends extra elements to ByteSlice.
+func (ms ByteSlice) Append(elms ...byte) {
+	*ms.getOrig() = append(*ms.getOrig(), elms...)
+}
+
 // MoveTo moves ByteSlice to another instance.
 func (ms ByteSlice) MoveTo(dest ByteSlice) {
 	*dest.getOrig() = *ms.getOrig()
@@ -119,6 +138,25 @@ func (ms Float64Slice) SetAt(i int, val float64) {
 	(*ms.getOrig())[i] = val
 }
 
+// EnsureCapacity ensures Float64Slice has at least the specified capacity.
+// 1. If the newCap <= cap, then is no change in capacity.
+// 2. If the newCap > cap, then the slice capacity will be expanded to the provided value.
+func (ms Float64Slice) EnsureCapacity(newCap int) {
+	oldCap := cap(*ms.getOrig())
+	if newCap <= oldCap {
+		return
+	}
+
+	newOrig := make([]float64, len(*ms.getOrig()), newCap)
+	copy(newOrig, *ms.getOrig())
+	*ms.getOrig() = newOrig
+}
+
+// Append appends extra elements to Float64Slice.
+func (ms Float64Slice) Append(elms ...float64) {
+	*ms.getOrig() = append(*ms.getOrig(), elms...)
+}
+
 // MoveTo moves Float64Slice to another instance.
 func (ms Float64Slice) MoveTo(dest Float64Slice) {
 	*dest.getOrig() = *ms.getOrig()
@@ -175,6 +213,25 @@ func (ms UInt64Slice) At(i int) uint64 {
 // SetAt sets uint64 item at particular index.
 func (ms UInt64Slice) SetAt(i int, val uint64) {
 	(*ms.getOrig())[i] = val
+}
+
+// EnsureCapacity ensures UInt64Slice has at least the specified capacity.
+// 1. If the newCap <= cap, then is no change in capacity.
+// 2. If the newCap > cap, then the slice capacity will be expanded to the provided value.
+func (ms UInt64Slice) EnsureCapacity(newCap int) {
+	oldCap := cap(*ms.getOrig())
+	if newCap <= oldCap {
+		return
+	}
+
+	newOrig := make([]uint64, len(*ms.getOrig()), newCap)
+	copy(newOrig, *ms.getOrig())
+	*ms.getOrig() = newOrig
+}
+
+// Append appends extra elements to UInt64Slice.
+func (ms UInt64Slice) Append(elms ...uint64) {
+	*ms.getOrig() = append(*ms.getOrig(), elms...)
 }
 
 // MoveTo moves UInt64Slice to another instance.

--- a/pdata/pcommon/generated_primitive_slice_test.go
+++ b/pdata/pcommon/generated_primitive_slice_test.go
@@ -54,6 +54,22 @@ func TestNewByteSlice(t *testing.T) {
 	assert.Equal(t, byte(1), mv.At(0))
 }
 
+func TestByteSliceAppend(t *testing.T) {
+	ms := NewByteSlice()
+	ms.FromRaw([]byte{1, 2, 3})
+	ms.Append(4, 5)
+	assert.Equal(t, 5, ms.Len())
+	assert.Equal(t, byte(5), ms.At(4))
+}
+
+func TestByteSliceEnsureCapacity(t *testing.T) {
+	ms := NewByteSlice()
+	ms.EnsureCapacity(4)
+	assert.Equal(t, 4, cap(*ms.getOrig()))
+	ms.EnsureCapacity(2)
+	assert.Equal(t, 4, cap(*ms.getOrig()))
+}
+
 func TestNewFloat64Slice(t *testing.T) {
 	ms := NewFloat64Slice()
 	assert.Equal(t, 0, ms.Len())
@@ -85,6 +101,22 @@ func TestNewFloat64Slice(t *testing.T) {
 	assert.Equal(t, float64(1), mv.At(0))
 }
 
+func TestFloat64SliceAppend(t *testing.T) {
+	ms := NewFloat64Slice()
+	ms.FromRaw([]float64{1, 2, 3})
+	ms.Append(4, 5)
+	assert.Equal(t, 5, ms.Len())
+	assert.Equal(t, float64(5), ms.At(4))
+}
+
+func TestFloat64SliceEnsureCapacity(t *testing.T) {
+	ms := NewFloat64Slice()
+	ms.EnsureCapacity(4)
+	assert.Equal(t, 4, cap(*ms.getOrig()))
+	ms.EnsureCapacity(2)
+	assert.Equal(t, 4, cap(*ms.getOrig()))
+}
+
 func TestNewUInt64Slice(t *testing.T) {
 	ms := NewUInt64Slice()
 	assert.Equal(t, 0, ms.Len())
@@ -114,4 +146,20 @@ func TestNewUInt64Slice(t *testing.T) {
 	ms.MoveTo(mv)
 	assert.Equal(t, 3, mv.Len())
 	assert.Equal(t, uint64(1), mv.At(0))
+}
+
+func TestUInt64SliceAppend(t *testing.T) {
+	ms := NewUInt64Slice()
+	ms.FromRaw([]uint64{1, 2, 3})
+	ms.Append(4, 5)
+	assert.Equal(t, 5, ms.Len())
+	assert.Equal(t, uint64(5), ms.At(4))
+}
+
+func TestUInt64SliceEnsureCapacity(t *testing.T) {
+	ms := NewUInt64Slice()
+	ms.EnsureCapacity(4)
+	assert.Equal(t, 4, cap(*ms.getOrig()))
+	ms.EnsureCapacity(2)
+	assert.Equal(t, 4, cap(*ms.getOrig()))
 }


### PR DESCRIPTION
Follow-up PR from https://github.com/open-telemetry/opentelemetry-collector/pull/5971:

> No way of increasing the capacity or length. We can discuss about that API.

Given that we have `SetAt` interface not `Append...`, I think it makes sense to have `SetLen`. But I'm open to other suggestions

Fixes https://github.com/open-telemetry/opentelemetry-collector/issues/6063

cc @bogdandrutu 
