### PR TITLE
[.github] Add support for stable-v1 modset

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -5,6 +5,12 @@ on:
     # Determine the version number that will be assigned to the release. During the beta phase, we increment
     # the minor version number and set the patch number to 0.
     inputs:
+      candidate-stable-v1:
+        description: Stable v1 candidate version (stable-v1, like 1.1.0). Don't include a leading `v`.
+
+      current-stable-v1:
+        description: Current v1 version (stable-v1, like 1.0.0). Don't include a leading `v`.
+
       candidate-stable:
         description: Release candidate version (stable, like 1.0.0-rcv0014). Don't include a leading `v`.
 
@@ -56,7 +62,8 @@ jobs:
           go-version: ~1.20.11
       # Prepare Core for release.
       #   - Update CHANGELOG.md file, this is done via chloggen
-      #   - Run make prepare-release PREVIOUS_VERSION=1.0.0 RELEASE_CANDIDATE=1.1.0 MODSET=stable
+      #   - Run make prepare-release PREVIOUS_VERSION=1.0.0 RELEASE_CANDIDATE=1.1.0 MODSET=stable-v1
+      #   - Run make prepare-release PREVIOUS_VERSION=1.0.0-rcv0017 RELEASE_CANDIDATE=1.0.0-rcv0018 MODSET=stable
       #   - Run make prepare-release PREVIOUS_VERSION=0.52.0 RELEASE_CANDIDATE=0.53.0 MODSET=beta
       - name: Prepare release for core
         env:
@@ -64,8 +71,10 @@ jobs:
           REPO: open-telemetry/opentelemetry-collector
           CANDIDATE_BETA: ${{ inputs.candidate-beta }}
           CANDIDATE_STABLE: ${{ inputs.candidate-stable }}
+          CANDIDATE_STABLE_V1: ${{ inputs.candidate-stable-v1 }} 
           CURRENT_BETA: ${{ inputs.current-beta }}
           CURRENT_STABLE: ${{ inputs.current-stable }}
+          CURRENT_STABLE_V1: ${{ inputs.current-stable-v1 }}
         run: ./.github/workflows/scripts/release-prepare-release.sh
       # To keep track of the progress, it might be helpful to create a tracking issue similar to #6067. You are responsible
       # for all of the steps under the "Performed by collector release manager" heading. Once the issue is created, you can
@@ -75,7 +84,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CANDIDATE_BETA: ${{ inputs.candidate-beta }}
           CANDIDATE_STABLE: ${{ inputs.candidate-stable }}
+          CANDIDATE_STABLE_V1: ${{ inputs.candidate-stable-v1 }} 
           CURRENT_BETA: ${{ inputs.current-beta }}
           CURRENT_STABLE: ${{ inputs.current-stable }}
+          CURRENT_STABLE_V1: ${{ inputs.current-stable-v1 }}
           REPO: open-telemetry/opentelemetry-collector
         run: ./.github/workflows/scripts/release-create-tracking-issue.sh

--- a/.github/workflows/scripts/release-create-tracking-issue.sh
+++ b/.github/workflows/scripts/release-create-tracking-issue.sh
@@ -3,12 +3,15 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-RELEASE_VERSION=v${CANDIDATE_STABLE}/v${CANDIDATE_BETA}
-if [ "${CANDIDATE_STABLE}" == "" ]; then
-    RELEASE_VERSION="v${CANDIDATE_BETA}"
+RELEASE_VERSION=""
+if [ "${CANDIDATE_STABLE_V1}" == "" ]; then
+    RELEASE_VERSION="${RELEASE_VERSION}/v${CANDIDATE_STABLE_V1}"
 fi
-if [ "${CANDIDATE_BETA}" == "" ]; then
-    RELEASE_VERSION="v${CANDIDATE_STABLE}"
+if [ "${CANDIDATE_STABLE}" != "" ]; then
+    RELEASE_VERSION="${RELEASE_VERSION}/v${CANDIDATE_STABLE}"
+fi
+if [ "${CANDIDATE_BETA}" != "" ]; then
+    RELEASE_VERSION="${RELEASE_VERSION}/v${CANDIDATE_BETA}"
 fi
 
 EXISTING_ISSUE=$( gh issue list --search "in:title Release ${RELEASE_VERSION}" --json url --jq '.[].url' --repo "${REPO}" --state open --label release )

