### PR TITLE
enhancement: record internal telemetry spans from all components, not just receivers

### DIFF
--- a/.chloggen/record-child-traces.yaml
+++ b/.chloggen/record-child-traces.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: obsreport
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Internal collector telemetry spans are now collected from all components, not just receivers.
+
+# One or more tracking issues or pull requests related to the change
+issues: [7947]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/service/telemetry/otel_trace_sampler.go
+++ b/service/telemetry/otel_trace_sampler.go
@@ -10,7 +10,7 @@ import (
 type recordSampler struct{}
 
 func (r recordSampler) ShouldSample(_ sdktrace.SamplingParameters) sdktrace.SamplingResult {
-	return sdktrace.SamplingResult{Decision: sdktrace.RecordOnly}
+	return sdktrace.SamplingResult{Decision: sdktrace.RecordAndSample}
 }
 
 func (r recordSampler) Description() string {

--- a/service/telemetry/otel_trace_sampler.go
+++ b/service/telemetry/otel_trace_sampler.go
@@ -10,7 +10,7 @@ import (
 type recordSampler struct{}
 
 func (r recordSampler) ShouldSample(_ sdktrace.SamplingParameters) sdktrace.SamplingResult {
-	return sdktrace.SamplingResult{Decision: sdktrace.RecordAndSample}
+	return sdktrace.SamplingResult{Decision: sdktrace.RecordOnly}
 }
 
 func (r recordSampler) Description() string {
@@ -24,5 +24,6 @@ func alwaysRecord() sdktrace.Sampler {
 		sdktrace.WithRemoteParentSampled(sdktrace.AlwaysSample()),
 		sdktrace.WithRemoteParentNotSampled(rs),
 		sdktrace.WithLocalParentSampled(sdktrace.AlwaysSample()),
+		sdktrace.WithLocalParentNotSampled(sdktrace.AlwaysSample()),
 		sdktrace.WithRemoteParentSampled(rs))
 }


### PR DESCRIPTION
**Description:**

Configured the internal tracer to record child spans. This effectively extends span recording to capture processor and exporter-reported spans, and not just receiver spans.

The reason this works is because of this code: https://github.com/open-telemetry/opentelemetry-go/blob/fc88a6a25b9ccd8cb370947dd913898e9c37f838/sdk/trace/sampling.go#L276-L279

If the parent span is not set to sampled, child spans (like the ones created for subsequent component in the otel pipeline) will be non-recording spans and won't be recorded.

**Issue:** https://github.com/open-telemetry/opentelemetry-collector/issues/7947

**Testing:**
I wrote a custom extension to capture the internal traces and send to a local jaeger instance I created.

Telemetry before:

![image](https://github.com/open-telemetry/opentelemetry-collector/assets/2083713/8cf2ffa8-5481-4415-b3f8-43d123ab5bae)

Telemetry after:

![image](https://github.com/open-telemetry/opentelemetry-collector/assets/2083713/4ae95a80-4c8e-468b-aeff-a95478717a23)