### PR TITLE
Add template converter

### DIFF
--- a/.chloggen/template-converter.yaml
+++ b/.chloggen/template-converter.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: confmap
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add confmap/templateconverter
+
+# One or more tracking issues or pull requests related to the change
+issues: [8344]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/confmap/converter/templateconverter/config.go
+++ b/confmap/converter/templateconverter/config.go
@@ -1,0 +1,121 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package templateconverter // import "go.opentelemetry.io/collector/confmap/converter/templateconverter"
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"text/template"
+
+	"gopkg.in/yaml.v3"
+)
+
+type instanceID struct {
+	tmplType string
+	instName string
+}
+
+func newInstanceID(id string) (*instanceID, error) {
+	parts := strings.SplitN(id, "/", 3)
+	switch len(parts) {
+	case 2: // template/type
+		return &instanceID{
+			tmplType: parts[1],
+		}, nil
+	case 3: // template/type/name
+		return &instanceID{
+			tmplType: parts[1],
+			instName: parts[2],
+		}, nil
+	}
+	return nil, fmt.Errorf("'template' must be followed by type")
+}
+
+func (id *instanceID) withPrefix(prefix string) string {
+	if id.instName == "" {
+		return prefix + "/" + id.tmplType
+	}
+	return prefix + "/" + id.tmplType + "/" + id.instName
+}
+
+type templateConfig struct {
+	Receivers  map[string]any             `yaml:"receivers,omitempty"`
+	Processors map[string]any             `yaml:"processors,omitempty"`
+	Pipelines  map[string]partialPipeline `yaml:"pipelines,omitempty"`
+}
+
+type partialPipeline struct {
+	Receivers  []string `yaml:"receivers,omitempty"`
+	Processors []string `yaml:"processors,omitempty"`
+}
+
+func newTemplateConfig(id *instanceID, tmpl *template.Template, parameters any) (*templateConfig, error) {
+	var rendered bytes.Buffer
+	var err error
+	if err = tmpl.Execute(&rendered, parameters); err != nil {
+		return nil, fmt.Errorf("render: %w", err)
+	}
+
+	cfg := new(templateConfig)
+	if err = yaml.Unmarshal(rendered.Bytes(), cfg); err != nil {
+		return nil, fmt.Errorf("malformed: %w", err)
+	}
+
+	if len(cfg.Receivers) == 0 {
+		return nil, errors.New("must have at least one receiver")
+	}
+
+	if len(cfg.Processors) > 0 && len(cfg.Pipelines) == 0 {
+		return nil, errors.New("template containing processors must have at least one pipeline")
+	}
+	cfg.applyScope(id.tmplType, id.instName)
+	return cfg, nil
+}
+
+func (cfg *templateConfig) applyScope(tmplType, instName string) {
+	// Apply a scope to all component IDs in the template.
+	// At a minimum, the this appends the template type, but will
+	// also apply the template instance name if possible.
+	scopeMapKeys(cfg.Receivers, tmplType, instName)
+	scopeMapKeys(cfg.Processors, tmplType, instName)
+	for _, p := range cfg.Pipelines {
+		scopeSliceValues(p.Receivers, tmplType, instName)
+		scopeSliceValues(p.Processors, tmplType, instName)
+	}
+}
+
+// In order to ensure the component IDs in this template are globally unique,
+// appending the template instance name to the ID of each component.
+func scopeMapKeys(cfgs map[string]any, tmplType, instName string) {
+	// To avoid risk of collision, build a list of IDs,
+	// sort them by length, and then append starting with the longest.
+	componentIDs := make([]string, 0, len(cfgs))
+	for componentID := range cfgs {
+		componentIDs = append(componentIDs, componentID)
+	}
+	sort.Slice(componentIDs, func(i, j int) bool {
+		return len(componentIDs[i]) > len(componentIDs[j])
+	})
+	for _, componentID := range componentIDs {
+		cfg := cfgs[componentID]
+		delete(cfgs, componentID)
+		cfgs[scopedID(componentID, tmplType, instName)] = cfg
+	}
+}
+
+func scopeSliceValues(componentIDs []string, tmplType, instName string) {
+	for i, componentID := range componentIDs {
+		componentIDs[i] = scopedID(componentID, tmplType, instName)
+	}
+}
+
+func scopedID(componentID string, templateType, instanceName string) string {
+	if instanceName == "" {
+		return componentID + "/" + templateType
+	}
+	return componentID + "/" + templateType + "/" + instanceName
+}

--- a/confmap/converter/templateconverter/converter.go
+++ b/confmap/converter/templateconverter/converter.go
@@ -50,7 +50,14 @@ func (c *converter) Convert(_ context.Context, conf *confmap.Conf) error {
 	}
 
 	c.cfg = conf.ToStringMap()
