### PR TITLE
bug: fix flaky test TestQueuedRetry_RequeuingEnabled

### DIFF
--- a/exporter/exporterhelper/queue_sender_test.go
+++ b/exporter/exporterhelper/queue_sender_test.go
@@ -244,9 +244,9 @@ func TestQueuedRetry_RequeuingEnabled(t *testing.T) {
 	traceErr := consumererror.NewTraces(errors.New("some error"), testdata.GenerateTraces(1))
 	mockR := newMockRequest(1, traceErr)
 	ocs.run(func() {
+		ocs.waitGroup.Add(1) // necessary because we'll call send() again after requeueing
 		// This is asynchronous so it should just enqueue, no errors expected.
 		require.NoError(t, be.send(context.Background(), mockR))
-		ocs.waitGroup.Add(1) // necessary because we'll call send() again after requeueing
 	})
 	ocs.awaitAsyncProcessing()
 


### PR DESCRIPTION
**Description:** fixes a flaky test 
Fixing a bug - TestQueuedRetry_RequeuingEnabled has been failing occasionally. Upon investigation, `be.send` calls the underlying `observabilityConsumerSender.send` which calls `wg.Done()`, so we need to add `wg.Add(1)` before that

**Link to tracking Issue:** #6624

**Testing:** Ran the same test multiple times before/after change: `go test -race -run TestQueuedRetry_RequeuingEnabled -count 1000`

**Documentation:** N/A