### PR TITLE
[featuregate] Remove deprecated function NewFlag

### DIFF
--- a/.chloggen/mx-psi_remove-NewFlags.yaml
+++ b/.chloggen/mx-psi_remove-NewFlags.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: featuregate
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove deprecate function `featuregate.NewFlag`
+
+# One or more tracking issues or pull requests related to the change
+issues: [8727]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: Use `featuregate.Registry`'s `RegisterFlags` method instead.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/featuregate/flag.go
+++ b/featuregate/flag.go
@@ -15,16 +15,6 @@ const (
 	featureGatesFlagDescription = "Comma-delimited list of feature gate identifiers. Prefix with '-' to disable the feature. '+' or no prefix will enable the feature."
 )
 
-// NewFlag returns a flag.Value that directly applies feature gate statuses to a Registry.
-// Deprecated: Use Registry's RegisterFlags method instead.
-func NewFlag(reg *Registry) flag.Value {
-	return newFeatureGateValue(reg)
-}
-
-func newFeatureGateValue(reg *Registry) flag.Value {
-	return &flagValue{reg: reg}
-}
-
 // RegisterFlagsOption is an option for RegisterFlags.
 type RegisterFlagsOption interface {
 	private()
@@ -32,7 +22,7 @@ type RegisterFlagsOption interface {
 
 // RegisterFlags that directly applies feature gate statuses to a Registry.
 func (r *Registry) RegisterFlags(flagSet *flag.FlagSet, _ ...RegisterFlagsOption) {
-	flagSet.Var(newFeatureGateValue(r), featureGatesFlag, featureGatesFlagDescription)
+	flagSet.Var(&flagValue{reg: r}, featureGatesFlag, featureGatesFlagDescription)
 }
 
 // flagValue implements the flag.Value interface and directly applies feature gate statuses to a Registry.


### PR DESCRIPTION
**Description:** 

Removes deprecated function `featuregate.NewFlag`. 

This PR MUST NOT be merged before v0.89.0 is released.

**Link to tracking Issue:** Follow up to #8727
