### PR TITLE
[chore] Fix flaky test TestPersistentQueue_FullCapacity

### DIFF
--- a/exporter/exporterhelper/internal/persistent_queue_test.go
+++ b/exporter/exporterhelper/internal/persistent_queue_test.go
@@ -83,6 +83,7 @@ func TestPersistentQueue_FullCapacity(t *testing.T) {
 
 	// First request is picked by the consumer. Wait until the consumer is blocked on done.
 	assert.NoError(t, pq.Offer(context.Background(), req))
+	start <- struct{}{}
 	close(start)
 
 	for i := 0; i < 10; i++ {


### PR DESCRIPTION
Another fix for the flaky test `TestPersistentQueue_FullCapacity`. We need to make sure that the first item is consumed from the queue before proceeding. Otherwise, it can occasionally fail with:

```
--- FAIL: TestPersistentQueue_FullCapacity (0.00s)
    persistent_queue_test.go:91:
        	Error Trace:	/home/runner/work/opentelemetry-collector/opentelemetry-collector/exporter/exporterhelper/internal/persistent_queue_test.go:91
        	Error:      	Received unexpected error:
        	            	sending queue is full
        	Test:       	TestPersistentQueue_FullCapacity
FAIL
```
