### PR TITLE
Disambiguate component ID in 'connectortest' package

### DIFF
--- a/connector/connectortest/connector.go
+++ b/connector/connectortest/connector.go
@@ -101,7 +101,11 @@ type nopConnector struct {
 // NewNopBuilder returns a connector.Builder that constructs nop receivers.
 func NewNopBuilder() *connector.Builder {
 	nopFactory := NewNopFactory()
+	// Use a different ID than receivertest and exportertest to avoid ambiguous
+	// configuration scenarios. Ambiguous IDs are detected in the 'otelcol' package,
+	// but lower level packages such as 'service' assume that IDs are disambiguated.
+	connID := component.NewIDWithName(typeStr, "conn")
 	return connector.NewBuilder(
-		map[component.ID]component.Config{component.NewID(typeStr): nopFactory.CreateDefaultConfig()},
+		map[component.ID]component.Config{connID: nopFactory.CreateDefaultConfig()},
 		map[component.Type]connector.Factory{typeStr: nopFactory})
 }

--- a/connector/connectortest/connector_test.go
+++ b/connector/connectortest/connector_test.go
@@ -98,7 +98,7 @@ func TestNewNopBuilder(t *testing.T) {
 	factory := NewNopFactory()
 	cfg := factory.CreateDefaultConfig()
 	set := NewNopCreateSettings()
-	set.ID = component.NewID(typeStr)
+	set.ID = component.NewIDWithName(typeStr, "conn")
 
 	tracesToTraces, err := factory.CreateTracesToTraces(context.Background(), set, cfg, consumertest.NewNop())
 	require.NoError(t, err)

--- a/internal/sharedgate/sharedgate.go
+++ b/internal/sharedgate/sharedgate.go
@@ -19,6 +19,6 @@ import "go.opentelemetry.io/collector/featuregate"
 
 var ConnectorsFeatureGate = featuregate.GlobalRegistry().MustRegister(
 	"enableConnectors",
-	featuregate.StageBeta,
+	featuregate.StageAlpha,
 	featuregate.WithRegisterDescription("Enables 'connectors', a new type of component for transmitting signals between pipelines."),
 	featuregate.WithRegisterReferenceURL("https://github.com/open-telemetry/opentelemetry-collector/issues/2336"))

--- a/internal/sharedgate/sharedgate.go
+++ b/internal/sharedgate/sharedgate.go
@@ -19,6 +19,6 @@ import "go.opentelemetry.io/collector/featuregate"
 
 var ConnectorsFeatureGate = featuregate.GlobalRegistry().MustRegister(
 	"enableConnectors",
-	featuregate.StageAlpha,
+	featuregate.StageBeta,
 	featuregate.WithRegisterDescription("Enables 'connectors', a new type of component for transmitting signals between pipelines."),
 	featuregate.WithRegisterReferenceURL("https://github.com/open-telemetry/opentelemetry-collector/issues/2336"))


### PR DESCRIPTION
Use a different ID than `receivertest` and `exportertest` to avoid ambiguous configuration scenarios. Ambiguous IDs are detected in the `otelcol` package, but lower level packages such as `service` assume that IDs are disambiguated.

To demonstrate this working with the connectors feature gate enabled, I've temporarily updated the gate level to beta. Once tests pass, I will revert the gate level to alpha.