### PR TITLE
Rename ptrace.StatusCode to SpanStatusCode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Deprecate `p[metric|log|trace]otlp.RegiserServer` in favor of `p[metric|log|trace]otlp.RegiserGRPCServer` (#6180)
 - Deprecate `pcommon.NewValueString` in favor of `pcommon.NewValueStr` (#6209)
+- Deprecate `ptrace.StatusCode` along its enum constants favor of `SpanStatusCode` (#6212)
+  - `StatusCodeUnset` renamed to `SpanStatusCodeUnset`.
+  - `StatusCodeOk` renamed to `SpanStatusCodeOk`.
+  - `StatusCodeError` renamed to `SpanStatusCodeError`.
 
 ### 💡 Enhancements 💡
 

--- a/pdata/internal/cmd/pdatagen/internal/trace_structs.go
+++ b/pdata/internal/cmd/pdatagen/internal/trace_structs.go
@@ -197,7 +197,7 @@ var spanStatus = &messageValueStruct{
 			fieldName:       "Code",
 			originFieldName: "Code",
 			returnType: &primitiveType{
-				structName: "StatusCode",
+				structName: "SpanStatusCode",
 				rawType:    "otlptrace.Status_StatusCode",
 				defaultVal: "0",
 				testVal:    "1",

--- a/pdata/ptrace/generated_traces.go
+++ b/pdata/ptrace/generated_traces.go
@@ -1220,12 +1220,12 @@ func (ms SpanStatus) MoveTo(dest SpanStatus) {
 }
 
 // Code returns the code associated with this SpanStatus.
-func (ms SpanStatus) Code() StatusCode {
-	return StatusCode(ms.getOrig().Code)
+func (ms SpanStatus) Code() SpanStatusCode {
+	return SpanStatusCode(ms.getOrig().Code)
 }
 
 // SetCode replaces the code associated with this SpanStatus.
-func (ms SpanStatus) SetCode(v StatusCode) {
+func (ms SpanStatus) SetCode(v SpanStatusCode) {
 	ms.getOrig().Code = otlptrace.Status_StatusCode(v)
 }
 

--- a/pdata/ptrace/generated_traces_test.go
+++ b/pdata/ptrace/generated_traces_test.go
@@ -902,8 +902,8 @@ func TestSpanStatus_CopyTo(t *testing.T) {
 
 func TestSpanStatus_Code(t *testing.T) {
 	ms := NewSpanStatus()
-	assert.Equal(t, StatusCode(0), ms.Code())
-	testValCode := StatusCode(1)
+	assert.Equal(t, SpanStatusCode(0), ms.Code())
+	testValCode := SpanStatusCode(1)
 	ms.SetCode(testValCode)
 	assert.Equal(t, testValCode, ms.Code())
 }

--- a/pdata/ptrace/traces.go
+++ b/pdata/ptrace/traces.go
@@ -120,14 +120,26 @@ const (
 	SpanKindConsumer = SpanKind(otlptrace.Span_SPAN_KIND_CONSUMER)
 )
 
-// StatusCode mirrors the codes defined at
+// SpanStatusCode mirrors the codes defined at
 // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#set-status
-type StatusCode int32
+type SpanStatusCode int32
+
+// Deprecated: [0.62.0] Use SpanStatusCode instead
+type StatusCode = SpanStatusCode
 
 const (
-	StatusCodeUnset = StatusCode(otlptrace.Status_STATUS_CODE_UNSET)
-	StatusCodeOk    = StatusCode(otlptrace.Status_STATUS_CODE_OK)
-	StatusCodeError = StatusCode(otlptrace.Status_STATUS_CODE_ERROR)
+	SpanStatusCodeUnset = SpanStatusCode(otlptrace.Status_STATUS_CODE_UNSET)
+	SpanStatusCodeOk    = SpanStatusCode(otlptrace.Status_STATUS_CODE_OK)
+	SpanStatusCodeError = SpanStatusCode(otlptrace.Status_STATUS_CODE_ERROR)
+
+	// Deprecated: [0.62.0] Use SpanStatusCodeUnset instead
+	StatusCodeUnset = SpanStatusCodeUnset
+
+	// Deprecated: [0.62.0] Use SpanStatusCodeOk instead
+	StatusCodeOk = SpanStatusCodeOk
+
+	// Deprecated: [0.62.0] Use SpanStatusCodeError instead
+	StatusCodeError = SpanStatusCodeError
 )
 
 // String returns the string representation of the StatusCode.


### PR DESCRIPTION
For consistency with `SpanKind` and other enum constants.

Related issue https://github.com/open-telemetry/opentelemetry-collector/issues/6200

