### PR TITLE
Add headers to HTTPServerSettings

### DIFF
--- a/.chloggen/http-server-headers-config.yaml
+++ b/.chloggen/http-server-headers-config.yaml
@@ -5,7 +5,7 @@ change_type: enhancement
 component: confighttp
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Add `headers` configuration option on HTTPServerSettings. It allows for additional headers to be attached to each HTTP response sent to the client
+note: Add `response_headers` configuration option on HTTPServerSettings. It allows for additional headers to be attached to each HTTP response sent to the client
 
 # One or more tracking issues or pull requests related to the change
 issues: [7328]

--- a/.chloggen/http-server-headers-config.yaml
+++ b/.chloggen/http-server-headers-config.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: confighttp
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add `headers` configuration option on HTTPServerSettings. It allows for additional headers to be attached to each HTTP response sent to the client
+
+# One or more tracking issues or pull requests related to the change
+issues: [7328]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/config/confighttp/confighttp.go
+++ b/config/confighttp/confighttp.go
@@ -219,7 +219,7 @@ type HTTPServerSettings struct {
 
 	// Additional headers attached to each HTTP response sent to the client.
 	// Header values are opaque since they may be sensitive.
-	Headers map[string]configopaque.String `mapstructure:"headers"`
+	ResponseHeaders map[string]configopaque.String `mapstructure:"response_headers"`
 }
 
 // ToListener creates a net.Listener.
@@ -297,8 +297,8 @@ func (hss *HTTPServerSettings) ToServer(host component.Host, settings component.
 		handler = cors.New(co).Handler(handler)
 	}
 
-	if hss.Headers != nil {
-		handler = headerHandler(handler, hss.Headers)
+	if hss.ResponseHeaders != nil {
+		handler = responseHeadersHandler(handler, hss.ResponseHeaders)
 	}
 
 	// Enable OpenTelemetry observability plugin.
@@ -325,7 +325,7 @@ func (hss *HTTPServerSettings) ToServer(host component.Host, settings component.
 	}, nil
 }
 
-func headerHandler(handler http.Handler, headers map[string]configopaque.String) http.Handler {
+func responseHeadersHandler(handler http.Handler, headers map[string]configopaque.String) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		h := w.Header()
 

--- a/config/confighttp/confighttp_test.go
+++ b/config/confighttp/confighttp_test.go
@@ -826,8 +826,8 @@ func TestHttpServerHeaders(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			hss := &HTTPServerSettings{
-				Endpoint: "localhost:0",
-				Headers:  tt.headers,
+				Endpoint:        "localhost:0",
+				ResponseHeaders: tt.headers,
 			}
 
 			ln, err := hss.ToListener()

--- a/config/confighttp/confighttp_test.go
+++ b/config/confighttp/confighttp_test.go
@@ -801,6 +801,64 @@ func TestHttpCorsWithSettings(t *testing.T) {
 	assert.Equal(t, "*", rec.Header().Get("Access-Control-Allow-Origin"))
 }
 
+func TestHttpServerHeaders(t *testing.T) {
+	tests := []struct {
+		name    string
+		headers map[string]configopaque.String
+	}{
+		{
+			name:    "noHeaders",
+			headers: nil,
+		},
+		{
+			name:    "emptyHeaders",
+			headers: map[string]configopaque.String{},
+		},
+		{
+			name: "withHeaders",
+			headers: map[string]configopaque.String{
+				"x-new-header-1": "value1",
+				"x-new-header-2": "value2",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hss := &HTTPServerSettings{
+				Endpoint: "localhost:0",
+				Headers:  tt.headers,
+			}
+
+			ln, err := hss.ToListener()
+			require.NoError(t, err)
+
+			s, err := hss.ToServer(
+				componenttest.NewNopHost(),
+				componenttest.NewNopTelemetrySettings(),
+				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusOK)
+				}))
+			require.NoError(t, err)
+
+			go func() {
+				_ = s.Serve(ln)
+			}()
+
+			// TODO: make starting server deterministic
+			// Wait for the servers to start
+			<-time.After(10 * time.Millisecond)
+
+			url := fmt.Sprintf("http://%s", ln.Addr().String())
+
+			// Verify allowed domain gets responses that allow CORS.
+			verifyHeadersResp(t, url, tt.headers)
+
+			require.NoError(t, s.Close())
+		})
+	}
+}
+
 func verifyCorsResp(t *testing.T, url string, origin string, maxAge int, extraHeader bool, wantStatus int, wantAllowed bool) {
 	req, err := http.NewRequest(http.MethodOptions, url, nil)
 	require.NoError(t, err, "Error creating trace OPTIONS request: %v", err)
@@ -839,6 +897,25 @@ func verifyCorsResp(t *testing.T, url string, origin string, maxAge int, extraHe
 	assert.Equal(t, wantMaxAge, resp.Header.Get("Access-Control-Max-Age"))
 }
 
+func verifyHeadersResp(t *testing.T, url string, expected map[string]configopaque.String) {
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	require.NoError(t, err, "Error creating request: %v", err)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err, "Error sending request to http server: %v", err)
+
+	err = resp.Body.Close()
+	if err != nil {
+		t.Errorf("Error closing response body, %v", err)
+	}
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	for k, v := range expected {
+		assert.Equal(t, string(v), resp.Header.Get(k))
+	}
+}
+
 func ExampleHTTPServerSettings() {
 	settings := HTTPServerSettings{
 		Endpoint: "localhost:443",
@@ -860,7 +937,7 @@ func ExampleHTTPServerSettings() {
 	}
 }
 
-func TestHttpHeaders(t *testing.T) {
+func TestHttpClientHeaders(t *testing.T) {
 	tests := []struct {
 		name    string
 		headers map[string]configopaque.String


### PR DESCRIPTION
**Description:**
Add `headers` configuration option on HTTPServerSettings. It allows for additional headers to be attached to each HTTP response sent to the client

**Link to tracking Issue:**
#7328

**Testing:**
I've added a test case that ensures the code still works with `nil` or an empty map along with one with a set of headers 

**Documentation:**
I've added comments in the struct, I imagine it will automatically be included in the doc?