### PR TITLE
[memorylimiter] Fix cgroups parsing

### DIFF
--- a/.chloggen/fix-memory-limiter.yaml
+++ b/.chloggen/fix-memory-limiter.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: memorylimiterprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fix incorrect parsing of cgroups when running Collector with host mount"
+
+# One or more tracking issues or pull requests related to the change
+issues: [6826]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/internal/cgroups/cgroups.go
+++ b/internal/cgroups/cgroups.go
@@ -104,7 +104,9 @@ func NewCGroups(procPathMountInfo, procPathCGroup string) (CGroups, error) {
 			if err != nil {
 				return err
 			}
-			cgroups[opt] = NewCGroup(cgroupPath)
+			if strings.HasPrefix(cgroupPath, "/sys") {
+				cgroups[opt] = NewCGroup(cgroupPath)
+			}
 		}
 
 		return nil

--- a/internal/cgroups/testdata/proc/cgroups/mountinfo
+++ b/internal/cgroups/testdata/proc/cgroups/mountinfo
@@ -6,3 +6,5 @@
 6 5 0:5 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime shared:6 - cgroup cgroup rw,cpuset
 7 5 0:6 /docker /sys/fs/cgroup/cpu,cpuacct rw,nosuid,nodev,noexec,relatime shared:7 - cgroup cgroup rw,cpu,cpuacct
 8 5 0:7 /docker /sys/fs/cgroup/memory rw,nosuid,nodev,noexec,relatime shared:8 - cgroup cgroup rw,memory
+9 1 0:8 / /var/lib/docker/overlay2/9054a95f2cf7296867089e1bd37931742a17eb3308a795d51adb2654ee2276df/merged/sys/fs/cgroup ro,nosuid,nodev,noexec,relatime - tmpfs tmpfs rw,mode=755
+10 9 0:9 /docker /var/lib/docker/overlay2/9054a95f2cf7296867089e1bd37931742a17eb3308a795d51adb2654ee2276df/merged/sys/fs/cgroup/memory ro,nosuid,nodev,noexec,relatime master:17 - cgroup cgroup rw,memory


### PR DESCRIPTION
https://github.com/open-telemetry/opentelemetry-collector/pull/6825 was accidentally merged and reverted, this PR reverts the revert commit -> open-telemetry/opentelemetry-collector#7142

There are more discussion in the original PR https://github.com/open-telemetry/opentelemetry-collector/pull/6825 

## Important (read before submitting)

**Description:** 

Fixing Memory limiter bug, when container mount's hosts sys filesystem, cgroups might incorrectly parse current container's memory.

The only way I figure we can fix this is to limit the search to `/sys` ? But I'm not sure if there are kernel's that would mount this in a different place?

**Link to tracking Issue:**  https://github.com/open-telemetry/opentelemetry-collector/issues/6826
and https://github.com/open-telemetry/opentelemetry-helm-charts/issues/543

**Testing:** 
- Added unit tests
-
**Documentation:** < Describe the documentation added.>

