### PR TITLE
Deprecate pmetric.OptionalType, unused enum type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 - Replace `pcommon.NewValueBytes` with `pcommon.NewValueBytesEmpty`. (#6088)
 - Delete deprecated `pcommon.Value.SetBytesVal`. (#6088)
 
+### 🚩 Deprecations 🚩
+
+- Deprecate pmetric.OptionalType, unused enum type. (#6096)
+
 ### 💡 Enhancements 💡
 
 - Add AppendEmpty and EnsureCapacity method to primitive pdata slices (#6060)

--- a/pdata/pmetric/metrics.go
+++ b/pdata/pmetric/metrics.go
@@ -249,15 +249,17 @@ func (nt ExemplarValueType) String() string {
 	return ""
 }
 
-// OptionalType wraps optional fields into oneof fields
+// Deprecated: [v0.61.0] not used, will be deleted in next release.
 type OptionalType int32
 
 const (
+	// Deprecated: [v0.61.0] not used, will be deleted in next release.
 	OptionalTypeNone OptionalType = iota
+	// Deprecated: [v0.61.0] not used, will be deleted in next release.
 	OptionalTypeDouble
 )
 
-// String returns the string representation of the OptionalType.
+// Deprecated: [v0.61.0] not used, will be deleted in next release.
 func (ot OptionalType) String() string {
 	switch ot {
 	case OptionalTypeNone:


### PR DESCRIPTION
Signed-off-by: Bogdan <bogdandrutu@gmail.com>
