### PR TITLE
[chore] migrate obsreport to use errors.Join instead of go.uber.org/multierr

### DIFF
--- a/obsreport/obsreport_exporter.go
+++ b/obsreport/obsreport_exporter.go
@@ -11,7 +11,6 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
-	"go.uber.org/multierr"
 	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/component"
@@ -89,37 +88,37 @@ func (exp *Exporter) createOtelMetrics(cfg ExporterSettings) error {
 		obsmetrics.ExporterPrefix+obsmetrics.SentSpansKey,
 		metric.WithDescription("Number of spans successfully sent to destination."),
 		metric.WithUnit("1"))
-	errors = multierr.Append(errors, err)
+	errors = errors.Join(errors, err)
 
 	exp.failedToSendSpans, err = meter.Int64Counter(
 		obsmetrics.ExporterPrefix+obsmetrics.FailedToSendSpansKey,
 		metric.WithDescription("Number of spans in failed attempts to send to destination."),
 		metric.WithUnit("1"))
-	errors = multierr.Append(errors, err)
+	errors = errors.Join(errors, err)
 
 	exp.sentMetricPoints, err = meter.Int64Counter(
 		obsmetrics.ExporterPrefix+obsmetrics.SentMetricPointsKey,
 		metric.WithDescription("Number of metric points successfully sent to destination."),
 		metric.WithUnit("1"))
-	errors = multierr.Append(errors, err)
+	errors = errors.Join(errors, err)
 
 	exp.failedToSendMetricPoints, err = meter.Int64Counter(
 		obsmetrics.ExporterPrefix+obsmetrics.FailedToSendMetricPointsKey,
 		metric.WithDescription("Number of metric points in failed attempts to send to destination."),
 		metric.WithUnit("1"))
-	errors = multierr.Append(errors, err)
+	errors = errors.Join(errors, err)
 
 	exp.sentLogRecords, err = meter.Int64Counter(
 		obsmetrics.ExporterPrefix+obsmetrics.SentLogRecordsKey,
 		metric.WithDescription("Number of log record successfully sent to destination."),
 		metric.WithUnit("1"))
-	errors = multierr.Append(errors, err)
+	errors = errors.Join(errors, err)
 
 	exp.failedToSendLogRecords, err = meter.Int64Counter(
 		obsmetrics.ExporterPrefix+obsmetrics.FailedToSendLogRecordsKey,
 		metric.WithDescription("Number of log records in failed attempts to send to destination."),
 		metric.WithUnit("1"))
-	errors = multierr.Append(errors, err)
+	errors = errors.Join(errors, err)
 
 	return errors
 }

--- a/obsreport/obsreport_processor.go
+++ b/obsreport/obsreport_processor.go
@@ -11,7 +11,6 @@ import (
 	"go.opencensus.io/tag"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
-	"go.uber.org/multierr"
 	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/component"
@@ -102,63 +101,63 @@ func (por *Processor) createOtelMetrics(cfg ProcessorSettings) error {
 		metric.WithDescription("Number of spans successfully pushed into the next component in the pipeline."),
 		metric.WithUnit("1"),
 	)
-	errors = multierr.Append(errors, err)
+	errors = errors.Join(errors, err)
 
 	por.refusedSpansCounter, err = meter.Int64Counter(
 		obsmetrics.ProcessorPrefix+obsmetrics.RefusedSpansKey,
 		metric.WithDescription("Number of spans that were rejected by the next component in the pipeline."),
 		metric.WithUnit("1"),
 	)
-	errors = multierr.Append(errors, err)
+	errors = errors.Join(errors, err)
 
 	por.droppedSpansCounter, err = meter.Int64Counter(
 		obsmetrics.ProcessorPrefix+obsmetrics.DroppedSpansKey,
 		metric.WithDescription("Number of spans that were dropped."),
 		metric.WithUnit("1"),
 	)
-	errors = multierr.Append(errors, err)
+	errors = errors.Join(errors, err)
 
 	por.acceptedMetricPointsCounter, err = meter.Int64Counter(
 		obsmetrics.ProcessorPrefix+obsmetrics.AcceptedMetricPointsKey,
 		metric.WithDescription("Number of metric points successfully pushed into the next component in the pipeline."),
 		metric.WithUnit("1"),
 	)
-	errors = multierr.Append(errors, err)
+	errors = errors.Join(errors, err)
 
 	por.refusedMetricPointsCounter, err = meter.Int64Counter(
 		obsmetrics.ProcessorPrefix+obsmetrics.RefusedMetricPointsKey,
 		metric.WithDescription("Number of metric points that were rejected by the next component in the pipeline."),
 		metric.WithUnit("1"),
 	)
-	errors = multierr.Append(errors, err)
+	errors = errors.Join(errors, err)
 
 	por.droppedMetricPointsCounter, err = meter.Int64Counter(
 		obsmetrics.ProcessorPrefix+obsmetrics.DroppedMetricPointsKey,
 		metric.WithDescription("Number of metric points that were dropped."),
 		metric.WithUnit("1"),
 	)
-	errors = multierr.Append(errors, err)
+	errors = errors.Join(errors, err)
 
 	por.acceptedLogRecordsCounter, err = meter.Int64Counter(
 		obsmetrics.ProcessorPrefix+obsmetrics.AcceptedLogRecordsKey,
 		metric.WithDescription("Number of log records successfully pushed into the next component in the pipeline."),
 		metric.WithUnit("1"),
 	)
-	errors = multierr.Append(errors, err)
+	errors = errors.Join(errors, err)
 
 	por.refusedLogRecordsCounter, err = meter.Int64Counter(
 		obsmetrics.ProcessorPrefix+obsmetrics.RefusedLogRecordsKey,
 		metric.WithDescription("Number of log records that were rejected by the next component in the pipeline."),
 		metric.WithUnit("1"),
 	)
-	errors = multierr.Append(errors, err)
+	errors = errors.Join(errors, err)
 
 	por.droppedLogRecordsCounter, err = meter.Int64Counter(
 		obsmetrics.ProcessorPrefix+obsmetrics.DroppedLogRecordsKey,
 		metric.WithDescription("Number of log records that were dropped."),
 		metric.WithUnit("1"),
 	)
-	errors = multierr.Append(errors, err)
+	errors = errors.Join(errors, err)
 
 	return errors
 }

