### PR TITLE
Fix github dependabot-pr workflow

### DIFF
--- a/.github/workflows/scripts/dependabot-pr.sh
+++ b/.github/workflows/scripts/dependabot-pr.sh
@@ -7,7 +7,7 @@ PR_NAME=dependabot-prs/`date +'%Y-%m-%dT%H%M%S'`
 git checkout -b $PR_NAME
 
 IFS=$'\n'
-requests=$(gh pr list --search "author:app/dependabot" --json number,title --template '{{range .}}{{tablerow .title}}{{end}}')
+requests=$( gh pr list --search "author:app/dependabot" --json title --jq '.[].title' | sort )
 message=""
 dirs=`find . -type f -name "go.mod" -exec dirname {} \; | sort `
 


### PR DESCRIPTION
This fixes issues like https://github.com/open-telemetry/opentelemetry-collector/actions/runs/3079821528 where the PR name is too long, same fix already in contrib.

Signed-off-by: Bogdan <bogdandrutu@gmail.com>
