### PR TITLE
Retract pdata v1.0.0-rc10 and several modules v0.76.0 which depended on it

### DIFF
--- a/cmd/otelcorecol/go.mod
+++ b/cmd/otelcorecol/go.mod
@@ -71,7 +71,7 @@ require (
 	go.opentelemetry.io/collector/confmap v0.76.0 // indirect
 	go.opentelemetry.io/collector/consumer v0.76.0 // indirect
 	go.opentelemetry.io/collector/featuregate v0.76.0 // indirect
-	go.opentelemetry.io/collector/pdata v1.0.0-rc10 // indirect
+	go.opentelemetry.io/collector/pdata v1.0.0-rc9 // indirect
 	go.opentelemetry.io/collector/semconv v0.76.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.40.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.40.0 // indirect
@@ -132,3 +132,5 @@ replace go.opentelemetry.io/collector/processor/batchprocessor => ../../processo
 replace go.opentelemetry.io/collector/processor/memorylimiterprocessor => ../../processor/memorylimiterprocessor
 
 replace go.opentelemetry.io/collector/semconv => ../../semconv
+
+retract v0.76.0 // Depends on retraced pdata v1.0.0-rc10 module

--- a/connector/forwardconnector/go.mod
+++ b/connector/forwardconnector/go.mod
@@ -7,7 +7,7 @@ require (
 	go.opentelemetry.io/collector v0.76.0
 	go.opentelemetry.io/collector/component v0.76.0
 	go.opentelemetry.io/collector/consumer v0.76.0
-	go.opentelemetry.io/collector/pdata v1.0.0-rc10
+	go.opentelemetry.io/collector/pdata v1.0.0-rc9
 )
 
 require (
@@ -59,4 +59,7 @@ replace go.opentelemetry.io/collector/consumer => ../../consumer
 
 replace go.opentelemetry.io/collector/confmap => ../../confmap
 
-retract v0.69.0 // Release failed, use v0.69.1
+retract (
+	v0.76.0 // Depends on retraced pdata v1.0.0-rc10 module
+	v0.69.0 // Release failed, use v0.69.1
+)

--- a/consumer/go.mod
+++ b/consumer/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/stretchr/testify v1.8.2
 	go.opentelemetry.io/collector v0.76.0
-	go.opentelemetry.io/collector/pdata v1.0.0-rc10
+	go.opentelemetry.io/collector/pdata v1.0.0-rc9
 )
 
 require (
@@ -44,4 +44,7 @@ replace go.opentelemetry.io/collector/featuregate => ../featuregate
 
 replace go.opentelemetry.io/collector/confmap => ../confmap
 
-retract v0.69.0 // Release failed, use v0.69.1
+retract (
+	v0.76.0 // Depends on retraced pdata v1.0.0-rc10 module
+	v0.69.0 // Release failed, use v0.69.1
+)

--- a/exporter/go.mod
+++ b/exporter/go.mod
@@ -9,7 +9,7 @@ require (
 	go.opentelemetry.io/collector v0.76.0
 	go.opentelemetry.io/collector/component v0.76.0
 	go.opentelemetry.io/collector/consumer v0.76.0
-	go.opentelemetry.io/collector/pdata v1.0.0-rc10
+	go.opentelemetry.io/collector/pdata v1.0.0-rc9
 	go.opentelemetry.io/otel v1.14.0
 	go.opentelemetry.io/otel/sdk v1.14.0
 	go.opentelemetry.io/otel/trace v1.14.0
@@ -78,3 +78,5 @@ replace go.opentelemetry.io/collector/pdata => ../pdata
 replace go.opentelemetry.io/collector/receiver => ../receiver
 
 replace go.opentelemetry.io/collector/semconv => ../semconv
+
+retract v0.76.0 // Depends on retraced pdata v1.0.0-rc10 module

--- a/exporter/loggingexporter/go.mod
+++ b/exporter/loggingexporter/go.mod
@@ -9,7 +9,7 @@ require (
 	go.opentelemetry.io/collector/confmap v0.76.0
 	go.opentelemetry.io/collector/consumer v0.76.0
 	go.opentelemetry.io/collector/exporter v0.76.0
-	go.opentelemetry.io/collector/pdata v1.0.0-rc10
+	go.opentelemetry.io/collector/pdata v1.0.0-rc9
 	go.uber.org/zap v1.24.0
 	golang.org/x/sys v0.7.0
 )
@@ -64,4 +64,7 @@ replace go.opentelemetry.io/collector/semconv => ../../semconv
 
 replace go.opentelemetry.io/collector/extension/zpagesextension => ../../extension/zpagesextension
 
-retract v0.69.0 // Release failed, use v0.69.1
+retract (
+	v0.76.0 // Depends on retraced pdata v1.0.0-rc10 module
+	v0.69.0 // Release failed, use v0.69.1
+)

--- a/exporter/otlpexporter/go.mod
+++ b/exporter/otlpexporter/go.mod
@@ -9,7 +9,7 @@ require (
 	go.opentelemetry.io/collector/confmap v0.76.0
 	go.opentelemetry.io/collector/consumer v0.76.0
 	go.opentelemetry.io/collector/exporter v0.76.0
-	go.opentelemetry.io/collector/pdata v1.0.0-rc10
+	go.opentelemetry.io/collector/pdata v1.0.0-rc9
 	google.golang.org/genproto v0.0.0-20230110181048-76db0878b65f
 	google.golang.org/grpc v1.54.0
 	google.golang.org/protobuf v1.30.0
@@ -70,4 +70,7 @@ replace go.opentelemetry.io/collector/extension/zpagesextension => ../../extensi
 
 replace go.opentelemetry.io/collector/consumer => ../../consumer
 
-retract v0.69.0 // Release failed, use v0.69.1
+retract (
+	v0.76.0 // Depends on retraced pdata v1.0.0-rc10 module
+	v0.69.0 // Release failed, use v0.69.1
+)

--- a/exporter/otlphttpexporter/go.mod
+++ b/exporter/otlphttpexporter/go.mod
@@ -9,7 +9,7 @@ require (
 	go.opentelemetry.io/collector/confmap v0.76.0
 	go.opentelemetry.io/collector/consumer v0.76.0
 	go.opentelemetry.io/collector/exporter v0.76.0
-	go.opentelemetry.io/collector/pdata v1.0.0-rc10
+	go.opentelemetry.io/collector/pdata v1.0.0-rc9
 	go.opentelemetry.io/collector/receiver v0.76.0
 	go.opentelemetry.io/collector/receiver/otlpreceiver v0.76.0
 	go.uber.org/zap v1.24.0
@@ -76,4 +76,7 @@ replace go.opentelemetry.io/collector/extension/zpagesextension => ../../extensi
 
 replace go.opentelemetry.io/collector/consumer => ../../consumer
 
-retract v0.69.0 // Release failed, use v0.69.1
+retract (
+	v0.76.0 // Depends on retraced pdata v1.0.0-rc10 module
+	v0.69.0 // Release failed, use v0.69.1
+)

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	go.opentelemetry.io/collector/exporter v0.76.0
 	go.opentelemetry.io/collector/extension/zpagesextension v0.76.0
 	go.opentelemetry.io/collector/featuregate v0.76.0
-	go.opentelemetry.io/collector/pdata v1.0.0-rc10
+	go.opentelemetry.io/collector/pdata v1.0.0-rc9
 	go.opentelemetry.io/collector/receiver v0.76.0
 	go.opentelemetry.io/collector/semconv v0.76.0
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.40.0
@@ -105,6 +105,7 @@ replace go.opentelemetry.io/collector/receiver => ./receiver
 replace go.opentelemetry.io/collector/extension/zpagesextension => ./extension/zpagesextension
 
 retract (
+	v0.76.0 // Depends on retraced pdata v1.0.0-rc10 module
 	v0.69.0 // Release failed, use v0.69.1
 	v0.57.1 // Release failed, use v0.57.2
 	v0.57.0 // Release failed, use v0.57.2

--- a/pdata/go.mod
+++ b/pdata/go.mod
@@ -25,6 +25,7 @@ require (
 )
 
 retract (
+	v1.0.0-rc10 // RC version scheme discovered to be alphabetical, use v1.0.0-rc9 (no changes)
 	v0.57.1 // Release failed, use v0.57.2
 	v0.57.0 // Release failed, use v0.57.2
 )

--- a/processor/batchprocessor/go.mod
+++ b/processor/batchprocessor/go.mod
@@ -13,7 +13,7 @@ require (
 	go.opentelemetry.io/collector/component v0.76.0
 	go.opentelemetry.io/collector/confmap v0.76.0
 	go.opentelemetry.io/collector/consumer v0.76.0
-	go.opentelemetry.io/collector/pdata v1.0.0-rc10
+	go.opentelemetry.io/collector/pdata v1.0.0-rc9
 	go.opentelemetry.io/otel v1.14.0
 	go.opentelemetry.io/otel/exporters/prometheus v0.37.0
 	go.opentelemetry.io/otel/metric v0.37.0
@@ -80,4 +80,7 @@ replace go.opentelemetry.io/collector/extension/zpagesextension => ../../extensi
 
 replace go.opentelemetry.io/collector/consumer => ../../consumer
 
-retract v0.69.0 // Release failed, use v0.69.1
+retract (
+	v0.76.0 // Depends on retraced pdata v1.0.0-rc10 module
+	v0.69.0 // Release failed, use v0.69.1
+)

--- a/processor/memorylimiterprocessor/go.mod
+++ b/processor/memorylimiterprocessor/go.mod
@@ -8,7 +8,7 @@ require (
 	go.opentelemetry.io/collector/component v0.76.0
 	go.opentelemetry.io/collector/confmap v0.76.0
 	go.opentelemetry.io/collector/consumer v0.76.0
-	go.opentelemetry.io/collector/pdata v1.0.0-rc10
+	go.opentelemetry.io/collector/pdata v1.0.0-rc9
 	go.uber.org/zap v1.24.0
 )
 
@@ -69,4 +69,7 @@ replace go.opentelemetry.io/collector/extension/zpagesextension => ../../extensi
 
 replace go.opentelemetry.io/collector/consumer => ../../consumer
 
-retract v0.69.0 // Release failed, use v0.69.1
+retract (
+	v0.76.0 // Depends on retraced pdata v1.0.0-rc10 module
+	v0.69.0 // Release failed, use v0.69.1
+)

--- a/receiver/go.mod
+++ b/receiver/go.mod
@@ -7,7 +7,7 @@ require (
 	go.opentelemetry.io/collector v0.76.0
 	go.opentelemetry.io/collector/component v0.76.0
 	go.opentelemetry.io/collector/consumer v0.76.0
-	go.opentelemetry.io/collector/pdata v1.0.0-rc10
+	go.opentelemetry.io/collector/pdata v1.0.0-rc9
 	go.opentelemetry.io/otel v1.14.0
 	go.opentelemetry.io/otel/sdk v1.14.0
 	go.uber.org/multierr v1.11.0
@@ -76,3 +76,5 @@ replace go.opentelemetry.io/collector/featuregate => ../featuregate
 replace go.opentelemetry.io/collector/pdata => ../pdata
 
 replace go.opentelemetry.io/collector/semconv => ../semconv
+
+retract v0.76.0 // Depends on retraced pdata v1.0.0-rc10 module

--- a/receiver/otlpreceiver/go.mod
+++ b/receiver/otlpreceiver/go.mod
@@ -9,7 +9,7 @@ require (
 	go.opentelemetry.io/collector/component v0.76.0
 	go.opentelemetry.io/collector/confmap v0.76.0
 	go.opentelemetry.io/collector/consumer v0.76.0
-	go.opentelemetry.io/collector/pdata v1.0.0-rc10
+	go.opentelemetry.io/collector/pdata v1.0.0-rc9
 	go.opentelemetry.io/collector/receiver v0.76.0
 	go.opentelemetry.io/collector/semconv v0.76.0
 	go.uber.org/zap v1.24.0
@@ -89,4 +89,7 @@ replace go.opentelemetry.io/collector/extension/zpagesextension => ../../extensi
 
 replace go.opentelemetry.io/collector/consumer => ../../consumer
 
-retract v0.69.0 // Release failed, use v0.69.1
+retract (
+	v0.76.0 // Depends on retraced pdata v1.0.0-rc10 module
+	v0.69.0 // Release failed, use v0.69.1
+)

--- a/versions.yaml
+++ b/versions.yaml
@@ -14,7 +14,7 @@
 
 module-sets:
   stable:
-    version: v1.0.0-rc10
+    version: v1.0.0-rc9
     modules:
       - go.opentelemetry.io/collector/pdata
   beta:


### PR DESCRIPTION
Our versioning scheme for release candidate modules depends on alphabetical ordering. As a result `rc10` is interpreted as being less then `rc2` through `rc9`.

This causes all sorts of problems with dependency management. e.g.:
`go: downgraded [go.opentelemetry.io/collector/pdata](http://go.opentelemetry.io/collector/pdata) v1.0.0-rc9.0.20230424163446-8e33ded10872 => v1.0.0-rc10`

As a result, I suggest we retract `pdata v1.0.0-rc10` and all `v0.76.0` modules that depend on it.