### PR TITLE
[confmap] Skip exported functions/channels when marshaling configuration.

### DIFF
--- a/.chloggen/unsupported-kind-encoding.yaml
+++ b/.chloggen/unsupported-kind-encoding.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: confmap
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Skip exported functions/channels when marshaling configuration.
+
+# One or more tracking issues or pull requests related to the change
+issues: [8627]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/confmap/confmap.go
+++ b/confmap/confmap.go
@@ -175,6 +175,7 @@ func encoderConfig(rawVal any) *encoder.EncoderConfig {
 		EncodeHook: mapstructure.ComposeDecodeHookFunc(
 			encoder.TextMarshalerHookFunc(),
 			marshalerHookFunc(rawVal),
+			encoder.UnsupportedKindHookFunc(),
 		),
 	}
 }


### PR DESCRIPTION
**Description:** `go-yaml` does not support `reflect.Func` or `reflect.Chan`. `confmap.Marshal` should also just ignore these fields.

Adds an `UnsupportedKindHookFunc` after the other decode hooks to filter out the unsupported kinds after it's gone through the `encoding.TextMarshaler` and `confmap.Marshaler` rounds. This way if a function or channel type does implement a `encoding.TextMarshaler`, it will still use it.

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector/issues/8627

**Testing:** Added test cases for encoding unsupported kinds.
