### PR TITLE
[cmd/builder] Specify limitations of `go install` on the README

### DIFF
--- a/cmd/builder/README.md
+++ b/cmd/builder/README.md
@@ -51,8 +51,21 @@ $ /tmp/dist/otelcol-custom --config=/tmp/otelcol.yaml
 
 ## Installation
 
-Download the binary for your respective platform under the ["Releases"](https://github.com/open-telemetry/opentelemetry-collector/releases/latest) page.
-If install an official release build, the binary is named `ocb`, but if you installed by using `go install`, it will be called `builder`.
+There are two supported ways to install the builder: via the official releases (recommended) and through `go install`.
+
+### Official releases 
+
+This is the recommended installation method. Download the binary for your respective platform under the ["Releases"](https://github.com/open-telemetry/opentelemetry-collector/releases/latest) page.
+
+### `go install`
+
+You need to have a `go` compiler in your PATH. Run the following command to install the latest version:
+
+```
+go install go.opentelemetry.io/collector/cmd/builder@latest
+```
+
+If installing through this method the binary will be called `builder`. Binaries installed through this method [will incorrectly show `dev` as their version](https://github.com/open-telemetry/opentelemetry-collector/issues/8691).
 
 ## Running
 


### PR DESCRIPTION
**Description:** 

Document `go install` limitations on `cmd/builder` README.

**Link to tracking Issue:** Fixes #8691
