### PR TITLE
Batch processor support for split-only configuration

### DIFF
--- a/.chloggen/batchprocessor-zeroconfig.yaml
+++ b/.chloggen/batchprocessor-zeroconfig.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: batchprocessor
+
+note: Support zero timeout.
+
+issues: [7508]
+
+subtext: This allows the batchprocessor to limit request sizes without introducing delay in a pipeline, to act only as a splitter.

--- a/processor/batchprocessor/README.md
+++ b/processor/batchprocessor/README.md
@@ -23,8 +23,9 @@ Please refer to [config.go](./config.go) for the config spec.
 The following configuration options can be modified:
 - `send_batch_size` (default = 8192): Number of spans, metric data points, or log
 records after which a batch will be sent regardless of the timeout.
-- `timeout` (default = 200ms): Time duration after which a batch will be sent
-regardless of size.
+- `timeout` (default = 200ms): Time duration after which a batch will
+be sent regardless of size.  If set to zero, `send_batch_size` is
+ignored as data will be sent immediately, subject to only `send_batch_max_size`.
 - `send_batch_max_size` (default = 0): The upper limit of the batch size.
   `0` means no upper limit of the batch size.
   This property ensures that larger batches are split into smaller units.
@@ -32,12 +33,28 @@ regardless of size.
 
 Examples:
 
+This configuration contains one default batch processor and a second
+with custom settings.  The `batch/2` processor will buffer up to 10000
+spans, metric data points, or log records for up to 10 seconds without
+splitting data items to enforce a maximum batch size.
+
 ```yaml
 processors:
   batch:
   batch/2:
     send_batch_size: 10000
     timeout: 10s
+```
+
+This configuration will enforce a maximum batch size limit of 10000
+spans, metric data points, or log records without introducing any
+artificial delays.
+
+```yaml
+processors:
+  batch:
+    send_max_batch_size: 10000
+    timeout: 0s
 ```
 
 Refer to [config.yaml](./testdata/config.yaml) for detailed

--- a/processor/batchprocessor/batch_processor.go
+++ b/processor/batchprocessor/batch_processor.go
@@ -113,16 +113,15 @@ func (bp *batchProcessor) Shutdown(context.Context) error {
 
 func (bp *batchProcessor) startProcessingCycle() {
 	defer bp.goroutines.Done()
+
+	// timerCh ensures we only block when there is a
+	// timer, since <- from a nil channel is blocking.
+	var timerCh <-chan time.Time
 	if bp.timeout != 0 && bp.sendBatchSize != 0 {
 		bp.timer = time.NewTimer(bp.timeout)
+		timerCh = bp.timer.C
 	}
 	for {
-		// timerCh ensures we only block when there is a
-		// timer, since <- from a nil channel is blocking.
-		var timerCh <-chan time.Time
-		if bp.timer != nil {
-			timerCh = bp.timer.C
-		}
 		select {
 		case <-bp.shutdownC:
 		DONE:

--- a/processor/batchprocessor/config.go
+++ b/processor/batchprocessor/config.go
@@ -24,9 +24,12 @@ import (
 // Config defines configuration for batch processor.
 type Config struct {
 	// Timeout sets the time after which a batch will be sent regardless of size.
+	// When this is set to zero, batched data will be sent immediately.
 	Timeout time.Duration `mapstructure:"timeout"`
 
 	// SendBatchSize is the size of a batch which after hit, will trigger it to be sent.
+	// SendBatchSize of 0 implies ignoring timeout, data will be sent immediately
+	// subject to only send_batch_max_size.
 	SendBatchSize uint32 `mapstructure:"send_batch_size"`
 
 	// SendBatchMaxSize is the maximum size of a batch. It must be larger than SendBatchSize.
@@ -41,6 +44,9 @@ var _ component.Config = (*Config)(nil)
 func (cfg *Config) Validate() error {
 	if cfg.SendBatchMaxSize > 0 && cfg.SendBatchMaxSize < cfg.SendBatchSize {
 		return errors.New("send_batch_max_size must be greater or equal to send_batch_size")
+	}
+	if cfg.Timeout < 0 {
+		return errors.New("timeout must be greater or equal to 0")
 	}
 	return nil
 }

--- a/processor/batchprocessor/config_test.go
+++ b/processor/batchprocessor/config_test.go
@@ -72,3 +72,15 @@ func TestValidateConfig_InvalidBatchSize(t *testing.T) {
 	}
 	assert.Error(t, cfg.Validate())
 }
+
+func TestValidateConfig_InvalidTimeout(t *testing.T) {
+	cfg := &Config{
+		Timeout: -time.Second,
+	}
+	assert.Error(t, cfg.Validate())
+}
+
+func TestValidateConfig_ValidZero(t *testing.T) {
+	cfg := &Config{}
+	assert.NoError(t, cfg.Validate())
+}


### PR DESCRIPTION

**Description:** Implement the fixes proposed in #7508. Otherwise, using a `batchprocessor` with `Config{}` passes validation but acts badly at runtime there is both a zero-duration timer and the call to `sendItems` never returns, constantly sending empty batches.

**Link to tracking Issue:** #7508.

**Testing:** Two new tests.

**Documentation:** Updated.