### PR TITLE
Handle trailing slash on endpoint for otlphttp

### DIFF
--- a/.chloggen/otlphttpexporter-trailing-slash.yaml
+++ b/.chloggen/otlphttpexporter-trailing-slash.yaml
@@ -5,10 +5,10 @@ change_type: enhancement
 component: otlphttpexporter
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Add support for trailing slash in endpoint URL
+note: "Add support for trailing slash in endpoint URL"
 
 # One or more tracking issues or pull requests related to the change
-issues: []
+issues: [8084]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/otlphttpexporter-trailing-slash.yaml
+++ b/.chloggen/otlphttpexporter-trailing-slash.yaml
@@ -13,4 +13,4 @@ issues: [8084]
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
-subtext:
+subtext: URLs like `http://localhost:4318/` will now be treated as if they were `http://localhost:4318`

--- a/.chloggen/otlphttpexporter-trailing-slash.yaml
+++ b/.chloggen/otlphttpexporter-trailing-slash.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: otlphttpexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add support for trailing slash in endpoint URL
+
+# One or more tracking issues or pull requests related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/otlphttpexporter-trailing-slash.yaml
+++ b/.chloggen/otlphttpexporter-trailing-slash.yaml
@@ -5,7 +5,7 @@ change_type: enhancement
 component: otlphttpexporter
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: "Add support for trailing slash in endpoint URL"
+note: Add support for trailing slash in endpoint URL
 
 # One or more tracking issues or pull requests related to the change
 issues: [8084]

--- a/exporter/otlphttpexporter/factory.go
+++ b/exporter/otlphttpexporter/factory.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/url"
 	"time"
+	"strings"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configcompression"
@@ -61,7 +62,7 @@ func composeSignalURL(oCfg *Config, signalOverrideURL string, signalName string)
 	case oCfg.Endpoint == "":
 		return "", fmt.Errorf("either endpoint or %s_endpoint must be specified", signalName)
 	default:
-		if oCfg.Endpoint[len(oCfg.Endpoint)-1] == '/' {
+		if strings.HasSuffix(oCfg.Endpoint, "/") {
 			return oCfg.Endpoint + "v1/" + signalName, nil
 		}
 		return oCfg.Endpoint + "/v1/" + signalName, nil

--- a/exporter/otlphttpexporter/factory.go
+++ b/exporter/otlphttpexporter/factory.go
@@ -7,8 +7,8 @@ import (
 	"context"
 	"fmt"
 	"net/url"
-	"time"
 	"strings"
+	"time"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configcompression"

--- a/exporter/otlphttpexporter/factory.go
+++ b/exporter/otlphttpexporter/factory.go
@@ -61,6 +61,9 @@ func composeSignalURL(oCfg *Config, signalOverrideURL string, signalName string)
 	case oCfg.Endpoint == "":
 		return "", fmt.Errorf("either endpoint or %s_endpoint must be specified", signalName)
 	default:
+		if oCfg.Endpoint[len(oCfg.Endpoint)-1] == '/' {
+			return oCfg.Endpoint + "v1/" + signalName, nil
+		}
 		return oCfg.Endpoint + "/v1/" + signalName, nil
 	}
 }

--- a/exporter/otlphttpexporter/factory_test.go
+++ b/exporter/otlphttpexporter/factory_test.go
@@ -193,3 +193,20 @@ func TestCreateLogsExporter(t *testing.T) {
 	require.Nil(t, err)
 	require.NotNil(t, oexp)
 }
+
+func TestComposeSignalURL(t *testing.T) {
+	factory := NewFactory()
+	cfg := factory.CreateDefaultConfig().(*Config)
+
+	// Has slash at end
+	cfg.HTTPClientSettings.Endpoint = "http://www.gooddeals.com/"
+	url, err := composeSignalURL(cfg, "", "traces")
+	require.NoError(t, err)
+	assert.Equal(t, "http://www.gooddeals.com/v1/traces", url)
+
+	// No slash at end
+	cfg.HTTPClientSettings.Endpoint = "http://www.gooddeals.com"
+	url, err = composeSignalURL(cfg, "", "traces")
+	require.NoError(t, err)
+	assert.Equal(t, "http://www.gooddeals.com/v1/traces", url)
+}

--- a/exporter/otlphttpexporter/factory_test.go
+++ b/exporter/otlphttpexporter/factory_test.go
@@ -199,14 +199,14 @@ func TestComposeSignalURL(t *testing.T) {
 	cfg := factory.CreateDefaultConfig().(*Config)
 
 	// Has slash at end
-	cfg.HTTPClientSettings.Endpoint = "http://www.gooddeals.com/"
+	cfg.HTTPClientSettings.Endpoint = "http://localhost:4318/"
 	url, err := composeSignalURL(cfg, "", "traces")
 	require.NoError(t, err)
-	assert.Equal(t, "http://www.gooddeals.com/v1/traces", url)
+	assert.Equal(t, "http://localhost:4318/v1/traces", url)
 
 	// No slash at end
-	cfg.HTTPClientSettings.Endpoint = "http://www.gooddeals.com"
+	cfg.HTTPClientSettings.Endpoint = "http://localhost:4318"
 	url, err = composeSignalURL(cfg, "", "traces")
 	require.NoError(t, err)
-	assert.Equal(t, "http://www.gooddeals.com/v1/traces", url)
+	assert.Equal(t, "http://localhost:4318/v1/traces", url)
 }


### PR DESCRIPTION
This makes it so we don't put a double slash on the endpoint for otlphttp when it exists.

The spec says that this kind of stuff should be handled w.r.t. the OTEL_EXPORTER_OTLP_ENDPOINT env var and says nothing about programmatic handling of this config. But I still think it's a worthwhile change on a common-ish[1] ergonomic issue.

[1] while the collector isn't the only source of this, at honeycomb we emitted an error related to a misconfigured otlphttp endpoint ~2.5 million times over the past month

fixes https://github.com/open-telemetry/opentelemetry-collector/issues/8084