### PR TITLE
Add connector.MakeFactoryMap

### DIFF
--- a/.chloggen/connector-factory-map.yaml
+++ b/.chloggen/connector-factory-map.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: connector
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add MakeFactoryMap
+
+# One or more tracking issues or pull requests related to the change
+issues: [6889]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/connector/connector.go
+++ b/connector/connector.go
@@ -453,3 +453,16 @@ func NewFactory(cfgType component.Type, createDefaultConfig component.CreateDefa
 	}
 	return f
 }
+
+// MakeFactoryMap takes a list of connector factories and returns a map with factory type as keys.
+// It returns a non-nil error when there are factories with duplicate type.
+func MakeFactoryMap(factories ...Factory) (map[component.Type]Factory, error) {
+	fMap := map[component.Type]Factory{}
+	for _, f := range factories {
+		if _, ok := fMap[f.Type()]; ok {
+			return fMap, fmt.Errorf("duplicate connector factory %q", f.Type())
+		}
+		fMap[f.Type()] = f
+	}
+	return fMap, nil
+}

--- a/connector/connector_test.go
+++ b/connector/connector_test.go
@@ -183,6 +183,44 @@ func TestNewFactoryWithAllTypes(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestMakeFactoryMap(t *testing.T) {
+	type testCase struct {
+		name string
+		in   []Factory
+		out  map[component.Type]Factory
+	}
+
+	p1 := NewFactory("p1", nil)
+	p2 := NewFactory("p2", nil)
+	testCases := []testCase{
+		{
+			name: "different names",
+			in:   []Factory{p1, p2},
+			out: map[component.Type]Factory{
+				p1.Type(): p1,
+				p2.Type(): p2,
+			},
+		},
+		{
+			name: "same name",
+			in:   []Factory{p1, p2, NewFactory("p1", nil)},
+		},
+	}
+
+	for i := range testCases {
+		tt := testCases[i]
+		t.Run(tt.name, func(t *testing.T) {
+			out, err := MakeFactoryMap(tt.in...)
+			if tt.out == nil {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.out, out)
+		})
+	}
+}
+
 func createTracesToTraces(context.Context, CreateSettings, component.Config, consumer.Traces) (Traces, error) {
 	return nil, nil
 }


### PR DESCRIPTION
This adds the `connector.MakeFactoryMap` function, similar to that found in other component type packages.