### PR TITLE
Add zstd decompression support to HTTPServerSettings

### DIFF
--- a/.chloggen/add-zstd-decompression.yaml
+++ b/.chloggen/add-zstd-decompression.yaml
@@ -1,0 +1,17 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: HTTPServerSettings
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add zstd support to HTTPServerSettings
+
+# One or more tracking issues or pull requests related to the change
+issues: [7927]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: This adds ability to decompress zstd-compressed HTTP requests to|
+  all receivers that use HTTPServerSettings.

--- a/.chloggen/fix-unsupported-content-encoding-bug.yaml
+++ b/.chloggen/fix-unsupported-content-encoding-bug.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: HTTPServerSettings
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Ensure requests with unsupported Content-Encoding return HTTP 400 Bad Request
+
+# One or more tracking issues or pull requests related to the change
+issues: [7927]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/config/confighttp/compression.go
+++ b/config/confighttp/compression.go
@@ -142,7 +142,7 @@ func newBodyReader(r *http.Request) (io.ReadCloser, error) {
 		if err != nil {
 			return nil, err
 		}
-		return io.NopCloser(zr), nil
+		return zr.IOReadCloser(), nil
 	case "":
 		// Not a compressed payload. Nothing to do.
 		return nil, nil


### PR DESCRIPTION
This adds ability to decompress zstd-compressed HTTP requests to all receivers that use HTTPServerSettings.

Also added missing error handling for the case when an unsupported compression type was used in the request. Now it correctly returns 400 Bad Request. Also added a unit test to verify this case.

Once this is merged I will submit a PR in contrib repo to add end-to-end tests that use zstd compression in the testbed.

