### PR TITLE
Add a flag for enabling config watch

### DIFF
--- a/.chloggen/config-hot-reloading.yaml
+++ b/.chloggen/config-hot-reloading.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: service/collector
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add a flag enabling configuration watch
+
+# One or more tracking issues or pull requests related to the change
+issues: [5966]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/otelcol/command.go
+++ b/otelcol/command.go
@@ -55,8 +55,11 @@ func newCollectorWithFlags(set CollectorSettings, flags *flag.FlagSet) (*Collect
 			return nil, errors.New("at least one config flag must be provided")
 		}
 
+		providerSettings := newDefaultConfigProviderSettings(configFlags)
+		providerSettings.ResolverSettings.EnableConfigWatch = getWatchConfigFlag(flags)
+
 		var err error
-		set.ConfigProvider, err = NewConfigProvider(newDefaultConfigProviderSettings(configFlags))
+		set.ConfigProvider, err = NewConfigProvider(providerSettings)
 		if err != nil {
 			return nil, err
 		}

--- a/otelcol/command_test.go
+++ b/otelcol/command_test.go
@@ -15,6 +15,7 @@
 package otelcol
 
 import (
+	"fmt"
 	"path/filepath"
 	"testing"
 
@@ -56,4 +57,22 @@ func TestNewCommandInvalidComponent(t *testing.T) {
 
 	cmd := NewCommand(CollectorSettings{Factories: factories, ConfigProvider: cfgProvider})
 	require.Error(t, cmd.Execute())
+}
+
+// simple sanity check to verify that it succeeds with a basic default config
+func TestNewCollectorWithFlags(t *testing.T) {
+	factories, err := nopFactories()
+	require.NoError(t, err)
+
+	cmdLineArgs := []string{fmt.Sprintf("--%s=%s", configFlag, "someconfig.yaml")}
+	flgs := flags()
+	err = flgs.Parse(cmdLineArgs)
+	require.NoError(t, err)
+	set := CollectorSettings{
+		BuildInfo: component.BuildInfo{Version: "test_version"},
+		Factories: factories,
+	}
+
+	_, err = newCollectorWithFlags(set, flgs)
+	require.NoError(t, err)
 }

--- a/otelcol/flags.go
+++ b/otelcol/flags.go
@@ -25,6 +25,7 @@ import (
 const (
 	configFlag       = "config"
 	featureGatesFlag = "feature-gates"
+	watchConfigFlag  = "watch-config"
 )
 
 type configFlagValue struct {
@@ -64,6 +65,13 @@ func flags() *flag.FlagSet {
 	flagSet.Var(featuregate.FlagValue{}, featureGatesFlag,
 		"Comma-delimited list of feature gate identifiers. Prefix with '-' to disable the feature. '+' or no prefix will enable the feature.")
 
+	flagSet.BoolVar(
+		new(bool),
+		watchConfigFlag,
+		false,
+		"Enable config watch for configuration sources.",
+	)
+
 	return flagSet
 }
 
@@ -74,4 +82,8 @@ func getConfigFlag(flagSet *flag.FlagSet) []string {
 
 func getFeatureGatesFlag(flagSet *flag.FlagSet) featuregate.FlagValue {
 	return flagSet.Lookup(featureGatesFlag).Value.(featuregate.FlagValue)
+}
+
+func getWatchConfigFlag(flagSet *flag.FlagSet) bool {
+	return flagSet.Lookup(watchConfigFlag).Value.(flag.Getter).Get().(bool)
 }

--- a/otelcol/flags_test.go
+++ b/otelcol/flags_test.go
@@ -78,3 +78,46 @@ func TestSetFlag(t *testing.T) {
 		})
 	}
 }
+
+func TestConfigFlag(t *testing.T) {
+	tests := []struct {
+		name          string
+		args          []string
+		expectedValue bool
+		expectedErr   string
+	}{
+		{
+			name:          "flag set",
+			args:          []string{"--watch-config"},
+			expectedValue: true,
+		},
+		{
+			name:          "flag set by value",
+			args:          []string{"--watch-config=true"},
+			expectedValue: true,
+		},
+		{
+			name:          "flag not set",
+			args:          []string{},
+			expectedValue: false,
+		},
+		{
+			name:        "invalid value",
+			args:        []string{"--watch-config=somevalue"},
+			expectedErr: `invalid boolean value "somevalue" for -watch-config: parse error`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			flgs := flags()
+			err := flgs.Parse(tt.args)
+			if tt.expectedErr != "" {
+				assert.EqualError(t, err, tt.expectedErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedValue, getWatchConfigFlag(flgs))
+		})
+	}
+}


### PR DESCRIPTION
**Description:**
Add a flag to control configuration watching. 

Technically this is a breaking change, as the flag defaults to false, and this is currently unconditionally enabled. In practice, none of the currently available config sources implement notifications, so users shouldn't see any difference unless they're using a distribution which specifically added such a config source. This being disabled by default will also allow changes like #5945 to be merged without affecting users unless they opt-in to the behaviour.

I'm open to suggestions for the flag name.

**Link to tracking Issue:** #5966 

**Testing:**
Added a unit test for the default (disabled), and updated the one checking for the other case.

**Documentation:** 
Do I need to update this in https://github.com/open-telemetry/opentelemetry.io?
