### PR TITLE
add github action to automate the release parts of the process

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -33,7 +33,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CANDIDATE_BETA: ${{ inputs.candidate-beta }}
           CANDIDATE_STABLE: ${{ inputs.candidate-stable }}
-          REPO: codeboten/opentelemetry-collector
+          REPO: open-telemetry/opentelemetry-collector
         run: |
           EXISTING_ISSUE=$( gh issue list --search "Release v${CANDIDATE_BETA}/v${CANDIDATE_STABLE}" --json url --jq '.[].url' --repo ${REPO} )
           if [ "${EXISTING_ISSUE}" != "" ]; then
@@ -132,7 +132,6 @@ jobs:
           CURRENT_BETA: ${{ inputs.current-beta }}
           CURRENT_STABLE: ${{ inputs.current-stable }}
         run: |
-          make chlog-install
           make chlog-update VERSION=${CANDIDATE_STABLE}/${CANDIDATE_BETA}
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -8,6 +8,7 @@ on:
       candidate-stable:
         required: true
         description: Release candidate version (stable, like 1.0.0-rc4)
+
       current-stable:
         required: true
         description: Current version (stable, like 1.0.0-rc3)

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -105,15 +105,6 @@ jobs:
               echo "$(gh run list --branch main --json status,url --jq '[.[] | select(.status != "queued" and .status != "in_progress")][0].url' --workflow build-and-test --repo ${REPO} )"
               exit 1
           fi
-      # Update Contrib to use the latest in development version of Core. Run make update-otel in
-      # Contrib root directory and if it results in any changes, submit a PR. Open this PR as draft.
-      # This is to ensure that the latest core does not break contrib in any way. We’ll update it
-      # once more to the final release number later.
-      - name: Make update-otel in contrib
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: open-telemetry/opentelemetry-collector-contrib
-        run: "echo TODO" # TODO: This may require a webhook in contrib
       - uses: actions/checkout@v3
       - name: Setup Go
         uses: actions/setup-go@v3
@@ -148,9 +139,3 @@ jobs:
           - make prepare-release GH=none PREVIOUS_VERSION=${CURRENT_STABLE} RELEASE_CANDIDATE=${CANDIDATE_STABLE} MODSET=stable
           - make prepare-release GH=none PREVIOUS_VERSION=${CURRENT_BETA} RELEASE_CANDIDATE=${CANDIDATE_BETA} MODSET=beta
           "
-
-# Still TODO manually:
-#     Create a branch named release/<release-series> (e.g. release/v0.45.x) from the changelog update commit and push to open-telemetry/opentelemetry-collector.
-#     Tag all the module groups (stable, beta) with the new release version by running the make push-tags command (e.g. make push-tags MODSET=stable and make push-tags MODSET=beta). Wait for the new tag build to pass successfully.
-#     The release script for the collector builder should create a new GitHub release for the builder. This is a separate release from the core, but we might join them in the future if it makes sense.
-#     A new v0.55.0 release should be automatically created on Github by now. Edit it and use the contents from the CHANGELOG.md as the release's description. At the top of the release's changelog, add a link to the releases repository where the binaries and other artifacts are landing, like:

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -13,10 +13,10 @@ on:
         description: Current version (stable)
       candidate-beta:
         required: true
-        description: Release candidate version (stable)
+        description: Release candidate version (beta)
       current-beta:
         required: true
