### PR TITLE
Replace existing featuregate.FlagValue with a direct apply version

### DIFF
--- a/.chloggen/featuregateflag.yaml
+++ b/.chloggen/featuregateflag.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: featuregate
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecate `FlagValue` in favor of `NewFlag`.
+
+# One or more tracking issues or pull requests related to the change
+issues: [7042]

--- a/featuregate/flag.go
+++ b/featuregate/flag.go
@@ -1,0 +1,66 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package featuregate // import "go.opentelemetry.io/collector/featuregate"
+
+import (
+	"flag"
+	"strings"
+
+	"go.uber.org/multierr"
+)
+
+// NewFlag returns a flag.Value that directly applies feature gate statuses to a Registry.
+func NewFlag(reg *Registry) flag.Value {
+	return &flagValue{reg: reg}
+}
+
+// flagValue implements the flag.Value interface and directly applies feature gate statuses to a Registry.
+type flagValue struct {
+	reg *Registry
+}
+
+func (f *flagValue) String() string {
+	var ids []string
+	f.reg.VisitAll(func(g *Gate) {
+		id := g.ID()
+		if !g.IsEnabled() {
+			id = "-" + id
+		}
+		ids = append(ids, id)
+	})
+	return strings.Join(ids, ",")
+}
+
+func (f *flagValue) Set(s string) error {
+	if s == "" {
+		return nil
+	}
+
+	var errs error
+	ids := strings.Split(s, ",")
+	for i := range ids {
+		id := ids[i]
+		val := true
+		switch id[0] {
+		case '-':
+			id = id[1:]
+			val = false
+		case '+':
+			id = id[1:]
+		}
+		errs = multierr.Append(errs, f.reg.Set(id, val))
+	}
+	return errs
+}

--- a/featuregate/flag_test.go
+++ b/featuregate/flag_test.go
@@ -1,0 +1,128 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package featuregate
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewFlag(t *testing.T) {
+	for _, tt := range []struct {
+		name           string
+		input          string
+		expectedSetErr bool
+		expected       map[string]bool
+		expectedStr    string
+	}{
+		{
+			name:        "empty item",
+			input:       "",
+			expected:    map[string]bool{"alpha": false, "beta": true, "stable": true},
+			expectedStr: "-alpha,beta,stable",
+		},
+		{
+			name:        "simple enable alpha",
+			input:       "alpha",
+			expected:    map[string]bool{"alpha": true, "beta": true, "stable": true},
+			expectedStr: "alpha,beta,stable",
+		},
+		{
+			name:        "plus enable alpha",
+			input:       "+alpha",
+			expected:    map[string]bool{"alpha": true, "beta": true, "stable": true},
+			expectedStr: "alpha,beta,stable",
+		},
+		{
+			name:        "disabled beta",
+			input:       "-beta",
+			expected:    map[string]bool{"alpha": false, "beta": false, "stable": true},
+			expectedStr: "-alpha,-beta,stable",
+		},
+		{
+			name:        "multiple items",
+			input:       "-beta,alpha",
+			expected:    map[string]bool{"alpha": true, "beta": false, "stable": true},
+			expectedStr: "alpha,-beta,stable",
+		},
+		{
+			name:        "multiple items with plus",
+			input:       "-beta,+alpha",
+			expected:    map[string]bool{"alpha": true, "beta": false, "stable": true},
+			expectedStr: "alpha,-beta,stable",
+		},
+		{
+			name:        "repeated items",
+			input:       "alpha,-beta,-alpha",
+			expected:    map[string]bool{"alpha": false, "beta": false, "stable": true},
+			expectedStr: "-alpha,-beta,stable",
+		},
+		{
+			name:        "multiple plus items",
+			input:       "+alpha,+beta",
+			expected:    map[string]bool{"alpha": true, "beta": true, "stable": true},
+			expectedStr: "alpha,beta,stable",
+		},
+		{
+			name:           "enable stable",
+			input:          "stable",
+			expectedSetErr: true,
+			expected:       map[string]bool{"alpha": false, "beta": true, "stable": true},
+			expectedStr:    "-alpha,beta,stable",
+		},
+		{
+			name:           "disable stable",
+			input:          "stable",
+			expectedSetErr: true,
+			expected:       map[string]bool{"alpha": false, "beta": true, "stable": true},
+			expectedStr:    "-alpha,beta,stable",
+		},
+		{
+			name:           "enable missing",
+			input:          "missing",
+			expectedSetErr: true,
+			expected:       map[string]bool{"alpha": false, "beta": true, "stable": true},
+			expectedStr:    "-alpha,beta,stable",
+		},
+		{
+			name:           "disable missing",
+			input:          "missing",
+			expectedSetErr: true,
+			expected:       map[string]bool{"alpha": false, "beta": true, "stable": true},
+			expectedStr:    "-alpha,beta,stable",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			reg := NewRegistry()
+			reg.MustRegister("alpha", StageAlpha)
+			reg.MustRegister("beta", StageBeta)
+			reg.MustRegister("stable", StageStable, WithRegisterRemovalVersion("1.0.0"))
+			v := NewFlag(reg)
+			if tt.expectedSetErr {
+				require.Error(t, v.Set(tt.input))
+			} else {
+				require.NoError(t, v.Set(tt.input))
+			}
+			got := map[string]bool{}
+			reg.VisitAll(func(g *Gate) {
+				got[g.ID()] = g.IsEnabled()
+			})
+			assert.Equal(t, tt.expected, got)
+			assert.Equal(t, tt.expectedStr, v.String())
+		})
+	}
+}

