### PR TITLE
add feature gate for supporting additional exporters

### DIFF
--- a/.chloggen/codeboten_add-featuregate-telemetry.yaml
+++ b/.chloggen/codeboten_add-featuregate-telemetry.yaml
@@ -5,7 +5,7 @@ change_type: enhancement
 component: service
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: "Add feature gate `telemetry.useOtelWithExtendedConfigurationForInternalTelemetry` to start adding support for exporting internal telemetry"
+note: "Add feature gate `telemetry.useOtelWithSDKConfigurationForInternalTelemetry` that will add support for configuring the export of internal telemetry to additional destinations in future releases"
 
 # One or more tracking issues or pull requests related to the change
 issues: [7641]

--- a/.chloggen/codeboten_add-featuregate-telemetry.yaml
+++ b/.chloggen/codeboten_add-featuregate-telemetry.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: service
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Add feature gate `telemetry.useOtelWithExtendedConfigurationForInternalTelemetry` to start adding support for exporting internal telemetry"
+
+# One or more tracking issues or pull requests related to the change
+issues: [7641]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/internal/obsreportconfig/obsreportconfig.go
+++ b/internal/obsreportconfig/obsreportconfig.go
@@ -39,6 +39,14 @@ var DisableHighCardinalityMetricsfeatureGate = featuregate.GlobalRegistry().Must
 	featuregate.WithRegisterDescription("controls whether the collector should enable potentially high"+
 		"cardinality metrics. The gate will be removed when the collector allows for view configuration."))
 
