### PR TITLE
[docs/release] Specify platform tier for bugfix releases

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -116,7 +116,7 @@ When considering making a bugfix release on the `v0.N.x` release cycle, the bug 
     - Reverting a feature gate.
     - Changing the configuration to an easy to find value.
 2. The bug happens in common setups. To gauge this, maintainers can consider the following:
-    - The bug is not specific to a platform on [Tier 2 or below](docs/platform-support.md#tiered-platform-support-model).
+    - The bug is not specific to a platform on [Tier 2 or below](../docs/platform-support.md#tiered-platform-support-model).
     - The bug happens with the default configuration or with a commonly used one (e.g. has been reported by multiple people)
 3. The bug is sufficiently severe. For example (non-exhaustive list):
     - The bug makes the Collector crash reliably

--- a/docs/release.md
+++ b/docs/release.md
@@ -116,7 +116,7 @@ When considering making a bugfix release on the `v0.N.x` release cycle, the bug 
     - Reverting a feature gate.
     - Changing the configuration to an easy to find value.
 2. The bug happens in common setups. To gauge this, maintainers can consider the following:
-    - If the bug is specific to a certain platform, then the platform is [Tier 1](../docs/platform-support.md#tiered-platform-support-model).
+    - If the bug is specific to a certain platform, and if that platform is in [Tier 1](../docs/platform-support.md#tiered-platform-support-model).
     - The bug happens with the default configuration or with a commonly used one (e.g. has been reported by multiple people)
 3. The bug is sufficiently severe. For example (non-exhaustive list):
     - The bug makes the Collector crash reliably

--- a/docs/release.md
+++ b/docs/release.md
@@ -116,7 +116,7 @@ When considering making a bugfix release on the `v0.N.x` release cycle, the bug 
     - Reverting a feature gate.
     - Changing the configuration to an easy to find value.
 2. The bug happens in common setups. To gauge this, maintainers can consider the following:
-    - The bug is not specific to a platform on [Tier 2 or below](../platform-support.md#tiered-platform-support-model).
+    - The bug is not specific to a platform on [Tier 2 or below](docs/platform-support.md#tiered-platform-support-model).
     - The bug happens with the default configuration or with a commonly used one (e.g. has been reported by multiple people)
 3. The bug is sufficiently severe. For example (non-exhaustive list):
     - The bug makes the Collector crash reliably

--- a/docs/release.md
+++ b/docs/release.md
@@ -116,7 +116,7 @@ When considering making a bugfix release on the `v0.N.x` release cycle, the bug 
     - Reverting a feature gate.
     - Changing the configuration to an easy to find value.
 2. The bug happens in common setups. To gauge this, maintainers can consider the following:
-    - The bug is not specific to an uncommon platform
+    - The bug is not specific to a platform on [Tier 2 or below](/docs/platform-support.md#tiered-platform-support-model).
     - The bug happens with the default configuration or with a commonly used one (e.g. has been reported by multiple people)
 3. The bug is sufficiently severe. For example (non-exhaustive list):
     - The bug makes the Collector crash reliably

--- a/docs/release.md
+++ b/docs/release.md
@@ -116,7 +116,7 @@ When considering making a bugfix release on the `v0.N.x` release cycle, the bug 
     - Reverting a feature gate.
     - Changing the configuration to an easy to find value.
 2. The bug happens in common setups. To gauge this, maintainers can consider the following:
-    - The bug is not specific to a platform on [Tier 2 or below](/docs/platform-support.md#tiered-platform-support-model).
+    - The bug is not specific to a platform on [Tier 2 or below](../platform-support.md#tiered-platform-support-model).
     - The bug happens with the default configuration or with a commonly used one (e.g. has been reported by multiple people)
 3. The bug is sufficiently severe. For example (non-exhaustive list):
     - The bug makes the Collector crash reliably

--- a/docs/release.md
+++ b/docs/release.md
@@ -116,7 +116,7 @@ When considering making a bugfix release on the `v0.N.x` release cycle, the bug 
     - Reverting a feature gate.
     - Changing the configuration to an easy to find value.
 2. The bug happens in common setups. To gauge this, maintainers can consider the following:
-    - The bug is not specific to a platform on [Tier 2 or below](../docs/platform-support.md#tiered-platform-support-model).
+    - If the bug is specific to a certain platform, then the platform is [Tier 1](../docs/platform-support.md#tiered-platform-support-model).
     - The bug happens with the default configuration or with a commonly used one (e.g. has been reported by multiple people)
 3. The bug is sufficiently severe. For example (non-exhaustive list):
     - The bug makes the Collector crash reliably


### PR DESCRIPTION
**Description:** 

Since we now have support tiers defined, we can clarify what platforms allow for a bugfix release
