### PR TITLE
[chore] Update release schedule

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -134,11 +134,10 @@ The following documents the procedure to release a bugfix
 
 | Date       | Version | Release manager |
 |------------|---------|-----------------|
-| 2023-07-17 | v0.82.0 | @jpkrohling     |
-| 2023-07-31 | v0.83.0 | @djaglowski     |
-| 2023-08-14 | v0.84.0 | @dmitryax       |
-| 2023-08-28 | v0.85.0 | @codeboten      |
-| 2023-09-11 | v0.86.0 | @codeboten      |
-| 2023-09-25 | v0.87.0 | @bogdandrutu    |
-| 2023-10-09 | v0.88.0 | @Aneurysm9      |
-| 2023-10-23 | v0.89.0 | @mx-psi         |
+| 2023-08-14 | v0.83.0 | @djaglowski     |
+| 2023-08-28 | v0.84.0 | @dmitryax       |
+| 2023-09-11 | v0.85.0 | @codeboten      |
+| 2023-09-25 | v0.86.0 | @bogdandrutu    |
+| 2023-10-09 | v0.87.0 | @Aneurysm9      |
+| 2023-10-23 | v0.88.0 | @mx-psi         |
+| 2023-11-06 | v0.89.0 | @jpkrohling     |


### PR DESCRIPTION
- v0.82.0 release was delayed but is underway today
- Since we've nearly reached the original release date for v0.83.0, push future release schedule by 2 weeks
- @codeboten was scheduled for 2 sequential releases. Rather than shift dates for all release managers, only shift those up until @codeboten's first scheduled release. This elimates the double release and changes scheduled dates only for myself and @dmitryax.