### PR TITLE
Metric is deprecated in v2 kube-state-metrics. Fixes #8835.

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -16,7 +16,7 @@ desired reliability level.
 ### Low on CPU Resources
 
 This depends on the CPU metrics available on the deployment, eg.:
-`kube_pod_container_resource_limits_cpu_cores` for Kubernetes. Let's call it
+`kube_pod_container_resource_limits{resource="cpu", unit="core"}` for Kubernetes. Let's call it
 `available_cores` below. The idea here is to have an upper bound of the number
 of available cores, and the maximum expected ingestion rate considered safe,
 let's call it `safe_rate`, per core. This should trigger increase of resources/


### PR DESCRIPTION
Documentation update.

**Link to tracking Issue:** #8835

