### PR TITLE
[component] Rename "In development" stability level to "Development"

### DIFF
--- a/.chloggen/rename-dev-stability-level.yaml
+++ b/.chloggen/rename-dev-stability-level.yaml
@@ -1,0 +1,6 @@
+change_type: deprecation
+component: component
+note: Deprecate `StabilityLevelInDevelopment` enum const in favor of `StabilityLevelDevelopment`.
+issues: [6561]
+subtext: |-
+  Also rename all mentions of "In development" stability level to "Development".

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ we intend to provide high-quality components as part of this repository, we ackn
 for prime time. As such, each component should list its current stability level for each telemetry signal, according to
 the following definitions:
 
-### In development
+### Development
 
 Not all pieces of the component are in place yet and it might not be available as part of any distributions yet. Bugs and performance issues should be reported, but it is likely that the component owners might not give them much attention. Your feedback is still desired, especially when it comes to the user-experience (configuration options, component observability, technical implementation details, ...). Configuration options might break often depending on how things evolve. The component should not be used in production.
 

--- a/component/component.go
+++ b/component/component.go
@@ -116,11 +116,14 @@ const (
 	StabilityLevelUndefined StabilityLevel = iota // skip 0, start types from 1.
 	StabilityLevelUnmaintained
 	StabilityLevelDeprecated
-	StabilityLevelInDevelopment
+	StabilityLevelDevelopment
 	StabilityLevelAlpha
 	StabilityLevelBeta
 	StabilityLevelStable
 )
