### PR TITLE
deprecate `obsreport.New[Receiver|Scraper|Processor|Exporter]` in favor of `obsreport.MustNew*`

### DIFF
--- a/.chloggen/obsreport_new_methods.yaml
+++ b/.chloggen/obsreport_new_methods.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'deprecation'
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: obsreport
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "deprecate `obsreport.New[Receiver|Scraper|Processor|Exporter]` in favor of `obsreport.MustNew[Receiver|Scraper|Processor|Exporter]`"
+
+# One or more tracking issues or pull requests related to the change
+issues: [6458]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/exporter/exporterhelper/obsreport.go
+++ b/exporter/exporterhelper/obsreport.go
@@ -99,7 +99,7 @@ func newObsExporter(cfg obsreport.ExporterSettings, insts *instruments) *obsExpo
 	failedToEnqueueLogRecordsEntry, _ := insts.failedToEnqueueLogRecords.GetEntry(labelValue)
 
 	return &obsExporter{
-		Exporter:                         obsreport.NewExporter(cfg),
+		Exporter:                         obsreport.MustNewExporter(cfg),
 		failedToEnqueueTraceSpansEntry:   failedToEnqueueTraceSpansEntry,
 		failedToEnqueueMetricPointsEntry: failedToEnqueueMetricPointsEntry,
 		failedToEnqueueLogRecordsEntry:   failedToEnqueueLogRecordsEntry,

--- a/obsreport/obsreport_exporter.go
+++ b/obsreport/obsreport_exporter.go
@@ -64,8 +64,11 @@ type ExporterSettings struct {
 	ExporterCreateSettings component.ExporterCreateSettings
 }
 
-// NewExporter creates a new Exporter.
-func NewExporter(cfg ExporterSettings) *Exporter {
+// Deprecated: [v0.64.0] use MustNewExporter.
+var NewExporter = MustNewExporter
+
+// MustNewExporter creates a new Exporter.
+func MustNewExporter(cfg ExporterSettings) *Exporter {
 	return newExporter(cfg, featuregate.GetRegistry())
 }
 

--- a/obsreport/obsreport_exporter.go
+++ b/obsreport/obsreport_exporter.go
@@ -24,6 +24,7 @@ import (
 	"go.opentelemetry.io/otel/metric/instrument/syncint64"
 	"go.opentelemetry.io/otel/metric/unit"
 	"go.opentelemetry.io/otel/trace"
+	"go.uber.org/multierr"
 	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/component"
@@ -65,14 +66,26 @@ type ExporterSettings struct {
 }
 
 // Deprecated: [v0.64.0] use MustNewExporter.
-var NewExporter = MustNewExporter
+func NewExporter(cfg ExporterSettings) *Exporter {
+	exp, err := newExporter(cfg, featuregate.GetRegistry())
+	if err != nil && cfg.ExporterCreateSettings.Logger != nil {
+		cfg.ExporterCreateSettings.Logger.Warn("Error creating an obsreport.Exporter", zap.Error(err))
+	}
+
+	return exp
+}
 
 // MustNewExporter creates a new Exporter.
 func MustNewExporter(cfg ExporterSettings) *Exporter {
-	return newExporter(cfg, featuregate.GetRegistry())
+	exp, err := newExporter(cfg, featuregate.GetRegistry())
+	if err != nil {
+		panic(err)
+	}
+
+	return exp
 }
 
-func newExporter(cfg ExporterSettings, registry *featuregate.Registry) *Exporter {
+func newExporter(cfg ExporterSettings, registry *featuregate.Registry) (*Exporter, error) {
 	exp := &Exporter{
 		level:          cfg.ExporterCreateSettings.TelemetrySettings.MetricsLevel,
 		spanNamePrefix: obsmetrics.ExporterPrefix + cfg.ExporterID.String(),
@@ -86,58 +99,58 @@ func newExporter(cfg ExporterSettings, registry *featuregate.Registry) *Exporter
 		},
 	}
 
-	exp.createOtelMetrics(cfg)
+	if err := exp.createOtelMetrics(cfg); err != nil {
+		return nil, err
+	}
 
-	return exp
+	return exp, nil
 }
 
-func (exp *Exporter) createOtelMetrics(cfg ExporterSettings) {
+func (exp *Exporter) createOtelMetrics(cfg ExporterSettings) error {
 	if !exp.useOtelForMetrics {
-		return
+		return nil
 	}
 	meter := cfg.ExporterCreateSettings.MeterProvider.Meter(exporterScope)
 
-	var err error
-	handleError := func(metricName string, err error) {
-		if err != nil {
-			exp.logger.Warn("failed to create otel instrument", zap.Error(err), zap.String("metric", metricName))
-		}
-	}
+	var errors, err error
+
 	exp.sentSpans, err = meter.SyncInt64().Counter(
 		obsmetrics.ExporterPrefix+obsmetrics.SentSpansKey,
 		instrument.WithDescription("Number of spans successfully sent to destination."),
 		instrument.WithUnit(unit.Dimensionless))
-	handleError(obsmetrics.ExporterPrefix+obsmetrics.SentSpansKey, err)
+	errors = multierr.Append(errors, err)
 
 	exp.failedToSendSpans, err = meter.SyncInt64().Counter(
 		obsmetrics.ExporterPrefix+obsmetrics.FailedToSendSpansKey,
 		instrument.WithDescription("Number of spans in failed attempts to send to destination."),
 		instrument.WithUnit(unit.Dimensionless))
-	handleError(obsmetrics.ExporterPrefix+obsmetrics.FailedToSendSpansKey, err)
+	errors = multierr.Append(errors, err)
 
 	exp.sentMetricPoints, err = meter.SyncInt64().Counter(
 		obsmetrics.ExporterPrefix+obsmetrics.SentMetricPointsKey,
 		instrument.WithDescription("Number of metric points successfully sent to destination."),
 		instrument.WithUnit(unit.Dimensionless))
-	handleError(obsmetrics.ExporterPrefix+obsmetrics.SentMetricPointsKey, err)
+	errors = multierr.Append(errors, err)
 
 	exp.failedToSendMetricPoints, err = meter.SyncInt64().Counter(
 		obsmetrics.ExporterPrefix+obsmetrics.FailedToSendMetricPointsKey,
 		instrument.WithDescription("Number of metric points in failed attempts to send to destination."),
 		instrument.WithUnit(unit.Dimensionless))
-	handleError(obsmetrics.ExporterPrefix+obsmetrics.FailedToSendMetricPointsKey, err)
+	errors = multierr.Append(errors, err)
 
 	exp.sentLogRecords, err = meter.SyncInt64().Counter(
 		obsmetrics.ExporterPrefix+obsmetrics.SentLogRecordsKey,
 		instrument.WithDescription("Number of log record successfully sent to destination."),
 		instrument.WithUnit(unit.Dimensionless))
-	handleError(obsmetrics.ExporterPrefix+obsmetrics.SentLogRecordsKey, err)
+	errors = multierr.Append(errors, err)
 
 	exp.failedToSendLogRecords, err = meter.SyncInt64().Counter(
 		obsmetrics.ExporterPrefix+obsmetrics.FailedToSendLogRecordsKey,
 		instrument.WithDescription("Number of log records in failed attempts to send to destination."),
 		instrument.WithUnit(unit.Dimensionless))
-	handleError(obsmetrics.ExporterPrefix+obsmetrics.FailedToSendLogRecordsKey, err)
+	errors = multierr.Append(errors, err)
+
+	return errors
 }
 
 // StartTracesOp is called at the start of an Export operation.

--- a/obsreport/obsreport_processor.go
+++ b/obsreport/obsreport_processor.go
@@ -53,8 +53,11 @@ type ProcessorSettings struct {
 	ProcessorCreateSettings component.ProcessorCreateSettings
 }
 
-// NewProcessor creates a new Processor.
-func NewProcessor(cfg ProcessorSettings) *Processor {
+// Deprecated: [v0.64.0] use MustNewProcessor.
+var NewProcessor = MustNewProcessor
+
+// MustNewProcessor creates a new Processor.
+func MustNewProcessor(cfg ProcessorSettings) *Processor {
 	return &Processor{
 		level:    cfg.ProcessorCreateSettings.MetricsLevel,
 		mutators: []tag.Mutator{tag.Upsert(obsmetrics.TagKeyProcessor, cfg.ProcessorID.String(), tag.WithTTL(tag.TTLNoPropagation))},

--- a/obsreport/obsreport_receiver.go
+++ b/obsreport/obsreport_receiver.go
@@ -25,6 +25,7 @@ import (
 	"go.opentelemetry.io/otel/metric/instrument/syncint64"
 	"go.opentelemetry.io/otel/metric/unit"
 	"go.opentelemetry.io/otel/trace"
+	"go.uber.org/multierr"
 	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/component"
@@ -77,14 +78,25 @@ type ReceiverSettings struct {
 }
 
 // Deprecated: [v0.64.0] use MustNewReceiver.
-var NewReceiver = MustNewReceiver
+func NewReceiver(cfg ReceiverSettings) *Receiver {
+	rcv, err := newReceiver(cfg, featuregate.GetRegistry())
+	if err != nil && cfg.ReceiverCreateSettings.Logger != nil {
+		cfg.ReceiverCreateSettings.Logger.Warn("Error creating an obsreport.Exporter", zap.Error(err))
+	}
+	return rcv
+}
 
 // MustNewReceiver creates a new Receiver.
 func MustNewReceiver(cfg ReceiverSettings) *Receiver {
-	return newReceiver(cfg, featuregate.GetRegistry())
+	rcv, err := newReceiver(cfg, featuregate.GetRegistry())
+	if err != nil {
+		panic(err)
+	}
+
+	return rcv
 }
 
-func newReceiver(cfg ReceiverSettings, registry *featuregate.Registry) *Receiver {
+func newReceiver(cfg ReceiverSettings, registry *featuregate.Registry) (*Receiver, error) {
 	rec := &Receiver{
 		level:          cfg.ReceiverCreateSettings.TelemetrySettings.MetricsLevel,
 		spanNamePrefix: obsmetrics.ReceiverPrefix + cfg.ReceiverID.String(),
@@ -105,64 +117,63 @@ func newReceiver(cfg ReceiverSettings, registry *featuregate.Registry) *Receiver
 		},
 	}
 
-	rec.createOtelMetrics()
+	if err := rec.createOtelMetrics(); err != nil {
+		return nil, err
+	}
 
-	return rec
+	return rec, nil
 }
 
-func (rec *Receiver) createOtelMetrics() {
+func (rec *Receiver) createOtelMetrics() error {
 	if !rec.useOtelForMetrics {
-		return
+		return nil
 	}
 
-	var err error
-	handleError := func(metricName string, err error) {
-		if err != nil {
-			rec.logger.Warn("failed to create otel instrument", zap.Error(err), zap.String("metric", metricName))
-		}
-	}
+	var errors, err error
 
 	rec.acceptedSpansCounter, err = rec.meter.SyncInt64().Counter(
 		obsmetrics.ReceiverPrefix+obsmetrics.AcceptedSpansKey,
 		instrument.WithDescription("Number of spans successfully pushed into the pipeline."),
 		instrument.WithUnit(unit.Dimensionless),
 	)
-	handleError(obsmetrics.ReceiverPrefix+obsmetrics.AcceptedSpansKey, err)
+	errors = multierr.Append(errors, err)
 
 	rec.refusedSpansCounter, err = rec.meter.SyncInt64().Counter(
 		obsmetrics.ReceiverPrefix+obsmetrics.RefusedSpansKey,
 		instrument.WithDescription("Number of spans that could not be pushed into the pipeline."),
 		instrument.WithUnit(unit.Dimensionless),
 	)
-	handleError(obsmetrics.ReceiverPrefix+obsmetrics.RefusedSpansKey, err)
+	errors = multierr.Append(errors, err)
 
 	rec.acceptedMetricPointsCounter, err = rec.meter.SyncInt64().Counter(
 		obsmetrics.ReceiverPrefix+obsmetrics.AcceptedMetricPointsKey,
 		instrument.WithDescription("Number of metric points successfully pushed into the pipeline."),
 		instrument.WithUnit(unit.Dimensionless),
 	)
-	handleError(obsmetrics.ReceiverPrefix+obsmetrics.AcceptedMetricPointsKey, err)
+	errors = multierr.Append(errors, err)
 
 	rec.refusedMetricPointsCounter, err = rec.meter.SyncInt64().Counter(
 		obsmetrics.ReceiverPrefix+obsmetrics.RefusedMetricPointsKey,
 		instrument.WithDescription("Number of metric points that could not be pushed into the pipeline."),
 		instrument.WithUnit(unit.Dimensionless),
 	)
-	handleError(obsmetrics.ReceiverPrefix+obsmetrics.RefusedMetricPointsKey, err)
+	errors = multierr.Append(errors, err)
 
 	rec.acceptedLogRecordsCounter, err = rec.meter.SyncInt64().Counter(
 		obsmetrics.ReceiverPrefix+obsmetrics.AcceptedLogRecordsKey,
 		instrument.WithDescription("Number of log records successfully pushed into the pipeline."),
 		instrument.WithUnit(unit.Dimensionless),
 	)
-	handleError(obsmetrics.ReceiverPrefix+obsmetrics.AcceptedLogRecordsKey, err)
+	errors = multierr.Append(errors, err)
 
 	rec.refusedLogRecordsCounter, err = rec.meter.SyncInt64().Counter(
 		obsmetrics.ReceiverPrefix+obsmetrics.RefusedLogRecordsKey,
 		instrument.WithDescription("Number of log records that could not be pushed into the pipeline."),
 		instrument.WithUnit(unit.Dimensionless),
 	)
-	handleError(obsmetrics.ReceiverPrefix+obsmetrics.RefusedLogRecordsKey, err)
+	errors = multierr.Append(errors, err)
+
+	return errors
 }
 
 // StartTracesOp is called when a request is received from a client.

--- a/obsreport/obsreport_receiver.go
+++ b/obsreport/obsreport_receiver.go
@@ -81,7 +81,7 @@ type ReceiverSettings struct {
 func NewReceiver(cfg ReceiverSettings) *Receiver {
 	rcv, err := newReceiver(cfg, featuregate.GetRegistry())
 	if err != nil && cfg.ReceiverCreateSettings.Logger != nil {
-		cfg.ReceiverCreateSettings.Logger.Warn("Error creating an obsreport.Exporter", zap.Error(err))
+		cfg.ReceiverCreateSettings.Logger.Warn("Error creating an obsreport.Receiver", zap.Error(err))
 	}
 	return rcv
 }

--- a/obsreport/obsreport_receiver.go
+++ b/obsreport/obsreport_receiver.go
@@ -76,8 +76,11 @@ type ReceiverSettings struct {
 	ReceiverCreateSettings component.ReceiverCreateSettings
 }
 
-// NewReceiver creates a new Receiver.
-func NewReceiver(cfg ReceiverSettings) *Receiver {
+// Deprecated: [v0.64.0] use MustNewReceiver.
+var NewReceiver = MustNewReceiver
+
+// MustNewReceiver creates a new Receiver.
+func MustNewReceiver(cfg ReceiverSettings) *Receiver {
 	return newReceiver(cfg, featuregate.GetRegistry())
 }
 

--- a/obsreport/obsreport_scraper.go
+++ b/obsreport/obsreport_scraper.go
@@ -46,8 +46,11 @@ type ScraperSettings struct {
 	ReceiverCreateSettings component.ReceiverCreateSettings
 }
 
-// NewScraper creates a new Scraper.
-func NewScraper(cfg ScraperSettings) *Scraper {
+// Deprecated: [v0.64.0] use MustNewScraper.
+var NewScraper = MustNewScraper
+
+// MustNewScraper creates a new Scraper.
+func MustNewScraper(cfg ScraperSettings) *Scraper {
 	return &Scraper{
 		level:      cfg.ReceiverCreateSettings.TelemetrySettings.MetricsLevel,
 		receiverID: cfg.ReceiverID,

--- a/obsreport/obsreport_test.go
+++ b/obsreport/obsreport_test.go
@@ -227,7 +227,7 @@ func TestScrapeMetricsDataOp(t *testing.T) {
 		{items: 15, err: nil},
 	}
 	for i := range params {
-		scrp := NewScraper(ScraperSettings{
+		scrp := MustNewScraper(ScraperSettings{
 			ReceiverID:             receiver,
 			Scraper:                scraper,
 			ReceiverCreateSettings: tt.ToReceiverCreateSettings(),
@@ -430,7 +430,7 @@ func TestReceiveWithLongLivedCtx(t *testing.T) {
 	for i := range params {
 		// Use a new context on each operation to simulate distinct operations
 		// under the same long lived context.
-		rec := NewReceiver(ReceiverSettings{
+		rec := MustNewReceiver(ReceiverSettings{
 			ReceiverID:             receiver,
 			Transport:              transport,
 			LongLivedCtx:           true,
@@ -477,7 +477,7 @@ func TestProcessorTraceData(t *testing.T) {
 	const refusedSpans = 19
 	const droppedSpans = 13
 
-	obsrep := NewProcessor(ProcessorSettings{
+	obsrep := MustNewProcessor(ProcessorSettings{
 		ProcessorID:             processor,
 		ProcessorCreateSettings: tt.ToProcessorCreateSettings(),
 	})
@@ -497,7 +497,7 @@ func TestProcessorMetricsData(t *testing.T) {
 	const refusedPoints = 11
 	const droppedPoints = 17
 
-	obsrep := NewProcessor(ProcessorSettings{
+	obsrep := MustNewProcessor(ProcessorSettings{
 		ProcessorID:             processor,
 		ProcessorCreateSettings: tt.ToProcessorCreateSettings(),
 	})
@@ -539,7 +539,7 @@ func TestProcessorLogRecords(t *testing.T) {
 	const refusedRecords = 11
 	const droppedRecords = 17
 
-	obsrep := NewProcessor(ProcessorSettings{
+	obsrep := MustNewProcessor(ProcessorSettings{
 		ProcessorID:             processor,
 		ProcessorCreateSettings: tt.ToProcessorCreateSettings(),
 	})

--- a/obsreport/obsreport_test.go
+++ b/obsreport/obsreport_test.go
@@ -84,11 +84,12 @@ func TestReceiveTraceDataOp(t *testing.T) {
 			{items: 42, err: nil},
 		}
 		for i, param := range params {
-			rec := newReceiver(ReceiverSettings{
+			rec, err := newReceiver(ReceiverSettings{
 				ReceiverID:             receiver,
 				Transport:              transport,
 				ReceiverCreateSettings: tt.ToReceiverCreateSettings(),
 			}, registry)
+			require.NoError(t, err)
 			ctx := rec.StartTracesOp(parentCtx)
 			assert.NotNil(t, ctx)
 			rec.EndTracesOp(ctx, format, params[i].items, param.err)
@@ -130,11 +131,13 @@ func TestReceiveLogsOp(t *testing.T) {
 			{items: 42, err: nil},
 		}
 		for i, param := range params {
-			rec := newReceiver(ReceiverSettings{
+			rec, err := newReceiver(ReceiverSettings{
 				ReceiverID:             receiver,
 				Transport:              transport,
 				ReceiverCreateSettings: tt.ToReceiverCreateSettings(),
 			}, registry)
+			require.NoError(t, err)
+
 			ctx := rec.StartLogsOp(parentCtx)
 			assert.NotNil(t, ctx)
 			rec.EndLogsOp(ctx, format, params[i].items, param.err)
@@ -176,11 +179,13 @@ func TestReceiveMetricsOp(t *testing.T) {
 			{items: 29, err: nil},
 		}
 		for i, param := range params {
-			rec := newReceiver(ReceiverSettings{
+			rec, err := newReceiver(ReceiverSettings{
 				ReceiverID:             receiver,
 				Transport:              transport,
 				ReceiverCreateSettings: tt.ToReceiverCreateSettings(),
 			}, registry)
+			require.NoError(t, err)
+
 			ctx := rec.StartMetricsOp(parentCtx)
 			assert.NotNil(t, ctx)
 			rec.EndMetricsOp(ctx, format, params[i].items, param.err)
@@ -276,10 +281,11 @@ func TestExportTraceDataOp(t *testing.T) {
 		parentCtx, parentSpan := tt.TracerProvider.Tracer("test").Start(context.Background(), t.Name())
 		defer parentSpan.End()
 
-		obsrep := newExporter(ExporterSettings{
+		obsrep, err := newExporter(ExporterSettings{
 			ExporterID:             exporter,
 			ExporterCreateSettings: tt.ToExporterCreateSettings(),
 		}, registry)
+		require.NoError(t, err)
 
 		params := []testParams{
 			{items: 22, err: nil},
@@ -324,10 +330,11 @@ func TestExportMetricsOp(t *testing.T) {
 		parentCtx, parentSpan := tt.TracerProvider.Tracer("test").Start(context.Background(), t.Name())
 		defer parentSpan.End()
 
-		obsrep := newExporter(ExporterSettings{
+		obsrep, err := newExporter(ExporterSettings{
 			ExporterID:             exporter,
 			ExporterCreateSettings: tt.ToExporterCreateSettings(),
 		}, registry)
+		require.NoError(t, err)
 
 		params := []testParams{
 			{items: 17, err: nil},
@@ -372,10 +379,11 @@ func TestExportLogsOp(t *testing.T) {
 		parentCtx, parentSpan := tt.TracerProvider.Tracer("test").Start(context.Background(), t.Name())
 		defer parentSpan.End()
 
-		obsrep := newExporter(ExporterSettings{
+		obsrep, err := newExporter(ExporterSettings{
 			ExporterID:             exporter,
 			ExporterCreateSettings: tt.ToExporterCreateSettings(),
 		}, registry)
+		require.NoError(t, err)
 
 		params := []testParams{
 			{items: 17, err: nil},

--- a/obsreport/obsreporttest/obsreporttest_test.go
+++ b/obsreport/obsreporttest/obsreporttest_test.go
@@ -41,7 +41,7 @@ func TestCheckReceiverTracesViews(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
-	rec := obsreport.NewReceiver(obsreport.ReceiverSettings{
+	rec := obsreport.MustNewReceiver(obsreport.ReceiverSettings{
 		ReceiverID:             receiver,
 		Transport:              transport,
 		ReceiverCreateSettings: tt.ToReceiverCreateSettings(),
@@ -61,7 +61,7 @@ func TestCheckReceiverMetricsViews(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
-	rec := obsreport.NewReceiver(obsreport.ReceiverSettings{
+	rec := obsreport.MustNewReceiver(obsreport.ReceiverSettings{
 		ReceiverID:             receiver,
 		Transport:              transport,
 		ReceiverCreateSettings: tt.ToReceiverCreateSettings(),
@@ -81,7 +81,7 @@ func TestCheckReceiverLogsViews(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
-	rec := obsreport.NewReceiver(obsreport.ReceiverSettings{
+	rec := obsreport.MustNewReceiver(obsreport.ReceiverSettings{
 		ReceiverID:             receiver,
 		Transport:              transport,
 		ReceiverCreateSettings: tt.ToReceiverCreateSettings(),
@@ -101,7 +101,7 @@ func TestCheckExporterTracesViews(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
-	obsrep := obsreport.NewExporter(obsreport.ExporterSettings{
+	obsrep := obsreport.MustNewExporter(obsreport.ExporterSettings{
 		ExporterID:             exporter,
 		ExporterCreateSettings: tt.ToExporterCreateSettings(),
 	})
@@ -120,7 +120,7 @@ func TestCheckExporterMetricsViews(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
-	obsrep := obsreport.NewExporter(obsreport.ExporterSettings{
+	obsrep := obsreport.MustNewExporter(obsreport.ExporterSettings{
 		ExporterID:             exporter,
 		ExporterCreateSettings: tt.ToExporterCreateSettings(),
 	})
@@ -139,7 +139,7 @@ func TestCheckExporterLogsViews(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
-	obsrep := obsreport.NewExporter(obsreport.ExporterSettings{
+	obsrep := obsreport.MustNewExporter(obsreport.ExporterSettings{
 		ExporterID:             exporter,
 		ExporterCreateSettings: tt.ToExporterCreateSettings(),
 	})

--- a/processor/memorylimiterprocessor/memorylimiter.go
+++ b/processor/memorylimiterprocessor/memorylimiter.go
@@ -122,7 +122,7 @@ func newMemoryLimiter(set component.ProcessorCreateSettings, cfg *Config) (*memo
 		readMemStatsFn: runtime.ReadMemStats,
 		logger:         logger,
 		forceDrop:      atomic.NewBool(false),
-		obsrep: obsreport.NewProcessor(obsreport.ProcessorSettings{
+		obsrep: obsreport.MustNewProcessor(obsreport.ProcessorSettings{
 			ProcessorID:             cfg.ID(),
 			ProcessorCreateSettings: set,
 		}),

--- a/processor/memorylimiterprocessor/memorylimiter_test.go
+++ b/processor/memorylimiterprocessor/memorylimiter_test.go
@@ -458,5 +458,5 @@ func newObsReport() *obsreport.Processor {
 	}
 	set.ProcessorCreateSettings.MetricsLevel = configtelemetry.LevelNone
 
-	return obsreport.NewProcessor(set)
+	return obsreport.MustNewProcessor(set)
 }

--- a/receiver/otlpreceiver/internal/logs/otlp.go
+++ b/receiver/otlpreceiver/internal/logs/otlp.go
@@ -39,7 +39,7 @@ type Receiver struct {
 func New(id config.ComponentID, nextConsumer consumer.Logs, set component.ReceiverCreateSettings) *Receiver {
 	return &Receiver{
 		nextConsumer: nextConsumer,
-		obsrecv: obsreport.NewReceiver(obsreport.ReceiverSettings{
+		obsrecv: obsreport.MustNewReceiver(obsreport.ReceiverSettings{
 			ReceiverID:             id,
 			Transport:              receiverTransport,
 			ReceiverCreateSettings: set,

--- a/receiver/otlpreceiver/internal/metrics/otlp.go
+++ b/receiver/otlpreceiver/internal/metrics/otlp.go
@@ -39,7 +39,7 @@ type Receiver struct {
 func New(id config.ComponentID, nextConsumer consumer.Metrics, set component.ReceiverCreateSettings) *Receiver {
 	return &Receiver{
 		nextConsumer: nextConsumer,
-		obsrecv: obsreport.NewReceiver(obsreport.ReceiverSettings{
+		obsrecv: obsreport.MustNewReceiver(obsreport.ReceiverSettings{
 			ReceiverID:             id,
 			Transport:              receiverTransport,
 			ReceiverCreateSettings: set,

--- a/receiver/otlpreceiver/internal/trace/otlp.go
+++ b/receiver/otlpreceiver/internal/trace/otlp.go
@@ -39,7 +39,7 @@ type Receiver struct {
 func New(id config.ComponentID, nextConsumer consumer.Traces, set component.ReceiverCreateSettings) *Receiver {
 	return &Receiver{
 		nextConsumer: nextConsumer,
-		obsrecv: obsreport.NewReceiver(obsreport.ReceiverSettings{
+		obsrecv: obsreport.MustNewReceiver(obsreport.ReceiverSettings{
 			ReceiverID:             id,
 			Transport:              receiverTransport,
 			ReceiverCreateSettings: set,

--- a/receiver/scraperhelper/scrapercontroller.go
+++ b/receiver/scraperhelper/scrapercontroller.go
@@ -110,7 +110,7 @@ func NewScraperControllerReceiver(
 		nextConsumer:       nextConsumer,
 		done:               make(chan struct{}),
 		terminated:         make(chan struct{}),
-		obsrecv: obsreport.NewReceiver(obsreport.ReceiverSettings{
+		obsrecv: obsreport.MustNewReceiver(obsreport.ReceiverSettings{
 			ReceiverID:             cfg.ID(),
 			Transport:              "",
 			ReceiverCreateSettings: set,
@@ -185,7 +185,7 @@ func (sc *controller) scrapeMetricsAndReport(ctx context.Context) {
 	metrics := pmetric.NewMetrics()
 
 	for _, scraper := range sc.scrapers {
-		scrp := obsreport.NewScraper(obsreport.ScraperSettings{
+		scrp := obsreport.MustNewScraper(obsreport.ScraperSettings{
 			ReceiverID:             sc.id,
 			Scraper:                scraper.ID(),
 			ReceiverCreateSettings: sc.recvSettings,


### PR DESCRIPTION
**Description:** As the `obsreport.[Receiver|Scraper|Processor|Exporter]` starts to use otel go, we need to return an error if one happens during the creation of otel go metrics. This is the first part for adding `error` as a return of these functions.

**Link to tracking Issue:** #6458

