### PR TITLE
[chore] update go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	go.opencensus.io v0.23.0
 	go.opentelemetry.io/collector/extension/zpagesextension v0.0.0-20221102221454-bfc45c16c979
 	go.opentelemetry.io/collector/pdata v0.63.1
-	go.opentelemetry.io/collector/processor/batchprocessor v0.0.0-00010101000000-000000000000
+	go.opentelemetry.io/collector/processor/batchprocessor v0.0.0-20221103161931-a167b006e8c0
 	go.opentelemetry.io/collector/semconv v0.63.1
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.36.4
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.36.4


### PR DESCRIPTION
This updates the dependency for the batch processor in go.mod to make updating contrib easier.

The error in contrib:

```
go: downloading go.opentelemetry.io/collector/processor/batchprocessor v0.0.0-00010101000000-000000000000
github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azureblobreceiver tested by
        github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azureblobreceiver.test imports
        go.opentelemetry.io/collector/service/servicetest imports
        go.opentelemetry.io/collector/service imports
        go.opentelemetry.io/collector/processor/batchprocessor: go.opentelemetry.io/collector/processor/batchprocessor@v0.0.0-00010101000000-000000000000: invalid version: unknown revision 000000000000
```