### PR TITLE
Log errors even when retry_on_failure is not used

### DIFF
--- a/.chloggen/fix_logging_without_retry.yaml
+++ b/.chloggen/fix_logging_without_retry.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: exporterhelper
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Log export errors when retry is not used by the component.
+
+# One or more tracking issues or pull requests related to the change
+issues: [8791]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/exporterhelper/common_test.go
+++ b/exporter/exporterhelper/common_test.go
@@ -12,6 +12,8 @@ import (
 	"go.opencensus.io/tag"
 	"go.opentelemetry.io/otel/codes"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -78,4 +80,17 @@ func TestQueueRetryOptionsWithRequestExporter(t *testing.T) {
 		_, _ = newBaseExporter(exportertest.NewNopCreateSettings(), "", true, nil, nil, newNoopObsrepSender,
 			WithRetry(NewDefaultRetrySettings()), WithQueue(NewDefaultQueueSettings()))
 	})
+}
+
+func TestBaseExporterLogging(t *testing.T) {
+	set := exportertest.NewNopCreateSettings()
+	logger, observed := observer.New(zap.DebugLevel)
+	set.Logger = zap.New(logger)
+	bs, err := newBaseExporter(set, "", true, nil, nil, newNoopObsrepSender)
+	require.Nil(t, err)
+	require.True(t, bs.requestExporter)
+	sendErr := bs.send(newErrorRequest(context.Background()))
+	require.Error(t, sendErr)
+
+	require.Len(t, observed.FilterLevelExact(zap.ErrorLevel).All(), 1)
 }


### PR DESCRIPTION
**Description:**

Fixes https://github.com/open-telemetry/opentelemetry-collector/issues/8791.
Logging errors normally happens in the retry exporter helper if retry_on_failure is disabled:

https://github.com/open-telemetry/opentelemetry-collector/blob/66166c4cc371fbe945d7ff19232decd3ee65f76a/exporter/exporterhelper/retry_sender.go#L108-L115

When WithRetry is not specified in the component, no logging happens at all. This change makes the "base" retry sender log errors, so that if a component does not specify WithRetry, it still has errors logged, similar to the behavior with disabled retry.

**Testing:**

Unit tests added
