### PR TITLE
[pdata] Deprecate [Metrics|Logs|Traces].MoveTo methods

### DIFF
--- a/.chloggen/pdata-deprecate-moveto.yaml
+++ b/.chloggen/pdata-deprecate-moveto.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: pdata
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecate [Metrics|Logs|Traces].MoveTo methods.
+
+# One or more tracking issues or pull requests related to the change
+issues: [7091]

--- a/pdata/plog/logs.go
+++ b/pdata/plog/logs.go
@@ -39,6 +39,7 @@ func NewLogs() Logs {
 
 // MoveTo moves the Logs instance overriding the destination and
 // resetting the current instance to its zero value.
+// Deprecated: [1.0.0-rc5] The method can be replaced with a plain assignment.
 func (ms Logs) MoveTo(dest Logs) {
 	*dest.getOrig() = *ms.getOrig()
 	*ms.getOrig() = otlpcollectorlog.ExportLogsServiceRequest{}

--- a/pdata/pmetric/metrics.go
+++ b/pdata/pmetric/metrics.go
@@ -44,6 +44,7 @@ func (ms Metrics) CopyTo(dest Metrics) {
 
 // MoveTo moves the Metrics instance overriding the destination and
 // resetting the current instance to its zero value.
+// Deprecated: [1.0.0-rc5] The method can be replaced with a plain assignment.
 func (ms Metrics) MoveTo(dest Metrics) {
 	*dest.getOrig() = *ms.getOrig()
 	*ms.getOrig() = otlpcollectormetrics.ExportMetricsServiceRequest{}

--- a/pdata/ptrace/traces.go
+++ b/pdata/ptrace/traces.go
@@ -39,6 +39,7 @@ func NewTraces() Traces {
 
 // MoveTo moves the Traces instance overriding the destination and
 // resetting the current instance to its zero value.
+// Deprecated: [1.0.0-rc5] The method can be replaced with a plain assignment.
 func (ms Traces) MoveTo(dest Traces) {
 	*dest.getOrig() = *ms.getOrig()
 	*ms.getOrig() = otlpcollectortrace.ExportTraceServiceRequest{}


### PR DESCRIPTION
The methods don't provide any value and can be replaced with simple assignments.

This also unblocks https://github.com/open-telemetry/opentelemetry-collector/pull/7088