### PR TITLE
Incorporate next consumer's capabilities into connector capabilities

### DIFF
--- a/.chloggen/connectors-wrap-mutates.yaml
+++ b/.chloggen/connectors-wrap-mutates.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: connectors
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: When replicating data to connectors, consider whether the next pipeline will mutate data
+
+# One or more tracking issues or pull requests related to the change
+issues: [7776]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/service/internal/testcomponents/example_connector.go
+++ b/service/internal/testcomponents/example_connector.go
@@ -113,5 +113,5 @@ type ExampleConnector struct {
 }
 
 func (c *ExampleConnector) Capabilities() consumer.Capabilities {
-	return consumer.Capabilities{MutatesData: true}
+	return consumer.Capabilities{MutatesData: false}
 }


### PR DESCRIPTION
Resolves #7776

The collector copies data whenever handing it to components that may mutate it. The point at which a copy must be made is within a fanout consumer. There are two points at which a fanout consumer may be placed:
1. Immediately after a receiver shared by multiple pipelines
2. Immediately before multiple exporters of a single pipeline

When data is fanned out _to_ a connector (acting as an exporter), we must ensure that the fanout consumer before exporters (point 2 above) is able to take into account whether or not the connector will be handing the data off to a pipeline that will mutate the data. 