### PR TITLE
Clarify that memory limiter refuses data, doesn't drop it

### DIFF
--- a/processor/memorylimiterprocessor/config.go
+++ b/processor/memorylimiterprocessor/config.go
@@ -13,8 +13,7 @@
 // limitations under the License.
 
 // Package memorylimiterprocessor provides a processor for OpenTelemetry Service pipeline
-// that drops data on the pipeline according to the current state of memory
-// usage.
+// that refuses data on the pipeline according to the current state of memory usage.
 package memorylimiterprocessor // import "go.opentelemetry.io/collector/processor/memorylimiterprocessor"
 
 import (

--- a/processor/memorylimiterprocessor/internal/mock_exporter.go
+++ b/processor/memorylimiterprocessor/internal/mock_exporter.go
@@ -1,0 +1,78 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal // import "go.opentelemetry.io/collector/processor/memorylimiterprocessor/internal"
+
+import (
+	"context"
+	"sync/atomic"
+
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/pdata/plog"
+)
+
+type MockExporter struct {
+	destAvailable     int64
+	acceptedLogCount  int64
+	deliveredLogCount int64
+	Logs              []plog.Logs
+}
+
+var _ consumer.Logs = (*MockExporter)(nil)
+
+func (e *MockExporter) Capabilities() consumer.Capabilities {
+	return consumer.Capabilities{}
+}
+
+func (e *MockExporter) ConsumeLogs(_ context.Context, ld plog.Logs) error {
+	atomic.AddInt64(&e.acceptedLogCount, int64(ld.LogRecordCount()))
+
+	if atomic.LoadInt64(&e.destAvailable) == 1 {
+		// Destination is available, immediately deliver.
+		atomic.AddInt64(&e.deliveredLogCount, int64(ld.LogRecordCount()))
+	} else {
+		// Destination is not available. Queue the logs in the exporter.
+		e.Logs = append(e.Logs, ld)
+	}
+	return nil
+}
+
+func (e *MockExporter) SetDestAvailable(available bool) {
+	if available {
+		// Pretend we delivered all queued accepted logs.
+		atomic.AddInt64(&e.deliveredLogCount, e.acceptedLogCount)
+
+		// Get rid of the delivered logs so that memory can be collected.
+		e.Logs = nil
+
+		// Now mark destination available so that subsequent ConsumeLogs
+		// don't queue the logs anymore.
+		atomic.StoreInt64(&e.destAvailable, 1)
+
+	} else {
+		atomic.StoreInt64(&e.destAvailable, 0)
+	}
+}
+
+func (e *MockExporter) AcceptedLogCount() int {
+	return int(atomic.LoadInt64(&e.acceptedLogCount))
+}
+
+func (e *MockExporter) DeliveredLogCount() int {
+	return int(atomic.LoadInt64(&e.deliveredLogCount))
+}
+
+func NewMockExporter() *MockExporter {
+	return &MockExporter{}
+}

--- a/processor/memorylimiterprocessor/internal/mock_receiver.go
+++ b/processor/memorylimiterprocessor/internal/mock_receiver.go
@@ -1,0 +1,72 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal // import "go.opentelemetry.io/collector/processor/memorylimiterprocessor/internal"
+
+import (
+	"context"
+	"strings"
+	"sync"
+
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/consumer/consumererror"
+	"go.opentelemetry.io/collector/pdata/plog"
+)
+
+type MockReceiver struct {
+	ProduceCount      int
+	NextConsumer      consumer.Logs
+	lastConsumeResult error
+	mux               sync.Mutex
+}
+
+func (m *MockReceiver) Start() {
+	go m.produce()
+}
+
+// This function demonstrates how the receivers should behave when the ConsumeLogs/Traces/Metrics
+// call returns an error.
+func (m *MockReceiver) produce() {
+	for i := 0; i < m.ProduceCount; i++ {
+		// Create a large log to consume some memory.
+		ld := plog.NewLogs()
+		lr := ld.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
+		kiloStr := strings.Repeat("x", 10*1024)
+		lr.SetSeverityText(kiloStr)
+
+	retry:
+		// Send to the pipeline.
+		err := m.NextConsumer.ConsumeLogs(context.Background(), ld)
+
+		// Remember the result to be used in the tests.
+		m.mux.Lock()
+		m.lastConsumeResult = err
+		m.mux.Unlock()
+
+		if err != nil {
+			// Sending to the pipeline failed.
+			if !consumererror.IsPermanent(err) {
+				// Retryable error. Try the same data again.
+				goto retry
+			}
+			// Permanent error. Drop it.
+		}
+	}
+}
+
+func (m *MockReceiver) LastConsumeResult() error {
+	m.mux.Lock()
+	defer m.mux.Unlock()
+	return m.lastConsumeResult
+}

--- a/processor/memorylimiterprocessor/memorylimiter_test.go
+++ b/processor/memorylimiterprocessor/memorylimiter_test.go
@@ -35,6 +35,8 @@ import (
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.opentelemetry.io/collector/processor"
+	"go.opentelemetry.io/collector/processor/memorylimiterprocessor/internal"
 	"go.opentelemetry.io/collector/processor/processorhelper"
 	"go.opentelemetry.io/collector/processor/processortest"
 )
@@ -112,7 +114,7 @@ func TestMetricsMemoryPressureResponse(t *testing.T) {
 		usageChecker: memUsageChecker{
 			memAllocLimit: 1024,
 		},
-		forceDrop: &atomic.Bool{},
+		mustRefuse: &atomic.Bool{},
 		readMemStatsFn: func(ms *runtime.MemStats) {
 			ms.Alloc = currentMemAlloc
 		},
@@ -140,7 +142,7 @@ func TestMetricsMemoryPressureResponse(t *testing.T) {
 	// Above memAllocLimit.
 	currentMemAlloc = 1800
 	ml.checkMemLimits()
-	assert.Equal(t, errForcedDrop, mp.ConsumeMetrics(ctx, md))
+	assert.Equal(t, errDataRefused, mp.ConsumeMetrics(ctx, md))
 
 	// Check ballast effect
 	ml.ballastSize = 1000
@@ -153,7 +155,7 @@ func TestMetricsMemoryPressureResponse(t *testing.T) {
 	// Above memAllocLimit even accountiing for ballast.
 	currentMemAlloc = 1800 + ml.ballastSize
 	ml.checkMemLimits()
-	assert.Equal(t, errForcedDrop, mp.ConsumeMetrics(ctx, md))
+	assert.Equal(t, errDataRefused, mp.ConsumeMetrics(ctx, md))
 
 	// Restore ballast to default.
 	ml.ballastSize = 0
@@ -169,7 +171,7 @@ func TestMetricsMemoryPressureResponse(t *testing.T) {
 	// Above memSpikeLimit.
 	currentMemAlloc = 550
 	ml.checkMemLimits()
-	assert.Equal(t, errForcedDrop, mp.ConsumeMetrics(ctx, md))
+	assert.Equal(t, errDataRefused, mp.ConsumeMetrics(ctx, md))
 
 }
 
@@ -181,7 +183,7 @@ func TestTraceMemoryPressureResponse(t *testing.T) {
 		usageChecker: memUsageChecker{
 			memAllocLimit: 1024,
 		},
-		forceDrop: &atomic.Bool{},
+		mustRefuse: &atomic.Bool{},
 		readMemStatsFn: func(ms *runtime.MemStats) {
 			ms.Alloc = currentMemAlloc
 		},
@@ -209,7 +211,7 @@ func TestTraceMemoryPressureResponse(t *testing.T) {
 	// Above memAllocLimit.
 	currentMemAlloc = 1800
 	ml.checkMemLimits()
-	assert.Equal(t, errForcedDrop, tp.ConsumeTraces(ctx, td))
+	assert.Equal(t, errDataRefused, tp.ConsumeTraces(ctx, td))
 
 	// Check ballast effect
 	ml.ballastSize = 1000
@@ -222,7 +224,7 @@ func TestTraceMemoryPressureResponse(t *testing.T) {
 	// Above memAllocLimit even accountiing for ballast.
 	currentMemAlloc = 1800 + ml.ballastSize
 	ml.checkMemLimits()
-	assert.Equal(t, errForcedDrop, tp.ConsumeTraces(ctx, td))
+	assert.Equal(t, errDataRefused, tp.ConsumeTraces(ctx, td))
 
 	// Restore ballast to default.
 	ml.ballastSize = 0
@@ -238,7 +240,7 @@ func TestTraceMemoryPressureResponse(t *testing.T) {
 	// Above memSpikeLimit.
 	currentMemAlloc = 550
 	ml.checkMemLimits()
-	assert.Equal(t, errForcedDrop, tp.ConsumeTraces(ctx, td))
+	assert.Equal(t, errDataRefused, tp.ConsumeTraces(ctx, td))
 
 }
 
@@ -250,7 +252,7 @@ func TestLogMemoryPressureResponse(t *testing.T) {
 		usageChecker: memUsageChecker{
 			memAllocLimit: 1024,
 		},
-		forceDrop: &atomic.Bool{},
+		mustRefuse: &atomic.Bool{},
 		readMemStatsFn: func(ms *runtime.MemStats) {
 			ms.Alloc = currentMemAlloc
 		},
@@ -278,7 +280,7 @@ func TestLogMemoryPressureResponse(t *testing.T) {
 	// Above memAllocLimit.
 	currentMemAlloc = 1800
 	ml.checkMemLimits()
-	assert.Equal(t, errForcedDrop, lp.ConsumeLogs(ctx, ld))
+	assert.Equal(t, errDataRefused, lp.ConsumeLogs(ctx, ld))
 
 	// Check ballast effect
 	ml.ballastSize = 1000
@@ -291,7 +293,7 @@ func TestLogMemoryPressureResponse(t *testing.T) {
 	// Above memAllocLimit even accountiing for ballast.
 	currentMemAlloc = 1800 + ml.ballastSize
 	ml.checkMemLimits()
-	assert.Equal(t, errForcedDrop, lp.ConsumeLogs(ctx, ld))
+	assert.Equal(t, errDataRefused, lp.ConsumeLogs(ctx, ld))
 
 	// Restore ballast to default.
 	ml.ballastSize = 0
@@ -307,7 +309,7 @@ func TestLogMemoryPressureResponse(t *testing.T) {
 	// Above memSpikeLimit.
 	currentMemAlloc = 550
 	ml.checkMemLimits()
-	assert.Equal(t, errForcedDrop, lp.ConsumeLogs(ctx, ld))
+	assert.Equal(t, errDataRefused, lp.ConsumeLogs(ctx, ld))
 }
 
 func TestGetDecision(t *testing.T) {
@@ -349,7 +351,7 @@ func TestGetDecision(t *testing.T) {
 	})
 }
 
-func TestDropDecision(t *testing.T) {
+func TestRefuseDecision(t *testing.T) {
 	decison1000Limit30Spike30, err := newPercentageMemUsageChecker(1000, 60, 30)
 	require.NoError(t, err)
 	decison1000Limit60Spike50, err := newPercentageMemUsageChecker(1000, 60, 50)
@@ -364,46 +366,46 @@ func TestDropDecision(t *testing.T) {
 		name         string
 		usageChecker memUsageChecker
 		ms           *runtime.MemStats
-		shouldDrop   bool
+		shouldRefuse bool
 	}{
 		{
-			name:         "should drop over limit",
+			name:         "should refuse over limit",
 			usageChecker: *decison1000Limit30Spike30,
 			ms:           &runtime.MemStats{Alloc: 600},
-			shouldDrop:   true,
+			shouldRefuse: true,
 		},
 		{
-			name:         "should not drop",
+			name:         "should not refuse",
 			usageChecker: *decison1000Limit30Spike30,
 			ms:           &runtime.MemStats{Alloc: 100},
-			shouldDrop:   false,
+			shouldRefuse: false,
 		},
 		{
-			name: "should not drop spike, fixed usageChecker",
+			name: "should not refuse spike, fixed usageChecker",
 			usageChecker: memUsageChecker{
 				memAllocLimit: 600,
 				memSpikeLimit: 500,
 			},
-			ms:         &runtime.MemStats{Alloc: 300},
-			shouldDrop: true,
+			ms:           &runtime.MemStats{Alloc: 300},
+			shouldRefuse: true,
 		},
 		{
-			name:         "should drop, spike, percentage usageChecker",
+			name:         "should refuse, spike, percentage usageChecker",
 			usageChecker: *decison1000Limit60Spike50,
 			ms:           &runtime.MemStats{Alloc: 300},
-			shouldDrop:   true,
+			shouldRefuse: true,
 		},
 		{
-			name:         "should drop, spike, percentage usageChecker",
+			name:         "should refuse, spike, percentage usageChecker",
 			usageChecker: *decison1000Limit40Spike20,
 			ms:           &runtime.MemStats{Alloc: 250},
-			shouldDrop:   true,
+			shouldRefuse: true,
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			shouldDrop := test.usageChecker.aboveSoftLimit(test.ms)
-			assert.Equal(t, test.shouldDrop, shouldDrop)
+			shouldRefuse := test.usageChecker.aboveSoftLimit(test.ms)
+			assert.Equal(t, test.shouldRefuse, shouldRefuse)
 		})
 	}
 }
@@ -451,4 +453,87 @@ func newObsReport(t *testing.T) *obsreport.Processor {
 	require.NoError(t, err)
 
 	return proc
+}
+
+func TestNoDataLoss(t *testing.T) {
+	// Create an exporter.
+	exporter := internal.NewMockExporter()
+
+	// Mark exporter's destination unavailable. The exporter will accept data and will queue it,
+	// thus increasing the memory usage of the Collector.
+	exporter.SetDestAvailable(false)
+
+	// Create a memory limiter processor.
+
+	cfg := createDefaultConfig().(*Config)
+
+	// Check frequently to make the test quick.
+	cfg.CheckInterval = time.Millisecond * 10
+
+	// By how much we expect memory usage to increase because of queuing up of produced data.
+	const expectedMemoryIncreaseMiB = 10
+
+	var ms runtime.MemStats
+	runtime.ReadMemStats(&ms)
+
+	// Set the limit to current usage plus expected increase. This means initially we will not be limited.
+	cfg.MemoryLimitMiB = uint32(ms.Alloc/(1024*1024) + expectedMemoryIncreaseMiB)
+	cfg.MemorySpikeLimitMiB = 1
+
+	set := processortest.NewNopCreateSettings()
+
+	limiter, err := newMemoryLimiter(set, cfg)
+	require.NoError(t, err)
+
+	processor, err := processorhelper.NewLogsProcessor(context.Background(), processor.CreateSettings{}, cfg, exporter,
+		limiter.processLogs,
+		processorhelper.WithStart(limiter.start),
+		processorhelper.WithShutdown(limiter.shutdown))
+	require.NoError(t, err)
+
+	// Create a receiver.
+
+	receiver := &internal.MockReceiver{
+		ProduceCount: 1e5, // Must produce enough logs to make sure memory increases by at least expectedMemoryIncreaseMiB
+		NextConsumer: processor,
+	}
+
+	err = processor.Start(context.Background(), componenttest.NewNopHost())
+	require.NoError(t, err)
+
+	// Start producing data.
+	receiver.Start()
+
+	// The exporter was created such that its destination is not available.
+	// This will result in queuing of produced data inside the exporter and memory usage
+	// will increase.
+
+	// We must eventually hit the memory limit and the receiver must see an error from memory limiter.
+	require.Eventually(t, func() bool {
+		// Did last ConsumeLogs call return an error?
+		return receiver.LastConsumeResult() != nil
+	}, 5*time.Second, 1*time.Millisecond)
+
+	// We are now memory limited and receiver can't produce data anymore.
+
+	// Now make the exporter's destination available.
+	exporter.SetDestAvailable(true)
+
+	// We should now see that exporter's queue is purged and memory usage goes down.
+
+	// Eventually we must see that receiver's ConsumeLog call returns success again.
+	require.Eventually(t, func() bool {
+		return receiver.LastConsumeResult() == nil
+	}, 5*time.Second, 1*time.Millisecond)
+
+	// And eventually the exporter must confirm that it delivered exact number of produced logs.
+	require.Eventually(t, func() bool {
+		return receiver.ProduceCount == exporter.DeliveredLogCount()
+	}, 5*time.Second, 1*time.Millisecond)
+
+	// Double check that the number of logs accepted by exporter matches the number of produced by receiver.
+	assert.Equal(t, receiver.ProduceCount, exporter.AcceptedLogCount())
+
+	err = processor.Shutdown(context.Background())
+	require.NoError(t, err)
 }


### PR DESCRIPTION
Contributes to https://github.com/open-telemetry/opentelemetry-collector/issues/1084

- Clarify what the memory limiter does.
- Set expectations from receivers, how they are supposed to react
  when the memory limiter refuses the data.
- Add a test that demonstrates that memory limiter does not lose data
  if the receiver and exporter behave according to the contract.

All receivers must adhere to this contract. See for example
an issue opened against filelog receiver:
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/20511

Note that there are no functional changes to the memory limiter.

Future work: one additional thing we can do is implement a backoff
logic in the memory limiter. When in memory limited mode the processor
can introduce pauses before it returns from the ConsumeLogs/Traces/Metrics
call. This will allow to slow down the inflow of data into the Collector
and give time for the pipeline to clear and memory usage to return to the
normal. This needs to be explored further.