### PR TITLE
[exporterhelper] Replace experimental converter interface with function

### DIFF
--- a/.chloggen/dmitryax_use-func-instead-of-converter-interface.yaml
+++ b/.chloggen/dmitryax_use-func-instead-of-converter-interface.yaml
@@ -1,0 +1,20 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: exporterhelper
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Replace converter interface with function in the new experimental exporter helper.
+
+# One or more tracking issues or pull requests related to the change
+issues: [8122]
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/exporter/exporterhelper/constants.go
+++ b/exporter/exporterhelper/constants.go
@@ -18,10 +18,10 @@ var (
 	errNilPushMetricsData = errors.New("nil PushMetrics")
 	// errNilPushLogsData is returned when a nil PushLogs is given.
 	errNilPushLogsData = errors.New("nil PushLogs")
-	// errNilTracesConverter is returned when a nil TracesConverter is given.
-	errNilTracesConverter = errors.New("nil TracesConverter")
-	// errNilMetricsConverter is returned when a nil MetricsConverter is given.
-	errNilMetricsConverter = errors.New("nil MetricsConverter")
-	// errNilLogsConverter is returned when a nil LogsConverter is given.
-	errNilLogsConverter = errors.New("nil LogsConverter")
+	// errNilTracesConverter is returned when a nil RequestFromTracesFunc is given.
+	errNilTracesConverter = errors.New("nil RequestFromTracesFunc")
+	// errNilMetricsConverter is returned when a nil RequestFromMetricsFunc is given.
+	errNilMetricsConverter = errors.New("nil RequestFromMetricsFunc")
+	// errNilLogsConverter is returned when a nil RequestFromLogsFunc is given.
+	errNilLogsConverter = errors.New("nil RequestFromLogsFunc")
 )

--- a/exporter/exporterhelper/logs.go
+++ b/exporter/exporterhelper/logs.go
@@ -110,13 +110,10 @@ func NewLogsExporter(
 	}, err
 }
 
-// LogsConverter provides an interface for converting plog.Logs into a request.
+// RequestFromLogsFunc converts plog.Logs data into a user-defined request.
 // This API is at the early stage of development and may change without backward compatibility
 // until https://github.com/open-telemetry/opentelemetry-collector/issues/8122 is resolved.
-type LogsConverter interface {
-	// RequestFromLogs converts plog.Logs data into a request.
-	RequestFromLogs(context.Context, plog.Logs) (Request, error)
-}
+type RequestFromLogsFunc func(context.Context, plog.Logs) (Request, error)
 
 // NewLogsRequestExporter creates new logs exporter based on custom LogsConverter and RequestSender.
 // This API is at the early stage of development and may change without backward compatibility
