### PR TITLE
upgrade core version default to 0.76.1

### DIFF
--- a/cmd/builder/internal/config/default.yaml
+++ b/cmd/builder/internal/config/default.yaml
@@ -2,21 +2,21 @@ dist:
   module: go.opentelemetry.io/collector/cmd/otelcorecol
   name: otelcorecol
   description: Local OpenTelemetry Collector binary, testing only.
-  version: 0.76.0-dev
-  otelcol_version: 0.76.0
+  version: 0.76.1-dev
+  otelcol_version: 0.76.1
 
 receivers:
-  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.76.0
+  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.76.1
 exporters:
-  - gomod: go.opentelemetry.io/collector/exporter/loggingexporter v0.76.0
-  - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.76.0
-  - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.76.0
+  - gomod: go.opentelemetry.io/collector/exporter/loggingexporter v0.76.1
+  - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.76.1
+  - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.76.1
 extensions:
-  - gomod: go.opentelemetry.io/collector/extension/ballastextension v0.76.0
-  - gomod: go.opentelemetry.io/collector/extension/zpagesextension v0.76.0
+  - gomod: go.opentelemetry.io/collector/extension/ballastextension v0.76.1
+  - gomod: go.opentelemetry.io/collector/extension/zpagesextension v0.76.1
 processors:
-  - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.76.0
-  - gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.76.0
+  - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.76.1
+  - gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.76.1
 connectors:
-  - gomod: go.opentelemetry.io/collector/connector/forwardconnector v0.76.0
+  - gomod: go.opentelemetry.io/collector/connector/forwardconnector v0.76.1
 


### PR DESCRIPTION


**Description:** upgrade core version default to 0.76.1

**Link to tracking Issue:**
#7598
https://github.com/open-telemetry/opentelemetry-collector/issues/7598

**Testing:** 
using existing regression testing

**Documentation:**
none