### PR TITLE
[chore] update release configuration

### DIFF
--- a/cmd/builder/.goreleaser.yml
+++ b/cmd/builder/.goreleaser.yml
@@ -27,6 +27,8 @@ release:
   github:
     owner: open-telemetry
     name: opentelemetry-collector
+  header: |
+    ### Images and binaries here: https://github.com/open-telemetry/opentelemetry-collector-releases/releases/tag/{{ .Tag }}
 archives:
   - format: binary
 checksum:

--- a/docs/release.md
+++ b/docs/release.md
@@ -54,11 +54,7 @@ It is possible that a core approver isn't a contrib approver. In that case, the 
 
 1. The release script for the collector builder should create a new GitHub release for the builder. This is a separate release from the core, but we might join them in the future if it makes sense.
 
-1. A new `v0.55.0` release should be automatically created on Github by now. Edit it and use the contents from the CHANGELOG.md as the release's description. At the top of the release's changelog, add a link to the releases repository where the binaries and other artifacts are landing, like:
-
-```
-### Images and binaries here: https://github.com/open-telemetry/opentelemetry-collector-releases/releases/tag/v0.55.0
-```
+2. A new `v0.55.0` release should be automatically created on Github by now. Edit it and use the contents from the CHANGELOG.md as the release's description.
 
 ## Releasing opentelemetry-collector-contrib
 


### PR DESCRIPTION
This removes the need to add the location of the releases repo at the top of the changelog.

Signed-off-by: Alex Boten <aboten@lightstep.com>
