### PR TITLE
Remove dependency on batchprocessor from service package

### DIFF
--- a/.chloggen/rmdepbatch.yaml
+++ b/.chloggen/rmdepbatch.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: batchprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecate metric views funcs, for OC and Otel.
+
+# One or more tracking issues or pull requests related to the change
+issues: [6730]

--- a/component/go.mod
+++ b/component/go.mod
@@ -50,6 +50,4 @@ replace go.opentelemetry.io/collector/pdata => ../pdata
 
 replace go.opentelemetry.io/collector/semconv => ../semconv
 
-replace go.opentelemetry.io/collector/processor/batchprocessor => ../processor/batchprocessor
-
 replace go.opentelemetry.io/collector/extension/zpagesextension => ../extension/zpagesextension

--- a/consumer/go.mod
+++ b/consumer/go.mod
@@ -33,8 +33,6 @@ replace go.opentelemetry.io/collector/pdata => ../pdata
 
 replace go.opentelemetry.io/collector/semconv => ../semconv
 
-replace go.opentelemetry.io/collector/processor/batchprocessor => ../processor/batchprocessor
-
 replace go.opentelemetry.io/collector/extension/zpagesextension => ../extension/zpagesextension
 
 replace go.opentelemetry.io/collector/component => ../component

--- a/exporter/loggingexporter/go.mod
+++ b/exporter/loggingexporter/go.mod
@@ -57,5 +57,3 @@ replace go.opentelemetry.io/collector/pdata => ../../pdata
 replace go.opentelemetry.io/collector/semconv => ../../semconv
 
 replace go.opentelemetry.io/collector/extension/zpagesextension => ../../extension/zpagesextension
-
-replace go.opentelemetry.io/collector/processor/batchprocessor => ../../processor/batchprocessor

--- a/exporter/otlpexporter/go.mod
+++ b/exporter/otlpexporter/go.mod
@@ -61,6 +61,4 @@ replace go.opentelemetry.io/collector/semconv => ../../semconv
 
 replace go.opentelemetry.io/collector/extension/zpagesextension => ../../extension/zpagesextension
 
-replace go.opentelemetry.io/collector/processor/batchprocessor => ../../processor/batchprocessor
-
 replace go.opentelemetry.io/collector/consumer => ../../consumer

--- a/exporter/otlphttpexporter/go.mod
+++ b/exporter/otlphttpexporter/go.mod
@@ -67,6 +67,4 @@ replace go.opentelemetry.io/collector/semconv => ../../semconv
 
 replace go.opentelemetry.io/collector/extension/zpagesextension => ../../extension/zpagesextension
 
-replace go.opentelemetry.io/collector/processor/batchprocessor => ../../processor/batchprocessor
-
 replace go.opentelemetry.io/collector/consumer => ../../consumer

--- a/extension/ballastextension/go.mod
+++ b/extension/ballastextension/go.mod
@@ -58,6 +58,4 @@ replace go.opentelemetry.io/collector/semconv => ../../semconv
 
 replace go.opentelemetry.io/collector/extension/zpagesextension => ../zpagesextension
 
-replace go.opentelemetry.io/collector/processor/batchprocessor => ../../processor/batchprocessor
-
 replace go.opentelemetry.io/collector/consumer => ../../consumer

--- a/extension/zpagesextension/go.mod
+++ b/extension/zpagesextension/go.mod
@@ -55,6 +55,4 @@ replace go.opentelemetry.io/collector/pdata => ../../pdata
 
 replace go.opentelemetry.io/collector/semconv => ../../semconv
 
-replace go.opentelemetry.io/collector/processor/batchprocessor => ../../processor/batchprocessor
-
 replace go.opentelemetry.io/collector/consumer => ../../consumer

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,6 @@ require (
 	go.opentelemetry.io/collector/extension/zpagesextension v0.67.0
 	go.opentelemetry.io/collector/featuregate v0.67.0
 	go.opentelemetry.io/collector/pdata v1.0.0-rc1
-	go.opentelemetry.io/collector/processor/batchprocessor v0.67.0
 	go.opentelemetry.io/collector/semconv v0.67.0
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.36.4
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.36.4
@@ -95,8 +94,6 @@ replace go.opentelemetry.io/collector/semconv => ./semconv
 replace go.opentelemetry.io/collector/pdata => ./pdata
 
 replace go.opentelemetry.io/collector/extension/zpagesextension => ./extension/zpagesextension
-
-replace go.opentelemetry.io/collector/processor/batchprocessor => ./processor/batchprocessor
 
 retract (
 	v0.57.1 // Release failed, use v0.57.2

--- a/processor/batchprocessor/metrics.go
+++ b/processor/batchprocessor/metrics.go
@@ -55,8 +55,16 @@ const (
 	triggerBatchSize
 )
 
+func init() {
+	// TODO: Find a way to handle the error.
+	_ = view.Register(metricViews()...)
+}
+
+// Deprecated: [v0.68.0] will be removed soon, views are initialize in init.
+var MetricViews = metricViews
+
 // MetricViews returns the metrics views related to batching
-func MetricViews() []*view.View {
+func metricViews() []*view.View {
 	processorTagKeys := []tag.Key{processorTagKey}
 
 	countBatchSizeTriggerSendView := &view.View{
@@ -101,6 +109,7 @@ func MetricViews() []*view.View {
 	}
 }
 
+// Deprecated: [v0.68.0] will be removed soon, views are initialize in the service for the moment until a generic solution is provided.
 func OtelMetricsViews() ([]otelview.View, error) {
 	var views []otelview.View
 	var err error

--- a/processor/memorylimiterprocessor/go.mod
+++ b/processor/memorylimiterprocessor/go.mod
@@ -57,8 +57,6 @@ replace go.opentelemetry.io/collector/pdata => ../../pdata
 
 replace go.opentelemetry.io/collector/semconv => ../../semconv
 
-replace go.opentelemetry.io/collector/processor/batchprocessor => ../batchprocessor
-
 replace go.opentelemetry.io/collector/extension/zpagesextension => ../../extension/zpagesextension
 
 replace go.opentelemetry.io/collector/consumer => ../../consumer

--- a/receiver/otlpreceiver/go.mod
+++ b/receiver/otlpreceiver/go.mod
@@ -81,6 +81,4 @@ replace go.opentelemetry.io/collector/semconv => ../../semconv
 
 replace go.opentelemetry.io/collector/extension/zpagesextension => ../../extension/zpagesextension
 
-replace go.opentelemetry.io/collector/processor/batchprocessor => ../../processor/batchprocessor
-
 replace go.opentelemetry.io/collector/consumer => ../../consumer


### PR DESCRIPTION
Reason is to make sure we don't expose yet a hack pattern to register Otel views until a proper design is in place and to move the OC views registration to the same model as contrib. Also this cleans dependencies between core modules.