### PR TITLE
[docs] fix code reference in configtls readme

### DIFF
--- a/config/configtls/README.md
+++ b/config/configtls/README.md
@@ -41,7 +41,7 @@ __IMPORTANT__: TLS 1.0 and 1.1 are deprecated due to known vulnerabilities and s
 - `min_version` (default = "1.2"): Minimum acceptable TLS version.
   - options: ["1.0", "1.1", "1.2", "1.3"]
 
-- `max_version` (default = "" handled by [crypto/tls](https://github.com/golang/go/blob/master/src/crypto/tls/common.go#L700) - currently TLS 1.3): Maximum acceptable TLS version.
+- `max_version` (default = "" handled by [crypto/tls](https://github.com/golang/go/blob/ed9db1d36ad6ef61095d5941ad9ee6da7ab6d05a/src/crypto/tls/common.go#L700) - currently TLS 1.3): Maximum acceptable TLS version.
   - options: ["1.0", "1.1", "1.2", "1.3"]
 
 Additionally certificates may be reloaded by setting the below configuration.


### PR DESCRIPTION
**Documentation:** Fix code reference to upstream Go TLS package code line.

The link to upstream Golang crypto/tls code line is wrong, because it was changed since Go release 1.19.

I suggest to use commit reference instead of volatile master branch.

```
https://github.com/golang/go/blob/ed9db1d36ad6ef61095d5941ad9ee6da7ab6d05a/src/crypto/tls/common.go#L700
```

Alternative fix would be to use release branch reference (a bit riskier).

```
https://github.com/golang/go/blob/release-branch.go1.19/src/crypto/tls/common.go#L700
```

Let me know if you prefer this to be referenced using Go release branch so I change the PR.