### PR TITLE
Revert "Revert "Fix: Force usage of case-sensitive keys in configurations (#6876)" (#6988)"

### DIFF
--- a/.chloggen/case-sensitive-configuration.yaml
+++ b/.chloggen/case-sensitive-configuration.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'bug_fix'
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: confmap
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix bug in confmap validation that allowed the usage of case-insensitive keys in the configurations, despite them failing silently.
+
+# One or more tracking issues or pull requests related to the change
+issues: [6876]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/confmap/confmap.go
+++ b/confmap/confmap.go
@@ -161,6 +161,7 @@ func decodeConfig(m *Conf, result interface{}, errorUnused bool) error {
 		Result:           result,
 		TagName:          "mapstructure",
 		WeaklyTypedInput: true,
+		MatchName:        caseSensitiveMatchName,
 		DecodeHook: mapstructure.ComposeDecodeHookFunc(
 			expandNilStructPointersHookFunc(),
 			mapstructure.StringToSliceHookFunc(","),
@@ -187,6 +188,13 @@ func encoderConfig(rawVal interface{}) *encoder.EncoderConfig {
 			marshalerHookFunc(rawVal),
 		),
 	}
+}
+
+// case-sensitive version of the callback to be used in the MatchName property
+// of the DecoderConfig. The default for MatchEqual is to use strings.EqualFold,
+// which is case-insensitive.
+func caseSensitiveMatchName(a, b string) bool {
+	return a == b
 }
 
 // In cases where a config has a mapping of something to a struct pointers

--- a/confmap/confmap.go
+++ b/confmap/confmap.go
@@ -116,7 +116,6 @@ func (l *Conf) Get(key string) interface{} {
 }
 
 // IsSet checks to see if the key has been set in any of the data locations.
-// IsSet is case-insensitive for a key.
 func (l *Conf) IsSet(key string) bool {
 	return l.k.Exists(key)
 }

--- a/exporter/loggingexporter/config_test.go
+++ b/exporter/loggingexporter/config_test.go
@@ -74,6 +74,10 @@ func TestUnmarshalConfig(t *testing.T) {
 			filename:    "invalid_verbosity_loglevel.yaml",
 			expectedErr: "'loglevel' and 'verbosity' are incompatible. Use only 'verbosity' instead",
 		},
+		{
+			filename:    "config_loglevel_typo.yaml",
+			expectedErr: "1 error(s) decoding:\n\n* '' has invalid keys: logLevel",
+		},
 	}
 
 	for _, tt := range tests {

--- a/exporter/loggingexporter/testdata/config_loglevel_typo.yaml
+++ b/exporter/loggingexporter/testdata/config_loglevel_typo.yaml
@@ -1,0 +1,2 @@
+# Typo in the configuration that assumes that this property is camelcase
+logLevel: debug


### PR DESCRIPTION
This reverts commit 80cabdd33c50eaf386293f90fd8ac57cb3a10dc9.

Closes #7002