### PR TITLE
add stdout exporter support

### DIFF
--- a/.chloggen/codeboten_add-console-exporter.yaml
+++ b/.chloggen/codeboten_add-console-exporter.yaml
@@ -1,0 +1,18 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: service
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add support for exporting internal metrics to the console
+
+# One or more tracking issues or pull requests related to the change
+issues: [7641]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Internal collector metrics can now be exported to the console
+  using the otel-go stdout exporter.

--- a/cmd/otelcorecol/go.mod
+++ b/cmd/otelcorecol/go.mod
@@ -94,6 +94,7 @@ require (
 	go.opentelemetry.io/otel v1.16.0 // indirect
 	go.opentelemetry.io/otel/bridge/opencensus v0.39.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.39.0 // indirect
+	go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v0.39.0 // indirect
 	go.opentelemetry.io/otel/metric v1.16.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.16.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v0.39.0 // indirect

--- a/cmd/otelcorecol/go.sum
+++ b/cmd/otelcorecol/go.sum
@@ -1026,6 +1026,8 @@ go.opentelemetry.io/otel/bridge/opencensus v0.39.0 h1:YHivttTaDhbZIHuPlg1sWsy2P5
 go.opentelemetry.io/otel/bridge/opencensus v0.39.0/go.mod h1:vZ4537pNjFDXEx//WldAR6Ro2LC8wwmFC76njAXwNPE=
 go.opentelemetry.io/otel/exporters/prometheus v0.39.0 h1:whAaiHxOatgtKd+w0dOi//1KUxj3KoPINZdtDaDj3IA=
 go.opentelemetry.io/otel/exporters/prometheus v0.39.0/go.mod h1:4jo5Q4CROlCpSPsXLhymi+LYrDXd2ObU5wbKayfZs7Y=
+go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v0.39.0 h1:fl2WmyenEf6LYYlfHAtCUEDyGcpwJNqD4dHGO7PVm4w=
+go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v0.39.0/go.mod h1:csyQxQ0UHHKVA8KApS7eUO/klMO5sd/av5CNZNU4O6w=
 go.opentelemetry.io/otel/metric v1.16.0 h1:RbrpwVG1Hfv85LgnZ7+txXioPDoh6EdbZHo26Q3hqOo=
 go.opentelemetry.io/otel/metric v1.16.0/go.mod h1:QE47cpOmkwipPiefDwo2wDzwJrlfxxNYodqc4xnGCo4=
 go.opentelemetry.io/otel/sdk v1.16.0 h1:Z1Ok1YsijYL0CSJpHt4cS3wDDh7p572grzNrBMiMWgE=

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	go.opentelemetry.io/otel v1.16.0
 	go.opentelemetry.io/otel/bridge/opencensus v0.39.0
 	go.opentelemetry.io/otel/exporters/prometheus v0.39.0
+	go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v0.39.0
 	go.opentelemetry.io/otel/metric v1.16.0
 	go.opentelemetry.io/otel/sdk v1.16.0
 	go.opentelemetry.io/otel/sdk/metric v0.39.0

--- a/go.sum
+++ b/go.sum
@@ -411,6 +411,8 @@ go.opentelemetry.io/otel/bridge/opencensus v0.39.0 h1:YHivttTaDhbZIHuPlg1sWsy2P5
 go.opentelemetry.io/otel/bridge/opencensus v0.39.0/go.mod h1:vZ4537pNjFDXEx//WldAR6Ro2LC8wwmFC76njAXwNPE=
 go.opentelemetry.io/otel/exporters/prometheus v0.39.0 h1:whAaiHxOatgtKd+w0dOi//1KUxj3KoPINZdtDaDj3IA=
 go.opentelemetry.io/otel/exporters/prometheus v0.39.0/go.mod h1:4jo5Q4CROlCpSPsXLhymi+LYrDXd2ObU5wbKayfZs7Y=
+go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v0.39.0 h1:fl2WmyenEf6LYYlfHAtCUEDyGcpwJNqD4dHGO7PVm4w=
+go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v0.39.0/go.mod h1:csyQxQ0UHHKVA8KApS7eUO/klMO5sd/av5CNZNU4O6w=
 go.opentelemetry.io/otel/metric v1.16.0 h1:RbrpwVG1Hfv85LgnZ7+txXioPDoh6EdbZHo26Q3hqOo=
 go.opentelemetry.io/otel/metric v1.16.0/go.mod h1:QE47cpOmkwipPiefDwo2wDzwJrlfxxNYodqc4xnGCo4=
 go.opentelemetry.io/otel/sdk v1.16.0 h1:Z1Ok1YsijYL0CSJpHt4cS3wDDh7p572grzNrBMiMWgE=

--- a/service/internal/proctelemetry/config_test.go
+++ b/service/internal/proctelemetry/config_test.go
@@ -80,6 +80,27 @@ func TestMetricReader(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "periodic/invalid-exporter",
+			reader: telemetry.MetricReader{
+				Periodic: &telemetry.PeriodicMetricReader{
+					Exporter: telemetry.MetricExporter{
+						Prometheus: &telemetry.Prometheus{
+							Host: strPtr("locahost"),
+							Port: intPtr(8080),
+						},
+					},
+				},
+			},
+			err: errors.New("no valid exporter"),
+		},
+		{
+			name: "periodic/no-exporter",
+			reader: telemetry.MetricReader{
+				Periodic: &telemetry.PeriodicMetricReader{},
+			},
+			err: errors.New("no valid exporter"),
+		},
 	}
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {

--- a/service/internal/proctelemetry/config_test.go
+++ b/service/internal/proctelemetry/config_test.go
@@ -101,6 +101,16 @@ func TestMetricReader(t *testing.T) {
 			},
 			err: errors.New("no valid exporter"),
 		},
+		{
+			name: "periodic/console-exporter",
+			reader: telemetry.MetricReader{
+				Periodic: &telemetry.PeriodicMetricReader{
+					Exporter: telemetry.MetricExporter{
+						Console: telemetry.Console{},
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {

--- a/service/telemetry/config.go
+++ b/service/telemetry/config.go
@@ -152,6 +152,12 @@ func (mr *MetricReader) Unmarshal(conf *confmap.Conf) error {
 		}
 		return nil
 	}
+	if mr.Periodic != nil {
+		if mr.Periodic.Exporter.Console == nil {
+			return fmt.Errorf("invalid exporter configuration")
+		}
+		return nil
+	}
 
 	return fmt.Errorf("unsupported metric reader type %s", conf.AllKeys())
 }

--- a/service/telemetry/config_test.go
+++ b/service/telemetry/config_test.go
@@ -133,6 +133,23 @@ func TestUnmarshalMetricReader(t *testing.T) {
 				},
 			}}),
 		},
+		{
+			name: "valid periodic reader type, valid console exporter",
+			cfg: confmap.NewFromStringMap(map[string]any{"periodic": PeriodicMetricReader{
+				Exporter: MetricExporter{
+					Console: Console{},
+				},
+			}}),
+		},
+		{
+			name: "valid periodic reader type, invalid console exporter",
+			cfg: confmap.NewFromStringMap(map[string]any{"periodic": PeriodicMetricReader{
+				Exporter: MetricExporter{
+					Prometheus: &Prometheus{},
+				},
+			}}),
+			err: "invalid exporter configuration",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Internal metrics can now be additionally configure to export using the stdout exporter.

Linked issue: https://github.com/open-telemetry/opentelemetry-collector/issues/7641
