### PR TITLE
Persistent queue should stop consumer before stopping storage

### DIFF
--- a/.chloggen/persistentqueuedupdata.yaml
+++ b/.chloggen/persistentqueuedupdata.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: otlpexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix a bug that exporter persistent queue is sending duplicate data after restarting.
+
+# One or more tracking issues or pull requests related to the change
+issues: [6692]

--- a/exporter/exporterhelper/internal/persistent_queue.go
+++ b/exporter/exporterhelper/internal/persistent_queue.go
@@ -80,9 +80,10 @@ func (pq *persistentQueue) Produce(item Request) bool {
 // Stop stops accepting items, shuts down the queue and closes the persistent queue
 func (pq *persistentQueue) Stop() {
 	pq.stopOnce.Do(func() {
-		pq.storage.stop()
+		// stop the consumers before the storage or the successful processing result will fail to write to persistent storage
 		close(pq.stopChan)
 		pq.stopWG.Wait()
+		pq.storage.stop()
 	})
 }
 

--- a/exporter/exporterhelper/internal/persistent_queue.go
+++ b/exporter/exporterhelper/internal/persistent_queue.go
@@ -25,6 +25,13 @@ import (
 	"go.opentelemetry.io/collector/extension/experimental/storage"
 )
 
+// Monkey patching for unit test
+var (
+	stopStorage = func(queue *persistentQueue) {
+		queue.storage.stop()
+	}
+)
+
 // persistentQueue holds the queue backed by file storage
 type persistentQueue struct {
 	logger     *zap.Logger
@@ -83,7 +90,7 @@ func (pq *persistentQueue) Stop() {
 		// stop the consumers before the storage or the successful processing result will fail to write to persistent storage
 		close(pq.stopChan)
 		pq.stopWG.Wait()
-		pq.storage.stop()
+		stopStorage(pq)
 	})
 }
 

--- a/exporter/exporterhelper/internal/persistent_queue_test.go
+++ b/exporter/exporterhelper/internal/persistent_queue_test.go
@@ -102,6 +102,42 @@ func TestPersistentQueue_Close(t *testing.T) {
 	}, 5*time.Second, 10*time.Millisecond)
 }
 
+// Verify storage closes after queue consumers. If not in this order, successfully consumed items won't be updated in storage
+func TestPersistentQueue_Close_StorageCloseAfterConsumers(t *testing.T) {
+	path := t.TempDir()
+
+	ext := createStorageExtension(path)
+	t.Cleanup(func() { require.NoError(t, ext.Shutdown(context.Background())) })
+
+	wq := createTestQueue(ext, 1001)
+	traces := newTraces(1, 10)
+
+	lastRequestProcessedTime := time.Now()
+	req := newFakeTracesRequest(traces)
+	req.processingFinishedCallback = func() {
+		lastRequestProcessedTime = time.Now()
+	}
+
+	fnBefore := stopStorage
+	stopStorageTime := time.Now()
+	stopStorage = func(queue *persistentQueue) {
+		stopStorageTime = time.Now()
+		queue.storage.stop()
+	}
+
+	wq.StartConsumers(1, func(item Request) {})
+
+	for i := 0; i < 1000; i++ {
+		wq.Produce(req)
+	}
+	require.Eventually(t, func() bool {
+		wq.Stop()
+		return true
+	}, 5*time.Second, 10*time.Millisecond)
+	require.True(t, stopStorageTime.After(lastRequestProcessedTime), "storage stop time should be after last request processed time")
+	stopStorage = fnBefore
+}
+
 func TestPersistentQueue_ConsumersProducers(t *testing.T) {
 	cases := []struct {
 		numMessagesProduced int


### PR DESCRIPTION
**Description:** <Describe what has changed. 
Fix a bug that exporter persistent queue is sending duplicate data after restarting. This is due to consumer still processing requests after the persistent storage client has shutdown, resulting successful request not updated in the storage.

**Link to tracking Issue:**
https://github.com/open-telemetry/opentelemetry-collector/issues/6692

**Testing:**
- Running existing unit test on close
- added a unit test case to verify storage stopping time is after last item consumed from consumers

**Documentation:**
Updated changelog
