### PR TITLE
Do not add Logger field queue name, already configured

### DIFF
--- a/exporter/exporterhelper/internal/persistent_queue.go
+++ b/exporter/exporterhelper/internal/persistent_queue.go
@@ -6,7 +6,6 @@ package internal // import "go.opentelemetry.io/collector/exporter/exporterhelpe
 import (
 	"context"
 	"errors"
-	"fmt"
 	"sync"
 
 	"go.opentelemetry.io/collector/component"
@@ -39,12 +38,6 @@ type persistentQueue struct {
 	unmarshaler  QueueRequestUnmarshaler
 }
 
-// buildPersistentStorageName returns a name that is constructed out of queue name and signal type. This is done
-// to avoid conflicts between different signals, which require unique persistent storage name
-func buildPersistentStorageName(name string, signal component.DataType) string {
-	return fmt.Sprintf("%s-%s", name, signal)
-}
-
 // NewPersistentQueue creates a new queue backed by file storage; name and signal must be a unique combination that identifies the queue storage
 func NewPersistentQueue(capacity int, numConsumers int, storageID component.ID, marshaler QueueRequestMarshaler,
 	unmarshaler QueueRequestUnmarshaler, set exporter.CreateSettings) Queue {
@@ -65,8 +58,7 @@ func (pq *persistentQueue) Start(ctx context.Context, host component.Host, set Q
 	if err != nil {
 		return err
 	}
-	storageName := buildPersistentStorageName(pq.set.ID.Name(), set.DataType)
-	pq.storage = newPersistentContiguousStorage(ctx, storageName, storageClient, pq.set.Logger, pq.capacity, pq.marshaler, pq.unmarshaler)
+	pq.storage = newPersistentContiguousStorage(ctx, storageClient, pq.set.Logger, pq.capacity, pq.marshaler, pq.unmarshaler)
 	for i := 0; i < pq.numConsumers; i++ {
 		pq.stopWG.Add(1)
 		go func() {

--- a/exporter/exporterhelper/internal/persistent_storage.go
+++ b/exporter/exporterhelper/internal/persistent_storage.go
@@ -64,7 +64,6 @@ type itemIndex uint64
 
 const (
 	zapKey           = "key"
-	zapQueueNameKey  = "queueName"
 	zapErrorCount    = "errorCount"
 	zapNumberOfItems = "numberOfItems"
 
@@ -80,10 +79,10 @@ var (
 
 // newPersistentContiguousStorage creates a new file-storage extension backed queue;
 // queueName parameter must be a unique value that identifies the queue.
-func newPersistentContiguousStorage(ctx context.Context, queueName string, client storage.Client,
+func newPersistentContiguousStorage(ctx context.Context, client storage.Client,
 	logger *zap.Logger, capacity uint64, marshaler QueueRequestMarshaler, unmarshaler QueueRequestUnmarshaler) *persistentContiguousStorage {
 	pcs := &persistentContiguousStorage{
-		logger:      logger.With(zap.String(zapQueueNameKey, queueName)),
+		logger:      logger,
 		client:      client,
 		unmarshaler: unmarshaler,
 		marshaler:   marshaler,

--- a/exporter/exporterhelper/internal/persistent_storage_test.go
+++ b/exporter/exporterhelper/internal/persistent_storage_test.go
@@ -29,7 +29,7 @@ func createTestClient(t testing.TB, extension storage.Extension) storage.Client 
 }
 
 func createTestPersistentStorageWithCapacity(client storage.Client, capacity uint64) *persistentContiguousStorage {
-	return newPersistentContiguousStorage(context.Background(), "foo", client, zap.NewNop(), capacity,
+	return newPersistentContiguousStorage(context.Background(), client, zap.NewNop(), capacity,
 		newFakeTracesRequestMarshalerFunc(), newFakeTracesRequestUnmarshalerFunc())
 }
 


### PR DESCRIPTION
These data are already logger fields, see https://github.com/open-telemetry/opentelemetry-collector/blob/main/service/internal/components/loggers.go#L40

* ID is under `name`
* DataType is under `data_type`