--- a/.github/workflows/scripts/release-prepare-release.sh
+++ b/.github/workflows/scripts/release-prepare-release.sh
@@ -3,17 +3,20 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-if [ "${CANDIDATE_STABLE}" == "" ] && [ "${CANDIDATE_BETA}" == "" ]; then
-    echo "One of CANDIDATE_STABLE or CANDIDATE_BETA must be set"
+if [ "${CANDIDATE_STABLE_V1}" == "" ] && [ "${CANDIDATE_STABLE}" == "" ] && [ "${CANDIDATE_BETA}" == "" ]; then
+    echo "One of CANDIDATE_STABLE_V1, CANDIDATE_STABLE or CANDIDATE_BETA must be set"
     exit 1
 fi
 
-RELEASE_VERSION=v${CANDIDATE_STABLE}/v${CANDIDATE_BETA}
-if [ "${CANDIDATE_STABLE}" == "" ]; then
-    RELEASE_VERSION="v${CANDIDATE_BETA}"
+RELEASE_VERSION=""
+if [ "${CANDIDATE_STABLE_V1}" == "" ]; then
+    RELEASE_VERSION="${RELEASE_VERSION}/v${CANDIDATE_STABLE_V1}"
 fi
-if [ "${CANDIDATE_BETA}" == "" ]; then
-    RELEASE_VERSION="v${CANDIDATE_STABLE}"
+if [ "${CANDIDATE_STABLE}" != "" ]; then
+    RELEASE_VERSION="${RELEASE_VERSION}/v${CANDIDATE_STABLE}"
+fi
+if [ "${CANDIDATE_BETA}" != "" ]; then
+    RELEASE_VERSION="${RELEASE_VERSION}/v${CANDIDATE_BETA}"
 fi
 
 make chlog-update VERSION="${RELEASE_VERSION}"
@@ -25,6 +28,11 @@ git checkout -b "${BRANCH}"
 git add --all
 git commit -m "Changelog update ${RELEASE_VERSION}"
 
+if [ "${CANDIDATE_STABLE_V1}" != "" ]; then
+    make prepare-release GH=none PREVIOUS_VERSION="${CURRENT_STABLE_V1}" RELEASE_CANDIDATE="${CANDIDATE_STABLE_V1}" MODSET=stable-v1
+    COMMANDS+="
+- make prepare-release GH=none PREVIOUS_VERSION=${CURRENT_STABLE_V1} RELEASE_CANDIDATE=${CURRENT_STABLE_V1} MODSET=stable-v1"
+fi
 if [ "${CANDIDATE_STABLE}" != "" ]; then
     make prepare-release GH=none PREVIOUS_VERSION="${CURRENT_STABLE}" RELEASE_CANDIDATE="${CANDIDATE_STABLE}" MODSET=stable
     COMMANDS+="

--- a/docs/release.md
+++ b/docs/release.md
@@ -41,7 +41,8 @@ It is possible that a core approver isn't a contrib approver. In that case, the 
 5. Make sure you are on `release/<release-series>`. Tag the module groups with the new release version by running:
    - `make push-tags MODSET=beta` for beta modules group,
    - `make push-tags MODSET=stable` beta stable modules group, only if there were changes since the last release.
-   
+   - `make push-tags MODSET=stable-v1` stable v1.x modules group, only if there were changes since the last release.
+
    If you set your remote using `https` you need to include `REMOTE=https://github.com/open-telemetry/opentelemetry-collector.git` in each command. Wait for the new tag build to pass successfully.
 
 6. The release script for the collector builder should create a new GitHub release for the builder. This is a separate release from the core, but we might join them in the future if it makes sense.

--- a/versions.yaml
+++ b/versions.yaml
@@ -2,6 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 module-sets:
+  stable-v1:
+    version: v1.0.0
+    modules: []
   stable:
     version: v1.0.0-rcv0018
     modules:


### PR DESCRIPTION
**Description:** 

Adds support for a new, `stable-v1` module set. This is the module we will use for 1.0.0 releases.

The current `stable` module set is kept for release candidates (we can rename to `stable-rc` if that makes sense?).