### PR TITLE
[scraper helper] Include support for timeout

### DIFF
--- a/.chloggen/msg_introduce-timeout-scrape.yaml
+++ b/.chloggen/msg_introduce-timeout-scrape.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: "enhancement"
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: scraper helper
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Ensuring that scrapers must finished within their scrape interval
+
+# One or more tracking issues or pull requests related to the change
+issues: [7703]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/scraperhelper/scrapercontroller.go
+++ b/receiver/scraperhelper/scrapercontroller.go
@@ -47,6 +47,7 @@ type controller struct {
 	logger             *zap.Logger
 	collectionInterval time.Duration
 	initialDelay       time.Duration
+	timeout            time.Duration
 	nextConsumer       consumer.Metrics
 
 	scrapers    []Scraper
@@ -91,6 +92,7 @@ func NewScraperControllerReceiver(
 		logger:             set.Logger,
 		collectionInterval: cfg.CollectionInterval,
 		initialDelay:       cfg.InitialDelay,
+		timeout:            cfg.Timeout,
 		nextConsumer:       nextConsumer,
 		done:               make(chan struct{}),
 		terminated:         make(chan struct{}),
@@ -172,7 +174,7 @@ func (sc *controller) startScraping() {
 		for {
 			select {
 			case <-sc.tickerCh:
-				ctx, done := context.WithTimeout(context.Background(), sc.collectionInterval)
+				ctx, done := context.WithTimeout(context.Background(), sc.timeout)
 				sc.scrapeMetricsAndReport(ctx)
 				done()
 			case <-sc.done:

--- a/receiver/scraperhelper/settings.go
+++ b/receiver/scraperhelper/settings.go
@@ -28,7 +28,7 @@ type ScraperControllerSettings struct {
 	CollectionInterval time.Duration `mapstructure:"collection_interval"`
 	// InitialDelay sets the initial start delay for the scraper,
 	// any non positive value is assumed to be immediately.
-	InitialDelay time.Duration `mapstructure:"intial_delay"`
+	InitialDelay time.Duration `mapstructure:"initial_delay"`
 	// Timeout is used to set scraper's context deadline, it must be within
 	// the range of (0, CollectionInterval]
 	Timeout time.Duration `mapstructure:"timeout"`

--- a/receiver/scraperhelper/settings.go
+++ b/receiver/scraperhelper/settings.go
@@ -14,8 +14,8 @@ import (
 )
 
 var (
-	ErrNonPositiveInterval    = errors.New("requires positive value")
-	ErrTimeoutExceedsInterval = errors.New("timeout value exceeds collection interval")
+	errNonPositiveInterval    = errors.New("requires positive value")
+	errTimeoutExceedsInterval = errors.New("timeout value exceeds collection interval")
 )
 
 // ScraperControllerSettings defines common settings for a scraper controller
@@ -45,14 +45,14 @@ func NewDefaultScraperControllerSettings(component.Type) ScraperControllerSettin
 }
 
 func (set *ScraperControllerSettings) Validate() (errs error) {
-	if set.CollectionInterval < 1 {
-		errs = multierr.Append(errs, fmt.Errorf(`"collection_interval": %w`, ErrNonPositiveInterval))
+	if set.CollectionInterval <= 0 {
+		errs = multierr.Append(errs, fmt.Errorf(`"collection_interval": %w`, errNonPositiveInterval))
 	}
-	if set.Timeout < 1 {
-		errs = multierr.Append(errs, fmt.Errorf(`"timeout": %w`, ErrNonPositiveInterval))
+	if set.Timeout <= 0 {
+		errs = multierr.Append(errs, fmt.Errorf(`"timeout": %w`, errNonPositiveInterval))
 	}
 	if set.Timeout > set.CollectionInterval {
-		errs = multierr.Append(errs, ErrTimeoutExceedsInterval)
+		errs = multierr.Append(errs, errTimeoutExceedsInterval)
 	}
 	return errs
 }

--- a/receiver/scraperhelper/settings.go
+++ b/receiver/scraperhelper/settings.go
@@ -26,7 +26,9 @@ type ScraperControllerSettings struct {
 	// should be called and used as the context timeout
 	// to ensure that scrapers don't exceed the interval.
 	CollectionInterval time.Duration `mapstructure:"collection_interval"`
-	InitialDelay       time.Duration `mapstructure:"intial_delay"`
+	// InitialDelay sets the initial start delay for the scraper,
+	// any non positive value is assumed to be immediately.
+	InitialDelay time.Duration `mapstructure:"intial_delay"`
 	// Timeout is used to set scraper's context deadline, it must be within
 	// the range of (0, CollectionInterval]
 	Timeout time.Duration `mapstructure:"timeout"`
@@ -37,6 +39,7 @@ type ScraperControllerSettings struct {
 func NewDefaultScraperControllerSettings(component.Type) ScraperControllerSettings {
 	return ScraperControllerSettings{
 		CollectionInterval: time.Minute,
+		InitialDelay:       time.Second,
 		Timeout:            time.Minute,
 	}
 }

--- a/receiver/scraperhelper/settings.go
+++ b/receiver/scraperhelper/settings.go
@@ -1,0 +1,44 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package scraperhelper // import "go.opentelemetry.io/collector/receiver/scraperhelper"
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"go.uber.org/multierr"
+
+	"go.opentelemetry.io/collector/component"
+)
+
+var (
+	ErrNonPositiveInterval = errors.New("requires positive value")
+)
+
+// ScraperControllerSettings defines common settings for a scraper controller
+// configuration. Scraper controller receivers can embed this struct, instead
+// of receiver.Settings, and extend it with more fields if needed.
+type ScraperControllerSettings struct {
+	// CollectionInterval sets the how frequently the scraper
+	// should be called and used as the context timeout
+	// to ensure that scrapers don't exceed the interval.
+	CollectionInterval time.Duration `mapstructure:"collection_interval"`
+	InitialDelay       time.Duration `mapstructure:"intial_delay"`
+}
+
+// NewDefaultScraperControllerSettings returns default scraper controller
+// settings with a collection interval of one minute.
+func NewDefaultScraperControllerSettings(component.Type) ScraperControllerSettings {
+	return ScraperControllerSettings{
+		CollectionInterval: time.Minute,
+	}
+}
+
+func (set *ScraperControllerSettings) Validate() (errs error) {
+	if set.CollectionInterval < 1 {
+		errs = multierr.Append(errs, fmt.Errorf(`"collection_interval": %w`, ErrNonPositiveInterval))
+	}
+	return errs
+}

--- a/receiver/scraperhelper/settings_test.go
+++ b/receiver/scraperhelper/settings_test.go
@@ -1,0 +1,43 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package scraperhelper
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestScrapeControllerSettings(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name   string
+		set    ScraperControllerSettings
+		errVal string
+	}{
+		{
+			name:   "default configuration",
+			set:    NewDefaultScraperControllerSettings("scraper"),
+			errVal: "",
+		},
+		{
+			name:   "zero collection interval",
+			set:    ScraperControllerSettings{},
+			errVal: `"collection_interval": requires positive value`,
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tc.set.Validate()
+			if tc.errVal == "" {
+				assert.NoError(t, err, "Must not error")
+				return
+			}
+			assert.EqualError(t, err, tc.errVal, "Must match the expected error")
+		})
+	}
+}

--- a/receiver/scraperhelper/settings_test.go
+++ b/receiver/scraperhelper/settings_test.go
@@ -23,9 +23,25 @@ func TestScrapeControllerSettings(t *testing.T) {
 			errVal: "",
 		},
 		{
-			name:   "zero collection interval",
+			name:   "zero value configuration",
 			set:    ScraperControllerSettings{},
-			errVal: `"collection_interval": requires positive value`,
+			errVal: `"collection_interval": requires positive value; "timeout": requires positive value`,
+		},
+		{
+			name: "invalid timeout",
+			set: ScraperControllerSettings{
+				CollectionInterval: 10,
+				Timeout:            -1,
+			},
+			errVal: `"timeout": requires positive value`,
+		},
+		{
+			name: "timeout exceeds scrape duration",
+			set: ScraperControllerSettings{
+				CollectionInterval: 2,
+				Timeout:            3,
+			},
+			errVal: `timeout value exceeds collection interval`,
 		},
 	} {
 		tc := tc


### PR DESCRIPTION
**Description:** 
This introduces a change that each scraper context is cancelled by the next collection period.

**Link to tracking Issue:** 
NA

**Testing:**
It requires integration tests against both core and contrib.

**Documentation:** 
Add comments to the collection interval to explain usage.


**Alternative**

I had considered adding a new field named `Timeout` which would require to be equal or less than collection interval.
However, since a lot of scrapers already have adopted a timeout fields, I worry about potential conflicts so I opted for this approach.