### PR TITLE
Allow any registered gRPC load balancer to be used

### DIFF
--- a/config/configgrpc/configgrpc.go
+++ b/config/configgrpc/configgrpc.go
@@ -17,7 +17,7 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"go.opentelemetry.io/otel"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/balancer/roundrobin"
+	"google.golang.org/grpc/balancer"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/encoding/gzip"
@@ -37,9 +37,6 @@ import (
 )
 
 var errMetadataNotFound = errors.New("no request metadata found")
-
-// Allowed balancer names to be set in grpclb_policy to discover the servers.
-var allowedBalancerNames = []string{roundrobin.Name, grpc.PickFirstBalancerName}
 
 // KeepaliveClientConfig exposes the keepalive.ClientParameters to be used by the exporter.
 // Refer to the original data-structure for the meaning of each parameter:
@@ -269,12 +266,7 @@ func (gcs *GRPCClientSettings) toDialOptions(host component.Host, settings compo
 }
 
 func validateBalancerName(balancerName string) bool {
-	for _, item := range allowedBalancerNames {
-		if item == balancerName {
-			return true
-		}
-	}
-	return false
+	return balancer.Get(balancerName) != nil
 }
 
 // ToListener returns the net.Listener constructed from the settings.

--- a/config/configgrpc/configgrpc_test.go
+++ b/config/configgrpc/configgrpc_test.go
@@ -18,6 +18,7 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/balancer"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/peer"
 
@@ -34,6 +35,21 @@ import (
 	"go.opentelemetry.io/collector/obsreport/obsreporttest"
 	"go.opentelemetry.io/collector/pdata/ptrace/ptraceotlp"
 )
+
+// testBalancerBuilder facilitates testing validateBalancerName().
+type testBalancerBuilder struct{}
+
+func (testBalancerBuilder) Build(cc balancer.ClientConn, opts balancer.BuildOptions) balancer.Balancer {
+	return nil
+}
+
+func (testBalancerBuilder) Name() string {
+	return "configgrpc_balancer_test"
+}
+
+func init() {
+	balancer.Register(testBalancerBuilder{})
+}
 
 func TestDefaultGrpcClientSettings(t *testing.T) {
 	tt, err := obsreporttest.SetupTelemetry(component.NewID("component"))
@@ -137,7 +153,7 @@ func TestAllGrpcClientSettings(t *testing.T) {
 				ReadBufferSize:  1024,
 				WriteBufferSize: 1024,
 				WaitForReady:    true,
-				BalancerName:    "round_robin",
+				BalancerName:    "configgrpc_balancer_test",
 				Authority:       "pseudo-authority",
 				Auth:            &configauth.Authentication{AuthenticatorID: component.NewID("testauth")},
 			},


### PR DESCRIPTION

**Description:** gRPC-Go's `balancer` package includes a static registration mechanism and a way to inspect whether a balancer name is registered. We should use this mechanism instead of hard-coding an allowlist of balancer names. 

Custom collector configurations may have additional balancers linked in, and we should allow them to be used.

**Testing:** existing cover this, pass

**Documentation:** Existing documentation refers to gRPC balancer package, does not mention any allowlist behavior.
