### PR TITLE
[consumer] Add retryable error types and add counts to permanent errors

### DIFF
--- a/consumer/consumererror/README.md
+++ b/consumer/consumererror/README.md
@@ -19,14 +19,19 @@ necessary for the Collector to act as a proxy for a backend, i.e. relay a status
 code returned from a backend in a response to a system upstream from the
 Collector.
 
+**Combining errors from multiple downstream consumers**: If errors occur in
+multiple components downstream from the caller in a pipeline, the caller should
+be able to combine the downstream errors into an error it returns.
+
 ## Creating an error
 
-To create a new error, call the `consumererror.New[Signal]` function with the
-error you want to wrap and any options that add additional metadata. Errors are
-either considered permanent or retryable, depending on whether the `WithRetry`
-option is passed. A permanent error indicates that the error will always occur
-for a given set of telemetry records and should be dropped. The permanence of an
-error can be checked with `consumererror.IsPermanent`.
+To create a new error, call the `consumererror.NewError` function with the error
+you want to wrap and any options that add additional metadata. Errors are either
+considered permanent or retryable, depending on whether the
+`WithRetryable[Signal]` option is passed. A permanent error indicates that the
+error will always occur for a given set of telemetry records and should be
+dropped. The permanence of an error can be checked with
+`consumererror.IsPermanent`.
 
 To help communicate information about the error to the caller, options with
 additional metadata may be included. While some of the options are semantically
@@ -35,15 +40,15 @@ together and the package will determine which option takes precedence.
 
 ### WithRejectedCount(rejected int)
 
-Include a count of the records that were rejected (spans, datapoints, log
-records, etc.). The caller should have a full count of rejected records, so this
-option is only needed to indicate a partial success.
+Include a count of the records that were permanently rejected (spans,
+datapoints, log records, etc.). The caller should have a full count of rejected
+records, so this option is only needed to indicate a partial success.
 
 When using this option in an exporter or other component dealing with mapping
 non-pdata formats, the rejected count should be based on the count of pdata
 records that failed.
 
-### WithRetry(pdata, ...RetryOptions)
+### WithRetryable\[Signal\](pdata, ...RetryOptions)
 
 Indicate that a temporary condition is the cause of an error and that the
 request should be retried with the default delay. Use of this option means that
@@ -63,6 +68,16 @@ exporting.
 Annotate the error with a gRPC status code obtained from a response during
 exporting.
 
+### WithDownstreamMetadata(consumererror.Error)
+
+Take metadata from a downstream error (e.g. network codes) when creating this
+error. Does not copy any signal data from the downstream error.
+
+### WithDownstreamErrors(...error)
+
+Allows fanout consumers to include multiple downstream errors as the cause of
+this error.
+
 ## Reading from an error
 
 The `consumererror.Error` type supports the following methods. Each method has a
@@ -70,21 +85,44 @@ method signature like `(data, bool)` with the second value indicating whether
 the option was passed during the error's creation.
 
 - `Count`: Get the count of permanently rejected records.
-- `Retry`: Gets the information necessary to retry the request.
+- `Retryable[Signal]`: Gets the information necessary to retry the request for a
+  given signal.
 - `ToHTTP`: Returns an integer representing the HTTP status code. If both
   `WithHTTPStatus` and `WithGRPCStatus` were passed, the HTTP status is used
   first and gRPC status second.
 - `ToGRPC`: Returns a `*status.Status` object representing the status returned
   from the gRPC server. If both `WithHTTPStatus` and `WithGRPCStatus` were
   passed, the gRPC status is used first and HTTP status second.
