### PR TITLE
[chore] Remove telemetryInitializer from CollectorSettings

### DIFF
--- a/service/collector_test.go
+++ b/service/collector_test.go
@@ -16,30 +16,21 @@
 package service
 
 import (
-	"bufio"
 	"context"
 	"errors"
-	"net/http"
 	"path/filepath"
-	"strings"
 	"sync"
 	"syscall"
 	"testing"
 	"time"
 
-	"github.com/prometheus/common/expfmt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
-	"go.opentelemetry.io/collector/confmap"
-	"go.opentelemetry.io/collector/extension/zpagesextension"
 	"go.opentelemetry.io/collector/featuregate"
 	"go.opentelemetry.io/collector/internal/obsreportconfig"
-	"go.opentelemetry.io/collector/internal/testutil"
 )
 
 func TestStateString(t *testing.T) {
@@ -61,7 +52,6 @@ func TestCollectorStartAsGoRoutine(t *testing.T) {
 		BuildInfo:      component.NewDefaultBuildInfo(),
 		Factories:      factories,
 		ConfigProvider: cfgProvider,
-		telemetry:      newColTelemetry(featuregate.NewRegistry()),
 	}
 	col, err := New(set)
 	require.NoError(t, err)
@@ -89,7 +79,6 @@ func TestCollectorCancelContext(t *testing.T) {
 		BuildInfo:      component.NewDefaultBuildInfo(),
 		Factories:      factories,
 		ConfigProvider: cfgProvider,
-		telemetry:      newColTelemetry(featuregate.NewRegistry()),
 	}
 	col, err := New(set)
 	require.NoError(t, err)
@@ -127,7 +116,6 @@ func TestCollectorStateAfterConfigChange(t *testing.T) {
 		BuildInfo:      component.NewDefaultBuildInfo(),
 		Factories:      factories,
 		ConfigProvider: &mockCfgProvider{ConfigProvider: provider, watcher: watcher},
-		telemetry:      newColTelemetry(featuregate.NewRegistry()),
 	})
 	require.NoError(t, err)
 
@@ -160,7 +148,6 @@ func TestCollectorReportError(t *testing.T) {
 		BuildInfo:      component.NewDefaultBuildInfo(),
 		Factories:      factories,
 		ConfigProvider: cfgProvider,
-		telemetry:      newColTelemetry(featuregate.NewRegistry()),
 	})
 	require.NoError(t, err)
 
@@ -187,7 +174,6 @@ func TestCollectorSendSignal(t *testing.T) {
 		BuildInfo:      component.NewDefaultBuildInfo(),
 		Factories:      factories,
 		ConfigProvider: cfgProvider,
-		telemetry:      newColTelemetry(featuregate.NewRegistry()),
 	})
 	require.NoError(t, err)
 
@@ -221,7 +207,6 @@ func TestCollectorFailedShutdown(t *testing.T) {
 		BuildInfo:      component.NewDefaultBuildInfo(),
 		Factories:      factories,
 		ConfigProvider: cfgProvider,
-		telemetry:      newColTelemetry(featuregate.NewRegistry()),
 	})
 	require.NoError(t, err)
 
@@ -253,178 +238,13 @@ func TestCollectorStartInvalidConfig(t *testing.T) {
 		BuildInfo:      component.NewDefaultBuildInfo(),
 		Factories:      factories,
 		ConfigProvider: cfgProvider,
-		telemetry:      newColTelemetry(featuregate.NewRegistry()),
 	})
 	require.NoError(t, err)
 	assert.Error(t, col.Run(context.Background()))
 }
 
