### PR TITLE
Remove tigrannajaryan as Maintainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,11 +145,11 @@ Here is a list of community roles with current and previous members:
    - [Alex Boten](https://github.com/codeboten), Lightstep
    - [Bogdan Drutu](https://github.com/BogdanDrutu), Splunk
    - [Dmitrii Anoshin](https://github.com/dmitryax), Splunk
-   - [Tigran Najaryan](https://github.com/tigrannajaryan), Splunk
 
 - Emeritus Maintainers:
 
    - [Paulo Janotti](https://github.com/pjanotti), Splunk
+   - [Tigran Najaryan](https://github.com/tigrannajaryan), Splunk
 
 Learn more about roles in [Community membership](https://github.com/open-telemetry/community/blob/main/community-membership.md).
 In addition to what is described at the organization-level, the SIG Collector requires all core approvers to take part in rotating

--- a/docs/release.md
+++ b/docs/release.md
@@ -142,7 +142,6 @@ The following documents the procedure to release a bugfix
 
 | Date       | Version | Release manager |
 |------------|---------|-----------------|
-| 2022-11-21 | v0.65.0 | @tigrannajaryan |
 | 2022-12-07 | v0.66.0 | @Aneurysm9      |
 | 2022-12-21 | v0.67.0 | @mx-psi         |
 | 2023-01-04 | v0.68.0 | @dmitryax       |


### PR DESCRIPTION
I plan to focus on other OpenTelemetry areas, such as OpAMP and Logs and no longer have time to be a Collector maintainer.

It has been a please working with all @open-telemetry/collector-approvers @open-telemetry/collector-contrib-approvers @open-telemetry/collector-maintainers @open-telemetry/collector-contrib-maintainer @open-telemetry/collector-contrib-triagers @open-telemetry/collector-triagers  :-)
