### PR TITLE
Update the usage of set-output command in GH actions

### DIFF
--- a/.github/workflows/check-links.yaml
+++ b/.github/workflows/check-links.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Get changed files
         id: changes
         run: |
-          echo "::set-output name=md::$(git diff --name-only --diff-filter=ACMRTUXB $(git merge-base origin/main ${{ github.event.pull_request.head.sha }}) ${{ github.event.pull_request.head.sha }} | grep .md$ | xargs)"
+          echo "md=$(git diff --name-only --diff-filter=ACMRTUXB $(git merge-base origin/main ${{ github.event.pull_request.head.sha }}) ${{ github.event.pull_request.head.sha }} | grep .md$ | xargs)" >> $GITHUB_OUTPUT
   check-links:
     runs-on: ubuntu-latest
     needs: changedfiles

--- a/.github/workflows/scripts/set_release_tag.sh
+++ b/.github/workflows/scripts/set_release_tag.sh
@@ -1,5 +1,5 @@
 TAG="${GITHUB_REF##*/}"
 if [[ $TAG =~ ^v[0-9]+\.[0-9]+\.[0-9]+.* ]]
 then
-    echo "::set-output name=tag::$TAG"
+    echo "tag=$TAG" >> $GITHUB_OUTPUT
 fi

--- a/.github/workflows/scripts/verify-dist-files-exist.sh
+++ b/.github/workflows/scripts/verify-dist-files-exist.sh
@@ -11,8 +11,8 @@ do
     if [[ ! -f $f ]]
     then
         echo "$f does not exist."
-        echo "::set-output name=passed::false"
+        echo "passed=false" >> $GITHUB_OUTPUT
         exit 0 
     fi
 done
-echo "::set-output name=passed::true"
+echo "passed=true" >> $GITHUB_OUTPUT


### PR DESCRIPTION
**Description:** 
This PR updates the usage of save-output command in GH actions.

Reference : https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/


**Documentation:** 

N/A

ChangeLog is not required
