### PR TITLE
[chore] fix typo in documentation

### DIFF
--- a/exporter/otlpexporter/config.go
+++ b/exporter/otlpexporter/config.go
@@ -22,7 +22,7 @@ import (
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 )
 
-// Config defines configuration for OpenCensus exporter.
+// Config defines configuration for OTLP exporter.
 type Config struct {
 	exporterhelper.TimeoutSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct.
 	exporterhelper.QueueSettings   `mapstructure:"sending_queue"`


### PR DESCRIPTION
OTLP exporter referencing itself as the OpenCensus exporter.
