### PR TITLE
Prefix auth funcs/types with Server to be consistent with Client.

### DIFF
--- a/.chloggen/move-configauth-to-extension-step-1.yaml
+++ b/.chloggen/move-configauth-to-extension-step-1.yaml
@@ -18,3 +18,10 @@ subtext: |-
   - configauth.WithClientShutdown -> auth.WithClientShutdown
   - configauth.WithClientRoundTripper -> auth.WithClientRoundTripper
   - configauth.WithPerRPCCredentials -> auth.WithClientPerRPCCredentials
+  - configauth.ServerAuthenticator -> auth.Server
+  - configauth.NewServerAuthenticator -> auth.NewServer
+  - configauth.Option -> auth.ServerOption
+  - configauth.AuthenticateFunc -> auth.ServerAuthenticateFunc
+  - configauth.WithAuthenticate -> auth.WithServerAuthenticate
+  - configauth.WithStart -> auth.WithServerStart
+  - configauth.WithShutdown -> auth.WithServerShutdown

--- a/config/configauth/deprecated.go
+++ b/config/configauth/deprecated.go
@@ -43,20 +43,20 @@ var NewClientAuthenticator = auth.NewClient
 // Deprecated: [v0.67.0] Use auth.Server
 type ServerAuthenticator = auth.Server
 
-// Deprecated: [v0.67.0] Use auth.AuthenticateFunc
-type AuthenticateFunc = auth.AuthenticateFunc
+// Deprecated: [v0.67.0] Use auth.ServerAuthenticateFunc
+type AuthenticateFunc = auth.ServerAuthenticateFunc
 
-// Deprecated: [v0.67.0] Use auth.Option
-type Option = auth.Option
+// Deprecated: [v0.67.0] Use auth.ServerOption
+type Option = auth.ServerOption
 
-// Deprecated: [v0.67.0] Use auth.WithAuthenticate
-var WithAuthenticate = auth.WithAuthenticate
+// Deprecated: [v0.67.0] Use auth.WithServerAuthenticate
+var WithAuthenticate = auth.WithServerAuthenticate
 
-// Deprecated: [v0.67.0] Use auth.WithStart
-var WithStart = auth.WithStart
+// Deprecated: [v0.67.0] Use auth.WithServerStart
+var WithStart = auth.WithServerStart
 
 // Deprecated: [v0.67.0] Use auth.WithShutdown
-var WithShutdown = auth.WithShutdown
+var WithShutdown = auth.WithServerShutdown
 
 // Deprecated: [v0.67.0] Use auth.NewServer
 var NewServerAuthenticator = auth.NewServer

--- a/config/configgrpc/configgrpc_test.go
+++ b/config/configgrpc/configgrpc_test.go
@@ -918,7 +918,7 @@ func TestDefaultUnaryInterceptorAuthSucceeded(t *testing.T) {
 	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("authorization", "some-auth-data"))
 
 	// test
-	res, err := authUnaryServerInterceptor(ctx, nil, &grpc.UnaryServerInfo{}, handler, authFunc)
+	res, err := authUnaryServerInterceptor(ctx, nil, &grpc.UnaryServerInfo{}, handler, auth.NewServer(auth.WithServerAuthenticate(authFunc)))
 
 	// verify
 	assert.Nil(t, res)
@@ -942,7 +942,7 @@ func TestDefaultUnaryInterceptorAuthFailure(t *testing.T) {
 	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("authorization", "some-auth-data"))
 
 	// test
-	res, err := authUnaryServerInterceptor(ctx, nil, &grpc.UnaryServerInfo{}, handler, authFunc)
+	res, err := authUnaryServerInterceptor(ctx, nil, &grpc.UnaryServerInfo{}, handler, auth.NewServer(auth.WithServerAuthenticate(authFunc)))
 
 	// verify
 	assert.Nil(t, res)
@@ -962,7 +962,7 @@ func TestDefaultUnaryInterceptorMissingMetadata(t *testing.T) {
 	}
 
 	// test
-	res, err := authUnaryServerInterceptor(context.Background(), nil, &grpc.UnaryServerInfo{}, handler, authFunc)
+	res, err := authUnaryServerInterceptor(context.Background(), nil, &grpc.UnaryServerInfo{}, handler, auth.NewServer(auth.WithServerAuthenticate(authFunc)))
 
 	// verify
 	assert.Nil(t, res)
@@ -993,7 +993,7 @@ func TestDefaultStreamInterceptorAuthSucceeded(t *testing.T) {
 	}
 
 	// test
-	err := authStreamServerInterceptor(nil, streamServer, &grpc.StreamServerInfo{}, handler, authFunc)
+	err := authStreamServerInterceptor(nil, streamServer, &grpc.StreamServerInfo{}, handler, auth.NewServer(auth.WithServerAuthenticate(authFunc)))
 
 	// verify
 	assert.NoError(t, err)
@@ -1019,7 +1019,7 @@ func TestDefaultStreamInterceptorAuthFailure(t *testing.T) {
 	}
 
 	// test
-	err := authStreamServerInterceptor(nil, streamServer, &grpc.StreamServerInfo{}, handler, authFunc)
+	err := authStreamServerInterceptor(nil, streamServer, &grpc.StreamServerInfo{}, handler, auth.NewServer(auth.WithServerAuthenticate(authFunc)))
 
 	// verify
 	assert.Equal(t, expectedErr, err)
@@ -1041,7 +1041,7 @@ func TestDefaultStreamInterceptorMissingMetadata(t *testing.T) {
 	}
 
 	// test
