### PR TITLE
[chore] bump version of go to 1.19.10

### DIFF
--- a/.github/workflows/api-compatibility.yml
+++ b/.github/workflows/api-compatibility.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: ~1.19.9
+          go-version: ~1.19.10
       
       # Generate apidiff states of Main
       - name: Generate-States

--- a/.github/workflows/build-and-test-windows.yaml
+++ b/.github/workflows/build-and-test-windows.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: ~1.19.9
+          go-version: ~1.19.10
       - name: Cache Go
         uses: actions/cache@v3
         env:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: ~1.19.9
+          go-version: ~1.19.10
       - name: Cache Go
         id: go-cache
         uses: actions/cache@v3
@@ -41,7 +41,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: ~1.19.9
+          go-version: ~1.19.10
       - name: Cache Go
         id: go-cache
         uses: actions/cache@v3
@@ -64,7 +64,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: ~1.19.9
+          go-version: ~1.19.10
       - name: Cache Go
         id: go-cache
         uses: actions/cache@v3
@@ -88,7 +88,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: ~1.19.9
+          go-version: ~1.19.10
       - name: Cache Go
         id: go-cache
         uses: actions/cache@v3
@@ -168,7 +168,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: ~1.19.9
+          go-version: ~1.19.10
       - name: Cache Go
         id: go-cache
         uses: actions/cache@v3
@@ -228,7 +228,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: ~1.19.9
+          go-version: ~1.19.10
       - name: Cache Go
         id: go-cache
         uses: actions/cache@v3

--- a/.github/workflows/builder-integration-test.yaml
+++ b/.github/workflows/builder-integration-test.yaml
@@ -30,6 +30,6 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: ~1.19.9
+          go-version: ~1.19.10
       - name: Test
         run: cd ./cmd/builder && ./test/test.sh

--- a/.github/workflows/builder-release.yaml
+++ b/.github/workflows/builder-release.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: ~1.19.9
+          go-version: ~1.19.10
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4
         with:

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: ~1.19.9
+          go-version: ~1.19.10
       - name: Cache Go
         id: go-cache
         uses: actions/cache@v3

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: ~1.19.9
+          go-version: ~1.19.10
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/contrib-tests.yml
+++ b/.github/workflows/contrib-tests.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: ~1.19.9
+          go-version: ~1.19.10
       - name: Run Contrib Tests
         run: |
           contrib_path=/tmp/opentelemetry-collector-contrib

--- a/.github/workflows/create-dependabot-pr.yml
+++ b/.github/workflows/create-dependabot-pr.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: ~1.19.9
+          go-version: ~1.19.10
       - name: Run dependabot-pr.sh
         run: ./.github/workflows/scripts/dependabot-pr.sh
         env:

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: ~1.19.9
+          go-version: ~1.19.10
       # Prepare Core for release.
       #   - Update CHANGELOG.md file, this is done via chloggen
       #   - Run make prepare-release PREVIOUS_VERSION=1.0.0 RELEASE_CANDIDATE=1.1.0 MODSET=stable

--- a/cmd/builder/internal/builder/main_test.go
+++ b/cmd/builder/internal/builder/main_test.go
@@ -79,7 +79,7 @@ func TestGenerateAndCompile(t *testing.T) {
 				cfg := NewDefaultConfig()
 				cfg.Distribution.OutputPath = t.TempDir()
 				cfg.Replaces = append(cfg.Replaces, replaces...)
-				cfg.LDFlags = `-X "test.gitVersion=0743dc6c6411272b98494a9b32a63378e84c34da" -X "test.gitTag=local-testing" -X "test.goVersion=go version go1.19.9 darwin/amd64"`
+				cfg.LDFlags = `-X "test.gitVersion=0743dc6c6411272b98494a9b32a63378e84c34da" -X "test.gitTag=local-testing" -X "test.goVersion=go version go1.19.10 darwin/amd64"`
 				return cfg
 			},
 		},


### PR DESCRIPTION
This is to address https://pkg.go.dev/vuln/GO-2023-1840
