### PR TITLE
Allow connectors to route data to specific consumers

### DIFF
--- a/.chloggen/connectors-routing.yaml
+++ b/.chloggen/connectors-routing.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: connectors
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Provide connectors with a mechanism to route data to specific pipelines
+
+# One or more tracking issues or pull requests related to the change
+issues: [7152]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/connector/connector.go
+++ b/connector/connector.go
@@ -22,6 +22,9 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/pdata/ptrace"
 )
 
 // A Traces connector acts as an exporter from a traces pipeline and a receiver
@@ -41,6 +44,12 @@ type Traces interface {
 	consumer.Traces
 }
 
+// TracesRouter feeds the first consumer.Traces in each of the specified pipelines.
+type TracesRouter interface {
+	consumer.Traces
+	RouteTraces(context.Context, ptrace.Traces, ...component.ID) error
+}
+
 // A Metrics connector acts as an exporter from a metrics pipeline and a receiver
 // to one or more traces, metrics, or logs pipelines.
 // Metrics feeds a consumer.Traces, consumer.Metrics, or consumer.Logs with data.
@@ -57,6 +66,12 @@ type Metrics interface {
 	consumer.Metrics
 }
 
+// MetricsRouter feeds the first consumer.Metrics in each of the specified pipelines.
+type MetricsRouter interface {
+	consumer.Metrics
+	RouteMetrics(context.Context, pmetric.Metrics, ...component.ID) error
+}
+
 // A Logs connector acts as an exporter from a logs pipeline and a receiver
 // to one or more traces, metrics, or logs pipelines.
 // Logs feeds a consumer.Traces, consumer.Metrics, or consumer.Logs with data.
