### PR TITLE
Rename ProducerConsumerQueue to Queue

### DIFF
--- a/exporter/exporterhelper/internal/bounded_memory_queue.go
+++ b/exporter/exporterhelper/internal/bounded_memory_queue.go
@@ -24,7 +24,7 @@ type boundedMemoryQueue struct {
 }
 
 // NewBoundedMemoryQueue constructs the new queue of specified capacity. Capacity cannot be 0.
-func NewBoundedMemoryQueue(capacity int, numConsumers int) ProducerConsumerQueue {
+func NewBoundedMemoryQueue(capacity int, numConsumers int) Queue {
 	return &boundedMemoryQueue{
 		items:        make(chan Request, capacity),
 		stopped:      &atomic.Bool{},
@@ -65,12 +65,12 @@ func (q *boundedMemoryQueue) Produce(item Request) bool {
 	}
 }
 
-// Stop stops all consumers, as well as the length reporter if started,
-// and releases the items channel. It blocks until all consumers have stopped.
-func (q *boundedMemoryQueue) Stop() {
+// Shutdown stops accepting items, and stops all consumers. It blocks until all consumers have stopped.
+func (q *boundedMemoryQueue) Shutdown(context.Context) error {
 	q.stopped.Store(true) // disable producer
 	close(q.items)
 	q.stopWG.Wait()
+	return nil
 }
 
 // Size returns the current size of the queue

--- a/exporter/exporterhelper/internal/bounded_memory_queue_test.go
+++ b/exporter/exporterhelper/internal/bounded_memory_queue_test.go
@@ -96,7 +96,7 @@ func TestBoundedQueue(t *testing.T) {
 		consumerState.assertConsumed(expected)
 	}
 
-	q.Stop()
+	assert.NoError(t, q.Shutdown(context.Background()))
 	assert.False(t, q.Produce(newStringRequest("x")), "cannot push to closed queue")
 }
 
@@ -127,7 +127,7 @@ func TestShutdownWhileNotEmpty(t *testing.T) {
 	q.Produce(newStringRequest("i"))
 	q.Produce(newStringRequest("j"))
 
-	q.Stop()
+	assert.NoError(t, q.Shutdown(context.Background()))
 
 	assert.False(t, q.Produce(newStringRequest("x")), "cannot push to closed queue")
 	consumerState.assertConsumed(map[string]bool{
@@ -198,7 +198,7 @@ func queueUsage(b *testing.B, capacity int, numConsumers int, numberOfItems int)
 		for j := 0; j < numberOfItems; j++ {
 			q.Produce(newStringRequest(fmt.Sprintf("%d", j)))
 		}
-		q.Stop()
+		assert.NoError(b, q.Shutdown(context.Background()))
 	}
 }
 
@@ -255,7 +255,7 @@ func TestZeroSizeWithConsumers(t *testing.T) {
 
 	assert.True(t, q.Produce(newStringRequest("a"))) // in process
 
-	q.Stop()
+	assert.NoError(t, q.Shutdown(context.Background()))
 }
 
 func TestZeroSizeNoConsumers(t *testing.T) {
@@ -266,5 +266,5 @@ func TestZeroSizeNoConsumers(t *testing.T) {
 
 	assert.False(t, q.Produce(newStringRequest("a"))) // in process
 
-	q.Stop()
+	assert.NoError(t, q.Shutdown(context.Background()))
 }

--- a/exporter/exporterhelper/internal/persistent_storage_test.go
+++ b/exporter/exporterhelper/internal/persistent_storage_test.go
@@ -22,22 +22,19 @@ import (
 	"go.opentelemetry.io/collector/pdata/ptrace"
 )
 
-func createTestClient(extension storage.Extension) storage.Client {
+func createTestClient(t testing.TB, extension storage.Extension) storage.Client {
 	client, err := extension.GetClient(context.Background(), component.KindReceiver, component.ID{}, "")
-	if err != nil {
-		panic(err)
-	}
+	require.NoError(t, err)
 	return client
 }
 
-func createTestPersistentStorageWithLoggingAndCapacity(client storage.Client, logger *zap.Logger, capacity uint64) *persistentContiguousStorage {
-	return newPersistentContiguousStorage(context.Background(), "foo", client, logger, capacity,
+func createTestPersistentStorageWithCapacity(client storage.Client, capacity uint64) *persistentContiguousStorage {
+	return newPersistentContiguousStorage(context.Background(), "foo", client, zap.NewNop(), capacity,
 		newFakeTracesRequestMarshalerFunc(), newFakeTracesRequestUnmarshalerFunc())
 }
 
 func createTestPersistentStorage(client storage.Client) *persistentContiguousStorage {
-	logger := zap.NewNop()
-	return createTestPersistentStorageWithLoggingAndCapacity(client, logger, 1000)
+	return createTestPersistentStorageWithCapacity(client, 1000)
 }
 
 type fakeTracesRequest struct {
@@ -81,8 +78,7 @@ func newFakeTracesRequestMarshalerFunc() RequestMarshaler {
 }
 
 func TestPersistentStorage_CorruptedData(t *testing.T) {
-	traces := newTraces(5, 10)
-	req := newFakeTracesRequest(traces)
+	req := newFakeTracesRequest(newTraces(5, 10))
 
 	cases := []struct {
 		name                               string
@@ -146,7 +142,7 @@ func TestPersistentStorage_CorruptedData(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			ext := NewMockStorageExtension(nil)
-			client := createTestClient(ext)
+			client := createTestClient(t, ext)
 			ps := createTestPersistentStorage(client)
 
 			ctx := context.Background()
@@ -159,7 +155,7 @@ func TestPersistentStorage_CorruptedData(t *testing.T) {
 			require.Eventually(t, func() bool {
 				return ps.size() == 2
 			}, 5*time.Second, 10*time.Millisecond)
-			ps.stop()
+			assert.NoError(t, ps.stop(context.Background()))
 
 			// ... so now we can corrupt data (in several ways)
 			if c.corruptAllData || c.corruptSomeData {
@@ -195,11 +191,10 @@ func TestPersistentStorage_CorruptedData(t *testing.T) {
 }
 
 func TestPersistentStorage_CurrentlyProcessedItems(t *testing.T) {
-	traces := newTraces(5, 10)
-	req := newFakeTracesRequest(traces)
+	req := newFakeTracesRequest(newTraces(5, 10))
 
 	ext := NewMockStorageExtension(nil)
-	client := createTestClient(ext)
+	client := createTestClient(t, ext)
 	ps := createTestPersistentStorage(client)
 
 	for i := 0; i < 5; i++ {
@@ -260,14 +255,13 @@ func TestPersistentStorage_CurrentlyProcessedItems(t *testing.T) {
 // close to full and with some items dispatched
 func TestPersistentStorage_StartWithNonDispatched(t *testing.T) {
 	var capacity uint64 = 5 // arbitrary small number
-	logger := zap.NewNop()
 
 	traces := newTraces(5, 10)
 	req := newFakeTracesRequest(traces)
 
 	ext := NewMockStorageExtension(nil)
-	client := createTestClient(ext)
-	ps := createTestPersistentStorageWithLoggingAndCapacity(client, logger, capacity)
+	client := createTestClient(t, ext)
+	ps := createTestPersistentStorageWithCapacity(client, capacity)
 
 	// Put in items up to capacity
 	for i := 0; i < int(capacity); i++ {
@@ -278,16 +272,15 @@ func TestPersistentStorage_StartWithNonDispatched(t *testing.T) {
 	// get one item out, but don't mark it as processed
 	<-ps.get()
 	// put one more item in
-	err := ps.put(req)
-	require.NoError(t, err)
+	require.NoError(t, ps.put(req))
 
 	require.Eventually(t, func() bool {
 		return ps.size() == capacity-1
 	}, 5*time.Second, 10*time.Millisecond)
-	ps.stop()
+	assert.NoError(t, ps.stop(context.Background()))
 
 	// Reload
-	newPs := createTestPersistentStorageWithLoggingAndCapacity(client, logger, capacity)
+	newPs := createTestPersistentStorageWithCapacity(client, capacity)
 
 	require.Eventually(t, func() bool {
 		newPs.mu.Lock()
@@ -296,67 +289,42 @@ func TestPersistentStorage_StartWithNonDispatched(t *testing.T) {
 	}, 5*time.Second, 10*time.Millisecond)
 }
 
-func TestPersistentStorage_RepeatPutCloseReadClose(t *testing.T) {
-	traces := newTraces(5, 10)
-	req := newFakeTracesRequest(traces)
-
-	for i := 0; i < 10; i++ {
-		ext := NewMockStorageExtension(nil)
-		client := createTestClient(ext)
-		ps := createTestPersistentStorage(client)
-		require.Equal(t, uint64(0), ps.size())
-
-		// Put two elements
-		err := ps.put(req)
-		require.NoError(t, err)
-		err = ps.put(req)
-		require.NoError(t, err)
-
-		err = ext.Shutdown(context.Background())
-		require.NoError(t, err)
-
-		// TODO: when replacing mock with real storage, this could actually be uncommented
-		// ext = NewMockStorageExtension(nil)
-		// ps = createTestPersistentStorage(ext)
-
-		// The first element should be already picked by loop
-		require.Eventually(t, func() bool {
-			return ps.size() == 1
-		}, 5*time.Second, 10*time.Millisecond)
-
-		// Lets read both of the elements we put
-		readReq := <-ps.get()
-		require.Equal(t, req.td, readReq.(*fakeTracesRequest).td)
-
-		readReq = <-ps.get()
-		require.Equal(t, req.td, readReq.(*fakeTracesRequest).td)
-		require.Equal(t, uint64(0), ps.size())
-
-		err = ext.Shutdown(context.Background())
-		require.NoError(t, err)
-	}
-
-	// No more items
+func TestPersistentStorage_PutCloseReadClose(t *testing.T) {
+	req := newFakeTracesRequest(newTraces(5, 10))
 	ext := NewMockStorageExtension(nil)
-	wq := createTestQueue(t, 1000, 1, func(Request) {})
-	require.Equal(t, 0, wq.Size())
-	require.NoError(t, ext.Shutdown(context.Background()))
+	ps := createTestPersistentStorage(createTestClient(t, ext))
+	require.Equal(t, uint64(0), ps.size())
+
+	// Put two elements and close the extension
+	require.NoError(t, ps.put(req))
+	require.NoError(t, ps.put(req))
+
+	// TODO: Uncomment when the shutdown logic is fixed, right now loop is blocked if no consumer.
+	// ps.stop()
+	// ps = createTestPersistentStorage(createTestClient(t, ext))
+
+	// The first element should be already picked by loop
+	require.Eventually(t, func() bool {
+		return ps.size() > 0
+	}, 5*time.Second, 10*time.Millisecond)
+
+	// Lets read both of the elements we put
+	readReq := <-ps.get()
+	require.Equal(t, req.td, readReq.(*fakeTracesRequest).td)
+
+	readReq = <-ps.get()
+	require.Equal(t, req.td, readReq.(*fakeTracesRequest).td)
+	require.Equal(t, uint64(0), ps.size())
+	assert.NoError(t, ps.stop(context.Background()))
 }
 
 func TestPersistentStorage_EmptyRequest(t *testing.T) {
 	ext := NewMockStorageExtension(nil)
-	client := createTestClient(ext)
-	ps := createTestPersistentStorage(client)
-
+	ps := createTestPersistentStorage(createTestClient(t, ext))
 	require.Equal(t, uint64(0), ps.size())
-
-	err := ps.put(nil)
-	require.NoError(t, err)
-
+	require.NoError(t, ps.put(nil))
 	require.Equal(t, uint64(0), ps.size())
-
-	err = ext.Shutdown(context.Background())
-	require.NoError(t, err)
+	require.NoError(t, ext.Shutdown(context.Background()))
 }
 
 func BenchmarkPersistentStorage_TraceSpans(b *testing.B) {
@@ -381,17 +349,15 @@ func BenchmarkPersistentStorage_TraceSpans(b *testing.B) {
 	for _, c := range cases {
 		b.Run(fmt.Sprintf("#traces: %d #spansPerTrace: %d", c.numTraces, c.numSpansPerTrace), func(bb *testing.B) {
 			ext := NewMockStorageExtension(nil)
-			client := createTestClient(ext)
-			ps := createTestPersistentStorageWithLoggingAndCapacity(client, zap.NewNop(), 10000000)
+			client := createTestClient(b, ext)
+			ps := createTestPersistentStorageWithCapacity(client, 10000000)
 
-			traces := newTraces(c.numTraces, c.numSpansPerTrace)
-			req := newFakeTracesRequest(traces)
+			req := newFakeTracesRequest(newTraces(c.numTraces, c.numSpansPerTrace))
 
 			bb.ResetTimer()
 
 			for i := 0; i < bb.N; i++ {
-				err := ps.put(req)
-				require.NoError(bb, err)
+				require.NoError(bb, ps.put(req))
 			}
 
 			for i := 0; i < bb.N; i++ {
@@ -463,10 +429,10 @@ func TestItemIndexArrayMarshaling(t *testing.T) {
 
 func TestPersistentStorage_StopShouldCloseClient(t *testing.T) {
 	ext := NewMockStorageExtension(nil)
-	client := createTestClient(ext)
+	client := createTestClient(t, ext)
 	ps := createTestPersistentStorage(client)
 
-	ps.stop()
+	assert.NoError(t, ps.stop(context.Background()))
 
 	castedClient, ok := client.(*mockStorageClient)
 	require.True(t, ok, "expected client to be mockStorageClient")
@@ -474,9 +440,7 @@ func TestPersistentStorage_StopShouldCloseClient(t *testing.T) {
 }
 
 func TestPersistentStorage_StorageFull(t *testing.T) {
-	var err error
-	traces := newTraces(5, 10)
-	req := newFakeTracesRequest(traces)
+	req := newFakeTracesRequest(newTraces(5, 10))
 	marshaled, err := newFakeTracesRequestMarshalerFunc()(req)
 	require.NoError(t, err)
 	maxSizeInBytes := len(marshaled) * 5 // arbitrary small number
@@ -501,8 +465,7 @@ func TestPersistentStorage_StorageFull(t *testing.T) {
 	client.SetMaxSizeInBytes(newMaxSize)
 
 	// Try to put an item in, should fail
-	err = ps.put(req)
-	require.Error(t, err)
+	require.Error(t, ps.put(req))
 
 	// Take out all the items
 	for i := reqCount; i > 0; i-- {
@@ -512,8 +475,7 @@ func TestPersistentStorage_StorageFull(t *testing.T) {
 
 	// We should be able to put a new item in
 	// However, this will fail if deleting items fails with full storage
-	err = ps.put(req)
-	require.NoError(t, err)
+	require.NoError(t, ps.put(req))
 }
 
 func TestPersistentStorage_ItemDispatchingFinish_ErrorHandling(t *testing.T) {
@@ -557,7 +519,6 @@ func TestPersistentStorage_ItemDispatchingFinish_ErrorHandling(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.description, func(t *testing.T) {
-			testCase := testCase
 			client := newFakeStorageClientWithErrors(testCase.storageErrors)
 			ps := createTestPersistentStorage(client)
 			client.Reset()
@@ -597,8 +558,7 @@ type fakeBoundedStorageClient struct {
 
 func (m *fakeBoundedStorageClient) Get(ctx context.Context, key string) ([]byte, error) {
 	op := storage.GetOperation(key)
-	err := m.Batch(ctx, op)
-	if err != nil {
+	if err := m.Batch(ctx, op); err != nil {
 		return nil, err
 	}
 
@@ -643,7 +603,7 @@ func (m *fakeBoundedStorageClient) Batch(_ context.Context, ops ...storage.Opera
 		}
 	}
 
-	m.sizeInBytes += (totalAdded - totalRemoved)
+	m.sizeInBytes += totalAdded - totalRemoved
 
 	return nil
 }
@@ -726,9 +686,8 @@ func (m *fakeStorageClientWithErrors) Batch(_ context.Context, _ ...storage.Oper
 		return nil
 	}
 
-	err := m.errors[m.nextErrorIndex]
 	m.nextErrorIndex++
-	return err
+	return m.errors[m.nextErrorIndex-1]
 }
 
 func (m *fakeStorageClientWithErrors) Reset() {

--- a/exporter/exporterhelper/internal/queue.go
+++ b/exporter/exporterhelper/internal/queue.go
@@ -18,9 +18,9 @@ type QueueSettings struct {
 	Callback func(item Request)
 }
 
-// ProducerConsumerQueue defines a producer-consumer exchange which can be backed by e.g. the memory-based ring buffer queue
+// Queue defines a producer-consumer exchange which can be backed by e.g. the memory-based ring buffer queue
 // (boundedMemoryQueue) or via a disk-based queue (persistentQueue)
-type ProducerConsumerQueue interface {
+type Queue interface {
 	// Start starts the queue with a given number of goroutines consuming items from the queue
 	// and passing them into the consumer callback.
 	Start(ctx context.Context, host component.Host, set QueueSettings) error
@@ -29,9 +29,8 @@ type ProducerConsumerQueue interface {
 	Produce(item Request) bool
 	// Size returns the current Size of the queue
 	Size() int
-	// Stop stops all consumers, as well as the length reporter if started,
-	// and releases the items channel. It blocks until all consumers have stopped.
-	Stop()
+	// Shutdown stops accepting items, and stops all consumers. It blocks until all consumers have stopped.
+	Shutdown(ctx context.Context) error
 	// Capacity returns the capacity of the queue.
 	Capacity() int
 	// IsPersistent returns true if the queue is persistent.

--- a/exporter/exporterhelper/queue_sender_test.go
+++ b/exporter/exporterhelper/queue_sender_test.go
@@ -362,8 +362,8 @@ func TestQueuedRetryPersistentEnabled_shutdown_dataIsRequeued(t *testing.T) {
 
 	// wraps original queue so we can count operations
 	be.queueSender.(*queueSender).queue = &producerConsumerQueueWithCounter{
-		ProducerConsumerQueue: be.queueSender.(*queueSender).queue,
-		produceCounter:        produceCounter,
+		Queue:          be.queueSender.(*queueSender).queue,
+		produceCounter: produceCounter,
 	}
 	be.queueSender.(*queueSender).requeuingEnabled = true
 

--- a/exporter/exporterhelper/retry_sender.go
+++ b/exporter/exporterhelper/retry_sender.go
@@ -4,6 +4,7 @@
 package exporterhelper // import "go.opentelemetry.io/collector/exporter/exporterhelper"
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"time"
@@ -99,8 +100,9 @@ func newRetrySender(id component.ID, rCfg RetrySettings, logger *zap.Logger, onT
 	}
 }
 
-func (rs *retrySender) shutdown() {
+func (rs *retrySender) shutdown(context.Context) error {
 	close(rs.stopCh)
+	return nil
 }
 
 // send implements the requestSender interface

--- a/exporter/exporterhelper/retry_sender_test.go
+++ b/exporter/exporterhelper/retry_sender_test.go
@@ -396,11 +396,11 @@ func tagsMatchLabelKeys(tags []tag.Tag, keys []metricdata.LabelKey, labels []met
 }
 
 type producerConsumerQueueWithCounter struct {
-	internal.ProducerConsumerQueue
+	internal.Queue
 	produceCounter *atomic.Uint32
 }
 
 func (pcq *producerConsumerQueueWithCounter) Produce(item internal.Request) bool {
 	pcq.produceCounter.Add(1)
-	return pcq.ProducerConsumerQueue.Produce(item)
+	return pcq.Queue.Produce(item)
 }


### PR DESCRIPTION
* Rename Stop to Shutdown, add context and return error.
* Fix test nits.
* Return errors from Shutdown instead of log them.
