### PR TITLE
[chore] add semconvkit to reduce toil

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -227,13 +227,14 @@ genpdata:
 	$(MAKE) fmt
 
 # Generate semantic convention constants. Requires a clone of the opentelemetry-specification repo
-gensemconv: $(SEMCONVGEN)
+gensemconv: $(SEMCONVGEN) $(SEMCONVKIT)
 	@[ "${SPECPATH}" ] || ( echo ">> env var SPECPATH is not set"; exit 1 )
 	@[ "${SPECTAG}" ] || ( echo ">> env var SPECTAG is not set"; exit 1 )
 	@echo "Generating semantic convention constants from specification version ${SPECTAG} at ${SPECPATH}"
 	$(SEMCONVGEN) -o semconv/${SPECTAG} -t semconv/template.j2 -s ${SPECTAG} -i ${SPECPATH}/model/. --only=resource -p conventionType=resource -f generated_resource.go
 	$(SEMCONVGEN) -o semconv/${SPECTAG} -t semconv/template.j2 -s ${SPECTAG} -i ${SPECPATH}/model/. --only=event -p conventionType=event -f generated_event.go
 	$(SEMCONVGEN) -o semconv/${SPECTAG} -t semconv/template.j2 -s ${SPECTAG} -i ${SPECPATH}/model/. --only=span -p conventionType=trace -f generated_trace.go
+	$(SEMCONVKIT) -output "semconv/$(SPECTAG)" -tag "$(SPECTAG)"
 
 # Checks that the HEAD of the contrib repo checked out in CONTRIB_PATH compiles
 # against the current version of this repo.

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -32,6 +32,7 @@ MISSPELL     := $(TOOLS_BIN_DIR)/misspell
 MULTIMOD     := $(TOOLS_BIN_DIR)/multimod
 PORTO        := $(TOOLS_BIN_DIR)/porto
 SEMCONVGEN   := $(TOOLS_BIN_DIR)/semconvgen
+SEMCONVKIT   := $(TOOLS_BIN_DIR)/semconvkit
 YQ           := $(TOOLS_BIN_DIR)/yq
 
 .PHONY: install-tools

