### PR TITLE
[exporterhelper] Add WithRequestQueue option to the exporter

### DIFF
--- a/.chloggen/exporter-helper-v2.yaml
+++ b/.chloggen/exporter-helper-v2.yaml
@@ -1,0 +1,32 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: exporter/exporterhelper
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add API for enabling queue in the new exporter helpers.
+
+# One or more tracking issues or pull requests related to the change
+issues: [7874]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The following experimental API is introduced in exporter package:
+    - `exporterhelper.WithRequestQueue`: a new exporter helper option for using a queue.
+    - `exporterqueue.Queue`: an interface for queue implementations.
+    - `exporterqueue.Factory`: a queue factory interface, implementations of this interface are intended to be used with WithRequestQueue option.
+    - `exporterqueue.Settings`: queue factory settings.
+    - `exporterqueue.Config`: common configuration for queue implementations.
+    - `exporterqueue.NewDefaultConfig`: a function for creating a default queue configuration.
+    - `exporterqueue.NewMemoryQueueFactory`: a new factory for creating a memory queue.
+    - `exporterqueue.NewPersistentQueueFactory: a factory for creating a persistent queue.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/exporter/exporterhelper/logs_test.go
+++ b/exporter/exporterhelper/logs_test.go
@@ -25,8 +25,8 @@ import (
 	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/exporter"
-	"go.opentelemetry.io/collector/exporter/exporterhelper/internal"
 	"go.opentelemetry.io/collector/exporter/exportertest"
+	"go.opentelemetry.io/collector/exporter/internal/queue"
 	"go.opentelemetry.io/collector/internal/obsreportconfig/obsmetrics"
 	"go.opentelemetry.io/collector/internal/testdata"
 	"go.opentelemetry.io/collector/pdata/plog"
@@ -167,7 +167,7 @@ func TestLogsExporter_WithPersistentQueue(t *testing.T) {
 	require.NoError(t, err)
 
 	host := &mockHost{ext: map[component.ID]component.Component{
-		storageID: internal.NewMockStorageExtension(nil),
+		storageID: queue.NewMockStorageExtension(nil),
 	}}
 	require.NoError(t, te.Start(context.Background(), host))
 	t.Cleanup(func() { require.NoError(t, te.Shutdown(context.Background())) })

--- a/exporter/exporterhelper/metrics_test.go
+++ b/exporter/exporterhelper/metrics_test.go
@@ -25,8 +25,8 @@ import (
 	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/exporter"
-	"go.opentelemetry.io/collector/exporter/exporterhelper/internal"
 	"go.opentelemetry.io/collector/exporter/exportertest"
+	"go.opentelemetry.io/collector/exporter/internal/queue"
 	"go.opentelemetry.io/collector/internal/obsreportconfig/obsmetrics"
 	"go.opentelemetry.io/collector/internal/testdata"
 	"go.opentelemetry.io/collector/pdata/pmetric"
@@ -168,7 +168,7 @@ func TestMetricsExporter_WithPersistentQueue(t *testing.T) {
 	require.NoError(t, err)
 
 	host := &mockHost{ext: map[component.ID]component.Component{
-		storageID: internal.NewMockStorageExtension(nil),
+		storageID: queue.NewMockStorageExtension(nil),
 	}}
 	require.NoError(t, te.Start(context.Background(), host))
 	t.Cleanup(func() { require.NoError(t, te.Shutdown(context.Background())) })

--- a/exporter/exporterhelper/queue_sender_test.go
+++ b/exporter/exporterhelper/queue_sender_test.go
@@ -18,8 +18,9 @@ import (
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/configretry"
 	"go.opentelemetry.io/collector/exporter"
-	"go.opentelemetry.io/collector/exporter/exporterhelper/internal"
+	"go.opentelemetry.io/collector/exporter/exporterqueue"
 	"go.opentelemetry.io/collector/exporter/exportertest"
+	"go.opentelemetry.io/collector/exporter/internal/queue"
 )
 
 func TestQueuedRetry_StopWhileWaiting(t *testing.T) {
@@ -101,41 +102,85 @@ func TestQueuedRetry_RejectOnFull(t *testing.T) {
 }
 
 func TestQueuedRetryHappyPath(t *testing.T) {
-	tt, err := componenttest.SetupTelemetry(defaultID)
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
+	tests := []struct {
+		name        string
+		queueOption Option
+	}{
+		{
+			name: "WithQueue",
+			queueOption: WithQueue(QueueSettings{
+				Enabled:      true,
+				QueueSize:    10,
+				NumConsumers: 1,
+			}),
+		},
+		{
+			name: "WithRequestQueue/MemoryQueueFactory",
+			queueOption: WithRequestQueue(exporterqueue.Config{
+				Enabled:      true,
+				QueueSize:    10,
+				NumConsumers: 1,
+			}, exporterqueue.NewMemoryQueueFactory[Request]()),
+		},
+		{
+			name: "WithRequestQueue/PersistentQueueFactory",
+			queueOption: WithRequestQueue(exporterqueue.Config{
+				Enabled:      true,
+				QueueSize:    10,
+				NumConsumers: 1,
+			}, exporterqueue.NewPersistentQueueFactory[Request](nil, exporterqueue.PersistentQueueSettings[Request]{})),
+		},
+		{
+			name: "WithRequestQueue/PersistentQueueFactory/RequestsLimit",
+			queueOption: WithRequestQueue(exporterqueue.Config{
+				Enabled:      true,
+				QueueSize:    10,
+				NumConsumers: 1,
+			}, exporterqueue.NewPersistentQueueFactory[Request](nil, exporterqueue.PersistentQueueSettings[Request]{})),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tel, err := componenttest.SetupTelemetry(defaultID)
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, tel.Shutdown(context.Background())) })
 
-	qCfg := NewDefaultQueueSettings()
-	rCfg := configretry.NewDefaultBackOffConfig()
-	set := exporter.CreateSettings{ID: defaultID, TelemetrySettings: tt.TelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()}
-	be, err := newBaseExporter(set, defaultType, false, nil, nil, newObservabilityConsumerSender, WithRetry(rCfg), WithQueue(qCfg))
-	require.NoError(t, err)
-	ocs := be.obsrepSender.(*observabilityConsumerSender)
-	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
-	t.Cleanup(func() {
-		assert.NoError(t, be.Shutdown(context.Background()))
-	})
+			rCfg := configretry.NewDefaultBackOffConfig()
+			set := exporter.CreateSettings{ID: defaultID, TelemetrySettings: tel.TelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()}
+			be, err := newBaseExporter(set, defaultType, false, nil, nil, newObservabilityConsumerSender, WithRetry(rCfg), tt.queueOption)
+			require.NoError(t, err)
+			ocs := be.obsrepSender.(*observabilityConsumerSender)
 
-	wantRequests := 10
-	reqs := make([]*mockRequest, 0, 10)
-	for i := 0; i < wantRequests; i++ {
-		ocs.run(func() {
-			req := newMockRequest(2, nil)
-			reqs = append(reqs, req)
-			require.NoError(t, be.send(context.Background(), req))
+			wantRequests := 10
+			reqs := make([]*mockRequest, 0, 10)
+			for i := 0; i < wantRequests; i++ {
+				ocs.run(func() {
+					req := newMockRequest(2, nil)
+					reqs = append(reqs, req)
+					require.NoError(t, be.send(context.Background(), req))
+				})
+			}
+
+			// expect queue to be full
+			require.Error(t, be.send(context.Background(), newMockRequest(2, nil)))
+
+			require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
+			t.Cleanup(func() {
+				assert.NoError(t, be.Shutdown(context.Background()))
+			})
+
+			// Wait until all batches received
+			ocs.awaitAsyncProcessing()
+
+			require.Len(t, reqs, wantRequests)
+			for _, req := range reqs {
+				req.checkNumRequests(t, 1)
+			}
+
+			ocs.checkSendItemsCount(t, 2*wantRequests)
+			ocs.checkDroppedItemsCount(t, 0)
 		})
 	}
-
-	// Wait until all batches received
-	ocs.awaitAsyncProcessing()
-
-	require.Len(t, reqs, wantRequests)
-	for _, req := range reqs {
-		req.checkNumRequests(t, 1)
-	}
-
-	ocs.checkSendItemsCount(t, 2*wantRequests)
-	ocs.checkDroppedItemsCount(t, 0)
 }
 func TestQueuedRetry_QueueMetricsReported(t *testing.T) {
 	tt, err := componenttest.SetupTelemetry(defaultID)
@@ -193,27 +238,52 @@ func TestQueueSettings_Validate(t *testing.T) {
 }
 
 func TestQueueRetryWithDisabledQueue(t *testing.T) {
-	qs := NewDefaultQueueSettings()
-	qs.Enabled = false
-	set := exportertest.NewNopCreateSettings()
-	logger, observed := observer.New(zap.ErrorLevel)
-	set.Logger = zap.New(logger)
-	be, err := newBaseExporter(set, component.DataTypeLogs, false, nil, nil, newObservabilityConsumerSender,
-		WithQueue(qs))
-	require.NoError(t, err)
-	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
-	ocs := be.obsrepSender.(*observabilityConsumerSender)
-	mockR := newMockRequest(2, errors.New("some error"))
-	ocs.run(func() {
-		require.Error(t, be.send(context.Background(), mockR))
-	})
-	assert.Len(t, observed.All(), 1)
-	assert.Equal(t, "Exporting failed. Rejecting data. Try enabling sending_queue to survive temporary failures.", observed.All()[0].Message)
-	ocs.awaitAsyncProcessing()
-	mockR.checkNumRequests(t, 1)
-	ocs.checkSendItemsCount(t, 0)
-	ocs.checkDroppedItemsCount(t, 2)
-	require.NoError(t, be.Shutdown(context.Background()))
+	tests := []struct {
+		name        string
+		queueOption Option
+	}{
+		{
+			name: "WithQueue",
+			queueOption: func() Option {
+				qs := NewDefaultQueueSettings()
+				qs.Enabled = false
+				return WithQueue(qs)
+			}(),
+		},
+		{
+			name: "WithRequestQueue",
+			queueOption: func() Option {
+				qs := exporterqueue.NewDefaultConfig()
+				qs.Enabled = false
+				return WithRequestQueue(qs, exporterqueue.NewMemoryQueueFactory[Request]())
+			}(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			set := exportertest.NewNopCreateSettings()
+			logger, observed := observer.New(zap.ErrorLevel)
+			set.Logger = zap.New(logger)
+			be, err := newBaseExporter(set, component.DataTypeLogs, false, nil, nil, newObservabilityConsumerSender,
+				tt.queueOption)
+			require.NoError(t, err)
+			require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
+			ocs := be.obsrepSender.(*observabilityConsumerSender)
+			mockR := newMockRequest(2, errors.New("some error"))
+			ocs.run(func() {
+				require.Error(t, be.send(context.Background(), mockR))
+			})
+			assert.Len(t, observed.All(), 1)
+			assert.Equal(t, "Exporting failed. Rejecting data. Try enabling sending_queue to survive temporary failures.", observed.All()[0].Message)
+			ocs.awaitAsyncProcessing()
+			mockR.checkNumRequests(t, 1)
+			ocs.checkSendItemsCount(t, 0)
+			ocs.checkDroppedItemsCount(t, 2)
+			require.NoError(t, be.Shutdown(context.Background()))
+		})
+	}
+
 }
 
 func TestQueueFailedRequestDropped(t *testing.T) {
@@ -245,7 +315,7 @@ func TestQueuedRetryPersistenceEnabled(t *testing.T) {
 	require.NoError(t, err)
 
 	var extensions = map[component.ID]component.Component{
-		storageID: internal.NewMockStorageExtension(nil),
+		storageID: queue.NewMockStorageExtension(nil),
 	}
 	host := &mockHost{ext: extensions}
 
@@ -269,7 +339,7 @@ func TestQueuedRetryPersistenceEnabledStorageError(t *testing.T) {
 	require.NoError(t, err)
 
 	var extensions = map[component.ID]component.Component{
-		storageID: internal.NewMockStorageExtension(storageError),
+		storageID: queue.NewMockStorageExtension(storageError),
 	}
 	host := &mockHost{ext: extensions}
 
@@ -293,7 +363,7 @@ func TestQueuedRetryPersistentEnabled_NoDataLossOnShutdown(t *testing.T) {
 	require.NoError(t, err)
 
 	var extensions = map[component.ID]component.Component{
-		storageID: internal.NewMockStorageExtension(nil),
+		storageID: queue.NewMockStorageExtension(nil),
 	}
 	host := &mockHost{ext: extensions}
 
@@ -323,7 +393,8 @@ func TestQueuedRetryPersistentEnabled_NoDataLossOnShutdown(t *testing.T) {
 }
 
 func TestQueueSenderNoStartShutdown(t *testing.T) {
-	qs := newQueueSender(NewDefaultQueueSettings(), exportertest.NewNopCreateSettings(), defaultType, nil, nil, nil)
+	queue := queue.NewBoundedMemoryQueue[Request](queue.MemoryQueueSettings[Request]{})
+	qs := newQueueSender(queue, exportertest.NewNopCreateSettings(), 1, "")
 	assert.NoError(t, qs.Shutdown(context.Background()))
 }
 

--- a/exporter/exporterhelper/request.go
+++ b/exporter/exporterhelper/request.go
@@ -33,13 +33,11 @@ type RequestErrorHandler interface {
 }
 
 // RequestMarshaler is a function that can marshal a Request into bytes.
-// This API is at the early stage of development and may change without backward compatibility
-// until https://github.com/open-telemetry/opentelemetry-collector/issues/8122 is resolved.
+// Deprecated: [v0.94.0] Use exporterqueue.Marshaler[Request] instead.
 type RequestMarshaler func(req Request) ([]byte, error)
 
 // RequestUnmarshaler is a function that can unmarshal bytes into a Request.
-// This API is at the early stage of development and may change without backward compatibility
-// until https://github.com/open-telemetry/opentelemetry-collector/issues/8122 is resolved.
+// Deprecated: [v0.94.0] Use exporterqueue.Unmarshaler[Request] instead.
 type RequestUnmarshaler func(data []byte) (Request, error)
 
 // extractPartialRequest returns a new Request that may contain the items left to be sent

--- a/exporter/exporterhelper/retry_sender.go
+++ b/exporter/exporterhelper/retry_sender.go
@@ -17,7 +17,7 @@ import (
 	"go.opentelemetry.io/collector/config/configretry"
 	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/exporter"
-	"go.opentelemetry.io/collector/exporter/exporterhelper/internal"
+	"go.opentelemetry.io/collector/exporter/internal/queue"
 	"go.opentelemetry.io/collector/internal/obsreportconfig/obsmetrics"
 )
 
@@ -127,7 +127,7 @@ func (rs *retrySender) send(ctx context.Context, req Request) error {
 		case <-ctx.Done():
 			return fmt.Errorf("request is cancelled or timed out %w", err)
 		case <-rs.stopCh:
-			return internal.NewShutdownErr(err)
+			return queue.NewShutdownErr(err)
 		case <-time.After(backoffDelay):
 		}
 	}

--- a/exporter/exporterhelper/retry_sender_test.go
+++ b/exporter/exporterhelper/retry_sender_test.go
@@ -20,11 +20,12 @@ import (
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/configretry"
 	"go.opentelemetry.io/collector/consumer/consumererror"
+	"go.opentelemetry.io/collector/exporter/exporterqueue"
 	"go.opentelemetry.io/collector/exporter/exportertest"
 	"go.opentelemetry.io/collector/internal/testdata"
 )
 
-func mockRequestUnmarshaler(mr Request) RequestUnmarshaler {
+func mockRequestUnmarshaler(mr Request) exporterqueue.Unmarshaler[Request] {
 	return func(bytes []byte) (Request, error) {
 		return mr, nil
 	}

--- a/exporter/exporterhelper/traces.go
+++ b/exporter/exporterhelper/traces.go
@@ -13,7 +13,8 @@ import (
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/exporter"
-	"go.opentelemetry.io/collector/exporter/exporterhelper/internal"
+	"go.opentelemetry.io/collector/exporter/exporterqueue"
+	"go.opentelemetry.io/collector/exporter/internal/queue"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 )
 
@@ -32,7 +33,7 @@ func newTracesRequest(td ptrace.Traces, pusher consumer.ConsumeTracesFunc) Reque
 	}
 }
 
-func newTraceRequestUnmarshalerFunc(pusher consumer.ConsumeTracesFunc) RequestUnmarshaler {
+func newTraceRequestUnmarshalerFunc(pusher consumer.ConsumeTracesFunc) exporterqueue.Unmarshaler[Request] {
 	return func(bytes []byte) (Request, error) {
 		traces, err := tracesUnmarshaler.UnmarshalTraces(bytes)
 		if err != nil {
@@ -96,7 +97,7 @@ func NewTracesExporter(
 	tc, err := consumer.NewTraces(func(ctx context.Context, td ptrace.Traces) error {
 		req := newTracesRequest(td, pusher)
 		serr := be.send(ctx, req)
-		if errors.Is(serr, internal.ErrQueueIsFull) {
+		if errors.Is(serr, queue.ErrQueueIsFull) {
 			be.obsrep.recordEnqueueFailure(ctx, component.DataTypeTraces, int64(req.ItemsCount()))
 		}
 		return serr
@@ -144,7 +145,7 @@ func NewTracesRequestExporter(
 			return consumererror.NewPermanent(cErr)
 		}
 		sErr := be.send(ctx, req)
-		if errors.Is(sErr, internal.ErrQueueIsFull) {
+		if errors.Is(sErr, queue.ErrQueueIsFull) {
 			be.obsrep.recordEnqueueFailure(ctx, component.DataTypeTraces, int64(req.ItemsCount()))
 		}
 		return sErr

--- a/exporter/exporterhelper/traces_test.go
+++ b/exporter/exporterhelper/traces_test.go
@@ -25,8 +25,8 @@ import (
 	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/exporter"
-	"go.opentelemetry.io/collector/exporter/exporterhelper/internal"
 	"go.opentelemetry.io/collector/exporter/exportertest"
+	"go.opentelemetry.io/collector/exporter/internal/queue"
 	"go.opentelemetry.io/collector/internal/obsreportconfig/obsmetrics"
 	"go.opentelemetry.io/collector/internal/testdata"
 	"go.opentelemetry.io/collector/pdata/ptrace"
@@ -165,7 +165,7 @@ func TestTracesExporter_WithPersistentQueue(t *testing.T) {
 	require.NoError(t, err)
 
 	host := &mockHost{ext: map[component.ID]component.Component{
-		storageID: internal.NewMockStorageExtension(nil),
+		storageID: queue.NewMockStorageExtension(nil),
 	}}
 	require.NoError(t, te.Start(context.Background(), host))
 	t.Cleanup(func() { require.NoError(t, te.Shutdown(context.Background())) })

--- a/exporter/exporterqueue/config.go
+++ b/exporter/exporterqueue/config.go
@@ -1,0 +1,61 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package exporterqueue // import "go.opentelemetry.io/collector/exporter/exporterqueue"
+
+import (
+	"errors"
+
+	"go.opentelemetry.io/collector/component"
+)
+
+// Config defines configuration for queueing requests before exporting.
+// It's supposed to be used with the new exporter helpers New[Traces|Metrics|Logs]RequestExporter.
+// This API is at the early stage of development and may change without backward compatibility
+// until https://github.com/open-telemetry/opentelemetry-collector/issues/8122 is resolved.
+type Config struct {
+	// Enabled indicates whether to not enqueue batches before exporting.
+	Enabled bool `mapstructure:"enabled"`
+	// NumConsumers is the number of consumers from the queue.
+	NumConsumers int `mapstructure:"num_consumers"`
+	// QueueSize is the maximum number of requests allowed in queue at any given time.
+	QueueSize int `mapstructure:"queue_size"`
+}
+
+// NewDefaultConfig returns the default Config.
+// This API is at the early stage of development and may change without backward compatibility
+// until https://github.com/open-telemetry/opentelemetry-collector/issues/8122 is resolved.
+func NewDefaultConfig() Config {
+	return Config{
+		Enabled:      true,
+		NumConsumers: 10,
+		QueueSize:    1_000,
+	}
+}
+
+// Validate checks if the QueueSettings configuration is valid
+func (qCfg *Config) Validate() error {
+	if !qCfg.Enabled {
+		return nil
+	}
+	if qCfg.NumConsumers <= 0 {
+		return errors.New("number of consumers must be positive")
+	}
+	if qCfg.QueueSize <= 0 {
+		return errors.New("queue size must be positive")
+	}
+	return nil
+}
+
+// PersistentQueueConfig defines configuration for queueing requests in a persistent storage.
+// The struct is provided to be added in the exporter configuration as one struct under the "sending_queue" key.
+// The exporter helper Go interface requires the fields to be provided separately to WithRequestQueue and
+// NewPersistentQueueFactory.
+// This API is at the early stage of development and may change without backward compatibility
+// until https://github.com/open-telemetry/opentelemetry-collector/issues/8122 is resolved.
+type PersistentQueueConfig struct {
+	Config `mapstructure:",squash"`
+	// StorageID if not empty, enables the persistent storage and uses the component specified
+	// as a storage extension for the persistent queue
+	StorageID *component.ID `mapstructure:"storage"`
+}

--- a/exporter/exporterqueue/config_test.go
+++ b/exporter/exporterqueue/config_test.go
@@ -1,0 +1,26 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package exporterqueue
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestQueueConfig_Validate(t *testing.T) {
+	qCfg := NewDefaultConfig()
+	assert.NoError(t, qCfg.Validate())
+
+	qCfg.NumConsumers = 0
+	assert.EqualError(t, qCfg.Validate(), "number of consumers must be positive")
+
+	qCfg = NewDefaultConfig()
+	qCfg.QueueSize = 0
+	assert.EqualError(t, qCfg.Validate(), "queue size must be positive")
+
+	// Confirm Validate doesn't return error with invalid config when feature is disabled
+	qCfg.Enabled = false
+	assert.NoError(t, qCfg.Validate())
+}

--- a/exporter/exporterqueue/queue.go
+++ b/exporter/exporterqueue/queue.go
@@ -1,0 +1,96 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package exporterqueue // import "go.opentelemetry.io/collector/exporter/exporterqueue"
+
+import (
+	"context"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/exporter"
+	"go.opentelemetry.io/collector/exporter/internal/queue"
+)
+
+// Queue defines a producer-consumer exchange which can be backed by e.g. the memory-based ring buffer queue
+// (boundedMemoryQueue) or via a disk-based queue (persistentQueue)
+// This API is at the early stage of development and may change without backward compatibility
+// until https://github.com/open-telemetry/opentelemetry-collector/issues/8122 is resolved.
+type Queue[T any] queue.Queue[T]
+
+// Settings defines settings for creating a queue.
+type Settings struct {
+	DataType         component.DataType
+	ExporterSettings exporter.CreateSettings
+}
+
+// Marshaler is a function that can marshal a request into bytes.
+// This API is at the early stage of development and may change without backward compatibility
+// until https://github.com/open-telemetry/opentelemetry-collector/issues/8122 is resolved.
+type Marshaler[T any] func(T) ([]byte, error)
+
+// Unmarshaler is a function that can unmarshal bytes into a request.
+// This API is at the early stage of development and may change without backward compatibility
+// until https://github.com/open-telemetry/opentelemetry-collector/issues/8122 is resolved.
+type Unmarshaler[T any] func([]byte) (T, error)
+
+// Factory is a function that creates a new queue.
+// This API is at the early stage of development and may change without backward compatibility
+// until https://github.com/open-telemetry/opentelemetry-collector/issues/8122 is resolved.
+type Factory[T any] func(context.Context, Settings, Config) Queue[T]
+
+// NewMemoryQueueFactory returns a factory to create a new memory queue.
+// This API is at the early stage of development and may change without backward compatibility
+// until https://github.com/open-telemetry/opentelemetry-collector/issues/8122 is resolved.
+func NewMemoryQueueFactory[T itemsCounter]() Factory[T] {
+	return func(_ context.Context, _ Settings, cfg Config) Queue[T] {
+		return queue.NewBoundedMemoryQueue[T](queue.MemoryQueueSettings[T]{
+			Sizer:    sizerFromConfig[T](cfg),
+			Capacity: capacityFromConfig(cfg),
+		})
+	}
+}
+
+// PersistentQueueSettings defines developer settings for the persistent queue factory.
+// This API is at the early stage of development and may change without backward compatibility
+// until https://github.com/open-telemetry/opentelemetry-collector/issues/8122 is resolved.
+type PersistentQueueSettings[T any] struct {
+	// Marshaler is used to serialize queue elements before storing them in the persistent storage.
+	Marshaler Marshaler[T]
+	// Unmarshaler is used to deserialize requests after reading them from the persistent storage.
+	Unmarshaler Unmarshaler[T]
+}
+
+// NewPersistentQueueFactory returns a factory to create a new persistent queue.
+// If cfg.StorageID is nil then it falls back to memory queue.
+// This API is at the early stage of development and may change without backward compatibility
+// until https://github.com/open-telemetry/opentelemetry-collector/issues/8122 is resolved.
+func NewPersistentQueueFactory[T itemsCounter](storageID *component.ID, factorySettings PersistentQueueSettings[T]) Factory[T] {
+	if storageID == nil {
+		return NewMemoryQueueFactory[T]()
+	}
+	return func(_ context.Context, set Settings, cfg Config) Queue[T] {
+		return queue.NewPersistentQueue[T](queue.PersistentQueueSettings[T]{
+			Sizer:            sizerFromConfig[T](cfg),
+			Capacity:         capacityFromConfig(cfg),
+			DataType:         set.DataType,
+			StorageID:        *storageID,
+			Marshaler:        factorySettings.Marshaler,
+			Unmarshaler:      factorySettings.Unmarshaler,
+			ExporterSettings: set.ExporterSettings,
+		})
+	}
+}
+
+type itemsCounter interface {
+	ItemsCount() int
+}
+
+func sizerFromConfig[T itemsCounter](Config) queue.Sizer[T] {
+	// TODO: Handle other ways to measure the queue size once they are added.
+	return &queue.RequestSizer[T]{}
+}
+
+func capacityFromConfig(cfg Config) int {
+	// TODO: Handle other ways to measure the queue size once they are added.
+	return cfg.QueueSize
+}

--- a/exporter/internal/queue/bounded_memory_queue.go
+++ b/exporter/internal/queue/bounded_memory_queue.go
@@ -3,7 +3,7 @@
 // Copyright (c) 2017 Uber Technologies, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-package internal // import "go.opentelemetry.io/collector/exporter/exporterhelper/internal"
+package queue // import "go.opentelemetry.io/collector/exporter/internal/queue"
 
 import (
 	"context"

--- a/exporter/internal/queue/bounded_memory_queue_test.go
+++ b/exporter/internal/queue/bounded_memory_queue_test.go
@@ -3,7 +3,7 @@
 // Copyright (c) 2017 Uber Technologies, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-package internal
+package queue
 
 import (
 	"context"

--- a/exporter/internal/queue/consumers.go
+++ b/exporter/internal/queue/consumers.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package internal // import "go.opentelemetry.io/collector/exporter/exporterhelper/internal"
+package queue // import "go.opentelemetry.io/collector/exporter/internal/queue"
 
 import (
 	"context"
@@ -10,15 +10,15 @@ import (
 	"go.opentelemetry.io/collector/component"
 )
 
-type QueueConsumers[T any] struct {
+type Consumers[T any] struct {
 	queue        Queue[T]
 	numConsumers int
 	consumeFunc  func(context.Context, T) error
 	stopWG       sync.WaitGroup
 }
 
-func NewQueueConsumers[T any](q Queue[T], numConsumers int, consumeFunc func(context.Context, T) error) *QueueConsumers[T] {
-	return &QueueConsumers[T]{
+func NewQueueConsumers[T any](q Queue[T], numConsumers int, consumeFunc func(context.Context, T) error) *Consumers[T] {
+	return &Consumers[T]{
 		queue:        q,
 		numConsumers: numConsumers,
 		consumeFunc:  consumeFunc,
@@ -27,7 +27,7 @@ func NewQueueConsumers[T any](q Queue[T], numConsumers int, consumeFunc func(con
 }
 
 // Start ensures that queue and all consumers are started.
-func (qc *QueueConsumers[T]) Start(ctx context.Context, host component.Host) error {
+func (qc *Consumers[T]) Start(ctx context.Context, host component.Host) error {
 	if err := qc.queue.Start(ctx, host); err != nil {
 		return err
 	}
@@ -52,7 +52,7 @@ func (qc *QueueConsumers[T]) Start(ctx context.Context, host component.Host) err
 }
 
 // Shutdown ensures that queue and all consumers are stopped.
-func (qc *QueueConsumers[T]) Shutdown(ctx context.Context) error {
+func (qc *Consumers[T]) Shutdown(ctx context.Context) error {
 	if err := qc.queue.Shutdown(ctx); err != nil {
 		return err
 	}

--- a/exporter/internal/queue/err.go
+++ b/exporter/internal/queue/err.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package internal // import "go.opentelemetry.io/collector/exporter/exporterhelper/internal"
+package queue // import "go.opentelemetry.io/collector/exporter/internal/queue"
 
 type shutdownErr struct {
 	err error

--- a/exporter/internal/queue/mock_storage.go
+++ b/exporter/internal/queue/mock_storage.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package internal // import "go.opentelemetry.io/collector/exporter/exporterhelper/internal"
+package queue // import "go.opentelemetry.io/collector/exporter/internal/queue"
 
 import (
 	"context"

--- a/exporter/internal/queue/package_test.go
+++ b/exporter/internal/queue/package_test.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package internal
+package queue
 
 import (
 	"testing"

--- a/exporter/internal/queue/persistent_queue.go
+++ b/exporter/internal/queue/persistent_queue.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package internal // import "go.opentelemetry.io/collector/exporter/exporterhelper/internal"
+package queue // import "go.opentelemetry.io/collector/exporter/internal/queue"
 
 import (
 	"context"

--- a/exporter/internal/queue/persistent_queue_test.go
+++ b/exporter/internal/queue/persistent_queue_test.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package internal
+package queue
 
 import (
 	"context"

--- a/exporter/internal/queue/queue.go
+++ b/exporter/internal/queue/queue.go
@@ -3,7 +3,7 @@
 // Copyright (c) 2017 Uber Technologies, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-package internal // import "go.opentelemetry.io/collector/exporter/exporterhelper/internal"
+package queue // import "go.opentelemetry.io/collector/exporter/internal/queue"
 
 import (
 	"context"

--- a/exporter/internal/queue/queue_capacity.go
+++ b/exporter/internal/queue/queue_capacity.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package internal // import "go.opentelemetry.io/collector/exporter/exporterhelper/internal"
+package queue // import "go.opentelemetry.io/collector/exporter/internal/queue"
 
 import (
 	"sync/atomic"

--- a/exporter/internal/queue/queue_capacity_test.go
+++ b/exporter/internal/queue/queue_capacity_test.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package internal
+package queue
 
 import (
 	"testing"


### PR DESCRIPTION
Introduce a way to enable queue in the new exporter helper with a developer interface suggested in https://github.com/open-telemetry/opentelemetry-collector/pull/8248#discussion_r1302102261. 

The new configuration interface for the end users provides a new `queue_size_items` option to limit the queue by a number of spans, log records, or metric data points. The previous way to limit the queue by number of requests is preserved under the same field, `queue_size,` which will later be deprecated through a longer transition process.

Tracking issue: https://github.com/open-telemetry/opentelemetry-collector/issues/8122