### PR TITLE
Mark connectors as stable

### DIFF
--- a/.chloggen/connectors-stable.yaml
+++ b/.chloggen/connectors-stable.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: connector
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Mark 'service.connectors' featuregate as stable
+
+# One or more tracking issues or pull requests related to the change
+issues: [2336]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/otelcol/config_test.go
+++ b/otelcol/config_test.go
@@ -20,13 +20,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configtelemetry"
-	"go.opentelemetry.io/collector/featuregate"
-	"go.opentelemetry.io/collector/otelcol/internal/sharedgate"
 	"go.opentelemetry.io/collector/service"
 	"go.opentelemetry.io/collector/service/telemetry"
 )
@@ -256,10 +253,6 @@ func TestConfigValidate(t *testing.T) {
 		},
 	}
 
-	require.NoError(t, featuregate.GlobalRegistry().Set(sharedgate.ConnectorsFeatureGate.ID(), true))
-	defer func() {
-		require.NoError(t, featuregate.GlobalRegistry().Set(sharedgate.ConnectorsFeatureGate.ID(), false))
-	}()
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
 			cfg := test.cfgFn()

--- a/otelcol/internal/sharedgate/sharedgate.go
+++ b/otelcol/internal/sharedgate/sharedgate.go
@@ -19,6 +19,8 @@ import "go.opentelemetry.io/collector/featuregate"
 
 var ConnectorsFeatureGate = featuregate.GlobalRegistry().MustRegister(
 	"service.connectors",
-	featuregate.StageBeta,
+	featuregate.StageStable,
+	featuregate.WithRegisterFromVersion("v0.71.0"),
 	featuregate.WithRegisterDescription("Enables 'connectors', a new type of component for transmitting signals between pipelines."),
-	featuregate.WithRegisterReferenceURL("https://github.com/open-telemetry/opentelemetry-collector/issues/2336"))
+	featuregate.WithRegisterReferenceURL("https://github.com/open-telemetry/opentelemetry-collector/issues/2336"),
+	featuregate.WithRegisterToVersion("v0.78.0"))

--- a/otelcol/otelcoltest/config_test.go
+++ b/otelcol/otelcoltest/config_test.go
@@ -22,8 +22,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/collector/component"
-	"go.opentelemetry.io/collector/featuregate"
-	"go.opentelemetry.io/collector/otelcol/internal/sharedgate"
 	"go.opentelemetry.io/collector/service"
 )
 
@@ -76,10 +74,6 @@ func TestLoadConfigAndValidate(t *testing.T) {
 	factories, err := NopFactories()
 	assert.NoError(t, err)
 
-	require.NoError(t, featuregate.GlobalRegistry().Set(sharedgate.ConnectorsFeatureGate.ID(), true))
-	defer func() {
-		require.NoError(t, featuregate.GlobalRegistry().Set(sharedgate.ConnectorsFeatureGate.ID(), false))
-	}()
 	cfgValidate, errValidate := LoadConfigAndValidate(filepath.Join("testdata", "config.yaml"), factories)
 	require.NoError(t, errValidate)
 


### PR DESCRIPTION
I believe the connectors codebase has proven to be very stable, as we haven't had to make any changes to support development of individual connectors. If there are no objections, I'd like to mark the gate stable ahead of the next release.