### PR TITLE
[chore] use pull_request_target in gh action

### DIFF
--- a/.github/workflows/milestone-add-to-pr.yml
+++ b/.github/workflows/milestone-add-to-pr.yml
@@ -3,7 +3,7 @@
 
 name: 'Project: Add PR to Milestone'
 on:
-  pull_request:
+  pull_request_target:
     types:
       - closed
 
@@ -13,8 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@v6
-        env:
-          GITHUB_TOKEN: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}
         with:
           script: |
             const milestones = await github.rest.issues.listMilestones({


### PR DESCRIPTION
This solves the permission issue of pull request from remote forks.
