### PR TITLE
[pdata] Rename p[trace|metric|log]otlp.ExportPartialSuccess

### DIFF
--- a/.chloggen/generatepartialresponse.yaml
+++ b/.chloggen/generatepartialresponse.yaml
@@ -8,4 +8,4 @@ component: pdata
 note: Introduce partial success fields in ExportServiceResponse.
 
 # One or more tracking issues or pull requests related to the change
-issues: [5815, 5816]
+issues: [5815, 5816, 6365]

--- a/pdata/internal/cmd/pdatagen/internal/plogotlp_structs.go
+++ b/pdata/internal/cmd/pdatagen/internal/plogotlp_structs.go
@@ -41,9 +41,10 @@ var logOtlpFile = &File{
 }
 
 var exportLogsPartialSuccess = &messageValueStruct{
-	structName:     "ExportLogsPartialSuccess",
-	description:    "// ExportLogsPartialSuccess represents the details of a partially successful export request.",
-	originFullName: "otlpcollectorlog.ExportLogsPartialSuccess",
+	structName:         "ExportPartialSuccess",
+	internalStructName: "LogsExportPartialSuccess",
+	description:        "// ExportPartialSuccess represents the details of a partially successful export request.",
+	originFullName:     "otlpcollectorlog.ExportLogsPartialSuccess",
 	fields: []baseField{
 		&primitiveField{
 			fieldName:  "RejectedLogRecords",

--- a/pdata/internal/cmd/pdatagen/internal/pmetricotlp_structs.go
+++ b/pdata/internal/cmd/pdatagen/internal/pmetricotlp_structs.go
@@ -42,9 +42,10 @@ var metricsOtlpFile = &File{
 }
 
 var exportMetricsPartialSuccess = &messageValueStruct{
-	structName:     "ExportMetricsPartialSuccess",
-	description:    "// ExportMetricsPartialSuccess represents the details of a partially successful export request.",
-	originFullName: "otlpcollectormetrics.ExportMetricsPartialSuccess",
+	structName:         "ExportPartialSuccess",
+	internalStructName: "MetricsExportPartialSuccess",
+	description:        "// ExportPartialSuccess represents the details of a partially successful export request.",
+	originFullName:     "otlpcollectormetrics.ExportMetricsPartialSuccess",
 	fields: []baseField{
 		&primitiveField{
 			fieldName:  "RejectedDataPoints",

--- a/pdata/internal/cmd/pdatagen/internal/ptraceotlp_structs.go
+++ b/pdata/internal/cmd/pdatagen/internal/ptraceotlp_structs.go
@@ -42,9 +42,10 @@ var traceOtlpFile = &File{
 }
 
 var exportTracePartialSuccess = &messageValueStruct{
-	structName:     "ExportTracePartialSuccess",
-	description:    "// ExportTracePartialSuccess represents the details of a partially successful export request.",
-	originFullName: "otlpcollectortrace.ExportTracePartialSuccess",
+	structName:         "ExportPartialSuccess",
+	internalStructName: "TracesExportPartialSuccess",
+	description:        "// ExportPartialSuccess represents the details of a partially successful export request.",
+	originFullName:     "otlpcollectortrace.ExportTracePartialSuccess",
 	fields: []baseField{
 		&primitiveField{
 			fieldName:  "RejectedSpans",

--- a/pdata/internal/generated_wrapper_logs_otlp.go
+++ b/pdata/internal/generated_wrapper_logs_otlp.go
@@ -21,26 +21,26 @@ import (
 	otlpcollectorlog "go.opentelemetry.io/collector/pdata/internal/data/protogen/collector/logs/v1"
 )
 
-type ExportLogsPartialSuccess struct {
+type LogsExportPartialSuccess struct {
 	orig *otlpcollectorlog.ExportLogsPartialSuccess
 }
 
-func GetOrigExportLogsPartialSuccess(ms ExportLogsPartialSuccess) *otlpcollectorlog.ExportLogsPartialSuccess {
+func GetOrigLogsExportPartialSuccess(ms LogsExportPartialSuccess) *otlpcollectorlog.ExportLogsPartialSuccess {
 	return ms.orig
 }
 
-func NewExportLogsPartialSuccess(orig *otlpcollectorlog.ExportLogsPartialSuccess) ExportLogsPartialSuccess {
-	return ExportLogsPartialSuccess{orig: orig}
+func NewLogsExportPartialSuccess(orig *otlpcollectorlog.ExportLogsPartialSuccess) LogsExportPartialSuccess {
+	return LogsExportPartialSuccess{orig: orig}
 }
 
-func GenerateTestExportLogsPartialSuccess() ExportLogsPartialSuccess {
+func GenerateTestLogsExportPartialSuccess() LogsExportPartialSuccess {
 	orig := otlpcollectorlog.ExportLogsPartialSuccess{}
-	tv := NewExportLogsPartialSuccess(&orig)
-	FillTestExportLogsPartialSuccess(tv)
+	tv := NewLogsExportPartialSuccess(&orig)
+	FillTestLogsExportPartialSuccess(tv)
 	return tv
 }
 
-func FillTestExportLogsPartialSuccess(tv ExportLogsPartialSuccess) {
+func FillTestLogsExportPartialSuccess(tv LogsExportPartialSuccess) {
 	tv.orig.RejectedLogRecords = int64(13)
 	tv.orig.ErrorMessage = "error message"
 }

--- a/pdata/internal/generated_wrapper_metrics_otlp.go
+++ b/pdata/internal/generated_wrapper_metrics_otlp.go
@@ -21,26 +21,26 @@ import (
 	otlpcollectormetrics "go.opentelemetry.io/collector/pdata/internal/data/protogen/collector/metrics/v1"
 )
 
-type ExportMetricsPartialSuccess struct {
+type MetricsExportPartialSuccess struct {
 	orig *otlpcollectormetrics.ExportMetricsPartialSuccess
 }
 
-func GetOrigExportMetricsPartialSuccess(ms ExportMetricsPartialSuccess) *otlpcollectormetrics.ExportMetricsPartialSuccess {
+func GetOrigMetricsExportPartialSuccess(ms MetricsExportPartialSuccess) *otlpcollectormetrics.ExportMetricsPartialSuccess {
 	return ms.orig
 }
 
-func NewExportMetricsPartialSuccess(orig *otlpcollectormetrics.ExportMetricsPartialSuccess) ExportMetricsPartialSuccess {
-	return ExportMetricsPartialSuccess{orig: orig}
+func NewMetricsExportPartialSuccess(orig *otlpcollectormetrics.ExportMetricsPartialSuccess) MetricsExportPartialSuccess {
+	return MetricsExportPartialSuccess{orig: orig}
 }
 
-func GenerateTestExportMetricsPartialSuccess() ExportMetricsPartialSuccess {
+func GenerateTestMetricsExportPartialSuccess() MetricsExportPartialSuccess {
 	orig := otlpcollectormetrics.ExportMetricsPartialSuccess{}
-	tv := NewExportMetricsPartialSuccess(&orig)
-	FillTestExportMetricsPartialSuccess(tv)
+	tv := NewMetricsExportPartialSuccess(&orig)
+	FillTestMetricsExportPartialSuccess(tv)
 	return tv
 }
 
-func FillTestExportMetricsPartialSuccess(tv ExportMetricsPartialSuccess) {
+func FillTestMetricsExportPartialSuccess(tv MetricsExportPartialSuccess) {
 	tv.orig.RejectedDataPoints = int64(13)
 	tv.orig.ErrorMessage = "error message"
 }

--- a/pdata/internal/generated_wrapper_traces_otlp.go
+++ b/pdata/internal/generated_wrapper_traces_otlp.go
@@ -21,26 +21,26 @@ import (
 	otlpcollectortrace "go.opentelemetry.io/collector/pdata/internal/data/protogen/collector/trace/v1"
 )
 
-type ExportTracePartialSuccess struct {
+type TracesExportPartialSuccess struct {
 	orig *otlpcollectortrace.ExportTracePartialSuccess
 }
 
-func GetOrigExportTracePartialSuccess(ms ExportTracePartialSuccess) *otlpcollectortrace.ExportTracePartialSuccess {
+func GetOrigTracesExportPartialSuccess(ms TracesExportPartialSuccess) *otlpcollectortrace.ExportTracePartialSuccess {
 	return ms.orig
 }
 
-func NewExportTracePartialSuccess(orig *otlpcollectortrace.ExportTracePartialSuccess) ExportTracePartialSuccess {
-	return ExportTracePartialSuccess{orig: orig}
+func NewTracesExportPartialSuccess(orig *otlpcollectortrace.ExportTracePartialSuccess) TracesExportPartialSuccess {
+	return TracesExportPartialSuccess{orig: orig}
 }
 
-func GenerateTestExportTracePartialSuccess() ExportTracePartialSuccess {
+func GenerateTestTracesExportPartialSuccess() TracesExportPartialSuccess {
 	orig := otlpcollectortrace.ExportTracePartialSuccess{}
-	tv := NewExportTracePartialSuccess(&orig)
-	FillTestExportTracePartialSuccess(tv)
+	tv := NewTracesExportPartialSuccess(&orig)
+	FillTestTracesExportPartialSuccess(tv)
 	return tv
 }
 
-func FillTestExportTracePartialSuccess(tv ExportTracePartialSuccess) {
+func FillTestTracesExportPartialSuccess(tv TracesExportPartialSuccess) {
 	tv.orig.RejectedSpans = int64(13)
 	tv.orig.ErrorMessage = "error message"
 }

--- a/pdata/plog/plogotlp/generated_logs_otlp.go
+++ b/pdata/plog/plogotlp/generated_logs_otlp.go
@@ -22,61 +22,61 @@ import (
 	otlpcollectorlog "go.opentelemetry.io/collector/pdata/internal/data/protogen/collector/logs/v1"
 )
 
-// ExportLogsPartialSuccess represents the details of a partially successful export request.
+// ExportPartialSuccess represents the details of a partially successful export request.
 //
 // This is a reference type, if passed by value and callee modifies it the
 // caller will see the modification.
 //
-// Must use NewExportLogsPartialSuccess function to create new instances.
+// Must use NewExportPartialSuccess function to create new instances.
 // Important: zero-initialized instance is not valid for use.
 
-type ExportLogsPartialSuccess internal.ExportLogsPartialSuccess
+type ExportPartialSuccess internal.LogsExportPartialSuccess
 
-func newExportLogsPartialSuccess(orig *otlpcollectorlog.ExportLogsPartialSuccess) ExportLogsPartialSuccess {
-	return ExportLogsPartialSuccess(internal.NewExportLogsPartialSuccess(orig))
+func newExportPartialSuccess(orig *otlpcollectorlog.ExportLogsPartialSuccess) ExportPartialSuccess {
+	return ExportPartialSuccess(internal.NewLogsExportPartialSuccess(orig))
 }
 
-func (ms ExportLogsPartialSuccess) getOrig() *otlpcollectorlog.ExportLogsPartialSuccess {
-	return internal.GetOrigExportLogsPartialSuccess(internal.ExportLogsPartialSuccess(ms))
+func (ms ExportPartialSuccess) getOrig() *otlpcollectorlog.ExportLogsPartialSuccess {
+	return internal.GetOrigLogsExportPartialSuccess(internal.LogsExportPartialSuccess(ms))
 }
 
-// NewExportLogsPartialSuccess creates a new empty ExportLogsPartialSuccess.
+// NewExportPartialSuccess creates a new empty ExportPartialSuccess.
 //
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
-func NewExportLogsPartialSuccess() ExportLogsPartialSuccess {
-	return newExportLogsPartialSuccess(&otlpcollectorlog.ExportLogsPartialSuccess{})
+func NewExportPartialSuccess() ExportPartialSuccess {
+	return newExportPartialSuccess(&otlpcollectorlog.ExportLogsPartialSuccess{})
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and
 // resetting the current instance to its zero value
-func (ms ExportLogsPartialSuccess) MoveTo(dest ExportLogsPartialSuccess) {
+func (ms ExportPartialSuccess) MoveTo(dest ExportPartialSuccess) {
 	*dest.getOrig() = *ms.getOrig()
 	*ms.getOrig() = otlpcollectorlog.ExportLogsPartialSuccess{}
 }
 
-// RejectedLogRecords returns the rejectedlogrecords associated with this ExportLogsPartialSuccess.
-func (ms ExportLogsPartialSuccess) RejectedLogRecords() int64 {
+// RejectedLogRecords returns the rejectedlogrecords associated with this ExportPartialSuccess.
+func (ms ExportPartialSuccess) RejectedLogRecords() int64 {
 	return ms.getOrig().RejectedLogRecords
 }
 
-// SetRejectedLogRecords replaces the rejectedlogrecords associated with this ExportLogsPartialSuccess.
-func (ms ExportLogsPartialSuccess) SetRejectedLogRecords(v int64) {
+// SetRejectedLogRecords replaces the rejectedlogrecords associated with this ExportPartialSuccess.
+func (ms ExportPartialSuccess) SetRejectedLogRecords(v int64) {
 	ms.getOrig().RejectedLogRecords = v
 }
 
-// ErrorMessage returns the errormessage associated with this ExportLogsPartialSuccess.
-func (ms ExportLogsPartialSuccess) ErrorMessage() string {
+// ErrorMessage returns the errormessage associated with this ExportPartialSuccess.
+func (ms ExportPartialSuccess) ErrorMessage() string {
 	return ms.getOrig().ErrorMessage
 }
 
-// SetErrorMessage replaces the errormessage associated with this ExportLogsPartialSuccess.
-func (ms ExportLogsPartialSuccess) SetErrorMessage(v string) {
+// SetErrorMessage replaces the errormessage associated with this ExportPartialSuccess.
+func (ms ExportPartialSuccess) SetErrorMessage(v string) {
 	ms.getOrig().ErrorMessage = v
 }
 
 // CopyTo copies all properties from the current struct overriding the destination.
-func (ms ExportLogsPartialSuccess) CopyTo(dest ExportLogsPartialSuccess) {
+func (ms ExportPartialSuccess) CopyTo(dest ExportPartialSuccess) {
 	dest.SetRejectedLogRecords(ms.RejectedLogRecords())
 	dest.SetErrorMessage(ms.ErrorMessage())
 }

--- a/pdata/plog/plogotlp/generated_logs_otlp_test.go
+++ b/pdata/plog/plogotlp/generated_logs_otlp_test.go
@@ -25,33 +25,33 @@ import (
 	"go.opentelemetry.io/collector/pdata/internal"
 )
 
-func TestExportLogsPartialSuccess_MoveTo(t *testing.T) {
-	ms := ExportLogsPartialSuccess(internal.GenerateTestExportLogsPartialSuccess())
-	dest := NewExportLogsPartialSuccess()
+func TestExportPartialSuccess_MoveTo(t *testing.T) {
+	ms := ExportPartialSuccess(internal.GenerateTestLogsExportPartialSuccess())
+	dest := NewExportPartialSuccess()
 	ms.MoveTo(dest)
-	assert.Equal(t, NewExportLogsPartialSuccess(), ms)
-	assert.Equal(t, ExportLogsPartialSuccess(internal.GenerateTestExportLogsPartialSuccess()), dest)
+	assert.Equal(t, NewExportPartialSuccess(), ms)
+	assert.Equal(t, ExportPartialSuccess(internal.GenerateTestLogsExportPartialSuccess()), dest)
 }
 
-func TestExportLogsPartialSuccess_CopyTo(t *testing.T) {
-	ms := NewExportLogsPartialSuccess()
-	orig := NewExportLogsPartialSuccess()
+func TestExportPartialSuccess_CopyTo(t *testing.T) {
+	ms := NewExportPartialSuccess()
+	orig := NewExportPartialSuccess()
 	orig.CopyTo(ms)
 	assert.Equal(t, orig, ms)
-	orig = ExportLogsPartialSuccess(internal.GenerateTestExportLogsPartialSuccess())
+	orig = ExportPartialSuccess(internal.GenerateTestLogsExportPartialSuccess())
 	orig.CopyTo(ms)
 	assert.Equal(t, orig, ms)
 }
 
-func TestExportLogsPartialSuccess_RejectedLogRecords(t *testing.T) {
-	ms := NewExportLogsPartialSuccess()
+func TestExportPartialSuccess_RejectedLogRecords(t *testing.T) {
+	ms := NewExportPartialSuccess()
 	assert.Equal(t, int64(0), ms.RejectedLogRecords())
 	ms.SetRejectedLogRecords(int64(13))
 	assert.Equal(t, int64(13), ms.RejectedLogRecords())
 }
 
-func TestExportLogsPartialSuccess_ErrorMessage(t *testing.T) {
-	ms := NewExportLogsPartialSuccess()
+func TestExportPartialSuccess_ErrorMessage(t *testing.T) {
+	ms := NewExportPartialSuccess()
 	assert.Equal(t, "", ms.ErrorMessage())
 	ms.SetErrorMessage("error message")
 	assert.Equal(t, "error message", ms.ErrorMessage())

--- a/pdata/plog/plogotlp/response.go
+++ b/pdata/plog/plogotlp/response.go
@@ -55,9 +55,9 @@ func (lr ExportResponse) UnmarshalJSON(data []byte) error {
 	return plogjson.UnmarshalExportLogsServiceResponse(data, lr.orig)
 }
 
-// PartialSuccess returns the ExportLogsPartialSuccess associated with this ExportResponse.
-func (lr ExportResponse) PartialSuccess() ExportLogsPartialSuccess {
-	return ExportLogsPartialSuccess(internal.NewExportLogsPartialSuccess(&lr.orig.PartialSuccess))
+// PartialSuccess returns the ExportPartialSuccess associated with this ExportResponse.
+func (lr ExportResponse) PartialSuccess() ExportPartialSuccess {
+	return ExportPartialSuccess(internal.NewLogsExportPartialSuccess(&lr.orig.PartialSuccess))
 }
 
 // Deprecated: [v0.63.0] use ExportResponse.

--- a/pdata/pmetric/pmetricotlp/generated_metrics_otlp.go
+++ b/pdata/pmetric/pmetricotlp/generated_metrics_otlp.go
@@ -22,61 +22,61 @@ import (
 	otlpcollectormetrics "go.opentelemetry.io/collector/pdata/internal/data/protogen/collector/metrics/v1"
 )
 
-// ExportMetricsPartialSuccess represents the details of a partially successful export request.
+// ExportPartialSuccess represents the details of a partially successful export request.
 //
 // This is a reference type, if passed by value and callee modifies it the
 // caller will see the modification.
 //
-// Must use NewExportMetricsPartialSuccess function to create new instances.
+// Must use NewExportPartialSuccess function to create new instances.
 // Important: zero-initialized instance is not valid for use.
 
-type ExportMetricsPartialSuccess internal.ExportMetricsPartialSuccess
+type ExportPartialSuccess internal.MetricsExportPartialSuccess
 
-func newExportMetricsPartialSuccess(orig *otlpcollectormetrics.ExportMetricsPartialSuccess) ExportMetricsPartialSuccess {
-	return ExportMetricsPartialSuccess(internal.NewExportMetricsPartialSuccess(orig))
+func newExportPartialSuccess(orig *otlpcollectormetrics.ExportMetricsPartialSuccess) ExportPartialSuccess {
+	return ExportPartialSuccess(internal.NewMetricsExportPartialSuccess(orig))
 }
 
-func (ms ExportMetricsPartialSuccess) getOrig() *otlpcollectormetrics.ExportMetricsPartialSuccess {
-	return internal.GetOrigExportMetricsPartialSuccess(internal.ExportMetricsPartialSuccess(ms))
+func (ms ExportPartialSuccess) getOrig() *otlpcollectormetrics.ExportMetricsPartialSuccess {
+	return internal.GetOrigMetricsExportPartialSuccess(internal.MetricsExportPartialSuccess(ms))
 }
 
-// NewExportMetricsPartialSuccess creates a new empty ExportMetricsPartialSuccess.
+// NewExportPartialSuccess creates a new empty ExportPartialSuccess.
 //
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
-func NewExportMetricsPartialSuccess() ExportMetricsPartialSuccess {
-	return newExportMetricsPartialSuccess(&otlpcollectormetrics.ExportMetricsPartialSuccess{})
+func NewExportPartialSuccess() ExportPartialSuccess {
+	return newExportPartialSuccess(&otlpcollectormetrics.ExportMetricsPartialSuccess{})
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and
 // resetting the current instance to its zero value
-func (ms ExportMetricsPartialSuccess) MoveTo(dest ExportMetricsPartialSuccess) {
+func (ms ExportPartialSuccess) MoveTo(dest ExportPartialSuccess) {
 	*dest.getOrig() = *ms.getOrig()
 	*ms.getOrig() = otlpcollectormetrics.ExportMetricsPartialSuccess{}
 }
 
-// RejectedDataPoints returns the rejecteddatapoints associated with this ExportMetricsPartialSuccess.
-func (ms ExportMetricsPartialSuccess) RejectedDataPoints() int64 {
+// RejectedDataPoints returns the rejecteddatapoints associated with this ExportPartialSuccess.
+func (ms ExportPartialSuccess) RejectedDataPoints() int64 {
 	return ms.getOrig().RejectedDataPoints
 }
 
-// SetRejectedDataPoints replaces the rejecteddatapoints associated with this ExportMetricsPartialSuccess.
-func (ms ExportMetricsPartialSuccess) SetRejectedDataPoints(v int64) {
+// SetRejectedDataPoints replaces the rejecteddatapoints associated with this ExportPartialSuccess.
+func (ms ExportPartialSuccess) SetRejectedDataPoints(v int64) {
 	ms.getOrig().RejectedDataPoints = v
 }
 
-// ErrorMessage returns the errormessage associated with this ExportMetricsPartialSuccess.
-func (ms ExportMetricsPartialSuccess) ErrorMessage() string {
+// ErrorMessage returns the errormessage associated with this ExportPartialSuccess.
+func (ms ExportPartialSuccess) ErrorMessage() string {
 	return ms.getOrig().ErrorMessage
 }
 
-// SetErrorMessage replaces the errormessage associated with this ExportMetricsPartialSuccess.
-func (ms ExportMetricsPartialSuccess) SetErrorMessage(v string) {
+// SetErrorMessage replaces the errormessage associated with this ExportPartialSuccess.
+func (ms ExportPartialSuccess) SetErrorMessage(v string) {
 	ms.getOrig().ErrorMessage = v
 }
 
 // CopyTo copies all properties from the current struct overriding the destination.
-func (ms ExportMetricsPartialSuccess) CopyTo(dest ExportMetricsPartialSuccess) {
+func (ms ExportPartialSuccess) CopyTo(dest ExportPartialSuccess) {
 	dest.SetRejectedDataPoints(ms.RejectedDataPoints())
 	dest.SetErrorMessage(ms.ErrorMessage())
 }

--- a/pdata/pmetric/pmetricotlp/generated_metrics_otlp_test.go
+++ b/pdata/pmetric/pmetricotlp/generated_metrics_otlp_test.go
@@ -25,33 +25,33 @@ import (
 	"go.opentelemetry.io/collector/pdata/internal"
 )
 
-func TestExportMetricsPartialSuccess_MoveTo(t *testing.T) {
-	ms := ExportMetricsPartialSuccess(internal.GenerateTestExportMetricsPartialSuccess())
-	dest := NewExportMetricsPartialSuccess()
+func TestExportPartialSuccess_MoveTo(t *testing.T) {
+	ms := ExportPartialSuccess(internal.GenerateTestMetricsExportPartialSuccess())
+	dest := NewExportPartialSuccess()
 	ms.MoveTo(dest)
-	assert.Equal(t, NewExportMetricsPartialSuccess(), ms)
-	assert.Equal(t, ExportMetricsPartialSuccess(internal.GenerateTestExportMetricsPartialSuccess()), dest)
+	assert.Equal(t, NewExportPartialSuccess(), ms)
+	assert.Equal(t, ExportPartialSuccess(internal.GenerateTestMetricsExportPartialSuccess()), dest)
 }
 
-func TestExportMetricsPartialSuccess_CopyTo(t *testing.T) {
-	ms := NewExportMetricsPartialSuccess()
-	orig := NewExportMetricsPartialSuccess()
+func TestExportPartialSuccess_CopyTo(t *testing.T) {
+	ms := NewExportPartialSuccess()
+	orig := NewExportPartialSuccess()
 	orig.CopyTo(ms)
 	assert.Equal(t, orig, ms)
-	orig = ExportMetricsPartialSuccess(internal.GenerateTestExportMetricsPartialSuccess())
+	orig = ExportPartialSuccess(internal.GenerateTestMetricsExportPartialSuccess())
 	orig.CopyTo(ms)
 	assert.Equal(t, orig, ms)
 }
 
-func TestExportMetricsPartialSuccess_RejectedDataPoints(t *testing.T) {
-	ms := NewExportMetricsPartialSuccess()
+func TestExportPartialSuccess_RejectedDataPoints(t *testing.T) {
+	ms := NewExportPartialSuccess()
 	assert.Equal(t, int64(0), ms.RejectedDataPoints())
 	ms.SetRejectedDataPoints(int64(13))
 	assert.Equal(t, int64(13), ms.RejectedDataPoints())
 }
 
-func TestExportMetricsPartialSuccess_ErrorMessage(t *testing.T) {
-	ms := NewExportMetricsPartialSuccess()
+func TestExportPartialSuccess_ErrorMessage(t *testing.T) {
+	ms := NewExportPartialSuccess()
 	assert.Equal(t, "", ms.ErrorMessage())
 	ms.SetErrorMessage("error message")
 	assert.Equal(t, "error message", ms.ErrorMessage())

--- a/pdata/pmetric/pmetricotlp/response.go
+++ b/pdata/pmetric/pmetricotlp/response.go
@@ -56,8 +56,8 @@ func (ms ExportResponse) UnmarshalJSON(data []byte) error {
 }
 
 // PartialSuccess returns the ExportLogsPartialSuccess associated with this ExportResponse.
-func (ms ExportResponse) PartialSuccess() ExportMetricsPartialSuccess {
-	return ExportMetricsPartialSuccess(internal.NewExportMetricsPartialSuccess(&ms.orig.PartialSuccess))
+func (ms ExportResponse) PartialSuccess() ExportPartialSuccess {
+	return ExportPartialSuccess(internal.NewMetricsExportPartialSuccess(&ms.orig.PartialSuccess))
 }
 
 // Deprecated: [v0.63.0] use ExportResponse.

--- a/pdata/ptrace/ptraceotlp/generated_traces_otlp.go
+++ b/pdata/ptrace/ptraceotlp/generated_traces_otlp.go
@@ -22,61 +22,61 @@ import (
 	otlpcollectortrace "go.opentelemetry.io/collector/pdata/internal/data/protogen/collector/trace/v1"
 )
 
-// ExportTracePartialSuccess represents the details of a partially successful export request.
+// ExportPartialSuccess represents the details of a partially successful export request.
 //
 // This is a reference type, if passed by value and callee modifies it the
 // caller will see the modification.
 //
-// Must use NewExportTracePartialSuccess function to create new instances.
+// Must use NewExportPartialSuccess function to create new instances.
 // Important: zero-initialized instance is not valid for use.
 
-type ExportTracePartialSuccess internal.ExportTracePartialSuccess
+type ExportPartialSuccess internal.TracesExportPartialSuccess
 
-func newExportTracePartialSuccess(orig *otlpcollectortrace.ExportTracePartialSuccess) ExportTracePartialSuccess {
-	return ExportTracePartialSuccess(internal.NewExportTracePartialSuccess(orig))
+func newExportPartialSuccess(orig *otlpcollectortrace.ExportTracePartialSuccess) ExportPartialSuccess {
+	return ExportPartialSuccess(internal.NewTracesExportPartialSuccess(orig))
 }
 
-func (ms ExportTracePartialSuccess) getOrig() *otlpcollectortrace.ExportTracePartialSuccess {
-	return internal.GetOrigExportTracePartialSuccess(internal.ExportTracePartialSuccess(ms))
+func (ms ExportPartialSuccess) getOrig() *otlpcollectortrace.ExportTracePartialSuccess {
+	return internal.GetOrigTracesExportPartialSuccess(internal.TracesExportPartialSuccess(ms))
 }
 
-// NewExportTracePartialSuccess creates a new empty ExportTracePartialSuccess.
+// NewExportPartialSuccess creates a new empty ExportPartialSuccess.
 //
 // This must be used only in testing code. Users should use "AppendEmpty" when part of a Slice,
 // OR directly access the member if this is embedded in another struct.
-func NewExportTracePartialSuccess() ExportTracePartialSuccess {
-	return newExportTracePartialSuccess(&otlpcollectortrace.ExportTracePartialSuccess{})
+func NewExportPartialSuccess() ExportPartialSuccess {
+	return newExportPartialSuccess(&otlpcollectortrace.ExportTracePartialSuccess{})
 }
 
 // MoveTo moves all properties from the current struct overriding the destination and
 // resetting the current instance to its zero value
-func (ms ExportTracePartialSuccess) MoveTo(dest ExportTracePartialSuccess) {
+func (ms ExportPartialSuccess) MoveTo(dest ExportPartialSuccess) {
 	*dest.getOrig() = *ms.getOrig()
 	*ms.getOrig() = otlpcollectortrace.ExportTracePartialSuccess{}
 }
 
-// RejectedSpans returns the rejectedspans associated with this ExportTracePartialSuccess.
-func (ms ExportTracePartialSuccess) RejectedSpans() int64 {
+// RejectedSpans returns the rejectedspans associated with this ExportPartialSuccess.
+func (ms ExportPartialSuccess) RejectedSpans() int64 {
 	return ms.getOrig().RejectedSpans
 }
 
-// SetRejectedSpans replaces the rejectedspans associated with this ExportTracePartialSuccess.
-func (ms ExportTracePartialSuccess) SetRejectedSpans(v int64) {
+// SetRejectedSpans replaces the rejectedspans associated with this ExportPartialSuccess.
+func (ms ExportPartialSuccess) SetRejectedSpans(v int64) {
 	ms.getOrig().RejectedSpans = v
 }
 
-// ErrorMessage returns the errormessage associated with this ExportTracePartialSuccess.
-func (ms ExportTracePartialSuccess) ErrorMessage() string {
+// ErrorMessage returns the errormessage associated with this ExportPartialSuccess.
+func (ms ExportPartialSuccess) ErrorMessage() string {
 	return ms.getOrig().ErrorMessage
 }
 
-// SetErrorMessage replaces the errormessage associated with this ExportTracePartialSuccess.
-func (ms ExportTracePartialSuccess) SetErrorMessage(v string) {
+// SetErrorMessage replaces the errormessage associated with this ExportPartialSuccess.
+func (ms ExportPartialSuccess) SetErrorMessage(v string) {
 	ms.getOrig().ErrorMessage = v
 }
 
 // CopyTo copies all properties from the current struct overriding the destination.
-func (ms ExportTracePartialSuccess) CopyTo(dest ExportTracePartialSuccess) {
+func (ms ExportPartialSuccess) CopyTo(dest ExportPartialSuccess) {
 	dest.SetRejectedSpans(ms.RejectedSpans())
 	dest.SetErrorMessage(ms.ErrorMessage())
 }

--- a/pdata/ptrace/ptraceotlp/generated_traces_otlp_test.go
+++ b/pdata/ptrace/ptraceotlp/generated_traces_otlp_test.go
@@ -25,33 +25,33 @@ import (
 	"go.opentelemetry.io/collector/pdata/internal"
 )
 
-func TestExportTracePartialSuccess_MoveTo(t *testing.T) {
-	ms := ExportTracePartialSuccess(internal.GenerateTestExportTracePartialSuccess())
-	dest := NewExportTracePartialSuccess()
+func TestExportPartialSuccess_MoveTo(t *testing.T) {
+	ms := ExportPartialSuccess(internal.GenerateTestTracesExportPartialSuccess())
+	dest := NewExportPartialSuccess()
 	ms.MoveTo(dest)
-	assert.Equal(t, NewExportTracePartialSuccess(), ms)
-	assert.Equal(t, ExportTracePartialSuccess(internal.GenerateTestExportTracePartialSuccess()), dest)
+	assert.Equal(t, NewExportPartialSuccess(), ms)
+	assert.Equal(t, ExportPartialSuccess(internal.GenerateTestTracesExportPartialSuccess()), dest)
 }
 
-func TestExportTracePartialSuccess_CopyTo(t *testing.T) {
-	ms := NewExportTracePartialSuccess()
-	orig := NewExportTracePartialSuccess()
+func TestExportPartialSuccess_CopyTo(t *testing.T) {
+	ms := NewExportPartialSuccess()
+	orig := NewExportPartialSuccess()
 	orig.CopyTo(ms)
 	assert.Equal(t, orig, ms)
-	orig = ExportTracePartialSuccess(internal.GenerateTestExportTracePartialSuccess())
+	orig = ExportPartialSuccess(internal.GenerateTestTracesExportPartialSuccess())
 	orig.CopyTo(ms)
 	assert.Equal(t, orig, ms)
 }
 
-func TestExportTracePartialSuccess_RejectedSpans(t *testing.T) {
-	ms := NewExportTracePartialSuccess()
+func TestExportPartialSuccess_RejectedSpans(t *testing.T) {
+	ms := NewExportPartialSuccess()
 	assert.Equal(t, int64(0), ms.RejectedSpans())
 	ms.SetRejectedSpans(int64(13))
 	assert.Equal(t, int64(13), ms.RejectedSpans())
 }
 
-func TestExportTracePartialSuccess_ErrorMessage(t *testing.T) {
-	ms := NewExportTracePartialSuccess()
+func TestExportPartialSuccess_ErrorMessage(t *testing.T) {
+	ms := NewExportPartialSuccess()
 	assert.Equal(t, "", ms.ErrorMessage())
 	ms.SetErrorMessage("error message")
 	assert.Equal(t, "error message", ms.ErrorMessage())

--- a/pdata/ptrace/ptraceotlp/response.go
+++ b/pdata/ptrace/ptraceotlp/response.go
@@ -56,8 +56,8 @@ func (ms ExportResponse) UnmarshalJSON(data []byte) error {
 }
 
 // PartialSuccess returns the ExportLogsPartialSuccess associated with this ExportResponse.
-func (ms ExportResponse) PartialSuccess() ExportTracePartialSuccess {
-	return ExportTracePartialSuccess(internal.NewExportTracePartialSuccess(&ms.orig.PartialSuccess))
+func (ms ExportResponse) PartialSuccess() ExportPartialSuccess {
+	return ExportPartialSuccess(internal.NewTracesExportPartialSuccess(&ms.orig.PartialSuccess))
 }
 
 // Deprecated: [v0.63.0] use ExportResponse.


### PR DESCRIPTION
Rename `p[trace|metric|log]otlp.Export[Trace|Metrics|Logs]PartialSuccess` to `p[trace|metric|log]otlp.ExportPartialSuccess` for simplicity and consistency with Export[Request|Response]

This doesn't need a deprection because `p[trace|metric|log]otlp.Export[Trace|Metrics|Logs]PartialSuccess` is not released yet.

Resolves https://github.com/open-telemetry/opentelemetry-collector/issues/6365