### PR TITLE
[confighttp] add IP range filters support

### DIFF
--- a/.chloggen/httpserveroptions-allow-deny-ip-ranges.yaml
+++ b/.chloggen/httpserveroptions-allow-deny-ip-ranges.yaml
@@ -7,7 +7,7 @@ change_type: enhancement
 component: confighttp
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Add `AllowedIPRanges` (`allowed_ip_ranges`)  and `RejectedIPRanges` (`rejected_ip_ranges`) to `confighttp.HTTPServerOptions`.
+note: Add `AllowedIPRanges` (`allowed_ip_ranges`)  and `DeniedIPRanges` (`denied_ip_ranges`) to `confighttp.HTTPServerOptions`.
 
 # One or more tracking issues or pull requests related to the change
 issues: [8798]

--- a/.chloggen/httpserveroptions-allow-reject-ip-ranges.yaml
+++ b/.chloggen/httpserveroptions-allow-reject-ip-ranges.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: confighttp
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add `AllowedIPRanges` (`allowed_ip_ranges`)  and `RejectedIPRanges` (`rejected_ip_ranges`) to `confighttp.HTTPServerOptions`.
+
+# One or more tracking issues or pull requests related to the change
+issues: [8798]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/config/confighttp/README.md
+++ b/config/confighttp/README.md
@@ -46,6 +46,11 @@ exporter:
       test1: "value1"
       "test 2": "value 2"
     compression: zstd
+    allowed_ip_ranges:
+     - 10.0.0.1/16
+     - 192.168.1.1/32
+    rejected_ip_ranges:
+     - 5.0.0.0/8
 ```
 
 ## Server Configuration
@@ -71,6 +76,15 @@ will not be enabled.
 - `endpoint`: Valid value syntax available [here](https://github.com/grpc/grpc/blob/master/doc/naming.md)
 - [`tls`](../configtls/README.md)
 - [`auth`](../configauth/README.md)
+- `allowed_ip_ranges`: limits incoming requests to specific IP ranges.
+If empty, all IPs are allowed.
+IPs outside the ranges will receive a 403 HTTP response code.
+IP ranges are represented using the CIDR notation.
+- `rejected_ip_ranges`: rejects incoming requests from specific IP ranges.
+If empty, all IPs are allowed.
+IPs in the ranges will receive a 403 HTTP response code.
+IP ranges are represented using the CIDR notation.
+`rejected_ip_ranges` are evaluated before `allowed_ip_ranges`.
 
 You can enable [`attribute processor`][attribute-processor] to append any http header to span's attribute using custom key. You also need to enable the "include_metadata"
 

--- a/config/confighttp/README.md
+++ b/config/confighttp/README.md
@@ -49,7 +49,7 @@ exporter:
     allowed_ip_ranges:
      - 10.0.0.1/16
      - 192.168.1.1/32
-    rejected_ip_ranges:
+    denied_ip_ranges:
      - 5.0.0.0/8
 ```
 
@@ -80,11 +80,11 @@ will not be enabled.
 If empty, all IPs are allowed.
 IPs outside the ranges will receive a 403 HTTP response code.
 IP ranges are represented using the CIDR notation.
-- `rejected_ip_ranges`: rejects incoming requests from specific IP ranges.
+- `denied_ip_ranges`: denies incoming requests from specific IP ranges.
 If empty, all IPs are allowed.
 IPs in the ranges will receive a 403 HTTP response code.
 IP ranges are represented using the CIDR notation.
-`rejected_ip_ranges` are evaluated before `allowed_ip_ranges`.
+`denied_ip_ranges` are evaluated before `allowed_ip_ranges`.
 
 You can enable [`attribute processor`][attribute-processor] to append any http header to span's attribute using custom key. You also need to enable the "include_metadata"
 

--- a/config/confighttp/README.md
+++ b/config/confighttp/README.md
@@ -78,11 +78,11 @@ will not be enabled.
 - [`auth`](../configauth/README.md)
 - `allowed_ip_ranges`: limits incoming requests to specific IP ranges.
 If empty, all IPs are allowed.
