### PR TITLE
Deprecate p[trace|metric|log]otlp.NewClient in favor of p[trace|metric|log]otlp.NewGRPCClient

### DIFF
--- a/.chloggen/grpcclient.yaml
+++ b/.chloggen/grpcclient.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: pdata
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Deprecate `p[trace|metric|log]otlp.NewClient` in favor of `p[trace|metric|log]otlp.NewGRPCClient`"
+
+# One or more tracking issues or pull requests related to the change
+issues: [6350]

--- a/config/configgrpc/configgrpc_test.go
+++ b/config/configgrpc/configgrpc_test.go
@@ -580,7 +580,7 @@ func TestHttpReception(t *testing.T) {
 			assert.NoError(t, errClient)
 			grpcClientConn, errDial := grpc.Dial(gcs.Endpoint, clientOpts...)
 			assert.NoError(t, errDial)
-			client := ptraceotlp.NewClient(grpcClientConn)
+			client := ptraceotlp.NewGRPCClient(grpcClientConn)
 			ctx, cancelFunc := context.WithTimeout(context.Background(), 2*time.Second)
 			resp, errResp := client.Export(ctx, ptraceotlp.NewRequest(), grpc.WaitForReady(true))
 			if test.hasError {
@@ -631,7 +631,7 @@ func TestReceiveOnUnixDomainSocket(t *testing.T) {
 	assert.NoError(t, errClient)
 	grpcClientConn, errDial := grpc.Dial(gcs.Endpoint, clientOpts...)
 	assert.NoError(t, errDial)
-	client := ptraceotlp.NewClient(grpcClientConn)
+	client := ptraceotlp.NewGRPCClient(grpcClientConn)
 	ctx, cancelFunc := context.WithTimeout(context.Background(), 2*time.Second)
 	resp, errResp := client.Export(ctx, ptraceotlp.NewRequest(), grpc.WaitForReady(true))
 	assert.NoError(t, errResp)
@@ -844,7 +844,7 @@ func TestClientInfoInterceptors(t *testing.T) {
 				grpcClientConn, errDial := grpc.Dial(gcs.Endpoint, clientOpts...)
 				require.NoError(t, errDial)
 
-				cl := ptraceotlp.NewClient(grpcClientConn)
+				cl := ptraceotlp.NewGRPCClient(grpcClientConn)
 				ctx, cancelFunc := context.WithTimeout(context.Background(), 2*time.Second)
 				defer cancelFunc()
 

--- a/exporter/otlpexporter/otlp.go
+++ b/exporter/otlpexporter/otlp.go
@@ -85,9 +85,9 @@ func (e *exporter) start(ctx context.Context, host component.Host) (err error) {
 		return err
 	}
 
-	e.traceExporter = ptraceotlp.NewClient(e.clientConn)
-	e.metricExporter = pmetricotlp.NewClient(e.clientConn)
-	e.logExporter = plogotlp.NewClient(e.clientConn)
+	e.traceExporter = ptraceotlp.NewGRPCClient(e.clientConn)
+	e.metricExporter = pmetricotlp.NewGRPCClient(e.clientConn)
+	e.logExporter = plogotlp.NewGRPCClient(e.clientConn)
 	e.metadata = metadata.New(e.config.GRPCClientSettings.Headers)
 	e.callOptions = []grpc.CallOption{
 		grpc.WaitForReady(e.config.GRPCClientSettings.WaitForReady),

--- a/pdata/plog/plogotlp/grpc.go
+++ b/pdata/plog/plogotlp/grpc.go
@@ -34,10 +34,13 @@ type GRPCClient interface {
 	Export(ctx context.Context, request Request, opts ...grpc.CallOption) (Response, error)
 }
 
-// NewClient returns a new Client connected using the given connection.
-func NewClient(cc *grpc.ClientConn) GRPCClient {
+// NewGRPCClient returns a new GRPCClient connected using the given connection.
+func NewGRPCClient(cc *grpc.ClientConn) GRPCClient {
 	return &grpcClient{rawClient: otlpcollectorlog.NewLogsServiceClient(cc)}
 }
+
+// Deprecated: [v0.63.0]: use NewGRPCClient.
+var NewClient = NewGRPCClient
 
 type grpcClient struct {
 	rawClient otlpcollectorlog.LogsServiceClient

--- a/pdata/plog/plogotlp/grpc_test.go
+++ b/pdata/plog/plogotlp/grpc_test.go
@@ -58,7 +58,7 @@ func TestGrpc(t *testing.T) {
 		assert.NoError(t, cc.Close())
 	})
 
-	logClient := NewClient(cc)
+	logClient := NewGRPCClient(cc)
 
 	resp, err := logClient.Export(context.Background(), generateLogsRequest())
 	assert.NoError(t, err)
@@ -91,7 +91,7 @@ func TestGrpcError(t *testing.T) {
 		assert.NoError(t, cc.Close())
 	})
 
-	logClient := NewClient(cc)
+	logClient := NewGRPCClient(cc)
 	resp, err := logClient.Export(context.Background(), generateLogsRequest())
 	require.Error(t, err)
 	st, okSt := status.FromError(err)

--- a/pdata/pmetric/pmetricotlp/grpc.go
+++ b/pdata/pmetric/pmetricotlp/grpc.go
@@ -34,10 +34,13 @@ type GRPCClient interface {
 	Export(ctx context.Context, request Request, opts ...grpc.CallOption) (Response, error)
 }
 
-// NewClient returns a new Client connected using the given connection.
-func NewClient(cc *grpc.ClientConn) GRPCClient {
+// NewGRPCClient returns a new GRPCClient connected using the given connection.
+func NewGRPCClient(cc *grpc.ClientConn) GRPCClient {
 	return &grpcClient{rawClient: otlpcollectormetrics.NewMetricsServiceClient(cc)}
 }
+
+// Deprecated: [v0.63.0]: use NewGRPCClient.
+var NewClient = NewGRPCClient
 
 type grpcClient struct {
 	rawClient otlpcollectormetrics.MetricsServiceClient

--- a/pdata/pmetric/pmetricotlp/grpc_test.go
+++ b/pdata/pmetric/pmetricotlp/grpc_test.go
@@ -58,7 +58,7 @@ func TestGrpc(t *testing.T) {
 		assert.NoError(t, cc.Close())
 	})
 
-	logClient := NewClient(cc)
+	logClient := NewGRPCClient(cc)
 
 	resp, err := logClient.Export(context.Background(), generateMetricsRequest())
 	assert.NoError(t, err)
@@ -91,7 +91,7 @@ func TestGrpcError(t *testing.T) {
 		assert.NoError(t, cc.Close())
 	})
 
-	logClient := NewClient(cc)
+	logClient := NewGRPCClient(cc)
 	resp, err := logClient.Export(context.Background(), generateMetricsRequest())
 	require.Error(t, err)
 	st, okSt := status.FromError(err)

--- a/pdata/ptrace/ptraceotlp/grpc.go
+++ b/pdata/ptrace/ptraceotlp/grpc.go
@@ -34,10 +34,13 @@ type GRPCClient interface {
 	Export(ctx context.Context, request Request, opts ...grpc.CallOption) (Response, error)
 }
 
-// NewClient returns a new Client connected using the given connection.
-func NewClient(cc *grpc.ClientConn) GRPCClient {
+// NewGRPCClient returns a new GRPCClient connected using the given connection.
+func NewGRPCClient(cc *grpc.ClientConn) GRPCClient {
 	return &grpcClient{rawClient: otlpcollectortrace.NewTraceServiceClient(cc)}
 }
+
+// Deprecated: [v0.63.0]: use NewGRPCClient.
+var NewClient = NewGRPCClient
 
 type grpcClient struct {
 	rawClient otlpcollectortrace.TraceServiceClient

--- a/pdata/ptrace/ptraceotlp/grpc_test.go
+++ b/pdata/ptrace/ptraceotlp/grpc_test.go
@@ -58,7 +58,7 @@ func TestGrpc(t *testing.T) {
 		assert.NoError(t, cc.Close())
 	})
 
-	logClient := NewClient(cc)
+	logClient := NewGRPCClient(cc)
 
 	resp, err := logClient.Export(context.Background(), generateTracesRequest())
 	assert.NoError(t, err)
@@ -91,7 +91,7 @@ func TestGrpcError(t *testing.T) {
 		assert.NoError(t, cc.Close())
 	})
 
-	logClient := NewClient(cc)
+	logClient := NewGRPCClient(cc)
 	resp, err := logClient.Export(context.Background(), generateTracesRequest())
 	require.Error(t, err)
 	st, okSt := status.FromError(err)

--- a/receiver/otlpreceiver/internal/logs/otlp_test.go
+++ b/receiver/otlpreceiver/internal/logs/otlp_test.go
@@ -75,7 +75,7 @@ func makeLogsServiceClient(t *testing.T, lc consumer.Logs) plogotlp.GRPCClient {
 		require.NoError(t, cc.Close())
 	})
 
-	return plogotlp.NewClient(cc)
+	return plogotlp.NewGRPCClient(cc)
 }
 
 func otlpReceiverOnGRPCServer(t *testing.T, lc consumer.Logs) net.Addr {

--- a/receiver/otlpreceiver/internal/metrics/otlp_test.go
+++ b/receiver/otlpreceiver/internal/metrics/otlp_test.go
@@ -76,7 +76,7 @@ func makeMetricsServiceClient(t *testing.T, mc consumer.Metrics) pmetricotlp.GRP
 		require.NoError(t, cc.Close())
 	})
 
-	return pmetricotlp.NewClient(cc)
+	return pmetricotlp.NewGRPCClient(cc)
 }
 
 func otlpReceiverOnGRPCServer(t *testing.T, mc consumer.Metrics) net.Addr {

--- a/receiver/otlpreceiver/internal/trace/otlp_test.go
+++ b/receiver/otlpreceiver/internal/trace/otlp_test.go
@@ -73,7 +73,7 @@ func makeTraceServiceClient(t *testing.T, tc consumer.Traces) ptraceotlp.GRPCCli
 		require.NoError(t, cc.Close())
 	})
 
-	return ptraceotlp.NewClient(cc)
+	return ptraceotlp.NewGRPCClient(cc)
 }
 
 func otlpReceiverOnGRPCServer(t *testing.T, tc consumer.Traces) net.Addr {

--- a/receiver/otlpreceiver/otlp_test.go
+++ b/receiver/otlpreceiver/otlp_test.go
@@ -1002,7 +1002,7 @@ loop:
 }
 
 func exportTraces(cc *grpc.ClientConn, td ptrace.Traces) error {
-	acc := ptraceotlp.NewClient(cc)
+	acc := ptraceotlp.NewGRPCClient(cc)
 	req := ptraceotlp.NewRequestFromTraces(td)
 	_, err := acc.Export(context.Background(), req)
 


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-collector/issues/6350