### PR TITLE
Make NewDefaultConfigProviderSettings public

### DIFF
--- a/otelcol/collector_test.go
+++ b/otelcol/collector_test.go
@@ -42,7 +42,7 @@ func TestCollectorStartAsGoRoutine(t *testing.T) {
 	factories, err := nopFactories()
 	require.NoError(t, err)
 
-	cfgProvider, err := NewConfigProvider(newDefaultConfigProviderSettings([]string{filepath.Join("testdata", "otelcol-nop.yaml")}))
+	cfgProvider, err := NewConfigProvider(NewDefaultConfigProviderSettings([]string{filepath.Join("testdata", "otelcol-nop.yaml")}))
 	require.NoError(t, err)
 
 	set := CollectorSettings{
@@ -69,7 +69,7 @@ func TestCollectorCancelContext(t *testing.T) {
 	factories, err := nopFactories()
 	require.NoError(t, err)
 
-	cfgProvider, err := NewConfigProvider(newDefaultConfigProviderSettings([]string{filepath.Join("testdata", "otelcol-nop.yaml")}))
+	cfgProvider, err := NewConfigProvider(NewDefaultConfigProviderSettings([]string{filepath.Join("testdata", "otelcol-nop.yaml")}))
 	require.NoError(t, err)
 
 	set := CollectorSettings{
@@ -105,7 +105,7 @@ func TestCollectorStateAfterConfigChange(t *testing.T) {
 	factories, err := nopFactories()
 	require.NoError(t, err)
 
-	provider, err := NewConfigProvider(newDefaultConfigProviderSettings([]string{filepath.Join("testdata", "otelcol-nop.yaml")}))
+	provider, err := NewConfigProvider(NewDefaultConfigProviderSettings([]string{filepath.Join("testdata", "otelcol-nop.yaml")}))
 	require.NoError(t, err)
 
 	watcher := make(chan error, 1)
@@ -138,7 +138,7 @@ func TestCollectorReportError(t *testing.T) {
 	factories, err := nopFactories()
 	require.NoError(t, err)
 
-	cfgProvider, err := NewConfigProvider(newDefaultConfigProviderSettings([]string{filepath.Join("testdata", "otelcol-nop.yaml")}))
+	cfgProvider, err := NewConfigProvider(NewDefaultConfigProviderSettings([]string{filepath.Join("testdata", "otelcol-nop.yaml")}))
 	require.NoError(t, err)
 
 	col, err := NewCollector(CollectorSettings{
@@ -164,7 +164,7 @@ func TestCollectorSendSignal(t *testing.T) {
 	factories, err := nopFactories()
 	require.NoError(t, err)
 
-	cfgProvider, err := NewConfigProvider(newDefaultConfigProviderSettings([]string{filepath.Join("testdata", "otelcol-nop.yaml")}))
+	cfgProvider, err := NewConfigProvider(NewDefaultConfigProviderSettings([]string{filepath.Join("testdata", "otelcol-nop.yaml")}))
 	require.NoError(t, err)
 
 	col, err := NewCollector(CollectorSettings{
@@ -197,7 +197,7 @@ func TestCollectorFailedShutdown(t *testing.T) {
 	factories, err := nopFactories()
 	require.NoError(t, err)
 
-	cfgProvider, err := NewConfigProvider(newDefaultConfigProviderSettings([]string{filepath.Join("testdata", "otelcol-nop.yaml")}))
+	cfgProvider, err := NewConfigProvider(NewDefaultConfigProviderSettings([]string{filepath.Join("testdata", "otelcol-nop.yaml")}))
 	require.NoError(t, err)
 
 	col, err := NewCollector(CollectorSettings{
@@ -228,7 +228,7 @@ func TestCollectorStartInvalidConfig(t *testing.T) {
 	factories, err := nopFactories()
 	require.NoError(t, err)
 
-	cfgProvider, err := NewConfigProvider(newDefaultConfigProviderSettings([]string{filepath.Join("testdata", "otelcol-invalid.yaml")}))
+	cfgProvider, err := NewConfigProvider(NewDefaultConfigProviderSettings([]string{filepath.Join("testdata", "otelcol-invalid.yaml")}))
 	require.NoError(t, err)
 
 	col, err := NewCollector(CollectorSettings{
@@ -255,7 +255,7 @@ func TestCollectorStartWithTraceContextPropagation(t *testing.T) {
 			factories, err := nopFactories()
 			require.NoError(t, err)
 
-			cfgProvider, err := NewConfigProvider(newDefaultConfigProviderSettings([]string{filepath.Join("testdata", tt.file)}))
+			cfgProvider, err := NewConfigProvider(NewDefaultConfigProviderSettings([]string{filepath.Join("testdata", tt.file)}))
 			require.NoError(t, err)
 
 			set := CollectorSettings{
@@ -293,7 +293,7 @@ func TestCollectorRun(t *testing.T) {
 			factories, err := nopFactories()
 			require.NoError(t, err)
 
-			cfgProvider, err := NewConfigProvider(newDefaultConfigProviderSettings([]string{filepath.Join("testdata", tt.file)}))
+			cfgProvider, err := NewConfigProvider(NewDefaultConfigProviderSettings([]string{filepath.Join("testdata", tt.file)}))
 			require.NoError(t, err)
 
 			set := CollectorSettings{
@@ -317,7 +317,7 @@ func TestCollectorShutdownBeforeRun(t *testing.T) {
 	factories, err := nopFactories()
 	require.NoError(t, err)
 
-	cfgProvider, err := NewConfigProvider(newDefaultConfigProviderSettings([]string{filepath.Join("testdata", "otelcol-nop.yaml")}))
+	cfgProvider, err := NewConfigProvider(NewDefaultConfigProviderSettings([]string{filepath.Join("testdata", "otelcol-nop.yaml")}))
 	require.NoError(t, err)
 
 	set := CollectorSettings{
@@ -342,7 +342,7 @@ func TestCollectorClosedStateOnStartUpError(t *testing.T) {
 	factories, err := nopFactories()
 	require.NoError(t, err)
 
-	cfgProvider, err := NewConfigProvider(newDefaultConfigProviderSettings([]string{filepath.Join("testdata", "otelcol-invalid.yaml")}))
+	cfgProvider, err := NewConfigProvider(NewDefaultConfigProviderSettings([]string{filepath.Join("testdata", "otelcol-invalid.yaml")}))
 	require.NoError(t, err)
 
 	// Load a bad config causing startup to fail

--- a/otelcol/collector_windows.go
+++ b/otelcol/collector_windows.go
@@ -149,7 +149,7 @@ func newWithWindowsEventLogCore(set CollectorSettings, flags *flag.FlagSet, elog
 			return nil, errors.New("at least one config flag must be provided")
 		}
 
-		set.ConfigProvider, err = NewConfigProvider(newDefaultConfigProviderSettings(configFlags))
+		set.ConfigProvider, err = NewConfigProvider(NewDefaultConfigProviderSettings(configFlags))
 		if err != nil {
 			return nil, err
 		}

--- a/otelcol/command.go
+++ b/otelcol/command.go
@@ -41,7 +41,7 @@ func NewCommand(set CollectorSettings) *cobra.Command {
 					return errors.New("at least one config flag must be provided")
 				}
 
-				set.ConfigProvider, err = NewConfigProvider(newDefaultConfigProviderSettings(configFlags))
+				set.ConfigProvider, err = NewConfigProvider(NewDefaultConfigProviderSettings(configFlags))
 				if err != nil {
 					return err
 				}

--- a/otelcol/command_components_test.go
+++ b/otelcol/command_components_test.go
@@ -31,7 +31,7 @@ func TestNewBuildSubCommand(t *testing.T) {
 	factories, err := nopFactories()
 	require.NoError(t, err)
 
-	cfgProvider, err := NewConfigProvider(newDefaultConfigProviderSettings([]string{filepath.Join("testdata", "otelcol-nop.yaml")}))
+	cfgProvider, err := NewConfigProvider(NewDefaultConfigProviderSettings([]string{filepath.Join("testdata", "otelcol-nop.yaml")}))
 	require.NoError(t, err)
 
 	set := CollectorSettings{

--- a/otelcol/configprovider.go
+++ b/otelcol/configprovider.go
@@ -115,7 +115,7 @@ func (cm *configProvider) Shutdown(ctx context.Context) error {
 	return cm.mapResolver.Shutdown(ctx)
 }
 
-func newDefaultConfigProviderSettings(uris []string) ConfigProviderSettings {
+func NewDefaultConfigProviderSettings(uris []string) ConfigProviderSettings {
 	return ConfigProviderSettings{
 		ResolverSettings: confmap.ResolverSettings{
 			URIs:       uris,


### PR DESCRIPTION
Signed-off-by: Travis Tomsu travis.tomsu@gmail.com

**Description:** Makes the function to create default config provider settings public, enabling using this function in e2e unit tests. Not sure why this is private, but the other functions to make e2e unit tests work are public (service.New -> service.CollectorSettings struct -> service.ConfigProvider). 

I currently have a copy of this function in my codebase, but I'd like to be able to use the one that's included by default to confirm everything starts up as intended.

**Testing:** Passed locally.
