### PR TITLE
[fanoutconsumer] Mark fanout consumer error as permanent

### DIFF
--- a/.chloggen/fanoutconsumer-permanenterror.yaml
+++ b/.chloggen/fanoutconsumer-permanenterror.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'enhancement'
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: fanoutconsumer
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: The fanoutconsumer now returns a permanent error if at least one consumer succeeded and one failed.
+
+# One or more tracking issues or pull requests related to the change
+issues: [7868]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:


### PR DESCRIPTION
Based on discussions from the SIG's call, I changed one of the fanout consumers to mark the returned error as permanent if at least one consumer succeeded and one failed, as we don't want retries to be performed on those situations.

Once this is done, #7486 will be changed to return a 500 in case the error it receives is a permanent error.

Signed-off-by: Juraci Paixão Kröhling juraci@kroehling.de