### PR TITLE
[pdata] Rename enum zero value constants to have `Empty` suffix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@
   - ValueTypeMap.String() -> "Map"
   - ValueTypeSlice.String() -> "Slice"
   - ValueTypeBytes.String() -> "Bytes"
+- Rename output of `[MetricType|NumberDataPointValueType|ExemplarValueType].String()` for zero values from `"None"` to 
+  `"Empty"` (#6270)
 
 ### 🚩 Deprecations 🚩
 
@@ -40,6 +42,11 @@
 - Deprecate `pmetric.[New]?Buckets` in favor of `pmetric.[New]?ExponentialHistogramDataPointBuckets` (#6261)
 - Deprecate `plog.SeverityNumberUndefined` in favor of `plog.SeverityNumberUnspecified` (#6269)
 - Deprecate `pmetric.[New]?ValueAtQuantile[Slice]?` in favor of `pmetric.[New]?SummaryDataPointValueAtQuantile[Slice]?` (#6262)
+- Deprecate enum zero constants ending with `None` (#6270)
+  - Deprecate `pmetric.MetricTypeNone` in favor of `pmetric.MetricTypeEmpty`
+  - Deprecate `pmetric.NumberDataPointValueTypeNone` in favor of `pmetric.NumberDataPointValueTypeEmpty`
+  - Deprecate `pmetric.ExemplarValueTypeNone` in favor of `pmetric.ExemplarValueTypeEmpty`
+- Deprecate `plog.SeverityNumberUndefined` in favor of `plog.SeverityNumberUnspecified` (#6269)
 
 ### 💡 Enhancements 💡
 

--- a/exporter/loggingexporter/internal/otlptext/databuffer.go
+++ b/exporter/loggingexporter/internal/otlptext/databuffer.go
@@ -76,7 +76,7 @@ func (b *dataBuffer) logMetricDescriptor(md pmetric.Metric) {
 
 func (b *dataBuffer) logMetricDataPoints(m pmetric.Metric) {
 	switch m.Type() {
-	case pmetric.MetricTypeNone:
+	case pmetric.MetricTypeEmpty:
 		return
 	case pmetric.MetricTypeGauge:
 		b.logNumberDataPoints(m.Gauge().DataPoints())

--- a/internal/testdata/metric.go
+++ b/internal/testdata/metric.go
@@ -71,7 +71,7 @@ func GenerateMetricsAllTypesEmpty() pmetric.Metrics {
 
 func GenerateMetricsMetricTypeInvalid() pmetric.Metrics {
 	md := generateMetricsOneEmptyInstrumentationScope()
-	initMetric(md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().AppendEmpty(), TestSumIntMetricName, pmetric.MetricTypeNone)
+	initMetric(md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().AppendEmpty(), TestSumIntMetricName, pmetric.MetricTypeEmpty)
 	return md
 }
 

--- a/pdata/internal/cmd/pdatagen/internal/base_fields.go
+++ b/pdata/internal/cmd/pdatagen/internal/base_fields.go
@@ -64,7 +64,7 @@ func (ms ${structName}) ${typeFuncName}() ${typeName} {
 
 const oneOfTypeAccessorHeaderTestTemplate = `func Test${structName}_${typeFuncName}(t *testing.T) {
 	tv := New${structName}()
-	assert.Equal(t, ${typeName}None, tv.${typeFuncName}())
+	assert.Equal(t, ${typeName}Empty, tv.${typeFuncName}())
 }
 `
 
@@ -547,7 +547,7 @@ func (of *oneOfField) generateTypeAccessors(ms baseStruct, sb *strings.Builder) 
 		v.generateTypeSwitchCase(of, sb)
 	}
 	sb.WriteString("\t}\n")
-	sb.WriteString("\treturn " + of.typeName + "None\n")
+	sb.WriteString("\treturn " + of.typeName + "Empty\n")
 	sb.WriteString("}\n")
 }
 

--- a/pdata/pmetric/generated_metrics.go
+++ b/pdata/pmetric/generated_metrics.go
@@ -645,7 +645,7 @@ func (ms Metric) Type() MetricType {
 	case *otlpmetrics.Metric_Summary:
 		return MetricTypeSummary
 	}
-	return MetricTypeNone
+	return MetricTypeEmpty
 }
 
 // Gauge returns the gauge associated with this Metric.
@@ -1260,7 +1260,7 @@ func (ms NumberDataPoint) ValueType() NumberDataPointValueType {
 	case *otlpmetrics.NumberDataPoint_AsInt:
 		return NumberDataPointValueTypeInt
 	}
-	return NumberDataPointValueTypeNone
+	return NumberDataPointValueTypeEmpty
 }
 
 // DoubleValue returns the double associated with this NumberDataPoint.
@@ -2625,7 +2625,7 @@ func (ms Exemplar) ValueType() ExemplarValueType {
 	case *otlpmetrics.Exemplar_AsInt:
 		return ExemplarValueTypeInt
 	}
-	return ExemplarValueTypeNone
+	return ExemplarValueTypeEmpty
 }
 
 // DoubleValue returns the double associated with this Exemplar.

--- a/pdata/pmetric/generated_metrics_test.go
+++ b/pdata/pmetric/generated_metrics_test.go
@@ -475,7 +475,7 @@ func TestMetric_Unit(t *testing.T) {
 
 func TestMetric_Type(t *testing.T) {
 	tv := NewMetric()
-	assert.Equal(t, MetricTypeNone, tv.Type())
+	assert.Equal(t, MetricTypeEmpty, tv.Type())
 }
 
 func TestMetric_Gauge(t *testing.T) {
@@ -862,7 +862,7 @@ func TestNumberDataPoint_Timestamp(t *testing.T) {
 
 func TestNumberDataPoint_ValueType(t *testing.T) {
 	tv := NewNumberDataPoint()
-	assert.Equal(t, NumberDataPointValueTypeNone, tv.ValueType())
+	assert.Equal(t, NumberDataPointValueTypeEmpty, tv.ValueType())
 }
 
 func TestNumberDataPoint_DoubleValue(t *testing.T) {
@@ -1807,7 +1807,7 @@ func TestExemplar_Timestamp(t *testing.T) {
 
 func TestExemplar_ValueType(t *testing.T) {
 	tv := NewExemplar()
-	assert.Equal(t, ExemplarValueTypeNone, tv.ValueType())
+	assert.Equal(t, ExemplarValueTypeEmpty, tv.ValueType())
 }
 
 func TestExemplar_DoubleValue(t *testing.T) {

--- a/pdata/pmetric/metrics.go
+++ b/pdata/pmetric/metrics.go
@@ -102,7 +102,8 @@ func (ms Metrics) DataPointCount() (dataPointCount int) {
 type MetricType int32
 
 const (
-	MetricTypeNone MetricType = iota
+	// MetricTypeEmpty means that metric type is unset.
+	MetricTypeEmpty MetricType = iota
 	MetricTypeGauge
 	MetricTypeSum
 	MetricTypeHistogram
@@ -110,11 +111,14 @@ const (
 	MetricTypeSummary
 )
 
+// Deprecated: [0.62.0] Use MetricTypeEmpty instead.
+const MetricTypeNone = MetricTypeEmpty
+
 // String returns the string representation of the MetricType.
 func (mdt MetricType) String() string {
 	switch mdt {
-	case MetricTypeNone:
-		return "None"
+	case MetricTypeEmpty:
+		return "Empty"
 	case MetricTypeGauge:
 		return "Gauge"
 	case MetricTypeSum:
@@ -173,16 +177,20 @@ const (
 type NumberDataPointValueType int32
 
 const (
-	NumberDataPointValueTypeNone NumberDataPointValueType = iota
+	// NumberDataPointValueTypeEmpty means that data point value is unset.
+	NumberDataPointValueTypeEmpty NumberDataPointValueType = iota
 	NumberDataPointValueTypeInt
 	NumberDataPointValueTypeDouble
 )
 
+// Deprecated: [0.62.0] Use NumberDataPointValueTypeEmpty instead.
+const NumberDataPointValueTypeNone = NumberDataPointValueTypeEmpty
+
 // String returns the string representation of the NumberDataPointValueType.
 func (nt NumberDataPointValueType) String() string {
 	switch nt {
-	case NumberDataPointValueTypeNone:
-		return "None"
+	case NumberDataPointValueTypeEmpty:
+		return "Empty"
 	case NumberDataPointValueTypeInt:
 		return "Int"
 	case NumberDataPointValueTypeDouble:
@@ -195,16 +203,20 @@ func (nt NumberDataPointValueType) String() string {
 type ExemplarValueType int32
 
 const (
-	ExemplarValueTypeNone ExemplarValueType = iota
+	// ExemplarValueTypeEmpty means that exemplar value is unset.
+	ExemplarValueTypeEmpty ExemplarValueType = iota
 	ExemplarValueTypeInt
 	ExemplarValueTypeDouble
 )
 
+// Deprecated: [0.62.0] Use ExemplarValueTypeEmpty instead.
+const ExemplarValueTypeNone = ExemplarValueTypeEmpty
+
 // String returns the string representation of the ExemplarValueType.
 func (nt ExemplarValueType) String() string {
 	switch nt {
-	case ExemplarValueTypeNone:
-		return "None"
+	case ExemplarValueTypeEmpty:
+		return "Empty"
 	case ExemplarValueTypeInt:
 		return "Int"
 	case ExemplarValueTypeDouble:

--- a/pdata/pmetric/metrics_test.go
+++ b/pdata/pmetric/metrics_test.go
@@ -36,7 +36,7 @@ const (
 )
 
 func TestMetricTypeString(t *testing.T) {
-	assert.Equal(t, "None", MetricTypeNone.String())
+	assert.Equal(t, "Empty", MetricTypeEmpty.String())
 	assert.Equal(t, "Gauge", MetricTypeGauge.String())
 	assert.Equal(t, "Sum", MetricTypeSum.String())
 	assert.Equal(t, "Histogram", MetricTypeHistogram.String())
@@ -53,14 +53,14 @@ func TestAggregationTemporalityString(t *testing.T) {
 }
 
 func TestNumberDataPointValueTypeString(t *testing.T) {
-	assert.Equal(t, "None", NumberDataPointValueTypeNone.String())
+	assert.Equal(t, "Empty", NumberDataPointValueTypeEmpty.String())
 	assert.Equal(t, "Int", NumberDataPointValueTypeInt.String())
 	assert.Equal(t, "Double", NumberDataPointValueTypeDouble.String())
 	assert.Equal(t, "", (NumberDataPointValueTypeDouble + 1).String())
 }
 
 func TestExemplarValueTypeString(t *testing.T) {
-	assert.Equal(t, "None", ExemplarValueTypeNone.String())
+	assert.Equal(t, "Empty", ExemplarValueTypeEmpty.String())
 	assert.Equal(t, "Int", ExemplarValueTypeInt.String())
 	assert.Equal(t, "Double", ExemplarValueTypeDouble.String())
 	assert.Equal(t, "", (ExemplarValueTypeDouble + 1).String())


### PR DESCRIPTION
For consistency with `pcommon.ValueType`

Resolves https://github.com/open-telemetry/opentelemetry-collector/issues/6256