### PR TITLE
[chore] Fix builder integration test

### DIFF
--- a/.github/workflows/builder-integration-test.yaml
+++ b/.github/workflows/builder-integration-test.yaml
@@ -4,15 +4,11 @@ on:
   # on changes to the main branch touching the builder
   push:
     branches: [ main ]
-    paths:
-      - 'cmd/builder/**'
 
   # on PRs touching the builder
   pull_request:
     branches: [ main ]
-    paths:
-      - 'cmd/builder/**'
-  
+
   # once a day at 6:17 AM UTC
   schedule:
     - cron: '17 6 * * *'

--- a/cmd/builder/test/core.builder.yaml
+++ b/cmd/builder/test/core.builder.yaml
@@ -25,4 +25,5 @@ replaces:
   - go.opentelemetry.io/collector/extension/zpagesextension => ${WORKSPACE_DIR}/extension/zpagesextension
   - go.opentelemetry.io/collector/featuregate => ${WORKSPACE_DIR}/featuregate
   - go.opentelemetry.io/collector/processor/batchprocessor => ${WORKSPACE_DIR}/processor/batchprocessor
+  - go.opentelemetry.io/collector/receiver/otlpreceiver => ${WORKSPACE_DIR}/receiver/otlpreceiver
   - go.opentelemetry.io/collector/semconv => ${WORKSPACE_DIR}/semconv


### PR DESCRIPTION
https://github.com/open-telemetry/opentelemetry-collector/pull/6784 introduced a change to the interface of `sharedcomponent.GetOrAdd`, which affected the builder integration test. 

The integration test is affected because it does not replace every package, but rather only specific packages listed in `cmd/builder/test/core.builder.yaml`.

This PR also enables this integration test for all PRs as well as all merges to `main`. This will prevent similar issues from going unnoticed. Alternately, we could ensure that all local modules are replaced. However, this test takes ~75 seconds to run, which is far from being the bottleneck in our CI process.

The failing test can be reproduced locally by running `(cd ./cmd/builder && ./test/test.sh)`, and can also be see [here](https://github.com/open-telemetry/opentelemetry-collector/actions/runs/3689988584/jobs/6246534671). 