### PR TITLE
Added security recommendation to use configopaque.String for sensitive fields

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,8 @@ Components comprise of exporters, extensions, receivers, and processors. The key
 
 For more details on components, see the [Adding New Components](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#adding-new-components) document and the tutorial [Building a Trace Receiver](https://opentelemetry.io/docs/collector/trace-receiver/) which provides a detailed example of building a component.
 
+When adding a new component to the OpenTelemetry Collector, ensure that any configuration structs used by the component include fields with the `configopaque.String` type for sensitive data. This ensures that the data is stored and serialized in an opaque format that is secure and prevents accidental exposure
+
 When submitting a component to the community, consider breaking it down into separate PRs as follows:
 
 * First PR should include the overall structure of the new component:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ Components comprise of exporters, extensions, receivers, and processors. The key
 
 For more details on components, see the [Adding New Components](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#adding-new-components) document and the tutorial [Building a Trace Receiver](https://opentelemetry.io/docs/collector/trace-receiver/) which provides a detailed example of building a component.
 
-When adding a new component to the OpenTelemetry Collector, ensure that any configuration structs used by the component include fields with the `configopaque.String` type for sensitive data. This ensures that the data is stored and serialized in an opaque format that is secure and prevents accidental exposure
+When adding a new component to the OpenTelemetry Collector, ensure that any configuration structs used by the component include fields with the `configopaque.String` type for sensitive data. This ensures that the data is stored and serialized in an opaque format that is secure and prevents accidental exposure.
 
 When submitting a component to the community, consider breaking it down into separate PRs as follows:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ Components comprise of exporters, extensions, receivers, and processors. The key
 
 For more details on components, see the [Adding New Components](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#adding-new-components) document and the tutorial [Building a Trace Receiver](https://opentelemetry.io/docs/collector/trace-receiver/) which provides a detailed example of building a component.
 
-When adding a new component to the OpenTelemetry Collector, ensure that any configuration structs used by the component include fields with the `configopaque.String` type for sensitive data. This ensures that the data is stored and serialized in an opaque format that is secure and prevents accidental exposure.
+When adding a new component to the OpenTelemetry Collector, ensure that any configuration structs used by the component include fields with the `configopaque.String` type for sensitive data. This ensures that the data is masked when serialized to prevent accidental exposure.
 
 When submitting a component to the community, consider breaking it down into separate PRs as follows:
 

--- a/docs/security-best-practices.md
+++ b/docs/security-best-practices.md
@@ -85,6 +85,10 @@ variable expansion.
 > [this](https://opentelemetry.io/docs/collector/configuration/#configuration-environment-variables)
 > documentation.
 
+When defining Go structs for configuration data that may contain sensitive information, use the `configopaque` package to define fields with the `configopaque.String` type. This ensures that the data is stored and serialized in an opaque format that is secure and prevents accidental exposure.
+
+> For more information, see the [configopaque](https://pkg.go.dev/go.opentelemetry.io/collector/config/configopaque) documentation.
+
 Component developers MUST get configuration information from the Collector's
 configuration file. Component developers SHOULD leverage [configuration helper
 functions](https://github.com/open-telemetry/opentelemetry-collector/tree/main/config).

--- a/docs/security-best-practices.md
+++ b/docs/security-best-practices.md
@@ -85,7 +85,7 @@ variable expansion.
 > [this](https://opentelemetry.io/docs/collector/configuration/#configuration-environment-variables)
 > documentation.
 
-When defining Go structs for configuration data that may contain sensitive information, use the `configopaque` package to define fields with the `configopaque.String` type. This ensures that the data is stored and serialized in an opaque format that is secure and prevents accidental exposure.
+When defining Go structs for configuration data that may contain sensitive information, use the `configopaque` package to define fields with the `configopaque.String` type. This ensures that the data is masked when serialized to prevent accidental exposure.
 
 > For more information, see the [configopaque](https://pkg.go.dev/go.opentelemetry.io/collector/config/configopaque) documentation.
 


### PR DESCRIPTION



**Description:** 

**Link to tracking Issue:** 
Fix:https://github.com/open-telemetry/opentelemetry-collector/issues/6854

**Documentation:** 
Added a nudge for [the configopaque package](https://pkg.go.dev/go.opentelemetry.io/collector/config/configopaque)  in the [security recommendations document](https://github.com/open-telemetry/opentelemetry-collector/blob/v0.68.0/docs/security-best-practices.md#configuration) and also in the contributing doc under ["when adding a new component"](https://github.com/open-telemetry/opentelemetry-collector/blob/v0.68.0/CONTRIBUTING.md#when-adding-a-new-component) section.