-        description: Current version (stable)
+        description: Current version (beta)
 jobs:
   # Releasing opentelemetry-collector
   prepare-release:

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,154 @@
+name: Automation - Prepare Release
+
+on:
+  workflow_dispatch:
+    # Determine the version number that will be assigned to the release. During the beta phase, we increment
+    # the minor version number and set the patch number to 0.
+    inputs:
+      candidate-stable:
+        required: true
+        description: Release candidate version (stable)
+      current-stable:
+        required: true
+        description: Current version (stable)
+      candidate-beta:
+        required: true
+        description: Release candidate version (stable)
+      current-beta:
+        required: true
+        description: Current version (stable)
+jobs:
+  # Releasing opentelemetry-collector
+  prepare-release:
+    runs-on: ubuntu-latest
+    steps:
+      # To keep track of the progress, it might be helpful to create a tracking issue similar to #6067. You are responsible
+      # for all of the steps under the "Performed by collector release manager" heading. Once the issue is created, you can
+      # create the individual ones by hovering them and clicking the "Convert to issue" button on the right hand side.
+      - name: Create issue for tracking release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CANDIDATE_BETA: ${{ inputs.candidate-beta }}
+          CANDIDATE_STABLE: ${{ inputs.candidate-stable }}
+          REPO: codeboten/opentelemetry-collector
+        run: |
+          EXISTING_ISSUE=$( gh issue list --search "Release v${CANDIDATE_BETA}/v${CANDIDATE_STABLE}" --json url --jq '.[].url' --repo ${REPO} )
+          if [ "${EXISTING_ISSUE}" != "" ]; then
+            echo "Issue already exists: ${EXISTING_ISSUE}"
+            exit 0
+          fi
+          gh issue create -a ${GITHUB_ACTOR} --repo ${REPO} --label release --title "Release v${CANDIDATE_BETA}/v${CANDIDATE_STABLE}" --body "Like #4522, but for v${CANDIDATE_BETA}/v${CANDIDATE_STABLE}
+          **Performed by collector release manager**
+
+          - [ ] Prepare stable core release v${CANDIDATE_STABLE}
+          - [ ] Prepare beta core release v${CANDIDATE_BETA}
+          - [ ] Tag and release stable core v${CANDIDATE_STABLE}
+          - [ ] Tag and release beta core v${CANDIDATE_BETA}
+          - [ ] Prepare contrib release v${CANDIDATE_BETA}
+          - [ ] Tag and release contrib v${CANDIDATE_BETA}
+          - [ ] Prepare otelcol-releases v${CANDIDATE_BETA}
+          - [ ] Release binaries and container images v${CANDIDATE_BETA}
+
+          **Performed by operator maintainers**
+
+          - [ ] Release the operator v${CANDIDATE_BETA}
+
+          **Performed by helm chart maintainers**
+
+          - [ ] Update the opentelemetry-collector helm chart to use v${CANDIDATE_BETA}"
+      # Make sure that there are no open issues with release:blocker label in Core. The release has to be delayed until they are resolved.
+      - name: Check blockers in core
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: open-telemetry/opentelemetry-collector
+        run: |
+          BLOCKERS=$( gh issue list --search "label:release:blocker" --json url --jq '.[].url' --repo ${REPO} )
+          if [ "${BLOCKERS}" != "" ]; then
+              echo "Release blockers in ${REPO} repo: ${BLOCKERS}"
+              exit 1
+          fi
+      # Make sure that there are no open issues with release:blocker label in Contrib. The release has to be delayed until they are resolved.
+      - name: Check blockers in contrib
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: open-telemetry/opentelemetry-collector-contrib
+        run: |
+          BLOCKERS=$( gh issue list --search "label:release:blocker" --json url --jq '.[].url' --repo ${REPO} )
+          if [ "${BLOCKERS}" != "" ]; then
+              echo "Release blockers in ${REPO} repo: ${BLOCKERS}"
+              exit 1
+          fi
+      # Make sure the current main branch build successfully passes (Core).
+      - name: Check build status in core
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: open-telemetry/opentelemetry-collector
+        run: |
+          RESULT=$(gh run list --branch main --json status --jq '[.[] | select(.status != "queued" and .status != "in_progress")][0].status' --workflow build-and-test --repo ${REPO} )
+          if [ "${RESULT}" != "completed" ]; then
+              echo "Build status in ${REPO} is not completed: ${RESULT}"
+              echo "$(gh run list --branch main --json status,url --jq '[.[] | select(.status != "queued" and .status != "in_progress")][0].url' --workflow build-and-test --repo ${REPO} )"
+              exit 1
+          fi
+      # Make sure the current main branch build successfully passes (Contrib).
+      - name: Check build status in contrib
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: open-telemetry/opentelemetry-collector-contrib
+        run: |
+          RESULT=$(gh run list --branch main --json status --jq '[.[] | select(.status != "queued" and .status != "in_progress")][0].status' --workflow build-and-test --repo ${REPO} )
+          if [ "${RESULT}" != "completed" ]; then
+              echo "Build status in ${REPO} is not completed: ${RESULT}"
+              echo "$(gh run list --branch main --json status,url --jq '[.[] | select(.status != "queued" and .status != "in_progress")][0].url' --workflow build-and-test --repo ${REPO} )"
+              exit 1
+          fi
+      # Update Contrib to use the latest in development version of Core. Run make update-otel in
+      # Contrib root directory and if it results in any changes, submit a PR. Open this PR as draft.
+      # This is to ensure that the latest core does not break contrib in any way. We’ll update it
+      # once more to the final release number later.
+      - name: Make update-otel in contrib
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: open-telemetry/opentelemetry-collector-contrib
+        run: "echo TODO" # TODO: This may require a webhook in contrib
+      - uses: actions/checkout@v3
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.19
+      # Prepare Core for release.
+      #   - Update CHANGELOG.md file, this is done via chloggen
+      #   - Run make prepare-release PREVIOUS_VERSION=1.0.0 RELEASE_CANDIDATE=1.1.0 MODSET=stable
+      #   - Run make prepare-release PREVIOUS_VERSION=0.52.0 RELEASE_CANDIDATE=0.53.0 MODSET=beta
+      - name: Prepare release for core
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: open-telemetry/opentelemetry-collector
+          CANDIDATE_BETA: ${{ inputs.candidate-beta }}
+          CANDIDATE_STABLE: ${{ inputs.candidate-stable }}
+          CURRENT_BETA: ${{ inputs.current-beta }}
+          CURRENT_STABLE: ${{ inputs.current-stable }}
+        run: |
+          make chlog-install
+          make chlog-update VERSION=${CANDIDATE_STABLE}/${CANDIDATE_BETA}
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+          BRANCH="prepare-release-prs/${CANDIDATE_BETA}-${CANDIDATE_STABLE}"
+          git checkout -b ${BRANCH}
+          git add --all
+          git commit -m "Changelog update ${CANDIDATE_BETA}/${CANDIDATE_STABLE}"
+          make prepare-release GH=none PREVIOUS_VERSION=${CURRENT_STABLE} RELEASE_CANDIDATE=${CANDIDATE_STABLE} MODSET=stable
+          make prepare-release GH=none PREVIOUS_VERSION=${CURRENT_BETA} RELEASE_CANDIDATE=${CANDIDATE_BETA} MODSET=beta
+          git push origin ${BRANCH}
+          gh pr create --title "[chore] Prepare release ${CANDIDATE_BETA}/${CANDIDATE_STABLE}" --body "
+          The following commands were run to prepare this release:
+          - make chlog-update VERSION=${CANDIDATE_BETA}/${CANDIDATE_STABLE}
+          - make prepare-release GH=none PREVIOUS_VERSION=${CURRENT_STABLE} RELEASE_CANDIDATE=${CANDIDATE_STABLE} MODSET=stable
+          - make prepare-release GH=none PREVIOUS_VERSION=${CURRENT_BETA} RELEASE_CANDIDATE=${CANDIDATE_BETA} MODSET=beta
+          "
+
+# Still TODO manually:
+#     Create a branch named release/<release-series> (e.g. release/v0.45.x) from the changelog update commit and push to open-telemetry/opentelemetry-collector.
+#     Tag all the module groups (stable, beta) with the new release version by running the make push-tags command (e.g. make push-tags MODSET=stable and make push-tags MODSET=beta). Wait for the new tag build to pass successfully.
+#     The release script for the collector builder should create a new GitHub release for the builder. This is a separate release from the core, but we might join them in the future if it makes sense.
+#     A new v0.55.0 release should be automatically created on Github by now. Edit it and use the contents from the CHANGELOG.md as the release's description. At the top of the release's changelog, add a link to the releases repository where the binaries and other artifacts are landing, like:

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -25,6 +25,7 @@ jobs:
   prepare-release:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
       # To keep track of the progress, it might be helpful to create a tracking issue similar to #6067. You are responsible
       # for all of the steps under the "Performed by collector release manager" heading. Once the issue is created, you can
       # create the individual ones by hovering them and clicking the "Convert to issue" button on the right hand side.
