### PR TITLE
[chore] fix flaky test associated with bounded_memory_queue

### DIFF
--- a/.chloggen/fix-bounded-memory-queue-stop.yaml
+++ b/.chloggen/fix-bounded-memory-queue-stop.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: exporterhelper
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix bounded memory queue stopping behavior to avoid panics.
+
+# One or more tracking issues or pull requests related to the change
+issues: [8124]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -3,7 +3,7 @@ ALL_PKGS := $(sort $(shell go list ./...))
 # COVER_PKGS is the list of packages to include in the coverage
 COVER_PKGS := $(shell go list ./... | tr "\n" ",")
 
-GOTEST_OPT?= -race -timeout 120s -v
+GOTEST_OPT?= -race -timeout 120s
 GOCMD?= go
 GOTEST=$(GOCMD) test
 GOOS := $(shell $(GOCMD) env GOOS)

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -3,7 +3,7 @@ ALL_PKGS := $(sort $(shell go list ./...))
 # COVER_PKGS is the list of packages to include in the coverage
 COVER_PKGS := $(shell go list ./... | tr "\n" ",")
 
-GOTEST_OPT?= -race -timeout 120s
+GOTEST_OPT?= -race -timeout 120s -v
 GOCMD?= go
 GOTEST=$(GOCMD) test
 GOOS := $(shell $(GOCMD) env GOOS)

--- a/exporter/exporterhelper/internal/bounded_memory_queue.go
+++ b/exporter/exporterhelper/internal/bounded_memory_queue.go
@@ -7,6 +7,7 @@ package internal // import "go.opentelemetry.io/collector/exporter/exporterhelpe
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"sync/atomic"
 
