### PR TITLE
Prefix auth funcs/types with Client. Add *Func types

### DIFF
--- a/.chloggen/move-configauth-to-extension-step-1.yaml
+++ b/.chloggen/move-configauth-to-extension-step-1.yaml
@@ -10,3 +10,11 @@ note: Define new authextension package and use new package in collector repo
 # One or more tracking issues or pull requests related to the change
 issues: [6467]
 
+subtext: |-
+  - configauth.ClientAuthenticator -> auth.Client
+  - configauth.NewClientAuthenticator -> auth.NewClient
+  - configauth.ClientOption -> auth.ClientOption
+  - configauth.WithClientStart -> auth.WithClientStart
+  - configauth.WithClientShutdown -> auth.WithClientShutdown
+  - configauth.WithClientRoundTripper -> auth.WithClientRoundTripper
+  - configauth.WithPerRPCCredentials -> auth.WithClientPerRPCCredentials

--- a/config/configauth/deprecated.go
+++ b/config/configauth/deprecated.go
@@ -34,8 +34,8 @@ var WithClientShutdown = auth.WithClientShutdown
 // Deprecated: [v0.67.0] Use auth.WithClientRoundTripper
 var WithClientRoundTripper = auth.WithClientRoundTripper
 
-// Deprecated: [v0.67.0] Use auth.WithPerRPCCredentials
-var WithPerRPCCredentials = auth.WithPerRPCCredentials
+// Deprecated: [v0.67.0] Use auth.WithClientPerRPCCredentials
+var WithPerRPCCredentials = auth.WithClientPerRPCCredentials
 
 // Deprecated: [v0.67.0] Use auth.NewClient
 var NewClientAuthenticator = auth.NewClient

--- a/extension/auth/default_clientauthenticator.go
+++ b/extension/auth/default_clientauthenticator.go
@@ -15,7 +15,6 @@
 package auth // import "go.opentelemetry.io/collector/extension/auth"
 
 import (
-	"context"
 	"net/http"
 
 	"google.golang.org/grpc/credentials"
@@ -25,14 +24,34 @@ import (
 
 var _ Client = (*defaultClient)(nil)
 
-// Option represents the possible options for NewServerAuthenticator.
+// ClientOption represents the possible options for NewServerAuthenticator.
 type ClientOption func(*defaultClient)
+
+// ClientRoundTripperFunc specifies the function that returns a RoundTripper that can be used to authenticate HTTP requests.
+type ClientRoundTripperFunc func(base http.RoundTripper) (http.RoundTripper, error)
+
+func (f ClientRoundTripperFunc) RoundTripper(base http.RoundTripper) (http.RoundTripper, error) {
+	if f == nil {
+		return base, nil
+	}
+	return f(base)
+}
+
+// ClientPerRPCCredentialsFunc specifies the function that returns a PerRPCCredentials that can be used to authenticate gRPC requests.
+type ClientPerRPCCredentialsFunc func() (credentials.PerRPCCredentials, error)
+
+func (f ClientPerRPCCredentialsFunc) PerRPCCredentials() (credentials.PerRPCCredentials, error) {
+	if f == nil {
+		return nil, nil
+	}
+	return f()
+}
 
 type defaultClient struct {
 	component.StartFunc
 	component.ShutdownFunc
-	roundTripperFunc      func(base http.RoundTripper) (http.RoundTripper, error)
-	perRPCCredentialsFunc func() (credentials.PerRPCCredentials, error)
+	ClientRoundTripperFunc
+	ClientPerRPCCredentialsFunc
 }
 
 // WithClientStart overrides the default `Start` function for a component.Component.
@@ -53,52 +72,27 @@ func WithClientShutdown(shutdownFunc component.ShutdownFunc) ClientOption {
 
 // WithClientRoundTripper provides a `RoundTripper` function for this client authenticator.
 // The default round tripper is no-op.
-func WithClientRoundTripper(roundTripperFunc func(base http.RoundTripper) (http.RoundTripper, error)) ClientOption {
+func WithClientRoundTripper(roundTripperFunc ClientRoundTripperFunc) ClientOption {
 	return func(o *defaultClient) {
-		o.roundTripperFunc = roundTripperFunc
+		o.ClientRoundTripperFunc = roundTripperFunc
 	}
 }
 
-// WithPerRPCCredentials provides a `PerRPCCredentials` function for this client authenticator.
+// WithClientPerRPCCredentials provides a `PerRPCCredentials` function for this client authenticator.
 // There's no default.
-func WithPerRPCCredentials(perRPCCredentialsFunc func() (credentials.PerRPCCredentials, error)) ClientOption {
+func WithClientPerRPCCredentials(perRPCCredentialsFunc ClientPerRPCCredentialsFunc) ClientOption {
 	return func(o *defaultClient) {
-		o.perRPCCredentialsFunc = perRPCCredentialsFunc
+		o.ClientPerRPCCredentialsFunc = perRPCCredentialsFunc
 	}
 }
 
 // NewClient returns a Client configured with the provided options.
 func NewClient(options ...ClientOption) Client {
-	bc := &defaultClient{
-		StartFunc:             func(ctx context.Context, host component.Host) error { return nil },
-		ShutdownFunc:          func(ctx context.Context) error { return nil },
-		roundTripperFunc:      func(base http.RoundTripper) (http.RoundTripper, error) { return base, nil },
-		perRPCCredentialsFunc: func() (credentials.PerRPCCredentials, error) { return nil, nil },
-	}
+	bc := &defaultClient{}
 
 	for _, op := range options {
 		op(bc)
 	}
 
 	return bc
-}
-
-// Start the component.
-func (a *defaultClient) Start(ctx context.Context, host component.Host) error {
-	return a.StartFunc(ctx, host)
-}
-
-// Shutdown stops the component.
-func (a *defaultClient) Shutdown(ctx context.Context) error {
-	return a.ShutdownFunc(ctx)
-}
-
-// RoundTripper adds the base HTTP RoundTripper in this authenticator's round tripper.
-func (a *defaultClient) RoundTripper(base http.RoundTripper) (http.RoundTripper, error) {
-	return a.roundTripperFunc(base)
-}
-
-// PerRPCCredentials returns this authenticator's credentials.PerRPCCredentials implementation.
-func (a *defaultClient) PerRPCCredentials() (credentials.PerRPCCredentials, error) {
-	return a.perRPCCredentialsFunc()
 }

--- a/extension/auth/default_clientauthenticator_test.go
+++ b/extension/auth/default_clientauthenticator_test.go
@@ -114,7 +114,7 @@ func (c *customPerRPCCredentials) RequireTransportSecurity() bool {
 
 func TestWithPerRPCCredentials(t *testing.T) {
 	called := false
-	e := NewClient(WithPerRPCCredentials(func() (credentials.PerRPCCredentials, error) {
+	e := NewClient(WithClientPerRPCCredentials(func() (credentials.PerRPCCredentials, error) {
 		called = true
 		return &customPerRPCCredentials{}, nil
 	}))


### PR DESCRIPTION
No need to deprecate/break things since these new types were added in this release.

