### PR TITLE
[pdata] Update pcommon.ValueType.String() output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,16 @@
 - Delete deprecated `StringVal` and `SetStringVal` methods. (#6178)
 - Delete deprecated `ValueTypeString` method. (#6178)
 - Change AggregationTemporality.String to simpler, easier to read. (#6117)
+- Update `pcommon.ValueType.String` output to string representation of corresponding type identifiers. The following 
+  values will be returned: (#6247)
+  - ValueTypeEmpty.String() -> "Empty"
+  - ValueTypeStr.String() -> "Str"
+  - ValueTypeBool.String() -> "Bool"
+  - ValueTypeInt.String() -> "Int"
+  - ValueTypeDouble.String() -> "Double"
+  - ValueTypeMap.String() -> "Map"
+  - ValueTypeSlice.String() -> "Slice"
+  - ValueTypeBytes.String() -> "Bytes"
 
 ### 🚩 Deprecations 🚩
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -177,7 +177,7 @@ With the modified configuration if you re-run the test above the log output shou
 ```
 2020-11-11T04:08:17.344Z	DEBUG	loggingexporter/logging_exporter.go:353	ResourceSpans #0
 Resource labels:
-     -> service.name: STRING(api)
+     -> service.name: Str(api)
 ScopeSpans #0
 Span #0
     Trace ID       : 5982fe77008310cc80f1da5e10147519
@@ -188,7 +188,7 @@ Span #0
     Start time     : 2018-01-24 08:16:15.726 +0000 UTC
     End time       : 2018-01-24 08:16:15.752 +0000 UTC
 Attributes:
-     -> data.http_response_code: STRING(201)
+     -> data.http_response_code: Str(201)
 ```
 
 ### Health Check

--- a/exporter/loggingexporter/internal/otlptext/databuffer_test.go
+++ b/exporter/loggingexporter/internal/otlptext/databuffer_test.go
@@ -30,7 +30,7 @@ func TestNestedArraySerializesCorrectly(t *testing.T) {
 	ava.Slice().AppendEmpty().SetBool(true)
 	ava.Slice().AppendEmpty().SetDouble(5.5)
 
-	assert.Equal(t, `SLICE(["foo",42,["bar"],true,5.5])`, valueToString(ava))
+	assert.Equal(t, `Slice(["foo",42,["bar"],true,5.5])`, valueToString(ava))
 }
 
 func TestNestedMapSerializesCorrectly(t *testing.T) {
@@ -39,5 +39,5 @@ func TestNestedMapSerializesCorrectly(t *testing.T) {
 	av.PutStr("foo", "test")
 	av.PutEmptyMap("zoo").PutInt("bar", 13)
 
-	assert.Equal(t, `MAP({"foo":"test","zoo":{"bar":13}})`, valueToString(ava))
+	assert.Equal(t, `Map({"foo":"test","zoo":{"bar":13}})`, valueToString(ava))
 }

--- a/exporter/loggingexporter/internal/otlptext/testdata/logs/embedded_maps.out
+++ b/exporter/loggingexporter/internal/otlptext/testdata/logs/embedded_maps.out
@@ -8,10 +8,10 @@ ObservedTimestamp: 1970-01-01 00:00:00 +0000 UTC
 Timestamp: 2020-02-11 20:26:13.000000789 +0000 UTC
 SeverityText: INFO
 SeverityNumber: SEVERITY_NUMBER_INFO(9)
-Body: MAP({"key1":"val1","key2":{"key21":"val21","key22":"val22"}})
+Body: Map({"key1":"val1","key2":{"key21":"val21","key22":"val22"}})
 Attributes:
-     -> key1: MAP({"key11":"val11","key12":"val12","key13":{"key131":"val131"}})
-     -> key2: STRING(val2)
+     -> key1: Map({"key11":"val11","key12":"val12","key13":{"key131":"val131"}})
+     -> key2: Str(val2)
 Trace ID: 
 Span ID: 
 Flags: 0

--- a/exporter/loggingexporter/internal/otlptext/testdata/logs/one_record.out
+++ b/exporter/loggingexporter/internal/otlptext/testdata/logs/one_record.out
@@ -1,7 +1,7 @@
 ResourceLog #0
 Resource SchemaURL: 
 Resource attributes:
-     -> resource-attr: STRING(resource-attr-val-1)
+     -> resource-attr: Str(resource-attr-val-1)
 ScopeLogs #0
 ScopeLogs SchemaURL: 
 InstrumentationScope  
@@ -10,10 +10,10 @@ ObservedTimestamp: 1970-01-01 00:00:00 +0000 UTC
 Timestamp: 2020-02-11 20:26:13.000000789 +0000 UTC
 SeverityText: Info
 SeverityNumber: SEVERITY_NUMBER_INFO(9)
-Body: STRING(This is a log message)
+Body: Str(This is a log message)
 Attributes:
-     -> app: STRING(server)
-     -> instance_num: INT(1)
+     -> app: Str(server)
+     -> instance_num: Int(1)
 Trace ID: 08040201000000000000000000000000
 Span ID: 0102040800000000
 Flags: 0

--- a/exporter/loggingexporter/internal/otlptext/testdata/logs/two_records.out
+++ b/exporter/loggingexporter/internal/otlptext/testdata/logs/two_records.out
@@ -1,7 +1,7 @@
 ResourceLog #0
 Resource SchemaURL: 
 Resource attributes:
-     -> resource-attr: STRING(resource-attr-val-1)
+     -> resource-attr: Str(resource-attr-val-1)
 ScopeLogs #0
 ScopeLogs SchemaURL: 
 InstrumentationScope  
@@ -10,10 +10,10 @@ ObservedTimestamp: 1970-01-01 00:00:00 +0000 UTC
 Timestamp: 2020-02-11 20:26:13.000000789 +0000 UTC
 SeverityText: Info
 SeverityNumber: SEVERITY_NUMBER_INFO(9)
-Body: STRING(This is a log message)
+Body: Str(This is a log message)
 Attributes:
-     -> app: STRING(server)
-     -> instance_num: INT(1)
+     -> app: Str(server)
+     -> instance_num: Int(1)
 Trace ID: 08040201000000000000000000000000
 Span ID: 0102040800000000
 Flags: 0
@@ -22,10 +22,10 @@ ObservedTimestamp: 1970-01-01 00:00:00 +0000 UTC
 Timestamp: 2020-02-11 20:26:13.000000789 +0000 UTC
 SeverityText: Info
 SeverityNumber: SEVERITY_NUMBER_INFO(9)
-Body: STRING(something happened)
+Body: Str(something happened)
 Attributes:
-     -> customer: STRING(acme)
-     -> env: STRING(dev)
+     -> customer: Str(acme)
+     -> env: Str(dev)
 Trace ID: 
 Span ID: 
 Flags: 0

--- a/pdata/pcommon/common.go
+++ b/pdata/pcommon/common.go
@@ -48,21 +48,21 @@ const (
 func (avt ValueType) String() string {
 	switch avt {
 	case ValueTypeEmpty:
-		return "EMPTY"
+		return "Empty"
 	case ValueTypeStr:
-		return "STRING"
+		return "Str"
 	case ValueTypeBool:
-		return "BOOL"
+		return "Bool"
 	case ValueTypeInt:
-		return "INT"
+		return "Int"
 	case ValueTypeDouble:
-		return "DOUBLE"
+		return "Double"
 	case ValueTypeMap:
-		return "MAP"
+		return "Map"
 	case ValueTypeSlice:
-		return "SLICE"
+		return "Slice"
 	case ValueTypeBytes:
-		return "BYTES"
+		return "Bytes"
 	}
 	return ""
 }

--- a/pdata/pcommon/common_test.go
+++ b/pdata/pcommon/common_test.go
@@ -57,14 +57,14 @@ func TestValue(t *testing.T) {
 }
 
 func TestValueType(t *testing.T) {
-	assert.EqualValues(t, "EMPTY", ValueTypeEmpty.String())
-	assert.EqualValues(t, "STRING", ValueTypeStr.String())
-	assert.EqualValues(t, "BOOL", ValueTypeBool.String())
-	assert.EqualValues(t, "INT", ValueTypeInt.String())
-	assert.EqualValues(t, "DOUBLE", ValueTypeDouble.String())
-	assert.EqualValues(t, "MAP", ValueTypeMap.String())
-	assert.EqualValues(t, "SLICE", ValueTypeSlice.String())
-	assert.EqualValues(t, "BYTES", ValueTypeBytes.String())
+	assert.EqualValues(t, "Empty", ValueTypeEmpty.String())
+	assert.EqualValues(t, "Str", ValueTypeStr.String())
+	assert.EqualValues(t, "Bool", ValueTypeBool.String())
+	assert.EqualValues(t, "Int", ValueTypeInt.String())
+	assert.EqualValues(t, "Double", ValueTypeDouble.String())
+	assert.EqualValues(t, "Map", ValueTypeMap.String())
+	assert.EqualValues(t, "Slice", ValueTypeSlice.String())
+	assert.EqualValues(t, "Bytes", ValueTypeBytes.String())
 	assert.EqualValues(t, "", ValueType(100).String())
 }
 


### PR DESCRIPTION
Recently we updated all names related to pdata String value. It makes sense to update string returned by Value.String accordingly to avoid discrepancy with other value types

Updates https://github.com/open-telemetry/opentelemetry-collector/issues/6249