### PR TITLE
[chore] update go.mod for new modules

### DIFF
--- a/extension/ballastextension/go.mod
+++ b/extension/ballastextension/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/stretchr/testify v1.8.1
-	go.opentelemetry.io/collector v0.0.0-00010101000000-000000000000
+	go.opentelemetry.io/collector v0.63.1
 	go.uber.org/zap v1.23.0
 )
 

--- a/extension/zpagesextension/go.mod
+++ b/extension/zpagesextension/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/stretchr/testify v1.8.1
-	go.opentelemetry.io/collector v0.0.0-00010101000000-000000000000
+	go.opentelemetry.io/collector v0.63.1
 	go.opentelemetry.io/contrib/zpages v0.36.4
 	go.opentelemetry.io/otel/sdk v1.11.1
 	go.opentelemetry.io/otel/trace v1.11.1

--- a/go.mod
+++ b/go.mod
@@ -20,8 +20,8 @@ require (
 	github.com/spf13/cobra v1.6.1
 	github.com/stretchr/testify v1.8.1
 	go.opencensus.io v0.23.0
-	go.opentelemetry.io/collector/extension/ballastextension v0.63.1
-	go.opentelemetry.io/collector/extension/zpagesextension v0.63.1
+	go.opentelemetry.io/collector/extension/ballastextension v0.0.0-00010101000000-000000000000
+	go.opentelemetry.io/collector/extension/zpagesextension v0.0.0-00010101000000-000000000000
 	go.opentelemetry.io/collector/pdata v0.63.1
 	go.opentelemetry.io/collector/semconv v0.63.1
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.36.4

--- a/receiver/otlpreceiver/go.mod
+++ b/receiver/otlpreceiver/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/gogo/protobuf v1.3.2
 	github.com/stretchr/testify v1.8.1
-	go.opentelemetry.io/collector v0.0.0-00010101000000-000000000000
+	go.opentelemetry.io/collector v0.63.1
 	go.opentelemetry.io/collector/pdata v0.63.1
 	go.opentelemetry.io/collector/semconv v0.63.1
 	go.uber.org/zap v1.23.0


### PR DESCRIPTION
These were requiring an invalid version of the collector (which was overwritten via replace statements in the module) but causes any modules that include them to require the invalid version of the collector.
