### PR TITLE
[exporterhelper] fix bug with queue size and capacity metrics

### DIFF
--- a/.chloggen/codeboten_fix-queue-size-metric.yaml
+++ b/.chloggen/codeboten_fix-queue-size-metric.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: exporterhelper
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: fix bug with queue size and capacity metrics
+
+# One or more tracking issues or pull requests related to the change
+issues: [8682]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/exporterhelper/queue_sender.go
+++ b/exporter/exporterhelper/queue_sender.go
@@ -27,7 +27,7 @@ const defaultQueueSize = 1000
 
 var (
 	errSendingQueueIsFull = errors.New("sending_queue is full")
-	scopeName             = "go.opentelemetry.io/collector/exporterhelper/queue_sender"
+	scopeName             = "go.opentelemetry.io/collector/exporterhelper"
 )
 
 // QueueSettings defines configuration for queueing batches before sending to the consumerSender.

--- a/exporter/exporterhelper/queue_sender_test.go
+++ b/exporter/exporterhelper/queue_sender_test.go
@@ -19,6 +19,8 @@ import (
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/exporter/exporterhelper/internal"
 	"go.opentelemetry.io/collector/exporter/exportertest"
+	"go.opentelemetry.io/collector/featuregate"
+	"go.opentelemetry.io/collector/internal/obsreportconfig"
 	"go.opentelemetry.io/collector/internal/testdata"
 	"go.opentelemetry.io/collector/obsreport/obsreporttest"
 )
@@ -132,11 +134,24 @@ func TestQueuedRetryHappyPath(t *testing.T) {
 	ocs.checkDroppedItemsCount(t, 0)
 }
 
+// Force the state of feature gate for a test
+func setFeatureGateForTest(t testing.TB, gate *featuregate.Gate, enabled bool) func() {
+	originalValue := gate.IsEnabled()
+	require.NoError(t, featuregate.GlobalRegistry().Set(gate.ID(), enabled))
+	return func() {
+		require.NoError(t, featuregate.GlobalRegistry().Set(gate.ID(), originalValue))
+	}
+}
+
 func TestQueuedRetry_QueueMetricsReported(t *testing.T) {
+	tt, err := obsreporttest.SetupTelemetry(defaultID)
+	require.NoError(t, err)
+
 	qCfg := NewDefaultQueueSettings()
 	qCfg.NumConsumers = 0 // to make every request go straight to the queue
 	rCfg := NewDefaultRetrySettings()
-	be, err := newBaseExporter(defaultSettings, "", false, nil, nil, newObservabilityConsumerSender, WithRetry(rCfg), WithQueue(qCfg))
+	set := exporter.CreateSettings{ID: defaultID, TelemetrySettings: tt.TelemetrySettings, BuildInfo: component.NewDefaultBuildInfo()}
+	be, err := newBaseExporter(set, "", false, nil, nil, newObservabilityConsumerSender, WithRetry(rCfg), WithQueue(qCfg))
 	require.NoError(t, err)
 	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
 
@@ -148,6 +163,31 @@ func TestQueuedRetry_QueueMetricsReported(t *testing.T) {
 
 	assert.NoError(t, be.Shutdown(context.Background()))
 	checkValueForGlobalManager(t, defaultExporterTags, int64(0), "exporter/queue_size")
+}
+
+func TestQueuedRetry_QueueMetricsReportedUsingOTel(t *testing.T) {
+	resetFlag := setFeatureGateForTest(t, obsreportconfig.UseOtelForInternalMetricsfeatureGate, true)
+	defer resetFlag()
+
+	tt, err := obsreporttest.SetupTelemetry(defaultID)
+	require.NoError(t, err)
+
+	qCfg := NewDefaultQueueSettings()
+	qCfg.NumConsumers = 0 // to make every request go straight to the queue
+	rCfg := NewDefaultRetrySettings()
+	set := exporter.CreateSettings{ID: defaultID, TelemetrySettings: tt.TelemetrySettings, BuildInfo: component.NewDefaultBuildInfo()}
+	be, err := newBaseExporter(set, "", false, nil, nil, newObservabilityConsumerSender, WithRetry(rCfg), WithQueue(qCfg))
+	require.NoError(t, err)
+	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
+
+	require.NoError(t, tt.CheckExporterMetricGauge("exporter_queue_capacity", int64(defaultQueueSize)))
+
+	for i := 0; i < 7; i++ {
+		require.NoError(t, be.send(newErrorRequest(context.Background())))
+	}
+	require.NoError(t, tt.CheckExporterMetricGauge("exporter_queue_size", int64(7)))
+
+	assert.NoError(t, be.Shutdown(context.Background()))
 }
 
 func TestNoCancellationContext(t *testing.T) {

--- a/obsreport/obsreporttest/obsreporttest.go
+++ b/obsreport/obsreporttest/obsreporttest.go
@@ -78,6 +78,10 @@ func (tts *TestTelemetry) CheckExporterLogs(sentLogRecords, sendFailedLogRecords
 	return tts.prometheusChecker.checkExporterLogs(tts.id, sentLogRecords, sendFailedLogRecords)
 }
 
+func (tts *TestTelemetry) CheckExporterMetricGauge(metric string, val int64) error {
+	return tts.prometheusChecker.checkExporterMetricGauge(tts.id, metric, val)
+}
+
 // CheckProcessorTraces checks that for the current exported values for trace exporter metrics match given values.
 // When this function is called it is required to also call SetupTelemetry as first thing.
 func (tts *TestTelemetry) CheckProcessorTraces(acceptedSpans, refusedSpans, droppedSpans int64) error {


### PR DESCRIPTION
This change ensures the queue_size and queue_capacity metrics are available when using OpenTelemetry for the collector's internal metrics.

Fixes #8682
