### PR TITLE
Update otelcoltest to validate num connectors

### DIFF
--- a/otelcol/otelcoltest/config_test.go
+++ b/otelcol/otelcoltest/config_test.go
@@ -53,6 +53,10 @@ func TestLoadConfig(t *testing.T) {
 	assert.Contains(t, cfg.Processors, component.NewID("nop"))
 	assert.Contains(t, cfg.Processors, component.NewIDWithName("nop", "myprocessor"))
 
+	// Verify connectors
+	assert.Len(t, cfg.Connectors, 1)
+	assert.Contains(t, cfg.Connectors, component.NewIDWithName("nop", "myconnector"))
+
 	// Verify service.
 	require.Len(t, cfg.Service.Extensions, 1)
 	assert.Contains(t, cfg.Service.Extensions, component.NewID("nop"))


### PR DESCRIPTION
Very minor test detail missed in previous PR. Part of #6700 