### PR TITLE
[service] remove _total suffix for otel generated metrics

### DIFF
--- a/.chloggen/codeboten_prom-without-suffix.yaml
+++ b/.chloggen/codeboten_prom-without-suffix.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: service
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "To remain backwards compatible w/ the metrics generated today, otel generated metrics will be generated without the `_total` suffix"
+
+# One or more tracking issues or pull requests related to the change
+issues: [7454]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/obsreport/obsreporttest/obsreporttest.go
+++ b/obsreport/obsreporttest/obsreporttest.go
@@ -160,7 +160,7 @@ func SetupTelemetry(id component.ID) (TestTelemetry, error) {
 
 	promRegOtel := prometheus.NewRegistry()
 
-	exp, err := otelprom.New(otelprom.WithRegisterer(promRegOtel), otelprom.WithoutUnits(), otelprom.WithoutScopeInfo())
+	exp, err := otelprom.New(otelprom.WithRegisterer(promRegOtel), otelprom.WithoutUnits(), otelprom.WithoutScopeInfo(), otelprom.WithoutCounterSuffixes())
 	if err != nil {
 		return settings, err
 	}

--- a/obsreport/obsreporttest/otelprometheuschecker.go
+++ b/obsreport/obsreporttest/otelprometheuschecker.go
@@ -150,11 +150,7 @@ func (pc *prometheusChecker) getMetric(expectedName string, expectedType io_prom
 
 	metricFamily, ok := parsed[expectedName]
 	if !ok {
-		// OTel Go adds `_total` suffix for all monotonic sum.
-		metricFamily, ok = parsed[expectedName+"_total"]
-		if !ok {
-			return nil, fmt.Errorf("metric '%s' not found", expectedName)
-		}
+		return nil, fmt.Errorf("metric '%s' not found", expectedName)
 	}
 
 	if metricFamily.Type.String() != expectedType.String() {

--- a/processor/batchprocessor/metrics_test.go
+++ b/processor/batchprocessor/metrics_test.go
@@ -86,7 +86,7 @@ func setupTelemetry(t *testing.T, useOtel bool) testTelemetry {
 
 	if useOtel {
 		promReg := prometheus.NewRegistry()
-		exporter, err := otelprom.New(otelprom.WithRegisterer(promReg), otelprom.WithoutUnits(), otelprom.WithoutScopeInfo())
+		exporter, err := otelprom.New(otelprom.WithRegisterer(promReg), otelprom.WithoutUnits(), otelprom.WithoutScopeInfo(), otelprom.WithoutCounterSuffixes())
 		require.NoError(t, err)
 
 		telemetry.meterProvider = sdkmetric.NewMeterProvider(
@@ -202,11 +202,6 @@ func (tt *testTelemetry) assertBoundaries(t *testing.T, expected []float64, hist
 }
 
 func (tt *testTelemetry) getMetric(t *testing.T, name string, mtype io_prometheus_client.MetricType, got map[string]*io_prometheus_client.MetricFamily) *io_prometheus_client.Metric {
-	if tt.useOtel && mtype == io_prometheus_client.MetricType_COUNTER {
-		// OTel Go suffixes counters with `_total`
-		name += "_total"
-	}
-
 	metricFamily, ok := got[name]
 	require.True(t, ok, "expected metric '%s' not found", name)
 	require.Equal(t, mtype, metricFamily.GetType())

--- a/service/internal/proctelemetry/config.go
+++ b/service/internal/proctelemetry/config.go
@@ -210,7 +210,10 @@ func initPrometheusExporter(prometheusConfig *config.Prometheus, asyncErrorChann
 		otelprom.WithoutUnits(),
 		// Disabled for the moment until this becomes stable, and we are ready to break backwards compatibility.
 		otelprom.WithoutScopeInfo(),
-		otelprom.WithProducer(opencensus.NewMetricProducer()))
+		otelprom.WithProducer(opencensus.NewMetricProducer()),
+		// This allows us to produce metrics that are backwards compatible w/ opencensus
+		otelprom.WithoutCounterSuffixes(),
+	)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error creating otel prometheus exporter: %w", err)
 	}

--- a/service/internal/proctelemetry/process_telemetry_test.go
+++ b/service/internal/proctelemetry/process_telemetry_test.go
@@ -52,7 +52,6 @@ var expectedMetrics = []string{
 }
 
 var otelExpectedMetrics = []string{
-	// OTel Go adds `_total` suffix
 	"process_uptime",
 	"process_runtime_heap_alloc_bytes",
 	"process_runtime_total_alloc_bytes",
@@ -73,7 +72,7 @@ func setupTelemetry(t *testing.T) testTelemetry {
 	require.NoError(t, err)
 
 	promReg := prometheus.NewRegistry()
-	exporter, err := otelprom.New(otelprom.WithRegisterer(promReg), otelprom.WithoutUnits())
+	exporter, err := otelprom.New(otelprom.WithRegisterer(promReg), otelprom.WithoutUnits(), otelprom.WithoutCounterSuffixes())
 	require.NoError(t, err)
 
 	settings.meterProvider = sdkmetric.NewMeterProvider(
@@ -112,10 +111,6 @@ func TestOtelProcessTelemetry(t *testing.T) {
 
 	for _, metricName := range tel.expectedMetrics {
 		metric, ok := mp[metricName]
-		if !ok {
-			withSuffix := metricName + "_total"
-			metric, ok = mp[withSuffix]
-		}
 		require.True(t, ok)
 		require.True(t, len(metric.Metric) == 1)
 		var metricValue float64

--- a/service/telemetry_test.go
+++ b/service/telemetry_test.go
@@ -126,15 +126,15 @@ func TestTelemetryInit(t *testing.T) {
 			name:    "UseOpenTelemetryForInternalMetrics",
 			useOtel: true,
 			expectedMetrics: map[string]metricValue{
-				metricPrefix + ocPrefix + counterName + "_total": {
+				metricPrefix + ocPrefix + counterName: {
 					value:  13,
 					labels: map[string]string{},
 				},
-				metricPrefix + otelPrefix + counterName + "_total": {
+				metricPrefix + otelPrefix + counterName: {
 					value:  13,
 					labels: map[string]string{},
 				},
-				metricPrefix + grpcPrefix + counterName + "_total": {
+				metricPrefix + grpcPrefix + counterName: {
 					value: 11,
 					labels: map[string]string{
 						"net_sock_peer_addr": "",
@@ -142,7 +142,7 @@ func TestTelemetryInit(t *testing.T) {
 						"net_sock_peer_port": "",
 					},
 				},
-				metricPrefix + httpPrefix + counterName + "_total": {
+				metricPrefix + httpPrefix + counterName: {
 					value: 10,
 					labels: map[string]string{
 						"net_host_name": "",
@@ -164,19 +164,19 @@ func TestTelemetryInit(t *testing.T) {
 			useOtel:         true,
 			disableHighCard: true,
 			expectedMetrics: map[string]metricValue{
-				metricPrefix + ocPrefix + counterName + "_total": {
+				metricPrefix + ocPrefix + counterName: {
 					value:  13,
 					labels: map[string]string{},
 				},
-				metricPrefix + otelPrefix + counterName + "_total": {
+				metricPrefix + otelPrefix + counterName: {
 					value:  13,
 					labels: map[string]string{},
 				},
-				metricPrefix + grpcPrefix + counterName + "_total": {
+				metricPrefix + grpcPrefix + counterName: {
 					value:  11,
 					labels: map[string]string{},
 				},
-				metricPrefix + httpPrefix + counterName + "_total": {
+				metricPrefix + httpPrefix + counterName: {
 					value:  10,
 					labels: map[string]string{},
 				},
@@ -213,15 +213,15 @@ func TestTelemetryInit(t *testing.T) {
 				},
 			},
 			expectedMetrics: map[string]metricValue{
-				metricPrefix + ocPrefix + counterName + "_total": {
+				metricPrefix + ocPrefix + counterName: {
 					value:  13,
 					labels: map[string]string{},
 				},
-				metricPrefix + otelPrefix + counterName + "_total": {
+				metricPrefix + otelPrefix + counterName: {
 					value:  13,
 					labels: map[string]string{},
 				},
-				metricPrefix + grpcPrefix + counterName + "_total": {
+				metricPrefix + grpcPrefix + counterName: {
 					value: 11,
 					labels: map[string]string{
 						"net_sock_peer_addr": "",
@@ -229,7 +229,7 @@ func TestTelemetryInit(t *testing.T) {
 						"net_sock_peer_port": "",
 					},
 				},
-				metricPrefix + httpPrefix + counterName + "_total": {
+				metricPrefix + httpPrefix + counterName: {
 					value: 10,
 					labels: map[string]string{
 						"net_host_name": "",


### PR DESCRIPTION
This ensures backwards compatibility with the metrics generated via opencensus by default today.

Part of #7454
