### PR TITLE
Delete deprecated SetBucketCounts and SetExplicitBounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Delete deprecated `pcommon.ImmutableByteSlice` and `pcommon.NewImmutableByteSlice`. (#6107)
 - Delete deprecated `pcommon.ImmutableFloat64Slice` and `pcommon.NewImmutableFloat64Slice`. (#6107)
 - Delete deprecated `pcommon.ImmutableUInt64Slice` and `pcommon.NewImmutableUInt64Slice`. (#6107)
+- Delete deprecated `*DataPoint.SetBucketCounts` and `*DataPoint.SetExplicitBounds`. (#6108)
 
 ### 🚩 Deprecations 🚩
 

--- a/pdata/internal/cmd/pdatagen/internal/base_fields.go
+++ b/pdata/internal/cmd/pdatagen/internal/base_fields.go
@@ -55,12 +55,6 @@ func (ms ${structName}) Set${fieldName}(v ${returnType}) {
 const accessorsPrimitiveSliceTemplate = `// ${fieldName} returns the ${lowerFieldName} associated with this ${structName}.
 func (ms ${structName}) ${fieldName}() ${packageName}${returnType} {
 	return ${packageName}${returnType}(internal.New${returnType}(&ms.getOrig().${originFieldName}))
-}
-
-// Set${fieldName} replaces the ${lowerFieldName} associated with this ${structName}.
-// Deprecated: [0.60.0] Use ${fieldName}().FromRaw() instead
-func (ms ${structName}) Set${fieldName}(v ${packageName}${returnType}) {
-	ms.getOrig().${originFieldName} = *internal.GetOrig${returnType}(internal.${returnType}(v))
 }`
 
 const oneOfTypeAccessorHeaderTemplate = `// ${originFieldName}Type returns the type of the ${lowerOriginFieldName} for this ${structName}.

--- a/pdata/pmetric/generated_metrics.go
+++ b/pdata/pmetric/generated_metrics.go
@@ -1547,21 +1547,9 @@ func (ms HistogramDataPoint) BucketCounts() pcommon.UInt64Slice {
 	return pcommon.UInt64Slice(internal.NewUInt64Slice(&ms.getOrig().BucketCounts))
 }
 
-// SetBucketCounts replaces the bucketcounts associated with this HistogramDataPoint.
-// Deprecated: [0.60.0] Use BucketCounts().FromRaw() instead
-func (ms HistogramDataPoint) SetBucketCounts(v pcommon.UInt64Slice) {
-	ms.getOrig().BucketCounts = *internal.GetOrigUInt64Slice(internal.UInt64Slice(v))
-}
-
 // ExplicitBounds returns the explicitbounds associated with this HistogramDataPoint.
 func (ms HistogramDataPoint) ExplicitBounds() pcommon.Float64Slice {
 	return pcommon.Float64Slice(internal.NewFloat64Slice(&ms.getOrig().ExplicitBounds))
-}
-
-// SetExplicitBounds replaces the explicitbounds associated with this HistogramDataPoint.
-// Deprecated: [0.60.0] Use ExplicitBounds().FromRaw() instead
-func (ms HistogramDataPoint) SetExplicitBounds(v pcommon.Float64Slice) {
-	ms.getOrig().ExplicitBounds = *internal.GetOrigFloat64Slice(internal.Float64Slice(v))
 }
 
 // Exemplars returns the Exemplars associated with this HistogramDataPoint.
@@ -2011,12 +1999,6 @@ func (ms Buckets) SetOffset(v int32) {
 // BucketCounts returns the bucketcounts associated with this Buckets.
 func (ms Buckets) BucketCounts() pcommon.UInt64Slice {
 	return pcommon.UInt64Slice(internal.NewUInt64Slice(&ms.getOrig().BucketCounts))
-}
-
-// SetBucketCounts replaces the bucketcounts associated with this Buckets.
-// Deprecated: [0.60.0] Use BucketCounts().FromRaw() instead
-func (ms Buckets) SetBucketCounts(v pcommon.UInt64Slice) {
-	ms.getOrig().BucketCounts = *internal.GetOrigUInt64Slice(internal.UInt64Slice(v))
 }
 
 // CopyTo copies all properties from the current struct to the dest.


### PR DESCRIPTION
Signed-off-by: Bogdan <bogdandrutu@gmail.com>
