### PR TITLE
[chore] [exporterhelper] Move workers from queue to queueSender

### DIFF
--- a/exporter/exporterhelper/internal/bounded_memory_queue.go
+++ b/exporter/exporterhelper/internal/bounded_memory_queue.go
@@ -7,7 +7,6 @@ package internal // import "go.opentelemetry.io/collector/exporter/exporterhelpe
 
 import (
 	"context"
-	"sync"
 	"sync/atomic"
 
 	"go.opentelemetry.io/collector/component"
@@ -17,41 +16,21 @@ import (
 // where the queue is bounded and if it fills up due to slow consumers, the new items written by
 // the producer are dropped.
 type boundedMemoryQueue[T any] struct {
-	stopWG       sync.WaitGroup
-	stopped      *atomic.Bool
-	items        chan QueueRequest[T]
-	numConsumers int
+	component.StartFunc
+	stopped *atomic.Bool
+	items   chan QueueRequest[T]
 }
 
-// NewBoundedMemoryQueue constructs the new queue of specified capacity. Capacity cannot be 0.
-func NewBoundedMemoryQueue[T any](capacity int, numConsumers int) Queue[T] {
+// NewBoundedMemoryQueue constructs the new queue of specified capacity, and with an optional
+// callback for dropped items (e.g. useful to emit metrics).
+func NewBoundedMemoryQueue[T any](capacity int) Queue[T] {
 	return &boundedMemoryQueue[T]{
-		items:        make(chan QueueRequest[T], capacity),
-		stopped:      &atomic.Bool{},
-		numConsumers: numConsumers,
+		items:   make(chan QueueRequest[T], capacity),
+		stopped: &atomic.Bool{},
 	}
 }
 
-// Start starts a given number of goroutines consuming items from the queue
-// and passing them into the consumer callback.
-func (q *boundedMemoryQueue[T]) Start(_ context.Context, _ component.Host, set QueueSettings[T]) error {
-	var startWG sync.WaitGroup
-	for i := 0; i < q.numConsumers; i++ {
-		q.stopWG.Add(1)
-		startWG.Add(1)
-		go func() {
-			startWG.Done()
-			defer q.stopWG.Done()
-			for item := range q.items {
-				set.Callback(item)
-			}
-		}()
-	}
-	startWG.Wait()
-	return nil
-}
-
-// Offer is used by the producer to submit new item to the queue. Returns false in case of queue overflow.
+// Offer is used by the producer to submit new item to the queue.
 func (q *boundedMemoryQueue[T]) Offer(ctx context.Context, req T) error {
 	if q.stopped.Load() {
 		return ErrQueueIsStopped
@@ -65,11 +44,16 @@ func (q *boundedMemoryQueue[T]) Offer(ctx context.Context, req T) error {
 	}
 }
 
+// Poll returns a request from the queue once it's available. It returns false if the queue is stopped.
+func (q *boundedMemoryQueue[T]) Poll() (QueueRequest[T], bool) {
+	item, ok := <-q.items
+	return item, ok
+}
+
 // Shutdown stops accepting items, and stops all consumers. It blocks until all consumers have stopped.
 func (q *boundedMemoryQueue[T]) Shutdown(context.Context) error {
 	q.stopped.Store(true) // disable producer
 	close(q.items)
-	q.stopWG.Wait()
 	return nil
 }
 

--- a/exporter/exporterhelper/internal/consumers.go
+++ b/exporter/exporterhelper/internal/consumers.go
@@ -1,0 +1,52 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package internal // import "go.opentelemetry.io/collector/exporter/exporterhelper/internal"
+
+import (
+	"context"
+	"sync"
+)
+
+type QueueConsumers[T any] struct {
+	queue        Queue[T]
+	numConsumers int
+	callback     func(context.Context, T)
+	stopWG       sync.WaitGroup
+}
+
+func NewQueueConsumers[T any](q Queue[T], numConsumers int, callback func(context.Context, T)) *QueueConsumers[T] {
+	return &QueueConsumers[T]{
+		queue:        q,
+		numConsumers: numConsumers,
+		callback:     callback,
+		stopWG:       sync.WaitGroup{},
+	}
+}
+
+// Start ensures that all consumers are started.
+func (c *QueueConsumers[T]) Start() {
+	var startWG sync.WaitGroup
+	for i := 0; i < c.numConsumers; i++ {
+		c.stopWG.Add(1)
+		startWG.Add(1)
+		go func() {
+			startWG.Done()
+			defer c.stopWG.Done()
+			for {
+				item, success := c.queue.Poll()
+				if !success {
+					return
+				}
+				c.callback(item.Context, item.Request)
+				item.OnProcessingFinished()
+			}
+		}()
+	}
+	startWG.Wait()
+}
+
+// Shutdown ensures that all consumers are stopped.
+func (c *QueueConsumers[T]) Shutdown() {
+	c.stopWG.Wait()
+}

--- a/exporter/exporterhelper/internal/persistent_storage.go
+++ b/exporter/exporterhelper/internal/persistent_storage.go
@@ -82,7 +82,6 @@ func newPersistentContiguousStorage[T any](
 		putChan:     make(chan struct{}, capacity),
 		stopChan:    make(chan struct{}),
 	}
-
 }
 
 func (pcs *persistentContiguousStorage[T]) start(ctx context.Context, client storage.Client) {
@@ -123,8 +122,9 @@ func (pcs *persistentContiguousStorage[T]) initPersistentContiguousStorage(ctx c
 	}
 }
 
-// get returns the request channel that all the requests will be send on
-func (pcs *persistentContiguousStorage[T]) get() (QueueRequest[T], bool) {
+// Poll returns the next available item from the queue, or blocks until one is available.
+// If the queue is stopped, returns (QueueRequest{}, false)
+func (pcs *persistentContiguousStorage[T]) Poll() (QueueRequest[T], bool) {
 	for {
 		select {
 		case <-pcs.stopChan:

--- a/exporter/exporterhelper/internal/queue.go
+++ b/exporter/exporterhelper/internal/queue.go
@@ -19,25 +19,19 @@ var (
 	ErrQueueIsStopped = errors.New("sending queue is stopped")
 )
 
-type QueueSettings[T any] struct {
-	DataType component.DataType
-	Callback func(QueueRequest[T])
-}
-
 // Queue defines a producer-consumer exchange which can be backed by e.g. the memory-based ring buffer queue
 // (boundedMemoryQueue) or via a disk-based queue (persistentQueue)
 type Queue[T any] interface {
-	// Start starts the queue with a given number of goroutines consuming items from the queue
-	// and passing them into the consumer callback.
-	Start(ctx context.Context, host component.Host, set QueueSettings[T]) error
+	component.Component
 	// Offer inserts the specified element into this queue if it is possible to do so immediately
 	// without violating capacity restrictions. If success returns no error.
 	// It returns ErrQueueIsFull if no space is currently available.
 	Offer(ctx context.Context, item T) error
+	// Poll returns the head of this queue. The call blocks until there is an item available.
+	// It returns false if the queue is stopped.
+	Poll() (QueueRequest[T], bool)
 	// Size returns the current Size of the queue
 	Size() int
-	// Shutdown stops accepting items, and stops all consumers. It blocks until all consumers have stopped.
-	Shutdown(ctx context.Context) error
 	// Capacity returns the capacity of the queue.
 	Capacity() int
 }

--- a/exporter/exporterhelper/queue_sender_test.go
+++ b/exporter/exporterhelper/queue_sender_test.go
@@ -345,7 +345,6 @@ func TestQueuedRetryPersistenceEnabledStorageError(t *testing.T) {
 }
 
 func TestQueuedRetryPersistentEnabled_shutdown_dataIsRequeued(t *testing.T) {
-
 	produceCounter := &atomic.Uint32{}
 
 	qCfg := NewDefaultQueueSettings()


### PR DESCRIPTION
Move the common workers loop logic from each queue implementation to the sender.

Based on https://github.com/open-telemetry/opentelemetry-collector/pull/8828