### PR TITLE
Add component node types

### DIFF
--- a/cmd/otelcorecol/go.mod
+++ b/cmd/otelcorecol/go.mod
@@ -84,6 +84,7 @@ require (
 	go.uber.org/zap v1.24.0 // indirect
 	golang.org/x/net v0.5.0 // indirect
 	golang.org/x/text v0.6.0 // indirect
+	gonum.org/v1/gonum v0.12.0 // indirect
 	google.golang.org/genproto v0.0.0-20221118155620-16455021b5e6 // indirect
 	google.golang.org/grpc v1.52.0 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect

--- a/cmd/otelcorecol/go.sum
+++ b/cmd/otelcorecol/go.sum
@@ -470,6 +470,7 @@ golang.org/x/exp v0.0.0-20191129062945-2f5052295587/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
+golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6 h1:QE6XYQK6naiK1EPAe1g/ILLxN5RBoH5xkJk3CqlMI/Y=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
@@ -678,6 +679,8 @@ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+gonum.org/v1/gonum v0.12.0 h1:xKuo6hzt+gMav00meVPUlXwSdoEJP46BR+wdxQEFK2o=
+gonum.org/v1/gonum v0.12.0/go.mod h1:73TDxJfAAHeA8Mk9mf8NlIppyhQNo5GLTcYeqgo2lvY=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E3M=
 google.golang.org/api v0.8.0/go.mod h1:o4eAsZoiT+ibD93RtjEohWalFOjRDx6CVaqeizhEnKg=

--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	go.uber.org/zap v1.24.0
 	golang.org/x/net v0.5.0
 	golang.org/x/sys v0.4.0
+	gonum.org/v1/gonum v0.12.0
 	google.golang.org/grpc v1.52.0
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -471,6 +471,7 @@ golang.org/x/exp v0.0.0-20191129062945-2f5052295587/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
+golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6 h1:QE6XYQK6naiK1EPAe1g/ILLxN5RBoH5xkJk3CqlMI/Y=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
@@ -679,6 +680,8 @@ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+gonum.org/v1/gonum v0.12.0 h1:xKuo6hzt+gMav00meVPUlXwSdoEJP46BR+wdxQEFK2o=
+gonum.org/v1/gonum v0.12.0/go.mod h1:73TDxJfAAHeA8Mk9mf8NlIppyhQNo5GLTcYeqgo2lvY=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E3M=
 google.golang.org/api v0.8.0/go.mod h1:o4eAsZoiT+ibD93RtjEohWalFOjRDx6CVaqeizhEnKg=

--- a/service/nodes.go
+++ b/service/nodes.go
@@ -1,0 +1,120 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// nolint:unused
+package service // import "go.opentelemetry.io/collector/service"
+
+import (
+	"hash/fnv"
+	"strings"
+
+	"gonum.org/v1/gonum/graph"
+
+	"go.opentelemetry.io/collector/component"
+)
+
+type nodeID int64
+
+func (n nodeID) ID() int64 {
+	return int64(n)
+}
+
+func newNodeID(parts ...string) nodeID {
+	h := fnv.New64a()
+	h.Write([]byte(strings.Join(parts, "|")))
+	return nodeID(h.Sum64())
+}
+
+type componentNode interface {
+	component.Component
+	graph.Node
+}
+
+var _ componentNode = &receiverNode{}
+
+// A receiver instance can be shared by multiple pipelines of the same type.
+// Therefore, nodeID is derived from "pipeline type" and "component ID".
+type receiverNode struct {
+	nodeID
+	componentID  component.ID
+	pipelineType component.DataType
+	component.Component
+}
+
+func newReceiverNode(pipelineID component.ID, recvID component.ID) *receiverNode {
+	return &receiverNode{
+		nodeID:       newNodeID("receiver", string(pipelineID.Type()), recvID.String()),
+		componentID:  recvID,
+		pipelineType: pipelineID.Type(),
+	}
+}
+
+var _ componentNode = &processorNode{}
+
+// Every processor instance is unique to one pipeline.
+// Therefore, nodeID is derived from "pipeline ID" and "component ID".
+type processorNode struct {
+	nodeID
+	componentID component.ID
+	pipelineID  component.ID
+	component.Component
+}
+
+func newProcessorNode(pipelineID, procID component.ID) *processorNode {
+	return &processorNode{
+		nodeID:      newNodeID("processor", pipelineID.String(), procID.String()),
+		componentID: procID,
+		pipelineID:  pipelineID,
+	}
+}
+
+var _ componentNode = &exporterNode{}
+
+// An exporter instance can be shared by multiple pipelines of the same type.
+// Therefore, nodeID is derived from "pipeline type" and "component ID".
+type exporterNode struct {
+	nodeID
+	componentID  component.ID
+	pipelineType component.DataType
+	component.Component
+}
+
+func newExporterNode(pipelineID component.ID, exprID component.ID) *exporterNode {
+	return &exporterNode{
+		nodeID:       newNodeID("exporter", string(pipelineID.Type()), exprID.String()),
+		componentID:  exprID,
+		pipelineType: pipelineID.Type(),
+	}
+}
+
+var _ componentNode = &connectorNode{}
+
+// A connector instance connects one pipeline type to one other pipeline type.
+// Therefore, nodeID is derived from "exporter pipeline type", "receiver pipeline type", and "component ID".
+type connectorNode struct {
+	nodeID
+	componentID      component.ID
+	exprPipelineType component.DataType
+	rcvrPipelineType component.DataType
+	component.Component
+}
+
+func newConnectorNode(exprPipelineType, rcvrPipelineType component.DataType, connID component.ID) *connectorNode {
+	return &connectorNode{
+		nodeID:           newNodeID("connector", connID.String(), string(exprPipelineType), string(rcvrPipelineType)),
+		componentID:      connID,
+		exprPipelineType: exprPipelineType,
+		rcvrPipelineType: rcvrPipelineType,
+	}
+}


### PR DESCRIPTION
Part of #6700

In order to manage components in a directed graph, each node must be associated with a unique identifier (`int64`) in the case of the `gonum` library. This PR defines a simple hashing system for all types of components, as well as a struct type for each component that contains all of the context necessary to reason about the nodes within the graph.