@@ -133,7 +134,10 @@ func (q *boundedMemoryQueue) eventLoop() {
 
 // Produce is used by the producer to submit new item to the queue. Returns false in case of queue overflow.
 func (q *boundedMemoryQueue) Produce(item Request) bool {
+	fmt.Println("produce")
+	//debug.PrintStack()
 	if q.stopped.Load() {
+		fmt.Println("stopped")
 		return false
 	}
 	waitForAccept := make(chan bool, 1)

--- a/exporter/exporterhelper/internal/bounded_memory_queue.go
+++ b/exporter/exporterhelper/internal/bounded_memory_queue.go
@@ -7,6 +7,7 @@ package internal // import "go.opentelemetry.io/collector/exporter/exporterhelpe
 
 import (
 	"context"
+	"runtime/debug"
 	"sync"
 	"sync/atomic"
 
@@ -128,6 +129,7 @@ func (q *boundedMemoryQueue) Produce(item Request) bool {
 	if q.stopped.Load() {
 		return false
 	}
+	debug.PrintStack()
 	waitForAccept := make(chan bool, 1)
 	pipelineItem := &queueEvent{
 		request:    item,

--- a/exporter/exporterhelper/internal/bounded_memory_queue.go
+++ b/exporter/exporterhelper/internal/bounded_memory_queue.go
@@ -79,11 +79,11 @@ func (q *boundedMemoryQueue) eventLoop() {
 				continue
 			}
 			q.size++
+			q.items <- req
 			overflow = q.capacity == 0 || q.size >= q.capacity
 			if overflow {
 				q.overflow.Store(true)
 			}
-			q.items <- req
 			continue
 		}
 		if done, ok := e.(bool); ok && done {

--- a/exporter/exporterhelper/internal/bounded_memory_queue.go
+++ b/exporter/exporterhelper/internal/bounded_memory_queue.go
@@ -7,7 +7,6 @@ package internal // import "go.opentelemetry.io/collector/exporter/exporterhelpe
 
 import (
 	"context"
-	"runtime/debug"
 	"sync"
 	"sync/atomic"
 
@@ -129,7 +128,6 @@ func (q *boundedMemoryQueue) Produce(item Request) bool {
 	if q.stopped.Load() {
 		return false
 	}
-	debug.PrintStack()
 	waitForAccept := make(chan bool, 1)
 	pipelineItem := &queueEvent{
 		request:    item,

--- a/exporter/exporterhelper/internal/bounded_memory_queue.go
+++ b/exporter/exporterhelper/internal/bounded_memory_queue.go
@@ -7,7 +7,6 @@ package internal // import "go.opentelemetry.io/collector/exporter/exporterhelpe
 
 import (
 	"context"
-	"fmt"
 	"sync"
 	"sync/atomic"
 
@@ -134,10 +133,7 @@ func (q *boundedMemoryQueue) eventLoop() {
 
 // Produce is used by the producer to submit new item to the queue. Returns false in case of queue overflow.
 func (q *boundedMemoryQueue) Produce(item Request) bool {
-	fmt.Println("produce")
-	//debug.PrintStack()
 	if q.stopped.Load() {
-		fmt.Println("stopped")
 		return false
 	}
 	waitForAccept := make(chan bool, 1)

--- a/exporter/exporterhelper/internal/bounded_memory_queue.go
+++ b/exporter/exporterhelper/internal/bounded_memory_queue.go
@@ -86,8 +86,16 @@ func (q *boundedMemoryQueue) eventLoop() {
 			continue
 		}
 		if q.stopped.Load() && e.stopChan != nil {
+			// if we have no consumers, empty the queue.
+			if q.numConsumers == 0 {
+				for len(q.items) > 0 {
+					<-q.items
+					q.size--
+				}
+			}
 			if q.size > 0 {
 				// we have a stop signal, but there are still elements in the queue.
+
 				// Requeue:
 				go func() {
 					q.eventChan <- e

--- a/exporter/exporterhelper/internal/bounded_memory_queue_test.go
+++ b/exporter/exporterhelper/internal/bounded_memory_queue_test.go
@@ -73,6 +73,7 @@ func TestBoundedQueue(t *testing.T) {
 
 	// produce two more items. The first one should be accepted, but not consumed.
 	assert.True(t, q.Produce(newStringRequest("b")))
+	consumerState.waitToConsumeOnce()
 	assert.Equal(t, 2, q.Size())
 	// the second should be rejected since the queue is full
 	assert.False(t, q.Produce(newStringRequest("c")))

--- a/exporter/exporterhelper/logs_test.go
+++ b/exporter/exporterhelper/logs_test.go
@@ -239,6 +239,11 @@ func TestLogsExporter_WithRecordEnqueueFailedMetrics(t *testing.T) {
 	te, err := NewLogsExporter(context.Background(), exporter.CreateSettings{ID: fakeLogsExporterName, TelemetrySettings: tt.TelemetrySettings, BuildInfo: component.NewDefaultBuildInfo()}, &fakeLogsExporterConfig, newPushLogsData(wantErr), WithRetry(rCfg), WithQueue(qCfg))
 	require.NoError(t, err)
 	require.NotNil(t, te)
+	err = te.Start(context.Background(), componenttest.NewNopHost())
+	require.NoError(t, err)
+	defer func() {
+		_ = te.Shutdown(context.Background())
+	}()
 
 	md := testdata.GenerateLogs(3)
 	const numBatches = 7

--- a/exporter/exporterhelper/metrics_test.go
+++ b/exporter/exporterhelper/metrics_test.go
@@ -239,6 +239,11 @@ func TestMetricsExporter_WithRecordEnqueueFailedMetrics(t *testing.T) {
 	te, err := NewMetricsExporter(context.Background(), exporter.CreateSettings{ID: fakeMetricsExporterName, TelemetrySettings: tt.TelemetrySettings, BuildInfo: component.NewDefaultBuildInfo()}, &fakeMetricsExporterConfig, newPushMetricsData(wantErr), WithRetry(rCfg), WithQueue(qCfg))
 	require.NoError(t, err)
 	require.NotNil(t, te)
+	err = te.Start(context.Background(), componenttest.NewNopHost())
+	require.NoError(t, err)
+	defer func() {
+		_ = te.Shutdown(context.Background())
+	}()
 
 	md := testdata.GenerateMetrics(1)
 	const numBatches = 7

--- a/exporter/exporterhelper/queue_sender_test.go
+++ b/exporter/exporterhelper/queue_sender_test.go
@@ -351,7 +351,7 @@ func TestQueuedRetryPersistentEnabled_shutdown_dataIsRequeued(t *testing.T) {
 	qCfg := NewDefaultQueueSettings()
 	qCfg.NumConsumers = 1
 	rCfg := NewDefaultRetrySettings()
-	rCfg.InitialInterval = time.Millisecond
+	rCfg.InitialInterval = 5 * time.Millisecond
 	rCfg.MaxElapsedTime = 0 // retry infinitely so shutdown can be triggered
 
 	be, err := newBaseExporter(defaultSettings, "", false, nil, nil, newNoopObsrepSender, WithRetry(rCfg), WithQueue(qCfg))

--- a/exporter/exporterhelper/queue_sender_test.go
+++ b/exporter/exporterhelper/queue_sender_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/consumer/consumererror"

--- a/exporter/exporterhelper/queue_sender_test.go
+++ b/exporter/exporterhelper/queue_sender_test.go
@@ -6,7 +6,6 @@ package exporterhelper
 import (
 	"context"
 	"errors"
-	"fmt"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -348,13 +347,13 @@ func TestQueuedRetryPersistenceEnabledStorageError(t *testing.T) {
 
 func TestQueuedRetryPersistentEnabled_shutdown_dataIsRequeued(t *testing.T) {
 
-	fmt.Println("start of test")
 	produceCounter := &atomic.Uint32{}
 
 	qCfg := NewDefaultQueueSettings()
 	qCfg.NumConsumers = 1
 	rCfg := NewDefaultRetrySettings()
-	rCfg.InitialInterval = 1 * time.Millisecond
+	rCfg.InitialInterval = 100 * time.Millisecond
+	rCfg.MaxInterval = rCfg.InitialInterval
 	rCfg.MaxElapsedTime = 0 // retry infinitely so shutdown can be triggered
 
 	set := exportertest.NewNopCreateSettings()
@@ -377,7 +376,7 @@ func TestQueuedRetryPersistentEnabled_shutdown_dataIsRequeued(t *testing.T) {
 	// first wait for the item to be produced to the queue initially
 	assert.True(t, produceCounter.Load() == uint32(1))
 	// buffer some time so the failure is pushed back.
-	time.Sleep(1 * time.Second)
+	time.Sleep(200 * time.Millisecond)
 	require.NoError(t, be.Shutdown(context.Background()))
 	require.Eventually(t, func() bool {
 		return produceCounter.Load() == uint32(2)

--- a/exporter/exporterhelper/queue_sender_test.go
+++ b/exporter/exporterhelper/queue_sender_test.go
@@ -185,7 +185,9 @@ func TestQueuedRetry_QueueMetricsReportedUsingOTel(t *testing.T) {
 	for i := 0; i < 7; i++ {
 		require.NoError(t, be.send(newErrorRequest(context.Background())))
 	}
-	require.NoError(t, tt.CheckExporterMetricGauge("exporter_queue_size", int64(7)))
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		assert.NoError(collect, tt.CheckExporterMetricGauge("exporter_queue_size", int64(7)))
+	}, 1*time.Second, 1*time.Millisecond)
 
 	assert.NoError(t, be.Shutdown(context.Background()))
 }

--- a/exporter/exporterhelper/queue_sender_test.go
+++ b/exporter/exporterhelper/queue_sender_test.go
@@ -379,7 +379,8 @@ func TestQueuedRetryPersistentEnabled_shutdown_dataIsRequeued(t *testing.T) {
 	// buffer some time so the failure is pushed back.
 	time.Sleep(1 * time.Second)
 	require.NoError(t, be.Shutdown(context.Background()))
-	assert.True(t, produceCounter.Load() == uint32(2))
+	time.Sleep(1 * time.Second)
+	assert.Equal(t, uint32(2), produceCounter.Load())
 }
 
 type mockHost struct {

--- a/exporter/exporterhelper/queue_sender_test.go
+++ b/exporter/exporterhelper/queue_sender_test.go
@@ -6,6 +6,7 @@ package exporterhelper
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -347,6 +348,7 @@ func TestQueuedRetryPersistenceEnabledStorageError(t *testing.T) {
 
 func TestQueuedRetryPersistentEnabled_shutdown_dataIsRequeued(t *testing.T) {
 
+	fmt.Println("start of test")
 	produceCounter := &atomic.Uint32{}
 
 	qCfg := NewDefaultQueueSettings()
@@ -374,6 +376,8 @@ func TestQueuedRetryPersistentEnabled_shutdown_dataIsRequeued(t *testing.T) {
 	require.NoError(t, be.send(newErrorRequest(context.Background())))
 	// first wait for the item to be produced to the queue initially
 	assert.True(t, produceCounter.Load() == uint32(1))
+	// buffer some time so the failure is pushed back.
+	time.Sleep(1 * time.Second)
 	require.NoError(t, be.Shutdown(context.Background()))
 	assert.True(t, produceCounter.Load() == uint32(2))
 }

--- a/exporter/exporterhelper/queue_sender_test.go
+++ b/exporter/exporterhelper/queue_sender_test.go
@@ -160,6 +160,9 @@ func TestQueuedRetry_QueueMetricsReported(t *testing.T) {
 		require.NoError(t, be.send(newErrorRequest(context.Background())))
 	}
 	checkValueForGlobalManager(t, defaultExporterTags, int64(7), "exporter/queue_size")
+
+	assert.NoError(t, be.Shutdown(context.Background()))
+	checkValueForGlobalManager(t, defaultExporterTags, int64(0), "exporter/queue_size")
 }
 
 func TestQueuedRetry_QueueMetricsReportedUsingOTel(t *testing.T) {

--- a/exporter/exporterhelper/queue_sender_test.go
+++ b/exporter/exporterhelper/queue_sender_test.go
@@ -372,7 +372,9 @@ func TestQueuedRetryPersistentEnabled_shutdown_dataIsRequeued(t *testing.T) {
 	assert.True(t, produceCounter.Load() == uint32(1))
 	// shuts down and ensure the item is produced in the queue again
 	require.NoError(t, be.Shutdown(context.Background()))
-	assert.True(t, produceCounter.Load() == uint32(2))
+	assert.Eventually(t, func() bool {
+		return produceCounter.Load() == uint32(2)
+	}, 2*time.Second, 1*time.Millisecond)
 }
 
 type mockHost struct {

--- a/exporter/exporterhelper/queue_sender_test.go
+++ b/exporter/exporterhelper/queue_sender_test.go
@@ -381,7 +381,7 @@ func TestQueuedRetryPersistentEnabled_shutdown_dataIsRequeued(t *testing.T) {
 	require.NoError(t, be.Shutdown(context.Background()))
 	require.Eventually(t, func() bool {
 		return produceCounter.Load() == uint32(2)
-	}, 1*time.Millisecond, 1*time.Second)
+	}, 1*time.Second, 1*time.Millisecond)
 }
 
 type mockHost struct {

--- a/exporter/exporterhelper/queue_sender_test.go
+++ b/exporter/exporterhelper/queue_sender_test.go
@@ -378,9 +378,9 @@ func TestQueuedRetryPersistentEnabled_shutdown_dataIsRequeued(t *testing.T) {
 	// buffer some time so the failure is pushed back.
 	time.Sleep(200 * time.Millisecond)
 	require.NoError(t, be.Shutdown(context.Background()))
-	require.Eventually(t, func() bool {
+	require.Eventuallyf(t, func() bool {
 		return produceCounter.Load() == uint32(2)
-	}, 1*time.Second, 1*time.Millisecond)
+	}, 1*time.Second, 1*time.Millisecond, "Produce count: %d", produceCounter.Load())
 }
 
 type mockHost struct {

--- a/exporter/exporterhelper/queue_sender_test.go
+++ b/exporter/exporterhelper/queue_sender_test.go
@@ -379,8 +379,9 @@ func TestQueuedRetryPersistentEnabled_shutdown_dataIsRequeued(t *testing.T) {
 	// buffer some time so the failure is pushed back.
 	time.Sleep(1 * time.Second)
 	require.NoError(t, be.Shutdown(context.Background()))
-	time.Sleep(1 * time.Second)
-	assert.Equal(t, uint32(2), produceCounter.Load())
+	require.Eventually(t, func() bool {
+		return produceCounter.Load() == uint32(2)
+	}, 1*time.Millisecond, 1*time.Second)
 }
 
 type mockHost struct {

--- a/exporter/exporterhelper/queue_sender_test.go
+++ b/exporter/exporterhelper/queue_sender_test.go
@@ -370,12 +370,12 @@ func TestQueuedRetryPersistentEnabled_shutdown_dataIsRequeued(t *testing.T) {
 	// Invoke queuedRetrySender so the producer will put the item for consumer to poll
 	require.NoError(t, be.send(newErrorRequest(context.Background())))
 	// first wait for the item to be produced to the queue initially
-	require.Eventuallyf(t, func() bool {
-		return produceCounter.Load() == uint32(1)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, uint32(1), produceCounter.Load())
 	}, 1*time.Second, 1*time.Millisecond, "Produce count: %d", produceCounter.Load())
 	require.NoError(t, be.Shutdown(context.Background()))
-	require.Eventuallyf(t, func() bool {
-		return produceCounter.Load() >= uint32(2)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.True(c, produceCounter.Load() >= uint32(2))
 	}, 1*time.Second, 1*time.Millisecond, "Produce count: %d", produceCounter.Load())
 }
 

--- a/exporter/exporterhelper/traces_test.go
+++ b/exporter/exporterhelper/traces_test.go
@@ -236,6 +236,11 @@ func TestTracesExporter_WithRecordEnqueueFailedMetrics(t *testing.T) {
 	te, err := NewTracesExporter(context.Background(), exporter.CreateSettings{ID: fakeTracesExporterName, TelemetrySettings: tt.TelemetrySettings, BuildInfo: component.NewDefaultBuildInfo()}, &fakeTracesExporterConfig, newTraceDataPusher(wantErr), WithRetry(rCfg), WithQueue(qCfg))
 	require.NoError(t, err)
 	require.NotNil(t, te)
+	err = te.Start(context.Background(), componenttest.NewNopHost())
+	require.NoError(t, err)
+	defer func() {
+		_ = te.Shutdown(context.Background())
+	}()
 
 	td := testdata.GenerateTraces(2)
 	const numBatches = 7


### PR DESCRIPTION
**Description:** 
Fix bounded memory queue stopping behavior to avoid panics.

Before:
```
goos: darwin
goarch: arm64
pkg: go.opentelemetry.io/collector/exporter/exporterhelper/internal
Benchmark_QueueUsage_10000_1_50000-10       	       1	12230623208 ns/op	 2563240 B/op	  149758 allocs/op
Benchmark_QueueUsage_10000_2_50000-10       	       1	6098770209 ns/op	 2563792 B/op	  149763 allocs/op
Benchmark_QueueUsage_10000_5_50000-10       	       1	2288959958 ns/op	 2565400 B/op	  149776 allocs/op
Benchmark_QueueUsage_10000_10_50000-10      	       1	1153033709 ns/op	 2567848 B/op	  149788 allocs/op
Benchmark_QueueUsage_50000_1_50000-10       	       1	59734605167 ns/op	 3201576 B/op	  149753 allocs/op
Benchmark_QueueUsage_50000_2_50000-10       	       1	34550001750 ns/op	 3202728 B/op	  149758 allocs/op
Benchmark_QueueUsage_50000_5_50000-10       	       1	13308404875 ns/op	 3203592 B/op	  149764 allocs/op
Benchmark_QueueUsage_50000_10_50000-10      	       1	7089828500 ns/op	 3205672 B/op	  149783 allocs/op
Benchmark_QueueUsage_10000_1_250000-10      	       1	13404509625 ns/op	12173272 B/op	  749781 allocs/op
Benchmark_QueueUsage_10000_2_250000-10      	       1	6800464208 ns/op	12171432 B/op	  749784 allocs/op
Benchmark_QueueUsage_10000_5_250000-10      	       1	2668322250 ns/op	12169176 B/op	  749779 allocs/op
Benchmark_QueueUsage_10000_10_250000-10     	       1	1297472375 ns/op	12173472 B/op	  749807 allocs/op
BenchmarkPersistentStorage_TraceSpans/#traces:_1_#spansPerTrace:_1-10         	  885627	      1408 ns/op	     876 B/op	      11 allocs/op
BenchmarkPersistentStorage_TraceSpans/#traces:_1_#spansPerTrace:_10-10        	  386420	      3131 ns/op	    3507 B/op	      11 allocs/op
BenchmarkPersistentStorage_TraceSpans/#traces:_10_#spansPerTrace:_10-10       	   58326	     20666 ns/op	   27779 B/op	      11 allocs/op
PASS
ok  	go.opentelemetry.io/collector/exporter/exporterhelper/internal	166.125s

```


After:
```
goos: darwin
goarch: arm64
pkg: go.opentelemetry.io/collector/exporter/exporterhelper/internal
Benchmark_QueueUsage_10000_1_50000-10       	       1	11422502458 ns/op	 2563368 B/op	  149763 allocs/op
Benchmark_QueueUsage_10000_2_50000-10       	       1	5704231500 ns/op	 2563480 B/op	  149764 allocs/op
Benchmark_QueueUsage_10000_5_50000-10       	       1	2320336334 ns/op	 2566392 B/op	  149785 allocs/op
Benchmark_QueueUsage_10000_10_50000-10      	       1	1141204375 ns/op	 2568200 B/op	  149794 allocs/op
Benchmark_QueueUsage_50000_1_50000-10       	       1	57261643291 ns/op	 3201800 B/op	  149758 allocs/op
Benchmark_QueueUsage_50000_2_50000-10       	       1	28473611125 ns/op	 3201728 B/op	  149760 allocs/op
Benchmark_QueueUsage_50000_5_50000-10       	       1	11412506500 ns/op	 3202040 B/op	  149764 allocs/op
Benchmark_QueueUsage_50000_10_50000-10      	       1	5698795917 ns/op	 3204616 B/op	  149784 allocs/op
Benchmark_QueueUsage_10000_1_250000-10      	       1	11471291042 ns/op	12173264 B/op	  749784 allocs/op
Benchmark_QueueUsage_10000_2_250000-10      	       1	5734358125 ns/op	12169504 B/op	  749789 allocs/op
Benchmark_QueueUsage_10000_5_250000-10      	       1	2311201583 ns/op	12169800 B/op	  749788 allocs/op
Benchmark_QueueUsage_10000_10_250000-10     	       1	1164992208 ns/op	12172664 B/op	  749813 allocs/op
BenchmarkPersistentStorage_TraceSpans/#traces:_1_#spansPerTrace:_1-10         	  984412	      1402 ns/op	     854 B/op	      11 allocs/op
BenchmarkPersistentStorage_TraceSpans/#traces:_1_#spansPerTrace:_10-10        	  388896	      3226 ns/op	    3506 B/op	      11 allocs/op
BenchmarkPersistentStorage_TraceSpans/#traces:_10_#spansPerTrace:_10-10       	   57034	     21307 ns/op	   27784 B/op	      11 allocs/op
PASS
ok  	go.opentelemetry.io/collector/exporter/exporterhelper/internal	149.059s

```

Benchstat:
```
goos: darwin
goarch: arm64
pkg: go.opentelemetry.io/collector/exporter/exporterhelper/internal
                                                               │  before.txt  │              after6.txt              │
                                                               │    sec/op    │    sec/op     vs base                │
_QueueUsage_10000_1_50000-10                                      12.23 ± ∞ ¹    11.42 ± ∞ ¹       ~ (p=1.000 n=1) ²
_QueueUsage_10000_2_50000-10                                      6.099 ± ∞ ¹    5.704 ± ∞ ¹       ~ (p=1.000 n=1) ²
_QueueUsage_10000_5_50000-10                                      2.289 ± ∞ ¹    2.320 ± ∞ ¹       ~ (p=1.000 n=1) ²
_QueueUsage_10000_10_50000-10                                     1.153 ± ∞ ¹    1.141 ± ∞ ¹       ~ (p=1.000 n=1) ²
_QueueUsage_50000_1_50000-10                                      59.73 ± ∞ ¹    57.26 ± ∞ ¹       ~ (p=1.000 n=1) ²
_QueueUsage_50000_2_50000-10                                      34.55 ± ∞ ¹    28.47 ± ∞ ¹       ~ (p=1.000 n=1) ²
_QueueUsage_50000_5_50000-10                                      13.31 ± ∞ ¹    11.41 ± ∞ ¹       ~ (p=1.000 n=1) ²
_QueueUsage_50000_10_50000-10                                     7.090 ± ∞ ¹    5.699 ± ∞ ¹       ~ (p=1.000 n=1) ²
_QueueUsage_10000_1_250000-10                                     13.40 ± ∞ ¹    11.47 ± ∞ ¹       ~ (p=1.000 n=1) ²
_QueueUsage_10000_2_250000-10                                     6.800 ± ∞ ¹    5.734 ± ∞ ¹       ~ (p=1.000 n=1) ²
_QueueUsage_10000_5_250000-10                                     2.668 ± ∞ ¹    2.311 ± ∞ ¹       ~ (p=1.000 n=1) ²
_QueueUsage_10000_10_250000-10                                    1.297 ± ∞ ¹    1.165 ± ∞ ¹       ~ (p=1.000 n=1) ²
PersistentStorage_TraceSpans/#traces:_1_#spansPerTrace:_1-10     1.408µ ± ∞ ¹   1.402µ ± ∞ ¹       ~ (p=1.000 n=1) ²
PersistentStorage_TraceSpans/#traces:_1_#spansPerTrace:_10-10    3.131µ ± ∞ ¹   3.226µ ± ∞ ¹       ~ (p=1.000 n=1) ²
PersistentStorage_TraceSpans/#traces:_10_#spansPerTrace:_10-10   20.67µ ± ∞ ¹   21.31µ ± ∞ ¹       ~ (p=1.000 n=1) ²
geomean                                                          400.7m         368.4m        -8.06%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

                                                               │  before.txt   │              after6.txt               │
                                                               │     B/op      │     B/op       vs base                │
_QueueUsage_10000_1_50000-10                                     2.444Mi ± ∞ ¹   2.445Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_QueueUsage_10000_2_50000-10                                     2.445Mi ± ∞ ¹   2.445Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_QueueUsage_10000_5_50000-10                                     2.447Mi ± ∞ ¹   2.448Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_QueueUsage_10000_10_50000-10                                    2.449Mi ± ∞ ¹   2.449Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_QueueUsage_50000_1_50000-10                                     3.053Mi ± ∞ ¹   3.053Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_QueueUsage_50000_2_50000-10                                     3.054Mi ± ∞ ¹   3.053Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_QueueUsage_50000_5_50000-10                                     3.055Mi ± ∞ ¹   3.054Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_QueueUsage_50000_10_50000-10                                    3.057Mi ± ∞ ¹   3.056Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_QueueUsage_10000_1_250000-10                                    11.61Mi ± ∞ ¹   11.61Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_QueueUsage_10000_2_250000-10                                    11.61Mi ± ∞ ¹   11.61Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_QueueUsage_10000_5_250000-10                                    11.61Mi ± ∞ ¹   11.61Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_QueueUsage_10000_10_250000-10                                   11.61Mi ± ∞ ¹   11.61Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
PersistentStorage_TraceSpans/#traces:_1_#spansPerTrace:_1-10       876.0 ± ∞ ¹     854.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
PersistentStorage_TraceSpans/#traces:_1_#spansPerTrace:_10-10    3.425Ki ± ∞ ¹   3.424Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
PersistentStorage_TraceSpans/#traces:_10_#spansPerTrace:_10-10   27.13Ki ± ∞ ¹   27.13Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
geomean                                                          1.100Mi         1.098Mi        -0.18%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

                                                               │  before.txt  │              after6.txt              │
                                                               │  allocs/op   │  allocs/op    vs base                │
_QueueUsage_10000_1_50000-10                                     149.8k ± ∞ ¹   149.8k ± ∞ ¹       ~ (p=1.000 n=1) ²
_QueueUsage_10000_2_50000-10                                     149.8k ± ∞ ¹   149.8k ± ∞ ¹       ~ (p=1.000 n=1) ²
_QueueUsage_10000_5_50000-10                                     149.8k ± ∞ ¹   149.8k ± ∞ ¹       ~ (p=1.000 n=1) ²
_QueueUsage_10000_10_50000-10                                    149.8k ± ∞ ¹   149.8k ± ∞ ¹       ~ (p=1.000 n=1) ²
_QueueUsage_50000_1_50000-10                                     149.8k ± ∞ ¹   149.8k ± ∞ ¹       ~ (p=1.000 n=1) ²
_QueueUsage_50000_2_50000-10                                     149.8k ± ∞ ¹   149.8k ± ∞ ¹       ~ (p=1.000 n=1) ²
_QueueUsage_50000_5_50000-10                                     149.8k ± ∞ ¹   149.8k ± ∞ ¹       ~ (p=1.000 n=1) ³
_QueueUsage_50000_10_50000-10                                    149.8k ± ∞ ¹   149.8k ± ∞ ¹       ~ (p=1.000 n=1) ²
_QueueUsage_10000_1_250000-10                                    749.8k ± ∞ ¹   749.8k ± ∞ ¹       ~ (p=1.000 n=1) ²
_QueueUsage_10000_2_250000-10                                    749.8k ± ∞ ¹   749.8k ± ∞ ¹       ~ (p=1.000 n=1) ²
_QueueUsage_10000_5_250000-10                                    749.8k ± ∞ ¹   749.8k ± ∞ ¹       ~ (p=1.000 n=1) ²
_QueueUsage_10000_10_250000-10                                   749.8k ± ∞ ¹   749.8k ± ∞ ¹       ~ (p=1.000 n=1) ²
PersistentStorage_TraceSpans/#traces:_1_#spansPerTrace:_1-10      11.00 ± ∞ ¹    11.00 ± ∞ ¹       ~ (p=1.000 n=1) ³
PersistentStorage_TraceSpans/#traces:_1_#spansPerTrace:_10-10     11.00 ± ∞ ¹    11.00 ± ∞ ¹       ~ (p=1.000 n=1) ³
PersistentStorage_TraceSpans/#traces:_10_#spansPerTrace:_10-10    11.00 ± ∞ ¹    11.00 ± ∞ ¹       ~ (p=1.000 n=1) ³
geomean                                                          34.29k         34.29k        +0.00%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05
³ all samples are equal
```
**Link to tracking Issue:** 
Fixes #8124
