### PR TITLE
[chore] Fix TestQueuedRetryPersistentEnabled_shutdown_dataIsRequeued

### DIFF
--- a/exporter/exporterhelper/retry_sender_test.go
+++ b/exporter/exporterhelper/retry_sender_test.go
@@ -21,12 +21,11 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/consumer/consumererror"
-	"go.opentelemetry.io/collector/exporter/exporterhelper/internal"
 	"go.opentelemetry.io/collector/exporter/exportertest"
 	"go.opentelemetry.io/collector/internal/testdata"
 )
 
-func mockRequestUnmarshaler(mr *mockRequest) RequestUnmarshaler {
+func mockRequestUnmarshaler(mr Request) RequestUnmarshaler {
 	return func(bytes []byte) (Request, error) {
 		return mr, nil
 	}
@@ -404,14 +403,4 @@ func tagsMatchLabelKeys(tags []tag.Tag, keys []metricdata.LabelKey, labels []met
 		}
 	}
 	return true
-}
-
-type producerConsumerQueueWithCounter struct {
-	internal.Queue[Request]
-	produceCounter *atomic.Uint32
-}
-
-func (pcq *producerConsumerQueueWithCounter) Offer(ctx context.Context, item Request) error {
-	pcq.produceCounter.Add(1)
-	return pcq.Queue.Offer(ctx, item)
 }


### PR DESCRIPTION
Fix flaky TestQueuedRetryPersistentEnabled_shutdown_dataIsRequeued by moving it to persistent queue.
- It makes the test easy to validate given that the size of the persistent queue is always available even if it's closed.
- It brings behavior closer to the name of the test
- It removes the flakiness associated with data race specific to re-enqueuing to the bounded memory queue by shutdown which should be resolved separately once the re-enqueue option is available for the memory queue

Fixes https://github.com/open-telemetry/opentelemetry-collector/issues/8124