### PR TITLE
Simplify forward connector by removing sharedcomponent

### DIFF
--- a/connector/forwardconnector/forward.go
+++ b/connector/forwardconnector/forward.go
@@ -20,30 +20,20 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/connector"
 	"go.opentelemetry.io/collector/consumer"
-	"go.opentelemetry.io/collector/internal/sharedcomponent"
 )
 
 const (
 	typeStr = "forward"
 )
 
-type forwardFactory struct {
-	// This is the map of already created forward connectors for particular configurations.
-	// We maintain this map because the Factory is asked trace, metric, and log receivers
-	// separately but they must not create separate objects. When the connector is shutdown
-	// it should be removed from this map so the same configuration can be recreated successfully.
-	components *sharedcomponent.SharedComponents[component.ID, *forward]
-}
-
 // NewFactory returns a connector.Factory.
 func NewFactory() connector.Factory {
-	f := &forwardFactory{components: sharedcomponent.NewSharedComponents[component.ID, *forward]()}
 	return connector.NewFactory(
 		typeStr,
 		createDefaultConfig,
-		connector.WithTracesToTraces(f.createTracesToTraces, component.StabilityLevelDevelopment),
-		connector.WithMetricsToMetrics(f.createMetricsToMetrics, component.StabilityLevelDevelopment),
-		connector.WithLogsToLogs(f.createLogsToLogs, component.StabilityLevelDevelopment),
+		connector.WithTracesToTraces(createTracesToTraces, component.StabilityLevelDevelopment),
+		connector.WithMetricsToMetrics(createMetricsToMetrics, component.StabilityLevelDevelopment),
+		connector.WithLogsToLogs(createLogsToLogs, component.StabilityLevelDevelopment),
 	)
 }
 
@@ -53,51 +43,33 @@ func createDefaultConfig() component.Config {
 }
 
 // createTracesToTraces creates a trace receiver based on provided config.
-func (f *forwardFactory) createTracesToTraces(
+func createTracesToTraces(
 	_ context.Context,
 	set connector.CreateSettings,
 	cfg component.Config,
 	nextConsumer consumer.Traces,
 ) (connector.Traces, error) {
-	comp, _ := f.components.GetOrAdd(set.ID, func() (*forward, error) {
-		return &forward{}, nil
-	})
-
-	conn := comp.Unwrap()
-	conn.Traces = nextConsumer
-	return conn, nil
+	return &forward{Traces: nextConsumer}, nil
 }
 
 // createMetricsToMetrics creates a metrics receiver based on provided config.
-func (f *forwardFactory) createMetricsToMetrics(
+func createMetricsToMetrics(
 	_ context.Context,
 	set connector.CreateSettings,
 	cfg component.Config,
 	nextConsumer consumer.Metrics,
 ) (connector.Metrics, error) {
-	comp, _ := f.components.GetOrAdd(set.ID, func() (*forward, error) {
-		return &forward{}, nil
-	})
-
-	conn := comp.Unwrap()
-	conn.Metrics = nextConsumer
-	return conn, nil
+	return &forward{Metrics: nextConsumer}, nil
 }
 
 // createLogsToLogs creates a log receiver based on provided config.
-func (f *forwardFactory) createLogsToLogs(
+func createLogsToLogs(
 	_ context.Context,
 	set connector.CreateSettings,
 	cfg component.Config,
 	nextConsumer consumer.Logs,
 ) (connector.Logs, error) {
-	comp, _ := f.components.GetOrAdd(set.ID, func() (*forward, error) {
-		return &forward{}, nil
-	})
-
-	conn := comp.Unwrap()
-	conn.Logs = nextConsumer
-	return conn, nil
+	return &forward{Logs: nextConsumer}, nil
 }
 
 // forward is used to pass signals directly from one pipeline to another.


### PR DESCRIPTION
There isn't really any reason to use `sharedcomponent` in the forward connector because there is no shared state or interaction between signals. 