### PR TITLE
Remove code path to unused service implementation

### DIFF
--- a/service/graph.go
+++ b/service/graph.go
@@ -32,8 +32,6 @@ import (
 	"go.opentelemetry.io/collector/service/internal/fanoutconsumer"
 )
 
-var _ pipelines = (*pipelinesGraph)(nil)
-
 type pipelinesGraph struct {
 	// All component instances represented as nodes, with directed edges indicating data flow.
 	componentGraph *simple.DirectedGraph
@@ -42,7 +40,7 @@ type pipelinesGraph struct {
 	pipelines map[component.ID]*pipelineNodes
 }
 
-func buildPipelinesGraph(ctx context.Context, set pipelinesSettings) (pipelines, error) {
+func buildPipelinesGraph(ctx context.Context, set pipelinesSettings) (*pipelinesGraph, error) {
 	pipelines := &pipelinesGraph{
 		componentGraph: simple.NewDirectedGraph(),
 		pipelines:      make(map[component.ID]*pipelineNodes, len(set.PipelineConfigs)),

--- a/service/graph_test.go
+++ b/service/graph_test.go
@@ -638,11 +638,8 @@ func TestConnectorPipelinesGraph(t *testing.T) {
 				PipelineConfigs: test.pipelineConfigs,
 			}
 
-			pipelinesInterface, err := buildPipelinesGraph(context.Background(), set)
+			pg, err := buildPipelinesGraph(context.Background(), set)
 			require.NoError(t, err)
-
-			pg, ok := pipelinesInterface.(*pipelinesGraph)
-			require.True(t, ok)
 
 			assert.Equal(t, len(test.pipelineConfigs), len(pg.pipelines))
 

--- a/service/host.go
+++ b/service/host.go
@@ -36,7 +36,7 @@ type serviceHost struct {
 
 	buildInfo component.BuildInfo
 
-	pipelines
+	pipelines         *pipelinesGraph
 	serviceExtensions *extensions.Extensions
 }
 

--- a/service/pipelines.go
+++ b/service/pipelines.go
@@ -38,15 +38,6 @@ const (
 	zComponentKind = "zcomponentkind"
 )
 
-type pipelines interface {
-	StartAll(ctx context.Context, host component.Host) error
-	ShutdownAll(ctx context.Context) error
-	GetExporters() map[component.DataType]map[component.ID]component.Component
-	HandleZPages(w http.ResponseWriter, r *http.Request)
-}
-
-var _ pipelines = (*builtPipelines)(nil)
-
 // baseConsumer redeclared here since not public in consumer package. May consider to make that public.
 type baseConsumer interface {
 	Capabilities() consumer.Capabilities
@@ -180,7 +171,7 @@ type pipelinesSettings struct {
 }
 
 // buildPipelines builds all pipelines from config.
-func buildPipelines(ctx context.Context, set pipelinesSettings) (pipelines, error) {
+func buildPipelines(ctx context.Context, set pipelinesSettings) (*builtPipelines, error) {
 	exps := &builtPipelines{
 		telemetry:    set.Telemetry,
 		allReceivers: make(map[component.DataType]map[component.ID]component.Component),

--- a/service/pipelines_test.go
+++ b/service/pipelines_test.go
@@ -182,7 +182,7 @@ func TestBuildPipelines(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			// Build the pipeline
-			pips, err := buildPipelines(context.Background(), pipelinesSettings{
+			pipelines, err := buildPipelines(context.Background(), pipelinesSettings{
 				Telemetry: componenttest.NewNopTelemetrySettings(),
 				BuildInfo: component.NewDefaultBuildInfo(),
 				ReceiverBuilder: receiver.NewBuilder(
@@ -212,9 +212,7 @@ func TestBuildPipelines(t *testing.T) {
 				PipelineConfigs: test.pipelineConfigs,
 			})
 			assert.NoError(t, err)
-			assert.IsType(t, &builtPipelines{}, pips)
 
-			pipelines := pips.(*builtPipelines)
 			assert.NoError(t, pipelines.StartAll(context.Background(), componenttest.NewNopHost()))
 
 			for dt, pipeline := range test.pipelineConfigs {

--- a/service/service.go
+++ b/service/service.go
@@ -37,7 +37,7 @@ import (
 	"go.opentelemetry.io/collector/service/telemetry"
 )
 
-var graphFeatureGate = featuregate.GlobalRegistry().MustRegister(
+var graphFeatureGate = featuregate.GlobalRegistry().MustRegister( // nolint:unused
 	"service.graph",
 	featuregate.StageStable,
 	featuregate.WithRegisterRemovalVersion("v0.74.0"),
@@ -89,10 +89,6 @@ func New(ctx context.Context, set Settings, cfg Config) (*Service, error) {
 	if set.useOtel != nil {
 		useOtel = *set.useOtel
 	}
-	useGraph := graphFeatureGate.IsEnabled()
-	if set.useGraph != nil {
-		useGraph = *set.useGraph
-	}
 	srv := &Service{
 		buildInfo: set.BuildInfo,
 		host: &serviceHost{
@@ -124,7 +120,7 @@ func New(ctx context.Context, set Settings, cfg Config) (*Service, error) {
 	srv.telemetrySettings.MeterProvider = srv.telemetryInitializer.mp
 
 	// process the configuration and initialize the pipeline
-	if err = srv.initExtensionsAndPipeline(ctx, set, cfg, useGraph); err != nil {
+	if err = srv.initExtensionsAndPipeline(ctx, set, cfg); err != nil {
 		// If pipeline initialization fails then shut down the telemetry server
 		if shutdownErr := srv.telemetryInitializer.shutdown(); shutdownErr != nil {
 			err = multierr.Append(err, fmt.Errorf("failed to shutdown collector telemetry: %w", shutdownErr))
@@ -190,7 +186,7 @@ func (srv *Service) Shutdown(ctx context.Context) error {
 	return errs
 }
 
-func (srv *Service) initExtensionsAndPipeline(ctx context.Context, set Settings, cfg Config, useGraph bool) error {
+func (srv *Service) initExtensionsAndPipeline(ctx context.Context, set Settings, cfg Config) error {
 	var err error
 	extensionsSettings := extensions.Settings{
 		Telemetry:  srv.telemetrySettings,
@@ -211,14 +207,8 @@ func (srv *Service) initExtensionsAndPipeline(ctx context.Context, set Settings,
 		PipelineConfigs:  cfg.Pipelines,
 	}
 
-	if useGraph {
-		if srv.host.pipelines, err = buildPipelinesGraph(ctx, pSet); err != nil {
-			return fmt.Errorf("failed to build pipelines: %w", err)
-		}
-	} else {
-		if srv.host.pipelines, err = buildPipelines(ctx, pSet); err != nil {
-			return fmt.Errorf("failed to build pipelines: %w", err)
-		}
+	if srv.host.pipelines, err = buildPipelinesGraph(ctx, pSet); err != nil {
+		return fmt.Errorf("failed to build pipelines: %w", err)
 	}
 
 	if cfg.Telemetry.Metrics.Level != configtelemetry.LevelNone && cfg.Telemetry.Metrics.Address != "" {

--- a/service/service.go
+++ b/service/service.go
@@ -37,7 +37,7 @@ import (
 	"go.opentelemetry.io/collector/service/telemetry"
 )
 
-var graphFeatureGate = featuregate.GlobalRegistry().MustRegister( // nolint:unused
+var _ = featuregate.GlobalRegistry().MustRegister(
 	"service.graph",
 	featuregate.StageStable,
 	featuregate.WithRegisterRemovalVersion("v0.74.0"),
@@ -71,8 +71,7 @@ type Settings struct {
 	LoggingOptions []zap.Option
 
 	// For testing purpose only.
-	useOtel  *bool
-	useGraph *bool
+	useOtel *bool
 }
 
 // Service represents the implementation of a component.Host.

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -217,11 +217,7 @@ func TestServiceTelemetryCleanupOnError(t *testing.T) {
 func TestServiceTelemetryWithOpenCensusMetrics(t *testing.T) {
 	for _, tc := range ownMetricsTestCases() {
 		t.Run(tc.name, func(t *testing.T) {
-			testCollectorStartHelper(t, false, false, tc)
-		})
-
-		t.Run(tc.name+"/connectors", func(t *testing.T) {
-			testCollectorStartHelper(t, false, true, tc)
+			testCollectorStartHelper(t, false, tc)
 		})
 	}
 }
@@ -229,16 +225,12 @@ func TestServiceTelemetryWithOpenCensusMetrics(t *testing.T) {
 func TestServiceTelemetryWithOpenTelemetryMetrics(t *testing.T) {
 	for _, tc := range ownMetricsTestCases() {
 		t.Run(tc.name, func(t *testing.T) {
-			testCollectorStartHelper(t, true, false, tc)
-		})
-
-		t.Run(tc.name+"/connectors", func(t *testing.T) {
-			testCollectorStartHelper(t, true, true, tc)
+			testCollectorStartHelper(t, true, tc)
 		})
 	}
 }
 
-func testCollectorStartHelper(t *testing.T, useOtel bool, useGraph bool, tc ownMetricsTestCase) {
+func testCollectorStartHelper(t *testing.T, useOtel bool, tc ownMetricsTestCase) {
 	var once sync.Once
 	loggingHookCalled := false
 	hook := func(entry zapcore.Entry) error {
@@ -258,7 +250,6 @@ func testCollectorStartHelper(t *testing.T, useOtel bool, useGraph bool, tc ownM
 		map[component.Type]extension.Factory{"zpages": zpagesextension.NewFactory()})
 	set.LoggingOptions = []zap.Option{zap.Hooks(hook)}
 	set.useOtel = &useOtel
-	set.useGraph = &useGraph
 
 	cfg := newNopConfig()
 	cfg.Extensions = []component.ID{component.NewID("zpages")}


### PR DESCRIPTION
Follows #7201 

The `service.graph` feature gate is now stable, so it cannot be changed. This PR removes the code path to the previous implementation of the service pipelines since it is now unused. It does not contain any user facing changes. There will be further code to remove but this PR is limited to these initial steps:
- Remove usage of service.graph feature gate (without removing the feature gate itself)
- Remove service.pipelines interface

