### PR TITLE
Add Range methods to pdata slices

### DIFF
--- a/.chloggen/pdata-slice-range-only.yaml
+++ b/.chloggen/pdata-slice-range-only.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: pdata
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add "Range" method to slices
+
+# One or more tracking issues or pull requests related to the change
+issues: [8938]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/exporter/internal/otlptext/databuffer.go
+++ b/exporter/internal/otlptext/databuffer.go
@@ -89,7 +89,7 @@ func (b *dataBuffer) logMetricDataPoints(m pmetric.Metric) {
 }
 
 func (b *dataBuffer) logNumberDataPoints(ps pmetric.NumberDataPointSlice) {
-	ps.ForEachIndex(func(i int, p pmetric.NumberDataPoint) {
+	ps.Range(func(i int, p pmetric.NumberDataPoint) {
 		b.logEntry("NumberDataPoints #%d", i)
 		b.logDataPointAttributes(p.Attributes())
 
@@ -107,7 +107,7 @@ func (b *dataBuffer) logNumberDataPoints(ps pmetric.NumberDataPointSlice) {
 }
 
 func (b *dataBuffer) logHistogramDataPoints(ps pmetric.HistogramDataPointSlice) {
-	ps.ForEachIndex(func(i int, p pmetric.HistogramDataPoint) {
+	ps.Range(func(i int, p pmetric.HistogramDataPoint) {
 		b.logEntry("HistogramDataPoints #%d", i)
 		b.logDataPointAttributes(p.Attributes())
 
@@ -140,7 +140,7 @@ func (b *dataBuffer) logHistogramDataPoints(ps pmetric.HistogramDataPointSlice) 
 }
 
 func (b *dataBuffer) logExponentialHistogramDataPoints(ps pmetric.ExponentialHistogramDataPointSlice) {
-	ps.ForEachIndex(func(i int, p pmetric.ExponentialHistogramDataPoint) {
+	ps.Range(func(i int, p pmetric.ExponentialHistogramDataPoint) {
 		b.logEntry("ExponentialHistogramDataPoints #%d", i)
 		b.logDataPointAttributes(p.Attributes())
 
@@ -198,7 +198,7 @@ func (b *dataBuffer) logExponentialHistogramDataPoints(ps pmetric.ExponentialHis
 }
 
 func (b *dataBuffer) logDoubleSummaryDataPoints(ps pmetric.SummaryDataPointSlice) {
-	ps.ForEachIndex(func(i int, p pmetric.SummaryDataPoint) {
+	ps.Range(func(i int, p pmetric.SummaryDataPoint) {
 		b.logEntry("SummaryDataPoints #%d", i)
 		b.logDataPointAttributes(p.Attributes())
 
@@ -207,7 +207,7 @@ func (b *dataBuffer) logDoubleSummaryDataPoints(ps pmetric.SummaryDataPointSlice
 		b.logEntry("Count: %d", p.Count())
 		b.logEntry("Sum: %f", p.Sum())
 
-		p.QuantileValues().ForEachIndex(func(i int, quantile pmetric.SummaryDataPointValueAtQuantile) {
+		p.QuantileValues().Range(func(i int, quantile pmetric.SummaryDataPointValueAtQuantile) {
 			b.logEntry("QuantileValue #%d: Quantile %f, Value %f", i, quantile.Quantile(), quantile.Value())
 		})
 	})
@@ -223,7 +223,7 @@ func (b *dataBuffer) logEvents(description string, se ptrace.SpanEventSlice) {
 	}
 
 	b.logEntry("%s:", description)
-	se.ForEachIndex(func(i int, el ptrace.SpanEvent) {
+	se.Range(func(i int, el ptrace.SpanEvent) {
 		e := se.At(i)
 		b.logEntry("SpanEvent #%d", i)
 		b.logEntry("     -> Name: %s", e.Name())
@@ -240,7 +240,7 @@ func (b *dataBuffer) logLinks(description string, sl ptrace.SpanLinkSlice) {
 
 	b.logEntry("%s:", description)
 
-	sl.ForEachIndex(func(i int, l ptrace.SpanLink) {
+	sl.Range(func(i int, l ptrace.SpanLink) {
 		b.logEntry("SpanLink #%d", i)
 		b.logEntry("     -> Trace ID: %s", l.TraceID())
 		b.logEntry("     -> ID: %s", l.SpanID())
@@ -257,7 +257,7 @@ func (b *dataBuffer) logExemplars(description string, se pmetric.ExemplarSlice) 
 
 	b.logEntry("%s:", description)
 
-	se.ForEachIndex(func(i int, e pmetric.Exemplar) {
+	se.Range(func(i int, e pmetric.Exemplar) {
 		b.logEntry("Exemplar #%d", i)
 		b.logEntry("     -> Trace ID: %s", e.TraceID())
 		b.logEntry("     -> Span ID: %s", e.SpanID())

--- a/exporter/internal/otlptext/databuffer.go
+++ b/exporter/internal/otlptext/databuffer.go
@@ -89,8 +89,7 @@ func (b *dataBuffer) logMetricDataPoints(m pmetric.Metric) {
 }
 
 func (b *dataBuffer) logNumberDataPoints(ps pmetric.NumberDataPointSlice) {
-	for i := 0; i < ps.Len(); i++ {
-		p := ps.At(i)
+	ps.ForEachIndex(func(i int, p pmetric.NumberDataPoint) {
 		b.logEntry("NumberDataPoints #%d", i)
 		b.logDataPointAttributes(p.Attributes())
 
@@ -104,12 +103,11 @@ func (b *dataBuffer) logNumberDataPoints(ps pmetric.NumberDataPointSlice) {
 		}
 
 		b.logExemplars("Exemplars", p.Exemplars())
-	}
+	})
 }
 
 func (b *dataBuffer) logHistogramDataPoints(ps pmetric.HistogramDataPointSlice) {
-	for i := 0; i < ps.Len(); i++ {
-		p := ps.At(i)
+	ps.ForEachIndex(func(i int, p pmetric.HistogramDataPoint) {
 		b.logEntry("HistogramDataPoints #%d", i)
 		b.logDataPointAttributes(p.Attributes())
 
@@ -138,12 +136,11 @@ func (b *dataBuffer) logHistogramDataPoints(ps pmetric.HistogramDataPointSlice) 
 		}
 
 		b.logExemplars("Exemplars", p.Exemplars())
-	}
+	})
 }
 
 func (b *dataBuffer) logExponentialHistogramDataPoints(ps pmetric.ExponentialHistogramDataPointSlice) {
-	for i := 0; i < ps.Len(); i++ {
-		p := ps.At(i)
+	ps.ForEachIndex(func(i int, p pmetric.ExponentialHistogramDataPoint) {
 		b.logEntry("ExponentialHistogramDataPoints #%d", i)
 		b.logDataPointAttributes(p.Attributes())
 
@@ -197,12 +194,11 @@ func (b *dataBuffer) logExponentialHistogramDataPoints(ps pmetric.ExponentialHis
 		}
 
 		b.logExemplars("Exemplars", p.Exemplars())
-	}
+	})
 }
 
 func (b *dataBuffer) logDoubleSummaryDataPoints(ps pmetric.SummaryDataPointSlice) {
-	for i := 0; i < ps.Len(); i++ {
-		p := ps.At(i)
+	ps.ForEachIndex(func(i int, p pmetric.SummaryDataPoint) {
 		b.logEntry("SummaryDataPoints #%d", i)
 		b.logDataPointAttributes(p.Attributes())
 
@@ -211,12 +207,10 @@ func (b *dataBuffer) logDoubleSummaryDataPoints(ps pmetric.SummaryDataPointSlice
 		b.logEntry("Count: %d", p.Count())
 		b.logEntry("Sum: %f", p.Sum())
 
-		quantiles := p.QuantileValues()
-		for i := 0; i < quantiles.Len(); i++ {
-			quantile := quantiles.At(i)
+		p.QuantileValues().ForEachIndex(func(i int, quantile pmetric.SummaryDataPointValueAtQuantile) {
 			b.logEntry("QuantileValue #%d: Quantile %f, Value %f", i, quantile.Quantile(), quantile.Value())
-		}
-	}
+		})
+	})
 }
 
 func (b *dataBuffer) logDataPointAttributes(attributes pcommon.Map) {
@@ -229,14 +223,14 @@ func (b *dataBuffer) logEvents(description string, se ptrace.SpanEventSlice) {
 	}
 
 	b.logEntry("%s:", description)
-	for i := 0; i < se.Len(); i++ {
+	se.ForEachIndex(func(i int, el ptrace.SpanEvent) {
 		e := se.At(i)
 		b.logEntry("SpanEvent #%d", i)
 		b.logEntry("     -> Name: %s", e.Name())
 		b.logEntry("     -> Timestamp: %s", e.Timestamp())
 		b.logEntry("     -> DroppedAttributesCount: %d", e.DroppedAttributesCount())
 		b.logAttributes("     -> Attributes:", e.Attributes())
-	}
+	})
 }
 
 func (b *dataBuffer) logLinks(description string, sl ptrace.SpanLinkSlice) {
@@ -246,15 +240,14 @@ func (b *dataBuffer) logLinks(description string, sl ptrace.SpanLinkSlice) {
 
 	b.logEntry("%s:", description)
 
-	for i := 0; i < sl.Len(); i++ {
-		l := sl.At(i)
+	sl.ForEachIndex(func(i int, l ptrace.SpanLink) {
 		b.logEntry("SpanLink #%d", i)
 		b.logEntry("     -> Trace ID: %s", l.TraceID())
 		b.logEntry("     -> ID: %s", l.SpanID())
 		b.logEntry("     -> TraceState: %s", l.TraceState().AsRaw())
 		b.logEntry("     -> DroppedAttributesCount: %d", l.DroppedAttributesCount())
 		b.logAttributes("     -> Attributes:", l.Attributes())
-	}
+	})
 }
 
 func (b *dataBuffer) logExemplars(description string, se pmetric.ExemplarSlice) {
@@ -264,8 +257,7 @@ func (b *dataBuffer) logExemplars(description string, se pmetric.ExemplarSlice) 
 
 	b.logEntry("%s:", description)
 
-	for i := 0; i < se.Len(); i++ {
-		e := se.At(i)
+	se.ForEachIndex(func(i int, e pmetric.Exemplar) {
 		b.logEntry("Exemplar #%d", i)
 		b.logEntry("     -> Trace ID: %s", e.TraceID())
 		b.logEntry("     -> Span ID: %s", e.SpanID())
@@ -277,7 +269,7 @@ func (b *dataBuffer) logExemplars(description string, se pmetric.ExemplarSlice) 
 			b.logEntry("     -> Value: %f", e.DoubleValue())
 		}
 		b.logAttributes("     -> FilteredAttributes", e.FilteredAttributes())
-	}
+	})
 }
 
 func valueToString(v pcommon.Value) string {

--- a/exporter/internal/otlptext/logs.go
+++ b/exporter/internal/otlptext/logs.go
@@ -17,15 +17,15 @@ type textLogsMarshaler struct{}
 // MarshalLogs plog.Logs to OTLP text.
 func (textLogsMarshaler) MarshalLogs(ld plog.Logs) ([]byte, error) {
 	buf := dataBuffer{}
-	ld.ResourceLogs().ForEachIndex(func(i int, rl plog.ResourceLogs) {
+	ld.ResourceLogs().Range(func(i int, rl plog.ResourceLogs) {
 		buf.logEntry("ResourceLog #%d", i)
 		buf.logEntry("Resource SchemaURL: %s", rl.SchemaUrl())
 		buf.logAttributes("Resource attributes", rl.Resource().Attributes())
-		rl.ScopeLogs().ForEachIndex(func(j int, ils plog.ScopeLogs) {
+		rl.ScopeLogs().Range(func(j int, ils plog.ScopeLogs) {
 			buf.logEntry("ScopeLogs #%d", j)
 			buf.logEntry("ScopeLogs SchemaURL: %s", ils.SchemaUrl())
 			buf.logInstrumentationScope(ils.Scope())
-			ils.LogRecords().ForEachIndex(func(k int, lr plog.LogRecord) {
+			ils.LogRecords().Range(func(k int, lr plog.LogRecord) {
 				buf.logEntry("LogRecord #%d", k)
 				buf.logEntry("ObservedTimestamp: %s", lr.ObservedTimestamp())
 				buf.logEntry("Timestamp: %s", lr.Timestamp())

--- a/exporter/internal/otlptext/metrics.go
+++ b/exporter/internal/otlptext/metrics.go
@@ -15,15 +15,15 @@ type textMetricsMarshaler struct{}
 // MarshalMetrics pmetric.Metrics to OTLP text.
 func (textMetricsMarshaler) MarshalMetrics(md pmetric.Metrics) ([]byte, error) {
 	buf := dataBuffer{}
-	md.ResourceMetrics().ForEachIndex(func(i int, rm pmetric.ResourceMetrics) {
+	md.ResourceMetrics().Range(func(i int, rm pmetric.ResourceMetrics) {
 		buf.logEntry("ResourceMetrics #%d", i)
 		buf.logEntry("Resource SchemaURL: %s", rm.SchemaUrl())
 		buf.logAttributes("Resource attributes", rm.Resource().Attributes())
-		rm.ScopeMetrics().ForEachIndex(func(j int, ilm pmetric.ScopeMetrics) {
+		rm.ScopeMetrics().Range(func(j int, ilm pmetric.ScopeMetrics) {
 			buf.logEntry("ScopeMetrics #%d", j)
 			buf.logEntry("ScopeMetrics SchemaURL: %s", ilm.SchemaUrl())
 			buf.logInstrumentationScope(ilm.Scope())
-			ilm.Metrics().ForEachIndex(func(k int, metric pmetric.Metric) {
+			ilm.Metrics().Range(func(k int, metric pmetric.Metric) {
 				buf.logEntry("Metric #%d", k)
 				buf.logMetricDescriptor(metric)
 				buf.logMetricDataPoints(metric)

--- a/exporter/internal/otlptext/metrics.go
+++ b/exporter/internal/otlptext/metrics.go
@@ -15,27 +15,20 @@ type textMetricsMarshaler struct{}
 // MarshalMetrics pmetric.Metrics to OTLP text.
 func (textMetricsMarshaler) MarshalMetrics(md pmetric.Metrics) ([]byte, error) {
 	buf := dataBuffer{}
-	rms := md.ResourceMetrics()
-	for i := 0; i < rms.Len(); i++ {
+	md.ResourceMetrics().ForEachIndex(func(i int, rm pmetric.ResourceMetrics) {
 		buf.logEntry("ResourceMetrics #%d", i)
-		rm := rms.At(i)
 		buf.logEntry("Resource SchemaURL: %s", rm.SchemaUrl())
 		buf.logAttributes("Resource attributes", rm.Resource().Attributes())
-		ilms := rm.ScopeMetrics()
-		for j := 0; j < ilms.Len(); j++ {
+		rm.ScopeMetrics().ForEachIndex(func(j int, ilm pmetric.ScopeMetrics) {
 			buf.logEntry("ScopeMetrics #%d", j)
-			ilm := ilms.At(j)
 			buf.logEntry("ScopeMetrics SchemaURL: %s", ilm.SchemaUrl())
 			buf.logInstrumentationScope(ilm.Scope())
-			metrics := ilm.Metrics()
-			for k := 0; k < metrics.Len(); k++ {
+			ilm.Metrics().ForEachIndex(func(k int, metric pmetric.Metric) {
 				buf.logEntry("Metric #%d", k)
-				metric := metrics.At(k)
 				buf.logMetricDescriptor(metric)
 				buf.logMetricDataPoints(metric)
-			}
-		}
-	}
-
+			})
+		})
+	})
 	return buf.buf.Bytes(), nil
 }

--- a/exporter/internal/otlptext/traces.go
+++ b/exporter/internal/otlptext/traces.go
@@ -17,15 +17,15 @@ type textTracesMarshaler struct{}
 // MarshalTraces ptrace.Traces to OTLP text.
 func (textTracesMarshaler) MarshalTraces(td ptrace.Traces) ([]byte, error) {
 	buf := dataBuffer{}
-	td.ResourceSpans().ForEachIndex(func(i int, rs ptrace.ResourceSpans) {
+	td.ResourceSpans().Range(func(i int, rs ptrace.ResourceSpans) {
 		buf.logEntry("ResourceSpans #%d", i)
 		buf.logEntry("Resource SchemaURL: %s", rs.SchemaUrl())
 		buf.logAttributes("Resource attributes", rs.Resource().Attributes())
-		rs.ScopeSpans().ForEachIndex(func(j int, ils ptrace.ScopeSpans) {
+		rs.ScopeSpans().Range(func(j int, ils ptrace.ScopeSpans) {
 			buf.logEntry("ScopeSpans #%d", j)
 			buf.logEntry("ScopeSpans SchemaURL: %s", ils.SchemaUrl())
 			buf.logInstrumentationScope(ils.Scope())
-			ils.Spans().ForEachIndex(func(k int, span ptrace.Span) {
+			ils.Spans().Range(func(k int, span ptrace.Span) {
 				buf.logEntry("Span #%d", k)
 				buf.logAttr("Trace ID", span.TraceID())
 				buf.logAttr("Parent ID", span.ParentSpanID())

--- a/pdata/internal/cmd/pdatagen/internal/base_slices.go
+++ b/pdata/internal/cmd/pdatagen/internal/base_slices.go
@@ -156,7 +156,14 @@ func (es {{ .structName }}) Sort(less func(a, b {{ .elementName }}) bool) {
 	es.state.AssertMutable()
 	sort.SliceStable(*es.orig, func(i, j int) bool { return less(es.At(i), es.At(j)) })
 }
-{{- end }}`
+{{- end }}
+
+// ForEach iterates over {{ .structName }} and executes f against each element.
+func (es {{ .structName }}) ForEach(f func(el {{ .elementName }})) {
+	for i := 0; i < es.Len(); i++ {
+		f(es.At(i))
+	}
+}`
 
 const sliceTestTemplate = `func Test{{ .structName }}(t *testing.T) {
 	es := New{{ .structName }}()
@@ -281,7 +288,23 @@ func Test{{ .structName }}_Sort(t *testing.T) {
 		assert.True(t, uintptr(unsafe.Pointer(es.At(i-1).orig)) > uintptr(unsafe.Pointer(es.At(i).orig)))
 	}
 }
-{{- end }}`
+{{- end }}
+
+func Test{{ .structName }}_ForEach(t *testing.T) {
+	// Test ForEach on empty slice
+	emptySlice := New{{ .structName }}()
+	emptySlice.ForEach(func(el {{ .elementName }}) {
+		t.Fail()
+	})
+
+	// Test ForEach
+	slice := generateTest{{ .structName }}()
+	pos := 0
+	slice.ForEach(func(el {{ .elementName }}) {
+		pos++
+	})
+	assert.Equal(t, 7, slice.Len())
+}`
 
 const sliceGenerateTest = `func generateTest{{ .structName }}() {{ .structName }} {
 	es := New{{ .structName }}()

--- a/pdata/internal/cmd/pdatagen/internal/base_slices.go
+++ b/pdata/internal/cmd/pdatagen/internal/base_slices.go
@@ -159,9 +159,17 @@ func (es {{ .structName }}) Sort(less func(a, b {{ .elementName }}) bool) {
 {{- end }}
 
 // ForEach iterates over {{ .structName }} and executes f against each element.
-func (es {{ .structName }}) ForEach(f func(el {{ .elementName }})) {
+func (es {{ .structName }}) ForEach(f func({{ .elementName }})) {
 	for i := 0; i < es.Len(); i++ {
 		f(es.At(i))
+	}
+}
+
+// ForEachIndex iterates over {{ .structName }} and executes f against each element.
+// The function also passes the iteration index.
+func (es {{ .structName }}) ForEachIndex(f func(int, {{ .elementName }})) {
+	for i := 0; i < es.Len(); i++ {
+		f(i, es.At(i))
 	}
 }`
 
@@ -299,11 +307,27 @@ func Test{{ .structName }}_ForEach(t *testing.T) {
 
 	// Test ForEach
 	slice := generateTest{{ .structName }}()
-	pos := 0
+	count := 0
 	slice.ForEach(func(el {{ .elementName }}) {
-		pos++
+		count++
 	})
-	assert.Equal(t, 7, slice.Len())
+	assert.Equal(t, 7, count)
+}
+
+func Test{{ .structName }}_ForEachIndex(t *testing.T) {
+	// Test ForEach on empty slice
+	emptySlice := New{{ .structName }}()
+	emptySlice.ForEachIndex(func(i int, el {{ .elementName }}) {
+		t.Fail()
+	})
+
+	// Test ForEach
+	slice := generateTest{{ .structName }}()
+	total := 0
+	slice.ForEachIndex(func(i int, el {{ .elementName }}) {
+		total+=i
+	})
+	assert.Equal(t, 0+1+2+3+4+5+6, total)
 }`
 
 const sliceGenerateTest = `func generateTest{{ .structName }}() {{ .structName }} {

--- a/pdata/internal/cmd/pdatagen/internal/base_slices.go
+++ b/pdata/internal/cmd/pdatagen/internal/base_slices.go
@@ -158,30 +158,13 @@ func (es {{ .structName }}) Sort(less func(a, b {{ .elementName }}) bool) {
 }
 {{- end }}
 
-// ForEach iterates over {{ .structName }} and executes f against each element.
-func (es {{ .structName }}) ForEach(f func({{ .elementName }})) {
-	for i := 0; i < es.Len(); i++ {
-		f(es.At(i))
-	}
-}
 
-// ForEachIndex iterates over {{ .structName }} and executes f against each element.
+// Range iterates over {{ .structName }} and executes f against each element.
 // The function also passes the iteration index.
-func (es {{ .structName }}) ForEachIndex(f func(int, {{ .elementName }})) {
+func (es {{ .structName }}) Range(f func(int, {{ .elementName }})) {
 	for i := 0; i < es.Len(); i++ {
 		f(i, es.At(i))
 	}
-}
-
-// ForEachWhile iterates over {{ .structName }} and executes f against each element.
-// The function also passes the iteration index.
-func (es {{ .structName }}) ForEachWhile(f func({{ .elementName }}) bool) bool {
-	for i := 0; i < es.Len(); i++ {
-		if !f(es.At(i)) {
-			return false
-		}
-	}
-	return true
 }`
 
 const sliceTestTemplate = `func Test{{ .structName }}(t *testing.T) {
@@ -309,67 +292,20 @@ func Test{{ .structName }}_Sort(t *testing.T) {
 }
 {{- end }}
 
-func Test{{ .structName }}_ForEach(t *testing.T) {
-	// Test ForEach on empty slice
+func Test{{ .structName }}_Range(t *testing.T) {
+	// Test _Range on empty slice
 	emptySlice := New{{ .structName }}()
-	emptySlice.ForEach(func(el {{ .elementName }}) {
+	emptySlice.Range(func(i int, el {{ .elementName }}) {
 		t.Fail()
 	})
 
-	// Test ForEach
-	slice := generateTest{{ .structName }}()
-	count := 0
-	slice.ForEach(func(el {{ .elementName }}) {
-		count++
-	})
-	assert.Equal(t, 7, count)
-}
-
-func Test{{ .structName }}_ForEachIndex(t *testing.T) {
-	// Test _ForEachIndex on empty slice
-	emptySlice := New{{ .structName }}()
-	emptySlice.ForEachIndex(func(i int, el {{ .elementName }}) {
-		t.Fail()
-	})
-
-	// Test _ForEachIndex
+	// Test _Range
 	slice := generateTest{{ .structName }}()
 	total := 0
-	slice.ForEachIndex(func(i int, el {{ .elementName }}) {
+	slice.Range(func(i int, el {{ .elementName }}) {
 		total+=i
 	})
 	assert.Equal(t, 0+1+2+3+4+5+6, total)
-}
-
-func Test{{ .structName }}_ForEachWhile(t *testing.T) {
-	// Test ForEach on empty slice
-	emptySlice := New{{ .structName }}()
-	emptySlice.ForEachWhile(func(el {{ .elementName }}) bool {
-		t.Fail()
-		return false
-	})
-
-	// Test ForEachWhile stops short
-	slice := generateTest{{ .structName }}()
-	last := 0
-	proceed := slice.ForEachWhile(func(el {{ .elementName }}) bool{
-		last++
-		if last == 4 {
-			return false
-		}
-		return true
-	})
-	assert.False(t, proceed)
-	assert.Equal(t, 4, last)
-
-	// Test ForEachWhile completes
-	last = 0
-	proceed = slice.ForEachWhile(func(el {{ .elementName }}) bool{
-		last++
-		return true
-	})
-	assert.True(t, proceed)
-	assert.Equal(t, 7, last)
 }`
 
 const sliceGenerateTest = `func generateTest{{ .structName }}() {{ .structName }} {

--- a/pdata/internal/cmd/pdatagen/internal/base_slices.go
+++ b/pdata/internal/cmd/pdatagen/internal/base_slices.go
@@ -171,6 +171,17 @@ func (es {{ .structName }}) ForEachIndex(f func(int, {{ .elementName }})) {
 	for i := 0; i < es.Len(); i++ {
 		f(i, es.At(i))
 	}
+}
+
+// ForEachWhile iterates over {{ .structName }} and executes f against each element.
+// The function also passes the iteration index.
+func (es {{ .structName }}) ForEachWhile(f func({{ .elementName }}) bool) bool {
+	for i := 0; i < es.Len(); i++ {
+		if !f(es.At(i)) {
+			return false
+		}
+	}
+	return true
 }`
 
 const sliceTestTemplate = `func Test{{ .structName }}(t *testing.T) {
@@ -315,19 +326,50 @@ func Test{{ .structName }}_ForEach(t *testing.T) {
 }
 
 func Test{{ .structName }}_ForEachIndex(t *testing.T) {
-	// Test ForEach on empty slice
+	// Test _ForEachIndex on empty slice
 	emptySlice := New{{ .structName }}()
 	emptySlice.ForEachIndex(func(i int, el {{ .elementName }}) {
 		t.Fail()
 	})
 
-	// Test ForEach
+	// Test _ForEachIndex
 	slice := generateTest{{ .structName }}()
 	total := 0
 	slice.ForEachIndex(func(i int, el {{ .elementName }}) {
 		total+=i
 	})
 	assert.Equal(t, 0+1+2+3+4+5+6, total)
+}
+
+func Test{{ .structName }}_ForEachWhile(t *testing.T) {
+	// Test ForEach on empty slice
+	emptySlice := New{{ .structName }}()
+	emptySlice.ForEachWhile(func(el {{ .elementName }}) bool {
+		t.Fail()
+		return false
+	})
+
+	// Test ForEachWhile stops short
+	slice := generateTest{{ .structName }}()
+	last := 0
+	proceed := slice.ForEachWhile(func(el {{ .elementName }}) bool{
+		last++
+		if last == 4 {
+			return false
+		}
+		return true
+	})
+	assert.False(t, proceed)
+	assert.Equal(t, 4, last)
+
+	// Test ForEachWhile completes
+	last = 0
+	proceed = slice.ForEachWhile(func(el {{ .elementName }}) bool{
+		last++
+		return true
+	})
+	assert.True(t, proceed)
+	assert.Equal(t, 7, last)
 }`
 
 const sliceGenerateTest = `func generateTest{{ .structName }}() {{ .structName }} {

--- a/pdata/plog/generated_logrecordslice.go
+++ b/pdata/plog/generated_logrecordslice.go
@@ -165,3 +165,14 @@ func (es LogRecordSlice) ForEachIndex(f func(int, LogRecord)) {
 		f(i, es.At(i))
 	}
 }
+
+// ForEachWhile iterates over LogRecordSlice and executes f against each element.
+// The function also passes the iteration index.
+func (es LogRecordSlice) ForEachWhile(f func(LogRecord) bool) bool {
+	for i := 0; i < es.Len(); i++ {
+		if !f(es.At(i)) {
+			return false
+		}
+	}
+	return true
+}

--- a/pdata/plog/generated_logrecordslice.go
+++ b/pdata/plog/generated_logrecordslice.go
@@ -150,3 +150,10 @@ func (es LogRecordSlice) Sort(less func(a, b LogRecord) bool) {
 	es.state.AssertMutable()
 	sort.SliceStable(*es.orig, func(i, j int) bool { return less(es.At(i), es.At(j)) })
 }
+
+// ForEach iterates over LogRecordSlice and executes f against each element.
+func (es LogRecordSlice) ForEach(f func(el LogRecord)) {
+	for i := 0; i < es.Len(); i++ {
+		f(es.At(i))
+	}
+}

--- a/pdata/plog/generated_logrecordslice.go
+++ b/pdata/plog/generated_logrecordslice.go
@@ -151,28 +151,10 @@ func (es LogRecordSlice) Sort(less func(a, b LogRecord) bool) {
 	sort.SliceStable(*es.orig, func(i, j int) bool { return less(es.At(i), es.At(j)) })
 }
 
-// ForEach iterates over LogRecordSlice and executes f against each element.
-func (es LogRecordSlice) ForEach(f func(LogRecord)) {
-	for i := 0; i < es.Len(); i++ {
-		f(es.At(i))
-	}
-}
-
-// ForEachIndex iterates over LogRecordSlice and executes f against each element.
+// Range iterates over LogRecordSlice and executes f against each element.
 // The function also passes the iteration index.
-func (es LogRecordSlice) ForEachIndex(f func(int, LogRecord)) {
+func (es LogRecordSlice) Range(f func(int, LogRecord)) {
 	for i := 0; i < es.Len(); i++ {
 		f(i, es.At(i))
 	}
-}
-
-// ForEachWhile iterates over LogRecordSlice and executes f against each element.
-// The function also passes the iteration index.
-func (es LogRecordSlice) ForEachWhile(f func(LogRecord) bool) bool {
-	for i := 0; i < es.Len(); i++ {
-		if !f(es.At(i)) {
-			return false
-		}
-	}
-	return true
 }

--- a/pdata/plog/generated_logrecordslice.go
+++ b/pdata/plog/generated_logrecordslice.go
@@ -152,8 +152,16 @@ func (es LogRecordSlice) Sort(less func(a, b LogRecord) bool) {
 }
 
 // ForEach iterates over LogRecordSlice and executes f against each element.
-func (es LogRecordSlice) ForEach(f func(el LogRecord)) {
+func (es LogRecordSlice) ForEach(f func(LogRecord)) {
 	for i := 0; i < es.Len(); i++ {
 		f(es.At(i))
+	}
+}
+
+// ForEachIndex iterates over LogRecordSlice and executes f against each element.
+// The function also passes the iteration index.
+func (es LogRecordSlice) ForEachIndex(f func(int, LogRecord)) {
+	for i := 0; i < es.Len(); i++ {
+		f(i, es.At(i))
 	}
 }

--- a/pdata/plog/generated_logrecordslice_test.go
+++ b/pdata/plog/generated_logrecordslice_test.go
@@ -139,6 +139,22 @@ func TestLogRecordSlice_Sort(t *testing.T) {
 	}
 }
 
+func TestLogRecordSlice_ForEach(t *testing.T) {
+	// Test ForEach on empty slice
+	emptySlice := NewLogRecordSlice()
+	emptySlice.ForEach(func(el LogRecord) {
+		t.Fail()
+	})
+
+	// Test ForEach
+	slice := generateTestLogRecordSlice()
+	pos := 0
+	slice.ForEach(func(el LogRecord) {
+		pos++
+	})
+	assert.Equal(t, 7, slice.Len())
+}
+
 func generateTestLogRecordSlice() LogRecordSlice {
 	es := NewLogRecordSlice()
 	fillTestLogRecordSlice(es)

--- a/pdata/plog/generated_logrecordslice_test.go
+++ b/pdata/plog/generated_logrecordslice_test.go
@@ -148,11 +148,27 @@ func TestLogRecordSlice_ForEach(t *testing.T) {
 
 	// Test ForEach
 	slice := generateTestLogRecordSlice()
-	pos := 0
+	count := 0
 	slice.ForEach(func(el LogRecord) {
-		pos++
+		count++
 	})
-	assert.Equal(t, 7, slice.Len())
+	assert.Equal(t, 7, count)
+}
+
+func TestLogRecordSlice_ForEachIndex(t *testing.T) {
+	// Test ForEach on empty slice
+	emptySlice := NewLogRecordSlice()
+	emptySlice.ForEachIndex(func(i int, el LogRecord) {
+		t.Fail()
+	})
+
+	// Test ForEach
+	slice := generateTestLogRecordSlice()
+	total := 0
+	slice.ForEachIndex(func(i int, el LogRecord) {
+		total += i
+	})
+	assert.Equal(t, 0+1+2+3+4+5+6, total)
 }
 
 func generateTestLogRecordSlice() LogRecordSlice {

--- a/pdata/plog/generated_logrecordslice_test.go
+++ b/pdata/plog/generated_logrecordslice_test.go
@@ -156,19 +156,50 @@ func TestLogRecordSlice_ForEach(t *testing.T) {
 }
 
 func TestLogRecordSlice_ForEachIndex(t *testing.T) {
-	// Test ForEach on empty slice
+	// Test _ForEachIndex on empty slice
 	emptySlice := NewLogRecordSlice()
 	emptySlice.ForEachIndex(func(i int, el LogRecord) {
 		t.Fail()
 	})
 
-	// Test ForEach
+	// Test _ForEachIndex
 	slice := generateTestLogRecordSlice()
 	total := 0
 	slice.ForEachIndex(func(i int, el LogRecord) {
 		total += i
 	})
 	assert.Equal(t, 0+1+2+3+4+5+6, total)
+}
+
+func TestLogRecordSlice_ForEachWhile(t *testing.T) {
+	// Test ForEach on empty slice
+	emptySlice := NewLogRecordSlice()
+	emptySlice.ForEachWhile(func(el LogRecord) bool {
+		t.Fail()
+		return false
+	})
+
+	// Test ForEachWhile stops short
+	slice := generateTestLogRecordSlice()
+	last := 0
+	proceed := slice.ForEachWhile(func(el LogRecord) bool {
+		last++
+		if last == 4 {
+			return false
+		}
+		return true
+	})
+	assert.False(t, proceed)
+	assert.Equal(t, 4, last)
+
+	// Test ForEachWhile completes
+	last = 0
+	proceed = slice.ForEachWhile(func(el LogRecord) bool {
+		last++
+		return true
+	})
+	assert.True(t, proceed)
+	assert.Equal(t, 7, last)
 }
 
 func generateTestLogRecordSlice() LogRecordSlice {

--- a/pdata/plog/generated_logrecordslice_test.go
+++ b/pdata/plog/generated_logrecordslice_test.go
@@ -139,67 +139,20 @@ func TestLogRecordSlice_Sort(t *testing.T) {
 	}
 }
 
-func TestLogRecordSlice_ForEach(t *testing.T) {
-	// Test ForEach on empty slice
+func TestLogRecordSlice_Range(t *testing.T) {
+	// Test _Range on empty slice
 	emptySlice := NewLogRecordSlice()
-	emptySlice.ForEach(func(el LogRecord) {
+	emptySlice.Range(func(i int, el LogRecord) {
 		t.Fail()
 	})
 
-	// Test ForEach
-	slice := generateTestLogRecordSlice()
-	count := 0
-	slice.ForEach(func(el LogRecord) {
-		count++
-	})
-	assert.Equal(t, 7, count)
-}
-
-func TestLogRecordSlice_ForEachIndex(t *testing.T) {
-	// Test _ForEachIndex on empty slice
-	emptySlice := NewLogRecordSlice()
-	emptySlice.ForEachIndex(func(i int, el LogRecord) {
-		t.Fail()
-	})
-
-	// Test _ForEachIndex
+	// Test _Range
 	slice := generateTestLogRecordSlice()
 	total := 0
-	slice.ForEachIndex(func(i int, el LogRecord) {
+	slice.Range(func(i int, el LogRecord) {
 		total += i
 	})
 	assert.Equal(t, 0+1+2+3+4+5+6, total)
-}
-
-func TestLogRecordSlice_ForEachWhile(t *testing.T) {
-	// Test ForEach on empty slice
-	emptySlice := NewLogRecordSlice()
-	emptySlice.ForEachWhile(func(el LogRecord) bool {
-		t.Fail()
-		return false
-	})
-
-	// Test ForEachWhile stops short
-	slice := generateTestLogRecordSlice()
-	last := 0
-	proceed := slice.ForEachWhile(func(el LogRecord) bool {
-		last++
-		if last == 4 {
-			return false
-		}
-		return true
-	})
-	assert.False(t, proceed)
-	assert.Equal(t, 4, last)
-
-	// Test ForEachWhile completes
-	last = 0
-	proceed = slice.ForEachWhile(func(el LogRecord) bool {
-		last++
-		return true
-	})
-	assert.True(t, proceed)
-	assert.Equal(t, 7, last)
 }
 
 func generateTestLogRecordSlice() LogRecordSlice {

--- a/pdata/plog/generated_resourcelogsslice.go
+++ b/pdata/plog/generated_resourcelogsslice.go
@@ -152,8 +152,16 @@ func (es ResourceLogsSlice) Sort(less func(a, b ResourceLogs) bool) {
 }
 
 // ForEach iterates over ResourceLogsSlice and executes f against each element.
-func (es ResourceLogsSlice) ForEach(f func(el ResourceLogs)) {
+func (es ResourceLogsSlice) ForEach(f func(ResourceLogs)) {
 	for i := 0; i < es.Len(); i++ {
 		f(es.At(i))
+	}
+}
+
+// ForEachIndex iterates over ResourceLogsSlice and executes f against each element.
+// The function also passes the iteration index.
+func (es ResourceLogsSlice) ForEachIndex(f func(int, ResourceLogs)) {
+	for i := 0; i < es.Len(); i++ {
+		f(i, es.At(i))
 	}
 }

--- a/pdata/plog/generated_resourcelogsslice.go
+++ b/pdata/plog/generated_resourcelogsslice.go
@@ -165,3 +165,14 @@ func (es ResourceLogsSlice) ForEachIndex(f func(int, ResourceLogs)) {
 		f(i, es.At(i))
 	}
 }
+
+// ForEachWhile iterates over ResourceLogsSlice and executes f against each element.
+// The function also passes the iteration index.
+func (es ResourceLogsSlice) ForEachWhile(f func(ResourceLogs) bool) bool {
+	for i := 0; i < es.Len(); i++ {
+		if !f(es.At(i)) {
+			return false
+		}
+	}
+	return true
+}

--- a/pdata/plog/generated_resourcelogsslice.go
+++ b/pdata/plog/generated_resourcelogsslice.go
@@ -151,28 +151,10 @@ func (es ResourceLogsSlice) Sort(less func(a, b ResourceLogs) bool) {
 	sort.SliceStable(*es.orig, func(i, j int) bool { return less(es.At(i), es.At(j)) })
 }
 
-// ForEach iterates over ResourceLogsSlice and executes f against each element.
-func (es ResourceLogsSlice) ForEach(f func(ResourceLogs)) {
-	for i := 0; i < es.Len(); i++ {
-		f(es.At(i))
-	}
-}
-
-// ForEachIndex iterates over ResourceLogsSlice and executes f against each element.
+// Range iterates over ResourceLogsSlice and executes f against each element.
 // The function also passes the iteration index.
-func (es ResourceLogsSlice) ForEachIndex(f func(int, ResourceLogs)) {
+func (es ResourceLogsSlice) Range(f func(int, ResourceLogs)) {
 	for i := 0; i < es.Len(); i++ {
 		f(i, es.At(i))
 	}
-}
-
-// ForEachWhile iterates over ResourceLogsSlice and executes f against each element.
-// The function also passes the iteration index.
-func (es ResourceLogsSlice) ForEachWhile(f func(ResourceLogs) bool) bool {
-	for i := 0; i < es.Len(); i++ {
-		if !f(es.At(i)) {
-			return false
-		}
-	}
-	return true
 }

--- a/pdata/plog/generated_resourcelogsslice.go
+++ b/pdata/plog/generated_resourcelogsslice.go
@@ -150,3 +150,10 @@ func (es ResourceLogsSlice) Sort(less func(a, b ResourceLogs) bool) {
 	es.state.AssertMutable()
 	sort.SliceStable(*es.orig, func(i, j int) bool { return less(es.At(i), es.At(j)) })
 }
+
+// ForEach iterates over ResourceLogsSlice and executes f against each element.
+func (es ResourceLogsSlice) ForEach(f func(el ResourceLogs)) {
+	for i := 0; i < es.Len(); i++ {
+		f(es.At(i))
+	}
+}

--- a/pdata/plog/generated_resourcelogsslice_test.go
+++ b/pdata/plog/generated_resourcelogsslice_test.go
@@ -156,19 +156,50 @@ func TestResourceLogsSlice_ForEach(t *testing.T) {
 }
 
 func TestResourceLogsSlice_ForEachIndex(t *testing.T) {
-	// Test ForEach on empty slice
+	// Test _ForEachIndex on empty slice
 	emptySlice := NewResourceLogsSlice()
 	emptySlice.ForEachIndex(func(i int, el ResourceLogs) {
 		t.Fail()
 	})
 
-	// Test ForEach
+	// Test _ForEachIndex
 	slice := generateTestResourceLogsSlice()
 	total := 0
 	slice.ForEachIndex(func(i int, el ResourceLogs) {
 		total += i
 	})
 	assert.Equal(t, 0+1+2+3+4+5+6, total)
+}
+
+func TestResourceLogsSlice_ForEachWhile(t *testing.T) {
+	// Test ForEach on empty slice
+	emptySlice := NewResourceLogsSlice()
+	emptySlice.ForEachWhile(func(el ResourceLogs) bool {
+		t.Fail()
+		return false
+	})
+
+	// Test ForEachWhile stops short
+	slice := generateTestResourceLogsSlice()
+	last := 0
+	proceed := slice.ForEachWhile(func(el ResourceLogs) bool {
+		last++
+		if last == 4 {
+			return false
+		}
+		return true
+	})
+	assert.False(t, proceed)
+	assert.Equal(t, 4, last)
+
+	// Test ForEachWhile completes
+	last = 0
+	proceed = slice.ForEachWhile(func(el ResourceLogs) bool {
+		last++
+		return true
+	})
+	assert.True(t, proceed)
+	assert.Equal(t, 7, last)
 }
 
 func generateTestResourceLogsSlice() ResourceLogsSlice {

--- a/pdata/plog/generated_resourcelogsslice_test.go
+++ b/pdata/plog/generated_resourcelogsslice_test.go
@@ -139,67 +139,20 @@ func TestResourceLogsSlice_Sort(t *testing.T) {
 	}
 }
 
-func TestResourceLogsSlice_ForEach(t *testing.T) {
-	// Test ForEach on empty slice
+func TestResourceLogsSlice_Range(t *testing.T) {
+	// Test _Range on empty slice
 	emptySlice := NewResourceLogsSlice()
-	emptySlice.ForEach(func(el ResourceLogs) {
+	emptySlice.Range(func(i int, el ResourceLogs) {
 		t.Fail()
 	})
 
-	// Test ForEach
-	slice := generateTestResourceLogsSlice()
-	count := 0
-	slice.ForEach(func(el ResourceLogs) {
-		count++
-	})
-	assert.Equal(t, 7, count)
-}
-
-func TestResourceLogsSlice_ForEachIndex(t *testing.T) {
-	// Test _ForEachIndex on empty slice
-	emptySlice := NewResourceLogsSlice()
-	emptySlice.ForEachIndex(func(i int, el ResourceLogs) {
-		t.Fail()
-	})
-
-	// Test _ForEachIndex
+	// Test _Range
 	slice := generateTestResourceLogsSlice()
 	total := 0
-	slice.ForEachIndex(func(i int, el ResourceLogs) {
+	slice.Range(func(i int, el ResourceLogs) {
 		total += i
 	})
 	assert.Equal(t, 0+1+2+3+4+5+6, total)
-}
-
-func TestResourceLogsSlice_ForEachWhile(t *testing.T) {
-	// Test ForEach on empty slice
-	emptySlice := NewResourceLogsSlice()
-	emptySlice.ForEachWhile(func(el ResourceLogs) bool {
-		t.Fail()
-		return false
-	})
-
-	// Test ForEachWhile stops short
-	slice := generateTestResourceLogsSlice()
-	last := 0
-	proceed := slice.ForEachWhile(func(el ResourceLogs) bool {
-		last++
-		if last == 4 {
-			return false
-		}
-		return true
-	})
-	assert.False(t, proceed)
-	assert.Equal(t, 4, last)
-
-	// Test ForEachWhile completes
-	last = 0
-	proceed = slice.ForEachWhile(func(el ResourceLogs) bool {
-		last++
-		return true
-	})
-	assert.True(t, proceed)
-	assert.Equal(t, 7, last)
 }
 
 func generateTestResourceLogsSlice() ResourceLogsSlice {

--- a/pdata/plog/generated_resourcelogsslice_test.go
+++ b/pdata/plog/generated_resourcelogsslice_test.go
@@ -148,11 +148,27 @@ func TestResourceLogsSlice_ForEach(t *testing.T) {
 
 	// Test ForEach
 	slice := generateTestResourceLogsSlice()
-	pos := 0
+	count := 0
 	slice.ForEach(func(el ResourceLogs) {
-		pos++
+		count++
 	})
-	assert.Equal(t, 7, slice.Len())
+	assert.Equal(t, 7, count)
+}
+
+func TestResourceLogsSlice_ForEachIndex(t *testing.T) {
+	// Test ForEach on empty slice
+	emptySlice := NewResourceLogsSlice()
+	emptySlice.ForEachIndex(func(i int, el ResourceLogs) {
+		t.Fail()
+	})
+
+	// Test ForEach
+	slice := generateTestResourceLogsSlice()
+	total := 0
+	slice.ForEachIndex(func(i int, el ResourceLogs) {
+		total += i
+	})
+	assert.Equal(t, 0+1+2+3+4+5+6, total)
 }
 
 func generateTestResourceLogsSlice() ResourceLogsSlice {

--- a/pdata/plog/generated_resourcelogsslice_test.go
+++ b/pdata/plog/generated_resourcelogsslice_test.go
@@ -139,6 +139,22 @@ func TestResourceLogsSlice_Sort(t *testing.T) {
 	}
 }
 
+func TestResourceLogsSlice_ForEach(t *testing.T) {
+	// Test ForEach on empty slice
+	emptySlice := NewResourceLogsSlice()
+	emptySlice.ForEach(func(el ResourceLogs) {
+		t.Fail()
+	})
+
+	// Test ForEach
+	slice := generateTestResourceLogsSlice()
+	pos := 0
+	slice.ForEach(func(el ResourceLogs) {
+		pos++
+	})
+	assert.Equal(t, 7, slice.Len())
+}
+
 func generateTestResourceLogsSlice() ResourceLogsSlice {
 	es := NewResourceLogsSlice()
 	fillTestResourceLogsSlice(es)

--- a/pdata/plog/generated_scopelogsslice.go
+++ b/pdata/plog/generated_scopelogsslice.go
@@ -152,8 +152,16 @@ func (es ScopeLogsSlice) Sort(less func(a, b ScopeLogs) bool) {
 }
 
 // ForEach iterates over ScopeLogsSlice and executes f against each element.
-func (es ScopeLogsSlice) ForEach(f func(el ScopeLogs)) {
+func (es ScopeLogsSlice) ForEach(f func(ScopeLogs)) {
 	for i := 0; i < es.Len(); i++ {
 		f(es.At(i))
+	}
+}
+
+// ForEachIndex iterates over ScopeLogsSlice and executes f against each element.
+// The function also passes the iteration index.
+func (es ScopeLogsSlice) ForEachIndex(f func(int, ScopeLogs)) {
+	for i := 0; i < es.Len(); i++ {
+		f(i, es.At(i))
 	}
 }

--- a/pdata/plog/generated_scopelogsslice.go
+++ b/pdata/plog/generated_scopelogsslice.go
@@ -151,28 +151,10 @@ func (es ScopeLogsSlice) Sort(less func(a, b ScopeLogs) bool) {
 	sort.SliceStable(*es.orig, func(i, j int) bool { return less(es.At(i), es.At(j)) })
 }
 
-// ForEach iterates over ScopeLogsSlice and executes f against each element.
-func (es ScopeLogsSlice) ForEach(f func(ScopeLogs)) {
-	for i := 0; i < es.Len(); i++ {
-		f(es.At(i))
-	}
-}
-
-// ForEachIndex iterates over ScopeLogsSlice and executes f against each element.
+// Range iterates over ScopeLogsSlice and executes f against each element.
 // The function also passes the iteration index.
-func (es ScopeLogsSlice) ForEachIndex(f func(int, ScopeLogs)) {
+func (es ScopeLogsSlice) Range(f func(int, ScopeLogs)) {
 	for i := 0; i < es.Len(); i++ {
 		f(i, es.At(i))
 	}
-}
-
-// ForEachWhile iterates over ScopeLogsSlice and executes f against each element.
-// The function also passes the iteration index.
-func (es ScopeLogsSlice) ForEachWhile(f func(ScopeLogs) bool) bool {
-	for i := 0; i < es.Len(); i++ {
-		if !f(es.At(i)) {
-			return false
-		}
-	}
-	return true
 }

--- a/pdata/plog/generated_scopelogsslice.go
+++ b/pdata/plog/generated_scopelogsslice.go
@@ -165,3 +165,14 @@ func (es ScopeLogsSlice) ForEachIndex(f func(int, ScopeLogs)) {
 		f(i, es.At(i))
 	}
 }
+
+// ForEachWhile iterates over ScopeLogsSlice and executes f against each element.
+// The function also passes the iteration index.
+func (es ScopeLogsSlice) ForEachWhile(f func(ScopeLogs) bool) bool {
+	for i := 0; i < es.Len(); i++ {
+		if !f(es.At(i)) {
+			return false
+		}
+	}
+	return true
+}

--- a/pdata/plog/generated_scopelogsslice.go
+++ b/pdata/plog/generated_scopelogsslice.go
@@ -150,3 +150,10 @@ func (es ScopeLogsSlice) Sort(less func(a, b ScopeLogs) bool) {
 	es.state.AssertMutable()
 	sort.SliceStable(*es.orig, func(i, j int) bool { return less(es.At(i), es.At(j)) })
 }
+
+// ForEach iterates over ScopeLogsSlice and executes f against each element.
+func (es ScopeLogsSlice) ForEach(f func(el ScopeLogs)) {
+	for i := 0; i < es.Len(); i++ {
+		f(es.At(i))
+	}
+}

--- a/pdata/plog/generated_scopelogsslice_test.go
+++ b/pdata/plog/generated_scopelogsslice_test.go
@@ -156,19 +156,50 @@ func TestScopeLogsSlice_ForEach(t *testing.T) {
 }
 
 func TestScopeLogsSlice_ForEachIndex(t *testing.T) {
-	// Test ForEach on empty slice
+	// Test _ForEachIndex on empty slice
 	emptySlice := NewScopeLogsSlice()
 	emptySlice.ForEachIndex(func(i int, el ScopeLogs) {
 		t.Fail()
 	})
 
-	// Test ForEach
+	// Test _ForEachIndex
 	slice := generateTestScopeLogsSlice()
 	total := 0
 	slice.ForEachIndex(func(i int, el ScopeLogs) {
 		total += i
 	})
 	assert.Equal(t, 0+1+2+3+4+5+6, total)
+}
+
+func TestScopeLogsSlice_ForEachWhile(t *testing.T) {
+	// Test ForEach on empty slice
+	emptySlice := NewScopeLogsSlice()
+	emptySlice.ForEachWhile(func(el ScopeLogs) bool {
+		t.Fail()
+		return false
+	})
+
+	// Test ForEachWhile stops short
+	slice := generateTestScopeLogsSlice()
+	last := 0
+	proceed := slice.ForEachWhile(func(el ScopeLogs) bool {
+		last++
+		if last == 4 {
+			return false
+		}
+		return true
+	})
+	assert.False(t, proceed)
+	assert.Equal(t, 4, last)
+
+	// Test ForEachWhile completes
+	last = 0
+	proceed = slice.ForEachWhile(func(el ScopeLogs) bool {
+		last++
+		return true
+	})
+	assert.True(t, proceed)
+	assert.Equal(t, 7, last)
 }
 
 func generateTestScopeLogsSlice() ScopeLogsSlice {

--- a/pdata/plog/generated_scopelogsslice_test.go
+++ b/pdata/plog/generated_scopelogsslice_test.go
@@ -139,67 +139,20 @@ func TestScopeLogsSlice_Sort(t *testing.T) {
 	}
 }
 
-func TestScopeLogsSlice_ForEach(t *testing.T) {
-	// Test ForEach on empty slice
+func TestScopeLogsSlice_Range(t *testing.T) {
+	// Test _Range on empty slice
 	emptySlice := NewScopeLogsSlice()
-	emptySlice.ForEach(func(el ScopeLogs) {
+	emptySlice.Range(func(i int, el ScopeLogs) {
 		t.Fail()
 	})
 
-	// Test ForEach
-	slice := generateTestScopeLogsSlice()
-	count := 0
-	slice.ForEach(func(el ScopeLogs) {
-		count++
-	})
-	assert.Equal(t, 7, count)
-}
-
-func TestScopeLogsSlice_ForEachIndex(t *testing.T) {
-	// Test _ForEachIndex on empty slice
-	emptySlice := NewScopeLogsSlice()
-	emptySlice.ForEachIndex(func(i int, el ScopeLogs) {
-		t.Fail()
-	})
-
-	// Test _ForEachIndex
+	// Test _Range
 	slice := generateTestScopeLogsSlice()
 	total := 0
-	slice.ForEachIndex(func(i int, el ScopeLogs) {
+	slice.Range(func(i int, el ScopeLogs) {
 		total += i
 	})
 	assert.Equal(t, 0+1+2+3+4+5+6, total)
-}
-
-func TestScopeLogsSlice_ForEachWhile(t *testing.T) {
-	// Test ForEach on empty slice
-	emptySlice := NewScopeLogsSlice()
-	emptySlice.ForEachWhile(func(el ScopeLogs) bool {
-		t.Fail()
-		return false
-	})
-
-	// Test ForEachWhile stops short
-	slice := generateTestScopeLogsSlice()
-	last := 0
-	proceed := slice.ForEachWhile(func(el ScopeLogs) bool {
-		last++
-		if last == 4 {
-			return false
-		}
-		return true
-	})
-	assert.False(t, proceed)
-	assert.Equal(t, 4, last)
-
-	// Test ForEachWhile completes
-	last = 0
-	proceed = slice.ForEachWhile(func(el ScopeLogs) bool {
-		last++
-		return true
-	})
-	assert.True(t, proceed)
-	assert.Equal(t, 7, last)
 }
 
 func generateTestScopeLogsSlice() ScopeLogsSlice {

--- a/pdata/plog/generated_scopelogsslice_test.go
+++ b/pdata/plog/generated_scopelogsslice_test.go
@@ -148,11 +148,27 @@ func TestScopeLogsSlice_ForEach(t *testing.T) {
 
 	// Test ForEach
 	slice := generateTestScopeLogsSlice()
-	pos := 0
+	count := 0
 	slice.ForEach(func(el ScopeLogs) {
-		pos++
+		count++
 	})
-	assert.Equal(t, 7, slice.Len())
+	assert.Equal(t, 7, count)
+}
+
+func TestScopeLogsSlice_ForEachIndex(t *testing.T) {
+	// Test ForEach on empty slice
+	emptySlice := NewScopeLogsSlice()
+	emptySlice.ForEachIndex(func(i int, el ScopeLogs) {
+		t.Fail()
+	})
+
+	// Test ForEach
+	slice := generateTestScopeLogsSlice()
+	total := 0
+	slice.ForEachIndex(func(i int, el ScopeLogs) {
+		total += i
+	})
+	assert.Equal(t, 0+1+2+3+4+5+6, total)
 }
 
 func generateTestScopeLogsSlice() ScopeLogsSlice {

--- a/pdata/plog/generated_scopelogsslice_test.go
+++ b/pdata/plog/generated_scopelogsslice_test.go
@@ -139,6 +139,22 @@ func TestScopeLogsSlice_Sort(t *testing.T) {
 	}
 }
 
+func TestScopeLogsSlice_ForEach(t *testing.T) {
+	// Test ForEach on empty slice
+	emptySlice := NewScopeLogsSlice()
+	emptySlice.ForEach(func(el ScopeLogs) {
+		t.Fail()
+	})
+
+	// Test ForEach
+	slice := generateTestScopeLogsSlice()
+	pos := 0
+	slice.ForEach(func(el ScopeLogs) {
+		pos++
+	})
+	assert.Equal(t, 7, slice.Len())
+}
+
 func generateTestScopeLogsSlice() ScopeLogsSlice {
 	es := NewScopeLogsSlice()
 	fillTestScopeLogsSlice(es)

--- a/pdata/pmetric/generated_exemplarslice.go
+++ b/pdata/pmetric/generated_exemplarslice.go
@@ -149,3 +149,14 @@ func (es ExemplarSlice) ForEachIndex(f func(int, Exemplar)) {
 		f(i, es.At(i))
 	}
 }
+
+// ForEachWhile iterates over ExemplarSlice and executes f against each element.
+// The function also passes the iteration index.
+func (es ExemplarSlice) ForEachWhile(f func(Exemplar) bool) bool {
+	for i := 0; i < es.Len(); i++ {
+		if !f(es.At(i)) {
+			return false
+		}
+	}
+	return true
+}

--- a/pdata/pmetric/generated_exemplarslice.go
+++ b/pdata/pmetric/generated_exemplarslice.go
@@ -136,8 +136,16 @@ func (es ExemplarSlice) CopyTo(dest ExemplarSlice) {
 }
 
 // ForEach iterates over ExemplarSlice and executes f against each element.
-func (es ExemplarSlice) ForEach(f func(el Exemplar)) {
+func (es ExemplarSlice) ForEach(f func(Exemplar)) {
 	for i := 0; i < es.Len(); i++ {
 		f(es.At(i))
+	}
+}
+
+// ForEachIndex iterates over ExemplarSlice and executes f against each element.
+// The function also passes the iteration index.
+func (es ExemplarSlice) ForEachIndex(f func(int, Exemplar)) {
+	for i := 0; i < es.Len(); i++ {
+		f(i, es.At(i))
 	}
 }

--- a/pdata/pmetric/generated_exemplarslice.go
+++ b/pdata/pmetric/generated_exemplarslice.go
@@ -134,3 +134,10 @@ func (es ExemplarSlice) CopyTo(dest ExemplarSlice) {
 		newExemplar(&(*es.orig)[i], es.state).CopyTo(newExemplar(&(*dest.orig)[i], dest.state))
 	}
 }
+
+// ForEach iterates over ExemplarSlice and executes f against each element.
+func (es ExemplarSlice) ForEach(f func(el Exemplar)) {
+	for i := 0; i < es.Len(); i++ {
+		f(es.At(i))
+	}
+}

--- a/pdata/pmetric/generated_exemplarslice.go
+++ b/pdata/pmetric/generated_exemplarslice.go
@@ -135,28 +135,10 @@ func (es ExemplarSlice) CopyTo(dest ExemplarSlice) {
 	}
 }
 
-// ForEach iterates over ExemplarSlice and executes f against each element.
-func (es ExemplarSlice) ForEach(f func(Exemplar)) {
-	for i := 0; i < es.Len(); i++ {
-		f(es.At(i))
-	}
-}
-
-// ForEachIndex iterates over ExemplarSlice and executes f against each element.
+// Range iterates over ExemplarSlice and executes f against each element.
 // The function also passes the iteration index.
-func (es ExemplarSlice) ForEachIndex(f func(int, Exemplar)) {
+func (es ExemplarSlice) Range(f func(int, Exemplar)) {
 	for i := 0; i < es.Len(); i++ {
 		f(i, es.At(i))
 	}
-}
-
-// ForEachWhile iterates over ExemplarSlice and executes f against each element.
-// The function also passes the iteration index.
-func (es ExemplarSlice) ForEachWhile(f func(Exemplar) bool) bool {
-	for i := 0; i < es.Len(); i++ {
-		if !f(es.At(i)) {
-			return false
-		}
-	}
-	return true
 }

--- a/pdata/pmetric/generated_exemplarslice_test.go
+++ b/pdata/pmetric/generated_exemplarslice_test.go
@@ -131,11 +131,27 @@ func TestExemplarSlice_ForEach(t *testing.T) {
 
 	// Test ForEach
 	slice := generateTestExemplarSlice()
-	pos := 0
+	count := 0
 	slice.ForEach(func(el Exemplar) {
-		pos++
+		count++
 	})
-	assert.Equal(t, 7, slice.Len())
+	assert.Equal(t, 7, count)
+}
+
+func TestExemplarSlice_ForEachIndex(t *testing.T) {
+	// Test ForEach on empty slice
+	emptySlice := NewExemplarSlice()
+	emptySlice.ForEachIndex(func(i int, el Exemplar) {
+		t.Fail()
+	})
+
+	// Test ForEach
+	slice := generateTestExemplarSlice()
+	total := 0
+	slice.ForEachIndex(func(i int, el Exemplar) {
+		total += i
+	})
+	assert.Equal(t, 0+1+2+3+4+5+6, total)
 }
 
 func generateTestExemplarSlice() ExemplarSlice {

--- a/pdata/pmetric/generated_exemplarslice_test.go
+++ b/pdata/pmetric/generated_exemplarslice_test.go
@@ -139,19 +139,50 @@ func TestExemplarSlice_ForEach(t *testing.T) {
 }
 
 func TestExemplarSlice_ForEachIndex(t *testing.T) {
-	// Test ForEach on empty slice
+	// Test _ForEachIndex on empty slice
 	emptySlice := NewExemplarSlice()
 	emptySlice.ForEachIndex(func(i int, el Exemplar) {
 		t.Fail()
 	})
 
-	// Test ForEach
+	// Test _ForEachIndex
 	slice := generateTestExemplarSlice()
 	total := 0
 	slice.ForEachIndex(func(i int, el Exemplar) {
 		total += i
 	})
 	assert.Equal(t, 0+1+2+3+4+5+6, total)
+}
+
+func TestExemplarSlice_ForEachWhile(t *testing.T) {
+	// Test ForEach on empty slice
+	emptySlice := NewExemplarSlice()
+	emptySlice.ForEachWhile(func(el Exemplar) bool {
+		t.Fail()
+		return false
+	})
+
+	// Test ForEachWhile stops short
+	slice := generateTestExemplarSlice()
+	last := 0
+	proceed := slice.ForEachWhile(func(el Exemplar) bool {
+		last++
+		if last == 4 {
+			return false
+		}
+		return true
+	})
+	assert.False(t, proceed)
+	assert.Equal(t, 4, last)
+
+	// Test ForEachWhile completes
+	last = 0
+	proceed = slice.ForEachWhile(func(el Exemplar) bool {
+		last++
+		return true
+	})
+	assert.True(t, proceed)
+	assert.Equal(t, 7, last)
 }
 
 func generateTestExemplarSlice() ExemplarSlice {

--- a/pdata/pmetric/generated_exemplarslice_test.go
+++ b/pdata/pmetric/generated_exemplarslice_test.go
@@ -122,6 +122,22 @@ func TestExemplarSlice_RemoveIf(t *testing.T) {
 	assert.Equal(t, 5, filtered.Len())
 }
 
+func TestExemplarSlice_ForEach(t *testing.T) {
+	// Test ForEach on empty slice
+	emptySlice := NewExemplarSlice()
+	emptySlice.ForEach(func(el Exemplar) {
+		t.Fail()
+	})
+
+	// Test ForEach
+	slice := generateTestExemplarSlice()
+	pos := 0
+	slice.ForEach(func(el Exemplar) {
+		pos++
+	})
+	assert.Equal(t, 7, slice.Len())
+}
+
 func generateTestExemplarSlice() ExemplarSlice {
 	es := NewExemplarSlice()
 	fillTestExemplarSlice(es)

--- a/pdata/pmetric/generated_exemplarslice_test.go
+++ b/pdata/pmetric/generated_exemplarslice_test.go
@@ -122,67 +122,20 @@ func TestExemplarSlice_RemoveIf(t *testing.T) {
 	assert.Equal(t, 5, filtered.Len())
 }
 
-func TestExemplarSlice_ForEach(t *testing.T) {
-	// Test ForEach on empty slice
+func TestExemplarSlice_Range(t *testing.T) {
+	// Test _Range on empty slice
 	emptySlice := NewExemplarSlice()
-	emptySlice.ForEach(func(el Exemplar) {
+	emptySlice.Range(func(i int, el Exemplar) {
 		t.Fail()
 	})
 
-	// Test ForEach
-	slice := generateTestExemplarSlice()
-	count := 0
-	slice.ForEach(func(el Exemplar) {
-		count++
-	})
-	assert.Equal(t, 7, count)
-}
-
-func TestExemplarSlice_ForEachIndex(t *testing.T) {
-	// Test _ForEachIndex on empty slice
-	emptySlice := NewExemplarSlice()
-	emptySlice.ForEachIndex(func(i int, el Exemplar) {
-		t.Fail()
-	})
-
-	// Test _ForEachIndex
+	// Test _Range
 	slice := generateTestExemplarSlice()
 	total := 0
-	slice.ForEachIndex(func(i int, el Exemplar) {
+	slice.Range(func(i int, el Exemplar) {
 		total += i
 	})
 	assert.Equal(t, 0+1+2+3+4+5+6, total)
-}
-
-func TestExemplarSlice_ForEachWhile(t *testing.T) {
-	// Test ForEach on empty slice
-	emptySlice := NewExemplarSlice()
-	emptySlice.ForEachWhile(func(el Exemplar) bool {
-		t.Fail()
-		return false
-	})
-
-	// Test ForEachWhile stops short
-	slice := generateTestExemplarSlice()
-	last := 0
-	proceed := slice.ForEachWhile(func(el Exemplar) bool {
-		last++
-		if last == 4 {
-			return false
-		}
-		return true
-	})
-	assert.False(t, proceed)
-	assert.Equal(t, 4, last)
-
-	// Test ForEachWhile completes
-	last = 0
-	proceed = slice.ForEachWhile(func(el Exemplar) bool {
-		last++
-		return true
-	})
-	assert.True(t, proceed)
-	assert.Equal(t, 7, last)
 }
 
 func generateTestExemplarSlice() ExemplarSlice {

--- a/pdata/pmetric/generated_exponentialhistogramdatapointslice.go
+++ b/pdata/pmetric/generated_exponentialhistogramdatapointslice.go
@@ -165,3 +165,14 @@ func (es ExponentialHistogramDataPointSlice) ForEachIndex(f func(int, Exponentia
 		f(i, es.At(i))
 	}
 }
+
+// ForEachWhile iterates over ExponentialHistogramDataPointSlice and executes f against each element.
+// The function also passes the iteration index.
+func (es ExponentialHistogramDataPointSlice) ForEachWhile(f func(ExponentialHistogramDataPoint) bool) bool {
+	for i := 0; i < es.Len(); i++ {
+		if !f(es.At(i)) {
+			return false
+		}
+	}
+	return true
+}

--- a/pdata/pmetric/generated_exponentialhistogramdatapointslice.go
+++ b/pdata/pmetric/generated_exponentialhistogramdatapointslice.go
@@ -151,28 +151,10 @@ func (es ExponentialHistogramDataPointSlice) Sort(less func(a, b ExponentialHist
 	sort.SliceStable(*es.orig, func(i, j int) bool { return less(es.At(i), es.At(j)) })
 }
 
-// ForEach iterates over ExponentialHistogramDataPointSlice and executes f against each element.
-func (es ExponentialHistogramDataPointSlice) ForEach(f func(ExponentialHistogramDataPoint)) {
-	for i := 0; i < es.Len(); i++ {
-		f(es.At(i))
-	}
-}
-
-// ForEachIndex iterates over ExponentialHistogramDataPointSlice and executes f against each element.
+// Range iterates over ExponentialHistogramDataPointSlice and executes f against each element.
 // The function also passes the iteration index.
-func (es ExponentialHistogramDataPointSlice) ForEachIndex(f func(int, ExponentialHistogramDataPoint)) {
+func (es ExponentialHistogramDataPointSlice) Range(f func(int, ExponentialHistogramDataPoint)) {
 	for i := 0; i < es.Len(); i++ {
 		f(i, es.At(i))
 	}
-}
-
-// ForEachWhile iterates over ExponentialHistogramDataPointSlice and executes f against each element.
-// The function also passes the iteration index.
-func (es ExponentialHistogramDataPointSlice) ForEachWhile(f func(ExponentialHistogramDataPoint) bool) bool {
-	for i := 0; i < es.Len(); i++ {
-		if !f(es.At(i)) {
-			return false
-		}
-	}
-	return true
 }

--- a/pdata/pmetric/generated_exponentialhistogramdatapointslice.go
+++ b/pdata/pmetric/generated_exponentialhistogramdatapointslice.go
@@ -152,8 +152,16 @@ func (es ExponentialHistogramDataPointSlice) Sort(less func(a, b ExponentialHist
 }
 
 // ForEach iterates over ExponentialHistogramDataPointSlice and executes f against each element.
-func (es ExponentialHistogramDataPointSlice) ForEach(f func(el ExponentialHistogramDataPoint)) {
+func (es ExponentialHistogramDataPointSlice) ForEach(f func(ExponentialHistogramDataPoint)) {
 	for i := 0; i < es.Len(); i++ {
 		f(es.At(i))
+	}
+}
+
+// ForEachIndex iterates over ExponentialHistogramDataPointSlice and executes f against each element.
+// The function also passes the iteration index.
+func (es ExponentialHistogramDataPointSlice) ForEachIndex(f func(int, ExponentialHistogramDataPoint)) {
+	for i := 0; i < es.Len(); i++ {
+		f(i, es.At(i))
 	}
 }

--- a/pdata/pmetric/generated_exponentialhistogramdatapointslice.go
+++ b/pdata/pmetric/generated_exponentialhistogramdatapointslice.go
@@ -150,3 +150,10 @@ func (es ExponentialHistogramDataPointSlice) Sort(less func(a, b ExponentialHist
 	es.state.AssertMutable()
 	sort.SliceStable(*es.orig, func(i, j int) bool { return less(es.At(i), es.At(j)) })
 }
+
+// ForEach iterates over ExponentialHistogramDataPointSlice and executes f against each element.
+func (es ExponentialHistogramDataPointSlice) ForEach(f func(el ExponentialHistogramDataPoint)) {
+	for i := 0; i < es.Len(); i++ {
+		f(es.At(i))
+	}
+}

--- a/pdata/pmetric/generated_exponentialhistogramdatapointslice_test.go
+++ b/pdata/pmetric/generated_exponentialhistogramdatapointslice_test.go
@@ -139,67 +139,20 @@ func TestExponentialHistogramDataPointSlice_Sort(t *testing.T) {
 	}
 }
 
-func TestExponentialHistogramDataPointSlice_ForEach(t *testing.T) {
-	// Test ForEach on empty slice
+func TestExponentialHistogramDataPointSlice_Range(t *testing.T) {
+	// Test _Range on empty slice
 	emptySlice := NewExponentialHistogramDataPointSlice()
-	emptySlice.ForEach(func(el ExponentialHistogramDataPoint) {
+	emptySlice.Range(func(i int, el ExponentialHistogramDataPoint) {
 		t.Fail()
 	})
 
-	// Test ForEach
-	slice := generateTestExponentialHistogramDataPointSlice()
-	count := 0
-	slice.ForEach(func(el ExponentialHistogramDataPoint) {
-		count++
-	})
-	assert.Equal(t, 7, count)
-}
-
-func TestExponentialHistogramDataPointSlice_ForEachIndex(t *testing.T) {
-	// Test _ForEachIndex on empty slice
-	emptySlice := NewExponentialHistogramDataPointSlice()
-	emptySlice.ForEachIndex(func(i int, el ExponentialHistogramDataPoint) {
-		t.Fail()
-	})
-
-	// Test _ForEachIndex
+	// Test _Range
 	slice := generateTestExponentialHistogramDataPointSlice()
 	total := 0
-	slice.ForEachIndex(func(i int, el ExponentialHistogramDataPoint) {
+	slice.Range(func(i int, el ExponentialHistogramDataPoint) {
 		total += i
 	})
 	assert.Equal(t, 0+1+2+3+4+5+6, total)
-}
-
-func TestExponentialHistogramDataPointSlice_ForEachWhile(t *testing.T) {
-	// Test ForEach on empty slice
-	emptySlice := NewExponentialHistogramDataPointSlice()
-	emptySlice.ForEachWhile(func(el ExponentialHistogramDataPoint) bool {
-		t.Fail()
-		return false
-	})
-
-	// Test ForEachWhile stops short
-	slice := generateTestExponentialHistogramDataPointSlice()
-	last := 0
-	proceed := slice.ForEachWhile(func(el ExponentialHistogramDataPoint) bool {
-		last++
-		if last == 4 {
-			return false
-		}
-		return true
-	})
-	assert.False(t, proceed)
-	assert.Equal(t, 4, last)
-
-	// Test ForEachWhile completes
-	last = 0
-	proceed = slice.ForEachWhile(func(el ExponentialHistogramDataPoint) bool {
-		last++
-		return true
-	})
-	assert.True(t, proceed)
-	assert.Equal(t, 7, last)
 }
 
 func generateTestExponentialHistogramDataPointSlice() ExponentialHistogramDataPointSlice {

--- a/pdata/pmetric/generated_exponentialhistogramdatapointslice_test.go
+++ b/pdata/pmetric/generated_exponentialhistogramdatapointslice_test.go
@@ -148,11 +148,27 @@ func TestExponentialHistogramDataPointSlice_ForEach(t *testing.T) {
 
 	// Test ForEach
 	slice := generateTestExponentialHistogramDataPointSlice()
-	pos := 0
+	count := 0
 	slice.ForEach(func(el ExponentialHistogramDataPoint) {
-		pos++
+		count++
 	})
-	assert.Equal(t, 7, slice.Len())
+	assert.Equal(t, 7, count)
+}
+
+func TestExponentialHistogramDataPointSlice_ForEachIndex(t *testing.T) {
+	// Test ForEach on empty slice
+	emptySlice := NewExponentialHistogramDataPointSlice()
+	emptySlice.ForEachIndex(func(i int, el ExponentialHistogramDataPoint) {
+		t.Fail()
+	})
+
+	// Test ForEach
+	slice := generateTestExponentialHistogramDataPointSlice()
+	total := 0
+	slice.ForEachIndex(func(i int, el ExponentialHistogramDataPoint) {
+		total += i
+	})
+	assert.Equal(t, 0+1+2+3+4+5+6, total)
 }
 
 func generateTestExponentialHistogramDataPointSlice() ExponentialHistogramDataPointSlice {

--- a/pdata/pmetric/generated_exponentialhistogramdatapointslice_test.go
+++ b/pdata/pmetric/generated_exponentialhistogramdatapointslice_test.go
@@ -139,6 +139,22 @@ func TestExponentialHistogramDataPointSlice_Sort(t *testing.T) {
 	}
 }
 
+func TestExponentialHistogramDataPointSlice_ForEach(t *testing.T) {
+	// Test ForEach on empty slice
+	emptySlice := NewExponentialHistogramDataPointSlice()
+	emptySlice.ForEach(func(el ExponentialHistogramDataPoint) {
+		t.Fail()
+	})
+
+	// Test ForEach
+	slice := generateTestExponentialHistogramDataPointSlice()
+	pos := 0
+	slice.ForEach(func(el ExponentialHistogramDataPoint) {
+		pos++
+	})
+	assert.Equal(t, 7, slice.Len())
+}
+
 func generateTestExponentialHistogramDataPointSlice() ExponentialHistogramDataPointSlice {
 	es := NewExponentialHistogramDataPointSlice()
 	fillTestExponentialHistogramDataPointSlice(es)

--- a/pdata/pmetric/generated_exponentialhistogramdatapointslice_test.go
+++ b/pdata/pmetric/generated_exponentialhistogramdatapointslice_test.go
@@ -156,19 +156,50 @@ func TestExponentialHistogramDataPointSlice_ForEach(t *testing.T) {
 }
 
 func TestExponentialHistogramDataPointSlice_ForEachIndex(t *testing.T) {
-	// Test ForEach on empty slice
+	// Test _ForEachIndex on empty slice
 	emptySlice := NewExponentialHistogramDataPointSlice()
 	emptySlice.ForEachIndex(func(i int, el ExponentialHistogramDataPoint) {
 		t.Fail()
 	})
 
-	// Test ForEach
+	// Test _ForEachIndex
 	slice := generateTestExponentialHistogramDataPointSlice()
 	total := 0
 	slice.ForEachIndex(func(i int, el ExponentialHistogramDataPoint) {
 		total += i
 	})
 	assert.Equal(t, 0+1+2+3+4+5+6, total)
+}
+
+func TestExponentialHistogramDataPointSlice_ForEachWhile(t *testing.T) {
+	// Test ForEach on empty slice
+	emptySlice := NewExponentialHistogramDataPointSlice()
+	emptySlice.ForEachWhile(func(el ExponentialHistogramDataPoint) bool {
+		t.Fail()
+		return false
+	})
+
+	// Test ForEachWhile stops short
+	slice := generateTestExponentialHistogramDataPointSlice()
+	last := 0
+	proceed := slice.ForEachWhile(func(el ExponentialHistogramDataPoint) bool {
+		last++
+		if last == 4 {
+			return false
+		}
+		return true
+	})
+	assert.False(t, proceed)
+	assert.Equal(t, 4, last)
+
+	// Test ForEachWhile completes
+	last = 0
+	proceed = slice.ForEachWhile(func(el ExponentialHistogramDataPoint) bool {
+		last++
+		return true
+	})
+	assert.True(t, proceed)
+	assert.Equal(t, 7, last)
 }
 
 func generateTestExponentialHistogramDataPointSlice() ExponentialHistogramDataPointSlice {

--- a/pdata/pmetric/generated_histogramdatapointslice.go
+++ b/pdata/pmetric/generated_histogramdatapointslice.go
@@ -151,28 +151,10 @@ func (es HistogramDataPointSlice) Sort(less func(a, b HistogramDataPoint) bool) 
 	sort.SliceStable(*es.orig, func(i, j int) bool { return less(es.At(i), es.At(j)) })
 }
 
-// ForEach iterates over HistogramDataPointSlice and executes f against each element.
-func (es HistogramDataPointSlice) ForEach(f func(HistogramDataPoint)) {
-	for i := 0; i < es.Len(); i++ {
-		f(es.At(i))
-	}
-}
-
-// ForEachIndex iterates over HistogramDataPointSlice and executes f against each element.
+// Range iterates over HistogramDataPointSlice and executes f against each element.
 // The function also passes the iteration index.
-func (es HistogramDataPointSlice) ForEachIndex(f func(int, HistogramDataPoint)) {
+func (es HistogramDataPointSlice) Range(f func(int, HistogramDataPoint)) {
 	for i := 0; i < es.Len(); i++ {
 		f(i, es.At(i))
 	}
-}
-
-// ForEachWhile iterates over HistogramDataPointSlice and executes f against each element.
-// The function also passes the iteration index.
-func (es HistogramDataPointSlice) ForEachWhile(f func(HistogramDataPoint) bool) bool {
-	for i := 0; i < es.Len(); i++ {
-		if !f(es.At(i)) {
-			return false
-		}
-	}
-	return true
 }

--- a/pdata/pmetric/generated_histogramdatapointslice.go
+++ b/pdata/pmetric/generated_histogramdatapointslice.go
@@ -152,8 +152,16 @@ func (es HistogramDataPointSlice) Sort(less func(a, b HistogramDataPoint) bool) 
 }
 
 // ForEach iterates over HistogramDataPointSlice and executes f against each element.
-func (es HistogramDataPointSlice) ForEach(f func(el HistogramDataPoint)) {
+func (es HistogramDataPointSlice) ForEach(f func(HistogramDataPoint)) {
 	for i := 0; i < es.Len(); i++ {
 		f(es.At(i))
+	}
+}
+
+// ForEachIndex iterates over HistogramDataPointSlice and executes f against each element.
+// The function also passes the iteration index.
+func (es HistogramDataPointSlice) ForEachIndex(f func(int, HistogramDataPoint)) {
+	for i := 0; i < es.Len(); i++ {
+		f(i, es.At(i))
 	}
 }

--- a/pdata/pmetric/generated_histogramdatapointslice.go
+++ b/pdata/pmetric/generated_histogramdatapointslice.go
@@ -165,3 +165,14 @@ func (es HistogramDataPointSlice) ForEachIndex(f func(int, HistogramDataPoint)) 
 		f(i, es.At(i))
 	}
 }
+
+// ForEachWhile iterates over HistogramDataPointSlice and executes f against each element.
+// The function also passes the iteration index.
+func (es HistogramDataPointSlice) ForEachWhile(f func(HistogramDataPoint) bool) bool {
+	for i := 0; i < es.Len(); i++ {
+		if !f(es.At(i)) {
+			return false
+		}
+	}
+	return true
+}

--- a/pdata/pmetric/generated_histogramdatapointslice.go
+++ b/pdata/pmetric/generated_histogramdatapointslice.go
@@ -150,3 +150,10 @@ func (es HistogramDataPointSlice) Sort(less func(a, b HistogramDataPoint) bool) 
 	es.state.AssertMutable()
 	sort.SliceStable(*es.orig, func(i, j int) bool { return less(es.At(i), es.At(j)) })
 }
+
+// ForEach iterates over HistogramDataPointSlice and executes f against each element.
+func (es HistogramDataPointSlice) ForEach(f func(el HistogramDataPoint)) {
+	for i := 0; i < es.Len(); i++ {
+		f(es.At(i))
+	}
+}

--- a/pdata/pmetric/generated_histogramdatapointslice_test.go
+++ b/pdata/pmetric/generated_histogramdatapointslice_test.go
@@ -148,11 +148,27 @@ func TestHistogramDataPointSlice_ForEach(t *testing.T) {
 
 	// Test ForEach
 	slice := generateTestHistogramDataPointSlice()
-	pos := 0
+	count := 0
 	slice.ForEach(func(el HistogramDataPoint) {
-		pos++
+		count++
 	})
-	assert.Equal(t, 7, slice.Len())
+	assert.Equal(t, 7, count)
+}
+
+func TestHistogramDataPointSlice_ForEachIndex(t *testing.T) {
+	// Test ForEach on empty slice
+	emptySlice := NewHistogramDataPointSlice()
+	emptySlice.ForEachIndex(func(i int, el HistogramDataPoint) {
+		t.Fail()
+	})
+
+	// Test ForEach
+	slice := generateTestHistogramDataPointSlice()
+	total := 0
+	slice.ForEachIndex(func(i int, el HistogramDataPoint) {
+		total += i
+	})
+	assert.Equal(t, 0+1+2+3+4+5+6, total)
 }
 
 func generateTestHistogramDataPointSlice() HistogramDataPointSlice {

--- a/pdata/pmetric/generated_histogramdatapointslice_test.go
+++ b/pdata/pmetric/generated_histogramdatapointslice_test.go
@@ -139,67 +139,20 @@ func TestHistogramDataPointSlice_Sort(t *testing.T) {
 	}
 }
 
-func TestHistogramDataPointSlice_ForEach(t *testing.T) {
-	// Test ForEach on empty slice
+func TestHistogramDataPointSlice_Range(t *testing.T) {
+	// Test _Range on empty slice
 	emptySlice := NewHistogramDataPointSlice()
-	emptySlice.ForEach(func(el HistogramDataPoint) {
+	emptySlice.Range(func(i int, el HistogramDataPoint) {
 		t.Fail()
 	})
 
-	// Test ForEach
-	slice := generateTestHistogramDataPointSlice()
-	count := 0
-	slice.ForEach(func(el HistogramDataPoint) {
-		count++
-	})
-	assert.Equal(t, 7, count)
-}
-
-func TestHistogramDataPointSlice_ForEachIndex(t *testing.T) {
-	// Test _ForEachIndex on empty slice
-	emptySlice := NewHistogramDataPointSlice()
-	emptySlice.ForEachIndex(func(i int, el HistogramDataPoint) {
-		t.Fail()
-	})
-
-	// Test _ForEachIndex
+	// Test _Range
 	slice := generateTestHistogramDataPointSlice()
 	total := 0
-	slice.ForEachIndex(func(i int, el HistogramDataPoint) {
+	slice.Range(func(i int, el HistogramDataPoint) {
 		total += i
 	})
 	assert.Equal(t, 0+1+2+3+4+5+6, total)
-}
-
-func TestHistogramDataPointSlice_ForEachWhile(t *testing.T) {
-	// Test ForEach on empty slice
-	emptySlice := NewHistogramDataPointSlice()
-	emptySlice.ForEachWhile(func(el HistogramDataPoint) bool {
-		t.Fail()
-		return false
-	})
-
-	// Test ForEachWhile stops short
-	slice := generateTestHistogramDataPointSlice()
-	last := 0
-	proceed := slice.ForEachWhile(func(el HistogramDataPoint) bool {
-		last++
-		if last == 4 {
-			return false
-		}
-		return true
-	})
-	assert.False(t, proceed)
-	assert.Equal(t, 4, last)
-
-	// Test ForEachWhile completes
-	last = 0
-	proceed = slice.ForEachWhile(func(el HistogramDataPoint) bool {
-		last++
-		return true
-	})
-	assert.True(t, proceed)
-	assert.Equal(t, 7, last)
 }
 
 func generateTestHistogramDataPointSlice() HistogramDataPointSlice {

--- a/pdata/pmetric/generated_histogramdatapointslice_test.go
+++ b/pdata/pmetric/generated_histogramdatapointslice_test.go
@@ -156,19 +156,50 @@ func TestHistogramDataPointSlice_ForEach(t *testing.T) {
 }
 
 func TestHistogramDataPointSlice_ForEachIndex(t *testing.T) {
-	// Test ForEach on empty slice
+	// Test _ForEachIndex on empty slice
 	emptySlice := NewHistogramDataPointSlice()
 	emptySlice.ForEachIndex(func(i int, el HistogramDataPoint) {
 		t.Fail()
 	})
 
-	// Test ForEach
+	// Test _ForEachIndex
 	slice := generateTestHistogramDataPointSlice()
 	total := 0
 	slice.ForEachIndex(func(i int, el HistogramDataPoint) {
 		total += i
 	})
 	assert.Equal(t, 0+1+2+3+4+5+6, total)
+}
+
+func TestHistogramDataPointSlice_ForEachWhile(t *testing.T) {
+	// Test ForEach on empty slice
+	emptySlice := NewHistogramDataPointSlice()
+	emptySlice.ForEachWhile(func(el HistogramDataPoint) bool {
+		t.Fail()
+		return false
+	})
+
+	// Test ForEachWhile stops short
+	slice := generateTestHistogramDataPointSlice()
+	last := 0
+	proceed := slice.ForEachWhile(func(el HistogramDataPoint) bool {
+		last++
+		if last == 4 {
+			return false
+		}
+		return true
+	})
+	assert.False(t, proceed)
+	assert.Equal(t, 4, last)
+
+	// Test ForEachWhile completes
+	last = 0
+	proceed = slice.ForEachWhile(func(el HistogramDataPoint) bool {
+		last++
+		return true
+	})
+	assert.True(t, proceed)
+	assert.Equal(t, 7, last)
 }
 
 func generateTestHistogramDataPointSlice() HistogramDataPointSlice {

--- a/pdata/pmetric/generated_histogramdatapointslice_test.go
+++ b/pdata/pmetric/generated_histogramdatapointslice_test.go
@@ -139,6 +139,22 @@ func TestHistogramDataPointSlice_Sort(t *testing.T) {
 	}
 }
 
+func TestHistogramDataPointSlice_ForEach(t *testing.T) {
+	// Test ForEach on empty slice
+	emptySlice := NewHistogramDataPointSlice()
+	emptySlice.ForEach(func(el HistogramDataPoint) {
+		t.Fail()
+	})
+
+	// Test ForEach
+	slice := generateTestHistogramDataPointSlice()
+	pos := 0
+	slice.ForEach(func(el HistogramDataPoint) {
+		pos++
+	})
+	assert.Equal(t, 7, slice.Len())
+}
+
 func generateTestHistogramDataPointSlice() HistogramDataPointSlice {
 	es := NewHistogramDataPointSlice()
 	fillTestHistogramDataPointSlice(es)

--- a/pdata/pmetric/generated_metricslice.go
+++ b/pdata/pmetric/generated_metricslice.go
@@ -165,3 +165,14 @@ func (es MetricSlice) ForEachIndex(f func(int, Metric)) {
 		f(i, es.At(i))
 	}
 }
+
+// ForEachWhile iterates over MetricSlice and executes f against each element.
+// The function also passes the iteration index.
+func (es MetricSlice) ForEachWhile(f func(Metric) bool) bool {
+	for i := 0; i < es.Len(); i++ {
+		if !f(es.At(i)) {
+			return false
+		}
+	}
+	return true
+}

--- a/pdata/pmetric/generated_metricslice.go
+++ b/pdata/pmetric/generated_metricslice.go
@@ -152,8 +152,16 @@ func (es MetricSlice) Sort(less func(a, b Metric) bool) {
 }
 
 // ForEach iterates over MetricSlice and executes f against each element.
-func (es MetricSlice) ForEach(f func(el Metric)) {
+func (es MetricSlice) ForEach(f func(Metric)) {
 	for i := 0; i < es.Len(); i++ {
 		f(es.At(i))
+	}
+}
+
+// ForEachIndex iterates over MetricSlice and executes f against each element.
+// The function also passes the iteration index.
+func (es MetricSlice) ForEachIndex(f func(int, Metric)) {
+	for i := 0; i < es.Len(); i++ {
+		f(i, es.At(i))
 	}
 }

--- a/pdata/pmetric/generated_metricslice.go
+++ b/pdata/pmetric/generated_metricslice.go
@@ -150,3 +150,10 @@ func (es MetricSlice) Sort(less func(a, b Metric) bool) {
 	es.state.AssertMutable()
 	sort.SliceStable(*es.orig, func(i, j int) bool { return less(es.At(i), es.At(j)) })
 }
+
+// ForEach iterates over MetricSlice and executes f against each element.
+func (es MetricSlice) ForEach(f func(el Metric)) {
+	for i := 0; i < es.Len(); i++ {
+		f(es.At(i))
+	}
+}

--- a/pdata/pmetric/generated_metricslice.go
+++ b/pdata/pmetric/generated_metricslice.go
@@ -151,28 +151,10 @@ func (es MetricSlice) Sort(less func(a, b Metric) bool) {
 	sort.SliceStable(*es.orig, func(i, j int) bool { return less(es.At(i), es.At(j)) })
 }
 
-// ForEach iterates over MetricSlice and executes f against each element.
-func (es MetricSlice) ForEach(f func(Metric)) {
-	for i := 0; i < es.Len(); i++ {
-		f(es.At(i))
-	}
-}
-
-// ForEachIndex iterates over MetricSlice and executes f against each element.
+// Range iterates over MetricSlice and executes f against each element.
 // The function also passes the iteration index.
-func (es MetricSlice) ForEachIndex(f func(int, Metric)) {
+func (es MetricSlice) Range(f func(int, Metric)) {
 	for i := 0; i < es.Len(); i++ {
 		f(i, es.At(i))
 	}
-}
-
-// ForEachWhile iterates over MetricSlice and executes f against each element.
-// The function also passes the iteration index.
-func (es MetricSlice) ForEachWhile(f func(Metric) bool) bool {
-	for i := 0; i < es.Len(); i++ {
-		if !f(es.At(i)) {
-			return false
-		}
-	}
-	return true
 }

--- a/pdata/pmetric/generated_metricslice_test.go
+++ b/pdata/pmetric/generated_metricslice_test.go
@@ -156,19 +156,50 @@ func TestMetricSlice_ForEach(t *testing.T) {
 }
 
 func TestMetricSlice_ForEachIndex(t *testing.T) {
-	// Test ForEach on empty slice
+	// Test _ForEachIndex on empty slice
 	emptySlice := NewMetricSlice()
 	emptySlice.ForEachIndex(func(i int, el Metric) {
 		t.Fail()
 	})
 
-	// Test ForEach
+	// Test _ForEachIndex
 	slice := generateTestMetricSlice()
 	total := 0
 	slice.ForEachIndex(func(i int, el Metric) {
 		total += i
 	})
 	assert.Equal(t, 0+1+2+3+4+5+6, total)
+}
+
+func TestMetricSlice_ForEachWhile(t *testing.T) {
+	// Test ForEach on empty slice
+	emptySlice := NewMetricSlice()
+	emptySlice.ForEachWhile(func(el Metric) bool {
+		t.Fail()
+		return false
+	})
+
+	// Test ForEachWhile stops short
+	slice := generateTestMetricSlice()
+	last := 0
+	proceed := slice.ForEachWhile(func(el Metric) bool {
+		last++
+		if last == 4 {
+			return false
+		}
+		return true
+	})
+	assert.False(t, proceed)
+	assert.Equal(t, 4, last)
+
+	// Test ForEachWhile completes
+	last = 0
+	proceed = slice.ForEachWhile(func(el Metric) bool {
+		last++
+		return true
+	})
+	assert.True(t, proceed)
+	assert.Equal(t, 7, last)
 }
 
 func generateTestMetricSlice() MetricSlice {

--- a/pdata/pmetric/generated_metricslice_test.go
+++ b/pdata/pmetric/generated_metricslice_test.go
@@ -139,67 +139,20 @@ func TestMetricSlice_Sort(t *testing.T) {
 	}
 }
 
-func TestMetricSlice_ForEach(t *testing.T) {
-	// Test ForEach on empty slice
+func TestMetricSlice_Range(t *testing.T) {
+	// Test _Range on empty slice
 	emptySlice := NewMetricSlice()
-	emptySlice.ForEach(func(el Metric) {
+	emptySlice.Range(func(i int, el Metric) {
 		t.Fail()
 	})
 
-	// Test ForEach
-	slice := generateTestMetricSlice()
-	count := 0
-	slice.ForEach(func(el Metric) {
-		count++
-	})
-	assert.Equal(t, 7, count)
-}
-
-func TestMetricSlice_ForEachIndex(t *testing.T) {
-	// Test _ForEachIndex on empty slice
-	emptySlice := NewMetricSlice()
-	emptySlice.ForEachIndex(func(i int, el Metric) {
-		t.Fail()
-	})
-
-	// Test _ForEachIndex
+	// Test _Range
 	slice := generateTestMetricSlice()
 	total := 0
-	slice.ForEachIndex(func(i int, el Metric) {
+	slice.Range(func(i int, el Metric) {
 		total += i
 	})
 	assert.Equal(t, 0+1+2+3+4+5+6, total)
-}
-
-func TestMetricSlice_ForEachWhile(t *testing.T) {
-	// Test ForEach on empty slice
-	emptySlice := NewMetricSlice()
-	emptySlice.ForEachWhile(func(el Metric) bool {
-		t.Fail()
-		return false
-	})
-
-	// Test ForEachWhile stops short
-	slice := generateTestMetricSlice()
-	last := 0
-	proceed := slice.ForEachWhile(func(el Metric) bool {
-		last++
-		if last == 4 {
-			return false
-		}
-		return true
-	})
-	assert.False(t, proceed)
-	assert.Equal(t, 4, last)
-
-	// Test ForEachWhile completes
-	last = 0
-	proceed = slice.ForEachWhile(func(el Metric) bool {
-		last++
-		return true
-	})
-	assert.True(t, proceed)
-	assert.Equal(t, 7, last)
 }
 
 func generateTestMetricSlice() MetricSlice {

--- a/pdata/pmetric/generated_metricslice_test.go
+++ b/pdata/pmetric/generated_metricslice_test.go
@@ -139,6 +139,22 @@ func TestMetricSlice_Sort(t *testing.T) {
 	}
 }
 
+func TestMetricSlice_ForEach(t *testing.T) {
+	// Test ForEach on empty slice
+	emptySlice := NewMetricSlice()
+	emptySlice.ForEach(func(el Metric) {
+		t.Fail()
+	})
+
+	// Test ForEach
+	slice := generateTestMetricSlice()
+	pos := 0
+	slice.ForEach(func(el Metric) {
+		pos++
+	})
+	assert.Equal(t, 7, slice.Len())
+}
+
 func generateTestMetricSlice() MetricSlice {
 	es := NewMetricSlice()
 	fillTestMetricSlice(es)

--- a/pdata/pmetric/generated_metricslice_test.go
+++ b/pdata/pmetric/generated_metricslice_test.go
@@ -148,11 +148,27 @@ func TestMetricSlice_ForEach(t *testing.T) {
 
 	// Test ForEach
 	slice := generateTestMetricSlice()
-	pos := 0
+	count := 0
 	slice.ForEach(func(el Metric) {
-		pos++
+		count++
 	})
-	assert.Equal(t, 7, slice.Len())
+	assert.Equal(t, 7, count)
+}
+
+func TestMetricSlice_ForEachIndex(t *testing.T) {
+	// Test ForEach on empty slice
+	emptySlice := NewMetricSlice()
+	emptySlice.ForEachIndex(func(i int, el Metric) {
+		t.Fail()
+	})
+
+	// Test ForEach
+	slice := generateTestMetricSlice()
+	total := 0
+	slice.ForEachIndex(func(i int, el Metric) {
+		total += i
+	})
+	assert.Equal(t, 0+1+2+3+4+5+6, total)
 }
 
 func generateTestMetricSlice() MetricSlice {

--- a/pdata/pmetric/generated_numberdatapointslice.go
+++ b/pdata/pmetric/generated_numberdatapointslice.go
@@ -151,28 +151,10 @@ func (es NumberDataPointSlice) Sort(less func(a, b NumberDataPoint) bool) {
 	sort.SliceStable(*es.orig, func(i, j int) bool { return less(es.At(i), es.At(j)) })
 }
 
-// ForEach iterates over NumberDataPointSlice and executes f against each element.
-func (es NumberDataPointSlice) ForEach(f func(NumberDataPoint)) {
-	for i := 0; i < es.Len(); i++ {
-		f(es.At(i))
-	}
-}
-
-// ForEachIndex iterates over NumberDataPointSlice and executes f against each element.
+// Range iterates over NumberDataPointSlice and executes f against each element.
 // The function also passes the iteration index.
-func (es NumberDataPointSlice) ForEachIndex(f func(int, NumberDataPoint)) {
+func (es NumberDataPointSlice) Range(f func(int, NumberDataPoint)) {
 	for i := 0; i < es.Len(); i++ {
 		f(i, es.At(i))
 	}
-}
-
-// ForEachWhile iterates over NumberDataPointSlice and executes f against each element.
-// The function also passes the iteration index.
-func (es NumberDataPointSlice) ForEachWhile(f func(NumberDataPoint) bool) bool {
-	for i := 0; i < es.Len(); i++ {
-		if !f(es.At(i)) {
-			return false
-		}
-	}
-	return true
 }

--- a/pdata/pmetric/generated_numberdatapointslice.go
+++ b/pdata/pmetric/generated_numberdatapointslice.go
@@ -150,3 +150,10 @@ func (es NumberDataPointSlice) Sort(less func(a, b NumberDataPoint) bool) {
 	es.state.AssertMutable()
 	sort.SliceStable(*es.orig, func(i, j int) bool { return less(es.At(i), es.At(j)) })
 }
+
+// ForEach iterates over NumberDataPointSlice and executes f against each element.
+func (es NumberDataPointSlice) ForEach(f func(el NumberDataPoint)) {
+	for i := 0; i < es.Len(); i++ {
+		f(es.At(i))
+	}
+}

--- a/pdata/pmetric/generated_numberdatapointslice.go
+++ b/pdata/pmetric/generated_numberdatapointslice.go
@@ -165,3 +165,14 @@ func (es NumberDataPointSlice) ForEachIndex(f func(int, NumberDataPoint)) {
 		f(i, es.At(i))
 	}
 }
+
+// ForEachWhile iterates over NumberDataPointSlice and executes f against each element.
+// The function also passes the iteration index.
+func (es NumberDataPointSlice) ForEachWhile(f func(NumberDataPoint) bool) bool {
+	for i := 0; i < es.Len(); i++ {
+		if !f(es.At(i)) {
+			return false
+		}
+	}
+	return true
+}

--- a/pdata/pmetric/generated_numberdatapointslice.go
+++ b/pdata/pmetric/generated_numberdatapointslice.go
@@ -152,8 +152,16 @@ func (es NumberDataPointSlice) Sort(less func(a, b NumberDataPoint) bool) {
 }
 
 // ForEach iterates over NumberDataPointSlice and executes f against each element.
-func (es NumberDataPointSlice) ForEach(f func(el NumberDataPoint)) {
+func (es NumberDataPointSlice) ForEach(f func(NumberDataPoint)) {
 	for i := 0; i < es.Len(); i++ {
 		f(es.At(i))
+	}
+}
+
+// ForEachIndex iterates over NumberDataPointSlice and executes f against each element.
+// The function also passes the iteration index.
+func (es NumberDataPointSlice) ForEachIndex(f func(int, NumberDataPoint)) {
+	for i := 0; i < es.Len(); i++ {
+		f(i, es.At(i))
 	}
 }

--- a/pdata/pmetric/generated_numberdatapointslice_test.go
+++ b/pdata/pmetric/generated_numberdatapointslice_test.go
@@ -148,11 +148,27 @@ func TestNumberDataPointSlice_ForEach(t *testing.T) {
 
 	// Test ForEach
 	slice := generateTestNumberDataPointSlice()
-	pos := 0
+	count := 0
 	slice.ForEach(func(el NumberDataPoint) {
-		pos++
+		count++
 	})
-	assert.Equal(t, 7, slice.Len())
+	assert.Equal(t, 7, count)
+}
+
+func TestNumberDataPointSlice_ForEachIndex(t *testing.T) {
+	// Test ForEach on empty slice
+	emptySlice := NewNumberDataPointSlice()
+	emptySlice.ForEachIndex(func(i int, el NumberDataPoint) {
+		t.Fail()
+	})
+
+	// Test ForEach
+	slice := generateTestNumberDataPointSlice()
+	total := 0
+	slice.ForEachIndex(func(i int, el NumberDataPoint) {
+		total += i
+	})
+	assert.Equal(t, 0+1+2+3+4+5+6, total)
 }
 
 func generateTestNumberDataPointSlice() NumberDataPointSlice {

--- a/pdata/pmetric/generated_numberdatapointslice_test.go
+++ b/pdata/pmetric/generated_numberdatapointslice_test.go
@@ -139,67 +139,20 @@ func TestNumberDataPointSlice_Sort(t *testing.T) {
 	}
 }
 
-func TestNumberDataPointSlice_ForEach(t *testing.T) {
-	// Test ForEach on empty slice
+func TestNumberDataPointSlice_Range(t *testing.T) {
+	// Test _Range on empty slice
 	emptySlice := NewNumberDataPointSlice()
-	emptySlice.ForEach(func(el NumberDataPoint) {
+	emptySlice.Range(func(i int, el NumberDataPoint) {
 		t.Fail()
 	})
 
-	// Test ForEach
-	slice := generateTestNumberDataPointSlice()
-	count := 0
-	slice.ForEach(func(el NumberDataPoint) {
-		count++
-	})
-	assert.Equal(t, 7, count)
-}
-
-func TestNumberDataPointSlice_ForEachIndex(t *testing.T) {
-	// Test _ForEachIndex on empty slice
-	emptySlice := NewNumberDataPointSlice()
-	emptySlice.ForEachIndex(func(i int, el NumberDataPoint) {
-		t.Fail()
-	})
-
-	// Test _ForEachIndex
+	// Test _Range
 	slice := generateTestNumberDataPointSlice()
 	total := 0
-	slice.ForEachIndex(func(i int, el NumberDataPoint) {
+	slice.Range(func(i int, el NumberDataPoint) {
 		total += i
 	})
 	assert.Equal(t, 0+1+2+3+4+5+6, total)
-}
-
-func TestNumberDataPointSlice_ForEachWhile(t *testing.T) {
-	// Test ForEach on empty slice
-	emptySlice := NewNumberDataPointSlice()
-	emptySlice.ForEachWhile(func(el NumberDataPoint) bool {
-		t.Fail()
-		return false
-	})
-
-	// Test ForEachWhile stops short
-	slice := generateTestNumberDataPointSlice()
-	last := 0
-	proceed := slice.ForEachWhile(func(el NumberDataPoint) bool {
-		last++
-		if last == 4 {
-			return false
-		}
-		return true
-	})
-	assert.False(t, proceed)
-	assert.Equal(t, 4, last)
-
-	// Test ForEachWhile completes
-	last = 0
-	proceed = slice.ForEachWhile(func(el NumberDataPoint) bool {
-		last++
-		return true
-	})
-	assert.True(t, proceed)
-	assert.Equal(t, 7, last)
 }
 
 func generateTestNumberDataPointSlice() NumberDataPointSlice {

--- a/pdata/pmetric/generated_numberdatapointslice_test.go
+++ b/pdata/pmetric/generated_numberdatapointslice_test.go
@@ -139,6 +139,22 @@ func TestNumberDataPointSlice_Sort(t *testing.T) {
 	}
 }
 
+func TestNumberDataPointSlice_ForEach(t *testing.T) {
+	// Test ForEach on empty slice
+	emptySlice := NewNumberDataPointSlice()
+	emptySlice.ForEach(func(el NumberDataPoint) {
+		t.Fail()
+	})
+
+	// Test ForEach
+	slice := generateTestNumberDataPointSlice()
+	pos := 0
+	slice.ForEach(func(el NumberDataPoint) {
+		pos++
+	})
+	assert.Equal(t, 7, slice.Len())
+}
+
 func generateTestNumberDataPointSlice() NumberDataPointSlice {
 	es := NewNumberDataPointSlice()
 	fillTestNumberDataPointSlice(es)

--- a/pdata/pmetric/generated_numberdatapointslice_test.go
+++ b/pdata/pmetric/generated_numberdatapointslice_test.go
@@ -156,19 +156,50 @@ func TestNumberDataPointSlice_ForEach(t *testing.T) {
 }
 
 func TestNumberDataPointSlice_ForEachIndex(t *testing.T) {
-	// Test ForEach on empty slice
+	// Test _ForEachIndex on empty slice
 	emptySlice := NewNumberDataPointSlice()
 	emptySlice.ForEachIndex(func(i int, el NumberDataPoint) {
 		t.Fail()
 	})
 
-	// Test ForEach
+	// Test _ForEachIndex
 	slice := generateTestNumberDataPointSlice()
 	total := 0
 	slice.ForEachIndex(func(i int, el NumberDataPoint) {
 		total += i
 	})
 	assert.Equal(t, 0+1+2+3+4+5+6, total)
+}
+
+func TestNumberDataPointSlice_ForEachWhile(t *testing.T) {
+	// Test ForEach on empty slice
+	emptySlice := NewNumberDataPointSlice()
+	emptySlice.ForEachWhile(func(el NumberDataPoint) bool {
+		t.Fail()
+		return false
+	})
+
+	// Test ForEachWhile stops short
+	slice := generateTestNumberDataPointSlice()
+	last := 0
+	proceed := slice.ForEachWhile(func(el NumberDataPoint) bool {
+		last++
+		if last == 4 {
+			return false
+		}
+		return true
+	})
+	assert.False(t, proceed)
+	assert.Equal(t, 4, last)
+
+	// Test ForEachWhile completes
+	last = 0
+	proceed = slice.ForEachWhile(func(el NumberDataPoint) bool {
+		last++
+		return true
+	})
+	assert.True(t, proceed)
+	assert.Equal(t, 7, last)
 }
 
 func generateTestNumberDataPointSlice() NumberDataPointSlice {

--- a/pdata/pmetric/generated_resourcemetricsslice.go
+++ b/pdata/pmetric/generated_resourcemetricsslice.go
@@ -165,3 +165,14 @@ func (es ResourceMetricsSlice) ForEachIndex(f func(int, ResourceMetrics)) {
 		f(i, es.At(i))
 	}
 }
+
+// ForEachWhile iterates over ResourceMetricsSlice and executes f against each element.
+// The function also passes the iteration index.
+func (es ResourceMetricsSlice) ForEachWhile(f func(ResourceMetrics) bool) bool {
+	for i := 0; i < es.Len(); i++ {
+		if !f(es.At(i)) {
+			return false
+		}
+	}
+	return true
+}

--- a/pdata/pmetric/generated_resourcemetricsslice.go
+++ b/pdata/pmetric/generated_resourcemetricsslice.go
@@ -152,8 +152,16 @@ func (es ResourceMetricsSlice) Sort(less func(a, b ResourceMetrics) bool) {
 }
 
 // ForEach iterates over ResourceMetricsSlice and executes f against each element.
-func (es ResourceMetricsSlice) ForEach(f func(el ResourceMetrics)) {
+func (es ResourceMetricsSlice) ForEach(f func(ResourceMetrics)) {
 	for i := 0; i < es.Len(); i++ {
 		f(es.At(i))
+	}
+}
+
+// ForEachIndex iterates over ResourceMetricsSlice and executes f against each element.
+// The function also passes the iteration index.
+func (es ResourceMetricsSlice) ForEachIndex(f func(int, ResourceMetrics)) {
+	for i := 0; i < es.Len(); i++ {
+		f(i, es.At(i))
 	}
 }

--- a/pdata/pmetric/generated_resourcemetricsslice.go
+++ b/pdata/pmetric/generated_resourcemetricsslice.go
@@ -150,3 +150,10 @@ func (es ResourceMetricsSlice) Sort(less func(a, b ResourceMetrics) bool) {
 	es.state.AssertMutable()
 	sort.SliceStable(*es.orig, func(i, j int) bool { return less(es.At(i), es.At(j)) })
 }
+
+// ForEach iterates over ResourceMetricsSlice and executes f against each element.
+func (es ResourceMetricsSlice) ForEach(f func(el ResourceMetrics)) {
+	for i := 0; i < es.Len(); i++ {
+		f(es.At(i))
+	}
+}

--- a/pdata/pmetric/generated_resourcemetricsslice.go
+++ b/pdata/pmetric/generated_resourcemetricsslice.go
@@ -151,28 +151,10 @@ func (es ResourceMetricsSlice) Sort(less func(a, b ResourceMetrics) bool) {
 	sort.SliceStable(*es.orig, func(i, j int) bool { return less(es.At(i), es.At(j)) })
 }
 
-// ForEach iterates over ResourceMetricsSlice and executes f against each element.
-func (es ResourceMetricsSlice) ForEach(f func(ResourceMetrics)) {
-	for i := 0; i < es.Len(); i++ {
-		f(es.At(i))
-	}
-}
-
-// ForEachIndex iterates over ResourceMetricsSlice and executes f against each element.
+// Range iterates over ResourceMetricsSlice and executes f against each element.
 // The function also passes the iteration index.
-func (es ResourceMetricsSlice) ForEachIndex(f func(int, ResourceMetrics)) {
+func (es ResourceMetricsSlice) Range(f func(int, ResourceMetrics)) {
 	for i := 0; i < es.Len(); i++ {
 		f(i, es.At(i))
 	}
-}
-
-// ForEachWhile iterates over ResourceMetricsSlice and executes f against each element.
-// The function also passes the iteration index.
-func (es ResourceMetricsSlice) ForEachWhile(f func(ResourceMetrics) bool) bool {
-	for i := 0; i < es.Len(); i++ {
-		if !f(es.At(i)) {
-			return false
-		}
-	}
-	return true
 }

--- a/pdata/pmetric/generated_resourcemetricsslice_test.go
+++ b/pdata/pmetric/generated_resourcemetricsslice_test.go
@@ -139,67 +139,20 @@ func TestResourceMetricsSlice_Sort(t *testing.T) {
 	}
 }
 
-func TestResourceMetricsSlice_ForEach(t *testing.T) {
-	// Test ForEach on empty slice
+func TestResourceMetricsSlice_Range(t *testing.T) {
+	// Test _Range on empty slice
 	emptySlice := NewResourceMetricsSlice()
-	emptySlice.ForEach(func(el ResourceMetrics) {
+	emptySlice.Range(func(i int, el ResourceMetrics) {
 		t.Fail()
 	})
 
-	// Test ForEach
-	slice := generateTestResourceMetricsSlice()
-	count := 0
-	slice.ForEach(func(el ResourceMetrics) {
-		count++
-	})
-	assert.Equal(t, 7, count)
-}
-
-func TestResourceMetricsSlice_ForEachIndex(t *testing.T) {
-	// Test _ForEachIndex on empty slice
-	emptySlice := NewResourceMetricsSlice()
-	emptySlice.ForEachIndex(func(i int, el ResourceMetrics) {
-		t.Fail()
-	})
-
-	// Test _ForEachIndex
+	// Test _Range
 	slice := generateTestResourceMetricsSlice()
 	total := 0
-	slice.ForEachIndex(func(i int, el ResourceMetrics) {
+	slice.Range(func(i int, el ResourceMetrics) {
 		total += i
 	})
 	assert.Equal(t, 0+1+2+3+4+5+6, total)
-}
-
-func TestResourceMetricsSlice_ForEachWhile(t *testing.T) {
-	// Test ForEach on empty slice
-	emptySlice := NewResourceMetricsSlice()
-	emptySlice.ForEachWhile(func(el ResourceMetrics) bool {
-		t.Fail()
-		return false
-	})
-
-	// Test ForEachWhile stops short
-	slice := generateTestResourceMetricsSlice()
-	last := 0
-	proceed := slice.ForEachWhile(func(el ResourceMetrics) bool {
-		last++
-		if last == 4 {
-			return false
-		}
-		return true
-	})
-	assert.False(t, proceed)
-	assert.Equal(t, 4, last)
-
-	// Test ForEachWhile completes
-	last = 0
-	proceed = slice.ForEachWhile(func(el ResourceMetrics) bool {
-		last++
-		return true
-	})
-	assert.True(t, proceed)
-	assert.Equal(t, 7, last)
 }
 
 func generateTestResourceMetricsSlice() ResourceMetricsSlice {

--- a/pdata/pmetric/generated_resourcemetricsslice_test.go
+++ b/pdata/pmetric/generated_resourcemetricsslice_test.go
@@ -156,19 +156,50 @@ func TestResourceMetricsSlice_ForEach(t *testing.T) {
 }
 
 func TestResourceMetricsSlice_ForEachIndex(t *testing.T) {
-	// Test ForEach on empty slice
+	// Test _ForEachIndex on empty slice
 	emptySlice := NewResourceMetricsSlice()
 	emptySlice.ForEachIndex(func(i int, el ResourceMetrics) {
 		t.Fail()
 	})
 
-	// Test ForEach
+	// Test _ForEachIndex
 	slice := generateTestResourceMetricsSlice()
 	total := 0
 	slice.ForEachIndex(func(i int, el ResourceMetrics) {
 		total += i
 	})
 	assert.Equal(t, 0+1+2+3+4+5+6, total)
+}
+
+func TestResourceMetricsSlice_ForEachWhile(t *testing.T) {
+	// Test ForEach on empty slice
+	emptySlice := NewResourceMetricsSlice()
+	emptySlice.ForEachWhile(func(el ResourceMetrics) bool {
+		t.Fail()
+		return false
+	})
+
+	// Test ForEachWhile stops short
+	slice := generateTestResourceMetricsSlice()
+	last := 0
+	proceed := slice.ForEachWhile(func(el ResourceMetrics) bool {
+		last++
+		if last == 4 {
+			return false
+		}
+		return true
+	})
+	assert.False(t, proceed)
+	assert.Equal(t, 4, last)
+
+	// Test ForEachWhile completes
+	last = 0
+	proceed = slice.ForEachWhile(func(el ResourceMetrics) bool {
+		last++
+		return true
+	})
+	assert.True(t, proceed)
+	assert.Equal(t, 7, last)
 }
 
 func generateTestResourceMetricsSlice() ResourceMetricsSlice {

--- a/pdata/pmetric/generated_resourcemetricsslice_test.go
+++ b/pdata/pmetric/generated_resourcemetricsslice_test.go
@@ -139,6 +139,22 @@ func TestResourceMetricsSlice_Sort(t *testing.T) {
 	}
 }
 
+func TestResourceMetricsSlice_ForEach(t *testing.T) {
+	// Test ForEach on empty slice
+	emptySlice := NewResourceMetricsSlice()
+	emptySlice.ForEach(func(el ResourceMetrics) {
+		t.Fail()
+	})
+
+	// Test ForEach
+	slice := generateTestResourceMetricsSlice()
+	pos := 0
+	slice.ForEach(func(el ResourceMetrics) {
+		pos++
+	})
+	assert.Equal(t, 7, slice.Len())
+}
+
 func generateTestResourceMetricsSlice() ResourceMetricsSlice {
 	es := NewResourceMetricsSlice()
 	fillTestResourceMetricsSlice(es)

--- a/pdata/pmetric/generated_resourcemetricsslice_test.go
+++ b/pdata/pmetric/generated_resourcemetricsslice_test.go
@@ -148,11 +148,27 @@ func TestResourceMetricsSlice_ForEach(t *testing.T) {
 
 	// Test ForEach
 	slice := generateTestResourceMetricsSlice()
-	pos := 0
+	count := 0
 	slice.ForEach(func(el ResourceMetrics) {
-		pos++
+		count++
 	})
-	assert.Equal(t, 7, slice.Len())
+	assert.Equal(t, 7, count)
+}
+
+func TestResourceMetricsSlice_ForEachIndex(t *testing.T) {
+	// Test ForEach on empty slice
+	emptySlice := NewResourceMetricsSlice()
+	emptySlice.ForEachIndex(func(i int, el ResourceMetrics) {
+		t.Fail()
+	})
+
+	// Test ForEach
+	slice := generateTestResourceMetricsSlice()
+	total := 0
+	slice.ForEachIndex(func(i int, el ResourceMetrics) {
+		total += i
+	})
+	assert.Equal(t, 0+1+2+3+4+5+6, total)
 }
 
 func generateTestResourceMetricsSlice() ResourceMetricsSlice {

--- a/pdata/pmetric/generated_scopemetricsslice.go
+++ b/pdata/pmetric/generated_scopemetricsslice.go
@@ -151,28 +151,10 @@ func (es ScopeMetricsSlice) Sort(less func(a, b ScopeMetrics) bool) {
 	sort.SliceStable(*es.orig, func(i, j int) bool { return less(es.At(i), es.At(j)) })
 }
 
-// ForEach iterates over ScopeMetricsSlice and executes f against each element.
-func (es ScopeMetricsSlice) ForEach(f func(ScopeMetrics)) {
-	for i := 0; i < es.Len(); i++ {
-		f(es.At(i))
-	}
-}
-
-// ForEachIndex iterates over ScopeMetricsSlice and executes f against each element.
+// Range iterates over ScopeMetricsSlice and executes f against each element.
 // The function also passes the iteration index.
-func (es ScopeMetricsSlice) ForEachIndex(f func(int, ScopeMetrics)) {
+func (es ScopeMetricsSlice) Range(f func(int, ScopeMetrics)) {
 	for i := 0; i < es.Len(); i++ {
 		f(i, es.At(i))
 	}
-}
-
-// ForEachWhile iterates over ScopeMetricsSlice and executes f against each element.
-// The function also passes the iteration index.
-func (es ScopeMetricsSlice) ForEachWhile(f func(ScopeMetrics) bool) bool {
-	for i := 0; i < es.Len(); i++ {
-		if !f(es.At(i)) {
-			return false
-		}
-	}
-	return true
 }

--- a/pdata/pmetric/generated_scopemetricsslice.go
+++ b/pdata/pmetric/generated_scopemetricsslice.go
@@ -165,3 +165,14 @@ func (es ScopeMetricsSlice) ForEachIndex(f func(int, ScopeMetrics)) {
 		f(i, es.At(i))
 	}
 }
+
+// ForEachWhile iterates over ScopeMetricsSlice and executes f against each element.
+// The function also passes the iteration index.
+func (es ScopeMetricsSlice) ForEachWhile(f func(ScopeMetrics) bool) bool {
+	for i := 0; i < es.Len(); i++ {
+		if !f(es.At(i)) {
+			return false
+		}
+	}
+	return true
+}

--- a/pdata/pmetric/generated_scopemetricsslice.go
+++ b/pdata/pmetric/generated_scopemetricsslice.go
@@ -152,8 +152,16 @@ func (es ScopeMetricsSlice) Sort(less func(a, b ScopeMetrics) bool) {
 }
 
 // ForEach iterates over ScopeMetricsSlice and executes f against each element.
-func (es ScopeMetricsSlice) ForEach(f func(el ScopeMetrics)) {
+func (es ScopeMetricsSlice) ForEach(f func(ScopeMetrics)) {
 	for i := 0; i < es.Len(); i++ {
 		f(es.At(i))
+	}
+}
+
+// ForEachIndex iterates over ScopeMetricsSlice and executes f against each element.
+// The function also passes the iteration index.
+func (es ScopeMetricsSlice) ForEachIndex(f func(int, ScopeMetrics)) {
+	for i := 0; i < es.Len(); i++ {
+		f(i, es.At(i))
 	}
 }

--- a/pdata/pmetric/generated_scopemetricsslice.go
+++ b/pdata/pmetric/generated_scopemetricsslice.go
@@ -150,3 +150,10 @@ func (es ScopeMetricsSlice) Sort(less func(a, b ScopeMetrics) bool) {
 	es.state.AssertMutable()
 	sort.SliceStable(*es.orig, func(i, j int) bool { return less(es.At(i), es.At(j)) })
 }
+
+// ForEach iterates over ScopeMetricsSlice and executes f against each element.
+func (es ScopeMetricsSlice) ForEach(f func(el ScopeMetrics)) {
+	for i := 0; i < es.Len(); i++ {
+		f(es.At(i))
+	}
+}

--- a/pdata/pmetric/generated_scopemetricsslice_test.go
+++ b/pdata/pmetric/generated_scopemetricsslice_test.go
@@ -139,67 +139,20 @@ func TestScopeMetricsSlice_Sort(t *testing.T) {
 	}
 }
 
-func TestScopeMetricsSlice_ForEach(t *testing.T) {
-	// Test ForEach on empty slice
+func TestScopeMetricsSlice_Range(t *testing.T) {
+	// Test _Range on empty slice
 	emptySlice := NewScopeMetricsSlice()
-	emptySlice.ForEach(func(el ScopeMetrics) {
+	emptySlice.Range(func(i int, el ScopeMetrics) {
 		t.Fail()
 	})
 
-	// Test ForEach
-	slice := generateTestScopeMetricsSlice()
-	count := 0
-	slice.ForEach(func(el ScopeMetrics) {
-		count++
-	})
-	assert.Equal(t, 7, count)
-}
-
-func TestScopeMetricsSlice_ForEachIndex(t *testing.T) {
-	// Test _ForEachIndex on empty slice
-	emptySlice := NewScopeMetricsSlice()
-	emptySlice.ForEachIndex(func(i int, el ScopeMetrics) {
-		t.Fail()
-	})
-
-	// Test _ForEachIndex
+	// Test _Range
 	slice := generateTestScopeMetricsSlice()
 	total := 0
-	slice.ForEachIndex(func(i int, el ScopeMetrics) {
+	slice.Range(func(i int, el ScopeMetrics) {
 		total += i
 	})
 	assert.Equal(t, 0+1+2+3+4+5+6, total)
-}
-
-func TestScopeMetricsSlice_ForEachWhile(t *testing.T) {
-	// Test ForEach on empty slice
-	emptySlice := NewScopeMetricsSlice()
-	emptySlice.ForEachWhile(func(el ScopeMetrics) bool {
-		t.Fail()
-		return false
-	})
-
-	// Test ForEachWhile stops short
-	slice := generateTestScopeMetricsSlice()
-	last := 0
-	proceed := slice.ForEachWhile(func(el ScopeMetrics) bool {
-		last++
-		if last == 4 {
-			return false
-		}
-		return true
-	})
-	assert.False(t, proceed)
-	assert.Equal(t, 4, last)
-
-	// Test ForEachWhile completes
-	last = 0
-	proceed = slice.ForEachWhile(func(el ScopeMetrics) bool {
-		last++
-		return true
-	})
-	assert.True(t, proceed)
-	assert.Equal(t, 7, last)
 }
 
 func generateTestScopeMetricsSlice() ScopeMetricsSlice {

--- a/pdata/pmetric/generated_scopemetricsslice_test.go
+++ b/pdata/pmetric/generated_scopemetricsslice_test.go
@@ -148,11 +148,27 @@ func TestScopeMetricsSlice_ForEach(t *testing.T) {
 
 	// Test ForEach
 	slice := generateTestScopeMetricsSlice()
-	pos := 0
+	count := 0
 	slice.ForEach(func(el ScopeMetrics) {
-		pos++
+		count++
 	})
-	assert.Equal(t, 7, slice.Len())
+	assert.Equal(t, 7, count)
+}
+
+func TestScopeMetricsSlice_ForEachIndex(t *testing.T) {
+	// Test ForEach on empty slice
+	emptySlice := NewScopeMetricsSlice()
+	emptySlice.ForEachIndex(func(i int, el ScopeMetrics) {
+		t.Fail()
+	})
+
+	// Test ForEach
+	slice := generateTestScopeMetricsSlice()
+	total := 0
+	slice.ForEachIndex(func(i int, el ScopeMetrics) {
+		total += i
+	})
+	assert.Equal(t, 0+1+2+3+4+5+6, total)
 }
 
 func generateTestScopeMetricsSlice() ScopeMetricsSlice {

--- a/pdata/pmetric/generated_scopemetricsslice_test.go
+++ b/pdata/pmetric/generated_scopemetricsslice_test.go
@@ -139,6 +139,22 @@ func TestScopeMetricsSlice_Sort(t *testing.T) {
 	}
 }
 
+func TestScopeMetricsSlice_ForEach(t *testing.T) {
+	// Test ForEach on empty slice
+	emptySlice := NewScopeMetricsSlice()
+	emptySlice.ForEach(func(el ScopeMetrics) {
+		t.Fail()
+	})
+
+	// Test ForEach
+	slice := generateTestScopeMetricsSlice()
+	pos := 0
+	slice.ForEach(func(el ScopeMetrics) {
+		pos++
+	})
+	assert.Equal(t, 7, slice.Len())
+}
+
 func generateTestScopeMetricsSlice() ScopeMetricsSlice {
 	es := NewScopeMetricsSlice()
 	fillTestScopeMetricsSlice(es)

--- a/pdata/pmetric/generated_scopemetricsslice_test.go
+++ b/pdata/pmetric/generated_scopemetricsslice_test.go
@@ -156,19 +156,50 @@ func TestScopeMetricsSlice_ForEach(t *testing.T) {
 }
 
 func TestScopeMetricsSlice_ForEachIndex(t *testing.T) {
-	// Test ForEach on empty slice
+	// Test _ForEachIndex on empty slice
 	emptySlice := NewScopeMetricsSlice()
 	emptySlice.ForEachIndex(func(i int, el ScopeMetrics) {
 		t.Fail()
 	})
 
-	// Test ForEach
+	// Test _ForEachIndex
 	slice := generateTestScopeMetricsSlice()
 	total := 0
 	slice.ForEachIndex(func(i int, el ScopeMetrics) {
 		total += i
 	})
 	assert.Equal(t, 0+1+2+3+4+5+6, total)
+}
+
+func TestScopeMetricsSlice_ForEachWhile(t *testing.T) {
+	// Test ForEach on empty slice
+	emptySlice := NewScopeMetricsSlice()
+	emptySlice.ForEachWhile(func(el ScopeMetrics) bool {
+		t.Fail()
+		return false
+	})
+
+	// Test ForEachWhile stops short
+	slice := generateTestScopeMetricsSlice()
+	last := 0
+	proceed := slice.ForEachWhile(func(el ScopeMetrics) bool {
+		last++
+		if last == 4 {
+			return false
+		}
+		return true
+	})
+	assert.False(t, proceed)
+	assert.Equal(t, 4, last)
+
+	// Test ForEachWhile completes
+	last = 0
+	proceed = slice.ForEachWhile(func(el ScopeMetrics) bool {
+		last++
+		return true
+	})
+	assert.True(t, proceed)
+	assert.Equal(t, 7, last)
 }
 
 func generateTestScopeMetricsSlice() ScopeMetricsSlice {

--- a/pdata/pmetric/generated_summarydatapointslice.go
+++ b/pdata/pmetric/generated_summarydatapointslice.go
@@ -152,8 +152,16 @@ func (es SummaryDataPointSlice) Sort(less func(a, b SummaryDataPoint) bool) {
 }
 
 // ForEach iterates over SummaryDataPointSlice and executes f against each element.
-func (es SummaryDataPointSlice) ForEach(f func(el SummaryDataPoint)) {
+func (es SummaryDataPointSlice) ForEach(f func(SummaryDataPoint)) {
 	for i := 0; i < es.Len(); i++ {
 		f(es.At(i))
+	}
+}
+
+// ForEachIndex iterates over SummaryDataPointSlice and executes f against each element.
+// The function also passes the iteration index.
+func (es SummaryDataPointSlice) ForEachIndex(f func(int, SummaryDataPoint)) {
+	for i := 0; i < es.Len(); i++ {
+		f(i, es.At(i))
 	}
 }

--- a/pdata/pmetric/generated_summarydatapointslice.go
+++ b/pdata/pmetric/generated_summarydatapointslice.go
@@ -150,3 +150,10 @@ func (es SummaryDataPointSlice) Sort(less func(a, b SummaryDataPoint) bool) {
 	es.state.AssertMutable()
 	sort.SliceStable(*es.orig, func(i, j int) bool { return less(es.At(i), es.At(j)) })
 }
+
+// ForEach iterates over SummaryDataPointSlice and executes f against each element.
+func (es SummaryDataPointSlice) ForEach(f func(el SummaryDataPoint)) {
+	for i := 0; i < es.Len(); i++ {
+		f(es.At(i))
+	}
+}

--- a/pdata/pmetric/generated_summarydatapointslice.go
+++ b/pdata/pmetric/generated_summarydatapointslice.go
@@ -151,28 +151,10 @@ func (es SummaryDataPointSlice) Sort(less func(a, b SummaryDataPoint) bool) {
 	sort.SliceStable(*es.orig, func(i, j int) bool { return less(es.At(i), es.At(j)) })
 }
 
-// ForEach iterates over SummaryDataPointSlice and executes f against each element.
-func (es SummaryDataPointSlice) ForEach(f func(SummaryDataPoint)) {
-	for i := 0; i < es.Len(); i++ {
-		f(es.At(i))
-	}
-}
-
-// ForEachIndex iterates over SummaryDataPointSlice and executes f against each element.
+// Range iterates over SummaryDataPointSlice and executes f against each element.
 // The function also passes the iteration index.
-func (es SummaryDataPointSlice) ForEachIndex(f func(int, SummaryDataPoint)) {
+func (es SummaryDataPointSlice) Range(f func(int, SummaryDataPoint)) {
 	for i := 0; i < es.Len(); i++ {
 		f(i, es.At(i))
 	}
-}
-
-// ForEachWhile iterates over SummaryDataPointSlice and executes f against each element.
-// The function also passes the iteration index.
-func (es SummaryDataPointSlice) ForEachWhile(f func(SummaryDataPoint) bool) bool {
-	for i := 0; i < es.Len(); i++ {
-		if !f(es.At(i)) {
-			return false
-		}
-	}
-	return true
 }

--- a/pdata/pmetric/generated_summarydatapointslice.go
+++ b/pdata/pmetric/generated_summarydatapointslice.go
@@ -165,3 +165,14 @@ func (es SummaryDataPointSlice) ForEachIndex(f func(int, SummaryDataPoint)) {
 		f(i, es.At(i))
 	}
 }
+
+// ForEachWhile iterates over SummaryDataPointSlice and executes f against each element.
+// The function also passes the iteration index.
+func (es SummaryDataPointSlice) ForEachWhile(f func(SummaryDataPoint) bool) bool {
+	for i := 0; i < es.Len(); i++ {
+		if !f(es.At(i)) {
+			return false
+		}
+	}
+	return true
+}

--- a/pdata/pmetric/generated_summarydatapointslice_test.go
+++ b/pdata/pmetric/generated_summarydatapointslice_test.go
@@ -139,67 +139,20 @@ func TestSummaryDataPointSlice_Sort(t *testing.T) {
 	}
 }
 
-func TestSummaryDataPointSlice_ForEach(t *testing.T) {
-	// Test ForEach on empty slice
+func TestSummaryDataPointSlice_Range(t *testing.T) {
+	// Test _Range on empty slice
 	emptySlice := NewSummaryDataPointSlice()
-	emptySlice.ForEach(func(el SummaryDataPoint) {
+	emptySlice.Range(func(i int, el SummaryDataPoint) {
 		t.Fail()
 	})
 
-	// Test ForEach
-	slice := generateTestSummaryDataPointSlice()
-	count := 0
-	slice.ForEach(func(el SummaryDataPoint) {
-		count++
-	})
-	assert.Equal(t, 7, count)
-}
-
-func TestSummaryDataPointSlice_ForEachIndex(t *testing.T) {
-	// Test _ForEachIndex on empty slice
-	emptySlice := NewSummaryDataPointSlice()
-	emptySlice.ForEachIndex(func(i int, el SummaryDataPoint) {
-		t.Fail()
-	})
-
-	// Test _ForEachIndex
+	// Test _Range
 	slice := generateTestSummaryDataPointSlice()
 	total := 0
-	slice.ForEachIndex(func(i int, el SummaryDataPoint) {
+	slice.Range(func(i int, el SummaryDataPoint) {
 		total += i
 	})
 	assert.Equal(t, 0+1+2+3+4+5+6, total)
-}
-
-func TestSummaryDataPointSlice_ForEachWhile(t *testing.T) {
-	// Test ForEach on empty slice
-	emptySlice := NewSummaryDataPointSlice()
-	emptySlice.ForEachWhile(func(el SummaryDataPoint) bool {
-		t.Fail()
-		return false
-	})
-
-	// Test ForEachWhile stops short
-	slice := generateTestSummaryDataPointSlice()
-	last := 0
-	proceed := slice.ForEachWhile(func(el SummaryDataPoint) bool {
-		last++
-		if last == 4 {
-			return false
-		}
-		return true
-	})
-	assert.False(t, proceed)
-	assert.Equal(t, 4, last)
-
-	// Test ForEachWhile completes
-	last = 0
-	proceed = slice.ForEachWhile(func(el SummaryDataPoint) bool {
-		last++
-		return true
-	})
-	assert.True(t, proceed)
-	assert.Equal(t, 7, last)
 }
 
 func generateTestSummaryDataPointSlice() SummaryDataPointSlice {

--- a/pdata/pmetric/generated_summarydatapointslice_test.go
+++ b/pdata/pmetric/generated_summarydatapointslice_test.go
@@ -148,11 +148,27 @@ func TestSummaryDataPointSlice_ForEach(t *testing.T) {
 
 	// Test ForEach
 	slice := generateTestSummaryDataPointSlice()
-	pos := 0
+	count := 0
 	slice.ForEach(func(el SummaryDataPoint) {
-		pos++
+		count++
 	})
-	assert.Equal(t, 7, slice.Len())
+	assert.Equal(t, 7, count)
+}
+
+func TestSummaryDataPointSlice_ForEachIndex(t *testing.T) {
+	// Test ForEach on empty slice
+	emptySlice := NewSummaryDataPointSlice()
+	emptySlice.ForEachIndex(func(i int, el SummaryDataPoint) {
+		t.Fail()
+	})
+
+	// Test ForEach
+	slice := generateTestSummaryDataPointSlice()
+	total := 0
+	slice.ForEachIndex(func(i int, el SummaryDataPoint) {
+		total += i
+	})
+	assert.Equal(t, 0+1+2+3+4+5+6, total)
 }
 
 func generateTestSummaryDataPointSlice() SummaryDataPointSlice {

--- a/pdata/pmetric/generated_summarydatapointslice_test.go
+++ b/pdata/pmetric/generated_summarydatapointslice_test.go
@@ -156,19 +156,50 @@ func TestSummaryDataPointSlice_ForEach(t *testing.T) {
 }
 
 func TestSummaryDataPointSlice_ForEachIndex(t *testing.T) {
-	// Test ForEach on empty slice
+	// Test _ForEachIndex on empty slice
 	emptySlice := NewSummaryDataPointSlice()
 	emptySlice.ForEachIndex(func(i int, el SummaryDataPoint) {
 		t.Fail()
 	})
 
-	// Test ForEach
+	// Test _ForEachIndex
 	slice := generateTestSummaryDataPointSlice()
 	total := 0
 	slice.ForEachIndex(func(i int, el SummaryDataPoint) {
 		total += i
 	})
 	assert.Equal(t, 0+1+2+3+4+5+6, total)
+}
+
+func TestSummaryDataPointSlice_ForEachWhile(t *testing.T) {
+	// Test ForEach on empty slice
+	emptySlice := NewSummaryDataPointSlice()
+	emptySlice.ForEachWhile(func(el SummaryDataPoint) bool {
+		t.Fail()
+		return false
+	})
+
+	// Test ForEachWhile stops short
+	slice := generateTestSummaryDataPointSlice()
+	last := 0
+	proceed := slice.ForEachWhile(func(el SummaryDataPoint) bool {
+		last++
+		if last == 4 {
+			return false
+		}
+		return true
+	})
+	assert.False(t, proceed)
+	assert.Equal(t, 4, last)
+
+	// Test ForEachWhile completes
+	last = 0
+	proceed = slice.ForEachWhile(func(el SummaryDataPoint) bool {
+		last++
+		return true
+	})
+	assert.True(t, proceed)
+	assert.Equal(t, 7, last)
 }
 
 func generateTestSummaryDataPointSlice() SummaryDataPointSlice {

--- a/pdata/pmetric/generated_summarydatapointslice_test.go
+++ b/pdata/pmetric/generated_summarydatapointslice_test.go
@@ -139,6 +139,22 @@ func TestSummaryDataPointSlice_Sort(t *testing.T) {
 	}
 }
 
+func TestSummaryDataPointSlice_ForEach(t *testing.T) {
+	// Test ForEach on empty slice
+	emptySlice := NewSummaryDataPointSlice()
+	emptySlice.ForEach(func(el SummaryDataPoint) {
+		t.Fail()
+	})
+
+	// Test ForEach
+	slice := generateTestSummaryDataPointSlice()
+	pos := 0
+	slice.ForEach(func(el SummaryDataPoint) {
+		pos++
+	})
+	assert.Equal(t, 7, slice.Len())
+}
+
 func generateTestSummaryDataPointSlice() SummaryDataPointSlice {
 	es := NewSummaryDataPointSlice()
 	fillTestSummaryDataPointSlice(es)

--- a/pdata/pmetric/generated_summarydatapointvalueatquantileslice.go
+++ b/pdata/pmetric/generated_summarydatapointvalueatquantileslice.go
@@ -150,3 +150,10 @@ func (es SummaryDataPointValueAtQuantileSlice) Sort(less func(a, b SummaryDataPo
 	es.state.AssertMutable()
 	sort.SliceStable(*es.orig, func(i, j int) bool { return less(es.At(i), es.At(j)) })
 }
+
+// ForEach iterates over SummaryDataPointValueAtQuantileSlice and executes f against each element.
+func (es SummaryDataPointValueAtQuantileSlice) ForEach(f func(el SummaryDataPointValueAtQuantile)) {
+	for i := 0; i < es.Len(); i++ {
+		f(es.At(i))
+	}
+}

--- a/pdata/pmetric/generated_summarydatapointvalueatquantileslice.go
+++ b/pdata/pmetric/generated_summarydatapointvalueatquantileslice.go
@@ -152,8 +152,16 @@ func (es SummaryDataPointValueAtQuantileSlice) Sort(less func(a, b SummaryDataPo
 }
 
 // ForEach iterates over SummaryDataPointValueAtQuantileSlice and executes f against each element.
-func (es SummaryDataPointValueAtQuantileSlice) ForEach(f func(el SummaryDataPointValueAtQuantile)) {
+func (es SummaryDataPointValueAtQuantileSlice) ForEach(f func(SummaryDataPointValueAtQuantile)) {
 	for i := 0; i < es.Len(); i++ {
 		f(es.At(i))
+	}
+}
+
+// ForEachIndex iterates over SummaryDataPointValueAtQuantileSlice and executes f against each element.
+// The function also passes the iteration index.
+func (es SummaryDataPointValueAtQuantileSlice) ForEachIndex(f func(int, SummaryDataPointValueAtQuantile)) {
+	for i := 0; i < es.Len(); i++ {
+		f(i, es.At(i))
 	}
 }

--- a/pdata/pmetric/generated_summarydatapointvalueatquantileslice.go
+++ b/pdata/pmetric/generated_summarydatapointvalueatquantileslice.go
@@ -165,3 +165,14 @@ func (es SummaryDataPointValueAtQuantileSlice) ForEachIndex(f func(int, SummaryD
 		f(i, es.At(i))
 	}
 }
+
+// ForEachWhile iterates over SummaryDataPointValueAtQuantileSlice and executes f against each element.
+// The function also passes the iteration index.
+func (es SummaryDataPointValueAtQuantileSlice) ForEachWhile(f func(SummaryDataPointValueAtQuantile) bool) bool {
+	for i := 0; i < es.Len(); i++ {
+		if !f(es.At(i)) {
+			return false
+		}
+	}
+	return true
+}

--- a/pdata/pmetric/generated_summarydatapointvalueatquantileslice.go
+++ b/pdata/pmetric/generated_summarydatapointvalueatquantileslice.go
@@ -151,28 +151,10 @@ func (es SummaryDataPointValueAtQuantileSlice) Sort(less func(a, b SummaryDataPo
 	sort.SliceStable(*es.orig, func(i, j int) bool { return less(es.At(i), es.At(j)) })
 }
 
-// ForEach iterates over SummaryDataPointValueAtQuantileSlice and executes f against each element.
-func (es SummaryDataPointValueAtQuantileSlice) ForEach(f func(SummaryDataPointValueAtQuantile)) {
-	for i := 0; i < es.Len(); i++ {
-		f(es.At(i))
-	}
-}
-
-// ForEachIndex iterates over SummaryDataPointValueAtQuantileSlice and executes f against each element.
+// Range iterates over SummaryDataPointValueAtQuantileSlice and executes f against each element.
 // The function also passes the iteration index.
-func (es SummaryDataPointValueAtQuantileSlice) ForEachIndex(f func(int, SummaryDataPointValueAtQuantile)) {
+func (es SummaryDataPointValueAtQuantileSlice) Range(f func(int, SummaryDataPointValueAtQuantile)) {
 	for i := 0; i < es.Len(); i++ {
 		f(i, es.At(i))
 	}
-}
-
-// ForEachWhile iterates over SummaryDataPointValueAtQuantileSlice and executes f against each element.
-// The function also passes the iteration index.
-func (es SummaryDataPointValueAtQuantileSlice) ForEachWhile(f func(SummaryDataPointValueAtQuantile) bool) bool {
-	for i := 0; i < es.Len(); i++ {
-		if !f(es.At(i)) {
-			return false
-		}
-	}
-	return true
 }

--- a/pdata/pmetric/generated_summarydatapointvalueatquantileslice_test.go
+++ b/pdata/pmetric/generated_summarydatapointvalueatquantileslice_test.go
@@ -156,19 +156,50 @@ func TestSummaryDataPointValueAtQuantileSlice_ForEach(t *testing.T) {
 }
 
 func TestSummaryDataPointValueAtQuantileSlice_ForEachIndex(t *testing.T) {
-	// Test ForEach on empty slice
+	// Test _ForEachIndex on empty slice
 	emptySlice := NewSummaryDataPointValueAtQuantileSlice()
 	emptySlice.ForEachIndex(func(i int, el SummaryDataPointValueAtQuantile) {
 		t.Fail()
 	})
 
-	// Test ForEach
+	// Test _ForEachIndex
 	slice := generateTestSummaryDataPointValueAtQuantileSlice()
 	total := 0
 	slice.ForEachIndex(func(i int, el SummaryDataPointValueAtQuantile) {
 		total += i
 	})
 	assert.Equal(t, 0+1+2+3+4+5+6, total)
+}
+
+func TestSummaryDataPointValueAtQuantileSlice_ForEachWhile(t *testing.T) {
+	// Test ForEach on empty slice
+	emptySlice := NewSummaryDataPointValueAtQuantileSlice()
+	emptySlice.ForEachWhile(func(el SummaryDataPointValueAtQuantile) bool {
+		t.Fail()
+		return false
+	})
+
+	// Test ForEachWhile stops short
+	slice := generateTestSummaryDataPointValueAtQuantileSlice()
+	last := 0
+	proceed := slice.ForEachWhile(func(el SummaryDataPointValueAtQuantile) bool {
+		last++
+		if last == 4 {
+			return false
+		}
+		return true
+	})
+	assert.False(t, proceed)
+	assert.Equal(t, 4, last)
+
+	// Test ForEachWhile completes
+	last = 0
+	proceed = slice.ForEachWhile(func(el SummaryDataPointValueAtQuantile) bool {
+		last++
+		return true
+	})
+	assert.True(t, proceed)
+	assert.Equal(t, 7, last)
 }
 
 func generateTestSummaryDataPointValueAtQuantileSlice() SummaryDataPointValueAtQuantileSlice {

--- a/pdata/pmetric/generated_summarydatapointvalueatquantileslice_test.go
+++ b/pdata/pmetric/generated_summarydatapointvalueatquantileslice_test.go
@@ -139,67 +139,20 @@ func TestSummaryDataPointValueAtQuantileSlice_Sort(t *testing.T) {
 	}
 }
 
-func TestSummaryDataPointValueAtQuantileSlice_ForEach(t *testing.T) {
-	// Test ForEach on empty slice
+func TestSummaryDataPointValueAtQuantileSlice_Range(t *testing.T) {
+	// Test _Range on empty slice
 	emptySlice := NewSummaryDataPointValueAtQuantileSlice()
-	emptySlice.ForEach(func(el SummaryDataPointValueAtQuantile) {
+	emptySlice.Range(func(i int, el SummaryDataPointValueAtQuantile) {
 		t.Fail()
 	})
 
-	// Test ForEach
-	slice := generateTestSummaryDataPointValueAtQuantileSlice()
-	count := 0
-	slice.ForEach(func(el SummaryDataPointValueAtQuantile) {
-		count++
-	})
-	assert.Equal(t, 7, count)
-}
-
-func TestSummaryDataPointValueAtQuantileSlice_ForEachIndex(t *testing.T) {
-	// Test _ForEachIndex on empty slice
-	emptySlice := NewSummaryDataPointValueAtQuantileSlice()
-	emptySlice.ForEachIndex(func(i int, el SummaryDataPointValueAtQuantile) {
-		t.Fail()
-	})
-
-	// Test _ForEachIndex
+	// Test _Range
 	slice := generateTestSummaryDataPointValueAtQuantileSlice()
 	total := 0
-	slice.ForEachIndex(func(i int, el SummaryDataPointValueAtQuantile) {
+	slice.Range(func(i int, el SummaryDataPointValueAtQuantile) {
 		total += i
 	})
 	assert.Equal(t, 0+1+2+3+4+5+6, total)
-}
-
-func TestSummaryDataPointValueAtQuantileSlice_ForEachWhile(t *testing.T) {
-	// Test ForEach on empty slice
-	emptySlice := NewSummaryDataPointValueAtQuantileSlice()
-	emptySlice.ForEachWhile(func(el SummaryDataPointValueAtQuantile) bool {
-		t.Fail()
-		return false
-	})
-
-	// Test ForEachWhile stops short
-	slice := generateTestSummaryDataPointValueAtQuantileSlice()
-	last := 0
-	proceed := slice.ForEachWhile(func(el SummaryDataPointValueAtQuantile) bool {
-		last++
-		if last == 4 {
-			return false
-		}
-		return true
-	})
-	assert.False(t, proceed)
-	assert.Equal(t, 4, last)
-
-	// Test ForEachWhile completes
-	last = 0
-	proceed = slice.ForEachWhile(func(el SummaryDataPointValueAtQuantile) bool {
-		last++
-		return true
-	})
-	assert.True(t, proceed)
-	assert.Equal(t, 7, last)
 }
 
 func generateTestSummaryDataPointValueAtQuantileSlice() SummaryDataPointValueAtQuantileSlice {

--- a/pdata/pmetric/generated_summarydatapointvalueatquantileslice_test.go
+++ b/pdata/pmetric/generated_summarydatapointvalueatquantileslice_test.go
@@ -148,11 +148,27 @@ func TestSummaryDataPointValueAtQuantileSlice_ForEach(t *testing.T) {
 
 	// Test ForEach
 	slice := generateTestSummaryDataPointValueAtQuantileSlice()
-	pos := 0
+	count := 0
 	slice.ForEach(func(el SummaryDataPointValueAtQuantile) {
-		pos++
+		count++
 	})
-	assert.Equal(t, 7, slice.Len())
+	assert.Equal(t, 7, count)
+}
+
+func TestSummaryDataPointValueAtQuantileSlice_ForEachIndex(t *testing.T) {
+	// Test ForEach on empty slice
+	emptySlice := NewSummaryDataPointValueAtQuantileSlice()
+	emptySlice.ForEachIndex(func(i int, el SummaryDataPointValueAtQuantile) {
+		t.Fail()
+	})
+
+	// Test ForEach
+	slice := generateTestSummaryDataPointValueAtQuantileSlice()
+	total := 0
+	slice.ForEachIndex(func(i int, el SummaryDataPointValueAtQuantile) {
+		total += i
+	})
+	assert.Equal(t, 0+1+2+3+4+5+6, total)
 }
 
 func generateTestSummaryDataPointValueAtQuantileSlice() SummaryDataPointValueAtQuantileSlice {

--- a/pdata/pmetric/generated_summarydatapointvalueatquantileslice_test.go
+++ b/pdata/pmetric/generated_summarydatapointvalueatquantileslice_test.go
@@ -139,6 +139,22 @@ func TestSummaryDataPointValueAtQuantileSlice_Sort(t *testing.T) {
 	}
 }
 
+func TestSummaryDataPointValueAtQuantileSlice_ForEach(t *testing.T) {
+	// Test ForEach on empty slice
+	emptySlice := NewSummaryDataPointValueAtQuantileSlice()
+	emptySlice.ForEach(func(el SummaryDataPointValueAtQuantile) {
+		t.Fail()
+	})
+
+	// Test ForEach
+	slice := generateTestSummaryDataPointValueAtQuantileSlice()
+	pos := 0
+	slice.ForEach(func(el SummaryDataPointValueAtQuantile) {
+		pos++
+	})
+	assert.Equal(t, 7, slice.Len())
+}
+
 func generateTestSummaryDataPointValueAtQuantileSlice() SummaryDataPointValueAtQuantileSlice {
 	es := NewSummaryDataPointValueAtQuantileSlice()
 	fillTestSummaryDataPointValueAtQuantileSlice(es)

--- a/pdata/ptrace/generated_resourcespansslice.go
+++ b/pdata/ptrace/generated_resourcespansslice.go
@@ -150,3 +150,10 @@ func (es ResourceSpansSlice) Sort(less func(a, b ResourceSpans) bool) {
 	es.state.AssertMutable()
 	sort.SliceStable(*es.orig, func(i, j int) bool { return less(es.At(i), es.At(j)) })
 }
+
+// ForEach iterates over ResourceSpansSlice and executes f against each element.
+func (es ResourceSpansSlice) ForEach(f func(el ResourceSpans)) {
+	for i := 0; i < es.Len(); i++ {
+		f(es.At(i))
+	}
+}

--- a/pdata/ptrace/generated_resourcespansslice.go
+++ b/pdata/ptrace/generated_resourcespansslice.go
@@ -151,28 +151,10 @@ func (es ResourceSpansSlice) Sort(less func(a, b ResourceSpans) bool) {
 	sort.SliceStable(*es.orig, func(i, j int) bool { return less(es.At(i), es.At(j)) })
 }
 
-// ForEach iterates over ResourceSpansSlice and executes f against each element.
-func (es ResourceSpansSlice) ForEach(f func(ResourceSpans)) {
-	for i := 0; i < es.Len(); i++ {
-		f(es.At(i))
-	}
-}
-
-// ForEachIndex iterates over ResourceSpansSlice and executes f against each element.
+// Range iterates over ResourceSpansSlice and executes f against each element.
 // The function also passes the iteration index.
-func (es ResourceSpansSlice) ForEachIndex(f func(int, ResourceSpans)) {
+func (es ResourceSpansSlice) Range(f func(int, ResourceSpans)) {
 	for i := 0; i < es.Len(); i++ {
 		f(i, es.At(i))
 	}
-}
-
-// ForEachWhile iterates over ResourceSpansSlice and executes f against each element.
-// The function also passes the iteration index.
-func (es ResourceSpansSlice) ForEachWhile(f func(ResourceSpans) bool) bool {
-	for i := 0; i < es.Len(); i++ {
-		if !f(es.At(i)) {
-			return false
-		}
-	}
-	return true
 }

--- a/pdata/ptrace/generated_resourcespansslice.go
+++ b/pdata/ptrace/generated_resourcespansslice.go
@@ -165,3 +165,14 @@ func (es ResourceSpansSlice) ForEachIndex(f func(int, ResourceSpans)) {
 		f(i, es.At(i))
 	}
 }
+
+// ForEachWhile iterates over ResourceSpansSlice and executes f against each element.
+// The function also passes the iteration index.
+func (es ResourceSpansSlice) ForEachWhile(f func(ResourceSpans) bool) bool {
+	for i := 0; i < es.Len(); i++ {
+		if !f(es.At(i)) {
+			return false
+		}
+	}
+	return true
+}

--- a/pdata/ptrace/generated_resourcespansslice.go
+++ b/pdata/ptrace/generated_resourcespansslice.go
@@ -152,8 +152,16 @@ func (es ResourceSpansSlice) Sort(less func(a, b ResourceSpans) bool) {
 }
 
 // ForEach iterates over ResourceSpansSlice and executes f against each element.
-func (es ResourceSpansSlice) ForEach(f func(el ResourceSpans)) {
+func (es ResourceSpansSlice) ForEach(f func(ResourceSpans)) {
 	for i := 0; i < es.Len(); i++ {
 		f(es.At(i))
+	}
+}
+
+// ForEachIndex iterates over ResourceSpansSlice and executes f against each element.
+// The function also passes the iteration index.
+func (es ResourceSpansSlice) ForEachIndex(f func(int, ResourceSpans)) {
+	for i := 0; i < es.Len(); i++ {
+		f(i, es.At(i))
 	}
 }

--- a/pdata/ptrace/generated_resourcespansslice_test.go
+++ b/pdata/ptrace/generated_resourcespansslice_test.go
@@ -148,11 +148,27 @@ func TestResourceSpansSlice_ForEach(t *testing.T) {
 
 	// Test ForEach
 	slice := generateTestResourceSpansSlice()
-	pos := 0
+	count := 0
 	slice.ForEach(func(el ResourceSpans) {
-		pos++
+		count++
 	})
-	assert.Equal(t, 7, slice.Len())
+	assert.Equal(t, 7, count)
+}
+
+func TestResourceSpansSlice_ForEachIndex(t *testing.T) {
+	// Test ForEach on empty slice
+	emptySlice := NewResourceSpansSlice()
+	emptySlice.ForEachIndex(func(i int, el ResourceSpans) {
+		t.Fail()
+	})
+
+	// Test ForEach
+	slice := generateTestResourceSpansSlice()
+	total := 0
+	slice.ForEachIndex(func(i int, el ResourceSpans) {
+		total += i
+	})
+	assert.Equal(t, 0+1+2+3+4+5+6, total)
 }
 
 func generateTestResourceSpansSlice() ResourceSpansSlice {

--- a/pdata/ptrace/generated_resourcespansslice_test.go
+++ b/pdata/ptrace/generated_resourcespansslice_test.go
@@ -139,67 +139,20 @@ func TestResourceSpansSlice_Sort(t *testing.T) {
 	}
 }
 
-func TestResourceSpansSlice_ForEach(t *testing.T) {
-	// Test ForEach on empty slice
+func TestResourceSpansSlice_Range(t *testing.T) {
+	// Test _Range on empty slice
 	emptySlice := NewResourceSpansSlice()
-	emptySlice.ForEach(func(el ResourceSpans) {
+	emptySlice.Range(func(i int, el ResourceSpans) {
 		t.Fail()
 	})
 
-	// Test ForEach
-	slice := generateTestResourceSpansSlice()
-	count := 0
-	slice.ForEach(func(el ResourceSpans) {
-		count++
-	})
-	assert.Equal(t, 7, count)
-}
-
-func TestResourceSpansSlice_ForEachIndex(t *testing.T) {
-	// Test _ForEachIndex on empty slice
-	emptySlice := NewResourceSpansSlice()
-	emptySlice.ForEachIndex(func(i int, el ResourceSpans) {
-		t.Fail()
-	})
-
-	// Test _ForEachIndex
+	// Test _Range
 	slice := generateTestResourceSpansSlice()
 	total := 0
-	slice.ForEachIndex(func(i int, el ResourceSpans) {
+	slice.Range(func(i int, el ResourceSpans) {
 		total += i
 	})
 	assert.Equal(t, 0+1+2+3+4+5+6, total)
-}
-
-func TestResourceSpansSlice_ForEachWhile(t *testing.T) {
-	// Test ForEach on empty slice
-	emptySlice := NewResourceSpansSlice()
-	emptySlice.ForEachWhile(func(el ResourceSpans) bool {
-		t.Fail()
-		return false
-	})
-
-	// Test ForEachWhile stops short
-	slice := generateTestResourceSpansSlice()
-	last := 0
-	proceed := slice.ForEachWhile(func(el ResourceSpans) bool {
-		last++
-		if last == 4 {
-			return false
-		}
-		return true
-	})
-	assert.False(t, proceed)
-	assert.Equal(t, 4, last)
-
-	// Test ForEachWhile completes
-	last = 0
-	proceed = slice.ForEachWhile(func(el ResourceSpans) bool {
-		last++
-		return true
-	})
-	assert.True(t, proceed)
-	assert.Equal(t, 7, last)
 }
 
 func generateTestResourceSpansSlice() ResourceSpansSlice {

--- a/pdata/ptrace/generated_resourcespansslice_test.go
+++ b/pdata/ptrace/generated_resourcespansslice_test.go
@@ -139,6 +139,22 @@ func TestResourceSpansSlice_Sort(t *testing.T) {
 	}
 }
 
+func TestResourceSpansSlice_ForEach(t *testing.T) {
+	// Test ForEach on empty slice
+	emptySlice := NewResourceSpansSlice()
+	emptySlice.ForEach(func(el ResourceSpans) {
+		t.Fail()
+	})
+
+	// Test ForEach
+	slice := generateTestResourceSpansSlice()
+	pos := 0
+	slice.ForEach(func(el ResourceSpans) {
+		pos++
+	})
+	assert.Equal(t, 7, slice.Len())
+}
+
 func generateTestResourceSpansSlice() ResourceSpansSlice {
 	es := NewResourceSpansSlice()
 	fillTestResourceSpansSlice(es)

--- a/pdata/ptrace/generated_resourcespansslice_test.go
+++ b/pdata/ptrace/generated_resourcespansslice_test.go
@@ -156,19 +156,50 @@ func TestResourceSpansSlice_ForEach(t *testing.T) {
 }
 
 func TestResourceSpansSlice_ForEachIndex(t *testing.T) {
-	// Test ForEach on empty slice
+	// Test _ForEachIndex on empty slice
 	emptySlice := NewResourceSpansSlice()
 	emptySlice.ForEachIndex(func(i int, el ResourceSpans) {
 		t.Fail()
 	})
 
-	// Test ForEach
+	// Test _ForEachIndex
 	slice := generateTestResourceSpansSlice()
 	total := 0
 	slice.ForEachIndex(func(i int, el ResourceSpans) {
 		total += i
 	})
 	assert.Equal(t, 0+1+2+3+4+5+6, total)
+}
+
+func TestResourceSpansSlice_ForEachWhile(t *testing.T) {
+	// Test ForEach on empty slice
+	emptySlice := NewResourceSpansSlice()
+	emptySlice.ForEachWhile(func(el ResourceSpans) bool {
+		t.Fail()
+		return false
+	})
+
+	// Test ForEachWhile stops short
+	slice := generateTestResourceSpansSlice()
+	last := 0
+	proceed := slice.ForEachWhile(func(el ResourceSpans) bool {
+		last++
+		if last == 4 {
+			return false
+		}
+		return true
+	})
+	assert.False(t, proceed)
+	assert.Equal(t, 4, last)
+
+	// Test ForEachWhile completes
+	last = 0
+	proceed = slice.ForEachWhile(func(el ResourceSpans) bool {
+		last++
+		return true
+	})
+	assert.True(t, proceed)
+	assert.Equal(t, 7, last)
 }
 
 func generateTestResourceSpansSlice() ResourceSpansSlice {

--- a/pdata/ptrace/generated_scopespansslice.go
+++ b/pdata/ptrace/generated_scopespansslice.go
@@ -152,8 +152,16 @@ func (es ScopeSpansSlice) Sort(less func(a, b ScopeSpans) bool) {
 }
 
 // ForEach iterates over ScopeSpansSlice and executes f against each element.
-func (es ScopeSpansSlice) ForEach(f func(el ScopeSpans)) {
+func (es ScopeSpansSlice) ForEach(f func(ScopeSpans)) {
 	for i := 0; i < es.Len(); i++ {
 		f(es.At(i))
+	}
+}
+
+// ForEachIndex iterates over ScopeSpansSlice and executes f against each element.
+// The function also passes the iteration index.
+func (es ScopeSpansSlice) ForEachIndex(f func(int, ScopeSpans)) {
+	for i := 0; i < es.Len(); i++ {
+		f(i, es.At(i))
 	}
 }

--- a/pdata/ptrace/generated_scopespansslice.go
+++ b/pdata/ptrace/generated_scopespansslice.go
@@ -165,3 +165,14 @@ func (es ScopeSpansSlice) ForEachIndex(f func(int, ScopeSpans)) {
 		f(i, es.At(i))
 	}
 }
+
+// ForEachWhile iterates over ScopeSpansSlice and executes f against each element.
+// The function also passes the iteration index.
+func (es ScopeSpansSlice) ForEachWhile(f func(ScopeSpans) bool) bool {
+	for i := 0; i < es.Len(); i++ {
+		if !f(es.At(i)) {
+			return false
+		}
+	}
+	return true
+}

--- a/pdata/ptrace/generated_scopespansslice.go
+++ b/pdata/ptrace/generated_scopespansslice.go
@@ -150,3 +150,10 @@ func (es ScopeSpansSlice) Sort(less func(a, b ScopeSpans) bool) {
 	es.state.AssertMutable()
 	sort.SliceStable(*es.orig, func(i, j int) bool { return less(es.At(i), es.At(j)) })
 }
+
+// ForEach iterates over ScopeSpansSlice and executes f against each element.
+func (es ScopeSpansSlice) ForEach(f func(el ScopeSpans)) {
+	for i := 0; i < es.Len(); i++ {
+		f(es.At(i))
+	}
+}

--- a/pdata/ptrace/generated_scopespansslice.go
+++ b/pdata/ptrace/generated_scopespansslice.go
@@ -151,28 +151,10 @@ func (es ScopeSpansSlice) Sort(less func(a, b ScopeSpans) bool) {
 	sort.SliceStable(*es.orig, func(i, j int) bool { return less(es.At(i), es.At(j)) })
 }
 
-// ForEach iterates over ScopeSpansSlice and executes f against each element.
-func (es ScopeSpansSlice) ForEach(f func(ScopeSpans)) {
-	for i := 0; i < es.Len(); i++ {
-		f(es.At(i))
-	}
-}
-
-// ForEachIndex iterates over ScopeSpansSlice and executes f against each element.
+// Range iterates over ScopeSpansSlice and executes f against each element.
 // The function also passes the iteration index.
-func (es ScopeSpansSlice) ForEachIndex(f func(int, ScopeSpans)) {
+func (es ScopeSpansSlice) Range(f func(int, ScopeSpans)) {
 	for i := 0; i < es.Len(); i++ {
 		f(i, es.At(i))
 	}
-}
-
-// ForEachWhile iterates over ScopeSpansSlice and executes f against each element.
-// The function also passes the iteration index.
-func (es ScopeSpansSlice) ForEachWhile(f func(ScopeSpans) bool) bool {
-	for i := 0; i < es.Len(); i++ {
-		if !f(es.At(i)) {
-			return false
-		}
-	}
-	return true
 }

--- a/pdata/ptrace/generated_scopespansslice_test.go
+++ b/pdata/ptrace/generated_scopespansslice_test.go
@@ -156,19 +156,50 @@ func TestScopeSpansSlice_ForEach(t *testing.T) {
 }
 
 func TestScopeSpansSlice_ForEachIndex(t *testing.T) {
-	// Test ForEach on empty slice
+	// Test _ForEachIndex on empty slice
 	emptySlice := NewScopeSpansSlice()
 	emptySlice.ForEachIndex(func(i int, el ScopeSpans) {
 		t.Fail()
 	})
 
-	// Test ForEach
+	// Test _ForEachIndex
 	slice := generateTestScopeSpansSlice()
 	total := 0
 	slice.ForEachIndex(func(i int, el ScopeSpans) {
 		total += i
 	})
 	assert.Equal(t, 0+1+2+3+4+5+6, total)
+}
+
+func TestScopeSpansSlice_ForEachWhile(t *testing.T) {
+	// Test ForEach on empty slice
+	emptySlice := NewScopeSpansSlice()
+	emptySlice.ForEachWhile(func(el ScopeSpans) bool {
+		t.Fail()
+		return false
+	})
+
+	// Test ForEachWhile stops short
+	slice := generateTestScopeSpansSlice()
+	last := 0
+	proceed := slice.ForEachWhile(func(el ScopeSpans) bool {
+		last++
+		if last == 4 {
+			return false
+		}
+		return true
+	})
+	assert.False(t, proceed)
+	assert.Equal(t, 4, last)
+
+	// Test ForEachWhile completes
+	last = 0
+	proceed = slice.ForEachWhile(func(el ScopeSpans) bool {
+		last++
+		return true
+	})
+	assert.True(t, proceed)
+	assert.Equal(t, 7, last)
 }
 
 func generateTestScopeSpansSlice() ScopeSpansSlice {

--- a/pdata/ptrace/generated_scopespansslice_test.go
+++ b/pdata/ptrace/generated_scopespansslice_test.go
@@ -139,67 +139,20 @@ func TestScopeSpansSlice_Sort(t *testing.T) {
 	}
 }
 
-func TestScopeSpansSlice_ForEach(t *testing.T) {
-	// Test ForEach on empty slice
+func TestScopeSpansSlice_Range(t *testing.T) {
+	// Test _Range on empty slice
 	emptySlice := NewScopeSpansSlice()
-	emptySlice.ForEach(func(el ScopeSpans) {
+	emptySlice.Range(func(i int, el ScopeSpans) {
 		t.Fail()
 	})
 
-	// Test ForEach
-	slice := generateTestScopeSpansSlice()
-	count := 0
-	slice.ForEach(func(el ScopeSpans) {
-		count++
-	})
-	assert.Equal(t, 7, count)
-}
-
-func TestScopeSpansSlice_ForEachIndex(t *testing.T) {
-	// Test _ForEachIndex on empty slice
-	emptySlice := NewScopeSpansSlice()
-	emptySlice.ForEachIndex(func(i int, el ScopeSpans) {
-		t.Fail()
-	})
-
-	// Test _ForEachIndex
+	// Test _Range
 	slice := generateTestScopeSpansSlice()
 	total := 0
-	slice.ForEachIndex(func(i int, el ScopeSpans) {
+	slice.Range(func(i int, el ScopeSpans) {
 		total += i
 	})
 	assert.Equal(t, 0+1+2+3+4+5+6, total)
-}
-
-func TestScopeSpansSlice_ForEachWhile(t *testing.T) {
-	// Test ForEach on empty slice
-	emptySlice := NewScopeSpansSlice()
-	emptySlice.ForEachWhile(func(el ScopeSpans) bool {
-		t.Fail()
-		return false
-	})
-
-	// Test ForEachWhile stops short
-	slice := generateTestScopeSpansSlice()
-	last := 0
-	proceed := slice.ForEachWhile(func(el ScopeSpans) bool {
-		last++
-		if last == 4 {
-			return false
-		}
-		return true
-	})
-	assert.False(t, proceed)
-	assert.Equal(t, 4, last)
-
-	// Test ForEachWhile completes
-	last = 0
-	proceed = slice.ForEachWhile(func(el ScopeSpans) bool {
-		last++
-		return true
-	})
-	assert.True(t, proceed)
-	assert.Equal(t, 7, last)
 }
 
 func generateTestScopeSpansSlice() ScopeSpansSlice {

--- a/pdata/ptrace/generated_scopespansslice_test.go
+++ b/pdata/ptrace/generated_scopespansslice_test.go
@@ -139,6 +139,22 @@ func TestScopeSpansSlice_Sort(t *testing.T) {
 	}
 }
 
+func TestScopeSpansSlice_ForEach(t *testing.T) {
+	// Test ForEach on empty slice
+	emptySlice := NewScopeSpansSlice()
+	emptySlice.ForEach(func(el ScopeSpans) {
+		t.Fail()
+	})
+
+	// Test ForEach
+	slice := generateTestScopeSpansSlice()
+	pos := 0
+	slice.ForEach(func(el ScopeSpans) {
+		pos++
+	})
+	assert.Equal(t, 7, slice.Len())
+}
+
 func generateTestScopeSpansSlice() ScopeSpansSlice {
 	es := NewScopeSpansSlice()
 	fillTestScopeSpansSlice(es)

--- a/pdata/ptrace/generated_scopespansslice_test.go
+++ b/pdata/ptrace/generated_scopespansslice_test.go
@@ -148,11 +148,27 @@ func TestScopeSpansSlice_ForEach(t *testing.T) {
 
 	// Test ForEach
 	slice := generateTestScopeSpansSlice()
-	pos := 0
+	count := 0
 	slice.ForEach(func(el ScopeSpans) {
-		pos++
+		count++
 	})
-	assert.Equal(t, 7, slice.Len())
+	assert.Equal(t, 7, count)
+}
+
+func TestScopeSpansSlice_ForEachIndex(t *testing.T) {
+	// Test ForEach on empty slice
+	emptySlice := NewScopeSpansSlice()
+	emptySlice.ForEachIndex(func(i int, el ScopeSpans) {
+		t.Fail()
+	})
+
+	// Test ForEach
+	slice := generateTestScopeSpansSlice()
+	total := 0
+	slice.ForEachIndex(func(i int, el ScopeSpans) {
+		total += i
+	})
+	assert.Equal(t, 0+1+2+3+4+5+6, total)
 }
 
 func generateTestScopeSpansSlice() ScopeSpansSlice {

--- a/pdata/ptrace/generated_spaneventslice.go
+++ b/pdata/ptrace/generated_spaneventslice.go
@@ -151,28 +151,10 @@ func (es SpanEventSlice) Sort(less func(a, b SpanEvent) bool) {
 	sort.SliceStable(*es.orig, func(i, j int) bool { return less(es.At(i), es.At(j)) })
 }
 
-// ForEach iterates over SpanEventSlice and executes f against each element.
-func (es SpanEventSlice) ForEach(f func(SpanEvent)) {
-	for i := 0; i < es.Len(); i++ {
-		f(es.At(i))
-	}
-}
-
-// ForEachIndex iterates over SpanEventSlice and executes f against each element.
+// Range iterates over SpanEventSlice and executes f against each element.
 // The function also passes the iteration index.
-func (es SpanEventSlice) ForEachIndex(f func(int, SpanEvent)) {
+func (es SpanEventSlice) Range(f func(int, SpanEvent)) {
 	for i := 0; i < es.Len(); i++ {
 		f(i, es.At(i))
 	}
-}
-
-// ForEachWhile iterates over SpanEventSlice and executes f against each element.
-// The function also passes the iteration index.
-func (es SpanEventSlice) ForEachWhile(f func(SpanEvent) bool) bool {
-	for i := 0; i < es.Len(); i++ {
-		if !f(es.At(i)) {
-			return false
-		}
-	}
-	return true
 }

--- a/pdata/ptrace/generated_spaneventslice.go
+++ b/pdata/ptrace/generated_spaneventslice.go
@@ -165,3 +165,14 @@ func (es SpanEventSlice) ForEachIndex(f func(int, SpanEvent)) {
 		f(i, es.At(i))
 	}
 }
+
+// ForEachWhile iterates over SpanEventSlice and executes f against each element.
+// The function also passes the iteration index.
+func (es SpanEventSlice) ForEachWhile(f func(SpanEvent) bool) bool {
+	for i := 0; i < es.Len(); i++ {
+		if !f(es.At(i)) {
+			return false
+		}
+	}
+	return true
+}

--- a/pdata/ptrace/generated_spaneventslice.go
+++ b/pdata/ptrace/generated_spaneventslice.go
@@ -152,8 +152,16 @@ func (es SpanEventSlice) Sort(less func(a, b SpanEvent) bool) {
 }
 
 // ForEach iterates over SpanEventSlice and executes f against each element.
-func (es SpanEventSlice) ForEach(f func(el SpanEvent)) {
+func (es SpanEventSlice) ForEach(f func(SpanEvent)) {
 	for i := 0; i < es.Len(); i++ {
 		f(es.At(i))
+	}
+}
+
+// ForEachIndex iterates over SpanEventSlice and executes f against each element.
+// The function also passes the iteration index.
+func (es SpanEventSlice) ForEachIndex(f func(int, SpanEvent)) {
+	for i := 0; i < es.Len(); i++ {
+		f(i, es.At(i))
 	}
 }

--- a/pdata/ptrace/generated_spaneventslice.go
+++ b/pdata/ptrace/generated_spaneventslice.go
@@ -150,3 +150,10 @@ func (es SpanEventSlice) Sort(less func(a, b SpanEvent) bool) {
 	es.state.AssertMutable()
 	sort.SliceStable(*es.orig, func(i, j int) bool { return less(es.At(i), es.At(j)) })
 }
+
+// ForEach iterates over SpanEventSlice and executes f against each element.
+func (es SpanEventSlice) ForEach(f func(el SpanEvent)) {
+	for i := 0; i < es.Len(); i++ {
+		f(es.At(i))
+	}
+}

--- a/pdata/ptrace/generated_spaneventslice_test.go
+++ b/pdata/ptrace/generated_spaneventslice_test.go
@@ -139,67 +139,20 @@ func TestSpanEventSlice_Sort(t *testing.T) {
 	}
 }
 
-func TestSpanEventSlice_ForEach(t *testing.T) {
-	// Test ForEach on empty slice
+func TestSpanEventSlice_Range(t *testing.T) {
+	// Test _Range on empty slice
 	emptySlice := NewSpanEventSlice()
-	emptySlice.ForEach(func(el SpanEvent) {
+	emptySlice.Range(func(i int, el SpanEvent) {
 		t.Fail()
 	})
 
-	// Test ForEach
-	slice := generateTestSpanEventSlice()
-	count := 0
-	slice.ForEach(func(el SpanEvent) {
-		count++
-	})
-	assert.Equal(t, 7, count)
-}
-
-func TestSpanEventSlice_ForEachIndex(t *testing.T) {
-	// Test _ForEachIndex on empty slice
-	emptySlice := NewSpanEventSlice()
-	emptySlice.ForEachIndex(func(i int, el SpanEvent) {
-		t.Fail()
-	})
-
-	// Test _ForEachIndex
+	// Test _Range
 	slice := generateTestSpanEventSlice()
 	total := 0
-	slice.ForEachIndex(func(i int, el SpanEvent) {
+	slice.Range(func(i int, el SpanEvent) {
 		total += i
 	})
 	assert.Equal(t, 0+1+2+3+4+5+6, total)
-}
-
-func TestSpanEventSlice_ForEachWhile(t *testing.T) {
-	// Test ForEach on empty slice
-	emptySlice := NewSpanEventSlice()
-	emptySlice.ForEachWhile(func(el SpanEvent) bool {
-		t.Fail()
-		return false
-	})
-
-	// Test ForEachWhile stops short
-	slice := generateTestSpanEventSlice()
-	last := 0
-	proceed := slice.ForEachWhile(func(el SpanEvent) bool {
-		last++
-		if last == 4 {
-			return false
-		}
-		return true
-	})
-	assert.False(t, proceed)
-	assert.Equal(t, 4, last)
-
-	// Test ForEachWhile completes
-	last = 0
-	proceed = slice.ForEachWhile(func(el SpanEvent) bool {
-		last++
-		return true
-	})
-	assert.True(t, proceed)
-	assert.Equal(t, 7, last)
 }
 
 func generateTestSpanEventSlice() SpanEventSlice {

--- a/pdata/ptrace/generated_spaneventslice_test.go
+++ b/pdata/ptrace/generated_spaneventslice_test.go
@@ -156,19 +156,50 @@ func TestSpanEventSlice_ForEach(t *testing.T) {
 }
 
 func TestSpanEventSlice_ForEachIndex(t *testing.T) {
-	// Test ForEach on empty slice
+	// Test _ForEachIndex on empty slice
 	emptySlice := NewSpanEventSlice()
 	emptySlice.ForEachIndex(func(i int, el SpanEvent) {
 		t.Fail()
 	})
 
-	// Test ForEach
+	// Test _ForEachIndex
 	slice := generateTestSpanEventSlice()
 	total := 0
 	slice.ForEachIndex(func(i int, el SpanEvent) {
 		total += i
 	})
 	assert.Equal(t, 0+1+2+3+4+5+6, total)
+}
+
+func TestSpanEventSlice_ForEachWhile(t *testing.T) {
+	// Test ForEach on empty slice
+	emptySlice := NewSpanEventSlice()
+	emptySlice.ForEachWhile(func(el SpanEvent) bool {
+		t.Fail()
+		return false
+	})
+
+	// Test ForEachWhile stops short
+	slice := generateTestSpanEventSlice()
+	last := 0
+	proceed := slice.ForEachWhile(func(el SpanEvent) bool {
+		last++
+		if last == 4 {
+			return false
+		}
+		return true
+	})
+	assert.False(t, proceed)
+	assert.Equal(t, 4, last)
+
+	// Test ForEachWhile completes
+	last = 0
+	proceed = slice.ForEachWhile(func(el SpanEvent) bool {
+		last++
+		return true
+	})
+	assert.True(t, proceed)
+	assert.Equal(t, 7, last)
 }
 
 func generateTestSpanEventSlice() SpanEventSlice {

--- a/pdata/ptrace/generated_spaneventslice_test.go
+++ b/pdata/ptrace/generated_spaneventslice_test.go
@@ -139,6 +139,22 @@ func TestSpanEventSlice_Sort(t *testing.T) {
 	}
 }
 
+func TestSpanEventSlice_ForEach(t *testing.T) {
+	// Test ForEach on empty slice
+	emptySlice := NewSpanEventSlice()
+	emptySlice.ForEach(func(el SpanEvent) {
+		t.Fail()
+	})
+
+	// Test ForEach
+	slice := generateTestSpanEventSlice()
+	pos := 0
+	slice.ForEach(func(el SpanEvent) {
+		pos++
+	})
+	assert.Equal(t, 7, slice.Len())
+}
+
 func generateTestSpanEventSlice() SpanEventSlice {
 	es := NewSpanEventSlice()
 	fillTestSpanEventSlice(es)

--- a/pdata/ptrace/generated_spaneventslice_test.go
+++ b/pdata/ptrace/generated_spaneventslice_test.go
@@ -148,11 +148,27 @@ func TestSpanEventSlice_ForEach(t *testing.T) {
 
 	// Test ForEach
 	slice := generateTestSpanEventSlice()
-	pos := 0
+	count := 0
 	slice.ForEach(func(el SpanEvent) {
-		pos++
+		count++
 	})
-	assert.Equal(t, 7, slice.Len())
+	assert.Equal(t, 7, count)
+}
+
+func TestSpanEventSlice_ForEachIndex(t *testing.T) {
+	// Test ForEach on empty slice
+	emptySlice := NewSpanEventSlice()
+	emptySlice.ForEachIndex(func(i int, el SpanEvent) {
+		t.Fail()
+	})
+
+	// Test ForEach
+	slice := generateTestSpanEventSlice()
+	total := 0
+	slice.ForEachIndex(func(i int, el SpanEvent) {
+		total += i
+	})
+	assert.Equal(t, 0+1+2+3+4+5+6, total)
 }
 
 func generateTestSpanEventSlice() SpanEventSlice {

--- a/pdata/ptrace/generated_spanlinkslice.go
+++ b/pdata/ptrace/generated_spanlinkslice.go
@@ -150,3 +150,10 @@ func (es SpanLinkSlice) Sort(less func(a, b SpanLink) bool) {
 	es.state.AssertMutable()
 	sort.SliceStable(*es.orig, func(i, j int) bool { return less(es.At(i), es.At(j)) })
 }
+
+// ForEach iterates over SpanLinkSlice and executes f against each element.
+func (es SpanLinkSlice) ForEach(f func(el SpanLink)) {
+	for i := 0; i < es.Len(); i++ {
+		f(es.At(i))
+	}
+}

--- a/pdata/ptrace/generated_spanlinkslice.go
+++ b/pdata/ptrace/generated_spanlinkslice.go
@@ -165,3 +165,14 @@ func (es SpanLinkSlice) ForEachIndex(f func(int, SpanLink)) {
 		f(i, es.At(i))
 	}
 }
+
+// ForEachWhile iterates over SpanLinkSlice and executes f against each element.
+// The function also passes the iteration index.
+func (es SpanLinkSlice) ForEachWhile(f func(SpanLink) bool) bool {
+	for i := 0; i < es.Len(); i++ {
+		if !f(es.At(i)) {
+			return false
+		}
+	}
+	return true
+}

--- a/pdata/ptrace/generated_spanlinkslice.go
+++ b/pdata/ptrace/generated_spanlinkslice.go
@@ -152,8 +152,16 @@ func (es SpanLinkSlice) Sort(less func(a, b SpanLink) bool) {
 }
 
 // ForEach iterates over SpanLinkSlice and executes f against each element.
-func (es SpanLinkSlice) ForEach(f func(el SpanLink)) {
+func (es SpanLinkSlice) ForEach(f func(SpanLink)) {
 	for i := 0; i < es.Len(); i++ {
 		f(es.At(i))
+	}
+}
+
+// ForEachIndex iterates over SpanLinkSlice and executes f against each element.
+// The function also passes the iteration index.
+func (es SpanLinkSlice) ForEachIndex(f func(int, SpanLink)) {
+	for i := 0; i < es.Len(); i++ {
+		f(i, es.At(i))
 	}
 }

--- a/pdata/ptrace/generated_spanlinkslice.go
+++ b/pdata/ptrace/generated_spanlinkslice.go
@@ -151,28 +151,10 @@ func (es SpanLinkSlice) Sort(less func(a, b SpanLink) bool) {
 	sort.SliceStable(*es.orig, func(i, j int) bool { return less(es.At(i), es.At(j)) })
 }
 
-// ForEach iterates over SpanLinkSlice and executes f against each element.
-func (es SpanLinkSlice) ForEach(f func(SpanLink)) {
-	for i := 0; i < es.Len(); i++ {
-		f(es.At(i))
-	}
-}
-
-// ForEachIndex iterates over SpanLinkSlice and executes f against each element.
+// Range iterates over SpanLinkSlice and executes f against each element.
 // The function also passes the iteration index.
-func (es SpanLinkSlice) ForEachIndex(f func(int, SpanLink)) {
+func (es SpanLinkSlice) Range(f func(int, SpanLink)) {
 	for i := 0; i < es.Len(); i++ {
 		f(i, es.At(i))
 	}
-}
-
-// ForEachWhile iterates over SpanLinkSlice and executes f against each element.
-// The function also passes the iteration index.
-func (es SpanLinkSlice) ForEachWhile(f func(SpanLink) bool) bool {
-	for i := 0; i < es.Len(); i++ {
-		if !f(es.At(i)) {
-			return false
-		}
-	}
-	return true
 }

--- a/pdata/ptrace/generated_spanlinkslice_test.go
+++ b/pdata/ptrace/generated_spanlinkslice_test.go
@@ -148,11 +148,27 @@ func TestSpanLinkSlice_ForEach(t *testing.T) {
 
 	// Test ForEach
 	slice := generateTestSpanLinkSlice()
-	pos := 0
+	count := 0
 	slice.ForEach(func(el SpanLink) {
-		pos++
+		count++
 	})
-	assert.Equal(t, 7, slice.Len())
+	assert.Equal(t, 7, count)
+}
+
+func TestSpanLinkSlice_ForEachIndex(t *testing.T) {
+	// Test ForEach on empty slice
+	emptySlice := NewSpanLinkSlice()
+	emptySlice.ForEachIndex(func(i int, el SpanLink) {
+		t.Fail()
+	})
+
+	// Test ForEach
+	slice := generateTestSpanLinkSlice()
+	total := 0
+	slice.ForEachIndex(func(i int, el SpanLink) {
+		total += i
+	})
+	assert.Equal(t, 0+1+2+3+4+5+6, total)
 }
 
 func generateTestSpanLinkSlice() SpanLinkSlice {

--- a/pdata/ptrace/generated_spanlinkslice_test.go
+++ b/pdata/ptrace/generated_spanlinkslice_test.go
@@ -139,6 +139,22 @@ func TestSpanLinkSlice_Sort(t *testing.T) {
 	}
 }
 
+func TestSpanLinkSlice_ForEach(t *testing.T) {
+	// Test ForEach on empty slice
+	emptySlice := NewSpanLinkSlice()
+	emptySlice.ForEach(func(el SpanLink) {
+		t.Fail()
+	})
+
+	// Test ForEach
+	slice := generateTestSpanLinkSlice()
+	pos := 0
+	slice.ForEach(func(el SpanLink) {
+		pos++
+	})
+	assert.Equal(t, 7, slice.Len())
+}
+
 func generateTestSpanLinkSlice() SpanLinkSlice {
 	es := NewSpanLinkSlice()
 	fillTestSpanLinkSlice(es)

--- a/pdata/ptrace/generated_spanlinkslice_test.go
+++ b/pdata/ptrace/generated_spanlinkslice_test.go
@@ -156,19 +156,50 @@ func TestSpanLinkSlice_ForEach(t *testing.T) {
 }
 
 func TestSpanLinkSlice_ForEachIndex(t *testing.T) {
-	// Test ForEach on empty slice
+	// Test _ForEachIndex on empty slice
 	emptySlice := NewSpanLinkSlice()
 	emptySlice.ForEachIndex(func(i int, el SpanLink) {
 		t.Fail()
 	})
 
-	// Test ForEach
+	// Test _ForEachIndex
 	slice := generateTestSpanLinkSlice()
 	total := 0
 	slice.ForEachIndex(func(i int, el SpanLink) {
 		total += i
 	})
 	assert.Equal(t, 0+1+2+3+4+5+6, total)
+}
+
+func TestSpanLinkSlice_ForEachWhile(t *testing.T) {
+	// Test ForEach on empty slice
+	emptySlice := NewSpanLinkSlice()
+	emptySlice.ForEachWhile(func(el SpanLink) bool {
+		t.Fail()
+		return false
+	})
+
+	// Test ForEachWhile stops short
+	slice := generateTestSpanLinkSlice()
+	last := 0
+	proceed := slice.ForEachWhile(func(el SpanLink) bool {
+		last++
+		if last == 4 {
+			return false
+		}
+		return true
+	})
+	assert.False(t, proceed)
+	assert.Equal(t, 4, last)
+
+	// Test ForEachWhile completes
+	last = 0
+	proceed = slice.ForEachWhile(func(el SpanLink) bool {
+		last++
+		return true
+	})
+	assert.True(t, proceed)
+	assert.Equal(t, 7, last)
 }
 
 func generateTestSpanLinkSlice() SpanLinkSlice {

--- a/pdata/ptrace/generated_spanlinkslice_test.go
+++ b/pdata/ptrace/generated_spanlinkslice_test.go
@@ -139,67 +139,20 @@ func TestSpanLinkSlice_Sort(t *testing.T) {
 	}
 }
 
-func TestSpanLinkSlice_ForEach(t *testing.T) {
-	// Test ForEach on empty slice
+func TestSpanLinkSlice_Range(t *testing.T) {
+	// Test _Range on empty slice
 	emptySlice := NewSpanLinkSlice()
-	emptySlice.ForEach(func(el SpanLink) {
+	emptySlice.Range(func(i int, el SpanLink) {
 		t.Fail()
 	})
 
-	// Test ForEach
-	slice := generateTestSpanLinkSlice()
-	count := 0
-	slice.ForEach(func(el SpanLink) {
-		count++
-	})
-	assert.Equal(t, 7, count)
-}
-
-func TestSpanLinkSlice_ForEachIndex(t *testing.T) {
-	// Test _ForEachIndex on empty slice
-	emptySlice := NewSpanLinkSlice()
-	emptySlice.ForEachIndex(func(i int, el SpanLink) {
-		t.Fail()
-	})
-
-	// Test _ForEachIndex
+	// Test _Range
 	slice := generateTestSpanLinkSlice()
 	total := 0
-	slice.ForEachIndex(func(i int, el SpanLink) {
+	slice.Range(func(i int, el SpanLink) {
 		total += i
 	})
 	assert.Equal(t, 0+1+2+3+4+5+6, total)
-}
-
-func TestSpanLinkSlice_ForEachWhile(t *testing.T) {
-	// Test ForEach on empty slice
-	emptySlice := NewSpanLinkSlice()
-	emptySlice.ForEachWhile(func(el SpanLink) bool {
-		t.Fail()
-		return false
-	})
-
-	// Test ForEachWhile stops short
-	slice := generateTestSpanLinkSlice()
-	last := 0
-	proceed := slice.ForEachWhile(func(el SpanLink) bool {
-		last++
-		if last == 4 {
-			return false
-		}
-		return true
-	})
-	assert.False(t, proceed)
-	assert.Equal(t, 4, last)
-
-	// Test ForEachWhile completes
-	last = 0
-	proceed = slice.ForEachWhile(func(el SpanLink) bool {
-		last++
-		return true
-	})
-	assert.True(t, proceed)
-	assert.Equal(t, 7, last)
 }
 
 func generateTestSpanLinkSlice() SpanLinkSlice {

--- a/pdata/ptrace/generated_spanslice.go
+++ b/pdata/ptrace/generated_spanslice.go
@@ -165,3 +165,14 @@ func (es SpanSlice) ForEachIndex(f func(int, Span)) {
 		f(i, es.At(i))
 	}
 }
+
+// ForEachWhile iterates over SpanSlice and executes f against each element.
+// The function also passes the iteration index.
+func (es SpanSlice) ForEachWhile(f func(Span) bool) bool {
+	for i := 0; i < es.Len(); i++ {
+		if !f(es.At(i)) {
+			return false
+		}
+	}
+	return true
+}

--- a/pdata/ptrace/generated_spanslice.go
+++ b/pdata/ptrace/generated_spanslice.go
@@ -150,3 +150,10 @@ func (es SpanSlice) Sort(less func(a, b Span) bool) {
 	es.state.AssertMutable()
 	sort.SliceStable(*es.orig, func(i, j int) bool { return less(es.At(i), es.At(j)) })
 }
+
+// ForEach iterates over SpanSlice and executes f against each element.
+func (es SpanSlice) ForEach(f func(el Span)) {
+	for i := 0; i < es.Len(); i++ {
+		f(es.At(i))
+	}
+}

--- a/pdata/ptrace/generated_spanslice.go
+++ b/pdata/ptrace/generated_spanslice.go
@@ -152,8 +152,16 @@ func (es SpanSlice) Sort(less func(a, b Span) bool) {
 }
 
 // ForEach iterates over SpanSlice and executes f against each element.
-func (es SpanSlice) ForEach(f func(el Span)) {
+func (es SpanSlice) ForEach(f func(Span)) {
 	for i := 0; i < es.Len(); i++ {
 		f(es.At(i))
+	}
+}
+
+// ForEachIndex iterates over SpanSlice and executes f against each element.
+// The function also passes the iteration index.
+func (es SpanSlice) ForEachIndex(f func(int, Span)) {
+	for i := 0; i < es.Len(); i++ {
+		f(i, es.At(i))
 	}
 }

--- a/pdata/ptrace/generated_spanslice.go
+++ b/pdata/ptrace/generated_spanslice.go
@@ -151,28 +151,10 @@ func (es SpanSlice) Sort(less func(a, b Span) bool) {
 	sort.SliceStable(*es.orig, func(i, j int) bool { return less(es.At(i), es.At(j)) })
 }
 
-// ForEach iterates over SpanSlice and executes f against each element.
-func (es SpanSlice) ForEach(f func(Span)) {
-	for i := 0; i < es.Len(); i++ {
-		f(es.At(i))
-	}
-}
-
-// ForEachIndex iterates over SpanSlice and executes f against each element.
+// Range iterates over SpanSlice and executes f against each element.
 // The function also passes the iteration index.
-func (es SpanSlice) ForEachIndex(f func(int, Span)) {
+func (es SpanSlice) Range(f func(int, Span)) {
 	for i := 0; i < es.Len(); i++ {
 		f(i, es.At(i))
 	}
-}
-
-// ForEachWhile iterates over SpanSlice and executes f against each element.
-// The function also passes the iteration index.
-func (es SpanSlice) ForEachWhile(f func(Span) bool) bool {
-	for i := 0; i < es.Len(); i++ {
-		if !f(es.At(i)) {
-			return false
-		}
-	}
-	return true
 }

--- a/pdata/ptrace/generated_spanslice_test.go
+++ b/pdata/ptrace/generated_spanslice_test.go
@@ -139,6 +139,22 @@ func TestSpanSlice_Sort(t *testing.T) {
 	}
 }
 
+func TestSpanSlice_ForEach(t *testing.T) {
+	// Test ForEach on empty slice
+	emptySlice := NewSpanSlice()
+	emptySlice.ForEach(func(el Span) {
+		t.Fail()
+	})
+
+	// Test ForEach
+	slice := generateTestSpanSlice()
+	pos := 0
+	slice.ForEach(func(el Span) {
+		pos++
+	})
+	assert.Equal(t, 7, slice.Len())
+}
+
 func generateTestSpanSlice() SpanSlice {
 	es := NewSpanSlice()
 	fillTestSpanSlice(es)

--- a/pdata/ptrace/generated_spanslice_test.go
+++ b/pdata/ptrace/generated_spanslice_test.go
@@ -148,11 +148,27 @@ func TestSpanSlice_ForEach(t *testing.T) {
 
 	// Test ForEach
 	slice := generateTestSpanSlice()
-	pos := 0
+	count := 0
 	slice.ForEach(func(el Span) {
-		pos++
+		count++
 	})
-	assert.Equal(t, 7, slice.Len())
+	assert.Equal(t, 7, count)
+}
+
+func TestSpanSlice_ForEachIndex(t *testing.T) {
+	// Test ForEach on empty slice
+	emptySlice := NewSpanSlice()
+	emptySlice.ForEachIndex(func(i int, el Span) {
+		t.Fail()
+	})
+
+	// Test ForEach
+	slice := generateTestSpanSlice()
+	total := 0
+	slice.ForEachIndex(func(i int, el Span) {
+		total += i
+	})
+	assert.Equal(t, 0+1+2+3+4+5+6, total)
 }
 
 func generateTestSpanSlice() SpanSlice {

--- a/pdata/ptrace/generated_spanslice_test.go
+++ b/pdata/ptrace/generated_spanslice_test.go
@@ -139,67 +139,20 @@ func TestSpanSlice_Sort(t *testing.T) {
 	}
 }
 
-func TestSpanSlice_ForEach(t *testing.T) {
-	// Test ForEach on empty slice
+func TestSpanSlice_Range(t *testing.T) {
+	// Test _Range on empty slice
 	emptySlice := NewSpanSlice()
-	emptySlice.ForEach(func(el Span) {
+	emptySlice.Range(func(i int, el Span) {
 		t.Fail()
 	})
 
-	// Test ForEach
-	slice := generateTestSpanSlice()
-	count := 0
-	slice.ForEach(func(el Span) {
-		count++
-	})
-	assert.Equal(t, 7, count)
-}
-
-func TestSpanSlice_ForEachIndex(t *testing.T) {
-	// Test _ForEachIndex on empty slice
-	emptySlice := NewSpanSlice()
-	emptySlice.ForEachIndex(func(i int, el Span) {
-		t.Fail()
-	})
-
-	// Test _ForEachIndex
+	// Test _Range
 	slice := generateTestSpanSlice()
 	total := 0
-	slice.ForEachIndex(func(i int, el Span) {
+	slice.Range(func(i int, el Span) {
 		total += i
 	})
 	assert.Equal(t, 0+1+2+3+4+5+6, total)
-}
-
-func TestSpanSlice_ForEachWhile(t *testing.T) {
-	// Test ForEach on empty slice
-	emptySlice := NewSpanSlice()
-	emptySlice.ForEachWhile(func(el Span) bool {
-		t.Fail()
-		return false
-	})
-
-	// Test ForEachWhile stops short
-	slice := generateTestSpanSlice()
-	last := 0
-	proceed := slice.ForEachWhile(func(el Span) bool {
-		last++
-		if last == 4 {
-			return false
-		}
-		return true
-	})
-	assert.False(t, proceed)
-	assert.Equal(t, 4, last)
-
-	// Test ForEachWhile completes
-	last = 0
-	proceed = slice.ForEachWhile(func(el Span) bool {
-		last++
-		return true
-	})
-	assert.True(t, proceed)
-	assert.Equal(t, 7, last)
 }
 
 func generateTestSpanSlice() SpanSlice {

--- a/pdata/ptrace/generated_spanslice_test.go
+++ b/pdata/ptrace/generated_spanslice_test.go
@@ -156,19 +156,50 @@ func TestSpanSlice_ForEach(t *testing.T) {
 }
 
 func TestSpanSlice_ForEachIndex(t *testing.T) {
-	// Test ForEach on empty slice
+	// Test _ForEachIndex on empty slice
 	emptySlice := NewSpanSlice()
 	emptySlice.ForEachIndex(func(i int, el Span) {
 		t.Fail()
 	})
 
-	// Test ForEach
+	// Test _ForEachIndex
 	slice := generateTestSpanSlice()
 	total := 0
 	slice.ForEachIndex(func(i int, el Span) {
 		total += i
 	})
 	assert.Equal(t, 0+1+2+3+4+5+6, total)
+}
+
+func TestSpanSlice_ForEachWhile(t *testing.T) {
+	// Test ForEach on empty slice
+	emptySlice := NewSpanSlice()
+	emptySlice.ForEachWhile(func(el Span) bool {
+		t.Fail()
+		return false
+	})
+
+	// Test ForEachWhile stops short
+	slice := generateTestSpanSlice()
+	last := 0
+	proceed := slice.ForEachWhile(func(el Span) bool {
+		last++
+		if last == 4 {
+			return false
+		}
+		return true
+	})
+	assert.False(t, proceed)
+	assert.Equal(t, 4, last)
+
+	// Test ForEachWhile completes
+	last = 0
+	proceed = slice.ForEachWhile(func(el Span) bool {
+		last++
+		return true
+	})
+	assert.True(t, proceed)
+	assert.Equal(t, 7, last)
 }
 
 func generateTestSpanSlice() SpanSlice {

--- a/processor/batchprocessor/batch_processor_test.go
+++ b/processor/batchprocessor/batch_processor_test.go
@@ -552,18 +552,14 @@ func getTestSpanName(requestNum, index int) string {
 
 func spansReceivedByName(tds []ptrace.Traces) map[string]ptrace.Span {
 	spansReceivedByName := map[string]ptrace.Span{}
-	for i := range tds {
-		rss := tds[i].ResourceSpans()
-		for i := 0; i < rss.Len(); i++ {
-			ilss := rss.At(i).ScopeSpans()
-			for j := 0; j < ilss.Len(); j++ {
-				spans := ilss.At(j).Spans()
-				for k := 0; k < spans.Len(); k++ {
-					span := spans.At(k)
-					spansReceivedByName[spans.At(k).Name()] = span
-				}
-			}
-		}
+	for _, td := range tds {
+		td.ResourceSpans().ForEach(func(rs ptrace.ResourceSpans) {
+			rs.ScopeSpans().ForEach(func(ss ptrace.ScopeSpans) {
+				ss.Spans().ForEach(func(span ptrace.Span) {
+					spansReceivedByName[span.Name()] = span
+				})
+			})
+		})
 	}
 	return spansReceivedByName
 }
@@ -571,17 +567,13 @@ func spansReceivedByName(tds []ptrace.Traces) map[string]ptrace.Span {
 func metricsReceivedByName(mds []pmetric.Metrics) map[string]pmetric.Metric {
 	metricsReceivedByName := map[string]pmetric.Metric{}
 	for _, md := range mds {
-		rms := md.ResourceMetrics()
-		for i := 0; i < rms.Len(); i++ {
-			ilms := rms.At(i).ScopeMetrics()
-			for j := 0; j < ilms.Len(); j++ {
-				metrics := ilms.At(j).Metrics()
-				for k := 0; k < metrics.Len(); k++ {
-					metric := metrics.At(k)
+		md.ResourceMetrics().ForEach(func(rm pmetric.ResourceMetrics) {
+			rm.ScopeMetrics().ForEach(func(rm pmetric.ScopeMetrics) {
+				rm.Metrics().ForEach(func(metric pmetric.Metric) {
 					metricsReceivedByName[metric.Name()] = metric
-				}
-			}
-		}
+				})
+			})
+		})
 	}
 	return metricsReceivedByName
 }
@@ -850,19 +842,14 @@ func getTestLogSeverityText(requestNum, index int) string {
 
 func logsReceivedBySeverityText(lds []plog.Logs) map[string]plog.LogRecord {
 	logsReceivedBySeverityText := map[string]plog.LogRecord{}
-	for i := range lds {
-		ld := lds[i]
-		rms := ld.ResourceLogs()
-		for i := 0; i < rms.Len(); i++ {
-			ilms := rms.At(i).ScopeLogs()
-			for j := 0; j < ilms.Len(); j++ {
-				logs := ilms.At(j).LogRecords()
-				for k := 0; k < logs.Len(); k++ {
-					log := logs.At(k)
+	for _, ld := range lds {
+		ld.ResourceLogs().ForEach(func(rl plog.ResourceLogs) {
+			rl.ScopeLogs().ForEach(func(sl plog.ScopeLogs) {
+				sl.LogRecords().ForEach(func(log plog.LogRecord) {
 					logsReceivedBySeverityText[log.SeverityText()] = log
-				}
-			}
-		}
+				})
+			})
+		})
 	}
 	return logsReceivedBySeverityText
 }

--- a/processor/batchprocessor/batch_processor_test.go
+++ b/processor/batchprocessor/batch_processor_test.go
@@ -553,9 +553,9 @@ func getTestSpanName(requestNum, index int) string {
 func spansReceivedByName(tds []ptrace.Traces) map[string]ptrace.Span {
 	spansReceivedByName := map[string]ptrace.Span{}
 	for _, td := range tds {
-		td.ResourceSpans().ForEach(func(rs ptrace.ResourceSpans) {
-			rs.ScopeSpans().ForEach(func(ss ptrace.ScopeSpans) {
-				ss.Spans().ForEach(func(span ptrace.Span) {
+		td.ResourceSpans().Range(func(_ int, rs ptrace.ResourceSpans) {
+			rs.ScopeSpans().Range(func(_ int, ss ptrace.ScopeSpans) {
+				ss.Spans().Range(func(_ int, span ptrace.Span) {
 					spansReceivedByName[span.Name()] = span
 				})
 			})
@@ -567,9 +567,9 @@ func spansReceivedByName(tds []ptrace.Traces) map[string]ptrace.Span {
 func metricsReceivedByName(mds []pmetric.Metrics) map[string]pmetric.Metric {
 	metricsReceivedByName := map[string]pmetric.Metric{}
 	for _, md := range mds {
-		md.ResourceMetrics().ForEach(func(rm pmetric.ResourceMetrics) {
-			rm.ScopeMetrics().ForEach(func(rm pmetric.ScopeMetrics) {
-				rm.Metrics().ForEach(func(metric pmetric.Metric) {
+		md.ResourceMetrics().Range(func(_ int, rm pmetric.ResourceMetrics) {
+			rm.ScopeMetrics().Range(func(_ int, rm pmetric.ScopeMetrics) {
+				rm.Metrics().Range(func(_ int, metric pmetric.Metric) {
 					metricsReceivedByName[metric.Name()] = metric
 				})
 			})
@@ -843,9 +843,9 @@ func getTestLogSeverityText(requestNum, index int) string {
 func logsReceivedBySeverityText(lds []plog.Logs) map[string]plog.LogRecord {
 	logsReceivedBySeverityText := map[string]plog.LogRecord{}
 	for _, ld := range lds {
-		ld.ResourceLogs().ForEach(func(rl plog.ResourceLogs) {
-			rl.ScopeLogs().ForEach(func(sl plog.ScopeLogs) {
-				sl.LogRecords().ForEach(func(log plog.LogRecord) {
+		ld.ResourceLogs().Range(func(_ int, rl plog.ResourceLogs) {
+			rl.ScopeLogs().Range(func(_ int, sl plog.ScopeLogs) {
+				sl.LogRecords().Range(func(_ int, log plog.LogRecord) {
 					logsReceivedBySeverityText[log.SeverityText()] = log
 				})
 			})

--- a/processor/batchprocessor/splitmetrics_test.go
+++ b/processor/batchprocessor/splitmetrics_test.go
@@ -30,7 +30,7 @@ func TestSplitMetrics(t *testing.T) {
 	md := testdata.GenerateMetrics(20)
 	metrics := md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics()
 	dataPointCount := metricDPC(metrics.At(0))
-	metrics.ForEachIndex(func(i int, metric pmetric.Metric) {
+	metrics.Range(func(i int, metric pmetric.Metric) {
 		metric.SetName(getTestMetricName(0, i))
 		assert.Equal(t, dataPointCount, metricDPC(metric))
 	})
@@ -76,7 +76,7 @@ func TestSplitMetricsMultipleResourceSpans(t *testing.T) {
 	md := testdata.GenerateMetrics(20)
 	metrics := md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics()
 	dataPointCount := metricDPC(metrics.At(0))
-	metrics.ForEachIndex(func(i int, metric pmetric.Metric) {
+	metrics.Range(func(i int, metric pmetric.Metric) {
 		metric.SetName(getTestMetricName(0, i))
 		assert.Equal(t, dataPointCount, metricDPC(metric))
 	})
@@ -84,7 +84,7 @@ func TestSplitMetricsMultipleResourceSpans(t *testing.T) {
 	testdata.GenerateMetrics(20).
 		ResourceMetrics().At(0).CopyTo(md.ResourceMetrics().AppendEmpty())
 	metrics = md.ResourceMetrics().At(1).ScopeMetrics().At(0).Metrics()
-	metrics.ForEachIndex(func(i int, metric pmetric.Metric) {
+	metrics.Range(func(i int, metric pmetric.Metric) {
 		metric.SetName(getTestMetricName(1, i))
 	})
 
@@ -101,7 +101,7 @@ func TestSplitMetricsMultipleResourceSpans_SplitSizeGreaterThanMetricSize(t *tes
 	td := testdata.GenerateMetrics(20)
 	metrics := td.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics()
 	dataPointCount := metricDPC(metrics.At(0))
-	metrics.ForEachIndex(func(i int, metric pmetric.Metric) {
+	metrics.Range(func(i int, metric pmetric.Metric) {
 		metric.SetName(getTestMetricName(0, i))
 		assert.Equal(t, dataPointCount, metricDPC(metric))
 	})
@@ -109,7 +109,7 @@ func TestSplitMetricsMultipleResourceSpans_SplitSizeGreaterThanMetricSize(t *tes
 	testdata.GenerateMetrics(20).
 		ResourceMetrics().At(0).CopyTo(td.ResourceMetrics().AppendEmpty())
 	metrics = td.ResourceMetrics().At(1).ScopeMetrics().At(0).Metrics()
-	metrics.ForEachIndex(func(i int, metric pmetric.Metric) {
+	metrics.Range(func(i int, metric pmetric.Metric) {
 		metric.SetName(getTestMetricName(1, i))
 	})
 
@@ -129,7 +129,7 @@ func TestSplitMetricsUneven(t *testing.T) {
 	md := testdata.GenerateMetrics(10)
 	metrics := md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics()
 	dataPointCount := 2
-	metrics.ForEachIndex(func(i int, metric pmetric.Metric) {
+	metrics.Range(func(i int, metric pmetric.Metric) {
 		metric.SetName(getTestMetricName(0, i))
 		assert.Equal(t, dataPointCount, metricDPC(metric))
 	})
@@ -156,7 +156,7 @@ func TestSplitMetricsAllTypes(t *testing.T) {
 	md := testdata.GenerateMetricsAllTypes()
 	dataPointCount := 2
 	metrics := md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics()
-	metrics.ForEachIndex(func(i int, metric pmetric.Metric) {
+	metrics.Range(func(i int, metric pmetric.Metric) {
 		metric.SetName(getTestMetricName(0, i))
 		assert.Equal(t, dataPointCount, metricDPC(metric))
 	})
@@ -255,7 +255,7 @@ func TestSplitMetricsBatchSizeSmallerThanDataPointCount(t *testing.T) {
 	md := testdata.GenerateMetrics(2)
 	metrics := md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics()
 	dataPointCount := 2
-	metrics.ForEachIndex(func(i int, metric pmetric.Metric) {
+	metrics.Range(func(i int, metric pmetric.Metric) {
 		metric.SetName(getTestMetricName(0, i))
 		assert.Equal(t, dataPointCount, metricDPC(metric))
 	})
@@ -290,7 +290,7 @@ func TestSplitMetricsMultipleILM(t *testing.T) {
 	md := testdata.GenerateMetrics(20)
 	metrics := md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics()
 	dataPointCount := metricDPC(metrics.At(0))
-	metrics.ForEachIndex(func(i int, metric pmetric.Metric) {
+	metrics.Range(func(i int, metric pmetric.Metric) {
 		metric.SetName(getTestMetricName(0, i))
 		assert.Equal(t, dataPointCount, metricDPC(metric))
 	})
@@ -302,7 +302,7 @@ func TestSplitMetricsMultipleILM(t *testing.T) {
 	md.ResourceMetrics().At(0).ScopeMetrics().At(0).
 		CopyTo(md.ResourceMetrics().At(0).ScopeMetrics().AppendEmpty())
 	metrics = md.ResourceMetrics().At(0).ScopeMetrics().At(2).Metrics()
-	metrics.ForEachIndex(func(i int, metric pmetric.Metric) {
+	metrics.Range(func(i int, metric pmetric.Metric) {
 		metric.SetName(getTestMetricName(2, i))
 	})
 

--- a/processor/batchprocessor/splitmetrics_test.go
+++ b/processor/batchprocessor/splitmetrics_test.go
@@ -30,10 +30,10 @@ func TestSplitMetrics(t *testing.T) {
 	md := testdata.GenerateMetrics(20)
 	metrics := md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics()
 	dataPointCount := metricDPC(metrics.At(0))
-	for i := 0; i < metrics.Len(); i++ {
-		metrics.At(i).SetName(getTestMetricName(0, i))
-		assert.Equal(t, dataPointCount, metricDPC(metrics.At(i)))
-	}
+	metrics.ForEachIndex(func(i int, metric pmetric.Metric) {
+		metric.SetName(getTestMetricName(0, i))
+		assert.Equal(t, dataPointCount, metricDPC(metric))
+	})
 	cp := pmetric.NewMetrics()
 	cpMetrics := cp.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics()
 	cpMetrics.EnsureCapacity(5)
@@ -76,17 +76,17 @@ func TestSplitMetricsMultipleResourceSpans(t *testing.T) {
 	md := testdata.GenerateMetrics(20)
 	metrics := md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics()
 	dataPointCount := metricDPC(metrics.At(0))
-	for i := 0; i < metrics.Len(); i++ {
-		metrics.At(i).SetName(getTestMetricName(0, i))
-		assert.Equal(t, dataPointCount, metricDPC(metrics.At(i)))
-	}
+	metrics.ForEachIndex(func(i int, metric pmetric.Metric) {
+		metric.SetName(getTestMetricName(0, i))
+		assert.Equal(t, dataPointCount, metricDPC(metric))
+	})
 	// add second index to resource metrics
 	testdata.GenerateMetrics(20).
 		ResourceMetrics().At(0).CopyTo(md.ResourceMetrics().AppendEmpty())
 	metrics = md.ResourceMetrics().At(1).ScopeMetrics().At(0).Metrics()
-	for i := 0; i < metrics.Len(); i++ {
-		metrics.At(i).SetName(getTestMetricName(1, i))
-	}
+	metrics.ForEachIndex(func(i int, metric pmetric.Metric) {
+		metric.SetName(getTestMetricName(1, i))
+	})
 
 	splitMetricCount := 5
 	splitSize := splitMetricCount * dataPointCount
@@ -101,17 +101,17 @@ func TestSplitMetricsMultipleResourceSpans_SplitSizeGreaterThanMetricSize(t *tes
 	td := testdata.GenerateMetrics(20)
 	metrics := td.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics()
 	dataPointCount := metricDPC(metrics.At(0))
-	for i := 0; i < metrics.Len(); i++ {
-		metrics.At(i).SetName(getTestMetricName(0, i))
-		assert.Equal(t, dataPointCount, metricDPC(metrics.At(i)))
-	}
+	metrics.ForEachIndex(func(i int, metric pmetric.Metric) {
+		metric.SetName(getTestMetricName(0, i))
+		assert.Equal(t, dataPointCount, metricDPC(metric))
+	})
 	// add second index to resource metrics
 	testdata.GenerateMetrics(20).
 		ResourceMetrics().At(0).CopyTo(td.ResourceMetrics().AppendEmpty())
 	metrics = td.ResourceMetrics().At(1).ScopeMetrics().At(0).Metrics()
-	for i := 0; i < metrics.Len(); i++ {
-		metrics.At(i).SetName(getTestMetricName(1, i))
-	}
+	metrics.ForEachIndex(func(i int, metric pmetric.Metric) {
+		metric.SetName(getTestMetricName(1, i))
+	})
 
 	splitMetricCount := 25
 	splitSize := splitMetricCount * dataPointCount
@@ -129,10 +129,10 @@ func TestSplitMetricsUneven(t *testing.T) {
 	md := testdata.GenerateMetrics(10)
 	metrics := md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics()
 	dataPointCount := 2
-	for i := 0; i < metrics.Len(); i++ {
-		metrics.At(i).SetName(getTestMetricName(0, i))
-		assert.Equal(t, dataPointCount, metricDPC(metrics.At(i)))
-	}
+	metrics.ForEachIndex(func(i int, metric pmetric.Metric) {
+		metric.SetName(getTestMetricName(0, i))
+		assert.Equal(t, dataPointCount, metricDPC(metric))
+	})
 
 	splitSize := 9
 	split := splitMetrics(splitSize, md)
@@ -156,10 +156,10 @@ func TestSplitMetricsAllTypes(t *testing.T) {
 	md := testdata.GenerateMetricsAllTypes()
 	dataPointCount := 2
 	metrics := md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics()
-	for i := 0; i < metrics.Len(); i++ {
-		metrics.At(i).SetName(getTestMetricName(0, i))
-		assert.Equal(t, dataPointCount, metricDPC(metrics.At(i)))
-	}
+	metrics.ForEachIndex(func(i int, metric pmetric.Metric) {
+		metric.SetName(getTestMetricName(0, i))
+		assert.Equal(t, dataPointCount, metricDPC(metric))
+	})
 
 	splitSize := 2
 	// Start with 7 metric types, and 2 points per-metric. Split out the first,
@@ -255,10 +255,10 @@ func TestSplitMetricsBatchSizeSmallerThanDataPointCount(t *testing.T) {
 	md := testdata.GenerateMetrics(2)
 	metrics := md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics()
 	dataPointCount := 2
-	for i := 0; i < metrics.Len(); i++ {
-		metrics.At(i).SetName(getTestMetricName(0, i))
-		assert.Equal(t, dataPointCount, metricDPC(metrics.At(i)))
-	}
+	metrics.ForEachIndex(func(i int, metric pmetric.Metric) {
+		metric.SetName(getTestMetricName(0, i))
+		assert.Equal(t, dataPointCount, metricDPC(metric))
+	})
 
 	splitSize := 1
 	split := splitMetrics(splitSize, md)
@@ -290,10 +290,10 @@ func TestSplitMetricsMultipleILM(t *testing.T) {
 	md := testdata.GenerateMetrics(20)
 	metrics := md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics()
 	dataPointCount := metricDPC(metrics.At(0))
-	for i := 0; i < metrics.Len(); i++ {
-		metrics.At(i).SetName(getTestMetricName(0, i))
-		assert.Equal(t, dataPointCount, metricDPC(metrics.At(i)))
-	}
+	metrics.ForEachIndex(func(i int, metric pmetric.Metric) {
+		metric.SetName(getTestMetricName(0, i))
+		assert.Equal(t, dataPointCount, metricDPC(metric))
+	})
 	// add second index to ilm
 	md.ResourceMetrics().At(0).ScopeMetrics().At(0).
 		CopyTo(md.ResourceMetrics().At(0).ScopeMetrics().AppendEmpty())
@@ -302,9 +302,9 @@ func TestSplitMetricsMultipleILM(t *testing.T) {
 	md.ResourceMetrics().At(0).ScopeMetrics().At(0).
 		CopyTo(md.ResourceMetrics().At(0).ScopeMetrics().AppendEmpty())
 	metrics = md.ResourceMetrics().At(0).ScopeMetrics().At(2).Metrics()
-	for i := 0; i < metrics.Len(); i++ {
-		metrics.At(i).SetName(getTestMetricName(2, i))
-	}
+	metrics.ForEachIndex(func(i int, metric pmetric.Metric) {
+		metric.SetName(getTestMetricName(2, i))
+	})
 
 	splitMetricCount := 40
 	splitSize := splitMetricCount * dataPointCount

--- a/processor/batchprocessor/splittraces_test.go
+++ b/processor/batchprocessor/splittraces_test.go
@@ -29,7 +29,7 @@ func TestSplitTraces_noop(t *testing.T) {
 func TestSplitTraces(t *testing.T) {
 	td := testdata.GenerateTraces(20)
 	spans := td.ResourceSpans().At(0).ScopeSpans().At(0).Spans()
-	spans.ForEachIndex(func(i int, span ptrace.Span) {
+	spans.Range(func(i int, span ptrace.Span) {
 		spans.At(i).SetName(getTestSpanName(0, i))
 	})
 	cp := ptrace.NewTraces()
@@ -72,14 +72,14 @@ func TestSplitTraces(t *testing.T) {
 func TestSplitTracesMultipleResourceSpans(t *testing.T) {
 	td := testdata.GenerateTraces(20)
 	spans := td.ResourceSpans().At(0).ScopeSpans().At(0).Spans()
-	spans.ForEachIndex(func(i int, span ptrace.Span) {
+	spans.Range(func(i int, span ptrace.Span) {
 		spans.At(i).SetName(getTestSpanName(0, i))
 	})
 	// add second index to resource spans
 	testdata.GenerateTraces(20).
 		ResourceSpans().At(0).CopyTo(td.ResourceSpans().AppendEmpty())
 	spans = td.ResourceSpans().At(1).ScopeSpans().At(0).Spans()
-	spans.ForEachIndex(func(i int, span ptrace.Span) {
+	spans.Range(func(i int, span ptrace.Span) {
 		spans.At(i).SetName(getTestSpanName(1, i))
 	})
 
@@ -94,14 +94,14 @@ func TestSplitTracesMultipleResourceSpans(t *testing.T) {
 func TestSplitTracesMultipleResourceSpans_SplitSizeGreaterThanSpanSize(t *testing.T) {
 	td := testdata.GenerateTraces(20)
 	spans := td.ResourceSpans().At(0).ScopeSpans().At(0).Spans()
-	spans.ForEachIndex(func(i int, span ptrace.Span) {
+	spans.Range(func(i int, span ptrace.Span) {
 		spans.At(i).SetName(getTestSpanName(0, i))
 	})
 	// add second index to resource spans
 	testdata.GenerateTraces(20).
 		ResourceSpans().At(0).CopyTo(td.ResourceSpans().AppendEmpty())
 	spans = td.ResourceSpans().At(1).ScopeSpans().At(0).Spans()
-	spans.ForEachIndex(func(i int, span ptrace.Span) {
+	spans.Range(func(i int, span ptrace.Span) {
 		spans.At(i).SetName(getTestSpanName(1, i))
 	})
 
@@ -119,14 +119,14 @@ func TestSplitTracesMultipleResourceSpans_SplitSizeGreaterThanSpanSize(t *testin
 func TestSplitTracesMultipleILS(t *testing.T) {
 	td := testdata.GenerateTraces(20)
 	spans := td.ResourceSpans().At(0).ScopeSpans().At(0).Spans()
-	spans.ForEachIndex(func(i int, span ptrace.Span) {
+	spans.Range(func(i int, span ptrace.Span) {
 		spans.At(i).SetName(getTestSpanName(0, i))
 	})
 	// add second index to ILS
 	td.ResourceSpans().At(0).ScopeSpans().At(0).
 		CopyTo(td.ResourceSpans().At(0).ScopeSpans().AppendEmpty())
 	spans = td.ResourceSpans().At(0).ScopeSpans().At(1).Spans()
-	spans.ForEachIndex(func(i int, span ptrace.Span) {
+	spans.Range(func(i int, span ptrace.Span) {
 		spans.At(i).SetName(getTestSpanName(1, i))
 	})
 
@@ -134,7 +134,7 @@ func TestSplitTracesMultipleILS(t *testing.T) {
 	td.ResourceSpans().At(0).ScopeSpans().At(0).
 		CopyTo(td.ResourceSpans().At(0).ScopeSpans().AppendEmpty())
 	spans = td.ResourceSpans().At(0).ScopeSpans().At(2).Spans()
-	spans.ForEachIndex(func(i int, span ptrace.Span) {
+	spans.Range(func(i int, span ptrace.Span) {
 		spans.At(i).SetName(getTestSpanName(2, i))
 	})
 

--- a/processor/batchprocessor/splittraces_test.go
+++ b/processor/batchprocessor/splittraces_test.go
@@ -29,9 +29,9 @@ func TestSplitTraces_noop(t *testing.T) {
 func TestSplitTraces(t *testing.T) {
 	td := testdata.GenerateTraces(20)
 	spans := td.ResourceSpans().At(0).ScopeSpans().At(0).Spans()
-	for i := 0; i < spans.Len(); i++ {
+	spans.ForEachIndex(func(i int, span ptrace.Span) {
 		spans.At(i).SetName(getTestSpanName(0, i))
-	}
+	})
 	cp := ptrace.NewTraces()
 	cpSpans := cp.ResourceSpans().AppendEmpty().ScopeSpans().AppendEmpty().Spans()
 	cpSpans.EnsureCapacity(5)
@@ -72,16 +72,16 @@ func TestSplitTraces(t *testing.T) {
 func TestSplitTracesMultipleResourceSpans(t *testing.T) {
 	td := testdata.GenerateTraces(20)
 	spans := td.ResourceSpans().At(0).ScopeSpans().At(0).Spans()
-	for i := 0; i < spans.Len(); i++ {
+	spans.ForEachIndex(func(i int, span ptrace.Span) {
 		spans.At(i).SetName(getTestSpanName(0, i))
-	}
+	})
 	// add second index to resource spans
 	testdata.GenerateTraces(20).
 		ResourceSpans().At(0).CopyTo(td.ResourceSpans().AppendEmpty())
 	spans = td.ResourceSpans().At(1).ScopeSpans().At(0).Spans()
-	for i := 0; i < spans.Len(); i++ {
+	spans.ForEachIndex(func(i int, span ptrace.Span) {
 		spans.At(i).SetName(getTestSpanName(1, i))
-	}
+	})
 
 	splitSize := 5
 	split := splitTraces(splitSize, td)
@@ -94,16 +94,16 @@ func TestSplitTracesMultipleResourceSpans(t *testing.T) {
 func TestSplitTracesMultipleResourceSpans_SplitSizeGreaterThanSpanSize(t *testing.T) {
 	td := testdata.GenerateTraces(20)
 	spans := td.ResourceSpans().At(0).ScopeSpans().At(0).Spans()
-	for i := 0; i < spans.Len(); i++ {
+	spans.ForEachIndex(func(i int, span ptrace.Span) {
 		spans.At(i).SetName(getTestSpanName(0, i))
-	}
+	})
 	// add second index to resource spans
 	testdata.GenerateTraces(20).
 		ResourceSpans().At(0).CopyTo(td.ResourceSpans().AppendEmpty())
 	spans = td.ResourceSpans().At(1).ScopeSpans().At(0).Spans()
-	for i := 0; i < spans.Len(); i++ {
+	spans.ForEachIndex(func(i int, span ptrace.Span) {
 		spans.At(i).SetName(getTestSpanName(1, i))
-	}
+	})
 
 	splitSize := 25
 	split := splitTraces(splitSize, td)
@@ -119,24 +119,24 @@ func TestSplitTracesMultipleResourceSpans_SplitSizeGreaterThanSpanSize(t *testin
 func TestSplitTracesMultipleILS(t *testing.T) {
 	td := testdata.GenerateTraces(20)
 	spans := td.ResourceSpans().At(0).ScopeSpans().At(0).Spans()
-	for i := 0; i < spans.Len(); i++ {
+	spans.ForEachIndex(func(i int, span ptrace.Span) {
 		spans.At(i).SetName(getTestSpanName(0, i))
-	}
+	})
 	// add second index to ILS
 	td.ResourceSpans().At(0).ScopeSpans().At(0).
 		CopyTo(td.ResourceSpans().At(0).ScopeSpans().AppendEmpty())
 	spans = td.ResourceSpans().At(0).ScopeSpans().At(1).Spans()
-	for i := 0; i < spans.Len(); i++ {
+	spans.ForEachIndex(func(i int, span ptrace.Span) {
 		spans.At(i).SetName(getTestSpanName(1, i))
-	}
+	})
 
 	// add third index to ILS
 	td.ResourceSpans().At(0).ScopeSpans().At(0).
 		CopyTo(td.ResourceSpans().At(0).ScopeSpans().AppendEmpty())
 	spans = td.ResourceSpans().At(0).ScopeSpans().At(2).Spans()
-	for i := 0; i < spans.Len(); i++ {
+	spans.ForEachIndex(func(i int, span ptrace.Span) {
 		spans.At(i).SetName(getTestSpanName(2, i))
-	}
+	})
 
 	splitSize := 40
 	split := splitTraces(splitSize, td)

--- a/receiver/receivertest/contract_checker.go
+++ b/receiver/receivertest/contract_checker.go
@@ -339,25 +339,25 @@ func (m *mockConsumer) ConsumeTraces(_ context.Context, data ptrace.Traces) erro
 // idSetFromTraces computes an idSet from given ptrace.Traces. The idSet will contain ids of all spans.
 func idSetFromTraces(data ptrace.Traces) (idSet, error) {
 	ds := map[UniqueIDAttrVal]bool{}
-	var err error
-	data.ResourceSpans().ForEachWhile(func(rs ptrace.ResourceSpans) bool {
-		return rs.ScopeSpans().ForEachWhile(func(ss ptrace.ScopeSpans) bool {
-			return ss.Spans().ForEachWhile(func(elem ptrace.Span) bool {
+	rss := data.ResourceSpans()
+	for i := 0; i < rss.Len(); i++ {
+		ils := rss.At(i).ScopeSpans()
+		for j := 0; j < ils.Len(); j++ {
+			ss := ils.At(j).Spans()
+			for k := 0; k < ss.Len(); k++ {
+				elem := ss.At(k)
 				key, exists := elem.Attributes().Get(UniqueIDAttrName)
 				if !exists {
-					err = fmt.Errorf("invalid data element, attribute %q is missing", UniqueIDAttrName)
-					return false
+					return ds, fmt.Errorf("invalid data element, attribute %q is missing", UniqueIDAttrName)
 				}
 				if key.Type() != pcommon.ValueTypeStr {
-					err = fmt.Errorf("invalid data element, attribute %q is wrong type %v", UniqueIDAttrName, key.Type())
-					return false
+					return ds, fmt.Errorf("invalid data element, attribute %q is wrong type %v", UniqueIDAttrName, key.Type())
 				}
 				ds[UniqueIDAttrVal(key.Str())] = true
-				return true
-			})
-		})
-	})
-	return ds, err
+			}
+		}
+	}
+	return ds, nil
 }
 
 func (m *mockConsumer) ConsumeLogs(_ context.Context, data plog.Logs) error {
@@ -369,25 +369,25 @@ func (m *mockConsumer) ConsumeLogs(_ context.Context, data plog.Logs) error {
 // idSetFromLogs computes an idSet from given plog.Logs. The idSet will contain ids of all log records.
 func idSetFromLogs(data plog.Logs) (idSet, error) {
 	ds := map[UniqueIDAttrVal]bool{}
-	var err error
-	data.ResourceLogs().ForEachWhile(func(rs plog.ResourceLogs) bool {
-		return rs.ScopeLogs().ForEachWhile(func(ss plog.ScopeLogs) bool {
-			return ss.LogRecords().ForEachWhile(func(elem plog.LogRecord) bool {
+	rss := data.ResourceLogs()
+	for i := 0; i < rss.Len(); i++ {
+		ils := rss.At(i).ScopeLogs()
+		for j := 0; j < ils.Len(); j++ {
+			ss := ils.At(j).LogRecords()
+			for k := 0; k < ss.Len(); k++ {
+				elem := ss.At(k)
 				key, exists := elem.Attributes().Get(UniqueIDAttrName)
 				if !exists {
-					err = fmt.Errorf("invalid data element, attribute %q is missing", UniqueIDAttrName)
-					return false
+					return ds, fmt.Errorf("invalid data element, attribute %q is missing", UniqueIDAttrName)
 				}
 				if key.Type() != pcommon.ValueTypeStr {
-					err = fmt.Errorf("invalid data element, attribute %q is wrong type %v", UniqueIDAttrName, key.Type())
-					return false
+					return ds, fmt.Errorf("invalid data element, attribute %q is wrong type %v", UniqueIDAttrName, key.Type())
 				}
 				ds[UniqueIDAttrVal(key.Str())] = true
-				return true
-			})
-		})
-	})
-	return ds, err
+			}
+		}
+	}
+	return ds, nil
 }
 
 // TODO: Implement mockConsumer.ConsumeMetrics()

--- a/receiver/receivertest/contract_checker.go
+++ b/receiver/receivertest/contract_checker.go
@@ -339,25 +339,25 @@ func (m *mockConsumer) ConsumeTraces(_ context.Context, data ptrace.Traces) erro
 // idSetFromTraces computes an idSet from given ptrace.Traces. The idSet will contain ids of all spans.
 func idSetFromTraces(data ptrace.Traces) (idSet, error) {
 	ds := map[UniqueIDAttrVal]bool{}
-	rss := data.ResourceSpans()
-	for i := 0; i < rss.Len(); i++ {
-		ils := rss.At(i).ScopeSpans()
-		for j := 0; j < ils.Len(); j++ {
-			ss := ils.At(j).Spans()
-			for k := 0; k < ss.Len(); k++ {
-				elem := ss.At(k)
+	var err error
+	data.ResourceSpans().ForEachWhile(func(rs ptrace.ResourceSpans) bool {
+		return rs.ScopeSpans().ForEachWhile(func(ss ptrace.ScopeSpans) bool {
+			return ss.Spans().ForEachWhile(func(elem ptrace.Span) bool {
 				key, exists := elem.Attributes().Get(UniqueIDAttrName)
 				if !exists {
-					return ds, fmt.Errorf("invalid data element, attribute %q is missing", UniqueIDAttrName)
+					err = fmt.Errorf("invalid data element, attribute %q is missing", UniqueIDAttrName)
+					return false
 				}
 				if key.Type() != pcommon.ValueTypeStr {
-					return ds, fmt.Errorf("invalid data element, attribute %q is wrong type %v", UniqueIDAttrName, key.Type())
+					err = fmt.Errorf("invalid data element, attribute %q is wrong type %v", UniqueIDAttrName, key.Type())
+					return false
 				}
 				ds[UniqueIDAttrVal(key.Str())] = true
-			}
-		}
-	}
-	return ds, nil
+				return true
+			})
+		})
+	})
+	return ds, err
 }
 
 func (m *mockConsumer) ConsumeLogs(_ context.Context, data plog.Logs) error {
@@ -369,25 +369,25 @@ func (m *mockConsumer) ConsumeLogs(_ context.Context, data plog.Logs) error {
 // idSetFromLogs computes an idSet from given plog.Logs. The idSet will contain ids of all log records.
 func idSetFromLogs(data plog.Logs) (idSet, error) {
 	ds := map[UniqueIDAttrVal]bool{}
-	rss := data.ResourceLogs()
-	for i := 0; i < rss.Len(); i++ {
-		ils := rss.At(i).ScopeLogs()
-		for j := 0; j < ils.Len(); j++ {
-			ss := ils.At(j).LogRecords()
-			for k := 0; k < ss.Len(); k++ {
-				elem := ss.At(k)
+	var err error
+	data.ResourceLogs().ForEachWhile(func(rs plog.ResourceLogs) bool {
+		return rs.ScopeLogs().ForEachWhile(func(ss plog.ScopeLogs) bool {
+			return ss.LogRecords().ForEachWhile(func(elem plog.LogRecord) bool {
 				key, exists := elem.Attributes().Get(UniqueIDAttrName)
 				if !exists {
-					return ds, fmt.Errorf("invalid data element, attribute %q is missing", UniqueIDAttrName)
+					err = fmt.Errorf("invalid data element, attribute %q is missing", UniqueIDAttrName)
+					return false
 				}
 				if key.Type() != pcommon.ValueTypeStr {
-					return ds, fmt.Errorf("invalid data element, attribute %q is wrong type %v", UniqueIDAttrName, key.Type())
+					err = fmt.Errorf("invalid data element, attribute %q is wrong type %v", UniqueIDAttrName, key.Type())
+					return false
 				}
 				ds[UniqueIDAttrVal(key.Str())] = true
-			}
-		}
-	}
-	return ds, nil
+				return true
+			})
+		})
+	})
+	return ds, err
 }
 
 // TODO: Implement mockConsumer.ConsumeMetrics()


### PR DESCRIPTION
**Description:**

This PR adds a `Range` method to each pdata slice struct.

I updated many loops throughout the codebase to demonstrate usage of the functions. I may have missed a few or applied the pattern unnecessarily in simple situations, but primarily am seeking feedback on the implementation at this point.

**Link to tracking Issue:** #8927.

**Testing:**

Tests are added for generated methods.