@@ -70,6 +85,12 @@ type Metrics interface {
 type Logs interface {
 	component.Component
 	consumer.Logs
+}
+
+// LogsRouter feeds the first consumer.Logs in each of the specified pipelines.
+type LogsRouter interface {
+	consumer.Logs
+	RouteLogs(context.Context, plog.Logs, ...component.ID) error
 }
 
 // CreateSettings configures Connector creators.

--- a/service/graph.go
+++ b/service/graph.go
@@ -181,18 +181,24 @@ func (g *pipelinesGraph) buildComponents(ctx context.Context, set pipelinesSetti
 			n.Component, err = buildConnector(ctx, n.componentID, set.Telemetry, set.BuildInfo, set.ConnectorBuilder,
 				n.exprPipelineType, n.rcvrPipelineType, g.nextConsumers(n.ID()))
 		case *capabilitiesNode:
-			cap := consumer.Capabilities{}
+			cap := consumer.Capabilities{MutatesData: false}
 			for _, proc := range g.pipelines[n.pipelineID].processors {
 				cap.MutatesData = cap.MutatesData || proc.getConsumer().Capabilities().MutatesData
 			}
 			next := g.nextConsumers(n.ID())[0]
 			switch n.pipelineID.Type() {
 			case component.DataTypeTraces:
-				n.baseConsumer = capabilityconsumer.NewTraces(next.(consumer.Traces), cap)
+				cc := capabilityconsumer.NewTraces(next.(consumer.Traces), cap)
+				n.baseConsumer = cc
+				n.ConsumeTracesFunc = cc.ConsumeTraces
 			case component.DataTypeMetrics:
-				n.baseConsumer = capabilityconsumer.NewMetrics(next.(consumer.Metrics), cap)
+				cc := capabilityconsumer.NewMetrics(next.(consumer.Metrics), cap)
+				n.baseConsumer = cc
+				n.ConsumeMetricsFunc = cc.ConsumeMetrics
 			case component.DataTypeLogs:
-				n.baseConsumer = capabilityconsumer.NewLogs(next.(consumer.Logs), cap)
+				cc := capabilityconsumer.NewLogs(next.(consumer.Logs), cap)
+				n.baseConsumer = cc
+				n.ConsumeLogsFunc = cc.ConsumeLogs
 			}
 		case *fanOutNode:
 			nexts := g.nextConsumers(n.ID())

--- a/service/graph_test.go
+++ b/service/graph_test.go
@@ -813,6 +813,191 @@ func TestConnectorPipelinesGraph(t *testing.T) {
 	}
 }
 
+func TestConnectorRouter(t *testing.T) {
+	rcvrID := component.NewID("examplereceiver")
+	routeTracesID := component.NewIDWithName("examplerouter", "traces")
+	routeMetricsID := component.NewIDWithName("examplerouter", "metrics")
+	routeLogsID := component.NewIDWithName("examplerouter", "logs")
+	expRightID := component.NewIDWithName("exampleexporter", "right")
+	expLeftID := component.NewIDWithName("exampleexporter", "left")
+
+	tracesInID := component.NewIDWithName("traces", "in")
+	tracesRightID := component.NewIDWithName("traces", "right")
+	tracesLeftID := component.NewIDWithName("traces", "left")
+
+	metricsInID := component.NewIDWithName("metrics", "in")
+	metricsRightID := component.NewIDWithName("metrics", "right")
+	metricsLeftID := component.NewIDWithName("metrics", "left")
+
+	logsInID := component.NewIDWithName("logs", "in")
+	logsRightID := component.NewIDWithName("logs", "right")
+	logsLeftID := component.NewIDWithName("logs", "left")
+
+	ctx := context.Background()
+	set := pipelinesSettings{
+		Telemetry: componenttest.NewNopTelemetrySettings(),
+		BuildInfo: component.NewDefaultBuildInfo(),
+		ReceiverBuilder: receiver.NewBuilder(
+			map[component.ID]component.Config{
+				rcvrID: testcomponents.ExampleReceiverFactory.CreateDefaultConfig(),
+			},
+			map[component.Type]receiver.Factory{
+				testcomponents.ExampleReceiverFactory.Type(): testcomponents.ExampleReceiverFactory,
+			},
+		),
+		ExporterBuilder: exporter.NewBuilder(
+			map[component.ID]component.Config{
+				expRightID: testcomponents.ExampleExporterFactory.CreateDefaultConfig(),
+				expLeftID:  testcomponents.ExampleExporterFactory.CreateDefaultConfig(),
+			},
+			map[component.Type]exporter.Factory{
+				testcomponents.ExampleExporterFactory.Type(): testcomponents.ExampleExporterFactory,
+			},
+		),
+		ConnectorBuilder: connector.NewBuilder(
+			map[component.ID]component.Config{
+				routeTracesID: testcomponents.ExampleRouterConfig{
+					Traces: &testcomponents.LeftRightConfig{
+						Right: tracesRightID,
+						Left:  tracesLeftID,
+					},
+				},
+				routeMetricsID: testcomponents.ExampleRouterConfig{
+					Metrics: &testcomponents.LeftRightConfig{
+						Right: metricsRightID,
+						Left:  metricsLeftID,
+					},
+				},
+				routeLogsID: testcomponents.ExampleRouterConfig{
+					Logs: &testcomponents.LeftRightConfig{
+						Right: logsRightID,
+						Left:  logsLeftID,
+					},
+				},
+			},
+			map[component.Type]connector.Factory{
+				testcomponents.ExampleRouterFactory.Type(): testcomponents.ExampleRouterFactory,
+			},
+		),
+		PipelineConfigs: map[component.ID]*PipelineConfig{
+			tracesInID: {
+				Receivers: []component.ID{rcvrID},
+				Exporters: []component.ID{routeTracesID},
+			},
+			tracesRightID: {
+				Receivers: []component.ID{routeTracesID},
+				Exporters: []component.ID{expRightID},
+			},
+			tracesLeftID: {
+				Receivers: []component.ID{routeTracesID},
+				Exporters: []component.ID{expLeftID},
+			},
+			metricsInID: {
+				Receivers: []component.ID{rcvrID},
+				Exporters: []component.ID{routeMetricsID},
+			},
+			metricsRightID: {
+				Receivers: []component.ID{routeMetricsID},
+				Exporters: []component.ID{expRightID},
+			},
+			metricsLeftID: {
+				Receivers: []component.ID{routeMetricsID},
+				Exporters: []component.ID{expLeftID},
+			},
+			logsInID: {
+				Receivers: []component.ID{rcvrID},
+				Exporters: []component.ID{routeLogsID},
+			},
+			logsRightID: {
+				Receivers: []component.ID{routeLogsID},
+				Exporters: []component.ID{expRightID},
+			},
+			logsLeftID: {
+				Receivers: []component.ID{routeLogsID},
+				Exporters: []component.ID{expLeftID},
+			},
+		},
+	}
+
+	pipelinesInterface, err := buildPipelinesGraph(ctx, set)
+	require.NoError(t, err)
+
+	pg, ok := pipelinesInterface.(*pipelinesGraph)
+	require.True(t, ok)
+
+	allReceivers := pg.getReceivers()
+	allExporters := pg.GetExporters()
+
+	assert.Equal(t, len(set.PipelineConfigs), len(pg.pipelines))
+
+	// Get a handle for the traces receiver and both exporters
+	tracesReceiver := allReceivers[component.DataTypeTraces][rcvrID].(*testcomponents.ExampleReceiver)
+	tracesRight := allExporters[component.DataTypeTraces][expRightID].(*testcomponents.ExampleExporter)
+	tracesLeft := allExporters[component.DataTypeTraces][expLeftID].(*testcomponents.ExampleExporter)
+
+	// Consume 1, validate it went right
+	assert.NoError(t, tracesReceiver.ConsumeTraces(ctx, testdata.GenerateTraces(1)))
+	assert.Equal(t, 1, len(tracesRight.Traces))
+	assert.Equal(t, 0, len(tracesLeft.Traces))
+
+	// Consume 1, validate it went left
+	assert.NoError(t, tracesReceiver.ConsumeTraces(ctx, testdata.GenerateTraces(1)))
+	assert.Equal(t, 1, len(tracesRight.Traces))
+	assert.Equal(t, 1, len(tracesLeft.Traces))
+
+	// Consume 3, validate 2 went right, 1 went left
+	assert.NoError(t, tracesReceiver.ConsumeTraces(ctx, testdata.GenerateTraces(1)))
+	assert.NoError(t, tracesReceiver.ConsumeTraces(ctx, testdata.GenerateTraces(1)))
+	assert.NoError(t, tracesReceiver.ConsumeTraces(ctx, testdata.GenerateTraces(1)))
+	assert.Equal(t, 3, len(tracesRight.Traces))
+	assert.Equal(t, 2, len(tracesLeft.Traces))
+
+	// Get a handle for the metrics receiver and both exporters
+	metricsReceiver := allReceivers[component.DataTypeMetrics][rcvrID].(*testcomponents.ExampleReceiver)
+	metricsRight := allExporters[component.DataTypeMetrics][expRightID].(*testcomponents.ExampleExporter)
+	metricsLeft := allExporters[component.DataTypeMetrics][expLeftID].(*testcomponents.ExampleExporter)
+
+	// Consume 1, validate it went right
+	assert.NoError(t, metricsReceiver.ConsumeMetrics(ctx, testdata.GenerateMetrics(1)))
+	assert.Equal(t, 1, len(metricsRight.Metrics))
+	assert.Equal(t, 0, len(metricsLeft.Metrics))
+
+	// Consume 1, validate it went left
+	assert.NoError(t, metricsReceiver.ConsumeMetrics(ctx, testdata.GenerateMetrics(1)))
+	assert.Equal(t, 1, len(metricsRight.Metrics))
+	assert.Equal(t, 1, len(metricsLeft.Metrics))
+
+	// Consume 3, validate 2 went right, 1 went left
+	assert.NoError(t, metricsReceiver.ConsumeMetrics(ctx, testdata.GenerateMetrics(1)))
+	assert.NoError(t, metricsReceiver.ConsumeMetrics(ctx, testdata.GenerateMetrics(1)))
+	assert.NoError(t, metricsReceiver.ConsumeMetrics(ctx, testdata.GenerateMetrics(1)))
+	assert.Equal(t, 3, len(metricsRight.Metrics))
+	assert.Equal(t, 2, len(metricsLeft.Metrics))
+
+	// Get a handle for the logs receiver and both exporters
+	logsReceiver := allReceivers[component.DataTypeLogs][rcvrID].(*testcomponents.ExampleReceiver)
+	logsRight := allExporters[component.DataTypeLogs][expRightID].(*testcomponents.ExampleExporter)
+	logsLeft := allExporters[component.DataTypeLogs][expLeftID].(*testcomponents.ExampleExporter)
+
+	// Consume 1, validate it went right
+	assert.NoError(t, logsReceiver.ConsumeLogs(ctx, testdata.GenerateLogs(1)))
+	assert.Equal(t, 1, len(logsRight.Logs))
+	assert.Equal(t, 0, len(logsLeft.Logs))
+
+	// Consume 1, validate it went left
+	assert.NoError(t, logsReceiver.ConsumeLogs(ctx, testdata.GenerateLogs(1)))
+	assert.Equal(t, 1, len(logsRight.Logs))
+	assert.Equal(t, 1, len(logsLeft.Logs))
+
+	// Consume 3, validate 2 went right, 1 went left
+	assert.NoError(t, logsReceiver.ConsumeLogs(ctx, testdata.GenerateLogs(1)))
+	assert.NoError(t, logsReceiver.ConsumeLogs(ctx, testdata.GenerateLogs(1)))
+	assert.NoError(t, logsReceiver.ConsumeLogs(ctx, testdata.GenerateLogs(1)))
+	assert.Equal(t, 3, len(logsRight.Logs))
+	assert.Equal(t, 2, len(logsLeft.Logs))
+
+}
+
 func TestGraphBuildErrors(t *testing.T) {
 	nopReceiverFactory := receivertest.NewNopFactory()
 	nopProcessorFactory := processortest.NewNopFactory()

--- a/service/internal/fanoutconsumer/metrics_test.go
+++ b/service/internal/fanoutconsumer/metrics_test.go
@@ -17,13 +17,17 @@ package fanoutconsumer
 import (
 	"context"
 	"errors"
+	"fmt"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/internal/testdata"
+	"go.opentelemetry.io/collector/pdata/pmetric"
 )
 
 func TestMetricsNotMultiplexing(t *testing.T) {
@@ -192,4 +196,82 @@ type mutatingMetricsSink struct {
 
 func (mts *mutatingMetricsSink) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{MutatesData: true}
+}
+
+func TestMetricsRouterMultiplexing(t *testing.T) {
+	var max = 20
+	for numIDs := 0; numIDs < max; numIDs++ {
+		for numCons := 1; numCons < max; numCons++ {
+			for numMetrics := 1; numMetrics < max; numMetrics++ {
+				t.Run(
+					fmt.Sprintf("%d-ids/%d-cons/%d-logs", numIDs, numCons, numMetrics),
+					fuzzMetricsRouter(numIDs, numCons, numMetrics),
+				)
+			}
+		}
+	}
+}
+
+func fuzzMetricsRouter(numIDs, numCons, numMetrics int) func(*testing.T) {
+	return func(t *testing.T) {
+		allIDs := make([]component.ID, 0, numCons)
+		allCons := make([]consumer.Metrics, 0, numCons)
+		allConsMap := make(map[component.ID]consumer.Metrics)
+
+		// If any consumer is mutating, the router must report mutating
+		for i := 0; i < numCons; i++ {
+			allIDs = append(allIDs, component.NewIDWithName("sink", strconv.Itoa(numCons)))
+			// Random chance for each consumer to be mutating
+			if (numCons+numMetrics+i)%4 == 0 {
+				allCons = append(allCons, &mutatingMetricsSink{MetricsSink: new(consumertest.MetricsSink)})
+			} else {
+				allCons = append(allCons, new(consumertest.MetricsSink))
+			}
+			allConsMap[allIDs[i]] = allCons[i]
+		}
+
+		r := NewMetricsRouter(allConsMap)
+		assert.False(t, r.Capabilities().MutatesData)
+
+		md := testdata.GenerateMetrics(1)
+
+		// Keep track of how many logs each consumer should receive.
+		// This will be validated after every call to RouteMetrics.
+		expected := make(map[component.ID]int, numCons)
+
+		for i := 0; i < numMetrics; i++ {
+			// Build a random set of ids (no duplicates)
+			randCons := make(map[component.ID]bool, numIDs)
+			for j := 0; j < numIDs; j++ {
+				// This number should be pretty random and less than numCons
+				conNum := (numCons + numIDs + i + j) % numCons
+				randCons[allIDs[conNum]] = true
+			}
+
+			// Convert to slice, update expectations
+			conIDs := make([]component.ID, 0, len(randCons))
+			for id := range randCons {
+				conIDs = append(conIDs, id)
+				expected[id]++
+			}
+
+			// Route to list of consumers
+			assert.NoError(t, r.RouteMetrics(context.Background(), md, conIDs...))
+
+			// Validate expectations for all consumers
+			for id := range expected {
+				metrics := []pmetric.Metrics{}
+				switch con := allConsMap[id].(type) {
+				case *consumertest.MetricsSink:
+					metrics = con.AllMetrics()
+				case *mutatingMetricsSink:
+					metrics = con.AllMetrics()
+				}
+				assert.Len(t, metrics, expected[id])
+				for n := 0; n < len(metrics); n++ {
+					assert.EqualValues(t, md, metrics[n])
+				}
+			}
+		}
+	}
 }

--- a/service/internal/fanoutconsumer/traces_test.go
+++ b/service/internal/fanoutconsumer/traces_test.go
@@ -17,13 +17,17 @@ package fanoutconsumer
 import (
 	"context"
 	"errors"
+	"fmt"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/internal/testdata"
+	"go.opentelemetry.io/collector/pdata/ptrace"
 )
 
 func TestTracesNotMultiplexing(t *testing.T) {
@@ -192,4 +196,82 @@ type mutatingTracesSink struct {
 
 func (mts *mutatingTracesSink) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{MutatesData: true}
+}
+
+func TestTracesRouterMultiplexing(t *testing.T) {
+	var max = 20
+	for numIDs := 0; numIDs < max; numIDs++ {
+		for numCons := 1; numCons < max; numCons++ {
+			for numTraces := 1; numTraces < max; numTraces++ {
+				t.Run(
+					fmt.Sprintf("%d-ids/%d-cons/%d-logs", numIDs, numCons, numTraces),
+					fuzzTracesRouter(numIDs, numCons, numTraces),
+				)
+			}
+		}
+	}
+}
+
+func fuzzTracesRouter(numIDs, numCons, numTraces int) func(*testing.T) {
+	return func(t *testing.T) {
+		allIDs := make([]component.ID, 0, numCons)
+		allCons := make([]consumer.Traces, 0, numCons)
+		allConsMap := make(map[component.ID]consumer.Traces)
+
+		// If any consumer is mutating, the router must report mutating
+		for i := 0; i < numCons; i++ {
+			allIDs = append(allIDs, component.NewIDWithName("sink", strconv.Itoa(numCons)))
+			// Random chance for each consumer to be mutating
+			if (numCons+numTraces+i)%4 == 0 {
+				allCons = append(allCons, &mutatingTracesSink{TracesSink: new(consumertest.TracesSink)})
+			} else {
+				allCons = append(allCons, new(consumertest.TracesSink))
+			}
+			allConsMap[allIDs[i]] = allCons[i]
+		}
+
+		r := NewTracesRouter(allConsMap)
+		assert.False(t, r.Capabilities().MutatesData)
+
+		td := testdata.GenerateTraces(1)
+
+		// Keep track of how many logs each consumer should receive.
+		// This will be validated after every call to RouteTraces.
+		expected := make(map[component.ID]int, numCons)
+
+		for i := 0; i < numTraces; i++ {
+			// Build a random set of ids (no duplicates)
+			randCons := make(map[component.ID]bool, numIDs)
+			for j := 0; j < numIDs; j++ {
+				// This number should be pretty random and less than numCons
+				conNum := (numCons + numIDs + i + j) % numCons
+				randCons[allIDs[conNum]] = true
+			}
+
+			// Convert to slice, update expectations
+			conIDs := make([]component.ID, 0, len(randCons))
+			for id := range randCons {
+				conIDs = append(conIDs, id)
+				expected[id]++
+			}
+
+			// Route to list of consumers
+			assert.NoError(t, r.RouteTraces(context.Background(), td, conIDs...))
+
+			// Validate expectations for all consumers
+			for id := range expected {
+				traces := []ptrace.Traces{}
+				switch con := allConsMap[id].(type) {
+				case *consumertest.TracesSink:
+					traces = con.AllTraces()
+				case *mutatingTracesSink:
+					traces = con.AllTraces()
+				}
+				assert.Len(t, traces, expected[id])
+				for n := 0; n < len(traces); n++ {
+					assert.EqualValues(t, td, traces[n])
+				}
+			}
+		}
+	}
 }

--- a/service/internal/testcomponents/example_router.go
+++ b/service/internal/testcomponents/example_router.go
@@ -1,0 +1,126 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testcomponents // import "go.opentelemetry.io/collector/service/internal/testcomponents"
+
+import (
+	"context"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/connector"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+)
+
+const routerType = "examplerouter"
+
+// ExampleRouterFactory is factory for ExampleRouter.
+var ExampleRouterFactory = connector.NewFactory(
+	routerType,
+	createExampleRouterDefaultConfig,
+	connector.WithTracesToTraces(createExampleTracesRouter, component.StabilityLevelDevelopment),
+	connector.WithMetricsToMetrics(createExampleMetricsRouter, component.StabilityLevelDevelopment),
+	connector.WithLogsToLogs(createExampleLogsRouter, component.StabilityLevelDevelopment),
+)
+
+type LeftRightConfig struct {
+	Left  component.ID `mapstructure:"left"`
+	Right component.ID `mapstructure:"right"`
+}
+
+type ExampleRouterConfig struct {
+	Traces  *LeftRightConfig `mapstructure:"traces"`
+	Metrics *LeftRightConfig `mapstructure:"metrics"`
+	Logs    *LeftRightConfig `mapstructure:"logs"`
+}
+
+func createExampleRouterDefaultConfig() component.Config {
+	return &ExampleRouterConfig{}
+}
+
+func createExampleTracesRouter(_ context.Context, _ connector.CreateSettings, cfg component.Config, traces consumer.Traces) (connector.Traces, error) {
+	c := cfg.(ExampleRouterConfig)
+	return &ExampleRouter{
+		traces:      traces.(connector.TracesRouter),
+		tracesRight: c.Traces.Right,
+		tracesLeft:  c.Traces.Left,
+	}, nil
+}
+
+func createExampleMetricsRouter(_ context.Context, _ connector.CreateSettings, cfg component.Config, metrics consumer.Metrics) (connector.Metrics, error) {
+	c := cfg.(ExampleRouterConfig)
+	return &ExampleRouter{
+		metrics:      metrics.(connector.MetricsRouter),
+		metricsRight: c.Metrics.Right,
+		metricsLeft:  c.Metrics.Left,
+	}, nil
+}
+
+func createExampleLogsRouter(_ context.Context, _ connector.CreateSettings, cfg component.Config, logs consumer.Logs) (connector.Logs, error) {
+	c := cfg.(ExampleRouterConfig)
+	return &ExampleRouter{
+		logs:      logs.(connector.LogsRouter),
+		logsRight: c.Logs.Right,
+		logsLeft:  c.Logs.Left,
+	}, nil
+}
+
+type ExampleRouter struct {
+	componentState
+
+	traces      connector.TracesRouter
+	tracesRight component.ID
+	tracesLeft  component.ID
+	tracesNum   int
+
+	metrics      connector.MetricsRouter
+	metricsRight component.ID
+	metricsLeft  component.ID
+	metricsNum   int
+
+	logs      connector.LogsRouter
+	logsRight component.ID
+	logsLeft  component.ID
+	logsNum   int
+}
+
+func (r *ExampleRouter) ConsumeTraces(ctx context.Context, td ptrace.Traces) error {
+	r.tracesNum++
+	if r.tracesNum%2 == 0 {
+		return r.traces.RouteTraces(ctx, td, r.tracesLeft)
+	}
+	return r.traces.RouteTraces(ctx, td, r.tracesRight)
+}
+
+func (r *ExampleRouter) ConsumeMetrics(ctx context.Context, md pmetric.Metrics) error {
+	r.metricsNum++
+	if r.metricsNum%2 == 0 {
+		return r.metrics.RouteMetrics(ctx, md, r.metricsLeft)
+	}
+	return r.metrics.RouteMetrics(ctx, md, r.metricsRight)
+}
+
+func (r *ExampleRouter) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
+	r.logsNum++
+	if r.logsNum%2 == 0 {
+		return r.logs.RouteLogs(ctx, ld, r.logsLeft)
+	}
+	return r.logs.RouteLogs(ctx, ld, r.logsRight)
+}
+
+func (r *ExampleRouter) Capabilities() consumer.Capabilities {
+	return consumer.Capabilities{MutatesData: false}
+}

--- a/service/internal/testcomponents/example_router_test.go
+++ b/service/internal/testcomponents/example_router_test.go
@@ -1,0 +1,159 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testcomponents
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/connector/connectortest"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/internal/testdata"
+	"go.opentelemetry.io/collector/service/internal/fanoutconsumer"
+)
+
+func TestExampleRouter(t *testing.T) {
+	conn := &ExampleRouter{}
+	host := componenttest.NewNopHost()
+	assert.False(t, conn.Started())
+	assert.NoError(t, conn.Start(context.Background(), host))
+	assert.True(t, conn.Started())
+
+	assert.False(t, conn.Stopped())
+	assert.NoError(t, conn.Shutdown(context.Background()))
+	assert.True(t, conn.Stopped())
+}
+
+func TestTracesRouter(t *testing.T) {
+	leftID := component.NewIDWithName("sink", "left")
+	rightID := component.NewIDWithName("sink", "right")
+
+	sinkLeft := new(consumertest.TracesSink)
+	sinkRight := new(consumertest.TracesSink)
+
+	// The service will build a router to give to every connector.
+	// Many connectors will just call router.ConsumeTraces,
+	// but some implementation will call RouteTraces instead.
+	router := fanoutconsumer.NewTracesRouter(
+		map[component.ID]consumer.Traces{
+			leftID:  sinkLeft,
+			rightID: sinkRight,
+		})
+
+	cfg := ExampleRouterConfig{Traces: &LeftRightConfig{Left: leftID, Right: rightID}}
+	tr, err := ExampleRouterFactory.CreateTracesToTraces(
+		context.Background(), connectortest.NewNopCreateSettings(), cfg, router)
+	assert.NoError(t, err)
+	assert.False(t, tr.Capabilities().MutatesData)
+
+	td := testdata.GenerateTraces(1)
+
+	assert.NoError(t, tr.ConsumeTraces(context.Background(), td))
+	assert.Len(t, sinkRight.AllTraces(), 1)
+	assert.Len(t, sinkLeft.AllTraces(), 0)
+
+	assert.NoError(t, tr.ConsumeTraces(context.Background(), td))
+	assert.Len(t, sinkRight.AllTraces(), 1)
+	assert.Len(t, sinkLeft.AllTraces(), 1)
+
+	assert.NoError(t, tr.ConsumeTraces(context.Background(), td))
+	assert.NoError(t, tr.ConsumeTraces(context.Background(), td))
+	assert.NoError(t, tr.ConsumeTraces(context.Background(), td))
+	assert.Len(t, sinkRight.AllTraces(), 3)
+	assert.Len(t, sinkLeft.AllTraces(), 2)
+}
+
+func TestMetricsRouter(t *testing.T) {
+	leftID := component.NewIDWithName("sink", "left")
+	rightID := component.NewIDWithName("sink", "right")
+
+	sinkLeft := new(consumertest.MetricsSink)
+	sinkRight := new(consumertest.MetricsSink)
+
+	// The service will build a router to give to every connector.
+	// Many connectors will just call router.ConsumeMetrics,
+	// but some implementation will call RouteMetrics instead.
+	router := fanoutconsumer.NewMetricsRouter(
+		map[component.ID]consumer.Metrics{
+			leftID:  sinkLeft,
+			rightID: sinkRight,
+		})
+
+	cfg := ExampleRouterConfig{Metrics: &LeftRightConfig{Left: leftID, Right: rightID}}
+	mr, err := ExampleRouterFactory.CreateMetricsToMetrics(
+		context.Background(), connectortest.NewNopCreateSettings(), cfg, router)
+	assert.NoError(t, err)
+	assert.False(t, mr.Capabilities().MutatesData)
+
+	md := testdata.GenerateMetrics(1)
+
+	assert.NoError(t, mr.ConsumeMetrics(context.Background(), md))
+	assert.Len(t, sinkRight.AllMetrics(), 1)
+	assert.Len(t, sinkLeft.AllMetrics(), 0)
+
+	assert.NoError(t, mr.ConsumeMetrics(context.Background(), md))
+	assert.Len(t, sinkRight.AllMetrics(), 1)
+	assert.Len(t, sinkLeft.AllMetrics(), 1)
+
+	assert.NoError(t, mr.ConsumeMetrics(context.Background(), md))
+	assert.NoError(t, mr.ConsumeMetrics(context.Background(), md))
+	assert.NoError(t, mr.ConsumeMetrics(context.Background(), md))
+	assert.Len(t, sinkRight.AllMetrics(), 3)
+	assert.Len(t, sinkLeft.AllMetrics(), 2)
+}
+
+func TestLogsRouter(t *testing.T) {
+	leftID := component.NewIDWithName("sink", "left")
+	rightID := component.NewIDWithName("sink", "right")
+
+	sinkLeft := new(consumertest.LogsSink)
+	sinkRight := new(consumertest.LogsSink)
+
+	// The service will build a router to give to every connector.
+	// Many connectors will just call router.ConsumeLogs,
+	// but some implementation will call RouteLogs instead.
+	router := fanoutconsumer.NewLogsRouter(
+		map[component.ID]consumer.Logs{
+			leftID:  sinkLeft,
+			rightID: sinkRight,
+		})
+
+	cfg := ExampleRouterConfig{Logs: &LeftRightConfig{Left: leftID, Right: rightID}}
+	lr, err := ExampleRouterFactory.CreateLogsToLogs(
+		context.Background(), connectortest.NewNopCreateSettings(), cfg, router)
+	assert.NoError(t, err)
+	assert.False(t, lr.Capabilities().MutatesData)
+
+	ld := testdata.GenerateLogs(1)
+
+	assert.NoError(t, lr.ConsumeLogs(context.Background(), ld))
+	assert.Len(t, sinkRight.AllLogs(), 1)
+	assert.Len(t, sinkLeft.AllLogs(), 0)
+
+	assert.NoError(t, lr.ConsumeLogs(context.Background(), ld))
+	assert.Len(t, sinkRight.AllLogs(), 1)
+	assert.Len(t, sinkLeft.AllLogs(), 1)
+
+	assert.NoError(t, lr.ConsumeLogs(context.Background(), ld))
+	assert.NoError(t, lr.ConsumeLogs(context.Background(), ld))
+	assert.NoError(t, lr.ConsumeLogs(context.Background(), ld))
+	assert.Len(t, sinkRight.AllLogs(), 3)
+	assert.Len(t, sinkLeft.AllLogs(), 2)
+}


### PR DESCRIPTION
This is a proposed solution for #7147. 
- Adds `connector.<Type>Router` interface to extend `consumer.<Type>` with a `Route<Type>` method.
- Adds implementations of `connector.<Type>Router` in `service/internal/fanoutconsumer` 
  - `Route<Type>` methods build a fanout consumer every call. I think this likely needs to be more efficient, but can be addressed later if the overall design looks good.
- Getting the first consumer from a pipeline is a lot easier if the `capabilitiesNode` is a proper consumer, so I restored this, hopefully correctly this time.
- Adds an example router in `service/internal/testcomponents`. To simulate routing, it keeps a counter and uses parity to route one way or the other.
- Adds a test to `service/graph_test.go` that validates expected behavior of the example router.