### PR TITLE
[config/confighttp] Support zstd and snappy decompress

### DIFF
--- a/.chloggen/fix_confighttp.yaml
+++ b/.chloggen/fix_confighttp.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: "enhancement"
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: "exporter/otlphttpexporter"
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Support zstd and snappy compress
+
+# One or more tracking issues or pull requests related to the change
+issues: [7632]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:


### PR DESCRIPTION
fix https://github.com/open-telemetry/opentelemetry-collector/issues/7632
**Description:** 
bug: the otlphttp exporter zstd and snappy compression is not work.
how to fix: add zstd and snappy decompress reader.
