### PR TITLE
Move shutdown telemetry to Service

### DIFF
--- a/.chloggen/shutdowntel.yaml
+++ b/.chloggen/shutdowntel.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: service
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Shutdown internal telemetry with the Service (every time config changes).
+
+# One or more tracking issues or pull requests related to the change
+issues: [5564]

--- a/service/collector_test.go
+++ b/service/collector_test.go
@@ -29,8 +29,6 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
-	"go.opentelemetry.io/collector/featuregate"
-	"go.opentelemetry.io/collector/internal/obsreportconfig"
 )
 
 func TestStateString(t *testing.T) {
@@ -241,26 +239,6 @@ func TestCollectorStartInvalidConfig(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Error(t, col.Run(context.Background()))
-}
-
-func TestCollectorStartWithOpenCensusMetrics(t *testing.T) {
-	for _, tc := range ownMetricsTestCases() {
-		t.Run(tc.name, func(t *testing.T) {
-			testCollectorStartHelper(t, newColTelemetry(featuregate.NewRegistry()), tc)
-		})
-	}
-}
-
-func TestCollectorStartWithOpenTelemetryMetrics(t *testing.T) {
-	for _, tc := range ownMetricsTestCases() {
-		t.Run(tc.name, func(t *testing.T) {
-			registry := featuregate.NewRegistry()
-			obsreportconfig.RegisterInternalMetricFeatureGate(registry)
-			colTel := newColTelemetry(registry)
-			require.NoError(t, colTel.registry.Apply(map[string]bool{obsreportconfig.UseOtelForInternalMetricsfeatureGateID: true}))
-			testCollectorStartHelper(t, colTel, tc)
-		})
-	}
 }
 
 func TestCollectorStartWithTraceContextPropagation(t *testing.T) {

--- a/service/settings.go
+++ b/service/settings.go
@@ -18,6 +18,7 @@ import (
 	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/featuregate"
 )
 
 // settings holds configuration for building a new service.
@@ -38,7 +39,7 @@ type settings struct {
 	LoggingOptions []zap.Option
 
 	// For testing purpose only.
-	telemetry *telemetryInitializer
+	registry *featuregate.Registry
 }
 
 // CollectorSettings holds configuration for creating a new Collector.

--- a/service/telemetry_test.go
+++ b/service/telemetry_test.go
@@ -32,8 +32,10 @@ import (
 	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config/configtelemetry"
 	"go.opentelemetry.io/collector/featuregate"
 	"go.opentelemetry.io/collector/internal/obsreportconfig"
+	"go.opentelemetry.io/collector/internal/testutil"
 	semconv "go.opentelemetry.io/collector/semconv/v1.5.0"
 	"go.opentelemetry.io/collector/service/telemetry"
 )
@@ -152,9 +154,13 @@ func TestTelemetryInit(t *testing.T) {
 				Resource: map[string]*string{
 					semconv.AttributeServiceInstanceID: &testInstanceID,
 				},
+				Metrics: telemetry.MetricsConfig{
+					Level:   configtelemetry.LevelDetailed,
+					Address: testutil.GetAvailableLocalAddress(t),
+				},
 			}
 
-			err := tel.initOnce(buildInfo, zap.NewNop(), cfg)
+			err := tel.init(buildInfo, zap.NewNop(), cfg, make(chan error))
 			require.NoError(t, err)
 			defer func() {
 				require.NoError(t, tel.shutdown())


### PR DESCRIPTION
This removes any "private" dependency between Collector and Service and will allow to move collector to otelcol per the deprecation notice.

Updates https://github.com/open-telemetry/opentelemetry-collector/issues/5564