### PR TITLE
[component helper] Adding lifecycle state management to *helper.

### DIFF
--- a/internal/lifecycle/state.go
+++ b/internal/lifecycle/state.go
@@ -1,0 +1,55 @@
+// Copyright  The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lifecycle // import "go.opentelemetry.io/collector/internal/lifecycle"
+
+import "go.uber.org/atomic"
+
+// Lifecycle represents the current
+// running state of the component
+// that is intended to be concurrency safe.
+type State interface {
+	// Start atomically updates the state and returns true if
+	// the previous state was not running.
+	Start() (started bool)
+
+	// Stop atomically updates the state and returns true if
+	// the previous state was not shutdown.
+	Stop() (stopped bool)
+}
+
+type state struct {
+	current *atomic.Int64
+}
+
+const (
+	shutdown = iota
+	running
+)
+
+var (
+	_ State = (*state)(nil)
+)
+
+func NewState() State {
+	return &state{current: atomic.NewInt64(shutdown)}
+}
+
+func (s *state) Start() (started bool) {
+	return s.current.Swap(running) == shutdown
+}
+
+func (s *state) Stop() (stopped bool) {
+	return s.current.Swap(shutdown) == running
+}

--- a/internal/lifecycle/state_test.go
+++ b/internal/lifecycle/state_test.go
@@ -1,0 +1,75 @@
+// Copyright  The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lifecycle
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLifecycleState(t *testing.T) {
+	t.Parallel()
+
+	state := NewState()
+	assert.True(t, state.Start(), "Must confirm the state has been updated")
+	assert.False(t, state.Start(), "Must confirm the state no state change")
+
+	assert.True(t, state.Stop(), "Must confirm the state has been updated")
+	assert.False(t, state.Stop(), "Must confirm the state no state change")
+}
+
+func TestLifecycleConcurrency(t *testing.T) {
+	t.Parallel()
+
+	state := NewState()
+
+	var (
+		updated int
+		start   = make(chan struct{})
+		wg      sync.WaitGroup
+	)
+
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			if state.Start() {
+				updated++
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+	assert.Equal(t, 1, updated, "Must have only been updated once")
+
+	start = make(chan struct{})
+
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			if state.Stop() {
+				updated--
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+	assert.Equal(t, 0, updated, "Must have only been updated once")
+}


### PR DESCRIPTION
**Description:** 

Extending the current helpers to adhere to the current component expectations

**Link to tracking Issue:** 
https://github.com/open-telemetry/opentelemetry-collector/issues/6507

**Testing:**

Haven't extended the tests yet, but my intention is to extend the lifecycle test to check if a component can:
- Allow for partial shutdown
- is restartable 

**Documentation:** 
Haven't added it yet, just wanting to get feedback to check the approach.