### PR TITLE
[exporterhelper] Remove redundant request interfaces

### DIFF
--- a/.chloggen/update-eperimental-request-api.yaml
+++ b/.chloggen/update-eperimental-request-api.yaml
@@ -1,0 +1,30 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: exporter/exporterhelper
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: The experimental Request API is updated and moved to a separate package.
+
+# One or more tracking issues or pull requests related to the change
+issues: [7874]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  - The experimental `Request` interface is moved from exporter/exporterhelper to exporter/exporterhelper/request 
+    package and updated to include ItemsCount() method.
+  - `RequestItemsCounter` is removed.
+  - Added the following APIs to exporter/exporterhelper/request package:
+    - request.ErrorHandler: an optional interface for handling errors that occur during request processing.
+    - request.Marshaler: a function that can marshal a Request into bytes.
+    - request.Unmarshaler: a function that can unmarshal bytes into a Request
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/exporter/exporterhelper/common_test.go
+++ b/exporter/exporterhelper/common_test.go
@@ -91,7 +91,7 @@ func TestBaseExporterLogging(t *testing.T) {
 	bs, err := newBaseExporter(set, "", true, nil, nil, newNoopObsrepSender, WithRetry(rCfg))
 	require.Nil(t, err)
 	require.True(t, bs.requestExporter)
-	sendErr := bs.send(newErrorRequest(context.Background()))
+	sendErr := bs.send(context.Background(), newErrorRequest())
 	require.Error(t, sendErr)
 
 	require.Len(t, observed.FilterLevelExact(zap.ErrorLevel).All(), 1)

--- a/exporter/exporterhelper/internal/bounded_memory_queue_test.go
+++ b/exporter/exporterhelper/internal/bounded_memory_queue_test.go
@@ -21,19 +21,18 @@ import (
 	"go.opentelemetry.io/collector/component/componenttest"
 )
 
-func newNopQueueSettings(callback func(item Request)) QueueSettings {
+func newNopQueueSettings(callback func(any)) QueueSettings {
 	return QueueSettings{
 		DataType: component.DataTypeMetrics,
-		Callback: callback,
+		Callback: func(item QueueRequest) { callback(item.Request) },
 	}
 }
 
 type stringRequest struct {
-	Request
 	str string
 }
 
-func newStringRequest(str string) Request {
+func newStringRequest(str string) stringRequest {
 	return stringRequest{str: str}
 }
 
@@ -48,7 +47,7 @@ func TestBoundedQueue(t *testing.T) {
 	startLock.Lock() // block consumers
 	consumerState := newConsumerState(t)
 
-	assert.NoError(t, q.Start(context.Background(), componenttest.NewNopHost(), newNopQueueSettings(func(item Request) {
+	assert.NoError(t, q.Start(context.Background(), componenttest.NewNopHost(), newNopQueueSettings(func(item any) {
 		consumerState.record(item.(stringRequest).str)
 
 		// block further processing until startLock is released
@@ -57,7 +56,7 @@ func TestBoundedQueue(t *testing.T) {
 		startLock.Unlock()
 	})))
 
-	assert.True(t, q.Produce(newStringRequest("a")))
+	assert.True(t, q.Produce(context.Background(), newStringRequest("a")))
 
 	// at this point "a" may or may not have been received by the consumer go-routine
 	// so let's make sure it has been
@@ -70,10 +69,10 @@ func TestBoundedQueue(t *testing.T) {
 	})
 
 	// produce two more items. The first one should be accepted, but not consumed.
-	assert.True(t, q.Produce(newStringRequest("b")))
+	assert.True(t, q.Produce(context.Background(), newStringRequest("b")))
 	assert.Equal(t, 1, q.Size())
 	// the second should be rejected since the queue is full
-	assert.False(t, q.Produce(newStringRequest("c")))
+	assert.False(t, q.Produce(context.Background(), newStringRequest("c")))
 	assert.Equal(t, 1, q.Size())
 
 	startLock.Unlock() // unblock consumer
@@ -89,13 +88,13 @@ func TestBoundedQueue(t *testing.T) {
 		"b": true,
 	}
 	for _, item := range []string{"d", "e", "f"} {
-		assert.True(t, q.Produce(newStringRequest(item)))
+		assert.True(t, q.Produce(context.Background(), newStringRequest(item)))
 		expected[item] = true
 		consumerState.assertConsumed(expected)
 	}
 
 	assert.NoError(t, q.Shutdown(context.Background()))
-	assert.False(t, q.Produce(newStringRequest("x")), "cannot push to closed queue")
+	assert.False(t, q.Produce(context.Background(), newStringRequest("x")), "cannot push to closed queue")
 }
 
 // In this test we run a queue with many items and a slow consumer.
@@ -109,25 +108,25 @@ func TestShutdownWhileNotEmpty(t *testing.T) {
 
 	consumerState := newConsumerState(t)
 
-	assert.NoError(t, q.Start(context.Background(), componenttest.NewNopHost(), newNopQueueSettings(func(item Request) {
+	assert.NoError(t, q.Start(context.Background(), componenttest.NewNopHost(), newNopQueueSettings(func(item any) {
 		consumerState.record(item.(stringRequest).str)
 		time.Sleep(1 * time.Second)
 	})))
 
-	q.Produce(newStringRequest("a"))
-	q.Produce(newStringRequest("b"))
-	q.Produce(newStringRequest("c"))
-	q.Produce(newStringRequest("d"))
-	q.Produce(newStringRequest("e"))
-	q.Produce(newStringRequest("f"))
-	q.Produce(newStringRequest("g"))
-	q.Produce(newStringRequest("h"))
-	q.Produce(newStringRequest("i"))
-	q.Produce(newStringRequest("j"))
+	q.Produce(context.Background(), newStringRequest("a"))
+	q.Produce(context.Background(), newStringRequest("b"))
+	q.Produce(context.Background(), newStringRequest("c"))
+	q.Produce(context.Background(), newStringRequest("d"))
+	q.Produce(context.Background(), newStringRequest("e"))
+	q.Produce(context.Background(), newStringRequest("f"))
+	q.Produce(context.Background(), newStringRequest("g"))
+	q.Produce(context.Background(), newStringRequest("h"))
+	q.Produce(context.Background(), newStringRequest("i"))
+	q.Produce(context.Background(), newStringRequest("j"))
 
 	assert.NoError(t, q.Shutdown(context.Background()))
 
-	assert.False(t, q.Produce(newStringRequest("x")), "cannot push to closed queue")
+	assert.False(t, q.Produce(context.Background(), newStringRequest("x")), "cannot push to closed queue")
 	consumerState.assertConsumed(map[string]bool{
 		"a": true,
 		"b": true,
@@ -189,12 +188,12 @@ func queueUsage(b *testing.B, capacity int, numConsumers int, numberOfItems int)
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		q := NewBoundedMemoryQueue(capacity, numConsumers)
-		err := q.Start(context.Background(), componenttest.NewNopHost(), newNopQueueSettings(func(item Request) {
+		err := q.Start(context.Background(), componenttest.NewNopHost(), newNopQueueSettings(func(item any) {
 			time.Sleep(1 * time.Millisecond)
 		}))
 		require.NoError(b, err)
 		for j := 0; j < numberOfItems; j++ {
-			q.Produce(newStringRequest(fmt.Sprintf("%d", j)))
+			q.Produce(context.Background(), newStringRequest(fmt.Sprintf("%d", j)))
 		}
 		assert.NoError(b, q.Shutdown(context.Background()))
 	}
@@ -248,10 +247,10 @@ func (s *consumerState) assertConsumed(expected map[string]bool) {
 func TestZeroSizeWithConsumers(t *testing.T) {
 	q := NewBoundedMemoryQueue(0, 1)
 
-	err := q.Start(context.Background(), componenttest.NewNopHost(), newNopQueueSettings(func(item Request) {}))
+	err := q.Start(context.Background(), componenttest.NewNopHost(), newNopQueueSettings(func(item any) {}))
 	assert.NoError(t, err)
 
-	assert.True(t, q.Produce(newStringRequest("a"))) // in process
+	assert.True(t, q.Produce(context.Background(), newStringRequest("a"))) // in process
 
 	assert.NoError(t, q.Shutdown(context.Background()))
 }
@@ -259,10 +258,10 @@ func TestZeroSizeWithConsumers(t *testing.T) {
 func TestZeroSizeNoConsumers(t *testing.T) {
 	q := NewBoundedMemoryQueue(0, 0)
 
-	err := q.Start(context.Background(), componenttest.NewNopHost(), newNopQueueSettings(func(item Request) {}))
+	err := q.Start(context.Background(), componenttest.NewNopHost(), newNopQueueSettings(func(item any) {}))
 	assert.NoError(t, err)
 
-	assert.False(t, q.Produce(newStringRequest("a"))) // in process
+	assert.False(t, q.Produce(context.Background(), newStringRequest("a"))) // in process
 
 	assert.NoError(t, q.Shutdown(context.Background()))
 }

--- a/exporter/exporterhelper/internal/persistent_queue.go
+++ b/exporter/exporterhelper/internal/persistent_queue.go
@@ -35,8 +35,8 @@ type persistentQueue struct {
 	storage      *persistentContiguousStorage
 	capacity     uint64
 	numConsumers int
-	marshaler    RequestMarshaler
-	unmarshaler  RequestUnmarshaler
+	marshaler    QueueRequestMarshaler
+	unmarshaler  QueueRequestUnmarshaler
 }
 
 // buildPersistentStorageName returns a name that is constructed out of queue name and signal type. This is done
@@ -46,8 +46,8 @@ func buildPersistentStorageName(name string, signal component.DataType) string {
 }
 
 // NewPersistentQueue creates a new queue backed by file storage; name and signal must be a unique combination that identifies the queue storage
-func NewPersistentQueue(capacity int, numConsumers int, storageID component.ID, marshaler RequestMarshaler,
-	unmarshaler RequestUnmarshaler, set exporter.CreateSettings) Queue {
+func NewPersistentQueue(capacity int, numConsumers int, storageID component.ID, marshaler QueueRequestMarshaler,
+	unmarshaler QueueRequestUnmarshaler, set exporter.CreateSettings) Queue {
 	return &persistentQueue{
 		capacity:     uint64(capacity),
 		numConsumers: numConsumers,
@@ -85,7 +85,8 @@ func (pq *persistentQueue) Start(ctx context.Context, host component.Host, set Q
 }
 
 // Produce adds an item to the queue and returns true if it was accepted
-func (pq *persistentQueue) Produce(item Request) bool {
+// Request context is currently ignored by the persistent queue.
+func (pq *persistentQueue) Produce(_ context.Context, item any) bool {
 	err := pq.storage.put(item)
 	return err == nil
 }

--- a/exporter/exporterhelper/internal/queue.go
+++ b/exporter/exporterhelper/internal/queue.go
@@ -13,7 +13,7 @@ import (
 
 type QueueSettings struct {
 	DataType component.DataType
-	Callback func(item Request)
+	Callback func(QueueRequest)
 }
 
 // Queue defines a producer-consumer exchange which can be backed by e.g. the memory-based ring buffer queue
@@ -24,7 +24,7 @@ type Queue interface {
 	Start(ctx context.Context, host component.Host, set QueueSettings) error
 	// Produce is used by the producer to submit new item to the queue. Returns false if the item wasn't added
 	// to the queue due to queue overflow.
-	Produce(item Request) bool
+	Produce(ctx context.Context, item any) bool
 	// Size returns the current Size of the queue
 	Size() int
 	// Shutdown stops accepting items, and stops all consumers. It blocks until all consumers have stopped.

--- a/exporter/exporterhelper/internal/request.go
+++ b/exporter/exporterhelper/internal/request.go
@@ -5,32 +5,27 @@ package internal // import "go.opentelemetry.io/collector/exporter/exporterhelpe
 
 import "context"
 
-// Request defines capabilities required for persistent storage of a request
-type Request interface {
-	// Context returns the context.Context of the requests.
-	Context() context.Context
-
-	// SetContext updates the context.Context of the requests.
-	SetContext(context.Context)
-
-	Export(ctx context.Context) error
-
-	// OnError returns a new Request may contain the items left to be sent if some items failed to process and can be retried.
-	// Otherwise, it should return the original Request.
-	OnError(error) Request
-
-	// Count returns the count of spans/metric points or log records.
-	Count() int
-
-	// OnProcessingFinished calls the optional callback function to handle cleanup after all processing is finished
-	OnProcessingFinished()
-
-	// SetOnProcessingFinished allows to set an optional callback function to do the cleanup (e.g. remove the item from persistent queue)
-	SetOnProcessingFinished(callback func())
+// QueueRequest defines a request coming through a queue.
+type QueueRequest struct {
+	Request                  any
+	Context                  context.Context
+	onProcessingFinishedFunc func()
 }
 
-// RequestUnmarshaler defines a function which takes a byte slice and unmarshals it into a relevant request
-type RequestUnmarshaler func([]byte) (Request, error)
+func newQueueRequest(ctx context.Context, req any) QueueRequest {
+	return QueueRequest{
+		Request: req,
+		Context: ctx,
+	}
+}
 
-// RequestMarshaler defines a function which takes a request and marshals it into a byte slice
-type RequestMarshaler func(Request) ([]byte, error)
+// OnProcessingFinished calls the optional callback function to handle cleanup after all processing is finished
+func (qr *QueueRequest) OnProcessingFinished() {
+	if qr.onProcessingFinishedFunc != nil {
+		qr.onProcessingFinishedFunc()
+	}
+}
+
+type QueueRequestMarshaler func(req any) ([]byte, error)
+
+type QueueRequestUnmarshaler func(data []byte) (any, error)

--- a/exporter/exporterhelper/logs.go
+++ b/exporter/exporterhelper/logs.go
@@ -13,7 +13,6 @@ import (
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/exporter"
-	"go.opentelemetry.io/collector/exporter/exporterhelper/internal"
 	"go.opentelemetry.io/collector/pdata/plog"
 )
 
@@ -21,37 +20,35 @@ var logsMarshaler = &plog.ProtoMarshaler{}
 var logsUnmarshaler = &plog.ProtoUnmarshaler{}
 
 type logsRequest struct {
-	baseRequest
 	ld     plog.Logs
 	pusher consumer.ConsumeLogsFunc
 }
 
-func newLogsRequest(ctx context.Context, ld plog.Logs, pusher consumer.ConsumeLogsFunc) internal.Request {
+func newLogsRequest(ld plog.Logs, pusher consumer.ConsumeLogsFunc) Request {
 	return &logsRequest{
-		baseRequest: baseRequest{ctx: ctx},
-		ld:          ld,
-		pusher:      pusher,
+		ld:     ld,
+		pusher: pusher,
 	}
 }
 
-func newLogsRequestUnmarshalerFunc(pusher consumer.ConsumeLogsFunc) internal.RequestUnmarshaler {
-	return func(bytes []byte) (internal.Request, error) {
+func newLogsRequestUnmarshalerFunc(pusher consumer.ConsumeLogsFunc) RequestUnmarshaler {
+	return func(bytes []byte) (Request, error) {
 		logs, err := logsUnmarshaler.UnmarshalLogs(bytes)
 		if err != nil {
 			return nil, err
 		}
-		return newLogsRequest(context.Background(), logs, pusher), nil
+		return newLogsRequest(logs, pusher), nil
 	}
 }
 
-func logsRequestMarshaler(req internal.Request) ([]byte, error) {
+func logsRequestMarshaler(req Request) ([]byte, error) {
 	return logsMarshaler.MarshalLogs(req.(*logsRequest).ld)
 }
 
-func (req *logsRequest) OnError(err error) internal.Request {
+func (req *logsRequest) OnError(err error) Request {
 	var logError consumererror.Logs
 	if errors.As(err, &logError) {
-		return newLogsRequest(req.ctx, logError.Data(), req.pusher)
+		return newLogsRequest(logError.Data(), req.pusher)
 	}
 	return req
 }
@@ -60,7 +57,7 @@ func (req *logsRequest) Export(ctx context.Context) error {
 	return req.pusher(ctx, req.ld)
 }
 
-func (req *logsRequest) Count() int {
+func (req *logsRequest) ItemsCount() int {
 	return req.ld.LogRecordCount()
 }
 
@@ -96,10 +93,10 @@ func NewLogsExporter(
 	}
 
 	lc, err := consumer.NewLogs(func(ctx context.Context, ld plog.Logs) error {
-		req := newLogsRequest(ctx, ld, pusher)
-		serr := be.send(req)
+		req := newLogsRequest(ld, pusher)
+		serr := be.send(ctx, req)
 		if errors.Is(serr, errSendingQueueIsFull) {
-			be.obsrep.recordEnqueueFailure(req.Context(), component.DataTypeLogs, int64(req.Count()))
+			be.obsrep.recordEnqueueFailure(ctx, component.DataTypeLogs, int64(req.ItemsCount()))
 		}
 		return serr
 	}, be.consumerOptions...)
@@ -148,10 +145,9 @@ func NewLogsRequestExporter(
 				zap.Error(err))
 			return consumererror.NewPermanent(cErr)
 		}
-		r := newRequest(ctx, req)
-		sErr := be.send(r)
+		sErr := be.send(ctx, req)
 		if errors.Is(sErr, errSendingQueueIsFull) {
-			be.obsrep.recordEnqueueFailure(r.Context(), component.DataTypeLogs, int64(r.Count()))
+			be.obsrep.recordEnqueueFailure(ctx, component.DataTypeLogs, int64(req.ItemsCount()))
 		}
 		return sErr
 	}, be.consumerOptions...)
@@ -171,9 +167,9 @@ func newLogsExporterWithObservability(obsrep *ObsReport) requestSender {
 	return &logsExporterWithObservability{obsrep: obsrep}
 }
 
-func (lewo *logsExporterWithObservability) send(req internal.Request) error {
-	req.SetContext(lewo.obsrep.StartLogsOp(req.Context()))
-	err := lewo.nextSender.send(req)
-	lewo.obsrep.EndLogsOp(req.Context(), req.Count(), err)
+func (lewo *logsExporterWithObservability) send(ctx context.Context, req Request) error {
+	c := lewo.obsrep.StartLogsOp(ctx)
+	err := lewo.nextSender.send(c, req)
+	lewo.obsrep.EndLogsOp(c, req.ItemsCount(), err)
 	return err
 }

--- a/exporter/exporterhelper/logs_test.go
+++ b/exporter/exporterhelper/logs_test.go
@@ -42,13 +42,13 @@ var (
 )
 
 func TestLogsRequest(t *testing.T) {
-	lr := newLogsRequest(context.Background(), testdata.GenerateLogs(1), nil)
+	lr := newLogsRequest(testdata.GenerateLogs(1), nil)
 
 	logErr := consumererror.NewLogs(errors.New("some error"), plog.NewLogs())
 	assert.EqualValues(
 		t,
-		newLogsRequest(context.Background(), plog.NewLogs(), nil),
-		lr.OnError(logErr),
+		newLogsRequest(plog.NewLogs(), nil),
+		lr.(RequestErrorHandler).OnError(logErr),
 	)
 }
 

--- a/exporter/exporterhelper/metrics.go
+++ b/exporter/exporterhelper/metrics.go
@@ -13,7 +13,6 @@ import (
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/exporter"
-	"go.opentelemetry.io/collector/exporter/exporterhelper/internal"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 )
 
@@ -21,37 +20,35 @@ var metricsMarshaler = &pmetric.ProtoMarshaler{}
 var metricsUnmarshaler = &pmetric.ProtoUnmarshaler{}
 
 type metricsRequest struct {
-	baseRequest
 	md     pmetric.Metrics
 	pusher consumer.ConsumeMetricsFunc
 }
 
-func newMetricsRequest(ctx context.Context, md pmetric.Metrics, pusher consumer.ConsumeMetricsFunc) internal.Request {
+func newMetricsRequest(md pmetric.Metrics, pusher consumer.ConsumeMetricsFunc) Request {
 	return &metricsRequest{
-		baseRequest: baseRequest{ctx: ctx},
-		md:          md,
-		pusher:      pusher,
+		md:     md,
+		pusher: pusher,
 	}
 }
 
-func newMetricsRequestUnmarshalerFunc(pusher consumer.ConsumeMetricsFunc) internal.RequestUnmarshaler {
-	return func(bytes []byte) (internal.Request, error) {
+func newMetricsRequestUnmarshalerFunc(pusher consumer.ConsumeMetricsFunc) RequestUnmarshaler {
+	return func(bytes []byte) (Request, error) {
 		metrics, err := metricsUnmarshaler.UnmarshalMetrics(bytes)
 		if err != nil {
 			return nil, err
 		}
-		return newMetricsRequest(context.Background(), metrics, pusher), nil
+		return newMetricsRequest(metrics, pusher), nil
 	}
 }
 
-func metricsRequestMarshaler(req internal.Request) ([]byte, error) {
+func metricsRequestMarshaler(req Request) ([]byte, error) {
 	return metricsMarshaler.MarshalMetrics(req.(*metricsRequest).md)
 }
 
-func (req *metricsRequest) OnError(err error) internal.Request {
+func (req *metricsRequest) OnError(err error) Request {
 	var metricsError consumererror.Metrics
 	if errors.As(err, &metricsError) {
-		return newMetricsRequest(req.ctx, metricsError.Data(), req.pusher)
+		return newMetricsRequest(metricsError.Data(), req.pusher)
 	}
 	return req
 }
@@ -60,7 +57,7 @@ func (req *metricsRequest) Export(ctx context.Context) error {
 	return req.pusher(ctx, req.md)
 }
 
-func (req *metricsRequest) Count() int {
+func (req *metricsRequest) ItemsCount() int {
 	return req.md.DataPointCount()
 }
 
@@ -96,10 +93,10 @@ func NewMetricsExporter(
 	}
 
 	mc, err := consumer.NewMetrics(func(ctx context.Context, md pmetric.Metrics) error {
-		req := newMetricsRequest(ctx, md, pusher)
-		serr := be.send(req)
+		req := newMetricsRequest(md, pusher)
+		serr := be.send(ctx, req)
 		if errors.Is(serr, errSendingQueueIsFull) {
-			be.obsrep.recordEnqueueFailure(req.Context(), component.DataTypeMetrics, int64(req.Count()))
+			be.obsrep.recordEnqueueFailure(ctx, component.DataTypeMetrics, int64(req.ItemsCount()))
 		}
 		return serr
 	}, be.consumerOptions...)
@@ -148,10 +145,9 @@ func NewMetricsRequestExporter(
 				zap.Error(err))
 			return consumererror.NewPermanent(cErr)
 		}
-		r := newRequest(ctx, req)
-		sErr := be.send(r)
+		sErr := be.send(ctx, req)
 		if errors.Is(sErr, errSendingQueueIsFull) {
-			be.obsrep.recordEnqueueFailure(r.Context(), component.DataTypeMetrics, int64(r.Count()))
+			be.obsrep.recordEnqueueFailure(ctx, component.DataTypeMetrics, int64(req.ItemsCount()))
 		}
 		return sErr
 	}, be.consumerOptions...)
@@ -171,9 +167,9 @@ func newMetricsSenderWithObservability(obsrep *ObsReport) requestSender {
 	return &metricsSenderWithObservability{obsrep: obsrep}
 }
 
-func (mewo *metricsSenderWithObservability) send(req internal.Request) error {
-	req.SetContext(mewo.obsrep.StartMetricsOp(req.Context()))
-	err := mewo.nextSender.send(req)
-	mewo.obsrep.EndMetricsOp(req.Context(), req.Count(), err)
+func (mewo *metricsSenderWithObservability) send(ctx context.Context, req Request) error {
+	c := mewo.obsrep.StartMetricsOp(ctx)
+	err := mewo.nextSender.send(c, req)
+	mewo.obsrep.EndMetricsOp(c, req.ItemsCount(), err)
 	return err
 }

--- a/exporter/exporterhelper/metrics_test.go
+++ b/exporter/exporterhelper/metrics_test.go
@@ -42,13 +42,13 @@ var (
 )
 
 func TestMetricsRequest(t *testing.T) {
-	mr := newMetricsRequest(context.Background(), testdata.GenerateMetrics(1), nil)
+	mr := newMetricsRequest(testdata.GenerateMetrics(1), nil)
 
 	metricsErr := consumererror.NewMetrics(errors.New("some error"), pmetric.NewMetrics())
 	assert.EqualValues(
 		t,
-		newMetricsRequest(context.Background(), pmetric.NewMetrics(), nil),
-		mr.OnError(metricsErr),
+		newMetricsRequest(pmetric.NewMetrics(), nil),
+		mr.(RequestErrorHandler).OnError(metricsErr),
 	)
 }
 

--- a/exporter/exporterhelper/queue_sender_test.go
+++ b/exporter/exporterhelper/queue_sender_test.go
@@ -34,17 +34,17 @@ func TestQueuedRetry_StopWhileWaiting(t *testing.T) {
 	ocs := be.obsrepSender.(*observabilityConsumerSender)
 	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
 
-	firstMockR := newErrorRequest(context.Background())
+	firstMockR := newErrorRequest()
 	ocs.run(func() {
 		// This is asynchronous so it should just enqueue, no errors expected.
-		require.NoError(t, be.send(firstMockR))
+		require.NoError(t, be.send(context.Background(), firstMockR))
 	})
 
 	// Enqueue another request to ensure when calling shutdown we drain the queue.
-	secondMockR := newMockRequest(context.Background(), 3, nil)
+	secondMockR := newMockRequest(3, nil)
 	ocs.run(func() {
 		// This is asynchronous so it should just enqueue, no errors expected.
-		require.NoError(t, be.send(secondMockR))
+		require.NoError(t, be.send(context.Background(), secondMockR))
 	})
 
 	require.LessOrEqual(t, 1, be.queueSender.(*queueSender).queue.Size())
@@ -71,10 +71,10 @@ func TestQueuedRetry_DoNotPreserveCancellation(t *testing.T) {
 
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	cancelFunc()
-	mockR := newMockRequest(ctx, 2, nil)
+	mockR := newMockRequest(2, nil)
 	ocs.run(func() {
 		// This is asynchronous so it should just enqueue, no errors expected.
-		require.NoError(t, be.send(mockR))
+		require.NoError(t, be.send(ctx, mockR))
 	})
 	ocs.awaitAsyncProcessing()
 
@@ -94,7 +94,7 @@ func TestQueuedRetry_DropOnFull(t *testing.T) {
 	t.Cleanup(func() {
 		assert.NoError(t, be.Shutdown(context.Background()))
 	})
-	require.Error(t, be.send(newMockRequest(context.Background(), 2, nil)))
+	require.Error(t, be.send(context.Background(), newMockRequest(2, nil)))
 }
 
 func TestQueuedRetryHappyPath(t *testing.T) {
@@ -117,9 +117,9 @@ func TestQueuedRetryHappyPath(t *testing.T) {
 	reqs := make([]*mockRequest, 0, 10)
 	for i := 0; i < wantRequests; i++ {
 		ocs.run(func() {
-			req := newMockRequest(context.Background(), 2, nil)
+			req := newMockRequest(2, nil)
 			reqs = append(reqs, req)
-			require.NoError(t, be.send(req))
+			require.NoError(t, be.send(context.Background(), req))
 		})
 	}
 
@@ -158,7 +158,7 @@ func TestQueuedRetry_QueueMetricsReported(t *testing.T) {
 
 	checkValueForGlobalManager(t, defaultExporterTags, int64(defaultQueueSize), "exporter/queue_capacity")
 	for i := 0; i < 7; i++ {
-		require.NoError(t, be.send(newErrorRequest(context.Background())))
+		require.NoError(t, be.send(context.Background(), newErrorRequest()))
 	}
 	checkValueForGlobalManager(t, defaultExporterTags, int64(7), "exporter/queue_size")
 
@@ -184,7 +184,7 @@ func TestQueuedRetry_QueueMetricsReportedUsingOTel(t *testing.T) {
 	require.NoError(t, tt.CheckExporterMetricGauge("exporter_queue_capacity", int64(defaultQueueSize)))
 
 	for i := 0; i < 7; i++ {
-		require.NoError(t, be.send(newErrorRequest(context.Background())))
+		require.NoError(t, be.send(context.Background(), newErrorRequest()))
 	}
 	require.NoError(t, tt.CheckExporterMetricGauge("exporter_queue_size", int64(7)))
 
@@ -240,10 +240,10 @@ func TestQueuedRetry_RequeuingEnabled(t *testing.T) {
 	})
 
 	traceErr := consumererror.NewTraces(errors.New("some error"), testdata.GenerateTraces(1))
-	mockR := newMockRequest(context.Background(), 1, traceErr)
+	mockR := newMockRequest(1, traceErr)
 	ocs.run(func() {
 		// This is asynchronous so it should just enqueue, no errors expected.
-		require.NoError(t, be.send(mockR))
+		require.NoError(t, be.send(context.Background(), mockR))
 		ocs.waitGroup.Add(1) // necessary because we'll call send() again after requeueing
 	})
 	ocs.awaitAsyncProcessing()
@@ -270,11 +270,11 @@ func TestQueuedRetry_RequeuingEnabledQueueFull(t *testing.T) {
 	})
 
 	traceErr := consumererror.NewTraces(errors.New("some error"), testdata.GenerateTraces(1))
-	mockR := newMockRequest(context.Background(), 1, traceErr)
+	mockR := newMockRequest(1, traceErr)
 
 	ocs := be.obsrepSender.(*observabilityConsumerSender)
 	ocs.run(func() {
-		require.Error(t, be.retrySender.send(mockR), "sending_queue is full")
+		require.Error(t, be.retrySender.send(context.Background(), mockR), "sending_queue is full")
 	})
 	mockR.checkNumRequests(t, 1)
 }
@@ -287,9 +287,9 @@ func TestQueueRetryWithDisabledQueue(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
 	ocs := be.obsrepSender.(*observabilityConsumerSender)
-	mockR := newMockRequest(context.Background(), 2, errors.New("some error"))
+	mockR := newMockRequest(2, errors.New("some error"))
 	ocs.run(func() {
-		require.Error(t, be.send(mockR))
+		require.Error(t, be.send(context.Background(), mockR))
 	})
 	ocs.awaitAsyncProcessing()
 	mockR.checkNumRequests(t, 1)
@@ -367,7 +367,7 @@ func TestQueuedRetryPersistentEnabled_shutdown_dataIsRequeued(t *testing.T) {
 	be.queueSender.(*queueSender).requeuingEnabled = true
 
 	// Invoke queuedRetrySender so the producer will put the item for consumer to poll
-	require.NoError(t, be.send(newErrorRequest(context.Background())))
+	require.NoError(t, be.send(context.Background(), newErrorRequest()))
 
 	// first wait for the item to be produced to the queue initially
 	assert.Eventually(t, func() bool {

--- a/exporter/exporterhelper/request.go
+++ b/exporter/exporterhelper/request.go
@@ -5,8 +5,6 @@ package exporterhelper // import "go.opentelemetry.io/collector/exporter/exporte
 
 import (
 	"context"
-
-	"go.opentelemetry.io/collector/exporter/exporterhelper/internal"
 )
 
 // Request represents a single request that can be sent to an external endpoint.
@@ -15,47 +13,31 @@ import (
 type Request interface {
 	// Export exports the request to an external endpoint.
 	Export(ctx context.Context) error
-}
-
-// RequestItemsCounter is an optional interface that can be implemented by Request to provide a number of items
-// in the request. This is a recommended interface to implement for exporters. It is required for batching and queueing
-// based on number of items. Also, it's used for reporting number of items in collector's logs, metrics and traces.
-// If not implemented, collector's logs, metrics and traces will report 0 items.
-// This API is at the early stage of development and may change without backward compatibility
-// until https://github.com/open-telemetry/opentelemetry-collector/issues/8122 is resolved.
-type RequestItemsCounter interface {
 	// ItemsCount returns a number of basic items in the request where item is the smallest piece of data that can be
 	// sent. For example, for OTLP exporter, this value represents the number of spans,
 	// metric data points or log records.
 	ItemsCount() int
 }
 
-type request struct {
+// RequestErrorHandler is an optional interface that can be implemented by Request to provide a way handle partial
+// temporary failures. For example, if some items failed to process and can be retried, this interface allows to
+// return a new Request that contains the items left to be sent. Otherwise, the original Request should be returned.
+// If not implemented, the original Request will be returned assuming the error is applied to the whole Request.
+// This API is at the early stage of development and may change without backward compatibility
+// until https://github.com/open-telemetry/opentelemetry-collector/issues/8122 is resolved.
+type RequestErrorHandler interface {
 	Request
-	baseRequest
+	// OnError returns a new Request may contain the items left to be sent if some items failed to process and can be retried.
+	// Otherwise, it should return the original Request.
+	OnError(error) Request
 }
 
-var _ internal.Request = (*request)(nil)
+// RequestMarshaler is a function that can marshal a Request into bytes.
+// This API is at the early stage of development and may change without backward compatibility
+// until https://github.com/open-telemetry/opentelemetry-collector/issues/8122 is resolved.
+type RequestMarshaler func(req Request) ([]byte, error)
 
-func newRequest(ctx context.Context, req Request) *request {
-	return &request{
-		Request:     req,
-		baseRequest: baseRequest{ctx: ctx},
-	}
-}
-
-func (req *request) OnError(_ error) internal.Request {
-	// Potentially we could introduce a new RequestError type that would represent partially succeeded request.
-	// In that case we should consider returning them back to the pipeline converted back to pdata in case if
-	// sending queue is disabled. We leave it as a future improvement if decided that it's needed.
-	return req
-}
-
-// Count returns a number of items in the request. If the request does not implement RequestItemsCounter
-// then 0 is returned.
-func (req *request) Count() int {
-	if counter, ok := req.Request.(RequestItemsCounter); ok {
-		return counter.ItemsCount()
-	}
-	return 0
-}
+// RequestUnmarshaler is a function that can unmarshal bytes into a Request.
+// This API is at the early stage of development and may change without backward compatibility
+// until https://github.com/open-telemetry/opentelemetry-collector/issues/8122 is resolved.
+type RequestUnmarshaler func(data []byte) (Request, error)

--- a/exporter/exporterhelper/retry_sender.go
+++ b/exporter/exporterhelper/retry_sender.go
@@ -16,7 +16,6 @@ import (
 
 	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/exporter"
-	"go.opentelemetry.io/collector/exporter/exporterhelper/internal"
 	"go.opentelemetry.io/collector/internal/obsreportconfig/obsmetrics"
 )
 
@@ -74,7 +73,7 @@ func NewThrottleRetry(err error, delay time.Duration) error {
 	}
 }
 
-type onRequestHandlingFinishedFunc func(*zap.Logger, internal.Request, error) error
+type onRequestHandlingFinishedFunc func(context.Context, Request, error, *zap.Logger) error
 
 type retrySender struct {
 	baseRequestSender
@@ -87,7 +86,7 @@ type retrySender struct {
 
 func newRetrySender(config RetrySettings, set exporter.CreateSettings, onTemporaryFailure onRequestHandlingFinishedFunc) *retrySender {
 	if onTemporaryFailure == nil {
-		onTemporaryFailure = func(logger *zap.Logger, req internal.Request, err error) error {
+		onTemporaryFailure = func(_ context.Context, _ Request, err error, _ *zap.Logger) error {
 			return err
 		}
 	}
@@ -106,7 +105,7 @@ func (rs *retrySender) Shutdown(context.Context) error {
 }
 
 // send implements the requestSender interface
-func (rs *retrySender) send(req internal.Request) error {
+func (rs *retrySender) send(ctx context.Context, req Request) error {
 	// Do not use NewExponentialBackOff since it calls Reset and the code here must
 	// call Reset after changing the InitialInterval (this saves an unnecessary call to Now).
 	expBackoff := backoff.ExponentialBackOff{
@@ -119,14 +118,14 @@ func (rs *retrySender) send(req internal.Request) error {
 		Clock:               backoff.SystemClock,
 	}
 	expBackoff.Reset()
-	span := trace.SpanFromContext(req.Context())
+	span := trace.SpanFromContext(ctx)
 	retryNum := int64(0)
 	for {
 		span.AddEvent(
 			"Sending request.",
 			trace.WithAttributes(rs.traceAttribute, attribute.Int64("retry_num", retryNum)))
 
-		err := rs.nextSender.send(req)
+		err := rs.nextSender.send(ctx, req)
 		if err == nil {
 			return nil
 		}
@@ -136,20 +135,22 @@ func (rs *retrySender) send(req internal.Request) error {
 			rs.logger.Error(
 				"Exporting failed. The error is not retryable. Dropping data.",
 				zap.Error(err),
-				zap.Int("dropped_items", req.Count()),
+				zap.Int("dropped_items", req.ItemsCount()),
 			)
 			return err
 		}
 
 		// Give the request a chance to extract signal data to retry if only some data
 		// failed to process.
-		req = req.OnError(err)
+		if errReq, ok := req.(RequestErrorHandler); ok {
+			req = errReq.OnError(err)
+		}
 
 		backoffDelay := expBackoff.NextBackOff()
 		if backoffDelay == backoff.Stop {
 			// throw away the batch
 			err = fmt.Errorf("max elapsed time expired %w", err)
-			return rs.onTemporaryFailure(rs.logger, req, err)
+			return rs.onTemporaryFailure(ctx, req, err, rs.logger)
 		}
 
 		throttleErr := throttleRetry{}
@@ -174,10 +175,10 @@ func (rs *retrySender) send(req internal.Request) error {
 
 		// back-off, but get interrupted when shutting down or request is cancelled or timed out.
 		select {
-		case <-req.Context().Done():
-			return fmt.Errorf("request is cancelled or timed out %w", err)
+		case <-ctx.Done():
+			return fmt.Errorf("Request is cancelled or timed out %w", err)
 		case <-rs.stopCh:
-			return rs.onTemporaryFailure(rs.logger, req, fmt.Errorf("interrupted due to shutdown %w", err))
+			return rs.onTemporaryFailure(ctx, req, fmt.Errorf("interrupted due to shutdown %w", err), rs.logger)
 		case <-time.After(backoffDelay):
 		}
 	}

--- a/exporter/exporterhelper/retry_sender_test.go
+++ b/exporter/exporterhelper/retry_sender_test.go
@@ -26,20 +26,20 @@ import (
 	"go.opentelemetry.io/collector/internal/testdata"
 )
 
-func mockRequestUnmarshaler(mr *mockRequest) internal.RequestUnmarshaler {
-	return func(bytes []byte) (internal.Request, error) {
+func mockRequestUnmarshaler(mr *mockRequest) RequestUnmarshaler {
+	return func(bytes []byte) (Request, error) {
 		return mr, nil
 	}
 }
 
-func mockRequestMarshaler(_ internal.Request) ([]byte, error) {
+func mockRequestMarshaler(_ Request) ([]byte, error) {
 	return nil, nil
 }
 
 func TestQueuedRetry_DropOnPermanentError(t *testing.T) {
 	qCfg := NewDefaultQueueSettings()
 	rCfg := NewDefaultRetrySettings()
-	mockR := newMockRequest(context.Background(), 2, consumererror.NewPermanent(errors.New("bad data")))
+	mockR := newMockRequest(2, consumererror.NewPermanent(errors.New("bad data")))
 	be, err := newBaseExporter(defaultSettings, "", false, nil, nil, newObservabilityConsumerSender, WithRetry(rCfg), WithQueue(qCfg))
 	require.NoError(t, err)
 	ocs := be.obsrepSender.(*observabilityConsumerSender)
@@ -50,7 +50,7 @@ func TestQueuedRetry_DropOnPermanentError(t *testing.T) {
 
 	ocs.run(func() {
 		// This is asynchronous so it should just enqueue, no errors expected.
-		require.NoError(t, be.send(mockR))
+		require.NoError(t, be.send(context.Background(), mockR))
 	})
 	ocs.awaitAsyncProcessing()
 	// In the newMockConcurrentExporter we count requests and items even for failed requests
@@ -64,7 +64,7 @@ func TestQueuedRetry_DropOnNoRetry(t *testing.T) {
 	rCfg := NewDefaultRetrySettings()
 	rCfg.Enabled = false
 	be, err := newBaseExporter(defaultSettings, "", false, mockRequestMarshaler,
-		mockRequestUnmarshaler(newMockRequest(context.Background(), 2, errors.New("transient error"))),
+		mockRequestUnmarshaler(newMockRequest(2, errors.New("transient error"))),
 		newObservabilityConsumerSender, WithRetry(rCfg), WithQueue(qCfg))
 	require.NoError(t, err)
 	ocs := be.obsrepSender.(*observabilityConsumerSender)
@@ -73,10 +73,10 @@ func TestQueuedRetry_DropOnNoRetry(t *testing.T) {
 		assert.NoError(t, be.Shutdown(context.Background()))
 	})
 
-	mockR := newMockRequest(context.Background(), 2, errors.New("transient error"))
+	mockR := newMockRequest(2, errors.New("transient error"))
 	ocs.run(func() {
 		// This is asynchronous so it should just enqueue, no errors expected.
-		require.NoError(t, be.send(mockR))
+		require.NoError(t, be.send(context.Background(), mockR))
 	})
 	ocs.awaitAsyncProcessing()
 	// In the newMockConcurrentExporter we count requests and items even for failed requests
@@ -98,11 +98,11 @@ func TestQueuedRetry_OnError(t *testing.T) {
 	})
 
 	traceErr := consumererror.NewTraces(errors.New("some error"), testdata.GenerateTraces(1))
-	mockR := newMockRequest(context.Background(), 2, traceErr)
+	mockR := newMockRequest(2, traceErr)
 	ocs := be.obsrepSender.(*observabilityConsumerSender)
 	ocs.run(func() {
 		// This is asynchronous so it should just enqueue, no errors expected.
-		require.NoError(t, be.send(mockR))
+		require.NoError(t, be.send(context.Background(), mockR))
 	})
 	ocs.awaitAsyncProcessing()
 
@@ -128,14 +128,14 @@ func TestQueuedRetry_MaxElapsedTime(t *testing.T) {
 
 	ocs.run(func() {
 		// Add an item that will always fail.
-		require.NoError(t, be.send(newErrorRequest(context.Background())))
+		require.NoError(t, be.send(context.Background(), newErrorRequest()))
 	})
 
-	mockR := newMockRequest(context.Background(), 2, nil)
+	mockR := newMockRequest(2, nil)
 	start := time.Now()
 	ocs.run(func() {
 		// This is asynchronous so it should just enqueue, no errors expected.
-		require.NoError(t, be.send(mockR))
+		require.NoError(t, be.send(context.Background(), mockR))
 	})
 	ocs.awaitAsyncProcessing()
 
@@ -173,11 +173,11 @@ func TestQueuedRetry_ThrottleError(t *testing.T) {
 	})
 
 	retry := NewThrottleRetry(errors.New("throttle error"), 100*time.Millisecond)
-	mockR := newMockRequest(context.Background(), 2, wrappedError{retry})
+	mockR := newMockRequest(2, wrappedError{retry})
 	start := time.Now()
 	ocs.run(func() {
 		// This is asynchronous so it should just enqueue, no errors expected.
-		require.NoError(t, be.send(mockR))
+		require.NoError(t, be.send(context.Background(), mockR))
 	})
 	ocs.awaitAsyncProcessing()
 
@@ -204,10 +204,10 @@ func TestQueuedRetry_RetryOnError(t *testing.T) {
 		assert.NoError(t, be.Shutdown(context.Background()))
 	})
 
-	mockR := newMockRequest(context.Background(), 2, errors.New("transient error"))
+	mockR := newMockRequest(2, errors.New("transient error"))
 	ocs.run(func() {
 		// This is asynchronous so it should just enqueue, no errors expected.
-		require.NoError(t, be.send(mockR))
+		require.NoError(t, be.send(context.Background(), mockR))
 	})
 	ocs.awaitAsyncProcessing()
 
@@ -225,9 +225,9 @@ func TestQueueRetryWithNoQueue(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
 	ocs := be.obsrepSender.(*observabilityConsumerSender)
-	mockR := newMockRequest(context.Background(), 2, errors.New("some error"))
+	mockR := newMockRequest(2, errors.New("some error"))
 	ocs.run(func() {
-		require.Error(t, be.send(mockR))
+		require.Error(t, be.send(context.Background(), mockR))
 	})
 	ocs.awaitAsyncProcessing()
 	mockR.checkNumRequests(t, 1)
@@ -244,9 +244,9 @@ func TestQueueRetryWithDisabledRetires(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, be.Start(context.Background(), componenttest.NewNopHost()))
 	ocs := be.obsrepSender.(*observabilityConsumerSender)
-	mockR := newMockRequest(context.Background(), 2, errors.New("some error"))
+	mockR := newMockRequest(2, errors.New("some error"))
 	ocs.run(func() {
-		require.Error(t, be.send(mockR))
+		require.Error(t, be.send(context.Background(), mockR))
 	})
 	ocs.awaitAsyncProcessing()
 	mockR.checkNumRequests(t, 1)
@@ -255,30 +255,25 @@ func TestQueueRetryWithDisabledRetires(t *testing.T) {
 	require.NoError(t, be.Shutdown(context.Background()))
 }
 
-type mockErrorRequest struct {
-	baseRequest
-}
+type mockErrorRequest struct{}
 
 func (mer *mockErrorRequest) Export(_ context.Context) error {
 	return errors.New("transient error")
 }
 
-func (mer *mockErrorRequest) OnError(error) internal.Request {
+func (mer *mockErrorRequest) OnError(error) Request {
 	return mer
 }
 
-func (mer *mockErrorRequest) Count() int {
+func (mer *mockErrorRequest) ItemsCount() int {
 	return 7
 }
 
-func newErrorRequest(ctx context.Context) internal.Request {
-	return &mockErrorRequest{
-		baseRequest: baseRequest{ctx: ctx},
-	}
+func newErrorRequest() Request {
+	return &mockErrorRequest{}
 }
 
 type mockRequest struct {
-	baseRequest
 	cnt          int
 	mu           sync.Mutex
 	consumeError error
@@ -298,9 +293,8 @@ func (m *mockRequest) Export(ctx context.Context) error {
 	return ctx.Err()
 }
 
-func (m *mockRequest) OnError(error) internal.Request {
+func (m *mockRequest) OnError(error) Request {
 	return &mockRequest{
-		baseRequest:  m.baseRequest,
 		cnt:          1,
 		consumeError: nil,
 		requestCount: m.requestCount,
@@ -313,13 +307,12 @@ func (m *mockRequest) checkNumRequests(t *testing.T, want int) {
 	}, time.Second, 1*time.Millisecond)
 }
 
-func (m *mockRequest) Count() int {
+func (m *mockRequest) ItemsCount() int {
 	return m.cnt
 }
 
-func newMockRequest(ctx context.Context, cnt int, consumeError error) *mockRequest {
+func newMockRequest(cnt int, consumeError error) *mockRequest {
 	return &mockRequest{
-		baseRequest:  baseRequest{ctx: ctx},
 		cnt:          cnt,
 		consumeError: consumeError,
 		requestCount: &atomic.Int64{},
@@ -341,12 +334,12 @@ func newObservabilityConsumerSender(_ *ObsReport) requestSender {
 	}
 }
 
-func (ocs *observabilityConsumerSender) send(req internal.Request) error {
-	err := ocs.nextSender.send(req)
+func (ocs *observabilityConsumerSender) send(ctx context.Context, req Request) error {
+	err := ocs.nextSender.send(ctx, req)
 	if err != nil {
-		ocs.droppedItemsCount.Add(int64(req.Count()))
+		ocs.droppedItemsCount.Add(int64(req.ItemsCount()))
 	} else {
-		ocs.sentItemsCount.Add(int64(req.Count()))
+		ocs.sentItemsCount.Add(int64(req.ItemsCount()))
 	}
 	ocs.waitGroup.Done()
 	return err
@@ -418,7 +411,7 @@ type producerConsumerQueueWithCounter struct {
 	produceCounter *atomic.Uint32
 }
 
-func (pcq *producerConsumerQueueWithCounter) Produce(item internal.Request) bool {
+func (pcq *producerConsumerQueueWithCounter) Produce(ctx context.Context, item any) bool {
 	pcq.produceCounter.Add(1)
-	return pcq.Queue.Produce(item)
+	return pcq.Queue.Produce(ctx, item)
 }

--- a/exporter/exporterhelper/timeout_sender.go
+++ b/exporter/exporterhelper/timeout_sender.go
@@ -6,8 +6,6 @@ package exporterhelper // import "go.opentelemetry.io/collector/exporter/exporte
 import (
 	"context"
 	"time"
-
-	"go.opentelemetry.io/collector/exporter/exporterhelper/internal"
 )
 
 // TimeoutSettings for timeout. The timeout applies to individual attempts to send data to the backend.
@@ -29,13 +27,12 @@ type timeoutSender struct {
 	cfg TimeoutSettings
 }
 
-func (ts *timeoutSender) send(req internal.Request) error {
+func (ts *timeoutSender) send(ctx context.Context, req Request) error {
 	// Intentionally don't overwrite the context inside the request, because in case of retries deadline will not be
 	// updated because this deadline most likely is before the next one.
-	ctx := req.Context()
 	if ts.cfg.Timeout > 0 {
 		var cancelFunc func()
-		ctx, cancelFunc = context.WithTimeout(req.Context(), ts.cfg.Timeout)
+		ctx, cancelFunc = context.WithTimeout(ctx, ts.cfg.Timeout)
 		defer cancelFunc()
 	}
 	return req.Export(ctx)

--- a/exporter/exporterhelper/traces_test.go
+++ b/exporter/exporterhelper/traces_test.go
@@ -42,10 +42,10 @@ var (
 )
 
 func TestTracesRequest(t *testing.T) {
-	mr := newTracesRequest(context.Background(), testdata.GenerateTraces(1), nil)
+	mr := newTracesRequest(testdata.GenerateTraces(1), nil)
 
 	traceErr := consumererror.NewTraces(errors.New("some error"), ptrace.NewTraces())
-	assert.EqualValues(t, newTracesRequest(context.Background(), ptrace.NewTraces(), nil), mr.OnError(traceErr))
+	assert.EqualValues(t, newTracesRequest(ptrace.NewTraces(), nil), mr.(RequestErrorHandler).OnError(traceErr))
 }
 
 func TestTracesExporter_InvalidName(t *testing.T) {


### PR DESCRIPTION
Pass request+context through the senders pipeline similar to what we do in the collector's pipeline. Use a helper QueueRequest struct for passing requests through queues

This changes also moves the experimental Request interface to a separate package.