### PR TITLE
Fix logging exporter to not mutate the data

### DIFF
--- a/.chloggen/fixlogging.yaml
+++ b/.chloggen/fixlogging.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: loggingexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix logging exporter to not mutate the data
+
+# One or more tracking issues or pull requests related to the change
+issues: [6420]

--- a/exporter/loggingexporter/internal/otlptext/databuffer.go
+++ b/exporter/loggingexporter/internal/otlptext/databuffer.go
@@ -52,7 +52,7 @@ func (b *dataBuffer) logAttributes(header string, m pcommon.Map) {
 		attrPrefix = headerParts[0] + attrPrefix
 	}
 
-	m.Sort().Range(func(k string, v pcommon.Value) bool {
+	m.Range(func(k string, v pcommon.Value) bool {
 		b.logEntry("%s %s: %s", attrPrefix, k, valueToString(v))
 		return true
 	})

--- a/pdata/pcommon/common.go
+++ b/pdata/pcommon/common.go
@@ -717,6 +717,9 @@ func (m Map) PutEmptySlice(k string) Slice {
 // Returns the same instance to allow nicer code like:
 //
 //	assert.EqualValues(t, expected.Sort(), actual.Sort())
+//
+// IMPORTANT: Sort mutates the data, if you call this function in a consumer,
+// the consumer must be configured that it mutates data.
 func (m Map) Sort() Map {
 	// Intention is to move the nil values at the end.
 	sort.SliceStable(*m.getOrig(), func(i, j int) bool {


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-collector/issues/6420

Affected versions:
* v0.62.0
* v0.62.1
* v0.63.0
* v0.64.0

If anyone experience this, simple fix is to remove the logging exporter.