### PR TITLE
[chore]: Validate number of consumers in exporterhelper

### DIFF
--- a/exporter/exporterhelper/queue_sender.go
+++ b/exporter/exporterhelper/queue_sender.go
@@ -59,6 +59,10 @@ func (qCfg *QueueSettings) Validate() error {
 		return errors.New("queue size must be positive")
 	}
 
+	if qCfg.NumConsumers <= 0 {
+		return errors.New("number of queue consumers must be positive")
+	}
+
 	return nil
 }
 

--- a/exporter/exporterhelper/queue_sender_test.go
+++ b/exporter/exporterhelper/queue_sender_test.go
@@ -173,6 +173,11 @@ func TestQueueSettings_Validate(t *testing.T) {
 	qCfg.QueueSize = 0
 	assert.EqualError(t, qCfg.Validate(), "queue size must be positive")
 
+	qCfg = NewDefaultQueueSettings()
+	qCfg.NumConsumers = 0
+
+	assert.EqualError(t, qCfg.Validate(), "number of queue consumers must be positive")
+
 	// Confirm Validate doesn't return error with invalid config when feature is disabled
 	qCfg.Enabled = false
 	assert.NoError(t, qCfg.Validate())


### PR DESCRIPTION

**Description:** Validate number of consumers in exporterhelper

This is a very small bug fix that does not even deserve a changelog entry. The collector will not work if a queue with a number of consumers <= 0 is used, so we should fail loudly instead of just hanging not draining the data from the queue.

**Testing:** UTs were added.


_Please delete paragraphs that you did not use before submitting._