@@ -34,78 +35,31 @@ jobs:
           CANDIDATE_BETA: ${{ inputs.candidate-beta }}
           CANDIDATE_STABLE: ${{ inputs.candidate-stable }}
           REPO: open-telemetry/opentelemetry-collector
-        run: |
-          EXISTING_ISSUE=$( gh issue list --search "Release v${CANDIDATE_BETA}/v${CANDIDATE_STABLE}" --json url --jq '.[].url' --repo ${REPO} )
-          if [ "${EXISTING_ISSUE}" != "" ]; then
-            echo "Issue already exists: ${EXISTING_ISSUE}"
-            exit 0
-          fi
-          gh issue create -a ${GITHUB_ACTOR} --repo ${REPO} --label release --title "Release v${CANDIDATE_BETA}/v${CANDIDATE_STABLE}" --body "Like #4522, but for v${CANDIDATE_BETA}/v${CANDIDATE_STABLE}
-          **Performed by collector release manager**
-
-          - [ ] Prepare stable core release v${CANDIDATE_STABLE}
-          - [ ] Prepare beta core release v${CANDIDATE_BETA}
-          - [ ] Tag and release stable core v${CANDIDATE_STABLE}
-          - [ ] Tag and release beta core v${CANDIDATE_BETA}
-          - [ ] Prepare contrib release v${CANDIDATE_BETA}
-          - [ ] Tag and release contrib v${CANDIDATE_BETA}
-          - [ ] Prepare otelcol-releases v${CANDIDATE_BETA}
-          - [ ] Release binaries and container images v${CANDIDATE_BETA}
-
-          **Performed by operator maintainers**
-
-          - [ ] Release the operator v${CANDIDATE_BETA}
-
-          **Performed by helm chart maintainers**
-
-          - [ ] Update the opentelemetry-collector helm chart to use v${CANDIDATE_BETA}"
+        run: ./.github/workflows/scripts/release-create-tracking-issue.sh
       # Make sure that there are no open issues with release:blocker label in Core. The release has to be delayed until they are resolved.
       - name: Check blockers in core
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: open-telemetry/opentelemetry-collector
-        run: |
-          BLOCKERS=$( gh issue list --search "label:release:blocker" --json url --jq '.[].url' --repo ${REPO} )
-          if [ "${BLOCKERS}" != "" ]; then
-              echo "Release blockers in ${REPO} repo: ${BLOCKERS}"
-              exit 1
-          fi
+        run: ./.github/workflows/scripts/release-check-blockers.sh
       # Make sure that there are no open issues with release:blocker label in Contrib. The release has to be delayed until they are resolved.
       - name: Check blockers in contrib
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: open-telemetry/opentelemetry-collector-contrib
-        run: |
-          BLOCKERS=$( gh issue list --search "label:release:blocker" --json url --jq '.[].url' --repo ${REPO} )
-          if [ "${BLOCKERS}" != "" ]; then
-              echo "Release blockers in ${REPO} repo: ${BLOCKERS}"
-              exit 1
-          fi
+        run: ./.github/workflows/scripts/release-check-blockers.sh
       # Make sure the current main branch build successfully passes (Core).
       - name: Check build status in core
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: open-telemetry/opentelemetry-collector
-        run: |
-          RESULT=$(gh run list --branch main --json status --jq '[.[] | select(.status != "queued" and .status != "in_progress")][0].status' --workflow build-and-test --repo ${REPO} )
-          if [ "${RESULT}" != "completed" ]; then
-              echo "Build status in ${REPO} is not completed: ${RESULT}"
-              echo "$(gh run list --branch main --json status,url --jq '[.[] | select(.status != "queued" and .status != "in_progress")][0].url' --workflow build-and-test --repo ${REPO} )"
-              exit 1
-          fi
+        run: ./.github/workflows/scripts/release-check-build-status.sh
       # Make sure the current main branch build successfully passes (Contrib).
       - name: Check build status in contrib
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: open-telemetry/opentelemetry-collector-contrib
-        run: |
-          RESULT=$(gh run list --branch main --json status --jq '[.[] | select(.status != "queued" and .status != "in_progress")][0].status' --workflow build-and-test --repo ${REPO} )
-          if [ "${RESULT}" != "completed" ]; then
-              echo "Build status in ${REPO} is not completed: ${RESULT}"
-              echo "$(gh run list --branch main --json status,url --jq '[.[] | select(.status != "queued" and .status != "in_progress")][0].url' --workflow build-and-test --repo ${REPO} )"
-              exit 1
-          fi
-      - uses: actions/checkout@v3
+        run: ./.github/workflows/scripts/release-check-build-status.sh
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
@@ -122,20 +76,4 @@ jobs:
           CANDIDATE_STABLE: ${{ inputs.candidate-stable }}
           CURRENT_BETA: ${{ inputs.current-beta }}
           CURRENT_STABLE: ${{ inputs.current-stable }}
