### PR TITLE
[chore] [pdata] don't generate a cycle import in the internal package

### DIFF
--- a/pdata/internal/cmd/pdatagen/internal/packages.go
+++ b/pdata/internal/cmd/pdatagen/internal/packages.go
@@ -119,6 +119,9 @@ func (p *Package) GenerateInternalFiles() error {
 		// Add imports
 		sb.WriteString("import (" + newLine)
 		for _, imp := range p.imports {
+			if imp == `"go.opentelemetry.io/collector/pdata/internal"` {
+				continue
+			}
 			if imp != "" {
 				sb.WriteString("\t" + imp + newLine)
 			} else {


### PR DESCRIPTION
To avoid warnings thrown by `make genpdata`:
```
go run pdata/internal/cmd/pdatagen/main.go
/Library/Developer/CommandLineTools/usr/bin/make fmt
package go.opentelemetry.io/collector/internal/fanoutconsumer
	imports go.opentelemetry.io/collector/component
	imports go.opentelemetry.io/collector/pdata/pcommon
	imports go.opentelemetry.io/collector/pdata/internal
	imports go.opentelemetry.io/collector/pdata/internal: import cycle not allowed
package go.opentelemetry.io/collector/internal/fanoutconsumer
	imports go.opentelemetry.io/collector/component
	imports go.opentelemetry.io/collector/pdata/pcommon
	imports go.opentelemetry.io/collector/pdata/internal
	imports go.opentelemetry.io/collector/pdata/internal: import cycle not allowed
```

The invalid imports are removed by `go fmt` after that anyway, but it's still annoying.