### PR TITLE
Don't escape go error output in builder

### DIFF
--- a/cmd/builder/internal/builder/main.go
+++ b/cmd/builder/internal/builder/main.go
@@ -94,7 +94,7 @@ func Compile(cfg Config) error {
 	cmd := exec.Command(cfg.Distribution.Go, args...)
 	cmd.Dir = cfg.Distribution.OutputPath
 	if out, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("failed to compile the OpenTelemetry Collector distribution: %w. Output: %q", err, out)
+		return fmt.Errorf("failed to compile the OpenTelemetry Collector distribution: %w. Output:\n%s", err, out)
 	}
 	cfg.Logger.Info("Compiled", zap.String("binary", fmt.Sprintf("%s/%s", cfg.Distribution.OutputPath, cfg.Distribution.Name)))
 
@@ -112,7 +112,7 @@ func GetModules(cfg Config) error {
 	cmd := exec.Command(cfg.Distribution.Go, "mod", "tidy", "-compat=1.18")
 	cmd.Dir = cfg.Distribution.OutputPath
 	if out, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("failed to update go.mod: %w. Output: %q", err, out)
+		return fmt.Errorf("failed to update go.mod: %w. Output:\n%s", err, out)
 	}
 
 	cfg.Logger.Info("Getting go modules")
@@ -125,7 +125,7 @@ func GetModules(cfg Config) error {
 		cmd := exec.Command(cfg.Distribution.Go, "mod", "download")
 		cmd.Dir = cfg.Distribution.OutputPath
 		if out, err := cmd.CombinedOutput(); err != nil {
-			failReason = fmt.Sprintf("%s. Output: %q", err, out)
+			failReason = fmt.Sprintf("%s. Output:\n%s", err, out)
 			cfg.Logger.Info("Failed modules download", zap.String("retry", fmt.Sprintf("%d/%d", i, retries)))
 			time.Sleep(5 * time.Second)
 			continue


### PR DESCRIPTION
Fixes #6591

**Description:** 
Fixes #6591

Whereas before an error would look like this:

```
2022-11-22T08:38:42.377-0800    INFO    internal/command.go:125 OpenTelemetry Collector Builder {"version": "dev", "date": "unknown"}
2022-11-22T08:38:42.382-0800    INFO    internal/command.go:158 Using config file       {"path": "./cmd/otelcontribcol/manifest.yaml"}
2022-11-22T08:38:42.383-0800    INFO    builder/config.go:107   Using go        {"go-executable": "/usr/bin/go"}
2022-11-22T08:38:42.394-0800    INFO    builder/main.go:76      Sources created {"path": "./bin"}
2022-11-22T08:38:43.582-0800    INFO    builder/main.go:118     Getting go modules
2022-11-22T08:38:43.750-0800    INFO    builder/main.go:87      Compiling
Error: failed to compile the OpenTelemetry Collector distribution: exit status 2. Output: "# github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsxrayexporter/internal/translator\n../exporter/awsxrayexporter/internal/translator/segment.go:193:41: undefined: traceutil.SpanIDToHexOrEmptyString\n../exporter/awsxrayexporter/internal/translator/segment.go:198:41: undefined: traceutil.SpanIDToHexOrEmptyString\n# github.com/open-telemetry/opentelemetry-collector-contrib/exporter/azuremonitorexporter\n<snip>
```

It now looks like this:

```
2022-11-22T08:38:42.377-0800    INFO    internal/command.go:125 OpenTelemetry Collector Builder {"version": "dev", "date": "unknown"}
2022-11-22T08:38:42.382-0800    INFO    internal/command.go:158 Using config file       {"path": "./cmd/otelcontribcol/manifest.yaml"}
2022-11-22T08:38:42.383-0800    INFO    builder/config.go:107   Using go        {"go-executable": "/usr/bin/go"}
2022-11-22T08:38:42.394-0800    INFO    builder/main.go:76      Sources created {"path": "./bin"}
2022-11-22T08:38:43.582-0800    INFO    builder/main.go:118     Getting go modules
2022-11-22T08:38:43.750-0800    INFO    builder/main.go:87      Compiling
Error: failed to compile the OpenTelemetry Collector distribution: exit status 2. Output:
# github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsxrayexporter/internal/translator
../exporter/awsxrayexporter/internal/translator/segment.go:193:41: undefined: traceutil.SpanIDToHexOrEmptyString
../exporter/awsxrayexporter/internal/translator/segment.go:198:41: undefined: traceutil.SpanIDToHexOrEmptyString
# github.com/open-telemetry/opentelemetry-collector-contrib/exporter/azuremonitorexporter
<snip>
```

**Link to tracking Issue:** #6591

**Testing:** I manually tested the output to be able to write this PR description, and I ran `make all` in the repo.