### PR TITLE
Allow configuration of fields, RandomizationFactor and Multiplier, for `retry_on_failure`

### DIFF
--- a/.chloggen/allow-config-exp-backoff-parameters.yaml
+++ b/.chloggen/allow-config-exp-backoff-parameters.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: exporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Allow configuration of fields, `RandomizationFactor` and `Multiplier`, for exponential backoff algorithm when retry on failure is enabled"
+
+# One or more tracking issues or pull requests related to the change
+issues: [6610]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/exporter/exporterhelper/queued_retry.go
+++ b/exporter/exporterhelper/queued_retry.go
@@ -251,6 +251,11 @@ type RetrySettings struct {
 	Enabled bool `mapstructure:"enabled"`
 	// InitialInterval the time to wait after the first failure before retrying.
 	InitialInterval time.Duration `mapstructure:"initial_interval"`
+	// RandomizationFactor is a random factor used to calculate next backoffs
+	// Randomized interval = RetryInterval * (1 ± RandomizationFactor)
+	RandomizationFactor float64 `mapstructure:"randomization_factor"`
+	// Multiplier is the value multiplied by the backoff interval bounds
+	Multiplier float64 `mapstructure:"multiplier"`
 	// MaxInterval is the upper bound on backoff interval. Once this value is reached the delay between
 	// consecutive retries will always be `MaxInterval`.
 	MaxInterval time.Duration `mapstructure:"max_interval"`
@@ -262,10 +267,12 @@ type RetrySettings struct {
 // NewDefaultRetrySettings returns the default settings for RetrySettings.
 func NewDefaultRetrySettings() RetrySettings {
 	return RetrySettings{
-		Enabled:         true,
-		InitialInterval: 5 * time.Second,
-		MaxInterval:     30 * time.Second,
-		MaxElapsedTime:  5 * time.Minute,
+		Enabled:             true,
+		InitialInterval:     5 * time.Second,
+		RandomizationFactor: backoff.DefaultRandomizationFactor,
+		Multiplier:          backoff.DefaultMultiplier,
+		MaxInterval:         30 * time.Second,
+		MaxElapsedTime:      5 * time.Minute,
 	}
 }
 
@@ -369,8 +376,8 @@ func (rs *retrySender) send(req internal.Request) error {
 	// call Reset after changing the InitialInterval (this saves an unnecessary call to Now).
 	expBackoff := backoff.ExponentialBackOff{
 		InitialInterval:     rs.cfg.InitialInterval,
-		RandomizationFactor: backoff.DefaultRandomizationFactor,
-		Multiplier:          backoff.DefaultMultiplier,
+		RandomizationFactor: rs.cfg.RandomizationFactor,
+		Multiplier:          rs.cfg.Multiplier,
 		MaxInterval:         rs.cfg.MaxInterval,
 		MaxElapsedTime:      rs.cfg.MaxElapsedTime,
 		Stop:                backoff.Stop,

--- a/exporter/otlpexporter/cfg-schema.yaml
+++ b/exporter/otlpexporter/cfg-schema.yaml
@@ -40,6 +40,17 @@ fields:
     default: 5s
     doc: |
       InitialInterval the time to wait after the first failure before retrying.
+  - name: randomization_factor
+    kind: float64
+    default: 0.5
+    doc: |
+      RandomizationFactor is a random factor used to calculate next backoffs.
+      Randomized interval = RetryInterval * (1 ± RandomizationFactor)
+  - name: multiplier
+    kind: float64
+    default: 1.5
+    doc: |
+      Multiplier is the value multiplied by the backoff interval bounds
   - name: max_interval
     type: time.Duration
     kind: int64

--- a/exporter/otlpexporter/config_test.go
+++ b/exporter/otlpexporter/config_test.go
@@ -51,10 +51,12 @@ func TestUnmarshalConfig(t *testing.T) {
 				Timeout: 10 * time.Second,
 			},
 			RetrySettings: exporterhelper.RetrySettings{
-				Enabled:         true,
-				InitialInterval: 10 * time.Second,
-				MaxInterval:     1 * time.Minute,
-				MaxElapsedTime:  10 * time.Minute,
+				Enabled:             true,
+				InitialInterval:     10 * time.Second,
+				RandomizationFactor: 0.7,
+				Multiplier:          1.3,
+				MaxInterval:         1 * time.Minute,
+				MaxElapsedTime:      10 * time.Minute,
 			},
 			QueueSettings: exporterhelper.QueueSettings{
 				Enabled:      true,

--- a/exporter/otlpexporter/testdata/config.yaml
+++ b/exporter/otlpexporter/testdata/config.yaml
@@ -10,6 +10,8 @@ sending_queue:
 retry_on_failure:
   enabled: true
   initial_interval: 10s
+  randomization_factor: 0.7
+  multiplier: 1.3
   max_interval: 60s
   max_elapsed_time: 10m
 auth:

--- a/exporter/otlphttpexporter/config_test.go
+++ b/exporter/otlphttpexporter/config_test.go
@@ -49,10 +49,12 @@ func TestUnmarshalConfig(t *testing.T) {
 	assert.Equal(t,
 		&Config{
 			RetrySettings: exporterhelper.RetrySettings{
-				Enabled:         true,
-				InitialInterval: 10 * time.Second,
-				MaxInterval:     1 * time.Minute,
-				MaxElapsedTime:  10 * time.Minute,
+				Enabled:             true,
+				InitialInterval:     10 * time.Second,
+				RandomizationFactor: 0.7,
+				Multiplier:          1.3,
+				MaxInterval:         1 * time.Minute,
+				MaxElapsedTime:      10 * time.Minute,
 			},
 			QueueSettings: exporterhelper.QueueSettings{
 				Enabled:      true,

--- a/exporter/otlphttpexporter/testdata/config.yaml
+++ b/exporter/otlphttpexporter/testdata/config.yaml
@@ -14,6 +14,8 @@ sending_queue:
 retry_on_failure:
   enabled: true
   initial_interval: 10s
+  randomization_factor: 0.7
+  multiplier: 1.3
   max_interval: 60s
   max_elapsed_time: 10m
 headers:


### PR DESCRIPTION
Enhancement - Allow fields from Exponentional Backoff Algorithm, RandomizationFactor and Multiplier, be configured by the user. Defaults values weren't changed.

**Link to tracking Issue:** #6610 

**Testing:** Added the new fields to the testdata/config.yaml files that are parsed by `TestUnmarshalConfig` in "otlphttpexporter/config_test.go" and "otlpexporter/config_test.go"

**Documentation:** Added field's description to cfg-schema.yaml

**Others:** Does you think it requires an addition in the changelog?