### PR TITLE
add gRPC health check

### DIFF
--- a/.chloggen/grpc-healthcheck.yaml
+++ b/.chloggen/grpc-healthcheck.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: configgrpc
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: gRPC servers now have the option to register the standard grpc.health.v1.Health healthcheck service.
+
+# One or more tracking issues or pull requests related to the change
+issues: [3040]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/config/configgrpc/README.md
+++ b/config/configgrpc/README.md
@@ -110,4 +110,5 @@ see [confignet README](../confignet/README.md).
 - [`read_buffer_size`](https://godoc.org/google.golang.org/grpc#ReadBufferSize)
 - [`tls`](../configtls/README.md)
 - [`write_buffer_size`](https://godoc.org/google.golang.org/grpc#WriteBufferSize)
+- [`healthcheck`](https://github.com/grpc/grpc/blob/master/doc/health-checking.md): registers the health check service
 - [`auth`](../configauth/README.md)

--- a/config/configgrpc/configgrpc.go
+++ b/config/configgrpc/configgrpc.go
@@ -286,10 +286,7 @@ func (gss *GRPCServerSettings) ToServer(host component.Host, settings component.
 		return nil, err
 	}
 	opts = append(opts, extraOpts...)
-	grpcServer, err := grpc.NewServer(opts...), nil
-	if err != nil {
-		return nil, err
-	}
+	grpcServer := grpc.NewServer(opts...)
 	if gss.HealthCheck {
 		healthServer := health.NewServer()
 		grpc_health_v1.RegisterHealthServer(grpcServer, healthServer)


### PR DESCRIPTION
**Description:** added an option to gRPC server for serving the standard health check service grpc.health.v1.Health

**Link to tracking Issue:** #3040

**Testing:** added test to check that the gRPC service was registered

**Documentation:** added entry in readme for `healthcheck` key