### PR TITLE
Add support for linux/s390x architecture

### DIFF
--- a/.chloggen/s390x-platform-enablement.yaml
+++ b/.chloggen/s390x-platform-enablement.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: supported platforms
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add `linux/s390x` architecture to cross build tests in CI
+
+# One or more tracking issues or pull requests related to the change
+issues: [8213]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -238,6 +238,8 @@ jobs:
           - goos: linux
             goarch: arm
             goarm: 7
+          - goos: linux
+            goarch: s390x
           - goos: windows
             goarch: 386
           - goos: windows


### PR DESCRIPTION
The `s390x` CPU architecture is the base for IBM zSeries (aka mainframe) systems. It is beneficial for users of this platform to have a supported way to install pre-compiled binaries for the OpenTelemetry collector in a Linux environment. This issue and associated pull requests will enable the building of all relevant binary artifacts for `linux/s390x` as part of the regular CI pipeline.

IBM has performed tests internally to ensure successful build (via cross-compilation) and runtime (on native platform) integrity of the OpenTelemetry collector (core and contrib) via the unit test suites and specific use-cases.

For more information and discussion please refer to the initial feature request issue (open-telemetry/opentelemetry-collector-releases#378).

Resolves: #8213