--- a/obsreport/obsreport_receiver.go
+++ b/obsreport/obsreport_receiver.go
@@ -11,7 +11,6 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
-	"go.uber.org/multierr"
 	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/component"
@@ -107,42 +106,42 @@ func (rec *Receiver) createOtelMetrics() error {
 		metric.WithDescription("Number of spans successfully pushed into the pipeline."),
 		metric.WithUnit("1"),
 	)
-	errors = multierr.Append(errors, err)
+	errors = errors.Join(errors, err)
 
 	rec.refusedSpansCounter, err = rec.meter.Int64Counter(
 		obsmetrics.ReceiverPrefix+obsmetrics.RefusedSpansKey,
 		metric.WithDescription("Number of spans that could not be pushed into the pipeline."),
 		metric.WithUnit("1"),
 	)
-	errors = multierr.Append(errors, err)
+	errors = errors.Join(errors, err)
 
 	rec.acceptedMetricPointsCounter, err = rec.meter.Int64Counter(
 		obsmetrics.ReceiverPrefix+obsmetrics.AcceptedMetricPointsKey,
 		metric.WithDescription("Number of metric points successfully pushed into the pipeline."),
 		metric.WithUnit("1"),
 	)
-	errors = multierr.Append(errors, err)
+	errors = errors.Join(errors, err)
 
 	rec.refusedMetricPointsCounter, err = rec.meter.Int64Counter(
 		obsmetrics.ReceiverPrefix+obsmetrics.RefusedMetricPointsKey,
 		metric.WithDescription("Number of metric points that could not be pushed into the pipeline."),
 		metric.WithUnit("1"),
 	)
-	errors = multierr.Append(errors, err)
+	errors = errors.Join(errors, err)
 
 	rec.acceptedLogRecordsCounter, err = rec.meter.Int64Counter(
 		obsmetrics.ReceiverPrefix+obsmetrics.AcceptedLogRecordsKey,
 		metric.WithDescription("Number of log records successfully pushed into the pipeline."),
 		metric.WithUnit("1"),
 	)
-	errors = multierr.Append(errors, err)
+	errors = errors.Join(errors, err)
 
 	rec.refusedLogRecordsCounter, err = rec.meter.Int64Counter(
 		obsmetrics.ReceiverPrefix+obsmetrics.RefusedLogRecordsKey,
 		metric.WithDescription("Number of log records that could not be pushed into the pipeline."),
 		metric.WithUnit("1"),
 	)
-	errors = multierr.Append(errors, err)
+	errors = errors.Join(errors, err)
 
 	return errors
 }

--- a/obsreport/obsreport_scraper.go
+++ b/obsreport/obsreport_scraper.go
@@ -12,7 +12,6 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
-	"go.uber.org/multierr"
 	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/component"
@@ -94,14 +93,14 @@ func (s *Scraper) createOtelMetrics(cfg ScraperSettings) error {
 		metric.WithDescription("Number of metric points successfully scraped."),
 		metric.WithUnit("1"),
 	)
-	errors = multierr.Append(errors, err)
+	errors = errors.Join(errors, err)
 
 	s.erroredMetricsPoints, err = meter.Int64Counter(
 		obsmetrics.ScraperPrefix+obsmetrics.ErroredMetricPointsKey,
 		metric.WithDescription("Number of metric points that were unable to be scraped."),
 		metric.WithUnit("1"),
 	)
-	errors = multierr.Append(errors, err)
+	errors = errors.Join(errors, err)
 
 	return errors
 }

--- a/obsreport/obsreporttest/obsreporttest.go
+++ b/obsreport/obsreporttest/obsreporttest.go
@@ -5,6 +5,7 @@ package obsreporttest // import "go.opentelemetry.io/collector/obsreport/obsrepo
 
 import (
 	"context"
+	"errors"
 
 	ocprom "contrib.go.opencensus.io/exporter/prometheus"
 	"github.com/prometheus/client_golang/prometheus"
@@ -14,7 +15,6 @@ import (
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
-	"go.uber.org/multierr"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -136,9 +136,9 @@ func (tts *TestTelemetry) Shutdown(ctx context.Context) error {
 	view.Unregister(tts.views...)
 	view.UnregisterExporter(tts.ocExporter)
 	var errs error
-	errs = multierr.Append(errs, tts.SpanRecorder.Shutdown(ctx))
+	errs = errors.Join(errs, tts.SpanRecorder.Shutdown(ctx))
 	if tts.meterProvider != nil {
-		errs = multierr.Append(errs, tts.meterProvider.Shutdown(ctx))
+		errs = errors.Join(errs, tts.meterProvider.Shutdown(ctx))
 	}
 	return errs
 }


### PR DESCRIPTION
Part of: https://github.com/open-telemetry/opentelemetry-collector/issues/8210