### PR TITLE
Fix Reference drive-letter specification link invalid #6374

### DIFF
--- a/confmap/resolver.go
+++ b/confmap/resolver.go
@@ -29,7 +29,7 @@ import (
 
 var (
 	// follows drive-letter specification:
-	// https://tools.ietf.org/id/draft-kerwin-file-scheme-07.html#syntax
+	// https://datatracker.ietf.org/doc/html/draft-kerwin-file-scheme-07.html#section-2.2
 	driverLetterRegexp = regexp.MustCompile("^[A-z]:")
 
 	// Scheme name consist of a sequence of characters beginning with a letter and followed by any


### PR DESCRIPTION
Description: 

Made change to correct broken link in comments

Link to tracking Issue:

fixes #6374 

