### PR TITLE
[chore] update release build job to trigger on v* tag push

### DIFF
--- a/.github/workflows/builder-release.yaml
+++ b/.github/workflows/builder-release.yaml
@@ -3,7 +3,7 @@ name: Builder - Release
 on:
   push:
     tags:
-      - 'cmd/builder/v*'
+      - 'v*'
 
 jobs:
   goreleaser:


### PR DESCRIPTION
In the last 3 releases, this job has created a release for the cmd/builder/v* tag, which caused an issue in the release process and introduced additional manual steps. An alternative to this would be to create two releases, one for the builder and one for the collector, but that seems overkill at this point.

Fix #6849

Signed-off-by: Alex Boten <aboten@lightstep.com>