-	for templateID, parameters := range c.cfg["receivers"].(map[string]any) {
+	if c.cfg["receivers"] == nil {
+		return nil // invalid, but let the unmarshaler handle it
+	}
+	receiverCfgs, ok := c.cfg["receivers"].(map[string]any)
+	if !ok {
+		return nil // invalid, but let the unmarshaler handle it
+	}
+	for templateID, parameters := range receiverCfgs {
 		if !strings.HasPrefix(templateID, "template") {
 			continue
 		}

--- a/confmap/converter/templateconverter/converter.go
+++ b/confmap/converter/templateconverter/converter.go
@@ -1,0 +1,262 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package templateconverter // import "go.opentelemetry.io/collector/confmap/converter/templateconverter"
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"text/template"
+
+	"go.opentelemetry.io/collector/confmap"
+)
+
+// Define a template type by adding a "templates" section to the config.
+//
+// templates:
+//
+//	receivers:
+//	  my_template: |
+//	    receivers: ... # required, one or more
+//	    processors: ... # optional
+//	    pipelines: ...  # required if processors are used, otherwise optional
+//
+// Instantiate a templated receiver:
+//
+// receivers:
+//
+//	template/my_template[/name]:
+//	  parameter_one: value_one
+//	  parameter_two: value_two
+type converter struct {
+	cfg               map[string]any
+	receiverTemplates map[string]*template.Template
+}
+
+// New returns a confmap.Converter, that renders all templates and inserts them into the given confmap.Conf.
+func New() confmap.Converter {
+	return &converter{
+		receiverTemplates: make(map[string]*template.Template),
+	}
+}
+
+func (c *converter) Convert(_ context.Context, conf *confmap.Conf) error {
+	if err := c.parseTemplates(conf); err != nil {
+		return err
+	} else if len(c.receiverTemplates) == 0 {
+		return nil
+	}
+
+	c.cfg = conf.ToStringMap()
+	for templateID, parameters := range c.cfg["receivers"].(map[string]any) {
+		if !strings.HasPrefix(templateID, "template") {
+			continue
+		}
+
+		id, err := newInstanceID(templateID)
+		if err != nil {
+			return err
+		}
+
+		tmpl, ok := c.receiverTemplates[id.tmplType]
+		if !ok {
+			return fmt.Errorf("template type %q not found", id.tmplType)
+		}
+
+		cfg, err := newTemplateConfig(id, tmpl, parameters)
+		if err != nil {
+			return err
+		}
+
+		c.expandTemplate(cfg, id)
+	}
+	delete(c.cfg, "templates")
+
+	*conf = *confmap.NewFromStringMap(c.cfg)
+	return nil
+}
+
+func (c *converter) parseTemplates(conf *confmap.Conf) error {
+	if !conf.IsSet("templates") {
+		return nil
+	}
+
+	templatesMap, ok := conf.ToStringMap()["templates"].(map[string]any)
+	if !ok {
+		return fmt.Errorf("'templates' must be a map")
+	}
+	if templatesMap["receivers"] == nil {
+		return fmt.Errorf("'templates' must contain a 'receivers' section")
+	}
+
+	receiverTemplates, ok := templatesMap["receivers"].(map[string]any)
+	if !ok {
+		return fmt.Errorf("'templates::receivers' must be a map")
+	}
+
+	for templateType, templateVal := range receiverTemplates {
+		templateStr, ok := templateVal.(string)
+		if !ok {
+			return fmt.Errorf("'templates::receivers::%s' must be a string", templateType)
+		}
+		parsedTemplate, err := template.New(templateType).Parse(templateStr)
+		if err != nil {
+			return err
+		}
+		c.receiverTemplates[templateType] = parsedTemplate
+	}
+	return nil
+}
+
+func (c *converter) expandTemplate(cfg *templateConfig, id *instanceID) {
+	// Delete the reference to this template instance and
+	// replace it with the rendered receiver(s).
+	delete(c.cfg["receivers"].(map[string]any), id.withPrefix("template"))
+	for receiverID, receiverCfg := range cfg.Receivers {
+		c.cfg["receivers"].(map[string]any)[receiverID] = receiverCfg
+	}
+
+	// Special case where the template only contains receivers. In this case,
+	// we can just substitute the rendered receivers in place of the template ID.
+	if len(cfg.Processors) == 0 && len(cfg.Pipelines) == 0 {
+		c.expandSimple(cfg, id)
+	} else {
+		c.expandComplex(cfg, id)
+	}
+}
+
+// Special case where the template only contains receivers. In this case,
+// we can just substitute the rendered receivers in place of the template ID.
+func (c *converter) expandSimple(cfg *templateConfig, id *instanceID) {
+	pipelinesMap := c.cfg["service"].(map[string]any)["pipelines"].(map[string]any)
+	for _, pipelineMap := range pipelinesMap {
+		receiverIDs := pipelineMap.(map[string]any)["receivers"].([]any)
+		newReceiverIDs := make([]any, 0, len(receiverIDs))
+		for _, receiverID := range receiverIDs {
+			if receiverID != id.withPrefix("template") {
+				newReceiverIDs = append(newReceiverIDs, receiverID)
+			}
+		}
+
+		if len(newReceiverIDs) == len(receiverIDs) {
+			// This pipeline did not use the template
+			continue
+		}
+
+		for receiverID := range cfg.Receivers {
+			newReceiverIDs = append(newReceiverIDs, receiverID)
+		}
+		// This makes tests deterministic
+		sort.Slice(newReceiverIDs, func(i, j int) bool {
+			return newReceiverIDs[i].(string) < newReceiverIDs[j].(string)
+		})
+		pipelineMap.(map[string]any)["receivers"] = newReceiverIDs
+	}
+}
+
+// Any partial pipelines defined in a template will be expanded into full pipelines.
+// These will all use a forward connector to emit data to the pipelines in which
+// the template was used as a receiver.
+func (c *converter) expandComplex(cfg *templateConfig, id *instanceID) {
+	pipelinesMap := c.cfg["service"].(map[string]any)["pipelines"].(map[string]any)
+	// Update the processors section by adding any rendered processors.
+	if len(cfg.Processors) > 0 && c.cfg["processors"] == nil {
+		c.cfg["processors"] = make(map[string]any, len(cfg.Processors))
+	}
+	for processorID, processorCfg := range cfg.Processors {
+		c.cfg["processors"].(map[string]any)[processorID] = processorCfg
+	}
+
+	// Add a dedicated forward connector for this template instance.
+	// This will consume data from the partial pipelines and emit to
+	// any top-level pipelines that used the template as a receiver.
+	connectorID := id.withPrefix("forward")
+	if c.cfg["connectors"] == nil {
+		c.cfg["connectors"] = make(map[string]any, 1)
+	}
+	c.cfg["connectors"].(map[string]any)[connectorID] = nil
+
+	// Crawl through existing "pipelines" and replace all references
+	// to this instance of the template with the forward connector.
+	//
+	// Also take note of the pipeline data types in which the template is used.
+	// We'll use these later to include only relevant partial pipelines.
+	var usedTraces, usedMetrics, usedLogs bool
+	for pipelineID := range pipelinesMap {
+		switch {
+		case isTraces(pipelineID):
+			usedTraces = true
+		case isMetrics(pipelineID):
+			usedMetrics = true
+		case isLogs(pipelineID):
+			usedLogs = true
+		default:
+			continue
+		}
+
+		pipelineMap := pipelinesMap[pipelineID].(map[string]any)
+		receiverIDs := pipelineMap["receivers"].([]any)
+		for i, receiverID := range receiverIDs {
+			if receiverID == id.withPrefix("template") {
+				receiverIDs[i] = connectorID
+			}
+		}
+		pipelineMap["receivers"] = receiverIDs
+	}
+
+	// For each partial pipeline, build a full pipeline by appending
+	// the forward connector as the exporter.
+	//
+	// Only include the pipeline if the template was used as a receiver
+	// in a pipeline of the same data type.
+	for partialName, partial := range cfg.Pipelines {
+		switch {
+		case isTraces(partialName):
+			if !usedTraces {
+				continue
+			}
+		case isMetrics(partialName):
+			if !usedMetrics {
+				continue
+			}
+		case isLogs(partialName):
+			if !usedLogs {
+				continue
+			}
+		default:
+			continue
+		}
+
+		scopedPipelineName := id.withPrefix(partialName)
+		receivers := make([]any, 0, len(partial.Receivers))
+		for _, receiverID := range partial.Receivers {
+			receivers = append(receivers, receiverID)
+		}
+		processors := make([]any, 0, len(partial.Processors))
+		for _, processorID := range partial.Processors {
+			processors = append(processors, processorID)
+		}
+		newPipeline := map[string]any{
+			"receivers": receivers,
+			"exporters": []any{connectorID},
+		}
+		if len(partial.Processors) > 0 {
+			newPipeline["processors"] = processors
+		}
+		pipelinesMap[scopedPipelineName] = newPipeline
+	}
+}
+
+func isTraces(pipelineID string) bool {
+	return pipelineID == "traces" || strings.HasPrefix(pipelineID, "traces/")
+}
+
+func isMetrics(pipelineID string) bool {
+	return pipelineID == "metrics" || strings.HasPrefix(pipelineID, "metrics/")
+}
+
+func isLogs(pipelineID string) bool {
+	return pipelineID == "logs" || strings.HasPrefix(pipelineID, "logs/")
+}

--- a/confmap/converter/templateconverter/converter_test.go
+++ b/confmap/converter/templateconverter/converter_test.go
@@ -1,0 +1,112 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package templateconverter
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/collector/confmap/confmaptest"
+)
+
+func TestTemplateConverter(t *testing.T) {
+	for _, tc := range []string{
+		"no-templates",
+		"single-receiver-no-pipelines",
+		"single-receiver",
+		"single-processor",
+		"multiple-receivers-no-pipelines",
+		"multiple-receivers-single-pipeline",
+		"multiple-receivers-separate-pipelines",
+		"multiple-processors",
+		"multiple-pipelines",
+		"multiple-templates",
+		"multiple-template-instances",
+		"auto-skip-traces",
+		"auto-skip-metrics",
+		"auto-skip-logs",
+		"extra-pipeline",
+		"extra-receiver",
+		"only-processor-templated",
+		"extra-receiver-no-pipelines",
+		"unused-template",
+	} {
+		t.Run(tc, func(t *testing.T) {
+			conf, err := confmaptest.LoadConf(filepath.Join("testdata", "valid", tc, "config.yaml"))
+			require.NoError(t, err)
+
+			expected, err := confmaptest.LoadConf(filepath.Join("testdata", "valid", tc, "expected.yaml"))
+			require.NoError(t, err)
+
+			require.NoError(t, New().Convert(context.Background(), conf))
+			expectedMap := expected.ToStringMap()
+			actualMap := conf.ToStringMap()
+			assert.Equal(t, expectedMap, actualMap)
+		})
+	}
+}
+
+func TestRenderError(t *testing.T) {
+	var testCases = []struct {
+		name      string
+		expectErr string
+	}{
+		{
+			name:      "template-not-found",
+			expectErr: "template type \"non_existent\" not found",
+		},
+		{
+			name:      "malformed-template-id",
+			expectErr: "'template' must be followed by type",
+		},
+		{
+			name:      "malformed-template-structure",
+			expectErr: "malformed: yaml: unmarshal errors",
+		},
+		{
+			name:      "malformed-template-syntax",
+			expectErr: "template: my_filelog_template:4: unexpected",
+		},
+		{
+			name:      "missing-receiver",
+			expectErr: "must have at least one receiver",
+		},
+		{
+			name:      "missing-pipeline",
+			expectErr: "template containing processors must have at least one pipeline",
+		},
+		{
+			name:      "templates-wrong-type",
+			expectErr: "'templates' must be a map",
+		},
+		{
+			name:      "templates-receivers-missing",
+			expectErr: "'templates' must contain a 'receivers' section",
+		},
+		{
+			name:      "templates-receivers-wrong-type",
+			expectErr: "'templates::receivers' must be a map",
+		},
+		{
+			name:      "templates-receivers-raw-wrong-type",
+			expectErr: "'templates::receivers::my_filelog_template' must be a string",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			conf, err := confmaptest.LoadConf(filepath.Join("testdata", "invalid", tc.name+".yaml"))
+			require.NoError(t, err)
+
+			err = New().Convert(context.Background(), conf)
+			// validate that err is not nil and that it contains the expected error message
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), tc.expectErr)
+		})
+	}
+}

