### PR TITLE
[pdata] Simplify pdatagen to rely more on the proto naming dependency

### DIFF
--- a/pdata/internal/cmd/pdatagen/internal/base_fields.go
+++ b/pdata/internal/cmd/pdatagen/internal/base_fields.go
@@ -19,9 +19,9 @@ import (
 	"strings"
 )
 
-const accessorSliceTemplate = `// ${fieldName} returns the ${originFieldName} associated with this ${structName}.
+const accessorSliceTemplate = `// ${fieldName} returns the ${fieldName} associated with this ${structName}.
 func (ms ${structName}) ${fieldName}() ${packageName}${returnType} {
-	return ${packageName}${returnType}(internal.New${returnType}(&ms.getOrig().${originFieldName}))
+	return ${packageName}${returnType}(internal.New${returnType}(&ms.getOrig().${fieldName}))
 }`
 
 const accessorsSliceTestTemplate = `func Test${structName}_${fieldName}(t *testing.T) {
@@ -33,7 +33,7 @@ const accessorsSliceTestTemplate = `func Test${structName}_${fieldName}(t *testi
 
 const accessorsMessageValueTemplate = `// ${fieldName} returns the ${lowerFieldName} associated with this ${structName}.
 func (ms ${structName}) ${fieldName}() ${packageName}${returnType} {
-	return ${packageName}${returnType}(internal.New${returnType}(&ms.getOrig().${originFieldName}))
+	return ${packageName}${returnType}(internal.New${returnType}(&ms.getOrig().${fieldName}))
 }`
 
 const accessorsMessageValueTestTemplate = `func Test${structName}_${fieldName}(t *testing.T) {
@@ -44,17 +44,17 @@ const accessorsMessageValueTestTemplate = `func Test${structName}_${fieldName}(t
 
 const accessorsPrimitiveTemplate = `// ${fieldName} returns the ${lowerFieldName} associated with this ${structName}.
 func (ms ${structName}) ${fieldName}() ${packageName}${returnType} {
-	return ms.getOrig().${originFieldName}
+	return ms.getOrig().${fieldName}
 }
 
 // Set${fieldName} replaces the ${lowerFieldName} associated with this ${structName}.
 func (ms ${structName}) Set${fieldName}(v ${returnType}) {
-	ms.getOrig().${originFieldName} = v
+	ms.getOrig().${fieldName} = v
 }`
 
 const accessorsPrimitiveSliceTemplate = `// ${fieldName} returns the ${lowerFieldName} associated with this ${structName}.
 func (ms ${structName}) ${fieldName}() ${packageName}${returnType} {
-	return ${packageName}${returnType}(internal.New${returnType}(&ms.getOrig().${originFieldName}))
+	return ${packageName}${returnType}(internal.New${returnType}(&ms.getOrig().${fieldName}))
 }`
 
 const oneOfTypeAccessorHeaderTemplate = `// ${typeFuncName} returns the type of the ${lowerOriginFieldName} for this ${structName}.
@@ -79,7 +79,7 @@ func (ms ${structName}) ${fieldName}() ${returnType} {
 	if !ok {
 		return ${returnType}{}
 	}
-	return new${returnType}(v.${originFieldName})
+	return new${returnType}(v.${fieldName})
 }
 
 // SetEmpty${fieldName} sets an empty ${lowerFieldName} to this ${structName}.
@@ -88,8 +88,8 @@ func (ms ${structName}) ${fieldName}() ${returnType} {
 //
 // Calling this function on zero-initialized ${structName} will cause a panic.
 func (ms ${structName}) SetEmpty${fieldName}() ${returnType} {
-	val := &${originFieldPackageName}.${originFieldName}{}
-	ms.getOrig().${originOneOfFieldName} = &${originStructType}{${originFieldName}: val}
+	val := &${originFieldPackageName}.${fieldName}{}
+	ms.getOrig().${originOneOfFieldName} = &${originStructType}{${fieldName}: val}
 	return new${returnType}(val)
 }`
 
@@ -188,9 +188,8 @@ type baseField interface {
 }
 
 type sliceField struct {
-	fieldName       string
-	originFieldName string
-	returnSlice     baseSlice
+	fieldName   string
+	returnSlice baseSlice
 }
 
 func (sf *sliceField) generateAccessors(ms baseStruct, sb *strings.Builder) {
@@ -207,8 +206,6 @@ func (sf *sliceField) generateAccessors(ms baseStruct, sb *strings.Builder) {
 			return ""
 		case "returnType":
 			return sf.returnSlice.getName()
-		case "originFieldName":
-			return sf.originFieldName
 		default:
 			panic(name)
 		}
@@ -236,7 +233,7 @@ func (sf *sliceField) generateAccessorsTest(ms baseStruct, sb *strings.Builder) 
 }
 
 func (sf *sliceField) generateSetWithTestValue(sb *strings.Builder) {
-	sb.WriteString("\tFillTest" + sf.returnSlice.getName() + "(New" + sf.returnSlice.getName() + "(&tv.orig." + sf.originFieldName + "))")
+	sb.WriteString("\tFillTest" + sf.returnSlice.getName() + "(New" + sf.returnSlice.getName() + "(&tv.orig." + sf.fieldName + "))")
 }
 
 func (sf *sliceField) generateCopyToValue(_ baseStruct, sb *strings.Builder) {
@@ -246,9 +243,8 @@ func (sf *sliceField) generateCopyToValue(_ baseStruct, sb *strings.Builder) {
 var _ baseField = (*sliceField)(nil)
 
 type messageValueField struct {
-	fieldName       string
-	originFieldName string
-	returnMessage   baseStruct
+	fieldName     string
+	returnMessage baseStruct
 }
 
 func (mf *messageValueField) generateAccessors(ms baseStruct, sb *strings.Builder) {
@@ -267,8 +263,6 @@ func (mf *messageValueField) generateAccessors(ms baseStruct, sb *strings.Builde
 			return ""
 		case "returnType":
 			return mf.returnMessage.getName()
-		case "originFieldName":
-			return mf.originFieldName
 		default:
 			panic(name)
 		}
@@ -296,7 +290,7 @@ func (mf *messageValueField) generateAccessorsTest(ms baseStruct, sb *strings.Bu
 }
 
 func (mf *messageValueField) generateSetWithTestValue(sb *strings.Builder) {
-	sb.WriteString("\tFillTest" + mf.returnMessage.getName() + "(New" + mf.returnMessage.getName() + "(&tv.orig." + mf.originFieldName + "))")
+	sb.WriteString("\tFillTest" + mf.returnMessage.getName() + "(New" + mf.returnMessage.getName() + "(&tv.orig." + mf.fieldName + "))")
 }
 
 func (mf *messageValueField) generateCopyToValue(_ baseStruct, sb *strings.Builder) {
@@ -306,11 +300,10 @@ func (mf *messageValueField) generateCopyToValue(_ baseStruct, sb *strings.Build
 var _ baseField = (*messageValueField)(nil)
 
 type primitiveField struct {
-	fieldName       string
-	originFieldName string
-	returnType      string
-	defaultVal      string
-	testVal         string
+	fieldName  string
+	returnType string
+	defaultVal string
+	testVal    string
 }
 
 func (pf *primitiveField) generateAccessors(ms baseStruct, sb *strings.Builder) {
@@ -326,8 +319,6 @@ func (pf *primitiveField) generateAccessors(ms baseStruct, sb *strings.Builder) 
 			return strings.ToLower(pf.fieldName)
 		case "returnType":
 			return pf.returnType
-		case "originFieldName":
-			return pf.originFieldName
 		default:
 			panic(name)
 		}
@@ -354,7 +345,7 @@ func (pf *primitiveField) generateAccessorsTest(ms baseStruct, sb *strings.Build
 }
 
 func (pf *primitiveField) generateSetWithTestValue(sb *strings.Builder) {
-	sb.WriteString("\ttv.orig." + pf.originFieldName + " = " + pf.testVal)
+	sb.WriteString("\ttv.orig." + pf.fieldName + " = " + pf.testVal)
 }
 
 func (pf *primitiveField) generateCopyToValue(_ baseStruct, sb *strings.Builder) {
@@ -397,6 +388,9 @@ func (ptf *primitiveTypedField) generateAccessors(ms baseStruct, sb *strings.Bui
 		case "rawType":
 			return ptf.returnType.rawType
 		case "originFieldName":
+			if ptf.originFieldName == "" {
+				return ptf.fieldName
+			}
 			return ptf.originFieldName
 		default:
 			panic(name)
@@ -429,7 +423,11 @@ func (ptf *primitiveTypedField) generateAccessorsTest(ms baseStruct, sb *strings
 }
 
 func (ptf *primitiveTypedField) generateSetWithTestValue(sb *strings.Builder) {
-	sb.WriteString("\ttv.orig." + ptf.originFieldName + " = " + ptf.returnType.testVal)
+	originFieldName := ptf.fieldName
+	if ptf.originFieldName != "" {
+		originFieldName = ptf.originFieldName
+	}
+	sb.WriteString("\ttv.orig." + originFieldName + " = " + ptf.returnType.testVal)
 }
 
 func (ptf *primitiveTypedField) generateCopyToValue(_ baseStruct, sb *strings.Builder) {
@@ -441,7 +439,6 @@ var _ baseField = (*primitiveTypedField)(nil)
 // primitiveSliceField is used to generate fields for slice of primitive types
 type primitiveSliceField struct {
 	fieldName         string
-	originFieldName   string
 	returnPackageName string
 	returnType        string
 	defaultVal        string
@@ -465,8 +462,6 @@ func (psf *primitiveSliceField) generateAccessors(ms baseStruct, sb *strings.Bui
 				return psf.returnPackageName + "."
 			}
 			return ""
-		case "originFieldName":
-			return psf.originFieldName
 		default:
 			panic(name)
 		}
@@ -498,7 +493,7 @@ func (psf *primitiveSliceField) generateAccessorsTest(ms baseStruct, sb *strings
 }
 
 func (psf *primitiveSliceField) generateSetWithTestValue(sb *strings.Builder) {
-	sb.WriteString("\ttv.orig." + psf.originFieldName + " = " + psf.testVal)
+	sb.WriteString("\ttv.orig." + psf.fieldName + " = " + psf.testVal)
 }
 
 func (psf *primitiveSliceField) generateCopyToValue(ms baseStruct, sb *strings.Builder) {
@@ -682,7 +677,6 @@ var _ oneOfValue = (*oneOfPrimitiveValue)(nil)
 
 type oneOfMessageValue struct {
 	fieldName              string
-	originFieldName        string
 	originFieldPackageName string
 	returnMessage          *messageValueStruct
 }
@@ -694,8 +688,6 @@ func (omv *oneOfMessageValue) generateAccessors(ms baseStruct, of *oneOfField, s
 			return omv.fieldName
 		case "lowerFieldName":
 			return strings.ToLower(omv.fieldName)
-		case "originFieldName":
-			return omv.originFieldName
 		case "originOneOfTypeFuncName":
 			return of.typeFuncName()
 		case "originOneOfFieldName":
@@ -703,7 +695,7 @@ func (omv *oneOfMessageValue) generateAccessors(ms baseStruct, of *oneOfField, s
 		case "originFieldPackageName":
 			return omv.originFieldPackageName
 		case "originStructType":
-			return of.originTypePrefix + omv.originFieldName
+			return of.originTypePrefix + omv.fieldName
 		case "returnType":
 			return omv.returnMessage.structName
 		case "structName":
@@ -738,8 +730,8 @@ func (omv *oneOfMessageValue) generateTests(ms baseStruct, of *oneOfField, sb *s
 }
 
 func (omv *oneOfMessageValue) generateSetWithTestValue(of *oneOfField, sb *strings.Builder) {
-	sb.WriteString("\ttv.orig." + of.originFieldName + " = &" + of.originTypePrefix + omv.originFieldName + "{" + omv.originFieldName + ": &" + omv.originFieldPackageName + "." + omv.originFieldName + "{}}\n")
-	sb.WriteString("\tFillTest" + omv.returnMessage.structName + "(New" + omv.fieldName + "(tv.orig.Get" + omv.originFieldName + "()))")
+	sb.WriteString("\ttv.orig." + of.originFieldName + " = &" + of.originTypePrefix + omv.fieldName + "{" + omv.fieldName + ": &" + omv.originFieldPackageName + "." + omv.fieldName + "{}}\n")
+	sb.WriteString("\tFillTest" + omv.returnMessage.structName + "(New" + omv.fieldName + "(tv.orig.Get" + omv.fieldName + "()))")
 }
 
 func (omv *oneOfMessageValue) generateCopyToValue(of *oneOfField, sb *strings.Builder) {
@@ -759,7 +751,7 @@ func (omv *oneOfMessageValue) generateCopyToValue(of *oneOfField, sb *strings.Bu
 }
 
 func (omv *oneOfMessageValue) generateTypeSwitchCase(of *oneOfField, sb *strings.Builder) {
-	sb.WriteString("\tcase *" + of.originTypePrefix + omv.originFieldName + ":\n")
+	sb.WriteString("\tcase *" + of.originTypePrefix + omv.fieldName + ":\n")
 	sb.WriteString("\t\treturn " + of.typeName + omv.fieldName + "\n")
 }
 
@@ -770,7 +762,6 @@ type optionalPrimitiveValue struct {
 	defaultVal       string
 	testVal          string
 	returnType       string
-	originFieldName  string
 	originTypePrefix string
 }
 
@@ -785,10 +776,8 @@ func (opv *optionalPrimitiveValue) generateAccessors(ms baseStruct, sb *strings.
 			return strings.ToLower(opv.fieldName)
 		case "returnType":
 			return opv.returnType
-		case "originFieldName":
-			return opv.originFieldName
 		case "originStructType":
-			return opv.originTypePrefix + opv.originFieldName
+			return opv.originTypePrefix + opv.fieldName
 		default:
 			panic(name)
 		}
@@ -817,7 +806,7 @@ func (opv *optionalPrimitiveValue) generateAccessorsTest(ms baseStruct, sb *stri
 }
 
 func (opv *optionalPrimitiveValue) generateSetWithTestValue(sb *strings.Builder) {
-	sb.WriteString("\ttv.orig." + opv.originFieldName + "_ = &" + opv.originTypePrefix + opv.originFieldName + "{" + opv.originFieldName + ":" + opv.testVal + "}")
+	sb.WriteString("\ttv.orig." + opv.fieldName + "_ = &" + opv.originTypePrefix + opv.fieldName + "{" + opv.fieldName + ":" + opv.testVal + "}")
 }
 
 func (opv *optionalPrimitiveValue) generateCopyToValue(_ baseStruct, sb *strings.Builder) {

--- a/pdata/internal/cmd/pdatagen/internal/common_structs.go
+++ b/pdata/internal/cmd/pdatagen/internal/common_structs.go
@@ -42,11 +42,10 @@ var scope = &messageValueStruct{
 	fields: []baseField{
 		nameField,
 		&primitiveField{
-			fieldName:       "Version",
-			originFieldName: "Version",
-			returnType:      "string",
-			defaultVal:      `""`,
-			testVal:         `"test_version"`,
+			fieldName:  "Version",
+			returnType: "string",
+			defaultVal: `""`,
+			testVal:    `"test_version"`,
 		},
 		attributes,
 		droppedAttributesCount,
@@ -67,9 +66,8 @@ var attributeKeyValue = &messageValueStruct{
 }
 
 var scopeField = &messageValueField{
-	fieldName:       "Scope",
-	originFieldName: "Scope",
-	returnMessage:   scope,
+	fieldName:     "Scope",
+	returnMessage: scope,
 }
 
 var traceState = &messageValueStruct{
@@ -104,17 +102,15 @@ var endTimeField = &primitiveTypedField{
 }
 
 var attributes = &sliceField{
-	fieldName:       "Attributes",
-	originFieldName: "Attributes",
-	returnSlice:     mapStruct,
+	fieldName:   "Attributes",
+	returnSlice: mapStruct,
 }
 
 var nameField = &primitiveField{
-	fieldName:       "Name",
-	originFieldName: "Name",
-	returnType:      "string",
-	defaultVal:      `""`,
-	testVal:         `"test_name"`,
+	fieldName:  "Name",
+	returnType: "string",
+	defaultVal: `""`,
+	testVal:    `"test_name"`,
 }
 
 var anyValue = &messageValueStruct{
@@ -163,9 +159,8 @@ var spanIDType = &primitiveType{
 }
 
 var schemaURLField = &primitiveField{
-	fieldName:       "SchemaUrl",
-	originFieldName: "SchemaUrl",
-	returnType:      "string",
-	defaultVal:      `""`,
-	testVal:         `"https://opentelemetry.io/schemas/1.5.0"`,
+	fieldName:  "SchemaUrl",
+	returnType: "string",
+	defaultVal: `""`,
+	testVal:    `"https://opentelemetry.io/schemas/1.5.0"`,
 }

--- a/pdata/internal/cmd/pdatagen/internal/log_structs.go
+++ b/pdata/internal/cmd/pdatagen/internal/log_structs.go
@@ -55,9 +55,8 @@ var resourceLogs = &messageValueStruct{
 		resourceField,
 		schemaURLField,
 		&sliceField{
-			fieldName:       "ScopeLogs",
-			originFieldName: "ScopeLogs",
-			returnSlice:     scopeLogsSlice,
+			fieldName:   "ScopeLogs",
+			returnSlice: scopeLogsSlice,
 		},
 	},
 }
@@ -75,9 +74,8 @@ var scopeLogs = &messageValueStruct{
 		scopeField,
 		schemaURLField,
 		&sliceField{
-			fieldName:       "LogRecords",
-			originFieldName: "LogRecords",
-			returnSlice:     logSlice,
+			fieldName:   "LogRecords",
+			returnSlice: logSlice,
 		},
 	},
 }
@@ -105,8 +103,7 @@ var logRecord = &messageValueStruct{
 		traceIDField,
 		spanIDField,
 		&primitiveTypedField{
-			fieldName:       "Flags",
-			originFieldName: "Flags",
+			fieldName: "Flags",
 			returnType: &primitiveType{
 				structName: "LogRecordFlags",
 				rawType:    "uint32",
@@ -115,15 +112,13 @@ var logRecord = &messageValueStruct{
 			},
 		},
 		&primitiveField{
-			fieldName:       "SeverityText",
-			originFieldName: "SeverityText",
-			returnType:      "string",
-			defaultVal:      `""`,
-			testVal:         `"INFO"`,
+			fieldName:  "SeverityText",
+			returnType: "string",
+			defaultVal: `""`,
+			testVal:    `"INFO"`,
 		},
 		&primitiveTypedField{
-			fieldName:       "SeverityNumber",
-			originFieldName: "SeverityNumber",
+			fieldName: "SeverityNumber",
 			returnType: &primitiveType{
 				structName: "SeverityNumber",
 				rawType:    "otlplogs.SeverityNumber",
@@ -138,7 +133,6 @@ var logRecord = &messageValueStruct{
 }
 
 var bodyField = &messageValueField{
-	fieldName:       "Body",
-	originFieldName: "Body",
-	returnMessage:   anyValue,
+	fieldName:     "Body",
+	returnMessage: anyValue,
 }

--- a/pdata/internal/cmd/pdatagen/internal/metrics_structs.go
+++ b/pdata/internal/cmd/pdatagen/internal/metrics_structs.go
@@ -73,9 +73,8 @@ var resourceMetrics = &messageValueStruct{
 		resourceField,
 		schemaURLField,
 		&sliceField{
-			fieldName:       "ScopeMetrics",
-			originFieldName: "ScopeMetrics",
-			returnSlice:     scopeMetricsSlice,
+			fieldName:   "ScopeMetrics",
+			returnSlice: scopeMetricsSlice,
 		},
 	},
 }
@@ -93,9 +92,8 @@ var scopeMetrics = &messageValueStruct{
 		scopeField,
 		schemaURLField,
 		&sliceField{
-			fieldName:       "Metrics",
-			originFieldName: "Metrics",
-			returnSlice:     metricSlice,
+			fieldName:   "Metrics",
+			returnSlice: metricSlice,
 		},
 	},
 }
@@ -113,18 +111,16 @@ var metric = &messageValueStruct{
 	fields: []baseField{
 		nameField,
 		&primitiveField{
-			fieldName:       "Description",
-			originFieldName: "Description",
-			returnType:      "string",
-			defaultVal:      `""`,
-			testVal:         `"test_description"`,
+			fieldName:  "Description",
+			returnType: "string",
+			defaultVal: `""`,
+			testVal:    `"test_description"`,
 		},
 		&primitiveField{
-			fieldName:       "Unit",
-			originFieldName: "Unit",
-			returnType:      "string",
-			defaultVal:      `""`,
-			testVal:         `"1"`,
+			fieldName:  "Unit",
+			returnType: "string",
+			defaultVal: `""`,
+			testVal:    `"1"`,
 		},
 		&oneOfField{
 			typeName:                   "MetricType",
@@ -135,31 +131,26 @@ var metric = &messageValueStruct{
 			values: []oneOfValue{
 				&oneOfMessageValue{
 					fieldName:              "Gauge",
-					originFieldName:        "Gauge",
 					originFieldPackageName: "otlpmetrics",
 					returnMessage:          gauge,
 				},
 				&oneOfMessageValue{
 					fieldName:              "Sum",
-					originFieldName:        "Sum",
 					originFieldPackageName: "otlpmetrics",
 					returnMessage:          sum,
 				},
 				&oneOfMessageValue{
 					fieldName:              "Histogram",
-					originFieldName:        "Histogram",
 					originFieldPackageName: "otlpmetrics",
 					returnMessage:          histogram,
 				},
 				&oneOfMessageValue{
 					fieldName:              "ExponentialHistogram",
-					originFieldName:        "ExponentialHistogram",
 					originFieldPackageName: "otlpmetrics",
 					returnMessage:          exponentialHistogram,
 				},
 				&oneOfMessageValue{
 					fieldName:              "Summary",
-					originFieldName:        "Summary",
 					originFieldPackageName: "otlpmetrics",
 					returnMessage:          summary,
 				},
@@ -174,9 +165,8 @@ var gauge = &messageValueStruct{
 	originFullName: "otlpmetrics.Gauge",
 	fields: []baseField{
 		&sliceField{
-			fieldName:       "DataPoints",
-			originFieldName: "DataPoints",
-			returnSlice:     numberDataPointSlice,
+			fieldName:   "DataPoints",
+			returnSlice: numberDataPointSlice,
 		},
 	},
 }
@@ -189,9 +179,8 @@ var sum = &messageValueStruct{
 		aggregationTemporalityField,
 		isMonotonicField,
 		&sliceField{
-			fieldName:       "DataPoints",
-			originFieldName: "DataPoints",
-			returnSlice:     numberDataPointSlice,
+			fieldName:   "DataPoints",
+			returnSlice: numberDataPointSlice,
 		},
 	},
 }
@@ -203,9 +192,8 @@ var histogram = &messageValueStruct{
 	fields: []baseField{
 		aggregationTemporalityField,
 		&sliceField{
-			fieldName:       "DataPoints",
-			originFieldName: "DataPoints",
-			returnSlice:     histogramDataPointSlice,
+			fieldName:   "DataPoints",
+			returnSlice: histogramDataPointSlice,
 		},
 	},
 }
@@ -218,9 +206,8 @@ var exponentialHistogram = &messageValueStruct{
 	fields: []baseField{
 		aggregationTemporalityField,
 		&sliceField{
-			fieldName:       "DataPoints",
-			originFieldName: "DataPoints",
-			returnSlice:     exponentialHistogramDataPointSlice,
+			fieldName:   "DataPoints",
+			returnSlice: exponentialHistogramDataPointSlice,
 		},
 	},
 }
@@ -231,9 +218,8 @@ var summary = &messageValueStruct{
 	originFullName: "otlpmetrics.Summary",
 	fields: []baseField{
 		&sliceField{
-			fieldName:       "DataPoints",
-			originFieldName: "DataPoints",
-			returnSlice:     summaryDataPointSlice,
+			fieldName:   "DataPoints",
+			returnSlice: summaryDataPointSlice,
 		},
 	},
 }
@@ -299,7 +285,6 @@ var histogramDataPoint = &messageValueStruct{
 		dataPointFlagsField,
 		&optionalPrimitiveValue{
 			fieldName:        "Min",
-			originFieldName:  "Min",
 			originTypePrefix: "otlpmetrics.HistogramDataPoint_",
 			returnType:       "float64",
 			defaultVal:       "float64(0.0)",
@@ -307,7 +292,6 @@ var histogramDataPoint = &messageValueStruct{
 		},
 		&optionalPrimitiveValue{
 			fieldName:        "Max",
-			originFieldName:  "Max",
 			originTypePrefix: "otlpmetrics.HistogramDataPoint_",
 			returnType:       "float64",
 			defaultVal:       "float64(0.0)",
@@ -335,41 +319,35 @@ var exponentialHistogramDataPoint = &messageValueStruct{
 		countField,
 		&optionalPrimitiveValue{
 			fieldName:        "Sum",
-			originFieldName:  "Sum",
 			originTypePrefix: "otlpmetrics.ExponentialHistogramDataPoint_",
 			returnType:       "float64",
 			defaultVal:       "float64(0.0)",
 			testVal:          "float64(17.13)",
 		},
 		&primitiveField{
-			fieldName:       "Scale",
-			originFieldName: "Scale",
-			returnType:      "int32",
-			defaultVal:      "int32(0)",
-			testVal:         "int32(4)",
+			fieldName:  "Scale",
+			returnType: "int32",
+			defaultVal: "int32(0)",
+			testVal:    "int32(4)",
 		},
 		&primitiveField{
-			fieldName:       "ZeroCount",
-			originFieldName: "ZeroCount",
-			returnType:      "uint64",
-			defaultVal:      "uint64(0)",
-			testVal:         "uint64(201)",
+			fieldName:  "ZeroCount",
+			returnType: "uint64",
+			defaultVal: "uint64(0)",
+			testVal:    "uint64(201)",
 		},
 		&messageValueField{
-			fieldName:       "Positive",
-			originFieldName: "Positive",
-			returnMessage:   bucketsValues,
+			fieldName:     "Positive",
+			returnMessage: bucketsValues,
 		},
 		&messageValueField{
-			fieldName:       "Negative",
-			originFieldName: "Negative",
-			returnMessage:   bucketsValues,
+			fieldName:     "Negative",
+			returnMessage: bucketsValues,
 		},
 		exemplarsField,
 		dataPointFlagsField,
 		&optionalPrimitiveValue{
 			fieldName:        "Min",
-			originFieldName:  "Min",
 			originTypePrefix: "otlpmetrics.ExponentialHistogramDataPoint_",
 			returnType:       "float64",
 			defaultVal:       "float64(0.0)",
@@ -377,7 +355,6 @@ var exponentialHistogramDataPoint = &messageValueStruct{
 		},
 		&optionalPrimitiveValue{
 			fieldName:        "Max",
-			originFieldName:  "Max",
 			originTypePrefix: "otlpmetrics.ExponentialHistogramDataPoint_",
 			returnType:       "float64",
 			defaultVal:       "float64(0.0)",
@@ -392,11 +369,10 @@ var bucketsValues = &messageValueStruct{
 	originFullName: "otlpmetrics.ExponentialHistogramDataPoint_Buckets",
 	fields: []baseField{
 		&primitiveField{
-			fieldName:       "Offset",
-			originFieldName: "Offset",
-			returnType:      "int32",
-			defaultVal:      "int32(0)",
-			testVal:         "int32(909)",
+			fieldName:  "Offset",
+			returnType: "int32",
+			defaultVal: "int32(0)",
+			testVal:    "int32(909)",
 		},
 		bucketCountsField,
 	},
@@ -418,9 +394,8 @@ var summaryDataPoint = &messageValueStruct{
 		countField,
 		doubleSumField,
 		&sliceField{
-			fieldName:       "QuantileValues",
-			originFieldName: "QuantileValues",
-			returnSlice:     quantileValuesSlice,
+			fieldName:   "QuantileValues",
+			returnSlice: quantileValuesSlice,
 		},
 		dataPointFlagsField,
 	},
@@ -478,9 +453,8 @@ var exemplar = &messageValueStruct{
 			},
 		},
 		&sliceField{
-			fieldName:       "FilteredAttributes",
-			originFieldName: "FilteredAttributes",
-			returnSlice:     mapStruct,
+			fieldName:   "FilteredAttributes",
+			returnSlice: mapStruct,
 		},
 		traceIDField,
 		spanIDField,
@@ -488,8 +462,7 @@ var exemplar = &messageValueStruct{
 }
 
 var dataPointFlagsField = &primitiveTypedField{
-	fieldName:       "Flags",
-	originFieldName: "Flags",
+	fieldName: "Flags",
 	returnType: &primitiveType{
 		structName: "DataPointFlags",
 		rawType:    "uint32",
@@ -499,38 +472,33 @@ var dataPointFlagsField = &primitiveTypedField{
 }
 
 var exemplarsField = &sliceField{
-	fieldName:       "Exemplars",
-	originFieldName: "Exemplars",
-	returnSlice:     exemplarSlice,
+	fieldName:   "Exemplars",
+	returnSlice: exemplarSlice,
 }
 
 var countField = &primitiveField{
-	fieldName:       "Count",
-	originFieldName: "Count",
-	returnType:      "uint64",
-	defaultVal:      "uint64(0)",
-	testVal:         "uint64(17)",
+	fieldName:  "Count",
+	returnType: "uint64",
+	defaultVal: "uint64(0)",
+	testVal:    "uint64(17)",
 }
 
 var doubleSumField = &primitiveField{
-	fieldName:       "Sum",
-	originFieldName: "Sum",
-	returnType:      "float64",
-	defaultVal:      "float64(0.0)",
-	testVal:         "float64(17.13)",
+	fieldName:  "Sum",
+	returnType: "float64",
+	defaultVal: "float64(0.0)",
+	testVal:    "float64(17.13)",
 }
 
 var valueFloat64Field = &primitiveField{
-	fieldName:       "Value",
-	originFieldName: "Value",
-	returnType:      "float64",
-	defaultVal:      "float64(0.0)",
-	testVal:         "float64(17.13)",
+	fieldName:  "Value",
+	returnType: "float64",
+	defaultVal: "float64(0.0)",
+	testVal:    "float64(17.13)",
 }
 
 var bucketCountsField = &primitiveSliceField{
 	fieldName:         "BucketCounts",
-	originFieldName:   "BucketCounts",
 	returnType:        "UInt64Slice",
 	returnPackageName: "pcommon",
 	defaultVal:        "[]uint64(nil)",
@@ -540,7 +508,6 @@ var bucketCountsField = &primitiveSliceField{
 
 var explicitBoundsField = &primitiveSliceField{
 	fieldName:         "ExplicitBounds",
-	originFieldName:   "ExplicitBounds",
 	returnType:        "Float64Slice",
 	returnPackageName: "pcommon",
 	defaultVal:        "[]float64(nil)",
@@ -549,24 +516,21 @@ var explicitBoundsField = &primitiveSliceField{
 }
 
 var quantileField = &primitiveField{
-	fieldName:       "Quantile",
-	originFieldName: "Quantile",
-	returnType:      "float64",
-	defaultVal:      "float64(0.0)",
-	testVal:         "float64(17.13)",
+	fieldName:  "Quantile",
+	returnType: "float64",
+	defaultVal: "float64(0.0)",
+	testVal:    "float64(17.13)",
 }
 
 var isMonotonicField = &primitiveField{
-	fieldName:       "IsMonotonic",
-	originFieldName: "IsMonotonic",
-	returnType:      "bool",
-	defaultVal:      "false",
-	testVal:         "true",
+	fieldName:  "IsMonotonic",
+	returnType: "bool",
+	defaultVal: "false",
+	testVal:    "true",
 }
 
 var aggregationTemporalityField = &primitiveTypedField{
-	fieldName:       "AggregationTemporality",
-	originFieldName: "AggregationTemporality",
+	fieldName: "AggregationTemporality",
 	returnType: &primitiveType{
 		structName: "AggregationTemporality",
 		rawType:    "otlpmetrics.AggregationTemporality",
@@ -577,7 +541,6 @@ var aggregationTemporalityField = &primitiveTypedField{
 
 var optionalDoubleSumField = &optionalPrimitiveValue{
 	fieldName:        "Sum",
-	originFieldName:  "Sum",
 	originTypePrefix: "otlpmetrics.HistogramDataPoint_",
 	returnType:       "float64",
 	defaultVal:       "float64(0.0)",

--- a/pdata/internal/cmd/pdatagen/internal/resource_structs.go
+++ b/pdata/internal/cmd/pdatagen/internal/resource_structs.go
@@ -44,7 +44,6 @@ var resource = &messageValueStruct{
 }
 
 var resourceField = &messageValueField{
-	fieldName:       "Resource",
-	originFieldName: "Resource",
-	returnMessage:   resource,
+	fieldName:     "Resource",
+	returnMessage: resource,
 }

--- a/pdata/internal/cmd/pdatagen/internal/trace_structs.go
+++ b/pdata/internal/cmd/pdatagen/internal/trace_structs.go
@@ -60,9 +60,8 @@ var resourceSpans = &messageValueStruct{
 		resourceField,
 		schemaURLField,
 		&sliceField{
-			fieldName:       "ScopeSpans",
-			originFieldName: "ScopeSpans",
-			returnSlice:     scopeSpansSlice,
+			fieldName:   "ScopeSpans",
+			returnSlice: scopeSpansSlice,
 		},
 	},
 }
@@ -80,9 +79,8 @@ var scopeSpans = &messageValueStruct{
 		scopeField,
 		schemaURLField,
 		&sliceField{
-			fieldName:       "Spans",
-			originFieldName: "Spans",
-			returnSlice:     spanSlice,
+			fieldName:   "Spans",
+			returnSlice: spanSlice,
 		},
 	},
 }
@@ -104,8 +102,7 @@ var span = &messageValueStruct{
 		parentSpanIDField,
 		nameField,
 		&primitiveTypedField{
-			fieldName:       "Kind",
-			originFieldName: "Kind",
+			fieldName: "Kind",
 			returnType: &primitiveType{
 				structName: "SpanKind",
 				rawType:    "otlptrace.Span_SpanKind",
@@ -118,33 +115,28 @@ var span = &messageValueStruct{
 		attributes,
 		droppedAttributesCount,
 		&sliceField{
-			fieldName:       "Events",
-			originFieldName: "Events",
-			returnSlice:     spanEventSlice,
+			fieldName:   "Events",
+			returnSlice: spanEventSlice,
 		},
 		&primitiveField{
-			fieldName:       "DroppedEventsCount",
-			originFieldName: "DroppedEventsCount",
-			returnType:      "uint32",
-			defaultVal:      "uint32(0)",
-			testVal:         "uint32(17)",
+			fieldName:  "DroppedEventsCount",
+			returnType: "uint32",
+			defaultVal: "uint32(0)",
+			testVal:    "uint32(17)",
 		},
 		&sliceField{
-			fieldName:       "Links",
-			originFieldName: "Links",
-			returnSlice:     spanLinkSlice,
+			fieldName:   "Links",
+			returnSlice: spanLinkSlice,
 		},
 		&primitiveField{
-			fieldName:       "DroppedLinksCount",
-			originFieldName: "DroppedLinksCount",
-			returnType:      "uint32",
-			defaultVal:      "uint32(0)",
-			testVal:         "uint32(17)",
+			fieldName:  "DroppedLinksCount",
+			returnType: "uint32",
+			defaultVal: "uint32(0)",
+			testVal:    "uint32(17)",
 		},
 		&messageValueField{
-			fieldName:       "Status",
-			originFieldName: "Status",
-			returnMessage:   spanStatus,
+			fieldName:     "Status",
+			returnMessage: spanStatus,
 		},
 	},
 }
@@ -194,8 +186,7 @@ var spanStatus = &messageValueStruct{
 	originFullName: "otlptrace.Status",
 	fields: []baseField{
 		&primitiveTypedField{
-			fieldName:       "Code",
-			originFieldName: "Code",
+			fieldName: "Code",
 			returnType: &primitiveType{
 				structName: "StatusCode",
 				rawType:    "otlptrace.Status_StatusCode",
@@ -204,25 +195,22 @@ var spanStatus = &messageValueStruct{
 			},
 		},
 		&primitiveField{
-			fieldName:       "Message",
-			originFieldName: "Message",
-			returnType:      "string",
-			defaultVal:      `""`,
-			testVal:         `"cancelled"`,
+			fieldName:  "Message",
+			returnType: "string",
+			defaultVal: `""`,
+			testVal:    `"cancelled"`,
 		},
 	},
 }
 
 var traceStateField = &messageValueField{
-	fieldName:       "TraceState",
-	originFieldName: "TraceState",
-	returnMessage:   traceState,
+	fieldName:     "TraceState",
+	returnMessage: traceState,
 }
 
 var droppedAttributesCount = &primitiveField{
-	fieldName:       "DroppedAttributesCount",
-	originFieldName: "DroppedAttributesCount",
-	returnType:      "uint32",
-	defaultVal:      "uint32(0)",
-	testVal:         "uint32(17)",
+	fieldName:  "DroppedAttributesCount",
+	returnType: "uint32",
+	defaultVal: "uint32(0)",
+	testVal:    "uint32(17)",
 }


### PR DESCRIPTION
Given the documented naming recommendations for pdata in https://github.com/open-telemetry/opentelemetry-collector/pull/6255, simplify pdatagen to encourage the same naming between pdata and proto fields.
