### PR TITLE
Split graph based pipelines implementation from connectors functionality

### DIFF
--- a/.chloggen/enablegraph.yaml
+++ b/.chloggen/enablegraph.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: service
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Enable new pipelines implementation using graphs. Controlled by the `service.graph` featuregate.
+
+# One or more tracking issues or pull requests related to the change
+issues: [2336]

--- a/otelcol/config.go
+++ b/otelcol/config.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 
 	"go.opentelemetry.io/collector/component"
-	"go.opentelemetry.io/collector/internal/sharedgate"
+	"go.opentelemetry.io/collector/otelcol/internal/sharedgate"
 	"go.opentelemetry.io/collector/service"
 )
 

--- a/otelcol/config_test.go
+++ b/otelcol/config_test.go
@@ -26,7 +26,7 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configtelemetry"
 	"go.opentelemetry.io/collector/featuregate"
-	"go.opentelemetry.io/collector/internal/sharedgate"
+	"go.opentelemetry.io/collector/otelcol/internal/sharedgate"
 	"go.opentelemetry.io/collector/service"
 	"go.opentelemetry.io/collector/service/telemetry"
 )

--- a/otelcol/internal/sharedgate/sharedgate.go
+++ b/otelcol/internal/sharedgate/sharedgate.go
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 // Package sharedgate exposes a featuregate that is used by multiple packages.
-package sharedgate // import "go.opentelemetry.io/collector/internal/sharedgate"
+package sharedgate // import "go.opentelemetry.io/collector/otelcol/internal/sharedgate"
 
 import "go.opentelemetry.io/collector/featuregate"
 

--- a/otelcol/otelcoltest/config_test.go
+++ b/otelcol/otelcoltest/config_test.go
@@ -23,7 +23,7 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/featuregate"
-	"go.opentelemetry.io/collector/internal/sharedgate"
+	"go.opentelemetry.io/collector/otelcol/internal/sharedgate"
 	"go.opentelemetry.io/collector/service"
 )
 


### PR DESCRIPTION
Add a separate featuregate to control the new graph base pipelines implementation release. This way we can enable the graph base implementation now, and keep connectors still in alpha (since the validation of the otelcol Config will fail) to limit the number of changes necessary to enable connectors.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
