### PR TITLE
[exporter/otlphttpexporter] Partial success HTTP response handling

### DIFF
--- a/.chloggen/handle-http-response-partial-success.yaml
+++ b/.chloggen/handle-http-response-partial-success.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: otlphttpexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix the handling of the HTTP response to ignore responses not encoded as protobuf
+
+# One or more tracking issues or pull requests related to the change
+issues: [8263]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]


### PR DESCRIPTION

**Description:**
Fix the handling of the HTTP response to  ignore responses not encoded as protobuf

**Link to tracking Issue:**
Fixes #8263