### PR TITLE
[service] use `WithNamespace` instead of `WrapRegistererWithPrefix`

### DIFF
--- a/.chloggen/codeboten_use-namespace.yaml
+++ b/.chloggen/codeboten_use-namespace.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: service
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: use WithNamespace instead of WrapRegistererWithPrefix
+
+# One or more tracking issues or pull requests related to the change
+issues: [8988]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Using this functionality in the otel prom exporter fixes a bug where the
+  target_info was prefixed as otelcol_target_info previously.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/service/internal/proctelemetry/config.go
+++ b/service/internal/proctelemetry/config.go
@@ -203,9 +203,8 @@ func initPrometheusExporter(prometheusConfig *config.Prometheus, asyncErrorChann
 	if prometheusConfig.Port == nil {
 		return nil, nil, fmt.Errorf("port must be specified")
 	}
-	wrappedRegisterer := prometheus.WrapRegistererWithPrefix("otelcol_", promRegistry)
 	exporter, err := otelprom.New(
-		otelprom.WithRegisterer(wrappedRegisterer),
+		otelprom.WithRegisterer(promRegistry),
 		// https://github.com/open-telemetry/opentelemetry-collector/issues/8043
 		otelprom.WithoutUnits(),
 		// Disabled for the moment until this becomes stable, and we are ready to break backwards compatibility.
@@ -213,6 +212,7 @@ func initPrometheusExporter(prometheusConfig *config.Prometheus, asyncErrorChann
 		otelprom.WithProducer(opencensus.NewMetricProducer()),
 		// This allows us to produce metrics that are backwards compatible w/ opencensus
 		otelprom.WithoutCounterSuffixes(),
+		otelprom.WithNamespace("otelcol_"),
 	)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error creating otel prometheus exporter: %w", err)

--- a/service/internal/proctelemetry/config.go
+++ b/service/internal/proctelemetry/config.go
@@ -212,7 +212,7 @@ func initPrometheusExporter(prometheusConfig *config.Prometheus, asyncErrorChann
 		otelprom.WithProducer(opencensus.NewMetricProducer()),
 		// This allows us to produce metrics that are backwards compatible w/ opencensus
 		otelprom.WithoutCounterSuffixes(),
-		otelprom.WithNamespace("otelcol_"),
+		otelprom.WithNamespace("otelcol"),
 	)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error creating otel prometheus exporter: %w", err)

--- a/service/telemetry_test.go
+++ b/service/telemetry_test.go
@@ -149,7 +149,7 @@ func TestTelemetryInit(t *testing.T) {
 						"net_host_port": "",
 					},
 				},
-				metricPrefix + "target_info": {
+				"target_info": {
 					value: 0,
 					labels: map[string]string{
 						"service_name":        "otelcol",
@@ -180,7 +180,7 @@ func TestTelemetryInit(t *testing.T) {
 					value:  10,
 					labels: map[string]string{},
 				},
-				metricPrefix + "target_info": {
+				"target_info": {
 					value: 0,
 					labels: map[string]string{
 						"service_name":        "otelcol",
@@ -236,7 +236,7 @@ func TestTelemetryInit(t *testing.T) {
 						"net_host_port": "",
 					},
 				},
-				metricPrefix + "target_info": {
+				"target_info": {
 					value: 0,
 					labels: map[string]string{
 						"service_name":        "otelcol",


### PR DESCRIPTION
Using this functionality in the otel prom exporter fixes a bug where the target_info was prefixed as otelcol_target_info previously.
