### PR TITLE
Add DecodeHookFunc opt for confmap

### DIFF
--- a/confmap/confmap.go
+++ b/confmap/confmap.go
@@ -77,9 +77,9 @@ func WithErrorUnused() UnmarshalOption {
 
 // WithDecodeHookFunc allows adding custom mapstucture.DecodeHookFunc to the decoder.
 // Can be called multiple times to add multiple hook functions.
-func WithDecodeHookFunc(fn mapstructure.DecodeHookFunc) UnmarshalOption {
+func WithDecodeHookFunc(fn ...mapstructure.DecodeHookFunc) UnmarshalOption {
 	return unmarshalOptionFunc(func(uo *unmarshalOption) {
-		uo.hookFuncs = append(uo.hookFuncs, fn)
+		uo.hookFuncs = append(uo.hookFuncs, fn...)
 	})
 }
 
@@ -101,9 +101,9 @@ func (l *Conf) Unmarshal(result interface{}, opts ...UnmarshalOption) error {
 
 // WithHookFunc allows adding custom mapstucture.DecodeHookFunc to the encoder.
 // Can be called multiple times to add multiple hook functions.
-func WithEncodeHookFunc(fn mapstructure.DecodeHookFunc) MarshalOption {
+func WithEncodeHookFunc(fn ...mapstructure.DecodeHookFunc) MarshalOption {
 	return marshalOptionFunc(func(uo *marshalOption) {
-		uo.hookFuncs = append(uo.hookFuncs, fn)
+		uo.hookFuncs = append(uo.hookFuncs, fn...)
 	})
 }
 

--- a/confmap/confmap_test.go
+++ b/confmap/confmap_test.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -161,6 +162,28 @@ func TestUnmarshalWithErrorUnused(t *testing.T) {
 	}
 	conf := NewFromStringMap(stringMap)
 	assert.Error(t, conf.Unmarshal(&TestIDConfig{}, WithErrorUnused()))
+}
+
+func TestUnmarshalWithDecodeHookFunc(t *testing.T) {
+	stringMap := map[string]interface{}{
+		"boolean": true,
+		"string":  "this is a string",
+	}
+	conf := NewFromStringMap(stringMap)
+	assert.Error(t, conf.Unmarshal(&TestIDConfig{}, WithDecodeHookFunc(func(f reflect.Kind, t reflect.Kind, data any) (any, error) {
+		return nil, errors.New("decode hook error")
+	})))
+}
+
+func TestMarshalWithEncodeHookFunc(t *testing.T) {
+	stringMap := map[string]interface{}{
+		"boolean": true,
+		"string":  "this is a string",
+	}
+	conf := NewFromStringMap(stringMap)
+	assert.Error(t, conf.Marshal(&TestIDConfig{}, WithEncodeHookFunc(func(f reflect.Kind, t reflect.Kind, data any) (any, error) {
+		return nil, errors.New("encode hook error")
+	})))
 }
 
 type TestConfig struct {


### PR DESCRIPTION
Adding `mapstructure.DecodeHookFunc` as options to `conf.Unmarshal` and `conf.Marshal`.

For example to allow custom unmarshaling / marshaling of built-in types like `url.URL`.

```go
func MapstructureStringToUrlFunc() mapstructure.DecodeHookFunc {
	return func(
		f reflect.Type,
		t reflect.Type,
		data interface{}) (interface{}, error) {
		if f.Kind() != reflect.String {
			return data, nil
		}
		if t != reflect.TypeOf(url.URL{}) {
			return data, nil
		}

		return url.Parse(data.(string))
	}
}

err := conf.Unmarshal(&config, confmap.WithDecodeHookFunc(
  MapstructureStringToUrlFunc(),
))
```