### PR TITLE
Make impossible to implement RegistryOption outside featuregate package

### DIFF
--- a/.chloggen/registeroption.yaml
+++ b/.chloggen/registeroption.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: featuregate
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Make impossible to implement RegistryOption outside `featuregate` package
+
+# One or more tracking issues or pull requests related to the change
+issues: [6532]


### PR DESCRIPTION
This was something the I missed during the previous review.
