### PR TITLE
[loggingexporter] Fix display of bucket boundaries of exponential histograms

### DIFF
--- a/.chloggen/fix_loggingexporter_exponential_histogram_buckets.yaml
+++ b/.chloggen/fix_loggingexporter_exponential_histogram_buckets.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: loggingexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix display of bucket boundaries of exponential histograms to correctly reflect inclusive/exclusive bounds.
+
+# One or more tracking issues or pull requests related to the change
+issues: []

--- a/.chloggen/fix_loggingexporter_exponential_histogram_buckets.yaml
+++ b/.chloggen/fix_loggingexporter_exponential_histogram_buckets.yaml
@@ -8,4 +8,4 @@ component: loggingexporter
 note: Fix display of bucket boundaries of exponential histograms to correctly reflect inclusive/exclusive bounds.
 
 # One or more tracking issues or pull requests related to the change
-issues: []
+issues: [7445]

--- a/exporter/loggingexporter/internal/otlptext/databuffer.go
+++ b/exporter/loggingexporter/internal/otlptext/databuffer.go
@@ -189,7 +189,7 @@ func (b *dataBuffer) logExponentialHistogramDataPoints(ps pmetric.ExponentialHis
 			index := p.Negative().Offset() + int32(pos)
 			lower := math.Exp(float64(index) * factor)
 			upper := math.Exp(float64(index+1) * factor)
-			b.logEntry("Bucket (%f, %f], Count: %d", -upper, -lower, negB.At(pos))
+			b.logEntry("Bucket [%f, %f), Count: %d", -upper, -lower, negB.At(pos))
 		}
 
 		if p.ZeroCount() != 0 {
@@ -200,7 +200,7 @@ func (b *dataBuffer) logExponentialHistogramDataPoints(ps pmetric.ExponentialHis
 			index := p.Positive().Offset() + int32(pos)
 			lower := math.Exp(float64(index) * factor)
 			upper := math.Exp(float64(index+1) * factor)
-			b.logEntry("Bucket [%f, %f), Count: %d", lower, upper, posB.At(pos))
+			b.logEntry("Bucket (%f, %f], Count: %d", lower, upper, posB.At(pos))
 		}
 	}
 }

--- a/exporter/loggingexporter/internal/otlptext/testdata/metrics/metrics_with_all_types.out
+++ b/exporter/loggingexporter/internal/otlptext/testdata/metrics/metrics_with_all_types.out
@@ -127,11 +127,11 @@ StartTimestamp: 2020-02-11 20:26:12.000000321 +0000 UTC
 Timestamp: 2020-02-11 20:26:13.000000789 +0000 UTC
 Count: 5
 Sum: 0.150000
-Bucket (-1.414214, -1.000000], Count: 1
-Bucket (-1.000000, -0.707107], Count: 1
+Bucket [-1.414214, -1.000000), Count: 1
+Bucket [-1.000000, -0.707107), Count: 1
 Bucket [0, 0], Count: 1
-Bucket [1.414214, 2.000000), Count: 1
-Bucket [2.000000, 2.828427), Count: 1
+Bucket (1.414214, 2.000000], Count: 1
+Bucket (2.000000, 2.828427], Count: 1
 ExponentialHistogramDataPoints #1
 Data point attributes:
      -> label-2: Str(label-value-2)
@@ -142,8 +142,8 @@ Sum: 1.250000
 Min: 0.000000
 Max: 1.000000
 Bucket [0, 0], Count: 1
-Bucket [0.250000, 1.000000), Count: 1
-Bucket [1.000000, 4.000000), Count: 1
+Bucket (0.250000, 1.000000], Count: 1
+Bucket (1.000000, 4.000000], Count: 1
 Metric #6
 Descriptor:
      -> Name: summary


### PR DESCRIPTION
The interval notation used for displaying bucket boundaries of exponential histograms was incorrect.

Should be:
Negative buckets -> lower bound is inclusive, upper bound exclusive
Positive buckets -> lower bound is exclusive, upper bound inclusive

See: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/data-model.md#exponential-buckets

> The ExponentialHistogram bucket identified by index, a signed integer, represents values in the population that are greater than base\*\*index and less than or equal to base\*\*(index+1).
>
> The positive and negative ranges of the histogram are expressed separately. Negative values are mapped by their absolute value into the negative range using the same scale as the positive range. Note that in the negative range, therefore, histogram buckets use lower-inclusive boundaries.