-	err := authStreamServerInterceptor(nil, streamServer, &grpc.StreamServerInfo{}, handler, authFunc)
+	err := authStreamServerInterceptor(nil, streamServer, &grpc.StreamServerInfo{}, handler, auth.NewServer(auth.WithServerAuthenticate(authFunc)))
 
 	// verify
 	assert.Equal(t, errMetadataNotFound, err)

--- a/config/confighttp/confighttp.go
+++ b/config/confighttp/confighttp.go
@@ -278,12 +278,12 @@ func (hss *HTTPServerSettings) ToServer(host component.Host, settings component.
 	}
 
 	if hss.Auth != nil {
-		authenticator, err := hss.Auth.GetServerAuthenticator(host.GetExtensions())
+		server, err := hss.Auth.GetServerAuthenticator(host.GetExtensions())
 		if err != nil {
 			return nil, err
 		}
 
-		handler = authInterceptor(handler, authenticator.Authenticate)
+		handler = authInterceptor(handler, server)
 	}
 
 	if hss.CORS != nil && len(hss.CORS.AllowedOrigins) > 0 {
@@ -343,9 +343,9 @@ type CORSSettings struct {
 	MaxAge int `mapstructure:"max_age"`
 }
 
-func authInterceptor(next http.Handler, authenticate auth.AuthenticateFunc) http.Handler {
+func authInterceptor(next http.Handler, server auth.Server) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ctx, err := authenticate(r.Context(), r.Header)
+		ctx, err := server.Authenticate(r.Context(), r.Header)
 		if err != nil {
 			http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
 			return

--- a/config/confighttp/confighttp_test.go
+++ b/config/confighttp/confighttp_test.go
@@ -741,7 +741,7 @@ func TestHttpCorsWithSettings(t *testing.T) {
 	host := &mockHost{
 		ext: map[component.ID]component.Component{
 			component.NewID("mock"): auth.NewServer(
-				auth.WithAuthenticate(func(ctx context.Context, headers map[string][]string) (context.Context, error) {
+				auth.WithServerAuthenticate(func(ctx context.Context, headers map[string][]string) (context.Context, error) {
 					return ctx, errors.New("Settings failed")
 				}),
 			),
@@ -936,7 +936,7 @@ func TestServerAuth(t *testing.T) {
 	host := &mockHost{
 		ext: map[component.ID]component.Component{
 			component.NewID("mock"): auth.NewServer(
-				auth.WithAuthenticate(func(ctx context.Context, headers map[string][]string) (context.Context, error) {
+				auth.WithServerAuthenticate(func(ctx context.Context, headers map[string][]string) (context.Context, error) {
 					authCalled = true
 					return ctx, nil
 				}),
@@ -983,7 +983,7 @@ func TestFailedServerAuth(t *testing.T) {
 	host := &mockHost{
 		ext: map[component.ID]component.Component{
 			component.NewID("mock"): auth.NewServer(
-				auth.WithAuthenticate(func(ctx context.Context, headers map[string][]string) (context.Context, error) {
+				auth.WithServerAuthenticate(func(ctx context.Context, headers map[string][]string) (context.Context, error) {
 					return ctx, errors.New("Settings failed")
 				}),
 			),

--- a/extension/auth/default_serverauthenticator_test.go
+++ b/extension/auth/default_serverauthenticator_test.go
@@ -46,11 +46,11 @@ func TestDefaultValues(t *testing.T) {
 	})
 }
 
-func TestWithAuthenticateFunc(t *testing.T) {
+func TestWithServerAuthenticateFunc(t *testing.T) {
 	// prepare
 	authCalled := false
 	e := NewServer(
-		WithAuthenticate(func(ctx context.Context, headers map[string][]string) (context.Context, error) {
+		WithServerAuthenticate(func(ctx context.Context, headers map[string][]string) (context.Context, error) {
 			authCalled = true
 			return ctx, nil
 		}),
@@ -64,9 +64,9 @@ func TestWithAuthenticateFunc(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestWithStart(t *testing.T) {
+func TestWithServerStart(t *testing.T) {
 	called := false
-	e := NewServer(WithStart(func(c context.Context, h component.Host) error {
+	e := NewServer(WithServerStart(func(c context.Context, h component.Host) error {
 		called = true
 		return nil
 	}))
@@ -79,9 +79,9 @@ func TestWithStart(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestWithShutdown(t *testing.T) {
+func TestWithServerShutdown(t *testing.T) {
 	called := false
-	e := NewServer(WithShutdown(func(c context.Context) error {
+	e := NewServer(WithServerShutdown(func(c context.Context) error {
 		called = true
 		return nil
 	}))

--- a/extension/auth/serverauth.go
+++ b/extension/auth/serverauth.go
@@ -38,7 +38,3 @@ type Server interface {
 	// The context keys to be used are not defined yet.
 	Authenticate(ctx context.Context, headers map[string][]string) (context.Context, error)
 }
-
-// AuthenticateFunc defines the signature for the function responsible for performing the authentication based on the given headers map.
-// See Server.Authenticate.
-type AuthenticateFunc func(ctx context.Context, headers map[string][]string) (context.Context, error)


### PR DESCRIPTION
No need to deprecate/break things since these new types were added in this release.

The reason for Option -> ServerOption is to be consistent with ClientOption.

The reason for AuthenticateFunc -> ServerAuthenticateFunc is because we may have the same Authenticate func on the client in the future and to avoid name conflicts.