### PR TITLE
PoC: Respond to OPTIONS requests correctly in the HTTP receiver

### DIFF
--- a/.chloggen/preflight-request-handling-http-receiver-1.yaml
+++ b/.chloggen/preflight-request-handling-http-receiver-1.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: otlpreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Support OPTIONS requests in the OTLP HTTP receiver for better CORS handling
+
+# One or more tracking issues or pull requests related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/config/confighttp/confighttp.go
+++ b/config/confighttp/confighttp.go
@@ -294,6 +294,7 @@ func (hss *HTTPServerSettings) ToServer(host component.Host, settings component.
 			AllowCredentials: true,
 			AllowedHeaders:   hss.CORS.AllowedHeaders,
 			MaxAge:           hss.CORS.MaxAge,
+			AllowedMethods:   []string{http.MethodOptions, http.MethodPost},
 		}
 		handler = cors.New(co).Handler(handler)
 	}

--- a/receiver/otlpreceiver/otlp.go
+++ b/receiver/otlpreceiver/otlp.go
@@ -201,6 +201,10 @@ func (r *otlpReceiver) registerTraceConsumer(tc consumer.Traces) error {
 	httpTracesReceiver := trace.New(tc, r.obsrepHTTP)
 	if r.httpMux != nil {
 		r.httpMux.HandleFunc("/v1/traces", func(resp http.ResponseWriter, req *http.Request) {
+			if req.Method == http.MethodOptions {
+				handleCorsPreflightRequest(resp)
+				return
+			}
 			if req.Method != http.MethodPost {
 				handleUnmatchedMethod(resp)
 				return
@@ -226,6 +230,10 @@ func (r *otlpReceiver) registerMetricsConsumer(mc consumer.Metrics) error {
 	httpMetricsReceiver := metrics.New(mc, r.obsrepHTTP)
 	if r.httpMux != nil {
 		r.httpMux.HandleFunc("/v1/metrics", func(resp http.ResponseWriter, req *http.Request) {
+			if req.Method == http.MethodOptions {
+				handleCorsPreflightRequest(resp)
+				return
+			}
 			if req.Method != http.MethodPost {
 				handleUnmatchedMethod(resp)
 				return
@@ -251,6 +259,10 @@ func (r *otlpReceiver) registerLogsConsumer(lc consumer.Logs) error {
 	httpLogsReceiver := logs.New(lc, r.obsrepHTTP)
 	if r.httpMux != nil {
 		r.httpMux.HandleFunc("/v1/logs", func(resp http.ResponseWriter, req *http.Request) {
+			if req.Method == http.MethodOptions {
+				handleCorsPreflightRequest(resp)
+				return
+			}
 			if req.Method != http.MethodPost {
 				handleUnmatchedMethod(resp)
 				return
@@ -276,4 +288,9 @@ func handleUnmatchedMethod(resp http.ResponseWriter) {
 func handleUnmatchedContentType(resp http.ResponseWriter) {
 	status := http.StatusUnsupportedMediaType
 	writeResponse(resp, "text/plain", status, []byte(fmt.Sprintf("%v unsupported media type, supported: [%s, %s]", status, jsonContentType, pbContentType)))
+}
+
+func handleCorsPreflightRequest(resp http.ResponseWriter) {
+	status := http.StatusNoContent
+	writeResponse(resp, "text/plain", status, []byte(""))
 }


### PR DESCRIPTION
**Description:**

The OTel Collector correctly handles cross-origin `POST` requests. However, if a browser attempts to make a [pre-flight request](https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request), it fails with an HTTP 405 (Method Not Allowed) error.

This is my first PR against the OpenTelemetry, please excuse any missteps. I'm happy to fix them, as well as make any further improvements to this PR to get it to a state where it can be merged.

**Testing:**

With a configuration that accepts HTTP requests, and forwards them to an OTLP endpoint:

```
receivers:
  otlp:
    protocols:
      grpc: # on port 4317
      http: # on port 4318
        endpoint: "0.0.0.0:4318"
        cors:
          allowed_origins: ["http://*","https://*"]
          allowed_headers: ["*"]
exporters:
  otlp:
    endpoint: "foo.bar.com"
    headers:
      "api-key": "XXXX"
service:
  extensions: []
  pipelines:
    traces:
      receivers: [otlp]
      processors: []
      exporters: [otlp]
    metrics:
      receivers: [otlp]
      processors: []
      exporters: [otlp]

```

This request succeeds.

```
curl -vk http://localhost:4318/v1/traces -X OPTIONS \
  -H 'Accept: application/json' \
  -H 'Accept-Language: en-GB,en-US;q=0.9,en;q=0.8' \
  -H 'Connection: keep-alive' \
  -H 'Content-Type: application/json' \
  -H 'Origin: https://www.example.com' \
  -H 'Referer: https://www.example.com/' \
  -H 'Sec-Fetch-Dest: empty' \
  -H 'Sec-Fetch-Mode: cors' \
  -H 'Sec-Fetch-Site: same-site' \
  -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36' \
  -H 'api-key;' \
  -H 'sec-ch-ua: "Not_A Brand";v="99", "Google Chrome";v="109", "Chromium";v="109"' \
  -H 'sec-ch-ua-mobile: ?0' \
  -H 'sec-ch-ua-platform: "macOS"' \
  --data-raw '{"resourceSpans":[...]}' \
  --compressed\
 -H 'Access-Control-Request-Method: POST' -H 'Access-Control-Request-Headers: Content-Type'
*   Trying 127.0.0.1:4318...
* Connected to localhost (127.0.0.1) port 4318 (#0)
> OPTIONS /v1/traces HTTP/1.1
> Host: localhost:4318
> Accept-Encoding: deflate, gzip
> Accept: application/json
> Accept-Language: en-GB,en-US;q=0.9,en;q=0.8
> Connection: keep-alive
> Content-Type: application/json
> Origin: https://www.example.com
> Referer: https://www.example.com/
> Sec-Fetch-Dest: empty
> Sec-Fetch-Mode: cors
> Sec-Fetch-Site: same-site
> User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36
> api-key:
> sec-ch-ua: "Not_A Brand";v="99", "Google Chrome";v="109", "Chromium";v="109"
> sec-ch-ua-mobile: ?0
> sec-ch-ua-platform: "macOS"
> Access-Control-Request-Method: POST
> Access-Control-Request-Headers: Content-Type
> Content-Length: 759
>
* Mark bundle as not supporting multiuse
< HTTP/1.1 204 No Content
< Access-Control-Allow-Credentials: true
< Access-Control-Allow-Headers: Content-Type
< Access-Control-Allow-Methods: POST
< Access-Control-Allow-Origin: https://www.example.com
< Vary: Origin
< Vary: Access-Control-Request-Method
< Vary: Access-Control-Request-Headers
< Date: Thu, 23 Feb 2023 09:14:07 GMT
<
* Connection #0 to host localhost left intact
```

This is the behaviour after applying the current patch. Current behaviour on the `main` branch:

```
* Mark bundle as not supporting multiuse
< HTTP/1.1 405 Method Not Allowed
< Access-Control-Allow-Credentials: true
< Access-Control-Allow-Origin: https://www.example.com
< Content-Type: text/plain
< Vary: Origin
< Date: Thu, 23 Feb 2023 08:36:38 GMT
< Content-Length: 41
<
* Connection #0 to host localhost left intact
405 method not allowed, supported: [POST]%
```

**Documentation:**

I'm not sure if this needs a documentation update, happy to make an additional commit to this PR if we need one.
