### PR TITLE
[exporter/logging] Show more counters in not detailed verbosity

### DIFF
--- a/.chloggen/logexporter-more-numbers.yaml
+++ b/.chloggen/logexporter-more-numbers.yaml
@@ -1,0 +1,18 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: loggingexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Show more counters in not detailed verbosity
+
+# One or more tracking issues or pull requests related to the change
+issues: [7461]
+
+subtext: |
+  The logging exporter now shows more counters when the verbosity is not detailed. The following numbers are added:
+  - Number of resource logs
+  - Number of resource spans
+  - Number of resource metrics
+  - Number of data points

--- a/exporter/loggingexporter/logging_exporter.go
+++ b/exporter/loggingexporter/logging_exporter.go
@@ -37,7 +37,9 @@ type loggingExporter struct {
 }
 
 func (s *loggingExporter) pushTraces(_ context.Context, td ptrace.Traces) error {
-	s.logger.Info("TracesExporter", zap.Int("#spans", td.SpanCount()))
+	s.logger.Info("TracesExporter",
+		zap.Int("resource spans", td.ResourceSpans().Len()),
+		zap.Int("spans", td.SpanCount()))
 	if s.verbosity != configtelemetry.LevelDetailed {
 		return nil
 	}
@@ -51,7 +53,10 @@ func (s *loggingExporter) pushTraces(_ context.Context, td ptrace.Traces) error 
 }
 
 func (s *loggingExporter) pushMetrics(_ context.Context, md pmetric.Metrics) error {
-	s.logger.Info("MetricsExporter", zap.Int("#metrics", md.MetricCount()))
+	s.logger.Info("MetricsExporter",
+		zap.Int("resource metrics", md.ResourceMetrics().Len()),
+		zap.Int("metrics", md.MetricCount()),
+		zap.Int("data points", md.DataPointCount()))
 	if s.verbosity != configtelemetry.LevelDetailed {
 		return nil
 	}
@@ -65,7 +70,9 @@ func (s *loggingExporter) pushMetrics(_ context.Context, md pmetric.Metrics) err
 }
 
 func (s *loggingExporter) pushLogs(_ context.Context, ld plog.Logs) error {
-	s.logger.Info("LogsExporter", zap.Int("#logs", ld.LogRecordCount()))
+	s.logger.Info("LogsExporter",
+		zap.Int("resource logs", ld.ResourceLogs().Len()),
+		zap.Int("log records", ld.LogRecordCount()))
 	if s.verbosity != configtelemetry.LevelDetailed {
 		return nil
 	}


### PR DESCRIPTION
Currently, we show the following numbers in non-detailed verbosity:
- log records that are written with confusing label `#logs`
- spans
- metrics which is not consistent with other places (e.g. batch processor) where we count data points instead.

This change adds resource metrics/logs/spans and data point counter with a consistent label naming to non-detailed verbosity output.