--- a/confmap/converter/templateconverter/testdata/invalid/malformed-template-id.yaml
+++ b/confmap/converter/templateconverter/testdata/invalid/malformed-template-id.yaml
@@ -1,0 +1,25 @@
+receivers:
+  template: # missing "/<template_type>[/<template_name>]"
+    my_file: foo.log
+processors:
+  batch:
+exporters:
+  otlp:
+    endpoint: localhost:4317
+
+service:
+  pipelines:
+    logs:
+      receivers: [template/my_filelog_template]
+      processors: [batch]
+      exporters: [otlp]
+
+templates:
+  receivers:
+    my_filelog_template: |
+      receivers:
+        filelog:
+          include: {{ .my_file }}
+      pipelines:
+        logs:
+          receivers: [filelog]

--- a/confmap/converter/templateconverter/testdata/invalid/malformed-template-structure.yaml
+++ b/confmap/converter/templateconverter/testdata/invalid/malformed-template-structure.yaml
@@ -1,0 +1,22 @@
+receivers:
+  template/my_filelog_template:
+processors:
+  batch:
+exporters:
+  otlp:
+    endpoint: localhost:4317
+
+service:
+  pipelines:
+    logs:
+      receivers: [template/my_filelog_template]
+      processors: [batch]
+      exporters: [otlp]
+
+templates:
+  receivers:
+    my_filelog_template: |
+      receivers:
+        filelog:
+          include: {{ .my_file }}
+      pipelines: []

