### PR TITLE
[chore] Update changelog entry for the recent pdata functionality

### DIFF
--- a/CHANGELOG-API.md
+++ b/CHANGELOG-API.md
@@ -9,6 +9,15 @@ If you are looking for user-facing changes, check out [CHANGELOG.md](./CHANGELOG
 
 ## v1.0.0-rcv0016/v0.87.0
 
+### 💡 Enhancements 💡
+
+- `pdata`: Introduce API to control pdata mutability (#6794)
+  This change introduces new API pdata methods to control the mutability:
+  - p[metric|trace|log].[Metrics|Traces|Logs].MarkReadOnly() - marks the pdata as read-only. Any subsequent
+    mutations will result in a panic.
+  - p[metric|trace|log].[Metrics|Traces|Logs].IsReadOnly() - returns true if the pdata is marked as read-only.
+  Currently, all the data is kept mutable. This API will be used by fanout consumer in the following releases. 
+
 ### 🛑 Breaking changes 🛑
 
 - `obsreport`: remove methods/structs deprecated in previous release. (#8492)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,6 @@ If you are looking for developer-facing changes, check out [CHANGELOG-API.md](./
 - `service/telemetry exporter/exporterhelper`: Enable sampling logging by default and apply it to all components. (#8134)
   The sampled logger configuration can be disabled easily by setting the `service::telemetry::logs::sampling::enabled` to `false`.
 - `core`: Adds the ability for components to report status and for extensions to subscribe to status events by implementing an optional StatusWatcher interface. (#7682)
-- `pdata`: Introduce runtime assertions to catch incorrect pdata mutations (#6794)
-  This change introduces an option to enable runtime assertions to catch unintentional pdata mutations in components
-  that are claimed as non-mutating pdata. Without these assertions, runtime errors may still occur, but thrown by
-  unrelated components, making it very difficult to troubleshoot.
-  
 
 ### 🧰 Bug fixes 🧰
 


### PR DESCRIPTION
The first iteration doesn't affect the end users. So moving it from user to API changelog
