### PR TITLE
Exposed Size, Marshal and Unmarshall operations for ResourceLogs and LogRecord

### DIFF
--- a/pdata/internal/wrapper_logs.go
+++ b/pdata/internal/wrapper_logs.go
@@ -44,3 +44,27 @@ func LogsFromProto(orig otlplogs.LogsData) Logs {
 		ResourceLogs: orig.ResourceLogs,
 	}}
 }
+
+// ResourceLogsToProto internal helper to convert ResourceLogs to protobuf representation.
+func ResourceLogsToProto(rl ResourceLogs) otlplogs.ResourceLogs {
+	return *rl.orig
+}
+
+// ResourceLogsFromProto internal helper to convert protobuf representation to ResourceLogs.
+func ResourceLogsFromProto(orig otlplogs.ResourceLogs) ResourceLogs {
+	return ResourceLogs{
+		orig: &orig,
+	}
+}
+
+// LogRecordToProto internal helper to convert LogRecord to protobuf representation.
+func LogRecordToProto(lr LogRecord) otlplogs.LogRecord {
+	return *lr.orig
+}
+
+// LogRecordFromProto internal helper to convert protobuf representation to LogRecord.
+func LogRecordFromProto(orig otlplogs.LogRecord) LogRecord {
+	return LogRecord{
+		orig: &orig,
+	}
+}

--- a/pdata/plog/encoding.go
+++ b/pdata/plog/encoding.go
@@ -25,6 +25,14 @@ type Marshaler interface {
 	// MarshalLogs the given pdata.Logs into bytes.
 	// If the error is not nil, the returned bytes slice cannot be used.
 	MarshalLogs(ld Logs) ([]byte, error)
+
+	// MarshalResourceLogs the given pdata.ResourceLogs into bytes.
+	// If the error is not nil, the returned bytes slice cannot be used.
+	MarshalResourceLogs(ld ResourceLogs) ([]byte, error)
+
+	// MarshalLogRecord the given pdata.LogRecord into bytes.
+	// If the error is not nil, the returned bytes slice cannot be used.
+	MarshalLogRecord(lr LogRecord) ([]byte, error)
 }
 
 // Unmarshaler unmarshalls bytes into pdata.Logs.
@@ -32,6 +40,14 @@ type Unmarshaler interface {
 	// UnmarshalLogs the given bytes into pdata.Logs.
 	// If the error is not nil, the returned pdata.Logs cannot be used.
 	UnmarshalLogs(buf []byte) (Logs, error)
+
+	// UnmarshalResourceLogs the given bytes into pdata.ResourceLogs.
+	// If the error is not nil, the returned pdata.ResourceLogs cannot be used.
+	UnmarshalResourceLogs(buf []byte) (ResourceLogs, error)
+
+	// UnmarshalLogRecord the given bytes into pdata.LogRecord.
+	// If the error is not nil, the returned pdata.LogRecord cannot be used.
+	UnmarshalLogRecord(buf []byte) (LogRecord, error)
 }
 
 // Sizer is an optional interface implemented by the Marshaler,
