### PR TITLE
Add receiver.Builder to help with creating components form a set of configs and factories

### DIFF
--- a/.chloggen/draftbuilder.yaml
+++ b/.chloggen/draftbuilder.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: components
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add [receiver|processor|exporter|extension].Builder to help with creating components form a set of configs and factories
+
+# One or more tracking issues or pull requests related to the change
+issues: [6803]

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"fmt"
 
+	"go.uber.org/zap"
+
 	"go.opentelemetry.io/collector/component"
 )
 
@@ -169,4 +171,78 @@ func MakeFactoryMap(factories ...Factory) (map[component.Type]Factory, error) {
 		fMap[f.Type()] = f
 	}
 	return fMap, nil
+}
+
+// Builder exporter is a helper struct that given a set of Configs and Factories helps with creating exporters.
+type Builder struct {
+	cfgs      map[component.ID]component.Config
+	factories map[component.Type]Factory
+}
+
+// NewBuilder creates a new exporter.Builder to help with creating components form a set of configs and factories.
+func NewBuilder(cfgs map[component.ID]component.Config, factories map[component.Type]Factory) *Builder {
+	return &Builder{cfgs: cfgs, factories: factories}
+}
+
+// CreateTraces creates a Traces exporter based on the settings and config.
+func (b *Builder) CreateTraces(ctx context.Context, set CreateSettings) (Traces, error) {
+	cfg, existsCfg := b.cfgs[set.ID]
+	if !existsCfg {
+		return nil, fmt.Errorf("exporter %q is not configured", set.ID)
+	}
+
+	f, existsFactory := b.factories[set.ID.Type()]
+	if !existsFactory {
+		return nil, fmt.Errorf("exporter factory not available for: %q", set.ID)
+	}
+
+	logStabilityLevel(set.Logger, f.TracesExporterStability())
+	return f.CreateTracesExporter(ctx, set, cfg)
+}
+
+// CreateMetrics creates a Metrics exporter based on the settings and config.
+func (b *Builder) CreateMetrics(ctx context.Context, set CreateSettings) (Metrics, error) {
+	cfg, existsCfg := b.cfgs[set.ID]
+	if !existsCfg {
+		return nil, fmt.Errorf("exporter %q is not configured", set.ID)
+	}
+
+	f, existsFactory := b.factories[set.ID.Type()]
+	if !existsFactory {
+		return nil, fmt.Errorf("exporter factory not available for: %q", set.ID)
+	}
+
+	logStabilityLevel(set.Logger, f.MetricsExporterStability())
+	return f.CreateMetricsExporter(ctx, set, cfg)
+}
+
+// CreateLogs creates a Logs exporter based on the settings and config.
+func (b *Builder) CreateLogs(ctx context.Context, set CreateSettings) (Logs, error) {
+	cfg, existsCfg := b.cfgs[set.ID]
+	if !existsCfg {
+		return nil, fmt.Errorf("exporter %q is not configured", set.ID)
+	}
+
+	f, existsFactory := b.factories[set.ID.Type()]
+	if !existsFactory {
+		return nil, fmt.Errorf("exporter factory not available for: %q", set.ID)
+	}
+
+	logStabilityLevel(set.Logger, f.LogsExporterStability())
+	return f.CreateLogsExporter(ctx, set, cfg)
+}
+
+func (b *Builder) Factory(componentType component.Type) component.Factory {
+	return b.factories[componentType]
+}
+
+// logStabilityLevel logs the stability level of a component. The log level is set to info for
+// undefined, unmaintained, deprecated and development. The log level is set to debug
+// for alpha, beta and stable.
+func logStabilityLevel(logger *zap.Logger, sl component.StabilityLevel) {
+	if sl >= component.StabilityLevelAlpha {
+		logger.Debug(sl.LogMessage())
+	} else {
+		logger.Info(sl.LogMessage())
+	}
 }

--- a/exporter/exportertest/nop_exporter.go
+++ b/exporter/exportertest/nop_exporter.go
@@ -20,6 +20,8 @@ import (
 	"go.opentelemetry.io/collector/exporter"
 )
 
