### PR TITLE
[chore] Fix panic in queue_retry tests

### DIFF
--- a/exporter/exporterhelper/queued_retry_test.go
+++ b/exporter/exporterhelper/queued_retry_test.go
@@ -307,8 +307,9 @@ func TestQueuedRetry_DropOnFull(t *testing.T) {
 	t.Cleanup(func() {
 		assert.NoError(t, be.Shutdown(context.Background()))
 	})
-	err = be.sender.send(newMockRequest(context.Background(), 2, errors.New("transient error")))
-	require.Error(t, err)
+	ocs.run(func() {
+		require.Error(t, be.sender.send(newMockRequest(context.Background(), 2, errors.New("transient error"))))
+	})
 }
 
 func TestQueuedRetryHappyPath(t *testing.T) {


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-collector/issues/6759

The tests helpers for obsreport should be reworked, but this one is a quick fix that should prevent it from panicking.