### PR TITLE
rename exporterhelper obsreport method

### DIFF
--- a/.chloggen/codeboten_obsreport-dep.yaml
+++ b/.chloggen/codeboten_obsreport-dep.yaml
@@ -17,9 +17,9 @@ issues: [8492]
 # Use pipe (|) for multiline entries.
 subtext: |
   These deprecated methods/structs have been moved to exporterhelper:
-  - `obsreport.Exporter` -> `exporterhelper.Exporter`
-  - `obsreport.ExporterSettings` -> `exporterhelper.Settings`
-  - `obsreport.NewExporter` -> `exporterhelper.New`
+  - `obsreport.Exporter` -> `exporterhelper.ObsReport`
+  - `obsreport.ExporterSettings` -> `exporterhelper.ObsReportSettings`
+  - `obsreport.NewExporter` -> `exporterhelper.NewObsReport`
 
 # Optional: The change log or logs in which this entry should be included.
 # e.g. '[user]' or '[user, api]'

--- a/exporter/exporterhelper/common.go
+++ b/exporter/exporterhelper/common.go
@@ -168,7 +168,7 @@ type baseExporter struct {
 func newBaseExporter(set exporter.CreateSettings, signal component.DataType, requestExporter bool, marshaler internal.RequestMarshaler,
 	unmarshaler internal.RequestUnmarshaler, osf obsrepSenderFactory, options ...Option) (*baseExporter, error) {
 
-	obsrep, err := newObsExporter(Settings{ExporterID: set.ID, ExporterCreateSettings: set}, globalInstruments)
+	obsrep, err := newObsExporter(ObsReportSettings{ExporterID: set.ID, ExporterCreateSettings: set}, globalInstruments)
 	if err != nil {
 		return nil, err
 	}

--- a/exporter/exporterhelper/obsexporter_test.go
+++ b/exporter/exporterhelper/obsexporter_test.go
@@ -29,7 +29,7 @@ func TestExportTraceDataOp(t *testing.T) {
 		parentCtx, parentSpan := tt.TracerProvider.Tracer("test").Start(context.Background(), t.Name())
 		defer parentSpan.End()
 
-		obsrep, err := newExporter(Settings{
+		obsrep, err := newExporter(ObsReportSettings{
 			ExporterID:             exporterID,
 			ExporterCreateSettings: tt.ToExporterCreateSettings(),
 		}, useOtel)
@@ -77,7 +77,7 @@ func TestExportMetricsOp(t *testing.T) {
 		parentCtx, parentSpan := tt.TracerProvider.Tracer("test").Start(context.Background(), t.Name())
 		defer parentSpan.End()
 
-		obsrep, err := newExporter(Settings{
+		obsrep, err := newExporter(ObsReportSettings{
 			ExporterID:             exporterID,
 			ExporterCreateSettings: tt.ToExporterCreateSettings(),
 		}, useOtel)
@@ -126,7 +126,7 @@ func TestExportLogsOp(t *testing.T) {
 		parentCtx, parentSpan := tt.TracerProvider.Tracer("test").Start(context.Background(), t.Name())
 		defer parentSpan.End()
 
-		obsrep, err := newExporter(Settings{
+		obsrep, err := newExporter(ObsReportSettings{
 			ExporterID:             exporterID,
 			ExporterCreateSettings: tt.ToExporterCreateSettings(),
 		}, useOtel)

--- a/exporter/exporterhelper/obsreport.go
+++ b/exporter/exporterhelper/obsreport.go
@@ -73,26 +73,26 @@ func newInstruments(registry *metric.Registry) *instruments {
 
 // obsExporter is a helper to add observability to an exporter.
 type obsExporter struct {
-	*Exporter
+	*ObsReport
 	failedToEnqueueTraceSpansEntry   *metric.Int64CumulativeEntry
 	failedToEnqueueMetricPointsEntry *metric.Int64CumulativeEntry
 	failedToEnqueueLogRecordsEntry   *metric.Int64CumulativeEntry
 }
 
 // newObsExporter creates a new observability exporter.
-func newObsExporter(cfg Settings, insts *instruments) (*obsExporter, error) {
+func newObsExporter(cfg ObsReportSettings, insts *instruments) (*obsExporter, error) {
 	labelValue := metricdata.NewLabelValue(cfg.ExporterID.String())
 	failedToEnqueueTraceSpansEntry, _ := insts.failedToEnqueueTraceSpans.GetEntry(labelValue)
 	failedToEnqueueMetricPointsEntry, _ := insts.failedToEnqueueMetricPoints.GetEntry(labelValue)
 	failedToEnqueueLogRecordsEntry, _ := insts.failedToEnqueueLogRecords.GetEntry(labelValue)
 
-	exp, err := New(cfg)
+	exp, err := NewObsReport(cfg)
 	if err != nil {
 		return nil, err
 	}
 
 	return &obsExporter{
-		Exporter:                         exp,
+		ObsReport:                        exp,
 		failedToEnqueueTraceSpansEntry:   failedToEnqueueTraceSpansEntry,
 		failedToEnqueueMetricPointsEntry: failedToEnqueueMetricPointsEntry,
 		failedToEnqueueLogRecordsEntry:   failedToEnqueueLogRecordsEntry,

--- a/exporter/exporterhelper/obsreport_test.go
+++ b/exporter/exporterhelper/obsreport_test.go
@@ -22,7 +22,7 @@ func TestExportEnqueueFailure(t *testing.T) {
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
 	insts := newInstruments(metric.NewRegistry())
-	obsrep, err := newObsExporter(Settings{
+	obsrep, err := newObsExporter(ObsReportSettings{
 		ExporterID:             exporter,
 		ExporterCreateSettings: tt.ToExporterCreateSettings(),
 	}, insts)

--- a/obsreport/obsreport_exporter.go
+++ b/obsreport/obsreport_exporter.go
@@ -7,20 +7,17 @@ import "go.opentelemetry.io/collector/exporter/exporterhelper"
 
 // Exporter is a helper to add observability to an exporter.
 //
-// Deprecated: [0.85.0] Use exporterhelper.Exporter instead.
-type Exporter = exporterhelper.Exporter
+// Deprecated: [0.85.0] Use exporterhelper.ObsReport instead.
+type Exporter = exporterhelper.ObsReport
 
 // ExporterSettings are settings for creating an Exporter.
 //
-// Deprecated: [0.85.0] Use exporterhelper.Settings instead.
-type ExporterSettings = exporterhelper.Settings
+// Deprecated: [0.85.0] Use exporterhelper.ObsReportSettings instead.
+type ExporterSettings = exporterhelper.ObsReportSettings
 
 // NewExporter creates a new Exporter.
 //
 // Deprecated: [0.85.0] Use exporterhelper.New instead.
-func NewExporter(cfg ExporterSettings) (*exporterhelper.Exporter, error) {
-	return exporterhelper.New(exporterhelper.Settings{
-		ExporterID:             cfg.ExporterID,
-		ExporterCreateSettings: cfg.ExporterCreateSettings,
-	})
+func NewExporter(cfg ExporterSettings) (*exporterhelper.ObsReport, error) {
+	return exporterhelper.NewObsReport(cfg)
 }

--- a/obsreport/obsreporttest/obsreporttest_test.go
+++ b/obsreport/obsreporttest/obsreporttest_test.go
@@ -192,7 +192,7 @@ func TestCheckExporterTracesViews(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
-	obsrep, err := exporterhelper.New(exporterhelper.Settings{
+	obsrep, err := exporterhelper.NewObsReport(exporterhelper.ObsReportSettings{
 		ExporterID:             exporter,
 		ExporterCreateSettings: tt.ToExporterCreateSettings(),
 	})
@@ -212,7 +212,7 @@ func TestCheckExporterMetricsViews(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
-	obsrep, err := exporterhelper.New(exporterhelper.Settings{
+	obsrep, err := exporterhelper.NewObsReport(exporterhelper.ObsReportSettings{
 		ExporterID:             exporter,
 		ExporterCreateSettings: tt.ToExporterCreateSettings(),
 	})
@@ -232,7 +232,7 @@ func TestCheckExporterLogsViews(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
-	obsrep, err := exporterhelper.New(exporterhelper.Settings{
+	obsrep, err := exporterhelper.NewObsReport(exporterhelper.ObsReportSettings{
 		ExporterID:             exporter,
 		ExporterCreateSettings: tt.ToExporterCreateSettings(),
 	})


### PR DESCRIPTION
This aligns better with the other new methods in the various helper modules.