+- `DownstreamErrors`: Returns multiple downstream errors if multiple errors
+  happened downstream from this component.
+
+## Passing errors upstream
+
+When passing errors upstream, a component should ensure that all signal data and
+counts in an error come from the component itself and not from a downstream
+error. This way any processing that was done in the component isn't reflected in
+the data that is passed to the caller, which is expecting the included data to
+reflect what it sent downstream. To do this, use the `WithDownstreamMetadata`
+option when creating the new error, and pass any related signal data as part of
+it.
+
+## Other considerations
+
+### Asynchronous processing
+
+Note that the use of any components that do asynchronous processing, for example
+the batch processor, will cut off the upward flow of information at the
+asynchronous component. This means that something like a network status code
+cannot be propagated from an exporter to a receiver if the batch processor is
+used in the pipeline.
 
 ## Examples
 
 Creating an error:
 
 ```golang
-consumererror.NewTraces(
-    consumererror.WithRetry(
+consumererror.NewError(
+    consumererror.WithRetryableTraces(
         traces,
         consumererror.WithRetryDelay(2 * time.Duration)
     ),
@@ -103,10 +141,11 @@ if cErr, ok := consumererror.As(err); ok {
         statusCode = code
     }
     
-    retry, ok := cErr.Retry()
+    retry, ok := cErr.RetryableTraces()
 
     if ok {
         doRetry(retry)
     }
 }
 ```
+

--- a/consumer/consumererror/README.md
+++ b/consumer/consumererror/README.md
@@ -33,7 +33,7 @@ additional metadata may be included. While some of the options are semantically
 mutually-exclusive and shouldn't be combined, any set of options can be used
 together and the package will determine which option takes precedence.
 
-### WithCount(rejected int)
+### WithRejectedCount(rejected int)
 
 Include a count of the records that were rejected (spans, datapoints, log
 records, etc.). The caller should have a full count of rejected records, so this

--- a/consumer/consumererror/README.md
+++ b/consumer/consumererror/README.md
@@ -1,0 +1,112 @@
+# Consumer errors
+
+This package contains error types that should be returned by a consumer when an
+error occurs while processing telemetry. The error types included in this
+include functionality for communicating upstream in the pipeline details about
+the error for use by the caller. Ideally the top-level error returned by a
+consumer in its consume function should be from this package.
+
+## Use cases
+
+**Retry logic**: Errors should be allowed to embed rejected telemetry records to
+be retried by the consumer.
+
+**Indicating partial success**: Errors can indicate that not all records were
+accepted, for example as in an OTLP partial success message.
+
+**Communicating network error codes**: Errors should allow embedding information
+necessary for the Collector to act as a proxy for a backend, i.e. relay a status
+code returned from a backend in a response to a system upstream from the
+Collector.
+
+## Creating an error
+
+To create a new error, call the `consumererror.New[Signal]` function with the
+error you want to wrap and any options that add additional metadata. Errors are
+either considered permanent or retryable, depending on whether the `WithRetry`
+option is passed. A permanent error indicates that the error will always occur
+for a given set of telemetry records and should be dropped. The permanence of an
+error can be checked with `consumererror.IsPermanent`.
+
+To help communicate information about the error to the caller, options with
+additional metadata may be included. While some of the options are semantically
+mutually-exclusive and shouldn't be combined, any set of options can be used
+together and the package will determine which option takes precedence.
+
+### WithCount(rejected int)
+
+Include a count of the records that were rejected (spans, datapoints, log
+records, etc.). The caller should have a full count of rejected records, so this
+option is only needed to indicate a partial success.
+
+When using this option in an exporter or other component dealing with mapping
+non-pdata formats, the rejected count should be based on the count of pdata
+records that failed.
+
+### WithRetry(pdata, ...RetryOptions)
+
+Indicate that a temporary condition is the cause of an error and that the
+request should be retried with the default delay. Use of this option means that
+an error is not considered permanent.
+
+#### WithRetryDelay(delay time.Duration)
+
+Indicate that the payload should be retried after a certain amount of time.
+
+### WithHTTPStatus(int)
+
+Annotate the error with an HTTP status code obtained from a response during
+exporting.
+
+### WithGRPCStatus(*status.Status)
+
+Annotate the error with a gRPC status code obtained from a response during
+exporting.
+
+## Reading from an error
+
+The `consumererror.Error` type supports the following methods. Each method has a
+method signature like `(data, bool)` with the second value indicating whether
+the option was passed during the error's creation.
+
+- `Count`: Get the count of permanently rejected records.
+- `Retry`: Gets the information necessary to retry the request.
+- `ToHTTP`: Returns an integer representing the HTTP status code. If both
+  `WithHTTPStatus` and `WithGRPCStatus` were passed, the HTTP status is used
+  first and gRPC status second.
+- `ToGRPC`: Returns a `*status.Status` object representing the status returned
+  from the gRPC server. If both `WithHTTPStatus` and `WithGRPCStatus` were
+  passed, the gRPC status is used first and HTTP status second.
+
+## Examples
+
+Creating an error:
+
+```golang
+consumererror.NewTraces(
+    consumererror.WithRetry(
+        traces,
+        consumererror.WithRetryDelay(2 * time.Duration)
+    ),
+    consumererror.WithHTTPStatus(429)
+)
+```
+
+Using an error:
+
+```golang
+err := nextConsumer(ctx, traces)
+
+if cErr, ok := consumererror.As(err); ok {
+    code, ok := cErr.ToHTTP()
+    if ok {
+        statusCode = code
+    }
+    
+    retry, ok := cErr.Retry()
+
+    if ok {
+        doRetry(retry)
+    }
+}
+```

