### PR TITLE
[chore] avoid negative waitGroup in test

### DIFF
--- a/exporter/exporterhelper/queue_sender_test.go
+++ b/exporter/exporterhelper/queue_sender_test.go
@@ -271,7 +271,10 @@ func TestQueuedRetry_RequeuingEnabledQueueFull(t *testing.T) {
 	traceErr := consumererror.NewTraces(errors.New("some error"), testdata.GenerateTraces(1))
 	mockR := newMockRequest(context.Background(), 1, traceErr)
 
-	require.Error(t, be.retrySender.send(mockR), "sending_queue is full")
+	ocs := be.obsrepSender.(*observabilityConsumerSender)
+	ocs.run(func() {
+		require.Error(t, be.retrySender.send(mockR), "sending_queue is full")
+	})
 	mockR.checkNumRequests(t, 1)
 }
 


### PR DESCRIPTION
When sending a retry, make sure to do so inside the run function of the observability sender. Otherwise, tests may produce a negative wait group error when we start to enforce shutdown of the queues.