### PR TITLE
Fix undefined symbol errors on building otelcorecol for Plan 9

### DIFF
--- a/.chloggen/otelcol-plan9build.yaml
+++ b/.chloggen/otelcol-plan9build.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: loggingexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix undefined symbol errors on building otelcorecol for Plan 9
+
+# One or more tracking issues or pull requests related to the change
+issues: [6924]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/exporter/loggingexporter/known_sync_error_plan9.go
+++ b/exporter/loggingexporter/known_sync_error_plan9.go
@@ -12,35 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build linux || darwin
-// +build linux darwin
+//go:build plan9
+// +build plan9
 
 package loggingexporter // import "go.opentelemetry.io/collector/exporter/loggingexporter"
 
-import (
-	"errors"
-	"syscall"
-)
-
-var knownSyncErrors = []error{
-	// sync /dev/stdout: invalid argument
-	syscall.EINVAL,
-	// sync /dev/stdout: not supported
-	syscall.ENOTSUP,
-	// sync /dev/stdout: inappropriate ioctl for device
-	syscall.ENOTTY,
-	// sync /dev/stdout: bad file descriptor
-	syscall.EBADF,
-}
-
 // knownSyncError returns true if the given error is one of the known
-// non-actionable errors returned by Sync on Linux and macOS.
+// non-actionable errors returned by Sync on Plan 9.
 func knownSyncError(err error) bool {
-	for _, syncError := range knownSyncErrors {
-		if errors.Is(err, syncError) {
-			return true
-		}
-	}
-
 	return false
 }


### PR DESCRIPTION
**Description:**

Building **otelcorecol** was broken for Plan 9.

```console
$ cd cmd/otelcorecol
$ GOOS=plan9 go build
# go.opentelemetry.io/collector/exporter/loggingexporter
../../exporter/loggingexporter/known_sync_error.go:29:10: undefined: syscall.ENOTSUP
../../exporter/loggingexporter/known_sync_error.go:31:10: undefined: syscall.ENOTTY
../../exporter/loggingexporter/known_sync_error.go:33:10: undefined: syscall.EBADF
```

**Testing:**
Though I'm not sure yet there are more other issues when otelcorecol is running on Plan 9, at least, this PR is fixed undefined symbol errors and I checked **otelcorecol** shows a help successfully with `-h` option.
