### PR TITLE
Merge release/v0.90.x into main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ If you are looking for developer-facing changes, check out [CHANGELOG-API.md](./
 
 <!-- next version -->
 
+## v0.90.1
+
+### 🧰 Bug fixes 🧰
+
+- `exporterhelper`: Remove noisy log (#9017)
+
 ## v1.0.0/v0.90.0
 
 ### 🛑 Breaking changes 🛑

--- a/cmd/builder/internal/builder/config.go
+++ b/cmd/builder/internal/builder/config.go
@@ -16,7 +16,7 @@ import (
 	"go.uber.org/zap"
 )
 
-const defaultOtelColVersion = "0.90.0"
+const defaultOtelColVersion = "0.90.1"
 
 // ErrInvalidGoMod indicates an invalid gomod
 var ErrInvalidGoMod = errors.New("invalid gomod specification for module")

--- a/cmd/builder/test/core.builder.yaml
+++ b/cmd/builder/test/core.builder.yaml
@@ -1,20 +1,20 @@
 dist:
   module: go.opentelemetry.io/collector/builder/test/core
-  otelcol_version: 0.90.0
+  otelcol_version: 0.90.1
 
 extensions:
   - import: go.opentelemetry.io/collector/extension/zpagesextension
-    gomod: go.opentelemetry.io/collector v0.90.0
+    gomod: go.opentelemetry.io/collector v0.90.1
     path: ${WORKSPACE_DIR}
 
 receivers:
   - import: go.opentelemetry.io/collector/receiver/otlpreceiver
-    gomod: go.opentelemetry.io/collector v0.90.0
+    gomod: go.opentelemetry.io/collector v0.90.1
     path: ${WORKSPACE_DIR}
 
 exporters:
   - import: go.opentelemetry.io/collector/exporter/debugexporter
-    gomod: go.opentelemetry.io/collector v0.90.0
+    gomod: go.opentelemetry.io/collector v0.90.1
     path: ${WORKSPACE_DIR}
 
 replaces:

--- a/cmd/otelcorecol/builder-config.yaml
+++ b/cmd/otelcorecol/builder-config.yaml
@@ -2,24 +2,24 @@ dist:
   module: go.opentelemetry.io/collector/cmd/otelcorecol
   name: otelcorecol
   description: Local OpenTelemetry Collector binary, testing only.
-  version: 0.90.0-dev
-  otelcol_version: 0.90.0
+  version: 0.90.1-dev
+  otelcol_version: 0.90.1
 
 receivers:
-  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.90.0
+  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.90.1
 exporters:
-  - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.90.0
-  - gomod: go.opentelemetry.io/collector/exporter/loggingexporter v0.90.0
-  - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.90.0
-  - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.90.0
+  - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.90.1
+  - gomod: go.opentelemetry.io/collector/exporter/loggingexporter v0.90.1
+  - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.90.1
+  - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.90.1
 extensions:
-  - gomod: go.opentelemetry.io/collector/extension/ballastextension v0.90.0
-  - gomod: go.opentelemetry.io/collector/extension/zpagesextension v0.90.0
+  - gomod: go.opentelemetry.io/collector/extension/ballastextension v0.90.1
+  - gomod: go.opentelemetry.io/collector/extension/zpagesextension v0.90.1
 processors:
-  - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.90.0
-  - gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.90.0
+  - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.90.1
+  - gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.90.1
 connectors:
-  - gomod: go.opentelemetry.io/collector/connector/forwardconnector v0.90.0
+  - gomod: go.opentelemetry.io/collector/connector/forwardconnector v0.90.1
 
 replaces:
   - go.opentelemetry.io/collector => ../../

--- a/cmd/otelcorecol/go.mod
+++ b/cmd/otelcorecol/go.mod
@@ -8,21 +8,21 @@ require (
 	github.com/stretchr/testify v1.8.4
 	go.opentelemetry.io/collector/component v0.90.0
 	go.opentelemetry.io/collector/connector v0.90.0
-	go.opentelemetry.io/collector/connector/forwardconnector v0.90.0
+	go.opentelemetry.io/collector/connector/forwardconnector v0.90.1
 	go.opentelemetry.io/collector/exporter v0.90.0
-	go.opentelemetry.io/collector/exporter/debugexporter v0.90.0
-	go.opentelemetry.io/collector/exporter/loggingexporter v0.90.0
-	go.opentelemetry.io/collector/exporter/otlpexporter v0.90.0
-	go.opentelemetry.io/collector/exporter/otlphttpexporter v0.90.0
+	go.opentelemetry.io/collector/exporter/debugexporter v0.90.1
+	go.opentelemetry.io/collector/exporter/loggingexporter v0.90.1
+	go.opentelemetry.io/collector/exporter/otlpexporter v0.90.1
+	go.opentelemetry.io/collector/exporter/otlphttpexporter v0.90.1
 	go.opentelemetry.io/collector/extension v0.90.0
-	go.opentelemetry.io/collector/extension/ballastextension v0.90.0
-	go.opentelemetry.io/collector/extension/zpagesextension v0.90.0
-	go.opentelemetry.io/collector/otelcol v0.90.0
+	go.opentelemetry.io/collector/extension/ballastextension v0.90.1
+	go.opentelemetry.io/collector/extension/zpagesextension v0.90.1
+	go.opentelemetry.io/collector/otelcol v0.90.1
 	go.opentelemetry.io/collector/processor v0.90.0
-	go.opentelemetry.io/collector/processor/batchprocessor v0.90.0
-	go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.90.0
+	go.opentelemetry.io/collector/processor/batchprocessor v0.90.1
+	go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.90.1
 	go.opentelemetry.io/collector/receiver v0.90.0
-	go.opentelemetry.io/collector/receiver/otlpreceiver v0.90.0
+	go.opentelemetry.io/collector/receiver/otlpreceiver v0.90.1
 	golang.org/x/sys v0.15.0
 )
 

--- a/cmd/otelcorecol/main.go
+++ b/cmd/otelcorecol/main.go
@@ -14,7 +14,7 @@ func main() {
 	info := component.BuildInfo{
 		Command:     "otelcorecol",
 		Description: "Local OpenTelemetry Collector binary, testing only.",
-		Version:     "0.90.0-dev",
+		Version:     "0.90.1-dev",
 	}
 
 	if err := run(otelcol.CollectorSettings{BuildInfo: info, Factories: components}); err != nil {

--- a/examples/k8s/otel-config.yaml
+++ b/examples/k8s/otel-config.yaml
@@ -68,7 +68,7 @@ spec:
       - command:
           - "/otelcol"
           - "--config=/conf/otel-agent-config.yaml"
-        image: otel/opentelemetry-collector:0.90.0
+        image: otel/opentelemetry-collector:0.90.1
         name: otel-agent
         resources:
           limits:
@@ -187,7 +187,7 @@ spec:
       - command:
           - "/otelcol"
           - "--config=/conf/otel-collector-config.yaml"
-        image: otel/opentelemetry-collector:0.90.0
+        image: otel/opentelemetry-collector:0.90.1
         name: otel-collector
         resources:
           limits:

--- a/versions.yaml
+++ b/versions.yaml
@@ -8,7 +8,7 @@ module-sets:
       - go.opentelemetry.io/collector/featuregate
       - go.opentelemetry.io/collector/pdata
   beta:
-    version: v0.90.0
+    version: v0.90.1
     modules:
       - go.opentelemetry.io/collector
       - go.opentelemetry.io/collector/cmd/builder


### PR DESCRIPTION
Started from `origin/main`, merged `origin/release/v0.69.x` into it and resolved merge conflicts.