### PR TITLE
[pdata] Expose pcommon.Value.AsRaw/FromRaw methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Delete deprecated `config.Unmarshalable` interface. (#6084)
 - Delete deprecated `p[metric|log|trace].MarshalerSizer` interfaces (#6083)
 
+### 💡 Enhancements 💡
+
+- Expose `AsRaw` and `FromRaw` `pcommon.Value` methods (#6090)
+
 ## v0.60.0 Beta
 
 ### 🛑 Breaking changes 🛑

--- a/pdata/pcommon/common.go
+++ b/pdata/pcommon/common.go
@@ -140,7 +140,7 @@ func (v Value) getOrig() *otlpcommon.AnyValue {
 	return internal.GetOrigValue(internal.Value(v))
 }
 
-func (v Value) fromRaw(iv interface{}) {
+func (v Value) FromRaw(iv interface{}) {
 	switch tv := iv.(type) {
 	case nil:
 		v.getOrig().Value = nil
@@ -504,7 +504,7 @@ func float64AsString(f float64) string {
 	return string(b)
 }
 
-func (v Value) asRaw() interface{} {
+func (v Value) AsRaw() interface{} {
 	switch v.Type() {
 	case ValueTypeEmpty:
 		return nil
@@ -1019,7 +1019,7 @@ func (m Map) CopyTo(dest Map) {
 func (m Map) AsRaw() map[string]interface{} {
 	rawMap := make(map[string]interface{})
 	m.Range(func(k string, v Value) bool {
-		rawMap[k] = v.asRaw()
+		rawMap[k] = v.AsRaw()
 		return true
 	})
 	return rawMap
@@ -1035,7 +1035,7 @@ func (m Map) FromRaw(rawMap map[string]interface{}) {
 	ix := 0
 	for k, iv := range rawMap {
 		origs[ix].Key = k
-		newValue(&origs[ix].Value).fromRaw(iv)
+		newValue(&origs[ix].Value).FromRaw(iv)
 		ix++
 	}
 	*m.getOrig() = origs
@@ -1053,7 +1053,7 @@ func NewSliceFromRaw(rawSlice []interface{}) Slice {
 func (es Slice) AsRaw() []interface{} {
 	rawSlice := make([]interface{}, 0, es.Len())
 	for i := 0; i < es.Len(); i++ {
-		rawSlice = append(rawSlice, es.At(i).asRaw())
+		rawSlice = append(rawSlice, es.At(i).AsRaw())
 	}
 	return rawSlice
 }
@@ -1066,7 +1066,7 @@ func (es Slice) FromRaw(rawSlice []interface{}) {
 	}
 	origs := make([]otlpcommon.AnyValue, len(rawSlice))
 	for ix, iv := range rawSlice {
-		newValue(&origs[ix]).fromRaw(iv)
+		newValue(&origs[ix]).FromRaw(iv)
 	}
 	*es.getOrig() = origs
 }

--- a/pdata/pcommon/common_test.go
+++ b/pdata/pcommon/common_test.go
@@ -639,7 +639,7 @@ func TestMap_Range(t *testing.T) {
 	assert.Equal(t, 1, calls)
 
 	am.Range(func(k string, v Value) bool {
-		assert.Equal(t, rawMap[k], v.asRaw())
+		assert.Equal(t, rawMap[k], v.AsRaw())
 		delete(rawMap, k)
 		return true
 	})
@@ -1047,7 +1047,7 @@ func TestValueAsRaw(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			actual := test.input.asRaw()
+			actual := test.input.AsRaw()
 			assert.Equal(t, test.expected, actual)
 		})
 	}
@@ -1206,7 +1206,7 @@ func TestNewValueFromRaw(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			actual := NewValueEmpty()
-			actual.fromRaw(tt.input)
+			actual.FromRaw(tt.input)
 			assert.Equal(t, tt.expected, actual)
 		})
 	}


### PR DESCRIPTION
These methods would be good to expose given that we have it for several other types. They would be pretty useful to replace custom functions in https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/pkg/telemetryquerylanguage/contexts/internal/tqlcommon/value.go