### PR TITLE
[docs] Correct the exporter README section on data mutation

### DIFF
--- a/exporter/README.md
+++ b/exporter/README.md
@@ -81,12 +81,10 @@ When multiple exporters are configured to send the same data (e.g. by configurin
 exporters for the same pipeline):
 * exporters *not* configured to mutate the data will have shared access to the data
 * exporters with the Capabilities to mutate the data will receive a copy of the data
+
 Exporters access export data when `ConsumeTraces`/`ConsumeMetrics`/`ConsumeLogs`
-function is called. Exporters MUST NOT modify the `pdata.Traces`/`pdata.Metrics`/`pdata.Logs` argument of
-these functions. If the exporter needs to modify the data while performing the exporting
-the exporter can clone the data and perform the modification on the clone or use a
-copy-on-write approach for individual sub-parts of `pdata.Traces`/`pdata.Metrics`/`pdata.Logs`.
-Any approach that does not mutate the original `pdata.Traces`/`pdata.Metrics`/`pdata.Logs` is allowed.
+function is called. Unless exporter's capabalities includes mutation, the exporter MUST NOT modify the `pdata.Traces`/`pdata.Metrics`/`pdata.Logs` argument of
+these functions. Any approach that does not mutate the original `pdata.Traces`/`pdata.Metrics`/`pdata.Logs` is allowed without mutation capability.
 
 ## Proxy Support
 

--- a/exporter/README.md
+++ b/exporter/README.md
@@ -83,8 +83,8 @@ exporters for the same pipeline):
 * exporters with the Capabilities to mutate the data will receive a copy of the data
 
 Exporters access export data when `ConsumeTraces`/`ConsumeMetrics`/`ConsumeLogs`
-function is called. Unless exporter's capabalities includes mutation, the exporter MUST NOT modify the `pdata.Traces`/`pdata.Metrics`/`pdata.Logs` argument of
-these functions. Any approach that does not mutate the original `pdata.Traces`/`pdata.Metrics`/`pdata.Logs` is allowed without mutation capability.
+function is called. Unless exporter's capabalities include mutation, the exporter MUST NOT modify the `pdata.Traces`/`pdata.Metrics`/`pdata.Logs` argument of
+these functions. Any approach that does not mutate the original `pdata.Traces`/`pdata.Metrics`/`pdata.Logs` is allowed without the mutation capability.
 
 ## Proxy Support
 


### PR DESCRIPTION
Leftover from previous change in #5318.

**Description:**
The README misleadingly states that exporters must not modify the export data (or create and work on a copy). However, when the mutation capability is declared, the exporter will already receive a copy of data, and therefore it's not necessary to copy the data again in order to mutate it. I believe this section has been mistakenly left in the README during the work on #5318.


