### PR TITLE
[exporterhelper] Refactor options and baseExporter

### DIFF
--- a/.chloggen/exporterhelper-avoid-messages.yaml
+++ b/.chloggen/exporterhelper-avoid-messages.yaml
@@ -1,0 +1,20 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: exporterhelper
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Stop logging error messages suggesting user to enable `retry_on_failure` or `sending_queue` when they are not available.
+
+# One or more tracking issues or pull requests related to the change
+issues: [8369]
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/exporterhelper/common_test.go
+++ b/exporter/exporterhelper/common_test.go
@@ -1,5 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
+
 package exporterhelper
 
 import (
@@ -31,12 +32,16 @@ var (
 	}
 )
 
+func newNoopObsrepSender(_ *obsExporter) requestSender {
+	return &baseRequestSender{}
+}
+
 func TestBaseExporter(t *testing.T) {
-	be, err := newBaseExporter(defaultSettings, newBaseSettings(false, nil, nil), "")
+	be, err := newBaseExporter(defaultSettings, "", false, nil, nil, newNoopObsrepSender)
 	require.NoError(t, err)
 	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
 	require.NoError(t, be.Shutdown(context.Background()))
-	be, err = newBaseExporter(defaultSettings, newBaseSettings(true, nil, nil), "")
+	be, err = newBaseExporter(defaultSettings, "", true, nil, nil, newNoopObsrepSender)
 	require.NoError(t, err)
 	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
 	require.NoError(t, be.Shutdown(context.Background()))
@@ -45,13 +50,10 @@ func TestBaseExporter(t *testing.T) {
 func TestBaseExporterWithOptions(t *testing.T) {
 	want := errors.New("my error")
 	be, err := newBaseExporter(
-		defaultSettings,
-		newBaseSettings(
-			false, nil, nil,
-			WithStart(func(ctx context.Context, host component.Host) error { return want }),
-			WithShutdown(func(ctx context.Context) error { return want }),
-			WithTimeout(NewDefaultTimeoutSettings())),
-		"",
+		defaultSettings, "", false, nil, nil, newNoopObsrepSender,
+		WithStart(func(ctx context.Context, host component.Host) error { return want }),
+		WithShutdown(func(ctx context.Context) error { return want }),
+		WithTimeout(NewDefaultTimeoutSettings()),
 	)
 	require.NoError(t, err)
 	require.Equal(t, want, be.Start(context.Background(), componenttest.NewNopHost()))

--- a/exporter/exporterhelper/logs.go
+++ b/exporter/exporterhelper/logs.go
@@ -89,26 +89,20 @@ func NewLogsExporter(
 		return nil, errNilPushLogsData
 	}
 
-	bs := newBaseSettings(false, logsRequestMarshaler, newLogsRequestUnmarshalerFunc(pusher), options...)
-	be, err := newBaseExporter(set, bs, component.DataTypeLogs)
+	be, err := newBaseExporter(set, component.DataTypeLogs, false, logsRequestMarshaler,
+		newLogsRequestUnmarshalerFunc(pusher), newLogsExporterWithObservability, options...)
 	if err != nil {
 		return nil, err
 	}
-	be.wrapConsumerSender(func(nextSender requestSender) requestSender {
-		return &logsExporterWithObservability{
-			obsrep:     be.obsrep,
-			nextSender: nextSender,
-		}
-	})
 
 	lc, err := consumer.NewLogs(func(ctx context.Context, ld plog.Logs) error {
 		req := newLogsRequest(ctx, ld, pusher)
-		serr := be.sender.send(req)
+		serr := be.send(req)
 		if errors.Is(serr, errSendingQueueIsFull) {
 			be.obsrep.recordLogsEnqueueFailure(req.Context(), int64(req.Count()))
 		}
 		return serr
-	}, bs.consumerOptions...)
+	}, be.consumerOptions...)
 
 	return &logsExporter{
 		baseExporter: be,
@@ -141,18 +135,10 @@ func NewLogsRequestExporter(
 		return nil, errNilLogsConverter
 	}
 
-	bs := newBaseSettings(true, nil, nil, options...)
-
-	be, err := newBaseExporter(set, bs, component.DataTypeLogs)
+	be, err := newBaseExporter(set, component.DataTypeLogs, true, nil, nil, newLogsExporterWithObservability, options...)
 	if err != nil {
 		return nil, err
 	}
-	be.wrapConsumerSender(func(nextSender requestSender) requestSender {
-		return &logsExporterWithObservability{
-			obsrep:     be.obsrep,
-			nextSender: nextSender,
-		}
-	})
 
 	lc, err := consumer.NewLogs(func(ctx context.Context, ld plog.Logs) error {
 		req, cErr := converter.RequestFromLogs(ctx, ld)
@@ -166,12 +152,12 @@ func NewLogsRequestExporter(
 			baseRequest: baseRequest{ctx: ctx},
 			Request:     req,
 		}
-		sErr := be.sender.send(r)
+		sErr := be.send(r)
 		if errors.Is(sErr, errSendingQueueIsFull) {
 			be.obsrep.recordLogsEnqueueFailure(r.Context(), int64(r.Count()))
 		}
 		return sErr
-	}, bs.consumerOptions...)
+	}, be.consumerOptions...)
 
 	return &logsExporter{
 		baseExporter: be,
@@ -180,8 +166,12 @@ func NewLogsRequestExporter(
 }
 
 type logsExporterWithObservability struct {
-	obsrep     *obsExporter
-	nextSender requestSender
+	baseRequestSender
+	obsrep *obsExporter
+}
+
+func newLogsExporterWithObservability(obsrep *obsExporter) requestSender {
+	return &logsExporterWithObservability{obsrep: obsrep}
 }
 
 func (lewo *logsExporterWithObservability) send(req internal.Request) error {

--- a/exporter/exporterhelper/metrics.go
+++ b/exporter/exporterhelper/metrics.go
@@ -89,26 +89,20 @@ func NewMetricsExporter(
 		return nil, errNilPushMetricsData
 	}
 
-	bs := newBaseSettings(false, metricsRequestMarshaler, newMetricsRequestUnmarshalerFunc(pusher), options...)
-	be, err := newBaseExporter(set, bs, component.DataTypeMetrics)
+	be, err := newBaseExporter(set, component.DataTypeMetrics, false, metricsRequestMarshaler,
+		newMetricsRequestUnmarshalerFunc(pusher), newMetricsSenderWithObservability, options...)
 	if err != nil {
 		return nil, err
 	}
-	be.wrapConsumerSender(func(nextSender requestSender) requestSender {
-		return &metricsSenderWithObservability{
-			obsrep:     be.obsrep,
-			nextSender: nextSender,
-		}
-	})
 
 	mc, err := consumer.NewMetrics(func(ctx context.Context, md pmetric.Metrics) error {
 		req := newMetricsRequest(ctx, md, pusher)
-		serr := be.sender.send(req)
+		serr := be.send(req)
 		if errors.Is(serr, errSendingQueueIsFull) {
 			be.obsrep.recordMetricsEnqueueFailure(req.Context(), int64(req.Count()))
 		}
 		return serr
-	}, bs.consumerOptions...)
+	}, be.consumerOptions...)
 
 	return &metricsExporter{
 		baseExporter: be,
@@ -141,18 +135,10 @@ func NewMetricsRequestExporter(
 		return nil, errNilMetricsConverter
 	}
 
-	bs := newBaseSettings(true, nil, nil, options...)
-
-	be, err := newBaseExporter(set, bs, component.DataTypeMetrics)
+	be, err := newBaseExporter(set, component.DataTypeMetrics, true, nil, nil, newMetricsSenderWithObservability, options...)
 	if err != nil {
 		return nil, err
 	}
-	be.wrapConsumerSender(func(nextSender requestSender) requestSender {
-		return &metricsSenderWithObservability{
-			obsrep:     be.obsrep,
-			nextSender: nextSender,
-		}
-	})
 
 	mc, err := consumer.NewMetrics(func(ctx context.Context, md pmetric.Metrics) error {
 		req, cErr := converter.RequestFromMetrics(ctx, md)
@@ -166,12 +152,12 @@ func NewMetricsRequestExporter(
 			Request:     req,
 			baseRequest: baseRequest{ctx: ctx},
 		}
-		sErr := be.sender.send(r)
+		sErr := be.send(r)
 		if errors.Is(sErr, errSendingQueueIsFull) {
 			be.obsrep.recordMetricsEnqueueFailure(r.Context(), int64(r.Count()))
 		}
 		return sErr
-	}, bs.consumerOptions...)
+	}, be.consumerOptions...)
 
 	return &metricsExporter{
 		baseExporter: be,
@@ -180,8 +166,12 @@ func NewMetricsRequestExporter(
 }
 
 type metricsSenderWithObservability struct {
-	obsrep     *obsExporter
-	nextSender requestSender
+	baseRequestSender
+	obsrep *obsExporter
+}
+
+func newMetricsSenderWithObservability(obsrep *obsExporter) requestSender {
+	return &metricsSenderWithObservability{obsrep: obsrep}
 }
 
 func (mewo *metricsSenderWithObservability) send(req internal.Request) error {

--- a/exporter/exporterhelper/queued_retry.go
+++ b/exporter/exporterhelper/queued_retry.go
@@ -14,7 +14,6 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer/consumererror"
@@ -65,51 +64,32 @@ func (qCfg *QueueSettings) Validate() error {
 	return nil
 }
 
-type queuedRetrySender struct {
+type queueSender struct {
+	baseRequestSender
 	fullName         string
 	id               component.ID
 	signal           component.DataType
-	consumerSender   requestSender
 	queue            internal.ProducerConsumerQueue
-	retryStopCh      chan struct{}
 	traceAttribute   attribute.KeyValue
 	logger           *zap.Logger
 	requeuingEnabled bool
 }
 
-func newQueuedRetrySender(id component.ID, signal component.DataType, queue internal.ProducerConsumerQueue,
-	rCfg RetrySettings, nextSender requestSender, logger *zap.Logger) *queuedRetrySender {
-	retryStopCh := make(chan struct{})
-	sampledLogger := createSampledLogger(logger)
-	traceAttr := attribute.String(obsmetrics.ExporterKey, id.String())
-
-	qrs := &queuedRetrySender{
+func newQueueSender(id component.ID, signal component.DataType, queue internal.ProducerConsumerQueue, logger *zap.Logger) *queueSender {
+	return &queueSender{
 		fullName:       id.String(),
 		id:             id,
 		signal:         signal,
 		queue:          queue,
-		retryStopCh:    retryStopCh,
-		traceAttribute: traceAttr,
-		logger:         sampledLogger,
+		traceAttribute: attribute.String(obsmetrics.ExporterKey, id.String()),
+		logger:         logger,
 		// TODO: this can be further exposed as a config param rather than relying on a type of queue
 		requeuingEnabled: queue != nil && queue.IsPersistent(),
 	}
-
-	qrs.consumerSender = &retrySender{
-		traceAttribute: traceAttr,
-		cfg:            rCfg,
-		nextSender:     nextSender,
-		stopCh:         retryStopCh,
-		logger:         sampledLogger,
-		// Following three functions actually depend on queuedRetrySender
-		onTemporaryFailure: qrs.onTemporaryFailure,
-	}
-
-	return qrs
 }
 
-func (qrs *queuedRetrySender) onTemporaryFailure(logger *zap.Logger, req internal.Request, err error) error {
-	if !qrs.requeuingEnabled || qrs.queue == nil {
+func (qs *queueSender) onTemporaryFailure(logger *zap.Logger, req internal.Request, err error) error {
+	if !qs.requeuingEnabled || qs.queue == nil {
 		logger.Error(
 			"Exporting failed. No more retries left. Dropping data.",
 			zap.Error(err),
@@ -118,7 +98,7 @@ func (qrs *queuedRetrySender) onTemporaryFailure(logger *zap.Logger, req interna
 		return err
 	}
 
-	if qrs.queue.Produce(req) {
+	if qs.queue.Produce(req) {
 		logger.Error(
 			"Exporting failed. Putting back to the end of the queue.",
 			zap.Error(err),
@@ -134,16 +114,16 @@ func (qrs *queuedRetrySender) onTemporaryFailure(logger *zap.Logger, req interna
 }
 
 // start is invoked during service startup.
-func (qrs *queuedRetrySender) start(ctx context.Context, host component.Host, set exporter.CreateSettings) error {
-	if qrs.queue == nil {
+func (qs *queueSender) start(ctx context.Context, host component.Host, set exporter.CreateSettings) error {
+	if qs.queue == nil {
 		return nil
 	}
 
-	err := qrs.queue.Start(ctx, host, internal.QueueSettings{
+	err := qs.queue.Start(ctx, host, internal.QueueSettings{
 		CreateSettings: set,
-		DataType:       qrs.signal,
+		DataType:       qs.signal,
 		Callback: func(item internal.Request) {
-			_ = qrs.consumerSender.send(item)
+			_ = qs.nextSender.send(item)
 			item.OnProcessingFinished()
 		},
 	})
@@ -153,14 +133,14 @@ func (qrs *queuedRetrySender) start(ctx context.Context, host component.Host, se
 
 	// Start reporting queue length metric
 	err = globalInstruments.queueSize.UpsertEntry(func() int64 {
-		return int64(qrs.queue.Size())
-	}, metricdata.NewLabelValue(qrs.fullName))
+		return int64(qs.queue.Size())
+	}, metricdata.NewLabelValue(qs.fullName))
 	if err != nil {
 		return fmt.Errorf("failed to create retry queue size metric: %w", err)
 	}
 	err = globalInstruments.queueCapacity.UpsertEntry(func() int64 {
-		return int64(qrs.queue.Capacity())
-	}, metricdata.NewLabelValue(qrs.fullName))
+		return int64(qs.queue.Capacity())
+	}, metricdata.NewLabelValue(qs.fullName))
 	if err != nil {
 		return fmt.Errorf("failed to create retry queue capacity metric: %w", err)
 	}
@@ -169,19 +149,16 @@ func (qrs *queuedRetrySender) start(ctx context.Context, host component.Host, se
 }
 
 // shutdown is invoked during service shutdown.
-func (qrs *queuedRetrySender) shutdown() {
-	// First Stop the retry goroutines, so that unblocks the queue numWorkers.
-	close(qrs.retryStopCh)
-
-	if qrs.queue != nil {
+func (qs *queueSender) shutdown() {
+	if qs.queue != nil {
 		// Cleanup queue metrics reporting
 		_ = globalInstruments.queueSize.UpsertEntry(func() int64 {
 			return int64(0)
-		}, metricdata.NewLabelValue(qrs.fullName))
+		}, metricdata.NewLabelValue(qs.fullName))
 
 		// Stop the queued sender, this will drain the queue and will call the retry (which is stopped) that will only
 		// try once every request.
-		qrs.queue.Stop()
+		qs.queue.Stop()
 	}
 }
 
@@ -217,31 +194,12 @@ func NewDefaultRetrySettings() RetrySettings {
 	}
 }
 
-func createSampledLogger(logger *zap.Logger) *zap.Logger {
-	if logger.Core().Enabled(zapcore.DebugLevel) {
-		// Debugging is enabled. Don't do any sampling.
-		return logger
-	}
-
-	// Create a logger that samples all messages to 1 per 10 seconds initially,
-	// and 1/100 of messages after that.
-	opts := zap.WrapCore(func(core zapcore.Core) zapcore.Core {
-		return zapcore.NewSamplerWithOptions(
-			core,
-			10*time.Second,
-			1,
-			100,
-		)
-	})
-	return logger.WithOptions(opts)
-}
-
 // send implements the requestSender interface
-func (qrs *queuedRetrySender) send(req internal.Request) error {
-	if qrs.queue == nil {
-		err := qrs.consumerSender.send(req)
+func (qs *queueSender) send(req internal.Request) error {
+	if qs.queue == nil {
+		err := qs.nextSender.send(req)
 		if err != nil {
-			qrs.logger.Error(
+			qs.logger.Error(
 				"Exporting failed. Dropping data. Try enabling sending_queue to survive temporary failures.",
 				zap.Int("dropped_items", req.Count()),
 			)
@@ -254,16 +212,16 @@ func (qrs *queuedRetrySender) send(req internal.Request) error {
 	req.SetContext(noCancellationContext{Context: req.Context()})
 
 	span := trace.SpanFromContext(req.Context())
-	if !qrs.queue.Produce(req) {
-		qrs.logger.Error(
+	if !qs.queue.Produce(req) {
+		qs.logger.Error(
 			"Dropping data because sending_queue is full. Try increasing queue_size.",
 			zap.Int("dropped_items", req.Count()),
 		)
-		span.AddEvent("Dropped item, sending_queue is full.", trace.WithAttributes(qrs.traceAttribute))
+		span.AddEvent("Dropped item, sending_queue is full.", trace.WithAttributes(qs.traceAttribute))
 		return errSendingQueueIsFull
 	}
 
-	span.AddEvent("Enqueued item.", trace.WithAttributes(qrs.traceAttribute))
+	span.AddEvent("Enqueued item.", trace.WithAttributes(qs.traceAttribute))
 	return nil
 }
 
@@ -292,12 +250,31 @@ func NewThrottleRetry(err error, delay time.Duration) error {
 type onRequestHandlingFinishedFunc func(*zap.Logger, internal.Request, error) error
 
 type retrySender struct {
+	baseRequestSender
 	traceAttribute     attribute.KeyValue
 	cfg                RetrySettings
-	nextSender         requestSender
 	stopCh             chan struct{}
 	logger             *zap.Logger
 	onTemporaryFailure onRequestHandlingFinishedFunc
+}
+
+func newRetrySender(id component.ID, rCfg RetrySettings, logger *zap.Logger, onTemporaryFailure onRequestHandlingFinishedFunc) *retrySender {
+	if onTemporaryFailure == nil {
+		onTemporaryFailure = func(logger *zap.Logger, req internal.Request, err error) error {
+			return err
+		}
+	}
+	return &retrySender{
+		traceAttribute:     attribute.String(obsmetrics.ExporterKey, id.String()),
+		cfg:                rCfg,
+		stopCh:             make(chan struct{}),
+		logger:             logger,
+		onTemporaryFailure: onTemporaryFailure,
+	}
+}
+
+func (rs *retrySender) shutdown() {
+	close(rs.stopCh)
 }
 
 // send implements the requestSender interface

--- a/exporter/exporterhelper/traces.go
+++ b/exporter/exporterhelper/traces.go
@@ -89,26 +89,20 @@ func NewTracesExporter(
 		return nil, errNilPushTraceData
 	}
 
-	bs := newBaseSettings(false, tracesRequestMarshaler, newTraceRequestUnmarshalerFunc(pusher), options...)
-	be, err := newBaseExporter(set, bs, component.DataTypeTraces)
+	be, err := newBaseExporter(set, component.DataTypeTraces, false, tracesRequestMarshaler,
+		newTraceRequestUnmarshalerFunc(pusher), newTracesExporterWithObservability, options...)
 	if err != nil {
 		return nil, err
 	}
-	be.wrapConsumerSender(func(nextSender requestSender) requestSender {
-		return &tracesExporterWithObservability{
-			obsrep:     be.obsrep,
-			nextSender: nextSender,
-		}
-	})
 
 	tc, err := consumer.NewTraces(func(ctx context.Context, td ptrace.Traces) error {
 		req := newTracesRequest(ctx, td, pusher)
-		serr := be.sender.send(req)
+		serr := be.send(req)
 		if errors.Is(serr, errSendingQueueIsFull) {
 			be.obsrep.recordTracesEnqueueFailure(req.Context(), int64(req.Count()))
 		}
 		return serr
-	}, bs.consumerOptions...)
+	}, be.consumerOptions...)
 
 	return &traceExporter{
 		baseExporter: be,
@@ -141,18 +135,10 @@ func NewTracesRequestExporter(
 		return nil, errNilTracesConverter
 	}
 
-	bs := newBaseSettings(true, nil, nil, options...)
-
-	be, err := newBaseExporter(set, bs, component.DataTypeTraces)
+	be, err := newBaseExporter(set, component.DataTypeTraces, true, nil, nil, newTracesExporterWithObservability, options...)
 	if err != nil {
 		return nil, err
 	}
-	be.wrapConsumerSender(func(nextSender requestSender) requestSender {
-		return &tracesExporterWithObservability{
-			obsrep:     be.obsrep,
-			nextSender: nextSender,
-		}
-	})
 
 	tc, err := consumer.NewTraces(func(ctx context.Context, td ptrace.Traces) error {
 		req, cErr := converter.RequestFromTraces(ctx, td)
@@ -166,12 +152,12 @@ func NewTracesRequestExporter(
 			baseRequest: baseRequest{ctx: ctx},
 			Request:     req,
 		}
-		sErr := be.sender.send(r)
+		sErr := be.send(r)
 		if errors.Is(sErr, errSendingQueueIsFull) {
 			be.obsrep.recordTracesEnqueueFailure(r.Context(), int64(r.Count()))
 		}
 		return sErr
-	}, bs.consumerOptions...)
+	}, be.consumerOptions...)
 
 	return &traceExporter{
 		baseExporter: be,
@@ -180,8 +166,12 @@ func NewTracesRequestExporter(
 }
 
 type tracesExporterWithObservability struct {
-	obsrep     *obsExporter
-	nextSender requestSender
+	baseRequestSender
+	obsrep *obsExporter
+}
+
+func newTracesExporterWithObservability(obsrep *obsExporter) requestSender {
+	return &tracesExporterWithObservability{obsrep: obsrep}
 }
 
 func (tewo *tracesExporterWithObservability) send(req internal.Request) error {


### PR DESCRIPTION
Separate all the parts of the baseExporter into an explicit chain of request senders. It makes it easier to follow the data flow and add additional senders. 

This change also removes the baseSettings, because keeping the settings is not needed anymore. All the options update the internal senders in place.

This change also removes confusing error messages like "Exporting failed. Dropping data. Try enabling sending_queue to survive temporary failures" when the Queue is not even available in the exporter (WithQueue option is not applied) which means users don't `sending_queue` config option. Now, such messages are only shown when the sending_queue (or retry_on_failure) is available, but not enabled by the user.