### PR TITLE
Use strict mode to drive explicit behaviors when setting feature gates

### DIFF
--- a/.chloggen/featuregate_strict_mode.yaml
+++ b/.chloggen/featuregate_strict_mode.yaml
@@ -5,7 +5,7 @@ change_type: enhancement
 component: featuregate
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Use strict mode to drive explicit behaviors when setting feature gates
+note: Add a new flag to set feature gates with additional validation
 
 # One or more tracking issues or pull requests related to the change
 issues: [7804]
@@ -13,4 +13,8 @@ issues: [7804]
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
-subtext:
+subtext: |
+  In strict mode, the collector will perform additional checks on startup to validate the feature gates set:
+  * All alpha and beta feature gates must be set explicitly.
+  * All beta feature gates must be explicitly enabled.
+  * All stable feature gates must be left unset.

--- a/.chloggen/featuregate_strict_mode.yaml
+++ b/.chloggen/featuregate_strict_mode.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: featuregate
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Use strict mode to drive explicit behaviors when setting feature gates
+
+# One or more tracking issues or pull requests related to the change
+issues: [7804]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/featuregate_strict_mode.yaml
+++ b/.chloggen/featuregate_strict_mode.yaml
@@ -1,5 +1,5 @@
 # One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
-change_type: enhancement
+change_type: breaking
 
 # The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
 component: featuregate
@@ -18,3 +18,4 @@ subtext: |
   * All alpha and beta feature gates must be set explicitly.
   * All beta feature gates must be explicitly enabled.
   * All stable feature gates must be left unset.
+change_logs: [api, user]

--- a/.chloggen/featuregate_strict_mode.yaml
+++ b/.chloggen/featuregate_strict_mode.yaml
@@ -5,7 +5,7 @@ change_type: enhancement
 component: featuregate
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Add a new flag to set feature gates with additional validation
+note: "Add new flag `--feature-gates-strict` to set feature gates with additional validation"
 
 # One or more tracking issues or pull requests related to the change
 issues: [7804]

--- a/featuregate/README.md
+++ b/featuregate/README.md
@@ -56,7 +56,7 @@ This will enable `gate1` and `gate3` and disable `gate2`.
 
 Features gate can be executed in strict mode as well.
 
-To activate, use the flag `--feature-gates-strict=true`.
+To activate, use the flag `--feature-gates-strict`.
 
 When set, the flag adds validation rules:
 

--- a/featuregate/README.md
+++ b/featuregate/README.md
@@ -52,6 +52,21 @@ otelcol --config=config.yaml --feature-gates=gate1,-gate2,+gate3
 
 This will enable `gate1` and `gate3` and disable `gate2`.
 
+### Strict mode
+
+Features gate can be executed in strict mode as well. This mode uses the flag `--feature-gates-strict`.
+This flag is mutually exclusive flag with `--feature-gates`.
+
+The flag follows the same notation as the `--feature-gates` flag and is interpreted with additional rules by the collector:
+
+* If the feature gate is alpha, the collector will fail to start if the feature gate is not explicitly set, 
+whether it is enabled or disabled.
+* If the feature gate is considered beta and therefore enabled by default, the collector will fail if the gate is not enabled.
+* If the feature gate is stable, the strict mode fails if the feature gate flag is used.
+
+The strict mode is typically used when testing collector upgrades to ensure that changes to feature gates stability levels
+are tracked and explicitly managed as part of the upgrade.
+
 ## Feature Lifecycle
 
 Features controlled by a `Gate` should follow a three-stage lifecycle, 

--- a/featuregate/README.md
+++ b/featuregate/README.md
@@ -55,7 +55,6 @@ This will enable `gate1` and `gate3` and disable `gate2`.
 ### Strict mode
 
 Features gate can be executed in strict mode as well. This mode uses the flag `--feature-gates-strict`.
-This flag is mutually exclusive flag with `--feature-gates`.
 
 The flag follows the same notation as the `--feature-gates` flag and is interpreted with additional rules by the collector:
 

--- a/featuregate/README.md
+++ b/featuregate/README.md
@@ -56,7 +56,7 @@ This will enable `gate1` and `gate3` and disable `gate2`.
 
 Features gate can be executed in strict mode as well. This mode uses the flag `--feature-gates-strict`.
 