-        run: |
-          make chlog-update VERSION=${CANDIDATE_STABLE}/${CANDIDATE_BETA}
-          git config user.name "$GITHUB_ACTOR"
-          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-          BRANCH="prepare-release-prs/${CANDIDATE_BETA}-${CANDIDATE_STABLE}"
-          git checkout -b ${BRANCH}
-          git add --all
-          git commit -m "Changelog update ${CANDIDATE_BETA}/${CANDIDATE_STABLE}"
-          make prepare-release GH=none PREVIOUS_VERSION=${CURRENT_STABLE} RELEASE_CANDIDATE=${CANDIDATE_STABLE} MODSET=stable
-          make prepare-release GH=none PREVIOUS_VERSION=${CURRENT_BETA} RELEASE_CANDIDATE=${CANDIDATE_BETA} MODSET=beta
-          git push origin ${BRANCH}
-          gh pr create --title "[chore] Prepare release ${CANDIDATE_BETA}/${CANDIDATE_STABLE}" --body "
-          The following commands were run to prepare this release:
-          - make chlog-update VERSION=${CANDIDATE_BETA}/${CANDIDATE_STABLE}
-          - make prepare-release GH=none PREVIOUS_VERSION=${CURRENT_STABLE} RELEASE_CANDIDATE=${CANDIDATE_STABLE} MODSET=stable
-          - make prepare-release GH=none PREVIOUS_VERSION=${CURRENT_BETA} RELEASE_CANDIDATE=${CANDIDATE_BETA} MODSET=beta
-          "
+        run: ./.github/workflows/scripts/release-prepare-release.sh

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -7,16 +7,18 @@ on:
     inputs:
       candidate-stable:
         required: true
