### PR TITLE
Delete deprecated plog.LogRecord.[Set]FlagStruct funcs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Replace `pcommon.NewValueBytes` with `pcommon.NewValueBytesEmpty`. (#6088)
 - Delete deprecated `pcommon.Value.SetBytesVal`. (#6088)
 - Delete deprecated `pmetric.Metric.SetDataType`. (#6095)
+- Delete deprecated `plog.LogRecord.[Set]FlagStruct` funcs. (#6100)
 
 ### 🚩 Deprecations 🚩
 

--- a/pdata/plog/logs.go
+++ b/pdata/plog/logs.go
@@ -104,13 +104,3 @@ const (
 
 // String returns the string representation of the SeverityNumber.
 func (sn SeverityNumber) String() string { return otlplogs.SeverityNumber(sn).String() }
-
-// Deprecated: [v0.60.0] use Flags().
-func (ms LogRecord) FlagsStruct() LogRecordFlags {
-	return ms.Flags()
-}
-
-// Deprecated: [v0.60.0] use SetFlags().
-func (ms LogRecord) SetFlagsStruct(v LogRecordFlags) {
-	ms.SetFlags(v)
-}


### PR DESCRIPTION
Signed-off-by: Bogdan <bogdandrutu@gmail.com>
