### PR TITLE
add benchmark test for multi batch processing

### DIFF
--- a/processor/batchprocessor/batch_processor_test.go
+++ b/processor/batchprocessor/batch_processor_test.go
@@ -611,6 +611,20 @@ func BenchmarkBatchMetricProcessor(b *testing.B) {
 		Timeout:       100 * time.Millisecond,
 		SendBatchSize: 2000,
 	}
+	runMetricsProcessorBenchmark(b, cfg)
+}
+
+func BenchmarkMultiBatchMetricProcessor(b *testing.B) {
+	b.StopTimer()
+	cfg := Config{
+		Timeout:       100 * time.Millisecond,
+		SendBatchSize: 2000,
+		MetadataKeys:  []string{"test", "test2"},
+	}
+	runMetricsProcessorBenchmark(b, cfg)
+}
+
+func runMetricsProcessorBenchmark(b *testing.B, cfg Config) {
 	ctx := context.Background()
 	sink := new(metricsSink)
 	creationSet := processortest.NewNopCreateSettings()

--- a/processor/batchprocessor/batch_processor_test.go
+++ b/processor/batchprocessor/batch_processor_test.go
@@ -634,16 +634,12 @@ func runMetricsProcessorBenchmark(b *testing.B, cfg Config) {
 	require.NoError(b, err)
 	require.NoError(b, batcher.Start(ctx, componenttest.NewNopHost()))
 
-	mds := make([]pmetric.Metrics, 0, b.N)
-	for n := 0; n < b.N; n++ {
-		mds = append(mds,
-			testdata.GenerateMetrics(metricsPerRequest),
-		)
-	}
 	b.StartTimer()
-	for n := 0; n < b.N; n++ {
-		require.NoError(b, batcher.ConsumeMetrics(ctx, mds[n]))
-	}
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			require.NoError(b, batcher.ConsumeMetrics(ctx, testdata.GenerateMetrics(metricsPerRequest)))
+		}
+	})
 	b.StopTimer()
 	require.NoError(b, batcher.Shutdown(ctx))
 	require.Equal(b, b.N*metricsPerRequest, sink.metricsCount)


### PR DESCRIPTION
This refactors the batch processor tests to make testing multiple configuration scenarios easier. It adds a testcase for a batch processor w/ metadata keys.
