### PR TITLE
[chore] [exporterhelper] Remove retry sender -> queue sender callback

### DIFF
--- a/exporter/exporterhelper/retry_sender.go
+++ b/exporter/exporterhelper/retry_sender.go
@@ -73,29 +73,20 @@ func NewThrottleRetry(err error, delay time.Duration) error {
 	}
 }
 
-type onRequestHandlingFinishedFunc func(context.Context, Request, error, *zap.Logger) error
-
 type retrySender struct {
 	baseRequestSender
-	traceAttribute     attribute.KeyValue
-	cfg                RetrySettings
-	stopCh             chan struct{}
-	logger             *zap.Logger
-	onTemporaryFailure onRequestHandlingFinishedFunc
+	traceAttribute attribute.KeyValue
+	cfg            RetrySettings
+	stopCh         chan struct{}
+	logger         *zap.Logger
 }
 
-func newRetrySender(config RetrySettings, set exporter.CreateSettings, onTemporaryFailure onRequestHandlingFinishedFunc) *retrySender {
-	if onTemporaryFailure == nil {
-		onTemporaryFailure = func(_ context.Context, _ Request, err error, _ *zap.Logger) error {
-			return err
-		}
-	}
+func newRetrySender(config RetrySettings, set exporter.CreateSettings) *retrySender {
 	return &retrySender{
-		traceAttribute:     attribute.String(obsmetrics.ExporterKey, set.ID.String()),
-		cfg:                config,
-		stopCh:             make(chan struct{}),
-		logger:             set.Logger,
-		onTemporaryFailure: onTemporaryFailure,
+		traceAttribute: attribute.String(obsmetrics.ExporterKey, set.ID.String()),
+		cfg:            config,
+		stopCh:         make(chan struct{}),
+		logger:         set.Logger,
 	}
 }
 
@@ -126,6 +117,7 @@ func (rs *retrySender) send(ctx context.Context, req Request) error {
 			trace.WithAttributes(rs.traceAttribute, attribute.Int64("retry_num", retryNum)))
 
 		err := rs.nextSender.send(ctx, req)
+		rs.logger.Info("Exporting finished.", zap.Error(err))
 		if err == nil {
 			return nil
 		}
@@ -148,9 +140,7 @@ func (rs *retrySender) send(ctx context.Context, req Request) error {
 
 		backoffDelay := expBackoff.NextBackOff()
 		if backoffDelay == backoff.Stop {
-			// throw away the batch
-			err = fmt.Errorf("max elapsed time expired %w", err)
-			return rs.onTemporaryFailure(ctx, req, err, rs.logger)
+			return fmt.Errorf("max elapsed time expired %w", err)
 		}
 
 		throttleErr := throttleRetry{}
@@ -178,7 +168,7 @@ func (rs *retrySender) send(ctx context.Context, req Request) error {
 		case <-ctx.Done():
 			return fmt.Errorf("request is cancelled or timed out %w", err)
 		case <-rs.stopCh:
-			return rs.onTemporaryFailure(ctx, req, fmt.Errorf("interrupted due to shutdown %w", err), rs.logger)
+			return fmt.Errorf("interrupted due to shutdown %w", err)
 		case <-time.After(backoffDelay):
 		}
 	}


### PR DESCRIPTION
Use returned error instead to simplify the senders feedback loop. This change preserves the behavior. Re-enqueueing of the temporary failures depends on the enabled retry sender. This will be changed in the next step when re-queueing becomes a configurable option

