### PR TITLE
Return Unauthenticated GRPC code on error

### DIFF
--- a/config/configgrpc/README.md
+++ b/config/configgrpc/README.md
@@ -107,3 +107,13 @@ see [confignet README](../confignet/README.md).
 - [`read_buffer_size`](https://godoc.org/google.golang.org/grpc#ReadBufferSize)
 - [`tls`](../configtls/README.md)
 - [`write_buffer_size`](https://godoc.org/google.golang.org/grpc#WriteBufferSize)
+
+## GRPC Status codes for authorization extensions
+
+GRPC defines a set of known [status codes](https://grpc.github.io/grpc/core/md_doc_statuscodes.html) that must be returned with all responses. Status Code `OK` should be returned on success and an appropriate code chosen for other cases.
+
+OpenTelemetry authorization extensions are handled as a GRPC interceptor and any errors encountered during an authorization check are converted to the GRPC `UNAUTHENTICATED` status.
+
+Any other code set by extensions are overwritten.
+
+**NOTE**: Authentication extensions that explicitly return an `status.Error()` will result in a duplicated error message as the result is wrapped. Extensions should use native Go error types and status codes should be added by this library.

--- a/config/configgrpc/configgrpc.go
+++ b/config/configgrpc/configgrpc.go
@@ -18,12 +18,14 @@ import (
 	"go.opentelemetry.io/otel"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/balancer/roundrobin"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/encoding/gzip"
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/peer"
+	"google.golang.org/grpc/status"
 
 	"go.opentelemetry.io/collector/client"
 	"go.opentelemetry.io/collector/component"
@@ -36,7 +38,7 @@ import (
 	"go.opentelemetry.io/collector/extension/auth"
 )
 
-var errMetadataNotFound = errors.New("no request metadata found")
+var errMetadataNotFound = status.Error(codes.Unauthenticated, "no request metadata found")
 
 // Allowed balancer names to be set in grpclb_policy to discover the servers.
 var allowedBalancerNames = []string{roundrobin.Name, grpc.PickFirstBalancerName}
@@ -434,7 +436,7 @@ func authUnaryServerInterceptor(ctx context.Context, req any, _ *grpc.UnaryServe
 
 	ctx, err := server.Authenticate(ctx, headers)
 	if err != nil {
-		return nil, err
+		return nil, status.Error(codes.Unauthenticated, err.Error())
 	}
 
 	return handler(ctx, req)
@@ -449,7 +451,7 @@ func authStreamServerInterceptor(srv any, stream grpc.ServerStream, _ *grpc.Stre
 
 	ctx, err := server.Authenticate(ctx, headers)
 	if err != nil {
-		return err
+		return status.Error(codes.Unauthenticated, err.Error())
 	}
 
 	return handler(srv, wrapServerStream(ctx, stream))


### PR DESCRIPTION
**Description:**
Because `configgrpc` doesn't explicitly set an GRPC status code, `grpc-go` will return the `Unknown` code if there is an error. This doesn't match the spec and can lead to issues in clients that expect the "correct" status code and throw errors in the case of an "unknown" code. All GRPC authentication errors should use the `Unauthenticated (16)` code.

This updated behaviour matches [confighttp.go](https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/confighttp/confighttp.go#L346) that always returns `Unauthorized (401)` for errors.

See the [GRPC Status code spec](https://grpc.github.io/grpc/core/md_doc_statuscodes.html) and the [GRPC <-> HTTP code mapping](https://github.com/grpc/grpc/blob/master/doc/http-grpc-status-mapping.md).

**Link to tracking Issue:** #7646

**Testing:** 
- Updated unit tests to explicitly check for error codes and compare to GRPC error types.

**Documentation:** Updated `README.md` to include details on error codes