+
+// Deprecated: [0.65.0] Use StabilityLevelDevelopment instead.
+const StabilityLevelInDevelopment = StabilityLevelDevelopment
 
 func (sl StabilityLevel) String() string {
 	switch sl {
@@ -130,8 +133,8 @@ func (sl StabilityLevel) String() string {
 		return "Unmaintained"
 	case StabilityLevelDeprecated:
 		return "Deprecated"
-	case StabilityLevelInDevelopment:
-		return "In development"
+	case StabilityLevelDevelopment:
+		return "Development"
 	case StabilityLevelAlpha:
 		return "Alpha"
 	case StabilityLevelBeta:
@@ -148,8 +151,8 @@ func (sl StabilityLevel) LogMessage() string {
 		return "Unmaintained component. Actively looking for contributors. Component will become deprecated after 6 months of remaining unmaintained."
 	case StabilityLevelDeprecated:
 		return "Deprecated component. Will be removed in future releases."
-	case StabilityLevelInDevelopment:
-		return "In development component. May change in the future."
+	case StabilityLevelDevelopment:
+		return "Development component. May change in the future."
 	case StabilityLevelAlpha:
 		return "Alpha component. May change in the future."
 	case StabilityLevelBeta:

--- a/component/component_test.go
+++ b/component/component_test.go
@@ -29,7 +29,7 @@ func TestStabilityLevelString(t *testing.T) {
 	assert.EqualValues(t, "Undefined", StabilityLevelUndefined.String())
 	assert.EqualValues(t, "Unmaintained", StabilityLevelUnmaintained.String())
 	assert.EqualValues(t, "Deprecated", StabilityLevelDeprecated.String())
-	assert.EqualValues(t, "In development", StabilityLevelInDevelopment.String())
+	assert.EqualValues(t, "Development", StabilityLevelDevelopment.String())
 	assert.EqualValues(t, "Alpha", StabilityLevelAlpha.String())
 	assert.EqualValues(t, "Beta", StabilityLevelBeta.String())
 	assert.EqualValues(t, "Stable", StabilityLevelStable.String())

--- a/component/exporter_test.go
+++ b/component/exporter_test.go
@@ -48,13 +48,13 @@ func TestNewExporterFactory_WithOptions(t *testing.T) {
 	factory := component.NewExporterFactory(
 		typeStr,
 		func() component.ExporterConfig { return &defaultCfg },
-		component.WithTracesExporter(createTracesExporter, component.StabilityLevelInDevelopment),
+		component.WithTracesExporter(createTracesExporter, component.StabilityLevelDevelopment),
 		component.WithMetricsExporter(createMetricsExporter, component.StabilityLevelAlpha),
 		component.WithLogsExporter(createLogsExporter, component.StabilityLevelDeprecated))
 	assert.EqualValues(t, typeStr, factory.Type())
 	assert.EqualValues(t, &defaultCfg, factory.CreateDefaultConfig())
 
-	assert.Equal(t, component.StabilityLevelInDevelopment, factory.TracesExporterStability())
+	assert.Equal(t, component.StabilityLevelDevelopment, factory.TracesExporterStability())
 	_, err := factory.CreateTracesExporter(context.Background(), component.ExporterCreateSettings{}, &defaultCfg)
 	assert.NoError(t, err)
 

--- a/component/extension_test.go
+++ b/component/extension_test.go
@@ -42,11 +42,11 @@ func TestNewExtensionFactory(t *testing.T) {
 		func(ctx context.Context, settings component.ExtensionCreateSettings, extension component.ExtensionConfig) (component.Extension, error) {
 			return nopExtensionInstance, nil
 		},
-		component.StabilityLevelInDevelopment)
+		component.StabilityLevelDevelopment)
 	assert.EqualValues(t, typeStr, factory.Type())
 	assert.EqualValues(t, &defaultCfg, factory.CreateDefaultConfig())
 
-	assert.Equal(t, component.StabilityLevelInDevelopment, factory.ExtensionStability())
+	assert.Equal(t, component.StabilityLevelDevelopment, factory.ExtensionStability())
 	ext, err := factory.CreateExtension(context.Background(), component.ExtensionCreateSettings{}, &defaultCfg)
 	assert.NoError(t, err)
 	assert.Same(t, nopExtensionInstance, ext)

--- a/docs/scraping-receivers.md
+++ b/docs/scraping-receivers.md
@@ -56,7 +56,7 @@ All the requirements defined for components in [the Collector's README](../READM
 applicable to the scraping receivers as well. In addition, the following rules applied specifically to scraping
 metrics receivers:
 
-### In development
+### Development
 
 The receiver is not ready for use. All the metrics emitted by the receiver are not finalized and can change in any way.
 

--- a/exporter/loggingexporter/README.md
+++ b/exporter/loggingexporter/README.md
@@ -1,10 +1,10 @@
 # Logging Exporter
 
-| Status                   |                         |
-| ------------------------ | ----------------------- |
-| Stability                | [In development]        |
-| Supported pipeline types | traces, metrics, logs   |
-| Distributions            | [core], [contrib]       |
+| Status                   |                       |
+| ------------------------ |-----------------------|
+| Stability                | [Development]         |
+| Supported pipeline types | traces, metrics, logs |
+| Distributions            | [core], [contrib]     |
 
 Exports data to the console via zap.Logger.
 
@@ -43,4 +43,4 @@ exporters:
 
 [contrib]: https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib
 [core]: https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol
-[In development]: https://github.com/open-telemetry/opentelemetry-collector#in-development
+[Development]: https://github.com/open-telemetry/opentelemetry-collector#in-development

--- a/exporter/loggingexporter/factory.go
+++ b/exporter/loggingexporter/factory.go
@@ -43,9 +43,9 @@ func NewFactory() component.ExporterFactory {
 	return component.NewExporterFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithTracesExporter(createTracesExporter, component.StabilityLevelInDevelopment),
-		component.WithMetricsExporter(createMetricsExporter, component.StabilityLevelInDevelopment),
-		component.WithLogsExporter(createLogsExporter, component.StabilityLevelInDevelopment),
+		component.WithTracesExporter(createTracesExporter, component.StabilityLevelDevelopment),
+		component.WithMetricsExporter(createMetricsExporter, component.StabilityLevelDevelopment),
+		component.WithLogsExporter(createLogsExporter, component.StabilityLevelDevelopment),
 	)
 }
 

--- a/service/extensions/extensions_test.go
+++ b/service/extensions/extensions_test.go
@@ -118,7 +118,7 @@ func newBadExtensionFactory() component.ExtensionFactory {
 		func(ctx context.Context, set component.ExtensionCreateSettings, extension component.ExtensionConfig) (component.Extension, error) {
 			return nil, nil
 		},
-		component.StabilityLevelInDevelopment,
+		component.StabilityLevelDevelopment,
 	)
 }
 
@@ -135,6 +135,6 @@ func newCreateErrorExtensionFactory() component.ExtensionFactory {
 		func(ctx context.Context, set component.ExtensionCreateSettings, extension component.ExtensionConfig) (component.Extension, error) {
 			return nil, errors.New("cannot create \"err\" extension type")
 		},
-		component.StabilityLevelInDevelopment,
+		component.StabilityLevelDevelopment,
 	)
 }

--- a/service/internal/components/components.go
+++ b/service/internal/components/components.go
@@ -21,7 +21,7 @@ import (
 )
 
 // LogStabilityLevel logs the stability level of a component. The log level is set to info for
-// undefined, unmaintained, deprecated and in development. The log level is set to debug
+// undefined, unmaintained, deprecated and development. The log level is set to debug
 // for alpha, beta and stable.
 func LogStabilityLevel(logger *zap.Logger, sl component.StabilityLevel) {
 	if sl >= component.StabilityLevelAlpha {

--- a/service/internal/components/components_test.go
+++ b/service/internal/components/components_test.go
@@ -47,7 +47,7 @@ func TestLogStabilityLevel(t *testing.T) {
 		LogStabilityLevel(logger, component.StabilityLevelUndefined)
 		LogStabilityLevel(logger, component.StabilityLevelUnmaintained)
 		LogStabilityLevel(logger, component.StabilityLevelDeprecated)
-		LogStabilityLevel(logger, component.StabilityLevelInDevelopment)
+		LogStabilityLevel(logger, component.StabilityLevelDevelopment)
 		LogStabilityLevel(logger, component.StabilityLevelAlpha)
 		LogStabilityLevel(logger, component.StabilityLevelBeta)
 		LogStabilityLevel(logger, component.StabilityLevelStable)

--- a/service/internal/testcomponents/example_exporter.go
+++ b/service/internal/testcomponents/example_exporter.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	typeStr   = "exampleexporter"
-	stability = component.StabilityLevelInDevelopment
+	stability = component.StabilityLevelDevelopment
 )
 
 // ExampleExporterConfig config for ExampleExporter.

--- a/service/internal/testcomponents/example_processor.go
+++ b/service/internal/testcomponents/example_processor.go
@@ -33,9 +33,9 @@ type ExampleProcessorConfig struct {
 var ExampleProcessorFactory = component.NewProcessorFactory(
 	procType,
 	createDefaultConfig,
-	component.WithTracesProcessor(createTracesProcessor, component.StabilityLevelInDevelopment),
-	component.WithMetricsProcessor(createMetricsProcessor, component.StabilityLevelInDevelopment),
-	component.WithLogsProcessor(createLogsProcessor, component.StabilityLevelInDevelopment))
+	component.WithTracesProcessor(createTracesProcessor, component.StabilityLevelDevelopment),
+	component.WithMetricsProcessor(createMetricsProcessor, component.StabilityLevelDevelopment),
+	component.WithLogsProcessor(createLogsProcessor, component.StabilityLevelDevelopment))
 
 // CreateDefaultConfig creates the default configuration for the Processor.
 func createDefaultConfig() component.ProcessorConfig {

--- a/service/internal/testcomponents/example_receiver.go
+++ b/service/internal/testcomponents/example_receiver.go
@@ -33,9 +33,9 @@ type ExampleReceiverConfig struct {
 var ExampleReceiverFactory = component.NewReceiverFactory(
 	receiverType,
 	createReceiverDefaultConfig,
-	component.WithTracesReceiver(createTracesReceiver, component.StabilityLevelInDevelopment),
-	component.WithMetricsReceiver(createMetricsReceiver, component.StabilityLevelInDevelopment),
-	component.WithLogsReceiver(createLogsReceiver, component.StabilityLevelInDevelopment))
+	component.WithTracesReceiver(createTracesReceiver, component.StabilityLevelDevelopment),
+	component.WithMetricsReceiver(createMetricsReceiver, component.StabilityLevelDevelopment),
+	component.WithLogsReceiver(createLogsReceiver, component.StabilityLevelDevelopment))
 
 func createReceiverDefaultConfig() component.ReceiverConfig {
 	return &ExampleReceiverConfig{


### PR DESCRIPTION
The decision to rename this stability level was made in https://github.com/open-telemetry/opentelemetry-collector/pull/6531#discussion_r1020619947