### PR TITLE
[service/extensions] extension lifecycle order

### DIFF
--- a/.chloggen/extension-lifecycle-order.yaml
+++ b/.chloggen/extension-lifecycle-order.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: service/extensions
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Implement strict ordering of startup, shutdown and notifications to extensions.
+
+# One or more tracking issues or pull requests related to the change
+issues: [8732]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/extension-lifecycle-order.yaml
+++ b/.chloggen/extension-lifecycle-order.yaml
@@ -1,13 +1,13 @@
 # Use this changelog template to create an entry for release notes.
 
 # One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
-change_type: bug_fix
+change_type: enhancement
 
 # The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
 component: service/extensions
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Implement strict ordering of startup, shutdown and notifications to extensions.
+note: Allow extensions to declare dependencies on other extensions and guarantee start/stop/notification order accordingly.
 
 # One or more tracking issues or pull requests related to the change
 issues: [8732]

--- a/docs/service-extensions.md
+++ b/docs/service-extensions.md
@@ -1,37 +1,37 @@
 # OpenTelemetry Collector: Extensions
 
 Besides the pipeline elements (receivers, processors, and exporters) the Collector
-uses various service extensions (e.g.: healthcheck, z-pages, etc). 
+uses various service extensions (e.g.: healthcheck, z-pages, etc).
 This document describes the “extensions” design and how they are implemented.
 
 ## Configuration and Interface
 
-The configuration follows the same pattern used for pipelines: a base 
-configuration type and the creation of factories to instantiate the extension 
+The configuration follows the same pattern used for pipelines: a base
+configuration type and the creation of factories to instantiate the extension
 objects.
 
-In order to support generic service extensions an interface is defined 
+In order to support generic service extensions an interface is defined
 so the service can interact uniformly with these. At minimum service extensions
-need to implement the interface that covers Start and Shutdown. 
+need to implement the interface that covers Start and Shutdown.
 
