### PR TITLE
Add an option to skip generating the go.mod in the builder

### DIFF
--- a/.chloggen/builder-skip-generate.yaml
+++ b/.chloggen/builder-skip-generate.yaml
@@ -1,0 +1,12 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: cmd/builder
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add "--skip-generate" option to make builder skip source generation
+
+# One or more tracking issues or pull requests related to the change
+issues: [7541]
+

--- a/cmd/builder/README.md
+++ b/cmd/builder/README.md
@@ -112,3 +112,24 @@ replaces:
   # a list of "replaces" directives that will be part of the resulting go.mod
   - github.com/open-telemetry/opentelemetry-collector-contrib/internal/common => github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.40.0
 ```
+
+## Steps
+
+The builder has 3 steps:
+
+* Generate: generates the golang source code
+* Get modules: generates the go.mod file based on the imported modules in the generated golang source code
+* Compilation: builds the OpenTelemetry Collector executable
+
+Each step can be skipped independently: `--skip-generate`, `--skip-get-modules` and `--skip-compilation`.
+
+For instance, a code generation step could execute
+
+```console
+ocb --skip-compilation --config=config.yaml
+```
+then commit the code in a git repo. A CI can sync the code and execute
+```console
+ocb --skip-generate --skip-get-modules --config=config.yaml
+```
+to only execute the compilation step.

--- a/cmd/builder/internal/builder/config.go
+++ b/cmd/builder/internal/builder/config.go
@@ -23,6 +23,7 @@ var ErrInvalidGoMod = errors.New("invalid gomod specification for module")
 // Config holds the builder's configuration
 type Config struct {
 	Logger          *zap.Logger
+	SkipGenerate    bool   `mapstructure:"-"`
 	SkipCompilation bool   `mapstructure:"-"`
 	SkipGetModules  bool   `mapstructure:"-"`
 	LDFlags         string `mapstructure:"-"`

--- a/cmd/builder/internal/builder/main.go
+++ b/cmd/builder/internal/builder/main.go
@@ -36,6 +36,10 @@ func GenerateAndCompile(cfg Config) error {
 
 // Generate assembles a new distribution based on the given configuration
 func Generate(cfg Config) error {
+	if cfg.SkipGenerate {
+		cfg.Logger.Info("Skipping generating source codes.")
+		return nil
+	}
 	// create a warning message for non-aligned builder and collector base
 	if cfg.Distribution.OtelColVersion != defaultOtelColVersion {
 		cfg.Logger.Info("You're building a distribution with non-aligned version of the builder. Compilation may fail due to API changes. Please upgrade your builder or API", zap.String("builder-version", defaultOtelColVersion))

--- a/cmd/builder/internal/builder/main_test.go
+++ b/cmd/builder/internal/builder/main_test.go
@@ -5,6 +5,8 @@ package builder
 
 import (
 	"fmt"
+	"io"
+	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -31,6 +33,18 @@ func TestGenerateInvalidOutputPath(t *testing.T) {
 	err := Generate(cfg)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failed to create output path")
+}
+
+func TestSkipGenerate(t *testing.T) {
+	cfg := NewDefaultConfig()
+	cfg.Distribution.OutputPath = t.TempDir()
+	cfg.SkipGenerate = true
+	err := Generate(cfg)
+	require.NoError(t, err)
+	outputFile, err := os.Open(cfg.Distribution.OutputPath)
+	require.NoError(t, err)
+	_, err = outputFile.Readdirnames(1)
+	require.ErrorIs(t, err, io.EOF, "skip generate should leave output directory empty")
 }
 
 func TestGenerateAndCompile(t *testing.T) {

--- a/cmd/builder/internal/builder/main_test.go
+++ b/cmd/builder/internal/builder/main_test.go
@@ -17,20 +17,20 @@ import (
 )
 
 func TestGenerateDefault(t *testing.T) {
-	require.NoError(t, Generate(NewDefaultConfig()))
+	require.NoError(t, Generate(NewDefaultConfig(), allTemplates))
 }
 
 func TestGenerateInvalidCollectorVersion(t *testing.T) {
 	cfg := NewDefaultConfig()
 	cfg.Distribution.OtelColVersion = "invalid"
-	err := Generate(cfg)
+	err := Generate(cfg, allTemplates)
 	require.NoError(t, err)
 }
 
 func TestGenerateInvalidOutputPath(t *testing.T) {
 	cfg := NewDefaultConfig()
 	cfg.Distribution.OutputPath = "/:invalid"
-	err := Generate(cfg)
+	err := Generate(cfg, allTemplates)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failed to create output path")
 }
@@ -39,7 +39,7 @@ func TestSkipGenerate(t *testing.T) {
 	cfg := NewDefaultConfig()
 	cfg.Distribution.OutputPath = t.TempDir()
 	cfg.SkipGenerate = true
-	err := Generate(cfg)
+	err := Generate(cfg, allTemplates)
 	require.NoError(t, err)
 	outputFile, err := os.Open(cfg.Distribution.OutputPath)
 	require.NoError(t, err)

--- a/cmd/builder/internal/command.go
+++ b/cmd/builder/internal/command.go
@@ -20,6 +20,7 @@ import (
 )
 
 const (
+	skipGenerateFlag               = "skip-generate"
 	skipCompilationFlag            = "skip-compilation"
 	skipGetModulesFlag             = "skip-get-modules"
 	ldflagsFlag                    = "ldflags"
@@ -74,6 +75,7 @@ configuration is provided, ocb will generate a default Collector.
 	cmd.Flags().StringVar(&cfgFile, "config", "", "build configuration file")
 
 	// the distribution parameters, which we accept as CLI flags as well
+	cmd.Flags().BoolVar(&cfg.SkipGenerate, skipGenerateFlag, false, "Whether builder should skip generating go code (default false)")
 	cmd.Flags().BoolVar(&cfg.SkipCompilation, skipCompilationFlag, false, "Whether builder should only generate go code with no compile of the collector (default false)")
 	cmd.Flags().BoolVar(&cfg.SkipGetModules, skipGetModulesFlag, false, "Whether builder should skip updating go.mod and retrieve Go module list (default false)")
 	cmd.Flags().StringVar(&cfg.LDFlags, ldflagsFlag, "", `ldflags to include in the "go build" command`)
@@ -160,6 +162,9 @@ func applyCfgFromFile(flags *flag.FlagSet, cfgFromFile builder.Config) {
 	cfg.Replaces = cfgFromFile.Replaces
 	cfg.Excludes = cfgFromFile.Excludes
 
+	if !flags.Changed(skipGenerateFlag) && cfgFromFile.SkipGenerate {
+		cfg.SkipGenerate = cfgFromFile.SkipGenerate
+	}
 	if !flags.Changed(skipCompilationFlag) && cfgFromFile.SkipCompilation {
 		cfg.SkipCompilation = cfgFromFile.SkipCompilation
 	}

--- a/cmd/builder/internal/command.go
+++ b/cmd/builder/internal/command.go
@@ -23,6 +23,7 @@ const (
 	skipGenerateFlag               = "skip-generate"
 	skipCompilationFlag            = "skip-compilation"
 	skipGetModulesFlag             = "skip-get-modules"
+	skipNewGoModFlag               = "skip-new-go-mod"
 	ldflagsFlag                    = "ldflags"
 	distributionNameFlag           = "name"
 	distributionDescriptionFlag    = "description"
@@ -78,6 +79,7 @@ configuration is provided, ocb will generate a default Collector.
 	cmd.Flags().BoolVar(&cfg.SkipGenerate, skipGenerateFlag, false, "Whether builder should skip generating go code (default false)")
 	cmd.Flags().BoolVar(&cfg.SkipCompilation, skipCompilationFlag, false, "Whether builder should only generate go code with no compile of the collector (default false)")
 	cmd.Flags().BoolVar(&cfg.SkipGetModules, skipGetModulesFlag, false, "Whether builder should skip updating go.mod and retrieve Go module list (default false)")
+	cmd.Flags().BoolVar(&cfg.SkipNewGoMod, skipNewGoModFlag, false, "Whether builder should skip generating a new go.mod with fresh dependencies or to update an existing go module instead (default false)")
 	cmd.Flags().StringVar(&cfg.LDFlags, ldflagsFlag, "", `ldflags to include in the "go build" command`)
 	cmd.Flags().StringVar(&cfg.Distribution.Name, distributionNameFlag, "otelcol-custom", "The executable name for the OpenTelemetry Collector distribution")
 	if err := cmd.Flags().MarkDeprecated(distributionNameFlag, "use config distribution::name"); err != nil {
@@ -170,6 +172,9 @@ func applyCfgFromFile(flags *flag.FlagSet, cfgFromFile builder.Config) {
 	}
 	if !flags.Changed(skipGetModulesFlag) && cfgFromFile.SkipGetModules {
 		cfg.SkipGetModules = cfgFromFile.SkipGetModules
+	}
+	if !flags.Changed(skipNewGoModFlag) && cfgFromFile.SkipNewGoMod {
+		cfg.SkipNewGoMod = cfgFromFile.SkipNewGoMod
 	}
 	if !flags.Changed(distributionNameFlag) && cfgFromFile.Distribution.Name != "" {
 		cfg.Distribution.Name = cfgFromFile.Distribution.Name

--- a/cmd/builder/internal/command_test.go
+++ b/cmd/builder/internal/command_test.go
@@ -178,11 +178,54 @@ func Test_applyCfgFromFile(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "Skip generate false",
+			args: args{
+				flags: flag.NewFlagSet("version=1.0.0", 1),
+				cfgFromFile: builder.Config{
+					Logger:          zap.NewNop(),
+					SkipGenerate:    false,
+					SkipCompilation: true,
+					SkipGetModules:  true,
+					Distribution:    testDistribution,
+				},
+			},
+			want: builder.Config{
+				Logger:          zap.NewNop(),
+				SkipGenerate:    false,
+				SkipCompilation: true,
+				SkipGetModules:  true,
+				Distribution:    testDistribution,
+			},
+			wantErr: false,
+		},
+		{
+			name: "Skip generate true",
+			args: args{
+				flags: flag.NewFlagSet("version=1.0.0", 1),
+				cfgFromFile: builder.Config{
+					Logger:          zap.NewNop(),
+					SkipGenerate:    true,
+					SkipCompilation: true,
+					SkipGetModules:  true,
+					Distribution:    testDistribution,
+				},
+			},
+			want: builder.Config{
+				Logger:          zap.NewNop(),
+				SkipGenerate:    true,
+				SkipCompilation: true,
+				SkipGetModules:  true,
+				Distribution:    testDistribution,
+			},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			applyCfgFromFile(tt.args.flags, tt.args.cfgFromFile)
 			assert.Equal(t, tt.want.Distribution, cfg.Distribution)
+			assert.Equal(t, tt.want.SkipGenerate, cfg.SkipGenerate)
 			assert.Equal(t, tt.want.SkipCompilation, cfg.SkipCompilation)
 			assert.Equal(t, tt.want.SkipGetModules, cfg.SkipGetModules)
 			assert.Equal(t, tt.want.Excludes, cfg.Excludes)


### PR DESCRIPTION
**Description:** 
Adds to #7542, making this PR add two options, one to skip generation of all code (meaning to verify the config only), and one to skip generation of the go.mod file. 

Skipping the generation of the go.mod file means that instead of calling `go mod tidy` on a newly-generated `go.mod` file, we instead call `go get` on each module to update an existing go.mod file. This allows the builder to be integrated into a Golang monorepo where the collector is part of a larger build.

**Link to tracking Issue:** #7541 

**Testing:** This has been tested manually. There are no existing tests for the GetModules code path that needed to be tested here. Willing to add more tests if this PR is something the maintainers will accept.

**Documentation:** TODO