### PR TITLE
[pdata] Restore NewValueBytesEmpty that was removed without deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - Delete deprecated `pcommon.Map.Upsert*` funcs. (#6088)
 - Delete deprecated `pcommon.Map.Update*` funcs. (#6088)
 - Delete deprecated `pcommon.Map.Update*` funcs. (#6088)
-- Replace `pcommon.NewValueBytes` with `pcommon.NewValueBytesEmpty`. (#6088)
+- Change `pcommon.NewValueBytes` signature to match `pcommon.NewValueBytesEmpty`. (#6088)
 - Delete deprecated `pcommon.Value.SetBytesVal`. (#6088)
 - Delete deprecated `pmetric.Metric.SetDataType`. (#6095)
 - Delete deprecated `plog.LogRecord.[Set]FlagStruct` funcs. (#6100)
@@ -20,6 +20,7 @@
 ### 🚩 Deprecations 🚩
 
 - Deprecate pmetric.OptionalType, unused enum type. (#6096)
+- Deprecate `pcommon.NewValueBytesEmpty` in favor of `pcommon.NewValueBytes` that now has the same signature. (#6105)
 
 ### 💡 Enhancements 💡
 

--- a/pdata/pcommon/common.go
+++ b/pdata/pcommon/common.go
@@ -125,6 +125,9 @@ func NewValueBytes() Value {
 	return newValue(&otlpcommon.AnyValue{Value: &otlpcommon.AnyValue_BytesValue{BytesValue: nil}})
 }
 
+// Deprecated: [0.61.0] Use NewValueBytes instead
+var NewValueBytesEmpty = NewValueBytes
+
 func newValue(orig *otlpcommon.AnyValue) Value {
 	return Value(internal.NewValue(orig))
 }


### PR DESCRIPTION
Appeared that we accidentally broke the deprecation rule in https://github.com/open-telemetry/opentelemetry-collector/pull/6088. This PR unblocks core dependency upgrade in contrib