### PR TITLE
Add entry point to build graph-based pipelines

### DIFF
--- a/internal/sharedgate/sharedgate.go
+++ b/internal/sharedgate/sharedgate.go
@@ -1,0 +1,24 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package sharedgate exposes a featuregate that is used by multiple packages.
+package sharedgate // import "go.opentelemetry.io/collector/internal/sharedgate"
+
+import "go.opentelemetry.io/collector/featuregate"
+
+var ConnectorsFeatureGate = featuregate.GlobalRegistry().MustRegister(
+	"enableConnectors",
+	featuregate.StageAlpha,
+	featuregate.WithRegisterDescription("Enables 'connectors', a new type of component for transmitting signals between pipelines."),
+	featuregate.WithRegisterReferenceURL("https://github.com/open-telemetry/opentelemetry-collector/issues/2336"))

--- a/otelcol/config.go
+++ b/otelcol/config.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 
 	"go.opentelemetry.io/collector/component"
-	"go.opentelemetry.io/collector/featuregate"
+	"go.opentelemetry.io/collector/internal/sharedgate"
 	"go.opentelemetry.io/collector/service"
 )
 
@@ -27,12 +27,6 @@ var (
 	errMissingExporters = errors.New("no exporter configuration specified in config")
 	errMissingReceivers = errors.New("no receiver configuration specified in config")
 )
-
-var connectorsFeatureGate = featuregate.GlobalRegistry().MustRegister(
-	"otelcol.enableConnectors",
-	featuregate.StageAlpha,
-	featuregate.WithRegisterDescription("Enables 'connectors', a new type of component for transmitting signals between pipelines."),
-	featuregate.WithRegisterReferenceURL("https://github.com/open-telemetry/opentelemetry-collector/issues/2336"))
 
 // Config defines the configuration for the various elements of collector or agent.
 type Config struct {
@@ -114,8 +108,8 @@ func (cfg *Config) Validate() error {
 		}
 	}
 
-	if len(cfg.Connectors) != 0 && !connectorsFeatureGate.IsEnabled() {
-		return fmt.Errorf("connectors require feature gate: %s", connectorsFeatureGate.ID())
+	if len(cfg.Connectors) != 0 && !sharedgate.ConnectorsFeatureGate.IsEnabled() {
+		return fmt.Errorf("connectors require feature gate: %s", sharedgate.ConnectorsFeatureGate.ID())
 	}
 
 	if err := cfg.Service.Validate(); err != nil {

--- a/otelcol/config_test.go
+++ b/otelcol/config_test.go
@@ -26,6 +26,7 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configtelemetry"
 	"go.opentelemetry.io/collector/featuregate"
+	"go.opentelemetry.io/collector/internal/sharedgate"
 	"go.opentelemetry.io/collector/service"
 	"go.opentelemetry.io/collector/service/telemetry"
 )
@@ -255,9 +256,9 @@ func TestConfigValidate(t *testing.T) {
 		},
 	}
 
-	require.NoError(t, featuregate.GlobalRegistry().Set(connectorsFeatureGate.ID(), true))
+	require.NoError(t, featuregate.GlobalRegistry().Set(sharedgate.ConnectorsFeatureGate.ID(), true))
 	defer func() {
-		require.NoError(t, featuregate.GlobalRegistry().Set(connectorsFeatureGate.ID(), false))
+		require.NoError(t, featuregate.GlobalRegistry().Set(sharedgate.ConnectorsFeatureGate.ID(), false))
 	}()
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {

--- a/otelcol/otelcoltest/config_test.go
+++ b/otelcol/otelcoltest/config_test.go
@@ -23,6 +23,7 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/featuregate"
+	"go.opentelemetry.io/collector/internal/sharedgate"
 	"go.opentelemetry.io/collector/service"
 )
 
@@ -75,9 +76,9 @@ func TestLoadConfigAndValidate(t *testing.T) {
 	factories, err := NopFactories()
 	assert.NoError(t, err)
 
-	require.NoError(t, featuregate.GlobalRegistry().Set("otelcol.enableConnectors", true))
+	require.NoError(t, featuregate.GlobalRegistry().Set(sharedgate.ConnectorsFeatureGate.ID(), true))
 	defer func() {
-		require.NoError(t, featuregate.GlobalRegistry().Set("otelcol.enableConnectors", false))
+		require.NoError(t, featuregate.GlobalRegistry().Set(sharedgate.ConnectorsFeatureGate.ID(), false))
 	}()
 	cfgValidate, errValidate := LoadConfigAndValidate(filepath.Join("testdata", "config.yaml"), factories)
 	require.NoError(t, errValidate)

--- a/service/graph.go
+++ b/service/graph.go
@@ -16,6 +16,7 @@ package service // import "go.opentelemetry.io/collector/service"
 
 import (
 	"context"
+	"errors"
 	"net/http"
 
 	"go.uber.org/multierr"
@@ -30,6 +31,11 @@ var _ pipelines = (*pipelinesGraph)(nil)
 type pipelinesGraph struct {
 	// All component instances represented as nodes, with directed edges indicating data flow.
 	componentGraph *simple.DirectedGraph
+}
+
+func buildPipelinesGraph(_ context.Context, _ pipelinesSettings) (pipelines, error) {
+	err := errors.New("not yet implemented")
+	return &pipelinesGraph{componentGraph: simple.NewDirectedGraph()}, err
 }
 
 func (g *pipelinesGraph) StartAll(ctx context.Context, host component.Host) error {


### PR DESCRIPTION
Part of #6700

The remainder of the connectors implementation is concerned with setting up the component graph and building each node's associated component. I believe the best way to add these capabilities incrementally will be to so in a top-down way. 

- This PR adds the entry point to building the component graph. 
- Next, outline the steps to set up and build the graph.
- Then add nodes, then edges. 
- Finally, build each node's associated component.

#6700 contains extensive testing of the graph as a whole. However, these tests interface primarily with the graph's built components. I'm not seeing a reasonable way to include coverage for a partially built graph, which I expect we would have if we follow the contribution path I've described above. My hope is that we can move forward for a few PRs based on the understanding that test coverage will be comprehensive in the end.

---

This PR adds the entry point to building the component graph. This entry point is hidden behind the same feature gate that was already to the `otelcol` package in #6964. However, it moves the gate to the `service` so that both packages can use it.