### PR TITLE
Improve configauth docs

### DIFF
--- a/config/configauth/README.md
+++ b/config/configauth/README.md
@@ -8,11 +8,16 @@ This module defines necessary interfaces to implement server and client type aut
 The currently known authenticators are:
 
 - Server Authenticators
-  - [oidc](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/oidcauthextension)
+  - [Basic Auth Extension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/basicauthextension)
+  - [Bearer Token Extension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/bearertokenauthextension)
+  - [OIDC Extension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/oidcauthextension)
 
 - Client Authenticators
-  - [oauth2](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/oauth2clientauthextension)
-  - [BearerToken](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/bearertokenauthextension)
+  - [ASAP Client Authentication Extension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/asapauthextension)
+  - [Basic Auth Extension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/basicauthextension)
+  - [Bearer Token Extension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/bearertokenauthextension)
+  - [OAuth2 Client Extension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/oauth2clientauthextension)
+  - [Sigv4 Extension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/sigv4authextension)
 
 Examples:
 ```yaml

--- a/config/configgrpc/README.md
+++ b/config/configgrpc/README.md
@@ -26,6 +26,7 @@ README](../configtls/README.md).
   - `timeout`
 - [`read_buffer_size`](https://godoc.org/google.golang.org/grpc#ReadBufferSize)
 - [`write_buffer_size`](https://godoc.org/google.golang.org/grpc#WriteBufferSize)
+- [`auth`](../configauth/README.md)
 
 Please note that [`per_rpc_auth`](https://pkg.go.dev/google.golang.org/grpc#PerRPCCredentials) which allows the credentials to send for every RPC is now moved to become an [extension](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/extension/bearertokenauthextension). Note that this feature isn't about sending the headers only during the initial connection as an `authorization` header under the `headers` would do: this is sent for every RPC performed during an established connection.
 
@@ -35,6 +36,8 @@ Example:
 exporters:
   otlp:
     endpoint: otelcol2:55690
+    auth:
+      authenticator: some-authenticator-extension
     tls:
       ca_file: ca.pem
       cert_file: cert.pem
@@ -107,3 +110,4 @@ see [confignet README](../confignet/README.md).
 - [`read_buffer_size`](https://godoc.org/google.golang.org/grpc#ReadBufferSize)
 - [`tls`](../configtls/README.md)
 - [`write_buffer_size`](https://godoc.org/google.golang.org/grpc#WriteBufferSize)
+- [`auth`](../configauth/README.md)

--- a/config/confighttp/README.md
+++ b/config/confighttp/README.md
@@ -27,6 +27,7 @@ README](../configtls/README.md).
 - [`max_idle_conns_per_host`](https://golang.org/pkg/net/http/#Transport)
 - [`max_conns_per_host`](https://golang.org/pkg/net/http/#Transport)
 - [`idle_conn_timeout`](https://golang.org/pkg/net/http/#Transport)
+- [`auth`](../configauth/README.md)
 
 Example:
 
@@ -34,6 +35,8 @@ Example:
 exporter:
   otlp:
     endpoint: otelcol2:55690
+    auth:
+      authenticator: some-authenticator-extension
     tls:
       ca_file: ca.pem
       cert_file: cert.pem
@@ -66,6 +69,7 @@ will not be enabled.
   not set, browsers use a default of 5 seconds.
 - `endpoint`: Valid value syntax available [here](https://github.com/grpc/grpc/blob/master/doc/naming.md)
 - [`tls`](../configtls/README.md)
+- [`auth`](../configauth/README.md)
 
 You can enable [`attribute processor`][attribute-processor] to append any http header to span's attribute using custom key. You also need to enable the "include_metadata"
 
@@ -77,6 +81,8 @@ receivers:
     protocols:
       http:
         include_metadata: true
+        auth:
+          authenticator: some-authenticator-extension
         cors:
           allowed_origins:
             - https://foo.bar.com

--- a/receiver/otlpreceiver/README.md
+++ b/receiver/otlpreceiver/README.md
@@ -37,7 +37,9 @@ The following settings are configurable:
 Several helper files are leveraged to provide additional capabilities automatically:
 
 - [gRPC settings](https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/configgrpc/README.md) including CORS
+- [HTTP settings](https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/confighttp/README.md)
 - [TLS and mTLS settings](https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/configtls/README.md)
+- [Auth settings](https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/configauth/README.md)
 
 ## Writing with HTTP/JSON
 


### PR DESCRIPTION
Based on https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/26352, I realized that the confighttp and configgrpc helpers lack links to the configauth package. This PR fixes that and updates the list of known authenticators.

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>
