### PR TITLE
[chore] more localhost configuration

### DIFF
--- a/service/testdata/otelcol-invalid.yaml
+++ b/service/testdata/otelcol-invalid.yaml
@@ -8,6 +8,9 @@ exporters:
   nop:
 
 service:
+  telemetry:
+    metrics:
+      address: localhost:8888
   pipelines:
     traces:
       receivers: [nop]

--- a/service/testdata/otelcol-invalidprop.yaml
+++ b/service/testdata/otelcol-invalidprop.yaml
@@ -13,6 +13,8 @@ service:
       propagators:
       - "unknown"
       - "tracecontext"
+    metrics:
+      address: localhost:8888
   pipelines:
     traces:
       receivers: [nop]

--- a/service/testdata/otelcol-nop.yaml
+++ b/service/testdata/otelcol-nop.yaml
@@ -11,6 +11,9 @@ extensions:
   nop:
 
 service:
+  telemetry:
+    metrics:
+      address: localhost:8888
   extensions: [nop]
   pipelines:
     traces:

--- a/service/testdata/otelcol-validprop.yaml
+++ b/service/testdata/otelcol-validprop.yaml
@@ -13,6 +13,8 @@ service:
       propagators:
         - "b3"
         - "tracecontext"
+    metrics:
+      address: localhost:8888
   pipelines:
     traces:
       receivers: [nop]


### PR DESCRIPTION
Additional tests were binding telemetry on 0.0.0.0:8888, this change fixes that to bind to localhost instead.
