### PR TITLE
[chore] update check-changes to match the release docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -397,19 +397,19 @@ endif
 	changed_files=""; \
 	for mod in $${mods}; do \
 		if [ "$${mod}" == "go.opentelemetry.io/collector" ]; then \
-			changed_files+=$$(git diff --name-only v$(PREVIOUS_VERSION) -- $$(printf '%s\n' $${all_submods[@]} | sed 's/^/:!/' | paste -sd' ' -) | grep -E '.+\.go$$'); \
-		elif ! git rev-parse --quiet --verify $${mod}/v$(PREVIOUS_VERSION) >/dev/null; then \
-			echo "Module $${mod} does not have a v$(PREVIOUS_VERSION) tag"; \
+			changed_files+=$$(git diff --name-only $(PREVIOUS_VERSION) -- $$(printf '%s\n' $${all_submods[@]} | sed 's/^/:!/' | paste -sd' ' -) | grep -E '.+\.go$$'); \
+		elif ! git rev-parse --quiet --verify $${mod}/$(PREVIOUS_VERSION) >/dev/null; then \
+			echo "Module $${mod} does not have a $(PREVIOUS_VERSION) tag"; \
 			echo "$(MODSET) release is required."; \
 			exit 0; \
 		else \
-			changed_files+=$$(git diff --name-only $${mod}/v$(PREVIOUS_VERSION) -- $${mod} | grep -E '.+\.go$$'); \
+			changed_files+=$$(git diff --name-only $${mod}/$(PREVIOUS_VERSION) -- $${mod} | grep -E '.+\.go$$'); \
 		fi; \
 	done; \
 	if [ -n "$${changed_files}" ]; then \
-		echo "The following files changed in $(MODSET) modules since v$(PREVIOUS_VERSION): $${changed_files}"; \
+		echo "The following files changed in $(MODSET) modules since $(PREVIOUS_VERSION): $${changed_files}"; \
 	else \
-		echo "No $(MODSET) modules have changed since v$(PREVIOUS_VERSION)"; \
+		echo "No $(MODSET) modules have changed since $(PREVIOUS_VERSION)"; \
 		echo "No need to release $(MODSET)."; \
 		exit 1; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -391,25 +391,31 @@ ifndef PREVIOUS_VERSION
 	@echo "PREVIOUS_VERSION not defined"
 	@echo "usage: make check-changes PREVIOUS_VERSION=<version eg 0.52.0> MODSET=beta"
 	exit 1
+else
+ifeq (, $(findstring v,$(PREVIOUS_VERSION)))
+NORMALIZED_PREVIOUS_VERSION="v$(PREVIOUS_VERSION)"
+else
+NORMALIZED_PREVIOUS_VERSION="$(PREVIOUS_VERSION)"
+endif
 endif
 	@all_submods=$$($(YQ) e '.module-sets.*.modules[] | select(. != "go.opentelemetry.io/collector")' versions.yaml | sed 's/^go\.opentelemetry\.io\/collector\///'); \
 	mods=$$($(YQ) e '.module-sets.$(MODSET).modules[]' versions.yaml | sed 's/^go\.opentelemetry\.io\/collector\///'); \
 	changed_files=""; \
 	for mod in $${mods}; do \
 		if [ "$${mod}" == "go.opentelemetry.io/collector" ]; then \
-			changed_files+=$$(git diff --name-only $(PREVIOUS_VERSION) -- $$(printf '%s\n' $${all_submods[@]} | sed 's/^/:!/' | paste -sd' ' -) | grep -E '.+\.go$$'); \
-		elif ! git rev-parse --quiet --verify $${mod}/$(PREVIOUS_VERSION) >/dev/null; then \
-			echo "Module $${mod} does not have a $(PREVIOUS_VERSION) tag"; \
+			changed_files+=$$(git diff --name-only $(NORMALIZED_PREVIOUS_VERSION) -- $$(printf '%s\n' $${all_submods[@]} | sed 's/^/:!/' | paste -sd' ' -) | grep -E '.+\.go$$'); \
+		elif ! git rev-parse --quiet --verify $${mod}/$(NORMALIZED_PREVIOUS_VERSION) >/dev/null; then \
+			echo "Module $${mod} does not have a $(NORMALIZED_PREVIOUS_VERSION) tag"; \
 			echo "$(MODSET) release is required."; \
 			exit 0; \
 		else \
-			changed_files+=$$(git diff --name-only $${mod}/$(PREVIOUS_VERSION) -- $${mod} | grep -E '.+\.go$$'); \
+			changed_files+=$$(git diff --name-only $${mod}/$(NORMALIZED_PREVIOUS_VERSION) -- $${mod} | grep -E '.+\.go$$'); \
 		fi; \
 	done; \
 	if [ -n "$${changed_files}" ]; then \
-		echo "The following files changed in $(MODSET) modules since $(PREVIOUS_VERSION): $${changed_files}"; \
+		echo "The following files changed in $(MODSET) modules since $(NORMALIZED_PREVIOUS_VERSION): $${changed_files}"; \
 	else \
-		echo "No $(MODSET) modules have changed since $(PREVIOUS_VERSION)"; \
+		echo "No $(MODSET) modules have changed since $(NORMALIZED_PREVIOUS_VERSION)"; \
 		echo "No need to release $(MODSET)."; \
 		exit 1; \
 	fi


### PR DESCRIPTION
Don't prefix the version number w/ a `v` as the docs already tell the release manager to do so, plus this way it's easier to copy/paste the version from the module set.
