### PR TITLE
Update connectors flag and documentation

### DIFF
--- a/.chloggen/connnectors-changelog.yaml
+++ b/.chloggen/connnectors-changelog.yaml
@@ -1,0 +1,26 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'enhancement'
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: connectors
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add "connectors", a new type of pipeline component
+
+# One or more tracking issues or pull requests related to the change
+issues: [2336]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  - Connectors connect pipelines by acting as an exporter in one or more pipelines and simultaneously
+  as a receiver of corresponding data in one or more other pipelines. For example:
+    - The `forward` connector can export data to another pipeline of the same type. This allows you
+    to merge data from multiple pipelines onto a common pipeline. Or, you can replicate data onto multiple
+    pipelines so that it may be processed in different ways and/or exported to different backends.
+    - The `count` connector can count data of any type. Regardless of the type of data that is counted, it
+    emits counts as metrics onto a metrics pipeline.
+  - Connectors are currently disabled by default but can be enabled with the `connectors` feature gate.
+  - See the [connectors README](https://github.com/open-telemetry/opentelemetry-collector/blob/main/connector/README.md)
+  for more details on how to use connectors.

--- a/.chloggen/connnectors-changelog.yaml
+++ b/.chloggen/connnectors-changelog.yaml
@@ -21,6 +21,6 @@ subtext: |
     pipelines so that it may be processed in different ways and/or exported to different backends.
     - The `count` connector can count data of any type. Regardless of the type of data that is counted, it
     emits counts as metrics onto a metrics pipeline.
-  - Connectors are currently disabled by default but can be enabled with the `connectors` feature gate.
+  - Connectors are currently disabled by default but can be enabled with the `service.connectors` feature gate.
   - See the [connectors README](https://github.com/open-telemetry/opentelemetry-collector/blob/main/connector/README.md)
   for more details on how to use connectors.

--- a/connector/README.md
+++ b/connector/README.md
@@ -5,6 +5,11 @@ and emits data as a receiver in another pipeline. It may consume and emit data o
 type, or of different data types. A connector may generate and emit data to summarize the
 consumed data, or it may simply replicate or route data.
 
+## Status
+
+Connectors are currently in `Alpha` stage. To enable connectors, run the collector with the
+`connectors` feature gate. e.g. `./otelcol --config config.yaml --feature-gates connectors`.
+
 ## Supported Data Types
 
 Each type of connector is designed to work with one or more _pairs_ of data types and may only

--- a/connector/README.md
+++ b/connector/README.md
@@ -8,7 +8,7 @@ consumed data, or it may simply replicate or route data.
 ## Status
 
 Connectors are currently in `Alpha` stage. To enable connectors, run the collector with the
-`connectors` feature gate. e.g. `./otelcol --config config.yaml --feature-gates connectors`.
+`service.connectors` feature gate. e.g. `./otelcol --config config.yaml --feature-gates connectors`.
 
 ## Supported Data Types
 

--- a/internal/sharedgate/sharedgate.go
+++ b/internal/sharedgate/sharedgate.go
@@ -18,7 +18,7 @@ package sharedgate // import "go.opentelemetry.io/collector/internal/sharedgate"
 import "go.opentelemetry.io/collector/featuregate"
 
 var ConnectorsFeatureGate = featuregate.GlobalRegistry().MustRegister(
-	"enableConnectors",
+	"connectors",
 	featuregate.StageAlpha,
 	featuregate.WithRegisterDescription("Enables 'connectors', a new type of component for transmitting signals between pipelines."),
 	featuregate.WithRegisterReferenceURL("https://github.com/open-telemetry/opentelemetry-collector/issues/2336"))

--- a/internal/sharedgate/sharedgate.go
+++ b/internal/sharedgate/sharedgate.go
@@ -18,7 +18,7 @@ package sharedgate // import "go.opentelemetry.io/collector/internal/sharedgate"
 import "go.opentelemetry.io/collector/featuregate"
 
 var ConnectorsFeatureGate = featuregate.GlobalRegistry().MustRegister(
-	"connectors",
+	"service.connectors",
 	featuregate.StageAlpha,
 	featuregate.WithRegisterDescription("Enables 'connectors', a new type of component for transmitting signals between pipelines."),
 	featuregate.WithRegisterReferenceURL("https://github.com/open-telemetry/opentelemetry-collector/issues/2336"))


### PR DESCRIPTION
This PR is preparation for the v0.71.0 release, which would be the first with a functional implementation of the connectors framework.
- Changes the feature gate from `enableConnectors` to `connectors`, which makes more sense in the long run because the enabled status is independent of the gate's _name_.
- Adds a note to the connectors README about the status of the feature set and how to enable.
- Adds a changelog entry with a basic description of the feature set and a link to the README.