@@ -39,4 +55,10 @@ type Unmarshaler interface {
 type Sizer interface {
 	// LogsSize returns the size in bytes of a marshaled Logs.
 	LogsSize(ld Logs) int
+
+	// ResourceLogsSize returns the size in bytes of a marshaled ResourceLogs.
+	ResourceLogsSize(rl ResourceLogs) int
+
+	// LogRecordSize returns the size in bytes of a marshaled LogRecord.
+	LogRecordSize(lr LogRecord) int
 }

--- a/pdata/plog/internal/plogjson/json.go
+++ b/pdata/plog/internal/plogjson/json.go
@@ -52,6 +52,24 @@ func UnmarshalLogsData(buf []byte, dest *otlplogs.LogsData) error {
 	return iter.Error
 }
 
+func UnmarshalResourceLogs(buf []byte, dest *otlplogs.ResourceLogs) error {
+	iter := jsoniter.ConfigFastest.BorrowIterator(buf)
+	defer jsoniter.ConfigFastest.ReturnIterator(iter)
+	dest = readResourceLogs(iter)
+	if len(dest.ScopeLogs) == 0 {
+		dest.ScopeLogs = dest.DeprecatedScopeLogs
+	}
+	dest.DeprecatedScopeLogs = nil
+	return iter.Error
+}
+
+func UnmarshalLogRecord(buf []byte, dest *otlplogs.LogRecord) error {
+	iter := jsoniter.ConfigFastest.BorrowIterator(buf)
+	defer jsoniter.ConfigFastest.ReturnIterator(iter)
+	dest = readLog(iter)
+	return iter.Error
+}
+
 func UnmarshalExportLogsServiceRequest(buf []byte, dest *otlpcollectorlog.ExportLogsServiceRequest) error {
 	iter := jsoniter.ConfigFastest.BorrowIterator(buf)
 	defer jsoniter.ConfigFastest.ReturnIterator(iter)

--- a/pdata/plog/json.go
+++ b/pdata/plog/json.go
@@ -35,6 +35,20 @@ func (*JSONMarshaler) MarshalLogs(ld Logs) ([]byte, error) {
 	return buf.Bytes(), err
 }
 
+func (m *JSONMarshaler) MarshalResourceLogs(rl ResourceLogs) ([]byte, error) {
+	buf := bytes.Buffer{}
+	pb := internal.ResourceLogsToProto(internal.ResourceLogs(rl))
+	err := delegate.Marshal(&buf, &pb)
+	return buf.Bytes(), err
+}
+
+func (m *JSONMarshaler) MarshalLogRecord(lr LogRecord) ([]byte, error) {
+	buf := bytes.Buffer{}
+	pb := internal.LogRecordToProto(internal.LogRecord(lr))
+	err := delegate.Marshal(&buf, &pb)
+	return buf.Bytes(), err
+}
+
 var _ Unmarshaler = (*JSONUnmarshaler)(nil)
 
 type JSONUnmarshaler struct{}
@@ -45,4 +59,20 @@ func (*JSONUnmarshaler) UnmarshalLogs(buf []byte) (Logs, error) {
 		return Logs{}, err
 	}
 	return Logs(internal.LogsFromProto(ld)), nil
+}
+
+func (*JSONUnmarshaler) UnmarshalResourceLogs(buf []byte) (ResourceLogs, error) {
+	var rl otlplogs.ResourceLogs
+	if err := plogjson.UnmarshalResourceLogs(buf, &rl); err != nil {
+		return ResourceLogs{}, err
+	}
+	return ResourceLogs(internal.ResourceLogsFromProto(rl)), nil
+}
+
+func (*JSONUnmarshaler) UnmarshalLogRecord(buf []byte) (LogRecord, error) {
+	var lr otlplogs.LogRecord
+	if err := plogjson.UnmarshalLogRecord(buf, &lr); err != nil {
+		return LogRecord{}, err
+	}
+	return LogRecord(internal.LogRecordFromProto(lr)), nil
 }

--- a/pdata/plog/pb.go
+++ b/pdata/plog/pb.go
@@ -28,8 +28,30 @@ func (e *ProtoMarshaler) MarshalLogs(ld Logs) ([]byte, error) {
 	return pb.Marshal()
 }
 
+func (e *ProtoMarshaler) MarshalResourceLogs(rl ResourceLogs) ([]byte, error) {
+	pb := internal.ResourceLogsToProto(internal.ResourceLogs(rl))
+	return pb.Marshal()
+}
+
+func (e *ProtoMarshaler) MarshalLogRecord(lr LogRecord) ([]byte, error) {
+	pb := internal.LogRecordToProto(internal.LogRecord(lr))
+	return pb.Marshal()
+}
+
 func (e *ProtoMarshaler) LogsSize(ld Logs) int {
 	pb := internal.LogsToProto(internal.Logs(ld))
+	return pb.Size()
+}
+
+func (e *ProtoMarshaler) ResourceLogsSize(rl ResourceLogs) int {
+	pb := internal.ResourceLogsToProto(internal.ResourceLogs(rl))
+
+	return pb.Size()
+}
+
+func (e *ProtoMarshaler) LogRecordSize(lr LogRecord) int {
+	pb := internal.LogRecordToProto(internal.LogRecord(lr))
+
 	return pb.Size()
 }
 
@@ -41,4 +63,16 @@ func (d *ProtoUnmarshaler) UnmarshalLogs(buf []byte) (Logs, error) {
 	pb := otlplogs.LogsData{}
 	err := pb.Unmarshal(buf)
 	return Logs(internal.LogsFromProto(pb)), err
+}
+
+func (d *ProtoUnmarshaler) UnmarshalResourceLogs(buf []byte) (ResourceLogs, error) {
+	pb := otlplogs.ResourceLogs{}
+	err := pb.Unmarshal(buf)
+	return ResourceLogs(internal.ResourceLogsFromProto(pb)), err
+}
+
+func (d *ProtoUnmarshaler) UnmarshalLogRecord(buf []byte) (LogRecord, error) {
+	pb := otlplogs.LogRecord{}
+	err := pb.Unmarshal(buf)
+	return LogRecord(internal.LogRecordFromProto(pb)), err
 }

--- a/pdata/plog/pb_test.go
+++ b/pdata/plog/pb_test.go
@@ -30,7 +30,7 @@ func TestProtoLogsUnmarshalerError(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestProtoSizer(t *testing.T) {
+func TestLogsProtoSizer(t *testing.T) {
 	marshaler := &ProtoMarshaler{}
 	ld := NewLogs()
 	ld.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords().AppendEmpty().SetSeverityText("error")
@@ -43,9 +43,37 @@ func TestProtoSizer(t *testing.T) {
 
 }
 
+func TestResourceLogsProtoSizer(t *testing.T) {
+	marshaler := &ProtoMarshaler{}
+	rl := NewResourceLogs()
+	rl.ScopeLogs().AppendEmpty().LogRecords().AppendEmpty().SetSeverityText("error")
+
+	size := marshaler.ResourceLogsSize(rl)
+
+	bytes, err := marshaler.MarshalResourceLogs(rl)
+	require.NoError(t, err)
+	assert.Equal(t, len(bytes), size)
+
+}
+
+func TestLogRecordProtoSizer(t *testing.T) {
+	marshaler := &ProtoMarshaler{}
+	lr := NewLogRecord()
+	lr.SetSeverityText("error")
+
+	size := marshaler.LogRecordSize(lr)
+
+	bytes, err := marshaler.MarshalLogRecord(lr)
+	require.NoError(t, err)
+	assert.Equal(t, len(bytes), size)
+
+}
+
 func TestProtoSizerEmptyLogs(t *testing.T) {
 	sizer := &ProtoMarshaler{}
 	assert.Equal(t, 0, sizer.LogsSize(NewLogs()))
+	assert.Equal(t, 2, sizer.ResourceLogsSize(NewResourceLogs())) // 2 due to non-nil values
+	assert.Equal(t, 6, sizer.LogRecordSize(NewLogRecord()))       // 6 due to non-nil values
 }
 
 func BenchmarkLogsToProto(b *testing.B) {
@@ -75,6 +103,60 @@ func BenchmarkLogsFromProto(b *testing.B) {
 	}
 }
 
+func BenchmarkResourceLogsToProto(b *testing.B) {
+	marshaler := &ProtoMarshaler{}
+	resourceLogs := generateBenchmarkResourceLogs(128)
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		buf, err := marshaler.MarshalResourceLogs(resourceLogs)
+		require.NoError(b, err)
+		assert.NotEqual(b, 0, len(buf))
+	}
+}
+
+func BenchmarkResourceLogsFromProto(b *testing.B) {
+	marshaler := &ProtoMarshaler{}
+	unmarshaler := &ProtoUnmarshaler{}
+	baseResourceLogs := generateBenchmarkResourceLogs(128)
+	buf, err := marshaler.MarshalResourceLogs(baseResourceLogs)
+	require.NoError(b, err)
+	assert.NotEqual(b, 0, len(buf))
+	b.ResetTimer()
+	b.ReportAllocs()
+	for n := 0; n < b.N; n++ {
+		resourceLogs, err := unmarshaler.UnmarshalResourceLogs(buf)
+		require.NoError(b, err)
+		assert.Equal(b, baseResourceLogs.ScopeLogs().Len(), resourceLogs.ScopeLogs().Len())
+	}
+}
+
+func BenchmarkLogRecordToProto(b *testing.B) {
+	marshaler := &ProtoMarshaler{}
+	logRecord := generateBenchmarkLogRecord()
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		buf, err := marshaler.MarshalLogRecord(logRecord)
+		require.NoError(b, err)
+		assert.NotEqual(b, 0, len(buf))
+	}
+}
+
+func BenchmarkLogRecordFromProto(b *testing.B) {
+	marshaler := &ProtoMarshaler{}
+	unmarshaler := &ProtoUnmarshaler{}
+	baseLogRecord := generateBenchmarkLogRecord()
+	buf, err := marshaler.MarshalLogRecord(baseLogRecord)
+	require.NoError(b, err)
+	assert.NotEqual(b, 0, len(buf))
+	b.ResetTimer()
+	b.ReportAllocs()
+	for n := 0; n < b.N; n++ {
+		logRecord, err := unmarshaler.UnmarshalLogRecord(buf)
+		require.NoError(b, err)
+		assert.Equal(b, baseLogRecord.Body().Bytes().Len(), logRecord.Body().Bytes().Len())
+	}
+}
+
 func generateBenchmarkLogs(logsCount int) Logs {
 	endTime := pcommon.NewTimestampFromTime(time.Now())
 
@@ -85,5 +167,26 @@ func generateBenchmarkLogs(logsCount int) Logs {
 		im := ilm.LogRecords().AppendEmpty()
 		im.SetTimestamp(endTime)
 	}
+	return md
+}
+
+func generateBenchmarkResourceLogs(logsCount int) ResourceLogs {
+	endTime := pcommon.NewTimestampFromTime(time.Now())
+
+	md := NewResourceLogs()
+	ilm := md.ScopeLogs().AppendEmpty()
+	ilm.LogRecords().EnsureCapacity(logsCount)
+	for i := 0; i < logsCount; i++ {
+		im := ilm.LogRecords().AppendEmpty()
+		im.SetTimestamp(endTime)
+	}
+	return md
+}
+
+func generateBenchmarkLogRecord() LogRecord {
+	timestamp := pcommon.NewTimestampFromTime(time.Now())
+
+	md := NewLogRecord()
+	md.SetTimestamp(timestamp)
 	return md
 }


### PR DESCRIPTION
**Description:** Added exposed Size() computation methods for ResourceLogs and LogRecord in the Sizer interface, consequently changes in Marshaller, Unmarshaller as well. Added unit tests also

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector/issues/6566

**Testing:** Only added the unit tests in `pdata/plog/pb_test.go`. The internal methods for size computation were already present and should work as expected.

**Documentation:** Haven't added it yet, just wanting to get feedback to check the approach.
