### PR TITLE
Revert usage of multimod for diff between versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -435,8 +435,44 @@ push-tags: $(MULTIMOD)
 	done;
 
 .PHONY: check-changes
-check-changes: $(MULTIMOD)
-	$(MULTIMOD) diff -p $(PREVIOUS_VERSION) -m $(MODSET)
+check-changes: $(YQ)
+ifndef MODSET
+	@echo "MODSET not defined"
+	@echo "usage: make check-changes PREVIOUS_VERSION=<version eg 0.52.0> MODSET=beta"
+	exit 1
+endif
+ifndef PREVIOUS_VERSION
+	@echo "PREVIOUS_VERSION not defined"
+	@echo "usage: make check-changes PREVIOUS_VERSION=<version eg 0.52.0> MODSET=beta"
+	exit 1
+else
+ifeq (, $(findstring v,$(PREVIOUS_VERSION)))
+NORMALIZED_PREVIOUS_VERSION="v$(PREVIOUS_VERSION)"
+else
+NORMALIZED_PREVIOUS_VERSION="$(PREVIOUS_VERSION)"
+endif
+endif
+	@all_submods=$$($(YQ) e '.module-sets.*.modules[] | select(. != "go.opentelemetry.io/collector")' versions.yaml | sed 's/^go\.opentelemetry\.io\/collector\///'); \
+	mods=$$($(YQ) e '.module-sets.$(MODSET).modules[]' versions.yaml | sed 's/^go\.opentelemetry\.io\/collector\///'); \
+	changed_files=""; \
+	for mod in $${mods}; do \
+		if [ "$${mod}" == "go.opentelemetry.io/collector" ]; then \
+			changed_files+=$$(git diff --name-only $(NORMALIZED_PREVIOUS_VERSION) -- $$(printf '%s\n' $${all_submods[@]} | sed 's/^/:!/' | paste -sd' ' -) | grep -E '.+\.go$$'); \
+		elif ! git rev-parse --quiet --verify $${mod}/$(NORMALIZED_PREVIOUS_VERSION) >/dev/null; then \
+			echo "Module $${mod} does not have a $(NORMALIZED_PREVIOUS_VERSION) tag"; \
+			echo "$(MODSET) release is required."; \
+			exit 0; \
+		else \
+			changed_files+=$$(git diff --name-only $${mod}/$(NORMALIZED_PREVIOUS_VERSION) -- $${mod} | grep -E '.+\.go$$'); \
+		fi; \
+	done; \
+	if [ -n "$${changed_files}" ]; then \
+		echo "The following files changed in $(MODSET) modules since $(NORMALIZED_PREVIOUS_VERSION): $${changed_files}"; \
+	else \
+		echo "No $(MODSET) modules have changed since $(NORMALIZED_PREVIOUS_VERSION)"; \
+		echo "No need to release $(MODSET)."; \
+		exit 1; \
+	fi
 
 .PHONY: prepare-release
 prepare-release:


### PR DESCRIPTION
This PR reverts #8024, as it introduced a new behavior, causing the release to be blocked.

Apparently, multimod has a return code of 1 when diffs are seen, causing the prepare-release target to break. After this release, we can try to get multimod to behave in the same way as this PR.

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>
