### PR TITLE
forwardconnector: mark as mutates data

### DIFF
--- a/.chloggen/forward-copy.yaml
+++ b/.chloggen/forward-copy.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: forwardconnector
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: forwardconnector makes a copy of data in case subsequent pipelines mutate it.
+
+# One or more tracking issues or pull requests related to the change
+issues: [7776]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/connector/forwardconnector/forward.go
+++ b/connector/forwardconnector/forward.go
@@ -73,5 +73,6 @@ type forward struct {
 }
 
 func (c *forward) Capabilities() consumer.Capabilities {
-	return consumer.Capabilities{MutatesData: false}
+	// forward doesn't mutate data, but the connected pipeline might.
+	return consumer.Capabilities{MutatesData: true}
 }


### PR DESCRIPTION
**Description:** Pessimistically mark the forward connector as `MutatesData: true`, as the connected output pipeline(s) may mutate

**Link to tracking Issue:** #7776