### PR TITLE
Manually report status for core exporters

### DIFF
--- a/.chloggen/core-exporters-manual-status.yaml
+++ b/.chloggen/core-exporters-manual-status.yaml
@@ -7,7 +7,7 @@ change_type: 'enhancement'
 component: core exporters
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: This PR adds status reporting to the core exporters (otlp, otlphttp, and debug)
+note: This PR adds status reporting to the core exporters (otlp and otlphttp)
 
 # One or more tracking issues or pull requests related to the change
 issues: [7682]

--- a/.chloggen/core-exporters-manual-status.yaml
+++ b/.chloggen/core-exporters-manual-status.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'enhancement'
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: core exporters
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: This PR adds status reporting to the core exporters (otlp, otlphttp, and debug)
+
+# One or more tracking issues or pull requests related to the change
+issues: [7682]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/internal/common/factory.go
+++ b/exporter/internal/common/factory.go
@@ -34,7 +34,6 @@ func CreateTracesExporter(ctx context.Context, set exporter.CreateSettings, conf
 	s := newLoggingExporter(exporterLogger, c.Verbosity)
 	return exporterhelper.NewTracesExporter(ctx, set, config,
 		s.pushTraces,
-		exporterhelper.WithStart(newStartFunc(&set.TelemetrySettings)),
 		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
 		exporterhelper.WithTimeout(exporterhelper.TimeoutSettings{Timeout: 0}),
 		exporterhelper.WithShutdown(otlptext.LoggerSync(exporterLogger)),
@@ -46,7 +45,6 @@ func CreateMetricsExporter(ctx context.Context, set exporter.CreateSettings, con
 	s := newLoggingExporter(exporterLogger, c.Verbosity)
 	return exporterhelper.NewMetricsExporter(ctx, set, config,
 		s.pushMetrics,
-		exporterhelper.WithStart(newStartFunc(&set.TelemetrySettings)),
 		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
 		exporterhelper.WithTimeout(exporterhelper.TimeoutSettings{Timeout: 0}),
 		exporterhelper.WithShutdown(otlptext.LoggerSync(exporterLogger)),
@@ -58,7 +56,6 @@ func CreateLogsExporter(ctx context.Context, set exporter.CreateSettings, config
 	s := newLoggingExporter(exporterLogger, c.Verbosity)
 	return exporterhelper.NewLogsExporter(ctx, set, config,
 		s.pushLogs,
-		exporterhelper.WithStart(newStartFunc(&set.TelemetrySettings)),
 		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
 		exporterhelper.WithTimeout(exporterhelper.TimeoutSettings{Timeout: 0}),
 		exporterhelper.WithShutdown(otlptext.LoggerSync(exporterLogger)),
@@ -84,11 +81,4 @@ func (c *Common) createLogger(logger *zap.Logger) *zap.Logger {
 	)
 
 	return zap.New(core)
-}
-
-func newStartFunc(telemetry *component.TelemetrySettings) component.StartFunc {
-	return func(context.Context, component.Host) error {
-		_ = telemetry.ReportComponentStatus(component.NewStatusEvent(component.StatusOK))
-		return nil
-	}
 }

--- a/exporter/otlpexporter/otlp.go
+++ b/exporter/otlpexporter/otlp.go
@@ -163,7 +163,7 @@ func (e *baseExporter) processError(err error) error {
 	// Now, this is this a real error.
 
 	if isComponentPermanentError(st) {
-		_ = e.settings.ReportComponentStatus(component.NewPermanentErrorEvent(err))
+		e.settings.ReportStatus(component.NewPermanentErrorEvent(err))
 	}
 
 	retryInfo := getRetryInfo(st)
@@ -187,10 +187,10 @@ func (e *baseExporter) processError(err error) error {
 
 func (e *baseExporter) reportStatusFromError(err error) {
 	if err != nil {
-		_ = e.settings.ReportComponentStatus(component.NewRecoverableErrorEvent(err))
+		e.settings.ReportStatus(component.NewRecoverableErrorEvent(err))
 		return
 	}
-	_ = e.settings.ReportComponentStatus(component.NewStatusEvent(component.StatusOK))
+	e.settings.ReportStatus(component.NewStatusEvent(component.StatusOK))
 }
 
 func shouldRetry(code codes.Code, retryInfo *errdetails.RetryInfo) bool {

--- a/exporter/otlpexporter/otlp.go
+++ b/exporter/otlpexporter/otlp.go
@@ -78,7 +78,7 @@ func (e *baseExporter) start(ctx context.Context, host component.Host) (err erro
 	e.callOptions = []grpc.CallOption{
 		grpc.WaitForReady(e.config.GRPCClientSettings.WaitForReady),
 	}
-	_ = e.settings.ReportComponentStatus(component.NewStatusEvent(component.StatusOK))
+
 	return
 }
 

--- a/exporter/otlpexporter/otlp_test.go
+++ b/exporter/otlpexporter/otlp_test.go
@@ -693,7 +693,7 @@ func TestComponentStatus(t *testing.T) {
 
 			factory := NewFactory()
 			cfg := factory.CreateDefaultConfig().(*Config)
-			cfg.QueueSettings.Enabled = false
+			cfg.QueueConfig.Enabled = false
 			cfg.GRPCClientSettings = configgrpc.GRPCClientSettings{
 				Endpoint: ln.Addr().String(),
 				TLSSetting: configtls.TLSClientSetting{
@@ -702,12 +702,11 @@ func TestComponentStatus(t *testing.T) {
 			}
 			var lastStatus component.Status
 			set := exportertest.NewNopCreateSettings()
-			set.TelemetrySettings.ReportComponentStatus = func(ev *component.StatusEvent) error {
+			set.TelemetrySettings.ReportStatus = func(ev *component.StatusEvent) {
 				// simulate the finite-state machine used in real world status reporting
 				if lastStatus != component.StatusPermanentError {
 					lastStatus = ev.Status()
 				}
-				return nil
 			}
 			exp, err := factory.CreateTracesExporter(context.Background(), set, cfg)
 			require.NoError(t, err)

--- a/exporter/otlphttpexporter/otlp.go
+++ b/exporter/otlphttpexporter/otlp.go
@@ -82,7 +82,6 @@ func (e *baseExporter) start(_ context.Context, host component.Host) error {
 		return err
 	}
 	e.client = client
-	_ = e.settings.ReportComponentStatus(component.NewStatusEvent(component.StatusOK))
 	return nil
 }
 

--- a/exporter/otlphttpexporter/otlp.go
+++ b/exporter/otlphttpexporter/otlp.go
@@ -222,6 +222,8 @@ func isComponentPermanentError(code int) bool {
 		return true
 	case http.StatusMethodNotAllowed:
 		return true
+	case http.StatusRequestEntityTooLarge:
+		return true
 	case http.StatusRequestURITooLong:
 		return true
 	case http.StatusRequestHeaderFieldsTooLarge:

--- a/exporter/otlphttpexporter/otlp.go
+++ b/exporter/otlphttpexporter/otlp.go
@@ -121,7 +121,7 @@ func (e *baseExporter) export(ctx context.Context, url string, request []byte, p
 	e.logger.Debug("Preparing to make HTTP request", zap.String("url", url))
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(request))
 	if err != nil {
-		_ = e.settings.ReportComponentStatus(component.NewPermanentErrorEvent(err))
+		e.settings.ReportStatus(component.NewPermanentErrorEvent(err))
 		err = consumererror.NewPermanent(err)
 		return
 	}
@@ -177,7 +177,7 @@ func (e *baseExporter) export(ctx context.Context, url string, request []byte, p
 	}
 
 	if isComponentPermanentError(resp.StatusCode) {
-		_ = e.settings.ReportComponentStatus(component.NewPermanentErrorEvent(formattedErr))
+		e.settings.ReportStatus(component.NewPermanentErrorEvent(formattedErr))
 	}
 
 	err = consumererror.NewPermanent(formattedErr)
@@ -186,10 +186,10 @@ func (e *baseExporter) export(ctx context.Context, url string, request []byte, p
 
 func (e *baseExporter) reportStatusFromError(err error) {
 	if err != nil {
-		_ = e.settings.ReportComponentStatus(component.NewRecoverableErrorEvent(err))
+		e.settings.ReportStatus(component.NewRecoverableErrorEvent(err))
 		return
 	}
-	_ = e.settings.ReportComponentStatus(component.NewStatusEvent(component.StatusOK))
+	e.settings.ReportStatus(component.NewStatusEvent(component.StatusOK))
 }
 
 // Determine if the status code is retryable according to the specification.

--- a/exporter/otlphttpexporter/otlp_test.go
+++ b/exporter/otlphttpexporter/otlp_test.go
@@ -21,6 +21,7 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/config/configopaque"
@@ -673,12 +674,11 @@ func TestComponentStatus(t *testing.T) {
 
 			var lastStatus component.Status
 			set := exportertest.NewNopCreateSettings()
-			set.TelemetrySettings.ReportComponentStatus = func(ev *component.StatusEvent) error {
+			set.TelemetrySettings.ReportStatus = func(ev *component.StatusEvent) {
 				// simulate the finite-state machine used in real world status reporting
 				if lastStatus != component.StatusPermanentError {
 					lastStatus = ev.Status()
 				}
-				return nil
 			}
 
 			exp, err := createTracesExporter(context.Background(), set, cfg)

--- a/exporter/otlphttpexporter/otlp_test.go
+++ b/exporter/otlphttpexporter/otlp_test.go
@@ -634,7 +634,7 @@ func TestComponentStatus(t *testing.T) {
 		{
 			name:            "413",
 			responseStatus:  http.StatusRequestEntityTooLarge,
-			componentStatus: component.StatusRecoverableError,
+			componentStatus: component.StatusPermanentError,
 		},
 		{
 			name:            "414",


### PR DESCRIPTION
**Description:**
This is a PR is an alternative to #8684. It adds manual status reporting to the otlp, otlphttp, and debug exporters. Reviewers, please compare with #8684 and weigh in on what approach you prefer, and/or additional suggestions.

**Link to tracking Issue:** #7682

**Testing:** Units, manual.



