### PR TITLE
fix builder config from env

### DIFF
--- a/.chloggen/builder-env.yaml
+++ b/.chloggen/builder-env.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: builder
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: fix setting `dist.*` keys from env
+
+# One or more tracking issues or pull requests related to the change
+issues: [8239]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/cmd/builder/internal/command.go
+++ b/cmd/builder/internal/command.go
@@ -134,7 +134,10 @@ func initConfig(flags *flag.FlagSet) error {
 
 	// handle env variables
 	if err := k.Load(env.Provider("", ".", func(s string) string {
-		return strings.ReplaceAll(s, ".", "_")
+		// Only values from the `dist.` group can be set,
+		// and the subfields in `dist.` contain `_` in their names.
+		// All other fields are arrays and the koanf env provider doesn't provide a straightforward way to set arrarys.
+		return strings.Replace(strings.ToLower(s), "dist_", "dist.", 1)
 	}), nil); err != nil {
 		return fmt.Errorf("failed to load environment variables: %w", err)
 	}


### PR DESCRIPTION
**Description:** partially fix loading builder config from the env. This moves the env option from unusable (wrong parsing of nested keys), to usable for the `dist.*` settings, but not for any of the components/modules, which will require more complex parsing for arrays.

**Link to tracking Issue:** #8239

**Testing:** try running it locally
