### PR TITLE
Mark forward connector as beta

### DIFF
--- a/.chloggen/forward-beta.yaml
+++ b/.chloggen/forward-beta.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'enhancement'
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: forwardconnector
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Promote to beta
+
+# One or more tracking issues or pull requests related to the change
+issues: [7579]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/connector/forwardconnector/README.md
+++ b/connector/forwardconnector/README.md
@@ -2,9 +2,9 @@
 
 | Status                   |                                                           |
 |------------------------- |---------------------------------------------------------- |
-| Stability                | [Alpha]                                          |
+| Stability                | [beta]                                          |
 | Supported pipeline types | See [Supported Pipeline Types](#supported-pipeline-types) |
-| Distributions            | []                                                        |
+| Distributions            | [core, contrib]                                                        |
 
 The `forward` connector can merge or fork pipelines of the same type.
 
@@ -122,7 +122,9 @@ service:
   #   exporters: [logging]
 ```
 
-[Alpha]:https://github.com/open-telemetry/opentelemetry-collector#alpha
+[beta]:https://github.com/open-telemetry/opentelemetry-collector#beta
+[core]:https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol
+[contrib]:https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib
 [Connectors README]:https://github.com/open-telemetry/opentelemetry-collector/blob/main/connector/README.md
 [Exporter Pipeline Type]:https://github.com/open-telemetry/opentelemetry-collector/blob/main/connector/README.md#exporter-pipeline-type
 [Receiver Pipeline Type]:https://github.com/open-telemetry/opentelemetry-collector/blob/main/connector/README.md#receiver-pipeline-type

--- a/connector/forwardconnector/forward.go
+++ b/connector/forwardconnector/forward.go
@@ -31,9 +31,9 @@ func NewFactory() connector.Factory {
 	return connector.NewFactory(
 		typeStr,
 		createDefaultConfig,
-		connector.WithTracesToTraces(createTracesToTraces, component.StabilityLevelDevelopment),
-		connector.WithMetricsToMetrics(createMetricsToMetrics, component.StabilityLevelDevelopment),
-		connector.WithLogsToLogs(createLogsToLogs, component.StabilityLevelDevelopment),
+		connector.WithTracesToTraces(createTracesToTraces, component.StabilityLevelBeta),
+		connector.WithMetricsToMetrics(createMetricsToMetrics, component.StabilityLevelBeta),
+		connector.WithLogsToLogs(createLogsToLogs, component.StabilityLevelBeta),
 	)
 }
 


### PR DESCRIPTION
This also updates the readme to indicate correctly the distributions that already contain the connector.