### PR TITLE
List valid feature gates when failing to load invalid gate

### DIFF
--- a/.chloggen/log-featuregates.yaml
+++ b/.chloggen/log-featuregates.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: featuregate
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: List valid feature gates when failing to load invalid gate
+
+# One or more tracking issues or pull requests related to the change
+issues: [8505]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/featuregate/registry.go
+++ b/featuregate/registry.go
@@ -109,7 +109,11 @@ func (r *Registry) Register(id string, stage Stage, opts ...RegisterOption) (*Ga
 func (r *Registry) Set(id string, enabled bool) error {
 	v, ok := r.gates.Load(id)
 	if !ok {
-		return fmt.Errorf("no such feature gate %q", id)
+		validGates := []string{}
+		r.VisitAll(func(g *Gate) {
+			validGates = append(validGates, g.ID())
+		})
+		return fmt.Errorf("no such feature gate %q. valid gates: %v", id, validGates)
 	}
 	g := v.(*Gate)
 


### PR DESCRIPTION
I found myself troubleshooting an issue with a feature gate not being accepted and found this to be helpful.

Usage:

```
./bin/otelcorecol --feature-gates=fake
Error: invalid argument "fake" for "--feature-gates" flag: no such feature gate "fake". valid gates: [confmap.expandEnabled telemetry.disableHighCardinalityMetrics telemetry.useOtelForInternalMetrics telemetry.useOtelWithSDKConfigurationForInternalTelemetry]
```