### PR TITLE
Add omits to confighttp's TLSSetting and CustomRoundTripper fields

### DIFF
--- a/.chloggen/tlsomit.yaml
+++ b/.chloggen/tlsomit.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: confighttp
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Add mapstructure omits to CustomRoundTripper and TLSSetting fields for confighttp"
+
+# One or more tracking issues or pull requests related to the change
+issues: [8211]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/config/confighttp/confighttp.go
+++ b/config/confighttp/confighttp.go
@@ -50,7 +50,7 @@ type HTTPClientSettings struct {
 	Headers map[string]configopaque.String `mapstructure:"headers"`
 
 	// Custom Round Tripper to allow for individual components to intercept HTTP requests
-	CustomRoundTripper func(next http.RoundTripper) (http.RoundTripper, error)
+	CustomRoundTripper func(next http.RoundTripper) (http.RoundTripper, error) `mapstructure:"-"`
 
 	// Auth configuration for outgoing HTTP calls.
 	Auth *configauth.Authentication `mapstructure:"auth"`

--- a/config/confighttp/confighttp.go
+++ b/config/confighttp/confighttp.go
@@ -33,7 +33,7 @@ type HTTPClientSettings struct {
 	Endpoint string `mapstructure:"endpoint"`
 
 	// TLSSetting struct exposes TLS client configuration.
-	TLSSetting configtls.TLSClientSetting `mapstructure:"tls"`
+	TLSSetting configtls.TLSClientSetting `mapstructure:"tls,omitempty"`
 
 	// ReadBufferSize for HTTP client. See http.Transport.ReadBufferSize.
 	ReadBufferSize int `mapstructure:"read_buffer_size"`


### PR DESCRIPTION
**Description:**
- Adds `omitempty` mapstructure tag to confighttp's `TLSSetting` field - The [resourcedetection](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/resourcedetectionprocessor/README.md) processor defined in opentelemetry-collector-contrib panics with a nullpointer exception when the default values are used. 
- Adds ignore to CustomRoundtripper - The resourcedetection processor cannot be marshalled due to the `CustomRoundTripper` field being of type function. To allow marshalling we ignore this field.


**Testing:** ensured all current tests pass. `make gotest`
