### PR TITLE
Deprecate New[JSON|Proto][Marshaler|Unmarshale], expose the structs

### DIFF
--- a/.chloggen/structs.yaml
+++ b/.chloggen/structs.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: pdata
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Deprecate `New[JSON|Proto][Marshaler|Unmarshale]` in favor of exposing the underlying structs"
+
+# One or more tracking issues or pull requests related to the change
+issues: [6340]

--- a/config/configgrpc/configgrpc_benchmark_test.go
+++ b/config/configgrpc/configgrpc_benchmark_test.go
@@ -134,7 +134,7 @@ func setupTestPayloads() []testPayload {
 	payloads := make([]testPayload, 0)
 
 	// log payloads
-	logMarshaler := &logMarshaler{plog.NewProtoMarshaler()}
+	logMarshaler := &logMarshaler{Marshaler: &plog.ProtoMarshaler{}}
 	payloads = append(payloads, testPayload{
 		name:      "sm_log_request",
 		message:   testdata.GenerateLogs(1),
@@ -149,7 +149,7 @@ func setupTestPayloads() []testPayload {
 		marshaler: logMarshaler})
 
 	// trace payloads
-	tracesMarshaler := &traceMarshaler{ptrace.NewProtoMarshaler()}
+	tracesMarshaler := &traceMarshaler{Marshaler: &ptrace.ProtoMarshaler{}}
 	payloads = append(payloads, testPayload{
 		name:      "sm_trace_request",
 		message:   testdata.GenerateTraces(1),
@@ -164,7 +164,7 @@ func setupTestPayloads() []testPayload {
 		marshaler: tracesMarshaler})
 
 	// metric payloads
-	metricsMarshaler := &metricsMarshaler{pmetric.NewProtoMarshaler()}
+	metricsMarshaler := &metricsMarshaler{Marshaler: &pmetric.ProtoMarshaler{}}
 	payloads = append(payloads, testPayload{
 		name:      "sm_metric_request",
 		message:   testdata.GenerateMetrics(1),

--- a/exporter/exporterhelper/internal/persistent_storage_test.go
+++ b/exporter/exporterhelper/internal/persistent_storage_test.go
@@ -67,7 +67,8 @@ func newFakeTracesRequest(td ptrace.Traces) *fakeTracesRequest {
 }
 
 func (fd *fakeTracesRequest) Marshal() ([]byte, error) {
-	return ptrace.NewProtoMarshaler().MarshalTraces(fd.td)
+	marshaler := &ptrace.ProtoMarshaler{}
+	return marshaler.MarshalTraces(fd.td)
 }
 
 func (fd *fakeTracesRequest) OnProcessingFinished() {
@@ -82,7 +83,8 @@ func (fd *fakeTracesRequest) SetOnProcessingFinished(callback func()) {
 
 func newFakeTracesRequestUnmarshalerFunc() RequestUnmarshaler {
 	return func(bytes []byte) (Request, error) {
-		traces, err := ptrace.NewProtoUnmarshaler().UnmarshalTraces(bytes)
+		unmarshaler := ptrace.ProtoUnmarshaler{}
+		traces, err := unmarshaler.UnmarshalTraces(bytes)
 		if err != nil {
 			return nil, err
 		}

--- a/exporter/exporterhelper/logs.go
+++ b/exporter/exporterhelper/logs.go
@@ -26,8 +26,8 @@ import (
 	"go.opentelemetry.io/collector/pdata/plog"
 )
 
-var logsMarshaler = plog.NewProtoMarshaler()
-var logsUnmarshaler = plog.NewProtoUnmarshaler()
+var logsMarshaler = &plog.ProtoMarshaler{}
+var logsUnmarshaler = &plog.ProtoUnmarshaler{}
 
 type logsRequest struct {
 	baseRequest

--- a/exporter/exporterhelper/metrics.go
+++ b/exporter/exporterhelper/metrics.go
@@ -26,8 +26,8 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric"
 )
 
-var metricsMarshaler = pmetric.NewProtoMarshaler()
-var metricsUnmarshaler = pmetric.NewProtoUnmarshaler()
+var metricsMarshaler = &pmetric.ProtoMarshaler{}
+var metricsUnmarshaler = &pmetric.ProtoUnmarshaler{}
 
 type metricsRequest struct {
 	baseRequest

--- a/exporter/exporterhelper/queued_retry_test.go
+++ b/exporter/exporterhelper/queued_retry_test.go
@@ -611,7 +611,8 @@ func (m *mockRequest) Export(ctx context.Context) error {
 }
 
 func (m *mockRequest) Marshal() ([]byte, error) {
-	return ptrace.NewProtoMarshaler().MarshalTraces(ptrace.NewTraces())
+	marshaler := &ptrace.ProtoMarshaler{}
+	return marshaler.MarshalTraces(ptrace.NewTraces())
 }
 
 func (m *mockRequest) OnError(error) internal.Request {

--- a/exporter/exporterhelper/traces.go
+++ b/exporter/exporterhelper/traces.go
@@ -26,8 +26,8 @@ import (
 	"go.opentelemetry.io/collector/pdata/ptrace"
 )
 
-var tracesMarshaler = ptrace.NewProtoMarshaler()
-var tracesUnmarshaler = ptrace.NewProtoUnmarshaler()
+var tracesMarshaler = &ptrace.ProtoMarshaler{}
+var tracesUnmarshaler = &ptrace.ProtoUnmarshaler{}
 
 type tracesRequest struct {
 	baseRequest

--- a/pdata/plog/json.go
+++ b/pdata/plog/json.go
@@ -24,32 +24,36 @@ import (
 	"go.opentelemetry.io/collector/pdata/plog/internal/plogjson"
 )
 
-// NewJSONMarshaler returns a Marshaler. Marshals to OTLP json bytes.
+var delegate = &jsonpb.Marshaler{
+	EnumsAsInts: true,
+}
+
+// Deprecated: [v0.63.0] use &JSONMarshaler{}
 func NewJSONMarshaler() Marshaler {
-	return &jsonMarshaler{delegate: jsonpb.Marshaler{
-		EnumsAsInts: true,
-	}}
+	return &JSONMarshaler{}
 }
 
-type jsonMarshaler struct {
-	delegate jsonpb.Marshaler
-}
+var _ Marshaler = (*JSONMarshaler)(nil)
 
-func (e *jsonMarshaler) MarshalLogs(ld Logs) ([]byte, error) {
+type JSONMarshaler struct{}
+
+func (*JSONMarshaler) MarshalLogs(ld Logs) ([]byte, error) {
 	buf := bytes.Buffer{}
 	pb := internal.LogsToProto(internal.Logs(ld))
-	err := e.delegate.Marshal(&buf, &pb)
+	err := delegate.Marshal(&buf, &pb)
 	return buf.Bytes(), err
 }
 
-type jsonUnmarshaler struct{}
+var _ Unmarshaler = (*JSONUnmarshaler)(nil)
 
-// NewJSONUnmarshaler returns a model.Unmarshaler. Unmarshals from OTLP json bytes.
+type JSONUnmarshaler struct{}
+
+// Deprecated: [v0.63.0] use &JSONUnmarshaler{}
 func NewJSONUnmarshaler() Unmarshaler {
-	return &jsonUnmarshaler{}
+	return &JSONUnmarshaler{}
 }
 
-func (jsonUnmarshaler) UnmarshalLogs(buf []byte) (Logs, error) {
+func (*JSONUnmarshaler) UnmarshalLogs(buf []byte) (Logs, error) {
 	var ld otlplogs.LogsData
 	if err := plogjson.UnmarshalLogsData(buf, &ld); err != nil {
 		return Logs{}, err

--- a/pdata/plog/pb.go
+++ b/pdata/plog/pb.go
@@ -19,42 +19,35 @@ import (
 	otlplogs "go.opentelemetry.io/collector/pdata/internal/data/protogen/logs/v1"
 )
 
-// NewProtoMarshaler returns a MarshalSizer.
-// Marshals to OTLP binary protobuf bytes and calculates the size of the marshaled Logs.
+// Deprecated: [v0.63.0] use &ProtoMarshaler{}
 func NewProtoMarshaler() MarshalSizer {
-	return newPbMarshaler()
+	return &ProtoMarshaler{}
 }
 
-type pbMarshaler struct{}
+var _ MarshalSizer = (*ProtoMarshaler)(nil)
 
-func newPbMarshaler() *pbMarshaler {
-	return &pbMarshaler{}
-}
+type ProtoMarshaler struct{}
 
-var _ Sizer = (*pbMarshaler)(nil)
-
-func (e *pbMarshaler) MarshalLogs(ld Logs) ([]byte, error) {
+func (e *ProtoMarshaler) MarshalLogs(ld Logs) ([]byte, error) {
 	pb := internal.LogsToProto(internal.Logs(ld))
 	return pb.Marshal()
 }
 
-func (e *pbMarshaler) LogsSize(ld Logs) int {
+func (e *ProtoMarshaler) LogsSize(ld Logs) int {
 	pb := internal.LogsToProto(internal.Logs(ld))
 	return pb.Size()
 }
 
-type pbUnmarshaler struct{}
+var _ Unmarshaler = (*ProtoUnmarshaler)(nil)
 
-// NewProtoUnmarshaler returns a model.Unmarshaler. Unmarshals from OTLP binary protobuf bytes.
+type ProtoUnmarshaler struct{}
+
+// Deprecated: [v0.63.0] use &ProtoUnmarshaler{}
 func NewProtoUnmarshaler() Unmarshaler {
-	return newPbUnmarshaler()
+	return &ProtoUnmarshaler{}
 }
 
-func newPbUnmarshaler() *pbUnmarshaler {
-	return &pbUnmarshaler{}
-}
-
-func (d *pbUnmarshaler) UnmarshalLogs(buf []byte) (Logs, error) {
+func (d *ProtoUnmarshaler) UnmarshalLogs(buf []byte) (Logs, error) {
 	pb := otlplogs.LogsData{}
 	err := pb.Unmarshal(buf)
 	return Logs(internal.LogsFromProto(pb)), err

--- a/pdata/plog/pb_test.go
+++ b/pdata/plog/pb_test.go
@@ -24,14 +24,14 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 )
 
-func TestProtoLogsUnmarshaler_error(t *testing.T) {
-	p := NewProtoUnmarshaler()
+func TestProtoLogsUnmarshalerError(t *testing.T) {
+	p := &ProtoUnmarshaler{}
 	_, err := p.UnmarshalLogs([]byte("+$%"))
 	assert.Error(t, err)
 }
 
 func TestProtoSizer(t *testing.T) {
-	marshaler := NewProtoMarshaler()
+	marshaler := &ProtoMarshaler{}
 	ld := NewLogs()
 	ld.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords().AppendEmpty().SetSeverityText("error")
 
@@ -43,14 +43,13 @@ func TestProtoSizer(t *testing.T) {
 
 }
 
-func TestProtoSizer_withNil(t *testing.T) {
-	sizer := NewProtoMarshaler().(Sizer)
-
+func TestProtoSizerEmptyLogs(t *testing.T) {
+	sizer := &ProtoMarshaler{}
 	assert.Equal(t, 0, sizer.LogsSize(NewLogs()))
 }
 
 func BenchmarkLogsToProto(b *testing.B) {
-	marshaler := NewProtoMarshaler()
+	marshaler := &ProtoMarshaler{}
 	logs := generateBenchmarkLogs(128)
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
@@ -61,8 +60,8 @@ func BenchmarkLogsToProto(b *testing.B) {
 }
 
 func BenchmarkLogsFromProto(b *testing.B) {
-	marshaler := NewProtoMarshaler()
-	unmarshaler := NewProtoUnmarshaler()
+	marshaler := &ProtoMarshaler{}
+	unmarshaler := &ProtoUnmarshaler{}
 	baseLogs := generateBenchmarkLogs(128)
 	buf, err := marshaler.MarshalLogs(baseLogs)
 	require.NoError(b, err)

--- a/pdata/pmetric/json.go
+++ b/pdata/pmetric/json.go
@@ -24,32 +24,34 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric/internal/pmetricjson"
 )
 
-// NewJSONMarshaler returns a model.Marshaler. Marshals to OTLP json bytes.
+var delegate = &jsonpb.Marshaler{
+	EnumsAsInts: true,
+}
+
+// Deprecated: [v0.63.0] use &JSONMarshaler{}
 func NewJSONMarshaler() Marshaler {
-	return &jsonMarshaler{delegate: jsonpb.Marshaler{
-		EnumsAsInts: true,
-	}}
+	return &JSONMarshaler{}
 }
 
-type jsonMarshaler struct {
-	delegate jsonpb.Marshaler
-}
+var _ Marshaler = (*JSONMarshaler)(nil)
 
-func (e *jsonMarshaler) MarshalMetrics(md Metrics) ([]byte, error) {
+type JSONMarshaler struct{}
+
+func (*JSONMarshaler) MarshalMetrics(md Metrics) ([]byte, error) {
 	buf := bytes.Buffer{}
 	pb := internal.MetricsToProto(internal.Metrics(md))
-	err := e.delegate.Marshal(&buf, &pb)
+	err := delegate.Marshal(&buf, &pb)
 	return buf.Bytes(), err
 }
 
-type jsonUnmarshaler struct{}
+type JSONUnmarshaler struct{}
 
-// NewJSONUnmarshaler returns a model.Unmarshaler. Unmarshals from OTLP json bytes.
+// Deprecated: [v0.63.0] use &JSONUnmarshaler{}
 func NewJSONUnmarshaler() Unmarshaler {
-	return &jsonUnmarshaler{}
+	return &JSONUnmarshaler{}
 }
 
-func (jsonUnmarshaler) UnmarshalMetrics(buf []byte) (Metrics, error) {
+func (*JSONUnmarshaler) UnmarshalMetrics(buf []byte) (Metrics, error) {
 	var md otlpmetrics.MetricsData
 	if err := pmetricjson.UnmarshalMetricsData(buf, &md); err != nil {
 		return Metrics{}, err

--- a/pdata/pmetric/json_test.go
+++ b/pdata/pmetric/json_test.go
@@ -38,11 +38,11 @@ var metricsOTLP = func() Metrics {
 var metricsJSON = `{"resourceMetrics":[{"resource":{"attributes":[{"key":"host.name","value":{"stringValue":"testHost"}}]},"scopeMetrics":[{"scope":{"name":"name","version":"version"},"metrics":[{"name":"testMetric"}]}]}]}`
 
 func TestMetricsJSON(t *testing.T) {
-	encoder := NewJSONMarshaler()
+	encoder := &JSONMarshaler{}
 	jsonBuf, err := encoder.MarshalMetrics(metricsOTLP)
 	assert.NoError(t, err)
 
-	decoder := NewJSONUnmarshaler()
+	decoder := &JSONUnmarshaler{}
 	var got interface{}
 	got, err = decoder.UnmarshalMetrics(jsonBuf)
 	assert.NoError(t, err)
@@ -51,7 +51,7 @@ func TestMetricsJSON(t *testing.T) {
 }
 
 func TestMetricsJSON_Marshal(t *testing.T) {
-	encoder := NewJSONMarshaler()
+	encoder := &JSONMarshaler{}
 	jsonBuf, err := encoder.MarshalMetrics(metricsOTLP)
 	assert.NoError(t, err)
 	assert.Equal(t, metricsJSON, string(jsonBuf))
@@ -306,21 +306,25 @@ func Test_jsonUnmarshaler_UnmarshalMetrics(t *testing.T) {
 			},
 		},
 	}
+	oldDelegate := delegate
+	t.Cleanup(func() {
+		delegate = oldDelegate
+	})
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			for _, opEnumsAsInts := range []bool{true, false} {
 				for _, opEmitDefaults := range []bool{true, false} {
 					for _, opOrigName := range []bool{true, false} {
-						marshaller := &jsonMarshaler{
-							delegate: jsonpb.Marshaler{
-								EnumsAsInts:  opEnumsAsInts,
-								EmitDefaults: opEmitDefaults,
-								OrigName:     opOrigName,
-							}}
+						delegate = &jsonpb.Marshaler{
+							EnumsAsInts:  opEnumsAsInts,
+							EmitDefaults: opEmitDefaults,
+							OrigName:     opOrigName,
+						}
+						encoder := &JSONMarshaler{}
 						m := tt.args.md()
-						jsonBuf, err := marshaller.MarshalMetrics(m)
+						jsonBuf, err := encoder.MarshalMetrics(m)
 						assert.NoError(t, err)
-						decoder := NewJSONUnmarshaler()
+						decoder := JSONUnmarshaler{}
 						got, err := decoder.UnmarshalMetrics(jsonBuf)
 						assert.NoError(t, err)
 						assert.EqualValues(t, m, got)

--- a/pdata/pmetric/pb.go
+++ b/pdata/pmetric/pb.go
@@ -19,42 +19,33 @@ import (
 	otlpmetrics "go.opentelemetry.io/collector/pdata/internal/data/protogen/metrics/v1"
 )
 
-// NewProtoMarshaler returns a MarshalSizer.
-// Marshals to OTLP binary protobuf bytes and calculates the size of the marshaled Metrics.
+// Deprecated: [v0.63.0] use &ProtoMarshaler{}
 func NewProtoMarshaler() MarshalSizer {
-	return newPbMarshaler()
+	return &ProtoMarshaler{}
 }
 
-type pbMarshaler struct{}
+var _ MarshalSizer = (*ProtoMarshaler)(nil)
 
-func newPbMarshaler() *pbMarshaler {
-	return &pbMarshaler{}
-}
+type ProtoMarshaler struct{}
 
-var _ Sizer = (*pbMarshaler)(nil)
-
-func (e *pbMarshaler) MarshalMetrics(md Metrics) ([]byte, error) {
+func (e *ProtoMarshaler) MarshalMetrics(md Metrics) ([]byte, error) {
 	pb := internal.MetricsToProto(internal.Metrics(md))
 	return pb.Marshal()
 }
 
-func (e *pbMarshaler) MetricsSize(md Metrics) int {
+func (e *ProtoMarshaler) MetricsSize(md Metrics) int {
 	pb := internal.MetricsToProto(internal.Metrics(md))
 	return pb.Size()
 }
 
-type pbUnmarshaler struct{}
+type ProtoUnmarshaler struct{}
 
-// NewProtoUnmarshaler returns a model.Unmarshaler. Unmarshals from OTLP binary protobuf bytes.
+// Deprecated: [v0.63.0] use &ProtoUnmarshaler{}
 func NewProtoUnmarshaler() Unmarshaler {
-	return newPbUnmarshaler()
+	return &ProtoUnmarshaler{}
 }
 
-func newPbUnmarshaler() *pbUnmarshaler {
-	return &pbUnmarshaler{}
-}
-
-func (d *pbUnmarshaler) UnmarshalMetrics(buf []byte) (Metrics, error) {
+func (d *ProtoUnmarshaler) UnmarshalMetrics(buf []byte) (Metrics, error) {
 	pb := otlpmetrics.MetricsData{}
 	err := pb.Unmarshal(buf)
 	return Metrics(internal.MetricsFromProto(pb)), err

--- a/pdata/pmetric/pb_test.go
+++ b/pdata/pmetric/pb_test.go
@@ -24,14 +24,14 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 )
 
-func TestProtoMetricsUnmarshaler_error(t *testing.T) {
-	p := NewProtoUnmarshaler()
+func TestProtoMetricsUnmarshalerError(t *testing.T) {
+	p := &ProtoUnmarshaler{}
 	_, err := p.UnmarshalMetrics([]byte("+$%"))
 	assert.Error(t, err)
 }
 
 func TestProtoSizer(t *testing.T) {
-	marshaler := NewProtoMarshaler()
+	marshaler := &ProtoMarshaler{}
 	md := NewMetrics()
 	md.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty().SetName("foo")
 
@@ -42,14 +42,13 @@ func TestProtoSizer(t *testing.T) {
 	assert.Equal(t, len(bytes), size)
 }
 
-func TestProtoSizer_withNil(t *testing.T) {
-	sizer := NewProtoMarshaler().(Sizer)
-
+func TestProtoSizerEmptyMetrics(t *testing.T) {
+	sizer := &ProtoMarshaler{}
 	assert.Equal(t, 0, sizer.MetricsSize(NewMetrics()))
 }
 
 func BenchmarkMetricsToProto(b *testing.B) {
-	marshaler := NewProtoMarshaler()
+	marshaler := &ProtoMarshaler{}
 	metrics := generateBenchmarkMetrics(128)
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
@@ -60,8 +59,8 @@ func BenchmarkMetricsToProto(b *testing.B) {
 }
 
 func BenchmarkMetricsFromProto(b *testing.B) {
-	marshaler := NewProtoMarshaler()
-	unmarshaler := NewProtoUnmarshaler()
+	marshaler := &ProtoMarshaler{}
+	unmarshaler := &ProtoUnmarshaler{}
 	baseMetrics := generateBenchmarkMetrics(128)
 	buf, err := marshaler.MarshalMetrics(baseMetrics)
 	require.NoError(b, err)

--- a/pdata/ptrace/json.go
+++ b/pdata/ptrace/json.go
@@ -24,32 +24,34 @@ import (
 	"go.opentelemetry.io/collector/pdata/ptrace/internal/ptracejson"
 )
 
-// NewJSONMarshaler returns a model.Marshaler. Marshals to OTLP json bytes.
+var delegate = &jsonpb.Marshaler{
+	EnumsAsInts: true,
+}
+
+// Deprecated: [v0.63.0] use &JSONMarshaler{}
 func NewJSONMarshaler() Marshaler {
-	return &jsonMarshaler{delegate: jsonpb.Marshaler{
-		EnumsAsInts: true,
-	}}
+	return &JSONMarshaler{}
 }
 
-type jsonMarshaler struct {
-	delegate jsonpb.Marshaler
-}
+var _ Marshaler = (*JSONMarshaler)(nil)
 
-func (e *jsonMarshaler) MarshalTraces(td Traces) ([]byte, error) {
+type JSONMarshaler struct{}
+
+func (*JSONMarshaler) MarshalTraces(td Traces) ([]byte, error) {
 	buf := bytes.Buffer{}
 	pb := internal.TracesToProto(internal.Traces(td))
-	err := e.delegate.Marshal(&buf, &pb)
+	err := delegate.Marshal(&buf, &pb)
 	return buf.Bytes(), err
 }
 
-// NewJSONUnmarshaler returns a model.Unmarshaler. Unmarshalls from OTLP json bytes.
+type JSONUnmarshaler struct{}
+
+// Deprecated: [v0.63.0] use &JSONUnmarshaler{}
 func NewJSONUnmarshaler() Unmarshaler {
-	return &jsonUnmarshaler{}
+	return &JSONUnmarshaler{}
 }
 
-type jsonUnmarshaler struct{}
-
-func (jsonUnmarshaler) UnmarshalTraces(buf []byte) (Traces, error) {
+func (*JSONUnmarshaler) UnmarshalTraces(buf []byte) (Traces, error) {
 	var td otlptrace.TracesData
 	if err := ptracejson.UnmarshalTraceData(buf, &td); err != nil {
 		return Traces{}, err

--- a/pdata/ptrace/json_test.go
+++ b/pdata/ptrace/json_test.go
@@ -37,11 +37,11 @@ var tracesOTLP = func() Traces {
 var tracesJSON = `{"resourceSpans":[{"resource":{"attributes":[{"key":"host.name","value":{"stringValue":"testHost"}}]},"scopeSpans":[{"scope":{"name":"name","version":"version"},"spans":[{"traceId":"","spanId":"","parentSpanId":"","name":"testSpan","status":{}}]}]}]}`
 
 func TestTracesJSON(t *testing.T) {
-	encoder := NewJSONMarshaler()
+	encoder := &JSONMarshaler{}
 	jsonBuf, err := encoder.MarshalTraces(tracesOTLP)
 	assert.NoError(t, err)
 
-	decoder := NewJSONUnmarshaler()
+	decoder := &JSONUnmarshaler{}
 	var got interface{}
 	got, err = decoder.UnmarshalTraces(jsonBuf)
 	assert.NoError(t, err)
@@ -50,7 +50,7 @@ func TestTracesJSON(t *testing.T) {
 }
 
 func TestTracesJSON_Marshal(t *testing.T) {
-	encoder := NewJSONMarshaler()
+	encoder := &JSONMarshaler{}
 	jsonBuf, err := encoder.MarshalTraces(tracesOTLP)
 	assert.NoError(t, err)
 	assert.Equal(t, tracesJSON, string(jsonBuf))
@@ -127,11 +127,11 @@ var tracesOTLPFull = func() Traces {
 }()
 
 func TestJSONFull(t *testing.T) {
-	encoder := NewJSONMarshaler()
+	encoder := &JSONMarshaler{}
 	jsonBuf, err := encoder.MarshalTraces(tracesOTLPFull)
 	assert.NoError(t, err)
 
-	decoder := NewJSONUnmarshaler()
+	decoder := &JSONUnmarshaler{}
 	got, err := decoder.UnmarshalTraces(jsonBuf)
 	assert.NoError(t, err)
 	assert.EqualValues(t, tracesOTLPFull, got)
@@ -140,10 +140,10 @@ func TestJSONFull(t *testing.T) {
 func BenchmarkJSONUnmarshal(b *testing.B) {
 	b.ReportAllocs()
 
-	encoder := NewJSONMarshaler()
+	encoder := &JSONMarshaler{}
 	jsonBuf, err := encoder.MarshalTraces(tracesOTLPFull)
 	assert.NoError(b, err)
-	decoder := NewJSONUnmarshaler()
+	decoder := &JSONUnmarshaler{}
 
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {

--- a/pdata/ptrace/pb.go
+++ b/pdata/ptrace/pb.go
@@ -19,42 +19,33 @@ import (
 	otlptrace "go.opentelemetry.io/collector/pdata/internal/data/protogen/trace/v1"
 )
 
-// NewProtoMarshaler returns a MarshalSizer.
-// Marshals to OTLP binary protobuf bytes and calculates the size of the marshaled Traces.
+// Deprecated: [v0.63.0] use &ProtoMarshaler{}
 func NewProtoMarshaler() MarshalSizer {
-	return newPbMarshaler()
+	return &ProtoMarshaler{}
 }
 
-type pbMarshaler struct{}
+var _ MarshalSizer = (*ProtoMarshaler)(nil)
 
-func newPbMarshaler() *pbMarshaler {
-	return &pbMarshaler{}
-}
+type ProtoMarshaler struct{}
 
-var _ Sizer = (*pbMarshaler)(nil)
-
-func (e *pbMarshaler) MarshalTraces(td Traces) ([]byte, error) {
+func (e *ProtoMarshaler) MarshalTraces(td Traces) ([]byte, error) {
 	pb := internal.TracesToProto(internal.Traces(td))
 	return pb.Marshal()
 }
 
-func (e *pbMarshaler) TracesSize(td Traces) int {
+func (e *ProtoMarshaler) TracesSize(td Traces) int {
 	pb := internal.TracesToProto(internal.Traces(td))
 	return pb.Size()
 }
 
-type pbUnmarshaler struct{}
+type ProtoUnmarshaler struct{}
 
-// NewProtoUnmarshaler returns a model.Unmarshaler. Unmarshals from OTLP binary protobuf bytes.
+// Deprecated: [v0.63.0] use &ProtoUnmarshaler{}
 func NewProtoUnmarshaler() Unmarshaler {
-	return newPbUnmarshaler()
+	return &ProtoUnmarshaler{}
 }
 
-func newPbUnmarshaler() *pbUnmarshaler {
-	return &pbUnmarshaler{}
-}
-
-func (d *pbUnmarshaler) UnmarshalTraces(buf []byte) (Traces, error) {
+func (d *ProtoUnmarshaler) UnmarshalTraces(buf []byte) (Traces, error) {
 	pb := otlptrace.TracesData{}
 	err := pb.Unmarshal(buf)
 	return Traces(internal.TracesFromProto(pb)), err

--- a/pdata/ptrace/pb_test.go
+++ b/pdata/ptrace/pb_test.go
@@ -24,14 +24,14 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 )
 
-func TestProtoTracesUnmarshaler_error(t *testing.T) {
-	p := NewProtoUnmarshaler()
+func TestProtoTracesUnmarshalerError(t *testing.T) {
+	p := &ProtoUnmarshaler{}
 	_, err := p.UnmarshalTraces([]byte("+$%"))
 	assert.Error(t, err)
 }
 
 func TestProtoSizer(t *testing.T) {
-	marshaler := NewProtoMarshaler()
+	marshaler := &ProtoMarshaler{}
 	td := NewTraces()
 	rms := td.ResourceSpans()
 	rms.AppendEmpty().ScopeSpans().AppendEmpty().Spans().AppendEmpty().SetName("foo")
@@ -43,14 +43,13 @@ func TestProtoSizer(t *testing.T) {
 	assert.Equal(t, len(bytes), size)
 }
 
-func TestProtoSizer_withNil(t *testing.T) {
-	sizer := NewProtoMarshaler().(Sizer)
-
+func TestProtoSizerEmptyTraces(t *testing.T) {
+	sizer := &ProtoMarshaler{}
 	assert.Equal(t, 0, sizer.TracesSize(NewTraces()))
 }
 
 func BenchmarkTracesToProto(b *testing.B) {
-	marshaler := NewProtoMarshaler()
+	marshaler := &ProtoMarshaler{}
 	traces := generateBenchmarkTraces(128)
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
@@ -61,8 +60,8 @@ func BenchmarkTracesToProto(b *testing.B) {
 }
 
 func BenchmarkTracesFromProto(b *testing.B) {
-	marshaler := NewProtoMarshaler()
-	unmarshaler := NewProtoUnmarshaler()
+	marshaler := &ProtoMarshaler{}
+	unmarshaler := &ProtoUnmarshaler{}
 	baseTraces := generateBenchmarkTraces(128)
 	buf, err := marshaler.MarshalTraces(baseTraces)
 	require.NoError(b, err)

--- a/processor/batchprocessor/batch_processor.go
+++ b/processor/batchprocessor/batch_processor.go
@@ -227,7 +227,7 @@ type batchTraces struct {
 }
 
 func newBatchTraces(nextConsumer consumer.Traces) *batchTraces {
-	return &batchTraces{nextConsumer: nextConsumer, traceData: ptrace.NewTraces(), sizer: ptrace.NewProtoMarshaler()}
+	return &batchTraces{nextConsumer: nextConsumer, traceData: ptrace.NewTraces(), sizer: &ptrace.ProtoMarshaler{}}
 }
 
 // add updates current batchTraces by adding new TraceData object
@@ -274,7 +274,7 @@ type batchMetrics struct {
 }
 
 func newBatchMetrics(nextConsumer consumer.Metrics) *batchMetrics {
-	return &batchMetrics{nextConsumer: nextConsumer, metricData: pmetric.NewMetrics(), sizer: pmetric.NewProtoMarshaler()}
+	return &batchMetrics{nextConsumer: nextConsumer, metricData: pmetric.NewMetrics(), sizer: &pmetric.ProtoMarshaler{}}
 }
 
 func (bm *batchMetrics) export(ctx context.Context, sendBatchMaxSize int, returnBytes bool) (int, int, error) {
@@ -320,7 +320,7 @@ type batchLogs struct {
 }
 
 func newBatchLogs(nextConsumer consumer.Logs) *batchLogs {
-	return &batchLogs{nextConsumer: nextConsumer, logData: plog.NewLogs(), sizer: plog.NewProtoMarshaler()}
+	return &batchLogs{nextConsumer: nextConsumer, logData: plog.NewLogs(), sizer: &plog.ProtoMarshaler{}}
 }
 
 func (bl *batchLogs) export(ctx context.Context, sendBatchMaxSize int, returnBytes bool) (int, int, error) {

--- a/processor/batchprocessor/batch_processor_test.go
+++ b/processor/batchprocessor/batch_processor_test.go
@@ -122,7 +122,7 @@ func TestBatchProcessorSpansDeliveredEnforceBatchSize(t *testing.T) {
 }
 
 func TestBatchProcessorSentBySize(t *testing.T) {
-	sizer := ptrace.NewProtoMarshaler()
+	sizer := &ptrace.ProtoMarshaler{}
 	views := MetricViews()
 	require.NoError(t, view.Register(views...))
 	defer view.Unregister(views...)
@@ -359,7 +359,7 @@ func TestBatchMetricProcessor_ReceivingData(t *testing.T) {
 }
 
 func TestBatchMetricProcessor_BatchSize(t *testing.T) {
-	sizer := pmetric.NewProtoMarshaler()
+	sizer := &pmetric.ProtoMarshaler{}
 	views := MetricViews()
 	require.NoError(t, view.Register(views...))
 	defer view.Unregister(views...)
@@ -564,7 +564,7 @@ func getTestMetricName(requestNum, index int) string {
 }
 
 func BenchmarkTraceSizeBytes(b *testing.B) {
-	sizer := ptrace.NewProtoMarshaler()
+	sizer := &ptrace.ProtoMarshaler{}
 	td := testdata.GenerateTraces(8192)
 	for n := 0; n < b.N; n++ {
 		fmt.Println(sizer.TracesSize(td))
@@ -677,7 +677,7 @@ func TestBatchLogProcessor_ReceivingData(t *testing.T) {
 }
 
 func TestBatchLogProcessor_BatchSize(t *testing.T) {
-	sizer := plog.NewProtoMarshaler()
+	sizer := &plog.ProtoMarshaler{}
 	views := MetricViews()
 	require.NoError(t, view.Register(views...))
 	defer view.Unregister(views...)

--- a/receiver/otlpreceiver/otlp_test.go
+++ b/receiver/otlpreceiver/otlp_test.go
@@ -424,7 +424,8 @@ func TestProtoHttp(t *testing.T) {
 	<-time.After(10 * time.Millisecond)
 
 	td := testdata.GenerateTraces(1)
-	traceBytes, err := ptrace.NewProtoMarshaler().MarshalTraces(td)
+	marshaler := &ptrace.ProtoMarshaler{}
+	traceBytes, err := marshaler.MarshalTraces(td)
 	if err != nil {
 		t.Errorf("Error marshaling protobuf: %v", err)
 	}
@@ -931,7 +932,8 @@ func TestShutdown(t *testing.T) {
 	}
 	senderHTTP := func(td ptrace.Traces) {
 		// Send request via OTLP/HTTP.
-		traceBytes, err2 := ptrace.NewProtoMarshaler().MarshalTraces(td)
+		marshaler := &ptrace.ProtoMarshaler{}
+		traceBytes, err2 := marshaler.MarshalTraces(td)
 		if err2 != nil {
 			t.Errorf("Error marshaling protobuf: %v", err2)
 		}


### PR DESCRIPTION
The main motivation is because we want to be able to extend these Marshaler/Unmarshaler implementation with possible options.

Because of that we have 2 options: 1. add Option to each New func, OR 2. expose the structs so that later users can configure different options inside these structs, similar with `jsonpb.Marshaler`.

I implemented the version 2 since it is simpler, and less code, and also common in the industry.
