### PR TITLE
[chore] Fix checkValueForProducer test helper for queue metrics

### DIFF
--- a/exporter/exporterhelper/queued_retry_test.go
+++ b/exporter/exporterhelper/queued_retry_test.go
@@ -768,10 +768,11 @@ func checkValueForGlobalManager(t *testing.T, wantTags []tag.Tag, value int64, v
 func checkValueForProducer(t *testing.T, producer metricproducer.Producer, wantTags []tag.Tag, value int64, vName string) bool {
 	for _, metric := range producer.Read() {
 		if metric.Descriptor.Name == vName && len(metric.TimeSeries) > 0 {
-			lastValue := metric.TimeSeries[len(metric.TimeSeries)-1]
-			if tagsMatchLabelKeys(wantTags, metric.Descriptor.LabelKeys, lastValue.LabelValues) {
-				require.Equal(t, value, lastValue.Points[len(lastValue.Points)-1].Value.(int64))
-				return true
+			for _, ts := range metric.TimeSeries {
+				if tagsMatchLabelKeys(wantTags, metric.Descriptor.LabelKeys, ts.LabelValues) {
+					require.Equal(t, value, ts.Points[len(ts.Points)-1].Value.(int64))
+					return true
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This check assumes that every OC metric has only one datapoint. But, since the queue metrics are defined globally, they are accumulate more datapoints with different labels from different tests. This change removes that assumption. It allows having more tests for the exporter queue without breaking TestQueuedRetry_QueueMetricsReported.

Ideally, we should avoid defining instruments globally or clear them up after each test. The first option would require passing the OpenCensus registry in as a public field of TelemetrySettings from the service start. The second option would require a bigger refactoring. 

I think we can allow several tests emitting datapoints for the global instruments for now until we migrate to OTel metrics.

Fixes tests failing in https://github.com/open-telemetry/opentelemetry-collector/pull/8250