### PR TITLE
[chore] Fix release issue creation script

### DIFF
--- a/.github/workflows/scripts/release-create-tracking-issue.sh
+++ b/.github/workflows/scripts/release-create-tracking-issue.sh
@@ -11,7 +11,7 @@ if [ "${CANDIDATE_BETA}" == "" ]; then
     RELEASE_VERSION="v${CANDIDATE_STABLE}"
 fi
 
-EXISTING_ISSUE=$( gh issue list --search "Release ${RELEASE_VERSION}" --json url --jq '.[].url' --repo "${REPO}" )
+EXISTING_ISSUE=$( gh issue list --search "in:title Release ${RELEASE_VERSION}" --json url --jq '.[].url' --repo "${REPO}" --state open --label release )
 
 if [ "${EXISTING_ISSUE}" != "" ]; then
     echo "Issue already exists: ${EXISTING_ISSUE}"


### PR DESCRIPTION
Make the filtering for existing issues strict to avoid picking unrelated issues. This happened in during 0.84.0 release
```
+ RELEASE_VERSION=v/v0.84.0
+ '[' '' == '' ']'
+ RELEASE_VERSION=v0.84.0
+ '[' 0.84.0 == '' ']'
++ gh issue list --search 'Release v0.84.0' --json url --jq '.[].url' --repo open-telemetry/opentelemetry-collector
+ EXISTING_ISSUE=https://github.com/open-telemetry/opentelemetry-collector/issues/8063
+ '[' https://github.com/open-telemetry/opentelemetry-collector/issues/8063 '!=' '' ']'
+ echo 'Issue already exists: https://github.com/open-telemetry/opentelemetry-collector/issues/8063'
+ exit 0
Issue already exists: https://github.com/open-telemetry/opentelemetry-collector/issues/8063
```