-        description: Release candidate version (stable)
+        description: Release candidate version (stable, like 1.0.0-rc4)
       current-stable:
         required: true
-        description: Current version (stable)
+        description: Current version (stable, like 1.0.0-rc3)
+
       candidate-beta:
         required: true
-        description: Release candidate version (beta)
+        description: Release candidate version (beta, like 0.70.0)
+
       current-beta:
         required: true
-        description: Current version (beta)
+        description: Current version (beta, like 0.69.1)
 jobs:
   # Releasing opentelemetry-collector
   prepare-release:

--- a/.github/workflows/scripts/release-check-blockers.sh
+++ b/.github/workflows/scripts/release-check-blockers.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -ex
+
+BLOCKERS=$( gh issue list --search "label:release:blocker" --json url --jq '.[].url' --repo "${REPO}" )
+if [ "${BLOCKERS}" != "" ]; then
+    echo "Release blockers in ${REPO} repo: ${BLOCKERS}"
+    exit 1
+fi

--- a/.github/workflows/scripts/release-check-build-status.sh
+++ b/.github/workflows/scripts/release-check-build-status.sh
@@ -1,0 +1,11 @@
+#!/bin/bash -ex
+
+BRANCH=main
+WORKFLOW=build-and-test
+
+RESULT=$(gh run list --branch "${BRANCH}" --json status --jq '[.[] | select(.status != "queued" and .status != "in_progress")][0].status' --workflow "${WORKFLOW}" --repo "${REPO}" )
+if [ "${RESULT}" != "completed" ]; then
+    echo "Build status in ${REPO} is not completed: ${RESULT}"
+    gh run list --branch "${BRANCH}" --json status,url --jq '[.[] | select(.status != "queued" and .status != "in_progress")][0].url' --workflow "${WORKFLOW}" --repo "${REPO}"
+    exit 1
+fi

