### PR TITLE
Add stability levels to components output

### DIFF
--- a/.chloggen/components-command-with-stability-levels.yaml
+++ b/.chloggen/components-command-with-stability-levels.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: components command
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: The "components" command now lists the component's stability levels.
+
+# One or more tracking issues or pull requests related to the change
+issues: [8289]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: Note that the format of this output is NOT stable and can change between versions.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/otelcol/command_components.go
+++ b/otelcol/command_components.go
@@ -13,8 +13,8 @@ import (
 )
 
 type componentWithStability struct {
-	Name            component.Type
-	StabilityLevels map[string]string
+	Name      component.Type
+	Stability map[string]string
 }
 
 type componentsOutput struct {
@@ -31,6 +31,7 @@ func newComponentsCommand(set CollectorSettings) *cobra.Command {
 	return &cobra.Command{
 		Use:   "components",
 		Short: "Outputs available components in this collector distribution",
+		Long:  "Outputs available components in this collector distribution including their stability levels. The output format is not stable and can change between releases.",
 		Args:  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 
@@ -38,25 +39,25 @@ func newComponentsCommand(set CollectorSettings) *cobra.Command {
 			for con := range set.Factories.Connectors {
 				components.Connectors = append(components.Connectors, componentWithStability{
 					Name: con,
-					StabilityLevels: map[string]string{
-						"logstologs":    set.Factories.Connectors[con].LogsToLogsStability().String(),
-						"logstometrics": set.Factories.Connectors[con].LogsToMetricsStability().String(),
-						"logstotraces":  set.Factories.Connectors[con].LogsToTracesStability().String(),
+					Stability: map[string]string{
+						"logs-to-logs":    set.Factories.Connectors[con].LogsToLogsStability().String(),
+						"logs-to-metrics": set.Factories.Connectors[con].LogsToMetricsStability().String(),
+						"logs-to-traces":  set.Factories.Connectors[con].LogsToTracesStability().String(),
 
-						"metricstologs":    set.Factories.Connectors[con].MetricsToLogsStability().String(),
-						"metricstometrics": set.Factories.Connectors[con].MetricsToMetricsStability().String(),
-						"metricstotraces":  set.Factories.Connectors[con].MetricsToTracesStability().String(),
+						"metrics-to-logs":    set.Factories.Connectors[con].MetricsToLogsStability().String(),
+						"metrics-to-metrics": set.Factories.Connectors[con].MetricsToMetricsStability().String(),
+						"metrics-to-traces":  set.Factories.Connectors[con].MetricsToTracesStability().String(),
 
-						"tracestologs":    set.Factories.Connectors[con].TracesToLogsStability().String(),
-						"tracestometrics": set.Factories.Connectors[con].TracesToMetricsStability().String(),
-						"tracestotraces":  set.Factories.Connectors[con].TracesToTracesStability().String(),
+						"traces-to-logs":    set.Factories.Connectors[con].TracesToLogsStability().String(),
+						"traces-to-metrics": set.Factories.Connectors[con].TracesToMetricsStability().String(),
+						"traces-to-traces":  set.Factories.Connectors[con].TracesToTracesStability().String(),
 					},
 				})
 			}
 			for ext := range set.Factories.Extensions {
 				components.Extensions = append(components.Extensions, componentWithStability{
 					Name: ext,
-					StabilityLevels: map[string]string{
+					Stability: map[string]string{
 						"extension": set.Factories.Extensions[ext].ExtensionStability().String(),
 					},
 				})
@@ -64,7 +65,7 @@ func newComponentsCommand(set CollectorSettings) *cobra.Command {
 			for prs := range set.Factories.Processors {
 				components.Processors = append(components.Processors, componentWithStability{
 					Name: prs,
-					StabilityLevels: map[string]string{
+					Stability: map[string]string{
 						"logs":    set.Factories.Processors[prs].LogsProcessorStability().String(),
 						"metrics": set.Factories.Processors[prs].MetricsProcessorStability().String(),
 						"traces":  set.Factories.Processors[prs].TracesProcessorStability().String(),
@@ -74,7 +75,7 @@ func newComponentsCommand(set CollectorSettings) *cobra.Command {
 			for rcv := range set.Factories.Receivers {
 				components.Receivers = append(components.Receivers, componentWithStability{
 					Name: rcv,
-					StabilityLevels: map[string]string{
+					Stability: map[string]string{
 						"logs":    set.Factories.Receivers[rcv].LogsReceiverStability().String(),
 						"metrics": set.Factories.Receivers[rcv].MetricsReceiverStability().String(),
 						"traces":  set.Factories.Receivers[rcv].TracesReceiverStability().String(),
@@ -84,7 +85,7 @@ func newComponentsCommand(set CollectorSettings) *cobra.Command {
 			for exp := range set.Factories.Exporters {
 				components.Exporters = append(components.Exporters, componentWithStability{
 					Name: exp,
-					StabilityLevels: map[string]string{
+					Stability: map[string]string{
 						"logs":    set.Factories.Exporters[exp].LogsExporterStability().String(),
 						"metrics": set.Factories.Exporters[exp].MetricsExporterStability().String(),
 						"traces":  set.Factories.Exporters[exp].TracesExporterStability().String(),

--- a/otelcol/command_components_test.go
+++ b/otelcol/command_components_test.go
@@ -32,12 +32,53 @@ func TestNewBuildSubCommand(t *testing.T) {
 	cmd.SetArgs([]string{"components"})
 
 	ExpectedYamlStruct := componentsOutput{
-		BuildInfo:  component.NewDefaultBuildInfo(),
-		Receivers:  []component.Type{"nop"},
-		Processors: []component.Type{"nop"},
-		Exporters:  []component.Type{"nop"},
-		Connectors: []component.Type{"nop"},
-		Extensions: []component.Type{"nop"},
+		BuildInfo: component.NewDefaultBuildInfo(),
+		Receivers: []componentWithStability{{
+			Name: component.Type("nop"),
+			StabilityLevels: map[string]string{
+				"logs":    "Stable",
+				"metrics": "Stable",
+				"traces":  "Stable",
+			},
+		}},
+		Processors: []componentWithStability{{
+			Name: component.Type("nop"),
+			StabilityLevels: map[string]string{
+				"logs":    "Stable",
+				"metrics": "Stable",
+				"traces":  "Stable",
+			},
+		}},
+		Exporters: []componentWithStability{{
+			Name: component.Type("nop"),
+			StabilityLevels: map[string]string{
+				"logs":    "Stable",
+				"metrics": "Stable",
+				"traces":  "Stable",
+			},
+		}},
+		Connectors: []componentWithStability{{
+			Name: component.Type("nop"),
+			StabilityLevels: map[string]string{
+				"logstologs":    "Development",
+				"logstometrics": "Development",
+				"logstotraces":  "Development",
+
+				"metricstologs":    "Development",
+				"metricstometrics": "Development",
+				"metricstotraces":  "Development",
+
+				"tracestologs":    "Development",
+				"tracestometrics": "Development",
+				"tracestotraces":  "Development",
+			},
+		}},
+		Extensions: []componentWithStability{{
+			Name: component.Type("nop"),
+			StabilityLevels: map[string]string{
+				"extension": "Stable",
+			},
+		}},
 	}
 	ExpectedOutput, err := yaml.Marshal(ExpectedYamlStruct)
 	require.NoError(t, err)

--- a/otelcol/command_components_test.go
+++ b/otelcol/command_components_test.go
@@ -35,7 +35,7 @@ func TestNewBuildSubCommand(t *testing.T) {
 		BuildInfo: component.NewDefaultBuildInfo(),
 		Receivers: []componentWithStability{{
 			Name: component.Type("nop"),
-			StabilityLevels: map[string]string{
+			Stability: map[string]string{
 				"logs":    "Stable",
 				"metrics": "Stable",
 				"traces":  "Stable",
@@ -43,7 +43,7 @@ func TestNewBuildSubCommand(t *testing.T) {
 		}},
 		Processors: []componentWithStability{{
 			Name: component.Type("nop"),
-			StabilityLevels: map[string]string{
+			Stability: map[string]string{
 				"logs":    "Stable",
 				"metrics": "Stable",
 				"traces":  "Stable",
@@ -51,7 +51,7 @@ func TestNewBuildSubCommand(t *testing.T) {
 		}},
 		Exporters: []componentWithStability{{
 			Name: component.Type("nop"),
-			StabilityLevels: map[string]string{
+			Stability: map[string]string{
 				"logs":    "Stable",
 				"metrics": "Stable",
 				"traces":  "Stable",
@@ -59,23 +59,23 @@ func TestNewBuildSubCommand(t *testing.T) {
 		}},
 		Connectors: []componentWithStability{{
 			Name: component.Type("nop"),
-			StabilityLevels: map[string]string{
-				"logstologs":    "Development",
-				"logstometrics": "Development",
-				"logstotraces":  "Development",
+			Stability: map[string]string{
+				"logs-to-logs":    "Development",
+				"logs-to-metrics": "Development",
+				"logs-to-traces":  "Development",
 
-				"metricstologs":    "Development",
-				"metricstometrics": "Development",
-				"metricstotraces":  "Development",
+				"metrics-to-logs":    "Development",
+				"metrics-to-metrics": "Development",
+				"metrics-to-traces":  "Development",
 
-				"tracestologs":    "Development",
-				"tracestometrics": "Development",
-				"tracestotraces":  "Development",
+				"traces-to-logs":    "Development",
+				"traces-to-metrics": "Development",
+				"traces-to-traces":  "Development",
 			},
 		}},
 		Extensions: []componentWithStability{{
 			Name: component.Type("nop"),
-			StabilityLevels: map[string]string{
+			Stability: map[string]string{
 				"extension": "Stable",
 			},
 		}},


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/9518

Example output:

```
buildinfo:
    command: otelcorecol
    description: Local OpenTelemetry Collector binary, testing only.
    version: 0.83.0-dev
receivers:
    - name: otlp
      stability:
        logs: Beta
        metrics: Stable
        traces: Stable
processors:
    - name: memory_limiter
      stability:
        logs: Beta
        metrics: Beta
        traces: Beta
    - name: batch
      stability:
        logs: Stable
        metrics: Stable
        traces: Stable
exporters:
    - name: logging
      stability:
        logs: Development
        metrics: Development
        traces: Development
    - name: otlp
      stability:
        logs: Beta
        metrics: Stable
        traces: Stable
    - name: otlphttp
      stability:
        logs: Beta
        metrics: Stable
        traces: Stable
connectors:
    - name: forward
      stability:
        logs-to-logs: Beta
        logs-to-metrics: Undefined
        logs-to-traces: Undefined
        metrics-to-logs: Undefined
        metrics-to-metrics: Beta
        metrics-to-traces: Undefined
        traces-to-logs: Undefined
        traces-to-metrics: Undefined
        traces-to-traces: Beta
extensions:
    - name: memory_ballast
      stability:
        extension: Beta
    - name: zpages
      stability:
        extension: Beta
```

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>
