### PR TITLE
flag --dry-run

### DIFF
--- a/.chloggen/dryrun.yaml
+++ b/.chloggen/dryrun.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: service
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: flag `--dry-run` exits the collector after component setup
+
+# One or more tracking issues or pull requests related to the change
+issues: [4613]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/service/collector.go
+++ b/service/collector.go
@@ -172,6 +172,11 @@ func (col *Collector) Run(ctx context.Context) error {
 		signal.Notify(col.signalsChannel, os.Interrupt, syscall.SIGTERM)
 	}
 
+	if col.set.DryRun {
+		col.service.telemetrySettings.Logger.Info("Dry run complete, terminating process")
+		return col.shutdown(ctx)
+	}
+
 LOOP:
 	for {
 		select {

--- a/service/command.go
+++ b/service/command.go
@@ -30,6 +30,7 @@ func NewCommand(set CollectorSettings) *cobra.Command {
 		Version:      set.BuildInfo.Version,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			set.DryRun = getDryRunFlag(flagSet)
 			if err := featuregate.GetRegistry().Apply(getFeatureGatesFlag(flagSet)); err != nil {
 				return err
 			}

--- a/service/flags.go
+++ b/service/flags.go
@@ -24,6 +24,7 @@ import (
 
 const (
 	configFlag       = "config"
+	dryRunFlag       = "dry-run"
 	featureGatesFlag = "feature-gates"
 )
 
@@ -48,6 +49,8 @@ func flags() *flag.FlagSet {
 	flagSet.Var(cfgs, configFlag, "Locations to the config file(s), note that only a"+
 		" single location can be set per flag entry e.g. `--config=file:/path/to/first --config=file:path/to/second`.")
 
+	flagSet.BoolVar(new(bool), dryRunFlag, false, "Dry run, setup components but don't run.")
+
 	flagSet.Func("set",
 		"Set arbitrary component config property. The component has to be defined in the config file and the flag"+
 			" has a higher precedence. Array config properties are overridden and maps are joined. Example --set=processors.batch.timeout=2s",
@@ -70,6 +73,10 @@ func flags() *flag.FlagSet {
 func getConfigFlag(flagSet *flag.FlagSet) []string {
 	cfv := flagSet.Lookup(configFlag).Value.(*configFlagValue)
 	return append(cfv.values, cfv.sets...)
+}
+
+func getDryRunFlag(flagSet *flag.FlagSet) bool {
+	return flagSet.Lookup(dryRunFlag).Value.(flag.Getter).Get().(bool)
 }
 
 func getFeatureGatesFlag(flagSet *flag.FlagSet) featuregate.FlagValue {

--- a/service/settings.go
+++ b/service/settings.go
@@ -55,6 +55,9 @@ type CollectorSettings struct {
 	// and manually handle the signals to shutdown the collector.
 	DisableGracefulShutdown bool
 
+	// DryRun shuts downthe collector immediately after components have been setup.
+	DryRun bool
+
 	// ConfigProvider provides the service configuration.
 	// If the provider watches for configuration change, collector may reload the new configuration upon changes.
 	ConfigProvider ConfigProvider


### PR DESCRIPTION
**Description:** <Describe what has changed. 

add a `--dry-run` flag allowing a faster feedback loop for invalid config

**Link to tracking Issue:** #4613 

**Testing:**

`TestCollectorDryRun`: test setting `DryRun` via `CollectorSettings` exits the collector quickly.

Manually built a collector with the builder and tried running it with the flag with both valid and invalid config.
