### PR TITLE
Add externally provided Prometheus registry to service.New

### DIFF
--- a/connector/forwardconnector/go.mod
+++ b/connector/forwardconnector/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	go.opentelemetry.io/collector v0.80.0 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.80.0 // indirect
 	go.opentelemetry.io/collector/confmap v0.80.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.0.0-rcv0013 // indirect

--- a/connector/go.mod
+++ b/connector/go.mod
@@ -4,6 +4,7 @@ go 1.19
 
 require (
 	github.com/stretchr/testify v1.8.4
+	go.opentelemetry.io/collector v0.80.0
 	go.opentelemetry.io/collector/component v0.80.0
 	go.opentelemetry.io/collector/consumer v0.80.0
 	go.opentelemetry.io/collector/pdata v1.0.0-rcv0013

--- a/service/telemetry.go
+++ b/service/telemetry.go
@@ -68,7 +68,7 @@ func newColTelemetry(useOtel bool, disableHighCardinality bool, extendedConfig b
 	}
 }
 
-func (tel *telemetryInitializer) init(res *resource.Resource, settings component.TelemetrySettings, cfg telemetry.Config, asyncErrorChannel chan error) error {
+func (tel *telemetryInitializer) init(res *resource.Resource, promRegistry *prometheus.Registry, settings component.TelemetrySettings, cfg telemetry.Config, asyncErrorChannel chan error) error {
 	if cfg.Metrics.Level == configtelemetry.LevelNone || cfg.Metrics.Address == "" {
 		settings.Logger.Info(
 			"Skipping telemetry setup.",
@@ -86,11 +86,10 @@ func (tel *telemetryInitializer) init(res *resource.Resource, settings component
 		return err
 	}
 
-	return tel.initPrometheus(res, settings.Logger, cfg.Metrics.Address, cfg.Metrics.Level, asyncErrorChannel)
+	return tel.initPrometheus(res, promRegistry, settings.Logger, cfg.Metrics.Address, cfg.Metrics.Level, asyncErrorChannel)
 }
 
-func (tel *telemetryInitializer) initPrometheus(res *resource.Resource, logger *zap.Logger, address string, level configtelemetry.Level, asyncErrorChannel chan error) error {
-	promRegistry := prometheus.NewRegistry()
+func (tel *telemetryInitializer) initPrometheus(res *resource.Resource, promRegistry *prometheus.Registry, logger *zap.Logger, address string, level configtelemetry.Level, asyncErrorChannel chan error) error {
 	if tel.useOtel {
 		if err := tel.initOpenTelemetry(res, promRegistry); err != nil {
 			return err

--- a/service/telemetry_test.go
+++ b/service/telemetry_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus"
 	io_prometheus_client "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
 	"github.com/stretchr/testify/assert"
@@ -206,7 +207,7 @@ func TestTelemetryInit(t *testing.T) {
 				Logger:   zap.NewNop(),
 				Resource: res,
 			}
-			err := tel.init(otelRes, settings, cfg, make(chan error))
+			err := tel.init(otelRes, prometheus.NewRegistry(), settings, cfg, make(chan error))
 			require.NoError(t, err)
 			defer func() {
 				require.NoError(t, tel.shutdown())


### PR DESCRIPTION
**Description:**

Service.New() can now be provided with an external reference to a prometheus.Registry.

The rationale behind those changes is that current internal registry cannot be shared with external users of collector.

Example: my team and I are working on a project on top of the OpenTelemetry and, consequently, are building a thing on top of opentelemetry-collector. The thing has two metric endpoints itself, and we do not want to have a third one inside the collector. With external prometheus.Registry we can now provide Service.New() with our own registry and make an endpoint with its metrics by ourselves.

I believe this contribution aligns with Observable and Extensible items from ```vision.md```

**Testing:**
No additional tests were made as the changes seem quite trivial and do not introduce any breaking API changes