--- a/consumer/consumererror/permanent.go
+++ b/consumer/consumererror/permanent.go
@@ -19,42 +19,36 @@ import (
 	"strconv"
 )
 
-// NO_DATA_COUNT indicates an unknown quantity of telemetry items.
-const NO_DATA_COUNT = -1
+// noDataCount indicates an unknown number of records.
+const noDataCount = -1
 
 // Permanent is an error that will always be returned if its source
 // receives the same inputs.
 type Permanent struct {
 	error
-	successful int
-	failed     int
+	rejected int
 }
 
-// Deprecated [v0.75.0] Use consumererror.NewPermanentWithCounts instead.
+// Deprecated [v0.76.0] Use consumererror.NewPermanentWithCount instead.
 func NewPermanent(err error) error {
-	return Permanent{error: err, successful: NO_DATA_COUNT, failed: NO_DATA_COUNT}
+	return Permanent{error: err, rejected: noDataCount}
 }
 
-// NewPermanentWithCounts wraps an error to indicate that it is a permanent error, i.e. an
+// NewPermanentWithCount wraps an error to indicate that it is a permanent error, i.e. an
 // error that will be always returned if its source receives the same inputs.
-// The error should also include the number of successful and failed telemetry items
-// if the counts are known. Unknown counts should be set to consumererror.NO_DATA_COUNT.
-func NewPermanentWithCounts(err error, successful, failed int) error {
-	return Permanent{error: err, successful: successful, failed: failed}
+// The error should also include the number of rejected records.
+func NewPermanentWithCount(err error, rejected int) error {
+	return Permanent{error: err, rejected: rejected}
 }
 
 func (p Permanent) Error() string {
-	successful := "unknown"
-	failed := "unknown"
+	rejected := "unknown"
 
-	if p.successful != NO_DATA_COUNT {
-		successful = strconv.Itoa(p.successful)
-	}
-	if p.failed != NO_DATA_COUNT {
-		failed = strconv.Itoa(p.failed)
+	if p.rejected != noDataCount {
+		rejected = strconv.Itoa(p.rejected)
 	}
 
-	return "Permanent error (" + successful + " successful, " + failed + " failed): " + p.error.Error()
+	return "Permanent error (" + rejected + " rejected): " + p.error.Error()
 }
 
 // Unwrap returns the wrapped error for use by `errors.Is` and `errors.As`.
@@ -62,12 +56,8 @@ func (p Permanent) Unwrap() error {
 	return p.error
 }
 
-func (p Permanent) Successful() int {
-	return p.successful
-}
-
-func (p Permanent) Failed() int {
-	return p.failed
+func (p Permanent) Rejected() int {
+	return p.rejected
 }
 
 // IsPermanent checks if an error was wrapped with the NewPermanent function, which

--- a/consumer/consumererror/permanent_test.go
+++ b/consumer/consumererror/permanent_test.go
@@ -63,27 +63,25 @@ func TestPermanent_Unwrap(t *testing.T) {
 }
 
 func TestPermanent_WithCounts(t *testing.T) {
-	err := NewPermanentWithCounts(testErrorType{"testError"}, 1, 2)
+	err := NewPermanentWithCount(testErrorType{"testError"}, 1, 2)
 	require.True(t, IsPermanent(err))
 
 	permanentError, ok := err.(Permanent)
 	require.True(t, ok, "Error isn't a permanent error")
-	require.Equal(t, 1, permanentError.Successful())
-	require.Equal(t, 2, permanentError.Failed())
+	require.Equal(t, 2, permanentError.Rejected())
 }
 
 func TestPermanent_NoCounts(t *testing.T) {
-	err := NewPermanentWithCounts(testErrorType{"testError"}, NO_DATA_COUNT, NO_DATA_COUNT)
+	err := NewPermanentWithCount(testErrorType{"testError"}, noDataCount)
 	require.True(t, IsPermanent(err))
 
 	permanentError, ok := err.(Permanent)
 	require.True(t, ok, "Error isn't a permanent error")
-	require.Equal(t, NO_DATA_COUNT, permanentError.Successful())
-	require.Equal(t, NO_DATA_COUNT, permanentError.Failed())
+	require.Equal(t, noDataCount, permanentError.Rejected())
 }
 
 func TestPermanent_ErrorMessageWithCounts(t *testing.T) {
-	err := NewPermanentWithCounts(testErrorType{"testError"}, 1, 2)
+	err := NewPermanentWithCount(testErrorType{"testError"}, 1, 2)
 	require.True(t, IsPermanent(err))
 
 	permanentError, ok := err.(Permanent)
@@ -94,7 +92,7 @@ func TestPermanent_ErrorMessageWithCounts(t *testing.T) {
 }
 
 func TestPermanent_ErrorMessageNoCounts(t *testing.T) {
-	err := NewPermanentWithCounts(testErrorType{"testError"}, NO_DATA_COUNT, NO_DATA_COUNT)
+	err := NewPermanentWithCount(testErrorType{"testError"}, noDataCount)
 	require.True(t, IsPermanent(err))
 
 	permanentError, ok := err.(Permanent)

--- a/consumer/consumererror/permanent_test.go
+++ b/consumer/consumererror/permanent_test.go
@@ -61,3 +61,45 @@ func TestPermanent_Unwrap(t *testing.T) {
 
 	require.Equal(t, err, target)
 }
+
+func TestPermanent_WithCounts(t *testing.T) {
+	err := NewPermanentWithCounts(testErrorType{"testError"}, 1, 2)
+	require.True(t, IsPermanent(err))
+
+	permanentError, ok := err.(Permanent)
+	require.True(t, ok, "Error isn't a permanent error")
+	require.Equal(t, 1, permanentError.Successful())
+	require.Equal(t, 2, permanentError.Failed())
+}
+
+func TestPermanent_NoCounts(t *testing.T) {
+	err := NewPermanentWithCounts(testErrorType{"testError"}, NO_DATA_COUNT, NO_DATA_COUNT)
+	require.True(t, IsPermanent(err))
+
+	permanentError, ok := err.(Permanent)
+	require.True(t, ok, "Error isn't a permanent error")
+	require.Equal(t, NO_DATA_COUNT, permanentError.Successful())
+	require.Equal(t, NO_DATA_COUNT, permanentError.Failed())
+}
+
+func TestPermanent_ErrorMessageWithCounts(t *testing.T) {
+	err := NewPermanentWithCounts(testErrorType{"testError"}, 1, 2)
+	require.True(t, IsPermanent(err))
+
+	permanentError, ok := err.(Permanent)
+	require.True(t, ok, "Error isn't a permanent error")
+	require.ErrorContains(t, permanentError, "1 successful")
+	require.ErrorContains(t, permanentError, "2 failed")
+	require.ErrorContains(t, permanentError, permanentError.Unwrap().Error())
+}
+
+func TestPermanent_ErrorMessageNoCounts(t *testing.T) {
+	err := NewPermanentWithCounts(testErrorType{"testError"}, NO_DATA_COUNT, NO_DATA_COUNT)
+	require.True(t, IsPermanent(err))
+
+	permanentError, ok := err.(Permanent)
+	require.True(t, ok, "Error isn't a permanent error")
+	require.ErrorContains(t, permanentError, "unknown successful")
+	require.ErrorContains(t, permanentError, "unknown failed")
+	require.ErrorContains(t, permanentError, permanentError.Unwrap().Error())
+}

--- a/consumer/consumererror/retryable.go
+++ b/consumer/consumererror/retryable.go
@@ -53,7 +53,7 @@ type RetryableTraces struct {
 	retryable[ptrace.Traces]
 }
 
-// Deprecated [v0.75.0] Use `RetryableTraces` instead
+// Deprecated [v0.76.0] Use `RetryableTraces` instead
 type Traces RetryableTraces
 
 // NewRetryableTraces creates a Traces that can encapsulate received data that failed to be processed or sent.
@@ -66,7 +66,7 @@ func NewRetryableTraces(err error, data ptrace.Traces) error {
 	}
 }
 
-// Deprecated [v0.75.0] Use `NewRetryableTraces` instead
+// Deprecated [v0.76.0] Use `NewRetryableTraces` instead
 func NewTraces(err error, data ptrace.Traces) error {
 	return NewRetryableTraces(err, data)
 }

--- a/obsreport/obsreport_exporter.go
+++ b/obsreport/obsreport_exporter.go
@@ -261,7 +261,7 @@ func toNumItems(numExportedItems int, err error) (int64, int64) {
 	if err != nil {
 		var permErr consumererror.Permanent
 		if errors.As(err, &permErr) { {
-			rejected := int64(e.Rejected())
+			rejected := int64(permErr.Rejected())
 			return int64(numExportedItems) - rejected, rejected
 		}
 		return 0, int64(numExportedItems)

--- a/obsreport/obsreport_exporter.go
+++ b/obsreport/obsreport_exporter.go
@@ -16,6 +16,7 @@ package obsreport // import "go.opentelemetry.io/collector/obsreport"
 
 import (
 	"context"
+	"errors"
 
 	"go.opencensus.io/stats"
 	"go.opencensus.io/tag"
@@ -260,7 +261,7 @@ func endSpan(ctx context.Context, err error, numSent, numFailedToSend int64, sen
 func toNumItems(numExportedItems int, err error) (int64, int64) {
 	if err != nil {
 		var permErr consumererror.Permanent
-		if errors.As(err, &permErr) { {
+		if errors.As(err, &permErr) {
 			rejected := int64(permErr.Rejected())
 			return int64(numExportedItems) - rejected, rejected
 		}

--- a/obsreport/obsreport_exporter.go
+++ b/obsreport/obsreport_exporter.go
@@ -259,7 +259,8 @@ func endSpan(ctx context.Context, err error, numSent, numFailedToSend int64, sen
 
 func toNumItems(numExportedItems int, err error) (int64, int64) {
 	if err != nil {
-		if e, ok := err.(consumererror.Permanent); ok {
+		var permErr consumererror.Permanent
+		if errors.As(err, &permErr) { {
 			rejected := int64(e.Rejected())
 			return int64(numExportedItems) - rejected, rejected
 		}


### PR DESCRIPTION
**Description:**
This will replace `exporterhelper.throttleRetry` with `consumererror.Retryable[Traces|Metrics|Logs]` types and add success/fail counts to the permanent error types.

Right now this PR is just intended to be a discussion point for how these types should look. I will complete a full implementation once there is consensus on how these should look.

**Link to tracking Issue:**

Resolves https://github.com/open-telemetry/opentelemetry-collector/issues/7047
