### PR TITLE
[chore] Retract failed release v0.69.0

### DIFF
--- a/cmd/builder/go.mod
+++ b/cmd/builder/go.mod
@@ -40,6 +40,7 @@ require (
 )
 
 retract (
+	v0.69.0 // Release failed, use v0.69.1 
 	v0.57.1 // Release failed, use v0.57.2
 	v0.57.0 // Release failed, use v0.57.2
 )

--- a/cmd/builder/go.mod
+++ b/cmd/builder/go.mod
@@ -40,7 +40,7 @@ require (
 )
 
 retract (
-	v0.69.0 // Release failed, use v0.69.1 
+	v0.69.0 // Release failed, use v0.69.1
 	v0.57.1 // Release failed, use v0.57.2
 	v0.57.0 // Release failed, use v0.57.2
 )

--- a/cmd/otelcorecol/go.mod
+++ b/cmd/otelcorecol/go.mod
@@ -120,6 +120,4 @@ replace go.opentelemetry.io/collector/semconv => ../../semconv
 
 replace go.opentelemetry.io/collector/receiver/otlpreceiver => ../../receiver/otlpreceiver
 
-retract (
-	v0.69.0 // Release failed, use v0.69.1 
-)
+retract v0.69.0 // Release failed, use v0.69.1

--- a/cmd/otelcorecol/go.mod
+++ b/cmd/otelcorecol/go.mod
@@ -119,3 +119,7 @@ replace go.opentelemetry.io/collector/processor/memorylimiterprocessor => ../../
 replace go.opentelemetry.io/collector/semconv => ../../semconv
 
 replace go.opentelemetry.io/collector/receiver/otlpreceiver => ../../receiver/otlpreceiver
+
+retract (
+	v0.69.0 // Release failed, use v0.69.1 
+)

--- a/cmd/otelcorecol/go.mod
+++ b/cmd/otelcorecol/go.mod
@@ -119,5 +119,3 @@ replace go.opentelemetry.io/collector/processor/memorylimiterprocessor => ../../
 replace go.opentelemetry.io/collector/semconv => ../../semconv
 
 replace go.opentelemetry.io/collector/receiver/otlpreceiver => ../../receiver/otlpreceiver
-
-retract v0.69.0 // Release failed, use v0.69.1

--- a/component/go.mod
+++ b/component/go.mod
@@ -39,6 +39,4 @@ replace go.opentelemetry.io/collector/semconv => ../semconv
 
 replace go.opentelemetry.io/collector/extension/zpagesextension => ../extension/zpagesextension
 
-retract (
-	v0.69.0 // Release failed, use v0.69.1 
-)
+retract v0.69.0 // Release failed, use v0.69.1

--- a/component/go.mod
+++ b/component/go.mod
@@ -38,3 +38,7 @@ replace go.opentelemetry.io/collector/pdata => ../pdata
 replace go.opentelemetry.io/collector/semconv => ../semconv
 
 replace go.opentelemetry.io/collector/extension/zpagesextension => ../extension/zpagesextension
+
+retract (
+	v0.69.0 // Release failed, use v0.69.1 
+)

--- a/confmap/go.mod
+++ b/confmap/go.mod
@@ -20,3 +20,7 @@ require (
 )
 
 replace go.opentelemetry.io/collector/featuregate => ../featuregate
+
+retract (
+	v0.69.0 // Release failed, use v0.69.1 
+)

