### PR TITLE
Merge `release/v0.69.x` into `main`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 <!-- next version -->
 
+## v0.69.1
+
+### 🧰 Bug fixes 🧰
+
+- `various modules`: Fix issue where some collector modules imported previous version of other modules (#6929)
+
 ## v1.0.0-RC3/v0.69.0
 
 ### 🛑 Breaking changes 🛑

--- a/cmd/builder/internal/builder/config.go
+++ b/cmd/builder/internal/builder/config.go
@@ -26,7 +26,7 @@ import (
 	"go.uber.org/zap"
 )
 
-const defaultOtelColVersion = "0.69.0"
+const defaultOtelColVersion = "0.69.1"
 
 // ErrInvalidGoMod indicates an invalid gomod
 var ErrInvalidGoMod = errors.New("invalid gomod specification for module")

--- a/cmd/builder/internal/config/default.yaml
+++ b/cmd/builder/internal/config/default.yaml
@@ -2,19 +2,19 @@ dist:
   module: go.opentelemetry.io/collector/cmd/otelcorecol
   name: otelcorecol
   description: Local OpenTelemetry Collector binary, testing only.
-  version: 0.69.0-dev
-  otelcol_version: 0.69.0
+  version: 0.69.1-dev
+  otelcol_version: 0.69.1
 
 receivers:
-  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.69.0
+  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.69.1
 exporters:
-  - gomod: go.opentelemetry.io/collector/exporter/loggingexporter v0.69.0
-  - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.69.0
-  - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.69.0
+  - gomod: go.opentelemetry.io/collector/exporter/loggingexporter v0.69.1
+  - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.69.1
+  - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.69.1
 extensions:
-  - gomod: go.opentelemetry.io/collector/extension/ballastextension v0.69.0
-  - gomod: go.opentelemetry.io/collector/extension/zpagesextension v0.69.0
+  - gomod: go.opentelemetry.io/collector/extension/ballastextension v0.69.1
+  - gomod: go.opentelemetry.io/collector/extension/zpagesextension v0.69.1
 processors:
-  - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.69.0
-  - gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.69.0
+  - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.69.1
+  - gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.69.1
 

--- a/cmd/builder/test/core.builder.yaml
+++ b/cmd/builder/test/core.builder.yaml
@@ -1,20 +1,20 @@
 dist:
   module: go.opentelemetry.io/collector/builder/test/core
-  otelcol_version: 0.69.0
+  otelcol_version: 0.69.1
 
 extensions:
   - import: go.opentelemetry.io/collector/extension/zpagesextension
-    gomod: go.opentelemetry.io/collector v0.69.0
+    gomod: go.opentelemetry.io/collector v0.69.1
     path: ${WORKSPACE_DIR}
 
 receivers:
   - import: go.opentelemetry.io/collector/receiver/otlpreceiver
-    gomod: go.opentelemetry.io/collector v0.69.0
+    gomod: go.opentelemetry.io/collector v0.69.1
     path: ${WORKSPACE_DIR}
 
 exporters:
   - import: go.opentelemetry.io/collector/exporter/loggingexporter
-    gomod: go.opentelemetry.io/collector v0.69.0
+    gomod: go.opentelemetry.io/collector v0.69.1
     path: ${WORKSPACE_DIR}
 
 replaces:

--- a/cmd/otelcorecol/builder-config.yaml
+++ b/cmd/otelcorecol/builder-config.yaml
@@ -2,21 +2,21 @@ dist:
   module: go.opentelemetry.io/collector/cmd/otelcorecol
   name: otelcorecol
   description: Local OpenTelemetry Collector binary, testing only.
-  version: 0.69.0-dev
-  otelcol_version: 0.69.0
+  version: 0.69.1-dev
+  otelcol_version: 0.69.1
 
 receivers:
-  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.69.0
+  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.69.1
 exporters:
-  - gomod: go.opentelemetry.io/collector/exporter/loggingexporter v0.69.0
-  - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.69.0
-  - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.69.0
+  - gomod: go.opentelemetry.io/collector/exporter/loggingexporter v0.69.1
+  - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.69.1
+  - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.69.1
 extensions:
-  - gomod: go.opentelemetry.io/collector/extension/ballastextension v0.69.0
-  - gomod: go.opentelemetry.io/collector/extension/zpagesextension v0.69.0
+  - gomod: go.opentelemetry.io/collector/extension/ballastextension v0.69.1
+  - gomod: go.opentelemetry.io/collector/extension/zpagesextension v0.69.1
 processors:
-  - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.69.0
-  - gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.69.0
+  - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.69.1
+  - gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.69.1
 
 replaces:
   - go.opentelemetry.io/collector => ../../

--- a/cmd/otelcorecol/go.mod
+++ b/cmd/otelcorecol/go.mod
@@ -6,16 +6,16 @@ go 1.18
 
 require (
 	github.com/stretchr/testify v1.8.1
-	go.opentelemetry.io/collector v0.69.0
-	go.opentelemetry.io/collector/component v0.68.0
-	go.opentelemetry.io/collector/exporter/loggingexporter v0.69.0
-	go.opentelemetry.io/collector/exporter/otlpexporter v0.69.0
-	go.opentelemetry.io/collector/exporter/otlphttpexporter v0.69.0
-	go.opentelemetry.io/collector/extension/ballastextension v0.69.0
-	go.opentelemetry.io/collector/extension/zpagesextension v0.69.0
-	go.opentelemetry.io/collector/processor/batchprocessor v0.69.0
-	go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.69.0
-	go.opentelemetry.io/collector/receiver/otlpreceiver v0.69.0
+	go.opentelemetry.io/collector v0.69.1
+	go.opentelemetry.io/collector/component v0.69.1
+	go.opentelemetry.io/collector/exporter/loggingexporter v0.69.1
+	go.opentelemetry.io/collector/exporter/otlpexporter v0.69.1
+	go.opentelemetry.io/collector/exporter/otlphttpexporter v0.69.1
+	go.opentelemetry.io/collector/extension/ballastextension v0.69.1
+	go.opentelemetry.io/collector/extension/zpagesextension v0.69.1
+	go.opentelemetry.io/collector/processor/batchprocessor v0.69.1
+	go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.69.1
+	go.opentelemetry.io/collector/receiver/otlpreceiver v0.69.1
 	golang.org/x/sys v0.4.0
 )
 
@@ -63,11 +63,11 @@ require (
 	github.com/tklauser/numcpus v0.6.0 // indirect
 	github.com/yusufpapurcu/wmi v1.2.2 // indirect
 	go.opencensus.io v0.24.0 // indirect
-	go.opentelemetry.io/collector/confmap v0.68.0 // indirect
-	go.opentelemetry.io/collector/consumer v0.68.0 // indirect
-	go.opentelemetry.io/collector/featuregate v0.68.0 // indirect
-	go.opentelemetry.io/collector/pdata v1.0.0-rc2 // indirect
-	go.opentelemetry.io/collector/semconv v0.68.0 // indirect
+	go.opentelemetry.io/collector/confmap v0.69.1 // indirect
+	go.opentelemetry.io/collector/consumer v0.69.1 // indirect
+	go.opentelemetry.io/collector/featuregate v0.69.1 // indirect
+	go.opentelemetry.io/collector/pdata v1.0.0-rc3 // indirect
+	go.opentelemetry.io/collector/semconv v0.69.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.37.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.37.0 // indirect
 	go.opentelemetry.io/contrib/propagators/b3 v1.12.0 // indirect

--- a/cmd/otelcorecol/main.go
+++ b/cmd/otelcorecol/main.go
@@ -19,7 +19,7 @@ func main() {
 	info := component.BuildInfo{
 		Command:     "otelcorecol",
 		Description: "Local OpenTelemetry Collector binary, testing only.",
-		Version:     "0.69.0-dev",
+		Version:     "0.69.1-dev",
 	}
 
 	if err := run(otelcol.CollectorSettings{BuildInfo: info, Factories: factories}); err != nil {

--- a/component/go.mod
+++ b/component/go.mod
@@ -4,8 +4,8 @@ go 1.18
 
 require (
 	github.com/stretchr/testify v1.8.1
-	go.opentelemetry.io/collector v0.68.0
-	go.opentelemetry.io/collector/confmap v0.68.0
+	go.opentelemetry.io/collector v0.69.1
+	go.opentelemetry.io/collector/confmap v0.69.1
 	go.opentelemetry.io/otel/metric v0.34.0
 	go.opentelemetry.io/otel/trace v1.11.2
 	go.uber.org/multierr v1.9.0
@@ -19,7 +19,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/collector/featuregate v0.68.0 // indirect
+	go.opentelemetry.io/collector/featuregate v0.69.1 // indirect
 	go.opentelemetry.io/otel v1.11.2 // indirect
 	go.uber.org/atomic v1.10.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/confmap/go.mod
+++ b/confmap/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/knadh/koanf v1.4.5
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/stretchr/testify v1.8.1
-	go.opentelemetry.io/collector/featuregate v0.68.0
+	go.opentelemetry.io/collector/featuregate v0.69.1
 	go.uber.org/multierr v1.9.0
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/connector/forwardconnector/go.mod
+++ b/connector/forwardconnector/go.mod
@@ -4,10 +4,10 @@ go 1.18
 
 require (
 	github.com/stretchr/testify v1.8.1
-	go.opentelemetry.io/collector v0.68.0
-	go.opentelemetry.io/collector/component v0.68.0
-	go.opentelemetry.io/collector/consumer v0.68.0
-	go.opentelemetry.io/collector/pdata v1.0.0-rc2
+	go.opentelemetry.io/collector v0.69.1
+	go.opentelemetry.io/collector/component v0.69.1
+	go.opentelemetry.io/collector/consumer v0.69.1
+	go.opentelemetry.io/collector/pdata v1.0.0-rc3
 )
 
 require (
@@ -22,8 +22,8 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/collector/confmap v0.68.0 // indirect
-	go.opentelemetry.io/collector/featuregate v0.68.0 // indirect
+	go.opentelemetry.io/collector/confmap v0.69.1 // indirect
+	go.opentelemetry.io/collector/featuregate v0.69.1 // indirect
 	go.opentelemetry.io/otel v1.11.2 // indirect
 	go.opentelemetry.io/otel/metric v0.34.0 // indirect
 	go.opentelemetry.io/otel/trace v1.11.2 // indirect

--- a/consumer/go.mod
+++ b/consumer/go.mod
@@ -4,8 +4,8 @@ go 1.18
 
 require (
 	github.com/stretchr/testify v1.8.1
-	go.opentelemetry.io/collector v0.68.0
-	go.opentelemetry.io/collector/pdata v1.0.0-rc2
+	go.opentelemetry.io/collector v0.69.1
+	go.opentelemetry.io/collector/pdata v1.0.0-rc3
 )
 
 require (

--- a/examples/k8s/otel-config.yaml
+++ b/examples/k8s/otel-config.yaml
@@ -66,7 +66,7 @@ spec:
       - command:
           - "/otelcol"
           - "--config=/conf/otel-agent-config.yaml"
-        image: otel/opentelemetry-collector:0.68.0
+        image: otel/opentelemetry-collector:0.69.1
         name: otel-agent
         resources:
           limits:
@@ -177,7 +177,7 @@ spec:
       - command:
           - "/otelcol"
           - "--config=/conf/otel-collector-config.yaml"
-        image: otel/opentelemetry-collector:0.68.0
+        image: otel/opentelemetry-collector:0.69.1
         name: otel-collector
         resources:
           limits:

--- a/exporter/loggingexporter/go.mod
+++ b/exporter/loggingexporter/go.mod
@@ -4,11 +4,11 @@ go 1.18
 
 require (
 	github.com/stretchr/testify v1.8.1
-	go.opentelemetry.io/collector v0.68.0
-	go.opentelemetry.io/collector/component v0.68.0
-	go.opentelemetry.io/collector/confmap v0.68.0
-	go.opentelemetry.io/collector/consumer v0.68.0
-	go.opentelemetry.io/collector/pdata v1.0.0-rc2
+	go.opentelemetry.io/collector v0.69.1
+	go.opentelemetry.io/collector/component v0.69.1
+	go.opentelemetry.io/collector/confmap v0.69.1
+	go.opentelemetry.io/collector/consumer v0.69.1
+	go.opentelemetry.io/collector/pdata v1.0.0-rc3
 	go.uber.org/zap v1.24.0
 	golang.org/x/sys v0.4.0
 )
@@ -28,7 +28,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opencensus.io v0.24.0 // indirect
-	go.opentelemetry.io/collector/featuregate v0.68.0 // indirect
+	go.opentelemetry.io/collector/featuregate v0.69.1 // indirect
 	go.opentelemetry.io/otel v1.11.2 // indirect
 	go.opentelemetry.io/otel/metric v0.34.0 // indirect
 	go.opentelemetry.io/otel/trace v1.11.2 // indirect

--- a/exporter/otlpexporter/go.mod
+++ b/exporter/otlpexporter/go.mod
@@ -4,11 +4,11 @@ go 1.18
 
 require (
 	github.com/stretchr/testify v1.8.1
-	go.opentelemetry.io/collector v0.68.0
-	go.opentelemetry.io/collector/component v0.68.0
-	go.opentelemetry.io/collector/confmap v0.68.0
-	go.opentelemetry.io/collector/consumer v0.68.0
-	go.opentelemetry.io/collector/pdata v1.0.0-rc2
+	go.opentelemetry.io/collector v0.69.1
+	go.opentelemetry.io/collector/component v0.69.1
+	go.opentelemetry.io/collector/confmap v0.69.1
+	go.opentelemetry.io/collector/consumer v0.69.1
+	go.opentelemetry.io/collector/pdata v1.0.0-rc3
 	go.uber.org/atomic v1.10.0
 	google.golang.org/genproto v0.0.0-20221018160656-63c7b68cfc55
 	google.golang.org/grpc v1.51.0
@@ -34,7 +34,7 @@ require (
 	github.com/mostynb/go-grpc-compression v1.1.17 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opencensus.io v0.24.0 // indirect
-	go.opentelemetry.io/collector/featuregate v0.68.0 // indirect
+	go.opentelemetry.io/collector/featuregate v0.69.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.37.0 // indirect
 	go.opentelemetry.io/otel v1.11.2 // indirect
 	go.opentelemetry.io/otel/metric v0.34.0 // indirect

--- a/exporter/otlphttpexporter/go.mod
+++ b/exporter/otlphttpexporter/go.mod
@@ -4,12 +4,12 @@ go 1.18
 
 require (
 	github.com/stretchr/testify v1.8.1
-	go.opentelemetry.io/collector v0.68.0
-	go.opentelemetry.io/collector/component v0.68.0
-	go.opentelemetry.io/collector/confmap v0.68.0
-	go.opentelemetry.io/collector/consumer v0.68.0
-	go.opentelemetry.io/collector/pdata v1.0.0-rc2
-	go.opentelemetry.io/collector/receiver/otlpreceiver v0.68.0
+	go.opentelemetry.io/collector v0.69.1
+	go.opentelemetry.io/collector/component v0.69.1
+	go.opentelemetry.io/collector/confmap v0.69.1
+	go.opentelemetry.io/collector/consumer v0.69.1
+	go.opentelemetry.io/collector/pdata v1.0.0-rc3
+	go.opentelemetry.io/collector/receiver/otlpreceiver v0.69.1
 	go.uber.org/zap v1.24.0
 	google.golang.org/genproto v0.0.0-20221027153422-115e99e71e1c
 	google.golang.org/grpc v1.51.0
@@ -37,7 +37,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rs/cors v1.8.3 // indirect
 	go.opencensus.io v0.24.0 // indirect
-	go.opentelemetry.io/collector/featuregate v0.68.0 // indirect
+	go.opentelemetry.io/collector/featuregate v0.69.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.37.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.37.0 // indirect
 	go.opentelemetry.io/otel v1.11.2 // indirect

--- a/extension/ballastextension/go.mod
+++ b/extension/ballastextension/go.mod
@@ -4,9 +4,9 @@ go 1.18
 
 require (
 	github.com/stretchr/testify v1.8.1
-	go.opentelemetry.io/collector v0.68.0
-	go.opentelemetry.io/collector/component v0.68.0
-	go.opentelemetry.io/collector/confmap v0.68.0
+	go.opentelemetry.io/collector v0.69.1
+	go.opentelemetry.io/collector/component v0.69.1
+	go.opentelemetry.io/collector/confmap v0.69.1
 	go.uber.org/zap v1.24.0
 )
 
@@ -24,7 +24,7 @@ require (
 	github.com/tklauser/go-sysconf v0.3.11 // indirect
 	github.com/tklauser/numcpus v0.6.0 // indirect
 	github.com/yusufpapurcu/wmi v1.2.2 // indirect
-	go.opentelemetry.io/collector/featuregate v0.68.0 // indirect
+	go.opentelemetry.io/collector/featuregate v0.69.1 // indirect
 	go.opentelemetry.io/otel v1.11.2 // indirect
 	go.opentelemetry.io/otel/metric v0.34.0 // indirect
 	go.opentelemetry.io/otel/trace v1.11.2 // indirect

--- a/extension/zpagesextension/go.mod
+++ b/extension/zpagesextension/go.mod
@@ -4,9 +4,9 @@ go 1.18
 
 require (
 	github.com/stretchr/testify v1.8.1
-	go.opentelemetry.io/collector v0.68.0
-	go.opentelemetry.io/collector/component v0.68.0
-	go.opentelemetry.io/collector/confmap v0.68.0
+	go.opentelemetry.io/collector v0.69.1
+	go.opentelemetry.io/collector/component v0.69.1
+	go.opentelemetry.io/collector/confmap v0.69.1
 	go.opentelemetry.io/contrib/zpages v0.37.0
 	go.opentelemetry.io/otel/sdk v1.11.2
 	go.opentelemetry.io/otel/trace v1.11.2
@@ -22,7 +22,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/collector/featuregate v0.68.0 // indirect
+	go.opentelemetry.io/collector/featuregate v0.69.1 // indirect
 	go.opentelemetry.io/otel v1.11.2 // indirect
 	go.opentelemetry.io/otel/metric v0.34.0 // indirect
 	go.uber.org/atomic v1.10.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -17,13 +17,13 @@ require (
 	github.com/spf13/cobra v1.6.1
 	github.com/stretchr/testify v1.8.1
 	go.opencensus.io v0.24.0
-	go.opentelemetry.io/collector/component v0.68.0
-	go.opentelemetry.io/collector/confmap v0.68.0
-	go.opentelemetry.io/collector/consumer v0.68.0
-	go.opentelemetry.io/collector/extension/zpagesextension v0.68.0
-	go.opentelemetry.io/collector/featuregate v0.68.0
-	go.opentelemetry.io/collector/pdata v1.0.0-rc2
-	go.opentelemetry.io/collector/semconv v0.68.0
+	go.opentelemetry.io/collector/component v0.69.1
+	go.opentelemetry.io/collector/confmap v0.69.1
+	go.opentelemetry.io/collector/consumer v0.69.1
+	go.opentelemetry.io/collector/extension/zpagesextension v0.69.1
+	go.opentelemetry.io/collector/featuregate v0.69.1
+	go.opentelemetry.io/collector/pdata v1.0.0-rc3
+	go.opentelemetry.io/collector/semconv v0.69.1
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.37.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.37.0
 	go.opentelemetry.io/contrib/propagators/b3 v1.12.0

--- a/processor/batchprocessor/go.mod
+++ b/processor/batchprocessor/go.mod
@@ -9,12 +9,12 @@ require (
 	github.com/prometheus/common v0.39.0
 	github.com/stretchr/testify v1.8.1
 	go.opencensus.io v0.24.0
-	go.opentelemetry.io/collector v0.68.0
-	go.opentelemetry.io/collector/component v0.68.0
-	go.opentelemetry.io/collector/confmap v0.68.0
-	go.opentelemetry.io/collector/consumer v0.68.0
-	go.opentelemetry.io/collector/featuregate v0.68.0
-	go.opentelemetry.io/collector/pdata v1.0.0-rc2
+	go.opentelemetry.io/collector v0.69.1
+	go.opentelemetry.io/collector/component v0.69.1
+	go.opentelemetry.io/collector/confmap v0.69.1
+	go.opentelemetry.io/collector/consumer v0.69.1
+	go.opentelemetry.io/collector/featuregate v0.69.1
+	go.opentelemetry.io/collector/pdata v1.0.0-rc3
 	go.opentelemetry.io/otel v1.11.2
 	go.opentelemetry.io/otel/exporters/prometheus v0.34.0
 	go.opentelemetry.io/otel/metric v0.34.0

--- a/processor/memorylimiterprocessor/go.mod
+++ b/processor/memorylimiterprocessor/go.mod
@@ -4,11 +4,11 @@ go 1.18
 
 require (
 	github.com/stretchr/testify v1.8.1
-	go.opentelemetry.io/collector v0.68.0
-	go.opentelemetry.io/collector/component v0.68.0
-	go.opentelemetry.io/collector/confmap v0.68.0
-	go.opentelemetry.io/collector/consumer v0.68.0
-	go.opentelemetry.io/collector/pdata v1.0.0-rc2
+	go.opentelemetry.io/collector v0.69.1
+	go.opentelemetry.io/collector/component v0.69.1
+	go.opentelemetry.io/collector/confmap v0.69.1
+	go.opentelemetry.io/collector/consumer v0.69.1
+	go.opentelemetry.io/collector/pdata v1.0.0-rc3
 	go.uber.org/atomic v1.10.0
 	go.uber.org/zap v1.24.0
 )
@@ -33,7 +33,7 @@ require (
 	github.com/tklauser/numcpus v0.6.0 // indirect
 	github.com/yusufpapurcu/wmi v1.2.2 // indirect
 	go.opencensus.io v0.24.0 // indirect
-	go.opentelemetry.io/collector/featuregate v0.68.0 // indirect
+	go.opentelemetry.io/collector/featuregate v0.69.1 // indirect
 	go.opentelemetry.io/otel v1.11.2 // indirect
 	go.opentelemetry.io/otel/metric v0.34.0 // indirect
 	go.opentelemetry.io/otel/trace v1.11.2 // indirect

--- a/receiver/otlpreceiver/go.mod
+++ b/receiver/otlpreceiver/go.mod
@@ -5,12 +5,12 @@ go 1.18
 require (
 	github.com/gogo/protobuf v1.3.2
 	github.com/stretchr/testify v1.8.1
-	go.opentelemetry.io/collector v0.68.0
-	go.opentelemetry.io/collector/component v0.68.0
-	go.opentelemetry.io/collector/confmap v0.68.0
-	go.opentelemetry.io/collector/consumer v0.68.0
-	go.opentelemetry.io/collector/pdata v1.0.0-rc2
-	go.opentelemetry.io/collector/semconv v0.68.0
+	go.opentelemetry.io/collector v0.69.1
+	go.opentelemetry.io/collector/component v0.69.1
+	go.opentelemetry.io/collector/confmap v0.69.1
+	go.opentelemetry.io/collector/consumer v0.69.1
+	go.opentelemetry.io/collector/pdata v1.0.0-rc3
+	go.opentelemetry.io/collector/semconv v0.69.1
 	go.uber.org/zap v1.24.0
 	google.golang.org/genproto v0.0.0-20221027153422-115e99e71e1c
 	google.golang.org/grpc v1.51.0
@@ -49,7 +49,7 @@ require (
 	github.com/prometheus/statsd_exporter v0.22.7 // indirect
 	github.com/rs/cors v1.8.3 // indirect
 	go.opencensus.io v0.24.0 // indirect
-	go.opentelemetry.io/collector/featuregate v0.68.0 // indirect
+	go.opentelemetry.io/collector/featuregate v0.69.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.37.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.37.0 // indirect
 	go.opentelemetry.io/otel v1.11.2 // indirect

--- a/versions.yaml
+++ b/versions.yaml
@@ -18,7 +18,7 @@ module-sets:
     modules:
       - go.opentelemetry.io/collector/pdata
   beta:
-    version: v0.69.0
+    version: v0.69.1
     modules:
       - go.opentelemetry.io/collector
       - go.opentelemetry.io/collector/component


### PR DESCRIPTION
This branch started from `origin/main`, merged `origin/release/v0.69.x` into it and resolved merge conflicts.