### PR TITLE
[chore] [exporterheper] Fix not-started queue sender shutdown

### DIFF
--- a/exporter/exporterhelper/queue_sender_test.go
+++ b/exporter/exporterhelper/queue_sender_test.go
@@ -431,6 +431,11 @@ func TestQueuedRetryPersistentEnabled_shutdown_dataIsRequeued(t *testing.T) {
 	}, time.Second, 1*time.Millisecond)
 }
 
+func TestQueueSenderNoStartShutdown(t *testing.T) {
+	qs := newQueueSender(NewDefaultQueueSettings(), exportertest.NewNopCreateSettings(), "", nil, nil)
+	assert.NoError(t, qs.Shutdown(context.Background()))
+}
+
 type mockHost struct {
 	component.Host
 	ext map[component.ID]component.Component


### PR DESCRIPTION
Do not panic on the shutdown of a not-started queue sender
