### PR TITLE
[chore][extension] update NotifyConfig contract

### DIFF
--- a/extension/extension.go
+++ b/extension/extension.go
@@ -45,8 +45,9 @@ type PipelineWatcher interface {
 // wishes to be notified of the Collector's effective configuration.
 type ConfigWatcher interface {
 	// NotifyConfig notifies the extension of the Collector's current effective configuration.
-	// The extension owns the `confmap.Conf`. Callers should ensure that it's safe to
-	// store the pointer `conf` and use it later concurrently
+	// The extension owns the `confmap.Conf`. Callers must ensure that it's safe for
+	// extensions to store the `conf` pointer and use it concurrently with any other
+	// instances of `conf`.
 	NotifyConfig(ctx context.Context, conf *confmap.Conf) error
 }
 

--- a/extension/extension.go
+++ b/extension/extension.go
@@ -45,6 +45,8 @@ type PipelineWatcher interface {
 // wishes to be notified of the Collector's effective configuration.
 type ConfigWatcher interface {
 	// NotifyConfig notifies the extension of the Collector's current effective configuration.
+	// The extension owns the `confmap.Conf`. Callers should ensure that it's safe to
+	// store the pointer `conf` and use it later concurrently
 	NotifyConfig(ctx context.Context, conf *confmap.Conf) error
 }
 


### PR DESCRIPTION
**Description:**
The collector implementation makes a copy of effective configuration before calling `NotifyConfig` so it's safe for the config watcher to save the pointer and use it later. It is resonable to promise this in the API contract.

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/29277#discussion_r1406522281

**Testing:** No behavior changes.

**Documentation:**  godoc