### PR TITLE
Deprecate Config.Validate() in favor of component.ValidateConfig

### DIFF
--- a/.chloggen/deprecatevalidate.yaml
+++ b/.chloggen/deprecatevalidate.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: component
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecate `component.Config.Validate` in favor of `component.ValidateConfig`
+
+# One or more tracking issues or pull requests related to the change
+issues: [6572]

--- a/component/config.go
+++ b/component/config.go
@@ -18,14 +18,33 @@ import (
 	"go.opentelemetry.io/collector/confmap"
 )
 
-// Type is the component type as it is used in the config.
-type Type string
+type Config interface {
+	identifiable
+	// Deprecated: [v0.65.0] use component.ValidateConfig.
+	Validate() error
 
-// validatable defines the interface for the configuration validation.
-type validatable interface {
-	// Validate validates the configuration and returns an error if invalid.
+	privateConfig()
+}
+
+// ConfigValidator defines an optional interface for configurations to implement to do validation.
+type ConfigValidator interface {
+	// Validate the configuration and returns an error if invalid.
 	Validate() error
 }
+
+// ValidateConfig validates a config, by doing this:
+//   - Call Validate on the config itself if the config implements ConfigValidator.
+func ValidateConfig(cfg Config) error {
+	validator, ok := cfg.(ConfigValidator)
+	if !ok {
+		return nil
+	}
+
+	return validator.Validate()
+}
+
+// Type is the component type as it is used in the config.
+type Type string
 
 // DataType is a special Type that represents the data types supported by the collector. We currently support
 // collecting metrics, traces and logs, this can expand in the future.

--- a/component/exporter.go
+++ b/component/exporter.go
@@ -24,10 +24,7 @@ import (
 // ExporterConfig is the configuration of a component.Exporter. Specific Exporter must implement
 // this interface and must embed config.ExporterSettings struct or a struct that extends it.
 type ExporterConfig interface {
-	identifiable
-	validatable
-
-	privateConfigExporter()
+	Config
 }
 
 // UnmarshalExporterConfig helper function to unmarshal an ExporterConfig.

--- a/component/extension.go
+++ b/component/extension.go
@@ -23,10 +23,7 @@ import (
 // ExtensionConfig is the configuration of a component.Extension. Specific Extension must implement
 // this interface and must embed config.ExtensionSettings struct or a struct that extends it.
 type ExtensionConfig interface {
-	identifiable
-	validatable
-
-	privateConfigExtension()
+	Config
 }
 
 // UnmarshalExtensionConfig helper function to unmarshal an ExtensionConfig.

--- a/component/processor.go
+++ b/component/processor.go
@@ -24,10 +24,7 @@ import (
 // ProcessorConfig is the configuration of a component.Processor. Specific Processor must implement
 // this interface and must embed ProcessorSettings struct or a struct that extends it.
 type ProcessorConfig interface {
-	identifiable
-	validatable
-
-	privateConfigProcessor()
+	Config
 }
 
 // UnmarshalProcessorConfig helper function to unmarshal a ProcessorConfig.

--- a/component/receiver.go
+++ b/component/receiver.go
@@ -24,10 +24,7 @@ import (
 // ReceiverConfig is the configuration of a component.Receiver. Specific Extension must implement
 // this interface and must embed ReceiverSettings struct or a struct that extends it.
 type ReceiverConfig interface {
-	identifiable
-	validatable
-
-	privateConfigReceiver()
+	Config
 }
 
 // UnmarshalReceiverConfig helper function to unmarshal a ReceiverConfig.

--- a/config/exporter.go
+++ b/config/exporter.go
@@ -45,7 +45,7 @@ func (es *ExporterSettings) SetIDName(idName string) {
 	es.id = component.NewIDWithName(es.id.Type(), idName)
 }
 
-// Validate validates the configuration and returns an error if invalid.
+// Deprecated: [v0.65.0] use component.ValidateConfig.
 func (es *ExporterSettings) Validate() error {
 	return nil
 }

--- a/config/extension.go
+++ b/config/extension.go
@@ -45,7 +45,7 @@ func (es *ExtensionSettings) SetIDName(idName string) {
 	es.id = component.NewIDWithName(es.id.Type(), idName)
 }
 
-// Validate validates the configuration and returns an error if invalid.
+// Deprecated: [v0.65.0] use component.ValidateConfig.
 func (es *ExtensionSettings) Validate() error {
 	return nil
 }

--- a/config/processor.go
+++ b/config/processor.go
@@ -45,7 +45,7 @@ func (ps *ProcessorSettings) SetIDName(idName string) {
 	ps.id = component.NewIDWithName(ps.id.Type(), idName)
 }
 
-// Validate validates the configuration and returns an error if invalid.
+// Deprecated: [v0.65.0] use component.ValidateConfig.
 func (ps *ProcessorSettings) Validate() error {
 	return nil
 }

--- a/config/receiver.go
+++ b/config/receiver.go
@@ -45,7 +45,7 @@ func (rs *ReceiverSettings) SetIDName(idName string) {
 	rs.id = component.NewIDWithName(rs.id.Type(), idName)
 }
 
-// Deprecated: [v0.65.0] use component.ValidateConfig.
+// Deprecated: [v0.65.0] Not needed anymore since the Validate() will be moved from Config interface to the optional ConfigValidator interface.
 func (rs *ReceiverSettings) Validate() error {
 	return nil
 }

--- a/config/receiver.go
+++ b/config/receiver.go
@@ -45,7 +45,7 @@ func (rs *ReceiverSettings) SetIDName(idName string) {
 	rs.id = component.NewIDWithName(rs.id.Type(), idName)
 }
 
-// Validate validates the configuration and returns an error if invalid.
+// Deprecated: [v0.65.0] use component.ValidateConfig.
 func (rs *ReceiverSettings) Validate() error {
 	return nil
 }

--- a/exporter/otlphttpexporter/config_test.go
+++ b/exporter/otlphttpexporter/config_test.go
@@ -37,7 +37,7 @@ func TestUnmarshalDefaultConfig(t *testing.T) {
 	assert.NoError(t, component.UnmarshalExporterConfig(confmap.New(), cfg))
 	assert.Equal(t, factory.CreateDefaultConfig(), cfg)
 	// Default/Empty config is invalid.
-	assert.Error(t, cfg.Validate())
+	assert.Error(t, component.ValidateConfig(cfg))
 }
 
 func TestUnmarshalConfig(t *testing.T) {

--- a/receiver/otlpreceiver/config_test.go
+++ b/receiver/otlpreceiver/config_test.go
@@ -193,12 +193,12 @@ func TestUnmarshalConfigEmptyProtocols(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
 	assert.NoError(t, component.UnmarshalReceiverConfig(cm, cfg))
-	assert.EqualError(t, cfg.Validate(), "must specify at least one protocol when using the OTLP receiver")
+	assert.EqualError(t, component.ValidateConfig(cfg), "must specify at least one protocol when using the OTLP receiver")
 }
 
 func TestUnmarshalConfigEmpty(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
 	assert.NoError(t, component.UnmarshalReceiverConfig(confmap.New(), cfg))
-	assert.EqualError(t, cfg.Validate(), "must specify at least one protocol when using the OTLP receiver")
+	assert.EqualError(t, component.ValidateConfig(cfg), "must specify at least one protocol when using the OTLP receiver")
 }

--- a/service/config.go
+++ b/service/config.go
@@ -60,7 +60,7 @@ func (cfg *Config) Validate() error {
 
 	// Validate the receiver configuration.
 	for recvID, recvCfg := range cfg.Receivers {
-		if err := recvCfg.Validate(); err != nil {
+		if err := component.ValidateConfig(recvCfg); err != nil {
 			return fmt.Errorf("receiver %q has invalid configuration: %w", recvID, err)
 		}
 	}
@@ -73,21 +73,21 @@ func (cfg *Config) Validate() error {
 
 	// Validate the exporter configuration.
 	for expID, expCfg := range cfg.Exporters {
-		if err := expCfg.Validate(); err != nil {
+		if err := component.ValidateConfig(expCfg); err != nil {
 			return fmt.Errorf("exporter %q has invalid configuration: %w", expID, err)
 		}
 	}
 
 	// Validate the processor configuration.
 	for procID, procCfg := range cfg.Processors {
-		if err := procCfg.Validate(); err != nil {
+		if err := component.ValidateConfig(procCfg); err != nil {
 			return fmt.Errorf("processor %q has invalid configuration: %w", procID, err)
 		}
 	}
 
 	// Validate the extension configuration.
 	for extID, extCfg := range cfg.Extensions {
-		if err := extCfg.Validate(); err != nil {
+		if err := component.ValidateConfig(extCfg); err != nil {
 			return fmt.Errorf("extension %q has invalid configuration: %w", extID, err)
 		}
 	}


### PR DESCRIPTION
This PR is "split" from https://github.com/open-telemetry/opentelemetry-collector/pull/6544, to avoid breaking changes and go via deprecation.

It is a bit hacky, but better than breaking everyone who uses this interface.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
