### PR TITLE
Revert how the args are parsed on windows

### DIFF
--- a/.chloggen/revertargs.yaml
+++ b/.chloggen/revertargs.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: service
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix running collector as a windows service.
+
+# One or more tracking issues or pull requests related to the change
+issues: [6433]

--- a/service/collector_windows.go
+++ b/service/collector_windows.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"os"
 	"time"
 
 	"go.uber.org/zap"
@@ -56,11 +57,6 @@ func (s *windowsService) Execute(args []string, requests <-chan svc.ChangeReques
 		return false, 1501 // 1501: ERROR_EVENTLOG_CANT_START
 	}
 
-	// Parse all the flags manually.
-	if err = s.flags.Parse(args[1:]); err != nil {
-		return false, 1639 // 1639: ERROR_INVALID_COMMAND_LINE
-	}
-
 	colErrorChannel := make(chan error, 1)
 
 	changes <- svc.Status{State: svc.StartPending}
@@ -93,6 +89,11 @@ func (s *windowsService) Execute(args []string, requests <-chan svc.ChangeReques
 }
 
 func (s *windowsService) start(elog *eventlog.Log, colErrorChannel chan error) error {
+	// Parse all the flags manually.
+	if err := s.flags.Parse(os.Args[1:]); err != nil {
+		return err
+	}
+
 	if err := featuregate.GetRegistry().Apply(getFeatureGatesFlag(s.flags)); err != nil {
 		return err
 	}

--- a/service/collector_windows_test.go
+++ b/service/collector_windows_test.go
@@ -18,6 +18,7 @@
 package service
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -30,6 +31,10 @@ import (
 )
 
 func TestNewSvcHandler(t *testing.T) {
+	oldArgs := os.Args
+	defer func() { os.Args = oldArgs }()
+	os.Args = []string{"otelcol", "--config", filepath.Join("testdata", "otelcol-nop.yaml")}
+
 	factories, err := componenttest.NopFactories()
 	require.NoError(t, err)
 
@@ -40,7 +45,7 @@ func TestNewSvcHandler(t *testing.T) {
 	changes := make(chan svc.Status)
 	go func() {
 		defer close(colDone)
-		ssec, errno := s.Execute([]string{"otelcol", "--config", filepath.Join("testdata", "otelcol-nop.yaml")}, requests, changes)
+		ssec, errno := s.Execute([]string{"svc name"}, requests, changes)
 		assert.Equal(t, uint32(0), errno)
 		assert.False(t, ssec)
 	}()


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-collector/issues/6433