### PR TITLE
[ci] Specify 7 as arm version for arm build in CI

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -217,6 +217,7 @@ jobs:
             goarch: ppc64le
           - goos: linux
             goarch: arm
+            goarm: 7
           - goos: windows
             goarch: 386
           - goos: windows
@@ -241,5 +242,6 @@ jobs:
         env:
           GOOS: ${{matrix.goos}}
           GOARCH: ${{matrix.goarch}}
+          GOARM: ${{matrix.goarm}}
         run: |
           make otelcorecol


### PR DESCRIPTION
**Description:**

Previously, we [introduced linux/arm to the cross build tests](https://github.com/open-telemetry/opentelemetry-collector/pull/5472) in the CI to add an armv7 release. 

However, without specifying the `GOARM` variable, it falls back to the default value. The default value is not always `7` as it depends on the platform that we are building on. [There are changes to default to GOARM=7 for all non-arm systems in the upcoming golang version](https://go-review.googlesource.com/c/go/+/470695)

We are building on `linux/amd64` machine in github action so `GOARM` defaults to `5` which is different from what we want. 

In this pull request, I added `GOARM` as an environment variable and `goarm` in the arm matrix option so we can explicit set `GOARM=7`. 


**Testing:** 

Able to run `make otelcoreol` with the following configurations locally

- [x] `GOOS=linux`, `GOARCH=arm`, `GOARM=7`
- [x] `GOOS=linux`, `GOARCH=arm64`, `GOARM=` 
- [x] `GOOS=darwin`, `GOARCH=amd64`, `GOARM=`
