### PR TITLE
Add metadata.yaml as a requirement

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ Components refer to connectors, exporters, extensions, processors, and receivers
 * Implement the `component.Component` interface
 * Provide a configuration structure which defines the configuration of the component
 * Provide the implementation which performs the component operation
-* Have a `metadata.yaml` file and it's generated code (using [mdatadgen](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/cmd/mdatagen/README.md)).
+* Have a `metadata.yaml` file and its generated code (using [mdatadgen](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/cmd/mdatagen/README.md)).
 
 For more details on components, see the [Adding New Components](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#adding-new-components) document and the tutorial [Building a Trace Receiver](https://opentelemetry.io/docs/collector/trace-receiver/) which provides a detailed example of building a component.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,7 @@ Components refer to connectors, exporters, extensions, processors, and receivers
 * Implement the `component.Component` interface
 * Provide a configuration structure which defines the configuration of the component
 * Provide the implementation which performs the component operation
+* Have a `metadata.yaml` file and it's generated code (using [mdatadgen](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/cmd/mdatagen/README.md)).
 
 For more details on components, see the [Adding New Components](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#adding-new-components) document and the tutorial [Building a Trace Receiver](https://opentelemetry.io/docs/collector/trace-receiver/) which provides a detailed example of building a component.
 
@@ -56,6 +57,7 @@ When submitting a component to the community, consider breaking it down into sep
 * **First PR** should include the overall structure of the new component:
   * Readme, configuration, and factory implementation usually using the helper
     factory structs.
+  * `metadata.yaml` and it's generated code (using [mdatadgen](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/cmd/mdatagen/README.md)).
   * This PR is usually trivial to review, so the size limit does not apply to
     it.
   * The component should use [`In Development` Stability](https://github.com/open-telemetry/opentelemetry-collector#development) in its README.


### PR DESCRIPTION
**Description:**

This PR adds the `metadata.yaml` as a requirement in the contributing guidelines.

**Link to tracking Issue:**

https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/20908.