### PR TITLE
[docs, .github] Add new issue template for stabilizing a module

### DIFF
--- a/.github/ISSUE_TEMPLATE/stabilization.md
+++ b/.github/ISSUE_TEMPLATE/stabilization.md
@@ -13,7 +13,7 @@ Before stabilizing a module, an approver or maintainer must make sure that the f
 - [ ] No TODOs in the module code that would require breaking changes
 - [ ] No deprecated symbols in the module
 - [ ] No symbols marked as experimental in the module
-- [ ] The module follows the [Coding guidelines](CONTRIBUTING.md#coding-guidelines)
+- [ ] The module follows the [Coding guidelines](https://github.com/open-telemetry/opentelemetry-collector/blob/main/CONTRIBUTING.md)
 
 Please also make sure to publicly announce our intent to stabilize the module on:
 

--- a/.github/ISSUE_TEMPLATE/stabilization.md
+++ b/.github/ISSUE_TEMPLATE/stabilization.md
@@ -1,0 +1,24 @@
+---
+name: Module stabilization
+about: Stabilize a module before a 1.0 release
+title: 'Stabilize module X'
+labels: 'stabilization'
+assignees: ''
+---
+
+Before stabilizing a module, an approver or maintainer must make sure that the following criteria are met:
+
+- [ ] One RC release or more have been done of this module
+- [ ] No open issues or PRs in the module that would require breaking changes
+- [ ] No TODOs in the module code that would require breaking changes
+- [ ] No deprecated symbols in the module
+- [ ] No symbols marked as experimental in the module
+- [ ] The module follows the [Coding guidelines](CONTRIBUTING.md#coding-guidelines)
+
+Please also make sure to publicly announce our intent to stabilize the module on:
+
+- [ ] The #otel-collector CNCF Slack Channel
+- [ ] The #opentelemetry CNCF Slack channel
+- [ ] A Collector SIG meeting (if unable to attend, just add to the agenda)
+
+To help other people verify the above criteria, please link to an RC release, the announcement and other links used to complete the above in a comment on this issue.

--- a/docs/release.md
+++ b/docs/release.md
@@ -141,6 +141,10 @@ The following documents the procedure to release a bugfix
 7. Once the branch has been merged, it will be auto-deleted. Restore the release branch via GitHub.
 8. Once the patch is release, disable the **Merge pull request** setting.
 
+## 1.0 release
+
+Stable modules adhere to our [versioning document guarantees](../VERSIONING.md), so we need to be careful before releasing. Before adding a module to the stable module set and making a first 1.0 release, please [open a new stabilization issue](https://github.com/open-telemetry/opentelemetry-collector/issues/new/choose) and follow the instructions in the issue template.
+
 ## Release schedule
 
 | Date       | Version | Release manager |


### PR DESCRIPTION
**Description:** 

This adds a new release template for stabilizing a module.
The intent is to try this out for pdata and featuregate, and iterate on the template over time.
