### PR TITLE
[chore] add retry for coverage upload

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -185,11 +185,15 @@ jobs:
       - name: Run Unit Tests With Coverage
         run: make gotest-with-cover
       - name: Upload coverage report
-        uses: codecov/codecov-action@v3
+        uses: Wandalen/wretry.action@v1.3.0
         with:
-          file: ./coverage.txt
-          fail_ci_if_error: true
-          verbose: true
+          action: codecov/codecov-action@v3
+          with: |
+            file: ./coverage.txt
+            fail_ci_if_error: true
+            verbose: true
+          attempt_limit: 10
+          attempt_delay: 15000
 
   cross-build-collector:
     needs: [setup-environment]


### PR DESCRIPTION
This is using the same gh action as in contrib to
address failing coverage upload actions.

Fix https://github.com/open-telemetry/opentelemetry-collector/issues/7131