### PR TITLE
[chore] update go-jsonschema

### DIFF
--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/a8m/envsubst v1.4.2
-	github.com/atombender/go-jsonschema v0.11.0
+	github.com/atombender/go-jsonschema v0.12.0
 	github.com/client9/misspell v0.3.4
 	github.com/golangci/golangci-lint v1.53.3
 	github.com/google/addlicense v1.1.1
@@ -232,6 +232,3 @@ retract (
 	v0.57.1 // Release failed, use v0.57.2
 	v0.57.0 // Release failed, use v0.57.2
 )
-
-// work around until https://github.com/omissis/go-jsonschema/pull/80 is merged
-replace github.com/atombender/go-jsonschema v0.11.0 => github.com/codeboten/go-jsonschema v0.0.0-20230622190031-76e0cafc4ced

--- a/internal/tools/go.sum
+++ b/internal/tools/go.sum
@@ -89,6 +89,8 @@ github.com/ashanbrown/forbidigo v1.5.3 h1:jfg+fkm/snMx+V9FBwsl1d340BV/99kZGv5jN9
 github.com/ashanbrown/forbidigo v1.5.3/go.mod h1:Y8j9jy9ZYAEHXdu723cUlraTqbzjKF1MUyfOKL+AjcU=
 github.com/ashanbrown/makezero v1.1.1 h1:iCQ87C0V0vSyO+M9E/FZYbu65auqH0lnsOkf5FcB28s=
 github.com/ashanbrown/makezero v1.1.1/go.mod h1:i1bJLCRSCHOcOa9Y6MyF2FTfMZMFdHvxKHxgO5Z1axI=
+github.com/atombender/go-jsonschema v0.12.0 h1:3akbGLTV41vVeNIdSMZfM4lcqQgVnwmOLF8zKnFdWH4=
+github.com/atombender/go-jsonschema v0.12.0/go.mod h1:6WyhPNbz6H8M3IzlAd1DMENTh/QUHBYoFe8na6yl1FE=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
@@ -131,8 +133,6 @@ github.com/cloudflare/circl v1.3.3/go.mod h1:5XYMA4rFBvNIrhs50XuiBJ15vF2pZn4nnUK
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
-github.com/codeboten/go-jsonschema v0.0.0-20230622190031-76e0cafc4ced h1:wZe0sCnIxs39oMjxSrZFZDq6ZPxByIcALMGk5nE5nvA=
-github.com/codeboten/go-jsonschema v0.0.0-20230622190031-76e0cafc4ced/go.mod h1:6WyhPNbz6H8M3IzlAd1DMENTh/QUHBYoFe8na6yl1FE=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/curioswitch/go-reassign v0.2.0 h1:G9UZyOcpk/d7Gd6mqYgd8XYWFMw/znxwGDUstnC9DIo=


### PR DESCRIPTION
The version that supports -tags is now in the main repo.
