### PR TITLE
Deprecate component.Receiver* in favor of new receiver.*

### DIFF
--- a/.chloggen/mv-receiver.yaml
+++ b/.chloggen/mv-receiver.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: component
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecate `Receiver` related structs and functions in favor of `receiver` package
+
+# One or more tracking issues or pull requests related to the change
+issues: [6687]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/cmd/builder/internal/builder/templates/components.go.tmpl
+++ b/cmd/builder/internal/builder/templates/components.go.tmpl
@@ -6,6 +6,7 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/extension"
+	"go.opentelemetry.io/collector/receiver"
 	{{- range .Exporters}}
 	{{.Name}} "{{.Import}}"
 	{{- end}}
@@ -33,7 +34,7 @@ func components() (component.Factories, error) {
 		return component.Factories{}, err
 	}
 
-	factories.Receivers, err = component.MakeReceiverFactoryMap(
+	factories.Receivers, err = receiver.MakeFactoryMap(
 		{{- range .Receivers}}
 		{{.Name}}.NewFactory(),
 		{{- end}}

--- a/cmd/otelcorecol/components.go
+++ b/cmd/otelcorecol/components.go
@@ -13,6 +13,7 @@ import (
 	zpagesextension "go.opentelemetry.io/collector/extension/zpagesextension"
 	batchprocessor "go.opentelemetry.io/collector/processor/batchprocessor"
 	memorylimiterprocessor "go.opentelemetry.io/collector/processor/memorylimiterprocessor"
+	"go.opentelemetry.io/collector/receiver"
 	otlpreceiver "go.opentelemetry.io/collector/receiver/otlpreceiver"
 )
 
@@ -28,7 +29,7 @@ func components() (component.Factories, error) {
 		return component.Factories{}, err
 	}
 
-	factories.Receivers, err = component.MakeReceiverFactoryMap(
+	factories.Receivers, err = receiver.MakeFactoryMap(
 		otlpreceiver.NewFactory(),
 	)
 	if err != nil {

--- a/component/componenttest/nop_factories.go
+++ b/component/componenttest/nop_factories.go
@@ -18,6 +18,7 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/extension"
+	"go.opentelemetry.io/collector/receiver"
 )
 
 // NopFactories returns a component.Factories with all nop factories.
@@ -30,7 +31,7 @@ func NopFactories() (component.Factories, error) {
 		return component.Factories{}, err
 	}
 
-	if factories.Receivers, err = component.MakeReceiverFactoryMap(NewNopReceiverFactory()); err != nil {
+	if factories.Receivers, err = receiver.MakeFactoryMap(NewNopReceiverFactory()); err != nil {
 		return component.Factories{}, err
 	}
 

--- a/component/componenttest/nop_receiver.go
+++ b/component/componenttest/nop_receiver.go
@@ -20,11 +20,12 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/receiver"
 )
 
-// NewNopReceiverCreateSettings returns a new nop settings for Create*Receiver functions.
-func NewNopReceiverCreateSettings() component.ReceiverCreateSettings {
-	return component.ReceiverCreateSettings{
+// Deprecated: [v0.67.0] use receivertest.NewNopCreateSettings.
+func NewNopReceiverCreateSettings() receiver.CreateSettings {
+	return receiver.CreateSettings{
 		TelemetrySettings: NewNopTelemetrySettings(),
 		BuildInfo:         component.NewDefaultBuildInfo(),
 	}
@@ -34,29 +35,29 @@ type nopReceiverConfig struct {
 	config.ReceiverSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
 }
 
-// NewNopReceiverFactory returns a component.ReceiverFactory that constructs nop receivers.
-func NewNopReceiverFactory() component.ReceiverFactory {
-	return component.NewReceiverFactory(
+// Deprecated: [v0.67.0] use receivertest.NewNopFactory
+func NewNopReceiverFactory() receiver.Factory {
+	return receiver.NewFactory(
 		"nop",
 		func() component.Config {
 			return &nopReceiverConfig{
 				ReceiverSettings: config.NewReceiverSettings(component.NewID("nop")),
 			}
 		},
-		component.WithTracesReceiver(createTracesReceiver, component.StabilityLevelStable),
-		component.WithMetricsReceiver(createMetricsReceiver, component.StabilityLevelStable),
-		component.WithLogsReceiver(createLogsReceiver, component.StabilityLevelStable))
+		receiver.WithTraces(createTraces, component.StabilityLevelStable),
+		receiver.WithMetrics(createMetrics, component.StabilityLevelStable),
+		receiver.WithLogs(createLogs, component.StabilityLevelStable))
 }
 
-func createTracesReceiver(context.Context, component.ReceiverCreateSettings, component.Config, consumer.Traces) (component.TracesReceiver, error) {
+func createTraces(context.Context, receiver.CreateSettings, component.Config, consumer.Traces) (receiver.Traces, error) {
 	return nopReceiverInstance, nil
 }
 
-func createMetricsReceiver(context.Context, component.ReceiverCreateSettings, component.Config, consumer.Metrics) (component.MetricsReceiver, error) {
+func createMetrics(context.Context, receiver.CreateSettings, component.Config, consumer.Metrics) (receiver.Metrics, error) {
 	return nopReceiverInstance, nil
 }
 
-func createLogsReceiver(context.Context, component.ReceiverCreateSettings, component.Config, consumer.Logs) (component.LogsReceiver, error) {
+func createLogs(context.Context, receiver.CreateSettings, component.Config, consumer.Logs) (receiver.Logs, error) {
 	return nopReceiverInstance, nil
 }
 

--- a/component/factories.go
+++ b/component/factories.go
@@ -34,9 +34,7 @@ type Factories struct {
 	Extensions map[Type]ExtensionFactory
 }
 
-// MakeReceiverFactoryMap takes a list of receiver factories and returns a map
-// with factory type as keys. It returns a non-nil error when more than one factories
-// have the same type.
+// Deprecated: [v0.67.0] use receiver.MakeFactoryMap
 func MakeReceiverFactoryMap(factories ...ReceiverFactory) (map[Type]ReceiverFactory, error) {
 	fMap := map[Type]ReceiverFactory{}
 	for _, f := range factories {

--- a/component/host.go
+++ b/component/host.go
@@ -28,8 +28,8 @@ type Host interface {
 	// GetFactory of the specified kind. Returns the factory for a component type.
 	// This allows components to create other components. For example:
 	//   func (r MyReceiver) Start(host component.Host) error {
-	//     apacheFactory := host.GetFactory(KindReceiver,"apache").(component.ReceiverFactory)
-	//     receiver, err := apacheFactory.CreateMetricsReceiver(...)
+	//     apacheFactory := host.GetFactory(KindReceiver,"apache").(receiver.Factory)
+	//     receiver, err := apacheFactory.CreateMetrics(...)
 	//     ...
 	//   }
 	//

--- a/component/receiver.go
+++ b/component/receiver.go
@@ -164,7 +164,6 @@ func (r receiverFactory) MetricsReceiverStability() StabilityLevel {
 	return r.metricsStabilityLevel
 }
 
-// Deprecated: [v0.67.0] use receiver.LogsStabiilty.
 func (r receiverFactory) LogsReceiverStability() StabilityLevel {
 	return r.logsStabilityLevel
 }

--- a/component/receiver.go
+++ b/component/receiver.go
@@ -160,7 +160,6 @@ func (r receiverFactory) TracesReceiverStability() StabilityLevel {
 	return r.tracesStabilityLevel
 }
 
-// Deprecated: [v0.67.0] use receiver.MetricsStabiilty.
 func (r receiverFactory) MetricsReceiverStability() StabilityLevel {
 	return r.metricsStabilityLevel
 }

--- a/component/receiver.go
+++ b/component/receiver.go
@@ -156,7 +156,6 @@ type receiverFactory struct {
 	logsStabilityLevel StabilityLevel
 }
 
-// Deprecated: [v0.67.0] use receiver.TracesStabiilty.
 func (r receiverFactory) TracesReceiverStability() StabilityLevel {
 	return r.tracesStabilityLevel
 }

--- a/component/receiver.go
+++ b/component/receiver.go
@@ -26,34 +26,22 @@ type ReceiverConfig = Config
 // Deprecated: [v0.67.0] use UnmarshalConfig.
 var UnmarshalReceiverConfig = UnmarshalConfig
 
-// A TracesReceiver receives traces.
-// Its purpose is to translate data from any format to the collector's internal trace format.
-// TracesReceiver feeds a consumer.Traces with data.
-//
-// For example it could be Zipkin data source which translates Zipkin spans into ptrace.Traces.
+// Deprecated: [v0.67.0] use receiver.Traces.
 type TracesReceiver interface {
 	Component
 }
 
-// A MetricsReceiver receives metrics.
-// Its purpose is to translate data from any format to the collector's internal metrics format.
-// MetricsReceiver feeds a consumer.Metrics with data.
-//
-// For example it could be Prometheus data source which translates Prometheus metrics into pmetric.Metrics.
+// Deprecated: [v0.67.0] use receiver.Metrics.
 type MetricsReceiver interface {
 	Component
 }
 
-// A LogsReceiver receives logs.
-// Its purpose is to translate data from any format to the collector's internal logs data format.
-// LogsReceiver feeds a consumer.Logs with data.
-//
-// For example a LogsReceiver can read syslogs and convert them into plog.Logs.
+// Deprecated: [v0.67.0] use receiver.Logs.
 type LogsReceiver interface {
 	Component
 }
 
-// ReceiverCreateSettings configures Receiver creators.
+// Deprecated: [v0.67.0] use receiver.CreateSettings.
 type ReceiverCreateSettings struct {
 	// ID returns the ID of the component that will be created.
 	ID ID
@@ -64,10 +52,7 @@ type ReceiverCreateSettings struct {
 	BuildInfo BuildInfo
 }
 
-// ReceiverFactory is factory interface for receivers.
-//
-// This interface cannot be directly implemented. Implementations must
-// use the NewReceiverFactory to implement it.
+// Deprecated: [v0.67.0] use receivrer.Factory.
 type ReceiverFactory interface {
 	Factory
 
@@ -96,7 +81,7 @@ type ReceiverFactory interface {
 	LogsReceiverStability() StabilityLevel
 }
 
-// ReceiverFactoryOption apply changes to ReceiverOptions.
+// Deprecated: [v0.67.0] use receiver.FactoryOption.
 type ReceiverFactoryOption interface {
 	// applyReceiverFactoryOption applies the option.
 	applyReceiverFactoryOption(o *receiverFactory)
@@ -114,7 +99,7 @@ func (f receiverFactoryOptionFunc) applyReceiverFactoryOption(o *receiverFactory
 // Deprecated: [v0.67.0] use CreateDefaultConfigFunc.
 type ReceiverCreateDefaultConfigFunc = CreateDefaultConfigFunc
 
-// CreateTracesReceiverFunc is the equivalent of ReceiverFactory.CreateTracesReceiver().
+// Deprecated: [v0.67.0] use receiver.CreateTracesFunc.
 type CreateTracesReceiverFunc func(context.Context, ReceiverCreateSettings, Config, consumer.Traces) (TracesReceiver, error)
 
 // CreateTracesReceiver implements ReceiverFactory.CreateTracesReceiver().
@@ -129,7 +114,7 @@ func (f CreateTracesReceiverFunc) CreateTracesReceiver(
 	return f(ctx, set, cfg, nextConsumer)
 }
 
-// CreateMetricsReceiverFunc is the equivalent of ReceiverFactory.CreateMetricsReceiver().
+// Deprecated: [v0.67.0] use receiver.CreateMetricsFunc.
 type CreateMetricsReceiverFunc func(context.Context, ReceiverCreateSettings, Config, consumer.Metrics) (MetricsReceiver, error)
 
 // CreateMetricsReceiver implements ReceiverFactory.CreateMetricsReceiver().
@@ -145,7 +130,7 @@ func (f CreateMetricsReceiverFunc) CreateMetricsReceiver(
 	return f(ctx, set, cfg, nextConsumer)
 }
 
-// CreateLogsReceiverFunc is the equivalent of ReceiverFactory.CreateLogsReceiver().
+// Deprecated: [v0.67.0] use receiver.CreateLogsFunc.
 type CreateLogsReceiverFunc func(context.Context, ReceiverCreateSettings, Config, consumer.Logs) (LogsReceiver, error)
 
 // CreateLogsReceiver implements ReceiverFactory.CreateLogsReceiver().
@@ -171,19 +156,22 @@ type receiverFactory struct {
 	logsStabilityLevel StabilityLevel
 }
 
+// Deprecated: [v0.67.0] use receiver.TracesStabiilty.
 func (r receiverFactory) TracesReceiverStability() StabilityLevel {
 	return r.tracesStabilityLevel
 }
 
+// Deprecated: [v0.67.0] use receiver.MetricsStabiilty.
 func (r receiverFactory) MetricsReceiverStability() StabilityLevel {
 	return r.metricsStabilityLevel
 }
 
+// Deprecated: [v0.67.0] use receiver.LogsStabiilty.
 func (r receiverFactory) LogsReceiverStability() StabilityLevel {
 	return r.logsStabilityLevel
 }
 
-// WithTracesReceiver overrides the default "error not supported" implementation for CreateTracesReceiver and the default "undefined" stability level.
+// Deprecated: [v0.67.0] use receiver.WithTraces.
 func WithTracesReceiver(createTracesReceiver CreateTracesReceiverFunc, sl StabilityLevel) ReceiverFactoryOption {
 	return receiverFactoryOptionFunc(func(o *receiverFactory) {
 		o.tracesStabilityLevel = sl
@@ -191,7 +179,7 @@ func WithTracesReceiver(createTracesReceiver CreateTracesReceiverFunc, sl Stabil
 	})
 }
 
-// WithMetricsReceiver overrides the default "error not supported" implementation for CreateMetricsReceiver and the default "undefined" stability level.
+// Deprecated: [v0.67.0] use receiver.WithMetrics.
 func WithMetricsReceiver(createMetricsReceiver CreateMetricsReceiverFunc, sl StabilityLevel) ReceiverFactoryOption {
 	return receiverFactoryOptionFunc(func(o *receiverFactory) {
 		o.metricsStabilityLevel = sl
@@ -199,7 +187,7 @@ func WithMetricsReceiver(createMetricsReceiver CreateMetricsReceiverFunc, sl Sta
 	})
 }
 
-// WithLogsReceiver overrides the default "error not supported" implementation for CreateLogsReceiver and the default "undefined" stability level.
+// Deprecated: [v0.67.0] use receiver.WithLogs.
 func WithLogsReceiver(createLogsReceiver CreateLogsReceiverFunc, sl StabilityLevel) ReceiverFactoryOption {
 	return receiverFactoryOptionFunc(func(o *receiverFactory) {
 		o.logsStabilityLevel = sl
@@ -207,7 +195,7 @@ func WithLogsReceiver(createLogsReceiver CreateLogsReceiverFunc, sl StabilityLev
 	})
 }
 
-// NewReceiverFactory returns a ReceiverFactory.
+// Deprecated: [v0.67.0] use receiver.NewFactory.
 func NewReceiverFactory(cfgType Type, createDefaultConfig CreateDefaultConfigFunc, options ...ReceiverFactoryOption) ReceiverFactory {
 	f := &receiverFactory{
 		baseFactory: baseFactory{

--- a/config/receiver.go
+++ b/config/receiver.go
@@ -17,7 +17,7 @@ import (
 	"go.opentelemetry.io/collector/component"
 )
 
-// ReceiverSettings defines common settings for a component.Receiver configuration.
+// ReceiverSettings defines common settings for a receiver.Receiver configuration.
 // Specific receivers can embed this struct and extend it with more fields if needed.
 //
 // When embedded in the receiver config it must be with `mapstructure:",squash"` tag.

--- a/exporter/otlphttpexporter/otlp_test.go
+++ b/exporter/otlphttpexporter/otlp_test.go
@@ -52,6 +52,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/collector/pdata/ptrace/ptraceotlp"
 	"go.opentelemetry.io/collector/receiver/otlpreceiver"
+	"go.opentelemetry.io/collector/receiver/receivertest"
 )
 
 func TestInvalidConfig(t *testing.T) {
@@ -345,7 +346,7 @@ func createExporterConfig(baseURL string, defaultCfg component.Config) *Config {
 func startTracesReceiver(t *testing.T, addr string, next consumer.Traces) {
 	factory := otlpreceiver.NewFactory()
 	cfg := createReceiverConfig(addr, factory.CreateDefaultConfig())
-	recv, err := factory.CreateTracesReceiver(context.Background(), componenttest.NewNopReceiverCreateSettings(), cfg, next)
+	recv, err := factory.CreateTracesReceiver(context.Background(), receivertest.NewNopCreateSettings(), cfg, next)
 	require.NoError(t, err)
 	startAndCleanup(t, recv)
 }
@@ -353,7 +354,7 @@ func startTracesReceiver(t *testing.T, addr string, next consumer.Traces) {
 func startMetricsReceiver(t *testing.T, addr string, next consumer.Metrics) {
 	factory := otlpreceiver.NewFactory()
 	cfg := createReceiverConfig(addr, factory.CreateDefaultConfig())
-	recv, err := factory.CreateMetricsReceiver(context.Background(), componenttest.NewNopReceiverCreateSettings(), cfg, next)
+	recv, err := factory.CreateMetricsReceiver(context.Background(), receivertest.NewNopCreateSettings(), cfg, next)
 	require.NoError(t, err)
 	startAndCleanup(t, recv)
 }
@@ -361,7 +362,7 @@ func startMetricsReceiver(t *testing.T, addr string, next consumer.Metrics) {
 func startLogsReceiver(t *testing.T, addr string, next consumer.Logs) {
 	factory := otlpreceiver.NewFactory()
 	cfg := createReceiverConfig(addr, factory.CreateDefaultConfig())
-	recv, err := factory.CreateLogsReceiver(context.Background(), componenttest.NewNopReceiverCreateSettings(), cfg, next)
+	recv, err := factory.CreateLogsReceiver(context.Background(), receivertest.NewNopCreateSettings(), cfg, next)
 	require.NoError(t, err)
 	startAndCleanup(t, recv)
 }

--- a/obsreport/obsreport_receiver.go
+++ b/obsreport/obsreport_receiver.go
@@ -33,6 +33,7 @@ import (
 	"go.opentelemetry.io/collector/featuregate"
 	"go.opentelemetry.io/collector/internal/obsreportconfig"
 	"go.opentelemetry.io/collector/internal/obsreportconfig/obsmetrics"
+	"go.opentelemetry.io/collector/receiver"
 )
 
 const (
@@ -41,7 +42,7 @@ const (
 	receiverScope = scopeName + nameSep + receiverName
 )
 
-// Receiver is a helper to add observability to a component.Receiver.
+// Receiver is a helper to add observability to a receiver.Receiver.
 type Receiver struct {
 	level          configtelemetry.Level
 	spanNamePrefix string
@@ -73,7 +74,7 @@ type ReceiverSettings struct {
 	// eg.: a gRPC stream, for which many batches of data are received in individual
 	// operations without a corresponding new context per operation.
 	LongLivedCtx           bool
-	ReceiverCreateSettings component.ReceiverCreateSettings
+	ReceiverCreateSettings receiver.CreateSettings
 }
 
 // NewReceiver creates a new Receiver.

--- a/obsreport/obsreport_scraper.go
+++ b/obsreport/obsreport_scraper.go
@@ -33,6 +33,7 @@ import (
 	"go.opentelemetry.io/collector/featuregate"
 	"go.opentelemetry.io/collector/internal/obsreportconfig"
 	"go.opentelemetry.io/collector/internal/obsreportconfig/obsmetrics"
+	"go.opentelemetry.io/collector/receiver"
 	"go.opentelemetry.io/collector/receiver/scrapererror"
 )
 
@@ -61,7 +62,7 @@ type Scraper struct {
 type ScraperSettings struct {
 	ReceiverID             component.ID
 	Scraper                component.ID
-	ReceiverCreateSettings component.ReceiverCreateSettings
+	ReceiverCreateSettings receiver.CreateSettings
 }
 
 // NewScraper creates a new Scraper.

--- a/obsreport/obsreporttest/obsreporttest.go
+++ b/obsreport/obsreporttest/obsreporttest.go
@@ -33,6 +33,8 @@ import (
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/exporter/exportertest"
 	"go.opentelemetry.io/collector/internal/obsreportconfig"
+	"go.opentelemetry.io/collector/receiver"
+	"go.opentelemetry.io/collector/receiver/receivertest"
 )
 
 const (
@@ -77,8 +79,8 @@ func (tts *TestTelemetry) ToProcessorCreateSettings() component.ProcessorCreateS
 }
 
 // ToReceiverCreateSettings returns ReceiverCreateSettings with configured TelemetrySettings
-func (tts *TestTelemetry) ToReceiverCreateSettings() component.ReceiverCreateSettings {
-	set := componenttest.NewNopReceiverCreateSettings()
+func (tts *TestTelemetry) ToReceiverCreateSettings() receiver.CreateSettings {
+	set := receivertest.NewNopCreateSettings()
 	set.TelemetrySettings = tts.TelemetrySettings
 	set.ID = tts.id
 	return set

--- a/otelcol/config_provider_test.go
+++ b/otelcol/config_provider_test.go
@@ -32,12 +32,13 @@ import (
 	"go.opentelemetry.io/collector/confmap/provider/yamlprovider"
 	"go.opentelemetry.io/collector/exporter/exportertest"
 	"go.opentelemetry.io/collector/extension/extensiontest"
+	"go.opentelemetry.io/collector/receiver/receivertest"
 	"go.opentelemetry.io/collector/service"
 	"go.opentelemetry.io/collector/service/telemetry"
 )
 
 var configNop = &Config{
-	Receivers:  map[component.ID]component.Config{component.NewID("nop"): componenttest.NewNopReceiverFactory().CreateDefaultConfig()},
+	Receivers:  map[component.ID]component.Config{component.NewID("nop"): receivertest.NewNopFactory().CreateDefaultConfig()},
 	Processors: map[component.ID]component.Config{component.NewID("nop"): componenttest.NewNopProcessorFactory().CreateDefaultConfig()},
 	Exporters:  map[component.ID]component.Config{component.NewID("nop"): exportertest.NewNopFactory().CreateDefaultConfig()},
 	Extensions: map[component.ID]component.Config{component.NewID("nop"): extensiontest.NewNopFactory().CreateDefaultConfig()},

--- a/receiver/otlpreceiver/factory.go
+++ b/receiver/otlpreceiver/factory.go
@@ -24,6 +24,7 @@ import (
 	"go.opentelemetry.io/collector/config/confignet"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/internal/sharedcomponent"
+	"go.opentelemetry.io/collector/receiver"
 )
 
 const (
@@ -34,13 +35,13 @@ const (
 )
 
 // NewFactory creates a new OTLP receiver factory.
-func NewFactory() component.ReceiverFactory {
-	return component.NewReceiverFactory(
+func NewFactory() receiver.Factory {
+	return receiver.NewFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithTracesReceiver(createTracesReceiver, component.StabilityLevelStable),
-		component.WithMetricsReceiver(createMetricsReceiver, component.StabilityLevelStable),
-		component.WithLogsReceiver(createLogReceiver, component.StabilityLevelBeta))
+		receiver.WithTraces(createTraces, component.StabilityLevelStable),
+		receiver.WithMetrics(createMetrics, component.StabilityLevelStable),
+		receiver.WithLogs(createLog, component.StabilityLevelBeta))
 }
 
 // createDefaultConfig creates the default configuration for receiver.
@@ -63,13 +64,13 @@ func createDefaultConfig() component.Config {
 	}
 }
 
-// createTracesReceiver creates a trace receiver based on provided config.
-func createTracesReceiver(
+// createTraces creates a trace receiver based on provided config.
+func createTraces(
 	_ context.Context,
-	set component.ReceiverCreateSettings,
+	set receiver.CreateSettings,
 	cfg component.Config,
 	nextConsumer consumer.Traces,
-) (component.TracesReceiver, error) {
+) (receiver.Traces, error) {
 	r := receivers.GetOrAdd(cfg, func() component.Component {
 		return newOtlpReceiver(cfg.(*Config), set)
 	})
@@ -80,13 +81,13 @@ func createTracesReceiver(
 	return r, nil
 }
 
-// createMetricsReceiver creates a metrics receiver based on provided config.
-func createMetricsReceiver(
+// createMetrics creates a metrics receiver based on provided config.
+func createMetrics(
 	_ context.Context,
-	set component.ReceiverCreateSettings,
+	set receiver.CreateSettings,
 	cfg component.Config,
 	consumer consumer.Metrics,
-) (component.MetricsReceiver, error) {
+) (receiver.Metrics, error) {
 	r := receivers.GetOrAdd(cfg, func() component.Component {
 		return newOtlpReceiver(cfg.(*Config), set)
 	})
@@ -97,13 +98,13 @@ func createMetricsReceiver(
 	return r, nil
 }
 
-// createLogReceiver creates a log receiver based on provided config.
-func createLogReceiver(
+// createLog creates a log receiver based on provided config.
+func createLog(
 	_ context.Context,
-	set component.ReceiverCreateSettings,
+	set receiver.CreateSettings,
 	cfg component.Config,
 	consumer consumer.Logs,
-) (component.LogsReceiver, error) {
+) (receiver.Logs, error) {
 	r := receivers.GetOrAdd(cfg, func() component.Component {
 		return newOtlpReceiver(cfg.(*Config), set)
 	})

--- a/receiver/otlpreceiver/factory_test.go
+++ b/receiver/otlpreceiver/factory_test.go
@@ -30,6 +30,7 @@ import (
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/internal/testutil"
+	"go.opentelemetry.io/collector/receiver/receivertest"
 )
 
 func TestCreateDefaultConfig(t *testing.T) {
@@ -45,7 +46,7 @@ func TestCreateReceiver(t *testing.T) {
 	cfg.GRPC.NetAddr.Endpoint = testutil.GetAvailableLocalAddress(t)
 	cfg.HTTP.Endpoint = testutil.GetAvailableLocalAddress(t)
 
-	creationSet := componenttest.NewNopReceiverCreateSettings()
+	creationSet := receivertest.NewNopCreateSettings()
 	tReceiver, err := factory.CreateTracesReceiver(context.Background(), creationSet, cfg, consumertest.NewNop())
 	assert.NotNil(t, tReceiver)
 	assert.NoError(t, err)
@@ -113,7 +114,7 @@ func TestCreateTracesReceiver(t *testing.T) {
 		},
 	}
 	ctx := context.Background()
-	creationSet := componenttest.NewNopReceiverCreateSettings()
+	creationSet := receivertest.NewNopCreateSettings()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			sink := new(consumertest.TracesSink)
@@ -189,7 +190,7 @@ func TestCreateMetricReceiver(t *testing.T) {
 		},
 	}
 	ctx := context.Background()
-	creationSet := componenttest.NewNopReceiverCreateSettings()
+	creationSet := receivertest.NewNopCreateSettings()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			sink := new(consumertest.MetricsSink)
@@ -292,7 +293,7 @@ func TestCreateLogReceiver(t *testing.T) {
 		},
 	}
 	ctx := context.Background()
-	creationSet := componenttest.NewNopReceiverCreateSettings()
+	creationSet := receivertest.NewNopCreateSettings()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mr, err := factory.CreateLogsReceiver(ctx, creationSet, tt.cfg, tt.sink)

--- a/receiver/otlpreceiver/internal/logs/otlp.go
+++ b/receiver/otlpreceiver/internal/logs/otlp.go
@@ -17,10 +17,10 @@ package logs // import "go.opentelemetry.io/collector/receiver/otlpreceiver/inte
 import (
 	"context"
 
-	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/obsreport"
 	"go.opentelemetry.io/collector/pdata/plog/plogotlp"
+	"go.opentelemetry.io/collector/receiver"
 )
 
 const (
@@ -35,7 +35,7 @@ type Receiver struct {
 }
 
 // New creates a new Receiver reference.
-func New(nextConsumer consumer.Logs, set component.ReceiverCreateSettings) (*Receiver, error) {
+func New(nextConsumer consumer.Logs, set receiver.CreateSettings) (*Receiver, error) {
 	obsrecv, err := obsreport.NewReceiver(obsreport.ReceiverSettings{
 		ReceiverID:             set.ID,
 		Transport:              receiverTransport,

--- a/receiver/otlpreceiver/internal/logs/otlp_test.go
+++ b/receiver/otlpreceiver/internal/logs/otlp_test.go
@@ -26,11 +26,11 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 
 	"go.opentelemetry.io/collector/component"
-	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/internal/testdata"
 	"go.opentelemetry.io/collector/pdata/plog/plogotlp"
+	"go.opentelemetry.io/collector/receiver/receivertest"
 )
 
 func TestExport(t *testing.T) {
@@ -86,7 +86,7 @@ func otlpReceiverOnGRPCServer(t *testing.T, lc consumer.Logs) net.Addr {
 		require.NoError(t, ln.Close())
 	})
 
-	set := componenttest.NewNopReceiverCreateSettings()
+	set := receivertest.NewNopCreateSettings()
 	set.ID = component.NewIDWithName("otlp", "log")
 	r, err := New(lc, set)
 	require.NoError(t, err)

--- a/receiver/otlpreceiver/internal/metrics/otlp.go
+++ b/receiver/otlpreceiver/internal/metrics/otlp.go
@@ -17,10 +17,10 @@ package metrics // import "go.opentelemetry.io/collector/receiver/otlpreceiver/i
 import (
 	"context"
 
-	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/obsreport"
 	"go.opentelemetry.io/collector/pdata/pmetric/pmetricotlp"
+	"go.opentelemetry.io/collector/receiver"
 )
 
 const (
@@ -35,7 +35,7 @@ type Receiver struct {
 }
 
 // New creates a new Receiver reference.
-func New(nextConsumer consumer.Metrics, set component.ReceiverCreateSettings) (*Receiver, error) {
+func New(nextConsumer consumer.Metrics, set receiver.CreateSettings) (*Receiver, error) {
 	obsrecv, err := obsreport.NewReceiver(obsreport.ReceiverSettings{
 		ReceiverID:             set.ID,
 		Transport:              receiverTransport,

--- a/receiver/otlpreceiver/internal/metrics/otlp_test.go
+++ b/receiver/otlpreceiver/internal/metrics/otlp_test.go
@@ -26,11 +26,11 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 
 	"go.opentelemetry.io/collector/component"
-	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/internal/testdata"
 	"go.opentelemetry.io/collector/pdata/pmetric/pmetricotlp"
+	"go.opentelemetry.io/collector/receiver/receivertest"
 )
 
 func TestExport(t *testing.T) {
@@ -87,7 +87,7 @@ func otlpReceiverOnGRPCServer(t *testing.T, mc consumer.Metrics) net.Addr {
 		require.NoError(t, ln.Close())
 	})
 
-	set := componenttest.NewNopReceiverCreateSettings()
+	set := receivertest.NewNopCreateSettings()
 	set.ID = component.NewIDWithName("otlp", "metrics")
 	r, err := New(mc, set)
 	require.NoError(t, err)

--- a/receiver/otlpreceiver/internal/trace/otlp.go
+++ b/receiver/otlpreceiver/internal/trace/otlp.go
@@ -17,10 +17,10 @@ package trace // import "go.opentelemetry.io/collector/receiver/otlpreceiver/int
 import (
 	"context"
 
-	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/obsreport"
 	"go.opentelemetry.io/collector/pdata/ptrace/ptraceotlp"
+	"go.opentelemetry.io/collector/receiver"
 )
 
 const (
@@ -35,7 +35,7 @@ type Receiver struct {
 }
 
 // New creates a new Receiver reference.
-func New(nextConsumer consumer.Traces, set component.ReceiverCreateSettings) (*Receiver, error) {
+func New(nextConsumer consumer.Traces, set receiver.CreateSettings) (*Receiver, error) {
 	obsrecv, err := obsreport.NewReceiver(obsreport.ReceiverSettings{
 		ReceiverID:             set.ID,
 		Transport:              receiverTransport,

--- a/receiver/otlpreceiver/internal/trace/otlp_test.go
+++ b/receiver/otlpreceiver/internal/trace/otlp_test.go
@@ -26,11 +26,11 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 
 	"go.opentelemetry.io/collector/component"
-	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/internal/testdata"
 	"go.opentelemetry.io/collector/pdata/ptrace/ptraceotlp"
+	"go.opentelemetry.io/collector/receiver/receivertest"
 )
 
 func TestExport(t *testing.T) {
@@ -84,7 +84,7 @@ func otlpReceiverOnGRPCServer(t *testing.T, tc consumer.Traces) net.Addr {
 		require.NoError(t, ln.Close())
 	})
 
-	set := componenttest.NewNopReceiverCreateSettings()
+	set := receivertest.NewNopCreateSettings()
 	set.ID = component.NewIDWithName("otlp", "trace")
 	r, err := New(tc, set)
 	require.NoError(t, err)

--- a/receiver/otlpreceiver/otlp.go
+++ b/receiver/otlpreceiver/otlp.go
@@ -32,6 +32,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/plog/plogotlp"
 	"go.opentelemetry.io/collector/pdata/pmetric/pmetricotlp"
 	"go.opentelemetry.io/collector/pdata/ptrace/ptraceotlp"
+	"go.opentelemetry.io/collector/receiver"
 	"go.opentelemetry.io/collector/receiver/otlpreceiver/internal/logs"
 	"go.opentelemetry.io/collector/receiver/otlpreceiver/internal/metrics"
 	"go.opentelemetry.io/collector/receiver/otlpreceiver/internal/trace"
@@ -49,13 +50,13 @@ type otlpReceiver struct {
 	logReceiver     *logs.Receiver
 	shutdownWG      sync.WaitGroup
 
-	settings component.ReceiverCreateSettings
+	settings receiver.CreateSettings
 }
 
 // newOtlpReceiver just creates the OpenTelemetry receiver services. It is the caller's
 // responsibility to invoke the respective Start*Reception methods as well
 // as the various Stop*Reception methods to end it.
-func newOtlpReceiver(cfg *Config, settings component.ReceiverCreateSettings) *otlpReceiver {
+func newOtlpReceiver(cfg *Config, settings receiver.CreateSettings) *otlpReceiver {
 	r := &otlpReceiver{
 		cfg:      cfg,
 		settings: settings,

--- a/receiver/otlpreceiver/otlp_test.go
+++ b/receiver/otlpreceiver/otlp_test.go
@@ -53,6 +53,8 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/collector/pdata/ptrace/ptraceotlp"
+	"go.opentelemetry.io/collector/receiver"
+	"go.opentelemetry.io/collector/receiver/receivertest"
 	semconv "go.opentelemetry.io/collector/semconv/v1.5.0"
 )
 
@@ -193,7 +195,7 @@ func TestHandleInvalidRequests(t *testing.T) {
 	// Traces
 	tr, err := NewFactory().CreateTracesReceiver(
 		context.Background(),
-		componenttest.NewNopReceiverCreateSettings(),
+		receivertest.NewNopCreateSettings(),
 		cfg,
 		consumertest.NewNop())
 	require.NoError(t, err)
@@ -203,7 +205,7 @@ func TestHandleInvalidRequests(t *testing.T) {
 	// Metrics
 	mr, err := NewFactory().CreateMetricsReceiver(
 		context.Background(),
-		componenttest.NewNopReceiverCreateSettings(),
+		receivertest.NewNopCreateSettings(),
 		cfg,
 		consumertest.NewNop())
 	require.NoError(t, err)
@@ -213,7 +215,7 @@ func TestHandleInvalidRequests(t *testing.T) {
 	// Logs
 	lr, err := NewFactory().CreateLogsReceiver(
 		context.Background(),
-		componenttest.NewNopReceiverCreateSettings(),
+		receivertest.NewNopCreateSettings(),
 		cfg,
 		consumertest.NewNop())
 	require.NoError(t, err)
@@ -728,7 +730,7 @@ func TestGRPCInvalidTLSCredentials(t *testing.T) {
 
 	r, err := NewFactory().CreateTracesReceiver(
 		context.Background(),
-		componenttest.NewNopReceiverCreateSettings(),
+		receivertest.NewNopCreateSettings(),
 		cfg,
 		consumertest.NewNop())
 	require.NoError(t, err)
@@ -797,7 +799,7 @@ func TestHTTPInvalidTLSCredentials(t *testing.T) {
 	// TLS is resolved during Start for HTTP.
 	r, err := NewFactory().CreateTracesReceiver(
 		context.Background(),
-		componenttest.NewNopReceiverCreateSettings(),
+		receivertest.NewNopCreateSettings(),
 		cfg,
 		consumertest.NewNop())
 	require.NoError(t, err)
@@ -821,7 +823,7 @@ func testHTTPMaxRequestBodySizeJSON(t *testing.T, payload []byte, size int, expe
 
 	r, err := NewFactory().CreateTracesReceiver(
 		context.Background(),
-		componenttest.NewNopReceiverCreateSettings(),
+		receivertest.NewNopCreateSettings(),
 		cfg,
 		consumertest.NewNop())
 	require.NoError(t, err)
@@ -866,8 +868,8 @@ func newHTTPReceiver(t *testing.T, endpoint string, tc consumer.Traces, mc consu
 	return newReceiver(t, factory, cfg, otlpReceiverID, tc, mc)
 }
 
-func newReceiver(t *testing.T, factory component.ReceiverFactory, cfg *Config, id component.ID, tc consumer.Traces, mc consumer.Metrics) component.Component {
-	set := componenttest.NewNopReceiverCreateSettings()
+func newReceiver(t *testing.T, factory receiver.Factory, cfg *Config, id component.ID, tc consumer.Traces, mc consumer.Metrics) component.Component {
+	set := receivertest.NewNopCreateSettings()
 	set.TelemetrySettings.MetricsLevel = configtelemetry.LevelNormal
 	set.ID = id
 	var r component.Component
@@ -910,7 +912,7 @@ func TestShutdown(t *testing.T) {
 	cfg := factory.CreateDefaultConfig().(*Config)
 	cfg.GRPC.NetAddr.Endpoint = endpointGrpc
 	cfg.HTTP.Endpoint = endpointHTTP
-	set := componenttest.NewNopReceiverCreateSettings()
+	set := receivertest.NewNopCreateSettings()
 	set.ID = otlpReceiverID
 	r, err := NewFactory().CreateTracesReceiver(
 		context.Background(),

--- a/receiver/receiver.go
+++ b/receiver/receiver.go
@@ -1,0 +1,78 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package receiver // import "go.opentelemetry.io/collector/receiver"
+
+import (
+	"go.opentelemetry.io/collector/component"
+)
+
+// A TracesReceiver receives traces.
+// Its purpose is to translate data from any format to the collector's internal trace format.
+// TracesReceiver feeds a consumer.Traces with data.
+//
+// For example it could be Zipkin data source which translates Zipkin spans into ptrace.Traces.
+type Traces = component.TracesReceiver //nolint:staticcheck
+
+// A MetricsReceiver receives metrics.
+// Its purpose is to translate data from any format to the collector's internal metrics format.
+// MetricsReceiver feeds a consumer.Metrics with data.
+//
+// For example it could be Prometheus data source which translates Prometheus metrics into pmetric.Metrics.
+type Metrics = component.MetricsReceiver //nolint:staticcheck
+
+// A LogsReceiver receives logs.
+// Its purpose is to translate data from any format to the collector's internal logs data format.
+// LogsReceiver feeds a consumer.Logs with data.
+//
+// For example a LogsReceiver can read syslogs and convert them into plog.Logs.
+type Logs = component.LogsReceiver //nolint:staticcheck
+
+// CreateSettings configures Receiver creators.
+type CreateSettings = component.ReceiverCreateSettings //nolint:staticcheck
+
+// Factory is factory interface for receivers.
+//
+// This interface cannot be directly implemented. Implementations must
+// use the NewReceiverFactory to implement it.
+type Factory = component.ReceiverFactory //nolint:staticcheck
+
+// FactoryOption apply changes to ReceiverOptions.
+type FactoryOption = component.ReceiverFactoryOption //nolint:staticcheck
+
+// CreateTracesFunc is the equivalent of ReceiverFactory.CreateTracesReceiver().
+type CreateTracesFunc = component.CreateTracesReceiverFunc //nolint:staticcheck
+
+// CreateMetricsFunc is the equivalent of ReceiverFactory.CreateMetricsReceiver().
+type CreateMetricsFunc = component.CreateMetricsReceiverFunc //nolint:staticcheck
+
+// CreateLogsReceiverFunc is the equivalent of ReceiverFactory.CreateLogsReceiver().
+type CreateLogsFunc = component.CreateLogsReceiverFunc //nolint:staticcheck
+
+// WithTraces overrides the default "error not supported" implementation for CreateTracesReceiver and the default "undefined" stability level.
+var WithTraces = component.WithTracesReceiver //nolint:staticcheck
+
+// WithMetrics overrides the default "error not supported" implementation for CreateMetricsReceiver and the default "undefined" stability level.
+var WithMetrics = component.WithMetricsReceiver //nolint:staticcheck
+
+// WithLogs overrides the default "error not supported" implementation for CreateLogsReceiver and the default "undefined" stability level.
+var WithLogs = component.WithLogsReceiver //nolint:staticcheck
+
+// NewFactory returns a ReceiverFactory.
+var NewFactory = component.NewReceiverFactory //nolint:staticcheck
+
+// MakeFactoryMap takes a list of receiver factories and returns a map
+// with factory type as keys. It returns a non-nil error when more than one factories
+// have the same type.
+var MakeFactoryMap = component.MakeReceiverFactoryMap //nolint:staticcheck

--- a/receiver/receiver_test.go
+++ b/receiver/receiver_test.go
@@ -12,9 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// TODO: Move tests back to component package after config.*Settings are removed.
-
-package component_test
+package receiver
 
 import (
 	"context"
@@ -30,52 +28,52 @@ import (
 func TestNewReceiverFactory(t *testing.T) {
 	const typeStr = "test"
 	defaultCfg := config.NewReceiverSettings(component.NewID(typeStr))
-	factory := component.NewReceiverFactory(
+	factory := NewFactory(
 		typeStr,
 		func() component.Config { return &defaultCfg })
 	assert.EqualValues(t, typeStr, factory.Type())
 	assert.EqualValues(t, &defaultCfg, factory.CreateDefaultConfig())
-	_, err := factory.CreateTracesReceiver(context.Background(), component.ReceiverCreateSettings{}, &defaultCfg, nil)
+	_, err := factory.CreateTracesReceiver(context.Background(), CreateSettings{}, &defaultCfg, nil)
 	assert.Error(t, err)
-	_, err = factory.CreateMetricsReceiver(context.Background(), component.ReceiverCreateSettings{}, &defaultCfg, nil)
+	_, err = factory.CreateMetricsReceiver(context.Background(), CreateSettings{}, &defaultCfg, nil)
 	assert.Error(t, err)
-	_, err = factory.CreateLogsReceiver(context.Background(), component.ReceiverCreateSettings{}, &defaultCfg, nil)
+	_, err = factory.CreateLogsReceiver(context.Background(), CreateSettings{}, &defaultCfg, nil)
 	assert.Error(t, err)
 }
 
 func TestNewReceiverFactory_WithOptions(t *testing.T) {
 	const typeStr = "test"
 	defaultCfg := config.NewReceiverSettings(component.NewID(typeStr))
-	factory := component.NewReceiverFactory(
+	factory := NewFactory(
 		typeStr,
 		func() component.Config { return &defaultCfg },
-		component.WithTracesReceiver(createTracesReceiver, component.StabilityLevelDeprecated),
-		component.WithMetricsReceiver(createMetricsReceiver, component.StabilityLevelAlpha),
-		component.WithLogsReceiver(createLogsReceiver, component.StabilityLevelStable))
+		WithTraces(createTraces, component.StabilityLevelDeprecated),
+		WithMetrics(createMetrics, component.StabilityLevelAlpha),
+		WithLogs(createLogs, component.StabilityLevelStable))
 	assert.EqualValues(t, typeStr, factory.Type())
 	assert.EqualValues(t, &defaultCfg, factory.CreateDefaultConfig())
 
 	assert.Equal(t, component.StabilityLevelDeprecated, factory.TracesReceiverStability())
-	_, err := factory.CreateTracesReceiver(context.Background(), component.ReceiverCreateSettings{}, &defaultCfg, nil)
+	_, err := factory.CreateTracesReceiver(context.Background(), CreateSettings{}, &defaultCfg, nil)
 	assert.NoError(t, err)
 
 	assert.Equal(t, component.StabilityLevelAlpha, factory.MetricsReceiverStability())
-	_, err = factory.CreateMetricsReceiver(context.Background(), component.ReceiverCreateSettings{}, &defaultCfg, nil)
+	_, err = factory.CreateMetricsReceiver(context.Background(), CreateSettings{}, &defaultCfg, nil)
 	assert.NoError(t, err)
 
 	assert.Equal(t, component.StabilityLevelStable, factory.LogsReceiverStability())
-	_, err = factory.CreateLogsReceiver(context.Background(), component.ReceiverCreateSettings{}, &defaultCfg, nil)
+	_, err = factory.CreateLogsReceiver(context.Background(), CreateSettings{}, &defaultCfg, nil)
 	assert.NoError(t, err)
 }
 
-func createTracesReceiver(context.Context, component.ReceiverCreateSettings, component.Config, consumer.Traces) (component.TracesReceiver, error) {
+func createTraces(context.Context, CreateSettings, component.Config, consumer.Traces) (Traces, error) {
 	return nil, nil
 }
 
-func createMetricsReceiver(context.Context, component.ReceiverCreateSettings, component.Config, consumer.Metrics) (component.MetricsReceiver, error) {
+func createMetrics(context.Context, CreateSettings, component.Config, consumer.Metrics) (Metrics, error) {
 	return nil, nil
 }
 
-func createLogsReceiver(context.Context, component.ReceiverCreateSettings, component.Config, consumer.Logs) (component.LogsReceiver, error) {
+func createLogs(context.Context, CreateSettings, component.Config, consumer.Logs) (Logs, error) {
 	return nil, nil
 }

--- a/receiver/receivertest/nop_receiver.go
+++ b/receiver/receivertest/nop_receiver.go
@@ -1,0 +1,23 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package receivertest // import "go.opentelemetry.io/collector/receiver/receivertest"
+
+import "go.opentelemetry.io/collector/component/componenttest"
+
+// NewNopCreateSettings returns a new nop settings for Create* functions.
+var NewNopCreateSettings = componenttest.NewNopReceiverCreateSettings //nolint:staticcheck
+
+// NewNopFactory returns a receiver.Factory that constructs nop receivers.
+var NewNopFactory = componenttest.NewNopReceiverFactory //nolint:staticcheck

--- a/receiver/receivertest/nop_receiver_test.go
+++ b/receiver/receivertest/nop_receiver_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package componenttest
+package receivertest
 
 import (
 	"context"
@@ -22,29 +22,29 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/collector/component"
-	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 )
 
-func TestNewNopReceiverFactory(t *testing.T) {
-	factory := NewNopReceiverFactory()
+func TestNewNopFactory(t *testing.T) {
+	factory := NewNopFactory()
 	require.NotNil(t, factory)
 	assert.Equal(t, component.Type("nop"), factory.Type())
 	cfg := factory.CreateDefaultConfig()
-	assert.Equal(t, &nopReceiverConfig{ReceiverSettings: config.NewReceiverSettings(component.NewID("nop"))}, cfg)
+	// assert.Equal(t, &nopReceiverConfig{ReceiverSettings: config.NewReceiverSettings(component.NewID("nop"))}, cfg)
 
-	traces, err := factory.CreateTracesReceiver(context.Background(), NewNopReceiverCreateSettings(), cfg, consumertest.NewNop())
+	traces, err := factory.CreateTracesReceiver(context.Background(), NewNopCreateSettings(), cfg, consumertest.NewNop())
 	require.NoError(t, err)
-	assert.NoError(t, traces.Start(context.Background(), NewNopHost()))
+	assert.NoError(t, traces.Start(context.Background(), componenttest.NewNopHost()))
 	assert.NoError(t, traces.Shutdown(context.Background()))
 
-	metrics, err := factory.CreateMetricsReceiver(context.Background(), NewNopReceiverCreateSettings(), cfg, consumertest.NewNop())
+	metrics, err := factory.CreateMetricsReceiver(context.Background(), NewNopCreateSettings(), cfg, consumertest.NewNop())
 	require.NoError(t, err)
-	assert.NoError(t, metrics.Start(context.Background(), NewNopHost()))
+	assert.NoError(t, metrics.Start(context.Background(), componenttest.NewNopHost()))
 	assert.NoError(t, metrics.Shutdown(context.Background()))
 
-	logs, err := factory.CreateLogsReceiver(context.Background(), NewNopReceiverCreateSettings(), cfg, consumertest.NewNop())
+	logs, err := factory.CreateLogsReceiver(context.Background(), NewNopCreateSettings(), cfg, consumertest.NewNop())
 	require.NoError(t, err)
-	assert.NoError(t, logs.Start(context.Background(), NewNopHost()))
+	assert.NoError(t, logs.Start(context.Background(), componenttest.NewNopHost()))
 	assert.NoError(t, logs.Shutdown(context.Background()))
 }

--- a/receiver/scraperhelper/scrapercontroller.go
+++ b/receiver/scraperhelper/scrapercontroller.go
@@ -27,12 +27,13 @@ import (
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/obsreport"
 	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/receiver"
 	"go.opentelemetry.io/collector/receiver/scrapererror"
 )
 
 // ScraperControllerSettings defines common settings for a scraper controller
 // configuration. Scraper controller receivers can embed this struct, instead
-// of component.ReceiverSettings, and extend it with more fields if needed.
+// of receiver.Settings, and extend it with more fields if needed.
 type ScraperControllerSettings struct {
 	config.ReceiverSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
 	CollectionInterval      time.Duration            `mapstructure:"collection_interval"`
@@ -86,13 +87,13 @@ type controller struct {
 	terminated  chan struct{}
 
 	obsrecv      *obsreport.Receiver
-	recvSettings component.ReceiverCreateSettings
+	recvSettings receiver.CreateSettings
 }
 
 // NewScraperControllerReceiver creates a Receiver with the configured options, that can control multiple scrapers.
 func NewScraperControllerReceiver(
 	cfg *ScraperControllerSettings,
-	set component.ReceiverCreateSettings,
+	set receiver.CreateSettings,
 	nextConsumer consumer.Metrics,
 	options ...ScraperControllerOption,
 ) (component.Component, error) {

--- a/receiver/scraperhelper/scrapercontroller_test.go
+++ b/receiver/scraperhelper/scrapercontroller_test.go
@@ -32,6 +32,7 @@ import (
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/obsreport/obsreporttest"
 	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/receiver/receivertest"
 	"go.opentelemetry.io/collector/receiver/scrapererror"
 )
 
@@ -340,7 +341,7 @@ func TestSingleScrapePerTick(t *testing.T) {
 
 	receiver, err := NewScraperControllerReceiver(
 		cfg,
-		componenttest.NewNopReceiverCreateSettings(),
+		receivertest.NewNopCreateSettings(),
 		new(consumertest.MetricsSink),
 		AddScraper(scp),
 		WithTickerChannel(tickerCh),

--- a/service/internal/configunmarshaler/receivers.go
+++ b/service/internal/configunmarshaler/receivers.go
@@ -19,6 +19,7 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/confmap"
+	"go.opentelemetry.io/collector/receiver"
 )
 
 // receiversKeyName is the configuration key name for receivers section.
@@ -27,10 +28,10 @@ const receiversKeyName = "receivers"
 type Receivers struct {
 	recvs map[component.ID]component.Config
 
-	factories map[component.Type]component.ReceiverFactory
+	factories map[component.Type]receiver.Factory
 }
 
-func NewReceivers(factories map[component.Type]component.ReceiverFactory) *Receivers {
+func NewReceivers(factories map[component.Type]receiver.Factory) *Receivers {
 	return &Receivers{factories: factories}
 }
 

--- a/service/internal/configunmarshaler/receivers_test.go
+++ b/service/internal/configunmarshaler/receivers_test.go
@@ -21,12 +21,13 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/collector/component"
-	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/confmap"
+	"go.opentelemetry.io/collector/receiver"
+	"go.opentelemetry.io/collector/receiver/receivertest"
 )
 
 func TestReceiversUnmarshal(t *testing.T) {
-	factories, err := component.MakeReceiverFactoryMap(componenttest.NewNopReceiverFactory())
+	factories, err := receiver.MakeFactoryMap(receivertest.NewNopFactory())
 	require.NoError(t, err)
 
 	recvs := NewReceivers(factories)
@@ -100,7 +101,7 @@ func TestReceiversUnmarshalError(t *testing.T) {
 		},
 	}
 
-	factories, err := component.MakeReceiverFactoryMap(componenttest.NewNopReceiverFactory())
+	factories, err := receiver.MakeFactoryMap(receivertest.NewNopFactory())
 	assert.NoError(t, err)
 
 	for _, tt := range testCases {

--- a/service/internal/testcomponents/example_receiver.go
+++ b/service/internal/testcomponents/example_receiver.go
@@ -20,6 +20,7 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/receiver"
 )
 
 const receiverType = component.Type("examplereceiver")
@@ -30,12 +31,12 @@ type ExampleReceiverConfig struct {
 }
 
 // ExampleReceiverFactory is factory for ExampleReceiver.
-var ExampleReceiverFactory = component.NewReceiverFactory(
+var ExampleReceiverFactory = receiver.NewFactory(
 	receiverType,
 	createReceiverDefaultConfig,
-	component.WithTracesReceiver(createTracesReceiver, component.StabilityLevelDevelopment),
-	component.WithMetricsReceiver(createMetricsReceiver, component.StabilityLevelDevelopment),
-	component.WithLogsReceiver(createLogsReceiver, component.StabilityLevelDevelopment))
+	receiver.WithTraces(createTracesReceiver, component.StabilityLevelDevelopment),
+	receiver.WithMetrics(createMetricsReceiver, component.StabilityLevelDevelopment),
+	receiver.WithLogs(createLogsReceiver, component.StabilityLevelDevelopment))
 
 func createReceiverDefaultConfig() component.Config {
 	return &ExampleReceiverConfig{
@@ -46,36 +47,36 @@ func createReceiverDefaultConfig() component.Config {
 // createTracesReceiver creates a trace receiver based on this config.
 func createTracesReceiver(
 	_ context.Context,
-	_ component.ReceiverCreateSettings,
+	_ receiver.CreateSettings,
 	cfg component.Config,
 	nextConsumer consumer.Traces,
-) (component.TracesReceiver, error) {
-	receiver := createReceiver(cfg)
-	receiver.Traces = nextConsumer
-	return receiver, nil
+) (receiver.Traces, error) {
+	tr := createReceiver(cfg)
+	tr.Traces = nextConsumer
+	return tr, nil
 }
 
 // createMetricsReceiver creates a metrics receiver based on this config.
 func createMetricsReceiver(
 	_ context.Context,
-	_ component.ReceiverCreateSettings,
+	_ receiver.CreateSettings,
 	cfg component.Config,
 	nextConsumer consumer.Metrics,
-) (component.MetricsReceiver, error) {
-	receiver := createReceiver(cfg)
-	receiver.Metrics = nextConsumer
-	return receiver, nil
+) (receiver.Metrics, error) {
+	mr := createReceiver(cfg)
+	mr.Metrics = nextConsumer
+	return mr, nil
 }
 
 func createLogsReceiver(
 	_ context.Context,
-	_ component.ReceiverCreateSettings,
+	_ receiver.CreateSettings,
 	cfg component.Config,
 	nextConsumer consumer.Logs,
-) (component.LogsReceiver, error) {
-	receiver := createReceiver(cfg)
-	receiver.Logs = nextConsumer
-	return receiver, nil
+) (receiver.Logs, error) {
+	lr := createReceiver(cfg)
+	lr.Logs = nextConsumer
+	return lr, nil
 }
 
 func createReceiver(cfg component.Config) *ExampleReceiver {
@@ -83,14 +84,14 @@ func createReceiver(cfg component.Config) *ExampleReceiver {
 	// receivers per config.
 
 	// Check to see if there is already a receiver for this config.
-	receiver, ok := exampleReceivers[cfg]
+	er, ok := exampleReceivers[cfg]
 	if !ok {
-		receiver = &ExampleReceiver{}
+		er = &ExampleReceiver{}
 		// Remember the receiver in the map
-		exampleReceivers[cfg] = receiver
+		exampleReceivers[cfg] = er
 	}
 
-	return receiver
+	return er
 }
 
 // ExampleReceiver allows producing traces and metrics for testing purposes.

--- a/service/pipelines.go
+++ b/service/pipelines.go
@@ -26,6 +26,7 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/exporter"
+	"go.opentelemetry.io/collector/receiver"
 	"go.opentelemetry.io/collector/service/internal/capabilityconsumer"
 	"go.opentelemetry.io/collector/service/internal/components"
 	"go.opentelemetry.io/collector/service/internal/fanoutconsumer"
@@ -183,8 +184,8 @@ type pipelinesSettings struct {
 	Telemetry component.TelemetrySettings
 	BuildInfo component.BuildInfo
 
-	// ReceiverFactories maps receiver type names in the config to the respective component.ReceiverFactory.
-	ReceiverFactories map[component.Type]component.ReceiverFactory
+	// ReceiverFactories maps receiver type names in the config to the respective receiver.Factory.
+	ReceiverFactories map[component.Type]receiver.Factory
 
 	// ReceiverConfigs is a map of component.ID to component.Config.
 	ReceiverConfigs map[component.ID]component.Config
@@ -498,7 +499,7 @@ func buildReceiver(ctx context.Context,
 	settings component.TelemetrySettings,
 	buildInfo component.BuildInfo,
 	cfgs map[component.ID]component.Config,
-	factories map[component.Type]component.ReceiverFactory,
+	factories map[component.Type]receiver.Factory,
 	id component.ID,
 	pipelineID component.ID,
 	nexts []baseConsumer,
@@ -513,7 +514,7 @@ func buildReceiver(ctx context.Context,
 		return nil, fmt.Errorf("receiver factory not available for: %q", id)
 	}
 
-	set := component.ReceiverCreateSettings{
+	set := receiver.CreateSettings{
 		ID:                id,
 		TelemetrySettings: settings,
 		BuildInfo:         buildInfo,
@@ -529,7 +530,7 @@ func buildReceiver(ctx context.Context,
 	return recv, nil
 }
 
-func createReceiver(ctx context.Context, set component.ReceiverCreateSettings, cfg component.Config, id component.ID, pipelineID component.ID, nexts []baseConsumer, factory component.ReceiverFactory) (component.Component, error) {
+func createReceiver(ctx context.Context, set receiver.CreateSettings, cfg component.Config, id component.ID, pipelineID component.ID, nexts []baseConsumer, factory receiver.Factory) (component.Component, error) {
 	switch pipelineID.Type() {
 	case component.DataTypeTraces:
 		var consumers []consumer.Traces
@@ -560,7 +561,7 @@ func receiverLogger(logger *zap.Logger, id component.ID, dt component.DataType) 
 		zap.String(components.ZapKindPipeline, string(dt)))
 }
 
-func getReceiverStabilityLevel(factory component.ReceiverFactory, dt component.DataType) component.StabilityLevel {
+func getReceiverStabilityLevel(factory receiver.Factory, dt component.DataType) component.StabilityLevel {
 	switch dt {
 	case component.DataTypeTraces:
 		return factory.TracesReceiverStability()


### PR DESCRIPTION
This is a necessary prerequisite for moving `component.Factories` to `service.Factories`. Otherwise, a circular dependency is created [here](https://github.com/open-telemetry/opentelemetry-collector/blob/f34cc5399aaf902a8d51a7e484d4256d7ce76551/service/internal/configunmarshaler/receivers_test.go#L29). 

Similar changes already made for extensions, breaking the circular dependency [here](https://github.com/open-telemetry/opentelemetry-collector/blob/f34cc5399aaf902a8d51a7e484d4256d7ce76551/service/internal/configunmarshaler/extensions_test.go#L30).