-In addition to this base interface there is support to notify extensions when 
-pipelines are “ready” and when they are about to be stopped, i.e.: “not ready” 
-to receive data. These are a necessary addition to allow implementing extensions 
-that indicate to LBs and external systems if the service instance is ready or 
-not to receive data 
-(e.g.: a [k8s readiness probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#define-readiness-probes)). 
-These state changes are under the control of the service server hosting 
+In addition to this base interface there is support to notify extensions when
+pipelines are “ready” and when they are about to be stopped, i.e.: “not ready”
+to receive data. These are a necessary addition to allow implementing extensions
+that indicate to LBs and external systems if the service instance is ready or
+not to receive data
+(e.g.: a [k8s readiness probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#define-readiness-probes)).
+These state changes are under the control of the service server hosting
 the extensions.
 
-There are more complex scenarios in which there can be notifications of state 
-changes from the extensions to their host. These more complex cases are not 
+There are more complex scenarios in which there can be notifications of state
+changes from the extensions to their host. These more complex cases are not
 supported at this moment, but this design doesn’t prevent such extensions in the
 future[^1].
 
 
 ## Collector State and Extensions
 
-The diagram below shows the basic state transitions of the OpenTelemetry Collector 
+The diagram below shows the basic state transitions of the OpenTelemetry Collector
 and how it will interact with the service extensions.
 
 ![ServiceLifeCycle](images/design-service-lifecycle.png)
@@ -39,9 +39,9 @@ and how it will interact with the service extensions.
 
 ## Configuration
 
-The config package will be extended to load the service extensions when the 
-configuration is loaded. The settings for service extensions will live in the 
-same configuration file as the pipeline elements. Below is an example of how 
+The config package will be extended to load the service extensions when the
+configuration is loaded. The settings for service extensions will live in the
+same configuration file as the pipeline elements. Below is an example of how
 these sections would look like in the configuration file:
 
 ```yaml
@@ -61,17 +61,18 @@ extensions:
 # The service lists extensions not directly related to data pipelines, but used
 # by the service.
 service:
-  # extensions lists the extensions added to the service. They are started
-  # in the order presented below and stopped in the reverse order.
+  # extensions lists the extensions added to the service. The start-up order respects
+  # any internal dependencies between extensions, but otherwise is arbitrary.
+  # The stop order is always the reverse of the start-up order.
   extensions: [health_check, pprof, zpages]
 ```
 
 The configuration base type does not share any common fields.
 
 The configuration, analogous to pipelines, allows to have multiple extensions of
-the same type. Implementers of extensions need to take care to return error 
+the same type. Implementers of extensions need to take care to return error
 if it can only execute a single instance. (Note: the configuration uses composite
-key names in the form of `type[/name]` 
+key names in the form of `type[/name]`
 as defined in this [this document](https://docs.google.com/document/d/1NeheFG7DmcUYo_h2vLtNRlia9x5wOJMlV4QKEK05FhQ/edit#)).
 
 The factory follows the same pattern established for pipeline configuration:
@@ -80,7 +81,7 @@ The factory follows the same pattern established for pipeline configuration:
 // Factory is a factory interface for extensions to the service.
 type Factory interface {
     // Type gets the type of the extension created by this factory.
-    Type() string 
+    Type() string
 
     // CreateDefaultConfig creates the default configuration for the extension.
     CreateDefaultConfig() config.Extension
@@ -93,7 +94,7 @@ type Factory interface {
 
 ## Extension Interface
 
-The interface defined below is the minimum required for 
+The interface defined below is the minimum required for
 extensions in use on the service:
 
 ```go
@@ -141,6 +142,6 @@ type Host interface {
 ## Notes
 
 [^1]:
-     This can be done by adding specific interfaces to extension types that support 
-     those and having the service checking which of the extension instances support 
+     This can be done by adding specific interfaces to extension types that support
+     those and having the service checking which of the extension instances support
      each interface.

--- a/extension/extension.go
+++ b/extension/extension.go
@@ -16,6 +16,11 @@ import (
 // to the service, examples: health check endpoint, z-pages, etc.
 type Extension = component.Component
 
+// TODO this can even be DependentComponent, but not sure if there's a use case for that.
+type DependentExtension interface {
+	Dependencies() []component.ID
+}
+
 // PipelineWatcher is an extra interface for Extension hosted by the OpenTelemetry
 // Collector that is to be implemented by extensions interested in changes to pipeline
 // states. Typically this will be used by extensions that change their behavior if data is

--- a/extension/extension.go
+++ b/extension/extension.go
@@ -20,6 +20,7 @@ type Extension = component.Component
 // that depend on other extensions and must be started only after their dependencies.
 // See https://github.com/open-telemetry/opentelemetry-collector/pull/8768 for examples.
 type Dependent interface {
+	Extension
 	Dependencies() []component.ID
 }
 

--- a/extension/extension.go
+++ b/extension/extension.go
@@ -16,7 +16,9 @@ import (
 // to the service, examples: health check endpoint, z-pages, etc.
 type Extension = component.Component
 
-// TODO this can even be DependentComponent, but not sure if there's a use case for that.
+// DependentExtension is an optional interface that can be implemented by extensions
+// that depend on other extensions and must be started only after their dependencies.
+// See https://github.com/open-telemetry/opentelemetry-collector/pull/8768 for examples.
 type DependentExtension interface {
 	Dependencies() []component.ID
 }

--- a/extension/extension.go
+++ b/extension/extension.go
@@ -16,10 +16,10 @@ import (
 // to the service, examples: health check endpoint, z-pages, etc.
 type Extension = component.Component
 
-// DependentExtension is an optional interface that can be implemented by extensions
+// Dependent is an optional interface that can be implemented by extensions
 // that depend on other extensions and must be started only after their dependencies.
 // See https://github.com/open-telemetry/opentelemetry-collector/pull/8768 for examples.
-type DependentExtension interface {
+type Dependent interface {
 	Dependencies() []component.ID
 }
 

--- a/service/extensions/extensions.go
+++ b/service/extensions/extensions.go
@@ -24,15 +24,9 @@ const zExtensionName = "zextensionname"
 // Extensions is a map of extensions created from extension configs.
 type Extensions struct {
 	telemetry    servicetelemetry.TelemetrySettings
-<<<<<<< HEAD
 	extMap       map[component.ID]extension.Extension
 	instanceIDs  map[component.ID]*component.InstanceID
 	extensionIDs []component.ID // start order (and reverse stop order)
-=======
-	extensionIDs []component.ID
-	extMap       map[component.ID]extension.Extension
-	instanceIDs  map[component.ID]*component.InstanceID
->>>>>>> 24dfe7690 ([service/extensions] enforce order of start and shutdown of extensions according to configuration)
 }
 
 // Start starts all extensions.
@@ -169,7 +163,6 @@ func New(ctx context.Context, set Settings, cfg Config) (*Extensions, error) {
 		instanceIDs:  make(map[component.ID]*component.InstanceID),
 		extensionIDs: make([]component.ID, 0, len(cfg)),
 	}
-	graph := newDependencyGraph()
 	for _, extID := range cfg {
 		instanceID := &component.InstanceID{
 			ID:   extID,
@@ -194,9 +187,9 @@ func New(ctx context.Context, set Settings, cfg Config) (*Extensions, error) {
 
 		exts.extMap[extID] = ext
 		exts.instanceIDs[extID] = instanceID
-		exts.extensionIDs = append(exts.extensionIDs, extID)
 	}
-	order, err := graph.sort()
+	graph := newDependencyGraph(exts)
+	order, err := graph.computeOrder()
 	if err != nil {
 		return nil, err
 	}

--- a/service/extensions/extensions.go
+++ b/service/extensions/extensions.go
@@ -188,8 +188,7 @@ func New(ctx context.Context, set Settings, cfg Config) (*Extensions, error) {
 		exts.extMap[extID] = ext
 		exts.instanceIDs[extID] = instanceID
 	}
-	graph := newDependencyGraph(exts)
-	order, err := graph.computeOrder()
+	order, err := computeOrder(exts)
 	if err != nil {
 		return nil, err
 	}

--- a/service/extensions/extensions.go
+++ b/service/extensions/extensions.go
@@ -80,7 +80,6 @@ func (bes *Extensions) NotifyPipelineReady() error {
 }
 
 func (bes *Extensions) NotifyPipelineNotReady() error {
-	// Notify extensions in reverse order.
 	var errs error
 	for _, extID := range bes.extensionIDs {
 		ext := bes.extMap[extID]

--- a/service/extensions/extensions.go
+++ b/service/extensions/extensions.go
@@ -57,7 +57,8 @@ func (bes *Extensions) Start(ctx context.Context, host component.Host) error {
 func (bes *Extensions) Shutdown(ctx context.Context) error {
 	bes.telemetry.Logger.Info("Stopping extensions...")
 	var errs error
-	for _, extID := range bes.extensionIDs {
+	for i := len(bes.extensionIDs) - 1; i >= 0; i-- {
+		extID := bes.extensionIDs[i]
 		instanceID := bes.instanceIDs[extID]
 		ext := bes.extMap[extID]
 		_ = bes.telemetry.ReportComponentStatus(instanceID, component.NewStatusEvent(component.StatusStopping))

--- a/service/extensions/extensions_test.go
+++ b/service/extensions/extensions_test.go
@@ -507,7 +507,7 @@ type recordingExtension struct {
 	createSettings   extension.CreateSettings
 }
 
-var _ extension.DependentExtension = (*recordingExtension)(nil)
+var _ extension.Dependent = (*recordingExtension)(nil)
 
 func (ext *recordingExtension) Dependencies() []component.ID {
 	if len(ext.config.dependencies) == 0 {

--- a/service/extensions/extensions_test.go
+++ b/service/extensions/extensions_test.go
@@ -100,14 +100,14 @@ func TestOrdering(t *testing.T) {
 	recordingExtensionFactory := newRecordingExtensionFactory(func(set extension.CreateSettings, host component.Host) error {
 		id := set.ID.String()
 		if id != "recording" {
-			// we're only interested in the bar/baz order
+			// we're only interested in the relative foo/bar order
 			startOrder = append(startOrder, set.ID.String())
 		}
 		return nil
 	}, func(set extension.CreateSettings) error {
 		id := set.ID.String()
 		if id != "recording" {
-			// we're only interested in the bar/baz order
+			// we're only interested in the relative foo/bar order
 			shutdownOrder = append(shutdownOrder, set.ID.String())
 		}
 		return nil

--- a/service/extensions/extensions_test.go
+++ b/service/extensions/extensions_test.go
@@ -128,7 +128,7 @@ func TestOrdering(t *testing.T) {
 	require.Equal(t, []string{"recording", "recording/foo", "recording/bar"}, startOrder)
 	err = exts.Shutdown(context.Background())
 	require.NoError(t, err)
-	require.Equal(t, []string{"recording", "recording/foo", "recording/bar"}, shutdownOrder)
+	require.Equal(t, []string{"recording/bar", "recording/foo", "recording"}, shutdownOrder)
 }
 
 func TestNotifyConfig(t *testing.T) {

--- a/service/extensions/extensions_test.go
+++ b/service/extensions/extensions_test.go
@@ -146,7 +146,7 @@ func TestOrdering(t *testing.T) {
 				{name: "foo", deps: []string{"bar"}},
 				{name: "bar", deps: []string{"foo"}},
 			},
-			err: "unable to sort the extenions",
+			err: "unable to order extenions",
 		},
 	}
 	for _, testCase := range tests {

--- a/service/extensions/extensions_test.go
+++ b/service/extensions/extensions_test.go
@@ -6,7 +6,6 @@ package extensions
 import (
 	"context"
 	"errors"
-	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -195,9 +194,16 @@ func (tc testOrderCase) testOrdering(t *testing.T) {
 	err = exts.Shutdown(context.Background())
 	require.NoError(t, err)
 
+	// TODO From Go 1.21 can use slices.Reverse()
+	reverseSlice := func(s []string) {
+		for i, j := 0, len(s)-1; i < j; i, j = i+1, j-1 {
+			s[i], s[j] = s[j], s[i]
+		}
+	}
+
 	if len(tc.order) > 0 {
 		require.Equal(t, tc.order, startOrder)
-		slices.Reverse(shutdownOrder)
+		reverseSlice(shutdownOrder)
 		require.Equal(t, tc.order, shutdownOrder)
 	}
 }

--- a/service/extensions/graph.go
+++ b/service/extensions/graph.go
@@ -19,18 +19,14 @@ func (n node) ID() int64 {
 	return n.nodeID
 }
 
-func newNode(id int, extID component.ID) *node {
-	return &node{
-		nodeID: int64(id),
-		extID:  extID,
-	}
-}
-
 func computeOrder(exts *Extensions) ([]component.ID, error) {
 	graph := simple.NewDirectedGraph()
 	nodes := make(map[component.ID]*node)
 	for extID := range exts.extMap {
-		n := newNode(len(nodes)+1, extID)
+		n := &node{
+			nodeID: int64(len(nodes) + 1),
+			extID:  extID,
+		}
 		graph.AddNode(n)
 		nodes[extID] = n
 	}
@@ -48,7 +44,7 @@ func computeOrder(exts *Extensions) ([]component.ID, error) {
 	}
 	orderedNodes, err := topo.Sort(graph)
 	if err != nil {
-		return nil, fmt.Errorf("unable to sort the dependency graph: %w", err)
+		return nil, fmt.Errorf("unable to sort the extenions dependency graph: %w", err)
 	}
 
 	order := make([]component.ID, len(orderedNodes))

--- a/service/extensions/graph.go
+++ b/service/extensions/graph.go
@@ -1,0 +1,65 @@
+package extensions
+
+import (
+	"hash/fnv"
+
+	"gonum.org/v1/gonum/graph/simple"
+	"gonum.org/v1/gonum/graph/topo"
+
+	"go.opentelemetry.io/collector/component"
+)
+
+type dependencyGraph struct {
+	graph *simple.DirectedGraph
+	order []component.ID
+}
+
+type nodeID int64
+
+func (n nodeID) ID() int64 {
+	return int64(n)
+}
+
+func newNodeID(extID component.ID) nodeID {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(extID.String()))
+	return nodeID(h.Sum64())
+}
+
+type node struct {
+	nodeID
+	extID component.ID
+}
+
+func newNode(extID component.ID) *node {
+	return &node{
+		nodeID: newNodeID(extID),
+		extID:  extID,
+	}
+}
+
+func newDependencyGraph() *dependencyGraph {
+	return &dependencyGraph{
+		graph: simple.NewDirectedGraph(),
+	}
+}
+
+func (dg *dependencyGraph) addNode(extID component.ID) {
+	dg.graph.AddNode(newNode(extID))
+}
+
+func (dg *dependencyGraph) addDependency(fromExtID, toExtID component.ID) {
+	dg.graph.SetEdge(dg.graph.NewEdge(newNodeID(fromExtID), newNodeID(toExtID)))
+}
+
+func (dg *dependencyGraph) sort() ([]component.ID, error) {
+	nodes, err := topo.Sort(dg.graph)
+	if err != nil {
+		return nil, err
+	}
+	order := make([]component.ID, 0, len(nodes))
+	for i, n := range nodes {
+		order[i] = n.(*node).extID
+	}
+	return order, nil
+}

--- a/service/extensions/graph.go
+++ b/service/extensions/graph.go
@@ -1,4 +1,7 @@
-package extensions
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package extensions // import "go.opentelemetry.io/collector/service/extensions"
 
 import (
 	"fmt"

--- a/service/extensions/graph.go
+++ b/service/extensions/graph.go
@@ -1,64 +1,74 @@
 package extensions
 
 import (
+	"fmt"
 	"hash/fnv"
 
 	"gonum.org/v1/gonum/graph/simple"
 	"gonum.org/v1/gonum/graph/topo"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/extension"
 )
 
 type dependencyGraph struct {
+	exts  *Extensions
 	graph *simple.DirectedGraph
-	order []component.ID
-}
-
-type nodeID int64
-
-func (n nodeID) ID() int64 {
-	return int64(n)
-}
-
-func newNodeID(extID component.ID) nodeID {
-	h := fnv.New64a()
-	_, _ = h.Write([]byte(extID.String()))
-	return nodeID(h.Sum64())
 }
 
 type node struct {
-	nodeID
-	extID component.ID
+	nodeID uint64
+	extID  component.ID
+}
+
+func (n node) ID() int64 {
+	return int64(n.nodeID)
 }
 
 func newNode(extID component.ID) *node {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(extID.String()))
 	return &node{
-		nodeID: newNodeID(extID),
+		nodeID: h.Sum64(),
 		extID:  extID,
 	}
 }
 
-func newDependencyGraph() *dependencyGraph {
+func newDependencyGraph(exts *Extensions) *dependencyGraph {
 	return &dependencyGraph{
+		exts:  exts,
 		graph: simple.NewDirectedGraph(),
 	}
 }
 
-func (dg *dependencyGraph) addNode(extID component.ID) {
-	dg.graph.AddNode(newNode(extID))
-}
-
-func (dg *dependencyGraph) addDependency(fromExtID, toExtID component.ID) {
-	dg.graph.SetEdge(dg.graph.NewEdge(newNodeID(fromExtID), newNodeID(toExtID)))
-}
-
-func (dg *dependencyGraph) sort() ([]component.ID, error) {
-	nodes, err := topo.Sort(dg.graph)
-	if err != nil {
-		return nil, err
+func (dg *dependencyGraph) computeOrder() ([]component.ID, error) {
+	nodes := make(map[component.ID]*node)
+	for extID := range dg.exts.extMap {
+		n := newNode(extID)
+		dg.graph.AddNode(n)
+		nodes[extID] = n
 	}
-	order := make([]component.ID, len(nodes))
-	for i, n := range nodes {
+	fmt.Printf("%+v\n", nodes)
+	for extID, ext := range dg.exts.extMap {
+		n := nodes[extID]
+		if dep, ok := ext.(extension.DependentExtension); ok {
+			for _, depID := range dep.Dependencies() {
+				if d, ok := nodes[depID]; ok {
+					dg.graph.SetEdge(dg.graph.NewEdge(n, d))
+				} else {
+					return nil, fmt.Errorf("unable to find extension %s on which extension %s depends", depID, extID)
+				}
+			}
+		}
+	}
+	fmt.Printf("%+v\n", dg.graph)
+	orderedNodes, err := topo.Sort(dg.graph)
+	if err != nil {
+		return nil, fmt.Errorf("unable to sort the dependency graph: %w", err)
+	}
+
+	order := make([]component.ID, len(orderedNodes))
+	for i, n := range orderedNodes {
 		order[i] = n.(*node).extID
 	}
 	return order, nil

--- a/service/extensions/graph.go
+++ b/service/extensions/graph.go
@@ -38,7 +38,7 @@ func computeOrder(exts *Extensions) ([]component.ID, error) {
 		if dep, ok := ext.(extension.DependentExtension); ok {
 			for _, depID := range dep.Dependencies() {
 				if d, ok := nodes[depID]; ok {
-					graph.SetEdge(graph.NewEdge(n, d))
+					graph.SetEdge(graph.NewEdge(d, n))
 				} else {
 					return nil, fmt.Errorf("unable to find extension %s on which extension %s depends", depID, extID)
 				}

--- a/service/extensions/graph.go
+++ b/service/extensions/graph.go
@@ -11,13 +11,8 @@ import (
 	"go.opentelemetry.io/collector/extension"
 )
 
-type dependencyGraph struct {
-	exts  *Extensions
-	graph *simple.DirectedGraph
-}
-
 type node struct {
-	nodeID uint64
+	nodeID int64
 	extID  component.ID
 }
 
@@ -29,40 +24,32 @@ func newNode(extID component.ID) *node {
 	h := fnv.New64a()
 	_, _ = h.Write([]byte(extID.String()))
 	return &node{
-		nodeID: h.Sum64(),
+		nodeID: int64(h.Sum64()),
 		extID:  extID,
 	}
 }
 
-func newDependencyGraph(exts *Extensions) *dependencyGraph {
-	return &dependencyGraph{
-		exts:  exts,
-		graph: simple.NewDirectedGraph(),
-	}
-}
-
-func (dg *dependencyGraph) computeOrder() ([]component.ID, error) {
+func computeOrder(exts *Extensions) ([]component.ID, error) {
+	graph := simple.NewDirectedGraph()
 	nodes := make(map[component.ID]*node)
-	for extID := range dg.exts.extMap {
+	for extID := range exts.extMap {
 		n := newNode(extID)
-		dg.graph.AddNode(n)
+		graph.AddNode(n)
 		nodes[extID] = n
 	}
-	fmt.Printf("%+v\n", nodes)
-	for extID, ext := range dg.exts.extMap {
+	for extID, ext := range exts.extMap {
 		n := nodes[extID]
 		if dep, ok := ext.(extension.DependentExtension); ok {
 			for _, depID := range dep.Dependencies() {
 				if d, ok := nodes[depID]; ok {
-					dg.graph.SetEdge(dg.graph.NewEdge(n, d))
+					graph.SetEdge(graph.NewEdge(n, d))
 				} else {
 					return nil, fmt.Errorf("unable to find extension %s on which extension %s depends", depID, extID)
 				}
 			}
 		}
 	}
-	fmt.Printf("%+v\n", dg.graph)
-	orderedNodes, err := topo.Sort(dg.graph)
+	orderedNodes, err := topo.Sort(graph)
 	if err != nil {
 		return nil, fmt.Errorf("unable to sort the dependency graph: %w", err)
 	}

--- a/service/extensions/graph.go
+++ b/service/extensions/graph.go
@@ -2,7 +2,6 @@ package extensions
 
 import (
 	"fmt"
-	"hash/fnv"
 
 	"gonum.org/v1/gonum/graph/simple"
 	"gonum.org/v1/gonum/graph/topo"
@@ -17,14 +16,12 @@ type node struct {
 }
 
 func (n node) ID() int64 {
-	return int64(n.nodeID)
+	return n.nodeID
 }
 
-func newNode(extID component.ID) *node {
-	h := fnv.New64a()
-	_, _ = h.Write([]byte(extID.String()))
+func newNode(id int, extID component.ID) *node {
 	return &node{
-		nodeID: int64(h.Sum64()),
+		nodeID: int64(id),
 		extID:  extID,
 	}
 }
@@ -33,7 +30,7 @@ func computeOrder(exts *Extensions) ([]component.ID, error) {
 	graph := simple.NewDirectedGraph()
 	nodes := make(map[component.ID]*node)
 	for extID := range exts.extMap {
-		n := newNode(extID)
+		n := newNode(len(nodes)+1, extID)
 		graph.AddNode(n)
 		nodes[extID] = n
 	}

--- a/service/extensions/graph.go
+++ b/service/extensions/graph.go
@@ -57,7 +57,7 @@ func (dg *dependencyGraph) sort() ([]component.ID, error) {
 	if err != nil {
 		return nil, err
 	}
-	order := make([]component.ID, 0, len(nodes))
+	order := make([]component.ID, len(nodes))
 	for i, n := range nodes {
 		order[i] = n.(*node).extID
 	}

--- a/service/extensions/graph_test.go
+++ b/service/extensions/graph_test.go
@@ -1,0 +1,21 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package extensions // import "go.opentelemetry.io/collector/service/extensions"
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gonum.org/v1/gonum/graph"
+	"gonum.org/v1/gonum/graph/topo"
+)
+
+func TestCycleErr(t *testing.T) {
+	err := errors.New("foo")
+	assert.Equal(t, err, cycleErr(err, nil), "cycleErr should return the error unchanged when it's unrecognized")
+
+	var topoErr topo.Unorderable = [][]graph.Node{{}}
+	assert.Equal(t, topoErr, cycleErr(topoErr, nil), "cycleErr should return topo.Unorderable error unchanged when no cycles are found")
+}


### PR DESCRIPTION
**Description**:
Enforce order of start and shutdown of extensions according to their internally declared dependencies

**Link to tracking Issue**:
Resolves #8732

**Motivation**:
This is an alternative approach to #8733 which uses declaration order in the config to start extensions. That approach (a) enforces order when it's not always necessary to enforce, and (b) exposes unnecessary complexity to the user by making them responsible for the order.

This PR instead derives the desired order of extensions based on the dependencies they declare by implementing a `DependentExtension` interface. That means that extensions that must depend on others can expose this interface and be guaranteed to start after their dependencies, while other extensions can be started in arbitrary order (same as happens today because of iterating over a map).

The extensions that have dependencies have two options to expose them:
  1. if the dependency is always static (e.g. `jaeger_query` extension depending on `jaeger_storage` as in the OP), the extension can express this statically as well, by returning a predefined ID of the dependent extension
  2. in cases where dependencies are dynamic, the extension can read the names of the dependencies from its configuration.

The 2nd scenario is illustrated by the following configuration. Here each complex extension knows that it needs  dependencies that implement `storage` and `encoding` interfaces  (both existing APIs in collector & contrib), but does not know statically which instances of those, the actual names are supplied by the user in the configuration.

```yaml
extensions:
  complex_extension_1:
    storage: filestorage
    encoding: otlpencoding
  complex_extension_2:
    storage: dbstorage
    encoding: jsonencoding
  filestorage:
    ...
  dbstorage:
    ...
  otlpencoding:
  jsonencoding:
```

**Changes**:
* Introduce `DependentExtension` optional interface 
* Change `Extensions` constructor to derive the required order using a directed graph (similar to pipelines)
* Inherited from #8733 - use new ordered list of IDs to start/stop/notify extensions in the desired order (previously a map was used to iterate over, which resulted in random order).
* Tests

**Testing**:
Unit tests

