### PR TITLE
Fixed issue where telemetryInitializer is not cleaned up when newService errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,10 @@
 - Add prometheus metric prefix and constant service attributes to Collector's own telemetry when using OpenTelemetry for internal telemetry (#6223)
 - `exporter/logging`: Apply consistent rendering of map values (#6244)
 
+### 🧰 Bug fixes 🧰
+
+- Fixed bug where `telemetryInitializer` is not cleaned up when `newService` errors ()
+
 ## v0.61.0 Beta
 
 ### 🛑 Breaking changes 🛑

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@
 
 ### 🧰 Bug fixes 🧰
 
-- Fixed bug where `telemetryInitializer` is not cleaned up when `newService` errors ()
+- Fixed bug where `telemetryInitializer` is not cleaned up when `newService` errors (#6239)
 
 ## v0.61.0 Beta
 

--- a/service/service.go
+++ b/service/service.go
@@ -77,7 +77,7 @@ func newService(set *settings) (*service, error) {
 
 	// If there is any error after we initialize telemetry we need to ensure we clean that up for any future service
 	defer func() {
-		if returnErrs != nil {
+		if returnErrs == nil {
 			return
 		}
 

--- a/service/service.go
+++ b/service/service.go
@@ -78,9 +78,12 @@ func newService(set *settings) (*service, error) {
 	// If there is any error after we initialize telemetry we need to ensure we clean that up for any future service
 	defer func() {
 		if returnErrs != nil {
-			if shutdownErr := srv.telemetryInitializer.shutdown(); shutdownErr != nil {
-				returnErrs = multierr.Append(returnErrs, fmt.Errorf("failed to shutdown collector telemetry: %w", shutdownErr))
-			}
+			return
+		}
+
+		// This function is returning due to an error, ensure we shut down the telemetryInitializer
+		if shutdownErr := srv.telemetryInitializer.shutdown(); shutdownErr != nil {
+			returnErrs = multierr.Append(returnErrs, fmt.Errorf("failed to shutdown collector telemetry: %w", shutdownErr))
 		}
 	}()
 

--- a/service/service.go
+++ b/service/service.go
@@ -74,7 +74,7 @@ func newService(set *settings) (*service, error) {
 	srv.telemetrySettings.MeterProvider = srv.telemetryInitializer.mp
 
 	// process the configuration and initialize the pipeline
-	if err := srv.initPipeline(set); err != nil {
+	if err = srv.initExtensionsAndPipeline(set); err != nil {
 		// If pipeline initialization fails then shut down the telemetry server
 		if shutdownErr := srv.telemetryInitializer.shutdown(); shutdownErr != nil {
 			err = multierr.Append(err, fmt.Errorf("failed to shutdown collector telemetry: %w", shutdownErr))
@@ -132,7 +132,7 @@ func (srv *service) Shutdown(ctx context.Context) error {
 	return errs
 }
 
-func (srv *service) initPipeline(set *settings) error {
+func (srv *service) initExtensionsAndPipeline(set *settings) error {
 	var err error
 	extensionsSettings := extensions.Settings{
 		Telemetry: srv.telemetrySettings,

--- a/service/service.go
+++ b/service/service.go
@@ -71,7 +71,6 @@ func newService(set *settings) (*service, error) {
 	if err = srv.telemetryInitializer.init(set.BuildInfo, srv.telemetrySettings.Logger, set.Config.Service.Telemetry, set.AsyncErrorChannel); err != nil {
 		return nil, fmt.Errorf("failed to initialize telemetry: %w", err)
 	}
-
 	srv.telemetrySettings.MeterProvider = srv.telemetryInitializer.mp
 
 	// process the configuration and initialize the pipeline


### PR DESCRIPTION
**Description:** <Describe what has changed. 
Fixing a bug - Fixed issue where the `telemetryInitializer` was not cleaned up if `newService` errors after `telemetryInitializer.init` is called. This would cause subsequent calls to new service to error on `telemetryInitializer.init`.

Fixes: #6238 

**Testing:**
- Added a new unit test that fails without new cleanup logic
- Tested with our OPAMP enabled [agent](https://github.com/observIQ/observiq-otel-collector) and [server](https://github.com/observiq/bindplane-op). On reconfigure our agent runs a new instance of the Collector within the agent process. This was exposing the issue when a bad config is sent.