--- a/confmap/converter/templateconverter/testdata/invalid/malformed-template-syntax.yaml
+++ b/confmap/converter/templateconverter/testdata/invalid/malformed-template-syntax.yaml
@@ -1,0 +1,22 @@
+receivers:
+  template/my_filelog_template:
+processors:
+  batch:
+exporters:
+  otlp:
+    endpoint: localhost:4317
+
+service:
+  pipelines:
+    logs:
+      receivers: [template/my_filelog_template]
+      processors: [batch]
+      exporters: [otlp]
+
+templates:
+  receivers:
+    my_filelog_template: |
+      receivers:
+        filelog:
+          include: {{ .my_file }}
+      pipe [{{{{{{}}}}]

--- a/confmap/converter/templateconverter/testdata/invalid/missing-pipeline.yaml
+++ b/confmap/converter/templateconverter/testdata/invalid/missing-pipeline.yaml
@@ -1,0 +1,24 @@
+receivers:
+  template/my_filelog_template:
+    my_file: foo.log
+processors:
+  batch:
+exporters:
+  otlp:
+    endpoint: localhost:4317
+
+service:
+  pipelines:
+    logs:
+      receivers: [template/my_filelog_template]
+      processors: [batch]
+      exporters: [otlp]
+
+templates:
+  receivers:
+    my_filelog_template: |
+      receivers:
+        filelog:
+          include: {{ .my_file }}
+      processors:
+        batch:

--- a/confmap/converter/templateconverter/testdata/invalid/missing-receiver.yaml
+++ b/confmap/converter/templateconverter/testdata/invalid/missing-receiver.yaml
@@ -1,0 +1,22 @@
+receivers:
+  template/my_filelog_template:
+    my_file: foo.log
+processors:
+  batch:
+exporters:
+  otlp:
+    endpoint: localhost:4317
+
+service:
+  pipelines:
+    logs:
+      receivers: [template/my_filelog_template]
+      processors: [batch]
+      exporters: [otlp]
+
+templates:
+  receivers:
+    my_filelog_template: |
+      pipelines:
+        logs:
+          receivers: [filelog]

--- a/confmap/converter/templateconverter/testdata/invalid/template-not-found.yaml
+++ b/confmap/converter/templateconverter/testdata/invalid/template-not-found.yaml
@@ -1,0 +1,24 @@
+receivers:
+  template/non_existent:
+processors:
+  batch:
+exporters:
+  otlp:
+    endpoint: localhost:4317
+
+service:
+  pipelines:
+    logs:
+      receivers: [template/my_filelog_template]
+      processors: [batch]
+      exporters: [otlp]
+
+templates:
+  receivers:
+    my_filelog_template: |
+      receivers:
+        filelog:
+          include: {{ .my_file }}
+      pipelines:
+        logs:
+          receivers: [filelog]

--- a/confmap/converter/templateconverter/testdata/invalid/templates-missing-receivers.yaml
+++ b/confmap/converter/templateconverter/testdata/invalid/templates-missing-receivers.yaml
@@ -1,0 +1,18 @@
+receivers:
+  template/my_filelog_template:
+    my_file: foo.log
+processors:
+  batch:
+exporters:
+  otlp:
+    endpoint: localhost:4317
+
+service:
+  pipelines:
+    logs:
+      receivers: [template/my_filelog_template]
+      processors: [batch]
+      exporters: [otlp]
+
+templates:
+  foo:

--- a/confmap/converter/templateconverter/testdata/invalid/templates-receivers-missing.yaml
+++ b/confmap/converter/templateconverter/testdata/invalid/templates-receivers-missing.yaml
@@ -1,0 +1,17 @@
+receivers:
+  filelog:
+    include: foo.log
+exporters:
+  otlp:
+    endpoint: localhost:4319
+
+service:
+  pipelines:
+    metrics:
+      receivers: [template/my_otlp_template]
+      exporters: [otlp]
+    traces:
+      receivers: [template/my_otlp_template]
+      exporters: [otlp]
+
+templates: {}

--- a/confmap/converter/templateconverter/testdata/invalid/templates-receivers-raw-wrong-type.yaml
+++ b/confmap/converter/templateconverter/testdata/invalid/templates-receivers-raw-wrong-type.yaml
@@ -1,0 +1,19 @@
+receivers:
+  filelog:
+    include: foo.log
+exporters:
+  otlp:
+    endpoint: localhost:4319
+
+service:
+  pipelines:
+    metrics:
+      receivers: [template/my_otlp_template]
+      exporters: [otlp]
+    traces:
+      receivers: [template/my_otlp_template]
+      exporters: [otlp]
+
+templates:
+  receivers:
+    my_filelog_template: 123

--- a/confmap/converter/templateconverter/testdata/invalid/templates-receivers-wrong-type.yaml
+++ b/confmap/converter/templateconverter/testdata/invalid/templates-receivers-wrong-type.yaml
@@ -1,0 +1,18 @@
+receivers:
+  filelog:
+    include: foo.log
+exporters:
+  otlp:
+    endpoint: localhost:4319
+
+service:
+  pipelines:
+    metrics:
+      receivers: [template/my_otlp_template]
+      exporters: [otlp]
+    traces:
+      receivers: [template/my_otlp_template]
+      exporters: [otlp]
+
+templates:
+  receivers: []

--- a/confmap/converter/templateconverter/testdata/invalid/templates-wrong-type.yaml
+++ b/confmap/converter/templateconverter/testdata/invalid/templates-wrong-type.yaml
@@ -1,0 +1,17 @@
+receivers:
+  template/my_filelog_template:
+    my_file: foo.log
+processors:
+  batch:
+exporters:
+  otlp:
+    endpoint: localhost:4317
+
+service:
+  pipelines:
+    logs:
+      receivers: [template/my_filelog_template]
+      processors: [batch]
+      exporters: [otlp]
+
+templates: []

--- a/confmap/converter/templateconverter/testdata/valid/auto-skip-logs/config.yaml
+++ b/confmap/converter/templateconverter/testdata/valid/auto-skip-logs/config.yaml
@@ -1,0 +1,29 @@
+receivers:
+  template/my_otlp_template:
+    port: 4317
+exporters:
+  otlp:
+    endpoint: localhost:4319
+
+service:
+  pipelines:
+    metrics:
+      receivers: [template/my_otlp_template]
+      exporters: [otlp]
+    traces:
+      receivers: [template/my_otlp_template]
+      exporters: [otlp]
+
+templates:
+  receivers:
+    my_otlp_template: |
+      receivers:
+        otlp:
+          endpoint: localhost:{{ .port }}
+      pipelines:
+        logs:
+          receivers: [otlp]
+        metrics:
+          receivers: [otlp]
+        traces:
+          receivers: [otlp]

--- a/confmap/converter/templateconverter/testdata/valid/auto-skip-logs/expected.yaml
+++ b/confmap/converter/templateconverter/testdata/valid/auto-skip-logs/expected.yaml
@@ -1,0 +1,23 @@
+receivers:
+  otlp/my_otlp_template:
+    endpoint: localhost:4317
+exporters:
+  otlp:
+    endpoint: localhost:4319
+connectors:
+  forward/my_otlp_template:
+
+service:
+  pipelines:
+    traces/my_otlp_template:
+      receivers: [otlp/my_otlp_template]
+      exporters: [forward/my_otlp_template]
+    metrics/my_otlp_template:
+      receivers: [otlp/my_otlp_template]
+      exporters: [forward/my_otlp_template]
+    traces:
+      receivers: [forward/my_otlp_template]
+      exporters: [otlp]
+    metrics:
+      receivers: [forward/my_otlp_template]
+      exporters: [otlp]

--- a/confmap/converter/templateconverter/testdata/valid/auto-skip-metrics/config.yaml
+++ b/confmap/converter/templateconverter/testdata/valid/auto-skip-metrics/config.yaml
@@ -1,0 +1,29 @@
+receivers:
+  template/my_otlp_template:
+    port: 4317
+exporters:
+  otlp:
+    endpoint: localhost:4319
+
+service:
+  pipelines:
+    traces:
+      receivers: [template/my_otlp_template]
+      exporters: [otlp]
+    logs:
+      receivers: [template/my_otlp_template]
+      exporters: [otlp]
+
+templates:
+  receivers:
+    my_otlp_template: |
+      receivers:
+        otlp:
+          endpoint: localhost:{{ .port }}
+      pipelines:
+        logs:
+          receivers: [otlp]
+        metrics:
+          receivers: [otlp]
+        traces:
+          receivers: [otlp]

--- a/confmap/converter/templateconverter/testdata/valid/auto-skip-metrics/expected.yaml
+++ b/confmap/converter/templateconverter/testdata/valid/auto-skip-metrics/expected.yaml
@@ -1,0 +1,23 @@
+receivers:
+  otlp/my_otlp_template:
+    endpoint: localhost:4317
+exporters:
+  otlp:
+    endpoint: localhost:4319
+connectors:
+  forward/my_otlp_template:
+
+service:
+  pipelines:
+    traces/my_otlp_template:
+      receivers: [otlp/my_otlp_template]
+      exporters: [forward/my_otlp_template]
+    logs/my_otlp_template:
+      receivers: [otlp/my_otlp_template]
+      exporters: [forward/my_otlp_template]
+    traces:
+      receivers: [forward/my_otlp_template]
+      exporters: [otlp]
+    logs:
+      receivers: [forward/my_otlp_template]
+      exporters: [otlp]

--- a/confmap/converter/templateconverter/testdata/valid/auto-skip-traces/config.yaml
+++ b/confmap/converter/templateconverter/testdata/valid/auto-skip-traces/config.yaml
@@ -1,0 +1,29 @@
+receivers:
+  template/my_otlp_template:
+    port: 4317
+exporters:
+  otlp:
+    endpoint: localhost:4319
+
+service:
+  pipelines:
+    metrics:
+      receivers: [template/my_otlp_template]
+      exporters: [otlp]
+    logs:
+      receivers: [template/my_otlp_template]
+      exporters: [otlp]
+
+templates:
+  receivers:
+    my_otlp_template: |
+      receivers:
+        otlp:
+          endpoint: localhost:{{ .port }}
+      pipelines:
+        logs:
+          receivers: [otlp]
+        metrics:
+          receivers: [otlp]
+        traces:
+          receivers: [otlp]

--- a/confmap/converter/templateconverter/testdata/valid/auto-skip-traces/expected.yaml
+++ b/confmap/converter/templateconverter/testdata/valid/auto-skip-traces/expected.yaml
@@ -1,0 +1,23 @@
+receivers:
+  otlp/my_otlp_template:
+    endpoint: localhost:4317
+exporters:
+  otlp:
+    endpoint: localhost:4319
+connectors:
+  forward/my_otlp_template:
+
+service:
+  pipelines:
+    metrics/my_otlp_template:
+      receivers: [otlp/my_otlp_template]
+      exporters: [forward/my_otlp_template]
+    logs/my_otlp_template:
+      receivers: [otlp/my_otlp_template]
+      exporters: [forward/my_otlp_template]
+    metrics:
+      receivers: [forward/my_otlp_template]
+      exporters: [otlp]
+    logs:
+      receivers: [forward/my_otlp_template]
+      exporters: [otlp]

--- a/confmap/converter/templateconverter/testdata/valid/extra-pipeline/config.yaml
+++ b/confmap/converter/templateconverter/testdata/valid/extra-pipeline/config.yaml
@@ -1,0 +1,29 @@
+# Test that template expansion doesn't touch pipelines which contain
+# no templated receivers.
+receivers:
+  template/my_filelog_template:
+    my_file: foo.log
+  extra:
+    foo: bar
+processors:
+  batch:
+exporters:
+  otlp:
+    endpoint: localhost:4317
+
+service:
+  pipelines:
+    logs:
+      receivers: [template/my_filelog_template]
+      processors: [batch]
+      exporters: [otlp]
+    metrics:
+      receivers: [extra]
+      exporters: [otlp]
+
+templates:
+  receivers:
+    my_filelog_template: |
+      receivers:
+        filelog:
+          include: {{ .my_file }}

--- a/confmap/converter/templateconverter/testdata/valid/extra-pipeline/expected.yaml
+++ b/confmap/converter/templateconverter/testdata/valid/extra-pipeline/expected.yaml
@@ -1,0 +1,20 @@
+receivers:
+  filelog/my_filelog_template:
+    include: foo.log
+  extra:
+    foo: bar
+processors:
+  batch:
+exporters:
+  otlp:
+    endpoint: localhost:4317
+
+service:
+  pipelines:
+    logs:
+      receivers: [filelog/my_filelog_template]
+      processors: [batch]
+      exporters: [otlp]
+    metrics:
+      receivers: [extra]
+      exporters: [otlp]

--- a/confmap/converter/templateconverter/testdata/valid/extra-receiver-no-pipelines/config.yaml
+++ b/confmap/converter/templateconverter/testdata/valid/extra-receiver-no-pipelines/config.yaml
@@ -1,0 +1,26 @@
+# Test that template expansion doesn't touch non-templated receivers
+# used in the same pipeline.
+receivers:
+  template/my_filelog_template:
+    my_file: foo.log
+  extra:
+    foo: bar
+processors:
+  batch:
+exporters:
+  otlp:
+    endpoint: localhost:4317
+
+service:
+  pipelines:
+    logs:
+      receivers: [extra, template/my_filelog_template]
+      processors: [batch]
+      exporters: [otlp]
+
+templates:
+  receivers:
+    my_filelog_template: |
+      receivers:
+        filelog:
+          include: {{ .my_file }}

--- a/confmap/converter/templateconverter/testdata/valid/extra-receiver-no-pipelines/expected.yaml
+++ b/confmap/converter/templateconverter/testdata/valid/extra-receiver-no-pipelines/expected.yaml
@@ -1,0 +1,17 @@
+receivers:
+  filelog/my_filelog_template:
+    include: foo.log
+  extra:
+    foo: bar
+processors:
+  batch:
+exporters:
+  otlp:
+    endpoint: localhost:4317
+
+service:
+  pipelines:
+    logs:
+      receivers: [extra, filelog/my_filelog_template]
+      processors: [batch]
+      exporters: [otlp]

--- a/confmap/converter/templateconverter/testdata/valid/extra-receiver/config.yaml
+++ b/confmap/converter/templateconverter/testdata/valid/extra-receiver/config.yaml
@@ -1,0 +1,28 @@
+# Test that template expansion doesn't touch non-templated receivers.
+receivers:
+  template/my_filelog_template:
+    my_file: foo.log
+  extra:
+    foo: bar
+processors:
+  batch:
+exporters:
+  otlp:
+    endpoint: localhost:4317
+
+service:
+  pipelines:
+    logs:
+      receivers: [extra, template/my_filelog_template]
+      processors: [batch]
+      exporters: [otlp]
+
+templates:
+  receivers:
+    my_filelog_template: |
+      receivers:
+        filelog:
+          include: {{ .my_file }}
+      pipelines:
+        logs:
+          receivers: [filelog]

--- a/confmap/converter/templateconverter/testdata/valid/extra-receiver/expected.yaml
+++ b/confmap/converter/templateconverter/testdata/valid/extra-receiver/expected.yaml
@@ -1,0 +1,22 @@
+receivers:
+  filelog/my_filelog_template:
+    include: foo.log
+  extra:
+    foo: bar
+processors:
+  batch:
+exporters:
+  otlp:
+    endpoint: localhost:4317
+connectors:
+  forward/my_filelog_template:
+
+service:
+  pipelines:
+    logs/my_filelog_template:
+      receivers: [filelog/my_filelog_template]
+      exporters: [forward/my_filelog_template]
+    logs:
+      receivers: [extra, forward/my_filelog_template]
+      processors: [batch]
+      exporters: [otlp]

--- a/confmap/converter/templateconverter/testdata/valid/multiple-pipelines/config.yaml
+++ b/confmap/converter/templateconverter/testdata/valid/multiple-pipelines/config.yaml
@@ -1,0 +1,35 @@
+receivers:
+  template/my_filelog_template:
+    my_foo_file: foo.log
+    my_bar_file: bar.log
+processors:
+  batch:
+exporters:
+  otlp:
+    endpoint: localhost:4317
+
+service:
+  pipelines:
+    logs:
+      receivers: [template/my_filelog_template]
+      processors: [batch]
+      exporters: [otlp]
+
+templates:
+  receivers:
+    my_filelog_template: |
+      receivers:
+        filelog/foo:
+          include: {{ .my_foo_file }}
+        filelog/bar:
+          include: {{ .my_bar_file }}
+      processors:
+        batch/1:
+        batch/2:
+      pipelines:
+        logs/a:
+          receivers: [filelog/foo]
+          processors: [batch/1]
+        logs/b:
+          receivers: [filelog/bar]
+          processors: [batch/2]

--- a/confmap/converter/templateconverter/testdata/valid/multiple-pipelines/expected.yaml
+++ b/confmap/converter/templateconverter/testdata/valid/multiple-pipelines/expected.yaml
@@ -1,0 +1,29 @@
+receivers:
+  filelog/foo/my_filelog_template:
+    include: foo.log
+  filelog/bar/my_filelog_template:
+    include: bar.log
+processors:
+  batch:
+  batch/1/my_filelog_template:
+  batch/2/my_filelog_template:
+exporters:
+  otlp:
+    endpoint: localhost:4317
+connectors:
+  forward/my_filelog_template:
+
+service:
+  pipelines:
+    logs/a/my_filelog_template:
+      receivers: [filelog/foo/my_filelog_template]
+      processors: [batch/1/my_filelog_template]
+      exporters: [forward/my_filelog_template]
+    logs/b/my_filelog_template:
+      receivers: [filelog/bar/my_filelog_template]
+      processors: [batch/2/my_filelog_template]
+      exporters: [forward/my_filelog_template]
+    logs:
+      receivers: [forward/my_filelog_template]
+      processors: [batch]
+      exporters: [otlp]

--- a/confmap/converter/templateconverter/testdata/valid/multiple-processors/config.yaml
+++ b/confmap/converter/templateconverter/testdata/valid/multiple-processors/config.yaml
@@ -1,0 +1,29 @@
+receivers:
+  template/my_filelog_template:
+    my_file: foo.log
+processors:
+  batch:
+exporters:
+  otlp:
+    endpoint: localhost:4317
+
+service:
+  pipelines:
+    logs:
+      receivers: [template/my_filelog_template]
+      processors: [batch]
+      exporters: [otlp]
+
+templates:
+  receivers:
+    my_filelog_template: |
+      receivers:
+        filelog:
+          include: {{ .my_file }}
+      processors:
+        batch/1:
+        batch/2:
+      pipelines:
+        logs:
+          receivers: [filelog]
+          processors: [batch/1, batch/2]

--- a/confmap/converter/templateconverter/testdata/valid/multiple-processors/expected.yaml
+++ b/confmap/converter/templateconverter/testdata/valid/multiple-processors/expected.yaml
@@ -1,0 +1,23 @@
+receivers:
+  filelog/my_filelog_template:
+    include: foo.log
+processors:
+  batch:
+  batch/1/my_filelog_template:
+  batch/2/my_filelog_template:
+exporters:
+  otlp:
+    endpoint: localhost:4317
+connectors:
+  forward/my_filelog_template:
+
+service:
+  pipelines:
+    logs/my_filelog_template:
+      receivers: [filelog/my_filelog_template]
+      processors: [batch/1/my_filelog_template, batch/2/my_filelog_template]
+      exporters: [forward/my_filelog_template]
+    logs:
+      receivers: [forward/my_filelog_template]
+      processors: [batch]
+      exporters: [otlp]

--- a/confmap/converter/templateconverter/testdata/valid/multiple-receivers-no-pipelines/config.yaml
+++ b/confmap/converter/templateconverter/testdata/valid/multiple-receivers-no-pipelines/config.yaml
@@ -1,0 +1,25 @@
+receivers:
+  template/my_filelog_template:
+    my_foo_file: foo.log
+    my_bar_file: bar.log
+processors:
+  batch:
+exporters:
+  otlp:
+    endpoint: localhost:4317
+
+service:
+  pipelines:
+    logs:
+      receivers: [template/my_filelog_template]
+      processors: [batch]
+      exporters: [otlp]
+
+templates:
+  receivers:
+    my_filelog_template: |
+      receivers:
+        filelog/foo:
+          include: {{ .my_foo_file }}
+        filelog/bar:
+          include: {{ .my_bar_file }}

--- a/confmap/converter/templateconverter/testdata/valid/multiple-receivers-no-pipelines/expected.yaml
+++ b/confmap/converter/templateconverter/testdata/valid/multiple-receivers-no-pipelines/expected.yaml
@@ -1,0 +1,17 @@
+receivers:
+  filelog/bar/my_filelog_template:
+    include: bar.log
+  filelog/foo/my_filelog_template:
+    include: foo.log
+processors:
+  batch:
+exporters:
+  otlp:
+    endpoint: localhost:4317
+
+service:
+  pipelines:
+    logs:
+      receivers: [filelog/bar/my_filelog_template, filelog/foo/my_filelog_template]
+      processors: [batch]
+      exporters: [otlp]

--- a/confmap/converter/templateconverter/testdata/valid/multiple-receivers-separate-pipelines/config.yaml
+++ b/confmap/converter/templateconverter/testdata/valid/multiple-receivers-separate-pipelines/config.yaml
@@ -1,0 +1,30 @@
+receivers:
+  template/my_filelog_template:
+    my_foo_file: foo.log
+    my_bar_file: bar.log
+processors:
+  batch:
+exporters:
+  otlp:
+    endpoint: localhost:4317
+
+service:
+  pipelines:
+    logs:
+      receivers: [template/my_filelog_template]
+      processors: [batch]
+      exporters: [otlp]
+
+templates:
+  receivers:
+    my_filelog_template: |
+      receivers:
+        filelog/foo:
+          include: {{ .my_foo_file }}
+        filelog/bar:
+          include: {{ .my_bar_file }}
+      pipelines:
+        logs/foo:
+          receivers: [filelog/foo]
+        logs/bar:
+          receivers: [filelog/bar]

--- a/confmap/converter/templateconverter/testdata/valid/multiple-receivers-separate-pipelines/expected.yaml
+++ b/confmap/converter/templateconverter/testdata/valid/multiple-receivers-separate-pipelines/expected.yaml
@@ -1,0 +1,25 @@
+receivers:
+  filelog/foo/my_filelog_template:
+    include: foo.log
+  filelog/bar/my_filelog_template:
+    include: bar.log
+processors:
+  batch:
+exporters:
+  otlp:
+    endpoint: localhost:4317
+connectors:
+  forward/my_filelog_template:
+
+service:
+  pipelines:
+    logs/foo/my_filelog_template:
+      receivers: [filelog/foo/my_filelog_template]
+      exporters: [forward/my_filelog_template]
+    logs/bar/my_filelog_template:
+      receivers: [filelog/bar/my_filelog_template]
+      exporters: [forward/my_filelog_template]
+    logs:
+      receivers: [forward/my_filelog_template]
+      processors: [batch]
+      exporters: [otlp]

--- a/confmap/converter/templateconverter/testdata/valid/multiple-receivers-single-pipeline/config.yaml
+++ b/confmap/converter/templateconverter/testdata/valid/multiple-receivers-single-pipeline/config.yaml
@@ -1,0 +1,28 @@
+receivers:
+  template/my_filelog_template:
+    my_foo_file: foo.log
+    my_bar_file: bar.log
+processors:
+  batch:
+exporters:
+  otlp:
+    endpoint: localhost:4317
+
+service:
+  pipelines:
+    logs:
+      receivers: [template/my_filelog_template]
+      processors: [batch]
+      exporters: [otlp]
+
+templates:
+  receivers:
+    my_filelog_template: |
+      receivers:
+        filelog/foo:
+          include: {{ .my_foo_file }}
+        filelog/bar:
+          include: {{ .my_bar_file }}
+      pipelines:
+        logs:
+          receivers: [filelog/foo, filelog/bar]

--- a/confmap/converter/templateconverter/testdata/valid/multiple-receivers-single-pipeline/expected.yaml
+++ b/confmap/converter/templateconverter/testdata/valid/multiple-receivers-single-pipeline/expected.yaml
@@ -1,0 +1,22 @@
+receivers:
+  filelog/foo/my_filelog_template:
+    include: foo.log
+  filelog/bar/my_filelog_template:
+    include: bar.log
+processors:
+  batch:
+exporters:
+  otlp:
+    endpoint: localhost:4317
+connectors:
+  forward/my_filelog_template:
+
+service:
+  pipelines:
+    logs/my_filelog_template:
+      receivers: [filelog/foo/my_filelog_template, filelog/bar/my_filelog_template]
+      exporters: [forward/my_filelog_template]
+    logs:
+      receivers: [forward/my_filelog_template]
+      processors: [batch]
+      exporters: [otlp]

--- a/confmap/converter/templateconverter/testdata/valid/multiple-template-instances/config.yaml
+++ b/confmap/converter/templateconverter/testdata/valid/multiple-template-instances/config.yaml
@@ -1,0 +1,30 @@
+receivers:
+  template/my_filelog_template/1:
+    my_file: foo.log
+  template/my_filelog_template/2:
+    my_file: bar.log
+processors:
+  batch:
+exporters:
+  otlp:
+    endpoint: localhost:4317
+
+service:
+  pipelines:
+    logs:
+      receivers: [template/my_filelog_template/1, template/my_filelog_template/2]
+      processors: [batch]
+      exporters: [otlp]
+
+templates:
+  receivers:
+    my_filelog_template: |
+      receivers:
+        filelog:
+          include: {{ .my_file }}
+      processors:
+        batch:
+      pipelines:
+        logs:
+          receivers: [filelog]
+          processors: [batch]

--- a/confmap/converter/templateconverter/testdata/valid/multiple-template-instances/expected.yaml
+++ b/confmap/converter/templateconverter/testdata/valid/multiple-template-instances/expected.yaml
@@ -1,0 +1,30 @@
+receivers:
+  filelog/my_filelog_template/1:
+    include: foo.log
+  filelog/my_filelog_template/2:
+    include: bar.log
+processors:
+  batch:
+  batch/my_filelog_template/1:
+  batch/my_filelog_template/2:
+exporters:
+  otlp:
+    endpoint: localhost:4317
+connectors:
+  forward/my_filelog_template/1:
+  forward/my_filelog_template/2:
+
+service:
+  pipelines:
+    logs/my_filelog_template/1:
+      receivers: [filelog/my_filelog_template/1]
+      processors: [batch/my_filelog_template/1]
+      exporters: [forward/my_filelog_template/1]
+    logs/my_filelog_template/2:
+      receivers: [filelog/my_filelog_template/2]
+      processors: [batch/my_filelog_template/2]
+      exporters: [forward/my_filelog_template/2]
+    logs:
+      receivers: [forward/my_filelog_template/1, forward/my_filelog_template/2]
+      processors: [batch]
+      exporters: [otlp]

--- a/confmap/converter/templateconverter/testdata/valid/multiple-templates/config.yaml
+++ b/confmap/converter/templateconverter/testdata/valid/multiple-templates/config.yaml
@@ -1,0 +1,53 @@
+receivers:
+  template/my_filelog_template:
+    my_foo_file: foo.log
+    my_bar_file: bar.log
+  template/my_otlp_template:
+    http_port: 4318
+    grpc_port: 4317
+processors:
+  batch:
+exporters:
+  otlp:
+    endpoint: localhost:4319
+
+service:
+  pipelines:
+    logs:
+      receivers: [template/my_filelog_template]
+      processors: [batch]
+      exporters: [otlp]
+
+templates:
+  receivers:
+    my_filelog_template: |
+      receivers:
+        filelog/foo:
+          include: {{ .my_foo_file }}
+        filelog/bar:
+          include: {{ .my_bar_file }}
+      processors:
+        batch/1:
+        batch/2:
+      pipelines:
+        logs/a:
+          receivers: [filelog/foo]
+          processors: [batch/1]
+        logs/b:
+          receivers: [filelog/bar]
+          processors: [batch/2]
+    my_otlp_template: |
+      receivers:
+        otlp/http:
+          protocols:
+            http:
+              endpoint: localhost:{{ .http_port }}
+        otlp/grpc:
+          protocols:
+            grpc:
+              endpoint: localhost:{{ .grpc_port }}
+      pipelines:
+        logs/http:
+          receivers: [otlp/http]
+        logs/grpc:
+          receivers: [otlp/grpc]

--- a/confmap/converter/templateconverter/testdata/valid/multiple-templates/expected.yaml
+++ b/confmap/converter/templateconverter/testdata/valid/multiple-templates/expected.yaml
@@ -1,0 +1,45 @@
+receivers:
+  filelog/foo/my_filelog_template:
+    include: foo.log
+  filelog/bar/my_filelog_template:
+    include: bar.log
+  otlp/http/my_otlp_template:
+    protocols:
+      http:
+        endpoint: localhost:4318
+  otlp/grpc/my_otlp_template:
+    protocols:
+      grpc:
+        endpoint: localhost:4317
+processors:
+  batch:
+  batch/1/my_filelog_template:
+  batch/2/my_filelog_template:
+exporters:
+  otlp:
+    endpoint: localhost:4319
+connectors:
+  forward/my_filelog_template:
+  forward/my_otlp_template:
+
+service:
+  pipelines:
+    logs/a/my_filelog_template:
+      receivers: [filelog/foo/my_filelog_template]
+      processors: [batch/1/my_filelog_template]
+      exporters: [forward/my_filelog_template]
+    logs/b/my_filelog_template:
+      receivers: [filelog/bar/my_filelog_template]
+      processors: [batch/2/my_filelog_template]
+      exporters: [forward/my_filelog_template]
+    logs/http/my_otlp_template:
+      receivers: [otlp/http/my_otlp_template]
+      exporters: [forward/my_otlp_template]
+    logs/grpc/my_otlp_template:
+      receivers: [otlp/grpc/my_otlp_template]
+      exporters: [forward/my_otlp_template]
+    logs:
+      receivers: [forward/my_filelog_template]
+      processors: [batch]
+      exporters: [otlp]
+

--- a/confmap/converter/templateconverter/testdata/valid/no-templates/config.yaml
+++ b/confmap/converter/templateconverter/testdata/valid/no-templates/config.yaml
@@ -1,0 +1,15 @@
+receivers:
+  filelog:
+    include: foo.log
+exporters:
+  otlp:
+    endpoint: localhost:4319
+
+service:
+  pipelines:
+    metrics:
+      receivers: [template/my_otlp_template]
+      exporters: [otlp]
+    traces:
+      receivers: [template/my_otlp_template]
+      exporters: [otlp]

--- a/confmap/converter/templateconverter/testdata/valid/no-templates/expected.yaml
+++ b/confmap/converter/templateconverter/testdata/valid/no-templates/expected.yaml
@@ -1,0 +1,15 @@
+receivers:
+  filelog:
+    include: foo.log
+exporters:
+  otlp:
+    endpoint: localhost:4319
+
+service:
+  pipelines:
+    metrics:
+      receivers: [template/my_otlp_template]
+      exporters: [otlp]
+    traces:
+      receivers: [template/my_otlp_template]
+      exporters: [otlp]

--- a/confmap/converter/templateconverter/testdata/valid/only-processor-templated/config.yaml
+++ b/confmap/converter/templateconverter/testdata/valid/only-processor-templated/config.yaml
@@ -1,0 +1,27 @@
+# No processors defined in top level section.
+# Test that we create the processors section when expanding the template.
+receivers:
+  template/my_filelog_template:
+    my_file: foo.log
+exporters:
+  otlp:
+    endpoint: localhost:4317
+
+service:
+  pipelines:
+    logs:
+      receivers: [template/my_filelog_template]
+      exporters: [otlp]
+
+templates:
+  receivers:
+    my_filelog_template: |
+      receivers:
+        filelog:
+          include: {{ .my_file }}
+      processors:
+        batch:
+      pipelines:
+        logs:
+          receivers: [filelog]
+          processors: [batch]

--- a/confmap/converter/templateconverter/testdata/valid/only-processor-templated/expected.yaml
+++ b/confmap/converter/templateconverter/testdata/valid/only-processor-templated/expected.yaml
@@ -1,0 +1,20 @@
+receivers:
+  filelog/my_filelog_template:
+    include: foo.log
+processors:
+  batch/my_filelog_template:
+exporters:
+  otlp:
+    endpoint: localhost:4317
+connectors:
+  forward/my_filelog_template:
+
+service:
+  pipelines:
+    logs/my_filelog_template:
+      receivers: [filelog/my_filelog_template]
+      processors: [batch/my_filelog_template]
+      exporters: [forward/my_filelog_template]
+    logs:
+      receivers: [forward/my_filelog_template]
+      exporters: [otlp]

--- a/confmap/converter/templateconverter/testdata/valid/single-processor/config.yaml
+++ b/confmap/converter/templateconverter/testdata/valid/single-processor/config.yaml
@@ -1,0 +1,28 @@
+receivers:
+  template/my_filelog_template:
+    my_file: foo.log
+processors:
+  batch:
+exporters:
+  otlp:
+    endpoint: localhost:4317
+
+service:
+  pipelines:
+    logs:
+      receivers: [template/my_filelog_template]
+      processors: [batch]
+      exporters: [otlp]
+
+templates:
+  receivers:
+    my_filelog_template: |
+      receivers:
+        filelog:
+          include: {{ .my_file }}
+      processors:
+        batch:
+      pipelines:
+        logs:
+          receivers: [filelog]
+          processors: [batch]

--- a/confmap/converter/templateconverter/testdata/valid/single-processor/expected.yaml
+++ b/confmap/converter/templateconverter/testdata/valid/single-processor/expected.yaml
@@ -1,0 +1,22 @@
+receivers:
+  filelog/my_filelog_template:
+    include: foo.log
+processors:
+  batch:
+  batch/my_filelog_template:
+exporters:
+  otlp:
+    endpoint: localhost:4317
+connectors:
+  forward/my_filelog_template:
+
+service:
+  pipelines:
+    logs/my_filelog_template:
+      receivers: [filelog/my_filelog_template]
+      processors: [batch/my_filelog_template]
+      exporters: [forward/my_filelog_template]
+    logs:
+      receivers: [forward/my_filelog_template]
+      processors: [batch]
+      exporters: [otlp]

--- a/confmap/converter/templateconverter/testdata/valid/single-receiver-no-pipelines/config.yaml
+++ b/confmap/converter/templateconverter/testdata/valid/single-receiver-no-pipelines/config.yaml
@@ -1,0 +1,22 @@
+receivers:
+  template/my_filelog_template:
+    my_file: foo.log
+processors:
+  batch:
+exporters:
+  otlp:
+    endpoint: localhost:4317
+
+service:
+  pipelines:
+    logs:
+      receivers: [template/my_filelog_template]
+      processors: [batch]
+      exporters: [otlp]
+
+templates:
+  receivers:
+    my_filelog_template: |
+      receivers:
+        filelog:
+          include: {{ .my_file }}

--- a/confmap/converter/templateconverter/testdata/valid/single-receiver-no-pipelines/expected.yaml
+++ b/confmap/converter/templateconverter/testdata/valid/single-receiver-no-pipelines/expected.yaml
@@ -1,0 +1,15 @@
+receivers:
+  filelog/my_filelog_template:
+    include: foo.log
+processors:
+  batch:
+exporters:
+  otlp:
+    endpoint: localhost:4317
+
+service:
+  pipelines:
+    logs:
+      receivers: [filelog/my_filelog_template]
+      processors: [batch]
+      exporters: [otlp]

--- a/confmap/converter/templateconverter/testdata/valid/single-receiver/config.yaml
+++ b/confmap/converter/templateconverter/testdata/valid/single-receiver/config.yaml
@@ -1,0 +1,25 @@
+receivers:
+  template/my_filelog_template:
+    my_file: foo.log
+processors:
+  batch:
+exporters:
+  otlp:
+    endpoint: localhost:4317
+
+service:
+  pipelines:
+    logs:
+      receivers: [template/my_filelog_template]
+      processors: [batch]
+      exporters: [otlp]
+
+templates:
+  receivers:
+    my_filelog_template: |
+      receivers:
+        filelog:
+          include: {{ .my_file }}
+      pipelines:
+        logs:
+          receivers: [filelog]

--- a/confmap/converter/templateconverter/testdata/valid/single-receiver/expected.yaml
+++ b/confmap/converter/templateconverter/testdata/valid/single-receiver/expected.yaml
@@ -1,0 +1,20 @@
+receivers:
+  filelog/my_filelog_template:
+    include: foo.log
+processors:
+  batch:
+exporters:
+  otlp:
+    endpoint: localhost:4317
+connectors:
+  forward/my_filelog_template:
+
+service:
+  pipelines:
+    logs/my_filelog_template:
+      receivers: [filelog/my_filelog_template]
+      exporters: [forward/my_filelog_template]
+    logs:
+      receivers: [forward/my_filelog_template]
+      processors: [batch]
+      exporters: [otlp]

--- a/confmap/converter/templateconverter/testdata/valid/unused-template/config.yaml
+++ b/confmap/converter/templateconverter/testdata/valid/unused-template/config.yaml
@@ -1,0 +1,51 @@
+# Test that unused templates are ignored.
+receivers:
+  template/my_filelog_template:
+    my_foo_file: foo.log
+    my_bar_file: bar.log
+processors:
+  batch:
+exporters:
+  otlp:
+    endpoint: localhost:4319
+
+service:
+  pipelines:
+    logs:
+      receivers: [template/my_filelog_template]
+      processors: [batch]
+      exporters: [otlp]
+
+templates:
+  receivers:
+    my_filelog_template: |
+      receivers:
+        filelog/foo:
+          include: {{ .my_foo_file }}
+        filelog/bar:
+          include: {{ .my_bar_file }}
+      processors:
+        batch/1:
+        batch/2:
+      pipelines:
+        logs/a:
+          receivers: [filelog/foo]
+          processors: [batch/1]
+        logs/b:
+          receivers: [filelog/bar]
+          processors: [batch/2]
+    my_otlp_template: |
+      receivers:
+        otlp/http:
+          protocols:
+            http:
+              endpoint: localhost:{{ .http_port }}
+        otlp/grpc:
+          protocols:
+            grpc:
+              endpoint: localhost:{{ .grpc_port }}
+      pipelines:
+        logs/http:
+          receivers: [otlp/http]
+        logs/grpc:
+          receivers: [otlp/grpc]

--- a/confmap/converter/templateconverter/testdata/valid/unused-template/expected.yaml
+++ b/confmap/converter/templateconverter/testdata/valid/unused-template/expected.yaml
@@ -1,0 +1,29 @@
+receivers:
+  filelog/foo/my_filelog_template:
+    include: foo.log
+  filelog/bar/my_filelog_template:
+    include: bar.log
+processors:
+  batch:
+  batch/1/my_filelog_template:
+  batch/2/my_filelog_template:
+exporters:
+  otlp:
+    endpoint: localhost:4319
+connectors:
+  forward/my_filelog_template:
+
+service:
+  pipelines:
+    logs/a/my_filelog_template:
+      receivers: [filelog/foo/my_filelog_template]
+      processors: [batch/1/my_filelog_template]
+      exporters: [forward/my_filelog_template]
+    logs/b/my_filelog_template:
+      receivers: [filelog/bar/my_filelog_template]
+      processors: [batch/2/my_filelog_template]
+      exporters: [forward/my_filelog_template]
+    logs:
+      receivers: [forward/my_filelog_template]
+      processors: [batch]
+      exporters: [otlp]

--- a/confmap/resolver.go
+++ b/confmap/resolver.go
@@ -141,6 +141,9 @@ func (mr *Resolver) Resolve(ctx context.Context) (*Conf, error) {
 	for _, k := range retMap.AllKeys() {
 		val, err := mr.expandValueRecursively(ctx, retMap.Get(k))
 		if err != nil {
+			if strings.HasPrefix(k, "templates::") {
+				return nil, fmt.Errorf("cannot expand value in template %q: %w", k, err)
+			}
 			return nil, err
 		}
 		cfgMap[k] = val


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-collector/issues/8372

Alternative to https://github.com/open-telemetry/opentelemetry-collector/pull/8504

---

This approach uses only a template _converter_. This means that any provider may provide templates as part of the raw configuration.

In the simplest case, this looks like this, where the config and a template are defined in the same file:

```yaml
receivers:
  template/my_filelog_template:
    my_file: foo.log
processors:
  batch:
exporters:
  otlp:
    endpoint: localhost:4317

service:
  pipelines:
    logs:
      receivers: [template/my_filelog_template]
      processors: [batch]
      exporters: [otlp]

templates:
  receivers:
    my_filelog_template: |
      receivers:
        filelog:
          include: {{ .my_file }}
```

Note that this it is not really the intention of templates. Typically, the `templates` section would be provided outside of the main config.

```yaml
# config.yaml
receivers:
  template/my_filelog_template:
    my_file: foo.log
processors:
  batch:
exporters:
  otlp:
    endpoint: localhost:4317

service:
  pipelines:
    logs:
      receivers: [template/my_filelog_template]
      processors: [batch]
      exporters: [otlp]
```

```yaml
# my_template.yaml
templates:
  receivers:
    my_filelog_template: |
      receivers:
        filelog:
          include: {{ .my_file }}
```

Additional notes:
- A template would typically be more complex, such that the user is saved some difficulty - this example only shows how the template is defined relative to its usage. Move complex examples are covered in the tests.
- The `templates` section is deleted by the converter after expanding any templates, similar to how environment variable expansion deletes the original reference to the env var. So although it appears to be part of the config, it is should be considered a precursor to the actual collector configuration.