### PR TITLE
[chore] ensure checks run on push to renovatebot branch

### DIFF
--- a/.github/workflows/build-and-test-windows.yaml
+++ b/.github/workflows/build-and-test-windows.yaml
@@ -1,7 +1,7 @@
 name: build-and-test-windows
 on:
   push:
-    branches: [ main ]
+    branches: [ main, 'renovatebot/**' ]
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+*'
   pull_request:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,7 +1,7 @@
 name: build-and-test
 on:
   push:
-    branches: [main]
+    branches: [main, 'renovatebot/**']
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+*"
   pull_request:

--- a/.github/workflows/builder-integration-test.yaml
+++ b/.github/workflows/builder-integration-test.yaml
@@ -3,7 +3,7 @@ name: Builder - Integration tests
 on:
   # on changes to the main branch touching the builder
   push:
-    branches: [ main ]
+    branches: [ main, 'renovatebot/**' ]
 
   # on PRs touching the builder
   pull_request:

--- a/.github/workflows/check-links.yaml
+++ b/.github/workflows/check-links.yaml
@@ -1,7 +1,7 @@
 name: check-links
 on:
   push:
-    branches: [ main ]
+    branches: [ main, 'renovatebot/**' ]
     paths-ignore:
       - 'cmd/builder/**'
   pull_request:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,7 +1,7 @@
 name: "CodeQL Analysis"
 on:
   push:
-    branches: [ main ]
+    branches: [ main, 'renovatebot/**' ]
   pull_request:
 
 concurrency:

--- a/.github/workflows/contrib-tests.yml
+++ b/.github/workflows/contrib-tests.yml
@@ -1,7 +1,7 @@
 name: contrib-tests
 on:
   push:
-    branches: [ main ]
+    branches: [ main, 'renovatebot/**' ]
     tags:
       - v[0-9]+.[0-9]+.[0-9]+.*
   pull_request:

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,7 +1,7 @@
 name: Shellcheck lint
 on:
   push:
-    branches: [ main ]
+    branches: [ main, 'renovatebot/**' ]
   pull_request:
     branches: [ main ]
 


### PR DESCRIPTION
Otherwise, PRs for dependency updates will not re-trigger the CI once gotidy has been run and pushed to the branch.
