### PR TITLE
Enable `useOtelForInternalMetrics` by default

### DIFF
--- a/.chloggen/codeboten_use-otel-for-metrics.yaml
+++ b/.chloggen/codeboten_use-otel-for-metrics.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: obsreport
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Enable `useOtelForInternalMetrics` by default"
+
+# One or more tracking issues or pull requests related to the change
+issues: [5687]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/internal/obsreportconfig/obsreportconfig.go
+++ b/internal/obsreportconfig/obsreportconfig.go
@@ -28,7 +28,7 @@ import (
 // telemetrySettings for internal metrics.
 var UseOtelForInternalMetricsfeatureGate = featuregate.GlobalRegistry().MustRegister(
 	"telemetry.useOtelForInternalMetrics",
-	featuregate.StageAlpha,
+	featuregate.StageBeta,
 	featuregate.WithRegisterDescription("controls whether the collector uses OpenTelemetry for internal metrics"))
 
 // AllViews returns all the OpenCensus views requires by obsreport package.


### PR DESCRIPTION
Following up on enabling otel metrics by default as per the comment https://github.com/open-telemetry/opentelemetry-collector/issues/5687#issuecomment-1276921970

Fixes #7454
