### PR TITLE
[chore] [exporterhelper] Ensure TestQueuedRetry_DropOnFull doesn't panic

### DIFF
--- a/exporter/exporterhelper/queue_sender_test.go
+++ b/exporter/exporterhelper/queue_sender_test.go
@@ -87,7 +87,8 @@ func TestQueuedRetry_DoNotPreserveCancellation(t *testing.T) {
 func TestQueuedRetry_DropOnFull(t *testing.T) {
 	qCfg := NewDefaultQueueSettings()
 	qCfg.QueueSize = 0
-	be, err := newBaseExporter(defaultSettings, "", false, nil, nil, newObservabilityConsumerSender, WithQueue(qCfg))
+	qCfg.NumConsumers = 0
+	be, err := newBaseExporter(defaultSettings, "", false, nil, nil, newNoopObsrepSender, WithQueue(qCfg))
 	require.NoError(t, err)
 	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
 	t.Cleanup(func() {


### PR DESCRIPTION
Make the imitation of queue overflow more reliable to make the test pass in https://github.com/open-telemetry/opentelemetry-collector/pull/8829