### PR TITLE
[configtelemetry] Update strings returned by `Level.[String|MarshalText]`

### DIFF
--- a/.chloggen/level-update-string.yaml
+++ b/.chloggen/level-update-string.yaml
@@ -1,0 +1,9 @@
+change_type: breaking
+component: configtelemetry
+note: Update values returned by `Level.String` and `Level.MarshalText` method.
+issues: [6490]
+subtext: |
+  - All returned strings are capitalized.
+  - "" is returned for integers that are out of Level enum range.
+  - It also affects `Level.Marshal` output, but it's not a problem because `Unmarshal` method accepts strings in
+  all cases, e.g. "normal", "Normal" and "NORMAL".

--- a/config/configtelemetry/configtelemetry.go
+++ b/config/configtelemetry/configtelemetry.go
@@ -31,10 +31,10 @@ const (
 	// LevelDetailed adds dimensions and views to the previous levels.
 	LevelDetailed
 
-	levelNoneStr     = "none"
-	levelBasicStr    = "basic"
-	levelNormalStr   = "normal"
-	levelDetailedStr = "detailed"
+	levelNoneStr     = "None"
+	levelBasicStr    = "Basic"
+	levelNormalStr   = "Normal"
+	levelDetailedStr = "Detailed"
 )
 
 // Level is the level of internal telemetry (metrics, logs, traces about the component itself)
@@ -55,7 +55,7 @@ func (l Level) String() string {
 	case LevelDetailed:
 		return levelDetailedStr
 	}
-	return "unknown"
+	return ""
 }
 
 // MarshalText marshals Level to text.
@@ -71,16 +71,16 @@ func (l *Level) UnmarshalText(text []byte) error {
 
 	str := strings.ToLower(string(text))
 	switch str {
-	case levelNoneStr:
+	case strings.ToLower(levelNoneStr):
 		*l = LevelNone
 		return nil
-	case levelBasicStr:
+	case strings.ToLower(levelBasicStr):
 		*l = LevelBasic
 		return nil
-	case levelNormalStr:
+	case strings.ToLower(levelNormalStr):
 		*l = LevelNormal
 		return nil
-	case levelDetailedStr:
+	case strings.ToLower(levelDetailedStr):
 		*l = LevelDetailed
 		return nil
 	}

--- a/config/configtelemetry/configtelemetry_test.go
+++ b/config/configtelemetry/configtelemetry_test.go
@@ -22,49 +22,46 @@ import (
 
 func TestUnmarshalText(t *testing.T) {
 	tests := []struct {
-		str   string
+		str   []string
 		level Level
 		err   bool
 	}{
 		{
-			str:   "",
+			str:   []string{"", "other_string"},
 			level: LevelNone,
 			err:   true,
 		},
 		{
-			str:   "other_string",
-			level: LevelNone,
-			err:   true,
-		},
-		{
-			str:   levelNoneStr,
+			str:   []string{"none", "None", "NONE"},
 			level: LevelNone,
 		},
 		{
-			str:   levelBasicStr,
+			str:   []string{"basic", "Basic", "BASIC"},
 			level: LevelBasic,
 		},
 		{
-			str:   levelNormalStr,
+			str:   []string{"normal", "Normal", "NORMAL"},
 			level: LevelNormal,
 		},
 		{
-			str:   levelDetailedStr,
+			str:   []string{"detailed", "Detailed", "DETAILED"},
 			level: LevelDetailed,
 		},
 	}
 
 	for _, test := range tests {
-		t.Run(test.str, func(t *testing.T) {
-			var lvl Level
-			err := lvl.UnmarshalText([]byte(test.str))
-			if test.err {
-				assert.Error(t, err)
-			} else {
-				assert.NoError(t, err)
-				assert.Equal(t, test.level, lvl)
-			}
-		})
+		for _, str := range test.str {
+			t.Run(str, func(t *testing.T) {
+				var lvl Level
+				err := lvl.UnmarshalText([]byte(str))
+				if test.err {
+					assert.Error(t, err)
+				} else {
+					assert.NoError(t, err)
+					assert.Equal(t, test.level, lvl)
+				}
+			})
+		}
 	}
 }
 
@@ -73,14 +70,14 @@ func TestUnmarshalTextNilLevel(t *testing.T) {
 	assert.Error(t, lvl.UnmarshalText([]byte(levelNormalStr)))
 }
 
-func TestLevelString(t *testing.T) {
+func TestLevelStringMarshal(t *testing.T) {
 	tests := []struct {
 		str   string
 		level Level
 		err   bool
 	}{
 		{
-			str:   "unknown",
+			str:   "",
 			level: Level(-10),
 		},
 		{

--- a/exporter/loggingexporter/config_test.go
+++ b/exporter/loggingexporter/config_test.go
@@ -108,7 +108,7 @@ func TestValidate(t *testing.T) {
 			cfg: &Config{
 				Verbosity: configtelemetry.LevelNone,
 			},
-			expectedErr: "verbosity level \"none\" is not supported",
+			expectedErr: "verbosity level \"None\" is not supported",
 		},
 		{
 			name: "verbosity detailed",


### PR DESCRIPTION
  - All returned strings are capitalized.
  - "" is returned for integers that are out of Level enum range.
  - It also affects `Level.MarshalText` output, but it's not a problem because `UnmarshalText` method accepts strings in all cases, e.g. "normal", "Normal" and "NORMAL".

Updates https://github.com/open-telemetry/opentelemetry-collector/issues/6490