### PR TITLE
Add note about bugfix releases for security-relates issues

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -93,7 +93,7 @@ When considering making a bugfix release on the `v0.N.x` release cycle, the bug 
     - The bug produces significant data loss
     - The bug makes the Collector negatively affect its environment (e.g. significantly affects its host machine)
 
-We aim to provide a release that fixes security-related issues in at most 30 days since they are publicly announced; with the current release schedule this means security issues will typically not warrant a bugfix release. An exception is critical vulnerabilities (CVSSv3 score >= 9.0), which will warrant a release within five days.
+We aim to provide a release that fixes security-related issues in at most 30 days since they are publicly announced; with the current release schedule this means security issues will typically not warrant a bugfix release. An exception is critical vulnerabilities (CVSSv3 score >= 9.0), which will warrant a release within five business days.
 
 The OpenTelemetry Collector maintainers will ultimately have the responsibility to assess if a given bug or security issue fulfills all the necessary criteria and may grant exceptions in a case-by-case basis.
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -93,7 +93,7 @@ When considering making a bugfix release on the `v0.N.x` release cycle, the bug 
     - The bug produces significant data loss
     - The bug makes the Collector negatively affect its environment (e.g. significantly affects its host machine)
 
-We aim to provide a release that fixes security-related issues in at most 30 days since they are publicly announced; with the current release schedule this means security issues will typically not warrant a bugfix release. An exception is critical vulnerabilities (CVSSv3 score >= 9.0), which will warrant a bugfix release.
+We aim to provide a release that fixes security-related issues in at most 30 days since they are publicly announced; with the current release schedule this means security issues will typically not warrant a bugfix release. An exception is critical vulnerabilities (CVSSv3 score >= 9.0), which will warrant a release within five days.
 
 The OpenTelemetry Collector maintainers will ultimately have the responsibility to assess if a given bug or security issue fulfills all the necessary criteria and may grant exceptions in a case-by-case basis.
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -93,7 +93,9 @@ When considering making a bugfix release on the `v0.N.x` release cycle, the bug 
     - The bug produces significant data loss
     - The bug makes the Collector negatively affect its environment (e.g. significantly affects its host machine)
 
-The OpenTelemetry Collector maintainers will ultimately have the responsibility to assess if a given bug fulfills all the necessary criteria and may grant exceptions in a case-by-case basis.
+We aim to provide a release that fixes security-related issues in at most 30 days since they are publicly announced; with the current release schedule this means security issues will typically not warrant a bugfix release. An exception is critical vulnerabilities (CVSSv3 score >= 9.0), which will warrant a bugfix release.
+
+The OpenTelemetry Collector maintainers will ultimately have the responsibility to assess if a given bug or security issue fulfills all the necessary criteria and may grant exceptions in a case-by-case basis.
 
 ### Bugfix release procedure
 


### PR DESCRIPTION
**Description:** 

Adds note about when we will typically make a release for security-related issues. This introduces an informal 30 day SLA ([the tightest TTR SLA for Gitlab](https://about.gitlab.com/handbook/security/threat-management/vulnerability-management/#remediation-slas)) for security-related issues. Since we release every ~14 days, this means we will, in most cases, not make bugfix releases for security related issues. Critical vulnerabilities are added as an exception.

This relates to the discussion around CVE-2023-24534 and CVE-2023-24536.
