### PR TITLE
[chore] [exporterhelper] Remove redundant Marshal methods from test structs

### DIFF
--- a/exporter/exporterhelper/internal/persistent_storage_test.go
+++ b/exporter/exporterhelper/internal/persistent_storage_test.go
@@ -62,11 +62,6 @@ func newFakeTracesRequest(td ptrace.Traces) *fakeTracesRequest {
 	}
 }
 
-func (fd *fakeTracesRequest) Marshal() ([]byte, error) {
-	marshaler := &ptrace.ProtoMarshaler{}
-	return marshaler.MarshalTraces(fd.td)
-}
-
 func (fd *fakeTracesRequest) OnProcessingFinished() {
 	if fd.processingFinishedCallback != nil {
 		fd.processingFinishedCallback()
@@ -480,7 +475,7 @@ func TestPersistentStorage_StorageFull(t *testing.T) {
 	var err error
 	traces := newTraces(5, 10)
 	req := newFakeTracesRequest(traces)
-	marshaled, err := req.Marshal()
+	marshaled, err := newFakeTracesRequestMarshalerFunc()(req)
 	require.NoError(t, err)
 	maxSizeInBytes := len(marshaled) * 5 // arbitrary small number
 	freeSpaceInBytes := 1

--- a/exporter/exporterhelper/queued_retry_test.go
+++ b/exporter/exporterhelper/queued_retry_test.go
@@ -27,7 +27,6 @@ import (
 	"go.opentelemetry.io/collector/extension/extensiontest"
 	"go.opentelemetry.io/collector/internal/testdata"
 	"go.opentelemetry.io/collector/obsreport/obsreporttest"
-	"go.opentelemetry.io/collector/pdata/ptrace"
 )
 
 func mockRequestUnmarshaler(mr *mockRequest) internal.RequestUnmarshaler {
@@ -650,10 +649,6 @@ func (mer *mockErrorRequest) OnError(error) internal.Request {
 	return mer
 }
 
-func (mer *mockErrorRequest) Marshal() ([]byte, error) {
-	return nil, nil
-}
-
 func (mer *mockErrorRequest) Count() int {
 	return 7
 }
@@ -683,11 +678,6 @@ func (m *mockRequest) Export(ctx context.Context) error {
 	}
 	// Respond like gRPC/HTTP, if context is cancelled, return error
 	return ctx.Err()
-}
-
-func (m *mockRequest) Marshal() ([]byte, error) {
-	marshaler := &ptrace.ProtoMarshaler{}
-	return marshaler.MarshalTraces(ptrace.NewTraces())
 }
 
 func (m *mockRequest) OnError(error) internal.Request {


### PR DESCRIPTION
The method was removed from the Request interface in https://github.com/open-telemetry/opentelemetry-collector/pull/8178, so the implementation on the test structs is not required anymore
