### PR TITLE
Remove Validate() from Config interfaces and make it optional interface

### DIFF
--- a/.chloggen/rmvalidate.yaml
+++ b/.chloggen/rmvalidate.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: component
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove `Validate()` from component.*Config interfaces and make it optional interface
+
+# One or more tracking issues or pull requests related to the change
+issues: [6544]

--- a/component/config.go
+++ b/component/config.go
@@ -20,8 +20,6 @@ import (
 
 type Config interface {
 	identifiable
-	// Deprecated: [v0.65.0] use component.ValidateConfig.
-	Validate() error
 
 	privateConfig()
 }

--- a/config/exporter.go
+++ b/config/exporter.go
@@ -44,8 +44,3 @@ func (es *ExporterSettings) ID() component.ID {
 func (es *ExporterSettings) SetIDName(idName string) {
 	es.id = component.NewIDWithName(es.id.Type(), idName)
 }
-
-// Deprecated: [v0.65.0] use component.ValidateConfig.
-func (es *ExporterSettings) Validate() error {
-	return nil
-}

--- a/config/extension.go
+++ b/config/extension.go
@@ -44,8 +44,3 @@ func (es *ExtensionSettings) ID() component.ID {
 func (es *ExtensionSettings) SetIDName(idName string) {
 	es.id = component.NewIDWithName(es.id.Type(), idName)
 }
-
-// Deprecated: [v0.65.0] use component.ValidateConfig.
-func (es *ExtensionSettings) Validate() error {
-	return nil
-}

--- a/config/processor.go
+++ b/config/processor.go
@@ -44,8 +44,3 @@ func (ps *ProcessorSettings) ID() component.ID {
 func (ps *ProcessorSettings) SetIDName(idName string) {
 	ps.id = component.NewIDWithName(ps.id.Type(), idName)
 }
-
-// Deprecated: [v0.65.0] use component.ValidateConfig.
-func (ps *ProcessorSettings) Validate() error {
-	return nil
-}

--- a/config/receiver.go
+++ b/config/receiver.go
@@ -44,8 +44,3 @@ func (rs *ReceiverSettings) ID() component.ID {
 func (rs *ReceiverSettings) SetIDName(idName string) {
 	rs.id = component.NewIDWithName(rs.id.Type(), idName)
 }
-
-// Deprecated: [v0.65.0] Not needed anymore since the Validate() will be moved from Config interface to the optional ConfigValidator interface.
-func (rs *ReceiverSettings) Validate() error {
-	return nil
-}


### PR DESCRIPTION
The reason is to remove the need that every Config includes the "config.*Settings" structs, and remove these structs completely.

One of the functionality they offer right now is that they provide the "default" implementation for `Validate`, and this PR provides a solution to that, by making the `Validate` a proper optional functionality to implement instead of optionally override it.

Alternative is to make mandatory for every `component.*Config` to implement `Validate` and not provide a default in the `config.*Settings`, that also solves the dependency problem (between component and config), but it comes with a small caveat, since if we want to extend the capability to validate sub-configs then for these will be optionally implemented functionality, because of that I believe it is more consistent to make it optionally implementable everywhere.