### PR TITLE
[cmd/builder] (docs) Fix link to collector builder releases

### DIFF
--- a/cmd/builder/README.md
+++ b/cmd/builder/README.md
@@ -55,7 +55,7 @@ There are two supported ways to install the builder: via the official releases (
 
 ### Official releases 
 
-This is the recommended installation method. Download the binary for your respective platform under the ["Releases"](https://github.com/open-telemetry/opentelemetry-collector/releases/latest) page.
+This is the recommended installation method. Download the binary for your respective platform under the ["Releases"](https://github.com/open-telemetry/opentelemetry-collector/releases?q=builder) page.
 
 ### `go install`
 


### PR DESCRIPTION
**Description:**
With the collector builder now in the same repo as the collector itself, `/latest` is not a good place to find the latest release of the collector builder. This change provides a link that finds the desired release.