--- a/.github/workflows/scripts/release-create-tracking-issue.sh
+++ b/.github/workflows/scripts/release-create-tracking-issue.sh
@@ -1,0 +1,28 @@
+#!/bin/bash -ex
+
+EXISTING_ISSUE=$( gh issue list --search "Release v${CANDIDATE_BETA}/v${CANDIDATE_STABLE}" --json url --jq '.[].url' --repo "${REPO}" )
+
+if [ "${EXISTING_ISSUE}" != "" ]; then
+    echo "Issue already exists: ${EXISTING_ISSUE}"
+    exit 0
+fi
+
+gh issue create -a "${GITHUB_ACTOR}" --repo "${REPO}" --label release --title "Release v${CANDIDATE_BETA}/v${CANDIDATE_STABLE}" --body "Like #4522, but for v${CANDIDATE_BETA}/v${CANDIDATE_STABLE}
+**Performed by collector release manager**
+
+- [ ] Prepare stable core release v${CANDIDATE_STABLE}
+- [ ] Prepare beta core release v${CANDIDATE_BETA}
+- [ ] Tag and release stable core v${CANDIDATE_STABLE}
+- [ ] Tag and release beta core v${CANDIDATE_BETA}
+- [ ] Prepare contrib release v${CANDIDATE_BETA}
+- [ ] Tag and release contrib v${CANDIDATE_BETA}
+- [ ] Prepare otelcol-releases v${CANDIDATE_BETA}
+- [ ] Release binaries and container images v${CANDIDATE_BETA}
+
+**Performed by operator maintainers**
+
+- [ ] Release the operator v${CANDIDATE_BETA}
+
+**Performed by helm chart maintainers**
+
+- [ ] Update the opentelemetry-collector helm chart to use v${CANDIDATE_BETA}"

--- a/.github/workflows/scripts/release-prepare-release.sh
+++ b/.github/workflows/scripts/release-prepare-release.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+make chlog-update VERSION="${CANDIDATE_STABLE}/${CANDIDATE_BETA}"
+git config user.name "$GITHUB_ACTOR"
+git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+BRANCH="prepare-release-prs/${CANDIDATE_BETA}-${CANDIDATE_STABLE}"
+git checkout -b "${BRANCH}"
+git add --all
+git commit -m "Changelog update ${CANDIDATE_BETA}/${CANDIDATE_STABLE}"
+
+make prepare-release GH=none PREVIOUS_VERSION="${CURRENT_STABLE}" RELEASE_CANDIDATE="${CANDIDATE_STABLE}" MODSET=stable
+make prepare-release GH=none PREVIOUS_VERSION="${CURRENT_BETA}" RELEASE_CANDIDATE="${CANDIDATE_BETA}" MODSET=beta
+git push origin "${BRANCH}"
+
+gh pr create --title "[chore] Prepare release ${CANDIDATE_BETA}/${CANDIDATE_STABLE}" --body "
+The following commands were run to prepare this release:
+- make chlog-update VERSION=${CANDIDATE_BETA}/${CANDIDATE_STABLE}
+- make prepare-release GH=none PREVIOUS_VERSION=${CURRENT_STABLE} RELEASE_CANDIDATE=${CANDIDATE_STABLE} MODSET=stable
+- make prepare-release GH=none PREVIOUS_VERSION=${CURRENT_BETA} RELEASE_CANDIDATE=${CANDIDATE_BETA} MODSET=beta
+"

