### PR TITLE
[chore] update tidy job to use local repo instead of fork

### DIFF
--- a/.github/workflows/tidy-dependencies.yml
+++ b/.github/workflows/tidy-dependencies.yml
@@ -13,9 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          repository: "renovate-bot/open-telemetry-_-opentelemetry-collector"
           ref: ${{ github.head_ref }}
-          token: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}
       - uses: actions/setup-go@v4
         with:
           go-version: ~1.20.11


### PR DESCRIPTION
Switching from forking renovate to renovate, the PRs will now be on a branch in the local repo.