### PR TITLE
Remove get from newly added funcs on Gate that don't conflict

### DIFF
--- a/featuregate/gates.go
+++ b/featuregate/gates.go
@@ -109,15 +109,15 @@ func (g *Gate) GetDescription() string {
 	return g.Description
 }
 
-func (g *Gate) GetStage() Stage {
+func (g *Gate) Stage() Stage {
 	return g.stage
 }
 
-func (g *Gate) GetReferenceURL() string {
+func (g *Gate) ReferenceURL() string {
 	return g.referenceURL
 }
 
-func (g *Gate) GetRemovalVersion() string {
+func (g *Gate) RemovalVersion() string {
 	return g.removalVersion
 }
 

--- a/featuregate/gates_test.go
+++ b/featuregate/gates_test.go
@@ -192,9 +192,9 @@ func TestGateMethods(t *testing.T) {
 	assert.Equal(t, "test", g.GetID())
 	assert.Equal(t, "test gate", g.GetDescription())
 	assert.Equal(t, false, g.IsEnabled())
-	assert.Equal(t, Alpha, g.GetStage())
-	assert.Equal(t, "http://example.com", g.GetReferenceURL())
-	assert.Equal(t, "v0.64.0", g.GetRemovalVersion())
+	assert.Equal(t, Alpha, g.Stage())
+	assert.Equal(t, "http://example.com", g.ReferenceURL())
+	assert.Equal(t, "v0.64.0", g.RemovalVersion())
 }
 
 func TestStageNames(t *testing.T) {

--- a/service/zpages.go
+++ b/service/zpages.go
@@ -75,9 +75,9 @@ func getFeaturesTableData() zpages.FeatureGateTableData {
 			ID:             g.GetID(),
 			Enabled:        g.IsEnabled(),
 			Description:    g.GetDescription(),
-			ReferenceURL:   g.GetReferenceURL(),
-			Stage:          g.GetStage().String(),
-			RemovalVersion: g.GetRemovalVersion(),
+			ReferenceURL:   g.ReferenceURL(),
+			Stage:          g.Stage().String(),
+			RemovalVersion: g.RemovalVersion(),
 		})
 	}
 


### PR DESCRIPTION
Because of the conflict between the public member and func name, cannot do the same for ID/Description, will fix in a later version after we remove the public members.

No need for deprecation, they were added in this version.

/cc @mx-psi based on the discussion from https://github.com/open-telemetry/opentelemetry-collector/pull/6447