### PR TITLE
Add options to confmap Marshal/Unmarshal, deprecate UnmarshalExact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - Deprecate `pcommon.Map.PutString` in favor of `pcommon.Map.PutStr` (#6210)
 - Deprecate `pcommon.NewValueString` in favor of `pcommon.NewValueStr` (#6209)
 - Deprecate `pmetric.MetricAggregationTemporality` enum type in favor of `pmetric.AggregationTemporality` (#6249)
+- Deprecate `confmap.Conf.UnmarshalExact` in favor of `confmap.Conf.Unmarshal(.., WithErrorUnused)` (#6231)
 
 ### 💡 Enhancements 💡
 

--- a/config/common.go
+++ b/config/common.go
@@ -48,5 +48,5 @@ func unmarshal(componentSection *confmap.Conf, intoCfg interface{}) error {
 		return cu.Unmarshal(componentSection)
 	}
 
-	return componentSection.UnmarshalExact(intoCfg)
+	return componentSection.Unmarshal(intoCfg, confmap.WithErrorUnused())
 }

--- a/receiver/otlpreceiver/config.go
+++ b/receiver/otlpreceiver/config.go
@@ -61,7 +61,7 @@ func (cfg *Config) Unmarshal(componentParser *confmap.Conf) error {
 		return errors.New("empty config for OTLP receiver")
 	}
 	// first load the config normally
-	err := componentParser.UnmarshalExact(cfg)
+	err := componentParser.Unmarshal(cfg, confmap.WithErrorUnused())
 	if err != nil {
 		return err
 	}

--- a/service/internal/configunmarshaler/defaultunmarshaler.go
+++ b/service/internal/configunmarshaler/defaultunmarshaler.go
@@ -92,7 +92,7 @@ func (ConfigUnmarshaler) Unmarshal(v *confmap.Conf, factories component.Factorie
 
 	// Unmarshal top level sections and validate.
 	rawCfg := configSettings{}
-	if err := v.UnmarshalExact(&rawCfg); err != nil {
+	if err := v.Unmarshal(&rawCfg, confmap.WithErrorUnused()); err != nil {
 		return nil, configError{
 			error: fmt.Errorf("error reading top level configuration sections: %w", err),
 			code:  errUnmarshalTopLevelStructure,
@@ -185,7 +185,7 @@ func unmarshalService(srvRaw map[string]interface{}) (config.Service, error) {
 		},
 	}
 
-	if err := confmap.NewFromStringMap(srvRaw).UnmarshalExact(&srv); err != nil {
+	if err := confmap.NewFromStringMap(srvRaw).Unmarshal(&srv, confmap.WithErrorUnused()); err != nil {
 		return srv, fmt.Errorf("error reading service configuration: %w", err)
 	}
 


### PR DESCRIPTION
Officially this can be considered breaking change because of a use in a `var foo func(interface{}) error = conf.Unmarshal`, not in a normal calling usage, but this is an edgecase that we can except and move forward with this.

This will allow to add more options to Marshal/Unmarshal in the future.
