### PR TITLE
fix(receiver/otlpreceiver): make the configuration HttpServerSettings public

### DIFF
--- a/receiver/otlpreceiver/config.go
+++ b/receiver/otlpreceiver/config.go
@@ -21,7 +21,7 @@ const (
 	protoHTTP = "protocols::http"
 )
 
-type httpServerSettings struct {
+type HttpServerSettings struct {
 	*confighttp.HTTPServerSettings `mapstructure:",squash"`
 
 	// The URL path to receive traces on. If omitted "/v1/traces" will be used.
@@ -37,7 +37,7 @@ type httpServerSettings struct {
 // Protocols is the configuration for the supported protocols.
 type Protocols struct {
 	GRPC *configgrpc.GRPCServerSettings `mapstructure:"grpc"`
-	HTTP *httpServerSettings            `mapstructure:"http"`
+	HTTP *HttpServerSettings            `mapstructure:"http"`
 }
 
 // Config defines configuration for OTLP receiver.

--- a/receiver/otlpreceiver/config_test.go
+++ b/receiver/otlpreceiver/config_test.go
@@ -115,7 +115,7 @@ func TestUnmarshalConfig(t *testing.T) {
 						},
 					},
 				},
-				HTTP: &httpServerSettings{
+				HTTP: &HttpServerSettings{
 					HTTPServerSettings: &confighttp.HTTPServerSettings{
 						Endpoint: "0.0.0.0:4318",
 						TLSSetting: &configtls.TLSServerSetting{
@@ -154,7 +154,7 @@ func TestUnmarshalConfigUnix(t *testing.T) {
 					},
 					ReadBufferSize: 512 * 1024,
 				},
-				HTTP: &httpServerSettings{
+				HTTP: &HttpServerSettings{
 					HTTPServerSettings: &confighttp.HTTPServerSettings{
 						Endpoint: "/tmp/http_otlp.sock",
 					},

--- a/receiver/otlpreceiver/factory.go
+++ b/receiver/otlpreceiver/factory.go
@@ -48,7 +48,7 @@ func createDefaultConfig() component.Config {
 				// We almost write 0 bytes, so no need to tune WriteBufferSize.
 				ReadBufferSize: 512 * 1024,
 			},
-			HTTP: &httpServerSettings{
+			HTTP: &HttpServerSettings{
 				HTTPServerSettings: &confighttp.HTTPServerSettings{
 					Endpoint: defaultHTTPEndpoint,
 				},

--- a/receiver/otlpreceiver/factory_test.go
+++ b/receiver/otlpreceiver/factory_test.go
@@ -51,7 +51,7 @@ func TestCreateTracesReceiver(t *testing.T) {
 			Transport: "tcp",
 		},
 	}
-	defaultHTTPSettings := &httpServerSettings{
+	defaultHTTPSettings := &HttpServerSettings{
 		HTTPServerSettings: &confighttp.HTTPServerSettings{
 			Endpoint: testutil.GetAvailableLocalAddress(t),
 		},
@@ -94,7 +94,7 @@ func TestCreateTracesReceiver(t *testing.T) {
 			cfg: &Config{
 				Protocols: Protocols{
 					GRPC: defaultGRPCSettings,
-					HTTP: &httpServerSettings{
+					HTTP: &HttpServerSettings{
 						HTTPServerSettings: &confighttp.HTTPServerSettings{
 							Endpoint: "localhost:112233",
 						},
@@ -132,7 +132,7 @@ func TestCreateMetricReceiver(t *testing.T) {
 			Transport: "tcp",
 		},
 	}
-	defaultHTTPSettings := &httpServerSettings{
+	defaultHTTPSettings := &HttpServerSettings{
 		HTTPServerSettings: &confighttp.HTTPServerSettings{
 			Endpoint: testutil.GetAvailableLocalAddress(t),
 		},
@@ -175,7 +175,7 @@ func TestCreateMetricReceiver(t *testing.T) {
 			cfg: &Config{
 				Protocols: Protocols{
 					GRPC: defaultGRPCSettings,
-					HTTP: &httpServerSettings{
+					HTTP: &HttpServerSettings{
 						HTTPServerSettings: &confighttp.HTTPServerSettings{
 							Endpoint: "327.0.0.1:1122",
 						},
@@ -212,7 +212,7 @@ func TestCreateLogReceiver(t *testing.T) {
 			Transport: "tcp",
 		},
 	}
-	defaultHTTPSettings := &httpServerSettings{
+	defaultHTTPSettings := &HttpServerSettings{
 		HTTPServerSettings: &confighttp.HTTPServerSettings{
 			Endpoint: testutil.GetAvailableLocalAddress(t),
 		},
@@ -259,7 +259,7 @@ func TestCreateLogReceiver(t *testing.T) {
 			cfg: &Config{
 				Protocols: Protocols{
 					GRPC: defaultGRPCSettings,
-					HTTP: &httpServerSettings{
+					HTTP: &HttpServerSettings{
 						HTTPServerSettings: &confighttp.HTTPServerSettings{
 							Endpoint: "327.0.0.1:1122",
 						},
@@ -275,7 +275,7 @@ func TestCreateLogReceiver(t *testing.T) {
 			cfg: &Config{
 				Protocols: Protocols{
 					GRPC: defaultGRPCSettings,
-					HTTP: &httpServerSettings{
+					HTTP: &HttpServerSettings{
 						HTTPServerSettings: &confighttp.HTTPServerSettings{
 							Endpoint: "127.0.0.1:1122",
 						},

--- a/receiver/otlpreceiver/otlp_test.go
+++ b/receiver/otlpreceiver/otlp_test.go
@@ -201,7 +201,7 @@ func TestHandleInvalidRequests(t *testing.T) {
 	endpoint := testutil.GetAvailableLocalAddress(t)
 	cfg := &Config{
 		Protocols: Protocols{
-			HTTP: &httpServerSettings{
+			HTTP: &HttpServerSettings{
 				HTTPServerSettings: &confighttp.HTTPServerSettings{
 					Endpoint: endpoint,
 				},
@@ -900,7 +900,7 @@ func TestGRPCMaxRecvSize(t *testing.T) {
 func TestHTTPInvalidTLSCredentials(t *testing.T) {
 	cfg := &Config{
 		Protocols: Protocols{
-			HTTP: &httpServerSettings{
+			HTTP: &HttpServerSettings{
 				HTTPServerSettings: &confighttp.HTTPServerSettings{
 					Endpoint: testutil.GetAvailableLocalAddress(t),
 					TLSSetting: &configtls.TLSServerSetting{
@@ -933,7 +933,7 @@ func testHTTPMaxRequestBodySizeJSON(t *testing.T, payload []byte, size int, expe
 	url := fmt.Sprintf("http://%s/v1/traces", endpoint)
 	cfg := &Config{
 		Protocols: Protocols{
-			HTTP: &httpServerSettings{
+			HTTP: &HttpServerSettings{
 				HTTPServerSettings: &confighttp.HTTPServerSettings{
 					Endpoint:           endpoint,
 					MaxRequestBodySize: int64(size),


### PR DESCRIPTION
**Description:** Make the configuration for the OTLP Receiver httpServerSettings to be public
Fixing the bug opened  #8175 

**Link to tracking Issue:**#8175