### PR TITLE
[confighttp] Change Headers field type to have opaque values

### DIFF
--- a/.chloggen/mx-psi_configopaque-http.yaml
+++ b/.chloggen/mx-psi_configopaque-http.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: config/confighttp
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecate confighttp.HTTPClientSettings.Headers in favor of confighttp.HTTPClientSettings.OpaqueHeaders
+
+# One or more tracking issues or pull requests related to the change
+issues: [5653]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/mx-psi_configopaque-http.yaml
+++ b/.chloggen/mx-psi_configopaque-http.yaml
@@ -1,11 +1,11 @@
 # One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
-change_type: deprecation
+change_type: breaking
 
 # The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
 component: config/confighttp
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Deprecate confighttp.HTTPClientSettings.Headers in favor of confighttp.HTTPClientSettings.OpaqueHeaders
+note: Change confighttp.HTTPClientSettings.Headers type to map[string]configopaque.String
 
 # One or more tracking issues or pull requests related to the change
 issues: [5653]

--- a/config/confighttp/confighttp_test.go
+++ b/config/confighttp/confighttp_test.go
@@ -824,41 +824,20 @@ func ExampleHTTPServerSettings() {
 
 func TestHttpHeaders(t *testing.T) {
 	tests := []struct {
-		name          string
-		headers       map[string]string
-		opaqueHeaders map[string]configopaque.String
-		shouldErr     bool
+		name    string
+		headers map[string]configopaque.String
 	}{
 		{
 			name: "with_headers",
-			headers: map[string]string{
+			headers: map[string]configopaque.String{
 				"header1": "value1",
 			},
-		},
-		{
-			name: "with__opaque_headers",
-			opaqueHeaders: map[string]configopaque.String{
-				"header1": "value1",
-			},
-		},
-		{
-			name: "with_both",
-			headers: map[string]string{
-				"header1": "value1",
-			},
-			opaqueHeaders: map[string]configopaque.String{
-				"header1": "value1",
-			},
-			shouldErr: true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				for k, v := range tt.headers {
-					assert.Equal(t, r.Header.Get(k), v)
-				}
-				for k, v := range tt.opaqueHeaders {
 					assert.Equal(t, r.Header.Get(k), string(v))
 				}
 				w.WriteHeader(200)
@@ -872,13 +851,8 @@ func TestHttpHeaders(t *testing.T) {
 				WriteBufferSize: 0,
 				Timeout:         0,
 				Headers:         tt.headers,
-				OpaqueHeaders:   tt.opaqueHeaders,
 			}
-			client, err := setting.ToClient(componenttest.NewNopHost(), componenttest.NewNopTelemetrySettings())
-			if tt.shouldErr {
-				assert.Error(t, err)
-				return
-			}
+			client, _ := setting.ToClient(componenttest.NewNopHost(), componenttest.NewNopTelemetrySettings())
 			req, err := http.NewRequest("GET", setting.Endpoint, nil)
 			assert.NoError(t, err)
 			_, err = client.Do(req)

--- a/exporter/otlphttpexporter/config_test.go
+++ b/exporter/otlphttpexporter/config_test.go
@@ -25,6 +25,7 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/confighttp"
+	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/config/configtls"
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
@@ -61,7 +62,7 @@ func TestUnmarshalConfig(t *testing.T) {
 				QueueSize:    10,
 			},
 			HTTPClientSettings: confighttp.HTTPClientSettings{
-				Headers: map[string]string{
+				OpaqueHeaders: map[string]configopaque.String{
 					"can you have a . here?": "F0000000-0000-0000-0000-000000000000",
 					"header1":                "234",
 					"another":                "somevalue",

--- a/exporter/otlphttpexporter/config_test.go
+++ b/exporter/otlphttpexporter/config_test.go
@@ -62,8 +62,7 @@ func TestUnmarshalConfig(t *testing.T) {
 				QueueSize:    10,
 			},
 			HTTPClientSettings: confighttp.HTTPClientSettings{
-				Headers: map[string]string{},
-				OpaqueHeaders: map[string]configopaque.String{
+				Headers: map[string]configopaque.String{
 					"can you have a . here?": "F0000000-0000-0000-0000-000000000000",
 					"header1":                "234",
 					"another":                "somevalue",

--- a/exporter/otlphttpexporter/config_test.go
+++ b/exporter/otlphttpexporter/config_test.go
@@ -62,6 +62,7 @@ func TestUnmarshalConfig(t *testing.T) {
 				QueueSize:    10,
 			},
 			HTTPClientSettings: confighttp.HTTPClientSettings{
+				Headers: map[string]string{},
 				OpaqueHeaders: map[string]configopaque.String{
 					"can you have a . here?": "F0000000-0000-0000-0000-000000000000",
 					"header1":                "234",

--- a/exporter/otlphttpexporter/factory.go
+++ b/exporter/otlphttpexporter/factory.go
@@ -53,6 +53,7 @@ func createDefaultConfig() component.Config {
 		HTTPClientSettings: confighttp.HTTPClientSettings{
 			Endpoint:      "",
 			Timeout:       30 * time.Second,
+			Headers:       map[string]string{},
 			OpaqueHeaders: map[string]configopaque.String{},
 			// Default to gzip compression
 			Compression: configcompression.Gzip,

--- a/exporter/otlphttpexporter/factory.go
+++ b/exporter/otlphttpexporter/factory.go
@@ -24,6 +24,7 @@ import (
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/configcompression"
 	"go.opentelemetry.io/collector/config/confighttp"
+	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 )
@@ -50,9 +51,9 @@ func createDefaultConfig() component.Config {
 		RetrySettings:    exporterhelper.NewDefaultRetrySettings(),
 		QueueSettings:    exporterhelper.NewDefaultQueueSettings(),
 		HTTPClientSettings: confighttp.HTTPClientSettings{
-			Endpoint: "",
-			Timeout:  30 * time.Second,
-			Headers:  map[string]string{},
+			Endpoint:      "",
+			Timeout:       30 * time.Second,
+			OpaqueHeaders: map[string]configopaque.String{},
 			// Default to gzip compression
 			Compression: configcompression.Gzip,
 			// We almost read 0 bytes, so no need to tune ReadBufferSize.

--- a/exporter/otlphttpexporter/factory.go
+++ b/exporter/otlphttpexporter/factory.go
@@ -51,10 +51,9 @@ func createDefaultConfig() component.Config {
 		RetrySettings:    exporterhelper.NewDefaultRetrySettings(),
 		QueueSettings:    exporterhelper.NewDefaultQueueSettings(),
 		HTTPClientSettings: confighttp.HTTPClientSettings{
-			Endpoint:      "",
-			Timeout:       30 * time.Second,
-			Headers:       map[string]string{},
-			OpaqueHeaders: map[string]configopaque.String{},
+			Endpoint: "",
+			Timeout:  30 * time.Second,
+			Headers:  map[string]configopaque.String{},
 			// Default to gzip compression
 			Compression: configcompression.Gzip,
 			// We almost read 0 bytes, so no need to tune ReadBufferSize.

--- a/exporter/otlphttpexporter/factory_test.go
+++ b/exporter/otlphttpexporter/factory_test.go
@@ -28,6 +28,7 @@ import (
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/configcompression"
 	"go.opentelemetry.io/collector/config/confighttp"
+	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/config/configtls"
 	"go.opentelemetry.io/collector/internal/testutil"
 )
@@ -97,7 +98,7 @@ func TestCreateTracesExporter(t *testing.T) {
 				ExporterSettings: config.NewExporterSettings(component.NewID(typeStr)),
 				HTTPClientSettings: confighttp.HTTPClientSettings{
 					Endpoint: endpoint,
-					Headers: map[string]string{
+					OpaqueHeaders: map[string]configopaque.String{
 						"hdr1": "val1",
 						"hdr2": "val2",
 					},

--- a/exporter/otlphttpexporter/factory_test.go
+++ b/exporter/otlphttpexporter/factory_test.go
@@ -98,7 +98,7 @@ func TestCreateTracesExporter(t *testing.T) {
 				ExporterSettings: config.NewExporterSettings(component.NewID(typeStr)),
 				HTTPClientSettings: confighttp.HTTPClientSettings{
 					Endpoint: endpoint,
-					OpaqueHeaders: map[string]configopaque.String{
+					Headers: map[string]configopaque.String{
 						"hdr1": "val1",
 						"hdr2": "val2",
 					},

--- a/exporter/otlphttpexporter/otlp_test.go
+++ b/exporter/otlphttpexporter/otlp_test.go
@@ -39,6 +39,7 @@ import (
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/confighttp"
+	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/consumer/consumertest"
@@ -524,7 +525,7 @@ func TestUserAgent(t *testing.T) {
 
 	tests := []struct {
 		name       string
-		headers    map[string]string
+		headers    map[string]configopaque.String
 		expectedUA string
 	}{
 		{
@@ -533,12 +534,12 @@ func TestUserAgent(t *testing.T) {
 		},
 		{
 			name:       "custom_user_agent",
-			headers:    map[string]string{"User-Agent": "My Custom Agent"},
+			headers:    map[string]configopaque.String{"User-Agent": "My Custom Agent"},
 			expectedUA: "My Custom Agent",
 		},
 		{
 			name:       "custom_user_agent_lowercase",
-			headers:    map[string]string{"user-agent": "My Custom Agent"},
+			headers:    map[string]configopaque.String{"user-agent": "My Custom Agent"},
 			expectedUA: "My Custom Agent",
 		},
 	}


### PR DESCRIPTION
**Description:**

Change `Headers` field on HTTP client config to have opaque values and transparent keys.

Depends on #6470

**Link to tracking Issue:** Updates #5653
