### PR TITLE
Handle partial success responses in the OTLP HTTP exporter

### DIFF
--- a/.chloggen/otlphttp-partial-success.yaml
+++ b/.chloggen/otlphttp-partial-success.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: otlphttpexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Treat partial success responses as errors
+
+# One or more tracking issues or pull requests related to the change
+issues: [6686]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/exporter/otlphttpexporter/otlp.go
+++ b/exporter/otlphttpexporter/otlp.go
@@ -133,12 +133,7 @@ func (e *baseExporter) export(ctx context.Context, url string, request []byte, p
 	}()
 
 	if resp.StatusCode >= 200 && resp.StatusCode <= 299 {
-		if err := handlePartialSuccessResponse(resp, partialSuccessHandler); err != nil {
-			return err
-		}
-
-		// Request is successful.
-		return nil
+		return handlePartialSuccessResponse(resp, partialSuccessHandler)
 	}
 
 	respStatus := readResponseStatus(resp)


### PR DESCRIPTION
**Description:**

Handle partial success messages returned from OTLP HTTP backends.

**Link to tracking Issue:**

Fixes https://github.com/open-telemetry/opentelemetry-collector/issues/6686

**Testing:**

Unit tests. I was able to manually test partial success messages when submitting metrics to a vendor backend. I'd welcome any additional places to test this.
