### PR TITLE
Add support for :authority pseudo-header for grpc client

### DIFF
--- a/.chloggen/otlp_with_authority.yaml
+++ b/.chloggen/otlp_with_authority.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: configgrpc
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Add support for :authority pseudo-header in grpc client"
+
+# One or more tracking issues or pull requests related to the change
+issues: [8228]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/config/configgrpc/configgrpc.go
+++ b/config/configgrpc/configgrpc.go
@@ -86,6 +86,10 @@ type GRPCClientSettings struct {
 	// https://github.com/grpc/grpc-go/blob/master/examples/features/load_balancing/README.md
 	BalancerName string `mapstructure:"balancer_name"`
 
+	// WithAuthority parameter configures client to rewrite ":authority" header
+	// (godoc.org/google.golang.org/grpc#WithAuthority)
+	Authority string `mapstructure:"authority"`
+
 	// Auth configuration for outgoing RPCs.
 	Auth *configauth.Authentication `mapstructure:"auth"`
 }
@@ -245,6 +249,10 @@ func (gcs *GRPCClientSettings) toDialOptions(host component.Host, settings compo
 			return nil, fmt.Errorf("invalid balancer_name: %s", gcs.BalancerName)
 		}
 		opts = append(opts, grpc.WithDefaultServiceConfig(fmt.Sprintf(`{"loadBalancingPolicy":"%s"}`, gcs.BalancerName)))
+	}
+
+	if gcs.Authority != "" {
+		opts = append(opts, grpc.WithAuthority(gcs.Authority))
 	}
 
 	otelOpts := []otelgrpc.Option{

--- a/config/configgrpc/configgrpc_test.go
+++ b/config/configgrpc/configgrpc_test.go
@@ -80,6 +80,7 @@ func TestAllGrpcClientSettings(t *testing.T) {
 				WriteBufferSize: 1024,
 				WaitForReady:    true,
 				BalancerName:    "round_robin",
+				Authority:       "pseudo-authority",
 				Auth:            &configauth.Authentication{AuthenticatorID: component.NewID("testauth")},
 			},
 			host: &mockHost{
@@ -108,6 +109,7 @@ func TestAllGrpcClientSettings(t *testing.T) {
 				WriteBufferSize: 1024,
 				WaitForReady:    true,
 				BalancerName:    "round_robin",
+				Authority:       "pseudo-authority",
 				Auth:            &configauth.Authentication{AuthenticatorID: component.NewID("testauth")},
 			},
 			host: &mockHost{
@@ -136,6 +138,7 @@ func TestAllGrpcClientSettings(t *testing.T) {
 				WriteBufferSize: 1024,
 				WaitForReady:    true,
 				BalancerName:    "round_robin",
+				Authority:       "pseudo-authority",
 				Auth:            &configauth.Authentication{AuthenticatorID: component.NewID("testauth")},
 			},
 			host: &mockHost{
@@ -149,7 +152,7 @@ func TestAllGrpcClientSettings(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			opts, err := test.settings.toDialOptions(test.host, tt.TelemetrySettings)
 			assert.NoError(t, err)
-			assert.Len(t, opts, 9)
+			assert.Len(t, opts, 10)
 		})
 	}
 }


### PR DESCRIPTION
This adds support for configuring `authority` dial option for grpc exporter

