### PR TITLE
Add connectors to otelcol config

### DIFF
--- a/otelcol/configprovider.go
+++ b/otelcol/configprovider.go
@@ -102,6 +102,7 @@ func (cm *configProvider) Get(ctx context.Context, factories Factories) (*Config
 		Receivers:  cfg.Receivers.Configs(),
 		Processors: cfg.Processors.Configs(),
 		Exporters:  cfg.Exporters.Configs(),
+		Connectors: cfg.Connectors.Configs(),
 		Extensions: cfg.Extensions.Configs(),
 		Service:    cfg.Service,
 	}, nil

--- a/otelcol/unmarshaler.go
+++ b/otelcol/unmarshaler.go
@@ -17,7 +17,6 @@ package otelcol // import "go.opentelemetry.io/collector/otelcol"
 import (
 	"go.uber.org/zap/zapcore"
 
-	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configtelemetry"
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/connector"
@@ -47,7 +46,7 @@ func unmarshal(v *confmap.Conf, factories Factories) (*configSettings, error) {
 		Receivers:  configunmarshaler.NewConfigs(factories.Receivers),
 		Processors: configunmarshaler.NewConfigs(factories.Processors),
 		Exporters:  configunmarshaler.NewConfigs(factories.Exporters),
-		Connectors: configunmarshaler.NewConfigs(map[component.Type]connector.Factory{}),
+		Connectors: configunmarshaler.NewConfigs(factories.Connectors),
 		Extensions: configunmarshaler.NewConfigs(factories.Extensions),
 		// TODO: Add a component.ServiceFactory to allow this to be defined by the Service.
 		Service: service.Config{


### PR DESCRIPTION
Part of #6700 

This PR adds connectors to the `otelcol.Config` and updates associated config provider and unmarshaler.