### PR TITLE
[release] Update release schedule

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -129,10 +129,10 @@ The OpenTelemetry Collector maintainers will ultimately have the responsibility 
 
 | Date       | Version | Release manager |
 |------------|---------|-----------------|
-| 2022-11-09 | v0.64.0 | @jpkrohling     |
-| 2022-11-23 | v0.65.0 | @tigrannajaryan |
+| 2022-11-21 | v0.65.0 | @tigrannajaryan |
 | 2022-12-07 | v0.66.0 | @Aneurysm9      |
 | 2022-12-21 | v0.67.0 | @mx-psi         |
 | 2023-01-04 | v0.68.0 | @dmitryax       |
 | 2023-01-18 | v0.69.0 | @bogdandrutu    |
 | 2022-02-01 | v0.70.0 | @codeboten      |
+| 2022-02-15 | v0.71.0 | @jpkrohling     |


### PR DESCRIPTION
**Description:** 

Update release schedule per internal discussion to happen on Monday instead of Wednesday next week.

The rationale is that we want to have some more distance with Thanksgiving, when many approvers and maintainers will be out of office.
