### PR TITLE
[chore] [exporterhelper] Do not requeue on shutdown

### DIFF
--- a/exporter/exporterhelper/internal/bounded_memory_queue.go
+++ b/exporter/exporterhelper/internal/bounded_memory_queue.go
@@ -7,7 +7,6 @@ package internal // import "go.opentelemetry.io/collector/exporter/exporterhelpe
 
 import (
 	"context"
-	"sync/atomic"
 
 	"go.opentelemetry.io/collector/component"
 )
@@ -17,25 +16,19 @@ import (
 // the producer are dropped.
 type boundedMemoryQueue[T any] struct {
 	component.StartFunc
-	stopped *atomic.Bool
-	items   chan queueRequest[T]
+	items chan queueRequest[T]
 }
 
 // NewBoundedMemoryQueue constructs the new queue of specified capacity, and with an optional
 // callback for dropped items (e.g. useful to emit metrics).
 func NewBoundedMemoryQueue[T any](capacity int) Queue[T] {
 	return &boundedMemoryQueue[T]{
-		items:   make(chan queueRequest[T], capacity),
-		stopped: &atomic.Bool{},
+		items: make(chan queueRequest[T], capacity),
 	}
 }
 
-// Offer is used by the producer to submit new item to the queue.
+// Offer is used by the producer to submit new item to the queue. Calling this method on a stopped queue will panic.
 func (q *boundedMemoryQueue[T]) Offer(ctx context.Context, req T) error {
-	if q.stopped.Load() {
-		return ErrQueueIsStopped
-	}
-
 	select {
 	case q.items <- queueRequest[T]{ctx: ctx, req: req}:
 		return nil
@@ -46,8 +39,8 @@ func (q *boundedMemoryQueue[T]) Offer(ctx context.Context, req T) error {
 
 // Consume applies the provided function on the head of queue.
 // The call blocks until there is an item available or the queue is stopped.
-// The function returns true when an item is consumed or false if the queue is stopped.
-func (q *boundedMemoryQueue[T]) Consume(consumeFunc func(context.Context, T)) bool {
+// The function returns true when an item is consumed or false if the queue is stopped and emptied.
+func (q *boundedMemoryQueue[T]) Consume(consumeFunc func(context.Context, T) bool) bool {
 	item, ok := <-q.items
 	if !ok {
 		return false
@@ -56,9 +49,8 @@ func (q *boundedMemoryQueue[T]) Consume(consumeFunc func(context.Context, T)) bo
 	return true
 }
 
-// Shutdown stops accepting items, and stops all consumers. It blocks until all consumers have stopped.
+// Shutdown closes the queue channel to initiate draining of the queue.
 func (q *boundedMemoryQueue[T]) Shutdown(context.Context) error {
-	q.stopped.Store(true) // disable producer
 	close(q.items)
 	return nil
 }

--- a/exporter/exporterhelper/internal/consumers.go
+++ b/exporter/exporterhelper/internal/consumers.go
@@ -13,11 +13,11 @@ import (
 type QueueConsumers[T any] struct {
 	queue        Queue[T]
 	numConsumers int
-	consumeFunc  func(context.Context, T)
+	consumeFunc  func(context.Context, T) bool
 	stopWG       sync.WaitGroup
 }
 
-func NewQueueConsumers[T any](q Queue[T], numConsumers int, consumeFunc func(context.Context, T)) *QueueConsumers[T] {
+func NewQueueConsumers[T any](q Queue[T], numConsumers int, consumeFunc func(context.Context, T) bool) *QueueConsumers[T] {
 	return &QueueConsumers[T]{
 		queue:        q,
 		numConsumers: numConsumers,

--- a/exporter/exporterhelper/internal/persistent_queue.go
+++ b/exporter/exporterhelper/internal/persistent_queue.go
@@ -141,7 +141,7 @@ func (pq *persistentQueue[T]) initPersistentContiguousStorage(ctx context.Contex
 // Consume applies the provided function on the head of queue.
 // The call blocks until there is an item available or the queue is stopped.
 // The function returns true when an item is consumed or false if the queue is stopped.
-func (pq *persistentQueue[T]) Consume(consumeFunc func(context.Context, T)) bool {
+func (pq *persistentQueue[T]) Consume(consumeFunc func(context.Context, T) bool) bool {
 	var (
 		req                  T
 		onProcessingFinished func()
@@ -157,8 +157,9 @@ func (pq *persistentQueue[T]) Consume(consumeFunc func(context.Context, T)) bool
 		}
 
 		if consumed {
-			consumeFunc(context.Background(), req)
-			onProcessingFinished()
+			if ok := consumeFunc(context.Background(), req); ok {
+				onProcessingFinished()
+			}
 			return true
 		}
 	}

--- a/exporter/exporterhelper/internal/queue.go
+++ b/exporter/exporterhelper/internal/queue.go
@@ -30,7 +30,8 @@ type Queue[T any] interface {
 	// Consume applies the provided function on the head of queue.
 	// The call blocks until there is an item available or the queue is stopped.
 	// The function returns true when an item is consumed or false if the queue is stopped.
-	Consume(func(ctx context.Context, item T)) bool
+	// The provided callback function returns true if the item was consumed or false if the consumer is stopped.
+	Consume(func(ctx context.Context, item T) bool) bool
 	// Size returns the current Size of the queue
 	Size() int
 	// Capacity returns the capacity of the queue.

--- a/exporter/exporterhelper/retry_sender_test.go
+++ b/exporter/exporterhelper/retry_sender_test.go
@@ -32,7 +32,7 @@ func mockRequestUnmarshaler(mr Request) RequestUnmarshaler {
 }
 
 func mockRequestMarshaler(_ Request) ([]byte, error) {
-	return nil, nil
+	return []byte("mockRequest"), nil
 }
 
 func TestQueuedRetry_DropOnPermanentError(t *testing.T) {


### PR DESCRIPTION
This change unblocks adding the `enqueue_on_failure` option to the queue sender by removing the requeue behavior on the shutdown. If we don't remove requeue on shutdown, it's possible to run into a situation described in https://github.com/open-telemetry/opentelemetry-collector/issues/7388. After the recent refactoring, the chance of running into it is pretty small, but it's still possible.

The only reason to requeue on shutdown is to make sure there is no data loss with the persistent queue enabled. The persistent queue captures all the inflight requests in the persistent storage anyway, so there is no reason to requeue an inflight request. The only downside is it potentially can cause sending duplicate data on the collector restart in case of a partially failed request during shutdown.

Another option would be to rework the memory queue to never close the channel but still ensure draining.