### PR TITLE
[exporter/logging] Apply consistent map value rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Add semantic conventions for specification v1.10-v1.13 (#6213)
 - `receiver/otlp`: Make logs related to gRCPC and HTTP server startup clearer (#6174)
 - Add prometheus metric prefix and constant service attributes to Collector's own telemetry when using OpenTelemetry for internal telemetry (#6223)
+- `exporter/logging`: Apply consistent rendering of map values (#6244)
 
 ## v0.61.0 Beta
 

--- a/exporter/loggingexporter/internal/otlptext/databuffer.go
+++ b/exporter/loggingexporter/internal/otlptext/databuffer.go
@@ -16,10 +16,8 @@ package otlptext // import "go.opentelemetry.io/collector/exporter/loggingexport
 
 import (
 	"bytes"
-	"encoding/base64"
 	"fmt"
 	"math"
-	"strconv"
 	"strings"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -40,14 +38,22 @@ func (b *dataBuffer) logAttr(attr string, value string) {
 	b.logEntry("    %-15s: %s", attr, value)
 }
 
-func (b *dataBuffer) logAttributes(attr string, m pcommon.Map) {
+func (b *dataBuffer) logAttributes(header string, m pcommon.Map) {
 	if m.Len() == 0 {
 		return
 	}
 
-	b.logEntry("%s:", attr)
-	m.Range(func(k string, v pcommon.Value) bool {
-		b.logEntry("     -> %s: %s(%s)", k, v.Type().String(), attributeValueToString(v))
+	b.logEntry("%s:", header)
+	attrPrefix := "     ->"
+
+	// Add offset to attributes if needed.
+	headerParts := strings.Split(header, "->")
+	if len(headerParts) > 1 {
+		attrPrefix = headerParts[0] + attrPrefix
+	}
+
+	m.Sort().Range(func(k string, v pcommon.Value) bool {
+		b.logEntry("%s %s: %s", attrPrefix, k, valueToString(v))
 		return true
 	})
 }
@@ -238,11 +244,7 @@ func (b *dataBuffer) logEvents(description string, se ptrace.SpanEventSlice) {
 		if e.Attributes().Len() == 0 {
 			continue
 		}
-		b.logEntry("     -> Attributes:")
-		e.Attributes().Range(func(k string, v pcommon.Value) bool {
-			b.logEntry("         -> %s: %s(%s)", k, v.Type().String(), attributeValueToString(v))
-			return true
-		})
+		b.logAttributes("     -> Attributes:", e.Attributes())
 	}
 }
 
@@ -263,58 +265,10 @@ func (b *dataBuffer) logLinks(description string, sl ptrace.SpanLinkSlice) {
 		if l.Attributes().Len() == 0 {
 			continue
 		}
-		b.logEntry("     -> Attributes:")
-		l.Attributes().Range(func(k string, v pcommon.Value) bool {
-			b.logEntry("         -> %s: %s(%s)", k, v.Type().String(), attributeValueToString(v))
-			return true
-		})
+		b.logAttributes("     -> Attributes:", l.Attributes())
 	}
 }
 
-func attributeValueToString(v pcommon.Value) string {
-	switch v.Type() {
-	case pcommon.ValueTypeStr:
-		return v.Str()
-	case pcommon.ValueTypeBool:
-		return strconv.FormatBool(v.Bool())
-	case pcommon.ValueTypeDouble:
-		return strconv.FormatFloat(v.Double(), 'f', -1, 64)
-	case pcommon.ValueTypeInt:
-		return strconv.FormatInt(v.Int(), 10)
-	case pcommon.ValueTypeBytes:
-		return base64.StdEncoding.EncodeToString(v.Bytes().AsRaw())
-	case pcommon.ValueTypeSlice:
-		return sliceToString(v.Slice())
-	case pcommon.ValueTypeMap:
-		return mapToString(v.Map())
-	default:
-		return fmt.Sprintf("<Unknown OpenTelemetry attribute value type %q>", v.Type())
-	}
-}
-
-func sliceToString(s pcommon.Slice) string {
-	var b strings.Builder
-	b.WriteByte('[')
-	for i := 0; i < s.Len(); i++ {
-		if i < s.Len()-1 {
-			fmt.Fprintf(&b, "%s, ", attributeValueToString(s.At(i)))
-		} else {
-			b.WriteString(attributeValueToString(s.At(i)))
-		}
-	}
-
-	b.WriteByte(']')
-	return b.String()
-}
-
-func mapToString(m pcommon.Map) string {
-	var b strings.Builder
-	b.WriteString("{\n")
-
-	m.Sort().Range(func(k string, v pcommon.Value) bool {
-		fmt.Fprintf(&b, "     -> %s: %s(%s)\n", k, v.Type(), v.AsString())
-		return true
-	})
-	b.WriteByte('}')
-	return b.String()
+func valueToString(v pcommon.Value) string {
+	return fmt.Sprintf("%s(%s)", v.Type().String(), v.AsString())
 }

--- a/exporter/loggingexporter/internal/otlptext/databuffer_test.go
+++ b/exporter/loggingexporter/internal/otlptext/databuffer_test.go
@@ -26,30 +26,18 @@ func TestNestedArraySerializesCorrectly(t *testing.T) {
 	ava := pcommon.NewValueSlice()
 	ava.Slice().AppendEmpty().SetStr("foo")
 	ava.Slice().AppendEmpty().SetInt(42)
-
-	ava2 := pcommon.NewValueSlice()
-	ava2.Slice().AppendEmpty().SetStr("bar")
-	ava2.CopyTo(ava.Slice().AppendEmpty())
-
+	ava.Slice().AppendEmpty().SetEmptySlice().AppendEmpty().SetStr("bar")
 	ava.Slice().AppendEmpty().SetBool(true)
 	ava.Slice().AppendEmpty().SetDouble(5.5)
 
-	assert.Equal(t, 5, ava.Slice().Len())
-	assert.Equal(t, "[foo, 42, [bar], true, 5.5]", attributeValueToString(ava))
+	assert.Equal(t, `SLICE(["foo",42,["bar"],true,5.5])`, valueToString(ava))
 }
 
 func TestNestedMapSerializesCorrectly(t *testing.T) {
 	ava := pcommon.NewValueMap()
 	av := ava.Map()
 	av.PutStr("foo", "test")
-
 	av.PutEmptyMap("zoo").PutInt("bar", 13)
 
-	expected := `{
-     -> foo: STRING(test)
-     -> zoo: MAP({"bar":13})
-}`
-
-	assert.Equal(t, 2, ava.Map().Len())
-	assert.Equal(t, expected, attributeValueToString(ava))
+	assert.Equal(t, `MAP({"foo":"test","zoo":{"bar":13}})`, valueToString(ava))
 }

--- a/exporter/loggingexporter/internal/otlptext/logs.go
+++ b/exporter/loggingexporter/internal/otlptext/logs.go
@@ -49,7 +49,7 @@ func (textLogsMarshaler) MarshalLogs(ld plog.Logs) ([]byte, error) {
 				buf.logEntry("Timestamp: %s", lr.Timestamp())
 				buf.logEntry("SeverityText: %s", lr.SeverityText())
 				buf.logEntry("SeverityNumber: %s(%d)", lr.SeverityNumber(), lr.SeverityNumber())
-				buf.logEntry("Body: %s", attributeValueToString(lr.Body()))
+				buf.logEntry("Body: %s", valueToString(lr.Body()))
 				buf.logAttributes("Attributes", lr.Attributes())
 				buf.logEntry("Trace ID: %s", lr.TraceID().HexString())
 				buf.logEntry("Span ID: %s", lr.SpanID().HexString())

--- a/exporter/loggingexporter/internal/otlptext/logs_test.go
+++ b/exporter/loggingexporter/internal/otlptext/logs_test.go
@@ -15,34 +15,72 @@
 package otlptext
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/collector/internal/testdata"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
 )
 
 func TestLogsText(t *testing.T) {
-	type args struct {
-		ld plog.Logs
-	}
 	tests := []struct {
-		name  string
-		args  args
-		empty bool
+		name string
+		in   plog.Logs
+		out  string
 	}{
-		{"empty logs", args{ld: plog.NewLogs()}, true},
-		{"logs with one log", args{ld: testdata.GenerateLogs(1)}, false},
-		{"logs with lots of log records", args{ld: testdata.GenerateLogs(10)}, false},
+		{
+			name: "empty_logs",
+			in:   plog.NewLogs(),
+			out:  "empty.out",
+		},
+		{
+			name: "logs_with_one_record",
+			in:   testdata.GenerateLogs(1),
+			out:  "one_record.out",
+		},
+		{
+			name: "logs_with_two_records",
+			in:   testdata.GenerateLogs(2),
+			out:  "two_records.out",
+		},
+		{
+			name: "logs_with_embedded_maps",
+			in: func() plog.Logs {
+				ls := plog.NewLogs()
+				l := ls.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
+				l.SetTimestamp(pcommon.NewTimestampFromTime(time.Date(2020, 2, 11, 20, 26, 13, 789, time.UTC)))
+				l.SetSeverityNumber(plog.SeverityNumberInfo)
+				l.SetSeverityText("INFO")
+				bm := l.Body().SetEmptyMap()
+				bm.PutStr("key1", "val1")
+				bmm := bm.PutEmptyMap("key2")
+				bmm.PutStr("key21", "val21")
+				bmm.PutStr("key22", "val22")
+				am := l.Attributes().PutEmptyMap("key1")
+				am.PutStr("key11", "val11")
+				am.PutStr("key12", "val12")
+				am.PutEmptyMap("key13").PutStr("key131", "val131")
+				l.Attributes().PutStr("key2", "val2")
+				return ls
+			}(),
+			out: "embedded_maps.out",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			logs, err := NewTextLogsMarshaler().MarshalLogs(tt.args.ld)
+			got, err := NewTextLogsMarshaler().MarshalLogs(tt.in)
 			assert.NoError(t, err)
-			if !tt.empty {
-				assert.NotEmpty(t, logs)
-			}
+			out, err := os.ReadFile(filepath.Join("testdata", "logs", tt.out))
+			require.NoError(t, err)
+			expected := strings.ReplaceAll(string(out), "\r", "")
+			assert.Equal(t, expected, string(got))
 		})
 	}
 }

--- a/exporter/loggingexporter/internal/otlptext/testdata/logs/embedded_maps.out
+++ b/exporter/loggingexporter/internal/otlptext/testdata/logs/embedded_maps.out
@@ -1,0 +1,17 @@
+ResourceLog #0
+Resource SchemaURL: 
+ScopeLogs #0
+ScopeLogs SchemaURL: 
+InstrumentationScope  
+LogRecord #0
+ObservedTimestamp: 1970-01-01 00:00:00 +0000 UTC
+Timestamp: 2020-02-11 20:26:13.000000789 +0000 UTC
+SeverityText: INFO
+SeverityNumber: SEVERITY_NUMBER_INFO(9)
+Body: MAP({"key1":"val1","key2":{"key21":"val21","key22":"val22"}})
+Attributes:
+     -> key1: MAP({"key11":"val11","key12":"val12","key13":{"key131":"val131"}})
+     -> key2: STRING(val2)
+Trace ID: 
+Span ID: 
+Flags: 0

--- a/exporter/loggingexporter/internal/otlptext/testdata/logs/one_record.out
+++ b/exporter/loggingexporter/internal/otlptext/testdata/logs/one_record.out
@@ -1,0 +1,19 @@
+ResourceLog #0
+Resource SchemaURL: 
+Resource attributes:
+     -> resource-attr: STRING(resource-attr-val-1)
+ScopeLogs #0
+ScopeLogs SchemaURL: 
+InstrumentationScope  
+LogRecord #0
+ObservedTimestamp: 1970-01-01 00:00:00 +0000 UTC
+Timestamp: 2020-02-11 20:26:13.000000789 +0000 UTC
+SeverityText: Info
+SeverityNumber: SEVERITY_NUMBER_INFO(9)
+Body: STRING(This is a log message)
+Attributes:
+     -> app: STRING(server)
+     -> instance_num: INT(1)
+Trace ID: 08040201000000000000000000000000
+Span ID: 0102040800000000
+Flags: 0

--- a/exporter/loggingexporter/internal/otlptext/testdata/logs/two_records.out
+++ b/exporter/loggingexporter/internal/otlptext/testdata/logs/two_records.out
@@ -1,0 +1,31 @@
+ResourceLog #0
+Resource SchemaURL: 
+Resource attributes:
+     -> resource-attr: STRING(resource-attr-val-1)
+ScopeLogs #0
+ScopeLogs SchemaURL: 
+InstrumentationScope  
+LogRecord #0
+ObservedTimestamp: 1970-01-01 00:00:00 +0000 UTC
+Timestamp: 2020-02-11 20:26:13.000000789 +0000 UTC
+SeverityText: Info
+SeverityNumber: SEVERITY_NUMBER_INFO(9)
+Body: STRING(This is a log message)
+Attributes:
+     -> app: STRING(server)
+     -> instance_num: INT(1)
+Trace ID: 08040201000000000000000000000000
+Span ID: 0102040800000000
+Flags: 0
+LogRecord #1
+ObservedTimestamp: 1970-01-01 00:00:00 +0000 UTC
+Timestamp: 2020-02-11 20:26:13.000000789 +0000 UTC
+SeverityText: Info
+SeverityNumber: SEVERITY_NUMBER_INFO(9)
+Body: STRING(something happened)
+Attributes:
+     -> customer: STRING(acme)
+     -> env: STRING(dev)
+Trace ID: 
+Span ID: 
+Flags: 0


### PR DESCRIPTION
Remove custom rendering for slice and map values and use Value.AsString() instead

Resolves: https://github.com/open-telemetry/opentelemetry-collector/issues/6243
