### PR TITLE
[chore][exporter/exporterhelper] Clarifications in README

### DIFF
--- a/exporter/exporterhelper/README.md
+++ b/exporter/exporterhelper/README.md
@@ -22,7 +22,7 @@ The following configuration options can be modified:
     - `requests_per_second` is the average number of requests per seconds
     - `requests_per_batch` is the average number of requests per batch (if 
       [the batch processor](https://github.com/open-telemetry/opentelemetry-collector/tree/main/processor/batchprocessor)
-      is used, the metric `batch_send_size` can be used for estimation)
+      is used, the metric `send_batch_size` can be used for estimation)
 - `timeout` (default = 5s): Time to wait per individual attempt to send data to a backend
 
 The `initial_interval`, `max_interval`, `max_elapsed_time`, and `timeout` options accept 

--- a/exporter/exporterhelper/README.md
+++ b/exporter/exporterhelper/README.md
@@ -38,7 +38,8 @@ valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
 To use the persistent queue, the following setting needs to be set:
 
 - `sending_queue`
-  - `storage` (default = none): When set, enables persistence and uses the component specified as a storage extension for the persistent queue
+  - `storage` (default = none): When set, enables persistence and uses the component specified as a storage extension for the persistent queue.
+    There is no in-memory queue when set.
 
 The maximum number of batches stored to disk can be controlled using `sending_queue.queue_size` parameter (which,
 similarly as for in-memory buffering, defaults to 1000 batches).


### PR DESCRIPTION
**Description:**
Minor clarifications in the README. 

1. The [batch processor's option](https://github.com/open-telemetry/opentelemetry-collector/blob/8bea0d372c9965a99dd88d1f5c4c4b7acee9db40/processor/batchprocessor/config.go#L24) is named `send_batch_size`, not `batch_send_size`.
2. It may be obvious but I didn't instantly realize the sending queue is one or the other (in-memory or persistent). This adds a comment to make it clear.

For reference, I'm adding this as a result of investigation for this issue: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/29006