### PR TITLE
[chore] clean up old references in docs

### DIFF
--- a/exporter/exporterhelper/obsreport.go
+++ b/exporter/exporterhelper/obsreport.go
@@ -83,7 +83,7 @@ func newInstruments(registry *metric.Registry) *instruments {
 	return insts
 }
 
-// obsExporter is a helper to add observability to a component.Exporter.
+// obsExporter is a helper to add observability to an exporter.
 type obsExporter struct {
 	*obsreport.Exporter
 	failedToEnqueueTraceSpansEntry   *metric.Int64CumulativeEntry

--- a/obsreport/obsreport_exporter.go
+++ b/obsreport/obsreport_exporter.go
@@ -38,7 +38,7 @@ const (
 	exporterScope = scopeName + nameSep + exporterName
 )
 
-// Exporter is a helper to add observability to a component.Exporter.
+// Exporter is a helper to add observability to an exporter.
 type Exporter struct {
 	level          configtelemetry.Level
 	spanNamePrefix string

--- a/obsreport/obsreport_processor.go
+++ b/obsreport/obsreport_processor.go
@@ -51,7 +51,7 @@ func BuildProcessorCustomMetricName(configType, metric string) string {
 	return componentPrefix + configType + obsmetrics.NameSep + metric
 }
 
-// Processor is a helper to add observability to a component.Processor.
+// Processor is a helper to add observability to a processor.
 type Processor struct {
 	level    configtelemetry.Level
 	mutators []tag.Mutator

--- a/obsreport/obsreport_receiver.go
+++ b/obsreport/obsreport_receiver.go
@@ -38,7 +38,7 @@ const (
 	receiverScope = scopeName + nameSep + receiverName
 )
 
-// Receiver is a helper to add observability to a receiver.Receiver.
+// Receiver is a helper to add observability to a receiver.
 type Receiver struct {
 	level          configtelemetry.Level
 	spanNamePrefix string

--- a/obsreport/obsreport_scraper.go
+++ b/obsreport/obsreport_scraper.go
@@ -39,7 +39,7 @@ var (
 	scraperScope = scopeName + nameSep + scraperName
 )
 
-// Scraper is a helper to add observability to a component.Scraper.
+// Scraper is a helper to add observability to a scraper.
 type Scraper struct {
 	level      configtelemetry.Level
 	receiverID component.ID

--- a/processor/processorhelper/logs.go
+++ b/processor/processorhelper/logs.go
@@ -36,7 +36,7 @@ type logProcessor struct {
 	consumer.Logs
 }
 
-// NewLogsProcessor creates a component.LogsProcessor that ensure context propagation and the right tags are set.
+// NewLogsProcessor creates a processor.Logs that ensure context propagation and the right tags are set.
 func NewLogsProcessor(
 	_ context.Context,
 	set processor.CreateSettings,

--- a/processor/processorhelper/metrics.go
+++ b/processor/processorhelper/metrics.go
@@ -36,7 +36,7 @@ type metricsProcessor struct {
 	consumer.Metrics
 }
 
-// NewMetricsProcessor creates a component.MetricsProcessor that ensure context propagation and the right tags are set.
+// NewMetricsProcessor creates a processor.Metrics that ensure context propagation and the right tags are set.
 func NewMetricsProcessor(
 	_ context.Context,
 	set processor.CreateSettings,

--- a/processor/processorhelper/traces.go
+++ b/processor/processorhelper/traces.go
@@ -36,7 +36,7 @@ type tracesProcessor struct {
 	consumer.Traces
 }
 
-// NewTracesProcessor creates a component.TracesProcessor that ensure context propagation and the right tags are set.
+// NewTracesProcessor creates a processor.Traces that ensure context propagation and the right tags are set.
 func NewTracesProcessor(
 	_ context.Context,
 	set processor.CreateSettings,


### PR DESCRIPTION
This removes the remaining references to components living in the `component` module. Fixes #6578
