### PR TITLE
 [pdata] [chore] Use extracted copyOrig instead of CopyTo on new objects

### DIFF
--- a/pdata/internal/cmd/pdatagen/internal/base_slices.go
+++ b/pdata/internal/cmd/pdatagen/internal/base_slices.go
@@ -215,22 +215,26 @@ func Test${structName}_RemoveIf(t *testing.T) {
 
 const slicePtrTemplate = `// CopyTo copies all elements from the current slice overriding the destination.
 func (es ${structName}) CopyTo(dest ${structName}) {
-	srcLen := es.Len()
-	destCap := cap(*dest.orig)
+	copyOrig${structName}(dest.orig, es.orig)
+}
+
+func copyOrig${structName}(dest, src *[]*${originName}) {
+	srcLen := len(*src)
+	destCap := cap(*dest)
 	if srcLen <= destCap {
-		(*dest.orig) = (*dest.orig)[:srcLen:destCap]
-		for i := range *es.orig {
-			new${elementName}((*es.orig)[i]).CopyTo(new${elementName}((*dest.orig)[i]))
+		*dest = (*dest)[:srcLen:destCap]
+		for i := range *src {
+			copyOrig${elementName}((*dest)[i], (*src)[i])
 		}
 		return
 	}
 	origs := make([]${originName}, srcLen)
 	wrappers := make([]*${originName}, srcLen)
-	for i := range *es.orig {
+	for i := range *src {
 		wrappers[i] = &origs[i]
-		new${elementName}((*es.orig)[i]).CopyTo(new${elementName}(wrappers[i]))
+		copyOrig${elementName}(wrappers[i], (*src)[i])
 	}
-	*dest.orig = wrappers
+	*dest = wrappers
 }
 
 // Sort sorts the ${elementName} elements within ${structName} given the
@@ -259,16 +263,20 @@ const slicePtrTestTemplate = `func Test${structName}_Sort(t *testing.T) {
 
 const sliceValueTemplate = `// CopyTo copies all elements from the current slice overriding the destination.
 func (es ${structName}) CopyTo(dest ${structName}) {
-	srcLen := es.Len()
-	destCap := cap(*dest.orig)
+	copyOrig${structName}(dest.orig, es.orig)
+}
+
+func copyOrig${structName}(dest, src *[]${originName}) {
+	srcLen := len(*src)
+	destCap := cap(*dest)
 	if srcLen <= destCap {
-		(*dest.orig) = (*dest.orig)[:srcLen:destCap]
+		*dest = (*dest)[:srcLen:destCap]
 	} else {
-		(*dest.orig) = make([]${originName}, srcLen)
+		*dest = make([]${originName}, srcLen)
 	}
 
-	for i := range *es.orig {
-		new${elementName}(&(*es.orig)[i]).CopyTo(new${elementName}(&(*dest.orig)[i]))
+	for i := range *src {
+		copyOrig${elementName}(&(*dest)[i], &(*src)[i])
 	}
 }`
 

--- a/pdata/internal/cmd/pdatagen/internal/primitive_slice_structs.go
+++ b/pdata/internal/cmd/pdatagen/internal/primitive_slice_structs.go
@@ -39,12 +39,12 @@ func New${structName}() ${structName} {
 
 // AsRaw returns a copy of the []${itemType} slice.
 func (ms ${structName}) AsRaw() []${itemType} {
-	return copy${structName}(nil, *ms.getOrig())
+	return internal.CopyOrig${structName}(nil, *ms.getOrig())
 }
 
 // FromRaw copies raw []${itemType} into the slice ${structName}.
 func (ms ${structName}) FromRaw(val []${itemType}) {
-	*ms.getOrig() = copy${structName}(*ms.getOrig(), val)
+	*ms.getOrig() = internal.CopyOrig${structName}(*ms.getOrig(), val)
 }
 
 // Len returns length of the []${itemType} slice value.
@@ -97,12 +97,7 @@ func (ms ${structName}) MoveTo(dest ${structName}) {
 
 // CopyTo copies all elements from the current slice overriding the destination.
 func (ms ${structName}) CopyTo(dest ${structName}) {
-	*dest.getOrig() = copy${structName}(*dest.getOrig(), *ms.getOrig())
-}
-
-func copy${structName}(dst, src []${itemType}) []${itemType} {
-	dst = dst[:0]
-	return append(dst, src...)
+	*dest.getOrig() = internal.CopyOrig${structName}(*dest.getOrig(), *ms.getOrig())
 }`
 
 const immutableSliceTestTemplate = `func TestNew${structName}(t *testing.T) {
@@ -163,6 +158,11 @@ func GetOrig${structName}(ms ${structName}) *[]${itemType} {
 
 func New${structName}(orig *[]${itemType}) ${structName} {
 	return ${structName}{orig: orig}
+}
+
+func CopyOrig${structName}(dst, src []${itemType}) []${itemType} {
+	dst = dst[:0]
+	return append(dst, src...)
 }`
 
 // primitiveSliceStruct generates a struct for a slice of primitive value elements. The structs are always generated

--- a/pdata/internal/generated_wrapper_byteslice.go
+++ b/pdata/internal/generated_wrapper_byteslice.go
@@ -28,3 +28,8 @@ func GetOrigByteSlice(ms ByteSlice) *[]byte {
 func NewByteSlice(orig *[]byte) ByteSlice {
 	return ByteSlice{orig: orig}
 }
+
+func CopyOrigByteSlice(dst, src []byte) []byte {
+	dst = dst[:0]
+	return append(dst, src...)
+}

--- a/pdata/internal/generated_wrapper_float64slice.go
+++ b/pdata/internal/generated_wrapper_float64slice.go
@@ -28,3 +28,8 @@ func GetOrigFloat64Slice(ms Float64Slice) *[]float64 {
 func NewFloat64Slice(orig *[]float64) Float64Slice {
 	return Float64Slice{orig: orig}
 }
+
+func CopyOrigFloat64Slice(dst, src []float64) []float64 {
+	dst = dst[:0]
+	return append(dst, src...)
+}

--- a/pdata/internal/generated_wrapper_instrumentationscope.go
+++ b/pdata/internal/generated_wrapper_instrumentationscope.go
@@ -33,6 +33,13 @@ func NewInstrumentationScope(orig *otlpcommon.InstrumentationScope) Instrumentat
 	return InstrumentationScope{orig: orig}
 }
 
+func CopyOrigInstrumentationScope(dest, src *otlpcommon.InstrumentationScope) {
+	dest.Name = src.Name
+	dest.Version = src.Version
+	CopyOrigMap(&dest.Attributes, &src.Attributes)
+	dest.DroppedAttributesCount = src.DroppedAttributesCount
+}
+
 func GenerateTestInstrumentationScope() InstrumentationScope {
 	orig := otlpcommon.InstrumentationScope{}
 	tv := NewInstrumentationScope(&orig)

--- a/pdata/internal/generated_wrapper_resource.go
+++ b/pdata/internal/generated_wrapper_resource.go
@@ -33,6 +33,11 @@ func NewResource(orig *otlpresource.Resource) Resource {
 	return Resource{orig: orig}
 }
 
+func CopyOrigResource(dest, src *otlpresource.Resource) {
+	CopyOrigMap(&dest.Attributes, &src.Attributes)
+	dest.DroppedAttributesCount = src.DroppedAttributesCount
+}
+
 func GenerateTestResource() Resource {
 	orig := otlpresource.Resource{}
 	tv := NewResource(&orig)

--- a/pdata/internal/generated_wrapper_uint64slice.go
+++ b/pdata/internal/generated_wrapper_uint64slice.go
@@ -28,3 +28,8 @@ func GetOrigUInt64Slice(ms UInt64Slice) *[]uint64 {
 func NewUInt64Slice(orig *[]uint64) UInt64Slice {
 	return UInt64Slice{orig: orig}
 }
+
+func CopyOrigUInt64Slice(dst, src []uint64) []uint64 {
+	dst = dst[:0]
+	return append(dst, src...)
+}

--- a/pdata/internal/wrapper_map.go
+++ b/pdata/internal/wrapper_map.go
@@ -30,6 +30,31 @@ func NewMap(orig *[]otlpcommon.KeyValue) Map {
 	return Map{orig: orig}
 }
 
+func CopyOrigMap(dst, src *[]otlpcommon.KeyValue) {
+	newLen := len(*src)
+	oldCap := cap(*dst)
+	if newLen <= oldCap {
+		// New slice fits in existing slice, no need to reallocate.
+		*dst = (*dst)[:newLen:oldCap]
+		for i := range *src {
+			akv := &(*src)[i]
+			destAkv := &(*dst)[i]
+			destAkv.Key = akv.Key
+			CopyOrigValue(&destAkv.Value, &akv.Value)
+		}
+		return
+	}
+
+	// New slice is bigger than exist slice. Allocate new space.
+	origs := make([]otlpcommon.KeyValue, len(*src))
+	for i := range *src {
+		akv := &(*src)[i]
+		origs[i].Key = akv.Key
+		CopyOrigValue(&origs[i].Value, &akv.Value)
+	}
+	*dst = origs
+}
+
 func GenerateTestMap() Map {
 	var orig []otlpcommon.KeyValue
 	ms := NewMap(&orig)

--- a/pdata/internal/wrapper_slice.go
+++ b/pdata/internal/wrapper_slice.go
@@ -30,6 +30,19 @@ func NewSlice(orig *[]otlpcommon.AnyValue) Slice {
 	return Slice{orig: orig}
 }
 
+func CopyOrigSlice(dst, src *[]otlpcommon.AnyValue) {
+	srcLen := len(*src)
+	destCap := cap(*dst)
+	if srcLen <= destCap {
+		*dst = (*dst)[:srcLen:destCap]
+	} else {
+		*dst = make([]otlpcommon.AnyValue, srcLen)
+	}
+	for i := range *src {
+		CopyOrigValue(&(*dst)[i], &(*src)[i])
+	}
+}
+
 func GenerateTestSlice() Slice {
 	orig := []otlpcommon.AnyValue{}
 	tv := NewSlice(&orig)

--- a/pdata/internal/wrapper_tracestate.go
+++ b/pdata/internal/wrapper_tracestate.go
@@ -26,6 +26,10 @@ func NewTraceState(orig *string) TraceState {
 	return TraceState{orig: orig}
 }
 
+func CopyOrigTraceState(dest, src *string) {
+	*dest = *src
+}
+
 func GenerateTestTraceState() TraceState {
 	var orig string
 	ms := NewTraceState(&orig)

--- a/pdata/internal/wrapper_value.go
+++ b/pdata/internal/wrapper_value.go
@@ -30,6 +30,46 @@ func NewValue(orig *otlpcommon.AnyValue) Value {
 	return Value{orig: orig}
 }
 
+func CopyOrigValue(dst, src *otlpcommon.AnyValue) {
+	switch ov := src.Value.(type) {
+	case *otlpcommon.AnyValue_KvlistValue:
+		kv, ok := dst.Value.(*otlpcommon.AnyValue_KvlistValue)
+		if !ok {
+			kv = &otlpcommon.AnyValue_KvlistValue{KvlistValue: &otlpcommon.KeyValueList{}}
+			dst.Value = kv
+		}
+		if ov.KvlistValue == nil {
+			kv.KvlistValue = nil
+			return
+		}
+		// Deep copy to dest.
+		CopyOrigMap(&kv.KvlistValue.Values, &ov.KvlistValue.Values)
+	case *otlpcommon.AnyValue_ArrayValue:
+		av, ok := dst.Value.(*otlpcommon.AnyValue_ArrayValue)
+		if !ok {
+			av = &otlpcommon.AnyValue_ArrayValue{ArrayValue: &otlpcommon.ArrayValue{}}
+			dst.Value = av
+		}
+		if ov.ArrayValue == nil {
+			av.ArrayValue = nil
+			return
+		}
+		// Deep copy to dest.
+		CopyOrigSlice(&av.ArrayValue.Values, &ov.ArrayValue.Values)
+	case *otlpcommon.AnyValue_BytesValue:
+		bv, ok := dst.Value.(*otlpcommon.AnyValue_BytesValue)
+		if !ok {
+			bv = &otlpcommon.AnyValue_BytesValue{}
+			dst.Value = bv
+		}
+		bv.BytesValue = make([]byte, len(ov.BytesValue))
+		copy(bv.BytesValue, ov.BytesValue)
+	default:
+		// Primitive immutable type, no need for deep copy.
+		dst.Value = ov
+	}
+}
+
 func FillTestValue(dest Value) {
 	dest.orig.Value = &otlpcommon.AnyValue_StringValue{StringValue: "v"}
 }

--- a/pdata/pcommon/generated_byteslice.go
+++ b/pdata/pcommon/generated_byteslice.go
@@ -40,12 +40,12 @@ func NewByteSlice() ByteSlice {
 
 // AsRaw returns a copy of the []byte slice.
 func (ms ByteSlice) AsRaw() []byte {
-	return copyByteSlice(nil, *ms.getOrig())
+	return internal.CopyOrigByteSlice(nil, *ms.getOrig())
 }
 
 // FromRaw copies raw []byte into the slice ByteSlice.
 func (ms ByteSlice) FromRaw(val []byte) {
-	*ms.getOrig() = copyByteSlice(*ms.getOrig(), val)
+	*ms.getOrig() = internal.CopyOrigByteSlice(*ms.getOrig(), val)
 }
 
 // Len returns length of the []byte slice value.
@@ -98,10 +98,5 @@ func (ms ByteSlice) MoveTo(dest ByteSlice) {
 
 // CopyTo copies all elements from the current slice overriding the destination.
 func (ms ByteSlice) CopyTo(dest ByteSlice) {
-	*dest.getOrig() = copyByteSlice(*dest.getOrig(), *ms.getOrig())
-}
-
-func copyByteSlice(dst, src []byte) []byte {
-	dst = dst[:0]
-	return append(dst, src...)
+	*dest.getOrig() = internal.CopyOrigByteSlice(*dest.getOrig(), *ms.getOrig())
 }

--- a/pdata/pcommon/generated_float64slice.go
+++ b/pdata/pcommon/generated_float64slice.go
@@ -40,12 +40,12 @@ func NewFloat64Slice() Float64Slice {
 
 // AsRaw returns a copy of the []float64 slice.
 func (ms Float64Slice) AsRaw() []float64 {
-	return copyFloat64Slice(nil, *ms.getOrig())
+	return internal.CopyOrigFloat64Slice(nil, *ms.getOrig())
 }
 
 // FromRaw copies raw []float64 into the slice Float64Slice.
 func (ms Float64Slice) FromRaw(val []float64) {
-	*ms.getOrig() = copyFloat64Slice(*ms.getOrig(), val)
+	*ms.getOrig() = internal.CopyOrigFloat64Slice(*ms.getOrig(), val)
 }
 
 // Len returns length of the []float64 slice value.
@@ -98,10 +98,5 @@ func (ms Float64Slice) MoveTo(dest Float64Slice) {
 
 // CopyTo copies all elements from the current slice overriding the destination.
 func (ms Float64Slice) CopyTo(dest Float64Slice) {
-	*dest.getOrig() = copyFloat64Slice(*dest.getOrig(), *ms.getOrig())
-}
-
-func copyFloat64Slice(dst, src []float64) []float64 {
-	dst = dst[:0]
-	return append(dst, src...)
+	*dest.getOrig() = internal.CopyOrigFloat64Slice(*dest.getOrig(), *ms.getOrig())
 }

--- a/pdata/pcommon/generated_instrumentationscope.go
+++ b/pdata/pcommon/generated_instrumentationscope.go
@@ -91,8 +91,5 @@ func (ms InstrumentationScope) SetDroppedAttributesCount(v uint32) {
 
 // CopyTo copies all properties from the current struct overriding the destination.
 func (ms InstrumentationScope) CopyTo(dest InstrumentationScope) {
-	dest.SetName(ms.Name())
-	dest.SetVersion(ms.Version())
-	ms.Attributes().CopyTo(dest.Attributes())
-	dest.SetDroppedAttributesCount(ms.DroppedAttributesCount())
+	internal.CopyOrigInstrumentationScope(dest.getOrig(), ms.getOrig())
 }

--- a/pdata/pcommon/generated_resource.go
+++ b/pdata/pcommon/generated_resource.go
@@ -71,6 +71,5 @@ func (ms Resource) SetDroppedAttributesCount(v uint32) {
 
 // CopyTo copies all properties from the current struct overriding the destination.
 func (ms Resource) CopyTo(dest Resource) {
-	ms.Attributes().CopyTo(dest.Attributes())
-	dest.SetDroppedAttributesCount(ms.DroppedAttributesCount())
+	internal.CopyOrigResource(dest.getOrig(), ms.getOrig())
 }

--- a/pdata/pcommon/generated_uint64slice.go
+++ b/pdata/pcommon/generated_uint64slice.go
@@ -40,12 +40,12 @@ func NewUInt64Slice() UInt64Slice {
 
 // AsRaw returns a copy of the []uint64 slice.
 func (ms UInt64Slice) AsRaw() []uint64 {
-	return copyUInt64Slice(nil, *ms.getOrig())
+	return internal.CopyOrigUInt64Slice(nil, *ms.getOrig())
 }
 
 // FromRaw copies raw []uint64 into the slice UInt64Slice.
 func (ms UInt64Slice) FromRaw(val []uint64) {
-	*ms.getOrig() = copyUInt64Slice(*ms.getOrig(), val)
+	*ms.getOrig() = internal.CopyOrigUInt64Slice(*ms.getOrig(), val)
 }
 
 // Len returns length of the []uint64 slice value.
@@ -98,10 +98,5 @@ func (ms UInt64Slice) MoveTo(dest UInt64Slice) {
 
 // CopyTo copies all elements from the current slice overriding the destination.
 func (ms UInt64Slice) CopyTo(dest UInt64Slice) {
-	*dest.getOrig() = copyUInt64Slice(*dest.getOrig(), *ms.getOrig())
-}
-
-func copyUInt64Slice(dst, src []uint64) []uint64 {
-	dst = dst[:0]
-	return append(dst, src...)
+	*dest.getOrig() = internal.CopyOrigUInt64Slice(*dest.getOrig(), *ms.getOrig())
 }

--- a/pdata/pcommon/map.go
+++ b/pdata/pcommon/map.go
@@ -218,28 +218,7 @@ func (m Map) Range(f func(k string, v Value) bool) {
 
 // CopyTo copies all elements from the current map overriding the destination.
 func (m Map) CopyTo(dest Map) {
-	newLen := len(*m.getOrig())
-	oldCap := cap(*dest.getOrig())
-	if newLen <= oldCap {
-		// New slice fits in existing slice, no need to reallocate.
-		*dest.getOrig() = (*dest.getOrig())[:newLen:oldCap]
-		for i := range *m.getOrig() {
-			akv := &(*m.getOrig())[i]
-			destAkv := &(*dest.getOrig())[i]
-			destAkv.Key = akv.Key
-			newValue(&akv.Value).CopyTo(newValue(&destAkv.Value))
-		}
-		return
-	}
-
-	// New slice is bigger than exist slice. Allocate new space.
-	origs := make([]otlpcommon.KeyValue, len(*m.getOrig()))
-	for i := range *m.getOrig() {
-		akv := &(*m.getOrig())[i]
-		origs[i].Key = akv.Key
-		newValue(&akv.Value).CopyTo(newValue(&origs[i].Value))
-	}
-	*dest.getOrig() = origs
+	internal.CopyOrigMap(dest.getOrig(), m.getOrig())
 }
 
 // AsRaw returns a standard go map representation of this Map.

--- a/pdata/pcommon/slice.go
+++ b/pdata/pcommon/slice.go
@@ -66,17 +66,7 @@ func (es Slice) At(ix int) Value {
 
 // CopyTo copies all elements from the current slice overriding the destination.
 func (es Slice) CopyTo(dest Slice) {
-	srcLen := es.Len()
-	destCap := cap(*dest.getOrig())
-	if srcLen <= destCap {
-		(*dest.getOrig()) = (*dest.getOrig())[:srcLen:destCap]
-	} else {
-		(*dest.getOrig()) = make([]otlpcommon.AnyValue, srcLen)
-	}
-
-	for i := range *es.getOrig() {
-		newValue(&(*es.getOrig())[i]).CopyTo(newValue(&(*dest.getOrig())[i]))
-	}
+	internal.CopyOrigSlice(dest.getOrig(), es.getOrig())
 }
 
 // EnsureCapacity is an operation that ensures the slice has at least the specified capacity.

--- a/pdata/pcommon/trace_state.go
+++ b/pdata/pcommon/trace_state.go
@@ -48,5 +48,5 @@ func (ms TraceState) MoveTo(dest TraceState) {
 
 // CopyTo copies the TraceState instance overriding the destination.
 func (ms TraceState) CopyTo(dest TraceState) {
-	*dest.getOrig() = *ms.getOrig()
+	internal.CopyOrigTraceState(dest.getOrig(), ms.getOrig())
 }

--- a/pdata/pcommon/value.go
+++ b/pdata/pcommon/value.go
@@ -318,44 +318,7 @@ func (v Value) SetEmptySlice() Slice {
 
 // CopyTo copies the Value instance overriding the destination.
 func (v Value) CopyTo(dest Value) {
-	destOrig := dest.getOrig()
-	switch ov := v.getOrig().Value.(type) {
-	case *otlpcommon.AnyValue_KvlistValue:
-		kv, ok := destOrig.Value.(*otlpcommon.AnyValue_KvlistValue)
-		if !ok {
-			kv = &otlpcommon.AnyValue_KvlistValue{KvlistValue: &otlpcommon.KeyValueList{}}
-			destOrig.Value = kv
-		}
-		if ov.KvlistValue == nil {
-			kv.KvlistValue = nil
-			return
-		}
-		// Deep copy to dest.
-		newMap(&ov.KvlistValue.Values).CopyTo(newMap(&kv.KvlistValue.Values))
-	case *otlpcommon.AnyValue_ArrayValue:
-		av, ok := destOrig.Value.(*otlpcommon.AnyValue_ArrayValue)
-		if !ok {
-			av = &otlpcommon.AnyValue_ArrayValue{ArrayValue: &otlpcommon.ArrayValue{}}
-			destOrig.Value = av
-		}
-		if ov.ArrayValue == nil {
-			av.ArrayValue = nil
-			return
-		}
-		// Deep copy to dest.
-		newSlice(&ov.ArrayValue.Values).CopyTo(newSlice(&av.ArrayValue.Values))
-	case *otlpcommon.AnyValue_BytesValue:
-		bv, ok := destOrig.Value.(*otlpcommon.AnyValue_BytesValue)
-		if !ok {
-			bv = &otlpcommon.AnyValue_BytesValue{}
-			destOrig.Value = bv
-		}
-		bv.BytesValue = make([]byte, len(ov.BytesValue))
-		copy(bv.BytesValue, ov.BytesValue)
-	default:
-		// Primitive immutable type, no need for deep copy.
-		destOrig.Value = ov
-	}
+	internal.CopyOrigValue(dest.getOrig(), v.getOrig())
 }
 
 // AsString converts an OTLP Value object of any type to its equivalent string

--- a/pdata/plog/generated_logrecord.go
+++ b/pdata/plog/generated_logrecord.go
@@ -146,14 +146,18 @@ func (ms LogRecord) SetDroppedAttributesCount(v uint32) {
 
 // CopyTo copies all properties from the current struct overriding the destination.
 func (ms LogRecord) CopyTo(dest LogRecord) {
-	dest.SetObservedTimestamp(ms.ObservedTimestamp())
-	dest.SetTimestamp(ms.Timestamp())
-	dest.SetTraceID(ms.TraceID())
-	dest.SetSpanID(ms.SpanID())
-	dest.SetFlags(ms.Flags())
-	dest.SetSeverityText(ms.SeverityText())
-	dest.SetSeverityNumber(ms.SeverityNumber())
-	ms.Body().CopyTo(dest.Body())
-	ms.Attributes().CopyTo(dest.Attributes())
-	dest.SetDroppedAttributesCount(ms.DroppedAttributesCount())
+	copyOrigLogRecord(dest.orig, ms.orig)
+}
+
+func copyOrigLogRecord(dest, src *otlplogs.LogRecord) {
+	dest.ObservedTimeUnixNano = src.ObservedTimeUnixNano
+	dest.TimeUnixNano = src.TimeUnixNano
+	dest.TraceId = src.TraceId
+	dest.SpanId = src.SpanId
+	dest.Flags = src.Flags
+	dest.SeverityText = src.SeverityText
+	dest.SeverityNumber = src.SeverityNumber
+	internal.CopyOrigValue(&dest.Body, &src.Body)
+	internal.CopyOrigMap(&dest.Attributes, &src.Attributes)
+	dest.DroppedAttributesCount = src.DroppedAttributesCount
 }

--- a/pdata/plog/generated_logrecordslice.go
+++ b/pdata/plog/generated_logrecordslice.go
@@ -128,22 +128,26 @@ func (es LogRecordSlice) RemoveIf(f func(LogRecord) bool) {
 
 // CopyTo copies all elements from the current slice overriding the destination.
 func (es LogRecordSlice) CopyTo(dest LogRecordSlice) {
-	srcLen := es.Len()
-	destCap := cap(*dest.orig)
+	copyOrigLogRecordSlice(dest.orig, es.orig)
+}
+
+func copyOrigLogRecordSlice(dest, src *[]*otlplogs.LogRecord) {
+	srcLen := len(*src)
+	destCap := cap(*dest)
 	if srcLen <= destCap {
-		(*dest.orig) = (*dest.orig)[:srcLen:destCap]
-		for i := range *es.orig {
-			newLogRecord((*es.orig)[i]).CopyTo(newLogRecord((*dest.orig)[i]))
+		*dest = (*dest)[:srcLen:destCap]
+		for i := range *src {
+			copyOrigLogRecord((*dest)[i], (*src)[i])
 		}
 		return
 	}
 	origs := make([]otlplogs.LogRecord, srcLen)
 	wrappers := make([]*otlplogs.LogRecord, srcLen)
-	for i := range *es.orig {
+	for i := range *src {
 		wrappers[i] = &origs[i]
-		newLogRecord((*es.orig)[i]).CopyTo(newLogRecord(wrappers[i]))
+		copyOrigLogRecord(wrappers[i], (*src)[i])
 	}
-	*dest.orig = wrappers
+	*dest = wrappers
 }
 
 // Sort sorts the LogRecord elements within LogRecordSlice given the

--- a/pdata/plog/generated_resourcelogs.go
+++ b/pdata/plog/generated_resourcelogs.go
@@ -75,7 +75,11 @@ func (ms ResourceLogs) ScopeLogs() ScopeLogsSlice {
 
 // CopyTo copies all properties from the current struct overriding the destination.
 func (ms ResourceLogs) CopyTo(dest ResourceLogs) {
-	ms.Resource().CopyTo(dest.Resource())
-	dest.SetSchemaUrl(ms.SchemaUrl())
-	ms.ScopeLogs().CopyTo(dest.ScopeLogs())
+	copyOrigResourceLogs(dest.orig, ms.orig)
+}
+
+func copyOrigResourceLogs(dest, src *otlplogs.ResourceLogs) {
+	internal.CopyOrigResource(&dest.Resource, &src.Resource)
+	dest.SchemaUrl = src.SchemaUrl
+	copyOrigScopeLogsSlice(&dest.ScopeLogs, &src.ScopeLogs)
 }

--- a/pdata/plog/generated_resourcelogsslice.go
+++ b/pdata/plog/generated_resourcelogsslice.go
@@ -128,22 +128,26 @@ func (es ResourceLogsSlice) RemoveIf(f func(ResourceLogs) bool) {
 
 // CopyTo copies all elements from the current slice overriding the destination.
 func (es ResourceLogsSlice) CopyTo(dest ResourceLogsSlice) {
-	srcLen := es.Len()
-	destCap := cap(*dest.orig)
+	copyOrigResourceLogsSlice(dest.orig, es.orig)
+}
+
+func copyOrigResourceLogsSlice(dest, src *[]*otlplogs.ResourceLogs) {
+	srcLen := len(*src)
+	destCap := cap(*dest)
 	if srcLen <= destCap {
-		(*dest.orig) = (*dest.orig)[:srcLen:destCap]
-		for i := range *es.orig {
-			newResourceLogs((*es.orig)[i]).CopyTo(newResourceLogs((*dest.orig)[i]))
+		*dest = (*dest)[:srcLen:destCap]
+		for i := range *src {
+			copyOrigResourceLogs((*dest)[i], (*src)[i])
 		}
 		return
 	}
 	origs := make([]otlplogs.ResourceLogs, srcLen)
 	wrappers := make([]*otlplogs.ResourceLogs, srcLen)
-	for i := range *es.orig {
+	for i := range *src {
 		wrappers[i] = &origs[i]
-		newResourceLogs((*es.orig)[i]).CopyTo(newResourceLogs(wrappers[i]))
+		copyOrigResourceLogs(wrappers[i], (*src)[i])
 	}
-	*dest.orig = wrappers
+	*dest = wrappers
 }
 
 // Sort sorts the ResourceLogs elements within ResourceLogsSlice given the

--- a/pdata/plog/generated_scopelogs.go
+++ b/pdata/plog/generated_scopelogs.go
@@ -75,7 +75,11 @@ func (ms ScopeLogs) LogRecords() LogRecordSlice {
 
 // CopyTo copies all properties from the current struct overriding the destination.
 func (ms ScopeLogs) CopyTo(dest ScopeLogs) {
-	ms.Scope().CopyTo(dest.Scope())
-	dest.SetSchemaUrl(ms.SchemaUrl())
-	ms.LogRecords().CopyTo(dest.LogRecords())
+	copyOrigScopeLogs(dest.orig, ms.orig)
+}
+
+func copyOrigScopeLogs(dest, src *otlplogs.ScopeLogs) {
+	internal.CopyOrigInstrumentationScope(&dest.Scope, &src.Scope)
+	dest.SchemaUrl = src.SchemaUrl
+	copyOrigLogRecordSlice(&dest.LogRecords, &src.LogRecords)
 }

--- a/pdata/plog/generated_scopelogsslice.go
+++ b/pdata/plog/generated_scopelogsslice.go
@@ -128,22 +128,26 @@ func (es ScopeLogsSlice) RemoveIf(f func(ScopeLogs) bool) {
 
 // CopyTo copies all elements from the current slice overriding the destination.
 func (es ScopeLogsSlice) CopyTo(dest ScopeLogsSlice) {
-	srcLen := es.Len()
-	destCap := cap(*dest.orig)
+	copyOrigScopeLogsSlice(dest.orig, es.orig)
+}
+
+func copyOrigScopeLogsSlice(dest, src *[]*otlplogs.ScopeLogs) {
+	srcLen := len(*src)
+	destCap := cap(*dest)
 	if srcLen <= destCap {
-		(*dest.orig) = (*dest.orig)[:srcLen:destCap]
-		for i := range *es.orig {
-			newScopeLogs((*es.orig)[i]).CopyTo(newScopeLogs((*dest.orig)[i]))
+		*dest = (*dest)[:srcLen:destCap]
+		for i := range *src {
+			copyOrigScopeLogs((*dest)[i], (*src)[i])
 		}
 		return
 	}
 	origs := make([]otlplogs.ScopeLogs, srcLen)
 	wrappers := make([]*otlplogs.ScopeLogs, srcLen)
-	for i := range *es.orig {
+	for i := range *src {
 		wrappers[i] = &origs[i]
-		newScopeLogs((*es.orig)[i]).CopyTo(newScopeLogs(wrappers[i]))
+		copyOrigScopeLogs(wrappers[i], (*src)[i])
 	}
-	*dest.orig = wrappers
+	*dest = wrappers
 }
 
 // Sort sorts the ScopeLogs elements within ScopeLogsSlice given the

--- a/pdata/plog/logs.go
+++ b/pdata/plog/logs.go
@@ -38,7 +38,7 @@ func NewLogs() Logs {
 
 // CopyTo copies the Logs instance overriding the destination.
 func (ms Logs) CopyTo(dest Logs) {
-	ms.ResourceLogs().CopyTo(dest.ResourceLogs())
+	copyOrigResourceLogsSlice(dest.ResourceLogs().orig, ms.ResourceLogs().orig)
 }
 
 // LogRecordCount calculates the total number of log records.

--- a/pdata/plog/logs_test.go
+++ b/pdata/plog/logs_test.go
@@ -123,3 +123,24 @@ func TestLogsCopyTo(t *testing.T) {
 	logs.CopyTo(logsCopy)
 	assert.EqualValues(t, logs, logsCopy)
 }
+
+func BenchmarkLogsCopyTo(b *testing.B) {
+	logs := NewLogs()
+	fillTestResourceLogsSlice(logs.ResourceLogs())
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		logs.CopyTo(NewLogs())
+	}
+}
+
+func BenchmarkLogsCopyToReuseDest(b *testing.B) {
+	logs := NewLogs()
+	fillTestResourceLogsSlice(logs.ResourceLogs())
+	dest := NewLogs()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		logs.CopyTo(dest)
+	}
+}

--- a/pdata/plog/plogotlp/generated_exportpartialsuccess.go
+++ b/pdata/plog/plogotlp/generated_exportpartialsuccess.go
@@ -73,6 +73,10 @@ func (ms ExportPartialSuccess) SetErrorMessage(v string) {
 
 // CopyTo copies all properties from the current struct overriding the destination.
 func (ms ExportPartialSuccess) CopyTo(dest ExportPartialSuccess) {
-	dest.SetRejectedLogRecords(ms.RejectedLogRecords())
-	dest.SetErrorMessage(ms.ErrorMessage())
+	copyOrigExportPartialSuccess(dest.orig, ms.orig)
+}
+
+func copyOrigExportPartialSuccess(dest, src *otlpcollectorlog.ExportLogsPartialSuccess) {
+	dest.RejectedLogRecords = src.RejectedLogRecords
+	dest.ErrorMessage = src.ErrorMessage
 }

--- a/pdata/pmetric/generated_exemplar.go
+++ b/pdata/pmetric/generated_exemplar.go
@@ -130,15 +130,18 @@ func (ms Exemplar) SetSpanID(v pcommon.SpanID) {
 
 // CopyTo copies all properties from the current struct overriding the destination.
 func (ms Exemplar) CopyTo(dest Exemplar) {
-	dest.SetTimestamp(ms.Timestamp())
-	switch ms.ValueType() {
-	case ExemplarValueTypeDouble:
-		dest.SetDoubleValue(ms.DoubleValue())
-	case ExemplarValueTypeInt:
-		dest.SetIntValue(ms.IntValue())
-	}
+	copyOrigExemplar(dest.orig, ms.orig)
+}
 
-	ms.FilteredAttributes().CopyTo(dest.FilteredAttributes())
-	dest.SetTraceID(ms.TraceID())
-	dest.SetSpanID(ms.SpanID())
+func copyOrigExemplar(dest, src *otlpmetrics.Exemplar) {
+	dest.TimeUnixNano = src.TimeUnixNano
+	switch v := src.Value.(type) {
+	case *otlpmetrics.Exemplar_AsDouble:
+		dest.Value = &otlpmetrics.Exemplar_AsDouble{AsDouble: v.AsDouble}
+	case *otlpmetrics.Exemplar_AsInt:
+		dest.Value = &otlpmetrics.Exemplar_AsInt{AsInt: v.AsInt}
+	}
+	internal.CopyOrigMap(&dest.FilteredAttributes, &src.FilteredAttributes)
+	dest.TraceId = src.TraceId
+	dest.SpanId = src.SpanId
 }

--- a/pdata/pmetric/generated_exemplarslice.go
+++ b/pdata/pmetric/generated_exemplarslice.go
@@ -126,15 +126,19 @@ func (es ExemplarSlice) RemoveIf(f func(Exemplar) bool) {
 
 // CopyTo copies all elements from the current slice overriding the destination.
 func (es ExemplarSlice) CopyTo(dest ExemplarSlice) {
-	srcLen := es.Len()
-	destCap := cap(*dest.orig)
+	copyOrigExemplarSlice(dest.orig, es.orig)
+}
+
+func copyOrigExemplarSlice(dest, src *[]otlpmetrics.Exemplar) {
+	srcLen := len(*src)
+	destCap := cap(*dest)
 	if srcLen <= destCap {
-		(*dest.orig) = (*dest.orig)[:srcLen:destCap]
+		*dest = (*dest)[:srcLen:destCap]
 	} else {
-		(*dest.orig) = make([]otlpmetrics.Exemplar, srcLen)
+		*dest = make([]otlpmetrics.Exemplar, srcLen)
 	}
 
-	for i := range *es.orig {
-		newExemplar(&(*es.orig)[i]).CopyTo(newExemplar(&(*dest.orig)[i]))
+	for i := range *src {
+		copyOrigExemplar(&(*dest)[i], &(*src)[i])
 	}
 }

--- a/pdata/pmetric/generated_exponentialhistogram.go
+++ b/pdata/pmetric/generated_exponentialhistogram.go
@@ -69,6 +69,10 @@ func (ms ExponentialHistogram) DataPoints() ExponentialHistogramDataPointSlice {
 
 // CopyTo copies all properties from the current struct overriding the destination.
 func (ms ExponentialHistogram) CopyTo(dest ExponentialHistogram) {
-	dest.SetAggregationTemporality(ms.AggregationTemporality())
-	ms.DataPoints().CopyTo(dest.DataPoints())
+	copyOrigExponentialHistogram(dest.orig, ms.orig)
+}
+
+func copyOrigExponentialHistogram(dest, src *otlpmetrics.ExponentialHistogram) {
+	dest.AggregationTemporality = src.AggregationTemporality
+	copyOrigExponentialHistogramDataPointSlice(&dest.DataPoints, &src.DataPoints)
 }

--- a/pdata/pmetric/generated_exponentialhistogramdatapoint.go
+++ b/pdata/pmetric/generated_exponentialhistogramdatapoint.go
@@ -201,26 +201,27 @@ func (ms ExponentialHistogramDataPoint) RemoveMax() {
 
 // CopyTo copies all properties from the current struct overriding the destination.
 func (ms ExponentialHistogramDataPoint) CopyTo(dest ExponentialHistogramDataPoint) {
-	ms.Attributes().CopyTo(dest.Attributes())
-	dest.SetStartTimestamp(ms.StartTimestamp())
-	dest.SetTimestamp(ms.Timestamp())
-	dest.SetCount(ms.Count())
-	if ms.HasSum() {
-		dest.SetSum(ms.Sum())
-	}
+	copyOrigExponentialHistogramDataPoint(dest.orig, ms.orig)
+}
 
-	dest.SetScale(ms.Scale())
-	dest.SetZeroCount(ms.ZeroCount())
-	ms.Positive().CopyTo(dest.Positive())
-	ms.Negative().CopyTo(dest.Negative())
-	ms.Exemplars().CopyTo(dest.Exemplars())
-	dest.SetFlags(ms.Flags())
-	if ms.HasMin() {
-		dest.SetMin(ms.Min())
+func copyOrigExponentialHistogramDataPoint(dest, src *otlpmetrics.ExponentialHistogramDataPoint) {
+	internal.CopyOrigMap(&dest.Attributes, &src.Attributes)
+	dest.StartTimeUnixNano = src.StartTimeUnixNano
+	dest.TimeUnixNano = src.TimeUnixNano
+	dest.Count = src.Count
+	if src.Sum_ != nil {
+		dest.Sum_ = &otlpmetrics.ExponentialHistogramDataPoint_Sum{Sum: src.GetSum()}
 	}
-
-	if ms.HasMax() {
-		dest.SetMax(ms.Max())
+	dest.Scale = src.Scale
+	dest.ZeroCount = src.ZeroCount
+	copyOrigExponentialHistogramDataPointBuckets(&dest.Positive, &src.Positive)
+	copyOrigExponentialHistogramDataPointBuckets(&dest.Negative, &src.Negative)
+	copyOrigExemplarSlice(&dest.Exemplars, &src.Exemplars)
+	dest.Flags = src.Flags
+	if src.Min_ != nil {
+		dest.Min_ = &otlpmetrics.ExponentialHistogramDataPoint_Min{Min: src.GetMin()}
 	}
-
+	if src.Max_ != nil {
+		dest.Max_ = &otlpmetrics.ExponentialHistogramDataPoint_Max{Max: src.GetMax()}
+	}
 }

--- a/pdata/pmetric/generated_exponentialhistogramdatapointbuckets.go
+++ b/pdata/pmetric/generated_exponentialhistogramdatapointbuckets.go
@@ -70,6 +70,10 @@ func (ms ExponentialHistogramDataPointBuckets) BucketCounts() pcommon.UInt64Slic
 
 // CopyTo copies all properties from the current struct overriding the destination.
 func (ms ExponentialHistogramDataPointBuckets) CopyTo(dest ExponentialHistogramDataPointBuckets) {
-	dest.SetOffset(ms.Offset())
-	ms.BucketCounts().CopyTo(dest.BucketCounts())
+	copyOrigExponentialHistogramDataPointBuckets(dest.orig, ms.orig)
+}
+
+func copyOrigExponentialHistogramDataPointBuckets(dest, src *otlpmetrics.ExponentialHistogramDataPoint_Buckets) {
+	dest.Offset = src.Offset
+	dest.BucketCounts = internal.CopyOrigUInt64Slice(dest.BucketCounts, src.BucketCounts)
 }

--- a/pdata/pmetric/generated_exponentialhistogramdatapointslice.go
+++ b/pdata/pmetric/generated_exponentialhistogramdatapointslice.go
@@ -128,22 +128,26 @@ func (es ExponentialHistogramDataPointSlice) RemoveIf(f func(ExponentialHistogra
 
 // CopyTo copies all elements from the current slice overriding the destination.
 func (es ExponentialHistogramDataPointSlice) CopyTo(dest ExponentialHistogramDataPointSlice) {
-	srcLen := es.Len()
-	destCap := cap(*dest.orig)
+	copyOrigExponentialHistogramDataPointSlice(dest.orig, es.orig)
+}
+
+func copyOrigExponentialHistogramDataPointSlice(dest, src *[]*otlpmetrics.ExponentialHistogramDataPoint) {
+	srcLen := len(*src)
+	destCap := cap(*dest)
 	if srcLen <= destCap {
-		(*dest.orig) = (*dest.orig)[:srcLen:destCap]
-		for i := range *es.orig {
-			newExponentialHistogramDataPoint((*es.orig)[i]).CopyTo(newExponentialHistogramDataPoint((*dest.orig)[i]))
+		*dest = (*dest)[:srcLen:destCap]
+		for i := range *src {
+			copyOrigExponentialHistogramDataPoint((*dest)[i], (*src)[i])
 		}
 		return
 	}
 	origs := make([]otlpmetrics.ExponentialHistogramDataPoint, srcLen)
 	wrappers := make([]*otlpmetrics.ExponentialHistogramDataPoint, srcLen)
-	for i := range *es.orig {
+	for i := range *src {
 		wrappers[i] = &origs[i]
-		newExponentialHistogramDataPoint((*es.orig)[i]).CopyTo(newExponentialHistogramDataPoint(wrappers[i]))
+		copyOrigExponentialHistogramDataPoint(wrappers[i], (*src)[i])
 	}
-	*dest.orig = wrappers
+	*dest = wrappers
 }
 
 // Sort sorts the ExponentialHistogramDataPoint elements within ExponentialHistogramDataPointSlice given the

--- a/pdata/pmetric/generated_gauge.go
+++ b/pdata/pmetric/generated_gauge.go
@@ -58,5 +58,9 @@ func (ms Gauge) DataPoints() NumberDataPointSlice {
 
 // CopyTo copies all properties from the current struct overriding the destination.
 func (ms Gauge) CopyTo(dest Gauge) {
-	ms.DataPoints().CopyTo(dest.DataPoints())
+	copyOrigGauge(dest.orig, ms.orig)
+}
+
+func copyOrigGauge(dest, src *otlpmetrics.Gauge) {
+	copyOrigNumberDataPointSlice(&dest.DataPoints, &src.DataPoints)
 }

--- a/pdata/pmetric/generated_histogram.go
+++ b/pdata/pmetric/generated_histogram.go
@@ -68,6 +68,10 @@ func (ms Histogram) DataPoints() HistogramDataPointSlice {
 
 // CopyTo copies all properties from the current struct overriding the destination.
 func (ms Histogram) CopyTo(dest Histogram) {
-	dest.SetAggregationTemporality(ms.AggregationTemporality())
-	ms.DataPoints().CopyTo(dest.DataPoints())
+	copyOrigHistogram(dest.orig, ms.orig)
+}
+
+func copyOrigHistogram(dest, src *otlpmetrics.Histogram) {
+	dest.AggregationTemporality = src.AggregationTemporality
+	copyOrigHistogramDataPointSlice(&dest.DataPoints, &src.DataPoints)
 }

--- a/pdata/pmetric/generated_histogramdatapoint.go
+++ b/pdata/pmetric/generated_histogramdatapoint.go
@@ -178,24 +178,25 @@ func (ms HistogramDataPoint) RemoveMax() {
 
 // CopyTo copies all properties from the current struct overriding the destination.
 func (ms HistogramDataPoint) CopyTo(dest HistogramDataPoint) {
-	ms.Attributes().CopyTo(dest.Attributes())
-	dest.SetStartTimestamp(ms.StartTimestamp())
-	dest.SetTimestamp(ms.Timestamp())
-	dest.SetCount(ms.Count())
-	if ms.HasSum() {
-		dest.SetSum(ms.Sum())
-	}
+	copyOrigHistogramDataPoint(dest.orig, ms.orig)
+}
 
-	ms.BucketCounts().CopyTo(dest.BucketCounts())
-	ms.ExplicitBounds().CopyTo(dest.ExplicitBounds())
-	ms.Exemplars().CopyTo(dest.Exemplars())
-	dest.SetFlags(ms.Flags())
-	if ms.HasMin() {
-		dest.SetMin(ms.Min())
+func copyOrigHistogramDataPoint(dest, src *otlpmetrics.HistogramDataPoint) {
+	internal.CopyOrigMap(&dest.Attributes, &src.Attributes)
+	dest.StartTimeUnixNano = src.StartTimeUnixNano
+	dest.TimeUnixNano = src.TimeUnixNano
+	dest.Count = src.Count
+	if src.Sum_ != nil {
+		dest.Sum_ = &otlpmetrics.HistogramDataPoint_Sum{Sum: src.GetSum()}
 	}
-
-	if ms.HasMax() {
-		dest.SetMax(ms.Max())
+	dest.BucketCounts = internal.CopyOrigUInt64Slice(dest.BucketCounts, src.BucketCounts)
+	dest.ExplicitBounds = internal.CopyOrigFloat64Slice(dest.ExplicitBounds, src.ExplicitBounds)
+	copyOrigExemplarSlice(&dest.Exemplars, &src.Exemplars)
+	dest.Flags = src.Flags
+	if src.Min_ != nil {
+		dest.Min_ = &otlpmetrics.HistogramDataPoint_Min{Min: src.GetMin()}
 	}
-
+	if src.Max_ != nil {
+		dest.Max_ = &otlpmetrics.HistogramDataPoint_Max{Max: src.GetMax()}
+	}
 }

--- a/pdata/pmetric/generated_histogramdatapointslice.go
+++ b/pdata/pmetric/generated_histogramdatapointslice.go
@@ -128,22 +128,26 @@ func (es HistogramDataPointSlice) RemoveIf(f func(HistogramDataPoint) bool) {
 
 // CopyTo copies all elements from the current slice overriding the destination.
 func (es HistogramDataPointSlice) CopyTo(dest HistogramDataPointSlice) {
-	srcLen := es.Len()
-	destCap := cap(*dest.orig)
+	copyOrigHistogramDataPointSlice(dest.orig, es.orig)
+}
+
+func copyOrigHistogramDataPointSlice(dest, src *[]*otlpmetrics.HistogramDataPoint) {
+	srcLen := len(*src)
+	destCap := cap(*dest)
 	if srcLen <= destCap {
-		(*dest.orig) = (*dest.orig)[:srcLen:destCap]
-		for i := range *es.orig {
-			newHistogramDataPoint((*es.orig)[i]).CopyTo(newHistogramDataPoint((*dest.orig)[i]))
+		*dest = (*dest)[:srcLen:destCap]
+		for i := range *src {
+			copyOrigHistogramDataPoint((*dest)[i], (*src)[i])
 		}
 		return
 	}
 	origs := make([]otlpmetrics.HistogramDataPoint, srcLen)
 	wrappers := make([]*otlpmetrics.HistogramDataPoint, srcLen)
-	for i := range *es.orig {
+	for i := range *src {
 		wrappers[i] = &origs[i]
-		newHistogramDataPoint((*es.orig)[i]).CopyTo(newHistogramDataPoint(wrappers[i]))
+		copyOrigHistogramDataPoint(wrappers[i], (*src)[i])
 	}
-	*dest.orig = wrappers
+	*dest = wrappers
 }
 
 // Sort sorts the HistogramDataPoint elements within HistogramDataPointSlice given the

--- a/pdata/pmetric/generated_metric.go
+++ b/pdata/pmetric/generated_metric.go
@@ -227,20 +227,33 @@ func (ms Metric) SetEmptySummary() Summary {
 
 // CopyTo copies all properties from the current struct overriding the destination.
 func (ms Metric) CopyTo(dest Metric) {
-	dest.SetName(ms.Name())
-	dest.SetDescription(ms.Description())
-	dest.SetUnit(ms.Unit())
-	switch ms.Type() {
-	case MetricTypeGauge:
-		ms.Gauge().CopyTo(dest.SetEmptyGauge())
-	case MetricTypeSum:
-		ms.Sum().CopyTo(dest.SetEmptySum())
-	case MetricTypeHistogram:
-		ms.Histogram().CopyTo(dest.SetEmptyHistogram())
-	case MetricTypeExponentialHistogram:
-		ms.ExponentialHistogram().CopyTo(dest.SetEmptyExponentialHistogram())
-	case MetricTypeSummary:
-		ms.Summary().CopyTo(dest.SetEmptySummary())
-	}
+	copyOrigMetric(dest.orig, ms.orig)
+}
 
+func copyOrigMetric(dest, src *otlpmetrics.Metric) {
+	dest.Name = src.Name
+	dest.Description = src.Description
+	dest.Unit = src.Unit
+	switch v := src.Data.(type) {
+	case *otlpmetrics.Metric_Gauge:
+		destGauge := &otlpmetrics.Gauge{}
+		copyOrigGauge(destGauge, v.Gauge)
+		dest.Data = &otlpmetrics.Metric_Gauge{Gauge: destGauge}
+	case *otlpmetrics.Metric_Sum:
+		destSum := &otlpmetrics.Sum{}
+		copyOrigSum(destSum, v.Sum)
+		dest.Data = &otlpmetrics.Metric_Sum{Sum: destSum}
+	case *otlpmetrics.Metric_Histogram:
+		destHistogram := &otlpmetrics.Histogram{}
+		copyOrigHistogram(destHistogram, v.Histogram)
+		dest.Data = &otlpmetrics.Metric_Histogram{Histogram: destHistogram}
+	case *otlpmetrics.Metric_ExponentialHistogram:
+		destExponentialHistogram := &otlpmetrics.ExponentialHistogram{}
+		copyOrigExponentialHistogram(destExponentialHistogram, v.ExponentialHistogram)
+		dest.Data = &otlpmetrics.Metric_ExponentialHistogram{ExponentialHistogram: destExponentialHistogram}
+	case *otlpmetrics.Metric_Summary:
+		destSummary := &otlpmetrics.Summary{}
+		copyOrigSummary(destSummary, v.Summary)
+		dest.Data = &otlpmetrics.Metric_Summary{Summary: destSummary}
+	}
 }

--- a/pdata/pmetric/generated_metricslice.go
+++ b/pdata/pmetric/generated_metricslice.go
@@ -128,22 +128,26 @@ func (es MetricSlice) RemoveIf(f func(Metric) bool) {
 
 // CopyTo copies all elements from the current slice overriding the destination.
 func (es MetricSlice) CopyTo(dest MetricSlice) {
-	srcLen := es.Len()
-	destCap := cap(*dest.orig)
+	copyOrigMetricSlice(dest.orig, es.orig)
+}
+
+func copyOrigMetricSlice(dest, src *[]*otlpmetrics.Metric) {
+	srcLen := len(*src)
+	destCap := cap(*dest)
 	if srcLen <= destCap {
-		(*dest.orig) = (*dest.orig)[:srcLen:destCap]
-		for i := range *es.orig {
-			newMetric((*es.orig)[i]).CopyTo(newMetric((*dest.orig)[i]))
+		*dest = (*dest)[:srcLen:destCap]
+		for i := range *src {
+			copyOrigMetric((*dest)[i], (*src)[i])
 		}
 		return
 	}
 	origs := make([]otlpmetrics.Metric, srcLen)
 	wrappers := make([]*otlpmetrics.Metric, srcLen)
-	for i := range *es.orig {
+	for i := range *src {
 		wrappers[i] = &origs[i]
-		newMetric((*es.orig)[i]).CopyTo(newMetric(wrappers[i]))
+		copyOrigMetric(wrappers[i], (*src)[i])
 	}
-	*dest.orig = wrappers
+	*dest = wrappers
 }
 
 // Sort sorts the Metric elements within MetricSlice given the

--- a/pdata/pmetric/generated_numberdatapoint.go
+++ b/pdata/pmetric/generated_numberdatapoint.go
@@ -131,16 +131,19 @@ func (ms NumberDataPoint) SetFlags(v DataPointFlags) {
 
 // CopyTo copies all properties from the current struct overriding the destination.
 func (ms NumberDataPoint) CopyTo(dest NumberDataPoint) {
-	ms.Attributes().CopyTo(dest.Attributes())
-	dest.SetStartTimestamp(ms.StartTimestamp())
-	dest.SetTimestamp(ms.Timestamp())
-	switch ms.ValueType() {
-	case NumberDataPointValueTypeDouble:
-		dest.SetDoubleValue(ms.DoubleValue())
-	case NumberDataPointValueTypeInt:
-		dest.SetIntValue(ms.IntValue())
-	}
+	copyOrigNumberDataPoint(dest.orig, ms.orig)
+}
 
-	ms.Exemplars().CopyTo(dest.Exemplars())
-	dest.SetFlags(ms.Flags())
+func copyOrigNumberDataPoint(dest, src *otlpmetrics.NumberDataPoint) {
+	internal.CopyOrigMap(&dest.Attributes, &src.Attributes)
+	dest.StartTimeUnixNano = src.StartTimeUnixNano
+	dest.TimeUnixNano = src.TimeUnixNano
+	switch v := src.Value.(type) {
+	case *otlpmetrics.NumberDataPoint_AsDouble:
+		dest.Value = &otlpmetrics.NumberDataPoint_AsDouble{AsDouble: v.AsDouble}
+	case *otlpmetrics.NumberDataPoint_AsInt:
+		dest.Value = &otlpmetrics.NumberDataPoint_AsInt{AsInt: v.AsInt}
+	}
+	copyOrigExemplarSlice(&dest.Exemplars, &src.Exemplars)
+	dest.Flags = src.Flags
 }

--- a/pdata/pmetric/generated_numberdatapointslice.go
+++ b/pdata/pmetric/generated_numberdatapointslice.go
@@ -128,22 +128,26 @@ func (es NumberDataPointSlice) RemoveIf(f func(NumberDataPoint) bool) {
 
 // CopyTo copies all elements from the current slice overriding the destination.
 func (es NumberDataPointSlice) CopyTo(dest NumberDataPointSlice) {
-	srcLen := es.Len()
-	destCap := cap(*dest.orig)
+	copyOrigNumberDataPointSlice(dest.orig, es.orig)
+}
+
+func copyOrigNumberDataPointSlice(dest, src *[]*otlpmetrics.NumberDataPoint) {
+	srcLen := len(*src)
+	destCap := cap(*dest)
 	if srcLen <= destCap {
-		(*dest.orig) = (*dest.orig)[:srcLen:destCap]
-		for i := range *es.orig {
-			newNumberDataPoint((*es.orig)[i]).CopyTo(newNumberDataPoint((*dest.orig)[i]))
+		*dest = (*dest)[:srcLen:destCap]
+		for i := range *src {
+			copyOrigNumberDataPoint((*dest)[i], (*src)[i])
 		}
 		return
 	}
 	origs := make([]otlpmetrics.NumberDataPoint, srcLen)
 	wrappers := make([]*otlpmetrics.NumberDataPoint, srcLen)
-	for i := range *es.orig {
+	for i := range *src {
 		wrappers[i] = &origs[i]
-		newNumberDataPoint((*es.orig)[i]).CopyTo(newNumberDataPoint(wrappers[i]))
+		copyOrigNumberDataPoint(wrappers[i], (*src)[i])
 	}
-	*dest.orig = wrappers
+	*dest = wrappers
 }
 
 // Sort sorts the NumberDataPoint elements within NumberDataPointSlice given the

--- a/pdata/pmetric/generated_resourcemetrics.go
+++ b/pdata/pmetric/generated_resourcemetrics.go
@@ -75,7 +75,11 @@ func (ms ResourceMetrics) ScopeMetrics() ScopeMetricsSlice {
 
 // CopyTo copies all properties from the current struct overriding the destination.
 func (ms ResourceMetrics) CopyTo(dest ResourceMetrics) {
-	ms.Resource().CopyTo(dest.Resource())
-	dest.SetSchemaUrl(ms.SchemaUrl())
-	ms.ScopeMetrics().CopyTo(dest.ScopeMetrics())
+	copyOrigResourceMetrics(dest.orig, ms.orig)
+}
+
+func copyOrigResourceMetrics(dest, src *otlpmetrics.ResourceMetrics) {
+	internal.CopyOrigResource(&dest.Resource, &src.Resource)
+	dest.SchemaUrl = src.SchemaUrl
+	copyOrigScopeMetricsSlice(&dest.ScopeMetrics, &src.ScopeMetrics)
 }

--- a/pdata/pmetric/generated_resourcemetricsslice.go
+++ b/pdata/pmetric/generated_resourcemetricsslice.go
@@ -128,22 +128,26 @@ func (es ResourceMetricsSlice) RemoveIf(f func(ResourceMetrics) bool) {
 
 // CopyTo copies all elements from the current slice overriding the destination.
 func (es ResourceMetricsSlice) CopyTo(dest ResourceMetricsSlice) {
-	srcLen := es.Len()
-	destCap := cap(*dest.orig)
+	copyOrigResourceMetricsSlice(dest.orig, es.orig)
+}
+
+func copyOrigResourceMetricsSlice(dest, src *[]*otlpmetrics.ResourceMetrics) {
+	srcLen := len(*src)
+	destCap := cap(*dest)
 	if srcLen <= destCap {
-		(*dest.orig) = (*dest.orig)[:srcLen:destCap]
-		for i := range *es.orig {
-			newResourceMetrics((*es.orig)[i]).CopyTo(newResourceMetrics((*dest.orig)[i]))
+		*dest = (*dest)[:srcLen:destCap]
+		for i := range *src {
+			copyOrigResourceMetrics((*dest)[i], (*src)[i])
 		}
 		return
 	}
 	origs := make([]otlpmetrics.ResourceMetrics, srcLen)
 	wrappers := make([]*otlpmetrics.ResourceMetrics, srcLen)
-	for i := range *es.orig {
+	for i := range *src {
 		wrappers[i] = &origs[i]
-		newResourceMetrics((*es.orig)[i]).CopyTo(newResourceMetrics(wrappers[i]))
+		copyOrigResourceMetrics(wrappers[i], (*src)[i])
 	}
-	*dest.orig = wrappers
+	*dest = wrappers
 }
 
 // Sort sorts the ResourceMetrics elements within ResourceMetricsSlice given the

--- a/pdata/pmetric/generated_scopemetrics.go
+++ b/pdata/pmetric/generated_scopemetrics.go
@@ -75,7 +75,11 @@ func (ms ScopeMetrics) Metrics() MetricSlice {
 
 // CopyTo copies all properties from the current struct overriding the destination.
 func (ms ScopeMetrics) CopyTo(dest ScopeMetrics) {
-	ms.Scope().CopyTo(dest.Scope())
-	dest.SetSchemaUrl(ms.SchemaUrl())
-	ms.Metrics().CopyTo(dest.Metrics())
+	copyOrigScopeMetrics(dest.orig, ms.orig)
+}
+
+func copyOrigScopeMetrics(dest, src *otlpmetrics.ScopeMetrics) {
+	internal.CopyOrigInstrumentationScope(&dest.Scope, &src.Scope)
+	dest.SchemaUrl = src.SchemaUrl
+	copyOrigMetricSlice(&dest.Metrics, &src.Metrics)
 }

--- a/pdata/pmetric/generated_scopemetricsslice.go
+++ b/pdata/pmetric/generated_scopemetricsslice.go
@@ -128,22 +128,26 @@ func (es ScopeMetricsSlice) RemoveIf(f func(ScopeMetrics) bool) {
 
 // CopyTo copies all elements from the current slice overriding the destination.
 func (es ScopeMetricsSlice) CopyTo(dest ScopeMetricsSlice) {
-	srcLen := es.Len()
-	destCap := cap(*dest.orig)
+	copyOrigScopeMetricsSlice(dest.orig, es.orig)
+}
+
+func copyOrigScopeMetricsSlice(dest, src *[]*otlpmetrics.ScopeMetrics) {
+	srcLen := len(*src)
+	destCap := cap(*dest)
 	if srcLen <= destCap {
-		(*dest.orig) = (*dest.orig)[:srcLen:destCap]
-		for i := range *es.orig {
-			newScopeMetrics((*es.orig)[i]).CopyTo(newScopeMetrics((*dest.orig)[i]))
+		*dest = (*dest)[:srcLen:destCap]
+		for i := range *src {
+			copyOrigScopeMetrics((*dest)[i], (*src)[i])
 		}
 		return
 	}
 	origs := make([]otlpmetrics.ScopeMetrics, srcLen)
 	wrappers := make([]*otlpmetrics.ScopeMetrics, srcLen)
-	for i := range *es.orig {
+	for i := range *src {
 		wrappers[i] = &origs[i]
-		newScopeMetrics((*es.orig)[i]).CopyTo(newScopeMetrics(wrappers[i]))
+		copyOrigScopeMetrics(wrappers[i], (*src)[i])
 	}
-	*dest.orig = wrappers
+	*dest = wrappers
 }
 
 // Sort sorts the ScopeMetrics elements within ScopeMetricsSlice given the

--- a/pdata/pmetric/generated_sum.go
+++ b/pdata/pmetric/generated_sum.go
@@ -78,7 +78,11 @@ func (ms Sum) DataPoints() NumberDataPointSlice {
 
 // CopyTo copies all properties from the current struct overriding the destination.
 func (ms Sum) CopyTo(dest Sum) {
-	dest.SetAggregationTemporality(ms.AggregationTemporality())
-	dest.SetIsMonotonic(ms.IsMonotonic())
-	ms.DataPoints().CopyTo(dest.DataPoints())
+	copyOrigSum(dest.orig, ms.orig)
+}
+
+func copyOrigSum(dest, src *otlpmetrics.Sum) {
+	dest.AggregationTemporality = src.AggregationTemporality
+	dest.IsMonotonic = src.IsMonotonic
+	copyOrigNumberDataPointSlice(&dest.DataPoints, &src.DataPoints)
 }

--- a/pdata/pmetric/generated_summary.go
+++ b/pdata/pmetric/generated_summary.go
@@ -58,5 +58,9 @@ func (ms Summary) DataPoints() SummaryDataPointSlice {
 
 // CopyTo copies all properties from the current struct overriding the destination.
 func (ms Summary) CopyTo(dest Summary) {
-	ms.DataPoints().CopyTo(dest.DataPoints())
+	copyOrigSummary(dest.orig, ms.orig)
+}
+
+func copyOrigSummary(dest, src *otlpmetrics.Summary) {
+	copyOrigSummaryDataPointSlice(&dest.DataPoints, &src.DataPoints)
 }

--- a/pdata/pmetric/generated_summarydatapoint.go
+++ b/pdata/pmetric/generated_summarydatapoint.go
@@ -115,11 +115,15 @@ func (ms SummaryDataPoint) SetFlags(v DataPointFlags) {
 
 // CopyTo copies all properties from the current struct overriding the destination.
 func (ms SummaryDataPoint) CopyTo(dest SummaryDataPoint) {
-	ms.Attributes().CopyTo(dest.Attributes())
-	dest.SetStartTimestamp(ms.StartTimestamp())
-	dest.SetTimestamp(ms.Timestamp())
-	dest.SetCount(ms.Count())
-	dest.SetSum(ms.Sum())
-	ms.QuantileValues().CopyTo(dest.QuantileValues())
-	dest.SetFlags(ms.Flags())
+	copyOrigSummaryDataPoint(dest.orig, ms.orig)
+}
+
+func copyOrigSummaryDataPoint(dest, src *otlpmetrics.SummaryDataPoint) {
+	internal.CopyOrigMap(&dest.Attributes, &src.Attributes)
+	dest.StartTimeUnixNano = src.StartTimeUnixNano
+	dest.TimeUnixNano = src.TimeUnixNano
+	dest.Count = src.Count
+	dest.Sum = src.Sum
+	copyOrigSummaryDataPointValueAtQuantileSlice(&dest.QuantileValues, &src.QuantileValues)
+	dest.Flags = src.Flags
 }

--- a/pdata/pmetric/generated_summarydatapointslice.go
+++ b/pdata/pmetric/generated_summarydatapointslice.go
@@ -128,22 +128,26 @@ func (es SummaryDataPointSlice) RemoveIf(f func(SummaryDataPoint) bool) {
 
 // CopyTo copies all elements from the current slice overriding the destination.
 func (es SummaryDataPointSlice) CopyTo(dest SummaryDataPointSlice) {
-	srcLen := es.Len()
-	destCap := cap(*dest.orig)
+	copyOrigSummaryDataPointSlice(dest.orig, es.orig)
+}
+
+func copyOrigSummaryDataPointSlice(dest, src *[]*otlpmetrics.SummaryDataPoint) {
+	srcLen := len(*src)
+	destCap := cap(*dest)
 	if srcLen <= destCap {
-		(*dest.orig) = (*dest.orig)[:srcLen:destCap]
-		for i := range *es.orig {
-			newSummaryDataPoint((*es.orig)[i]).CopyTo(newSummaryDataPoint((*dest.orig)[i]))
+		*dest = (*dest)[:srcLen:destCap]
+		for i := range *src {
+			copyOrigSummaryDataPoint((*dest)[i], (*src)[i])
 		}
 		return
 	}
 	origs := make([]otlpmetrics.SummaryDataPoint, srcLen)
 	wrappers := make([]*otlpmetrics.SummaryDataPoint, srcLen)
-	for i := range *es.orig {
+	for i := range *src {
 		wrappers[i] = &origs[i]
-		newSummaryDataPoint((*es.orig)[i]).CopyTo(newSummaryDataPoint(wrappers[i]))
+		copyOrigSummaryDataPoint(wrappers[i], (*src)[i])
 	}
-	*dest.orig = wrappers
+	*dest = wrappers
 }
 
 // Sort sorts the SummaryDataPoint elements within SummaryDataPointSlice given the

--- a/pdata/pmetric/generated_summarydatapointvalueatquantile.go
+++ b/pdata/pmetric/generated_summarydatapointvalueatquantile.go
@@ -73,6 +73,10 @@ func (ms SummaryDataPointValueAtQuantile) SetValue(v float64) {
 
 // CopyTo copies all properties from the current struct overriding the destination.
 func (ms SummaryDataPointValueAtQuantile) CopyTo(dest SummaryDataPointValueAtQuantile) {
-	dest.SetQuantile(ms.Quantile())
-	dest.SetValue(ms.Value())
+	copyOrigSummaryDataPointValueAtQuantile(dest.orig, ms.orig)
+}
+
+func copyOrigSummaryDataPointValueAtQuantile(dest, src *otlpmetrics.SummaryDataPoint_ValueAtQuantile) {
+	dest.Quantile = src.Quantile
+	dest.Value = src.Value
 }

--- a/pdata/pmetric/generated_summarydatapointvalueatquantileslice.go
+++ b/pdata/pmetric/generated_summarydatapointvalueatquantileslice.go
@@ -128,22 +128,26 @@ func (es SummaryDataPointValueAtQuantileSlice) RemoveIf(f func(SummaryDataPointV
 
 // CopyTo copies all elements from the current slice overriding the destination.
 func (es SummaryDataPointValueAtQuantileSlice) CopyTo(dest SummaryDataPointValueAtQuantileSlice) {
-	srcLen := es.Len()
-	destCap := cap(*dest.orig)
+	copyOrigSummaryDataPointValueAtQuantileSlice(dest.orig, es.orig)
+}
+
+func copyOrigSummaryDataPointValueAtQuantileSlice(dest, src *[]*otlpmetrics.SummaryDataPoint_ValueAtQuantile) {
+	srcLen := len(*src)
+	destCap := cap(*dest)
 	if srcLen <= destCap {
-		(*dest.orig) = (*dest.orig)[:srcLen:destCap]
-		for i := range *es.orig {
-			newSummaryDataPointValueAtQuantile((*es.orig)[i]).CopyTo(newSummaryDataPointValueAtQuantile((*dest.orig)[i]))
+		*dest = (*dest)[:srcLen:destCap]
+		for i := range *src {
+			copyOrigSummaryDataPointValueAtQuantile((*dest)[i], (*src)[i])
 		}
 		return
 	}
 	origs := make([]otlpmetrics.SummaryDataPoint_ValueAtQuantile, srcLen)
 	wrappers := make([]*otlpmetrics.SummaryDataPoint_ValueAtQuantile, srcLen)
-	for i := range *es.orig {
+	for i := range *src {
 		wrappers[i] = &origs[i]
-		newSummaryDataPointValueAtQuantile((*es.orig)[i]).CopyTo(newSummaryDataPointValueAtQuantile(wrappers[i]))
+		copyOrigSummaryDataPointValueAtQuantile(wrappers[i], (*src)[i])
 	}
-	*dest.orig = wrappers
+	*dest = wrappers
 }
 
 // Sort sorts the SummaryDataPointValueAtQuantile elements within SummaryDataPointValueAtQuantileSlice given the

--- a/pdata/pmetric/metrics.go
+++ b/pdata/pmetric/metrics.go
@@ -38,7 +38,7 @@ func NewMetrics() Metrics {
 
 // CopyTo copies the Metrics instance overriding the destination.
 func (ms Metrics) CopyTo(dest Metrics) {
-	ms.ResourceMetrics().CopyTo(dest.ResourceMetrics())
+	copyOrigResourceMetricsSlice(dest.ResourceMetrics().orig, ms.ResourceMetrics().orig)
 }
 
 // ResourceMetrics returns the ResourceMetricsSlice associated with this Metrics.

--- a/pdata/pmetric/metrics_test.go
+++ b/pdata/pmetric/metrics_test.go
@@ -646,6 +646,27 @@ func TestMetricsCopyTo(t *testing.T) {
 	assert.EqualValues(t, metrics, metricsCopy)
 }
 
+func BenchmarkMetricsCopyTo(b *testing.B) {
+	metrics := NewMetrics()
+	fillTestResourceMetricsSlice(metrics.ResourceMetrics())
+	b.ReportAllocs()
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		metrics.CopyTo(NewMetrics())
+	}
+}
+
+func BenchmarkMetricsCopyToReuseDest(b *testing.B) {
+	metrics := NewMetrics()
+	fillTestResourceMetricsSlice(metrics.ResourceMetrics())
+	dest := NewMetrics()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		metrics.CopyTo(dest)
+	}
+}
+
 func BenchmarkOtlpToFromInternal_PassThrough(b *testing.B) {
 	req := &otlpcollectormetrics.ExportMetricsServiceRequest{
 		ResourceMetrics: []*otlpmetrics.ResourceMetrics{

--- a/pdata/pmetric/pmetricotlp/generated_exportpartialsuccess.go
+++ b/pdata/pmetric/pmetricotlp/generated_exportpartialsuccess.go
@@ -73,6 +73,10 @@ func (ms ExportPartialSuccess) SetErrorMessage(v string) {
 
 // CopyTo copies all properties from the current struct overriding the destination.
 func (ms ExportPartialSuccess) CopyTo(dest ExportPartialSuccess) {
-	dest.SetRejectedDataPoints(ms.RejectedDataPoints())
-	dest.SetErrorMessage(ms.ErrorMessage())
+	copyOrigExportPartialSuccess(dest.orig, ms.orig)
+}
+
+func copyOrigExportPartialSuccess(dest, src *otlpcollectormetrics.ExportMetricsPartialSuccess) {
+	dest.RejectedDataPoints = src.RejectedDataPoints
+	dest.ErrorMessage = src.ErrorMessage
 }

--- a/pdata/ptrace/generated_resourcespans.go
+++ b/pdata/ptrace/generated_resourcespans.go
@@ -75,7 +75,11 @@ func (ms ResourceSpans) ScopeSpans() ScopeSpansSlice {
 
 // CopyTo copies all properties from the current struct overriding the destination.
 func (ms ResourceSpans) CopyTo(dest ResourceSpans) {
-	ms.Resource().CopyTo(dest.Resource())
-	dest.SetSchemaUrl(ms.SchemaUrl())
-	ms.ScopeSpans().CopyTo(dest.ScopeSpans())
+	copyOrigResourceSpans(dest.orig, ms.orig)
+}
+
+func copyOrigResourceSpans(dest, src *otlptrace.ResourceSpans) {
+	internal.CopyOrigResource(&dest.Resource, &src.Resource)
+	dest.SchemaUrl = src.SchemaUrl
+	copyOrigScopeSpansSlice(&dest.ScopeSpans, &src.ScopeSpans)
 }

--- a/pdata/ptrace/generated_resourcespansslice.go
+++ b/pdata/ptrace/generated_resourcespansslice.go
@@ -128,22 +128,26 @@ func (es ResourceSpansSlice) RemoveIf(f func(ResourceSpans) bool) {
 
 // CopyTo copies all elements from the current slice overriding the destination.
 func (es ResourceSpansSlice) CopyTo(dest ResourceSpansSlice) {
-	srcLen := es.Len()
-	destCap := cap(*dest.orig)
+	copyOrigResourceSpansSlice(dest.orig, es.orig)
+}
+
+func copyOrigResourceSpansSlice(dest, src *[]*otlptrace.ResourceSpans) {
+	srcLen := len(*src)
+	destCap := cap(*dest)
 	if srcLen <= destCap {
-		(*dest.orig) = (*dest.orig)[:srcLen:destCap]
-		for i := range *es.orig {
-			newResourceSpans((*es.orig)[i]).CopyTo(newResourceSpans((*dest.orig)[i]))
+		*dest = (*dest)[:srcLen:destCap]
+		for i := range *src {
+			copyOrigResourceSpans((*dest)[i], (*src)[i])
 		}
 		return
 	}
 	origs := make([]otlptrace.ResourceSpans, srcLen)
 	wrappers := make([]*otlptrace.ResourceSpans, srcLen)
-	for i := range *es.orig {
+	for i := range *src {
 		wrappers[i] = &origs[i]
-		newResourceSpans((*es.orig)[i]).CopyTo(newResourceSpans(wrappers[i]))
+		copyOrigResourceSpans(wrappers[i], (*src)[i])
 	}
-	*dest.orig = wrappers
+	*dest = wrappers
 }
 
 // Sort sorts the ResourceSpans elements within ResourceSpansSlice given the

--- a/pdata/ptrace/generated_scopespans.go
+++ b/pdata/ptrace/generated_scopespans.go
@@ -75,7 +75,11 @@ func (ms ScopeSpans) Spans() SpanSlice {
 
 // CopyTo copies all properties from the current struct overriding the destination.
 func (ms ScopeSpans) CopyTo(dest ScopeSpans) {
-	ms.Scope().CopyTo(dest.Scope())
-	dest.SetSchemaUrl(ms.SchemaUrl())
-	ms.Spans().CopyTo(dest.Spans())
+	copyOrigScopeSpans(dest.orig, ms.orig)
+}
+
+func copyOrigScopeSpans(dest, src *otlptrace.ScopeSpans) {
+	internal.CopyOrigInstrumentationScope(&dest.Scope, &src.Scope)
+	dest.SchemaUrl = src.SchemaUrl
+	copyOrigSpanSlice(&dest.Spans, &src.Spans)
 }

--- a/pdata/ptrace/generated_scopespansslice.go
+++ b/pdata/ptrace/generated_scopespansslice.go
@@ -128,22 +128,26 @@ func (es ScopeSpansSlice) RemoveIf(f func(ScopeSpans) bool) {
 
 // CopyTo copies all elements from the current slice overriding the destination.
 func (es ScopeSpansSlice) CopyTo(dest ScopeSpansSlice) {
-	srcLen := es.Len()
-	destCap := cap(*dest.orig)
+	copyOrigScopeSpansSlice(dest.orig, es.orig)
+}
+
+func copyOrigScopeSpansSlice(dest, src *[]*otlptrace.ScopeSpans) {
+	srcLen := len(*src)
+	destCap := cap(*dest)
 	if srcLen <= destCap {
-		(*dest.orig) = (*dest.orig)[:srcLen:destCap]
-		for i := range *es.orig {
-			newScopeSpans((*es.orig)[i]).CopyTo(newScopeSpans((*dest.orig)[i]))
+		*dest = (*dest)[:srcLen:destCap]
+		for i := range *src {
+			copyOrigScopeSpans((*dest)[i], (*src)[i])
 		}
 		return
 	}
 	origs := make([]otlptrace.ScopeSpans, srcLen)
 	wrappers := make([]*otlptrace.ScopeSpans, srcLen)
-	for i := range *es.orig {
+	for i := range *src {
 		wrappers[i] = &origs[i]
-		newScopeSpans((*es.orig)[i]).CopyTo(newScopeSpans(wrappers[i]))
+		copyOrigScopeSpans(wrappers[i], (*src)[i])
 	}
-	*dest.orig = wrappers
+	*dest = wrappers
 }
 
 // Sort sorts the ScopeSpans elements within ScopeSpansSlice given the

--- a/pdata/ptrace/generated_span.go
+++ b/pdata/ptrace/generated_span.go
@@ -182,19 +182,23 @@ func (ms Span) Status() Status {
 
 // CopyTo copies all properties from the current struct overriding the destination.
 func (ms Span) CopyTo(dest Span) {
-	dest.SetTraceID(ms.TraceID())
-	dest.SetSpanID(ms.SpanID())
-	ms.TraceState().CopyTo(dest.TraceState())
-	dest.SetParentSpanID(ms.ParentSpanID())
-	dest.SetName(ms.Name())
-	dest.SetKind(ms.Kind())
-	dest.SetStartTimestamp(ms.StartTimestamp())
-	dest.SetEndTimestamp(ms.EndTimestamp())
-	ms.Attributes().CopyTo(dest.Attributes())
-	dest.SetDroppedAttributesCount(ms.DroppedAttributesCount())
-	ms.Events().CopyTo(dest.Events())
-	dest.SetDroppedEventsCount(ms.DroppedEventsCount())
-	ms.Links().CopyTo(dest.Links())
-	dest.SetDroppedLinksCount(ms.DroppedLinksCount())
-	ms.Status().CopyTo(dest.Status())
+	copyOrigSpan(dest.orig, ms.orig)
+}
+
+func copyOrigSpan(dest, src *otlptrace.Span) {
+	dest.TraceId = src.TraceId
+	dest.SpanId = src.SpanId
+	internal.CopyOrigTraceState(&dest.TraceState, &src.TraceState)
+	dest.ParentSpanId = src.ParentSpanId
+	dest.Name = src.Name
+	dest.Kind = src.Kind
+	dest.StartTimeUnixNano = src.StartTimeUnixNano
+	dest.EndTimeUnixNano = src.EndTimeUnixNano
+	internal.CopyOrigMap(&dest.Attributes, &src.Attributes)
+	dest.DroppedAttributesCount = src.DroppedAttributesCount
+	copyOrigSpanEventSlice(&dest.Events, &src.Events)
+	dest.DroppedEventsCount = src.DroppedEventsCount
+	copyOrigSpanLinkSlice(&dest.Links, &src.Links)
+	dest.DroppedLinksCount = src.DroppedLinksCount
+	copyOrigStatus(&dest.Status, &src.Status)
 }

--- a/pdata/ptrace/generated_spanevent.go
+++ b/pdata/ptrace/generated_spanevent.go
@@ -91,8 +91,12 @@ func (ms SpanEvent) SetDroppedAttributesCount(v uint32) {
 
 // CopyTo copies all properties from the current struct overriding the destination.
 func (ms SpanEvent) CopyTo(dest SpanEvent) {
-	dest.SetTimestamp(ms.Timestamp())
-	dest.SetName(ms.Name())
-	ms.Attributes().CopyTo(dest.Attributes())
-	dest.SetDroppedAttributesCount(ms.DroppedAttributesCount())
+	copyOrigSpanEvent(dest.orig, ms.orig)
+}
+
+func copyOrigSpanEvent(dest, src *otlptrace.Span_Event) {
+	dest.TimeUnixNano = src.TimeUnixNano
+	dest.Name = src.Name
+	internal.CopyOrigMap(&dest.Attributes, &src.Attributes)
+	dest.DroppedAttributesCount = src.DroppedAttributesCount
 }

--- a/pdata/ptrace/generated_spaneventslice.go
+++ b/pdata/ptrace/generated_spaneventslice.go
@@ -128,22 +128,26 @@ func (es SpanEventSlice) RemoveIf(f func(SpanEvent) bool) {
 
 // CopyTo copies all elements from the current slice overriding the destination.
 func (es SpanEventSlice) CopyTo(dest SpanEventSlice) {
-	srcLen := es.Len()
-	destCap := cap(*dest.orig)
+	copyOrigSpanEventSlice(dest.orig, es.orig)
+}
+
+func copyOrigSpanEventSlice(dest, src *[]*otlptrace.Span_Event) {
+	srcLen := len(*src)
+	destCap := cap(*dest)
 	if srcLen <= destCap {
-		(*dest.orig) = (*dest.orig)[:srcLen:destCap]
-		for i := range *es.orig {
-			newSpanEvent((*es.orig)[i]).CopyTo(newSpanEvent((*dest.orig)[i]))
+		*dest = (*dest)[:srcLen:destCap]
+		for i := range *src {
+			copyOrigSpanEvent((*dest)[i], (*src)[i])
 		}
 		return
 	}
 	origs := make([]otlptrace.Span_Event, srcLen)
 	wrappers := make([]*otlptrace.Span_Event, srcLen)
-	for i := range *es.orig {
+	for i := range *src {
 		wrappers[i] = &origs[i]
-		newSpanEvent((*es.orig)[i]).CopyTo(newSpanEvent(wrappers[i]))
+		copyOrigSpanEvent(wrappers[i], (*src)[i])
 	}
-	*dest.orig = wrappers
+	*dest = wrappers
 }
 
 // Sort sorts the SpanEvent elements within SpanEventSlice given the

--- a/pdata/ptrace/generated_spanlink.go
+++ b/pdata/ptrace/generated_spanlink.go
@@ -98,9 +98,13 @@ func (ms SpanLink) SetDroppedAttributesCount(v uint32) {
 
 // CopyTo copies all properties from the current struct overriding the destination.
 func (ms SpanLink) CopyTo(dest SpanLink) {
-	dest.SetTraceID(ms.TraceID())
-	dest.SetSpanID(ms.SpanID())
-	ms.TraceState().CopyTo(dest.TraceState())
-	ms.Attributes().CopyTo(dest.Attributes())
-	dest.SetDroppedAttributesCount(ms.DroppedAttributesCount())
+	copyOrigSpanLink(dest.orig, ms.orig)
+}
+
+func copyOrigSpanLink(dest, src *otlptrace.Span_Link) {
+	dest.TraceId = src.TraceId
+	dest.SpanId = src.SpanId
+	internal.CopyOrigTraceState(&dest.TraceState, &src.TraceState)
+	internal.CopyOrigMap(&dest.Attributes, &src.Attributes)
+	dest.DroppedAttributesCount = src.DroppedAttributesCount
 }

--- a/pdata/ptrace/generated_spanlinkslice.go
+++ b/pdata/ptrace/generated_spanlinkslice.go
@@ -128,22 +128,26 @@ func (es SpanLinkSlice) RemoveIf(f func(SpanLink) bool) {
 
 // CopyTo copies all elements from the current slice overriding the destination.
 func (es SpanLinkSlice) CopyTo(dest SpanLinkSlice) {
-	srcLen := es.Len()
-	destCap := cap(*dest.orig)
+	copyOrigSpanLinkSlice(dest.orig, es.orig)
+}
+
+func copyOrigSpanLinkSlice(dest, src *[]*otlptrace.Span_Link) {
+	srcLen := len(*src)
+	destCap := cap(*dest)
 	if srcLen <= destCap {
-		(*dest.orig) = (*dest.orig)[:srcLen:destCap]
-		for i := range *es.orig {
-			newSpanLink((*es.orig)[i]).CopyTo(newSpanLink((*dest.orig)[i]))
+		*dest = (*dest)[:srcLen:destCap]
+		for i := range *src {
+			copyOrigSpanLink((*dest)[i], (*src)[i])
 		}
 		return
 	}
 	origs := make([]otlptrace.Span_Link, srcLen)
 	wrappers := make([]*otlptrace.Span_Link, srcLen)
-	for i := range *es.orig {
+	for i := range *src {
 		wrappers[i] = &origs[i]
-		newSpanLink((*es.orig)[i]).CopyTo(newSpanLink(wrappers[i]))
+		copyOrigSpanLink(wrappers[i], (*src)[i])
 	}
-	*dest.orig = wrappers
+	*dest = wrappers
 }
 
 // Sort sorts the SpanLink elements within SpanLinkSlice given the

--- a/pdata/ptrace/generated_spanslice.go
+++ b/pdata/ptrace/generated_spanslice.go
@@ -128,22 +128,26 @@ func (es SpanSlice) RemoveIf(f func(Span) bool) {
 
 // CopyTo copies all elements from the current slice overriding the destination.
 func (es SpanSlice) CopyTo(dest SpanSlice) {
-	srcLen := es.Len()
-	destCap := cap(*dest.orig)
+	copyOrigSpanSlice(dest.orig, es.orig)
+}
+
+func copyOrigSpanSlice(dest, src *[]*otlptrace.Span) {
+	srcLen := len(*src)
+	destCap := cap(*dest)
 	if srcLen <= destCap {
-		(*dest.orig) = (*dest.orig)[:srcLen:destCap]
-		for i := range *es.orig {
-			newSpan((*es.orig)[i]).CopyTo(newSpan((*dest.orig)[i]))
+		*dest = (*dest)[:srcLen:destCap]
+		for i := range *src {
+			copyOrigSpan((*dest)[i], (*src)[i])
 		}
 		return
 	}
 	origs := make([]otlptrace.Span, srcLen)
 	wrappers := make([]*otlptrace.Span, srcLen)
-	for i := range *es.orig {
+	for i := range *src {
 		wrappers[i] = &origs[i]
-		newSpan((*es.orig)[i]).CopyTo(newSpan(wrappers[i]))
+		copyOrigSpan(wrappers[i], (*src)[i])
 	}
-	*dest.orig = wrappers
+	*dest = wrappers
 }
 
 // Sort sorts the Span elements within SpanSlice given the

--- a/pdata/ptrace/generated_status.go
+++ b/pdata/ptrace/generated_status.go
@@ -74,6 +74,10 @@ func (ms Status) SetMessage(v string) {
 
 // CopyTo copies all properties from the current struct overriding the destination.
 func (ms Status) CopyTo(dest Status) {
-	dest.SetCode(ms.Code())
-	dest.SetMessage(ms.Message())
+	copyOrigStatus(dest.orig, ms.orig)
+}
+
+func copyOrigStatus(dest, src *otlptrace.Status) {
+	dest.Code = src.Code
+	dest.Message = src.Message
 }

--- a/pdata/ptrace/ptraceotlp/generated_exportpartialsuccess.go
+++ b/pdata/ptrace/ptraceotlp/generated_exportpartialsuccess.go
@@ -73,6 +73,10 @@ func (ms ExportPartialSuccess) SetErrorMessage(v string) {
 
 // CopyTo copies all properties from the current struct overriding the destination.
 func (ms ExportPartialSuccess) CopyTo(dest ExportPartialSuccess) {
-	dest.SetRejectedSpans(ms.RejectedSpans())
-	dest.SetErrorMessage(ms.ErrorMessage())
+	copyOrigExportPartialSuccess(dest.orig, ms.orig)
+}
+
+func copyOrigExportPartialSuccess(dest, src *otlpcollectortrace.ExportTracePartialSuccess) {
+	dest.RejectedSpans = src.RejectedSpans
+	dest.ErrorMessage = src.ErrorMessage
 }

--- a/pdata/ptrace/traces.go
+++ b/pdata/ptrace/traces.go
@@ -38,7 +38,7 @@ func NewTraces() Traces {
 
 // CopyTo copies the Traces instance overriding the destination.
 func (ms Traces) CopyTo(dest Traces) {
-	ms.ResourceSpans().CopyTo(dest.ResourceSpans())
+	copyOrigResourceSpansSlice(dest.ResourceSpans().orig, ms.ResourceSpans().orig)
 }
 
 // SpanCount calculates the total number of spans.

--- a/pdata/ptrace/traces_test.go
+++ b/pdata/ptrace/traces_test.go
@@ -124,3 +124,24 @@ func TestTracesCopyTo(t *testing.T) {
 	traces.CopyTo(tracesCopy)
 	assert.EqualValues(t, traces, tracesCopy)
 }
+
+func BenchmarkTracesCopyTo(b *testing.B) {
+	traces := NewTraces()
+	fillTestResourceSpansSlice(traces.ResourceSpans())
+	b.ReportAllocs()
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		traces.CopyTo(NewTraces())
+	}
+}
+
+func BenchmarkTracesCopyToReuseDest(b *testing.B) {
+	traces := NewTraces()
+	fillTestResourceSpansSlice(traces.ResourceSpans())
+	dest := NewTraces()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		traces.CopyTo(dest)
+	}
+}


### PR DESCRIPTION
This change slightly improves performance of CopyTo methods and makes things easier for https://github.com/open-telemetry/opentelemetry-collector/pull/7205

Before:
```
goos: darwin
goarch: arm64
pkg: go.opentelemetry.io/collector/pdata/pmetric
BenchmarkMetricsCopyTo
BenchmarkMetricsCopyTo-10    	     890	   1299537 ns/op	 2286313 B/op	   42359 allocs/op
BenchmarkLogsCopyTo
BenchmarkLogsCopyTo-10    	   50179	     23463 ns/op	   66400 B/op	     513 allocs/op
BenchmarkTracesCopyTo
BenchmarkTracesCopyTo-10    	    3712	    352776 ns/op	  613639 B/op	    6687 allocs/op
BenchmarkMetricsCopyToReuseDest
BenchmarkMetricsCopyToReuseDest-10    	     898	   1248538 ns/op	 2252874 B/op	   42189 allocs/op
BenchmarkLogsCopyToReuseDest
BenchmarkLogsCopyToReuseDest-10    	  234370	      5152 ns/op	       0 B/op	       0 allocs/op
BenchmarkTracesCopyToReuseDest
BenchmarkTracesCopyToReuseDest-10    	   23239	     50635 ns/op	      26 B/op	       0 allocs/op
PASS
```

After:
```
goos: darwin
goarch: arm64
pkg: go.opentelemetry.io/collector/pdata/pmetric
BenchmarkMetricsCopyTo
BenchmarkMetricsCopyTo-10    	     928	   1229692 ns/op	 2286312 B/op	   42359 allocs/op
BenchmarkLogsCopyTo
BenchmarkLogsCopyTo-10    	   51979	     23356 ns/op	   66400 B/op	     513 allocs/op
BenchmarkTracesCopyTo
BenchmarkTracesCopyTo-10    	    3144	    345044 ns/op	  613637 B/op	    6687 allocs/op
BenchmarkMetricsCopyToReuseDest
BenchmarkMetricsCopyToReuseDest-10    	     986	   1189443 ns/op	 2252871 B/op	   42189 allocs/op
BenchmarkLogsCopyToReuseDest
BenchmarkLogsCopyToReuseDest-10    	  249128	      4534 ns/op	       0 B/op	       0 allocs/op
BenchmarkTracesCopyToReuseDest
BenchmarkTracesCopyToReuseDest-10    	   26362	     44933 ns/op	      23 B/op	       0 allocs/op
PASS
```