### PR TITLE
[chore] Drop builtin builder configuration integration tests.

### DIFF
--- a/cmd/builder/go.mod
+++ b/cmd/builder/go.mod
@@ -26,6 +26,7 @@ require (
 )
 
 require (
+	github.com/benbjohnson/clock v1.1.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect

--- a/cmd/builder/go.sum
+++ b/cmd/builder/go.sum
@@ -22,6 +22,7 @@ github.com/aws/aws-sdk-go-v2/service/sso v1.4.2/go.mod h1:NBvT9R1MEF+Ud6ApJKM0G+
 github.com/aws/aws-sdk-go-v2/service/sts v1.7.2/go.mod h1:8EzeIqfWt2wWT4rJVu3f21TfrhJ8AEMzVybRNSb/b4g=
 github.com/aws/smithy-go v1.8.0/go.mod h1:SObp3lf9smib00L/v3U2eAKG8FyQ7iLrJnQiAmR5n+E=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
+github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=

--- a/cmd/builder/test/test.sh
+++ b/cmd/builder/test/test.sh
@@ -25,11 +25,7 @@ test_build_config() {
 
     echo "Starting test '${test}' at `date`" >> "${out}/test.log"
 
-    if [ -z "$build_config" ] ; then
-        go run . --go "${GOBIN}" --output-path "${out}" --name otelcol-built-test > "${out}/builder.log" 2>&1
-    else
-        go run . --go "${GOBIN}" --config "$build_config" --output-path "${out}" --name otelcol-built-test > "${out}/builder.log" 2>&1
-    fi
+    go run . --go "${GOBIN}" --config "$build_config" --output-path "${out}" --name otelcol-built-test > "${out}/builder.log" 2>&1
 
     if [ $? != 0 ]; then
         echo "❌ FAIL ${test}. Failed to compile the test ${test}. Build logs:"
@@ -111,9 +107,6 @@ base=`mktemp -d`
 echo "Running the tests in ${base}"
 
 failed=false
-
-# Test that an empty build configuration builds a working default collector.
-test_build_config "default"
 
 for test in $tests
 do


### PR DESCRIPTION
**Description:**

Drop the integration tests for the builtin builder configuration. We assume that it is a working config because it is generated from with the source tree and should be covered by collector tests. Add a unit test to ensure some basic sanity for the builtin configuration.

**Link to tracking Issue:** This fixes #6076.

**Testing:** Ran unit an integration tests.

**Documentation:**  N/A
