### PR TITLE
Add support to TLSSetting to not only read from file path, but from memory

### DIFF
--- a/.chloggen/add-tls-settings-from-memory.yaml
+++ b/.chloggen/add-tls-settings-from-memory.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: configtls
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Allow TLS Settings to be provided in memory in addition to filepath.
+
+# One or more tracking issues or pull requests related to the change
+issues: [7313]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/config/configgrpc/configgrpc_test.go
+++ b/config/configgrpc/configgrpc_test.go
@@ -239,7 +239,7 @@ func TestGRPCClientSettingsError(t *testing.T) {
 		host     component.Host
 	}{
 		{
-			err: "^failed to load TLS config: failed to load CA CertPool: failed to load CA /doesnt/exist:",
+			err: "^failed to load TLS config: failed to load CA CertPool File: failed to load cert /doesnt/exist:",
 			settings: GRPCClientSettings{
 				Headers:     nil,
 				Endpoint:    "",
@@ -255,7 +255,7 @@ func TestGRPCClientSettingsError(t *testing.T) {
 			},
 		},
 		{
-			err: "^failed to load TLS config: for auth via TLS, either both certificate and key must be supplied, or neither",
+			err: "^failed to load TLS config: failed to load TLS cert and key: for auth via TLS, either both certificate and key must be supplied, or neither",
 			settings: GRPCClientSettings{
 				Headers:     nil,
 				Endpoint:    "",
@@ -425,7 +425,7 @@ func TestGRPCServerSettingsError(t *testing.T) {
 		err      string
 	}{
 		{
-			err: "^failed to load TLS config: failed to load CA CertPool: failed to load CA /doesnt/exist:",
+			err: "^failed to load TLS config: failed to load CA CertPool File: failed to load cert /doesnt/exist:",
 			settings: GRPCServerSettings{
 				NetAddr: confignet.NetAddr{
 					Endpoint:  "127.0.0.1:1234",
@@ -439,7 +439,7 @@ func TestGRPCServerSettingsError(t *testing.T) {
 			},
 		},
 		{
-			err: "^failed to load TLS config: for auth via TLS, either both certificate and key must be supplied, or neither",
+			err: "^failed to load TLS config: failed to load TLS cert and key: for auth via TLS, either both certificate and key must be supplied, or neither",
 			settings: GRPCServerSettings{
 				NetAddr: confignet.NetAddr{
 					Endpoint:  "127.0.0.1:1234",

--- a/config/configgrpc/configgrpc_test.go
+++ b/config/configgrpc/configgrpc_test.go
@@ -255,7 +255,7 @@ func TestGRPCClientSettingsError(t *testing.T) {
 			},
 		},
 		{
-			err: "^failed to load TLS config: failed to load TLS cert and key: for auth via TLS, either both certificate and key must be supplied, or neither",
+			err: "^failed to load TLS config: failed to load TLS cert and key: for auth via TLS, provide both certificate and key, or neither",
 			settings: GRPCClientSettings{
 				Headers:     nil,
 				Endpoint:    "",
@@ -439,7 +439,7 @@ func TestGRPCServerSettingsError(t *testing.T) {
 			},
 		},
 		{
-			err: "^failed to load TLS config: failed to load TLS cert and key: for auth via TLS, either both certificate and key must be supplied, or neither",
+			err: "^failed to load TLS config: failed to load TLS cert and key: for auth via TLS, provide both certificate and key, or neither",
 			settings: GRPCServerSettings{
 				NetAddr: confignet.NetAddr{
 					Endpoint:  "127.0.0.1:1234",

--- a/config/confighttp/confighttp_test.go
+++ b/config/confighttp/confighttp_test.go
@@ -223,7 +223,7 @@ func TestHTTPClientSettingsError(t *testing.T) {
 		err      string
 	}{
 		{
-			err: "^failed to load TLS config: failed to load CA CertPool: failed to load CA /doesnt/exist:",
+			err: "^failed to load TLS config: failed to load CA CertPool File: failed to load cert /doesnt/exist:",
 			settings: HTTPClientSettings{
 				Endpoint: "",
 				TLSSetting: configtls.TLSClientSetting{
@@ -236,7 +236,7 @@ func TestHTTPClientSettingsError(t *testing.T) {
 			},
 		},
 		{
-			err: "^failed to load TLS config: for auth via TLS, either both certificate and key must be supplied, or neither",
+			err: "^failed to load TLS config: failed to load TLS cert and key: for auth via TLS, either both certificate and key must be supplied, or neither",
 			settings: HTTPClientSettings{
 				Endpoint: "",
 				TLSSetting: configtls.TLSClientSetting{
@@ -406,7 +406,7 @@ func TestHTTPServerSettingsError(t *testing.T) {
 		err      string
 	}{
 		{
-			err: "^failed to load TLS config: failed to load CA CertPool: failed to load CA /doesnt/exist:",
+			err: "^failed to load TLS config: failed to load CA CertPool File: failed to load cert /doesnt/exist:",
 			settings: HTTPServerSettings{
 				Endpoint: "localhost:0",
 				TLSSetting: &configtls.TLSServerSetting{
@@ -417,7 +417,7 @@ func TestHTTPServerSettingsError(t *testing.T) {
 			},
 		},
 		{
-			err: "^failed to load TLS config: for auth via TLS, either both certificate and key must be supplied, or neither",
+			err: "^failed to load TLS config: failed to load TLS cert and key: for auth via TLS, either both certificate and key must be supplied, or neither",
 			settings: HTTPServerSettings{
 				Endpoint: "localhost:0",
 				TLSSetting: &configtls.TLSServerSetting{
@@ -428,7 +428,7 @@ func TestHTTPServerSettingsError(t *testing.T) {
 			},
 		},
 		{
-			err: "failed to load client CA CertPool: failed to load CA /doesnt/exist:",
+			err: "failed to load client CA CertPool: failed to load CA /doesnt/exist: open /doesnt/exist:",
 			settings: HTTPServerSettings{
 				Endpoint: "localhost:0",
 				TLSSetting: &configtls.TLSServerSetting{

--- a/config/confighttp/confighttp_test.go
+++ b/config/confighttp/confighttp_test.go
@@ -236,7 +236,7 @@ func TestHTTPClientSettingsError(t *testing.T) {
 			},
 		},
 		{
-			err: "^failed to load TLS config: failed to load TLS cert and key: for auth via TLS, either both certificate and key must be supplied, or neither",
+			err: "^failed to load TLS config: failed to load TLS cert and key: for auth via TLS, provide both certificate and key, or neither",
 			settings: HTTPClientSettings{
 				Endpoint: "",
 				TLSSetting: configtls.TLSClientSetting{
@@ -417,7 +417,7 @@ func TestHTTPServerSettingsError(t *testing.T) {
 			},
 		},
 		{
-			err: "^failed to load TLS config: failed to load TLS cert and key: for auth via TLS, either both certificate and key must be supplied, or neither",
+			err: "^failed to load TLS config: failed to load TLS cert and key: for auth via TLS, provide both certificate and key, or neither",
 			settings: HTTPServerSettings{
 				Endpoint: "localhost:0",
 				TLSSetting: &configtls.TLSServerSetting{

--- a/config/confighttp/confighttp_test.go
+++ b/config/confighttp/confighttp_test.go
@@ -428,7 +428,7 @@ func TestHTTPServerSettingsError(t *testing.T) {
 			},
 		},
 		{
-			err: "failed to load client CA CertPool: failed to load CA /doesnt/exist: open /doesnt/exist:",
+			err: "failed to load client CA CertPool: failed to load CA /doesnt/exist:",
 			settings: HTTPServerSettings{
 				Endpoint: "localhost:0",
 				TLSSetting: &configtls.TLSServerSetting{

--- a/config/configtls/README.md
+++ b/config/configtls/README.md
@@ -18,14 +18,18 @@ As a result, the following parameters are also required:
 
 - `cert_file`: Path to the TLS cert to use for TLS required connections. Should
   only be used if `insecure` is set to false.
+  - `cert_pem`: Alternative to `cert_file`. Provide the certificate contents as a string instead of a filepath.
+
 - `key_file`: Path to the TLS key to use for TLS required connections. Should
   only be used if `insecure` is set to false.
+  - `key_pem`: Alternative to `key_file`. Provide the key contents as a string instead of a filepath.
 
 A certificate authority may also need to be defined:
 
 - `ca_file`: Path to the CA cert. For a client this verifies the server
   certificate. For a server this verifies client certificates. If empty uses
   system root CA. Should only be used if `insecure` is set to false.
+  - `ca_pem`: Alternative to `ca_file`. Provide the CA cert contents as a string instead of a filepath.
 
 Additionally you can configure TLS to be enabled but skip verifying the server's
 certificate chain. This cannot be combined with `insecure` since `insecure`

--- a/config/configtls/configtls.go
+++ b/config/configtls/configtls.go
@@ -202,7 +202,7 @@ func (c TLSSetting) loadCACertPool() (*x509.CertPool, error) {
 
 	switch {
 	case c.hasCAFile() && c.hasCAPem():
-		return nil, fmt.Errorf("failed to load CA CertPool: CA File and PEM cannot both be provided")
+		return nil, fmt.Errorf("failed to load CA CertPool: provide either a CA file or the PEM-encoded string, but not both")
 	case c.hasCAFile():
 		// Set up user specified truststore from file
 		certPool, err = c.loadCertFile(c.CAFile)
@@ -240,13 +240,13 @@ func (c TLSSetting) loadCertPem(certPem []byte) (*x509.CertPool, error) {
 func (c TLSSetting) loadCertificate() (tls.Certificate, error) {
 	switch {
 	case c.hasCert() != c.hasKey():
-		return tls.Certificate{}, fmt.Errorf("for auth via TLS, either both certificate and key must be supplied, or neither")
+		return tls.Certificate{}, fmt.Errorf("for auth via TLS, provide both certificate and key, or neither")
 	case !c.hasCert() && !c.hasKey():
 		return tls.Certificate{}, nil
 	case c.hasCertFile() && c.hasCertPem():
-		return tls.Certificate{}, fmt.Errorf("for auth via TLS, certificate file and PEM cannot both be provided")
+		return tls.Certificate{}, fmt.Errorf("for auth via TLS, provide either a certificate or the PEM-encoded string, but not both")
 	case c.hasKeyFile() && c.hasKeyPem():
-		return tls.Certificate{}, fmt.Errorf("for auth via TLS, key file and PEM cannot both be provided")
+		return tls.Certificate{}, fmt.Errorf("for auth via TLS, provide either a key or the PEM-encoded string, but not both")
 	}
 
 	var certPem, keyPem []byte

--- a/config/configtls/configtls_test.go
+++ b/config/configtls/configtls_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.opentelemetry.io/collector/config/configopaque"
 )
 

--- a/config/configtls/configtls_test.go
+++ b/config/configtls/configtls_test.go
@@ -172,7 +172,7 @@ func TestOptionsToConfig(t *testing.T) {
 				CAFile: "testdata/ca-1.crt",
 				CAPem:  readFilePanics("testdata/ca-1.crt"),
 			},
-			expectError: "CA File and PEM cannot both be provided",
+			expectError: "provide either a CA file or the PEM-encoded string, but not both",
 		},
 		{
 			name: "should fail Cert file and PEM both provided",

--- a/config/configtls/configtls_test.go
+++ b/config/configtls/configtls_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/config/configopaque"
 )
 
 func TestOptionsToConfig(t *testing.T) {
@@ -242,13 +243,13 @@ func TestOptionsToConfig(t *testing.T) {
 	}
 }
 
-func readFilePanics(filePath string) []byte {
+func readFilePanics(filePath string) configopaque.String {
 	fileContents, err := os.ReadFile(filepath.Clean(filePath))
 	if err != nil {
 		panic(fmt.Sprintf("failed to read file %s: %v", filePath, err))
 	}
 
-	return fileContents
+	return configopaque.String(fileContents)
 }
 
 func TestLoadTLSClientConfigError(t *testing.T) {

--- a/config/configtls/configtls_test.go
+++ b/config/configtls/configtls_test.go
@@ -66,7 +66,7 @@ func TestOptionsToConfig(t *testing.T) {
 				CAFile:   filepath.Join("testdata", "ca-1.crt"),
 				CertFile: filepath.Join("testdata", "server-1.crt"),
 			},
-			expectError: "both certificate and key must be supplied",
+			expectError: "provide both certificate and key, or neither",
 		},
 		{
 			name: "should fail with invalid TLS KeyFile",
@@ -83,7 +83,7 @@ func TestOptionsToConfig(t *testing.T) {
 				CAFile:  filepath.Join("testdata", "ca-1.crt"),
 				KeyFile: filepath.Join("testdata", "server-1.key"),
 			},
-			expectError: "both certificate and key must be supplied",
+			expectError: "provide both certificate and key, or neither",
 		},
 		{
 			name: "should fail with invalid TLS Cert",
@@ -181,7 +181,7 @@ func TestOptionsToConfig(t *testing.T) {
 				CertPem:  readFilePanics("testdata/server-1.crt"),
 				KeyFile:  "testdata/server-1.key",
 			},
-			expectError: "for auth via TLS, certificate file and PEM cannot both be provided",
+			expectError: "provide either a certificate or the PEM-encoded string, but not both",
 		},
 		{
 			name: "should fail Key file and PEM both provided",
@@ -190,7 +190,7 @@ func TestOptionsToConfig(t *testing.T) {
 				KeyFile:  "testdata/ca-1.crt",
 				KeyPem:   readFilePanics("testdata/server-1.key"),
 			},
-			expectError: "for auth via TLS, key file and PEM cannot both be provided",
+			expectError: "provide either a key or the PEM-encoded string, but not both",
 		},
 		{
 			name: "should fail to load valid TLS settings with bad Cert PEM",
@@ -216,7 +216,7 @@ func TestOptionsToConfig(t *testing.T) {
 				CAPem:   readFilePanics("testdata/ca-1.crt"),
 				CertPem: readFilePanics("testdata/server-1.crt"),
 			},
-			expectError: "both certificate and key must be supplied",
+			expectError: "provide both certificate and key, or neither",
 		},
 		{
 			name: "should fail with missing TLS Cert PEM",
@@ -224,7 +224,7 @@ func TestOptionsToConfig(t *testing.T) {
 				CAPem:  readFilePanics("testdata/ca-1.crt"),
 				KeyPem: readFilePanics("testdata/server-1.key"),
 			},
-			expectError: "both certificate and key must be supplied",
+			expectError: "provide both certificate and key, or neither",
 		},
 	}
 

--- a/config/configtls/configtls_test.go
+++ b/config/configtls/configtls_test.go
@@ -17,6 +17,7 @@ package configtls
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -49,7 +50,7 @@ func TestOptionsToConfig(t *testing.T) {
 		{
 			name:        "should fail with invalid CA file content",
 			options:     TLSSetting{CAFile: filepath.Join("testdata", "testCA-bad.txt")},
-			expectError: "failed to parse CA",
+			expectError: "failed to parse cert",
 		},
 		{
 			name: "should load valid TLS  settings",
@@ -105,7 +106,7 @@ func TestOptionsToConfig(t *testing.T) {
 			options: TLSSetting{
 				CAFile: filepath.Join("testdata", "testCA-bad.txt"),
 			},
-			expectError: "failed to parse CA",
+			expectError: "failed to parse cert",
 		},
 		{
 			name: "should pass with valid CA pool",
@@ -134,6 +135,97 @@ func TestOptionsToConfig(t *testing.T) {
 			},
 			expectError: "invalid TLS max_",
 		},
+		{
+			name:    "should load custom CA PEM",
+			options: TLSSetting{CAPem: readFilePanics("testdata/ca-1.crt")},
+		},
+		{
+			name: "should load valid TLS settings with PEMs",
+			options: TLSSetting{
+				CAPem:   readFilePanics("testdata/ca-1.crt"),
+				CertPem: readFilePanics("testdata/server-1.crt"),
+				KeyPem:  readFilePanics("testdata/server-1.key"),
+			},
+		},
+		{
+			name: "mix Cert file and Key PEM provided",
+			options: TLSSetting{
+				CertFile: "testdata/server-1.crt",
+				KeyPem:   readFilePanics("testdata/server-1.key"),
+			},
+		},
+		{
+			name: "mix Cert PEM and Key File provided",
+			options: TLSSetting{
+				CertPem: readFilePanics("testdata/server-1.crt"),
+				KeyFile: "testdata/server-1.key",
+			},
+		},
+		{
+			name:        "should fail with invalid CA PEM",
+			options:     TLSSetting{CAPem: readFilePanics("testdata/testCA-bad.txt")},
+			expectError: "failed to parse cert",
+		},
+		{
+			name: "should fail CA file and PEM both provided",
+			options: TLSSetting{
+				CAFile: "testdata/ca-1.crt",
+				CAPem:  readFilePanics("testdata/ca-1.crt"),
+			},
+			expectError: "CA File and PEM cannot both be provided",
+		},
+		{
+			name: "should fail Cert file and PEM both provided",
+			options: TLSSetting{
+				CertFile: "testdata/server-1.crt",
+				CertPem:  readFilePanics("testdata/server-1.crt"),
+				KeyFile:  "testdata/server-1.key",
+			},
+			expectError: "for auth via TLS, certificate file and PEM cannot both be provided",
+		},
+		{
+			name: "should fail Key file and PEM both provided",
+			options: TLSSetting{
+				CertFile: "testdata/server-1.crt",
+				KeyFile:  "testdata/ca-1.crt",
+				KeyPem:   readFilePanics("testdata/server-1.key"),
+			},
+			expectError: "for auth via TLS, key file and PEM cannot both be provided",
+		},
+		{
+			name: "should fail to load valid TLS settings with bad Cert PEM",
+			options: TLSSetting{
+				CAPem:   readFilePanics("testdata/ca-1.crt"),
+				CertPem: readFilePanics("testdata/testCA-bad.txt"),
+				KeyPem:  readFilePanics("testdata/server-1.key"),
+			},
+			expectError: "failed to load TLS cert and key PEMs",
+		},
+		{
+			name: "should fail to load valid TLS settings with bad Key PEM",
+			options: TLSSetting{
+				CAPem:   readFilePanics("testdata/ca-1.crt"),
+				CertPem: readFilePanics("testdata/server-1.crt"),
+				KeyPem:  readFilePanics("testdata/testCA-bad.txt"),
+			},
+			expectError: "failed to load TLS cert and key PEMs",
+		},
+		{
+			name: "should fail with missing TLS KeyPem",
+			options: TLSSetting{
+				CAPem:   readFilePanics("testdata/ca-1.crt"),
+				CertPem: readFilePanics("testdata/server-1.crt"),
+			},
+			expectError: "both certificate and key must be supplied",
+		},
+		{
+			name: "should fail with missing TLS Cert PEM",
+			options: TLSSetting{
+				CAPem:  readFilePanics("testdata/ca-1.crt"),
+				KeyPem: readFilePanics("testdata/server-1.key"),
+			},
+			expectError: "both certificate and key must be supplied",
+		},
 	}
 
 	for _, test := range tests {
@@ -148,6 +240,15 @@ func TestOptionsToConfig(t *testing.T) {
 			}
 		})
 	}
+}
+
+func readFilePanics(filePath string) []byte {
+	fileContents, err := os.ReadFile(filepath.Clean(filePath))
+	if err != nil {
+		panic(fmt.Sprintf("failed to read file %s: %v", filePath, err))
+	}
+
+	return fileContents
 }
 
 func TestLoadTLSClientConfigError(t *testing.T) {
@@ -412,7 +513,7 @@ func TestCertificateReload(t *testing.T) {
 			cert2:          "testCA-bad.txt",
 			key2:           "client-2.key",
 			dns1:           "example1",
-			errText:        "failed to load TLS cert and key: tls: failed to find any PEM data in certificate input",
+			errText:        "failed to load TLS cert and key: failed to load TLS cert and key PEMs: tls: failed to find any PEM data in certificate input",
 		},
 	}
 

--- a/receiver/otlpreceiver/otlp_test.go
+++ b/receiver/otlpreceiver/otlp_test.go
@@ -821,7 +821,7 @@ func TestGRPCInvalidTLSCredentials(t *testing.T) {
 
 	assert.EqualError(t,
 		r.Start(context.Background(), componenttest.NewNopHost()),
-		`failed to load TLS config: for auth via TLS, either both certificate and key must be supplied, or neither`)
+		`failed to load TLS config: failed to load TLS cert and key: for auth via TLS, either both certificate and key must be supplied, or neither`)
 }
 
 func TestGRPCMaxRecvSize(t *testing.T) {
@@ -887,7 +887,7 @@ func TestHTTPInvalidTLSCredentials(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, r)
 	assert.EqualError(t, r.Start(context.Background(), componenttest.NewNopHost()),
-		`failed to load TLS config: for auth via TLS, either both certificate and key must be supplied, or neither`)
+		`failed to load TLS config: failed to load TLS cert and key: for auth via TLS, either both certificate and key must be supplied, or neither`)
 }
 
 func testHTTPMaxRequestBodySizeJSON(t *testing.T, payload []byte, size int, expectedStatusCode int) {

--- a/receiver/otlpreceiver/otlp_test.go
+++ b/receiver/otlpreceiver/otlp_test.go
@@ -821,7 +821,7 @@ func TestGRPCInvalidTLSCredentials(t *testing.T) {
 
 	assert.EqualError(t,
 		r.Start(context.Background(), componenttest.NewNopHost()),
-		`failed to load TLS config: failed to load TLS cert and key: for auth via TLS, either both certificate and key must be supplied, or neither`)
+		`failed to load TLS config: failed to load TLS cert and key: for auth via TLS, provide both certificate and key, or neither`)
 }
 
 func TestGRPCMaxRecvSize(t *testing.T) {
@@ -887,7 +887,7 @@ func TestHTTPInvalidTLSCredentials(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, r)
 	assert.EqualError(t, r.Start(context.Background(), componenttest.NewNopHost()),
-		`failed to load TLS config: failed to load TLS cert and key: for auth via TLS, either both certificate and key must be supplied, or neither`)
+		`failed to load TLS config: failed to load TLS cert and key: for auth via TLS, provide both certificate and key, or neither`)
 }
 
 func testHTTPMaxRequestBodySizeJSON(t *testing.T, payload []byte, size int, expectedStatusCode int) {


### PR DESCRIPTION
**Description:** This implements a version of the proposed changes requested in the linked issue.

**Related:** A [PR](https://github.com/prometheus/common/pull/472) accomplishing similar was accepted into Prometheus recently.

**Link to tracking Issue:** #7313

**Testing:** Added tests for a variety of scenarios around filepath vs in memory certs.

**Documentation:** Added new parameters to the README