### PR TITLE
[component] Update values returned by `StabilityLevel.String` method

### DIFF
--- a/.chloggen/update-stability-level-string.yaml
+++ b/.chloggen/update-stability-level-string.yaml
@@ -1,0 +1,8 @@
+change_type: breaking
+component: component
+note: Update values returned by `StabilityLevel.String` method.
+issues: [6490]
+subtext: |
+  - All returned strings are capitalized.
+  - "Undefined" is returned only for `StabilityLevelUndefined`.
+  - "" is returned for integers that are out of StabilityLevel enum range.

--- a/component/component.go
+++ b/component/component.go
@@ -120,20 +120,22 @@ const (
 
 func (sl StabilityLevel) String() string {
 	switch sl {
+	case StabilityLevelUndefined:
+		return "Undefined"
 	case StabilityLevelUnmaintained:
-		return "unmaintained"
+		return "Unmaintained"
 	case StabilityLevelDeprecated:
-		return "deprecated"
+		return "Deprecated"
 	case StabilityLevelInDevelopment:
-		return "in development"
+		return "In development"
 	case StabilityLevelAlpha:
-		return "alpha"
+		return "Alpha"
 	case StabilityLevelBeta:
-		return "beta"
+		return "Beta"
 	case StabilityLevelStable:
-		return "stable"
+		return "Stable"
 	}
-	return "undefined"
+	return ""
 }
 
 func (sl StabilityLevel) LogMessage() string {

--- a/component/component_test.go
+++ b/component/component_test.go
@@ -24,3 +24,14 @@ func TestBaseInternal(t *testing.T) {
 	base := baseFactory{}
 	assert.NotPanics(t, base.unexportedFactoryFunc)
 }
+
+func TestStabilityLevelString(t *testing.T) {
+	assert.EqualValues(t, "Undefined", StabilityLevelUndefined.String())
+	assert.EqualValues(t, "Unmaintained", StabilityLevelUnmaintained.String())
+	assert.EqualValues(t, "Deprecated", StabilityLevelDeprecated.String())
+	assert.EqualValues(t, "In development", StabilityLevelInDevelopment.String())
+	assert.EqualValues(t, "Alpha", StabilityLevelAlpha.String())
+	assert.EqualValues(t, "Beta", StabilityLevelBeta.String())
+	assert.EqualValues(t, "Stable", StabilityLevelStable.String())
+	assert.EqualValues(t, "", StabilityLevel(100).String())
+}


### PR DESCRIPTION
This change updates values returned by `StabilityLevel.String` to be consistent with other enum types:
  - All returned strings are capitalized.
  - "Undefined" is returned only for `StabilityLevelUndefined`.
  - "" is returned for integers that are out of StabilityLevel enum range.

Updates https://github.com/open-telemetry/opentelemetry-collector/issues/6490