### PR TITLE
[pdata] Rename RegiserServer funcs to RegiserGRPCServer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### 🚩 Deprecations 🚩
+
+- Deprecate `p[metric|log|trace]otlp.RegiserServer` in favor of `p[metric|log|trace]otlp.RegiserGRPCServer` (#6180)
+
 ## v0.61.0 Beta
 
 ### 🛑 Breaking changes 🛑

--- a/config/configgrpc/configgrpc_test.go
+++ b/config/configgrpc/configgrpc_test.go
@@ -566,7 +566,7 @@ func TestHttpReception(t *testing.T) {
 			opts, err := gss.ToServerOption(componenttest.NewNopHost(), componenttest.NewNopTelemetrySettings())
 			assert.NoError(t, err)
 			s := grpc.NewServer(opts...)
-			ptraceotlp.RegisterServer(s, &grpcTraceServer{})
+			ptraceotlp.RegisterGRPCServer(s, &grpcTraceServer{})
 
 			go func() {
 				_ = s.Serve(ln)
@@ -615,7 +615,7 @@ func TestReceiveOnUnixDomainSocket(t *testing.T) {
 	opts, err := gss.ToServerOption(componenttest.NewNopHost(), componenttest.NewNopTelemetrySettings())
 	assert.NoError(t, err)
 	s := grpc.NewServer(opts...)
-	ptraceotlp.RegisterServer(s, &grpcTraceServer{})
+	ptraceotlp.RegisterGRPCServer(s, &grpcTraceServer{})
 
 	go func() {
 		_ = s.Serve(ln)
@@ -811,7 +811,7 @@ func TestClientInfoInterceptors(t *testing.T) {
 				opts, err := gss.ToServerOption(componenttest.NewNopHost(), componenttest.NewNopTelemetrySettings())
 				require.NoError(t, err)
 				srv := grpc.NewServer(opts...)
-				ptraceotlp.RegisterServer(srv, mock)
+				ptraceotlp.RegisterGRPCServer(srv, mock)
 
 				defer srv.Stop()
 

--- a/exporter/otlpexporter/otlp_test.go
+++ b/exporter/otlpexporter/otlp_test.go
@@ -115,7 +115,7 @@ func otlpTracesReceiverOnGRPCServer(ln net.Listener, useTLS bool) (*mockTracesRe
 	}
 
 	// Now run it as a gRPC server
-	ptraceotlp.RegisterServer(rcv.srv, rcv)
+	ptraceotlp.RegisterGRPCServer(rcv.srv, rcv)
 	go func() {
 		_ = rcv.srv.Serve(ln)
 	}()
@@ -155,7 +155,7 @@ func otlpLogsReceiverOnGRPCServer(ln net.Listener) *mockLogsReceiver {
 	}
 
 	// Now run it as a gRPC server
-	plogotlp.RegisterServer(rcv.srv, rcv)
+	plogotlp.RegisterGRPCServer(rcv.srv, rcv)
 	go func() {
 		_ = rcv.srv.Serve(ln)
 	}()
@@ -195,7 +195,7 @@ func otlpMetricsReceiverOnGRPCServer(ln net.Listener) *mockMetricsReceiver {
 	}
 
 	// Now run it as a gRPC server
-	pmetricotlp.RegisterServer(rcv.srv, rcv)
+	pmetricotlp.RegisterGRPCServer(rcv.srv, rcv)
 	go func() {
 		_ = rcv.srv.Serve(ln)
 	}()

--- a/pdata/plog/plogotlp/logs.go
+++ b/pdata/plog/plogotlp/logs.go
@@ -155,10 +155,13 @@ type GRPCServer interface {
 // Deprecated: [0.61.0] Use GRPCServer instead
 type Server = GRPCServer
 
-// RegisterServer registers the Server to the grpc.Server.
-func RegisterServer(s *grpc.Server, srv GRPCServer) {
+// RegisterGRPCServer registers the Server to the grpc.Server.
+func RegisterGRPCServer(s *grpc.Server, srv GRPCServer) {
 	otlpcollectorlog.RegisterLogsServiceServer(s, &rawLogsServer{srv: srv})
 }
+
+// Deprecated: [0.62.0] Use RegisterGRPCServer instead
+var RegisterServer = RegisterGRPCServer
 
 type rawLogsServer struct {
 	srv GRPCServer

--- a/pdata/plog/plogotlp/logs_test.go
+++ b/pdata/plog/plogotlp/logs_test.go
@@ -83,7 +83,7 @@ func TestRequestJSON(t *testing.T) {
 func TestGrpc(t *testing.T) {
 	lis := bufconn.Listen(1024 * 1024)
 	s := grpc.NewServer()
-	RegisterServer(s, &fakeLogsServer{t: t})
+	RegisterGRPCServer(s, &fakeLogsServer{t: t})
 	wg := sync.WaitGroup{}
 	wg.Add(1)
 	go func() {
@@ -116,7 +116,7 @@ func TestGrpc(t *testing.T) {
 func TestGrpcError(t *testing.T) {
 	lis := bufconn.Listen(1024 * 1024)
 	s := grpc.NewServer()
-	RegisterServer(s, &fakeLogsServer{t: t, err: errors.New("my error")})
+	RegisterGRPCServer(s, &fakeLogsServer{t: t, err: errors.New("my error")})
 	wg := sync.WaitGroup{}
 	wg.Add(1)
 	go func() {

--- a/pdata/pmetric/pmetricotlp/metrics.go
+++ b/pdata/pmetric/pmetricotlp/metrics.go
@@ -151,10 +151,13 @@ type GRPCServer interface {
 // Deprecated: [0.61.0] Use GRPCServer instead
 type Server = GRPCServer
 
-// RegisterServer registers the GRPCServer to the grpc.Server.
-func RegisterServer(s *grpc.Server, srv GRPCServer) {
+// RegisterGRPCServer registers the GRPCServer to the grpc.Server.
+func RegisterGRPCServer(s *grpc.Server, srv GRPCServer) {
 	otlpcollectormetrics.RegisterMetricsServiceServer(s, &rawMetricsServer{srv: srv})
 }
+
+// Deprecated: [0.62.0] Use RegisterGRPCServer instead
+var RegisterServer = RegisterGRPCServer
 
 type rawMetricsServer struct {
 	srv Server

--- a/pdata/pmetric/pmetricotlp/metrics_test.go
+++ b/pdata/pmetric/pmetricotlp/metrics_test.go
@@ -79,7 +79,7 @@ func TestRequestJSON(t *testing.T) {
 func TestGrpc(t *testing.T) {
 	lis := bufconn.Listen(1024 * 1024)
 	s := grpc.NewServer()
-	RegisterServer(s, &fakeMetricsServer{t: t})
+	RegisterGRPCServer(s, &fakeMetricsServer{t: t})
 	wg := sync.WaitGroup{}
 	wg.Add(1)
 	go func() {
@@ -112,7 +112,7 @@ func TestGrpc(t *testing.T) {
 func TestGrpcError(t *testing.T) {
 	lis := bufconn.Listen(1024 * 1024)
 	s := grpc.NewServer()
-	RegisterServer(s, &fakeMetricsServer{t: t, err: errors.New("my error")})
+	RegisterGRPCServer(s, &fakeMetricsServer{t: t, err: errors.New("my error")})
 	wg := sync.WaitGroup{}
 	wg.Add(1)
 	go func() {

--- a/pdata/ptrace/ptraceotlp/traces.go
+++ b/pdata/ptrace/ptraceotlp/traces.go
@@ -156,10 +156,13 @@ type GRPCServer interface {
 // Deprecated: [0.61.0] Use GRPCServer instead
 type Server = GRPCServer
 
-// RegisterServer registers the GRPCServer to the grpc.Server.
-func RegisterServer(s *grpc.Server, srv GRPCServer) {
+// RegisterGRPCServer registers the GRPCServer to the grpc.Server.
+func RegisterGRPCServer(s *grpc.Server, srv GRPCServer) {
 	otlpcollectortrace.RegisterTraceServiceServer(s, &rawTracesServer{srv: srv})
 }
+
+// Deprecated: [0.62.0] Use RegisterGRPCServer instead
+var RegisterServer = RegisterGRPCServer
 
 type rawTracesServer struct {
 	srv GRPCServer

--- a/pdata/ptrace/ptraceotlp/traces_test.go
+++ b/pdata/ptrace/ptraceotlp/traces_test.go
@@ -83,7 +83,7 @@ func TestRequestJSON(t *testing.T) {
 func TestGrpc(t *testing.T) {
 	lis := bufconn.Listen(1024 * 1024)
 	s := grpc.NewServer()
-	RegisterServer(s, &fakeTracesServer{t: t})
+	RegisterGRPCServer(s, &fakeTracesServer{t: t})
 	wg := sync.WaitGroup{}
 	wg.Add(1)
 	go func() {
@@ -116,7 +116,7 @@ func TestGrpc(t *testing.T) {
 func TestGrpcError(t *testing.T) {
 	lis := bufconn.Listen(1024 * 1024)
 	s := grpc.NewServer()
-	RegisterServer(s, &fakeTracesServer{t: t, err: errors.New("my error")})
+	RegisterGRPCServer(s, &fakeTracesServer{t: t, err: errors.New("my error")})
 	wg := sync.WaitGroup{}
 	wg.Add(1)
 	go func() {

--- a/receiver/otlpreceiver/internal/logs/otlp_test.go
+++ b/receiver/otlpreceiver/internal/logs/otlp_test.go
@@ -92,7 +92,7 @@ func otlpReceiverOnGRPCServer(t *testing.T, lc consumer.Logs) net.Addr {
 	r := New(config.NewComponentIDWithName("otlp", "log"), lc, componenttest.NewNopReceiverCreateSettings())
 	// Now run it as a gRPC server
 	srv := grpc.NewServer()
-	plogotlp.RegisterServer(srv, r)
+	plogotlp.RegisterGRPCServer(srv, r)
 	go func() {
 		_ = srv.Serve(ln)
 	}()

--- a/receiver/otlpreceiver/internal/metrics/otlp_test.go
+++ b/receiver/otlpreceiver/internal/metrics/otlp_test.go
@@ -93,7 +93,7 @@ func otlpReceiverOnGRPCServer(t *testing.T, mc consumer.Metrics) net.Addr {
 	r := New(config.NewComponentIDWithName("otlp", "metrics"), mc, componenttest.NewNopReceiverCreateSettings())
 	// Now run it as a gRPC server
 	srv := grpc.NewServer()
-	pmetricotlp.RegisterServer(srv, r)
+	pmetricotlp.RegisterGRPCServer(srv, r)
 	go func() {
 		_ = srv.Serve(ln)
 	}()

--- a/receiver/otlpreceiver/internal/trace/otlp_test.go
+++ b/receiver/otlpreceiver/internal/trace/otlp_test.go
@@ -90,7 +90,7 @@ func otlpReceiverOnGRPCServer(t *testing.T, tc consumer.Traces) net.Addr {
 	r := New(config.NewComponentIDWithName("otlp", "trace"), tc, componenttest.NewNopReceiverCreateSettings())
 	// Now run it as a gRPC server
 	srv := grpc.NewServer()
-	ptraceotlp.RegisterServer(srv, r)
+	ptraceotlp.RegisterGRPCServer(srv, r)
 	go func() {
 		_ = srv.Serve(ln)
 	}()

--- a/receiver/otlpreceiver/otlp.go
+++ b/receiver/otlpreceiver/otlp.go
@@ -113,15 +113,15 @@ func (r *otlpReceiver) startProtocolServers(host component.Host) error {
 		r.serverGRPC = grpc.NewServer(opts...)
 
 		if r.traceReceiver != nil {
-			ptraceotlp.RegisterServer(r.serverGRPC, r.traceReceiver)
+			ptraceotlp.RegisterGRPCServer(r.serverGRPC, r.traceReceiver)
 		}
 
 		if r.metricsReceiver != nil {
-			pmetricotlp.RegisterServer(r.serverGRPC, r.metricsReceiver)
+			pmetricotlp.RegisterGRPCServer(r.serverGRPC, r.metricsReceiver)
 		}
 
 		if r.logReceiver != nil {
-			plogotlp.RegisterServer(r.serverGRPC, r.logReceiver)
+			plogotlp.RegisterGRPCServer(r.serverGRPC, r.logReceiver)
 		}
 
 		err = r.startGRPCServer(r.cfg.GRPC, host)


### PR DESCRIPTION
`p[log|trace|metric]otlp` packages don't have grpc part in it anymore, so we need to add GRPC part to the related methods. 

This change should've been landed in https://github.com/open-telemetry/opentelemetry-collector/pull/6165