### PR TITLE
[exporterhelper] Add queue options to the new exporter helper

### DIFF
--- a/.chloggen/exporter-helper-v2.yaml
+++ b/.chloggen/exporter-helper-v2.yaml
@@ -1,0 +1,33 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: exporter/exporterhelper
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add API for enabling queue in the new exporter helpers.
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The following experimental API is introduced in exporter/exporterhelper package:
+    - `RequestMarshaler`: a new interface for marshaling client-provided requests.
+    - `RequestUnmarshaler`: a new interface for unmarshaling client-provided requests.
+    - `WithMemoryQueue`: a new exporter helper option for using a memory queue.
+    - `WithPersistentQueue`: a new exporter helper option for using a persistent queue.
+    - `QueueConfig`: a configuration for queueing requests used by WithMemoryQueue option. 
+    - `NewDefaultQueueConfig`: a function for creating a default QueueConfig.
+    - `PersistentQueueConfig`: a configuration for queueing requests in persistent storage used by WithPersistentQueue option.
+    - `NewDefaultPersistentQueueConfig`: a function for creating a default PersistentQueueConfig.
+    All the new APIs are intended to be used by exporters that operate over client-provided requests instead of pdata.
+
+# One or more tracking issues or pull requests related to the change
+issues: [7874]
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/exporter/exporterhelper/request.go
+++ b/exporter/exporterhelper/request.go
@@ -59,3 +59,13 @@ func (req *request) Count() int {
 	}
 	return 0
 }
+
+// RequestMarshaler is a function that can marshal a Request into bytes.
+// This API is at the early stage of development and may change without backward compatibility
+// until https://github.com/open-telemetry/opentelemetry-collector/issues/8122 is resolved.
+type RequestMarshaler func(req Request) ([]byte, error)
+
+// RequestUnmarshaler is a function that can unmarshal bytes into a Request.
+// This API is at the early stage of development and may change without backward compatibility
+// until https://github.com/open-telemetry/opentelemetry-collector/issues/8122 is resolved.
+type RequestUnmarshaler func(data []byte) (Request, error)

--- a/exporter/exporterhelper/request_test.go
+++ b/exporter/exporterhelper/request_test.go
@@ -5,6 +5,8 @@ package exporterhelper
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/pmetric"
@@ -12,33 +14,61 @@ import (
 )
 
 type fakeRequest struct {
-	items int
-	err   error
+	Items          int
+	exportCallback func(req Request) error
 }
 
 func (r fakeRequest) Export(_ context.Context) error {
-	return r.err
+	if r.exportCallback == nil {
+		return nil
+	}
+	return r.exportCallback(r)
 }
 
 func (r fakeRequest) ItemsCount() int {
-	return r.items
+	return r.Items
 }
 
 type fakeRequestConverter struct {
-	metricsError error
-	tracesError  error
-	logsError    error
-	requestError error
+	metricsError   error
+	tracesError    error
+	logsError      error
+	exportCallback func(req Request) error
 }
 
 func (c fakeRequestConverter) RequestFromMetrics(_ context.Context, md pmetric.Metrics) (Request, error) {
-	return fakeRequest{items: md.DataPointCount(), err: c.requestError}, c.metricsError
+	return c.fakeRequest(md.DataPointCount()), c.metricsError
 }
 
 func (c fakeRequestConverter) RequestFromTraces(_ context.Context, td ptrace.Traces) (Request, error) {
-	return fakeRequest{items: td.SpanCount(), err: c.requestError}, c.tracesError
+	return c.fakeRequest(td.SpanCount()), c.tracesError
 }
 
 func (c fakeRequestConverter) RequestFromLogs(_ context.Context, ld plog.Logs) (Request, error) {
-	return fakeRequest{items: ld.LogRecordCount(), err: c.requestError}, c.logsError
+	return c.fakeRequest(ld.LogRecordCount()), c.logsError
+}
+
+func (c fakeRequestConverter) fakeRequest(items int) Request {
+	return fakeRequest{Items: items, exportCallback: c.exportCallback}
+}
+
+func (c fakeRequestConverter) requestMarshalerFunc() RequestMarshaler {
+	return func(req Request) ([]byte, error) {
+		r, ok := req.(fakeRequest)
+		if !ok {
+			return nil, errors.New("invalid request type")
+		}
+		return json.Marshal(r)
+	}
+}
+
+func (c fakeRequestConverter) requestUnmarshalerFunc() RequestUnmarshaler {
+	return func(bytes []byte) (Request, error) {
+		var r fakeRequest
+		if err := json.Unmarshal(bytes, &r); err != nil {
+			return nil, err
+		}
+		r.exportCallback = c.exportCallback
+		return r, nil
+	}
 }


### PR DESCRIPTION
This change enabled queue capability for the new exporter helper. For now, it preserves the same user configuration interface as the existing exporter helper has. The only difference is that implementing persistence is optional now as it requires providing marshal and unmarshal functions for the custom request. 

Later, it's possible to introduce more options for controlling the queue: count of items or bytes in the queue.

Tracking issue: https://github.com/open-telemetry/opentelemetry-collector/issues/8122