### PR TITLE
[chore] Update go version used in workflows to ~1.28.8

### DIFF
--- a/.github/workflows/api-compatibility.yml
+++ b/.github/workflows/api-compatibility.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: ~1.20.7
+          go-version: ~1.20.8
 
       # Generate apidiff states of Main
       - name: Generate-States

--- a/.github/workflows/build-and-test-windows.yaml
+++ b/.github/workflows/build-and-test-windows.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: ~1.20.7
+          go-version: ~1.20.8
       - name: Cache Go
         uses: actions/cache@v3
         env:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -133,7 +133,7 @@ jobs:
   unittest-matrix:
     strategy:
       matrix:
-        go-version: ["1.21", "1.20"] # 1.20 needs quotes otherwise it's interpreted as 1.2
+        go-version: ["~1.21.1", "~1.20.8"] # 1.20 needs quotes otherwise it's interpreted as 1.2
     runs-on: ubuntu-latest
     needs: [setup-environment]
     steps:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: ~1.20.7
+          go-version: ~1.20.8
       - name: Cache Go
         id: go-cache
         uses: actions/cache@v3
@@ -41,7 +41,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: ~1.20.7
+          go-version: ~1.20.8
       - name: Cache Go
         id: go-cache
         uses: actions/cache@v3
@@ -64,7 +64,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: ~1.20.7
+          go-version: ~1.20.8
       - name: Cache Go
         id: go-cache
         uses: actions/cache@v3
@@ -88,7 +88,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: ~1.20.7
+          go-version: ~1.20.8
       - name: Cache Go
         id: go-cache
         uses: actions/cache@v3
@@ -249,7 +249,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: ~1.20.7
+          go-version: ~1.20.8
       - name: Cache Go
         id: go-cache
         uses: actions/cache@v3

--- a/.github/workflows/builder-integration-test.yaml
+++ b/.github/workflows/builder-integration-test.yaml
@@ -30,6 +30,6 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: ~1.20.7
+          go-version: ~1.20.8
       - name: Test
         run: make builder-integration-test

--- a/.github/workflows/builder-release.yaml
+++ b/.github/workflows/builder-release.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: ~1.20.7
+          go-version: ~1.20.8
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4
         with:

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: ~1.20.7
+          go-version: ~1.20.8
       - name: Cache Go
         id: go-cache
         uses: actions/cache@v3

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: ~1.20.7
+          go-version: ~1.20.8
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/contrib-tests.yml
+++ b/.github/workflows/contrib-tests.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: ~1.20.7
+          go-version: ~1.20.8
       - name: Run Contrib Tests
         run: |
           contrib_path=/tmp/opentelemetry-collector-contrib

--- a/.github/workflows/create-dependabot-pr.yml
+++ b/.github/workflows/create-dependabot-pr.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: ~1.20.7
+          go-version: ~1.20.8
       - name: Run dependabot-pr.sh
         run: ./.github/workflows/scripts/dependabot-pr.sh
         env:

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: ~1.20.7
+          go-version: ~1.20.8
 
       - name: Run benchmark
         run: make gobenchmark

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: ~1.20.7
+          go-version: ~1.20.8
       # Prepare Core for release.
       #   - Update CHANGELOG.md file, this is done via chloggen
       #   - Run make prepare-release PREVIOUS_VERSION=1.0.0 RELEASE_CANDIDATE=1.1.0 MODSET=stable

--- a/.github/workflows/tidy-dependencies.yml
+++ b/.github/workflows/tidy-dependencies.yml
@@ -18,7 +18,7 @@ jobs:
           token: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}
       - uses: actions/setup-go@v4
         with:
-          go-version: ~1.20.7
+          go-version: ~1.20.8
           cache: false
       - name: Cache Go
         id: go-cache


### PR DESCRIPTION
**Description:** This is a defensive PR to update the minimum go version used in the collectors github actions workflows. The latest go patch version contains fixes for a CVE that could affect a go build tool chain. 