+const typeStr = "nop"
+
 // NewNopCreateSettings returns a new nop settings for Create*Exporter functions.
 func NewNopCreateSettings() exporter.CreateSettings {
 	return exporter.CreateSettings{
@@ -30,3 +32,11 @@ func NewNopCreateSettings() exporter.CreateSettings {
 
 // NewNopFactory returns an exporter.Factory that constructs nop exporters.
 var NewNopFactory = componenttest.NewNopExporterFactory //nolint:staticcheck
+
+// NewNopBuilder returns a exporter.Builder that constructs nop receivers.
+func NewNopBuilder() *exporter.Builder {
+	nopFactory := NewNopFactory()
+	return exporter.NewBuilder(
+		map[component.ID]component.Config{component.NewID(typeStr): nopFactory.CreateDefaultConfig()},
+		map[component.Type]exporter.Factory{typeStr: nopFactory})
+}

--- a/exporter/exportertest/nop_exporter_test.go
+++ b/exporter/exportertest/nop_exporter_test.go
@@ -53,3 +53,31 @@ func TestNewNopFactory(t *testing.T) {
 	assert.NoError(t, logs.ConsumeLogs(context.Background(), plog.NewLogs()))
 	assert.NoError(t, logs.Shutdown(context.Background()))
 }
+
+func TestNewNopBuilder(t *testing.T) {
+	builder := NewNopBuilder()
+	require.NotNil(t, builder)
+
+	factory := NewNopFactory()
+	cfg := factory.CreateDefaultConfig()
+	set := NewNopCreateSettings()
+	set.ID = component.NewID(typeStr)
+
+	traces, err := factory.CreateTracesExporter(context.Background(), set, cfg)
+	require.NoError(t, err)
+	bTraces, err := builder.CreateTraces(context.Background(), set)
+	require.NoError(t, err)
+	assert.IsType(t, traces, bTraces)
+
+	metrics, err := factory.CreateMetricsExporter(context.Background(), set, cfg)
+	require.NoError(t, err)
+	bMetrics, err := builder.CreateMetrics(context.Background(), set)
+	require.NoError(t, err)
+	assert.IsType(t, metrics, bMetrics)
+
+	logs, err := factory.CreateLogsExporter(context.Background(), set, cfg)
+	require.NoError(t, err)
+	bLogs, err := builder.CreateLogs(context.Background(), set)
+	require.NoError(t, err)
+	assert.IsType(t, logs, bLogs)
+}

--- a/extension/extensiontest/nop_extension.go
+++ b/extension/extensiontest/nop_extension.go
@@ -20,6 +20,8 @@ import (
 	"go.opentelemetry.io/collector/extension"
 )
 
+const typeStr = "nop"
+
 // NewNopCreateSettings returns a new nop settings for extension.Factory Create* functions.
 func NewNopCreateSettings() extension.CreateSettings {
 	return extension.CreateSettings{
@@ -30,3 +32,11 @@ func NewNopCreateSettings() extension.CreateSettings {
 
 // NewNopFactory returns an extension.Factory that constructs nop extensions.
 var NewNopFactory = componenttest.NewNopExtensionFactory //nolint:staticcheck
+
+// NewNopBuilder returns a extension.Builder that constructs nop receivers.
+func NewNopBuilder() *extension.Builder {
+	nopFactory := NewNopFactory()
+	return extension.NewBuilder(
+		map[component.ID]component.Config{component.NewID(typeStr): nopFactory.CreateDefaultConfig()},
+		map[component.Type]extension.Factory{typeStr: nopFactory})
+}

--- a/extension/extensiontest/nop_extension_test.go
+++ b/extension/extensiontest/nop_extension_test.go
@@ -37,3 +37,19 @@ func TestNewNopFactory(t *testing.T) {
 	assert.NoError(t, traces.Start(context.Background(), componenttest.NewNopHost()))
 	assert.NoError(t, traces.Shutdown(context.Background()))
 }
+
+func TestNewNopBuilder(t *testing.T) {
+	builder := NewNopBuilder()
+	require.NotNil(t, builder)
+
+	factory := NewNopFactory()
+	cfg := factory.CreateDefaultConfig()
+	set := NewNopCreateSettings()
+	set.ID = component.NewID(typeStr)
+
+	ext, err := factory.CreateExtension(context.Background(), set, cfg)
+	require.NoError(t, err)
+	bExt, err := builder.Create(context.Background(), set)
+	require.NoError(t, err)
+	assert.IsType(t, ext, bExt)
+}

--- a/otelcol/collector.go
+++ b/otelcol/collector.go
@@ -29,7 +29,11 @@ import (
 	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/exporter"
+	"go.opentelemetry.io/collector/extension"
 	"go.opentelemetry.io/collector/otelcol/internal/grpclog"
+	"go.opentelemetry.io/collector/processor"
+	"go.opentelemetry.io/collector/receiver"
 	"go.opentelemetry.io/collector/service"
 )
 
@@ -157,17 +161,13 @@ func (col *Collector) setupConfigurationComponents(ctx context.Context) error {
 	}
 
 	col.service, err = service.New(ctx, service.Settings{
-		BuildInfo:          col.set.BuildInfo,
-		ReceiverFactories:  col.set.Factories.Receivers,
-		ReceiverConfigs:    cfg.Receivers,
-		ProcessorFactories: col.set.Factories.Processors,
-		ProcessorConfigs:   cfg.Processors,
-		ExporterFactories:  col.set.Factories.Exporters,
-		ExporterConfigs:    cfg.Exporters,
-		ExtensionFactories: col.set.Factories.Extensions,
-		ExtensionConfigs:   cfg.Extensions,
-		AsyncErrorChannel:  col.asyncErrorChannel,
-		LoggingOptions:     col.set.LoggingOptions,
+		BuildInfo:         col.set.BuildInfo,
+		Receivers:         receiver.NewBuilder(cfg.Receivers, col.set.Factories.Receivers),
+		Processors:        processor.NewBuilder(cfg.Processors, col.set.Factories.Processors),
+		Exporters:         exporter.NewBuilder(cfg.Exporters, col.set.Factories.Exporters),
+		Extensions:        extension.NewBuilder(cfg.Extensions, col.set.Factories.Extensions),
+		AsyncErrorChannel: col.asyncErrorChannel,
+		LoggingOptions:    col.set.LoggingOptions,
 	}, cfg.Service)
 	if err != nil {
 		return err

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -15,7 +15,13 @@
 package processor // import "go.opentelemetry.io/collector/processor"
 
 import (
+	"context"
+	"fmt"
+
+	"go.uber.org/zap"
+
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/consumer"
 )
 
 // Traces is a processor that can consume traces.
@@ -63,3 +69,77 @@ var NewFactory = component.NewProcessorFactory //nolint:staticcheck
 // MakeFactoryMap takes a list of factories and returns a map with Factory type as keys.
 // It returns a non-nil error when there are factories with duplicate type.
 var MakeFactoryMap = component.MakeProcessorFactoryMap //nolint:staticcheck
+
+// Builder processor is a helper struct that given a set of Configs and Factories helps with creating processors.
+type Builder struct {
+	cfgs      map[component.ID]component.Config
+	factories map[component.Type]Factory
+}
+
+// NewBuilder creates a new processor.Builder to help with creating components form a set of configs and factories.
+func NewBuilder(cfgs map[component.ID]component.Config, factories map[component.Type]Factory) *Builder {
+	return &Builder{cfgs: cfgs, factories: factories}
+}
+
+// CreateTraces creates a Traces processor based on the settings and config.
+func (b *Builder) CreateTraces(ctx context.Context, set CreateSettings, next consumer.Traces) (Traces, error) {
+	cfg, existsCfg := b.cfgs[set.ID]
+	if !existsCfg {
+		return nil, fmt.Errorf("processor %q is not configured", set.ID)
+	}
+
+	f, existsFactory := b.factories[set.ID.Type()]
+	if !existsFactory {
+		return nil, fmt.Errorf("processor factory not available for: %q", set.ID)
+	}
+
+	logStabilityLevel(set.Logger, f.TracesProcessorStability())
+	return f.CreateTracesProcessor(ctx, set, cfg, next)
+}
+
+// CreateMetrics creates a Metrics processor based on the settings and config.
+func (b *Builder) CreateMetrics(ctx context.Context, set CreateSettings, next consumer.Metrics) (Metrics, error) {
+	cfg, existsCfg := b.cfgs[set.ID]
+	if !existsCfg {
+		return nil, fmt.Errorf("processor %q is not configured", set.ID)
+	}
+
+	f, existsFactory := b.factories[set.ID.Type()]
+	if !existsFactory {
+		return nil, fmt.Errorf("processor factory not available for: %q", set.ID)
+	}
+
+	logStabilityLevel(set.Logger, f.MetricsProcessorStability())
+	return f.CreateMetricsProcessor(ctx, set, cfg, next)
+}
+
+// CreateLogs creates a Logs processor based on the settings and config.
+func (b *Builder) CreateLogs(ctx context.Context, set CreateSettings, next consumer.Logs) (Logs, error) {
+	cfg, existsCfg := b.cfgs[set.ID]
+	if !existsCfg {
+		return nil, fmt.Errorf("processor %q is not configured", set.ID)
+	}
+
+	f, existsFactory := b.factories[set.ID.Type()]
+	if !existsFactory {
+		return nil, fmt.Errorf("processor factory not available for: %q", set.ID)
+	}
+
+	logStabilityLevel(set.Logger, f.LogsProcessorStability())
+	return f.CreateLogsProcessor(ctx, set, cfg, next)
+}
+
+func (b *Builder) Factory(componentType component.Type) component.Factory {
+	return b.factories[componentType]
+}
+
+// logStabilityLevel logs the stability level of a component. The log level is set to info for
+// undefined, unmaintained, deprecated and development. The log level is set to debug
+// for alpha, beta and stable.
+func logStabilityLevel(logger *zap.Logger, sl component.StabilityLevel) {
+	if sl >= component.StabilityLevelAlpha {
+		logger.Debug(sl.LogMessage())
+	} else {
+		logger.Info(sl.LogMessage())
+	}
+}

--- a/processor/processortest/nop_processor.go
+++ b/processor/processortest/nop_processor.go
@@ -15,11 +15,23 @@
 package processortest // import "go.opentelemetry.io/collector/processor/processortest"
 
 import (
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/processor"
 )
+
+const typeStr = "nop"
 
 // NewNopCreateSettings returns a new nop settings for Create* functions.
 var NewNopCreateSettings = componenttest.NewNopProcessorCreateSettings //nolint:staticcheck
 
 // NewNopFactory returns a component.ProcessorFactory that constructs nop processors.
 var NewNopFactory = componenttest.NewNopProcessorFactory //nolint:staticcheck
+
+// NewNopBuilder returns a processor.Builder that constructs nop receivers.
+func NewNopBuilder() *processor.Builder {
+	nopFactory := NewNopFactory()
+	return processor.NewBuilder(
+		map[component.ID]component.Config{component.NewID(typeStr): nopFactory.CreateDefaultConfig()},
+		map[component.Type]processor.Factory{typeStr: nopFactory})
+}

--- a/processor/processortest/nop_processor_test.go
+++ b/processor/processortest/nop_processor_test.go
@@ -58,3 +58,31 @@ func TestNewNopFactory(t *testing.T) {
 	assert.NoError(t, logs.ConsumeLogs(context.Background(), plog.NewLogs()))
 	assert.NoError(t, logs.Shutdown(context.Background()))
 }
+
+func TestNewNopBuilder(t *testing.T) {
+	builder := NewNopBuilder()
+	require.NotNil(t, builder)
+
+	factory := NewNopFactory()
+	cfg := factory.CreateDefaultConfig()
+	set := NewNopCreateSettings()
+	set.ID = component.NewID(typeStr)
+
+	traces, err := factory.CreateTracesProcessor(context.Background(), set, cfg, consumertest.NewNop())
+	require.NoError(t, err)
+	bTraces, err := builder.CreateTraces(context.Background(), set, consumertest.NewNop())
+	require.NoError(t, err)
+	assert.IsType(t, traces, bTraces)
+
+	metrics, err := factory.CreateMetricsProcessor(context.Background(), set, cfg, consumertest.NewNop())
+	require.NoError(t, err)
+	bMetrics, err := builder.CreateMetrics(context.Background(), set, consumertest.NewNop())
+	require.NoError(t, err)
+	assert.IsType(t, metrics, bMetrics)
+
+	logs, err := factory.CreateLogsProcessor(context.Background(), set, cfg, consumertest.NewNop())
+	require.NoError(t, err)
+	bLogs, err := builder.CreateLogs(context.Background(), set, consumertest.NewNop())
+	require.NoError(t, err)
+	assert.IsType(t, logs, bLogs)
+}

--- a/receiver/receiver.go
+++ b/receiver/receiver.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"fmt"
 
+	"go.uber.org/zap"
+
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
 )
@@ -194,4 +196,78 @@ func MakeFactoryMap(factories ...Factory) (map[component.Type]Factory, error) {
 		fMap[f.Type()] = f
 	}
 	return fMap, nil
+}
+
+// Builder receiver is a helper struct that given a set of Configs and Factories helps with creating receivers.
+type Builder struct {
+	cfgs      map[component.ID]component.Config
+	factories map[component.Type]Factory
+}
+
+// NewBuilder creates a new receiver.Builder to help with creating components form a set of configs and factories.
+func NewBuilder(cfgs map[component.ID]component.Config, factories map[component.Type]Factory) *Builder {
+	return &Builder{cfgs: cfgs, factories: factories}
+}
+
+// CreateTraces creates a Traces receiver based on the settings and config.
+func (b *Builder) CreateTraces(ctx context.Context, set CreateSettings, next consumer.Traces) (Traces, error) {
+	cfg, existsCfg := b.cfgs[set.ID]
+	if !existsCfg {
+		return nil, fmt.Errorf("receiver %q is not configured", set.ID)
+	}
+
+	f, existsFactory := b.factories[set.ID.Type()]
+	if !existsFactory {
+		return nil, fmt.Errorf("receiver factory not available for: %q", set.ID)
+	}
+
+	logStabilityLevel(set.Logger, f.TracesReceiverStability())
+	return f.CreateTracesReceiver(ctx, set, cfg, next)
+}
+
+// CreateMetrics creates a Metrics receiver based on the settings and config.
+func (b *Builder) CreateMetrics(ctx context.Context, set CreateSettings, next consumer.Metrics) (Metrics, error) {
+	cfg, existsCfg := b.cfgs[set.ID]
+	if !existsCfg {
+		return nil, fmt.Errorf("receiver %q is not configured", set.ID)
+	}
+
+	f, existsFactory := b.factories[set.ID.Type()]
+	if !existsFactory {
+		return nil, fmt.Errorf("receiver factory not available for: %q", set.ID)
+	}
+
+	logStabilityLevel(set.Logger, f.MetricsReceiverStability())
+	return f.CreateMetricsReceiver(ctx, set, cfg, next)
+}
+
+// CreateLogs creates a Logs receiver based on the settings and config.
+func (b *Builder) CreateLogs(ctx context.Context, set CreateSettings, next consumer.Logs) (Logs, error) {
+	cfg, existsCfg := b.cfgs[set.ID]
+	if !existsCfg {
+		return nil, fmt.Errorf("receiver %q is not configured", set.ID)
+	}
+
+	f, existsFactory := b.factories[set.ID.Type()]
+	if !existsFactory {
+		return nil, fmt.Errorf("receiver factory not available for: %q", set.ID)
+	}
+
+	logStabilityLevel(set.Logger, f.LogsReceiverStability())
+	return f.CreateLogsReceiver(ctx, set, cfg, next)
+}
+
+func (b *Builder) Factory(componentType component.Type) component.Factory {
+	return b.factories[componentType]
+}
+
+// logStabilityLevel logs the stability level of a component. The log level is set to info for
+// undefined, unmaintained, deprecated and development. The log level is set to debug
+// for alpha, beta and stable.
+func logStabilityLevel(logger *zap.Logger, sl component.StabilityLevel) {
+	if sl >= component.StabilityLevelAlpha {
+		logger.Debug(sl.LogMessage())
+	} else {
+		logger.Info(sl.LogMessage())
+	}
 }

--- a/receiver/receivertest/nop_receiver.go
+++ b/receiver/receivertest/nop_receiver.go
@@ -20,6 +20,8 @@ import (
 	"go.opentelemetry.io/collector/receiver"
 )
 
+const typeStr = "nop"
+
 // NewNopCreateSettings returns a new nop settings for Create* functions.
 func NewNopCreateSettings() receiver.CreateSettings {
 	return receiver.CreateSettings{
@@ -30,3 +32,11 @@ func NewNopCreateSettings() receiver.CreateSettings {
 
 // NewNopFactory returns a receiver.Factory that constructs nop receivers.
 var NewNopFactory = componenttest.NewNopReceiverFactory //nolint:staticcheck
+
+// NewNopBuilder returns a receiver.Builder that constructs nop receivers.
+func NewNopBuilder() *receiver.Builder {
+	nopFactory := NewNopFactory()
+	return receiver.NewBuilder(
+		map[component.ID]component.Config{component.NewID(typeStr): nopFactory.CreateDefaultConfig()},
+		map[component.Type]receiver.Factory{typeStr: nopFactory})
+}

--- a/receiver/receivertest/nop_receiver_test.go
+++ b/receiver/receivertest/nop_receiver_test.go
@@ -48,3 +48,31 @@ func TestNewNopFactory(t *testing.T) {
 	assert.NoError(t, logs.Start(context.Background(), componenttest.NewNopHost()))
 	assert.NoError(t, logs.Shutdown(context.Background()))
 }
+
+func TestNewNopBuilder(t *testing.T) {
+	builder := NewNopBuilder()
+	require.NotNil(t, builder)
+
+	factory := NewNopFactory()
+	cfg := factory.CreateDefaultConfig()
+	set := NewNopCreateSettings()
+	set.ID = component.NewID(typeStr)
+
+	traces, err := factory.CreateTracesReceiver(context.Background(), set, cfg, consumertest.NewNop())
+	require.NoError(t, err)
+	bTraces, err := builder.CreateTraces(context.Background(), set, consumertest.NewNop())
+	require.NoError(t, err)
+	assert.IsType(t, traces, bTraces)
+
+	metrics, err := factory.CreateMetricsReceiver(context.Background(), set, cfg, consumertest.NewNop())
+	require.NoError(t, err)
+	bMetrics, err := builder.CreateMetrics(context.Background(), set, consumertest.NewNop())
+	require.NoError(t, err)
+	assert.IsType(t, metrics, bMetrics)
+
+	logs, err := factory.CreateLogsReceiver(context.Background(), set, cfg, consumertest.NewNop())
+	require.NoError(t, err)
+	bLogs, err := builder.CreateLogs(context.Background(), set, consumertest.NewNop())
+	require.NoError(t, err)
+	assert.IsType(t, logs, bLogs)
+}

--- a/service/extensions/extensions_test.go
+++ b/service/extensions/extensions_test.go
@@ -48,7 +48,7 @@ func TestBuildExtensions(t *testing.T) {
 			serviceExtensions: []component.ID{
 				component.NewID("myextension"),
 			},
-			wantErrMsg: "extension \"myextension\" is not configured",
+			wantErrMsg: "failed to create extension \"myextension\": extension \"myextension\" is not configured",
 		},
 		{
 			name: "missing_extension_factory",
@@ -58,7 +58,7 @@ func TestBuildExtensions(t *testing.T) {
 			serviceExtensions: []component.ID{
 				component.NewID("unknown"),
 			},
-			wantErrMsg: "extension factory for type \"unknown\" is not configured",
+			wantErrMsg: "failed to create extension \"unknown\": extension factory not available for: \"unknown\"",
 		},
 		{
 			name: "error_on_create_extension",

--- a/service/host.go
+++ b/service/host.go
@@ -26,16 +26,16 @@ import (
 var _ component.Host = (*serviceHost)(nil)
 
 type serviceHost struct {
-	asyncErrorChannel  chan error
-	receiverFactories  map[component.Type]receiver.Factory
-	processorFactories map[component.Type]processor.Factory
-	exporterFactories  map[component.Type]exporter.Factory
-	extensionFactories map[component.Type]extension.Factory
+	asyncErrorChannel chan error
+	receivers         *receiver.Builder
+	processors        *processor.Builder
+	exporters         *exporter.Builder
+	extensions        *extension.Builder
 
 	buildInfo component.BuildInfo
 
-	pipelines  *builtPipelines
-	extensions *extensions.Extensions
+	pipelines         *builtPipelines
+	serviceExtensions *extensions.Extensions
 }
 
 // ReportFatalError is used to report to the host that the receiver encountered
@@ -48,19 +48,19 @@ func (host *serviceHost) ReportFatalError(err error) {
 func (host *serviceHost) GetFactory(kind component.Kind, componentType component.Type) component.Factory {
 	switch kind {
 	case component.KindReceiver:
-		return host.receiverFactories[componentType]
+		return host.receivers.Factory(componentType)
 	case component.KindProcessor:
-		return host.processorFactories[componentType]
+		return host.processors.Factory(componentType)
 	case component.KindExporter:
-		return host.exporterFactories[componentType]
+		return host.exporters.Factory(componentType)
 	case component.KindExtension:
-		return host.extensionFactories[componentType]
+		return host.extensions.Factory(componentType)
 	}
 	return nil
 }
 
 func (host *serviceHost) GetExtensions() map[component.ID]component.Component {
-	return host.extensions.GetExtensions()
+	return host.serviceExtensions.GetExtensions()
 }
 
 func (host *serviceHost) GetExporters() map[component.DataType]map[component.ID]component.Component {

--- a/service/pipelines_test.go
+++ b/service/pipelines_test.go
@@ -184,27 +184,30 @@ func TestBuildPipelines(t *testing.T) {
 			pipelines, err := buildPipelines(context.Background(), pipelinesSettings{
 				Telemetry: componenttest.NewNopTelemetrySettings(),
 				BuildInfo: component.NewDefaultBuildInfo(),
-				ReceiverFactories: map[component.Type]receiver.Factory{
-					testcomponents.ExampleReceiverFactory.Type(): testcomponents.ExampleReceiverFactory,
-				},
-				ReceiverConfigs: map[component.ID]component.Config{
-					component.NewID("examplereceiver"):              testcomponents.ExampleReceiverFactory.CreateDefaultConfig(),
-					component.NewIDWithName("examplereceiver", "1"): testcomponents.ExampleReceiverFactory.CreateDefaultConfig(),
-				},
-				ProcessorFactories: map[component.Type]processor.Factory{
-					testcomponents.ExampleProcessorFactory.Type(): testcomponents.ExampleProcessorFactory,
-				},
-				ProcessorConfigs: map[component.ID]component.Config{
-					component.NewID("exampleprocessor"):              testcomponents.ExampleProcessorFactory.CreateDefaultConfig(),
-					component.NewIDWithName("exampleprocessor", "1"): testcomponents.ExampleProcessorFactory.CreateDefaultConfig(),
-				},
-				ExporterFactories: map[component.Type]exporter.Factory{
-					testcomponents.ExampleExporterFactory.Type(): testcomponents.ExampleExporterFactory,
-				},
-				ExporterConfigs: map[component.ID]component.Config{
-					component.NewID("exampleexporter"):              testcomponents.ExampleExporterFactory.CreateDefaultConfig(),
-					component.NewIDWithName("exampleexporter", "1"): testcomponents.ExampleExporterFactory.CreateDefaultConfig(),
-				},
+				Receivers: receiver.NewBuilder(
+					map[component.ID]component.Config{
+						component.NewID("examplereceiver"):              testcomponents.ExampleReceiverFactory.CreateDefaultConfig(),
+						component.NewIDWithName("examplereceiver", "1"): testcomponents.ExampleReceiverFactory.CreateDefaultConfig(),
+					},
+					map[component.Type]receiver.Factory{
+						testcomponents.ExampleReceiverFactory.Type(): testcomponents.ExampleReceiverFactory,
+					}),
+				Processors: processor.NewBuilder(
+					map[component.ID]component.Config{
+						component.NewID("exampleprocessor"):              testcomponents.ExampleProcessorFactory.CreateDefaultConfig(),
+						component.NewIDWithName("exampleprocessor", "1"): testcomponents.ExampleProcessorFactory.CreateDefaultConfig(),
+					},
+					map[component.Type]processor.Factory{
+						testcomponents.ExampleProcessorFactory.Type(): testcomponents.ExampleProcessorFactory,
+					}),
+				Exporters: exporter.NewBuilder(
+					map[component.ID]component.Config{
+						component.NewID("exampleexporter"):              testcomponents.ExampleExporterFactory.CreateDefaultConfig(),
+						component.NewIDWithName("exampleexporter", "1"): testcomponents.ExampleExporterFactory.CreateDefaultConfig(),
+					},
+					map[component.Type]exporter.Factory{
+						testcomponents.ExampleExporterFactory.Type(): testcomponents.ExampleExporterFactory,
+					}),
 				PipelineConfigs: test.pipelineConfigs,
 			})
 			assert.NoError(t, err)
@@ -300,318 +303,299 @@ func TestBuildErrors(t *testing.T) {
 	badExporterFactory := newBadExporterFactory()
 
 	tests := []struct {
-		name     string
-		settings pipelinesSettings
-		expected string
+		name             string
+		ReceiverConfigs  map[component.ID]component.Config
+		ProcessorConfigs map[component.ID]component.Config
+		ExporterConfigs  map[component.ID]component.Config
+		PipelineConfigs  map[component.ID]*PipelineConfig
+		expected         string
 	}{
 		{
 			name: "not_supported_exporter_logs",
-			settings: pipelinesSettings{
-				ReceiverConfigs: map[component.ID]component.Config{
-					component.NewID("nop"): nopReceiverFactory.CreateDefaultConfig(),
-				},
-				ExporterConfigs: map[component.ID]component.Config{
-					component.NewID("bf"): badExporterFactory.CreateDefaultConfig(),
-				},
-				PipelineConfigs: map[component.ID]*PipelineConfig{
-					component.NewID("logs"): {
-						Receivers: []component.ID{component.NewID("nop")},
-						Exporters: []component.ID{component.NewID("bf")},
-					},
+			ReceiverConfigs: map[component.ID]component.Config{
+				component.NewID("nop"): nopReceiverFactory.CreateDefaultConfig(),
+			},
+			ExporterConfigs: map[component.ID]component.Config{
+				component.NewID("bf"): badExporterFactory.CreateDefaultConfig(),
+			},
+			PipelineConfigs: map[component.ID]*PipelineConfig{
+				component.NewID("logs"): {
+					Receivers: []component.ID{component.NewID("nop")},
+					Exporters: []component.ID{component.NewID("bf")},
 				},
 			},
 			expected: "failed to create \"bf\" exporter, in pipeline \"logs\": telemetry type is not supported",
 		},
 		{
 			name: "not_supported_exporter_metrics",
-			settings: pipelinesSettings{
-				ReceiverConfigs: map[component.ID]component.Config{
-					component.NewID("nop"): nopReceiverFactory.CreateDefaultConfig(),
-				},
-				ExporterConfigs: map[component.ID]component.Config{
-					component.NewID("bf"): badExporterFactory.CreateDefaultConfig(),
-				},
-				PipelineConfigs: map[component.ID]*PipelineConfig{
-					component.NewID("metrics"): {
-						Receivers: []component.ID{component.NewID("nop")},
-						Exporters: []component.ID{component.NewID("bf")},
-					},
+			ReceiverConfigs: map[component.ID]component.Config{
+				component.NewID("nop"): nopReceiverFactory.CreateDefaultConfig(),
+			},
+			ExporterConfigs: map[component.ID]component.Config{
+				component.NewID("bf"): badExporterFactory.CreateDefaultConfig(),
+			},
+			PipelineConfigs: map[component.ID]*PipelineConfig{
+				component.NewID("metrics"): {
+					Receivers: []component.ID{component.NewID("nop")},
+					Exporters: []component.ID{component.NewID("bf")},
 				},
 			},
 			expected: "failed to create \"bf\" exporter, in pipeline \"metrics\": telemetry type is not supported",
 		},
 		{
 			name: "not_supported_exporter_traces",
-			settings: pipelinesSettings{
-				ReceiverConfigs: map[component.ID]component.Config{
-					component.NewID("nop"): nopReceiverFactory.CreateDefaultConfig(),
-				},
-				ExporterConfigs: map[component.ID]component.Config{
-					component.NewID("bf"): badExporterFactory.CreateDefaultConfig(),
-				},
-				PipelineConfigs: map[component.ID]*PipelineConfig{
-					component.NewID("traces"): {
-						Receivers: []component.ID{component.NewID("nop")},
-						Exporters: []component.ID{component.NewID("bf")},
-					},
+			ReceiverConfigs: map[component.ID]component.Config{
+				component.NewID("nop"): nopReceiverFactory.CreateDefaultConfig(),
+			},
+			ExporterConfigs: map[component.ID]component.Config{
+				component.NewID("bf"): badExporterFactory.CreateDefaultConfig(),
+			},
+			PipelineConfigs: map[component.ID]*PipelineConfig{
+				component.NewID("traces"): {
+					Receivers: []component.ID{component.NewID("nop")},
+					Exporters: []component.ID{component.NewID("bf")},
 				},
 			},
 			expected: "failed to create \"bf\" exporter, in pipeline \"traces\": telemetry type is not supported",
 		},
 		{
 			name: "not_supported_processor_logs",
-			settings: pipelinesSettings{
-				ReceiverConfigs: map[component.ID]component.Config{
-					component.NewID("nop"): nopReceiverFactory.CreateDefaultConfig(),
-				},
-				ProcessorConfigs: map[component.ID]component.Config{
-					component.NewID("bf"): badProcessorFactory.CreateDefaultConfig(),
-				},
-				ExporterConfigs: map[component.ID]component.Config{
-					component.NewID("nop"): nopExporterFactory.CreateDefaultConfig(),
-				},
-				PipelineConfigs: map[component.ID]*PipelineConfig{
-					component.NewID("logs"): {
-						Receivers:  []component.ID{component.NewID("nop")},
-						Processors: []component.ID{component.NewID("bf")},
-						Exporters:  []component.ID{component.NewID("nop")},
-					},
+			ReceiverConfigs: map[component.ID]component.Config{
+				component.NewID("nop"): nopReceiverFactory.CreateDefaultConfig(),
+			},
+			ProcessorConfigs: map[component.ID]component.Config{
+				component.NewID("bf"): badProcessorFactory.CreateDefaultConfig(),
+			},
+			ExporterConfigs: map[component.ID]component.Config{
+				component.NewID("nop"): nopExporterFactory.CreateDefaultConfig(),
+			},
+			PipelineConfigs: map[component.ID]*PipelineConfig{
+				component.NewID("logs"): {
+					Receivers:  []component.ID{component.NewID("nop")},
+					Processors: []component.ID{component.NewID("bf")},
+					Exporters:  []component.ID{component.NewID("nop")},
 				},
 			},
 			expected: "failed to create \"bf\" processor, in pipeline \"logs\": telemetry type is not supported",
 		},
 		{
 			name: "not_supported_processor_metrics",
-			settings: pipelinesSettings{
-				ReceiverConfigs: map[component.ID]component.Config{
-					component.NewID("nop"): nopReceiverFactory.CreateDefaultConfig(),
-				},
-				ProcessorConfigs: map[component.ID]component.Config{
-					component.NewID("bf"): badProcessorFactory.CreateDefaultConfig(),
-				},
-				ExporterConfigs: map[component.ID]component.Config{
-					component.NewID("nop"): nopExporterFactory.CreateDefaultConfig(),
-				},
-				PipelineConfigs: map[component.ID]*PipelineConfig{
-					component.NewID("metrics"): {
-						Receivers:  []component.ID{component.NewID("nop")},
-						Processors: []component.ID{component.NewID("bf")},
-						Exporters:  []component.ID{component.NewID("nop")},
-					},
+			ReceiverConfigs: map[component.ID]component.Config{
+				component.NewID("nop"): nopReceiverFactory.CreateDefaultConfig(),
+			},
+			ProcessorConfigs: map[component.ID]component.Config{
+				component.NewID("bf"): badProcessorFactory.CreateDefaultConfig(),
+			},
+			ExporterConfigs: map[component.ID]component.Config{
+				component.NewID("nop"): nopExporterFactory.CreateDefaultConfig(),
+			},
+			PipelineConfigs: map[component.ID]*PipelineConfig{
+				component.NewID("metrics"): {
+					Receivers:  []component.ID{component.NewID("nop")},
+					Processors: []component.ID{component.NewID("bf")},
+					Exporters:  []component.ID{component.NewID("nop")},
 				},
 			},
 			expected: "failed to create \"bf\" processor, in pipeline \"metrics\": telemetry type is not supported",
 		},
 		{
 			name: "not_supported_processor_traces",
-			settings: pipelinesSettings{
-				ReceiverConfigs: map[component.ID]component.Config{
-					component.NewID("nop"): nopReceiverFactory.CreateDefaultConfig(),
-				},
-				ProcessorConfigs: map[component.ID]component.Config{
-					component.NewID("bf"): badProcessorFactory.CreateDefaultConfig(),
-				},
-				ExporterConfigs: map[component.ID]component.Config{
-					component.NewID("nop"): nopExporterFactory.CreateDefaultConfig(),
-				},
-				PipelineConfigs: map[component.ID]*PipelineConfig{
-					component.NewID("traces"): {
-						Receivers:  []component.ID{component.NewID("nop")},
-						Processors: []component.ID{component.NewID("bf")},
-						Exporters:  []component.ID{component.NewID("nop")},
-					},
+			ReceiverConfigs: map[component.ID]component.Config{
+				component.NewID("nop"): nopReceiverFactory.CreateDefaultConfig(),
+			},
+			ProcessorConfigs: map[component.ID]component.Config{
+				component.NewID("bf"): badProcessorFactory.CreateDefaultConfig(),
+			},
+			ExporterConfigs: map[component.ID]component.Config{
+				component.NewID("nop"): nopExporterFactory.CreateDefaultConfig(),
+			},
+			PipelineConfigs: map[component.ID]*PipelineConfig{
+				component.NewID("traces"): {
+					Receivers:  []component.ID{component.NewID("nop")},
+					Processors: []component.ID{component.NewID("bf")},
+					Exporters:  []component.ID{component.NewID("nop")},
 				},
 			},
 			expected: "failed to create \"bf\" processor, in pipeline \"traces\": telemetry type is not supported",
 		},
 		{
 			name: "not_supported_receiver_logs",
-			settings: pipelinesSettings{
-				ReceiverConfigs: map[component.ID]component.Config{
-					component.NewID("bf"): badReceiverFactory.CreateDefaultConfig(),
-				},
-				ExporterConfigs: map[component.ID]component.Config{
-					component.NewID("nop"): nopExporterFactory.CreateDefaultConfig(),
-				},
-				PipelineConfigs: map[component.ID]*PipelineConfig{
-					component.NewID("logs"): {
-						Receivers: []component.ID{component.NewID("bf")},
-						Exporters: []component.ID{component.NewID("nop")},
-					},
+			ReceiverConfigs: map[component.ID]component.Config{
+				component.NewID("bf"): badReceiverFactory.CreateDefaultConfig(),
+			},
+			ExporterConfigs: map[component.ID]component.Config{
+				component.NewID("nop"): nopExporterFactory.CreateDefaultConfig(),
+			},
+			PipelineConfigs: map[component.ID]*PipelineConfig{
+				component.NewID("logs"): {
+					Receivers: []component.ID{component.NewID("bf")},
+					Exporters: []component.ID{component.NewID("nop")},
 				},
 			},
 			expected: "failed to create \"bf\" receiver, in pipeline \"logs\": telemetry type is not supported",
 		},
 		{
 			name: "not_supported_receiver_metrics",
-			settings: pipelinesSettings{
-				ReceiverConfigs: map[component.ID]component.Config{
-					component.NewID("bf"): badReceiverFactory.CreateDefaultConfig(),
-				},
-				ExporterConfigs: map[component.ID]component.Config{
-					component.NewID("nop"): nopExporterFactory.CreateDefaultConfig(),
-				},
-				PipelineConfigs: map[component.ID]*PipelineConfig{
-					component.NewID("metrics"): {
-						Receivers: []component.ID{component.NewID("bf")},
-						Exporters: []component.ID{component.NewID("nop")},
-					},
+			ReceiverConfigs: map[component.ID]component.Config{
+				component.NewID("bf"): badReceiverFactory.CreateDefaultConfig(),
+			},
+			ExporterConfigs: map[component.ID]component.Config{
+				component.NewID("nop"): nopExporterFactory.CreateDefaultConfig(),
+			},
+			PipelineConfigs: map[component.ID]*PipelineConfig{
+				component.NewID("metrics"): {
+					Receivers: []component.ID{component.NewID("bf")},
+					Exporters: []component.ID{component.NewID("nop")},
 				},
 			},
 			expected: "failed to create \"bf\" receiver, in pipeline \"metrics\": telemetry type is not supported",
 		},
 		{
 			name: "not_supported_receiver_traces",
-			settings: pipelinesSettings{
-				ReceiverConfigs: map[component.ID]component.Config{
-					component.NewID("bf"): badReceiverFactory.CreateDefaultConfig(),
-				},
-				ExporterConfigs: map[component.ID]component.Config{
-					component.NewID("nop"): nopExporterFactory.CreateDefaultConfig(),
-				},
-				PipelineConfigs: map[component.ID]*PipelineConfig{
-					component.NewID("traces"): {
-						Receivers: []component.ID{component.NewID("bf")},
-						Exporters: []component.ID{component.NewID("nop")},
-					},
+			ReceiverConfigs: map[component.ID]component.Config{
+				component.NewID("bf"): badReceiverFactory.CreateDefaultConfig(),
+			},
+			ExporterConfigs: map[component.ID]component.Config{
+				component.NewID("nop"): nopExporterFactory.CreateDefaultConfig(),
+			},
+			PipelineConfigs: map[component.ID]*PipelineConfig{
+				component.NewID("traces"): {
+					Receivers: []component.ID{component.NewID("bf")},
+					Exporters: []component.ID{component.NewID("nop")},
 				},
 			},
 			expected: "failed to create \"bf\" receiver, in pipeline \"traces\": telemetry type is not supported",
 		},
 		{
 			name: "unknown_exporter_config",
-			settings: pipelinesSettings{
-				ReceiverConfigs: map[component.ID]component.Config{
-					component.NewID("nop"): nopReceiverFactory.CreateDefaultConfig(),
-				},
-				ExporterConfigs: map[component.ID]component.Config{
-					component.NewID("nop"): nopExporterFactory.CreateDefaultConfig(),
-				},
-				PipelineConfigs: map[component.ID]*PipelineConfig{
-					component.NewID("traces"): {
-						Receivers: []component.ID{component.NewID("nop")},
-						Exporters: []component.ID{component.NewID("nop"), component.NewIDWithName("nop", "1")},
-					},
+			ReceiverConfigs: map[component.ID]component.Config{
+				component.NewID("nop"): nopReceiverFactory.CreateDefaultConfig(),
+			},
+			ExporterConfigs: map[component.ID]component.Config{
+				component.NewID("nop"): nopExporterFactory.CreateDefaultConfig(),
+			},
+			PipelineConfigs: map[component.ID]*PipelineConfig{
+				component.NewID("traces"): {
+					Receivers: []component.ID{component.NewID("nop")},
+					Exporters: []component.ID{component.NewID("nop"), component.NewIDWithName("nop", "1")},
 				},
 			},
-			expected: "exporter \"nop/1\" is not configured",
+			expected: "failed to create \"nop/1\" exporter, in pipeline \"traces\": exporter \"nop/1\" is not configured",
 		},
 		{
 			name: "unknown_exporter_factory",
-			settings: pipelinesSettings{
-				ReceiverConfigs: map[component.ID]component.Config{
-					component.NewID("nop"): nopReceiverFactory.CreateDefaultConfig(),
-				},
-				ExporterConfigs: map[component.ID]component.Config{
-					component.NewID("unknown"): nopExporterFactory.CreateDefaultConfig(),
-				},
-				PipelineConfigs: map[component.ID]*PipelineConfig{
-					component.NewID("traces"): {
-						Receivers: []component.ID{component.NewID("nop")},
-						Exporters: []component.ID{component.NewID("unknown")},
-					},
+			ReceiverConfigs: map[component.ID]component.Config{
+				component.NewID("nop"): nopReceiverFactory.CreateDefaultConfig(),
+			},
+			ExporterConfigs: map[component.ID]component.Config{
+				component.NewID("unknown"): nopExporterFactory.CreateDefaultConfig(),
+			},
+			PipelineConfigs: map[component.ID]*PipelineConfig{
+				component.NewID("traces"): {
+					Receivers: []component.ID{component.NewID("nop")},
+					Exporters: []component.ID{component.NewID("unknown")},
 				},
 			},
-			expected: "exporter factory not available for: \"unknown\"",
+			expected: "failed to create \"unknown\" exporter, in pipeline \"traces\": exporter factory not available for: \"unknown\"",
 		},
 		{
 			name: "unknown_processor_config",
-			settings: pipelinesSettings{
-				ReceiverConfigs: map[component.ID]component.Config{
-					component.NewID("nop"): nopReceiverFactory.CreateDefaultConfig(),
-				},
-				ProcessorConfigs: map[component.ID]component.Config{
-					component.NewID("nop"): nopProcessorFactory.CreateDefaultConfig(),
-				},
-				ExporterConfigs: map[component.ID]component.Config{
-					component.NewID("nop"): nopExporterFactory.CreateDefaultConfig(),
-				},
-				PipelineConfigs: map[component.ID]*PipelineConfig{
-					component.NewID("metrics"): {
-						Receivers:  []component.ID{component.NewID("nop")},
-						Processors: []component.ID{component.NewID("nop"), component.NewIDWithName("nop", "1")},
-						Exporters:  []component.ID{component.NewID("nop")},
-					},
+			ReceiverConfigs: map[component.ID]component.Config{
+				component.NewID("nop"): nopReceiverFactory.CreateDefaultConfig(),
+			},
+			ProcessorConfigs: map[component.ID]component.Config{
+				component.NewID("nop"): nopProcessorFactory.CreateDefaultConfig(),
+			},
+			ExporterConfigs: map[component.ID]component.Config{
+				component.NewID("nop"): nopExporterFactory.CreateDefaultConfig(),
+			},
+			PipelineConfigs: map[component.ID]*PipelineConfig{
+				component.NewID("metrics"): {
+					Receivers:  []component.ID{component.NewID("nop")},
+					Processors: []component.ID{component.NewID("nop"), component.NewIDWithName("nop", "1")},
+					Exporters:  []component.ID{component.NewID("nop")},
 				},
 			},
-			expected: "processor \"nop/1\" is not configured",
+			expected: "failed to create \"nop/1\" processor, in pipeline \"metrics\": processor \"nop/1\" is not configured",
 		},
 		{
 			name: "unknown_processor_factory",
-			settings: pipelinesSettings{
-				ReceiverConfigs: map[component.ID]component.Config{
-					component.NewID("nop"): nopReceiverFactory.CreateDefaultConfig(),
-				},
-				ProcessorConfigs: map[component.ID]component.Config{
-					component.NewID("unknown"): nopProcessorFactory.CreateDefaultConfig(),
-				},
-				ExporterConfigs: map[component.ID]component.Config{
-					component.NewID("nop"): nopExporterFactory.CreateDefaultConfig(),
-				},
-				PipelineConfigs: map[component.ID]*PipelineConfig{
-					component.NewID("metrics"): {
-						Receivers:  []component.ID{component.NewID("nop")},
-						Processors: []component.ID{component.NewID("unknown")},
-						Exporters:  []component.ID{component.NewID("nop")},
-					},
+			ReceiverConfigs: map[component.ID]component.Config{
+				component.NewID("nop"): nopReceiverFactory.CreateDefaultConfig(),
+			},
+			ProcessorConfigs: map[component.ID]component.Config{
+				component.NewID("unknown"): nopProcessorFactory.CreateDefaultConfig(),
+			},
+			ExporterConfigs: map[component.ID]component.Config{
+				component.NewID("nop"): nopExporterFactory.CreateDefaultConfig(),
+			},
+			PipelineConfigs: map[component.ID]*PipelineConfig{
+				component.NewID("metrics"): {
+					Receivers:  []component.ID{component.NewID("nop")},
+					Processors: []component.ID{component.NewID("unknown")},
+					Exporters:  []component.ID{component.NewID("nop")},
 				},
 			},
-			expected: "processor factory not available for: \"unknown\"",
+			expected: "failed to create \"unknown\" processor, in pipeline \"metrics\": processor factory not available for: \"unknown\"",
 		},
 		{
 			name: "unknown_receiver_config",
-			settings: pipelinesSettings{
-				ReceiverConfigs: map[component.ID]component.Config{
-					component.NewID("nop"): nopReceiverFactory.CreateDefaultConfig(),
-				},
-				ExporterConfigs: map[component.ID]component.Config{
-					component.NewID("nop"): nopExporterFactory.CreateDefaultConfig(),
-				},
-				PipelineConfigs: map[component.ID]*PipelineConfig{
-					component.NewID("logs"): {
-						Receivers: []component.ID{component.NewID("nop"), component.NewIDWithName("nop", "1")},
-						Exporters: []component.ID{component.NewID("nop")},
-					},
+			ReceiverConfigs: map[component.ID]component.Config{
+				component.NewID("nop"): nopReceiverFactory.CreateDefaultConfig(),
+			},
+			ExporterConfigs: map[component.ID]component.Config{
+				component.NewID("nop"): nopExporterFactory.CreateDefaultConfig(),
+			},
+			PipelineConfigs: map[component.ID]*PipelineConfig{
+				component.NewID("logs"): {
+					Receivers: []component.ID{component.NewID("nop"), component.NewIDWithName("nop", "1")},
+					Exporters: []component.ID{component.NewID("nop")},
 				},
 			},
-			expected: "receiver \"nop/1\" is not configured",
+			expected: "failed to create \"nop/1\" receiver, in pipeline \"logs\": receiver \"nop/1\" is not configured",
 		},
 		{
 			name: "unknown_receiver_factory",
-			settings: pipelinesSettings{
-				ReceiverConfigs: map[component.ID]component.Config{
-					component.NewID("unknown"): nopReceiverFactory.CreateDefaultConfig(),
-				},
-				ExporterConfigs: map[component.ID]component.Config{
-					component.NewID("nop"): nopExporterFactory.CreateDefaultConfig(),
-				},
-				PipelineConfigs: map[component.ID]*PipelineConfig{
-					component.NewID("logs"): {
-						Receivers: []component.ID{component.NewID("unknown")},
-						Exporters: []component.ID{component.NewID("nop")},
-					},
+			ReceiverConfigs: map[component.ID]component.Config{
+				component.NewID("unknown"): nopReceiverFactory.CreateDefaultConfig(),
+			},
+			ExporterConfigs: map[component.ID]component.Config{
+				component.NewID("nop"): nopExporterFactory.CreateDefaultConfig(),
+			},
+			PipelineConfigs: map[component.ID]*PipelineConfig{
+				component.NewID("logs"): {
+					Receivers: []component.ID{component.NewID("unknown")},
+					Exporters: []component.ID{component.NewID("nop")},
 				},
 			},
-			expected: "receiver factory not available for: \"unknown\"",
+			expected: "failed to create \"unknown\" receiver, in pipeline \"logs\": receiver factory not available for: \"unknown\"",
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			set := test.settings
-			set.BuildInfo = component.NewDefaultBuildInfo()
-			set.Telemetry = componenttest.NewNopTelemetrySettings()
-			set.ReceiverFactories = map[component.Type]receiver.Factory{
-				nopReceiverFactory.Type(): nopReceiverFactory,
-				badReceiverFactory.Type(): badReceiverFactory,
-			}
-			set.ProcessorFactories = map[component.Type]processor.Factory{
-				nopProcessorFactory.Type(): nopProcessorFactory,
-				badProcessorFactory.Type(): badProcessorFactory,
-			}
-			set.ExporterFactories = map[component.Type]exporter.Factory{
-				nopExporterFactory.Type(): nopExporterFactory,
-				badExporterFactory.Type(): badExporterFactory,
+			set := pipelinesSettings{
+				Telemetry: componenttest.NewNopTelemetrySettings(),
+				BuildInfo: component.NewDefaultBuildInfo(),
+				Receivers: receiver.NewBuilder(
+					test.ReceiverConfigs,
+					map[component.Type]receiver.Factory{
+						nopReceiverFactory.Type(): nopReceiverFactory,
+						badReceiverFactory.Type(): badReceiverFactory,
+					}),
+				Processors: processor.NewBuilder(
+					test.ProcessorConfigs,
+					map[component.Type]processor.Factory{
+						nopProcessorFactory.Type(): nopProcessorFactory,
+						badProcessorFactory.Type(): badProcessorFactory,
+					}),
+				Exporters: exporter.NewBuilder(
+					test.ExporterConfigs,
+					map[component.Type]exporter.Factory{
+						nopExporterFactory.Type(): nopExporterFactory,
+						badExporterFactory.Type(): badExporterFactory,
+					}),
+				PipelineConfigs: test.PipelineConfigs,
 			}
 
 			_, err := buildPipelines(context.Background(), set)
@@ -631,30 +615,33 @@ func TestFailToStartAndShutdown(t *testing.T) {
 	set := pipelinesSettings{
 		Telemetry: componenttest.NewNopTelemetrySettings(),
 		BuildInfo: component.NewDefaultBuildInfo(),
-		ReceiverFactories: map[component.Type]receiver.Factory{
-			nopReceiverFactory.Type(): nopReceiverFactory,
-			errReceiverFactory.Type(): errReceiverFactory,
-		},
-		ReceiverConfigs: map[component.ID]component.Config{
-			component.NewID(nopReceiverFactory.Type()): nopReceiverFactory.CreateDefaultConfig(),
-			component.NewID(errReceiverFactory.Type()): errReceiverFactory.CreateDefaultConfig(),
-		},
-		ProcessorFactories: map[component.Type]processor.Factory{
-			nopProcessorFactory.Type(): nopProcessorFactory,
-			errProcessorFactory.Type(): errProcessorFactory,
-		},
-		ProcessorConfigs: map[component.ID]component.Config{
-			component.NewID(nopProcessorFactory.Type()): nopProcessorFactory.CreateDefaultConfig(),
-			component.NewID(errProcessorFactory.Type()): errProcessorFactory.CreateDefaultConfig(),
-		},
-		ExporterFactories: map[component.Type]exporter.Factory{
-			nopExporterFactory.Type(): nopExporterFactory,
-			errExporterFactory.Type(): errExporterFactory,
-		},
-		ExporterConfigs: map[component.ID]component.Config{
-			component.NewID(nopExporterFactory.Type()): nopExporterFactory.CreateDefaultConfig(),
-			component.NewID(errExporterFactory.Type()): errExporterFactory.CreateDefaultConfig(),
-		},
+		Receivers: receiver.NewBuilder(
+			map[component.ID]component.Config{
+				component.NewID(nopReceiverFactory.Type()): nopReceiverFactory.CreateDefaultConfig(),
+				component.NewID(errReceiverFactory.Type()): errReceiverFactory.CreateDefaultConfig(),
+			},
+			map[component.Type]receiver.Factory{
+				nopReceiverFactory.Type(): nopReceiverFactory,
+				errReceiverFactory.Type(): errReceiverFactory,
+			}),
+		Processors: processor.NewBuilder(
+			map[component.ID]component.Config{
+				component.NewID(nopProcessorFactory.Type()): nopProcessorFactory.CreateDefaultConfig(),
+				component.NewID(errProcessorFactory.Type()): errProcessorFactory.CreateDefaultConfig(),
+			},
+			map[component.Type]processor.Factory{
+				nopProcessorFactory.Type(): nopProcessorFactory,
+				errProcessorFactory.Type(): errProcessorFactory,
+			}),
+		Exporters: exporter.NewBuilder(
+			map[component.ID]component.Config{
+				component.NewID(nopExporterFactory.Type()): nopExporterFactory.CreateDefaultConfig(),
+				component.NewID(errExporterFactory.Type()): errExporterFactory.CreateDefaultConfig(),
+			},
+			map[component.Type]exporter.Factory{
+				nopExporterFactory.Type(): nopExporterFactory,
+				errExporterFactory.Type(): errExporterFactory,
+			}),
 	}
 
 	for _, dt := range []component.DataType{component.DataTypeTraces, component.DataTypeMetrics, component.DataTypeLogs} {

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -32,7 +32,6 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/confignet"
 	"go.opentelemetry.io/collector/config/configtelemetry"
-	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/exporter/exportertest"
 	"go.opentelemetry.io/collector/extension"
 	"go.opentelemetry.io/collector/extension/extensiontest"
@@ -40,9 +39,7 @@ import (
 	"go.opentelemetry.io/collector/featuregate"
 	"go.opentelemetry.io/collector/internal/obsreportconfig"
 	"go.opentelemetry.io/collector/internal/testutil"
-	"go.opentelemetry.io/collector/processor"
 	"go.opentelemetry.io/collector/processor/processortest"
-	"go.opentelemetry.io/collector/receiver"
 	"go.opentelemetry.io/collector/receiver/receivertest"
 	"go.opentelemetry.io/collector/service/telemetry"
 )
@@ -151,16 +148,16 @@ func TestServiceGetFactory(t *testing.T) {
 	})
 
 	assert.Nil(t, srv.host.GetFactory(component.KindReceiver, "wrongtype"))
-	assert.Equal(t, set.ReceiverFactories["nop"], srv.host.GetFactory(component.KindReceiver, "nop"))
+	assert.Equal(t, set.Receivers.Factory("nop"), srv.host.GetFactory(component.KindReceiver, "nop"))
 
 	assert.Nil(t, srv.host.GetFactory(component.KindProcessor, "wrongtype"))
-	assert.Equal(t, set.ProcessorFactories["nop"], srv.host.GetFactory(component.KindProcessor, "nop"))
+	assert.Equal(t, set.Processors.Factory("nop"), srv.host.GetFactory(component.KindProcessor, "nop"))
 
 	assert.Nil(t, srv.host.GetFactory(component.KindExporter, "wrongtype"))
-	assert.Equal(t, set.ExporterFactories["nop"], srv.host.GetFactory(component.KindExporter, "nop"))
+	assert.Equal(t, set.Exporters.Factory("nop"), srv.host.GetFactory(component.KindExporter, "nop"))
 
 	assert.Nil(t, srv.host.GetFactory(component.KindExtension, "wrongtype"))
-	assert.Equal(t, set.ExtensionFactories["nop"], srv.host.GetFactory(component.KindExtension, "nop"))
+	assert.Equal(t, set.Extensions.Factory("nop"), srv.host.GetFactory(component.KindExtension, "nop"))
 
 	// Try retrieve non existing component.Kind.
 	assert.Nil(t, srv.host.GetFactory(42, "nop"))
@@ -250,17 +247,14 @@ func testCollectorStartHelper(t *testing.T, reg *featuregate.Registry, tc ownMet
 
 	set := newNopSettings()
 	set.BuildInfo = component.BuildInfo{Version: "test version"}
-	set.ExtensionConfigs[component.NewID("zpages")] = &zpagesextension.Config{
-		TCPAddr: confignet.TCPAddr{
-			Endpoint: zpagesAddr,
-		},
-	}
-	set.ExtensionFactories["zpages"] = zpagesextension.NewFactory()
+	set.Extensions = extension.NewBuilder(
+		map[component.ID]component.Config{component.NewID("zpages"): &zpagesextension.Config{TCPAddr: confignet.TCPAddr{Endpoint: zpagesAddr}}},
+		map[component.Type]extension.Factory{"zpages": zpagesextension.NewFactory()})
 	set.LoggingOptions = []zap.Option{zap.Hooks(hook)}
 	set.registry = reg
 
 	cfg := newNopConfig()
-	cfg.Extensions = []component.ID{component.NewID("nop"), component.NewID("zpages")}
+	cfg.Extensions = []component.ID{component.NewID("zpages")}
 	cfg.Telemetry.Metrics.Address = metricsAddr
 	cfg.Telemetry.Resource = make(map[string]*string)
 	// Include resource attributes under the service::telemetry::resource key.
@@ -395,15 +389,11 @@ func assertZPages(t *testing.T, zpagesAddr string) {
 
 func newNopSettings() Settings {
 	return Settings{
-		BuildInfo:          component.NewDefaultBuildInfo(),
-		ReceiverFactories:  map[component.Type]receiver.Factory{"nop": receivertest.NewNopFactory()},
-		ReceiverConfigs:    map[component.ID]component.Config{component.NewID("nop"): receivertest.NewNopFactory().CreateDefaultConfig()},
-		ProcessorFactories: map[component.Type]processor.Factory{"nop": processortest.NewNopFactory()},
-		ProcessorConfigs:   map[component.ID]component.Config{component.NewID("nop"): processortest.NewNopFactory().CreateDefaultConfig()},
-		ExporterFactories:  map[component.Type]exporter.Factory{"nop": exportertest.NewNopFactory()},
-		ExporterConfigs:    map[component.ID]component.Config{component.NewID("nop"): exportertest.NewNopFactory().CreateDefaultConfig()},
-		ExtensionFactories: map[component.Type]extension.Factory{"nop": extensiontest.NewNopFactory()},
-		ExtensionConfigs:   map[component.ID]component.Config{component.NewID("nop"): extensiontest.NewNopFactory().CreateDefaultConfig()},
+		BuildInfo:  component.NewDefaultBuildInfo(),
+		Receivers:  receivertest.NewNopBuilder(),
+		Processors: processortest.NewNopBuilder(),
+		Exporters:  exportertest.NewNopBuilder(),
+		Extensions: extensiontest.NewNopBuilder(),
 	}
 }
 

--- a/service/zpages.go
+++ b/service/zpages.go
@@ -34,7 +34,7 @@ const (
 func (host *serviceHost) RegisterZPages(mux *http.ServeMux, pathPrefix string) {
 	mux.HandleFunc(path.Join(pathPrefix, servicezPath), host.zPagesRequest)
 	mux.HandleFunc(path.Join(pathPrefix, pipelinezPath), host.pipelines.HandleZPages)
-	mux.HandleFunc(path.Join(pathPrefix, extensionzPath), host.extensions.HandleZPages)
+	mux.HandleFunc(path.Join(pathPrefix, extensionzPath), host.serviceExtensions.HandleZPages)
 	mux.HandleFunc(path.Join(pathPrefix, featurezPath), handleFeaturezRequest)
 }
 


### PR DESCRIPTION
The main idea is that we pass a `receiver.Builder` (a combo of configs and factories that can create Receivers to the Service) instead of configs and factories separately. This way we help other distributions to re-implement service/host.