### PR TITLE
[memory limiter processor] Refactor internal structure to improve testability

### DIFF
--- a/cmd/otelcorecol/go.mod
+++ b/cmd/otelcorecol/go.mod
@@ -59,6 +59,7 @@ require (
 	github.com/shirou/gopsutil/v3 v3.22.10 // indirect
 	github.com/spf13/cobra v1.6.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/tilinna/clock v1.1.0 // indirect
 	github.com/tklauser/go-sysconf v0.3.11 // indirect
 	github.com/tklauser/numcpus v0.6.0 // indirect
 	github.com/yusufpapurcu/wmi v1.2.2 // indirect

--- a/cmd/otelcorecol/go.sum
+++ b/cmd/otelcorecol/go.sum
@@ -388,6 +388,7 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
@@ -400,6 +401,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stvp/go-udp-testing v0.0.0-20201019212854-469649b16807/go.mod h1:7jxmlfBCDBXRzr0eAQJ48XC1hBu1np4CS5+cHEYfwpc=
+github.com/tilinna/clock v1.1.0 h1:6IQQQCo6KoBxVudv6gwtY8o4eDfhHo8ojA5dP0MfhSs=
+github.com/tilinna/clock v1.1.0/go.mod h1:ZsP7BcY7sEEz7ktc0IVy8Us6boDrK8VradlKRUGfOao=
 github.com/tklauser/go-sysconf v0.3.10/go.mod h1:C8XykCvCb+Gn0oNCWPIlcb0RuglQTYaQ2hGm7jmxEFk=
 github.com/tklauser/go-sysconf v0.3.11 h1:89WgdJhk5SNwJfu+GKyYveZ4IaJ7xAkecBo+KdJV0CM=
 github.com/tklauser/go-sysconf v0.3.11/go.mod h1:GqXfhXY3kiPa0nAXPDIQIWzJbMCB7AmcWpGR8lSZfqI=

--- a/processor/memorylimiterprocessor/factory.go
+++ b/processor/memorylimiterprocessor/factory.go
@@ -62,8 +62,8 @@ func (f *factory) createTracesProcessor(
 	set processor.CreateSettings,
 	cfg component.Config,
 	nextConsumer consumer.Traces,
-) (processor.Traces, error) {
-	memLimiter, err := f.getMemoryLimiter(set, cfg)
+) (component.TracesProcessor, error) {
+	memLimiter, err := f.getMemoryLimiter(ctx, set, cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -79,8 +79,8 @@ func (f *factory) createMetricsProcessor(
 	set processor.CreateSettings,
 	cfg component.Config,
 	nextConsumer consumer.Metrics,
-) (processor.Metrics, error) {
-	memLimiter, err := f.getMemoryLimiter(set, cfg)
+) (component.MetricsProcessor, error) {
+	memLimiter, err := f.getMemoryLimiter(ctx, set, cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -96,8 +96,8 @@ func (f *factory) createLogsProcessor(
 	set processor.CreateSettings,
 	cfg component.Config,
 	nextConsumer consumer.Logs,
-) (processor.Logs, error) {
-	memLimiter, err := f.getMemoryLimiter(set, cfg)
+) (component.LogsProcessor, error) {
+	memLimiter, err := f.getMemoryLimiter(ctx, set, cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -110,7 +110,7 @@ func (f *factory) createLogsProcessor(
 
 // getMemoryLimiter checks if we have a cached memoryLimiter with a specific config,
 // otherwise initialize and add one to the store.
-func (f *factory) getMemoryLimiter(set processor.CreateSettings, cfg component.Config) (*memoryLimiter, error) {
+func (f *factory) getMemoryLimiter(ctx context.Context, set component.ProcessorCreateSettings, cfg component.Config) (*memoryLimiter, error) {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
@@ -118,7 +118,11 @@ func (f *factory) getMemoryLimiter(set processor.CreateSettings, cfg component.C
 		return memLimiter, nil
 	}
 
-	memLimiter, err := newMemoryLimiter(set, cfg.(*Config))
+	memLimiter, err := newMemoryLimiter(
+		ctx,
+		set,
+		cfg.(*Config),
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/processor/memorylimiterprocessor/factory.go
+++ b/processor/memorylimiterprocessor/factory.go
@@ -62,7 +62,7 @@ func (f *factory) createTracesProcessor(
 	set processor.CreateSettings,
 	cfg component.Config,
 	nextConsumer consumer.Traces,
-) (component.TracesProcessor, error) {
+) (processor.Traces, error) {
 	memLimiter, err := f.getMemoryLimiter(ctx, set, cfg)
 	if err != nil {
 		return nil, err
@@ -79,7 +79,7 @@ func (f *factory) createMetricsProcessor(
 	set processor.CreateSettings,
 	cfg component.Config,
 	nextConsumer consumer.Metrics,
-) (component.MetricsProcessor, error) {
+) (processor.Metrics, error) {
 	memLimiter, err := f.getMemoryLimiter(ctx, set, cfg)
 	if err != nil {
 		return nil, err
@@ -96,7 +96,7 @@ func (f *factory) createLogsProcessor(
 	set processor.CreateSettings,
 	cfg component.Config,
 	nextConsumer consumer.Logs,
-) (component.LogsProcessor, error) {
+) (processor.Logs, error) {
 	memLimiter, err := f.getMemoryLimiter(ctx, set, cfg)
 	if err != nil {
 		return nil, err
@@ -110,7 +110,7 @@ func (f *factory) createLogsProcessor(
 
 // getMemoryLimiter checks if we have a cached memoryLimiter with a specific config,
 // otherwise initialize and add one to the store.
-func (f *factory) getMemoryLimiter(ctx context.Context, set component.ProcessorCreateSettings, cfg component.Config) (*memoryLimiter, error) {
+func (f *factory) getMemoryLimiter(ctx context.Context, set processor.CreateSettings, cfg component.Config) (*memoryLimiter, error) {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 

--- a/processor/memorylimiterprocessor/factory_test.go
+++ b/processor/memorylimiterprocessor/factory_test.go
@@ -24,6 +24,7 @@ import (
 
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/processor/processortest"
 )
 
 func TestCreateDefaultConfig(t *testing.T) {
@@ -51,19 +52,19 @@ func TestCreateProcessor(t *testing.T) {
 	pCfg.MemorySpikeLimitMiB = 1907
 	pCfg.CheckInterval = 100 * time.Millisecond
 
-	tp, err := factory.CreateTracesProcessor(context.Background(), componenttest.NewNopProcessorCreateSettings(), cfg, consumertest.NewNop())
+	tp, err := factory.CreateTracesProcessor(context.Background(), processortest.NewNopCreateSettings(), cfg, consumertest.NewNop())
 	assert.NoError(t, err)
 	assert.NotNil(t, tp)
 
 	assert.NoError(t, tp.Shutdown(context.Background()))
 	assert.NoError(t, tp.Start(context.Background(), componenttest.NewNopHost()))
 
-	mp, err := factory.CreateMetricsProcessor(context.Background(), componenttest.NewNopProcessorCreateSettings(), cfg, consumertest.NewNop())
+	mp, err := factory.CreateMetricsProcessor(context.Background(), processortest.NewNopCreateSettings(), cfg, consumertest.NewNop())
 	assert.NoError(t, err)
 	assert.NotNil(t, mp)
 	assert.NoError(t, mp.Start(context.Background(), componenttest.NewNopHost()))
 
-	lp, err := factory.CreateLogsProcessor(context.Background(), componenttest.NewNopProcessorCreateSettings(), cfg, consumertest.NewNop())
+	lp, err := factory.CreateLogsProcessor(context.Background(), processortest.NewNopCreateSettings(), cfg, consumertest.NewNop())
 	assert.NoError(t, err)
 	assert.NotNil(t, lp)
 	assert.NoError(t, lp.Start(context.Background(), componenttest.NewNopHost()))

--- a/processor/memorylimiterprocessor/factory_test.go
+++ b/processor/memorylimiterprocessor/factory_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/processor/processortest"
@@ -42,9 +43,7 @@ func TestCreateProcessor(t *testing.T) {
 
 	cfg := factory.CreateDefaultConfig()
 
-	if conf, ok := cfg.(interface{ Validate() error }); ok {
-		assert.Error(t, conf.Validate(), "Must error with default config")
-	}
+	assert.Error(t, component.ValidateConfig(cfg), "Must error with default config")
 
 	// Create processor with a valid config.
 	pCfg := cfg.(*Config)

--- a/processor/memorylimiterprocessor/go.mod
+++ b/processor/memorylimiterprocessor/go.mod
@@ -4,6 +4,7 @@ go 1.18
 
 require (
 	github.com/stretchr/testify v1.8.1
+	github.com/tilinna/clock v1.1.0
 	go.opentelemetry.io/collector v0.67.0
 	go.opentelemetry.io/collector/component v0.67.0
 	go.opentelemetry.io/collector/confmap v0.67.0
@@ -14,6 +15,7 @@ require (
 )
 
 require (
+	github.com/benbjohnson/clock v1.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
@@ -29,6 +31,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/shirou/gopsutil/v3 v3.22.10 // indirect
+	github.com/stretchr/objx v0.5.0 // indirect
 	github.com/yusufpapurcu/wmi v1.2.2 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/collector/featuregate v0.67.0 // indirect

--- a/processor/memorylimiterprocessor/go.sum
+++ b/processor/memorylimiterprocessor/go.sum
@@ -24,6 +24,7 @@ github.com/aws/aws-sdk-go-v2/service/sso v1.4.2/go.mod h1:NBvT9R1MEF+Ud6ApJKM0G+
 github.com/aws/aws-sdk-go-v2/service/sts v1.7.2/go.mod h1:8EzeIqfWt2wWT4rJVu3f21TfrhJ8AEMzVybRNSb/b4g=
 github.com/aws/smithy-go v1.8.0/go.mod h1:SObp3lf9smib00L/v3U2eAKG8FyQ7iLrJnQiAmR5n+E=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
+github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -267,6 +268,7 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
@@ -277,6 +279,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/tilinna/clock v1.1.0 h1:6IQQQCo6KoBxVudv6gwtY8o4eDfhHo8ojA5dP0MfhSs=
+github.com/tilinna/clock v1.1.0/go.mod h1:ZsP7BcY7sEEz7ktc0IVy8Us6boDrK8VradlKRUGfOao=
 github.com/tklauser/go-sysconf v0.3.10/go.mod h1:C8XykCvCb+Gn0oNCWPIlcb0RuglQTYaQ2hGm7jmxEFk=
 github.com/tklauser/numcpus v0.4.0/go.mod h1:1+UI3pD8NW14VMwdgJNJ1ESk2UnwhAnz5hMwiKKqXCQ=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/processor/memorylimiterprocessor/internal/memory/check.go
+++ b/processor/memorylimiterprocessor/internal/memory/check.go
@@ -1,0 +1,73 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package memory
+
+import (
+	"go.opentelemetry.io/collector/internal/iruntime"
+)
+
+const (
+	mibBytes = 1024 * 1024
+)
+
+// Checker is used to compare the limits against the current reported
+// runtime allocation size.
+type Checker struct {
+	allocLimit uint64
+	spikeLimit uint64
+}
+
+// TotalFunc defines a means of loading current memory used
+// that can be overridden within tests
+type TotalFunc func() (uint64, error)
+
+func (fn TotalFunc) Load() (uint64, error) {
+	if fn != nil {
+		return fn()
+	}
+	return iruntime.TotalMemory()
+}
+
+func (fn TotalFunc) NewMemChecker(limitMiB uint64, spikeMiB uint64, limitPercentage uint64, spikePercentage uint64) (*Checker, error) {
+	if hardLimit := limitMiB * mibBytes; hardLimit != 0 {
+		spikeLimit := spikeMiB * mibBytes
+		if spikeLimit == 0 {
+			spikeLimit = hardLimit / 5
+		}
+		return &Checker{
+			allocLimit: hardLimit,
+			spikeLimit: spikeLimit,
+		}, nil
+	}
+	totalMem, err := fn.Load()
+	if err != nil {
+		return nil, err
+	}
+	return &Checker{
+		allocLimit: limitPercentage * totalMem / 100,
+		spikeLimit: spikePercentage * totalMem / 100,
+	}, nil
+}
+
+func (c Checker) AboveSoftLimit(ms *Stats) bool {
+	return ms.Alloc >= c.allocLimit-c.spikeLimit
+}
+
+func (c Checker) AboveHardLimit(ms *Stats) bool {
+	return ms.Alloc >= c.allocLimit
+}
+
+func (c Checker) SoftLimitMiB() uint64 { return c.spikeLimit }
+func (c Checker) HardLimitMiB() uint64 { return c.allocLimit }

--- a/processor/memorylimiterprocessor/internal/memory/check.go
+++ b/processor/memorylimiterprocessor/internal/memory/check.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package memory
+package memory // import "go.opentelemetry.io/collector/processor/memorylimiterprocessor/internal/memory"
 
 import (
 	"go.opentelemetry.io/collector/internal/iruntime"

--- a/processor/memorylimiterprocessor/internal/memory/check_test.go
+++ b/processor/memorylimiterprocessor/internal/memory/check_test.go
@@ -1,0 +1,253 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package memory
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadTotal(t *testing.T) {
+	t.Parallel()
+
+	errFailed := errors.New("failed")
+
+	for _, tc := range []struct {
+		name string
+		fn   TotalFunc
+		val  uint64
+		err  error
+	}{
+		{
+			name: "default invocation",
+		},
+		{
+			name: "check value without error",
+			fn: func() (uint64, error) {
+				return 100, nil
+			},
+			val: 100,
+			err: nil,
+		},
+		{
+			name: "check value with error",
+			fn: func() (uint64, error) {
+				return 0, errFailed
+			},
+			val: 0,
+			err: errFailed,
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			total, err := tc.fn.Load()
+			if tc.fn == nil {
+				// exiting here due to allow coverage of default
+				// method but since it can vary to os / arch
+				// the values are not validated
+				return
+			}
+			assert.Equal(t, tc.val, total, "Must match expected value")
+			assert.ErrorIs(t, err, tc.err, "Must match the expected error")
+		})
+	}
+}
+
+func TestMemoryChecker(t *testing.T) {
+	t.Parallel()
+
+	errFailed := errors.New("failed")
+
+	for _, tc := range []struct {
+		name  string
+		total TotalFunc
+		usage StatsFunc
+
+		limitMiB     uint64
+		spikeMiB     uint64
+		limitPercent uint64
+		spikePercent uint64
+
+		limiter *Checker
+
+		aboveSoft bool
+		aboveHard bool
+		err       error
+	}{
+		{
+			name: "no limits are breached using fixed limits",
+			total: func() (uint64, error) {
+				return 100 * mibBytes, nil
+			},
+			usage: func(s *Stats) {
+				s.Alloc = 10 * mibBytes
+			},
+			limitMiB: 20,
+			spikeMiB: 10,
+
+			limiter: &Checker{
+				allocLimit: 20 * mibBytes,
+				spikeLimit: 10 * mibBytes,
+			},
+
+			aboveSoft: false,
+			aboveHard: false,
+		},
+		{
+			name: "no limits are breached using fixed limits no spike defined",
+			total: func() (uint64, error) {
+				return 100 * mibBytes, nil
+			},
+			usage: func(s *Stats) {
+				s.Alloc = 10 * mibBytes
+			},
+			limitMiB: 20,
+
+			limiter: &Checker{
+				allocLimit: 20 * mibBytes,
+				spikeLimit: 20 * mibBytes / 5,
+			},
+
+			aboveSoft: false,
+			aboveHard: false,
+		},
+		{
+			name: "limits are breached using fixed limits",
+			total: func() (uint64, error) {
+				return 100 * mibBytes, nil
+			},
+			usage: func(s *Stats) {
+				s.Alloc = 30 * mibBytes
+			},
+			limitMiB: 20,
+			spikeMiB: 10,
+
+			limiter: &Checker{
+				allocLimit: 20 * mibBytes,
+				spikeLimit: 10 * mibBytes,
+			},
+
+			aboveSoft: true,
+			aboveHard: true,
+		},
+		{
+			name: "soft limits are breached using fixed limits",
+			total: func() (uint64, error) {
+				return 100 * mibBytes, nil
+			},
+			usage: func(s *Stats) {
+				s.Alloc = 20 * mibBytes
+			},
+			limitMiB: 20,
+			spikeMiB: 10,
+
+			limiter: &Checker{
+				allocLimit: 20 * mibBytes,
+				spikeLimit: 10 * mibBytes,
+			},
+
+			aboveSoft: true,
+			aboveHard: false,
+		},
+		{
+			name: "no limits are breached using percentage limits",
+			total: func() (uint64, error) {
+				return 100 * mibBytes, nil
+			},
+			usage: func(s *Stats) {
+				s.Alloc = 10 * mibBytes
+			},
+			limitPercent: 80,
+			spikePercent: 60,
+
+			limiter: &Checker{
+				allocLimit: 100 * mibBytes * 80 / 100,
+				spikeLimit: 100 * mibBytes * 60 / 100,
+			},
+
+			aboveSoft: false,
+			aboveHard: false,
+		},
+		{
+			name: "soft limits are breached using percentage limits",
+			total: func() (uint64, error) {
+				return 100 * mibBytes, nil
+			},
+			usage: func(s *Stats) {
+				s.Alloc = 62 * mibBytes
+			},
+			limitPercent: 80,
+			spikePercent: 60,
+
+			limiter: &Checker{
+				allocLimit: 100 * mibBytes * 80 / 100,
+				spikeLimit: 100 * mibBytes * 60 / 100,
+			},
+
+			aboveSoft: true,
+			aboveHard: false,
+		},
+		{
+			name: "both limits are breached using percentage limits",
+			total: func() (uint64, error) {
+				return 100 * mibBytes, nil
+			},
+			usage: func(s *Stats) {
+				s.Alloc = 88 * mibBytes
+			},
+			limitPercent: 80,
+			spikePercent: 60,
+
+			limiter: &Checker{
+				allocLimit: 100 * mibBytes * 80 / 100,
+				spikeLimit: 100 * mibBytes * 60 / 100,
+			},
+
+			aboveSoft: true,
+			aboveHard: true,
+		},
+		{
+			name: "total function errors",
+			total: func() (uint64, error) {
+				return 0, errFailed
+			},
+			err: errFailed,
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			check, err := tc.total.NewMemChecker(
+				tc.limitMiB,
+				tc.spikeMiB,
+				tc.limitPercent,
+				tc.spikePercent,
+			)
+			require.ErrorIs(t, err, tc.err)
+			if tc.err != nil {
+				return
+			}
+			assert.Equal(t, tc.limiter.SoftLimitMiB(), check.SoftLimitMiB())
+			assert.Equal(t, tc.limiter.HardLimitMiB(), check.HardLimitMiB())
+
+			s, _ := tc.usage.Load(1000)
+
+			assert.Equal(t, tc.aboveSoft, check.AboveSoftLimit(s))
+			assert.Equal(t, tc.aboveHard, check.AboveHardLimit(s))
+		})
+	}
+}

--- a/processor/memorylimiterprocessor/internal/memory/gc.go
+++ b/processor/memorylimiterprocessor/internal/memory/gc.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package memory
+package memory // import "go.opentelemetry.io/collector/processor/memorylimiterprocessor/internal/memory"
 
 import "runtime"
 

--- a/processor/memorylimiterprocessor/internal/memory/gc.go
+++ b/processor/memorylimiterprocessor/internal/memory/gc.go
@@ -1,0 +1,32 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package memory
+
+import "runtime"
+
+// GCFunc allows for the function
+// to be swapped out during tests
+// to validate expectations.
+type GCFunc func()
+
+// Do will use the defined function
+// otherwise, it will default to `runtime.GC`
+func (gc GCFunc) Do() {
+	if gc != nil {
+		gc()
+	} else {
+		runtime.GC()
+	}
+}

--- a/processor/memorylimiterprocessor/internal/memory/gc_test.go
+++ b/processor/memorylimiterprocessor/internal/memory/gc_test.go
@@ -1,0 +1,44 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package memory
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGCFunc(t *testing.T) {
+	t.Parallel()
+
+	called := false
+
+	for _, tc := range []struct {
+		name string
+		fn   GCFunc
+	}{
+		{name: "default", fn: nil},
+		{name: "override", fn: func() {
+			called = true
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.NotPanics(t, func() {
+				tc.fn.Do()
+			}, "Must not panic running GC function")
+		})
+	}
+	assert.True(t, called, "Override function must have been called")
+}

--- a/processor/memorylimiterprocessor/internal/memory/memory.go
+++ b/processor/memorylimiterprocessor/internal/memory/memory.go
@@ -1,0 +1,43 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package memory
+
+import (
+	"runtime"
+)
+
+type Stats = runtime.MemStats
+
+// StatsFunc defines a means of loading the current memory stats
+// that can be overridden within tests.
+type StatsFunc func(*Stats)
+
+func (fn StatsFunc) Load(ballastSize uint64) (*Stats, bool) {
+	ms := new(Stats)
+	fn.Update(ms)
+	mismatched := ms.Alloc < ballastSize
+	if ms.Alloc >= ballastSize {
+		ms.Alloc -= ballastSize
+	}
+	return ms, mismatched
+}
+
+func (fn StatsFunc) Update(ms *Stats) {
+	if fn != nil {
+		fn(ms)
+	} else {
+		runtime.ReadMemStats(ms)
+	}
+}

--- a/processor/memorylimiterprocessor/internal/memory/memory.go
+++ b/processor/memorylimiterprocessor/internal/memory/memory.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package memory
+package memory // import "go.opentelemetry.io/collector/processor/memorylimiterprocessor/internal/memory"
 
 import (
 	"runtime"

--- a/processor/memorylimiterprocessor/internal/memory/memory_test.go
+++ b/processor/memorylimiterprocessor/internal/memory/memory_test.go
@@ -1,0 +1,74 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package memory
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLoadStats(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		fn   StatsFunc
+
+		ballastSize uint64
+		expect      *Stats
+		mismatched  bool
+	}{
+		{
+			name:        "testing default function",
+			ballastSize: 100,
+		},
+		{
+			name: "testing expected stats",
+			fn: func(s *Stats) {
+				s.Alloc = 1000
+			},
+			ballastSize: 300,
+			expect: &Stats{
+				Alloc: 700,
+			},
+			mismatched: false,
+		},
+		{
+			name: "mismatched ballast size",
+			fn: func(s *Stats) {
+				s.Alloc = 1000
+			},
+			ballastSize: 2000,
+			expect: &Stats{
+				Alloc: 1000,
+			},
+			mismatched: true,
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			s, mismatched := tc.fn.Load(tc.ballastSize)
+			if tc.fn == nil {
+				assert.NotNil(t, s, "Must be able to load stats from runtime")
+				return
+			}
+			assert.EqualValues(t, tc.expect, s, "Must match the expected stat value")
+			assert.Equal(t, tc.mismatched, mismatched, "Must match the expected mismatch value")
+		})
+	}
+}

--- a/processor/memorylimiterprocessor/internal/memorytest/memory.go
+++ b/processor/memorylimiterprocessor/internal/memorytest/memory.go
@@ -1,0 +1,146 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package memorytest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+
+	"go.opentelemetry.io/collector/processor/memorylimiterprocessor/internal/memory"
+)
+
+// MockMemory can be used to set expectations within tests
+type MockMemory interface {
+	Stats(*memory.Stats)
+	Total() (uint64, error)
+	GC()
+}
+
+type mockMemory struct {
+	mock.Mock
+}
+
+// MethodOptions allows to add expectations
+// to the method being called.
+type MethodOption func(*mock.Call)
+
+// MockOption allows to set expectations for the
+// configured MockMemory
+type MockOption func(*mockMemory)
+
+// WithMethodCalled is used to define how many times
+// the configured method is expected to be called.
+func WithMethodCalled(times int) MethodOption {
+	return func(c *mock.Call) {
+		if times < 1 {
+			c.Maybe()
+			times = 0
+		}
+		c.Times(times)
+	}
+}
+
+// AsStatsFunc is a convenience function to convert the mocked
+// memory as the memory.StatsFunc since casting can be problematic
+func AsStatsFunc(mm MockMemory) memory.StatsFunc {
+	return mm.Stats
+}
+
+// AsTotalFunc is a convenience function to convert the mocked
+// memory as the memory.TotalFunc since casting can be problematic
+func AsTotalFunc(mm MockMemory) memory.TotalFunc {
+	return mm.Total
+}
+
+// AsGCFunc is a convenience function to convert the mocked
+// memory as the memory.GCFunc since casting can be problematic
+func AsGCFunc(mm MockMemory) memory.GCFunc {
+	return mm.GC
+}
+
+func (mm *mockMemory) Stats(s *memory.Stats) {
+	args := mm.Called()
+	(*s) = *(args.Get(0).(*memory.Stats))
+
+}
+
+func (mm *mockMemory) Total() (uint64, error) {
+	args := mm.Called()
+	return args.Get(0).(uint64), args.Error(1)
+}
+
+func (mm *mockMemory) GC() {
+	mm.Called()
+}
+
+// WithAssertMockedStats defines what `MockMemory.Stats()` will return.
+func WithAssertMockedStats(updated *memory.Stats, opts ...MethodOption) MockOption {
+	return func(mm *mockMemory) {
+		call := mm.On("Stats").Return(updated)
+		for _, opt := range opts {
+			opt(call)
+		}
+	}
+}
+
+// WithAssertMockedTotal defines what `MockMemory.Total()` will return.
+func WithAssertMockedTotal(size uint64, err error, opts ...MethodOption) MockOption {
+	return func(mm *mockMemory) {
+		call := mm.On("Total").Return(size, err)
+		for _, opt := range opts {
+			opt(call)
+		}
+	}
+}
+
+// WithAssertMockedGC defines what `MockMemory.GC()` will return.
+func WithAssertMockedGC(opts ...MethodOption) MockOption {
+	return func(mm *mockMemory) {
+		call := mm.On("GC").Return()
+		for _, opt := range opts {
+			opt(call)
+		}
+	}
+}
+
+// NewMockMemory returns a MockMemory that can be configured to return
+// values as defined by the options to be used within tests.
+//
+// An example of configuration is:
+//
+//	memorytest.NewMockMemory(
+//		t,
+//		memorytest.WithAssertMockedTotal(1200, nil, memorytest.WithMethodCalled(1)),
+//		memorytest.WithAssertMockedGC(memorytest.WithMethodCalled(0)),
+//		memorytest.WithAssertMockedStats(&memory.Stats{Alloc:40}, memorytest.WithMethodCalled(6)),
+//	)
+//
+// The above configuration will return a `memorytest.MockMemory` that is expecting
+// `MockMemory.Total` is to be called once with the values of `(1200, nil)`
+// `MockMemory.Stats` is to be called six times with the value of `&memory.Stats{Alloc:40}`
+// If the associated `*testing.T` does not meat the expectations set, the test will fail on cleanup.
+func NewMockMemory(tb testing.TB, opts ...MockOption) MockMemory {
+	tb.Helper()
+
+	m := &mockMemory{}
+	for _, opt := range opts {
+		opt(m)
+	}
+	tb.Cleanup(func() {
+		m.AssertExpectations(tb)
+	})
+	return m
+}

--- a/processor/memorylimiterprocessor/internal/memorytest/memory.go
+++ b/processor/memorylimiterprocessor/internal/memorytest/memory.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package memorytest
+package memorytest // import "go.opentelemetry.io/collector/processor/memorylimiterprocessor/internal/memorytest"
 
 import (
 	"testing"

--- a/processor/memorylimiterprocessor/internal/memorytest/memory_test.go
+++ b/processor/memorylimiterprocessor/internal/memorytest/memory_test.go
@@ -1,0 +1,96 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package memorytest
+
+import (
+	"errors"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"go.opentelemetry.io/collector/processor/memorylimiterprocessor/internal/memory"
+)
+
+func TestNewMockMemory(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name       string
+		opts       []MockOption
+		invocation func(tb testing.TB, mm MockMemory)
+	}{
+		{
+			name: "no method calls",
+			opts: []MockOption{
+				WithAssertMockedStats(nil, WithMethodCalled(0)),
+				WithAssertMockedTotal(0, nil, WithMethodCalled(0)),
+			},
+			invocation: func(tb testing.TB, mm MockMemory) {},
+		},
+		{
+			name: "expects total to be called",
+			opts: []MockOption{
+				WithAssertMockedTotal(100, nil, WithMethodCalled(1)),
+			},
+			invocation: func(tb testing.TB, mm MockMemory) {
+				v, err := AsTotalFunc(mm).Load()
+				assert.EqualValues(t, 100, v, "Must match the expected value")
+				assert.NoError(t, err, "Must not error")
+			},
+		},
+		{
+			name: "expects total func to fail",
+			opts: []MockOption{
+				WithAssertMockedTotal(0, errors.New("boom"), WithMethodCalled(1)),
+			},
+			invocation: func(tb testing.TB, mm MockMemory) {
+				v, err := AsTotalFunc(mm).Load()
+				assert.Zero(t, v, "Must return 0")
+				assert.Error(t, err, "Must return an error")
+			},
+		},
+		{
+			name: "expects stats to be called",
+			opts: []MockOption{
+				WithAssertMockedStats(&runtime.MemStats{Alloc: 1000}, WithMethodCalled(1)),
+			},
+			invocation: func(tb testing.TB, mm MockMemory) {
+				s, mismatched := AsStatsFunc(mm).Load(0)
+				assert.EqualValues(t, &memory.Stats{Alloc: 1000}, s, "Must match values")
+				assert.False(t, mismatched, "Must not be mismatched")
+			},
+		},
+		{
+			name: "expects GC to be called",
+			opts: []MockOption{
+				WithAssertMockedGC(WithMethodCalled(1)),
+			},
+			invocation: func(tb testing.TB, mm MockMemory) {
+				assert.NotPanics(tb, func() {
+					AsGCFunc(mm).Do()
+				}, "Must not panic during invocation")
+			},
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			mm := NewMockMemory(t, tc.opts...)
+			tc.invocation(t, mm)
+		})
+	}
+}

--- a/processor/memorylimiterprocessor/memorylimiter.go
+++ b/processor/memorylimiterprocessor/memorylimiter.go
@@ -28,6 +28,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.opentelemetry.io/collector/processor"
 	"go.opentelemetry.io/collector/processor/memorylimiterprocessor/internal/memory"
 )
 
@@ -70,7 +71,7 @@ type memoryLimiter struct {
 }
 
 // newMemoryLimiter returns a new memorylimiter processor.
-func newMemoryLimiter(ctx context.Context, set component.ProcessorCreateSettings, cfg *Config, opts ...func(*memorySettings)) (*memoryLimiter, error) {
+func newMemoryLimiter(ctx context.Context, set processor.CreateSettings, cfg *Config, opts ...func(*memorySettings)) (*memoryLimiter, error) {
 	memSettings := &memorySettings{}
 	for _, opt := range opts {
 		opt(memSettings)
@@ -117,7 +118,7 @@ func newMemoryLimiter(ctx context.Context, set component.ProcessorCreateSettings
 func (ml *memoryLimiter) start(ctx context.Context, host component.Host) error {
 	select {
 	case ml.sem <- struct{}{}:
-		// aquired Sem, start processor
+		// acquired Sem, start processor
 	default:
 		return nil
 	}
@@ -149,7 +150,7 @@ func (ml *memoryLimiter) start(ctx context.Context, host component.Host) error {
 func (ml *memoryLimiter) shutdown(context.Context) error {
 	select {
 	case <-ml.sem:
-		// aquired sem, shutdown processor
+		// acquired sem, shutdown processor
 	default:
 		return nil
 	}

--- a/processor/memorylimiterprocessor/observer.go
+++ b/processor/memorylimiterprocessor/observer.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package memorylimiterprocessor
+package memorylimiterprocessor // import "go.opentelemetry.io/collector/processor/memorylimiterprocessor"
 
 import (
 	"context"

--- a/processor/memorylimiterprocessor/observer.go
+++ b/processor/memorylimiterprocessor/observer.go
@@ -1,0 +1,143 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package memorylimiterprocessor
+
+import (
+	"context"
+	"runtime"
+	"time"
+
+	"github.com/tilinna/clock"
+	"go.uber.org/atomic"
+	"go.uber.org/zap"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/processor/memorylimiterprocessor/internal/memory"
+)
+
+const (
+	// minGCIntervalWhenSoftLimited is the min interval between forced GC when in soft limited mode.
+	// We don't want to do GCs too frequently since it is a CPU-heavy operation.
+	minGCIntervalWhenSoftLimited = 10 * time.Second
+
+	mibBytes = 1024 * 1024
+)
+
+// observer is used to check the current memory usage
+// ether compared against a static amount or the total
+// limit as defined against the ballast.
+type observer struct {
+	limits      memory.Checker
+	ballastSize uint64
+
+	stats memory.StatsFunc
+	gc    memory.GCFunc
+	clock clock.Clock
+
+	log *zap.Logger
+
+	exceeded           *atomic.Bool
+	reportedMismatched bool
+	lastGC             time.Time
+}
+
+type option func(o *observer)
+
+func withMemoryStats(fn memory.StatsFunc) option {
+	return func(o *observer) {
+		o.stats = fn
+	}
+}
+
+func withMemoryGC(fn memory.GCFunc) option {
+	return func(o *observer) {
+		o.gc = fn
+	}
+}
+
+func memstatToZapField(ms *runtime.MemStats) zap.Field {
+	return zap.Uint64("cur_mem_mib", ms.Alloc/mibBytes)
+}
+
+func newObserver(ctx context.Context, limits memory.Checker, log *zap.Logger, opts ...option) *observer {
+	o := &observer{
+		limits:   limits,
+		clock:    clock.FromContext(ctx),
+		log:      log,
+		exceeded: atomic.NewBool(false),
+		lastGC:   clock.FromContext(ctx).Now(),
+	}
+	for _, opt := range opts {
+		opt(o)
+	}
+	return o
+}
+
+func (o *observer) start(_ context.Context, host component.Host) error { //nolint:unparam // Implements to component.StartFunc
+	for _, extension := range host.GetExtensions() {
+		if ext, ok := extension.(interface{ GetBallastSize() uint64 }); ok {
+			o.ballastSize = ext.GetBallastSize()
+			break
+		}
+	}
+	return nil
+}
+
+// memoryExceeded reports true if current usage has exceeded the limits provided
+func (o *observer) memoryExceeded() bool {
+	return o.exceeded.Load()
+}
+
+func (o *observer) checkMemoryUsage() {
+	ms, mismatched := o.stats.Load(o.ballastSize)
+	if mismatched && !o.reportedMismatched {
+		o.reportedMismatched = true
+		o.log.Warn(`"size_mib" in ballast extension is likely incorrectly configured.`)
+	}
+
+	o.log.Debug("Current usage memory", memstatToZapField(ms))
+
+	var (
+		limitsExceeded = o.exceeded.Load()
+		hardExceeded   = o.limits.AboveHardLimit(ms)
+		softExceeded   = o.limits.AboveSoftLimit(ms)
+	)
+	switch {
+	case softExceeded, hardExceeded:
+		// Since GC is an expensive CPU operation, while we are above the soft limit
+		// but the lastGC time is less than the allowed GC interval
+		// then it is ignored until the interval has passed or the hard limit is reached.
+		if !hardExceeded && o.clock.Since(o.lastGC) < minGCIntervalWhenSoftLimited {
+			break
+		}
+		o.log.Warn("Memory usage has exceeded defined limits, forcing GC event",
+			memstatToZapField(ms),
+			zap.Bool("soft-breach", softExceeded),
+			zap.Bool("hard-breach", hardExceeded),
+		)
+		o.gc.Do()
+		o.lastGC = o.clock.Now()
+		o.stats.Update(ms)
+	default:
+		// In the event that neither limits are being breached currently
+		// after previously breaching, the pipeline(s) have returned to safe operation levels.
+		if limitsExceeded {
+			o.log.Info("Memory usage back within limits. Resuming normal operation.", memstatToZapField(ms))
+		}
+	}
+	// In the event that after a GC operation, the soft limit is still being breached
+	// then it should report that data should be dropped until it can recover.
+	o.exceeded.Store(o.limits.AboveSoftLimit(ms))
+}

--- a/processor/memorylimiterprocessor/observer_test.go
+++ b/processor/memorylimiterprocessor/observer_test.go
@@ -1,0 +1,194 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package memorylimiterprocessor
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tilinna/clock"
+	"go.uber.org/zap/zaptest"
+
+	"go.opentelemetry.io/collector/processor/memorylimiterprocessor/internal/memory"
+	"go.opentelemetry.io/collector/processor/memorylimiterprocessor/internal/memorytest"
+)
+
+func TestObserver(t *testing.T) {
+	t.Parallel()
+
+	type Event struct {
+		step     string
+		advance  time.Duration
+		exceeded bool
+	}
+
+	for _, tc := range []struct {
+		name       string
+		memoryOpts []memorytest.MockOption
+		conf       *Config
+
+		events []Event
+	}{
+		{
+			name: "simple system events under limits",
+			memoryOpts: []memorytest.MockOption{
+				memorytest.WithAssertMockedGC(
+					memorytest.WithMethodCalled(0),
+				),
+				memorytest.WithAssertMockedStats(
+					&memory.Stats{Alloc: 10 * mibBytes},
+					memorytest.WithMethodCalled(2),
+				),
+			},
+			conf: &Config{
+				MemoryLimitMiB:      80,
+				MemorySpikeLimitMiB: 60,
+			},
+			events: []Event{
+				{step: "started", advance: time.Second, exceeded: false},
+				{step: "under limits", advance: time.Second, exceeded: false},
+			},
+		},
+		{
+			name: "breaches soft limit",
+			memoryOpts: []memorytest.MockOption{
+				memorytest.WithAssertMockedGC(
+					memorytest.WithMethodCalled(1),
+				),
+				memorytest.WithAssertMockedStats(
+					&memory.Stats{Alloc: 30 * mibBytes},
+					memorytest.WithMethodCalled(1),
+				),
+				memorytest.WithAssertMockedStats(
+					&memory.Stats{Alloc: 600 * mibBytes},
+					memorytest.WithMethodCalled(2),
+				),
+				memorytest.WithAssertMockedStats(
+					&memory.Stats{Alloc: 30 * mibBytes},
+					memorytest.WithMethodCalled(1),
+				),
+			},
+			conf: &Config{
+				MemoryLimitMiB:      800,
+				MemorySpikeLimitMiB: 500,
+			},
+			events: []Event{
+				{step: "started", advance: time.Second, exceeded: false},
+				{step: "breaching soft", advance: time.Second, exceeded: true},
+				{step: "forced GC, recovered", advance: 2 * minGCIntervalWhenSoftLimited, exceeded: false},
+			},
+		},
+		{
+			name: "breaches soft limit and recovers",
+			memoryOpts: []memorytest.MockOption{
+				memorytest.WithAssertMockedGC(
+					memorytest.WithMethodCalled(0),
+				),
+				memorytest.WithAssertMockedStats(
+					&memory.Stats{Alloc: 300 * mibBytes},
+					memorytest.WithMethodCalled(1),
+				),
+				memorytest.WithAssertMockedStats(
+					&memory.Stats{Alloc: 1600 * mibBytes},
+					memorytest.WithMethodCalled(1),
+				),
+				memorytest.WithAssertMockedStats(
+					&memory.Stats{Alloc: 300 * mibBytes},
+					memorytest.WithMethodCalled(1),
+				),
+			},
+			conf: &Config{
+				MemoryLimitMiB:      2000,
+				MemorySpikeLimitMiB: 1500,
+			},
+			events: []Event{
+				{step: "started", advance: time.Second, exceeded: false},
+				{step: "breaching soft limit", advance: time.Second, exceeded: true},
+				{step: "recovered naturall", advance: time.Second, exceeded: false},
+			},
+		},
+		{
+			name: "breaches hard limit and recovers",
+			memoryOpts: []memorytest.MockOption{
+				memorytest.WithAssertMockedGC(
+					memorytest.WithMethodCalled(1),
+				),
+				memorytest.WithAssertMockedStats(
+					&memory.Stats{Alloc: 300 * mibBytes},
+					memorytest.WithMethodCalled(1),
+				),
+				memorytest.WithAssertMockedStats(
+					&memory.Stats{Alloc: 6000 * mibBytes},
+					memorytest.WithMethodCalled(2),
+				),
+				memorytest.WithAssertMockedStats(
+					&memory.Stats{Alloc: 300 * mibBytes},
+					memorytest.WithMethodCalled(1),
+				),
+			},
+			conf: &Config{
+				MemoryLimitMiB:      2000,
+				MemorySpikeLimitMiB: 1500,
+			},
+			events: []Event{
+				{step: "started", advance: time.Second, exceeded: false},
+				{step: "breached hard limit", advance: time.Second, exceeded: true},
+				{step: "recovered", advance: time.Second, exceeded: false},
+			},
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ctx, done := context.WithCancel(context.Background())
+			defer done()
+
+			clck := clock.NewMock(time.Unix(100, 0))
+
+			ctx = clock.Context(ctx, clck)
+
+			mem := memorytest.NewMockMemory(t, tc.memoryOpts...)
+
+			limiter, err := memorytest.AsTotalFunc(mem).NewMemChecker(
+				uint64(tc.conf.MemoryLimitMiB),
+				uint64(tc.conf.MemorySpikeLimitMiB),
+				uint64(tc.conf.MemoryLimitPercentage),
+				uint64(tc.conf.MemorySpikePercentage),
+			)
+			require.NoError(t, err, "Must not error when loading mem checker")
+
+			obs := newObserver(
+				ctx,
+				*limiter,
+				zaptest.NewLogger(t),
+				withMemoryStats(mem.Stats),
+				withMemoryGC(mem.GC),
+			)
+
+			assert.NoError(t, obs.start(ctx, &host{ballastSize: 0}))
+
+			for _, event := range tc.events {
+				clck.Add(event.advance)
+				obs.checkMemoryUsage()
+
+				assert.Equal(t, event.exceeded, obs.memoryExceeded(), event.step)
+			}
+			assert.Zero(t, clck.Len(), "Must have closed all timers and tickers")
+		})
+	}
+}


### PR DESCRIPTION
**Description:** 

This refactor includes several major improvements:
- chore: Mocked memory with expectations to allow for improved validation on tests
- bugfix: ensures the background task is correctly shutdown since `ticker.C` doesn't actually close
- enhancement:  moves configuration checking into `Config.Validate()` so it doesn't require the pipeline to start
- chore: using virtual time to validate scheduler and expected GC calls (soft vs hard)
- chore: split memory observer and memory limiter from each other to improve maintainability 

**Link to tracking Issue:** 
NA

**Testing:** 

I've updated the testing throughout.

**Documentation:** 

There is no user facing changes present by this, so none are required.