### PR TITLE
[chore]add package and examples documentation to configopaque package

### DIFF
--- a/config/configopaque/doc.go
+++ b/config/configopaque/doc.go
@@ -15,7 +15,7 @@
 // Package configopaque implements String type alias to mask sensitive information.
 // Use configopaque.String on the type of sensitive fields, to mask the
 // opaque string into a string of '*' of equal length.
-
+//
 // This ensure that no sensitive information is leaked when printing the
 // full Collector configurations.
 package configopaque // import "go.opentelemetry.io/collector/config/configopaque"

--- a/config/configopaque/doc.go
+++ b/config/configopaque/doc.go
@@ -1,0 +1,21 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package configopaque implements String type alias to mask sensitive information.
+// Use configopaque.String on the type of sensitive fields, to mask the
+// opaque string into a string of '*' of equal length.
+
+// This ensure that no sensitive information is leaked when printing the
+// full Collector configurations.
+package configopaque // import "go.opentelemetry.io/collector/config/configopaque"

--- a/config/configopaque/doc.go
+++ b/config/configopaque/doc.go
@@ -14,7 +14,7 @@
 
 // Package configopaque implements String type alias to mask sensitive information.
 // Use configopaque.String on the type of sensitive fields, to mask the
-// opaque string into a string of '*' of equal length.
+// opaque string as `[REDACTED]`.
 //
 // This ensure that no sensitive information is leaked when printing the
 // full Collector configurations.

--- a/config/configopaque/doc_test.go
+++ b/config/configopaque/doc_test.go
@@ -42,7 +42,7 @@ func Example_opaqueString() {
 	}
 	fmt.Printf("encoded cfg (YAML) is:\n%s\n\n", string(bytes))
 	//Output: encoded cfg (YAML) is:
-	// censored: '*********'
+	// censored: '[REDACTED]'
 	// uncensored: not sensitive
 }
 
@@ -66,9 +66,9 @@ func Example_opaqueSlice() {
 	//Output: encoded cfg (JSON) is
 	// {
 	//   "Censored": [
-	//     "****",
-	//     "**",
-	//     "*********"
+	//     "[REDACTED]",
+	//     "[REDACTED]",
+	//     "[REDACTED]"
 	//   ],
 	//   "Uncensored": [
 	//     "data",
@@ -103,7 +103,7 @@ func Example_opaqueMap() {
 	fmt.Printf("encoded cfg (YAML) is:\n%s\n\n", string(bytes))
 	//Output: encoded cfg (YAML) is:
 	//censored:
-	//     token: '**************'
+	//     token: '[REDACTED]'
 	//uncensored:
 	//     key: cloud.zone
 	//     value: zone-1

--- a/config/configopaque/doc_test.go
+++ b/config/configopaque/doc_test.go
@@ -18,8 +18,9 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"go.opentelemetry.io/collector/config/configopaque"
 	"gopkg.in/yaml.v3"
+
+	"go.opentelemetry.io/collector/config/configopaque"
 )
 
 func Example_opaqueString() {

--- a/config/configopaque/doc_test.go
+++ b/config/configopaque/doc_test.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 
 	"go.opentelemetry.io/collector/config/configopaque"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 func Example_opaqueString() {
@@ -102,11 +102,11 @@ func Example_opaqueMap() {
 	}
 	fmt.Printf("encoded cfg (YAML) is:\n%s\n\n", string(bytes))
 	//Output: encoded cfg (YAML) is:
-	// censored:
-	//   token: '**************'
-	// uncensored:
-	//   key: cloud.zone
-	//   value: zone-1
+	//censored:
+	//     token: '**************'
+	//uncensored:
+	//     key: cloud.zone
+	//     value: zone-1
 }
 
 type ExampleConfigMap struct {

--- a/config/configopaque/doc_test.go
+++ b/config/configopaque/doc_test.go
@@ -1,0 +1,115 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package configopaque_test
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"go.opentelemetry.io/collector/config/configopaque"
+	"gopkg.in/yaml.v2"
+)
+
+func Example_opaqueString() {
+	rawBytes := []byte(`{
+		"Censored":   "sensitive",
+		"Uncensored": "not sensitive"
+	}`)
+
+	// JSON unmarshaling
+	var cfg ExampleConfigString
+	err := json.Unmarshal(rawBytes, &cfg)
+	if err != nil {
+		panic(err)
+	}
+
+	// YAML marshaling
+	bytes, err := yaml.Marshal(cfg)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("encoded cfg (YAML) is:\n%s\n\n", string(bytes))
+	//Output: encoded cfg (YAML) is:
+	// censored: '*********'
+	// uncensored: not sensitive
+}
+
+type ExampleConfigString struct {
+	Censored   configopaque.String
+	Uncensored string
+}
+
+func Example_opaqueSlice() {
+	cfg := &ExampleConfigSlice{
+		Censored:   []configopaque.String{"data", "is", "sensitive"},
+		Uncensored: []string{"data", "is", "not", "sensitive"},
+	}
+
+	// JSON marshaling
+	bytes, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("encoded cfg (JSON) is\n%s\n\n", string(bytes))
+	//Output: encoded cfg (JSON) is
+	// {
+	//   "Censored": [
+	//     "****",
+	//     "**",
+	//     "*********"
+	//   ],
+	//   "Uncensored": [
+	//     "data",
+	//     "is",
+	//     "not",
+	//     "sensitive"
+	//   ]
+	// }
+}
+
+type ExampleConfigSlice struct {
+	Censored   []configopaque.String
+	Uncensored []string
+}
+
+func Example_opaqueMap() {
+	cfg := &ExampleConfigMap{
+		Censored: map[string]configopaque.String{
+			"token": "sensitivetoken",
+		},
+		Uncensored: map[string]string{
+			"key":   "cloud.zone",
+			"value": "zone-1",
+		},
+	}
+
+	// yaml marshaling
+	bytes, err := yaml.Marshal(cfg)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("encoded cfg (YAML) is:\n%s\n\n", string(bytes))
+	//Output: encoded cfg (YAML) is:
+	// censored:
+	//   token: '**************'
+	// uncensored:
+	//   key: cloud.zone
+	//   value: zone-1
+}
+
+type ExampleConfigMap struct {
+	Censored   map[string]configopaque.String
+	Uncensored map[string]string
+}


### PR DESCRIPTION
**Description:** <Describe what has changed. 
- Add a package-level comment for `configopaque` package
- Add examples test to showcase how the configuration struct with field `configopaque.String`,` []configopaque.String` and `map[string]configopaque.String` looks once marshalled.

**Link to tracking Issue:** <Issue number if applicable>
#6855

**Testing:** < Describe what testing was performed and which tests were added.>
Add example test with the expected output.

**Documentation:** 
N/A
