### PR TITLE
Fix nil panic from otlp exporter

### DIFF
--- a/.chloggen/authpanic.yaml
+++ b/.chloggen/authpanic.yaml
@@ -1,0 +1,12 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: otlpexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix nil panic from otlp exporter in case of errors during Start.
+
+# One or more tracking issues or pull requests related to the change
+issues: [6633]
+

--- a/exporter/otlpexporter/factory_test.go
+++ b/exporter/otlpexporter/factory_test.go
@@ -206,9 +206,10 @@ func TestCreateTracesExporter(t *testing.T) {
 			err = consumer.Start(context.Background(), componenttest.NewNopHost())
 			if tt.mustFailOnStart {
 				assert.Error(t, err)
-				return
+			} else {
+				assert.NoError(t, err)
 			}
-			assert.NoError(t, err)
+			// Shutdown is called even when Start fails
 			err = consumer.Shutdown(context.Background())
 			if err != nil {
 				// Since the endpoint of OTLP exporter doesn't actually exist,

--- a/exporter/otlpexporter/otlp.go
+++ b/exporter/otlpexporter/otlp.go
@@ -77,7 +77,6 @@ func (e *exporter) start(ctx context.Context, host component.Host) (err error) {
 	if e.clientConn, err = e.config.GRPCClientSettings.ToClientConn(ctx, host, e.settings, grpc.WithUserAgent(e.userAgent)); err != nil {
 		return err
 	}
-
 	e.traceExporter = ptraceotlp.NewGRPCClient(e.clientConn)
 	e.metricExporter = pmetricotlp.NewGRPCClient(e.clientConn)
 	e.logExporter = plogotlp.NewGRPCClient(e.clientConn)

--- a/exporter/otlpexporter/otlp.go
+++ b/exporter/otlpexporter/otlp.go
@@ -90,7 +90,10 @@ func (e *exporter) start(ctx context.Context, host component.Host) (err error) {
 }
 
 func (e *exporter) shutdown(context.Context) error {
-	return e.clientConn.Close()
+	if e.clientConn != nil {
+		return e.clientConn.Close()
+	}
+	return nil
 }
 
 func (e *exporter) pushTraces(ctx context.Context, td ptrace.Traces) error {


### PR DESCRIPTION
**Description:** 

Fixing a bug - The OTLP exporter panics when collector tries to shut down the pipelines  as soon as an error happens during start up. 

An error is startup of the exporter will leave exporter with nil connection, followed by shutdown method of exporter invokes calling close on nil connection leading to panic

In the earlier versions since shutdown methods were never called when Start fails, we never observed this behavior.

**Link to tracking Issue:**   https://github.com/open-telemetry/opentelemetry-collector/issues/6619

**Testing:** Manual testing to see collector shuts down gracefully without any panic 

```bash 
2022/11/28 21:50:31 proto: duplicate proto type registered: jaeger.api_v2.PostSpansRequest
2022/11/28 21:50:31 proto: duplicate proto type registered: jaeger.api_v2.PostSpansResponse
2022-11-28T21:50:31.796-0800	info	service/telemetry.go:111	Setting up own telemetry...
2022-11-28T21:50:31.796-0800	info	service/telemetry.go:141	Serving Prometheus metrics	{"address": ":8888", "level": "Basic"}
2022-11-28T21:50:31.796-0800	debug	components/components.go:28	Stable component.	{"kind": "exporter", "data_type": "traces", "name": "otlp/auth", "stability": "Stable"}
2022-11-28T21:50:31.796-0800	debug	components/components.go:28	Stable component.	{"kind": "receiver", "name": "otlp", "pipeline": "traces", "stability": "Stable"}
2022-11-28T21:50:31.796-0800	info	service/service.go:89	Starting otelcontribcol...	{"Version": "v0.42.0-2740-g7f4d4425a0", "NumCPU": 12}
2022-11-28T21:50:31.797-0800	info	extensions/extensions.go:41	Starting extensions...
2022-11-28T21:50:31.797-0800	info	extensions/extensions.go:44	Extension is starting...	{"kind": "extension", "name": "basicauth"}
2022-11-28T21:50:31.797-0800	info	extensions/extensions.go:48	Extension started.	{"kind": "extension", "name": "basicauth"}
2022-11-28T21:50:31.797-0800	info	pipelines/pipelines.go:74	Starting exporters...
2022-11-28T21:50:31.797-0800	info	pipelines/pipelines.go:78	Exporter is starting...	{"kind": "exporter", "data_type": "traces", "name": "otlp/auth"}
2022-11-28T21:50:31.797-0800	info	zapgrpc/zapgrpc.go:174	[core] [Channel #1] Channel created	{"grpc_log": true}
2022-11-28T21:50:31.797-0800	info	zapgrpc/zapgrpc.go:174	[core] [Channel #1] Channel Connectivity change to SHUTDOWN	{"grpc_log": true}
2022-11-28T21:50:31.797-0800	info	zapgrpc/zapgrpc.go:174	[core] [Channel #1] Channel deleted	{"grpc_log": true}
error
<nil>
2022-11-28T21:50:31.797-0800	info	service/service.go:115	Starting shutdown...
2022-11-28T21:50:31.797-0800	info	pipelines/pipelines.go:118	Stopping receivers...
2022-11-28T21:50:31.797-0800	info	pipelines/pipelines.go:125	Stopping processors...
2022-11-28T21:50:31.797-0800	info	pipelines/pipelines.go:132	Stopping exporters...
2022-11-28T21:50:31.797-0800	info	extensions/extensions.go:55	Stopping extensions...
2022-11-28T21:50:31.797-0800	info	service/service.go:129	Shutdown complete.
Error: cannot start pipelines: grpc: the credentials require transport level security (use grpc.WithTransportCredentials() to set)
2022-11-28 21:50:31.797531 I | collector server run finished with error: cannot start pipelines: grpc: the credentials require transport level security (use grpc.WithTransportCredentials() to set)
```
