### PR TITLE
cgroups: accurate procfs parsing

### DIFF
--- a/.chloggen/cgroup-subsys-line-parse.yaml
+++ b/.chloggen/cgroup-subsys-line-parse.yaml
@@ -1,0 +1,7 @@
+change_type: bug_fix
+
+component: cgroups
+
+note: split line into exactly 3 parts while parsing /proc/{pid}/cgroup
+
+issues: [6389]

--- a/internal/cgroups/subsys.go
+++ b/internal/cgroups/subsys.go
@@ -70,7 +70,7 @@ type CGroupSubsys struct {
 // NewCGroupSubsysFromLine returns a new *CGroupSubsys by parsing a string in
 // the format of `/proc/$PID/cgroup`
 func NewCGroupSubsysFromLine(line string) (*CGroupSubsys, error) {
-	fields := strings.Split(line, _cgroupSep)
+	fields := strings.SplitN(line, _cgroupSep, _csFieldCount)
 
 	if len(fields) != _csFieldCount {
 		return nil, cgroupSubsysFormatInvalidError{line}

--- a/internal/cgroups/subsys_test.go
+++ b/internal/cgroups/subsys_test.go
@@ -70,6 +70,15 @@ func TestNewCGroupSubsysFromLine(t *testing.T) {
 				Name:       "/docker/1234567890abcdef",
 			},
 		},
+		{
+			name: "sophisticated-path",
+			line: "4:pids:/example.slice:extra-path-designator",
+			expectedSubsys: &CGroupSubsys{
+				ID:         4,
+				Subsystems: []string{"pids"},
+				Name:       "/example.slice:extra-path-designator",
+			},
+		},
 	}
 
 	for _, tt := range testTable {
@@ -82,7 +91,6 @@ func TestNewCGroupSubsysFromLine(t *testing.T) {
 func TestNewCGroupSubsysFromLineErr(t *testing.T) {
 	lines := []string{
 		"1:cpu",
-		"1:cpu,cpuacct:/:/necessary-field",
 		"not-a-number:cpu:/",
 	}
 	_, parseError := strconv.Atoi("not-a-number")
@@ -98,13 +106,8 @@ func TestNewCGroupSubsysFromLineErr(t *testing.T) {
 			expectedError: cgroupSubsysFormatInvalidError{lines[0]},
 		},
 		{
-			name:          "more-fields",
-			line:          lines[1],
-			expectedError: cgroupSubsysFormatInvalidError{lines[1]},
-		},
-		{
 			name:          "illegal-id",
-			line:          lines[2],
+			line:          lines[1],
 			expectedError: parseError,
 		},
 	}


### PR DESCRIPTION
**Description:** split line into exactly 3 parts while parsing /proc/{pid}/cgroup.

**Link to tracking Issue:** #6389

**Testing:** None

**Documentation:** None