--- a/Makefile
+++ b/Makefile
@@ -398,15 +398,13 @@ else
 endif
 	# ensure a clean branch
 	git diff -s --exit-code || (echo "local repository not clean"; exit 1)
-	# TODO: update changelog
-	# update versions.yaml config.go builder-config.yaml
 	sed -i.bak 's/$(PREVIOUS_VERSION)/$(RELEASE_CANDIDATE)/g' versions.yaml
 	sed -i.bak 's/$(PREVIOUS_VERSION)/$(RELEASE_CANDIDATE)/g' ./cmd/builder/internal/builder/config.go
+	sed -i.bak 's/$(PREVIOUS_VERSION)/$(RELEASE_CANDIDATE)/g' ./cmd/builder/test/core.builder.yaml
 	sed -i.bak 's/$(PREVIOUS_VERSION)/$(RELEASE_CANDIDATE)/g' ./cmd/otelcorecol/builder-config.yaml
 	sed -i.bak 's/$(PREVIOUS_VERSION)/$(RELEASE_CANDIDATE)/g' examples/k8s/otel-config.yaml
 	find . -name "*.bak" -type f -delete
 	# commit changes before running multimod
-	git checkout -b opentelemetry-collector-bot/release-$(RELEASE_CANDIDATE)
 	git add .
 	git commit -m "prepare release $(RELEASE_CANDIDATE)"
 	$(MAKE) multimod-prerelease
@@ -414,13 +412,7 @@ endif
 	$(MAKE) -C cmd/builder config
 	$(MAKE) genotelcorecol
 	git add .
-	git commit -m "add multimod changes" || (echo "no multimod changes to commit")
-	git push fork opentelemetry-collector-bot/release-$(RELEASE_CANDIDATE)
-	@if [ -z "$(GH)" ]; then \
-		echo "'gh' command not found, can't submit the PR on your behalf."; \
-		exit 1; \
-	fi
-	$(GH) pr create --title "[chore] prepare release $(RELEASE_CANDIDATE)"
+	git commit -m "add multimod changes $(RELEASE_CANDIDATE)" || (echo "no multimod changes to commit")
 
 .PHONY: clean
 clean:

--- a/docs/release.md
+++ b/docs/release.md
@@ -25,36 +25,19 @@ It is possible that a core approver isn't a contrib approver. In that case, the 
 
 ## Releasing opentelemetry-collector
 
