### PR TITLE
[exporterhelper] New exporter helper for custom requests

### DIFF
--- a/.chloggen/exporter-helper-v2.yaml
+++ b/.chloggen/exporter-helper-v2.yaml
@@ -1,0 +1,12 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: exporter/exporterhelper
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Introduce a new exporter helper that operates over client-provided requests instead of pdata
+
+# One or more tracking issues or pull requests related to the change
+issues: [7874]
+

--- a/exporter/exporterhelper/common_test.go
+++ b/exporter/exporterhelper/common_test.go
@@ -32,7 +32,11 @@ var (
 )
 
 func TestBaseExporter(t *testing.T) {
-	be, err := newBaseExporter(defaultSettings, fromOptions(), "")
+	be, err := newBaseExporter(defaultSettings, newBaseSettings(false), "")
+	require.NoError(t, err)
+	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
+	require.NoError(t, be.Shutdown(context.Background()))
+	be, err = newBaseExporter(defaultSettings, newBaseSettings(true), "")
 	require.NoError(t, err)
 	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
 	require.NoError(t, be.Shutdown(context.Background()))
@@ -42,7 +46,8 @@ func TestBaseExporterWithOptions(t *testing.T) {
 	want := errors.New("my error")
 	be, err := newBaseExporter(
 		defaultSettings,
-		fromOptions(
+		newBaseSettings(
+			false,
 			WithStart(func(ctx context.Context, host component.Host) error { return want }),
 			WithShutdown(func(ctx context.Context) error { return want }),
 			WithTimeout(NewDefaultTimeoutSettings())),

--- a/exporter/exporterhelper/common_test.go
+++ b/exporter/exporterhelper/common_test.go
@@ -14,11 +14,8 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
-	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/exporter"
-	"go.opentelemetry.io/collector/exporter/exporterhelper/internal"
 	"go.opentelemetry.io/collector/exporter/exportertest"
-	"go.opentelemetry.io/collector/pdata/ptrace"
 )
 
 var (
@@ -35,7 +32,7 @@ var (
 )
 
 func TestBaseExporter(t *testing.T) {
-	be, err := newBaseExporter(defaultSettings, fromOptions(), "", nopRequestUnmarshaler())
+	be, err := newBaseExporter(defaultSettings, fromOptions(), "")
 	require.NoError(t, err)
 	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
 	require.NoError(t, be.Shutdown(context.Background()))
@@ -50,7 +47,6 @@ func TestBaseExporterWithOptions(t *testing.T) {
 			WithShutdown(func(ctx context.Context) error { return want }),
 			WithTimeout(NewDefaultTimeoutSettings())),
 		"",
-		nopRequestUnmarshaler(),
 	)
 	require.NoError(t, err)
 	require.Equal(t, want, be.Start(context.Background(), componenttest.NewNopHost()))
@@ -64,14 +60,4 @@ func checkStatus(t *testing.T, sd sdktrace.ReadOnlySpan, err error) {
 	} else {
 		require.Equal(t, codes.Unset, sd.Status().Code, "SpanData %v", sd)
 	}
-}
-
-func nopTracePusher() consumer.ConsumeTracesFunc {
-	return func(ctx context.Context, ld ptrace.Traces) error {
-		return nil
-	}
-}
-
-func nopRequestUnmarshaler() internal.RequestUnmarshaler {
-	return newTraceRequestUnmarshalerFunc(nopTracePusher())
 }

--- a/exporter/exporterhelper/constants.go
+++ b/exporter/exporterhelper/constants.go
@@ -18,4 +18,12 @@ var (
 	errNilPushMetricsData = errors.New("nil PushMetrics")
 	// errNilPushLogsData is returned when a nil PushLogs is given.
 	errNilPushLogsData = errors.New("nil PushLogs")
+	// errNilTracesConverter is returned when a nil TracesConverter is given.
+	errNilTracesConverter = errors.New("nil TracesConverter")
+	// errNilMetricsConverter is returned when a nil MetricsConverter is given.
+	errNilMetricsConverter = errors.New("nil MetricsConverter")
+	// errNilLogsConverter is returned when a nil LogsConverter is given.
+	errNilLogsConverter = errors.New("nil LogsConverter")
+	// errNilRequestSender is returned when a nil RequestSender is given.
+	errNilRequestSender = errors.New("nil RequestSender")
 )

--- a/exporter/exporterhelper/internal/persistent_queue.go
+++ b/exporter/exporterhelper/internal/persistent_queue.go
@@ -35,11 +35,21 @@ func buildPersistentStorageName(name string, signal component.DataType) string {
 	return fmt.Sprintf("%s-%s", name, signal)
 }
 
+type PersistentQueueSettings struct {
+	Name        string
+	Signal      component.DataType
+	Capacity    uint64
+	Logger      *zap.Logger
+	Client      storage.Client
+	Unmarshaler RequestUnmarshaler
+	Marshaler   RequestMarshaler
+}
+
 // NewPersistentQueue creates a new queue backed by file storage; name and signal must be a unique combination that identifies the queue storage
-func NewPersistentQueue(ctx context.Context, name string, signal component.DataType, capacity int, logger *zap.Logger, client storage.Client, unmarshaler RequestUnmarshaler) ProducerConsumerQueue {
+func NewPersistentQueue(ctx context.Context, params PersistentQueueSettings) ProducerConsumerQueue {
 	return &persistentQueue{
 		stopChan: make(chan struct{}),
-		storage:  newPersistentContiguousStorage(ctx, buildPersistentStorageName(name, signal), uint64(capacity), logger, client, unmarshaler),
+		storage:  newPersistentContiguousStorage(ctx, buildPersistentStorageName(params.Name, params.Signal), params),
 	}
 }
 

--- a/exporter/exporterhelper/internal/persistent_queue_test.go
+++ b/exporter/exporterhelper/internal/persistent_queue_test.go
@@ -28,7 +28,15 @@ func createTestQueue(extension storage.Extension, capacity int) *persistentQueue
 		panic(err)
 	}
 
-	wq := NewPersistentQueue(context.Background(), "foo", component.DataTypeTraces, capacity, logger, client, newFakeTracesRequestUnmarshalerFunc())
+	wq := NewPersistentQueue(context.Background(), PersistentQueueSettings{
+		Name:        "foo",
+		Signal:      component.DataTypeTraces,
+		Capacity:    uint64(capacity),
+		Logger:      logger,
+		Client:      client,
+		Unmarshaler: newFakeTracesRequestUnmarshalerFunc(),
+		Marshaler:   newFakeTracesRequestMarshalerFunc(),
+	})
 	return wq.(*persistentQueue)
 }
 

--- a/exporter/exporterhelper/internal/persistent_storage.go
+++ b/exporter/exporterhelper/internal/persistent_storage.go
@@ -43,6 +43,7 @@ type persistentContiguousStorage struct {
 	queueName   string
 	client      storage.Client
 	unmarshaler RequestUnmarshaler
+	marshaler   RequestMarshaler
 
 	putChan  chan struct{}
 	stopChan chan struct{}
@@ -80,14 +81,15 @@ var (
 
 // newPersistentContiguousStorage creates a new file-storage extension backed queue;
 // queueName parameter must be a unique value that identifies the queue.
-func newPersistentContiguousStorage(ctx context.Context, queueName string, capacity uint64, logger *zap.Logger, client storage.Client, unmarshaler RequestUnmarshaler) *persistentContiguousStorage {
+func newPersistentContiguousStorage(ctx context.Context, queueName string, set PersistentQueueSettings) *persistentContiguousStorage {
 	pcs := &persistentContiguousStorage{
-		logger:      logger,
-		client:      client,
+		logger:      set.Logger,
+		client:      set.Client,
 		queueName:   queueName,
-		unmarshaler: unmarshaler,
-		capacity:    capacity,
-		putChan:     make(chan struct{}, capacity),
+		unmarshaler: set.Unmarshaler,
+		marshaler:   set.Marshaler,
+		capacity:    set.Capacity,
+		putChan:     make(chan struct{}, set.Capacity),
 		reqChan:     make(chan Request),
 		stopChan:    make(chan struct{}),
 		itemsCount:  &atomic.Uint64{},

--- a/exporter/exporterhelper/internal/persistent_storage_batch.go
+++ b/exporter/exporterhelper/internal/persistent_storage_batch.go
@@ -137,7 +137,7 @@ func (bof *batchStruct) getItemIndexArrayResult(key string) ([]itemIndex, error)
 
 // setRequest adds Set operation over a given request to the batch
 func (bof *batchStruct) setRequest(key string, value Request) *batchStruct {
-	return bof.set(key, value, requestToBytes)
+	return bof.set(key, value, bof.requestToBytes)
 }
 
 // setItemIndex adds Set operation over a given itemIndex to the batch
@@ -206,8 +206,8 @@ func bytesToItemIndexArray(b []byte) (any, error) {
 	return val, err
 }
 
-func requestToBytes(req any) ([]byte, error) {
-	return req.(Request).Marshal()
+func (bof *batchStruct) requestToBytes(req any) ([]byte, error) {
+	return bof.pcs.marshaler(req.(Request))
 }
 
 func (bof *batchStruct) bytesToRequest(b []byte) (any, error) {

--- a/exporter/exporterhelper/internal/request.go
+++ b/exporter/exporterhelper/internal/request.go
@@ -19,11 +19,8 @@ type Request interface {
 	// Otherwise, it should return the original Request.
 	OnError(error) Request
 
-	// Count returns the count of spans/metric points or log records.
-	Count() int
-
-	// Marshal serializes the current request into a byte stream
-	Marshal() ([]byte, error)
+	// ItemsCount returns the number of basic items in the request (spans, date points or log records for OTLP)
+	ItemsCount() int
 
 	// OnProcessingFinished calls the optional callback function to handle cleanup after all processing is finished
 	OnProcessingFinished()
@@ -34,3 +31,6 @@ type Request interface {
 
 // RequestUnmarshaler defines a function which takes a byte slice and unmarshals it into a relevant request
 type RequestUnmarshaler func([]byte) (Request, error)
+
+// RequestMarshaler defines a function which takes a request and marshals it into a byte slice
+type RequestMarshaler func(Request) ([]byte, error)

--- a/exporter/exporterhelper/logs.go
+++ b/exporter/exporterhelper/logs.go
@@ -93,7 +93,7 @@ func NewLogsExporter(
 		return nil, errNilPushLogsData
 	}
 
-	bs := fromOptions(options...)
+	bs := newBaseSettings(false, options...)
 	bs.marshaler = logsRequestMarshaler
 	bs.unmarshaler = newLogsRequestUnmarshalerFunc(pusher)
 	be, err := newBaseExporter(set, bs, component.DataTypeLogs)
@@ -127,8 +127,8 @@ type LogsConverter interface {
 	RequestFromLogs(context.Context, plog.Logs) (Request, error)
 }
 
-// NewLogsExporterV2 creates new logs exporter based on custom LogsConverter and RequestSender.
-func NewLogsExporterV2(
+// NewLogsRequestExporter creates new logs exporter based on custom LogsConverter and RequestSender.
+func NewLogsRequestExporter(
 	_ context.Context,
 	set exporter.CreateSettings,
 	converter LogsConverter,
@@ -147,7 +147,7 @@ func NewLogsExporterV2(
 		return nil, errNilRequestSender
 	}
 
-	bs := fromOptions(options...)
+	bs := newBaseSettings(true, options...)
 	bs.RequestSender = sender
 
 	be, err := newBaseExporter(set, bs, component.DataTypeLogs)

--- a/exporter/exporterhelper/logs.go
+++ b/exporter/exporterhelper/logs.go
@@ -60,10 +60,6 @@ func (req *logsRequest) Export(ctx context.Context) error {
 	return req.pusher(ctx, req.ld)
 }
 
-func (req *logsRequest) Marshal() ([]byte, error) {
-	return logsMarshaler.MarshalLogs(req.ld)
-}
-
 func (req *logsRequest) ItemsCount() int {
 	return req.ld.LogRecordCount()
 }

--- a/exporter/exporterhelper/metrics.go
+++ b/exporter/exporterhelper/metrics.go
@@ -60,11 +60,6 @@ func (req *metricsRequest) Export(ctx context.Context) error {
 	return req.pusher(ctx, req.md)
 }
 
-// Marshal provides serialization capabilities required by persistent queue
-func (req *metricsRequest) Marshal() ([]byte, error) {
-	return metricsMarshaler.MarshalMetrics(req.md)
-}
-
 func (req *metricsRequest) ItemsCount() int {
 	return req.md.DataPointCount()
 }

--- a/exporter/exporterhelper/metrics.go
+++ b/exporter/exporterhelper/metrics.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"errors"
 
+	"go.uber.org/zap"
+
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumererror"
@@ -42,6 +44,10 @@ func newMetricsRequestUnmarshalerFunc(pusher consumer.ConsumeMetricsFunc) intern
 	}
 }
 
+func metricsRequestMarshaler(req internal.Request) ([]byte, error) {
+	return metricsMarshaler.MarshalMetrics(req.(*metricsRequest).md)
+}
+
 func (req *metricsRequest) OnError(err error) internal.Request {
 	var metricsError consumererror.Metrics
 	if errors.As(err, &metricsError) {
@@ -59,7 +65,7 @@ func (req *metricsRequest) Marshal() ([]byte, error) {
 	return metricsMarshaler.MarshalMetrics(req.md)
 }
 
-func (req *metricsRequest) Count() int {
+func (req *metricsRequest) ItemsCount() int {
 	return req.md.DataPointCount()
 }
 
@@ -89,7 +95,9 @@ func NewMetricsExporter(
 	}
 
 	bs := fromOptions(options...)
-	be, err := newBaseExporter(set, bs, component.DataTypeMetrics, newMetricsRequestUnmarshalerFunc(pusher))
+	bs.marshaler = metricsRequestMarshaler
+	bs.unmarshaler = newMetricsRequestUnmarshalerFunc(pusher)
+	be, err := newBaseExporter(set, bs, component.DataTypeMetrics)
 	if err != nil {
 		return nil, err
 	}
@@ -104,9 +112,73 @@ func NewMetricsExporter(
 		req := newMetricsRequest(ctx, md, pusher)
 		serr := be.sender.send(req)
 		if errors.Is(serr, errSendingQueueIsFull) {
-			be.obsrep.recordMetricsEnqueueFailure(req.Context(), int64(req.Count()))
+			be.obsrep.recordMetricsEnqueueFailure(req.Context(), int64(req.ItemsCount()))
 		}
 		return serr
+	}, bs.consumerOptions...)
+
+	return &metricsExporter{
+		baseExporter: be,
+		Metrics:      mc,
+	}, err
+}
+
+type MetricsConverter interface {
+	// RequestFromMetrics converts pdata.Metrics into a request.
+	RequestFromMetrics(context.Context, pmetric.Metrics) (Request, error)
+}
+
+// NewMetricsExporterV2 creates a new metrics exporter based on a custom TracesConverter and RequestSender.
+func NewMetricsExporterV2(
+	_ context.Context,
+	set exporter.CreateSettings,
+	converter MetricsConverter,
+	sender RequestSender,
+	options ...Option,
+) (exporter.Metrics, error) {
+	if set.Logger == nil {
+		return nil, errNilLogger
+	}
+
+	if converter == nil {
+		return nil, errNilMetricsConverter
+	}
+
+	if sender == nil {
+		return nil, errNilRequestSender
+	}
+
+	bs := fromOptions(options...)
+	bs.RequestSender = sender
+
+	be, err := newBaseExporter(set, bs, component.DataTypeMetrics)
+	if err != nil {
+		return nil, err
+	}
+	be.wrapConsumerSender(func(nextSender requestSender) requestSender {
+		return &metricsSenderWithObservability{
+			obsrep:     be.obsrep,
+			nextSender: nextSender,
+		}
+	})
+
+	mc, err := consumer.NewMetrics(func(ctx context.Context, md pmetric.Metrics) error {
+		req, cErr := converter.RequestFromMetrics(ctx, md)
+		if cErr != nil {
+			set.Logger.Error("Failed to convert metrics. Dropping data.",
+				zap.Int("dropped_data_points", md.DataPointCount()),
+				zap.Error(err))
+			return consumererror.NewPermanent(cErr)
+		}
+		sErr := be.sender.send(&request{
+			Request:     req,
+			baseRequest: baseRequest{ctx: ctx},
+			sender:      sender,
+		})
+		if errors.Is(sErr, errSendingQueueIsFull) {
+			be.obsrep.recordMetricsEnqueueFailure(ctx, int64(req.ItemsCount()))
+		}
+		return sErr
 	}, bs.consumerOptions...)
 
 	return &metricsExporter{
@@ -123,6 +195,6 @@ type metricsSenderWithObservability struct {
 func (mewo *metricsSenderWithObservability) send(req internal.Request) error {
 	req.SetContext(mewo.obsrep.StartMetricsOp(req.Context()))
 	err := mewo.nextSender.send(req)
-	mewo.obsrep.EndMetricsOp(req.Context(), req.Count(), err)
+	mewo.obsrep.EndMetricsOp(req.Context(), req.ItemsCount(), err)
 	return err
 }

--- a/exporter/exporterhelper/metrics.go
+++ b/exporter/exporterhelper/metrics.go
@@ -94,7 +94,7 @@ func NewMetricsExporter(
 		return nil, errNilPushMetricsData
 	}
 
-	bs := fromOptions(options...)
+	bs := newBaseSettings(false, options...)
 	bs.marshaler = metricsRequestMarshaler
 	bs.unmarshaler = newMetricsRequestUnmarshalerFunc(pusher)
 	be, err := newBaseExporter(set, bs, component.DataTypeMetrics)
@@ -128,8 +128,8 @@ type MetricsConverter interface {
 	RequestFromMetrics(context.Context, pmetric.Metrics) (Request, error)
 }
 
-// NewMetricsExporterV2 creates a new metrics exporter based on a custom TracesConverter and RequestSender.
-func NewMetricsExporterV2(
+// NewMetricsRequestExporter creates a new metrics exporter based on a custom TracesConverter and RequestSender.
+func NewMetricsRequestExporter(
 	_ context.Context,
 	set exporter.CreateSettings,
 	converter MetricsConverter,
@@ -148,7 +148,7 @@ func NewMetricsExporterV2(
 		return nil, errNilRequestSender
 	}
 
-	bs := fromOptions(options...)
+	bs := newBaseSettings(true, options...)
 	bs.RequestSender = sender
 
 	be, err := newBaseExporter(set, bs, component.DataTypeMetrics)

--- a/exporter/exporterhelper/queued_retry.go
+++ b/exporter/exporterhelper/queued_retry.go
@@ -70,33 +70,32 @@ func (qCfg *QueueSettings) Validate() error {
 }
 
 type queuedRetrySender struct {
-	fullName           string
-	id                 component.ID
-	signal             component.DataType
-	cfg                QueueSettings
-	consumerSender     requestSender
-	queue              internal.ProducerConsumerQueue
-	retryStopCh        chan struct{}
-	traceAttribute     attribute.KeyValue
-	logger             *zap.Logger
-	requeuingEnabled   bool
-	requestUnmarshaler internal.RequestUnmarshaler
+	fullName         string
+	id               component.ID
+	signal           component.DataType
+	queueSettings    queueSettings
+	consumerSender   requestSender
+	queue            internal.ProducerConsumerQueue
+	retryStopCh      chan struct{}
+	traceAttribute   attribute.KeyValue
+	logger           *zap.Logger
+	requeuingEnabled bool
 }
 
-func newQueuedRetrySender(id component.ID, signal component.DataType, qCfg QueueSettings, rCfg RetrySettings, reqUnmarshaler internal.RequestUnmarshaler, nextSender requestSender, logger *zap.Logger) *queuedRetrySender {
+func newQueuedRetrySender(id component.ID, signal component.DataType, qs queueSettings, rCfg RetrySettings,
+	nextSender requestSender, logger *zap.Logger) *queuedRetrySender {
 	retryStopCh := make(chan struct{})
 	sampledLogger := createSampledLogger(logger)
 	traceAttr := attribute.String(obsmetrics.ExporterKey, id.String())
 
 	qrs := &queuedRetrySender{
-		fullName:           id.String(),
-		id:                 id,
-		signal:             signal,
-		cfg:                qCfg,
-		retryStopCh:        retryStopCh,
-		traceAttribute:     traceAttr,
-		logger:             sampledLogger,
-		requestUnmarshaler: reqUnmarshaler,
+		fullName:       id.String(),
+		id:             id,
+		signal:         signal,
+		queueSettings:  qs,
+		retryStopCh:    retryStopCh,
+		traceAttribute: traceAttr,
+		logger:         sampledLogger,
 	}
 
 	qrs.consumerSender = &retrySender{
@@ -109,8 +108,8 @@ func newQueuedRetrySender(id component.ID, signal component.DataType, qCfg Queue
 		onTemporaryFailure: qrs.onTemporaryFailure,
 	}
 
-	if qCfg.StorageID == nil {
-		qrs.queue = internal.NewBoundedMemoryQueue(qrs.cfg.QueueSize)
+	if !qs.persistenceEnabled() {
+		qrs.queue = internal.NewBoundedMemoryQueue(qs.config.QueueSize)
 	}
 	// The Persistent Queue is initialized separately as it needs extra information about the component
 
@@ -143,16 +142,24 @@ func toStorageClient(ctx context.Context, storageID component.ID, host component
 
 // initializePersistentQueue uses extra information for initialization available from component.Host
 func (qrs *queuedRetrySender) initializePersistentQueue(ctx context.Context, host component.Host) error {
-	if qrs.cfg.StorageID == nil {
+	if !qrs.queueSettings.persistenceEnabled() {
 		return nil
 	}
 
-	storageClient, err := toStorageClient(ctx, *qrs.cfg.StorageID, host, qrs.id, qrs.signal)
+	storageClient, err := toStorageClient(ctx, *qrs.queueSettings.config.StorageID, host, qrs.id, qrs.signal)
 	if err != nil {
 		return err
 	}
 
-	qrs.queue = internal.NewPersistentQueue(ctx, qrs.fullName, qrs.signal, qrs.cfg.QueueSize, qrs.logger, storageClient, qrs.requestUnmarshaler)
+	qrs.queue = internal.NewPersistentQueue(ctx, internal.PersistentQueueSettings{
+		Name:        qrs.fullName,
+		Signal:      qrs.signal,
+		Capacity:    uint64(qrs.queueSettings.config.QueueSize),
+		Logger:      qrs.logger,
+		Client:      storageClient,
+		Marshaler:   qrs.queueSettings.marshaler,
+		Unmarshaler: qrs.queueSettings.unmarshaler,
+	})
 
 	// TODO: this can be further exposed as a config param rather than relying on a type of queue
 	qrs.requeuingEnabled = true
@@ -165,7 +172,7 @@ func (qrs *queuedRetrySender) onTemporaryFailure(logger *zap.Logger, req interna
 		logger.Error(
 			"Exporting failed. No more retries left. Dropping data.",
 			zap.Error(err),
-			zap.Int("dropped_items", req.Count()),
+			zap.Int("dropped_items", req.ItemsCount()),
 		)
 		return err
 	}
@@ -179,7 +186,7 @@ func (qrs *queuedRetrySender) onTemporaryFailure(logger *zap.Logger, req interna
 		logger.Error(
 			"Exporting failed. Queue did not accept requeuing request. Dropping data.",
 			zap.Error(err),
-			zap.Int("dropped_items", req.Count()),
+			zap.Int("dropped_items", req.ItemsCount()),
 		)
 	}
 	return err
@@ -191,13 +198,13 @@ func (qrs *queuedRetrySender) start(ctx context.Context, host component.Host) er
 		return err
 	}
 
-	qrs.queue.StartConsumers(qrs.cfg.NumConsumers, func(item internal.Request) {
+	qrs.queue.StartConsumers(qrs.queueSettings.config.NumConsumers, func(item internal.Request) {
 		_ = qrs.consumerSender.send(item)
 		item.OnProcessingFinished()
 	})
 
 	// Start reporting queue length metric
-	if qrs.cfg.Enabled {
+	if qrs.queueSettings.config.Enabled {
 		err := globalInstruments.queueSize.UpsertEntry(func() int64 {
 			return int64(qrs.queue.Size())
 		}, metricdata.NewLabelValue(qrs.fullName))
@@ -205,7 +212,7 @@ func (qrs *queuedRetrySender) start(ctx context.Context, host component.Host) er
 			return fmt.Errorf("failed to create retry queue size metric: %w", err)
 		}
 		err = globalInstruments.queueCapacity.UpsertEntry(func() int64 {
-			return int64(qrs.cfg.QueueSize)
+			return int64(qrs.queueSettings.config.QueueSize)
 		}, metricdata.NewLabelValue(qrs.fullName))
 		if err != nil {
 			return fmt.Errorf("failed to create retry queue capacity metric: %w", err)
@@ -218,7 +225,7 @@ func (qrs *queuedRetrySender) start(ctx context.Context, host component.Host) er
 // shutdown is invoked during service shutdown.
 func (qrs *queuedRetrySender) shutdown() {
 	// Cleanup queue metrics reporting
-	if qrs.cfg.Enabled {
+	if qrs.queueSettings.config.Enabled {
 		_ = globalInstruments.queueSize.UpsertEntry(func() int64 {
 			return int64(0)
 		}, metricdata.NewLabelValue(qrs.fullName))
@@ -287,12 +294,12 @@ func createSampledLogger(logger *zap.Logger) *zap.Logger {
 
 // send implements the requestSender interface
 func (qrs *queuedRetrySender) send(req internal.Request) error {
-	if !qrs.cfg.Enabled {
+	if !qrs.queueSettings.config.Enabled {
 		err := qrs.consumerSender.send(req)
 		if err != nil {
 			qrs.logger.Error(
 				"Exporting failed. Dropping data. Try enabling sending_queue to survive temporary failures.",
-				zap.Int("dropped_items", req.Count()),
+				zap.Int("dropped_items", req.ItemsCount()),
 			)
 		}
 		return err
@@ -306,7 +313,7 @@ func (qrs *queuedRetrySender) send(req internal.Request) error {
 	if !qrs.queue.Produce(req) {
 		qrs.logger.Error(
 			"Dropping data because sending_queue is full. Try increasing queue_size.",
-			zap.Int("dropped_items", req.Count()),
+			zap.Int("dropped_items", req.ItemsCount()),
 		)
 		span.AddEvent("Dropped item, sending_queue is full.", trace.WithAttributes(qrs.traceAttribute))
 		return errSendingQueueIsFull
@@ -391,7 +398,7 @@ func (rs *retrySender) send(req internal.Request) error {
 			rs.logger.Error(
 				"Exporting failed. The error is not retryable. Dropping data.",
 				zap.Error(err),
-				zap.Int("dropped_items", req.Count()),
+				zap.Int("dropped_items", req.ItemsCount()),
 			)
 			return err
 		}

--- a/exporter/exporterhelper/queued_retry_test.go
+++ b/exporter/exporterhelper/queued_retry_test.go
@@ -36,11 +36,18 @@ func mockRequestUnmarshaler(mr *mockRequest) internal.RequestUnmarshaler {
 	}
 }
 
+func mockRequestMarshaler(_ internal.Request) ([]byte, error) {
+	return nil, nil
+}
+
 func TestQueuedRetry_DropOnPermanentError(t *testing.T) {
 	qCfg := NewDefaultQueueSettings()
 	rCfg := NewDefaultRetrySettings()
 	mockR := newMockRequest(context.Background(), 2, consumererror.NewPermanent(errors.New("bad data")))
-	be, err := newBaseExporter(defaultSettings, fromOptions(WithRetry(rCfg), WithQueue(qCfg)), "", mockRequestUnmarshaler(mockR))
+	bs := fromOptions(WithRetry(rCfg), WithQueue(qCfg))
+	bs.marshaler = mockRequestMarshaler
+	bs.unmarshaler = mockRequestUnmarshaler(mockR)
+	be, err := newBaseExporter(defaultSettings, bs, "")
 	require.NoError(t, err)
 	ocs := newObservabilityConsumerSender(be.qrSender.consumerSender)
 	be.qrSender.consumerSender = ocs
@@ -64,7 +71,10 @@ func TestQueuedRetry_DropOnNoRetry(t *testing.T) {
 	qCfg := NewDefaultQueueSettings()
 	rCfg := NewDefaultRetrySettings()
 	rCfg.Enabled = false
-	be, err := newBaseExporter(defaultSettings, fromOptions(WithRetry(rCfg), WithQueue(qCfg)), "", nopRequestUnmarshaler())
+	bs := fromOptions(WithRetry(rCfg), WithQueue(qCfg))
+	bs.marshaler = mockRequestMarshaler
+	bs.unmarshaler = mockRequestUnmarshaler(newMockRequest(context.Background(), 2, errors.New("transient error")))
+	be, err := newBaseExporter(defaultSettings, bs, "")
 	require.NoError(t, err)
 	ocs := newObservabilityConsumerSender(be.qrSender.consumerSender)
 	be.qrSender.consumerSender = ocs
@@ -90,7 +100,7 @@ func TestQueuedRetry_OnError(t *testing.T) {
 	qCfg.NumConsumers = 1
 	rCfg := NewDefaultRetrySettings()
 	rCfg.InitialInterval = 0
-	be, err := newBaseExporter(defaultSettings, fromOptions(WithRetry(rCfg), WithQueue(qCfg)), "", nopRequestUnmarshaler())
+	be, err := newBaseExporter(defaultSettings, fromOptions(WithRetry(rCfg), WithQueue(qCfg)), "")
 	require.NoError(t, err)
 	ocs := newObservabilityConsumerSender(be.qrSender.consumerSender)
 	be.qrSender.consumerSender = ocs
@@ -117,7 +127,7 @@ func TestQueuedRetry_StopWhileWaiting(t *testing.T) {
 	qCfg := NewDefaultQueueSettings()
 	qCfg.NumConsumers = 1
 	rCfg := NewDefaultRetrySettings()
-	be, err := newBaseExporter(defaultSettings, fromOptions(WithRetry(rCfg), WithQueue(qCfg)), "", nopRequestUnmarshaler())
+	be, err := newBaseExporter(defaultSettings, fromOptions(WithRetry(rCfg), WithQueue(qCfg)), "")
 	require.NoError(t, err)
 	ocs := newObservabilityConsumerSender(be.qrSender.consumerSender)
 	be.qrSender.consumerSender = ocs
@@ -151,7 +161,7 @@ func TestQueuedRetry_DoNotPreserveCancellation(t *testing.T) {
 	qCfg := NewDefaultQueueSettings()
 	qCfg.NumConsumers = 1
 	rCfg := NewDefaultRetrySettings()
-	be, err := newBaseExporter(defaultSettings, fromOptions(WithRetry(rCfg), WithQueue(qCfg)), "", nopRequestUnmarshaler())
+	be, err := newBaseExporter(defaultSettings, fromOptions(WithRetry(rCfg), WithQueue(qCfg)), "")
 	require.NoError(t, err)
 	ocs := newObservabilityConsumerSender(be.qrSender.consumerSender)
 	be.qrSender.consumerSender = ocs
@@ -181,7 +191,7 @@ func TestQueuedRetry_MaxElapsedTime(t *testing.T) {
 	rCfg := NewDefaultRetrySettings()
 	rCfg.InitialInterval = time.Millisecond
 	rCfg.MaxElapsedTime = 100 * time.Millisecond
-	be, err := newBaseExporter(defaultSettings, fromOptions(WithRetry(rCfg), WithQueue(qCfg)), "", nopRequestUnmarshaler())
+	be, err := newBaseExporter(defaultSettings, fromOptions(WithRetry(rCfg), WithQueue(qCfg)), "")
 	require.NoError(t, err)
 	ocs := newObservabilityConsumerSender(be.qrSender.consumerSender)
 	be.qrSender.consumerSender = ocs
@@ -228,7 +238,7 @@ func TestQueuedRetry_ThrottleError(t *testing.T) {
 	qCfg.NumConsumers = 1
 	rCfg := NewDefaultRetrySettings()
 	rCfg.InitialInterval = 10 * time.Millisecond
-	be, err := newBaseExporter(defaultSettings, fromOptions(WithRetry(rCfg), WithQueue(qCfg)), "", nopRequestUnmarshaler())
+	be, err := newBaseExporter(defaultSettings, fromOptions(WithRetry(rCfg), WithQueue(qCfg)), "")
 	require.NoError(t, err)
 	ocs := newObservabilityConsumerSender(be.qrSender.consumerSender)
 	be.qrSender.consumerSender = ocs
@@ -261,7 +271,7 @@ func TestQueuedRetry_RetryOnError(t *testing.T) {
 	qCfg.QueueSize = 1
 	rCfg := NewDefaultRetrySettings()
 	rCfg.InitialInterval = 0
-	be, err := newBaseExporter(defaultSettings, fromOptions(WithRetry(rCfg), WithQueue(qCfg)), "", nopRequestUnmarshaler())
+	be, err := newBaseExporter(defaultSettings, fromOptions(WithRetry(rCfg), WithQueue(qCfg)), "")
 	require.NoError(t, err)
 	ocs := newObservabilityConsumerSender(be.qrSender.consumerSender)
 	be.qrSender.consumerSender = ocs
@@ -288,7 +298,7 @@ func TestQueuedRetry_DropOnFull(t *testing.T) {
 	qCfg := NewDefaultQueueSettings()
 	qCfg.QueueSize = 0
 	rCfg := NewDefaultRetrySettings()
-	be, err := newBaseExporter(defaultSettings, fromOptions(WithRetry(rCfg), WithQueue(qCfg)), "", nopRequestUnmarshaler())
+	be, err := newBaseExporter(defaultSettings, fromOptions(WithRetry(rCfg), WithQueue(qCfg)), "")
 	require.NoError(t, err)
 	ocs := newObservabilityConsumerSender(be.qrSender.consumerSender)
 	be.qrSender.consumerSender = ocs
@@ -309,7 +319,7 @@ func TestQueuedRetryHappyPath(t *testing.T) {
 	qCfg := NewDefaultQueueSettings()
 	rCfg := NewDefaultRetrySettings()
 	set := tt.ToExporterCreateSettings()
-	be, err := newBaseExporter(set, fromOptions(WithRetry(rCfg), WithQueue(qCfg)), "", nopRequestUnmarshaler())
+	be, err := newBaseExporter(set, fromOptions(WithRetry(rCfg), WithQueue(qCfg)), "")
 	require.NoError(t, err)
 	ocs := newObservabilityConsumerSender(be.qrSender.consumerSender)
 	be.qrSender.consumerSender = ocs
@@ -344,7 +354,7 @@ func TestQueuedRetry_QueueMetricsReported(t *testing.T) {
 	qCfg := NewDefaultQueueSettings()
 	qCfg.NumConsumers = 0 // to make every request go straight to the queue
 	rCfg := NewDefaultRetrySettings()
-	be, err := newBaseExporter(defaultSettings, fromOptions(WithRetry(rCfg), WithQueue(qCfg)), "", nopRequestUnmarshaler())
+	be, err := newBaseExporter(defaultSettings, fromOptions(WithRetry(rCfg), WithQueue(qCfg)), "")
 	require.NoError(t, err)
 	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
 
@@ -478,7 +488,7 @@ func TestQueuedRetry_RequeuingEnabled(t *testing.T) {
 	qCfg.NumConsumers = 1
 	rCfg := NewDefaultRetrySettings()
 	rCfg.MaxElapsedTime = time.Nanosecond // we don't want to retry at all, but requeue instead
-	be, err := newBaseExporter(defaultSettings, fromOptions(WithRetry(rCfg), WithQueue(qCfg)), "", nopRequestUnmarshaler())
+	be, err := newBaseExporter(defaultSettings, fromOptions(WithRetry(rCfg), WithQueue(qCfg)), "")
 	require.NoError(t, err)
 	ocs := newObservabilityConsumerSender(be.qrSender.consumerSender)
 	be.qrSender.consumerSender = ocs
@@ -510,7 +520,7 @@ func TestQueuedRetry_RequeuingEnabledQueueFull(t *testing.T) {
 	qCfg.QueueSize = 0
 	rCfg := NewDefaultRetrySettings()
 	rCfg.MaxElapsedTime = time.Nanosecond // we don't want to retry at all, but requeue instead
-	be, err := newBaseExporter(defaultSettings, fromOptions(WithRetry(rCfg), WithQueue(qCfg)), "", nopRequestUnmarshaler())
+	be, err := newBaseExporter(defaultSettings, fromOptions(WithRetry(rCfg), WithQueue(qCfg)), "")
 	require.NoError(t, err)
 	be.qrSender.requeuingEnabled = true
 	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
@@ -535,7 +545,7 @@ func TestQueuedRetryPersistenceEnabled(t *testing.T) {
 	qCfg.StorageID = &storageID // enable persistence
 	rCfg := NewDefaultRetrySettings()
 	set := tt.ToExporterCreateSettings()
-	be, err := newBaseExporter(set, fromOptions(WithRetry(rCfg), WithQueue(qCfg)), "", nopRequestUnmarshaler())
+	be, err := newBaseExporter(set, fromOptions(WithRetry(rCfg), WithQueue(qCfg)), "")
 	require.NoError(t, err)
 
 	var extensions = map[component.ID]component.Component{
@@ -559,7 +569,10 @@ func TestQueuedRetryPersistenceEnabledStorageError(t *testing.T) {
 	qCfg.StorageID = &storageID // enable persistence
 	rCfg := NewDefaultRetrySettings()
 	set := tt.ToExporterCreateSettings()
-	be, err := newBaseExporter(set, fromOptions(WithRetry(rCfg), WithQueue(qCfg)), "", nopRequestUnmarshaler())
+	bs := fromOptions(WithRetry(rCfg), WithQueue(qCfg))
+	bs.marshaler = mockRequestMarshaler
+	bs.unmarshaler = mockRequestUnmarshaler(&mockRequest{})
+	be, err := newBaseExporter(set, bs, "")
 	require.NoError(t, err)
 
 	var extensions = map[component.ID]component.Component{
@@ -583,7 +596,7 @@ func TestQueuedRetryPersistentEnabled_shutdown_dataIsRequeued(t *testing.T) {
 
 	req := newMockRequest(context.Background(), 3, errors.New("some error"))
 
-	be, err := newBaseExporter(defaultSettings, fromOptions(WithRetry(rCfg), WithQueue(qCfg)), "", nopRequestUnmarshaler())
+	be, err := newBaseExporter(defaultSettings, fromOptions(WithRetry(rCfg), WithQueue(qCfg)), "")
 	require.NoError(t, err)
 
 	require.NoError(t, be.Start(context.Background(), &mockHost{}))
@@ -633,7 +646,7 @@ func (mer *mockErrorRequest) Marshal() ([]byte, error) {
 	return nil, nil
 }
 
-func (mer *mockErrorRequest) Count() int {
+func (mer *mockErrorRequest) ItemsCount() int {
 	return 7
 }
 
@@ -684,7 +697,7 @@ func (m *mockRequest) checkNumRequests(t *testing.T, want int) {
 	}, time.Second, 1*time.Millisecond)
 }
 
-func (m *mockRequest) Count() int {
+func (m *mockRequest) ItemsCount() int {
 	return m.cnt
 }
 
@@ -716,9 +729,9 @@ func newObservabilityConsumerSender(nextSender requestSender) *observabilityCons
 func (ocs *observabilityConsumerSender) send(req internal.Request) error {
 	err := ocs.nextSender.send(req)
 	if err != nil {
-		ocs.droppedItemsCount.Add(int64(req.Count()))
+		ocs.droppedItemsCount.Add(int64(req.ItemsCount()))
 	} else {
-		ocs.sentItemsCount.Add(int64(req.Count()))
+		ocs.sentItemsCount.Add(int64(req.ItemsCount()))
 	}
 	ocs.waitGroup.Done()
 	return err

--- a/exporter/exporterhelper/queued_retry_test.go
+++ b/exporter/exporterhelper/queued_retry_test.go
@@ -44,7 +44,7 @@ func TestQueuedRetry_DropOnPermanentError(t *testing.T) {
 	qCfg := NewDefaultQueueSettings()
 	rCfg := NewDefaultRetrySettings()
 	mockR := newMockRequest(context.Background(), 2, consumererror.NewPermanent(errors.New("bad data")))
-	bs := fromOptions(WithRetry(rCfg), WithQueue(qCfg))
+	bs := newBaseSettings(false, WithRetry(rCfg), WithQueue(qCfg))
 	bs.marshaler = mockRequestMarshaler
 	bs.unmarshaler = mockRequestUnmarshaler(mockR)
 	be, err := newBaseExporter(defaultSettings, bs, "")
@@ -71,7 +71,7 @@ func TestQueuedRetry_DropOnNoRetry(t *testing.T) {
 	qCfg := NewDefaultQueueSettings()
 	rCfg := NewDefaultRetrySettings()
 	rCfg.Enabled = false
-	bs := fromOptions(WithRetry(rCfg), WithQueue(qCfg))
+	bs := newBaseSettings(false, WithRetry(rCfg), WithQueue(qCfg))
 	bs.marshaler = mockRequestMarshaler
 	bs.unmarshaler = mockRequestUnmarshaler(newMockRequest(context.Background(), 2, errors.New("transient error")))
 	be, err := newBaseExporter(defaultSettings, bs, "")
@@ -100,7 +100,7 @@ func TestQueuedRetry_OnError(t *testing.T) {
 	qCfg.NumConsumers = 1
 	rCfg := NewDefaultRetrySettings()
 	rCfg.InitialInterval = 0
-	be, err := newBaseExporter(defaultSettings, fromOptions(WithRetry(rCfg), WithQueue(qCfg)), "")
+	be, err := newBaseExporter(defaultSettings, newBaseSettings(false, WithRetry(rCfg), WithQueue(qCfg)), "")
 	require.NoError(t, err)
 	ocs := newObservabilityConsumerSender(be.qrSender.consumerSender)
 	be.qrSender.consumerSender = ocs
@@ -127,7 +127,7 @@ func TestQueuedRetry_StopWhileWaiting(t *testing.T) {
 	qCfg := NewDefaultQueueSettings()
 	qCfg.NumConsumers = 1
 	rCfg := NewDefaultRetrySettings()
-	be, err := newBaseExporter(defaultSettings, fromOptions(WithRetry(rCfg), WithQueue(qCfg)), "")
+	be, err := newBaseExporter(defaultSettings, newBaseSettings(false, WithRetry(rCfg), WithQueue(qCfg)), "")
 	require.NoError(t, err)
 	ocs := newObservabilityConsumerSender(be.qrSender.consumerSender)
 	be.qrSender.consumerSender = ocs
@@ -161,7 +161,7 @@ func TestQueuedRetry_DoNotPreserveCancellation(t *testing.T) {
 	qCfg := NewDefaultQueueSettings()
 	qCfg.NumConsumers = 1
 	rCfg := NewDefaultRetrySettings()
-	be, err := newBaseExporter(defaultSettings, fromOptions(WithRetry(rCfg), WithQueue(qCfg)), "")
+	be, err := newBaseExporter(defaultSettings, newBaseSettings(false, WithRetry(rCfg), WithQueue(qCfg)), "")
 	require.NoError(t, err)
 	ocs := newObservabilityConsumerSender(be.qrSender.consumerSender)
 	be.qrSender.consumerSender = ocs
@@ -191,7 +191,7 @@ func TestQueuedRetry_MaxElapsedTime(t *testing.T) {
 	rCfg := NewDefaultRetrySettings()
 	rCfg.InitialInterval = time.Millisecond
 	rCfg.MaxElapsedTime = 100 * time.Millisecond
-	be, err := newBaseExporter(defaultSettings, fromOptions(WithRetry(rCfg), WithQueue(qCfg)), "")
+	be, err := newBaseExporter(defaultSettings, newBaseSettings(false, WithRetry(rCfg), WithQueue(qCfg)), "")
 	require.NoError(t, err)
 	ocs := newObservabilityConsumerSender(be.qrSender.consumerSender)
 	be.qrSender.consumerSender = ocs
@@ -238,7 +238,7 @@ func TestQueuedRetry_ThrottleError(t *testing.T) {
 	qCfg.NumConsumers = 1
 	rCfg := NewDefaultRetrySettings()
 	rCfg.InitialInterval = 10 * time.Millisecond
-	be, err := newBaseExporter(defaultSettings, fromOptions(WithRetry(rCfg), WithQueue(qCfg)), "")
+	be, err := newBaseExporter(defaultSettings, newBaseSettings(false, WithRetry(rCfg), WithQueue(qCfg)), "")
 	require.NoError(t, err)
 	ocs := newObservabilityConsumerSender(be.qrSender.consumerSender)
 	be.qrSender.consumerSender = ocs
@@ -271,7 +271,7 @@ func TestQueuedRetry_RetryOnError(t *testing.T) {
 	qCfg.QueueSize = 1
 	rCfg := NewDefaultRetrySettings()
 	rCfg.InitialInterval = 0
-	be, err := newBaseExporter(defaultSettings, fromOptions(WithRetry(rCfg), WithQueue(qCfg)), "")
+	be, err := newBaseExporter(defaultSettings, newBaseSettings(false, WithRetry(rCfg), WithQueue(qCfg)), "")
 	require.NoError(t, err)
 	ocs := newObservabilityConsumerSender(be.qrSender.consumerSender)
 	be.qrSender.consumerSender = ocs
@@ -298,7 +298,7 @@ func TestQueuedRetry_DropOnFull(t *testing.T) {
 	qCfg := NewDefaultQueueSettings()
 	qCfg.QueueSize = 0
 	rCfg := NewDefaultRetrySettings()
-	be, err := newBaseExporter(defaultSettings, fromOptions(WithRetry(rCfg), WithQueue(qCfg)), "")
+	be, err := newBaseExporter(defaultSettings, newBaseSettings(false, WithRetry(rCfg), WithQueue(qCfg)), "")
 	require.NoError(t, err)
 	ocs := newObservabilityConsumerSender(be.qrSender.consumerSender)
 	be.qrSender.consumerSender = ocs
@@ -319,7 +319,7 @@ func TestQueuedRetryHappyPath(t *testing.T) {
 	qCfg := NewDefaultQueueSettings()
 	rCfg := NewDefaultRetrySettings()
 	set := tt.ToExporterCreateSettings()
-	be, err := newBaseExporter(set, fromOptions(WithRetry(rCfg), WithQueue(qCfg)), "")
+	be, err := newBaseExporter(set, newBaseSettings(false, WithRetry(rCfg), WithQueue(qCfg)), "")
 	require.NoError(t, err)
 	ocs := newObservabilityConsumerSender(be.qrSender.consumerSender)
 	be.qrSender.consumerSender = ocs
@@ -354,7 +354,7 @@ func TestQueuedRetry_QueueMetricsReported(t *testing.T) {
 	qCfg := NewDefaultQueueSettings()
 	qCfg.NumConsumers = 0 // to make every request go straight to the queue
 	rCfg := NewDefaultRetrySettings()
-	be, err := newBaseExporter(defaultSettings, fromOptions(WithRetry(rCfg), WithQueue(qCfg)), "")
+	be, err := newBaseExporter(defaultSettings, newBaseSettings(false, WithRetry(rCfg), WithQueue(qCfg)), "")
 	require.NoError(t, err)
 	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
 
@@ -488,7 +488,7 @@ func TestQueuedRetry_RequeuingEnabled(t *testing.T) {
 	qCfg.NumConsumers = 1
 	rCfg := NewDefaultRetrySettings()
 	rCfg.MaxElapsedTime = time.Nanosecond // we don't want to retry at all, but requeue instead
-	be, err := newBaseExporter(defaultSettings, fromOptions(WithRetry(rCfg), WithQueue(qCfg)), "")
+	be, err := newBaseExporter(defaultSettings, newBaseSettings(false, WithRetry(rCfg), WithQueue(qCfg)), "")
 	require.NoError(t, err)
 	ocs := newObservabilityConsumerSender(be.qrSender.consumerSender)
 	be.qrSender.consumerSender = ocs
@@ -520,7 +520,7 @@ func TestQueuedRetry_RequeuingEnabledQueueFull(t *testing.T) {
 	qCfg.QueueSize = 0
 	rCfg := NewDefaultRetrySettings()
 	rCfg.MaxElapsedTime = time.Nanosecond // we don't want to retry at all, but requeue instead
-	be, err := newBaseExporter(defaultSettings, fromOptions(WithRetry(rCfg), WithQueue(qCfg)), "")
+	be, err := newBaseExporter(defaultSettings, newBaseSettings(false, WithRetry(rCfg), WithQueue(qCfg)), "")
 	require.NoError(t, err)
 	be.qrSender.requeuingEnabled = true
 	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
@@ -545,7 +545,7 @@ func TestQueuedRetryPersistenceEnabled(t *testing.T) {
 	qCfg.StorageID = &storageID // enable persistence
 	rCfg := NewDefaultRetrySettings()
 	set := tt.ToExporterCreateSettings()
-	be, err := newBaseExporter(set, fromOptions(WithRetry(rCfg), WithQueue(qCfg)), "")
+	be, err := newBaseExporter(set, newBaseSettings(false, WithRetry(rCfg), WithQueue(qCfg)), "")
 	require.NoError(t, err)
 
 	var extensions = map[component.ID]component.Component{
@@ -569,7 +569,7 @@ func TestQueuedRetryPersistenceEnabledStorageError(t *testing.T) {
 	qCfg.StorageID = &storageID // enable persistence
 	rCfg := NewDefaultRetrySettings()
 	set := tt.ToExporterCreateSettings()
-	bs := fromOptions(WithRetry(rCfg), WithQueue(qCfg))
+	bs := newBaseSettings(false, WithRetry(rCfg), WithQueue(qCfg))
 	bs.marshaler = mockRequestMarshaler
 	bs.unmarshaler = mockRequestUnmarshaler(&mockRequest{})
 	be, err := newBaseExporter(set, bs, "")
@@ -596,7 +596,7 @@ func TestQueuedRetryPersistentEnabled_shutdown_dataIsRequeued(t *testing.T) {
 
 	req := newMockRequest(context.Background(), 3, errors.New("some error"))
 
-	be, err := newBaseExporter(defaultSettings, fromOptions(WithRetry(rCfg), WithQueue(qCfg)), "")
+	be, err := newBaseExporter(defaultSettings, newBaseSettings(false, WithRetry(rCfg), WithQueue(qCfg)), "")
 	require.NoError(t, err)
 
 	require.NoError(t, be.Start(context.Background(), &mockHost{}))
@@ -628,6 +628,14 @@ func TestQueuedRetryPersistentEnabled_shutdown_dataIsRequeued(t *testing.T) {
 	assert.Eventually(t, func() bool {
 		return produceCounter.Load() == uint32(2)
 	}, time.Second, 1*time.Millisecond)
+}
+
+func TestQueueRetryOptionsWithRequestExporter(t *testing.T) {
+	bs := newBaseSettings(true, WithRetry(NewDefaultRetrySettings()))
+	assert.True(t, bs.requestExporter)
+	assert.Panics(t, func() {
+		_ = newBaseSettings(true, WithRetry(NewDefaultRetrySettings()), WithQueue(NewDefaultQueueSettings()))
+	})
 }
 
 type mockErrorRequest struct {

--- a/exporter/exporterhelper/request.go
+++ b/exporter/exporterhelper/request.go
@@ -11,7 +11,7 @@ import (
 
 // Request represents a single request that can be sent to the endpoint.
 type Request interface {
-	// ItemsCount returns the count basic item in the request, the smallest peaces of data that can be sent to the endpoint.
+	// ItemsCount returns the count basic item in the request, the smallest pieces of data that can be sent to the endpoint.
 	// For example, for OTLP exporter, this value represents the number of spans, metric data points or log records.
 	ItemsCount() int
 }

--- a/exporter/exporterhelper/request.go
+++ b/exporter/exporterhelper/request.go
@@ -1,0 +1,39 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package exporterhelper // import "go.opentelemetry.io/collector/exporter/exporterhelper"
+
+import (
+	"context"
+
+	"go.opentelemetry.io/collector/exporter/exporterhelper/internal"
+)
+
+// Request represents a single request that can be sent to the endpoint.
+type Request interface {
+	// ItemsCount returns the count basic item in the request, the smallest peaces of data that can be sent to the endpoint.
+	// For example, for OTLP exporter, this value represents the number of spans, metric data points or log records.
+	ItemsCount() int
+}
+
+// RequestSender is a helper function that sends a request.
+type RequestSender func(ctx context.Context, req Request) error
+
+type request struct {
+	Request
+	baseRequest
+	sender RequestSender
+}
+
+var _ internal.Request = (*request)(nil)
+
+func (req *request) Export(ctx context.Context) error {
+	return req.sender(ctx, req.Request)
+}
+
+func (req *request) OnError(_ error) internal.Request {
+	// Potentially we could introduce a new RequestError type that would represent partially succeeded request.
+	// In that case we should consider returning them back to the pipeline converted back to pdata in case if
+	// sending queue is disabled. We leave it as a future improvement if decided that it's needed.
+	return req
+}

--- a/exporter/exporterhelper/request_test.go
+++ b/exporter/exporterhelper/request_test.go
@@ -1,0 +1,44 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package exporterhelper // import "go.opentelemetry.io/collector/exporter/exporterhelper"
+
+import (
+	"context"
+
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+)
+
+type fakeRequest struct {
+	items int
+}
+
+func (r fakeRequest) ItemsCount() int {
+	return r.items
+}
+
+type fakeRequestConverter struct {
+	metricsError error
+	tracesError  error
+	logsError    error
+}
+
+func (c fakeRequestConverter) RequestFromMetrics(_ context.Context, md pmetric.Metrics) (Request, error) {
+	return fakeRequest{items: md.DataPointCount()}, c.metricsError
+}
+
+func (c fakeRequestConverter) RequestFromTraces(_ context.Context, td ptrace.Traces) (Request, error) {
+	return fakeRequest{items: td.SpanCount()}, c.tracesError
+}
+
+func (c fakeRequestConverter) RequestFromLogs(_ context.Context, ld plog.Logs) (Request, error) {
+	return fakeRequest{items: ld.LogRecordCount()}, c.logsError
+}
+
+func newFakeRequestSender(err error) RequestSender {
+	return func(_ context.Context, _ Request) error {
+		return err
+	}
+}

--- a/exporter/exporterhelper/traces.go
+++ b/exporter/exporterhelper/traces.go
@@ -94,7 +94,7 @@ func NewTracesExporter(
 		return nil, errNilPushTraceData
 	}
 
-	bs := fromOptions(options...)
+	bs := newBaseSettings(false, options...)
 	bs.marshaler = tracesRequestMarshaler
 	bs.unmarshaler = newTraceRequestUnmarshalerFunc(pusher)
 	be, err := newBaseExporter(set, bs, component.DataTypeTraces)
@@ -128,8 +128,8 @@ type TracesConverter interface {
 	RequestFromTraces(context.Context, ptrace.Traces) (Request, error)
 }
 
-// NewTracesExporterV2 creates a new traces exporter based on a custom TracesConverter and RequestSender.
-func NewTracesExporterV2(
+// NewTracesRequestExporter creates a new traces exporter based on a custom TracesConverter and RequestSender.
+func NewTracesRequestExporter(
 	_ context.Context,
 	set exporter.CreateSettings,
 	converter TracesConverter,
@@ -148,7 +148,7 @@ func NewTracesExporterV2(
 		return nil, errNilRequestSender
 	}
 
-	bs := fromOptions(options...)
+	bs := newBaseSettings(true, options...)
 	bs.RequestSender = sender
 
 	be, err := newBaseExporter(set, bs, component.DataTypeTraces)

--- a/exporter/exporterhelper/traces.go
+++ b/exporter/exporterhelper/traces.go
@@ -48,11 +48,6 @@ func tracesRequestMarshaler(req internal.Request) ([]byte, error) {
 	return tracesMarshaler.MarshalTraces(req.(*tracesRequest).td)
 }
 
-// Marshal provides serialization capabilities required by persistent queue
-func (req *tracesRequest) Marshal() ([]byte, error) {
-	return tracesMarshaler.MarshalTraces(req.td)
-}
-
 func (req *tracesRequest) OnError(err error) internal.Request {
 	var traceError consumererror.Traces
 	if errors.As(err, &traceError) {


### PR DESCRIPTION
Introduce a new exporter helper that operates over client-provided requests instead of pdata. The helper user now have to provide:
- Converter: an interface with a function implementing translation of pdata Metrics/Traces/Logs into a user-defined Request.
- Request sender: a function that will be called to send the Request

It opens a door for moving batching to the exporter, where batches will be built from client data format, instead of pdata. The batches can be properly sized by custom request size, which can be different from OTLP. The same custom request sizing will be applied to the sending queue. It will also improve performance of the sending queue retries for non-OTLP exporters, they don't need to translate pdata on every retry. 

This is an experimental API. Once stabilized, it's intended to replace the existing helpers.

Tracking Issue: https://github.com/open-telemetry/opentelemetry-collector/issues/8122

Related issue: https://github.com/open-telemetry/opentelemetry-collector/issues/4646 