### PR TITLE
[chore] Add omitempty for marshalling of logexporter

### DIFF
--- a/exporter/loggingexporter/config.go
+++ b/exporter/loggingexporter/config.go
@@ -38,10 +38,10 @@ var (
 type Config struct {
 	// LogLevel defines log level of the logging exporter; options are debug, info, warn, error.
 	// Deprecated: Use `Verbosity` instead.
-	LogLevel zapcore.Level `mapstructure:"loglevel"`
+	LogLevel zapcore.Level `mapstructure:"loglevel,omitempty"`
 
 	// Verbosity defines the logging exporter verbosity.
-	Verbosity configtelemetry.Level `mapstructure:"verbosity"`
+	Verbosity configtelemetry.Level `mapstructure:"verbosity,omitempty"`
 
 	// SamplingInitial defines how many samples are initially logged during each second.
 	SamplingInitial int `mapstructure:"sampling_initial"`

--- a/exporter/loggingexporter/config_test.go
+++ b/exporter/loggingexporter/config_test.go
@@ -155,11 +155,8 @@ func Test_UnmarshalMarshalled(t *testing.T) {
 			}
 			assert.Error(t, err)
 			assert.EqualError(t, err, tc.expectedErr)
-
 		})
-
 	}
-
 }
 
 func TestValidate(t *testing.T) {

--- a/exporter/loggingexporter/config_test.go
+++ b/exporter/loggingexporter/config_test.go
@@ -97,6 +97,71 @@ func TestUnmarshalConfig(t *testing.T) {
 	}
 }
 
+func Test_UnmarshalMarshalled(t *testing.T) {
+	for name, tc := range map[string]struct {
+		inCfg          *Config
+		expectedConfig *Config
+		expectedErr    string
+	}{
+		"Base": {
+			inCfg:          &Config{},
+			expectedConfig: &Config{},
+		},
+		"VerbositySpecified": {
+			inCfg: &Config{
+				Verbosity: configtelemetry.LevelDetailed,
+			},
+			expectedConfig: &Config{
+				Verbosity: configtelemetry.LevelDetailed,
+			},
+		},
+		"LogLevelSpecified": {
+			inCfg: &Config{
+				LogLevel: zapcore.DebugLevel,
+			},
+			expectedConfig: &Config{
+				LogLevel:     zapcore.DebugLevel,
+				Verbosity:    configtelemetry.LevelDetailed,
+				warnLogLevel: true,
+			},
+		},
+		"SpecifiedLogLevelExpectedErr": {
+			inCfg: &Config{
+				// Cannot specify both log level and verbosity so an error is expected
+				LogLevel:  zapcore.DebugLevel,
+				Verbosity: configtelemetry.LevelNormal,
+			},
+			expectedErr: "'loglevel' and 'verbosity' are incompatible. Use only 'verbosity' instead",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+
+			conf := confmap.New()
+			err := conf.Marshal(tc.inCfg)
+			assert.NoError(t, err)
+
+			raw := conf.ToStringMap()
+
+			conf = confmap.NewFromStringMap(raw)
+
+			outCfg := &Config{}
+
+			err = component.UnmarshalConfig(conf, outCfg)
+
+			if tc.expectedErr == "" {
+				assert.NoError(t, err)
+				assert.Equal(t, outCfg, tc.expectedConfig)
+				return
+			}
+			assert.Error(t, err)
+			assert.EqualError(t, err, tc.expectedErr)
+
+		})
+
+	}
+
+}
+
 func TestValidate(t *testing.T) {
 	tests := []struct {
 		name        string


### PR DESCRIPTION
**Description:** Fixing a bug: Add omitempty to the LogLevel and Verbosity fields so that marshalling them drop deprecated fields

We are importing the logexporter to build our config but leaving the loglevel empty is not removing it from the marshalling since it doesn't have omitempty. Viceversa since the code only allows either LogLevel of Verbosity it makes sense to also omitempty Verbosity as well. 

The default values should handle cases where users don't specify these values. Once LogLevel is fully removed the Verbosity omitempty could be removed if so desired. 

**Testing:** Unit testing added 



