### PR TITLE
Group imports in builder templates

### DIFF
--- a/cmd/builder/internal/builder/templates/components_test.go.tmpl
+++ b/cmd/builder/internal/builder/templates/components_test.go.tmpl
@@ -4,9 +4,7 @@ package main
 
 import (
 	"testing"
-
 	"github.com/stretchr/testify/assert"
-
 	"go.opentelemetry.io/collector/component/componenttest"
 )
 

--- a/cmd/builder/internal/builder/templates/main.go.tmpl
+++ b/cmd/builder/internal/builder/templates/main.go.tmpl
@@ -5,7 +5,6 @@ package main
 
 import (
 	"log"
-
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/otelcol"
 )

--- a/cmd/builder/internal/builder/templates/main_windows.go.tmpl
+++ b/cmd/builder/internal/builder/templates/main_windows.go.tmpl
@@ -8,9 +8,7 @@ package main
 import (
 	"fmt"
 	"os"
-
 	"golang.org/x/sys/windows/svc"
-
 	"go.opentelemetry.io/collector/otelcol"
 )
 


### PR DESCRIPTION
goimport does not merge different blocks, it only splits blocks based on the rules. Because of that we should have only one import group and every repo splits by their rules.

See https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/16828/files#diff-5040246c296b340124c7a2c8a7903ba51ae5fcf34a1d3e353cd2f49ab9bf07e3R14

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
