### PR TITLE
Remove unit suffixes from metrics exported by the otel-go prometheus exporter

### DIFF
--- a/.chloggen/remove_units_suffix_otel_go_prometheus_exporter.yaml
+++ b/.chloggen/remove_units_suffix_otel_go_prometheus_exporter.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: service/telemetry
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove unit suffixes from metrics exported by the otel-go prometheus exporter.
+
+# One or more tracking issues or pull requests related to the change
+issues: [6403]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/service/telemetry.go
+++ b/service/telemetry.go
@@ -235,7 +235,10 @@ func (tel *telemetryInitializer) initOpenTelemetry(attrs map[string]string, prom
 	}
 
 	wrappedRegisterer := prometheus.WrapRegistererWithPrefix("otelcol_", promRegistry)
-	exporter, err := otelprom.New(otelprom.WithRegisterer(wrappedRegisterer))
+	// We can remove `otelprom.WithoutUnits()` when the otel-go start exposing prometheus metrics using the OpenMetrics format
+	// which includes metric units that prometheusreceiver uses to trim unit's suffixes from metric names.
+	// https://github.com/open-telemetry/opentelemetry-go/issues/3468
+	exporter, err := otelprom.New(otelprom.WithRegisterer(wrappedRegisterer), otelprom.WithoutUnits())
 	if err != nil {
 		return fmt.Errorf("error creating otel prometheus exporter: %w", err)
 	}

--- a/service/telemetry_test.go
+++ b/service/telemetry_test.go
@@ -27,6 +27,8 @@ import (
 	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/view"
 	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/instrument"
+	"go.opentelemetry.io/otel/metric/unit"
 	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/component"
@@ -186,7 +188,7 @@ func TestTelemetryInit(t *testing.T) {
 
 func createTestMetrics(t *testing.T, mp metric.MeterProvider) *view.View {
 	// Creates a OTel Go counter
-	counter, err := mp.Meter("collector_test").SyncInt64().Counter(otelPrefix + counterName)
+	counter, err := mp.Meter("collector_test").SyncInt64().Counter(otelPrefix+counterName, instrument.WithUnit(unit.Milliseconds))
 	require.NoError(t, err)
 	counter.Add(context.Background(), 13)
 


### PR DESCRIPTION
**Description:** Disable the units suffixes added on metrics of otel-go. Type suffixes (`_total`) will still be added but can be trimmed with https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/16071. 

https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/16071 is supposed to remove both units and type's suffixes, but otel-go prometheus exporter doesn't expose the unit metadata, so we can't trim these units suffixes. 

This is a breaking change but it restores conformity of the metrics exported by the otel go sdk and opencensus sdk.

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector/issues/6403

**Testing:** Changed the unit test to add an unit to the created metric, which shouldn't be added as suffix.
