### PR TITLE
add ldflags builder cmd option

### DIFF
--- a/.chloggen/ldflags.yaml
+++ b/.chloggen/ldflags.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: builder
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: added ldflags command option
+
+# One or more tracking issues or pull requests related to the change
+issues: [6940]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/cmd/builder/internal/builder/config.go
+++ b/cmd/builder/internal/builder/config.go
@@ -34,8 +34,9 @@ var ErrInvalidGoMod = errors.New("invalid gomod specification for module")
 // Config holds the builder's configuration
 type Config struct {
 	Logger          *zap.Logger
-	SkipCompilation bool `mapstructure:"-"`
-	SkipGetModules  bool `mapstructure:"-"`
+	SkipCompilation bool   `mapstructure:"-"`
+	SkipGetModules  bool   `mapstructure:"-"`
+	LDFlags         string `mapstructure:"-"`
 
 	Distribution Distribution `mapstructure:"dist"`
 	Exporters    []Module     `mapstructure:"exporters"`

--- a/cmd/builder/internal/builder/main.go
+++ b/cmd/builder/internal/builder/main.go
@@ -84,15 +84,14 @@ func Compile(cfg Config) error {
 		return nil
 	}
 
-	cfg.Logger.Info("Compiling")
-
 	var ldflags = "-s -w"
-
 	args := []string{"build", "-trimpath", "-o", cfg.Distribution.Name}
 	if cfg.Distribution.DebugCompilation {
 		cfg.Logger.Info("Debug compilation is enabled, the debug symbols will be left on the resulting binary")
-		ldflags = ""
+		ldflags = cfg.LDFlags
 		args = append(args, "-gcflags=all=-N -l")
+	} else if len(cfg.LDFlags) > 0 {
+		ldflags = fmt.Sprintf("%s %s", ldflags, cfg.LDFlags)
 	}
 	args = append(args, "-ldflags="+ldflags)
 	if cfg.Distribution.BuildTags != "" {

--- a/cmd/builder/internal/builder/main.go
+++ b/cmd/builder/internal/builder/main.go
@@ -94,7 +94,7 @@ func Compile(cfg Config) error {
 		ldflags = cfg.LDFlags
 		args = append(args, "-gcflags=all=-N -l")
 	} else if len(cfg.LDFlags) > 0 {
-		ldflags = fmt.Sprintf("%s %s", ldflags, cfg.LDFlags)
+		ldflags += " " + cfg.LDFlags
 	}
 	args = append(args, "-ldflags="+ldflags)
 	if cfg.Distribution.BuildTags != "" {

--- a/cmd/builder/internal/builder/main.go
+++ b/cmd/builder/internal/builder/main.go
@@ -84,7 +84,10 @@ func Compile(cfg Config) error {
 		return nil
 	}
 
+	cfg.Logger.Info("Compiling")
+
 	var ldflags = "-s -w"
+
 	args := []string{"build", "-trimpath", "-o", cfg.Distribution.Name}
 	if cfg.Distribution.DebugCompilation {
 		cfg.Logger.Info("Debug compilation is enabled, the debug symbols will be left on the resulting binary")

--- a/cmd/builder/internal/builder/main_test.go
+++ b/cmd/builder/internal/builder/main_test.go
@@ -83,6 +83,16 @@ func TestGenerateAndCompile(t *testing.T) {
 			},
 		},
 		{
+			testCase: "LDFlags Compilation",
+			cfgBuilder: func(t *testing.T) Config {
+				cfg := NewDefaultConfig()
+				cfg.Distribution.OutputPath = t.TempDir()
+				cfg.Replaces = append(cfg.Replaces, replaces...)
+				cfg.LDFlags = `-X "test.gitVersion=0743dc6c6411272b98494a9b32a63378e84c34da" -X "test.gitTag=local-testing" -X "test.goVersion=go version go1.19.4 darwin/amd64"`
+				return cfg
+			},
+		},
+		{
 			testCase: "Debug Compilation",
 			cfgBuilder: func(t *testing.T) Config {
 				cfg := NewDefaultConfig()

--- a/cmd/builder/internal/command.go
+++ b/cmd/builder/internal/command.go
@@ -33,6 +33,7 @@ import (
 const (
 	skipCompilationFlag            = "skip-compilation"
 	skipGetModulesFlag             = "skip-get-modules"
+	ldflagsFlag                    = "ldflags"
 	distributionNameFlag           = "name"
 	distributionDescriptionFlag    = "description"
 	distributionVersionFlag        = "version"
@@ -86,6 +87,7 @@ configuration is provided, ocb will generate a default Collector.
 	// the distribution parameters, which we accept as CLI flags as well
 	cmd.Flags().BoolVar(&cfg.SkipCompilation, skipCompilationFlag, false, "Whether builder should only generate go code with no compile of the collector (default false)")
 	cmd.Flags().BoolVar(&cfg.SkipGetModules, skipGetModulesFlag, false, "Whether builder should skip updating go.mod and retrieve Go module list (default false)")
+	cmd.Flags().StringVar(&cfg.LDFlags, ldflagsFlag, "", `ldflags to include in the "go build" command`)
 	cmd.Flags().StringVar(&cfg.Distribution.Name, distributionNameFlag, "otelcol-custom", "The executable name for the OpenTelemetry Collector distribution")
 	if err := cmd.Flags().MarkDeprecated(distributionNameFlag, "use config distribution::name"); err != nil {
 		return nil, err


### PR DESCRIPTION
**Description:** Adding a feature - `ldflags` option in builder cmd, to be passed to `go build`

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector/issues/6940

**Testing:** manually built a collector with custom components who have build variables.  Passing `ldflags` set the values of these variables.

**Documentation:** I added a description for the `--help` command, but I can add a small explanation to the README if people would prefer.

