### PR TITLE
[config/confighttp] Ensure Auth happens after compression

### DIFF
--- a/.chloggen/fix_configHTTPAuth.yaml
+++ b/.chloggen/fix_configHTTPAuth.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: "bug_fix"
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: "config/confighttp"
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Ensure Auth RoundTripper follows compression/header changes
+
+# One or more tracking issues or pull requests related to the change
+issues: [7574]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/config/confighttp/confighttp_test.go
+++ b/config/confighttp/confighttp_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/config/configtelemetry"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
 
@@ -36,6 +37,7 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/configauth"
+	"go.opentelemetry.io/collector/config/configcompression"
 	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/config/configtls"
 	"go.opentelemetry.io/collector/extension/auth"
@@ -320,6 +322,34 @@ func TestHTTPClientSettingWithAuthConfig(t *testing.T) {
 			},
 		},
 		{
+			name: "with_auth_configuration_has_extension_and_headers",
+			settings: HTTPClientSettings{
+				Endpoint: "localhost:1234",
+				Auth:     &configauth.Authentication{AuthenticatorID: component.NewID("mock")},
+				Headers:  map[string]configopaque.String{"foo": "bar"},
+			},
+			shouldErr: false,
+			host: &mockHost{
+				ext: map[component.ID]component.Component{
+					component.NewID("mock"): &authtest.MockClient{ResultRoundTripper: &customRoundTripper{}},
+				},
+			},
+		},
+		{
+			name: "with_auth_configuration_has_extension_and_compression",
+			settings: HTTPClientSettings{
+				Endpoint:    "localhost:1234",
+				Auth:        &configauth.Authentication{AuthenticatorID: component.NewID("mock")},
+				Compression: configcompression.Gzip,
+			},
+			shouldErr: false,
+			host: &mockHost{
+				ext: map[component.ID]component.Component{
+					component.NewID("mock"): &authtest.MockClient{ResultRoundTripper: &customRoundTripper{}},
+				},
+			},
+		},
+		{
 			name: "with_auth_configuration_has_err_extension",
 			settings: HTTPClientSettings{
 				Endpoint: "localhost:1234",
@@ -336,15 +366,34 @@ func TestHTTPClientSettingWithAuthConfig(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			client, err := test.settings.ToClient(test.host, componenttest.NewNopTelemetrySettings())
+			// Omit TracerProvider and MeterProvider in TelemetrySettings as otelhttp.Transport cannot be introspected
+			client, err := test.settings.ToClient(test.host, component.TelemetrySettings{Logger: zap.NewNop(), MetricsLevel: configtelemetry.LevelNone})
 			if test.shouldErr {
 				assert.Error(t, err)
 				return
 			}
 			assert.NoError(t, err)
 			assert.NotNil(t, client)
+			transport := client.Transport
+
+			// Compression should wrap Auth, unwrap it
+			if configcompression.IsCompressed(test.settings.Compression) {
+				ct, ok := transport.(*compressRoundTripper)
+				assert.True(t, ok)
+				assert.Equal(t, test.settings.Compression, ct.compressionType)
+				transport = ct.RoundTripper
+			}
+
+			// Headers should wrap Auth, unwrap it
+			if test.settings.Headers != nil {
+				ht, ok := transport.(*headerRoundTripper)
+				assert.True(t, ok)
+				assert.Equal(t, test.settings.Headers, ht.headers)
+				transport = ht.transport
+			}
+
 			if test.settings.Auth != nil {
-				_, ok := client.Transport.(*customRoundTripper)
+				_, ok := transport.(*customRoundTripper)
 				assert.True(t, ok)
 			}
 		})

--- a/config/confighttp/confighttp_test.go
+++ b/config/confighttp/confighttp_test.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/collector/config/configtelemetry"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
 
@@ -39,6 +38,7 @@ import (
 	"go.opentelemetry.io/collector/config/configauth"
 	"go.opentelemetry.io/collector/config/configcompression"
 	"go.opentelemetry.io/collector/config/configopaque"
+	"go.opentelemetry.io/collector/config/configtelemetry"
 	"go.opentelemetry.io/collector/config/configtls"
 	"go.opentelemetry.io/collector/extension/auth"
 	"go.opentelemetry.io/collector/extension/auth/authtest"


### PR DESCRIPTION
When request signing-based authentication extensions are used it is necessary to ensure that the Auth RoundTripper is the innermost as changes to the request by other RoundTrippers (such as compression or headers) may invalidate the request signature.  This change will ensure that the Auth RoundTripper is invoked after all others and is followed directly by the http.Transport.