### PR TITLE
[service] Ensure test service eventually connects to telemetry port on restart

### DIFF
--- a/service/service_test.go
+++ b/service/service_test.go
@@ -340,13 +340,20 @@ func TestServiceTelemetryRestart(t *testing.T) {
 	require.NoError(t, srvTwo.Start(context.Background()))
 
 	// check telemetry server to ensure we get a response
-	// #nosec G107
-	resp, err = http.Get(telemetryURL)
-	assert.NoError(t, err)
+	require.Eventually(t,
+		func() bool {
+			// #nosec G107
+			resp, err = http.Get(telemetryURL)
+			return err == nil
+		},
+		500*time.Millisecond,
+		100*time.Millisecond,
+		"Must get a valid response from the service",
+	)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 	// Shutdown the new service
-	require.NoError(t, srvTwo.Shutdown(context.Background()))
+	assert.NoError(t, srvTwo.Shutdown(context.Background()))
 }
 
 func assertResourceLabels(t *testing.T, res pcommon.Resource, expectedLabels map[string]labelValue) {


### PR DESCRIPTION
**Description:**

There appears to be a flake in waiting for resources being released within tests:

```
    service_test.go:345: 
        	Error Trace:	/home/runner/work/opentelemetry-collector/opentelemetry-collector/service/service_test.go:345
        	Error:      	Received unexpected error:
        	            	Get "http://localhost:8888/metrics": dial tcp [::1]:8888: connect: connection refused
        	Test:       	TestServiceTelemetryRestart
```
See test run: https://github.com/open-telemetry/opentelemetry-collector/actions/runs/5267677421/jobs/9523273917?pr=7703

**Link to tracking Issue:**

NA

**Testing:**
NA

**Documentation:**
NA
