### PR TITLE
[pdata] Change [...Slice|Map].Sort methods to not return any value

### DIFF
--- a/.chloggen/pdata-sort-no-return.yaml
+++ b/.chloggen/pdata-sort-no-return.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: pdata
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Change [...Slice|Map].Sort methods to not return any value
+
+# One or more tracking issues or pull requests related to the change
+issues: [6660]

--- a/pdata/internal/cmd/pdatagen/internal/base_slices.go
+++ b/pdata/internal/cmd/pdatagen/internal/base_slices.go
@@ -191,15 +191,8 @@ func (es ${structName}) AppendEmpty() ${elementName} {
 // Sort sorts the ${elementName} elements within ${structName} given the
 // provided less function so that two instances of ${structName}
 // can be compared.
-//
-// Returns the same instance to allow nicer code like:
-//   lessFunc := func(a, b ${elementName}) bool {
-//     return a.Name() < b.Name() // choose any comparison here
-//   }
-//   assert.Equal(t, expected.Sort(lessFunc), actual.Sort(lessFunc))
-func (es ${structName}) Sort(less func(a, b ${elementName}) bool) ${structName} {
+func (es ${structName}) Sort(less func(a, b ${elementName}) bool) {
 	sort.SliceStable(*es.getOrig(), func(i, j int) bool { return less(es.At(i), es.At(j)) })
-	return es
 }
 `
 

--- a/pdata/pcommon/common.go
+++ b/pdata/pcommon/common.go
@@ -717,18 +717,14 @@ func (m Map) PutEmptySlice(k string) Slice {
 }
 
 // Sort sorts the entries in the Map so two instances can be compared.
-// Returns the same instance to allow nicer code like:
-//
-//	assert.EqualValues(t, expected.Sort(), actual.Sort())
 //
 // IMPORTANT: Sort mutates the data, if you call this function in a consumer,
 // the consumer must be configured that it mutates data.
-func (m Map) Sort() Map {
+func (m Map) Sort() {
 	// Intention is to move the nil values at the end.
 	sort.SliceStable(*m.getOrig(), func(i, j int) bool {
 		return (*m.getOrig())[i].Key < (*m.getOrig())[j].Key
 	})
-	return m
 }
 
 // Len returns the length of this map.

--- a/pdata/pcommon/common_test.go
+++ b/pdata/pcommon/common_test.go
@@ -302,7 +302,9 @@ func TestMap(t *testing.T) {
 	assert.EqualValues(t, NewMap(), removeMap)
 
 	// Test Sort
-	assert.EqualValues(t, NewMap(), NewMap().Sort())
+	sortMap := NewMap()
+	sortMap.Sort()
+	assert.EqualValues(t, NewMap(), sortMap)
 }
 
 func TestMapPutEmpty(t *testing.T) {
@@ -501,7 +503,8 @@ func TestMapWithEmpty(t *testing.T) {
 	assert.False(t, exist)
 
 	// Test Sort
-	assert.EqualValues(t, newMap(&origWithNil), sm.Sort())
+	sm.Sort()
+	assert.EqualValues(t, newMap(&origWithNil), sm)
 }
 
 func TestMapIterationNil(t *testing.T) {

--- a/pdata/plog/generated_logs.go
+++ b/pdata/plog/generated_logs.go
@@ -122,16 +122,8 @@ func (es ResourceLogsSlice) AppendEmpty() ResourceLogs {
 // Sort sorts the ResourceLogs elements within ResourceLogsSlice given the
 // provided less function so that two instances of ResourceLogsSlice
 // can be compared.
-//
-// Returns the same instance to allow nicer code like:
-//
-//	lessFunc := func(a, b ResourceLogs) bool {
-//	  return a.Name() < b.Name() // choose any comparison here
-//	}
-//	assert.Equal(t, expected.Sort(lessFunc), actual.Sort(lessFunc))
-func (es ResourceLogsSlice) Sort(less func(a, b ResourceLogs) bool) ResourceLogsSlice {
+func (es ResourceLogsSlice) Sort(less func(a, b ResourceLogs) bool) {
 	sort.SliceStable(*es.getOrig(), func(i, j int) bool { return less(es.At(i), es.At(j)) })
-	return es
 }
 
 // MoveAndAppendTo moves all elements from the current slice and appends them to the dest.
@@ -322,16 +314,8 @@ func (es ScopeLogsSlice) AppendEmpty() ScopeLogs {
 // Sort sorts the ScopeLogs elements within ScopeLogsSlice given the
 // provided less function so that two instances of ScopeLogsSlice
 // can be compared.
-//
-// Returns the same instance to allow nicer code like:
-//
-//	lessFunc := func(a, b ScopeLogs) bool {
-//	  return a.Name() < b.Name() // choose any comparison here
-//	}
-//	assert.Equal(t, expected.Sort(lessFunc), actual.Sort(lessFunc))
-func (es ScopeLogsSlice) Sort(less func(a, b ScopeLogs) bool) ScopeLogsSlice {
+func (es ScopeLogsSlice) Sort(less func(a, b ScopeLogs) bool) {
 	sort.SliceStable(*es.getOrig(), func(i, j int) bool { return less(es.At(i), es.At(j)) })
-	return es
 }
 
 // MoveAndAppendTo moves all elements from the current slice and appends them to the dest.
@@ -522,16 +506,8 @@ func (es LogRecordSlice) AppendEmpty() LogRecord {
 // Sort sorts the LogRecord elements within LogRecordSlice given the
 // provided less function so that two instances of LogRecordSlice
 // can be compared.
-//
-// Returns the same instance to allow nicer code like:
-//
-//	lessFunc := func(a, b LogRecord) bool {
-//	  return a.Name() < b.Name() // choose any comparison here
-//	}
-//	assert.Equal(t, expected.Sort(lessFunc), actual.Sort(lessFunc))
-func (es LogRecordSlice) Sort(less func(a, b LogRecord) bool) LogRecordSlice {
+func (es LogRecordSlice) Sort(less func(a, b LogRecord) bool) {
 	sort.SliceStable(*es.getOrig(), func(i, j int) bool { return less(es.At(i), es.At(j)) })
-	return es
 }
 
 // MoveAndAppendTo moves all elements from the current slice and appends them to the dest.

--- a/pdata/pmetric/generated_metrics.go
+++ b/pdata/pmetric/generated_metrics.go
@@ -122,16 +122,8 @@ func (es ResourceMetricsSlice) AppendEmpty() ResourceMetrics {
 // Sort sorts the ResourceMetrics elements within ResourceMetricsSlice given the
 // provided less function so that two instances of ResourceMetricsSlice
 // can be compared.
-//
-// Returns the same instance to allow nicer code like:
-//
-//	lessFunc := func(a, b ResourceMetrics) bool {
-//	  return a.Name() < b.Name() // choose any comparison here
-//	}
-//	assert.Equal(t, expected.Sort(lessFunc), actual.Sort(lessFunc))
-func (es ResourceMetricsSlice) Sort(less func(a, b ResourceMetrics) bool) ResourceMetricsSlice {
+func (es ResourceMetricsSlice) Sort(less func(a, b ResourceMetrics) bool) {
 	sort.SliceStable(*es.getOrig(), func(i, j int) bool { return less(es.At(i), es.At(j)) })
-	return es
 }
 
 // MoveAndAppendTo moves all elements from the current slice and appends them to the dest.
@@ -322,16 +314,8 @@ func (es ScopeMetricsSlice) AppendEmpty() ScopeMetrics {
 // Sort sorts the ScopeMetrics elements within ScopeMetricsSlice given the
 // provided less function so that two instances of ScopeMetricsSlice
 // can be compared.
-//
-// Returns the same instance to allow nicer code like:
-//
-//	lessFunc := func(a, b ScopeMetrics) bool {
-//	  return a.Name() < b.Name() // choose any comparison here
-//	}
-//	assert.Equal(t, expected.Sort(lessFunc), actual.Sort(lessFunc))
-func (es ScopeMetricsSlice) Sort(less func(a, b ScopeMetrics) bool) ScopeMetricsSlice {
+func (es ScopeMetricsSlice) Sort(less func(a, b ScopeMetrics) bool) {
 	sort.SliceStable(*es.getOrig(), func(i, j int) bool { return less(es.At(i), es.At(j)) })
-	return es
 }
 
 // MoveAndAppendTo moves all elements from the current slice and appends them to the dest.
@@ -522,16 +506,8 @@ func (es MetricSlice) AppendEmpty() Metric {
 // Sort sorts the Metric elements within MetricSlice given the
 // provided less function so that two instances of MetricSlice
 // can be compared.
-//
-// Returns the same instance to allow nicer code like:
-//
-//	lessFunc := func(a, b Metric) bool {
-//	  return a.Name() < b.Name() // choose any comparison here
-//	}
-//	assert.Equal(t, expected.Sort(lessFunc), actual.Sort(lessFunc))
-func (es MetricSlice) Sort(less func(a, b Metric) bool) MetricSlice {
+func (es MetricSlice) Sort(less func(a, b Metric) bool) {
 	sort.SliceStable(*es.getOrig(), func(i, j int) bool { return less(es.At(i), es.At(j)) })
-	return es
 }
 
 // MoveAndAppendTo moves all elements from the current slice and appends them to the dest.
@@ -1149,16 +1125,8 @@ func (es NumberDataPointSlice) AppendEmpty() NumberDataPoint {
 // Sort sorts the NumberDataPoint elements within NumberDataPointSlice given the
 // provided less function so that two instances of NumberDataPointSlice
 // can be compared.
-//
-// Returns the same instance to allow nicer code like:
-//
-//	lessFunc := func(a, b NumberDataPoint) bool {
-//	  return a.Name() < b.Name() // choose any comparison here
-//	}
-//	assert.Equal(t, expected.Sort(lessFunc), actual.Sort(lessFunc))
-func (es NumberDataPointSlice) Sort(less func(a, b NumberDataPoint) bool) NumberDataPointSlice {
+func (es NumberDataPointSlice) Sort(less func(a, b NumberDataPoint) bool) {
 	sort.SliceStable(*es.getOrig(), func(i, j int) bool { return less(es.At(i), es.At(j)) })
-	return es
 }
 
 // MoveAndAppendTo moves all elements from the current slice and appends them to the dest.
@@ -1414,16 +1382,8 @@ func (es HistogramDataPointSlice) AppendEmpty() HistogramDataPoint {
 // Sort sorts the HistogramDataPoint elements within HistogramDataPointSlice given the
 // provided less function so that two instances of HistogramDataPointSlice
 // can be compared.
-//
-// Returns the same instance to allow nicer code like:
-//
-//	lessFunc := func(a, b HistogramDataPoint) bool {
-//	  return a.Name() < b.Name() // choose any comparison here
-//	}
-//	assert.Equal(t, expected.Sort(lessFunc), actual.Sort(lessFunc))
-func (es HistogramDataPointSlice) Sort(less func(a, b HistogramDataPoint) bool) HistogramDataPointSlice {
+func (es HistogramDataPointSlice) Sort(less func(a, b HistogramDataPoint) bool) {
 	sort.SliceStable(*es.getOrig(), func(i, j int) bool { return less(es.At(i), es.At(j)) })
-	return es
 }
 
 // MoveAndAppendTo moves all elements from the current slice and appends them to the dest.
@@ -1734,16 +1694,8 @@ func (es ExponentialHistogramDataPointSlice) AppendEmpty() ExponentialHistogramD
 // Sort sorts the ExponentialHistogramDataPoint elements within ExponentialHistogramDataPointSlice given the
 // provided less function so that two instances of ExponentialHistogramDataPointSlice
 // can be compared.
-//
-// Returns the same instance to allow nicer code like:
-//
-//	lessFunc := func(a, b ExponentialHistogramDataPoint) bool {
-//	  return a.Name() < b.Name() // choose any comparison here
-//	}
-//	assert.Equal(t, expected.Sort(lessFunc), actual.Sort(lessFunc))
-func (es ExponentialHistogramDataPointSlice) Sort(less func(a, b ExponentialHistogramDataPoint) bool) ExponentialHistogramDataPointSlice {
+func (es ExponentialHistogramDataPointSlice) Sort(less func(a, b ExponentialHistogramDataPoint) bool) {
 	sort.SliceStable(*es.getOrig(), func(i, j int) bool { return less(es.At(i), es.At(j)) })
-	return es
 }
 
 // MoveAndAppendTo moves all elements from the current slice and appends them to the dest.
@@ -2133,16 +2085,8 @@ func (es SummaryDataPointSlice) AppendEmpty() SummaryDataPoint {
 // Sort sorts the SummaryDataPoint elements within SummaryDataPointSlice given the
 // provided less function so that two instances of SummaryDataPointSlice
 // can be compared.
-//
-// Returns the same instance to allow nicer code like:
-//
-//	lessFunc := func(a, b SummaryDataPoint) bool {
-//	  return a.Name() < b.Name() // choose any comparison here
-//	}
-//	assert.Equal(t, expected.Sort(lessFunc), actual.Sort(lessFunc))
-func (es SummaryDataPointSlice) Sort(less func(a, b SummaryDataPoint) bool) SummaryDataPointSlice {
+func (es SummaryDataPointSlice) Sort(less func(a, b SummaryDataPoint) bool) {
 	sort.SliceStable(*es.getOrig(), func(i, j int) bool { return less(es.At(i), es.At(j)) })
-	return es
 }
 
 // MoveAndAppendTo moves all elements from the current slice and appends them to the dest.
@@ -2377,16 +2321,8 @@ func (es SummaryDataPointValueAtQuantileSlice) AppendEmpty() SummaryDataPointVal
 // Sort sorts the SummaryDataPointValueAtQuantile elements within SummaryDataPointValueAtQuantileSlice given the
 // provided less function so that two instances of SummaryDataPointValueAtQuantileSlice
 // can be compared.
-//
-// Returns the same instance to allow nicer code like:
-//
-//	lessFunc := func(a, b SummaryDataPointValueAtQuantile) bool {
-//	  return a.Name() < b.Name() // choose any comparison here
-//	}
-//	assert.Equal(t, expected.Sort(lessFunc), actual.Sort(lessFunc))
-func (es SummaryDataPointValueAtQuantileSlice) Sort(less func(a, b SummaryDataPointValueAtQuantile) bool) SummaryDataPointValueAtQuantileSlice {
+func (es SummaryDataPointValueAtQuantileSlice) Sort(less func(a, b SummaryDataPointValueAtQuantile) bool) {
 	sort.SliceStable(*es.getOrig(), func(i, j int) bool { return less(es.At(i), es.At(j)) })
-	return es
 }
 
 // MoveAndAppendTo moves all elements from the current slice and appends them to the dest.

--- a/pdata/ptrace/generated_traces.go
+++ b/pdata/ptrace/generated_traces.go
@@ -122,16 +122,8 @@ func (es ResourceSpansSlice) AppendEmpty() ResourceSpans {
 // Sort sorts the ResourceSpans elements within ResourceSpansSlice given the
 // provided less function so that two instances of ResourceSpansSlice
 // can be compared.
-//
-// Returns the same instance to allow nicer code like:
-//
-//	lessFunc := func(a, b ResourceSpans) bool {
-//	  return a.Name() < b.Name() // choose any comparison here
-//	}
-//	assert.Equal(t, expected.Sort(lessFunc), actual.Sort(lessFunc))
-func (es ResourceSpansSlice) Sort(less func(a, b ResourceSpans) bool) ResourceSpansSlice {
+func (es ResourceSpansSlice) Sort(less func(a, b ResourceSpans) bool) {
 	sort.SliceStable(*es.getOrig(), func(i, j int) bool { return less(es.At(i), es.At(j)) })
-	return es
 }
 
 // MoveAndAppendTo moves all elements from the current slice and appends them to the dest.
@@ -322,16 +314,8 @@ func (es ScopeSpansSlice) AppendEmpty() ScopeSpans {
 // Sort sorts the ScopeSpans elements within ScopeSpansSlice given the
 // provided less function so that two instances of ScopeSpansSlice
 // can be compared.
-//
-// Returns the same instance to allow nicer code like:
-//
-//	lessFunc := func(a, b ScopeSpans) bool {
-//	  return a.Name() < b.Name() // choose any comparison here
-//	}
-//	assert.Equal(t, expected.Sort(lessFunc), actual.Sort(lessFunc))
-func (es ScopeSpansSlice) Sort(less func(a, b ScopeSpans) bool) ScopeSpansSlice {
+func (es ScopeSpansSlice) Sort(less func(a, b ScopeSpans) bool) {
 	sort.SliceStable(*es.getOrig(), func(i, j int) bool { return less(es.At(i), es.At(j)) })
-	return es
 }
 
 // MoveAndAppendTo moves all elements from the current slice and appends them to the dest.
@@ -522,16 +506,8 @@ func (es SpanSlice) AppendEmpty() Span {
 // Sort sorts the Span elements within SpanSlice given the
 // provided less function so that two instances of SpanSlice
 // can be compared.
-//
-// Returns the same instance to allow nicer code like:
-//
-//	lessFunc := func(a, b Span) bool {
-//	  return a.Name() < b.Name() // choose any comparison here
-//	}
-//	assert.Equal(t, expected.Sort(lessFunc), actual.Sort(lessFunc))
-func (es SpanSlice) Sort(less func(a, b Span) bool) SpanSlice {
+func (es SpanSlice) Sort(less func(a, b Span) bool) {
 	sort.SliceStable(*es.getOrig(), func(i, j int) bool { return less(es.At(i), es.At(j)) })
-	return es
 }
 
 // MoveAndAppendTo moves all elements from the current slice and appends them to the dest.
@@ -840,16 +816,8 @@ func (es SpanEventSlice) AppendEmpty() SpanEvent {
 // Sort sorts the SpanEvent elements within SpanEventSlice given the
 // provided less function so that two instances of SpanEventSlice
 // can be compared.
-//
-// Returns the same instance to allow nicer code like:
-//
-//	lessFunc := func(a, b SpanEvent) bool {
-//	  return a.Name() < b.Name() // choose any comparison here
-//	}
-//	assert.Equal(t, expected.Sort(lessFunc), actual.Sort(lessFunc))
-func (es SpanEventSlice) Sort(less func(a, b SpanEvent) bool) SpanEventSlice {
+func (es SpanEventSlice) Sort(less func(a, b SpanEvent) bool) {
 	sort.SliceStable(*es.getOrig(), func(i, j int) bool { return less(es.At(i), es.At(j)) })
-	return es
 }
 
 // MoveAndAppendTo moves all elements from the current slice and appends them to the dest.
@@ -1057,16 +1025,8 @@ func (es SpanLinkSlice) AppendEmpty() SpanLink {
 // Sort sorts the SpanLink elements within SpanLinkSlice given the
 // provided less function so that two instances of SpanLinkSlice
 // can be compared.
-//
-// Returns the same instance to allow nicer code like:
-//
-//	lessFunc := func(a, b SpanLink) bool {
-//	  return a.Name() < b.Name() // choose any comparison here
-//	}
-//	assert.Equal(t, expected.Sort(lessFunc), actual.Sort(lessFunc))
-func (es SpanLinkSlice) Sort(less func(a, b SpanLink) bool) SpanLinkSlice {
+func (es SpanLinkSlice) Sort(less func(a, b SpanLink) bool) {
 	sort.SliceStable(*es.getOrig(), func(i, j int) bool { return less(es.At(i), es.At(j)) })
-	return es
 }
 
 // MoveAndAppendTo moves all elements from the current slice and appends them to the dest.


### PR DESCRIPTION
Returning the same object from the `Sort` methods leads to subtle bugs when non-mutating components use the returned object assuming it's a copy. Making the methods not return anything makes it clear that they are mutating.

Resolves https://github.com/open-telemetry/opentelemetry-collector/issues/6660