### PR TITLE
[chore] [pdata] Simplify EnsureCapacity tests

### DIFF
--- a/pdata/internal/cmd/pdatagen/internal/base_slices.go
+++ b/pdata/internal/cmd/pdatagen/internal/base_slices.go
@@ -229,36 +229,20 @@ func Test${structName}_CopyTo(t *testing.T) {
 
 func Test${structName}_EnsureCapacity(t *testing.T) {
 	es := generateTest${structName}()
+
 	// Test ensure smaller capacity.
 	const ensureSmallLen = 4
-	expectedEs := make(map[*${originName}]bool)
-	for i := 0; i < es.Len(); i++ {
-		expectedEs[es.At(i).orig] = true
-	}
-	assert.Equal(t, es.Len(), len(expectedEs))
 	es.EnsureCapacity(ensureSmallLen)
 	assert.Less(t, ensureSmallLen, es.Len())
-	foundEs := make(map[*${originName}]bool, es.Len())
-	for i := 0; i < es.Len(); i++ {
-		foundEs[es.At(i).orig] = true
-	}
-	assert.Equal(t, expectedEs, foundEs)
+	assert.Equal(t, es.Len(), cap(*es.orig))
+	assert.Equal(t, generateTest${structName}(), es)
 
 	// Test ensure larger capacity
 	const ensureLargeLen = 9
-	oldLen := es.Len()
-	expectedEs = make(map[*${originName}]bool, oldLen)
-	for i := 0; i < oldLen; i++ {
-		expectedEs[es.At(i).orig] = true
-	}
-	assert.Equal(t, oldLen, len(expectedEs))
 	es.EnsureCapacity(ensureLargeLen)
+	assert.Less(t, generateTest${structName}().Len(), ensureLargeLen)
 	assert.Equal(t, ensureLargeLen, cap(*es.orig))
-	foundEs = make(map[*${originName}]bool, oldLen)
-	for i := 0; i < oldLen; i++ {
-		foundEs[es.At(i).orig] = true
-	}
-	assert.Equal(t, expectedEs, foundEs)
+	assert.Equal(t, generateTest${structName}(), es)
 }`
 
 const slicePtrGenerateTest = `
@@ -396,27 +380,20 @@ func Test${structName}_CopyTo(t *testing.T) {
 
 func Test${structName}_EnsureCapacity(t *testing.T) {
 	es := generateTest${structName}()
+
 	// Test ensure smaller capacity.
 	const ensureSmallLen = 4
-	expectedEs := make(map[*${originName}]bool)
-	for i := 0; i < es.Len(); i++ {
-		expectedEs[es.At(i).orig] = true
-	}
-	assert.Equal(t, es.Len(), len(expectedEs))
 	es.EnsureCapacity(ensureSmallLen)
 	assert.Less(t, ensureSmallLen, es.Len())
-	foundEs := make(map[*${originName}]bool, es.Len())
-	for i := 0; i < es.Len(); i++ {
-		foundEs[es.At(i).orig] = true
-	}
-	assert.Equal(t, expectedEs, foundEs)
+	assert.Equal(t, es.Len(), cap(*es.orig))
+	assert.Equal(t, generateTest${structName}(), es)
 
 	// Test ensure larger capacity
 	const ensureLargeLen = 9
-	oldLen := es.Len()
-	assert.Equal(t, oldLen, len(expectedEs))
 	es.EnsureCapacity(ensureLargeLen)
+	assert.Less(t, generateTest${structName}().Len(), ensureLargeLen)
 	assert.Equal(t, ensureLargeLen, cap(*es.orig))
+	assert.Equal(t, generateTest${structName}(), es)
 }`
 
 const sliceValueGenerateTest = `func generateTest${structName}() ${structName} {

--- a/pdata/plog/generated_logrecordslice_test.go
+++ b/pdata/plog/generated_logrecordslice_test.go
@@ -60,36 +60,20 @@ func TestLogRecordSlice_CopyTo(t *testing.T) {
 
 func TestLogRecordSlice_EnsureCapacity(t *testing.T) {
 	es := generateTestLogRecordSlice()
+
 	// Test ensure smaller capacity.
 	const ensureSmallLen = 4
-	expectedEs := make(map[*otlplogs.LogRecord]bool)
-	for i := 0; i < es.Len(); i++ {
-		expectedEs[es.At(i).orig] = true
-	}
-	assert.Equal(t, es.Len(), len(expectedEs))
 	es.EnsureCapacity(ensureSmallLen)
 	assert.Less(t, ensureSmallLen, es.Len())
-	foundEs := make(map[*otlplogs.LogRecord]bool, es.Len())
-	for i := 0; i < es.Len(); i++ {
-		foundEs[es.At(i).orig] = true
-	}
-	assert.Equal(t, expectedEs, foundEs)
+	assert.Equal(t, es.Len(), cap(*es.orig))
+	assert.Equal(t, generateTestLogRecordSlice(), es)
 
 	// Test ensure larger capacity
 	const ensureLargeLen = 9
-	oldLen := es.Len()
-	expectedEs = make(map[*otlplogs.LogRecord]bool, oldLen)
-	for i := 0; i < oldLen; i++ {
-		expectedEs[es.At(i).orig] = true
-	}
-	assert.Equal(t, oldLen, len(expectedEs))
 	es.EnsureCapacity(ensureLargeLen)
+	assert.Less(t, generateTestLogRecordSlice().Len(), ensureLargeLen)
 	assert.Equal(t, ensureLargeLen, cap(*es.orig))
-	foundEs = make(map[*otlplogs.LogRecord]bool, oldLen)
-	for i := 0; i < oldLen; i++ {
-		foundEs[es.At(i).orig] = true
-	}
-	assert.Equal(t, expectedEs, foundEs)
+	assert.Equal(t, generateTestLogRecordSlice(), es)
 }
 
 func TestLogRecordSlice_MoveAndAppendTo(t *testing.T) {

--- a/pdata/plog/generated_resourcelogsslice_test.go
+++ b/pdata/plog/generated_resourcelogsslice_test.go
@@ -60,36 +60,20 @@ func TestResourceLogsSlice_CopyTo(t *testing.T) {
 
 func TestResourceLogsSlice_EnsureCapacity(t *testing.T) {
 	es := generateTestResourceLogsSlice()
+
 	// Test ensure smaller capacity.
 	const ensureSmallLen = 4
-	expectedEs := make(map[*otlplogs.ResourceLogs]bool)
-	for i := 0; i < es.Len(); i++ {
-		expectedEs[es.At(i).orig] = true
-	}
-	assert.Equal(t, es.Len(), len(expectedEs))
 	es.EnsureCapacity(ensureSmallLen)
 	assert.Less(t, ensureSmallLen, es.Len())
-	foundEs := make(map[*otlplogs.ResourceLogs]bool, es.Len())
-	for i := 0; i < es.Len(); i++ {
-		foundEs[es.At(i).orig] = true
-	}
-	assert.Equal(t, expectedEs, foundEs)
+	assert.Equal(t, es.Len(), cap(*es.orig))
+	assert.Equal(t, generateTestResourceLogsSlice(), es)
 
 	// Test ensure larger capacity
 	const ensureLargeLen = 9
-	oldLen := es.Len()
-	expectedEs = make(map[*otlplogs.ResourceLogs]bool, oldLen)
-	for i := 0; i < oldLen; i++ {
-		expectedEs[es.At(i).orig] = true
-	}
-	assert.Equal(t, oldLen, len(expectedEs))
 	es.EnsureCapacity(ensureLargeLen)
+	assert.Less(t, generateTestResourceLogsSlice().Len(), ensureLargeLen)
 	assert.Equal(t, ensureLargeLen, cap(*es.orig))
-	foundEs = make(map[*otlplogs.ResourceLogs]bool, oldLen)
-	for i := 0; i < oldLen; i++ {
-		foundEs[es.At(i).orig] = true
-	}
-	assert.Equal(t, expectedEs, foundEs)
+	assert.Equal(t, generateTestResourceLogsSlice(), es)
 }
 
 func TestResourceLogsSlice_MoveAndAppendTo(t *testing.T) {

--- a/pdata/plog/generated_scopelogsslice_test.go
+++ b/pdata/plog/generated_scopelogsslice_test.go
@@ -60,36 +60,20 @@ func TestScopeLogsSlice_CopyTo(t *testing.T) {
 
 func TestScopeLogsSlice_EnsureCapacity(t *testing.T) {
 	es := generateTestScopeLogsSlice()
+
 	// Test ensure smaller capacity.
 	const ensureSmallLen = 4
-	expectedEs := make(map[*otlplogs.ScopeLogs]bool)
-	for i := 0; i < es.Len(); i++ {
-		expectedEs[es.At(i).orig] = true
-	}
-	assert.Equal(t, es.Len(), len(expectedEs))
 	es.EnsureCapacity(ensureSmallLen)
 	assert.Less(t, ensureSmallLen, es.Len())
-	foundEs := make(map[*otlplogs.ScopeLogs]bool, es.Len())
-	for i := 0; i < es.Len(); i++ {
-		foundEs[es.At(i).orig] = true
-	}
-	assert.Equal(t, expectedEs, foundEs)
+	assert.Equal(t, es.Len(), cap(*es.orig))
+	assert.Equal(t, generateTestScopeLogsSlice(), es)
 
 	// Test ensure larger capacity
 	const ensureLargeLen = 9
-	oldLen := es.Len()
-	expectedEs = make(map[*otlplogs.ScopeLogs]bool, oldLen)
-	for i := 0; i < oldLen; i++ {
-		expectedEs[es.At(i).orig] = true
-	}
-	assert.Equal(t, oldLen, len(expectedEs))
 	es.EnsureCapacity(ensureLargeLen)
+	assert.Less(t, generateTestScopeLogsSlice().Len(), ensureLargeLen)
 	assert.Equal(t, ensureLargeLen, cap(*es.orig))
-	foundEs = make(map[*otlplogs.ScopeLogs]bool, oldLen)
-	for i := 0; i < oldLen; i++ {
-		foundEs[es.At(i).orig] = true
-	}
-	assert.Equal(t, expectedEs, foundEs)
+	assert.Equal(t, generateTestScopeLogsSlice(), es)
 }
 
 func TestScopeLogsSlice_MoveAndAppendTo(t *testing.T) {

--- a/pdata/pmetric/generated_exemplarslice_test.go
+++ b/pdata/pmetric/generated_exemplarslice_test.go
@@ -60,27 +60,20 @@ func TestExemplarSlice_CopyTo(t *testing.T) {
 
 func TestExemplarSlice_EnsureCapacity(t *testing.T) {
 	es := generateTestExemplarSlice()
+
 	// Test ensure smaller capacity.
 	const ensureSmallLen = 4
-	expectedEs := make(map[*otlpmetrics.Exemplar]bool)
-	for i := 0; i < es.Len(); i++ {
-		expectedEs[es.At(i).orig] = true
-	}
-	assert.Equal(t, es.Len(), len(expectedEs))
 	es.EnsureCapacity(ensureSmallLen)
 	assert.Less(t, ensureSmallLen, es.Len())
-	foundEs := make(map[*otlpmetrics.Exemplar]bool, es.Len())
-	for i := 0; i < es.Len(); i++ {
-		foundEs[es.At(i).orig] = true
-	}
-	assert.Equal(t, expectedEs, foundEs)
+	assert.Equal(t, es.Len(), cap(*es.orig))
+	assert.Equal(t, generateTestExemplarSlice(), es)
 
 	// Test ensure larger capacity
 	const ensureLargeLen = 9
-	oldLen := es.Len()
-	assert.Equal(t, oldLen, len(expectedEs))
 	es.EnsureCapacity(ensureLargeLen)
+	assert.Less(t, generateTestExemplarSlice().Len(), ensureLargeLen)
 	assert.Equal(t, ensureLargeLen, cap(*es.orig))
+	assert.Equal(t, generateTestExemplarSlice(), es)
 }
 
 func TestExemplarSlice_MoveAndAppendTo(t *testing.T) {

--- a/pdata/pmetric/generated_exponentialhistogramdatapointslice_test.go
+++ b/pdata/pmetric/generated_exponentialhistogramdatapointslice_test.go
@@ -60,36 +60,20 @@ func TestExponentialHistogramDataPointSlice_CopyTo(t *testing.T) {
 
 func TestExponentialHistogramDataPointSlice_EnsureCapacity(t *testing.T) {
 	es := generateTestExponentialHistogramDataPointSlice()
+
 	// Test ensure smaller capacity.
 	const ensureSmallLen = 4
-	expectedEs := make(map[*otlpmetrics.ExponentialHistogramDataPoint]bool)
-	for i := 0; i < es.Len(); i++ {
-		expectedEs[es.At(i).orig] = true
-	}
-	assert.Equal(t, es.Len(), len(expectedEs))
 	es.EnsureCapacity(ensureSmallLen)
 	assert.Less(t, ensureSmallLen, es.Len())
-	foundEs := make(map[*otlpmetrics.ExponentialHistogramDataPoint]bool, es.Len())
-	for i := 0; i < es.Len(); i++ {
-		foundEs[es.At(i).orig] = true
-	}
-	assert.Equal(t, expectedEs, foundEs)
+	assert.Equal(t, es.Len(), cap(*es.orig))
+	assert.Equal(t, generateTestExponentialHistogramDataPointSlice(), es)
 
 	// Test ensure larger capacity
 	const ensureLargeLen = 9
-	oldLen := es.Len()
-	expectedEs = make(map[*otlpmetrics.ExponentialHistogramDataPoint]bool, oldLen)
-	for i := 0; i < oldLen; i++ {
-		expectedEs[es.At(i).orig] = true
-	}
-	assert.Equal(t, oldLen, len(expectedEs))
 	es.EnsureCapacity(ensureLargeLen)
+	assert.Less(t, generateTestExponentialHistogramDataPointSlice().Len(), ensureLargeLen)
 	assert.Equal(t, ensureLargeLen, cap(*es.orig))
-	foundEs = make(map[*otlpmetrics.ExponentialHistogramDataPoint]bool, oldLen)
-	for i := 0; i < oldLen; i++ {
-		foundEs[es.At(i).orig] = true
-	}
-	assert.Equal(t, expectedEs, foundEs)
+	assert.Equal(t, generateTestExponentialHistogramDataPointSlice(), es)
 }
 
 func TestExponentialHistogramDataPointSlice_MoveAndAppendTo(t *testing.T) {

--- a/pdata/pmetric/generated_histogramdatapointslice_test.go
+++ b/pdata/pmetric/generated_histogramdatapointslice_test.go
@@ -60,36 +60,20 @@ func TestHistogramDataPointSlice_CopyTo(t *testing.T) {
 
 func TestHistogramDataPointSlice_EnsureCapacity(t *testing.T) {
 	es := generateTestHistogramDataPointSlice()
+
 	// Test ensure smaller capacity.
 	const ensureSmallLen = 4
-	expectedEs := make(map[*otlpmetrics.HistogramDataPoint]bool)
-	for i := 0; i < es.Len(); i++ {
-		expectedEs[es.At(i).orig] = true
-	}
-	assert.Equal(t, es.Len(), len(expectedEs))
 	es.EnsureCapacity(ensureSmallLen)
 	assert.Less(t, ensureSmallLen, es.Len())
-	foundEs := make(map[*otlpmetrics.HistogramDataPoint]bool, es.Len())
-	for i := 0; i < es.Len(); i++ {
-		foundEs[es.At(i).orig] = true
-	}
-	assert.Equal(t, expectedEs, foundEs)
+	assert.Equal(t, es.Len(), cap(*es.orig))
+	assert.Equal(t, generateTestHistogramDataPointSlice(), es)
 
 	// Test ensure larger capacity
 	const ensureLargeLen = 9
-	oldLen := es.Len()
-	expectedEs = make(map[*otlpmetrics.HistogramDataPoint]bool, oldLen)
-	for i := 0; i < oldLen; i++ {
-		expectedEs[es.At(i).orig] = true
-	}
-	assert.Equal(t, oldLen, len(expectedEs))
 	es.EnsureCapacity(ensureLargeLen)
+	assert.Less(t, generateTestHistogramDataPointSlice().Len(), ensureLargeLen)
 	assert.Equal(t, ensureLargeLen, cap(*es.orig))
-	foundEs = make(map[*otlpmetrics.HistogramDataPoint]bool, oldLen)
-	for i := 0; i < oldLen; i++ {
-		foundEs[es.At(i).orig] = true
-	}
-	assert.Equal(t, expectedEs, foundEs)
+	assert.Equal(t, generateTestHistogramDataPointSlice(), es)
 }
 
 func TestHistogramDataPointSlice_MoveAndAppendTo(t *testing.T) {

--- a/pdata/pmetric/generated_metricslice_test.go
+++ b/pdata/pmetric/generated_metricslice_test.go
@@ -60,36 +60,20 @@ func TestMetricSlice_CopyTo(t *testing.T) {
 
 func TestMetricSlice_EnsureCapacity(t *testing.T) {
 	es := generateTestMetricSlice()
+
 	// Test ensure smaller capacity.
 	const ensureSmallLen = 4
-	expectedEs := make(map[*otlpmetrics.Metric]bool)
-	for i := 0; i < es.Len(); i++ {
-		expectedEs[es.At(i).orig] = true
-	}
-	assert.Equal(t, es.Len(), len(expectedEs))
 	es.EnsureCapacity(ensureSmallLen)
 	assert.Less(t, ensureSmallLen, es.Len())
-	foundEs := make(map[*otlpmetrics.Metric]bool, es.Len())
-	for i := 0; i < es.Len(); i++ {
-		foundEs[es.At(i).orig] = true
-	}
-	assert.Equal(t, expectedEs, foundEs)
+	assert.Equal(t, es.Len(), cap(*es.orig))
+	assert.Equal(t, generateTestMetricSlice(), es)
 
 	// Test ensure larger capacity
 	const ensureLargeLen = 9
-	oldLen := es.Len()
-	expectedEs = make(map[*otlpmetrics.Metric]bool, oldLen)
-	for i := 0; i < oldLen; i++ {
-		expectedEs[es.At(i).orig] = true
-	}
-	assert.Equal(t, oldLen, len(expectedEs))
 	es.EnsureCapacity(ensureLargeLen)
+	assert.Less(t, generateTestMetricSlice().Len(), ensureLargeLen)
 	assert.Equal(t, ensureLargeLen, cap(*es.orig))
-	foundEs = make(map[*otlpmetrics.Metric]bool, oldLen)
-	for i := 0; i < oldLen; i++ {
-		foundEs[es.At(i).orig] = true
-	}
-	assert.Equal(t, expectedEs, foundEs)
+	assert.Equal(t, generateTestMetricSlice(), es)
 }
 
 func TestMetricSlice_MoveAndAppendTo(t *testing.T) {

--- a/pdata/pmetric/generated_numberdatapointslice_test.go
+++ b/pdata/pmetric/generated_numberdatapointslice_test.go
@@ -60,36 +60,20 @@ func TestNumberDataPointSlice_CopyTo(t *testing.T) {
 
 func TestNumberDataPointSlice_EnsureCapacity(t *testing.T) {
 	es := generateTestNumberDataPointSlice()
+
 	// Test ensure smaller capacity.
 	const ensureSmallLen = 4
-	expectedEs := make(map[*otlpmetrics.NumberDataPoint]bool)
-	for i := 0; i < es.Len(); i++ {
-		expectedEs[es.At(i).orig] = true
-	}
-	assert.Equal(t, es.Len(), len(expectedEs))
 	es.EnsureCapacity(ensureSmallLen)
 	assert.Less(t, ensureSmallLen, es.Len())
-	foundEs := make(map[*otlpmetrics.NumberDataPoint]bool, es.Len())
-	for i := 0; i < es.Len(); i++ {
-		foundEs[es.At(i).orig] = true
-	}
-	assert.Equal(t, expectedEs, foundEs)
+	assert.Equal(t, es.Len(), cap(*es.orig))
+	assert.Equal(t, generateTestNumberDataPointSlice(), es)
 
 	// Test ensure larger capacity
 	const ensureLargeLen = 9
-	oldLen := es.Len()
-	expectedEs = make(map[*otlpmetrics.NumberDataPoint]bool, oldLen)
-	for i := 0; i < oldLen; i++ {
-		expectedEs[es.At(i).orig] = true
-	}
-	assert.Equal(t, oldLen, len(expectedEs))
 	es.EnsureCapacity(ensureLargeLen)
+	assert.Less(t, generateTestNumberDataPointSlice().Len(), ensureLargeLen)
 	assert.Equal(t, ensureLargeLen, cap(*es.orig))
-	foundEs = make(map[*otlpmetrics.NumberDataPoint]bool, oldLen)
-	for i := 0; i < oldLen; i++ {
-		foundEs[es.At(i).orig] = true
-	}
-	assert.Equal(t, expectedEs, foundEs)
+	assert.Equal(t, generateTestNumberDataPointSlice(), es)
 }
 
 func TestNumberDataPointSlice_MoveAndAppendTo(t *testing.T) {

--- a/pdata/pmetric/generated_resourcemetricsslice_test.go
+++ b/pdata/pmetric/generated_resourcemetricsslice_test.go
@@ -60,36 +60,20 @@ func TestResourceMetricsSlice_CopyTo(t *testing.T) {
 
 func TestResourceMetricsSlice_EnsureCapacity(t *testing.T) {
 	es := generateTestResourceMetricsSlice()
+
 	// Test ensure smaller capacity.
 	const ensureSmallLen = 4
-	expectedEs := make(map[*otlpmetrics.ResourceMetrics]bool)
-	for i := 0; i < es.Len(); i++ {
-		expectedEs[es.At(i).orig] = true
-	}
-	assert.Equal(t, es.Len(), len(expectedEs))
 	es.EnsureCapacity(ensureSmallLen)
 	assert.Less(t, ensureSmallLen, es.Len())
-	foundEs := make(map[*otlpmetrics.ResourceMetrics]bool, es.Len())
-	for i := 0; i < es.Len(); i++ {
-		foundEs[es.At(i).orig] = true
-	}
-	assert.Equal(t, expectedEs, foundEs)
+	assert.Equal(t, es.Len(), cap(*es.orig))
+	assert.Equal(t, generateTestResourceMetricsSlice(), es)
 
 	// Test ensure larger capacity
 	const ensureLargeLen = 9
-	oldLen := es.Len()
-	expectedEs = make(map[*otlpmetrics.ResourceMetrics]bool, oldLen)
-	for i := 0; i < oldLen; i++ {
-		expectedEs[es.At(i).orig] = true
-	}
-	assert.Equal(t, oldLen, len(expectedEs))
 	es.EnsureCapacity(ensureLargeLen)
+	assert.Less(t, generateTestResourceMetricsSlice().Len(), ensureLargeLen)
 	assert.Equal(t, ensureLargeLen, cap(*es.orig))
-	foundEs = make(map[*otlpmetrics.ResourceMetrics]bool, oldLen)
-	for i := 0; i < oldLen; i++ {
-		foundEs[es.At(i).orig] = true
-	}
-	assert.Equal(t, expectedEs, foundEs)
+	assert.Equal(t, generateTestResourceMetricsSlice(), es)
 }
 
 func TestResourceMetricsSlice_MoveAndAppendTo(t *testing.T) {

--- a/pdata/pmetric/generated_scopemetricsslice_test.go
+++ b/pdata/pmetric/generated_scopemetricsslice_test.go
@@ -60,36 +60,20 @@ func TestScopeMetricsSlice_CopyTo(t *testing.T) {
 
 func TestScopeMetricsSlice_EnsureCapacity(t *testing.T) {
 	es := generateTestScopeMetricsSlice()
+
 	// Test ensure smaller capacity.
 	const ensureSmallLen = 4
-	expectedEs := make(map[*otlpmetrics.ScopeMetrics]bool)
-	for i := 0; i < es.Len(); i++ {
-		expectedEs[es.At(i).orig] = true
-	}
-	assert.Equal(t, es.Len(), len(expectedEs))
 	es.EnsureCapacity(ensureSmallLen)
 	assert.Less(t, ensureSmallLen, es.Len())
-	foundEs := make(map[*otlpmetrics.ScopeMetrics]bool, es.Len())
-	for i := 0; i < es.Len(); i++ {
-		foundEs[es.At(i).orig] = true
-	}
-	assert.Equal(t, expectedEs, foundEs)
+	assert.Equal(t, es.Len(), cap(*es.orig))
+	assert.Equal(t, generateTestScopeMetricsSlice(), es)
 
 	// Test ensure larger capacity
 	const ensureLargeLen = 9
-	oldLen := es.Len()
-	expectedEs = make(map[*otlpmetrics.ScopeMetrics]bool, oldLen)
-	for i := 0; i < oldLen; i++ {
-		expectedEs[es.At(i).orig] = true
-	}
-	assert.Equal(t, oldLen, len(expectedEs))
 	es.EnsureCapacity(ensureLargeLen)
+	assert.Less(t, generateTestScopeMetricsSlice().Len(), ensureLargeLen)
 	assert.Equal(t, ensureLargeLen, cap(*es.orig))
-	foundEs = make(map[*otlpmetrics.ScopeMetrics]bool, oldLen)
-	for i := 0; i < oldLen; i++ {
-		foundEs[es.At(i).orig] = true
-	}
-	assert.Equal(t, expectedEs, foundEs)
+	assert.Equal(t, generateTestScopeMetricsSlice(), es)
 }
 
 func TestScopeMetricsSlice_MoveAndAppendTo(t *testing.T) {

--- a/pdata/pmetric/generated_summarydatapointslice_test.go
+++ b/pdata/pmetric/generated_summarydatapointslice_test.go
@@ -60,36 +60,20 @@ func TestSummaryDataPointSlice_CopyTo(t *testing.T) {
 
 func TestSummaryDataPointSlice_EnsureCapacity(t *testing.T) {
 	es := generateTestSummaryDataPointSlice()
+
 	// Test ensure smaller capacity.
 	const ensureSmallLen = 4
-	expectedEs := make(map[*otlpmetrics.SummaryDataPoint]bool)
-	for i := 0; i < es.Len(); i++ {
-		expectedEs[es.At(i).orig] = true
-	}
-	assert.Equal(t, es.Len(), len(expectedEs))
 	es.EnsureCapacity(ensureSmallLen)
 	assert.Less(t, ensureSmallLen, es.Len())
-	foundEs := make(map[*otlpmetrics.SummaryDataPoint]bool, es.Len())
-	for i := 0; i < es.Len(); i++ {
-		foundEs[es.At(i).orig] = true
-	}
-	assert.Equal(t, expectedEs, foundEs)
+	assert.Equal(t, es.Len(), cap(*es.orig))
+	assert.Equal(t, generateTestSummaryDataPointSlice(), es)
 
 	// Test ensure larger capacity
 	const ensureLargeLen = 9
-	oldLen := es.Len()
-	expectedEs = make(map[*otlpmetrics.SummaryDataPoint]bool, oldLen)
-	for i := 0; i < oldLen; i++ {
-		expectedEs[es.At(i).orig] = true
-	}
-	assert.Equal(t, oldLen, len(expectedEs))
 	es.EnsureCapacity(ensureLargeLen)
+	assert.Less(t, generateTestSummaryDataPointSlice().Len(), ensureLargeLen)
 	assert.Equal(t, ensureLargeLen, cap(*es.orig))
-	foundEs = make(map[*otlpmetrics.SummaryDataPoint]bool, oldLen)
-	for i := 0; i < oldLen; i++ {
-		foundEs[es.At(i).orig] = true
-	}
-	assert.Equal(t, expectedEs, foundEs)
+	assert.Equal(t, generateTestSummaryDataPointSlice(), es)
 }
 
 func TestSummaryDataPointSlice_MoveAndAppendTo(t *testing.T) {

--- a/pdata/pmetric/generated_summarydatapointvalueatquantileslice_test.go
+++ b/pdata/pmetric/generated_summarydatapointvalueatquantileslice_test.go
@@ -60,36 +60,20 @@ func TestSummaryDataPointValueAtQuantileSlice_CopyTo(t *testing.T) {
 
 func TestSummaryDataPointValueAtQuantileSlice_EnsureCapacity(t *testing.T) {
 	es := generateTestSummaryDataPointValueAtQuantileSlice()
+
 	// Test ensure smaller capacity.
 	const ensureSmallLen = 4
-	expectedEs := make(map[*otlpmetrics.SummaryDataPoint_ValueAtQuantile]bool)
-	for i := 0; i < es.Len(); i++ {
-		expectedEs[es.At(i).orig] = true
-	}
-	assert.Equal(t, es.Len(), len(expectedEs))
 	es.EnsureCapacity(ensureSmallLen)
 	assert.Less(t, ensureSmallLen, es.Len())
-	foundEs := make(map[*otlpmetrics.SummaryDataPoint_ValueAtQuantile]bool, es.Len())
-	for i := 0; i < es.Len(); i++ {
-		foundEs[es.At(i).orig] = true
-	}
-	assert.Equal(t, expectedEs, foundEs)
+	assert.Equal(t, es.Len(), cap(*es.orig))
+	assert.Equal(t, generateTestSummaryDataPointValueAtQuantileSlice(), es)
 
 	// Test ensure larger capacity
 	const ensureLargeLen = 9
-	oldLen := es.Len()
-	expectedEs = make(map[*otlpmetrics.SummaryDataPoint_ValueAtQuantile]bool, oldLen)
-	for i := 0; i < oldLen; i++ {
-		expectedEs[es.At(i).orig] = true
-	}
-	assert.Equal(t, oldLen, len(expectedEs))
 	es.EnsureCapacity(ensureLargeLen)
+	assert.Less(t, generateTestSummaryDataPointValueAtQuantileSlice().Len(), ensureLargeLen)
 	assert.Equal(t, ensureLargeLen, cap(*es.orig))
-	foundEs = make(map[*otlpmetrics.SummaryDataPoint_ValueAtQuantile]bool, oldLen)
-	for i := 0; i < oldLen; i++ {
-		foundEs[es.At(i).orig] = true
-	}
-	assert.Equal(t, expectedEs, foundEs)
+	assert.Equal(t, generateTestSummaryDataPointValueAtQuantileSlice(), es)
 }
 
 func TestSummaryDataPointValueAtQuantileSlice_MoveAndAppendTo(t *testing.T) {

--- a/pdata/ptrace/generated_resourcespansslice_test.go
+++ b/pdata/ptrace/generated_resourcespansslice_test.go
@@ -60,36 +60,20 @@ func TestResourceSpansSlice_CopyTo(t *testing.T) {
 
 func TestResourceSpansSlice_EnsureCapacity(t *testing.T) {
 	es := generateTestResourceSpansSlice()
+
 	// Test ensure smaller capacity.
 	const ensureSmallLen = 4
-	expectedEs := make(map[*otlptrace.ResourceSpans]bool)
-	for i := 0; i < es.Len(); i++ {
-		expectedEs[es.At(i).orig] = true
-	}
-	assert.Equal(t, es.Len(), len(expectedEs))
 	es.EnsureCapacity(ensureSmallLen)
 	assert.Less(t, ensureSmallLen, es.Len())
-	foundEs := make(map[*otlptrace.ResourceSpans]bool, es.Len())
-	for i := 0; i < es.Len(); i++ {
-		foundEs[es.At(i).orig] = true
-	}
-	assert.Equal(t, expectedEs, foundEs)
+	assert.Equal(t, es.Len(), cap(*es.orig))
+	assert.Equal(t, generateTestResourceSpansSlice(), es)
 
 	// Test ensure larger capacity
 	const ensureLargeLen = 9
-	oldLen := es.Len()
-	expectedEs = make(map[*otlptrace.ResourceSpans]bool, oldLen)
-	for i := 0; i < oldLen; i++ {
-		expectedEs[es.At(i).orig] = true
-	}
-	assert.Equal(t, oldLen, len(expectedEs))
 	es.EnsureCapacity(ensureLargeLen)
+	assert.Less(t, generateTestResourceSpansSlice().Len(), ensureLargeLen)
 	assert.Equal(t, ensureLargeLen, cap(*es.orig))
-	foundEs = make(map[*otlptrace.ResourceSpans]bool, oldLen)
-	for i := 0; i < oldLen; i++ {
-		foundEs[es.At(i).orig] = true
-	}
-	assert.Equal(t, expectedEs, foundEs)
+	assert.Equal(t, generateTestResourceSpansSlice(), es)
 }
 
 func TestResourceSpansSlice_MoveAndAppendTo(t *testing.T) {

--- a/pdata/ptrace/generated_scopespansslice_test.go
+++ b/pdata/ptrace/generated_scopespansslice_test.go
@@ -60,36 +60,20 @@ func TestScopeSpansSlice_CopyTo(t *testing.T) {
 
 func TestScopeSpansSlice_EnsureCapacity(t *testing.T) {
 	es := generateTestScopeSpansSlice()
+
 	// Test ensure smaller capacity.
 	const ensureSmallLen = 4
-	expectedEs := make(map[*otlptrace.ScopeSpans]bool)
-	for i := 0; i < es.Len(); i++ {
-		expectedEs[es.At(i).orig] = true
-	}
-	assert.Equal(t, es.Len(), len(expectedEs))
 	es.EnsureCapacity(ensureSmallLen)
 	assert.Less(t, ensureSmallLen, es.Len())
-	foundEs := make(map[*otlptrace.ScopeSpans]bool, es.Len())
-	for i := 0; i < es.Len(); i++ {
-		foundEs[es.At(i).orig] = true
-	}
-	assert.Equal(t, expectedEs, foundEs)
+	assert.Equal(t, es.Len(), cap(*es.orig))
+	assert.Equal(t, generateTestScopeSpansSlice(), es)
 
 	// Test ensure larger capacity
 	const ensureLargeLen = 9
-	oldLen := es.Len()
-	expectedEs = make(map[*otlptrace.ScopeSpans]bool, oldLen)
-	for i := 0; i < oldLen; i++ {
-		expectedEs[es.At(i).orig] = true
-	}
-	assert.Equal(t, oldLen, len(expectedEs))
 	es.EnsureCapacity(ensureLargeLen)
+	assert.Less(t, generateTestScopeSpansSlice().Len(), ensureLargeLen)
 	assert.Equal(t, ensureLargeLen, cap(*es.orig))
-	foundEs = make(map[*otlptrace.ScopeSpans]bool, oldLen)
-	for i := 0; i < oldLen; i++ {
-		foundEs[es.At(i).orig] = true
-	}
-	assert.Equal(t, expectedEs, foundEs)
+	assert.Equal(t, generateTestScopeSpansSlice(), es)
 }
 
 func TestScopeSpansSlice_MoveAndAppendTo(t *testing.T) {

--- a/pdata/ptrace/generated_spaneventslice_test.go
+++ b/pdata/ptrace/generated_spaneventslice_test.go
@@ -60,36 +60,20 @@ func TestSpanEventSlice_CopyTo(t *testing.T) {
 
 func TestSpanEventSlice_EnsureCapacity(t *testing.T) {
 	es := generateTestSpanEventSlice()
+
 	// Test ensure smaller capacity.
 	const ensureSmallLen = 4
-	expectedEs := make(map[*otlptrace.Span_Event]bool)
-	for i := 0; i < es.Len(); i++ {
-		expectedEs[es.At(i).orig] = true
-	}
-	assert.Equal(t, es.Len(), len(expectedEs))
 	es.EnsureCapacity(ensureSmallLen)
 	assert.Less(t, ensureSmallLen, es.Len())
-	foundEs := make(map[*otlptrace.Span_Event]bool, es.Len())
-	for i := 0; i < es.Len(); i++ {
-		foundEs[es.At(i).orig] = true
-	}
-	assert.Equal(t, expectedEs, foundEs)
+	assert.Equal(t, es.Len(), cap(*es.orig))
+	assert.Equal(t, generateTestSpanEventSlice(), es)
 
 	// Test ensure larger capacity
 	const ensureLargeLen = 9
-	oldLen := es.Len()
-	expectedEs = make(map[*otlptrace.Span_Event]bool, oldLen)
-	for i := 0; i < oldLen; i++ {
-		expectedEs[es.At(i).orig] = true
-	}
-	assert.Equal(t, oldLen, len(expectedEs))
 	es.EnsureCapacity(ensureLargeLen)
+	assert.Less(t, generateTestSpanEventSlice().Len(), ensureLargeLen)
 	assert.Equal(t, ensureLargeLen, cap(*es.orig))
-	foundEs = make(map[*otlptrace.Span_Event]bool, oldLen)
-	for i := 0; i < oldLen; i++ {
-		foundEs[es.At(i).orig] = true
-	}
-	assert.Equal(t, expectedEs, foundEs)
+	assert.Equal(t, generateTestSpanEventSlice(), es)
 }
 
 func TestSpanEventSlice_MoveAndAppendTo(t *testing.T) {

--- a/pdata/ptrace/generated_spanlinkslice_test.go
+++ b/pdata/ptrace/generated_spanlinkslice_test.go
@@ -60,36 +60,20 @@ func TestSpanLinkSlice_CopyTo(t *testing.T) {
 
 func TestSpanLinkSlice_EnsureCapacity(t *testing.T) {
 	es := generateTestSpanLinkSlice()
+
 	// Test ensure smaller capacity.
 	const ensureSmallLen = 4
-	expectedEs := make(map[*otlptrace.Span_Link]bool)
-	for i := 0; i < es.Len(); i++ {
-		expectedEs[es.At(i).orig] = true
-	}
-	assert.Equal(t, es.Len(), len(expectedEs))
 	es.EnsureCapacity(ensureSmallLen)
 	assert.Less(t, ensureSmallLen, es.Len())
-	foundEs := make(map[*otlptrace.Span_Link]bool, es.Len())
-	for i := 0; i < es.Len(); i++ {
-		foundEs[es.At(i).orig] = true
-	}
-	assert.Equal(t, expectedEs, foundEs)
+	assert.Equal(t, es.Len(), cap(*es.orig))
+	assert.Equal(t, generateTestSpanLinkSlice(), es)
 
 	// Test ensure larger capacity
 	const ensureLargeLen = 9
-	oldLen := es.Len()
-	expectedEs = make(map[*otlptrace.Span_Link]bool, oldLen)
-	for i := 0; i < oldLen; i++ {
-		expectedEs[es.At(i).orig] = true
-	}
-	assert.Equal(t, oldLen, len(expectedEs))
 	es.EnsureCapacity(ensureLargeLen)
+	assert.Less(t, generateTestSpanLinkSlice().Len(), ensureLargeLen)
 	assert.Equal(t, ensureLargeLen, cap(*es.orig))
-	foundEs = make(map[*otlptrace.Span_Link]bool, oldLen)
-	for i := 0; i < oldLen; i++ {
-		foundEs[es.At(i).orig] = true
-	}
-	assert.Equal(t, expectedEs, foundEs)
+	assert.Equal(t, generateTestSpanLinkSlice(), es)
 }
 
 func TestSpanLinkSlice_MoveAndAppendTo(t *testing.T) {

--- a/pdata/ptrace/generated_spanslice_test.go
+++ b/pdata/ptrace/generated_spanslice_test.go
@@ -60,36 +60,20 @@ func TestSpanSlice_CopyTo(t *testing.T) {
 
 func TestSpanSlice_EnsureCapacity(t *testing.T) {
 	es := generateTestSpanSlice()
+
 	// Test ensure smaller capacity.
 	const ensureSmallLen = 4
-	expectedEs := make(map[*otlptrace.Span]bool)
-	for i := 0; i < es.Len(); i++ {
-		expectedEs[es.At(i).orig] = true
-	}
-	assert.Equal(t, es.Len(), len(expectedEs))
 	es.EnsureCapacity(ensureSmallLen)
 	assert.Less(t, ensureSmallLen, es.Len())
-	foundEs := make(map[*otlptrace.Span]bool, es.Len())
-	for i := 0; i < es.Len(); i++ {
-		foundEs[es.At(i).orig] = true
-	}
-	assert.Equal(t, expectedEs, foundEs)
+	assert.Equal(t, es.Len(), cap(*es.orig))
+	assert.Equal(t, generateTestSpanSlice(), es)
 
 	// Test ensure larger capacity
 	const ensureLargeLen = 9
-	oldLen := es.Len()
-	expectedEs = make(map[*otlptrace.Span]bool, oldLen)
-	for i := 0; i < oldLen; i++ {
-		expectedEs[es.At(i).orig] = true
-	}
-	assert.Equal(t, oldLen, len(expectedEs))
 	es.EnsureCapacity(ensureLargeLen)
+	assert.Less(t, generateTestSpanSlice().Len(), ensureLargeLen)
 	assert.Equal(t, ensureLargeLen, cap(*es.orig))
-	foundEs = make(map[*otlptrace.Span]bool, oldLen)
-	for i := 0; i < oldLen; i++ {
-		foundEs[es.At(i).orig] = true
-	}
-	assert.Equal(t, expectedEs, foundEs)
+	assert.Equal(t, generateTestSpanSlice(), es)
 }
 
 func TestSpanSlice_MoveAndAppendTo(t *testing.T) {


### PR DESCRIPTION
This brings `slicePtr` and `sliceValue` tests the same view which helps to consolidate them
