### PR TITLE
[cmd/builder] add a flag to skip generating main files

### DIFF
--- a/.chloggen/ocb-skip-generate-main.yaml
+++ b/.chloggen/ocb-skip-generate-main.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: builder
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add a `--skip-generate-main` to disable generating main.go, main_others.go and main_windows.go files.
+
+# One or more tracking issues or pull requests related to the change
+issues: [8937]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/cmd/builder/internal/builder/config.go
+++ b/cmd/builder/internal/builder/config.go
@@ -23,12 +23,13 @@ var ErrInvalidGoMod = errors.New("invalid gomod specification for module")
 
 // Config holds the builder's configuration
 type Config struct {
-	Logger          *zap.Logger
-	SkipGenerate    bool   `mapstructure:"-"`
-	SkipCompilation bool   `mapstructure:"-"`
-	SkipGetModules  bool   `mapstructure:"-"`
-	LDFlags         string `mapstructure:"-"`
-	Verbose         bool   `mapstructure:"-"`
+	Logger           *zap.Logger
+	SkipGenerate     bool   `mapstructure:"-"`
+	SkipCompilation  bool   `mapstructure:"-"`
+	SkipGenerateMain bool   `mapstructure:"-"`
+	SkipGetModules   bool   `mapstructure:"-"`
+	LDFlags          string `mapstructure:"-"`
+	Verbose          bool   `mapstructure:"-"`
 
 	Distribution Distribution `mapstructure:"dist"`
 	Exporters    []Module     `mapstructure:"exporters"`

--- a/cmd/builder/internal/builder/main.go
+++ b/cmd/builder/internal/builder/main.go
@@ -75,14 +75,17 @@ func Generate(cfg Config) error {
 		return fmt.Errorf("failed to create output path: %w", err)
 	}
 
-	for _, tmpl := range []*template.Template{
-		mainTemplate,
-		mainOthersTemplate,
-		mainWindowsTemplate,
+	templates := []*template.Template{
 		componentsTemplate,
 		componentsTestTemplate,
 		goModTemplate,
-	} {
+	}
+	if !cfg.SkipGenerateMain {
+		templates = append(templates, mainTemplate,
+			mainOthersTemplate,
+			mainWindowsTemplate)
+	}
+	for _, tmpl := range templates {
 		if err := processAndWrite(cfg, tmpl, tmpl.Name(), cfg); err != nil {
 			return fmt.Errorf("failed to generate source file %q: %w", tmpl.Name(), err)
 		}

--- a/cmd/builder/internal/command.go
+++ b/cmd/builder/internal/command.go
@@ -23,6 +23,7 @@ const (
 	skipGenerateFlag               = "skip-generate"
 	skipCompilationFlag            = "skip-compilation"
 	skipGetModulesFlag             = "skip-get-modules"
+	skipGenerateMainFlag           = "skip-generate-main"
 	ldflagsFlag                    = "ldflags"
 	distributionNameFlag           = "name"
 	distributionDescriptionFlag    = "description"
@@ -82,6 +83,7 @@ configuration is provided, ocb will generate a default Collector.
 	// the distribution parameters, which we accept as CLI flags as well
 	cmd.Flags().BoolVar(&cfg.SkipGenerate, skipGenerateFlag, false, "Whether builder should skip generating go code (default false)")
 	cmd.Flags().BoolVar(&cfg.SkipCompilation, skipCompilationFlag, false, "Whether builder should only generate go code with no compile of the collector (default false)")
+	cmd.Flags().BoolVar(&cfg.SkipGenerateMain, skipGenerateMainFlag, false, "Whether builder should skip generating main.go, main_others.go and main_windows.go (default false)")
 	cmd.Flags().BoolVar(&cfg.SkipGetModules, skipGetModulesFlag, false, "Whether builder should skip updating go.mod and retrieve Go module list (default false)")
 	cmd.Flags().BoolVar(&cfg.Verbose, verboseFlag, false, "Whether builder should print verbose output (default false)")
 	cmd.Flags().StringVar(&cfg.LDFlags, ldflagsFlag, "", `ldflags to include in the "go build" command`)
@@ -179,6 +181,9 @@ func applyCfgFromFile(flags *flag.FlagSet, cfgFromFile builder.Config) {
 	}
 	if !flags.Changed(skipGetModulesFlag) && cfgFromFile.SkipGetModules {
 		cfg.SkipGetModules = cfgFromFile.SkipGetModules
+	}
+	if !flags.Changed(skipGenerateMainFlag) && cfgFromFile.SkipGenerateMain {
+		cfg.SkipGenerateMain = cfgFromFile.SkipGenerateMain
 	}
 	if !flags.Changed(distributionNameFlag) && cfgFromFile.Distribution.Name != "" {
 		cfg.Distribution.Name = cfgFromFile.Distribution.Name

--- a/cmd/builder/internal/command_test.go
+++ b/cmd/builder/internal/command_test.go
@@ -200,23 +200,46 @@ func Test_applyCfgFromFile(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "Skip generate main true",
+			args: args{
+				flags: flag.NewFlagSet("version=1.0.0", 1),
+				cfgFromFile: builder.Config{
+					Logger:           zap.NewNop(),
+					SkipCompilation:  true,
+					SkipGetModules:   true,
+					SkipGenerateMain: true,
+					Distribution:     testDistribution,
+				},
+			},
+			want: builder.Config{
+				Logger:           zap.NewNop(),
+				SkipCompilation:  true,
+				SkipGetModules:   true,
+				SkipGenerateMain: true,
+				Distribution:     testDistribution,
+			},
+			wantErr: false,
+		},
+		{
 			name: "Skip generate true",
 			args: args{
 				flags: flag.NewFlagSet("version=1.0.0", 1),
 				cfgFromFile: builder.Config{
-					Logger:          zap.NewNop(),
-					SkipGenerate:    true,
-					SkipCompilation: true,
-					SkipGetModules:  true,
-					Distribution:    testDistribution,
+					Logger:           zap.NewNop(),
+					SkipGenerate:     true,
+					SkipCompilation:  true,
+					SkipGetModules:   true,
+					SkipGenerateMain: true,
+					Distribution:     testDistribution,
 				},
 			},
 			want: builder.Config{
-				Logger:          zap.NewNop(),
-				SkipGenerate:    true,
-				SkipCompilation: true,
-				SkipGetModules:  true,
-				Distribution:    testDistribution,
+				Logger:           zap.NewNop(),
+				SkipGenerate:     true,
+				SkipCompilation:  true,
+				SkipGetModules:   true,
+				SkipGenerateMain: true,
+				Distribution:     testDistribution,
 			},
 			wantErr: false,
 		},
@@ -228,6 +251,7 @@ func Test_applyCfgFromFile(t *testing.T) {
 			assert.Equal(t, tt.want.SkipGenerate, cfg.SkipGenerate)
 			assert.Equal(t, tt.want.SkipCompilation, cfg.SkipCompilation)
 			assert.Equal(t, tt.want.SkipGetModules, cfg.SkipGetModules)
+			assert.Equal(t, tt.want.SkipGenerateMain, cfg.SkipGenerateMain)
 			assert.Equal(t, tt.want.Excludes, cfg.Excludes)
 			assert.Equal(t, tt.want.Exporters, cfg.Exporters)
 			assert.Equal(t, tt.want.Receivers, cfg.Receivers)


### PR DESCRIPTION
**Description:**
We have the need to generate list of components in tooling adjacent to the collector, such as configschema. For those, it makes sense to generate a list of components per type that can be used by the program in a programmatic way that differs from running the collector.

**Testing:**
Unit tests.
