### PR TITLE
[receiver/scrapercontroller] add ScrapeLevelError

### DIFF
--- a/receiver/scrapererror/scrapelevelerror.go
+++ b/receiver/scrapererror/scrapelevelerror.go
@@ -1,0 +1,92 @@
+package scrapererror
+
+import (
+	"errors"
+
+	"go.uber.org/multierr"
+	"go.uber.org/zap"
+)
+
+type ScrapeLevelErrors struct {
+	Errors        []error
+	WarningErrors []error
+	DebugErrors   []error
+}
+
+func (s *ScrapeLevelErrors) Error() string {
+	err := multierr.Combine(s.Errors...)
+	if err != nil {
+		return err.Error()
+	}
+	return ""
+}
+
+func (s *ScrapeLevelErrors) AddPartial(failed int, err error) {
+	s.Errors = append(s.Errors, NewPartialScrapeError(err, failed))
+}
+
+func (s *ScrapeLevelErrors) Add(err error) {
+	s.Errors = append(s.Errors, err)
+}
+
+func (s *ScrapeLevelErrors) AddPartialWarning(failed int, err error) {
+	s.WarningErrors = append(s.WarningErrors, NewPartialScrapeError(err, failed))
+}
+
+func (s *ScrapeLevelErrors) AddWarning(err error) {
+	s.WarningErrors = append(s.WarningErrors, err)
+}
+
+func (s *ScrapeLevelErrors) AddPartialDebug(failed int, err error) {
+	s.DebugErrors = append(s.DebugErrors, NewPartialScrapeError(err, failed))
+}
+
+func (s *ScrapeLevelErrors) AddDebug(err error) {
+	s.DebugErrors = append(s.DebugErrors, err)
+}
+
+func (s *ScrapeLevelErrors) CombineErrors() error {
+	if len(s.Errors) == 0 {
+		return nil
+	}
+
+	sumOfFailed := 0
+	isPartialScrapeError := false
+	for _, err := range s.Errors {
+		var partial PartialScrapeError
+		if errors.As(err, &partial) {
+			isPartialScrapeError = true
+			sumOfFailed += partial.Failed
+		}
+	}
+
+	combined := multierr.Combine(s.Errors...)
+	if !isPartialScrapeError {
+		return combined
+	}
+
+	if combined == nil {
+		return nil
+	}
+
+	return NewPartialScrapeError(combined, sumOfFailed)
+}
+
+func (s *ScrapeLevelErrors) ZapLogAll(logger *zap.Logger, scraperID string) {
+	scraperIDField := zap.String("scraper", scraperID)
+
+	errors := multierr.Combine(s.Errors...)
+	if errors != nil {
+		logger.Error("Error scraping metrics", zap.Error(errors), scraperIDField)
+	}
+
+	warningErrors := multierr.Combine(s.WarningErrors...)
+	if warningErrors != nil {
+		logger.Warn("Warning scraping metrics", zap.NamedError("warning", warningErrors), scraperIDField)
+	}
+
+	debugErrors := multierr.Combine(s.DebugErrors...)
+	if debugErrors != nil {
+		logger.Debug("Debug information scraping metrics", zap.NamedError("debug", debugErrors), scraperIDField)
+	}
+}

