### PR TITLE
Start enforcing grpc server implementation to embed UnimplementedGRPCServer, dissallow client implementation

### DIFF
--- a/.chloggen/disallowimpl.yaml
+++ b/.chloggen/disallowimpl.yaml
@@ -5,7 +5,7 @@ change_type: breaking
 component: pdata
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Enforce grpc server implementation to embed UnimplementedGRPCServer, dissallow client implementation
+note: Start enforcing grpc server implementation to embed UnimplementedGRPCServer, dissallow client implementation
 
 # One or more tracking issues or pull requests related to the change
 issues: [6966]

--- a/.chloggen/disallowimpl.yaml
+++ b/.chloggen/disallowimpl.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: pdata
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Enforce grpc server implementation to embed UnimplementedGRPCServer, dissallow client implementation
+
+# One or more tracking issues or pull requests related to the change
+issues: [6966]

--- a/config/configgrpc/configgrpc_test.go
+++ b/config/configgrpc/configgrpc_test.go
@@ -1057,6 +1057,7 @@ func (m *mockServerStream) Context() context.Context {
 }
 
 type grpcTraceServer struct {
+	ptraceotlp.UnimplementedGRPCServer
 	recordedContext context.Context
 }
 

--- a/exporter/otlpexporter/otlp_test.go
+++ b/exporter/otlpexporter/otlp_test.go
@@ -70,6 +70,7 @@ func (r *mockReceiver) setExportError(err error) {
 }
 
 type mockTracesReceiver struct {
+	ptraceotlp.UnimplementedGRPCServer
 	mockReceiver
 	lastRequest ptrace.Traces
 }
@@ -125,6 +126,7 @@ func otlpTracesReceiverOnGRPCServer(ln net.Listener, useTLS bool) (*mockTracesRe
 }
 
 type mockLogsReceiver struct {
+	plogotlp.UnimplementedGRPCServer
 	mockReceiver
 	lastRequest plog.Logs
 }
@@ -165,6 +167,7 @@ func otlpLogsReceiverOnGRPCServer(ln net.Listener) *mockLogsReceiver {
 }
 
 type mockMetricsReceiver struct {
+	pmetricotlp.UnimplementedGRPCServer
 	mockReceiver
 	lastRequest pmetric.Metrics
 }

--- a/pdata/plog/plogotlp/grpc.go
+++ b/pdata/plog/plogotlp/grpc.go
@@ -74,8 +74,6 @@ func (*UnimplementedGRPCServer) Export(context.Context, ExportRequest) (ExportRe
 	return ExportResponse{}, status.Errorf(codes.Unimplemented, "method Export not implemented")
 }
 
