### PR TITLE
[telemetry] Add log rotation support (#7352)

### DIFF
--- a/.chloggen/feature_rotation.yaml
+++ b/.chloggen/feature_rotation.yaml
@@ -1,0 +1,23 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: service/telemetry
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add rotation support for logs of otelcol itself
+
+# One or more tracking issues or pull requests related to the change
+issues: [7352]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/cmd/otelcorecol/go.mod
+++ b/cmd/otelcorecol/go.mod
@@ -126,6 +126,7 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240520151616-dc85e6b867a5 // indirect
 	google.golang.org/grpc v1.64.0 // indirect
 	google.golang.org/protobuf v1.34.2 // indirect
+	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 

--- a/cmd/otelcorecol/go.sum
+++ b/cmd/otelcorecol/go.sum
@@ -275,6 +275,8 @@ google.golang.org/protobuf v1.34.2/go.mod h1:qYOHts0dSfpeUzUFpOMr/WGzszTmLH+DiWn
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
+gopkg.in/natefinch/lumberjack.v2 v2.2.1 h1:bBRl1b0OH9s/DuPhuXpNl+VtCaJXFZ5/uEFST95x9zc=
+gopkg.in/natefinch/lumberjack.v2 v2.2.1/go.mod h1:YD8tP3GAjkrDg1eZH7EGmyESg/lsYskCTPBJVb9jqSc=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/config/configrotate/configrotate.go
+++ b/config/configrotate/configrotate.go
@@ -1,0 +1,75 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package configrotate // import "go.opentelemetry.io/collector/config/configrotate"
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"gopkg.in/natefinch/lumberjack.v2"
+)
+
+type Config struct {
+	// Enabled controls whether or not rotate logs
+	Enabled bool `mapstructure:"enabled"`
+
+	// MaxMegabytes is the maximum size in megabytes of the file before it gets
+	// rotated. It defaults to 100 megabytes.
+	MaxMegabytes int `mapstructure:"max_megabytes"`
+
+	// MaxDays is the maximum number of days to retain old log files based on the
+	// timestamp encoded in their filename.  Note that a day is defined as 24
+	// hours and may not exactly correspond to calendar days due to daylight
+	// savings, leap seconds, etc. The default is not to remove old log files
+	// based on age.
+	MaxDays int `mapstructure:"max_days"`
+
+	// MaxBackups is the maximum number of old log files to retain. The default
+	// is to 100 files.
+	MaxBackups int `mapstructure:"max_backups"`
+
+	// LocalTime determines if the time used for formatting the timestamps in
+	// backup files is the computer's local time.  The default is to use UTC
+	// time.
+	LocalTime bool `mapstructure:"localtime"`
+}
+
+func NewDefaultRotateConfig() *Config {
+	return &Config{
+		Enabled:      true,
+		MaxMegabytes: 100,
+		MaxDays:      0,
+		MaxBackups:   100,
+		LocalTime:    false,
+	}
+}
+
+func (cfg *Config) NewWriter(filename string) (io.WriteCloser, error) {
+	if cfg.MaxMegabytes < 0 {
+		return nil, fmt.Errorf("invalid MaxMegabytes %d", cfg.MaxMegabytes)
+	}
+	if cfg.MaxDays < 0 {
+		return nil, fmt.Errorf("invalid MaxDays %d", cfg.MaxDays)
+	}
+	// #nosec G302 G304 -- filename is a trusted safe path, and should allow to be read by other users
+	file, err := os.OpenFile(filename, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0644)
+	if err != nil {
+		return nil, err
+	}
+	if !cfg.Enabled {
+		return file, nil
+	}
+	return cfg.newLumberjackWriter(filename), nil
+}
+
+func (cfg *Config) newLumberjackWriter(filename string) io.WriteCloser {
+	return &lumberjack.Logger{
+		Filename:   filename,
+		MaxSize:    cfg.MaxMegabytes,
+		MaxAge:     cfg.MaxDays,
+		MaxBackups: cfg.MaxBackups,
+		LocalTime:  cfg.LocalTime,
+	}
+}