--- a/receiver/scrapererror/scrapelevelerror_test.go
+++ b/receiver/scrapererror/scrapelevelerror_test.go
@@ -1,0 +1,130 @@
+package scrapererror
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func TestScrapeLevelErrorsAddAndCombine(t *testing.T) {
+	errs := &ScrapeLevelErrors{}
+
+	errs.Add(errors.New("it messed up"))
+	errs.Add(errors.New("it messed up twice"))
+
+	err := errs.CombineErrors()
+
+	assert.False(t, IsPartialScrapeError(err))
+}
+
+func TestScrapeLevelErrorsAddWarningAndCombine(t *testing.T) {
+	errs := &ScrapeLevelErrors{}
+
+	errs.AddWarning(errors.New("it messed up"))
+	errs.AddWarning(errors.New("it messed up twice"))
+
+	err := errs.CombineErrors()
+
+	assert.Nil(t, err)
+}
+
+func TestScrapeLevelErrorsAddPartialAndCombine(t *testing.T) {
+	errs := &ScrapeLevelErrors{}
+
+	errs.AddPartial(1, errors.New("it messed up"))
+	errs.AddPartial(2, errors.New("it messed up twice"))
+
+	err := errs.CombineErrors()
+
+	assert.True(t, IsPartialScrapeError(err))
+	var partialErr PartialScrapeError
+	assert.True(t, errors.As(err, &partialErr))
+	assert.Equal(t, partialErr.Failed, 3)
+}
+
+func TestScrapeLevelErrorsLogAll(t *testing.T) {
+	testCases := []struct {
+		name     string
+		errs     []error
+		warnings []error
+		debugs   []error
+	}{
+		{
+			name:     "one of each",
+			errs:     []error{errors.New("failed bad")},
+			warnings: []error{errors.New("failed not that bad")},
+			debugs:   []error{errors.New("just in case you want to see it")},
+		},
+		{
+			name:     "just warnings and debugs",
+			warnings: []error{errors.New("failed not that bad")},
+			debugs:   []error{errors.New("just in case you want to see it")},
+		},
+		{
+			name:     "multiple of each",
+			errs:     []error{errors.New("failed bad"), errors.New("so so bad")},
+			warnings: []error{errors.New("failed not that bad"), errors.New("this too")},
+			debugs:   []error{errors.New("just in case you want to see it"), errors.New("do you want to see this")},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			errs := &ScrapeLevelErrors{}
+			for _, err := range tc.errs {
+				errs.Add(err)
+			}
+			for _, err := range tc.warnings {
+				errs.AddWarning(err)
+			}
+			for _, err := range tc.debugs {
+				errs.AddDebug(err)
+			}
+
+			observedCore, observedLogs := observer.New(zapcore.DebugLevel)
+			logger := zap.New(observedCore)
+
+			errs.ZapLogAll(logger, "testreceiver")
+
+			expectedLogs := 0
+			if len(tc.errs) > 0 {
+				expectedLogs++
+			}
+			if len(tc.warnings) > 0 {
+				expectedLogs++
+			}
+			if len(tc.debugs) > 0 {
+				expectedLogs++
+			}
+			assert.Equal(t, observedLogs.Len(), expectedLogs)
+
+			logEntries := observedLogs.All()
+			currLog := 0
+			if len(tc.errs) > 0 {
+				assertLogContainsErrors(t, tc.errs, logEntries[currLog], "error")
+				currLog++
+			}
+			if len(tc.warnings) > 0 {
+				assertLogContainsErrors(t, tc.warnings, logEntries[currLog], "warning")
+				currLog++
+			}
+			if len(tc.debugs) > 0 {
+				assertLogContainsErrors(t, tc.debugs, logEntries[currLog], "debug")
+				currLog++
+			}
+		})
+	}
+}
+
+func assertLogContainsErrors(t *testing.T, errs []error, entry observer.LoggedEntry, field string) {
+	t.Helper()
+
+	err, ok := entry.ContextMap()[field]
+	assert.True(t, ok, "expected log entry to contain field %s", field)
+	for _, e := range errs {
+		assert.Contains(t, err, e.Error())
+	}
+}


### PR DESCRIPTION
**Description:**
This PR adds a new error type called ScrapeLevelError. This error is optional, does not affect any default behaviour, and can be used by scrapers to produce errors that should be logged as Warning or Debug. The Scraper Controller can handle this error if a scraper produces it and log accordingly through the error rather than unilaterally logging an error like in the alternate case.

**Link to tracking Issue:** 
#5059
#8293

**Testing:** 
`make gotest`
[ ] run a test with a build of `otelcol` and a config that will scrape and produce `ScrapeLevelErrors`

**Documentation:** 
[ ] Add proper godoc comments
