### PR TITLE
[confighttp] Add option to disable HTTP keep-alives

### DIFF
--- a/.chloggen/disable_keep_alives.yaml
+++ b/.chloggen/disable_keep_alives.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: confighttp
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add option to disable HTTP keep-alives
+
+# One or more tracking issues or pull requests related to the change
+issues: [8260]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/config/confighttp/README.md
+++ b/config/confighttp/README.md
@@ -28,6 +28,7 @@ README](../configtls/README.md).
 - [`max_conns_per_host`](https://golang.org/pkg/net/http/#Transport)
 - [`idle_conn_timeout`](https://golang.org/pkg/net/http/#Transport)
 - [`auth`](../configauth/README.md)
+- [`disable_keep_alives`](https://golang.org/pkg/net/http/#Transport)
 
 Example:
 

--- a/config/confighttp/confighttp.go
+++ b/config/confighttp/confighttp.go
@@ -74,6 +74,14 @@ type HTTPClientSettings struct {
 	// IdleConnTimeout is the maximum amount of time a connection will remain open before closing itself.
 	// There's an already set value, and we want to override it only if an explicit value provided
 	IdleConnTimeout *time.Duration `mapstructure:"idle_conn_timeout"`
+
+	// DisableKeepAlives, if true, disables HTTP keep-alives and will only use the connection to the server
+	// for a single HTTP request.
+	//
+	// WARNING: enabling this option can result in significant overhead establishing a new HTTP(S)
+	// connection for every request. Before enabling this option please consider whether changes
+	// to idle connection settings can achieve your goal.
+	DisableKeepAlives bool `mapstructure:"disable_keep_alives"`
 }
 
 // NewDefaultHTTPClientSettings returns HTTPClientSettings type object with
@@ -123,6 +131,8 @@ func (hcs *HTTPClientSettings) ToClient(host component.Host, settings component.
 	if hcs.IdleConnTimeout != nil {
 		transport.IdleConnTimeout = *hcs.IdleConnTimeout
 	}
+
+	transport.DisableKeepAlives = hcs.DisableKeepAlives
 
 	clientTransport := (http.RoundTripper)(transport)
 

--- a/config/confighttp/confighttp_test.go
+++ b/config/confighttp/confighttp_test.go
@@ -73,6 +73,7 @@ func TestAllHTTPClientSettings(t *testing.T) {
 				IdleConnTimeout:     &idleConnTimeout,
 				CustomRoundTripper:  func(next http.RoundTripper) (http.RoundTripper, error) { return next, nil },
 				Compression:         "",
+				DisableKeepAlives:   true,
 			},
 			shouldError: false,
 		},
@@ -91,6 +92,7 @@ func TestAllHTTPClientSettings(t *testing.T) {
 				IdleConnTimeout:     &idleConnTimeout,
 				CustomRoundTripper:  func(next http.RoundTripper) (http.RoundTripper, error) { return next, nil },
 				Compression:         "none",
+				DisableKeepAlives:   true,
 			},
 			shouldError: false,
 		},
@@ -109,6 +111,7 @@ func TestAllHTTPClientSettings(t *testing.T) {
 				IdleConnTimeout:     &idleConnTimeout,
 				CustomRoundTripper:  func(next http.RoundTripper) (http.RoundTripper, error) { return next, nil },
 				Compression:         "gzip",
+				DisableKeepAlives:   true,
 			},
 			shouldError: false,
 		},
@@ -145,6 +148,7 @@ func TestAllHTTPClientSettings(t *testing.T) {
 				assert.EqualValues(t, 40, transport.MaxIdleConnsPerHost)
 				assert.EqualValues(t, 45, transport.MaxConnsPerHost)
 				assert.EqualValues(t, 30*time.Second, transport.IdleConnTimeout)
+				assert.EqualValues(t, true, transport.DisableKeepAlives)
 			case *compressRoundTripper:
 				assert.EqualValues(t, "gzip", transport.compressionType)
 			}
@@ -192,6 +196,7 @@ func TestPartialHTTPClientSettings(t *testing.T) {
 			assert.EqualValues(t, 0, transport.MaxIdleConnsPerHost)
 			assert.EqualValues(t, 0, transport.MaxConnsPerHost)
 			assert.EqualValues(t, 90*time.Second, transport.IdleConnTimeout)
+			assert.EqualValues(t, false, transport.DisableKeepAlives)
 
 		})
 	}


### PR DESCRIPTION
**Description:**

Add option to disable HTTP keep-alives which helps in better load balancing in k8s clusters when otlphttp exports are used to send logs to otlp receivers

**Link to tracking Issue:**  #8260
