### PR TITLE
[chore] update component module to v0.0.0

### DIFF
--- a/cmd/otelcorecol/go.mod
+++ b/cmd/otelcorecol/go.mod
@@ -7,7 +7,7 @@ go 1.18
 require (
 	github.com/stretchr/testify v1.8.1
 	go.opentelemetry.io/collector v0.64.1
-	go.opentelemetry.io/collector/component v0.64.1
+	go.opentelemetry.io/collector/component v0.0.0-20221115212826-19db2f15c85c
 	go.opentelemetry.io/collector/exporter/loggingexporter v0.64.1
 	go.opentelemetry.io/collector/exporter/otlpexporter v0.64.1
 	go.opentelemetry.io/collector/exporter/otlphttpexporter v0.64.1

--- a/exporter/loggingexporter/go.mod
+++ b/exporter/loggingexporter/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/stretchr/testify v1.8.1
 	go.opentelemetry.io/collector v0.64.1
-	go.opentelemetry.io/collector/component v0.64.1
+	go.opentelemetry.io/collector/component v0.0.0-20221115212826-19db2f15c85c
 	go.opentelemetry.io/collector/pdata v0.64.1
 	go.uber.org/zap v1.23.0
 	golang.org/x/sys v0.2.0

--- a/exporter/otlpexporter/go.mod
+++ b/exporter/otlpexporter/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/stretchr/testify v1.8.1
 	go.opentelemetry.io/collector v0.64.1
-	go.opentelemetry.io/collector/component v0.64.1
+	go.opentelemetry.io/collector/component v0.0.0-20221115212826-19db2f15c85c
 	go.opentelemetry.io/collector/pdata v0.64.1
 	go.uber.org/atomic v1.10.0
 	google.golang.org/genproto v0.0.0-20221018160656-63c7b68cfc55

--- a/exporter/otlphttpexporter/go.mod
+++ b/exporter/otlphttpexporter/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/stretchr/testify v1.8.1
 	go.opentelemetry.io/collector v0.64.1
-	go.opentelemetry.io/collector/component v0.64.1
+	go.opentelemetry.io/collector/component v0.0.0-20221115212826-19db2f15c85c
 	go.opentelemetry.io/collector/pdata v0.64.1
 	go.opentelemetry.io/collector/receiver/otlpreceiver v0.64.1
 	go.uber.org/zap v1.23.0

--- a/extension/ballastextension/go.mod
+++ b/extension/ballastextension/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/stretchr/testify v1.8.1
 	go.opentelemetry.io/collector v0.64.1
-	go.opentelemetry.io/collector/component v0.64.1
+	go.opentelemetry.io/collector/component v0.0.0-20221115212826-19db2f15c85c
 	go.uber.org/zap v1.23.0
 )
 

--- a/extension/zpagesextension/go.mod
+++ b/extension/zpagesextension/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/stretchr/testify v1.8.1
 	go.opentelemetry.io/collector v0.64.1
-	go.opentelemetry.io/collector/component v0.64.1
+	go.opentelemetry.io/collector/component v0.0.0-20221115212826-19db2f15c85c
 	go.opentelemetry.io/contrib/zpages v0.36.4
 	go.opentelemetry.io/otel/sdk v1.11.1
 	go.opentelemetry.io/otel/trace v1.11.1

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/spf13/cobra v1.6.1
 	github.com/stretchr/testify v1.8.1
 	go.opencensus.io v0.24.0
-	go.opentelemetry.io/collector/component v0.64.1
+	go.opentelemetry.io/collector/component v0.0.0-20221115212826-19db2f15c85c
 	go.opentelemetry.io/collector/extension/zpagesextension v0.64.1
 	go.opentelemetry.io/collector/pdata v0.64.1
 	go.opentelemetry.io/collector/processor/batchprocessor v0.64.1

--- a/processor/batchprocessor/go.mod
+++ b/processor/batchprocessor/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/stretchr/testify v1.8.1
 	go.opencensus.io v0.24.0
 	go.opentelemetry.io/collector v0.64.1
-	go.opentelemetry.io/collector/component v0.64.1
+	go.opentelemetry.io/collector/component v0.0.0-20221115212826-19db2f15c85c
 	go.opentelemetry.io/collector/pdata v0.64.1
 	go.uber.org/zap v1.23.0
 )

--- a/processor/memorylimiterprocessor/go.mod
+++ b/processor/memorylimiterprocessor/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/stretchr/testify v1.8.1
 	go.opentelemetry.io/collector v0.64.1
-	go.opentelemetry.io/collector/component v0.64.1
+	go.opentelemetry.io/collector/component v0.0.0-20221115212826-19db2f15c85c
 	go.opentelemetry.io/collector/pdata v0.64.1
 	go.uber.org/atomic v1.10.0
 	go.uber.org/zap v1.23.0

--- a/receiver/otlpreceiver/go.mod
+++ b/receiver/otlpreceiver/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/gogo/protobuf v1.3.2
 	github.com/stretchr/testify v1.8.1
 	go.opentelemetry.io/collector v0.64.1
-	go.opentelemetry.io/collector/component v0.64.1
+	go.opentelemetry.io/collector/component v0.0.0-20221115212826-19db2f15c85c
 	go.opentelemetry.io/collector/pdata v0.64.1
 	go.opentelemetry.io/collector/semconv v0.64.1
 	go.uber.org/zap v1.23.0


### PR DESCRIPTION
This makes updating otel core possible from contrib without having to write a bunch of replace statements.
