### PR TITLE
[chore] [exporterhelper] Fix requeuing of partially failed request

### DIFF
--- a/exporter/exporterhelper/queue_sender.go
+++ b/exporter/exporterhelper/queue_sender.go
@@ -133,7 +133,7 @@ func (qs *queueSender) consume(ctx context.Context, req Request) {
 		return
 	}
 
-	if qs.queue.Offer(ctx, req) == nil {
+	if qs.queue.Offer(ctx, extractPartialRequest(req, err)) == nil {
 		qs.logger.Error(
 			"Exporting failed. Putting back to the end of the queue.",
 			zap.Error(err),

--- a/exporter/exporterhelper/request.go
+++ b/exporter/exporterhelper/request.go
@@ -41,3 +41,12 @@ type RequestMarshaler func(req Request) ([]byte, error)
 // This API is at the early stage of development and may change without backward compatibility
 // until https://github.com/open-telemetry/opentelemetry-collector/issues/8122 is resolved.
 type RequestUnmarshaler func(data []byte) (Request, error)
+
+// extractPartialRequest returns a new Request that may contain the items left to be sent
+// if only some items failed to process and can be retried. Otherwise, it returns the original Request.
+func extractPartialRequest(req Request, err error) Request {
+	if errReq, ok := req.(RequestErrorHandler); ok {
+		return errReq.OnError(err)
+	}
+	return req
+}

--- a/exporter/exporterhelper/retry_sender.go
+++ b/exporter/exporterhelper/retry_sender.go
@@ -132,11 +132,7 @@ func (rs *retrySender) send(ctx context.Context, req Request) error {
 			return err
 		}
 
-		// Give the request a chance to extract signal data to retry if only some data
-		// failed to process.
-		if errReq, ok := req.(RequestErrorHandler); ok {
-			req = errReq.OnError(err)
-		}
+		req = extractPartialRequest(req, err)
 
 		backoffDelay := expBackoff.NextBackOff()
 		if backoffDelay == backoff.Stop {


### PR DESCRIPTION
After https://github.com/open-telemetry/opentelemetry-collector/pull/8985, the whole request is requeued even with the partial request error. This change fixes it and restores the previous behavior. No changelog is needed since the bug is not released yet.
