### PR TITLE
Always pass fanout consumers to connector factory functions

### DIFF
--- a/.chloggen/always_fanout.yaml
+++ b/.chloggen/always_fanout.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'enhancement'
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: connector
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Updates the way connector nodes are built to always pass a fanoutconsumer to their factory functions.
+
+# One or more tracking issues or pull requests related to the change
+issues: [7672, 7673]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/service/internal/graph/nodes.go
+++ b/service/internal/graph/nodes.go
@@ -238,7 +238,7 @@ func (n *connectorNode) buildComponent(
 
 	switch n.rcvrPipelineType {
 	case component.DataTypeTraces:
-		capability := nexts[0].Capabilities()
+		capability := consumer.Capabilities{MutatesData: false}
 		consumers := make(map[component.ID]consumer.Traces, len(nexts))
 		for _, next := range nexts {
 			consumers[next.(*capabilitiesNode).pipelineID] = next.(consumer.Traces)
@@ -271,7 +271,7 @@ func (n *connectorNode) buildComponent(
 		}
 
 	case component.DataTypeMetrics:
-		capability := nexts[0].Capabilities()
+		capability := consumer.Capabilities{MutatesData: false}
 		consumers := make(map[component.ID]consumer.Metrics, len(nexts))
 		for _, next := range nexts {
 			consumers[next.(*capabilitiesNode).pipelineID] = next.(consumer.Metrics)
@@ -303,7 +303,7 @@ func (n *connectorNode) buildComponent(
 			n.Component, n.baseConsumer = conn, conn
 		}
 	case component.DataTypeLogs:
-		capability := nexts[0].Capabilities()
+		capability := consumer.Capabilities{MutatesData: false}
 		consumers := make(map[component.ID]consumer.Logs, len(nexts))
 		for _, next := range nexts {
 			consumers[next.(*capabilitiesNode).pipelineID] = next.(consumer.Logs)

--- a/service/internal/graph/nodes.go
+++ b/service/internal/graph/nodes.go
@@ -238,16 +238,13 @@ func (n *connectorNode) buildComponent(
 
 	switch n.rcvrPipelineType {
 	case component.DataTypeTraces:
-		next := nexts[0].(consumer.Traces)
 		capability := nexts[0].Capabilities()
-		if len(nexts) > 1 {
-			consumers := make(map[component.ID]consumer.Traces, len(nexts))
-			for _, next := range nexts {
-				consumers[next.(*capabilitiesNode).pipelineID] = next.(consumer.Traces)
-				capability.MutatesData = capability.MutatesData || next.Capabilities().MutatesData
-			}
-			next = fanoutconsumer.NewTracesRouter(consumers)
+		consumers := make(map[component.ID]consumer.Traces, len(nexts))
+		for _, next := range nexts {
+			consumers[next.(*capabilitiesNode).pipelineID] = next.(consumer.Traces)
+			capability.MutatesData = capability.MutatesData || next.Capabilities().MutatesData
 		}
+		next := fanoutconsumer.NewTracesRouter(consumers)
 
 		switch n.exprPipelineType {
 		case component.DataTypeTraces:
@@ -274,16 +271,14 @@ func (n *connectorNode) buildComponent(
 		}
 
 	case component.DataTypeMetrics:
-		next := nexts[0].(consumer.Metrics)
 		capability := nexts[0].Capabilities()
-		if len(nexts) > 1 {
-			consumers := make(map[component.ID]consumer.Metrics, len(nexts))
-			for _, next := range nexts {
-				consumers[next.(*capabilitiesNode).pipelineID] = next.(consumer.Metrics)
-				capability.MutatesData = capability.MutatesData || next.Capabilities().MutatesData
-			}
-			next = fanoutconsumer.NewMetricsRouter(consumers)
+		consumers := make(map[component.ID]consumer.Metrics, len(nexts))
+		for _, next := range nexts {
+			consumers[next.(*capabilitiesNode).pipelineID] = next.(consumer.Metrics)
+			capability.MutatesData = capability.MutatesData || next.Capabilities().MutatesData
 		}
+		next := fanoutconsumer.NewMetricsRouter(consumers)
+
 		switch n.exprPipelineType {
 		case component.DataTypeTraces:
 			conn, err := builder.CreateTracesToMetrics(ctx, set, next)
@@ -308,16 +303,14 @@ func (n *connectorNode) buildComponent(
 			n.Component, n.baseConsumer = conn, conn
 		}
 	case component.DataTypeLogs:
-		next := nexts[0].(consumer.Logs)
 		capability := nexts[0].Capabilities()
-		if len(nexts) > 1 {
-			consumers := make(map[component.ID]consumer.Logs, len(nexts))
-			for _, next := range nexts {
-				consumers[next.(*capabilitiesNode).pipelineID] = next.(consumer.Logs)
-				capability.MutatesData = capability.MutatesData || next.Capabilities().MutatesData
-			}
-			next = fanoutconsumer.NewLogsRouter(consumers)
+		consumers := make(map[component.ID]consumer.Logs, len(nexts))
+		for _, next := range nexts {
+			consumers[next.(*capabilitiesNode).pipelineID] = next.(consumer.Logs)
+			capability.MutatesData = capability.MutatesData || next.Capabilities().MutatesData
 		}
+		next := fanoutconsumer.NewLogsRouter(consumers)
+
 		switch n.exprPipelineType {
 		case component.DataTypeTraces:
 			conn, err := builder.CreateTracesToLogs(ctx, set, next)


### PR DESCRIPTION
**Description:**
This is an implementation of https://github.com/open-telemetry/opentelemetry-collector/pull/7673#issuecomment-1572126437 which resolves some inconsistencies regarding fanout consumers and connectors. It updates the connector code to always pass a fanout consumer to connector factory functions (even if the connector emits to a single pipeline). This will likely pair with the work in #7673 to add helpers to construct connector routers (when needed) for tests.

**Link to tracking Issue:** #7672, #7673

**Testing:**
Unit testing

cc: @bogdandrutu @djaglowski 