### PR TITLE
[chore] [confighttp] Deprecate HTTPClientSettings.CustomRoundTripper

### DIFF
--- a/.chloggen/chore-8627.yaml
+++ b/.chloggen/chore-8627.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: confighttp
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add WithRoundTripper and deprecate HTTPClientSettings.CustomRoundTripper.
+
+# One or more tracking issues or pull requests related to the change
+issues: [8627]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/.chloggen/chore-8627.yaml
+++ b/.chloggen/chore-8627.yaml
@@ -7,7 +7,7 @@ change_type: deprecation
 component: confighttp
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Add WithRoundTripper and deprecate HTTPClientSettings.CustomRoundTripper.
+note: Add WithClientRoundTripper and deprecate HTTPClientSettings.CustomRoundTripper.
 
 # One or more tracking issues or pull requests related to the change
 issues: [8627]

--- a/config/confighttp/confighttp.go
+++ b/config/confighttp/confighttp.go
@@ -55,7 +55,7 @@ type HTTPClientSettings struct {
 
 	// Custom Round Tripper to allow for individual components to intercept HTTP requests
 	// Deprecated: [0.89.0] Replaced by confighttp.WithRoundTripper
-	CustomRoundTripper func(next http.RoundTripper) (http.RoundTripper, error)
+	CustomRoundTripper func(next http.RoundTripper) (http.RoundTripper, error) `mapstructure:"-"`
 
 	// Auth configuration for outgoing HTTP calls.
 	Auth *configauth.Authentication `mapstructure:"auth"`

--- a/config/confighttp/confighttp.go
+++ b/config/confighttp/confighttp.go
@@ -54,7 +54,7 @@ type HTTPClientSettings struct {
 	Headers map[string]configopaque.String `mapstructure:"headers"`
 
 	// Custom Round Tripper to allow for individual components to intercept HTTP requests
-	// Deprecated: [0.89.0] Replaced by confighttp.WithRoundTripper
+	// Deprecated: [0.91.0] Replaced by confighttp.WithRoundTripper
 	CustomRoundTripper func(next http.RoundTripper) (http.RoundTripper, error) `mapstructure:"-"`
 
 	// Auth configuration for outgoing HTTP calls.

--- a/config/confighttp/confighttp.go
+++ b/config/confighttp/confighttp.go
@@ -54,7 +54,7 @@ type HTTPClientSettings struct {
 	Headers map[string]configopaque.String `mapstructure:"headers"`
 
 	// Custom Round Tripper to allow for individual components to intercept HTTP requests
-	// Deprecated: [0.91.0] Replaced by confighttp.WithRoundTripper
+	// Deprecated: [0.92.0] Replaced by confighttp.WithClientRoundTripper
 	CustomRoundTripper func(next http.RoundTripper) (http.RoundTripper, error) `mapstructure:"-"`
 
 	// Auth configuration for outgoing HTTP calls.
@@ -122,8 +122,8 @@ func (fn toClientOptionFunc) apply(opts *toClientOptions) {
 	fn(opts)
 }
 
-// WithRoundTripper allow for individual components to intercept HTTP requests
-func WithRoundTripper(customRoundTripper func(next http.RoundTripper) (http.RoundTripper, error)) ToClientOption {
+// WithClientRoundTripper allow for individual components to intercept HTTP requests
+func WithClientRoundTripper(customRoundTripper func(next http.RoundTripper) (http.RoundTripper, error)) ToClientOption {
 	return toClientOptionFunc(func(opts *toClientOptions) {
 		opts.customRoundTripper = customRoundTripper
 	})
@@ -228,7 +228,7 @@ func (hcs *HTTPClientSettings) ToClient(host component.Host, settings component.
 	}
 
 	if hcs.CustomRoundTripper != nil {
-		settings.Logger.Warn("You are using a deprecated `CustomRoundTripper` field which will be removed soon; use `WithRoundTripper` instead")
+		settings.Logger.Warn("You are using a deprecated `CustomRoundTripper` field which will be removed soon; use `WithClientRoundTripper` instead")
 		clientTransport, err = hcs.CustomRoundTripper(clientTransport)
 		if err != nil {
 			return nil, err

--- a/config/confighttp/confighttp_test.go
+++ b/config/confighttp/confighttp_test.go
@@ -154,7 +154,7 @@ func TestAllHTTPClientSettings(t *testing.T) {
 	}
 }
 
-func TestHTTPClientSettingWithRoundTripper(t *testing.T) {
+func TestHTTPClientSettingWithClientRoundTripper(t *testing.T) {
 	host := &mockHost{
 		ext: map[component.ID]component.Component{
 			component.NewID("testauth"): &authtest.MockClient{ResultRoundTripper: &customRoundTripper{}},
@@ -245,7 +245,7 @@ func TestHTTPClientSettingWithRoundTripper(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			client, err := test.settings.ToClient(host, componenttest.NewNopTelemetrySettings(), WithRoundTripper(test.customRoundTripper))
+			client, err := test.settings.ToClient(host, componenttest.NewNopTelemetrySettings(), WithClientRoundTripper(test.customRoundTripper))
 			if test.shouldError {
 				assert.Error(t, err)
 				return


### PR DESCRIPTION
**Description:**
`HTTPClientSettings.CustomRoundTripper` is not an end-user option and may cause failure when marshaling/unmarshaling config.

This PR adds an optional argument to `ToClient()` and deprecates the `HTTPClientSettings.CustomRoundTripper` field.

**Link to tracking Issue:**
resolve #8627

**Testing:**
add `TestHTTPClientSettingWithRoundTripper()` to test the new approach with cases in `TestAllHTTPClientSettings()`.