--- a/config/configrotate/configrotate_test.go
+++ b/config/configrotate/configrotate_test.go
@@ -1,0 +1,121 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package configrotate
+
+import (
+	"os"
+	"path"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/natefinch/lumberjack.v2"
+)
+
+func TestRotationEnabledCreate(t *testing.T) {
+	tempDir := t.TempDir()
+	filename := path.Join(tempDir, "test.log")
+	maxMegabytes := 1524
+	maxDays := 145
+	maxBackups := 155
+	localTime := true
+	rotateConfig := Config{
+		Enabled:      true,
+		MaxMegabytes: maxMegabytes,
+		MaxDays:      maxDays,
+		MaxBackups:   maxBackups,
+		LocalTime:    localTime,
+	}
+	writer, err := rotateConfig.NewWriter(filename)
+	assert.NoError(t, err)
+	rotate, ok := writer.(*lumberjack.Logger)
+	assert.True(t, ok)
+	assert.Equal(t, rotate.Filename, filename)
+	assert.Equal(t, rotate.MaxSize, maxMegabytes)
+	assert.Equal(t, rotate.MaxAge, maxDays)
+	assert.Equal(t, rotate.LocalTime, localTime)
+}
+
+func TestRotateDisabledCreate(t *testing.T) {
+	rotateConfig := Config{
+		Enabled: false,
+	}
+	tempDir := t.TempDir()
+	filename := path.Join(tempDir, "test.log")
+	writer, err := rotateConfig.NewWriter(filename)
+	assert.NoError(t, err)
+	file, ok := writer.(*os.File)
+	assert.True(t, ok)
+	assert.Equal(t, file.Name(), filename)
+	assert.NoError(t, file.Close())
+}
+
+func TestErrorCreate(t *testing.T) {
+	tempdir := t.TempDir()
+	tests := []struct {
+		name         string
+		rotateConfig Config
+		filename     string
+		error        string
+	}{
+		{
+			name: "invalid filename",
+			rotateConfig: Config{
+				Enabled: true,
+			},
+			filename: filepath.Join(tempdir, "invalid/filename"),
+			error:    "no such file or directory",
+		},
+		{
+			name: "negative max megabytes",
+			rotateConfig: Config{
+				Enabled:      true,
+				MaxMegabytes: -1,
+			},
+			filename: filepath.Join(tempdir, "test.log"),
+			error:    "invalid MaxMegabytes",
+		},
+		{
+			name: "negative max days",
+			rotateConfig: Config{
+				Enabled: true,
+				MaxDays: -1,
+			},
+			filename: filepath.Join(tempdir, "test.log"),
+			error:    "invalid MaxDays",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			writer, err := tt.rotateConfig.NewWriter(tt.filename)
+			assert.ErrorContains(t, err, tt.error)
+			assert.Nil(t, writer)
+		})
+	}
+
+	// Sleep for 1 second to make sure all processes using the files are completed
+	// (on Windows fail to delete temp dir otherwise).
+	if runtime.GOOS == "windows" {
+		time.Sleep(1 * time.Second)
+	}
+}
+
+func TestCreateWithDefaultConfig(t *testing.T) {
+	rotateConfig := NewDefaultRotateConfig()
+	tempDir := t.TempDir()
+	filename := path.Join(tempDir, "test.log")
+	writer, err := rotateConfig.NewWriter(filename)
+	assert.NoError(t, err)
+	rotate, ok := writer.(*lumberjack.Logger)
+	assert.True(t, ok)
+	assert.Equal(t, rotate.Filename, filename)
+
+	// Sleep for 1 second to make sure all processes using the files are completed
+	// (on Windows fail to delete temp dir otherwise).
+	if runtime.GOOS == "windows" {
+		time.Sleep(1 * time.Second)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	go.uber.org/multierr v1.11.0
 	go.uber.org/zap v1.27.0
 	google.golang.org/grpc v1.64.0
+	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -161,5 +161,7 @@ google.golang.org/protobuf v1.34.2/go.mod h1:qYOHts0dSfpeUzUFpOMr/WGzszTmLH+DiWn
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
+gopkg.in/natefinch/lumberjack.v2 v2.2.1 h1:bBRl1b0OH9s/DuPhuXpNl+VtCaJXFZ5/uEFST95x9zc=
+gopkg.in/natefinch/lumberjack.v2 v2.2.1/go.mod h1:YD8tP3GAjkrDg1eZH7EGmyESg/lsYskCTPBJVb9jqSc=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/otelcol/go.mod
+++ b/otelcol/go.mod
@@ -5,6 +5,7 @@ go 1.21.0
 require (
 	github.com/spf13/cobra v1.8.0
 	github.com/stretchr/testify v1.9.0
+	go.opentelemetry.io/collector v0.102.1
 	go.opentelemetry.io/collector/component v0.102.1
 	go.opentelemetry.io/collector/config/configtelemetry v0.102.1
 	go.opentelemetry.io/collector/confmap v0.102.1
@@ -67,7 +68,6 @@ require (
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opencensus.io v0.24.0 // indirect
-	go.opentelemetry.io/collector v0.102.1 // indirect
 	go.opentelemetry.io/collector/consumer v0.102.1 // indirect
 	go.opentelemetry.io/collector/pdata v1.9.0 // indirect
 	go.opentelemetry.io/collector/pdata/testdata v0.102.1 // indirect
@@ -95,6 +95,7 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20240520151616-dc85e6b867a5 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240520151616-dc85e6b867a5 // indirect
 	google.golang.org/protobuf v1.34.2 // indirect
+	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 )
 
 replace go.opentelemetry.io/collector => ../

--- a/otelcol/go.sum
+++ b/otelcol/go.sum
@@ -259,6 +259,8 @@ google.golang.org/protobuf v1.34.2/go.mod h1:qYOHts0dSfpeUzUFpOMr/WGzszTmLH+DiWn
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
+gopkg.in/natefinch/lumberjack.v2 v2.2.1 h1:bBRl1b0OH9s/DuPhuXpNl+VtCaJXFZ5/uEFST95x9zc=
+gopkg.in/natefinch/lumberjack.v2 v2.2.1/go.mod h1:YD8tP3GAjkrDg1eZH7EGmyESg/lsYskCTPBJVb9jqSc=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/otelcol/unmarshaler_test.go
+++ b/otelcol/unmarshaler_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
+	"go.opentelemetry.io/collector/config/configrotate"
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/service"
 	"go.opentelemetry.io/collector/service/pipelines"
@@ -50,6 +51,13 @@ func TestUnmarshalEmptyAllSections(t *testing.T) {
 			Tick:       10 * time.Second,
 			Initial:    10,
 			Thereafter: 100,
+		},
+		Rotation: &configrotate.Config{
+			Enabled:      true,
+			MaxMegabytes: 100,
+			MaxDays:      0,
+			MaxBackups:   100,
+			LocalTime:    false,
 		},
 		DisableCaller:     zapProdCfg.DisableCaller,
 		DisableStacktrace: zapProdCfg.DisableStacktrace,

--- a/service/go.mod
+++ b/service/go.mod
@@ -86,6 +86,7 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240520151616-dc85e6b867a5 // indirect
 	google.golang.org/grpc v1.64.0 // indirect
 	google.golang.org/protobuf v1.34.2 // indirect
+	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 

--- a/service/go.sum
+++ b/service/go.sum
@@ -251,6 +251,8 @@ google.golang.org/protobuf v1.34.2/go.mod h1:qYOHts0dSfpeUzUFpOMr/WGzszTmLH+DiWn
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
+gopkg.in/natefinch/lumberjack.v2 v2.2.1 h1:bBRl1b0OH9s/DuPhuXpNl+VtCaJXFZ5/uEFST95x9zc=
+gopkg.in/natefinch/lumberjack.v2 v2.2.1/go.mod h1:YD8tP3GAjkrDg1eZH7EGmyESg/lsYskCTPBJVb9jqSc=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/service/telemetry/config.go
+++ b/service/telemetry/config.go
@@ -10,6 +10,7 @@ import (
 	"go.opentelemetry.io/contrib/config"
 	"go.uber.org/zap/zapcore"
 
+	"go.opentelemetry.io/collector/config/configrotate"
 	"go.opentelemetry.io/collector/config/configtelemetry"
 )
 
@@ -92,6 +93,19 @@ type LogsConfig struct {
 	//
 	// By default, there is no initial field.
 	InitialFields map[string]any `mapstructure:"initial_fields"`
+
+	// Rotation sets the way the log is rotated.
+	// Example:
+	//
+	//     rotation:
+	//         enabled: true
+	//         max_megabytes: 100
+	//         max_days: 0
+	//         max_backups: 100
+	//         localtime: false
+	//
+	// This example is also the default configuration.
+	Rotation *configrotate.Config `mapstructure:"rotation"`
 }
 
 // LogsSamplingConfig sets a sampling strategy for the logger. Sampling caps the

--- a/service/telemetry/factory.go
+++ b/service/telemetry/factory.go
@@ -12,6 +12,7 @@ import (
 	"go.uber.org/zap/zapcore"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config/configrotate"
 	"go.opentelemetry.io/collector/config/configtelemetry"
 	"go.opentelemetry.io/collector/service/telemetry/internal"
 )
@@ -28,6 +29,7 @@ func createDefaultConfig() component.Config {
 				Initial:    10,
 				Thereafter: 100,
 			},
+			Rotation:          configrotate.NewDefaultRotateConfig(),
 			OutputPaths:       []string{"stderr"},
 			ErrorOutputPaths:  []string{"stderr"},
 			DisableCaller:     false,

--- a/service/telemetry/logger.go
+++ b/service/telemetry/logger.go
@@ -101,6 +101,10 @@ func (w nopSyncSink) Sync() error {
 func setRotationURL(paths []string, rotationSchema string) ([]string, error) {
 	res := make([]string, 0, len(paths))
 	for _, p := range paths {
+		if p == "stdout" || p == "stderr" {
+			res = append(res, p)
+			continue
+		}
 		if runtime.GOOS == "windows" && filepath.IsAbs(p) {
 			res = append(res, rotationSchema+":?path="+url.QueryEscape(p))
 			continue

--- a/service/telemetry/logger.go
+++ b/service/telemetry/logger.go
@@ -4,8 +4,17 @@
 package telemetry // import "go.opentelemetry.io/collector/service/telemetry"
 
 import (
+	"fmt"
+	"io"
+	"net/url"
+	"path/filepath"
+	"runtime"
+
+	"github.com/google/uuid"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+
+	"go.opentelemetry.io/collector/config/configrotate"
 )
 
 func newLogger(cfg LogsConfig, options []zap.Option) (*zap.Logger, error) {
@@ -25,6 +34,22 @@ func newLogger(cfg LogsConfig, options []zap.Option) (*zap.Logger, error) {
 	if zapCfg.Encoding == "console" {
 		// Human-readable timestamps for console format of logs.
 		zapCfg.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
+	}
+
+	if cfg.Rotation != nil && cfg.Rotation.Enabled {
+		rotationSchema := "rotation-" + uuid.NewString()
+		err := zap.RegisterSink(rotationSchema, getRotationSinkFactory(cfg.Rotation))
+		if err != nil {
+			return nil, err
+		}
+		zapCfg.OutputPaths, err = setRotationURL(zapCfg.OutputPaths, rotationSchema)
+		if err != nil {
+			return nil, err
+		}
+		zapCfg.ErrorOutputPaths, err = setRotationURL(zapCfg.ErrorOutputPaths, rotationSchema)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	logger, err := zapCfg.Build(options...)
@@ -50,4 +75,64 @@ func newSampledLogger(logger *zap.Logger, sc *LogsSamplingConfig) *zap.Logger {
 		)
 	})
 	return logger.WithOptions(opts)
+}
+
+func getRotationSinkFactory(cfg *configrotate.Config) func(u *url.URL) (zap.Sink, error) {
+	return func(u *url.URL) (zap.Sink, error) {
+		p := u.Query().Get("path")
+		writer, err := cfg.NewWriter(p)
+		if err != nil {
+			return nil, err
+		}
+		return nopSyncSink{writer}, nil
+	}
+}
+
+// lumberjack.Logger does not provide a Sync() method, which is required by zap.Sink
+// explanation: https://github.com/natefinch/lumberjack/pull/47#issuecomment-322502210
+type nopSyncSink struct {
+	io.WriteCloser
+}
+
+func (w nopSyncSink) Sync() error {
+	return nil
+}
+
+func setRotationURL(paths []string, rotationSchema string) ([]string, error) {
+	res := make([]string, 0, len(paths))
+	for _, p := range paths {
+		if runtime.GOOS == "windows" && filepath.IsAbs(p) {
+			res = append(res, rotationSchema+":?path="+url.QueryEscape(p))
+			continue
+		}
+		u, err := url.Parse(p)
+		if err != nil {
+			return nil, err
+		}
+		if (u.Scheme == "" || u.Scheme == "file") &&
+			u.Path != "stdout" && u.Path != "stderr" {
+			// Copied from zap. Only clean URLs are allowed
+			if u.User != nil {
+				return nil, fmt.Errorf("user and password not allowed with file URLs: got %v", u)
+			}
+			if u.Fragment != "" {
+				return nil, fmt.Errorf("fragments not allowed with file URLs: got %v", u)
+			}
+			if u.RawQuery != "" {
+				return nil, fmt.Errorf("query parameters not allowed with file URLs: got %v", u)
+			}
+			// Error messages are better if we check hostname and port separately.
+			if u.Port() != "" {
+				return nil, fmt.Errorf("ports not allowed with file URLs: got %v", u)
+			}
+			if hn := u.Hostname(); hn != "" && hn != "localhost" {
+				return nil, fmt.Errorf("file URLs must leave host empty or use localhost: got %v", u)
+			}
+
+			res = append(res, rotationSchema+":?path="+url.QueryEscape(u.Path))
+			continue
+		}
+		res = append(res, p)
+	}
+	return res, nil
 }

--- a/service/telemetry/telemetry_test.go
+++ b/service/telemetry/telemetry_test.go
@@ -5,6 +5,12 @@ package telemetry
 
 import (
 	"context"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -12,7 +18,12 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
+	"go.opentelemetry.io/collector/config/configrotate"
 	"go.opentelemetry.io/collector/config/configtelemetry"
+)
+
+const (
+	backupTimeFormat = "2006-01-02T15-04-05.000"
 )
 
 func TestTelemetryConfiguration(t *testing.T) {
@@ -117,5 +128,322 @@ func TestSampledLogger(t *testing.T) {
 			assert.NoError(t, err)
 			assert.NotNil(t, logger)
 		})
+	}
+}
+
+type loggerBuildTest struct {
+	name string
+	cfg  LogsConfig
+	opts []zap.Option
+}
+
+func normalLoggerConfig() LogsConfig {
+	return LogsConfig{
+		Level:       zapcore.InfoLevel,
+		Development: false,
+		Encoding:    "console",
+		Sampling: &LogsSamplingConfig{
+			Initial:    100,
+			Thereafter: 100,
+		},
+		Rotation: &configrotate.Config{
+			Enabled:      true,
+			MaxMegabytes: 123,
+			MaxDays:      14,
+			MaxBackups:   132,
+			LocalTime:    false,
+		},
+		OutputPaths:       []string{"stderr"},
+		ErrorOutputPaths:  []string{"stderr"},
+		DisableCaller:     false,
+		DisableStacktrace: false,
+		InitialFields:     map[string]any(nil),
+	}
+}
+
+func TestLoggerBuild(t *testing.T) {
+	t.Parallel()
+	tempDir := t.TempDir()
+	var tests []loggerBuildTest
+
+	cfg := normalLoggerConfig()
+	cfg.Rotation = nil
+	tests = append(tests, loggerBuildTest{
+		name: "non rotation config",
+		cfg:  cfg,
+	})
+
+	cfg = normalLoggerConfig()
+	tests = append(tests, loggerBuildTest{
+		name: "logger config with normal rotation config",
+		cfg:  cfg,
+	})
+
+	cfg = normalLoggerConfig()
+	cfg.OutputPaths = append(cfg.OutputPaths, path.Join(tempDir, "test.log"))
+	cfg.ErrorOutputPaths = append(cfg.ErrorOutputPaths, (&url.URL{
+		Scheme: "file",
+		Host:   "localhost",
+		Path:   filepath.Join(tempDir, "test.err.log"),
+	}).String())
+	tests = append(tests, loggerBuildTest{
+		name: "rotation config with file",
+		cfg:  cfg,
+	})
+
+	cfg = normalLoggerConfig()
+	cfg.Encoding = "json"
+	tests = append(tests, loggerBuildTest{
+		name: "rotation config with json encoding",
+		cfg:  cfg,
+	})
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := newLogger(tt.cfg, tt.opts)
+			assert.NoError(t, err)
+		})
+	}
+
+	// Sleep for 1 second to make sure all processes using the files are completed
+	// (on Windows fail to delete temp dir otherwise).
+	if runtime.GOOS == "windows" {
+		time.Sleep(1 * time.Second)
+	}
+}
+
+func TestWrongLoggerBuild(t *testing.T) {
+	t.Parallel()
+	tempDir := t.TempDir()
+	var tests []loggerBuildTest
+
+	cfg := normalLoggerConfig()
+	cfg.OutputPaths = append(cfg.OutputPaths, (&url.URL{
+		Scheme:   "file",
+		Path:     path.Join(tempDir, "test.err.log"),
+		RawQuery: "error=1",
+	}).String())
+	tests = append(tests, loggerBuildTest{
+		name: "rotation config with dirty URL",
+		cfg:  cfg,
+	})
+
+	cfg = normalLoggerConfig()
+	// query should be empty
+	cfg.OutputPaths = append(cfg.OutputPaths, "test.error.log?path=test")
+	tests = append(tests, loggerBuildTest{
+		name: "rotation config with dirty URL.",
+		cfg:  cfg,
+	})
+
+	cfg = normalLoggerConfig()
+	// non-existent schema
+	cfg.OutputPaths = append(cfg.OutputPaths, "none:test")
+	tests = append(tests, loggerBuildTest{
+		name: "rotation config with non-existent schema as outputPath.",
+		cfg:  cfg,
+	})
+
+	cfg = normalLoggerConfig()
+	cfg.Encoding = "jsonabcdefg"
+	tests = append(tests, loggerBuildTest{
+		name: "rotation config with invalid encoding",
+		cfg:  cfg,
+	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := newLogger(tt.cfg, tt.opts)
+			assert.Error(t, err)
+		})
+	}
+
+	// Sleep for 1 second to make sure all processes using the files are completed
+	// (on Windows fail to delete temp dir otherwise).
+	if runtime.GOOS == "windows" {
+		time.Sleep(1 * time.Second)
+	}
+}
+
+func TestRotateFile(t *testing.T) {
+	t.Skip("Skip this test because due to the goroutine leak of lumberjack")
+	// zap doesn't close the output file even after sleeping for 5s.
+	// This is not caused by lumberjack.
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping test for windows")
+	}
+
+	t.Parallel()
+	tempDir := t.TempDir()
+	tempFile := "test.log"
+	tempFileNameLen := 4
+	tempFileExtLen := 3
+	cfg := normalLoggerConfig()
+	// The default sampling will drop some duplicated logs
+	cfg.Sampling = nil
+	cfg.OutputPaths = []string{path.Join(tempDir, tempFile)}
+	cfg.Rotation.MaxMegabytes = 1
+	logger, err := newLogger(cfg, nil)
+	assert.NoError(t, err)
+
+	// write logs of about 1.1MB.
+	tsBeforeLogging := time.Now()
+	for i := 0; i < 1100; i++ {
+		logger.Error(strings.Repeat("abcdefghij", 100))
+	}
+	err = logger.Sync()
+	assert.NoError(t, err)
+	files, err := os.ReadDir(tempDir)
+	assert.NoError(t, err)
+	assert.Len(t, files, 2)
+
+	cntTempFile := 0
+	for _, file := range files {
+		fileName := file.Name()
+		if fileName == tempFile {
+			cntTempFile++
+			continue
+		}
+
+		tsString := fileName[tempFileNameLen+1 : len(fileName)-tempFileExtLen-1]
+		ts, err := time.Parse(backupTimeFormat, tsString)
+		assert.NoError(t, err)
+		assert.LessOrEqual(t, tsBeforeLogging, ts)
+		assert.LessOrEqual(t, ts, time.Now())
+	}
+	assert.Equal(t, cntTempFile, 1)
+}
+
+func TestLargeOldFile(t *testing.T) {
+	t.Skip("Skip this test because due to the goroutine leak of lumberjack")
+	// zap doesn't close the output file even after sleeping for 5s.
+	// This is not caused by lumberjack.
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping test for windows")
+	}
+
+	t.Parallel()
+	tempDir := t.TempDir()
+	tempFile := "test.log"
+	tempPath := path.Join(tempDir, tempFile)
+
+	// #nosec G304 -- tempPath is a trusted safe path
+	f, err := os.Create(tempPath)
+	assert.NoError(t, err)
+	num, err := f.WriteString(strings.Repeat("abcdefghij", 10000000))
+	assert.NoError(t, err)
+	assert.Equal(t, num, 100000000)
+	assert.NoError(t, f.Close())
+	stat, err := os.Stat(tempPath)
+	assert.NoError(t, err)
+
+	cfg := normalLoggerConfig()
+	cfg.OutputPaths = []string{tempPath}
+	cfg.Rotation.MaxMegabytes = 1
+	logger, err := newLogger(cfg, nil)
+	assert.NoError(t, err)
+
+	logger.Error("test log")
+	err = logger.Sync()
+
+	assert.NoError(t, err)
+	files, err := os.ReadDir(tempDir)
+	assert.NoError(t, err)
+	assert.Len(t, files, 2)
+
+	cntTempFile := 0
+	for _, file := range files {
+		fileName := file.Name()
+		if fileName == tempFile {
+			cntTempFile++
+			continue
+		}
+		newStat, err := file.Info()
+		assert.NoError(t, err)
+		assert.Equal(t, stat.Size(), newStat.Size())
+		assert.True(t, os.SameFile(stat, newStat))
+	}
+	assert.Equal(t, cntTempFile, 1)
+}
+
+func TestRelativePath(t *testing.T) {
+	t.Skip("Skip this test because due to the goroutine leak of lumberjack")
+	// zap doesn't close the output file even after sleeping for 5s.
+	// This is not caused by lumberjack.
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping test for windows")
+	}
+
+	tempDir := t.TempDir()
+	dir, err := os.Getwd()
+	assert.NoError(t, err)
+	assert.NoError(t, os.Chdir(tempDir))
+	t.Cleanup(func() {
+		assert.NoError(t, os.Chdir(dir))
+	})
+	tempFile := "test.log"
+
+	cfg := normalLoggerConfig()
+	cfg.OutputPaths = []string{tempFile}
+	logger, err := newLogger(cfg, nil)
+	assert.NoError(t, err)
+
+	logger.Error("test log")
+	assert.NoError(t, logger.Sync())
+
+	stat, err := os.Stat(path.Join(tempDir, tempFile))
+	assert.NoError(t, err)
+	assert.False(t, stat.IsDir())
+}
+
+func TestInvalidUrls(t *testing.T) {
+	tests := []struct {
+		Name   string
+		URL    string
+		ErrMsg string
+	}{
+		{
+			Name:   "Url includes user",
+			URL:    "file://user:pass@localhost/path",
+			ErrMsg: "user and password not allowed with file URLs",
+		},
+		{
+			Name:   "Url includes fragments",
+			URL:    "file://localhost/path#fragment",
+			ErrMsg: "fragments not allowed with file URLs",
+		},
+		{
+			Name:   "Url includes query",
+			URL:    "file://localhost/path?k=v",
+			ErrMsg: "query parameters not allowed with file URLs",
+		},
+		{
+			Name:   "Url includes ports",
+			URL:    "file://localhost:8080/path",
+			ErrMsg: "ports not allowed with file URLs",
+		},
+		{
+			Name:   "Url includes host ranther than localhost",
+			URL:    "file://example.com/path",
+			ErrMsg: "file URLs must leave host empty or use localhost",
+		},
+		{
+			Name:   "Url cannot be parsed: invalid control character in Url",
+			URL:    "file://localhost/\x00path",
+			ErrMsg: "invalid control character in URL",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			cfg := normalLoggerConfig()
+			cfg.ErrorOutputPaths = []string{tt.URL}
+			_, err := newLogger(cfg, nil)
+			assert.ErrorContains(t, err, tt.ErrMsg)
+		})
+	}
+
+	// Sleep for 1 second to make sure all processes using the files are completed
+	// (on Windows fail to delete temp dir otherwise).
+	if runtime.GOOS == "windows" {
+		time.Sleep(1 * time.Second)
 	}
 }


### PR DESCRIPTION
**Description:**
 Add log rotation support. The logs of otelcol itself will be rotated by lumberjack.

**Link to tracking Issue:**
#7352 

**Testing:**
Creating logger with or without rotation, logging with rotation and logging with an old big file are added in unit tests.

I did some simple testing on Linux, macOS, and Windows.
