### PR TITLE
[exporterhelper] Add optional tiered sender to coordinate requests between two queues

### DIFF
--- a/.chloggen/tiered-sender.yaml
+++ b/.chloggen/tiered-sender.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: exporterhelper
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add optional tiered sender enabled by configuring a backlog queue.
+
+# One or more tracking issues or pull requests related to the change
+issues: [6331]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/exporter/exporterhelper/README.md
+++ b/exporter/exporterhelper/README.md
@@ -23,6 +23,8 @@ The following configuration options can be modified:
     - `requests_per_batch` is the average number of requests per batch (if 
       [the batch processor](https://github.com/open-telemetry/opentelemetry-collector/tree/main/processor/batchprocessor)
       is used, the metric `batch_send_size` can be used for estimation)
+- `backlog_queue`
+  - Same options as `sending_queue`. The only default value is (`enabled` = false)
 - `timeout` (default = 5s): Time to wait per individual attempt to send data to a backend
 
 ### Persistent Queue

--- a/exporter/exporterhelper/internal/bounded_memory_queue.go
+++ b/exporter/exporterhelper/internal/bounded_memory_queue.go
@@ -76,16 +76,14 @@ func (q *boundedMemoryQueue) Produce(item Request) bool {
 		if q.overflow == nil {
 			return false
 		}
-		if q.capacity == 0 {
+		select {
+		case old := <-q.items:
+			q.size.Add(^uint32(0))
+			q.overflow(old)
+		default:
 			q.overflow(item)
-		} else {
-			old := <-q.items
-			if q.overflow != nil {
-				q.overflow(old)
-			}
-			q.items <- item
+			return true
 		}
-		return true
 	}
 
 	q.size.Add(1)

--- a/exporter/exporterhelper/internal/bounded_memory_queue.go
+++ b/exporter/exporterhelper/internal/bounded_memory_queue.go
@@ -63,7 +63,8 @@ func (q *boundedMemoryQueue) StartConsumers(numWorkers int, callback RequestCall
 	startWG.Wait()
 }
 
-// Produce is used by the producer to submit new item to the queue. Returns false in case of queue overflow.
+// Produce is used by the producer to submit new item to the queue.
+// Returns false in case of queue overflow if callback is not set.
 func (q *boundedMemoryQueue) Produce(item Request) bool {
 	if q.stopped.Load() {
 		return false

--- a/exporter/exporterhelper/internal/persistent_queue.go
+++ b/exporter/exporterhelper/internal/persistent_queue.go
@@ -55,7 +55,7 @@ func NewPersistentQueue(ctx context.Context, name string, signal component.DataT
 }
 
 // StartConsumers starts the given number of consumers which will be consuming items
-func (pq *persistentQueue) StartConsumers(numWorkers int, callback func(item Request)) {
+func (pq *persistentQueue) StartConsumers(numWorkers int, callback RequestCallback) {
 	for i := 0; i < numWorkers; i++ {
 		pq.stopWG.Add(1)
 		go func() {

--- a/exporter/exporterhelper/internal/persistent_queue.go
+++ b/exporter/exporterhelper/internal/persistent_queue.go
@@ -78,6 +78,11 @@ func (pq *persistentQueue) Produce(item Request) bool {
 	return err == nil
 }
 
+// OnOverflow sets the callback that handles queue overflow.
+func (pq *persistentQueue) OnOverflow(callback RequestCallback) {
+	pq.storage.overflow = callback
+}
+
 // Stop stops accepting items, shuts down the queue and closes the persistent queue
 func (pq *persistentQueue) Stop() {
 	pq.stopOnce.Do(func() {

--- a/exporter/exporterhelper/internal/persistent_queue_test.go
+++ b/exporter/exporterhelper/internal/persistent_queue_test.go
@@ -201,9 +201,9 @@ func TestPersistentQueue_Overflow(t *testing.T) {
 	t.Cleanup(func() { require.NoError(t, ext.Shutdown(context.Background())) })
 
 	wq := createTestQueue(ext, 0)
-	overflowCounter := atomic.NewInt32(0)
+	overflowCounter := &atomic.Int32{}
 	wq.OnOverflow(func(item Request) {
-		overflowCounter.Add(1)
+		overflowCounter.Add(int32(1))
 	})
 	traces := newTraces(1, 10)
 

--- a/exporter/exporterhelper/internal/producer_consumer_queue.go
+++ b/exporter/exporterhelper/internal/producer_consumer_queue.go
@@ -16,7 +16,7 @@
 
 package internal // import "go.opentelemetry.io/collector/exporter/exporterhelper/internal"
 
-type RequestCallback func(item Request)
+type RequestCallback func(req Request)
 
 // ProducerConsumerQueue defines a producer-consumer exchange which can be backed by e.g. the memory-based ring buffer queue
 // (boundedMemoryQueue) or via a disk-based queue (persistentQueue)

--- a/exporter/exporterhelper/internal/producer_consumer_queue.go
+++ b/exporter/exporterhelper/internal/producer_consumer_queue.go
@@ -16,12 +16,14 @@
 
 package internal // import "go.opentelemetry.io/collector/exporter/exporterhelper/internal"
 
+type RequestCallback func(item Request)
+
 // ProducerConsumerQueue defines a producer-consumer exchange which can be backed by e.g. the memory-based ring buffer queue
 // (boundedMemoryQueue) or via a disk-based queue (persistentQueue)
 type ProducerConsumerQueue interface {
 	// StartConsumers starts a given number of goroutines consuming items from the queue
 	// and passing them into the consumer callback.
-	StartConsumers(num int, callback func(item Request))
+	StartConsumers(num int, callback RequestCallback)
 	// Produce is used by the producer to submit new item to the queue. Returns false if the item wasn't added
 	// to the queue due to queue overflow.
 	Produce(item Request) bool
@@ -30,4 +32,7 @@ type ProducerConsumerQueue interface {
 	// Stop stops all consumers, as well as the length reporter if started,
 	// and releases the items channel. It blocks until all consumers have stopped.
 	Stop()
+	// OnOverflow sets the callback used for overflow requests when Produce is called with a full
+	// queue.
+	OnOverflow(callback RequestCallback)
 }

--- a/exporter/exporterhelper/logs.go
+++ b/exporter/exporterhelper/logs.go
@@ -109,6 +109,9 @@ func NewLogsExporter(
 			nextSender: nextSender,
 		}
 	})
+	be.onDropped(func(req internal.Request) {
+		be.obsrep.recordLogsDropped(req.Context(), int64(req.Count()))
+	})
 
 	lc, err := consumer.NewLogs(func(ctx context.Context, ld plog.Logs) error {
 		req := newLogsRequest(ctx, ld, pusher)

--- a/exporter/exporterhelper/metrics.go
+++ b/exporter/exporterhelper/metrics.go
@@ -110,6 +110,9 @@ func NewMetricsExporter(
 			nextSender: nextSender,
 		}
 	})
+	be.onDropped(func(req internal.Request) {
+		be.obsrep.recordMetricsDropped(req.Context(), int64(req.Count()))
+	})
 
 	mc, err := consumer.NewMetrics(func(ctx context.Context, md pmetric.Metrics) error {
 		req := newMetricsRequest(ctx, md, pusher)

--- a/exporter/exporterhelper/obsreport_test.go
+++ b/exporter/exporterhelper/obsreport_test.go
@@ -17,7 +17,9 @@ package exporterhelper
 import (
 	"context"
 	"testing"
+	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opencensus.io/metric"
 	"go.opencensus.io/tag"
@@ -51,24 +53,60 @@ func TestExportEnqueueFailure(t *testing.T) {
 	metricPoints := int64(21)
 	obsrep.recordMetricsEnqueueFailure(context.Background(), metricPoints)
 	checkExporterEnqueueFailedMetricsStats(t, insts, exporter, metricPoints)
+
+	logRecords = int64(1)
+	obsrep.recordLogsDropped(context.Background(), logRecords)
+	checkExporterDroppedLogsStats(t, insts, exporter, logRecords)
+
+	spans = int64(2)
+	obsrep.recordTracesDropped(context.Background(), spans)
+	checkExporterDroppedTracesStats(t, insts, exporter, spans)
+
+	metricPoints = int64(3)
+	obsrep.recordMetricsDropped(context.Background(), metricPoints)
+	checkExporterDroppedMetricsStats(t, insts, exporter, metricPoints)
 }
 
 // checkExporterEnqueueFailedTracesStats checks that reported number of spans failed to enqueue match given values.
 // When this function is called it is required to also call SetupTelemetry as first thing.
 func checkExporterEnqueueFailedTracesStats(t *testing.T, insts *instruments, exporter component.ID, spans int64) {
-	checkValueForProducer(t, insts.registry, tagsForExporterView(exporter), spans, "exporter/enqueue_failed_spans")
+	checkStats(t, insts, exporter, spans, "exporter/enqueue_failed_spans")
 }
 
 // checkExporterEnqueueFailedMetricsStats checks that reported number of metric points failed to enqueue match given values.
 // When this function is called it is required to also call SetupTelemetry as first thing.
 func checkExporterEnqueueFailedMetricsStats(t *testing.T, insts *instruments, exporter component.ID, metricPoints int64) {
-	checkValueForProducer(t, insts.registry, tagsForExporterView(exporter), metricPoints, "exporter/enqueue_failed_metric_points")
+	checkStats(t, insts, exporter, metricPoints, "exporter/enqueue_failed_metric_points")
 }
 
 // checkExporterEnqueueFailedLogsStats checks that reported number of log records failed to enqueue match given values.
 // When this function is called it is required to also call SetupTelemetry as first thing.
 func checkExporterEnqueueFailedLogsStats(t *testing.T, insts *instruments, exporter component.ID, logRecords int64) {
-	checkValueForProducer(t, insts.registry, tagsForExporterView(exporter), logRecords, "exporter/enqueue_failed_log_records")
+	checkStats(t, insts, exporter, logRecords, "exporter/enqueue_failed_log_records")
+}
+
+// checkExporterDroppedTracesStats checks that reported number of spans dropped match given values.
+// When this function is called it is required to also call SetupTelemetry as first thing.
+func checkExporterDroppedTracesStats(t *testing.T, insts *instruments, exporter component.ID, spans int64) {
+	checkStats(t, insts, exporter, spans, "exporter/dropped_spans")
+}
+
+// checkExporterEnqueueFailedMetricsStats checks that reported number of metric points dropped match given values.
+// When this function is called it is required to also call SetupTelemetry as first thing.
+func checkExporterDroppedMetricsStats(t *testing.T, insts *instruments, exporter component.ID, metricPoints int64) {
+	checkStats(t, insts, exporter, metricPoints, "exporter/dropped_metric_points")
+}
+
+// checkExporterEnqueueFailedLogsStats checks that reported number of log records dropped match given values.
+// When this function is called it is required to also call SetupTelemetry as first thing.
+func checkExporterDroppedLogsStats(t *testing.T, insts *instruments, exporter component.ID, logRecords int64) {
+	checkStats(t, insts, exporter, logRecords, "exporter/dropped_log_records")
+}
+
+func checkStats(t *testing.T, insts *instruments, exporter component.ID, value int64, vName string) {
+	assert.Eventually(t, func() bool {
+		return checkValueForProducer(t, insts.registry, tagsForExporterView(exporter), value, vName)
+	}, time.Second, time.Millisecond)
 }
 
 // tagsForExporterView returns the tags that are needed for the exporter views.

--- a/exporter/exporterhelper/queued_retry.go
+++ b/exporter/exporterhelper/queued_retry.go
@@ -74,6 +74,10 @@ func (qCfg *QueueSettings) Validate() error {
 		return errors.New("queue size must be positive")
 	}
 
+	if qCfg.NumConsumers <= 0 {
+		return errors.New("number of consumers must be positive")
+	}
+
 	return nil
 }
 

--- a/exporter/exporterhelper/queued_retry_test.go
+++ b/exporter/exporterhelper/queued_retry_test.go
@@ -391,6 +391,10 @@ func TestQueueSettings_Validate(t *testing.T) {
 	qCfg.QueueSize = 0
 	assert.EqualError(t, qCfg.Validate(), "queue size must be positive")
 
+	qCfg.QueueSize = 1
+	qCfg.NumConsumers = 0
+	assert.EqualError(t, qCfg.Validate(), "number of consumers must be positive")
+
 	// Confirm Validate doesn't return error with invalid config when feature is disabled
 	qCfg.Enabled = false
 	assert.NoError(t, qCfg.Validate())

--- a/exporter/exporterhelper/queued_retry_test.go
+++ b/exporter/exporterhelper/queued_retry_test.go
@@ -17,7 +17,6 @@ package exporterhelper
 import (
 	"context"
 	"errors"
-	"fmt"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -754,13 +753,15 @@ func (ocs *observabilityConsumerSender) checkDroppedItemsCount(t *testing.T, wan
 // checkValueForGlobalManager checks that the given metrics with wantTags is reported by one of the
 // metric producers
 func checkValueForGlobalManager(t *testing.T, wantTags []tag.Tag, value int64, vName string) {
-	producers := metricproducer.GlobalManager().GetAll()
-	for _, producer := range producers {
-		if checkValueForProducer(t, producer, wantTags, value, vName) {
-			return
+	assert.Eventually(t, func() bool {
+		producers := metricproducer.GlobalManager().GetAll()
+		for _, producer := range producers {
+			if checkValueForProducer(t, producer, wantTags, value, vName) {
+				return true
+			}
 		}
-	}
-	require.Fail(t, fmt.Sprintf("could not find metric %v with tags %s reported", vName, wantTags))
+		return false
+	}, time.Second, time.Millisecond)
 }
 
 // checkValueForProducer checks that the given metrics with wantTags is reported by the metric producer

--- a/exporter/exporterhelper/queued_retry_test.go
+++ b/exporter/exporterhelper/queued_retry_test.go
@@ -583,7 +583,6 @@ func TestQueuedRetryPersistenceEnabledStorageError(t *testing.T) {
 }
 
 func TestQueuedRetryPersistentEnabled_shutdown_dataIsRequeued(t *testing.T) {
-
 	produceCounter := &atomic.Uint32{}
 
 	qCfg := NewDefaultQueueSettings()
@@ -600,14 +599,14 @@ func TestQueuedRetryPersistentEnabled_shutdown_dataIsRequeued(t *testing.T) {
 	require.NoError(t, be.Start(context.Background(), &mockHost{}))
 
 	// wraps original queue so we can count operations
-	be.qrSender.queue = &producerConsumerQueueWithCounter{
-		ProducerConsumerQueue: be.qrSender.queue,
+	be.sender.primary.queue = &producerConsumerQueueWithCounter{
+		ProducerConsumerQueue: be.sender.primary.queue,
 		produceCounter:        produceCounter,
 	}
-	be.qrSender.requeuingEnabled = true
+	be.sender.primary.requeuingEnabled = true
 
 	// replace nextSender inside retrySender to always return error so it doesn't exit send loop
-	castedSender, ok := be.qrSender.consumerSender.(*retrySender)
+	castedSender, ok := be.sender.primary.consumerSender.(*retrySender)
 	require.True(t, ok, "consumerSender should be a retrySender type")
 	castedSender.nextSender = &errorRequestSender{
 		errToReturn: errors.New("some error"),

--- a/exporter/exporterhelper/tiered.go
+++ b/exporter/exporterhelper/tiered.go
@@ -1,0 +1,163 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exporterhelper // import "go.opentelemetry.io/collector/exporter/exporterhelper"
+
+import (
+	"context"
+	"fmt"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.uber.org/zap"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/exporter/exporterhelper/internal"
+	"go.opentelemetry.io/collector/internal/obsreportconfig/obsmetrics"
+)
+
+type tieredSender struct {
+	name        string
+	id          component.ID
+	signal      component.DataType
+	logger      *zap.Logger
+	primary     *queuedRetrySender
+	backlog     *queuedRetrySender
+	retryStopCh chan struct{}
+}
+
+func newTieredSender(
+	id component.ID,
+	signal component.DataType,
+	qCfg QueueSettings,
+	bCfg QueueSettings,
+	rCfg RetrySettings,
+	reqUnmarshaler internal.RequestUnmarshaler,
+	nextSender requestSender,
+	logger *zap.Logger,
+) *tieredSender {
+	retryStopCh := make(chan struct{})
+	name := id.String()
+	traceAttr := attribute.String(obsmetrics.ExporterKey, name)
+
+	ts := &tieredSender{
+		name:        name,
+		id:          id,
+		signal:      signal,
+		logger:      logger,
+		retryStopCh: retryStopCh,
+	}
+
+	rs := &retrySender{
+		traceAttribute:     traceAttr,
+		cfg:                rCfg,
+		nextSender:         nextSender,
+		stopCh:             retryStopCh,
+		logger:             logger,
+		onTemporaryFailure: ts.onTemporaryFailure,
+	}
+
+	ts.primary = newQueuedRetrySender(name, id, signal, traceAttr, qCfg, reqUnmarshaler, rs, logger)
+	if qCfg.Enabled && bCfg.Enabled {
+		name = fmt.Sprintf("%s:backlog", name)
+		ts.backlog = newQueuedRetrySender(name, id, signal, traceAttr, bCfg, reqUnmarshaler, rs, logger)
+	}
+	return ts
+}
+
+// start is invoked during service startup.
+func (ts *tieredSender) start(ctx context.Context, host component.Host) error {
+	if err := ts.primary.start(ctx, host); err != nil {
+		return err
+	}
+	if ts.backlog != nil {
+		if err := ts.backlog.start(ctx, host); err != nil {
+			return err
+		}
+		ts.backlog.queue.OnOverflow(func(req internal.Request) {
+			ts.logger.Error(
+				"Backlog is full. Dropping data.",
+				zap.Int("dropped_items", req.Count()),
+			)
+		})
+		ts.primary.queue.OnOverflow(func(req internal.Request) {
+			if err := ts.backlog.send(req); err != nil {
+				ts.logger.Error(
+					"Unable to add overflow to backlog. Dropping data.",
+					zap.Error(err),
+					zap.Int("dropped_items", req.Count()),
+				)
+			}
+		})
+	}
+	return nil
+}
+
+// shutdown is invoked during service shutdown.
+func (ts *tieredSender) shutdown() {
+	// First Stop the retry goroutines, so that unblocks the queues.
+	close(ts.retryStopCh)
+
+	ts.primary.shutdown()
+	if ts.backlog != nil {
+		ts.backlog.shutdown()
+	}
+}
+
+// send the request to the primary sender.
+func (ts *tieredSender) send(req internal.Request) error {
+	return ts.primary.send(req)
+}
+
+// onTemporaryFailure tries to requeue the request if possible. Will send
+// to backlog if enabled.
+func (ts *tieredSender) onTemporaryFailure(logger *zap.Logger, req internal.Request, err error) error {
+	if !ts.primary.requeuingEnabled || ts.primary.queue == nil {
+		logger.Error(
+			"Exporting failed. No more retries left. Dropping data.",
+			zap.Error(err),
+			zap.Int("dropped_items", req.Count()),
+		)
+		return err
+	}
+
+	sender := ts.primary
+	if ts.backlog != nil {
+		sender = ts.backlog
+	}
+
+	if sendErr := sender.send(req); sendErr != nil {
+		logger.Error(
+			"Exporting failed. Queue did not accept requeuing request. Dropping data.",
+			zap.Error(err),
+			zap.String("sender_name", sender.fullName),
+			zap.Int("dropped_items", req.Count()),
+		)
+	} else {
+		logger.Error(
+			"Exporting failed. Putting back to the end of the queue.",
+			zap.String("sender_name", sender.fullName),
+			zap.Error(err),
+		)
+	}
+	return err
+}
+
+// wrapConsumerSender calls the wrap function on the primary's consumer sender
+// and sets it as the consumer sender for both primary and backlog if it is enabled.
+func (ts *tieredSender) wrapConsumerSender(wrap func(consumer requestSender) requestSender) {
+	ts.primary.consumerSender = wrap(ts.primary.consumerSender)
+	if ts.backlog != nil {
+		ts.backlog.consumerSender = ts.primary.consumerSender
+	}
+}

--- a/exporter/exporterhelper/tiered_test.go
+++ b/exporter/exporterhelper/tiered_test.go
@@ -1,0 +1,228 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exporterhelper
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
+
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/consumer/consumererror"
+	"go.opentelemetry.io/collector/exporter/exporterhelper/internal"
+	"go.opentelemetry.io/collector/internal/testdata"
+)
+
+func TestTiered_PrimaryQueueFull(t *testing.T) {
+	qCfg := NewDefaultQueueSettings()
+	qCfg.NumConsumers = 0
+	qCfg.QueueSize = 0
+	bCfg := NewDefaultQueueSettings()
+	bCfg.NumConsumers = 1
+	bCfg.QueueSize = 1
+	be, err := newBaseExporter(defaultSettings, fromOptions(WithQueue(qCfg), WithBacklog(bCfg)), "", nopRequestUnmarshaler())
+	require.NoError(t, err)
+	require.NotNil(t, be.sender.backlog)
+
+	be.sender.primary.requeuingEnabled = true
+	backlogObserver := newObservabilityConsumerSender(be.sender.backlog.consumerSender)
+	be.sender.backlog.consumerSender = backlogObserver
+
+	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
+	t.Cleanup(func() {
+		require.NoError(t, be.Shutdown(context.Background()))
+	})
+
+	mockR := newMockRequest(context.Background(), 2, nil)
+	backlogObserver.run(func() {
+		require.NoError(t, be.sender.send(mockR))
+	})
+	backlogObserver.awaitAsyncProcessing()
+
+	require.Zero(t, be.sender.primary.queue.Size())
+	require.Zero(t, be.sender.backlog.queue.Size())
+
+	// only the backlog actually gets sent
+	mockR.checkNumRequests(t, 1)
+	backlogObserver.checkSendItemsCount(t, 2)
+	backlogObserver.checkDroppedItemsCount(t, 0)
+}
+
+func TestTiered_PrimaryQueueOnError(t *testing.T) {
+	qCfg := NewDefaultQueueSettings()
+	qCfg.NumConsumers = 1
+	qCfg.QueueSize = 1
+	bCfg := NewDefaultQueueSettings()
+	bCfg.NumConsumers = 1
+	bCfg.QueueSize = 1
+	rCfg := NewDefaultRetrySettings()
+	rCfg.MaxElapsedTime = time.Nanosecond // we don't want to retry at all, but requeue instead
+	be, err := newBaseExporter(defaultSettings, fromOptions(WithRetry(rCfg), WithQueue(qCfg), WithBacklog(bCfg)), "", nopRequestUnmarshaler())
+	require.NoError(t, err)
+	require.NotNil(t, be.sender.backlog)
+
+	primaryObserver := newObservabilityConsumerSender(be.sender.primary.consumerSender)
+	be.sender.primary.consumerSender = primaryObserver
+	be.sender.primary.requeuingEnabled = true
+	backlogObserver := newObservabilityConsumerSender(be.sender.backlog.consumerSender)
+	be.sender.backlog.consumerSender = backlogObserver
+
+	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
+	t.Cleanup(func() {
+		require.NoError(t, be.Shutdown(context.Background()))
+	})
+
+	traceErr := consumererror.NewTraces(errors.New("some error"), testdata.GenerateTraces(1))
+	mockR := newMockRequest(context.Background(), 2, traceErr)
+	primaryObserver.waitGroup.Add(1)
+	backlogObserver.waitGroup.Add(1)
+	require.NoError(t, be.sender.send(mockR))
+	backlogObserver.awaitAsyncProcessing()
+
+	require.Zero(t, be.sender.primary.queue.Size())
+	require.Zero(t, be.sender.backlog.queue.Size())
+
+	// error on primary, success on backlog
+	mockR.checkNumRequests(t, 2)
+	// original request dropped
+	primaryObserver.checkSendItemsCount(t, 0)
+	primaryObserver.checkDroppedItemsCount(t, 2)
+	// backlog sends OnError request instead
+	backlogObserver.checkSendItemsCount(t, 1)
+	backlogObserver.checkDroppedItemsCount(t, 0)
+}
+
+func TestTiered_BacklogQueueFull(t *testing.T) {
+	qCfg := NewDefaultQueueSettings()
+	qCfg.NumConsumers = 0
+	qCfg.QueueSize = 0
+	bCfg := NewDefaultQueueSettings()
+	bCfg.NumConsumers = 0
+	bCfg.QueueSize = 0
+	be, err := newBaseExporter(defaultSettings, fromOptions(WithQueue(qCfg), WithBacklog(bCfg)), "", nopRequestUnmarshaler())
+	require.NoError(t, err)
+	require.NotNil(t, be.sender.backlog)
+	be.sender.primary.requeuingEnabled = true
+	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
+	t.Cleanup(func() {
+		require.NoError(t, be.Shutdown(context.Background()))
+	})
+
+	mockR := newMockRequest(context.Background(), 2, nil)
+	require.NoError(t, be.sender.send(mockR))
+
+	// replace overflow function to add counter
+	overflowCounter := atomic.NewUint32(0)
+	be.sender.backlog.queue.OnOverflow(func(item internal.Request) {
+		overflowCounter.Add(1)
+	})
+	require.NoError(t, be.sender.send(mockR))
+	require.Eventually(t, func() bool {
+		return overflowCounter.Load() == uint32(1)
+	}, time.Second, 1*time.Millisecond)
+}
+
+func TestTiered_BacklogProduceError(t *testing.T) {
+	qCfg := NewDefaultQueueSettings()
+	qCfg.NumConsumers = 0
+	qCfg.QueueSize = 0
+	bCfg := NewDefaultQueueSettings()
+	bCfg.NumConsumers = 0
+	bCfg.QueueSize = 0
+	be, err := newBaseExporter(defaultSettings, fromOptions(WithQueue(qCfg), WithBacklog(bCfg)), "", nopRequestUnmarshaler())
+	require.NoError(t, err)
+	require.NotNil(t, be.sender.backlog)
+
+	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
+
+	be.sender.backlog.cfg.Enabled = false
+	backlogObserver := newObservabilityConsumerSender(&errorRequestSender{
+		errToReturn: errors.New("some error"),
+	})
+	be.sender.backlog.consumerSender = backlogObserver
+
+	req := newMockRequest(context.Background(), 1, nil)
+	backlogObserver.run(func() {
+		require.NoError(t, be.sender.send(req))
+	})
+	backlogObserver.awaitAsyncProcessing()
+	backlogObserver.checkDroppedItemsCount(t, 1)
+}
+
+func TestTiered_BacklogEnabledWithoutPrimary(t *testing.T) {
+	bCfg := NewDefaultQueueSettings()
+	bCfg.NumConsumers = 0
+	bCfg.QueueSize = 0
+	be, err := newBaseExporter(defaultSettings, fromOptions(WithBacklog(bCfg)), "", nopRequestUnmarshaler())
+	require.NoError(t, err)
+	require.NotNil(t, be.sender.primary)
+	require.Nil(t, be.sender.backlog)
+}
+
+func TestTiered_Shutdown_PrimaryRequestsFlushedToBacklog(t *testing.T) {
+	qCfg := NewDefaultQueueSettings()
+	qCfg.NumConsumers = 1
+	bCfg := NewDefaultQueueSettings()
+	bCfg.NumConsumers = 1
+	rCfg := NewDefaultRetrySettings()
+	rCfg.InitialInterval = time.Millisecond
+	rCfg.MaxElapsedTime = 0
+	be, err := newBaseExporter(defaultSettings, fromOptions(WithRetry(rCfg), WithQueue(qCfg), WithBacklog(bCfg)), "", nopRequestUnmarshaler())
+	require.NoError(t, err)
+	require.NotNil(t, be.sender.backlog)
+
+	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
+	primaryCounter := atomic.NewUint32(0)
+	be.sender.primary.queue = &producerConsumerQueueWithCounter{
+		ProducerConsumerQueue: be.sender.primary.queue,
+		produceCounter:        primaryCounter,
+	}
+	be.sender.primary.requeuingEnabled = true
+	backlogCounter := atomic.NewUint32(0)
+	be.sender.backlog.queue = &producerConsumerQueueWithCounter{
+		ProducerConsumerQueue: be.sender.backlog.queue,
+		produceCounter:        backlogCounter,
+	}
+
+	// replace nextSender inside retrySender to always return error so it doesn't exit send loop
+	be.sender.wrapConsumerSender(func(consumer requestSender) requestSender {
+		consumer.(*retrySender).nextSender = &errorRequestSender{
+			errToReturn: errors.New("some error"),
+		}
+		return consumer
+	})
+
+	req := newMockRequest(context.Background(), 3, errors.New("some error"))
+	require.NoError(t, be.sender.send(req))
+
+	// first wait for all the items to be produced to the queue initially
+	require.Eventually(t, func() bool {
+		return primaryCounter.Load() == uint32(1)
+	}, time.Second, 1*time.Millisecond)
+
+	// shuts down and ensure the item is produced in the backlog queue again
+	require.NoError(t, be.Shutdown(context.Background()))
+	require.Eventually(t, func() bool {
+		// double the count due to the backlog receiving the primary
+		// requests and then shutting down itself, which results in
+		// requeuing on backlog
+		// primary -> retry -> backlog -> retry -> backlog
+		return backlogCounter.Load() == uint32(2)
+	}, time.Second, 1*time.Millisecond)
+}

--- a/exporter/exporterhelper/traces.go
+++ b/exporter/exporterhelper/traces.go
@@ -110,6 +110,9 @@ func NewTracesExporter(
 			nextSender: nextSender,
 		}
 	})
+	be.onDropped(func(req internal.Request) {
+		be.obsrep.recordTracesDropped(req.Context(), int64(req.Count()))
+	})
 
 	tc, err := consumer.NewTraces(func(ctx context.Context, td ptrace.Traces) error {
 		req := newTracesRequest(ctx, td, pusher)

--- a/exporter/otlpexporter/config.go
+++ b/exporter/otlpexporter/config.go
@@ -26,6 +26,7 @@ import (
 type Config struct {
 	exporterhelper.TimeoutSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct.
 	exporterhelper.QueueSettings   `mapstructure:"sending_queue"`
+	BacklogSettings                exporterhelper.QueueSettings `mapstructure:"backlog_queue"`
 	exporterhelper.RetrySettings   `mapstructure:"retry_on_failure"`
 
 	configgrpc.GRPCClientSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct.
@@ -37,6 +38,9 @@ var _ component.Config = (*Config)(nil)
 func (cfg *Config) Validate() error {
 	if err := cfg.QueueSettings.Validate(); err != nil {
 		return fmt.Errorf("queue settings has invalid configuration: %w", err)
+	}
+	if err := cfg.BacklogSettings.Validate(); err != nil {
+		return fmt.Errorf("backlog settings has invalid configuration: %w", err)
 	}
 
 	return nil

--- a/exporter/otlpexporter/config_test.go
+++ b/exporter/otlpexporter/config_test.go
@@ -45,6 +45,7 @@ func TestUnmarshalConfig(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
 	assert.NoError(t, component.UnmarshalConfig(cm, cfg))
+	assert.NoError(t, cfg.(*Config).Validate())
 	assert.Equal(t,
 		&Config{
 			TimeoutSettings: exporterhelper.TimeoutSettings{

--- a/exporter/otlpexporter/factory.go
+++ b/exporter/otlpexporter/factory.go
@@ -47,6 +47,7 @@ func createDefaultConfig() component.Config {
 		TimeoutSettings: exporterhelper.NewDefaultTimeoutSettings(),
 		RetrySettings:   exporterhelper.NewDefaultRetrySettings(),
 		QueueSettings:   exporterhelper.NewDefaultQueueSettings(),
+		BacklogSettings: exporterhelper.QueueSettings{Enabled: false},
 		GRPCClientSettings: configgrpc.GRPCClientSettings{
 			Headers: map[string]configopaque.String{},
 			// Default to gzip compression
@@ -73,6 +74,7 @@ func createTracesExporter(
 		exporterhelper.WithTimeout(oCfg.TimeoutSettings),
 		exporterhelper.WithRetry(oCfg.RetrySettings),
 		exporterhelper.WithQueue(oCfg.QueueSettings),
+		exporterhelper.WithBacklog(oCfg.BacklogSettings),
 		exporterhelper.WithStart(oce.start),
 		exporterhelper.WithShutdown(oce.shutdown))
 }
@@ -93,6 +95,7 @@ func createMetricsExporter(
 		exporterhelper.WithTimeout(oCfg.TimeoutSettings),
 		exporterhelper.WithRetry(oCfg.RetrySettings),
 		exporterhelper.WithQueue(oCfg.QueueSettings),
+		exporterhelper.WithBacklog(oCfg.BacklogSettings),
 		exporterhelper.WithStart(oce.start),
 		exporterhelper.WithShutdown(oce.shutdown),
 	)
@@ -114,6 +117,7 @@ func createLogsExporter(
 		exporterhelper.WithTimeout(oCfg.TimeoutSettings),
 		exporterhelper.WithRetry(oCfg.RetrySettings),
 		exporterhelper.WithQueue(oCfg.QueueSettings),
+		exporterhelper.WithBacklog(oCfg.BacklogSettings),
 		exporterhelper.WithStart(oce.start),
 		exporterhelper.WithShutdown(oce.shutdown),
 	)

--- a/exporter/otlpexporter/factory_test.go
+++ b/exporter/otlpexporter/factory_test.go
@@ -42,6 +42,7 @@ func TestCreateDefaultConfig(t *testing.T) {
 	assert.True(t, ok)
 	assert.Equal(t, ocfg.RetrySettings, exporterhelper.NewDefaultRetrySettings())
 	assert.Equal(t, ocfg.QueueSettings, exporterhelper.NewDefaultQueueSettings())
+	assert.Equal(t, ocfg.BacklogSettings, exporterhelper.QueueSettings{Enabled: false})
 	assert.Equal(t, ocfg.TimeoutSettings, exporterhelper.NewDefaultTimeoutSettings())
 	assert.Equal(t, ocfg.Compression, configcompression.Gzip)
 }

--- a/exporter/otlphttpexporter/config_test.go
+++ b/exporter/otlphttpexporter/config_test.go
@@ -46,6 +46,7 @@ func TestUnmarshalConfig(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
 	assert.NoError(t, component.UnmarshalConfig(cm, cfg))
+	assert.NoError(t, cfg.(*Config).Validate())
 	assert.Equal(t,
 		&Config{
 			RetrySettings: exporterhelper.RetrySettings{

--- a/exporter/otlphttpexporter/factory.go
+++ b/exporter/otlphttpexporter/factory.go
@@ -47,8 +47,9 @@ func NewFactory() exporter.Factory {
 
 func createDefaultConfig() component.Config {
 	return &Config{
-		RetrySettings: exporterhelper.NewDefaultRetrySettings(),
-		QueueSettings: exporterhelper.NewDefaultQueueSettings(),
+		RetrySettings:   exporterhelper.NewDefaultRetrySettings(),
+		QueueSettings:   exporterhelper.NewDefaultQueueSettings(),
+		BacklogSettings: exporterhelper.QueueSettings{Enabled: false},
 		HTTPClientSettings: confighttp.HTTPClientSettings{
 			Endpoint: "",
 			Timeout:  30 * time.Second,
@@ -99,7 +100,9 @@ func createTracesExporter(
 		// explicitly disable since we rely on http.Client timeout logic.
 		exporterhelper.WithTimeout(exporterhelper.TimeoutSettings{Timeout: 0}),
 		exporterhelper.WithRetry(oCfg.RetrySettings),
-		exporterhelper.WithQueue(oCfg.QueueSettings))
+		exporterhelper.WithQueue(oCfg.QueueSettings),
+		exporterhelper.WithBacklog(oCfg.BacklogSettings),
+	)
 }
 
 func createMetricsExporter(
@@ -125,7 +128,9 @@ func createMetricsExporter(
 		// explicitly disable since we rely on http.Client timeout logic.
 		exporterhelper.WithTimeout(exporterhelper.TimeoutSettings{Timeout: 0}),
 		exporterhelper.WithRetry(oCfg.RetrySettings),
-		exporterhelper.WithQueue(oCfg.QueueSettings))
+		exporterhelper.WithQueue(oCfg.QueueSettings),
+		exporterhelper.WithBacklog(oCfg.BacklogSettings),
+	)
 }
 
 func createLogsExporter(
@@ -151,5 +156,7 @@ func createLogsExporter(
 		// explicitly disable since we rely on http.Client timeout logic.
 		exporterhelper.WithTimeout(exporterhelper.TimeoutSettings{Timeout: 0}),
 		exporterhelper.WithRetry(oCfg.RetrySettings),
-		exporterhelper.WithQueue(oCfg.QueueSettings))
+		exporterhelper.WithQueue(oCfg.QueueSettings),
+		exporterhelper.WithBacklog(oCfg.BacklogSettings),
+	)
 }

--- a/exporter/otlphttpexporter/factory_test.go
+++ b/exporter/otlphttpexporter/factory_test.go
@@ -46,6 +46,7 @@ func TestCreateDefaultConfig(t *testing.T) {
 	assert.Equal(t, ocfg.RetrySettings.InitialInterval, 5*time.Second, "default retry InitialInterval")
 	assert.Equal(t, ocfg.RetrySettings.MaxInterval, 30*time.Second, "default retry MaxInterval")
 	assert.Equal(t, ocfg.QueueSettings.Enabled, true, "default sending queue is enabled")
+	assert.Equal(t, ocfg.BacklogSettings.Enabled, false, "default backlog queue is disabled")
 	assert.Equal(t, ocfg.Compression, configcompression.Gzip)
 }
 


### PR DESCRIPTION
**Description:**
The base exporter used in the `exporterhelper` has been changed to use a tiered sender instead of a queued retry sender. The tiered sender is optionally comprised of a primary queued retry sender (configured by `WithQueue`) and a backlog queued retry sender (configured by `WithBacklog`). Each request it receives gets sent to the primary queue first and if the primary queue has overflow, the earliest requests will be removed and sent to the backlog. If requeuing is enabled, the requeued requests will also be sent to the backlog.

The primary use-case for this is to use an in-memory queue for the primary and a persistent queue for the backlog. On shutdown, the in-memory queue will flush and send all of its requests to the backlog persistent queue. This way the primary queue doesn't need to be persistent, which can improve performance.

The default behavior remains the same. If the backlog queue is not enabled through configuration, then it will behave the same as before based on the queue and retry settings.

Example configuration:
```yaml
exporters:
  otlp:
    sending_queue:
      enabled: true
      num_consumers: 10
      queue_size: 50
    backlog_queue:
      enabled: true
      num_consumers: 1
      queue_size: 100
      storage: file_storage/otc
extensions:
  file_storage/otc:
    directory: /var/lib/storage/otc
    timeout: 10s
```

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector/issues/6331

**Testing:** Added unit tests to test overflow behavior. Added tests for tiered sender.

**Documentation:** N/A
