### PR TITLE
[README] Update wording on Go version policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ A component identified as unmaintained does not have an active code owner. Such 
 When used as a library, the OpenTelemetry Collector attempts to track the currently supported versions of Go, as [defined by the Go team](https://go.dev/doc/devel/release#policy).
 Removing support for an unsupported Go version is not considered a breaking change.
 
-Starting with the release of Go 1.18, support for Go versions on the OpenTelemetry Collector will be updated as follows:
+Support for Go versions on the OpenTelemetry Collector is updated as follows:
 
 1. The first release after the release of a new Go minor version `N` will add build and tests steps for the new Go minor version.
 2. The first release after the release of a new Go minor version `N` will remove support for Go version `N-2`.


### PR DESCRIPTION
No need to mention Go 1.18 there anymore :)
