### PR TITLE
{component,confmap}: make confmap.Unmarshal equivalent to component.UnmarshalConfig

### DIFF
--- a/component/config.go
+++ b/component/config.go
@@ -38,11 +38,8 @@ var configValidatorType = reflect.TypeOf((*ConfigValidator)(nil)).Elem()
 // UnmarshalConfig helper function to UnmarshalConfig a Config.
 // It checks if the config implements confmap.Unmarshaler and uses that if available,
 // otherwise uses Map.UnmarshalExact, erroring if a field is nonexistent.
+// Deprecated: Use conf.Unmarshal(&infoCfg, confmap.WithErrorUnused()) for the same result.
 func UnmarshalConfig(conf *confmap.Conf, intoCfg Config) error {
-	if cu, ok := intoCfg.(confmap.Unmarshaler); ok {
-		return cu.Unmarshal(conf)
-	}
-
 	return conf.Unmarshal(intoCfg, confmap.WithErrorUnused())
 }
 


### PR DESCRIPTION
This PR proposes a change which would make the two calls interchangeable. It uses a hacky way to intercept a circular call by keeping track of the calls themselves. 

This is a breaking change because `component.UnmarshalConfig` can no longer be called two times with the same `*confmap.Conf` and `component.Config` parameter. There is no such usage in the current repository (including contrib), but never the less worth mentioning.