### PR TITLE
[extension/authextension] define new authextension package and use new package in collector repo

### DIFF
--- a/.chloggen/move-configauth-to-extension-step-1.yaml
+++ b/.chloggen/move-configauth-to-extension-step-1.yaml
@@ -1,0 +1,12 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: extension/authextension
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Define new authextension package and use new package in collector repo
+
+# One or more tracking issues or pull requests related to the change
+issues: [6467]
+

--- a/config/configauth/configauth.go
+++ b/config/configauth/configauth.go
@@ -33,9 +33,9 @@ type Authentication struct {
 	AuthenticatorID component.ID `mapstructure:"authenticator"`
 }
 
-// GetServer attempts to select the appropriate Server from the list of extensions,
+// GetServerAuthenticator attempts to select the appropriate ServerAuthenticator from the list of extensions,
 // based on the requested extension name. If an authenticator is not found, an error is returned.
-func (a Authentication) GetServer(extensions map[component.ID]component.Component) (ServerAuthenticator, error) {
+func (a Authentication) GetServerAuthenticator(extensions map[component.ID]component.Component) (ServerAuthenticator, error) {
 	if ext, found := extensions[a.AuthenticatorID]; found {
 		if auth, ok := ext.(ServerAuthenticator); ok {
 			return auth, nil
@@ -46,10 +46,10 @@ func (a Authentication) GetServer(extensions map[component.ID]component.Componen
 	return nil, fmt.Errorf("failed to resolve authenticator %q: %w", a.AuthenticatorID, errAuthenticatorNotFound)
 }
 
-// GetClient attempts to select the appropriate Client from the list of extensions,
+// GetClientAuthenticator attempts to select the appropriate ClientAuthenticator from the list of extensions,
 // based on the component id of the extension. If an authenticator is not found, an error is returned.
 // This should be only used by HTTP clients.
-func (a Authentication) GetClient(extensions map[component.ID]component.Component) (ClientAuthenticator, error) {
+func (a Authentication) GetClientAuthenticator(extensions map[component.ID]component.Component) (ClientAuthenticator, error) {
 	if ext, found := extensions[a.AuthenticatorID]; found {
 		if auth, ok := ext.(ClientAuthenticator); ok {
 			return auth, nil

--- a/config/configauth/configauth.go
+++ b/config/configauth/configauth.go
@@ -27,15 +27,15 @@ var (
 	errNotServer             = errors.New("requested authenticator is not a server authenticator")
 )
 
-// Settings defines the auth settings for the receiver.
-type Settings struct {
+// Authentication defines the auth settings for the receiver.
+type Authentication struct {
 	// AuthenticatorID specifies the name of the extension to use in order to authenticate the incoming data point.
 	AuthenticatorID component.ID `mapstructure:"authenticator"`
 }
 
 // GetServer attempts to select the appropriate Server from the list of extensions,
 // based on the requested extension name. If an authenticator is not found, an error is returned.
-func (a Settings) GetServer(extensions map[component.ID]component.Component) (ServerAuthenticator, error) {
+func (a Authentication) GetServer(extensions map[component.ID]component.Component) (ServerAuthenticator, error) {
 	if ext, found := extensions[a.AuthenticatorID]; found {
 		if auth, ok := ext.(ServerAuthenticator); ok {
 			return auth, nil
@@ -49,7 +49,7 @@ func (a Settings) GetServer(extensions map[component.ID]component.Component) (Se
 // GetClient attempts to select the appropriate Client from the list of extensions,
 // based on the component id of the extension. If an authenticator is not found, an error is returned.
 // This should be only used by HTTP clients.
-func (a Settings) GetClient(extensions map[component.ID]component.Component) (ClientAuthenticator, error) {
+func (a Authentication) GetClient(extensions map[component.ID]component.Component) (ClientAuthenticator, error) {
 	if ext, found := extensions[a.AuthenticatorID]; found {
 		if auth, ok := ext.(ClientAuthenticator); ok {
 			return auth, nil

--- a/config/configauth/configauth.go
+++ b/config/configauth/configauth.go
@@ -22,39 +22,39 @@ import (
 )
 
 var (
-	errAuthenticatorNotFound  = errors.New("authenticator not found")
-	errNotClientAuthenticator = errors.New("requested authenticator is not a client authenticator")
-	errNotServerAuthenticator = errors.New("requested authenticator is not a server authenticator")
+	errAuthenticatorNotFound = errors.New("authenticator not found")
+	errNotClient             = errors.New("requested authenticator is not a client authenticator")
+	errNotServer             = errors.New("requested authenticator is not a server authenticator")
 )
 
-// Authentication defines the auth settings for the receiver.
-type Authentication struct {
+// Settings defines the auth settings for the receiver.
+type Settings struct {
 	// AuthenticatorID specifies the name of the extension to use in order to authenticate the incoming data point.
 	AuthenticatorID component.ID `mapstructure:"authenticator"`
 }
 
-// GetServerAuthenticator attempts to select the appropriate ServerAuthenticator from the list of extensions,
+// GetServer attempts to select the appropriate Server from the list of extensions,
 // based on the requested extension name. If an authenticator is not found, an error is returned.
-func (a Authentication) GetServerAuthenticator(extensions map[component.ID]component.Component) (ServerAuthenticator, error) {
+func (a Settings) GetServer(extensions map[component.ID]component.Component) (ServerAuthenticator, error) {
 	if ext, found := extensions[a.AuthenticatorID]; found {
 		if auth, ok := ext.(ServerAuthenticator); ok {
 			return auth, nil
 		}
-		return nil, errNotServerAuthenticator
+		return nil, errNotServer
 	}
 
 	return nil, fmt.Errorf("failed to resolve authenticator %q: %w", a.AuthenticatorID, errAuthenticatorNotFound)
 }
 
-// GetClientAuthenticator attempts to select the appropriate ClientAuthenticator from the list of extensions,
+// GetClient attempts to select the appropriate Client from the list of extensions,
 // based on the component id of the extension. If an authenticator is not found, an error is returned.
 // This should be only used by HTTP clients.
-func (a Authentication) GetClientAuthenticator(extensions map[component.ID]component.Component) (ClientAuthenticator, error) {
+func (a Settings) GetClient(extensions map[component.ID]component.Component) (ClientAuthenticator, error) {
 	if ext, found := extensions[a.AuthenticatorID]; found {
 		if auth, ok := ext.(ClientAuthenticator); ok {
 			return auth, nil
 		}
-		return nil, errNotClientAuthenticator
+		return nil, errNotClient
 	}
 	return nil, fmt.Errorf("failed to resolve authenticator %q: %w", a.AuthenticatorID, errAuthenticatorNotFound)
 }

--- a/config/configauth/configauth_test.go
+++ b/config/configauth/configauth_test.go
@@ -42,7 +42,7 @@ func TestGetServer(t *testing.T) {
 	for _, tC := range testCases {
 		t.Run(tC.desc, func(t *testing.T) {
 			// prepare
-			cfg := &Settings{
+			cfg := &Authentication{
 				AuthenticatorID: component.NewID("mock"),
 			}
 			ext := map[component.ID]component.Component{
@@ -64,7 +64,7 @@ func TestGetServer(t *testing.T) {
 }
 
 func TestGetServerFails(t *testing.T) {
-	cfg := &Settings{
+	cfg := &Authentication{
 		AuthenticatorID: component.NewID("does-not-exist"),
 	}
 
@@ -93,7 +93,7 @@ func TestGetClient(t *testing.T) {
 	for _, tC := range testCases {
 		t.Run(tC.desc, func(t *testing.T) {
 			// prepare
-			cfg := &Settings{
+			cfg := &Authentication{
 				AuthenticatorID: component.NewID("mock"),
 			}
 			ext := map[component.ID]component.Component{
@@ -115,7 +115,7 @@ func TestGetClient(t *testing.T) {
 }
 
 func TestGetClientFails(t *testing.T) {
-	cfg := &Settings{
+	cfg := &Authentication{
 		AuthenticatorID: component.NewID("does-not-exist"),
 	}
 	authenticator, err := cfg.GetClient(map[component.ID]component.Component{})

--- a/config/configauth/configauth_test.go
+++ b/config/configauth/configauth_test.go
@@ -49,7 +49,7 @@ func TestGetServer(t *testing.T) {
 				component.NewID("mock"): tC.authenticator,
 			}
 
-			authenticator, err := cfg.GetServer(ext)
+			authenticator, err := cfg.GetServerAuthenticator(ext)
 
 			// verify
 			if tC.expected != nil {
@@ -68,7 +68,7 @@ func TestGetServerFails(t *testing.T) {
 		AuthenticatorID: component.NewID("does-not-exist"),
 	}
 
-	authenticator, err := cfg.GetServer(map[component.ID]component.Component{})
+	authenticator, err := cfg.GetServerAuthenticator(map[component.ID]component.Component{})
 	assert.ErrorIs(t, err, errAuthenticatorNotFound)
 	assert.Nil(t, authenticator)
 }
@@ -100,7 +100,7 @@ func TestGetClient(t *testing.T) {
 				component.NewID("mock"): tC.authenticator,
 			}
 
-			authenticator, err := cfg.GetClient(ext)
+			authenticator, err := cfg.GetClientAuthenticator(ext)
 
 			// verify
 			if tC.expected != nil {
@@ -118,7 +118,7 @@ func TestGetClientFails(t *testing.T) {
 	cfg := &Authentication{
 		AuthenticatorID: component.NewID("does-not-exist"),
 	}
-	authenticator, err := cfg.GetClient(map[component.ID]component.Component{})
+	authenticator, err := cfg.GetClientAuthenticator(map[component.ID]component.Component{})
 	assert.ErrorIs(t, err, errAuthenticatorNotFound)
 	assert.Nil(t, authenticator)
 }

--- a/config/configauth/configauth_test.go
+++ b/config/configauth/configauth_test.go
@@ -22,7 +22,7 @@ import (
 	"go.opentelemetry.io/collector/component"
 )
 
-func TestGetServerAuthenticator(t *testing.T) {
+func TestGetServer(t *testing.T) {
 	testCases := []struct {
 		desc          string
 		authenticator component.Extension
@@ -35,21 +35,21 @@ func TestGetServerAuthenticator(t *testing.T) {
 		},
 		{
 			desc:          "not a server authenticator",
-			authenticator: &MockClientAuthenticator{},
-			expected:      errNotServerAuthenticator,
+			authenticator: NewClientAuthenticator(),
+			expected:      errNotServer,
 		},
 	}
 	for _, tC := range testCases {
 		t.Run(tC.desc, func(t *testing.T) {
 			// prepare
-			cfg := &Authentication{
+			cfg := &Settings{
 				AuthenticatorID: component.NewID("mock"),
 			}
 			ext := map[component.ID]component.Component{
 				component.NewID("mock"): tC.authenticator,
 			}
 
-			authenticator, err := cfg.GetServerAuthenticator(ext)
+			authenticator, err := cfg.GetServer(ext)
 
 			// verify
 			if tC.expected != nil {
@@ -63,17 +63,17 @@ func TestGetServerAuthenticator(t *testing.T) {
 	}
 }
 
-func TestGetServerAuthenticatorFails(t *testing.T) {
-	cfg := &Authentication{
+func TestGetServerFails(t *testing.T) {
+	cfg := &Settings{
 		AuthenticatorID: component.NewID("does-not-exist"),
 	}
 
-	authenticator, err := cfg.GetServerAuthenticator(map[component.ID]component.Component{})
+	authenticator, err := cfg.GetServer(map[component.ID]component.Component{})
 	assert.ErrorIs(t, err, errAuthenticatorNotFound)
 	assert.Nil(t, authenticator)
 }
 
-func TestGetClientAuthenticator(t *testing.T) {
+func TestGetClient(t *testing.T) {
 	testCases := []struct {
 		desc          string
 		authenticator component.Extension
@@ -81,26 +81,26 @@ func TestGetClientAuthenticator(t *testing.T) {
 	}{
 		{
 			desc:          "obtain client authenticator",
-			authenticator: &MockClientAuthenticator{},
+			authenticator: NewClientAuthenticator(),
 			expected:      nil,
 		},
 		{
 			desc:          "not a client authenticator",
 			authenticator: NewServerAuthenticator(),
-			expected:      errNotClientAuthenticator,
+			expected:      errNotClient,
 		},
 	}
 	for _, tC := range testCases {
 		t.Run(tC.desc, func(t *testing.T) {
 			// prepare
-			cfg := &Authentication{
+			cfg := &Settings{
 				AuthenticatorID: component.NewID("mock"),
 			}
 			ext := map[component.ID]component.Component{
 				component.NewID("mock"): tC.authenticator,
 			}
 
-			authenticator, err := cfg.GetClientAuthenticator(ext)
+			authenticator, err := cfg.GetClient(ext)
 
 			// verify
 			if tC.expected != nil {
@@ -114,11 +114,11 @@ func TestGetClientAuthenticator(t *testing.T) {
 	}
 }
 
-func TestGetClientAuthenticatorFails(t *testing.T) {
-	cfg := &Authentication{
+func TestGetClientFails(t *testing.T) {
+	cfg := &Settings{
 		AuthenticatorID: component.NewID("does-not-exist"),
 	}
-	authenticator, err := cfg.GetClientAuthenticator(map[component.ID]component.Component{})
+	authenticator, err := cfg.GetClient(map[component.ID]component.Component{})
 	assert.ErrorIs(t, err, errAuthenticatorNotFound)
 	assert.Nil(t, authenticator)
 }

--- a/config/configauth/deprecated.go
+++ b/config/configauth/deprecated.go
@@ -15,11 +15,6 @@
 package configauth // import "go.opentelemetry.io/collector/config/configauth"
 
 import (
-	"net/http"
-
-	"google.golang.org/grpc/credentials"
-
-	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/extension/auth"
 	"go.opentelemetry.io/collector/extension/auth/authtest"
 )
@@ -34,36 +29,26 @@ type ClientOption = auth.ClientOption
 // WithClientStart overrides the default `Start` function for a component.Component.
 // The default always returns nil.
 // Deprecated: [v0.67.0] Use auth.WithClientStart
-func WithClientStart(startFunc component.StartFunc) ClientOption {
-	return auth.WithClientStart(startFunc)
-}
+var WithClientStart = auth.WithClientStart
 
 // WithClientShutdown overrides the default `Shutdown` function for a component.Component.
 // The default always returns nil.
 // Deprecated: [v0.67.0] Use auth.WithClientShutdown
-func WithClientShutdown(shutdownFunc component.ShutdownFunc) ClientOption {
-	return auth.WithClientShutdown(shutdownFunc)
-}
+var WithClientShutdown = auth.WithClientShutdown
 
 // WithClientRoundTripper provides a `RoundTripper` function for this client authenticator.
 // The default round tripper is no-op.
 // Deprecated: [v0.67.0] Use auth.WithClientRoundTripper
-func WithClientRoundTripper(roundTripperFunc func(base http.RoundTripper) (http.RoundTripper, error)) ClientOption {
-	return auth.WithClientRoundTripper(roundTripperFunc)
-}
+var WithClientRoundTripper = auth.WithClientRoundTripper
 
 // WithPerRPCCredentials provides a `PerRPCCredentials` function for this client authenticator.
 // There's no default.
 // Deprecated: [v0.67.0] Use auth.WithPerRPCCredentials
-func WithPerRPCCredentials(perRPCCredentialsFunc func() (credentials.PerRPCCredentials, error)) ClientOption {
-	return auth.WithPerRPCCredentials(perRPCCredentialsFunc)
-}
+var WithPerRPCCredentials = auth.WithPerRPCCredentials
 
 // NewClientAuthenticator returns a ClientAuthenticator configured with the provided options.
 // Deprecated: [v0.67.0] Use auth.NewClient
-func NewClientAuthenticator(options ...ClientOption) ClientAuthenticator {
-	return auth.NewClient(options...)
-}
+var NewClientAuthenticator = auth.NewClient
 
 // Deprecated: [v0.67.0] Use auth.Server
 type ServerAuthenticator = auth.Server
@@ -77,29 +62,21 @@ type Option = auth.Option
 
 // WithAuthenticate specifies which function to use to perform the authentication.
 // Deprecated: [v0.67.0] Use auth.WithAuthenticate
-func WithAuthenticate(authenticateFunc AuthenticateFunc) Option {
-	return auth.WithAuthenticate(authenticateFunc)
-}
+var WithAuthenticate = auth.WithAuthenticate
 
 // WithStart overrides the default `Start` function for a component.Component.
 // The default always returns nil.
 // Deprecated: [v0.67.0] Use auth.WithStart
-func WithStart(startFunc component.StartFunc) Option {
-	return auth.WithStart(startFunc)
-}
+var WithStart = auth.WithStart
 
 // WithShutdown overrides the default `Shutdown` function for a component.Component.
 // The default always returns nil.
 // Deprecated: [v0.67.0] Use auth.WithShutdown
-func WithShutdown(shutdownFunc component.ShutdownFunc) Option {
-	return auth.WithShutdown(shutdownFunc)
-}
+var WithShutdown = auth.WithShutdown
 
 // NewServerAuthenticator returns a ServerAuthenticator configured with the provided options.
 // Deprecated: [v0.67.0] Use auth.NewServer
-func NewServerAuthenticator(options ...Option) ServerAuthenticator {
-	return auth.NewServer(options...)
-}
+var NewServerAuthenticator = auth.NewServer
 
 // Deprecated: [v0.67.0] Use auth.MockClient
 type MockClientAuthenticator = authtest.MockClient

--- a/config/configauth/deprecated.go
+++ b/config/configauth/deprecated.go
@@ -1,0 +1,105 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package configauth // import "go.opentelemetry.io/collector/config/configauth"
+
+import (
+	"net/http"
+
+	"google.golang.org/grpc/credentials"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/extension/auth"
+	"go.opentelemetry.io/collector/extension/auth/authtest"
+)
+
+// Deprecated: [v0.67.0] Use auth.Client
+type ClientAuthenticator = auth.Client
+
+// Option represents the possible options for NewServerAuthenticator.
+// Deprecated: [v0.67.0] Use auth.ClientOption
+type ClientOption = auth.ClientOption
+
+// WithClientStart overrides the default `Start` function for a component.Component.
+// The default always returns nil.
+// Deprecated: [v0.67.0] Use auth.WithClientStart
+func WithClientStart(startFunc component.StartFunc) ClientOption {
+	return auth.WithClientStart(startFunc)
+}
+
+// WithClientShutdown overrides the default `Shutdown` function for a component.Component.
+// The default always returns nil.
+// Deprecated: [v0.67.0] Use auth.WithClientShutdown
+func WithClientShutdown(shutdownFunc component.ShutdownFunc) ClientOption {
+	return auth.WithClientShutdown(shutdownFunc)
+}
+
+// WithClientRoundTripper provides a `RoundTripper` function for this client authenticator.
+// The default round tripper is no-op.
+// Deprecated: [v0.67.0] Use auth.WithClientRoundTripper
+func WithClientRoundTripper(roundTripperFunc func(base http.RoundTripper) (http.RoundTripper, error)) ClientOption {
+	return auth.WithClientRoundTripper(roundTripperFunc)
+}
+
+// WithPerRPCCredentials provides a `PerRPCCredentials` function for this client authenticator.
+// There's no default.
+// Deprecated: [v0.67.0] Use auth.WithPerRPCCredentials
+func WithPerRPCCredentials(perRPCCredentialsFunc func() (credentials.PerRPCCredentials, error)) ClientOption {
+	return auth.WithPerRPCCredentials(perRPCCredentialsFunc)
+}
+
+// NewClientAuthenticator returns a ClientAuthenticator configured with the provided options.
+// Deprecated: [v0.67.0] Use auth.NewClient
+func NewClientAuthenticator(options ...ClientOption) ClientAuthenticator {
+	return auth.NewClient(options...)
+}
+
+// Deprecated: [v0.67.0] Use auth.Server
+type ServerAuthenticator = auth.Server
+
+// Deprecated: [v0.67.0] Use auth.AuthenticateFunc
+type AuthenticateFunc = auth.AuthenticateFunc
+
+// Option represents the possible options for NewServerAuthenticator.
+// Deprecated: [v0.67.0] Use auth.Option
+type Option = auth.Option
+
+// WithAuthenticate specifies which function to use to perform the authentication.
+// Deprecated: [v0.67.0] Use auth.WithAuthenticate
+func WithAuthenticate(authenticateFunc AuthenticateFunc) Option {
+	return auth.WithAuthenticate(authenticateFunc)
+}
+
+// WithStart overrides the default `Start` function for a component.Component.
+// The default always returns nil.
+// Deprecated: [v0.67.0] Use auth.WithStart
+func WithStart(startFunc component.StartFunc) Option {
+	return auth.WithStart(startFunc)
+}
+
+// WithShutdown overrides the default `Shutdown` function for a component.Component.
+// The default always returns nil.
+// Deprecated: [v0.67.0] Use auth.WithShutdown
+func WithShutdown(shutdownFunc component.ShutdownFunc) Option {
+	return auth.WithShutdown(shutdownFunc)
+}
+
+// NewServerAuthenticator returns a ServerAuthenticator configured with the provided options.
+// Deprecated: [v0.67.0] Use auth.NewServer
+func NewServerAuthenticator(options ...Option) ServerAuthenticator {
+	return auth.NewServer(options...)
+}
+
+// Deprecated: [v0.67.0] Use auth.MockClient
+type MockClientAuthenticator = authtest.MockClient

--- a/config/configgrpc/configgrpc.go
+++ b/config/configgrpc/configgrpc.go
@@ -237,7 +237,7 @@ func (gcs *GRPCClientSettings) toDialOptions(host component.Host, settings compo
 			return nil, errors.New("no extensions configuration available")
 		}
 
-		grpcAuthenticator, cerr := gcs.Auth.GetClient(host.GetExtensions())
+		grpcAuthenticator, cerr := gcs.Auth.GetClientAuthenticator(host.GetExtensions())
 		if cerr != nil {
 			return nil, cerr
 		}
@@ -358,7 +358,7 @@ func (gss *GRPCServerSettings) toServerOption(host component.Host, settings comp
 	var sInterceptors []grpc.StreamServerInterceptor
 
 	if gss.Auth != nil {
-		authenticator, err := gss.Auth.GetServer(host.GetExtensions())
+		authenticator, err := gss.Auth.GetServerAuthenticator(host.GetExtensions())
 		if err != nil {
 			return nil, err
 		}

--- a/config/configgrpc/configgrpc.go
+++ b/config/configgrpc/configgrpc.go
@@ -97,7 +97,7 @@ type GRPCClientSettings struct {
 	BalancerName string `mapstructure:"balancer_name"`
 
 	// Auth configuration for outgoing RPCs.
-	Auth *configauth.Settings `mapstructure:"auth"`
+	Auth *configauth.Authentication `mapstructure:"auth"`
 }
 
 // KeepaliveServerConfig is the configuration for keepalive.
@@ -153,7 +153,7 @@ type GRPCServerSettings struct {
 	Keepalive *KeepaliveServerConfig `mapstructure:"keepalive"`
 
 	// Auth for this receiver
-	Auth *configauth.Settings `mapstructure:"auth"`
+	Auth *configauth.Authentication `mapstructure:"auth"`
 
 	// Include propagates the incoming connection's metadata to downstream consumers.
 	// Experimental: *NOTE* this option is subject to change or removal in the future.

--- a/config/configgrpc/configgrpc_test.go
+++ b/config/configgrpc/configgrpc_test.go
@@ -39,6 +39,8 @@ import (
 	"go.opentelemetry.io/collector/config/configcompression"
 	"go.opentelemetry.io/collector/config/confignet"
 	"go.opentelemetry.io/collector/config/configtls"
+	"go.opentelemetry.io/collector/extension/auth"
+	"go.opentelemetry.io/collector/extension/auth/authtest"
 	"go.opentelemetry.io/collector/obsreport/obsreporttest"
 	"go.opentelemetry.io/collector/pdata/ptrace/ptraceotlp"
 )
@@ -88,11 +90,11 @@ func TestAllGrpcClientSettings(t *testing.T) {
 				WriteBufferSize: 1024,
 				WaitForReady:    true,
 				BalancerName:    "round_robin",
-				Auth:            &configauth.Authentication{AuthenticatorID: component.NewID("testauth")},
+				Auth:            &configauth.Settings{AuthenticatorID: component.NewID("testauth")},
 			},
 			host: &mockHost{
 				ext: map[component.ID]component.Component{
-					component.NewID("testauth"): &configauth.MockClientAuthenticator{},
+					component.NewID("testauth"): &authtest.MockClient{},
 				},
 			},
 		},
@@ -116,11 +118,11 @@ func TestAllGrpcClientSettings(t *testing.T) {
 				WriteBufferSize: 1024,
 				WaitForReady:    true,
 				BalancerName:    "round_robin",
-				Auth:            &configauth.Authentication{AuthenticatorID: component.NewID("testauth")},
+				Auth:            &configauth.Settings{AuthenticatorID: component.NewID("testauth")},
 			},
 			host: &mockHost{
 				ext: map[component.ID]component.Component{
-					component.NewID("testauth"): &configauth.MockClientAuthenticator{},
+					component.NewID("testauth"): &authtest.MockClient{},
 				},
 			},
 		},
@@ -144,11 +146,11 @@ func TestAllGrpcClientSettings(t *testing.T) {
 				WriteBufferSize: 1024,
 				WaitForReady:    true,
 				BalancerName:    "round_robin",
-				Auth:            &configauth.Authentication{AuthenticatorID: component.NewID("testauth")},
+				Auth:            &configauth.Settings{AuthenticatorID: component.NewID("testauth")},
 			},
 			host: &mockHost{
 				ext: map[component.ID]component.Component{
-					component.NewID("testauth"): &configauth.MockClientAuthenticator{},
+					component.NewID("testauth"): &authtest.MockClient{},
 				},
 			},
 		},
@@ -212,12 +214,12 @@ func TestGrpcServerAuthSettings(t *testing.T) {
 			Endpoint: "0.0.0.0:1234",
 		},
 	}
-	gss.Auth = &configauth.Authentication{
+	gss.Auth = &configauth.Settings{
 		AuthenticatorID: component.NewID("mock"),
 	}
 	host := &mockHost{
 		ext: map[component.ID]component.Component{
-			component.NewID("mock"): configauth.NewServerAuthenticator(),
+			component.NewID("mock"): auth.NewServer(),
 		},
 	}
 	srv, err := gss.ToServer(host, componenttest.NewNopTelemetrySettings())
@@ -293,7 +295,7 @@ func TestGRPCClientSettingsError(t *testing.T) {
 			err: "failed to resolve authenticator \"doesntexist\": authenticator not found",
 			settings: GRPCClientSettings{
 				Endpoint: "localhost:1234",
-				Auth:     &configauth.Authentication{AuthenticatorID: component.NewID("doesntexist")},
+				Auth:     &configauth.Settings{AuthenticatorID: component.NewID("doesntexist")},
 			},
 			host: &mockHost{ext: map[component.ID]component.Component{}},
 		},
@@ -301,7 +303,7 @@ func TestGRPCClientSettingsError(t *testing.T) {
 			err: "no extensions configuration available",
 			settings: GRPCClientSettings{
 				Endpoint: "localhost:1234",
-				Auth:     &configauth.Authentication{AuthenticatorID: component.NewID("doesntexist")},
+				Auth:     &configauth.Settings{AuthenticatorID: component.NewID("doesntexist")},
 			},
 			host: &mockHost{},
 		},

--- a/config/configgrpc/configgrpc_test.go
+++ b/config/configgrpc/configgrpc_test.go
@@ -90,7 +90,7 @@ func TestAllGrpcClientSettings(t *testing.T) {
 				WriteBufferSize: 1024,
 				WaitForReady:    true,
 				BalancerName:    "round_robin",
-				Auth:            &configauth.Settings{AuthenticatorID: component.NewID("testauth")},
+				Auth:            &configauth.Authentication{AuthenticatorID: component.NewID("testauth")},
 			},
 			host: &mockHost{
 				ext: map[component.ID]component.Component{
@@ -118,7 +118,7 @@ func TestAllGrpcClientSettings(t *testing.T) {
 				WriteBufferSize: 1024,
 				WaitForReady:    true,
 				BalancerName:    "round_robin",
-				Auth:            &configauth.Settings{AuthenticatorID: component.NewID("testauth")},
+				Auth:            &configauth.Authentication{AuthenticatorID: component.NewID("testauth")},
 			},
 			host: &mockHost{
 				ext: map[component.ID]component.Component{
@@ -146,7 +146,7 @@ func TestAllGrpcClientSettings(t *testing.T) {
 				WriteBufferSize: 1024,
 				WaitForReady:    true,
 				BalancerName:    "round_robin",
-				Auth:            &configauth.Settings{AuthenticatorID: component.NewID("testauth")},
+				Auth:            &configauth.Authentication{AuthenticatorID: component.NewID("testauth")},
 			},
 			host: &mockHost{
 				ext: map[component.ID]component.Component{
@@ -214,7 +214,7 @@ func TestGrpcServerAuthSettings(t *testing.T) {
 			Endpoint: "0.0.0.0:1234",
 		},
 	}
-	gss.Auth = &configauth.Settings{
+	gss.Auth = &configauth.Authentication{
 		AuthenticatorID: component.NewID("mock"),
 	}
 	host := &mockHost{
@@ -295,7 +295,7 @@ func TestGRPCClientSettingsError(t *testing.T) {
 			err: "failed to resolve authenticator \"doesntexist\": authenticator not found",
 			settings: GRPCClientSettings{
 				Endpoint: "localhost:1234",
-				Auth:     &configauth.Settings{AuthenticatorID: component.NewID("doesntexist")},
+				Auth:     &configauth.Authentication{AuthenticatorID: component.NewID("doesntexist")},
 			},
 			host: &mockHost{ext: map[component.ID]component.Component{}},
 		},
@@ -303,7 +303,7 @@ func TestGRPCClientSettingsError(t *testing.T) {
 			err: "no extensions configuration available",
 			settings: GRPCClientSettings{
 				Endpoint: "localhost:1234",
-				Auth:     &configauth.Settings{AuthenticatorID: component.NewID("doesntexist")},
+				Auth:     &configauth.Authentication{AuthenticatorID: component.NewID("doesntexist")},
 			},
 			host: &mockHost{},
 		},

--- a/config/confighttp/confighttp.go
+++ b/config/confighttp/confighttp.go
@@ -161,7 +161,7 @@ func (hcs *HTTPClientSettings) ToClient(host component.Host, settings component.
 			return nil, errors.New("extensions configuration not found")
 		}
 
-		httpCustomAuthRoundTripper, aerr := hcs.Auth.GetClient(ext)
+		httpCustomAuthRoundTripper, aerr := hcs.Auth.GetClientAuthenticator(ext)
 		if aerr != nil {
 			return nil, aerr
 		}
@@ -278,7 +278,7 @@ func (hss *HTTPServerSettings) ToServer(host component.Host, settings component.
 	}
 
 	if hss.Auth != nil {
-		authenticator, err := hss.Auth.GetServer(host.GetExtensions())
+		authenticator, err := hss.Auth.GetServerAuthenticator(host.GetExtensions())
 		if err != nil {
 			return nil, err
 		}

--- a/config/confighttp/confighttp.go
+++ b/config/confighttp/confighttp.go
@@ -61,7 +61,7 @@ type HTTPClientSettings struct {
 	CustomRoundTripper func(next http.RoundTripper) (http.RoundTripper, error)
 
 	// Auth configuration for outgoing HTTP calls.
-	Auth *configauth.Settings `mapstructure:"auth"`
+	Auth *configauth.Authentication `mapstructure:"auth"`
 
 	// The compression key for supported compression types within collector.
 	Compression configcompression.CompressionType `mapstructure:"compression"`
@@ -212,7 +212,7 @@ type HTTPServerSettings struct {
 	CORS *CORSSettings `mapstructure:"cors"`
 
 	// Auth for this receiver
-	Auth *configauth.Settings `mapstructure:"auth"`
+	Auth *configauth.Authentication `mapstructure:"auth"`
 
 	// MaxRequestBodySize sets the maximum request body size in bytes
 	MaxRequestBodySize int64 `mapstructure:"max_request_body_size"`

--- a/config/confighttp/confighttp_test.go
+++ b/config/confighttp/confighttp_test.go
@@ -249,7 +249,7 @@ func TestHTTPClientSettingsError(t *testing.T) {
 			err: "failed to resolve authenticator \"dummy\": authenticator not found",
 			settings: HTTPClientSettings{
 				Endpoint: "https://localhost:1234/v1/traces",
-				Auth:     &configauth.Settings{AuthenticatorID: component.NewID("dummy")},
+				Auth:     &configauth.Authentication{AuthenticatorID: component.NewID("dummy")},
 			},
 		},
 	}
@@ -287,7 +287,7 @@ func TestHTTPClientSettingWithAuthConfig(t *testing.T) {
 			name: "with_auth_configuration_and_no_extension",
 			settings: HTTPClientSettings{
 				Endpoint: "localhost:1234",
-				Auth:     &configauth.Settings{AuthenticatorID: component.NewID("dummy")},
+				Auth:     &configauth.Authentication{AuthenticatorID: component.NewID("dummy")},
 			},
 			shouldErr: true,
 			host: &mockHost{
@@ -300,7 +300,7 @@ func TestHTTPClientSettingWithAuthConfig(t *testing.T) {
 			name: "with_auth_configuration_and_no_extension_map",
 			settings: HTTPClientSettings{
 				Endpoint: "localhost:1234",
-				Auth:     &configauth.Settings{AuthenticatorID: component.NewID("dummy")},
+				Auth:     &configauth.Authentication{AuthenticatorID: component.NewID("dummy")},
 			},
 			shouldErr: true,
 			host:      componenttest.NewNopHost(),
@@ -309,7 +309,7 @@ func TestHTTPClientSettingWithAuthConfig(t *testing.T) {
 			name: "with_auth_configuration_has_extension",
 			settings: HTTPClientSettings{
 				Endpoint: "localhost:1234",
-				Auth:     &configauth.Settings{AuthenticatorID: component.NewID("mock")},
+				Auth:     &configauth.Authentication{AuthenticatorID: component.NewID("mock")},
 			},
 			shouldErr: false,
 			host: &mockHost{
@@ -322,7 +322,7 @@ func TestHTTPClientSettingWithAuthConfig(t *testing.T) {
 			name: "with_auth_configuration_has_err_extension",
 			settings: HTTPClientSettings{
 				Endpoint: "localhost:1234",
-				Auth:     &configauth.Settings{AuthenticatorID: component.NewID("mock")},
+				Auth:     &configauth.Authentication{AuthenticatorID: component.NewID("mock")},
 			},
 			shouldErr: true,
 			host: &mockHost{
@@ -733,7 +733,7 @@ func TestHttpCorsWithSettings(t *testing.T) {
 		CORS: &CORSSettings{
 			AllowedOrigins: []string{"*"},
 		},
-		Auth: &configauth.Settings{
+		Auth: &configauth.Authentication{
 			AuthenticatorID: component.NewID("mock"),
 		},
 	}
@@ -928,7 +928,7 @@ func TestServerAuth(t *testing.T) {
 	authCalled := false
 	hss := HTTPServerSettings{
 		Endpoint: "localhost:0",
-		Auth: &configauth.Settings{
+		Auth: &configauth.Authentication{
 			AuthenticatorID: component.NewID("mock"),
 		},
 	}
@@ -962,7 +962,7 @@ func TestServerAuth(t *testing.T) {
 
 func TestInvalidServerAuth(t *testing.T) {
 	hss := HTTPServerSettings{
-		Auth: &configauth.Settings{
+		Auth: &configauth.Authentication{
 			AuthenticatorID: component.NewID("non-existing"),
 		},
 	}
@@ -976,7 +976,7 @@ func TestFailedServerAuth(t *testing.T) {
 	// prepare
 	hss := HTTPServerSettings{
 		Endpoint: "localhost:0",
-		Auth: &configauth.Settings{
+		Auth: &configauth.Authentication{
 			AuthenticatorID: component.NewID("mock"),
 		},
 	}

--- a/exporter/otlpexporter/config_test.go
+++ b/exporter/otlpexporter/config_test.go
@@ -83,7 +83,7 @@ func TestUnmarshalConfig(t *testing.T) {
 				},
 				WriteBufferSize: 512 * 1024,
 				BalancerName:    "round_robin",
-				Auth:            &configauth.Authentication{AuthenticatorID: component.NewID("nop")},
+				Auth:            &configauth.Settings{AuthenticatorID: component.NewID("nop")},
 			},
 		}, cfg)
 }

--- a/exporter/otlpexporter/config_test.go
+++ b/exporter/otlpexporter/config_test.go
@@ -83,7 +83,7 @@ func TestUnmarshalConfig(t *testing.T) {
 				},
 				WriteBufferSize: 512 * 1024,
 				BalancerName:    "round_robin",
-				Auth:            &configauth.Settings{AuthenticatorID: component.NewID("nop")},
+				Auth:            &configauth.Authentication{AuthenticatorID: component.NewID("nop")},
 			},
 		}, cfg)
 }

--- a/extension/auth/authtest/mock_clientauth.go
+++ b/extension/auth/authtest/mock_clientauth.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package configauth // import "go.opentelemetry.io/collector/config/configauth"
+package authtest // import "go.opentelemetry.io/collector/extension/auth/authtest"
 
 import (
 	"context"
@@ -22,42 +22,43 @@ import (
 	"google.golang.org/grpc/credentials"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/extension/auth"
 )
 
 var (
-	_            ClientAuthenticator = (*MockClientAuthenticator)(nil)
-	errMockError                     = errors.New("mock Error")
+	_            auth.Client = (*MockClient)(nil)
+	errMockError             = errors.New("mock Error")
 )
 
-// MockClientAuthenticator provides a mock implementation of GRPCClientAuthenticator and HTTPClientAuthenticator interfaces
-type MockClientAuthenticator struct {
+// MockClient provides a mock implementation of GRPCClient and HTTPClient interfaces
+type MockClient struct {
 	ResultRoundTripper      http.RoundTripper
 	ResultPerRPCCredentials credentials.PerRPCCredentials
 	MustError               bool
 }
 
-// Start for the MockClientAuthenticator does nothing
-func (m *MockClientAuthenticator) Start(ctx context.Context, host component.Host) error {
+// Start for the MockClient does nothing
+func (m *MockClient) Start(ctx context.Context, host component.Host) error {
 	return nil
 }
 
-// Shutdown for the MockClientAuthenticator does nothing
-func (m *MockClientAuthenticator) Shutdown(ctx context.Context) error {
+// Shutdown for the MockClient does nothing
+func (m *MockClient) Shutdown(ctx context.Context) error {
 	return nil
 }
 
-// RoundTripper for the MockClientAuthenticator either returns error if the mock authenticator is forced to or
+// RoundTripper for the MockClient either returns error if the mock authenticator is forced to or
 // returns the supplied resultRoundTripper.
-func (m *MockClientAuthenticator) RoundTripper(base http.RoundTripper) (http.RoundTripper, error) {
+func (m *MockClient) RoundTripper(base http.RoundTripper) (http.RoundTripper, error) {
 	if m.MustError {
 		return nil, errMockError
 	}
 	return m.ResultRoundTripper, nil
 }
 
-// PerRPCCredentials for the MockClientAuthenticator either returns error if the mock authenticator is forced to or
+// PerRPCCredentials for the MockClient either returns error if the mock authenticator is forced to or
 // returns the supplied resultPerRPCCredentials.
-func (m *MockClientAuthenticator) PerRPCCredentials() (credentials.PerRPCCredentials, error) {
+func (m *MockClient) PerRPCCredentials() (credentials.PerRPCCredentials, error) {
 	if m.MustError {
 		return nil, errMockError
 	}

--- a/extension/auth/authtest/mock_clientauth_test.go
+++ b/extension/auth/authtest/mock_clientauth_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package configauth
+package authtest
 
 import (
 	"context"
@@ -25,7 +25,7 @@ import (
 
 func TestNilStartAndShutdown(t *testing.T) {
 	// prepare
-	m := &MockClientAuthenticator{}
+	m := &MockClient{}
 
 	// test and verify
 	origCtx := context.Background()
@@ -47,12 +47,12 @@ func TestMockRoundTripper(t *testing.T) {
 	testcases := []struct {
 		name        string
 		expectedErr bool
-		clientAuth  MockClientAuthenticator
+		clientAuth  MockClient
 	}{
 		{
 			name:        "no_error",
 			expectedErr: false,
-			clientAuth: MockClientAuthenticator{
+			clientAuth: MockClient{
 				ResultRoundTripper: &customRoundTripper{},
 				MustError:          false,
 			},
@@ -60,7 +60,7 @@ func TestMockRoundTripper(t *testing.T) {
 		{
 			name:        "error",
 			expectedErr: true,
-			clientAuth: MockClientAuthenticator{
+			clientAuth: MockClient{
 				ResultRoundTripper: &customRoundTripper{},
 				MustError:          true,
 			},
@@ -99,12 +99,12 @@ func TestMockPerRPCCredential(t *testing.T) {
 	testcases := []struct {
 		name        string
 		expectedErr bool
-		clientAuth  MockClientAuthenticator
+		clientAuth  MockClient
 	}{
 		{
 			name:        "no_error",
 			expectedErr: false,
-			clientAuth: MockClientAuthenticator{
+			clientAuth: MockClient{
 				ResultPerRPCCredentials: &customPerRPCCredentials{},
 				MustError:               false,
 			},
@@ -112,7 +112,7 @@ func TestMockPerRPCCredential(t *testing.T) {
 		{
 			name:        "error",
 			expectedErr: true,
-			clientAuth: MockClientAuthenticator{
+			clientAuth: MockClient{
 				ResultPerRPCCredentials: &customPerRPCCredentials{},
 				MustError:               true,
 			},

--- a/extension/auth/clientauth.go
+++ b/extension/auth/clientauth.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package configauth // import "go.opentelemetry.io/collector/config/configauth"
+package auth // import "go.opentelemetry.io/collector/extension/auth"
 
 import (
 	"net/http"
@@ -22,10 +22,10 @@ import (
 	"go.opentelemetry.io/collector/component"
 )
 
-// ClientAuthenticator is an Extension that can be used as an authenticator for the configauth.Authentication option.
+// Client is an Extension that can be used as an authenticator for the configauth.Authentication option.
 // Authenticators are then included as part of OpenTelemetry Collector builds and can be referenced by their
 // names from the Authentication configuration.
-type ClientAuthenticator interface {
+type Client interface {
 	component.Extension
 
 	// RoundTripper returns a RoundTripper that can be used to authenticate HTTP requests.

--- a/extension/auth/default_clientauthenticator.go
+++ b/extension/auth/default_clientauthenticator.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package configauth // import "go.opentelemetry.io/collector/config/configauth"
+package auth // import "go.opentelemetry.io/collector/extension/auth"
 
 import (
 	"context"
@@ -23,12 +23,12 @@ import (
 	"go.opentelemetry.io/collector/component"
 )
 
-var _ ClientAuthenticator = (*defaultClientAuthenticator)(nil)
+var _ Client = (*defaultClient)(nil)
 
 // Option represents the possible options for NewServerAuthenticator.
-type ClientOption func(*defaultClientAuthenticator)
+type ClientOption func(*defaultClient)
 
-type defaultClientAuthenticator struct {
+type defaultClient struct {
 	component.StartFunc
 	component.ShutdownFunc
 	roundTripperFunc      func(base http.RoundTripper) (http.RoundTripper, error)
@@ -38,7 +38,7 @@ type defaultClientAuthenticator struct {
 // WithClientStart overrides the default `Start` function for a component.Component.
 // The default always returns nil.
 func WithClientStart(startFunc component.StartFunc) ClientOption {
-	return func(o *defaultClientAuthenticator) {
+	return func(o *defaultClient) {
 		o.StartFunc = startFunc
 	}
 }
@@ -46,7 +46,7 @@ func WithClientStart(startFunc component.StartFunc) ClientOption {
 // WithClientShutdown overrides the default `Shutdown` function for a component.Component.
 // The default always returns nil.
 func WithClientShutdown(shutdownFunc component.ShutdownFunc) ClientOption {
-	return func(o *defaultClientAuthenticator) {
+	return func(o *defaultClient) {
 		o.ShutdownFunc = shutdownFunc
 	}
 }
@@ -54,7 +54,7 @@ func WithClientShutdown(shutdownFunc component.ShutdownFunc) ClientOption {
 // WithClientRoundTripper provides a `RoundTripper` function for this client authenticator.
 // The default round tripper is no-op.
 func WithClientRoundTripper(roundTripperFunc func(base http.RoundTripper) (http.RoundTripper, error)) ClientOption {
-	return func(o *defaultClientAuthenticator) {
+	return func(o *defaultClient) {
 		o.roundTripperFunc = roundTripperFunc
 	}
 }
@@ -62,14 +62,14 @@ func WithClientRoundTripper(roundTripperFunc func(base http.RoundTripper) (http.
 // WithPerRPCCredentials provides a `PerRPCCredentials` function for this client authenticator.
 // There's no default.
 func WithPerRPCCredentials(perRPCCredentialsFunc func() (credentials.PerRPCCredentials, error)) ClientOption {
-	return func(o *defaultClientAuthenticator) {
+	return func(o *defaultClient) {
 		o.perRPCCredentialsFunc = perRPCCredentialsFunc
 	}
 }
 
-// NewClientAuthenticator returns a ClientAuthenticator configured with the provided options.
-func NewClientAuthenticator(options ...ClientOption) ClientAuthenticator {
-	bc := &defaultClientAuthenticator{
+// NewClient returns a Client configured with the provided options.
+func NewClient(options ...ClientOption) Client {
+	bc := &defaultClient{
 		StartFunc:             func(ctx context.Context, host component.Host) error { return nil },
 		ShutdownFunc:          func(ctx context.Context) error { return nil },
 		roundTripperFunc:      func(base http.RoundTripper) (http.RoundTripper, error) { return base, nil },
@@ -84,21 +84,21 @@ func NewClientAuthenticator(options ...ClientOption) ClientAuthenticator {
 }
 
 // Start the component.
-func (a *defaultClientAuthenticator) Start(ctx context.Context, host component.Host) error {
+func (a *defaultClient) Start(ctx context.Context, host component.Host) error {
 	return a.StartFunc(ctx, host)
 }
 
 // Shutdown stops the component.
-func (a *defaultClientAuthenticator) Shutdown(ctx context.Context) error {
+func (a *defaultClient) Shutdown(ctx context.Context) error {
 	return a.ShutdownFunc(ctx)
 }
 
 // RoundTripper adds the base HTTP RoundTripper in this authenticator's round tripper.
-func (a *defaultClientAuthenticator) RoundTripper(base http.RoundTripper) (http.RoundTripper, error) {
+func (a *defaultClient) RoundTripper(base http.RoundTripper) (http.RoundTripper, error) {
 	return a.roundTripperFunc(base)
 }
 
 // PerRPCCredentials returns this authenticator's credentials.PerRPCCredentials implementation.
-func (a *defaultClientAuthenticator) PerRPCCredentials() (credentials.PerRPCCredentials, error) {
+func (a *defaultClient) PerRPCCredentials() (credentials.PerRPCCredentials, error) {
 	return a.perRPCCredentialsFunc()
 }

--- a/extension/auth/default_clientauthenticator_test.go
+++ b/extension/auth/default_clientauthenticator_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package configauth
+package auth
 
 import (
 	"context"
@@ -28,7 +28,7 @@ import (
 
 func TestClientDefaultValues(t *testing.T) {
 	// prepare
-	e := NewClientAuthenticator()
+	e := NewClient()
 
 	// test
 	t.Run("start", func(t *testing.T) {
@@ -56,7 +56,7 @@ func TestClientDefaultValues(t *testing.T) {
 
 func TestWithClientStart(t *testing.T) {
 	called := false
-	e := NewClientAuthenticator(WithClientStart(func(c context.Context, h component.Host) error {
+	e := NewClient(WithClientStart(func(c context.Context, h component.Host) error {
 		called = true
 		return nil
 	}))
@@ -71,7 +71,7 @@ func TestWithClientStart(t *testing.T) {
 
 func TestWithClientShutdown(t *testing.T) {
 	called := false
-	e := NewClientAuthenticator(WithClientShutdown(func(c context.Context) error {
+	e := NewClient(WithClientShutdown(func(c context.Context) error {
 		called = true
 		return nil
 	}))
@@ -86,7 +86,7 @@ func TestWithClientShutdown(t *testing.T) {
 
 func TestWithClientRoundTripper(t *testing.T) {
 	called := false
-	e := NewClientAuthenticator(WithClientRoundTripper(func(base http.RoundTripper) (http.RoundTripper, error) {
+	e := NewClient(WithClientRoundTripper(func(base http.RoundTripper) (http.RoundTripper, error) {
 		called = true
 		return base, nil
 	}))
@@ -100,9 +100,21 @@ func TestWithClientRoundTripper(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+type customPerRPCCredentials struct{}
+
+var _ credentials.PerRPCCredentials = (*customPerRPCCredentials)(nil)
+
+func (c *customPerRPCCredentials) GetRequestMetadata(context.Context, ...string) (map[string]string, error) {
+	return nil, nil
+}
+
+func (c *customPerRPCCredentials) RequireTransportSecurity() bool {
+	return true
+}
+
 func TestWithPerRPCCredentials(t *testing.T) {
 	called := false
-	e := NewClientAuthenticator(WithPerRPCCredentials(func() (credentials.PerRPCCredentials, error) {
+	e := NewClient(WithPerRPCCredentials(func() (credentials.PerRPCCredentials, error) {
 		called = true
 		return &customPerRPCCredentials{}, nil
 	}))

--- a/extension/auth/default_serverauthenticator.go
+++ b/extension/auth/default_serverauthenticator.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package configauth // import "go.opentelemetry.io/collector/config/configauth"
+package auth // import "go.opentelemetry.io/collector/extension/auth"
 
 import (
 	"context"
@@ -20,12 +20,12 @@ import (
 	"go.opentelemetry.io/collector/component"
 )
 
-var _ ServerAuthenticator = (*defaultServerAuthenticator)(nil)
+var _ Server = (*defaultServer)(nil)
 
-// Option represents the possible options for NewServerAuthenticator.
-type Option func(*defaultServerAuthenticator)
+// Option represents the possible options for NewServer.
+type Option func(*defaultServer)
 
-type defaultServerAuthenticator struct {
+type defaultServer struct {
 	AuthenticateFunc
 	component.StartFunc
 	component.ShutdownFunc
@@ -33,7 +33,7 @@ type defaultServerAuthenticator struct {
 
 // WithAuthenticate specifies which function to use to perform the authentication.
 func WithAuthenticate(authenticateFunc AuthenticateFunc) Option {
-	return func(o *defaultServerAuthenticator) {
+	return func(o *defaultServer) {
 		o.AuthenticateFunc = authenticateFunc
 	}
 }
@@ -41,7 +41,7 @@ func WithAuthenticate(authenticateFunc AuthenticateFunc) Option {
 // WithStart overrides the default `Start` function for a component.Component.
 // The default always returns nil.
 func WithStart(startFunc component.StartFunc) Option {
-	return func(o *defaultServerAuthenticator) {
+	return func(o *defaultServer) {
 		o.StartFunc = startFunc
 	}
 }
@@ -49,14 +49,14 @@ func WithStart(startFunc component.StartFunc) Option {
 // WithShutdown overrides the default `Shutdown` function for a component.Component.
 // The default always returns nil.
 func WithShutdown(shutdownFunc component.ShutdownFunc) Option {
-	return func(o *defaultServerAuthenticator) {
+	return func(o *defaultServer) {
 		o.ShutdownFunc = shutdownFunc
 	}
 }
 
-// NewServerAuthenticator returns a ServerAuthenticator configured with the provided options.
-func NewServerAuthenticator(options ...Option) ServerAuthenticator {
-	bc := &defaultServerAuthenticator{
+// NewServer returns a Server configured with the provided options.
+func NewServer(options ...Option) Server {
+	bc := &defaultServer{
 		AuthenticateFunc: func(ctx context.Context, headers map[string][]string) (context.Context, error) { return ctx, nil },
 		StartFunc:        func(ctx context.Context, host component.Host) error { return nil },
 		ShutdownFunc:     func(ctx context.Context) error { return nil },
@@ -70,16 +70,16 @@ func NewServerAuthenticator(options ...Option) ServerAuthenticator {
 }
 
 // Authenticate performs the authentication.
-func (a *defaultServerAuthenticator) Authenticate(ctx context.Context, headers map[string][]string) (context.Context, error) {
+func (a *defaultServer) Authenticate(ctx context.Context, headers map[string][]string) (context.Context, error) {
 	return a.AuthenticateFunc(ctx, headers)
 }
 
 // Start the component.
-func (a *defaultServerAuthenticator) Start(ctx context.Context, host component.Host) error {
+func (a *defaultServer) Start(ctx context.Context, host component.Host) error {
 	return a.StartFunc(ctx, host)
 }
 
 // Shutdown stops the component.
-func (a *defaultServerAuthenticator) Shutdown(ctx context.Context) error {
+func (a *defaultServer) Shutdown(ctx context.Context) error {
 	return a.ShutdownFunc(ctx)
 }

--- a/extension/auth/default_serverauthenticator_test.go
+++ b/extension/auth/default_serverauthenticator_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package configauth
+package auth
 
 import (
 	"context"
@@ -26,7 +26,7 @@ import (
 
 func TestDefaultValues(t *testing.T) {
 	// prepare
-	e := NewServerAuthenticator()
+	e := NewServer()
 
 	// test
 	t.Run("start", func(t *testing.T) {
@@ -49,7 +49,7 @@ func TestDefaultValues(t *testing.T) {
 func TestWithAuthenticateFunc(t *testing.T) {
 	// prepare
 	authCalled := false
-	e := NewServerAuthenticator(
+	e := NewServer(
 		WithAuthenticate(func(ctx context.Context, headers map[string][]string) (context.Context, error) {
 			authCalled = true
 			return ctx, nil
@@ -66,7 +66,7 @@ func TestWithAuthenticateFunc(t *testing.T) {
 
 func TestWithStart(t *testing.T) {
 	called := false
-	e := NewServerAuthenticator(WithStart(func(c context.Context, h component.Host) error {
+	e := NewServer(WithStart(func(c context.Context, h component.Host) error {
 		called = true
 		return nil
 	}))
@@ -81,7 +81,7 @@ func TestWithStart(t *testing.T) {
 
 func TestWithShutdown(t *testing.T) {
 	called := false
-	e := NewServerAuthenticator(WithShutdown(func(c context.Context) error {
+	e := NewServer(WithShutdown(func(c context.Context) error {
 		called = true
 		return nil
 	}))

--- a/extension/auth/doc.go
+++ b/extension/auth/doc.go
@@ -1,0 +1,18 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package auth implements the configuration settings to
+// ensure authentication on incoming requests, and allows
+// exporters to add authentication on outgoing requests.
+package auth // import "go.opentelemetry.io/collector/extension/auth"

--- a/extension/auth/serverauth.go
+++ b/extension/auth/serverauth.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package configauth // import "go.opentelemetry.io/collector/config/configauth"
+package auth // import "go.opentelemetry.io/collector/extension/auth"
 
 import (
 	"context"
@@ -20,12 +20,12 @@ import (
 	"go.opentelemetry.io/collector/component"
 )
 
-// ServerAuthenticator is an Extension that can be used as an authenticator for the configauth.Authentication option.
+// Server is an Extension that can be used as an authenticator for the configauth.Authentication option.
 // Authenticators are then included as part of OpenTelemetry Collector builds and can be referenced by their
-// names from the Authentication configuration. Each ServerAuthenticator is free to define its own behavior and configuration options,
+// names from the Authentication configuration. Each Server is free to define its own behavior and configuration options,
 // but note that the expectations that come as part of Extensions exist here as well. For instance, multiple instances of the same
 // authenticator should be possible to exist under different names.
-type ServerAuthenticator interface {
+type Server interface {
 	component.Extension
 
 	// Authenticate checks whether the given headers map contains valid auth data. Successfully authenticated calls will always return a nil error.
@@ -40,5 +40,5 @@ type ServerAuthenticator interface {
 }
 
 // AuthenticateFunc defines the signature for the function responsible for performing the authentication based on the given headers map.
-// See ServerAuthenticator.Authenticate.
+// See Server.Authenticate.
 type AuthenticateFunc func(ctx context.Context, headers map[string][]string) (context.Context, error)


### PR DESCRIPTION
partly fix #4996

As I commented in https://github.com/open-telemetry/opentelemetry-collector/issues/4996#issuecomment-1296929370

> 1. defines new package `configauth` in the `extensions` directory, but for each exported type (for example `Authentication`), is only the alias of the homonymous one in the `config` directory, for example:
> 
> ```go
> import "go.opentelemetry.io/collector/config/configauth"
> 
> type Authentication = configauth.Authentication
> ```
> 
> 2. change all package or module which imports `config/configauth` to `extension/configauth`, for example configgrpc.go in `config/configgrpc`, change from
> 
> ```go
> import "go.opentelemetry.io/collector/config/configauth"
> ```
> 
> to
> 
> ```go
> import "go.opentelemetry.io/collector/extension/configauth"
> ```
> 
> 3. move all codes from `config/configauth` to  `extension/configauth`, and remove `config/configauth` package.

Signed-off-by: Ziqi Zhao <zhaoziqi9146@gmail.com>

This pr is the first step:
- define new `extension/authextension` but only use alias of the homonymous one in the `config/configauth` package
- change all usage of configauth to authextension in collector repo in order to validate this change.