### PR TITLE
[confmap] Add Conf.Delete

### DIFF
--- a/.chloggen/confmap-delete.yaml
+++ b/.chloggen/confmap-delete.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: confmap
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add Conf.Delete
+
+# One or more tracking issues or pull requests related to the change
+issues: [8491]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/confmap/confmap.go
+++ b/confmap/confmap.go
@@ -115,6 +115,11 @@ func (l *Conf) Merge(in *Conf) error {
 	return l.k.Merge(in.k)
 }
 
+// Delete deletes the value at the given key.
+func (l *Conf) Delete(key string) {
+	l.k.Delete(key)
+}
+
 // Sub returns new Conf instance representing a sub-config of this instance.
 // It returns an error is the sub-config is not a map[string]any (use Get()), and an empty Map if none exists.
 func (l *Conf) Sub(key string) (*Conf, error) {

--- a/confmap/confmap_test.go
+++ b/confmap/confmap_test.go
@@ -96,6 +96,48 @@ func TestToStringMap(t *testing.T) {
 	}
 }
 
+func TestBasicOperations(t *testing.T) {
+	stringMap := map[string]any{
+		"receivers": map[string]any{
+			"nop":            nil,
+			"nop/myreceiver": nil,
+		},
+		"processors": map[string]any{
+			"nop":             nil,
+			"nop/myprocessor": nil,
+		},
+		"exporters": map[string]any{
+			"nop":            nil,
+			"nop/myexporter": nil,
+		},
+		"extensions": map[string]any{
+			"nop":             nil,
+			"nop/myextension": nil,
+		},
+	}
+
+	conf := NewFromStringMap(stringMap)
+	assert.Equal(t, stringMap, conf.ToStringMap())
+
+	assert.True(t, conf.IsSet("receivers"))
+	receivers, err := conf.Sub("receivers")
+	assert.NoError(t, err)
+	assert.True(t, receivers.IsSet("nop"))
+
+	receivers.Delete("nop")
+	assert.False(t, receivers.IsSet("nop"))
+
+	conf.Delete("processors")
+	assert.False(t, conf.IsSet("processors"))
+
+	// restore by merging original over top of modified
+	conf2 := NewFromStringMap(stringMap)
+	assert.NoError(t, conf.Merge(conf2))
+
+	assert.Equal(t, stringMap, conf.ToStringMap())
+	assert.Equal(t, conf.ToStringMap(), conf2.ToStringMap())
+}
+
 func TestExpandNilStructPointersHookFunc(t *testing.T) {
 	stringMap := map[string]any{
 		"boolean": nil,


### PR DESCRIPTION
Working on https://github.com/open-telemetry/opentelemetry-collector/pull/8344 has convinced me that this is a reasonable function to expose because it would greatly simplify the way we work with the Conf.