### PR TITLE
Add ZeroThreshold field to exponentialHistogramDataPoint in pmetric package

### DIFF
--- a/.chloggen/expose-zerothreshold.yaml
+++ b/.chloggen/expose-zerothreshold.yaml
@@ -1,0 +1,15 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: pdata
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add ZeroThreshold field to exponentialHistogramDataPoint in pmetric package.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/.chloggen/expose-zerothreshold.yaml
+++ b/.chloggen/expose-zerothreshold.yaml
@@ -7,6 +7,9 @@ component: pdata
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Add ZeroThreshold field to exponentialHistogramDataPoint in pmetric package.
 
+# One or more tracking issues or pull requests related to the change
+issues: [8802]
+
 # Optional: The change log or logs in which this entry should be included.
 # e.g. '[user]' or '[user, api]'
 # Include 'user' if the change is relevant to end users.

--- a/pdata/internal/cmd/pdatagen/internal/pmetric_package.go
+++ b/pdata/internal/cmd/pdatagen/internal/pmetric_package.go
@@ -321,6 +321,12 @@ var exponentialHistogramDataPoint = &messageValueStruct{
 		sumField,
 		minField,
 		maxField,
+		&primitiveField{
+			fieldName:  "ZeroThreshold",
+			returnType: "float64",
+			defaultVal: "float64(0.0)",
+			testVal:    "float64(0.5)",
+		},
 	},
 }
 

--- a/pdata/pmetric/generated_exponentialhistogramdatapoint.go
+++ b/pdata/pmetric/generated_exponentialhistogramdatapoint.go
@@ -204,6 +204,17 @@ func (ms ExponentialHistogramDataPoint) RemoveMax() {
 	ms.orig.Max_ = nil
 }
 
+// ZeroThreshold returns the zerothreshold associated with this ExponentialHistogramDataPoint.
+func (ms ExponentialHistogramDataPoint) ZeroThreshold() float64 {
+	return ms.orig.ZeroThreshold
+}
+
+// SetZeroThreshold replaces the zerothreshold associated with this ExponentialHistogramDataPoint.
+func (ms ExponentialHistogramDataPoint) SetZeroThreshold(v float64) {
+	ms.state.AssertMutable()
+	ms.orig.ZeroThreshold = v
+}
+
 // CopyTo copies all properties from the current struct overriding the destination.
 func (ms ExponentialHistogramDataPoint) CopyTo(dest ExponentialHistogramDataPoint) {
 	dest.state.AssertMutable()
@@ -229,4 +240,5 @@ func (ms ExponentialHistogramDataPoint) CopyTo(dest ExponentialHistogramDataPoin
 		dest.SetMax(ms.Max())
 	}
 
+	dest.SetZeroThreshold(ms.ZeroThreshold())
 }

--- a/pdata/pmetric/generated_exponentialhistogramdatapoint_test.go
+++ b/pdata/pmetric/generated_exponentialhistogramdatapoint_test.go
@@ -158,6 +158,17 @@ func TestExponentialHistogramDataPoint_Max(t *testing.T) {
 	assert.False(t, ms.HasMax())
 }
 
+func TestExponentialHistogramDataPoint_ZeroThreshold(t *testing.T) {
+	ms := NewExponentialHistogramDataPoint()
+	assert.Equal(t, float64(0.0), ms.ZeroThreshold())
+	ms.SetZeroThreshold(float64(0.5))
+	assert.Equal(t, float64(0.5), ms.ZeroThreshold())
+	sharedState := internal.StateReadOnly
+	assert.Panics(t, func() {
+		newExponentialHistogramDataPoint(&otlpmetrics.ExponentialHistogramDataPoint{}, &sharedState).SetZeroThreshold(float64(0.5))
+	})
+}
+
 func generateTestExponentialHistogramDataPoint() ExponentialHistogramDataPoint {
 	tv := NewExponentialHistogramDataPoint()
 	fillTestExponentialHistogramDataPoint(tv)
@@ -178,4 +189,5 @@ func fillTestExponentialHistogramDataPoint(tv ExponentialHistogramDataPoint) {
 	tv.orig.Sum_ = &otlpmetrics.ExponentialHistogramDataPoint_Sum{Sum: float64(17.13)}
 	tv.orig.Min_ = &otlpmetrics.ExponentialHistogramDataPoint_Min{Min: float64(9.23)}
 	tv.orig.Max_ = &otlpmetrics.ExponentialHistogramDataPoint_Max{Max: float64(182.55)}
+	tv.orig.ZeroThreshold = float64(0.5)
 }


### PR DESCRIPTION
**Description:** Add ZeroThreshold field to exponentialHistogramDataPoint in pmetric package. It's needed to understand which values fall in the ZeroBucket


Fixes #8802 