### PR TITLE
Add connector validation to otelcol

### DIFF
--- a/otelcol/collector.go
+++ b/otelcol/collector.go
@@ -29,6 +29,7 @@ import (
 	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/connector"
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/extension"
 	"go.opentelemetry.io/collector/otelcol/internal/grpclog"
@@ -165,6 +166,7 @@ func (col *Collector) setupConfigurationComponents(ctx context.Context) error {
 		Receivers:         receiver.NewBuilder(cfg.Receivers, col.set.Factories.Receivers),
 		Processors:        processor.NewBuilder(cfg.Processors, col.set.Factories.Processors),
 		Exporters:         exporter.NewBuilder(cfg.Exporters, col.set.Factories.Exporters),
+		Connectors:        connector.NewBuilder(cfg.Connectors, col.set.Factories.Connectors),
 		Extensions:        extension.NewBuilder(cfg.Extensions, col.set.Factories.Extensions),
 		AsyncErrorChannel: col.asyncErrorChannel,
 		LoggingOptions:    col.set.LoggingOptions,

--- a/otelcol/config.go
+++ b/otelcol/config.go
@@ -108,7 +108,7 @@ func (cfg *Config) Validate() error {
 		}
 
 		if _, ok := cfg.Exporters[connID]; ok {
-			return fmt.Errorf("connectors::%s: cannot have same id as exporter", connID)
+			return fmt.Errorf("connectors::%s: there's already an exporter named %q", connID, connID)
 		}
 		if _, ok := cfg.Receivers[connID]; ok {
 			return fmt.Errorf("connectors::%s: cannot have same id as receiver", connID)

--- a/otelcol/config.go
+++ b/otelcol/config.go
@@ -101,6 +101,20 @@ func (cfg *Config) Validate() error {
 		}
 	}
 
+	// Validate the connector configuration.
+	for connID, connCfg := range cfg.Connectors {
+		if err := component.ValidateConfig(connCfg); err != nil {
+			return fmt.Errorf("connectors::%s: %w", connID, err)
+		}
+
+		if _, ok := cfg.Exporters[connID]; ok {
+			return fmt.Errorf("connectors::%s: cannot have same id as exporter", connID)
+		}
+		if _, ok := cfg.Receivers[connID]; ok {
+			return fmt.Errorf("connectors::%s: cannot have same id as receiver", connID)
+		}
+	}
+
 	// Validate the extension configuration.
 	for extID, extCfg := range cfg.Extensions {
 		if err := component.ValidateConfig(extCfg); err != nil {
@@ -124,14 +138,24 @@ func (cfg *Config) Validate() error {
 		}
 	}
 
+	// Keep track of whether connectors are used as receivers and exporters
+	connectorsAsReceivers := make(map[component.ID]struct{}, len(cfg.Connectors))
+	connectorsAsExporters := make(map[component.ID]struct{}, len(cfg.Connectors))
+
 	// Check that all pipelines reference only configured components.
 	for pipelineID, pipeline := range cfg.Service.Pipelines {
 		// Validate pipeline receiver name references.
 		for _, ref := range pipeline.Receivers {
 			// Check that the name referenced in the pipeline's receivers exists in the top-level receivers.
-			if cfg.Receivers[ref] == nil {
-				return fmt.Errorf("service::pipeline::%s: references receiver %q which is not configured", pipelineID, ref)
+			if _, ok := cfg.Receivers[ref]; ok {
+				continue
 			}
+
+			if _, ok := cfg.Connectors[ref]; ok {
+				connectorsAsReceivers[ref] = struct{}{}
+				continue
+			}
+			return fmt.Errorf("service::pipeline::%s: references receiver %q which is not configured", pipelineID, ref)
 		}
 
 		// Validate pipeline processor name references.
@@ -145,9 +169,26 @@ func (cfg *Config) Validate() error {
 		// Validate pipeline exporter name references.
 		for _, ref := range pipeline.Exporters {
 			// Check that the name referenced in the pipeline's Exporters exists in the top-level Exporters.
-			if cfg.Exporters[ref] == nil {
-				return fmt.Errorf("service::pipeline::%s: references exporter %q which is not configured", pipelineID, ref)
+			if _, ok := cfg.Exporters[ref]; ok {
+				continue
 			}
+			if _, ok := cfg.Connectors[ref]; ok {
+				connectorsAsExporters[ref] = struct{}{}
+				continue
+			}
+			return fmt.Errorf("service::pipeline::%s: references exporter %q which is not configured", pipelineID, ref)
+		}
+	}
+
+	// Validate that connectors are used as both receiver and exporter
+	for connID := range cfg.Connectors {
+		_, recOK := connectorsAsReceivers[connID]
+		_, expOK := connectorsAsExporters[connID]
+		if recOK && !expOK {
+			return fmt.Errorf("connectors::%s: must be used as both receiver and exporter but is not used as exporter", connID)
+		}
+		if !recOK && expOK {
+			return fmt.Errorf("connectors::%s: must be used as both receiver and exporter but is not used as receiver", connID)
 		}
 	}
 

--- a/otelcol/config.go
+++ b/otelcol/config.go
@@ -111,7 +111,7 @@ func (cfg *Config) Validate() error {
 			return fmt.Errorf("connectors::%s: there's already an exporter named %q", connID, connID)
 		}
 		if _, ok := cfg.Receivers[connID]; ok {
-			return fmt.Errorf("connectors::%s: cannot have same id as receiver", connID)
+			return fmt.Errorf("connectors::%s: there's already a receiver named %q", connID, connID)
 		}
 	}
 

--- a/otelcol/config_test.go
+++ b/otelcol/config_test.go
@@ -221,7 +221,7 @@ func TestConfigValidate(t *testing.T) {
 				pipe.Exporters = append(pipe.Exporters, component.NewIDWithName("nop", "2"))
 				return cfg
 			},
-			expected: errors.New(`connectors::nop/2: cannot have same id as receiver`),
+			expected: errors.New(`connectors::nop/2: there's already a receiver named "nop/2"`),
 		},
 		{
 			name: "ambiguous-connector-name-as-exporter",
@@ -234,7 +234,7 @@ func TestConfigValidate(t *testing.T) {
 				pipe.Exporters = append(pipe.Exporters, component.NewIDWithName("nop", "2"))
 				return cfg
 			},
-			expected: errors.New(`connectors::nop/2: cannot have same id as exporter`),
+			expected: errors.New(`connectors::nop/2: there's already an exporter named "nop/2"`),
 		},
 		{
 			name: "invalid-connector-reference-as-receiver",
@@ -288,6 +288,9 @@ func TestConfigValidate(t *testing.T) {
 	}
 
 	require.NoError(t, featuregate.GlobalRegistry().Apply(map[string]bool{connectorsFeatureGateID: true}))
+	defer func() {
+		require.NoError(t, featuregate.GlobalRegistry().Apply(map[string]bool{connectorsFeatureGateID: false}))
+	}()
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
 			cfg := test.cfgFn()

--- a/otelcol/otelcoltest/config_test.go
+++ b/otelcol/otelcoltest/config_test.go
@@ -72,6 +72,9 @@ func TestLoadConfigAndValidate(t *testing.T) {
 	assert.NoError(t, err)
 
 	require.NoError(t, featuregate.GlobalRegistry().Apply(map[string]bool{"otelcol.enableConnectors": true}))
+	defer func() {
+		require.NoError(t, featuregate.GlobalRegistry().Apply(map[string]bool{"otelcol.enableConnectors": false}))
+	}()
 	cfgValidate, errValidate := LoadConfigAndValidate(filepath.Join("testdata", "config.yaml"), factories)
 	require.NoError(t, errValidate)
 

--- a/otelcol/otelcoltest/config_test.go
+++ b/otelcol/otelcoltest/config_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/featuregate"
 	"go.opentelemetry.io/collector/service"
 )
 
@@ -70,6 +71,7 @@ func TestLoadConfigAndValidate(t *testing.T) {
 	factories, err := NopFactories()
 	assert.NoError(t, err)
 
+	require.NoError(t, featuregate.GlobalRegistry().Apply(map[string]bool{"otelcol.enableConnectors": true}))
 	cfgValidate, errValidate := LoadConfigAndValidate(filepath.Join("testdata", "config.yaml"), factories)
 	require.NoError(t, errValidate)
 

--- a/otelcol/otelcoltest/testdata/config.yaml
+++ b/otelcol/otelcoltest/testdata/config.yaml
@@ -10,6 +10,9 @@ exporters:
     nop:
     nop/myexporter:
 
+connectors:
+    nop/myconnector:
+
 extensions:
     nop:
     nop/myextension:


### PR DESCRIPTION
Part of #6700 

This PR finishes adding connectors to the otelcol config including validation. Validation for connectors is the same as with other components, except two additional checks are included:
1. That each connector is used as an exporter in at least one pipeline, and also as a receiver in at least one pipeline.
2. That each connector ID is distinct from receivers and exporters. (Depends on decision on https://github.com/open-telemetry/opentelemetry-collector/pull/6927#issuecomment-1400791808)