### PR TITLE
[pdata] Rename ValueAtQuantile to SummaryDataPointValueAtQuantile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 - Deprecate `ptrace.SpanStatus` favor of `ptrace.Status` (#6258)
 - Deprecate `pmetric.[New]?Buckets` in favor of `pmetric.[New]?ExponentialHistogramDataPointBuckets` (#6261)
 - Deprecate `plog.SeverityNumberUndefined` in favor of `plog.SeverityNumberUnspecified` (#6269)
+- Deprecate `pmetric.[New]?ValueAtQuantile[Slice]?` in favor of `pmetric.[New]?SummaryDataPointValueAtQuantile[Slice]?` (#6262)
 
 ### 💡 Enhancements 💡
 

--- a/pdata/internal/cmd/pdatagen/internal/metrics_structs.go
+++ b/pdata/internal/cmd/pdatagen/internal/metrics_structs.go
@@ -427,13 +427,13 @@ var summaryDataPoint = &messageValueStruct{
 }
 
 var quantileValuesSlice = &sliceOfPtrs{
-	structName: "ValueAtQuantileSlice",
+	structName: "SummaryDataPointValueAtQuantileSlice",
 	element:    quantileValues,
 }
 
 var quantileValues = &messageValueStruct{
-	structName:     "ValueAtQuantile",
-	description:    "// ValueAtQuantile is a quantile value within a Summary data point.",
+	structName:     "SummaryDataPointValueAtQuantile",
+	description:    "// SummaryDataPointValueAtQuantile is a quantile value within a Summary data point.",
 	originFullName: "otlpmetrics.SummaryDataPoint_ValueAtQuantile",
 	fields: []baseField{
 		quantileField,

--- a/pdata/internal/generated_wrapper_metrics.go
+++ b/pdata/internal/generated_wrapper_metrics.go
@@ -262,28 +262,28 @@ func NewSummaryDataPoint(orig *otlpmetrics.SummaryDataPoint) SummaryDataPoint {
 	return SummaryDataPoint{orig: orig}
 }
 
-type ValueAtQuantileSlice struct {
+type SummaryDataPointValueAtQuantileSlice struct {
 	orig *[]*otlpmetrics.SummaryDataPoint_ValueAtQuantile
 }
 
-func GetOrigValueAtQuantileSlice(ms ValueAtQuantileSlice) *[]*otlpmetrics.SummaryDataPoint_ValueAtQuantile {
+func GetOrigSummaryDataPointValueAtQuantileSlice(ms SummaryDataPointValueAtQuantileSlice) *[]*otlpmetrics.SummaryDataPoint_ValueAtQuantile {
 	return ms.orig
 }
 
-func NewValueAtQuantileSlice(orig *[]*otlpmetrics.SummaryDataPoint_ValueAtQuantile) ValueAtQuantileSlice {
-	return ValueAtQuantileSlice{orig: orig}
+func NewSummaryDataPointValueAtQuantileSlice(orig *[]*otlpmetrics.SummaryDataPoint_ValueAtQuantile) SummaryDataPointValueAtQuantileSlice {
+	return SummaryDataPointValueAtQuantileSlice{orig: orig}
 }
 
-type ValueAtQuantile struct {
+type SummaryDataPointValueAtQuantile struct {
 	orig *otlpmetrics.SummaryDataPoint_ValueAtQuantile
 }
 
-func GetOrigValueAtQuantile(ms ValueAtQuantile) *otlpmetrics.SummaryDataPoint_ValueAtQuantile {
+func GetOrigSummaryDataPointValueAtQuantile(ms SummaryDataPointValueAtQuantile) *otlpmetrics.SummaryDataPoint_ValueAtQuantile {
 	return ms.orig
 }
 
-func NewValueAtQuantile(orig *otlpmetrics.SummaryDataPoint_ValueAtQuantile) ValueAtQuantile {
-	return ValueAtQuantile{orig: orig}
+func NewSummaryDataPointValueAtQuantile(orig *otlpmetrics.SummaryDataPoint_ValueAtQuantile) SummaryDataPointValueAtQuantile {
+	return SummaryDataPointValueAtQuantile{orig: orig}
 }
 
 type ExemplarSlice struct {
@@ -600,33 +600,33 @@ func FillTestSummaryDataPoint(tv SummaryDataPoint) {
 	tv.orig.TimeUnixNano = 1234567890
 	tv.orig.Count = uint64(17)
 	tv.orig.Sum = float64(17.13)
-	FillTestValueAtQuantileSlice(NewValueAtQuantileSlice(&tv.orig.QuantileValues))
+	FillTestSummaryDataPointValueAtQuantileSlice(NewSummaryDataPointValueAtQuantileSlice(&tv.orig.QuantileValues))
 	tv.orig.Flags = 1
 }
 
-func GenerateTestValueAtQuantileSlice() ValueAtQuantileSlice {
+func GenerateTestSummaryDataPointValueAtQuantileSlice() SummaryDataPointValueAtQuantileSlice {
 	orig := []*otlpmetrics.SummaryDataPoint_ValueAtQuantile{}
-	tv := NewValueAtQuantileSlice(&orig)
-	FillTestValueAtQuantileSlice(tv)
+	tv := NewSummaryDataPointValueAtQuantileSlice(&orig)
+	FillTestSummaryDataPointValueAtQuantileSlice(tv)
 	return tv
 }
 
-func FillTestValueAtQuantileSlice(tv ValueAtQuantileSlice) {
+func FillTestSummaryDataPointValueAtQuantileSlice(tv SummaryDataPointValueAtQuantileSlice) {
 	*tv.orig = make([]*otlpmetrics.SummaryDataPoint_ValueAtQuantile, 7)
 	for i := 0; i < 7; i++ {
 		(*tv.orig)[i] = &otlpmetrics.SummaryDataPoint_ValueAtQuantile{}
-		FillTestValueAtQuantile(NewValueAtQuantile((*tv.orig)[i]))
+		FillTestSummaryDataPointValueAtQuantile(NewSummaryDataPointValueAtQuantile((*tv.orig)[i]))
 	}
 }
 
-func GenerateTestValueAtQuantile() ValueAtQuantile {
+func GenerateTestSummaryDataPointValueAtQuantile() SummaryDataPointValueAtQuantile {
 	orig := otlpmetrics.SummaryDataPoint_ValueAtQuantile{}
-	tv := NewValueAtQuantile(&orig)
-	FillTestValueAtQuantile(tv)
+	tv := NewSummaryDataPointValueAtQuantile(&orig)
+	FillTestSummaryDataPointValueAtQuantile(tv)
 	return tv
 }
 
-func FillTestValueAtQuantile(tv ValueAtQuantile) {
+func FillTestSummaryDataPointValueAtQuantile(tv SummaryDataPointValueAtQuantile) {
 	tv.orig.Quantile = float64(17.13)
 	tv.orig.Value = float64(17.13)
 }

--- a/pdata/pmetric/generated_metrics.go
+++ b/pdata/pmetric/generated_metrics.go
@@ -2226,8 +2226,8 @@ func (ms SummaryDataPoint) SetSum(v float64) {
 }
 
 // QuantileValues returns the QuantileValues associated with this SummaryDataPoint.
-func (ms SummaryDataPoint) QuantileValues() ValueAtQuantileSlice {
-	return ValueAtQuantileSlice(internal.NewValueAtQuantileSlice(&ms.getOrig().QuantileValues))
+func (ms SummaryDataPoint) QuantileValues() SummaryDataPointValueAtQuantileSlice {
+	return SummaryDataPointValueAtQuantileSlice(internal.NewSummaryDataPointValueAtQuantileSlice(&ms.getOrig().QuantileValues))
 }
 
 // Flags returns the flags associated with this SummaryDataPoint.
@@ -2251,34 +2251,34 @@ func (ms SummaryDataPoint) CopyTo(dest SummaryDataPoint) {
 	dest.SetFlags(ms.Flags())
 }
 
-// ValueAtQuantileSlice logically represents a slice of ValueAtQuantile.
+// SummaryDataPointValueAtQuantileSlice logically represents a slice of SummaryDataPointValueAtQuantile.
 //
 // This is a reference type. If passed by value and callee modifies it, the
 // caller will see the modification.
 //
-// Must use NewValueAtQuantileSlice function to create new instances.
+// Must use NewSummaryDataPointValueAtQuantileSlice function to create new instances.
 // Important: zero-initialized instance is not valid for use.
-type ValueAtQuantileSlice internal.ValueAtQuantileSlice
+type SummaryDataPointValueAtQuantileSlice internal.SummaryDataPointValueAtQuantileSlice
 
-func newValueAtQuantileSlice(orig *[]*otlpmetrics.SummaryDataPoint_ValueAtQuantile) ValueAtQuantileSlice {
-	return ValueAtQuantileSlice(internal.NewValueAtQuantileSlice(orig))
+func newSummaryDataPointValueAtQuantileSlice(orig *[]*otlpmetrics.SummaryDataPoint_ValueAtQuantile) SummaryDataPointValueAtQuantileSlice {
+	return SummaryDataPointValueAtQuantileSlice(internal.NewSummaryDataPointValueAtQuantileSlice(orig))
 }
 
-func (ms ValueAtQuantileSlice) getOrig() *[]*otlpmetrics.SummaryDataPoint_ValueAtQuantile {
-	return internal.GetOrigValueAtQuantileSlice(internal.ValueAtQuantileSlice(ms))
+func (ms SummaryDataPointValueAtQuantileSlice) getOrig() *[]*otlpmetrics.SummaryDataPoint_ValueAtQuantile {
+	return internal.GetOrigSummaryDataPointValueAtQuantileSlice(internal.SummaryDataPointValueAtQuantileSlice(ms))
 }
 
-// NewValueAtQuantileSlice creates a ValueAtQuantileSlice with 0 elements.
+// NewSummaryDataPointValueAtQuantileSlice creates a SummaryDataPointValueAtQuantileSlice with 0 elements.
 // Can use "EnsureCapacity" to initialize with a given capacity.
-func NewValueAtQuantileSlice() ValueAtQuantileSlice {
+func NewSummaryDataPointValueAtQuantileSlice() SummaryDataPointValueAtQuantileSlice {
 	orig := []*otlpmetrics.SummaryDataPoint_ValueAtQuantile(nil)
-	return newValueAtQuantileSlice(&orig)
+	return newSummaryDataPointValueAtQuantileSlice(&orig)
 }
 
 // Len returns the number of elements in the slice.
 //
-// Returns "0" for a newly instance created with "NewValueAtQuantileSlice()".
-func (es ValueAtQuantileSlice) Len() int {
+// Returns "0" for a newly instance created with "NewSummaryDataPointValueAtQuantileSlice()".
+func (es SummaryDataPointValueAtQuantileSlice) Len() int {
 	return len(*es.getOrig())
 }
 
@@ -2290,18 +2290,18 @@ func (es ValueAtQuantileSlice) Len() int {
 //	    e := es.At(i)
 //	    ... // Do something with the element
 //	}
-func (es ValueAtQuantileSlice) At(ix int) ValueAtQuantile {
-	return newValueAtQuantile((*es.getOrig())[ix])
+func (es SummaryDataPointValueAtQuantileSlice) At(ix int) SummaryDataPointValueAtQuantile {
+	return newSummaryDataPointValueAtQuantile((*es.getOrig())[ix])
 }
 
 // CopyTo copies all elements from the current slice to the dest.
-func (es ValueAtQuantileSlice) CopyTo(dest ValueAtQuantileSlice) {
+func (es SummaryDataPointValueAtQuantileSlice) CopyTo(dest SummaryDataPointValueAtQuantileSlice) {
 	srcLen := es.Len()
 	destCap := cap(*dest.getOrig())
 	if srcLen <= destCap {
 		(*dest.getOrig()) = (*dest.getOrig())[:srcLen:destCap]
 		for i := range *es.getOrig() {
-			newValueAtQuantile((*es.getOrig())[i]).CopyTo(newValueAtQuantile((*dest.getOrig())[i]))
+			newSummaryDataPointValueAtQuantile((*es.getOrig())[i]).CopyTo(newSummaryDataPointValueAtQuantile((*dest.getOrig())[i]))
 		}
 		return
 	}
@@ -2309,7 +2309,7 @@ func (es ValueAtQuantileSlice) CopyTo(dest ValueAtQuantileSlice) {
 	wrappers := make([]*otlpmetrics.SummaryDataPoint_ValueAtQuantile, srcLen)
 	for i := range *es.getOrig() {
 		wrappers[i] = &origs[i]
-		newValueAtQuantile((*es.getOrig())[i]).CopyTo(newValueAtQuantile(wrappers[i]))
+		newSummaryDataPointValueAtQuantile((*es.getOrig())[i]).CopyTo(newSummaryDataPointValueAtQuantile(wrappers[i]))
 	}
 	*dest.getOrig() = wrappers
 }
@@ -2318,15 +2318,15 @@ func (es ValueAtQuantileSlice) CopyTo(dest ValueAtQuantileSlice) {
 // 1. If the newCap <= cap then no change in capacity.
 // 2. If the newCap > cap then the slice capacity will be expanded to equal newCap.
 //
-// Here is how a new ValueAtQuantileSlice can be initialized:
+// Here is how a new SummaryDataPointValueAtQuantileSlice can be initialized:
 //
-//	es := NewValueAtQuantileSlice()
+//	es := NewSummaryDataPointValueAtQuantileSlice()
 //	es.EnsureCapacity(4)
 //	for i := 0; i < 4; i++ {
 //	    e := es.AppendEmpty()
 //	    // Here should set all the values for e.
 //	}
-func (es ValueAtQuantileSlice) EnsureCapacity(newCap int) {
+func (es SummaryDataPointValueAtQuantileSlice) EnsureCapacity(newCap int) {
 	oldCap := cap(*es.getOrig())
 	if newCap <= oldCap {
 		return
@@ -2337,31 +2337,31 @@ func (es ValueAtQuantileSlice) EnsureCapacity(newCap int) {
 	*es.getOrig() = newOrig
 }
 
-// AppendEmpty will append to the end of the slice an empty ValueAtQuantile.
-// It returns the newly added ValueAtQuantile.
-func (es ValueAtQuantileSlice) AppendEmpty() ValueAtQuantile {
+// AppendEmpty will append to the end of the slice an empty SummaryDataPointValueAtQuantile.
+// It returns the newly added SummaryDataPointValueAtQuantile.
+func (es SummaryDataPointValueAtQuantileSlice) AppendEmpty() SummaryDataPointValueAtQuantile {
 	*es.getOrig() = append(*es.getOrig(), &otlpmetrics.SummaryDataPoint_ValueAtQuantile{})
 	return es.At(es.Len() - 1)
 }
 
-// Sort sorts the ValueAtQuantile elements within ValueAtQuantileSlice given the
-// provided less function so that two instances of ValueAtQuantileSlice
+// Sort sorts the SummaryDataPointValueAtQuantile elements within SummaryDataPointValueAtQuantileSlice given the
+// provided less function so that two instances of SummaryDataPointValueAtQuantileSlice
 // can be compared.
 //
 // Returns the same instance to allow nicer code like:
 //
-//	lessFunc := func(a, b ValueAtQuantile) bool {
+//	lessFunc := func(a, b SummaryDataPointValueAtQuantile) bool {
 //	  return a.Name() < b.Name() // choose any comparison here
 //	}
 //	assert.Equal(t, expected.Sort(lessFunc), actual.Sort(lessFunc))
-func (es ValueAtQuantileSlice) Sort(less func(a, b ValueAtQuantile) bool) ValueAtQuantileSlice {
+func (es SummaryDataPointValueAtQuantileSlice) Sort(less func(a, b SummaryDataPointValueAtQuantile) bool) SummaryDataPointValueAtQuantileSlice {
 	sort.SliceStable(*es.getOrig(), func(i, j int) bool { return less(es.At(i), es.At(j)) })
 	return es
 }
 
 // MoveAndAppendTo moves all elements from the current slice and appends them to the dest.
 // The current slice will be cleared.
-func (es ValueAtQuantileSlice) MoveAndAppendTo(dest ValueAtQuantileSlice) {
+func (es SummaryDataPointValueAtQuantileSlice) MoveAndAppendTo(dest SummaryDataPointValueAtQuantileSlice) {
 	if *dest.getOrig() == nil {
 		// We can simply move the entire vector and avoid any allocations.
 		*dest.getOrig() = *es.getOrig()
@@ -2373,7 +2373,7 @@ func (es ValueAtQuantileSlice) MoveAndAppendTo(dest ValueAtQuantileSlice) {
 
 // RemoveIf calls f sequentially for each element present in the slice.
 // If f returns true, the element is removed from the slice.
-func (es ValueAtQuantileSlice) RemoveIf(f func(ValueAtQuantile) bool) {
+func (es SummaryDataPointValueAtQuantileSlice) RemoveIf(f func(SummaryDataPointValueAtQuantile) bool) {
 	newLen := 0
 	for i := 0; i < len(*es.getOrig()); i++ {
 		if f(es.At(i)) {
@@ -2391,61 +2391,61 @@ func (es ValueAtQuantileSlice) RemoveIf(f func(ValueAtQuantile) bool) {
 	*es.getOrig() = (*es.getOrig())[:newLen]
 }
 
-// ValueAtQuantile is a quantile value within a Summary data point.
+// SummaryDataPointValueAtQuantile is a quantile value within a Summary data point.
 //
 // This is a reference type, if passed by value and callee modifies it the
 // caller will see the modification.
 //
-// Must use NewValueAtQuantile function to create new instances.
+// Must use NewSummaryDataPointValueAtQuantile function to create new instances.
 // Important: zero-initialized instance is not valid for use.
 
-type ValueAtQuantile internal.ValueAtQuantile
+type SummaryDataPointValueAtQuantile internal.SummaryDataPointValueAtQuantile
 
-func newValueAtQuantile(orig *otlpmetrics.SummaryDataPoint_ValueAtQuantile) ValueAtQuantile {
-	return ValueAtQuantile(internal.NewValueAtQuantile(orig))
+func newSummaryDataPointValueAtQuantile(orig *otlpmetrics.SummaryDataPoint_ValueAtQuantile) SummaryDataPointValueAtQuantile {
+	return SummaryDataPointValueAtQuantile(internal.NewSummaryDataPointValueAtQuantile(orig))
 }
 
-func (ms ValueAtQuantile) getOrig() *otlpmetrics.SummaryDataPoint_ValueAtQuantile {
-	return internal.GetOrigValueAtQuantile(internal.ValueAtQuantile(ms))
+func (ms SummaryDataPointValueAtQuantile) getOrig() *otlpmetrics.SummaryDataPoint_ValueAtQuantile {
+	return internal.GetOrigSummaryDataPointValueAtQuantile(internal.SummaryDataPointValueAtQuantile(ms))
 }
 
-// NewValueAtQuantile creates a new empty ValueAtQuantile.
+// NewSummaryDataPointValueAtQuantile creates a new empty SummaryDataPointValueAtQuantile.
 //
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
-func NewValueAtQuantile() ValueAtQuantile {
-	return newValueAtQuantile(&otlpmetrics.SummaryDataPoint_ValueAtQuantile{})
+func NewSummaryDataPointValueAtQuantile() SummaryDataPointValueAtQuantile {
+	return newSummaryDataPointValueAtQuantile(&otlpmetrics.SummaryDataPoint_ValueAtQuantile{})
 }
 
 // MoveTo moves all properties from the current struct to dest
 // resetting the current instance to its zero value
-func (ms ValueAtQuantile) MoveTo(dest ValueAtQuantile) {
+func (ms SummaryDataPointValueAtQuantile) MoveTo(dest SummaryDataPointValueAtQuantile) {
 	*dest.getOrig() = *ms.getOrig()
 	*ms.getOrig() = otlpmetrics.SummaryDataPoint_ValueAtQuantile{}
 }
 
-// Quantile returns the quantile associated with this ValueAtQuantile.
-func (ms ValueAtQuantile) Quantile() float64 {
+// Quantile returns the quantile associated with this SummaryDataPointValueAtQuantile.
+func (ms SummaryDataPointValueAtQuantile) Quantile() float64 {
 	return ms.getOrig().Quantile
 }
 
-// SetQuantile replaces the quantile associated with this ValueAtQuantile.
-func (ms ValueAtQuantile) SetQuantile(v float64) {
+// SetQuantile replaces the quantile associated with this SummaryDataPointValueAtQuantile.
+func (ms SummaryDataPointValueAtQuantile) SetQuantile(v float64) {
 	ms.getOrig().Quantile = v
 }
 
-// Value returns the value associated with this ValueAtQuantile.
-func (ms ValueAtQuantile) Value() float64 {
+// Value returns the value associated with this SummaryDataPointValueAtQuantile.
+func (ms SummaryDataPointValueAtQuantile) Value() float64 {
 	return ms.getOrig().Value
 }
 
-// SetValue replaces the value associated with this ValueAtQuantile.
-func (ms ValueAtQuantile) SetValue(v float64) {
+// SetValue replaces the value associated with this SummaryDataPointValueAtQuantile.
+func (ms SummaryDataPointValueAtQuantile) SetValue(v float64) {
 	ms.getOrig().Value = v
 }
 
 // CopyTo copies all properties from the current struct to the dest.
-func (ms ValueAtQuantile) CopyTo(dest ValueAtQuantile) {
+func (ms SummaryDataPointValueAtQuantile) CopyTo(dest SummaryDataPointValueAtQuantile) {
 	dest.SetQuantile(ms.Quantile())
 	dest.SetValue(ms.Value())
 }

--- a/pdata/pmetric/generated_metrics_test.go
+++ b/pdata/pmetric/generated_metrics_test.go
@@ -1523,9 +1523,9 @@ func TestSummaryDataPoint_Sum(t *testing.T) {
 
 func TestSummaryDataPoint_QuantileValues(t *testing.T) {
 	ms := NewSummaryDataPoint()
-	assert.Equal(t, NewValueAtQuantileSlice(), ms.QuantileValues())
-	internal.FillTestValueAtQuantileSlice(internal.ValueAtQuantileSlice(ms.QuantileValues()))
-	assert.Equal(t, ValueAtQuantileSlice(internal.GenerateTestValueAtQuantileSlice()), ms.QuantileValues())
+	assert.Equal(t, NewSummaryDataPointValueAtQuantileSlice(), ms.QuantileValues())
+	internal.FillTestSummaryDataPointValueAtQuantileSlice(internal.SummaryDataPointValueAtQuantileSlice(ms.QuantileValues()))
+	assert.Equal(t, SummaryDataPointValueAtQuantileSlice(internal.GenerateTestSummaryDataPointValueAtQuantileSlice()), ms.QuantileValues())
 }
 
 func TestSummaryDataPoint_Flags(t *testing.T) {
@@ -1536,41 +1536,41 @@ func TestSummaryDataPoint_Flags(t *testing.T) {
 	assert.Equal(t, testValFlags, ms.Flags())
 }
 
-func TestValueAtQuantileSlice(t *testing.T) {
-	es := NewValueAtQuantileSlice()
+func TestSummaryDataPointValueAtQuantileSlice(t *testing.T) {
+	es := NewSummaryDataPointValueAtQuantileSlice()
 	assert.Equal(t, 0, es.Len())
-	es = newValueAtQuantileSlice(&[]*otlpmetrics.SummaryDataPoint_ValueAtQuantile{})
+	es = newSummaryDataPointValueAtQuantileSlice(&[]*otlpmetrics.SummaryDataPoint_ValueAtQuantile{})
 	assert.Equal(t, 0, es.Len())
 
 	es.EnsureCapacity(7)
-	emptyVal := newValueAtQuantile(&otlpmetrics.SummaryDataPoint_ValueAtQuantile{})
-	testVal := ValueAtQuantile(internal.GenerateTestValueAtQuantile())
+	emptyVal := newSummaryDataPointValueAtQuantile(&otlpmetrics.SummaryDataPoint_ValueAtQuantile{})
+	testVal := SummaryDataPointValueAtQuantile(internal.GenerateTestSummaryDataPointValueAtQuantile())
 	assert.Equal(t, 7, cap(*es.getOrig()))
 	for i := 0; i < es.Len(); i++ {
 		el := es.AppendEmpty()
 		assert.Equal(t, emptyVal, el)
-		internal.FillTestValueAtQuantile(internal.ValueAtQuantile(el))
+		internal.FillTestSummaryDataPointValueAtQuantile(internal.SummaryDataPointValueAtQuantile(el))
 		assert.Equal(t, testVal, el)
 	}
 }
 
-func TestValueAtQuantileSlice_CopyTo(t *testing.T) {
-	dest := NewValueAtQuantileSlice()
+func TestSummaryDataPointValueAtQuantileSlice_CopyTo(t *testing.T) {
+	dest := NewSummaryDataPointValueAtQuantileSlice()
 	// Test CopyTo to empty
-	NewValueAtQuantileSlice().CopyTo(dest)
-	assert.Equal(t, NewValueAtQuantileSlice(), dest)
+	NewSummaryDataPointValueAtQuantileSlice().CopyTo(dest)
+	assert.Equal(t, NewSummaryDataPointValueAtQuantileSlice(), dest)
 
 	// Test CopyTo larger slice
-	ValueAtQuantileSlice(internal.GenerateTestValueAtQuantileSlice()).CopyTo(dest)
-	assert.Equal(t, ValueAtQuantileSlice(internal.GenerateTestValueAtQuantileSlice()), dest)
+	SummaryDataPointValueAtQuantileSlice(internal.GenerateTestSummaryDataPointValueAtQuantileSlice()).CopyTo(dest)
+	assert.Equal(t, SummaryDataPointValueAtQuantileSlice(internal.GenerateTestSummaryDataPointValueAtQuantileSlice()), dest)
 
 	// Test CopyTo same size slice
-	ValueAtQuantileSlice(internal.GenerateTestValueAtQuantileSlice()).CopyTo(dest)
-	assert.Equal(t, ValueAtQuantileSlice(internal.GenerateTestValueAtQuantileSlice()), dest)
+	SummaryDataPointValueAtQuantileSlice(internal.GenerateTestSummaryDataPointValueAtQuantileSlice()).CopyTo(dest)
+	assert.Equal(t, SummaryDataPointValueAtQuantileSlice(internal.GenerateTestSummaryDataPointValueAtQuantileSlice()), dest)
 }
 
-func TestValueAtQuantileSlice_EnsureCapacity(t *testing.T) {
-	es := ValueAtQuantileSlice(internal.GenerateTestValueAtQuantileSlice())
+func TestSummaryDataPointValueAtQuantileSlice_EnsureCapacity(t *testing.T) {
+	es := SummaryDataPointValueAtQuantileSlice(internal.GenerateTestSummaryDataPointValueAtQuantileSlice())
 	// Test ensure smaller capacity.
 	const ensureSmallLen = 4
 	expectedEs := make(map[*otlpmetrics.SummaryDataPoint_ValueAtQuantile]bool)
@@ -1603,24 +1603,24 @@ func TestValueAtQuantileSlice_EnsureCapacity(t *testing.T) {
 	assert.Equal(t, expectedEs, foundEs)
 }
 
-func TestValueAtQuantileSlice_MoveAndAppendTo(t *testing.T) {
+func TestSummaryDataPointValueAtQuantileSlice_MoveAndAppendTo(t *testing.T) {
 	// Test MoveAndAppendTo to empty
-	expectedSlice := ValueAtQuantileSlice(internal.GenerateTestValueAtQuantileSlice())
-	dest := NewValueAtQuantileSlice()
-	src := ValueAtQuantileSlice(internal.GenerateTestValueAtQuantileSlice())
+	expectedSlice := SummaryDataPointValueAtQuantileSlice(internal.GenerateTestSummaryDataPointValueAtQuantileSlice())
+	dest := NewSummaryDataPointValueAtQuantileSlice()
+	src := SummaryDataPointValueAtQuantileSlice(internal.GenerateTestSummaryDataPointValueAtQuantileSlice())
 	src.MoveAndAppendTo(dest)
-	assert.Equal(t, ValueAtQuantileSlice(internal.GenerateTestValueAtQuantileSlice()), dest)
+	assert.Equal(t, SummaryDataPointValueAtQuantileSlice(internal.GenerateTestSummaryDataPointValueAtQuantileSlice()), dest)
 	assert.Equal(t, 0, src.Len())
 	assert.Equal(t, expectedSlice.Len(), dest.Len())
 
 	// Test MoveAndAppendTo empty slice
 	src.MoveAndAppendTo(dest)
-	assert.Equal(t, ValueAtQuantileSlice(internal.GenerateTestValueAtQuantileSlice()), dest)
+	assert.Equal(t, SummaryDataPointValueAtQuantileSlice(internal.GenerateTestSummaryDataPointValueAtQuantileSlice()), dest)
 	assert.Equal(t, 0, src.Len())
 	assert.Equal(t, expectedSlice.Len(), dest.Len())
 
 	// Test MoveAndAppendTo not empty slice
-	ValueAtQuantileSlice(internal.GenerateTestValueAtQuantileSlice()).MoveAndAppendTo(dest)
+	SummaryDataPointValueAtQuantileSlice(internal.GenerateTestSummaryDataPointValueAtQuantileSlice()).MoveAndAppendTo(dest)
 	assert.Equal(t, 2*expectedSlice.Len(), dest.Len())
 	for i := 0; i < expectedSlice.Len(); i++ {
 		assert.Equal(t, expectedSlice.At(i), dest.At(i))
@@ -1628,51 +1628,51 @@ func TestValueAtQuantileSlice_MoveAndAppendTo(t *testing.T) {
 	}
 }
 
-func TestValueAtQuantileSlice_RemoveIf(t *testing.T) {
+func TestSummaryDataPointValueAtQuantileSlice_RemoveIf(t *testing.T) {
 	// Test RemoveIf on empty slice
-	emptySlice := NewValueAtQuantileSlice()
-	emptySlice.RemoveIf(func(el ValueAtQuantile) bool {
+	emptySlice := NewSummaryDataPointValueAtQuantileSlice()
+	emptySlice.RemoveIf(func(el SummaryDataPointValueAtQuantile) bool {
 		t.Fail()
 		return false
 	})
 
 	// Test RemoveIf
-	filtered := ValueAtQuantileSlice(internal.GenerateTestValueAtQuantileSlice())
+	filtered := SummaryDataPointValueAtQuantileSlice(internal.GenerateTestSummaryDataPointValueAtQuantileSlice())
 	pos := 0
-	filtered.RemoveIf(func(el ValueAtQuantile) bool {
+	filtered.RemoveIf(func(el SummaryDataPointValueAtQuantile) bool {
 		pos++
 		return pos%3 == 0
 	})
 	assert.Equal(t, 5, filtered.Len())
 }
 
-func TestValueAtQuantile_MoveTo(t *testing.T) {
-	ms := ValueAtQuantile(internal.GenerateTestValueAtQuantile())
-	dest := NewValueAtQuantile()
+func TestSummaryDataPointValueAtQuantile_MoveTo(t *testing.T) {
+	ms := SummaryDataPointValueAtQuantile(internal.GenerateTestSummaryDataPointValueAtQuantile())
+	dest := NewSummaryDataPointValueAtQuantile()
 	ms.MoveTo(dest)
-	assert.Equal(t, NewValueAtQuantile(), ms)
-	assert.Equal(t, ValueAtQuantile(internal.GenerateTestValueAtQuantile()), dest)
+	assert.Equal(t, NewSummaryDataPointValueAtQuantile(), ms)
+	assert.Equal(t, SummaryDataPointValueAtQuantile(internal.GenerateTestSummaryDataPointValueAtQuantile()), dest)
 }
 
-func TestValueAtQuantile_CopyTo(t *testing.T) {
-	ms := NewValueAtQuantile()
-	orig := NewValueAtQuantile()
+func TestSummaryDataPointValueAtQuantile_CopyTo(t *testing.T) {
+	ms := NewSummaryDataPointValueAtQuantile()
+	orig := NewSummaryDataPointValueAtQuantile()
 	orig.CopyTo(ms)
 	assert.Equal(t, orig, ms)
-	orig = ValueAtQuantile(internal.GenerateTestValueAtQuantile())
+	orig = SummaryDataPointValueAtQuantile(internal.GenerateTestSummaryDataPointValueAtQuantile())
 	orig.CopyTo(ms)
 	assert.Equal(t, orig, ms)
 }
 
-func TestValueAtQuantile_Quantile(t *testing.T) {
-	ms := NewValueAtQuantile()
+func TestSummaryDataPointValueAtQuantile_Quantile(t *testing.T) {
+	ms := NewSummaryDataPointValueAtQuantile()
 	assert.Equal(t, float64(0.0), ms.Quantile())
 	ms.SetQuantile(float64(17.13))
 	assert.Equal(t, float64(17.13), ms.Quantile())
 }
 
-func TestValueAtQuantile_Value(t *testing.T) {
-	ms := NewValueAtQuantile()
+func TestSummaryDataPointValueAtQuantile_Value(t *testing.T) {
+	ms := NewSummaryDataPointValueAtQuantile()
 	assert.Equal(t, float64(0.0), ms.Value())
 	ms.SetValue(float64(17.13))
 	assert.Equal(t, float64(17.13), ms.Value())

--- a/pdata/pmetric/metrics.go
+++ b/pdata/pmetric/metrics.go
@@ -218,3 +218,15 @@ type Buckets = ExponentialHistogramDataPointBuckets
 
 // Deprecated: [0.62.0] Use NewExponentialHistogramDataPointBuckets instead.
 var NewBuckets = NewExponentialHistogramDataPointBuckets
+
+// Deprecated: [0.62.0] Use SummaryDataPointValueAtQuantile instead.
+type ValueAtQuantile = SummaryDataPointValueAtQuantile
+
+// Deprecated: [0.62.0] Use NewSummaryDataPointValueAtQuantile instead.
+var NewValueAtQuantile = NewSummaryDataPointValueAtQuantile
+
+// Deprecated: [0.62.0] Use SummaryDataPointValueAtQuantileSlice instead.
+type ValueAtQuantileSlice = SummaryDataPointValueAtQuantileSlice
+
+// Deprecated: [0.62.0] Use NewSummaryDataPointValueAtQuantileSlice instead.
+var NewValueAtQuantileSlice = NewSummaryDataPointValueAtQuantileSlice


### PR DESCRIPTION
Rename `pmetric.[New]?ValueAtQuantile[Slice]?` structs and functions to align them with the underlying protobuf messages. It should have `SummaryDataPoint` prefix as they are defined in the scope of `SummaryDataPoint` protobuf message.

Updates https://github.com/open-telemetry/opentelemetry-collector/issues/6257