-1. Make sure that there are no open issues with `release:blocker` label in [Core](https://github.com/open-telemetry/opentelemetry-collector/labels/release%3Ablocker) or [Contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib/labels/release%3Ablocker) repo. The release has to be delayed until they are resolved.
-
-1. Make sure the current `main` branch build successfully passes ([Core](https://github.com/open-telemetry/opentelemetry-collector/actions/workflows/build-and-test.yml?query=branch%3Amain) and [Contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/workflows/build-and-test.yml?query=branch%3Amain)).
-
 1. Determine the version number that will be assigned to the release. During the beta phase, we increment the minor version number and set the patch number to 0. In this document, we are using `v0.55.0` as the version to be released, following `v0.54.0`.
 
-1. To keep track of the progress, it might be helpful to create a [tracking issue](https://github.com/open-telemetry/opentelemetry-collector/issues/new?assignees=&labels=release&template=release.md&title=Release+vX.X.X) similar to [#6067](https://github.com/open-telemetry/opentelemetry-collector/issues/6067). You are responsible for all of the steps under the *"Performed by collector release manager"* heading. Once the issue is created, you can create the individual ones by hovering them and clicking the "Convert to issue" button on the right hand side.
+2. Run the "Prepare release" action.
 
-1. Update Contrib to use the latest in development version of Core. Run `make update-otel` in Contrib root directory and if it results in any changes, submit a PR. Open this PR as draft. This is to ensure that the latest core does not break contrib in any way. We’ll update it once more to the final release number later.
+3. Update Contrib to use the latest in development version of Core. Run `make update-otel` in Contrib root directory and if it results in any changes, submit a PR. Open this PR as draft. This is to ensure that the latest core does not break contrib in any way. We’ll update it once more to the final release number later.
 
-1. Prepare Core for release.
+4. Create a branch named `release/<release-series>` (e.g. `release/v0.45.x`) from the changelog update commit and push to `open-telemetry/opentelemetry-collector`.
 
-    * Update CHANGELOG.md file, this is done via `chloggen`. Run the following command from the root of the opentelemetry-collector-contrib repo:
-      * `make chlog-update VERSION=v0.55.0`
+5. Tag all the module groups (stable, beta) with the new release version by running the `make push-tags` command (e.g. `make push-tags MODSET=stable` and `make push-tags MODSET=beta`). Wait for the new tag build to pass successfully.
 
-    * Update the version numbers in `cmd/builder/test/core.builder.yaml`
+6. The release script for the collector builder should create a new GitHub release for the builder. This is a separate release from the core, but we might join them in the future if it makes sense.
 
-    * Run `make prepare-release PREVIOUS_VERSION=1.0.0 RELEASE_CANDIDATE=1.1.0 MODSET=stable`
-
-    * Run `make prepare-release PREVIOUS_VERSION=0.52.0 RELEASE_CANDIDATE=0.53.0 MODSET=beta`
-
-    * Ensure the `main` branch builds successfully.
-
-1. Create a branch named `release/<release-series>` (e.g. `release/v0.45.x`) from the changelog update commit and push to `open-telemetry/opentelemetry-collector`.
-
-1. Tag all the module groups (stable, beta) with the new release version by running the `make push-tags` command (e.g. `make push-tags MODSET=stable` and `make push-tags MODSET=beta`). Wait for the new tag build to pass successfully.
-
-1. The release script for the collector builder should create a new GitHub release for the builder. This is a separate release from the core, but we might join them in the future if it makes sense.
-
-2. A new `v0.55.0` release should be automatically created on Github by now. Edit it and use the contents from the CHANGELOG.md as the release's description.
+7. A new `v0.55.0` release should be automatically created on Github by now. Edit it and use the contents from the CHANGELOG.md as the release's description.
 
 ## Releasing opentelemetry-collector-contrib
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -27,7 +27,7 @@ It is possible that a core approver isn't a contrib approver. In that case, the 
 
 1. Determine the version number that will be assigned to the release. During the beta phase, we increment the minor version number and set the patch number to 0. In this document, we are using `v0.55.0` as the version to be released, following `v0.54.0`.
 
-2. Run the "Prepare release" action.
+2. Run the "Automation - Prepare Release" action. This will create an issue to track the progress of the release and a pull request to update the changelog and version numbers in the repo.
 
 3. Update Contrib to use the latest in development version of Core. Run `make update-otel` in Contrib root directory and if it results in any changes, submit a PR. Open this PR as draft. This is to ensure that the latest core does not break contrib in any way. We’ll update it once more to the final release number later.
 


### PR DESCRIPTION
This PR adds a github action that can be triggered manually to do the following:

- creates tracking issue
- checks for blockers in core
- checks for blockers in contrib
- checks status of build-and-test in core
- checks status of build-and-test in contrib
- runs chlog update
- runs make-prepare for both stable/beta
- creates a PR

See the tracking issue created [here](https://github.com/codeboten/opentelemetry-collector/issues/175)
You can see the PR produced [here](https://github.com/codeboten/opentelemetry-collector/pull/176)

Running the workflow looks like this:
<img width="316" alt="Screen Shot 2023-01-17 at 10 41 17 AM" src="https://user-images.githubusercontent.com/223565/212983842-1e929a41-d9e2-412d-a825-1c57430d0d3e.png">


Signed-off-by: Alex Boten <aboten@lightstep.com>
