### PR TITLE
Propose to shift release v0.76.0 and subsequent releases by one week

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -115,7 +115,7 @@ The following documents the procedure to release a bugfix
 | 2023-03-06 | v0.73.0 | @Aneurysm9      |
 | 2023-03-20 | v0.74.0 | @jpkrohling     |
 | 2023-04-03 | v0.75.0 | @mx-psi         |
-| 2023-04-17 | v0.76.0 | @djaglowski     |
-| 2023-05-01 | v0.77.0 | @dmitryax       |
-| 2023-05-15 | v0.78.0 | @bogdandrutu    |
-| 2023-05-29 | v0.79.0 | @codeboten      |
+| 2023-04-24 | v0.76.0 | @djaglowski     |
+| 2023-05-08 | v0.77.0 | @dmitryax       |
+| 2023-05-22 | v0.78.0 | @bogdandrutu    |
+| 2023-06-05 | v0.79.0 | @codeboten      |


### PR DESCRIPTION
Several maintainers will be attending Kubecon the week of 4/17. I'm proposing to shift this release and subsequent released by one week.