--- a/internal/tools/semconvkit/main.go
+++ b/internal/tools/semconvkit/main.go
@@ -40,6 +40,7 @@ func render(src, dest string, data *SemanticConventions) error {
 	}
 	for _, tmpl := range tmpls.Templates() {
 		target := filepath.Join(dest, strings.TrimSuffix(tmpl.Name(), ".tmpl"))
+		// nolint: gosec
 		wr, err := os.Create(target)
 		if err != nil {
 			return err

--- a/internal/tools/semconvkit/main.go
+++ b/internal/tools/semconvkit/main.go
@@ -1,0 +1,69 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"embed"
+	"flag"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"text/template"
+)
+
+var (
+	out = flag.String("output", "./", "output directory")
+	tag = flag.String("tag", "", "OpenTelemetry tagged version")
+
+	//go:embed templates/*.tmpl
+	rootFS embed.FS
+)
+
+// SemanticConventions are information about the semantic conventions being
+// generated.
+type SemanticConventions struct {
+	// TagVer is the tagged version (i.e. v1.7.0 and not 1.7.0).
+	TagVer string
+}
+
+func (sc SemanticConventions) SemVer() string {
+	return strings.TrimPrefix(*tag, "v")
+}
+
+// render renders all templates to the dest directory using the data.
+func render(src, dest string, data *SemanticConventions) error {
+	tmpls, err := template.ParseFS(rootFS, src)
+	if err != nil {
+		return err
+	}
+	for _, tmpl := range tmpls.Templates() {
+		target := filepath.Join(dest, strings.TrimSuffix(tmpl.Name(), ".tmpl"))
+		wr, err := os.Create(target)
+		if err != nil {
+			return err
+		}
+
+		err = tmpl.Execute(wr, data)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func main() {
+	flag.Parse()
+
+	if *tag == "" {
+		log.Fatalf("invalid tag: %q", *tag)
+	}
+
+	sc := &SemanticConventions{TagVer: *tag}
+
+	if err := render("templates/*.tmpl", *out, sc); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/internal/tools/semconvkit/templates/doc.go.tmpl
+++ b/internal/tools/semconvkit/templates/doc.go.tmpl
@@ -1,0 +1,20 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package semconv implements OpenTelemetry semantic conventions.
+//
+// OpenTelemetry semantic conventions are agreed standardized naming
+// patterns for OpenTelemetry things. This package represents the {{.TagVer}}
+// version of the OpenTelemetry semantic conventions.
+package semconv // import "go.opentelemetry.io/otel/semconv/{{.TagVer}}"

--- a/internal/tools/semconvkit/templates/doc.go.tmpl
+++ b/internal/tools/semconvkit/templates/doc.go.tmpl
@@ -1,20 +1,9 @@
 // Copyright The OpenTelemetry Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 // Package semconv implements OpenTelemetry semantic conventions.
 //
 // OpenTelemetry semantic conventions are agreed standardized naming
 // patterns for OpenTelemetry things. This package represents the {{.TagVer}}
 // version of the OpenTelemetry semantic conventions.
-package semconv // import "go.opentelemetry.io/otel/semconv/{{.TagVer}}"
+package semconv // import "go.opentelemetry.io/collector/semconv/{{.TagVer}}"

--- a/internal/tools/semconvkit/templates/schema.go.tmpl
+++ b/internal/tools/semconvkit/templates/schema.go.tmpl
@@ -1,0 +1,9 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package semconv // import "go.opentelemetry.io/collector/semconv/{{.TagVer}}"
+
+// SchemaURL is the schema URL that matches the version of the semantic conventions
+// that this package defines. Semconv packages starting from v1.4.0 must declare
+// non-empty schema URL in the form https://opentelemetry.io/schemas/<version>
+const SchemaURL = "https://opentelemetry.io/schemas/{{.SemVer}}"

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -24,6 +24,7 @@ import (
 	_ "go.opentelemetry.io/build-tools/crosslink"
 	_ "go.opentelemetry.io/build-tools/multimod"
 	_ "go.opentelemetry.io/build-tools/semconvgen"
+	_ "go.opentelemetry.io/collector/internal/tools/semconvkit"
 	_ "golang.org/x/exp/cmd/apidiff"
 	_ "golang.org/x/tools/cmd/goimports"
 	_ "golang.org/x/vuln/cmd/govulncheck"

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -24,8 +24,9 @@ import (
 	_ "go.opentelemetry.io/build-tools/crosslink"
 	_ "go.opentelemetry.io/build-tools/multimod"
 	_ "go.opentelemetry.io/build-tools/semconvgen"
-	_ "go.opentelemetry.io/collector/internal/tools/semconvkit"
 	_ "golang.org/x/exp/cmd/apidiff"
 	_ "golang.org/x/tools/cmd/goimports"
 	_ "golang.org/x/vuln/cmd/govulncheck"
+
+	_ "go.opentelemetry.io/collector/internal/tools/semconvkit"
 )

--- a/semconv/README.md
+++ b/semconv/README.md
@@ -16,8 +16,3 @@ Generating semantic convention constants from specification version v1.22.0 at /
 .tools/semconvgen -o semconv/v1.22.0 -t semconv/template.j2 -s v1.22.0 -i /tmp/semantic-conventions/model/. --only=event -p conventionType=event -f generated_event.go
 .tools/semconvgen -o semconv/v1.22.0 -t semconv/template.j2 -s v1.22.0 -i /tmp/semantic-conventions/model/. --only=span -p conventionType=trace -f generated_trace.go
 ```
-
-When generating the constants for a new version ot the specification it is important to note that only
-`generated_trace.go` and `generated_resource.go` are generated automatically. The `schema.go` and `nonstandard.go`
-files should be copied from a prior version's package and updated as appropriate. Most important will be to update
-the `SchemaURL` constant in `schema.go`.


### PR DESCRIPTION
This code, copied from the opentelemetry-go repo, allows to generate schema.go automatically as well, reducing effort needed to generate semantic convention packages in the future
