### PR TITLE
JSON marshaler emits enums as ints per spec reuqirements.

### DIFF
--- a/.chloggen/enumsasints.yaml
+++ b/.chloggen/enumsasints.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: pdata
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: JSON marshaler emits enums as ints per spec reuqirements. This may be a breaking change if receivers were not confirming with the spec.
+
+# One or more tracking issues or pull requests related to the change
+issues: [6338]

--- a/pdata/plog/json.go
+++ b/pdata/plog/json.go
@@ -26,7 +26,9 @@ import (
 
 // NewJSONMarshaler returns a Marshaler. Marshals to OTLP json bytes.
 func NewJSONMarshaler() Marshaler {
-	return &jsonMarshaler{delegate: jsonpb.Marshaler{}}
+	return &jsonMarshaler{delegate: jsonpb.Marshaler{
+		EnumsAsInts: true,
+	}}
 }
 
 type jsonMarshaler struct {

--- a/pdata/pmetric/json.go
+++ b/pdata/pmetric/json.go
@@ -26,7 +26,9 @@ import (
 
 // NewJSONMarshaler returns a model.Marshaler. Marshals to OTLP json bytes.
 func NewJSONMarshaler() Marshaler {
-	return &jsonMarshaler{delegate: jsonpb.Marshaler{}}
+	return &jsonMarshaler{delegate: jsonpb.Marshaler{
+		EnumsAsInts: true,
+	}}
 }
 
 type jsonMarshaler struct {

--- a/pdata/ptrace/json.go
+++ b/pdata/ptrace/json.go
@@ -26,7 +26,9 @@ import (
 
 // NewJSONMarshaler returns a model.Marshaler. Marshals to OTLP json bytes.
 func NewJSONMarshaler() Marshaler {
-	return &jsonMarshaler{delegate: jsonpb.Marshaler{}}
+	return &jsonMarshaler{delegate: jsonpb.Marshaler{
+		EnumsAsInts: true,
+	}}
 }
 
 type jsonMarshaler struct {


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-collector/issues/6338
