### PR TITLE
Removed error in service package readme, replaced ./otelcol build-info…

### DIFF
--- a/service/README.md
+++ b/service/README.md
@@ -101,7 +101,7 @@ key:
 Use the sub command build-info. Below is an example:
 
 ```bash
-   ./otelcorecol build-info
+   ./otelcorecol components
 ```
 Sample output:
 


### PR DESCRIPTION
Fixed error in readme of service module. Related to #6322 