### PR TITLE
[chore] more tweaking for renovatebot

### DIFF
--- a/.github/workflows/build-and-test-windows.yaml
+++ b/.github/workflows/build-and-test-windows.yaml
@@ -1,7 +1,7 @@
 name: build-and-test-windows
 on:
   push:
-    branches: [ main, 'renovatebot/**' ]
+    branches: [ main ]
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+*'
   pull_request:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,7 +1,7 @@
 name: build-and-test
 on:
   push:
-    branches: [main, 'renovatebot/**']
+    branches: [main]
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+*"
   pull_request:

--- a/.github/workflows/builder-integration-test.yaml
+++ b/.github/workflows/builder-integration-test.yaml
@@ -3,7 +3,7 @@ name: Builder - Integration tests
 on:
   # on changes to the main branch touching the builder
   push:
-    branches: [ main, 'renovatebot/**' ]
+    branches: [ main ]
 
   # on PRs touching the builder
   pull_request:

--- a/.github/workflows/check-links.yaml
+++ b/.github/workflows/check-links.yaml
@@ -1,7 +1,7 @@
 name: check-links
 on:
   push:
-    branches: [ main, 'renovatebot/**' ]
+    branches: [ main ]
     paths-ignore:
       - 'cmd/builder/**'
   pull_request:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,7 +1,7 @@
 name: "CodeQL Analysis"
 on:
   push:
-    branches: [ main, 'renovatebot/**' ]
+    branches: [ main ]
   pull_request:
 
 concurrency:

--- a/.github/workflows/contrib-tests.yml
+++ b/.github/workflows/contrib-tests.yml
@@ -1,7 +1,7 @@
 name: contrib-tests
 on:
   push:
-    branches: [ main, 'renovatebot/**' ]
+    branches: [ main ]
     tags:
       - v[0-9]+.[0-9]+.[0-9]+.*
   pull_request:

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,7 +1,7 @@
 name: Shellcheck lint
 on:
   push:
-    branches: [ main, 'renovatebot/**' ]
+    branches: [ main ]
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/tidy-dependencies.yml
+++ b/.github/workflows/tidy-dependencies.yml
@@ -9,7 +9,7 @@ jobs:
   setup-environment:
     timeout-minutes: 30
     runs-on: ubuntu-latest
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'dependencies') }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'renovatebot') }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -39,5 +39,6 @@ jobs:
           git config user.email 107717825+opentelemetrybot@users.noreply.github.com
           echo "git diff --exit-code || (git add . && git commit -m \"go mod tidy\" && git push)"
           git diff --exit-code || (git add . && git commit -m "go mod tidy" && git push)
-        env:
-          GITHUB_TOKEN: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}
+      - uses: actions-ecosystem/action-remove-labels@v1
+        with:
+          labels: renovatebot

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "labels": [
+      "renovatebot",
       "dependencies"
     ],
     "constraints": {


### PR DESCRIPTION
The previous change didn't work because opentelemetrybot doesn't have write permissions to push changes to the renovatebot branch. Reverting to using the standard github token, and testing triggering CI by removing the renovatebot label after the change has been pushed.
