### PR TITLE
[chore]: update docs to reflect verbosity for loggingexporter

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -169,7 +169,7 @@ You can also configure the `logging` exporter so the entire payload is printed:
 ```yaml
 exporters:
   logging:
-    loglevel: debug
+    verbosity: detailed
 ```
 
 With the modified configuration if you re-run the test above the log output should look like:

--- a/exporter/loggingexporter/README.md
+++ b/exporter/loggingexporter/README.md
@@ -14,7 +14,6 @@ Supported pipeline types: traces, metrics, logs
 
 The following settings are optional:
 
-// Deprecated: Use `verbosity` instead
 - `loglevel` (default = `info`): the log level of the logging export
   (debug|info|warn|error). When set to `debug`, pipeline data is verbosely 
   logged.
@@ -27,6 +26,9 @@ The following settings are optional:
   messages are logged (every Mth message is logged). Refer to [Zap
   docs](https://godoc.org/go.uber.org/zap/zapcore#NewSampler) for more details.
   on how sampling parameters impact number of messages.
+
+### Note
+`loglevel` is deprecated, use `verbosity` instead.
 
 Example:
 

--- a/exporter/loggingexporter/README.md
+++ b/exporter/loggingexporter/README.md
@@ -14,9 +14,9 @@ Supported pipeline types: traces, metrics, logs
 
 The following settings are optional:
 
-- `loglevel` (default = `info`): the log level of the logging export
-  (debug|info|warn|error). When set to `debug`, pipeline data is verbosely
-  logged.
+- `verbosity` (default = `normal`): the verbosity of the logging export
+  (detailed|normal|basic). When set to `detailed`, pipeline data is verbosely
+  logged. Anything above loglevel `info` is mapped to verbosity level `basic`.
 - `sampling_initial` (default = `2`): number of messages initially logged each
   second.
 - `sampling_thereafter` (default = `500`): sampling rate after the initial
@@ -29,7 +29,7 @@ Example:
 ```yaml
 exporters:
   logging:
-    loglevel: debug
+    verbosity: detailed
     sampling_initial: 5
     sampling_thereafter: 200
 ```

--- a/exporter/loggingexporter/README.md
+++ b/exporter/loggingexporter/README.md
@@ -14,6 +14,8 @@ Supported pipeline types: traces, metrics, logs
 
 The following settings are optional:
 
+- [Deprecated] `loglevel` (default = `info`): the log level of the logging export
+  (debug|info|warn|error). When set to `debug`, pipeline data is verbosely
 - `verbosity` (default = `normal`): the verbosity of the logging export
   (detailed|normal|basic). When set to `detailed`, pipeline data is verbosely
   logged. Anything above loglevel `info` is mapped to verbosity level `basic`.

--- a/exporter/loggingexporter/README.md
+++ b/exporter/loggingexporter/README.md
@@ -14,8 +14,10 @@ Supported pipeline types: traces, metrics, logs
 
 The following settings are optional:
 
-- [Deprecated] `loglevel` (default = `info`): the log level of the logging export
-  (debug|info|warn|error). When set to `debug`, pipeline data is verbosely
+// Deprecated: Use `verbosity` instead
+- `loglevel` (default = `info`): the log level of the logging export
+  (debug|info|warn|error). When set to `debug`, pipeline data is verbosely 
+  logged.
 - `verbosity` (default = `normal`): the verbosity of the logging export
   (detailed|normal|basic). When set to `detailed`, pipeline data is verbosely
   logged.

--- a/exporter/loggingexporter/README.md
+++ b/exporter/loggingexporter/README.md
@@ -16,6 +16,7 @@ The following settings are optional:
 
 - `loglevel` (default = `info`): the log level of the logging export
   (debug|info|warn|error). When set to `debug`, pipeline data is verbosely 
+      - **Note**: This option has been deprecated in favor of `verbosity`
   logged.
 - `verbosity` (default = `normal`): the verbosity of the logging export
   (detailed|normal|basic). When set to `detailed`, pipeline data is verbosely


### PR DESCRIPTION
Signed-off-by: Sakshi Patle <sakshi.patle121@gmail.com>


**Description:** 

Changing docs to deprecate loglevel in favour of verbosity

**Link to tracking Issue:** 

fixes https://github.com/open-telemetry/opentelemetry-collector/issues/6448


**Documentation:** 

Changing docs to deprecate loglevel in favour of verbosity