-The flag follows the same notation as the `--feature-gates` flag and is interpreted with additional rules by the collector:
+When set, the flag adds validation rules:
 
 * If the feature gate is alpha, the collector will fail to start if the feature gate is not explicitly set, 
 whether it is enabled or disabled.

--- a/featuregate/README.md
+++ b/featuregate/README.md
@@ -54,7 +54,9 @@ This will enable `gate1` and `gate3` and disable `gate2`.
 
 ### Strict mode
 
-Features gate can be executed in strict mode as well. This mode uses the flag `--feature-gates-strict`.
+Features gate can be executed in strict mode as well.
+
+To activate, use the flag `--feature-gates-strict=true`.
 
 When set, the flag adds validation rules:
 

--- a/featuregate/flag.go
+++ b/featuregate/flag.go
@@ -74,7 +74,7 @@ func (f *flagValue) Set(s string) error {
 			return
 		}
 		if f.reg.strict && !enabled && gate.stage == StageBeta {
-			errs = multierr.Append(errs, fmt.Errorf("gate %s must be explicitly enabled, remove strict mode to override", gate.id))
+			errs = multierr.Append(errs, fmt.Errorf("gate %q must be explicitly enabled, remove strict mode to override", gate.id))
 		}
 		if f.reg.strict && gate.stage == StageStable {
 			errs = multierr.Append(errs, fmt.Errorf("gate %q must not be set", gate.id))

--- a/featuregate/flag.go
+++ b/featuregate/flag.go
@@ -12,14 +12,14 @@ import (
 )
 
 // NewFlag returns a flag.Value that directly applies feature gate statuses to a Registry.
-func NewFlag(reg *Registry, strict bool) flag.Value {
+func NewFlag(reg *Registry, strict *bool) flag.Value {
 	return &flagValue{reg: reg, strict: strict}
 }
 
 // flagValue implements the flag.Value interface and directly applies feature gate statuses to a Registry.
 type flagValue struct {
 	reg    *Registry
-	strict bool
+	strict *bool
 }
 
 func (f *flagValue) String() string {
@@ -62,15 +62,15 @@ func (f *flagValue) Set(s string) error {
 	f.reg.VisitAll(func(gate *Gate) {
 		enabled, ok := gatesEnabled[gate.id]
 		if !ok {
-			if f.strict && (gate.stage == StageAlpha || gate.stage == StageBeta) {
+			if *f.strict && (gate.stage == StageAlpha || gate.stage == StageBeta) {
 				errs = multierr.Append(errs, fmt.Errorf("gate %q is in %s and is not explicitly configured", gate.id, gate.stage))
 			}
 			return
 		}
-		if f.strict && !enabled && gate.stage == StageBeta {
+		if *f.strict && !enabled && gate.stage == StageBeta {
 			errs = multierr.Append(errs, fmt.Errorf("gate %q is in beta and must be explicitly enabled", gate.id))
 		}
-		if f.strict && gate.stage == StageStable {
+		if *f.strict && gate.stage == StageStable {
 			errs = multierr.Append(errs, fmt.Errorf("gate %q is stable and must not be configured", gate.id))
 		}
 

--- a/featuregate/flag.go
+++ b/featuregate/flag.go
@@ -63,7 +63,7 @@ func (f *flagValue) Set(s string) error {
 		enabled, ok := gatesEnabled[gate.id]
 		if !ok {
 			if f.strict && (gate.stage == StageAlpha || gate.stage == StageBeta) {
-				errs = multierr.Append(errs, fmt.Errorf("gate %q is not explicitly configured", gate.id))
+				errs = multierr.Append(errs, fmt.Errorf("gate %q is in %s and is not explicitly configured", gate.id, gate.stage))
 			}
 			return
 		}

--- a/featuregate/flag.go
+++ b/featuregate/flag.go
@@ -63,15 +63,15 @@ func (f *flagValue) Set(s string) error {
 		enabled, ok := gatesEnabled[gate.id]
 		if !ok {
 			if f.strict && (gate.stage == StageAlpha || gate.stage == StageBeta) {
-				errs = multierr.Append(errs, fmt.Errorf("gate %q is not explicitly set", gate.id))
+				errs = multierr.Append(errs, fmt.Errorf("gate %q is not explicitly configured", gate.id))
 			}
 			return
 		}
 		if f.strict && !enabled && gate.stage == StageBeta {
-			errs = multierr.Append(errs, fmt.Errorf("gate %q must be explicitly enabled, remove strict mode to override", gate.id))
+			errs = multierr.Append(errs, fmt.Errorf("gate %q is in beta and must be explicitly enabled", gate.id))
 		}
 		if f.strict && gate.stage == StageStable {
-			errs = multierr.Append(errs, fmt.Errorf("gate %q must not be set", gate.id))
+			errs = multierr.Append(errs, fmt.Errorf("gate %q is stable and must not be configured", gate.id))
 		}
 
 		errs = multierr.Append(errs, f.reg.Set(gate.id, enabled))

--- a/featuregate/flag.go
+++ b/featuregate/flag.go
@@ -11,6 +11,13 @@ import (
 	"go.uber.org/multierr"
 )
 
+// NewFlag returns a flag.Value that directly applies feature gate statuses to a Registry.
+//
+// Deprecated: use NewFlags instead to get both gates and strict flags.
+func NewFlag(reg *Registry) flag.Value {
+	return &gatesFlagValue{args: &gateRegistrationArgs{reg: reg}}
+}
+
 // NewFlags returns two flag.Values: one that registers gates, and one that sets strict mode.
 func NewFlags(reg *Registry) (flag.Value, flag.Value) {
 	g := &gateRegistrationArgs{reg: reg}

--- a/featuregate/flag.go
+++ b/featuregate/flag.go
@@ -69,7 +69,7 @@ func (f *flagValue) Set(s string) error {
 		enabled, ok := gatesEnabled[gate.id]
 		if !ok {
 			if f.reg.strict && (gate.stage == StageAlpha || gate.stage == StageBeta) {
-				errs = multierr.Append(errs, fmt.Errorf("gate %s is not explicitly set", gate.id))
+				errs = multierr.Append(errs, fmt.Errorf("gate %q is not explicitly set", gate.id))
 			}
 			return
 		}

--- a/featuregate/flag.go
+++ b/featuregate/flag.go
@@ -63,7 +63,7 @@ func (f *flagValue) Set(s string) error {
 		enabled, ok := gatesEnabled[gate.id]
 		if !ok {
 			if *f.strict && (gate.stage == StageAlpha || gate.stage == StageBeta) {
-				errs = multierr.Append(errs, fmt.Errorf("gate %q is in %s and is not explicitly configured", gate.id, gate.stage))
+				errs = multierr.Append(errs, fmt.Errorf("gate %q is in %s and must be explicitly configured", gate.id, gate.stage))
 			}
 			return
 		}

--- a/featuregate/flag.go
+++ b/featuregate/flag.go
@@ -45,6 +45,10 @@ type strictFlagValue struct {
 	args *gateRegistrationArgs
 }
 
+func (f *strictFlagValue) IsBoolFlag() bool {
+	return true
+}
+
 func (f *strictFlagValue) String() string {
 	return fmt.Sprintf("%t", f.args.strict)
 }

--- a/featuregate/flag.go
+++ b/featuregate/flag.go
@@ -77,7 +77,7 @@ func (f *flagValue) Set(s string) error {
 			errs = multierr.Append(errs, fmt.Errorf("gate %s must be explicitly enabled, remove strict mode to override", gate.id))
 		}
 		if f.reg.strict && gate.stage == StageStable {
-			errs = multierr.Append(errs, fmt.Errorf("gate %s must not be set", gate.id))
+			errs = multierr.Append(errs, fmt.Errorf("gate %q must not be set", gate.id))
 		}
 
 		errs = multierr.Append(errs, f.reg.Set(gate.id, enabled))

--- a/featuregate/flag_test.go
+++ b/featuregate/flag_test.go
@@ -188,3 +188,15 @@ func TestNewFlag(t *testing.T) {
 		})
 	}
 }
+
+func TestStrictFlagValue_String(t *testing.T) {
+	s := strictFlagValue{args: &gateRegistrationArgs{strict: true}}
+	require.Equal(t, "true", s.String())
+	s.args.strict = false
+	require.Equal(t, "false", s.String())
+}
+
+func TestStrictFlagValue_IsBoolFlag(t *testing.T) {
+	s := strictFlagValue{args: &gateRegistrationArgs{strict: true}}
+	require.Equal(t, true, s.IsBoolFlag())
+}

--- a/featuregate/flag_test.go
+++ b/featuregate/flag_test.go
@@ -14,131 +14,151 @@ func TestNewFlag(t *testing.T) {
 	for _, tt := range []struct {
 		name           string
 		input          string
-		expectedSetErr bool
+		expectedSetErr string
 		expected       map[string]bool
 		expectedStr    string
+		strict         bool
 	}{
 		{
 			name:        "empty item",
 			input:       "",
 			expected:    map[string]bool{"alpha": false, "beta": true, "deprecated": false, "stable": true},
 			expectedStr: "-alpha,beta,-deprecated,stable",
+			strict:      false,
 		},
 		{
 			name:        "simple enable alpha",
 			input:       "alpha",
 			expected:    map[string]bool{"alpha": true, "beta": true, "deprecated": false, "stable": true},
 			expectedStr: "alpha,beta,-deprecated,stable",
+			strict:      false,
 		},
 		{
 			name:        "plus enable alpha",
 			input:       "+alpha",
 			expected:    map[string]bool{"alpha": true, "beta": true, "deprecated": false, "stable": true},
 			expectedStr: "alpha,beta,-deprecated,stable",
+			strict:      false,
 		},
 		{
 			name:        "disabled beta",
 			input:       "-beta",
 			expected:    map[string]bool{"alpha": false, "beta": false, "deprecated": false, "stable": true},
 			expectedStr: "-alpha,-beta,-deprecated,stable",
+			strict:      false,
 		},
 		{
 			name:        "multiple items",
 			input:       "-beta,alpha",
 			expected:    map[string]bool{"alpha": true, "beta": false, "deprecated": false, "stable": true},
 			expectedStr: "alpha,-beta,-deprecated,stable",
+			strict:      false,
 		},
 		{
 			name:        "multiple items with plus",
 			input:       "-beta,+alpha",
 			expected:    map[string]bool{"alpha": true, "beta": false, "deprecated": false, "stable": true},
 			expectedStr: "alpha,-beta,-deprecated,stable",
+			strict:      false,
 		},
 		{
 			name:        "repeated items",
 			input:       "alpha,-beta,-alpha",
 			expected:    map[string]bool{"alpha": false, "beta": false, "deprecated": false, "stable": true},
 			expectedStr: "-alpha,-beta,-deprecated,stable",
+			strict:      false,
 		},
 		{
 			name:        "multiple plus items",
 			input:       "+alpha,+beta",
 			expected:    map[string]bool{"alpha": true, "beta": true, "deprecated": false, "stable": true},
 			expectedStr: "alpha,beta,-deprecated,stable",
+			strict:      false,
 		},
 		{
 			name:        "enable stable",
 			input:       "stable",
 			expected:    map[string]bool{"alpha": false, "beta": true, "deprecated": false, "stable": true},
 			expectedStr: "-alpha,beta,-deprecated,stable",
+			strict:      false,
 		},
 		{
 			name:           "disable stable",
 			input:          "-stable",
-			expectedSetErr: true,
+			expectedSetErr: "feature gate \"stable\" is stable, can not be disabled",
 			expected:       map[string]bool{"alpha": false, "beta": true, "deprecated": false, "stable": true},
 			expectedStr:    "-alpha,beta,-deprecated,stable",
+			strict:         false,
 		},
 		{
 			name:           "enable deprecated",
 			input:          "deprecated",
-			expectedSetErr: true,
+			expectedSetErr: "feature gate \"deprecated\" is deprecated, can not be enabled",
 			expected:       map[string]bool{"alpha": false, "beta": true, "deprecated": false, "stable": true},
 			expectedStr:    "-alpha,beta,-deprecated,stable",
+			strict:         false,
 		},
 		{
 			name:        "disable deprecated",
 			input:       "-deprecated",
 			expected:    map[string]bool{"alpha": false, "beta": true, "deprecated": false, "stable": true},
 			expectedStr: "-alpha,beta,-deprecated,stable",
+			strict:      false,
 		},
 		{
 			name:           "enable missing",
 			input:          "missing",
-			expectedSetErr: true,
+			expectedSetErr: "missing",
 			expected:       map[string]bool{"alpha": false, "beta": true, "deprecated": false, "stable": true},
 			expectedStr:    "-alpha,beta,-deprecated,stable",
+			strict:         false,
 		},
 		{
 			name:           "disable missing",
 			input:          "missing",
-			expectedSetErr: true,
+			expectedSetErr: "missing",
 			expected:       map[string]bool{"alpha": false, "beta": true, "deprecated": false, "stable": true},
 			expectedStr:    "-alpha,beta,-deprecated,stable",
+			strict:         false,
 		},
 		{
 			name:        "strict mode",
-			input:       "strict,alpha,beta,-alpha",
+			input:       "alpha,beta,-alpha",
 			expected:    map[string]bool{"alpha": false, "beta": true, "deprecated": false, "stable": true},
-			expectedStr: "strict,-alpha,beta,-deprecated,stable",
+			expectedStr: "-alpha,beta,-deprecated,stable",
+			strict:      true,
 		},
 		{
 			name:           "strict mode but no alpha gate set",
-			input:          "strict,beta",
-			expectedSetErr: true,
+			input:          "beta",
+			expectedSetErr: "gate \"alpha\" is not explicitly set",
 			expected:       map[string]bool{"alpha": false, "beta": true, "deprecated": false, "stable": true},
-			expectedStr:    "strict,-alpha,beta,-deprecated,stable",
+			expectedStr:    "-alpha,beta,-deprecated,stable",
+			strict:         true,
 		},
 		{
 			name:           "strict mode but no beta gate set",
-			input:          "strict,alpha",
-			expectedSetErr: true,
+			input:          "alpha",
+			expectedSetErr: "gate \"beta\" is not explicitly set",
 			expected:       map[string]bool{"alpha": true, "beta": true, "deprecated": false, "stable": true},
-			expectedStr:    "strict,alpha,beta,-deprecated,stable",
+			expectedStr:    "alpha,beta,-deprecated,stable",
+			strict:         true,
 		},
 		{
 			name:           "strict mode but beta gate disabled",
-			input:          "strict,alpha,-beta",
-			expectedSetErr: true,
+			input:          "alpha,-beta",
+			expectedSetErr: "gate \"beta\" must be explicitly enabled, remove strict mode to override",
 			expected:       map[string]bool{"alpha": true, "beta": false, "deprecated": false, "stable": true},
-			expectedStr:    "strict,alpha,-beta,-deprecated,stable",
+			expectedStr:    "alpha,-beta,-deprecated,stable",
+			strict:         true,
 		},
 		{
 			name:           "strict mode but stable gate set",
-			input:          "strict,alpha,beta,stable",
-			expectedSetErr: true,
+			input:          "alpha,beta,stable",
+			expectedSetErr: "gate \"stable\" must not be set",
 			expected:       map[string]bool{"alpha": true, "beta": true, "deprecated": false, "stable": true},
-			expectedStr:    "strict,alpha,beta,-deprecated,stable",
+			expectedStr:    "alpha,beta,-deprecated,stable",
+			strict:         true,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
@@ -147,9 +167,9 @@ func TestNewFlag(t *testing.T) {
 			reg.MustRegister("beta", StageBeta)
 			reg.MustRegister("deprecated", StageDeprecated, WithRegisterToVersion("1.0.0"))
 			reg.MustRegister("stable", StageStable, WithRegisterToVersion("1.0.0"))
-			v := NewFlag(reg)
-			if tt.expectedSetErr {
-				require.Error(t, v.Set(tt.input))
+			v := NewFlag(reg, tt.strict)
+			if tt.expectedSetErr != "" {
+				require.ErrorContains(t, v.Set(tt.input), tt.expectedSetErr)
 			} else {
 				require.NoError(t, v.Set(tt.input))
 			}

--- a/featuregate/flag_test.go
+++ b/featuregate/flag_test.go
@@ -131,7 +131,7 @@ func TestNewFlag(t *testing.T) {
 		{
 			name:           "strict mode but no alpha gate set",
 			input:          "beta",
-			expectedSetErr: "gate \"alpha\" is not explicitly configured",
+			expectedSetErr: "gate \"alpha\" is in Alpha and is not explicitly configured",
 			expected:       map[string]bool{"alpha": false, "beta": true, "deprecated": false, "stable": true},
 			expectedStr:    "-alpha,beta,-deprecated,stable",
 			strict:         true,
@@ -139,7 +139,7 @@ func TestNewFlag(t *testing.T) {
 		{
 			name:           "strict mode but no beta gate set",
 			input:          "alpha",
-			expectedSetErr: "gate \"beta\" is not explicitly configured",
+			expectedSetErr: "gate \"beta\" is in Beta and is not explicitly configured",
 			expected:       map[string]bool{"alpha": true, "beta": true, "deprecated": false, "stable": true},
 			expectedStr:    "alpha,beta,-deprecated,stable",
 			strict:         true,

--- a/featuregate/flag_test.go
+++ b/featuregate/flag_test.go
@@ -131,7 +131,7 @@ func TestNewFlag(t *testing.T) {
 		{
 			name:           "strict mode but no alpha gate set",
 			input:          "beta",
-			expectedSetErr: "gate \"alpha\" is not explicitly set",
+			expectedSetErr: "gate \"alpha\" is not explicitly configured",
 			expected:       map[string]bool{"alpha": false, "beta": true, "deprecated": false, "stable": true},
 			expectedStr:    "-alpha,beta,-deprecated,stable",
 			strict:         true,
@@ -139,7 +139,7 @@ func TestNewFlag(t *testing.T) {
 		{
 			name:           "strict mode but no beta gate set",
 			input:          "alpha",
-			expectedSetErr: "gate \"beta\" is not explicitly set",
+			expectedSetErr: "gate \"beta\" is not explicitly configured",
 			expected:       map[string]bool{"alpha": true, "beta": true, "deprecated": false, "stable": true},
 			expectedStr:    "alpha,beta,-deprecated,stable",
 			strict:         true,
@@ -147,7 +147,7 @@ func TestNewFlag(t *testing.T) {
 		{
 			name:           "strict mode but beta gate disabled",
 			input:          "alpha,-beta",
-			expectedSetErr: "gate \"beta\" must be explicitly enabled, remove strict mode to override",
+			expectedSetErr: "gate \"beta\" is in beta and must be explicitly enabled",
 			expected:       map[string]bool{"alpha": true, "beta": false, "deprecated": false, "stable": true},
 			expectedStr:    "alpha,-beta,-deprecated,stable",
 			strict:         true,
@@ -155,7 +155,7 @@ func TestNewFlag(t *testing.T) {
 		{
 			name:           "strict mode but stable gate set",
 			input:          "alpha,beta,stable",
-			expectedSetErr: "gate \"stable\" must not be set",
+			expectedSetErr: "gate \"stable\" is stable and must not be configured",
 			expected:       map[string]bool{"alpha": true, "beta": true, "deprecated": false, "stable": true},
 			expectedStr:    "alpha,beta,-deprecated,stable",
 			strict:         true,

--- a/featuregate/flag_test.go
+++ b/featuregate/flag_test.go
@@ -131,7 +131,7 @@ func TestNewFlag(t *testing.T) {
 		{
 			name:           "strict mode but no alpha gate set",
 			input:          "beta",
-			expectedSetErr: "gate \"alpha\" is in Alpha and is not explicitly configured",
+			expectedSetErr: "gate \"alpha\" is in Alpha and must be explicitly configured",
 			expected:       map[string]bool{"alpha": false, "beta": true, "deprecated": false, "stable": true},
 			expectedStr:    "-alpha,beta,-deprecated,stable",
 			strict:         true,
@@ -139,7 +139,7 @@ func TestNewFlag(t *testing.T) {
 		{
 			name:           "strict mode but no beta gate set",
 			input:          "alpha",
-			expectedSetErr: "gate \"beta\" is in Beta and is not explicitly configured",
+			expectedSetErr: "gate \"beta\" is in Beta and must be explicitly configured",
 			expected:       map[string]bool{"alpha": true, "beta": true, "deprecated": false, "stable": true},
 			expectedStr:    "alpha,beta,-deprecated,stable",
 			strict:         true,

--- a/featuregate/flag_test.go
+++ b/featuregate/flag_test.go
@@ -167,18 +167,24 @@ func TestNewFlag(t *testing.T) {
 			reg.MustRegister("beta", StageBeta)
 			reg.MustRegister("deprecated", StageDeprecated, WithRegisterToVersion("1.0.0"))
 			reg.MustRegister("stable", StageStable, WithRegisterToVersion("1.0.0"))
-			v := NewFlag(reg, &tt.strict)
-			if tt.expectedSetErr != "" {
-				require.ErrorContains(t, v.Set(tt.input), tt.expectedSetErr)
+			gates, strict := NewFlags(reg)
+			if tt.strict {
+				require.NoError(t, strict.Set("true"))
 			} else {
-				require.NoError(t, v.Set(tt.input))
+				require.NoError(t, strict.Set(""))
+			}
+
+			if tt.expectedSetErr != "" {
+				require.ErrorContains(t, gates.Set(tt.input), tt.expectedSetErr)
+			} else {
+				require.NoError(t, gates.Set(tt.input))
 			}
 			got := map[string]bool{}
 			reg.VisitAll(func(g *Gate) {
 				got[g.ID()] = g.IsEnabled()
 			})
 			assert.Equal(t, tt.expected, got)
-			assert.Equal(t, tt.expectedStr, v.String())
+			assert.Equal(t, tt.expectedStr, gates.String())
 		})
 	}
 }

--- a/featuregate/flag_test.go
+++ b/featuregate/flag_test.go
@@ -106,6 +106,40 @@ func TestNewFlag(t *testing.T) {
 			expected:       map[string]bool{"alpha": false, "beta": true, "deprecated": false, "stable": true},
 			expectedStr:    "-alpha,beta,-deprecated,stable",
 		},
+		{
+			name:        "strict mode",
+			input:       "strict,alpha,beta,-alpha",
+			expected:    map[string]bool{"alpha": false, "beta": true, "deprecated": false, "stable": true},
+			expectedStr: "strict,-alpha,beta,-deprecated,stable",
+		},
+		{
+			name:           "strict mode but no alpha gate set",
+			input:          "strict,beta",
+			expectedSetErr: true,
+			expected:       map[string]bool{"alpha": false, "beta": true, "deprecated": false, "stable": true},
+			expectedStr:    "strict,-alpha,beta,-deprecated,stable",
+		},
+		{
+			name:           "strict mode but no beta gate set",
+			input:          "strict,alpha",
+			expectedSetErr: true,
+			expected:       map[string]bool{"alpha": true, "beta": true, "deprecated": false, "stable": true},
+			expectedStr:    "strict,alpha,beta,-deprecated,stable",
+		},
+		{
+			name:           "strict mode but beta gate disabled",
+			input:          "strict,alpha,-beta",
+			expectedSetErr: true,
+			expected:       map[string]bool{"alpha": true, "beta": false, "deprecated": false, "stable": true},
+			expectedStr:    "strict,alpha,-beta,-deprecated,stable",
+		},
+		{
+			name:           "strict mode but stable gate set",
+			input:          "strict,alpha,beta,stable",
+			expectedSetErr: true,
+			expected:       map[string]bool{"alpha": true, "beta": true, "deprecated": false, "stable": true},
+			expectedStr:    "strict,alpha,beta,-deprecated,stable",
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			reg := NewRegistry()

--- a/featuregate/flag_test.go
+++ b/featuregate/flag_test.go
@@ -167,7 +167,7 @@ func TestNewFlag(t *testing.T) {
 			reg.MustRegister("beta", StageBeta)
 			reg.MustRegister("deprecated", StageDeprecated, WithRegisterToVersion("1.0.0"))
 			reg.MustRegister("stable", StageStable, WithRegisterToVersion("1.0.0"))
-			v := NewFlag(reg, tt.strict)
+			v := NewFlag(reg, &tt.strict)
 			if tt.expectedSetErr != "" {
 				require.ErrorContains(t, v.Set(tt.input), tt.expectedSetErr)
 			} else {

--- a/featuregate/registry.go
+++ b/featuregate/registry.go
@@ -18,7 +18,8 @@ func GlobalRegistry() *Registry {
 }
 
 type Registry struct {
-	gates sync.Map
+	gates  sync.Map
+	strict bool
 }
 
 // NewRegistry returns a new empty Registry.

--- a/featuregate/registry.go
+++ b/featuregate/registry.go
@@ -18,8 +18,7 @@ func GlobalRegistry() *Registry {
 }
 
 type Registry struct {
-	gates  sync.Map
-	strict bool
+	gates sync.Map
 }
 
 // NewRegistry returns a new empty Registry.

--- a/otelcol/flags.go
+++ b/otelcol/flags.go
@@ -12,8 +12,9 @@ import (
 )
 
 const (
-	configFlag       = "config"
-	featureGatesFlag = "feature-gates"
+	configFlag             = "config"
+	featureGatesFlag       = "feature-gates"
+	featureGatesStrictFlag = "feature-gates-strict"
 )
 
 type configFlagValue struct {
@@ -50,8 +51,10 @@ func flags(reg *featuregate.Registry) *flag.FlagSet {
 			return nil
 		})
 
-	flagSet.Var(featuregate.NewFlag(reg), featureGatesFlag,
-		"Comma-delimited list of feature gate identifiers. Prefix with '-' to disable the feature. '+' or no prefix will enable the feature. Start with strict to enable strict mode.")
+	flagSet.Var(featuregate.NewFlag(reg, false), featureGatesFlag,
+		"Comma-delimited list of feature gate identifiers. Prefix with '-' to disable the feature. '+' or no prefix will enable the feature.")
+	flagSet.Var(featuregate.NewFlag(reg, true), featureGatesStrictFlag,
+		"Comma-delimited list of feature gate identifiers validated with strict mode. Prefix with '-' to disable the feature. '+' or no prefix will enable the feature.")
 
 	return flagSet
 }

--- a/otelcol/flags.go
+++ b/otelcol/flags.go
@@ -51,11 +51,12 @@ func flags(reg *featuregate.Registry) *flag.FlagSet {
 			return nil
 		})
 
-	flagSet.Var(featuregate.NewFlag(reg, false), featureGatesFlag,
-		"Comma-delimited list of feature gate identifiers. Prefix with '-' to disable the feature. '+' or no prefix will enable the feature.")
-	flagSet.Var(featuregate.NewFlag(reg, true), featureGatesStrictFlag,
-		"Comma-delimited list of feature gate identifiers validated with strict mode. Prefix with '-' to disable the feature. '+' or no prefix will enable the feature.")
+	strict := flagSet.Bool(featureGatesStrictFlag, false,
+		"Apply strict validation of feature gates.")
+	flag := featuregate.NewFlag(reg, strict)
 
+	flagSet.Var(flag, featureGatesFlag,
+		"Comma-delimited list of feature gate identifiers. Prefix with '-' to disable the feature. '+' or no prefix will enable the feature.")
 	return flagSet
 }
 

--- a/otelcol/flags.go
+++ b/otelcol/flags.go
@@ -51,11 +51,11 @@ func flags(reg *featuregate.Registry) *flag.FlagSet {
 			return nil
 		})
 
-	strict := flagSet.Bool(featureGatesStrictFlag, false,
+	gatesFlag, strictFlag := featuregate.NewFlags(reg)
+	flagSet.Var(strictFlag, featureGatesStrictFlag,
 		"Apply strict validation of feature gates.")
-	flag := featuregate.NewFlag(reg, strict)
 
-	flagSet.Var(flag, featureGatesFlag,
+	flagSet.Var(gatesFlag, featureGatesFlag,
 		"Comma-delimited list of feature gate identifiers. Prefix with '-' to disable the feature. '+' or no prefix will enable the feature.")
 	return flagSet
 }

--- a/otelcol/flags.go
+++ b/otelcol/flags.go
@@ -51,7 +51,7 @@ func flags(reg *featuregate.Registry) *flag.FlagSet {
 		})
 
 	flagSet.Var(featuregate.NewFlag(reg), featureGatesFlag,
-		"Comma-delimited list of feature gate identifiers. Prefix with '-' to disable the feature. '+' or no prefix will enable the feature.")
+		"Comma-delimited list of feature gate identifiers. Prefix with '-' to disable the feature. '+' or no prefix will enable the feature. Start with strict to enable strict mode.")
 
 	return flagSet
 }

--- a/otelcol/flags_test.go
+++ b/otelcol/flags_test.go
@@ -61,7 +61,7 @@ func TestSetFlag(t *testing.T) {
 		{
 			name:        "feature gates and strict",
 			args:        []string{"--feature-gates=alpha,-beta", "--feature-gates-strict=true"},
-			expectedErr: `invalid value "true" for flag -feature-gates-strict: gate "beta" is in beta and must be explicitly enabled`,
+			expectedErr: `invalid boolean value "true" for -feature-gates-strict: gate "beta" is in beta and must be explicitly enabled`,
 		},
 		{
 			name:        "strict flag first and feature gates",


### PR DESCRIPTION
**Description:** 
Implementation of a new feature gate flag that allows stricter validation of feature gate configuration.
This is useful when testing new versions of the collector to alert downstream maintainers that components have new or changed feature gates.

**Link to tracking Issue:**
#7804 

**Testing:**
Unit tests.

**Documentation:**
README changes.