--- a/featuregate/flags.go
+++ b/featuregate/flags.go
@@ -22,8 +22,7 @@ import (
 
 var _ flag.Value = (*FlagValue)(nil)
 
-// FlagValue implements the flag.Value interface and provides a mechanism for applying feature
-// gate statuses to a Registry
+// Deprecated: [v0.74.0] use NewFlag.
 type FlagValue map[string]bool
 
 // String returns a string representing the FlagValue

--- a/featuregate/go.mod
+++ b/featuregate/go.mod
@@ -2,7 +2,10 @@ module go.opentelemetry.io/collector/featuregate
 
 go 1.19
 
-require github.com/stretchr/testify v1.8.2
+require (
+	github.com/stretchr/testify v1.8.2
+	go.uber.org/multierr v1.10.0
+)
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/featuregate/go.sum
+++ b/featuregate/go.sum
@@ -10,6 +10,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=
+go.uber.org/multierr v1.10.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/featuregate/registry.go
+++ b/featuregate/registry.go
@@ -111,11 +111,11 @@ func (r *Registry) Register(id string, stage Stage, opts ...RegisterOption) (*Ga
 func (r *Registry) Set(id string, enabled bool) error {
 	v, ok := r.gates.Load(id)
 	if !ok {
-		return fmt.Errorf("no such feature gate -%v", id)
+		return fmt.Errorf("no such feature gate %q", id)
 	}
 	g := v.(*Gate)
 	if g.stage == StageStable {
-		return fmt.Errorf("feature gate %s is stable, can not be modified", id)
+		return fmt.Errorf("feature gate %q is stable, can not be modified", id)
 	}
 	g.enabled.Store(enabled)
 	return nil

--- a/otelcol/collector_windows.go
+++ b/otelcol/collector_windows.go
@@ -28,6 +28,8 @@ import (
 	"go.uber.org/zap/zapcore"
 	"golang.org/x/sys/windows/svc"
 	"golang.org/x/sys/windows/svc/eventlog"
+
+	"go.opentelemetry.io/collector/featuregate"
 )
 
 type windowsService struct {
@@ -38,7 +40,7 @@ type windowsService struct {
 
 // NewSvcHandler constructs a new svc.Handler using the given CollectorSettings.
 func NewSvcHandler(set CollectorSettings) svc.Handler {
-	return &windowsService{settings: set, flags: flags()}
+	return &windowsService{settings: set, flags: flags(featuregate.GlobalRegistry())}
 }
 
 // Execute implements https://godoc.org/golang.org/x/sys/windows/svc#Handler

--- a/otelcol/command.go
+++ b/otelcol/command.go
@@ -25,7 +25,7 @@ import (
 
 // NewCommand constructs a new cobra.Command using the given CollectorSettings.
 func NewCommand(set CollectorSettings) *cobra.Command {
-	flagSet := flags()
+	flagSet := flags(featuregate.GlobalRegistry())
 	rootCmd := &cobra.Command{
 		Use:          set.BuildInfo.Command,
 		Version:      set.BuildInfo.Version,
@@ -44,11 +44,6 @@ func NewCommand(set CollectorSettings) *cobra.Command {
 }
 
 func newCollectorWithFlags(set CollectorSettings, flags *flag.FlagSet) (*Collector, error) {
-	for id, enabled := range getFeatureGatesFlag(flags) {
-		if err := featuregate.GlobalRegistry().Set(id, enabled); err != nil {
-			return nil, err
-		}
-	}
 	if set.ConfigProvider == nil {
 		configFlags := getConfigFlag(flags)
 		if len(configFlags) == 0 {

--- a/otelcol/flags.go
+++ b/otelcol/flags.go
@@ -41,7 +41,7 @@ func (s *configFlagValue) String() string {
 	return "[" + strings.Join(s.values, ", ") + "]"
 }
 
-func flags() *flag.FlagSet {
+func flags(reg *featuregate.Registry) *flag.FlagSet {
 	flagSet := new(flag.FlagSet)
 
 	cfgs := new(configFlagValue)
@@ -61,7 +61,7 @@ func flags() *flag.FlagSet {
 			return nil
 		})
 
-	flagSet.Var(featuregate.FlagValue{}, featureGatesFlag,
+	flagSet.Var(featuregate.NewFlag(reg), featureGatesFlag,
 		"Comma-delimited list of feature gate identifiers. Prefix with '-' to disable the feature. '+' or no prefix will enable the feature.")
 
 	return flagSet
@@ -70,8 +70,4 @@ func flags() *flag.FlagSet {
 func getConfigFlag(flagSet *flag.FlagSet) []string {
 	cfv := flagSet.Lookup(configFlag).Value.(*configFlagValue)
 	return append(cfv.values, cfv.sets...)
-}
-
-func getFeatureGatesFlag(flagSet *flag.FlagSet) featuregate.FlagValue {
-	return flagSet.Lookup(featureGatesFlag).Value.(featuregate.FlagValue)
 }

--- a/otelcol/flags_test.go
+++ b/otelcol/flags_test.go
@@ -19,6 +19,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/collector/featuregate"
 )
 
 func TestSetFlag(t *testing.T) {
@@ -67,7 +69,7 @@ func TestSetFlag(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			flgs := flags()
+			flgs := flags(featuregate.NewRegistry())
 			err := flgs.Parse(tt.args)
 			if tt.expectedErr != "" {
 				assert.EqualError(t, err, tt.expectedErr)


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-collector/issues/7042

Uses direct values to/from a given registry. Simplifies usage, defers the "set" logic to the Registry.
