### PR TITLE
[pdata] Document that Marshalers/Unmarshalers use OTLP/JSON format explicitly

### DIFF
--- a/pdata/plog/json.go
+++ b/pdata/plog/json.go
@@ -15,8 +15,10 @@ import (
 	"go.opentelemetry.io/collector/pdata/internal/otlp"
 )
 
+// JSONMarshaler marshals pdata.Logs to JSON bytes using the OTLP/JSON format.
 type JSONMarshaler struct{}
 
+// MarshalLogs to the OTLP/JSON format.
 func (*JSONMarshaler) MarshalLogs(ld Logs) ([]byte, error) {
 	buf := bytes.Buffer{}
 	pb := internal.LogsToProto(internal.Logs(ld))
@@ -26,8 +28,10 @@ func (*JSONMarshaler) MarshalLogs(ld Logs) ([]byte, error) {
 
 var _ Unmarshaler = (*JSONUnmarshaler)(nil)
 
+// JSONUnmarshaler unmarshals OTLP/JSON formatted-bytes to pdata.Logs.
 type JSONUnmarshaler struct{}
 
+// UnmarshalLogs from OTLP/JSON format into pdata.Logs.
 func (*JSONUnmarshaler) UnmarshalLogs(buf []byte) (Logs, error) {
 	iter := jsoniter.ConfigFastest.BorrowIterator(buf)
 	defer jsoniter.ConfigFastest.ReturnIterator(iter)

--- a/pdata/pmetric/json.go
+++ b/pdata/pmetric/json.go
@@ -17,8 +17,10 @@ import (
 
 var _ Marshaler = (*JSONMarshaler)(nil)
 
+// JSONMarshaler marshals pdata.Metrics to JSON bytes using the OTLP/JSON format.
 type JSONMarshaler struct{}
 
+// MarshalMetrics to the OTLP/JSON format.
 func (*JSONMarshaler) MarshalMetrics(md Metrics) ([]byte, error) {
 	buf := bytes.Buffer{}
 	pb := internal.MetricsToProto(internal.Metrics(md))
@@ -26,8 +28,10 @@ func (*JSONMarshaler) MarshalMetrics(md Metrics) ([]byte, error) {
 	return buf.Bytes(), err
 }
 
+// JSONUnmarshaler unmarshals OTLP/JSON formatted-bytes to pdata.Metrics.
 type JSONUnmarshaler struct{}
 
+// UnmarshalMetrics from OTLP/JSON format into pdata.Metrics.
 func (*JSONUnmarshaler) UnmarshalMetrics(buf []byte) (Metrics, error) {
 	iter := jsoniter.ConfigFastest.BorrowIterator(buf)
 	defer jsoniter.ConfigFastest.ReturnIterator(iter)

--- a/pdata/ptrace/json.go
+++ b/pdata/ptrace/json.go
@@ -15,8 +15,10 @@ import (
 	"go.opentelemetry.io/collector/pdata/internal/otlp"
 )
 
+// JSONMarshaler marshals pdata.Traces to JSON bytes using the OTLP/JSON format.
 type JSONMarshaler struct{}
 
+// MarshalTraces to the OTLP/JSON format.
 func (*JSONMarshaler) MarshalTraces(td Traces) ([]byte, error) {
 	buf := bytes.Buffer{}
 	pb := internal.TracesToProto(internal.Traces(td))
@@ -24,8 +26,10 @@ func (*JSONMarshaler) MarshalTraces(td Traces) ([]byte, error) {
 	return buf.Bytes(), err
 }
 
+// JSONUnmarshaler unmarshals OTLP/JSON formatted-bytes to pdata.Traces.
 type JSONUnmarshaler struct{}
 
+// UnmarshalTraces from OTLP/JSON format into pdata.Traces.
 func (*JSONUnmarshaler) UnmarshalTraces(buf []byte) (Traces, error) {
 	iter := jsoniter.ConfigFastest.BorrowIterator(buf)
 	defer jsoniter.ConfigFastest.ReturnIterator(iter)


### PR DESCRIPTION
**Description:** 

Explicitly documents that the `JSONMarshaler` and `JSONUnmarshaler` as conforming to the format in the OTLP/JSON specification.

The intent is to be explicit that we follow this spec and that deviations (such as supporting snake case) are bugs that can be removed in a minor version update.

**Link to tracking Issue:** Relates to #6287