### PR TITLE
[exporterhelper] Fix persistent storage behaviour with no available space on device

### DIFF
--- a/.chloggen/fix_persistentstorage_disk-full.yaml
+++ b/.chloggen/fix_persistentstorage_disk-full.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: exporterhelper
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix persistent storage behaviour with no available space on device
+
+# One or more tracking issues or pull requests related to the change
+issues: [7198]

--- a/exporter/exporterhelper/internal/persistent_storage.go
+++ b/exporter/exporterhelper/internal/persistent_storage.go
@@ -260,8 +260,7 @@ func (pcs *persistentContiguousStorage) getNextItem(ctx context.Context) (Reques
 
 		if err != nil || req == nil {
 			// We need to make sure that currently dispatched items list is cleaned
-			err = pcs.itemDispatchingFinish(ctx, index)
-			if err != nil {
+			if err := pcs.itemDispatchingFinish(ctx, index); err != nil {
 				pcs.logger.Error("Error deleting item from queue",
 					zap.String(zapQueueNameKey, pcs.queueName), zap.Error(err))
 			}
@@ -273,8 +272,7 @@ func (pcs *persistentContiguousStorage) getNextItem(ctx context.Context) (Reques
 		req.SetOnProcessingFinished(func() {
 			pcs.mu.Lock()
 			defer pcs.mu.Unlock()
-			err := pcs.itemDispatchingFinish(ctx, index)
-			if err != nil {
+			if err := pcs.itemDispatchingFinish(ctx, index); err != nil {
 				pcs.logger.Error("Error deleting item from queue",
 					zap.String(zapQueueNameKey, pcs.queueName), zap.Error(err))
 			}
@@ -370,7 +368,7 @@ func (pcs *persistentContiguousStorage) itemDispatchingStart(ctx context.Context
 
 // itemDispatchingFinish removes the item from the list of currently dispatched items and deletes it from the persistent queue
 func (pcs *persistentContiguousStorage) itemDispatchingFinish(ctx context.Context, index itemIndex) error {
-	var err error
+	var batch *batchStruct
 	var updatedDispatchedItems []itemIndex
 	for _, it := range pcs.currentlyDispatchedItems {
 		if it != index {
@@ -379,31 +377,25 @@ func (pcs *persistentContiguousStorage) itemDispatchingFinish(ctx context.Contex
 	}
 	pcs.currentlyDispatchedItems = updatedDispatchedItems
 
-	_, err = newBatch(pcs).
+	batch = newBatch(pcs).
 		setItemIndexArray(currentlyDispatchedItemsKey, pcs.currentlyDispatchedItems).
-		delete(pcs.itemKey(index)).
-		execute(ctx)
-
-	if err == nil {
+		delete(pcs.itemKey(index))
+	if _, err := batch.execute(ctx); err != nil {
+		// got an error, try to gracefully handle it
+		pcs.logger.Warn("Failed updating currently dispatched items, trying to delete the item first",
+			zap.String(zapQueueNameKey, pcs.queueName), zap.Error(err))
+	} else {
 		return nil
 	}
 
-	// got an error, try to gracefully handle it
-	pcs.logger.Debug("Failed updating currently dispatched items, trying to delete the item first",
-		zap.String(zapQueueNameKey, pcs.queueName), zap.Error(err))
-
-	_, err = newBatch(pcs).
-		delete(pcs.itemKey(index)).
-		execute(ctx)
-	if err != nil {
+	if _, err := newBatch(pcs).delete(pcs.itemKey(index)).execute(ctx); err != nil {
 		// Return an error here, as this indicates an issue with the underlying storage medium
 		return fmt.Errorf("failed deleting item from queue, got error from storage: %w", err)
 	}
 
-	_, err = newBatch(pcs).
-		setItemIndexArray(currentlyDispatchedItemsKey, pcs.currentlyDispatchedItems).
-		execute(ctx)
-	if err != nil {
+	batch = newBatch(pcs).
+		setItemIndexArray(currentlyDispatchedItemsKey, pcs.currentlyDispatchedItems)
+	if _, err := batch.execute(ctx); err != nil {
 		// even if this fails, we still have the right dispatched items in memory
 		// at worst, we'll have the wrong list in storage, and we'll discard the nonexistent items during startup
 		return fmt.Errorf("failed updating currently dispatched items, but deleted item successfully: %w", err)

--- a/exporter/exporterhelper/internal/persistent_storage.go
+++ b/exporter/exporterhelper/internal/persistent_storage.go
@@ -385,6 +385,7 @@ func (pcs *persistentContiguousStorage) itemDispatchingFinish(ctx context.Contex
 		pcs.logger.Warn("Failed updating currently dispatched items, trying to delete the item first",
 			zap.String(zapQueueNameKey, pcs.queueName), zap.Error(err))
 	} else {
+		// Everything ok, exit
 		return nil
 	}
 

--- a/exporter/exporterhelper/internal/persistent_storage_test.go
+++ b/exporter/exporterhelper/internal/persistent_storage_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"reflect"
 	"sync"
+	"syscall"
 	"testing"
 	"time"
 
@@ -473,6 +474,49 @@ func TestPersistentStorage_StopShouldCloseClient(t *testing.T) {
 	require.Equal(t, uint64(1), castedClient.getCloseCount())
 }
 
+func TestPersistentStorage_StorageFull(t *testing.T) {
+	var err error
+	traces := newTraces(5, 10)
+	req := newFakeTracesRequest(traces)
+	marshalled, err := req.Marshal()
+	require.NoError(t, err)
+	maxSizeInBytes := len(marshalled) * 5
+	freeSpaceInBytes := 1
+
+	client := newMockBoundedStorageClient(maxSizeInBytes)
+	ps := createTestPersistentStorage(client)
+
+	// Put enough items in to fill the underlying storage
+	reqCount := 0
+	for {
+		err = ps.put(req)
+		if errors.Is(err, syscall.ENOSPC) {
+			break
+		}
+		require.NoError(t, err)
+		reqCount += 1
+	}
+
+	// Manually set the storage to only have a small amount of free space left
+	newMaxSize := client.GetSizeInBytes() + freeSpaceInBytes
+	client.SetMaxSizeInBytes(newMaxSize)
+
+	// Try to put an item in, should fail
+	err = ps.put(req)
+	require.Error(t, err)
+
+	// Take out all the items
+	for i := reqCount; i > 0; i-- {
+		request := <-ps.get()
+		request.OnProcessingFinished()
+	} 
+	
+	// We should be able to put a new item in
+	// However, this will fail if deleting items fails with full storage
+	err = ps.put(req)
+	require.NoError(t, err)
+}
+
 func requireCurrentlyDispatchedItemsEqual(t *testing.T, pcs *persistentContiguousStorage, compare []itemIndex) {
 	require.Eventually(t, func() bool {
 		pcs.mu.Lock()
@@ -555,4 +599,102 @@ func (m *mockStorageClient) Batch(_ context.Context, ops ...storage.Operation) e
 
 func (m *mockStorageClient) getCloseCount() uint64 {
 	return m.closeCounter
+}
+
+func newMockBoundedStorageClient(maxSizeInBytes int) *mockBoundedStorageClient {
+	return &mockBoundedStorageClient{
+		st: map[string][]byte{},
+		MaxSizeInBytes: maxSizeInBytes,
+	}
+}
+
+type mockBoundedStorageClient struct {
+	st           map[string][]byte
+	MaxSizeInBytes int
+	sizeInBytes int
+	mux          sync.Mutex
+}
+
+func (m *mockBoundedStorageClient) Get(ctx context.Context, key string) ([]byte, error) {
+	op := storage.GetOperation(key)
+	err := m.Batch(ctx, op)
+	if err != nil {
+		return nil, err
+	}
+
+	return op.Value, nil
+}
+
+func (m *mockBoundedStorageClient) Set(ctx context.Context, key string, value []byte) error {
+	return m.Batch(ctx, storage.SetOperation(key, value))
+}
+
+func (m *mockBoundedStorageClient) Delete(ctx context.Context, key string) error {
+	return m.Batch(ctx, storage.DeleteOperation(key))
+}
+
+func (m *mockBoundedStorageClient) Close(_ context.Context) error {
+	return nil
+}
+
+func (m *mockBoundedStorageClient) Batch(_ context.Context, ops ...storage.Operation) error {
+	m.mux.Lock()
+	defer m.mux.Unlock()
+
+	totalAdded, totalRemoved := m.getTotalSizeChange(ops)
+
+	if m.sizeInBytes + totalAdded > m.MaxSizeInBytes {
+		return fmt.Errorf("insufficient space available: %w", syscall.ENOSPC)
+	}
+
+	for _, op := range ops {
+		switch op.Type {
+		case storage.Get:
+			op.Value = m.st[op.Key]
+		case storage.Set:
+			m.st[op.Key] = op.Value
+		case storage.Delete:
+			delete(m.st, op.Key)
+		default:
+			return errors.New("wrong operation type")
+		}
+	}
+
+	m.sizeInBytes += (totalAdded - totalRemoved)
+
+	return nil
+}
+
+func (m *mockBoundedStorageClient) SetMaxSizeInBytes(newMaxSize int) {
+	m.mux.Lock()
+	defer m.mux.Unlock()
+	m.MaxSizeInBytes = newMaxSize
+}
+
+func (m *mockBoundedStorageClient) GetSizeInBytes() int {
+	m.mux.Lock()
+	defer m.mux.Unlock()
+	return m.sizeInBytes
+}
+
+func (m *mockBoundedStorageClient) getTotalSizeChange(ops []storage.Operation) (totalAdded int, totalRemoved int) {
+	totalAdded, totalRemoved = 0, 0
+	for _, op := range ops {
+		switch op.Type {
+		case storage.Set:
+			if oldValue, ok := m.st[op.Key]; ok {
+				totalRemoved += len(oldValue)
+			} else {
+				totalAdded += len(op.Key)
+			}
+			totalAdded += len(op.Value)
+		case storage.Delete:
+			if value, ok := m.st[op.Key]; ok {
+				totalRemoved += len(op.Key)
+				totalRemoved += len(value)
+			}
+		default:
+		}
+	}
+	return totalAdded, totalRemoved
 }

--- a/exporter/exporterhelper/internal/persistent_storage_test.go
+++ b/exporter/exporterhelper/internal/persistent_storage_test.go
@@ -795,7 +795,7 @@ func (m *mockStorageClientWithErrors) Close(_ context.Context) error {
 	return nil
 }
 
-func (m *mockStorageClientWithErrors) Batch(_ context.Context, ops ...storage.Operation) error {
+func (m *mockStorageClientWithErrors) Batch(_ context.Context, _ ...storage.Operation) error {
 	m.mux.Lock()
 	defer m.mux.Unlock()
 


### PR DESCRIPTION
Description:
Make the persistent storage handle not having any available disk space more gracefully. Right now, it may be impossible to actually delete items from the storage in that scenario.

The actual fix is pretty simple, most of the additions in this PR are test code and mocks necessary to even show the problem. The added test does actually fail without the fix.

Link to tracking Issue: https://github.com/open-telemetry/opentelemetry-collector/issues/7198

Testing:
Added a mock storage with the specific behavior required, and a test that fails without the fix.