### PR TITLE
Use http constants to replace numbers as parameters

### DIFF
--- a/config/confighttp/compression_test.go
+++ b/config/confighttp/compression_test.go
@@ -117,7 +117,7 @@ func TestHTTPClientCompression(t *testing.T) {
 			serverURL := fmt.Sprintf("http://%s", ln.Addr().String())
 			reqBody := bytes.NewBuffer(testBody)
 
-			req, err := http.NewRequest("GET", serverURL, reqBody)
+			req, err := http.NewRequest(http.MethodGet, serverURL, reqBody)
 			require.NoError(t, err, "failed to create request to test handler")
 
 			client := http.Client{}
@@ -216,7 +216,7 @@ func TestHTTPContentDecompressionHandler(t *testing.T) {
 			reqBody, err := tt.reqBodyFunc()
 			require.NoError(t, err, "failed to generate request body: %v", err)
 
-			req, err := http.NewRequest("GET", serverURL, reqBody)
+			req, err := http.NewRequest(http.MethodGet, serverURL, reqBody)
 			require.NoError(t, err, "failed to create request to test handler")
 			req.Header.Set("Content-Encoding", tt.encoding)
 
@@ -245,7 +245,7 @@ func TestHTTPContentCompressionRequestWithNilBody(t *testing.T) {
 	}))
 	defer server.Close()
 
-	req, err := http.NewRequest("GET", server.URL, nil)
+	req, err := http.NewRequest(http.MethodGet, server.URL, nil)
 	require.NoError(t, err, "failed to create request to test handler")
 
 	client := http.Client{}

--- a/config/confighttp/confighttp_test.go
+++ b/config/confighttp/confighttp_test.go
@@ -764,7 +764,7 @@ func TestHttpCorsWithSettings(t *testing.T) {
 }
 
 func verifyCorsResp(t *testing.T, url string, origin string, maxAge int, extraHeader bool, wantStatus int, wantAllowed bool) {
-	req, err := http.NewRequest("OPTIONS", url, nil)
+	req, err := http.NewRequest(http.MethodOptions, url, nil)
 	require.NoError(t, err, "Error creating trace OPTIONS request: %v", err)
 	req.Header.Set("Origin", origin)
 	if extraHeader {
@@ -853,7 +853,7 @@ func TestHttpHeaders(t *testing.T) {
 				Headers:         tt.headers,
 			}
 			client, _ := setting.ToClient(componenttest.NewNopHost(), componenttest.NewNopTelemetrySettings())
-			req, err := http.NewRequest("GET", setting.Endpoint, nil)
+			req, err := http.NewRequest(http.MethodGet, setting.Endpoint, nil)
 			assert.NoError(t, err)
 			_, err = client.Do(req)
 			assert.NoError(t, err)

--- a/obsreport/obsreporttest/otelprometheuschecker.go
+++ b/obsreport/obsreporttest/otelprometheuschecker.go
@@ -164,7 +164,7 @@ func (pc *prometheusChecker) getMetric(expectedName string, expectedType io_prom
 }
 
 func fetchPrometheusMetrics(handler http.Handler) (map[string]*io_prometheus_client.MetricFamily, error) {
-	req, err := http.NewRequest("GET", "/metrics", nil)
+	req, err := http.NewRequest(http.MethodGet, "/metrics", nil)
 	if err != nil {
 		return nil, err
 	}

--- a/processor/batchprocessor/metrics_test.go
+++ b/processor/batchprocessor/metrics_test.go
@@ -139,7 +139,7 @@ func (tt *testTelemetry) assertMetrics(t *testing.T, expected expectedMetrics) {
 		_, _ = view.RetrieveData(v.Name)
 	}
 
-	req, err := http.NewRequest("GET", "/metrics", nil)
+	req, err := http.NewRequest(http.MethodGet, "/metrics", nil)
 	require.NoError(t, err)
 
 	rr := httptest.NewRecorder()

--- a/service/internal/proctelemetry/process_telemetry_test.go
+++ b/service/internal/proctelemetry/process_telemetry_test.go
@@ -101,7 +101,7 @@ func setupTelemetry(t *testing.T) testTelemetry {
 }
 
 func fetchPrometheusMetrics(handler http.Handler) (map[string]*io_prometheus_client.MetricFamily, error) {
-	req, err := http.NewRequest("GET", "/metrics", nil)
+	req, err := http.NewRequest(http.MethodGet, "/metrics", nil)
 	if err != nil {
 		return nil, err
 	}

--- a/service/telemetry_test.go
+++ b/service/telemetry_test.go
@@ -212,7 +212,7 @@ func createTestMetrics(t *testing.T, mp metric.MeterProvider) *view.View {
 }
 
 func getMetricsFromPrometheus(t *testing.T, handler http.Handler) map[string]*io_prometheus_client.MetricFamily {
-	req, err := http.NewRequest("GET", "/metrics", nil)
+	req, err := http.NewRequest(http.MethodGet, "/metrics", nil)
 	require.NoError(t, err)
 
 	rr := httptest.NewRecorder()


### PR DESCRIPTION
## Important (read before submitting)
We are currently preparing for the upcoming 1.0 GA release. Pull requests that are not aligned with
the current roadmap https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/roadmap.md
and are not aimed at stabilizing and preparing the Collector for the release will not be accepted.

_Delete this paragraph before submitting._

**Description:** <Describe what has changed. 
Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.>
Use http constants to replace numbers as parameters

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** < Describe what testing was performed and which tests were added.>

**Documentation:** < Describe the documentation added.>

_Please delete paragraphs that you did not use before submitting._