-// mapConverter applies extraMap of config settings. Useful for overriding the config
-// for testing purposes. Keys must use "::" delimiter between levels.
-type mapConverter struct {
-	extraMap map[string]interface{}
-}
-
-func (m mapConverter) Convert(ctx context.Context, conf *confmap.Conf) error {
-	return conf.Merge(confmap.NewFromStringMap(m.extraMap))
-}
-
-type labelState int
-
-const (
-	labelNotPresent labelState = iota
-	labelSpecificValue
-	labelAnyValue
-)
-
-type labelValue struct {
-	label string
-	state labelState
-}
-
-type ownMetricsTestCase struct {
-	name                string
-	userDefinedResource map[string]*string
-	expectedLabels      map[string]labelValue
-}
-
-var testResourceAttrValue = "resource_attr_test_value"
-var testInstanceID = "test_instance_id"
-var testServiceVersion = "2022-05-20"
-
-func ownMetricsTestCases(version string) []ownMetricsTestCase {
-	return []ownMetricsTestCase{{
-		name:                "no resource",
-		userDefinedResource: nil,
-		// All labels added to all collector metrics by default are listed below.
-		// These labels are hard coded here in order to avoid inadvertent changes:
-		// at this point changing labels should be treated as a breaking changing
-		// and requires a good justification. The reason is that changes to metric
-		// names or labels can break alerting, dashboards, etc that are used to
-		// monitor the Collector in production deployments.
-		expectedLabels: map[string]labelValue{
-			"service_instance_id": {state: labelAnyValue},
-			"service_version":     {label: version, state: labelSpecificValue},
-		},
-	},
-		{
-			name: "resource with custom attr",
-			userDefinedResource: map[string]*string{
-				"custom_resource_attr": &testResourceAttrValue,
-			},
-			expectedLabels: map[string]labelValue{
-				"service_instance_id":  {state: labelAnyValue},
-				"service_version":      {label: version, state: labelSpecificValue},
-				"custom_resource_attr": {label: "resource_attr_test_value", state: labelSpecificValue},
-			},
-		},
-		{
-			name: "override service.instance.id",
-			userDefinedResource: map[string]*string{
-				"service.instance.id": &testInstanceID,
-			},
-			expectedLabels: map[string]labelValue{
-				"service_instance_id": {label: "test_instance_id", state: labelSpecificValue},
-				"service_version":     {label: version, state: labelSpecificValue},
-			},
-		},
-		{
-			name: "suppress service.instance.id",
-			userDefinedResource: map[string]*string{
-				"service.instance.id": nil, // nil value in config is used to suppress attributes.
-			},
-			expectedLabels: map[string]labelValue{
-				"service_instance_id": {state: labelNotPresent},
-				"service_version":     {label: version, state: labelSpecificValue},
-			},
-		},
-		{
-			name: "override service.version",
-			userDefinedResource: map[string]*string{
-				"service.version": &testServiceVersion,
-			},
-			expectedLabels: map[string]labelValue{
-				"service_instance_id": {state: labelAnyValue},
-				"service_version":     {label: "2022-05-20", state: labelSpecificValue},
-			},
-		},
-		{
-			name: "suppress service.version",
-			userDefinedResource: map[string]*string{
-				"service.version": nil, // nil value in config is used to suppress attributes.
-			},
-			expectedLabels: map[string]labelValue{
-				"service_instance_id": {state: labelAnyValue},
-				"service_version":     {state: labelNotPresent},
-			},
-		}}
-}
-
-func testCollectorStartHelper(t *testing.T, telemetry *telemetryInitializer, tc ownMetricsTestCase) {
-	factories, err := componenttest.NopFactories()
-	zpagesExt := zpagesextension.NewFactory()
-	factories.Extensions[zpagesExt.Type()] = zpagesExt
-	require.NoError(t, err)
-	var once sync.Once
-	loggingHookCalled := false
-	hook := func(entry zapcore.Entry) error {
-		once.Do(func() {
-			loggingHookCalled = true
-		})
-		return nil
-	}
-
-	metricsAddr := testutil.GetAvailableLocalAddress(t)
-	zpagesAddr := testutil.GetAvailableLocalAddress(t)
-	// Prepare config properties to be merged with the main config.
-	extraCfgAsProps := map[string]interface{}{
-		// Setup the zpages extension.
-		"extensions::zpages::endpoint": zpagesAddr,
-		"service::extensions":          "nop, zpages",
-		// Set the metrics address to expose own metrics on.
-		"service::telemetry::metrics::address": metricsAddr,
-	}
-	// Also include resource attributes under the service::telemetry::resource key.
-	for k, v := range tc.userDefinedResource {
-		extraCfgAsProps["service::telemetry::resource::"+k] = v
-	}
-
-	cfgSet := newDefaultConfigProviderSettings([]string{filepath.Join("testdata", "otelcol-nop.yaml")})
-	cfgSet.ResolverSettings.Converters = append([]confmap.Converter{
-		mapConverter{extraCfgAsProps}},
-		cfgSet.ResolverSettings.Converters...,
-	)
-	cfgProvider, err := NewConfigProvider(cfgSet)
-	require.NoError(t, err)
-
-	col, err := New(CollectorSettings{
-		BuildInfo:      component.BuildInfo{Version: "test version"},
-		Factories:      factories,
-		ConfigProvider: cfgProvider,
-		LoggingOptions: []zap.Option{zap.Hooks(hook)},
-		telemetry:      telemetry,
-	})
-	require.NoError(t, err)
-
-	wg := startCollector(context.Background(), t, col)
-
-	assert.Eventually(t, func() bool {
-		return StateRunning == col.GetState()
-	}, 2*time.Second, 200*time.Millisecond)
-	assert.True(t, loggingHookCalled)
-
-	assertMetrics(t, metricsAddr, tc.expectedLabels)
-
-	assertZPages(t, zpagesAddr)
-
-	col.Shutdown()
-
-	wg.Wait()
-	assert.Equal(t, StateClosed, col.GetState())
-}
-
 func TestCollectorStartWithOpenCensusMetrics(t *testing.T) {
-	for _, tc := range ownMetricsTestCases("test version") {
+	for _, tc := range ownMetricsTestCases() {
 		t.Run(tc.name, func(t *testing.T) {
 			testCollectorStartHelper(t, newColTelemetry(featuregate.NewRegistry()), tc)
 		})
@@ -432,7 +252,7 @@ func TestCollectorStartWithOpenCensusMetrics(t *testing.T) {
 }
 
 func TestCollectorStartWithOpenTelemetryMetrics(t *testing.T) {
-	for _, tc := range ownMetricsTestCases("test version") {
+	for _, tc := range ownMetricsTestCases() {
 		t.Run(tc.name, func(t *testing.T) {
 			registry := featuregate.NewRegistry()
 			obsreportconfig.RegisterInternalMetricFeatureGate(registry)
@@ -465,7 +285,6 @@ func TestCollectorStartWithTraceContextPropagation(t *testing.T) {
 				BuildInfo:      component.NewDefaultBuildInfo(),
 				Factories:      factories,
 				ConfigProvider: cfgProvider,
-				telemetry:      newColTelemetry(featuregate.NewRegistry()),
 			}
 
 			col, err := New(set)
@@ -504,7 +323,6 @@ func TestCollectorRun(t *testing.T) {
 				BuildInfo:      component.NewDefaultBuildInfo(),
 				Factories:      factories,
 				ConfigProvider: cfgProvider,
-				telemetry:      newColTelemetry(featuregate.NewRegistry()),
 			}
 			col, err := New(set)
 			require.NoError(t, err)
@@ -529,7 +347,6 @@ func TestCollectorShutdownBeforeRun(t *testing.T) {
 		BuildInfo:      component.NewDefaultBuildInfo(),
 		Factories:      factories,
 		ConfigProvider: cfgProvider,
-		telemetry:      newColTelemetry(featuregate.NewRegistry()),
 	}
 	col, err := New(set)
 	require.NoError(t, err)
@@ -556,7 +373,6 @@ func TestCollectorClosedStateOnStartUpError(t *testing.T) {
 		BuildInfo:      component.NewDefaultBuildInfo(),
 		Factories:      factories,
 		ConfigProvider: cfgProvider,
-		telemetry:      newColTelemetry(featuregate.NewRegistry()),
 	}
 	col, err := New(set)
 	require.NoError(t, err)
@@ -566,76 +382,6 @@ func TestCollectorClosedStateOnStartUpError(t *testing.T) {
 
 	// Expect state to be closed
 	assert.Equal(t, StateClosed, col.GetState())
-}
-
-func assertMetrics(t *testing.T, metricsAddr string, expectedLabels map[string]labelValue) {
-	client := &http.Client{}
-	resp, err := client.Get("http://" + metricsAddr + "/metrics")
-	require.NoError(t, err)
-
-	t.Cleanup(func() {
-		assert.NoError(t, resp.Body.Close())
-	})
-	reader := bufio.NewReader(resp.Body)
-
-	var parser expfmt.TextParser
-	parsed, err := parser.TextToMetricFamilies(reader)
-	require.NoError(t, err)
-
-	prefix := "otelcol"
-	for metricName, metricFamily := range parsed {
-		// require is used here so test fails with a single message.
-		require.True(
-			t,
-			strings.HasPrefix(metricName, prefix),
-			"expected prefix %q but string starts with %q",
-			prefix,
-			metricName[:len(prefix)+1]+"...")
-
-		for _, metric := range metricFamily.Metric {
-			labelMap := map[string]string{}
-			for _, labelPair := range metric.Label {
-				labelMap[*labelPair.Name] = *labelPair.Value
-			}
-
-			for k, v := range expectedLabels {
-				switch v.state {
-				case labelNotPresent:
-					_, present := labelMap[k]
-					assert.Falsef(t, present, "label %q must not be present", k)
-				case labelSpecificValue:
-					require.Equalf(t, v.label, labelMap[k], "mandatory label %q value mismatch", k)
-				case labelAnyValue:
-					assert.NotEmptyf(t, labelMap[k], "mandatory label %q not present", k)
-				}
-			}
-		}
-	}
-}
-
-func assertZPages(t *testing.T, zpagesAddr string) {
-	paths := []string{
-		"/debug/tracez",
-		// TODO: enable this when otel-metrics is used and this page is available.
-		// "/debug/rpcz",
-		"/debug/pipelinez",
-		"/debug/servicez",
-		"/debug/extensionz",
-	}
-
-	testZPagePathFn := func(t *testing.T, path string) {
-		client := &http.Client{}
-		resp, err := client.Get("http://" + zpagesAddr + path)
-		if !assert.NoError(t, err, "error retrieving zpage at %q", path) {
-			return
-		}
-		assert.Equal(t, http.StatusOK, resp.StatusCode, "unsuccessful zpage %q GET", path)
-		assert.NoError(t, resp.Body.Close())
-	}
-
-	for _, path := range paths {
-		testZPagePathFn(t, path)
-	}
 }
 
 func startCollector(ctx context.Context, t *testing.T, col *Collector) *sync.WaitGroup {

--- a/service/service.go
+++ b/service/service.go
@@ -171,3 +171,15 @@ func (srv *service) initExtensionsAndPipeline(set *settings) error {
 
 	return nil
 }
+
+func getBallastSize(host component.Host) uint64 {
+	var ballastSize uint64
+	extensions := host.GetExtensions()
+	for _, extension := range extensions {
+		if ext, ok := extension.(interface{ GetBallastSize() uint64 }); ok {
+			ballastSize = ext.GetBallastSize()
+			break
+		}
+	}
+	return ballastSize
+}

--- a/service/settings.go
+++ b/service/settings.go
@@ -65,7 +65,4 @@ type CollectorSettings struct {
 
 	// SkipSettingGRPCLogger avoids setting the grpc logger
 	SkipSettingGRPCLogger bool
-
-	// For testing purpose only.
-	telemetry *telemetryInitializer
 }


### PR DESCRIPTION
This will allow to move deprecated Collector to otelcol.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
