### PR TITLE
Clarify checkpointing order for receivers

### DIFF
--- a/receiver/doc.go
+++ b/receiver/doc.go
@@ -39,7 +39,7 @@
 // retried. In case of OTLP/HTTP for example, this means that HTTP 429 or 503 response
 // is returned.
 //
-// # Acknowledgment Handling
+// # Acknowledgment and Checkpointing
 //
 // The receivers that receive data via a network protocol that support acknowledgments
 // MUST follow this order of operations:
@@ -50,4 +50,8 @@
 //
 // This ensures there are strong delivery guarantees once the data is acknowledged
 // by the Collector.
+//
+// Similarly, receivers that use checkpointing to remember the position of last processed
+// data (e.g. via storage extension) MUST store the checkpoint only AFTER the Consume*()
+// call returns.
 package receiver // import "go.opentelemetry.io/collector/receiver"


### PR DESCRIPTION
This expands the delivery guarantees introduced for network-based receivers to receivers that use checkpointing.

The purpose of the requirement is the same: to prevent data losses. See previous PR: https://github.com/open-telemetry/opentelemetry-collector/pull/4262
