### PR TITLE
Changed how the telemetryInitializer is created

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 
 - Add AppendEmpty and EnsureCapacity method to primitive pdata slices (#6060)
 - Expose `AsRaw` and `FromRaw` `pcommon.Value` methods (#6090)
+- Updated how `telemetryInitializer` is created so it's instanced per Collector instance rather than global to the process ()
 
 ## v0.60.0 Beta
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@
 
 - Add AppendEmpty and EnsureCapacity method to primitive pdata slices (#6060)
 - Expose `AsRaw` and `FromRaw` `pcommon.Value` methods (#6090)
-- Updated how `telemetryInitializer` is created so it's instanced per Collector instance rather than global to the process ()
+- Updated how `telemetryInitializer` is created so it's instanced per Collector instance rather than global to the process (#6138)
 
 ## v0.60.0 Beta
 

--- a/service/collector.go
+++ b/service/collector.go
@@ -30,6 +30,7 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/extension/ballastextension"
+	"go.opentelemetry.io/collector/service/featuregate"
 	"go.opentelemetry.io/collector/service/internal/telemetrylogs"
 )
 
@@ -92,7 +93,7 @@ func New(set CollectorSettings) (*Collector, error) {
 	}
 
 	if set.telemetry == nil {
-		set.telemetry = collectorTelemetry
+		set.telemetry = newColTelemetry(featuregate.GetRegistry())
 	}
 
 	return &Collector{

--- a/service/collector.go
+++ b/service/collector.go
@@ -30,7 +30,7 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/extension/ballastextension"
-	"go.opentelemetry.io/collector/service/featuregate"
+	"go.opentelemetry.io/collector/featuregate"
 	"go.opentelemetry.io/collector/service/internal/telemetrylogs"
 )
 

--- a/service/collector_test.go
+++ b/service/collector_test.go
@@ -409,10 +409,9 @@ func TestCollectorStartWithOpenCensusMetrics(t *testing.T) {
 func TestCollectorStartWithOpenTelemetryMetrics(t *testing.T) {
 	for _, tc := range ownMetricsTestCases("test version") {
 		t.Run(tc.name, func(t *testing.T) {
-			// Reset once to allow multiple calls to newColTelemetry
-			internalMetricFGRegisterOnce = sync.Once{}
-
-			colTel := newColTelemetry(featuregate.NewRegistry())
+			registry := featuregate.NewRegistry()
+			registerInternalMetricFeatureGate(registry)
+			colTel := newColTelemetry(registry)
 			require.NoError(t, colTel.registry.Apply(map[string]bool{useOtelForInternalMetricsfeatureGateID: true}))
 			testCollectorStartHelper(t, colTel, tc)
 		})

--- a/service/collector_test.go
+++ b/service/collector_test.go
@@ -409,6 +409,9 @@ func TestCollectorStartWithOpenCensusMetrics(t *testing.T) {
 func TestCollectorStartWithOpenTelemetryMetrics(t *testing.T) {
 	for _, tc := range ownMetricsTestCases("test version") {
 		t.Run(tc.name, func(t *testing.T) {
+			// Reset once to allow multiple calls to newColTelemetry
+			internalMetricFGRegisterOnce = sync.Once{}
+
 			colTel := newColTelemetry(featuregate.NewRegistry())
 			require.NoError(t, colTel.registry.Apply(map[string]bool{useOtelForInternalMetricsfeatureGateID: true}))
 			testCollectorStartHelper(t, colTel, tc)

--- a/service/telemetry.go
+++ b/service/telemetry.go
@@ -46,8 +46,8 @@ import (
 	"go.opentelemetry.io/collector/service/telemetry"
 )
 
-// collectorTelemetry is collector's own telemetrySettings.
-var collectorTelemetry = newColTelemetry(featuregate.GetRegistry())
+// internalMetricFGRegisterOnce is a Once that ensures that the internal metric feature gate is only registered once
+var internalMetricFGRegisterOnce sync.Once
 
 const (
 	zapKeyTelemetryAddress = "address"
@@ -78,10 +78,13 @@ type telemetryInitializer struct {
 }
 
 func newColTelemetry(registry *featuregate.Registry) *telemetryInitializer {
-	registry.MustRegister(featuregate.Gate{
-		ID:          useOtelForInternalMetricsfeatureGateID,
-		Description: "controls whether the collector to uses OpenTelemetry for internal metrics",
-		Enabled:     false,
+	// Ensure we only do the register once
+	internalMetricFGRegisterOnce.Do(func() {
+		registry.MustRegister(featuregate.Gate{
+			ID:          useOtelForInternalMetricsfeatureGateID,
+			Description: "controls whether the collector to uses OpenTelemetry for internal metrics",
+			Enabled:     false,
+		})
 	})
 
 	return &telemetryInitializer{


### PR DESCRIPTION
**Description:** 
Changed how the `telemetryInitializer` is created. Previously only a single instance of the `telemetryInitializer` was created for a process. The caused an issue if a `Collector` instance was shutdown and a new one was created the new instance would get the global instance that was shutdown as a result of the first Collector instance being shutdown.

The new logic ensures the feature gate is only registered once but a new `telemetryInitializer` instance is created per instance of the collector.

**Link to tracking Issue:** 
Tangentially related to #5084. 

In that issue the desired design is:

> I think we are going to the direction to follow the language pattern which is after Shutdown you cannot call Run on the same instance, you have to create a new instance.

I believe this respects that design and fixes a bug where a new instance could not fully startup with the same expectations as the previous instance.

**Testing:** 
Modified unit tests. Also, tested with our OPAMP enabled [agent](https://github.com/observIQ/observiq-otel-collector) and [server](https://github.com/observiq/bindplane-op) to verify that we can create a new instance of the collector with a changed config in a single process and have telemetry still be active. Previously it would not be.
