### PR TITLE
[config/configopaque] fix secret length disclosure with configopaque String

### DIFF
--- a/.chloggen/opaque-fixed-length.yaml
+++ b/.chloggen/opaque-fixed-length.yaml
@@ -5,7 +5,7 @@ change_type: bug_fix
 component: config
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: set a fixed length to the asterisks string printed by configopaque.String, instead of disclosing secret length.
+note: use [REDACTED] when marshaling to text a configopaque.String, instead of disclosing secret length.
 
 # One or more tracking issues or pull requests related to the change
 issues: [6868]

--- a/.chloggen/opaque-fixed-length.yaml
+++ b/.chloggen/opaque-fixed-length.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: config
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: set a fixed length to the asterisks string printed by configopaque.String, instead of disclosing secret length.
+
+# One or more tracking issues or pull requests related to the change
+issues: [6868]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/config/configopaque/opaque.go
+++ b/config/configopaque/opaque.go
@@ -21,13 +21,13 @@ import (
 // String alias that is marshaled in an opaque way.
 type String string
 
-const maskedString = "********"
+const maskedString = "[REDACTED]"
 
 var maskedBytes = []byte(maskedString)
 
 var _ encoding.TextMarshaler = String("")
 
-// MarshalText marshals into a string of 8 '*' characters.
+// MarshalText marshals the string as `[REDACTED]`.
 func (s String) MarshalText() ([]byte, error) {
 	return maskedBytes, nil
 }

--- a/config/configopaque/opaque.go
+++ b/config/configopaque/opaque.go
@@ -23,11 +23,9 @@ type String string
 
 const maskedString = "[REDACTED]"
 
-var maskedBytes = []byte(maskedString)
-
 var _ encoding.TextMarshaler = String("")
 
 // MarshalText marshals the string as `[REDACTED]`.
 func (s String) MarshalText() ([]byte, error) {
-	return maskedBytes, nil
+	return []byte(maskedString), nil
 }

--- a/config/configopaque/opaque.go
+++ b/config/configopaque/opaque.go
@@ -15,16 +15,19 @@
 package configopaque // import "go.opentelemetry.io/collector/config/configopaque"
 
 import (
-	"bytes"
 	"encoding"
 )
 
 // String alias that is marshaled in an opaque way.
 type String string
 
+const maskedString = "********"
+
+var maskedBytes = []byte(maskedString)
+
 var _ encoding.TextMarshaler = String("")
 
-// MarshalText marshals into a string of '*' of length equal to the opaque string.
+// MarshalText marshals into a string of 8 '*' characters.
 func (s String) MarshalText() ([]byte, error) {
-	return bytes.Repeat([]byte("*"), len(s)), nil
+	return maskedBytes, nil
 }

--- a/config/configopaque/opaque_test.go
+++ b/config/configopaque/opaque_test.go
@@ -22,9 +22,10 @@ import (
 )
 
 func TestStringMarshalText(t *testing.T) {
-	var example String = "opaque"
-
-	opaque, err := example.MarshalText()
-	require.NoError(t, err)
-	assert.Equal(t, "******", string(opaque))
+	examples := []String{"opaque", "s", "veryveryveryveryveryveryveryveryveryverylong"}
+	for _, example := range examples {
+		opaque, err := example.MarshalText()
+		require.NoError(t, err)
+		assert.Equal(t, "********", string(opaque))
+	}
 }

--- a/config/configopaque/opaque_test.go
+++ b/config/configopaque/opaque_test.go
@@ -26,6 +26,6 @@ func TestStringMarshalText(t *testing.T) {
 	for _, example := range examples {
 		opaque, err := example.MarshalText()
 		require.NoError(t, err)
-		assert.Equal(t, "********", string(opaque))
+		assert.Equal(t, "[REDACTED]", string(opaque))
 	}
 }


### PR DESCRIPTION
**Description:**
Fix secret length disclosure with configopaque String. Use a 8 byte length consistently.

**Link to tracking Issue:**
#6868

**Testing:**
Added tests to show how the same string is outputted no matter what length of the secret
