### PR TITLE
[chore] Bump deployment image to 0.66.0

### DIFF
--- a/examples/k8s/otel-config.yaml
+++ b/examples/k8s/otel-config.yaml
@@ -66,7 +66,7 @@ spec:
       - command:
           - "/otelcol"
           - "--config=/conf/otel-agent-config.yaml"
-        image: otel/opentelemetry-collector:0.65.0
+        image: otel/opentelemetry-collector:0.66.0
         name: otel-agent
         resources:
           limits:
@@ -177,7 +177,7 @@ spec:
       - command:
           - "/otelcol"
           - "--config=/conf/otel-collector-config.yaml"
-        image: otel/opentelemetry-collector:0.65.0
+        image: otel/opentelemetry-collector:0.66.0
         name: otel-collector
         resources:
           limits:


### PR DESCRIPTION
While installing otel agent using [Kubernetes](https://opentelemetry.io/docs/collector/getting-started/#kubernetes) instructions. I was hitting `ErrImagePull` for version 0.65.0:
```
→ kubectl get pods
NAME                              READY   STATUS         RESTARTS   AGE
otel-agent-d2t5d                  0/1     ErrImagePull   0          14s
otel-collector-7bf5f66dcf-rc96s   0/1     ErrImagePull   0          14s
```
I tried to find the `0.65.0` tag in [DockerHub](https://hub.docker.com/r/otel/opentelemetry-collector/tags?page=1&name=0.65.0) but seems like it isn't there. Not sure why. Anyways, bumping the image to `0.66.0` solves the issue:
```
→ kubectl get pods
NAME                              READY   STATUS    RESTARTS   AGE
otel-agent-wxnnd                  1/1     Running   0          11m
otel-collector-7c4bc6c97d-fpqrq   1/1     Running   0          11m

```