### PR TITLE
[chore] fix double caching of golang dependencies

### DIFF
--- a/.github/workflows/build-and-test-windows.yaml
+++ b/.github/workflows/build-and-test-windows.yaml
@@ -20,6 +20,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: ~1.20.10
+          cache: false
       - name: Cache Go
         uses: actions/cache@v3
         env:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -20,6 +20,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: ~1.20.10
+          cache: false
       - name: Cache Go
         id: go-cache
         uses: actions/cache@v3
@@ -42,6 +43,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: ~1.20.10
+          cache: false
       - name: Cache Go
         id: go-cache
         uses: actions/cache@v3
@@ -65,6 +67,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: ~1.20.10
+          cache: false
       - name: Cache Go
         id: go-cache
         uses: actions/cache@v3
@@ -89,6 +92,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: ~1.20.10
+          cache: false
       - name: Cache Go
         id: go-cache
         uses: actions/cache@v3
@@ -143,6 +147,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go-version }}
+          cache: false
       - name: Cache Go
         id: go-cache
         uses: actions/cache@v3
@@ -185,6 +190,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: ~1.20.6
+          cache: false
       - name: Cache Go
         id: go-cache
         uses: actions/cache@v3
@@ -252,6 +258,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: ~1.20.10
+          cache: false
       - name: Cache Go
         id: go-cache
         uses: actions/cache@v3

--- a/.github/workflows/contrib-tests.yml
+++ b/.github/workflows/contrib-tests.yml
@@ -24,6 +24,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: ~1.20.10
+          cache: false
       - name: Run Contrib Tests
         run: |
           contrib_path=/tmp/opentelemetry-collector-contrib


### PR DESCRIPTION
Avoid double caching go dependencies, it ends up slowing the build with decompression errors.