### PR TITLE
[chore] update merged pull request w/ milestone (#293)

### DIFF
--- a/.github/workflows/milestone-add-to-pr.yml
+++ b/.github/workflows/milestone-add-to-pr.yml
@@ -1,0 +1,33 @@
+# This action adds the latest milestone to a pull request
+# when it is merged
+
+name: 'Project: Add PR to Milestone'
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  if_merged:
+    if: github.event.pull_request.merged
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            const milestones = await github.rest.issues.listMilestones({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: "open"
+            })
+            for (const milestone of milestones.data) {
+              if (milestone.title.startsWith("v")) {
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: ${{ github.event.pull_request.number }},
+                  milestone: milestone.number
+                });
+                return
+              }
+            }

--- a/.github/workflows/milestone-add-to-pr.yml
+++ b/.github/workflows/milestone-add-to-pr.yml
@@ -21,7 +21,7 @@ jobs:
               state: "open"
             })
             for (const milestone of milestones.data) {
-              if (milestone.title.startsWith("v")) {
+              if (milestone.title == "next version") {
                 await github.rest.issues.update({
                   owner: context.repo.owner,
                   repo: context.repo.repo,


### PR DESCRIPTION
Following the conversation in the SIG call on March 22, the github action in this PR will automatically add a merged PR to the first open milestone with `next version` name it finds.

I've tested this code in my fork