### PR TITLE
[chore] configure go version to latest 1.20

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,9 @@
     "labels": [
       "dependencies"
     ],
+    "constraints": {
+      "go": "1.20"
+    },
     "extends": [
       "config:base"
     ],


### PR DESCRIPTION
This configures renovate to use the latest go 1.20 instead of go 1.21

