### PR TITLE
[chore] disable writing benchmark results for now

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -18,6 +18,8 @@ jobs:
       - name: Run benchmark
         run: make gobenchmark
 
+      # Disabling until fine-grained permissions token enabled for the
+      # repository
       #- name: Store benchmark result
       #  uses: benchmark-action/github-action-benchmark@v1
       #  with:

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -18,12 +18,12 @@ jobs:
       - name: Run benchmark
         run: make gobenchmark
 
-      - name: Store benchmark result
-        uses: benchmark-action/github-action-benchmark@v1
-        with:
-          tool: 'go'
-          output-file-path: benchmarks.txt
-          gh-pages-branch: gh-pages
-          auto-push: true
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          benchmark-data-dir-path: "docs/dev/bench"
+      #- name: Store benchmark result
+      #  uses: benchmark-action/github-action-benchmark@v1
+      #  with:
+      #    tool: 'go'
+      #    output-file-path: benchmarks.txt
+      #    gh-pages-branch: gh-pages
+      #    auto-push: true
+      #    github-token: ${{ secrets.GITHUB_TOKEN }}
+      #    benchmark-data-dir-path: "docs/dev/bench"


### PR DESCRIPTION
Doing this will require a write token, to be able to update the branch. Will attempt to re-enable this once renovabot permissions are sorted out
