### PR TITLE
add support for periodic reader interval/timeout

### DIFF
--- a/.chloggen/codeboten_add-periodic-internal-timeout.yaml
+++ b/.chloggen/codeboten_add-periodic-internal-timeout.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: service
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Add support for `interval` and `timeout` configuration in periodic reader"
+
+# One or more tracking issues or pull requests related to the change
+issues: [7641]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/service/internal/proctelemetry/config_test.go
+++ b/service/internal/proctelemetry/config_test.go
@@ -111,6 +111,18 @@ func TestMetricReader(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "periodic/console-exporter-with-timeout-interval",
+			reader: telemetry.MetricReader{
+				Periodic: &telemetry.PeriodicMetricReader{
+					Interval: intPtr(10),
+					Timeout:  intPtr(5),
+					Exporter: telemetry.MetricExporter{
+						Console: telemetry.Console{},
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
This adds support for configuring `timeout` and `interval` options for the periodic metric exporter.

Linked issue: #7641