@@ -124,7 +121,7 @@ type LogsConverter interface {
 func NewLogsRequestExporter(
 	_ context.Context,
 	set exporter.CreateSettings,
-	converter LogsConverter,
+	converter RequestFromLogsFunc,
 	options ...Option,
 ) (exporter.Logs, error) {
 	if set.Logger == nil {
@@ -141,7 +138,7 @@ func NewLogsRequestExporter(
 	}
 
 	lc, err := consumer.NewLogs(func(ctx context.Context, ld plog.Logs) error {
-		req, cErr := converter.RequestFromLogs(ctx, ld)
+		req, cErr := converter(ctx, ld)
 		if cErr != nil {
 			set.Logger.Error("Failed to convert logs. Dropping data.",
 				zap.Int("dropped_log_records", ld.LogRecordCount()),

--- a/exporter/exporterhelper/metrics.go
+++ b/exporter/exporterhelper/metrics.go
@@ -110,13 +110,10 @@ func NewMetricsExporter(
 	}, err
 }
 
-// MetricsConverter provides an interface for converting pmetric.Metrics into a request.
+// RequestFromMetricsFunc converts pdata.Metrics into a user-defined request.
 // This API is at the early stage of development and may change without backward compatibility
 // until https://github.com/open-telemetry/opentelemetry-collector/issues/8122 is resolved.
-type MetricsConverter interface {
-	// RequestFromMetrics converts pdata.Metrics into a request.
-	RequestFromMetrics(context.Context, pmetric.Metrics) (Request, error)
-}
+type RequestFromMetricsFunc func(context.Context, pmetric.Metrics) (Request, error)
 
 // NewMetricsRequestExporter creates a new metrics exporter based on a custom MetricsConverter and RequestSender.
 // This API is at the early stage of development and may change without backward compatibility
@@ -124,7 +121,7 @@ type MetricsConverter interface {
 func NewMetricsRequestExporter(
 	_ context.Context,
 	set exporter.CreateSettings,
-	converter MetricsConverter,
+	converter RequestFromMetricsFunc,
 	options ...Option,
 ) (exporter.Metrics, error) {
 	if set.Logger == nil {
@@ -141,7 +138,7 @@ func NewMetricsRequestExporter(
 	}
 
 	mc, err := consumer.NewMetrics(func(ctx context.Context, md pmetric.Metrics) error {
-		req, cErr := converter.RequestFromMetrics(ctx, md)
+		req, cErr := converter(ctx, md)
 		if cErr != nil {
 			set.Logger.Error("Failed to convert metrics. Dropping data.",
 				zap.Int("dropped_data_points", md.DataPointCount()),

--- a/exporter/exporterhelper/metrics_test.go
+++ b/exporter/exporterhelper/metrics_test.go
@@ -64,7 +64,8 @@ func TestMetricsExporter_NilLogger(t *testing.T) {
 }
 
 func TestMetricsRequestExporter_NilLogger(t *testing.T) {
-	me, err := NewMetricsRequestExporter(context.Background(), exporter.CreateSettings{}, fakeRequestConverter{})
+	me, err := NewMetricsRequestExporter(context.Background(), exporter.CreateSettings{},
+		(&fakeRequestConverter{}).requestFromMetricsFunc)
 	require.Nil(t, me)
 	require.Equal(t, errNilLogger, err)
 }
@@ -95,7 +96,8 @@ func TestMetricsExporter_Default(t *testing.T) {
 
 func TestMetricsRequestExporter_Default(t *testing.T) {
 	md := pmetric.NewMetrics()
-	me, err := NewMetricsRequestExporter(context.Background(), exportertest.NewNopCreateSettings(), fakeRequestConverter{})
+	me, err := NewMetricsRequestExporter(context.Background(), exportertest.NewNopCreateSettings(),
+		(&fakeRequestConverter{}).requestFromMetricsFunc)
 	assert.NoError(t, err)
 	assert.NotNil(t, me)
 
@@ -116,8 +118,8 @@ func TestMetricsExporter_WithCapabilities(t *testing.T) {
 
 func TestMetricsRequestExporter_WithCapabilities(t *testing.T) {
 	capabilities := consumer.Capabilities{MutatesData: true}
-	me, err := NewMetricsRequestExporter(context.Background(), exportertest.NewNopCreateSettings(), fakeRequestConverter{},
-		WithCapabilities(capabilities))
+	me, err := NewMetricsRequestExporter(context.Background(), exportertest.NewNopCreateSettings(),
+		(&fakeRequestConverter{}).requestFromMetricsFunc, WithCapabilities(capabilities))
 	assert.NoError(t, err)
 	assert.NotNil(t, me)
 
@@ -136,7 +138,8 @@ func TestMetricsExporter_Default_ReturnError(t *testing.T) {
 func TestMetricsRequestExporter_Default_ConvertError(t *testing.T) {
 	md := pmetric.NewMetrics()
 	want := errors.New("convert_error")
-	me, err := NewMetricsRequestExporter(context.Background(), exportertest.NewNopCreateSettings(), fakeRequestConverter{metricsError: want})
+	me, err := NewMetricsRequestExporter(context.Background(), exportertest.NewNopCreateSettings(),
+		(&fakeRequestConverter{metricsError: want}).requestFromMetricsFunc)
 	require.NoError(t, err)
 	require.NotNil(t, me)
 	require.Equal(t, consumererror.NewPermanent(want), me.ConsumeMetrics(context.Background(), md))
@@ -146,7 +149,7 @@ func TestMetricsRequestExporter_Default_ExportError(t *testing.T) {
 	md := pmetric.NewMetrics()
 	want := errors.New("export_error")
 	me, err := NewMetricsRequestExporter(context.Background(), exportertest.NewNopCreateSettings(),
-		fakeRequestConverter{requestError: want})
+		(&fakeRequestConverter{requestError: want}).requestFromMetricsFunc)
 	require.NoError(t, err)
 	require.NotNil(t, me)
 	require.Equal(t, want, me.ConsumeMetrics(context.Background(), md))
@@ -193,7 +196,9 @@ func TestMetricsRequestExporter_WithRecordMetrics(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
-	me, err := NewMetricsRequestExporter(context.Background(), exporter.CreateSettings{ID: fakeMetricsExporterName, TelemetrySettings: tt.TelemetrySettings, BuildInfo: component.NewDefaultBuildInfo()}, fakeRequestConverter{})
+	me, err := NewMetricsRequestExporter(context.Background(),
+		exporter.CreateSettings{ID: fakeMetricsExporterName, TelemetrySettings: tt.TelemetrySettings, BuildInfo: component.NewDefaultBuildInfo()},
+		(&fakeRequestConverter{}).requestFromMetricsFunc)
 	require.NoError(t, err)
 	require.NotNil(t, me)
 
@@ -219,7 +224,9 @@ func TestMetricsRequestExporter_WithRecordMetrics_ExportError(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
-	me, err := NewMetricsRequestExporter(context.Background(), exporter.CreateSettings{ID: fakeMetricsExporterName, TelemetrySettings: tt.TelemetrySettings, BuildInfo: component.NewDefaultBuildInfo()}, fakeRequestConverter{requestError: want})
+	me, err := NewMetricsRequestExporter(context.Background(),
+		exporter.CreateSettings{ID: fakeMetricsExporterName, TelemetrySettings: tt.TelemetrySettings, BuildInfo: component.NewDefaultBuildInfo()},
+		(&fakeRequestConverter{requestError: want}).requestFromMetricsFunc)
 	require.NoError(t, err)
 	require.NotNil(t, me)
 
@@ -271,7 +278,7 @@ func TestMetricsRequestExporter_WithSpan(t *testing.T) {
 	otel.SetTracerProvider(set.TracerProvider)
 	defer otel.SetTracerProvider(trace.NewNoopTracerProvider())
 
-	me, err := NewMetricsRequestExporter(context.Background(), set, fakeRequestConverter{})
+	me, err := NewMetricsRequestExporter(context.Background(), set, (&fakeRequestConverter{}).requestFromMetricsFunc)
 	require.NoError(t, err)
 	require.NotNil(t, me)
 	checkWrapSpanForMetricsExporter(t, sr, set.TracerProvider.Tracer("test"), me, nil, 2)
@@ -299,7 +306,7 @@ func TestMetricsRequestExporter_WithSpan_ExportError(t *testing.T) {
 	defer otel.SetTracerProvider(trace.NewNoopTracerProvider())
 
 	want := errors.New("my_error")
-	me, err := NewMetricsRequestExporter(context.Background(), set, fakeRequestConverter{requestError: want})
+	me, err := NewMetricsRequestExporter(context.Background(), set, (&fakeRequestConverter{requestError: want}).requestFromMetricsFunc)
 	require.NoError(t, err)
 	require.NotNil(t, me)
 	checkWrapSpanForMetricsExporter(t, sr, set.TracerProvider.Tracer("test"), me, want, 2)
@@ -323,7 +330,7 @@ func TestMetricsRequestExporter_WithShutdown(t *testing.T) {
 	shutdown := func(context.Context) error { shutdownCalled = true; return nil }
 
 	me, err := NewMetricsRequestExporter(context.Background(), exportertest.NewNopCreateSettings(),
-		&fakeRequestConverter{}, WithShutdown(shutdown))
+		(&fakeRequestConverter{}).requestFromMetricsFunc, WithShutdown(shutdown))
 	assert.NotNil(t, me)
 	assert.NoError(t, err)
 
@@ -349,7 +356,7 @@ func TestMetricsRequestExporter_WithShutdown_ReturnError(t *testing.T) {
 	shutdownErr := func(context.Context) error { return want }
 
 	me, err := NewMetricsRequestExporter(context.Background(), exportertest.NewNopCreateSettings(),
-		&fakeRequestConverter{}, WithShutdown(shutdownErr))
+		(&fakeRequestConverter{}).requestFromMetricsFunc, WithShutdown(shutdownErr))
 	assert.NotNil(t, me)
 	assert.NoError(t, err)
 

--- a/exporter/exporterhelper/request_test.go
+++ b/exporter/exporterhelper/request_test.go
@@ -31,14 +31,14 @@ type fakeRequestConverter struct {
 	requestError error
 }
 
-func (c fakeRequestConverter) RequestFromMetrics(_ context.Context, md pmetric.Metrics) (Request, error) {
-	return fakeRequest{items: md.DataPointCount(), err: c.requestError}, c.metricsError
+func (frc *fakeRequestConverter) requestFromMetricsFunc(_ context.Context, md pmetric.Metrics) (Request, error) {
+	return fakeRequest{items: md.DataPointCount(), err: frc.requestError}, frc.metricsError
 }
 
-func (c fakeRequestConverter) RequestFromTraces(_ context.Context, td ptrace.Traces) (Request, error) {
-	return fakeRequest{items: td.SpanCount(), err: c.requestError}, c.tracesError
+func (frc *fakeRequestConverter) requestFromTracesFunc(_ context.Context, md ptrace.Traces) (Request, error) {
+	return fakeRequest{items: md.SpanCount(), err: frc.requestError}, frc.tracesError
 }
 
-func (c fakeRequestConverter) RequestFromLogs(_ context.Context, ld plog.Logs) (Request, error) {
-	return fakeRequest{items: ld.LogRecordCount(), err: c.requestError}, c.logsError
+func (frc *fakeRequestConverter) requestFromLogsFunc(_ context.Context, md plog.Logs) (Request, error) {
+	return fakeRequest{items: md.LogRecordCount(), err: frc.requestError}, frc.logsError
 }

--- a/exporter/exporterhelper/traces.go
+++ b/exporter/exporterhelper/traces.go
@@ -110,13 +110,10 @@ func NewTracesExporter(
 	}, err
 }
 
-// TracesConverter provides an interface for converting ptrace.Traces into a request.
+// RequestFromTracesFunc converts ptrace.Traces into a user-defined Request.
 // This API is at the early stage of development and may change without backward compatibility
 // until https://github.com/open-telemetry/opentelemetry-collector/issues/8122 is resolved.
-type TracesConverter interface {
-	// RequestFromTraces converts ptrace.Traces into a Request.
-	RequestFromTraces(context.Context, ptrace.Traces) (Request, error)
-}
+type RequestFromTracesFunc func(context.Context, ptrace.Traces) (Request, error)
 
 // NewTracesRequestExporter creates a new traces exporter based on a custom TracesConverter and RequestSender.
 // This API is at the early stage of development and may change without backward compatibility
@@ -124,7 +121,7 @@ type TracesConverter interface {
 func NewTracesRequestExporter(
 	_ context.Context,
 	set exporter.CreateSettings,
-	converter TracesConverter,
+	converter RequestFromTracesFunc,
 	options ...Option,
 ) (exporter.Traces, error) {
 	if set.Logger == nil {
@@ -141,7 +138,7 @@ func NewTracesRequestExporter(
 	}
 
 	tc, err := consumer.NewTraces(func(ctx context.Context, td ptrace.Traces) error {
-		req, cErr := converter.RequestFromTraces(ctx, td)
+		req, cErr := converter(ctx, td)
 		if cErr != nil {
 			set.Logger.Error("Failed to convert traces. Dropping data.",
 				zap.Int("dropped_spans", td.SpanCount()),

--- a/exporter/exporterhelper/traces_test.go
+++ b/exporter/exporterhelper/traces_test.go
@@ -60,7 +60,7 @@ func TestTracesExporter_NilLogger(t *testing.T) {
 }
 
 func TestTracesRequestExporter_NilLogger(t *testing.T) {
-	te, err := NewTracesRequestExporter(context.Background(), exporter.CreateSettings{}, &fakeRequestConverter{})
+	te, err := NewTracesRequestExporter(context.Background(), exporter.CreateSettings{}, (&fakeRequestConverter{}).requestFromTracesFunc)
 	require.Nil(t, te)
 	require.Equal(t, errNilLogger, err)
 }
@@ -91,7 +91,8 @@ func TestTracesExporter_Default(t *testing.T) {
 
 func TestTracesRequestExporter_Default(t *testing.T) {
 	td := ptrace.NewTraces()
-	te, err := NewTracesRequestExporter(context.Background(), exportertest.NewNopCreateSettings(), &fakeRequestConverter{})
+	te, err := NewTracesRequestExporter(context.Background(), exportertest.NewNopCreateSettings(),
+		(&fakeRequestConverter{}).requestFromTracesFunc)
 	assert.NotNil(t, te)
 	assert.NoError(t, err)
 
@@ -112,7 +113,8 @@ func TestTracesExporter_WithCapabilities(t *testing.T) {
 
 func TestTracesRequestExporter_WithCapabilities(t *testing.T) {
 	capabilities := consumer.Capabilities{MutatesData: true}
-	te, err := NewTracesRequestExporter(context.Background(), exportertest.NewNopCreateSettings(), &fakeRequestConverter{}, WithCapabilities(capabilities))
+	te, err := NewTracesRequestExporter(context.Background(), exportertest.NewNopCreateSettings(),
+		(&fakeRequestConverter{}).requestFromTracesFunc, WithCapabilities(capabilities))
 	assert.NotNil(t, te)
 	assert.NoError(t, err)
 
@@ -134,7 +136,7 @@ func TestTracesRequestExporter_Default_ConvertError(t *testing.T) {
 	td := ptrace.NewTraces()
 	want := errors.New("convert_error")
 	te, err := NewTracesRequestExporter(context.Background(), exportertest.NewNopCreateSettings(),
-		&fakeRequestConverter{tracesError: want})
+		(&fakeRequestConverter{tracesError: want}).requestFromTracesFunc)
 	require.NoError(t, err)
 	require.NotNil(t, te)
 	require.Equal(t, consumererror.NewPermanent(want), te.ConsumeTraces(context.Background(), td))
@@ -143,7 +145,8 @@ func TestTracesRequestExporter_Default_ConvertError(t *testing.T) {
 func TestTracesRequestExporter_Default_ExportError(t *testing.T) {
 	td := ptrace.NewTraces()
 	want := errors.New("export_error")
-	te, err := NewTracesRequestExporter(context.Background(), exportertest.NewNopCreateSettings(), &fakeRequestConverter{requestError: want})
+	te, err := NewTracesRequestExporter(context.Background(), exportertest.NewNopCreateSettings(),
+		(&fakeRequestConverter{requestError: want}).requestFromTracesFunc)
 	require.NoError(t, err)
 	require.NotNil(t, te)
 	require.Equal(t, want, te.ConsumeTraces(context.Background(), td))
@@ -190,7 +193,9 @@ func TestTracesRequestExporter_WithRecordMetrics(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
-	te, err := NewTracesRequestExporter(context.Background(), exporter.CreateSettings{ID: fakeTracesExporterName, TelemetrySettings: tt.TelemetrySettings, BuildInfo: component.NewDefaultBuildInfo()}, &fakeRequestConverter{})
+	te, err := NewTracesRequestExporter(context.Background(),
+		exporter.CreateSettings{ID: fakeTracesExporterName, TelemetrySettings: tt.TelemetrySettings, BuildInfo: component.NewDefaultBuildInfo()},
+		(&fakeRequestConverter{}).requestFromTracesFunc)
 	require.NoError(t, err)
 	require.NotNil(t, te)
 
@@ -216,7 +221,9 @@ func TestTracesRequestExporter_WithRecordMetrics_RequestSenderError(t *testing.T
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
 
-	te, err := NewTracesRequestExporter(context.Background(), exporter.CreateSettings{ID: fakeTracesExporterName, TelemetrySettings: tt.TelemetrySettings, BuildInfo: component.NewDefaultBuildInfo()}, &fakeRequestConverter{requestError: want})
+	te, err := NewTracesRequestExporter(context.Background(),
+		exporter.CreateSettings{ID: fakeTracesExporterName, TelemetrySettings: tt.TelemetrySettings, BuildInfo: component.NewDefaultBuildInfo()},
+		(&fakeRequestConverter{requestError: want}).requestFromTracesFunc)
 	require.NoError(t, err)
 	require.NotNil(t, te)
 
@@ -269,7 +276,7 @@ func TestTracesRequestExporter_WithSpan(t *testing.T) {
 	otel.SetTracerProvider(set.TracerProvider)
 	defer otel.SetTracerProvider(trace.NewNoopTracerProvider())
 
-	te, err := NewTracesRequestExporter(context.Background(), set, &fakeRequestConverter{})
+	te, err := NewTracesRequestExporter(context.Background(), set, (&fakeRequestConverter{}).requestFromTracesFunc)
 	require.NoError(t, err)
 	require.NotNil(t, te)
 
@@ -299,7 +306,7 @@ func TestTracesRequestExporter_WithSpan_ExportError(t *testing.T) {
 	defer otel.SetTracerProvider(trace.NewNoopTracerProvider())
 
 	want := errors.New("export_error")
-	te, err := NewTracesRequestExporter(context.Background(), set, &fakeRequestConverter{requestError: want})
+	te, err := NewTracesRequestExporter(context.Background(), set, (&fakeRequestConverter{requestError: want}).requestFromTracesFunc)
 	require.NoError(t, err)
 	require.NotNil(t, te)
 
@@ -323,7 +330,8 @@ func TestTracesRequestExporter_WithShutdown(t *testing.T) {
 	shutdownCalled := false
 	shutdown := func(context.Context) error { shutdownCalled = true; return nil }
 
-	te, err := NewTracesRequestExporter(context.Background(), exportertest.NewNopCreateSettings(), &fakeRequestConverter{}, WithShutdown(shutdown))
+	te, err := NewTracesRequestExporter(context.Background(), exportertest.NewNopCreateSettings(),
+		(&fakeRequestConverter{}).requestFromTracesFunc, WithShutdown(shutdown))
 	assert.NotNil(t, te)
 	assert.NoError(t, err)
 
@@ -348,7 +356,8 @@ func TestTracesRequestExporter_WithShutdown_ReturnError(t *testing.T) {
 	want := errors.New("my_error")
 	shutdownErr := func(context.Context) error { return want }
 
-	te, err := NewTracesRequestExporter(context.Background(), exportertest.NewNopCreateSettings(), &fakeRequestConverter{}, WithShutdown(shutdownErr))
+	te, err := NewTracesRequestExporter(context.Background(), exportertest.NewNopCreateSettings(),
+		(&fakeRequestConverter{}).requestFromTracesFunc, WithShutdown(shutdownErr))
 	assert.NotNil(t, te)
 	assert.NoError(t, err)
 


### PR DESCRIPTION
As proposed in https://github.com/open-telemetry/opentelemetry-collector/issues/8122#issuecomment-1688794509

If we need backward conversion, we will use an optional argument to the helper function instead of an optional interface.