### PR TITLE
make useOtelForInternalMetrics as beta

### DIFF
--- a/.chloggen/codeboten_make-otel-default.yaml
+++ b/.chloggen/codeboten_make-otel-default.yaml
@@ -1,0 +1,29 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: service
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Enable `telemetry.useOtelForInternalMetrics` by updating the flag to beta"
+
+# One or more tracking issues or pull requests related to the change
+issues: [7454]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The metrics generated should be consistent with the metrics generated
+  previously with OpenCensus. Users can disable the behaviour
+  by setting `--feature-gates -telemetry.useOtelForInternalMetrics` at
+  collector start.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/exporterhelper/obsexporter_test.go
+++ b/exporter/exporterhelper/obsexporter_test.go
@@ -180,6 +180,11 @@ type testParams struct {
 
 func testTelemetry(t *testing.T, id component.ID, testFunc func(t *testing.T, tt obsreporttest.TestTelemetry, useOtel bool)) {
 	t.Run("WithOC", func(t *testing.T) {
+		originalValue := obsreportconfig.UseOtelForInternalMetricsfeatureGate.IsEnabled()
+		require.NoError(t, featuregate.GlobalRegistry().Set(obsreportconfig.UseOtelForInternalMetricsfeatureGate.ID(), false))
+		defer func() {
+			require.NoError(t, featuregate.GlobalRegistry().Set(obsreportconfig.UseOtelForInternalMetricsfeatureGate.ID(), originalValue))
+		}()
 		tt, err := obsreporttest.SetupTelemetry(id)
 		require.NoError(t, err)
 		t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
@@ -188,11 +193,6 @@ func testTelemetry(t *testing.T, id component.ID, testFunc func(t *testing.T, tt
 	})
 
 	t.Run("WithOTel", func(t *testing.T) {
-		originalValue := obsreportconfig.UseOtelForInternalMetricsfeatureGate.IsEnabled()
-		require.NoError(t, featuregate.GlobalRegistry().Set(obsreportconfig.UseOtelForInternalMetricsfeatureGate.ID(), true))
-		defer func() {
-			require.NoError(t, featuregate.GlobalRegistry().Set(obsreportconfig.UseOtelForInternalMetricsfeatureGate.ID(), originalValue))
-		}()
 		tt, err := obsreporttest.SetupTelemetry(id)
 		require.NoError(t, err)
 		t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })

--- a/exporter/exporterhelper/queue_sender_test.go
+++ b/exporter/exporterhelper/queue_sender_test.go
@@ -144,6 +144,8 @@ func setFeatureGateForTest(t testing.TB, gate *featuregate.Gate, enabled bool) f
 }
 
 func TestQueuedRetry_QueueMetricsReported(t *testing.T) {
+	resetFlag := setFeatureGateForTest(t, obsreportconfig.UseOtelForInternalMetricsfeatureGate, false)
+	defer resetFlag()
 	tt, err := obsreporttest.SetupTelemetry(defaultID)
 	require.NoError(t, err)
 
@@ -166,9 +168,6 @@ func TestQueuedRetry_QueueMetricsReported(t *testing.T) {
 }
 
 func TestQueuedRetry_QueueMetricsReportedUsingOTel(t *testing.T) {
-	resetFlag := setFeatureGateForTest(t, obsreportconfig.UseOtelForInternalMetricsfeatureGate, true)
-	defer resetFlag()
-
 	tt, err := obsreporttest.SetupTelemetry(defaultID)
 	require.NoError(t, err)
 

--- a/internal/obsreportconfig/obsreportconfig.go
+++ b/internal/obsreportconfig/obsreportconfig.go
@@ -17,7 +17,7 @@ import (
 // telemetrySettings for internal metrics.
 var UseOtelForInternalMetricsfeatureGate = featuregate.GlobalRegistry().MustRegister(
 	"telemetry.useOtelForInternalMetrics",
-	featuregate.StageAlpha,
+	featuregate.StageBeta,
 	featuregate.WithRegisterDescription("controls whether the collector uses OpenTelemetry for internal metrics"))
 
 // DisableHighCardinalityMetricsfeatureGate is the feature gate that controls whether the collector should enable

--- a/internal/obsreportconfig/obsreportconfig_test.go
+++ b/internal/obsreportconfig/obsreportconfig_test.go
@@ -7,11 +7,18 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/collector/config/configtelemetry"
+	"go.opentelemetry.io/collector/featuregate"
 )
 
 func TestConfigure(t *testing.T) {
+	originalValue := UseOtelForInternalMetricsfeatureGate.IsEnabled()
+	require.NoError(t, featuregate.GlobalRegistry().Set(UseOtelForInternalMetricsfeatureGate.ID(), false))
+	defer func() {
+		require.NoError(t, featuregate.GlobalRegistry().Set(UseOtelForInternalMetricsfeatureGate.ID(), originalValue))
+	}()
 	tests := []struct {
 		name         string
 		level        configtelemetry.Level

--- a/processor/processorhelper/obsreport_test.go
+++ b/processor/processorhelper/obsreport_test.go
@@ -101,6 +101,11 @@ func TestProcessorLogRecords(t *testing.T) {
 
 func testTelemetry(t *testing.T, id component.ID, testFunc func(t *testing.T, tt obsreporttest.TestTelemetry, useOtel bool)) {
 	t.Run("WithOC", func(t *testing.T) {
+		originalValue := obsreportconfig.UseOtelForInternalMetricsfeatureGate.IsEnabled()
+		require.NoError(t, featuregate.GlobalRegistry().Set(obsreportconfig.UseOtelForInternalMetricsfeatureGate.ID(), false))
+		defer func() {
+			require.NoError(t, featuregate.GlobalRegistry().Set(obsreportconfig.UseOtelForInternalMetricsfeatureGate.ID(), originalValue))
+		}()
 		tt, err := obsreporttest.SetupTelemetry(id)
 		require.NoError(t, err)
 		t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
@@ -109,11 +114,6 @@ func testTelemetry(t *testing.T, id component.ID, testFunc func(t *testing.T, tt
 	})
 
 	t.Run("WithOTel", func(t *testing.T) {
-		originalValue := obsreportconfig.UseOtelForInternalMetricsfeatureGate.IsEnabled()
-		require.NoError(t, featuregate.GlobalRegistry().Set(obsreportconfig.UseOtelForInternalMetricsfeatureGate.ID(), true))
-		defer func() {
-			require.NoError(t, featuregate.GlobalRegistry().Set(obsreportconfig.UseOtelForInternalMetricsfeatureGate.ID(), originalValue))
-		}()
 		tt, err := obsreporttest.SetupTelemetry(id)
 		require.NoError(t, err)
 		t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })

--- a/receiver/receiverhelper/obsreport_test.go
+++ b/receiver/receiverhelper/obsreport_test.go
@@ -237,6 +237,11 @@ func TestReceiveWithLongLivedCtx(t *testing.T) {
 
 func testTelemetry(t *testing.T, id component.ID, testFunc func(t *testing.T, tt obsreporttest.TestTelemetry, useOtel bool)) {
 	t.Run("WithOC", func(t *testing.T) {
+		originalValue := obsreportconfig.UseOtelForInternalMetricsfeatureGate.IsEnabled()
+		require.NoError(t, featuregate.GlobalRegistry().Set(obsreportconfig.UseOtelForInternalMetricsfeatureGate.ID(), false))
+		defer func() {
+			require.NoError(t, featuregate.GlobalRegistry().Set(obsreportconfig.UseOtelForInternalMetricsfeatureGate.ID(), originalValue))
+		}()
 		tt, err := obsreporttest.SetupTelemetry(id)
 		require.NoError(t, err)
 		t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
@@ -245,11 +250,6 @@ func testTelemetry(t *testing.T, id component.ID, testFunc func(t *testing.T, tt
 	})
 
 	t.Run("WithOTel", func(t *testing.T) {
-		originalValue := obsreportconfig.UseOtelForInternalMetricsfeatureGate.IsEnabled()
-		require.NoError(t, featuregate.GlobalRegistry().Set(obsreportconfig.UseOtelForInternalMetricsfeatureGate.ID(), true))
-		defer func() {
-			require.NoError(t, featuregate.GlobalRegistry().Set(obsreportconfig.UseOtelForInternalMetricsfeatureGate.ID(), originalValue))
-		}()
 		tt, err := obsreporttest.SetupTelemetry(id)
 		require.NoError(t, err)
 		t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })

--- a/receiver/scraperhelper/obsreport_test.go
+++ b/receiver/scraperhelper/obsreport_test.go
@@ -94,6 +94,11 @@ func TestScrapeMetricsDataOp(t *testing.T) {
 
 func testTelemetry(t *testing.T, id component.ID, testFunc func(t *testing.T, tt obsreporttest.TestTelemetry, useOtel bool)) {
 	t.Run("WithOC", func(t *testing.T) {
+		originalValue := obsreportconfig.UseOtelForInternalMetricsfeatureGate.IsEnabled()
+		require.NoError(t, featuregate.GlobalRegistry().Set(obsreportconfig.UseOtelForInternalMetricsfeatureGate.ID(), false))
+		defer func() {
+			require.NoError(t, featuregate.GlobalRegistry().Set(obsreportconfig.UseOtelForInternalMetricsfeatureGate.ID(), originalValue))
+		}()
 		tt, err := obsreporttest.SetupTelemetry(id)
 		require.NoError(t, err)
 		t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })
@@ -102,11 +107,6 @@ func testTelemetry(t *testing.T, id component.ID, testFunc func(t *testing.T, tt
 	})
 
 	t.Run("WithOTel", func(t *testing.T) {
-		originalValue := obsreportconfig.UseOtelForInternalMetricsfeatureGate.IsEnabled()
-		require.NoError(t, featuregate.GlobalRegistry().Set(obsreportconfig.UseOtelForInternalMetricsfeatureGate.ID(), true))
-		defer func() {
-			require.NoError(t, featuregate.GlobalRegistry().Set(obsreportconfig.UseOtelForInternalMetricsfeatureGate.ID(), originalValue))
-		}()
 		tt, err := obsreporttest.SetupTelemetry(id)
 		require.NoError(t, err)
 		t.Cleanup(func() { require.NoError(t, tt.Shutdown(context.Background())) })


### PR DESCRIPTION
The metrics are now consistent with the metrics produced by OpenCensus. We should move the featuregate forward.

Note that the OpenTelemetry generated metrics includes grpc client/server metrics (for receivers/exporters that use grpc) and `target_info` metrics

Fixes https://github.com/open-telemetry/opentelemetry-collector/issues/7454
