### PR TITLE
[confmap] Fail fast on unsupported scheme

### DIFF
--- a/.chloggen/mx-psi_confmap-provider.yaml
+++ b/.chloggen/mx-psi_confmap-provider.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: confmap
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fail fast when a resolver has URIs with unsupported schemes.
+
+# One or more tracking issues or pull requests related to the change
+issues: [6274]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/confmap/resolver.go
+++ b/confmap/resolver.go
@@ -118,6 +118,9 @@ func NewResolver(set ResolverSettings) (*Resolver, error) {
 		if err != nil {
 			return nil, err
 		}
+		if _, ok := set.Providers[lURI.scheme]; !ok {
+			return nil, fmt.Errorf("unsupported scheme on URI %q", uri)
+		}
 		uris[i] = lURI
 	}
 	providersCopy := make(map[string]Provider, len(set.Providers))

--- a/confmap/resolver_test.go
+++ b/confmap/resolver_test.go
@@ -106,16 +106,17 @@ func TestResolverErrors(t *testing.T) {
 		locations         []string
 		providers         []Provider
 		converters        []Converter
+		expectBuildErr    bool
 		expectResolveErr  bool
 		expectWatchErr    bool
 		expectCloseErr    bool
 		expectShutdownErr bool
 	}{
 		{
-			name:             "unsupported location scheme",
-			locations:        []string{"mock:", "notsupported:"},
-			providers:        []Provider{&mockProvider{}},
-			expectResolveErr: true,
+			name:           "unsupported location scheme",
+			locations:      []string{"mock:", "notsupported:"},
+			providers:      []Provider{&mockProvider{}},
+			expectBuildErr: true,
 		},
 		{
 			name:      "retrieve location config error",
@@ -173,7 +174,11 @@ func TestResolverErrors(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			resolver, err := NewResolver(ResolverSettings{URIs: tt.locations, Providers: makeMapProvidersMap(tt.providers...), Converters: tt.converters})
-			assert.NoError(t, err)
+			if tt.expectBuildErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
 
 			_, errN := resolver.Resolve(context.Background())
 			if tt.expectResolveErr {
@@ -208,9 +213,10 @@ func TestResolverErrors(t *testing.T) {
 
 func TestBackwardsCompatibilityForFilePath(t *testing.T) {
 	tests := []struct {
-		name       string
-		location   string
-		errMessage string
+		name           string
+		location       string
+		errMessage     string
+		expectBuildErr bool
 	}{
 		{
 			name:       "unix",
@@ -238,21 +244,27 @@ func TestBackwardsCompatibilityForFilePath(t *testing.T) {
 			errMessage: `file:C:\test`,
 		},
 		{
-			name:       "invalid_scheme",
-			location:   `LL:\test`,
-			errMessage: `scheme "LL" is not supported for uri "LL:\\test"`,
+			name:           "invalid_scheme",
+			location:       `LL:\test`,
+			expectBuildErr: true,
 		},
 	}
 	for _, tt := range tests {
-		resolver, err := NewResolver(ResolverSettings{
-			URIs: []string{tt.location},
-			Providers: makeMapProvidersMap(newFakeProvider("file", func(_ context.Context, uri string, _ WatcherFunc) (*Retrieved, error) {
-				return nil, errors.New(uri)
-			})),
-			Converters: nil})
-		assert.NoError(t, err)
-		_, err = resolver.Resolve(context.Background())
-		assert.Contains(t, err.Error(), tt.errMessage, tt.name)
+		t.Run(tt.name, func(t *testing.T) {
+			resolver, err := NewResolver(ResolverSettings{
+				URIs: []string{tt.location},
+				Providers: makeMapProvidersMap(newFakeProvider("file", func(_ context.Context, uri string, _ WatcherFunc) (*Retrieved, error) {
+					return nil, errors.New(uri)
+				})),
+				Converters: nil})
+			if tt.expectBuildErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			_, err = resolver.Resolve(context.Background())
+			assert.Contains(t, err.Error(), tt.errMessage, tt.name)
+		})
 	}
 }
 


### PR DESCRIPTION
**Description:** 

Make `confmap.NewResolver` (and therefore `service.NewConfigProvider`) fail fast if there is an URI with an unsupported scheme.

**Link to tracking Issue:** Fixes #6274
