### PR TITLE
[chore][processor/batch] Update description of send_batch_size

### DIFF
--- a/processor/batchprocessor/README.md
+++ b/processor/batchprocessor/README.md
@@ -22,7 +22,10 @@ Please refer to [config.go](./config.go) for the config spec.
 
 The following configuration options can be modified:
 - `send_batch_size` (default = 8192): Number of spans, metric data points, or log
-records after which a batch will be sent regardless of the timeout.
+records after which a batch will be sent regardless of the timeout. `send_batch_size`
+acts as a trigger and does not affect the size of the batch. If you need to
+enforce batch size limits sent to the next component in the pipeline
+see `send_match_bax_size`.
 - `timeout` (default = 200ms): Time duration after which a batch will
 be sent regardless of size.  If set to zero, `send_batch_size` is
 ignored as data will be sent immediately, subject to only `send_batch_max_size`.

--- a/processor/batchprocessor/README.md
+++ b/processor/batchprocessor/README.md
@@ -25,7 +25,7 @@ The following configuration options can be modified:
 records after which a batch will be sent regardless of the timeout. `send_batch_size`
 acts as a trigger and does not affect the size of the batch. If you need to
 enforce batch size limits sent to the next component in the pipeline
-see `send_match_bax_size`.
+see `send_batch_max_size`.
 - `timeout` (default = 200ms): Time duration after which a batch will
 be sent regardless of size.  If set to zero, `send_batch_size` is
 ignored as data will be sent immediately, subject to only `send_batch_max_size`.


### PR DESCRIPTION
**Description:** This PR improves the description of the `send_batch_size` configuration option in the batch processor. The current documentation may not be 100 percent clear to new users of the processor. This change seeks to add clarification that `send_batch_size` is just a trigger to send and does not enforce limits. 

**Link to tracking Issue:** none, but this caught me off guard a bit. This change would have helped me build a better mental model of the processors capability. 

**Testing:** n/a

**Documentation:** n/a

_Please delete paragraphs that you did not use before submitting._
