### PR TITLE
Added cleanup if service errors on Start

### DIFF
--- a/.chloggen/service-cleanup-on-start-error.yaml
+++ b/.chloggen/service-cleanup-on-start-error.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: collector
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fixed collector service not cleaning up if it failed during Start
+
+# One or more tracking issues or pull requests related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/service-cleanup-on-start-error.yaml
+++ b/.chloggen/service-cleanup-on-start-error.yaml
@@ -8,7 +8,7 @@ component: collector
 note: Fixed collector service not cleaning up if it failed during Start
 
 # One or more tracking issues or pull requests related to the change
-issues: []
+issues: [6352]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/service/collector.go
+++ b/service/collector.go
@@ -153,10 +153,16 @@ func (col *Collector) setupConfigurationComponents(ctx context.Context) error {
 	}
 
 	if err = col.service.Start(ctx); err != nil {
+		errs := err
 		if shutdownErr := col.service.Shutdown(ctx); shutdownErr != nil {
-			return multierr.Append(err, fmt.Errorf("failed to shutdown service after error: %w", shutdownErr))
+			errs = multierr.Append(err, fmt.Errorf("failed to shutdown service after error: %w", shutdownErr))
 		}
-		return err
+
+		// TODO: Move this as part of the service shutdown.
+		if shutdownErr := col.service.telemetryInitializer.shutdown(); shutdownErr != nil {
+			errs = multierr.Append(errs, fmt.Errorf("failed to shutdown collector telemetry: %w", shutdownErr))
+		}
+		return errs
 	}
 	col.setCollectorState(Running)
 	return nil
@@ -224,6 +230,11 @@ func (col *Collector) shutdown(ctx context.Context) error {
 
 	if err := col.service.Shutdown(ctx); err != nil {
 		errs = multierr.Append(errs, fmt.Errorf("failed to shutdown service: %w", err))
+	}
+
+	// TODO: Move this as part of the service shutdown.
+	if err := col.service.telemetryInitializer.shutdown(); err != nil {
+		errs = multierr.Append(errs, fmt.Errorf("failed to shutdown collector telemetry: %w", err))
 	}
 
 	col.setCollectorState(Closed)

--- a/service/collector.go
+++ b/service/collector.go
@@ -233,7 +233,7 @@ func (col *Collector) shutdownServiceAndTelemetry(ctx context.Context) error {
 
 	// shutdown service
 	if err := col.service.Shutdown(ctx); err != nil {
-		errs = multierr.Append(err, fmt.Errorf("failed to shutdown service after error: %w", err))
+		errs = multierr.Append(errs, fmt.Errorf("failed to shutdown service after error: %w", err))
 	}
 
 	// TODO: Move this as part of the service shutdown.

--- a/service/collector.go
+++ b/service/collector.go
@@ -153,9 +153,7 @@ func (col *Collector) setupConfigurationComponents(ctx context.Context) error {
 	}
 
 	if err = col.service.Start(ctx); err != nil {
-		if shutdownErr := col.shutdownServiceAndTelemetry(ctx); shutdownErr != nil {
-			return multierr.Append(err, shutdownErr)
-		}
+		return multierr.Append(err, col.shutdownServiceAndTelemetry(ctx))
 	}
 	col.setCollectorState(Running)
 	return nil
@@ -221,9 +219,7 @@ func (col *Collector) shutdown(ctx context.Context) error {
 		errs = multierr.Append(errs, fmt.Errorf("failed to shutdown config provider: %w", err))
 	}
 
-	if err := col.shutdownServiceAndTelemetry(ctx); err != nil {
-		errs = multierr.Append(errs, err)
-	}
+	errs = multierr.Append(errs, col.shutdownServiceAndTelemetry(ctx))
 
 	col.setCollectorState(Closed)
 

--- a/service/service.go
+++ b/service/service.go
@@ -84,6 +84,7 @@ func newService(set *settings) (*service, error) {
 	return srv, nil
 }
 
+// Start starts the extensions and pipelines. If Start fails Shutdown should be called to ensure a clean state.
 func (srv *service) Start(ctx context.Context) error {
 	srv.telemetrySettings.Logger.Info("Starting "+srv.buildInfo.Command+"...",
 		zap.String("Version", srv.buildInfo.Version),
@@ -131,6 +132,9 @@ func (srv *service) Shutdown(ctx context.Context) error {
 		errs = multierr.Append(errs, fmt.Errorf("failed to shutdown telemetry: %w", err))
 	}
 
+	if err := srv.telemetryInitializer.shutdown(); err != nil {
+		errs = multierr.Append(errs, fmt.Errorf("failed to shutdown telemetry initializer: %w", err))
+	}
 	// TODO: Shutdown MeterProvider.
 	return errs
 }

--- a/service/service.go
+++ b/service/service.go
@@ -132,9 +132,6 @@ func (srv *service) Shutdown(ctx context.Context) error {
 		errs = multierr.Append(errs, fmt.Errorf("failed to shutdown telemetry: %w", err))
 	}
 
-	if err := srv.telemetryInitializer.shutdown(); err != nil {
-		errs = multierr.Append(errs, fmt.Errorf("failed to shutdown telemetry initializer: %w", err))
-	}
 	// TODO: Shutdown MeterProvider.
 	return errs
 }

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -152,6 +152,10 @@ func TestServiceTelemetryReusable(t *testing.T) {
 
 	// Create a service
 	telemetry := newColTelemetry(featuregate.NewRegistry())
+	// For safety ensure everything is cleaned up
+	t.Cleanup(func() {
+		assert.NoError(t, telemetry.shutdown())
+	})
 
 	srvOne, err := newService(&settings{
 		BuildInfo: component.NewDefaultBuildInfo(),
@@ -186,13 +190,6 @@ func TestServiceTelemetryReusable(t *testing.T) {
 		telemetry: telemetry,
 	})
 	require.NoError(t, err)
-
-	// For safety ensure everything is cleaned up
-	t.Cleanup(func() {
-		assert.NoError(t, telemetry.shutdown())
-		assert.NoError(t, srvOne.Shutdown(context.Background()))
-		assert.NoError(t, srvTwo.Shutdown(context.Background()))
-	})
 
 	// Start the new service
 	require.NoError(t, srvTwo.Start(context.Background()))

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -161,7 +161,7 @@ func TestServiceTelemetryReusable(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// Setup tu curl the telemetry URL to ensure it works
+	// URL of the telemetry service metrics endpoint
 	telemetryURL := fmt.Sprintf("http://%s/metrics", telemetry.server.Addr)
 
 	// Start the service


### PR DESCRIPTION
**Description:** Same as #6239. Call `service.Shutdown` if `service.Start` call errors in collector. A failed `service.Start` would leave up the `telemetryInitializer` and the next attempt at starting the collector would cause an error as the `telemetryInitializer` didn't clean up global state.

I'm not sure if this interferes with work on #5564. I moved the `service.telemetryInitializer.Shutdown` into `service.Shutdown`. Currently it the `telemetryInitializer` needs to be shutdown separately from the service. This changes makes it so calling `service.Shutdown` ensures all its state is cleaned up.

Fixes: #6352