### PR TITLE
[receiver/otlpreceiver] Fix README

### DIFF
--- a/receiver/otlpreceiver/README.md
+++ b/receiver/otlpreceiver/README.md
@@ -38,7 +38,6 @@ Several helper files are leveraged to provide additional capabilities automatica
 
 - [gRPC settings](https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/configgrpc/README.md) including CORS
 - [TLS and mTLS settings](https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/configtls/README.md)
-- [Queuing, retry and timeout settings](https://github.com/open-telemetry/opentelemetry-collector/blob/main/exporter/exporterhelper/README.md)
 
 ## Writing with HTTP/JSON
 


### PR DESCRIPTION
otlpreceiver does not use exporterhelper queue and retry mechanism

**Description:** Fix misleading README pointing to a piece of code apparently not used in the receiver (the link is for exporters)

**Testing:** Verify code for trace of exporterhelper. Double checked the config object that doesn't contain anything related to queue or retries

