### PR TITLE
remove go 1.18 support, bump minimum to go 1.19 and add testing for 1.20

### DIFF
--- a/.chloggen/go1-20.yaml
+++ b/.chloggen/go1-20.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: all
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove go 1.18 support, bump minimum to go 1.19 and add testing for 1.20
+
+# One or more tracking issues or pull requests related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/go1-20.yaml
+++ b/.chloggen/go1-20.yaml
@@ -8,7 +8,7 @@ component: all
 note: Remove go 1.18 support, bump minimum to go 1.19 and add testing for 1.20
 
 # One or more tracking issues or pull requests related to the change
-issues: []
+issues: [7151]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -109,7 +109,7 @@ jobs:
   unittest:
     strategy:
       matrix:
-        go-version: [1.19, 1.18]
+        go-version: [1.20, 1.19]
     runs-on: ubuntu-latest
     needs: [setup-environment]
     steps:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -109,7 +109,7 @@ jobs:
   unittest:
     strategy:
       matrix:
-        go-version: [1.20, 1.19]
+        go-version: ["1.20", 1.19] # 1.20 needs quotes otherwise it's interpreted as 1.2
     runs-on: ubuntu-latest
     needs: [setup-environment]
     steps:

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -59,7 +59,7 @@ fmt: $(GOIMPORTS)
 .PHONY: tidy
 tidy:
 	rm -fr go.sum
-	$(GOCMD) mod tidy -compat=1.18
+	$(GOCMD) mod tidy -compat=1.19
 
 .PHONY: lint
 lint: $(LINT)

--- a/cmd/builder/go.mod
+++ b/cmd/builder/go.mod
@@ -14,7 +14,7 @@
 
 module go.opentelemetry.io/collector/cmd/builder
 
-go 1.18
+go 1.19
 
 require (
 	github.com/knadh/koanf v1.5.0

--- a/cmd/builder/internal/builder/main.go
+++ b/cmd/builder/internal/builder/main.go
@@ -119,7 +119,7 @@ func GetModules(cfg Config) error {
 	}
 
 	// #nosec G204 -- cfg.Distribution.Go is trusted to be a safe path
-	cmd := exec.Command(cfg.Distribution.Go, "mod", "tidy", "-compat=1.18")
+	cmd := exec.Command(cfg.Distribution.Go, "mod", "tidy", "-compat=1.19")
 	cmd.Dir = cfg.Distribution.OutputPath
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("failed to update go.mod: %w. Output:\n%s", err, out)

--- a/cmd/builder/internal/builder/templates/go.mod.tmpl
+++ b/cmd/builder/internal/builder/templates/go.mod.tmpl
@@ -2,7 +2,7 @@
 
 module {{.Distribution.Module}}
 
-go 1.18
+go 1.19
 
 require (
 	{{- range .Connectors}}

--- a/cmd/otelcorecol/go.mod
+++ b/cmd/otelcorecol/go.mod
@@ -2,7 +2,7 @@
 
 module go.opentelemetry.io/collector/cmd/otelcorecol
 
-go 1.18
+go 1.19
 
 require (
 	github.com/stretchr/testify v1.8.1

--- a/component/go.mod
+++ b/component/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/component
 
-go 1.18
+go 1.19
 
 require (
 	github.com/stretchr/testify v1.8.1

--- a/confmap/go.mod
+++ b/confmap/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/confmap
 
-go 1.18
+go 1.19
 
 require (
 	github.com/knadh/koanf v1.5.0

--- a/connector/forwardconnector/go.mod
+++ b/connector/forwardconnector/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/connector/forwardconnector
 
-go 1.18
+go 1.19
 
 require (
 	github.com/stretchr/testify v1.8.1

--- a/consumer/go.mod
+++ b/consumer/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/consumer
 
-go 1.18
+go 1.19
 
 require (
 	github.com/stretchr/testify v1.8.1

--- a/exporter/loggingexporter/go.mod
+++ b/exporter/loggingexporter/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/exporter/loggingexporter
 
-go 1.18
+go 1.19
 
 require (
 	github.com/stretchr/testify v1.8.1

--- a/exporter/otlpexporter/go.mod
+++ b/exporter/otlpexporter/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/exporter/otlpexporter
 
-go 1.18
+go 1.19
 
 require (
 	github.com/stretchr/testify v1.8.1

--- a/exporter/otlphttpexporter/go.mod
+++ b/exporter/otlphttpexporter/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/exporter/otlphttpexporter
 
-go 1.18
+go 1.19
 
 require (
 	github.com/stretchr/testify v1.8.1

--- a/extension/ballastextension/go.mod
+++ b/extension/ballastextension/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/extension/ballastextension
 
-go 1.18
+go 1.19
 
 require (
 	github.com/stretchr/testify v1.8.1

--- a/extension/zpagesextension/go.mod
+++ b/extension/zpagesextension/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/extension/zpagesextension
 
-go 1.18
+go 1.19
 
 require (
 	github.com/stretchr/testify v1.8.1

--- a/featuregate/go.mod
+++ b/featuregate/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/featuregate
 
-go 1.18
+go 1.19
 
 require (
 	github.com/stretchr/testify v1.8.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector
 
-go 1.18
+go 1.19
 
 require (
 	contrib.go.opencensus.io/exporter/prometheus v0.4.2

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/internal/tools
 
-go 1.18
+go 1.19
 
 require (
 	github.com/client9/misspell v0.3.4

--- a/pdata/go.mod
+++ b/pdata/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/pdata
 
-go 1.18
+go 1.19
 
 require (
 	github.com/gogo/protobuf v1.3.2

--- a/processor/batchprocessor/go.mod
+++ b/processor/batchprocessor/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/processor/batchprocessor
 
-go 1.18
+go 1.19
 
 require (
 	contrib.go.opencensus.io/exporter/prometheus v0.4.2

--- a/processor/memorylimiterprocessor/go.mod
+++ b/processor/memorylimiterprocessor/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/processor/memorylimiterprocessor
 
-go 1.18
+go 1.19
 
 require (
 	github.com/stretchr/testify v1.8.1

--- a/receiver/otlpreceiver/go.mod
+++ b/receiver/otlpreceiver/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/receiver/otlpreceiver
 
-go 1.18
+go 1.19
 
 require (
 	github.com/gogo/protobuf v1.3.2

--- a/semconv/go.mod
+++ b/semconv/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/collector/semconv
 
-go 1.18
+go 1.19
 
 require github.com/stretchr/testify v1.8.1
 


### PR DESCRIPTION
Fixes #7159

Signed-off-by: Alex Boten <aboten@lightstep.com>
