### PR TITLE
[fanoutconsumer] [chore] Do not wrap one read-only consumer

### DIFF
--- a/internal/fanoutconsumer/logs.go
+++ b/internal/fanoutconsumer/logs.go
@@ -22,6 +22,11 @@ import (
 //   - Clones only to the consumer that needs to mutate the data.
 //   - If all consumers needs to mutate the data one will get the original mutable data.
 func NewLogs(lcs []consumer.Logs) consumer.Logs {
+	// Don't wrap if there is only one non-mutating consumer.
+	if len(lcs) == 1 && !lcs[0].Capabilities().MutatesData {
+		return lcs[0]
+	}
+
 	lc := &logsConsumer{}
 	for i := 0; i < len(lcs); i++ {
 		if lcs[i].Capabilities().MutatesData {

--- a/internal/fanoutconsumer/logs_test.go
+++ b/internal/fanoutconsumer/logs_test.go
@@ -20,6 +20,12 @@ import (
 	"go.opentelemetry.io/collector/pdata/plog"
 )
 
+func TestLogsNotMultiplexing(t *testing.T) {
+	nop := consumertest.NewNop()
+	lfc := NewLogs([]consumer.Logs{nop})
+	assert.Same(t, nop, lfc)
+}
+
 func TestLogsMultiplexingNonMutating(t *testing.T) {
 	p1 := new(consumertest.LogsSink)
 	p2 := new(consumertest.LogsSink)

--- a/internal/fanoutconsumer/metrics.go
+++ b/internal/fanoutconsumer/metrics.go
@@ -20,6 +20,11 @@ import (
 //   - Clones only to the consumer that needs to mutate the data.
 //   - If all consumers needs to mutate the data one will get the original mutable data.
 func NewMetrics(mcs []consumer.Metrics) consumer.Metrics {
+	// Don't wrap if there is only one non-mutating consumer.
+	if len(mcs) == 1 && !mcs[0].Capabilities().MutatesData {
+		return mcs[0]
+	}
+
 	mc := &metricsConsumer{}
 	for i := 0; i < len(mcs); i++ {
 		if mcs[i].Capabilities().MutatesData {

--- a/internal/fanoutconsumer/metrics_test.go
+++ b/internal/fanoutconsumer/metrics_test.go
@@ -20,6 +20,12 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric"
 )
 
+func TestMetricsNotMultiplexing(t *testing.T) {
+	nop := consumertest.NewNop()
+	mfc := NewMetrics([]consumer.Metrics{nop})
+	assert.Same(t, nop, mfc)
+}
+
 func TestMetricsMultiplexingNonMutating(t *testing.T) {
 	p1 := new(consumertest.MetricsSink)
 	p2 := new(consumertest.MetricsSink)

--- a/internal/fanoutconsumer/traces.go
+++ b/internal/fanoutconsumer/traces.go
@@ -20,6 +20,11 @@ import (
 //   - Clones only to the consumer that needs to mutate the data.
 //   - If all consumers needs to mutate the data one will get the original mutable data.
 func NewTraces(tcs []consumer.Traces) consumer.Traces {
+	// Don't wrap if there is only one non-mutating consumer.
+	if len(tcs) == 1 && !tcs[0].Capabilities().MutatesData {
+		return tcs[0]
+	}
+
 	tc := &tracesConsumer{}
 	for i := 0; i < len(tcs); i++ {
 		if tcs[i].Capabilities().MutatesData {

--- a/internal/fanoutconsumer/traces_test.go
+++ b/internal/fanoutconsumer/traces_test.go
@@ -20,6 +20,12 @@ import (
 	"go.opentelemetry.io/collector/pdata/ptrace"
 )
 
+func TestTracesNotMultiplexing(t *testing.T) {
+	nop := consumertest.NewNop()
+	tfc := NewTraces([]consumer.Traces{nop})
+	assert.Same(t, nop, tfc)
+}
+
 func TestTracesMultiplexingNonMutating(t *testing.T) {
 	p1 := new(consumertest.TracesSink)
 	p2 := new(consumertest.TracesSink)


### PR DESCRIPTION
A follow-up optimization after merging https://github.com/open-telemetry/opentelemetry-collector/pull/8634.

There is no need to create a fanout consumer for only one read-only consumer. This introduces a behavior that closely resembles its previous state, before the introduction of the readonly/mutable states.