### PR TITLE
Introduce component status reporting

### DIFF
--- a/component/component.go
+++ b/component/component.go
@@ -17,6 +17,8 @@ package component // import "go.opentelemetry.io/collector/component"
 import (
 	"context"
 	"errors"
+
+	"go.opentelemetry.io/collector/component/id"
 )
 
 var (
@@ -160,17 +162,17 @@ func (sl StabilityLevel) LogMessage() string {
 // use the factory helpers for the appropriate component type.
 type Factory interface {
 	// Type gets the type of the component created by this factory.
-	Type() Type
+	Type() id.Type
 
 	unexportedFactoryFunc()
 }
 
 type baseFactory struct {
-	cfgType Type
+	cfgType id.Type
 }
 
 func (baseFactory) unexportedFactoryFunc() {}
 
-func (bf baseFactory) Type() Type {
+func (bf baseFactory) Type() id.Type {
 	return bf.cfgType
 }

--- a/component/componenttest/nop_exporter.go
+++ b/component/componenttest/nop_exporter.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/id"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 )
@@ -40,7 +41,7 @@ func NewNopExporterFactory() component.ExporterFactory {
 		"nop",
 		func() component.ExporterConfig {
 			return &nopExporterConfig{
-				ExporterSettings: config.NewExporterSettings(component.NewID("nop")),
+				ExporterSettings: config.NewExporterSettings(id.NewID("nop")),
 			}
 		},
 		component.WithTracesExporter(createTracesExporter, component.StabilityLevelStable),

--- a/component/componenttest/nop_exporter_test.go
+++ b/component/componenttest/nop_exporter_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/id"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/pmetric"
@@ -31,9 +31,9 @@ import (
 func TestNewNopExporterFactory(t *testing.T) {
 	factory := NewNopExporterFactory()
 	require.NotNil(t, factory)
-	assert.Equal(t, component.Type("nop"), factory.Type())
+	assert.Equal(t, id.Type("nop"), factory.Type())
 	cfg := factory.CreateDefaultConfig()
-	assert.Equal(t, &nopExporterConfig{ExporterSettings: config.NewExporterSettings(component.NewID("nop"))}, cfg)
+	assert.Equal(t, &nopExporterConfig{ExporterSettings: config.NewExporterSettings(id.NewID("nop"))}, cfg)
 
 	traces, err := factory.CreateTracesExporter(context.Background(), NewNopExporterCreateSettings(), cfg)
 	require.NoError(t, err)

--- a/component/componenttest/nop_extension.go
+++ b/component/componenttest/nop_extension.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/id"
 	"go.opentelemetry.io/collector/config"
 )
 
@@ -39,7 +40,7 @@ func NewNopExtensionFactory() component.ExtensionFactory {
 		"nop",
 		func() component.ExtensionConfig {
 			return &nopExtensionConfig{
-				ExtensionSettings: config.NewExtensionSettings(component.NewID("nop")),
+				ExtensionSettings: config.NewExtensionSettings(id.NewID("nop")),
 			}
 		},
 		func(context.Context, component.ExtensionCreateSettings, component.ExtensionConfig) (component.Extension, error) {

--- a/component/componenttest/nop_extension_test.go
+++ b/component/componenttest/nop_extension_test.go
@@ -21,16 +21,16 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/id"
 	"go.opentelemetry.io/collector/config"
 )
 
 func TestNewNopExtensionFactory(t *testing.T) {
 	factory := NewNopExtensionFactory()
 	require.NotNil(t, factory)
-	assert.Equal(t, component.Type("nop"), factory.Type())
+	assert.Equal(t, id.Type("nop"), factory.Type())
 	cfg := factory.CreateDefaultConfig()
-	assert.Equal(t, &nopExtensionConfig{ExtensionSettings: config.NewExtensionSettings(component.NewID("nop"))}, cfg)
+	assert.Equal(t, &nopExtensionConfig{ExtensionSettings: config.NewExtensionSettings(id.NewID("nop"))}, cfg)
 
 	traces, err := factory.CreateExtension(context.Background(), NewNopExtensionCreateSettings(), cfg)
 	require.NoError(t, err)

--- a/component/componenttest/nop_host.go
+++ b/component/componenttest/nop_host.go
@@ -16,6 +16,8 @@ package componenttest // import "go.opentelemetry.io/collector/component/compone
 
 import (
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/id"
+	"go.opentelemetry.io/collector/component/status"
 )
 
 // nopHost mocks a receiver.ReceiverHost for test purposes.
@@ -28,14 +30,21 @@ func NewNopHost() component.Host {
 
 func (nh *nopHost) ReportFatalError(_ error) {}
 
-func (nh *nopHost) GetFactory(_ component.Kind, _ component.Type) component.Factory {
+func (nh *nopHost) GetFactory(_ component.Kind, _ id.Type) component.Factory {
 	return nil
 }
 
-func (nh *nopHost) GetExtensions() map[component.ID]component.Extension {
+func (nh *nopHost) GetExtensions() map[id.ID]component.Extension {
 	return nil
 }
 
-func (nh *nopHost) GetExporters() map[component.DataType]map[component.ID]component.Exporter {
+func (nh *nopHost) GetExporters() map[component.DataType]map[id.ID]component.Exporter {
+	return nil
+}
+
+func (nh *nopHost) ReportComponentStatus(event *status.ComponentEvent) {
+}
+
+func (nh *nopHost) RegisterStatusListener(options ...status.ListenerOption) component.StatusListenerUnregisterFunc {
 	return nil
 }

--- a/component/componenttest/nop_host_test.go
+++ b/component/componenttest/nop_host_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/status"
 )
 
 func TestNewNopHost(t *testing.T) {
@@ -30,6 +31,8 @@ func TestNewNopHost(t *testing.T) {
 	require.IsType(t, &nopHost{}, nh)
 
 	nh.ReportFatalError(errors.New("TestError"))
+	nh.ReportComponentStatus(&status.ComponentEvent{})
+	assert.Nil(t, nh.RegisterStatusListener())
 	assert.Nil(t, nh.GetExporters())
 	assert.Nil(t, nh.GetExtensions())
 	assert.Nil(t, nh.GetFactory(component.KindReceiver, "test"))

--- a/component/componenttest/nop_processor.go
+++ b/component/componenttest/nop_processor.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/id"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumertest"
@@ -41,7 +42,7 @@ func NewNopProcessorFactory() component.ProcessorFactory {
 		"nop",
 		func() component.ProcessorConfig {
 			return &nopProcessorConfig{
-				ProcessorSettings: config.NewProcessorSettings(component.NewID("nop")),
+				ProcessorSettings: config.NewProcessorSettings(id.NewID("nop")),
 			}
 		},
 		component.WithTracesProcessor(createTracesProcessor, component.StabilityLevelStable),

--- a/component/componenttest/nop_processor_test.go
+++ b/component/componenttest/nop_processor_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/id"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumertest"
@@ -33,9 +33,9 @@ import (
 func TestNewNopProcessorFactory(t *testing.T) {
 	factory := NewNopProcessorFactory()
 	require.NotNil(t, factory)
-	assert.Equal(t, component.Type("nop"), factory.Type())
+	assert.Equal(t, id.Type("nop"), factory.Type())
 	cfg := factory.CreateDefaultConfig()
-	assert.Equal(t, &nopProcessorConfig{ProcessorSettings: config.NewProcessorSettings(component.NewID("nop"))}, cfg)
+	assert.Equal(t, &nopProcessorConfig{ProcessorSettings: config.NewProcessorSettings(id.NewID("nop"))}, cfg)
 
 	traces, err := factory.CreateTracesProcessor(context.Background(), NewNopProcessorCreateSettings(), cfg, consumertest.NewNop())
 	require.NoError(t, err)

--- a/component/componenttest/nop_receiver.go
+++ b/component/componenttest/nop_receiver.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/id"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/consumer"
 )
@@ -40,7 +41,7 @@ func NewNopReceiverFactory() component.ReceiverFactory {
 		"nop",
 		func() component.ReceiverConfig {
 			return &nopReceiverConfig{
-				ReceiverSettings: config.NewReceiverSettings(component.NewID("nop")),
+				ReceiverSettings: config.NewReceiverSettings(id.NewID("nop")),
 			}
 		},
 		component.WithTracesReceiver(createTracesReceiver, component.StabilityLevelStable),

--- a/component/componenttest/nop_receiver_test.go
+++ b/component/componenttest/nop_receiver_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/id"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 )
@@ -29,9 +29,9 @@ import (
 func TestNewNopReceiverFactory(t *testing.T) {
 	factory := NewNopReceiverFactory()
 	require.NotNil(t, factory)
-	assert.Equal(t, component.Type("nop"), factory.Type())
+	assert.Equal(t, id.Type("nop"), factory.Type())
 	cfg := factory.CreateDefaultConfig()
-	assert.Equal(t, &nopReceiverConfig{ReceiverSettings: config.NewReceiverSettings(component.NewID("nop"))}, cfg)
+	assert.Equal(t, &nopReceiverConfig{ReceiverSettings: config.NewReceiverSettings(id.NewID("nop"))}, cfg)
 
 	traces, err := factory.CreateTracesReceiver(context.Background(), NewNopReceiverCreateSettings(), cfg, consumertest.NewNop())
 	require.NoError(t, err)

--- a/component/config.go
+++ b/component/config.go
@@ -15,11 +15,9 @@
 package component // import "go.opentelemetry.io/collector/component"
 
 import (
+	"go.opentelemetry.io/collector/component/id"
 	"go.opentelemetry.io/collector/confmap"
 )
-
-// Type is the component type as it is used in the config.
-type Type string
 
 // validatable defines the interface for the configuration validation.
 type validatable interface {
@@ -29,7 +27,7 @@ type validatable interface {
 
 // DataType is a special Type that represents the data types supported by the collector. We currently support
 // collecting metrics, traces and logs, this can expand in the future.
-type DataType = Type
+type DataType = id.Type
 
 // Currently supported data types. Add new data types here when new types are supported in the future.
 const (

--- a/component/experimental/component/factory.go
+++ b/component/experimental/component/factory.go
@@ -20,6 +20,7 @@ import (
 	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/id"
 	"go.opentelemetry.io/collector/config/experimental/config"
 	"go.opentelemetry.io/collector/config/experimental/configsource"
 )
@@ -56,4 +57,4 @@ type ConfigSourceFactory interface {
 }
 
 // ConfigSourceFactories maps the type of a ConfigSource to the respective factory object.
-type ConfigSourceFactories map[component.Type]ConfigSourceFactory
+type ConfigSourceFactories map[id.Type]ConfigSourceFactory

--- a/component/exporter.go
+++ b/component/exporter.go
@@ -17,6 +17,7 @@ package component // import "go.opentelemetry.io/collector/component"
 import (
 	"context"
 
+	"go.opentelemetry.io/collector/component/id"
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/consumer"
 )
@@ -213,7 +214,7 @@ func WithLogsExporter(createLogsExporter CreateLogsExporterFunc, sl StabilityLev
 }
 
 // NewExporterFactory returns a ExporterFactory.
-func NewExporterFactory(cfgType Type, createDefaultConfig ExporterCreateDefaultConfigFunc, options ...ExporterFactoryOption) ExporterFactory {
+func NewExporterFactory(cfgType id.Type, createDefaultConfig ExporterCreateDefaultConfigFunc, options ...ExporterFactoryOption) ExporterFactory {
 	f := &exporterFactory{
 		baseFactory:                     baseFactory{cfgType: cfgType},
 		ExporterCreateDefaultConfigFunc: createDefaultConfig,

--- a/component/exporter_test.go
+++ b/component/exporter_test.go
@@ -23,12 +23,13 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/id"
 	"go.opentelemetry.io/collector/config"
 )
 
 func TestNewExporterFactory(t *testing.T) {
 	const typeStr = "test"
-	defaultCfg := config.NewExporterSettings(component.NewID(typeStr))
+	defaultCfg := config.NewExporterSettings(id.NewID(typeStr))
 	factory := component.NewExporterFactory(
 		typeStr,
 		func() component.ExporterConfig { return &defaultCfg })
@@ -44,7 +45,7 @@ func TestNewExporterFactory(t *testing.T) {
 
 func TestNewExporterFactory_WithOptions(t *testing.T) {
 	const typeStr = "test"
-	defaultCfg := config.NewExporterSettings(component.NewID(typeStr))
+	defaultCfg := config.NewExporterSettings(id.NewID(typeStr))
 	factory := component.NewExporterFactory(
 		typeStr,
 		func() component.ExporterConfig { return &defaultCfg },

--- a/component/extension.go
+++ b/component/extension.go
@@ -17,6 +17,7 @@ package component // import "go.opentelemetry.io/collector/component"
 import (
 	"context"
 
+	"go.opentelemetry.io/collector/component/id"
 	"go.opentelemetry.io/collector/confmap"
 )
 
@@ -47,6 +48,7 @@ type Extension interface {
 // Collector that is to be implemented by extensions interested in changes to pipeline
 // states. Typically this will be used by extensions that change their behavior if data is
 // being ingested or not, e.g.: a k8s readiness probe.
+// Deprecated: [0.65.0] Use Host.RegisterStatusListener() instead.
 type PipelineWatcher interface {
 	// Ready notifies the Extension that all pipelines were built and the
 	// receivers were started, i.e.: the service is ready to receive data
@@ -117,7 +119,7 @@ func (ef *extensionFactory) ExtensionStability() StabilityLevel {
 
 // NewExtensionFactory returns a new ExtensionFactory  based on this configuration.
 func NewExtensionFactory(
-	cfgType Type,
+	cfgType id.Type,
 	createDefaultConfig ExtensionCreateDefaultConfigFunc,
 	createServiceExtension CreateExtensionFunc,
 	sl StabilityLevel) ExtensionFactory {

--- a/component/extension_test.go
+++ b/component/extension_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/id"
 	"go.opentelemetry.io/collector/config"
 )
 
@@ -33,7 +34,7 @@ type nopExtension struct {
 
 func TestNewExtensionFactory(t *testing.T) {
 	const typeStr = "test"
-	defaultCfg := config.NewExtensionSettings(component.NewID(typeStr))
+	defaultCfg := config.NewExtensionSettings(id.NewID(typeStr))
 	nopExtensionInstance := new(nopExtension)
 
 	factory := component.NewExtensionFactory(

--- a/component/factories.go
+++ b/component/factories.go
@@ -16,29 +16,31 @@ package component // import "go.opentelemetry.io/collector/component"
 
 import (
 	"fmt"
+
+	"go.opentelemetry.io/collector/component/id"
 )
 
 // Factories struct holds in a single type all component factories that
 // can be handled by the Config.
 type Factories struct {
 	// Receivers maps receiver type names in the config to the respective factory.
-	Receivers map[Type]ReceiverFactory
+	Receivers map[id.Type]ReceiverFactory
 
 	// Processors maps processor type names in the config to the respective factory.
-	Processors map[Type]ProcessorFactory
+	Processors map[id.Type]ProcessorFactory
 
 	// Exporters maps exporter type names in the config to the respective factory.
-	Exporters map[Type]ExporterFactory
+	Exporters map[id.Type]ExporterFactory
 
 	// Extensions maps extension type names in the config to the respective factory.
-	Extensions map[Type]ExtensionFactory
+	Extensions map[id.Type]ExtensionFactory
 }
 
 // MakeReceiverFactoryMap takes a list of receiver factories and returns a map
 // with factory type as keys. It returns a non-nil error when more than one factories
 // have the same type.
-func MakeReceiverFactoryMap(factories ...ReceiverFactory) (map[Type]ReceiverFactory, error) {
-	fMap := map[Type]ReceiverFactory{}
+func MakeReceiverFactoryMap(factories ...ReceiverFactory) (map[id.Type]ReceiverFactory, error) {
+	fMap := map[id.Type]ReceiverFactory{}
 	for _, f := range factories {
 		if _, ok := fMap[f.Type()]; ok {
 			return fMap, fmt.Errorf("duplicate receiver factory %q", f.Type())
@@ -51,8 +53,8 @@ func MakeReceiverFactoryMap(factories ...ReceiverFactory) (map[Type]ReceiverFact
 // MakeProcessorFactoryMap takes a list of processor factories and returns a map
 // with factory type as keys. It returns a non-nil error when more than one factories
 // have the same type.
-func MakeProcessorFactoryMap(factories ...ProcessorFactory) (map[Type]ProcessorFactory, error) {
-	fMap := map[Type]ProcessorFactory{}
+func MakeProcessorFactoryMap(factories ...ProcessorFactory) (map[id.Type]ProcessorFactory, error) {
+	fMap := map[id.Type]ProcessorFactory{}
 	for _, f := range factories {
 		if _, ok := fMap[f.Type()]; ok {
 			return fMap, fmt.Errorf("duplicate processor factory %q", f.Type())
@@ -65,8 +67,8 @@ func MakeProcessorFactoryMap(factories ...ProcessorFactory) (map[Type]ProcessorF
 // MakeExporterFactoryMap takes a list of exporter factories and returns a map
 // with factory type as keys. It returns a non-nil error when more than one factories
 // have the same type.
-func MakeExporterFactoryMap(factories ...ExporterFactory) (map[Type]ExporterFactory, error) {
-	fMap := map[Type]ExporterFactory{}
+func MakeExporterFactoryMap(factories ...ExporterFactory) (map[id.Type]ExporterFactory, error) {
+	fMap := map[id.Type]ExporterFactory{}
 	for _, f := range factories {
 		if _, ok := fMap[f.Type()]; ok {
 			return fMap, fmt.Errorf("duplicate exporter factory %q", f.Type())
@@ -79,8 +81,8 @@ func MakeExporterFactoryMap(factories ...ExporterFactory) (map[Type]ExporterFact
 // MakeExtensionFactoryMap takes a list of extension factories and returns a map
 // with factory type as keys. It returns a non-nil error when more than one factories
 // have the same type.
-func MakeExtensionFactoryMap(factories ...ExtensionFactory) (map[Type]ExtensionFactory, error) {
-	fMap := map[Type]ExtensionFactory{}
+func MakeExtensionFactoryMap(factories ...ExtensionFactory) (map[id.Type]ExtensionFactory, error) {
+	fMap := map[id.Type]ExtensionFactory{}
 	for _, f := range factories {
 		if _, ok := fMap[f.Type()]; ok {
 			return fMap, fmt.Errorf("duplicate extension factory %q", f.Type())

--- a/component/factories_test.go
+++ b/component/factories_test.go
@@ -18,13 +18,15 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"go.opentelemetry.io/collector/component/id"
 )
 
 func TestMakeExtensionFactoryMap(t *testing.T) {
 	type testCase struct {
 		name string
 		in   []ExtensionFactory
-		out  map[Type]ExtensionFactory
+		out  map[id.Type]ExtensionFactory
 	}
 
 	p1 := NewExtensionFactory("p1", nil, nil, StabilityLevelAlpha)
@@ -33,7 +35,7 @@ func TestMakeExtensionFactoryMap(t *testing.T) {
 		{
 			name: "different names",
 			in:   []ExtensionFactory{p1, p2},
-			out: map[Type]ExtensionFactory{
+			out: map[id.Type]ExtensionFactory{
 				p1.Type(): p1,
 				p2.Type(): p2,
 			},
@@ -61,7 +63,7 @@ func TestMakeReceiverFactoryMap(t *testing.T) {
 	type testCase struct {
 		name string
 		in   []ReceiverFactory
-		out  map[Type]ReceiverFactory
+		out  map[id.Type]ReceiverFactory
 	}
 
 	p1 := NewReceiverFactory("p1", nil)
@@ -70,7 +72,7 @@ func TestMakeReceiverFactoryMap(t *testing.T) {
 		{
 			name: "different names",
 			in:   []ReceiverFactory{p1, p2},
-			out: map[Type]ReceiverFactory{
+			out: map[id.Type]ReceiverFactory{
 				p1.Type(): p1,
 				p2.Type(): p2,
 			},
@@ -99,7 +101,7 @@ func TestMakeProcessorFactoryMap(t *testing.T) {
 	type testCase struct {
 		name string
 		in   []ProcessorFactory
-		out  map[Type]ProcessorFactory
+		out  map[id.Type]ProcessorFactory
 	}
 
 	p1 := NewProcessorFactory("p1", nil)
@@ -108,7 +110,7 @@ func TestMakeProcessorFactoryMap(t *testing.T) {
 		{
 			name: "different names",
 			in:   []ProcessorFactory{p1, p2},
-			out: map[Type]ProcessorFactory{
+			out: map[id.Type]ProcessorFactory{
 				p1.Type(): p1,
 				p2.Type(): p2,
 			},
@@ -137,7 +139,7 @@ func TestMakeExporterFactoryMap(t *testing.T) {
 	type testCase struct {
 		name string
 		in   []ExporterFactory
-		out  map[Type]ExporterFactory
+		out  map[id.Type]ExporterFactory
 	}
 
 	p1 := NewExporterFactory("p1", nil)
@@ -146,7 +148,7 @@ func TestMakeExporterFactoryMap(t *testing.T) {
 		{
 			name: "different names",
 			in:   []ExporterFactory{p1, p2},
-			out: map[Type]ExporterFactory{
+			out: map[id.Type]ExporterFactory{
 				p1.Type(): p1,
 				p2.Type(): p2,
 			},

--- a/component/id/id.go
+++ b/component/id/id.go
@@ -1,0 +1,95 @@
+// Copyright  The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package id
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// typeAndNameSeparator is the separator that is used between type and name in type/name composite keys.
+const typeAndNameSeparator = "/"
+
+// ID represents the identity for a component. It combines two values:
+// * type - the Type of the component.
+// * name - the name of that component.
+// The component ID (combination type + name) is unique for a given component.Kind.
+type ID struct {
+	typeVal Type   `mapstructure:"-"`
+	nameVal string `mapstructure:"-"`
+}
+
+// NewID returns a new ID with the given Type and empty name.
+func NewID(typeVal Type) ID {
+	return ID{typeVal: typeVal}
+}
+
+// NewIDWithName returns a new ID with the given Type and name.
+func NewIDWithName(typeVal Type, nameVal string) ID {
+	return ID{typeVal: typeVal, nameVal: nameVal}
+}
+
+// Type returns the type of the component.
+func (id ID) Type() Type {
+	return id.typeVal
+}
+
+// Name returns the custom name of the component.
+func (id ID) Name() string {
+	return id.nameVal
+}
+
+// MarshalText implements the encoding.TextMarshaler interface.
+// This marshals the type and name as one string in the config.
+func (id ID) MarshalText() (text []byte, err error) {
+	return []byte(id.String()), nil
+}
+
+// UnmarshalText implements the encoding.TextUnmarshaler interface.
+func (id *ID) UnmarshalText(text []byte) error {
+	idStr := string(text)
+	items := strings.SplitN(idStr, typeAndNameSeparator, 2)
+	if len(items) >= 1 {
+		id.typeVal = Type(strings.TrimSpace(items[0]))
+	}
+
+	if len(items) == 1 && id.typeVal == "" {
+		return errors.New("id must not be empty")
+	}
+
+	if id.typeVal == "" {
+		return fmt.Errorf("in %q id: the part before %s should not be empty", idStr, typeAndNameSeparator)
+	}
+
+	if len(items) > 1 {
+		// "name" part is present.
+		id.nameVal = strings.TrimSpace(items[1])
+		if id.nameVal == "" {
+			return fmt.Errorf("in %q id: the part after %s should not be empty", idStr, typeAndNameSeparator)
+		}
+	}
+
+	return nil
+}
+
+// String returns the ID string representation as "type[/name]" format.
+func (id ID) String() string {
+	if id.nameVal == "" {
+		return string(id.typeVal)
+	}
+
+	return string(id.typeVal) + typeAndNameSeparator + id.nameVal
+}

--- a/component/id/id_test.go
+++ b/component/id/id_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package component
+package id
 
 import (
 	"testing"

--- a/component/id/type.go
+++ b/component/id/type.go
@@ -1,10 +1,10 @@
-// Copyright The OpenTelemetry Authors
+// Copyright  The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//       http://www.apache.org/licenses/LICENSE-2.0
+//      http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -12,11 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package extensions // import "go.opentelemetry.io/collector/service/extensions"
+package id
 
-import (
-	"go.opentelemetry.io/collector/component/id"
-)
-
-// Config represents the ordered list of extensions configured for the service.
-type Config []id.ID
+// Type is the component type as it is used in the component's ID.
+type Type string

--- a/component/identifiable.go
+++ b/component/identifiable.go
@@ -15,89 +15,29 @@
 package component // import "go.opentelemetry.io/collector/component"
 
 import (
-	"errors"
-	"fmt"
-	"strings"
+	"go.opentelemetry.io/collector/component/id"
 )
-
-// typeAndNameSeparator is the separator that is used between type and name in type/name composite keys.
-const typeAndNameSeparator = "/"
 
 // identifiable is an interface that all components configurations MUST embed.
 type identifiable interface {
 	// ID returns the ID of the component that this configuration belongs to.
-	ID() ID
+	ID() id.ID
 	// SetIDName updates the name part of the ID for the component that this configuration belongs to.
 	SetIDName(idName string)
 }
 
-// ID represents the identity for a component. It combines two values:
-// * type - the Type of the component.
-// * name - the name of that component.
-// The component ID (combination type + name) is unique for a given component.Kind.
-type ID struct {
-	typeVal Type   `mapstructure:"-"`
-	nameVal string `mapstructure:"-"`
-}
+// Deprecated: [0.65.0] Use id.ID instead.
+type ID = id.ID
 
-// NewID returns a new ID with the given Type and empty name.
+// Deprecated: [0.65.0] Use id.Type instead.
+type Type = id.Type
+
+// Deprecated: [0.65.0] Use id.NewID instead.
 func NewID(typeVal Type) ID {
-	return ID{typeVal: typeVal}
+	return id.NewID(typeVal)
 }
 
-// NewIDWithName returns a new ID with the given Type and name.
+// Deprecated: [0.65.0] Use id.NewIDWithName instead.
 func NewIDWithName(typeVal Type, nameVal string) ID {
-	return ID{typeVal: typeVal, nameVal: nameVal}
-}
-
-// Type returns the type of the component.
-func (id ID) Type() Type {
-	return id.typeVal
-}
-
-// Name returns the custom name of the component.
-func (id ID) Name() string {
-	return id.nameVal
-}
-
-// MarshalText implements the encoding.TextMarshaler interface.
-// This marshals the type and name as one string in the config.
-func (id ID) MarshalText() (text []byte, err error) {
-	return []byte(id.String()), nil
-}
-
-// UnmarshalText implements the encoding.TextUnmarshaler interface.
-func (id *ID) UnmarshalText(text []byte) error {
-	idStr := string(text)
-	items := strings.SplitN(idStr, typeAndNameSeparator, 2)
-	if len(items) >= 1 {
-		id.typeVal = Type(strings.TrimSpace(items[0]))
-	}
-
-	if len(items) == 1 && id.typeVal == "" {
-		return errors.New("id must not be empty")
-	}
-
-	if id.typeVal == "" {
-		return fmt.Errorf("in %q id: the part before %s should not be empty", idStr, typeAndNameSeparator)
-	}
-
-	if len(items) > 1 {
-		// "name" part is present.
-		id.nameVal = strings.TrimSpace(items[1])
-		if id.nameVal == "" {
-			return fmt.Errorf("in %q id: the part after %s should not be empty", idStr, typeAndNameSeparator)
-		}
-	}
-
-	return nil
-}
-
-// String returns the ID string representation as "type[/name]" format.
-func (id ID) String() string {
-	if id.nameVal == "" {
-		return string(id.typeVal)
-	}
-
-	return string(id.typeVal) + typeAndNameSeparator + id.nameVal
+	return id.NewIDWithName(typeVal, nameVal)
 }

--- a/component/processor.go
+++ b/component/processor.go
@@ -17,6 +17,7 @@ package component // import "go.opentelemetry.io/collector/component"
 import (
 	"context"
 
+	"go.opentelemetry.io/collector/component/id"
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/consumer"
 )
@@ -228,7 +229,7 @@ func WithLogsProcessor(createLogsProcessor CreateLogsProcessorFunc, sl Stability
 }
 
 // NewProcessorFactory returns a ProcessorFactory.
-func NewProcessorFactory(cfgType Type, createDefaultConfig ProcessorCreateDefaultConfigFunc, options ...ProcessorFactoryOption) ProcessorFactory {
+func NewProcessorFactory(cfgType id.Type, createDefaultConfig ProcessorCreateDefaultConfigFunc, options ...ProcessorFactoryOption) ProcessorFactory {
 	f := &processorFactory{
 		baseFactory:                      baseFactory{cfgType: cfgType},
 		ProcessorCreateDefaultConfigFunc: createDefaultConfig,

--- a/component/processor_test.go
+++ b/component/processor_test.go
@@ -23,13 +23,14 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/id"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/consumer"
 )
 
 func TestNewProcessorFactory(t *testing.T) {
 	const typeStr = "test"
-	defaultCfg := config.NewProcessorSettings(component.NewID(typeStr))
+	defaultCfg := config.NewProcessorSettings(id.NewID(typeStr))
 	factory := component.NewProcessorFactory(
 		typeStr,
 		func() component.ProcessorConfig { return &defaultCfg })
@@ -45,7 +46,7 @@ func TestNewProcessorFactory(t *testing.T) {
 
 func TestNewProcessorFactory_WithOptions(t *testing.T) {
 	const typeStr = "test"
-	defaultCfg := config.NewProcessorSettings(component.NewID(typeStr))
+	defaultCfg := config.NewProcessorSettings(id.NewID(typeStr))
 	factory := component.NewProcessorFactory(
 		typeStr,
 		func() component.ProcessorConfig { return &defaultCfg },

--- a/component/receiver.go
+++ b/component/receiver.go
@@ -17,6 +17,7 @@ package component // import "go.opentelemetry.io/collector/component"
 import (
 	"context"
 
+	"go.opentelemetry.io/collector/component/id"
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/consumer"
 )
@@ -273,7 +274,7 @@ func WithLogsReceiver(createLogsReceiver CreateLogsReceiverFunc, sl StabilityLev
 }
 
 // NewReceiverFactory returns a ReceiverFactory.
-func NewReceiverFactory(cfgType Type, createDefaultConfig ReceiverCreateDefaultConfigFunc, options ...ReceiverFactoryOption) ReceiverFactory {
+func NewReceiverFactory(cfgType id.Type, createDefaultConfig ReceiverCreateDefaultConfigFunc, options ...ReceiverFactoryOption) ReceiverFactory {
 	f := &receiverFactory{
 		baseFactory:                     baseFactory{cfgType: cfgType},
 		ReceiverCreateDefaultConfigFunc: createDefaultConfig,

--- a/component/receiver_test.go
+++ b/component/receiver_test.go
@@ -23,13 +23,14 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/id"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/consumer"
 )
 
 func TestNewReceiverFactory(t *testing.T) {
 	const typeStr = "test"
-	defaultCfg := config.NewReceiverSettings(component.NewID(typeStr))
+	defaultCfg := config.NewReceiverSettings(id.NewID(typeStr))
 	factory := component.NewReceiverFactory(
 		typeStr,
 		func() component.ReceiverConfig { return &defaultCfg })
@@ -45,7 +46,7 @@ func TestNewReceiverFactory(t *testing.T) {
 
 func TestNewReceiverFactory_WithOptions(t *testing.T) {
 	const typeStr = "test"
-	defaultCfg := config.NewReceiverSettings(component.NewID(typeStr))
+	defaultCfg := config.NewReceiverSettings(id.NewID(typeStr))
 	factory := component.NewReceiverFactory(
 		typeStr,
 		func() component.ReceiverConfig { return &defaultCfg },

--- a/component/status/status.go
+++ b/component/status/status.go
@@ -1,0 +1,131 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package status
+
+import (
+	"errors"
+	"time"
+
+	"go.opentelemetry.io/collector/component/id"
+)
+
+// ComponentEventType represents an enumeration of component status event types.
+type ComponentEventType int
+
+const (
+	// ComponentOK indicates the component is functioning normally.
+	ComponentOK ComponentEventType = iota
+	// ComponentError indicates the component is in erroneous state.
+	ComponentError
+)
+
+// Source component that reports a status about itself.
+// The implementation of this interface must be comparable to be useful as a map key.
+type Source interface {
+	ID() id.ID
+}
+
+// ComponentEvent is a status event produced by a component to communicate its status to
+// registered listeners.
+// An event can signal that a component is working normally (status.ComponentOK),
+// or that it is in an error state (status.ComponentError). An error status may
+// optionally include an error object to provide additional insight to
+// registered listeners.
+type ComponentEvent struct {
+	eventType ComponentEventType
+	timestamp time.Time
+	source    Source
+	err       error
+}
+
+// Type returns the event type.
+func (ev *ComponentEvent) Type() ComponentEventType {
+	return ev.eventType
+}
+
+// Source is the component that is reporting its status.
+func (ev *ComponentEvent) Source() Source {
+	return ev.source
+}
+
+// Timestamp returns the time of the event.
+func (ev *ComponentEvent) Timestamp() time.Time {
+	return ev.timestamp
+}
+
+// Err returns the error associated with the ComponentEvent.
+func (ev *ComponentEvent) Err() error {
+	return ev.err
+}
+
+// ComponentEventOption applies options to a ComponentEvent.
+type ComponentEventOption func(*ComponentEvent) error
+
+// WithSource sets the source component for a ComponentEvent.
+func WithSource(source Source) ComponentEventOption {
+	return func(o *ComponentEvent) error {
+		o.source = source
+		return nil
+	}
+}
+
+// WithTimestamp sets the timestamp for a ComponentEvent.
+func WithTimestamp(timestamp time.Time) ComponentEventOption {
+	return func(o *ComponentEvent) error {
+		o.timestamp = timestamp
+		return nil
+	}
+}
+
+// WithError sets the error object of the Event. It is optional
+// and should only be applied to an Event of type ComponentError.
+func WithError(err error) ComponentEventOption {
+	return func(o *ComponentEvent) error {
+		if o.eventType == ComponentOK {
+			return errors.New("event with ComponentOK cannot have an error")
+		}
+		o.err = err
+		return nil
+	}
+}
+
+// NewComponentEvent creates and returns a ComponentEvent with default and provided
+// options. Will return an error if an error is provided for a non-error event
+// type (status.ComponentOK).
+// If the timestamp is not provided will set it to time.Now().
+func NewComponentEvent(
+	eventType ComponentEventType, options ...ComponentEventOption,
+) (*ComponentEvent, error) {
+	ev := ComponentEvent{
+		eventType: eventType,
+	}
+
+	for _, opt := range options {
+		if err := opt(&ev); err != nil {
+			return nil, err
+		}
+	}
+
+	if ev.timestamp.IsZero() {
+		ev.timestamp = time.Now()
+	}
+
+	return &ev, nil
+}
+
+// ComponentEventFunc is a callback function that receives ComponentEvent.
+type ComponentEventFunc func(event *ComponentEvent) error
+
+var noopComponentEventFunc = func(event *ComponentEvent) error { return nil }

--- a/component/status/status_listener.go
+++ b/component/status/status_listener.go
@@ -1,0 +1,63 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package status
+
+// Listener is a struct that holds component and pipeline status events handlers.
+type Listener struct {
+	componentEventHandler ComponentEventFunc
+	pipelineStatusHandler PipelineStatusFunc
+}
+
+// ComponentEventHandler delegates to the underlying handler registered to the Listener.
+func (l *Listener) ComponentEventHandler(event *ComponentEvent) error {
+	return l.componentEventHandler(event)
+}
+
+// PipelineStatusHandler delegates to the underlying handler registered to the Listener.
+func (l *Listener) PipelineStatusHandler(status PipelineReadiness) error {
+	return l.pipelineStatusHandler(status)
+}
+
+// ListenerOption applies options to a Listener.
+type ListenerOption func(*Listener)
+
+// WithComponentEventHandler allows you to supply a callback to be executed on
+// component status events.
+func WithComponentEventHandler(handler ComponentEventFunc) ListenerOption {
+	return func(o *Listener) {
+		o.componentEventHandler = handler
+	}
+}
+
+// WithPipelineStatusHandler allows to supply a callback to be executed when the pipeline
+// status changes.
+func WithPipelineStatusHandler(handler PipelineStatusFunc) ListenerOption {
+	return func(o *Listener) {
+		o.pipelineStatusHandler = handler
+	}
+}
+
+func NewStatusListener(options ...ListenerOption) *Listener {
+	l := &Listener{
+		componentEventHandler: noopComponentEventFunc,
+		pipelineStatusHandler: noopPipelineStatusFunc,
+	}
+
+	for _, opt := range options {
+		opt(l)
+	}
+
+	return l
+}

--- a/component/status/status_pipeline.go
+++ b/component/status/status_pipeline.go
@@ -12,23 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package components
+package status
 
-import (
-	"errors"
-	"testing"
+// PipelineReadiness represents an enumeration of pipeline statuses
+type PipelineReadiness int
 
-	"github.com/stretchr/testify/assert"
-	"go.uber.org/zap"
-
-	"go.opentelemetry.io/collector/component/componenttest"
-	"go.opentelemetry.io/collector/component/status"
+const (
+	// PipelineReady indicates the pipeline is ready
+	PipelineReady PipelineReadiness = iota
+	// PipelineNotReady indicates the pipeline is not ready
+	PipelineNotReady
 )
 
-func Test_newHostWrapper(t *testing.T) {
-	hw := NewHostWrapper(componenttest.NewNopHost(), nil, zap.NewNop())
-	hw.ReportFatalError(errors.New("test error"))
-	ev, err := status.NewComponentEvent(status.ComponentOK)
-	assert.NoError(t, err)
-	hw.ReportComponentStatus(ev)
-}
+// PipelineStatusFunc is a function to be called when the collector pipeline changes states
+type PipelineStatusFunc func(st PipelineReadiness) error
+
+var noopPipelineStatusFunc = func(st PipelineReadiness) error { return nil }

--- a/component/status/status_test.go
+++ b/component/status/status_test.go
@@ -1,0 +1,92 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package status
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"go.opentelemetry.io/collector/component/id"
+)
+
+type statusReportingComponent struct{}
+
+func (s statusReportingComponent) ID() id.ID {
+	return id.ID{}
+}
+
+func TestNewEventMinimal(t *testing.T) {
+	ev, err := NewComponentEvent(ComponentOK)
+	assert.NoError(t, err)
+	assert.Equal(t, ComponentOK, ev.Type())
+	assert.NotEqual(t, 0, ev.Timestamp())
+	assert.Equal(t, nil, ev.Source())
+	assert.Nil(t, ev.Err())
+}
+
+func TestNewEventAllOptions(t *testing.T) {
+	expectedTimestamp := time.Now()
+	expectedErr := errors.New("expect this")
+	source := &statusReportingComponent{}
+	ev, err := NewComponentEvent(
+		ComponentError,
+		WithSource(source),
+		WithTimestamp(expectedTimestamp),
+		WithError(expectedErr),
+	)
+	assert.NoError(t, err)
+	assert.Equal(t, ComponentError, ev.Type())
+	assert.Equal(t, source, ev.Source())
+	assert.Equal(t, expectedTimestamp, ev.Timestamp())
+	assert.Equal(t, expectedErr, ev.Err())
+}
+
+func TestNewEventErrorTypeMismatch(t *testing.T) {
+	testCases := []struct {
+		name        string
+		eventType   ComponentEventType
+		err         error
+		expectError bool
+	}{
+		{
+			"eventType: OK with error returns error",
+			ComponentOK,
+			errors.New("err"),
+			true,
+		},
+		{
+			"eventType: ComponentError with error returns event",
+			ComponentError,
+			errors.New("err"),
+			false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ev, err := NewComponentEvent(tc.eventType, WithError(tc.err))
+			if tc.expectError {
+				assert.Nil(t, ev)
+				assert.Error(t, err)
+			} else {
+				assert.NotNil(t, ev)
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/service/config.go
+++ b/service/config.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/id"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/service/telemetry"
 )
@@ -32,16 +33,16 @@ var (
 // Config defines the configuration for the various elements of collector or agent.
 type Config struct {
 	// Receivers is a map of ComponentID to Receivers.
-	Receivers map[component.ID]component.ReceiverConfig
+	Receivers map[id.ID]component.ReceiverConfig
 
 	// Exporters is a map of ComponentID to Exporters.
-	Exporters map[component.ID]component.ExporterConfig
+	Exporters map[id.ID]component.ExporterConfig
 
 	// Processors is a map of ComponentID to Processors.
-	Processors map[component.ID]component.ProcessorConfig
+	Processors map[id.ID]component.ProcessorConfig
 
 	// Extensions is a map of ComponentID to extensions.
-	Extensions map[component.ID]component.ExtensionConfig
+	Extensions map[id.ID]component.ExtensionConfig
 
 	Service ConfigService
 }
@@ -163,10 +164,10 @@ type ConfigService struct {
 	Telemetry telemetry.Config `mapstructure:"telemetry"`
 
 	// Extensions are the ordered list of extensions configured for the service.
-	Extensions []component.ID `mapstructure:"extensions"`
+	Extensions []id.ID `mapstructure:"extensions"`
 
 	// Pipelines are the set of data pipelines configured for the service.
-	Pipelines map[component.ID]*ConfigServicePipeline `mapstructure:"pipelines"`
+	Pipelines map[id.ID]*ConfigServicePipeline `mapstructure:"pipelines"`
 }
 
 type ConfigServicePipeline = config.Pipeline

--- a/service/config_provider_test.go
+++ b/service/config_provider_test.go
@@ -26,6 +26,7 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/component/id"
 	"go.opentelemetry.io/collector/config/configtelemetry"
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/confmap/provider/fileprovider"
@@ -34,27 +35,27 @@ import (
 )
 
 var configNop = &Config{
-	Receivers:  map[component.ID]component.ReceiverConfig{component.NewID("nop"): componenttest.NewNopReceiverFactory().CreateDefaultConfig()},
-	Processors: map[component.ID]component.ProcessorConfig{component.NewID("nop"): componenttest.NewNopProcessorFactory().CreateDefaultConfig()},
-	Exporters:  map[component.ID]component.ExporterConfig{component.NewID("nop"): componenttest.NewNopExporterFactory().CreateDefaultConfig()},
-	Extensions: map[component.ID]component.ExtensionConfig{component.NewID("nop"): componenttest.NewNopExtensionFactory().CreateDefaultConfig()},
+	Receivers:  map[id.ID]component.ReceiverConfig{id.NewID("nop"): componenttest.NewNopReceiverFactory().CreateDefaultConfig()},
+	Processors: map[id.ID]component.ProcessorConfig{id.NewID("nop"): componenttest.NewNopProcessorFactory().CreateDefaultConfig()},
+	Exporters:  map[id.ID]component.ExporterConfig{id.NewID("nop"): componenttest.NewNopExporterFactory().CreateDefaultConfig()},
+	Extensions: map[id.ID]component.ExtensionConfig{id.NewID("nop"): componenttest.NewNopExtensionFactory().CreateDefaultConfig()},
 	Service: ConfigService{
-		Extensions: []component.ID{component.NewID("nop")},
-		Pipelines: map[component.ID]*ConfigServicePipeline{
-			component.NewID("traces"): {
-				Receivers:  []component.ID{component.NewID("nop")},
-				Processors: []component.ID{component.NewID("nop")},
-				Exporters:  []component.ID{component.NewID("nop")},
+		Extensions: []id.ID{id.NewID("nop")},
+		Pipelines: map[id.ID]*ConfigServicePipeline{
+			id.NewID("traces"): {
+				Receivers:  []id.ID{id.NewID("nop")},
+				Processors: []id.ID{id.NewID("nop")},
+				Exporters:  []id.ID{id.NewID("nop")},
 			},
-			component.NewID("metrics"): {
-				Receivers:  []component.ID{component.NewID("nop")},
-				Processors: []component.ID{component.NewID("nop")},
-				Exporters:  []component.ID{component.NewID("nop")},
+			id.NewID("metrics"): {
+				Receivers:  []id.ID{id.NewID("nop")},
+				Processors: []id.ID{id.NewID("nop")},
+				Exporters:  []id.ID{id.NewID("nop")},
 			},
-			component.NewID("logs"): {
-				Receivers:  []component.ID{component.NewID("nop")},
-				Processors: []component.ID{component.NewID("nop")},
-				Exporters:  []component.ID{component.NewID("nop")},
+			id.NewID("logs"): {
+				Receivers:  []id.ID{id.NewID("nop")},
+				Processors: []id.ID{id.NewID("nop")},
+				Exporters:  []id.ID{id.NewID("nop")},
 			},
 		},
 		Telemetry: telemetry.Config{

--- a/service/config_test.go
+++ b/service/config_test.go
@@ -23,6 +23,7 @@ import (
 	"go.uber.org/zap/zapcore"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/id"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/configtelemetry"
 	"go.opentelemetry.io/collector/service/telemetry"
@@ -113,7 +114,7 @@ func TestConfigValidate(t *testing.T) {
 			name: "invalid-extension-reference",
 			cfgFn: func() *Config {
 				cfg := generateConfig()
-				cfg.Service.Extensions = append(cfg.Service.Extensions, component.NewIDWithName("nop", "2"))
+				cfg.Service.Extensions = append(cfg.Service.Extensions, id.NewIDWithName("nop", "2"))
 				return cfg
 			},
 			expected: errors.New(`service references extension "nop/2" which does not exist`),
@@ -122,8 +123,8 @@ func TestConfigValidate(t *testing.T) {
 			name: "invalid-receiver-reference",
 			cfgFn: func() *Config {
 				cfg := generateConfig()
-				pipe := cfg.Service.Pipelines[component.NewID("traces")]
-				pipe.Receivers = append(pipe.Receivers, component.NewIDWithName("nop", "2"))
+				pipe := cfg.Service.Pipelines[id.NewID("traces")]
+				pipe.Receivers = append(pipe.Receivers, id.NewIDWithName("nop", "2"))
 				return cfg
 			},
 			expected: errors.New(`pipeline "traces" references receiver "nop/2" which does not exist`),
@@ -132,8 +133,8 @@ func TestConfigValidate(t *testing.T) {
 			name: "invalid-processor-reference",
 			cfgFn: func() *Config {
 				cfg := generateConfig()
-				pipe := cfg.Service.Pipelines[component.NewID("traces")]
-				pipe.Processors = append(pipe.Processors, component.NewIDWithName("nop", "2"))
+				pipe := cfg.Service.Pipelines[id.NewID("traces")]
+				pipe.Processors = append(pipe.Processors, id.NewIDWithName("nop", "2"))
 				return cfg
 			},
 			expected: errors.New(`pipeline "traces" references processor "nop/2" which does not exist`),
@@ -142,8 +143,8 @@ func TestConfigValidate(t *testing.T) {
 			name: "invalid-exporter-reference",
 			cfgFn: func() *Config {
 				cfg := generateConfig()
-				pipe := cfg.Service.Pipelines[component.NewID("traces")]
-				pipe.Exporters = append(pipe.Exporters, component.NewIDWithName("nop", "2"))
+				pipe := cfg.Service.Pipelines[id.NewID("traces")]
+				pipe.Exporters = append(pipe.Exporters, id.NewIDWithName("nop", "2"))
 				return cfg
 			},
 			expected: errors.New(`pipeline "traces" references exporter "nop/2" which does not exist`),
@@ -152,7 +153,7 @@ func TestConfigValidate(t *testing.T) {
 			name: "missing-pipeline-receivers",
 			cfgFn: func() *Config {
 				cfg := generateConfig()
-				pipe := cfg.Service.Pipelines[component.NewID("traces")]
+				pipe := cfg.Service.Pipelines[id.NewID("traces")]
 				pipe.Receivers = nil
 				return cfg
 			},
@@ -162,7 +163,7 @@ func TestConfigValidate(t *testing.T) {
 			name: "missing-pipeline-exporters",
 			cfgFn: func() *Config {
 				cfg := generateConfig()
-				pipe := cfg.Service.Pipelines[component.NewID("traces")]
+				pipe := cfg.Service.Pipelines[id.NewID("traces")]
 				pipe.Exporters = nil
 				return cfg
 			},
@@ -181,8 +182,8 @@ func TestConfigValidate(t *testing.T) {
 			name: "invalid-receiver-config",
 			cfgFn: func() *Config {
 				cfg := generateConfig()
-				cfg.Receivers[component.NewID("nop")] = &nopRecvConfig{
-					ReceiverSettings: config.NewReceiverSettings(component.NewID("nop")),
+				cfg.Receivers[id.NewID("nop")] = &nopRecvConfig{
+					ReceiverSettings: config.NewReceiverSettings(id.NewID("nop")),
 					validateErr:      errInvalidRecvConfig,
 				}
 				return cfg
@@ -193,8 +194,8 @@ func TestConfigValidate(t *testing.T) {
 			name: "invalid-exporter-config",
 			cfgFn: func() *Config {
 				cfg := generateConfig()
-				cfg.Exporters[component.NewID("nop")] = &nopExpConfig{
-					ExporterSettings: config.NewExporterSettings(component.NewID("nop")),
+				cfg.Exporters[id.NewID("nop")] = &nopExpConfig{
+					ExporterSettings: config.NewExporterSettings(id.NewID("nop")),
 					validateErr:      errInvalidExpConfig,
 				}
 				return cfg
@@ -205,8 +206,8 @@ func TestConfigValidate(t *testing.T) {
 			name: "invalid-processor-config",
 			cfgFn: func() *Config {
 				cfg := generateConfig()
-				cfg.Processors[component.NewID("nop")] = &nopProcConfig{
-					ProcessorSettings: config.NewProcessorSettings(component.NewID("nop")),
+				cfg.Processors[id.NewID("nop")] = &nopProcConfig{
+					ProcessorSettings: config.NewProcessorSettings(id.NewID("nop")),
 					validateErr:       errInvalidProcConfig,
 				}
 				return cfg
@@ -217,8 +218,8 @@ func TestConfigValidate(t *testing.T) {
 			name: "invalid-extension-config",
 			cfgFn: func() *Config {
 				cfg := generateConfig()
-				cfg.Extensions[component.NewID("nop")] = &nopExtConfig{
-					ExtensionSettings: config.NewExtensionSettings(component.NewID("nop")),
+				cfg.Extensions[id.NewID("nop")] = &nopExtConfig{
+					ExtensionSettings: config.NewExtensionSettings(id.NewID("nop")),
 					validateErr:       errInvalidExtConfig,
 				}
 				return cfg
@@ -229,10 +230,10 @@ func TestConfigValidate(t *testing.T) {
 			name: "invalid-service-pipeline-type",
 			cfgFn: func() *Config {
 				cfg := generateConfig()
-				cfg.Service.Pipelines[component.NewID("wrongtype")] = &ConfigServicePipeline{
-					Receivers:  []component.ID{component.NewID("nop")},
-					Processors: []component.ID{component.NewID("nop")},
-					Exporters:  []component.ID{component.NewID("nop")},
+				cfg.Service.Pipelines[id.NewID("wrongtype")] = &ConfigServicePipeline{
+					Receivers:  []id.ID{id.NewID("nop")},
+					Processors: []id.ID{id.NewID("nop")},
+					Exporters:  []id.ID{id.NewID("nop")},
 				}
 				return cfg
 			},
@@ -260,24 +261,24 @@ func TestConfigValidate(t *testing.T) {
 
 func generateConfig() *Config {
 	return &Config{
-		Receivers: map[component.ID]component.ReceiverConfig{
-			component.NewID("nop"): &nopRecvConfig{
-				ReceiverSettings: config.NewReceiverSettings(component.NewID("nop")),
+		Receivers: map[id.ID]component.ReceiverConfig{
+			id.NewID("nop"): &nopRecvConfig{
+				ReceiverSettings: config.NewReceiverSettings(id.NewID("nop")),
 			},
 		},
-		Exporters: map[component.ID]component.ExporterConfig{
-			component.NewID("nop"): &nopExpConfig{
-				ExporterSettings: config.NewExporterSettings(component.NewID("nop")),
+		Exporters: map[id.ID]component.ExporterConfig{
+			id.NewID("nop"): &nopExpConfig{
+				ExporterSettings: config.NewExporterSettings(id.NewID("nop")),
 			},
 		},
-		Processors: map[component.ID]component.ProcessorConfig{
-			component.NewID("nop"): &nopProcConfig{
-				ProcessorSettings: config.NewProcessorSettings(component.NewID("nop")),
+		Processors: map[id.ID]component.ProcessorConfig{
+			id.NewID("nop"): &nopProcConfig{
+				ProcessorSettings: config.NewProcessorSettings(id.NewID("nop")),
 			},
 		},
-		Extensions: map[component.ID]component.ExtensionConfig{
-			component.NewID("nop"): &nopExtConfig{
-				ExtensionSettings: config.NewExtensionSettings(component.NewID("nop")),
+		Extensions: map[id.ID]component.ExtensionConfig{
+			id.NewID("nop"): &nopExtConfig{
+				ExtensionSettings: config.NewExtensionSettings(id.NewID("nop")),
 			},
 		},
 		Service: ConfigService{
@@ -297,12 +298,12 @@ func generateConfig() *Config {
 					Address: ":8080",
 				},
 			},
-			Extensions: []component.ID{component.NewID("nop")},
-			Pipelines: map[component.ID]*ConfigServicePipeline{
-				component.NewID("traces"): {
-					Receivers:  []component.ID{component.NewID("nop")},
-					Processors: []component.ID{component.NewID("nop")},
-					Exporters:  []component.ID{component.NewID("nop")},
+			Extensions: []id.ID{id.NewID("nop")},
+			Pipelines: map[id.ID]*ConfigServicePipeline{
+				id.NewID("traces"): {
+					Receivers:  []id.ID{id.NewID("nop")},
+					Processors: []id.ID{id.NewID("nop")},
+					Exporters:  []id.ID{id.NewID("nop")},
 				},
 			},
 		},

--- a/service/extensions/extensions_test.go
+++ b/service/extensions/extensions_test.go
@@ -24,6 +24,7 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/component/id"
 	"go.opentelemetry.io/collector/config"
 )
 
@@ -38,54 +39,54 @@ func TestBuildExtensions(t *testing.T) {
 	tests := []struct {
 		name              string
 		factories         component.Factories
-		extensionsConfigs map[component.ID]component.ExtensionConfig
-		serviceExtensions []component.ID
+		extensionsConfigs map[id.ID]component.ExtensionConfig
+		serviceExtensions []id.ID
 		wantErrMsg        string
 	}{
 		{
 			name: "extension_not_configured",
-			serviceExtensions: []component.ID{
-				component.NewID("myextension"),
+			serviceExtensions: []id.ID{
+				id.NewID("myextension"),
 			},
 			wantErrMsg: "extension \"myextension\" is not configured",
 		},
 		{
 			name: "missing_extension_factory",
-			extensionsConfigs: map[component.ID]component.ExtensionConfig{
-				component.NewID("unknown"): nopExtensionConfig,
+			extensionsConfigs: map[id.ID]component.ExtensionConfig{
+				id.NewID("unknown"): nopExtensionConfig,
 			},
-			serviceExtensions: []component.ID{
-				component.NewID("unknown"),
+			serviceExtensions: []id.ID{
+				id.NewID("unknown"),
 			},
 			wantErrMsg: "extension factory for type \"unknown\" is not configured",
 		},
 		{
 			name: "error_on_create_extension",
 			factories: component.Factories{
-				Extensions: map[component.Type]component.ExtensionFactory{
+				Extensions: map[id.Type]component.ExtensionFactory{
 					errExtensionFactory.Type(): errExtensionFactory,
 				},
 			},
-			extensionsConfigs: map[component.ID]component.ExtensionConfig{
-				component.NewID(errExtensionFactory.Type()): errExtensionConfig,
+			extensionsConfigs: map[id.ID]component.ExtensionConfig{
+				id.NewID(errExtensionFactory.Type()): errExtensionConfig,
 			},
-			serviceExtensions: []component.ID{
-				component.NewID(errExtensionFactory.Type()),
+			serviceExtensions: []id.ID{
+				id.NewID(errExtensionFactory.Type()),
 			},
 			wantErrMsg: "failed to create extension \"err\": cannot create \"err\" extension type",
 		},
 		{
 			name: "bad_factory",
 			factories: component.Factories{
-				Extensions: map[component.Type]component.ExtensionFactory{
+				Extensions: map[id.Type]component.ExtensionFactory{
 					badExtensionFactory.Type(): badExtensionFactory,
 				},
 			},
-			extensionsConfigs: map[component.ID]component.ExtensionConfig{
-				component.NewID(badExtensionFactory.Type()): badExtensionCfg,
+			extensionsConfigs: map[id.ID]component.ExtensionConfig{
+				id.NewID(badExtensionFactory.Type()): badExtensionCfg,
 			},
-			serviceExtensions: []component.ID{
-				component.NewID(badExtensionFactory.Type()),
+			serviceExtensions: []id.ID{
+				id.NewID(badExtensionFactory.Type()),
 			},
 			wantErrMsg: "factory for \"bf\" produced a nil extension",
 		},
@@ -112,7 +113,7 @@ func newBadExtensionFactory() component.ExtensionFactory {
 			return &struct {
 				config.ExtensionSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
 			}{
-				ExtensionSettings: config.NewExtensionSettings(component.NewID("bf")),
+				ExtensionSettings: config.NewExtensionSettings(id.NewID("bf")),
 			}
 		},
 		func(ctx context.Context, set component.ExtensionCreateSettings, extension component.ExtensionConfig) (component.Extension, error) {
@@ -129,7 +130,7 @@ func newCreateErrorExtensionFactory() component.ExtensionFactory {
 			return &struct {
 				config.ExtensionSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
 			}{
-				ExtensionSettings: config.NewExtensionSettings(component.NewID("err")),
+				ExtensionSettings: config.NewExtensionSettings(id.NewID("err")),
 			}
 		},
 		func(ctx context.Context, set component.ExtensionCreateSettings, extension component.ExtensionConfig) (component.Extension, error) {

--- a/service/host.go
+++ b/service/host.go
@@ -15,30 +15,48 @@
 package service // import "go.opentelemetry.io/collector/service"
 
 import (
+	"go.uber.org/zap"
+
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/id"
+	"go.opentelemetry.io/collector/component/status"
 	"go.opentelemetry.io/collector/service/extensions"
+	"go.opentelemetry.io/collector/service/internal/components"
 	"go.opentelemetry.io/collector/service/internal/pipelines"
 )
 
 var _ component.Host = (*serviceHost)(nil)
 
 type serviceHost struct {
-	asyncErrorChannel chan error
-	factories         component.Factories
-	buildInfo         component.BuildInfo
+	asyncErrorChannel   chan error
+	factories           component.Factories
+	buildInfo           component.BuildInfo
+	telemetry           component.TelemetrySettings
+	statusNotifications *components.Notifications
 
 	pipelines  *pipelines.Pipelines
 	extensions *extensions.Extensions
 }
 
+func newServiceHost(set *settings, telemetrySettings component.TelemetrySettings) *serviceHost {
+	return &serviceHost{
+		factories:           set.Factories,
+		buildInfo:           set.BuildInfo,
+		asyncErrorChannel:   set.AsyncErrorChannel,
+		statusNotifications: components.NewNotifications(),
+		telemetry:           telemetrySettings,
+	}
+}
+
 // ReportFatalError is used to report to the host that the receiver encountered
 // a fatal error (i.e.: an error that the instance can't recover from) after
 // its start function has already returned.
+// Deprecated: [0.65.0] Use ReportComponentStatus instead (with an event of type status.ComponentError).
 func (host *serviceHost) ReportFatalError(err error) {
 	host.asyncErrorChannel <- err
 }
 
-func (host *serviceHost) GetFactory(kind component.Kind, componentType component.Type) component.Factory {
+func (host *serviceHost) GetFactory(kind component.Kind, componentType id.Type) component.Factory {
 	switch kind {
 	case component.KindReceiver:
 		return host.factories.Receivers[componentType]
@@ -52,10 +70,21 @@ func (host *serviceHost) GetFactory(kind component.Kind, componentType component
 	return nil
 }
 
-func (host *serviceHost) GetExtensions() map[component.ID]component.Extension {
+func (host *serviceHost) GetExtensions() map[id.ID]component.Extension {
 	return host.extensions.GetExtensions()
 }
 
-func (host *serviceHost) GetExporters() map[component.DataType]map[component.ID]component.Exporter {
+func (host *serviceHost) GetExporters() map[component.DataType]map[id.ID]component.Exporter {
 	return host.pipelines.GetExporters()
+}
+
+func (host *serviceHost) RegisterStatusListener(options ...status.ListenerOption) component.StatusListenerUnregisterFunc {
+	return host.statusNotifications.RegisterListener(options...)
+}
+
+// ReportComponentStatus is an implementation of Host.ReportComponentStatus.
+func (host *serviceHost) ReportComponentStatus(event *status.ComponentEvent) {
+	if err := host.statusNotifications.SetComponentStatus(event); err != nil {
+		host.telemetry.Logger.Warn("Service failed to report status", zap.Error(err))
+	}
 }

--- a/service/internal/components/notifications.go
+++ b/service/internal/components/notifications.go
@@ -1,0 +1,126 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package components // import "go.opentelemetry.io/collector/service/internal/components"
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+
+	"go.uber.org/multierr"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/status"
+)
+
+var errRegistrationNotFound = errors.New("registration not found")
+
+// Notifications is a mechanism that facilitates the passing of status events between components.
+// Status events can be used to indicate that a component is functioning as expected, or that it is
+// in an error state. Events can be sent using the SetComponentStatus function, and
+// parties interested in receiving events can register a listener via the RegisterListener
+// function.
+// This functionality is exposed to the components via the Host interface.
+type Notifications struct {
+	mu        sync.RWMutex
+	listeners []*status.Listener
+}
+
+// NewNotifications returns a pointer to a newly initialized Notifications struct
+func NewNotifications() *Notifications {
+	return &Notifications{
+		listeners: []*status.Listener{},
+	}
+}
+
+// Shutdown stops notifications
+func (n *Notifications) Shutdown() {
+	n.mu.Lock()
+	n.listeners = nil
+	n.mu.Unlock()
+}
+
+// RegisterListener registers a component to listen to the events indicated by the passed in
+// ListenerOptions. It returns an UnregisterFunc, which should be called by the registering
+// component during Shutdown.
+func (n *Notifications) RegisterListener(options ...status.ListenerOption) component.StatusListenerUnregisterFunc {
+	l := status.NewStatusListener(options...)
+
+	n.mu.Lock()
+	n.listeners = append(n.listeners, l)
+	n.mu.Unlock()
+
+	return func() error {
+		return n.unregisterListener(l)
+	}
+}
+
+// SetComponentStatus notifies all registered listeners of a ComponentEvent. A ComponentEvent can indicate that
+// a component is functioning normally (component.StatusEventOK) or is in an error state (component.StatusEventError)
+func (n *Notifications) SetComponentStatus(event *status.ComponentEvent) (errs error) {
+	n.mu.RLock()
+	defer n.mu.RUnlock()
+
+	for _, listener := range n.listeners {
+		if err := listener.ComponentEventHandler(event); err != nil {
+			errs = multierr.Append(errs, fmt.Errorf("failure in status event handler: %w", err))
+		}
+
+	}
+
+	return errs
+}
+
+// SetPipelineStatus is to be called by the service when all pipelines have been built and the receivers
+// have started, i.e.: the service is ready to receive data (note that it may already have received
+// data when this method is called). All listeners that have registered a
+// PipelineReadyHandler will be notified.
+func (n *Notifications) SetPipelineStatus(status status.PipelineReadiness) (errs error) {
+	n.mu.RLock()
+	defer n.mu.RUnlock()
+
+	for _, listener := range n.listeners {
+		if err := listener.PipelineStatusHandler(status); err != nil {
+			errs = multierr.Append(errs, fmt.Errorf("failure in pipeline status handler: %w", err))
+		}
+	}
+
+	return errs
+}
+
+func (n *Notifications) unregisterListener(l *status.Listener) error {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
+	i := 0
+	for _, listener := range n.listeners {
+		if l != listener {
+			n.listeners[i] = listener
+			i++
+		}
+	}
+
+	if i == len(n.listeners) {
+		return errRegistrationNotFound
+	}
+
+	for j := i; j < len(n.listeners); j++ {
+		n.listeners[j] = nil
+	}
+
+	n.listeners = n.listeners[:i]
+
+	return nil
+}

--- a/service/internal/components/notifications_test.go
+++ b/service/internal/components/notifications_test.go
@@ -1,0 +1,308 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package components
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"go.opentelemetry.io/collector/component/status"
+)
+
+func TestNotifications_PipelineReadyNotReady(t *testing.T) {
+	notifications := NewNotifications()
+
+	l := newListenerSpy(false)
+
+	un := notifications.RegisterListener(
+		status.WithPipelineStatusHandler(l.PipelineStatusSpy.Func),
+	)
+
+	assert.False(t, l.PipelineStatusSpy.NotReadyCalled(), "Unexpected call to SetPipelineStatus")
+	assert.False(t, l.PipelineStatusSpy.NotReadyCalled(), "Unexpected call to PipelineNotReady")
+
+	assert.NoError(t, notifications.SetPipelineStatus(status.PipelineReady))
+	assert.True(t, l.PipelineStatusSpy.ReadyCalled(), "Expected call to SetPipelineStatus")
+
+	assert.NoError(t, notifications.SetPipelineStatus(status.PipelineNotReady))
+	assert.True(t, l.PipelineStatusSpy.NotReadyCalled(), "Expected call to PipelineNotReady")
+
+	assert.NoError(t, un())
+	notifications.Shutdown()
+}
+
+func TestNotifications_PipelineReadyNotReadyWithError(t *testing.T) {
+	notifications := NewNotifications()
+
+	l1 := newListenerSpy(true)
+	l2 := newListenerSpy(false)
+
+	un1 := notifications.RegisterListener(
+		status.WithPipelineStatusHandler(l1.PipelineStatusSpy.Func),
+	)
+
+	un2 := notifications.RegisterListener(
+		status.WithPipelineStatusHandler(l2.PipelineStatusSpy.Func),
+	)
+
+	assert.False(t, l1.PipelineStatusSpy.ReadyCalled(), "Unexpected call to SetPipelineStatus")
+	assert.False(t, l1.PipelineStatusSpy.NotReadyCalled(), "Unexpected call to PipelineNotReady")
+	assert.False(t, l2.PipelineStatusSpy.ReadyCalled(), "Unexpected call to SetPipelineStatus")
+	assert.False(t, l2.PipelineStatusSpy.NotReadyCalled(), "Unexpected call to PipelineNotReady")
+
+	assert.Error(t, notifications.SetPipelineStatus(status.PipelineReady))
+	assert.True(t, l1.PipelineStatusSpy.ReadyCalled(), "Expected call to SetPipelineStatus")
+	assert.True(t, l2.PipelineStatusSpy.ReadyCalled(), "Expected call to SetPipelineStatus")
+
+	assert.Error(t, notifications.SetPipelineStatus(status.PipelineNotReady))
+	assert.True(t, l1.PipelineStatusSpy.NotReadyCalled(), "Expected call to PipelineNotReady")
+	assert.True(t, l2.PipelineStatusSpy.NotReadyCalled(), "Expected call to PipelineNotReady")
+
+	assert.NoError(t, un1())
+	assert.NoError(t, un2())
+	notifications.Shutdown()
+}
+
+func TestNotifications_ReportStatus(t *testing.T) {
+	notifications := NewNotifications()
+
+	eeSpy := newStatusEventSpy(false)
+
+	un := notifications.RegisterListener(
+		status.WithComponentEventHandler(eeSpy.Func),
+	)
+
+	ev1, err := status.NewComponentEvent(
+		status.ComponentError,
+		status.WithError(errors.New("err1")),
+	)
+
+	assert.NoError(t, err)
+	assert.NoError(t, notifications.SetComponentStatus(ev1))
+	assert.True(t, eeSpy.Called(), "Expected call to status event handler")
+	assert.Equal(t, 1, eeSpy.CallCount)
+	assert.Equal(t, "err1", eeSpy.LastArg.Err().Error())
+
+	ev2, err := status.NewComponentEvent(
+		status.ComponentError,
+		status.WithError(errors.New("err2")),
+	)
+
+	assert.NoError(t, err)
+	assert.NoError(t, notifications.SetComponentStatus(ev2))
+	assert.True(t, eeSpy.Called(), "Expected call to status event handler")
+	assert.Equal(t, 2, eeSpy.CallCount)
+	assert.Equal(t, "err2", eeSpy.LastArg.Err().Error())
+
+	assert.NoError(t, un())
+	notifications.Shutdown()
+}
+
+func TestNotifications_AllHandlersOptional(t *testing.T) {
+	notifications := NewNotifications()
+	un := notifications.RegisterListener()
+
+	assert.NoError(t, notifications.SetPipelineStatus(status.PipelineReady))
+	ev, err := status.NewComponentEvent(
+		status.ComponentOK,
+	)
+	assert.NoError(t, err)
+	assert.NoError(t, notifications.SetComponentStatus(ev))
+
+	assert.NoError(t, notifications.SetPipelineStatus(status.PipelineNotReady))
+	assert.NoError(t, un())
+	notifications.Shutdown()
+}
+
+func TestNotifications_StatusHandlerWithError(t *testing.T) {
+	notifications := NewNotifications()
+
+	l1 := newListenerSpy(true)
+	l2 := newListenerSpy(false)
+
+	un1 := notifications.RegisterListener(
+		status.WithComponentEventHandler(l1.StatusEventSpy.Func),
+	)
+
+	un2 := notifications.RegisterListener(
+		status.WithComponentEventHandler(l2.StatusEventSpy.Func),
+	)
+
+	ev1, err := status.NewComponentEvent(status.ComponentOK)
+	assert.NoError(t, err)
+	assert.Error(t, notifications.SetComponentStatus(ev1))
+
+	ev2, err := status.NewComponentEvent(
+		status.ComponentError,
+		status.WithError(errors.New("err")),
+	)
+	assert.NoError(t, err)
+	assert.Error(t, notifications.SetComponentStatus(ev2))
+
+	assert.True(t, l1.StatusEventSpy.Called(), "Expected call to status event handler")
+	assert.Equal(t, 2, l1.StatusEventSpy.CallCount)
+	assert.True(t, l2.StatusEventSpy.Called(), "Expected call to status event handler")
+	assert.Equal(t, 2, l2.StatusEventSpy.CallCount)
+
+	assert.NoError(t, un1())
+	assert.NoError(t, un2())
+	notifications.Shutdown()
+}
+
+func TestNotifications_RegisterUnregister(t *testing.T) {
+	l1 := newListenerSpy(false)
+	l2 := newListenerSpy(false)
+
+	notifications := NewNotifications()
+
+	un1 := notifications.RegisterListener(
+		status.WithPipelineStatusHandler(l1.PipelineStatusSpy.Func),
+		status.WithComponentEventHandler(l1.StatusEventSpy.Func),
+	)
+
+	un2 := notifications.RegisterListener(
+		status.WithPipelineStatusHandler(l2.PipelineStatusSpy.Func),
+		status.WithComponentEventHandler(l2.StatusEventSpy.Func),
+	)
+
+	assert.NoError(t, notifications.SetPipelineStatus(status.PipelineReady))
+
+	ev1, err := status.NewComponentEvent(
+		status.ComponentError,
+		status.WithError(errors.New("err1")),
+	)
+	assert.NoError(t, err)
+	assert.NoError(t, notifications.SetComponentStatus(ev1))
+	assert.NoError(t, un1())
+
+	ev2, err := status.NewComponentEvent(
+		status.ComponentError,
+		status.WithError(errors.New("err2")),
+	)
+	assert.NoError(t, err)
+	assert.NoError(t, notifications.SetComponentStatus(ev2))
+	assert.NoError(t, un2())
+
+	ev3, err := status.NewComponentEvent(
+		status.ComponentOK,
+	)
+	assert.NoError(t, err)
+	assert.NoError(t, notifications.SetComponentStatus(ev3))
+
+	assert.NoError(t, notifications.SetPipelineStatus(status.PipelineNotReady))
+	notifications.Shutdown()
+
+	assert.True(t, l1.PipelineStatusSpy.ReadyCalled(), "Expected call to SetPipelineStatus")
+	assert.True(t, l1.StatusEventSpy.Called(), "Expected call to status event handler")
+	assert.Equal(t, 1, l1.StatusEventSpy.CallCount)
+	assert.Equal(t, "err1", l1.StatusEventSpy.LastArg.Err().Error())
+
+	assert.True(t, l2.PipelineStatusSpy.ReadyCalled(), "Exected call to SetPipelineStatus")
+	assert.True(t, l2.StatusEventSpy.Called(), "Expected call to status event handler")
+	assert.Equal(t, 2, l2.StatusEventSpy.CallCount)
+	assert.Equal(t, "err2", l2.StatusEventSpy.LastArg.Err().Error())
+}
+
+func TestNotifications_LateUnregisterReturnsError(t *testing.T) {
+	l1 := newListenerSpy(false)
+
+	notifications := NewNotifications()
+
+	unreg := notifications.RegisterListener(
+		status.WithPipelineStatusHandler(l1.PipelineStatusSpy.Func),
+	)
+
+	// shutdown unregisters listeners
+	notifications.Shutdown()
+	assert.Error(t, unreg())
+}
+
+type callCounter struct {
+	CallCount int
+}
+
+func (cc *callCounter) Called() bool {
+	return cc.CallCount > 0
+}
+
+type readyCallCounter struct {
+	ReadyCallCount    int
+	NotReadyCallCount int
+}
+
+func (cc *readyCallCounter) ReadyCalled() bool {
+	return cc.ReadyCallCount > 0
+}
+
+func (cc *readyCallCounter) NotReadyCalled() bool {
+	return cc.NotReadyCallCount > 0
+}
+
+type pipelineStatusSpy struct {
+	readyCallCounter
+	Func status.PipelineStatusFunc
+}
+
+func newPipelineEventSpy(returnErr bool) *pipelineStatusSpy {
+	var err error
+	if returnErr {
+		err = errors.New("pipeline func error")
+	}
+
+	spy := &pipelineStatusSpy{}
+	spy.Func = func(s status.PipelineReadiness) error {
+		if s == status.PipelineReady {
+			spy.ReadyCallCount++
+		} else {
+			spy.NotReadyCallCount++
+		}
+		return err
+	}
+	return spy
+}
+
+type statusEventSpy struct {
+	callCounter
+	Func    status.ComponentEventFunc
+	LastArg *status.ComponentEvent
+}
+
+func newStatusEventSpy(returnErr bool) *statusEventSpy {
+	var err error
+	if returnErr {
+		err = errors.New("error event func error")
+	}
+
+	spy := &statusEventSpy{}
+	spy.Func = func(ev *status.ComponentEvent) error {
+		spy.LastArg = ev
+		spy.CallCount++
+		return err
+	}
+	return spy
+}
+
+type listenerSpy struct {
+	PipelineStatusSpy *pipelineStatusSpy
+	StatusEventSpy    *statusEventSpy
+}
+
+func newListenerSpy(returnErr bool) *listenerSpy {
+	return &listenerSpy{
+		PipelineStatusSpy: newPipelineEventSpy(returnErr),
+		StatusEventSpy:    newStatusEventSpy(returnErr),
+	}
+}

--- a/service/internal/configunmarshaler/error.go
+++ b/service/internal/configunmarshaler/error.go
@@ -18,13 +18,13 @@ import (
 	"fmt"
 	"reflect"
 
-	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/id"
 )
 
-func errorUnknownType(component string, id component.ID, factories []reflect.Value) error {
+func errorUnknownType(component string, id id.ID, factories []reflect.Value) error {
 	return fmt.Errorf("unknown %s type: %q for id: %q (valid values: %v)", component, id.Type(), id, factories)
 }
 
-func errorUnmarshalError(component string, id component.ID, err error) error {
+func errorUnmarshalError(component string, id id.ID, err error) error {
 	return fmt.Errorf("error reading %s configuration for %q: %w", component, id, err)
 }

--- a/service/internal/configunmarshaler/exporters.go
+++ b/service/internal/configunmarshaler/exporters.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/id"
 	"go.opentelemetry.io/collector/confmap"
 )
 
@@ -25,23 +26,23 @@ import (
 const exportersKeyName = "exporters"
 
 type Exporters struct {
-	exps map[component.ID]component.ExporterConfig
+	exps map[id.ID]component.ExporterConfig
 
-	factories map[component.Type]component.ExporterFactory
+	factories map[id.Type]component.ExporterFactory
 }
 
-func NewExporters(factories map[component.Type]component.ExporterFactory) *Exporters {
+func NewExporters(factories map[id.Type]component.ExporterFactory) *Exporters {
 	return &Exporters{factories: factories}
 }
 
 func (e *Exporters) Unmarshal(conf *confmap.Conf) error {
-	rawExps := make(map[component.ID]map[string]interface{})
+	rawExps := make(map[id.ID]map[string]interface{})
 	if err := conf.Unmarshal(&rawExps, confmap.WithErrorUnused()); err != nil {
 		return err
 	}
 
 	// Prepare resulting map.
-	e.exps = make(map[component.ID]component.ExporterConfig)
+	e.exps = make(map[id.ID]component.ExporterConfig)
 
 	// Iterate over Exporters and create a config for each.
 	for id, value := range rawExps {
@@ -67,6 +68,6 @@ func (e *Exporters) Unmarshal(conf *confmap.Conf) error {
 	return nil
 }
 
-func (e *Exporters) GetExporters() map[component.ID]component.ExporterConfig {
+func (e *Exporters) GetExporters() map[id.ID]component.ExporterConfig {
 	return e.exps
 }

--- a/service/internal/configunmarshaler/exporters_test.go
+++ b/service/internal/configunmarshaler/exporters_test.go
@@ -22,6 +22,7 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/component/id"
 	"go.opentelemetry.io/collector/confmap"
 )
 
@@ -38,9 +39,9 @@ func TestExportersUnmarshal(t *testing.T) {
 
 	cfgWithName := factories.Exporters["nop"].CreateDefaultConfig()
 	cfgWithName.SetIDName("myexporter")
-	assert.Equal(t, map[component.ID]component.ExporterConfig{
-		component.NewID("nop"):                       factories.Exporters["nop"].CreateDefaultConfig(),
-		component.NewIDWithName("nop", "myexporter"): cfgWithName,
+	assert.Equal(t, map[id.ID]component.ExporterConfig{
+		id.NewID("nop"):                       factories.Exporters["nop"].CreateDefaultConfig(),
+		id.NewIDWithName("nop", "myexporter"): cfgWithName,
 	}, exps.GetExporters())
 }
 

--- a/service/internal/configunmarshaler/extensions.go
+++ b/service/internal/configunmarshaler/extensions.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/id"
 	"go.opentelemetry.io/collector/confmap"
 )
 
@@ -25,23 +26,23 @@ import (
 const extensionsKeyName = "extensions"
 
 type Extensions struct {
-	exts map[component.ID]component.ExtensionConfig
+	exts map[id.ID]component.ExtensionConfig
 
-	factories map[component.Type]component.ExtensionFactory
+	factories map[id.Type]component.ExtensionFactory
 }
 
-func NewExtensions(factories map[component.Type]component.ExtensionFactory) *Extensions {
+func NewExtensions(factories map[id.Type]component.ExtensionFactory) *Extensions {
 	return &Extensions{factories: factories}
 }
 
 func (e *Extensions) Unmarshal(conf *confmap.Conf) error {
-	rawExts := make(map[component.ID]map[string]interface{})
+	rawExts := make(map[id.ID]map[string]interface{})
 	if err := conf.Unmarshal(&rawExts, confmap.WithErrorUnused()); err != nil {
 		return err
 	}
 
 	// Prepare resulting map.
-	e.exts = make(map[component.ID]component.ExtensionConfig)
+	e.exts = make(map[id.ID]component.ExtensionConfig)
 
 	// Iterate over extensions and create a config for each.
 	for id, value := range rawExts {
@@ -67,6 +68,6 @@ func (e *Extensions) Unmarshal(conf *confmap.Conf) error {
 	return nil
 }
 
-func (e *Extensions) GetExtensions() map[component.ID]component.ExtensionConfig {
+func (e *Extensions) GetExtensions() map[id.ID]component.ExtensionConfig {
 	return e.exts
 }

--- a/service/internal/configunmarshaler/extensions_test.go
+++ b/service/internal/configunmarshaler/extensions_test.go
@@ -22,6 +22,7 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/component/id"
 	"go.opentelemetry.io/collector/confmap"
 )
 
@@ -38,9 +39,9 @@ func TestExtensionsUnmarshal(t *testing.T) {
 
 	cfgWithName := factories.Extensions["nop"].CreateDefaultConfig()
 	cfgWithName.SetIDName("myextension")
-	assert.Equal(t, map[component.ID]component.ExtensionConfig{
-		component.NewID("nop"):                        factories.Extensions["nop"].CreateDefaultConfig(),
-		component.NewIDWithName("nop", "myextension"): cfgWithName,
+	assert.Equal(t, map[id.ID]component.ExtensionConfig{
+		id.NewID("nop"):                        factories.Extensions["nop"].CreateDefaultConfig(),
+		id.NewIDWithName("nop", "myextension"): cfgWithName,
 	}, exts.GetExtensions())
 }
 

--- a/service/internal/configunmarshaler/processors.go
+++ b/service/internal/configunmarshaler/processors.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/id"
 	"go.opentelemetry.io/collector/confmap"
 )
 
@@ -25,23 +26,23 @@ import (
 const processorsKeyName = "processors"
 
 type Processors struct {
-	procs map[component.ID]component.ProcessorConfig
+	procs map[id.ID]component.ProcessorConfig
 
-	factories map[component.Type]component.ProcessorFactory
+	factories map[id.Type]component.ProcessorFactory
 }
 
-func NewProcessors(factories map[component.Type]component.ProcessorFactory) *Processors {
+func NewProcessors(factories map[id.Type]component.ProcessorFactory) *Processors {
 	return &Processors{factories: factories}
 }
 
 func (p *Processors) Unmarshal(conf *confmap.Conf) error {
-	rawProcs := make(map[component.ID]map[string]interface{})
+	rawProcs := make(map[id.ID]map[string]interface{})
 	if err := conf.Unmarshal(&rawProcs, confmap.WithErrorUnused()); err != nil {
 		return err
 	}
 
 	// Prepare resulting map.
-	p.procs = make(map[component.ID]component.ProcessorConfig)
+	p.procs = make(map[id.ID]component.ProcessorConfig)
 	// Iterate over processors and create a config for each.
 	for id, value := range rawProcs {
 		// Find processor factory based on "type" that we read from config source.
@@ -66,6 +67,6 @@ func (p *Processors) Unmarshal(conf *confmap.Conf) error {
 	return nil
 }
 
-func (p *Processors) GetProcessors() map[component.ID]component.ProcessorConfig {
+func (p *Processors) GetProcessors() map[id.ID]component.ProcessorConfig {
 	return p.procs
 }

--- a/service/internal/configunmarshaler/processors_test.go
+++ b/service/internal/configunmarshaler/processors_test.go
@@ -22,6 +22,7 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/component/id"
 	"go.opentelemetry.io/collector/confmap"
 )
 
@@ -38,9 +39,9 @@ func TestProcessorsUnmarshal(t *testing.T) {
 
 	cfgWithName := factories.Processors["nop"].CreateDefaultConfig()
 	cfgWithName.SetIDName("myprocessor")
-	assert.Equal(t, map[component.ID]component.ProcessorConfig{
-		component.NewID("nop"):                        factories.Processors["nop"].CreateDefaultConfig(),
-		component.NewIDWithName("nop", "myprocessor"): cfgWithName,
+	assert.Equal(t, map[id.ID]component.ProcessorConfig{
+		id.NewID("nop"):                        factories.Processors["nop"].CreateDefaultConfig(),
+		id.NewIDWithName("nop", "myprocessor"): cfgWithName,
 	}, procs.procs)
 }
 

--- a/service/internal/configunmarshaler/receivers.go
+++ b/service/internal/configunmarshaler/receivers.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/id"
 	"go.opentelemetry.io/collector/confmap"
 )
 
@@ -25,23 +26,23 @@ import (
 const receiversKeyName = "receivers"
 
 type Receivers struct {
-	recvs map[component.ID]component.ReceiverConfig
+	recvs map[id.ID]component.ReceiverConfig
 
-	factories map[component.Type]component.ReceiverFactory
+	factories map[id.Type]component.ReceiverFactory
 }
 
-func NewReceivers(factories map[component.Type]component.ReceiverFactory) *Receivers {
+func NewReceivers(factories map[id.Type]component.ReceiverFactory) *Receivers {
 	return &Receivers{factories: factories}
 }
 
 func (r *Receivers) Unmarshal(conf *confmap.Conf) error {
-	rawRecvs := make(map[component.ID]map[string]interface{})
+	rawRecvs := make(map[id.ID]map[string]interface{})
 	if err := conf.Unmarshal(&rawRecvs, confmap.WithErrorUnused()); err != nil {
 		return err
 	}
 
 	// Prepare resulting map.
-	r.recvs = make(map[component.ID]component.ReceiverConfig)
+	r.recvs = make(map[id.ID]component.ReceiverConfig)
 
 	// Iterate over input map and create a config for each.
 	for id, value := range rawRecvs {
@@ -67,6 +68,6 @@ func (r *Receivers) Unmarshal(conf *confmap.Conf) error {
 	return nil
 }
 
-func (r *Receivers) GetReceivers() map[component.ID]component.ReceiverConfig {
+func (r *Receivers) GetReceivers() map[id.ID]component.ReceiverConfig {
 	return r.recvs
 }

--- a/service/internal/configunmarshaler/receivers_test.go
+++ b/service/internal/configunmarshaler/receivers_test.go
@@ -22,6 +22,7 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/component/id"
 	"go.opentelemetry.io/collector/confmap"
 )
 
@@ -38,9 +39,9 @@ func TestReceiversUnmarshal(t *testing.T) {
 
 	cfgWithName := factories.Receivers["nop"].CreateDefaultConfig()
 	cfgWithName.SetIDName("myreceiver")
-	assert.Equal(t, map[component.ID]component.ReceiverConfig{
-		component.NewID("nop"):                       factories.Receivers["nop"].CreateDefaultConfig(),
-		component.NewIDWithName("nop", "myreceiver"): cfgWithName,
+	assert.Equal(t, map[id.ID]component.ReceiverConfig{
+		id.NewID("nop"):                       factories.Receivers["nop"].CreateDefaultConfig(),
+		id.NewIDWithName("nop", "myreceiver"): cfgWithName,
 	}, recvs.GetReceivers())
 }
 

--- a/service/internal/pipelines/pipelines_test.go
+++ b/service/internal/pipelines/pipelines_test.go
@@ -25,6 +25,7 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/component/id"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
@@ -38,48 +39,48 @@ import (
 func TestBuild(t *testing.T) {
 	tests := []struct {
 		name             string
-		receiverIDs      []component.ID
-		processorIDs     []component.ID
-		exporterIDs      []component.ID
+		receiverIDs      []id.ID
+		processorIDs     []id.ID
+		exporterIDs      []id.ID
 		expectedRequests int
 	}{
 		{
 			name:             "pipelines_simple.yaml",
-			receiverIDs:      []component.ID{component.NewID("examplereceiver")},
-			processorIDs:     []component.ID{component.NewID("exampleprocessor")},
-			exporterIDs:      []component.ID{component.NewID("exampleexporter")},
+			receiverIDs:      []id.ID{id.NewID("examplereceiver")},
+			processorIDs:     []id.ID{id.NewID("exampleprocessor")},
+			exporterIDs:      []id.ID{id.NewID("exampleexporter")},
 			expectedRequests: 1,
 		},
 		{
 			name:             "pipelines_simple_multi_proc.yaml",
-			receiverIDs:      []component.ID{component.NewID("examplereceiver")},
-			processorIDs:     []component.ID{component.NewID("exampleprocessor"), component.NewID("exampleprocessor")},
-			exporterIDs:      []component.ID{component.NewID("exampleexporter")},
+			receiverIDs:      []id.ID{id.NewID("examplereceiver")},
+			processorIDs:     []id.ID{id.NewID("exampleprocessor"), id.NewID("exampleprocessor")},
+			exporterIDs:      []id.ID{id.NewID("exampleexporter")},
 			expectedRequests: 1,
 		},
 		{
 			name:             "pipelines_simple_no_proc.yaml",
-			receiverIDs:      []component.ID{component.NewID("examplereceiver")},
-			exporterIDs:      []component.ID{component.NewID("exampleexporter")},
+			receiverIDs:      []id.ID{id.NewID("examplereceiver")},
+			exporterIDs:      []id.ID{id.NewID("exampleexporter")},
 			expectedRequests: 1,
 		},
 		{
 			name:             "pipelines_multi.yaml",
-			receiverIDs:      []component.ID{component.NewID("examplereceiver"), component.NewIDWithName("examplereceiver", "1")},
-			processorIDs:     []component.ID{component.NewID("exampleprocessor"), component.NewIDWithName("exampleprocessor", "1")},
-			exporterIDs:      []component.ID{component.NewID("exampleexporter"), component.NewIDWithName("exampleexporter", "1")},
+			receiverIDs:      []id.ID{id.NewID("examplereceiver"), id.NewIDWithName("examplereceiver", "1")},
+			processorIDs:     []id.ID{id.NewID("exampleprocessor"), id.NewIDWithName("exampleprocessor", "1")},
+			exporterIDs:      []id.ID{id.NewID("exampleexporter"), id.NewIDWithName("exampleexporter", "1")},
 			expectedRequests: 2,
 		},
 		{
 			name:             "pipelines_multi_no_proc.yaml",
-			receiverIDs:      []component.ID{component.NewID("examplereceiver"), component.NewIDWithName("examplereceiver", "1")},
-			exporterIDs:      []component.ID{component.NewID("exampleexporter"), component.NewIDWithName("exampleexporter", "1")},
+			receiverIDs:      []id.ID{id.NewID("examplereceiver"), id.NewIDWithName("examplereceiver", "1")},
+			exporterIDs:      []id.ID{id.NewID("exampleexporter"), id.NewIDWithName("exampleexporter", "1")},
 			expectedRequests: 2,
 		},
 		{
 			name:             "pipelines_exporter_multi_pipeline.yaml",
-			receiverIDs:      []component.ID{component.NewID("examplereceiver")},
-			exporterIDs:      []component.ID{component.NewID("exampleexporter")},
+			receiverIDs:      []id.ID{id.NewID("examplereceiver")},
+			exporterIDs:      []id.ID{id.NewID("exampleexporter")},
 			expectedRequests: 2,
 		},
 	}
@@ -116,17 +117,17 @@ func TestBuild(t *testing.T) {
 
 			// Verify processors created in the given order and started.
 			for i, procID := range test.processorIDs {
-				traceProcessor := pipelines.pipelines[component.NewID(component.DataTypeTraces)].processors[i]
+				traceProcessor := pipelines.pipelines[id.NewID(component.DataTypeTraces)].processors[i]
 				assert.Equal(t, procID, traceProcessor.id)
 				assert.True(t, traceProcessor.comp.(*testcomponents.ExampleProcessor).Started)
 
 				// Validate metrics.
-				metricsProcessor := pipelines.pipelines[component.NewID(component.DataTypeMetrics)].processors[i]
+				metricsProcessor := pipelines.pipelines[id.NewID(component.DataTypeMetrics)].processors[i]
 				assert.Equal(t, procID, metricsProcessor.id)
 				assert.True(t, metricsProcessor.comp.(*testcomponents.ExampleProcessor).Started)
 
 				// Validate logs.
-				logsProcessor := pipelines.pipelines[component.NewID(component.DataTypeLogs)].processors[i]
+				logsProcessor := pipelines.pipelines[id.NewID(component.DataTypeLogs)].processors[i]
 				assert.Equal(t, procID, logsProcessor.id)
 				assert.True(t, logsProcessor.comp.(*testcomponents.ExampleProcessor).Started)
 			}
@@ -165,15 +166,15 @@ func TestBuild(t *testing.T) {
 
 			// Verify processors shutdown.
 			for i := range test.processorIDs {
-				traceProcessor := pipelines.pipelines[component.NewID(component.DataTypeTraces)].processors[i]
+				traceProcessor := pipelines.pipelines[id.NewID(component.DataTypeTraces)].processors[i]
 				assert.True(t, traceProcessor.comp.(*testcomponents.ExampleProcessor).Stopped)
 
 				// Validate metrics.
-				metricsProcessor := pipelines.pipelines[component.NewID(component.DataTypeMetrics)].processors[i]
+				metricsProcessor := pipelines.pipelines[id.NewID(component.DataTypeMetrics)].processors[i]
 				assert.True(t, metricsProcessor.comp.(*testcomponents.ExampleProcessor).Stopped)
 
 				// Validate logs.
-				logsProcessor := pipelines.pipelines[component.NewID(component.DataTypeLogs)].processors[i]
+				logsProcessor := pipelines.pipelines[id.NewID(component.DataTypeLogs)].processors[i]
 				assert.True(t, logsProcessor.comp.(*testcomponents.ExampleProcessor).Stopped)
 			}
 
@@ -232,17 +233,17 @@ func TestBuildErrors(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.configFile, func(t *testing.T) {
 			factories := component.Factories{
-				Receivers: map[component.Type]component.ReceiverFactory{
+				Receivers: map[id.Type]component.ReceiverFactory{
 					nopReceiverFactory.Type(): nopReceiverFactory,
 					"unknown":                 nopReceiverFactory,
 					badReceiverFactory.Type(): badReceiverFactory,
 				},
-				Processors: map[component.Type]component.ProcessorFactory{
+				Processors: map[id.Type]component.ProcessorFactory{
 					nopProcessorFactory.Type(): nopProcessorFactory,
 					"unknown":                  nopProcessorFactory,
 					badProcessorFactory.Type(): badProcessorFactory,
 				},
-				Exporters: map[component.Type]component.ExporterFactory{
+				Exporters: map[id.Type]component.ExporterFactory{
 					nopExporterFactory.Type(): nopExporterFactory,
 					"unknown":                 nopExporterFactory,
 					badExporterFactory.Type(): badExporterFactory,
@@ -274,39 +275,39 @@ func TestFailToStartAndShutdown(t *testing.T) {
 	set := Settings{
 		Telemetry: componenttest.NewNopTelemetrySettings(),
 		BuildInfo: component.NewDefaultBuildInfo(),
-		ReceiverFactories: map[component.Type]component.ReceiverFactory{
+		ReceiverFactories: map[id.Type]component.ReceiverFactory{
 			nopReceiverFactory.Type(): nopReceiverFactory,
 			errReceiverFactory.Type(): errReceiverFactory,
 		},
-		ReceiverConfigs: map[component.ID]component.ReceiverConfig{
-			component.NewID(nopReceiverFactory.Type()): nopReceiverFactory.CreateDefaultConfig(),
-			component.NewID(errReceiverFactory.Type()): errReceiverFactory.CreateDefaultConfig(),
+		ReceiverConfigs: map[id.ID]component.ReceiverConfig{
+			id.NewID(nopReceiverFactory.Type()): nopReceiverFactory.CreateDefaultConfig(),
+			id.NewID(errReceiverFactory.Type()): errReceiverFactory.CreateDefaultConfig(),
 		},
-		ProcessorFactories: map[component.Type]component.ProcessorFactory{
+		ProcessorFactories: map[id.Type]component.ProcessorFactory{
 			nopProcessorFactory.Type(): nopProcessorFactory,
 			errProcessorFactory.Type(): errProcessorFactory,
 		},
-		ProcessorConfigs: map[component.ID]component.ProcessorConfig{
-			component.NewID(nopProcessorFactory.Type()): nopProcessorFactory.CreateDefaultConfig(),
-			component.NewID(errProcessorFactory.Type()): errProcessorFactory.CreateDefaultConfig(),
+		ProcessorConfigs: map[id.ID]component.ProcessorConfig{
+			id.NewID(nopProcessorFactory.Type()): nopProcessorFactory.CreateDefaultConfig(),
+			id.NewID(errProcessorFactory.Type()): errProcessorFactory.CreateDefaultConfig(),
 		},
-		ExporterFactories: map[component.Type]component.ExporterFactory{
+		ExporterFactories: map[id.Type]component.ExporterFactory{
 			nopExporterFactory.Type(): nopExporterFactory,
 			errExporterFactory.Type(): errExporterFactory,
 		},
-		ExporterConfigs: map[component.ID]component.ExporterConfig{
-			component.NewID(nopExporterFactory.Type()): nopExporterFactory.CreateDefaultConfig(),
-			component.NewID(errExporterFactory.Type()): errExporterFactory.CreateDefaultConfig(),
+		ExporterConfigs: map[id.ID]component.ExporterConfig{
+			id.NewID(nopExporterFactory.Type()): nopExporterFactory.CreateDefaultConfig(),
+			id.NewID(errExporterFactory.Type()): errExporterFactory.CreateDefaultConfig(),
 		},
 	}
 
 	for _, dt := range []component.DataType{component.DataTypeTraces, component.DataTypeMetrics, component.DataTypeLogs} {
 		t.Run(string(dt)+"/receiver", func(t *testing.T) {
-			set.PipelineConfigs = map[component.ID]*config.Pipeline{
-				component.NewID(dt): {
-					Receivers:  []component.ID{component.NewID("nop"), component.NewID("err")},
-					Processors: []component.ID{component.NewID("nop")},
-					Exporters:  []component.ID{component.NewID("nop")},
+			set.PipelineConfigs = map[id.ID]*config.Pipeline{
+				id.NewID(dt): {
+					Receivers:  []id.ID{id.NewID("nop"), id.NewID("err")},
+					Processors: []id.ID{id.NewID("nop")},
+					Exporters:  []id.ID{id.NewID("nop")},
 				},
 			}
 			pipelines, err := Build(context.Background(), set)
@@ -316,11 +317,11 @@ func TestFailToStartAndShutdown(t *testing.T) {
 		})
 
 		t.Run(string(dt)+"/processor", func(t *testing.T) {
-			set.PipelineConfigs = map[component.ID]*config.Pipeline{
-				component.NewID(dt): {
-					Receivers:  []component.ID{component.NewID("nop")},
-					Processors: []component.ID{component.NewID("nop"), component.NewID("err")},
-					Exporters:  []component.ID{component.NewID("nop")},
+			set.PipelineConfigs = map[id.ID]*config.Pipeline{
+				id.NewID(dt): {
+					Receivers:  []id.ID{id.NewID("nop")},
+					Processors: []id.ID{id.NewID("nop"), id.NewID("err")},
+					Exporters:  []id.ID{id.NewID("nop")},
 				},
 			}
 			pipelines, err := Build(context.Background(), set)
@@ -330,11 +331,11 @@ func TestFailToStartAndShutdown(t *testing.T) {
 		})
 
 		t.Run(string(dt)+"/exporter", func(t *testing.T) {
-			set.PipelineConfigs = map[component.ID]*config.Pipeline{
-				component.NewID(dt): {
-					Receivers:  []component.ID{component.NewID("nop")},
-					Processors: []component.ID{component.NewID("nop")},
-					Exporters:  []component.ID{component.NewID("nop"), component.NewID("err")},
+			set.PipelineConfigs = map[id.ID]*config.Pipeline{
+				id.NewID(dt): {
+					Receivers:  []id.ID{id.NewID("nop")},
+					Processors: []id.ID{id.NewID("nop")},
+					Exporters:  []id.ID{id.NewID("nop"), id.NewID("err")},
 				},
 			}
 			pipelines, err := Build(context.Background(), set)
@@ -350,7 +351,7 @@ func newBadReceiverFactory() component.ReceiverFactory {
 		return &struct {
 			config.ReceiverSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
 		}{
-			ReceiverSettings: config.NewReceiverSettings(component.NewID("bf")),
+			ReceiverSettings: config.NewReceiverSettings(id.NewID("bf")),
 		}
 	})
 }
@@ -360,7 +361,7 @@ func newBadProcessorFactory() component.ProcessorFactory {
 		return &struct {
 			config.ProcessorSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
 		}{
-			ProcessorSettings: config.NewProcessorSettings(component.NewID("bf")),
+			ProcessorSettings: config.NewProcessorSettings(id.NewID("bf")),
 		}
 	})
 }
@@ -370,7 +371,7 @@ func newBadExporterFactory() component.ExporterFactory {
 		return &struct {
 			config.ExporterSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
 		}{
-			ExporterSettings: config.NewExporterSettings(component.NewID("bf")),
+			ExporterSettings: config.NewExporterSettings(id.NewID("bf")),
 		}
 	})
 }
@@ -380,7 +381,7 @@ func newErrReceiverFactory() component.ReceiverFactory {
 		return &struct {
 			config.ReceiverSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
 		}{
-			ReceiverSettings: config.NewReceiverSettings(component.NewID("bf")),
+			ReceiverSettings: config.NewReceiverSettings(id.NewID("bf")),
 		}
 	},
 		component.WithTracesReceiver(func(context.Context, component.ReceiverCreateSettings, component.ReceiverConfig, consumer.Traces) (component.TracesReceiver, error) {
@@ -400,7 +401,7 @@ func newErrProcessorFactory() component.ProcessorFactory {
 		return &struct {
 			config.ProcessorSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
 		}{
-			ProcessorSettings: config.NewProcessorSettings(component.NewID("bf")),
+			ProcessorSettings: config.NewProcessorSettings(id.NewID("bf")),
 		}
 	},
 		component.WithTracesProcessor(func(context.Context, component.ProcessorCreateSettings, component.ProcessorConfig, consumer.Traces) (component.TracesProcessor, error) {
@@ -420,7 +421,7 @@ func newErrExporterFactory() component.ExporterFactory {
 		return &struct {
 			config.ExporterSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
 		}{
-			ExporterSettings: config.NewExporterSettings(component.NewID("bf")),
+			ExporterSettings: config.NewExporterSettings(id.NewID("bf")),
 		}
 	},
 		component.WithTracesExporter(func(context.Context, component.ExporterCreateSettings, component.ExporterConfig) (component.TracesExporter, error) {
@@ -474,7 +475,7 @@ type configSettings struct {
 }
 
 type serviceSettings struct {
-	Pipelines map[component.ID]*config.Pipeline `mapstructure:"pipelines"`
+	Pipelines map[id.ID]*config.Pipeline `mapstructure:"pipelines"`
 }
 
 func loadConfig(t *testing.T, fileName string, factories component.Factories) *configSettings {

--- a/service/internal/testcomponents/example_exporter.go
+++ b/service/internal/testcomponents/example_exporter.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/id"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/pdata/plog"
@@ -46,7 +47,7 @@ var ExampleExporterFactory = component.NewExporterFactory(
 
 func createExporterDefaultConfig() component.ExporterConfig {
 	return &ExampleExporterConfig{
-		ExporterSettings: config.NewExporterSettings(component.NewID(typeStr)),
+		ExporterSettings: config.NewExporterSettings(id.NewID(typeStr)),
 	}
 }
 

--- a/service/internal/testcomponents/example_factories.go
+++ b/service/internal/testcomponents/example_factories.go
@@ -16,18 +16,19 @@ package testcomponents // import "go.opentelemetry.io/collector/service/internal
 
 import (
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/id"
 )
 
 // ExampleComponents registers example factories. This is only used by tests.
 func ExampleComponents() (component.Factories, error) {
 	return component.Factories{
-		Receivers: map[component.Type]component.ReceiverFactory{
+		Receivers: map[id.Type]component.ReceiverFactory{
 			ExampleReceiverFactory.Type(): ExampleReceiverFactory,
 		},
-		Processors: map[component.Type]component.ProcessorFactory{
+		Processors: map[id.Type]component.ProcessorFactory{
 			ExampleProcessorFactory.Type(): ExampleProcessorFactory,
 		},
-		Exporters: map[component.Type]component.ExporterFactory{
+		Exporters: map[id.Type]component.ExporterFactory{
 			ExampleExporterFactory.Type(): ExampleExporterFactory,
 		},
 	}, nil

--- a/service/internal/testcomponents/example_processor.go
+++ b/service/internal/testcomponents/example_processor.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/id"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/consumer"
 )
@@ -40,7 +41,7 @@ var ExampleProcessorFactory = component.NewProcessorFactory(
 // CreateDefaultConfig creates the default configuration for the Processor.
 func createDefaultConfig() component.ProcessorConfig {
 	return &ExampleProcessorConfig{
-		ProcessorSettings: config.NewProcessorSettings(component.NewID(procType)),
+		ProcessorSettings: config.NewProcessorSettings(id.NewID(procType)),
 	}
 }
 

--- a/service/internal/testcomponents/example_receiver.go
+++ b/service/internal/testcomponents/example_receiver.go
@@ -18,11 +18,12 @@ import (
 	"context"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/id"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/consumer"
 )
 
-const receiverType = component.Type("examplereceiver")
+const receiverType = id.Type("examplereceiver")
 
 // ExampleReceiverConfig config for ExampleReceiver.
 type ExampleReceiverConfig struct {
@@ -39,7 +40,7 @@ var ExampleReceiverFactory = component.NewReceiverFactory(
 
 func createReceiverDefaultConfig() component.ReceiverConfig {
 	return &ExampleReceiverConfig{
-		ReceiverSettings: config.NewReceiverSettings(component.NewID(receiverType)),
+		ReceiverSettings: config.NewReceiverSettings(id.NewID(receiverType)),
 	}
 }
 

--- a/service/servicetest/configprovider_test.go
+++ b/service/servicetest/configprovider_test.go
@@ -21,8 +21,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/component/id"
 	"go.opentelemetry.io/collector/config"
 )
 
@@ -35,35 +35,35 @@ func TestLoadConfig(t *testing.T) {
 
 	// Verify extensions.
 	require.Len(t, cfg.Extensions, 2)
-	assert.Contains(t, cfg.Extensions, component.NewID("nop"))
-	assert.Contains(t, cfg.Extensions, component.NewIDWithName("nop", "myextension"))
+	assert.Contains(t, cfg.Extensions, id.NewID("nop"))
+	assert.Contains(t, cfg.Extensions, id.NewIDWithName("nop", "myextension"))
 
 	// Verify receivers
 	require.Len(t, cfg.Receivers, 2)
-	assert.Contains(t, cfg.Receivers, component.NewID("nop"))
-	assert.Contains(t, cfg.Receivers, component.NewIDWithName("nop", "myreceiver"))
+	assert.Contains(t, cfg.Receivers, id.NewID("nop"))
+	assert.Contains(t, cfg.Receivers, id.NewIDWithName("nop", "myreceiver"))
 
 	// Verify exporters
 	assert.Len(t, cfg.Exporters, 2)
-	assert.Contains(t, cfg.Exporters, component.NewID("nop"))
-	assert.Contains(t, cfg.Exporters, component.NewIDWithName("nop", "myexporter"))
+	assert.Contains(t, cfg.Exporters, id.NewID("nop"))
+	assert.Contains(t, cfg.Exporters, id.NewIDWithName("nop", "myexporter"))
 
 	// Verify procs
 	assert.Len(t, cfg.Processors, 2)
-	assert.Contains(t, cfg.Processors, component.NewID("nop"))
-	assert.Contains(t, cfg.Processors, component.NewIDWithName("nop", "myprocessor"))
+	assert.Contains(t, cfg.Processors, id.NewID("nop"))
+	assert.Contains(t, cfg.Processors, id.NewIDWithName("nop", "myprocessor"))
 
 	// Verify service.
 	require.Len(t, cfg.Service.Extensions, 1)
-	assert.Contains(t, cfg.Service.Extensions, component.NewID("nop"))
+	assert.Contains(t, cfg.Service.Extensions, id.NewID("nop"))
 	require.Len(t, cfg.Service.Pipelines, 1)
 	assert.Equal(t,
 		&config.Pipeline{
-			Receivers:  []component.ID{component.NewID("nop")},
-			Processors: []component.ID{component.NewID("nop")},
-			Exporters:  []component.ID{component.NewID("nop")},
+			Receivers:  []id.ID{id.NewID("nop")},
+			Processors: []id.ID{id.NewID("nop")},
+			Exporters:  []id.ID{id.NewID("nop")},
 		},
-		cfg.Service.Pipelines[component.NewID("traces")],
+		cfg.Service.Pipelines[id.NewID("traces")],
 		"Did not load pipeline config correctly")
 }
 

--- a/service/unmarshaler_test.go
+++ b/service/unmarshaler_test.go
@@ -21,8 +21,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
-	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/component/id"
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/service/telemetry"
 )
@@ -141,7 +141,7 @@ func TestConfigServicePipelineUnmarshalError(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
-			pipelines := make(map[component.ID]ConfigServicePipeline)
+			pipelines := make(map[id.ID]ConfigServicePipeline)
 			err := tt.conf.Unmarshal(&pipelines, confmap.WithErrorUnused())
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), tt.expectError)


### PR DESCRIPTION
## Summary of changes

- Add component/status package. This introduces the concepts of component status event and pipeline readiness status.
- Introduce Host.RegisterStatusListener() to allow components to listen for status changes.
- Deprecate Host.ReportFatalError() in favour of Host.ReportComponentStatus().
- Move component ID and Type to a separate component/id package. This is necessary to avoid dependency cycle with the new component/status package. Large part of the diff in this commit is because of this particular change. If this is too large and difficult to review we can split this commit into 2 parts where this particular change is a separate commit.
- Deprecated component.ID and component.Type in favour of id.ID and id.Type.

## TODO after this is merged

- healthcheck extension must register and listen to component statuses.
- Replace all ReportFatalError() calls by ReportComponentStatus() calls in core and contrib.

## Open Questions

- Do we want to name component/id package component/componentid instead?
- The pipelines readiness status is also implemented in the component/status package. We can split the status, componentstatus and pipelinestatus into separate packages but not sure if it warrants creation of a new top-level package just to be able to stay pure in the component package. We can try this if think it is a better approach.
- Listeners need to be able to tell if all current components are healthy. It is assumed that the listeners need to maintain a map of components and track the status of each component. This works only if we assume that the set of components cannot change during the lifetime of the listener. This assumption is true today but can change in the future if we introduce partial pipeline restarts where only modified/added/removed components are recreated (this will break listener's assumption and the map will become invalid). Should we instead keep track of this entire status map in the Host and broadcast the entire status to the listeners as a whole instead of (or in addition to) individual component events?