+// UseOtelWithExtendedConfigurationForInternalTelemetryFeatureGate is the feature gate that controls whether the collector
+// supports configuring the OpenTelemetry SDK via configuration
+var UseOtelWithExtendedConfigurationForInternalTelemetryFeatureGate = featuregate.GlobalRegistry().MustRegister(
+	"telemetry.useOtelWithExtendedConfigurationForInternalTelemetry",
+	featuregate.StageAlpha,
+	featuregate.WithRegisterDescription("controls whether the collector supports extended OpenTelemetry"+
+		"configuration for internal telemetry"))
+
 // AllViews returns all the OpenCensus views requires by obsreport package.
 func AllViews(level configtelemetry.Level) []*view.View {
 	if level == configtelemetry.LevelNone {

--- a/internal/obsreportconfig/obsreportconfig.go
+++ b/internal/obsreportconfig/obsreportconfig.go
@@ -39,10 +39,10 @@ var DisableHighCardinalityMetricsfeatureGate = featuregate.GlobalRegistry().Must
 	featuregate.WithRegisterDescription("controls whether the collector should enable potentially high"+
 		"cardinality metrics. The gate will be removed when the collector allows for view configuration."))
 
-// UseOtelWithExtendedConfigurationForInternalTelemetryFeatureGate is the feature gate that controls whether the collector
+// UseOtelWithSDKConfigurationForInternalTelemetryFeatureGate is the feature gate that controls whether the collector
 // supports configuring the OpenTelemetry SDK via configuration
-var UseOtelWithExtendedConfigurationForInternalTelemetryFeatureGate = featuregate.GlobalRegistry().MustRegister(
-	"telemetry.useOtelWithExtendedConfigurationForInternalTelemetry",
+var UseOtelWithSDKConfigurationForInternalTelemetryFeatureGate = featuregate.GlobalRegistry().MustRegister(
+	"telemetry.useOtelWithSDKConfigurationForInternalTelemetry",
 	featuregate.StageAlpha,
 	featuregate.WithRegisterDescription("controls whether the collector supports extended OpenTelemetry"+
 		"configuration for internal telemetry"))

--- a/service/service.go
+++ b/service/service.go
@@ -87,6 +87,7 @@ func New(ctx context.Context, set Settings, cfg Config) (*Service, error) {
 		useOtel = *set.useOtel
 	}
 	disableHighCard := obsreportconfig.DisableHighCardinalityMetricsfeatureGate.IsEnabled()
+	extendedConfig := obsreportconfig.UseOtelWithExtendedConfigurationForInternalTelemetryFeatureGate.IsEnabled()
 	srv := &Service{
 		buildInfo: set.BuildInfo,
 		host: &serviceHost{
@@ -98,7 +99,7 @@ func New(ctx context.Context, set Settings, cfg Config) (*Service, error) {
 			buildInfo:         set.BuildInfo,
 			asyncErrorChannel: set.AsyncErrorChannel,
 		},
-		telemetryInitializer: newColTelemetry(useOtel, disableHighCard),
+		telemetryInitializer: newColTelemetry(useOtel, disableHighCard, extendedConfig),
 	}
 	var err error
 	srv.telemetry, err = telemetry.New(ctx, telemetry.Settings{ZapOptions: set.LoggingOptions}, cfg.Telemetry)

--- a/service/service.go
+++ b/service/service.go
@@ -87,7 +87,7 @@ func New(ctx context.Context, set Settings, cfg Config) (*Service, error) {
 		useOtel = *set.useOtel
 	}
 	disableHighCard := obsreportconfig.DisableHighCardinalityMetricsfeatureGate.IsEnabled()
-	extendedConfig := obsreportconfig.UseOtelWithExtendedConfigurationForInternalTelemetryFeatureGate.IsEnabled()
+	extendedConfig := obsreportconfig.UseOtelWithSDKConfigurationForInternalTelemetryFeatureGate.IsEnabled()
 	srv := &Service{
 		buildInfo: set.BuildInfo,
 		host: &serviceHost{

--- a/service/telemetry.go
+++ b/service/telemetry.go
@@ -90,13 +90,15 @@ type telemetryInitializer struct {
 
 	useOtel                bool
 	disableHighCardinality bool
+	extendedConfig         bool
 }
 
-func newColTelemetry(useOtel bool, disableHighCardinality bool) *telemetryInitializer {
+func newColTelemetry(useOtel bool, disableHighCardinality bool, extendedConfig bool) *telemetryInitializer {
 	return &telemetryInitializer{
 		mp:                     noop.NewMeterProvider(),
 		useOtel:                useOtel,
 		disableHighCardinality: disableHighCardinality,
+		extendedConfig:         extendedConfig,
 	}
 }
 

--- a/service/telemetry/config.go
+++ b/service/telemetry/config.go
@@ -104,6 +104,18 @@ type LogsSamplingConfig struct {
 	Thereafter int `mapstructure:"thereafter"`
 }
 
+// MetricReader exposes configuration of metric readers to end users.
+// TODO: replace this temporary struct w/ auto-generated struct from jsonschema
+//
+// Experimental: *NOTE* this structure is subject to change or removal in the future.
+type MetricReader struct {
+	// Args corresponds to the JSON schema field "args".
+	Args any `mapstructure:"args"`
+
+	// Type corresponds to the JSON schema field "type".
+	Type string `mapstructure:"type"`
+}
+
 // MetricsConfig exposes the common Telemetry configuration for one component.
 // Experimental: *NOTE* this structure is subject to change or removal in the future.
 type MetricsConfig struct {
@@ -116,6 +128,10 @@ type MetricsConfig struct {
 
 	// Address is the [address]:port that metrics exposition should be bound to.
 	Address string `mapstructure:"address"`
+
+	// Readers allow configuration of metric readers to emit metrics to
+	// any number of supported backends.
+	Readers []MetricReader `mapstructure:"metric_readers"`
 }
 
 // TracesConfig exposes the common Telemetry configuration for collector's internal spans.

--- a/service/telemetry/config.go
+++ b/service/telemetry/config.go
@@ -106,6 +106,7 @@ type LogsSamplingConfig struct {
 
 // MetricReader exposes configuration of metric readers to end users.
 // TODO: replace this temporary struct w/ auto-generated struct from jsonschema
+// https://github.com/open-telemetry/opentelemetry-configuration/tree/main/schema
 //
 // Experimental: *NOTE* this structure is subject to change or removal in the future.
 type MetricReader struct {

--- a/service/telemetry_test.go
+++ b/service/telemetry_test.go
@@ -113,6 +113,7 @@ func TestTelemetryInit(t *testing.T) {
 		useOtel         bool
 		disableHighCard bool
 		expectedMetrics map[string]metricValue
+		extendedConfig  bool
 	}{
 		{
 			name:    "UseOpenCensusForInternalMetrics",
@@ -198,7 +199,7 @@ func TestTelemetryInit(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			tel := newColTelemetry(tc.useOtel, tc.disableHighCard)
+			tel := newColTelemetry(tc.useOtel, tc.disableHighCard, tc.extendedConfig)
 			buildInfo := component.NewDefaultBuildInfo()
 			cfg := telemetry.Config{
 				Resource: map[string]*string{


### PR DESCRIPTION
This adds the feature-gate `telemetry.useOtelWithExtendedConfigurationForInternalTelemetry` to start adding support for additional exporters for the collector's internal telemetry.

This is part of of https://github.com/open-telemetry/opentelemetry-collector/pull/7644