### PR TITLE
[extension/experimental/storage] [chore] Deprecate redundant test helper

### DIFF
--- a/extension/experimental/storage/nop_client.go
+++ b/extension/experimental/storage/nop_client.go
@@ -10,6 +10,7 @@ type nopClient struct{}
 var nopClientInstance Client = &nopClient{}
 
 // NewNopClient returns a nop client
+// Deprecated: [0.85.0] Use helpers from github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/storagetest instead.
 func NewNopClient() Client {
 	return nopClientInstance
 }


### PR DESCRIPTION
It is not used in this repo after https://github.com/open-telemetry/opentelemetry-collector/pull/8349 and should not be exported given that we have helpers close to the implementation in contrib
