### PR TITLE
[pdata] Add pcommon.Map.Equal method

### DIFF
--- a/.chloggen/map-equal.yaml
+++ b/.chloggen/map-equal.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: pdata
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add `pcommon.Map.Equal` method
+
+# One or more tracking issues or pull requests related to the change
+issues: [6688]


### PR DESCRIPTION
It's one of the measures towards deprecation of pcommon.Map.Sort

Updates https://github.com/open-telemetry/opentelemetry-collector/issues/6688

Performance of Value.Equal with a map isn't affected.

Benchmark results on:
goos: darwin
goarch: arm64

Before:

```
BenchmarkValueEqual-10    	 7666512	       153.0 ns/op	       0 B/op	       0 allocs/op
```

After:
```
BenchmarkValueEqual-10    	 7906196	       149.6 ns/op	       0 B/op	       0 allocs/op
```
