### PR TITLE
[test] Revert "[chore] Consistent pattern usage for command flags"

### DIFF
--- a/service/collector_windows.go
+++ b/service/collector_windows.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"os"
 	"time"
 
 	"go.uber.org/zap"
@@ -56,11 +57,6 @@ func (s *windowsService) Execute(args []string, requests <-chan svc.ChangeReques
 		return false, 1501 // 1501: ERROR_EVENTLOG_CANT_START
 	}
 
-	// Parse all the flags manually.
-	if err = s.flags.Parse(args[1:]); err != nil {
-		return false, 1639 // 1639: ERROR_INVALID_COMMAND_LINE
-	}
-
 	colErrorChannel := make(chan error, 1)
 
 	changes <- svc.Status{State: svc.StartPending}
@@ -93,7 +89,11 @@ func (s *windowsService) Execute(args []string, requests <-chan svc.ChangeReques
 }
 
 func (s *windowsService) start(elog *eventlog.Log, colErrorChannel chan error) error {
-	if err := featuregate.GetRegistry().Apply(getFeatureGatesFlag(s.flags)); err != nil {
+	// Parse all the args manually.
+	if err := s.flags.Parse(os.Args[1:]); err != nil {
+		return err
+	}
+	if err := featuregate.GetRegistry().Apply(gatesList); err != nil {
 		return err
 	}
 	var err error

--- a/service/collector_windows_test.go
+++ b/service/collector_windows_test.go
@@ -18,6 +18,7 @@
 package service
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -30,6 +31,10 @@ import (
 )
 
 func TestNewSvcHandler(t *testing.T) {
+	oldArgs := os.Args
+	defer func() { os.Args = oldArgs }()
+	os.Args = []string{"otelcol", "--config", filepath.Join("testdata", "otelcol-nop.yaml")}
+
 	factories, err := componenttest.NopFactories()
 	require.NoError(t, err)
 
@@ -40,7 +45,7 @@ func TestNewSvcHandler(t *testing.T) {
 	changes := make(chan svc.Status)
 	go func() {
 		defer close(colDone)
-		ssec, errno := s.Execute([]string{"otelcol", "--config", filepath.Join("testdata", "otelcol-nop.yaml")}, requests, changes)
+		ssec, errno := s.Execute([]string{"svc name"}, requests, changes)
 		assert.Equal(t, uint32(0), errno)
 		assert.False(t, ssec)
 	}()

--- a/service/command.go
+++ b/service/command.go
@@ -30,7 +30,7 @@ func NewCommand(set CollectorSettings) *cobra.Command {
 		Version:      set.BuildInfo.Version,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := featuregate.GetRegistry().Apply(getFeatureGatesFlag(flagSet)); err != nil {
+			if err := featuregate.GetRegistry().Apply(gatesList); err != nil {
 				return err
 			}
 			if set.ConfigProvider == nil {

--- a/service/flags.go
+++ b/service/flags.go
@@ -23,8 +23,12 @@ import (
 )
 
 const (
-	configFlag       = "config"
-	featureGatesFlag = "feature-gates"
+	configFlag = "config"
+)
+
+var (
+	// Command-line flag that control the configuration file.
+	gatesList = featuregate.FlagValue{}
 )
 
 type configFlagValue struct {
@@ -61,7 +65,9 @@ func flags() *flag.FlagSet {
 			return nil
 		})
 
-	flagSet.Var(featuregate.FlagValue{}, featureGatesFlag,
+	flagSet.Var(
+		gatesList,
+		"feature-gates",
 		"Comma-delimited list of feature gate identifiers. Prefix with '-' to disable the feature. '+' or no prefix will enable the feature.")
 
 	return flagSet
@@ -70,8 +76,4 @@ func flags() *flag.FlagSet {
 func getConfigFlag(flagSet *flag.FlagSet) []string {
 	cfv := flagSet.Lookup(configFlag).Value.(*configFlagValue)
 	return append(cfv.values, cfv.sets...)
-}
-
-func getFeatureGatesFlag(flagSet *flag.FlagSet) featuregate.FlagValue {
-	return flagSet.Lookup(featureGatesFlag).Value.(featuregate.FlagValue)
 }


### PR DESCRIPTION
Reverts open-telemetry/opentelemetry-collector#6285 as a test for open-telemetry/opentelemetry-collector-releases/issues/228