### PR TITLE
Improve logging of component start errors

### DIFF
--- a/service/extensions/extensions.go
+++ b/service/extensions/extensions.go
@@ -21,6 +21,7 @@ import (
 	"sort"
 
 	"go.uber.org/multierr"
+	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/extension"
@@ -43,6 +44,7 @@ func (bes *Extensions) Start(ctx context.Context, host component.Host) error {
 		extLogger := components.ExtensionLogger(bes.telemetry.Logger, extID)
 		extLogger.Info("Extension is starting...")
 		if err := ext.Start(ctx, components.NewHostWrapper(host, extLogger)); err != nil {
+			extLogger.WithOptions(zap.AddStacktrace(zap.DPanicLevel)).Error("Failed to start extension", zap.Error(err))
 			return err
 		}
 		extLogger.Info("Extension started.")

--- a/service/pipelines.go
+++ b/service/pipelines.go
@@ -21,6 +21,7 @@ import (
 	"sort"
 
 	"go.uber.org/multierr"
+	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/connector"
@@ -89,6 +90,7 @@ func (bps *builtPipelines) StartAll(ctx context.Context, host component.Host) er
 			expLogger := components.ExporterLogger(bps.telemetry.Logger, expID, dt)
 			expLogger.Info("Exporter is starting...")
 			if err := exp.Start(ctx, components.NewHostWrapper(host, expLogger)); err != nil {
+				expLogger.WithOptions(zap.AddStacktrace(zap.DPanicLevel)).Error("Failed to start exporter", zap.Error(err))
 				return err
 			}
 			expLogger.Info("Exporter started.")
@@ -101,6 +103,7 @@ func (bps *builtPipelines) StartAll(ctx context.Context, host component.Host) er
 			procLogger := components.ProcessorLogger(bps.telemetry.Logger, bp.processors[i].id, pipelineID)
 			procLogger.Info("Processor is starting...")
 			if err := bp.processors[i].comp.Start(ctx, components.NewHostWrapper(host, procLogger)); err != nil {
+				procLogger.WithOptions(zap.AddStacktrace(zap.DPanicLevel)).Error("Failed to start processor", zap.Error(err))
 				return err
 			}
 			procLogger.Info("Processor started.")
@@ -113,6 +116,7 @@ func (bps *builtPipelines) StartAll(ctx context.Context, host component.Host) er
 			recvLogger := components.ReceiverLogger(bps.telemetry.Logger, recvID, dt)
 			recvLogger.Info("Receiver is starting...")
 			if err := recv.Start(ctx, components.NewHostWrapper(host, recvLogger)); err != nil {
+				recvLogger.WithOptions(zap.AddStacktrace(zap.DPanicLevel)).Error("Failed to start receiver", zap.Error(err))
 				return err
 			}
 			recvLogger.Info("Receiver started.")


### PR DESCRIPTION
**Description:**
Improved logging of component start errors, so the log lines appear where they chronologically happen, rather than at the end. They also use the component logger, which makes them look nicer.

Output before change:
```text
2023-01-31T18:40:52.517+0100    info    service/pipelines.go:86 Starting exporters...
2023-01-31T18:40:52.517+0100    info    service/pipelines.go:90 Exporter is starting... {"kind": "exporter", "data_type": "traces", "name": "otlp"}
2023-01-31T18:40:52.518+0100    info    service/service.go:155  Starting shutdown...
...
Error: cannot start pipelines: failed to resolve authenticator "not_there": authenticator not found; failed to shutdown pipelines: no existing monitoring routine is running; no existing monitoring routine is running
2023/01/31 18:40:52 collector server run finished with error: cannot start pipelines: failed to resolve authenticator "not_there": authenticator not found; failed to shutdown pipelines: no existing monitoring routine is running; no existing monitoring routine is running
```

Output after change:
```text
2023-01-31T18:35:14.471+0100    info    service/pipelines.go:87 Starting exporters...
2023-01-31T18:35:14.471+0100    info    service/pipelines.go:91 Exporter is starting... {"kind": "exporter", "data_type": "metrics", "name": "otlp"}
2023-01-31T18:35:14.471+0100    error   service/pipelines.go:93 Failed to start exporter        {"kind": "exporter", "data_type": "metrics", "name": "otlp", "error": "failed to resolve authenticator \"not_there\": authenticator not found"}
2023-01-31T18:35:14.471+0100    info    service/service.go:155  Starting shutdown...
...
Error: cannot start pipelines: failed to resolve authenticator "not_there": authenticator not found; failed to shutdown pipelines: no existing monitoring routine is running; no existing monitoring routine is running
2023/01/31 18:35:14 collector server run finished with error: cannot start pipelines: failed to resolve authenticator "not_there": authenticator not found; failed to shutdown pipelines: no existing monitoring routine is running; no existing monitoring routine is running
```

**Link to tracking Issue:** #7078 

