### PR TITLE
Add configopaque package

### DIFF
--- a/.chloggen/addconfigopaque.yaml
+++ b/.chloggen/addconfigopaque.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: config/configopaque
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add new `configopaque.String` type alias for opaque strings.
+
+# One or more tracking issues or pull requests related to the change
+issues: [5653]

--- a/config/configopaque/opaque.go
+++ b/config/configopaque/opaque.go
@@ -28,6 +28,3 @@ var _ encoding.TextMarshaler = String("")
 func (s String) MarshalText() ([]byte, error) {
 	return bytes.Repeat([]byte("*"), len(s)), nil
 }
-
-// Headers is a string map with opaque values for configuration fields that set HTTP headers.
-type Headers map[string]String

--- a/config/configopaque/opaque.go
+++ b/config/configopaque/opaque.go
@@ -28,3 +28,6 @@ var _ encoding.TextMarshaler = String("")
 func (s String) MarshalText() ([]byte, error) {
 	return bytes.Repeat([]byte("*"), len(s)), nil
 }
+
+// Headers is a string map with opaque values for configuration fields that set HTTP headers.
+type Headers map[string]String

--- a/config/configopaque/opaque.go
+++ b/config/configopaque/opaque.go
@@ -22,7 +22,7 @@ import (
 // String alias that is marshaled in an opaque way.
 type String string
 
-var _ encoding.TextMarshaler = (*String)(nil)
+var _ encoding.TextMarshaler = String("")
 
 // MarshalText marshals into a string of '*' of length equal to the opaque string.
 func (s String) MarshalText() ([]byte, error) {

--- a/config/configopaque/opaque.go
+++ b/config/configopaque/opaque.go
@@ -1,0 +1,30 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package configopaque // import "go.opentelemetry.io/collector/config/configopaque"
+
+import (
+	"bytes"
+	"encoding"
+)
+
+// String alias that is marshaled in an opaque way.
+type String string
+
+var _ encoding.TextMarshaler = (*String)(nil)
+
+// MarshalText marshals into a string of '*' of length equal to the opaque string.
+func (s String) MarshalText() ([]byte, error) {
+	return bytes.Repeat([]byte("*"), len(s)), nil
+}

--- a/config/configopaque/opaque_test.go
+++ b/config/configopaque/opaque_test.go
@@ -1,0 +1,30 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package configopaque // import "go.opentelemetry.io/collector/config/configopaque"
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpaqueStringMarshalText(t *testing.T) {
+	var example String = "opaque"
+
+	opaque, err := example.MarshalText()
+	require.NoError(t, err)
+	assert.Equal(t, "******", string(opaque))
+}

--- a/config/configopaque/opaque_test.go
+++ b/config/configopaque/opaque_test.go
@@ -15,16 +15,28 @@
 package configopaque // import "go.opentelemetry.io/collector/config/configopaque"
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestOpaqueStringMarshalText(t *testing.T) {
+func TestStringMarshalText(t *testing.T) {
 	var example String = "opaque"
 
 	opaque, err := example.MarshalText()
 	require.NoError(t, err)
 	assert.Equal(t, "******", string(opaque))
+}
+
+func TestHeadersMarshalText(t *testing.T) {
+	var example = Headers{
+		"x-field-key":   "opaque",
+		"x-field-key-2": "opaque-2",
+	}
+
+	opaque, err := json.Marshal(example)
+	require.NoError(t, err)
+	assert.Equal(t, "{\"x-field-key\":\"******\",\"x-field-key-2\":\"********\"}", string(opaque))
 }

--- a/config/configopaque/opaque_test.go
+++ b/config/configopaque/opaque_test.go
@@ -15,7 +15,6 @@
 package configopaque // import "go.opentelemetry.io/collector/config/configopaque"
 
 import (
-	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -28,15 +27,4 @@ func TestStringMarshalText(t *testing.T) {
 	opaque, err := example.MarshalText()
 	require.NoError(t, err)
 	assert.Equal(t, "******", string(opaque))
-}
-
-func TestHeadersMarshalText(t *testing.T) {
-	var example = Headers{
-		"x-field-key":   "opaque",
-		"x-field-key-2": "opaque-2",
-	}
-
-	opaque, err := json.Marshal(example)
-	require.NoError(t, err)
-	assert.Equal(t, "{\"x-field-key\":\"******\",\"x-field-key-2\":\"********\"}", string(opaque))
 }


### PR DESCRIPTION
**Description:**

Add a `configopaque.String` type alias. This is the original proposal from #5653. I wanted to try this option out to make sure everyone understands the extent of breaking changes since, as mentioned on https://github.com/open-telemetry/opentelemetry-collector/issues/5653#issuecomment-1208609102, they should be minimal (as they only affect the Go API).

**Link to tracking Issue:** Updates #5653
