### PR TITLE
Remove zpagesPipeline interface

### DIFF
--- a/service/graph.go
+++ b/service/graph.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net/http"
 	"strings"
 
 	"go.uber.org/multierr"
@@ -313,48 +312,6 @@ func (g *pipelinesGraph) GetExporters() map[component.DataType]map[component.ID]
 		}
 	}
 	return exportersMap
-}
-
-func (g *pipelinesGraph) HandleZPages(w http.ResponseWriter, r *http.Request) {
-	handleZPages(w, r, g.pipelines)
-}
-
-func (p *pipelineNodes) receiverIDs() []string {
-	ids := make([]string, 0, len(p.receivers))
-	for _, c := range p.receivers {
-		switch n := c.(type) {
-		case *receiverNode:
-			ids = append(ids, n.componentID.String())
-		case *connectorNode:
-			ids = append(ids, n.componentID.String()+" (connector)")
-		}
-	}
-	return ids
-}
-
-func (p *pipelineNodes) processorIDs() []string {
-	ids := make([]string, 0, len(p.processors))
-	for _, c := range p.processors {
-		ids = append(ids, c.componentID.String())
-	}
-	return ids
-}
-
-func (p *pipelineNodes) exporterIDs() []string {
-	ids := make([]string, 0, len(p.exporters))
-	for _, c := range p.exporters {
-		switch n := c.(type) {
-		case *exporterNode:
-			ids = append(ids, n.componentID.String())
-		case *connectorNode:
-			ids = append(ids, n.componentID.String()+" (connector)")
-		}
-	}
-	return ids
-}
-
-func (p *pipelineNodes) mutatesData() bool {
-	return p.capabilitiesNode.getConsumer().Capabilities().MutatesData
 }
 
 func cycleErr(err error, cycles [][]graph.Node) error {

--- a/service/pipelines.go
+++ b/service/pipelines.go
@@ -422,34 +422,4 @@ func buildReceiver(ctx context.Context,
 	return recv, nil
 }
 
-func (bps *builtPipelines) HandleZPages(w http.ResponseWriter, r *http.Request) {
-	handleZPages(w, r, bps.pipelines)
-}
-
-func (bp *builtPipeline) receiverIDs() []string {
-	ids := make([]string, 0, len(bp.receivers))
-	for _, bc := range bp.receivers {
-		ids = append(ids, bc.id.String())
-	}
-	return ids
-}
-
-func (bp *builtPipeline) processorIDs() []string {
-	ids := make([]string, 0, len(bp.processors))
-	for _, bc := range bp.processors {
-		ids = append(ids, bc.id.String())
-	}
-	return ids
-}
-
-func (bp *builtPipeline) exporterIDs() []string {
-	ids := make([]string, 0, len(bp.exporters))
-	for _, bc := range bp.exporters {
-		ids = append(ids, bc.id.String())
-	}
-	return ids
-}
-
-func (bp *builtPipeline) mutatesData() bool {
-	return bp.lastConsumer.Capabilities().MutatesData
-}
+func (bps *builtPipelines) HandleZPages(_ http.ResponseWriter, _ *http.Request) {}


### PR DESCRIPTION
Follows #7201

The service.graph feature gate is now stable, so it cannot be changed. This PR removes the `zpagesPipeline` interface that supported the dual implementations of `service.pipelines`. It does not contain any user facing changes.