-IPs outside the ranges will receive a 403 HTTP response code.
+Connections outside the ranges will be closed.
 IP ranges are represented using the CIDR notation.
 - `denied_ip_ranges`: denies incoming requests from specific IP ranges.
 If empty, all IPs are allowed.
-IPs in the ranges will receive a 403 HTTP response code.
+Connections inside the ranges will be closed.
 IP ranges are represented using the CIDR notation.
 `denied_ip_ranges` are evaluated before `allowed_ip_ranges`.
 

--- a/config/confighttp/confighttp.go
+++ b/config/confighttp/confighttp.go
@@ -434,7 +434,7 @@ func rejectIPRanges(next http.Handler, ipRanges []*net.IPNet) http.Handler {
 			}
 		}
 		if rejected {
-			http.Error(w, "", 403)
+			http.Error(w, "", http.StatusForbidden)
 			return
 		}
 		next.ServeHTTP(w, r)
@@ -452,7 +452,7 @@ func allowIPRanges(next http.Handler, ipRanges []*net.IPNet) http.Handler {
 			}
 		}
 		if !allowed {
-			http.Error(w, "", 403)
+			http.Error(w, "", http.StatusForbidden)
 			return
 		}
 		next.ServeHTTP(w, r)

--- a/config/confighttp/confighttp_test.go
+++ b/config/confighttp/confighttp_test.go
@@ -815,12 +815,12 @@ func TestHttpCorsWithSettings(t *testing.T) {
 	assert.Equal(t, "*", rec.Header().Get("Access-Control-Allow-Origin"))
 }
 
-func TestIPRejected(t *testing.T) {
+func TestIPDenied(t *testing.T) {
 	_, r, err := net.ParseCIDR("192.168.1.1/16")
 	require.NoError(t, err)
 	hss := &HTTPServerSettings{
-		Endpoint:         "localhost:0",
-		RejectedIPRanges: []*net.IPNet{r},
+		Endpoint:       "localhost:0",
+		DeniedIPRanges: []*net.IPNet{r},
 	}
 
 	host := &mockHost{}
@@ -837,7 +837,7 @@ func TestIPRejected(t *testing.T) {
 		statusCode int
 	}{
 		{
-			"192.168.1.3 rejected",
+			"192.168.1.3 denied",
 			func() *http.Request {
 				req := httptest.NewRequest(http.MethodOptions, "/", nil)
 				req.RemoteAddr = "192.168.1.3"
@@ -890,7 +890,7 @@ func TestIPAllowed(t *testing.T) {
 		statusCode int
 	}{
 		{
-			"192.168.1.3 rejected",
+			"192.168.1.3 denied",
 			func() *http.Request {
 				req := httptest.NewRequest(http.MethodOptions, "/", nil)
 				req.RemoteAddr = "192.168.1.3"
@@ -1339,13 +1339,13 @@ func TestAllowIPRanges(t *testing.T) {
 	}
 }
 
-func TestRejectIPRanges(t *testing.T) {
+func TestDenyIPRanges(t *testing.T) {
 	_, n, err := net.ParseCIDR("2.10.15.4/32")
 	require.NoError(t, err)
 	_, n2, err := net.ParseCIDR("192.10.15.132/32")
 	require.NoError(t, err)
 
-	h := rejectIPRanges(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+	h := denyIPRanges(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 		_, _ = writer.Write([]byte("hello world"))
 	}), []*net.IPNet{n, n2})
 


### PR DESCRIPTION
**Description:**
Add `AllowedIPRanges` (`allowed_ip_ranges`)  and `DeniedIPRanges` (`denied_ip_ranges`) to `confighttp.HTTPServerOptions`.

**Link to tracking Issue:**
Fixes #8798 

**Testing:**
Unit tests.

**Documentation:**
README and docs.