### PR TITLE
[chore] fix unintended public type settings when moved pipelines

### DIFF
--- a/service/pipelines.go
+++ b/service/pipelines.go
@@ -177,8 +177,8 @@ func (bps *builtPipelines) HandleZPages(w http.ResponseWriter, r *http.Request) 
 	zpages.WriteHTMLPageFooter(w)
 }
 
-// Settings holds configuration for building builtPipelines.
-type Settings struct {
+// pipelinesSettings holds configuration for building builtPipelines.
+type pipelinesSettings struct {
 	Telemetry component.TelemetrySettings
 	BuildInfo component.BuildInfo
 
@@ -205,7 +205,7 @@ type Settings struct {
 }
 
 // buildPipelines builds all pipelines from config.
-func buildPipelines(ctx context.Context, set Settings) (*builtPipelines, error) {
+func buildPipelines(ctx context.Context, set pipelinesSettings) (*builtPipelines, error) {
 	exps := &builtPipelines{
 		telemetry:    set.Telemetry,
 		allReceivers: make(map[component.DataType]map[component.ID]component.Component),

--- a/service/pipelines_test.go
+++ b/service/pipelines_test.go
@@ -176,7 +176,7 @@ func TestBuildPipelines(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			// Build the pipeline
-			pipelines, err := buildPipelines(context.Background(), Settings{
+			pipelines, err := buildPipelines(context.Background(), pipelinesSettings{
 				Telemetry: componenttest.NewNopTelemetrySettings(),
 				BuildInfo: component.NewDefaultBuildInfo(),
 				ReceiverFactories: map[component.Type]component.ReceiverFactory{
@@ -296,11 +296,11 @@ func TestBuildErrors(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		settings Settings
+		settings pipelinesSettings
 	}{
 		{
 			name: "not_supported_exporter_logs",
-			settings: Settings{
+			settings: pipelinesSettings{
 				ReceiverConfigs: map[component.ID]component.Config{
 					component.NewID("nop"): nopReceiverFactory.CreateDefaultConfig(),
 				},
@@ -317,7 +317,7 @@ func TestBuildErrors(t *testing.T) {
 		},
 		{
 			name: "not_supported_exporter_metrics",
-			settings: Settings{
+			settings: pipelinesSettings{
 				ReceiverConfigs: map[component.ID]component.Config{
 					component.NewID("nop"): nopReceiverFactory.CreateDefaultConfig(),
 				},
@@ -334,7 +334,7 @@ func TestBuildErrors(t *testing.T) {
 		},
 		{
 			name: "not_supported_exporter_traces",
-			settings: Settings{
+			settings: pipelinesSettings{
 				ReceiverConfigs: map[component.ID]component.Config{
 					component.NewID("nop"): nopReceiverFactory.CreateDefaultConfig(),
 				},
@@ -351,7 +351,7 @@ func TestBuildErrors(t *testing.T) {
 		},
 		{
 			name: "not_supported_processor_logs",
-			settings: Settings{
+			settings: pipelinesSettings{
 				ReceiverConfigs: map[component.ID]component.Config{
 					component.NewID("nop"): nopReceiverFactory.CreateDefaultConfig(),
 				},
@@ -372,7 +372,7 @@ func TestBuildErrors(t *testing.T) {
 		},
 		{
 			name: "not_supported_processor_metrics",
-			settings: Settings{
+			settings: pipelinesSettings{
 				ReceiverConfigs: map[component.ID]component.Config{
 					component.NewID("nop"): nopReceiverFactory.CreateDefaultConfig(),
 				},
@@ -393,7 +393,7 @@ func TestBuildErrors(t *testing.T) {
 		},
 		{
 			name: "not_supported_processor_traces",
-			settings: Settings{
+			settings: pipelinesSettings{
 				ReceiverConfigs: map[component.ID]component.Config{
 					component.NewID("nop"): nopReceiverFactory.CreateDefaultConfig(),
 				},
@@ -414,7 +414,7 @@ func TestBuildErrors(t *testing.T) {
 		},
 		{
 			name: "not_supported_receiver_logs",
-			settings: Settings{
+			settings: pipelinesSettings{
 				ReceiverConfigs: map[component.ID]component.Config{
 					component.NewID("bf"): badReceiverFactory.CreateDefaultConfig(),
 				},
@@ -431,7 +431,7 @@ func TestBuildErrors(t *testing.T) {
 		},
 		{
 			name: "not_supported_receiver_metrics",
-			settings: Settings{
+			settings: pipelinesSettings{
 				ReceiverConfigs: map[component.ID]component.Config{
 					component.NewID("bf"): badReceiverFactory.CreateDefaultConfig(),
 				},
@@ -448,7 +448,7 @@ func TestBuildErrors(t *testing.T) {
 		},
 		{
 			name: "not_supported_receiver_traces",
-			settings: Settings{
+			settings: pipelinesSettings{
 				ReceiverConfigs: map[component.ID]component.Config{
 					component.NewID("bf"): badReceiverFactory.CreateDefaultConfig(),
 				},
@@ -465,7 +465,7 @@ func TestBuildErrors(t *testing.T) {
 		},
 		{
 			name: "unknown_exporter_config",
-			settings: Settings{
+			settings: pipelinesSettings{
 				ReceiverConfigs: map[component.ID]component.Config{
 					component.NewID("nop"): nopReceiverFactory.CreateDefaultConfig(),
 				},
@@ -482,7 +482,7 @@ func TestBuildErrors(t *testing.T) {
 		},
 		{
 			name: "unknown_exporter_factory",
-			settings: Settings{
+			settings: pipelinesSettings{
 				ReceiverConfigs: map[component.ID]component.Config{
 					component.NewID("nop"): nopReceiverFactory.CreateDefaultConfig(),
 				},
@@ -499,7 +499,7 @@ func TestBuildErrors(t *testing.T) {
 		},
 		{
 			name: "unknown_processor_config",
-			settings: Settings{
+			settings: pipelinesSettings{
 				ReceiverConfigs: map[component.ID]component.Config{
 					component.NewID("nop"): nopReceiverFactory.CreateDefaultConfig(),
 				},
@@ -520,7 +520,7 @@ func TestBuildErrors(t *testing.T) {
 		},
 		{
 			name: "unknown_processor_factory",
-			settings: Settings{
+			settings: pipelinesSettings{
 				ReceiverConfigs: map[component.ID]component.Config{
 					component.NewID("nop"): nopReceiverFactory.CreateDefaultConfig(),
 				},
@@ -541,7 +541,7 @@ func TestBuildErrors(t *testing.T) {
 		},
 		{
 			name: "unknown_receiver_config",
-			settings: Settings{
+			settings: pipelinesSettings{
 				ReceiverConfigs: map[component.ID]component.Config{
 					component.NewID("nop"): nopReceiverFactory.CreateDefaultConfig(),
 				},
@@ -558,7 +558,7 @@ func TestBuildErrors(t *testing.T) {
 		},
 		{
 			name: "unknown_receiver_factory",
-			settings: Settings{
+			settings: pipelinesSettings{
 				ReceiverConfigs: map[component.ID]component.Config{
 					component.NewID("unknown"): nopReceiverFactory.CreateDefaultConfig(),
 				},
@@ -607,7 +607,7 @@ func TestFailToStartAndShutdown(t *testing.T) {
 	nopProcessorFactory := componenttest.NewNopProcessorFactory()
 	nopExporterFactory := componenttest.NewNopExporterFactory()
 
-	set := Settings{
+	set := pipelinesSettings{
 		Telemetry: componenttest.NewNopTelemetrySettings(),
 		BuildInfo: component.NewDefaultBuildInfo(),
 		ReceiverFactories: map[component.Type]component.ReceiverFactory{

--- a/service/service.go
+++ b/service/service.go
@@ -147,7 +147,7 @@ func (srv *service) initExtensionsAndPipeline(set *settings) error {
 		return fmt.Errorf("failed build extensions: %w", err)
 	}
 
-	pipelinesSettings := Settings{
+	pSet := pipelinesSettings{
 		Telemetry:          srv.telemetrySettings,
 		BuildInfo:          srv.buildInfo,
 		ReceiverFactories:  srv.host.factories.Receivers,
@@ -158,7 +158,7 @@ func (srv *service) initExtensionsAndPipeline(set *settings) error {
 		ExporterConfigs:    srv.config.Exporters,
 		PipelineConfigs:    srv.config.Service.Pipelines,
 	}
-	if srv.host.pipelines, err = buildPipelines(context.Background(), pipelinesSettings); err != nil {
+	if srv.host.pipelines, err = buildPipelines(context.Background(), pSet); err != nil {
 		return fmt.Errorf("cannot build pipelines: %w", err)
 	}
 


### PR DESCRIPTION
Not a breaking change since the type was added (moved) in this cycle.