--- a/confmap/go.mod
+++ b/confmap/go.mod
@@ -21,6 +21,4 @@ require (
 
 replace go.opentelemetry.io/collector/featuregate => ../featuregate
 
-retract (
-	v0.69.0 // Release failed, use v0.69.1 
-)
+retract v0.69.0 // Release failed, use v0.69.1

--- a/connector/forwardconnector/go.mod
+++ b/connector/forwardconnector/go.mod
@@ -54,3 +54,7 @@ replace go.opentelemetry.io/collector/featuregate => ../../featuregate
 replace go.opentelemetry.io/collector/consumer => ../../consumer
 
 replace go.opentelemetry.io/collector/confmap => ../../confmap
+
+retract (
+	v0.69.0 // Release failed, use v0.69.1 
+)

--- a/connector/forwardconnector/go.mod
+++ b/connector/forwardconnector/go.mod
@@ -55,6 +55,4 @@ replace go.opentelemetry.io/collector/consumer => ../../consumer
 
 replace go.opentelemetry.io/collector/confmap => ../../confmap
 
-retract (
-	v0.69.0 // Release failed, use v0.69.1 
-)
+retract v0.69.0 // Release failed, use v0.69.1

--- a/consumer/go.mod
+++ b/consumer/go.mod
@@ -40,3 +40,7 @@ replace go.opentelemetry.io/collector/component => ../component
 replace go.opentelemetry.io/collector/featuregate => ../featuregate
 
 replace go.opentelemetry.io/collector/confmap => ../confmap
+
+retract (
+	v0.69.0 // Release failed, use v0.69.1 
+)

--- a/consumer/go.mod
+++ b/consumer/go.mod
@@ -41,6 +41,4 @@ replace go.opentelemetry.io/collector/featuregate => ../featuregate
 
 replace go.opentelemetry.io/collector/confmap => ../confmap
 
-retract (
-	v0.69.0 // Release failed, use v0.69.1 
-)
+retract v0.69.0 // Release failed, use v0.69.1

--- a/exporter/loggingexporter/go.mod
+++ b/exporter/loggingexporter/go.mod
@@ -58,6 +58,4 @@ replace go.opentelemetry.io/collector/semconv => ../../semconv
 
 replace go.opentelemetry.io/collector/extension/zpagesextension => ../../extension/zpagesextension
 
-retract (
-	v0.69.0 // Release failed, use v0.69.1 
-)
+retract v0.69.0 // Release failed, use v0.69.1

--- a/exporter/loggingexporter/go.mod
+++ b/exporter/loggingexporter/go.mod
@@ -57,3 +57,7 @@ replace go.opentelemetry.io/collector/pdata => ../../pdata
 replace go.opentelemetry.io/collector/semconv => ../../semconv
 
 replace go.opentelemetry.io/collector/extension/zpagesextension => ../../extension/zpagesextension
+
+retract (
+	v0.69.0 // Release failed, use v0.69.1 
+)

--- a/exporter/otlpexporter/go.mod
+++ b/exporter/otlpexporter/go.mod
@@ -63,6 +63,4 @@ replace go.opentelemetry.io/collector/extension/zpagesextension => ../../extensi
 
 replace go.opentelemetry.io/collector/consumer => ../../consumer
 
-retract (
-	v0.69.0 // Release failed, use v0.69.1 
-)
+retract v0.69.0 // Release failed, use v0.69.1

--- a/exporter/otlpexporter/go.mod
+++ b/exporter/otlpexporter/go.mod
@@ -62,3 +62,7 @@ replace go.opentelemetry.io/collector/semconv => ../../semconv
 replace go.opentelemetry.io/collector/extension/zpagesextension => ../../extension/zpagesextension
 
 replace go.opentelemetry.io/collector/consumer => ../../consumer
+
+retract (
+	v0.69.0 // Release failed, use v0.69.1 
+)

--- a/exporter/otlphttpexporter/go.mod
+++ b/exporter/otlphttpexporter/go.mod
@@ -68,3 +68,7 @@ replace go.opentelemetry.io/collector/semconv => ../../semconv
 replace go.opentelemetry.io/collector/extension/zpagesextension => ../../extension/zpagesextension
 
 replace go.opentelemetry.io/collector/consumer => ../../consumer
+
+retract (
+	v0.69.0 // Release failed, use v0.69.1 
+)

--- a/exporter/otlphttpexporter/go.mod
+++ b/exporter/otlphttpexporter/go.mod
@@ -69,6 +69,4 @@ replace go.opentelemetry.io/collector/extension/zpagesextension => ../../extensi
 
 replace go.opentelemetry.io/collector/consumer => ../../consumer
 
-retract (
-	v0.69.0 // Release failed, use v0.69.1 
-)
+retract v0.69.0 // Release failed, use v0.69.1

--- a/extension/ballastextension/go.mod
+++ b/extension/ballastextension/go.mod
@@ -50,6 +50,4 @@ replace go.opentelemetry.io/collector/extension/zpagesextension => ../zpagesexte
 
 replace go.opentelemetry.io/collector/consumer => ../../consumer
 
-retract (
-	v0.69.0 // Release failed, use v0.69.1 
-)
+retract v0.69.0 // Release failed, use v0.69.1

--- a/extension/ballastextension/go.mod
+++ b/extension/ballastextension/go.mod
@@ -49,3 +49,7 @@ replace go.opentelemetry.io/collector/semconv => ../../semconv
 replace go.opentelemetry.io/collector/extension/zpagesextension => ../zpagesextension
 
 replace go.opentelemetry.io/collector/consumer => ../../consumer
+
+retract (
+	v0.69.0 // Release failed, use v0.69.1 
+)

--- a/extension/zpagesextension/go.mod
+++ b/extension/zpagesextension/go.mod
@@ -44,3 +44,7 @@ replace go.opentelemetry.io/collector/pdata => ../../pdata
 replace go.opentelemetry.io/collector/semconv => ../../semconv
 
 replace go.opentelemetry.io/collector/consumer => ../../consumer
+
+retract (
+	v0.69.0 // Release failed, use v0.69.1 
+)

--- a/extension/zpagesextension/go.mod
+++ b/extension/zpagesextension/go.mod
@@ -45,6 +45,4 @@ replace go.opentelemetry.io/collector/semconv => ../../semconv
 
 replace go.opentelemetry.io/collector/consumer => ../../consumer
 
-retract (
-	v0.69.0 // Release failed, use v0.69.1 
-)
+retract v0.69.0 // Release failed, use v0.69.1

--- a/featuregate/go.mod
+++ b/featuregate/go.mod
@@ -9,3 +9,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+retract (
+	v0.69.0 // Release failed, use v0.69.1 
+)

--- a/featuregate/go.mod
+++ b/featuregate/go.mod
@@ -10,6 +10,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-retract (
-	v0.69.0 // Release failed, use v0.69.1 
-)
+retract v0.69.0 // Release failed, use v0.69.1

--- a/go.mod
+++ b/go.mod
@@ -96,7 +96,7 @@ replace go.opentelemetry.io/collector/pdata => ./pdata
 replace go.opentelemetry.io/collector/extension/zpagesextension => ./extension/zpagesextension
 
 retract (
-	v0.69.0 // Release failed, use v0.69.1 + v1.0.0-rc3
+	v0.69.0 // Release failed, use v0.69.1 
 	v0.57.1 // Release failed, use v0.57.2
 	v0.57.0 // Release failed, use v0.57.2
 	v0.32.0 // Contains incomplete metrics transition to proto 0.9.0, random components are not working.

--- a/go.mod
+++ b/go.mod
@@ -96,7 +96,7 @@ replace go.opentelemetry.io/collector/pdata => ./pdata
 replace go.opentelemetry.io/collector/extension/zpagesextension => ./extension/zpagesextension
 
 retract (
-	v0.69.0 // Release failed, use v0.69.1 
+	v0.69.0 // Release failed, use v0.69.1
 	v0.57.1 // Release failed, use v0.57.2
 	v0.57.0 // Release failed, use v0.57.2
 	v0.32.0 // Contains incomplete metrics transition to proto 0.9.0, random components are not working.

--- a/go.mod
+++ b/go.mod
@@ -96,6 +96,7 @@ replace go.opentelemetry.io/collector/pdata => ./pdata
 replace go.opentelemetry.io/collector/extension/zpagesextension => ./extension/zpagesextension
 
 retract (
+	v0.69.0 // Release failed, use v0.69.1 + v1.0.0-rc3
 	v0.57.1 // Release failed, use v0.57.2
 	v0.57.0 // Release failed, use v0.57.2
 	v0.32.0 // Contains incomplete metrics transition to proto 0.9.0, random components are not working.

--- a/processor/batchprocessor/go.mod
+++ b/processor/batchprocessor/go.mod
@@ -73,3 +73,7 @@ replace go.opentelemetry.io/collector/semconv => ../../semconv
 replace go.opentelemetry.io/collector/extension/zpagesextension => ../../extension/zpagesextension
 
 replace go.opentelemetry.io/collector/consumer => ../../consumer
+
+retract (
+	v0.69.0 // Release failed, use v0.69.1 
+)

--- a/processor/batchprocessor/go.mod
+++ b/processor/batchprocessor/go.mod
@@ -74,6 +74,4 @@ replace go.opentelemetry.io/collector/extension/zpagesextension => ../../extensi
 
 replace go.opentelemetry.io/collector/consumer => ../../consumer
 
-retract (
-	v0.69.0 // Release failed, use v0.69.1 
-)
+retract v0.69.0 // Release failed, use v0.69.1

--- a/processor/memorylimiterprocessor/go.mod
+++ b/processor/memorylimiterprocessor/go.mod
@@ -63,6 +63,4 @@ replace go.opentelemetry.io/collector/extension/zpagesextension => ../../extensi
 
 replace go.opentelemetry.io/collector/consumer => ../../consumer
 
-retract (
-	v0.69.0 // Release failed, use v0.69.1 
-)
+retract v0.69.0 // Release failed, use v0.69.1

--- a/processor/memorylimiterprocessor/go.mod
+++ b/processor/memorylimiterprocessor/go.mod
@@ -62,3 +62,7 @@ replace go.opentelemetry.io/collector/semconv => ../../semconv
 replace go.opentelemetry.io/collector/extension/zpagesextension => ../../extension/zpagesextension
 
 replace go.opentelemetry.io/collector/consumer => ../../consumer
+
+retract (
+	v0.69.0 // Release failed, use v0.69.1 
+)

--- a/receiver/otlpreceiver/go.mod
+++ b/receiver/otlpreceiver/go.mod
@@ -82,3 +82,7 @@ replace go.opentelemetry.io/collector/semconv => ../../semconv
 replace go.opentelemetry.io/collector/extension/zpagesextension => ../../extension/zpagesextension
 
 replace go.opentelemetry.io/collector/consumer => ../../consumer
+
+retract (
+	v0.69.0 // Release failed, use v0.69.1 
+)

--- a/receiver/otlpreceiver/go.mod
+++ b/receiver/otlpreceiver/go.mod
@@ -83,6 +83,4 @@ replace go.opentelemetry.io/collector/extension/zpagesextension => ../../extensi
 
 replace go.opentelemetry.io/collector/consumer => ../../consumer
 
-retract (
-	v0.69.0 // Release failed, use v0.69.1 
-)
+retract v0.69.0 // Release failed, use v0.69.1

--- a/semconv/go.mod
+++ b/semconv/go.mod
@@ -11,6 +11,7 @@ require (
 )
 
 retract (
+	v0.69.0 // Release failed, use v0.69.1 
 	v0.57.1 // Release failed, use v0.57.2
 	v0.57.0 // Release failed, use v0.57.2
 )

--- a/semconv/go.mod
+++ b/semconv/go.mod
@@ -11,7 +11,7 @@ require (
 )
 
 retract (
-	v0.69.0 // Release failed, use v0.69.1 
+	v0.69.0 // Release failed, use v0.69.1
 	v0.57.1 // Release failed, use v0.57.2
 	v0.57.0 // Release failed, use v0.57.2
 )


### PR DESCRIPTION
**Description:**
Ensuring users can't use v0.69.0 since it failed, should use fixed version v0.69.1

**Link to tracking Issue:** 
https://github.com/open-telemetry/opentelemetry-collector/issues/6908

