### PR TITLE
add support for additional decoders

### DIFF
--- a/.chloggen/codeboten_add-option-for-decompressor.yaml
+++ b/.chloggen/codeboten_add-option-for-decompressor.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: confighttp
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note:  "Add support for additional content decoders via `WithDecoder` server option"
+
+# One or more tracking issues or pull requests related to the change
+issues: [7977]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: 

--- a/config/confighttp/compression.go
+++ b/config/confighttp/compression.go
@@ -68,25 +68,68 @@ func (r *compressRoundTripper) RoundTrip(req *http.Request) (*http.Response, err
 type decompressor struct {
 	errHandler func(w http.ResponseWriter, r *http.Request, errorMsg string, statusCode int)
 	base       http.Handler
+	decoders   map[string]func(body io.ReadCloser) (io.ReadCloser, error)
 }
 
 // httpContentDecompressor offloads the task of handling compressed HTTP requests
 // by identifying the compression format in the "Content-Encoding" header and re-writing
 // request body so that the handlers further in the chain can work on decompressed data.
 // It supports gzip and deflate/zlib compression.
-func httpContentDecompressor(h http.Handler, eh func(w http.ResponseWriter, r *http.Request, errorMsg string, statusCode int)) http.Handler {
+func httpContentDecompressor(h http.Handler, eh func(w http.ResponseWriter, r *http.Request, errorMsg string, statusCode int), decoders map[string]func(body io.ReadCloser) (io.ReadCloser, error)) http.Handler {
 	errHandler := defaultErrorHandler
 	if eh != nil {
 		errHandler = eh
 	}
-	return &decompressor{
+
+	d := &decompressor{
 		errHandler: errHandler,
 		base:       h,
+		decoders: map[string]func(body io.ReadCloser) (io.ReadCloser, error){
+			"": func(body io.ReadCloser) (io.ReadCloser, error) {
+				// Not a compressed payload. Nothing to do.
+				return nil, nil
+			},
+			"gzip": func(body io.ReadCloser) (io.ReadCloser, error) {
+				gr, err := gzip.NewReader(body)
+				if err != nil {
+					return nil, err
+				}
+				return gr, nil
+			},
+			"zstd": func(body io.ReadCloser) (io.ReadCloser, error) {
+				zr, err := zstd.NewReader(
+					body,
+					// Concurrency 1 disables async decoding. We don't need async decoding, it is pointless
+					// for our use-case (a server accepting decoding http requests).
+					// Disabling async improves performance (I benchmarked it previously when working
+					// on https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/23257).
+					zstd.WithDecoderConcurrency(1),
+				)
+				if err != nil {
+					return nil, err
+				}
+				return zr.IOReadCloser(), nil
+			},
+			"zlib": func(body io.ReadCloser) (io.ReadCloser, error) {
+				zr, err := zlib.NewReader(body)
+				if err != nil {
+					return nil, err
+				}
+				return zr, nil
+			},
+		},
 	}
+	d.decoders["deflate"] = d.decoders["zlib"]
+
+	for key, dec := range decoders {
+		d.decoders[key] = dec
+	}
+
+	return d
 }
 
 func (d *decompressor) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	newBody, err := newBodyReader(r)
+	newBody, err := d.newBodyReader(r)
 	if err != nil {
 		d.errHandler(w, r, err.Error(), http.StatusBadRequest)
 		return
@@ -104,39 +147,13 @@ func (d *decompressor) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	d.base.ServeHTTP(w, r)
 }
 
-func newBodyReader(r *http.Request) (io.ReadCloser, error) {
+func (d *decompressor) newBodyReader(r *http.Request) (io.ReadCloser, error) {
 	encoding := r.Header.Get(headerContentEncoding)
-	switch encoding {
-	case string(configcompression.Gzip):
-		gr, err := gzip.NewReader(r.Body)
-		if err != nil {
-			return nil, err
-		}
-		return gr, nil
-	case string(configcompression.Deflate), string(configcompression.Zlib):
-		zr, err := zlib.NewReader(r.Body)
-		if err != nil {
-			return nil, err
-		}
-		return zr, nil
-	case "zstd":
-		zr, err := zstd.NewReader(
-			r.Body,
-			// Concurrency 1 disables async decoding. We don't need async decoding, it is pointless
-			// for our use-case (a server accepting decoding http requests).
-			// Disabling async improves performance (I benchmarked it previously when working
-			// on https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/23257).
-			zstd.WithDecoderConcurrency(1),
-		)
-		if err != nil {
-			return nil, err
-		}
-		return zr.IOReadCloser(), nil
-	case "":
-		// Not a compressed payload. Nothing to do.
-		return nil, nil
+	decoder, ok := d.decoders[encoding]
+	if !ok {
+		return nil, fmt.Errorf("unsupported %s: %s", headerContentEncoding, encoding)
 	}
-	return nil, fmt.Errorf("unsupported %s: %s", headerContentEncoding, encoding)
+	return decoder(r.Body)
 }
 
 // defaultErrorHandler writes the error message in plain text.


### PR DESCRIPTION
This provides the ability to add support for compression types which are not supported in core, to be supported by individual components.

This change addresses an issue caused by https://github.com/open-telemetry/opentelemetry-collector/pull/7927, which prevents receivers that use confighttp from adding support for their content-encoding types easily. They still can by implementing an error handler, but that seems messy.

An alternative to this PR is to not return an error for an unsupported encoding type as was the case before https://github.com/open-telemetry/opentelemetry-collector/pull/7927

If the approach is acceptable, I will add the unit tests and changelog