### PR TITLE
[chore] [forwardconnector] use defined struct for config

### DIFF
--- a/connector/forwardconnector/forward.go
+++ b/connector/forwardconnector/forward.go
@@ -26,9 +26,11 @@ func NewFactory() connector.Factory {
 	)
 }
 
+type Config struct{}
+
 // createDefaultConfig creates the default configuration.
 func createDefaultConfig() component.Config {
-	return &struct{}{}
+	return &Config{}
 }
 
 // createTracesToTraces creates a trace receiver based on provided config.

--- a/connector/forwardconnector/forward_test.go
+++ b/connector/forwardconnector/forward_test.go
@@ -19,7 +19,7 @@ import (
 func TestForward(t *testing.T) {
 	f := NewFactory()
 	cfg := f.CreateDefaultConfig()
-	assert.Equal(t, &struct{}{}, cfg)
+	assert.Equal(t, &Config{}, cfg)
 
 	ctx := context.Background()
 	set := connectortest.NewNopCreateSettings()


### PR DESCRIPTION
**Description:**
`cmd/configschema` currently doesn't work with anonymous config struct. (see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/26990#issuecomment-1797797681)

This PR refactors `forwardconnector` to use a defined struct for config.
