### PR TITLE
Remove deprecated pcommon.Map.Sort

### DIFF
--- a/.chloggen/rmsort.yaml
+++ b/.chloggen/rmsort.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: pcommon
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove deprecated Map.Sort
+
+# One or more tracking issues or pull requests related to the change
+issues: [6688]

--- a/pdata/pcommon/map.go
+++ b/pdata/pcommon/map.go
@@ -15,8 +15,6 @@
 package pcommon // import "go.opentelemetry.io/collector/pdata/pcommon"
 
 import (
-	"sort"
-
 	"go.uber.org/multierr"
 
 	"go.opentelemetry.io/collector/pdata/internal"
@@ -192,25 +190,6 @@ func (m Map) PutEmptySlice(k string) Slice {
 		*m.getOrig() = append(*m.getOrig(), otlpcommon.KeyValue{Key: k, Value: otlpcommon.AnyValue{Value: &vl}})
 	}
 	return Slice(internal.NewSlice(&vl.ArrayValue.Values))
-}
-
-// Sort sorts the entries in the Map so two instances can be compared.
-//
-// Deprecated: [1.0.0-rc4] This method will be removed as it leaks the underlying implementation.
-// Please use one of the following alternatives depending on your use case:
-//   - Map.AsRaw() if you need to compare two maps in tests.
-//   - github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest module if you use Sort()
-//     to prepare other pdata objects for comparison.
-//   - github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil module if you use Sort()
-//     to create Map identifiers.
-//
-// If your use case is not covered by the above alternatives, please comment on the issue
-// https://github.com/open-telemetry/opentelemetry-collector/issues/6688.
-func (m Map) Sort() {
-	// Intention is to move the nil values at the end.
-	sort.SliceStable(*m.getOrig(), func(i, j int) bool {
-		return (*m.getOrig())[i].Key < (*m.getOrig())[j].Key
-	})
 }
 
 // Len returns the length of this map.

--- a/pdata/pcommon/map_test.go
+++ b/pdata/pcommon/map_test.go
@@ -61,11 +61,6 @@ func TestMap(t *testing.T) {
 	removeMap := NewMap()
 	assert.False(t, removeMap.Remove("k"))
 	assert.EqualValues(t, NewMap(), removeMap)
-
-	// Test Sort
-	sortMap := NewMap()
-	sortMap.Sort()
-	assert.EqualValues(t, NewMap(), sortMap)
 }
 
 func TestMapPutEmpty(t *testing.T) {
@@ -262,10 +257,6 @@ func TestMapWithEmpty(t *testing.T) {
 
 	_, exist = sm.Get("test_key3")
 	assert.False(t, exist)
-
-	// Test Sort
-	sm.Sort()
-	assert.EqualValues(t, newMap(&origWithNil), sm)
 }
 
 func TestMapIterationNil(t *testing.T) {


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-collector/issues/6688

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
