### PR TITLE
Fully overrides default slice fields of config (#4001)

### DIFF
--- a/.chloggen/config-slice-fields.yaml
+++ b/.chloggen/config-slice-fields.yaml
@@ -1,0 +1,5 @@
+change_type: "bug_fix"
+component: "config"
+note: "Fully override default slice fields of config"
+issues: [4001]
+subtext:


### PR DESCRIPTION
**Description:** 

mapstructure library doesn't override full slice during unmarshalling. Origin issue: https://github.com/mitchellh/mapstructure/issues/74#issuecomment-279886492 To address this we zeroes every slice before unmarshalling unless user provided slice is nil.

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector/issues/4001
