### PR TITLE
Add testcomponents.StatefulComponent

### DIFF
--- a/service/internal/testcomponents/example_connector.go
+++ b/service/internal/testcomponents/example_connector.go
@@ -117,23 +117,10 @@ func createExampleLogsToLogs(_ context.Context, _ connector.CreateSettings, _ co
 }
 
 type ExampleConnector struct {
+	componentState
 	consumer.ConsumeTracesFunc
 	consumer.ConsumeMetricsFunc
 	consumer.ConsumeLogsFunc
-	Started bool
-	Stopped bool
-}
-
-// Start tells the Connector to start.
-func (c *ExampleConnector) Start(_ context.Context, _ component.Host) error {
-	c.Started = true
-	return nil
-}
-
-// Shutdown is invoked during shutdown.
-func (c *ExampleConnector) Shutdown(context.Context) error {
-	c.Stopped = true
-	return nil
 }
 
 func (c *ExampleConnector) Capabilities() consumer.Capabilities {

--- a/service/internal/testcomponents/example_connector_test.go
+++ b/service/internal/testcomponents/example_connector_test.go
@@ -26,11 +26,11 @@ import (
 func TestExampleConnector(t *testing.T) {
 	conn := &ExampleConnector{}
 	host := componenttest.NewNopHost()
-	assert.False(t, conn.Started)
+	assert.False(t, conn.Started())
 	assert.NoError(t, conn.Start(context.Background(), host))
-	assert.True(t, conn.Started)
+	assert.True(t, conn.Started())
 
-	assert.False(t, conn.Stopped)
+	assert.False(t, conn.Stopped())
 	assert.NoError(t, conn.Shutdown(context.Background()))
-	assert.True(t, conn.Stopped)
+	assert.True(t, conn.Stopped())
 }

--- a/service/internal/testcomponents/example_exporter.go
+++ b/service/internal/testcomponents/example_exporter.go
@@ -57,19 +57,10 @@ func createLogsExporter(context.Context, exporter.CreateSettings, component.Conf
 
 // ExampleExporter stores consumed traces and metrics for testing purposes.
 type ExampleExporter struct {
+	componentState
 	Traces  []ptrace.Traces
 	Metrics []pmetric.Metrics
 	Logs    []plog.Logs
-	Started bool
-	Stopped bool
-}
-
-// Start tells the exporter to start. The exporter may prepare for exporting
-// by connecting to the endpoint. Host parameter can be used for communicating
-// with the host after Start() has already returned.
-func (exp *ExampleExporter) Start(_ context.Context, _ component.Host) error {
-	exp.Started = true
-	return nil
 }
 
 // ConsumeTraces receives ptrace.Traces for processing by the consumer.Traces.
@@ -78,23 +69,18 @@ func (exp *ExampleExporter) ConsumeTraces(_ context.Context, td ptrace.Traces) e
 	return nil
 }
 
-func (exp *ExampleExporter) Capabilities() consumer.Capabilities {
-	return consumer.Capabilities{MutatesData: false}
-}
-
 // ConsumeMetrics receives pmetric.Metrics for processing by the Metrics.
 func (exp *ExampleExporter) ConsumeMetrics(_ context.Context, md pmetric.Metrics) error {
 	exp.Metrics = append(exp.Metrics, md)
 	return nil
 }
 
+// ConsumeLogs receives plog.Logs for processing by the Logs.
 func (exp *ExampleExporter) ConsumeLogs(_ context.Context, ld plog.Logs) error {
 	exp.Logs = append(exp.Logs, ld)
 	return nil
 }
 
-// Shutdown is invoked during shutdown.
-func (exp *ExampleExporter) Shutdown(context.Context) error {
-	exp.Stopped = true
-	return nil
+func (exp *ExampleExporter) Capabilities() consumer.Capabilities {
+	return consumer.Capabilities{MutatesData: false}
 }

--- a/service/internal/testcomponents/example_exporter_test.go
+++ b/service/internal/testcomponents/example_exporter_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 )
@@ -28,9 +29,9 @@ import (
 func TestExampleExporter(t *testing.T) {
 	exp := &ExampleExporter{}
 	host := componenttest.NewNopHost()
-	assert.False(t, exp.Started)
+	assert.False(t, exp.Started())
 	assert.NoError(t, exp.Start(context.Background(), host))
-	assert.True(t, exp.Started)
+	assert.True(t, exp.Started())
 
 	assert.Equal(t, 0, len(exp.Traces))
 	assert.NoError(t, exp.ConsumeTraces(context.Background(), ptrace.Traces{}))
@@ -40,7 +41,11 @@ func TestExampleExporter(t *testing.T) {
 	assert.NoError(t, exp.ConsumeMetrics(context.Background(), pmetric.Metrics{}))
 	assert.Equal(t, 1, len(exp.Metrics))
 
-	assert.False(t, exp.Stopped)
+	assert.Equal(t, 0, len(exp.Logs))
+	assert.NoError(t, exp.ConsumeLogs(context.Background(), plog.Logs{}))
+	assert.Equal(t, 1, len(exp.Logs))
+
+	assert.False(t, exp.Stopped())
 	assert.NoError(t, exp.Shutdown(context.Background()))
-	assert.True(t, exp.Stopped)
+	assert.True(t, exp.Stopped())
 }

--- a/service/internal/testcomponents/example_processor.go
+++ b/service/internal/testcomponents/example_processor.go
@@ -38,33 +38,22 @@ func createDefaultConfig() component.Config {
 }
 
 func createTracesProcessor(_ context.Context, _ processor.CreateSettings, _ component.Config, nextConsumer consumer.Traces) (processor.Traces, error) {
-	return &ExampleProcessor{Traces: nextConsumer}, nil
+	return &ExampleProcessor{ConsumeTracesFunc: nextConsumer.ConsumeTraces}, nil
 }
 
 func createMetricsProcessor(_ context.Context, _ processor.CreateSettings, _ component.Config, nextConsumer consumer.Metrics) (processor.Metrics, error) {
-	return &ExampleProcessor{Metrics: nextConsumer}, nil
+	return &ExampleProcessor{ConsumeMetricsFunc: nextConsumer.ConsumeMetrics}, nil
 }
 
 func createLogsProcessor(_ context.Context, _ processor.CreateSettings, _ component.Config, nextConsumer consumer.Logs) (processor.Logs, error) {
-	return &ExampleProcessor{Logs: nextConsumer}, nil
+	return &ExampleProcessor{ConsumeLogsFunc: nextConsumer.ConsumeLogs}, nil
 }
 
 type ExampleProcessor struct {
-	consumer.Traces
-	consumer.Metrics
-	consumer.Logs
-	Started bool
-	Stopped bool
-}
-
-func (ep *ExampleProcessor) Start(_ context.Context, _ component.Host) error {
-	ep.Started = true
-	return nil
-}
-
-func (ep *ExampleProcessor) Shutdown(_ context.Context) error {
-	ep.Stopped = true
-	return nil
+	componentState
+	consumer.ConsumeTracesFunc
+	consumer.ConsumeMetricsFunc
+	consumer.ConsumeLogsFunc
 }
 
 func (ep *ExampleProcessor) Capabilities() consumer.Capabilities {

--- a/service/internal/testcomponents/example_receiver.go
+++ b/service/internal/testcomponents/example_receiver.go
@@ -44,7 +44,7 @@ func createTracesReceiver(
 	nextConsumer consumer.Traces,
 ) (receiver.Traces, error) {
 	tr := createReceiver(cfg)
-	tr.Traces = nextConsumer
+	tr.ConsumeTracesFunc = nextConsumer.ConsumeTraces
 	return tr, nil
 }
 
@@ -56,7 +56,7 @@ func createMetricsReceiver(
 	nextConsumer consumer.Metrics,
 ) (receiver.Metrics, error) {
 	mr := createReceiver(cfg)
-	mr.Metrics = nextConsumer
+	mr.ConsumeMetricsFunc = nextConsumer.ConsumeMetrics
 	return mr, nil
 }
 
@@ -67,7 +67,7 @@ func createLogsReceiver(
 	nextConsumer consumer.Logs,
 ) (receiver.Logs, error) {
 	lr := createReceiver(cfg)
-	lr.Logs = nextConsumer
+	lr.ConsumeLogsFunc = nextConsumer.ConsumeLogs
 	return lr, nil
 }
 
@@ -88,23 +88,10 @@ func createReceiver(cfg component.Config) *ExampleReceiver {
 
 // ExampleReceiver allows producing traces and metrics for testing purposes.
 type ExampleReceiver struct {
-	consumer.Traces
-	consumer.Metrics
-	consumer.Logs
-	Started bool
-	Stopped bool
-}
-
-// Start tells the receiver to start its processing.
-func (erp *ExampleReceiver) Start(_ context.Context, _ component.Host) error {
-	erp.Started = true
-	return nil
-}
-
-// Shutdown tells the receiver that should stop reception,
-func (erp *ExampleReceiver) Shutdown(context.Context) error {
-	erp.Stopped = true
-	return nil
+	componentState
+	consumer.ConsumeTracesFunc
+	consumer.ConsumeMetricsFunc
+	consumer.ConsumeLogsFunc
 }
 
 // This is the map of already created example receivers for particular configurations.

--- a/service/internal/testcomponents/example_receiver_test.go
+++ b/service/internal/testcomponents/example_receiver_test.go
@@ -26,11 +26,11 @@ import (
 func TestExampleReceiver(t *testing.T) {
 	rcv := &ExampleReceiver{}
 	host := componenttest.NewNopHost()
-	assert.False(t, rcv.Started)
+	assert.False(t, rcv.Started())
 	assert.NoError(t, rcv.Start(context.Background(), host))
-	assert.True(t, rcv.Started)
+	assert.True(t, rcv.Started())
 
-	assert.False(t, rcv.Stopped)
+	assert.False(t, rcv.Stopped())
 	assert.NoError(t, rcv.Shutdown(context.Background()))
-	assert.True(t, rcv.Stopped)
+	assert.True(t, rcv.Stopped())
 }

--- a/service/internal/testcomponents/stateful_component.go
+++ b/service/internal/testcomponents/stateful_component.go
@@ -12,25 +12,33 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package testcomponents
+package testcomponents // import "go.opentelemetry.io/collector/service/internal/testcomponents"
 
 import (
 	"context"
-	"testing"
 
-	"github.com/stretchr/testify/assert"
-
-	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/component"
 )
 
-func TestExampleProcessor(t *testing.T) {
-	prc := &ExampleProcessor{}
-	host := componenttest.NewNopHost()
-	assert.False(t, prc.Started())
-	assert.NoError(t, prc.Start(context.Background(), host))
-	assert.True(t, prc.Started())
+type componentState struct {
+	started bool
+	stopped bool
+}
 
-	assert.False(t, prc.Stopped())
-	assert.NoError(t, prc.Shutdown(context.Background()))
-	assert.True(t, prc.Stopped())
+func (cs *componentState) Started() bool {
+	return cs.started
+}
+
+func (cs *componentState) Stopped() bool {
+	return cs.stopped
+}
+
+func (cs *componentState) Start(_ context.Context, _ component.Host) error {
+	cs.started = true
+	return nil
+}
+
+func (cs *componentState) Shutdown(_ context.Context) error {
+	cs.stopped = true
+	return nil
 }

--- a/service/pipelines_test.go
+++ b/service/pipelines_test.go
@@ -218,7 +218,7 @@ func TestBuildPipelines(t *testing.T) {
 				// Verify exporters created, started and empty.
 				for _, expID := range pipeline.Exporters {
 					exp := pipelines.GetExporters()[dt.Type()][expID].(*testcomponents.ExampleExporter)
-					assert.True(t, exp.Started)
+					assert.True(t, exp.Started())
 					switch dt.Type() {
 					case component.DataTypeTraces:
 						assert.Len(t, exp.Traces, 0)
@@ -233,13 +233,13 @@ func TestBuildPipelines(t *testing.T) {
 				for i, procID := range pipeline.Processors {
 					processor := pipelines.pipelines[dt].processors[i]
 					assert.Equal(t, procID, processor.id)
-					assert.True(t, processor.comp.(*testcomponents.ExampleProcessor).Started)
+					assert.True(t, processor.comp.(*testcomponents.ExampleProcessor).Started())
 				}
 
 				// Verify receivers created, started and send data to confirm pipelines correctly connected.
 				for _, recvID := range pipeline.Receivers {
 					receiver := pipelines.allReceivers[dt.Type()][recvID].(*testcomponents.ExampleReceiver)
-					assert.True(t, receiver.Started)
+					assert.True(t, receiver.Started())
 				}
 			}
 
@@ -264,13 +264,13 @@ func TestBuildPipelines(t *testing.T) {
 				// Verify receivers shutdown.
 				for _, recvID := range pipeline.Receivers {
 					receiver := pipelines.allReceivers[dt.Type()][recvID].(*testcomponents.ExampleReceiver)
-					assert.True(t, receiver.Stopped)
+					assert.True(t, receiver.Stopped())
 				}
 
 				// Verify processors shutdown.
 				for i := range pipeline.Processors {
 					processor := pipelines.pipelines[dt].processors[i]
-					assert.True(t, processor.comp.(*testcomponents.ExampleProcessor).Stopped)
+					assert.True(t, processor.comp.(*testcomponents.ExampleProcessor).Stopped())
 				}
 
 				// Now verify that exporters received data, and are shutdown.
@@ -287,7 +287,7 @@ func TestBuildPipelines(t *testing.T) {
 						require.Len(t, exp.Logs, test.expectedRequests)
 						assert.EqualValues(t, testdata.GenerateLogs(1), exp.Logs[0])
 					}
-					assert.True(t, exp.Stopped)
+					assert.True(t, exp.Stopped())
 				}
 			}
 		})


### PR DESCRIPTION
This is a small part of #6700. The main idea is to provide a common way to validate components, especially in complex pipelines. Current tests rely on uniform expectations such as all exporters receiving 1 signal. However, testing the connector framework would ideally include expectations on a per-component basis.

This PR adds only the basic start/stop functionality, which itself reduces repetitive code somewhat. In the future, I would like to validating expected signals observed by each component.