-func (*UnimplementedGRPCServer) unexported() {}
-
 // RegisterGRPCServer registers the Server to the grpc.Server.
 func RegisterGRPCServer(s *grpc.Server, srv GRPCServer) {
 	otlpcollectorlog.RegisterLogsServiceServer(s, &rawLogsServer{srv: srv})

--- a/pdata/plog/plogotlp/grpc.go
+++ b/pdata/plog/plogotlp/grpc.go
@@ -18,6 +18,8 @@ import (
 	"context"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	otlpcollectorlog "go.opentelemetry.io/collector/pdata/internal/data/protogen/collector/logs/v1"
 	"go.opentelemetry.io/collector/pdata/internal/otlp"
@@ -32,6 +34,9 @@ type GRPCClient interface {
 	// For performance reasons, it is recommended to keep this RPC
 	// alive for the entire life of the application.
 	Export(ctx context.Context, request ExportRequest, opts ...grpc.CallOption) (ExportResponse, error)
+
+	// unexported disallow implementation of the GRPCClient.
+	unexported()
 }
 
 // NewGRPCClient returns a new GRPCClient connected using the given connection.
@@ -48,14 +53,31 @@ func (c *grpcClient) Export(ctx context.Context, request ExportRequest, opts ...
 	return ExportResponse{orig: rsp}, err
 }
 
+func (c *grpcClient) unexported() {}
+
 // GRPCServer is the server API for OTLP gRPC LogsService service.
+// Implementations MUST embed UnimplementedGRPCServer.
 type GRPCServer interface {
 	// Export is called every time a new request is received.
 	//
 	// For performance reasons, it is recommended to keep this RPC
 	// alive for the entire life of the application.
 	Export(context.Context, ExportRequest) (ExportResponse, error)
+
+	// unexported forces everyone to embed UnimplementedGRPCServer.
+	unexported()
 }
+
+var _ GRPCServer = (*UnimplementedGRPCServer)(nil)
+
+// UnimplementedGRPCServer MUST be embedded to have forward compatible implementations.
+type UnimplementedGRPCServer struct{}
+
+func (*UnimplementedGRPCServer) Export(context.Context, ExportRequest) (ExportResponse, error) {
+	return ExportResponse{}, status.Errorf(codes.Unimplemented, "method Export not implemented")
+}
+
+func (*UnimplementedGRPCServer) unexported() {}
 
 // RegisterGRPCServer registers the Server to the grpc.Server.
 func RegisterGRPCServer(s *grpc.Server, srv GRPCServer) {

--- a/pdata/plog/plogotlp/grpc.go
+++ b/pdata/plog/plogotlp/grpc.go
@@ -34,6 +34,9 @@ type GRPCClient interface {
 	// For performance reasons, it is recommended to keep this RPC
 	// alive for the entire life of the application.
 	Export(ctx context.Context, request ExportRequest, opts ...grpc.CallOption) (ExportResponse, error)
+
+	// unexported disallow implementation of the GRPCClient.
+	unexported()
 }
 
 // NewGRPCClient returns a new GRPCClient connected using the given connection.
@@ -60,9 +63,6 @@ type GRPCServer interface {
 	// For performance reasons, it is recommended to keep this RPC
 	// alive for the entire life of the application.
 	Export(context.Context, ExportRequest) (ExportResponse, error)
-
-	// unexported forces everyone to embed UnimplementedGRPCServer.
-	unexported()
 }
 
 var _ GRPCServer = (*UnimplementedGRPCServer)(nil)

--- a/pdata/plog/plogotlp/grpc.go
+++ b/pdata/plog/plogotlp/grpc.go
@@ -34,9 +34,6 @@ type GRPCClient interface {
 	// For performance reasons, it is recommended to keep this RPC
 	// alive for the entire life of the application.
 	Export(ctx context.Context, request ExportRequest, opts ...grpc.CallOption) (ExportResponse, error)
-
-	// unexported disallow implementation of the GRPCClient.
-	unexported()
 }
 
 // NewGRPCClient returns a new GRPCClient connected using the given connection.

--- a/pdata/plog/plogotlp/grpc_test.go
+++ b/pdata/plog/plogotlp/grpc_test.go
@@ -102,6 +102,7 @@ func TestGrpcError(t *testing.T) {
 }
 
 type fakeLogsServer struct {
+	UnimplementedGRPCServer
 	t   *testing.T
 	err error
 }

--- a/pdata/pmetric/pmetricotlp/grpc.go
+++ b/pdata/pmetric/pmetricotlp/grpc.go
@@ -73,8 +73,6 @@ func (*UnimplementedGRPCServer) Export(context.Context, ExportRequest) (ExportRe
 	return ExportResponse{}, status.Errorf(codes.Unimplemented, "method Export not implemented")
 }
 
-func (*UnimplementedGRPCServer) unexported() {}
-
 // RegisterGRPCServer registers the GRPCServer to the grpc.Server.
 func RegisterGRPCServer(s *grpc.Server, srv GRPCServer) {
 	otlpcollectormetrics.RegisterMetricsServiceServer(s, &rawMetricsServer{srv: srv})

--- a/pdata/pmetric/pmetricotlp/grpc.go
+++ b/pdata/pmetric/pmetricotlp/grpc.go
@@ -18,6 +18,8 @@ import (
 	"context"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	otlpcollectormetrics "go.opentelemetry.io/collector/pdata/internal/data/protogen/collector/metrics/v1"
 	"go.opentelemetry.io/collector/pdata/internal/otlp"
@@ -32,6 +34,9 @@ type GRPCClient interface {
 	// For performance reasons, it is recommended to keep this RPC
 	// alive for the entire life of the application.
 	Export(ctx context.Context, request ExportRequest, opts ...grpc.CallOption) (ExportResponse, error)
+
+	// unexported disallow implementation of the GRPCClient.
+	unexported()
 }
 
 // NewGRPCClient returns a new GRPCClient connected using the given connection.
@@ -48,6 +53,8 @@ func (c *grpcClient) Export(ctx context.Context, request ExportRequest, opts ...
 	return ExportResponse{orig: rsp}, err
 }
 
+func (c *grpcClient) unexported() {}
+
 // GRPCServer is the server API for OTLP gRPC MetricsService service.
 type GRPCServer interface {
 	// Export is called every time a new request is received.
@@ -55,7 +62,21 @@ type GRPCServer interface {
 	// For performance reasons, it is recommended to keep this RPC
 	// alive for the entire life of the application.
 	Export(context.Context, ExportRequest) (ExportResponse, error)
+
+	// unexported forces everyone to embed UnimplementedGRPCServer.
+	unexported()
 }
+
+var _ GRPCServer = (*UnimplementedGRPCServer)(nil)
+
+// UnimplementedGRPCServer MUST be embedded to have forward compatible implementations.
+type UnimplementedGRPCServer struct{}
+
+func (*UnimplementedGRPCServer) Export(context.Context, ExportRequest) (ExportResponse, error) {
+	return ExportResponse{}, status.Errorf(codes.Unimplemented, "method Export not implemented")
+}
+
+func (*UnimplementedGRPCServer) unexported() {}
 
 // RegisterGRPCServer registers the GRPCServer to the grpc.Server.
 func RegisterGRPCServer(s *grpc.Server, srv GRPCServer) {

--- a/pdata/pmetric/pmetricotlp/grpc.go
+++ b/pdata/pmetric/pmetricotlp/grpc.go
@@ -62,9 +62,6 @@ type GRPCServer interface {
 	// For performance reasons, it is recommended to keep this RPC
 	// alive for the entire life of the application.
 	Export(context.Context, ExportRequest) (ExportResponse, error)
-
-	// unexported forces everyone to embed UnimplementedGRPCServer.
-	unexported()
 }
 
 var _ GRPCServer = (*UnimplementedGRPCServer)(nil)

--- a/pdata/pmetric/pmetricotlp/grpc_test.go
+++ b/pdata/pmetric/pmetricotlp/grpc_test.go
@@ -102,6 +102,7 @@ func TestGrpcError(t *testing.T) {
 }
 
 type fakeMetricsServer struct {
+	UnimplementedGRPCServer
 	t   *testing.T
 	err error
 }

--- a/pdata/ptrace/ptraceotlp/grpc.go
+++ b/pdata/ptrace/ptraceotlp/grpc.go
@@ -18,6 +18,8 @@ import (
 	"context"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	otlpcollectortrace "go.opentelemetry.io/collector/pdata/internal/data/protogen/collector/trace/v1"
 	"go.opentelemetry.io/collector/pdata/internal/otlp"
@@ -32,6 +34,9 @@ type GRPCClient interface {
 	// For performance reasons, it is recommended to keep this RPC
 	// alive for the entire life of the application.
 	Export(ctx context.Context, request ExportRequest, opts ...grpc.CallOption) (ExportResponse, error)
+
+	// unexported disallow implementation of the GRPCClient.
+	unexported()
 }
 
 // NewGRPCClient returns a new GRPCClient connected using the given connection.
@@ -49,6 +54,8 @@ func (c *grpcClient) Export(ctx context.Context, request ExportRequest, opts ...
 	return ExportResponse{orig: rsp}, err
 }
 
+func (c *grpcClient) unexported() {}
+
 // GRPCServer is the server API for OTLP gRPC TracesService service.
 type GRPCServer interface {
 	// Export is called every time a new request is received.
@@ -56,7 +63,21 @@ type GRPCServer interface {
 	// For performance reasons, it is recommended to keep this RPC
 	// alive for the entire life of the application.
 	Export(context.Context, ExportRequest) (ExportResponse, error)
+
+	// unexported forces everyone to embed UnimplementedGRPCServer.
+	unexported()
 }
+
+var _ GRPCServer = (*UnimplementedGRPCServer)(nil)
+
+// UnimplementedGRPCServer MUST be embedded to have forward compatible implementations.
+type UnimplementedGRPCServer struct{}
+
+func (*UnimplementedGRPCServer) Export(context.Context, ExportRequest) (ExportResponse, error) {
+	return ExportResponse{}, status.Errorf(codes.Unimplemented, "method Export not implemented")
+}
+
+func (*UnimplementedGRPCServer) unexported() {}
 
 // RegisterGRPCServer registers the GRPCServer to the grpc.Server.
 func RegisterGRPCServer(s *grpc.Server, srv GRPCServer) {

--- a/pdata/ptrace/ptraceotlp/grpc.go
+++ b/pdata/ptrace/ptraceotlp/grpc.go
@@ -34,9 +34,6 @@ type GRPCClient interface {
 	// For performance reasons, it is recommended to keep this RPC
 	// alive for the entire life of the application.
 	Export(ctx context.Context, request ExportRequest, opts ...grpc.CallOption) (ExportResponse, error)
-
-	// unexported disallow implementation of the GRPCClient.
-	unexported()
 }
 
 // NewGRPCClient returns a new GRPCClient connected using the given connection.

--- a/pdata/ptrace/ptraceotlp/grpc.go
+++ b/pdata/ptrace/ptraceotlp/grpc.go
@@ -34,6 +34,9 @@ type GRPCClient interface {
 	// For performance reasons, it is recommended to keep this RPC
 	// alive for the entire life of the application.
 	Export(ctx context.Context, request ExportRequest, opts ...grpc.CallOption) (ExportResponse, error)
+
+	// unexported disallow implementation of the GRPCClient.
+	unexported()
 }
 
 // NewGRPCClient returns a new GRPCClient connected using the given connection.
@@ -60,9 +63,6 @@ type GRPCServer interface {
 	// For performance reasons, it is recommended to keep this RPC
 	// alive for the entire life of the application.
 	Export(context.Context, ExportRequest) (ExportResponse, error)
-
-	// unexported forces everyone to embed UnimplementedGRPCServer.
-	unexported()
 }
 
 var _ GRPCServer = (*UnimplementedGRPCServer)(nil)
@@ -73,8 +73,6 @@ type UnimplementedGRPCServer struct{}
 func (*UnimplementedGRPCServer) Export(context.Context, ExportRequest) (ExportResponse, error) {
 	return ExportResponse{}, status.Errorf(codes.Unimplemented, "method Export not implemented")
 }
-
-func (*UnimplementedGRPCServer) unexported() {}
 
 // RegisterGRPCServer registers the GRPCServer to the grpc.Server.
 func RegisterGRPCServer(s *grpc.Server, srv GRPCServer) {

--- a/pdata/ptrace/ptraceotlp/grpc_test.go
+++ b/pdata/ptrace/ptraceotlp/grpc_test.go
@@ -102,6 +102,7 @@ func TestGrpcError(t *testing.T) {
 }
 
 type fakeTracesServer struct {
+	UnimplementedGRPCServer
 	t   *testing.T
 	err error
 }

--- a/receiver/otlpreceiver/internal/logs/otlp.go
+++ b/receiver/otlpreceiver/internal/logs/otlp.go
@@ -28,6 +28,7 @@ const (
 
 // Receiver is the type used to handle spans from OpenTelemetry exporters.
 type Receiver struct {
+	plogotlp.UnimplementedGRPCServer
 	nextConsumer consumer.Logs
 	obsrecv      *obsreport.Receiver
 }

--- a/receiver/otlpreceiver/internal/metrics/otlp.go
+++ b/receiver/otlpreceiver/internal/metrics/otlp.go
@@ -29,6 +29,7 @@ const (
 
 // Receiver is the type used to handle metrics from OpenTelemetry exporters.
 type Receiver struct {
+	pmetricotlp.UnimplementedGRPCServer
 	nextConsumer consumer.Metrics
 	obsrecv      *obsreport.Receiver
 }

--- a/receiver/otlpreceiver/internal/trace/otlp.go
+++ b/receiver/otlpreceiver/internal/trace/otlp.go
@@ -29,6 +29,7 @@ const (
 
 // Receiver is the type used to handle spans from OpenTelemetry exporters.
 type Receiver struct {
+	ptraceotlp.UnimplementedGRPCServer
 	nextConsumer consumer.Traces
 	obsrecv      *obsreport.Receiver
 }


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-collector/issues/6966

This pattern is inspired by the gRPC generated code.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>