### PR TITLE
Fix: Force usage of case-sensitive keys in configurations

### DIFF
--- a/.chloggen/case-sensitive-configuration.yaml
+++ b/.chloggen/case-sensitive-configuration.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'bug_fix'
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: confmap
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix bug in confmap validation that allowed the usage of case-insensitive keys in the configurations, leading to unexpected behavior.
+
+# One or more tracking issues or pull requests related to the change
+issues: [6876]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/case-sensitive-configuration.yaml
+++ b/.chloggen/case-sensitive-configuration.yaml
@@ -5,7 +5,7 @@ change_type: 'bug_fix'
 component: confmap
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Fix bug in confmap validation that allowed the usage of case-insensitive keys in the configurations, leading to unexpected behavior.
+note: Fix bug in confmap validation that allowed the usage of case-insensitive keys in the configurations, despite them failing silently.
 
 # One or more tracking issues or pull requests related to the change
 issues: [6876]

--- a/confmap/confmap.go
+++ b/confmap/confmap.go
@@ -193,8 +193,8 @@ func encoderConfig(rawVal interface{}) *encoder.EncoderConfig {
 // case-sensitive version of the callback to be used in the MatchName property
 // of the DecoderConfig. The default for MatchEqual is to use strings.EqualFold,
 // which is case-insensitive.
-func caseSensitiveMatchName() func(mapKey, keyName string) bool {
-	return func(mapKey, keyName string) bool { return mapKey == keyName }
+func caseSensitiveMatchName() func(a, b string) bool {
+	return func(a, b string) bool { return a == b }
 }
 
 // In cases where a config has a mapping of something to a struct pointers

--- a/confmap/confmap.go
+++ b/confmap/confmap.go
@@ -161,7 +161,7 @@ func decodeConfig(m *Conf, result interface{}, errorUnused bool) error {
 		Result:           result,
 		TagName:          "mapstructure",
 		WeaklyTypedInput: true,
-		MatchName:        caseSensitiveMatchName(),
+		MatchName:        caseSensitiveMatchName,
 		DecodeHook: mapstructure.ComposeDecodeHookFunc(
 			expandNilStructPointersHookFunc(),
 			mapstructure.StringToSliceHookFunc(","),
@@ -193,8 +193,8 @@ func encoderConfig(rawVal interface{}) *encoder.EncoderConfig {
 // case-sensitive version of the callback to be used in the MatchName property
 // of the DecoderConfig. The default for MatchEqual is to use strings.EqualFold,
 // which is case-insensitive.
-func caseSensitiveMatchName() func(a, b string) bool {
-	return func(a, b string) bool { return a == b }
+func caseSensitiveMatchName(a, b string) bool {
+	return a == b
 }
 
 // In cases where a config has a mapping of something to a struct pointers

--- a/confmap/confmap.go
+++ b/confmap/confmap.go
@@ -161,6 +161,7 @@ func decodeConfig(m *Conf, result interface{}, errorUnused bool) error {
 		Result:           result,
 		TagName:          "mapstructure",
 		WeaklyTypedInput: true,
+		MatchName:        caseSensitiveMatchName(),
 		DecodeHook: mapstructure.ComposeDecodeHookFunc(
 			expandNilStructPointersHookFunc(),
 			mapstructure.StringToSliceHookFunc(","),
@@ -187,6 +188,13 @@ func encoderConfig(rawVal interface{}) *encoder.EncoderConfig {
 			marshalerHookFunc(rawVal),
 		),
 	}
+}
+
+// case-sensitive version of the callback to be used in the MatchName property
+// of the DecoderConfig. The default for MatchEqual is to use strings.EqualFold,
+// which is case-insensitive.
+func caseSensitiveMatchName() func(mapKey, keyName string) bool {
+	return func(mapKey, keyName string) bool { return mapKey == keyName }
 }
 
 // In cases where a config has a mapping of something to a struct pointers

--- a/exporter/loggingexporter/config_test.go
+++ b/exporter/loggingexporter/config_test.go
@@ -74,6 +74,10 @@ func TestUnmarshalConfig(t *testing.T) {
 			filename:    "invalid_verbosity_loglevel.yaml",
 			expectedErr: "'loglevel' and 'verbosity' are incompatible. Use only 'verbosity' instead",
 		},
+		{
+			filename:    "config_loglevel_typo.yaml",
+			expectedErr: "1 error(s) decoding:\n\n* '' has invalid keys: logLevel",
+		},
 	}
 
 	for _, tt := range tests {

--- a/exporter/loggingexporter/testdata/config_loglevel_typo.yaml
+++ b/exporter/loggingexporter/testdata/config_loglevel_typo.yaml
@@ -1,0 +1,2 @@
+# Typo in the configuration that assumes that this property is camelcase
+logLevel: debug


### PR DESCRIPTION
Signed-off-by: Raphael Silva <rapphil@gmail.com>

**Description:** Fix bug that allowed users to specify invalid configurations that would pass validation but would not work properly or fail silently. E.g.: `loglevel`. If you specify `logLevel`, the validation would pass but the collector logging exporter would not produce logs.

**Testing:** Added unit test before changing the code.
