### PR TITLE
[featuregate] Removed deprecated functions

### DIFF
--- a/.chloggen/featuregate-remove-deprecated-functions.yaml
+++ b/.chloggen/featuregate-remove-deprecated-functions.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: featuregate
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove deprecated `RemovalVersion` and `WithRegisterRemovalVersion` functions.
+
+# One or more tracking issues or pull requests related to the change
+issues: [7587]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/featuregate/gate.go
+++ b/featuregate/gate.go
@@ -62,8 +62,3 @@ func (g *Gate) FromVersion() string {
 func (g *Gate) ToVersion() string {
 	return g.toVersion
 }
-
-// Deprecated: [v0.76.0] use ToVersion().
-func (g *Gate) RemovalVersion() string {
-	return g.ToVersion()
-}

--- a/featuregate/registry.go
+++ b/featuregate/registry.go
@@ -62,9 +62,6 @@ func WithRegisterReferenceURL(url string) RegisterOption {
 	})
 }
 
-// Deprecated: [v0.76.0] use WithRegisterToVersion.
-var WithRegisterRemovalVersion = WithRegisterToVersion
-
 // WithRegisterFromVersion is used to set the Gate "FromVersion".
 // The "FromVersion" contains the Collector release when a feature is introduced.
 func WithRegisterFromVersion(fromVersion string) RegisterOption {


### PR DESCRIPTION
**Description:** 
Removes deprecated `RemovalVersion` and `WithRegisterRemovalVersion` function.

**Link to tracking Issue:** 
https://github.com/open-telemetry/opentelemetry-collector/issues/7043