### PR TITLE
Add prometheus metric prefix and constant service attributes to otel-go prometheus exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Add config marshaler (#5566)
 - Add semantic conventions for specification v1.10-v1.13 (#6213)
 - `receiver/otlp`: Make logs related to gRCPC and HTTP server startup clearer (#6174)
+- Add prometheus metric prefix and constant service attributes to Collector's own telemetry when using OpenTelemetry for internal telemetry (#6223)
 
 ## v0.61.0 Beta
 

--- a/service/telemetry.go
+++ b/service/telemetry.go
@@ -249,16 +249,8 @@ func (tel *telemetryInitializer) initOpenTelemetry(attrs map[string]string) (htt
 	)
 
 	registry := prometheus.NewRegistry()
-	// OpenTelemetry specifies that resource attributes must not be attached to prometheus metrics,
-	// to be compatible with existing OpenCensus instrumentation we need to add them as constant labels
-	// to the prometheus registry.
-	// https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/data-model.md#resource-attributes-1
-	promLabels := make(prometheus.Labels)
-	for k, v := range attrs {
-		promLabels[sanitizePrometheusKey(k)] = v
-	}
 
-	wrappedRegisterer := prometheus.WrapRegistererWithPrefix("otelcol_", prometheus.WrapRegistererWith(promLabels, registry))
+	wrappedRegisterer := prometheus.WrapRegistererWithPrefix("otelcol_", registry)
 	if err := wrappedRegisterer.Register(exporter.Collector); err != nil {
 		return nil, fmt.Errorf("failed to register prometheus collector: %w", err)
 	}

--- a/service/telemetry.go
+++ b/service/telemetry.go
@@ -237,7 +237,7 @@ func (tel *telemetryInitializer) initOpenTelemetry(attrs map[string]string) (htt
 		resAttrs = append(resAttrs, attribute.String(k, v))
 	}
 
-	res, err := resource.New(context.TODO(), resource.WithAttributes(resAttrs...))
+	res, err := resource.New(context.Background(), resource.WithAttributes(resAttrs...))
 	if err != nil {
 		return nil, fmt.Errorf("error creating otel resources: %w", err)
 	}
@@ -249,6 +249,10 @@ func (tel *telemetryInitializer) initOpenTelemetry(attrs map[string]string) (htt
 	)
 
 	registry := prometheus.NewRegistry()
+	// OpenTelemetry specifies that resource attributes must not be attached to prometheus metrics,
+	// to be compatible with existing OpenCensus instrumentation we need to add them as constant labels
+	// to the prometheus registry.
+	// https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/data-model.md#resource-attributes-1
 	promLabels := make(prometheus.Labels)
 	for k, v := range attrs {
 		promLabels[sanitizePrometheusKey(k)] = v


### PR DESCRIPTION
**Description:** This wraps `prometheus.Registry` with the `otelcol_` prefix and the `service_` attributes as these are not supported directly by the OpenTelemetry Go Prometheus Exporter.

This ensures that metrics exported by otel-go is consistent with the existing opencensus metrics.

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector/issues/5882

**Testing:** Manual tested by adding a otel-go metric and testing this.


