### PR TITLE
Run builder tests with local collector module

### DIFF
--- a/cmd/builder/internal/builder/main_test.go
+++ b/cmd/builder/internal/builder/main_test.go
@@ -15,6 +15,8 @@
 package builder
 
 import (
+	"fmt"
+	"path/filepath"
 	"runtime"
 	"testing"
 	"time"
@@ -49,8 +51,12 @@ func TestGenerateAndCompileDefault(t *testing.T) {
 	cfg := NewDefaultConfig()
 	cfg.Distribution.OutputPath = t.TempDir()
 
-	// we override this version, otherwise this would break during releases
-	cfg.Distribution.OtelColVersion = "0.52.0"
+	// This test is dependent on the current file structure.
+	// The goal is find the root of the repo so we can replace the root module.
+	_, thisFile, _, _ := runtime.Caller(0)
+	workspaceDir := filepath.Dir(filepath.Dir(filepath.Dir(filepath.Dir(filepath.Dir(thisFile)))))
+	cfg.Replaces = append(cfg.Replaces, fmt.Sprintf("go.opentelemetry.io/collector => %s", workspaceDir))
+	cfg.Replaces = append(cfg.Replaces, fmt.Sprintf("go.opentelemetry.io/collector/component => %s/component", workspaceDir))
 
 	assert.NoError(t, cfg.Validate())
 	assert.NoError(t, cfg.SetGoPath())

--- a/cmd/builder/test/core.builder.yaml
+++ b/cmd/builder/test/core.builder.yaml
@@ -1,15 +1,22 @@
 dist:
   module: go.opentelemetry.io/collector/builder/test/core
-  otelcol_version: 0.44.0
+  otelcol_version: 0.66.0
 
 extensions:
   - import: go.opentelemetry.io/collector/extension/zpagesextension
-    gomod: go.opentelemetry.io/collector v0.44.0
+    gomod: go.opentelemetry.io/collector v0.66.0
+    path: ${WORKSPACE_DIR}
 
 receivers:
   - import: go.opentelemetry.io/collector/receiver/otlpreceiver
-    gomod: go.opentelemetry.io/collector v0.44.0
+    gomod: go.opentelemetry.io/collector v0.66.0
+    path: ${WORKSPACE_DIR}
 
 exporters:
   - import: go.opentelemetry.io/collector/exporter/loggingexporter
-    gomod: go.opentelemetry.io/collector v0.44.0
+    gomod: go.opentelemetry.io/collector v0.66.0
+    path: ${WORKSPACE_DIR}
+
+replaces:
+  - go.opentelemetry.io/collector => ${WORKSPACE_DIR}
+  - go.opentelemetry.io/collector/component => ${WORKSPACE_DIR}/component

--- a/cmd/builder/test/test.sh
+++ b/cmd/builder/test/test.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+export WORKSPACE_DIR=$( cd -- "$( dirname $(dirname $(dirname -- "${SCRIPT_DIR}")) )" &> /dev/null && pwd )
 
 GOBIN=$(go env GOBIN)
 if [[ "$GO" == "" ]]; then
@@ -25,7 +27,9 @@ test_build_config() {
 
     echo "Starting test '${test}' at `date`" >> "${out}/test.log"
 
-    go run . --go "${GOBIN}" --config "$build_config" --output-path "${out}" --name otelcol-built-test > "${out}/builder.log" 2>&1
+    final_build_config=$(basename ${build_config})
+    envsubst < "$build_config" > "${out}/${final_build_config}"
+    go run . --go "${GOBIN}" --config "${out}/${final_build_config}" --output-path "${out}" --name otelcol-built-test > "${out}/builder.log" 2>&1
 
     if [ $? != 0 ]; then
         echo "❌ FAIL ${test}. Failed to compile the test ${test}. Build logs:"

--- a/docs/release.md
+++ b/docs/release.md
@@ -40,6 +40,8 @@ It is possible that a core approver isn't a contrib approver. In that case, the 
     * Update CHANGELOG.md file, this is done via `chloggen`. Run the following command from the root of the opentelemetry-collector-contrib repo:
       * `make chlog-update VERSION=v0.55.0`
 
+    * Update the version numbers in `cmd/builder/test/core.builder.yaml`
+
     * Run `make prepare-release PREVIOUS_VERSION=0.52.0 RELEASE_CANDIDATE=0.53.0`
 
     * Ensure the `main` branch builds successfully.
@@ -92,12 +94,12 @@ The last step of the release process creates artifacts for the new version of th
 1. Ensure the "Release" action passes, this will
 
     1. push new container images to https://hub.docker.com/repository/docker/otel/opentelemetry-collector
-    
+
     1. create a Github release for the tag and push all the build artifacts to the Github release. See [example](https://github.com/open-telemetry/opentelemetry-collector-releases/actions/runs/1346637081).
 
 ## Troubleshooting
 
-1. `unknown revision internal/coreinternal/v0.55.0` -- This is typically an indication that there's a dependency on a new module. You can fix it by adding a new `replaces` entry to the `go.mod` for the affected module. 
+1. `unknown revision internal/coreinternal/v0.55.0` -- This is typically an indication that there's a dependency on a new module. You can fix it by adding a new `replaces` entry to the `go.mod` for the affected module.
 2. `commitChangesToNewBranch failed: invalid merge` -- This is a [known issue](https://github.com/open-telemetry/opentelemetry-go-build-tools/issues/47) with our release tooling. The current workaround is to clone a fresh copy of the repository and try again. Note that you may need to set up a `fork` remote pointing to your own fork for the release tooling to work properly.
 3. `could not run Go Mod Tidy: go mod tidy failed` when running `multimod` -- This is a [known issue](https://github.com/open-telemetry/opentelemetry-go-build-tools/issues/46) with our release tooling. The current workaround is to run `make gotidy` manually after the multimod tool fails and commit the result.
 


### PR DESCRIPTION
Most of the credit for this goes to @jpkrohling.

Builder tests were running against a very old version of the builder, rather than current code. The problem with this became apparent when attempting make an additive change to `component.Factories`. ([example failure](https://github.com/open-telemetry/opentelemetry-collector/actions/runs/3447893951/jobs/5754375816#step:4:23))