### PR TITLE
[featuregate] Move to stable module-set

### DIFF
--- a/.chloggen/prepare-featuregate-for-rc.yaml
+++ b/.chloggen/prepare-featuregate-for-rc.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: featuregate
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Promote `featuregate` to the stable module-set
+
+# One or more tracking issues or pull requests related to the change
+issues: [7693]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/versions.yaml
+++ b/versions.yaml
@@ -17,6 +17,7 @@ module-sets:
     version: v1.0.0-rcv0011
     modules:
       - go.opentelemetry.io/collector/pdata
+      - go.opentelemetry.io/collector/featuregate
   beta:
     version: v0.77.0
     modules:
@@ -32,7 +33,6 @@ module-sets:
       - go.opentelemetry.io/collector/exporter/otlphttpexporter
       - go.opentelemetry.io/collector/extension/ballastextension
       - go.opentelemetry.io/collector/extension/zpagesextension
-      - go.opentelemetry.io/collector/featuregate
       - go.opentelemetry.io/collector/processor/batchprocessor
       - go.opentelemetry.io/collector/processor/memorylimiterprocessor
       - go.opentelemetry.io/collector/receiver

--- a/versions.yaml
+++ b/versions.yaml
@@ -16,8 +16,8 @@ module-sets:
   stable:
     version: v1.0.0-rcv0011
     modules:
-      - go.opentelemetry.io/collector/pdata
       - go.opentelemetry.io/collector/featuregate
+      - go.opentelemetry.io/collector/pdata
   beta:
     version: v0.77.0
     modules:


### PR DESCRIPTION
**Description:** 
Moves the `featuregate` module to the stable module-set so that in the next release we provide a release candidate.

**Link to tracking Issue:** 

Closes https://github.com/open-telemetry/opentelemetry-collector/milestone/30
